### PR TITLE
fix(zig): fill empty cells with theme background color

### DIFF
--- a/zig/src/apprt/tui.zig
+++ b/zig/src/apprt/tui.zig
@@ -31,6 +31,22 @@ pub const VaxisSurface = struct {
         win.clear();
     }
 
+    /// Fills every cell in the window with a background color.
+    /// Used after clear() to replace the terminal's default background
+    /// with the editor theme's background, so empty cells match.
+    pub fn fillBg(self: *VaxisSurface, bg: u24) void {
+        const win = self.vx.window();
+        win.fill(.{
+            .style = .{
+                .bg = .{ .rgb = .{
+                    @as(u8, @intCast((bg >> 16) & 0xFF)),
+                    @as(u8, @intCast((bg >> 8) & 0xFF)),
+                    @as(u8, @intCast(bg & 0xFF)),
+                } },
+            },
+        });
+    }
+
     pub fn writeCell(self: *VaxisSurface, col: u16, row: u16, cell: Cell) void {
         const win = self.vx.window();
         const style = cellToStyle(cell);

--- a/zig/src/renderer.zig
+++ b/zig/src/renderer.zig
@@ -56,6 +56,12 @@ pub fn Renderer(comptime SurfaceT: type) type {
             switch (cmd) {
                 .clear => {
                     self.surface.clear();
+                    // Fill the entire screen with the theme background so empty
+                    // cells (right of text, below content) match the editor
+                    // theme instead of showing the terminal's default bg.
+                    if (self.default_bg != 0) {
+                        self.surface.fillBg(self.default_bg);
+                    }
                     // Safe to discard pending grapheme copies when the screen is cleared.
                     _ = self.arena.reset(.retain_capacity);
                 },
@@ -160,6 +166,11 @@ pub fn Renderer(comptime SurfaceT: type) type {
 
                 .set_default_bg => |bg| {
                     self.default_bg = bg;
+                    // Fill immediately so the theme background takes effect
+                    // even if no clear command follows in this batch.
+                    if (bg != 0) {
+                        self.surface.fillBg(bg);
+                    }
                 },
 
                 // edit_buffer, measure_text and highlight commands are handled by the event loop, not the renderer.
@@ -193,6 +204,8 @@ pub fn Renderer(comptime SurfaceT: type) type {
 /// A mock Surface that records calls for test verification.
 const MockSurface = struct {
     clear_count: usize = 0,
+    fill_bg_count: usize = 0,
+    last_fill_bg: u24 = 0,
     render_count: usize = 0,
     last_cursor_col: u16 = 0,
     last_cursor_row: u16 = 0,
@@ -214,6 +227,11 @@ const MockSurface = struct {
 
     pub fn clear(self: *MockSurface) void {
         self.clear_count += 1;
+    }
+
+    pub fn fillBg(self: *MockSurface, bg: u24) void {
+        self.last_fill_bg = bg;
+        self.fill_bg_count += 1;
     }
 
     pub fn writeCell(self: *MockSurface, _: u16, _: u16, cell: Cell) void {
@@ -361,6 +379,42 @@ test "set_default_bg stores default background" {
     try std.testing.expectEqual(@as(u24, 0), rend.default_bg);
     try rend.handleCommand(.{ .set_default_bg = 0x282C34 });
     try std.testing.expectEqual(@as(u24, 0x282C34), rend.default_bg);
+}
+
+test "set_default_bg fills surface with theme background" {
+    var mock = MockSurface{};
+    var rend = Renderer(MockSurface).init(&mock, std.testing.allocator);
+    defer rend.deinit();
+
+    try rend.handleCommand(.{ .set_default_bg = 0x282C34 });
+    try std.testing.expectEqual(@as(usize, 1), mock.fill_bg_count);
+    try std.testing.expectEqual(@as(u24, 0x282C34), mock.last_fill_bg);
+}
+
+test "clear with default_bg fills surface with theme background" {
+    var mock = MockSurface{};
+    var rend = Renderer(MockSurface).init(&mock, std.testing.allocator);
+    defer rend.deinit();
+
+    // Set theme bg first
+    try rend.handleCommand(.{ .set_default_bg = 0x282C34 });
+    mock.fill_bg_count = 0; // reset counter from set_default_bg
+
+    // Clear should fill with theme bg
+    try rend.handleCommand(.clear);
+    try std.testing.expectEqual(@as(usize, 1), mock.clear_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.fill_bg_count);
+    try std.testing.expectEqual(@as(u24, 0x282C34), mock.last_fill_bg);
+}
+
+test "clear without default_bg does not fill" {
+    var mock = MockSurface{};
+    var rend = Renderer(MockSurface).init(&mock, std.testing.allocator);
+    defer rend.deinit();
+
+    try rend.handleCommand(.clear);
+    try std.testing.expectEqual(@as(usize, 1), mock.clear_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.fill_bg_count);
 }
 
 test "draw_text with bg=0 uses default_bg when set" {

--- a/zig/src/surface.zig
+++ b/zig/src/surface.zig
@@ -47,6 +47,7 @@ pub const Cell = struct {
 /// Call as: `comptime { surface.assertSurface(@TypeOf(my_surface)); }`
 pub fn assertSurface(comptime T: type) void {
     if (!@hasDecl(T, "clear")) @compileError("Surface missing method: clear");
+    if (!@hasDecl(T, "fillBg")) @compileError("Surface missing method: fillBg");
     if (!@hasDecl(T, "writeCell")) @compileError("Surface missing method: writeCell");
     if (!@hasDecl(T, "showCursor")) @compileError("Surface missing method: showCursor");
     if (!@hasDecl(T, "setCursorShape")) @compileError("Surface missing method: setCursorShape");


### PR DESCRIPTION
# TL;DR

Empty cells in the TUI (right of text, below content) now use the editor theme background instead of the terminal's default background. No more color mismatch between the editor content and empty space.

## Context

The TUI renderer only wrote background colors to cells covered by `draw_text` commands. Cells that were never written to (the space past the end of each line, empty rows below content) fell through to the terminal's default background. If the terminal's background differed from the editor theme's background, you'd see a visible seam. This is the same class of issue the macOS GUI frontend had previously.

The standard approach used by Neovim, Helix, and Emacs is to fill every cell on screen with the theme background so no cell is left in the terminal's default state.

## Changes

- **`surface.zig`**: Added `fillBg(u24)` to the Surface interface. Each backend fills its grid with a background color in whatever way is native to it.
- **`apprt/tui.zig`**: `VaxisSurface.fillBg()` calls `win.fill()` with a vaxis cell styled with the theme background RGB.
- **`renderer.zig`**: Calls `surface.fillBg()` in two places:
  - On `set_default_bg`: immediate fill so the theme bg takes effect even without a subsequent clear.
  - On `clear`: fills after clearing so every frame starts with the theme background.
- **Tests**: Added 3 new tests (`set_default_bg fills surface`, `clear with default_bg fills`, `clear without default_bg does not fill`). Updated MockSurface with `fillBg` tracking fields.

libvaxis's cell-level diffing means the fill only writes to the terminal on the first frame or after a resize. Subsequent frames diff against the filled grid and skip unchanged cells.

## Verification

1. Check out this branch, rebuild (`cd zig && zig build`)
2. Open minga in a terminal whose default background differs from the editor theme
3. Verify the entire editor area has a uniform background color, including space to the right of short lines and below the file content
4. Resize the terminal and verify the background stays consistent
5. `cd zig && zig build test` passes