### PR TITLE
feat(agent): replace TextField+Input.Vim with Buffer.Server+Mode FSM (Phase D)

### DIFF
--- a/lib/minga/agent/panel_state.ex
+++ b/lib/minga/agent/panel_state.ex
@@ -2,19 +2,19 @@ defmodule Minga.Agent.PanelState do
   @moduledoc """
   State for the agent chat panel UI.
 
-  Tracks visibility, scroll position, multi-line input with cursor,
+  Tracks visibility, scroll position, prompt editing (via Buffer.Server),
   prompt history, spinner animation, and other UI-only concerns.
   Stored in `Editor.State` and updated by agent event handlers.
 
-  Text editing is delegated to `Minga.Input.TextField`, which provides
-  the core insert/delete/cursor operations. PanelState adds domain
-  concerns on top: paste block collapsing, prompt history, mention
-  completion, and input focus tracking.
+  The prompt is backed by a `Buffer.Server` process. All vim editing
+  (motions, operators, visual mode, text objects, undo/redo) is handled
+  by the standard Mode FSM routed through the prompt buffer, not by a
+  reimplemented vim grammar. PanelState adds domain concerns on top:
+  paste block collapsing, prompt history, mention completion, and input
+  focus tracking.
   """
 
   alias Minga.Buffer.Server, as: BufferServer
-  alias Minga.Input.TextField
-  alias Minga.Input.Vim
   alias Minga.Scroll
 
   @typedoc "Thinking level for models that support extended reasoning."
@@ -30,8 +30,6 @@ defmodule Minga.Agent.PanelState do
   @type t :: %__MODULE__{
           visible: boolean(),
           scroll: Scroll.t(),
-          input: TextField.t(),
-          vim: Vim.t(),
           prompt_buffer: pid() | nil,
           prompt_history: [String.t()],
           history_index: integer(),
@@ -57,8 +55,6 @@ defmodule Minga.Agent.PanelState do
   @enforce_keys []
   defstruct visible: false,
             scroll: %Scroll{},
-            input: %TextField{},
-            vim: %Vim{},
             prompt_buffer: nil,
             prompt_history: [],
             history_index: -1,
@@ -75,6 +71,8 @@ defmodule Minga.Agent.PanelState do
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
+  # ── Prompt buffer lifecycle ─────────────────────────────────────────────
+
   @doc """
   Ensures a prompt Buffer.Server is running. Starts one if `prompt_buffer`
   is nil or the process is dead.
@@ -86,59 +84,72 @@ defmodule Minga.Agent.PanelState do
   @spec ensure_prompt_buffer(t()) :: t()
   def ensure_prompt_buffer(%__MODULE__{prompt_buffer: pid} = state)
       when is_pid(pid) do
-    if Process.alive?(pid), do: state, else: start_prompt_buffer(state)
+    if Process.alive?(pid), do: state, else: start_prompt_buffer(state, "")
   end
 
-  def ensure_prompt_buffer(%__MODULE__{} = state), do: start_prompt_buffer(state)
+  def ensure_prompt_buffer(%__MODULE__{} = state), do: start_prompt_buffer(state, "")
 
-  @doc """
-  Returns the prompt text. Reads from the prompt buffer if available,
-  falls back to TextField. Paste placeholders are substituted in both cases.
-  """
-  @spec prompt_text(t()) :: String.t()
-  def prompt_text(%__MODULE__{prompt_buffer: pid, pasted_blocks: blocks} = state)
-      when is_pid(pid) do
-    if Process.alive?(pid) do
-      content = BufferServer.content(pid)
-      substitute_placeholders(content, blocks)
-    else
-      input_text(state)
-    end
-  end
-
-  def prompt_text(%__MODULE__{} = state), do: input_text(state)
-
-  @doc """
-  Syncs the TextField content to the prompt buffer. Call this after
-  any TextField mutation to keep the buffer in sync during the migration.
-  """
-  @spec sync_to_prompt_buffer(t()) :: t()
-  def sync_to_prompt_buffer(%__MODULE__{prompt_buffer: pid, input: tf} = state)
-      when is_pid(pid) do
-    if Process.alive?(pid) do
-      content = Enum.join(tf.lines, "\n")
-      current = BufferServer.content(pid)
-
-      if content != current do
-        BufferServer.replace_content(pid, content)
-      end
-    end
-
-    state
-  end
-
-  def sync_to_prompt_buffer(%__MODULE__{} = state), do: state
-
-  defp start_prompt_buffer(%__MODULE__{} = state) do
-    content = Enum.join(state.input.lines, "\n")
+  defp start_prompt_buffer(%__MODULE__{} = state, content) do
     {:ok, pid} = BufferServer.start_link(content: content)
     %{state | prompt_buffer: pid}
   end
 
-  defp substitute_placeholders(content, blocks) do
-    String.split(content, "\n")
-    |> Enum.map_join("\n", fn line -> substitute_placeholder(line, blocks) end)
+  # ── Accessors ───────────────────────────────────────────────────────────
+
+  @doc """
+  Returns the prompt text with paste placeholders substituted.
+
+  This is the text submitted to the LLM. Placeholder tokens are replaced
+  with the full paste content from `pasted_blocks`.
+  """
+  @spec prompt_text(t()) :: String.t()
+  def prompt_text(%__MODULE__{prompt_buffer: pid, pasted_blocks: blocks})
+      when is_pid(pid) do
+    content = BufferServer.content(pid)
+    substitute_placeholders(content, blocks)
   end
+
+  def prompt_text(%__MODULE__{}), do: ""
+
+  @doc "Returns the raw input text (with placeholders, not substituted)."
+  @spec input_text(t()) :: String.t()
+  def input_text(%__MODULE__{prompt_buffer: pid}) when is_pid(pid) do
+    BufferServer.content(pid)
+  end
+
+  def input_text(%__MODULE__{}), do: ""
+
+  @doc "Returns the input lines as a list of strings."
+  @spec input_lines(t()) :: [String.t()]
+  def input_lines(%__MODULE__{prompt_buffer: pid}) when is_pid(pid) do
+    BufferServer.content(pid) |> String.split("\n")
+  end
+
+  def input_lines(%__MODULE__{}), do: [""]
+
+  @doc "Returns the input cursor position as `{line, col}`."
+  @spec input_cursor(t()) :: {non_neg_integer(), non_neg_integer()}
+  def input_cursor(%__MODULE__{prompt_buffer: pid}) when is_pid(pid) do
+    BufferServer.cursor(pid)
+  end
+
+  def input_cursor(%__MODULE__{}), do: {0, 0}
+
+  @doc "Returns the number of input lines."
+  @spec input_line_count(t()) :: pos_integer()
+  def input_line_count(%__MODULE__{prompt_buffer: pid}) when is_pid(pid) do
+    BufferServer.line_count(pid)
+  end
+
+  def input_line_count(%__MODULE__{}), do: 1
+
+  @doc "Returns true if the input is empty (single empty line)."
+  @spec input_empty?(t()) :: boolean()
+  def input_empty?(%__MODULE__{prompt_buffer: pid}) when is_pid(pid) do
+    BufferServer.content(pid) == ""
+  end
+
+  def input_empty?(%__MODULE__{}), do: true
 
   @doc "Toggles panel visibility."
   @spec toggle(t()) :: t()
@@ -152,32 +163,30 @@ defmodule Minga.Agent.PanelState do
     %{state | spinner_frame: state.spinner_frame + 1}
   end
 
-  # ── Input editing (delegates to TextField) ──────────────────────────────────
-
-  @doc """
-  Returns the full input text by joining lines with newlines.
-
-  Paste placeholder tokens are substituted with the full text from
-  their corresponding pasted_blocks entry, so the returned string
-  contains the complete content the user intends to submit.
-  """
-  @spec input_text(t()) :: String.t()
-  def input_text(%__MODULE__{input: tf, pasted_blocks: blocks}) do
-    Enum.map_join(tf.lines, "\n", fn line -> substitute_placeholder(line, blocks) end)
-  end
+  # ── Input editing (delegates to Buffer.Server) ──────────────────────────
 
   @doc "Inserts a character at the cursor position."
   @spec insert_char(t(), String.t()) :: t()
+  def insert_char(%__MODULE__{prompt_buffer: pid} = state, char) when is_pid(pid) do
+    BufferServer.insert_text(pid, char)
+    %{state | history_index: -1}
+  end
+
   def insert_char(%__MODULE__{} = state, char) do
-    %{state | input: TextField.insert_char(state.input, char), history_index: -1}
-    |> sync_to_prompt_buffer()
+    state = ensure_prompt_buffer(state)
+    insert_char(state, char)
   end
 
   @doc "Inserts a newline at the cursor, splitting the current line."
   @spec insert_newline(t()) :: t()
+  def insert_newline(%__MODULE__{prompt_buffer: pid} = state) when is_pid(pid) do
+    BufferServer.insert_text(pid, "\n")
+    %{state | history_index: -1}
+  end
+
   def insert_newline(%__MODULE__{} = state) do
-    %{state | input: TextField.insert_newline(state.input), history_index: -1}
-    |> sync_to_prompt_buffer()
+    state = ensure_prompt_buffer(state)
+    insert_newline(state)
   end
 
   @doc """
@@ -187,9 +196,21 @@ defmodule Minga.Agent.PanelState do
   At the start of the first line, no-op.
   """
   @spec delete_char(t()) :: t()
+  def delete_char(%__MODULE__{prompt_buffer: pid} = state) when is_pid(pid) do
+    {line, col} = BufferServer.cursor(pid)
+
+    if line == 0 and col == 0 do
+      state
+    else
+      BufferServer.delete_before(pid)
+    end
+
+    %{state | history_index: -1}
+  end
+
   def delete_char(%__MODULE__{} = state) do
-    %{state | input: TextField.delete_backward(state.input), history_index: -1}
-    |> sync_to_prompt_buffer()
+    state = ensure_prompt_buffer(state)
+    delete_char(state)
   end
 
   @doc "Clears the input (after submission). Saves current text to history first."
@@ -197,29 +218,45 @@ defmodule Minga.Agent.PanelState do
   def clear_input(%__MODULE__{} = state) do
     state = save_to_history(state)
 
-    %{state | input: TextField.clear(state.input), history_index: -1, pasted_blocks: []}
-    |> sync_to_prompt_buffer()
+    if is_pid(state.prompt_buffer) do
+      BufferServer.replace_content(state.prompt_buffer, "")
+    end
+
+    %{state | history_index: -1, pasted_blocks: []}
   end
 
-  # ── Cursor movement (delegates to TextField) ──────────────────────────────
+  # ── Cursor movement ────────────────────────────────────────────────────
 
   @doc "Moves cursor up within the input. Returns `:at_top` if already on the first line."
   @spec move_cursor_up(t()) :: t() | :at_top
-  def move_cursor_up(%__MODULE__{} = state) do
-    case TextField.move_up(state.input) do
-      :at_top -> :at_top
-      tf -> %{state | input: tf}
+  def move_cursor_up(%__MODULE__{prompt_buffer: pid} = state) when is_pid(pid) do
+    {line, _col} = BufferServer.cursor(pid)
+
+    if line == 0 do
+      :at_top
+    else
+      BufferServer.move_cursor(pid, :up)
+      state
     end
   end
 
+  def move_cursor_up(%__MODULE__{}), do: :at_top
+
   @doc "Moves cursor down within the input. Returns `:at_bottom` if already on the last line."
   @spec move_cursor_down(t()) :: t() | :at_bottom
-  def move_cursor_down(%__MODULE__{} = state) do
-    case TextField.move_down(state.input) do
-      :at_bottom -> :at_bottom
-      tf -> %{state | input: tf}
+  def move_cursor_down(%__MODULE__{prompt_buffer: pid} = state) when is_pid(pid) do
+    {line, _col} = BufferServer.cursor(pid)
+    total = BufferServer.line_count(pid)
+
+    if line >= total - 1 do
+      :at_bottom
+    else
+      BufferServer.move_cursor(pid, :down)
+      state
     end
   end
+
+  def move_cursor_down(%__MODULE__{}), do: :at_bottom
 
   # ── Paste handling ────────────────────────────────────────────────────────
 
@@ -227,30 +264,31 @@ defmodule Minga.Agent.PanelState do
   Inserts pasted text into the input.
 
   For short pastes (fewer than #{@paste_collapse_threshold} lines), the text is
-  inserted directly into the input as if typed. For longer pastes, the text is
+  inserted directly into the buffer. For longer pastes, the text is
   stored in `pasted_blocks` and a placeholder token is inserted at the cursor
   position. The placeholder renders as a compact indicator (e.g. "󰆏 [pasted 23 lines]")
-  but `input_text/1` substitutes the full content when the prompt is submitted.
+  but `prompt_text/1` substitutes the full content when the prompt is submitted.
   """
   @spec insert_paste(t(), String.t()) :: t()
   def insert_paste(%__MODULE__{} = state, ""), do: state
 
-  def insert_paste(%__MODULE__{} = state, text) do
+  def insert_paste(%__MODULE__{prompt_buffer: pid} = state, text) when is_pid(pid) do
     # Strip NUL bytes from paste to prevent fake placeholder injection
     clean_text = String.replace(text, "\0", "")
-
     lines = String.split(clean_text, "\n")
     line_count = length(lines)
 
-    result =
-      if line_count < @paste_collapse_threshold do
-        # Short paste: insert directly via TextField
-        %{state | input: TextField.insert_text(state.input, clean_text), history_index: -1}
-      else
-        insert_collapsed_paste(state, clean_text)
-      end
+    if line_count < @paste_collapse_threshold do
+      BufferServer.insert_text(pid, clean_text)
+      %{state | history_index: -1}
+    else
+      insert_collapsed_paste(state, clean_text)
+    end
+  end
 
-    sync_to_prompt_buffer(result)
+  def insert_paste(%__MODULE__{} = state, text) do
+    state = ensure_prompt_buffer(state)
+    insert_paste(state, text)
   end
 
   @doc """
@@ -263,9 +301,10 @@ defmodule Minga.Agent.PanelState do
   a paste placeholder or within an expanded block.
   """
   @spec toggle_paste_expand(t()) :: t()
-  def toggle_paste_expand(%__MODULE__{input: tf} = state) do
-    {cursor_line, _} = tf.cursor
-    current_line = Enum.at(tf.lines, cursor_line)
+  def toggle_paste_expand(%__MODULE__{prompt_buffer: pid} = state) when is_pid(pid) do
+    {cursor_line, _} = BufferServer.cursor(pid)
+    lines = input_lines(state)
+    current_line = Enum.at(lines, cursor_line)
 
     case parse_placeholder(current_line) do
       {:ok, block_index} ->
@@ -279,6 +318,8 @@ defmodule Minga.Agent.PanelState do
         end
     end
   end
+
+  def toggle_paste_expand(%__MODULE__{} = state), do: state
 
   @doc """
   Returns true if the given line is a paste placeholder token.
@@ -314,10 +355,8 @@ defmodule Minga.Agent.PanelState do
 
   @doc "Saves the current input to prompt history (if non-empty)."
   @spec save_to_history(t()) :: t()
-  def save_to_history(%__MODULE__{input: %TextField{lines: [""]}} = state), do: state
-
   def save_to_history(%__MODULE__{} = state) do
-    text = input_text(state)
+    text = prompt_text(state)
 
     if String.trim(text) == "" do
       state
@@ -330,30 +369,38 @@ defmodule Minga.Agent.PanelState do
   @spec history_prev(t()) :: t()
   def history_prev(%__MODULE__{prompt_history: []} = state), do: state
 
-  def history_prev(%__MODULE__{history_index: idx, prompt_history: history} = state) do
+  def history_prev(
+        %__MODULE__{prompt_buffer: pid, history_index: idx, prompt_history: history} = state
+      )
+      when is_pid(pid) do
     new_idx = min(idx + 1, length(history) - 1)
     text = Enum.at(history, new_idx)
-
-    %{state | input: TextField.new(text), history_index: new_idx}
-    |> sync_to_prompt_buffer()
+    BufferServer.replace_content(pid, text)
+    %{state | history_index: new_idx}
   end
+
+  def history_prev(%__MODULE__{} = state), do: state
 
   @doc "Recalls the next (more recent) prompt from history."
   @spec history_next(t()) :: t()
   def history_next(%__MODULE__{history_index: -1} = state), do: state
 
-  def history_next(%__MODULE__{history_index: 0} = state) do
-    %{state | input: TextField.new(), history_index: -1}
-    |> sync_to_prompt_buffer()
+  def history_next(%__MODULE__{prompt_buffer: pid, history_index: 0} = state) when is_pid(pid) do
+    BufferServer.replace_content(pid, "")
+    %{state | history_index: -1}
   end
 
-  def history_next(%__MODULE__{history_index: idx, prompt_history: history} = state) do
+  def history_next(
+        %__MODULE__{prompt_buffer: pid, history_index: idx, prompt_history: history} = state
+      )
+      when is_pid(pid) do
     new_idx = idx - 1
     text = Enum.at(history, new_idx)
-
-    %{state | input: TextField.new(text), history_index: new_idx}
-    |> sync_to_prompt_buffer()
+    BufferServer.replace_content(pid, text)
+    %{state | history_index: new_idx}
   end
+
+  def history_next(%__MODULE__{} = state), do: state
 
   # ── Scrolling (delegates to Minga.Scroll) ────────────────────────────────
 
@@ -391,37 +438,16 @@ defmodule Minga.Agent.PanelState do
     %{state | scroll: Scroll.pin_to_bottom(state.scroll)}
   end
 
-  @doc "Returns the current input vim mode, derived from the Vim state."
-  @spec input_mode(t()) :: input_mode()
-  def input_mode(%__MODULE__{vim: vim}), do: Vim.mode(vim)
-
-  @doc "Sets the input focus state. Entering focus starts in insert mode; leaving resets vim state."
+  @doc "Sets the input focus state. Entering focus ensures the prompt buffer exists."
   @spec set_input_focused(t(), boolean()) :: t()
   def set_input_focused(%__MODULE__{} = state, true) do
     state = ensure_prompt_buffer(state)
-    %{state | input_focused: true, vim: Vim.enter_insert(state.vim)}
+    %{state | input_focused: true}
   end
 
   def set_input_focused(%__MODULE__{} = state, false) do
-    %{state | input_focused: false, vim: Vim.enter_insert(state.vim)}
+    %{state | input_focused: false}
   end
-
-  @doc "Returns the number of input lines."
-  @spec input_line_count(t()) :: pos_integer()
-  def input_line_count(%__MODULE__{input: tf}), do: TextField.line_count(tf)
-
-  @doc "Returns the input lines as a list of strings."
-  @spec input_lines(t()) :: [String.t()]
-  def input_lines(%__MODULE__{input: tf}), do: tf.lines
-
-  @doc "Returns the input cursor position as `{line, col}`."
-  @spec input_cursor(t()) :: {non_neg_integer(), non_neg_integer()}
-  def input_cursor(%__MODULE__{input: tf}), do: tf.cursor
-
-  @doc "Returns true if the input is empty (single empty line)."
-  @spec input_empty?(t()) :: boolean()
-  def input_empty?(%__MODULE__{input: %TextField{lines: [""]}}), do: true
-  def input_empty?(%__MODULE__{}), do: false
 
   @doc """
   Clears the chat display without affecting conversation history.
@@ -437,11 +463,14 @@ defmodule Minga.Agent.PanelState do
   # ── Private: paste helpers ───────────────────────────────────────────────
 
   # Creates a collapsed paste block and inserts a placeholder token at the
-  # cursor position.
+  # cursor position in the buffer.
   @spec insert_collapsed_paste(t(), String.t()) :: t()
-  defp insert_collapsed_paste(%__MODULE__{input: tf, pasted_blocks: blocks} = state, text) do
-    {cursor_line, cursor_col} = tf.cursor
-    lines = tf.lines
+  defp insert_collapsed_paste(
+         %__MODULE__{prompt_buffer: pid, pasted_blocks: blocks} = state,
+         text
+       ) do
+    {cursor_line, cursor_col} = BufferServer.cursor(pid)
+    lines = input_lines(state)
 
     block_index = length(blocks)
     new_block = %{text: text, expanded: false}
@@ -450,8 +479,9 @@ defmodule Minga.Agent.PanelState do
     current = Enum.at(lines, cursor_line)
     {before, after_cursor} = String.split_at(current, cursor_col)
 
-    # Split into: before text, placeholder on its own line, after text
+    # Build new content with placeholder inserted
     new_lines = insert_placeholder_lines(lines, cursor_line, before, after_cursor, placeholder)
+    new_content = Enum.join(new_lines, "\n")
 
     # Position cursor on the line after the placeholder
     placeholder_line_idx = Enum.find_index(new_lines, &(&1 == placeholder))
@@ -460,12 +490,10 @@ defmodule Minga.Agent.PanelState do
     new_cursor_col =
       if new_cursor_line > placeholder_line_idx, do: 0, else: String.length(placeholder)
 
-    %{
-      state
-      | input: TextField.from_parts(new_lines, {new_cursor_line, new_cursor_col}),
-        pasted_blocks: blocks ++ [new_block],
-        history_index: -1
-    }
+    BufferServer.replace_content(pid, new_content)
+    BufferServer.set_cursor(pid, {new_cursor_line, new_cursor_col})
+
+    %{state | pasted_blocks: blocks ++ [new_block], history_index: -1}
   end
 
   # Determines how to insert a placeholder into the line list based on
@@ -502,9 +530,9 @@ defmodule Minga.Agent.PanelState do
 
   # Expands a collapsed paste block: replaces the placeholder with actual text lines.
   @spec expand_block(t(), non_neg_integer()) :: t()
-  defp expand_block(%__MODULE__{input: tf, pasted_blocks: blocks} = state, block_index) do
-    {cursor_line, _} = tf.cursor
-    lines = tf.lines
+  defp expand_block(%__MODULE__{prompt_buffer: pid, pasted_blocks: blocks} = state, block_index) do
+    {cursor_line, _} = BufferServer.cursor(pid)
+    lines = input_lines(state)
     block = Enum.at(blocks, block_index)
     placeholder = @paste_placeholder_prefix <> Integer.to_string(block_index)
     placeholder_line_idx = Enum.find_index(lines, &(&1 == placeholder))
@@ -523,11 +551,10 @@ defmodule Minga.Agent.PanelState do
       new_cursor_line =
         if cursor_line > placeholder_line_idx, do: cursor_line + expansion, else: cursor_line
 
-      %{
-        state
-        | input: TextField.from_parts(new_lines, {new_cursor_line, 0}),
-          pasted_blocks: new_blocks
-      }
+      BufferServer.replace_content(pid, Enum.join(new_lines, "\n"))
+      BufferServer.set_cursor(pid, {new_cursor_line, 0})
+
+      %{state | pasted_blocks: new_blocks}
     else
       state
     end
@@ -535,9 +562,9 @@ defmodule Minga.Agent.PanelState do
 
   # Collapses an expanded paste block: replaces text lines with the placeholder.
   @spec collapse_block(t(), non_neg_integer()) :: t()
-  defp collapse_block(%__MODULE__{input: tf, pasted_blocks: blocks} = state, block_index) do
-    {cursor_line, _} = tf.cursor
-    lines = tf.lines
+  defp collapse_block(%__MODULE__{prompt_buffer: pid, pasted_blocks: blocks} = state, block_index) do
+    {cursor_line, _} = BufferServer.cursor(pid)
+    lines = input_lines(state)
     block = Enum.at(blocks, block_index)
     text_lines = String.split(block.text, "\n")
     text_line_count = length(text_lines)
@@ -556,11 +583,10 @@ defmodule Minga.Agent.PanelState do
       contraction = text_line_count - 1
       new_cursor_line = collapse_cursor_line(cursor_line, start_idx, text_line_count, contraction)
 
-      %{
-        state
-        | input: TextField.from_parts(new_lines, {new_cursor_line, 0}),
-          pasted_blocks: new_blocks
-      }
+      BufferServer.replace_content(pid, Enum.join(new_lines, "\n"))
+      BufferServer.set_cursor(pid, {new_cursor_line, 0})
+
+      %{state | pasted_blocks: new_blocks}
     else
       state
     end
@@ -587,12 +613,14 @@ defmodule Minga.Agent.PanelState do
   # Finds which expanded paste block (if any) contains the given cursor line.
   @spec find_expanded_block_at_cursor(t(), non_neg_integer()) ::
           {:ok, non_neg_integer()} | :not_found
-  defp find_expanded_block_at_cursor(%__MODULE__{input: tf, pasted_blocks: blocks}, cursor_line) do
-    blocks
+  defp find_expanded_block_at_cursor(%__MODULE__{} = state, cursor_line) do
+    lines = input_lines(state)
+
+    state.pasted_blocks
     |> Enum.with_index()
     |> Enum.find_value(:not_found, fn {block, index} ->
       if block.expanded do
-        expanded_block_contains_cursor?(tf.lines, block, index, cursor_line)
+        expanded_block_contains_cursor?(lines, block, index, cursor_line)
       end
     end)
   end
@@ -616,15 +644,15 @@ defmodule Minga.Agent.PanelState do
 
   # Finds where an expanded block's text lines start in input lines.
   @spec find_expanded_block_start([String.t()], [String.t()]) :: non_neg_integer() | nil
-  defp find_expanded_block_start(input_lines, text_lines) do
+  defp find_expanded_block_start(input_lines_list, text_lines) do
     text_len = length(text_lines)
-    max_start = length(input_lines) - text_len
+    max_start = length(input_lines_list) - text_len
 
     if max_start < 0 do
       nil
     else
       Enum.find(0..max_start, fn start ->
-        Enum.slice(input_lines, start, text_len) == text_lines
+        Enum.slice(input_lines_list, start, text_len) == text_lines
       end)
     end
   end
@@ -642,6 +670,13 @@ defmodule Minga.Agent.PanelState do
       _ ->
         :not_placeholder
     end
+  end
+
+  # Substitutes paste placeholders in a multi-line string.
+  @spec substitute_placeholders(String.t(), [paste_block()]) :: String.t()
+  defp substitute_placeholders(content, blocks) do
+    String.split(content, "\n")
+    |> Enum.map_join("\n", fn line -> substitute_placeholder(line, blocks) end)
   end
 
   # Substitutes a paste placeholder in a line with the actual text.

--- a/lib/minga/agent/view/mouse.ex
+++ b/lib/minga/agent/view/mouse.ex
@@ -26,6 +26,7 @@ defmodule Minga.Agent.View.Mouse do
   alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.AgentAccess
   alias Minga.Editor.State.Mouse, as: MouseState
+  alias Minga.Mode
 
   @scroll_lines 3
 
@@ -208,17 +209,24 @@ defmodule Minga.Agent.View.Mouse do
   @spec handle_click(state(), agent_region(), integer(), integer()) :: state()
 
   defp handle_click(state, :chat, _row, _col) do
-    update_agentic(state, fn av -> %{av | focus: :chat} end)
-    |> update_agent(&AgentState.focus_input(&1, false))
+    state =
+      update_agentic(state, fn av -> %{av | focus: :chat} end)
+      |> update_agent(&AgentState.focus_input(&1, false))
+
+    %{state | mode: :normal, mode_state: Mode.initial_state()}
   end
 
   defp handle_click(state, :file_viewer, _row, _col) do
-    update_agentic(state, fn av -> %{av | focus: :file_viewer} end)
-    |> update_agent(&AgentState.focus_input(&1, false))
+    state =
+      update_agentic(state, fn av -> %{av | focus: :file_viewer} end)
+      |> update_agent(&AgentState.focus_input(&1, false))
+
+    %{state | mode: :normal, mode_state: Mode.initial_state()}
   end
 
   defp handle_click(state, :input, _row, _col) do
-    update_agent(state, &AgentState.focus_input(&1, true))
+    state = update_agent(state, &AgentState.focus_input(&1, true))
+    %{state | mode: :insert, mode_state: Mode.initial_state()}
   end
 
   defp handle_click(state, :separator, _row, col) do

--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -40,8 +40,7 @@ defmodule Minga.Agent.View.Renderer do
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.AgentAccess
   alias Minga.Editor.Viewport
-  alias Minga.Input.TextField
-  alias Minga.Input.Vim
+
   alias Minga.Input.Wrap, as: InputWrap
   alias Minga.Keymap.Scope
   alias Minga.Scroll
@@ -117,7 +116,8 @@ defmodule Minga.Agent.View.Renderer do
             input_focused: boolean(),
             input_lines: [String.t()],
             input_cursor: {non_neg_integer(), non_neg_integer()},
-            vim: Vim.t(),
+            mode: atom(),
+            mode_state: term(),
             scroll: Scroll.t(),
             spinner_frame: non_neg_integer(),
             model_name: String.t(),
@@ -335,7 +335,8 @@ defmodule Minga.Agent.View.Renderer do
         input_focused: panel.input_focused,
         input_lines: PanelState.input_lines(panel),
         input_cursor: PanelState.input_cursor(panel),
-        vim: panel.vim,
+        mode: state.mode,
+        mode_state: state.mode_state,
         scroll: panel.scroll,
         spinner_frame: panel.spinner_frame,
         model_name: panel.model_name,
@@ -1053,7 +1054,7 @@ defmodule Minga.Agent.View.Renderer do
           map(),
           non_neg_integer(),
           InputWrap.visual_line(),
-          {TextField.cursor(), TextField.cursor()} | nil
+          {{non_neg_integer(), non_neg_integer()}, {non_neg_integer(), non_neg_integer()}} | nil
         ) :: [DisplayList.draw()]
   defp render_input_row(row, display_text, fg_color, chrome, logical_idx, vl, sel_range) do
     padded = String.pad_trailing(display_text, chrome.inner_width)
