### PR TITLE
fix(editor): apply agent split layout during startup

### DIFF
--- a/lib/minga/editor/startup.ex
+++ b/lib/minga/editor/startup.ex
@@ -6,13 +6,16 @@ defmodule Minga.Editor.Startup do
   Extracted to keep the GenServer module focused on message handling.
   """
 
+  alias Minga.Agent.BufferSync, as: AgentBufferSync
   alias Minga.Agent.View.State, as: ViewState
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Config.Loader, as: ConfigLoader
   alias Minga.Config.Options, as: ConfigOptions
   alias Minga.Editor.Commands
   alias Minga.Editor.FileWatcherHelpers
+  alias Minga.Editor.LayoutPreset
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.AgentAccess
   alias Minga.Editor.State.Buffers
   alias Minga.Editor.State.Tab
   alias Minga.Editor.State.TabBar
@@ -81,8 +84,33 @@ defmodule Minga.Editor.Startup do
       focus_stack: Minga.Input.default_stack()
     }
 
-    %{state | tab_bar: initial_tab_bar(active_buf, keymap_scope)}
+    state = %{state | tab_bar: initial_tab_bar(active_buf, keymap_scope)}
+    maybe_apply_agent_split(state)
   end
+
+  @doc """
+  Creates the agent buffer and applies the agent split layout when
+  booting into agent mode.
+
+  This bridges the gap between `startup_view_state` (which decides
+  *whether* to use agent mode) and the window tree (which needs an
+  actual agent chat window for the render pipeline to find). Without
+  this step, `LayoutPreset.has_agent_chat?/1` returns false and the
+  agent session never starts.
+  """
+  @spec maybe_apply_agent_split(EditorState.t()) :: EditorState.t()
+  def maybe_apply_agent_split(%{keymap_scope: :agent} = state) do
+    agent_buf = AgentBufferSync.start_buffer()
+
+    if is_pid(agent_buf) do
+      state = AgentAccess.update_agent(state, fn a -> %{a | buffer: agent_buf} end)
+      LayoutPreset.apply(state, :agent_right, agent_buf)
+    else
+      state
+    end
+  end
+
+  def maybe_apply_agent_split(state), do: state
 
   @spec subscribe_port(GenServer.server() | nil) :: :ok
   defp subscribe_port(nil), do: :ok
@@ -115,10 +143,12 @@ defmodule Minga.Editor.Startup do
   @doc """
   Determines the initial view state based on CLI flags and config.
 
