### PR TITLE
fix(port): handle long-form TTY names from ps on macOS

### DIFF
--- a/lib/minga/port/manager.ex
+++ b/lib/minga/port/manager.ex
@@ -241,16 +241,34 @@ defmodule Minga.Port.Manager do
 
   @spec detect_tty() :: String.t() | nil
   defp detect_tty do
-    # `ps -o tty=` returns the controlling terminal's short name (e.g. "s003")
-    # from the kernel — works even though System.cmd's child has piped stdin.
     with {output, 0} <- System.cmd("ps", ["-o", "tty=", "-p", to_string(:os.getpid())]),
-         tty_short = String.trim(output),
-         true <- tty_short != "" and tty_short != "??" do
-      # macOS: "s003" → "/dev/ttys003"
-      # Linux: "pts/3" → "/dev/pts/3"
-      "/dev/tty#{tty_short}"
+         tty_name = String.trim(output),
+         true <- tty_name != "" and tty_name != "??" do
+      tty_path_for(tty_name)
     else
       _ -> nil
+    end
+  end
+
+  @doc """
+  Builds a `/dev/` path from the tty name returned by `ps -o tty=`.
+
+  The format varies by OS and version:
+  - macOS long form: `"ttys008"` → `"/dev/ttys008"`
+  - macOS short form: `"s003"` → `"/dev/ttys003"`
+  - Linux: `"pts/3"` → `"/dev/pts/3"`
+
+  Checks if `/dev/{name}` exists first (handles long form and Linux).
+  Falls back to `/dev/tty{name}` for short forms.
+  """
+  @spec tty_path_for(String.t()) :: String.t()
+  def tty_path_for(tty_name) do
+    path = "/dev/#{tty_name}"
+
+    if File.exists?(path) do
+      path
+    else
+      "/dev/tty#{tty_name}"
     end
   end
 

--- a/test/minga/port/tty_detection_test.exs
+++ b/test/minga/port/tty_detection_test.exs
@@ -1,0 +1,52 @@
+defmodule Minga.Port.TtyDetectionTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Port.Manager
+
+  describe "tty_path_for/1" do
+    test "long-form macOS name produces /dev/ttys* path" do
+      # "ttys008" → "/dev/ttys008" (the file exists on macOS)
+      # We can't guarantee the exact device exists in CI, but we can
+      # verify the path construction logic: if /dev/ttys008 exists,
+      # use it directly; otherwise fall back to /dev/ttyttys008.
+      result = Manager.tty_path_for("ttys008")
+
+      # On macOS where /dev/ttys008 exists, we get the direct path.
+      # On Linux CI where it doesn't, we get the fallback.
+      assert result in ["/dev/ttys008", "/dev/ttyttys008"]
+
+      # The critical invariant: if the direct path exists, use it
+      if File.exists?("/dev/ttys008") do
+        assert result == "/dev/ttys008"
+      end
+    end
+
+    test "short-form macOS name prepends tty" do
+      # "s003" → /dev/s003 doesn't exist → fallback to "/dev/ttys003"
+      result = Manager.tty_path_for("s003")
+      assert result == "/dev/ttys003"
+    end
+
+    test "Linux pts path produces /dev/pts/*" do
+      # "pts/3" → "/dev/pts/3" exists on Linux
+      result = Manager.tty_path_for("pts/3")
+
+      if File.exists?("/dev/pts/3") do
+        assert result == "/dev/pts/3"
+      else
+        assert result == "/dev/ttypts/3"
+      end
+    end
+
+    test "direct path is preferred when the device file exists" do
+      # Use /dev/tty which exists on all Unix systems
+      # Simulate: if ps returned "tty", we'd check /dev/tty first
+      assert Manager.tty_path_for("tty") == "/dev/tty"
+    end
+
+    test "falls back to /dev/tty{name} when direct path missing" do
+      # A name that definitely won't have a matching /dev/ entry
+      assert Manager.tty_path_for("z999") == "/dev/ttyz999"
+    end
+  end
+end


### PR DESCRIPTION
The Zig renderer crashed on startup with ENXIO trying to open `/dev/ttyttys008`.

`ps -o tty=` returns `ttys008` (full name) on some macOS configurations, but `detect_tty/0` unconditionally prepended `/dev/tty`, producing the invalid path `/dev/ttyttys008`.

Fix: check if `/dev/{tty_name}` exists first (handles long form like `ttys008` → `/dev/ttys008`). Only prepend `/dev/tty` as a fallback for short forms (like `s003` → `/dev/ttys003`).