### PR TITLE
Boot into agentic view by default

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -316,6 +316,7 @@ Current status and planned features. Updated as development progresses.
 | Configurable panel split | ✅ | agent_panel_split config option; {/} resize; = reset #183 |
 | Notification toasts | ✅ | Top-right toasts for actions; auto-dismiss 3s; FIFO queue #179 |
 | Directory listing preview | ✅ | list_directory tool output shown with file/folder icons #220 |
+| Agent-first startup | ✅ | Boot into agentic view by default; configurable via `startup_view` and `agent_auto_context` #242 |
 | Inline completions (ghost text) | 📋 | #74 |
 | Agent-aware undo | 📋 | #76 |
 | Edit boundaries | 📋 | #78 |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -38,6 +38,8 @@ That's it. Save the file and restart Minga. Your options take effect immediately
 | `:agent_tool_approval` | `:destructive`, `:all`, `:none` | `:destructive` | When to prompt before executing agent tools |
 | `:agent_destructive_tools` | list of strings | `["write_file", "edit_file", "shell"]` | Which tools are classified as destructive |
 | `:agent_session_retention_days` | positive integer | `30` | Days to keep saved agent sessions before auto-pruning |
+| `:startup_view` | `:agent` or `:editor` | `:agent` | Which view to show on startup (see [Startup view](#startup-view) below) |
+| `:agent_auto_context` | boolean | `true` | Load CLI file as agent preview context on startup |
 | `:font_family` | string | `"Menlo"` | Font family or name (see [Fonts](#fonts) below) |
 | `:font_size` | positive integer | `13` | Font size in points (see [Fonts](#fonts) below) |
 | `:font_weight` | weight atom | `:regular` | Font weight (see [Fonts](#fonts) below) |
@@ -112,6 +114,61 @@ set :agent_destructive_tools, []
 The two options are orthogonal. `:agent_tool_approval` controls *whether* to prompt. `:agent_destructive_tools` controls *which tools* count as destructive when the mode is `:destructive`.
 
 For the full option API, see [`Minga.Config.Options`](https://jsmestad.github.io/minga/Minga.Config.Options.html).
+
+## Startup view
+
+Minga boots into the full-screen agentic view by default. The chat panel is visible, the input is focused, and an agent session starts automatically. You're ready to talk to the agent the moment Minga opens.
+
+If you pass a file on the command line (`minga foo.ex`), the file opens in the preview pane so the agent has context about what you're working on.
+
+### Switching to editor-first startup
+
+If you prefer the traditional file editing experience on startup, set `:startup_view` to `:editor`:
+
+```elixir
+set :startup_view, :editor
+```
+
+This restores the pre-1.0 behavior: Minga opens with a file buffer (or scratch buffer) and the agentic view is a toggle away via `SPC a t`.
+
+### Controlling auto-context
+
+When the agentic view is the startup view and you open a file from the CLI, the file's content is loaded into the preview pane by default. This makes the interaction feel like "I'm chatting about this file" rather than "I opened a file and there's a chat panel."
+
+To disable this and start with a blank agentic view even when a file is provided:
+
+```elixir
+set :agent_auto_context, false
+```
+
+The file is still opened in a buffer (accessible via `SPC b b`), it just isn't surfaced in the preview pane automatically.
+
+### CLI flag overrides
+
+CLI flags override config options for a single invocation:
+
+```bash
+# Force editor mode regardless of config
+minga --editor foo.ex
+
+# Agentic view but don't load the file as context
+minga --no-context foo.ex
+
+# Editor mode with no file (scratch buffer)
+minga --editor
+```
+
+### Summary of combinations
+
+| Config | CLI | Result |
+|--------|-----|--------|
+| `startup_view: :agent` (default) | `minga` | Agentic view, empty |
+| `startup_view: :agent` (default) | `minga foo.ex` | Agentic view, file in preview |
+| `startup_view: :agent`, `agent_auto_context: false` | `minga foo.ex` | Agentic view, preview empty, file in buffer list |
+| `startup_view: :agent` | `minga --no-context foo.ex` | Same as above |
+| `startup_view: :agent` | `minga --editor foo.ex` | Editor view, file open |
+| `startup_view: :editor` | `minga foo.ex` | Editor view, file open |
+| `startup_view: :editor` | `minga` | Editor view, scratch buffer |
 
 ## Themes
 
@@ -843,6 +900,8 @@ set :font_weight, :regular
 set :font_ligatures, true
 
 # ── Agent ─────────────────────────────────────────────────────────────
+set :startup_view, :agent           # boot into agentic view (default)
+set :agent_auto_context, true       # load CLI file as preview context (default)
 set :agent_tool_approval, :destructive
 set :agent_destructive_tools, ["write_file", "edit_file", "shell"]
 

--- a/lib/minga/cli.ex
+++ b/lib/minga/cli.ex
@@ -7,23 +7,48 @@ defmodule Minga.CLI do
 
   In Burrito mode, arguments are fetched via `Burrito.Util.Args.argv/0`
   which works whether running standalone or under Mix.
+
+  ## Startup view
+
+  By default, Minga boots into the agentic view (controlled by the
+  `:startup_view` config option). CLI flags can override the config:
+
+  - `--editor` forces the traditional file editing view
+  - `--no-context` opens the agentic view but skips loading the CLI
+    file argument as preview context
   """
 
   alias Burrito.Util.Args
 
   require Logger
 
+  @typedoc "Parsed CLI result."
+  @type parsed ::
+          {:open, file :: String.t() | nil, flags()}
+          | {:error, String.t()}
+
+  @typedoc "CLI flags that override config options."
+  @type flags :: %{
+          force_editor: boolean(),
+          no_context: boolean()
+        }
+
+  @default_flags %{force_editor: false, no_context: false}
+
   @doc "Main entry point for the CLI."
   @spec main([String.t()]) :: :ok
   def main(args) do
     case parse_args(args) do
-      {:file, path} ->
-        Minga.Log.debug(:editor, "Opening file: #{path}")
-        open_editor(path)
+      {:open, file, flags} ->
+        store_startup_flags(flags)
 
-      :no_file ->
-        Minga.Log.debug(:editor, "Starting with empty buffer")
-        open_editor(nil)
+        if file do
+          Minga.Log.debug(:editor, "Opening file: #{file}")
+        else
+          Minga.Log.debug(:editor, "Starting with empty buffer")
+        end
+
+        open_editor(file)
 
       {:error, message} ->
         IO.puts(:stderr, message)
@@ -47,30 +72,76 @@ defmodule Minga.CLI do
   @doc """
   Parses CLI arguments into an action.
 
-  Returns `{:file, path}`, `:no_file`, or `{:error, message}`.
+  Returns `{:open, file_or_nil, flags}` or `{:error, message}`.
+  Flags carry CLI overrides for startup behavior.
   """
-  @spec parse_args([String.t()]) :: {:file, String.t()} | :no_file | {:error, String.t()}
-  def parse_args([]), do: :no_file
-  def parse_args(["--help" | _]), do: {:error, usage()}
-  def parse_args(["-h" | _]), do: {:error, usage()}
-  def parse_args(["--version" | _]), do: {:error, "minga #{Minga.version()}"}
-  def parse_args(["-v" | _]), do: {:error, "minga #{Minga.version()}"}
-  def parse_args([file_path | _]), do: {:file, file_path}
+  @spec parse_args([String.t()]) :: parsed()
+  def parse_args(args) do
+    parse_args(args, nil, @default_flags)
+  end
+
+  @doc """
+  Returns the startup flags stored by the CLI, or defaults if none were set.
+
+  The editor reads these once during initialization to decide whether to
+  activate the agentic view and whether to auto-load file context.
+  """
+  @spec startup_flags() :: flags()
+  def startup_flags do
+    Application.get_env(:minga, :cli_startup_flags, @default_flags)
+  end
+
+  # ── Argument parsing ────────────────────────────────────────────────────────
+
+  @spec parse_args([String.t()], String.t() | nil, flags()) :: parsed()
+  defp parse_args([], file, flags), do: {:open, file, flags}
+
+  defp parse_args(["--help" | _], _file, _flags), do: {:error, usage()}
+  defp parse_args(["-h" | _], _file, _flags), do: {:error, usage()}
+  defp parse_args(["--version" | _], _file, _flags), do: {:error, "minga #{Minga.version()}"}
+  defp parse_args(["-v" | _], _file, _flags), do: {:error, "minga #{Minga.version()}"}
+
+  defp parse_args(["--editor" | rest], file, flags) do
+    parse_args(rest, file, %{flags | force_editor: true})
+  end
+
+  defp parse_args(["--no-context" | rest], file, flags) do
+    parse_args(rest, file, %{flags | no_context: true})
+  end
+
+  defp parse_args([<<"--", _::binary>> = flag | _], _file, _flags) do
+    {:error, "unknown flag: #{flag}\n\n#{usage()}"}
+  end
+
+  defp parse_args([file_path | rest], _file, flags) do
+    parse_args(rest, file_path, flags)
+  end
+
+  # ── Helpers ─────────────────────────────────────────────────────────────────
+
+  @spec store_startup_flags(flags()) :: :ok
+  defp store_startup_flags(flags) do
+    Application.put_env(:minga, :cli_startup_flags, flags)
+  end
 
   @spec usage() :: String.t()
   defp usage do
     """
-    minga #{Minga.version()} — BEAM-powered modal text editor
+    minga #{Minga.version()} -- BEAM-powered modal text editor
 
-    Usage: minga [filename]
+    Usage: minga [options] [filename]
 
     Options:
-      -h, --help       Show this help message
-      -v, --version    Show version
+      -h, --help         Show this help message
+      -v, --version      Show version
+      --editor           Start in file editing mode (skip agentic view)
+      --no-context       Don't load the file as agent context
 
     Examples:
-      minga README.md    Open a file
-      minga              Start with empty buffer
+      minga                    Start agentic view
+      minga README.md          Start agentic view with file as context
+      minga --editor README.md Open file in traditional editor
+      minga --no-context foo.ex  Agentic view, file open but not as context
     """
   end
 

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -30,6 +30,8 @@ defmodule Minga.Config.Options do
   | `:agent_tool_approval`  | `:destructive`, `:all`, or `:none`          | `:destructive` |
   | `:agent_destructive_tools` | list of tool name strings                | `["write_file", "edit_file", "shell"]` |
   | `:agent_panel_split`      | positive integer (30-80)                   | `65`       |
+  | `:startup_view`           | `:agent` or `:editor`                       | `:agent`   |
+  | `:agent_auto_context`     | boolean                                     | `true`     |
   | `:font_family`            | string (font name)                          | `"Menlo"`   |
   | `:font_size`              | positive integer (point size)               | `13`        |
   | `:font_weight`            | `:thin` / `:light` / `:regular` / `:medium` / `:semibold` / `:bold` / `:heavy` / `:black` | `:regular` |
@@ -87,6 +89,8 @@ defmodule Minga.Config.Options do
           | :agent_destructive_tools
           | :agent_session_retention_days
           | :agent_panel_split
+          | :startup_view
+          | :agent_auto_context
           | :font_family
           | :font_size
           | :font_weight
@@ -144,6 +148,8 @@ defmodule Minga.Config.Options do
     {:agent_destructive_tools, :string_list, ["write_file", "edit_file", "shell"]},
     {:agent_session_retention_days, :pos_integer, 30},
     {:agent_panel_split, :pos_integer, 65},
+    {:startup_view, {:enum, [:agent, :editor]}, :agent},
+    {:agent_auto_context, :boolean, true},
     {:font_family, :string, "Menlo"},
     {:font_size, :pos_integer, 13},
     {:font_weight, {:enum, [:thin, :light, :regular, :medium, :semibold, :bold, :heavy, :black]},

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -150,6 +150,9 @@ defmodule Minga.Editor do
     windows =
       if initial_window, do: %{initial_window_id => initial_window}, else: %{}
 
+    {keymap_scope, agentic_state, effective_tree} =
+      startup_view_state(port_manager, initial_window_id)
+
     state = %EditorState{
       buffers: %Buffers{
         active: active_buf,
@@ -163,11 +166,13 @@ defmodule Minga.Editor do
       mode: :normal,
       mode_state: Mode.initial_state(),
       windows: %Windows{
-        tree: WindowTree.new(initial_window_id),
+        tree: effective_tree,
         map: windows,
         active: initial_window_id,
         next_id: initial_window_id + 1
       },
+      keymap_scope: keymap_scope,
+      agentic: agentic_state,
       focus_stack: Minga.Input.default_stack()
     }
 
@@ -220,6 +225,7 @@ defmodule Minga.Editor do
         new_state = lsp_buffer_opened(new_state, pid)
         new_state = git_buffer_opened(new_state, pid)
         fire_hook(:after_open, [pid, file_path])
+        new_state = maybe_set_auto_context(new_state, file_path, pid)
         new_state = Renderer.render(new_state)
         {:reply, :ok, new_state}
 
@@ -292,6 +298,9 @@ defmodule Minga.Editor do
     new_state = Renderer.render(new_state)
     # Setup highlighting after first paint with correct viewport
     send(self(), :setup_highlight)
+    # If the agentic view was activated at init, start the session now
+    # that the port is connected and the viewport is known.
+    new_state = maybe_start_agent_session(new_state)
     {:noreply, new_state}
   end
 
@@ -689,6 +698,41 @@ defmodule Minga.Editor do
     {:noreply, state}
   end
 
+  # Determines the initial keymap scope, agentic view state, and window
+  # tree based on config and CLI flags. In headless test mode (port_manager
+  # is a pid, not the PortManager atom), always uses editor mode.
+  @spec startup_view_state(GenServer.server(), pos_integer()) ::
+          {Minga.Keymap.Scope.scope_name(), ViewState.t(), WindowTree.t() | nil}
+  defp startup_view_state(port_manager, window_id) do
+    tui_mode? = port_manager == PortManager
+    cli_flags = Minga.CLI.startup_flags()
+
+    want_agent? =
+      tui_mode? and
+        not cli_flags.force_editor and
+        safe_get_option(:startup_view, :agent) == :agent
+
+    if want_agent? do
+      # Agentic view: set state immediately, hide window tree so the
+      # agent panel takes the full screen. The agent session starts
+      # later when :ready arrives and the port is connected.
+      av = %ViewState{ViewState.new() | active: true, focus: :chat}
+      {:agent, av, nil}
+    else
+      {:editor, ViewState.new(), WindowTree.new(window_id)}
+    end
+  end
+
+  # Reads a config option, returning the fallback if the Options Agent
+  # isn't running (e.g., during headless tests that don't start the full
+  # supervision tree).
+  @spec safe_get_option(ConfigOptions.option_name(), term()) :: term()
+  defp safe_get_option(name, fallback) do
+    ConfigOptions.get(name)
+  rescue
+    _ -> fallback
+  end
+
   @spec fetch_capabilities(GenServer.server() | nil) :: Minga.Port.Capabilities.t()
   defp fetch_capabilities(nil), do: %Minga.Port.Capabilities{}
 
@@ -719,6 +763,69 @@ defmodule Minga.Editor do
   @spec update_preview(state(), (Preview.t() -> Preview.t())) :: state()
   defp update_preview(state, fun) do
     %{state | agentic: ViewState.update_preview(state.agentic, fun)}
+  end
+
+  # If the agentic view was activated during init, start the agent session
+  # now that the port is ready. Also loads auto-context if configured.
+  @spec maybe_start_agent_session(state()) :: state()
+  defp maybe_start_agent_session(%{agentic: %{active: true}, agent: %{session: nil}} = state) do
+    state = Commands.Agent.ensure_agent_session(state)
+    cli_flags = Minga.CLI.startup_flags()
+    maybe_load_auto_context(state, cli_flags)
+  rescue
+    e ->
+      Logger.warning("Failed to start agent session at boot: #{Exception.message(e)}")
+      state
+  end
+
+  defp maybe_start_agent_session(state), do: state
+
+  # Loads the active buffer's file into the agentic preview pane when
+  # agent_auto_context is enabled and a file buffer is open. Called once
+  # during startup after the agentic view activates.
+  @spec maybe_load_auto_context(state(), Minga.CLI.flags()) :: state()
+  defp maybe_load_auto_context(state, %{no_context: true}), do: state
+
+  defp maybe_load_auto_context(state, _flags) do
+    auto_context = ConfigOptions.get(:agent_auto_context)
+    active_buf = state.buffers.active
+
+    if auto_context and active_buf do
+      load_buffer_as_preview(state, active_buf)
+    else
+      state
+    end
+  end
+
+  # Sets a file's content as the agentic preview pane if the view is active
+  # and the preview is still empty. Used both at startup (via
+  # maybe_load_auto_context) and when a file is opened while the agentic
+  # view is already active (via maybe_set_auto_context).
+  @spec maybe_set_auto_context(state(), String.t(), pid()) :: state()
+  defp maybe_set_auto_context(state, file_path, buffer_pid) do
+    cli_flags = Minga.CLI.startup_flags()
+    auto_context = ConfigOptions.get(:agent_auto_context)
+    agentic_active = state.agentic.active
+    preview_empty = state.agentic.preview.content == :empty
+
+    if agentic_active and preview_empty and auto_context and not cli_flags.no_context do
+      content = BufferServer.content(buffer_pid)
+      update_preview(state, &Preview.set_file(&1, file_path, content))
+    else
+      state
+    end
+  end
+
+  @spec load_buffer_as_preview(state(), pid()) :: state()
+  defp load_buffer_as_preview(state, buffer_pid) do
+    case BufferServer.file_path(buffer_pid) do
+      nil ->
+        state
+
+      path ->
+        content = BufferServer.content(buffer_pid)
+        update_preview(state, &Preview.set_file(&1, path, content))
+    end
   end
 
   @spec existing_diff_for_path(state(), String.t()) :: DiffReview.t() | nil

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -214,6 +214,14 @@ defmodule Minga.Editor.Commands.Agent do
     state
   end
 
+  @doc "Starts an agent session if one isn't already running. No-op otherwise."
+  @spec ensure_agent_session(state()) :: state()
+  def ensure_agent_session(%{agent: %{session: nil}} = state) do
+    start_agent_session(state)
+  end
+
+  def ensure_agent_session(state), do: state
+
   @doc "Starts a fresh agent session."
   @spec new_agent_session(state()) :: state()
   def new_agent_session(%{agent: %{session: nil}} = state) do

--- a/test/minga/cli_test.exs
+++ b/test/minga/cli_test.exs
@@ -4,8 +4,8 @@ defmodule Minga.CLITest do
   alias Minga.CLI
 
   describe "parse_args/1" do
-    test "no arguments returns :no_file" do
-      assert CLI.parse_args([]) == :no_file
+    test "no arguments returns {:open, nil, default_flags}" do
+      assert {:open, nil, %{force_editor: false, no_context: false}} = CLI.parse_args([])
     end
 
     test "--help returns error with usage text" do
@@ -31,16 +31,67 @@ defmodule Minga.CLITest do
       assert message =~ "minga"
     end
 
-    test "single file argument returns {:file, path}" do
-      assert CLI.parse_args(["README.md"]) == {:file, "README.md"}
+    test "single file argument returns {:open, path, flags}" do
+      assert {:open, "README.md", %{force_editor: false, no_context: false}} =
+               CLI.parse_args(["README.md"])
     end
 
-    test "file argument with extra args takes the first" do
-      assert CLI.parse_args(["file.txt", "--extra"]) == {:file, "file.txt"}
+    test "file argument with extra non-flag args takes the last file" do
+      assert {:open, "other.txt", %{force_editor: false, no_context: false}} =
+               CLI.parse_args(["file.txt", "other.txt"])
     end
 
     test "--help takes precedence over file argument" do
       assert {:error, _} = CLI.parse_args(["--help", "file.txt"])
+    end
+
+    test "--editor flag sets force_editor" do
+      assert {:open, nil, %{force_editor: true, no_context: false}} =
+               CLI.parse_args(["--editor"])
+    end
+
+    test "--editor flag with file" do
+      assert {:open, "foo.ex", %{force_editor: true, no_context: false}} =
+               CLI.parse_args(["--editor", "foo.ex"])
+    end
+
+    test "--no-context flag sets no_context" do
+      assert {:open, nil, %{force_editor: false, no_context: true}} =
+               CLI.parse_args(["--no-context"])
+    end
+
+    test "--no-context flag with file" do
+      assert {:open, "foo.ex", %{force_editor: false, no_context: true}} =
+               CLI.parse_args(["--no-context", "foo.ex"])
+    end
+
+    test "--editor and --no-context together" do
+      assert {:open, "foo.ex", %{force_editor: true, no_context: true}} =
+               CLI.parse_args(["--editor", "--no-context", "foo.ex"])
+    end
+
+    test "flags can appear after file argument" do
+      assert {:open, "foo.ex", %{force_editor: true, no_context: false}} =
+               CLI.parse_args(["foo.ex", "--editor"])
+    end
+
+    test "unknown flag returns error" do
+      assert {:error, message} = CLI.parse_args(["--unknown"])
+      assert message =~ "unknown flag: --unknown"
+    end
+
+    test "usage text includes --editor and --no-context" do
+      assert {:error, message} = CLI.parse_args(["--help"])
+      assert message =~ "--editor"
+      assert message =~ "--no-context"
+    end
+  end
+
+  describe "startup_flags/0" do
+    test "returns default flags when no CLI flags were set" do
+      # Clear any flags from other tests
+      Application.delete_env(:minga, :cli_startup_flags)
+      assert %{force_editor: false, no_context: false} = CLI.startup_flags()
     end
   end
 
@@ -51,6 +102,14 @@ defmodule Minga.CLITest do
 
     test "file argument returns :ok even when editor isn't running" do
       assert :ok = CLI.main(["nonexistent_file.txt"])
+    end
+
+    test "main stores startup flags in application env" do
+      Application.delete_env(:minga, :cli_startup_flags)
+      CLI.main(["--editor", "some_file.ex"])
+      assert %{force_editor: true, no_context: false} = CLI.startup_flags()
+    after
+      Application.delete_env(:minga, :cli_startup_flags)
     end
   end
 end

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -51,6 +51,8 @@ defmodule Minga.Config.OptionsTest do
                agent_destructive_tools: ["write_file", "edit_file", "shell"],
                agent_session_retention_days: 30,
                agent_panel_split: 65,
+               startup_view: :agent,
+               agent_auto_context: true,
                font_family: "Menlo",
                font_size: 13,
                font_weight: :regular,
@@ -88,6 +90,18 @@ defmodule Minga.Config.OptionsTest do
     test "scroll_margin accepts zero", %{server: s} do
       assert {:ok, 0} = Options.set(s, :scroll_margin, 0)
       assert Options.get(s, :scroll_margin) == 0
+    end
+
+    test "set and get startup_view", %{server: s} do
+      assert Options.get(s, :startup_view) == :agent
+      assert {:ok, :editor} = Options.set(s, :startup_view, :editor)
+      assert Options.get(s, :startup_view) == :editor
+    end
+
+    test "set and get agent_auto_context", %{server: s} do
+      assert Options.get(s, :agent_auto_context) == true
+      assert {:ok, false} = Options.set(s, :agent_auto_context, false)
+      assert Options.get(s, :agent_auto_context) == false
     end
   end
 
@@ -173,6 +187,29 @@ defmodule Minga.Config.OptionsTest do
 
     test "font_ligatures rejects non-boolean", %{server: s} do
       assert {:error, _} = Options.set(s, :font_ligatures, "yes")
+    end
+
+    test "startup_view accepts :agent and :editor", %{server: s} do
+      assert {:ok, :editor} = Options.set(s, :startup_view, :editor)
+      assert {:ok, :agent} = Options.set(s, :startup_view, :agent)
+    end
+
+    test "startup_view rejects invalid atom", %{server: s} do
+      assert {:error, msg} = Options.set(s, :startup_view, :hybrid)
+      assert msg =~ "must be one of"
+    end
+
+    test "startup_view rejects non-atom", %{server: s} do
+      assert {:error, _} = Options.set(s, :startup_view, "agent")
+    end
+
+    test "agent_auto_context accepts boolean", %{server: s} do
+      assert {:ok, false} = Options.set(s, :agent_auto_context, false)
+      assert {:ok, true} = Options.set(s, :agent_auto_context, true)
+    end
+
+    test "agent_auto_context rejects non-boolean", %{server: s} do
+      assert {:error, _} = Options.set(s, :agent_auto_context, :yes)
     end
   end
 


### PR DESCRIPTION
# TL;DR
Minga now boots into the full-screen agentic view by default, with the agent session ready and input focused. File editing is one config option away for users who prefer the traditional experience.

Closes #242

## Context
Agentic UIs are becoming the primary interface for code editors. With the OpenCode parity epic (#192) nearly complete, making the agentic view the default startup experience positions Minga as agent-first rather than agent-capable. This is the natural next step after the agent panel, session management, and preview pane are all feature-complete.

## Changes
- **Two new config options** in `Config.Options`:
  - `startup_view` (`:agent` | `:editor`, default `:agent`): which view to show on boot
  - `agent_auto_context` (boolean, default `true`): whether a CLI file argument gets loaded into the preview pane as context

- **CLI flags** `--editor` and `--no-context` override config per-invocation. Unknown flags now return a clear error instead of being treated as filenames.

- **Immediate state setup in `Editor.init/1`**: the agentic view state (`active: true`, `keymap_scope: :agent`, window tree hidden) is set during initialization, not deferred to a message. The agent session starts when `:ready` arrives and the port is connected. This means the Elixir side is instantly in the right mode; input is just blocked until the renderer is ready.

- **Auto-context wiring**: when a file is opened via CLI while the agentic view is active, `Preview.set_file/3` loads it into the preview pane. This works regardless of timing (file opened before or after `:ready`).

- **Headless test safety**: in test mode (`port_manager` is a pid, not the `PortManager` atom), always uses editor mode. No agent infrastructure needed.

- **Documentation**: new "Startup view" section in `docs/CONFIGURATION.md` with a combination matrix table, config examples, and CLI flag docs. Options table and full example updated.

## Verification
1. `mix compile --warnings-as-errors` passes
2. `mix lint` passes (formatting, credo --strict, dialyzer)
3. `mix test test/minga/cli_test.exs test/minga/config/options_test.exs` all green (73 tests, 0 failures)
4. Integration and editor tests pass (106 tests, 0 failures in targeted runs)
5. Build the binary and run:
   - `minga` should open the agentic view with input focused
   - `minga foo.ex` should open the agentic view with foo.ex in the preview pane
   - `minga --editor foo.ex` should open the traditional file editor
   - `minga --no-context foo.ex` should open the agentic view without the file in preview
   - Setting `set :startup_view, :editor` in config should restore old behavior

## Acceptance Criteria Addressed
- Running `minga` with no arguments opens the agentic view ✅
- Running `minga foo.ex` opens the agentic view with file in preview ✅
- `startup_view: :editor` restores traditional behavior ✅
- `agent_auto_context: false` skips preview loading ✅
- `--editor` CLI flag overrides config ✅
- `--no-context` CLI flag overrides config ✅
- `docs/CONFIGURATION.md` updated with both options ✅
- No regressions when `startup_view: :editor` is set ✅