### PR TITLE
refactor(editor): replace all direct Logger calls with Minga.Log

### DIFF
--- a/lib/minga/agent/credentials.ex
+++ b/lib/minga/agent/credentials.ex
@@ -14,8 +14,6 @@ defmodule Minga.Agent.Credentials do
   sent to `*Messages*`.
   """
 
-  require Logger
-
   @typedoc "A supported provider name."
   @type provider :: String.t()
 

--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -31,8 +31,6 @@ defmodule Minga.Agent.Providers.Native do
 
   use GenServer
 
-  require Logger
-
   alias Minga.Agent.Credentials
   alias Minga.Agent.Event
   alias Minga.Agent.ModelLimits
@@ -161,7 +159,7 @@ defmodule Minga.Agent.Providers.Native do
       streaming: false
     }
 
-    Logger.info("[Agent.Native] started with model=#{model} root=#{project_root}")
+    Minga.Log.info(:agent, "[Agent.Native] started with model=#{model} root=#{project_root}")
 
     {:ok, state}
   end
@@ -206,7 +204,7 @@ defmodule Minga.Agent.Providers.Native do
   def handle_call(:abort, _from, state) do
     Task.shutdown(state.task, :brutal_kill)
     state = %{state | task: nil, streaming: false}
-    Logger.info("[Agent.Native] aborted current operation")
+    Minga.Log.info(:agent, "[Agent.Native] aborted current operation")
     {:reply, :ok, state}
   end
 
@@ -220,7 +218,7 @@ defmodule Minga.Agent.Providers.Native do
     context = Context.new([Context.system(system_prompt)])
 
     state = %{state | context: context, task: nil, streaming: false}
-    Logger.info("[Agent.Native] new session started")
+    Minga.Log.info(:agent, "[Agent.Native] new session started")
 
     {:reply, :ok, state}
   end
@@ -241,7 +239,7 @@ defmodule Minga.Agent.Providers.Native do
 
   def handle_call({:set_thinking_level, level}, _from, state) do
     if Map.has_key?(@thinking_levels, level) do
-      Logger.info("[Agent.Native] thinking level set to #{level}")
+      Minga.Log.info(:agent, "[Agent.Native] thinking level set to #{level}")
       {:reply, :ok, %{state | thinking_level: level}}
     else
       {:reply,
@@ -255,7 +253,7 @@ defmodule Minga.Agent.Providers.Native do
     next_index = rem(current_index + 1, length(@thinking_cycle))
     next_level = Enum.at(@thinking_cycle, next_index)
 
-    Logger.info("[Agent.Native] thinking level cycled to #{next_level}")
+    Minga.Log.info(:agent, "[Agent.Native] thinking level cycled to #{next_level}")
     {:reply, {:ok, %{"level" => next_level}}, %{state | thinking_level: next_level}}
   end
 
@@ -280,7 +278,7 @@ defmodule Minga.Agent.Providers.Native do
   def handle_info({ref, {:error, reason}}, %{task: %Task{ref: ref}} = state) do
     # Task completed with an error
     Process.demonitor(ref, [:flush])
-    Logger.error("[Agent.Native] agent loop error: #{inspect(reason)}")
+    Minga.Log.error(:agent, "[Agent.Native] agent loop error: #{inspect(reason)}")
     notify(state.subscriber, %Event.Error{message: format_error(reason)})
     notify(state.subscriber, %Event.AgentEnd{usage: nil})
     {:noreply, %{state | task: nil, streaming: false}}
@@ -288,7 +286,7 @@ defmodule Minga.Agent.Providers.Native do
 
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{task: %Task{ref: ref}} = state) do
     # Task crashed
-    Logger.error("[Agent.Native] agent task crashed: #{inspect(reason)}")
+    Minga.Log.error(:agent, "[Agent.Native] agent task crashed: #{inspect(reason)}")
     notify(state.subscriber, %Event.Error{message: "Agent task crashed: #{inspect(reason)}"})
     notify(state.subscriber, %Event.AgentEnd{usage: nil})
     {:noreply, %{state | task: nil, streaming: false}}

--- a/lib/minga/agent/providers/pi_rpc.ex
+++ b/lib/minga/agent/providers/pi_rpc.ex
@@ -16,8 +16,6 @@ defmodule Minga.Agent.Providers.PiRpc do
 
   use GenServer
 
-  require Logger
-
   alias Minga.Agent.Event
 
   @typedoc "Internal state for the Pi RPC provider."
@@ -198,7 +196,7 @@ defmodule Minga.Agent.Providers.PiRpc do
   end
 
   def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
-    Logger.warning("[Agent.PiRpc] pi process exited with status #{status}")
+    Minga.Log.warning(:agent, "[Agent.PiRpc] pi process exited with status #{status}")
     notify(state.subscriber, %Event.Error{message: "pi process exited (status #{status})"})
     {:stop, {:pi_exited, status}, %{state | port: nil}}
   end
@@ -292,7 +290,7 @@ defmodule Minga.Agent.Providers.PiRpc do
 
   defp send_command(port, command) do
     json = JSON.encode!(command)
-    Logger.info("[Agent → Pi] #{json}")
+    Minga.Log.info(:agent, "[Agent → Pi] #{json}")
     Port.command(port, [json, "\n"])
     :ok
   end
@@ -333,20 +331,20 @@ defmodule Minga.Agent.Providers.PiRpc do
         other -> other
       end
 
-    Logger.info("[Pi → Agent] message_update/#{summary}")
+    Minga.Log.info(:agent, "[Pi → Agent] message_update/#{summary}")
   end
 
   defp log_received_event(%{"type" => "response", "command" => cmd, "success" => success} = event) do
     error = if event["error"], do: " error=#{event["error"]}", else: ""
-    Logger.info("[Pi → Agent] response cmd=#{cmd} success=#{success}#{error}")
+    Minga.Log.info(:agent, "[Pi → Agent] response cmd=#{cmd} success=#{success}#{error}")
   end
 
   defp log_received_event(%{"type" => "extension_ui_request", "method" => method} = event) do
-    Logger.info("[Pi → Agent] extension_ui_request method=#{method} id=#{event["id"]}")
+    Minga.Log.info(:agent, "[Pi → Agent] extension_ui_request method=#{method} id=#{event["id"]}")
   end
 
   defp log_received_event(%{"type" => type}) do
-    Logger.info("[Pi → Agent] #{type}")
+    Minga.Log.info(:agent, "[Pi → Agent] #{type}")
   end
 
   defp log_received_event(_), do: :ok
@@ -447,7 +445,7 @@ defmodule Minga.Agent.Providers.PiRpc do
   defp handle_event(%{"type" => "extension_ui_request", "method" => method, "id" => id}, state)
        when method in ["select", "confirm", "input", "editor"] do
     # Dialog methods block pi until we respond. Auto-cancel for now.
-    Logger.info("[Agent.PiRpc] auto-cancelling dialog: #{method} (id=#{id})")
+    Minga.Log.info(:agent, "[Agent.PiRpc] auto-cancelling dialog: #{method} (id=#{id})")
     response = %{"type" => "extension_ui_response", "id" => id, "cancelled" => true}
     send_command(state.port, response)
     {:noreply, state}
@@ -459,7 +457,7 @@ defmodule Minga.Agent.Providers.PiRpc do
   end
 
   defp handle_event(%{"type" => "extension_error"} = event, state) do
-    Logger.warning("[Agent.PiRpc] extension error: #{event["error"]}")
+    Minga.Log.warning(:agent, "[Agent.PiRpc] extension error: #{event["error"]}")
     {:noreply, state}
   end
 

--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -21,8 +21,6 @@ defmodule Minga.Agent.Session do
 
   use GenServer
 
-  require Logger
-
   alias Minga.Agent.Credentials
   alias Minga.Agent.Event
   alias Minga.Agent.Message
@@ -378,7 +376,7 @@ defmodule Minga.Agent.Session do
   end
 
   def handle_call({:respond_to_approval, _decision}, _from, %{pending_approval: nil} = state) do
-    Logger.warning("[Session] respond_to_approval called with no pending approval")
+    Minga.Log.warning(:agent, "[Session] respond_to_approval called with no pending approval")
     {:reply, {:error, :no_pending_approval}, state}
   end
 
@@ -494,7 +492,7 @@ defmodule Minga.Agent.Session do
         {:noreply, state}
 
       {:error, reason} ->
-        Logger.error("[Agent.Session] failed to start provider: #{inspect(reason)}")
+        Minga.Log.error(:agent, "[Agent.Session] failed to start provider: #{inspect(reason)}")
         state = set_status(state, :error)
         state = %{state | error_message: format_error(reason)}
         broadcast(state, {:error, state.error_message})
@@ -508,7 +506,7 @@ defmodule Minga.Agent.Session do
   end
 
   def handle_info({:DOWN, _ref, :process, pid, reason}, %{provider: pid} = state) do
-    Logger.warning("[Agent.Session] provider process died: #{inspect(reason)}")
+    Minga.Log.warning(:agent, "[Agent.Session] provider process died: #{inspect(reason)}")
     state = set_status(state, :error)
     state = %{state | provider: nil, error_message: "Agent provider crashed"}
     broadcast(state, {:error, state.error_message})

--- a/lib/minga/agent/session_store.ex
+++ b/lib/minga/agent/session_store.ex
@@ -11,8 +11,6 @@ defmodule Minga.Agent.SessionStore do
   picker calls `list/0` to scan the directory for past sessions.
   """
 
