### PR TITLE
feat(agent): multi-level AGENTS.md discovery

### DIFF
--- a/lib/minga/agent/instructions.ex
+++ b/lib/minga/agent/instructions.ex
@@ -1,0 +1,151 @@
+defmodule Minga.Agent.Instructions do
+  @moduledoc """
+  Multi-level AGENTS.md discovery and assembly.
+
+  Discovers instruction files from multiple locations and layers them
+  into the system prompt. Files are checked in order, and all found
+  files are included with section headers showing their source path.
+
+  ## Discovery order
+
+  1. **Global**: `~/.config/minga/AGENTS.md` (user-wide defaults)
+  2. **Project root**: `AGENTS.md` at the project root
+  3. **Project config**: `.minga/AGENTS.md` at the project root
+  4. **Directory-scoped**: `AGENTS.md` files in parent directories between
+     the current file's directory and the project root (for monorepo subdirectory rules)
+
+  Global instructions come first, project instructions next, directory-scoped
+  instructions last (most specific wins when instructions conflict).
+  """
+
+  @typedoc "A discovered instruction file."
+  @type instruction :: %{
+          label: String.t(),
+          path: String.t(),
+          content: String.t()
+        }
+
+  @doc """
+  Discovers all instruction files and returns them as an ordered list.
+
+  `project_root` is the project root directory. `current_file` is the
+  path of the file the user is currently editing (optional, used for
+  directory-scoped discovery in monorepos).
+  """
+  @spec discover(String.t(), String.t() | nil) :: [instruction()]
+  def discover(project_root, current_file \\ nil) when is_binary(project_root) do
+    global_instructions() ++
+      project_instructions(project_root) ++
+      directory_instructions(project_root, current_file)
+  end
+
+  @doc """
+  Assembles discovered instructions into a single string with section headers.
+
+  Returns nil if no instruction files were found.
+  """
+  @spec assemble(String.t(), String.t() | nil) :: String.t() | nil
+  def assemble(project_root, current_file \\ nil) do
+    instructions = discover(project_root, current_file)
+
+    case instructions do
+      [] ->
+        nil
+
+      found ->
+        Enum.map_join(found, "\n\n", fn %{label: label, content: content} ->
+          "## #{label}\n\n#{String.trim(content)}"
+        end)
+    end
+  end
+
+  @doc """
+  Returns a summary of discovered instruction files (paths and sizes).
+
+  Useful for the `/instructions` slash command.
+  """
+  @spec summary(String.t(), String.t() | nil) :: String.t()
+  def summary(project_root, current_file \\ nil) do
+    instructions = discover(project_root, current_file)
+
+    case instructions do
+      [] ->
+        "No instruction files found.\n\nSearched:\n" <>
+          "  ~/.config/minga/AGENTS.md\n" <>
+          "  #{project_root}/AGENTS.md\n" <>
+          "  #{project_root}/.minga/AGENTS.md"
+
+      found ->
+        header = "Loaded #{length(found)} instruction file(s):\n"
+
+        lines =
+          Enum.map_join(found, "\n", fn %{label: label, path: path, content: content} ->
+            size = String.length(content)
+            "  ✓ #{label} (#{path}, #{size} chars)"
+          end)
+
+        header <> lines
+    end
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec global_instructions() :: [instruction()]
+  defp global_instructions do
+    config_dir = System.get_env("XDG_CONFIG_HOME") || Path.join(System.user_home!(), ".config")
+    path = Path.join([config_dir, "minga", "AGENTS.md"])
+    read_instruction("Global Instructions", path)
+  end
+
+  @spec project_instructions(String.t()) :: [instruction()]
+  defp project_instructions(project_root) do
+    root_path = Path.join(project_root, "AGENTS.md")
+    config_path = Path.join([project_root, ".minga", "AGENTS.md"])
+
+    read_instruction("Project Instructions", root_path) ++
+      read_instruction("Project Config Instructions", config_path)
+  end
+
+  @spec directory_instructions(String.t(), String.t() | nil) :: [instruction()]
+  defp directory_instructions(_project_root, nil), do: []
+
+  defp directory_instructions(project_root, current_file) do
+    file_dir = Path.dirname(current_file)
+    abs_root = Path.expand(project_root)
+    abs_dir = Path.expand(file_dir)
+
+    walk_up(abs_dir, abs_root)
+  end
+
+  # Walks up from `dir` toward `root`, collecting AGENTS.md files at each level.
+  # Skips the root itself (already handled by project_instructions).
+  # Returns files ordered from root-adjacent to most specific (deepest first reversed).
+  @spec walk_up(String.t(), String.t()) :: [instruction()]
+  defp walk_up(dir, root) when dir == root, do: []
+
+  defp walk_up(dir, root) do
+    if String.starts_with?(dir, root) do
+      parent = Path.dirname(dir)
+      parent_results = walk_up(parent, root)
+
+      path = Path.join(dir, "AGENTS.md")
+      relative = Path.relative_to(path, root)
+      label = "Directory Instructions (#{relative})"
+
+      parent_results ++ read_instruction(label, path)
+    else
+      []
+    end
+  end
+
+  @spec read_instruction(String.t(), String.t()) :: [instruction()]
+  defp read_instruction(label, path) do
+    case File.read(path) do
+      {:ok, content} when content != "" ->
+        [%{label: label, path: path, content: content}]
+
+      _ ->
+        []
+    end
+  end
+end

