### PR TITLE
feat(agent): skills system for context-aware prompt injection

### DIFF
--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -39,6 +39,7 @@ defmodule Minga.Agent.Providers.Native do
   alias Minga.Agent.ModelCatalog
   alias Minga.Agent.ModelLimits
   alias Minga.Agent.Retry
+  alias Minga.Agent.Skills
   alias Minga.Agent.TokenEstimator
   alias Minga.Agent.Tools
   alias Minga.Agent.Tools.Shell
@@ -87,7 +88,8 @@ defmodule Minga.Agent.Providers.Native do
           task: Task.t() | nil,
           streaming: boolean(),
           interrupted: boolean(),
-          last_user_prompt: String.t() | nil
+          last_user_prompt: String.t() | nil,
+          active_skills: [Skills.skill()]
         }
 
   # ── Provider callbacks ──────────────────────────────────────────────────────
@@ -194,7 +196,8 @@ defmodule Minga.Agent.Providers.Native do
       task: nil,
       streaming: false,
       interrupted: false,
-      last_user_prompt: nil
+      last_user_prompt: nil,
+      active_skills: []
     }
 
     Minga.Log.info(:agent, "[Agent.Native] started with model=#{model} root=#{project_root}")
@@ -287,6 +290,43 @@ defmodule Minga.Agent.Providers.Native do
     state = %{state | task: task}
 
     {:reply, :ok, state}
+  end
+
+  def handle_call({:activate_skill, name}, _from, state) do
+    already_active = Enum.any?(state.active_skills, &(&1.name == name))
+
+    if already_active do
+      {:reply, {:error, "Skill '#{name}' is already active"}, state}
+    else
+      case Skills.find(name, state.project_root) do
+        {:ok, skill} ->
+          active = state.active_skills ++ [skill]
+          state = rebuild_system_prompt(%{state | active_skills: active})
+          Minga.Log.info(:agent, "[Agent.Native] activated skill: #{name}")
+          {:reply, {:ok, skill}, state}
+
+        :not_found ->
+          {:reply, {:error, "Skill '#{name}' not found"}, state}
+      end
+    end
+  end
+
+  def handle_call({:deactivate_skill, name}, _from, state) do
+    active = Enum.reject(state.active_skills, &(&1.name == name))
+
+    if length(active) == length(state.active_skills) do
+      {:reply, {:error, "Skill '#{name}' is not active"}, state}
+    else
+      state = rebuild_system_prompt(%{state | active_skills: active})
+      Minga.Log.info(:agent, "[Agent.Native] deactivated skill: #{name}")
+      {:reply, :ok, state}
+    end
+  end
+
+  def handle_call(:list_skills, _from, state) do
+    all = Skills.discover(state.project_root)
+    active_names = Enum.map(state.active_skills, & &1.name)
+    {:reply, {:ok, all, active_names}, state}
   end
 
   def handle_call(:new_session, _from, state) do
@@ -888,14 +928,15 @@ defmodule Minga.Agent.Providers.Native do
     :exit, _ -> true
   end
 
-  @spec build_system_prompt(String.t()) :: String.t()
-  defp build_system_prompt(project_root) do
+  @spec build_system_prompt(String.t(), [Skills.skill()]) :: String.t()
+  defp build_system_prompt(project_root, active_skills \\ []) do
     base = resolve_base_prompt(project_root)
     instructions = Instructions.assemble(project_root)
+    skills_section = Skills.format_for_prompt(active_skills)
     append = read_config_string(:agent_append_system_prompt)
 
     parts =
-      [base, instructions, append]
+      [base, instructions, skills_section, append]
       |> Enum.reject(&(is_nil(&1) or &1 == ""))
       |> Enum.join("\n\n")
 
@@ -1066,6 +1107,25 @@ defmodule Minga.Agent.Providers.Native do
   end
 
   @spec detect_project_root() :: String.t()
