### PR TITLE
feat(agent): API key management with /auth command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Thumbs.db
 PLAN.md
 PLAN.md
 .build/
+test/tmp/

--- a/lib/minga/agent/credentials.ex
+++ b/lib/minga/agent/credentials.ex
@@ -1,0 +1,217 @@
+defmodule Minga.Agent.Credentials do
+  @moduledoc """
+  API key storage, resolution, and management for agent providers.
+
+  Keys are stored in `~/.config/minga/credentials.json` with restrictive
+  file permissions (0600). Environment variables always take precedence
+  over stored keys so existing setups are never broken.
+
+  Resolution order:
+  1. Environment variable (e.g. `ANTHROPIC_API_KEY`)
+  2. Credentials file
+
+  Keys are never logged, never included in session exports, and never
+  sent to `*Messages*`.
+  """
+
+  require Logger
+
+  @typedoc "A supported provider name."
+  @type provider :: String.t()
+
+  @typedoc "Source where a key was found."
+  @type key_source :: :env | :file | nil
+
+  @typedoc "Status entry for a single provider."
+  @type provider_status :: %{
+          provider: provider(),
+          configured: boolean(),
+          source: key_source()
+        }
+
+  @credentials_filename "credentials.json"
+
+  # Maps provider names to their environment variable.
+  @env_vars %{
+    "anthropic" => "ANTHROPIC_API_KEY",
+    "openai" => "OPENAI_API_KEY",
+    "google" => "GOOGLE_API_KEY"
+  }
+
+  @known_providers Map.keys(@env_vars)
+
+  @doc """
+  Returns the list of known provider names.
+  """
+  @spec known_providers() :: [provider()]
+  def known_providers, do: @known_providers
+
+  @doc """
+  Resolves an API key for the given provider.
+
+  Checks the environment variable first, then the credentials file.
+  Returns `{:ok, key, source}` if found, or `:error` if no key is
+  configured anywhere.
+  """
+  @spec resolve(provider()) :: {:ok, String.t(), key_source()} | :error
+  def resolve(provider) when is_binary(provider) do
+    case resolve_from_env(provider) do
+      {:ok, key} -> {:ok, key, :env}
+      :error -> resolve_from_file(provider)
+    end
+  end
+
+  @doc """
+  Stores an API key for a provider in the credentials file.
+
+  Creates the config directory and file if they don't exist. Sets
+  file permissions to 0600 (owner read/write only).
+  """
+  @spec store(provider(), String.t()) :: :ok | {:error, term()}
+  def store(provider, key) when is_binary(provider) and is_binary(key) do
+    path = credentials_path()
+    dir = Path.dirname(path)
+
+    with :ok <- ensure_directory(dir),
+         {:ok, existing} <- read_credentials_file(path),
+         updated = Map.put(existing, provider, key),
+         json = Jason.encode!(updated, pretty: true),
+         :ok <- File.write(path, json) do
+      File.chmod(path, 0o600)
+    end
+  end
+
+  @doc """
+  Removes a stored API key for a provider.
+
+  Only removes from the credentials file. Environment variables are
+  unaffected (and will still be used if set).
+  """
+  @spec revoke(provider()) :: :ok | {:error, term()}
+  def revoke(provider) when is_binary(provider) do
+    path = credentials_path()
+
+    case read_credentials_file(path) do
+      {:ok, existing} ->
+        updated = Map.delete(existing, provider)
+        json = Jason.encode!(updated, pretty: true)
+
+        with :ok <- File.write(path, json) do
+          File.chmod(path, 0o600)
+        end
+
+      {:error, :enoent} ->
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Returns the auth status for all known providers.
+
+  Each entry shows whether a key is configured and where it was found
+  (`:env`, `:file`, or `nil`). Keys themselves are never exposed.
+  """
+  @spec status() :: [provider_status()]
+  def status do
+    Enum.map(@known_providers, fn provider ->
+      case resolve(provider) do
+        {:ok, _key, source} ->
+          %{provider: provider, configured: true, source: source}
+
+        :error ->
+          %{provider: provider, configured: false, source: nil}
+      end
+    end)
+  end
+
+  @doc """
+  Returns true if any provider has a configured API key.
+  """
+  @spec any_configured?() :: boolean()
+  def any_configured? do
+    Enum.any?(status(), fn s -> s.configured end)
+  end
+
+  @doc """
+  Extracts the provider name from a model string like "anthropic:claude-sonnet-4-20250514".
+
+  Returns `"anthropic"` for bare model names (no prefix), since Anthropic
+  is the default provider.
+  """
+  @spec provider_from_model(String.t()) :: provider()
+  def provider_from_model(model) when is_binary(model) do
+    case String.split(model, ":", parts: 2) do
+      [provider, _model_name] -> String.downcase(provider)
+      [_bare_model] -> "anthropic"
+    end
+  end
+
+  @doc """
+  Returns the environment variable name for a provider, or nil if unknown.
+  """
+  @spec env_var_for(provider()) :: String.t() | nil
+  def env_var_for(provider) when is_binary(provider) do
+    Map.get(@env_vars, String.downcase(provider))
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec resolve_from_env(provider()) :: {:ok, String.t()} | :error
+  defp resolve_from_env(provider) do
+    case Map.get(@env_vars, String.downcase(provider)) do
+      nil ->
+        :error
+
+      var_name ->
+        case System.get_env(var_name) do
+          nil -> :error
+          "" -> :error
+          key -> {:ok, key}
+        end
+    end
+  end
+
+  @spec resolve_from_file(provider()) :: {:ok, String.t(), :file} | :error
+  defp resolve_from_file(provider) do
+    path = credentials_path()
+
+    case read_credentials_file(path) do
+      {:ok, creds} ->
+        case Map.get(creds, provider) do
+          nil -> :error
+          "" -> :error
+          key -> {:ok, key, :file}
+        end
+
+      {:error, _} ->
+        :error
+    end
+  end
+
+  @spec read_credentials_file(String.t()) :: {:ok, map()} | {:error, term()}
+  defp read_credentials_file(path) do
+    case File.read(path) do
+      {:ok, ""} -> {:ok, %{}}
+      {:ok, content} -> Jason.decode(content)
+      {:error, :enoent} -> {:ok, %{}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec ensure_directory(String.t()) :: :ok | {:error, term()}
+  defp ensure_directory(dir) do
+    case File.mkdir_p(dir) do
+      :ok -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec credentials_path() :: String.t()
+  defp credentials_path do
+    config_dir = System.get_env("XDG_CONFIG_HOME") || Path.join(System.user_home!(), ".config")
+    Path.join([config_dir, "minga", @credentials_filename])
+  end
+end

--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -33,6 +33,7 @@ defmodule Minga.Agent.Providers.Native do
 
   require Logger
 
+  alias Minga.Agent.Credentials
   alias Minga.Agent.Event
   alias Minga.Agent.Tools
   alias Minga.Config.Options
@@ -136,6 +137,11 @@ defmodule Minga.Agent.Providers.Native do
     tools = Keyword.get(opts, :tools) || Tools.all(project_root: project_root)
     system_prompt = build_system_prompt(project_root)
     context = Context.new([Context.system(system_prompt)])
+
+    # Resolve API key from credentials (env var or credentials file).
+    # If found in the file but not in the env, set the env var so ReqLLM
+    # picks it up automatically.
+    ensure_api_key_in_env(model)
 
     state = %{
       subscriber: subscriber,
@@ -593,6 +599,40 @@ defmodule Minga.Agent.Providers.Native do
     case File.read(path) do
       {:ok, content} -> content
       {:error, _} -> nil
+    end
+  end
+
+  # Sets the provider's API key env var if it's stored in the credentials
+  # file but not yet in the environment. This lets ReqLLM find the key
+  # without us having to thread it through every call.
+  @spec ensure_api_key_in_env(String.t()) :: :ok
+  defp ensure_api_key_in_env(model) do
+    provider = Credentials.provider_from_model(model)
+
+    case Credentials.resolve(provider) do
+      {:ok, key, :file} ->
+        # Key is in the credentials file but not in env; set it
+        case Credentials.env_var_for(provider) do
+          nil -> :ok
+          var_name -> System.put_env(var_name, key)
+        end
+
+        :ok
+
+      {:ok, _key, :env} ->
+        # Already in env, nothing to do
+        :ok
+
+      :error ->
+        # No key anywhere. The provider will fail on the first API call
+        # with a clear error from the API (e.g. "authentication_error").
+        Minga.Log.warning(
+          :agent,
+          "[Agent.Native] No API key found for #{provider}. " <>
+            "Use /auth to configure one, or set #{Credentials.env_var_for(provider) || "the provider's env var"}."
+        )
+
+        :ok
     end
   end
 

--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -23,6 +23,7 @@ defmodule Minga.Agent.Session do
 
   require Logger
 
+  alias Minga.Agent.Credentials
   alias Minga.Agent.Event
   alias Minga.Agent.Message
   alias Minga.Agent.ProviderResolver
@@ -489,6 +490,7 @@ defmodule Minga.Agent.Session do
         Process.monitor(pid)
         state = %{state | provider: pid}
         state = apply_pending_thinking_level(state)
+        state = maybe_show_auth_onboarding(state)
         {:noreply, state}
 
       {:error, reason} ->
@@ -739,6 +741,24 @@ defmodule Minga.Agent.Session do
   defp format_error(reason), do: inspect(reason)
 
   @spec apply_pending_thinking_level(state()) :: state()
+  # Shows an onboarding message when no API keys are configured and the
+  # native provider is active. Only fires once per session.
+  @spec maybe_show_auth_onboarding(map()) :: map()
+  defp maybe_show_auth_onboarding(state) do
+    if state.provider_module == Minga.Agent.Providers.Native and not Credentials.any_configured?() do
+      msg =
+        "No API keys configured. Use `/auth` to get started.\n\n" <>
+          "Example: `/auth anthropic sk-ant-your-key-here`\n" <>
+          "Run `/auth` with no arguments to see status for all providers."
+
+      messages = state.messages ++ [Message.system(msg)]
+      broadcast(state, {:system_message, msg, :info})
+      %{state | messages: messages}
+    else
+      state
+    end
+  end
+
   defp apply_pending_thinking_level(%{pending_thinking_level: nil} = state), do: state
 
   defp apply_pending_thinking_level(%{pending_thinking_level: level} = state) do

--- a/lib/minga/agent/slash_command.ex
+++ b/lib/minga/agent/slash_command.ex
@@ -8,6 +8,7 @@ defmodule Minga.Agent.SlashCommand do
   and any arguments after the command name.
   """
 
