### PR TITLE
feat(editor): complete remaining #441 and #442 acceptance criteria

### DIFF
--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -409,6 +409,22 @@ defmodule Minga.Editor do
     {:noreply, new_state}
   end
 
+  def handle_info({tag, {:textobject_positions, _version, positions}}, state)
+      when tag in [:minga_highlight, :minga_input] do
+    new_state =
+      case EditorState.active_window_struct(state) do
+        nil ->
+          state
+
+        %Window{id: id} ->
+          EditorState.update_window(state, id, fn w ->
+            %{w | textobject_positions: positions}
+          end)
+      end
+
+    {:noreply, new_state}
+  end
+
   def handle_info({tag, {:grammar_loaded, true, name}}, state)
       when tag in [:minga_highlight, :minga_input] do
     Minga.Log.info(:editor, "Grammar loaded: #{name}")

--- a/lib/minga/editor/commands.ex
+++ b/lib/minga/editor/commands.ex
@@ -44,6 +44,7 @@ defmodule Minga.Editor.Commands do
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.FileTree, as: FileTreeState
   alias Minga.Editor.State.TabBar
+  alias Minga.Editor.Window
   alias Minga.FileTree
   alias Minga.FileTree.BufferSync
   alias Minga.Formatter
@@ -59,7 +60,7 @@ defmodule Minga.Editor.Commands do
   @type action ::
           {:dot_repeat, non_neg_integer() | nil}
           | {:replay_macro, String.t()}