--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -35,6 +35,7 @@ defmodule Minga.Agent.Providers.Native do
 
   alias Minga.Agent.Credentials
   alias Minga.Agent.Event
+  alias Minga.Agent.Instructions
   alias Minga.Agent.ModelLimits
   alias Minga.Agent.TokenEstimator
   alias Minga.Agent.Tools
@@ -574,7 +575,7 @@ defmodule Minga.Agent.Providers.Native do
 
   @spec build_system_prompt(String.t()) :: String.t()
   defp build_system_prompt(project_root) do
-    agents_md = read_agents_md(project_root)
+    instructions = Instructions.assemble(project_root)
 
     """
     You are an AI coding assistant running inside Minga, a modal text editor. You help users by reading files, editing code, running shell commands, and writing new files.
@@ -600,18 +601,8 @@ defmodule Minga.Agent.Providers.Native do
 
     - Project root: #{project_root}
     - Current time: #{DateTime.utc_now() |> DateTime.to_iso8601()}
-    #{if agents_md, do: "\n## Project Instructions\n\n#{agents_md}", else: ""}
+    #{if instructions, do: "\n#{instructions}", else: ""}
     """
-  end
-
-  @spec read_agents_md(String.t()) :: String.t() | nil
-  defp read_agents_md(project_root) do
-    path = Path.join(project_root, "AGENTS.md")
-
-    case File.read(path) do
-      {:ok, content} -> content
-      {:error, _} -> nil
-    end
   end
 
   # Sets the provider's API key env var if it's stored in the credentials

