### PR TITLE
feat(editor): dashboard LSP section and bottom-pinned working directory

### DIFF
--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -82,7 +82,8 @@ defmodule Minga.Agent.View.Renderer do
       buf_index: 1,
       buf_count: 1,
       pending_approval: nil,
-      session_title: "Minga Agent"
+      session_title: "Minga Agent",
+      lsp_servers: []
     ]
 
     @type t :: %__MODULE__{
@@ -101,7 +102,8 @@ defmodule Minga.Agent.View.Renderer do
             buf_index: pos_integer(),
             buf_count: pos_integer(),
             pending_approval: map() | nil,
-            session_title: String.t()
+            session_title: String.t(),
+            lsp_servers: [atom()]
           }
 
     @typedoc "Agent panel fields needed for rendering."
@@ -320,8 +322,18 @@ defmodule Minga.Agent.View.Renderer do
       buf_index: state.buffers.active_index + 1,
       buf_count: length(state.buffers.list),
       pending_approval: state.agent.pending_approval,
-      session_title: session_title(messages)
+      session_title: session_title(messages),
+      lsp_servers: safe_lsp_servers()
     }
+  end
+
+  @spec safe_lsp_servers() :: [atom()]
+  defp safe_lsp_servers do
+    Minga.LSP.Supervisor.active_servers()
+  rescue
+    _ -> []
+  catch
+    :exit, _ -> []
   end
 
   @spec session_title([term()]) :: String.t()
@@ -509,17 +521,34 @@ defmodule Minga.Agent.View.Renderer do
 
     sections = dashboard_sections(input, width, at)
 
-    # Render sections line by line
+    # Working directory pinned to bottom 2 rows
+    cwd = File.cwd!() |> shorten_path()
+
+    dir_label =
+      dashboard_text(" Directory", width, fg: at.dashboard_label, bg: at.panel_bg, bold: true)
+
+    dir_value = dashboard_text("  #{cwd}", width, fg: at.text_fg, bg: at.panel_bg)
+
+    dir_start = row_off + max(height - 2, 0)
+
+    dir_cmds = [
+      dir_label.(dir_start, col_off),
+      dir_value.(min(dir_start + 1, row_off + height - 1), col_off)
+    ]
+
+    # Render sections top-down, stopping before the pinned directory
+    section_limit = max(height - 3, 1)
+
     {section_cmds, _} =
       Enum.reduce(sections, {[], row_off}, fn line, {acc, row} ->
-        if row >= row_off + height do
+        if row >= row_off + section_limit do
           {acc, row}
         else
           {[line.(row, col_off) | acc], row + 1}
         end
       end)
 
-    bg_cmds ++ Enum.reverse(section_cmds)
+    bg_cmds ++ Enum.reverse(section_cmds) ++ dir_cmds
   end
 
   @spec dashboard_sections(RenderInput.t(), pos_integer(), Theme.Agent.t()) :: [
@@ -602,14 +631,8 @@ defmodule Minga.Agent.View.Renderer do
       dashboard_blank(width, at)
     ]
 
-    # ── Working directory section ──
-    cwd = File.cwd!() |> shorten_path()
-
-    cwd_lines = [
-      dashboard_text(" Directory", width, fg: at.dashboard_label, bg: at.panel_bg, bold: true),
-      dashboard_text("  #{cwd}", width, fg: at.text_fg, bg: at.panel_bg),
-      dashboard_blank(width, at)
-    ]
+    # ── LSP section ──
+    lsp_lines = dashboard_lsp_section(input.lsp_servers, width, at)
 
     # ── Status section ──
     status_text =
@@ -629,7 +652,31 @@ defmodule Minga.Agent.View.Renderer do
       )
     ]
 
-    title_lines ++ context_lines ++ model_lines ++ cwd_lines ++ status_lines
+    title_lines ++ context_lines ++ model_lines ++ lsp_lines ++ status_lines
+  end
+
+  @spec dashboard_lsp_section([atom()], pos_integer(), Theme.Agent.t()) :: [
+          (non_neg_integer(), non_neg_integer() -> DisplayList.draw())
+        ]
+  defp dashboard_lsp_section([], width, at) do
+    [
+      dashboard_text(" LSP", width, fg: at.dashboard_label, bg: at.panel_bg, bold: true),
+      dashboard_text("  No servers active", width, fg: at.hint_fg, bg: at.panel_bg),
+      dashboard_blank(width, at)
+    ]
+  end
+
+  defp dashboard_lsp_section(servers, width, at) do
+    header = [
+      dashboard_text(" LSP", width, fg: at.dashboard_label, bg: at.panel_bg, bold: true)
+    ]
+
+    server_lines =
+      Enum.map(servers, fn name ->
+        dashboard_text("  #{name}", width, fg: at.text_fg, bg: at.panel_bg)
+      end)
+
+    header ++ server_lines ++ [dashboard_blank(width, at)]
   end
 
   @spec dashboard_text(String.t(), pos_integer(), keyword()) ::

