### PR TITLE
feat(agent): model cycling with SPC a M keybinding

### DIFF
--- a/lib/minga/agent/provider.ex
+++ b/lib/minga/agent/provider.ex
@@ -82,10 +82,14 @@ defmodule Minga.Agent.Provider do
   @doc "Cycles to the next thinking level and returns the new level."
   @callback cycle_thinking_level(provider()) :: {:ok, term()} | {:error, term()}
 
+  @doc "Cycles to the next model in the configured model rotation."
+  @callback cycle_model(provider()) :: {:ok, map()} | {:error, term()}
+
   @optional_callbacks [
     get_available_models: 1,
     get_commands: 1,
     set_thinking_level: 2,
-    cycle_thinking_level: 1
+    cycle_thinking_level: 1,
+    cycle_model: 1
   ]
 end

--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -144,6 +144,12 @@ defmodule Minga.Agent.Providers.Native do
     GenServer.call(pid, :compact, 30_000)
   end
 
+  @impl Minga.Agent.Provider
+  @spec cycle_model(GenServer.server()) :: {:ok, map()} | {:error, term()}
+  def cycle_model(pid) do
+    GenServer.call(pid, :cycle_model)
+  end
+
   # ── GenServer callbacks ─────────────────────────────────────────────────────
 
   @impl GenServer
@@ -311,6 +317,30 @@ defmodule Minga.Agent.Providers.Native do
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call(:cycle_model, _from, state) do
+    model_list = read_config_model_list()
+
+    if model_list == [] do
+      {:reply, {:error, "No model rotation configured. Set :agent_models in your config."}, state}
+    else
+      {next_model, next_thinking} = parse_model_entry(next_in_cycle(model_list, state.model))
+
+      new_state = %{
+        state
+        | model: next_model,
+          thinking_level: next_thinking || state.thinking_level,
+          context: ReqLLM.Context.new(),
+          tools: Minga.Agent.Tools.all(project_root: state.project_root),
+          system_prompt: build_system_prompt(state.project_root)
+      }
+
+      total = length(model_list)
+      index = Enum.find_index(model_list, &String.starts_with?(&1, next_model)) || 0
+
+      {:reply, {:ok, %{"model" => next_model, "index" => index + 1, "total" => total}}, new_state}
     end
   end
 
@@ -866,6 +896,34 @@ defmodule Minga.Agent.Providers.Native do
     _ -> @default_max_retries
   catch
     :exit, _ -> @default_max_retries
+  end
+
+  @spec read_config_model_list() :: [String.t()]
+  defp read_config_model_list do
+    Options.get(:agent_models)
+  rescue
+    _ -> []
+  catch
+    :exit, _ -> []
+  end
+
+  # Finds the next entry in the cycle after the current model.
+  @spec next_in_cycle([String.t()], String.t()) :: String.t()
+  defp next_in_cycle(model_list, current_model) do
+    current_index =
+      Enum.find_index(model_list, &String.starts_with?(&1, current_model)) || -1
+
+    next_index = rem(current_index + 1, length(model_list))
+    Enum.at(model_list, next_index)
+  end
+
+  # Parses "provider:model:thinking_level" or "provider:model" into {model_str, thinking | nil}.
+  @spec parse_model_entry(String.t()) :: {String.t(), String.t() | nil}
+  defp parse_model_entry(entry) do
+    case String.split(entry, ":") do
+      [provider, model, thinking] -> {"#{provider}:#{model}", thinking}
+      _ -> {entry, nil}
+    end
   end
 
   @spec detect_project_root() :: String.t()

--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -191,6 +191,12 @@ defmodule Minga.Agent.Session do
     GenServer.call(session, :cycle_thinking_level, 10_000)
   end
 
+  @doc "Cycles to the next model in the configured rotation."
+  @spec cycle_model(GenServer.server()) :: {:ok, map()} | {:error, term()}
+  def cycle_model(session) do
+    GenServer.call(session, :cycle_model, 10_000)
+  end
+
   @doc "Toggles the collapsed state of a tool call message."
   @spec toggle_tool_collapse(GenServer.server(), non_neg_integer()) :: :ok
   def toggle_tool_collapse(session, message_index) do
@@ -454,6 +460,15 @@ defmodule Minga.Agent.Session do
 
   def handle_call(:cycle_thinking_level, _from, state) do
     result = dispatch_optional(state.provider_module, :cycle_thinking_level, [state.provider])
+    {:reply, result, state}
+  end
+
+  def handle_call(:cycle_model, _from, %{provider: nil} = state) do
+    {:reply, {:error, :provider_not_ready}, state}
+  end
+
+  def handle_call(:cycle_model, _from, state) do
+    result = dispatch_optional(state.provider_module, :cycle_model, [state.provider])
     {:reply, result, state}
   end
 

--- a/lib/minga/command/parser.ex
+++ b/lib/minga/command/parser.ex
@@ -52,6 +52,7 @@ defmodule Minga.Command.Parser do
           | {:agent_set_provider, [String.t()]}
           | {:agent_set_model, [String.t()]}
           | {:agent_pick_model, []}
+          | {:agent_cycle_model, []}
           | {:agent_cycle_thinking, []}
           | {:goto_line, pos_integer()}
           | {:set, atom()}
@@ -118,6 +119,7 @@ defmodule Minga.Command.Parser do
   defp do_parse("agent-provider " <> provider), do: {:agent_set_provider, [String.trim(provider)]}
   defp do_parse("agent-model " <> model), do: {:agent_set_model, [String.trim(model)]}
   defp do_parse("agent-models"), do: {:agent_pick_model, []}