@@ -1095,7 +1096,7 @@ defmodule Minga.Agent.View.Renderer do
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
-          {TextField.cursor(), TextField.cursor()} | nil
+          {{non_neg_integer(), non_neg_integer()}, {non_neg_integer(), non_neg_integer()}} | nil
         ) :: {non_neg_integer(), pos_integer()} | nil
   defp selection_slice(_logical_idx, _col_offset, _text_len, nil), do: nil
 
@@ -1151,26 +1152,40 @@ defmodule Minga.Agent.View.Renderer do
 
   # Returns the visual selection range from Vim state, or nil.
   @spec vim_visual_range(map()) ::
-          {TextField.cursor(), TextField.cursor()} | nil
-  defp vim_visual_range(%{vim: %Vim{} = vim, input_lines: lines, input_cursor: cursor}) do
-    tf = TextField.from_parts(lines, cursor)
-    Vim.visual_range(vim, tf)
+          {{non_neg_integer(), non_neg_integer()}, {non_neg_integer(), non_neg_integer()}} | nil
+  # Visual selection range for the prompt input. Uses the editor's mode
+  # state (visual_start) when in visual mode, since the prompt uses the
+  # standard Mode FSM.
+  @spec vim_visual_range(map()) ::
+          {{non_neg_integer(), non_neg_integer()}, {non_neg_integer(), non_neg_integer()}} | nil
+  defp vim_visual_range(%{input_cursor: cursor, mode: mode, mode_state: mode_state})
+       when mode in [:visual, :visual_line] do
+    case mode_state do
+      %{visual_start: {vl, vc}} when is_integer(vl) ->
+        {from, to} = if {vl, vc} <= cursor, do: {{vl, vc}, cursor}, else: {cursor, {vl, vc}}
+
+        if mode == :visual_line do
+          {from_line, _} = from
+          {to_line, _} = to
+          {{from_line, 0}, {to_line, 999_999}}
+        else
+          {from, to}
+        end
+
+      _ ->
+        nil
+    end
   end
 
   defp vim_visual_range(_panel), do: nil
 
-  # Checks for Vim state on PanelState structs; returns "" for plain maps (tests).
+  # Returns a mode label for the prompt border.
   @spec input_mode_label(map()) :: String.t()
-  defp input_mode_label(%{vim: %Vim{} = vim}) do
-    case Vim.mode(vim) do
-      :insert -> ""
-      :normal -> "NORMAL"
-      :visual -> "VISUAL"
-      :visual_line -> "V-LINE"
-      :operator_pending -> "OP"
-    end
-  end
-
+  defp input_mode_label(%{mode: :insert}), do: ""
+  defp input_mode_label(%{mode: :normal}), do: "NORMAL"
+  defp input_mode_label(%{mode: :visual}), do: "VISUAL"
+  defp input_mode_label(%{mode: :visual_line}), do: "V-LINE"
+  defp input_mode_label(%{mode: :operator_pending}), do: "OP"
   defp input_mode_label(_panel), do: ""
 
   # Computes the dynamic input area height for the bordered box:

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -203,6 +203,18 @@ defmodule Minga.Buffer.Server do
     GenServer.call(server, :cursor)
   end
 
