### PR TITLE
feat(agent): recover from dropped streams with /continue

### DIFF
--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -84,7 +84,9 @@ defmodule Minga.Agent.Providers.Native do
           max_retries: non_neg_integer(),
           llm_client: llm_client(),
           task: Task.t() | nil,
-          streaming: boolean()
+          streaming: boolean(),
+          interrupted: boolean(),
+          last_user_prompt: String.t() | nil
         }
 
   # ── Provider callbacks ──────────────────────────────────────────────────────
@@ -150,6 +152,12 @@ defmodule Minga.Agent.Providers.Native do
     GenServer.call(pid, :cycle_model)
   end
 
+  @doc "Continues from an interrupted stream, asking the model to pick up where it left off."
+  @spec continue(GenServer.server()) :: :ok | {:error, term()}
+  def continue(pid) do
+    GenServer.call(pid, :continue)
+  end
+
   # ── GenServer callbacks ─────────────────────────────────────────────────────
 
   @impl GenServer
@@ -183,7 +191,9 @@ defmodule Minga.Agent.Providers.Native do
       max_retries: max_retries,
       llm_client: llm_client,
       task: nil,
-      streaming: false
+      streaming: false,
+      interrupted: false,
+      last_user_prompt: nil
     }
 
     Minga.Log.info(:agent, "[Agent.Native] started with model=#{model} root=#{project_root}")
@@ -199,7 +209,14 @@ defmodule Minga.Agent.Providers.Native do
   def handle_call({:send_prompt, text}, _from, state) do
     # Append user message to context
     context = Context.append(state.context, Context.user(text))
-    state = %{state | context: context, streaming: true}
+
+    state = %{
+      state
+      | context: context,
+        streaming: true,
+        interrupted: false,
+        last_user_prompt: text
+    }
 
     # Notify subscriber that agent is starting
     notify(state.subscriber, %Event.AgentStart{})
@@ -233,6 +250,40 @@ defmodule Minga.Agent.Providers.Native do
     Task.shutdown(state.task, :brutal_kill)
     state = %{state | task: nil, streaming: false}
     Minga.Log.info(:agent, "[Agent.Native] aborted current operation")
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:continue, _from, %{streaming: true} = state) do
+    {:reply, {:error, "Already streaming"}, state}
+  end
+
+  def handle_call(:continue, _from, %{interrupted: false} = state) do
+    {:reply, {:error, "No interrupted response to continue from"}, state}
+  end
+
+  def handle_call(:continue, _from, state) do
+    # Send a continuation prompt that tells the model to pick up where it left off
+    continuation =
+      "Your previous response was interrupted mid-stream. Please continue from where you left off. Do not repeat what you already said."
+
+    context = Context.append(state.context, Context.user(continuation))
+    state = %{state | context: context, streaming: true, interrupted: false}
+
+    notify(state.subscriber, %Event.AgentStart{})
+
+    lctx = %{
+      provider_pid: self(),
+      model: state.model,
+      tools: state.tools,
+      thinking_level: state.thinking_level,
+      max_tokens: state.max_tokens,
+      max_retries: state.max_retries,
+      llm_client: state.llm_client
+    }
+
+    task = Task.async(fn -> run_agent_loop(lctx, context) end)
+    state = %{state | task: task}
+
     {:reply, :ok, state}
   end
 
@@ -356,10 +407,20 @@ defmodule Minga.Agent.Providers.Native do
     {:noreply, %{state | context: context}}
   end
 
+  def handle_info({:stream_interrupted, _partial_text}, state) do
+    {:noreply, %{state | interrupted: true}}
+  end
+
   def handle_info({ref, :ok}, %{task: %Task{ref: ref}} = state) do
     # Task completed normally
     Process.demonitor(ref, [:flush])
     {:noreply, %{state | task: nil, streaming: false}}
+  end
+
+  def handle_info({ref, {:error, :stream_interrupted}}, %{task: %Task{ref: ref}} = state) do
+    # Stream was interrupted but partial response was preserved
+    Process.demonitor(ref, [:flush])
+    {:noreply, %{state | task: nil, streaming: false, interrupted: true}}
   end
 
   def handle_info({ref, {:error, reason}}, %{task: %Task{ref: ref}} = state) do
