### PR TITLE
feat(agent): enable Anthropic prompt caching

### DIFF
--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -313,7 +313,7 @@ defmodule Minga.Agent.Providers.Native do
 
   @spec run_agent_loop(loop_ctx(), Context.t()) :: :ok | {:error, term()}
   defp run_agent_loop(lctx, context) do
-    stream_opts = build_stream_opts(lctx.tools, lctx.thinking_level, lctx.max_tokens)
+    stream_opts = build_stream_opts(lctx.model, lctx.tools, lctx.thinking_level, lctx.max_tokens)
 
     # Emit pre-send token estimate so the context bar updates before the API call
     emit_context_usage(lctx, context)
@@ -582,21 +582,50 @@ defmodule Minga.Agent.Providers.Native do
 
   # ── Helpers ─────────────────────────────────────────────────────────────────
 
-  @spec build_stream_opts([ReqLLM.Tool.t()], String.t(), pos_integer()) :: keyword()
-  defp build_stream_opts(tools, thinking_level, max_tokens) do
+  @spec build_stream_opts(String.t(), [ReqLLM.Tool.t()], String.t(), pos_integer()) :: keyword()
+  defp build_stream_opts(model, tools, thinking_level, max_tokens) do
     opts = [tools: tools, max_tokens: max_tokens]
+
+    # Enable Anthropic prompt caching when the model is Anthropic
+    opts =
+      if anthropic_model?(model) and prompt_cache_enabled?() do
+        Keyword.put(opts, :provider_options, anthropic_prompt_cache: true)
+      else
+        opts
+      end
 
     case Map.get(@thinking_levels, thinking_level) do
       budget when is_integer(budget) and budget > 0 ->
-        Keyword.put(opts, :provider_options,
-          additional_model_request_fields: %{
-            thinking: %{type: "enabled", budget_tokens: budget}
-          }
-        )
+        # Merge thinking config into existing provider_options
+        existing = Keyword.get(opts, :provider_options, [])
+
+        merged =
+          Keyword.merge(existing,
+            additional_model_request_fields: %{
+              thinking: %{type: "enabled", budget_tokens: budget}
+            }
+          )
+
+        Keyword.put(opts, :provider_options, merged)
 
       _ ->
         opts
     end
+  end
+
+  @spec anthropic_model?(String.t()) :: boolean()
+  defp anthropic_model?(model) do
+    String.starts_with?(model, "anthropic:") or
+      not String.contains?(model, ":")
+  end
+
+  @spec prompt_cache_enabled?() :: boolean()
+  defp prompt_cache_enabled? do
+    Options.get(:agent_prompt_cache)
+  rescue
+    _ -> true
+  catch
+    :exit, _ -> true
   end
 
   @spec build_system_prompt(String.t()) :: String.t()

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -93,6 +93,7 @@ defmodule Minga.Config.Options do
           | :agent_auto_context
           | :agent_max_tokens
           | :agent_max_retries
+          | :agent_prompt_cache
           | :font_family
           | :font_size
           | :font_weight
@@ -154,6 +155,7 @@ defmodule Minga.Config.Options do
     {:agent_auto_context, :boolean, true},
     {:agent_max_tokens, :pos_integer, 16_384},
     {:agent_max_retries, :non_neg_integer, 3},
+    {:agent_prompt_cache, :boolean, true},
     {:font_family, :string, "Menlo"},
     {:font_size, :pos_integer, 13},
     {:font_weight, {:enum, [:thin, :light, :regular, :medium, :semibold, :bold, :heavy, :black]},

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -55,6 +55,7 @@ defmodule Minga.Config.OptionsTest do
                agent_auto_context: true,
                agent_max_tokens: 16_384,
                agent_max_retries: 3,
+               agent_prompt_cache: true,
                font_family: "Menlo",
                font_size: 13,
                font_weight: :regular,


### PR DESCRIPTION
## What

Enables Anthropic prompt caching for the native provider, reducing latency and cost for cached system prompt prefixes.

## Why

The system prompt and early turns are resent on every API call. Anthropic caching can cut input costs by 90% and latency by 85% for cached prefixes. Pi-agent enables this automatically; we should too.

## Changes

- **`Providers.Native`**: `build_stream_opts` now adds `anthropic_prompt_cache: true` for Anthropic models. Also fixes a bug where thinking config would overwrite existing provider_options instead of merging.
- **`Config.Options`**: New `:agent_prompt_cache` option (default `true`).

Cache hit/miss stats (`cache_read`, `cache_write`) were already extracted by `normalize_usage/1` and displayed in the UI. This just enables the feature.

Closes #271