### PR TITLE
feat(agent): configurable system prompt with append support

### DIFF
--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -231,6 +231,12 @@ defmodule Minga.Agent.Providers.Native do
   end
 
   def handle_call(:get_state, _from, state) do
+    system_prompt =
+      case state.context.messages do
+        [%{role: :system, content: content} | _] when is_binary(content) -> content
+        _ -> nil
+      end
+
     session_state = %{
       model: %{
         id: state.model,
@@ -238,7 +244,8 @@ defmodule Minga.Agent.Providers.Native do
         provider: "native"
       },
       is_streaming: state.streaming,
-      token_usage: nil
+      token_usage: nil,
+      system_prompt: system_prompt
     }
 
     {:reply, {:ok, session_state}, state}
@@ -628,35 +635,95 @@ defmodule Minga.Agent.Providers.Native do
 
   @spec build_system_prompt(String.t()) :: String.t()
   defp build_system_prompt(project_root) do
+    base = resolve_base_prompt(project_root)
     instructions = Instructions.assemble(project_root)
+    append = read_config_string(:agent_append_system_prompt)
 
-    """
-    You are an AI coding assistant running inside Minga, a modal text editor. You help users by reading files, editing code, running shell commands, and writing new files.
+    parts =
+      [base, instructions, append]
+      |> Enum.reject(&(is_nil(&1) or &1 == ""))
+      |> Enum.join("\n\n")
 
-    ## Available tools
+    parts
+  end
 
-    - read_file: Read file contents
-    - write_file: Create or overwrite files (creates parent directories automatically)
-    - edit_file: Make surgical edits (find exact text and replace). Read the file first to get exact text.
-    - list_directory: List files and directories at a path
-    - find: Find files by name or glob pattern. Prefer this over shell + find.
-    - grep: Search file contents for a pattern. Returns file:line:content. Prefer this over shell + grep.
-    - shell: Run shell commands in the project root
+  @default_system_prompt_template """
+  You are an AI coding assistant running inside Minga, a modal text editor. You help users by reading files, editing code, running shell commands, and writing new files.
 
-    ## Guidelines
+  ## Available tools
 
-    - Read files before editing them. The old_text in edit_file must match exactly.
-    - Use find to discover files by name or extension, and grep to search file contents.
-    - Use shell for running tests, linters, git commands, etc.
-    - Be concise and direct. Show file paths clearly when working with files.
-    - When you make changes, verify them by reading the result or running tests.
+  - read_file: Read file contents
+  - write_file: Create or overwrite files (creates parent directories automatically)
+  - edit_file: Make surgical edits (find exact text and replace). Read the file first to get exact text.
+  - list_directory: List files and directories at a path
+  - find: Find files by name or glob pattern. Prefer this over shell + find.
+  - grep: Search file contents for a pattern. Returns file:line:content. Prefer this over shell + grep.
+  - shell: Run shell commands in the project root
 
-    ## Environment
+  ## Guidelines
 
-    - Project root: #{project_root}
-    - Current time: #{DateTime.utc_now() |> DateTime.to_iso8601()}
-    #{if instructions, do: "\n#{instructions}", else: ""}
-    """
+  - Read files before editing them. The old_text in edit_file must match exactly.
+  - Use find to discover files by name or extension, and grep to search file contents.
+  - Use shell for running tests, linters, git commands, etc.
+  - Be concise and direct. Show file paths clearly when working with files.
+  - When you make changes, verify them by reading the result or running tests.
+  """
+
+  # Returns the base system prompt: either from config or the default template.
+  # Config value can be a string prompt or a file path.
+  @spec resolve_base_prompt(String.t()) :: String.t()
+  defp resolve_base_prompt(project_root) do
+    custom = read_config_string(:agent_system_prompt)
+
+    base =
+      if custom != "" do
+        resolve_prompt_value(custom, project_root)
+      else
+        @default_system_prompt_template
+      end
+
+    # Always append environment info
+    base <>
+      "\n## Environment\n\n" <>
+      "- Project root: #{project_root}\n" <>
+      "- Current time: #{DateTime.utc_now() |> DateTime.to_iso8601()}"
+  end
+
+  # If the value looks like a file path, read it. Otherwise return as-is.
+  @spec resolve_prompt_value(String.t(), String.t()) :: String.t()
+  defp resolve_prompt_value(value, project_root) do
+    expanded = expand_path(value, project_root)
+
+    if File.regular?(expanded) do
+      File.read!(expanded)
+    else
+      value
+    end
+  end
+
+  @spec expand_path(String.t(), String.t()) :: String.t()
+  defp expand_path("~/" <> rest, _project_root) do
+    Path.join(System.user_home!(), rest)
+  end
+
+  defp expand_path(path, project_root) do
+    if Path.type(path) == :absolute do
+      path
+    else
+      Path.join(project_root, path)
+    end
+  end
+
+  @spec read_config_string(atom()) :: String.t()
+  defp read_config_string(key) do
+    case Options.get(key) do
+      value when is_binary(value) -> value
+      _ -> ""
+    end
+  rescue
+    _ -> ""
+  catch
+    :exit, _ -> ""
   end
 
   # Sets the provider's API key env var if it's stored in the credentials