-  Returns `{keymap_scope, agentic_state, window_tree | nil}`.
+  Returns `{keymap_scope, agentic_state, window_tree}`. Both agent and
+  editor modes get a real WindowTree; agent mode creates the split layout
+  in `maybe_apply_agent_split/1` after the state struct is built.
   """
   @spec startup_view_state(GenServer.server() | nil, pos_integer()) ::
-          {atom(), ViewState.t(), WindowTree.t() | nil}
+          {atom(), ViewState.t(), WindowTree.t()}
   def startup_view_state(port_manager, window_id) do
     tui_mode? = port_manager == PortManager
     cli_flags = Minga.CLI.startup_flags()
@@ -130,7 +160,7 @@ defmodule Minga.Editor.Startup do
 
     if want_agent? do
       av = %ViewState{ViewState.new() | active: true, focus: :chat}
-      {:agent, av, nil}
+      {:agent, av, WindowTree.new(window_id)}
     else
       {:editor, ViewState.new(), WindowTree.new(window_id)}
     end

--- a/test/minga/editor/startup_test.exs
+++ b/test/minga/editor/startup_test.exs
@@ -1,0 +1,119 @@
+defmodule Minga.Editor.StartupTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Editor.LayoutPreset
+  alias Minga.Editor.Startup
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.Windows
+  alias Minga.Editor.Viewport
+  alias Minga.Editor.Window
+  alias Minga.Editor.Window.Content
+  alias Minga.Editor.WindowTree
+  alias Minga.Input
+  alias Minga.Mode
+  alias Minga.Port.Manager, as: PortManager
+
+  describe "startup_view_state/2" do
+    test "returns :agent scope with real window tree when startup_view is :agent" do
+      # TUI mode (PortManager atom) with default flags -> agent mode
+      {scope, agentic, tree} = Startup.startup_view_state(PortManager, 1)
+
+      assert scope == :agent
+      assert agentic.active == true
+      assert agentic.focus == :chat
+      assert tree == WindowTree.new(1)
+    end
+
+    test "returns :editor scope when force_editor flag is set" do
+      Application.put_env(:minga, :cli_startup_flags, %{force_editor: true, no_context: false})
+
+      {scope, agentic, tree} = Startup.startup_view_state(PortManager, 1)
+
+      assert scope == :editor
+      assert agentic.active == false
+      assert tree == WindowTree.new(1)
+    after
+      Application.delete_env(:minga, :cli_startup_flags)
+    end
+
+    test "returns :editor scope in headless mode (non-atom port_manager)" do
+      {scope, _agentic, tree} = Startup.startup_view_state(self(), 1)
+
+      assert scope == :editor
+      assert tree == WindowTree.new(1)
+    end
+  end
+
+  describe "maybe_apply_agent_split/1 (the regression guard)" do
+    test "creates agent chat window in window tree when keymap_scope is :agent" do
+      # Build a minimal state that looks like what build_initial_state produces
+      # in agent mode: keymap_scope :agent, a scratch buffer window, real tree.
+      {:ok, scratch} = BufferServer.start_link(content: "scratch")
+      window = Window.new(1, scratch, 24, 80)
+
+      state = %EditorState{
+        port_manager: self(),
+        viewport: Viewport.new(24, 80),
+        mode: :normal,
+        mode_state: Mode.initial_state(),
+        keymap_scope: :agent,
+        windows: %Windows{
+          tree: WindowTree.new(1),
+          map: %{1 => window},
+          active: 1,
+          next_id: 2
+        },
+        focus_stack: Input.default_stack()
+      }
+
+      result = Startup.maybe_apply_agent_split(state)
+
+      # The agent split must be applied: has_agent_chat? is the check that
+      # AgentLifecycle.maybe_start_session uses to decide whether to start
+      # the agent session. If this is false, the agent never boots.
+      assert LayoutPreset.has_agent_chat?(result),
+             "agent startup must create an agent_chat window so the session can start"
+
+      # The window tree should be a split (scratch left, agent right)
+      assert {:split, :vertical, {:leaf, 1}, {:leaf, 2}, _} = result.windows.tree
+
+      # The new window should have agent_chat content
+      agent_window = result.windows.map[2]
+      assert Content.agent_chat?(agent_window.content)
+
+      # The original scratch window should still be a buffer
+      assert Content.buffer?(result.windows.map[1].content)
+
+      # The agent buffer should be stored in agent state
+      assert is_pid(result.agent.buffer)
+      assert Process.alive?(result.agent.buffer)
+    end
+
+    test "is a no-op when keymap_scope is :editor" do
+      {:ok, scratch} = BufferServer.start_link(content: "scratch")
+      window = Window.new(1, scratch, 24, 80)
+
+      state = %EditorState{
+        port_manager: self(),
+        viewport: Viewport.new(24, 80),
+        mode: :normal,
+        mode_state: Mode.initial_state(),
+        keymap_scope: :editor,
+        windows: %Windows{
+          tree: WindowTree.new(1),
+          map: %{1 => window},
+          active: 1,
+          next_id: 2
+        },
+        focus_stack: Input.default_stack()
+      }
+
+      result = Startup.maybe_apply_agent_split(state)
+
+      refute LayoutPreset.has_agent_chat?(result)
+      assert result.windows.tree == WindowTree.new(1)
+      assert map_size(result.windows.map) == 1
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the agent view not appearing on startup. Users see `*scratch*` buffer instead of the agent chat.

## Root Cause

Commit a07c9cb8 ("refactor(agent): delete legacy Surface dispatch", PR #361) changed the agent session startup check in `AgentLifecycle.maybe_start_session/1` from:

```elixir
# Old: pattern match on surface module
def maybe_start_session(%{surface_module: AgentView} = state) do
  if agent.session == nil do ...
```

To:

```elixir
# New: check window map for agent_chat content
def maybe_start_session(state) do
  if agent.session == nil and LayoutPreset.has_agent_chat?(state) do ...
```

`has_agent_chat?/1` looks for a window with `{:agent_chat, _}` content in the window map. But startup never created one. The initial state had `keymap_scope: :agent` and a `nil` window tree, so the check failed and the agent session never started.

## Fix

Two changes in `Minga.Editor.Startup`:

1. **`startup_view_state` now returns a real `WindowTree` for agent mode** (not `nil`). The layout preset split operation needs a tree to work with.

2. **New `maybe_apply_agent_split/1`** runs after building the initial state. When `keymap_scope` is `:agent`, it creates the `*Agent*` buffer and applies the `:agent_right` layout preset. This gives both the render pipeline and `AgentLifecycle.maybe_start_session` the `agent_chat` window they expect.

## Tests

5 new tests in `StartupTest`:
- `startup_view_state` returns correct scope/tree for agent, editor, and headless modes
- `maybe_apply_agent_split` creates agent_chat window when keymap_scope is :agent (the regression guard)
- `maybe_apply_agent_split` is a no-op when keymap_scope is :editor

**3,949 tests pass. Lint + dialyzer clean.**