### PR TITLE
feat(agent): session export to Markdown via /export

### DIFF
--- a/lib/minga/agent/session_export.ex
+++ b/lib/minga/agent/session_export.ex
@@ -1,0 +1,223 @@
+defmodule Minga.Agent.SessionExport do
+  @moduledoc """
+  Exports agent conversation sessions to Markdown files.
+
+  Iterates the conversation context and formats each message into
+  readable Markdown: user prompts as blockquotes, assistant responses
+  as plain text, tool calls as collapsible `<details>` sections,
+  and system messages as italic notes.
+  """
+
+  alias ReqLLM.Message.ContentPart
+
+  @typedoc "Options for export."
+  @type export_opts :: [
+          project_root: String.t(),
+          model: String.t() | nil,
+          session_id: String.t() | nil
+        ]
+
+  @doc """
+  Exports conversation messages to a Markdown string.
+
+  Returns `{:ok, markdown, filename}` or `{:error, reason}`.
+  """
+  @spec to_markdown([ReqLLM.Message.t()], export_opts()) ::
+          {:ok, String.t(), String.t()} | {:error, String.t()}
+  def to_markdown([], _opts), do: {:error, "Nothing to export (empty session)"}
+
+  def to_markdown(messages, opts) when is_list(messages) do
+    # Filter out system messages from the export (they're internal)
+    exportable = Enum.reject(messages, fn msg -> msg.role == :system end)
+
+    if exportable == [] do
+      {:error, "Nothing to export (only system messages)"}
+    else
+      model = Keyword.get(opts, :model, "unknown")
+      session_id = Keyword.get(opts, :session_id) || short_id()
+      date = Date.utc_today() |> Date.to_iso8601()
+      filename = "minga-session-#{session_id}-#{date}.md"
+
+      header = """
+      # Minga Session Export
+
+      - **Date:** #{date}
+      - **Model:** #{model}
+      - **Messages:** #{length(exportable)}
+
+      ---
+      """
+
+      body = Enum.map_join(exportable, "\n\n---\n\n", &format_message/1)
+      markdown = header <> "\n" <> body <> "\n"
+
+      {:ok, markdown, filename}
+    end
+  end
+
+  @doc """
+  Exports and writes to a file in the project root.
+
+  Returns `{:ok, path}` or `{:error, reason}`.
+  """
+  @spec export_to_file([ReqLLM.Message.t()], export_opts()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def export_to_file(messages, opts) do
+    root = Keyword.get(opts, :project_root, File.cwd!())
+
+    case to_markdown(messages, opts) do
+      {:ok, markdown, filename} ->
+        path = Path.join(root, filename)
+        File.write!(path, markdown)
+        {:ok, path}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # ── Message formatting ──────────────────────────────────────────────────────
+
+  @spec format_message(ReqLLM.Message.t()) :: String.t()
+  defp format_message(%{role: :user} = msg) do
+    text = extract_text(msg.content)
+    images = count_images(msg.content)
+
+    image_note =
+      if images > 0,
+        do: " _(#{images} image#{if images > 1, do: "s", else: ""} attached)_",
+        else: ""
+
+    "## 👤 User#{image_note}\n\n" <> blockquote(text)
+  end
+
+  defp format_message(%{role: :assistant, tool_calls: tool_calls} = msg)
+       when is_list(tool_calls) and tool_calls != [] do
+    text = extract_text(msg.content)
+    thinking = extract_thinking(msg.content)
+
+    parts = []
+
+    parts =
+      if thinking != "" do
+        parts ++
+          [
+            "## 🤖 Assistant\n\n<details>\n<summary>💭 Thinking</summary>\n\n#{thinking}\n\n</details>"
+          ]
+      else
+        parts ++ ["## 🤖 Assistant"]
+      end
+
+    parts =
+      if text != "" do
+        parts ++ [text]
+      else
+        parts
+      end
+
+    tool_sections =
+      Enum.map(tool_calls, fn tc ->
+        name = tc.name || "unknown"
+        args = if tc.arguments, do: Jason.encode!(tc.arguments, pretty: true), else: "{}"
+
+        """
+        <details>
+        <summary>🔧 Tool call: #{name}</summary>
+
+        ```json
+        #{args}
+        ```
+
+        </details>
+        """
+      end)
+
+    Enum.join(parts ++ tool_sections, "\n\n")
+  end
+
+  defp format_message(%{role: :assistant} = msg) do
+    text = extract_text(msg.content)
+    thinking = extract_thinking(msg.content)
+
+    parts = ["## 🤖 Assistant"]
+
+    parts =
+      if thinking != "" do
+        parts ++ ["<details>\n<summary>💭 Thinking</summary>\n\n#{thinking}\n\n</details>"]
+      else
+        parts
+      end
+
+    parts =
+      if text != "" do
+        parts ++ [text]
+      else
+        parts
+      end
+
+    Enum.join(parts, "\n\n")
+  end
+
+  defp format_message(%{role: :tool} = msg) do
+    text = extract_text(msg.content)
+    name = msg.name || "tool"
+    tool_call_id = msg.tool_call_id || ""
+
+    """
+    <details>
+    <summary>📋 Tool result: #{name} (#{tool_call_id})</summary>
+
+    ```
+    #{String.slice(text, 0, 5000)}
+    ```
+
+    </details>
+    """
+  end
+
+  defp format_message(%{role: role} = msg) do
+    text = extract_text(msg.content)
+    "_#{role}: #{text}_"
+  end
+
+  # ── Helpers ─────────────────────────────────────────────────────────────────
+
+  @spec extract_text([ContentPart.t()]) :: String.t()
+  defp extract_text(parts) when is_list(parts) do
+    parts
+    |> Enum.filter(&(&1.type == :text))
+    |> Enum.map_join("", & &1.text)
+  end
+
+  defp extract_text(_), do: ""
+
+  @spec extract_thinking([ContentPart.t()]) :: String.t()
+  defp extract_thinking(parts) when is_list(parts) do
+    parts
+    |> Enum.filter(&(&1.type == :thinking))
+    |> Enum.map_join("", & &1.text)
+  end
+
+  defp extract_thinking(_), do: ""
+
+  @spec count_images([ContentPart.t()]) :: non_neg_integer()
+  defp count_images(parts) when is_list(parts) do
+    Enum.count(parts, &(&1.type in [:image, :image_url]))
+  end
+
+  defp count_images(_), do: 0
+
+  @spec blockquote(String.t()) :: String.t()
+  defp blockquote(text) do
+    text
+    |> String.split("\n")
+    |> Enum.map_join("\n", &("> " <> &1))
+  end
+
+  @spec short_id() :: String.t()
+  defp short_id do
+    :crypto.strong_rand_bytes(4)
+    |> Base.hex_encode32(case: :lower, padding: false)
+    |> String.slice(0, 6)
+  end
+end

--- a/lib/minga/agent/slash_command.ex
+++ b/lib/minga/agent/slash_command.ex
@@ -12,6 +12,7 @@ defmodule Minga.Agent.SlashCommand do
   alias Minga.Agent.Instructions
   alias Minga.Agent.PanelState
   alias Minga.Agent.Session
+  alias Minga.Agent.SessionExport
   alias Minga.Config.Options
   alias Minga.Editor.Commands.Agent, as: AgentCommands
   alias Minga.Editor.PickerUI
@@ -46,7 +47,8 @@ defmodule Minga.Agent.SlashCommand do
       description: "Show the current assembled system prompt"
     },
     %{name: "compact", description: "Compact conversation context (summarize older turns)"},