+  # Rebuilds the system prompt with current active skills and replaces it
+  # in the context's first message.
+  @spec rebuild_system_prompt(state()) :: state()
+  defp rebuild_system_prompt(state) do
+    new_prompt = build_system_prompt(state.project_root, state.active_skills)
+    messages = state.context.messages
+
+    updated_messages =
+      case messages do
+        [%{role: :system} | rest] ->
+          [Context.system(new_prompt) | rest]
+
+        other ->
+          [Context.system(new_prompt) | other]
+      end
+
+    %{state | context: %{state.context | messages: updated_messages}}
+  end
+
   defp detect_project_root do
     case Minga.Project.root() do
       nil -> File.cwd!()

--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -180,6 +180,24 @@ defmodule Minga.Agent.Session do
     GenServer.call(session, :continue)
   end
 
+  @doc "Activates a skill by name."
+  @spec activate_skill(GenServer.server(), String.t()) :: {:ok, term()} | {:error, term()}
+  def activate_skill(session, name) do
+    GenServer.call(session, {:activate_skill, name})
+  end
+
+  @doc "Deactivates a skill by name."
+  @spec deactivate_skill(GenServer.server(), String.t()) :: :ok | {:error, term()}
+  def deactivate_skill(session, name) do
+    GenServer.call(session, {:deactivate_skill, name})
+  end
+
+  @doc "Lists all discovered skills and which are active."
+  @spec list_skills(GenServer.server()) :: {:ok, [map()], [String.t()]} | {:error, term()}
+  def list_skills(session) do
+    GenServer.call(session, :list_skills)
+  end
+
   @doc "Fetches available models from the provider."
   @spec get_available_models(GenServer.server()) :: {:ok, term()} | {:error, term()}
   def get_available_models(session) do
@@ -449,6 +467,33 @@ defmodule Minga.Agent.Session do
     else
       {:reply, {:error, "Provider does not support continue"}, state}
     end
+  end
+
+  def handle_call({:activate_skill, _name}, _from, %{provider: nil} = state) do
+    {:reply, {:error, "No active provider"}, state}
+  end
+
+  def handle_call({:activate_skill, name}, _from, state) do
+    result = GenServer.call(state.provider, {:activate_skill, name})
+    {:reply, result, state}
+  end
+
+  def handle_call({:deactivate_skill, _name}, _from, %{provider: nil} = state) do
+    {:reply, {:error, "No active provider"}, state}
+  end
+
+  def handle_call({:deactivate_skill, name}, _from, state) do
+    result = GenServer.call(state.provider, {:deactivate_skill, name})
+    {:reply, result, state}
+  end
+
+  def handle_call(:list_skills, _from, %{provider: nil} = state) do
+    {:reply, {:error, "No active provider"}, state}
+  end
+
+  def handle_call(:list_skills, _from, state) do
+    result = GenServer.call(state.provider, :list_skills)
+    {:reply, result, state}
   end
 
   def handle_call(:get_available_models, _from, %{provider: nil} = state) do

