### PR TITLE
fix(editor): linewise yank (yy) followed by paste (p/P) now inserts as new lines

### DIFF
--- a/lib/minga/editor/commands/editing.ex
+++ b/lib/minga/editor/commands/editing.ex
@@ -11,6 +11,7 @@ defmodule Minga.Editor.Commands.Editing do
   alias Minga.Editor.Commands.Helpers
   alias Minga.Editor.Indent
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.Registers
   alias Minga.Mode
   alias Minga.Mode.ReplaceState
   alias Minga.Mode.VisualState
@@ -237,28 +238,27 @@ defmodule Minga.Editor.Commands.Editing do
   # ── Paste ─────────────────────────────────────────────────────────────────
 
   def execute(%{buffers: %{active: buf}} = state, :paste_before) do
-    {text, state} = Helpers.get_register(state)
+    {text, reg_type, state} = Helpers.get_register(state)
 
     case text do
       nil ->
         state
 
       t ->
-        BufferServer.insert_char(buf, t)
+        paste_content(buf, t, reg_type, :before)
         state
     end
   end
 
   def execute(%{buffers: %{active: buf}} = state, :paste_after) do
-    {text, state} = Helpers.get_register(state)
+    {text, reg_type, state} = Helpers.get_register(state)
 
     case text do
       nil ->
         state
 
       t ->
-        BufferServer.move(buf, :right)
-        BufferServer.insert_char(buf, t)
+        paste_content(buf, t, reg_type, :after)
         state
     end
   end
@@ -719,5 +719,55 @@ defmodule Minga.Editor.Commands.Editing do
       {_, idx} -> idx
       nil -> 0
     end
+  end
+
+  # ── Paste helpers ──────────────────────────────────────────────────────────
+
+  # Pastes text into the buffer, handling linewise vs charwise differently.
+  # Linewise: opens a new line above/below and inserts the content there.
+  # Charwise: inserts inline at (or one past) the cursor position.
+  @spec paste_content(pid(), String.t(), Registers.reg_type(), :before | :after) :: :ok
+  defp paste_content(buf, text, :linewise, direction) do
+    {line, _col} = BufferServer.cursor(buf)
+    # Strip the trailing newline that linewise yanks append
+    content = String.trim_trailing(text, "\n")
+
+    case direction do
+      :after ->
+        line_text = BufferServer.get_lines(buf, line, 1) |> List.first() |> then(&(&1 || ""))
+        BufferServer.move_to(buf, {line, byte_size(line_text)})
+        BufferServer.insert_char(buf, "\n" <> content)
+        BufferServer.move_to(buf, {line + 1, 0})
+        move_to_first_nonblank(buf)
+
+      :before ->
+        BufferServer.move_to(buf, {line, 0})
+        BufferServer.insert_char(buf, content <> "\n")
+        BufferServer.move_to(buf, {line, 0})
+        move_to_first_nonblank(buf)
+    end
+
+    :ok
+  end
+
+  defp paste_content(buf, text, :charwise, :before) do
+    BufferServer.insert_char(buf, text)
+    :ok
+  end
+
+  defp paste_content(buf, text, :charwise, :after) do
+    BufferServer.move(buf, :right)
+    BufferServer.insert_char(buf, text)
+    :ok
+  end
+
+  # Moves cursor to the first non-whitespace character on the current line.
+  @spec move_to_first_nonblank(pid()) :: :ok
+  defp move_to_first_nonblank(buf) do
+    {line, _col} = BufferServer.cursor(buf)
+    line_text = BufferServer.get_lines(buf, line, 1) |> List.first() |> then(&(&1 || ""))
+    indent = byte_size(line_text) - byte_size(String.trim_leading(line_text))
+    BufferServer.move_to(buf, {line, indent})
+    :ok
   end
 end