+  alias Minga.Agent.Credentials
   alias Minga.Agent.PanelState
   alias Minga.Agent.Session
   alias Minga.Editor.Commands.Agent, as: AgentCommands
@@ -29,7 +30,11 @@ defmodule Minga.Agent.SlashCommand do
     %{name: "thinking", description: "Set thinking level: /thinking [off|low|medium|high]"},
     %{name: "model", description: "Set the model: /model <name>"},
     %{name: "help", description: "Show available slash commands"},
-    %{name: "sessions", description: "Browse and switch between sessions"}
+    %{name: "sessions", description: "Browse and switch between sessions"},
+    %{
+      name: "auth",
+      description: "Manage API keys: /auth, /auth <provider>, /auth revoke <provider>"
+    }
   ]
 
   @doc "Returns the list of all registered slash commands."
@@ -76,6 +81,7 @@ defmodule Minga.Agent.SlashCommand do
   defp dispatch(state, "help", _args), do: {:ok, do_help(state)}
   defp dispatch(state, "?", _args), do: {:ok, do_help(state)}
   defp dispatch(state, "sessions", _args), do: {:ok, do_sessions(state)}
+  defp dispatch(state, "auth", args), do: {:ok, do_auth(state, args)}
   defp dispatch(_state, cmd, _args), do: {:error, "Unknown command: /#{cmd}"}
 
   # ── Command implementations ────────────────────────────────────────────────