+  defp do_parse("agent-cycle-model"), do: {:agent_cycle_model, []}
   defp do_parse("agent-thinking"), do: {:agent_cycle_thinking, []}
   defp do_parse("vsplit"), do: {:split_vertical, []}
   defp do_parse("vs"), do: {:split_vertical, []}

--- a/lib/minga/command/registry.ex
+++ b/lib/minga/command/registry.ex
@@ -93,6 +93,7 @@ defmodule Minga.Command.Registry do
     {:agent_abort, "Stop AI agent"},
     {:agent_new_session, "New AI agent session"},
     {:agent_pick_model, "Pick AI agent model"},
+    {:agent_cycle_model, "Cycle AI agent model"},
     {:agent_cycle_thinking, "Cycle AI thinking level"}
   ]
 

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -95,6 +95,7 @@ defmodule Minga.Config.Options do
           | :agent_auto_context
           | :agent_max_tokens
           | :agent_max_retries
+          | :agent_models
           | :agent_prompt_cache
           | :agent_system_prompt
           | :agent_append_system_prompt
@@ -161,6 +162,7 @@ defmodule Minga.Config.Options do
     {:agent_auto_context, :boolean, true},
     {:agent_max_tokens, :pos_integer, 16_384},
     {:agent_max_retries, :non_neg_integer, 3},
+    {:agent_models, :string_list, []},
     {:agent_prompt_cache, :boolean, true},
     {:agent_system_prompt, :string, ""},
     {:agent_append_system_prompt, :string, ""},

--- a/lib/minga/editor/commands.ex
+++ b/lib/minga/editor/commands.ex
@@ -162,6 +162,8 @@ defmodule Minga.Editor.Commands do
   def execute(state, :agent_session_history),
     do: PickerUI.open(state, Minga.Picker.SessionHistorySource)
 
+  def execute(state, :agent_cycle_model), do: AgentCommands.cycle_model(state)
+
   def execute(state, :agent_cycle_thinking), do: AgentCommands.cycle_thinking_level(state)
 
   # ── Agent scope commands (dispatched via keymap scope resolution) ──────────

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -498,6 +498,32 @@ defmodule Minga.Editor.Commands.Agent do
     end
   end
 
+  @doc "Cycles to the next model in the configured rotation."
+  @spec cycle_model(state()) :: state()
+  def cycle_model(state) do
+    if AgentAccess.session(state) == nil do
+      %{state | status_msg: "No agent session"}
+    else
+      case Session.cycle_model(AgentAccess.session(state)) do
+        {:ok, %{"model" => model, "index" => index, "total" => total}} ->
+          state = update_agent(state, &AgentState.set_model_name(&1, model))
+
+          Session.add_system_message(
+            AgentAccess.session(state),
+            "Model: #{model} [#{index}/#{total}]"
+          )
+
+          %{state | status_msg: "Model: #{model} [#{index}/#{total}]"}
+
+        {:error, reason} when is_binary(reason) ->
+          %{state | status_msg: reason}
+
+        {:error, reason} ->
+          %{state | status_msg: "Error: #{inspect(reason)}"}
+      end
+    end
+  end
+
   @doc "Sets the agent provider and restarts the session."
   @spec set_provider(state(), String.t()) :: state()
   def set_provider(state, provider) do

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -96,6 +96,7 @@ defmodule Minga.Keymap.Defaults do
     {[{?a, @none}, {?s, @none}], :agent_abort, "Stop agent"},
     {[{?a, @none}, {?n, @none}], :agent_new_session, "New agent session"},
     {[{?a, @none}, {?m, @none}], :agent_pick_model, "Pick agent model"},
+    {[{?a, @none}, {?M, @none}], :agent_cycle_model, "Cycle agent model"},
     {[{?a, @none}, {?h, @none}], :agent_session_history, "Session history"},
     {[{?a, @none}, {?T, @none}], :agent_cycle_thinking, "Cycle thinking level"},
 

--- a/test/minga/command/registry_test.exs
+++ b/test/minga/command/registry_test.exs
@@ -61,6 +61,7 @@ defmodule Minga.Command.RegistryTest do
           :agent_abort,
           :agent_new_session,
           :agent_pick_model,
+          :agent_cycle_model,
           :agent_cycle_thinking,
           :git_blame_line,
           :git_preview_hunk,

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -55,6 +55,7 @@ defmodule Minga.Config.OptionsTest do
                agent_auto_context: true,
                agent_max_tokens: 16_384,
                agent_max_retries: 3,
+               agent_models: [],
                agent_prompt_cache: true,
                agent_system_prompt: "",
                agent_append_system_prompt: "",


### PR DESCRIPTION
## What

Users can configure a list of favorite models and cycle through them with `SPC a M`. Each model entry supports an optional thinking level suffix.

## Why

Switching between a powerful model for complex tasks and a fast/cheap model for simple ones is a frequent workflow. Opening the picker every time is slow. A one-key cycle (like pi-agent's Ctrl+P) is much more ergonomic.

## Changes

- **`Config.Options`**: New `:agent_models` option (string list, default `[]`)
- **`Providers.Native`**: New `cycle_model/1` callback + `handle_call(:cycle_model)`. Parses thinking level suffix, resets session, returns position in cycle.
- **`Provider` behaviour**: New optional `cycle_model/1` callback
- **`Session`**: New `cycle_model/1` function routing to provider
- **`Commands.Agent`**: New `cycle_model/1` command with status message
- **`Commands`**: Wired `:agent_cycle_model` to the command
- **`Keymap.Defaults`**: `SPC a M` bound to cycle model
- **`Command.Registry`**: Registered `:agent_cycle_model`
- **`Command.Parser`**: Added `agent-cycle-model` parse entry

Closes #276