### PR TITLE
chore: clean up stale AgentView references from tests and comments

### DIFF
--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -19,7 +19,7 @@ defmodule Minga.Agent.View.Renderer do
   full width. The right panel (preview/dashboard) extends alongside the
   input area. This matches the OpenCode reference layout.
 
-  Called by `Minga.Editor.RenderPipeline` when the active surface is `AgentView`.
+  Called by `Minga.Editor.RenderPipeline` when the agent chat is visible in a window split.
   Returns `DisplayList.draw()` tuples.
   """
 

--- a/lib/minga/input/scoped.ex
+++ b/lib/minga/input/scoped.ex
@@ -57,7 +57,7 @@ defmodule Minga.Input.Scoped do
   # ── Agent scope ──────────────────────────────────────────────────────────
 
   # Agent scope: dispatch through scope resolution.
-  # Matches both full-screen AgentView surface AND window-level agent
+  # Matches window-level agent
   # chat content (Phase F: agent chat as a window pane within BufferView).
   def handle_key(%{keymap_scope: :agent} = state, cp, mods) do
     handle_agent_key(state, cp, mods)

--- a/lib/minga/surface/context.ex
+++ b/lib/minga/surface/context.ex
@@ -79,9 +79,8 @@ defmodule Minga.Surface.Context do
       whichkey: es.whichkey,
       modeline_click_regions: es.modeline_click_regions,
       tab_bar_click_regions: es.tab_bar_click_regions,
-      # Buffer/vim fields carried in context so AgentView can
-      # reconstruct a complete EditorState (agent commands
-      # reference buffers.active and mode state).
+      # Buffer/vim fields carried in context so agent commands
+      # can reference buffers.active and mode state.
       buffers: es.buffers,
       viewport: es.viewport,
       mode: es.mode,

--- a/test/minga/agent/view/mouse_test.exs
+++ b/test/minga/agent/view/mouse_test.exs
@@ -24,7 +24,7 @@ defmodule Minga.Agent.View.MouseTest do
       mode: :normal,
       mode_state: Minga.Mode.initial_state(),
       viewport: %Viewport{rows: 30, cols: 80, top: 0, left: 0},
-      surface_module: Minga.Surface.AgentView,
+      surface_module: Minga.Surface.BufferView,
       agentic: %ViewState{
         active: true,
         focus: focus,

--- a/test/minga/agent/view/renderer_test.exs
+++ b/test/minga/agent/view/renderer_test.exs
@@ -107,7 +107,7 @@ defmodule Minga.Agent.View.RendererTest do
       mode_state: Mode.initial_state(),
       buffers: %Buffers{active: buf, list: [buf], active_index: 0},
       focus_stack: Input.default_stack(),
-      surface_module: Minga.Surface.AgentView,
+      surface_module: Minga.Surface.BufferView,
       agent: agent,
       agentic: agentic,
       theme: Theme.get!(:doom_one),

--- a/test/minga/editor/commands/agent_agentic_view_test.exs
+++ b/test/minga/editor/commands/agent_agentic_view_test.exs
@@ -19,7 +19,6 @@ defmodule Minga.Editor.Commands.AgentAgenticViewTest do
   alias Minga.Editor.Window.Content
   alias Minga.Input
   alias Minga.Mode
-  alias Minga.Surface.AgentView
   alias Minga.Surface.BufferView
 
   defp base_state(opts \\ []) do
@@ -90,7 +89,7 @@ defmodule Minga.Editor.Commands.AgentAgenticViewTest do
       # Build agent tab with keymap scope
       agent_ctx = %{
         keymap_scope: :agent,
-        surface_module: AgentView
+        surface_module: Minga.Surface.BufferView
       }
 
       {tb, at} = TabBar.add(tb, :agent, "Agent")
@@ -104,7 +103,7 @@ defmodule Minga.Editor.Commands.AgentAgenticViewTest do
       # Always store an agent tab so AgentAccess can find it.
       # This ensures the agent buffer is accessible to toggle_agent_split.
       {tb, at} = TabBar.add(tb, :agent, "Agent")
-      agent_ctx = %{keymap_scope: :agent, surface_module: AgentView}
+      agent_ctx = %{keymap_scope: :agent, surface_module: Minga.Surface.BufferView}
       tb = TabBar.update_context(tb, at.id, agent_ctx)
       tb = TabBar.switch_to(tb, file_tab.id)
       %{state | tab_bar: tb}
@@ -254,7 +253,7 @@ defmodule Minga.Editor.Commands.AgentAgenticViewTest do
     end
 
     test "restores file tab context after closing agent tab" do
-      # Start with agent tab active (legacy full-screen AgentView)
+      # Start with agent tab active
       state = base_state(active: true)
       assert EditorState.active_tab_kind(state) == :agent
 

--- a/test/minga/editor/commands/agent_commands_test.exs
+++ b/test/minga/editor/commands/agent_commands_test.exs
@@ -2,10 +2,8 @@ defmodule Minga.Editor.Commands.AgentCommandsTest do
   @moduledoc """
   Characterization tests for Commands.Agent.
 