@@ -441,26 +502,38 @@ defmodule Minga.Agent.Providers.Native do
   @spec process_and_continue(loop_ctx(), Context.t(), StreamResponse.t()) ::
           :ok | {:error, term()}
   defp process_and_continue(lctx, context, stream_response) do
-    case StreamResponse.process_stream(stream_response,
-           on_result: fn text ->
-             send(lctx.provider_pid, {:agent_event, %Event.TextDelta{delta: text}})
-           end,
-           on_thinking: fn text ->
-             send(lctx.provider_pid, {:agent_event, %Event.ThinkingDelta{delta: text}})
-           end,
-           on_tool_call: fn chunk ->
-             send(
-               lctx.provider_pid,
-               {:agent_event,
-                %Event.ToolStart{
-                  tool_call_id:
-                    Map.get(chunk.metadata, :id, "tool_#{:erlang.unique_integer([:positive])}"),
-                  name: chunk.name || "unknown",
-                  args: chunk.arguments || %{}
-                }}
-             )
-           end
-         ) do
+    # Track partial text as it streams in. If the stream drops, we still
+    # have what was received so far. Using an Agent (the OTP kind, not the
+    # AI kind) for thread-safe accumulation from the callback closures.
+    {:ok, accumulator} = Agent.start_link(fn -> "" end)
+
+    result =
+      StreamResponse.process_stream(stream_response,
+        on_result: fn text ->
+          Agent.update(accumulator, fn acc -> acc <> text end)
+          send(lctx.provider_pid, {:agent_event, %Event.TextDelta{delta: text}})
+        end,
+        on_thinking: fn text ->
+          send(lctx.provider_pid, {:agent_event, %Event.ThinkingDelta{delta: text}})
+        end,
+        on_tool_call: fn chunk ->
+          send(
+            lctx.provider_pid,
+            {:agent_event,
+             %Event.ToolStart{
+               tool_call_id:
+                 Map.get(chunk.metadata, :id, "tool_#{:erlang.unique_integer([:positive])}"),
+               name: chunk.name || "unknown",
+               args: chunk.arguments || %{}
+             }}
+          )
+        end
+      )
+
+    partial_text = Agent.get(accumulator, & &1)
+    Agent.stop(accumulator)
+
+    case result do
       {:ok, response} ->
         tool_calls = extract_tool_calls(response)
         text = extract_text(response)
@@ -468,8 +541,41 @@ defmodule Minga.Agent.Providers.Native do
         dispatch_result(lctx, context, tool_calls, text, usage)
 
       {:error, reason} ->
-        emit_error_and_end(lctx.provider_pid, format_error(reason))
-        {:error, reason}
+        handle_stream_error(lctx, context, partial_text, reason)
+    end
+  end
+
+  # When a stream drops mid-response, preserve whatever text was received.
+  # If we got meaningful partial text, save it in context so the user can
+  # /continue from where it left off instead of losing everything.
+  @spec handle_stream_error(loop_ctx(), Context.t(), String.t(), term()) :: {:error, term()}
+  defp handle_stream_error(lctx, context, partial_text, reason) do
+    if partial_text != "" and String.length(partial_text) > 10 do
+      # Preserve the partial response in context
+      partial_msg = Context.assistant(partial_text <> "\n\n[response interrupted]")
+      updated_context = Context.append(context, partial_msg)
+      send(lctx.provider_pid, {:agent_context_update, updated_context})
+      send(lctx.provider_pid, {:stream_interrupted, partial_text})
+
+      send(
+        lctx.provider_pid,
+        {:agent_event,
+         %Event.TextDelta{
+           delta:
+             "\n\n⚠️ Stream interrupted: #{format_error(reason)}. " <>
+               "Partial response preserved. Use /continue to resume."
+         }}
+      )
+
+      send(
+        lctx.provider_pid,
+        {:agent_event, %Event.AgentEnd{usage: nil}}
+      )
+
+      {:error, :stream_interrupted}
+    else
+      emit_error_and_end(lctx.provider_pid, format_error(reason))
+      {:error, reason}
     end
   end
 

--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -167,6 +167,12 @@ defmodule Minga.Agent.Session do
     GenServer.call(session, :compact, 30_000)
   end
 
