### PR TITLE
fix(editor): blank content when opening file from agent tab

### DIFF
--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -326,7 +326,17 @@ defmodule Minga.Editor.State do
         # different content, and cached draws from the old buffer are
         # completely wrong. Also reset tracking fields so
         # detect_invalidation forces a full redraw on the next frame.
-        window = %{Window.invalidate(window) | buffer: buffers.active}
+        #
+        # Both `buffer` and `content` must be updated. The render
+        # pipeline checks `Content.agent_chat?(window.content)` to
+        # decide rendering paths, so a stale content tag causes the
+        # window to be routed to the wrong renderer (e.g., blank
+        # screen when opening a file from the agent tab).
+        window = %{
+          Window.invalidate(window)
+          | buffer: buffers.active,
+            content: Content.buffer(buffers.active)
+        }
 
         %{state | windows: %{ws | map: Map.put(windows, id, window)}}
 

--- a/test/minga/editor/state_test.exs
+++ b/test/minga/editor/state_test.exs
@@ -4,10 +4,13 @@ defmodule Minga.Editor.StateTest do
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Buffers
+  alias Minga.Editor.State.Tab
+  alias Minga.Editor.State.TabBar
   alias Minga.Editor.State.Windows
   alias Minga.Editor.Viewport
   alias Minga.Editor.VimState
   alias Minga.Editor.Window
+  alias Minga.Editor.Window.Content
   alias Minga.Editor.WindowTree
 
   # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -234,6 +237,149 @@ defmodule Minga.Editor.StateTest do
     test "excludes one row for minibuffer" do
       {state, _} = state_with_buffer()
       assert EditorState.screen_rect(state) == {0, 0, 80, 23}