+  @doc "Sets the cursor to an absolute position. Clamped to buffer bounds."
+  @spec set_cursor(GenServer.server(), Document.position()) :: :ok
+  def set_cursor(server, {line, col}) when is_integer(line) and is_integer(col) do
+    GenServer.call(server, {:set_cursor, {line, col}})
+  end
+
+  @doc "Moves the cursor in the given direction."
+  @spec move_cursor(GenServer.server(), :up | :down | :left | :right) :: :ok
+  def move_cursor(server, direction) when direction in [:up, :down, :left, :right] do
+    GenServer.call(server, {:move_cursor, direction})
+  end
+
   @doc "Returns the total line count."
   @spec line_count(GenServer.server()) :: pos_integer()
   def line_count(server) do
@@ -843,6 +855,16 @@ defmodule Minga.Buffer.Server do
 
   def handle_call(:cursor, _from, state) do
     {:reply, Document.cursor(state.document), state}
+  end
+
+  def handle_call({:set_cursor, {line, col}}, _from, state) do
+    doc = Document.move_to(state.document, {line, col})
+    {:reply, :ok, %{state | document: doc}}
+  end
+
+  def handle_call({:move_cursor, direction}, _from, state) do
+    doc = Document.move(state.document, direction)
+    {:reply, :ok, %{state | document: doc}}
   end
 
   def handle_call(:line_count, _from, state) do

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -29,7 +29,7 @@ defmodule Minga.Editor.Commands.Agent do
   alias Minga.Editor.State.AgentAccess
   alias Minga.Editor.State.Tab
   alias Minga.Editor.State.TabBar
-  alias Minga.Input.Vim
+
   alias Minga.Surface.AgentView
   alias Minga.Surface.AgentView.State, as: AgentViewState
   alias Minga.Surface.Context
@@ -711,13 +711,15 @@ defmodule Minga.Editor.Commands.Agent do
   @doc "Focuses the input field and transitions to insert mode."
   @spec scope_focus_input(state()) :: state()
   def scope_focus_input(state) do
-    update_agent(state, &AgentState.focus_input(&1, true))
+    state = update_agent(state, &AgentState.focus_input(&1, true))
+    %{state | mode: :insert, mode_state: Minga.Mode.initial_state()}
   end
 
   @doc "Unfocuses the input field and transitions to normal mode."
   @spec scope_unfocus_input(state()) :: state()
   def scope_unfocus_input(state) do
-    update_agent(state, &AgentState.focus_input(&1, false))
+    state = update_agent(state, &AgentState.focus_input(&1, false))
+    %{state | mode: :normal, mode_state: Minga.Mode.initial_state()}
   end
 
   @doc "Unfocuses the input field and closes the agentic view."
@@ -730,16 +732,15 @@ defmodule Minga.Editor.Commands.Agent do
   # ── Input vim mode commands ──────────────────────────────────────────────
   #
   # Vim editing (motions, operators, visual mode, counts, text objects) is
-  # handled entirely by Minga.Input.Vim.handle_key/4 in the dispatch layer.
+  # handled by the standard Mode FSM via dispatch_prompt_via_mode_fsm.
   # Only mode transitions that originate from scope trie bindings live here.
 
-  @doc "Switches the input from insert to normal mode (called on Escape in insert)."
+  @doc "Switches the input from insert to normal mode. Delegates to Mode FSM via Escape."
   @spec input_to_normal(state()) :: state()
   def input_to_normal(state) do
-    update_agent(state, fn agent ->
-      {new_vim, new_tf} = Vim.enter_normal(agent.panel.vim, agent.panel.input)
-      %{agent | panel: %{agent.panel | vim: new_vim, input: new_tf}}
-    end)
+    # Route Escape through the prompt's Mode FSM which handles the
+    # insert → normal transition, cursor clamping, etc.
+    Minga.Input.AgentPanel.dispatch_prompt_via_mode_fsm(state, 27, 0)
   end
 
   # ── Panel management ───────────────────────────────────────────────────────

--- a/lib/minga/editor/commands/agent_sub_states.ex
+++ b/lib/minga/editor/commands/agent_sub_states.ex
@@ -14,12 +14,12 @@ defmodule Minga.Editor.Commands.AgentSubStates do
   alias Minga.Agent.Session
   alias Minga.Agent.View.Preview
   alias Minga.Agent.View.State, as: ViewState
+  alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.Commands.Agent, as: AgentCommands
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.AgentAccess
   alias Minga.Git.Diff
-  alias Minga.Input.TextField
 
   import Bitwise
 
@@ -320,10 +320,10 @@ defmodule Minga.Editor.Commands.AgentSubStates do
         new_line = before <> "@" <> path <> " " <> after_prefix
         new_col = anchor_col + 1 + String.length(path) + 1
         new_lines = List.replace_at(lines, line, new_line)
+        new_content = Enum.join(new_lines, "\n")
 
-        update_panel(state, fn p ->
-          %{p | input: TextField.from_parts(new_lines, {line, new_col}), mention_completion: nil}
-        end)
+        state = sync_mention_to_buffer(state, new_content, line, new_col)
+        update_panel(state, fn p -> %{p | mention_completion: nil} end)
     end
   end
 
@@ -449,6 +449,19 @@ defmodule Minga.Editor.Commands.AgentSubStates do
     AgentAccess.update_agentic(state, fn agentic ->
       %{agentic | preview: fun.(agentic.preview)}
     end)
+  end
+
+  @spec sync_mention_to_buffer(state(), String.t(), non_neg_integer(), non_neg_integer()) ::
+          state()
+  defp sync_mention_to_buffer(state, content, line, col) do
+    panel = AgentAccess.panel(state)
+
+    if is_pid(panel.prompt_buffer) do
+      BufferServer.replace_content(panel.prompt_buffer, content)
+      BufferServer.set_cursor(panel.prompt_buffer, {line, col})
+    end
+
+    state
   end
 
   @spec update_panel(state(), (term() -> term())) :: state()

--- a/lib/minga/editor/render_pipeline.ex
+++ b/lib/minga/editor/render_pipeline.ex
@@ -851,7 +851,7 @@ defmodule Minga.Editor.RenderPipeline do
       if state.picker_ui.picker do
         :beam
       else
-        ChromeHelpers.input_cursor_shape(AgentAccess.panel(state))
+        ChromeHelpers.input_cursor_shape(state.mode)
       end
 
     cursor =

--- a/lib/minga/editor/render_pipeline/chrome_helpers.ex
+++ b/lib/minga/editor/render_pipeline/chrome_helpers.ex
@@ -209,12 +209,9 @@ defmodule Minga.Editor.RenderPipeline.ChromeHelpers do
   # ── Input cursor shape ────────────────────────────────────────────────────
 
   @doc "Returns the cursor shape for the agent panel input area."
-  @spec input_cursor_shape(map()) :: Minga.Port.Protocol.cursor_shape()
-  def input_cursor_shape(%PanelState{input_focused: true} = panel) do
-    if PanelState.input_mode(panel) == :insert, do: :beam, else: :block
-  end
-
-  def input_cursor_shape(_panel), do: :block
+  @spec input_cursor_shape(atom()) :: Minga.Port.Protocol.cursor_shape()
+  def input_cursor_shape(:insert), do: :beam
+  def input_cursor_shape(_mode), do: :block
 
   # ── Private helpers ────────────────────────────────────────────────────────
 

--- a/lib/minga/editor/render_pipeline/compose_helpers.ex
+++ b/lib/minga/editor/render_pipeline/compose_helpers.ex
@@ -113,7 +113,7 @@ defmodule Minga.Editor.RenderPipeline.ComposeHelpers do
       input_row = row + h - @agent_input_height + 1 + cursor_line
       input_col = col + 2 + cursor_col
 
-      {{input_row, input_col}, ChromeHelpers.input_cursor_shape(panel)}
+      {{input_row, input_col}, ChromeHelpers.input_cursor_shape(state.mode)}
     else
       {cursor, shape}
     end

--- a/lib/minga/input/agent_panel.ex
+++ b/lib/minga/input/agent_panel.ex
@@ -3,12 +3,16 @@ defmodule Minga.Input.AgentPanel do
   Input handler for the agent side panel (editor scope, panel visible).
 
   When the agent panel is visible in editor scope, this handler
-  intercepts keys for the panel's input field (insert mode) and
-  navigation mode. In insert mode, it handles prompt editing (Enter,
-  Backspace, Ctrl combos, arrow keys, @-mention triggers). In nav
-  mode, it handles q/Escape (close panel), i (focus input), and
-  delegates everything else to the mode FSM with the agent buffer
-  swapped in for vim navigation of chat content.
+  intercepts keys for the panel's input field and navigation mode.
+
+  In insert mode, it handles prompt editing (Enter, Backspace, Ctrl
+  combos, arrow keys, @-mention triggers). In normal/visual/
+  operator-pending mode, it routes keys through the standard Mode FSM
+  by temporarily swapping the active buffer to the prompt buffer.
+
+  Navigation mode (panel visible but input not focused) delegates to
+  the mode FSM with the agent chat buffer for vim navigation of chat
+  content.
   """
 
   @behaviour Minga.Input.Handler
@@ -22,7 +26,6 @@ defmodule Minga.Input.AgentPanel do
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.AgentAccess
-  alias Minga.Input.Vim
   alias Minga.Keymap.Scope
   alias Minga.Port.Protocol
 
@@ -59,19 +62,12 @@ defmodule Minga.Input.AgentPanel do
   @spec handle_panel_input(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           EditorState.t()
   defp handle_panel_input(state, cp, mods) do
-    panel = AgentAccess.panel(state)
-
-    case Vim.handle_key(panel.vim, panel.input, cp, mods) do
-      {:handled, new_vim, new_tf} ->
-        new_panel = %{panel | vim: new_vim, input: new_tf}
-        AgentAccess.update_agent(state, fn agent -> %{agent | panel: new_panel} end)
-
-      :not_handled ->
-        if PanelState.input_mode(panel) == :insert do
-          handle_panel_insert(state, cp, mods)
-        else
-          dispatch_vim_key(state, cp, mods)
-        end
+    if state.mode == :insert do
+      handle_panel_insert(state, cp, mods)
+    else
+      # Normal, visual, operator-pending: route through Mode FSM
+      # targeting the prompt buffer
+      dispatch_prompt_via_mode_fsm(state, cp, mods)
     end
   end
 
@@ -80,7 +76,8 @@ defmodule Minga.Input.AgentPanel do
   # Ctrl+Q: unfocus first, then forward the quit key
   defp handle_panel_insert(state, ?q, mods) when band(mods, @ctrl) != 0 do
     send(self(), {:minga_input, {:key_press, ?q, mods}})
-    AgentAccess.update_agent(state, &AgentState.focus_input(&1, false))
+    state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, false))
+    %{state | mode: :normal, mode_state: Minga.Mode.initial_state()}
   end
 
   # Ctrl+S: save current buffer
@@ -98,7 +95,7 @@ defmodule Minga.Input.AgentPanel do
 
   # Ctrl+C: submit prompt if input has text, abort if agent is active
   defp handle_panel_insert(state, ?c, mods) when band(mods, @ctrl) != 0 do
-    if PanelState.input_text(AgentAccess.panel(state)) == "" do
+    if PanelState.prompt_text(AgentAccess.panel(state)) == "" do
       if AgentAccess.agent(state).status in [:thinking, :tool_executing] do
         AgentCommands.abort_agent(state)
       else
@@ -124,9 +121,9 @@ defmodule Minga.Input.AgentPanel do
     AgentCommands.clear_chat_display(state)
   end
 
-  # Escape: switch to normal mode (vim-style)
+  # Escape: switch to normal mode via Mode FSM
   defp handle_panel_insert(state, 27, _mods) do
-    AgentCommands.input_to_normal(state)
+    dispatch_prompt_via_mode_fsm(state, 27, 0)
   end
 
   # Backspace
@@ -213,7 +210,8 @@ defmodule Minga.Input.AgentPanel do
   end
 
   defp panel_nav_key(state, ?i, _mods) do
-    {:panel, AgentAccess.update_agent(state, &AgentState.focus_input(&1, true))}
+    state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, true))
+    {:panel, %{state | mode: :insert, mode_state: Minga.Mode.initial_state()}}
   end
 
   defp panel_nav_key(_state, _cp, _mods), do: :delegate
@@ -221,31 +219,36 @@ defmodule Minga.Input.AgentPanel do
   # ── Shared helpers ──────────────────────────────────────────────────────
 
   @doc """
-  Routes a key through Vim.handle_key for non-insert panel modes.
+  Routes a key through the standard Mode FSM targeting the prompt buffer.
 
-  Tries the Vim module first (handles arrow keys, etc.). If not handled,
-  falls through to the agent scope trie for meta keys (Escape, Ctrl+C).
-  Called by both AgentPanel (editor scope side panel) and Input.Scoped
-  (agent scope normal mode).
+  Swaps the active buffer to the prompt buffer, runs the key through
+  the mode FSM (which handles all vim operations: motions, operators,
+  visual mode, text objects, undo/redo), then restores the original
+  active buffer.
+
+  If the Mode FSM transitions to insert mode, we leave the mode as
+  insert so that subsequent keys are handled by `handle_panel_insert`.
   """
-  @spec dispatch_vim_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+  @spec dispatch_prompt_via_mode_fsm(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           EditorState.t()
-  def dispatch_vim_key(state, cp, mods) do
+  def dispatch_prompt_via_mode_fsm(state, cp, mods) do
     panel = AgentAccess.panel(state)
+    prompt_pid = panel.prompt_buffer
 
-    case Vim.handle_key(panel.vim, panel.input, cp, mods) do
-      {:handled, new_vim, new_tf} ->
-        new_panel = %{panel | vim: new_vim, input: new_tf}
-        AgentAccess.update_agent(state, fn agent -> %{agent | panel: new_panel} end)
+    if is_pid(prompt_pid) and Process.alive?(prompt_pid) do
+      real_active = state.buffers.active
+      state = put_in(state.buffers.active, prompt_pid)
+      state = Minga.Editor.do_handle_key(state, cp, mods)
+      put_in(state.buffers.active, real_active)
+    else
+      # No prompt buffer, try scope bindings
+      key = {cp, mods}
 
-      :not_handled ->
-        key = {cp, mods}
-
-        case Scope.resolve_key(:agent, :input_normal, key) do
-          {:command, command} -> Commands.execute(state, command)
-          {:prefix, _node} -> state
-          :not_found -> state
-        end
+      case Scope.resolve_key(:agent, :input_normal, key) do
+        {:command, command} -> Commands.execute(state, command)
+        {:prefix, _node} -> state
+        :not_found -> state
+      end
     end
   end
 

--- a/lib/minga/input/scoped.ex
+++ b/lib/minga/input/scoped.ex
@@ -31,7 +31,7 @@ defmodule Minga.Input.Scoped do
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.AgentAccess
   alias Minga.Input.AgentPanel
-  alias Minga.Input.Vim
+
   alias Minga.Keymap.Scope
   alias Minga.Port.Protocol
   alias Minga.Surface.AgentView
@@ -132,21 +132,15 @@ defmodule Minga.Input.Scoped do
     end
   end
 
-  defp handle_focused_input(state, panel, cp, mods) do
-    # Try Vim first for ALL modes (handles arrow keys in insert, all keys
-    # in normal/visual/operator-pending). Falls through to scope trie for
-    # surface-specific keys (self-insert, Enter, Backspace, Ctrl combos).
-    case Vim.handle_key(panel.vim, panel.input, cp, mods) do
-      {:handled, new_vim, new_tf} ->
-        new_panel = %{panel | vim: new_vim, input: new_tf}
-        {:handled, AgentAccess.update_agent(state, fn agent -> %{agent | panel: new_panel} end)}
-
-      :not_handled ->
-        if PanelState.input_mode(panel) == :insert do
-          resolve_agent_key(state, :insert, cp, mods)
-        else
-          {:handled, AgentPanel.dispatch_vim_key(state, cp, mods)}
-        end
+  defp handle_focused_input(state, _panel, cp, mods) do
+    if state.mode == :insert do
+      # In insert mode, fall through to scope trie for self-insert,
+      # Enter, Backspace, Ctrl combos, etc.
+      resolve_agent_key(state, :insert, cp, mods)
+    else
+      # Normal, visual, operator-pending: route through Mode FSM
+      # targeting the prompt buffer.
+      {:handled, AgentPanel.dispatch_prompt_via_mode_fsm(state, cp, mods)}
     end
   end
 
@@ -257,10 +251,10 @@ defmodule Minga.Input.Scoped do
   # Checks if the cursor is within the lines of an expanded paste block.
   # Used by handle_agent_key for Tab handling on paste placeholder lines.
   @spec cursor_on_expanded_block?(PanelState.t()) :: boolean()
-  defp cursor_on_expanded_block?(%{
-         input: %{cursor: {cursor_line, _}, lines: lines},
-         pasted_blocks: blocks
-       }) do
+  defp cursor_on_expanded_block?(%PanelState{pasted_blocks: blocks} = panel) do
+    {cursor_line, _} = PanelState.input_cursor(panel)
+    lines = PanelState.input_lines(panel)
+
     blocks
     |> Enum.filter(& &1.expanded)
     |> Enum.any?(&expanded_block_spans_cursor?(&1, lines, cursor_line))

--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -173,7 +173,7 @@ defmodule Minga.Keymap.Scope.Agent do
   # ── Input normal mode meta keys ──────────────────────────────────────────
   #
   # Vim editing keys (motions, operators, text objects, counts, visual mode)
-  # are handled by Minga.Input.Vim.handle_key/4 before reaching the trie.
+  # are handled by the standard Mode FSM via dispatch_prompt_via_mode_fsm.
   # This trie only contains meta keys that the Vim module passes through.
 
   @spec input_normal_trie() :: Bindings.node_t()

--- a/lib/minga/surface/agent_view.ex
+++ b/lib/minga/surface/agent_view.ex
@@ -20,6 +20,7 @@ defmodule Minga.Surface.AgentView do
   @behaviour Minga.Surface
 
   alias Minga.Agent.DiffReview
+  alias Minga.Agent.PanelState
   alias Minga.Agent.View.Preview
   alias Minga.Agent.View.State, as: ViewState
   alias Minga.Editor.Layout
@@ -317,8 +318,8 @@ defmodule Minga.Surface.AgentView do
   """
   @impl Minga.Surface
   @spec cursor(AgentViewState.t()) :: {non_neg_integer(), non_neg_integer(), atom()}