+  @doc "Continues from an interrupted stream response."
+  @spec continue(GenServer.server()) :: :ok | {:error, term()}
+  def continue(session) do
+    GenServer.call(session, :continue)
+  end
+
   @doc "Fetches available models from the provider."
   @spec get_available_models(GenServer.server()) :: {:ok, term()} | {:error, term()}
   def get_available_models(session) do
@@ -422,6 +428,19 @@ defmodule Minga.Agent.Session do
       {:reply, result, state}
     else
       {:reply, {:error, "Provider does not support compaction"}, state}
+    end
+  end
+
+  def handle_call(:continue, _from, %{provider: nil} = state) do
+    {:reply, {:error, "No active provider"}, state}
+  end
+
+  def handle_call(:continue, _from, state) do
+    if function_exported?(state.provider_module, :continue, 1) do
+      result = state.provider_module.continue(state.provider)
+      {:reply, result, state}
+    else
+      {:reply, {:error, "Provider does not support continue"}, state}
     end
   end
 

--- a/lib/minga/agent/slash_command.ex
+++ b/lib/minga/agent/slash_command.ex
@@ -45,7 +45,8 @@ defmodule Minga.Agent.SlashCommand do
       name: "system-prompt",
       description: "Show the current assembled system prompt"
     },
-    %{name: "compact", description: "Compact conversation context (summarize older turns)"}
+    %{name: "compact", description: "Compact conversation context (summarize older turns)"},
+    %{name: "continue", description: "Continue from an interrupted stream response"}
   ]
 
   @doc "Returns the list of all registered slash commands."
@@ -96,6 +97,7 @@ defmodule Minga.Agent.SlashCommand do
   defp dispatch(state, "instructions", _args), do: {:ok, do_instructions(state)}
   defp dispatch(state, "system-prompt", _args), do: {:ok, do_system_prompt(state)}
   defp dispatch(state, "compact", _args), do: do_compact(state)
+  defp dispatch(state, "continue", _args), do: do_continue(state)
   defp dispatch(_state, cmd, _args), do: {:error, "Unknown command: /#{cmd}"}
 
   # ── Command implementations ────────────────────────────────────────────────
@@ -319,6 +321,23 @@ defmodule Minga.Agent.SlashCommand do
   end
 
   @spec do_compact(state()) :: {:ok, state()} | {:error, String.t()}
+  @spec do_continue(state()) :: {:ok, state()} | {:error, String.t()}
+  defp do_continue(state) do
+    session = AgentAccess.session(state)
+
+    if is_pid(session) do
+      case Session.continue(session) do
+        :ok ->
+          {:ok, emit_system_message(state, "Continuing from interrupted response...")}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      {:error, "No active agent session"}
+    end
+  end
+
   defp do_compact(state) do
     session = AgentAccess.session(state)
 

--- a/test/minga/agent/providers/native_test.exs
+++ b/test/minga/agent/providers/native_test.exs
@@ -275,6 +275,150 @@ defmodule Minga.Agent.Providers.NativeTest do
     end
   end
 
