### PR TITLE
feat(agent): image input support via @image.png mentions

### DIFF
--- a/lib/minga/agent/file_mention.ex
+++ b/lib/minga/agent/file_mention.ex
@@ -41,8 +41,21 @@ defmodule Minga.Agent.FileMention do
           anchor_col: non_neg_integer()
         }
 
+  alias ReqLLM.Message.ContentPart
+
   @max_candidates 10
   @max_file_size 256 * 1024
+  @max_image_size 5 * 1024 * 1024
+
+  @image_extensions ~w(.png .jpg .jpeg .gif .webp)
+
+  @image_media_types %{
+    ".png" => "image/png",
+    ".jpg" => "image/jpeg",
+    ".jpeg" => "image/jpeg",
+    ".gif" => "image/gif",
+    ".webp" => "image/webp"
+  }
 
   # ── Extraction ──────────────────────────────────────────────────────────────
 
@@ -81,12 +94,17 @@ defmodule Minga.Agent.FileMention do
   @doc """
   Resolves all `@path` mentions in the text and returns an augmented prompt.
 
-  Each mentioned file's content is prepended as a fenced code block.
-  The `@path` references are removed from the body text.
+  Each mentioned text file is prepended as a fenced code block.
+  Image files (PNG, JPEG, GIF, WebP) are returned as ContentPart structs
+  for multi-modal API requests.
 
-  Returns `{:error, message}` if any file doesn't exist or can't be read.
+  Returns:
+  - `{:ok, String.t()}` when only text files are mentioned
+  - `{:ok, [ContentPart.t()]}` when images are present (mixed text + image parts)
+  - `{:error, message}` if any file doesn't exist or can't be read
   """
