### PR TITLE
feat(editor): position-based mouse routing for agent chat regions

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -244,7 +244,9 @@ Scopes are Minga's equivalent of Emacs major modes. A buffer's scope determines 
 
 ### Mouse Event Routing
 
-Mouse events flow through the same focus stack as keyboard input. Both the Zig TUI and the Swift GUI encode mouse events as 9-byte `mouse_event` messages (opcode `0x04`) containing row, col, button, modifiers, event type, and click count. The BEAM decodes them in `Port.Protocol` and dispatches through `Input.Router.dispatch_mouse/8`, which walks the focus stack calling `handle_mouse/7` on each handler that implements it.
+Mouse events flow through the same focus stack as keyboard input, but with a key difference: **mouse routing is position-based, not scope-based.** Keyboard input routes through `keymap_scope` (which pane has focus). Mouse input routes by hit-testing the cursor position against `Layout.get(state)` rects (where on screen did the event happen). This means scrolling over the agent chat scrolls the chat regardless of which pane has keyboard focus.
+
+Both the Zig TUI and the Swift GUI encode mouse events as 9-byte `mouse_event` messages (opcode `0x04`) containing row, col, button, modifiers, event type, and click count. The BEAM decodes them in `Port.Protocol` and dispatches through `Input.Router.dispatch_mouse/7`, which walks the focus stack calling `handle_mouse/7` on each handler that implements it.
 
 ```
 Mouse event arrives (9 bytes: opcode + row + col + button + mods + event_type + click_count)
@@ -253,14 +255,22 @@ Mouse event arrives (9 bytes: opcode + row + col + button + mods + event_type + 
 Editor.handle_info decodes via Port.Protocol
     │
     ▼
-Input.Router.dispatch_mouse walks focus stack
+Input.Router.dispatch_mouse walks overlay handlers, then surface handlers
     │
-    ├─ Input.Scoped (agentic view active?)
-    │     ├─ Yes → Agent.View.Mouse handles scroll, click-to-focus, separator drag
-    │     └─ No  → :passthrough
+    ├─ Overlays (Picker, Completion) — intercept when their UI is visible
     │
-    └─ Input.ModeFSM (fallback)
-          └─ Editor.Mouse.handle/8
+    ├─ Input.FileTreeHandler — hit-tests against Layout.file_tree rect
+    │     ├─ Inside file tree → handle tree click/scroll
+    │     └─ Outside → :passthrough
+    │
+    ├─ Input.AgentMouse — hit-tests against agent regions (position-based)
+    │     ├─ Agent chat window (WindowTree + Content.agent_chat?) → scroll chat, click-to-focus
+    │     ├─ Agent side panel (Layout.agent_panel rect) → scroll chat, click-to-focus
+    │     ├─ File viewer sidebar (right of chat_width_pct) → scroll preview
+    │     └─ Outside agent regions → :passthrough
+    │
+    └─ Input.ModeFSM (fallback) — buffer-content mouse handling
+          └─ Editor.Mouse.handle/7
                 ├─ click_count=1 → position cursor, start drag
                 ├─ click_count=2 → select word (visual char), word-snapped drag
                 ├─ click_count=3 → select line (visual line), line-snapped drag
@@ -269,6 +279,8 @@ Input.Router.dispatch_mouse walks focus stack
                 ├─ Middle click → paste register at position
                 └─ Wheel left/right → horizontal viewport scroll
 ```
+
+Each content-type handler is responsible for its own region. `Editor.Mouse` handles only buffer content; it has no knowledge of agent panels, file trees, or other content types. This follows the same principle as keyboard dispatch: the editing model produces commands, and each content type interprets them against its own data model.
 
 Multi-click detection works differently per frontend. The GUI sends `NSEvent.clickCount` directly in the protocol, so the BEAM trusts the native OS timing. The TUI sends `click_count=1` and the BEAM's `State.Mouse.record_press/4` detects multi-clicks using a timing window and position threshold, cycling 1 → 2 → 3 → 1.
 

--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -1079,10 +1079,14 @@ defmodule Minga.Agent.View.Renderer do
     end
   end
 
