### PR TITLE
feat(agent): add prompt Buffer.Server shadowing TextField (Phase D step 1)

### DIFF
--- a/lib/minga/agent/panel_state.ex
+++ b/lib/minga/agent/panel_state.ex
@@ -12,6 +12,7 @@ defmodule Minga.Agent.PanelState do
   completion, and input focus tracking.
   """
 
+  alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Input.TextField
   alias Minga.Input.Vim
   alias Minga.Scroll
@@ -31,6 +32,7 @@ defmodule Minga.Agent.PanelState do
           scroll: Scroll.t(),
           input: TextField.t(),
           vim: Vim.t(),
+          prompt_buffer: pid() | nil,
           prompt_history: [String.t()],
           history_index: integer(),
           spinner_frame: non_neg_integer(),
@@ -57,6 +59,7 @@ defmodule Minga.Agent.PanelState do
             scroll: %Scroll{},
             input: %TextField{},
             vim: %Vim{},
+            prompt_buffer: nil,
             prompt_history: [],
             history_index: -1,
             spinner_frame: 0,
@@ -71,6 +74,71 @@ defmodule Minga.Agent.PanelState do
   @doc "Creates a new panel state."
   @spec new() :: t()
   def new, do: %__MODULE__{}
+
+  @doc """
+  Ensures a prompt Buffer.Server is running. Starts one if `prompt_buffer`
+  is nil or the process is dead.
+
+  Called lazily when the panel is first focused or made visible. The buffer
+  is an unlisted, unnamed process owned by the editor. It does not appear
+  in the buffer list or tab bar.
+  """
+  @spec ensure_prompt_buffer(t()) :: t()
+  def ensure_prompt_buffer(%__MODULE__{prompt_buffer: pid} = state)
+      when is_pid(pid) do
+    if Process.alive?(pid), do: state, else: start_prompt_buffer(state)
+  end
+
+  def ensure_prompt_buffer(%__MODULE__{} = state), do: start_prompt_buffer(state)
+
+  @doc """
+  Returns the prompt text. Reads from the prompt buffer if available,
+  falls back to TextField. Paste placeholders are substituted in both cases.
+  """
+  @spec prompt_text(t()) :: String.t()
+  def prompt_text(%__MODULE__{prompt_buffer: pid, pasted_blocks: blocks} = state)
+      when is_pid(pid) do
+    if Process.alive?(pid) do
+      content = BufferServer.content(pid)
+      substitute_placeholders(content, blocks)
+    else
+      input_text(state)
+    end
+  end
+
+  def prompt_text(%__MODULE__{} = state), do: input_text(state)
+
+  @doc """
+  Syncs the TextField content to the prompt buffer. Call this after
+  any TextField mutation to keep the buffer in sync during the migration.
+  """
+  @spec sync_to_prompt_buffer(t()) :: t()
+  def sync_to_prompt_buffer(%__MODULE__{prompt_buffer: pid, input: tf} = state)
+      when is_pid(pid) do
+    if Process.alive?(pid) do
+      content = Enum.join(tf.lines, "\n")
+      current = BufferServer.content(pid)
+
+      if content != current do
+        BufferServer.replace_content(pid, content)
+      end
+    end
+
+    state
+  end
+
+  def sync_to_prompt_buffer(%__MODULE__{} = state), do: state
+
+  defp start_prompt_buffer(%__MODULE__{} = state) do
+    content = Enum.join(state.input.lines, "\n")
+    {:ok, pid} = BufferServer.start_link(content: content)
+    %{state | prompt_buffer: pid}
+  end
+
+  defp substitute_placeholders(content, blocks) do
+    String.split(content, "\n")
+    |> Enum.map_join("\n", fn line -> substitute_placeholder(line, blocks) end)
+  end
 
   @doc "Toggles panel visibility."
   @spec toggle(t()) :: t()
@@ -102,12 +170,14 @@ defmodule Minga.Agent.PanelState do
   @spec insert_char(t(), String.t()) :: t()
   def insert_char(%__MODULE__{} = state, char) do
     %{state | input: TextField.insert_char(state.input, char), history_index: -1}
+    |> sync_to_prompt_buffer()
   end
 
   @doc "Inserts a newline at the cursor, splitting the current line."
   @spec insert_newline(t()) :: t()
   def insert_newline(%__MODULE__{} = state) do
     %{state | input: TextField.insert_newline(state.input), history_index: -1}
+    |> sync_to_prompt_buffer()
   end
 
   @doc """