--- a/lib/minga/agent/slash_command.ex
+++ b/lib/minga/agent/slash_command.ex
@@ -10,6 +10,7 @@ defmodule Minga.Agent.SlashCommand do
 
   alias Minga.Agent.Credentials
   alias Minga.Agent.Instructions
+  alias Minga.Config.Options
   alias Minga.Agent.PanelState
   alias Minga.Agent.Session
   alias Minga.Editor.Commands.Agent, as: AgentCommands
@@ -39,6 +40,10 @@ defmodule Minga.Agent.SlashCommand do
     %{
       name: "instructions",
       description: "Show which AGENTS.md instruction files are loaded"
+    },
+    %{
+      name: "system-prompt",
+      description: "Show the current assembled system prompt"
     }
   ]
 
@@ -88,6 +93,7 @@ defmodule Minga.Agent.SlashCommand do
   defp dispatch(state, "sessions", _args), do: {:ok, do_sessions(state)}
   defp dispatch(state, "auth", args), do: {:ok, do_auth(state, args)}
   defp dispatch(state, "instructions", _args), do: {:ok, do_instructions(state)}
+  defp dispatch(state, "system-prompt", _args), do: {:ok, do_system_prompt(state)}
   defp dispatch(_state, cmd, _args), do: {:error, "Unknown command: /#{cmd}"}
 
   # ── Command implementations ────────────────────────────────────────────────
@@ -271,6 +277,45 @@ defmodule Minga.Agent.SlashCommand do
   end
 
   @spec do_instructions(state()) :: state()
+  @spec do_system_prompt(state()) :: state()
+  defp do_system_prompt(state) do
+    # Rebuild the system prompt from the same logic the provider uses.
+    # This gives a faithful view of what the model sees.
+    root = detect_project_root()
+    instructions = Instructions.assemble(root)
+
+    custom_base = read_config_string(:agent_system_prompt)
+    append = read_config_string(:agent_append_system_prompt)
+
+    summary_parts = [
+      "**Base prompt:** #{if custom_base == "", do: "(default)", else: "custom"}",
+      if(instructions,
+        do: "**Instructions:** #{String.length(instructions)} chars from AGENTS.md files",
+        else: nil
+      ),
+      if(append != "", do: "**Append:** #{String.length(append)} chars from config", else: nil)
+    ]
+
+    summary = Enum.reject(summary_parts, &is_nil/1) |> Enum.join("\n")
+
+    emit_system_message(
+      state,
+      "System prompt assembly:\n\n#{summary}\n\nUse /instructions to see loaded instruction files."
+    )
+  end
+
+  @spec read_config_string(atom()) :: String.t()
+  defp read_config_string(key) do
+    case Options.get(key) do
+      value when is_binary(value) -> value
+      _ -> ""
+    end
+  rescue
+    _ -> ""
+  catch
+    :exit, _ -> ""
+  end
+
   defp do_instructions(state) do
     root = detect_project_root()
     summary = Instructions.summary(root)

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -96,6 +96,8 @@ defmodule Minga.Config.Options do
           | :agent_max_tokens
           | :agent_max_retries
           | :agent_prompt_cache
+          | :agent_system_prompt
+          | :agent_append_system_prompt
           | :font_family
           | :font_size
           | :font_weight
@@ -160,6 +162,8 @@ defmodule Minga.Config.Options do
     {:agent_max_tokens, :pos_integer, 16_384},
     {:agent_max_retries, :non_neg_integer, 3},
     {:agent_prompt_cache, :boolean, true},
+    {:agent_system_prompt, :string, ""},
+    {:agent_append_system_prompt, :string, ""},
     {:font_family, :string, "Menlo"},
     {:font_size, :pos_integer, 13},
     {:font_weight, {:enum, [:thin, :light, :regular, :medium, :semibold, :bold, :heavy, :black]},

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -56,6 +56,8 @@ defmodule Minga.Config.OptionsTest do
                agent_max_tokens: 16_384,
                agent_max_retries: 3,
                agent_prompt_cache: true,
+               agent_system_prompt: "",
+               agent_append_system_prompt: "",
                font_family: "Menlo",
                font_size: 13,
                font_weight: :regular,


### PR DESCRIPTION
## What

Users can now customize the native provider's system prompt via config, either replacing the base prompt entirely or appending additional instructions.

## Why

Different projects need different agent behavior. A Ruby project needs different instructions than an Elixir project. The hardcoded default prompt was a dead end for customization. Combined with #287 (AGENTS.md discovery), this gives users full control over what the model sees.

## Changes

- **`Config.Options`**: Two new options:
  - `:agent_system_prompt` — replaces the default base prompt (string or file path)
  - `:agent_append_system_prompt` — appends after all other layers
- **`Providers.Native`**: `build_system_prompt/1` refactored into layered assembly: base → AGENTS.md instructions → append. Default prompt extracted to module attribute. File path resolution supports `~/` and relative paths.
- **`SlashCommand`**: New `/system-prompt` command shows prompt assembly summary.

## Prompt layering order

1. Base prompt (config override or default)
2. Environment info (project root, timestamp)
3. AGENTS.md instruction files (from #287)
4. Append prompt (from config)

Closes #282