### PR TITLE
chore(zig): add zig fmt + zig build test pre-commit checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,12 +146,20 @@ Elixir 1.19's set-theoretic type system catches real bugs at compile time. Help 
 
 ### Pre-commit Checks (mandatory, no exceptions)
 
-**STOP. Before every `git commit` that touches Elixir files, run these commands and confirm they pass. Do not skip this step. Do not commit with "I'll fix it later." If a check fails, fix the issue before committing.**
+**STOP. Before every `git commit`, run the relevant checks below and confirm they pass. Do not skip this step. Do not commit with "I'll fix it later." If a check fails, fix the issue before committing.**
+
+**Elixir changes:**
 
 ```bash
 mix lint                          # Formatting, credo --strict, compile --warnings-as-errors
 mix test --warnings-as-errors     # Tests
 mix dialyzer                      # Typespec consistency
+```
+
+**Zig changes:**
+
+```bash
+mix zig.lint                      # zig fmt --check + zig build test
 ```
 
 If any check fails, fix it before committing. No exceptions.
@@ -181,7 +189,8 @@ end
 - Doc comments (`///`) on all public functions
 - Explicit error handling — no `catch unreachable` outside tests
 - `std.log` for debug output (stderr), never stdout (that's the Port channel)
-- `zig build test` must pass
+- `zig fmt` for all formatting (no manual style debates)
+- `mix zig.lint` must pass (`zig fmt --check` + `zig build test`)
 
 ### Logging and the `*Messages*` Buffer
 

--- a/lib/mix/tasks/zig.lint.ex
+++ b/lib/mix/tasks/zig.lint.ex
@@ -1,0 +1,45 @@
+defmodule Mix.Tasks.Zig.Lint do
+  @moduledoc """
+  Runs Zig formatting and test checks.
+
+  Equivalent to:
+
+      zig fmt --check zig/src/
+      zig build test
+
+  Exits non-zero if formatting is off or tests fail.
+  """
+
+  use Mix.Task
+
+  @shortdoc "Check Zig formatting and run Zig tests"
+
+  @impl Mix.Task
+  @spec run(list()) :: :ok
+  def run(_args) do
+    zig_root = Path.join(Mix.Project.project_file() |> Path.dirname(), "zig")
+
+    unless File.dir?(zig_root) do
+      Mix.raise("Zig directory not found at #{zig_root}")
+    end
+
+    run_step("zig fmt --check", zig_root, ["fmt", "--check", "src/"])
+    run_step("zig build test", zig_root, ["build", "test"])
+
+    Mix.shell().info([:green, "Zig lint passed.", :reset])
+  end
+
+  @spec run_step(String.t(), String.t(), [String.t()]) :: :ok
+  defp run_step(label, cwd, args) do
+    Mix.shell().info([:cyan, "Running #{label}...", :reset])
+
+    case System.cmd("zig", args, cd: cwd, stderr_to_stdout: true) do
+      {_output, 0} ->
+        :ok
+
+      {output, code} ->
+        Mix.shell().error(output)
+        Mix.raise("#{label} failed (exit #{code})")
+    end
+  end
+end

--- a/zig/src/apprt/tui.zig
+++ b/zig/src/apprt/tui.zig
@@ -372,7 +372,6 @@ pub const TuiRuntime = struct {
                     }
                     offset += protocol.commandSize(remaining);
                 }
-
             }
 
             // stdin HUP / error
@@ -548,8 +547,6 @@ fn handleTtyEvent(self: *TuiRuntime, event: vaxis.Event, stdout: *std.Io.Writer)
             if (key.mods.ctrl) mods |= protocol.MOD_CTRL;
             if (key.mods.alt) mods |= protocol.MOD_ALT;
             if (key.mods.super) mods |= protocol.MOD_SUPER;
-
-
 
             var kbuf: [6]u8 = undefined;
             const klen = try protocol.encodeKeyPress(&kbuf, key.codepoint, mods);

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -1365,7 +1365,6 @@ extern fn tree_sitter_make() ?*const c.TSLanguage;
 extern fn tree_sitter_diff() ?*const c.TSLanguage;
 extern fn tree_sitter_elisp() ?*const c.TSLanguage;
 
-
 /// Helper to resolve a highlight query via the query_loader, which handles
 /// `; inherits:` directives at comptime. All parent queries are prepended
 /// automatically before the query reaches ts_query_new.

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -15,7 +15,6 @@ pub const apprt = @import("apprt.zig");
 // Note: highlighter.zig is compiled into minga-parser, not the renderer.
 // Font rendering (CoreText, atlas) lives in the macOS Swift app (macos/).
 
