### PR TITLE
feat(agent): per-model cost calculation via LLMDB pricing

### DIFF
--- a/lib/minga/agent/cost_calculator.ex
+++ b/lib/minga/agent/cost_calculator.ex
@@ -1,0 +1,86 @@
+defmodule Minga.Agent.CostCalculator do
+  @moduledoc """
+  Calculates per-turn cost from token counts and LLMDB pricing data.
+
+  When the API response includes a cost value (e.g., Anthropic), that
+  value is used directly. When the API does not report cost, this module
+  looks up the model's per-token rates from LLMDB and computes the cost
+  from input/output/cache token counts.
+
+  All costs are in USD. Rates in LLMDB are per million tokens.
+  """
+
+  @typedoc "Token usage with cost."
+  @type usage_with_cost :: %{
+          input: non_neg_integer(),
+          output: non_neg_integer(),
+          cache_read: non_neg_integer(),
+          cache_write: non_neg_integer(),
+          cost: float()
+        }
+
+  @doc """
+  Ensures the usage map has an accurate cost value.
+
+  If the existing cost is non-zero, it's returned as-is (the API's value
+  is authoritative). Otherwise, the cost is calculated from LLMDB pricing
+  for the given model.
+
+  `model` should be the bare model ID (without provider prefix).
+  `provider` should be the provider atom (e.g., :anthropic).
+  """
+  @spec ensure_cost(map(), String.t(), atom()) :: map()
+  def ensure_cost(usage, model_id, provider) when is_map(usage) do
+    existing_cost = Map.get(usage, :cost, 0.0) || 0.0
+
+    if existing_cost > 0.0 do
+      usage
+    else
+      calculated = calculate_cost(usage, model_id, provider)
+      Map.put(usage, :cost, calculated)
+    end
+  end
+
+  @doc """
+  Calculates cost from token counts and LLMDB pricing.
+
+  Returns 0.0 if the model is not found in LLMDB.
+  """
+  @spec calculate_cost(map(), String.t(), atom()) :: float()
+  def calculate_cost(usage, model_id, provider) do
+    case find_model_pricing(model_id, provider) do
+      nil ->
+        0.0
+
+      rates ->
+        input = (Map.get(usage, :input, 0) || 0) * rate(rates, :input)
+        output = (Map.get(usage, :output, 0) || 0) * rate(rates, :output)
+        cache_read = (Map.get(usage, :cache_read, 0) || 0) * rate(rates, :cache_read)
+        cache_write = (Map.get(usage, :cache_write, 0) || 0) * rate(rates, :cache_write)
+
+        Float.round(input + output + cache_read + cache_write, 6)
+    end
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec find_model_pricing(String.t(), atom()) :: map() | nil
+  defp find_model_pricing(model_id, provider) do
+    case Enum.find(LLMDB.models(), &(&1.id == model_id and &1.provider == provider)) do
+      nil -> nil
+      model -> model.cost
+    end
+  rescue
+    _ -> nil
+  end
+
+  # Returns the per-token rate (LLMDB stores per-million-token rates).
+  @spec rate(map(), atom()) :: float()
+  defp rate(rates, key) do
+    case Map.get(rates, key) do
+      nil -> 0.0
+      r when is_number(r) -> r / 1_000_000
+      _ -> 0.0
+    end
+  end
+end

--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -31,6 +31,7 @@ defmodule Minga.Agent.Providers.Native do
 
   use GenServer
 
+  alias Minga.Agent.CostCalculator
   alias Minga.Agent.Credentials
   alias Minga.Agent.Event
   alias Minga.Agent.Instructions
@@ -396,7 +397,12 @@ defmodule Minga.Agent.Providers.Native do
     # No tool calls: final answer
     updated_context = Context.append(context, Context.assistant(text))
     send(lctx.provider_pid, {:agent_context_update, updated_context})
-    send(lctx.provider_pid, {:agent_event, %Event.AgentEnd{usage: normalize_usage(usage)}})
+
+    send(
+      lctx.provider_pid,
+      {:agent_event, %Event.AgentEnd{usage: normalize_usage(usage, lctx.model)}}
+    )
+
     :ok
   end
 
@@ -784,11 +790,11 @@ defmodule Minga.Agent.Providers.Native do
   defp extract_usage(%{usage: usage}) when is_map(usage), do: usage
   defp extract_usage(_), do: nil
 
-  @spec normalize_usage(map() | nil) :: Event.token_usage() | nil
-  defp normalize_usage(nil), do: nil
+  @spec normalize_usage(map() | nil, String.t()) :: Event.token_usage() | nil
+  defp normalize_usage(nil, _model), do: nil
 