-  require Logger
-
   @typedoc "Session metadata for the picker (without full message content)."
   @type session_meta :: %{
           id: String.t(),
@@ -59,7 +57,7 @@ defmodule Minga.Agent.SessionStore do
         File.rename(tmp_path, path)
 
       {:error, reason} ->
-        Logger.warning("[SessionStore] failed to save #{id}: #{reason}")
+        Minga.Log.warning(:agent, "[SessionStore] failed to save #{id}: #{reason}")
         {:error, reason}
     end
   end

--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -97,8 +97,10 @@ defmodule Minga.Application do
     pruned = SessionStore.prune(retention_days)
 
     if pruned > 0 do
-      require Logger
-      Logger.info("[Agent] pruned #{pruned} sessions older than #{retention_days} days")
+      Minga.Log.info(
+        :agent,
+        "[Agent] pruned #{pruned} sessions older than #{retention_days} days"
+      )
     end
 
     :ok

--- a/lib/minga/cli.ex
+++ b/lib/minga/cli.ex
@@ -20,8 +20,6 @@ defmodule Minga.CLI do
 
   alias Burrito.Util.Args
 
-  require Logger
-
   @typedoc "Parsed CLI result."
   @type parsed ::
           {:open, file :: String.t() | nil, flags()}
@@ -157,7 +155,7 @@ defmodule Minga.CLI do
             Minga.Editor.open_file(path)
 
           :timeout ->
-            Logger.error("Editor process did not start in time")
+            Minga.Log.error(:editor, "Editor process did not start in time")
         end
     end
 

--- a/lib/minga/config.ex
+++ b/lib/minga/config.ex
@@ -40,8 +40,6 @@ defmodule Minga.Config do
   alias Minga.Extension.Registry, as: ExtRegistry
   alias Minga.Keymap.Active, as: KeymapActive
 
-  require Logger
-
   @doc """
   Injects the config DSL into the calling module or script.
 
@@ -109,7 +107,7 @@ defmodule Minga.Config do
 
     case result do
       :ok -> :ok
-      {:error, reason} -> Logger.warning("bind failed: #{reason}")
+      {:error, reason} -> Minga.Log.warning(:config, "bind failed: #{reason}")
     end
 
     :ok
@@ -132,7 +130,7 @@ defmodule Minga.Config do
              is_binary(description) and is_list(opts) do
     case KeymapActive.bind(mode, key_str, command_name, description, opts) do
       :ok -> :ok
-      {:error, reason} -> Logger.warning("bind failed: #{reason}")
+      {:error, reason} -> Minga.Log.warning(:config, "bind failed: #{reason}")
     end
 
     :ok
@@ -219,7 +217,7 @@ defmodule Minga.Config do
         rescue
           e ->
             msg = "Command #{name} failed: #{Exception.message(e)}"
-            Logger.warning(msg)
+            Minga.Log.warning(:config, msg)
 
             try do
               Minga.API.message(msg)
@@ -357,7 +355,7 @@ defmodule Minga.Config do
     expanded = Path.expand(path)
 
     unless File.dir?(expanded) do
-      Logger.warning("extension #{name}: path does not exist: #{expanded}")
+      Minga.Log.warning(:config, "extension #{name}: path does not exist: #{expanded}")
     end
 
     ExtRegistry.register(name, expanded, config)

--- a/lib/minga/config/advice.ex
+++ b/lib/minga/config/advice.ex
@@ -48,8 +48,6 @@ defmodule Minga.Config.Advice do
       end)
   """
 
-  require Logger
-
   @valid_phases [:before, :after, :around, :override]
 
   @table __MODULE__
@@ -236,11 +234,12 @@ defmodule Minga.Config.Advice do
         fun.(acc)
       rescue
         e ->
-          Logger.warning("Advice #{phase}:#{command} failed: #{Exception.message(e)}")
+          Minga.Log.warning(:config, "Advice #{phase}:#{command} failed: #{Exception.message(e)}")
           acc
       catch
         kind, reason ->
-          Logger.warning(
+          Minga.Log.warning(
+            :config,
             "Advice #{phase}:#{command} crashed: #{inspect(kind)} #{inspect(reason)}"
           )
 
@@ -254,11 +253,15 @@ defmodule Minga.Config.Advice do
     core.(state)
   rescue
     e ->
-      Logger.warning("Advice core for #{command} failed: #{Exception.message(e)}")
+      Minga.Log.warning(:config, "Advice core for #{command} failed: #{Exception.message(e)}")
       state
   catch
     kind, reason ->
-      Logger.warning("Advice core for #{command} crashed: #{inspect(kind)} #{inspect(reason)}")
+      Minga.Log.warning(
+        :config,
+        "Advice core for #{command} crashed: #{inspect(kind)} #{inspect(reason)}"
+      )
+
       state
   end
 

--- a/lib/minga/config/hooks.ex
+++ b/lib/minga/config/hooks.ex
@@ -24,8 +24,6 @@ defmodule Minga.Config.Hooks do
 
   use Agent
 
-  require Logger
-
   @valid_events [:after_save, :after_open, :on_mode_change]
 
   @typedoc "Valid event names."
@@ -83,10 +81,13 @@ defmodule Minga.Config.Hooks do
           apply(hook, args)
         rescue
           e ->
-            Logger.warning("Hook #{event} failed: #{Exception.message(e)}")
+            Minga.Log.warning(:config, "Hook #{event} failed: #{Exception.message(e)}")
         catch
           kind, reason ->
-            Logger.warning("Hook #{event} crashed: #{inspect(kind)} #{inspect(reason)}")
+            Minga.Log.warning(
+              :config,
+              "Hook #{event} crashed: #{inspect(kind)} #{inspect(reason)}"
+            )
         end
       end)
     end

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -32,8 +32,6 @@ defmodule Minga.Config.Loader do
   alias Minga.Extension.Supervisor, as: ExtSupervisor
   alias Minga.Keymap.Active, as: KeymapActive
 
-  require Logger
-
   @typedoc "Loader state: stores paths, loaded modules, and any errors from each stage."
   @type state :: %{
           config_path: String.t(),
@@ -210,7 +208,7 @@ defmodule Minga.Config.Loader do
 
       {:error, reason} ->
         msg = "Could not read modules directory #{modules_dir}: #{inspect(reason)}"
-        Logger.warning(msg)
+        Minga.Log.warning(:config, msg)
         {[], [msg]}
     end
   end
@@ -244,17 +242,17 @@ defmodule Minga.Config.Loader do
   rescue
     e in [SyntaxError, TokenMissingError, CompileError] ->
       msg = "Module compile error in #{path}: #{Exception.message(e)}"
-      Logger.warning(msg)
+      Minga.Log.warning(:config, msg)
       {:error, msg}
 
     e ->
       msg = "Module error in #{path}: #{Exception.message(e)}"
-      Logger.warning(msg)
+      Minga.Log.warning(:config, msg)
       {:error, msg}
   catch
     kind, reason ->
       msg = "Module error in #{path}: #{inspect(kind)} #{inspect(reason)}"
-      Logger.warning(msg)
+      Minga.Log.warning(:config, msg)
       {:error, msg}
   end
 
@@ -299,17 +297,17 @@ defmodule Minga.Config.Loader do
   rescue
     e in [SyntaxError, TokenMissingError, CompileError] ->
       msg = "Config syntax error in #{path}: #{Exception.message(e)}"
-      Logger.warning(msg)
+      Minga.Log.warning(:config, msg)
       msg
 
     e ->
       msg = "Config error in #{path}: #{Exception.message(e)}"
-      Logger.warning(msg)
+      Minga.Log.warning(:config, msg)
       msg
   catch
     kind, reason ->
       msg = "Config error in #{path}: #{inspect(kind)} #{inspect(reason)}"
-      Logger.warning(msg)
+      Minga.Log.warning(:config, msg)
       msg
   end
 end

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -41,6 +41,8 @@ defmodule Minga.Config.Options do
   | `:log_level_lsp`          | log level or `:default`                     | `:default`  |
   | `:log_level_agent`        | log level or `:default`                     | `:default`  |
   | `:log_level_editor`       | log level or `:default`                     | `:default`  |
+  | `:log_level_config`       | log level or `:default`                     | `:default`  |
+  | `:log_level_port`         | log level or `:default`                     | `:default`  |
 
   Log level options control per-subsystem verbosity. Subsystem options
   default to `:default` (inherit from `:log_level`). See `Minga.Log`
@@ -101,6 +103,8 @@ defmodule Minga.Config.Options do
           | :log_level_lsp
           | :log_level_agent
           | :log_level_editor
+          | :log_level_config
+          | :log_level_port
 
   @typedoc "Line number display style."
   @type line_number_style :: :hybrid | :absolute | :relative | :none
@@ -161,7 +165,9 @@ defmodule Minga.Config.Options do
     {:log_level_render, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
     {:log_level_lsp, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
     {:log_level_agent, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
-    {:log_level_editor, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default}
+    {:log_level_editor, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
+    {:log_level_config, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
+    {:log_level_port, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default}
   ]
 
   @valid_names Enum.map(@option_specs, &elem(&1, 0))

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -45,8 +45,6 @@ defmodule Minga.Editor do
   alias Minga.Project
   alias Minga.Surface.AgentView
 
-  require Logger
-
   @typedoc "Options for starting the editor."
   @type start_opt ::
           {:name, GenServer.name()}

--- a/lib/minga/editor/agent_lifecycle.ex
+++ b/lib/minga/editor/agent_lifecycle.ex
@@ -23,8 +23,6 @@ defmodule Minga.Editor.AgentLifecycle do
   alias Minga.Editor.State.TabBar
   alias Minga.Surface.AgentView
 
-  require Logger
-
   @type state :: EditorState.t()
 
   @doc """
@@ -45,7 +43,7 @@ defmodule Minga.Editor.AgentLifecycle do
     end
   rescue
     e ->
-      Logger.warning("Failed to start agent session at boot: #{Exception.message(e)}")
+      Minga.Log.warning(:agent, "Failed to start agent session at boot: #{Exception.message(e)}")
       state
   end
 

--- a/lib/minga/editor/buffer_lifecycle.ex
+++ b/lib/minga/editor/buffer_lifecycle.ex
@@ -14,8 +14,6 @@ defmodule Minga.Editor.BufferLifecycle do
   alias Minga.Git.Buffer, as: GitBuffer
   alias Minga.Mode
 
-  require Logger
-
   @type state :: EditorState.t()
 
   # ── LSP lifecycle ──────────────────────────────────────────────────────
@@ -124,7 +122,7 @@ defmodule Minga.Editor.BufferLifecycle do
         %{state | git_buffers: Map.put(state.git_buffers, buffer_pid, git_pid)}
 
       {:error, reason} ->
-        Logger.warning("Failed to start git buffer: #{inspect(reason)}")
+        Minga.Log.warning(:editor, "Failed to start git buffer: #{inspect(reason)}")
         state
     end
   end

--- a/lib/minga/editor/commands/agent_session.ex
+++ b/lib/minga/editor/commands/agent_session.ex
@@ -68,9 +68,8 @@ defmodule Minga.Editor.Commands.AgentSession do
         end
 
       {:error, reason} ->
-        require Logger
         msg = format_session_error(reason)
-        Logger.error("[Agent] #{msg}")
+        Minga.Log.error(:agent, "[Agent] #{msg}")
         Minga.Editor.log_to_messages("[Agent] #{msg}")
         AgentAccess.update_agent(state, &AgentState.set_error(&1, msg))
     end

--- a/lib/minga/editor/commands/buffer_management.ex
+++ b/lib/minga/editor/commands/buffer_management.ex
@@ -23,8 +23,6 @@ defmodule Minga.Editor.Commands.BufferManagement do
   alias Minga.Formatter
   alias Minga.Mode
 
-  require Logger
-
   @type state :: EditorState.t()
 
   @spec execute(state(), Mode.command()) :: state()
@@ -119,7 +117,7 @@ defmodule Minga.Editor.Commands.BufferManagement do
         Commands.add_buffer(state, pid)
 
       {:error, reason} ->
-        Logger.error("Failed to create buffer: #{inspect(reason)}")
+        Minga.Log.error(:editor, "Failed to create buffer: #{inspect(reason)}")
         state
     end
   end
@@ -225,7 +223,7 @@ defmodule Minga.Editor.Commands.BufferManagement do
             Commands.add_buffer(state, pid)
 
           {:error, reason} ->
-            Logger.error("Failed to open file: #{inspect(reason)}")
+            Minga.Log.error(:editor, "Failed to open file: #{inspect(reason)}")
             state
         end
 
@@ -438,7 +436,7 @@ defmodule Minga.Editor.Commands.BufferManagement do
         EditorState.add_buffer(state, pid)
 
       {:error, reason} ->
-        Logger.warning("Failed to open config: #{inspect(reason)}")
+        Minga.Log.warning(:editor, "Failed to open config: #{inspect(reason)}")
         state
     end
   end
@@ -748,7 +746,7 @@ defmodule Minga.Editor.Commands.BufferManagement do
 
       {_, {:error, msg}} ->
         Minga.Editor.log_to_messages("Format-on-save failed: #{buf_name} (#{msg})")
-        Logger.warning("Format-on-save failed: #{msg}")
+        Minga.Log.warning(:editor, "Format-on-save failed: #{msg}")
         state
     end
   end

--- a/lib/minga/editor/startup.ex
+++ b/lib/minga/editor/startup.ex
@@ -23,8 +23,6 @@ defmodule Minga.Editor.Startup do
   alias Minga.Mode
   alias Minga.Port.Manager, as: PortManager
 
-  require Logger
-
   @doc """
   Builds the complete initial EditorState from startup opts.
 
@@ -92,7 +90,7 @@ defmodule Minga.Editor.Startup do
   defp subscribe_port(port_manager) do
     PortManager.subscribe(port_manager)
   catch
-    :exit, _ -> Logger.warning("Could not subscribe to port manager")
+    :exit, _ -> Minga.Log.warning(:editor, "Could not subscribe to port manager")
   end
 
   @doc """
@@ -173,7 +171,7 @@ defmodule Minga.Editor.Startup do
   def subscribe_to_parser(parser_manager) do
     Minga.Parser.Manager.subscribe(parser_manager)
   catch
-    :exit, _ -> Logger.warning("Could not subscribe to parser manager")
+    :exit, _ -> Minga.Log.warning(:editor, "Could not subscribe to parser manager")
   end
 
   @doc """

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -17,8 +17,6 @@ defmodule Minga.Extension.Supervisor do
 
   alias Minga.Extension.Registry, as: ExtRegistry
 
-  require Logger
-
   # ── Client API ──────────────────────────────────────────────────────────────
 
   @doc "Starts the extension supervisor."
@@ -81,19 +79,19 @@ defmodule Minga.Extension.Supervisor do
       case DynamicSupervisor.start_child(supervisor, child_spec) do
         {:ok, pid} ->
           ExtRegistry.update(registry, name, module: module, status: :running, pid: pid)
-          Logger.info("Extension #{name} started (#{module})")
+          Minga.Log.info(:config, "Extension #{name} started (#{module})")
           {:ok, pid}
 
         {:error, reason} ->
           msg = "Extension #{name} failed to start: #{inspect(reason)}"
-          Logger.warning(msg)
+          Minga.Log.warning(:config, msg)
           ExtRegistry.update(registry, name, module: module, status: :load_error, pid: nil)
           {:error, reason}
       end
     else
       {:error, reason} ->
         msg = "Extension #{name} load error: #{inspect(reason)}"
-        Logger.warning(msg)
+        Minga.Log.warning(:config, msg)
         ExtRegistry.update(registry, name, status: :load_error, pid: nil)
         {:error, reason}
     end

--- a/lib/minga/file_watcher.ex
+++ b/lib/minga/file_watcher.ex
@@ -21,8 +21,6 @@ defmodule Minga.FileWatcher do
 
   use GenServer
 
-  require Logger
-
   @enforce_keys [:subscriber, :debounce_ms]
   defstruct subscriber: nil,
             debounce_ms: nil,
@@ -146,7 +144,7 @@ defmodule Minga.FileWatcher do
   end
 
   def handle_info({:file_event, _watcher_pid, :stop}, %__MODULE__{} = state) do
-    Logger.warning("File watcher stopped unexpectedly")
+    Minga.Log.warning(:editor, "File watcher stopped unexpectedly")
     {:noreply, %__MODULE__{state | watcher: nil}}
   end
 
@@ -189,11 +187,11 @@ defmodule Minga.FileWatcher do
         pid
 
       :ignore ->
-        Logger.warning("File watcher not supported on this platform")
+        Minga.Log.warning(:editor, "File watcher not supported on this platform")
         nil
 
       {:error, reason} ->
-        Logger.error("Failed to start file watcher: #{inspect(reason)}")
+        Minga.Log.error(:editor, "Failed to start file watcher: #{inspect(reason)}")
         nil
     end
   end

--- a/lib/minga/input/global_bindings.ex
+++ b/lib/minga/input/global_bindings.ex
@@ -11,8 +11,6 @@ defmodule Minga.Input.GlobalBindings do
 
   import Bitwise
 
-  require Logger
-
   alias Minga.Buffer.Server, as: BufferServer
 
   alias Minga.Port.Protocol
@@ -27,7 +25,7 @@ defmodule Minga.Input.GlobalBindings do
     if state.buffers.active do
       case BufferServer.save(state.buffers.active) do
         :ok -> :ok
-        {:error, reason} -> Logger.error("Save failed: #{inspect(reason)}")
+        {:error, reason} -> Minga.Log.error(:editor, "Save failed: #{inspect(reason)}")
       end
     end
 

--- a/lib/minga/keymap/active.ex
+++ b/lib/minga/keymap/active.ex
@@ -40,8 +40,6 @@ defmodule Minga.Keymap.Active do
   alias Minga.Keymap.KeyParser
   alias Minga.Keymap.Scope
 
-  require Logger
-
   @typedoc """
   Per-scope, per-vim-state binding overrides from user config.
 
@@ -207,7 +205,7 @@ defmodule Minga.Keymap.Active do
         do_bind(server, mode, keys, command, description)
 
       {:error, reason} ->
-        Logger.warning("Invalid key binding #{inspect(key_str)}: #{reason}")
+        Minga.Log.warning(:config, "Invalid key binding #{inspect(key_str)}: #{reason}")
         {:error, reason}
     end
   end
@@ -279,7 +277,7 @@ defmodule Minga.Keymap.Active do
 
   # Normal mode: unsupported multi-key (not SPC-prefixed)
   defp do_bind(_server, :normal, keys, _command, _description) do
-    Logger.warning("Unsupported key sequence for normal mode: #{inspect(keys)}")
+    Minga.Log.warning(:config, "Unsupported key sequence for normal mode: #{inspect(keys)}")
     {:error, "unsupported key sequence for normal mode"}
   end
 
@@ -306,7 +304,7 @@ defmodule Minga.Keymap.Active do
   end
 
   defp do_bind(_server, mode, _keys, _command, _description) do
-    Logger.warning("Keybinding for mode #{inspect(mode)} not yet supported")
+    Minga.Log.warning(:config, "Keybinding for mode #{inspect(mode)} not yet supported")
     {:error, "keybinding for mode #{inspect(mode)} not yet supported"}
   end
 
@@ -328,7 +326,7 @@ defmodule Minga.Keymap.Active do
         end)
 
       {:error, reason} ->
-        Logger.warning("Invalid key binding #{inspect(key_str)}: #{reason}")
+        Minga.Log.warning(:config, "Invalid key binding #{inspect(key_str)}: #{reason}")
         {:error, reason}
     end
   end

--- a/lib/minga/log.ex
+++ b/lib/minga/log.ex
@@ -14,6 +14,8 @@ defmodule Minga.Log do
   | `:lsp`     | `:log_level_lsp`    | LSP client communication and errors      |
   | `:agent`   | `:log_level_agent`  | AI agent providers and sessions          |
   | `:editor`  | `:log_level_editor` | General editor operations and commands   |
+  | `:config`  | `:log_level_config` | Config loading, hooks, advice, extensions|
+  | `:port`    | `:log_level_port`   | Port/parser process management            |
 
   ## Usage
 
@@ -36,7 +38,7 @@ defmodule Minga.Log do
 
   alias Minga.Config.Options
 
-  @type subsystem :: :render | :lsp | :agent | :editor
+  @type subsystem :: :render | :lsp | :agent | :editor | :config | :port
 
   @type level :: :debug | :info | :warning | :error
 
@@ -52,7 +54,9 @@ defmodule Minga.Log do
     render: :log_level_render,
     lsp: :log_level_lsp,
     agent: :log_level_agent,
-    editor: :log_level_editor
+    editor: :log_level_editor,
+    config: :log_level_config,
+    port: :log_level_port
   }
 
   @doc "Logs a debug message for the given subsystem (if its level permits)."

--- a/lib/minga/lsp/client.ex
+++ b/lib/minga/lsp/client.ex
@@ -33,8 +33,6 @@ defmodule Minga.LSP.Client do
   alias Minga.LSP.JsonRpc
   alias Minga.LSP.PositionEncoding
 
-  require Logger
-
   @request_timeout 30_000
 
   # ── Client API ─────────────────────────────────────────────────────────────
@@ -302,12 +300,16 @@ defmodule Minga.LSP.Client do
   end
 
   def handle_info({port, {:exit_status, code}}, %{port: port} = state) do
-    Logger.warning("LSP server #{state.server_config.name} exited with code #{code}")
+    Minga.Log.warning(:lsp, "LSP server #{state.server_config.name} exited with code #{code}")
     {:stop, {:server_exited, code}, %{state | port: nil, status: :shutdown}}
   end
 
   def handle_info({:EXIT, port, reason}, %{port: port} = state) do
-    Logger.warning("LSP server #{state.server_config.name} port crashed: #{inspect(reason)}")
+    Minga.Log.warning(
+      :lsp,
+      "LSP server #{state.server_config.name} port crashed: #{inspect(reason)}"
+    )
+
     {:stop, {:port_crashed, reason}, %{state | port: nil, status: :shutdown}}
   end
 
@@ -317,7 +319,7 @@ defmodule Minga.LSP.Client do
         {:noreply, state}
 
       {%{from: from, method: method}, pending} ->
-        Logger.warning("LSP request #{method} (id=#{id}) timed out")
+        Minga.Log.warning(:lsp, "LSP request #{method} (id=#{id}) timed out")
         reply_to_caller(from, {:error, :timeout})
         {:noreply, %{state | pending: pending}}
     end
@@ -374,7 +376,7 @@ defmodule Minga.LSP.Client do
   defp handle_response(id, result, state) do
     case Map.pop(state.pending, id) do
       {nil, _pending} ->
-        Logger.warning("Received response for unknown request id=#{id}")
+        Minga.Log.warning(:lsp, "Received response for unknown request id=#{id}")
         state
 
       {%{method: method, from: from, timer: timer}, pending} ->
@@ -401,7 +403,10 @@ defmodule Minga.LSP.Client do
 
     send_notification(state, "initialized", %{})
 
-    Logger.info("LSP server #{state.server_config.name} initialized (encoding: #{encoding})")
+    Minga.Log.info(
+      :lsp,
+      "LSP server #{state.server_config.name} initialized (encoding: #{encoding})"
+    )
 
     notify_subscribers(state.subscribers, {:lsp_ready, state.server_config.name})
 
@@ -409,7 +414,7 @@ defmodule Minga.LSP.Client do
   end
 
   defp handle_method_response("initialize", {:error, error}, _from, state) do
-    Logger.error("LSP initialize failed: #{inspect(error)}")
+    Minga.Log.error(:lsp, "LSP initialize failed: #{inspect(error)}")
     state
   end
 
@@ -465,7 +470,15 @@ defmodule Minga.LSP.Client do
         _ -> :debug
       end
 
-    Logger.log(log_level, "LSP [#{state.server_config.name}]: #{message}")
+    msg = "LSP [#{state.server_config.name}]: #{message}"
+
+    case log_level do
+      :error -> Minga.Log.error(:lsp, msg)
+      :warning -> Minga.Log.warning(:lsp, msg)
+      :info -> Minga.Log.info(:lsp, msg)
+      :debug -> Minga.Log.debug(:lsp, msg)
+    end
+
     state
   end
 

--- a/lib/minga/lsp/supervisor.ex
+++ b/lib/minga/lsp/supervisor.ex
@@ -21,8 +21,6 @@ defmodule Minga.LSP.Supervisor do
   alias Minga.LSP.Client
   alias Minga.LSP.ServerRegistry
 
-  require Logger
-
   # ── Client API ─────────────────────────────────────────────────────────────
 
   @doc "Starts the LSP supervisor."
@@ -139,12 +137,15 @@ defmodule Minga.LSP.Supervisor do
 
       case DynamicSupervisor.start_child(supervisor, child_spec) do
         {:ok, pid} ->
-          Logger.info("Started LSP client #{server_config.name} for #{root_path}")
+          Minga.Log.info(:lsp, "Started LSP client #{server_config.name} for #{root_path}")
 
           {:ok, pid}
 
         {:error, reason} ->
-          Logger.error("Failed to start LSP client #{server_config.name}: #{inspect(reason)}")
+          Minga.Log.error(
+            :lsp,
+            "Failed to start LSP client #{server_config.name}: #{inspect(reason)}"
+          )
 
           {:error, reason}
       end

--- a/lib/minga/parser/manager.ex
+++ b/lib/minga/parser/manager.ex
@@ -24,8 +24,6 @@ defmodule Minga.Parser.Manager do
 
   alias Minga.Port.Protocol
 
-  require Logger
-
   @typedoc "Options for starting the parser manager."
   @type start_opt ::
           {:name, GenServer.name()}
@@ -107,18 +105,18 @@ defmodule Minga.Parser.Manager do
         {:noreply, state}
 
       {:error, reason} ->
-        Logger.warning("Parser: failed to decode event: #{inspect(reason)}")
+        Minga.Log.warning(:port, "Parser: failed to decode event: #{inspect(reason)}")
         {:noreply, state}
     end
   end
 
   def handle_info({port, {:exit_status, 0}}, %{port: port} = state) do
-    Logger.info("Parser process exited normally")
+    Minga.Log.info(:port, "Parser process exited normally")
     {:noreply, %{state | port: nil, ready: false}}
   end
 
   def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
-    Logger.error("Parser process exited with status #{status}")
+    Minga.Log.error(:port, "Parser process exited with status #{status}")
     {:noreply, %{state | port: nil, ready: false}}
   end
 
@@ -144,7 +142,7 @@ defmodule Minga.Parser.Manager do
 
       %{state | port: port, ready: true}
     else
-      Logger.warning("Parser binary not found at #{state.parser_path}")
+      Minga.Log.warning(:port, "Parser binary not found at #{state.parser_path}")
       state
     end
   end

--- a/lib/minga/picker/command_source.ex
+++ b/lib/minga/picker/command_source.ex
@@ -17,8 +17,6 @@ defmodule Minga.Picker.CommandSource do
   alias Minga.Keymap.Defaults
   alias Minga.Picker.OptionScopeSource
 
-  require Logger
-
   @impl true
   @spec title() :: String.t()
   def title, do: "Commands"
@@ -38,7 +36,7 @@ defmodule Minga.Picker.CommandSource do
       |> Enum.sort_by(fn {_id, label, _desc} -> label end)
     catch
       :exit, _ ->
-        Logger.warning("Command registry not available")
+        Minga.Log.warning(:editor, "Command registry not available")
         []
     end
   end

--- a/lib/minga/picker/file_source.ex
+++ b/lib/minga/picker/file_source.ex
@@ -12,8 +12,6 @@ defmodule Minga.Picker.FileSource do
   alias Minga.Editor.State, as: EditorState
   alias Minga.Log
 
-  require Logger
-
   @impl true
   @spec title() :: String.t()
   def title, do: "Find file"
@@ -30,7 +28,7 @@ defmodule Minga.Picker.FileSource do
         end)
 
       {:error, msg} ->
-        Logger.error("find_file: #{msg}")
+        Minga.Log.error(:editor, "find_file: #{msg}")
         []
     end
   end
@@ -50,7 +48,7 @@ defmodule Minga.Picker.FileSource do
             EditorState.add_buffer(state, pid)
 
           {:error, reason} ->
-            Logger.error("Failed to open file: #{inspect(reason)}")
+            Minga.Log.error(:editor, "Failed to open file: #{inspect(reason)}")
             state
         end
 
@@ -97,11 +95,11 @@ defmodule Minga.Picker.FileSource do
 
     case File.rm(abs_path) do
       :ok ->
-        Logger.info("Deleted file: #{abs_path}")
+        Minga.Log.info(:editor, "Deleted file: #{abs_path}")
         state
 
       {:error, reason} ->
-        Logger.error("Failed to delete file: #{inspect(reason)}")
+        Minga.Log.error(:editor, "Failed to delete file: #{inspect(reason)}")
         state
     end
   end

--- a/lib/minga/picker/project_search_source.ex
+++ b/lib/minga/picker/project_search_source.ex
@@ -11,8 +11,6 @@ defmodule Minga.Picker.ProjectSearchSource do
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.State, as: EditorState
 
-  require Logger
-
   @impl true
   @spec title() :: String.t()
   def title, do: "Search project"
@@ -68,7 +66,7 @@ defmodule Minga.Picker.ProjectSearchSource do
         new_state
 
       {:error, reason} ->
-        Logger.error("Failed to open file: #{inspect(reason)}")
+        Minga.Log.error(:editor, "Failed to open file: #{inspect(reason)}")
         state
     end
   end

--- a/lib/minga/picker/recent_file_source.ex
+++ b/lib/minga/picker/recent_file_source.ex
@@ -12,8 +12,6 @@ defmodule Minga.Picker.RecentFileSource do
   alias Minga.Editor.State, as: EditorState
   alias Minga.Project
 
-  require Logger
-
   @impl true
   @spec title() :: String.t()
   def title, do: "Recent files"
@@ -48,7 +46,7 @@ defmodule Minga.Picker.RecentFileSource do
             EditorState.add_buffer(state, pid)
 
           {:error, reason} ->
-            Logger.error("Failed to open file: #{inspect(reason)}")
+            Minga.Log.error(:editor, "Failed to open file: #{inspect(reason)}")
             state
         end
 

--- a/lib/minga/port/manager.ex
+++ b/lib/minga/port/manager.ex
@@ -19,8 +19,6 @@ defmodule Minga.Port.Manager do
 
   alias Minga.Port.Protocol
 
-  require Logger
-
   @typedoc "Renderer backend."
   @type backend :: :tui | :gui
 
@@ -168,20 +166,24 @@ defmodule Minga.Port.Manager do
         {:noreply, state}
 
       {:error, reason} ->
-        Logger.warning("Failed to decode event: #{inspect(reason)}, data: #{inspect(data)}")
+        Minga.Log.warning(
+          :port,
+          "Failed to decode event: #{inspect(reason)}, data: #{inspect(data)}"
+        )
+
         {:noreply, state}
     end
   end
 
   def handle_info({port, {:exit_status, 0}}, %{port: port} = state) do
-    Logger.info("Zig renderer exited normally")
+    Minga.Log.info(:port, "Zig renderer exited normally")
     Minga.Editor.log_to_messages("Renderer: exited normally")
     maybe_stop_system(0)
     {:noreply, %{state | port: nil, ready: false}}
   end
 
   def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
-    Logger.error("Zig renderer exited with status #{status}")
+    Minga.Log.error(:port, "Zig renderer exited with status #{status}")
     Minga.Editor.log_to_messages("Renderer: crashed (exit #{status})")
     maybe_stop_system(1)
     {:noreply, %{state | port: nil, ready: false}}

--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -29,8 +29,6 @@ defmodule Minga.Project do
   alias Minga.Config.Options, as: ConfigOptions
   alias Minga.Project.Detector
 
-  require Logger
-
   @enforce_keys []
   defstruct current_root: nil,
             project_type: nil,
@@ -205,7 +203,7 @@ defmodule Minga.Project do
 
       {:noreply, state}
     else
-      Logger.warning("Project.switch: directory not found: #{expanded}")
+      Minga.Log.warning(:editor, "Project.switch: directory not found: #{expanded}")
       {:noreply, state}
     end
   end
@@ -222,7 +220,7 @@ defmodule Minga.Project do
       state = add_to_known(state, expanded)
       {:noreply, state}
     else
-      Logger.warning("Project.add: directory not found: #{expanded}")
+      Minga.Log.warning(:editor, "Project.add: directory not found: #{expanded}")
       {:noreply, state}
     end
   end
@@ -275,7 +273,7 @@ defmodule Minga.Project do
 
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{rebuild_ref: ref} = state) do
     if reason != :normal do
-      Logger.warning("Project file cache rebuild failed: #{inspect(reason)}")
+      Minga.Log.warning(:editor, "Project file cache rebuild failed: #{inspect(reason)}")
     end
 
     {:noreply, %{state | rebuilding?: false, rebuild_ref: nil}}
@@ -378,7 +376,7 @@ defmodule Minga.Project do
     :ok
   rescue
     e ->
-      Logger.warning("Failed to persist known projects: #{Exception.message(e)}")
+      Minga.Log.warning(:editor, "Failed to persist known projects: #{Exception.message(e)}")
       :ok
   end
 
@@ -437,7 +435,7 @@ defmodule Minga.Project do
     :ok
   rescue
     e ->
-      Logger.warning("Failed to persist recent files: #{Exception.message(e)}")
+      Minga.Log.warning(:editor, "Failed to persist recent files: #{Exception.message(e)}")
       :ok
   end
 end

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -62,7 +62,9 @@ defmodule Minga.Config.OptionsTest do
                log_level_render: :default,
                log_level_lsp: :default,
                log_level_agent: :default,
-               log_level_editor: :default
+               log_level_editor: :default,
+               log_level_config: :default,
+               log_level_port: :default
              }
     end
   end


### PR DESCRIPTION
## What

Replaces ~80 direct `Logger.{debug,info,warning,error}` calls across 30 files with `Minga.Log` calls routed through per-subsystem log level filtering. This eliminates all Logger-related credo violations.

## Why

Direct Logger calls bypass the per-subsystem log level filtering that `Minga.Log` provides. Users couldn't selectively enable/disable debug output for specific subsystems (e.g., turn on `:lsp` debug logs without drowning in render noise).

## Changes

**New subsystems** added to `Minga.Log` and `Minga.Config.Options`:
- `:config` — config loading, hooks, advice, extensions, keybindings
- `:port` — Zig renderer and tree-sitter parser port management

**Subsystem assignments across all files:**
| Subsystem | Files |
|-----------|-------|
| `:agent` | agent providers, sessions, lifecycle, agent commands |
| `:lsp` | LSP client and supervisor |
| `:config` | config DSL, loader, hooks, advice, extensions, keymaps |
| `:port` | port/manager, parser/manager |
| `:editor` | CLI, buffer lifecycle, buffer commands, pickers, project, file watcher, startup |

**Cleanup:** removed all unused `require Logger` statements from application code.

## Verification

- `mix compile --warnings-as-errors` — clean
- `mix credo --strict` — zero Logger violations (was ~80)
- `mix test --warnings-as-errors` — 3945 tests, 0 failures
- `mix dialyzer` — 0 errors