### PR TITLE
fix(editor): PR #464 follow-up — tests, doc updates, and bug fixes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,6 +60,9 @@ Current status and planned features. Updated as development progresses.
 | `%` | ✅ | Matching bracket |
 | `;` `,` (repeat find) | 📋 | Stubbed, not yet wired |
 | `H` `M` `L` | 📋 | Screen top / middle / bottom |
+| `]f` / `[f` | ✅ | Goto next/prev function (tree-sitter textobject cache, #442) |
+| `]t` / `[t` | ✅ | Goto next/prev type/class (tree-sitter textobject cache, #442) |
+| `]a` / `[a` | ✅ | Goto next/prev argument/parameter (tree-sitter textobject cache, #442) |
 
 ## Operators
 
@@ -73,6 +76,7 @@ Current status and planned features. Updated as development progresses.
 | `x` / `X` | ✅ | Delete char under / before cursor |
 | `D` / `C` | ✅ | Delete / change to end of line |
 | `>>` / `<<` | ✅ | Indent / dedent |
+| `=` / `==` | ✅ | Reindent line/range/selection using tree-sitter indent heuristics (#441) |
 
 ## Text Objects
 
@@ -86,9 +90,14 @@ Current status and planned features. Updated as development progresses.
 | `i[` / `a[` | ✅ | Inner / a brackets |
 | `i{` / `a{` | ✅ | Inner / a braces |
 | `i<` / `a<` | ✅ | Inner / a angle brackets |
+| `if` / `af` | ✅ | Inner / around function (tree-sitter, #442) |
+| `ic` / `ac` | ✅ | Inner / around class/module (tree-sitter, #442) |
+| `ia` / `aa` | ✅ | Inner / around argument/parameter (tree-sitter, #442) |
+| `ib` / `ab` | ✅ | Inner / around block (tree-sitter, #442) |
 | `it` / `at` | 📋 | Inner / a HTML tag |
 | `ip` / `ap` | 📋 | Inner / a paragraph |
 | `is` / `as` | 📋 | Inner / a sentence |
+| Visual text objects | ✅ | `vi"`, `viw`, `vif`, `vaf`, etc. expand selection to text object range (#442) |
 
 ## Leader Key (`SPC`) Commands
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -79,6 +79,10 @@ The frontend runs as a child process of the BEAM. Communication uses stdin (BEAM
 | `0x33` | language_at_response | 7 + name_len | Language at a byte offset |
 | `0x34` | injection_ranges | 3 + variable | Injection language regions |
 | `0x35` | text_width | 7 | Display width of measured text |
+| `0x36` | fold_ranges | variable | Fold range results from tree-sitter |
+| `0x37` | indent_result | 13 | Indent level result for a line |
+| `0x38` | textobject_result | variable | Text object range result (or nil) |
+| `0x39` | textobject_positions | 9 + count × 9 | Proactive text object position cache |
 
 ### Frontend → BEAM (Diagnostics)
 
@@ -543,6 +547,39 @@ name:       [name_len]u8  language name for this region
 ```
 
 **Behavior:** Sent after `highlight_spans` when the parse found embedded language regions (e.g., JSON inside a Markdown fenced code block). The BEAM can use these ranges for injection-aware features like line comment toggling.
+
+### `0x39` textobject_positions
+
+Proactive cache of all `.around` text object positions in the current file, sent after each parse (initial and incremental). The BEAM caches these per-window for `]f`/`[f`-style navigation with zero per-keystroke IPC.
+
+```
+opcode:  u8  = 0x39
+version: u32           parse version counter
+count:   u32           number of entries
+entries: [count × 9]   array of position entries
+```
+
+Each entry:
+```
+type_id: u8   text object type (see table below)
+row:     u32  0-indexed line number
+col:     u32  0-indexed byte column
+```
+
+Total size: 9 + count × 9 bytes.
+
+**Type ID values:**
+
+| Value | Type |
+|-------|------|
+| `0x00` | function |
+| `0x01` | class |
+| `0x02` | parameter |
+| `0x03` | block |
+| `0x04` | comment |
+| `0x05` | test |
+
+**Behavior:** The Zig parser runs the `textobjects.scm` query against the parse tree and collects the start positions of all `.around` captures (e.g., `@function.around`, `@class.around`). Entries are sorted by (row, col) before sending. The BEAM decodes them into a `%{atom => [{row, col}]}` map and stores them on the active window struct. Navigation commands (`]f`, `[f`, etc.) scan this cached data with no further IPC to Zig.
 
 ---
 

--- a/lib/minga/mode/visual.ex
+++ b/lib/minga/mode/visual.ex
@@ -150,12 +150,13 @@ defmodule Minga.Mode.Visual do
     {:execute, :word_end_big, state}
   end
 
-  # Paragraph motions
-  def handle_key({?{, 0}, state) do
+  # Paragraph motions (guarded: only fire when no text object modifier is
+  # pending, so vi{ / vi} can dispatch to the brace text object handler).
+  def handle_key({?{, 0}, %VisualState{text_object_modifier: nil} = state) do
     {:execute, :paragraph_backward, state}
   end
 
-  def handle_key({?}, 0}, state) do
+  def handle_key({?}, 0}, %VisualState{text_object_modifier: nil} = state) do
     {:execute, :paragraph_forward, state}
   end
 

--- a/lib/minga/port/protocol.ex
+++ b/lib/minga/port/protocol.ex
@@ -704,7 +704,9 @@ defmodule Minga.Port.Protocol do
   end
 
   @spec decode_textobject_entries(binary(), non_neg_integer(), map()) :: map()
-  defp decode_textobject_entries(_data, 0, acc), do: acc
+  defp decode_textobject_entries(_data, 0, acc) do
+    Map.new(acc, fn {type, positions} -> {type, Enum.reverse(positions)} end)
+  end
 
   defp decode_textobject_entries(
          <<type_id::8, row::32, col::32, rest::binary>>,
@@ -713,11 +715,13 @@ defmodule Minga.Port.Protocol do
        ) do
     type_atom = textobj_type_to_atom(type_id)
     existing = Map.get(acc, type_atom, [])
-    updated = Map.put(acc, type_atom, existing ++ [{row, col}])
+    updated = Map.put(acc, type_atom, [{row, col} | existing])
     decode_textobject_entries(rest, remaining - 1, updated)
   end
 
-  defp decode_textobject_entries(_, _, acc), do: acc
+  defp decode_textobject_entries(_, _, acc) do
+    Map.new(acc, fn {type, positions} -> {type, Enum.reverse(positions)} end)
+  end
 
   @spec textobj_type_to_atom(non_neg_integer()) :: atom()
   defp textobj_type_to_atom(@textobj_function), do: :function

--- a/test/minga/editor/commands/editing_reindent_test.exs
+++ b/test/minga/editor/commands/editing_reindent_test.exs
@@ -1,0 +1,156 @@
+defmodule Minga.Editor.Commands.EditingReindentTest do
+  @moduledoc """
+  Tests for the = operator (reindent) mode transitions and dispatch.
+
+  Verifies that ==, =<motion>, and visual = correctly route through
+  operator-pending mode and return to normal mode. Content-level indent
+  correctness is tested in `test/minga/editor/indent_test.exs`.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Editor
+
+  defp start_editor(content) do
+    {:ok, buffer} = BufferServer.start_link(content: content)
+
+    {:ok, editor} =
+      Editor.start_link(
+        name: :"reindent_editor_#{:erlang.unique_integer([:positive])}",
+        port_manager: nil,
+        buffer: buffer,
+        width: 80,
+        height: 24
+      )
+
+    {editor, buffer}
+  end
+
+  defp send_key(editor, codepoint, mods \\ 0) do
+    send(editor, {:minga_input, {:key_press, codepoint, mods}})
+    _ = :sys.get_state(editor)
+  end
+
+  # ── == mode transitions ────────────────────────────────────────────────────
+
+  describe "== mode transitions" do
+    test "first = enters operator-pending with :reindent" do
+      {editor, _buffer} = start_editor("line 1\nline 2")
+      send_key(editor, ?=)
+
+      state = :sys.get_state(editor)
+      assert state.vim.mode == :operator_pending
+      assert state.vim.mode_state.operator == :reindent
+    end
+
+    test "== returns to normal mode" do
+      {editor, _buffer} = start_editor("line 1\nline 2")
+      send_key(editor, ?=)
+      send_key(editor, ?=)
+
+      state = :sys.get_state(editor)
+      assert state.vim.mode == :normal
+    end
+
+    test "=w returns to normal mode (word motion)" do
+      {editor, _buffer} = start_editor("line 1\nline 2\nline 3")
+      send_key(editor, ?=)
+      send_key(editor, ?w)
+
+      state = :sys.get_state(editor)
+      assert state.vim.mode == :normal
+    end
+
+    test "=G returns to normal mode" do
+      {editor, _buffer} = start_editor("line 1\nline 2\nline 3")
+      send_key(editor, ?=)
+      send_key(editor, ?G)
+
+      state = :sys.get_state(editor)
+      assert state.vim.mode == :normal
+    end
+
+    test "=gg returns to normal mode" do
+      {editor, _buffer} = start_editor("line 1\nline 2\nline 3")
+      send_key(editor, ?j)
+      send_key(editor, ?=)
+      send_key(editor, ?g)
+      send_key(editor, ?g)
+
+      state = :sys.get_state(editor)
+      assert state.vim.mode == :normal
+    end
+  end
+
+  # ── Visual = mode transitions ──────────────────────────────────────────────
+
+  describe "visual = mode transitions" do
+    test "V j = reindents visual selection and returns to normal" do
+      {editor, _buffer} = start_editor("line 1\nline 2\nline 3")
+      send_key(editor, ?V)
+      send_key(editor, ?j)
+      send_key(editor, ?=)
+
+      state = :sys.get_state(editor)
+      assert state.vim.mode == :normal
+    end
+
+    test "v l = returns to normal after characterwise reindent" do
+      {editor, _buffer} = start_editor("line 1\nline 2")
+      send_key(editor, ?v)
+      send_key(editor, ?j)
+      send_key(editor, ?=)
+
+      state = :sys.get_state(editor)
+      assert state.vim.mode == :normal
+    end
+  end
+
+  # ── = with text objects ────────────────────────────────────────────────────
+
+  describe "= with text objects" do
+    test "=iw enters operator-pending then dispatches and returns to normal" do
+      {editor, _buffer} = start_editor("hello world")
+      send_key(editor, ?=)
+
+      state = :sys.get_state(editor)
+      assert state.vim.mode == :operator_pending
+
+      send_key(editor, ?i)
+      send_key(editor, ?w)
+
+      state = :sys.get_state(editor)
+      assert state.vim.mode == :normal
+    end
+  end
+
+  # ── Content verification (simple cases) ────────────────────────────────────
+
+  describe "content verification" do
+    test "== does not corrupt buffer content" do
+      content = "hello\nworld\nfoo"
+      {editor, buffer} = start_editor(content)
+      send_key(editor, ?=)
+      send_key(editor, ?=)
+
+      result = BufferServer.content(buffer)
+      # Content should not lose characters. The line may gain/lose whitespace
+      # but the non-whitespace content should be preserved.
+      assert String.contains?(result, "hello")
+    end
+
+    test "=G does not crash on multi-line buffer" do
+      {editor, buffer} = start_editor("a\nb\nc\nd\ne")
+      send_key(editor, ?=)
+      send_key(editor, ?G)
+
+      result = BufferServer.content(buffer)
+      assert is_binary(result)
+      # All original non-whitespace content should be preserved
+      for char <- ["a", "b", "c", "d", "e"] do
+        assert String.contains?(result, char),
+               "Expected '#{char}' to be preserved after =G, content: #{inspect(result)}"
+      end
+    end
+  end
+end

--- a/test/minga/editor/window_textobject_test.exs
+++ b/test/minga/editor/window_textobject_test.exs
@@ -1,0 +1,137 @@
+defmodule Minga.Editor.WindowTextobjectTest do
+  @moduledoc """
+  Tests for `Window.next_textobject/3` and `Window.prev_textobject/3`.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.Viewport
+  alias Minga.Editor.Window
+  alias Minga.Editor.Window.Content
+
+  defp window_with_positions(positions) do
+    pid = self()
+
+    %Window{
+      id: 1,
+      content: Content.buffer(pid),
+      buffer: pid,
+      viewport: Viewport.new(24, 80),
+      textobject_positions: positions
+    }
+  end
+
+  # ── next_textobject/3 ──────────────────────────────────────────────────────
+
+  describe "next_textobject/3" do
+    test "returns nil for empty positions" do
+      win = window_with_positions(%{})
+      assert Window.next_textobject(win, :function, {0, 0}) == nil
+    end
+
+    test "returns nil when type has no entries" do
+      win = window_with_positions(%{class: [{5, 0}]})
+      assert Window.next_textobject(win, :function, {0, 0}) == nil
+    end
+
+    test "returns the first position after cursor on same line" do
+      win = window_with_positions(%{function: [{0, 0}, {0, 10}, {5, 0}]})
+      assert Window.next_textobject(win, :function, {0, 0}) == {0, 10}
+    end
+
+    test "returns position on a later line" do
+      win = window_with_positions(%{function: [{0, 0}, {5, 0}, {10, 0}]})
+      assert Window.next_textobject(win, :function, {0, 0}) == {5, 0}
+    end
+
+    test "returns nil when cursor is at or past all positions" do
+      win = window_with_positions(%{function: [{0, 0}, {5, 0}]})
+      assert Window.next_textobject(win, :function, {5, 0}) == nil
+    end
+
+    test "returns nil when cursor is past all positions" do
+      win = window_with_positions(%{function: [{0, 0}, {5, 0}]})
+      assert Window.next_textobject(win, :function, {10, 0}) == nil
+    end
+
+    test "handles single entry after cursor" do
+      win = window_with_positions(%{function: [{3, 5}]})
+      assert Window.next_textobject(win, :function, {0, 0}) == {3, 5}
+    end
+
+    test "skips entries before cursor" do
+      win = window_with_positions(%{function: [{1, 0}, {2, 0}, {3, 0}]})
+      assert Window.next_textobject(win, :function, {2, 0}) == {3, 0}
+    end
+
+    test "handles same-row comparison correctly" do
+      win = window_with_positions(%{function: [{5, 0}, {5, 10}, {5, 20}]})
+      assert Window.next_textobject(win, :function, {5, 10}) == {5, 20}
+    end
+  end
+
+  # ── prev_textobject/3 ──────────────────────────────────────────────────────
+
+  describe "prev_textobject/3" do
+    test "returns nil for empty positions" do
+      win = window_with_positions(%{})
+      assert Window.prev_textobject(win, :function, {10, 0}) == nil
+    end
+
+    test "returns nil when type has no entries" do
+      win = window_with_positions(%{class: [{5, 0}]})
+      assert Window.prev_textobject(win, :function, {10, 0}) == nil
+    end
+
+    test "returns the last position before cursor on same line" do
+      win = window_with_positions(%{function: [{5, 0}, {5, 10}, {5, 20}]})
+      assert Window.prev_textobject(win, :function, {5, 20}) == {5, 10}
+    end
+
+    test "returns position on an earlier line" do
+      win = window_with_positions(%{function: [{0, 0}, {5, 0}, {10, 0}]})
+      assert Window.prev_textobject(win, :function, {10, 0}) == {5, 0}
+    end
+
+    test "returns nil when cursor is at or before all positions" do
+      win = window_with_positions(%{function: [{5, 0}, {10, 0}]})
+      assert Window.prev_textobject(win, :function, {5, 0}) == nil
+    end
+
+    test "returns nil when cursor is before all positions" do
+      win = window_with_positions(%{function: [{5, 0}, {10, 0}]})
+      assert Window.prev_textobject(win, :function, {0, 0}) == nil
+    end
+
+    test "handles single entry before cursor" do
+      win = window_with_positions(%{function: [{3, 5}]})
+      assert Window.prev_textobject(win, :function, {10, 0}) == {3, 5}
+    end
+
+    test "skips entries after cursor" do
+      win = window_with_positions(%{function: [{1, 0}, {2, 0}, {3, 0}]})
+      assert Window.prev_textobject(win, :function, {2, 0}) == {1, 0}
+    end
+
+    test "handles same-row comparison correctly" do
+      win = window_with_positions(%{function: [{5, 0}, {5, 10}, {5, 20}]})
+      assert Window.prev_textobject(win, :function, {5, 10}) == {5, 0}
+    end
+  end
+
+  # ── Cross-type independence ────────────────────────────────────────────────
+
+  describe "cross-type independence" do
+    test "different types have independent position lists" do
+      win =
+        window_with_positions(%{
+          function: [{1, 0}, {10, 0}],
+          class: [{5, 0}, {20, 0}],
+          parameter: [{3, 5}]
+        })
+
+      assert Window.next_textobject(win, :function, {0, 0}) == {1, 0}
+      assert Window.next_textobject(win, :class, {0, 0}) == {5, 0}
+      assert Window.next_textobject(win, :parameter, {0, 0}) == {3, 5}
+    end
+  end
+end

--- a/test/minga/mode/normal_bracket_nav_test.exs
+++ b/test/minga/mode/normal_bracket_nav_test.exs
@@ -1,0 +1,117 @@
+defmodule Minga.Mode.NormalBracketNavTest do
+  @moduledoc """
+  Tests for bracket-prefix navigation keys: ]f/[f, ]t/[t, ]a/[a.
+  Also tests the = operator entry into operator-pending mode.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Mode.Normal
+  alias Minga.Mode.State, as: ModeState
+
+  defp state_with_bracket(direction) do
+    %ModeState{pending_bracket: direction}
+  end
+
+  # ── ]f / [f — function navigation ──────────────────────────────────────────
+
+  describe "]f / [f — goto next/prev function" do
+    test "]f emits goto_next_textobject for :function" do
+      state = state_with_bracket(:next)
+
+      assert {:execute, {:goto_next_textobject, :function}, %ModeState{pending_bracket: nil}} =
+               Normal.handle_key({?f, 0}, state)
+    end
+
+    test "[f emits goto_prev_textobject for :function" do
+      state = state_with_bracket(:prev)
+
+      assert {:execute, {:goto_prev_textobject, :function}, %ModeState{pending_bracket: nil}} =
+               Normal.handle_key({?f, 0}, state)
+    end
+  end
+
+  # ── ]t / [t — type/class navigation ────────────────────────────────────────
+
+  describe "]t / [t — goto next/prev class" do
+    test "]t emits goto_next_textobject for :class" do
+      state = state_with_bracket(:next)
+
+      assert {:execute, {:goto_next_textobject, :class}, %ModeState{pending_bracket: nil}} =
+               Normal.handle_key({?t, 0}, state)
+    end
+
+    test "[t emits goto_prev_textobject for :class" do
+      state = state_with_bracket(:prev)
+
+      assert {:execute, {:goto_prev_textobject, :class}, %ModeState{pending_bracket: nil}} =
+               Normal.handle_key({?t, 0}, state)
+    end
+  end
+
+  # ── ]a / [a — parameter navigation ─────────────────────────────────────────
+
+  describe "]a / [a — goto next/prev parameter" do
+    test "]a emits goto_next_textobject for :parameter" do
+      state = state_with_bracket(:next)
+
+      assert {:execute, {:goto_next_textobject, :parameter}, %ModeState{pending_bracket: nil}} =
+               Normal.handle_key({?a, 0}, state)
+    end
+
+    test "[a emits goto_prev_textobject for :parameter" do
+      state = state_with_bracket(:prev)
+
+      assert {:execute, {:goto_prev_textobject, :parameter}, %ModeState{pending_bracket: nil}} =
+               Normal.handle_key({?a, 0}, state)
+    end
+  end
+
+  # ── Bracket state resets on dispatch ───────────────────────────────────────
+
+  describe "bracket state resets on dispatch" do
+    test "pending_bracket is cleared after successful dispatch" do
+      state = state_with_bracket(:next)
+
+      {:execute, _, new_state} = Normal.handle_key({?f, 0}, state)
+      assert new_state.pending_bracket == nil
+    end
+  end
+
+  # ── `a` key guarded by pending_bracket ─────────────────────────────────────
+
+  describe "`a` key disambiguation" do
+    test "a with no bracket pending enters insert mode (append)" do
+      state = %ModeState{pending_bracket: nil}
+
+      assert {:execute_then_transition, [:move_right], :insert, _} =
+               Normal.handle_key({?a, 0}, state)
+    end
+
+    test "a with :next bracket pending emits goto_next_textobject :parameter" do
+      state = state_with_bracket(:next)
+
+      assert {:execute, {:goto_next_textobject, :parameter}, _} =
+               Normal.handle_key({?a, 0}, state)
+    end
+  end
+
+  # ── = operator entry ──────────────────────────────────────────────────────
+
+  describe "= operator" do
+    test "= enters operator-pending with :reindent operator" do
+      state = %ModeState{pending_bracket: nil}
+
+      assert {:transition, :operator_pending,
+              %Minga.Mode.OperatorPendingState{operator: :reindent}} =
+               Normal.handle_key({?=, 0}, state)
+    end
+
+    test "= passes count to operator-pending state" do
+      state = %ModeState{count: 5, pending_bracket: nil}
+
+      assert {:transition, :operator_pending,
+              %Minga.Mode.OperatorPendingState{operator: :reindent, op_count: 5}} =
+               Normal.handle_key({?=, 0}, state)
+    end
+  end
+end

--- a/test/minga/mode/operator_pending_test.exs
+++ b/test/minga/mode/operator_pending_test.exs
@@ -397,4 +397,71 @@ defmodule Minga.Mode.OperatorPendingTest do
                OperatorPending.handle_key({?g, 0}, state)
     end
   end
+
+  # ── Reindent (= operator) ─────────────────────────────────────────────────
+
+  describe "== (reindent current lines)" do
+    test "== emits {:reindent_lines, 1} and returns to :normal" do
+      state = op_state(:reindent)
+
+      assert {:execute_then_transition, [{:reindent_lines, 1}], :normal, _} =
+               OperatorPending.handle_key({?=, 0}, state)
+    end
+
+    test "== with op_count=3 emits {:reindent_lines, 3}" do
+      state = op_state(:reindent, 3)
+
+      assert {:execute_then_transition, [{:reindent_lines, 3}], :normal, _} =
+               OperatorPending.handle_key({?=, 0}, state)
+    end
+  end
+
+  describe "=motion (reindent to motion target)" do
+    test "=w emits {:reindent_motion, :word_forward} and returns to :normal" do
+      state = op_state(:reindent)
+
+      assert {:execute_then_transition, [{:reindent_motion, :word_forward}], :normal, _} =
+               OperatorPending.handle_key({?w, 0}, state)
+    end
+
+    test "=G emits {:reindent_motion, :document_end} and returns to :normal" do
+      state = op_state(:reindent)
+
+      assert {:execute_then_transition, [{:reindent_motion, :document_end}], :normal, _} =
+               OperatorPending.handle_key({?G, 0}, state)
+    end
+
+    test "=gg emits {:reindent_motion, :document_start} and returns to :normal" do
+      state = %OperatorPendingState{operator: :reindent, op_count: 1, pending_g: true}
+
+      assert {:execute_then_transition, [{:reindent_motion, :document_start}], :normal, _} =
+               OperatorPending.handle_key({?g, 0}, state)
+    end
+  end
+
+  describe "=<text_object> (reindent text object)" do
+    test "=if emits {:reindent_text_object, :inner, {:structural, :function}}" do
+      state = %OperatorPendingState{
+        operator: :reindent,
+        op_count: 1,
+        text_object_modifier: :inner
+      }
+
+      assert {:execute_then_transition,
+              [{:reindent_text_object, :inner, {:structural, :function}}], :normal, _} =
+               OperatorPending.handle_key({?f, 0}, state)
+    end
+
+    test "=af emits {:reindent_text_object, :around, {:structural, :function}}" do
+      state = %OperatorPendingState{
+        operator: :reindent,
+        op_count: 1,
+        text_object_modifier: :around
+      }
+
+      assert {:execute_then_transition,
+              [{:reindent_text_object, :around, {:structural, :function}}], :normal, _} =
+               OperatorPending.handle_key({?f, 0}, state)
+    end
+  end
 end

--- a/test/minga/mode/visual_text_object_test.exs
+++ b/test/minga/mode/visual_text_object_test.exs
@@ -1,0 +1,276 @@
+defmodule Minga.Mode.VisualTextObjectTest do
+  @moduledoc """
+  Tests for visual mode text object selection (viw, vi\", vif, vaf, etc.)
+  and the text_object_modifier state machine.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Mode.Visual
+  alias Minga.Mode.VisualState
+
+  defp visual_state(opts \\ []) do
+    anchor = Keyword.get(opts, :anchor, {0, 0})
+    type = Keyword.get(opts, :type, :char)
+    modifier = Keyword.get(opts, :modifier, nil)
+
+    %VisualState{
+      visual_anchor: anchor,
+      visual_type: type,
+      text_object_modifier: modifier
+    }
+  end
+
+  # ── text_object_modifier state machine ───────────────────────────────────────
+
+  describe "text_object_modifier state machine" do
+    test "i sets modifier to :inner" do
+      state = visual_state()
+
+      assert {:continue, %VisualState{text_object_modifier: :inner}} =
+               Visual.handle_key({?i, 0}, state)
+    end
+
+    test "a sets modifier to :around" do
+      state = visual_state()
+
+      assert {:continue, %VisualState{text_object_modifier: :around}} =
+               Visual.handle_key({?a, 0}, state)
+    end
+
+    test "modifier resets to nil after text object dispatch" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, :word}], %VisualState{} = new_state} =
+               Visual.handle_key({?w, 0}, state)
+
+      assert new_state.text_object_modifier == nil
+    end
+
+    test "i with modifier already set is a no-op (falls through to catch-all)" do
+      state = visual_state(modifier: :inner)
+      # i with modifier already :inner falls through to the unknown-key
+      # handler, which returns {:continue, state} unchanged. This is harmless.
+      result = Visual.handle_key({?i, 0}, state)
+      assert {:continue, %VisualState{text_object_modifier: :inner}} = result
+    end
+  end
+
+  # ── Regex text objects in visual mode ────────────────────────────────────────
+
+  describe "regex text objects in visual mode" do
+    test "viw selects inner word" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, :word}], %VisualState{}} =
+               Visual.handle_key({?w, 0}, state)
+    end
+
+    test "vaw selects around word" do
+      state = visual_state(modifier: :around)
+
+      assert {:execute, [{:visual_text_object, :around, :word}], %VisualState{}} =
+               Visual.handle_key({?w, 0}, state)
+    end
+
+    test "vi\" selects inner double-quoted string" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:quote, "\""}}], %VisualState{}} =
+               Visual.handle_key({?", 0}, state)
+    end
+
+    test "va' selects around single-quoted string" do
+      state = visual_state(modifier: :around)
+
+      assert {:execute, [{:visual_text_object, :around, {:quote, "'"}}], %VisualState{}} =
+               Visual.handle_key({?', 0}, state)
+    end
+
+    test "vi( selects inner parens" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:paren, "(", ")"}}], %VisualState{}} =
+               Visual.handle_key({?(, 0}, state)
+    end
+
+    test "va) also selects around parens" do
+      state = visual_state(modifier: :around)
+
+      assert {:execute, [{:visual_text_object, :around, {:paren, "(", ")"}}], %VisualState{}} =
+               Visual.handle_key({?), 0}, state)
+    end
+
+    test "vi[ selects inner brackets" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:paren, "[", "]"}}], %VisualState{}} =
+               Visual.handle_key({?[, 0}, state)
+    end
+
+    test "vi{ selects inner braces" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:paren, "{", "}"}}], %VisualState{}} =
+               Visual.handle_key({?{, 0}, state)
+    end
+  end
+
+  # ── Structural text objects in visual mode ──────────────────────────────────
+
+  describe "structural text objects in visual mode" do
+    test "vif selects inner function" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:structural, :function}}], %VisualState{}} =
+               Visual.handle_key({?f, 0}, state)
+    end
+
+    test "vaf selects around function" do
+      state = visual_state(modifier: :around)
+
+      assert {:execute, [{:visual_text_object, :around, {:structural, :function}}],
+              %VisualState{}} = Visual.handle_key({?f, 0}, state)
+    end
+
+    test "vic selects inner class" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:structural, :class}}], %VisualState{}} =
+               Visual.handle_key({?c, 0}, state)
+    end
+
+    test "vac selects around class" do
+      state = visual_state(modifier: :around)
+
+      assert {:execute, [{:visual_text_object, :around, {:structural, :class}}], %VisualState{}} =
+               Visual.handle_key({?c, 0}, state)
+    end
+
+    test "via selects inner parameter" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:structural, :parameter}}],
+              %VisualState{}} = Visual.handle_key({?a, 0}, state)
+    end
+
+    test "vab selects around block" do
+      state = visual_state(modifier: :around)
+
+      assert {:execute, [{:visual_text_object, :around, {:structural, :block}}], %VisualState{}} =
+               Visual.handle_key({?b, 0}, state)
+    end
+
+    test "vib selects inner block" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:structural, :block}}], %VisualState{}} =
+               Visual.handle_key({?b, 0}, state)
+    end
+  end
+
+  # ── Wrap handlers guard on text_object_modifier ─────────────────────────────
+
+  describe "wrap handlers guard on text_object_modifier" do
+    test "\" wraps selection when no modifier is pending" do
+      state = visual_state(modifier: nil)
+
+      assert {:execute_then_transition, [{:wrap_visual_selection, "\"", "\""}], :normal, _} =
+               Visual.handle_key({?", 0}, state)
+    end
+
+    test "\" selects text object when :inner modifier is pending" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:quote, "\""}}], _} =
+               Visual.handle_key({?", 0}, state)
+    end
+
+    test "( wraps selection when no modifier is pending" do
+      state = visual_state(modifier: nil)
+
+      assert {:execute_then_transition, [{:wrap_visual_selection, "(", ")"}], :normal, _} =
+               Visual.handle_key({?(, 0}, state)
+    end
+
+    test "( selects text object when :inner modifier is pending" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:paren, "(", ")"}}], _} =
+               Visual.handle_key({?(, 0}, state)
+    end
+
+    test "[ wraps selection when no modifier is pending" do
+      state = visual_state(modifier: nil)
+
+      assert {:execute_then_transition, [{:wrap_visual_selection, "[", "]"}], :normal, _} =
+               Visual.handle_key({?[, 0}, state)
+    end
+
+    test "[ selects text object when :around modifier is pending" do
+      state = visual_state(modifier: :around)
+
+      assert {:execute, [{:visual_text_object, :around, {:paren, "[", "]"}}], _} =
+               Visual.handle_key({?[, 0}, state)
+    end
+
+    test "' wraps selection when no modifier is pending" do
+      state = visual_state(modifier: nil)
+
+      assert {:execute_then_transition, [{:wrap_visual_selection, "'", "'"}], :normal, _} =
+               Visual.handle_key({?', 0}, state)
+    end
+
+    test "' selects text object when :inner modifier is pending" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:quote, "'"}}], _} =
+               Visual.handle_key({?', 0}, state)
+    end
+
+    test "` wraps selection when no modifier is pending" do
+      state = visual_state(modifier: nil)
+
+      assert {:execute_then_transition, [{:wrap_visual_selection, "`", "`"}], :normal, _} =
+               Visual.handle_key({?`, 0}, state)
+    end
+  end
+
+  # ── w and b guard on text_object_modifier ──────────────────────────────────
+
+  describe "w and b guard on text_object_modifier" do
+    test "w is :word_forward when no modifier" do
+      state = visual_state(modifier: nil)
+      assert {:execute, :word_forward, _} = Visual.handle_key({?w, 0}, state)
+    end
+
+    test "w selects inner word when modifier is :inner" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, :word}], _} =
+               Visual.handle_key({?w, 0}, state)
+    end
+
+    test "b is :word_backward when no modifier" do
+      state = visual_state(modifier: nil)
+      assert {:execute, :word_backward, _} = Visual.handle_key({?b, 0}, state)
+    end
+
+    test "b selects inner block when modifier is :inner" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, {:structural, :block}}], _} =
+               Visual.handle_key({?b, 0}, state)
+    end
+  end
+
+  # ── = reindent in visual mode ──────────────────────────────────────────────
+
+  describe "= reindent in visual mode" do
+    test "= reindents visual selection and transitions to normal" do
+      state = visual_state()
+
+      assert {:execute_then_transition, [:reindent_visual_selection], :normal, _} =
+               Visual.handle_key({?=, 0}, state)
+    end
+  end
+end

--- a/test/minga/port/protocol_textobject_positions_test.exs
+++ b/test/minga/port/protocol_textobject_positions_test.exs
@@ -1,0 +1,110 @@
+defmodule Minga.Port.ProtocolTextobjectPositionsTest do
+  @moduledoc """
+  Tests for decoding the `TEXTOBJECT_POSITIONS` (0x39) opcode.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Port.Protocol
+
+  @op_textobject_positions 0x39
+
+  # Type IDs matching Zig constants
+  @textobj_function 0
+  @textobj_class 1
+  @textobj_parameter 2
+  @textobj_block 3
+  @textobj_comment 4
+  @textobj_test 5
+
+  defp encode_entry(type_id, row, col) do
+    <<type_id::8, row::32, col::32>>
+  end
+
+  describe "decode_event/1 — textobject_positions (0x39)" do
+    test "decodes empty positions" do
+      payload = <<@op_textobject_positions, 1::32, 0::32>>
+
+      assert {:ok, {:textobject_positions, 1, positions}} = Protocol.decode_event(payload)
+      assert positions == %{}
+    end
+
+    test "decodes single function entry" do
+      entry = encode_entry(@textobj_function, 5, 0)
+      payload = <<@op_textobject_positions, 42::32, 1::32, entry::binary>>
+
+      assert {:ok, {:textobject_positions, 42, positions}} = Protocol.decode_event(payload)
+      assert positions == %{function: [{5, 0}]}
+    end
+
+    test "decodes multiple entries of the same type" do
+      entries =
+        encode_entry(@textobj_function, 0, 0) <>
+          encode_entry(@textobj_function, 5, 0) <>
+          encode_entry(@textobj_function, 10, 4)
+
+      payload = <<@op_textobject_positions, 1::32, 3::32, entries::binary>>
+
+      assert {:ok, {:textobject_positions, 1, positions}} = Protocol.decode_event(payload)
+      assert positions == %{function: [{0, 0}, {5, 0}, {10, 4}]}
+    end
+
+    test "decodes entries of different types" do
+      entries =
+        encode_entry(@textobj_function, 1, 0) <>
+          encode_entry(@textobj_class, 5, 2) <>
+          encode_entry(@textobj_parameter, 3, 10)
+
+      payload = <<@op_textobject_positions, 7::32, 3::32, entries::binary>>
+
+      assert {:ok, {:textobject_positions, 7, positions}} = Protocol.decode_event(payload)
+      assert positions == %{function: [{1, 0}], class: [{5, 2}], parameter: [{3, 10}]}
+    end
+
+    test "decodes all six known type IDs" do
+      entries =
+        encode_entry(@textobj_function, 0, 0) <>
+          encode_entry(@textobj_class, 1, 0) <>
+          encode_entry(@textobj_parameter, 2, 0) <>
+          encode_entry(@textobj_block, 3, 0) <>
+          encode_entry(@textobj_comment, 4, 0) <>
+          encode_entry(@textobj_test, 5, 0)
+
+      payload = <<@op_textobject_positions, 1::32, 6::32, entries::binary>>
+
+      assert {:ok, {:textobject_positions, 1, positions}} = Protocol.decode_event(payload)
+      assert Map.has_key?(positions, :function)
+      assert Map.has_key?(positions, :class)
+      assert Map.has_key?(positions, :parameter)
+      assert Map.has_key?(positions, :block)
+      assert Map.has_key?(positions, :comment)
+      assert Map.has_key?(positions, :test)
+    end
+
+    test "unknown type ID decodes as :unknown" do
+      entry = encode_entry(255, 0, 0)
+      payload = <<@op_textobject_positions, 1::32, 1::32, entry::binary>>
+
+      assert {:ok, {:textobject_positions, 1, positions}} = Protocol.decode_event(payload)
+      assert Map.has_key?(positions, :unknown)
+    end
+
+    test "preserves entry order (Zig sends sorted by row, col)" do
+      entries =
+        encode_entry(@textobj_function, 0, 5) <>
+          encode_entry(@textobj_function, 0, 15) <>
+          encode_entry(@textobj_function, 3, 0) <>
+          encode_entry(@textobj_function, 10, 2)
+
+      payload = <<@op_textobject_positions, 1::32, 4::32, entries::binary>>
+
+      assert {:ok, {:textobject_positions, 1, positions}} = Protocol.decode_event(payload)
+      assert positions[:function] == [{0, 5}, {0, 15}, {3, 0}, {10, 2}]
+    end
+
+    test "version counter is preserved" do
+      payload = <<@op_textobject_positions, 999::32, 0::32>>
+
+      assert {:ok, {:textobject_positions, 999, _positions}} = Protocol.decode_event(payload)
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

PR #464 shipped 560 lines of production code with zero tests. This PR adds 134 test assertions across 5 new test files, fixes a visual mode bug where `vi{`/`vi}` were unreachable, fixes an O(n²) protocol decode, and updates ROADMAP.md and PROTOCOL.md.

Closes #467

## Context

PR #464 completed the remaining acceptance criteria for #441 (tree-sitter indentation) and #442 (tree-sitter text objects). A post-merge review ([PR #464 audit](https://github.com/jsmestad/minga/pull/464)) found zero test files, missing doc updates, an O(n²) list accumulation pattern, and a production bug where `{`/`}` paragraph motions in visual mode swallowed text object selection.

## Changes

- **5 new test files** covering all untested code from PR #464:
  - `visual_text_object_test.exs`: 30 tests for `viw`, `vi"`, `vi(`, `vif`, `vaf`, `vic`, `vab`, text_object_modifier state machine, wrap handler guards, `w`/`b` disambiguation
  - `window_textobject_test.exs`: 19 tests for `Window.next_textobject/3` and `prev_textobject/3` (empty, single, boundary, cross-type)
  - `protocol_textobject_positions_test.exs`: 8 tests for `TEXTOBJECT_POSITIONS` (0x39) decode (empty, single, multi-type, all 6 types, unknown type, order preservation, version)
  - `normal_bracket_nav_test.exs`: 11 tests for `]f`/`[f`, `]t`/`[t`, `]a`/`[a` dispatch, `a` key disambiguation, `=` operator entry
  - `editing_reindent_test.exs`: 9 tests for `==`, `=w`, `=G`, `=gg`, visual `=`, `=iw` mode transitions

- **Added reindent operator-pending tests** to the existing `operator_pending_test.exs`: `==`, `=w`, `=G`, `=gg`, `=if`, `=af` (7 new tests)

- **Bug fix in `visual.ex`**: `{` and `}` paragraph motion handlers now guard on `text_object_modifier: nil`. Previously, pressing `{` or `}` in visual mode always dispatched paragraph motion, even when a text object modifier was pending. This made `vi{` and `vi}` unreachable; the paragraph handler matched first.

- **Performance fix in `protocol.ex`**: `decode_textobject_entries` now uses prepend-then-reverse instead of `existing ++ [{row, col}]` in the accumulation loop. O(n) total instead of O(n²).

- **ROADMAP.md**: Added `=`/`==` to Operators table, `if`/`af`/`ic`/`ac`/`ia`/`aa`/`ib`/`ab` to Text Objects table, `]f`/`[f`/`]t`/`[t`/`]a`/`[a` to Motions table, visual text objects row.

- **PROTOCOL.md**: Added opcodes 0x36-0x39 to the summary table. Added full wire format spec for `TEXTOBJECT_POSITIONS` (0x39) including type ID table.

## Verification

```bash
mix lint                          # passes (format + credo --strict + dialyzer)
mix test --warnings-as-errors     # 4644 tests, 0 failures
```

To verify the bug fix:
1. Open Minga, enter visual mode (`v`)
2. Press `i` then `{` — should select inner braces (was: paragraph backward)
3. Press `a` then `}` — should select around braces (was: paragraph forward)

## Acceptance Criteria Addressed

- Unit tests for `==`, `=<motion>`, visual `=` reindent commands ✅
- Unit tests for visual text objects (`viw`, `vi"`, `vi(`, `vif`, `vaf`, etc.) ✅
- Unit tests for `text_object_modifier` state machine ✅
- Unit tests for `Window.next_textobject/3` and `Window.prev_textobject/3` ✅
- Protocol round-trip test for `TEXTOBJECT_POSITIONS` (0x39) ✅
- Mode dispatch tests for `]f`, `[f`, `]t`, `[t`, `]a`, `[a` ✅
- `decode_textobject_entries` uses prepend-then-reverse ✅
- ROADMAP.md updated with `=`/`==`, structural text objects, navigation ✅
- docs/PROTOCOL.md documents 0x39 opcode ✅
- `mix lint` and `mix test --warnings-as-errors` pass ✅
- `mix dialyzer` passes ✅