@@ -119,13 +189,16 @@ defmodule Minga.Agent.PanelState do
   @spec delete_char(t()) :: t()
   def delete_char(%__MODULE__{} = state) do
     %{state | input: TextField.delete_backward(state.input), history_index: -1}
+    |> sync_to_prompt_buffer()
   end
 
   @doc "Clears the input (after submission). Saves current text to history first."
   @spec clear_input(t()) :: t()
   def clear_input(%__MODULE__{} = state) do
     state = save_to_history(state)
+
     %{state | input: TextField.clear(state.input), history_index: -1, pasted_blocks: []}
+    |> sync_to_prompt_buffer()
   end
 
   # ── Cursor movement (delegates to TextField) ──────────────────────────────
@@ -169,12 +242,15 @@ defmodule Minga.Agent.PanelState do
     lines = String.split(clean_text, "\n")
     line_count = length(lines)
 
-    if line_count < @paste_collapse_threshold do
-      # Short paste: insert directly via TextField
-      %{state | input: TextField.insert_text(state.input, clean_text), history_index: -1}
-    else
-      insert_collapsed_paste(state, clean_text)
-    end
+    result =
+      if line_count < @paste_collapse_threshold do
+        # Short paste: insert directly via TextField
+        %{state | input: TextField.insert_text(state.input, clean_text), history_index: -1}
+      else
+        insert_collapsed_paste(state, clean_text)
+      end
+
+    sync_to_prompt_buffer(result)
   end
 
   @doc """
@@ -257,7 +333,9 @@ defmodule Minga.Agent.PanelState do
   def history_prev(%__MODULE__{history_index: idx, prompt_history: history} = state) do
     new_idx = min(idx + 1, length(history) - 1)
     text = Enum.at(history, new_idx)
+
     %{state | input: TextField.new(text), history_index: new_idx}
+    |> sync_to_prompt_buffer()
   end
 
   @doc "Recalls the next (more recent) prompt from history."
@@ -266,12 +344,15 @@ defmodule Minga.Agent.PanelState do
 
   def history_next(%__MODULE__{history_index: 0} = state) do
     %{state | input: TextField.new(), history_index: -1}
+    |> sync_to_prompt_buffer()
   end
 
   def history_next(%__MODULE__{history_index: idx, prompt_history: history} = state) do
     new_idx = idx - 1
     text = Enum.at(history, new_idx)
+
     %{state | input: TextField.new(text), history_index: new_idx}
+    |> sync_to_prompt_buffer()
   end
 
   # ── Scrolling (delegates to Minga.Scroll) ────────────────────────────────
@@ -317,6 +398,7 @@ defmodule Minga.Agent.PanelState do
   @doc "Sets the input focus state. Entering focus starts in insert mode; leaving resets vim state."
   @spec set_input_focused(t(), boolean()) :: t()
   def set_input_focused(%__MODULE__{} = state, true) do
+    state = ensure_prompt_buffer(state)
     %{state | input_focused: true, vim: Vim.enter_insert(state.vim)}
   end
 

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -259,7 +259,7 @@ defmodule Minga.Editor.Commands.Agent do
         %{state | status_msg: "No agent session, try closing and reopening the panel"}
 
       true ->
-        text = PanelState.input_text(panel)
+        text = PanelState.prompt_text(panel)
 
         if SlashCommand.slash_command?(text) do
           state = update_agent(state, &AgentState.clear_input_and_scroll/1)
@@ -830,7 +830,7 @@ defmodule Minga.Editor.Commands.Agent do
   @doc "Submits if input has text, aborts if agent is active."
   @spec scope_submit_or_abort(state()) :: state()
   def scope_submit_or_abort(state) do
-    if PanelState.input_text(AgentAccess.panel(state)) != "" do
+    if PanelState.prompt_text(AgentAccess.panel(state)) != "" do
       submit_prompt(state)
     else
       abort_if_active(state)

--- a/test/minga/agent/prompt_buffer_test.exs
+++ b/test/minga/agent/prompt_buffer_test.exs
@@ -1,0 +1,169 @@
+defmodule Minga.Agent.PromptBufferTest do
+  @moduledoc """
+  Tests for the prompt Buffer.Server integration in PanelState.
+
+  These verify that the prompt buffer stays in sync with the TextField
+  during the migration period. Once TextField is removed, these tests
+  become the primary prompt storage tests.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Agent.PanelState
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Input.TextField
+
+  # ── Helpers ──────────────────────────────────────────────────────────────────
+
+  defp focused_panel(text \\ "") do
+    panel = PanelState.new()
+
+    panel =
+      if text != "" do
+        lines = String.split(text, "\n")
+        %{panel | input: TextField.from_parts(lines, {0, 0})}
+      else
+        panel
+      end
+
+    PanelState.set_input_focused(panel, true)
+  end
+
+  defp buffer_content(panel) do
+    BufferServer.content(panel.prompt_buffer)
+  end
+
+  # ── Lifecycle ────────────────────────────────────────────────────────────────
+
+  describe "prompt buffer lifecycle" do
+    test "new panel has no prompt buffer" do
+      panel = PanelState.new()
+      assert panel.prompt_buffer == nil
+    end
+
+    test "focusing starts the prompt buffer" do
+      panel = focused_panel()
+      assert is_pid(panel.prompt_buffer)
+      assert Process.alive?(panel.prompt_buffer)
+    end
+
+    test "prompt buffer starts with empty content" do
+      panel = focused_panel()
+      assert buffer_content(panel) == ""
+    end
+
+    test "prompt buffer starts with existing text if present" do
+      panel = focused_panel("existing text")
+      assert buffer_content(panel) == "existing text"
+    end
+
+    test "ensure_prompt_buffer is idempotent" do
+      panel = focused_panel()
+      pid1 = panel.prompt_buffer
+      panel = PanelState.ensure_prompt_buffer(panel)
+      assert panel.prompt_buffer == pid1
+    end
+
+    test "ensure_prompt_buffer restarts if process died" do
+      Process.flag(:trap_exit, true)
+      panel = focused_panel()
+      old_pid = panel.prompt_buffer
+      Process.exit(old_pid, :kill)
+
+      # Wait for the exit signal to arrive
+      receive do
+        {:EXIT, ^old_pid, :killed} -> :ok
+      after
+        100 -> flunk("expected EXIT signal")
+      end
+
+      panel = PanelState.ensure_prompt_buffer(panel)
+      assert is_pid(panel.prompt_buffer)
+      assert panel.prompt_buffer != old_pid
+      assert Process.alive?(panel.prompt_buffer)
+    end
+  end
+
+  # ── Sync on text operations ────────────────────────────────────────────────
+
+  describe "sync on text operations" do
+    test "insert_char syncs to prompt buffer" do
+      panel = focused_panel()
+      panel = PanelState.insert_char(panel, "h")
+      panel = PanelState.insert_char(panel, "i")
+      assert buffer_content(panel) == "hi"
+    end
+
+    test "insert_newline syncs to prompt buffer" do
+      panel = focused_panel()
+      panel = PanelState.insert_char(panel, "a")
+      panel = PanelState.insert_newline(panel)
+      panel = PanelState.insert_char(panel, "b")
+      assert buffer_content(panel) == "a\nb"
+    end
+
+    test "delete_char syncs to prompt buffer" do
+      panel = focused_panel("hello")
+      panel = %{panel | input: TextField.set_cursor(panel.input, {0, 5})}
+      panel = PanelState.delete_char(panel)
+      assert buffer_content(panel) == "hell"
+    end
+
+    test "clear_input syncs to prompt buffer" do
+      panel = focused_panel()
+      panel = PanelState.insert_char(panel, "x")
+      panel = PanelState.clear_input(panel)
+      assert buffer_content(panel) == ""
+    end
+
+    test "short paste syncs to prompt buffer" do
+      panel = focused_panel()
+      panel = PanelState.insert_paste(panel, "pasted")
+      assert buffer_content(panel) == "pasted"
+    end
+
+    test "history_prev syncs to prompt buffer" do
+      panel = focused_panel()
+      panel = PanelState.insert_char(panel, "x")
+      panel = PanelState.clear_input(panel)
+      panel = PanelState.history_prev(panel)
+      assert buffer_content(panel) == "x"
+    end
+
+    test "history_next syncs to prompt buffer" do
+      panel = focused_panel()
+      panel = PanelState.insert_char(panel, "a")
+      panel = PanelState.clear_input(panel)
+      panel = PanelState.insert_char(panel, "b")
+      panel = PanelState.clear_input(panel)
+
+      panel = PanelState.history_prev(panel)
+      panel = PanelState.history_prev(panel)
+      panel = PanelState.history_next(panel)
+      assert buffer_content(panel) == "b"
+    end
+  end
+
+  # ── prompt_text/1 ──────────────────────────────────────────────────────────
+
+  describe "prompt_text/1" do
+    test "reads from prompt buffer when available" do
+      panel = focused_panel()
+      panel = PanelState.insert_char(panel, "x")
+      assert PanelState.prompt_text(panel) == "x"
+    end
+
+    test "falls back to input_text when no buffer" do
+      panel = PanelState.new()
+      panel = %{panel | input: TextField.from_parts(["hello"], {0, 5})}
+      assert PanelState.prompt_text(panel) == "hello"
+    end
+
+    test "substitutes paste placeholders" do
+      panel = focused_panel()
+      panel = PanelState.insert_paste(panel, "line1\nline2\nline3")
+      text = PanelState.prompt_text(panel)
+      assert text == "line1\nline2\nline3"
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

