### PR TITLE
fix(agent): image chat indicator, vision check, and ContentPart crash

### DIFF
--- a/lib/minga/agent/buffer_sync.ex
+++ b/lib/minga/agent/buffer_sync.ex
@@ -55,6 +55,10 @@ defmodule Minga.Agent.BufferSync do
   end
 
   @spec message_to_markdown(term()) :: String.t()
+  defp message_to_markdown({:user, text, _attachments}) do
+    message_to_markdown({:user, text})
+  end
+
   defp message_to_markdown({:user, text}) do
     "## You\n\n#{text}"
   end

--- a/lib/minga/agent/chat_renderer.ex
+++ b/lib/minga/agent/chat_renderer.ex
@@ -401,6 +401,22 @@ defmodule Minga.Agent.ChatRenderer do
     [header | content] ++ [spacer]
   end
 
+  defp message_lines({:user, text, attachments}, at, width, _theme) do
+    header = {[{"▎ You", [fg: at.user_label, bold: true]}], :text, at.panel_bg}
+    content = text_to_lines(text, at, width, at.user_border)
+
+    attachment_lines =
+      Enum.map(attachments, fn %{filename: name, size_kb: kb} ->
+        indicator = "▎ 📎 #{name} (#{kb}KB)"
+
+        {[{String.slice(indicator, 0, width), [fg: at.user_border, italic: true]}], :text,
+         at.panel_bg}
+      end)
+
+    spacer = {[{"", []}], :empty, at.panel_bg}
+    [header | content] ++ attachment_lines ++ [spacer]
+  end
+
   defp message_lines({:assistant, text}, at, width, theme) do
     header = {[{"▎ Agent", [fg: at.assistant_label, bold: true]}], :text, at.panel_bg}
 

--- a/lib/minga/agent/file_mention.ex
+++ b/lib/minga/agent/file_mention.ex
@@ -41,6 +41,7 @@ defmodule Minga.Agent.FileMention do
           anchor_col: non_neg_integer()
         }
 
+  alias Minga.Agent.ModelLimits
   alias ReqLLM.Message.ContentPart
 
   @max_candidates 10