-  defp normalize_usage(usage) when is_map(usage) do
-    %{
+  defp normalize_usage(usage, model) when is_map(usage) do
+    normalized = %{
       input: Map.get(usage, :input_tokens, 0) || Map.get(usage, :input, 0),
       output: Map.get(usage, :output_tokens, 0) || Map.get(usage, :output, 0),
       cache_read: Map.get(usage, :cache_read_input_tokens, 0) || Map.get(usage, :cache_read, 0),
@@ -796,6 +802,19 @@ defmodule Minga.Agent.Providers.Native do
         Map.get(usage, :cache_creation_input_tokens, 0) || Map.get(usage, :cache_write, 0),
       cost: Map.get(usage, :total_cost, 0.0) || 0.0
     }
+
+    {provider_atom, model_id} = parse_model_string(model)
+    CostCalculator.ensure_cost(normalized, model_id, provider_atom)
+  end
+
+  @spec parse_model_string(String.t()) :: {atom(), String.t()}
+  defp parse_model_string(model) do
+    case String.split(model, ":", parts: 2) do
+      [provider, id] -> {String.to_existing_atom(provider), id}
+      _ -> {:unknown, model}
+    end
+  rescue
+    ArgumentError -> {:unknown, model}
   end
 
   @spec format_tool_result(term()) :: String.t()

--- a/test/minga/agent/cost_calculator_test.exs
+++ b/test/minga/agent/cost_calculator_test.exs
@@ -1,0 +1,55 @@
+defmodule Minga.Agent.CostCalculatorTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Agent.CostCalculator
+
+  describe "ensure_cost/3" do
+    test "preserves existing non-zero cost" do
+      usage = %{input: 1000, output: 500, cache_read: 0, cache_write: 0, cost: 0.05}
+
+      result = CostCalculator.ensure_cost(usage, "claude-sonnet-4-20250514", :anthropic)
+      assert result.cost == 0.05
+    end
+
+    test "calculates cost when existing cost is zero" do
+      usage = %{input: 1_000_000, output: 500_000, cache_read: 0, cache_write: 0, cost: 0.0}
+
+      result = CostCalculator.ensure_cost(usage, "claude-sonnet-4-20250514", :anthropic)
+      # input: 1M tokens * $3/MTok = $3.00
+      # output: 500k tokens * $15/MTok = $7.50
+      # Total: $10.50
+      assert result.cost > 0.0
+    end
+
+    test "calculates cost when cost key is nil" do
+      usage = %{input: 100_000, output: 50_000, cache_read: 0, cache_write: 0, cost: nil}
+
+      result = CostCalculator.ensure_cost(usage, "claude-sonnet-4-20250514", :anthropic)
+      assert result.cost > 0.0
+    end
+  end
+
+  describe "calculate_cost/3" do
+    test "returns zero for unknown model" do
+      usage = %{input: 1000, output: 500}
+
+      assert CostCalculator.calculate_cost(usage, "nonexistent-model", :unknown) == 0.0
+    end
+
+    test "includes cache read and write costs" do
+      usage = %{input: 0, output: 0, cache_read: 1_000_000, cache_write: 1_000_000}
+
+      cost = CostCalculator.calculate_cost(usage, "claude-sonnet-4-20250514", :anthropic)
+      # cache_read: 1M * $0.30/MTok = $0.30
+      # cache_write: 1M * $3.75/MTok = $3.75
+      assert cost > 0.0
+    end
+
+    test "handles nil values in usage gracefully" do
+      usage = %{input: nil, output: nil}
+
+      cost = CostCalculator.calculate_cost(usage, "claude-sonnet-4-20250514", :anthropic)
+      assert cost == 0.0
+    end
+  end
+end


### PR DESCRIPTION
## What

Every completed agent turn now shows accurate cost regardless of provider. When the API doesn't include cost in the response (OpenAI, Google), the cost is calculated from token counts and LLMDB's per-token pricing data.

## Why

Cost visibility is essential for responsible LLM usage. Without this, the per-turn cost display showed $0.00 for non-Anthropic models, making cost tracking useless when switching providers.

## Changes

- **`Minga.Agent.CostCalculator`** (new): Looks up model pricing from LLMDB. Calculates cost from input/output/cache token counts at per-million-token rates. Preserves API-reported cost when non-zero.
- **`Providers.Native`**: `normalize_usage/1` now takes the model string and calls `CostCalculator.ensure_cost/3` to fill in missing cost data. Added `parse_model_string/1` helper to split `provider:model_id`.
- **Tests**: 6 new tests covering cost preservation, calculation, cache costs, nil handling, and unknown models.

Closes #283