-          | {:whichkey_update, Minga.Editor.State.WhichKey.t()}
+          | {:whichkey_update, EditorState.WhichKey.t()}
 
   @doc """
   Executes a single command against the editor state.
@@ -108,7 +109,7 @@ defmodule Minga.Editor.Commands do
     if state.whichkey.timer, do: WhichKey.cancel_timeout(state.whichkey.timer)
     timer = WhichKey.start_timeout()
 
-    whichkey = %Minga.Editor.State.WhichKey{node: node, timer: timer, show: false}
+    whichkey = %EditorState.WhichKey{node: node, timer: timer, show: false}
     {state, {:whichkey_update, whichkey}}
   end
 
@@ -121,7 +122,7 @@ defmodule Minga.Editor.Commands do
     # to the correct command for the current filetype.
     {effective_node, state} = maybe_substitute_filetype_trie(state, node)
 
-    whichkey = %Minga.Editor.State.WhichKey{
+    whichkey = %EditorState.WhichKey{
       node: effective_node,
       timer: timer,
       show: state.whichkey.show
@@ -133,7 +134,7 @@ defmodule Minga.Editor.Commands do
   def execute(state, :leader_cancel) do
     if state.whichkey.timer, do: WhichKey.cancel_timeout(state.whichkey.timer)
 
-    whichkey = %Minga.Editor.State.WhichKey{node: nil, timer: nil, show: false}
+    whichkey = %EditorState.WhichKey{node: nil, timer: nil, show: false}
     {state, {:whichkey_update, whichkey}}
   end
 
@@ -340,12 +341,18 @@ defmodule Minga.Editor.Commands do
   def execute(state, {:dedent_lines, _} = cmd), do: Editing.execute(state, cmd)
   def execute(state, {:indent_motion, _} = cmd), do: Editing.execute(state, cmd)
   def execute(state, {:dedent_motion, _} = cmd), do: Editing.execute(state, cmd)
+  def execute(state, {:reindent_lines, _} = cmd), do: Editing.execute(state, cmd)
+  def execute(state, {:reindent_motion, _} = cmd), do: Editing.execute(state, cmd)
+  def execute(state, {:reindent_text_object, _, _} = cmd), do: Editing.execute(state, cmd)
 
   def execute(state, :indent_visual_selection),
     do: Editing.execute(state, :indent_visual_selection)
 
   def execute(state, :dedent_visual_selection),
     do: Editing.execute(state, :dedent_visual_selection)
+
+  def execute(state, :reindent_visual_selection),
+    do: Editing.execute(state, :reindent_visual_selection)
 
   # ── Operators ─────────────────────────────────────────────────────────────
 
@@ -366,6 +373,7 @@ defmodule Minga.Editor.Commands do
 
   def execute(state, :yank_visual_selection), do: Visual.execute(state, :yank_visual_selection)
   def execute(state, {:wrap_visual_selection, _, _} = cmd), do: Visual.execute(state, cmd)
+  def execute(state, {:visual_text_object, _, _} = cmd), do: Visual.execute(state, cmd)
 
   # ── Search ────────────────────────────────────────────────────────────────
 
@@ -476,6 +484,50 @@ defmodule Minga.Editor.Commands do
   def execute(state, :diagnostics_list) do
     PickerUI.open(state, Minga.Diagnostics.PickerSource)
   end
+
+  # ── Textobject navigation ──────────────────────────────────────────────────
+
+  def execute(%{buffers: %{active: buf}} = state, {:goto_next_textobject, type})
+      when is_pid(buf) do
+    {row, col} = BufferServer.cursor(buf)
+
+    case EditorState.active_window_struct(state) do
+      nil ->
+        state
+
+      %Window{} = win ->
+        case Window.next_textobject(win, type, {row, col}) do
+          nil ->
+            state
+
+          {target_row, target_col} ->
+            BufferServer.move_to(buf, {target_row, target_col})
+            state
+        end
+    end
+  end
+
+  def execute(%{buffers: %{active: buf}} = state, {:goto_prev_textobject, type})
+      when is_pid(buf) do
+    {row, col} = BufferServer.cursor(buf)
+
+    case EditorState.active_window_struct(state) do
+      nil ->
+        state
+
+      %Window{} = win ->
+        case Window.prev_textobject(win, type, {row, col}) do
+          nil ->
+            state
+
+          {target_row, target_col} ->
+            BufferServer.move_to(buf, {target_row, target_col})
+            state
+        end
+    end
+  end
+
+  # ── Diagnostics ───────────────────────────────────────────────────────────
 
   def execute(state, :next_diagnostic) do
     Diagnostics.execute(state, :next_diagnostic)

--- a/lib/minga/editor/commands/editing.ex
+++ b/lib/minga/editor/commands/editing.ex
@@ -356,6 +356,61 @@ defmodule Minga.Editor.Commands.Editing do
     state
   end
 
+  # ── Reindent (= operator) ──────────────────────────────────────────────────
+
+  def execute(%{buffers: %{active: buf}} = state, {:reindent_lines, n}) do
+    {cursor_line, _} = BufferServer.cursor(buf)
+    total = BufferServer.line_count(buf)
+    end_line = min(cursor_line + n - 1, total - 1)
+    do_reindent_lines(buf, cursor_line, end_line)
+    state
+  end
+
+  def execute(%{buffers: %{active: buf}} = state, {:reindent_motion, motion}) do
+    gb = BufferServer.snapshot(buf)
+    cursor = Document.cursor(gb)
+    target = Helpers.resolve_motion(gb, cursor, motion)
+    {cursor_line, _} = cursor
+    {target_line, _} = target
+    start_line = min(cursor_line, target_line)
+    end_line = max(cursor_line, target_line)
+    do_reindent_lines(buf, start_line, end_line)
+    state
+  end
+
+  def execute(
+        %{vim: %{mode_state: %VisualState{} = ms}, buffers: %{active: buf}} = state,
+        :reindent_visual_selection
+      ) do
+    anchor = ms.visual_anchor
+    cursor = BufferServer.cursor(buf)
+    {anchor_line, _} = anchor
+    {cursor_line, _} = cursor
+    start_line = min(anchor_line, cursor_line)
+    end_line = max(anchor_line, cursor_line)
+    do_reindent_lines(buf, start_line, end_line)
+    state
+  end
+
+  def execute(
+        %{buffers: %{active: buf}} = state,
+        {:reindent_text_object, modifier, spec}
+      )
+      when is_pid(buf) do
+    gb = BufferServer.snapshot(buf)
+    cursor = Document.cursor(gb)
+    range = Helpers.compute_text_object_range(gb, cursor, modifier, spec)
+
+    case range do
+      nil ->
+        state
+
+      {{start_line, _}, {end_line, _}} ->
+        do_reindent_lines(buf, start_line, end_line)
+        state
+    end
+  end
+
   # ── Comment toggling ────────────────────────────────────────────────────────
 
   def execute(%{buffers: %{active: buf}} = state, :comment_line) when is_pid(buf) do
@@ -431,6 +486,65 @@ defmodule Minga.Editor.Commands.Editing do
     end
 
     :ok
+  end
+
+  # ── Private reindent helpers ──────────────────────────────────────────────
+
+  @spec do_reindent_lines(pid(), non_neg_integer(), non_neg_integer()) :: :ok
+  defp do_reindent_lines(buf, start_line, end_line) do
+    {cursor_line, _} = BufferServer.cursor(buf)
+
+    for line <- start_line..end_line do
+      reindent_single_line(buf, line)
+    end
+
+    # Move cursor to first non-blank on cursor line
+    case BufferServer.get_lines(buf, cursor_line, 1) do
+      [text] ->
+        first_non_blank = Indent.first_non_blank_col(text)
+        BufferServer.move_to(buf, {cursor_line, first_non_blank})
+
+      [] ->
+        BufferServer.move_to(buf, {cursor_line, 0})
+    end
+
+    :ok
+  end
+
+  @spec reindent_single_line(pid(), non_neg_integer()) :: :ok
+  defp reindent_single_line(buf, line) do
+    # Compute the desired indent for this line based on the previous line
+    desired_indent =
+      if line == 0 do
+        ""
+      else
+        Indent.compute_for_newline(buf, line - 1)
+      end
+
+    # Check if current line starts with a dedent trigger
+    desired_indent =
+      if Indent.should_dedent_line?(buf, line) do
+        Indent.remove_one_indent_level(desired_indent, buf)
+      else
+        desired_indent
+      end
+
+    # Get current line text and its existing indent
+    case BufferServer.get_lines(buf, line, 1) do
+      [text] ->
+        current_indent = Indent.extract_leading_ws(text)
+
+        if current_indent != desired_indent do
+          # Replace leading whitespace using apply_text_edit
+          indent_end_col = byte_size(current_indent)
+          BufferServer.apply_text_edit(buf, line, 0, line, indent_end_col, desired_indent)
+        end
+
+        :ok
+
+      [] ->
+        :ok
+    end
   end
 
   # ── Private indent helpers ────────────────────────────────────────────────

--- a/lib/minga/editor/commands/visual.ex
+++ b/lib/minga/editor/commands/visual.ex
@@ -4,6 +4,7 @@ defmodule Minga.Editor.Commands.Visual do
   visual selection.
   """
 
