### PR TITLE
feat(keymap): keymap scope architecture for buffer-type-specific keybindings (#223)

### DIFF
--- a/lib/minga/agent/view/state.ex
+++ b/lib/minga/agent/view/state.ex
@@ -26,7 +26,7 @@ defmodule Minga.Agent.View.State do
   @type focus :: :chat | :file_viewer
 
   @typedoc "Active prefix key awaiting a follow-up keystroke."
-  @type prefix :: nil | :g | :z | :bracket_next | :bracket_prev
+  @type prefix :: nil | :g | :z | :bracket_next | :bracket_prev | Minga.Keymap.Bindings.Node.t()
 
   @typedoc "A search match: message index, byte start, byte end."
   @type search_match ::
@@ -148,7 +148,7 @@ defmodule Minga.Agent.View.State do
   @doc "Sets the pending prefix for multi-key sequences."
   @spec set_prefix(t(), prefix()) :: t()
   def set_prefix(%__MODULE__{} = av, prefix)
-      when prefix in [nil, :g, :z, :bracket_next, :bracket_prev] do
+      when prefix in [nil, :g, :z, :bracket_next, :bracket_prev] or is_map(prefix) do
     %{av | pending_prefix: prefix}
   end
 

--- a/lib/minga/editor/commands.ex
+++ b/lib/minga/editor/commands.ex
@@ -151,6 +151,76 @@ defmodule Minga.Editor.Commands do
 
   def execute(state, :agent_cycle_thinking), do: AgentCommands.cycle_thinking_level(state)
 
+  # ── Agent scope commands (dispatched via keymap scope resolution) ──────────
+  def execute(state, :agent_scroll_down), do: AgentCommands.scope_scroll_down(state)
+  def execute(state, :agent_scroll_up), do: AgentCommands.scope_scroll_up(state)
+  def execute(state, :agent_scroll_half_down), do: AgentCommands.scope_scroll_half_down(state)
+  def execute(state, :agent_scroll_half_up), do: AgentCommands.scope_scroll_half_up(state)
+  def execute(state, :agent_scroll_bottom), do: AgentCommands.scope_scroll_bottom(state)
+  def execute(state, :agent_scroll_top), do: AgentCommands.scope_scroll_top(state)
+  def execute(state, :agent_toggle_collapse), do: AgentCommands.scope_toggle_collapse(state)
+
+  def execute(state, :agent_toggle_all_collapse),
+    do: AgentCommands.scope_toggle_all_collapse(state)
+
+  def execute(state, :agent_expand_at_cursor), do: AgentCommands.scope_expand_at_cursor(state)
+  def execute(state, :agent_collapse_at_cursor), do: AgentCommands.scope_collapse_at_cursor(state)
+  def execute(state, :agent_collapse_all), do: AgentCommands.scope_collapse_all(state)
+  def execute(state, :agent_expand_all), do: AgentCommands.scope_expand_all(state)
+  def execute(state, :agent_next_message), do: AgentCommands.scope_next_message(state)
+  def execute(state, :agent_next_code_block), do: AgentCommands.scope_next_code_block(state)
+  def execute(state, :agent_next_tool_call), do: AgentCommands.scope_next_tool_call(state)
+  def execute(state, :agent_prev_message), do: AgentCommands.scope_prev_message(state)
+  def execute(state, :agent_prev_code_block), do: AgentCommands.scope_prev_code_block(state)
+  def execute(state, :agent_prev_tool_call), do: AgentCommands.scope_prev_tool_call(state)
+  def execute(state, :agent_copy_code_block), do: AgentCommands.scope_copy_code_block(state)
+  def execute(state, :agent_copy_message), do: AgentCommands.scope_copy_message(state)
+  def execute(state, :agent_open_code_block), do: AgentCommands.scope_open_code_block(state)
+  def execute(state, :agent_focus_input), do: AgentCommands.scope_focus_input(state)
+  def execute(state, :agent_unfocus_input), do: AgentCommands.scope_unfocus_input(state)
+  def execute(state, :agent_unfocus_and_quit), do: AgentCommands.scope_unfocus_and_quit(state)
+  def execute(state, :agent_grow_panel), do: AgentCommands.scope_grow_panel(state)
+  def execute(state, :agent_shrink_panel), do: AgentCommands.scope_shrink_panel(state)
+  def execute(state, :agent_reset_panel), do: AgentCommands.scope_reset_panel(state)
+  def execute(state, :agent_switch_focus), do: AgentCommands.scope_switch_focus(state)
+  def execute(state, :agent_start_search), do: AgentCommands.scope_start_search(state)
+  def execute(state, :agent_next_search_match), do: AgentCommands.scope_next_search_match(state)
+  def execute(state, :agent_prev_search_match), do: AgentCommands.scope_prev_search_match(state)
+  def execute(state, :agent_session_switcher), do: AgentCommands.scope_session_switcher(state)
+  def execute(state, :agent_toggle_help), do: AgentCommands.scope_toggle_help(state)
+  def execute(state, :agent_close), do: AgentCommands.scope_close(state)
+  def execute(state, :agent_dismiss_or_noop), do: AgentCommands.scope_dismiss_or_noop(state)
+  def execute(state, :agent_clear_chat), do: AgentCommands.scope_clear_chat(state)
+  def execute(state, :agent_submit_or_newline), do: AgentCommands.scope_submit_or_newline(state)
+  def execute(state, :agent_insert_newline), do: AgentCommands.scope_insert_newline(state)
+  def execute(state, :agent_submit_or_abort), do: AgentCommands.scope_submit_or_abort(state)
+  def execute(state, :agent_input_backspace), do: AgentCommands.input_backspace(state)
+  def execute(state, :agent_input_up), do: AgentCommands.scope_input_up(state)
+  def execute(state, :agent_input_down), do: AgentCommands.scope_input_down(state)
+  def execute(state, :agent_save_buffer), do: AgentCommands.scope_save_buffer(state)
+
+  def execute(state, {:agent_self_insert, char}),
+    do: AgentCommands.scope_self_insert(state, char)
+
+  def execute(state, :agent_accept_hunk), do: AgentCommands.scope_accept_hunk(state)
+  def execute(state, :agent_reject_hunk), do: AgentCommands.scope_reject_hunk(state)
+  def execute(state, :agent_accept_all_hunks), do: AgentCommands.scope_accept_all_hunks(state)
+  def execute(state, :agent_reject_all_hunks), do: AgentCommands.scope_reject_all_hunks(state)
+  def execute(state, :agent_approve_tool), do: AgentCommands.scope_approve_tool(state)
+  def execute(state, :agent_deny_tool), do: AgentCommands.scope_deny_tool(state)
+
+  def execute(state, :agent_trigger_mention),
+    do: AgentCommands.scope_trigger_mention(state)
+
+  # ── File tree scope commands ──────────────────────────────────────────────
+  def execute(state, :tree_open_or_toggle), do: tree_open_or_toggle(state)
+  def execute(state, :tree_toggle_directory), do: tree_toggle_directory(state)
+  def execute(state, :tree_expand), do: tree_expand(state)
+  def execute(state, :tree_collapse), do: tree_collapse(state)
+  def execute(state, :tree_toggle_hidden), do: tree_toggle_hidden(state)
+  def execute(state, :tree_refresh), do: tree_refresh(state)
+  def execute(state, :tree_close), do: tree_close(state)
+
   # ── Guard: no buffer → no-op ──────────────────────────────────────────────
 
   def execute(%{buffers: %{active: nil}} = state, _cmd), do: state
@@ -520,10 +590,11 @@ defmodule Minga.Editor.Commands do
 
   defp toggle_file_tree(%{file_tree: %{buffer: buf}} = state) when is_pid(buf) do
     GenServer.stop(buf, :normal)
-    %{state | file_tree: FileTreeState.close(state.file_tree)}
+    %{state | file_tree: FileTreeState.close(state.file_tree), keymap_scope: :editor}
   end
 
-  defp toggle_file_tree(state), do: %{state | file_tree: FileTreeState.close(state.file_tree)}
+  defp toggle_file_tree(state),
+    do: %{state | file_tree: FileTreeState.close(state.file_tree), keymap_scope: :editor}
 
   @spec open_file_tree(state()) :: state()
   defp open_file_tree(state) do
@@ -531,7 +602,7 @@ defmodule Minga.Editor.Commands do
     tree = FileTree.new(root)
     tree = reveal_active_in_tree(tree, state.buffers.active)
     buf = BufferSync.start_buffer(tree)
-    %{state | file_tree: FileTreeState.open(state.file_tree, tree, buf)}
+    %{state | file_tree: FileTreeState.open(state.file_tree, tree, buf), keymap_scope: :file_tree}
   end
 
   @spec reveal_active_in_tree(FileTree.t(), pid() | nil) :: FileTree.t()
@@ -542,5 +613,80 @@ defmodule Minga.Editor.Commands do
       nil -> tree
       path -> FileTree.reveal(tree, path)
     end
+  end
+
+  # ── File tree scope commands ──────────────────────────────────────────────
+
+  @spec tree_open_or_toggle(state()) :: state()
+  defp tree_open_or_toggle(%{file_tree: %{tree: nil}} = state), do: state
+
+  defp tree_open_or_toggle(%{file_tree: %{tree: tree}} = state) do
+    case FileTree.selected_entry(tree) do
+      %{dir?: true} ->
+        new_tree = FileTree.toggle_expand(tree)
+        tree_sync_and_update(state, new_tree)
+
+      %{dir?: false, path: path} ->
+        state = put_in(state.file_tree.focused, false)
+        state = %{state | keymap_scope: :editor}
+
+        case start_buffer(path) do
+          {:ok, pid} -> Minga.Editor.do_file_tree_open(state, pid, path, tree)
+          {:error, _} -> state
+        end
+
+      nil ->
+        state
+    end
+  end
+
+  @spec tree_toggle_directory(state()) :: state()
+  defp tree_toggle_directory(%{file_tree: %{tree: nil}} = state), do: state
+
+  defp tree_toggle_directory(%{file_tree: %{tree: tree}} = state) do
+    tree_sync_and_update(state, FileTree.toggle_expand(tree))
+  end
+
+  @spec tree_expand(state()) :: state()
+  defp tree_expand(%{file_tree: %{tree: nil}} = state), do: state
+
+  defp tree_expand(%{file_tree: %{tree: tree}} = state),
+    do: tree_sync_and_update(state, FileTree.expand(tree))
+
+  @spec tree_collapse(state()) :: state()
+  defp tree_collapse(%{file_tree: %{tree: nil}} = state), do: state
+
+  defp tree_collapse(%{file_tree: %{tree: tree}} = state),
+    do: tree_sync_and_update(state, FileTree.collapse(tree))
+
+  @spec tree_toggle_hidden(state()) :: state()
+  defp tree_toggle_hidden(%{file_tree: %{tree: nil}} = state), do: state
+
+  defp tree_toggle_hidden(%{file_tree: %{tree: tree}} = state),
+    do: tree_sync_and_update(state, FileTree.toggle_hidden(tree))
+
+  @spec tree_refresh(state()) :: state()
+  defp tree_refresh(%{file_tree: %{tree: nil}} = state), do: state
+
+  defp tree_refresh(%{file_tree: %{tree: tree}} = state),
+    do: tree_sync_and_update(state, FileTree.refresh(tree))
+
+  @spec tree_close(state()) :: state()
+  defp tree_close(%{file_tree: %{buffer: buf}} = state) when is_pid(buf) do
+    GenServer.stop(buf, :normal)
+    %{state | file_tree: FileTreeState.close(state.file_tree), keymap_scope: :editor}
+  end
+
+  defp tree_close(state),
+    do: %{state | file_tree: FileTreeState.close(state.file_tree), keymap_scope: :editor}
+
+  @spec tree_sync_and_update(state(), FileTree.t()) :: state()
+  defp tree_sync_and_update(%{file_tree: %{buffer: buf}} = state, new_tree) when is_pid(buf) do
+    BufferSync.sync(buf, new_tree)
+    put_in(state.file_tree.tree, new_tree)
+  end
+
+  defp tree_sync_and_update(state, new_tree) do
+    put_in(state.file_tree.tree, new_tree)
   end
 end

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -8,15 +8,27 @@ defmodule Minga.Editor.Commands.Agent do
   """
 
   alias Minga.Agent.BufferSync, as: AgentBufferSync
+  alias Minga.Agent.ChatRenderer
+  alias Minga.Agent.ChatSearch
+  alias Minga.Agent.DiffReview
   alias Minga.Agent.FileMention
+  alias Minga.Agent.Markdown
+  alias Minga.Agent.Message
   alias Minga.Agent.PanelState
   alias Minga.Agent.Session
   alias Minga.Agent.SlashCommand
+  alias Minga.Agent.View.Preview
   alias Minga.Agent.View.State, as: ViewState
   alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Clipboard
+  alias Minga.Editor.Commands
+  alias Minga.Editor.PickerUI
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.Windows
+  alias Minga.Git.Diff
+
+  import Bitwise
 
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
@@ -69,7 +81,7 @@ defmodule Minga.Editor.Commands.Agent do
         state
       end
 
-    %{state | agentic: new_av}
+    %{state | agentic: new_av, keymap_scope: :editor}
   end
 
   def toggle_agentic_view(%{agentic: %{active: false}} = state) do
@@ -80,6 +92,9 @@ defmodule Minga.Editor.Commands.Agent do
     %Windows{} = ws = state.windows
     alias Minga.Editor.State.FileTree, as: FileTreeState
     state = %{state | windows: %{ws | tree: nil}, file_tree: FileTreeState.close(state.file_tree)}
+
+    # Set keymap scope to agent
+    state = %{state | keymap_scope: :agent}
 
     # Ensure a session is running; start one if not.
     if state.agent.session == nil do
@@ -299,6 +314,571 @@ defmodule Minga.Editor.Commands.Agent do
     restart_session(state, "Model: #{model}")
   end
 
+  # ── Scope commands (keymap scope dispatch) ──────────────────────────────────
+  #
+  # These commands are bound in Keymap.Scope.Agent and dispatched through the
+  # scope resolution system. Focus-aware commands check state.agentic.focus to
+  # route to the correct panel (chat vs file viewer).
+
+  # ── Navigation ─────────────────────────────────────────────────────────────
+
+  @doc "Scrolls down 1 line in the focused panel."
+  @spec scope_scroll_down(state()) :: state()
+  def scope_scroll_down(%{agentic: %{focus: :file_viewer}} = state) do
+    update_agentic(state, &ViewState.scroll_viewer_down(&1, 1))
+  end
+
+  def scope_scroll_down(state) do
+    update_agent(state, &AgentState.scroll_down(&1, 1))
+  end
+
+  @doc "Scrolls up 1 line in the focused panel."
+  @spec scope_scroll_up(state()) :: state()
+  def scope_scroll_up(%{agentic: %{focus: :file_viewer}} = state) do
+    update_agentic(state, &ViewState.scroll_viewer_up(&1, 1))
+  end
+
+  def scope_scroll_up(state) do
+    update_agent(state, &AgentState.scroll_up(&1, 1))
+  end
+
+  @doc "Scrolls down half a page in the focused panel."
+  @spec scope_scroll_half_down(state()) :: state()
+  def scope_scroll_half_down(%{agentic: %{focus: :file_viewer}} = state) do
+    amount = half_page(state)
+    update_agentic(state, &ViewState.scroll_viewer_down(&1, amount))
+  end
+
+  def scope_scroll_half_down(state) do
+    amount = half_page(state)
+    update_agent(state, &AgentState.scroll_down(&1, amount))
+  end
+
+  @doc "Scrolls up half a page in the focused panel."
+  @spec scope_scroll_half_up(state()) :: state()
+  def scope_scroll_half_up(%{agentic: %{focus: :file_viewer}} = state) do
+    amount = half_page(state)
+    update_agentic(state, &ViewState.scroll_viewer_up(&1, amount))
+  end
+
+  def scope_scroll_half_up(state) do
+    amount = half_page(state)
+    update_agent(state, &AgentState.scroll_up(&1, amount))
+  end
+
+  @doc "Scrolls to the bottom of the focused panel."
+  @spec scope_scroll_bottom(state()) :: state()
+  def scope_scroll_bottom(%{agentic: %{focus: :file_viewer}} = state) do
+    update_agentic(state, &ViewState.scroll_viewer_to_bottom/1)
+  end
+
+  def scope_scroll_bottom(state) do
+    update_agent(state, &AgentState.scroll_to_bottom/1)
+  end
+
+  @doc "Scrolls to the top of the focused panel."
+  @spec scope_scroll_top(state()) :: state()
+  def scope_scroll_top(%{agentic: %{focus: :file_viewer}} = state) do
+    update_agentic(state, &ViewState.scroll_viewer_to_top/1)
+  end
+
+  def scope_scroll_top(state) do
+    update_agent(state, &AgentState.scroll_to_top/1)
+  end
+
+  # ── Fold / Collapse ────────────────────────────────────────────────────────
+
+  @doc "Toggles collapse at cursor (currently toggles all)."
+  @spec scope_toggle_collapse(state()) :: state()
+  def scope_toggle_collapse(state), do: toggle_all_collapses(state)
+
+  @doc "Toggles ALL collapses."
+  @spec scope_toggle_all_collapse(state()) :: state()
+  def scope_toggle_all_collapse(state), do: toggle_all_collapses(state)
+
+  @doc "Expands at cursor (stubbed, toggles all for now)."
+  @spec scope_expand_at_cursor(state()) :: state()
+  def scope_expand_at_cursor(state), do: state
+
+  @doc "Collapses at cursor (stubbed, toggles all for now)."
+  @spec scope_collapse_at_cursor(state()) :: state()
+  def scope_collapse_at_cursor(state), do: state
+
+  @doc "Collapses all thinking/tool blocks."
+  @spec scope_collapse_all(state()) :: state()
+  def scope_collapse_all(state), do: toggle_all_collapses(state)
+
+  @doc "Expands all thinking/tool blocks."
+  @spec scope_expand_all(state()) :: state()
+  def scope_expand_all(state), do: toggle_all_collapses(state)
+
+  # ── Bracket navigation ────────────────────────────────────────────────────
+
+  @doc "Jumps to next message (stubbed)."
+  @spec scope_next_message(state()) :: state()
+  def scope_next_message(state), do: state
+
+  @doc "Jumps to next code block or diff hunk."
+  @spec scope_next_code_block(state()) :: state()
+  def scope_next_code_block(%{agentic: %{preview: %Preview{content: {:diff, review}}}} = state) do
+    update_preview(state, &Preview.update_diff(&1, fn _ -> DiffReview.next_hunk(review) end))
+  end
+
+  def scope_next_code_block(state), do: state
+
+  @doc "Jumps to next tool call (stubbed)."
+  @spec scope_next_tool_call(state()) :: state()
+  def scope_next_tool_call(state), do: state
+
+  @doc "Jumps to previous message (stubbed)."
+  @spec scope_prev_message(state()) :: state()
+  def scope_prev_message(state), do: state
+
+  @doc "Jumps to previous code block or diff hunk."
+  @spec scope_prev_code_block(state()) :: state()
+  def scope_prev_code_block(%{agentic: %{preview: %Preview{content: {:diff, review}}}} = state) do
+    update_preview(state, &Preview.update_diff(&1, fn _ -> DiffReview.prev_hunk(review) end))
+  end
+
+  def scope_prev_code_block(state), do: state
+
+  @doc "Jumps to previous tool call (stubbed)."
+  @spec scope_prev_tool_call(state()) :: state()
+  def scope_prev_tool_call(state), do: state
+
+  # ── Copy ───────────────────────────────────────────────────────────────────
+
+  @doc "Copies the code block at the cursor to the clipboard."
+  @spec scope_copy_code_block(state()) :: state()
+  def scope_copy_code_block(state) do
+    case scroll_context(state) do
+      nil ->
+        state
+
+      {_idx, msg, line_type} ->
+        text = Message.text(msg)
+
+        if line_type == :code do
+          blocks = Markdown.extract_code_blocks(text)
+          content = code_block_for_scroll(state, blocks)
+          copy_to_clipboard(state, content, "code block")
+        else
+          copy_to_clipboard(state, text, "message")
+        end
+    end
+  end
+
+  @doc "Copies the full message at the cursor to the clipboard."
+  @spec scope_copy_message(state()) :: state()
+  def scope_copy_message(state) do
+    case scroll_context(state) do
+      nil -> state
+      {_idx, msg, _type} -> copy_to_clipboard(state, Message.text(msg), "message")
+    end
+  end
+
+  # ── Open code block ────────────────────────────────────────────────────────
+
+  @doc "Opens the code block at the cursor in an editor buffer."
+  @spec scope_open_code_block(state()) :: state()
+  def scope_open_code_block(state) do
+    case scroll_context(state) do
+      nil ->
+        state
+
+      {_idx, msg, :code} ->
+        text = Message.text(msg)
+        blocks = Markdown.extract_code_blocks(text)
+        block = code_block_at_scroll(state, blocks)
+        if block, do: open_code_block(state, block.language, block.content), else: state
+
+      {_idx, _msg, _other_type} ->
+        state
+    end
+  end
+
+  # ── Input focus ────────────────────────────────────────────────────────────
+
+  @doc "Focuses the input field and transitions to insert mode."
+  @spec scope_focus_input(state()) :: state()
+  def scope_focus_input(state) do
+    update_agent(state, &AgentState.focus_input(&1, true))
+  end
+
+  @doc "Unfocuses the input field and transitions to normal mode."
+  @spec scope_unfocus_input(state()) :: state()
+  def scope_unfocus_input(state) do
+    update_agent(state, &AgentState.focus_input(&1, false))
+  end
+
+  @doc "Unfocuses the input field and closes the agentic view."
+  @spec scope_unfocus_and_quit(state()) :: state()
+  def scope_unfocus_and_quit(state) do
+    state = update_agent(state, &AgentState.focus_input(&1, false))
+    toggle_agentic_view(state)
+  end
+
+  # ── Panel management ───────────────────────────────────────────────────────
+
+  @doc "Grows the chat panel width."
+  @spec scope_grow_panel(state()) :: state()
+  def scope_grow_panel(state), do: update_agentic(state, &ViewState.grow_chat/1)
+
+  @doc "Shrinks the chat panel width."
+  @spec scope_shrink_panel(state()) :: state()
+  def scope_shrink_panel(state), do: update_agentic(state, &ViewState.shrink_chat/1)
+
+  @doc "Resets the panel split to the default ratio."
+  @spec scope_reset_panel(state()) :: state()
+  def scope_reset_panel(state), do: update_agentic(state, &ViewState.reset_split/1)
+
+  @doc "Switches focus between chat and file viewer panels."
+  @spec scope_switch_focus(state()) :: state()
+  def scope_switch_focus(%{agentic: %{focus: :chat}} = state) do
+    update_agentic(state, &ViewState.set_focus(&1, :file_viewer))
+  end
+
+  def scope_switch_focus(state) do
+    update_agentic(state, &ViewState.set_focus(&1, :chat))
+  end
+
+  # ── Search ─────────────────────────────────────────────────────────────────
+
+  @doc "Starts search mode in the chat."
+  @spec scope_start_search(state()) :: state()
+  def scope_start_search(state) do
+    scroll = state.agent.panel.scroll_offset
+    update_agentic(state, &ViewState.start_search(&1, scroll))
+  end
+
+  @doc "Jumps to the next search match."
+  @spec scope_next_search_match(state()) :: state()
+  def scope_next_search_match(%{agentic: %{search: %{input_active: true}}} = state), do: state
+
+  def scope_next_search_match(state) do
+    state = update_agentic(state, &ViewState.next_search_match/1)
+    scroll_to_current_match(state)
+  end
+
+  @doc "Jumps to the previous search match."
+  @spec scope_prev_search_match(state()) :: state()
+  def scope_prev_search_match(%{agentic: %{search: %{input_active: true}}} = state), do: state
+
+  def scope_prev_search_match(state) do
+    state = update_agentic(state, &ViewState.prev_search_match/1)
+    scroll_to_current_match(state)
+  end
+
+  # ── Session ────────────────────────────────────────────────────────────────
+
+  @doc "Opens the session switcher picker."
+  @spec scope_session_switcher(state()) :: state()
+  def scope_session_switcher(state) do
+    PickerUI.open(state, Minga.Picker.AgentSessionSource)
+  end
+
+  # ── Help ───────────────────────────────────────────────────────────────────
+
+  @doc "Toggles the help overlay."
+  @spec scope_toggle_help(state()) :: state()
+  def scope_toggle_help(state), do: update_agentic(state, &ViewState.toggle_help/1)
+
+  # ── Close / dismiss ────────────────────────────────────────────────────────
+
+  @doc "Closes the agentic view."
+  @spec scope_close(state()) :: state()
+  def scope_close(state), do: toggle_agentic_view(state)
+
+  @doc "Dismisses active overlays or does nothing (ESC behavior)."
+  @spec scope_dismiss_or_noop(state()) :: state()
+  def scope_dismiss_or_noop(%{agentic: %{help_visible: true}} = state) do
+    update_agentic(state, &ViewState.dismiss_help/1)
+  end
+
+  def scope_dismiss_or_noop(state), do: state
+
+  # ── Clear ──────────────────────────────────────────────────────────────────
+
+  @doc "Clears the chat display without losing conversation history."
+  @spec scope_clear_chat(state()) :: state()
+  def scope_clear_chat(state) do
+    clear_chat_display(state)
+  end
+
+  # ── Insert mode commands ───────────────────────────────────────────────────
+
+  @doc "Submits the prompt or inserts a newline (context-dependent)."
+  @spec scope_submit_or_newline(state()) :: state()
+  def scope_submit_or_newline(state), do: submit_prompt(state)
+
+  @doc "Inserts a newline in the input field."
+  @spec scope_insert_newline(state()) :: state()
+  def scope_insert_newline(state) do
+    update_agent(state, &AgentState.insert_newline/1)
+  end
+
+  @doc "Submits if input has text, aborts if agent is active."
+  @spec scope_submit_or_abort(state()) :: state()
+  def scope_submit_or_abort(state) do
+    if PanelState.input_text(state.agent.panel) != "" do
+      submit_prompt(state)
+    else
+      abort_if_active(state)
+    end
+  end
+
+  @doc "Moves cursor up in input or recalls history."
+  @spec scope_input_up(state()) :: state()
+  def scope_input_up(state) do
+    {line, _col} = state.agent.panel.input_cursor
+
+    if line == 0 do
+      update_agent(state, &AgentState.history_prev/1)
+    else
+      update_agent(state, &AgentState.move_cursor_up/1)
+    end
+  end
+
+  @doc "Moves cursor down in input or advances history."
+  @spec scope_input_down(state()) :: state()
+  def scope_input_down(state) do
+    {line, _col} = state.agent.panel.input_cursor
+    max_line = length(state.agent.panel.input_lines) - 1
+
+    if line >= max_line do
+      update_agent(state, &AgentState.history_next/1)
+    else
+      update_agent(state, &AgentState.move_cursor_down/1)
+    end
+  end
+
+  @doc "Self-insert: adds a character to the input field."
+  @spec scope_self_insert(state(), String.t()) :: state()
+  def scope_self_insert(state, char) do
+    input_char(state, char)
+  end
+
+  @doc "Saves the active buffer (Ctrl+S from agent insert mode)."
+  @spec scope_save_buffer(state()) :: state()
+  def scope_save_buffer(state) do
+    # Delegate to the standard save command
+    Commands.execute(state, :save)
+  end
+
+  @doc "Aborts agent operation if one is active."
+  @spec scope_abort_if_active(state()) :: state()
+  def scope_abort_if_active(state) do
+    if state.agent.status in [:thinking, :tool_executing] do
+      abort_agent(state)
+    else
+      state
+    end
+  end
+
+  # ── Search input handling (sub-state within agent scope) ───────────────────
+
+  @doc "Handles a key during active search input."
+  @spec handle_search_key(state(), non_neg_integer()) :: state()
+  def handle_search_key(state, 13) do
+    # Enter: confirm search
+    update_agentic(state, &ViewState.confirm_search/1)
+  end
+
+  def handle_search_key(state, 27) do
+    # Escape: cancel search, restore scroll
+    saved = ViewState.search_saved_scroll(state.agentic)
+    state = update_agentic(state, &ViewState.cancel_search/1)
+    if saved, do: update_agent(state, &AgentState.set_scroll(&1, saved)), else: state
+  end
+
+  def handle_search_key(state, 127) do
+    # Backspace
+    query = ViewState.search_query(state.agentic) || ""
+
+    if query == "" do
+      handle_search_key(state, 27)
+    else
+      new_query = String.slice(query, 0..-2//1)
+      state = update_agentic(state, &ViewState.update_search_query(&1, new_query))
+      run_search(state, new_query)
+    end
+  end
+
+  def handle_search_key(state, cp) when cp >= 32 and cp <= 126 do
+    char = <<cp::utf8>>
+    query = (ViewState.search_query(state.agentic) || "") <> char
+    state = update_agentic(state, &ViewState.update_search_query(&1, query))
+    run_search(state, query)
+  end
+
+  def handle_search_key(state, _cp), do: state
+
+  # ── Mention completion handling (sub-state within agent scope) ─────────────
+
+  @doc "Handles a key during active mention completion."
+  @spec handle_mention_key(state(), non_neg_integer(), non_neg_integer()) :: state()
+  def handle_mention_key(state, 9, mods) do
+    if band(mods, 0x01) != 0 do
+      # Shift+Tab: prev candidate
+      update_panel(state, fn p ->
+        comp = FileMention.select_prev(p.mention_completion)
+        %{p | mention_completion: comp}
+      end)
+    else
+      # Tab: next candidate
+      update_panel(state, fn p ->
+        comp = FileMention.select_next(p.mention_completion)
+        %{p | mention_completion: comp}
+      end)
+    end
+  end
+
+  def handle_mention_key(state, 13, _mods) do
+    # Enter: accept selection
+    accept_mention_completion(state)
+  end
+
+  def handle_mention_key(state, 27, _mods) do
+    # Escape: cancel
+    update_panel(state, fn p -> %{p | mention_completion: nil} end)
+  end
+
+  def handle_mention_key(state, 127, _mods) do
+    # Backspace
+    comp = state.agent.panel.mention_completion
+
+    if comp.prefix == "" do
+      state = input_backspace(state)
+      update_panel(state, fn p -> %{p | mention_completion: nil} end)
+    else
+      state = input_backspace(state)
+      new_prefix = String.slice(comp.prefix, 0..-2//1)
+
+      update_panel(state, fn p ->
+        %{p | mention_completion: FileMention.update_prefix(comp, new_prefix)}
+      end)
+    end
+  end
+
+  def handle_mention_key(state, cp, mods)
+      when cp >= 32 and band(mods, 0x02) == 0 and band(mods, 0x04) == 0 do
+    mention_insert_char(state, <<cp::utf8>>)
+  end
+
+  def handle_mention_key(state, _cp_with_mods, _mods) when is_map(state), do: state
+
+  @spec mention_insert_char(state(), String.t()) :: state()
+  defp mention_insert_char(state, " ") do
+    state = update_panel(state, fn p -> %{p | mention_completion: nil} end)
+    input_char(state, " ")
+  end
+
+  defp mention_insert_char(state, char) do
+    state = input_char(state, char)
+    comp = state.agent.panel.mention_completion
+    new_prefix = comp.prefix <> char
+
+    update_panel(state, fn p ->
+      %{p | mention_completion: FileMention.update_prefix(comp, new_prefix)}
+    end)
+  end
+
+  # ── Diff review commands ───────────────────────────────────────────────────
+
+  @doc "Accepts the current diff hunk during review."
+  @spec scope_accept_hunk(state()) :: state()
+  def scope_accept_hunk(%{agentic: %{preview: %Preview{content: {:diff, _review}}}} = state) do
+    state =
+      update_preview(state, &Preview.update_diff(&1, fn r -> DiffReview.accept_current(r) end))
+
+    maybe_finish_review(state)
+  end
+
+  def scope_accept_hunk(state), do: state
+
+  @doc "Rejects the current diff hunk during review."
+  @spec scope_reject_hunk(state()) :: state()
+  def scope_reject_hunk(%{agentic: %{preview: %Preview{content: {:diff, review}}}} = state) do
+    hunk = DiffReview.current_hunk(review)
+
+    if hunk do
+      revert_hunk_on_disk(review.path, hunk)
+    end
+
+    state =
+      update_preview(state, &Preview.update_diff(&1, fn r -> DiffReview.reject_current(r) end))
+
+    maybe_finish_review(state)
+  end
+
+  def scope_reject_hunk(state), do: state
+
+  @doc "Accepts all remaining diff hunks."
+  @spec scope_accept_all_hunks(state()) :: state()
+  def scope_accept_all_hunks(%{agentic: %{preview: %Preview{content: {:diff, _}}}} = state) do
+    state =
+      update_preview(state, &Preview.update_diff(&1, fn r -> DiffReview.accept_all(r) end))
+
+    maybe_finish_review(state)
+  end
+
+  def scope_accept_all_hunks(state), do: state
+
+  @doc "Rejects all remaining diff hunks."
+  @spec scope_reject_all_hunks(state()) :: state()
+  def scope_reject_all_hunks(%{agentic: %{preview: %Preview{content: {:diff, review}}}} = state) do
+    unresolved_hunks =
+      review.hunks
+      |> Enum.with_index()
+      |> Enum.reject(fn {_hunk, idx} -> Map.has_key?(review.resolutions, idx) end)
+      |> Enum.map(fn {hunk, _idx} -> hunk end)
+      |> Enum.reverse()
+
+    revert_hunks_on_disk(review.path, unresolved_hunks)
+
+    state =
+      update_preview(state, &Preview.update_diff(&1, fn r -> DiffReview.reject_all(r) end))
+
+    maybe_finish_review(state)
+  end
+
+  def scope_reject_all_hunks(state), do: state
+
+  # ── Tool approval commands ─────────────────────────────────────────────────
+
+  @doc "Approves the pending tool execution."
+  @spec scope_approve_tool(state()) :: state()
+  def scope_approve_tool(%{agent: %{session: session, pending_approval: approval}} = state)
+      when is_pid(session) and is_map(approval) do
+    Session.respond_to_approval(session, :approve)
+    update_agent(state, &AgentState.clear_pending_approval/1)
+  end
+
+  def scope_approve_tool(state), do: state
+
+  @doc "Denies the pending tool execution."
+  @spec scope_deny_tool(state()) :: state()
+  def scope_deny_tool(%{agent: %{session: session, pending_approval: approval}} = state)
+      when is_pid(session) and is_map(approval) do
+    Session.respond_to_approval(session, :reject)
+    update_agent(state, &AgentState.clear_pending_approval/1)
+  end
+
+  def scope_deny_tool(state), do: state
+
+  # ── @-mention trigger ─────────────────────────────────────────────────────
+
+  @doc "Triggers @-mention file completion."
+  @spec scope_trigger_mention(state()) :: state()
+  def scope_trigger_mention(state) do
+    if should_trigger_mention?(state) do
+      state = input_char(state, "@")
+      start_mention_completion(state)
+    else
+      input_char(state, "@")
+    end
+  end
+
   # ── Private helpers ─────────────────────────────────────────────────────────
 
   @spec restart_session(state(), String.t()) :: state()
@@ -460,6 +1040,21 @@ defmodule Minga.Editor.Commands.Agent do
     %{state | agent: fun.(state.agent)}
   end
 
+  @spec update_agentic(state(), (ViewState.t() -> ViewState.t())) :: state()
+  defp update_agentic(state, fun) do
+    %{state | agentic: fun.(state.agentic)}
+  end
+
+  @spec update_preview(state(), (Preview.t() -> Preview.t())) :: state()
+  defp update_preview(state, fun) do
+    %{state | agentic: ViewState.update_preview(state.agentic, fun)}
+  end
+
+  @spec update_panel(state(), (PanelState.t() -> PanelState.t())) :: state()
+  defp update_panel(state, fun) do
+    update_agent(state, fn agent -> %{agent | panel: fun.(agent.panel)} end)
+  end
+
   @spec format_session_error(term()) :: String.t()
   defp format_session_error({:pi_not_found, msg}) when is_binary(msg), do: msg
   defp format_session_error({:noproc, _}), do: "Agent supervisor not running"
@@ -468,5 +1063,301 @@ defmodule Minga.Editor.Commands.Agent do
   @spec panel_height(state()) :: non_neg_integer()
   defp panel_height(state) do
     div(state.viewport.rows * 35, 100)
+  end
+
+  @spec half_page(state()) :: pos_integer()
+  defp half_page(state), do: max(div(state.viewport.rows, 2), 1)
+
+  @spec abort_if_active(state()) :: state()
+  defp abort_if_active(state) do
+    if state.agent.status in [:thinking, :tool_executing] do
+      abort_agent(state)
+    else
+      state
+    end
+  end
+
+  @spec toggle_all_collapses(state()) :: state()
+  defp toggle_all_collapses(state) do
+    if state.agent.session do
+      Session.toggle_all_tool_collapses(state.agent.session)
+    end
+
+    state
+  end
+
+  @spec scroll_context(state()) ::
+          {non_neg_integer(), Message.t(), ChatRenderer.line_type()} | nil
+  defp scroll_context(state) do
+    session = state.agent.session
+    panel = state.agent.panel
+
+    if session do
+      messages = safe_messages(session)
+      theme = state.theme
+      width = state.viewport.cols
+
+      line_map =
+        ChatRenderer.line_message_map(messages, width, theme, panel.display_start_index)
+
+      offset = panel.scroll_offset
+      total_lines = length(line_map)
+      target = max(total_lines - offset - 1, 0)
+
+      case Enum.at(line_map, target) do
+        {msg_idx, line_type} -> {msg_idx, Enum.at(messages, msg_idx), line_type}
+        nil -> nil
+      end
+    else
+      nil
+    end
+  end
+
+  @spec copy_to_clipboard(state(), String.t(), String.t()) :: state()
+  defp copy_to_clipboard(state, text, label) do
+    case Clipboard.write(text) do
+      :ok ->
+        if state.agent.session do
+          Session.add_system_message(state.agent.session, "Copied #{label} to clipboard")
+        end
+
+        update_agentic(state, &ViewState.push_toast(&1, "Copied #{label}", :info))
+
+      _error ->
+        if state.agent.session do
+          Session.add_system_message(state.agent.session, "Clipboard write failed", :error)
+        end
+
+        update_agentic(state, &ViewState.push_toast(&1, "Clipboard write failed", :error))
+    end
+
+    state
+  end
+
+  @spec code_block_for_scroll(state(), [Markdown.code_block()]) :: String.t()
+  defp code_block_for_scroll(_state, []), do: ""
+
+  defp code_block_for_scroll(state, blocks) do
+    idx = code_block_index_for_scroll(state, blocks)
+    Enum.at(blocks, idx, hd(blocks)).content
+  end
+
+  @spec code_block_at_scroll(state(), [Markdown.code_block()]) :: Markdown.code_block() | nil
+  defp code_block_at_scroll(_state, []), do: nil
+
+  defp code_block_at_scroll(state, blocks) do
+    index = code_block_index_for_scroll(state, blocks)
+    Enum.at(blocks, index)
+  end
+
+  @spec code_block_index_for_scroll(state(), [Markdown.code_block()]) :: non_neg_integer()
+  defp code_block_index_for_scroll(state, blocks) do
+    session = state.agent.session
+    panel = state.agent.panel
+    messages = safe_messages(session)
+
+    line_map =
+      ChatRenderer.line_message_map(
+        messages,
+        state.viewport.cols,
+        state.theme,
+        panel.display_start_index
+      )
+
+    offset = panel.scroll_offset
+    total_lines = length(line_map)
+    target = max(total_lines - offset - 1, 0)
+
+    {msg_idx, _type} =
+      case Enum.at(line_map, target) do
+        nil -> {0, :text}
+        entry -> entry
+      end
+
+    msg_start =
+      Enum.find_index(line_map, fn {idx, _} -> idx == msg_idx end) || 0
+
+    lines_for_msg =
+      line_map
+      |> Enum.drop(msg_start)
+      |> Enum.take_while(fn {idx, _} -> idx == msg_idx end)
+
+    relative = target - msg_start
+    idx = count_code_block_at(lines_for_msg, relative)
+    min(idx, length(blocks) - 1)
+  end
+
+  @spec count_code_block_at([{non_neg_integer(), ChatRenderer.line_type()}], non_neg_integer()) ::
+          non_neg_integer()
+  defp count_code_block_at(lines, target_offset) do
+    lines
+    |> Enum.take(target_offset + 1)
+    |> Enum.reduce({0, false}, fn {_idx, type}, {block_count, in_code} ->
+      case {type, in_code} do
+        {:code, false} -> {block_count, true}
+        {:code, true} -> {block_count, true}
+        {_, true} -> {block_count + 1, false}
+        {_, false} -> {block_count, false}
+      end
+    end)
+    |> elem(0)
+  end
+
+  @spec safe_messages(pid()) :: [Message.t()]
+  defp safe_messages(session) do
+    Session.messages(session)
+  catch
+    :exit, _ -> []
+  end
+
+  @spec run_search(state(), String.t()) :: state()
+  defp run_search(state, query) do
+    messages = if state.agent.session, do: safe_messages(state.agent.session), else: []
+    matches = ChatSearch.find_matches(messages, query)
+    state = update_agentic(state, &ViewState.set_search_matches(&1, matches))
+    if matches != [], do: scroll_to_current_match(state), else: state
+  end
+
+  @spec scroll_to_current_match(state()) :: state()
+  defp scroll_to_current_match(%{agentic: %{search: nil}} = state), do: state
+
+  defp scroll_to_current_match(%{agentic: %{search: search}} = state) do
+    case Enum.at(search.matches, search.current) do
+      nil -> state
+      match -> scroll_to_message(state, ChatSearch.match_message_index(match))
+    end
+  end
+
+  @spec scroll_to_message(state(), non_neg_integer()) :: state()
+  defp scroll_to_message(state, msg_idx) do
+    messages = if state.agent.session, do: safe_messages(state.agent.session), else: []
+
+    line_map =
+      ChatRenderer.line_message_map(
+        messages,
+        state.viewport.cols,
+        state.theme,
+        state.agent.panel.display_start_index
+      )
+
+    total_lines = length(line_map)
+
+    case Enum.find_index(line_map, fn {idx, _} -> idx == msg_idx end) do
+      nil ->
+        state
+
+      line_idx ->
+        scroll = max(total_lines - line_idx - 1, 0)
+        update_agent(state, &AgentState.set_scroll(&1, scroll))
+    end
+  end
+
+  @spec maybe_finish_review(state()) :: state()
+  defp maybe_finish_review(state) do
+    case Preview.diff_review(state.agentic.preview) do
+      %DiffReview{} = review ->
+        if DiffReview.resolved?(review), do: update_preview(state, &Preview.clear/1), else: state
+
+      nil ->
+        state
+    end
+  end
+
+  @spec revert_hunk_on_disk(String.t(), map()) :: :ok
+  defp revert_hunk_on_disk(path, hunk) do
+    case File.read(path) do
+      {:ok, content} ->
+        current_lines = String.split(content, "\n")
+        reverted = Diff.revert_hunk(current_lines, hunk)
+        File.write(path, Enum.join(reverted, "\n"))
+
+      {:error, _} ->
+        :ok
+    end
+  end
+
+  @spec revert_hunks_on_disk(String.t(), [map()]) :: :ok
+  defp revert_hunks_on_disk(path, hunks) do
+    case File.read(path) do
+      {:ok, content} ->
+        current_lines = String.split(content, "\n")
+
+        reverted =
+          Enum.reduce(hunks, current_lines, fn hunk, lines ->
+            Diff.revert_hunk(lines, hunk)
+          end)
+
+        File.write(path, Enum.join(reverted, "\n"))
+
+      {:error, _} ->
+        :ok
+    end
+  end
+
+  @spec should_trigger_mention?(state()) :: boolean()
+  defp should_trigger_mention?(state) do
+    panel = state.agent.panel
+    {line, col} = panel.input_cursor
+    current_line = Enum.at(panel.input_lines, line, "")
+    col == 0 or String.at(current_line, col - 1) in [" ", "\t", nil]
+  end
+
+  @spec start_mention_completion(state()) :: state()
+  defp start_mention_completion(state) do
+    files = list_project_files()
+    {line, col} = state.agent.panel.input_cursor
+    completion = FileMention.new_completion(files, line, col - 1)
+    update_panel(state, fn p -> %{p | mention_completion: completion} end)
+  end
+
+  @spec accept_mention_completion(state()) :: state()
+  defp accept_mention_completion(state) do
+    comp = state.agent.panel.mention_completion
+
+    case FileMention.selected_path(comp) do
+      nil ->
+        update_panel(state, fn p -> %{p | mention_completion: nil} end)
+
+      path ->
+        panel = state.agent.panel
+        {line, _col} = panel.input_cursor
+        current = Enum.at(panel.input_lines, line)
+        anchor_col = comp.anchor_col
+
+        before = String.slice(current, 0, anchor_col)
+
+        after_prefix =
+          String.slice(
+            current,
+            anchor_col + 1 + String.length(comp.prefix),
+            String.length(current)
+          )
+
+        new_line = before <> "@" <> path <> " " <> after_prefix
+        new_col = anchor_col + 1 + String.length(path) + 1
+        new_lines = List.replace_at(panel.input_lines, line, new_line)
+
+        update_panel(state, fn p ->
+          %{p | input_lines: new_lines, input_cursor: {line, new_col}, mention_completion: nil}
+        end)
+    end
+  end
+
+  @spec list_project_files() :: [String.t()]
+  defp list_project_files do
+    root =
+      try do
+        case Minga.Project.root() do
+          nil -> File.cwd!()
+          r -> r
+        end
+      catch
+        :exit, _ -> File.cwd!()
+      end
+
+    case Minga.FileFind.list_files(root) do
+      {:ok, paths} -> paths
+      {:error, _} -> []
+    end
   end
 end

--- a/lib/minga/editor/commands/movement.ex
+++ b/lib/minga/editor/commands/movement.ex
@@ -355,7 +355,8 @@ defmodule Minga.Editor.Commands.Movement do
 
   # When file tree is focused, navigating right unfocuses the tree
   defp navigate_window(%{file_tree: %{focused: true}} = state, :right) do
-    put_in(state.file_tree.focused, false)
+    state = put_in(state.file_tree.focused, false)
+    %{state | keymap_scope: :editor}
   end
 
   defp navigate_window(state, direction) do
@@ -373,7 +374,8 @@ defmodule Minga.Editor.Commands.Movement do
 
   @spec maybe_focus_file_tree(state(), :left | :right | :up | :down) :: state()
   defp maybe_focus_file_tree(%{file_tree: %{tree: %Minga.FileTree{}}} = state, :left) do
-    put_in(state.file_tree.focused, true)
+    state = put_in(state.file_tree.focused, true)
+    %{state | keymap_scope: :file_tree}
   end
 
   defp maybe_focus_file_tree(state, _direction), do: state

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -87,6 +87,7 @@ defmodule Minga.Editor.State do
             injection_ranges: %{},
             agent: %AgentState{},
             focus_stack: [],
+            keymap_scope: :editor,
             agentic: %ViewState{},
             capabilities: %Capabilities{},
             layout: nil
@@ -127,6 +128,7 @@ defmodule Minga.Editor.State do
           },
           agent: AgentState.t(),
           focus_stack: [module()],
+          keymap_scope: Minga.Keymap.Scope.scope_name(),
           agentic: ViewState.t(),
           capabilities: Capabilities.t(),
           layout: Minga.Editor.Layout.t() | nil

--- a/lib/minga/input.ex
+++ b/lib/minga/input.ex
@@ -16,24 +16,27 @@ defmodule Minga.Input do
   alias Minga.Input.GlobalBindings
   alias Minga.Input.ModeFSM
   alias Minga.Input.Picker
+  alias Minga.Input.Scoped
 
   @doc """
   Returns the default focus stack.
 
   Priority order (first handler wins):
   1. ConflictPrompt — modal, swallows all keys when active
-  2. AgenticViewKeys — full-screen agentic view (when active, handles all non-SPC keys)
-  3. AgentPanel — agent chat input (temporary, until agent becomes a buffer)
-  4. FileTree — file tree navigation (temporary, until tree becomes a buffer)
-  5. Picker — modal overlay, blocks all input while active
-  6. Completion — insert-mode sub-dispatch for popup navigation
-  7. GlobalBindings — Ctrl+S save, Ctrl+Q quit (always active)
-  8. ModeFSM — the normal vim mode system (fallback)
+  2. Scoped — keymap scope resolution (agent, file_tree, editor pass-through)
+  3. AgenticViewKeys — LEGACY: full-screen agentic view (kept until scope migration complete)
+  4. AgentPanel — agent chat input (temporary, until agent becomes a buffer)
+  5. FileTree — file tree navigation (temporary, until tree becomes a buffer)
+  6. Picker — modal overlay, blocks all input while active
+  7. Completion — insert-mode sub-dispatch for popup navigation
+  8. GlobalBindings — Ctrl+S save, Ctrl+Q quit (always active)
+  9. ModeFSM — the normal vim mode system (fallback)
   """
   @spec default_stack() :: [module()]
   def default_stack do
     [
       ConflictPrompt,
+      Scoped,
       AgenticViewKeys,
       AgentPanel,
       FileTree,

--- a/lib/minga/input/scoped.ex
+++ b/lib/minga/input/scoped.ex
@@ -1,0 +1,314 @@
+defmodule Minga.Input.Scoped do
+  @moduledoc """
+  Scope-aware input handler that replaces per-view focus stack entries.
+
+  Sits in the focus stack between modal overlays (picker, completion, conflict
+  prompt) and the vim mode FSM fallback. Resolves keys through the active
+  keymap scope, handling scope-specific bindings, prefix sequences, and
+  sub-state dispatch (search input, mention completion).
+
+  For the `:editor` scope, all keys pass through to the mode FSM (the scope
+  returns `:not_found` for every key).
+
+  For the `:agent` scope, keys are resolved against the agent scope trie.
+  Context-dependent sub-states (search input, mention completion, tool
+  approval, diff review) are handled before trie lookup. The leader key
+  (SPC) always passes through to the mode FSM for which-key integration.
+
+  For the `:file_tree` scope, tree-specific keys are handled and unmatched
+  keys pass through to the mode FSM for vim navigation.
+  """
+
+  @behaviour Minga.Input.Handler
+
+  import Bitwise
+
+  alias Minga.Agent.View.Preview
+  alias Minga.Agent.View.State, as: ViewState
+  alias Minga.Editor.Commands
+  alias Minga.Editor.Commands.Agent, as: AgentCommands
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Keymap.Scope
+  alias Minga.Port.Protocol
+
+  @ctrl Protocol.mod_ctrl()
+  @space 32
+
+  # ── Handler callback ───────────────────────────────────────────────────────
+
+  @impl true
+  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+
+  # Editor scope: always passthrough (let ModeFSM handle everything)
+  def handle_key(%{keymap_scope: :editor} = state, _cp, _mods) do
+    {:passthrough, state}
+  end
+
+  # Agent scope: dispatch through scope resolution
+  def handle_key(%{keymap_scope: :agent, agentic: %{active: true}} = state, cp, mods) do
+    handle_agent_key(state, cp, mods)
+  end
+
+  # Agent scope but not active (race condition guard): passthrough
+  def handle_key(%{keymap_scope: :agent} = state, _cp, _mods) do
+    {:passthrough, state}
+  end
+
+  # File tree scope: dispatch through scope resolution
+  def handle_key(%{keymap_scope: :file_tree, file_tree: %{focused: true}} = state, cp, mods) do
+    handle_file_tree_key(state, cp, mods)
+  end
+
+  # File tree scope but not focused: passthrough
+  def handle_key(%{keymap_scope: :file_tree} = state, _cp, _mods) do
+    {:passthrough, state}
+  end
+
+  # Unknown scope: passthrough
+  def handle_key(state, _cp, _mods), do: {:passthrough, state}
+
+  # ── Agent scope dispatch ───────────────────────────────────────────────────
+
+  @spec handle_agent_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+
+  # Dismiss toast on any key (then re-process)
+  defp handle_agent_key(%{agentic: %{toast: toast}} = state, cp, mods)
+       when toast != nil do
+    state = %{state | agentic: ViewState.dismiss_toast(state.agentic)}
+    handle_agent_key(state, cp, mods)
+  end
+
+  # SPC when not in insert mode: passthrough to leader/which-key
+  defp handle_agent_key(
+         %{agent: %{panel: %{input_focused: false}}} = state,
+         @space,
+         mods
+       )
+       when band(mods, @ctrl) == 0 do
+    {:passthrough, state}
+  end
+
+  # Leader sequence in progress: passthrough ALL keys to mode FSM
+  defp handle_agent_key(
+         %{mode_state: %{leader_node: node}, agent: %{panel: %{input_focused: false}}} = state,
+         _cp,
+         _mods
+       )
+       when is_map(node) do
+    {:passthrough, state}
+  end
+
+  # Sub-state: search input active
+  defp handle_agent_key(
+         %{agentic: %{search: %{input_active: true}}} = state,
+         cp,
+         _mods
+       ) do
+    {:handled, AgentCommands.handle_search_key(state, cp)}
+  end
+
+  # Sub-state: mention completion active (insert mode only)
+  defp handle_agent_key(
+         %{agent: %{panel: %{input_focused: true, mention_completion: comp}}} = state,
+         cp,
+         mods
+       )
+       when comp != nil do
+    {:handled, AgentCommands.handle_mention_key(state, cp, mods)}
+  end
+
+  # Sub-state: tool approval pending (y/n/Y/N)
+  defp handle_agent_key(
+         %{agent: %{pending_approval: approval, panel: %{input_focused: false}}} = state,
+         cp,
+         _mods
+       )
+       when is_map(approval) do
+    handle_approval_key(state, cp)
+  end
+
+  # Sub-state: diff review active in file_viewer focus (y/x/Y/X)
+  defp handle_agent_key(
+         %{
+           agentic: %{focus: :file_viewer, preview: %Preview{content: {:diff, _}}},
+           agent: %{panel: %{input_focused: false}}
+         } = state,
+         cp,
+         _mods
+       ) do
+    handle_diff_review_key(state, cp)
+  end
+
+  # Normal dispatch: determine vim state and resolve through scope
+  defp handle_agent_key(%{agent: %{panel: %{input_focused: true}}} = state, cp, mods) do
+    resolve_agent_key(state, :insert, cp, mods)
+  end
+
+  defp handle_agent_key(state, cp, mods) do
+    resolve_agent_key(state, :normal, cp, mods)
+  end
+
+  # ── Agent scope trie resolution ────────────────────────────────────────────
+
+  @spec resolve_agent_key(
+          EditorState.t(),
+          Scope.vim_state(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  defp resolve_agent_key(state, vim_state, cp, mods) do
+    key = {cp, mods}
+
+    # Check if we're continuing a prefix sequence
+    case state.agentic.pending_prefix do
+      nil ->
+        # Fresh lookup
+        resolve_scope_key(state, :agent, vim_state, key, cp, mods)
+
+      prefix_node when is_map(prefix_node) ->
+        # Continuing a prefix sequence stored as a trie node
+        state = %{state | agentic: ViewState.clear_prefix(state.agentic)}
+
+        case Scope.resolve_key_in_node(prefix_node, key) do
+          {:command, command} ->
+            {:handled, Commands.execute(state, command)}
+
+          {:prefix, sub_node} ->
+            # Another prefix level (rare)
+            {:handled, %{state | agentic: ViewState.set_prefix(state.agentic, sub_node)}}
+
+          :not_found ->
+            # Invalid prefix continuation, re-process the key normally
+            resolve_scope_key(state, :agent, vim_state, key, cp, mods)
+        end
+
+      _atom_prefix ->
+        # Legacy atom prefix (shouldn't happen in new system, but handle gracefully)
+        state = %{state | agentic: ViewState.clear_prefix(state.agentic)}
+        resolve_scope_key(state, :agent, vim_state, key, cp, mods)
+    end
+  end
+
+  @spec resolve_scope_key(
+          EditorState.t(),
+          Scope.scope_name(),
+          Scope.vim_state(),
+          {non_neg_integer(), non_neg_integer()},
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  defp resolve_scope_key(state, scope_name, vim_state, key, cp, mods) do
+    case Scope.resolve_key(scope_name, vim_state, key) do
+      {:command, command} ->
+        {:handled, Commands.execute(state, command)}
+
+      {:prefix, prefix_node} ->
+        # Store the prefix node for the next key
+        {:handled, %{state | agentic: ViewState.set_prefix(state.agentic, prefix_node)}}
+
+      :not_found ->
+        # No scope binding. In insert mode, self-insert printable chars.
+        if vim_state == :insert and cp >= 32 and band(mods, @ctrl) == 0 and
+             band(mods, 0x04) == 0 do
+          handle_agent_self_insert(state, cp, mods)
+        else
+          # Not handled by scope, pass through to mode FSM / next handler
+          {:handled, state}
+        end
+    end
+  end
+
+  # ── Agent self-insert (insert mode, printable chars) ───────────────────────
+
+  @spec handle_agent_self_insert(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          {:handled, EditorState.t()}
+  defp handle_agent_self_insert(state, ?@, _mods) do
+    {:handled, AgentCommands.scope_trigger_mention(state)}
+  end
+
+  defp handle_agent_self_insert(state, cp, _mods) do
+    char = <<cp::utf8>>
+    {:handled, Commands.execute(state, {:agent_self_insert, char})}
+  end
+
+  # ── Tool approval sub-state ────────────────────────────────────────────────
+
+  @spec handle_approval_key(EditorState.t(), non_neg_integer()) ::
+          {:handled, EditorState.t()}
+  defp handle_approval_key(state, ?y) do
+    {:handled, Commands.execute(state, :agent_approve_tool)}
+  end
+
+  defp handle_approval_key(state, ?n) do
+    {:handled, Commands.execute(state, :agent_deny_tool)}
+  end
+
+  defp handle_approval_key(state, ?Y) do
+    # Y = approve all (auto-approve future calls of this type)
+    {:handled, Commands.execute(state, :agent_approve_tool)}
+  end
+
+  defp handle_approval_key(state, _cp), do: {:handled, state}
+
+  # ── Diff review sub-state ──────────────────────────────────────────────────
+
+  @spec handle_diff_review_key(EditorState.t(), non_neg_integer()) ::
+          {:handled, EditorState.t()}
+  defp handle_diff_review_key(state, ?y) do
+    {:handled, Commands.execute(state, :agent_accept_hunk)}
+  end
+
+  defp handle_diff_review_key(state, ?x) do
+    {:handled, Commands.execute(state, :agent_reject_hunk)}
+  end
+
+  defp handle_diff_review_key(state, ?Y) do
+    {:handled, Commands.execute(state, :agent_accept_all_hunks)}
+  end
+
+  defp handle_diff_review_key(state, ?X) do
+    {:handled, Commands.execute(state, :agent_reject_all_hunks)}
+  end
+
+  # Navigation keys still work during diff review
+  defp handle_diff_review_key(state, cp) do
+    resolve_scope_key(state, :agent, :normal, {cp, 0}, cp, 0)
+  end
+
+  # ── File tree scope dispatch ───────────────────────────────────────────────
+
+  @spec handle_file_tree_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+
+  # Leader sequence in progress: delegate to mode FSM
+  defp handle_file_tree_key(state, cp, mods) do
+    if key_sequence_pending?(state) do
+      {:passthrough, state}
+    else
+      key = {cp, mods}
+
+      case Scope.resolve_key(:file_tree, :normal, key) do
+        {:command, command} ->
+          {:handled, Commands.execute(state, command)}
+
+        {:prefix, _node} ->
+          # File tree has no prefix sequences currently
+          {:handled, state}
+
+        :not_found ->
+          # Delegate to mode FSM for vim navigation (j/k/gg/G/etc.)
+          {:passthrough, state}
+      end
+    end
+  end
+
+  @spec key_sequence_pending?(EditorState.t()) :: boolean()
+  defp key_sequence_pending?(%{mode_state: %{leader_node: node}}) when node != nil, do: true
+  defp key_sequence_pending?(%{mode_state: %{pending_g: true}}), do: true
+  defp key_sequence_pending?(%{mode: mode}) when mode in [:operator_pending, :command], do: true
+  defp key_sequence_pending?(_state), do: false
+end

--- a/lib/minga/keymap/scope.ex
+++ b/lib/minga/keymap/scope.ex
@@ -1,0 +1,147 @@
+defmodule Minga.Keymap.Scope do
+  @moduledoc """
+  Behaviour and resolution logic for buffer-type-specific keybindings.
+
+  A keymap scope determines which keybindings are active based on the type of
+  view the user is interacting with. Think of scopes as Minga's equivalent of
+  Emacs major modes or Vim buffer-local keymaps.
+
+  Three built-in scopes ship with Minga:
+
+  * `:editor` — normal text editing (default)
+  * `:agent` — full-screen agentic view
+  * `:file_tree` — file tree panel
+
+  Each scope module implements this behaviour and declares its own keybindings
+  as trie data. Keymap resolution walks layers in priority order:
+
+  1. User overrides for the active scope + vim state (phase 2; empty for now)
+  2. Vim-state-specific bindings for the active scope
+  3. Shared bindings that apply across all vim states for the scope
+  4. Global bindings (leader sequences via SPC, Ctrl+S, Ctrl+Q)
+  5. Fallback to `Mode.process/3` for the `:editor` scope
+
+  ## Context parameter
+
+  The `keymap/2` callback receives a `context` keyword list. Phase 1 always
+  passes `[]`. Phase 2 (#215) will pass `[filetype: :elixir]` so the editor
+  scope can return filetype-specific bindings. Agent and file_tree scopes
+  ignore context.
+  """
+
+  alias Minga.Keymap.Bindings
+
+  @typedoc "Extra context for scope keymap resolution (e.g., filetype)."
+  @type context :: keyword()
+
+  @typedoc "A scope name atom."
+  @type scope_name :: :editor | :agent | :file_tree
+
+  @typedoc "Vim state relevant to scope resolution."
+  @type vim_state :: :normal | :insert
+
+  @typedoc """
+  Result of resolving a key through the scope system.
+
+  * `{:command, atom()}` — execute this named command
+  * `{:prefix, Bindings.node_t()}` — key is a prefix; more keys needed
+  * `:not_found` — scope has no binding for this key
+  """
+  @type resolve_result ::
+          {:command, atom()}
+          | {:prefix, Bindings.node_t()}
+          | :not_found
+
+  # ── Behaviour callbacks ────────────────────────────────────────────────────
+
+  @doc "Returns the atom name of this scope (e.g., `:agent`)."
+  @callback name() :: scope_name()
+
+  @doc "Returns a human-readable name for display (e.g., \"Agent\")."
+  @callback display_name() :: String.t()
+
+  @doc """
+  Returns the keybinding trie for a specific vim state.
+
+  The `context` parameter is a keyword list that phase 1 passes as `[]`.
+  Phase 2 will pass `[filetype: :elixir]` for filetype-specific bindings.
+  """
+  @callback keymap(vim_state(), context()) :: Bindings.node_t()
+
+  @doc """
+  Returns bindings that apply regardless of vim state.
+
+  These are checked after vim-state-specific bindings but before global
+  bindings. Useful for keys like Ctrl+C (abort) that work the same in
+  both normal and insert mode within a scope.
+  """
+  @callback shared_keymap() :: Bindings.node_t()
+
+  @doc "Called when this scope becomes active. Initialize scope-specific state."
+  @callback on_enter(state :: term()) :: term()
+
+  @doc "Called when this scope is deactivated. Clean up scope-specific state."
+  @callback on_exit(state :: term()) :: term()
+
+  # ── Registry ───────────────────────────────────────────────────────────────
+
+  @scope_modules %{
+    editor: Minga.Keymap.Scope.Editor,
+    agent: Minga.Keymap.Scope.Agent,
+    file_tree: Minga.Keymap.Scope.FileTree
+  }
+
+  @doc "Returns the scope module for a given scope name."
+  @spec module_for(scope_name()) :: module() | nil
+  def module_for(name) when is_atom(name), do: Map.get(@scope_modules, name)
+
+  @doc "Returns all registered scope names."
+  @spec all_scopes() :: [scope_name()]
+  def all_scopes, do: Map.keys(@scope_modules)
+
+  # ── Resolution ─────────────────────────────────────────────────────────────
+
+  @doc """
+  Resolves a key through the scope's keybinding layers.
+
+  Walks layers in priority order:
+  1. Vim-state-specific bindings for the active scope
+  2. Shared bindings for the active scope
+  3. Returns `:not_found` if no scope binding matches
+
+  Global bindings (leader sequences, Ctrl+S) and Mode.process fallback are
+  handled by the caller, not by this function.
+  """
+  @spec resolve_key(scope_name(), vim_state(), Bindings.key(), context()) :: resolve_result()
+  def resolve_key(scope_name, vim_state, key, context \\ []) do
+    case module_for(scope_name) do
+      nil ->
+        :not_found
+
+      mod ->
+        # Layer 1: vim-state-specific bindings
+        state_trie = mod.keymap(vim_state, context)
+
+        case Bindings.lookup(state_trie, key) do
+          :not_found ->
+            # Layer 2: shared bindings (cross vim-state)
+            shared_trie = mod.shared_keymap()
+            Bindings.lookup(shared_trie, key)
+
+          result ->
+            result
+        end
+    end
+  end
+
+  @doc """
+  Resolves a key against a specific trie node (for multi-key sequences).
+
+  Used when continuing a prefix sequence within a scope. The caller tracks
+  which trie node to continue from.
+  """
+  @spec resolve_key_in_node(Bindings.node_t(), Bindings.key()) :: resolve_result()
+  def resolve_key_in_node(node, key) do
+    Bindings.lookup(node, key)
+  end
+end

--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -1,0 +1,154 @@
+defmodule Minga.Keymap.Scope.Agent do
+  @moduledoc """
+  Keymap scope for the full-screen agentic view.
+
+  Provides vim-like navigation, fold/collapse, copy, search, and panel
+  management bindings. In normal mode, keys like `j`/`k` scroll the chat,
+  `y`/`Y` copy content, and prefix sequences (`z`, `g`, `]`, `[`) provide
+  fold, go-to, and bracket navigation.
+
+  In insert mode (input field focused), printable characters go to the input
+  field. Ctrl+C submits or aborts, ESC returns to normal mode.
+
+  All bindings are declared as trie data and resolved through the scope
+  system. Context-dependent behavior (e.g., `y` copies a code block normally
+  but accepts a diff hunk during review) is handled by guards on command
+  functions, not separate dispatch paths.
+  """
+
+  @behaviour Minga.Keymap.Scope
+
+  alias Minga.Keymap.Bindings
+
+  # Modifier bitmasks
+  @ctrl 0x02
+  @shift 0x01
+  @alt 0x04
+
+  # Special codepoints
+  @tab 9
+  @enter 13
+  @escape 27
+  @backspace 127
+
+  # ── Behaviour callbacks ────────────────────────────────────────────────────
+
+  @impl true
+  @spec name() :: :agent
+  def name, do: :agent
+
+  @impl true
+  @spec display_name() :: String.t()
+  def display_name, do: "Agent"
+
+  @impl true
+  @spec keymap(Minga.Keymap.Scope.vim_state(), Minga.Keymap.Scope.context()) ::
+          Bindings.node_t()
+  def keymap(:normal, _context), do: normal_trie()
+  def keymap(:insert, _context), do: insert_trie()
+  def keymap(_state, _context), do: Bindings.new()
+
+  @impl true
+  @spec shared_keymap() :: Bindings.node_t()
+  def shared_keymap, do: shared_trie()
+
+  @impl true
+  @spec on_enter(term()) :: term()
+  def on_enter(state), do: state
+
+  @impl true
+  @spec on_exit(term()) :: term()
+  def on_exit(state), do: state
+
+  # ── Normal mode bindings ───────────────────────────────────────────────────
+
+  @spec normal_trie() :: Bindings.node_t()
+  defp normal_trie do
+    Bindings.new()
+    # Navigation
+    |> Bindings.bind([{?j, 0}], :agent_scroll_down, "Scroll down")
+    |> Bindings.bind([{?k, 0}], :agent_scroll_up, "Scroll up")
+    |> Bindings.bind([{?d, @ctrl}], :agent_scroll_half_down, "Scroll half page down")
+    |> Bindings.bind([{?u, @ctrl}], :agent_scroll_half_up, "Scroll half page up")
+    |> Bindings.bind([{?G, 0}], :agent_scroll_bottom, "Scroll to bottom")
+    # g-prefix
+    |> Bindings.bind([{?g, 0}, {?g, 0}], :agent_scroll_top, "Scroll to top")
+    |> Bindings.bind([{?g, 0}, {?f, 0}], :agent_open_code_block, "Open code block in editor")
+    # z-prefix (fold/collapse)
+    |> Bindings.bind([{?z, 0}, {?a, 0}], :agent_toggle_collapse, "Toggle collapse at cursor")
+    |> Bindings.bind([{?z, 0}, {?A, 0}], :agent_toggle_all_collapse, "Toggle all collapses")
+    |> Bindings.bind([{?z, 0}, {?o, 0}], :agent_expand_at_cursor, "Expand at cursor")
+    |> Bindings.bind([{?z, 0}, {?c, 0}], :agent_collapse_at_cursor, "Collapse at cursor")
+    |> Bindings.bind([{?z, 0}, {?M, 0}], :agent_collapse_all, "Collapse all")
+    |> Bindings.bind([{?z, 0}, {?R, 0}], :agent_expand_all, "Expand all")
+    # ]-prefix (next item)
+    |> Bindings.bind([{?], 0}, {?m, 0}], :agent_next_message, "Next message")
+    |> Bindings.bind([{?], 0}, {?c, 0}], :agent_next_code_block, "Next code block/hunk")
+    |> Bindings.bind([{?], 0}, {?t, 0}], :agent_next_tool_call, "Next tool call")
+    # [-prefix (prev item)
+    |> Bindings.bind([{?[, 0}, {?m, 0}], :agent_prev_message, "Previous message")
+    |> Bindings.bind([{?[, 0}, {?c, 0}], :agent_prev_code_block, "Previous code block/hunk")
+    |> Bindings.bind([{?[, 0}, {?t, 0}], :agent_prev_tool_call, "Previous tool call")
+    # Copy
+    |> Bindings.bind([{?y, 0}], :agent_copy_code_block, "Copy code block")
+    |> Bindings.bind([{?Y, 0}], :agent_copy_message, "Copy full message")
+    # Input focus
+    |> Bindings.bind([{?i, 0}], :agent_focus_input, "Focus input")
+    |> Bindings.bind([{?a, 0}], :agent_focus_input, "Focus input")
+    |> Bindings.bind([{@enter, 0}], :agent_focus_input, "Focus input")
+    # Collapse toggle (magit-style o)
+    |> Bindings.bind([{?o, 0}], :agent_toggle_collapse, "Toggle collapse")
+    # Panel
+    |> Bindings.bind([{?}, 0}], :agent_grow_panel, "Grow chat panel")
+    |> Bindings.bind([{?{, 0}], :agent_shrink_panel, "Shrink chat panel")
+    |> Bindings.bind([{?=, 0}], :agent_reset_panel, "Reset panel split")
+    |> Bindings.bind([{@tab, 0}], :agent_switch_focus, "Switch panel focus")
+    # Search
+    |> Bindings.bind([{?/, 0}], :agent_start_search, "Search")
+    |> Bindings.bind([{?n, 0}], :agent_next_search_match, "Next search match")
+    |> Bindings.bind([{?N, 0}], :agent_prev_search_match, "Previous search match")
+    # Session
+    |> Bindings.bind([{?s, 0}], :agent_session_switcher, "Session switcher")
+    # Help
+    |> Bindings.bind([{??, 0}], :agent_toggle_help, "Toggle help overlay")
+    # Close
+    |> Bindings.bind([{?q, 0}], :agent_close, "Close agentic view")
+    |> Bindings.bind([{@escape, 0}], :agent_dismiss_or_noop, "Dismiss/cancel")
+    # Clear
+    |> Bindings.bind([{?l, @ctrl}], :agent_clear_chat, "Clear chat display")
+  end
+
+  # ── Insert mode bindings ───────────────────────────────────────────────────
+
+  @spec insert_trie() :: Bindings.node_t()
+  defp insert_trie do
+    Bindings.new()
+    # ESC exits insert mode (unfocus input)
+    |> Bindings.bind([{@escape, 0}], :agent_unfocus_input, "Unfocus input")
+    # Ctrl+Q unfocus + quit
+    |> Bindings.bind([{?q, @ctrl}], :agent_unfocus_and_quit, "Unfocus input and quit")
+    # Enter submits (plain), Shift+Enter or Alt+Enter inserts newline
+    |> Bindings.bind([{@enter, 0}], :agent_submit_or_newline, "Submit prompt")
+    |> Bindings.bind([{@enter, @shift}], :agent_insert_newline, "Insert newline")
+    |> Bindings.bind([{@enter, @alt}], :agent_insert_newline, "Insert newline")
+    # Backspace
+    |> Bindings.bind([{@backspace, 0}], :agent_input_backspace, "Delete character")
+    # Navigation in input
+    |> Bindings.bind([{0xF700, 0}], :agent_input_up, "Move up / history prev")
+    |> Bindings.bind([{0xF701, 0}], :agent_input_down, "Move down / history next")
+    # Ctrl modifiers
+    |> Bindings.bind([{?c, @ctrl}], :agent_submit_or_abort, "Submit or abort")
+    |> Bindings.bind([{?d, @ctrl}], :agent_scroll_half_down, "Scroll down (while typing)")
+    |> Bindings.bind([{?u, @ctrl}], :agent_scroll_half_up, "Scroll up (while typing)")
+    |> Bindings.bind([{?l, @ctrl}], :agent_clear_chat, "Clear chat display")
+    |> Bindings.bind([{?s, @ctrl}], :agent_save_buffer, "Save buffer")
+  end
+
+  # ── Shared bindings (both normal and insert) ───────────────────────────────
+
+  @spec shared_trie() :: Bindings.node_t()
+  defp shared_trie do
+    # Ctrl+C works the same in both modes
+    Bindings.new()
+  end
+end

--- a/lib/minga/keymap/scope/editor.ex
+++ b/lib/minga/keymap/scope/editor.ex
@@ -1,0 +1,42 @@
+defmodule Minga.Keymap.Scope.Editor do
+  @moduledoc """
+  Keymap scope for normal text editing.
+
+  This is the default scope. It provides no scope-specific bindings because
+  the existing `Mode` system (normal, insert, visual, etc.) handles all
+  editor keybindings. The scope exists so the resolution system has a
+  uniform interface for all contexts.
+
+  The input router falls through to `Mode.process/3` when the editor scope
+  returns `:not_found` for a key.
+  """
+
+  @behaviour Minga.Keymap.Scope
+
+  alias Minga.Keymap.Bindings
+
+  @impl true
+  @spec name() :: :editor
+  def name, do: :editor
+
+  @impl true
+  @spec display_name() :: String.t()
+  def display_name, do: "Editor"
+
+  @impl true
+  @spec keymap(Minga.Keymap.Scope.vim_state(), Minga.Keymap.Scope.context()) ::
+          Bindings.node_t()
+  def keymap(_vim_state, _context), do: Bindings.new()
+
+  @impl true
+  @spec shared_keymap() :: Bindings.node_t()
+  def shared_keymap, do: Bindings.new()
+
+  @impl true
+  @spec on_enter(term()) :: term()
+  def on_enter(state), do: state
+
+  @impl true
+  @spec on_exit(term()) :: term()
+  def on_exit(state), do: state
+end

--- a/lib/minga/keymap/scope/file_tree.ex
+++ b/lib/minga/keymap/scope/file_tree.ex
@@ -1,0 +1,64 @@
+defmodule Minga.Keymap.Scope.FileTree do
+  @moduledoc """
+  Keymap scope for the file tree panel.
+
+  Provides tree navigation and manipulation bindings: Enter to open files,
+  h/l to collapse/expand directories, H to toggle hidden files, r to refresh.
+  Unmatched keys fall through to the global leader trie and Mode.process
+  (for vim navigation like j/k/gg/G/Ctrl-d/Ctrl-u).
+
+  The file tree always operates in normal mode. Mode transitions to insert
+  or visual are blocked.
+  """
+
+  @behaviour Minga.Keymap.Scope
+
+  alias Minga.Keymap.Bindings
+
+  @tab 9
+  @enter 13
+  @escape 27
+
+  # ── Behaviour callbacks ────────────────────────────────────────────────────
+
+  @impl true
+  @spec name() :: :file_tree
+  def name, do: :file_tree
+
+  @impl true
+  @spec display_name() :: String.t()
+  def display_name, do: "File Tree"
+
+  @impl true
+  @spec keymap(Minga.Keymap.Scope.vim_state(), Minga.Keymap.Scope.context()) ::
+          Bindings.node_t()
+  def keymap(:normal, _context), do: normal_trie()
+  def keymap(_state, _context), do: Bindings.new()
+
+  @impl true
+  @spec shared_keymap() :: Bindings.node_t()
+  def shared_keymap, do: Bindings.new()
+
+  @impl true
+  @spec on_enter(term()) :: term()
+  def on_enter(state), do: state
+
+  @impl true
+  @spec on_exit(term()) :: term()
+  def on_exit(state), do: state
+
+  # ── Normal mode bindings ───────────────────────────────────────────────────
+
+  @spec normal_trie() :: Bindings.node_t()
+  defp normal_trie do
+    Bindings.new()
+    |> Bindings.bind([{@enter, 0}], :tree_open_or_toggle, "Open file / toggle directory")
+    |> Bindings.bind([{@tab, 0}], :tree_toggle_directory, "Toggle directory")
+    |> Bindings.bind([{?l, 0}], :tree_expand, "Expand directory")
+    |> Bindings.bind([{?h, 0}], :tree_collapse, "Collapse directory")
+    |> Bindings.bind([{?H, 0}], :tree_toggle_hidden, "Toggle hidden files")
+    |> Bindings.bind([{?r, 0}], :tree_refresh, "Refresh file tree")
+    |> Bindings.bind([{?q, 0}], :tree_close, "Close file tree")
+    |> Bindings.bind([{@escape, 0}], :tree_close, "Close file tree")
+  end
+end

--- a/test/minga/keymap/scope_test.exs
+++ b/test/minga/keymap/scope_test.exs
@@ -1,0 +1,201 @@
+defmodule Minga.Keymap.ScopeTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Keymap.Bindings
+  alias Minga.Keymap.Scope
+
+  describe "module_for/1" do
+    test "returns Editor module for :editor" do
+      assert Scope.module_for(:editor) == Minga.Keymap.Scope.Editor
+    end
+
+    test "returns Agent module for :agent" do
+      assert Scope.module_for(:agent) == Minga.Keymap.Scope.Agent
+    end
+
+    test "returns FileTree module for :file_tree" do
+      assert Scope.module_for(:file_tree) == Minga.Keymap.Scope.FileTree
+    end
+
+    test "returns nil for unknown scope" do
+      assert Scope.module_for(:bogus) == nil
+    end
+  end
+
+  describe "all_scopes/0" do
+    test "returns all three built-in scopes" do
+      scopes = Scope.all_scopes()
+      assert :editor in scopes
+      assert :agent in scopes
+      assert :file_tree in scopes
+      assert length(scopes) == 3
+    end
+  end
+
+  describe "resolve_key/4 with :editor scope" do
+    test "always returns :not_found (editor scope is pass-through)" do
+      assert Scope.resolve_key(:editor, :normal, {?j, 0}) == :not_found
+      assert Scope.resolve_key(:editor, :insert, {?a, 0}) == :not_found
+    end
+  end
+
+  describe "resolve_key/4 with :agent scope" do
+    test "resolves j to agent_scroll_down in normal mode" do
+      assert {:command, :agent_scroll_down} = Scope.resolve_key(:agent, :normal, {?j, 0})
+    end
+
+    test "resolves k to agent_scroll_up in normal mode" do
+      assert {:command, :agent_scroll_up} = Scope.resolve_key(:agent, :normal, {?k, 0})
+    end
+
+    test "resolves Ctrl+D to agent_scroll_half_down in normal mode" do
+      assert {:command, :agent_scroll_half_down} = Scope.resolve_key(:agent, :normal, {?d, 0x02})
+    end
+
+    test "resolves G to agent_scroll_bottom in normal mode" do
+      assert {:command, :agent_scroll_bottom} = Scope.resolve_key(:agent, :normal, {?G, 0})
+    end
+
+    test "g is a prefix in normal mode" do
+      assert {:prefix, _node} = Scope.resolve_key(:agent, :normal, {?g, 0})
+    end
+
+    test "gg resolves to agent_scroll_top via prefix walk" do
+      {:prefix, g_node} = Scope.resolve_key(:agent, :normal, {?g, 0})
+      assert {:command, :agent_scroll_top} = Scope.resolve_key_in_node(g_node, {?g, 0})
+    end
+
+    test "gf resolves to agent_open_code_block via prefix walk" do
+      {:prefix, g_node} = Scope.resolve_key(:agent, :normal, {?g, 0})
+      assert {:command, :agent_open_code_block} = Scope.resolve_key_in_node(g_node, {?f, 0})
+    end
+
+    test "z is a prefix in normal mode" do
+      assert {:prefix, _node} = Scope.resolve_key(:agent, :normal, {?z, 0})
+    end
+
+    test "za resolves to agent_toggle_collapse" do
+      {:prefix, z_node} = Scope.resolve_key(:agent, :normal, {?z, 0})
+      assert {:command, :agent_toggle_collapse} = Scope.resolve_key_in_node(z_node, {?a, 0})
+    end
+
+    test "zM resolves to agent_collapse_all" do
+      {:prefix, z_node} = Scope.resolve_key(:agent, :normal, {?z, 0})
+      assert {:command, :agent_collapse_all} = Scope.resolve_key_in_node(z_node, {?M, 0})
+    end
+
+    test "] is a prefix in normal mode" do
+      assert {:prefix, _node} = Scope.resolve_key(:agent, :normal, {?], 0})
+    end
+
+    test "]c resolves to agent_next_code_block" do
+      {:prefix, bracket_node} = Scope.resolve_key(:agent, :normal, {?], 0})
+
+      assert {:command, :agent_next_code_block} =
+               Scope.resolve_key_in_node(bracket_node, {?c, 0})
+    end
+
+    test "y resolves to agent_copy_code_block in normal mode" do
+      assert {:command, :agent_copy_code_block} = Scope.resolve_key(:agent, :normal, {?y, 0})
+    end
+
+    test "Y resolves to agent_copy_message in normal mode" do
+      assert {:command, :agent_copy_message} = Scope.resolve_key(:agent, :normal, {?Y, 0})
+    end
+
+    test "q resolves to agent_close in normal mode" do
+      assert {:command, :agent_close} = Scope.resolve_key(:agent, :normal, {?q, 0})
+    end
+
+    test "/ resolves to agent_start_search in normal mode" do
+      assert {:command, :agent_start_search} = Scope.resolve_key(:agent, :normal, {?/, 0})
+    end
+
+    test "? resolves to agent_toggle_help in normal mode" do
+      assert {:command, :agent_toggle_help} = Scope.resolve_key(:agent, :normal, {??, 0})
+    end
+
+    test "ESC resolves to agent_unfocus_input in insert mode" do
+      assert {:command, :agent_unfocus_input} = Scope.resolve_key(:agent, :insert, {27, 0})
+    end
+
+    test "Enter resolves to agent_submit_or_newline in insert mode" do
+      assert {:command, :agent_submit_or_newline} = Scope.resolve_key(:agent, :insert, {13, 0})
+    end
+
+    test "Backspace resolves to agent_input_backspace in insert mode" do
+      assert {:command, :agent_input_backspace} = Scope.resolve_key(:agent, :insert, {127, 0})
+    end
+
+    test "Ctrl+C resolves to agent_submit_or_abort in insert mode" do
+      assert {:command, :agent_submit_or_abort} = Scope.resolve_key(:agent, :insert, {?c, 0x02})
+    end
+
+    test "unknown key returns :not_found in normal mode" do
+      # tilde is not bound
+      assert :not_found = Scope.resolve_key(:agent, :normal, {?~, 0})
+    end
+
+    test "normal-mode keys don't resolve in insert mode" do
+      # j is bound in normal but not insert
+      assert :not_found = Scope.resolve_key(:agent, :insert, {?j, 0})
+    end
+  end
+
+  describe "resolve_key/4 with :file_tree scope" do
+    test "Enter resolves to tree_open_or_toggle" do
+      assert {:command, :tree_open_or_toggle} = Scope.resolve_key(:file_tree, :normal, {13, 0})
+    end
+
+    test "l resolves to tree_expand" do
+      assert {:command, :tree_expand} = Scope.resolve_key(:file_tree, :normal, {?l, 0})
+    end
+
+    test "h resolves to tree_collapse" do
+      assert {:command, :tree_collapse} = Scope.resolve_key(:file_tree, :normal, {?h, 0})
+    end
+
+    test "H resolves to tree_toggle_hidden" do
+      assert {:command, :tree_toggle_hidden} = Scope.resolve_key(:file_tree, :normal, {?H, 0})
+    end
+
+    test "q resolves to tree_close" do
+      assert {:command, :tree_close} = Scope.resolve_key(:file_tree, :normal, {?q, 0})
+    end
+
+    test "unknown key returns :not_found" do
+      assert :not_found = Scope.resolve_key(:file_tree, :normal, {?x, 0})
+    end
+  end
+
+  describe "resolve_key/4 with unknown scope" do
+    test "returns :not_found" do
+      assert :not_found = Scope.resolve_key(:nonexistent, :normal, {?j, 0})
+    end
+  end
+
+  describe "behaviour contract" do
+    for {scope_name, mod} <- [
+          editor: Minga.Keymap.Scope.Editor,
+          agent: Minga.Keymap.Scope.Agent,
+          file_tree: Minga.Keymap.Scope.FileTree
+        ] do
+      test "#{mod} implements name/0 returning #{scope_name}" do
+        assert unquote(mod).name() == unquote(scope_name)
+      end
+
+      test "#{mod} implements display_name/0 returning a string" do
+        assert is_binary(unquote(mod).display_name())
+      end
+
+      test "#{mod} implements keymap/2 returning a trie node" do
+        assert %Bindings.Node{} = unquote(mod).keymap(:normal, [])
+        assert %Bindings.Node{} = unquote(mod).keymap(:insert, [])
+      end
+
+      test "#{mod} implements shared_keymap/0 returning a trie node" do
+        assert %Bindings.Node{} = unquote(mod).shared_keymap()
+      end
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

Introduces keymap scopes, a buffer-type-specific keybinding system that replaces the focus stack for view-level key dispatch. Three scopes ship: `:editor` (pass-through), `:agent` (agentic view), and `:file_tree`. This is the architectural foundation; legacy handlers remain active as a safety net until the next PR cuts them over.

Part of #223

## Context

Issue #223 identifies a structural problem: the focus stack and the keymap/mode system are two parallel input systems that do not compose. Every new keybinding in the agentic view or file tree requires manual passthrough logic, creating a class of bugs where leader key sequences silently break in certain contexts.

This PR builds **phase 1 of the keymap scope architecture** (steps 1-6 of the ticket). It defines the `Keymap.Scope` behaviour, creates scope modules with trie-based bindings, extracts 50+ command functions from `Agent.View.Keys` into `Commands.Agent`, builds the `Input.Scoped` handler, and wires scope switching into toggle commands. The legacy handlers remain in the focus stack below the new scoped handler as a migration safety net.

The next PR will activate the scope handler as the primary dispatcher and remove the legacy handlers.

## Changes

- **`Keymap.Scope` behaviour** (`lib/minga/keymap/scope.ex`): Defines the contract for scope modules (`name`, `display_name`, `keymap/2`, `shared_keymap`, `on_enter`/`on_exit`). Includes a registry mapping scope names to modules and `resolve_key/4` which walks vim-state-specific bindings then shared bindings.

- **Three scope modules**: `Scope.Editor` (empty pass-through), `Scope.Agent` (full trie with 30+ normal-mode bindings including prefix sequences for `g`, `z`, `]`, `[`, plus insert-mode bindings), `Scope.FileTree` (8 tree-specific bindings).

- **`Input.Scoped` handler** (`lib/minga/input/scoped.ex`): Focus stack handler that routes keys through the active scope. Handles sub-state dispatch for search input, mention completion, tool approval, and diff review before trie lookup. Leader key (SPC) always passes through to the mode FSM for which-key. Self-insert for printable chars in agent insert mode.

- **50+ command functions** extracted from `Agent.View.Keys` into `Commands.Agent`: `scope_scroll_down`, `scope_copy_code_block`, `scope_toggle_collapse`, `handle_search_key`, `handle_mention_key`, diff review and tool approval commands, etc. All wired through `Commands.execute`.

- **File tree scope commands** added to `Commands.ex`: `tree_open_or_toggle`, `tree_expand`, `tree_collapse`, `tree_toggle_hidden`, `tree_refresh`, `tree_close`.

- **Scope switching**: `toggle_agentic_view` sets `keymap_scope: :agent` on activate, `:editor` on deactivate. `toggle_file_tree` and window navigation update scope on tree focus/unfocus.

- **EditorState**: Added `keymap_scope` field (default `:editor`).

- **ViewState**: Expanded `prefix` type to accept trie nodes alongside legacy atom prefixes.

**Design decision**: The scoped handler sits *above* the legacy handlers in the focus stack. When `keymap_scope` is `:editor`, it passes through immediately, so the legacy handlers still process keys for agent/file_tree views. This means zero behavior change in this PR. The cutover PR will set `keymap_scope` correctly and remove the legacy handlers.

## Verification

1. `mix compile --warnings-as-errors` passes clean
2. `mix test --warnings-as-errors` passes (3203 tests, 48 new scope tests)
3. `mix lint` passes (format + credo --strict + compile warnings)
4. No user-visible behavior change (legacy handlers still active below scoped handler)

To verify scope trie resolution independently:
```bash
mix test test/minga/keymap/scope_test.exs --verbose
```

## Acceptance Criteria Addressed

From #223:

- `Keymap.Scope` behaviour and registry ✅
- Scope modules for editor, agent, and file_tree ✅  
- Agentic view bindings registered in keymap system (trie data) ✅
- File tree bindings registered in keymap system ✅
- `keymap_scope` field in EditorState ✅
- Scope switching wired into toggle commands ✅
- Context-dependent keys use guards on command functions ✅
- Scope behaviour supports future filetype parameterization (#215) via `context` parameter ✅

**Not yet addressed** (next PR):
- Legacy focus stack handlers removed
- Which-key shows correct bindings for active scope
- Users can override scope-specific bindings via config
- `Keymap.Active` phase 2 infrastructure
- Documentation updates