### PR TITLE
feat(editor): add modeline to agent chat windows

### DIFF
--- a/lib/minga/editor/render_pipeline.ex
+++ b/lib/minga/editor/render_pipeline.ex
@@ -769,11 +769,26 @@ defmodule Minga.Editor.RenderPipeline do
   def build_chrome(state, layout, scrolls, cursor_info) do
     full_viewport = state.viewport
 
-    # Modeline per window
+    # Modeline per buffer window
     {modeline_draws, modeline_click_regions} =
       Enum.reduce(scrolls, {%{}, []}, fn {win_id, scroll}, {draws_acc, regions_acc} ->
         {draws, regions} = ChromeHelpers.render_window_modeline(state, scroll)
         {Map.put(draws_acc, win_id, draws), regions ++ regions_acc}
+      end)
+
+    # Modeline per agent chat window (skipped in scrolls, rendered here)
+    {modeline_draws, modeline_click_regions} =
+      layout.window_layouts
+      |> Enum.reduce({modeline_draws, modeline_click_regions}, fn {win_id, win_layout},
+                                                                  {draws_acc, regions_acc} ->
+        window = Map.get(state.windows.map, win_id)
+
+        if window != nil and Content.agent_chat?(window.content) do
+          {draws, regions} = ChromeHelpers.render_agent_modeline(state, win_layout)
+          {Map.put(draws_acc, win_id, draws), regions ++ regions_acc}
+        else
+          {draws_acc, regions_acc}
+        end
       end)
 
     # Separators (vertical split borders)

--- a/lib/minga/editor/render_pipeline/chrome_helpers.ex
+++ b/lib/minga/editor/render_pipeline/chrome_helpers.ex
@@ -95,6 +95,63 @@ defmodule Minga.Editor.RenderPipeline.ChromeHelpers do
     )
   end
 
+  @doc """
+  Renders the modeline for an agent chat window.
+
+  Shows vim mode, macro recording, and agent session status instead of
+  the filename/filetype/position info that buffer modelines display.
+  """
+  @spec render_agent_modeline(state(), Layout.window_layout()) ::
+          {[DisplayList.draw()], [Modeline.click_region()]}
+  def render_agent_modeline(state, win_layout) do
+    {modeline_row, _mc, modeline_width, modeline_height} = win_layout.modeline
+
+    if modeline_height == 0 do
+      {[], []}
+    else
+      {_row_off, col_off, _cw, _ch} = win_layout.content
+      agent = AgentAccess.agent(state)
+      panel = AgentAccess.panel(state)
+
+      message_count =
+        if agent.session do
+          try do
+            length(Session.messages(agent.session))
+          catch
+            :exit, _ -> 0
+          end
+        else
+          0
+        end
+
+      model_label =
+        if panel.model_name != "", do: panel.model_name, else: "Agent"
+
+      Modeline.render(
+        modeline_row,
+        modeline_width,
+        %{
+          mode: state.vim.mode,
+          mode_state: state.vim.mode_state,
+          file_name: "󰚩 #{model_label}",
+          filetype: :text,
+          dirty_marker: "",
+          cursor_line: message_count,
+          cursor_col: 0,
+          line_count: max(message_count, 1),
+          buf_index: 1,
+          buf_count: 1,
+          macro_recording: MacroRecorder.recording?(state.vim.macro_recorder),
+          agent_status: agent.status,
+          agent_theme_colors: Theme.agent_theme(state.theme),
+          mode_override: nil
+        },
+        state.theme,
+        col_off
+      )
+    end
+  end
+
   # ── Separators ─────────────────────────────────────────────────────────────
 
   @doc "Renders vertical split separators between windows."

--- a/test/minga/integration/agent_cursor_test.exs
+++ b/test/minga/integration/agent_cursor_test.exs
@@ -79,10 +79,24 @@ defmodule Minga.Integration.AgentCursorTest do
     }
   end
 