@@ -138,6 +144,133 @@ defmodule Minga.Agent.SlashCommand do
   @spec do_sessions(state()) :: state()
   defp do_sessions(state) do
     PickerUI.open(state, Minga.Picker.AgentSessionSource)
+  end
+
+  # ── Auth command ─────────────────────────────────────────────────────────────
+
+  @spec do_auth(state(), String.t()) :: state()
+  defp do_auth(state, "") do
+    # No args: show status for all providers
+    statuses = Credentials.status()
+
+    lines =
+      Enum.map_join(statuses, "\n", fn s ->
+        icon = if s.configured, do: "✓", else: "✗"
+        source_hint = if s.source, do: " (#{s.source})", else: ""
+        "  #{icon} #{String.capitalize(s.provider)}#{source_hint}"
+      end)
+
+    message =
+      "API key status:\n#{lines}\n\nUse /auth <provider> <key> to add a key.\nUse /auth revoke <provider> to remove one."
+
+    emit_system_message(state, message)
+  end
+
+  defp do_auth(state, args) do
+    parts = String.split(String.trim(args), " ", parts: 3)
+
+    case parts do
+      ["revoke", provider] ->
+        do_auth_revoke(state, String.downcase(provider))
+
+      ["revoke"] ->
+        emit_system_message(
+          state,
+          "Usage: /auth revoke <provider>\nProviders: #{Enum.join(Credentials.known_providers(), ", ")}"
+        )
+
+      [provider, key] ->
+        do_auth_store(state, String.downcase(provider), key)
+
+      [provider] ->
+        emit_system_message(
+          state,
+          "Usage: /auth #{provider} <api-key>\nPaste your API key after the provider name."
+        )
+
+      _ ->
+        emit_system_message(
+          state,
+          "Usage: /auth [provider] [key]\nProviders: #{Enum.join(Credentials.known_providers(), ", ")}"
+        )
+    end
+  end
+
+  @spec do_auth_store(state(), String.t(), String.t()) :: state()
+  defp do_auth_store(state, provider, key) do
+    case validate_and_store(provider, key) do
+      :ok ->
+        emit_system_message(
+          state,
+          "✓ #{String.capitalize(provider)} API key saved. It will be used for new sessions."
+        )
+
+      {:error, :unknown_provider} ->
+        emit_system_message(
+          state,
+          "Unknown provider: #{provider}\nKnown providers: #{Enum.join(Credentials.known_providers(), ", ")}"
+        )
+
+      {:error, reason} ->
+        emit_system_message(state, "✗ Failed to save key: #{inspect(reason)}")
+    end
+  end
+
+  @spec validate_and_store(String.t(), String.t()) :: :ok | {:error, term()}
+  defp validate_and_store(provider, key) do
+    if provider in Credentials.known_providers() do
+      case Credentials.store(provider, key) do
+        :ok ->
+          set_env_for_provider(provider, key)
+          :ok
+
+        error ->
+          error
+      end
+    else
+      {:error, :unknown_provider}
+    end
+  end
+
+  # Sets the env var for a provider so the current session picks it up immediately.
+  @spec set_env_for_provider(String.t(), String.t()) :: :ok
+  defp set_env_for_provider(provider, key) do
+    case Credentials.env_var_for(provider) do
+      nil -> :ok
+      var_name -> System.put_env(var_name, key)
+    end
+
+    :ok
+  end
+
+  @spec do_auth_revoke(state(), String.t()) :: state()
+  defp do_auth_revoke(state, provider) do
+    if provider in Credentials.known_providers() do
+      case Credentials.revoke(provider) do
+        :ok ->
+          emit_system_message(
+            state,
+            "✓ #{String.capitalize(provider)} API key removed from credentials file.\nNote: if the key is also set via environment variable (#{Credentials.env_var_for(provider)}), it will still be used."
+          )
+
+        {:error, reason} ->
+          emit_system_message(state, "✗ Failed to revoke key: #{inspect(reason)}")
+      end
+    else
+      emit_system_message(
+        state,
+        "Unknown provider: #{provider}\nKnown providers: #{Enum.join(Credentials.known_providers(), ", ")}"
+      )
+    end
+  end
+
+  @spec emit_system_message(state(), String.t()) :: state()
+  defp emit_system_message(state, message) do
+    if AgentAccess.session(state) do
+      Session.add_system_message(AgentAccess.session(state), message)
+    end
+
+    %{state | status_msg: String.slice(message, 0, 80)}
   end
 
   # ── Helpers ─────────────────────────────────────────────────────────────────