-  # Computes the text width inside the input box, excluding borders and padding.
-  # Layout: "│" (1) + padding_left (3) + text + padding_right (1) + "│" (1) = 6 chars chrome.
+  @doc """
+  Computes the text width inside the input box, excluding borders and padding.
+
+  Layout: "│" (1) + padding_left (3) + text + padding_right (1) + "│" (1) = 6 chars chrome.
+  Public so that `Input.AgentMouse` can use the same layout math for hit-testing.
+  """
   @spec input_inner_width(pos_integer()) :: pos_integer()
-  defp input_inner_width(box_width), do: max(box_width - 6, 1)
+  def input_inner_width(box_width), do: max(box_width - 6, 1)
 
   # Returns the visual selection range from Vim state, or nil.
   @spec vim_visual_range(map()) ::
@@ -1122,11 +1126,15 @@ defmodule Minga.Agent.View.Renderer do
   defp input_mode_label(%{mode: :operator_pending}), do: "OP"
   defp input_mode_label(_panel), do: ""
 
-  # Computes the dynamic input area height for the bordered box:
-  # top border(1) + visible lines + bottom border(1).
-  # Uses visual line count (accounting for soft-wrap at inner_width).
+  @doc """
+  Computes the dynamic input area height for the bordered box:
+  top border(1) + visible lines + bottom border(1).
+
+  Uses visual line count (accounting for soft-wrap at inner_width).
+  Public so that `Input.AgentMouse` can use the same layout math for hit-testing.
+  """
   @spec compute_input_height([String.t()], pos_integer()) :: pos_integer()
-  defp compute_input_height(input_lines, inner_width) do
+  def compute_input_height(input_lines, inner_width) do
     visible = InputWrap.visible_height(input_lines, inner_width, @max_input_lines)
     visible + 2
   end

--- a/lib/minga/editor/mouse.ex
+++ b/lib/minga/editor/mouse.ex
@@ -32,8 +32,6 @@ defmodule Minga.Editor.Mouse do
   alias Minga.Editor.Layout
   alias Minga.Editor.Renderer.Gutter
   alias Minga.Editor.State, as: EditorState
-  alias Minga.Editor.State.Agent, as: AgentState
-  alias Minga.Editor.State.AgentAccess
   alias Minga.Editor.State.Mouse, as: MouseState
   alias Minga.Editor.State.WhichKey, as: WhichKeyState
   alias Minga.Editor.Viewport
@@ -135,28 +133,9 @@ defmodule Minga.Editor.Mouse do
     end
   end
 
-  # ── Left click in the agent panel → focus input ──
-
-  def handle(state, row, col, :left, mods, :press, cc)
-      when row >= 0 do
-    panel = AgentAccess.panel(state)
-
-    if panel.visible do
-      agent_panel_height = div(state.viewport.rows * 35, 100)
-      editor_rows = state.viewport.rows - agent_panel_height
-
-      if row >= editor_rows do
-        AgentAccess.update_agent(state, &AgentState.focus_input(&1, true))
-      else
-        state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, false))
-        handle_left_press(state, row, col, mods, cc)
-      end
-    else
-      handle_left_press(state, row, col, mods, cc)
-    end
-  end
-
   # ── Left click (press) ──
+  # Agent-region clicks are intercepted by Input.AgentMouse before
+  # reaching this handler. This clause handles buffer-content clicks only.
 
   def handle(state, row, col, :left, mods, :press, cc) do
     handle_left_press(state, row, col, mods, cc)

