### PR TITLE
feat(agent): route chat navigation through Mode FSM via AgentChatNav

### DIFF
--- a/lib/minga/editor/commands.ex
+++ b/lib/minga/editor/commands.ex
@@ -165,12 +165,9 @@ defmodule Minga.Editor.Commands do
   def execute(state, :agent_cycle_thinking), do: AgentCommands.cycle_thinking_level(state)
 
   # ── Agent scope commands (dispatched via keymap scope resolution) ──────────
-  def execute(state, :agent_scroll_down), do: AgentCommands.scope_scroll_down(state)
-  def execute(state, :agent_scroll_up), do: AgentCommands.scope_scroll_up(state)
-  def execute(state, :agent_scroll_half_down), do: AgentCommands.scope_scroll_half_down(state)
-  def execute(state, :agent_scroll_half_up), do: AgentCommands.scope_scroll_half_up(state)
-  def execute(state, :agent_scroll_bottom), do: AgentCommands.scope_scroll_bottom(state)
-  def execute(state, :agent_scroll_top), do: AgentCommands.scope_scroll_top(state)
+  # Chat scroll commands (:agent_scroll_*) removed. Navigation keys (j, k,
+  # Ctrl-D, Ctrl-U, G, gg) now pass through the scope trie to AgentChatNav,
+  # which routes them through the Mode FSM against the *Agent* buffer.
   def execute(state, :agent_toggle_collapse), do: AgentCommands.scope_toggle_collapse(state)
 
   def execute(state, :agent_toggle_all_collapse),

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -518,72 +518,6 @@ defmodule Minga.Editor.Commands.Agent do
   # scope resolution system. Focus-aware commands check state.agentic.focus to
   # route to the correct panel (chat vs file viewer).
 
-  # ── Navigation ─────────────────────────────────────────────────────────────
-
-  @doc "Scrolls down 1 line in the focused panel."
-  @spec scope_scroll_down(state()) :: state()
-  def scope_scroll_down(state) do
-    if AgentAccess.agentic(state).focus == :file_viewer do
-      update_agentic(state, &ViewState.scroll_viewer_down(&1, 1))
-    else
-      update_agent(state, &AgentState.scroll_down(&1, 1))
-    end
-  end
-
-  @doc "Scrolls up 1 line in the focused panel."
-  @spec scope_scroll_up(state()) :: state()
-  def scope_scroll_up(state) do
-    if AgentAccess.agentic(state).focus == :file_viewer do
-      update_agentic(state, &ViewState.scroll_viewer_up(&1, 1))
-    else
-      update_agent(state, &AgentState.scroll_up(&1, 1))
-    end
-  end
-
-  @doc "Scrolls down half a page in the focused panel."
-  @spec scope_scroll_half_down(state()) :: state()
-  def scope_scroll_half_down(state) do
-    amount = half_page(state)
-
-    if AgentAccess.agentic(state).focus == :file_viewer do
-      update_agentic(state, &ViewState.scroll_viewer_down(&1, amount))
-    else
-      update_agent(state, &AgentState.scroll_down(&1, amount))
-    end
-  end
-
-  @doc "Scrolls up half a page in the focused panel."
-  @spec scope_scroll_half_up(state()) :: state()
-  def scope_scroll_half_up(state) do
-    amount = half_page(state)
-
-    if AgentAccess.agentic(state).focus == :file_viewer do
-      update_agentic(state, &ViewState.scroll_viewer_up(&1, amount))
-    else
-      update_agent(state, &AgentState.scroll_up(&1, amount))
-    end
-  end
-
-  @doc "Scrolls to the bottom of the focused panel."
-  @spec scope_scroll_bottom(state()) :: state()
-  def scope_scroll_bottom(state) do
-    if AgentAccess.agentic(state).focus == :file_viewer do
-      update_agentic(state, &ViewState.scroll_viewer_to_bottom/1)
-    else
-      update_agent(state, &AgentState.scroll_to_bottom/1)
-    end
-  end
-
-  @doc "Scrolls to the top of the focused panel."
-  @spec scope_scroll_top(state()) :: state()
-  def scope_scroll_top(state) do
-    if AgentAccess.agentic(state).focus == :file_viewer do
-      update_agentic(state, &ViewState.scroll_viewer_to_top/1)
-    else
-      update_agent(state, &AgentState.scroll_to_top/1)
-    end
-  end
-
   # ── Fold / Collapse ────────────────────────────────────────────────────────
 
   @doc "Toggles collapse at cursor (currently toggles all)."