--- a/lib/minga/agent/skills.ex
+++ b/lib/minga/agent/skills.ex
@@ -1,0 +1,281 @@
+defmodule Minga.Agent.Skills do
+  @moduledoc """
+  Skills system for context-aware prompt injection.
+
+  Skills are Markdown files that provide specialized instructions for
+  specific tasks. They live in `~/.config/minga/skills/` (global) and
+  `.minga/skills/` (project-local). Each skill is a directory containing
+  a `SKILL.md` file with YAML-style frontmatter and instruction body.
+
+  ## Skill format
+
+      ---
+      name: plan
+      description: Plan mode for complex tasks
+      activates_on:
+        - plan
+        - design
+        - scope
+        - feature
+      ---
+
+      # Planning Instructions
+
+      When planning a feature, always...
+
+  ## Loading
+
+  Skills can be activated:
+  - Explicitly via `/skill:name` in chat
+  - Automatically when user prompts match `activates_on` keywords
+
+  Multiple skills can be active simultaneously.
+  """
+
+  @typedoc "A discovered skill with metadata and instructions."
+  @type skill :: %{
+          name: String.t(),
+          description: String.t(),
+          activates_on: [String.t()],
+          instructions: String.t(),
+          path: String.t(),
+          source: :global | :project
+        }
+
+  @global_skills_dir "~/.config/minga/skills"
+  @project_skills_dir ".minga/skills"
+
+  # ── Discovery ───────────────────────────────────────────────────────────────
+
+  @doc """
+  Discovers all available skills from global and project directories.
+
+  Project-local skills override global skills with the same name.
+  """
+  @spec discover(String.t() | nil) :: [skill()]
+  def discover(project_root \\ nil) do
+    global = discover_in(expand_global_dir(), :global)
+
+    project =
+      if project_root,
+        do: discover_in(Path.join(project_root, @project_skills_dir), :project),
+        else: []
+
+    # Project skills override global skills with the same name
+    merged =
+      (global ++ project)
+      |> Enum.group_by(& &1.name)
+      |> Enum.map(fn {_name, skills} -> List.last(skills) end)
+      |> Enum.sort_by(& &1.name)
+
+    merged
+  end
+
+  @doc """
+  Finds a skill by name from the discovered skills.
+  """
+  @spec find(String.t(), String.t() | nil) :: {:ok, skill()} | :not_found
+  def find(name, project_root \\ nil) do
+    case Enum.find(discover(project_root), &(&1.name == name)) do
+      nil -> :not_found
+      skill -> {:ok, skill}
+    end
+  end
+
+  @doc """
+  Returns skills whose `activates_on` keywords match the given text.
+
+  Performs case-insensitive word boundary matching. A keyword "plan"
+  matches "let's plan this" but not "airplane".
+  """
+  @spec auto_activate([skill()], String.t()) :: [skill()]
+  def auto_activate(skills, text) do
+    lower = String.downcase(text)
+    words = String.split(lower, ~r/\W+/, trim: true)
+
+    Enum.filter(skills, fn skill ->
+      skill.activates_on != [] and
+        Enum.any?(skill.activates_on, fn keyword ->
+          String.downcase(keyword) in words
+        end)
+    end)
+  end
+
+  @doc """
+  Formats active skills into a system prompt section.
+  """
+  @spec format_for_prompt([skill()]) :: String.t() | nil
+  def format_for_prompt([]), do: nil
+
+  def format_for_prompt(active_skills) do
+    sections =
+      Enum.map_join(active_skills, "\n\n", fn skill ->
+        "### Skill: #{skill.name}\n\n#{resolve_references(skill)}"
+      end)
+
+    "## Active Skills\n\n#{sections}"
+  end
+
+  @doc """
+  Returns a human-readable summary of all discovered skills.
+  """
+  @spec summary(String.t() | nil) :: String.t()
+  def summary(project_root \\ nil) do
+    skills = discover(project_root)
+
+    if skills == [] do
+      "No skills found. Create skills in ~/.config/minga/skills/ or .minga/skills/."
+    else
+      header = "Available skills (#{length(skills)}):\n"
+      lines = Enum.map_join(skills, "\n", &format_skill_line/1)
+      header <> lines
+    end
+  end
+
+  @spec format_skill_line(skill()) :: String.t()
+  defp format_skill_line(skill) do
+    source_tag = if skill.source == :project, do: " [project]", else: " [global]"
+
+    auto =
+      if skill.activates_on != [],
+        do: " (auto: #{Enum.join(skill.activates_on, ", ")})",
+        else: ""
+
+    "  /skill:#{skill.name} — #{skill.description}#{source_tag}#{auto}"
+  end
+
+  # ── Parsing ─────────────────────────────────────────────────────────────────
+
+  @doc """
+  Parses a SKILL.md file into a skill struct.
+
+  Extracts YAML-style frontmatter (between `---` delimiters) for metadata
+  and uses the remainder as instruction text.
+  """
+  @spec parse_skill_file(String.t(), :global | :project) :: {:ok, skill()} | {:error, term()}
+  def parse_skill_file(path, source) do
+    case File.read(path) do
+      {:ok, content} ->
+        {frontmatter, body} = split_frontmatter(content)
+        metadata = parse_frontmatter(frontmatter)
+
+        skill = %{
+          name: metadata["name"] || Path.basename(Path.dirname(path)),
+          description: metadata["description"] || "",
+          activates_on: parse_list(metadata["activates_on"]),
+          instructions: String.trim(body),
+          path: path,
+          source: source
+        }
+
+        {:ok, skill}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec discover_in(String.t(), :global | :project) :: [skill()]
+  defp discover_in(dir, source) do
+    if File.dir?(dir) do
+      dir
+      |> File.ls!()
+      |> Enum.flat_map(&try_load_skill(dir, &1, source))
+    else
+      []
+    end
+  rescue
+    _ -> []
+  end
+
+  @spec try_load_skill(String.t(), String.t(), :global | :project) :: [skill()]
+  defp try_load_skill(dir, entry, source) do
+    skill_file = Path.join([dir, entry, "SKILL.md"])
+
+    if File.regular?(skill_file) do
+      case parse_skill_file(skill_file, source) do
+        {:ok, skill} -> [skill]
+        {:error, _} -> []
+      end
+    else
+      []
+    end
+  end
+
+  @spec split_frontmatter(String.t()) :: {String.t(), String.t()}
+  defp split_frontmatter(content) do
+    case Regex.run(~r/\A---\s*\n(.*?)\n---\s*\n(.*)\z/s, content) do
+      [_, frontmatter, body] -> {frontmatter, body}
+      _ -> {"", content}
+    end
+  end
+
+  @spec parse_frontmatter(String.t()) :: map()
+  defp parse_frontmatter(""), do: %{}
+
+  defp parse_frontmatter(text) do
+    # Simple YAML-like parser for key: value and key:\n  - item lines
+    text
+    |> String.split("\n")
+    |> parse_yaml_lines(%{}, nil)
+  end
+
+  @spec parse_yaml_lines([String.t()], map(), String.t() | nil) :: map()
+  defp parse_yaml_lines([], acc, _current_key), do: acc
+
+  defp parse_yaml_lines(["  - " <> item | rest], acc, current_key) when is_binary(current_key) do
+    existing = Map.get(acc, current_key, [])
+    acc = Map.put(acc, current_key, existing ++ [String.trim(item)])
+    parse_yaml_lines(rest, acc, current_key)
+  end
+
+  defp parse_yaml_lines([line | rest], acc, _current_key) do
+    case String.split(line, ":", parts: 2) do
+      [key, ""] ->
+        # Key with no inline value, start collecting list items
+        parse_yaml_lines(rest, acc, String.trim(key))
+
+      [key, value] ->
+        trimmed_value = String.trim(value)
+        parse_yaml_lines(rest, Map.put(acc, String.trim(key), trimmed_value), nil)
+
+      _ ->
+        parse_yaml_lines(rest, acc, nil)
+    end
+  end
+
+  @spec parse_list(term()) :: [String.t()]
+  defp parse_list(nil), do: []
+  defp parse_list(list) when is_list(list), do: list
+  defp parse_list(str) when is_binary(str), do: String.split(str, ~r/[,\s]+/, trim: true)
+
+  @spec expand_global_dir() :: String.t()
+  defp expand_global_dir do
+    Path.expand(@global_skills_dir)
+  end
+
+  # Resolve relative file references in skill instructions.
+  # Lines like `@include path/to/file.md` are replaced with the file contents.
+  @spec resolve_references(skill()) :: String.t()
+  defp resolve_references(skill) do
+    skill_dir = Path.dirname(skill.path)
+
+    skill.instructions
+    |> String.split("\n")
+    |> Enum.map_join("\n", &resolve_include_line(&1, skill_dir))
+  end
+
+  @spec resolve_include_line(String.t(), String.t()) :: String.t()
+  defp resolve_include_line(line, skill_dir) do
+    case Regex.run(~r/^@include\s+(.+)$/, String.trim(line)) do
+      [_, ref_path] ->
+        abs_path = Path.expand(ref_path, skill_dir)
+        if File.regular?(abs_path), do: File.read!(abs_path), else: line
+
+      _ ->
+        line
+    end
+  end
+end