-  Pins current behavior for pure `state -> state` functions before
-  the Phase 2 Surface extraction. Each test documents what the function
-  does today so that moving it into AgentView in Phase 2 can't silently
-  change behavior.
+  Tests pure `state -> state` functions for agent-related commands.
+  Agent state now lives on EditorState (agent panel, session, status).
 
   Functions that require a live Agent.Session (submit_prompt, abort_agent,
   clear_chat_display, etc.) are tested via EditorCase integration tests

--- a/test/minga/editor/commands/agent_split_test.exs
+++ b/test/minga/editor/commands/agent_split_test.exs
@@ -56,7 +56,7 @@ defmodule Minga.Editor.Commands.AgentSplitTest do
     agent_tab = Tab.new_agent(2, "Agent")
 
     agent_context = %{
-      surface_module: Minga.Surface.AgentView,
+      surface_module: Minga.Surface.BufferView,
       keymap_scope: :agent
     }
 

--- a/test/minga/editor/layout_test.exs
+++ b/test/minga/editor/layout_test.exs
@@ -12,7 +12,6 @@ defmodule Minga.Editor.LayoutTest do
   alias Minga.Editor.Window
   alias Minga.FileTree
   alias Minga.Mode
-  alias Minga.Surface.AgentView
 
   # ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -53,7 +52,7 @@ defmodule Minga.Editor.LayoutTest do
     default_panel = %AgentState{} |> Map.get(:panel)
     agent = %AgentState{panel: %{default_panel | visible: true}}
     agentic = ViewState.new()
-    agent_ctx = %{surface_module: AgentView, keymap_scope: :agent}
+    agent_ctx = %{surface_module: Minga.Surface.BufferView, keymap_scope: :agent}
 
     # Ensure a file tab exists and is active, then add a background agent tab.
     # TabBar.new/1 requires an initial Tab; we start with a file tab.

--- a/test/minga/input/agent_panel_nav_test.exs
+++ b/test/minga/input/agent_panel_nav_test.exs
@@ -53,7 +53,7 @@ defmodule Minga.Input.AgentPanelNavTest do
     %EditorState{
       port_manager: self(),
       viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
-      surface_module: Minga.Surface.AgentView,
+      surface_module: Minga.Surface.BufferView,
       agent: agent,
       agentic: agentic,
       buffers: %{active: nil, list: [], recent: []},

--- a/test/minga/input/sub_state_handlers_test.exs
+++ b/test/minga/input/sub_state_handlers_test.exs
@@ -70,7 +70,7 @@ defmodule Minga.Input.SubStateHandlersTest do
       buffers: %Buffers{active: buf, list: [buf]},
       focus_stack: [],
       keymap_scope: Keyword.get(opts, :keymap_scope, :editor),
-      surface_module: Minga.Surface.AgentView,
+      surface_module: Minga.Surface.BufferView,
       agent: agent,
       agentic: agentic,
       tab_bar: tab_bar


### PR DESCRIPTION
# TL;DR

Cleans up all remaining references to the deleted `Minga.Surface.AgentView` module across 11 test and production files. Pure housekeeping, no behavior changes.

Follows up on #362 (which deleted AgentView itself).

## Changes

- **Test fixtures**: All `surface_module: Minga.Surface.AgentView` replaced with `Minga.Surface.BufferView`
- **Stale aliases**: Removed `alias Minga.Surface.AgentView` from test files
- **Comments**: Updated references to "full-screen AgentView", "Phase 2 migration", and the deleted surface dispatch

## Verification

```bash
mix test --exclude external --warnings-as-errors  # 3,979 tests, 0 failures
mix lint                                           # clean
```