### PR TITLE
feat(agent): dedicated grep/search tool

### DIFF
--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -575,11 +575,13 @@ defmodule Minga.Agent.Providers.Native do
     - write_file: Create or overwrite files (creates parent directories automatically)
     - edit_file: Make surgical edits (find exact text and replace). Read the file first to get exact text.
     - list_directory: List files and directories at a path
+    - grep: Search file contents for a pattern. Returns file:line:content. Prefer this over shell + grep.
     - shell: Run shell commands in the project root
 
     ## Guidelines
 
     - Read files before editing them. The old_text in edit_file must match exactly.
+    - Use grep to search for code patterns, function definitions, imports, etc.
     - Use shell for running tests, linters, git commands, etc.
     - Be concise and direct. Show file paths clearly when working with files.
     - When you make changes, verify them by reading the result or running tests.

--- a/lib/minga/agent/tools.ex
+++ b/lib/minga/agent/tools.ex
@@ -19,6 +19,7 @@ defmodule Minga.Agent.Tools do
   """
 
   alias Minga.Agent.Tools.EditFile
+  alias Minga.Agent.Tools.Grep
   alias Minga.Agent.Tools.ListDirectory
   alias Minga.Agent.Tools.ReadFile
   alias Minga.Agent.Tools.Shell
@@ -69,6 +70,7 @@ defmodule Minga.Agent.Tools do
       write_file(root),
       edit_file(root),
       list_directory(root),
+      grep(root),
       shell(root)
     ]
   end
@@ -186,6 +188,50 @@ defmodule Minga.Agent.Tools do
       callback: fn args ->
         path = resolve_and_validate_path!(root, args["path"])
         ListDirectory.execute(path)
+      end
+    )
+  end
+
+  @spec grep(String.t()) :: Tool.t()
+  defp grep(root) do
+    Tool.new!(
+      name: "grep",
+      description: """
+      Search file contents for a pattern. Returns matching lines with file paths
+      and line numbers. Use this instead of shell + grep for structured, reliable
+      search results. The tool is read-only and does not require approval.
+      Prefer this over shell for searching code.
+      """,
+      parameter_schema: %{
+        "type" => "object",
+        "properties" => %{
+          "pattern" => %{
+            "type" => "string",
+            "description" => "The search pattern (regex supported)"
+          },
+          "path" => %{
+            "type" => "string",
+            "description" =>
+              "Directory to search in, relative to the project root. Defaults to the project root."
+          },
+          "glob" => %{
+            "type" => "string",
+            "description" => "File pattern filter, e.g. \"*.ex\" to search only Elixir files"
+          },
+          "case_sensitive" => %{
+            "type" => "boolean",
+            "description" => "Whether the search is case-sensitive (default: true)"
+          },
+          "context_lines" => %{
+            "type" => "integer",
+            "description" => "Number of context lines around each match (default: 0)"
+          }
+        },
+        "required" => ["pattern"]
+      },
+      callback: fn args ->
+        search_path = resolve_and_validate_path!(root, args["path"] || ".")
+        Grep.execute(args["pattern"], search_path, args)
       end
     )
   end

--- a/lib/minga/agent/tools/grep.ex
+++ b/lib/minga/agent/tools/grep.ex
@@ -1,0 +1,100 @@
+defmodule Minga.Agent.Tools.Grep do
+  @moduledoc """
+  Structured file content search tool for the native agent provider.
+
+  Prefers `rg` (ripgrep) if available on the system, falls back to
+  `grep -rn`. Output is structured as `path:line:content` and truncated
+  at a configurable match limit to avoid flooding the context window.
+  """
+
+  @max_matches 100
+
+  @doc """
+  Searches for `pattern` in files under `path`.
+
+  Options:
+  - `glob` — file pattern filter (e.g. `"*.ex"`)
+  - `case_sensitive` — whether the search is case-sensitive (default: true)
+  - `context_lines` — number of context lines around each match (default: 0)
+
+  Returns structured output with file path, line number, and matching line.
+  """
+  @spec execute(String.t(), String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
+  def execute(pattern, path, opts \\ %{}) when is_binary(pattern) and is_binary(path) do
+    glob = Map.get(opts, "glob")
+    case_sensitive = Map.get(opts, "case_sensitive", true)
+    context_lines = Map.get(opts, "context_lines", 0)
+
+    {cmd, args} = build_command(pattern, path, glob, case_sensitive, context_lines)
+
+    case System.cmd(cmd, args, stderr_to_stdout: true, cd: path) do
+      {output, 0} ->
+        {:ok, truncate_output(output)}
+
+      {output, 1} ->
+        # Exit code 1 means no matches (for both grep and rg)
+        if String.trim(output) == "" do
+          {:ok, "No matches found."}
+        else
+          {:ok, truncate_output(output)}
+        end
+
+      {output, _code} ->
+        {:error, "Search failed: #{String.trim(output)}"}
+    end
+  rescue
+    e in ErlangError ->
+      {:error, "Search command not found: #{Exception.message(e)}"}
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec build_command(String.t(), String.t(), String.t() | nil, boolean(), non_neg_integer()) ::
+          {String.t(), [String.t()]}
+  defp build_command(pattern, _path, glob, case_sensitive, context_lines) do
+    case System.find_executable("rg") do
+      nil -> build_grep_command(pattern, glob, case_sensitive, context_lines)
+      rg -> build_rg_command(rg, pattern, glob, case_sensitive, context_lines)
+    end
+  end
+
+  @spec build_rg_command(String.t(), String.t(), String.t() | nil, boolean(), non_neg_integer()) ::
+          {String.t(), [String.t()]}
+  defp build_rg_command(rg, pattern, glob, case_sensitive, context_lines) do
+    args = ["--no-heading", "--line-number", "--color", "never"]
+    args = if case_sensitive, do: args, else: args ++ ["--ignore-case"]
+
+    args =
+      if context_lines > 0,
+        do: args ++ ["--context", Integer.to_string(context_lines)],
+        else: args
+
+    args = if glob, do: args ++ ["--glob", glob], else: args
+    args = args ++ ["--max-count", Integer.to_string(@max_matches), pattern, "."]
+    {rg, args}
+  end
+
+  @spec build_grep_command(String.t(), String.t() | nil, boolean(), non_neg_integer()) ::
+          {String.t(), [String.t()]}
+  defp build_grep_command(pattern, glob, case_sensitive, context_lines) do
+    grep = System.find_executable("grep") || "grep"
+    args = ["-rn"]
+    args = if case_sensitive, do: args, else: args ++ ["-i"]
+    args = if context_lines > 0, do: args ++ ["-C", Integer.to_string(context_lines)], else: args
+    args = if glob, do: args ++ ["--include", glob], else: args
+    args = args ++ [pattern, "."]
+    {grep, args}
+  end
+
+  @spec truncate_output(String.t()) :: String.t()
+  defp truncate_output(output) do
+    lines = String.split(output, "\n")
+
+    if length(lines) > @max_matches do
+      truncated = Enum.take(lines, @max_matches) |> Enum.join("\n")
+      truncated <> "\n\n... (truncated, #{length(lines) - @max_matches} more lines)"
+    else
+      output
+    end
+  end
+end

--- a/test/minga/agent/tools/grep_test.exs
+++ b/test/minga/agent/tools/grep_test.exs
@@ -1,0 +1,81 @@
+defmodule Minga.Agent.Tools.GrepTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Agent.Tools.Grep
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: dir} do
+    # Create test files
+    File.write!(Path.join(dir, "hello.ex"), ~S"""
+    defmodule Hello do
+      def greet(name) do
+        "Hello, #{name}!"
+      end
+    end
+    """)
+
+    File.write!(Path.join(dir, "world.ex"), """
+    defmodule World do
+      def planet, do: "Earth"
+    end
+    """)
+
+    File.mkdir_p!(Path.join(dir, "sub"))
+
+    File.write!(Path.join(dir, "sub/nested.txt"), """
+    This is a nested file.
+    It contains some text.
+    And more text here.
+    """)
+
+    %{dir: dir}
+  end
+
+  describe "execute/3" do
+    test "finds matches in files", %{dir: dir} do
+      assert {:ok, output} = Grep.execute("defmodule", dir)
+      assert output =~ "Hello"
+      assert output =~ "World"
+    end
+
+    test "returns no matches message when pattern not found", %{dir: dir} do
+      assert {:ok, "No matches found."} = Grep.execute("nonexistent_pattern_xyz", dir)
+    end
+
+    test "respects glob filter", %{dir: dir} do
+      assert {:ok, output} = Grep.execute("text", dir, %{"glob" => "*.txt"})
+      assert output =~ "nested.txt"
+      refute output =~ ".ex"
+    end
+
+    test "case insensitive search", %{dir: dir} do
+      assert {:ok, output} = Grep.execute("hello", dir, %{"case_sensitive" => false})
+      assert output =~ "Hello"
+    end
+
+    test "case sensitive search misses different case", %{dir: dir} do
+      assert {:ok, output} = Grep.execute("hello", dir, %{"case_sensitive" => true})
+      # "hello" (lowercase) should not match "Hello" (capitalized)
+      # The only match would be the string interpolation template
+      refute output =~ "defmodule Hello"
+    end
+
+    test "context lines includes surrounding lines", %{dir: dir} do
+      assert {:ok, output} = Grep.execute("planet", dir, %{"context_lines" => 1})
+      # Should include surrounding lines
+      assert output =~ "World"
+    end
+
+    test "searches subdirectories", %{dir: dir} do
+      assert {:ok, output} = Grep.execute("nested", dir)
+      assert output =~ "nested"
+    end
+
+    test "returns error for invalid path", %{dir: dir} do
+      bad_path = Path.join(dir, "nonexistent_dir")
+      result = Grep.execute("test", bad_path)
+      assert {:error, _} = result
+    end
+  end
+end

--- a/test/minga/agent/tools_test.exs
+++ b/test/minga/agent/tools_test.exs
@@ -35,15 +35,16 @@ defmodule Minga.Agent.ToolsTest do
   end
 
   describe "all/1" do
-    test "returns a list of five tools", %{tmp_dir: dir} do
+    test "returns a list of six tools", %{tmp_dir: dir} do
       tools = Tools.all(project_root: dir)
-      assert length(tools) == 5
+      assert length(tools) == 6
 
       names = Enum.map(tools, & &1.name)
       assert "read_file" in names
       assert "write_file" in names
       assert "edit_file" in names
       assert "list_directory" in names
+      assert "grep" in names
       assert "shell" in names
     end
 


### PR DESCRIPTION
## What

Adds a structured `grep` tool so the agent can search file contents without shelling out. Uses ripgrep when available, falls back to `grep -rn`.

## Why

File search is one of the most frequent agent operations. The shell tool works but the model sometimes gets flags wrong, produces unstructured output, and triggers the approval prompt. A dedicated read-only tool with structured parameters produces consistent results and skips approval.

## Changes

- **`Tools.Grep`** (new): Structured search with pattern, path, glob, case_sensitive, context_lines parameters. Prefers `rg`, falls back to `grep -rn`. Output truncated at 100 matches.
- **`Tools`**: Registered as 6th tool, classified as non-destructive (no approval).
- **`Providers.Native`**: System prompt updated to mention grep and guide model usage.
- **Tests**: 8 new tests covering matches, no matches, glob filter, case sensitivity, context lines, subdirectory search, and error handling.

Closes #277