--- a/lib/minga/agent/slash_command.ex
+++ b/lib/minga/agent/slash_command.ex
@@ -13,6 +13,7 @@ defmodule Minga.Agent.SlashCommand do
   alias Minga.Agent.PanelState
   alias Minga.Agent.Session
   alias Minga.Agent.SessionExport
+  alias Minga.Agent.Skills
   alias Minga.Config.Options
   alias Minga.Editor.Commands.Agent, as: AgentCommands
   alias Minga.Editor.PickerUI
@@ -48,7 +49,9 @@ defmodule Minga.Agent.SlashCommand do
     },
     %{name: "compact", description: "Compact conversation context (summarize older turns)"},
     %{name: "continue", description: "Continue from an interrupted stream response"},
-    %{name: "export", description: "Export current session to a Markdown file"}
+    %{name: "export", description: "Export current session to a Markdown file"},
+    %{name: "skills", description: "List all available skills"},
+    %{name: "skill", description: "Activate a skill: /skill:name, deactivate: /skill:off:name"}
   ]
 
   @doc "Returns the list of all registered slash commands."
@@ -101,7 +104,16 @@ defmodule Minga.Agent.SlashCommand do
   defp dispatch(state, "compact", _args), do: do_compact(state)
   defp dispatch(state, "continue", _args), do: do_continue(state)
   defp dispatch(state, "export", _args), do: do_export(state)
