### PR TITLE
fix(editor): remove stale surface_module reference that crashes file picker

### DIFF
--- a/lib/minga/picker/file_source.ex
+++ b/lib/minga/picker/file_source.ex
@@ -38,7 +38,7 @@ defmodule Minga.Picker.FileSource do
   def on_select({rel_path, _label, _desc}, state) do
     abs_path = Path.expand(rel_path)
 
-    Log.debug(:editor, "[file_picker] on_select path=#{rel_path} surface=#{state.surface_module}")
+    Log.debug(:editor, "[file_picker] on_select path=#{rel_path}")
 
     case find_buffer_by_path(state, abs_path) do
       nil ->


### PR DESCRIPTION
## What

Opening a file via `SPC f f` crashes the Editor GenServer:

```
** (KeyError) key :surface_module not found in: %Minga.Editor.State{}
```

One-line fix: a debug log in `FileSource.on_select/2` referenced `state.surface_module`, a field that was removed from EditorState in a prior refactor.

## Root Cause

- **PR #318** (`4e010a4c`) replaced `state.agentic.active` with `state.surface_module` in a debug log in `file_source.ex`
- **Later refactor** (`a0c83432`) removed `surface_module` from the EditorState struct but missed this one log line
- Accessing a nonexistent struct field with dot notation raises `KeyError`, which terminates the Editor GenServer

## Your other questions

**"Shouldn't the error go to \*Messages\*, not the terminal?"** The Editor GenServer itself crashed. A dead process can't write to its own `*Messages*` buffer. The crash output goes to the Erlang logger (stderr/terminal). This is correct BEAM behavior for a fatal error. The real fix is not crashing in the first place.

**"Shouldn't Minga recover?"** The supervisor does restart the Editor, but you lose your session state. For a debug log to be able to nuke the editor is clearly wrong. This fix eliminates that.

## Fix

Removed the stale `surface=#{state.surface_module}` from the debug log. The surface module concept no longer exists.

All 4100 tests pass, `mix lint` and `mix dialyzer` clean.