-    %{name: "continue", description: "Continue from an interrupted stream response"}
+    %{name: "continue", description: "Continue from an interrupted stream response"},
+    %{name: "export", description: "Export current session to a Markdown file"}
   ]
 
   @doc "Returns the list of all registered slash commands."
@@ -98,6 +100,7 @@ defmodule Minga.Agent.SlashCommand do
   defp dispatch(state, "system-prompt", _args), do: {:ok, do_system_prompt(state)}
   defp dispatch(state, "compact", _args), do: do_compact(state)
   defp dispatch(state, "continue", _args), do: do_continue(state)
+  defp dispatch(state, "export", _args), do: do_export(state)
   defp dispatch(_state, cmd, _args), do: {:error, "Unknown command: /#{cmd}"}
 
   # ── Command implementations ────────────────────────────────────────────────
@@ -329,6 +332,30 @@ defmodule Minga.Agent.SlashCommand do
       case Session.continue(session) do
         :ok ->
           {:ok, emit_system_message(state, "Continuing from interrupted response...")}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      {:error, "No active agent session"}
+    end
+  end
+
+  @spec do_export(state()) :: {:ok, state()} | {:error, String.t()}
+  defp do_export(state) do
+    session = AgentAccess.session(state)
+
+    if is_pid(session) do
+      messages = Session.messages(session)
+      root = detect_project_root()
+
+      model = read_config_string(:agent_model)
+      model = if model == "", do: "unknown", else: model
+
+      case SessionExport.export_to_file(messages, project_root: root, model: model) do
+        {:ok, path} ->
+          relative = Path.relative_to(path, root)
+          {:ok, emit_system_message(state, "Session exported to ./#{relative}")}
 
         {:error, reason} ->
           {:error, reason}

