### PR TITLE
refactor(agent): replace direct panel.input access with PanelState accessors

### DIFF
--- a/lib/minga/agent/chat_renderer.ex
+++ b/lib/minga/agent/chat_renderer.ex
@@ -25,7 +25,7 @@ defmodule Minga.Agent.ChatRenderer do
   @type panel_state :: %{
           messages: [Message.t()],
           status: :idle | :thinking | :tool_executing | :error,
-          input: Minga.Input.TextField.t(),
+          input_lines: [String.t()],
           scroll: Minga.Scroll.t(),
           spinner_frame: non_neg_integer(),
           usage: map(),
@@ -295,7 +295,8 @@ defmodule Minga.Agent.ChatRenderer do
 
     blank = String.duplicate(" ", width)
 
-    is_empty = panel.input.lines == [""]
+    lines = panel.input_lines
+    is_empty = lines == [""]
 
     if is_empty do
       # Placeholder
@@ -314,8 +315,8 @@ defmodule Minga.Agent.ChatRenderer do
       input_row = row + 1
       cmds = [DisplayList.draw(input_row, col, blank, bg: at.input_bg) | cmds]
 
-      first_line = "  " <> (List.first(panel.input.lines) || "")
-      line_count = length(panel.input.lines)
+      first_line = "  " <> (List.first(lines) || "")
+      line_count = length(lines)
       indicator = if line_count > 1, do: " [#{line_count}L]", else: ""
       display = String.slice(first_line <> indicator, 0, width)
 

--- a/lib/minga/agent/panel_state.ex
+++ b/lib/minga/agent/panel_state.ex
@@ -410,6 +410,19 @@ defmodule Minga.Agent.PanelState do
   @spec input_line_count(t()) :: pos_integer()
   def input_line_count(%__MODULE__{input: tf}), do: TextField.line_count(tf)
 
+  @doc "Returns the input lines as a list of strings."
+  @spec input_lines(t()) :: [String.t()]
+  def input_lines(%__MODULE__{input: tf}), do: tf.lines
+
+  @doc "Returns the input cursor position as `{line, col}`."
+  @spec input_cursor(t()) :: {non_neg_integer(), non_neg_integer()}
+  def input_cursor(%__MODULE__{input: tf}), do: tf.cursor
+
+  @doc "Returns true if the input is empty (single empty line)."
+  @spec input_empty?(t()) :: boolean()
+  def input_empty?(%__MODULE__{input: %TextField{lines: [""]}}), do: true
+  def input_empty?(%__MODULE__{}), do: false
+
   @doc """
   Clears the chat display without affecting conversation history.
 

--- a/lib/minga/agent/view/mouse.ex
+++ b/lib/minga/agent/view/mouse.ex
@@ -20,6 +20,7 @@ defmodule Minga.Agent.View.Mouse do
       └──────── minibuffer ────────────────-┘  ← shared chrome (:passthrough)
   """
 
+  alias Minga.Agent.PanelState
   alias Minga.Agent.View.State, as: ViewState
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Agent, as: AgentState
@@ -154,8 +155,8 @@ defmodule Minga.Agent.View.Mouse do
     cols = state.viewport.cols
     rows = state.viewport.rows
 
-    input_lines = AgentAccess.panel(state).input.lines
-    input_height = min(length(input_lines), 5) + 2
+    panel = AgentAccess.panel(state)
+    input_height = min(PanelState.input_line_count(panel), 5) + 2
 
     # Tab bar at row 0, title bar at row 1, content starts at row 2.
     panel_start = 2

--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -115,7 +115,8 @@ defmodule Minga.Agent.View.Renderer do
     @typedoc "Agent panel fields needed for rendering."
     @type panel_data :: %{
             input_focused: boolean(),
-            input: Minga.Input.TextField.t(),
+            input_lines: [String.t()],
+            input_cursor: {non_neg_integer(), non_neg_integer()},
             vim: Vim.t(),
             scroll: Scroll.t(),
             spinner_frame: non_neg_integer(),
@@ -155,7 +156,7 @@ defmodule Minga.Agent.View.Renderer do
     chat_width = max(div(cols * chat_width_pct, 100), 20)
 
     input_height =
-      compute_input_height(input.panel.input.lines, input_inner_width(chat_width))
+      compute_input_height(input.panel.input_lines, input_inner_width(chat_width))
 
     # Tab bar at row 0, title bar at row 1, content starts at row 2.
     # Modeline at rows-2, minibuffer at rows-1.
@@ -236,9 +237,12 @@ defmodule Minga.Agent.View.Renderer do
       chat_width = max(div(cols * chat_width_pct, 100), 20)
       inner_width = input_inner_width(chat_width)
 
-      total_visual = InputWrap.visual_line_count(panel.input.lines, inner_width)
+      lines = PanelState.input_lines(panel)
+      cursor = PanelState.input_cursor(panel)
+
+      total_visual = InputWrap.visual_line_count(lines, inner_width)
       visible_lines = max(min(total_visual, @max_input_lines), 1)
-      input_height = compute_input_height(panel.input.lines, inner_width)
+      input_height = compute_input_height(lines, inner_width)
       modeline_row = rows - 1 - 1
       panel_start = 2
       panel_height = max(modeline_row - panel_start, 1)
@@ -247,7 +251,7 @@ defmodule Minga.Agent.View.Renderer do
 
       # Map logical cursor to visual position within wrapped lines
       {visual_line, visual_col} =
-        InputWrap.logical_to_visual(panel.input.lines, inner_width, panel.input.cursor)
+        InputWrap.logical_to_visual(lines, inner_width, cursor)
 
       scroll = InputWrap.scroll_offset(visual_line, visible_lines, total_visual)
       visible_offset = visual_line - scroll
@@ -307,7 +311,7 @@ defmodule Minga.Agent.View.Renderer do
     cols = state.viewport.cols
     pct = agentic.chat_width_pct
     chat_w = max(div(cols * pct, 100), 20)
-    input_h = compute_input_height(panel.input.lines, input_inner_width(chat_w))
+    input_h = compute_input_height(PanelState.input_lines(panel), input_inner_width(chat_w))
     content_rows = max(rows - 1 - 1 - input_h - 1 - 1, 1)
 
     buffer_snapshot =
@@ -329,7 +333,8 @@ defmodule Minga.Agent.View.Renderer do
       agent_status: agent.status,
       panel: %{
         input_focused: panel.input_focused,
-        input: panel.input,
+        input_lines: PanelState.input_lines(panel),
+        input_cursor: PanelState.input_cursor(panel),
         vim: panel.vim,
         scroll: panel.scroll,
         spinner_frame: panel.spinner_frame,
@@ -450,7 +455,7 @@ defmodule Minga.Agent.View.Renderer do
     panel_state = %{
       messages: input.messages,
       status: input.agent_status || :idle,
-      input: input.panel.input,
+      input_lines: input.panel.input_lines,
       scroll: input.panel.scroll,
       spinner_frame: input.panel.spinner_frame,
       usage: input.usage,
@@ -916,9 +921,9 @@ defmodule Minga.Agent.View.Renderer do
     panel = input.panel
     border_style = [fg: at.input_border, bg: at.panel_bg]
 
-    is_empty = panel.input.lines == [""]
+    is_empty = panel.input_lines == [""]
     inner_width = input_inner_width(width)
-    total_visual = InputWrap.visual_line_count(panel.input.lines, inner_width)
+    total_visual = InputWrap.visual_line_count(panel.input_lines, inner_width)
     visible_lines = max(min(total_visual, @max_input_lines), 1)
 
     # Horizontal layout: "│" (1) + "   " (3) + text + pad + " " (1) + "│" (1) = 6 chars of chrome
@@ -957,12 +962,12 @@ defmodule Minga.Agent.View.Renderer do
       else
         # Map logical cursor to visual row for scrolling
         {cursor_visual, _} =
-          InputWrap.logical_to_visual(panel.input.lines, inner_width, panel.input.cursor)
+          InputWrap.logical_to_visual(panel.input_lines, inner_width, panel.input_cursor)
 
         scroll = InputWrap.scroll_offset(cursor_visual, visible_lines, total_visual)
 
         # Build flat list of visual lines tagged with logical line index
-        visual_lines = InputWrap.wrap_lines(panel.input.lines, inner_width)
+        visual_lines = InputWrap.wrap_lines(panel.input_lines, inner_width)
 
         sel_range = vim_visual_range(panel)
 
@@ -982,7 +987,7 @@ defmodule Minga.Agent.View.Renderer do
         |> Enum.with_index()
         |> Enum.flat_map(fn {{logical_idx, vl}, idx} ->
           r = content_start + idx
-          line_text = Enum.at(panel.input.lines, logical_idx)
+          line_text = Enum.at(panel.input_lines, logical_idx)
 
           {display_text, fg_color} =
             visual_row_display(vl, line_text, inner_width, panel, at)
@@ -1144,12 +1149,13 @@ defmodule Minga.Agent.View.Renderer do
   @spec input_inner_width(pos_integer()) :: pos_integer()
   defp input_inner_width(box_width), do: max(box_width - 6, 1)
 
-  # Returns a mode label for the input border (empty string in insert mode).
   # Returns the visual selection range from Vim state, or nil.
   @spec vim_visual_range(map()) ::
           {TextField.cursor(), TextField.cursor()} | nil
-  defp vim_visual_range(%{vim: %Vim{} = vim, input: %TextField{} = tf}),
-    do: Vim.visual_range(vim, tf)
+  defp vim_visual_range(%{vim: %Vim{} = vim, input_lines: lines, input_cursor: cursor}) do
+    tf = TextField.from_parts(lines, cursor)
+    Vim.visual_range(vim, tf)
+  end
 
   defp vim_visual_range(_panel), do: nil
 

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -252,7 +252,7 @@ defmodule Minga.Editor.Commands.Agent do
     panel = AgentAccess.panel(state)
 
     cond do
-      panel.input.lines == [""] ->
+      PanelState.input_empty?(panel) ->
         state
 
       AgentAccess.session(state) == nil ->
@@ -841,7 +841,7 @@ defmodule Minga.Editor.Commands.Agent do
   @spec scope_input_up(state()) :: state()
   def scope_input_up(state) do
     panel = AgentAccess.panel(state)
-    {line, _col} = panel.input.cursor
+    {line, _col} = PanelState.input_cursor(panel)
 
     if line == 0 do
       update_agent(state, &AgentState.history_prev/1)
@@ -854,8 +854,8 @@ defmodule Minga.Editor.Commands.Agent do
   @spec scope_input_down(state()) :: state()
   def scope_input_down(state) do
     panel = AgentAccess.panel(state)
-    {line, _col} = panel.input.cursor
-    max_line = length(panel.input.lines) - 1
+    {line, _col} = PanelState.input_cursor(panel)
+    max_line = PanelState.input_line_count(panel) - 1
 
     if line >= max_line do
       update_agent(state, &AgentState.history_next/1)

--- a/lib/minga/editor/commands/agent_sub_states.ex
+++ b/lib/minga/editor/commands/agent_sub_states.ex
@@ -10,6 +10,7 @@ defmodule Minga.Editor.Commands.AgentSubStates do
   alias Minga.Agent.ChatSearch
   alias Minga.Agent.DiffReview
   alias Minga.Agent.FileMention
+  alias Minga.Agent.PanelState
   alias Minga.Agent.Session
   alias Minga.Agent.View.Preview
   alias Minga.Agent.View.State, as: ViewState
@@ -279,15 +280,15 @@ defmodule Minga.Editor.Commands.AgentSubStates do
   @spec should_trigger_mention?(state()) :: boolean()
   defp should_trigger_mention?(state) do
     panel = AgentAccess.panel(state)
-    {line, col} = panel.input.cursor
-    current_line = Enum.at(panel.input.lines, line, "")
+    {line, col} = PanelState.input_cursor(panel)
+    current_line = Enum.at(PanelState.input_lines(panel), line, "")
     col == 0 or String.at(current_line, col - 1) in [" ", "\t", nil]
   end
 
   @spec start_mention_completion(state()) :: state()
   defp start_mention_completion(state) do
     files = list_project_files()
-    {line, col} = AgentAccess.panel(state).input.cursor
+    {line, col} = PanelState.input_cursor(AgentAccess.panel(state))
     completion = FileMention.new_completion(files, line, col - 1)
     update_panel(state, fn p -> %{p | mention_completion: completion} end)
   end
@@ -302,8 +303,9 @@ defmodule Minga.Editor.Commands.AgentSubStates do
 
       path ->
         panel = AgentAccess.panel(state)
-        {line, _col} = panel.input.cursor
-        current = Enum.at(panel.input.lines, line)
+        {line, _col} = PanelState.input_cursor(panel)
+        lines = PanelState.input_lines(panel)
+        current = Enum.at(lines, line)
         anchor_col = comp.anchor_col
 
         before = String.slice(current, 0, anchor_col)
@@ -317,7 +319,7 @@ defmodule Minga.Editor.Commands.AgentSubStates do
 
         new_line = before <> "@" <> path <> " " <> after_prefix
         new_col = anchor_col + 1 + String.length(path) + 1
-        new_lines = List.replace_at(panel.input.lines, line, new_line)
+        new_lines = List.replace_at(lines, line, new_line)
 
         update_panel(state, fn p ->
           %{p | input: TextField.from_parts(new_lines, {line, new_col}), mention_completion: nil}

--- a/lib/minga/editor/render_pipeline/chrome_helpers.ex
+++ b/lib/minga/editor/render_pipeline/chrome_helpers.ex
@@ -171,7 +171,7 @@ defmodule Minga.Editor.RenderPipeline.ChromeHelpers do
     panel_state = %{
       messages: messages,
       status: agent.status || :idle,
-      input: panel.input,
+      input_lines: PanelState.input_lines(panel),
       scroll: panel.scroll,
       spinner_frame: panel.spinner_frame,
       usage: usage,

--- a/lib/minga/editor/render_pipeline/compose_helpers.ex
+++ b/lib/minga/editor/render_pipeline/compose_helpers.ex
@@ -8,6 +8,7 @@ defmodule Minga.Editor.RenderPipeline.ComposeHelpers do
   Extracted from `RenderPipeline` to reduce module size.
   """
 
+  alias Minga.Agent.PanelState
   alias Minga.Buffer.Unicode
   alias Minga.Editor.DisplayList
   alias Minga.Editor.DisplayList.{Overlay, WindowFrame}
@@ -108,7 +109,7 @@ defmodule Minga.Editor.RenderPipeline.ComposeHelpers do
     panel = AgentAccess.panel(state)
 
     if panel.visible and panel.input_focused do
-      {cursor_line, cursor_col} = panel.input.cursor
+      {cursor_line, cursor_col} = PanelState.input_cursor(panel)
       input_row = row + h - @agent_input_height + 1 + cursor_line
       input_col = col + 2 + cursor_col
 

--- a/lib/minga/input/scoped.ex
+++ b/lib/minga/input/scoped.ex
@@ -115,8 +115,8 @@ defmodule Minga.Input.Scoped do
     # Normal dispatch: determine vim state and resolve through scope
     # Tab on a paste placeholder line: toggle expand/collapse
     if cp == @tab and mods == 0 and panel.input_focused do
-      {cursor_line, _} = panel.input.cursor
-      current_line = Enum.at(panel.input.lines, cursor_line)
+      {cursor_line, _} = PanelState.input_cursor(panel)
+      current_line = Enum.at(PanelState.input_lines(panel), cursor_line)
 
       if PanelState.paste_placeholder?(current_line) or cursor_on_expanded_block?(panel) do
         {:handled, AgentCommands.toggle_paste_expand(state)}

--- a/test/minga/agent/view/renderer_test.exs
+++ b/test/minga/agent/view/renderer_test.exs
@@ -31,7 +31,8 @@ defmodule Minga.Agent.View.RendererTest do
       agent_status: :idle,
       panel: %{
         input_focused: false,
-        input: TextField.new(),
+        input_lines: [""],
+        input_cursor: {0, 0},
         scroll: Minga.Scroll.new(),
         spinner_frame: 0,
         model_name: "claude-sonnet-4",
@@ -341,7 +342,8 @@ defmodule Minga.Agent.View.RendererTest do
         agent_status: :idle,
         panel: %{
           input_focused: false,
-          input: TextField.from_parts([""], {0, 0}),
+          input_lines: [""],
+          input_cursor: {0, 0},
           scroll: Minga.Scroll.new(),
           spinner_frame: 0,
           model_name: "claude-sonnet-4",
@@ -380,7 +382,8 @@ defmodule Minga.Agent.View.RendererTest do
         agent_status: :thinking,
         panel: %{
           input_focused: true,
-          input: TextField.from_parts(["hello"], {0, 5}),
+          input_lines: ["hello"],
+          input_cursor: {0, 5},
           scroll: Minga.Scroll.new(),
           spinner_frame: 3,
           model_name: "claude-sonnet-4",
@@ -433,7 +436,8 @@ defmodule Minga.Agent.View.RendererTest do
         agent_status: :idle,
         panel: %{
           input_focused: false,
-          input: TextField.from_parts([""], {0, 0}),
+          input_lines: [""],
+          input_cursor: {0, 0},
           scroll: Minga.Scroll.new(),
           spinner_frame: 0,
           model_name: "claude-sonnet-4",
@@ -519,7 +523,8 @@ defmodule Minga.Agent.View.RendererTest do
         default_input(%{
           panel: %{
             input_focused: true,
-            input: TextField.from_parts([""], {0, 0}),
+            input_lines: [""],
+            input_cursor: {0, 0},
             scroll: Minga.Scroll.new(),
             spinner_frame: 0,
             model_name: "claude-sonnet-4",


### PR DESCRIPTION
# TL;DR

Migrates 30 call sites across 9 files from direct `panel.input.lines`/`panel.input.cursor` access to `PanelState.input_lines/1`, `PanelState.input_cursor/1`, and `PanelState.input_empty?/1`. No rendering code depends on `TextField` anymore.

Part of #324 (Phase D step 2)

## Context

Phase D replaces the agent prompt's `TextField` with a `Buffer.Server`. Before we can swap the storage, all callers that reach into `panel.input.lines` and `panel.input.cursor` need to go through accessor functions so the underlying data source can change without touching them again.

## Changes

**New PanelState accessors:**
- `input_lines/1`: returns the input lines as a list of strings
- `input_cursor/1`: returns the cursor position as `{line, col}`
- `input_empty?/1`: returns true if the input is a single empty line

**RenderInput.panel_data type updated:** carries `input_lines: [String.t()]` and `input_cursor: {non_neg_integer(), non_neg_integer()}` instead of `input: TextField.t()`. This means the entire rendering pipeline is decoupled from TextField.

**ChatRenderer.panel_state type updated:** same change, `input_lines` replaces `input`.

**30 call sites migrated:**
- `agent/view/renderer.ex` (12)
- `agent/chat_renderer.ex` (3)
- `editor/commands/agent.ex` (3)
- `editor/commands/agent_sub_states.ex` (5)
- `editor/render_pipeline/compose_helpers.ex` (1)
- `editor/render_pipeline/chrome_helpers.ex` (1)
- `agent/view/mouse.ex` (1)
- `input/scoped.ex` (2)
- Test file updated (2)

## Verification

```bash
mix test --exclude external --warnings-as-errors  # 3,997 tests, 0 failures
mix lint                                           # clean (format + credo + dialyzer)
```