### PR TITLE
ci: add dedicated Screen Snapshots job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,34 @@ jobs:
       - run: mix deps.get
       - run: mix test --warnings-as-errors
 
+  snapshots:
+    name: Screen Snapshots
+    runs-on: ubuntu-latest
+    needs: [lint]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Cache deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: deps-${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
+          restore-keys: deps-${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
+
+      - run: mix deps.get
+      - run: mix test test/minga/integration/ --warnings-as-errors
+
   test-zig:
     name: Test (Zig)
     runs-on: ubuntu-latest


### PR DESCRIPTION
# TL;DR

Adds a separate CI job that runs the 126 integration snapshot tests on every PR, giving clear "Screen Snapshots failed" signals when a PR breaks the UI layout.

Closes #456
Part of #444

## Context

PR #457 shipped 126 integration tests with snapshot baselines, but they only ran as part of the general `Test (Elixir)` job. A snapshot failure was indistinguishable from a unit test failure in the PR checks UI. This adds a dedicated job so developers immediately know whether they broke the screen layout vs a unit test.

## Changes

- Added `snapshots` job to `.github/workflows/ci.yml` that runs `mix test test/minga/integration/ --warnings-as-errors`
- Job runs after `lint`, uses the same Elixir/OTP/Zig versions and dep cache as existing jobs
- The conformance job (for neovim compatibility, #98) will be added when that harness ships

## Verification

Check that CI runs and the Screen Snapshots job appears as a separate check in the PR status. It should pass (all 126 tests are green on main).

## Acceptance Criteria Addressed

- Snapshot CI job runs on every push and PR ✅
- Job fails if any snapshot does not match its baseline (never auto-updates in CI) ✅
- Job uses the same Elixir/OTP/Zig versions as the main CI jobs ✅
- Job caches deps and _build the same way ✅
- Job appears as a separate check in PR UI ✅
- Conformance job deferred to #98 (noted in ticket)