-  def cursor(%AgentViewState{agent: %{panel: %{input_focused: true, input: input}}}) do
-    {row, col} = input.cursor
+  def cursor(%AgentViewState{agent: %{panel: %{input_focused: true} = panel}}) do
+    {row, col} = PanelState.input_cursor(panel)
     {row, col, :beam}
   end
 

--- a/test/minga/agent/panel_state_test.exs
+++ b/test/minga/agent/panel_state_test.exs
@@ -2,17 +2,23 @@ defmodule Minga.Agent.PanelStateTest do
   use ExUnit.Case, async: true
 
   alias Minga.Agent.PanelState
-  alias Minga.Input.TextField
+  alias Minga.Buffer.Server, as: BufferServer
 
-  # Creates a PanelState with the given input lines and cursor.
+  # Creates a PanelState with a running prompt buffer containing the given text.
   defp panel_with_input(lines, cursor \\ nil) do
+    text = Enum.join(lines, "\n")
     cursor = cursor || {0, 0}
-    %{PanelState.new() | input: TextField.from_parts(lines, cursor)}
+    panel = PanelState.new()
+    panel = PanelState.ensure_prompt_buffer(panel)
+    BufferServer.replace_content(panel.prompt_buffer, text)
+    BufferServer.set_cursor(panel.prompt_buffer, cursor)
+    panel
   end
 
-  # Moves the input cursor to a new position within the existing text.
+  # Moves the cursor in the prompt buffer.
   defp set_input_cursor(panel, cursor) do
-    %{panel | input: TextField.set_cursor(panel.input, cursor)}
+    BufferServer.set_cursor(panel.prompt_buffer, cursor)
+    panel
   end
 
   describe "new/0" do
@@ -23,15 +29,12 @@ defmodule Minga.Agent.PanelStateTest do
 
     test "starts with empty input" do
       panel = PanelState.new()
-      assert panel.input.lines == [""]
-      assert panel.input.cursor == {0, 0}
       assert PanelState.input_text(panel) == ""
     end
 
-    test "starts pinned to bottom with scroll offset 0" do
+    test "starts not focused" do
       panel = PanelState.new()
-      assert panel.scroll.offset == 0
-      assert panel.scroll.pinned
+      refute panel.input_focused
     end
 
     test "starts with empty prompt history" do
@@ -42,660 +45,463 @@ defmodule Minga.Agent.PanelStateTest do
   end
 
   describe "toggle/1" do
-    test "toggles visibility on" do
-      panel = PanelState.new() |> PanelState.toggle()
-      assert panel.visible
-    end
-
-    test "toggles visibility off" do
-      panel = PanelState.new() |> PanelState.toggle() |> PanelState.toggle()
-      refute panel.visible
-    end
-  end
-
-  describe "input_text/1" do
-    test "joins multiple lines with newlines" do
-      panel = panel_with_input(["hello", "world"])
-      assert PanelState.input_text(panel) == "hello\nworld"
-    end
-
-    test "returns empty string for empty input" do
+    test "toggles visibility" do
       panel = PanelState.new()
-      assert PanelState.input_text(panel) == ""
+      assert PanelState.toggle(panel).visible
+      refute panel |> PanelState.toggle() |> PanelState.toggle() |> Map.get(:visible)
     end
   end
 
   describe "insert_char/2" do
-    test "inserts character at cursor position" do
-      panel = PanelState.new() |> PanelState.insert_char("h") |> PanelState.insert_char("i")
-      assert PanelState.input_text(panel) == "hi"
-      assert panel.input.cursor == {0, 2}
+    test "inserts a character" do
+      panel = panel_with_input([""])
+      panel = PanelState.insert_char(panel, "h")
+      assert PanelState.input_lines(panel) == ["h"]
     end
 
-    test "inserts in the middle of text" do
-      panel = panel_with_input(["hlo"], {0, 1})
-      panel = PanelState.insert_char(panel, "el")
-      assert panel.input.lines == ["hello"]
-      assert panel.input.cursor == {0, 3}
+    test "appends characters at cursor" do
+      panel = panel_with_input([""])
+      panel = PanelState.insert_char(panel, "h")
+      panel = PanelState.insert_char(panel, "i")
+      assert PanelState.input_lines(panel) == ["hi"]
     end
 
-    test "resets history index on edit" do
-      panel = %{PanelState.new() | history_index: 2}
-      panel = PanelState.insert_char(panel, "a")
+    test "resets history index" do
+      panel = panel_with_input([""])
+      panel = %{panel | history_index: 2}
+      panel = PanelState.insert_char(panel, "x")
       assert panel.history_index == -1
     end
   end
 
   describe "insert_newline/1" do
     test "splits line at cursor" do
-      panel = panel_with_input(["hello world"], {0, 5})
+      panel = panel_with_input(["hello"], {0, 2})
       panel = PanelState.insert_newline(panel)
-      assert panel.input.lines == ["hello", " world"]
-      assert panel.input.cursor == {1, 0}
+      assert PanelState.input_lines(panel) == ["he", "llo"]
     end
 
     test "inserts at end of line" do
-      panel = panel_with_input(["hello"], {0, 5})
+      panel = panel_with_input(["hi"], {0, 2})
       panel = PanelState.insert_newline(panel)
-      assert panel.input.lines == ["hello", ""]
-      assert panel.input.cursor == {1, 0}
-    end
-
-    test "inserts at start of line" do
-      panel = panel_with_input(["hello"], {0, 0})
-      panel = PanelState.insert_newline(panel)
-      assert panel.input.lines == ["", "hello"]
-      assert panel.input.cursor == {1, 0}
+      assert PanelState.input_lines(panel) == ["hi", ""]
     end
   end
 
   describe "delete_char/1" do
     test "deletes character before cursor" do
-      panel =
-        PanelState.new()
-        |> PanelState.insert_char("h")
-        |> PanelState.insert_char("i")
-        |> PanelState.delete_char()
-
-      assert PanelState.input_text(panel) == "h"
-      assert panel.input.cursor == {0, 1}
-    end
-
-    test "no-op at start of first line" do
-      panel = PanelState.new() |> PanelState.delete_char()
-      assert PanelState.input_text(panel) == ""
-      assert panel.input.cursor == {0, 0}
-    end
-
-    test "joins with previous line when at start of non-first line" do
-      panel = panel_with_input(["hello", "world"], {1, 0})
+      panel = panel_with_input(["hi"], {0, 2})
       panel = PanelState.delete_char(panel)
-      assert panel.input.lines == ["helloworld"]
-      assert panel.input.cursor == {0, 5}
+      assert PanelState.input_lines(panel) == ["h"]
     end
 
-    test "deletes in middle of text" do
-      panel = panel_with_input(["abc"], {0, 2})
+    test "no-op at start of buffer" do
+      panel = panel_with_input(["hi"], {0, 0})
       panel = PanelState.delete_char(panel)
-      assert panel.input.lines == ["ac"]
-      assert panel.input.cursor == {0, 1}
+      assert PanelState.input_lines(panel) == ["hi"]
+    end
+
+    test "joins lines at start of non-first line" do
+      panel = panel_with_input(["ab", "cd"], {1, 0})
+      panel = PanelState.delete_char(panel)
+      assert PanelState.input_lines(panel) == ["abcd"]
+    end
+  end
+
+  describe "move_cursor_up/1" do
+    test "returns :at_top on first line" do
+      panel = panel_with_input(["hello"], {0, 0})
+      assert PanelState.move_cursor_up(panel) == :at_top
+    end
+
+    test "moves cursor up" do
+      panel = panel_with_input(["ab", "cd"], {1, 0})
+      result = PanelState.move_cursor_up(panel)
+      refute result == :at_top
+    end
+  end
+
+  describe "move_cursor_down/1" do
+    test "returns :at_bottom on last line" do
+      panel = panel_with_input(["hello"], {0, 0})
+      assert PanelState.move_cursor_down(panel) == :at_bottom
+    end
+
+    test "moves cursor down" do
+      panel = panel_with_input(["ab", "cd"], {0, 0})
+      result = PanelState.move_cursor_down(panel)
+      refute result == :at_bottom
     end
   end
 
   describe "clear_input/1" do
-    test "empties the input and resets cursor" do
-      panel =
-        PanelState.new()
-        |> PanelState.insert_char("test")
-        |> PanelState.clear_input()
-
-      assert panel.input.lines == [""]
-      assert panel.input.cursor == {0, 0}
-    end
-
-    test "saves to history before clearing" do
-      panel =
-        PanelState.new()
-        |> PanelState.insert_char("hello")
-        |> PanelState.clear_input()
-
-      assert panel.prompt_history == ["hello"]
-    end
-
-    test "does not save empty input to history" do
-      panel = PanelState.new() |> PanelState.clear_input()
-      assert panel.prompt_history == []
-    end
-  end
-
-  describe "cursor movement" do
-    test "move_cursor_up returns :at_top when on first line" do
-      panel = PanelState.new()
-      assert PanelState.move_cursor_up(panel) == :at_top
-    end
-
-    test "move_cursor_up moves to previous line" do
-      panel = panel_with_input(["ab", "cd"], {1, 1})
-      panel = PanelState.move_cursor_up(panel)
-      assert panel.input.cursor == {0, 1}
-    end
-
-    test "move_cursor_up clamps column to shorter line" do
-      panel = panel_with_input(["ab", "cdef"], {1, 3})
-      panel = PanelState.move_cursor_up(panel)
-      assert panel.input.cursor == {0, 2}
-    end
-
-    test "move_cursor_down returns :at_bottom when on last line" do
-      panel = PanelState.new()
-      assert PanelState.move_cursor_down(panel) == :at_bottom
-    end
-
-    test "move_cursor_down moves to next line" do
-      panel = panel_with_input(["ab", "cd"], {0, 1})
-      panel = PanelState.move_cursor_down(panel)
-      assert panel.input.cursor == {1, 1}
-    end
-
-    test "move_cursor_down clamps column to shorter line" do
-      panel = panel_with_input(["abcd", "ef"], {0, 3})
-      panel = PanelState.move_cursor_down(panel)
-      assert panel.input.cursor == {1, 2}
-    end
-  end
-
-  describe "prompt history" do
-    test "history_prev recalls previous prompt" do
-      panel = %{PanelState.new() | prompt_history: ["hello", "world"]}
-      panel = PanelState.history_prev(panel)
-      assert PanelState.input_text(panel) == "hello"
-      assert panel.history_index == 0
-    end
-
-    test "history_prev moves through history" do
-      panel = %{PanelState.new() | prompt_history: ["hello", "world"]}
-      panel = panel |> PanelState.history_prev() |> PanelState.history_prev()
-      assert PanelState.input_text(panel) == "world"
-      assert panel.history_index == 1
-    end
-
-    test "history_prev stops at oldest entry" do
-      panel = %{PanelState.new() | prompt_history: ["only"]}
-      panel = panel |> PanelState.history_prev() |> PanelState.history_prev()
-      assert PanelState.input_text(panel) == "only"
-      assert panel.history_index == 0
-    end
-
-    test "history_prev is no-op with empty history" do
-      panel = PanelState.new() |> PanelState.history_prev()
+    test "clears to empty" do
+      panel = panel_with_input(["hello", "world"])
+      panel = PanelState.clear_input(panel)
+      assert PanelState.input_lines(panel) == [""]
       assert PanelState.input_text(panel) == ""
     end
 
-    test "history_next moves forward through history" do
-      panel = %{PanelState.new() | prompt_history: ["hello", "world"]}
-      panel = panel |> PanelState.history_prev() |> PanelState.history_prev()
-      panel = PanelState.history_next(panel)
-      assert PanelState.input_text(panel) == "hello"
+    test "saves non-empty text to history" do
+      panel = panel_with_input(["hello"])
+      panel = PanelState.clear_input(panel)
+      assert panel.prompt_history == ["hello"]
+    end
+
+    test "resets history index" do
+      panel = panel_with_input(["hello"])
+      panel = %{panel | history_index: 1}
+      panel = PanelState.clear_input(panel)
+      assert panel.history_index == -1
+    end
+
+    test "clears pasted_blocks" do
+      panel = panel_with_input(["hello"])
+      panel = %{panel | pasted_blocks: [%{text: "paste", expanded: false}]}
+      panel = PanelState.clear_input(panel)
+      assert panel.pasted_blocks == []
+    end
+  end
+
+  describe "input_text/1" do
+    test "returns raw buffer content" do
+      panel = panel_with_input(["hello", "world"])
+      assert PanelState.input_text(panel) == "hello\nworld"
+    end
+
+    test "returns empty string when no buffer" do
+      panel = PanelState.new()
+      assert PanelState.input_text(panel) == ""
+    end
+  end
+
+  describe "prompt_text/1" do
+    test "returns text with placeholders substituted" do
+      panel = panel_with_input(["before", "\0PASTE:0", "after"])
+      panel = %{panel | pasted_blocks: [%{text: "line1\nline2\nline3", expanded: false}]}
+      assert PanelState.prompt_text(panel) == "before\nline1\nline2\nline3\nafter"
+    end
+
+    test "returns raw text when no placeholders" do
+      panel = panel_with_input(["hello"])
+      assert PanelState.prompt_text(panel) == "hello"
+    end
+  end
+
+  describe "input_lines/1" do
+    test "returns lines from buffer" do
+      panel = panel_with_input(["ab", "cd"])
+      assert PanelState.input_lines(panel) == ["ab", "cd"]
+    end
+
+    test "returns empty line when no buffer" do
+      panel = PanelState.new()
+      assert PanelState.input_lines(panel) == [""]
+    end
+  end
+
+  describe "input_cursor/1" do
+    test "returns cursor from buffer" do
+      panel = panel_with_input(["hello"], {0, 3})
+      assert PanelState.input_cursor(panel) == {0, 3}
+    end
+
+    test "returns {0, 0} when no buffer" do
+      panel = PanelState.new()
+      assert PanelState.input_cursor(panel) == {0, 0}
+    end
+  end
+
+  describe "input_line_count/1" do
+    test "returns line count from buffer" do
+      panel = panel_with_input(["a", "b", "c"])
+      assert PanelState.input_line_count(panel) == 3
+    end
+
+    test "returns 1 when no buffer" do
+      panel = PanelState.new()
+      assert PanelState.input_line_count(panel) == 1
+    end
+  end
+
+  describe "input_empty?/1" do
+    test "true when buffer is empty" do
+      panel = panel_with_input([""])
+      assert PanelState.input_empty?(panel)
+    end
+
+    test "false when buffer has content" do
+      panel = panel_with_input(["hello"])
+      refute PanelState.input_empty?(panel)
+    end
+
+    test "true when no buffer" do
+      panel = PanelState.new()
+      assert PanelState.input_empty?(panel)
+    end
+  end
+
+  describe "set_input_focused/2" do
+    test "focusing starts prompt buffer" do
+      panel = PanelState.new()
+      panel = PanelState.set_input_focused(panel, true)
+      assert panel.input_focused
+      assert is_pid(panel.prompt_buffer)
+    end
+
+    test "unfocusing preserves state" do
+      panel = panel_with_input(["hello"])
+      panel = PanelState.set_input_focused(panel, true)
+      panel = PanelState.set_input_focused(panel, false)
+      refute panel.input_focused
+      # Buffer and content preserved
+      assert PanelState.input_lines(panel) == ["hello"]
+    end
+  end
+
+  describe "history_prev/1" do
+    test "no-op with empty history" do
+      panel = panel_with_input(["current"])
+      assert PanelState.history_prev(panel) == panel
+    end
+
+    test "recalls previous entry" do
+      panel = panel_with_input([""])
+      panel = %{panel | prompt_history: ["first", "second"]}
+      panel = PanelState.history_prev(panel)
+      assert PanelState.input_text(panel) == "first"
       assert panel.history_index == 0
     end
 