@@ -955,9 +889,6 @@ defmodule Minga.Editor.Commands.Agent do
   defp panel_height(state) do
     div(state.viewport.rows * 35, 100)
   end
-
-  @spec half_page(state()) :: pos_integer()
-  defp half_page(state), do: max(div(state.viewport.rows, 2), 1)
 
   @spec abort_if_active(state()) :: state()
   defp abort_if_active(state) do

--- a/lib/minga/input.ex
+++ b/lib/minga/input.ex
@@ -18,6 +18,7 @@ defmodule Minga.Input do
   `surface_handlers/0` to build the split dispatch.
   """
 
+  alias Minga.Input.AgentChatNav
   alias Minga.Input.AgentPanel
   alias Minga.Input.AgentSearch
   alias Minga.Input.Completion
@@ -94,6 +95,7 @@ defmodule Minga.Input do
       AgentPanel,
       FileTreeHandler,
       Scoped,
+      AgentChatNav,
       GlobalBindings,
       ModeFSM
     ]

--- a/lib/minga/input/agent_chat_nav.ex
+++ b/lib/minga/input/agent_chat_nav.ex
@@ -1,0 +1,175 @@
+defmodule Minga.Input.AgentChatNav do
+  @moduledoc """
+  Input handler for vim navigation of agent chat content.
+
+  Sits after `Scoped` in the handler chain. When the agentic view is
+  active and the prompt input is not focused, this handler routes keys
+  through the standard Mode FSM against the agent's `*Agent*` buffer.
+  This gives chat navigation the full vim grammar (motions, counts,
+  search, text objects, visual selection for yank) for free.
+
+  Domain-specific bindings (toggle collapse, copy code block, focus
+  input, session switcher, etc.) are handled by the agent scope trie
+  in `Scoped`, which runs earlier in the chain. Only keys that the
+  scope trie doesn't claim reach this handler.
+
+  After the Mode FSM processes the key, the buffer cursor position is
+  synced to the chat scroll offset so the renderer shows the correct
+  region.
+
+  ## Why a separate handler (not inline in Scoped)
+
+  The scope trie and Mode FSM are two independent key dispatch systems.
+  Mixing them in a single handler creates prefix collisions (`g` is a
+  prefix in both) and forces reimplementation of vim commands as scope
+  bindings. Separating them keeps each system focused:
+
+  - Scope trie: domain commands only (collapse, copy, focus, session)
+  - Mode FSM: all vim navigation (motions, search, counts, dot repeat)
+
+  ## Why buffer swap (not a structured NavigableContent adapter)
+
+  The `*Agent*` buffer already contains the chat content as markdown,
+  synced by `BufferSync`. Using it for navigation gives us all vim
+  motions, search, and counts immediately. A structured ChatSnapshot
+  adapter is the next evolution: when built, this handler's internals
+  change (swap `do_handle_key` for NavigableContent dispatch) but its
+  position in the handler chain and its API remain the same.
+
+  ## Editor scope side panel
+
+  The side panel (`AgentPanel`, keymap_scope: :editor) uses the same
+  `delegate_to_mode_fsm/4` function for its chat navigation. Both
+  paths share the buffer-swap-and-sync pattern.
+  """
+
+  @behaviour Minga.Input.Handler
+
+  import Bitwise
+
+  alias Minga.Agent.View.State, as: ViewState
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.AgentAccess
+  alias Minga.Mode
+
+  @impl true
+  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          Minga.Input.Handler.result()
+  def handle_key(%{keymap_scope: :agent} = state, cp, mods) do
+    panel = AgentAccess.panel(state)
+
+    if panel.input_focused do
+      {:passthrough, state}
+    else
+      agentic = AgentAccess.agentic(state)
+
+      case agentic.focus do
+        :chat -> handle_chat_nav(state, cp, mods)
+        :file_viewer -> handle_viewer_nav(state, cp, mods)
+      end
+    end
+  end
+
+  def handle_key(state, _cp, _mods), do: {:passthrough, state}
+
+  # ── Chat navigation ─────────────────────────────────────────────────────
+
+  @spec handle_chat_nav(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          Minga.Input.Handler.result()
+  defp handle_chat_nav(state, cp, mods) do
+    agent = AgentAccess.agent(state)
+
+    if is_pid(agent.buffer) and Process.alive?(agent.buffer) do
+      {:handled, delegate_to_mode_fsm(state, agent.buffer, cp, mods)}
+    else
+      {:passthrough, state}
+    end
+  end
+
+  # ── File viewer navigation ─────────────────────────────────────────────
+
+  # The file viewer is a preview pane with its own scroll state, not a
+  # buffer with a cursor. Navigation keys scroll the preview.
+  @spec handle_viewer_nav(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          Minga.Input.Handler.result()
+  defp handle_viewer_nav(state, cp, mods) do
+    case viewer_nav_command(cp, mods) do
+      {:scroll, fun} ->
+        {:handled, AgentAccess.update_agentic(state, fun)}
+
+      :passthrough ->
+        {:passthrough, state}
+    end
+  end
+
+  @ctrl Minga.Port.Protocol.mod_ctrl()
+
+  @spec viewer_nav_command(non_neg_integer(), non_neg_integer()) ::
+          {:scroll, (ViewState.t() -> ViewState.t())} | :passthrough
+  defp viewer_nav_command(?j, 0), do: {:scroll, &ViewState.scroll_viewer_down(&1, 1)}
+  defp viewer_nav_command(?k, 0), do: {:scroll, &ViewState.scroll_viewer_up(&1, 1)}
+
+  defp viewer_nav_command(?d, mods) when band(mods, @ctrl) != 0,
+    do: {:scroll, &ViewState.scroll_viewer_down(&1, 10)}
+
+  defp viewer_nav_command(?u, mods) when band(mods, @ctrl) != 0,
+    do: {:scroll, &ViewState.scroll_viewer_up(&1, 10)}
+
+  defp viewer_nav_command(?G, 0), do: {:scroll, &ViewState.scroll_viewer_to_bottom/1}
+  defp viewer_nav_command(_cp, _mods), do: :passthrough
+
+  # ── Shared dispatch ─────────────────────────────────────────────────────
+
+  @doc """
+  Routes a key through the Mode FSM against the given buffer.
+
+  Swaps `buffers.active` to the target buffer, runs through
+  `do_handle_key` (Mode FSM + full KeyDispatch pipeline including
+  counts, dot repeat, macros), blocks mode transitions to insert
+  (chat is read-only, always normal mode), syncs the buffer cursor
+  to the chat scroll offset, and restores the original active buffer.
+
+  Used by both `AgentChatNav` (agentic view) and `AgentPanel` (side
+  panel) for chat navigation.
+  """
+  @spec delegate_to_mode_fsm(
+          EditorState.t(),
+          pid(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: EditorState.t()
+  def delegate_to_mode_fsm(state, chat_buffer, cp, mods) do
+    real_active = state.buffers.active
+    state = put_in(state.buffers.active, chat_buffer)
+
+    state = Minga.Editor.do_handle_key(state, cp, mods)
+
+    # Block mode transitions: chat content is read-only, always normal mode.
+    # The Mode FSM may try to enter insert/visual/etc. from vim keys that
+    # the scope trie didn't intercept. Reset to normal.
+    state =
+      if state.mode != :normal do
+        %{state | mode: :normal, mode_state: Mode.initial_state()}
+      else
+        state
+      end
+
+    # Sync buffer cursor to chat scroll offset so the renderer shows the
+    # region around the cursor. Unpins auto-scroll since the user is
+    # navigating manually.
+    {cursor_line, _col} = BufferServer.cursor(chat_buffer)
+    state = sync_scroll_to_cursor(state, cursor_line)
+
+    put_in(state.buffers.active, real_active)
+  end
+
+  @spec sync_scroll_to_cursor(EditorState.t(), non_neg_integer()) :: EditorState.t()
+  defp sync_scroll_to_cursor(state, cursor_line) do
+    AgentAccess.update_agent(state, fn agent ->
+      panel = agent.panel
+      scroll = %{panel.scroll | offset: cursor_line, pinned: false}
+      %{agent | panel: %{panel | scroll: scroll}}
+    end)
+  end
+end

--- a/lib/minga/input/agent_panel.ex
+++ b/lib/minga/input/agent_panel.ex
@@ -26,6 +26,7 @@ defmodule Minga.Input.AgentPanel do
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.AgentAccess
+  alias Minga.Input.AgentChatNav
   alias Minga.Keymap.Scope
   alias Minga.Port.Protocol
 
@@ -252,27 +253,16 @@ defmodule Minga.Input.AgentPanel do
     end
   end
 
-  # Swaps the active buffer to the agent buffer, runs the key through the
-  # mode FSM, blocks mode transitions, and restores the real buffer.
-  # Used for panel nav mode (vim navigation of chat content).
+  # Delegates to the shared AgentChatNav dispatch, which swaps the active
+  # buffer to the agent buffer, runs through Mode FSM, blocks mode
+  # transitions, syncs cursor to scroll, and restores the original buffer.
   @spec delegate_to_mode_fsm(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           EditorState.t()
   defp delegate_to_mode_fsm(state, cp, mods) do
     buf = AgentAccess.agent(state).buffer
 
-    if is_pid(buf) do
-      real_active = state.buffers.active
-      state = put_in(state.buffers.active, buf)
-      state = Minga.Editor.do_handle_key(state, cp, mods)
-
-      state =
-        if state.mode != :normal do
-          %{state | mode: :normal, mode_state: Minga.Mode.initial_state()}
-        else
-          state
-        end
-
-      put_in(state.buffers.active, real_active)
+    if is_pid(buf) and Process.alive?(buf) do
+      AgentChatNav.delegate_to_mode_fsm(state, buf, cp, mods)
     else
       state
     end

--- a/lib/minga/input/scoped.ex
+++ b/lib/minga/input/scoped.ex
@@ -210,8 +210,9 @@ defmodule Minga.Input.Scoped do
              band(mods, @alt) == 0 do
           handle_agent_self_insert(state, cp, mods)
         else
-          # Not handled by scope, swallow the key
-          {:handled, state}
+          # Not handled by scope. Pass through so AgentChatNav can route
+          # the key through the Mode FSM against the agent buffer.
+          {:passthrough, state}
         end
     end
   end

--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -71,31 +71,41 @@ defmodule Minga.Keymap.Scope.Agent do
   @spec normal_trie() :: Bindings.node_t()
   defp normal_trie do
     Bindings.new()
-    # Navigation
-    |> Bindings.bind([{?j, 0}], :agent_scroll_down, "Scroll down")
-    |> Bindings.bind([{?k, 0}], :agent_scroll_up, "Scroll up")
-    |> Bindings.bind([{?d, @ctrl}], :agent_scroll_half_down, "Scroll half page down")
-    |> Bindings.bind([{?u, @ctrl}], :agent_scroll_half_up, "Scroll half page up")
-    |> Bindings.bind([{?G, 0}], :agent_scroll_bottom, "Scroll to bottom")
-    # g-prefix
-    |> Bindings.bind([{?g, 0}, {?g, 0}], :agent_scroll_top, "Scroll to top")
+    #
+    # Navigation keys (j, k, w, b, e, G, Ctrl-D, Ctrl-U, /, n, N, etc.)
+    # are NOT bound here. They pass through to AgentChatNav, which routes
+    # them through the Mode FSM against the *Agent* buffer. This gives
+    # chat navigation the full vim grammar for free.
+    #
+    # Only DOMAIN-SPECIFIC commands live in this trie: collapse, copy,
+    # focus, session, panel management.
+    #
+    # PREFIX RULE: every prefix key claimed by this trie (g, z, ], [)
+    # must have ALL reasonable sub-bindings defined. Standard vim commands
+    # map to their Mode FSM command atoms. Domain commands map to agent-
+    # specific atoms. No sub-binding falls through, because the prefix
+    # key was consumed by the trie and the Mode FSM never saw it.
+    #
+    # g-prefix: domain + vim standard commands
+    |> Bindings.bind([{?g, 0}, {?g, 0}], :move_to_document_start, "Go to top")
     |> Bindings.bind([{?g, 0}, {?f, 0}], :agent_open_code_block, "Open code block in editor")
-    # z-prefix (fold/collapse)
+    |> Bindings.bind([{?g, 0}, {?d, 0}], :goto_definition, "Go to definition")
+    # z-prefix: domain fold/collapse commands
     |> Bindings.bind([{?z, 0}, {?a, 0}], :agent_toggle_collapse, "Toggle collapse at cursor")
     |> Bindings.bind([{?z, 0}, {?A, 0}], :agent_toggle_all_collapse, "Toggle all collapses")
     |> Bindings.bind([{?z, 0}, {?o, 0}], :agent_expand_at_cursor, "Expand at cursor")
     |> Bindings.bind([{?z, 0}, {?c, 0}], :agent_collapse_at_cursor, "Collapse at cursor")
     |> Bindings.bind([{?z, 0}, {?M, 0}], :agent_collapse_all, "Collapse all")
     |> Bindings.bind([{?z, 0}, {?R, 0}], :agent_expand_all, "Expand all")
-    # ]-prefix (next item)
+    # ]-prefix: semantic navigation (domain-specific)
     |> Bindings.bind([{?], 0}, {?m, 0}], :agent_next_message, "Next message")
     |> Bindings.bind([{?], 0}, {?c, 0}], :agent_next_code_block, "Next code block/hunk")
     |> Bindings.bind([{?], 0}, {?t, 0}], :agent_next_tool_call, "Next tool call")
-    # [-prefix (prev item)
+    # [-prefix: semantic navigation (domain-specific)
     |> Bindings.bind([{?[, 0}, {?m, 0}], :agent_prev_message, "Previous message")
     |> Bindings.bind([{?[, 0}, {?c, 0}], :agent_prev_code_block, "Previous code block/hunk")
     |> Bindings.bind([{?[, 0}, {?t, 0}], :agent_prev_tool_call, "Previous tool call")
-    # Copy
+    # Copy (domain: structured copy, not raw yank)
     |> Bindings.bind([{?y, 0}], :agent_copy_code_block, "Copy code block")
     |> Bindings.bind([{?Y, 0}], :agent_copy_message, "Copy full message")
     # Input focus
@@ -109,7 +119,7 @@ defmodule Minga.Keymap.Scope.Agent do
     |> Bindings.bind([{?{, 0}], :agent_shrink_panel, "Shrink chat panel")
     |> Bindings.bind([{?=, 0}], :agent_reset_panel, "Reset panel split")
     |> Bindings.bind([{@tab, 0}], :agent_switch_focus, "Switch panel focus")
-    # Search
+    # Search (agent-specific: searches structured messages, not buffer text)
     |> Bindings.bind([{?/, 0}], :agent_start_search, "Search")
     |> Bindings.bind([{?n, 0}], :agent_next_search_match, "Next search match")
     |> Bindings.bind([{?N, 0}], :agent_prev_search_match, "Previous search match")

--- a/test/minga/input/scoped_test.exs
+++ b/test/minga/input/scoped_test.exs
@@ -212,21 +212,22 @@ defmodule Minga.Input.ScopedTest do
       {:ok, state: base_state(keymap_scope: :agent, agentic_active: true)}
     end
 
-    test "j scrolls down", %{state: state} do
-      assert {:handled, new_state} = Scoped.handle_key(state, ?j, 0)
-
-      assert AgentAccess.panel(new_state).scroll.offset != AgentAccess.panel(state).scroll.offset or
-               new_state == state
+    test "j passthrough (handled by AgentChatNav → Mode FSM)", %{state: state} do
+      assert {:passthrough, _} = Scoped.handle_key(state, ?j, 0)
+      # Full chain handling (through AgentChatNav)
+      assert {:handled, _} = walk_surface_handlers(state, ?j, 0)
     end
 
-    test "k scrolls up", %{state: state} do
-      # First scroll down so there's room to scroll up
-      {:handled, scrolled} = Scoped.handle_key(state, ?j, 0)
-      assert {:handled, _} = Scoped.handle_key(scrolled, ?k, 0)
+    test "k passthrough (handled by AgentChatNav → Mode FSM)", %{state: state} do
+      assert {:passthrough, _} = Scoped.handle_key(state, ?k, 0)
+      # Full chain handling
+      assert {:handled, _} = walk_surface_handlers(state, ?k, 0)
     end
 
-    test "G scrolls to bottom", %{state: state} do
-      assert {:handled, _} = Scoped.handle_key(state, ?G, 0)
+    test "G passthrough (handled by AgentChatNav → Mode FSM)", %{state: state} do
+      assert {:passthrough, _} = Scoped.handle_key(state, ?G, 0)
+      # Full chain handling
+      assert {:handled, _} = walk_surface_handlers(state, ?G, 0)
     end
 
     test "q closes agentic view", %{state: state} do
@@ -308,12 +309,16 @@ defmodule Minga.Input.ScopedTest do
                AgentAccess.agentic(state).chat_width_pct
     end
 
-    test "Ctrl+D scrolls half page down", %{state: state} do
-      assert {:handled, _} = Scoped.handle_key(state, ?d, 0x02)
+    test "Ctrl+D passthrough (handled by AgentChatNav → Mode FSM)", %{state: state} do
+      assert {:passthrough, _} = Scoped.handle_key(state, ?d, 0x02)
+      # Full chain handling
+      assert {:handled, _} = walk_surface_handlers(state, ?d, 0x02)
     end
 
-    test "Ctrl+U scrolls half page up", %{state: state} do
-      assert {:handled, _} = Scoped.handle_key(state, ?u, 0x02)
+    test "Ctrl+U passthrough (handled by AgentChatNav → Mode FSM)", %{state: state} do
+      assert {:passthrough, _} = Scoped.handle_key(state, ?u, 0x02)
+      # Full chain handling
+      assert {:handled, _} = walk_surface_handlers(state, ?u, 0x02)
     end
 
     test "ESC dismisses help when visible", %{state: state} do
@@ -322,9 +327,11 @@ defmodule Minga.Input.ScopedTest do
       refute AgentAccess.agentic(new_state).help_visible
     end
 
-    test "unbound key is swallowed in normal mode", %{state: state} do
-      # tilde is not bound in agent scope
-      assert {:handled, ^state} = Scoped.handle_key(state, ?~, 0)
+    test "unbound key passthrough to Mode FSM", %{state: state} do
+      # tilde is not bound in agent scope, passes through to AgentChatNav → Mode FSM
+      assert {:passthrough, _} = Scoped.handle_key(state, ?~, 0)
+      # Full chain handling (AgentChatNav routes to Mode FSM)
+      assert {:handled, _} = walk_surface_handlers(state, ?~, 0)
     end
   end
 
@@ -390,15 +397,21 @@ defmodule Minga.Input.ScopedTest do
 
       assert ViewState.toast_visible?(AgentAccess.agentic(state))
 
-      {:handled, new_state} = Scoped.handle_key(state, ?j, 0)
+      # Toast dismissal is still handled by Scoped, but j itself returns passthrough
+      {:passthrough, new_state} = Scoped.handle_key(state, ?j, 0)
+      # Toast should be dismissed
       refute ViewState.toast_visible?(AgentAccess.agentic(new_state))
+      # Full chain still handles the key (through AgentChatNav)
+      {:handled, _} = walk_surface_handlers(state, ?j, 0)
     end
   end
 
   describe "agent scope — file viewer focus" do
-    test "j scrolls viewer when focus is :file_viewer" do
+    test "j passthrough, handled by AgentChatNav in file_viewer focus" do
       state = base_state(keymap_scope: :agent, agentic_active: true, focus: :file_viewer)
-      assert {:handled, _} = Scoped.handle_key(state, ?j, 0)
+      assert {:passthrough, _} = Scoped.handle_key(state, ?j, 0)
+      # Full chain handling through AgentChatNav
+      assert {:handled, _} = walk_surface_handlers(state, ?j, 0)
     end
 
     test "Tab switches back to chat from viewer" do

--- a/test/minga/keymap/scope_test.exs
+++ b/test/minga/keymap/scope_test.exs
@@ -40,29 +40,29 @@ defmodule Minga.Keymap.ScopeTest do
   end
 
   describe "resolve_key/4 with :agent scope" do
-    test "resolves j to agent_scroll_down in normal mode" do
-      assert {:command, :agent_scroll_down} = Scope.resolve_key(:agent, :normal, {?j, 0})
+    test "j returns :not_found (handled by Mode FSM)" do
+      assert :not_found = Scope.resolve_key(:agent, :normal, {?j, 0})
     end
 
-    test "resolves k to agent_scroll_up in normal mode" do
-      assert {:command, :agent_scroll_up} = Scope.resolve_key(:agent, :normal, {?k, 0})
+    test "k returns :not_found (handled by Mode FSM)" do
+      assert :not_found = Scope.resolve_key(:agent, :normal, {?k, 0})
     end
 
-    test "resolves Ctrl+D to agent_scroll_half_down in normal mode" do
-      assert {:command, :agent_scroll_half_down} = Scope.resolve_key(:agent, :normal, {?d, 0x02})
+    test "Ctrl+D returns :not_found (handled by Mode FSM)" do
+      assert :not_found = Scope.resolve_key(:agent, :normal, {?d, 0x02})
     end
 
-    test "resolves G to agent_scroll_bottom in normal mode" do
-      assert {:command, :agent_scroll_bottom} = Scope.resolve_key(:agent, :normal, {?G, 0})
+    test "G returns :not_found (handled by Mode FSM)" do
+      assert :not_found = Scope.resolve_key(:agent, :normal, {?G, 0})
     end
 
     test "g is a prefix in normal mode" do
       assert {:prefix, _node} = Scope.resolve_key(:agent, :normal, {?g, 0})
     end
 
-    test "gg resolves to agent_scroll_top via prefix walk" do
+    test "gg resolves to move_to_document_start via prefix walk" do
       {:prefix, g_node} = Scope.resolve_key(:agent, :normal, {?g, 0})
-      assert {:command, :agent_scroll_top} = Scope.resolve_key_in_node(g_node, {?g, 0})
+      assert {:command, :move_to_document_start} = Scope.resolve_key_in_node(g_node, {?g, 0})
     end
 
     test "gf resolves to agent_open_code_block via prefix walk" do

--- a/test/minga/keymap/scope_user_override_test.exs
+++ b/test/minga/keymap/scope_user_override_test.exs
@@ -45,8 +45,8 @@ defmodule Minga.Keymap.Scope.UserOverrideTest do
     test "non-overridden keys still work from scope defaults" do
       KeymapActive.bind({:agent, :normal}, "y", :my_yank, "My yank")
 
-      # j should still be agent_scroll_down from the default scope keymap
-      assert {:command, :agent_scroll_down} = Scope.resolve_key(:agent, :normal, {?j, 0})
+      # q should still be agent_close from the default scope keymap
+      assert {:command, :agent_close} = Scope.resolve_key(:agent, :normal, {?q, 0})
     end
 
     test "user can add new keys to a scope" do


### PR DESCRIPTION
# TL;DR

Chat navigation now goes through the standard Mode FSM instead of reimplemented scope commands. A new `AgentChatNav` handler sits after `Scoped` in the handler chain: navigation keys that the scope trie does not claim pass through to this handler, which swaps `buffers.active` to the `*Agent*` buffer and runs through `do_handle_key`. The chat gets the full vim grammar for free.

## Architecture

**Handler chain:** `Scoped → AgentChatNav → GlobalBindings → ModeFSM`

The agent scope trie now contains ONLY domain-specific commands:
- Fold/collapse: `za`, `zA`, `zo`, `zc`, `zM`, `zR`
- Semantic navigation: `]m`, `]c`, `]t`, `[m`, `[c`, `[t`
- Copy: `y` (code block), `Y` (message)
- Focus: `i`, `a`, `Enter`, `o`, `q`, `Escape`
- Panel: `}`, `{`, `=`, `Tab`, `s`, `?`
- Search: `/`, `n`, `N` (agent-specific structured search)
- Clear: `Ctrl-L`

Everything else (j, k, w, b, e, G, Ctrl-D, Ctrl-U, 0, $, ^, {, }, etc.) passes through the trie and is handled by `AgentChatNav`.

**Prefix collision rule:** every prefix key claimed by the trie (`g`, `z`, `]`, `[`) must have ALL sub-bindings fully defined. Standard vim commands map to their Mode FSM command atoms alongside domain commands. Example: `gg` → `:move_to_document_start` sits next to `gf` → `:agent_open_code_block`. No sub-binding falls through, because the prefix was consumed by the trie and the Mode FSM never saw it.

**File viewer focus:** when the preview pane is focused, `AgentChatNav` handles scroll keys directly (j/k/G/Ctrl-D/Ctrl-U for Preview scroll). This replaces the old focus-switching logic in `scope_scroll_*` commands.

**Side panel:** `AgentPanel` now delegates to `AgentChatNav.delegate_to_mode_fsm/4` for chat navigation, eliminating duplicate buffer-swap logic.

## What the chat gets for free now

Everything the Mode FSM supports that was previously unavailable in chat:
- Counts: `5j`, `10k`, `3w`
- All motions: `w`, `b`, `e`, `W`, `B`, `E`, `0`, `$`, `^`, `{`, `}`
- Find char: `f`, `F`, `t`, `T`, `;`, `,`
- Dot repeat, macro recording/replay
- Any future vim features added to the Mode FSM

## Deleted

6 `scope_scroll_*` functions from `AgentCommands` + 6 `Commands.execute` dispatch clauses. Net -69 lines of duplicated navigation logic.

## Upgrade path

The `*Agent*` buffer is the pragmatic first step. When a structured `ChatSnapshot` NavigableContent adapter is built later, `AgentChatNav`'s internals change (swap `do_handle_key` for NavigableContent dispatch) but its position in the handler chain and its public API remain the same. The architecture is correct regardless of the content implementation.

## Verification

```bash
mix test --exclude external --warnings-as-errors  # 3,970 tests, 0 failures
mix lint                                           # clean
mix dialyzer                                       # 0 errors
```