--- a/lib/minga/editor/commands/helpers.ex
+++ b/lib/minga/editor/commands/helpers.ex
@@ -39,17 +39,50 @@ defmodule Minga.Editor.Commands.Helpers do
   system clipboard. The 4-arity version lets callers override this
   explicitly (useful in tests to avoid depending on global Options state).
   """
-  @spec put_register(state(), String.t(), :yank | :delete) :: state()
-  def put_register(state, text, kind) do
-    put_register(state, text, kind, resolve_clipboard(state))
+  @spec put_register(state(), String.t(), :yank | :delete, Registers.reg_type()) :: state()
+  def put_register(state, text, kind, reg_type \\ :charwise) do
+    put_register_with_clipboard(state, text, kind, reg_type, resolve_clipboard(state))
   end
 
-  @spec put_register(state(), String.t(), :yank | :delete, clipboard_mode()) :: state()
-  def put_register(%{vim: %{reg: %{active: "_"}}} = state, _text, _kind, _clipboard) do
+  @doc """
+  Like `put_register/4` but with an explicit clipboard mode override.
+  Used in tests to avoid depending on global Options state.
+  """
+  @spec put_register_with_clipboard_override(
+          state(),
+          String.t(),
+          :yank | :delete,
+          Registers.reg_type(),
+          clipboard_mode()
+        ) :: state()
+  def put_register_with_clipboard_override(state, text, kind, reg_type, clipboard) do
+    put_register_with_clipboard(state, text, kind, reg_type, clipboard)
+  end
+
+  @spec put_register_with_clipboard(
+          state(),
+          String.t(),
+          :yank | :delete,
+          Registers.reg_type(),
+          clipboard_mode()
+        ) :: state()
+  defp put_register_with_clipboard(
+         %{vim: %{reg: %{active: "_"}}} = state,
+         _text,
+         _kind,
+         _reg_type,
+         _clipboard
+       ) do
     reset_active_register(state)
   end
 
-  def put_register(%{vim: %{reg: %{active: "+"}}} = state, text, kind, _clipboard) do
+  defp put_register_with_clipboard(
+         %{vim: %{reg: %{active: "+"}}} = state,
+         text,
+         kind,
+         reg_type,
+         _clipboard
+       ) do
     case Clipboard.write(text) do
       :ok ->
         :ok
@@ -61,39 +94,60 @@ defmodule Minga.Editor.Commands.Helpers do
         Minga.Log.warning(:editor, "Clipboard: write failed (#{reason})")
     end
 
-    state |> write_unnamed(text) |> maybe_write_yank(text, kind) |> reset_active_register()
+    state
+    |> write_unnamed(text, reg_type)
+    |> maybe_write_yank(text, kind, reg_type)
+    |> reset_active_register()
   end
 
-  def put_register(%{vim: %{reg: %{active: name} = reg}} = state, text, kind, clipboard)
-      when name >= "A" and name <= "Z" do
+  defp put_register_with_clipboard(
+         %{vim: %{reg: %{active: name} = reg}} = state,
+         text,
+         kind,
+         reg_type,
+         clipboard
+       )
+       when name >= "A" and name <= "Z" do
     lower = String.downcase(name)
-    existing = Registers.get(reg, lower) || ""
-    appended = existing <> text
+
+    {existing_text, _existing_type} =
+      case Registers.get(reg, lower) do
+        {t, ty} -> {t, ty}
+        nil -> {"", :charwise}
+      end
+
+    appended = existing_text <> text
 
     state
-    |> put_in_register(lower, appended)
-    |> write_unnamed(text)
-    |> maybe_write_yank(text, kind)
+    |> put_in_register(lower, appended, reg_type)
+    |> write_unnamed(text, reg_type)
+    |> maybe_write_yank(text, kind, reg_type)
     |> maybe_sync_clipboard(text, clipboard)
     |> reset_active_register()
   end
 
-  def put_register(%{vim: %{reg: %{active: name}}} = state, text, kind, clipboard)
-      when name >= "a" and name <= "z" do
+  defp put_register_with_clipboard(
+         %{vim: %{reg: %{active: name}}} = state,
+         text,
+         kind,
+         reg_type,
+         clipboard
+       )
+       when name >= "a" and name <= "z" do
     state
-    |> put_in_register(name, text)
-    |> write_unnamed(text)
-    |> maybe_write_yank(text, kind)
+    |> put_in_register(name, text, reg_type)
+    |> write_unnamed(text, reg_type)
+    |> maybe_write_yank(text, kind, reg_type)
     |> maybe_sync_clipboard(text, clipboard)
     |> reset_active_register()
   end
 
-  def put_register(state, text, kind, clipboard) do
+  defp put_register_with_clipboard(state, text, kind, reg_type, clipboard) do
     name = if state.vim.reg.active == "", do: "", else: state.vim.reg.active
 
     state
-    |> put_in_register(name, text)
-    |> maybe_write_yank(text, kind)
+    |> put_in_register(name, text, reg_type)
+    |> maybe_write_yank(text, kind, reg_type)
     |> maybe_sync_clipboard(text, clipboard)
     |> reset_active_register()
   end
@@ -109,59 +163,77 @@ defmodule Minga.Editor.Commands.Helpers do
   Reads `clipboard_mode` from `state` by default. The 2-arity version
   lets callers override this explicitly for testing.
   """
-  @spec get_register(state()) :: {String.t() | nil, state()}
+  @spec get_register(state()) :: {String.t() | nil, Registers.reg_type(), state()}
   def get_register(state) do
     get_register(state, resolve_clipboard(state))
   end
 
-  @spec get_register(state(), clipboard_mode()) :: {String.t() | nil, state()}
+  @spec get_register(state(), clipboard_mode()) ::
+          {String.t() | nil, Registers.reg_type(), state()}
   def get_register(%{vim: %{reg: %{active: "+"}}} = state, _clipboard) do
     text = Clipboard.read()
-    {text, reset_active_register(state)}
+    {text, :charwise, reset_active_register(state)}
   end
 
   def get_register(%{vim: %{reg: reg}} = state, clipboard) do
     key = if reg.active == "", do: "", else: reg.active
-    stored = Registers.get(reg, key)
-    text = maybe_read_clipboard(key, stored, clipboard)
-    {text, reset_active_register(state)}
+    entry = Registers.get(reg, key)
+
+    {text, reg_type} =
+      case entry do
+        {t, ty} -> {t, ty}
+        nil -> {nil, :charwise}
+      end
+
+    {final_text, final_type} = maybe_read_clipboard(key, text, reg_type, clipboard)
+    {final_text, final_type, reset_active_register(state)}
   end
 
   # When pasting from the unnamed register with clipboard sync enabled,
   # check the system clipboard. If its content differs from what we stored,
   # the user copied something externally, so prefer the clipboard content.
-  @spec maybe_read_clipboard(String.t(), String.t() | nil, clipboard_mode()) :: String.t() | nil
-  defp maybe_read_clipboard("", stored, clipboard) do
+  # Clipboard reads are always :charwise since we have no type metadata.
+  @spec maybe_read_clipboard(
+          String.t(),
+          String.t() | nil,
+          Registers.reg_type(),
+          clipboard_mode()
+        ) :: {String.t() | nil, Registers.reg_type()}
+  defp maybe_read_clipboard("", stored, reg_type, clipboard) do
     if clipboard in [:unnamedplus, :unnamed] do
-      read_clipboard_or_fallback(stored)
+      read_clipboard_or_fallback(stored, reg_type)
     else