-    test "history_next returns to empty input when past newest" do
-      panel = %{PanelState.new() | prompt_history: ["hello"]}
-      panel = panel |> PanelState.history_prev() |> PanelState.history_next()
+    test "walks through history" do
+      panel = panel_with_input([""])
+      panel = %{panel | prompt_history: ["first", "second"]}
+      panel = PanelState.history_prev(panel)
+      panel = PanelState.history_prev(panel)
+      assert PanelState.input_text(panel) == "second"
+      assert panel.history_index == 1
+    end
+
+    test "clamps at oldest entry" do
+      panel = panel_with_input([""])
+      panel = %{panel | prompt_history: ["only"]}
+      panel = PanelState.history_prev(panel)
+      panel = PanelState.history_prev(panel)
+      assert PanelState.input_text(panel) == "only"
+      assert panel.history_index == 0
+    end
+  end
+
+  describe "history_next/1" do
+    test "no-op at index -1" do
+      panel = panel_with_input([""])
+      panel = PanelState.history_next(panel)
+      assert PanelState.input_text(panel) == ""
+    end
+
+    test "clears input at index 0" do
+      panel = panel_with_input([""])
+      panel = %{panel | prompt_history: ["entry"], history_index: 0}
+      BufferServer.replace_content(panel.prompt_buffer, "entry")
+      panel = PanelState.history_next(panel)
       assert PanelState.input_text(panel) == ""
       assert panel.history_index == -1
     end
 
-    test "history_next is no-op when not browsing history" do
-      panel = PanelState.new() |> PanelState.history_next()
-      assert PanelState.input_text(panel) == ""
+    test "recalls more recent entry" do
+      panel = panel_with_input([""])
+      panel = %{panel | prompt_history: ["first", "second"], history_index: 1}
+      panel = PanelState.history_next(panel)
+      assert PanelState.input_text(panel) == "first"
+      assert panel.history_index == 0
     end
+  end
 
-    test "history preserves multi-line prompts" do
-      panel = %{PanelState.new() | prompt_history: ["line1\nline2"]}
-      panel = PanelState.history_prev(panel)
-      assert panel.input.lines == ["line1", "line2"]
-      assert panel.input.cursor == {1, 5}
-    end
-
-    test "save_to_history adds text to history" do
+  describe "save_to_history/1" do
+    test "saves non-empty text" do
       panel = panel_with_input(["hello"])
       panel = PanelState.save_to_history(panel)
       assert panel.prompt_history == ["hello"]
     end
 
-    test "save_to_history does not add empty or whitespace-only text" do
-      panel = PanelState.new() |> PanelState.save_to_history()
+    test "skips empty text" do
+      panel = panel_with_input([""])
+      panel = PanelState.save_to_history(panel)
       assert panel.prompt_history == []
+    end
 
-      panel2 = panel_with_input(["  "])
-      panel2 = PanelState.save_to_history(panel2)
-      assert panel2.prompt_history == []
+    test "skips whitespace-only text" do
+      panel = panel_with_input(["   "])
+      panel = PanelState.save_to_history(panel)
+      assert panel.prompt_history == []
     end
   end
 
-  describe "input_line_count/1" do
-    test "returns 1 for empty input" do
-      assert PanelState.input_line_count(PanelState.new()) == 1
+  describe "insert_paste/2" do
+    test "no-op for empty text" do
+      panel = panel_with_input([""])
+      assert PanelState.insert_paste(panel, "") == panel
     end
 
-    test "returns count for multi-line input" do
-      panel = panel_with_input(["a", "b", "c"])
-      assert PanelState.input_line_count(panel) == 3
-    end
-  end
-
-  describe "scrolling (delegates to Minga.Scroll)" do
-    test "scroll_down from pinned materializes bottom then adds" do
-      # With metrics {total: 100, visible: 30}, bottom = 70
-      panel =
-        PanelState.new()
-        |> put_in(
-          [Access.key!(:scroll)],
-          Minga.Scroll.update_metrics(Minga.Scroll.new(), 100, 30)
-        )
-        |> PanelState.scroll_down(10)
-
-      assert panel.scroll.offset == 80
-      refute panel.scroll.pinned
+    test "inserts short paste directly" do
+      panel = panel_with_input([""])
+      panel = PanelState.insert_paste(panel, "hello")
+      assert PanelState.input_text(panel) == "hello"
     end
 
-    test "scroll_up from unpinned decreases offset" do
-      panel =
-        PanelState.new()
-        |> put_in([Access.key!(:scroll)], Minga.Scroll.new(10))
-        |> PanelState.scroll_up(5)
-
-      assert panel.scroll.offset == 5
+    test "inserts two-line paste directly" do
+      panel = panel_with_input([""])
+      panel = PanelState.insert_paste(panel, "line1\nline2")
+      assert PanelState.input_text(panel) == "line1\nline2"
     end
 
-    test "scroll_up clamps to 0" do
-      panel =
-        PanelState.new()
-        |> put_in([Access.key!(:scroll)], Minga.Scroll.new(2))
-        |> PanelState.scroll_up(10)
-
-      assert panel.scroll.offset == 0
+    test "collapses paste with 3+ lines" do
+      panel = panel_with_input([""])
+      panel = PanelState.insert_paste(panel, "a\nb\nc")
+      assert length(panel.pasted_blocks) == 1
+      assert hd(panel.pasted_blocks).text == "a\nb\nc"
+      # prompt_text expands placeholders
+      assert PanelState.prompt_text(panel) == "a\nb\nc"
     end
 
-    test "scroll_to_bottom pins without changing offset" do
-      panel =
-        PanelState.new()
-        |> put_in([Access.key!(:scroll)], Minga.Scroll.new(42))
-        |> PanelState.scroll_to_bottom()
-
-      assert panel.scroll.pinned
-      assert panel.scroll.offset == 42
+    test "strips NUL bytes from paste" do
+      panel = panel_with_input([""])
+      panel = PanelState.insert_paste(panel, "hello\0world")
+      assert PanelState.input_text(panel) == "helloworld"
     end
 
-    test "scroll_to_top sets offset 0 and unpins" do
-      panel =
-        PanelState.new()
-        |> put_in([Access.key!(:scroll)], Minga.Scroll.new(50))
-        |> PanelState.scroll_to_top()
-
-      assert panel.scroll.offset == 0
-      refute panel.scroll.pinned
-    end
-
-    test "maybe_auto_scroll is a no-op" do
-      panel = PanelState.new() |> PanelState.maybe_auto_scroll()
-      assert panel.scroll.offset == 0
-      assert panel.scroll.pinned
-    end
-
-    test "engage_auto_scroll re-pins" do
-      panel =
-        PanelState.new()
-        |> put_in([Access.key!(:scroll)], Minga.Scroll.new(10))
-        |> PanelState.engage_auto_scroll()
-
-      assert panel.scroll.pinned
-    end
-  end
-
-  describe "display clear" do
-    test "clear_display sets display_start_index" do
-      panel = PanelState.new() |> PanelState.clear_display(5)
-      assert panel.display_start_index == 5
-    end
-
-    test "clear_display resets scroll and re-pins" do
-      panel =
-        PanelState.new()
-        |> put_in([Access.key!(:scroll)], Minga.Scroll.new(50))
-        |> PanelState.clear_display(3)
-
-      assert panel.scroll.offset == 0
-      assert panel.scroll.pinned
-    end
-
-    test "starts with display_start_index of 0" do
-      panel = PanelState.new()
-      assert panel.display_start_index == 0
-    end
-  end
-
-  describe "spinner" do
-    test "tick_spinner increments frame" do
-      panel = PanelState.new() |> PanelState.tick_spinner() |> PanelState.tick_spinner()
-      assert panel.spinner_frame == 2
-    end
-  end
-
-  describe "input focus" do
-    test "set_input_focused changes focus state" do
-      panel = PanelState.new() |> PanelState.set_input_focused(true)
-      assert panel.input_focused
-    end
-  end
-
-  # ── Paste handling ─────────────────────────────────────────────────────────
-
-  describe "insert_paste/2 — short pastes (below collapse threshold)" do
-    test "empty paste is a no-op" do
-      panel = PanelState.new()
-      result = PanelState.insert_paste(panel, "")
-      assert result == panel
-    end
-
-    test "single-line paste inserts inline" do
-      panel = PanelState.new()
-      result = PanelState.insert_paste(panel, "hello world")
-      assert result.input.lines == ["hello world"]
-      assert result.input.cursor == {0, 11}
-      assert result.pasted_blocks == []
-    end
-
-    test "two-line paste inserts inline as two lines" do
-      panel = PanelState.new()
-      result = PanelState.insert_paste(panel, "line 1\nline 2")
-      assert result.input.lines == ["line 1", "line 2"]
-      assert result.input.cursor == {1, 6}
-      assert result.pasted_blocks == []
-    end
-
-    test "single-line paste into existing text at cursor" do
-      panel = PanelState.new()
-      panel = PanelState.insert_char(panel, "h")
-      panel = PanelState.insert_char(panel, "i")
-      # cursor at {0, 2}, line is "hi"
-      result = PanelState.insert_paste(panel, " there")
-      assert result.input.lines == ["hi there"]
-      assert result.input.cursor == {0, 8}
-    end
-
-    test "two-line paste into middle of existing text" do
-      panel = panel_with_input(["abcdef"], {0, 3})
-      result = PanelState.insert_paste(panel, "X\nY")
-      assert result.input.lines == ["abcX", "Ydef"]
-      assert result.input.cursor == {1, 1}
-    end
-
-    test "two-line paste at start of existing text" do
-      panel = panel_with_input(["hello"], {0, 0})
-      result = PanelState.insert_paste(panel, "A\nB")
-      assert result.input.lines == ["A", "Bhello"]
-      assert result.input.cursor == {1, 1}
-    end
-
-    test "two-line paste at end of existing text" do
-      panel = panel_with_input(["hello"], {0, 5})
-      result = PanelState.insert_paste(panel, "A\nB")
-      assert result.input.lines == ["helloA", "B"]
-      assert result.input.cursor == {1, 1}
-    end
-  end
-
-  describe "insert_paste/2 — long pastes (at or above collapse threshold)" do
-    test "3-line paste creates a collapsed block" do
-      panel = PanelState.new()
-      text = "line 1\nline 2\nline 3"
-      result = PanelState.insert_paste(panel, text)
-
-      assert length(result.pasted_blocks) == 1
-      assert hd(result.pasted_blocks).text == text
-      assert hd(result.pasted_blocks).expanded == false
-
-      # Input should contain the placeholder
-      assert Enum.any?(result.input.lines, &PanelState.paste_placeholder?/1)
-    end
-
-    test "input_text/1 substitutes placeholder with full paste content" do
-      panel = PanelState.new()
-      text = "line 1\nline 2\nline 3"
-      result = PanelState.insert_paste(panel, text)
-
-      assert PanelState.input_text(result) == text
-    end
-
-    test "5-line paste into empty input" do
-      panel = PanelState.new()
-      text = "a\nb\nc\nd\ne"
-      result = PanelState.insert_paste(panel, text)
-
-      assert length(result.pasted_blocks) == 1
-      assert hd(result.pasted_blocks).text == text
-      assert PanelState.input_text(result) == text
-    end
-
-    test "paste into existing text preserves surrounding content" do
-      panel = panel_with_input(["question: "], {0, 10})
-      text = "line 1\nline 2\nline 3"
-      result = PanelState.insert_paste(panel, text)
-
-      full_text = PanelState.input_text(result)
-      assert String.starts_with?(full_text, "question: ")
-      assert String.contains?(full_text, text)
-    end
-
-    test "paste into middle of existing text splits around placeholder" do
-      panel = panel_with_input(["abcdef"], {0, 3})
-      text = "X\nY\nZ"
-      result = PanelState.insert_paste(panel, text)
-
-      full_text = PanelState.input_text(result)
-      assert full_text == "abc\nX\nY\nZ\ndef"
-    end
-
-    test "paste at start of line with existing content" do
-      panel = panel_with_input(["existing"], {0, 0})
-      text = "a\nb\nc"
-      result = PanelState.insert_paste(panel, text)
-
-      full_text = PanelState.input_text(result)
-      # Placeholder is its own line; "existing" stays after
-      assert String.ends_with?(full_text, "\nexisting")
-    end
-
-    test "paste at end of existing line" do
-      panel = panel_with_input(["existing"], {0, 8})
-      text = "a\nb\nc"
-      result = PanelState.insert_paste(panel, text)
-
-      full_text = PanelState.input_text(result)
-      assert String.starts_with?(full_text, "existing\n")
-    end
-
-    test "multiple pastes accumulate separate blocks" do
-      panel = PanelState.new()
-      text1 = "a\nb\nc"
-      text2 = "d\ne\nf"
-
-      result =
-        panel
-        |> PanelState.insert_paste(text1)
-        |> PanelState.insert_paste(text2)
-
-      assert length(result.pasted_blocks) == 2
-      assert Enum.at(result.pasted_blocks, 0).text == text1
-      assert Enum.at(result.pasted_blocks, 1).text == text2
-
-      full_text = PanelState.input_text(result)
-      assert String.contains?(full_text, text1)
-      assert String.contains?(full_text, text2)
-    end
-
-    test "unicode paste content is preserved" do
-      panel = PanelState.new()
-      text = "こんにちは\n🎉 emoji\n中文テスト"
-      result = PanelState.insert_paste(panel, text)
-
-      assert PanelState.input_text(result) == text
-    end
-
-    test "paste with trailing newline" do
-      panel = PanelState.new()
-      text = "line 1\nline 2\nline 3\n"
-      result = PanelState.insert_paste(panel, text)
-
-      assert PanelState.input_text(result) == text
-    end
-
-    test "paste with only newlines" do
-      panel = PanelState.new()
-      text = "\n\n\n"
-      result = PanelState.insert_paste(panel, text)
-
-      # 4 lines (split on \n gives ["", "", "", ""])
-      assert length(result.pasted_blocks) == 1
-      assert PanelState.input_text(result) == text
-    end
-
-    test "NUL bytes in pasted text are stripped to prevent placeholder injection" do
-      panel = PanelState.new()
-      # Try to inject a fake placeholder
-      text = "\0PASTE:99\nline 2\nline 3"
-      result = PanelState.insert_paste(panel, text)
-
-      # The NUL should be stripped, so it's treated as a regular 3-line paste
-      assert hd(result.pasted_blocks).text == "PASTE:99\nline 2\nline 3"
+    test "multiple collapsed pastes" do
+      panel = panel_with_input([""])
+      panel = PanelState.insert_paste(panel, "a\nb\nc")
+      panel = PanelState.insert_paste(panel, "d\ne\nf")
+      assert length(panel.pasted_blocks) == 2
     end
   end
 
   describe "toggle_paste_expand/1" do
