### PR TITLE
feat(editor): FloatingWindow rendering primitive

### DIFF
--- a/lib/minga/editor/floating_window.ex
+++ b/lib/minga/editor/floating_window.ex
@@ -1,0 +1,298 @@
+defmodule Minga.Editor.FloatingWindow do
+  @moduledoc """
+  Pure rendering helper for bordered, titled floating panels.
+
+  Takes a `Spec` struct describing the window's content, size, position,
+  and styling, and returns a list of `DisplayList.draw()` tuples. No
+  GenServer, no state. The caller (PickerUI, WhichKey, or any future
+  consumer) builds the spec, calls `render/1`, and includes the draws
+  as an `Overlay` in the render pipeline.
+
+  Works for both TUI (emulated overlays) and GUI (the draws are
+  frontend-agnostic styled text runs).
+
+  ## Example
+
+      spec = %FloatingWindow.Spec{
+        title: "Select Model",
+        content: [DisplayList.draw(0, 0, "claude-sonnet-4-20250514", fg: :white)],
+        width: {:percent, 60},
+        height: {:rows, 15},
+        border: :rounded,
+        theme: state.theme.popup,
+        viewport: {state.viewport.rows, state.viewport.cols}
+      }
+
+      draws = FloatingWindow.render(spec)
+  """
+
+  alias Minga.Editor.DisplayList
+
+  # ── Border character sets ────────────────────────────────────────────────
+
+  @type border_style :: :single | :double | :rounded | :none
+
+  @type border_chars :: %{
+          tl: String.t(),
+          tr: String.t(),
+          bl: String.t(),
+          br: String.t(),
+          h: String.t(),
+          v: String.t()
+        }
+
+  @border_single %{tl: "┌", tr: "┐", bl: "└", br: "┘", h: "─", v: "│"}
+  @border_double %{tl: "╔", tr: "╗", bl: "╚", br: "╝", h: "═", v: "║"}
+  @border_rounded %{tl: "╭", tr: "╮", bl: "╰", br: "╯", h: "─", v: "│"}
+
+  # ── Spec ─────────────────────────────────────────────────────────────────
+
+  defmodule Spec do
+    @moduledoc """
+    Specification for a floating window.
+
+    All fields except `theme` and `viewport` have sensible defaults.
+    """
+
+    @enforce_keys [:theme, :viewport]
+    defstruct title: nil,
+              footer: nil,
+              content: [],
+              width: {:percent, 60},
+              height: {:percent, 50},
+              position: :center,
+              border: :rounded,
+              theme: nil,
+              viewport: nil
+
+    @type size :: {:cols, pos_integer()} | {:rows, pos_integer()} | {:percent, 1..100}
+
+    @type position :: :center | {row_offset :: integer(), col_offset :: integer()}
+
+    @type t :: %__MODULE__{
+            title: String.t() | nil,
+            footer: String.t() | nil,
+            content: [Minga.Editor.DisplayList.draw()],
+            width: size(),
+            height: size(),
+            position: position(),
+            border: Minga.Editor.FloatingWindow.border_style(),
+            theme: map(),
+            viewport: {rows :: pos_integer(), cols :: pos_integer()}
+          }
+  end
+
+  # ── Public API ───────────────────────────────────────────────────────────
+
+  @doc """
+  Renders a floating window from the given spec.
+
+  Returns a flat list of `DisplayList.draw()` tuples representing the
+  border, title, footer, background fill, and content. The draws use
+  absolute screen coordinates and can be included directly in an
+  `Overlay` struct.
+  """
+  @spec render(Spec.t()) :: [DisplayList.draw()]
+  def render(%Spec{} = spec) do
+    {vp_rows, vp_cols} = spec.viewport
+    box = compute_box(spec, vp_rows, vp_cols)
+
+    bg_draws = render_background(box, spec.theme)
+    border_draws = render_border(box, spec.border, spec.theme)
+    title_draws = render_title(box, spec.title, spec.border, spec.theme)
+    footer_draws = render_footer(box, spec.footer, spec.border, spec.theme)
+    content_draws = offset_content(box, spec.content, spec.border)
+
+    bg_draws ++ border_draws ++ title_draws ++ footer_draws ++ content_draws
+  end
+
+  @doc """
+  Computes the interior dimensions (usable content area) for a spec.
+
+  Returns `{rows, cols}` representing how many rows and columns are
+  available for content inside the border. Useful for callers that need
+  to know how much content to prepare before calling `render/1`.
+  """
+  @spec interior_size(Spec.t()) :: {rows :: non_neg_integer(), cols :: non_neg_integer()}
+  def interior_size(%Spec{} = spec) do
+    {vp_rows, vp_cols} = spec.viewport
+    box = compute_box(spec, vp_rows, vp_cols)
+    border_inset = if spec.border == :none, do: 0, else: 1
+    interior_w = max(box.w - border_inset * 2, 0)
+    interior_h = max(box.h - border_inset * 2, 0)
+    {interior_h, interior_w}
+  end
+
+  # ── Box computation ──────────────────────────────────────────────────────
+
+  @typep box :: %{
+           row: non_neg_integer(),
+           col: non_neg_integer(),
+           w: pos_integer(),
+           h: pos_integer()
+         }
+
+  @spec compute_box(Spec.t(), pos_integer(), pos_integer()) :: box()
+  defp compute_box(spec, vp_rows, vp_cols) do
+    w = resolve_size(spec.width, vp_cols) |> clamp(1, vp_cols)
+    h = resolve_size(spec.height, vp_rows) |> clamp(1, vp_rows)
+
+    {row, col} = resolve_position(spec.position, h, w, vp_rows, vp_cols)
+
+    %{row: row, col: col, w: w, h: h}
+  end
+
+  @spec resolve_size(Spec.size(), pos_integer()) :: pos_integer()
+  defp resolve_size({:cols, n}, _max), do: n
+  defp resolve_size({:rows, n}, _max), do: n
+  defp resolve_size({:percent, pct}, max), do: max(div(max * pct, 100), 1)
+
+  @spec resolve_position(
+          Spec.position(),
+          pos_integer(),
+          pos_integer(),
+          pos_integer(),
+          pos_integer()
+        ) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp resolve_position(:center, h, w, vp_rows, vp_cols) do
+    row = max(div(vp_rows - h, 2), 0)
+    col = max(div(vp_cols - w, 2), 0)
+    {row, col}
+  end
+
+  defp resolve_position({row_off, col_off}, h, w, vp_rows, vp_cols) do
+    center_row = max(div(vp_rows - h, 2), 0)
+    center_col = max(div(vp_cols - w, 2), 0)
+    row = clamp(center_row + row_off, 0, max(vp_rows - h, 0))
+    col = clamp(center_col + col_off, 0, max(vp_cols - w, 0))
+    {row, col}
+  end
+
+  @spec clamp(integer(), integer(), integer()) :: integer()
+  defp clamp(val, lo, hi), do: max(lo, min(val, hi))
+
+  # ── Background fill ─────────────────────────────────────────────────────
+
+  @spec render_background(box(), map()) :: [DisplayList.draw()]
+  defp render_background(%{row: row, col: col, w: w, h: h}, theme) do
+    bg_style = [bg: theme.bg]
+    fill = String.duplicate(" ", w)
+
+    for r <- row..(row + h - 1) do
+      DisplayList.draw(r, col, fill, bg_style)
+    end
+  end
+
+  # ── Border rendering ─────────────────────────────────────────────────────
+
+  @spec render_border(box(), border_style(), map()) :: [DisplayList.draw()]
+  defp render_border(_box, :none, _theme), do: []
+
+  defp render_border(%{row: row, col: col, w: w, h: h}, style, theme) do
+    chars = border_chars(style)
+    border_style = [fg: theme.border_fg, bg: theme.bg]
+    inner_w = max(w - 2, 0)
+    horiz = String.duplicate(chars.h, inner_w)
+
+    top = DisplayList.draw(row, col, chars.tl <> horiz <> chars.tr, border_style)
+    bottom = DisplayList.draw(row + h - 1, col, chars.bl <> horiz <> chars.br, border_style)
+
+    sides =
+      for r <- (row + 1)..(row + h - 2) do
+        [
+          DisplayList.draw(r, col, chars.v, border_style),
+          DisplayList.draw(r, col + w - 1, chars.v, border_style)
+        ]
+      end
+
+    [top, bottom | List.flatten(sides)]
+  end
+
+  # ── Title / Footer ──────────────────────────────────────────────────────
+
+  @spec render_title(box(), String.t() | nil, border_style(), map()) :: [DisplayList.draw()]
+  defp render_title(_box, nil, _border, _theme), do: []
+  defp render_title(_box, "", _border, _theme), do: []
+  defp render_title(_box, _title, :none, _theme), do: []
+
+  defp render_title(%{row: row, col: col, w: w}, title, _border, theme) do
+    inner_w = max(w - 4, 0)
+    truncated = truncate(title, inner_w)
+    title_text = " #{truncated} "
+    title_len = String.length(title_text)
+    # Center the title in the top border
+    start_col = col + max(div(w - title_len, 2), 1)
+    title_style = title_style(theme)
+    [DisplayList.draw(row, start_col, title_text, title_style)]
+  end
+
+  @spec render_footer(box(), String.t() | nil, border_style(), map()) :: [DisplayList.draw()]
+  defp render_footer(_box, nil, _border, _theme), do: []
+  defp render_footer(_box, "", _border, _theme), do: []
+  defp render_footer(_box, _footer, :none, _theme), do: []
+
+  defp render_footer(%{row: row, col: col, w: w, h: h}, footer, _border, theme) do
+    inner_w = max(w - 4, 0)
+    truncated = truncate(footer, inner_w)
+    footer_text = " #{truncated} "
+    footer_len = String.length(footer_text)
+    start_col = col + max(div(w - footer_len, 2), 1)
+    footer_style = [fg: theme.border_fg, bg: theme.bg]
+    [DisplayList.draw(row + h - 1, start_col, footer_text, footer_style)]
+  end
+
+  # ── Content offsetting ──────────────────────────────────────────────────
+
+  @spec offset_content(box(), [DisplayList.draw()], border_style()) :: [DisplayList.draw()]
+  defp offset_content(_box, [], _border), do: []
+
+  defp offset_content(%{row: row, col: col, w: w, h: h}, content, border) do
+    inset = if border == :none, do: 0, else: 1
+    interior_row = row + inset
+    interior_col = col + inset
+    interior_w = max(w - inset * 2, 0)
+    interior_h = max(h - inset * 2, 0)
+
+    content
+    |> Enum.map(fn {r, c, text, style} ->
+      abs_row = r + interior_row
+      abs_col = c + interior_col
+
+      # Clip: skip draws outside the interior
+      if r < interior_h and c < interior_w do
+        # Truncate text that would overflow the right edge
+        max_len = max(interior_w - c, 0)
+        clipped_text = truncate(text, max_len)
+        DisplayList.draw(abs_row, abs_col, clipped_text, style)
+      else
+        nil
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  # ── Helpers ─────────────────────────────────────────────────────────────
+
+  @spec border_chars(border_style()) :: border_chars()
+  defp border_chars(:single), do: @border_single
+  defp border_chars(:double), do: @border_double
+  defp border_chars(:rounded), do: @border_rounded
+
+  @spec truncate(String.t(), non_neg_integer()) :: String.t()
+  defp truncate(text, max_len) when max_len <= 0, do: text
+
+  defp truncate(text, max_len) do
+    if String.length(text) > max_len do
+      String.slice(text, 0, max(max_len - 1, 0)) <> "…"
+    else
+      text
+    end
+  end
+
+  @spec title_style(map()) :: keyword()
+  defp title_style(theme) do
+    fg = Map.get(theme, :title_fg, theme.border_fg)
+    [fg: fg, bg: theme.bg, bold: true]
+  end
+end

--- a/lib/minga/theme.ex
+++ b/lib/minga/theme.ex
@@ -206,14 +206,17 @@ defmodule Minga.Theme do
   end
 
   defmodule Popup do
-    @moduledoc "Popup (which-key, etc.) colors."
+    @moduledoc "Popup (which-key, floating window, etc.) colors."
     @enforce_keys [:fg, :bg, :border_fg]
-    defstruct [:fg, :bg, :border_fg]
+    defstruct [:fg, :bg, :border_fg, :sel_fg, :sel_bg, :title_fg]
 
     @type t :: %__MODULE__{
             fg: Minga.Theme.color(),
             bg: Minga.Theme.color(),
-            border_fg: Minga.Theme.color()
+            border_fg: Minga.Theme.color(),
+            sel_fg: Minga.Theme.color() | nil,
+            sel_bg: Minga.Theme.color() | nil,
+            title_fg: Minga.Theme.color() | nil
           }
   end
 

--- a/lib/minga/theme/catppuccin.ex
+++ b/lib/minga/theme/catppuccin.ex
@@ -76,7 +76,10 @@ defmodule Minga.Theme.Catppuccin do
       popup: %Minga.Theme.Popup{
         fg: p.text,
         bg: p.surface0,
-        border_fg: p.overlay1
+        border_fg: p.overlay1,
+        sel_fg: p.base,
+        sel_bg: p.blue,
+        title_fg: p.blue
       },
       tree: %Minga.Theme.Tree{
         bg: p.mantle,

--- a/lib/minga/theme/doom_one.ex
+++ b/lib/minga/theme/doom_one.ex
@@ -94,7 +94,10 @@ defmodule Minga.Theme.DoomOne do
       popup: %Minga.Theme.Popup{
         fg: @base8,
         bg: 0x333333,
-        border_fg: @base6
+        border_fg: @base6,
+        sel_fg: @bg,
+        sel_bg: @blue,
+        title_fg: @blue
       },
       tree: %Minga.Theme.Tree{
         bg: @base3,

--- a/lib/minga/theme/one_dark.ex
+++ b/lib/minga/theme/one_dark.ex
@@ -91,7 +91,10 @@ defmodule Minga.Theme.OneDark do
       popup: %Minga.Theme.Popup{
         fg: @mono_1,
         bg: @syntax_guide,
-        border_fg: @mono_2
+        border_fg: @mono_2,
+        sel_fg: @syntax_bg,
+        sel_bg: @hue_2,
+        title_fg: @hue_2
       },
       tree: %Minga.Theme.Tree{
         bg: 0x21252B,

--- a/lib/minga/theme/one_light.ex
+++ b/lib/minga/theme/one_light.ex
@@ -91,7 +91,10 @@ defmodule Minga.Theme.OneLight do
       popup: %Minga.Theme.Popup{
         fg: @mono_1,
         bg: @syntax_guide,
-        border_fg: @mono_3
+        border_fg: @mono_3,
+        sel_fg: @syntax_bg,
+        sel_bg: @hue_2,
+        title_fg: @hue_2
       },
       tree: %Minga.Theme.Tree{
         bg: 0xF0F0F0,

--- a/test/minga/editor/floating_window_test.exs
+++ b/test/minga/editor/floating_window_test.exs
@@ -1,0 +1,320 @@
+defmodule Minga.Editor.FloatingWindowTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.DisplayList
+  alias Minga.Editor.FloatingWindow
+  alias Minga.Editor.FloatingWindow.Spec
+
+  @theme %{fg: 0xFFFFFF, bg: 0x333333, border_fg: 0x888888}
+
+  defp spec(overrides \\ []) do
+    defaults = %{
+      theme: @theme,
+      viewport: {24, 80}
+    }
+
+    struct!(Spec, Map.merge(defaults, Map.new(overrides)))
+  end
+
+  describe "render/1 basic output" do
+    test "returns a non-empty list of draws" do
+      draws = FloatingWindow.render(spec())
+      assert is_list(draws)
+      assert draws != []
+    end
+
+    test "all draws are valid {row, col, text, style} tuples" do
+      draws = FloatingWindow.render(spec())
+
+      Enum.each(draws, fn {row, col, text, style} ->
+        assert is_integer(row) and row >= 0
+        assert is_integer(col) and col >= 0
+        assert is_binary(text)
+        assert is_list(style)
+      end)
+    end
+  end
+
+  describe "centering" do
+    test "centers a 60% x 50% window in 80x24 viewport" do
+      draws = FloatingWindow.render(spec(width: {:percent, 60}, height: {:percent, 50}))
+      # 60% of 80 = 48 cols, 50% of 24 = 12 rows
+      # Center: row = (24-12)/2 = 6, col = (80-48)/2 = 16
+      rows = draws |> Enum.map(fn {r, _, _, _} -> r end) |> Enum.uniq() |> Enum.sort()
+      cols = draws |> Enum.map(fn {_, c, _, _} -> c end) |> Enum.min()
+      assert Enum.min(rows) == 6
+      assert Enum.max(rows) == 17
+      assert cols == 16
+    end
+
+    test "centers a fixed-size window" do
+      draws = FloatingWindow.render(spec(width: {:cols, 40}, height: {:rows, 10}))
+      # Center: row = (24-10)/2 = 7, col = (80-40)/2 = 20
+      rows = draws |> Enum.map(fn {r, _, _, _} -> r end) |> Enum.uniq() |> Enum.sort()
+      cols = draws |> Enum.map(fn {_, c, _, _} -> c end) |> Enum.min()
+      assert Enum.min(rows) == 7
+      assert cols == 20
+    end
+
+    test "offset from center" do
+      draws =
+        FloatingWindow.render(spec(width: {:cols, 20}, height: {:rows, 10}, position: {-3, 5}))
+
+      # Center would be row=7, col=30. Offset: row=4, col=35
+      min_row = draws |> Enum.map(fn {r, _, _, _} -> r end) |> Enum.min()
+      min_col = draws |> Enum.map(fn {_, c, _, _} -> c end) |> Enum.min()
+      assert min_row == 4
+      assert min_col == 35
+    end
+
+    test "clamps to viewport when window is larger than screen" do
+      draws =
+        FloatingWindow.render(spec(width: {:cols, 100}, height: {:rows, 30}, viewport: {24, 80}))
+
+      rows = draws |> Enum.map(fn {r, _, _, _} -> r end)
+      cols = draws |> Enum.map(fn {_, c, _, _} -> c end)
+      assert Enum.min(rows) >= 0
+      assert Enum.max(rows) < 24
+      assert Enum.min(cols) >= 0
+    end
+
+    test "works with small viewport" do
+      draws =
+        FloatingWindow.render(
+          spec(width: {:percent, 80}, height: {:percent, 80}, viewport: {10, 20})
+        )
+
+      # 80% of 20 = 16, 80% of 10 = 8
+      rows = draws |> Enum.map(fn {r, _, _, _} -> r end)
+      cols = draws |> Enum.map(fn {_, c, _, _} -> c end)
+      assert Enum.min(rows) >= 0
+      assert Enum.max(rows) < 10
+      assert Enum.min(cols) >= 0
+      assert Enum.max(cols) < 20
+    end
+  end
+
+  describe "border styles" do
+    test "rounded border uses correct characters" do
+      draws =
+        FloatingWindow.render(spec(width: {:cols, 10}, height: {:rows, 5}, border: :rounded))
+
+      texts = draws |> Enum.map(fn {_, _, t, _} -> t end)
+      top_border = Enum.find(texts, &String.starts_with?(&1, "╭"))
+      bottom_border = Enum.find(texts, &String.starts_with?(&1, "╰"))
+      assert top_border != nil
+      assert bottom_border != nil
+      assert String.ends_with?(top_border, "╮")
+      assert String.ends_with?(bottom_border, "╯")
+    end
+
+    test "single border uses correct characters" do
+      draws = FloatingWindow.render(spec(width: {:cols, 10}, height: {:rows, 5}, border: :single))
+      texts = draws |> Enum.map(fn {_, _, t, _} -> t end)
+      assert Enum.any?(texts, &String.starts_with?(&1, "┌"))
+      assert Enum.any?(texts, &String.starts_with?(&1, "└"))
+    end
+
+    test "double border uses correct characters" do
+      draws = FloatingWindow.render(spec(width: {:cols, 10}, height: {:rows, 5}, border: :double))
+      texts = draws |> Enum.map(fn {_, _, t, _} -> t end)
+      assert Enum.any?(texts, &String.starts_with?(&1, "╔"))
+      assert Enum.any?(texts, &String.starts_with?(&1, "╚"))
+    end
+
+    test "no border omits border characters" do
+      draws = FloatingWindow.render(spec(width: {:cols, 10}, height: {:rows, 5}, border: :none))
+      texts = draws |> Enum.map(fn {_, _, t, _} -> t end)
+      border_chars = ["╭", "╮", "╰", "╯", "┌", "┐", "└", "┘", "╔", "╗", "╚", "╝", "│", "║"]
+
+      refute Enum.any?(texts, fn t ->
+               Enum.any?(border_chars, &String.contains?(t, &1))
+             end)
+    end
+
+    test "sides are drawn between top and bottom" do
+      draws =
+        FloatingWindow.render(spec(width: {:cols, 10}, height: {:rows, 5}, border: :rounded))
+
+      side_draws = Enum.filter(draws, fn {_, _, t, _} -> t == "│" end)
+      # 5 rows - 2 (top/bottom) = 3 interior rows, 2 sides each = 6 side draws
+      assert length(side_draws) == 6
+    end
+  end
+
+  describe "title and footer" do
+    test "title appears in the top border row" do
+      draws = FloatingWindow.render(spec(title: "Hello", width: {:cols, 30}, height: {:rows, 10}))
+      # Top border row is the minimum row
+      min_row = draws |> Enum.map(fn {r, _, _, _} -> r end) |> Enum.min()
+
+      title_draw =
+        Enum.find(draws, fn {r, _, t, _} -> r == min_row and String.contains?(t, "Hello") end)
+
+      assert title_draw != nil
+    end
+
+    test "footer appears in the bottom border row" do
+      draws =
+        FloatingWindow.render(spec(footer: "Press q", width: {:cols, 30}, height: {:rows, 10}))
+
+      max_row = draws |> Enum.map(fn {r, _, _, _} -> r end) |> Enum.max()
+
+      footer_draw =
+        Enum.find(draws, fn {r, _, t, _} -> r == max_row and String.contains?(t, "Press q") end)
+
+      assert footer_draw != nil
+    end
+
+    test "title is truncated when window is narrow" do
+      draws =
+        FloatingWindow.render(
+          spec(
+            title: "This is a very long title that should be truncated",
+            width: {:cols, 15},
+            height: {:rows, 5}
+          )
+        )
+
+      min_row = draws |> Enum.map(fn {r, _, _, _} -> r end) |> Enum.min()
+
+      title_draw =
+        Enum.find(draws, fn {r, _, t, _} -> r == min_row and String.contains?(t, "…") end)
+
+      assert title_draw != nil
+    end
+
+    test "nil title produces no title draws" do
+      draws = FloatingWindow.render(spec(title: nil, width: {:cols, 20}, height: {:rows, 5}))
+      min_row = draws |> Enum.map(fn {r, _, _, _} -> r end) |> Enum.min()
+      # Only the border draw should be on the top row (no extra title overlay)
+      top_draws = Enum.filter(draws, fn {r, _, _, _} -> r == min_row end)
+      # Background fill + border = 2 draws on top row
+      assert length(top_draws) <= 2
+    end
+
+    test "title and footer with no border are not rendered" do
+      draws =
+        FloatingWindow.render(
+          spec(
+            title: "Hello",
+            footer: "World",
+            border: :none,
+            width: {:cols, 20},
+            height: {:rows, 5}
+          )
+        )
+
+      texts = draws |> Enum.map(fn {_, _, t, _} -> t end)
+      refute Enum.any?(texts, &String.contains?(&1, "Hello"))
+      refute Enum.any?(texts, &String.contains?(&1, "World"))
+    end
+  end
+
+  describe "content" do
+    test "content draws are offset into the interior" do
+      content = [DisplayList.draw(0, 0, "hello", fg: 0xFFFFFF)]
+
+      draws =
+        FloatingWindow.render(
+          spec(content: content, width: {:cols, 20}, height: {:rows, 10}, border: :rounded)
+        )
+
+      # Find the content draw (not border/background)
+      content_draw = Enum.find(draws, fn {_, _, t, _} -> t == "hello" end)
+      assert content_draw != nil
+
+      {row, col, _, _} = content_draw
+      # With a 20x10 window centered in 80x24:
+      # Box starts at row=7, col=30. Interior starts at row=8, col=31
+      assert row == 8
+      assert col == 31
+    end
+
+    test "content is clipped when it exceeds interior height" do
+      # Interior of a 10-row bordered window = 8 rows (0..7)
+      content =
+        for r <- 0..15 do
+          DisplayList.draw(r, 0, "line #{r}", [])
+        end
+
+      draws =
+        FloatingWindow.render(
+          spec(content: content, width: {:cols, 20}, height: {:rows, 10}, border: :rounded)
+        )
+
+      content_draws = Enum.filter(draws, fn {_, _, t, _} -> String.starts_with?(t, "line") end)
+      # Only 8 interior rows should have content
+      assert length(content_draws) == 8
+    end
+
+    test "content text is truncated at the right edge" do
+      content = [DisplayList.draw(0, 0, "this is a long text that overflows", [])]
+
+      draws =
+        FloatingWindow.render(
+          spec(content: content, width: {:cols, 15}, height: {:rows, 5}, border: :rounded)
+        )
+
+      content_draw = Enum.find(draws, fn {_, _, t, _} -> String.starts_with?(t, "this") end)
+      assert content_draw != nil
+      {_, _, text, _} = content_draw
+      # Interior width = 15 - 2 = 13. Text should be truncated to 13 chars
+      assert String.length(text) <= 13
+    end
+
+    test "content with no border gets full box dimensions" do
+      content = [DisplayList.draw(0, 0, "hello", [])]
+
+      draws =
+        FloatingWindow.render(
+          spec(content: content, width: {:cols, 20}, height: {:rows, 10}, border: :none)
+        )
+
+      content_draw = Enum.find(draws, fn {_, _, t, _} -> t == "hello" end)
+      assert content_draw != nil
+
+      {row, col, _, _} = content_draw
+      # No border inset, so content starts at box origin
+      # Box: row=7, col=30 (centered 20x10 in 80x24)
+      assert row == 7
+      assert col == 30
+    end
+
+    test "empty content produces no content draws" do
+      draws = FloatingWindow.render(spec(content: [], width: {:cols, 20}, height: {:rows, 5}))
+      # Should only have background + border draws
+      assert draws != []
+    end
+  end
+
+  describe "interior_size/1" do
+    test "returns interior dimensions for bordered window" do
+      s = spec(width: {:cols, 40}, height: {:rows, 20}, border: :rounded)
+      assert FloatingWindow.interior_size(s) == {18, 38}
+    end
+
+    test "returns full dimensions for borderless window" do
+      s = spec(width: {:cols, 40}, height: {:rows, 20}, border: :none)
+      assert FloatingWindow.interior_size(s) == {20, 40}
+    end
+
+    test "returns clamped dimensions when window exceeds viewport" do
+      s = spec(width: {:cols, 100}, height: {:rows, 50}, viewport: {24, 80}, border: :rounded)
+      {h, w} = FloatingWindow.interior_size(s)
+      assert h == 22
+      assert w == 78
+    end
+  end
+
+  describe "background fill" do
+    test "background covers the entire box" do
+      draws = FloatingWindow.render(spec(width: {:cols, 10}, height: {:rows, 5}))
+      # Background draws should cover all 5 rows of the box
+      bg_draws =
+        Enum.filter(draws, fn {_, _, t, _} -> String.length(t) == 10 and String.trim(t) == "" end)
+
+      assert length(bg_draws) == 5
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

Adds a pure rendering primitive for bordered, titled floating panels that works across both TUI and macOS GUI frontends. This is the foundation that the popup system's float mode, centered picker layout, and future settings panels will build on.

Part of #343

## Context

The TUI had no general-purpose floating window. The picker is bottom-anchored, the which-key popup is a bottom bar. Neovim-style centered floating panels (Lazy.nvim, Mason, Telescope centered layout) didn't exist yet. This PR adds the core rendering primitive; follow-up PRs will wire it into the picker and popup system.

The module produces `[DisplayList.draw()]` tuples, which are frontend-agnostic styled text runs. The TUI composites them as overlays; the macOS GUI can either consume the same draws or use native `NSPanel` when `float_support: :native`.

## Changes

- **`FloatingWindow` module** (`lib/minga/editor/floating_window.ex`): Pure function `render(spec) :: [DisplayList.draw()]`. Takes a `Spec` struct with title, footer, content draws, width/height (absolute or percent), position (:center or offset), border style, and theme. Computes the bounding box, renders background fill, border (Unicode box-drawing), title/footer centered in the border, and offsets content draws into the interior with clipping.

- **`FloatingWindow.Spec` struct**: Declarative specification with sensible defaults. `interior_size/1` helper lets callers pre-measure available space before preparing content.

- **Four border styles**: `:rounded` (╭╮╰╯), `:single` (┌┐└┘), `:double` (╔╗╚╝), `:none`.

- **Theme extension**: Added optional `sel_fg`, `sel_bg`, `title_fg` fields to `Theme.Popup`. All four themes (Doom One, Catppuccin, One Dark, One Light) updated with themed values. Backwards compatible since new fields default to `nil` with fallbacks.

## Verification

```bash
cd minga-worktrees/floating-window
mix lint                          # All checks pass
mix test --warnings-as-errors     # 4050 tests, 0 failures
mix dialyzer                      # 0 errors
```

## Acceptance Criteria Addressed

- A new `FloatingWindow` module can render a bordered, titled panel at a configurable position (centered, or explicit row/col offset from center) ✅
- The floating window supports: title text, border characters (single/double/rounded), content as a list of styled draw commands, optional footer text, and a configurable width/height (absolute or percentage of screen) ✅
- Theme support: the existing `theme.popup` colors apply, plus optional `title_fg` and selection colors ✅

**Not yet addressed (follow-up PRs):**
- Picker centered floating layout mode
- Which-key as a centered float
- Floating windows in the overlays list (needs a consumer to wire it)
- Mouse click routing for floating windows