+  alias Minga.Buffer.Document
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.Commands.Helpers
   alias Minga.Editor.State, as: EditorState
@@ -82,5 +83,25 @@ defmodule Minga.Editor.Commands.Visual do
     BufferServer.insert_char(buf, open)
     BufferServer.move_to(buf, {start_line, start_col})
     state
+  end
+
+  def execute(
+        %{buffers: %{active: buf}, vim: %{mode_state: %VisualState{} = ms} = vim} = state,
+        {:visual_text_object, modifier, spec}
+      ) do
+    gb = BufferServer.snapshot(buf)
+    cursor = Document.cursor(gb)
+    range = Helpers.compute_text_object_range(gb, cursor, modifier, spec)
+
+    case range do
+      nil ->
+        state
+
+      {start_pos, end_pos} ->
+        # Update visual anchor to start of text object, move cursor to end
+        new_ms = %{ms | visual_anchor: start_pos}
+        BufferServer.move_to(buf, end_pos)
+        %{state | vim: %{vim | mode_state: new_ms}}
+    end
   end
 end

--- a/lib/minga/editor/indent.ex
+++ b/lib/minga/editor/indent.ex
@@ -61,21 +61,46 @@ defmodule Minga.Editor.Indent do
     end
   end
 
+  @doc "Extracts leading whitespace from a line of text."
+  @spec extract_leading_ws(String.t()) :: String.t()
+  def extract_leading_ws(text) do
+    case Regex.run(~r/^(\s*)/, text) do
+      [_, ws] -> ws
+      _ -> ""
+    end
+  end
+
+  @doc "Returns the byte offset of the first non-blank character in text."
+  @spec first_non_blank_col(String.t()) :: non_neg_integer()
+  def first_non_blank_col(text) do
+    byte_size(extract_leading_ws(text))
+  end
+
+  @doc """
+  Removes one level of indentation from the given whitespace string.
+
+  If the whitespace ends with a tab, removes one tab. Otherwise removes
+  `tab_size` spaces (or whatever is available).
+  """
+  @spec remove_one_indent_level(String.t(), pid()) :: String.t()
+  def remove_one_indent_level(indent, buf) do
+    tab_size = BufferServer.get_option(buf, :tab_size) || 2
+
+    if String.ends_with?(indent, "\t") do
+      String.slice(indent, 0, String.length(indent) - 1)
+    else
+      remove_len = min(tab_size, byte_size(indent))
+      binary_part(indent, 0, byte_size(indent) - remove_len)
+    end
+  end
+
   # ── Private ────────────────────────────────────────────────────────────────
 
   @spec leading_whitespace(pid(), non_neg_integer()) :: String.t()
   defp leading_whitespace(buf, line_num) do
     case get_line_text(buf, line_num) do
       nil -> ""
-      text -> extract_leading_whitespace(text)
-    end
-  end
-
-  @spec extract_leading_whitespace(String.t()) :: String.t()
-  defp extract_leading_whitespace(text) do
-    case Regex.run(~r/^(\s*)/, text) do
-      [_, ws] -> ws
-      _ -> ""
+      text -> extract_leading_ws(text)
     end
   end
 

--- a/lib/minga/editor/window.ex
+++ b/lib/minga/editor/window.ex
@@ -59,6 +59,7 @@ defmodule Minga.Editor.Window do
           cursor: Document.position(),
           fold_map: FoldMap.t(),
           fold_ranges: [FoldRange.t()],
+          textobject_positions: %{atom() => [{non_neg_integer(), non_neg_integer()}]},
           popup_meta: PopupActive.t() | nil,
           dirty_lines: :all | %{optional(non_neg_integer()) => true},
           cached_gutter: %{optional(non_neg_integer()) => [DisplayList.draw()]},
@@ -80,6 +81,7 @@ defmodule Minga.Editor.Window do
     cursor: {0, 0},
     fold_map: %FoldMap{folds: []},
     fold_ranges: [],
+    textobject_positions: %{},
     popup_meta: nil,
     dirty_lines: %{},
     cached_gutter: %{},
@@ -168,6 +170,25 @@ defmodule Minga.Editor.Window do
   @doc "Returns true if this window has any active folds."
   @spec has_folds?(t()) :: boolean()
   def has_folds?(%__MODULE__{fold_map: fm}), do: not FoldMap.empty?(fm)