@@ -106,10 +107,36 @@ defmodule Minga.Agent.FileMention do
   @spec resolve_prompt(String.t(), String.t()) ::
           {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
   def resolve_prompt(text, project_root) do
+    resolve_prompt(text, project_root, [])
+  end
+
+  @doc """
+  Resolves mentions with options.
+
+  Options:
+    - `:model` — the model string for vision capability checking
+  """
+  @spec resolve_prompt(String.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
+  def resolve_prompt(text, project_root, opts) do
     mentions = extract_mentions(text)
 
     if mentions == [] do
       {:ok, text}
+    else
+      maybe_check_vision(mentions, text, project_root, opts)
+    end
+  end
+
+  @spec maybe_check_vision([mention()], String.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
+  defp maybe_check_vision(mentions, text, project_root, opts) do
+    has_images = Enum.any?(mentions, fn %{path: path} -> image_path?(path) end)
+    model = Keyword.get(opts, :model)
+
+    if has_images and model != nil and not ModelLimits.vision_capable?(model) do
+      {:error,
+       "Model #{model} does not support image input. Use a vision-capable model (Claude, GPT-4o, Gemini)."}
     else
       resolve_all(mentions, text, project_root)
     end

--- a/lib/minga/agent/message.ex
+++ b/lib/minga/agent/message.ex
@@ -21,9 +21,13 @@ defmodule Minga.Agent.Message do
           cost: float()
         }
 
+  @typedoc "Image attachment metadata for display in chat."
+  @type image_attachment :: %{filename: String.t(), size_kb: non_neg_integer()}
+
   @typedoc "A single conversation message."
   @type t ::
           {:user, String.t()}
+          | {:user, String.t(), [image_attachment()]}
           | {:assistant, String.t()}
           | {:thinking, String.t(), boolean()}
           | {:tool_call, tool_call()}
@@ -47,6 +51,13 @@ defmodule Minga.Agent.Message do
   @spec user(String.t()) :: t()
   def user(text) when is_binary(text), do: {:user, text}
 
+  @doc "Creates a new user message with image attachments."
+  @spec user(String.t(), [image_attachment()]) :: t()
+  def user(text, []) when is_binary(text), do: {:user, text}
+
+  def user(text, attachments) when is_binary(text) and is_list(attachments),
+    do: {:user, text, attachments}
+
   @doc "Creates a new assistant message (initially empty)."
   @spec assistant(String.t()) :: t()
   def assistant(text \\ ""), do: {:assistant, text}
@@ -64,6 +75,7 @@ defmodule Minga.Agent.Message do
   @doc "Extracts the plain text content of a message for clipboard copy."
   @spec text(t()) :: String.t()
   def text({:user, t}), do: t
+  def text({:user, t, _attachments}), do: t
   def text({:assistant, t}), do: t
   def text({:thinking, t, _collapsed}), do: t
   def text({:tool_call, tc}), do: "#{tc.name}: #{tc.result}"

--- a/lib/minga/agent/model_limits.ex
+++ b/lib/minga/agent/model_limits.ex
@@ -53,6 +53,44 @@ defmodule Minga.Agent.ModelLimits do
     Map.get(@limits, model_name) || prefix_match(model_name)
   end
 
+  # Models known to support vision (image input). Most modern large models
+  # support it, but some specialized or older models do not.
+  @vision_models MapSet.new([
+                   "claude-sonnet-4",
+                   "claude-opus-4",
+                   "claude-3-7-sonnet",
+                   "claude-3-5-sonnet",
+                   "claude-3-5-haiku",
+                   "claude-3-opus",
+                   "claude-3-sonnet",
+                   "claude-3-haiku",
+                   "gpt-4o",
+                   "gpt-4o-mini",
+                   "gpt-4-turbo",
+                   "o1",
+                   "o3",
+                   "o4-mini",
+                   "gemini-2.5-pro",
+                   "gemini-2.5-flash",
+                   "gemini-2.0-flash",
+                   "gemini-1.5-pro",
+                   "gemini-1.5-flash"
+                 ])
+
+  @doc """
+  Returns true if the model supports image/vision input.
+
+  Uses prefix matching so "claude-sonnet-4-20250514" matches "claude-sonnet-4".
+  Returns true for unknown models (safer to try and let the API reject it
+  than to block the user).
+  """
+  @spec vision_capable?(String.t()) :: boolean()
+  def vision_capable?(model_name) when is_binary(model_name) do
+    MapSet.member?(@vision_models, model_name) or
+      Enum.any?(@vision_models, &String.starts_with?(model_name, &1)) or
+      not Map.has_key?(@limits, model_name)
+  end
+
   # Sorted by key length descending so "gpt-4o" matches before "gpt-4".
   @sorted_limits @limits |> Enum.sort_by(fn {k, _} -> -String.length(k) end)
 

--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -306,12 +306,15 @@ defmodule Minga.Agent.Session do
     {:reply, {:error, :provider_not_ready}, state}
   end
 
-  def handle_call({:send_prompt, text}, _from, state) do
-    # Add user message to conversation
-    state = %{state | messages: state.messages ++ [Message.user(text)]}
+  def handle_call({:send_prompt, content}, _from, state) do
+    # Add user message to conversation.
+    # Content may be a plain string or a list of ContentPart structs
+    # (when images are attached via @image.png mentions).
+    {user_msg, send_content} = build_user_message(content)
+    state = %{state | messages: state.messages ++ [user_msg]}
     state = notify_messages_changed(state)
 
-    case state.provider_module.send_prompt(state.provider, text) do
+    case state.provider_module.send_prompt(state.provider, send_content) do
       :ok ->
         {:reply, :ok, state}
 
@@ -849,6 +852,40 @@ defmodule Minga.Agent.Session do
     end)
   end
 
+  # When content is a ContentPart list (images attached), extract the text
+  # for the chat message and pass the full parts to the provider.
+  @spec build_user_message(String.t() | [ReqLLM.Message.ContentPart.t()]) ::
+          {Message.t(), String.t() | [ReqLLM.Message.ContentPart.t()]}
+  defp build_user_message(content) when is_binary(content) do
+    {Message.user(content), content}
+  end
+
+  defp build_user_message(parts) when is_list(parts) do
+    text =
+      parts
+      |> Enum.filter(&(&1.type == :text))
+      |> Enum.map_join("", & &1.text)
+
+    attachments =
+      parts
+      |> Enum.filter(&(&1.type in [:image, :image_url]))
+      |> Enum.map(fn part ->
+        filename = get_in(part.metadata || %{}, [:filename]) || "image"
+        size_display = get_in(part.metadata || %{}, [:size_display]) || "?"
+        %{filename: filename, size_kb: parse_size_kb(size_display)}
+      end)
+
+    {Message.user(text, attachments), parts}
+  end
+
+  @spec parse_size_kb(String.t()) :: non_neg_integer()
+  defp parse_size_kb(display) do
+    case Integer.parse(String.replace(display, "KB", "")) do
+      {kb, _} -> kb
+      :error -> 0
+    end
+  end
+
   @doc false
   @spec notify_messages_changed(state()) :: state()
   defp notify_messages_changed(state) do
@@ -958,6 +995,7 @@ defmodule Minga.Agent.Session do
   defp first_user_prompt(messages) do
     Enum.find_value(messages, fn
       {:user, text} when is_binary(text) -> text
+      {:user, text, _attachments} when is_binary(text) -> text
       _ -> nil
     end)
   end

--- a/lib/minga/agent/session_store.ex
+++ b/lib/minga/agent/session_store.ex
@@ -155,6 +155,7 @@ defmodule Minga.Agent.SessionStore do
   end
 
   @spec serialize_message(Minga.Agent.Message.t()) :: map()
+  defp serialize_message({:user, text, _attachments}), do: %{"type" => "user", "text" => text}
   defp serialize_message({:user, text}), do: %{"type" => "user", "text" => text}
   defp serialize_message({:assistant, text}), do: %{"type" => "assistant", "text" => text}
 

--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -409,8 +409,9 @@ defmodule Minga.Agent.View.Renderer do
 
   @spec session_title([term()]) :: String.t()
   defp session_title(messages) do
-    case Enum.find(messages, fn msg -> match?({:user, _}, msg) end) do
+    case Enum.find(messages, fn msg -> match?({:user, _}, msg) or match?({:user, _, _}, msg) end) do
       {:user, text} -> truncate_title(text)
+      {:user, text, _attachments} -> truncate_title(text)
       nil -> "Minga Agent"
     end
   end

--- a/lib/minga/editor/agent_lifecycle.ex
+++ b/lib/minga/editor/agent_lifecycle.ex
@@ -169,6 +169,7 @@ defmodule Minga.Editor.AgentLifecycle do
   defp first_user_message(messages) do
     Enum.find_value(messages, fn
       {:user, text} -> text
+      {:user, text, _attachments} -> text
       _ -> nil
     end)
   end

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -229,7 +229,9 @@ defmodule Minga.Editor.Commands.Agent do
   defp send_prompt_to_llm(state, text) do
     # Resolve @file mentions before sending to the LLM.
     # Returns either a string (text only) or a list of ContentPart (when images are present).
-    with {:ok, resolved} <- resolve_mentions(text),
+    model = AgentAccess.panel(state).model_name
+
+    with {:ok, resolved} <- resolve_mentions(text, model: model),
          :ok <- Session.send_prompt(AgentAccess.session(state), resolved) do
       state = update_agent(state, &AgentState.clear_input_and_scroll/1)
 
@@ -248,11 +250,11 @@ defmodule Minga.Editor.Commands.Agent do
     end
   end
 
-  @spec resolve_mentions(String.t()) ::
+  @spec resolve_mentions(String.t(), keyword()) ::
           {:ok, String.t()} | {:ok, [ReqLLM.Message.ContentPart.t()]} | {:error, String.t()}
-  defp resolve_mentions(text) do
+  defp resolve_mentions(text, opts) do
     root = project_root()
-    FileMention.resolve_prompt(text, root)
+    FileMention.resolve_prompt(text, root, opts)
   end
 
   @spec project_root() :: String.t()


### PR DESCRIPTION
Fixes #372

This turned out to be worse than just missing UI polish. The image input feature (#281) has a **latent crash bug**: sending any `@image.png` mention crashes with `FunctionClauseError` because `Message.user/1` only accepts strings, but the Session passes it a ContentPart list.

## Changes

### 1. Fix ContentPart crash (bug)
`Session.handle_call(:send_prompt)` now uses `build_user_message/1` to extract text and image metadata from ContentPart lists before storing the chat message. The full ContentParts are still passed to the provider for the API call.

### 2. Chat image indicator (missing AC)
Added `{:user, text, attachments}` message variant. The chat renderer shows `📎 filename (245KB)` for each attached image. Updated all 6 files that pattern match on `{:user, text}`.

### 3. Vision capability check (missing AC)
`ModelLimits.vision_capable?/1` checks if a model supports image input. When the user mentions an image with a non-vision model, they get a clear error instead of a confusing API failure. Unknown models default to allowed.

## Files changed (10)
- `message.ex`: new `{:user, text, attachments}` type + `user/2`
- `session.ex`: `build_user_message/1` extracts text from ContentParts
- `chat_renderer.ex`: renders 📎 indicators for image attachments
- `model_limits.ex`: `vision_capable?/1`
- `file_mention.ex`: vision check before resolving images
- `commands/agent.ex`: passes model to resolve_mentions
- `buffer_sync.ex`, `session_store.ex`, `view/renderer.ex`, `agent_lifecycle.ex`: handle new tuple variant