### PR TITLE
feat(agent): model picker for native provider

### DIFF
--- a/lib/minga/agent/model_catalog.ex
+++ b/lib/minga/agent/model_catalog.ex
@@ -1,0 +1,117 @@
+defmodule Minga.Agent.ModelCatalog do
+  @moduledoc """
+  Curated model catalog for the native agent provider.
+
+  Wraps LLMDB to return models filtered to providers the user has
+  credentials for, excluding non-chat models (embeddings, image gen,
+  TTS, etc.) and deprecated/retired entries.
+
+  The output format matches what `Minga.Picker.AgentModelSource`
+  expects: a list of maps with string keys for `"id"`, `"name"`,
+  `"provider"`, `"context_window"`, and `"cost"`.
+  """
+
+  alias Minga.Agent.Credentials
+
+  @typedoc "A model entry suitable for the picker."
+  @type model_entry :: %{
+          String.t() => String.t() | integer() | map() | boolean()
+        }
+
+  @doc """
+  Returns available chat models for providers the user has API keys for.
+
+  `current_model` is the full `"provider:model_id"` string of the
+  currently active model, used to mark it in the list.
+  """
+  @spec available_models(String.t()) :: [model_entry()]
+  def available_models(current_model \\ "") do
+    configured_providers = configured_provider_atoms()
+
+    LLMDB.models()
+    |> Enum.filter(&include_model?(&1, configured_providers))
+    |> Enum.sort_by(&{&1.provider, &1.name})
+    |> Enum.map(&format_model(&1, current_model))
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  # Maps our credential provider strings to LLMDB provider atoms.
+  @provider_mapping %{
+    "anthropic" => :anthropic,
+    "openai" => :openai,
+    "google" => :google
+  }
+
+  @spec configured_provider_atoms() :: MapSet.t(atom())
+  defp configured_provider_atoms do
+    Credentials.known_providers()
+    |> Enum.filter(&has_credentials?/1)
+    |> Enum.map(&Map.get(@provider_mapping, &1))
+    |> Enum.reject(&is_nil/1)
+    |> MapSet.new()
+  end
+
+  @spec has_credentials?(String.t()) :: boolean()
+  defp has_credentials?(provider) do
+    case Credentials.resolve(provider) do
+      {:ok, _key, _source} -> true
+      _ -> false
+    end
+  end
+
+  # Non-chat model ID substrings to exclude.
+  @excluded_patterns ~w(embedding tts whisper moderation realtime dall-e sora codex imagen veo aqa gemma)
+
+  @spec include_model?(map(), MapSet.t(atom())) :: boolean()
+  defp include_model?(model, configured_providers) do
+    model.provider in configured_providers and
+      not model.deprecated and
+      not model.retired and
+      has_text_output?(model) and
+      has_reasonable_context?(model) and
+      not excluded_by_name?(model.id)
+  end
+
+  @spec has_text_output?(map()) :: boolean()
+  defp has_text_output?(%{modalities: %{output: outputs}}) when is_list(outputs) do
+    :text in outputs
+  end
+
+  defp has_text_output?(_), do: false
+
+  @spec has_reasonable_context?(map()) :: boolean()
+  defp has_reasonable_context?(%{limits: %{context: ctx}}) when is_integer(ctx) and ctx > 1000 do
+    true
+  end
+
+  defp has_reasonable_context?(_), do: false
+
+  @spec excluded_by_name?(String.t()) :: boolean()
+  defp excluded_by_name?(id) do
+    id_lower = String.downcase(id)
+    Enum.any?(@excluded_patterns, &String.contains?(id_lower, &1))
+  end
+
+  @spec format_model(map(), String.t()) :: model_entry()
+  defp format_model(model, current_model) do
+    provider_str = Atom.to_string(model.provider)
+    full_id = "#{provider_str}:#{model.id}"
+
+    %{
+      "id" => full_id,
+      "name" => model.name || model.id,
+      "provider" => provider_str,
+      "context_window" => model.limits[:context],
+      "cost" => format_cost(model.cost),
+      "current" => full_id == current_model
+    }
+  end
+
+  @spec format_cost(map()) :: map()
+  defp format_cost(%{input: input, output: output}) do
+    %{"input" => input, "output" => output}
+  end
+
+  defp format_cost(_), do: %{}
+end

--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -36,9 +36,10 @@ defmodule Minga.Agent.Providers.Native do
   alias Minga.Agent.Credentials
   alias Minga.Agent.Event
   alias Minga.Agent.Instructions
