### PR TITLE
feat(agent): configurable max output tokens

### DIFF
--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -58,6 +58,7 @@ defmodule Minga.Agent.Providers.Native do
           model: String.t(),
           tools: [ReqLLM.Tool.t()],
           thinking_level: String.t(),
+          max_tokens: pos_integer(),
           llm_client: llm_client()
         }
 
@@ -73,6 +74,7 @@ defmodule Minga.Agent.Providers.Native do
           tools: [ReqLLM.Tool.t()],
           project_root: String.t(),
           thinking_level: String.t(),
+          max_tokens: pos_integer(),
           llm_client: llm_client(),
           task: Task.t() | nil,
           streaming: boolean()
@@ -133,6 +135,7 @@ defmodule Minga.Agent.Providers.Native do
     thinking_level = Keyword.get(opts, :thinking_level, "off")
     project_root = Keyword.get(opts, :project_root) || detect_project_root()
 
+    max_tokens = Keyword.get(opts, :max_tokens) || read_config_max_tokens()
     llm_client = Keyword.get(opts, :llm_client, &ReqLLM.stream_text/3)
     tools = Keyword.get(opts, :tools) || Tools.all(project_root: project_root)
     system_prompt = build_system_prompt(project_root)
@@ -150,6 +153,7 @@ defmodule Minga.Agent.Providers.Native do
       tools: tools,
       project_root: project_root,
       thinking_level: thinking_level,
+      max_tokens: max_tokens,
       llm_client: llm_client,
       task: nil,
       streaming: false
@@ -179,6 +183,7 @@ defmodule Minga.Agent.Providers.Native do
       model: state.model,
       tools: state.tools,
       thinking_level: state.thinking_level,
+      max_tokens: state.max_tokens,
       llm_client: state.llm_client
     }
 
@@ -299,7 +304,7 @@ defmodule Minga.Agent.Providers.Native do
 
   @spec run_agent_loop(loop_ctx(), Context.t()) :: :ok | {:error, term()}
   defp run_agent_loop(lctx, context) do
-    stream_opts = build_stream_opts(lctx.tools, lctx.thinking_level)
+    stream_opts = build_stream_opts(lctx.tools, lctx.thinking_level, lctx.max_tokens)
 
     case lctx.llm_client.(lctx.model, context.messages, stream_opts) do
       {:ok, stream_response} ->
@@ -545,9 +550,9 @@ defmodule Minga.Agent.Providers.Native do
 
   # ── Helpers ─────────────────────────────────────────────────────────────────
 
-  @spec build_stream_opts([ReqLLM.Tool.t()], String.t()) :: keyword()
-  defp build_stream_opts(tools, thinking_level) do
-    opts = [tools: tools]
+  @spec build_stream_opts([ReqLLM.Tool.t()], String.t(), pos_integer()) :: keyword()
+  defp build_stream_opts(tools, thinking_level, max_tokens) do
+    opts = [tools: tools, max_tokens: max_tokens]
 
     case Map.get(@thinking_levels, thinking_level) do
       budget when is_integer(budget) and budget > 0 ->
@@ -634,6 +639,17 @@ defmodule Minga.Agent.Providers.Native do
 
         :ok
     end
+  end
+
+  @default_max_tokens 16_384
+
+  @spec read_config_max_tokens() :: pos_integer()
+  defp read_config_max_tokens do
+    Options.get(:agent_max_tokens)
+  rescue
+    _ -> @default_max_tokens
+  catch
+    :exit, _ -> @default_max_tokens
   end
 
   @spec detect_project_root() :: String.t()

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -91,6 +91,7 @@ defmodule Minga.Config.Options do
           | :agent_panel_split
           | :startup_view
           | :agent_auto_context
+          | :agent_max_tokens
           | :font_family
           | :font_size
           | :font_weight
@@ -150,6 +151,7 @@ defmodule Minga.Config.Options do
     {:agent_panel_split, :pos_integer, 65},
     {:startup_view, {:enum, [:agent, :editor]}, :agent},
     {:agent_auto_context, :boolean, true},
+    {:agent_max_tokens, :pos_integer, 16_384},
     {:font_family, :string, "Menlo"},
     {:font_size, :pos_integer, 13},
     {:font_weight, {:enum, [:thin, :light, :regular, :medium, :semibold, :bold, :heavy, :black]},

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -53,6 +53,7 @@ defmodule Minga.Config.OptionsTest do
                agent_panel_split: 65,
                startup_view: :agent,
                agent_auto_context: true,
+               agent_max_tokens: 16_384,
                font_family: "Menlo",
                font_size: 13,
                font_weight: :regular,


### PR DESCRIPTION
## What

Adds `:agent_max_tokens` config option so users can control the maximum output tokens per API response from the native provider.

## Why

Without explicit `max_tokens`, models use their default output limits which vary by provider. This leads to inconsistent behavior and no protection against runaway responses.

## Changes

- **`Config.Options`**: New `:agent_max_tokens` option, default 16384, type `:pos_integer`
- **`Providers.Native`**: Reads config on init, threads through loop context, passes to `build_stream_opts` which adds it to every ReqLLM call
- **Tests**: Updated options defaults test

Config usage: `set :agent_max_tokens, 8192`

Closes #272