--- a/lib/minga/lsp/supervisor.ex
+++ b/lib/minga/lsp/supervisor.ex
@@ -91,6 +91,28 @@ defmodule Minga.LSP.Supervisor do
     |> Enum.map(fn {_, pid, _, _} -> pid end)
   end
 
+  @doc """
+  Returns the names of all active LSP servers (e.g., `[:lexical, :gopls]`).
+
+  Safe to call from the render pipeline. Returns an empty list if the
+  supervisor is not running or no clients are active.
+  """
+  @spec active_servers(GenServer.server()) :: [atom()]
+  def active_servers(supervisor \\ __MODULE__) do
+    supervisor
+    |> all_clients()
+    |> Enum.map(fn pid ->
+      try do
+        Client.server_name(pid)
+      catch
+        :exit, _ -> nil
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
   # ── Supervisor Callbacks ───────────────────────────────────────────────────
 
   @impl true

--- a/test/minga/agent/view/renderer_test.exs
+++ b/test/minga/agent/view/renderer_test.exs
@@ -621,6 +621,49 @@ defmodule Minga.Agent.View.RendererTest do
       assert Enum.any?(texts, &String.contains?(&1, "Directory"))
     end
 
+    test "shows LSP section with no servers when list is empty" do
+      input = default_input(%{lsp_servers: []})
+      draws = Renderer.render(input)
+      texts = Enum.map(draws, fn d -> elem(d, 2) end)
+
+      assert Enum.any?(texts, &String.contains?(&1, "LSP"))
+      assert Enum.any?(texts, &String.contains?(&1, "No servers active"))
+    end
+
+    test "shows LSP section with active server names" do
+      input = default_input(%{lsp_servers: [:lexical, :gopls]})
+      draws = Renderer.render(input)
+      texts = Enum.map(draws, fn d -> elem(d, 2) end)
+
+      assert Enum.any?(texts, &String.contains?(&1, "LSP"))
+      assert Enum.any?(texts, &String.contains?(&1, "lexical"))
+      assert Enum.any?(texts, &String.contains?(&1, "gopls"))
+    end
+
+    test "working directory is pinned to the bottom of the panel" do
+      input = default_input()
+      draws = Renderer.render(input)
+
+      dir_draws =
+        Enum.filter(draws, fn {_row, _col, text, _style} ->
+          String.contains?(text, "Directory")
+        end)
+
+      status_draws =
+        Enum.filter(draws, fn {_row, _col, text, _style} ->
+          String.contains?(text, "Status")
+        end)
+
+      assert dir_draws != []
+      assert status_draws != []
+
+      dir_row = dir_draws |> hd() |> elem(0)
+      status_row = status_draws |> hd() |> elem(0)
+
+      assert dir_row > status_row,
+             "Directory (row #{dir_row}) should be below Status (row #{status_row})"
+    end
+
     test "not shown when preview has file content" do
       preview =
         Preview.set_file(


### PR DESCRIPTION
## What

Two improvements to the agentic view dashboard (right panel):

1. **LSP section** showing active language servers by name (e.g., `lexical`, `gopls`). Shows "No servers active" when none are running. Uses a new `LSP.Supervisor.active_servers/0` function that safely queries the dynamic supervisor.

2. **Working directory pinned to the bottom** of the panel. Always visible regardless of how many sections are above it, matching the OpenCode reference layout.

Section order: Session Title → Context → Model → LSP → Status → [spacer] → Directory (pinned).

Closes #245

## Changes

- `lib/minga/lsp/supervisor.ex`: New `active_servers/0` returning sorted unique server name atoms
- `lib/minga/agent/view/renderer.ex`:
  - `RenderInput` gets `lsp_servers: [atom()]` field
  - `extract_input` populates it via `safe_lsp_servers/0`
  - `dashboard_lsp_section/3` renders the LSP section
  - `render_dashboard` pins directory to bottom 2 rows
  - Extracted LSP section to reduce cyclomatic complexity
- Tests: LSP section with empty/populated servers, directory pinned below status

## Verification

```
mix lint                          # ✅
mix test --warnings-as-errors     # ✅ 3504 tests, 0 failures
mix dialyzer                      # ✅
```