+  describe "stream recovery" do
+    test "preserves partial text when stream drops mid-response", %{tmp_dir: dir} do
+      # Create a stream that emits some text then raises an error
+      client = fn _model, _messages, _opts ->
+        error_stream =
+          Stream.resource(
+            fn -> 0 end,
+            fn
+              0 -> {[ReqLLM.StreamChunk.text("Hello, I was saying something ")], 1}
+              1 -> {[ReqLLM.StreamChunk.text("important about ")], 2}
+              2 -> raise "connection reset by peer"
+            end,
+            fn _ -> :ok end
+          )
+
+        build_stream_response(error_stream)
+      end
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, max_retries: 0)
+      :ok = Native.send_prompt(pid, "Tell me something important")
+
+      events = collect_events(1_000)
+
+      # Should have streamed the partial text before the error
+      text_deltas = Enum.filter(events, &match?(%Event.TextDelta{}, &1))
+      streamed_text = Enum.map(text_deltas, & &1.delta) |> Enum.join()
+      assert streamed_text =~ "Hello, I was saying something"
+      assert streamed_text =~ "important about"
+
+      # Should have an interruption notice
+      assert streamed_text =~ "Stream interrupted"
+
+      # Should have AgentEnd (not left hanging)
+      assert Enum.any?(events, &match?(%Event.AgentEnd{}, &1))
+    end
+
+    test "continue resumes after interrupted stream", %{tmp_dir: dir} do
+      call_count = :counters.new(1, [:atomics])
+
+      client = fn _model, _messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          # First call: stream drops mid-response
+          error_stream =
+            Stream.resource(
+              fn -> 0 end,
+              fn
+                0 -> {[ReqLLM.StreamChunk.text("Partial response here")], 1}
+                1 -> raise "connection reset"
+              end,
+              fn _ -> :ok end
+            )
+
+          build_stream_response(error_stream)
+        else
+          # Second call (continue): complete response
+          chunks = [
+            ReqLLM.StreamChunk.text("Continuing from where I left off."),
+            ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
+          ]
+
+          build_stream_response(chunks)
+        end
+      end
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, max_retries: 0)
+
+      # First prompt gets interrupted
+      :ok = Native.send_prompt(pid, "Tell me something")
+      _events1 = collect_events(1_000)
+
+      # Continue should work
+      :ok = Native.continue(pid)
+      events2 = collect_events(1_000)
+
+      text_deltas = Enum.filter(events2, &match?(%Event.TextDelta{}, &1))
+      continued_text = Enum.map(text_deltas, & &1.delta) |> Enum.join()
+      assert continued_text =~ "Continuing from where I left off"
+    end
+
+    test "continue fails when no stream was interrupted", %{tmp_dir: dir} do
+      chunks = [
+        ReqLLM.StreamChunk.text("Complete response"),
+        ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
+      ]
+
+      client = fake_llm_client(chunks)
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client)
+
+      :ok = Native.send_prompt(pid, "Hello")
+      _events = collect_events(500)
+
+      assert {:error, "No interrupted response to continue from"} = Native.continue(pid)
+    end
+
+    test "continue fails while already streaming", %{tmp_dir: dir} do
+      client = fn _model, _messages, _opts ->
+        slow_stream =
+          Stream.unfold(0, fn n ->
+            Process.sleep(100)
+            {ReqLLM.StreamChunk.text("chunk #{n}"), n + 1}
+          end)
+
+        build_stream_response(slow_stream)
+      end
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client)
+      :ok = Native.send_prompt(pid, "Long story")
+      Process.sleep(50)
+
+      assert {:error, "Already streaming"} = Native.continue(pid)
+
+      Native.abort(pid)
+    end
+
+    test "small partial text does not trigger recovery", %{tmp_dir: dir} do
+      # Stream only a few characters, then error - should get a normal error, not recovery
+      client = fn _model, _messages, _opts ->
+        error_stream =
+          Stream.resource(
+            fn -> 0 end,
+            fn
+              0 -> {[ReqLLM.StreamChunk.text("Hi")], 1}
+              1 -> raise "connection reset"
+            end,
+            fn _ -> :ok end
+          )
+
+        build_stream_response(error_stream)
+      end
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, max_retries: 0)
+      :ok = Native.send_prompt(pid, "Hello")
+
+      events = collect_events(1_000)
+
+      # Should get a normal error, not the recovery path
+      error_events = Enum.filter(events, &match?(%Event.Error{}, &1))
+      assert length(error_events) >= 1
+    end
+  end
+
   describe "concurrent prompt rejection" do
     test "rejects second prompt while streaming", %{tmp_dir: dir} do
       client = fn _model, _messages, _opts ->


### PR DESCRIPTION
## What

When a stream drops mid-response, partial text is preserved in context and the user can /continue to resume.

## Why

Long agent responses (30-60s) are vulnerable to network hiccups. Previously, a dropped stream lost everything and showed a generic error. Now the partial response is kept and the user can resume without re-prompting.

## Changes

- **`Providers.Native`**: `process_and_continue` now tracks partial text via an OTP Agent accumulator alongside streaming callbacks. On stream error with >10 chars of partial text, saves partial response to context with `[interrupted]` marker and emits a recovery notice. New `continue/1` function sends a continuation prompt.
- **`Session`**: New `continue/1` routing to provider.
- **`SlashCommand`**: New `/continue` command.
- **State**: Added `interrupted` and `last_user_prompt` fields.
- **Tests**: 4 new tests covering partial preservation, continue flow, rejection when not interrupted, and rejection while streaming.

Closes #274