+    end
+  end
+
+  # ── sync_active_window_buffer/1 — window.content field ───────────────────────
+
+  describe "sync_active_window_buffer/1 content field" do
+    test "updates window.content to {:buffer, new_pid} when buffer changes" do
+      {state, _buf1} = state_with_buffer("hello")
+      buf2 = start_buffer("world")
+
+      state = %{state | buffers: Buffers.add(state.buffers, buf2)}
+      new_state = EditorState.sync_active_window_buffer(state)
+
+      window = Map.fetch!(new_state.windows.map, new_state.windows.active)
+      assert window.buffer == buf2
+      assert Content.buffer?(window.content), "content should be a :buffer reference"
+
+      assert Content.buffer_pid(window.content) == buf2,
+             "content should reference the new buffer pid, " <>
+               "got #{inspect(window.content)}"
+    end
+
+    test "updates content from agent_chat to buffer when buffer changes" do
+      agent_buf = start_buffer("")
+      file_buf = start_buffer("defmodule Foo, do: :ok")
+
+      # Build state with an agent_chat window
+      state =
+        %{new_state() | buffers: %Buffers{list: [agent_buf], active_index: 0, active: agent_buf}}
+
+      tree = WindowTree.new(1)
+      agent_window = Window.new_agent_chat(1, agent_buf, 24, 80)
+
+      state = %{
+        state
+        | windows: %Windows{tree: tree, map: %{1 => agent_window}, active: 1, next_id: 2}
+      }
+
+      # Confirm starting state: agent_chat content
+      window = Map.fetch!(state.windows.map, 1)
+      assert Content.agent_chat?(window.content)
+
+      # Switch active buffer to the file buffer
+      state = %{state | buffers: Buffers.add(state.buffers, file_buf)}
+      new_state = EditorState.sync_active_window_buffer(state)
+
+      window = Map.fetch!(new_state.windows.map, 1)
+      assert window.buffer == file_buf
+
+      assert window.content == Content.buffer(file_buf),
+             "content should switch from agent_chat to buffer, got #{inspect(window.content)}"
+    end
+
+    test "no-op when buffer has not changed" do
+      {state, buf1} = state_with_buffer("hello")
+      window_before = Map.fetch!(state.windows.map, state.windows.active)
+
+      new_state = EditorState.sync_active_window_buffer(state)
+
+      window_after = Map.fetch!(new_state.windows.map, new_state.windows.active)
+      assert window_after.buffer == buf1
+      assert window_after.content == window_before.content
+    end
+  end
+
+  # ── add_buffer/2 from agent tab ──────────────────────────────────────────────
+
+  describe "add_buffer/2 from agent tab" do
+    setup do
+      agent_buf = start_buffer("")
+
+      state =
+        %{new_state() | buffers: %Buffers{list: [agent_buf], active_index: 0, active: agent_buf}}
+
+      tree = WindowTree.new(1)
+      agent_window = Window.new_agent_chat(1, agent_buf, 24, 80)
+
+      state = %{
+        state
+        | windows: %Windows{tree: tree, map: %{1 => agent_window}, active: 1, next_id: 2},
+          tab_bar: TabBar.new(Tab.new_agent(1, "Agent")),
+          keymap_scope: :agent
+      }
+
+      %{state: state, agent_buf: agent_buf}
+    end
+
+    test "creates a file tab and makes it active", %{state: state} do
+      file_buf = start_buffer("file content")
+      new_state = EditorState.add_buffer(state, file_buf)
+
+      active_tab = TabBar.active(new_state.tab_bar)
+      assert active_tab.kind == :file
+    end
+
+    test "switches keymap_scope from :agent to :editor", %{state: state} do
+      file_buf = start_buffer("file content")
+      new_state = EditorState.add_buffer(state, file_buf)
+
+      assert new_state.keymap_scope == :editor
+    end
+
+    test "active window buffer points to the new file buffer", %{state: state} do
+      file_buf = start_buffer("file content")
+      new_state = EditorState.add_buffer(state, file_buf)
+
+      window = Map.fetch!(new_state.windows.map, new_state.windows.active)
+      assert window.buffer == file_buf
+    end
+
+    test "active window content is {:buffer, _}, not {:agent_chat, _}", %{state: state} do
+      file_buf = start_buffer("file content")
+      new_state = EditorState.add_buffer(state, file_buf)
+
+      window = Map.fetch!(new_state.windows.map, new_state.windows.active)
+
+      assert Content.buffer?(window.content),
+             "window content should be {:buffer, _} after opening file from agent tab, " <>
+               "got #{inspect(window.content)}"
+
+      refute Content.agent_chat?(window.content),
+             "window content should not be :agent_chat after opening file"
+    end
+
+    test "new file tab context has correct window content type", %{state: state} do
+      file_buf = start_buffer("file content")
+      new_state = EditorState.add_buffer(state, file_buf)
+
+      # The new file tab's snapshotted context should also have the correct
+      # window content type, so switching tabs restores it properly.
+      active_tab = TabBar.active(new_state.tab_bar)
+      tab_windows = active_tab.context[:windows]
+
+      if tab_windows do
+        active_win_id = tab_windows.active
+        tab_window = Map.get(tab_windows.map, active_win_id)
+
+        if tab_window do
+          assert Content.buffer?(tab_window.content),
+                 "tab context window content should be {:buffer, _}, " <>
+                   "got #{inspect(tab_window.content)}"
+        end
+      end
     end
   end
 end

