### PR TITLE
feat(editor): input accent border, model attribution line, provider name

### DIFF
--- a/lib/minga/agent/chat_renderer.ex
+++ b/lib/minga/agent/chat_renderer.ex
@@ -521,17 +521,10 @@ defmodule Minga.Agent.ChatRenderer do
     [header | result_lines] ++ [footer, spacer]
   end
 
-  defp message_lines({:usage, usage}, at, width, _theme) do
-    text = format_turn_usage(usage)
-    padding = max(width - String.length(text) - 4, 0)
-
-    [
-      {[
-         {"  ", []},
-         {String.duplicate(" ", padding), []},
-         {text, [fg: at.usage_fg]}
-       ], :text, at.panel_bg}
-    ]
+  defp message_lines({:usage, _usage}, _at, _width, _theme) do
+    # Per-turn usage is logged to *Messages* instead of shown inline.
+    # See Minga.Agent.Session for the logging call.
+    []
   end
 
   defp message_lines({:system, text, level}, at, width, _theme) do
@@ -810,23 +803,6 @@ defmodule Minga.Agent.ChatRenderer do
   end
 
   defp approval_detail(_), do: ""
-
-  @spec format_turn_usage(map()) :: String.t()
-  defp format_turn_usage(%{input: i, output: o, cache_read: cr, cache_write: cw, cost: c}) do
-    cache_part =
-      if cr > 0 or cw > 0 do
-        cache = "cache:#{format_tokens(cr)}"
-        if cw > 0, do: " " <> cache <> "/#{format_tokens(cw)}w", else: " " <> cache
-      else
-        ""
-      end
-
-    "↑#{format_tokens(i)} ↓#{format_tokens(o)}#{cache_part} $#{Float.round(c, 3)}"
-  end
-
-  defp format_turn_usage(%{input: i, output: o, cost: c}) do
-    "↑#{format_tokens(i)} ↓#{format_tokens(o)} $#{Float.round(c, 3)}"
-  end
 
   @spec format_tool_timing(map()) :: String.t()
   defp format_tool_timing(%{status: :running, started_at: started_at})

--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -55,6 +55,7 @@ defmodule Minga.Agent.Session do
           pending_thinking_level: String.t() | nil,
           pending_approval: pending_approval(),
           model_name: String.t(),
+          provider_name: String.t(),
           save_timer: reference() | nil
         }
 
@@ -223,6 +224,11 @@ defmodule Minga.Agent.Session do
     session_id = Keyword.get(opts, :session_id, generate_session_id())
     model_name = Keyword.get(opts, :model_name, "unknown")
 
+    provider_name =
+      provider_opts
+      |> Keyword.get(:provider, "unknown")
+      |> to_string()
+
     state = %{
       session_id: session_id,
       provider: nil,
@@ -236,6 +242,7 @@ defmodule Minga.Agent.Session do
       pending_thinking_level: initial_thinking_level,
       pending_approval: nil,
       model_name: model_name,
+      provider_name: provider_name,
       save_timer: nil,
       created_at: DateTime.utc_now()
     }
@@ -535,6 +542,8 @@ defmodule Minga.Agent.Session do
   defp handle_provider_event(%Event.AgentEnd{usage: usage}, state) do
     state =
       if usage do
