### PR TITLE
feat(agent): dedicated find/glob tool for file discovery

### DIFF
--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -641,13 +641,14 @@ defmodule Minga.Agent.Providers.Native do
     - write_file: Create or overwrite files (creates parent directories automatically)
     - edit_file: Make surgical edits (find exact text and replace). Read the file first to get exact text.
     - list_directory: List files and directories at a path
+    - find: Find files by name or glob pattern. Prefer this over shell + find.
     - grep: Search file contents for a pattern. Returns file:line:content. Prefer this over shell + grep.
     - shell: Run shell commands in the project root
 
     ## Guidelines
 
     - Read files before editing them. The old_text in edit_file must match exactly.
-    - Use grep to search for code patterns, function definitions, imports, etc.
+    - Use find to discover files by name or extension, and grep to search file contents.
     - Use shell for running tests, linters, git commands, etc.
     - Be concise and direct. Show file paths clearly when working with files.
     - When you make changes, verify them by reading the result or running tests.

--- a/lib/minga/agent/tools.ex
+++ b/lib/minga/agent/tools.ex
@@ -15,10 +15,13 @@ defmodule Minga.Agent.Tools do
   | `write_file`     | Write content to a file (creates or overwrites) |
   | `edit_file`      | Replace exact text in a file                    |
   | `list_directory` | List files and directories at a path            |