-  # Finds the row number containing the given text substring.
+  # Finds the first row number containing the given text substring.
   @spec find_row_containing([String.t()], String.t()) :: non_neg_integer() | nil
   defp find_row_containing(rows, text) do
     Enum.find_index(rows, &String.contains?(&1, text))
+  end
+
+  # Finds the last row number containing the given text substring.
+  # Useful for finding the modeline when the same text appears in other UI areas.
+  @spec find_last_row_containing([String.t()], String.t()) :: non_neg_integer() | nil
+  defp find_last_row_containing(rows, text) do
+    rows
+    |> Enum.with_index()
+    |> Enum.filter(fn {row, _idx} -> String.contains?(row, text) end)
+    |> List.last()
+    |> case do
+      {_row, idx} -> idx
+      nil -> nil
+    end
   end
 
   # ── Tests ────────────────────────────────────────────────────────────────────
@@ -146,6 +160,53 @@ defmodule Minga.Integration.AgentCursorTest do
                "At #{width}x#{height}: cursor should be on row #{content_row}, " <>
                  "got row #{cursor_row}."
       end
+    end
+  end
+
+  describe "agent modeline" do
+    test "modeline shows vim mode and model name in agent view" do
+      ctx = start_agent_editor()
+
+      rows = screen_text(ctx)
+
+      # The modeline is the last row containing the model name (the sidebar
+      # also shows it, so we need the bottom-most occurrence).
+      modeline_idx = find_last_row_containing(rows, "claude-sonnet-4")
+      assert modeline_idx != nil, "Should find model name in the modeline"
+
+      modeline_text = Enum.at(rows, modeline_idx)
+
+      assert String.contains?(modeline_text, "NORMAL"),
+             "Modeline should show NORMAL mode, got: #{modeline_text}"
+    end
+
+    test "modeline shows INSERT mode after focusing input" do
+      ctx = start_agent_editor()
+
+      send_keys(ctx, "i")
+
+      rows = screen_text(ctx)
+
+      modeline_idx = find_last_row_containing(rows, "claude-sonnet-4")
+      assert modeline_idx != nil, "Should find modeline with model name"
+
+      modeline_text = Enum.at(rows, modeline_idx)
+
+      assert String.contains?(modeline_text, "INSERT"),
+             "Modeline should show INSERT mode after pressing i, got: #{modeline_text}"
+    end
+
+    test "modeline is below the input area" do
+      ctx = start_agent_editor()
+
+      rows = screen_text(ctx)
+
+      prompt_row = find_row_containing(rows, "Prompt")
+      modeline_row = find_last_row_containing(rows, "claude-sonnet-4")
+
+      assert prompt_row != nil, "Should find the prompt border"
+      assert modeline_row != nil, "Should find the modeline"
+      assert modeline_row > prompt_row, "Modeline should be below the prompt border"
     end
   end
 end


### PR DESCRIPTION
# TL;DR
Agent chat windows now show a Doom-style modeline at the bottom with vim mode, macro recording state, agent status, and model name. Previously the modeline row was allocated but never rendered, leaving a blank gap.

## Context
The `subdivide_window` function in Layout reserves one row for a modeline in every window, including agent chat windows. But agent chat windows were skipped in the scroll stage (they render separately), so the chrome stage never produced modeline draws for them. Result: a wasted blank row at the bottom of the agent view.

## Changes
- **Chrome stage** (`render_pipeline.ex`): After rendering buffer window modelines, iterates `window_layouts` to find agent chat windows and renders their modelines via a new helper.
- **`render_agent_modeline`** (`chrome_helpers.ex`): Builds Doom-style modeline data appropriate for a chat context: model name (instead of filename), message count (instead of cursor position), vim mode, macro recording indicator, and agent status icon.
- **Tests** (`agent_cursor_test.exs`): 3 new integration tests verify the modeline shows the correct mode badge, updates on mode transitions, and renders below the prompt input area.

## Verification
1. `mix test test/minga/integration/agent_cursor_test.exs` (6 tests, 0 failures)
2. `mix lint` and `mix dialyzer` both clean
3. Full suite: 4669 tests, 0 failures