+  alias Minga.Agent.ModelCatalog
   alias Minga.Agent.ModelLimits
-  alias Minga.Agent.TokenEstimator
   alias Minga.Agent.Retry
+  alias Minga.Agent.TokenEstimator
   alias Minga.Agent.Tools
   alias Minga.Config.Options
   alias ReqLLM.Context
@@ -129,6 +130,12 @@ defmodule Minga.Agent.Providers.Native do
   @spec cycle_thinking_level(GenServer.server()) :: {:ok, term()} | {:error, term()}
   def cycle_thinking_level(pid) do
     GenServer.call(pid, :cycle_thinking_level)
+  end
+
+  @impl Minga.Agent.Provider
+  @spec get_available_models(GenServer.server()) :: {:ok, [map()]} | {:error, term()}
+  def get_available_models(pid) do
+    GenServer.call(pid, :get_available_models, 10_000)
   end
 
   # ── GenServer callbacks ─────────────────────────────────────────────────────
@@ -264,6 +271,11 @@ defmodule Minga.Agent.Providers.Native do
 
     Logger.info("[Agent.Native] thinking level cycled to #{next_level}")
     {:reply, {:ok, %{"level" => next_level}}, %{state | thinking_level: next_level}}
+  end
+
+  def handle_call(:get_available_models, _from, state) do
+    models = ModelCatalog.available_models(state.model)
+    {:reply, {:ok, models}, state}
   end
 
   @impl GenServer

--- a/lib/minga/picker/agent_model_source.ex
+++ b/lib/minga/picker/agent_model_source.ex
@@ -2,9 +2,13 @@ defmodule Minga.Picker.AgentModelSource do
   @moduledoc """
   Picker source for AI agent models.
 
-  Fetches available models from the running pi RPC session and presents
-  them for selection. Selecting a model switches the agent to use it via
-  `set_model` on the pi backend.
+  Fetches available models from the active agent session and presents
+  them for selection. Works with both the pi-agent backend (which
+  returns `%{"models" => [...]}`) and the native provider (which
+  returns a flat list of model maps).
+
+  Selecting a model sets it via `set_model` on the editor state, which
+  restarts the session with the new model.
   """
 
   @behaviour Minga.Picker.Source
@@ -26,27 +30,22 @@ defmodule Minga.Picker.AgentModelSource do
     session = AgentAccess.session(state)
 
     with true <- is_pid(session),
-         {:ok, %{"models" => models}} when is_list(models) <-
-           Session.get_available_models(session) do
+         {:ok, models} when is_list(models) <- fetch_models(session) do
       Enum.map(models, &format_model/1)
     else
       _ -> []
     end
   end
 
-  @spec format_model(map()) :: Minga.Picker.item()
-  defp format_model(model) do
-    id = model["id"] || "unknown"
-    provider = model["provider"] || "unknown"
-    name = model["name"] || id
-    cost_info = format_cost(model["cost"])
-
-    {{provider, id}, "#{name}", "#{provider} #{cost_info}"}
-  end
-
   @impl true
   @spec on_select(Minga.Picker.item(), term()) :: term()
+  def on_select({model_id, _label, _desc}, state) when is_binary(model_id) do
+    # Native provider: model_id is the full "provider:model_name" string
+    Minga.Editor.Commands.Agent.set_model(state, model_id)
+  end
+
   def on_select({{provider, model_id}, _label, _desc}, state) do