+
+  @doc "Finds the next textobject position of the given type after (row, col)."
+  @spec next_textobject(t(), atom(), {non_neg_integer(), non_neg_integer()}) ::
+          {non_neg_integer(), non_neg_integer()} | nil
+  def next_textobject(%__MODULE__{textobject_positions: positions}, type, {row, col}) do
+    positions
+    |> Map.get(type, [])
+    |> Enum.find(fn {r, c} -> r > row or (r == row and c > col) end)
+  end
+
+  @doc "Finds the previous textobject position of the given type before (row, col)."
+  @spec prev_textobject(t(), atom(), {non_neg_integer(), non_neg_integer()}) ::
+          {non_neg_integer(), non_neg_integer()} | nil
+  def prev_textobject(%__MODULE__{textobject_positions: positions}, type, {row, col}) do
+    positions
+    |> Map.get(type, [])
+    |> Enum.reverse()
+    |> Enum.find(fn {r, c} -> r < row or (r == row and c < col) end)
+  end
 
   @doc "Toggles the fold at the given buffer line using the window's available fold ranges."
   @spec toggle_fold(t(), non_neg_integer()) :: t()

--- a/lib/minga/mode/normal.ex
+++ b/lib/minga/mode/normal.ex
@@ -315,7 +315,7 @@ defmodule Minga.Mode.Normal do
     {:transition, :insert, state}
   end
 
-  def handle_key({?a, 0}, state) do
+  def handle_key({?a, 0}, %ModeState{pending_bracket: nil} = state) do
     {:execute_then_transition, [:move_right], :insert, state}
   end
 
@@ -442,6 +442,36 @@ defmodule Minga.Mode.Normal do
   # [c — previous git hunk
   def handle_key({?c, 0}, %ModeState{pending_bracket: :prev} = state) do
     {:execute, :prev_git_hunk, %{state | pending_bracket: nil}}
+  end
+
+  # ]f — next function
+  def handle_key({?f, 0}, %ModeState{pending_bracket: :next} = state) do
+    {:execute, {:goto_next_textobject, :function}, %{state | pending_bracket: nil}}
+  end
+
+  # [f — previous function
+  def handle_key({?f, 0}, %ModeState{pending_bracket: :prev} = state) do
+    {:execute, {:goto_prev_textobject, :function}, %{state | pending_bracket: nil}}
+  end
+
+  # ]t — next type/class
+  def handle_key({?t, 0}, %ModeState{pending_bracket: :next} = state) do
+    {:execute, {:goto_next_textobject, :class}, %{state | pending_bracket: nil}}
+  end
+
+  # [t — previous type/class
+  def handle_key({?t, 0}, %ModeState{pending_bracket: :prev} = state) do
+    {:execute, {:goto_prev_textobject, :class}, %{state | pending_bracket: nil}}
+  end
+
+  # ]a — next argument/parameter
+  def handle_key({?a, 0}, %ModeState{pending_bracket: :next} = state) do
+    {:execute, {:goto_next_textobject, :parameter}, %{state | pending_bracket: nil}}
+  end
+
+  # [a — previous argument/parameter
+  def handle_key({?a, 0}, %ModeState{pending_bracket: :prev} = state) do
+    {:execute, {:goto_prev_textobject, :parameter}, %{state | pending_bracket: nil}}
   end
 
   # Cancel bracket prefix on any unrecognized key
@@ -744,6 +774,12 @@ defmodule Minga.Mode.Normal do
   def handle_key({?<, 0}, %ModeState{count: count} = _state) do
     {:transition, :operator_pending,
      %Minga.Mode.OperatorPendingState{operator: :dedent, op_count: count || 1}}
+  end
+
+  # = — enter operator-pending for reindent
+  def handle_key({?=, 0}, %ModeState{count: count} = _state) do
+    {:transition, :operator_pending,
+     %Minga.Mode.OperatorPendingState{operator: :reindent, op_count: count || 1}}
   end
 
   # + — next line first non-blank

--- a/lib/minga/mode/operator_pending.ex
+++ b/lib/minga/mode/operator_pending.ex
@@ -284,6 +284,12 @@ defmodule Minga.Mode.OperatorPending do
      OPState.to_base_state(state)}
   end
 
+  # == — reindent current line(s)
+  def handle_key({?=, 0}, %OPState{operator: :reindent} = state) do
+    {:execute_then_transition, [{:reindent_lines, OPState.total_count(state)}], :normal,
+     OPState.to_base_state(state)}
+  end
+
   # ── Page / half-page motions ───────────────────────────────────────────────
 
   def handle_key({?d, mods}, %OPState{} = state) when band(mods, @ctrl) != 0 do
@@ -333,6 +339,7 @@ defmodule Minga.Mode.OperatorPending do
   defp text_object_command(:comment, modifier, spec), do: {:comment_text_object, modifier, spec}
   defp text_object_command(:indent, modifier, spec), do: {:indent_text_object, modifier, spec}
   defp text_object_command(:dedent, modifier, spec), do: {:dedent_text_object, modifier, spec}
+  defp text_object_command(:reindent, modifier, spec), do: {:reindent_text_object, modifier, spec}
 
   # Build and emit the motion command, with correct repetition.
   @spec execute_with_motion(OPState.t(), atom()) :: Mode.result()
@@ -354,4 +361,5 @@ defmodule Minga.Mode.OperatorPending do
   defp motion_command(:comment, motion), do: {:comment_motion, motion}
   defp motion_command(:indent, motion), do: {:indent_motion, motion}
   defp motion_command(:dedent, motion), do: {:dedent_motion, motion}