-
 // Vaxis is only needed for the TUI panic recovery path.
 const vaxis = if (build_options.backend == .tui) @import("vaxis") else struct {};
 
@@ -92,5 +91,4 @@ test {
     _ = renderer;
     _ = surface;
     _ = apprt;
-
 }

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -1520,9 +1520,16 @@ test "commandSize: draw_text with 5-byte text is 19 bytes" {
 test "commandSize: draw_text with 0-byte text is 14 bytes" {
     const data = [_]u8{
         OP_DRAW_TEXT,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
         0x00,
         0x00, 0x00, // text_len = 0
     };
@@ -1548,7 +1555,11 @@ test "batch decode: clear + set_cursor + batch_end parsed correctly" {
     // Concatenated batch: clear(1) + set_cursor(5) + batch_end(1) = 7 bytes
     const payload = [_]u8{
         OP_CLEAR,
-        OP_SET_CURSOR, 0x00, 0x05, 0x00, 0x0A,
+        OP_SET_CURSOR,
+        0x00,
+        0x05,
+        0x00,
+        0x0A,
         OP_BATCH_END,
     };
 
@@ -1688,8 +1699,14 @@ test "commandSize: set_language" {
 test "commandSize: parse_buffer" {
     const data = [_]u8{
         OP_PARSE_BUFFER,
-        0x00, 0x00, 0x00, 0x01,
-        0x00, 0x00, 0x00, 0x03,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x03,
     } ++ "abc".*;
     try std.testing.expectEqual(@as(usize, 12), commandSize(&data));
 }

--- a/zig/src/query_loader.zig
+++ b/zig/src/query_loader.zig
@@ -142,45 +142,248 @@ fn queryLookup(comptime name: []const u8, comptime qtype: QueryType) ?[]const u8
     };
 
     // Real languages (alphabetical)
-    if (comptime std.mem.eql(u8, name, "bash")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "bash/highlights.scm"), .folds => @embedFile(query_dir ++ "bash/folds.scm"), .indents => @embedFile(query_dir ++ "bash/indents.scm"), .textobjects => @embedFile(query_dir ++ "bash/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "c")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "c/highlights.scm"), .folds => @embedFile(query_dir ++ "c/folds.scm"), .indents => @embedFile(query_dir ++ "c/indents.scm"), .textobjects => @embedFile(query_dir ++ "c/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "c_sharp")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "c_sharp/highlights.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "cpp")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "cpp/highlights.scm"), .injections => @embedFile(query_dir ++ "cpp/injections.scm"), .folds => @embedFile(query_dir ++ "cpp/folds.scm"), .indents => @embedFile(query_dir ++ "cpp/indents.scm"), .textobjects => @embedFile(query_dir ++ "cpp/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "css")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "css/highlights.scm"), .folds => @embedFile(query_dir ++ "css/folds.scm"), .indents => @embedFile(query_dir ++ "css/indents.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "dart")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "dart/highlights.scm"), .folds => @embedFile(query_dir ++ "dart/folds.scm"), .indents => @embedFile(query_dir ++ "dart/indents.scm"), .textobjects => @embedFile(query_dir ++ "dart/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "diff")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "diff/highlights.scm"), .folds => @embedFile(query_dir ++ "diff/folds.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "dockerfile")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "dockerfile/highlights.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "elisp")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "elisp/highlights.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "elixir")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "elixir/highlights.scm"), .injections => @embedFile(query_dir ++ "elixir/injections.scm"), .folds => @embedFile(query_dir ++ "elixir/folds.scm"), .indents => @embedFile(query_dir ++ "elixir/indents.scm"), .textobjects => @embedFile(query_dir ++ "elixir/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "erlang")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "erlang/highlights.scm"), .folds => @embedFile(query_dir ++ "erlang/folds.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "gleam")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "gleam/highlights.scm"), .injections => @embedFile(query_dir ++ "gleam/injections.scm"), .locals => @embedFile(query_dir ++ "gleam/locals.scm"), .folds => @embedFile(query_dir ++ "gleam/folds.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "go")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "go/highlights.scm"), .folds => @embedFile(query_dir ++ "go/folds.scm"), .indents => @embedFile(query_dir ++ "go/indents.scm"), .textobjects => @embedFile(query_dir ++ "go/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "graphql")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "graphql/highlights.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "haskell")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "haskell/highlights.scm"), .folds => @embedFile(query_dir ++ "haskell/folds.scm"), .textobjects => @embedFile(query_dir ++ "haskell/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "hcl")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "hcl/highlights.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "html")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "html/highlights.scm"), .injections => @embedFile(query_dir ++ "html/injections.scm"), .folds => @embedFile(query_dir ++ "html/folds.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "java")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "java/highlights.scm"), .folds => @embedFile(query_dir ++ "java/folds.scm"), .indents => @embedFile(query_dir ++ "java/indents.scm"), .textobjects => @embedFile(query_dir ++ "java/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "javascript")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "javascript/highlights.scm"), .injections => @embedFile(query_dir ++ "javascript/injections.scm"), .locals => @embedFile(query_dir ++ "javascript/locals.scm"), .folds => @embedFile(query_dir ++ "javascript/folds.scm"), .indents => @embedFile(query_dir ++ "javascript/indents.scm"), .textobjects => @embedFile(query_dir ++ "javascript/textobjects.scm") };
-    if (comptime std.mem.eql(u8, name, "json")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "json/highlights.scm"), .folds => @embedFile(query_dir ++ "json/folds.scm"), .indents => @embedFile(query_dir ++ "json/indents.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "kotlin")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "kotlin/highlights.scm"), .folds => @embedFile(query_dir ++ "kotlin/folds.scm"), .indents => @embedFile(query_dir ++ "kotlin/indents.scm"), .textobjects => @embedFile(query_dir ++ "kotlin/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "lua")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "lua/highlights.scm"), .injections => @embedFile(query_dir ++ "lua/injections.scm"), .locals => @embedFile(query_dir ++ "lua/locals.scm"), .folds => @embedFile(query_dir ++ "lua/folds.scm"), .indents => @embedFile(query_dir ++ "lua/indents.scm"), .textobjects => @embedFile(query_dir ++ "lua/textobjects.scm") };
-    if (comptime std.mem.eql(u8, name, "make")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "make/highlights.scm"), .folds => @embedFile(query_dir ++ "make/folds.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "markdown")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "markdown/highlights.scm"), .injections => @embedFile(query_dir ++ "markdown/injections.scm"), .folds => @embedFile(query_dir ++ "markdown/folds.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "markdown_inline")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "markdown_inline/highlights.scm"), .injections => @embedFile(query_dir ++ "markdown_inline/injections.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "nix")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "nix/highlights.scm"), .folds => @embedFile(query_dir ++ "nix/folds.scm"), .indents => @embedFile(query_dir ++ "nix/indents.scm"), .textobjects => @embedFile(query_dir ++ "nix/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "ocaml")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "ocaml/highlights.scm"), .folds => @embedFile(query_dir ++ "ocaml/folds.scm"), .indents => @embedFile(query_dir ++ "ocaml/indents.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "php")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "php/highlights.scm"), .folds => @embedFile(query_dir ++ "php/folds.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "python")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "python/highlights.scm"), .folds => @embedFile(query_dir ++ "python/folds.scm"), .indents => @embedFile(query_dir ++ "python/indents.scm"), .textobjects => @embedFile(query_dir ++ "python/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "r")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "r/highlights.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "ruby")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "ruby/highlights.scm"), .locals => @embedFile(query_dir ++ "ruby/locals.scm"), .folds => @embedFile(query_dir ++ "ruby/folds.scm"), .indents => @embedFile(query_dir ++ "ruby/indents.scm"), .textobjects => @embedFile(query_dir ++ "ruby/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "rust")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "rust/highlights.scm"), .injections => @embedFile(query_dir ++ "rust/injections.scm"), .folds => @embedFile(query_dir ++ "rust/folds.scm"), .indents => @embedFile(query_dir ++ "rust/indents.scm"), .textobjects => @embedFile(query_dir ++ "rust/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "scala")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "scala/highlights.scm"), .folds => @embedFile(query_dir ++ "scala/folds.scm"), .indents => @embedFile(query_dir ++ "scala/indents.scm"), .textobjects => @embedFile(query_dir ++ "scala/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "scss")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "scss/highlights.scm"), .folds => @embedFile(query_dir ++ "scss/folds.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "toml")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "toml/highlights.scm"), .folds => @embedFile(query_dir ++ "toml/folds.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "tsx")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "tsx/highlights.scm"), .locals => @embedFile(query_dir ++ "tsx/locals.scm"), .folds => @embedFile(query_dir ++ "tsx/folds.scm"), .textobjects => @embedFile(query_dir ++ "tsx/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "typescript")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "typescript/highlights.scm"), .locals => @embedFile(query_dir ++ "typescript/locals.scm"), .folds => @embedFile(query_dir ++ "typescript/folds.scm"), .indents => @embedFile(query_dir ++ "typescript/indents.scm"), .textobjects => @embedFile(query_dir ++ "typescript/textobjects.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "yaml")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "yaml/highlights.scm"), .folds => @embedFile(query_dir ++ "yaml/folds.scm"), .indents => @embedFile(query_dir ++ "yaml/indents.scm"), else => null };
-    if (comptime std.mem.eql(u8, name, "zig")) return switch (qtype) { .highlights => @embedFile(query_dir ++ "zig/highlights.scm"), .injections => @embedFile(query_dir ++ "zig/injections.scm"), .folds => @embedFile(query_dir ++ "zig/folds.scm"), .indents => @embedFile(query_dir ++ "zig/indents.scm"), .textobjects => @embedFile(query_dir ++ "zig/textobjects.scm"), else => null };
+    if (comptime std.mem.eql(u8, name, "bash")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "bash/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "bash/folds.scm"),
+        .indents => @embedFile(query_dir ++ "bash/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "bash/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "c")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "c/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "c/folds.scm"),
+        .indents => @embedFile(query_dir ++ "c/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "c/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "c_sharp")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "c_sharp/highlights.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "cpp")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "cpp/highlights.scm"),
+        .injections => @embedFile(query_dir ++ "cpp/injections.scm"),
+        .folds => @embedFile(query_dir ++ "cpp/folds.scm"),
+        .indents => @embedFile(query_dir ++ "cpp/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "cpp/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "css")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "css/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "css/folds.scm"),
+        .indents => @embedFile(query_dir ++ "css/indents.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "dart")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "dart/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "dart/folds.scm"),
+        .indents => @embedFile(query_dir ++ "dart/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "dart/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "diff")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "diff/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "diff/folds.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "dockerfile")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "dockerfile/highlights.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "elisp")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "elisp/highlights.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "elixir")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "elixir/highlights.scm"),
+        .injections => @embedFile(query_dir ++ "elixir/injections.scm"),
+        .folds => @embedFile(query_dir ++ "elixir/folds.scm"),
+        .indents => @embedFile(query_dir ++ "elixir/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "elixir/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "erlang")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "erlang/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "erlang/folds.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "gleam")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "gleam/highlights.scm"),
+        .injections => @embedFile(query_dir ++ "gleam/injections.scm"),
+        .locals => @embedFile(query_dir ++ "gleam/locals.scm"),
+        .folds => @embedFile(query_dir ++ "gleam/folds.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "go")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "go/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "go/folds.scm"),
+        .indents => @embedFile(query_dir ++ "go/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "go/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "graphql")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "graphql/highlights.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "haskell")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "haskell/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "haskell/folds.scm"),
+        .textobjects => @embedFile(query_dir ++ "haskell/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "hcl")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "hcl/highlights.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "html")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "html/highlights.scm"),
+        .injections => @embedFile(query_dir ++ "html/injections.scm"),
+        .folds => @embedFile(query_dir ++ "html/folds.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "java")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "java/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "java/folds.scm"),
+        .indents => @embedFile(query_dir ++ "java/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "java/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "javascript")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "javascript/highlights.scm"),
+        .injections => @embedFile(query_dir ++ "javascript/injections.scm"),
+        .locals => @embedFile(query_dir ++ "javascript/locals.scm"),
+        .folds => @embedFile(query_dir ++ "javascript/folds.scm"),
+        .indents => @embedFile(query_dir ++ "javascript/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "javascript/textobjects.scm"),
+    };
+    if (comptime std.mem.eql(u8, name, "json")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "json/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "json/folds.scm"),
+        .indents => @embedFile(query_dir ++ "json/indents.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "kotlin")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "kotlin/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "kotlin/folds.scm"),
+        .indents => @embedFile(query_dir ++ "kotlin/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "kotlin/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "lua")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "lua/highlights.scm"),
+        .injections => @embedFile(query_dir ++ "lua/injections.scm"),
+        .locals => @embedFile(query_dir ++ "lua/locals.scm"),
+        .folds => @embedFile(query_dir ++ "lua/folds.scm"),
+        .indents => @embedFile(query_dir ++ "lua/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "lua/textobjects.scm"),
+    };
+    if (comptime std.mem.eql(u8, name, "make")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "make/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "make/folds.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "markdown")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "markdown/highlights.scm"),
+        .injections => @embedFile(query_dir ++ "markdown/injections.scm"),
+        .folds => @embedFile(query_dir ++ "markdown/folds.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "markdown_inline")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "markdown_inline/highlights.scm"),
+        .injections => @embedFile(query_dir ++ "markdown_inline/injections.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "nix")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "nix/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "nix/folds.scm"),
+        .indents => @embedFile(query_dir ++ "nix/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "nix/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "ocaml")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "ocaml/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "ocaml/folds.scm"),
+        .indents => @embedFile(query_dir ++ "ocaml/indents.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "php")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "php/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "php/folds.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "python")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "python/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "python/folds.scm"),
+        .indents => @embedFile(query_dir ++ "python/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "python/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "r")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "r/highlights.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "ruby")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "ruby/highlights.scm"),
+        .locals => @embedFile(query_dir ++ "ruby/locals.scm"),
+        .folds => @embedFile(query_dir ++ "ruby/folds.scm"),
+        .indents => @embedFile(query_dir ++ "ruby/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "ruby/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "rust")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "rust/highlights.scm"),
+        .injections => @embedFile(query_dir ++ "rust/injections.scm"),
+        .folds => @embedFile(query_dir ++ "rust/folds.scm"),
+        .indents => @embedFile(query_dir ++ "rust/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "rust/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "scala")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "scala/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "scala/folds.scm"),
+        .indents => @embedFile(query_dir ++ "scala/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "scala/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "scss")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "scss/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "scss/folds.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "toml")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "toml/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "toml/folds.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "tsx")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "tsx/highlights.scm"),
+        .locals => @embedFile(query_dir ++ "tsx/locals.scm"),
+        .folds => @embedFile(query_dir ++ "tsx/folds.scm"),
+        .textobjects => @embedFile(query_dir ++ "tsx/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "typescript")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "typescript/highlights.scm"),
+        .locals => @embedFile(query_dir ++ "typescript/locals.scm"),
+        .folds => @embedFile(query_dir ++ "typescript/folds.scm"),
+        .indents => @embedFile(query_dir ++ "typescript/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "typescript/textobjects.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "yaml")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "yaml/highlights.scm"),
+        .folds => @embedFile(query_dir ++ "yaml/folds.scm"),
+        .indents => @embedFile(query_dir ++ "yaml/indents.scm"),
+        else => null,
+    };
+    if (comptime std.mem.eql(u8, name, "zig")) return switch (qtype) {
+        .highlights => @embedFile(query_dir ++ "zig/highlights.scm"),
+        .injections => @embedFile(query_dir ++ "zig/injections.scm"),
+        .folds => @embedFile(query_dir ++ "zig/folds.scm"),
+        .indents => @embedFile(query_dir ++ "zig/indents.scm"),
+        .textobjects => @embedFile(query_dir ++ "zig/textobjects.scm"),
+        else => null,
+    };
 
     return null;
 }