+    # Pi-agent backend: separate provider and model_id
     Minga.Editor.Commands.Agent.set_provider(
       Minga.Editor.Commands.Agent.set_model(state, model_id),
       provider
@@ -57,10 +56,48 @@ defmodule Minga.Picker.AgentModelSource do
   @spec on_cancel(term()) :: term()
   def on_cancel(state), do: state
 
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  # Handles both response formats:
+  # - Native provider returns {:ok, [model_map, ...]}
+  # - Pi-agent returns {:ok, %{"models" => [model_map, ...]}}
+  @spec fetch_models(pid()) :: {:ok, [map()]} | {:error, term()}
+  defp fetch_models(session) do
+    case Session.get_available_models(session) do
+      {:ok, %{"models" => models}} when is_list(models) -> {:ok, models}
+      {:ok, models} when is_list(models) -> {:ok, models}
+      other -> other
+    end
+  end
+
+  @spec format_model(map()) :: Minga.Picker.item()
+  defp format_model(model) do
+    id = model["id"] || "unknown"
+    provider = model["provider"] || "unknown"
+    name = model["name"] || id
+    cost_info = format_cost(model["cost"])
+    context_info = format_context(model["context_window"])
+    current_marker = if model["current"], do: " ★", else: ""
+
+    desc = String.trim("#{provider}  #{context_info}  #{cost_info}#{current_marker}")
+
+    {id, name, desc}
+  end
+
   @spec format_cost(map() | nil) :: String.t()
-  defp format_cost(%{"input" => input, "output" => output}) do
+  defp format_cost(%{"input" => input, "output" => output})
+       when is_number(input) and is_number(output) do
     "$#{input}/#{output} per MTok"
   end
 
   defp format_cost(_), do: ""
+
+  @spec format_context(integer() | nil) :: String.t()
+  defp format_context(nil), do: ""
+
+  defp format_context(ctx) when is_integer(ctx) and ctx >= 1000 do
+    "#{div(ctx, 1000)}k ctx"
+  end
+
+  defp format_context(_), do: ""
 end

--- a/test/minga/agent/model_catalog_test.exs
+++ b/test/minga/agent/model_catalog_test.exs
@@ -1,0 +1,81 @@
+defmodule Minga.Agent.ModelCatalogTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Agent.ModelCatalog
+
+  describe "available_models/1" do
+    test "returns a list of maps with expected keys" do
+      models = ModelCatalog.available_models()
+
+      # Even if no API keys are set, the function should return a list
+      assert is_list(models)
+
+      for model <- models do
+        assert is_map(model)
+        assert Map.has_key?(model, "id")
+        assert Map.has_key?(model, "name")
+        assert Map.has_key?(model, "provider")
+        assert Map.has_key?(model, "context_window")
+        assert Map.has_key?(model, "cost")
+        assert Map.has_key?(model, "current")
+      end
+    end
+
+    test "model IDs use provider:model format" do
+      models = ModelCatalog.available_models()
+
+      for model <- models do
+        assert String.contains?(model["id"], ":")
+      end
+    end
+
+    test "excludes deprecated and retired models" do
+      models = ModelCatalog.available_models()
+
+      for model <- models do
+        refute String.contains?(model["name"] || "", "deprecated")
+      end
+    end
+
+    test "excludes non-chat models" do
+      models = ModelCatalog.available_models()
+      ids = Enum.map(models, & &1["id"])
+
+      for id <- ids do
+        refute String.contains?(id, "embedding")
+        refute String.contains?(id, "tts")
+        refute String.contains?(id, "whisper")
+        refute String.contains?(id, "dall-e")
+        refute String.contains?(id, "sora")
+      end
+    end
+
+    test "marks the current model" do
+      models = ModelCatalog.available_models("anthropic:claude-sonnet-4-20250514")
+
+      current = Enum.filter(models, & &1["current"])
+      non_current = Enum.reject(models, & &1["current"])
+
+      # If anthropic key is set, there should be exactly one current model
+      # If not set, no models from anthropic will appear
+      if Enum.any?(models, &(&1["provider"] == "anthropic")) do
+        assert length(current) == 1
+        assert hd(current)["id"] == "anthropic:claude-sonnet-4-20250514"
+      end
+
+      for model <- non_current do
+        refute model["current"]
+      end
+    end
+
+    test "only includes models for configured providers" do
+      models = ModelCatalog.available_models()
+      providers = Enum.map(models, & &1["provider"]) |> Enum.uniq()
+
+      # All returned providers should be ones we have credentials for
+      for provider <- providers do
+        assert provider in ["anthropic", "openai", "google"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Implements `get_available_models/1` for the native provider so the model picker (`SPC a m`) works without the pi-agent backend.

## Why

Model switching is a core workflow. Users frequently switch between fast/cheap models for simple tasks and powerful models for complex ones. Without this, native provider users had to type the full model string manually via `/model anthropic:claude-sonnet-4-20250514`.

## Changes

- **`Minga.Agent.ModelCatalog`** (new): Wraps LLMDB to return chat models filtered by configured API keys. Excludes non-chat models (embeddings, TTS, image gen, etc.), deprecated/retired entries, and models with tiny context windows. Output format matches what the picker expects.
- **`Providers.Native`**: Implements `get_available_models/1` callback, delegating to ModelCatalog.
- **`Picker.AgentModelSource`**: Updated to handle both native provider (flat list, `provider:model` IDs) and pi-agent (nested `%{"models" => [...]}`) response formats. Shows context window size and marks current model with ★.
- **Tests**: 6 new tests for ModelCatalog covering key format, exclusions, current model marking, and provider filtering.

Closes #275