### PR TITLE
feat(editor): two-column layout extends full height with input inside left panel

### DIFF
--- a/lib/minga/agent/view/mouse.ex
+++ b/lib/minga/agent/view/mouse.ex
@@ -10,14 +10,17 @@ defmodule Minga.Agent.View.Mouse do
 
   The agentic view layout is:
 
-      ┌─────── title bar (row 0) ───────────┐
-      │ chat panel  │sep│ file viewer        │
-      │             │   │                    │
-      ├─────── input area ──────────────────-┤
-      ├─────── modeline ────────────────────-┤
-      └─────── minibuffer ──────────────────-┘
+      ┌──────── tab bar (row 0) ────────────┐
+      ├──────── title bar (row 1) ──────────┤
+      │ chat panel  │sep│ file viewer       │
+      │             │   │                   │
+      │ input area  │   │ (continues)       │
+      ├──────── modeline ──────────────────-┤
+      └──────── minibuffer ────────────────-┘
 
-  Mouse events are routed based on which region they land in.
+  The two-column split extends the full height. The input area lives
+  inside the left column. Mouse events are routed based on which
+  region they land in.
   """
 
   alias Minga.Agent.View.State, as: ViewState
@@ -91,30 +94,30 @@ defmodule Minga.Agent.View.Mouse do
 
   @typep region :: :title | :chat | :file_viewer | :input | :separator | :modeline | :outside
 
+  @typep layout_info :: %{
+           sep_col: non_neg_integer(),
+           chat_width: pos_integer(),
+           input_row: non_neg_integer(),
+           modeline_row: non_neg_integer(),
+           panel_start: non_neg_integer()
+         }
+
   @spec hit_test(state(), integer(), integer()) :: region()
   defp hit_test(state, row, col) do
-    {_chat_rect, _viewer_rect, sep_col, input_row, modeline_row, panel_start} =
-      compute_layout(state)
-
-    cols = state.viewport.cols
-    chat_width_pct = state.agentic.chat_width_pct
-    chat_width = max(div(cols * chat_width_pct, 100), 20)
+    layout = compute_layout(state)
 
     cond do
-      row == 0 -> :title
-      row >= modeline_row -> :modeline
-      row >= input_row -> :input
-      row < panel_start -> :title
-      col == sep_col -> :separator
-      col < chat_width -> :chat
-      col > sep_col -> :file_viewer
+      row < layout.panel_start -> :title
+      row >= layout.modeline_row -> :modeline
+      row >= layout.input_row and col < layout.chat_width -> :input
+      col == layout.sep_col -> :separator
+      col < layout.chat_width -> :chat
+      col > layout.sep_col -> :file_viewer
       true -> :outside
     end
   end
 
-  @spec compute_layout(state()) ::
-          {rect :: tuple(), rect :: tuple(), non_neg_integer(), non_neg_integer(),
-           non_neg_integer(), non_neg_integer()}
+  @spec compute_layout(state()) :: layout_info()
   defp compute_layout(state) do
     cols = state.viewport.cols
     rows = state.viewport.rows
@@ -122,23 +125,28 @@ defmodule Minga.Agent.View.Mouse do
     input_lines = state.agent.panel.input_lines
     input_height = min(length(input_lines), 5) + 2
 
-    panel_start = 1
-    panel_end = rows - 1 - 1 - input_height
-    panel_height = max(panel_end - panel_start, 1)
+    # Tab bar at row 0, title bar at row 1, content starts at row 2.
+    panel_start = 2
+    modeline_row = rows - 1 - 1
+
+    # Two-column split extends from panel_start to modeline_row.
+    panel_height = max(modeline_row - panel_start, 1)
+
+    # Left column: chat on top, input at bottom.
+    chat_height = max(panel_height - input_height, 1)
+    input_row = panel_start + chat_height
 
     chat_width_pct = state.agentic.chat_width_pct
     chat_width = max(div(cols * chat_width_pct, 100), 20)
     sep_col = chat_width
-    viewer_col = chat_width + 1
-    viewer_width = max(cols - viewer_col, 10)
 
-    input_row = panel_end
-    modeline_row = input_row + input_height
-
-    chat_rect = {panel_start, 0, chat_width, panel_height}
-    viewer_rect = {panel_start, viewer_col, viewer_width, panel_height}
-
-    {chat_rect, viewer_rect, sep_col, input_row, modeline_row, panel_start}
+    %{
+      sep_col: sep_col,
+      chat_width: chat_width,
+      input_row: input_row,
+      modeline_row: modeline_row,
+      panel_start: panel_start
+    }
   end
 
   # ── Scroll handling ────────────────────────────────────────────────────────

--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -4,17 +4,20 @@ defmodule Minga.Agent.View.Renderer do
 
   Layout from top to bottom:
 
-      Row 0          Title bar (status, model, session info, token usage)
-      Row 1..H-6     Chat messages (left ~65%) │ File viewer (right ~35%)
-      Row H-5        Input border ─── Prompt ─── (full width)
-      Row H-4        Input text (full width)
-      Row H-3        Input padding (full width)
+      Row 0          Tab bar (rendered by TabBarRenderer)
+      Row 1          Title bar (status, model, session info, token usage)
+      Row 2..H-2     Left column: Chat + Input │ Right column: Preview/Dashboard
+        Left:          Chat messages (rows 2..H-2-input_h)
+                       Input border + text + model info (bottom of left col)
+        Right:         Preview or dashboard (full column height)
+        Separator:     Vertical │ (full column height)
       Row H-2        Modeline (full width)
       Row H-1        Minibuffer (reserved by editor)
 
-  The chat panel has no internal header or input; those are rendered at
-  full width by this module. The file viewer has a header bar at the top
-  of its rect showing the filename.
+  The two-column split extends the full height between title bar and
+  modeline. The input area renders within the left column only, not at
+  full width. The right panel (preview/dashboard) extends alongside the
+  input area. This matches the OpenCode reference layout.
 
   Called by `Minga.Editor.RenderPipeline` when `state.agentic.active` is true.
   Returns `DisplayList.draw()` tuples.
@@ -139,10 +142,18 @@ defmodule Minga.Agent.View.Renderer do
     rows = input.viewport.rows
 
     input_height = compute_input_height(input.panel.input_lines)
-    panel_end = rows - 1 - 1 - input_height
-    # Tab bar occupies row 0, title bar at row 1, content starts at row 2
+
+    # Tab bar at row 0, title bar at row 1, content starts at row 2.
+    # Modeline at rows-2, minibuffer at rows-1.
     panel_start = 2
-    panel_height = max(panel_end - panel_start, 1)
+    modeline_row = rows - 1 - 1
+
+    # The two-column split extends from panel_start to just above the modeline.
+    panel_height = max(modeline_row - panel_start, 1)
+
+    # Left column is split: chat on top, input at bottom.
+    chat_height = max(panel_height - input_height, 1)
+    input_row = panel_start + chat_height
 
     chat_width_pct = input.agentic.chat_width_pct
     chat_width = max(div(cols * chat_width_pct, 100), 20)
@@ -150,12 +161,12 @@ defmodule Minga.Agent.View.Renderer do
     viewer_col = chat_width + 1
     viewer_width = max(cols - viewer_col, 10)
 
-    input_row = panel_end
-    modeline_row = input_row + input_height
-
     title_commands = render_title_bar_from_input(input, 1, cols)
-    chat_commands = render_chat_from_input(input, {panel_start, 0, chat_width, panel_height})
 
+    # Left column: chat messages fill the top portion.
+    chat_commands = render_chat_from_input(input, {panel_start, 0, chat_width, chat_height})
+
+    # Separator and right column span the FULL panel height (alongside input).
     separator_commands =
       render_separator(separator_col, panel_start, panel_height, input.theme)
 
@@ -165,7 +176,8 @@ defmodule Minga.Agent.View.Renderer do
         {panel_start, viewer_col, viewer_width, panel_height}
       )
 
-    input_commands = render_input_from_input(input, input_row, cols)
+    # Input area renders within the left column only.
+    input_commands = render_input_from_input(input, input_row, chat_width)
     modeline_commands = render_modeline_from_input(input, modeline_row, cols)
 
     base =
@@ -781,11 +793,12 @@ defmodule Minga.Agent.View.Renderer do
     [header_cmd | gutter_cmds] ++ line_cmds ++ tilde_cmds
   end
 
-  # ── Full-width input area ───────────────────────────────────────────────────
+  # ── Input area (left column) ──────────────────────────────────────────────
 
   @spec render_input_from_input(RenderInput.t(), non_neg_integer(), pos_integer()) ::
           [DisplayList.draw()]
-  defp render_input_from_input(input, row, cols) do
+  defp render_input_from_input(input, row, width) do
+    cols = width
     at = Theme.agent_theme(input.theme)
     panel = input.panel
 

--- a/test/minga/agent/view/mouse_test.exs
+++ b/test/minga/agent/view/mouse_test.exs
@@ -78,12 +78,21 @@ defmodule Minga.Agent.View.MouseTest do
       assert new_state.agentic.focus == :file_viewer
     end
 
-    test "clicking input area focuses input" do
+    test "clicking input area in left column focuses input" do
       state = agentic_state()
-      # Input area starts at panel_end. With rows=30, input_height=3,
-      # panel_end = 30 - 1 - 1 - 3 = 25, so input_row = 25
+      # With rows=30: modeline at 28, panel_height=26, input_height=3,
+      # chat_height=23, input_row = 2 + 23 = 25. Click within left column.
       new_state = Mouse.handle(state, 25, 10, :left, 0, :press, 1)
       assert new_state.agent.panel.input_focused == true
+    end
+
+    test "clicking right column at input row height does NOT focus input" do
+      state = agentic_state()
+      # Same row 25, but in the right column (col 50 with 50% split of 80 cols)
+      # sep_col = 40, so col 50 is in the file_viewer region.
+      new_state = Mouse.handle(state, 25, 50, :left, 0, :press, 1)
+      assert new_state.agent.panel.input_focused == false
+      assert new_state.agentic.focus == :file_viewer
     end
 
     test "clicking chat unfocuses input" do

--- a/test/minga/agent/view/renderer_test.exs
+++ b/test/minga/agent/view/renderer_test.exs
@@ -225,14 +225,14 @@ defmodule Minga.Agent.View.RendererTest do
     end
   end
 
-  describe "full-width input area" do
-    test "input area renders at columns starting from 0" do
+  describe "input area inside left column" do
+    test "input border renders at col 0 within the left panel" do
       state = base_state(rows: 30, cols: 100)
       commands = Renderer.render(state)
 
-      # The input border should be at col 0 near the bottom
-      rows = state.viewport.rows
-      input_border_row = rows - 1 - 1 - 3
+      # With the new layout: modeline at row 28, input_height = 3,
+      # input starts at row 28 - 3 = 25
+      input_border_row = 30 - 1 - 1 - 3
 
       input_cmds =
         Enum.filter(commands, fn {row, col, _text, _style} ->
@@ -240,6 +240,71 @@ defmodule Minga.Agent.View.RendererTest do
         end)
 
       assert input_cmds != [], "expected input border at col 0"
+    end
+
+    test "input border width is constrained to left column (chat_width)" do
+      cols = 100
+      state = base_state(rows: 30, cols: cols)
+      commands = Renderer.render(state)
+
+      chat_width = div(cols * 65, 100)
+      input_border_row = 30 - 1 - 1 - 3
+
+      # Find the Prompt border command
+      border_cmds =
+        Enum.filter(commands, fn {row, col, text, _style} ->
+          row == input_border_row and col == 0 and String.contains?(text, "Prompt")
+        end)
+
+      assert [border_cmd | _] = border_cmds
+      {_row, _col, border_text, _style} = border_cmd
+
+      # Border text should be at most chat_width characters, not full terminal width
+      assert String.length(border_text) <= chat_width,
+             "input border should be ≤ chat_width (#{chat_width}), got #{String.length(border_text)}"
+    end
+
+    test "right panel extends alongside the input area" do
+      cols = 100
+      state = base_state(rows: 30, cols: cols)
+      commands = Renderer.render(state)
+
+      chat_width = div(cols * 65, 100)
+      viewer_col = chat_width + 1
+      input_border_row = 30 - 1 - 1 - 3
+
+      # The viewer/dashboard should have draw commands at rows alongside the input
+      viewer_at_input_rows =
+        Enum.filter(commands, fn {row, col, _text, _style} ->
+          row >= input_border_row and row < 30 - 2 and col >= viewer_col
+        end)
+
+      assert viewer_at_input_rows != [],
+             "expected right panel content at rows alongside the input area"
+    end
+
+    test "separator extends the full panel height including alongside input" do
+      cols = 100
+      state = base_state(rows: 30, cols: cols)
+      commands = Renderer.render(state)
+
+      chat_width = div(cols * 65, 100)
+      sep_col = chat_width
+      panel_start = 2
+      modeline_row = 30 - 2
+
+      sep_cmds =
+        Enum.filter(commands, fn {_row, col, text, _style} ->
+          col == sep_col and text == "│"
+        end)
+
+      sep_rows = Enum.map(sep_cmds, fn {row, _, _, _} -> row end) |> Enum.sort()
+
+      # Separator should span from panel_start to modeline_row - 1
+      expected_rows = Enum.to_list(panel_start..(modeline_row - 1))
+
+      assert sep_rows == expected_rows,
+             "separator should span rows #{panel_start}..#{modeline_row - 1}, got #{inspect(sep_rows)}"
     end
   end
 


### PR DESCRIPTION
## What

The agentic view's two-column split now runs from the title bar all the way to the modeline. The input area (prompt border, text, model info) renders within the left column only, and the right panel (preview/dashboard) extends alongside it. This matches the OpenCode reference layout from #192.

## Why

The previous layout broke the two-column split above the input area, making the input span full terminal width. The right panel stopped short, wasting space alongside the input. The new layout keeps the two-pane feel cohesive: the right panel shows context info (dashboard, file preview, diffs) at the same rows where you're typing your prompt.

Closes #243

## Changes

**Renderer (`lib/minga/agent/view/renderer.ex`):**
- `panel_height` now covers title bar → modeline (was title bar → input border)
- Left column internally split: chat on top (`chat_height`), input at bottom (`input_height`)
- Separator and right column span the full `panel_height`
- `render_input_from_input` receives `chat_width` instead of `cols`

**Mouse handler (`lib/minga/agent/view/mouse.ex`):**
- `compute_layout` matches the new geometry, returns a typed map for clarity
- `hit_test`: clicks at input-row height in the right column route to `:file_viewer`, not `:input`

**Tests:**
- Input border width constrained to left column (`chat_width`)
- Right panel renders alongside input area rows
- Separator spans full panel height (row 2 through modeline-1)
- Right-column click at input height routes to `file_viewer`

## Verification

```
mix lint                          # ✅
mix test --warnings-as-errors     # ✅ 3500 tests, 0 failures
mix dialyzer                      # ✅
```