--- a/test/minga/agent/session_export_test.exs
+++ b/test/minga/agent/session_export_test.exs
@@ -1,0 +1,137 @@
+defmodule Minga.Agent.SessionExportTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Agent.SessionExport
+  alias ReqLLM.Message
+  alias ReqLLM.Message.ContentPart
+
+  @moduletag :tmp_dir
+
+  defp user_msg(text) do
+    %Message{role: :user, content: [ContentPart.text(text)]}
+  end
+
+  defp assistant_msg(text) do
+    %Message{role: :assistant, content: [ContentPart.text(text)]}
+  end
+
+  defp system_msg(text) do
+    %Message{role: :system, content: [ContentPart.text(text)]}
+  end
+
+  defp tool_result_msg(name, tool_call_id, result) do
+    %Message{
+      role: :tool,
+      name: name,
+      tool_call_id: tool_call_id,
+      content: [ContentPart.text(result)]
+    }
+  end
+
+  describe "to_markdown/2" do
+    test "formats a simple conversation" do
+      messages = [
+        user_msg("What is 2+2?"),
+        assistant_msg("The answer is 4.")
+      ]
+
+      assert {:ok, md, filename} = SessionExport.to_markdown(messages, model: "claude-sonnet-4")
+      assert md =~ "# Minga Session Export"
+      assert md =~ "claude-sonnet-4"
+      assert md =~ "## 👤 User"
+      assert md =~ "> What is 2+2?"
+      assert md =~ "## 🤖 Assistant"
+      assert md =~ "The answer is 4."
+      assert filename =~ "minga-session-"
+      assert filename =~ ".md"
+    end
+
+    test "excludes system messages from export" do
+      messages = [
+        system_msg("You are a helpful assistant"),
+        user_msg("Hello"),
+        assistant_msg("Hi!")
+      ]
+
+      assert {:ok, md, _} = SessionExport.to_markdown(messages, [])
+      refute md =~ "You are a helpful assistant"
+      assert md =~ "Hello"
+      assert md =~ "Hi!"
+    end
+
+    test "returns error for empty messages" do
+      assert {:error, "Nothing to export" <> _} = SessionExport.to_markdown([], [])
+    end
+
+    test "returns error for system-only messages" do
+      messages = [system_msg("system prompt")]
+      assert {:error, "Nothing to export" <> _} = SessionExport.to_markdown(messages, [])
+    end
+
+    test "formats tool results as collapsible details" do
+      messages = [
+        user_msg("Read the file"),
+        tool_result_msg("read_file", "tc_1", "defmodule Foo do\nend")
+      ]
+
+      assert {:ok, md, _} = SessionExport.to_markdown(messages, [])
+      assert md =~ "<details>"
+      assert md =~ "read_file"
+      assert md =~ "defmodule Foo"
+    end
+
+    test "formats assistant messages with thinking" do
+      messages = [
+        user_msg("Think about this"),
+        %Message{
+          role: :assistant,
+          content: [
+            ContentPart.thinking("Let me consider..."),
+            ContentPart.text("Here is my answer.")
+          ]
+        }
+      ]
+
+      assert {:ok, md, _} = SessionExport.to_markdown(messages, [])
+      assert md =~ "💭 Thinking"
+      assert md =~ "Let me consider..."
+      assert md =~ "Here is my answer."
+    end
+
+    test "notes image attachments in user messages" do
+      messages = [
+        %Message{
+          role: :user,
+          content: [
+            ContentPart.text("What is this?"),
+            ContentPart.image(<<1, 2, 3>>, "image/png")
+          ]
+        }
+      ]
+
+      assert {:ok, md, _} = SessionExport.to_markdown(messages, [])
+      assert md =~ "1 image attached"
+    end
+  end
+
+  describe "export_to_file/2" do
+    test "writes markdown file to project root", %{tmp_dir: dir} do
+      messages = [
+        user_msg("Hello"),
+        assistant_msg("Hi!")
+      ]
+
+      assert {:ok, path} = SessionExport.export_to_file(messages, project_root: dir)
+      assert File.exists?(path)
+      assert String.starts_with?(path, dir)
+
+      content = File.read!(path)
+      assert content =~ "# Minga Session Export"
+      assert content =~ "Hello"
+    end
+
+    test "returns error for empty session", %{tmp_dir: dir} do
+      assert {:error, _} = SessionExport.export_to_file([], project_root: dir)
+    end
+  end
+end


### PR DESCRIPTION
## What

Users can export the current agent session to a Markdown file using `/export`.

## Why

Agent conversations contain valuable context: architectural decisions, debugging sessions, code reviews. Being able to save and share them turns ephemeral chat into durable documentation.

## Changes

- **`Minga.Agent.SessionExport`** (new): Formats conversation messages into Markdown. User prompts as blockquotes, assistant responses with optional thinking in collapsible details, tool calls/results in collapsible sections, image attachment counts noted.
- **`SlashCommand`**: New `/export` command writes session to `minga-session-{id}-{date}.md` in the project root.
- **Tests**: 9 tests covering message formatting, empty sessions, tool results, thinking blocks, image notes, file writing.

Closes #284