-      stored
+      {stored, reg_type}
     end
   end
 
-  defp maybe_read_clipboard(_key, stored, _clipboard), do: stored
+  defp maybe_read_clipboard(_key, stored, reg_type, _clipboard), do: {stored, reg_type}
 
-  @spec read_clipboard_or_fallback(String.t() | nil) :: String.t() | nil
-  defp read_clipboard_or_fallback(stored) do
+  @spec read_clipboard_or_fallback(String.t() | nil, Registers.reg_type()) ::
+          {String.t() | nil, Registers.reg_type()}
+  defp read_clipboard_or_fallback(stored, reg_type) do
     case Clipboard.read() do
-      nil -> stored
-      "" -> stored
-      clipboard_text when clipboard_text != stored -> clipboard_text
-      _same -> stored
+      nil -> {stored, reg_type}
+      "" -> {stored, reg_type}
+      clipboard_text when clipboard_text != stored -> {clipboard_text, :charwise}
+      _same -> {stored, reg_type}
     end
   end
 
-  @spec put_in_register(state(), String.t(), String.t()) :: state()
-  def put_in_register(state, name, text) do
-    %{state | vim: %{state.vim | reg: Registers.put(state.vim.reg, name, text)}}
+  @spec put_in_register(state(), String.t(), String.t(), Registers.reg_type()) :: state()
+  def put_in_register(state, name, text, reg_type \\ :charwise) do
+    %{state | vim: %{state.vim | reg: Registers.put(state.vim.reg, name, text, reg_type)}}
   end
 
-  @spec write_unnamed(state(), String.t()) :: state()
-  def write_unnamed(state, text), do: put_in_register(state, "", text)
+  @spec write_unnamed(state(), String.t(), Registers.reg_type()) :: state()
+  def write_unnamed(state, text, reg_type \\ :charwise),
+    do: put_in_register(state, "", text, reg_type)
 
-  @spec maybe_write_yank(state(), String.t(), :yank | :delete) :: state()
-  def maybe_write_yank(state, text, :yank), do: put_in_register(state, "0", text)
-  def maybe_write_yank(state, _text, :delete), do: state
+  @spec maybe_write_yank(state(), String.t(), :yank | :delete, Registers.reg_type()) :: state()
+  def maybe_write_yank(state, text, :yank, reg_type),
+    do: put_in_register(state, "0", text, reg_type)
+
+  def maybe_write_yank(state, _text, :delete, _reg_type), do: state
 
   @doc """
   Syncs text to the system clipboard when the `clipboard` option is set

--- a/lib/minga/editor/commands/operators.ex
+++ b/lib/minga/editor/commands/operators.ex
@@ -33,19 +33,19 @@ defmodule Minga.Editor.Commands.Operators do
     {line, _col} = BufferServer.cursor(buf)
     yanked = BufferServer.get_lines_content(buf, line, line)
     BufferServer.delete_lines(buf, line, line)
-    Helpers.put_register(state, yanked <> "\n", :delete)
+    Helpers.put_register(state, yanked <> "\n", :delete, :linewise)
   end
 
   def execute(%{buffers: %{active: buf}} = state, :change_line) do
     {line, _col} = BufferServer.cursor(buf)
     {:ok, yanked} = BufferServer.clear_line(buf, line)
-    Helpers.put_register(state, yanked <> "\n", :delete)
+    Helpers.put_register(state, yanked <> "\n", :delete, :linewise)
   end
 
   def execute(%{buffers: %{active: buf}} = state, :yank_line) do
     {line, _col} = BufferServer.cursor(buf)
     yanked = BufferServer.get_lines_content(buf, line, line)
-    Helpers.put_register(state, yanked <> "\n", :yank)
+    Helpers.put_register(state, yanked <> "\n", :yank, :linewise)
   end
 
   # ── Text object operators ─────────────────────────────────────────────────

--- a/lib/minga/editor/commands/visual.ex
+++ b/lib/minga/editor/commands/visual.ex
@@ -23,12 +23,12 @@ defmodule Minga.Editor.Commands.Visual do
     visual_type = ms.visual_type
     cursor = BufferServer.cursor(buf)
 
-    yanked =
+    {yanked, reg_type} =
       case visual_type do
         :char ->
           text = BufferServer.get_range(buf, anchor, cursor)
           BufferServer.delete_range(buf, anchor, cursor)
-          text
+          {text, :charwise}
 
         :line ->
           {anchor_line, _} = anchor
@@ -37,10 +37,10 @@ defmodule Minga.Editor.Commands.Visual do
           end_line = max(anchor_line, cursor_line)
           text = BufferServer.get_lines_content(buf, start_line, end_line)
           BufferServer.delete_lines(buf, start_line, end_line)
-          text <> "\n"
+          {text <> "\n", :linewise}
       end
 
-    Helpers.put_register(state, yanked, :delete)
+    Helpers.put_register(state, yanked, :delete, reg_type)
   end
 
   def execute(
@@ -51,20 +51,20 @@ defmodule Minga.Editor.Commands.Visual do
     visual_type = ms.visual_type
     cursor = BufferServer.cursor(buf)
 
-    yanked =
+    {yanked, reg_type} =
       case visual_type do
         :char ->
-          BufferServer.get_range(buf, anchor, cursor)
+          {BufferServer.get_range(buf, anchor, cursor), :charwise}
 
         :line ->
           {anchor_line, _} = anchor
           {cursor_line, _} = cursor
           start_line = min(anchor_line, cursor_line)
           end_line = max(anchor_line, cursor_line)
-          BufferServer.get_lines_content(buf, start_line, end_line) <> "\n"
+          {BufferServer.get_lines_content(buf, start_line, end_line) <> "\n", :linewise}
       end
 
-    Helpers.put_register(state, yanked, :yank)
+    Helpers.put_register(state, yanked, :yank, reg_type)
   end
 
   def execute(

--- a/lib/minga/editor/state/registers.ex
+++ b/lib/minga/editor/state/registers.ex
@@ -4,7 +4,17 @@ defmodule Minga.Editor.State.Registers do
 
   Tracks the named register store and the currently selected register
   (set by `\"x` before an operator).
+
+  Each register entry is a `{text, type}` tuple where type is `:charwise`
+  or `:linewise`. Linewise entries (from `yy`, `dd`, visual-line yank)
+  paste as new lines; charwise entries paste inline at the cursor.
   """