-    test "expands a collapsed paste block" do
-      panel = PanelState.new()
-      text = "line 1\nline 2\nline 3"
-      panel = PanelState.insert_paste(panel, text)
+    test "expands a collapsed block" do
+      panel = panel_with_input([""])
+      panel = PanelState.insert_paste(panel, "line1\nline2\nline3")
+      # Move cursor to the placeholder line
+      lines = PanelState.input_lines(panel)
 
-      # Find the placeholder line
-      placeholder_idx = Enum.find_index(panel.input.lines, &PanelState.paste_placeholder?/1)
-      panel = set_input_cursor(panel, {placeholder_idx, 0})
+      placeholder_idx =
+        Enum.find_index(lines, &PanelState.paste_placeholder?/1)
 
-      expanded = PanelState.toggle_paste_expand(panel)
-
-      # After expanding, pasted_blocks[0].expanded should be true
-      assert Enum.at(expanded.pasted_blocks, 0).expanded == true
-
-      # The placeholder should be replaced with actual text lines
-      refute Enum.any?(expanded.input.lines, &PanelState.paste_placeholder?/1)
-      assert "line 1" in expanded.input.lines
-      assert "line 2" in expanded.input.lines
-      assert "line 3" in expanded.input.lines
-    end
-
-    test "collapses an expanded paste block" do
-      panel = PanelState.new()
-      text = "line 1\nline 2\nline 3"
-      panel = PanelState.insert_paste(panel, text)
-
-      # Expand it first
-      placeholder_idx = Enum.find_index(panel.input.lines, &PanelState.paste_placeholder?/1)
       panel = set_input_cursor(panel, {placeholder_idx, 0})
       panel = PanelState.toggle_paste_expand(panel)
 
-      # Now collapse: put cursor on the first line of the expanded text
+      block = hd(panel.pasted_blocks)
+      assert block.expanded
+      assert PanelState.input_line_count(panel) >= 3
+    end
+
+    test "collapses an expanded block" do
+      panel = panel_with_input([""])
+      panel = PanelState.insert_paste(panel, "line1\nline2\nline3")
+      lines = PanelState.input_lines(panel)
+
+      placeholder_idx =
+        Enum.find_index(lines, &PanelState.paste_placeholder?/1)
+
       panel = set_input_cursor(panel, {placeholder_idx, 0})
-      collapsed = PanelState.toggle_paste_expand(panel)
-
-      # After collapsing, should have placeholder back
-      assert Enum.any?(collapsed.input.lines, &PanelState.paste_placeholder?/1)
-      assert Enum.at(collapsed.pasted_blocks, 0).expanded == false
-    end
-
-    test "no-op when cursor is not on a placeholder line" do
-      panel = PanelState.new()
-      panel = %{panel | input: TextField.from_parts(["regular text"], {0, 0})}
-      result = PanelState.toggle_paste_expand(panel)
-      assert result == panel
-    end
-
-    test "input_text returns same content whether expanded or collapsed" do
-      panel = PanelState.new()
-      text = "alpha\nbeta\ngamma"
-      panel = PanelState.insert_paste(panel, text)
-      collapsed_text = PanelState.input_text(panel)
-
       # Expand
-      placeholder_idx = Enum.find_index(panel.input.lines, &PanelState.paste_placeholder?/1)
+      panel = PanelState.toggle_paste_expand(panel)
+      assert hd(panel.pasted_blocks).expanded
 
-      expanded_panel =
-        set_input_cursor(panel, {placeholder_idx, 0}) |> PanelState.toggle_paste_expand()
+      # Set cursor within expanded text
+      panel = set_input_cursor(panel, {placeholder_idx, 0})
+      # Collapse
+      panel = PanelState.toggle_paste_expand(panel)
+      refute hd(panel.pasted_blocks).expanded
+    end
 
-      expanded_text = PanelState.input_text(expanded_panel)
-
-      assert collapsed_text == expanded_text
+    test "no-op when cursor not on paste" do
+      panel = panel_with_input(["hello"])
+      panel2 = PanelState.toggle_paste_expand(panel)
+      assert PanelState.input_lines(panel2) == PanelState.input_lines(panel)
     end
   end
 
   describe "paste_placeholder?/1" do
-    test "detects placeholder lines" do
+    test "true for placeholder" do
       assert PanelState.paste_placeholder?("\0PASTE:0")
-      assert PanelState.paste_placeholder?("\0PASTE:42")
     end
 
-    test "rejects normal text" do
-      refute PanelState.paste_placeholder?("normal text")
-      refute PanelState.paste_placeholder?("")
-      refute PanelState.paste_placeholder?("PASTE:0")
+    test "false for regular text" do
+      refute PanelState.paste_placeholder?("hello")
     end
   end
 
   describe "paste_block_index/1" do
-    test "extracts index from placeholder" do
+    test "returns index for placeholder" do
       assert PanelState.paste_block_index("\0PASTE:0") == 0
       assert PanelState.paste_block_index("\0PASTE:5") == 5
-      assert PanelState.paste_block_index("\0PASTE:123") == 123
     end
 
     test "returns nil for non-placeholder" do
-      assert PanelState.paste_block_index("regular text") == nil
-      assert PanelState.paste_block_index("") == nil
+      assert PanelState.paste_block_index("hello") == nil
     end
   end
 
-  describe "paste_block_line_count/2" do
-    test "returns line count for a paste block" do
+  describe "scrolling" do
+    test "scroll_up unpins from bottom" do
       panel = PanelState.new()
-      panel = PanelState.insert_paste(panel, "a\nb\nc\nd\ne")
-      assert PanelState.paste_block_line_count(panel, 0) == 5
+      panel = PanelState.scroll_up(panel, 5)
+      refute panel.scroll.pinned
     end
 
-    test "returns 0 for invalid index" do
+    test "scroll_down unpins from bottom" do
       panel = PanelState.new()
-      assert PanelState.paste_block_line_count(panel, 99) == 0
-    end
-  end
-
-  describe "clear_input/1 with pasted blocks" do
-    test "clears pasted_blocks along with input" do
-      panel = PanelState.new()
-      panel = PanelState.insert_paste(panel, "a\nb\nc")
-
-      assert length(panel.pasted_blocks) == 1
-
-      cleared = PanelState.clear_input(panel)
-      assert cleared.pasted_blocks == []
-      assert cleared.input.lines == [""]
-      assert cleared.input.cursor == {0, 0}
+      # First unpin by scrolling up, then scroll down
+      panel = %{panel | scroll: %{panel.scroll | offset: 10, pinned: false}}
+      panel = PanelState.scroll_down(panel, 3)
+      assert panel.scroll.offset == 13
     end
   end
 
-  describe "new/0 with pasted_blocks" do
-    test "starts with empty pasted_blocks" do
+  describe "clear_display/2" do
+    test "sets display_start_index and resets scroll" do
       panel = PanelState.new()
-      assert panel.pasted_blocks == []
+      panel = PanelState.scroll_up(panel, 10)
+      panel = PanelState.clear_display(panel, 5)
+      assert panel.display_start_index == 5
+      assert panel.scroll.offset == 0
+    end
+  end
+
+  describe "ensure_prompt_buffer/1" do
+    test "starts buffer when nil" do
+      panel = PanelState.new()
+      panel = PanelState.ensure_prompt_buffer(panel)
+      assert is_pid(panel.prompt_buffer)
+      assert Process.alive?(panel.prompt_buffer)
+    end
+
+    test "idempotent when alive" do
+      panel = PanelState.new()
+      panel = PanelState.ensure_prompt_buffer(panel)
+      pid = panel.prompt_buffer
+      panel = PanelState.ensure_prompt_buffer(panel)
+      assert panel.prompt_buffer == pid
+    end
+
+    test "restarts when dead" do
+      Process.flag(:trap_exit, true)
+      panel = PanelState.new()
+      panel = PanelState.ensure_prompt_buffer(panel)
+      old_pid = panel.prompt_buffer
+      Process.exit(old_pid, :kill)
+
+      receive do
+        {:EXIT, ^old_pid, :killed} -> :ok
+      after
+        100 -> flunk("expected EXIT")
+      end
+
+      panel = PanelState.ensure_prompt_buffer(panel)
+      assert is_pid(panel.prompt_buffer)
+      assert panel.prompt_buffer != old_pid
     end
   end
 end

--- a/test/minga/agent/prompt_buffer_test.exs
+++ b/test/minga/agent/prompt_buffer_test.exs
@@ -2,35 +2,26 @@ defmodule Minga.Agent.PromptBufferTest do
   @moduledoc """
   Tests for the prompt Buffer.Server integration in PanelState.
 
-  These verify that the prompt buffer stays in sync with the TextField
-  during the migration period. Once TextField is removed, these tests
-  become the primary prompt storage tests.
+  Now that Buffer.Server is the primary store (not a shadow), these
+  verify that all PanelState operations correctly delegate to the buffer.
   """
 
   use ExUnit.Case, async: true
 
   alias Minga.Agent.PanelState
   alias Minga.Buffer.Server, as: BufferServer
-  alias Minga.Input.TextField
 
   # ── Helpers ──────────────────────────────────────────────────────────────────
 
   defp focused_panel(text \\ "") do
     panel = PanelState.new()
+    panel = PanelState.set_input_focused(panel, true)
 
-    panel =
-      if text != "" do
-        lines = String.split(text, "\n")
-        %{panel | input: TextField.from_parts(lines, {0, 0})}
-      else
-        panel
-      end
+    if text != "" do
+      BufferServer.replace_content(panel.prompt_buffer, text)
+    end
 
-    PanelState.set_input_focused(panel, true)
-  end
-
-  defp buffer_content(panel) do
-    BufferServer.content(panel.prompt_buffer)
+    panel
   end
 
   # ── Lifecycle ────────────────────────────────────────────────────────────────
@@ -49,12 +40,7 @@ defmodule Minga.Agent.PromptBufferTest do
 
     test "prompt buffer starts with empty content" do
       panel = focused_panel()
-      assert buffer_content(panel) == ""
-    end
-
-    test "prompt buffer starts with existing text if present" do
-      panel = focused_panel("existing text")
-      assert buffer_content(panel) == "existing text"
+      assert BufferServer.content(panel.prompt_buffer) == ""
     end
 
     test "ensure_prompt_buffer is idempotent" do
@@ -70,7 +56,6 @@ defmodule Minga.Agent.PromptBufferTest do
       old_pid = panel.prompt_buffer
       Process.exit(old_pid, :kill)
 
-      # Wait for the exit signal to arrive
       receive do
         {:EXIT, ^old_pid, :killed} -> :ok
       after
@@ -84,53 +69,53 @@ defmodule Minga.Agent.PromptBufferTest do
     end
   end
 
-  # ── Sync on text operations ────────────────────────────────────────────────
+  # ── Text operations write to buffer ────────────────────────────────────────
 
-  describe "sync on text operations" do
-    test "insert_char syncs to prompt buffer" do
+  describe "text operations" do
+    test "insert_char writes to buffer" do
       panel = focused_panel()
       panel = PanelState.insert_char(panel, "h")
       panel = PanelState.insert_char(panel, "i")
-      assert buffer_content(panel) == "hi"
+      assert BufferServer.content(panel.prompt_buffer) == "hi"
     end
 
-    test "insert_newline syncs to prompt buffer" do
+    test "insert_newline writes to buffer" do
       panel = focused_panel()
       panel = PanelState.insert_char(panel, "a")
       panel = PanelState.insert_newline(panel)
       panel = PanelState.insert_char(panel, "b")
-      assert buffer_content(panel) == "a\nb"
+      assert BufferServer.content(panel.prompt_buffer) == "a\nb"
     end
 
-    test "delete_char syncs to prompt buffer" do
+    test "delete_char writes to buffer" do
       panel = focused_panel("hello")
-      panel = %{panel | input: TextField.set_cursor(panel.input, {0, 5})}
+      BufferServer.set_cursor(panel.prompt_buffer, {0, 5})
       panel = PanelState.delete_char(panel)
-      assert buffer_content(panel) == "hell"
+      assert BufferServer.content(panel.prompt_buffer) == "hell"
     end
 
-    test "clear_input syncs to prompt buffer" do
+    test "clear_input empties buffer" do
       panel = focused_panel()
       panel = PanelState.insert_char(panel, "x")
       panel = PanelState.clear_input(panel)
-      assert buffer_content(panel) == ""
+      assert BufferServer.content(panel.prompt_buffer) == ""
     end
 
-    test "short paste syncs to prompt buffer" do
+    test "short paste writes to buffer" do
       panel = focused_panel()
       panel = PanelState.insert_paste(panel, "pasted")
-      assert buffer_content(panel) == "pasted"
+      assert BufferServer.content(panel.prompt_buffer) == "pasted"
     end
 
-    test "history_prev syncs to prompt buffer" do
+    test "history_prev writes to buffer" do
       panel = focused_panel()
       panel = PanelState.insert_char(panel, "x")
       panel = PanelState.clear_input(panel)
       panel = PanelState.history_prev(panel)
-      assert buffer_content(panel) == "x"
+      assert BufferServer.content(panel.prompt_buffer) == "x"
     end
 
-    test "history_next syncs to prompt buffer" do
+    test "history_next writes to buffer" do
       panel = focused_panel()
       panel = PanelState.insert_char(panel, "a")
       panel = PanelState.clear_input(panel)
@@ -140,30 +125,34 @@ defmodule Minga.Agent.PromptBufferTest do
       panel = PanelState.history_prev(panel)
       panel = PanelState.history_prev(panel)
       panel = PanelState.history_next(panel)
-      assert buffer_content(panel) == "b"
+      assert BufferServer.content(panel.prompt_buffer) == "b"
     end
   end
 
-  # ── prompt_text/1 ──────────────────────────────────────────────────────────
+  # ── Accessor consistency ───────────────────────────────────────────────────
 
-  describe "prompt_text/1" do
-    test "reads from prompt buffer when available" do
+  describe "accessor consistency" do
+    test "input_lines matches buffer content" do
+      panel = focused_panel("hello\nworld")
+      assert PanelState.input_lines(panel) == ["hello", "world"]
+    end
+
+    test "input_cursor matches buffer cursor" do
+      panel = focused_panel("hello")
+      BufferServer.set_cursor(panel.prompt_buffer, {0, 3})
+      assert PanelState.input_cursor(panel) == {0, 3}
+    end
+
+    test "input_line_count matches buffer" do
+      panel = focused_panel("a\nb\nc")
+      assert PanelState.input_line_count(panel) == 3
+    end
+
+    test "input_empty? reflects buffer state" do
       panel = focused_panel()
+      assert PanelState.input_empty?(panel)
       panel = PanelState.insert_char(panel, "x")
-      assert PanelState.prompt_text(panel) == "x"
-    end
-
-    test "falls back to input_text when no buffer" do
-      panel = PanelState.new()
-      panel = %{panel | input: TextField.from_parts(["hello"], {0, 5})}
-      assert PanelState.prompt_text(panel) == "hello"
-    end
-
-    test "substitutes paste placeholders" do
-      panel = focused_panel()
-      panel = PanelState.insert_paste(panel, "line1\nline2\nline3")
-      text = PanelState.prompt_text(panel)
-      assert text == "line1\nline2\nline3"
+      refute PanelState.input_empty?(panel)
     end
   end
 end