+  defp motion_command(:reindent, motion), do: {:reindent_motion, motion}
 end

--- a/lib/minga/mode/operator_pending_state.ex
+++ b/lib/minga/mode/operator_pending_state.ex
@@ -16,7 +16,7 @@ defmodule Minga.Mode.OperatorPendingState do
             leader_keys: []
 
   @typedoc "The pending operator."
-  @type operator :: :comment | :delete | :change | :yank | :indent | :dedent
+  @type operator :: :comment | :delete | :change | :yank | :indent | :dedent | :reindent
 
   @typedoc "Text object modifier (inner vs around)."
   @type text_object_modifier :: :inner | :around

--- a/lib/minga/mode/visual.ex
+++ b/lib/minga/mode/visual.ex
@@ -95,11 +95,11 @@ defmodule Minga.Mode.Visual do
     {:execute, :move_right, state}
   end
 
-  def handle_key({?w, 0}, state) do
+  def handle_key({?w, 0}, %VisualState{text_object_modifier: nil} = state) do
     {:execute, :word_forward, state}
   end
 
-  def handle_key({?b, 0}, state) do
+  def handle_key({?b, 0}, %VisualState{text_object_modifier: nil} = state) do
     {:execute, :word_backward, state}
   end
 
@@ -218,28 +218,104 @@ defmodule Minga.Mode.Visual do
 
   # ── Wrapping (auto-pair) ──────────────────────────────────────────────────────
 