--- a/zig/src/renderer.zig
+++ b/zig/src/renderer.zig
@@ -326,14 +326,16 @@ test "handleCommand draw_text respects surface width boundary" {
     var rend = Renderer(MockSurface).init(&mock, std.testing.allocator);
     defer rend.deinit();
 
-    try rend.handleCommand(.{ .draw_text = .{
-        .row = 0,
-        .col = 0,
-        .fg = 0,
-        .bg = 0,
-        .attrs = 0,
-        .text = "abcde", // 5 chars but width is 3
-    } });
+    try rend.handleCommand(.{
+        .draw_text = .{
+            .row = 0,
+            .col = 0,
+            .fg = 0,
+            .bg = 0,
+            .attrs = 0,
+            .text = "abcde", // 5 chars but width is 3
+        },
+    });
     try std.testing.expectEqual(@as(usize, 3), mock.cells_written);
 }
 

--- a/zig/src/surface.zig
+++ b/zig/src/surface.zig
@@ -15,7 +15,6 @@
 ///   fn render(*Self) Error!void
 ///   fn width(*Self) u16
 ///   fn height(*Self) u16
-
 const protocol = @import("protocol.zig");
 
 /// Cursor shape, matching the port protocol values.


### PR DESCRIPTION
## What

Adds `mix zig.lint` as a pre-commit check for Zig changes, matching the existing `mix lint` workflow for Elixir.

### New task: `mix zig.lint`
Runs two checks sequentially:
1. `zig fmt --check src/` (formatting)
2. `zig build test` (unit tests)

Exits non-zero on the first failure with the full output.

### Formatting fixes
7 Zig source files had formatting drift. This commit applies `zig fmt` to bring them in line: `tui.zig`, `renderer.zig`, `main.zig`, `surface.zig`, `protocol.zig`, `highlighter.zig`, `query_loader.zig`.

### AGENTS.md updates
- Pre-commit section now shows Elixir and Zig checks separately
- Zig coding standards reference `zig fmt` and `mix zig.lint`

## Testing
- `mix zig.lint` passes
- All 4,542 Elixir tests pass
- `mix credo --strict` clean