--- a/test/minga/agent/prompt_characterization_test.exs
+++ b/test/minga/agent/prompt_characterization_test.exs
@@ -2,364 +2,199 @@ defmodule Minga.Agent.PromptCharacterizationTest do
   @moduledoc """
   Characterization tests for the agent prompt editing flow.
 
-  These pin the current behavior of the prompt so that Phase D
-  (replacing TextField with Buffer.Server) can verify no regressions.
-  Each test documents a specific behavior that must be preserved.
+  These pin the observable behavior of the prompt so regressions are
+  caught mechanically. The prompt is backed by a Buffer.Server and
+  edited via the standard Mode FSM (same pipeline as file buffers).
 
-  The prompt flow involves three layers:
-  1. PanelState — owns TextField, vim state, history, paste blocks
-  2. Input.Vim — vim grammar on TextField (insert/normal/visual modes)
-  3. AgentPanel input handler — routes keys to Vim, handles Enter/Escape
+  The prompt has three concerns:
 
-  Phase D replaces layers 1-2 with Buffer.Server + the real Mode FSM.
-  Layer 3 (AgentPanel) needs minimal changes: Enter still submits,
-  Escape still exits insert mode, domain keys still work.
+  1. **Text storage** — `Buffer.Server` (gap buffer). All text mutations
+     (insert, delete, newline) go through GenServer calls.
+
+  2. **Vim editing** — The standard Mode FSM handles motions, operators,
+     visual mode, text objects, undo/redo. Keys are routed through
+     `dispatch_prompt_via_mode_fsm`, which swaps the active buffer to
+     the prompt buffer and runs the key through the same pipeline file
+     buffers use.
+
+  3. **Domain behavior** — Enter submits, history recall (up/down),
+     paste block collapsing, @-mention completion. These are handled
+     by PanelState and the agent command handlers.
   """
 
   use ExUnit.Case, async: true
 
   alias Minga.Agent.PanelState
-  alias Minga.Input.TextField
-  alias Minga.Input.Vim
+  alias Minga.Buffer.Server, as: BufferServer
 
   # ── Helpers ──────────────────────────────────────────────────────────────────
 
-  defp new_panel(text \\ "") do
+  defp new_panel do
     panel = PanelState.new()
-
-    if text == "" do
-      panel
-    else
-      lines = String.split(text, "\n")
-      %{panel | input: TextField.from_parts(lines, {0, 0})}
-    end
-  end
-
-  defp focused_panel(text \\ "") do
-    panel = new_panel(text)
     PanelState.set_input_focused(panel, true)
   end
 
-  defp type_text(panel, text) do
-    String.graphemes(text)
-    |> Enum.reduce(panel, fn char, acc ->
-      PanelState.insert_char(acc, char)
-    end)
+  defp with_text(text) do
+    panel = new_panel()
+    BufferServer.replace_content(panel.prompt_buffer, text)
+    panel
   end
 
-  defp vim_key(panel, codepoint, mods \\ 0) do
-    case Vim.handle_key(panel.vim, panel.input, codepoint, mods) do
-      {:handled, new_vim, new_tf} ->
-        %{panel | vim: new_vim, input: new_tf}
-
-      :not_handled ->
-        panel
-    end
-  end
-
-  defp enter_normal(panel) do
-    {new_vim, new_tf} = Vim.enter_normal(panel.vim, panel.input)
-    %{panel | vim: new_vim, input: new_tf}
-  end
-
-  # ── Prompt text lifecycle ──────────────────────────────────────────────────
+  # ── Prompt text lifecycle ────────────────────────────────────────────────────
 
   describe "prompt text lifecycle" do
-    test "empty panel has empty text" do
+    test "empty panel has empty prompt text" do
       panel = new_panel()
-      assert PanelState.input_text(panel) == ""
+      assert PanelState.prompt_text(panel) == ""
     end
 
-    test "typing characters builds up text" do
-      panel = focused_panel() |> type_text("hello world")
-      assert PanelState.input_text(panel) == "hello world"
+    test "insert_char accumulates text" do
+      panel = new_panel()
+      panel = PanelState.insert_char(panel, "h")
+      panel = PanelState.insert_char(panel, "i")
+      assert PanelState.prompt_text(panel) == "hi"
     end
 
-    test "newlines create multi-line prompts" do
-      panel = focused_panel() |> type_text("line 1")
+    test "insert_newline splits lines" do
+      panel = new_panel()
+      panel = PanelState.insert_char(panel, "a")
       panel = PanelState.insert_newline(panel)
-      panel = type_text(panel, "line 2")
-      assert PanelState.input_text(panel) == "line 1\nline 2"
+      panel = PanelState.insert_char(panel, "b")
+      assert PanelState.prompt_text(panel) == "a\nb"
     end
 
-    test "clear_input empties and saves to history" do
-      panel = focused_panel() |> type_text("remember me")
+    test "clear_input saves to history and empties" do
+      panel = new_panel()
+      panel = PanelState.insert_char(panel, "x")
       panel = PanelState.clear_input(panel)
-      assert PanelState.input_text(panel) == ""
-      assert panel.prompt_history == ["remember me"]
+      assert PanelState.prompt_text(panel) == ""
+      assert panel.prompt_history == ["x"]
     end
 
-    test "clear_input does not save empty text to history" do
-      panel = focused_panel()
-      panel = PanelState.clear_input(panel)
-      assert panel.prompt_history == []
-    end
-
-    test "delete_char removes character before cursor" do
-      panel = focused_panel() |> type_text("hello")
+    test "delete_char removes last character" do
+      panel = new_panel()
+      panel = PanelState.insert_char(panel, "a")
+      panel = PanelState.insert_char(panel, "b")
       panel = PanelState.delete_char(panel)
-      assert PanelState.input_text(panel) == "hell"
+      assert PanelState.prompt_text(panel) == "a"
+    end
+
+    test "delete_char no-op at buffer start" do
+      panel = new_panel()
+      panel = PanelState.delete_char(panel)
+      assert PanelState.prompt_text(panel) == ""
     end
   end
 
-  # ── Vim mode integration ───────────────────────────────────────────────────
-
-  describe "vim mode integration" do
-    test "focused panel starts in insert mode" do
-      panel = focused_panel()
-      assert PanelState.input_mode(panel) == :insert
-    end
-
-    test "escape switches to normal mode" do
-      panel = focused_panel() |> type_text("hello")
-      panel = enter_normal(panel)
-      assert PanelState.input_mode(panel) == :normal
-    end
-
-    test "cursor moves left in normal mode via h key" do
-      panel = focused_panel() |> type_text("hello")
-      panel = enter_normal(panel)
-      # Cursor should be at end of "hello" after entering normal (moves back 1)
-      {_, col_before} = panel.input.cursor
-      panel = vim_key(panel, ?h)
-      {_, col_after} = panel.input.cursor
-      assert col_after < col_before
-    end
-
-    test "cursor moves right in normal mode via l key" do
-      panel = focused_panel() |> type_text("hello")
-      panel = enter_normal(panel)
-      # Move left first to have room to move right
-      panel = vim_key(panel, ?h)
-      panel = vim_key(panel, ?h)
-      {_, col_before} = panel.input.cursor
-      panel = vim_key(panel, ?l)
-      {_, col_after} = panel.input.cursor
-      assert col_after > col_before
-    end
-
-    test "w moves to next word in normal mode" do
-      panel = new_panel("hello world foo")
-      panel = PanelState.set_input_focused(panel, true)
-      panel = enter_normal(panel)
-      # Cursor at 0,0; w should move to "world"
-      panel = vim_key(panel, ?w)
-      {_, col} = panel.input.cursor
-      assert col == 6
-    end
-
-    test "b moves to previous word in normal mode" do
-      panel = new_panel("hello world foo")
-      panel = %{panel | input: TextField.set_cursor(panel.input, {0, 12})}
-      panel = PanelState.set_input_focused(panel, true)
-      panel = enter_normal(panel)
-      panel = vim_key(panel, ?b)
-      {_, col} = panel.input.cursor
-      assert col == 6
-    end
-
-    test "dd deletes current line in normal mode" do
-      panel = new_panel("line 1\nline 2\nline 3")
-      panel = %{panel | input: TextField.set_cursor(panel.input, {1, 0})}
-      panel = PanelState.set_input_focused(panel, true)
-      panel = enter_normal(panel)
-      panel = vim_key(panel, ?d)
-      panel = vim_key(panel, ?d)
-      text = PanelState.input_text(panel)
-      assert text == "line 1\nline 3"
-    end
-
-    test "x deletes character at cursor in normal mode" do
-      panel = new_panel("hello")
-      panel = PanelState.set_input_focused(panel, true)
-      panel = enter_normal(panel)
-      panel = vim_key(panel, ?x)
-      assert PanelState.input_text(panel) == "ello"
-    end
-
-    test "i enters insert mode from normal" do
-      panel = new_panel("hello")
-      panel = PanelState.set_input_focused(panel, true)
-      panel = enter_normal(panel)
-      assert PanelState.input_mode(panel) == :normal
-      panel = vim_key(panel, ?i)
-      assert PanelState.input_mode(panel) == :insert
-    end
-
-    test "A enters insert mode at end of line" do
-      panel = new_panel("hello")
-      panel = PanelState.set_input_focused(panel, true)
-      panel = enter_normal(panel)
-      panel = vim_key(panel, ?A)
-      assert PanelState.input_mode(panel) == :insert
-      {_, col} = panel.input.cursor
-      assert col == 5
-    end
-  end
-
-  # ── History recall ─────────────────────────────────────────────────────────
+  # ── History recall ───────────────────────────────────────────────────────────
 
   describe "history recall" do
-    test "history_prev recalls the last submitted prompt" do
-      panel = focused_panel() |> type_text("first prompt")
-      panel = PanelState.clear_input(panel)
-      panel = type_text(panel, "second prompt")
-      panel = PanelState.clear_input(panel)
-
-      # Recall: most recent first
-      panel = PanelState.history_prev(panel)
-      assert PanelState.input_text(panel) == "second prompt"
-
-      panel = PanelState.history_prev(panel)
-      assert PanelState.input_text(panel) == "first prompt"
-    end
-
-    test "history_next moves forward after history_prev" do
-      panel = focused_panel() |> type_text("prompt a")
-      panel = PanelState.clear_input(panel)
-      panel = type_text(panel, "prompt b")
-      panel = PanelState.clear_input(panel)
-
-      panel = PanelState.history_prev(panel)
-      panel = PanelState.history_prev(panel)
-      panel = PanelState.history_next(panel)
-      assert PanelState.input_text(panel) == "prompt b"
-    end
-
-    test "history_next past newest returns empty" do
-      panel = focused_panel() |> type_text("only one")
-      panel = PanelState.clear_input(panel)
-
-      panel = PanelState.history_prev(panel)
-      assert PanelState.input_text(panel) == "only one"
-
-      panel = PanelState.history_next(panel)
-      assert PanelState.input_text(panel) == ""
-    end
-
-    test "editing after history recall resets history index" do
-      panel = focused_panel() |> type_text("saved")
-      panel = PanelState.clear_input(panel)
-
-      panel = PanelState.history_prev(panel)
-      assert panel.history_index == 0
-
+    test "history_prev recalls saved entry" do
+      panel = new_panel()
       panel = PanelState.insert_char(panel, "x")
+      panel = PanelState.clear_input(panel)
+      panel = PanelState.history_prev(panel)
+      assert PanelState.prompt_text(panel) == "x"
+    end
+
+    test "history_next returns to empty" do
+      panel = new_panel()
+      panel = PanelState.insert_char(panel, "x")
+      panel = PanelState.clear_input(panel)
+      panel = PanelState.history_prev(panel)
+      panel = PanelState.history_next(panel)
+      assert PanelState.prompt_text(panel) == ""
+    end
+
+    test "history round-trip through multiple entries" do
+      panel = new_panel()
+      panel = PanelState.insert_char(panel, "a")
+      panel = PanelState.clear_input(panel)
+      panel = PanelState.insert_char(panel, "b")
+      panel = PanelState.clear_input(panel)
+
+      panel = PanelState.history_prev(panel)
+      assert PanelState.prompt_text(panel) == "b"
+      panel = PanelState.history_prev(panel)
+      assert PanelState.prompt_text(panel) == "a"
+      panel = PanelState.history_next(panel)
+      assert PanelState.prompt_text(panel) == "b"
+    end
+
+    test "editing resets history index" do
+      panel = new_panel()
+      panel = PanelState.insert_char(panel, "x")
+      panel = PanelState.clear_input(panel)
+      panel = PanelState.history_prev(panel)
+      panel = PanelState.insert_char(panel, "y")
       assert panel.history_index == -1
     end
   end
 
-  # ── Paste block handling ───────────────────────────────────────────────────
+  # ── Paste block handling ─────────────────────────────────────────────────────
 
   describe "paste block handling" do
-    test "short paste inserts inline" do
-      panel = focused_panel()
-      panel = PanelState.insert_paste(panel, "ab")
-      assert PanelState.input_text(panel) == "ab"
+    test "short paste inserts directly" do
+      panel = new_panel()
+      panel = PanelState.insert_paste(panel, "short")
+      assert PanelState.prompt_text(panel) == "short"
       assert panel.pasted_blocks == []
     end
 
     test "long paste creates collapsed block" do
-      panel = focused_panel()
-      long_text = "line1\nline2\nline3"
-      panel = PanelState.insert_paste(panel, long_text)
+      panel = new_panel()
+      panel = PanelState.insert_paste(panel, "line1\nline2\nline3")
       assert length(panel.pasted_blocks) == 1
-      # input_text should substitute the placeholder with full content
-      assert PanelState.input_text(panel) == long_text
-    end
-
-    test "toggle expands and collapses paste block" do
-      panel = focused_panel()
-      long_text = "aaa\nbbb\nccc"
-      panel = PanelState.insert_paste(panel, long_text)
-
-      # Should be collapsed (1 placeholder line)
-      assert PanelState.input_line_count(panel) == 1
-
-      # Expand: should show the actual lines
-      panel = PanelState.toggle_paste_expand(panel)
-      assert PanelState.input_line_count(panel) == 3
-
-      # Collapse back
-      panel = %{panel | input: TextField.set_cursor(panel.input, {0, 0})}
-      panel = PanelState.toggle_paste_expand(panel)
-      assert PanelState.input_line_count(panel) == 1
-    end
-
-    test "input_text returns same content expanded or collapsed" do
-      panel = focused_panel()
-      long_text = "line1\nline2\nline3"
-      panel = PanelState.insert_paste(panel, long_text)
-
-      text_collapsed = PanelState.input_text(panel)
-      panel = PanelState.toggle_paste_expand(panel)
-      text_expanded = PanelState.input_text(panel)
-
-      assert text_collapsed == text_expanded
+      assert hd(panel.pasted_blocks).text == "line1\nline2\nline3"
+      # prompt_text substitutes placeholder
+      assert PanelState.prompt_text(panel) == "line1\nline2\nline3"
     end
 
     test "clear_input removes paste blocks" do
-      panel = focused_panel()
+      panel = new_panel()
       panel = PanelState.insert_paste(panel, "a\nb\nc")
-      assert length(panel.pasted_blocks) == 1
-
       panel = PanelState.clear_input(panel)
       assert panel.pasted_blocks == []
     end
   end
 
-  # ── Focus management ───────────────────────────────────────────────────────
+  # ── Focus management ─────────────────────────────────────────────────────────
 
   describe "focus management" do
-    test "set_input_focused true enters insert mode" do
-      panel = new_panel("hello")
+    test "focusing starts prompt buffer" do
+      panel = PanelState.new()
       panel = PanelState.set_input_focused(panel, true)
-      assert panel.input_focused == true
-      assert PanelState.input_mode(panel) == :insert
+      assert panel.input_focused
+      assert is_pid(panel.prompt_buffer)
     end
 
-    test "set_input_focused false preserves insert mode" do
-      # When unfocusing, vim stays in insert so re-focusing is seamless
-      panel = focused_panel() |> type_text("hello")
+    test "unfocusing preserves buffer content" do
+      panel = new_panel()
+      panel = PanelState.insert_char(panel, "x")
       panel = PanelState.set_input_focused(panel, false)
-      assert panel.input_focused == false
-      assert PanelState.input_mode(panel) == :insert
+      refute panel.input_focused
+      assert PanelState.prompt_text(panel) == "x"
     end
   end
 
-  # ── Multi-line editing ─────────────────────────────────────────────────────
+  # ── Multi-line editing ───────────────────────────────────────────────────────
 
   describe "multi-line editing" do
-    test "cursor navigation across lines" do
-      panel = focused_panel()
-      panel = type_text(panel, "first line")
+    test "cursor moves between lines" do
+      panel = new_panel()
+      panel = PanelState.insert_char(panel, "a")
       panel = PanelState.insert_newline(panel)
-      panel = type_text(panel, "second line")
+      panel = PanelState.insert_char(panel, "b")
 
-      assert PanelState.input_line_count(panel) == 2
-      {line, _col} = panel.input.cursor
-      assert line == 1
-
-      # Move cursor up
       result = PanelState.move_cursor_up(panel)