--- a/lib/minga/agent/slash_command.ex
+++ b/lib/minga/agent/slash_command.ex
@@ -9,6 +9,7 @@ defmodule Minga.Agent.SlashCommand do
   """
 
   alias Minga.Agent.Credentials
+  alias Minga.Agent.Instructions
   alias Minga.Agent.PanelState
   alias Minga.Agent.Session
   alias Minga.Editor.Commands.Agent, as: AgentCommands
@@ -34,6 +35,10 @@ defmodule Minga.Agent.SlashCommand do
     %{
       name: "auth",
       description: "Manage API keys: /auth, /auth <provider>, /auth revoke <provider>"
+    },
+    %{
+      name: "instructions",
+      description: "Show which AGENTS.md instruction files are loaded"
     }
   ]
 
@@ -82,6 +87,7 @@ defmodule Minga.Agent.SlashCommand do
   defp dispatch(state, "?", _args), do: {:ok, do_help(state)}
   defp dispatch(state, "sessions", _args), do: {:ok, do_sessions(state)}
   defp dispatch(state, "auth", args), do: {:ok, do_auth(state, args)}
+  defp dispatch(state, "instructions", _args), do: {:ok, do_instructions(state)}
   defp dispatch(_state, cmd, _args), do: {:error, "Unknown command: /#{cmd}"}
 
   # ── Command implementations ────────────────────────────────────────────────
@@ -262,6 +268,25 @@ defmodule Minga.Agent.SlashCommand do
         "Unknown provider: #{provider}\nKnown providers: #{Enum.join(Credentials.known_providers(), ", ")}"
       )
     end
+  end
+
+  @spec do_instructions(state()) :: state()
+  defp do_instructions(state) do
+    root = detect_project_root()
+    summary = Instructions.summary(root)
+    emit_system_message(state, summary)
+  end
+
+  @spec detect_project_root() :: String.t()
+  defp detect_project_root do
+    case Minga.Project.root() do
+      nil -> File.cwd!()
+      root -> root
+    end
+  rescue
+    _ -> File.cwd!()
+  catch
+    :exit, _ -> File.cwd!()
   end
 
   @spec emit_system_message(state(), String.t()) :: state()

--- a/test/minga/agent/instructions_test.exs
+++ b/test/minga/agent/instructions_test.exs
@@ -1,0 +1,119 @@
+defmodule Minga.Agent.InstructionsTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Agent.Instructions
+
+  @moduletag :tmp_dir
+
+  describe "discover/2" do
+    test "finds project root AGENTS.md", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "AGENTS.md"), "Project rules here")
+
+      results = Instructions.discover(dir)
+      assert length(results) == 1
+      assert hd(results).label == "Project Instructions"
+      assert hd(results).content == "Project rules here"
+    end
+
+    test "finds .minga/AGENTS.md", %{tmp_dir: dir} do
+      File.mkdir_p!(Path.join(dir, ".minga"))
+      File.write!(Path.join([dir, ".minga", "AGENTS.md"]), "Config rules")
+
+      results = Instructions.discover(dir)
+      assert length(results) == 1
+      assert hd(results).label == "Project Config Instructions"
+    end
+
+    test "finds both project root and .minga AGENTS.md", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "AGENTS.md"), "Root rules")
+      File.mkdir_p!(Path.join(dir, ".minga"))
+      File.write!(Path.join([dir, ".minga", "AGENTS.md"]), "Config rules")
+
+      results = Instructions.discover(dir)
+      assert length(results) == 2
+      labels = Enum.map(results, & &1.label)
+      assert "Project Instructions" in labels
+      assert "Project Config Instructions" in labels
+    end
+
+    test "returns empty list when no files exist", %{tmp_dir: dir} do
+      assert Instructions.discover(dir) == []
+    end
+
+    test "finds directory-scoped AGENTS.md", %{tmp_dir: dir} do
+      # Create a subdirectory with its own AGENTS.md
+      sub = Path.join([dir, "lib", "agent"])
+      File.mkdir_p!(sub)
+      File.write!(Path.join(sub, "AGENTS.md"), "Agent-specific rules")
+
+      current_file = Path.join(sub, "some_file.ex")
+      results = Instructions.discover(dir, current_file)
+
+      dir_results = Enum.filter(results, &String.starts_with?(&1.label, "Directory"))
+      assert length(dir_results) == 1
+      assert hd(dir_results).content == "Agent-specific rules"
+    end
+
+    test "directory-scoped discovery walks up to root", %{tmp_dir: dir} do
+      # Create AGENTS.md at multiple levels
+      lib = Path.join(dir, "lib")
+      agent = Path.join(lib, "agent")
+      File.mkdir_p!(agent)
+      File.write!(Path.join(lib, "AGENTS.md"), "Lib rules")
+      File.write!(Path.join(agent, "AGENTS.md"), "Agent rules")
+
+      current_file = Path.join(agent, "foo.ex")
+      results = Instructions.discover(dir, current_file)
+
+      dir_results = Enum.filter(results, &String.starts_with?(&1.label, "Directory"))
+      assert length(dir_results) == 2
+    end
+
+    test "skips empty files", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "AGENTS.md"), "")
+      assert Instructions.discover(dir) == []
+    end
+  end
+
+  describe "assemble/2" do
+    test "returns nil when no files found", %{tmp_dir: dir} do
+      assert Instructions.assemble(dir) == nil
+    end
+
+    test "returns assembled content with section headers", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "AGENTS.md"), "Use tabs not spaces")
+
+      result = Instructions.assemble(dir)
+      assert result =~ "## Project Instructions"
+      assert result =~ "Use tabs not spaces"
+    end
+
+    test "multiple files are separated by headers", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "AGENTS.md"), "Root rules")
+      File.mkdir_p!(Path.join(dir, ".minga"))
+      File.write!(Path.join([dir, ".minga", "AGENTS.md"]), "Config rules")
+
+      result = Instructions.assemble(dir)
+      assert result =~ "## Project Instructions"
+      assert result =~ "## Project Config Instructions"
+      assert result =~ "Root rules"
+      assert result =~ "Config rules"
+    end
+  end
+
+  describe "summary/2" do
+    test "shows no files message when none found", %{tmp_dir: dir} do
+      result = Instructions.summary(dir)
+      assert result =~ "No instruction files found"
+    end
+
+    test "lists found files with sizes", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "AGENTS.md"), "Some content here")
+
+      result = Instructions.summary(dir)
+      assert result =~ "Loaded 1 instruction file(s)"
+      assert result =~ "✓ Project Instructions"
+      assert result =~ "chars"
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds layered instruction file discovery so the native provider reads AGENTS.md from multiple locations, matching the behavior of pi-agent and Claude Code.

## Why

Real projects need layered instructions: global defaults, project-wide rules, and directory-scoped guidance for monorepos. Without layering, users duplicate instructions across projects or cram everything into one file.

## Changes

- **`Minga.Agent.Instructions`** (new): Discovers instruction files from 4 locations (global, project root, .minga/, directory-scoped). Assembles them with section headers. Provides `summary/2` for the slash command.
- **`Providers.Native`**: `build_system_prompt/1` now uses `Instructions.assemble/2` instead of the old single-file `read_agents_md/1`.
- **`SlashCommand`**: New `/instructions` command shows which files are loaded with paths and sizes.
- **Tests**: 12 new tests covering discovery at each level, empty files, directory walking, assembly, and summary.

## Discovery order

1. `~/.config/minga/AGENTS.md` (global)
2. `{root}/AGENTS.md` (project)
3. `{root}/.minga/AGENTS.md` (project config)
4. `AGENTS.md` in parent dirs from current file to root (directory-scoped)

Closes #287