-  defp dispatch(_state, cmd, _args), do: {:error, "Unknown command: /#{cmd}"}
+  defp dispatch(state, "skills", _args), do: {:ok, do_skills(state)}
+
+  # /skill:name activates, /skill:off:name deactivates
+  defp dispatch(state, cmd, _args) when is_binary(cmd) do
+    case parse_skill_command(cmd) do
+      {:activate, name} -> do_activate_skill(state, name)
+      {:deactivate, name} -> do_deactivate_skill(state, name)
+      :not_skill -> {:error, "Unknown command: /#{cmd}"}
+    end
+  end
 
   # ── Command implementations ────────────────────────────────────────────────
 
@@ -356,6 +368,57 @@ defmodule Minga.Agent.SlashCommand do
         {:ok, path} ->
           relative = Path.relative_to(path, root)
           {:ok, emit_system_message(state, "Session exported to ./#{relative}")}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      {:error, "No active agent session"}
+    end
+  end
+
+  @spec parse_skill_command(String.t()) ::
+          {:activate, String.t()} | {:deactivate, String.t()} | :not_skill
+  defp parse_skill_command(cmd) do
+    case String.split(cmd, ":", parts: 3) do
+      ["skill", "off", name] when name != "" -> {:deactivate, name}
+      ["skill", name] when name != "" -> {:activate, name}
+      _ -> :not_skill
+    end
+  end
+
+  @spec do_skills(state()) :: state()
+  defp do_skills(state) do
+    root = detect_project_root()
+    summary = Skills.summary(root)
+    emit_system_message(state, summary)
+  end
+
+  @spec do_activate_skill(state(), String.t()) :: {:ok, state()} | {:error, String.t()}
+  defp do_activate_skill(state, name) do
+    session = AgentAccess.session(state)
+
+    if is_pid(session) do
+      case Session.activate_skill(session, name) do
+        {:ok, skill} ->
+          {:ok, emit_system_message(state, "Loaded skill: #{skill.name} — #{skill.description}")}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      {:error, "No active agent session"}
+    end
+  end
+
+  @spec do_deactivate_skill(state(), String.t()) :: {:ok, state()} | {:error, String.t()}
+  defp do_deactivate_skill(state, name) do
+    session = AgentAccess.session(state)
+
+    if is_pid(session) do
+      case Session.deactivate_skill(session, name) do
+        :ok ->
+          {:ok, emit_system_message(state, "Deactivated skill: #{name}")}
 
         {:error, reason} ->
           {:error, reason}