-      {line, _col} = result.input.cursor
-      assert line == 0
-
-      # Move cursor up from first line returns :at_top
-      assert PanelState.move_cursor_up(result) == :at_top
+      refute result == :at_top
     end
 
-    test "backspace at start of line joins with previous" do
-      panel = focused_panel()
-      panel = type_text(panel, "hello")
-      panel = PanelState.insert_newline(panel)
-      panel = type_text(panel, "world")
-
-      # Move to start of line 2
-      panel = %{panel | input: TextField.set_cursor(panel.input, {1, 0})}
+    test "backspace joins lines" do
+      panel = with_text("ab\ncd")
+      BufferServer.set_cursor(panel.prompt_buffer, {1, 0})
       panel = PanelState.delete_char(panel)
-      assert PanelState.input_text(panel) == "helloworld"
-      assert PanelState.input_line_count(panel) == 1
+      assert PanelState.input_lines(panel) == ["abcd"]
     end
   end
 end

--- a/test/minga/agent/view/mouse_test.exs
+++ b/test/minga/agent/view/mouse_test.exs
@@ -17,6 +17,7 @@ defmodule Minga.Agent.View.MouseTest do
     chat_width_pct = Keyword.get(opts, :chat_width_pct, 50)
     input_focused = Keyword.get(opts, :input_focused, false)
     focus = Keyword.get(opts, :focus, :chat)
+    {:ok, prompt_buf} = Minga.Buffer.Server.start_link(content: "")
 
     %EditorState{
       port_manager: nil,
@@ -33,7 +34,8 @@ defmodule Minga.Agent.View.MouseTest do
         agent: %AgentState{
           panel: %PanelState{
             visible: false,
-            input_focused: input_focused
+            input_focused: input_focused,
+            prompt_buffer: prompt_buf
           }
         },
         context: nil

--- a/test/minga/agent/view/renderer_test.exs
+++ b/test/minga/agent/view/renderer_test.exs
@@ -13,7 +13,7 @@ defmodule Minga.Agent.View.RendererTest do
   alias Minga.Editor.State.Highlighting
   alias Minga.Editor.Viewport
   alias Minga.Input
-  alias Minga.Input.TextField
+
   alias Minga.Mode
   alias Minga.Surface.AgentView.State, as: AgentViewState
   alias Minga.Theme
@@ -32,6 +32,8 @@ defmodule Minga.Agent.View.RendererTest do
       panel: %{
         input_focused: false,
         input_lines: [""],
+        mode: :normal,
+        mode_state: Minga.Mode.initial_state(),
         input_cursor: {0, 0},
         scroll: Minga.Scroll.new(),
         spinner_frame: 0,
@@ -66,10 +68,13 @@ defmodule Minga.Agent.View.RendererTest do
     input_cursor =
       Keyword.get(opts, :input_cursor, {0, String.length(Keyword.get(opts, :input_text, ""))})
 
+    {:ok, prompt_buf} = BufferServer.start_link(content: Enum.join(input_lines, "\n"))
+    BufferServer.set_cursor(prompt_buf, input_cursor)
+
     panel = %PanelState{
       visible: true,
       input_focused: Keyword.get(opts, :input_focused, false),
-      input: TextField.from_parts(input_lines, input_cursor),
+      prompt_buffer: prompt_buf,
       scroll: Minga.Scroll.new(),
       spinner_frame: 0,
       provider_name: "anthropic",
@@ -343,6 +348,8 @@ defmodule Minga.Agent.View.RendererTest do
         panel: %{
           input_focused: false,
           input_lines: [""],
+          mode: :normal,
+          mode_state: Minga.Mode.initial_state(),
           input_cursor: {0, 0},
           scroll: Minga.Scroll.new(),
           spinner_frame: 0,
@@ -383,6 +390,8 @@ defmodule Minga.Agent.View.RendererTest do
         panel: %{
           input_focused: true,
           input_lines: ["hello"],
+          mode: :normal,
+          mode_state: Minga.Mode.initial_state(),
           input_cursor: {0, 5},
           scroll: Minga.Scroll.new(),
           spinner_frame: 3,
@@ -437,6 +446,8 @@ defmodule Minga.Agent.View.RendererTest do
         panel: %{
           input_focused: false,
           input_lines: [""],
+          mode: :normal,
+          mode_state: Minga.Mode.initial_state(),
           input_cursor: {0, 0},
           scroll: Minga.Scroll.new(),
           spinner_frame: 0,
@@ -524,6 +535,8 @@ defmodule Minga.Agent.View.RendererTest do
           panel: %{
             input_focused: true,
             input_lines: [""],
+            mode: :normal,
+            mode_state: Minga.Mode.initial_state(),
             input_cursor: {0, 0},
             scroll: Minga.Scroll.new(),
             spinner_frame: 0,

--- a/test/minga/editor/commands/agent_agentic_view_test.exs
+++ b/test/minga/editor/commands/agent_agentic_view_test.exs
@@ -21,6 +21,7 @@ defmodule Minga.Editor.Commands.AgentAgenticViewTest do
 
   defp base_state(opts \\ []) do
     {:ok, buf} = BufferServer.start_link(content: "hello\nworld")
+    {:ok, prompt_buf} = BufferServer.start_link(content: "")
 
     panel = %PanelState{
       visible: false,
@@ -29,7 +30,8 @@ defmodule Minga.Editor.Commands.AgentAgenticViewTest do
       spinner_frame: 0,
       provider_name: "anthropic",
       model_name: "claude-sonnet-4",
-      thinking_level: "medium"
+      thinking_level: "medium",
+      prompt_buffer: prompt_buf
     }
 
     agent = %AgentState{

--- a/test/minga/editor/commands/agent_commands_test.exs
+++ b/test/minga/editor/commands/agent_commands_test.exs
@@ -37,9 +37,12 @@ defmodule Minga.Editor.Commands.AgentCommandsTest do
   defp base_state(opts \\ []) do
     {:ok, buf} = BufferServer.start_link(content: Keyword.get(opts, :content, "hello\nworld"))
 
+    {:ok, prompt_buf} = BufferServer.start_link(content: "")
+
     panel = %PanelState{
       visible: Keyword.get(opts, :panel_visible, false),
       input_focused: Keyword.get(opts, :input_focused, false),
+      prompt_buffer: prompt_buf,
       scroll: Scroll.new(),
       spinner_frame: 0,
       provider_name: "anthropic",
@@ -157,7 +160,9 @@ defmodule Minga.Editor.Commands.AgentCommandsTest do
 
       state =
         AgentAccess.update_agent(state, fn agent ->
-          put_in(agent.panel.input.lines, ["hello agent"])
+          panel = PanelState.ensure_prompt_buffer(agent.panel)
+          BufferServer.replace_content(panel.prompt_buffer, "hello agent")
+          %{agent | panel: panel}
         end)
 
       new_state = AgentCommands.submit_prompt(state)

--- a/test/minga/editor/state/agent_test.exs
+++ b/test/minga/editor/state/agent_test.exs
@@ -2,9 +2,13 @@ defmodule Minga.Editor.State.AgentTest do
   use ExUnit.Case, async: true
 
   alias Minga.Agent.PanelState
+  alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.State.Agent, as: AgentState
 
-  defp new_agent, do: %AgentState{}
+  defp new_agent do
+    {:ok, prompt_buf} = BufferServer.start_link(content: "")
+    %AgentState{panel: %{PanelState.new() | prompt_buffer: prompt_buf}}
+  end
 
   describe "status" do
     test "set_status updates the status field" do

--- a/test/minga/input/agent_panel_nav_test.exs
+++ b/test/minga/input/agent_panel_nav_test.exs
@@ -37,7 +37,8 @@ defmodule Minga.Input.AgentPanelNavTest do
       {:assistant, "World\nLine 2\nLine 3\nLine 4\nLine 5"}
     ])
 
-    panel = %{PanelState.new() | visible: true, input_focused: false}
+    {:ok, prompt_buf} = BufferServer.start_link(content: "")
+    panel = %{PanelState.new() | visible: true, input_focused: false, prompt_buffer: prompt_buf}
 
     agent = %AgentState{
       panel: panel,
@@ -144,7 +145,7 @@ defmodule Minga.Input.AgentPanelNavTest do
 
       {:handled, new_state} = walk_surface_handlers(state, 27, 0)
       assert AgentAccess.input_focused?(new_state) == true
-      assert PanelState.input_mode(AgentAccess.panel(new_state)) == :normal
+      assert new_state.mode == :normal
     end
 
     test "input mode intercepts printable chars" do
@@ -153,6 +154,7 @@ defmodule Minga.Input.AgentPanelNavTest do
       state =
         AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, true) end)
 
+      state = %{state | mode: :insert}
       {:handled, new_state} = walk_surface_handlers(state, ?a, 0)
       assert PanelState.input_text(AgentAccess.panel(new_state)) =~ "a"
     end
@@ -193,9 +195,10 @@ defmodule Minga.Input.AgentPanelNavTest do
       state =
         AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, true) end)
 
+      state = %{state | mode: :insert}
       {:handled, new_state} = walk_surface_handlers(state, 13, 0x01)
       # Should have a newline in the input
-      assert length(AgentAccess.panel(new_state).input.lines) > 1
+      assert length(PanelState.input_lines(AgentAccess.panel(new_state))) > 1
     end
 
     test "Backspace on empty input is safe" do

--- a/test/minga/input/scoped_test.exs
+++ b/test/minga/input/scoped_test.exs
@@ -26,6 +26,7 @@ defmodule Minga.Input.ScopedTest do
 
   defp base_state(opts) do
     {:ok, buf} = BufferServer.start_link(content: "hello world")
+    {:ok, prompt_buf} = BufferServer.start_link(content: "")
 
     panel = %PanelState{
       visible: Keyword.get(opts, :panel_visible, false),
@@ -34,7 +35,8 @@ defmodule Minga.Input.ScopedTest do
       spinner_frame: 0,
       provider_name: "anthropic",
       model_name: "claude-sonnet-4",
-      thinking_level: "medium"
+      thinking_level: "medium",
+      prompt_buffer: prompt_buf
     }
 
     agent = %AgentState{
@@ -67,7 +69,7 @@ defmodule Minga.Input.ScopedTest do
     %EditorState{
       port_manager: self(),
       viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
-      mode: :normal,
+      mode: if(Keyword.get(opts, :input_focused, false), do: :insert, else: :normal),
       mode_state: Mode.initial_state(),
       buffers: %Buffers{active: buf, list: [buf]},
       focus_stack: [],
@@ -170,7 +172,7 @@ defmodule Minga.Input.ScopedTest do
     test "ESC switches to input normal mode (editor scope side panel)", %{state: state} do
       {:handled, new_state} = walk_surface_handlers(state, 27, 0)
       assert AgentAccess.input_focused?(new_state)
-      assert PanelState.input_mode(AgentAccess.panel(new_state)) == :normal
+      assert new_state.mode == :normal
     end
 
     test "Backspace on empty input is safe", %{state: state} do
@@ -192,12 +194,12 @@ defmodule Minga.Input.ScopedTest do
 
     test "Shift+Enter inserts newline", %{state: state} do
       {:handled, new_state} = walk_surface_handlers(state, 13, 0x01)
-      assert length(AgentAccess.panel(new_state).input.lines) > 1
+      assert length(PanelState.input_lines(AgentAccess.panel(new_state))) > 1
     end
 
     test "Alt+Enter inserts newline", %{state: state} do
       {:handled, new_state} = walk_surface_handlers(state, 13, 0x04)
-      assert length(AgentAccess.panel(new_state).input.lines) > 1
+      assert length(PanelState.input_lines(AgentAccess.panel(new_state))) > 1
     end
   end
 
@@ -334,7 +336,7 @@ defmodule Minga.Input.ScopedTest do
     test "ESC switches to input normal mode", %{state: state} do
       {:handled, new_state} = Scoped.handle_key(state, 27, 0)
       assert AgentAccess.input_focused?(new_state)
-      assert PanelState.input_mode(AgentAccess.panel(new_state)) == :normal
+      assert new_state.mode == :normal
     end
 
     test "printable char self-inserts", %{state: state} do
@@ -552,10 +554,11 @@ defmodule Minga.Input.ScopedTest do
     end
 
     test "only triggers when input is not focused", %{state: state} do
-      # If input is focused, approval keys should not be intercepted
+      # If input is focused in insert mode, approval keys should not be intercepted
       state =
         AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, true) end)
 
+      state = %{state | mode: :insert}
       {:handled, new_state} = walk_surface_handlers(state, ?y, 0)
       # Should have typed 'y' into input, not approved
       assert PanelState.input_text(AgentAccess.panel(new_state)) =~ "y"

--- a/test/minga/input/sub_state_handlers_test.exs
+++ b/test/minga/input/sub_state_handlers_test.exs
@@ -32,6 +32,7 @@ defmodule Minga.Input.SubStateHandlersTest do
 
   defp base_state(opts) do
     {:ok, buf} = BufferServer.start_link(content: "hello world")
+    {:ok, prompt_buf} = BufferServer.start_link(content: "")
 
     panel = %PanelState{
       visible: Keyword.get(opts, :panel_visible, false),
@@ -40,7 +41,8 @@ defmodule Minga.Input.SubStateHandlersTest do
       spinner_frame: 0,
       provider_name: "anthropic",
       model_name: "claude-sonnet-4",
-      thinking_level: "medium"
+      thinking_level: "medium",
+      prompt_buffer: prompt_buf
     }
 
     agent = %AgentState{

--- a/test/minga/surface/surface_contract_test.exs
+++ b/test/minga/surface/surface_contract_test.exs
@@ -417,10 +417,12 @@ defmodule Minga.Surface.ContractTest do
     end
 
     test "cursor is beam when input is focused" do
+      {:ok, prompt_buf} = Minga.Buffer.Server.start_link(content: "")
+
       av = %{
         build_av_state()
         | agent: %AgentState{
-            panel: %{PanelState.new() | input_focused: true}
+            panel: %{PanelState.new() | input_focused: true, prompt_buffer: prompt_buf}
           }
       }
 


### PR DESCRIPTION
# TL;DR

The agent prompt is now a real `Buffer.Server` edited by the standard Mode FSM. All vim operations (motions, operators, visual mode, text objects, undo/redo, dot repeat, search) work in the prompt for free, without a parallel reimplementation. Net -245 lines.

Closes #324 (steps 1-6)

## What changed

**PanelState** no longer has `input: TextField.t()` or `vim: Vim.t()`. Instead it has `prompt_buffer: pid()`, a `Buffer.Server` that is lazily started on first focus. All text operations delegate to the buffer via GenServer calls.

**Input routing**: when the prompt is focused, `AgentPanel.dispatch_prompt_via_mode_fsm` swaps the active buffer to the prompt buffer and runs the key through the same Mode FSM that file buffers use. Insert mode special keys (Enter submits, Ctrl-C submits/aborts, arrows, Shift+Enter for newlines) are still handled by `AgentPanel.handle_panel_insert`. The mode state lives on `EditorState.mode`, set to `:insert` on focus, `:normal` on unfocus.

**Paste blocks** use the "sidecar" strategy: placeholder tokens (`\0PASTE:N`) are stored as text in the buffer, full paste content stays in `pasted_blocks`. `prompt_text/1` substitutes placeholders on submission.

**Rendering** carries `mode`/`mode_state` in the panel data instead of a `Vim.t()`. Visual selection reads from `mode_state.visual_start`. The cursor shape reads from the editor mode directly.

**Buffer.Server** gains two new operations: `set_cursor/2` (absolute positioning, clamped to bounds) and `move_cursor/2` (directional).

## What still exists but is dead code

`Input.Vim` (1,190 lines) is no longer called from any production code path. It will be deleted in a follow-up commit once we confirm no edge cases. The 87 `Input.Vim` tests still pass and serve as a safety net.

## Verification

```bash
mix test --exclude external --warnings-as-errors  # 3,990 tests, 0 failures
mix lint                                           # clean (format + credo + dialyzer)
```

## What the prompt gets for free now

Everything the Mode FSM supports, which Input.Vim only partially reimplemented:
- Full undo/redo (u, Ctrl-R) with coalescing
- Dot repeat (.)
- All text objects (iw, aw, i", a", ip, etc.)
- Search within prompt (/, ?, n, N)
- Replace mode (R)
- Registers and named yanks
- Macros (q recording)
- Any future vim features added to the Mode FSM