+
+  @typedoc "Whether register content should paste as whole lines or inline text."
+  @type reg_type :: :charwise | :linewise
+
+  @typedoc "A register entry: text content paired with its paste type."
+  @type entry :: {String.t(), reg_type()}
 
   @typedoc """
   Register store. Keys are register names:
@@ -14,7 +24,7 @@ defmodule Minga.Editor.State.Registers do
   - `\"+\"` — system clipboard (virtual; read/write via Minga.Clipboard)
   - `\"_\"` — black hole (never stored)
   """
-  @type registers :: %{String.t() => String.t()}
+  @type registers :: %{String.t() => entry()}
 
   @type t :: %__MODULE__{
           registers: registers(),
@@ -24,16 +34,20 @@ defmodule Minga.Editor.State.Registers do
   defstruct registers: %{},
             active: ""
 
-  @doc "Puts `text` into the named register `name`."
-  @spec put(t(), String.t(), String.t()) :: t()
-  def put(%__MODULE__{} = reg, name, text) do
-    %{reg | registers: Map.put(reg.registers, name, text)}
+  @doc "Puts `text` into the named register `name` with the given type."
+  @spec put(t(), String.t(), String.t(), reg_type()) :: t()
+  def put(%__MODULE__{} = reg, name, text, type \\ :charwise) do
+    %{reg | registers: Map.put(reg.registers, name, {text, type})}
   end
 
-  @doc "Gets the value of the named register `name`."
-  @spec get(t(), String.t()) :: String.t() | nil
+  @doc "Gets the entry for the named register `name`. Returns `{text, type}` or `nil`."
+  @spec get(t(), String.t()) :: entry() | nil
   def get(%__MODULE__{registers: regs}, name) do
-    Map.get(regs, name)
+    case Map.get(regs, name) do
+      # Migrate bare strings from old format (e.g., tests, deserialized state)
+      text when is_binary(text) -> {text, :charwise}
+      other -> other
+    end
   end
 
   @doc "Resets the active register selection to unnamed."

--- a/test/minga/editor/commands/clipboard_sync_test.exs
+++ b/test/minga/editor/commands/clipboard_sync_test.exs
@@ -61,7 +61,14 @@ defmodule Minga.Editor.Commands.ClipboardSyncTest do
     test "yy syncs to system clipboard", %{clipboard: agent} do
       sentinel = "yank-sync-#{System.unique_integer([:positive])}"
       state = make_state()
-      Helpers.put_register(state, sentinel, :yank, :unnamedplus)
+
+      Helpers.put_register_with_clipboard_override(
+        state,
+        sentinel,
+        :yank,
+        :charwise,
+        :unnamedplus
+      )
 
       assert clipboard_contents(agent) == sentinel
     end
@@ -69,7 +76,14 @@ defmodule Minga.Editor.Commands.ClipboardSyncTest do
     test "delete syncs to system clipboard", %{clipboard: agent} do
       sentinel = "delete-sync-#{System.unique_integer([:positive])}"
       state = make_state()
-      Helpers.put_register(state, sentinel, :delete, :unnamedplus)
+
+      Helpers.put_register_with_clipboard_override(
+        state,
+        sentinel,
+        :delete,
+        :charwise,
+        :unnamedplus
+      )
 
       assert clipboard_contents(agent) == sentinel
     end
@@ -77,7 +91,14 @@ defmodule Minga.Editor.Commands.ClipboardSyncTest do
     test "named register also syncs to clipboard", %{clipboard: agent} do
       sentinel = "named-sync-#{System.unique_integer([:positive])}"
       state = put_in(make_state().vim.reg.active, "a")
-      Helpers.put_register(state, sentinel, :yank, :unnamedplus)
+
+      Helpers.put_register_with_clipboard_override(
+        state,
+        sentinel,
+        :yank,
+        :charwise,
+        :unnamedplus
+      )
 
       assert clipboard_contents(agent) == sentinel
     end
@@ -86,7 +107,14 @@ defmodule Minga.Editor.Commands.ClipboardSyncTest do
       sentinel = "blackhole-guard-#{System.unique_integer([:positive])}"
       Agent.update(agent, fn _ -> sentinel end)
       state = put_in(make_state().vim.reg.active, "_")
-      Helpers.put_register(state, "should not appear", :yank, :unnamedplus)
+
+      Helpers.put_register_with_clipboard_override(
+        state,
+        "should not appear",
+        :yank,
+        :charwise,
+        :unnamedplus
+      )
 
       assert clipboard_contents(agent) == sentinel
     end
@@ -94,7 +122,14 @@ defmodule Minga.Editor.Commands.ClipboardSyncTest do
     test "explicit + register still works", %{clipboard: agent} do
       sentinel = "explicit-clip-#{System.unique_integer([:positive])}"
       state = put_in(make_state().vim.reg.active, "+")
-      Helpers.put_register(state, sentinel, :yank, :unnamedplus)
+
+      Helpers.put_register_with_clipboard_override(
+        state,
+        sentinel,
+        :yank,
+        :charwise,
+        :unnamedplus
+      )
 
       assert clipboard_contents(agent) == sentinel
     end
@@ -105,7 +140,14 @@ defmodule Minga.Editor.Commands.ClipboardSyncTest do
       sentinel = "none-guard-#{System.unique_integer([:positive])}"
       Agent.update(agent, fn _ -> sentinel end)
       state = make_state()
-      Helpers.put_register(state, "should not sync", :yank, :none)
+
+      Helpers.put_register_with_clipboard_override(
+        state,
+        "should not sync",
+        :yank,
+        :charwise,
+        :none
+      )
 
       assert clipboard_contents(agent) == sentinel
     end
@@ -113,7 +155,7 @@ defmodule Minga.Editor.Commands.ClipboardSyncTest do
     test "explicit + register still works even with clipboard: :none", %{clipboard: agent} do
       sentinel = "none-explicit-#{System.unique_integer([:positive])}"
       state = put_in(make_state().vim.reg.active, "+")
-      Helpers.put_register(state, sentinel, :yank, :none)
+      Helpers.put_register_with_clipboard_override(state, sentinel, :yank, :charwise, :none)
 
       assert clipboard_contents(agent) == sentinel
     end
@@ -127,20 +169,37 @@ defmodule Minga.Editor.Commands.ClipboardSyncTest do
       internal = "internal-#{System.unique_integer([:positive])}"
       external = "external-#{System.unique_integer([:positive])}"
       # Put something in the unnamed register
-      state = Helpers.put_register(state, internal, :yank, :unnamedplus)
+      state =
+        Helpers.put_register_with_clipboard_override(
+          state,
+          internal,
+          :yank,
+          :charwise,
+          :unnamedplus
+        )
+
       # Simulate external copy by writing directly to the in-memory clipboard
       Agent.update(agent, fn _ -> external end)
 
-      {text, _state} = Helpers.get_register(state, :unnamedplus)
+      {text, _type, _state} = Helpers.get_register(state, :unnamedplus)
       assert text == external
     end
 
     test "paste from unnamed register uses internal when clipboard matches" do
       sentinel = "same-#{System.unique_integer([:positive])}"
       state = make_state()
-      state = Helpers.put_register(state, sentinel, :yank, :unnamedplus)
+
+      state =
+        Helpers.put_register_with_clipboard_override(
+          state,
+          sentinel,
+          :yank,
+          :charwise,
+          :unnamedplus
+        )
+
       # Clipboard was synced, so it should match
-      {text, _state} = Helpers.get_register(state, :unnamedplus)
+      {text, _type, _state} = Helpers.get_register(state, :unnamedplus)
       assert text == sentinel
     end
 
@@ -151,7 +210,7 @@ defmodule Minga.Editor.Commands.ClipboardSyncTest do
       state = Helpers.put_in_register(state, "a", sentinel)
       state = put_in(state.vim.reg.active, "a")
 
-      {text, _state} = Helpers.get_register(state, :unnamedplus)
+      {text, _type, _state} = Helpers.get_register(state, :unnamedplus)
       assert text == sentinel
     end
   end

--- a/test/minga/editor/commands/editing_test.exs
+++ b/test/minga/editor/commands/editing_test.exs
@@ -185,4 +185,283 @@ defmodule Minga.Editor.Commands.EditingTest do
       assert BufferServer.content(buffer) == original
     end
   end
+
+  # ── Linewise paste ──────────────────────────────────────────────────────
+
+  describe "linewise paste (yy + p)" do
+    test "yy then p pastes yanked line below the current line" do
+      {editor, buffer} = start_editor("aaa\nbbb\nccc")
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+      send_key(editor, ?j)
+      send_key(editor, ?p)
+
+      assert BufferServer.content(buffer) == "aaa\nbbb\naaa\nccc"
+    end
+
+    test "yy then P pastes yanked line above the current line" do
+      {editor, buffer} = start_editor("aaa\nbbb\nccc")
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+      # move to line 2, paste above
+      send_key(editor, ?j)
+      send_key(editor, ?j)
+      send_key(editor, ?P)
+
+      assert BufferServer.content(buffer) == "aaa\nbbb\naaa\nccc"
+    end
+
+    test "p on the last line of the file appends a new line" do
+      {editor, buffer} = start_editor("aaa\nbbb")
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+      send_key(editor, ?j)
+      send_key(editor, ?p)
+
+      assert BufferServer.content(buffer) == "aaa\nbbb\naaa"
+    end
+
+    test "P on the first line of the file inserts above" do
+      {editor, buffer} = start_editor("aaa\nbbb")
+      BufferServer.move_to(buffer, {1, 0})
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?P)
+
+      assert BufferServer.content(buffer) == "bbb\naaa\nbbb"
+    end
+
+    test "cursor column is irrelevant for linewise paste" do
+      {editor, buffer} = start_editor("aaa\nbbb\nccc")
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+      # move to middle of line 1
+      BufferServer.move_to(buffer, {1, 2})
+      send_key(editor, ?p)
+
+      # Should still paste as a full new line, not splice at col 2
+      assert BufferServer.content(buffer) == "aaa\nbbb\naaa\nccc"
+    end
+  end
+
+  describe "linewise paste (dd + p/P)" do
+    test "dd then p moves deleted line below current line" do
+      {editor, buffer} = start_editor("aaa\nbbb\nccc")
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?d)
+      send_key(editor, ?d)
+      send_key(editor, ?p)
+
+      assert BufferServer.content(buffer) == "bbb\naaa\nccc"
+    end
+
+    test "dd then P pastes deleted line above current line" do
+      {editor, buffer} = start_editor("aaa\nbbb\nccc")
+      BufferServer.move_to(buffer, {1, 0})
+      send_key(editor, ?d)
+      send_key(editor, ?d)
+      # cursor is now on "ccc"
+      send_key(editor, ?P)
+
+      assert BufferServer.content(buffer) == "aaa\nbbb\nccc"
+    end
+  end
+
+  describe "linewise paste cursor positioning" do
+    test "p lands cursor on first non-blank of pasted line" do
+      {editor, buffer} = start_editor("  indented\nplain")
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+      send_key(editor, ?j)
+      send_key(editor, ?p)
+
+      {line, col} = BufferServer.cursor(buffer)
+      assert line == 2
+      assert col == 2
+    end
+
+    test "P lands cursor on first non-blank of pasted line" do
+      {editor, buffer} = start_editor("plain\n    deep")
+      BufferServer.move_to(buffer, {1, 0})
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?P)
+
+      {line, col} = BufferServer.cursor(buffer)
+      assert line == 0
+      assert col == 4
+    end
+
+    test "p with no-indent line lands cursor at col 0" do
+      {editor, buffer} = start_editor("noindent\nother")
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+      send_key(editor, ?j)
+      send_key(editor, ?p)
+
+      {line, col} = BufferServer.cursor(buffer)
+      assert line == 2
+      assert col == 0
+    end
+  end
+
+  describe "cc stores linewise register type" do
+    test "cc yanks the line content as linewise before clearing" do
+      {editor, _buffer} = start_editor("hello\nworld")
+      send_key(editor, ?c)
+      send_key(editor, ?c)
+
+      s = :sys.get_state(editor)
+      assert Map.get(s.vim.reg.registers, "") == {"hello\n", :linewise}
+    end
+  end
+
+  # ── Charwise paste (regression guard) ──────────────────────────────────
+
+  describe "charwise paste stays inline" do
+    test "yw then p pastes inline, no new line created" do
+      {editor, buffer} = start_editor("hello world")
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?y)
+      send_key(editor, ?w)
+      send_key(editor, ?$)
+      send_key(editor, ?p)
+
+      content = BufferServer.content(buffer)
+      refute String.contains?(content, "\n")
+    end
+
+    # NOTE: Vim's `x` should yank the deleted char into the unnamed register,
+    # but our `delete_at` doesn't do that yet. This test documents current
+    # behavior. When `x` is fixed to yank, update this test to assert "bac".
+    test "x does not currently store to register (known gap)" do
+      {editor, buffer} = start_editor("abc")
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?x)
+      assert BufferServer.content(buffer) == "bc"
+
+      # p is a no-op because x didn't yank
+      send_key(editor, ?p)
+      assert BufferServer.content(buffer) == "bc"
+    end
+
+    test "dw then p pastes deleted word inline" do
+      {editor, buffer} = start_editor("one two three")
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?d)
+      send_key(editor, ?w)
+      # "one " deleted, cursor at "two"
+      send_key(editor, ?$)
+      send_key(editor, ?p)
+
+      content = BufferServer.content(buffer)
+      refute String.contains?(content, "\n")
+      assert String.contains?(content, "one ")
+    end
+  end
+
+  # ── Named register linewise round-trip ─────────────────────────────────
+
+  describe "named register linewise round-trip" do
+    test ~S["ayy then "ap pastes as a new line] do
+      {editor, buffer} = start_editor("first\nsecond\nthird")
+      BufferServer.move_to(buffer, {0, 0})
+      # "ayy
+      send_key(editor, ?")
+      send_key(editor, ?a)
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+      # move to last line, "ap
+      send_key(editor, ?j)
+      send_key(editor, ?j)
+      send_key(editor, ?")
+      send_key(editor, ?a)
+      send_key(editor, ?p)
+
+      assert BufferServer.content(buffer) == "first\nsecond\nthird\nfirst"
+    end
+
+    test "named register preserves linewise type through multiple operations" do
+      {editor, buffer} = start_editor("alpha\nbeta\ngamma")
+      BufferServer.move_to(buffer, {0, 0})
+      # "ayy
+      send_key(editor, ?")
+      send_key(editor, ?a)
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+      # Now do an unnamed dd (overwrites unnamed register, not "a")
+      send_key(editor, ?j)
+      send_key(editor, ?d)
+      send_key(editor, ?d)
+      # "ap should still paste "alpha" as linewise from register a
+      send_key(editor, ?")
+      send_key(editor, ?a)
+      send_key(editor, ?p)
+
+      assert BufferServer.content(buffer) == "alpha\ngamma\nalpha"
+    end
+  end
+
+  # ── Visual-line paste ──────────────────────────────────────────────────
+
+  describe "visual-line yank and paste" do
+    test "Vjy then p pastes two lines below current line" do
+      {editor, buffer} = start_editor("aaa\nbbb\nccc\nddd")
+      BufferServer.move_to(buffer, {0, 0})
+      # V to enter visual-line, j to extend to line 1, y to yank
+      send_key(editor, ?V)
+      send_key(editor, ?j)
+      send_key(editor, ?y)
+      # Paste below wherever the cursor is after yank
+      send_key(editor, ?p)
+
+      lines = String.split(BufferServer.content(buffer), "\n")
+      # Should have 6 lines: original 4 + 2 pasted
+      assert length(lines) == 6
+      # The pasted block should contain "aaa" and "bbb" in order
+      assert Enum.count(lines, &(&1 == "aaa")) == 2
+      assert Enum.count(lines, &(&1 == "bbb")) == 2
+    end
+
+    test "Vd then p pastes deleted lines as linewise" do
+      {editor, buffer} = start_editor("aaa\nbbb\nccc")
+      BufferServer.move_to(buffer, {0, 0})
+      send_key(editor, ?V)
+      send_key(editor, ?j)
+      send_key(editor, ?d)
+      # "aaa" and "bbb" deleted, cursor on "ccc"
+      send_key(editor, ?p)
+
+      assert BufferServer.content(buffer) == "ccc\naaa\nbbb"
+    end
+  end
+
+  # ── Visual-char paste (charwise guard) ─────────────────────────────────
+
+  describe "visual-char yank and paste" do
+    test "vllly then p pastes inline" do
+      {editor, buffer} = start_editor("abcdefgh")
+      BufferServer.move_to(buffer, {0, 0})
+      # select "abcd"
+      send_key(editor, ?v)
+      send_key(editor, ?l)
+      send_key(editor, ?l)
+      send_key(editor, ?l)
+      send_key(editor, ?y)
+      # move to end and paste
+      send_key(editor, ?$)
+      send_key(editor, ?p)
+
+      content = BufferServer.content(buffer)
+      refute String.contains?(content, "\n")
+    end
+  end
 end

--- a/test/minga/editor/registers_test.exs
+++ b/test/minga/editor/registers_test.exs
@@ -97,9 +97,9 @@ defmodule Minga.Editor.RegistersTest do
       send_key(editor, ?y)
 
       s = state(editor)
-      assert Map.get(s.vim.reg.registers, "a") == "hello\n"
-      assert Map.get(s.vim.reg.registers, "0") == "hello\n"
-      assert Map.get(s.vim.reg.registers, "") == "hello\n"
+      assert Map.get(s.vim.reg.registers, "a") == {"hello\n", :linewise}
+      assert Map.get(s.vim.reg.registers, "0") == {"hello\n", :linewise}
+      assert Map.get(s.vim.reg.registers, "") == {"hello\n", :linewise}
     end
 
     test ~S["ayy / "ap round-trip pastes from register a] do
@@ -134,8 +134,8 @@ defmodule Minga.Editor.RegistersTest do
       send_key(editor, ?y)
 
       s = state(editor)
-      assert Map.get(s.vim.reg.registers, "a") == "hello\n"
-      assert Map.get(s.vim.reg.registers, "b") == "world\n"
+      assert Map.get(s.vim.reg.registers, "a") == {"hello\n", :linewise}
+      assert Map.get(s.vim.reg.registers, "b") == {"world\n", :linewise}
     end
   end
 
@@ -158,7 +158,7 @@ defmodule Minga.Editor.RegistersTest do
       send_key(editor, ?y)
 
       s = state(editor)
-      assert Map.get(s.vim.reg.registers, "a") == "hello\nworld\n"
+      assert Map.get(s.vim.reg.registers, "a") == {"hello\nworld\n", :linewise}
     end
 
     test "appending to an empty register is the same as writing" do
@@ -170,7 +170,7 @@ defmodule Minga.Editor.RegistersTest do
       send_key(editor, ?y)
       send_key(editor, ?y)
 
-      assert Map.get(state(editor).vim.reg.registers, "a") == "hello\n"
+      assert Map.get(state(editor).vim.reg.registers, "a") == {"hello\n", :linewise}
     end
   end
 
@@ -183,15 +183,15 @@ defmodule Minga.Editor.RegistersTest do
 
       send_key(editor, ?y)
       send_key(editor, ?y)
-      assert Map.get(state(editor).vim.reg.registers, "0") == "hello\n"
+      assert Map.get(state(editor).vim.reg.registers, "0") == {"hello\n", :linewise}
 
       BufferServer.move_to(buffer, {1, 0})
       send_key(editor, ?d)
       send_key(editor, ?d)
 
       s = state(editor)
-      assert Map.get(s.vim.reg.registers, "0") == "hello\n"
-      assert Map.get(s.vim.reg.registers, "") == "world\n"
+      assert Map.get(s.vim.reg.registers, "0") == {"hello\n", :linewise}
+      assert Map.get(s.vim.reg.registers, "") == {"world\n", :linewise}
     end
 
     test "consecutive deletes do not update 0" do
@@ -207,7 +207,7 @@ defmodule Minga.Editor.RegistersTest do
       send_key(editor, ?d)
       send_key(editor, ?d)
 
-      assert Map.get(state(editor).vim.reg.registers, "0") == "hello\n"
+      assert Map.get(state(editor).vim.reg.registers, "0") == {"hello\n", :linewise}
     end
   end
 
@@ -220,7 +220,7 @@ defmodule Minga.Editor.RegistersTest do
 
       send_key(editor, ?y)
       send_key(editor, ?y)
-      assert Map.get(state(editor).vim.reg.registers, "") == "hello\n"
+      assert Map.get(state(editor).vim.reg.registers, "") == {"hello\n", :linewise}
 
       BufferServer.move_to(buffer, {1, 0})
       send_key(editor, ?")
@@ -229,8 +229,8 @@ defmodule Minga.Editor.RegistersTest do
       send_key(editor, ?d)
 
       s = state(editor)
-      assert Map.get(s.vim.reg.registers, "") == "hello\n"
-      assert Map.get(s.vim.reg.registers, "0") == "hello\n"
+      assert Map.get(s.vim.reg.registers, "") == {"hello\n", :linewise}
+      assert Map.get(s.vim.reg.registers, "0") == {"hello\n", :linewise}
       refute Map.has_key?(s.vim.reg.registers, "_")
     end
 
@@ -259,7 +259,7 @@ defmodule Minga.Editor.RegistersTest do
       BufferServer.move_to(buffer, {0, 0})
       send_key(editor, ?y)
       send_key(editor, ?y)
-      assert Map.get(state(editor).vim.reg.registers, "") == "hello\n"
+      assert Map.get(state(editor).vim.reg.registers, "") == {"hello\n", :linewise}
     end
 
     test "dd without prefix writes to unnamed" do
@@ -267,7 +267,7 @@ defmodule Minga.Editor.RegistersTest do
       BufferServer.move_to(buffer, {0, 0})
       send_key(editor, ?d)
       send_key(editor, ?d)
-      assert Map.get(state(editor).vim.reg.registers, "") == "hello\n"
+      assert Map.get(state(editor).vim.reg.registers, "") == {"hello\n", :linewise}
     end
 
     test "p pastes from unnamed when no register selected" do
@@ -314,8 +314,8 @@ defmodule Minga.Editor.RegistersTest do
       send_key(editor, ?d)
 
       s = state(editor)
-      assert Map.get(s.vim.reg.registers, "") == "world\n"
-      assert Map.get(s.vim.reg.registers, "a") == "hello\n"
+      assert Map.get(s.vim.reg.registers, "") == {"world\n", :linewise}
+      assert Map.get(s.vim.reg.registers, "a") == {"hello\n", :linewise}
 
       # "ap should paste "hello" from register a
       send_key(editor, ?")

--- a/test/minga/editor/state/registers_test.exs
+++ b/test/minga/editor/state/registers_test.exs
@@ -1,0 +1,73 @@
+defmodule Minga.Editor.State.RegistersTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.State.Registers
+
+  describe "put/4 and get/2" do
+    test "stores charwise entry by default" do
+      reg = %Registers{} |> Registers.put("a", "hello")
+      assert Registers.get(reg, "a") == {"hello", :charwise}
+    end
+
+    test "stores linewise entry when type is :linewise" do
+      reg = %Registers{} |> Registers.put("a", "hello\n", :linewise)
+      assert Registers.get(reg, "a") == {"hello\n", :linewise}
+    end
+
+    test "overwrites previous entry" do
+      reg =
+        %Registers{}
+        |> Registers.put("a", "first", :charwise)
+        |> Registers.put("a", "second", :linewise)
+
+      assert Registers.get(reg, "a") == {"second", :linewise}
+    end
+
+    test "returns nil for unset register" do
+      assert Registers.get(%Registers{}, "z") == nil
+    end
+
+    test "independent registers don't interfere" do
+      reg =
+        %Registers{}
+        |> Registers.put("a", "alpha", :charwise)
+        |> Registers.put("b", "beta\n", :linewise)
+
+      assert Registers.get(reg, "a") == {"alpha", :charwise}
+      assert Registers.get(reg, "b") == {"beta\n", :linewise}
+    end
+  end
+
+  describe "bare string migration" do
+    test "get/2 migrates a bare string to {:charwise}" do
+      reg = %Registers{registers: %{"a" => "legacy"}}
+      assert Registers.get(reg, "a") == {"legacy", :charwise}
+    end
+
+    test "get/2 returns nil for missing key even with legacy data" do
+      reg = %Registers{registers: %{"a" => "legacy"}}
+      assert Registers.get(reg, "b") == nil
+    end
+  end
+
+  describe "unnamed register" do
+    test "empty string key is the unnamed register" do
+      reg = %Registers{} |> Registers.put("", "unnamed content", :linewise)
+      assert Registers.get(reg, "") == {"unnamed content", :linewise}
+    end
+  end
+
+  describe "reset_active/1" do
+    test "resets active register to empty string" do
+      reg = %Registers{active: "a"} |> Registers.reset_active()
+      assert reg.active == ""
+    end
+  end
+
+  describe "set_active/2" do
+    test "sets the active register" do
+      reg = %Registers{} |> Registers.set_active("z")
+      assert reg.active == "z"
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR
`yy` then `p` now pastes the yanked line as a new line below (Vim behavior), instead of splicing text inline at the cursor column.

Closes #476

## Context
Register entries were bare strings with no type metadata. Every paste operation inserted text inline at the cursor position (characterwise). Linewise operations like `yy` and `dd` appended a trailing `\n` but the paste commands never checked for it. Result: `yy` then `p` would splice the yanked line into the middle of the current line.

## Changes
- **`Registers`** (`state/registers.ex`): Entries are now `{text, :charwise | :linewise}` tuples. `get/2` migrates bare strings (from old state or tests) to `{text, :charwise}` for backward compatibility.
- **`Helpers`** (`commands/helpers.ex`): `put_register` accepts and threads `reg_type` through all register write paths (unnamed, named, yank register, clipboard sync). `get_register` returns a 3-tuple `{text, type, state}`. Added `put_register_with_clipboard_override/5` for tests that need explicit clipboard mode.
- **`Operators`** (`commands/operators.ex`): `yank_line`, `delete_line`, `change_line` pass `:linewise` to `put_register`.
- **`Visual`** (`commands/visual.ex`): Visual-line yank/delete pass `:linewise`; visual-char passes `:charwise`.
- **`Editing`** (`commands/editing.ex`): `paste_after`/`paste_before` check the register type. Linewise paste opens a new line and positions cursor on first non-blank. Charwise paste is unchanged.

## Verification
1. `mix test --warnings-as-errors` — 4675 tests, 0 failures
2. `mix lint` — clean (format, credo --strict, compile --warnings-as-errors, dialyzer)
3. Manual: open a file, `yy`, `p` — line duplicated below. `dd`, `p` — line moved down. `yw`, `p` — word pasted inline.