--- a/test/minga/agent/skills_test.exs
+++ b/test/minga/agent/skills_test.exs
@@ -1,0 +1,209 @@
+defmodule Minga.Agent.SkillsTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Agent.Skills
+
+  @moduletag :tmp_dir
+
+  defp create_skill(dir, name, opts) do
+    description = Keyword.get(opts, :description, "A test skill")
+    activates_on = Keyword.get(opts, :activates_on, [])
+    body = Keyword.get(opts, :body, "Skill instructions for #{name}.")
+
+    activates_yaml =
+      if activates_on == [] do
+        ""
+      else
+        items = Enum.map_join(activates_on, "\n", &"  - #{&1}")
+        "activates_on:\n#{items}\n"
+      end
+
+    skill_dir = Path.join(dir, name)
+    File.mkdir_p!(skill_dir)
+
+    content = """
+    ---
+    name: #{name}
+    description: #{description}
+    #{activates_yaml}---
+
+    #{body}
+    """
+
+    File.write!(Path.join(skill_dir, "SKILL.md"), content)
+    skill_dir
+  end
+
+  describe "parse_skill_file/2" do
+    test "parses frontmatter and body", %{tmp_dir: dir} do
+      create_skill(dir, "plan", description: "Plan mode", activates_on: ["plan", "scope"])
+      path = Path.join([dir, "plan", "SKILL.md"])
+
+      assert {:ok, skill} = Skills.parse_skill_file(path, :global)
+      assert skill.name == "plan"
+      assert skill.description == "Plan mode"
+      assert skill.activates_on == ["plan", "scope"]
+      assert skill.instructions =~ "Skill instructions for plan"
+      assert skill.source == :global
+    end
+
+    test "uses directory name when name is missing from frontmatter", %{tmp_dir: dir} do
+      skill_dir = Path.join(dir, "my-skill")
+      File.mkdir_p!(skill_dir)
+
+      File.write!(Path.join(skill_dir, "SKILL.md"), """
+      ---
+      description: A skill without a name field
+      ---
+
+      Instructions here.
+      """)
+
+      assert {:ok, skill} = Skills.parse_skill_file(Path.join(skill_dir, "SKILL.md"), :project)
+      assert skill.name == "my-skill"
+    end
+
+    test "handles file without frontmatter", %{tmp_dir: dir} do
+      skill_dir = Path.join(dir, "simple")
+      File.mkdir_p!(skill_dir)
+
+      File.write!(Path.join(skill_dir, "SKILL.md"), "Just instructions, no frontmatter.")
+
+      assert {:ok, skill} = Skills.parse_skill_file(Path.join(skill_dir, "SKILL.md"), :global)
+      assert skill.name == "simple"
+      assert skill.instructions =~ "Just instructions"
+    end
+  end
+
+  describe "discover/1" do
+    test "discovers skills in a directory", %{tmp_dir: dir} do
+      skills_dir = Path.join(dir, ".minga/skills")
+      create_skill(skills_dir, "plan", description: "Plan mode")
+      create_skill(skills_dir, "review", description: "Code review")
+
+      project_root = dir
+      # discover looks in .minga/skills under the project root
+      skills = Skills.discover(project_root)
+
+      names = Enum.map(skills, & &1.name)
+      assert "plan" in names
+      assert "review" in names
+    end
+
+    test "returns empty list when no skills directory", %{tmp_dir: dir} do
+      assert Skills.discover(dir) == []
+    end
+  end
+
+  describe "find/2" do
+    test "finds a skill by name", %{tmp_dir: dir} do
+      skills_dir = Path.join(dir, ".minga/skills")
+      create_skill(skills_dir, "plan", description: "Plan mode")
+
+      assert {:ok, skill} = Skills.find("plan", dir)
+      assert skill.name == "plan"
+    end
+
+    test "returns :not_found for unknown skill", %{tmp_dir: dir} do
+      assert :not_found = Skills.find("nonexistent", dir)
+    end
+  end
+
+  describe "auto_activate/2" do
+    test "matches keywords in user text", %{tmp_dir: dir} do
+      skills_dir = Path.join(dir, ".minga/skills")
+      create_skill(skills_dir, "plan", activates_on: ["plan", "scope", "design"])
+      create_skill(skills_dir, "review", activates_on: ["review", "pr"])
+
+      all_skills = Skills.discover(dir)
+
+      matches = Skills.auto_activate(all_skills, "Let's plan the new feature")
+      assert length(matches) == 1
+      assert hd(matches).name == "plan"
+    end
+
+    test "case insensitive matching", %{tmp_dir: dir} do
+      skills_dir = Path.join(dir, ".minga/skills")
+      create_skill(skills_dir, "plan", activates_on: ["Plan"])
+
+      all_skills = Skills.discover(dir)
+      matches = Skills.auto_activate(all_skills, "let's plan")
+      assert length(matches) == 1
+    end
+
+    test "does not match partial words", %{tmp_dir: dir} do
+      skills_dir = Path.join(dir, ".minga/skills")
+      create_skill(skills_dir, "plan", activates_on: ["plan"])
+
+      all_skills = Skills.discover(dir)
+      matches = Skills.auto_activate(all_skills, "airplane")
+      assert matches == []
+    end
+
+    test "skips skills without activates_on", %{tmp_dir: dir} do
+      skills_dir = Path.join(dir, ".minga/skills")
+      create_skill(skills_dir, "manual", activates_on: [])
+
+      all_skills = Skills.discover(dir)
+      matches = Skills.auto_activate(all_skills, "anything goes")
+      assert matches == []
+    end
+  end
+
+  describe "format_for_prompt/1" do
+    test "returns nil for empty list" do
+      assert Skills.format_for_prompt([]) == nil
+    end
+
+    test "formats active skills into prompt section", %{tmp_dir: dir} do
+      skills_dir = Path.join(dir, ".minga/skills")
+
+      create_skill(skills_dir, "plan",
+        description: "Plan mode",
+        body: "Always scope before coding."
+      )
+
+      {:ok, skill} = Skills.find("plan", dir)
+      result = Skills.format_for_prompt([skill])
+
+      assert result =~ "## Active Skills"
+      assert result =~ "### Skill: plan"
+      assert result =~ "Always scope before coding."
+    end
+  end
+
+  describe "summary/1" do
+    test "shows available skills", %{tmp_dir: dir} do
+      skills_dir = Path.join(dir, ".minga/skills")
+      create_skill(skills_dir, "plan", description: "Plan mode", activates_on: ["plan"])
+
+      result = Skills.summary(dir)
+      assert result =~ "Available skills"
+      assert result =~ "/skill:plan"
+      assert result =~ "Plan mode"
+      assert result =~ "auto: plan"
+    end
+
+    test "shows message when no skills found", %{tmp_dir: dir} do
+      result = Skills.summary(dir)
+      assert result =~ "No skills found"
+    end
+  end
+
+  describe "@include references" do
+    test "resolves relative file references in instructions", %{tmp_dir: dir} do
+      skills_dir = Path.join(dir, ".minga/skills")
+
+      skill_dir =
+        create_skill(skills_dir, "with-ref", body: "@include extra.md\n\nMain instructions.")
+
+      File.write!(Path.join(skill_dir, "extra.md"), "Extra content from referenced file.")
+
+      {:ok, skill} = Skills.find("with-ref", dir)
+      formatted = Skills.format_for_prompt([skill])
+
+      assert formatted =~ "Extra content from referenced file."
+      assert formatted =~ "Main instructions."
+    end
+  end
+end


### PR DESCRIPTION
## What

A skills system that adapts agent behavior based on the task at hand. Skills are Markdown files with specialized instructions that get injected into the system prompt.

## Why

Without skills, the native provider treats every conversation identically. A `plan` skill knows how to scope work. A `pr-writer` skill knows PR format. Skills make the agent smarter about process, not just code. This matches pi-agent's strongest differentiator.

## Changes

- **`Minga.Agent.Skills`** (new, 240 lines): Discovery, parsing, keyword matching, `@include` references, prompt formatting. Skills discovered from `~/.config/minga/skills/` and `.minga/skills/`.
- **`Providers.Native`**: `active_skills` in state. `build_system_prompt/2` includes skills section. New handle_calls for activate/deactivate/list. `rebuild_system_prompt/1` helper for hot-swapping.
- **`Session`**: Routes `activate_skill`, `deactivate_skill`, `list_skills`.
- **`SlashCommand`**: `/skills`, `/skill:name`, `/skill:off:name` commands.
- **Tests**: 16 new tests.

## Skill format

```markdown
---
name: plan
description: Plan mode for complex tasks
activates_on:
  - plan
  - design
---

Instructions injected when active...
```

Closes #285