--- a/test/minga/integration/file_open_from_agent_tab_test.exs
+++ b/test/minga/integration/file_open_from_agent_tab_test.exs
@@ -1,0 +1,294 @@
+defmodule Minga.Integration.FileOpenFromAgentTabTest do
+  @moduledoc """
+  Integration test for opening a file while the agent tab is active.
+
+  Reproduces a bug where `SPC f f` (file picker) selects a file and
+  the tab bar correctly shows the new file tab, but the content area
+  renders blank. The tab is there, the buffer exists, but nothing draws.
+
+  Root cause: `sync_active_window_buffer/1` updates `window.buffer` but
+  not `window.content`. The render pipeline checks `Content.agent_chat?`
+  to skip agent windows from the normal buffer rendering path, so the
+  window keeps being treated as agent chat. But `add_buffer_as_new_tab`
+  already reset the agentic view state, so the agent chat renderer draws
+  nothing. Result: blank content area.
+  """
+
+  use Minga.Test.EditorCase, async: false
+
+  alias Minga.Agent.BufferSync, as: AgentBufferSync
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Editor
+  alias Minga.Editor.State.Tab
+  alias Minga.Editor.State.TabBar
+  alias Minga.Editor.Window
+  alias Minga.Editor.Window.Content
+  alias Minga.Test.HeadlessPort
+
+  @moduletag :tmp_dir
+
+  # ── Helpers ──────────────────────────────────────────────────────────────────
+
+  # Starts an editor in agent mode: agent tab active, agent chat window,
+  # keymap scope set to :agent. This mirrors the state when Minga boots
+  # into the agentic view (the default).
+  @spec start_editor_in_agent_mode(keyword()) :: map()
+  defp start_editor_in_agent_mode(opts \\ []) do
+    width = Keyword.get(opts, :width, 80)
+    height = Keyword.get(opts, :height, 24)
+    id = :erlang.unique_integer([:positive])
+
+    {:ok, port} = HeadlessPort.start_link(width: width, height: height)
+
+    # Create the agent buffer (the *Agent* chat buffer)
+    agent_buf = AgentBufferSync.start_buffer()
+    assert is_pid(agent_buf), "Failed to start agent buffer"
+
+    # Create a scratch buffer so the editor has something in the buffer list
+    {:ok, scratch_buf} = BufferServer.start_link(content: "", buffer_name: "*scratch*")
+
+    # Start the editor with the scratch buffer; we'll reconfigure the
+    # state to look like agent mode below.
+    {:ok, editor} =
+      Editor.start_link(
+        name: :"headless_agent_editor_#{id}",
+        port_manager: port,
+        buffer: scratch_buf,
+        width: width,
+        height: height
+      )
+
+    # Reconfigure the editor state to agent mode. This replicates what
+    # Startup.build_initial_state does when keymap_scope is :agent.
+    :sys.replace_state(editor, fn state ->
+      win_id = state.windows.active
+
+      agent_window = Window.new_agent_chat(win_id, agent_buf, height, width)
+
+      windows = %{
+        state.windows
+        | map: Map.put(state.windows.map, win_id, agent_window)
+      }
+
+      agent_tab_bar = TabBar.new(Tab.new_agent(1, "Agent"))
+
+      agent_state =
+        Map.update!(state.agent, :buffer, fn _ -> agent_buf end)
+
+      %{
+        state
+        | windows: windows,
+          tab_bar: agent_tab_bar,
+          keymap_scope: :agent,
+          agent: agent_state
+      }
+    end)
+
+    # Trigger a render so the agent view is visible
+    ref = HeadlessPort.prepare_await(port)
+    send(editor, {:minga_input, {:ready, width, height}})
+    {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+
+    %{
+      editor: editor,
+      buffer: scratch_buf,
+      agent_buffer: agent_buf,
+      port: port,
+      width: width,
+      height: height
+    }
+  end
+
+  # ── Tests ────────────────────────────────────────────────────────────────────
+
+  describe "opening a file from the agent tab" do
+    test "window content type switches from agent_chat to buffer", %{tmp_dir: tmp_dir} do
+      # This test pinpoints the root cause: after add_buffer from an
+      # agent tab, window.content must be {:buffer, file_pid}, not
+      # {:agent_chat, old_pid}. If content stays agent_chat, the render
+      # pipeline treats the window as an agent chat window and skips
+      # normal buffer rendering.
+      ctx = start_editor_in_agent_mode()
+
+      # Confirm we start in agent mode with agent_chat window
+      state = :sys.get_state(ctx.editor)
+      win_id = state.windows.active
+      window = Map.get(state.windows.map, win_id)
+      assert Content.agent_chat?(window.content), "Should start with agent_chat window"
+
+      # Create a test file and open it
+      file_path = Path.join(tmp_dir, "content_type_test.exs")
+      File.write!(file_path, "defmodule ContentTypeTest do\n  :ok\nend\n")
+
+      ref = HeadlessPort.prepare_await(ctx.port)
+      :ok = Editor.open_file(ctx.editor, file_path)
+      {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+
+      # After opening a file, the window content MUST be {:buffer, _}
+      state = :sys.get_state(ctx.editor)
+      win_id = state.windows.active
+      window = Map.get(state.windows.map, win_id)
+
+      assert Content.buffer?(window.content),
+             "Window content should be {:buffer, _} after opening file, " <>
+               "got #{inspect(window.content)}"
+    end
+
+    test "file content is visible on screen after opening", %{tmp_dir: tmp_dir} do
+      ctx = start_editor_in_agent_mode()
+
+      file_path = Path.join(tmp_dir, ".credo.exs")
+
+      File.write!(file_path, """
+      %{
+        configs: [
+          %{
+            name: "default",
+            files: %{
+              included: ["lib/", "test/"],
+              excluded: []
+            }
+          }
+        ]
+      }
+      """)
+
+      ref = HeadlessPort.prepare_await(ctx.port)
+      :ok = Editor.open_file(ctx.editor, file_path)
+      {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+
+      # Tab bar should show the file
+      tab_row = screen_row(ctx, 0)
+
+      assert String.contains?(tab_row, ".credo.exs"),
+             "Tab bar should show .credo.exs, got: #{inspect(tab_row)}"
+
+      # Content rows (rows 1 through height-2, excluding tab bar and modeline)
+      # must contain the file's text, not be blank.
+      content_rows =
+        1..(ctx.height - 2)
+        |> Enum.map(&screen_row(ctx, &1))
+        |> Enum.filter(&(String.trim(&1) != ""))
+
+      assert content_rows != [],
+             "Content area should have non-empty rows. Screen:\n#{Enum.join(screen_text(ctx), "\n")}"
+
+      assert Enum.any?(content_rows, &String.contains?(&1, "configs")),
+             "File content 'configs' should appear in content rows. Content rows:\n" <>
+               Enum.join(content_rows, "\n")
+    end
+
+    test "modeline shows file info, not agent prompt", %{tmp_dir: tmp_dir} do
+      ctx = start_editor_in_agent_mode()
+
+      file_path = Path.join(tmp_dir, "modeline_test.txt")
+      File.write!(file_path, "hello\nworld")
+
+      ref = HeadlessPort.prepare_await(ctx.port)
+      :ok = Editor.open_file(ctx.editor, file_path)
+      {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+
+      ml = modeline(ctx)
+
+      # Modeline should show normal file-editing indicators
+      assert String.contains?(ml, "NORMAL"),
+             "Modeline should show NORMAL mode, got: #{inspect(ml)}"
+
+      # Modeline should NOT show agent prompt indicators
+      refute String.contains?(ml, "Prompt"),
+             "Modeline should not show 'Prompt' after opening file, got: #{inspect(ml)}"
+    end
+
+    test "keymap scope switches to :editor", %{tmp_dir: tmp_dir} do
+      ctx = start_editor_in_agent_mode()
+
+      state = :sys.get_state(ctx.editor)
+      assert state.keymap_scope == :agent
+
+      file_path = Path.join(tmp_dir, "scope_test.txt")
+      File.write!(file_path, "test content")
+
+      ref = HeadlessPort.prepare_await(ctx.port)
+      :ok = Editor.open_file(ctx.editor, file_path)
+      {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+
+      state = :sys.get_state(ctx.editor)
+
+      assert state.keymap_scope == :editor,
+             "Scope should be :editor after opening file, got #{state.keymap_scope}"
+    end
+
+    test "normal mode editing works on the opened file", %{tmp_dir: tmp_dir} do
+      ctx = start_editor_in_agent_mode()
+
+      file_path = Path.join(tmp_dir, "edit_test.txt")
+      File.write!(file_path, "hello\nworld\nfoo")
+
+      ref = HeadlessPort.prepare_await(ctx.port)
+      :ok = Editor.open_file(ctx.editor, file_path)
+      {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+
+      # Navigate down and verify cursor moves
+      send_key(ctx, ?j)
+
+      active_buf = :sys.get_state(ctx.editor).buffers.active
+      {line, _col} = BufferServer.cursor(active_buf)
+      assert line == 1, "Expected cursor on line 1 after j, got #{line}"
+
+      # Insert mode should work
+      send_keys(ctx, "iHELLO<Esc>")
+      content = BufferServer.content(active_buf)
+
+      assert String.contains?(content, "HELLO"),
+             "Insert should work on the opened file, got: #{inspect(content)}"
+    end
+
+    test "tab switch back to agent and forward to file works", %{tmp_dir: tmp_dir} do
+      ctx = start_editor_in_agent_mode()
+
+      file_path = Path.join(tmp_dir, "tab_switch.txt")
+      File.write!(file_path, "switchable content")
+
+      ref = HeadlessPort.prepare_await(ctx.port)
+      :ok = Editor.open_file(ctx.editor, file_path)
+      {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+
+      # Verify file tab is active
+      state = :sys.get_state(ctx.editor)
+      assert TabBar.active(state.tab_bar).kind == :file
+
+      # Click on the agent tab (first tab, row 0)
+      send_mouse(ctx, 0, 2, :left)
+
+      state = :sys.get_state(ctx.editor)
+
+      assert TabBar.active(state.tab_bar).kind == :agent,
+             "Should be on agent tab after clicking tab 1"
+
+      # Click back on the file tab
+      # The file tab label should be in the tab bar
+      tab_row = screen_row(ctx, 0)
+
+      assert String.contains?(tab_row, "tab_switch"),
+             "Tab bar should show file tab, got: #{inspect(tab_row)}"
+
+      # Find approximate position of the file tab (after the agent tab)
+      # Agent tab label is short, file tab starts around col 15-20
+      send_mouse(ctx, 0, 25, :left)
+
+      state = :sys.get_state(ctx.editor)
+
+      if TabBar.active(state.tab_bar).kind == :file do
+        # Successfully switched back to file tab.
+        # Content should be visible again.
+        content_rows =
+          1..(ctx.height - 2)
+          |> Enum.map(&screen_row(ctx, &1))
+          |> Enum.filter(&(String.trim(&1) != ""))
+
+        assert Enum.any?(content_rows, &String.contains?(&1, "switchable")),
+               "File content should be visible after switching back to file tab"
+      end
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

Opening a file via `SPC f f` while the agent tab was active showed the correct tab label but a completely blank content area. Fixed by updating `window.content` alongside `window.buffer` in `sync_active_window_buffer`.

## Context

When Minga boots into agent mode (the default), the active window has `content: {:agent_chat, pid}`. Opening a file from the file picker calls `EditorState.add_buffer`, which calls `sync_active_window_buffer` to point the window at the new file buffer. The render pipeline uses `Content.agent_chat?(window.content)` to route windows: agent_chat windows are skipped by the normal buffer scroll/content stages and rendered by a separate agent chat renderer.

## Changes

- **`lib/minga/editor/state.ex`**: `sync_active_window_buffer/1` now sets `content: Content.buffer(buffers.active)` alongside the existing `buffer: buffers.active` assignment. Previously it only updated `buffer`, leaving `content` stale. When the old content was `{:agent_chat, _}`, the render pipeline kept routing the window to the agent chat renderer, which drew nothing because `add_buffer_as_new_tab` had already reset the agentic view state.

- **`test/minga/editor/state_test.exs`**: 7 new unit tests covering:
  - `sync_active_window_buffer` updates `window.content` when the buffer changes (buffer-to-buffer and agent_chat-to-buffer)
  - `add_buffer` from an agent tab produces a window with `{:buffer, _}` content, correct keymap scope, and correct snapshotted tab context

- **`test/minga/integration/file_open_from_agent_tab_test.exs`**: 6 new integration tests that start the editor in agent mode and open a file via `Editor.open_file/2`, verifying content renders, modeline shows file info, keymap scope switches, editing works, and tab switching round-trips correctly.

## Verification

```bash
mix lint                          # passes
mix test --warnings-as-errors     # 4556 tests, 0 failures
mix dialyzer                      # 0 errors
```

Manual: `bin/minga`, `SPC f f`, select any file. The file content should render immediately instead of showing a blank screen.