Adds a `Buffer.Server` process that shadows the agent prompt's `TextField`, keeping both in sync during the migration. Prompt submission now reads from the buffer. This is step 1 of 9 in Phase D (issue #324).

Part of #324

## Context

Phase D replaces the agent prompt's `TextField` + `Input.Vim` (1,190 lines of reimplemented vim) with a real `Buffer.Server` that uses the standard Mode FSM. This PR lays the foundation by introducing the buffer process alongside the existing TextField, proving they stay in sync before swapping authority.

## Changes

- **`prompt_buffer` field on PanelState**: starts as nil, lazily initialized when the panel is first focused via `ensure_prompt_buffer/1`. Idempotent; restarts if the process dies.

- **Sync on every mutation**: `insert_char`, `insert_newline`, `delete_char`, `clear_input`, `insert_paste`, `history_prev`, `history_next` all call `sync_to_prompt_buffer/1` after updating the TextField. The buffer always reflects the current prompt content.

- **`prompt_text/1`**: new function that reads from the buffer when available, falls back to `input_text/1`. Handles paste placeholder substitution in both paths.

- **Submission wired to buffer**: `submit_prompt` and `scope_submit_or_abort` now call `prompt_text/1` instead of `input_text/1`.

- **Design decision: shadow, don't replace.** TextField remains the source of truth for cursor position, paste blocks, and vim mode during the migration. The buffer shadows it so we can verify correctness. Future steps swap authority and eventually delete TextField.

## Verification

```bash
mix test test/minga/agent/prompt_buffer_test.exs     # 16 tests, 0 failures
mix test test/minga/agent/prompt_characterization_test.exs  # 29 tests, 0 failures
mix test --warnings-as-errors                         # 3,997 tests, 0 failures
mix lint                                              # clean
```