-  @spec resolve_prompt(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec resolve_prompt(String.t(), String.t()) ::
+          {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
   def resolve_prompt(text, project_root) do
     mentions = extract_mentions(text)
 
@@ -97,13 +115,25 @@ defmodule Minga.Agent.FileMention do
     end
   end
 
+  @doc "Returns true if the path has an image file extension."
+  @spec image_path?(String.t()) :: boolean()
+  def image_path?(path) do
+    ext = path |> Path.extname() |> String.downcase()
+    ext in @image_extensions
+  end
+
   @spec resolve_all([mention()], String.t(), String.t()) ::
-          {:ok, String.t()} | {:error, String.t()}
+          {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
   defp resolve_all(mentions, text, root) do
     results =
       Enum.map(mentions, fn %{path: path} ->
         abs_path = Path.expand(path, root)
-        {path, read_file_safe(abs_path)}
+
+        if image_path?(path) do
+          {path, read_image_safe(abs_path)}
+        else
+          {path, read_file_safe(abs_path)}
+        end
       end)
 
     errors = Enum.filter(results, fn {_path, result} -> match?({:error, _}, result) end)
@@ -112,16 +142,96 @@ defmodule Minga.Agent.FileMention do
       missing = Enum.map(errors, fn {path, {:error, reason}} -> "  #{path}: #{reason}" end)
       {:error, "Cannot resolve file mentions:\n#{Enum.join(missing, "\n")}"}
     else
-      context_blocks =
-        Enum.map_join(results, "\n\n", fn {path, {:ok, content}} ->
-          ext = Path.extname(path) |> String.trim_leading(".")
-          "Contents of #{path}:\n```#{ext}\n#{content}\n```"
-        end)
+      has_images =
+        Enum.any?(results, fn {_path, result} -> match?({:ok, {:image, _, _, _}}, result) end)
 
-      # Remove @mentions from the body text
       body = remove_mentions(text, mentions)
-      prompt = context_blocks <> "\n\n" <> String.trim(body)
-      {:ok, prompt}
+
+      if has_images do
+        build_multimodal_parts(results, body)
+      else
+        build_text_prompt(results, body)
+      end
+    end
+  end
+
+  @spec build_text_prompt([{String.t(), {:ok, String.t()}}], String.t()) :: {:ok, String.t()}
+  defp build_text_prompt(results, body) do
+    context_blocks =
+      Enum.map_join(results, "\n\n", fn {path, {:ok, content}} ->
+        ext = Path.extname(path) |> String.trim_leading(".")
+        "Contents of #{path}:\n```#{ext}\n#{content}\n```"
+      end)
+
+    prompt = context_blocks <> "\n\n" <> String.trim(body)
+    {:ok, prompt}
+  end
+
+  @spec build_multimodal_parts(
+          [
+            {String.t(),
+             {:ok, String.t()} | {:ok, {:image, binary(), String.t(), non_neg_integer()}}}
+          ],
+          String.t()
+        ) :: {:ok, [ContentPart.t()]}
+  defp build_multimodal_parts(results, body) do
+    # Build text context for non-image files
+    text_parts =
+      results
+      |> Enum.reject(fn {_path, result} -> match?({:ok, {:image, _, _, _}}, result) end)
+      |> Enum.map(fn {path, {:ok, content}} ->
+        ext = Path.extname(path) |> String.trim_leading(".")
+        "Contents of #{path}:\n```#{ext}\n#{content}\n```"
+      end)
+
+    # Build image parts
+    image_parts =
+      results
+      |> Enum.filter(fn {_path, result} -> match?({:ok, {:image, _, _, _}}, result) end)
+      |> Enum.map(fn {path, {:ok, {:image, data, media_type, size}}} ->
+        size_kb = div(size, 1024)
+        metadata = %{filename: Path.basename(path), size_display: "#{size_kb}KB"}
+        ContentPart.image(data, media_type, metadata)
+      end)
+
+    # Combine: text context first, then the user's prompt, then images
+    text_context = Enum.join(text_parts, "\n\n")
+
+    prompt_text =
+      if text_context == "" do
+        String.trim(body)
+      else
+        text_context <> "\n\n" <> String.trim(body)
+      end
+
+    parts = [ContentPart.text(prompt_text) | image_parts]
+    {:ok, parts}
+  end
+
+  @spec read_image_safe(String.t()) ::
+          {:ok, {:image, binary(), String.t(), non_neg_integer()}} | {:error, String.t()}
+  defp read_image_safe(path) do
+    ext = path |> Path.extname() |> String.downcase()
+    media_type = Map.get(@image_media_types, ext, "image/png")
+
+    case File.stat(path) do
+      {:ok, %{type: :regular, size: size}} when size > @max_image_size ->
+        {:error, "image too large (#{div(size, 1024)}KB, max #{div(@max_image_size, 1024)}KB)"}
+
+      {:ok, %{type: :regular, size: size}} ->
+        case File.read(path) do
+          {:ok, data} -> {:ok, {:image, data, media_type, size}}
+          {:error, reason} -> {:error, "#{reason}"}
+        end
+
+      {:ok, %{type: type}} ->
+        {:error, "not a regular file (#{type})"}
+
+      {:error, :enoent} ->
+        {:error, "file not found"}
+
+      {:error, reason} ->
+        {:error, "#{reason}"}
     end
   end
 

--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -207,16 +207,17 @@ defmodule Minga.Agent.Providers.Native do
     {:reply, {:error, :already_streaming}, state}
   end
 
-  def handle_call({:send_prompt, text}, _from, state) do
-    # Append user message to context
-    context = Context.append(state.context, Context.user(text))
+  def handle_call({:send_prompt, content}, _from, state) do
+    # Append user message to context.
+    # content is either a string or a list of ContentPart (for multi-modal).
+    context = Context.append(state.context, Context.user(content))
 
     state = %{
       state
       | context: context,
         streaming: true,
         interrupted: false,
-        last_user_prompt: text
+        last_user_prompt: content
     }
 
     # Notify subscriber that agent is starting

--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -67,10 +67,16 @@ defmodule Minga.Agent.Session do
     GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name))
   end
 
-  @doc "Sends a user prompt to the agent."
-  @spec send_prompt(GenServer.server(), String.t()) :: :ok | {:error, term()}
-  def send_prompt(session, text) when is_binary(text) do
-    GenServer.call(session, {:send_prompt, text})
+  @doc """
+  Sends a user prompt to the agent.
+
+  Accepts either a plain text string or a list of ContentPart structs
+  (for multi-modal messages with images).
+  """
+  @spec send_prompt(GenServer.server(), String.t() | [ReqLLM.Message.ContentPart.t()]) ::
+          :ok | {:error, term()}
+  def send_prompt(session, content) when is_binary(content) or is_list(content) do
+    GenServer.call(session, {:send_prompt, content})
   end
 
   @doc "Aborts the current agent operation."

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -355,9 +355,10 @@ defmodule Minga.Editor.Commands.Agent do
 
   @spec send_prompt_to_llm(state(), String.t()) :: state()
   defp send_prompt_to_llm(state, text) do
-    # Resolve @file mentions before sending to the LLM
-    with {:ok, resolved_text} <- resolve_mentions(text),
-         :ok <- Session.send_prompt(AgentAccess.session(state), resolved_text) do
+    # Resolve @file mentions before sending to the LLM.
+    # Returns either a string (text only) or a list of ContentPart (when images are present).
+    with {:ok, resolved} <- resolve_mentions(text),
+         :ok <- Session.send_prompt(AgentAccess.session(state), resolved) do
       state = update_agent(state, &AgentState.clear_input_and_scroll/1)
 
       AgentAccess.update_agentic(state, fn _ ->
@@ -375,7 +376,8 @@ defmodule Minga.Editor.Commands.Agent do
     end
   end
 
-  @spec resolve_mentions(String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec resolve_mentions(String.t()) ::
+          {:ok, String.t()} | {:ok, [ReqLLM.Message.ContentPart.t()]} | {:error, String.t()}
   defp resolve_mentions(text) do
     root = project_root()
     FileMention.resolve_prompt(text, root)

--- a/test/minga/agent/file_mention_test.exs
+++ b/test/minga/agent/file_mention_test.exs
@@ -104,6 +104,97 @@ defmodule Minga.Agent.FileMentionTest do
     end
   end
 
+  # ── Image support ────────────────────────────────────────────────────────────
+
+  describe "image_path?/1" do
+    test "recognizes image extensions" do
+      assert FileMention.image_path?("screenshot.png")
+      assert FileMention.image_path?("photo.jpg")
+      assert FileMention.image_path?("photo.jpeg")
+      assert FileMention.image_path?("anim.gif")
+      assert FileMention.image_path?("modern.webp")
+    end
+
+    test "case insensitive" do
+      assert FileMention.image_path?("PHOTO.PNG")
+      assert FileMention.image_path?("image.JPG")
+    end
+
+    test "rejects non-image extensions" do
+      refute FileMention.image_path?("code.ex")
+      refute FileMention.image_path?("readme.md")
+      refute FileMention.image_path?("data.json")
+    end
+  end
+
+  describe "resolve_prompt/2 with images" do
+    test "returns ContentPart list when image is mentioned", %{tmp_dir: dir} do
+      # Create a minimal 1x1 red PNG (67 bytes)
+      png_data = create_minimal_png()
+      path = Path.join(dir, "screenshot.png")
+      File.write!(path, png_data)
+
+      {:ok, parts} = FileMention.resolve_prompt("@screenshot.png what is this?", dir)
+
+      assert is_list(parts)
+      assert length(parts) == 2
+
+      [text_part, image_part] = parts
+      assert text_part.type == :text
+      assert text_part.text =~ "what is this?"
+
+      assert image_part.type == :image
+      assert image_part.media_type == "image/png"
+      assert is_binary(image_part.data)
+    end
+
+    test "mixes text files and images as content parts", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "code.ex"), "defmodule Foo do\nend")
+      File.write!(Path.join(dir, "design.png"), create_minimal_png())
+
+      {:ok, parts} = FileMention.resolve_prompt("@code.ex @design.png compare", dir)
+
+      assert is_list(parts)
+      text_parts = Enum.filter(parts, &(&1.type == :text))
+      image_parts = Enum.filter(parts, &(&1.type == :image))
+
+      assert length(text_parts) == 1
+      assert length(image_parts) == 1
+
+      assert hd(text_parts).text =~ "defmodule Foo"
+      assert hd(text_parts).text =~ "compare"
+    end
+
+    test "rejects oversized images", %{tmp_dir: dir} do
+      # Create a file that exceeds the 5MB limit
+      path = Path.join(dir, "huge.png")
+      File.write!(path, :binary.copy(<<0>>, 6 * 1024 * 1024))
+
+      assert {:error, msg} = FileMention.resolve_prompt("@huge.png look", dir)
+      assert msg =~ "image too large"
+    end
+
+    test "returns error for missing image file", %{tmp_dir: dir} do
+      assert {:error, msg} = FileMention.resolve_prompt("@missing.png look", dir)
+      assert msg =~ "file not found"
+    end
+
+    test "text-only mentions still return a string", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "test.ex"), "code")
+
+      {:ok, result} = FileMention.resolve_prompt("@test.ex explain", dir)
+      assert is_binary(result)
+    end
+  end
+
+  # Helper to create a minimal valid PNG for testing
+  defp create_minimal_png do
+    # Minimal 1x1 red PNG
+    <<137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 2,
+      0, 0, 0, 144, 119, 83, 222, 0, 0, 0, 12, 73, 68, 65, 84, 8, 215, 99, 248, 207, 192, 0, 0, 0,
+      3, 0, 1, 24, 216, 141, 110, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130>>
+  end
+
   # ── Completion ──────────────────────────────────────────────────────────────
 
   describe "new_completion/3" do


### PR DESCRIPTION
## What

Users can attach images to agent prompts using `@path/to/image.png` mentions. Images are sent inline as base64-encoded content parts for vision-capable models (Claude, GPT-4o, Gemini).

## Why

Image input is essential for UI work: "make it match this mockup", "what's wrong with this chart". Without it, the native provider can't handle visual tasks. Supported formats: PNG, JPEG, GIF, WebP.

## Changes

- **`FileMention`**: Detects image extensions and reads as binary. `resolve_prompt` returns `[ContentPart.t()]` when images are present, preserving backward compat with string return for text-only mentions. Images capped at 5MB.
- **`Session.send_prompt/2`**: Now accepts both strings and ContentPart lists.
- **`Providers.Native`**: Passes content to `Context.user/1` which handles both formats.
- **`Commands.Agent`**: Updated spec for multimodal resolve result.
- **Tests**: 8 new tests for image detection, multimodal resolution, mixed text+image, size limits, error cases.

Closes #281