-  # Typing an opening delimiter wraps the visual selection.
-  def handle_key({?(, 0}, state) do
+  # Typing an opening delimiter wraps the visual selection (only when no text
+  # object modifier is pending, to avoid conflicts with vi"/va(/etc.).
+  def handle_key({?(, 0}, %VisualState{text_object_modifier: nil} = state) do
     {:execute_then_transition, [{:wrap_visual_selection, "(", ")"}], :normal, state}
   end
 
-  def handle_key({?[, 0}, state) do
+  def handle_key({?[, 0}, %VisualState{text_object_modifier: nil} = state) do
     {:execute_then_transition, [{:wrap_visual_selection, "[", "]"}], :normal, state}
   end
 
   # Note: { and } are paragraph motions in Visual mode, so { wrapping is not
   # available here. Use operator-pending text objects instead (e.g. vi{).
 
-  def handle_key({?", 0}, state) do
+  def handle_key({?", 0}, %VisualState{text_object_modifier: nil} = state) do
     {:execute_then_transition, [{:wrap_visual_selection, "\"", "\""}], :normal, state}
   end
 
-  def handle_key({?', 0}, state) do
+  def handle_key({?', 0}, %VisualState{text_object_modifier: nil} = state) do
     {:execute_then_transition, [{:wrap_visual_selection, "'", "'"}], :normal, state}
   end
 
-  def handle_key({?`, 0}, state) do
+  def handle_key({?`, 0}, %VisualState{text_object_modifier: nil} = state) do
     {:execute_then_transition, [{:wrap_visual_selection, "`", "`"}], :normal, state}
+  end
+
+  # ── Text object selection ──────────────────────────────────────────────────────
+
+  # `i` enters "inner" text object mode.
+  def handle_key({?i, 0}, %VisualState{text_object_modifier: nil} = state) do
+    {:continue, %{state | text_object_modifier: :inner}}
+  end
+
+  # `a` enters "around" text object mode (only when no modifier set).
+  def handle_key({?a, 0}, %VisualState{text_object_modifier: nil} = state) do
+    {:continue, %{state | text_object_modifier: :around}}
+  end
+
+  # Word text object
+  def handle_key({?w, 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] do
+    {:execute, [{:visual_text_object, modifier, :word}], %{state | text_object_modifier: nil}}
+  end
+
+  # Quote text objects
+  def handle_key({?", 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] do
+    {:execute, [{:visual_text_object, modifier, {:quote, "\""}}],
+     %{state | text_object_modifier: nil}}
+  end
+
+  def handle_key({?', 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] do
+    {:execute, [{:visual_text_object, modifier, {:quote, "'"}}],
+     %{state | text_object_modifier: nil}}
+  end
+
+  # Paren text objects
+  def handle_key({paren, 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] and paren in [?(, ?)] do
+    {:execute, [{:visual_text_object, modifier, {:paren, "(", ")"}}],
+     %{state | text_object_modifier: nil}}
+  end
+
+  def handle_key({bracket, 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] and bracket in [?[, ?]] do
+    {:execute, [{:visual_text_object, modifier, {:paren, "[", "]"}}],
+     %{state | text_object_modifier: nil}}
+  end
+
+  def handle_key({brace, 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] and brace in [?{, ?}] do
+    {:execute, [{:visual_text_object, modifier, {:paren, "{", "}"}}],
+     %{state | text_object_modifier: nil}}
+  end
+
+  # Structural text objects (tree-sitter)
+  def handle_key({?f, 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] do
+    {:execute, [{:visual_text_object, modifier, {:structural, :function}}],
+     %{state | text_object_modifier: nil}}
+  end
+
+  def handle_key({?c, 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] do
+    {:execute, [{:visual_text_object, modifier, {:structural, :class}}],
+     %{state | text_object_modifier: nil}}
+  end
+
+  def handle_key({?a, 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] do
+    {:execute, [{:visual_text_object, modifier, {:structural, :parameter}}],
+     %{state | text_object_modifier: nil}}
+  end
+
+  def handle_key({?b, 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] do
+    {:execute, [{:visual_text_object, modifier, {:structural, :block}}],
+     %{state | text_object_modifier: nil}}
   end
 
   # ── Operators ────────────────────────────────────────────────────────────────
@@ -253,6 +329,11 @@ defmodule Minga.Mode.Visual do
   # < — dedent visual selection, return to Normal
   def handle_key({?<, 0}, state) do
     {:execute_then_transition, [:dedent_visual_selection], :normal, state}
+  end
+
+  # = — reindent visual selection, return to Normal
+  def handle_key({?=, 0}, state) do
+    {:execute_then_transition, [:reindent_visual_selection], :normal, state}
   end
 
   # d — delete selection, return to Normal

--- a/lib/minga/mode/visual_state.ex
+++ b/lib/minga/mode/visual_state.ex
@@ -11,16 +11,21 @@ defmodule Minga.Mode.VisualState do
             visual_anchor: {0, 0},
             count: nil,
             leader_node: nil,
-            leader_keys: []
+            leader_keys: [],
+            text_object_modifier: nil
 
   @typedoc "Selection type: characterwise or linewise."
   @type selection_type :: :char | :line
+
+  @typedoc "Text object modifier (inner vs around) for visual text object selection."
+  @type text_object_modifier :: :inner | :around | nil
 
   @type t :: %__MODULE__{
           visual_type: selection_type(),
           visual_anchor: {non_neg_integer(), non_neg_integer()},
           count: non_neg_integer() | nil,
           leader_node: Minga.Keymap.Bindings.node_t() | nil,
-          leader_keys: [String.t()]
+          leader_keys: [String.t()],
+          text_object_modifier: text_object_modifier()
         }
 end

--- a/lib/minga/port/protocol.ex
+++ b/lib/minga/port/protocol.ex
@@ -73,6 +73,14 @@ defmodule Minga.Port.Protocol do
   @op_set_textobject_query 0x2B
   @op_request_textobject 0x2C
 
+  # Well-known textobject type IDs (match Zig constants)
+  @textobj_function 0
+  @textobj_class 1
+  @textobj_parameter 2
+  @textobj_block 3
+  @textobj_comment 4
+  @textobj_test 5
+
   # Highlight responses (Zig → BEAM)
   @op_highlight_spans 0x30
   @op_highlight_names 0x31
@@ -83,6 +91,7 @@ defmodule Minga.Port.Protocol do
   @op_fold_ranges 0x36
   @op_indent_result 0x37
   @op_textobject_result 0x38
+  @op_textobject_positions 0x39
 
   # Config commands (BEAM → frontend)
   @op_set_font 0x50
@@ -165,6 +174,8 @@ defmodule Minga.Port.Protocol do
              result ::
                {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
                | nil}
+          | {:textobject_positions, version :: non_neg_integer(),
+             %{atom() => [{non_neg_integer(), non_neg_integer()}]}}
           | {:log_message, level :: String.t(), text :: String.t()}
 
   @typedoc "Cursor shape."
@@ -600,6 +611,11 @@ defmodule Minga.Port.Protocol do
     {:ok, {:textobject_result, request_id, nil}}
   end
 
+  def decode_event(<<@op_textobject_positions, version::32, count::32, entries::binary>>) do
+    positions = decode_textobject_entries(entries, count, %{})
+    {:ok, {:textobject_positions, version, positions}}
+  end
+
   def decode_event(<<@op_log_message, level_byte::8, msg_len::16, msg::binary-size(msg_len)>>) do
     level = decode_log_level(level_byte)
     {:ok, {:log_message, level, msg}}
@@ -686,6 +702,31 @@ defmodule Minga.Port.Protocol do
   def decode_command(<<>>) do
     {:error, :malformed}
   end
+
+  @spec decode_textobject_entries(binary(), non_neg_integer(), map()) :: map()
+  defp decode_textobject_entries(_data, 0, acc), do: acc
+
+  defp decode_textobject_entries(
+         <<type_id::8, row::32, col::32, rest::binary>>,
+         remaining,
+         acc
+       ) do
+    type_atom = textobj_type_to_atom(type_id)
+    existing = Map.get(acc, type_atom, [])
+    updated = Map.put(acc, type_atom, existing ++ [{row, col}])
+    decode_textobject_entries(rest, remaining - 1, updated)
+  end
+
+  defp decode_textobject_entries(_, _, acc), do: acc
+
+  @spec textobj_type_to_atom(non_neg_integer()) :: atom()
+  defp textobj_type_to_atom(@textobj_function), do: :function
+  defp textobj_type_to_atom(@textobj_class), do: :class
+  defp textobj_type_to_atom(@textobj_parameter), do: :parameter
+  defp textobj_type_to_atom(@textobj_block), do: :block
+  defp textobj_type_to_atom(@textobj_comment), do: :comment
+  defp textobj_type_to_atom(@textobj_test), do: :test
+  defp textobj_type_to_atom(_), do: :unknown
 
   # ── Private ──
 

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -697,6 +697,95 @@ pub const Highlighter = struct {
         return best;
     }
 
+    /// Alias for the shared TextobjectEntry type (defined in protocol to avoid circular imports).
+    pub const TextobjectEntry = protocol.TextobjectEntry;
+
+    /// Well-known textobject type IDs (match order in around_types below).
+    pub const TEXTOBJ_FUNCTION: u8 = 0;
+    pub const TEXTOBJ_CLASS: u8 = 1;
+    pub const TEXTOBJ_PARAMETER: u8 = 2;
+    pub const TEXTOBJ_BLOCK: u8 = 3;
+    pub const TEXTOBJ_COMMENT: u8 = 4;
+    pub const TEXTOBJ_TEST: u8 = 5;
+    pub const TEXTOBJ_TYPE_COUNT: u8 = 6;
+
+    const around_types = [_][]const u8{
+        "function.around",
+        "class.around",
+        "parameter.around",
+        "block.around",
+        "comment.around",
+        "test.around",
+    };
+
+    /// Collect all `.around` textobject positions from the current tree.
+    ///
+    /// Returns a flat array of entries sorted by (row, col). Each entry has a
+    /// type_id matching the constants above. Only `.around` captures are
+    /// collected since navigation (`]f`/`[f`) targets the start of the outer
+    /// structure.
+    ///
+    /// Caller owns the returned slice and must free it with `allocator`.
+    pub fn collectTextobjectPositions(self: *Highlighter, allocator: std.mem.Allocator) []TextobjectEntry {
+        const tq = self.textobject_query orelse return &.{};
+        const tree = self.tree orelse return &.{};
+        const root = c.ts_tree_root_node(tree);
+
+        // Map capture index → type_id for .around captures.
+        const cap_count = c.ts_query_capture_count(tq);
+        var cap_to_type: [64]?u8 = .{null} ** 64;
+        var has_any = false;
+
+        for (0..@min(cap_count, 64)) |i| {
+            var name_len: u32 = 0;
+            const name_ptr = c.ts_query_capture_name_for_id(tq, @intCast(i), &name_len);
+            if (name_ptr == null) continue;
+            const cap_name = name_ptr[0..name_len];
+
+            for (around_types, 0..) |atype, tidx| {
+                if (std.mem.eql(u8, cap_name, atype)) {
+                    cap_to_type[i] = @intCast(tidx);
+                    has_any = true;
+                    break;
+                }
+            }
+        }
+
+        if (!has_any) return &.{};
+
+        const cursor = c.ts_query_cursor_new() orelse return &.{};
+        defer c.ts_query_cursor_delete(cursor);
+        c.ts_query_cursor_exec(cursor, tq, root);
+
+        var entries = std.ArrayListUnmanaged(TextobjectEntry){};
+
+        var match: c.TSQueryMatch = undefined;
+        while (c.ts_query_cursor_next_match(cursor, &match)) {
+            const captures = match.captures[0..@intCast(match.capture_count)];
+            for (captures) |cap| {
+                if (cap.index >= 64) continue;
+                const type_id = cap_to_type[cap.index] orelse continue;
+                const start = c.ts_node_start_point(cap.node);
+                entries.append(allocator, .{
+                    .type_id = type_id,
+                    .row = start.row,
+                    .col = start.column,
+                }) catch continue;
+            }
+        }
+
+        // Sort by (row, col) for binary search on the BEAM side.
+        const items = entries.items;
+        std.mem.sortUnstable(TextobjectEntry, items, {}, struct {
+            fn lessThan(_: void, a: TextobjectEntry, b: TextobjectEntry) bool {
+                if (a.row != b.row) return a.row < b.row;
+                return a.col < b.col;
+            }
+        }.lessThan);
+
+        return entries.toOwnedSlice(allocator) catch &.{};
+    }
+
     /// Find the byte offset where a given line starts in the source.
     fn lineStartByte(source: []const u8, target_line: u32) usize {
         var line: u32 = 0;

--- a/zig/src/parser_main.zig
+++ b/zig/src/parser_main.zig
@@ -128,6 +128,9 @@ fn handleCommand(
             if (hl.fold_query != null) {
                 try sendFoldResults(hl, pb.version, stdout, alloc);
             }
+            if (hl.textobject_query != null) {
+                try sendTextobjectPositions(hl, pb.version, stdout, alloc);
+            }
         },
         .edit_buffer => {
             // Handled at dispatch level via handleEditBuffer().
@@ -213,6 +216,25 @@ fn handleEditBuffer(
     if (hl.fold_query != null) {
         try sendFoldResults(hl, decoded.version, stdout, alloc);
     }
+    if (hl.textobject_query != null) {
+        try sendTextobjectPositions(hl, decoded.version, stdout, alloc);
+    }
+}
+
+/// Send textobject positions to stdout.
+fn sendTextobjectPositions(
+    hl: *highlighter_mod.Highlighter,
+    version: u32,
+    stdout: *std.Io.Writer,
+    alloc: std.mem.Allocator,
+) !void {
+    const entries = hl.collectTextobjectPositions(alloc);
+    defer if (entries.len > 0) alloc.free(entries);
+
+    const buf = try protocol.encodeTextobjectPositions(alloc, version, entries);
+    defer alloc.free(buf);
+    try protocol.writeMessage(stdout, buf);
+    try stdout.flush();
 }
 
 /// Send fold range results to stdout.

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -79,6 +79,7 @@ pub const OP_INDENT_RESULT: u8 = 0x37;
 
 // Textobject responses (Zig → BEAM)
 pub const OP_TEXTOBJECT_RESULT: u8 = 0x38;
+pub const OP_TEXTOBJECT_POSITIONS: u8 = 0x39;
 
 // Log messages (Zig → BEAM)
 pub const OP_LOG_MESSAGE: u8 = 0x60;
@@ -934,6 +935,35 @@ pub fn encodeTextobjectResult(buf: *[22]u8, request_id: u32, result: ?Textobject
         buf[5] = 0; // not found
         return 6;
     }
+}
+
+/// A single textobject position for the proactive position cache.
+pub const TextobjectEntry = struct {
+    type_id: u8,
+    row: u32,
+    col: u32,
+};
+
+/// Encodes textobject_positions: opcode(1) + version(4) + count(4) + [type_id(1) + row(4) + col(4)] * count
+pub fn encodeTextobjectPositions(allocator: std.mem.Allocator, version: u32, entries: []const TextobjectEntry) ![]u8 {
+    const entry_size: usize = 9; // type_id(1) + row(4) + col(4)
+    const header_size: usize = 9; // opcode(1) + version(4) + count(4)
+    const total_size = header_size + entries.len * entry_size;
+
+    const buf = try allocator.alloc(u8, total_size);
+    buf[0] = OP_TEXTOBJECT_POSITIONS;
+    std.mem.writeInt(u32, buf[1..5], version, .big);
+    std.mem.writeInt(u32, buf[5..9], @intCast(entries.len), .big);
+
+    var pos: usize = header_size;
+    for (entries) |e| {
+        buf[pos] = e.type_id;
+        std.mem.writeInt(u32, buf[pos + 1 ..][0..4], e.row, .big);
+        std.mem.writeInt(u32, buf[pos + 5 ..][0..4], e.col, .big);
+        pos += entry_size;
+    }
+
+    return buf;
 }
 
 /// Encodes indent_result: opcode(1) + request_id(4) + line(4) + indent_level(4, signed)


### PR DESCRIPTION
# TL;DR

Completes the missing acceptance criteria from #441 (= operator, ==, visual =) and #442 (visual mode text objects, ]f/[f goto-next/prev with proactive cache).

Closes #441, closes #442

## What was missing

**#441 (indentation):**
- `==` re-indent current line
- `=<motion>` re-indent range (e.g., `=ap` for paragraph)
- Visual `=` re-indent selection
- All three were listed in the acceptance criteria but shipped as "follow-up" in PR #459

**#442 (text objects):**
- Visual mode text objects (`vif`, `vaf`, `vic`, `viw`, etc.)
- `]f`/`[f` goto-next/prev function, `]t`/`[t` class, `]a`/`[a` parameter
- Both listed in acceptance criteria, shipped as "follow-up" in PR #460

## Changes

### = operator (reindent)

- `==` reindents current line using `Indent.compute_for_newline` + dedent detection
- `=<motion>` reindents a range: `=ap` (paragraph), `=gg` (to start), `=G` (to end)
- Visual `=` reindents the selection
- `=if` / `=af` reindents function body/around (combines with tree-sitter text objects)
- `Indent` module gets `extract_leading_ws/1`, `first_non_blank_col/1`, `remove_one_indent_level/2`
- `reindent_single_line` replaces leading whitespace via `apply_text_edit` (no line replacement needed)

### Visual mode text objects

- `i`/`a` in visual mode set `text_object_modifier` on `VisualState`
- All regex text objects: `viw`/`vaw`, `vi"`/`va"`, `vi(`/`va(`, `vi{`/`va{`, etc.
- All structural text objects: `vif`/`vaf`, `vic`/`vac`, `via`/`vaa`, `vib`/`vab`
- Selection expands to text object range (anchor = start, cursor = end)
- Wrap handlers (`"`, `'`, `(`, `[`) guard on `text_object_modifier: nil` so `vi"` selects inside quotes instead of wrapping

### Goto next/prev text object (proactive cache)

After each parse, Zig collects all `.around` textobject positions in one pass and sends `TEXTOBJECT_POSITIONS` (0x39) to BEAM. The BEAM caches them on the Window struct as `%{type => [{row, col}]}`. Navigation does a list scan on the cached data with zero per-keystroke IPC.

Wire format: `version(4) + count(4) + [type_id(1) + row(4) + col(4)] * count`
Type IDs: 0=function, 1=class, 2=parameter, 3=block, 4=comment, 5=test

Keybindings: `]f`/`[f` (function), `]t`/`[t` (class), `]a`/`[a` (parameter)

## Verification

- 4527 tests pass (0 failures, 1 excluded)
- `mix lint` clean (credo --strict passes)
- `zig build && zig build test` pass
