### PR TITLE
fix(agent): focus input when opening agent split pane

### DIFF
--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -157,6 +157,7 @@ defmodule Minga.Editor.Commands.Agent do
       |> Layout.invalidate()
       |> EditorState.invalidate_all_windows()
       |> maybe_start_session()
+      |> then(&update_agent(&1, fn a -> AgentState.focus_input(a, true) end))
     else
       state
     end


### PR DESCRIPTION
## What

Fixes #289. When opening the agent split pane via `SPC a a` or `SPC a t`, the input was not focused. The user had to manually press `i` before they could type.

## Why

The `toggle_panel` path correctly called `focus_input`, but `toggle_agent_split` (used by the keybindings) did not. One-line fix in `apply_agent_split`.

## Changes

- `lib/minga/editor/commands/agent.ex`: call `focus_input(true)` after applying the agent split layout

## Testing

- `mix lint` passes
- `mix test --warnings-as-errors` passes (3,988 tests, 0 failures)