### PR TITLE
fix(editor): buffer log messages during Editor restart so crash reports reach *Messages*

### DIFF
--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -34,6 +34,11 @@ defmodule Minga.Application do
   @impl true
   @spec start(Application.start_type(), term()) :: {:ok, pid()} | {:error, term()}
   def start(_type, _args) do
+    # Create the log buffer ETS table owned by the supervisor process.
+    # This table survives Editor crashes so the LoggerHandler can queue
+    # messages while the Editor is restarting. The Editor flushes it on init.
+    Minga.LoggerHandler.ensure_buffer_table()
+
     base_children = [
       Minga.Config.Options,
       Minga.Keymap.Active,

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -120,6 +120,18 @@ defmodule Minga.Editor do
         log_message(state, "Editor started")
       end
 
+    # Flush any log messages that arrived while the Editor was down
+    # (e.g., supervisor crash reports from a previous Editor crash).
+    # Must happen after *Messages* buffer is ready but before we return.
+    flushed = Minga.LoggerHandler.flush_buffer()
+
+    state =
+      if flushed > 0 do
+        log_message(state, "Replayed #{flushed} message(s) from before restart")
+      else
+        state
+      end
+
     state = Startup.apply_config_options(state)
     Minga.Diagnostics.subscribe()
 

--- a/lib/minga/logger_handler.ex
+++ b/lib/minga/logger_handler.ex
@@ -12,6 +12,14 @@ defmodule Minga.LoggerHandler do
   3. Redirects the `:standard_error` IO device to the same log file so that
      raw BEAM warnings (e.g. `IO.warn/2`) don't corrupt the TUI either
 
+  ## Crash recovery
+
+  When the Editor GenServer is down (e.g., mid-restart after a crash), log
+  messages are buffered in an ETS table owned by the Application supervisor.
+  The Editor calls `flush_buffer/0` during `init/1` to replay them into
+  `*Messages*`. The buffer is capped at `@max_buffered` entries to prevent
+  unbounded growth during crash loops.
+
   ## Installation
 
   Called from `Minga.Editor.init/1` after the `*Messages*` buffer is ready:
@@ -25,6 +33,26 @@ defmodule Minga.LoggerHandler do
   @file_handler_id :minga_file
   @log_dir Path.expand("~/.local/share/minga")
   @log_file "minga.log"
+  @buffer_table :minga_log_buffer
+  @max_buffered 50
+
+  @doc """
+  Creates the ETS buffer table if it doesn't already exist.
+
+  Called from `Minga.Application.start/2` so the table is owned by the
+  supervisor process and survives Editor crashes.
+  """
+  @spec ensure_buffer_table() :: :ok
+  def ensure_buffer_table do
+    case :ets.whereis(@buffer_table) do
+      :undefined ->
+        :ets.new(@buffer_table, [:named_table, :ordered_set, :public])
+        :ok
+
+      _ref ->
+        :ok
+    end
+  end
 
   @doc """
   Install the custom handlers and redirect stderr to a log file.
@@ -71,6 +99,39 @@ defmodule Minga.LoggerHandler do
     :ok
   end
 
+  @doc """
+  Flush buffered log messages into the Editor.
+
+  Called from `Editor.init/1` after `*Messages*` is ready. Replays all
+  buffered messages in order, then clears the buffer. Messages that arrived
+  while the Editor was down (e.g., supervisor crash reports) will appear
+  in `*Messages*` as if they'd been logged normally.
+  """
+  @spec flush_buffer() :: non_neg_integer()
+  def flush_buffer do
+    case :ets.whereis(@buffer_table) do
+      :undefined ->
+        0
+
+      _ref ->
+        entries = :ets.tab2list(@buffer_table)
+        :ets.delete_all_objects(@buffer_table)
+        Enum.each(entries, &replay_entry/1)
+        length(entries)
+    end
+  end
+
+  @spec replay_entry({integer(), String.t(), atom()}) :: :ok
+  defp replay_entry({_key, text, level}) do
+    Minga.Editor.log_to_messages(text)
+
+    if level in [:warning, :error] do
+      Minga.Editor.log_to_warnings(text)
+    end
+
+    :ok
+  end
+
   # ── :logger handler callbacks (OTP 21+) ────────────────────────────────────
 
   @doc false
@@ -93,7 +154,7 @@ defmodule Minga.LoggerHandler do
 
     case Process.whereis(Minga.Editor) do
       nil ->
-        :ok
+        buffer_message(text, level)
 
       _pid ->
         Minga.Editor.log_to_messages(text)
@@ -101,6 +162,46 @@ defmodule Minga.LoggerHandler do
         if level in [:warning, :error] do
           Minga.Editor.log_to_warnings(text)
         end
+    end
+  end
+
+  # ── Buffer for messages during Editor downtime ─────────────────────────────
+
+  @spec buffer_message(String.t(), atom()) :: :ok
+  defp buffer_message(text, level) do
+    case :ets.whereis(@buffer_table) do
+      :undefined ->
+        :ok
+
+      _ref ->
+        key = System.monotonic_time(:nanosecond)
+        :ets.insert(@buffer_table, {key, text, level})
+        maybe_trim_buffer()
+    end
+  end
+
+  @spec maybe_trim_buffer() :: :ok
+  defp maybe_trim_buffer do
+    size = :ets.info(@buffer_table, :size)
+
+    if size > @max_buffered do
+      delete_oldest(size - @max_buffered)
+    end
+
+    :ok
+  end
+
+  @spec delete_oldest(non_neg_integer()) :: :ok
+  defp delete_oldest(0), do: :ok
+
+  defp delete_oldest(remaining) do
+    case :ets.first(@buffer_table) do
+      :"$end_of_table" ->
+        :ok
+
+      key ->
+        :ets.delete(@buffer_table, key)
+        delete_oldest(remaining - 1)
     end
   end
 

--- a/test/minga/logger_handler_test.exs
+++ b/test/minga/logger_handler_test.exs
@@ -1,0 +1,161 @@
+defmodule Minga.LoggerHandlerTest do
+  use ExUnit.Case, async: false
+
+  alias Minga.LoggerHandler
+
+  @buffer_table :minga_log_buffer
+
+  setup do
+    LoggerHandler.ensure_buffer_table()
+    :ets.delete_all_objects(@buffer_table)
+    :ok
+  end
+
+  describe "ensure_buffer_table/0" do
+    test "creates the ETS table" do
+      assert :ets.whereis(@buffer_table) != :undefined
+    end
+
+    test "is idempotent" do
+      assert LoggerHandler.ensure_buffer_table() == :ok
+      assert LoggerHandler.ensure_buffer_table() == :ok
+      assert :ets.whereis(@buffer_table) != :undefined
+    end
+  end
+
+  describe "log/2 buffering when Editor is down" do
+    test "buffers messages when Editor is not running" do
+      # Editor is not started in this test, so whereis returns nil
+      refute Process.whereis(Minga.Editor)
+
+      event = %{level: :error, msg: {:string, "boom"}, meta: %{}}
+      LoggerHandler.log(event, %{})
+
+      entries = :ets.tab2list(@buffer_table)
+      assert length(entries) == 1
+      [{_key, text, level}] = entries
+      assert text == "[error] boom"
+      assert level == :error
+    end
+
+    test "buffers multiple messages in order" do
+      refute Process.whereis(Minga.Editor)
+
+      for i <- 1..5 do
+        event = %{level: :info, msg: {:string, "msg #{i}"}, meta: %{}}
+        LoggerHandler.log(event, %{})
+      end
+
+      entries = :ets.tab2list(@buffer_table)
+      assert length(entries) == 5
+
+      texts = Enum.map(entries, fn {_key, text, _level} -> text end)
+
+      assert texts == [
+               "[info] msg 1",
+               "[info] msg 2",
+               "[info] msg 3",
+               "[info] msg 4",
+               "[info] msg 5"
+             ]
+    end
+
+    test "trims buffer to max size" do
+      refute Process.whereis(Minga.Editor)
+
+      # Buffer 60 messages (max is 50)
+      for i <- 1..60 do
+        event = %{level: :info, msg: {:string, "msg #{i}"}, meta: %{}}
+        LoggerHandler.log(event, %{})
+      end
+
+      size = :ets.info(@buffer_table, :size)
+      assert size == 50
+
+      # The oldest messages should have been trimmed, keeping 11..60
+      entries = :ets.tab2list(@buffer_table)
+      texts = Enum.map(entries, fn {_key, text, _level} -> text end)
+      assert hd(texts) == "[info] msg 11"
+      assert List.last(texts) == "[info] msg 60"
+    end
+  end
+
+  describe "flush_buffer/0" do
+    test "returns 0 when buffer is empty" do
+      assert LoggerHandler.flush_buffer() == 0
+    end
+
+    test "clears the buffer after flushing" do
+      refute Process.whereis(Minga.Editor)
+
+      event = %{level: :info, msg: {:string, "test"}, meta: %{}}
+      LoggerHandler.log(event, %{})
+      assert :ets.info(@buffer_table, :size) == 1
+
+      # flush_buffer sends casts to the Editor, which isn't running.
+      # The casts will be dropped (GenServer.cast to a nil pid is a no-op),
+      # but the buffer should still be cleared.
+      LoggerHandler.flush_buffer()
+      assert :ets.info(@buffer_table, :size) == 0
+    end
+
+    test "returns the count of flushed messages" do
+      refute Process.whereis(Minga.Editor)
+
+      for i <- 1..3 do
+        event = %{level: :warning, msg: {:string, "warn #{i}"}, meta: %{}}
+        LoggerHandler.log(event, %{})
+      end
+
+      assert LoggerHandler.flush_buffer() == 3
+    end
+  end
+
+  describe "log/2 message formatting" do
+    test "formats string messages" do
+      refute Process.whereis(Minga.Editor)
+
+      event = %{level: :info, msg: {:string, "hello world"}, meta: %{}}
+      LoggerHandler.log(event, %{})
+
+      [{_key, text, _level}] = :ets.tab2list(@buffer_table)
+      assert text == "[info] hello world"
+    end
+
+    test "formats report messages" do
+      refute Process.whereis(Minga.Editor)
+
+      event = %{level: :error, msg: {:report, %{reason: :crashed}}, meta: %{}}
+      LoggerHandler.log(event, %{})
+
+      [{_key, text, _level}] = :ets.tab2list(@buffer_table)
+      assert text =~ "[error]"
+      assert text =~ "reason"
+    end
+
+    test "formats erlang format string messages" do
+      refute Process.whereis(Minga.Editor)
+
+      event = %{level: :warning, msg: {~c"process ~p crashed", [self()]}, meta: %{}}
+      LoggerHandler.log(event, %{})
+
+      [{_key, text, _level}] = :ets.tab2list(@buffer_table)
+      assert text =~ "[warning] process"
+      assert text =~ "crashed"
+    end
+
+    test "preserves level for warning/error routing" do
+      refute Process.whereis(Minga.Editor)
+
+      LoggerHandler.log(%{level: :error, msg: {:string, "err"}, meta: %{}}, %{})
+      LoggerHandler.log(%{level: :warning, msg: {:string, "warn"}, meta: %{}}, %{})
+      LoggerHandler.log(%{level: :info, msg: {:string, "info"}, meta: %{}}, %{})
+
+      entries = :ets.tab2list(@buffer_table)
+      levels = Enum.map(entries, fn {_key, _text, level} -> level end)
+      assert :error in levels
+      assert :warning in levels
+      assert :info in levels
+    end
+  end
+end


### PR DESCRIPTION
## What

When the Editor GenServer crashes, all log messages (including the supervisor crash report) were silently dropped. The LoggerHandler checked `Process.whereis(Minga.Editor)`, got `nil` during the restart window, and threw the messages away. Users saw crash output in the terminal (macOS app) or nothing at all (TUI).

After this fix, crash reports and any other messages that arrive while the Editor is restarting are buffered in an ETS table and replayed into `*Messages*` when the Editor comes back up.

## How it works

The ETS table `:minga_log_buffer` is created in `Application.start/2`, which means it is owned by the Application supervisor process. This is the key detail: because the supervisor outlives the Editor, the table survives Editor crashes.

```
Editor crashes → LoggerHandler.log/2 sees nil → writes to ETS
  → Supervisor restarts Editor → Editor.init/1 calls flush_buffer/0
  → buffered messages replayed into *Messages* and *Warnings*
```

The buffer is capped at 50 entries (oldest trimmed first via `ordered_set` key ordering) to prevent unbounded growth if the Editor enters a crash loop.

## Changes

| File | What |
|------|------|
| `lib/minga/application.ex` | Creates `:minga_log_buffer` ETS table at startup |
| `lib/minga/logger_handler.ex` | Buffers messages when Editor is nil instead of dropping; `flush_buffer/0` replays and clears; `ensure_buffer_table/0` for idempotent creation |
| `lib/minga/editor.ex` | Calls `flush_buffer/0` after `*Messages*` is ready; logs "Replayed N message(s)" when entries were recovered |
| `test/minga/logger_handler_test.exs` | 12 new tests: buffering, ordering, trimming, flushing, formatting, level preservation |

## Testing

All 4112 tests pass. The 1 failure in `BufferPickerTest` is pre-existing (confirmed by running against `main` without changes).

`mix lint` and `mix dialyzer` clean.

Closes #423