--- a/test/minga/agent/credentials_test.exs
+++ b/test/minga/agent/credentials_test.exs
@@ -1,0 +1,168 @@
+defmodule Minga.Agent.CredentialsTest do
+  use ExUnit.Case, async: false
+
+  alias Minga.Agent.Credentials
+
+  @test_dir "test/tmp/credentials_test"
+
+  setup do
+    # Use a unique temp dir per test to avoid interference
+    dir = Path.join(@test_dir, "#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    # Override XDG_CONFIG_HOME so credentials_path() points to our temp dir
+    # We need to set the parent of "minga/" since credentials_path joins "minga"
+    parent_dir = Path.join(dir, "config")
+    File.mkdir_p!(Path.join(parent_dir, "minga"))
+    System.put_env("XDG_CONFIG_HOME", parent_dir)
+
+    on_exit(fn ->
+      System.delete_env("XDG_CONFIG_HOME")
+      File.rm_rf!(dir)
+    end)
+
+    %{
+      dir: dir,
+      config_dir: parent_dir,
+      creds_path: Path.join([parent_dir, "minga", "credentials.json"])
+    }
+  end
+
+  describe "store/2 and resolve/1" do
+    test "stores and resolves a key from file", %{creds_path: creds_path} do
+      assert :ok = Credentials.store("anthropic", "sk-ant-test-123")
+      assert {:ok, "sk-ant-test-123", :file} = Credentials.resolve("anthropic")
+
+      # Verify file permissions
+      {:ok, stat} = File.stat(creds_path)
+      assert stat.access == :read_write
+    end
+
+    test "env var takes precedence over file" do
+      System.put_env("ANTHROPIC_API_KEY", "env-key-123")
+
+      on_exit(fn -> System.delete_env("ANTHROPIC_API_KEY") end)
+
+      :ok = Credentials.store("anthropic", "file-key-456")
+      assert {:ok, "env-key-123", :env} = Credentials.resolve("anthropic")
+    end
+
+    test "returns :error when no key is configured" do
+      # Make sure env var is not set
+      System.delete_env("ANTHROPIC_API_KEY")
+      assert :error = Credentials.resolve("anthropic")
+    end
+
+    test "stores keys for multiple providers" do
+      :ok = Credentials.store("anthropic", "ant-key")
+      :ok = Credentials.store("openai", "oai-key")
+
+      assert {:ok, "ant-key", :file} = Credentials.resolve("anthropic")
+      assert {:ok, "oai-key", :file} = Credentials.resolve("openai")
+    end
+
+    test "overwrites existing key on re-store" do
+      :ok = Credentials.store("anthropic", "old-key")
+      :ok = Credentials.store("anthropic", "new-key")
+
+      assert {:ok, "new-key", :file} = Credentials.resolve("anthropic")
+    end
+  end
+
+  describe "revoke/1" do
+    test "removes a stored key" do
+      System.delete_env("ANTHROPIC_API_KEY")
+      :ok = Credentials.store("anthropic", "sk-ant-test")
+      assert {:ok, _, :file} = Credentials.resolve("anthropic")
+
+      :ok = Credentials.revoke("anthropic")
+      assert :error = Credentials.resolve("anthropic")
+    end
+
+    test "revoke is a no-op when no file exists" do
+      assert :ok = Credentials.revoke("anthropic")
+    end
+
+    test "revoke preserves other providers" do
+      System.delete_env("OPENAI_API_KEY")
+      :ok = Credentials.store("anthropic", "ant-key")
+      :ok = Credentials.store("openai", "oai-key")
+
+      :ok = Credentials.revoke("anthropic")
+      assert :error = Credentials.resolve("anthropic")
+      assert {:ok, "oai-key", :file} = Credentials.resolve("openai")
+    end
+  end
+
+  describe "status/0" do
+    test "reports unconfigured when nothing is set" do
+      System.delete_env("ANTHROPIC_API_KEY")
+      System.delete_env("OPENAI_API_KEY")
+      System.delete_env("GOOGLE_API_KEY")
+
+      statuses = Credentials.status()
+      assert length(statuses) == 3
+      assert Enum.all?(statuses, fn s -> s.configured == false end)
+    end
+
+    test "reports configured with correct source" do
+      System.delete_env("ANTHROPIC_API_KEY")
+      System.delete_env("OPENAI_API_KEY")
+      System.delete_env("GOOGLE_API_KEY")
+
+      :ok = Credentials.store("anthropic", "ant-key")
+      System.put_env("OPENAI_API_KEY", "oai-env-key")
+
+      on_exit(fn -> System.delete_env("OPENAI_API_KEY") end)
+
+      statuses = Credentials.status()
+      ant = Enum.find(statuses, &(&1.provider == "anthropic"))
+      oai = Enum.find(statuses, &(&1.provider == "openai"))
+      ggl = Enum.find(statuses, &(&1.provider == "google"))
+
+      assert ant.configured == true
+      assert ant.source == :file
+      assert oai.configured == true
+      assert oai.source == :env
+      assert ggl.configured == false
+    end
+  end
+
+  describe "any_configured?/0" do
+    test "returns false when nothing is configured" do
+      System.delete_env("ANTHROPIC_API_KEY")
+      System.delete_env("OPENAI_API_KEY")
+      System.delete_env("GOOGLE_API_KEY")
+
+      refute Credentials.any_configured?()
+    end
+
+    test "returns true when at least one key exists" do
+      :ok = Credentials.store("anthropic", "some-key")
+      assert Credentials.any_configured?()
+    end
+  end
+
+  describe "provider_from_model/1" do
+    test "extracts provider from prefixed model string" do
+      assert "anthropic" = Credentials.provider_from_model("anthropic:claude-sonnet-4-20250514")
+      assert "openai" = Credentials.provider_from_model("openai:gpt-4o")
+      assert "google" = Credentials.provider_from_model("google:gemini-pro")
+    end
+
+    test "defaults to anthropic for bare model names" do
+      assert "anthropic" = Credentials.provider_from_model("claude-sonnet-4-20250514")
+    end
+  end
+
+  describe "env_var_for/1" do
+    test "returns correct env var names" do
+      assert "ANTHROPIC_API_KEY" = Credentials.env_var_for("anthropic")
+      assert "OPENAI_API_KEY" = Credentials.env_var_for("openai")
+      assert "GOOGLE_API_KEY" = Credentials.env_var_for("google")
+    end
+
+    test "returns nil for unknown provider" do
+      assert nil == Credentials.env_var_for("unknown")
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds persistent API key storage and a `/auth` slash command so users can configure API keys without setting environment variables. This is the first-run blocker for the native provider (#268).

## Why

New users who open the agent panel without the right env var get a cryptic error. Every serious agentic tool has a guided auth flow. This closes that gap.

## Changes

- **`Minga.Agent.Credentials`** (new): Reads/writes `~/.config/minga/credentials.json` with 0600 permissions. Resolution order: env var first, then credentials file. Provides `resolve/1`, `store/2`, `revoke/1`, `status/0`.
- **`/auth` slash command**: `/auth` shows status, `/auth <provider> <key>` stores a key, `/auth revoke <provider>` removes one. Also sets the env var for the current session so ReqLLM picks it up immediately.
- **Native provider**: Calls `Credentials.resolve/1` on init and sets env vars from stored keys. Logs a warning if no key is found.
- **First-run detection**: When no API keys are configured anywhere, the session shows an onboarding message with instructions.

## Testing

16 new tests in `credentials_test.exs` covering store/resolve/revoke/status/provider extraction. Full suite passes (4013 tests, 0 failures).

Closes #278