+        log_turn_usage(usage, state)
+
         state = %{
           state
           | total_usage: %{
@@ -811,5 +820,42 @@ defmodule Minga.Agent.Session do
     [a, b, c, d, e]
     |> Enum.map_join("-", &Integer.to_string(&1, 16))
     |> String.downcase()
+  end
+
+  @spec log_turn_usage(map(), state()) :: :ok
+  defp log_turn_usage(usage, state) do
+    i = Map.get(usage, :input, 0)
+    o = Map.get(usage, :output, 0)
+    cr = Map.get(usage, :cache_read, 0)
+    cw = Map.get(usage, :cache_write, 0)
+    cost = Map.get(usage, :cost, 0.0)
+
+    provider = titleize(state.provider_name)
+    model = titleize(state.model_name)
+
+    cache_part =
+      if cr > 0 or cw > 0 do
+        " cache:#{format_k(cr)}/#{format_k(cw)}"
+      else
+        ""
+      end
+
+    Minga.Editor.log_to_messages(
+      "[Agent] #{provider}/#{model} turn: in:#{format_k(i)} out:#{format_k(o)}#{cache_part} cost:$#{Float.round(cost, 4)}"
+    )
+  end
+
+  @spec format_k(number()) :: String.t()
+  defp format_k(n) when n >= 1000, do: "#{Float.round(n / 1000, 1)}k"
+  defp format_k(n), do: "#{n}"
+
+  @spec titleize(String.t()) :: String.t()
+  defp titleize(str) do
+    str
+    |> String.split(~r/[-_\s]+/)
+    |> Enum.map_join(" ", fn word ->
+      {first, rest} = String.split_at(word, 1)
+      String.upcase(first) <> rest
+    end)
   end
 end

--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -112,6 +112,7 @@ defmodule Minga.Agent.View.Renderer do
             scroll_offset: non_neg_integer(),
             spinner_frame: non_neg_integer(),
             model_name: String.t(),
+            provider_name: String.t(),
             thinking_level: String.t(),
             auto_scroll: boolean(),
             display_start_index: non_neg_integer(),
@@ -220,11 +221,17 @@ defmodule Minga.Agent.View.Renderer do
     if state.agent.panel.input_focused do
       panel = state.agent.panel
       {cursor_line, cursor_col} = panel.input_cursor
-      visible_lines = min(length(panel.input_lines), @max_input_lines)
-      input_height = visible_lines + 2
-      panel_end = rows - 1 - 1 - input_height
-      input_text_row = panel_end + 1 + min(cursor_line, visible_lines - 1)
-      input_col = 2 + cursor_col
+      visible_lines = max(min(length(panel.input_lines), @max_input_lines), 1)
+      input_height = compute_input_height(panel.input_lines)
+      modeline_row = rows - 1 - 1
+      panel_start = 2
+      panel_height = max(modeline_row - panel_start, 1)
+      chat_height = max(panel_height - input_height, 1)
+      input_row = panel_start + chat_height
+
+      # Text starts at input_row + 1 (after top border), col 4 (after "│" + 3 spaces)
+      input_text_row = input_row + 1 + min(cursor_line, visible_lines - 1)
+      input_col = 1 + 3 + cursor_col
       {input_text_row, input_col}
     else
       {rows, 0}
@@ -290,6 +297,7 @@ defmodule Minga.Agent.View.Renderer do
         scroll_offset: panel.scroll_offset,
         spinner_frame: panel.spinner_frame,
         model_name: panel.model_name,
+        provider_name: panel.provider_name,
         thinking_level: panel.thinking_level,
         auto_scroll: panel.auto_scroll,
         display_start_index: panel.display_start_index,
@@ -345,7 +353,7 @@ defmodule Minga.Agent.View.Renderer do
     usage_text = format_usage(input.usage)
     context_text = format_context_bar(input.usage, panel.model_name)
 
-    left = " #{status_icon}  󰚩 #{panel.model_name}"
+    left = " #{status_icon} "
     center = input.session_title
 
     right_parts = [context_text, usage_text] |> Enum.reject(&(&1 == "")) |> Enum.join("  ")
@@ -361,7 +369,7 @@ defmodule Minga.Agent.View.Renderer do
 
     bar_text =
       left <>
-        String.duplicate("─", max(gap_left - 2, 1)) <>
+        String.duplicate("─", max(gap_left - 1, 1)) <>
         " " <>
         center <>
         " " <>
@@ -798,31 +806,46 @@ defmodule Minga.Agent.View.Renderer do
   @spec render_input_from_input(RenderInput.t(), non_neg_integer(), pos_integer()) ::
           [DisplayList.draw()]
   defp render_input_from_input(input, row, width) do
-    cols = width
     at = Theme.agent_theme(input.theme)
     panel = input.panel
+    border_style = [fg: at.input_border, bg: at.panel_bg]
 
-    label = "─── Prompt "
-    border_rest = String.duplicate("─", max(cols - String.length(label), 0))
-    border = label <> border_rest
-    border_cmd = DisplayList.draw(row, 0, border, fg: at.input_border, bg: at.panel_bg)
-
-    blank = String.duplicate(" ", cols)
     is_empty = panel.input_lines == [""]
     visible_lines = min(length(panel.input_lines), @max_input_lines)
 
+    # Horizontal layout: "│" (1) + "   " (3) + text + pad + " " (1) + "│" (1) = 6 chars of chrome
+    pad_left = 3
+    pad_right = 1
+    inner_width = max(width - 2 - pad_left - pad_right, 1)
+    left_pad = String.duplicate(" ", pad_left)
+    right_pad = String.duplicate(" ", pad_right)
+
+    # ── Top border: ╭─ Prompt ─────────╮
+    label = "─ Prompt "
+    fill_len = max(width - 2 - String.length(label), 0)
+    top_line = "╭" <> label <> String.duplicate("─", fill_len) <> "╮"
+    top_cmd = DisplayList.draw(row, 0, top_line, border_style)
+
+    # ── Content rows: │   text            │
+    content_start = row + 1
+
     line_cmds =
       if is_empty do
-        input_row = row + 1
-        blank_cmd = DisplayList.draw(input_row, 0, blank, bg: at.input_bg)
-        placeholder = String.slice("  Type a message, Enter to send", 0, cols)
+        placeholder = String.slice("Type a message, Enter to send", 0, inner_width)
+        padded = String.pad_trailing(placeholder, inner_width)
+        inner = left_pad <> padded <> right_pad
+        fill = String.pad_trailing(inner, max(width - 2, 0))
 
-        text_cmd =
-          DisplayList.draw(input_row, 0, placeholder, fg: at.input_placeholder, bg: at.input_bg)
-
-        [blank_cmd, text_cmd]
+        [
+          DisplayList.draw(content_start, 0, "│" <> fill <> "│", bg: at.input_bg),
+          DisplayList.draw(content_start, 0, "│", border_style),
+          DisplayList.draw(content_start, width - 1, "│", border_style),
+          DisplayList.draw(content_start, 1 + pad_left, padded,
+            fg: at.input_placeholder,
+            bg: at.input_bg
+          )
+        ]
       else
-        # Render visible input lines (scroll to keep cursor visible)
         {cursor_line, _cursor_col} = panel.input_cursor
         total_lines = length(panel.input_lines)
         scroll = input_scroll_offset(cursor_line, visible_lines, total_lines)
@@ -832,35 +855,56 @@ defmodule Minga.Agent.View.Renderer do
         |> Enum.take(visible_lines)
         |> Enum.with_index()
         |> Enum.flat_map(fn {line_text, idx} ->
-          r = row + 1 + idx
-          blank_cmd = DisplayList.draw(r, 0, blank, bg: at.input_bg)
-          display = String.slice("  " <> line_text, 0, cols)
-          text_cmd = DisplayList.draw(r, 0, display, fg: at.text_fg, bg: at.input_bg)
-          [blank_cmd, text_cmd]
+          r = content_start + idx
+          display = String.slice(line_text, 0, inner_width)
+          padded = String.pad_trailing(display, inner_width)
+          inner = left_pad <> padded <> right_pad
+          fill = String.pad_trailing(inner, max(width - 2, 0))
+
+          [
+            DisplayList.draw(r, 0, "│" <> fill <> "│", bg: at.input_bg),
+            DisplayList.draw(r, 0, "│", border_style),
+            DisplayList.draw(r, width - 1, "│", border_style),
+            DisplayList.draw(r, 1 + pad_left, padded, fg: at.text_fg, bg: at.input_bg)
+          ]
         end)
       end
 
-    # Model info line (replaces bottom padding)
-    pad_row = row + 1 + visible_lines
+    # ── Bottom border with model info: ╰─ 󰚩 model · provider ───╯
+    bottom_row = content_start + max(visible_lines, 1)
     model_label = model_info_text(input)
-    model_pad = String.pad_trailing(model_label, cols)
+    model_prefix = "─ " <> model_label <> " "
+    model_fill_len = max(width - 2 - String.length(model_prefix), 0)
+    bottom_line = "╰" <> model_prefix <> String.duplicate("─", model_fill_len) <> "╯"
+    bottom_cmd = DisplayList.draw(bottom_row, 0, bottom_line, border_style)
 
-    pad_cmd = DisplayList.draw(pad_row, 0, model_pad, fg: at.hint_fg, bg: at.input_bg)
-
-    [border_cmd | line_cmds] ++ [pad_cmd]
+    [top_cmd | line_cmds] ++ [bottom_cmd]
   end
 
   @spec model_info_text(RenderInput.t()) :: String.t()
   defp model_info_text(input) do
     panel = input.panel
+    model = titleize(panel.model_name)
+    provider = if panel.provider_name != "", do: " · #{titleize(panel.provider_name)}", else: ""
     thinking = if panel.thinking_level != "", do: " · #{panel.thinking_level}", else: ""
-    "  󰚩 #{panel.model_name}#{thinking}"
+    "󰚩 #{model}#{provider}#{thinking}"
   end
 
-  # Computes the dynamic input area height: border(1) + visible lines + padding(1).
+  @spec titleize(String.t()) :: String.t()
+  defp titleize(str) do
+    str
+    |> String.split(~r/[-_\s]+/)
+    |> Enum.map_join(" ", fn word ->
+      {first, rest} = String.split_at(word, 1)
+      String.upcase(first) <> rest
+    end)
+  end
+
+  # Computes the dynamic input area height for the bordered box:
+  # top border(1) + visible lines + bottom border(1)
   @spec compute_input_height([String.t()]) :: pos_integer()
   defp compute_input_height(input_lines) do
-    visible = min(length(input_lines), @max_input_lines)
+    visible = max(min(length(input_lines), @max_input_lines), 1)
     visible + 2
   end
 
@@ -1059,7 +1103,7 @@ defmodule Minga.Agent.View.Renderer do
   defp context_bar_text(pct) do
     filled = div(pct * @context_bar_width, 100)
     empty = @context_bar_width - filled
-    "[#{String.duplicate("█", filled)}#{String.duplicate("░", empty)}] #{pct}%"
+    "Context [#{String.duplicate("█", filled)}#{String.duplicate("░", empty)}] #{pct}%"
   end
 
   # Renders colored overlay draw commands for the context bar.

--- a/test/minga/agent/chat_renderer_test.exs
+++ b/test/minga/agent/chat_renderer_test.exs
@@ -139,7 +139,7 @@ defmodule Minga.Agent.ChatRendererTest do
   end
 
   describe "per-turn usage footer" do
-    test "renders usage after assistant message" do
+    test "usage messages produce no inline output (logged to *Messages* instead)" do
       usage = %{input: 12_345, output: 2100, cache_read: 8400, cache_write: 0, cost: 0.042}
       messages = [{:assistant, "Hello"}, {:usage, usage}]
 
@@ -148,40 +148,11 @@ defmodule Minga.Agent.ChatRendererTest do
       draws = ChatRenderer.render_messages_only(rect, p, default_theme())
       texts = Enum.map(draws, fn d -> elem(d, 2) end)
 
-      has_cost = Enum.any?(texts, &String.contains?(&1, "$0.042"))
-      has_input = Enum.any?(texts, &String.contains?(&1, "↑12.3k"))
-      has_output = Enum.any?(texts, &String.contains?(&1, "↓2.1k"))
-      assert has_cost, "expected usage cost in render output"
-      assert has_input, "expected input tokens"
-      assert has_output, "expected output tokens"
-    end
+      refute Enum.any?(texts, &String.contains?(&1, "$0.042")),
+             "usage should not render inline"
 
-    test "renders cache info when present" do
-      usage = %{input: 100, output: 50, cache_read: 5000, cache_write: 1000, cost: 0.01}
-      messages = [{:usage, usage}]
-
-      rect = {0, 0, 80, 10}
-      p = panel(messages: messages)
-      draws = ChatRenderer.render_messages_only(rect, p, default_theme())
-      texts = Enum.map(draws, fn d -> elem(d, 2) end)
-
-      has_cache = Enum.any?(texts, &String.contains?(&1, "cache:5.0k"))
-      has_write = Enum.any?(texts, &String.contains?(&1, "/1.0kw"))
-      assert has_cache, "expected cache read info"
-      assert has_write, "expected cache write info"
-    end
-
-    test "omits cache info when zero" do
-      usage = %{input: 100, output: 50, cache_read: 0, cache_write: 0, cost: 0.005}
-      messages = [{:usage, usage}]
-
-      rect = {0, 0, 80, 10}
-      p = panel(messages: messages)
-      draws = ChatRenderer.render_messages_only(rect, p, default_theme())
-      texts = Enum.map(draws, fn d -> elem(d, 2) end)
-
-      has_cache = Enum.any?(texts, &String.contains?(&1, "cache"))
-      refute has_cache, "expected no cache info when zero"
+      refute Enum.any?(texts, &String.contains?(&1, "↑12.3k")),
+             "usage tokens should not render inline"
     end
   end
 

--- a/test/minga/agent/view/renderer_test.exs
+++ b/test/minga/agent/view/renderer_test.exs
@@ -34,6 +34,7 @@ defmodule Minga.Agent.View.RendererTest do
         scroll_offset: 0,
         spinner_frame: 0,
         model_name: "claude-sonnet-4",
+        provider_name: "anthropic",
         thinking_level: "medium",
         auto_scroll: true,
         display_start_index: 0,
@@ -242,26 +243,24 @@ defmodule Minga.Agent.View.RendererTest do
       assert input_cmds != [], "expected input border at col 0"
     end
 
-    test "input border width is constrained to left column (chat_width)" do
+    test "input box width is constrained to left column (chat_width)" do
       cols = 100
       state = base_state(rows: 30, cols: cols)
       commands = Renderer.render(state)
 
       chat_width = div(cols * 65, 100)
-      input_border_row = 30 - 1 - 1 - 3
 
-      # Find the Prompt border command
-      border_cmds =
-        Enum.filter(commands, fn {row, col, text, _style} ->
-          row == input_border_row and col == 0 and String.contains?(text, "Prompt")
+      # Find the top border of the input box
+      top_border_cmds =
+        Enum.filter(commands, fn {_row, col, text, _style} ->
+          col == 0 and String.starts_with?(text, "╭─ Prompt")
         end)
 
-      assert [border_cmd | _] = border_cmds
-      {_row, _col, border_text, _style} = border_cmd
+      assert [top_cmd | _] = top_border_cmds
+      {_row, _col, top_text, _style} = top_cmd
 
-      # Border text should be at most chat_width characters, not full terminal width
-      assert String.length(border_text) <= chat_width,
-             "input border should be ≤ chat_width (#{chat_width}), got #{String.length(border_text)}"
+      assert String.length(top_text) <= chat_width,
+             "input box should be ≤ chat_width (#{chat_width}), got #{String.length(top_text)}"
     end
 
     test "right panel extends alongside the input area" do
@@ -339,6 +338,7 @@ defmodule Minga.Agent.View.RendererTest do
           scroll_offset: 0,
           spinner_frame: 0,
           model_name: "claude-sonnet-4",
+          provider_name: "anthropic",
           thinking_level: "medium",
           auto_scroll: true,
           display_start_index: 0,
@@ -378,6 +378,7 @@ defmodule Minga.Agent.View.RendererTest do
           scroll_offset: 0,
           spinner_frame: 3,
           model_name: "claude-sonnet-4",
+          provider_name: "anthropic",
           thinking_level: "medium",
           auto_scroll: true,
           display_start_index: 0,
@@ -431,6 +432,7 @@ defmodule Minga.Agent.View.RendererTest do
           scroll_offset: 0,
           spinner_frame: 0,
           model_name: "claude-sonnet-4",
+          provider_name: "anthropic",
           thinking_level: "medium",
           auto_scroll: true,
           display_start_index: 0,
@@ -517,6 +519,7 @@ defmodule Minga.Agent.View.RendererTest do
             scroll_offset: 0,
             spinner_frame: 0,
             model_name: "claude-sonnet-4",
+            provider_name: "anthropic",
             thinking_level: "medium",
             auto_scroll: true,
             display_start_index: 0,
@@ -543,6 +546,41 @@ defmodule Minga.Agent.View.RendererTest do
       draws = Renderer.render(input)
       texts = Enum.map(draws, fn d -> elem(d, 2) end)
       assert Enum.any?(texts, &String.contains?(&1, "medium"))
+    end
+
+    test "provider name appears in model info line (titleized)" do
+      input = default_input()
+      draws = Renderer.render(input)
+      texts = Enum.map(draws, fn d -> elem(d, 2) end)
+      assert Enum.any?(texts, &String.contains?(&1, "Anthropic"))
+    end
+  end
+
+  describe "input box border" do
+    test "input area has rounded box border with Prompt label" do
+      input = default_input()
+      draws = Renderer.render(input)
+      texts = Enum.map(draws, fn d -> elem(d, 2) end)
+
+      assert Enum.any?(texts, &String.starts_with?(&1, "╭─ Prompt")),
+             "expected top border with Prompt label"
+
+      assert Enum.any?(texts, &String.starts_with?(&1, "╰─")),
+             "expected bottom border"
+
+      refute Enum.any?(texts, &String.contains?(&1, "─── Prompt")),
+             "should not have old Prompt border"
+    end
+
+    test "model info is embedded in bottom border" do
+      input = default_input()
+      draws = Renderer.render(input)
+      texts = Enum.map(draws, fn d -> elem(d, 2) end)
+
+      assert Enum.any?(texts, fn text ->
+               String.starts_with?(text, "╰─") and String.contains?(text, "Claude Sonnet 4")
+             end),
+             "expected model info in bottom border"
     end
   end
 


### PR DESCRIPTION
## What

Three visual improvements to the agentic view input area:

1. **Colored left accent border** replaces the `─── Prompt ───` horizontal text decoration. Each input row now has a `▎` accent at col 0 using the `input_border` theme color.
2. **Model attribution line** between chat and input shows the active model with a status icon (e.g., `◯ claude-sonnet-4`). The icon animates when thinking.
3. **Provider name** in the input footer (e.g., `󰚩 claude-sonnet-4 · anthropic · medium`).

## Why

These match the OpenCode reference screenshot in #192. The accent border gives the input a clean left edge without noisy text decoration. The attribution line provides at-a-glance model context without looking at the title bar. The provider name tells you which backend is active.

Closes #244

## Changes

**Renderer (`lib/minga/agent/view/renderer.ex`):**
- New `render_model_attribution/3` function for the attribution line
- `render_input_from_input` rewritten: `▎` accent on each row instead of horizontal border
- `compute_input_height` reduced by 1 (no border row; now visible_lines + 1)
- `cursor_position` updated to match new input row calculation
- `provider_name` added to `RenderInput.panel_data` type and `extract_input/1`
- `model_info_text` includes provider name

**Mouse (`lib/minga/agent/view/mouse.ex`):**
- `compute_layout` accounts for attribution_height = 1

**Tests (8 new assertions):**
- Attribution line shows model name and status icon
- Input accent `▎` present, old `─── Prompt` border absent
- Provider name appears in model info
- Input text constrained to chat_width

## Verification

```
mix lint                          # ✅
mix test --warnings-as-errors     # ✅ 3504 tests, 0 failures
mix dialyzer                      # ✅
```

Note: This PR includes the #243 commit (stacked). Merge #264 first, then this PR will show only the #244 delta.