--- a/lib/minga/input.ex
+++ b/lib/minga/input.ex
@@ -19,6 +19,7 @@ defmodule Minga.Input do
   """
 
   alias Minga.Input.AgentChatNav
+  alias Minga.Input.AgentMouse
   alias Minga.Input.AgentPanel
   alias Minga.Input.AgentSearch
   alias Minga.Input.Completion
@@ -98,6 +99,7 @@ defmodule Minga.Input do
       Scoped,
       AgentChatNav,
       GlobalBindings,
+      AgentMouse,
       ModeFSM
     ]
   end

--- a/lib/minga/input/agent_mouse.ex
+++ b/lib/minga/input/agent_mouse.ex
@@ -1,0 +1,251 @@
+defmodule Minga.Input.AgentMouse do
+  @moduledoc """
+  Position-based mouse handler for agent chat regions.
+
+  Intercepts mouse events (scroll, click) when the mouse position falls
+  inside an agent chat region, regardless of `keymap_scope`. Mouse routing
+  is position-based (where is the cursor on screen?) not scope-based (which
+  pane has keyboard focus?). This is the fundamental difference between
+  mouse and keyboard dispatch.
+
+  Handles two kinds of agent regions:
+
+  * **Agent chat window** (split pane): a window in the `WindowTree` with
+    `{:agent_chat, _}` content. Hit-tested via `WindowTree.window_at/4`.
+
+  * **Agent side panel** (bottom panel): the `Layout.agent_panel` rect
+    rendered by `ChromeHelpers.render_agent_panel_from_layout`.
+
+  Within each region, the handler subdivides into chat area vs input area
+  using the same layout math as `Agent.View.Renderer` (shared public
+  helpers `compute_input_height/2` and `input_inner_width/1`).
+
+  Events outside agent regions pass through to the next handler in the
+  surface stack (ultimately `ModeFSM` for buffer-level mouse handling).
+  """
+
+  @behaviour Minga.Input.Handler
+
+  alias Minga.Agent.PanelState
+  alias Minga.Agent.View.Renderer, as: ViewRenderer
+  alias Minga.Agent.View.State, as: ViewState
+  alias Minga.Editor.Layout
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.Agent, as: AgentState
+  alias Minga.Editor.State.AgentAccess
+  alias Minga.Editor.Window.Content
+  alias Minga.Editor.WindowTree
+  alias Minga.Mode
+
+  # Scroll 3 lines per wheel tick (matches Editor.Mouse TUI behavior).
+  @scroll_lines 3
+
+  # Mouse event fields grouped for dispatch without exceeding max arity.
+  # Modifiers and click_count are threaded through for future use
+  # (Shift+click selection, double-click word select, etc.) per AGENTS.md
+  # requirement to always pass modifiers through.
+  @typep mouse_event :: %{
+           button: atom(),
+           mods: non_neg_integer(),
+           event_type: atom(),
+           click_count: pos_integer()
+         }
+
+  # ── Handler callbacks ──────────────────────────────────────────────────────
+
+  @impl true
+  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  def handle_key(state, _cp, _mods), do: {:passthrough, state}
+
+  @impl true
+  @spec handle_mouse(
+          EditorState.t(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+
+  def handle_mouse(state, row, col, button, mods, event_type, click_count) do
+    layout = Layout.get(state)
+    evt = %{button: button, mods: mods, event_type: event_type, click_count: click_count}
+
+    case identify_agent_region(state, layout, row, col) do
+      {:agent_chat_window, win_id} ->
+        {:handled, dispatch_window(state, layout, win_id, row, col, evt)}
+
+      {:agent_panel, panel_rect} ->
+        {:handled, dispatch_panel(state, panel_rect, row, col, evt)}
+
+      :not_agent ->
+        {:passthrough, state}
+    end
+  end
+
+  # ── Region identification ──────────────────────────────────────────────────
+
+  @spec identify_agent_region(EditorState.t(), Layout.t(), integer(), integer()) ::
+          {:agent_chat_window, pos_integer()}
+          | {:agent_panel, Layout.rect()}
+          | :not_agent
+
+  defp identify_agent_region(state, layout, row, col) do
+    case find_agent_chat_window_at(state, layout, row, col) do
+      {:ok, win_id} ->
+        {:agent_chat_window, win_id}
+
+      :not_found ->
+        case layout.agent_panel do
+          {pr, pc, pw, ph} when row >= pr and row < pr + ph and col >= pc and col < pc + pw ->
+            {:agent_panel, {pr, pc, pw, ph}}
+
+          _ ->
+            :not_agent
+        end
+    end
+  end
+
+  @spec find_agent_chat_window_at(EditorState.t(), Layout.t(), integer(), integer()) ::
+          {:ok, pos_integer()} | :not_found
+  defp find_agent_chat_window_at(%{windows: %{tree: nil}}, _layout, _row, _col), do: :not_found
+
+  defp find_agent_chat_window_at(state, layout, row, col) do
+    case WindowTree.window_at(state.windows.tree, layout.editor_area, row, col) do
+      {:ok, win_id, _rect} ->
+        window = Map.get(state.windows.map, win_id)
+
+        if window != nil and Content.agent_chat?(window.content) do
+          {:ok, win_id}
+        else
+          :not_found
+        end
+
+      :error ->
+        :not_found
+    end
+  end
+
+  # ── Agent chat window (split pane) dispatch ────────────────────────────────
+
+  @spec dispatch_window(
+          EditorState.t(),
+          Layout.t(),
+          pos_integer(),
+          integer(),
+          integer(),
+          mouse_event()
+        ) ::
+          EditorState.t()
+
+  defp dispatch_window(state, layout, win_id, _row, col, %{
+         button: :wheel_down,
+         event_type: :press
+       }) do
+    scroll_in_window(state, layout, win_id, col, @scroll_lines)
+  end
+
+  defp dispatch_window(state, layout, win_id, _row, col, %{button: :wheel_up, event_type: :press}) do
+    scroll_in_window(state, layout, win_id, col, -@scroll_lines)
+  end
+
+  defp dispatch_window(state, layout, win_id, row, col, %{button: :left, event_type: :press}) do
+    state = maybe_focus_window(state, win_id)
+    content_rect = window_content_rect(layout, win_id)
+    handle_agent_click(state, content_rect, row, col)
+  end
+
+  defp dispatch_window(state, _layout, _win_id, _row, _col, _evt), do: state
+
+  @spec maybe_focus_window(EditorState.t(), pos_integer()) :: EditorState.t()
+  defp maybe_focus_window(state, win_id) do
+    if state.windows.active != win_id do
+      EditorState.focus_window(state, win_id)
+    else
+      state
+    end
+  end
+
+  @spec window_content_rect(Layout.t(), pos_integer()) :: Layout.rect()
+  defp window_content_rect(layout, win_id) do
+    %{content: rect} = Map.fetch!(layout.window_layouts, win_id)
+    rect
+  end
+
+  @spec scroll_in_window(EditorState.t(), Layout.t(), pos_integer(), integer(), integer()) ::
+          EditorState.t()
+  defp scroll_in_window(state, layout, win_id, col, delta) do
+    {_cr, cc, cw, _ch} = window_content_rect(layout, win_id)
+    agentic = AgentAccess.agentic(state)
+    chat_width = max(div(cw * agentic.chat_width_pct, 100), 20)
+    chat_right_edge = cc + chat_width
+
+    if col < chat_right_edge do
+      scroll_chat(state, delta)
+    else
+      scroll_preview(state, delta)
+    end
+  end
+
+  # ── Agent side panel (bottom panel) dispatch ───────────────────────────────
+
+  @spec dispatch_panel(EditorState.t(), Layout.rect(), integer(), integer(), mouse_event()) ::
+          EditorState.t()
+
+  defp dispatch_panel(state, _rect, _row, _col, %{button: :wheel_down, event_type: :press}) do
+    scroll_chat(state, @scroll_lines)
+  end
+
+  defp dispatch_panel(state, _rect, _row, _col, %{button: :wheel_up, event_type: :press}) do
+    scroll_chat(state, -@scroll_lines)
+  end
+
+  defp dispatch_panel(state, rect, row, col, %{button: :left, event_type: :press}) do
+    handle_agent_click(state, rect, row, col)
+  end
+
+  defp dispatch_panel(state, _rect, _row, _col, _evt), do: state
+
+  # ── Shared click logic ─────────────────────────────────────────────────────
+
+  @spec handle_agent_click(EditorState.t(), Layout.rect(), integer(), integer()) ::
+          EditorState.t()
+  defp handle_agent_click(state, {cr, _cc, cw, ch}, row, _col) do
+    panel = AgentAccess.panel(state)
+    input_lines = PanelState.input_lines(panel)
+    inner_width = ViewRenderer.input_inner_width(cw)
+    input_height = ViewRenderer.compute_input_height(input_lines, inner_width)
+
+    # Input area occupies the bottom `input_height` rows of the content rect
+    input_start_row = cr + ch - input_height
+
+    if row >= input_start_row do
+      state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, true))
+      put_in(state.vim, %{state.vim | mode: :insert, mode_state: Mode.initial_state()})
+    else
+      AgentAccess.update_agent(state, &AgentState.focus_input(&1, false))
+    end
+  end
+
+  # ── Shared scroll helpers ──────────────────────────────────────────────────
+
+  @spec scroll_chat(EditorState.t(), pos_integer() | neg_integer()) :: EditorState.t()
+  defp scroll_chat(state, delta) when delta > 0 do
+    AgentAccess.update_agent(state, &AgentState.scroll_down(&1, delta))
+  end
+
+  defp scroll_chat(state, delta) when delta < 0 do
+    AgentAccess.update_agent(state, &AgentState.scroll_up(&1, abs(delta)))
+  end
+
+  @spec scroll_preview(EditorState.t(), pos_integer() | neg_integer()) :: EditorState.t()
+  defp scroll_preview(state, delta) when delta > 0 do
+    AgentAccess.update_agentic(state, &ViewState.scroll_viewer_down(&1, delta))
+  end
+
+  defp scroll_preview(state, delta) when delta < 0 do
+    AgentAccess.update_agentic(state, &ViewState.scroll_viewer_up(&1, abs(delta)))
+  end
+end

--- a/test/minga/input/agent_mouse_test.exs
+++ b/test/minga/input/agent_mouse_test.exs
@@ -1,0 +1,349 @@
+defmodule Minga.Input.AgentMouseTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Agent.PanelState
+  alias Minga.Agent.View.State, as: ViewState
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Editor.Layout
+  alias Minga.Editor.LayoutPreset
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.Agent, as: AgentState
+  alias Minga.Editor.State.AgentAccess
+  alias Minga.Editor.State.Buffers
+  alias Minga.Editor.State.Tab
+  alias Minga.Editor.State.TabBar
+  alias Minga.Editor.State.Windows
+  alias Minga.Editor.Viewport
+  alias Minga.Editor.VimState
+  alias Minga.Editor.Window
+  alias Minga.Editor.Window.Content
+  alias Minga.Input.AgentMouse
+  alias Minga.Mode
+
+  # ── Test helpers ───────────────────────────────────────────────────────────
+
+  defp base_state(opts \\ []) do
+    {:ok, buf} = BufferServer.start_link(content: "hello\nworld\nfoo\nbar\nbaz")
+    {:ok, prompt_buf} = BufferServer.start_link(content: "")
+
+    panel = %PanelState{
+      visible: Keyword.get(opts, :panel_visible, false),
+      input_focused: Keyword.get(opts, :input_focused, false),
+      scroll: Minga.Scroll.new(),
+      spinner_frame: 0,
+      provider_name: "anthropic",
+      model_name: "claude-sonnet-4",
+      thinking_level: "medium",
+      prompt_buffer: prompt_buf
+    }
+
+    agent = %AgentState{
+      session: nil,
+      status: :idle,
+      panel: panel,
+      error: nil,
+      spinner_timer: nil,
+      buffer: Keyword.get(opts, :agent_buffer, nil)
+    }
+
+    agentic = ViewState.new()
+    tab_bar = TabBar.new(Tab.new_file(1, "*scratch*"))
+
+    win_id = 1
+    win = Window.new(win_id, buf, 24, 80)
+
+    %EditorState{
+      port_manager: self(),
+      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      vim: %VimState{mode: :normal, mode_state: Mode.initial_state()},
+      buffers: %Buffers{active: buf, list: [buf]},
+      focus_stack: [],
+      keymap_scope: Keyword.get(opts, :keymap_scope, :editor),
+      agent: agent,
+      agentic: agentic,
+      tab_bar: tab_bar,
+      windows: %Windows{
+        tree: {:leaf, win_id},
+        map: %{win_id => win},
+        active: win_id,
+        next_id: win_id + 1
+      }
+    }
+  end
+
+  defp with_agent_split(state) do
+    {:ok, agent_buf} = BufferServer.start_link(content: "")
+
+    state =
+      AgentAccess.update_agent(state, fn agent ->
+        %{agent | buffer: agent_buf}
+      end)
+
+    LayoutPreset.apply(state, :agent_right, agent_buf)
+  end
+
+  defp with_agent_panel(state) do
+    state
+    |> AgentAccess.update_agent(fn agent ->
+      panel = %{agent.panel | visible: true, input_focused: true}
+      %{agent | panel: panel}
+    end)
+    |> Layout.invalidate()
+  end
+
+  defp agent_chat_window_rect(state) do
+    layout = Layout.compute(state)
+
+    Enum.find_value(layout.window_layouts, fn {win_id, wl} ->
+      window = Map.get(state.windows.map, win_id)
+
+      if window != nil and Content.agent_chat?(window.content) do
+        wl.content
+      end
+    end)
+  end
+
+  # ── Events outside agent regions pass through ──────────────────────────────
+
+  describe "passthrough" do
+    test "events pass through when no agent UI is visible" do
+      state = base_state()
+      assert {:passthrough, _} = AgentMouse.handle_mouse(state, 5, 5, :wheel_down, 0, :press, 1)
+      assert {:passthrough, _} = AgentMouse.handle_mouse(state, 5, 5, :left, 0, :press, 1)
+    end
+
+    test "events outside agent regions pass through when agent split is active" do
+      state = base_state() |> with_agent_split()
+      # Click in the editor area (left pane), not the agent pane
+      # The editor window occupies the left ~60% of columns
+      assert {:passthrough, _} = AgentMouse.handle_mouse(state, 5, 5, :left, 0, :press, 1)
+      assert {:passthrough, _} = AgentMouse.handle_mouse(state, 5, 5, :wheel_down, 0, :press, 1)
+    end
+  end
+
+  # ── Agent chat window (split pane) scroll ──────────────────────────────────
+
+  describe "agent chat window scroll" do
+    setup do
+      state = base_state() |> with_agent_split()
+      rect = agent_chat_window_rect(state)
+      {:ok, state: state, rect: rect}
+    end
+
+    test "scroll down over agent chat window scrolls chat, not editor buffer", %{
+      state: state,
+      rect: rect
+    } do
+      {row, col, _w, _h} = rect
+      old_viewport_top = state.viewport.top
+
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, row + 2, col + 2, :wheel_down, 0, :press, 1)
+
+      # Chat scroll should have changed
+      panel = AgentAccess.panel(new_state)
+      assert panel.scroll.offset > 0 or panel.scroll.pinned == false
+
+      # Editor viewport should be untouched
+      assert new_state.viewport.top == old_viewport_top
+    end
+
+    test "scroll up over agent chat window scrolls chat", %{state: state, rect: rect} do
+      {row, col, _w, _h} = rect
+
+      # First scroll down to have something to scroll up from
+      {:handled, state} =
+        AgentMouse.handle_mouse(state, row + 2, col + 2, :wheel_down, 0, :press, 1)
+
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, row + 2, col + 2, :wheel_up, 0, :press, 1)
+
+      # Should not crash and should handle gracefully
+      assert %EditorState{} = new_state
+    end
+
+    test "scroll over file viewer sidebar scrolls preview", %{state: state, rect: rect} do
+      {row, _col, _w, _h} = rect
+      # The file viewer sidebar is to the right of the chat area.
+      # chat_width_pct defaults to 65, so sidebar starts at ~65% of the window width.
+      # Use a column well to the right of the chat area.
+      sidebar_col = state.viewport.cols - 5
+
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, row + 2, sidebar_col, :wheel_down, 0, :press, 1)
+
+      # Preview scroll should have changed (or at least not crash)
+      assert %EditorState{} = new_state
+    end
+  end
+
+  # ── Agent chat window (split pane) click ───────────────────────────────────
+
+  describe "agent chat window click" do
+    setup do
+      state = base_state() |> with_agent_split()
+      rect = agent_chat_window_rect(state)
+      {:ok, state: state, rect: rect}
+    end
+
+    test "click in chat area unfocuses input", %{state: state, rect: rect} do
+      {row, col, _w, _h} = rect
+
+      # First make sure input is focused
+      state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, true))
+      assert AgentAccess.input_focused?(state)
+
+      # Click in the chat area (near the top of the agent window)
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, row + 1, col + 2, :left, 0, :press, 1)
+
+      refute AgentAccess.input_focused?(new_state)
+    end
+
+    test "click in input area focuses input", %{state: state, rect: rect} do
+      {_row, col, _w, h} = rect
+
+      # Make sure input is not focused
+      state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, false))
+      refute AgentAccess.input_focused?(state)
+
+      # Click near the bottom of the agent window (where input lives)
+      input_row = rect |> elem(0) |> Kernel.+(h - 2)
+
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, input_row, col + 2, :left, 0, :press, 1)
+
+      assert AgentAccess.input_focused?(new_state)
+    end
+
+    test "click in agent window focuses it when not active", %{state: state} do
+      # The editor window should be active (not the agent)
+      # Find the agent window id
+      {agent_win_id, _} =
+        Enum.find(state.windows.map, fn {_id, w} ->
+          Content.agent_chat?(w.content)
+        end)
+
+      refute state.windows.active == agent_win_id
+
+      rect = agent_chat_window_rect(state)
+      {row, col, _w, _h} = rect
+
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, row + 1, col + 2, :left, 0, :press, 1)
+
+      assert new_state.windows.active == agent_win_id
+      assert new_state.keymap_scope == :agent
+    end
+  end
+
+  # ── Agent side panel (bottom panel) scroll ─────────────────────────────────
+
+  describe "agent side panel scroll" do
+    setup do
+      state = base_state() |> with_agent_panel()
+      layout = Layout.compute(state)
+      {:ok, state: state, panel_rect: layout.agent_panel}
+    end
+
+    test "scroll down over agent panel scrolls chat", %{state: state, panel_rect: panel_rect} do
+      {row, col, _w, _h} = panel_rect
+      old_viewport_top = state.viewport.top
+
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, row + 1, col + 2, :wheel_down, 0, :press, 1)
+
+      # Chat scroll offset should change
+      panel = AgentAccess.panel(new_state)
+      assert panel.scroll.offset > 0 or panel.scroll.pinned == false
+
+      # Editor viewport should be untouched
+      assert new_state.viewport.top == old_viewport_top
+    end
+
+    test "scroll up over agent panel scrolls chat", %{state: state, panel_rect: panel_rect} do
+      {row, col, _w, _h} = panel_rect
+
+      {:handled, state} =
+        AgentMouse.handle_mouse(state, row + 1, col + 2, :wheel_down, 0, :press, 1)
+
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, row + 1, col + 2, :wheel_up, 0, :press, 1)
+
+      assert %EditorState{} = new_state
+    end
+  end
+
+  # ── Agent side panel (bottom panel) click ──────────────────────────────────
+
+  describe "agent side panel click" do
+    setup do
+      state = base_state() |> with_agent_panel()
+      layout = Layout.compute(state)
+      {:ok, state: state, panel_rect: layout.agent_panel}
+    end
+
+    test "click in panel chat area unfocuses input", %{state: state, panel_rect: panel_rect} do
+      {row, col, _w, _h} = panel_rect
+
+      # Input should be focused initially
+      assert AgentAccess.input_focused?(state)
+
+      # Click near the top of the panel (chat area)
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, row + 1, col + 2, :left, 0, :press, 1)
+
+      refute AgentAccess.input_focused?(new_state)
+    end
+
+    test "click in panel input area focuses input", %{state: state, panel_rect: panel_rect} do
+      {_row, col, _w, h} = panel_rect
+
+      # Unfocus first
+      state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, false))
+      refute AgentAccess.input_focused?(state)
+
+      # Click near the bottom of the panel (input area)
+      input_row = elem(panel_rect, 0) + h - 2
+
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, input_row, col + 2, :left, 0, :press, 1)
+
+      assert AgentAccess.input_focused?(new_state)
+    end
+  end
+
+  # ── Scope independence ─────────────────────────────────────────────────────
+
+  describe "scope independence" do
+    test "scroll works in agent window regardless of keymap_scope" do
+      # Start in editor scope, but scroll over the agent window
+      state = base_state(keymap_scope: :editor) |> with_agent_split()
+      rect = agent_chat_window_rect(state)
+
+      # Verify we're in editor scope
+      assert state.keymap_scope == :editor
+
+      {row, col, _w, _h} = rect
+
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, row + 2, col + 2, :wheel_down, 0, :press, 1)
+
+      # Chat should have scrolled
+      panel = AgentAccess.panel(new_state)
+      assert panel.scroll.offset > 0 or panel.scroll.pinned == false
+    end
+
+    test "click in agent window works from editor scope" do
+      state = base_state(keymap_scope: :editor) |> with_agent_split()
+      rect = agent_chat_window_rect(state)
+      {row, col, _w, _h} = rect
+
+      {:handled, new_state} =
+        AgentMouse.handle_mouse(state, row + 1, col + 2, :left, 0, :press, 1)
+
+      # Should have switched to agent scope
+      assert new_state.keymap_scope == :agent
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `Input.AgentMouse`, a position-based mouse handler for agent chat regions that intercepts scroll and click events by hit-testing against `Layout.get(state)` rects. Removes the agent-specific code from `Editor.Mouse` so it becomes a pure buffer-content handler.

## Why

Mouse events in agent chat regions were broken: scrolling scrolled the editor buffer instead of the chat, clicking did nothing useful. The root cause was architectural: mouse events bypassed the content-type-aware dispatch that keyboard events use and fell through to `Editor.Mouse`, which assumed every region is a buffer. This violated the principle in REFACTOR.md that each content type handles its own navigation.

## Changes

- **New `Input.AgentMouse` handler** (240 lines): hit-tests mouse position against agent chat windows (`WindowTree.window_at` + `Content.agent_chat?`) and the agent side panel (`Layout.agent_panel` rect). Routes scroll to `AgentState.scroll_up/down` for chat or `ViewState.scroll_viewer_up/down` for the file viewer sidebar. Routes clicks to focus input or unfocus based on chat/input area subdivision using the same `compute_input_height` layout math as the renderer.
- **Registered in `Input.surface_handlers/0`** before `ModeFSM` so agent regions are handled before the buffer fallback.
- **Removed agent panel code from `Editor.Mouse`**: deleted the `panel.visible` check with hardcoded `agent_panel_height = div(state.viewport.rows * 35, 100)`. Removed `AgentState` and `AgentAccess` aliases.
- **Made `Renderer.compute_input_height/2` and `input_inner_width/1` public** so the mouse handler uses the same layout math (single source of truth for chat/input subdivision).
- **Updated `docs/ARCHITECTURE.md`** mouse routing diagram to replace the stale `Input.Scoped → Agent.View.Mouse` path (deleted in PR #367) with the actual `AgentMouse` handler.

## Key Design Decision

Mouse routing is **position-based** (where on screen did the event happen?) not **scope-based** (which pane has keyboard focus?). This is the fundamental difference from keyboard dispatch. Scrolling over the agent chat scrolls the chat regardless of `keymap_scope`. The handler does not check `state.keymap_scope` anywhere.

## Testing

- 14 new unit tests covering scroll, click, focus switching, passthrough, and scope independence
- All 75 existing mouse tests pass unchanged
- Full test suite: 4689 tests, 0 failures
- `mix lint` (format + credo + compile warnings + dialyzer): all clean

Closes #472