### PR TITLE
fix(editor): dashboard always shows when no file preview is active

### DIFF
--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -471,7 +471,7 @@ defmodule Minga.Agent.View.Renderer do
     DirectoryRenderer.render(rect, path, entries, scroll, input.theme)
   end
 
-  defp render_preview(%{preview: %Preview{content: :empty}, buffer_snapshot: nil} = input, rect) do
+  defp render_preview(%{preview: %Preview{content: :empty}} = input, rect) do
     render_dashboard(input, rect)
   end
 

--- a/test/minga/agent/view/renderer_test.exs
+++ b/test/minga/agent/view/renderer_test.exs
@@ -366,7 +366,9 @@ defmodule Minga.Agent.View.RendererTest do
       assert Enum.all?(commands, &is_tuple/1)
     end
 
-    test "renders with buffer snapshot data" do
+    test "renders with file preview data" do
+      preview = Preview.set_file(Preview.new(), "/tmp/test.ex", "line one\nline two")
+
       input = %Renderer.RenderInput{
         viewport: Viewport.new(30, 100),
         theme: Theme.get!(:doom_one),
@@ -393,12 +395,8 @@ defmodule Minga.Agent.View.RendererTest do
         },
         messages: [],
         usage: %{input: 1500, output: 300, cache_read: 0, cache_write: 0, cost: 0.012},
-        buffer_snapshot: %{
-          lines: ["line one", "line two"],
-          line_count: 2,
-          first_line_byte_offset: 0,
-          name: "test.ex"
-        },
+        preview: preview,
+        buffer_snapshot: nil,
         highlight: nil,
         mode: :normal,
         mode_state: nil,


### PR DESCRIPTION
## What

The right panel in the agentic view was showing the `*scratch*` buffer instead of the dashboard.

## Why

`render_preview` matched on `preview.content == :empty AND buffer_snapshot == nil`, but there is always a buffer snapshot (the scratch buffer is always active). The empty-preview clause never matched, so it fell through to `render_buffer_preview` and displayed scratch contents.

## Fix

Match on `preview.content == :empty` regardless of `buffer_snapshot`. The dashboard is the correct default when no file preview has been explicitly set by a tool or user action.

One-line change in the pattern match, plus a test update.

## Verification

```
mix lint                          # ✅
mix test --warnings-as-errors     # ✅ 3501 tests, 0 failures
mix dialyzer                      # ✅
```