+  | `find`           | Find files by name/glob pattern                 |
+  | `grep`           | Search file contents for a pattern              |
   | `shell`          | Run a shell command in the project root         |
   """
 
   alias Minga.Agent.Tools.EditFile
+  alias Minga.Agent.Tools.Find
   alias Minga.Agent.Tools.Grep
   alias Minga.Agent.Tools.ListDirectory
   alias Minga.Agent.Tools.ReadFile
@@ -70,6 +73,7 @@ defmodule Minga.Agent.Tools do
       write_file(root),
       edit_file(root),
       list_directory(root),
+      find(root),
       grep(root),
       shell(root)
     ]
@@ -188,6 +192,46 @@ defmodule Minga.Agent.Tools do
       callback: fn args ->
         path = resolve_and_validate_path!(root, args["path"])
         ListDirectory.execute(path)
+      end
+    )
+  end
+
+  @spec find(String.t()) :: Tool.t()
+  defp find(root) do
+    Tool.new!(
+      name: "find",
+      description: """
+      Find files and directories by name pattern (glob). Returns a sorted list
+      of matching paths relative to the project root. Use this to discover files
+      by name or extension. The tool is read-only and does not require approval.
+      """,
+      parameter_schema: %{
+        "type" => "object",
+        "properties" => %{
+          "pattern" => %{
+            "type" => "string",
+            "description" => "Glob pattern to match, e.g. \"*.ex\", \"test_*.exs\", \"Makefile\""
+          },
+          "path" => %{
+            "type" => "string",
+            "description" =>
+              "Directory to search in, relative to the project root. Defaults to the project root."
+          },
+          "type" => %{
+            "type" => "string",
+            "enum" => ["file", "directory", "any"],
+            "description" => "Type of entries to find (default: \"file\")"
+          },
+          "max_depth" => %{
+            "type" => "integer",
+            "description" => "Maximum directory depth to search (default: 10)"
+          }
+        },
+        "required" => ["pattern"]
+      },
+      callback: fn args ->
+        search_path = resolve_and_validate_path!(root, args["path"] || ".")
+        Find.execute(args["pattern"], search_path, args)
       end
     )
   end

--- a/lib/minga/agent/tools/find.ex
+++ b/lib/minga/agent/tools/find.ex
@@ -1,0 +1,114 @@
+defmodule Minga.Agent.Tools.Find do
+  @moduledoc """
+  Structured file discovery tool for the native agent provider.
+
+  Prefers `fd` if available on the system, falls back to `find`.
+  Output is a sorted list of matching paths relative to the search
+  directory, truncated at a configurable limit.
+  """
+
+  @max_results 200
+
+  @doc """
+  Searches for files matching `pattern` under `path`.
+
+  Options:
+  - `type` — `"file"`, `"directory"`, or `"any"` (default: `"file"`)
+  - `max_depth` — maximum directory depth (default: 10)
+
+  Returns a sorted list of matching paths, one per line.
+  """
+  @spec execute(String.t(), String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
+  def execute(pattern, path, opts \\ %{}) when is_binary(pattern) and is_binary(path) do
+    type = Map.get(opts, "type", "file")
+    max_depth = Map.get(opts, "max_depth", 10)
+
+    {cmd, args} = build_command(pattern, path, type, max_depth)
+
+    case System.cmd(cmd, args, stderr_to_stdout: true, cd: path) do
+      {output, 0} ->
+        if String.trim(output) == "" do
+          {:ok, "No matches found."}
+        else
+          {:ok, format_output(output)}
+        end
+
+      {output, 1} ->
+        # Exit code 1 means no matches for fd/find
+        trimmed = String.trim(output)
+
+        if trimmed == "" do
+          {:ok, "No matches found."}
+        else
+          {:ok, format_output(output)}
+        end
+
+      {output, _code} ->
+        {:error, "Find failed: #{String.trim(output)}"}
+    end
+  rescue
+    e in ErlangError ->
+      {:error, "Find command not found: #{Exception.message(e)}"}
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec build_command(String.t(), String.t(), String.t(), non_neg_integer()) ::
+          {String.t(), [String.t()]}
+  defp build_command(pattern, _path, type, max_depth) do
+    case System.find_executable("fd") do
+      nil -> build_find_command(pattern, type, max_depth)
+      fd -> build_fd_command(fd, pattern, type, max_depth)
+    end
+  end
+
+  @spec build_fd_command(String.t(), String.t(), String.t(), non_neg_integer()) ::
+          {String.t(), [String.t()]}
+  defp build_fd_command(fd, pattern, type, max_depth) do
+    args = ["--color", "never", "--glob", "--max-depth", Integer.to_string(max_depth)]
+
+    args =
+      case type do
+        "file" -> args ++ ["--type", "f"]
+        "directory" -> args ++ ["--type", "d"]
+        _ -> args
+      end
+
+    args = args ++ ["--max-results", Integer.to_string(@max_results), pattern, "."]
+    {fd, args}
+  end
+
+  @spec build_find_command(String.t(), String.t(), non_neg_integer()) ::
+          {String.t(), [String.t()]}
+  defp build_find_command(pattern, type, max_depth) do
+    find = System.find_executable("find") || "find"
+
+    args = [".", "-maxdepth", Integer.to_string(max_depth)]
+
+    args =
+      case type do
+        "file" -> args ++ ["-type", "f"]
+        "directory" -> args ++ ["-type", "d"]
+        _ -> args
+      end
+
+    # Use -name for glob matching
+    args = args ++ ["-name", pattern]
+    {find, args}
+  end
+
+  @spec format_output(String.t()) :: String.t()
+  defp format_output(output) do
+    lines =
+      output
+      |> String.split("\n", trim: true)
+      |> Enum.sort()
+
+    if length(lines) > @max_results do
+      truncated = Enum.take(lines, @max_results) |> Enum.join("\n")
+      truncated <> "\n\n... (truncated, #{length(lines) - @max_results} more results)"
+    else
+      Enum.join(lines, "\n")
+    end
+  end
+end

--- a/test/minga/agent/tools/find_test.exs
+++ b/test/minga/agent/tools/find_test.exs
@@ -1,0 +1,60 @@
+defmodule Minga.Agent.Tools.FindTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Agent.Tools.Find
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: dir} do
+    File.write!(Path.join(dir, "hello.ex"), "defmodule Hello")
+    File.write!(Path.join(dir, "world.ex"), "defmodule World")
+    File.write!(Path.join(dir, "README.md"), "# Readme")
+    File.mkdir_p!(Path.join(dir, "lib"))
+    File.write!(Path.join([dir, "lib", "app.ex"]), "defmodule App")
+    File.mkdir_p!(Path.join([dir, "lib", "sub"]))
+    File.write!(Path.join([dir, "lib", "sub", "nested.ex"]), "defmodule Nested")
+
+    %{dir: dir}
+  end
+
+  describe "execute/3" do
+    test "finds files matching a glob pattern", %{dir: dir} do
+      assert {:ok, output} = Find.execute("*.ex", dir)
+      assert output =~ "hello.ex"
+      assert output =~ "world.ex"
+      refute output =~ "README.md"
+    end
+
+    test "finds files in subdirectories", %{dir: dir} do
+      assert {:ok, output} = Find.execute("*.ex", dir)
+      assert output =~ "nested.ex"
+    end
+
+    test "returns no matches message when nothing found", %{dir: dir} do
+      assert {:ok, "No matches found."} = Find.execute("*.xyz", dir)
+    end
+
+    test "finds directories when type is directory", %{dir: dir} do
+      assert {:ok, output} = Find.execute("sub", dir, %{"type" => "directory"})
+      assert output =~ "sub"
+    end
+
+    test "respects max_depth", %{dir: dir} do
+      assert {:ok, output} = Find.execute("*.ex", dir, %{"max_depth" => 1})
+      assert output =~ "hello.ex"
+      refute output =~ "nested.ex"
+    end
+
+    test "results are sorted", %{dir: dir} do
+      assert {:ok, output} = Find.execute("*.ex", dir)
+      lines = String.split(output, "\n", trim: true)
+      assert lines == Enum.sort(lines)
+    end
+
+    test "returns error for invalid path", %{dir: dir} do
+      bad_path = Path.join(dir, "nonexistent_dir")
+      result = Find.execute("*.ex", bad_path)
+      assert {:error, _} = result
+    end
+  end
+end

--- a/test/minga/agent/tools_test.exs
+++ b/test/minga/agent/tools_test.exs
@@ -35,15 +35,16 @@ defmodule Minga.Agent.ToolsTest do
   end
 
   describe "all/1" do
-    test "returns a list of six tools", %{tmp_dir: dir} do
+    test "returns a list of seven tools", %{tmp_dir: dir} do
       tools = Tools.all(project_root: dir)
-      assert length(tools) == 6
+      assert length(tools) == 7
 
       names = Enum.map(tools, & &1.name)
       assert "read_file" in names
       assert "write_file" in names
       assert "edit_file" in names
       assert "list_directory" in names
+      assert "find" in names
       assert "grep" in names
       assert "shell" in names
     end


### PR DESCRIPTION
## What

Adds a structured `find` tool so the agent can discover files by name or glob pattern without shelling out.

## Why

File discovery is the first thing an agent does when exploring a codebase. The shell tool works but triggers the approval prompt (destructive), and models frequently get `find` flags wrong. A dedicated read-only tool with structured parameters (pattern, path, type, max_depth) is consistent, approval-free, and harder to misuse.

## Changes

- **`Tools.Find`** (new): Glob-based file discovery using `fd` (preferred) or `find` (fallback). Supports file/directory/any type filtering and max depth. Output sorted and truncated at 200 results.
- **`Tools`**: Registered as 7th tool, classified as non-destructive.
- **`Providers.Native`**: System prompt updated to mention find and guide usage.
- **Tests**: 7 new tests covering glob matching, subdirectories, no matches, directory type, max_depth, sort order, and error handling.

Closes #279