### PR TITLE
refactor: unified Language registry consolidates per-language config

### DIFF
--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -43,6 +43,7 @@ defmodule Minga.Application do
     Grammar.init_registry()
 
     base_children = [
+      Minga.Language.Registry,
       Minga.Config.Options,
       Minga.Keymap.Active,
       Minga.Config.Hooks,

--- a/lib/minga/comment.ex
+++ b/lib/minga/comment.ex
@@ -13,6 +13,7 @@ defmodule Minga.Comment do
   """
 
   alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Language.Registry, as: LangRegistry
 
   @typedoc "A single injection range from tree-sitter."
   @type injection_range :: %{
@@ -20,78 +21,6 @@ defmodule Minga.Comment do
           end_byte: non_neg_integer(),
           language: String.t()
         }
-
-  # ── Comment string lookup ──────────────────────────────────────────────────
-
-  @comment_strings %{
-    # Hash-style
-    elixir: "# ",
-    python: "# ",
-    ruby: "# ",
-    bash: "# ",
-    fish: "# ",
-    yaml: "# ",
-    toml: "# ",
-    make: "# ",
-    dockerfile: "# ",
-    gitconfig: "# ",
-    conf: "# ",
-    nix: "# ",
-    r: "# ",
-    perl: "# ",
-    csv: "# ",
-    editorconfig: "# ",
-
-    # Double-slash style
-    zig: "// ",
-    c: "// ",
-    cpp: "// ",
-    go: "// ",
-    rust: "// ",
-    javascript: "// ",
-    typescript: "// ",
-    javascript_react: "// ",
-    typescript_react: "// ",
-    java: "// ",
-    kotlin: "// ",
-    swift: "// ",
-    c_sharp: "// ",
-    scala: "// ",
-    dart: "// ",
-    php: "// ",
-    protobuf: "// ",
-    hcl: "// ",
-    gleam: "// ",
-    json: "// ",
-
-    # Double-dash style
-    lua: "-- ",
-    sql: "-- ",
-    haskell: "-- ",
-
-    # Semicolon style
-    emacs_lisp: ";; ",
-    lfe: ";; ",
-    ini: "; ",
-    vim: "\" ",
-
-    # Percent style
-    erlang: "% ",
-
-    # XML/HTML use block comments, but we provide a line-ish default
-    html: "<!-- ",
-    xml: "<!-- ",
-    css: "/* ",
-    scss: "// ",
-
-    # Other
-    heex: "<%!-- ",
-    graphql: "# ",
-    diff: "# ",
-    markdown: "<!-- ",
-    ocaml: "(* ",
-    text: "# "
-  }
 
   @typedoc "Direction the toggle should go."
   @type toggle_direction :: :comment | :uncomment
@@ -114,7 +43,10 @@ defmodule Minga.Comment do
   """
   @spec comment_string(atom()) :: String.t()
   def comment_string(filetype) do
-    Map.get(@comment_strings, filetype, "# ")
+    case LangRegistry.get(filetype) do
+      %{comment_token: token} when is_binary(token) -> token
+      _ -> "# "
+    end
   end
 
   @doc """

--- a/lib/minga/devicon.ex
+++ b/lib/minga/devicon.ex
@@ -2,15 +2,21 @@ defmodule Minga.Devicon do
   @moduledoc """
   Maps filetypes and special buffer types to Nerd Font icons and colors.
 
-  A pure functional module with pattern-matched clauses. No GenServer, no
-  ETS, no config. The icon/color data is compiled into the module. This
-  mirrors how `Minga.Filetype` works.
+  Language filetypes are looked up from the `Minga.Language.Registry` at
+  runtime. Special buffer types (agent, messages, scratch, help) are
+  hardcoded since they aren't languages.
 
   Used by the tab bar, file tree, buffer picker, and anywhere else that
   displays a filename alongside a visual indicator.
   """
 
+  alias Minga.Language.Registry, as: LangRegistry
+
   @type filetype :: atom()
+
+  # Default icon and color for unknown filetypes
+  @default_icon "\u{E612}"
+  @default_color 0x6D8086
 
   @doc "Returns the Nerd Font icon for the given filetype."
   @spec icon(filetype()) :: String.t()
@@ -23,140 +29,22 @@ defmodule Minga.Devicon do
   @doc "Returns `{icon, color}` for the given filetype."
   @spec icon_and_color(filetype()) :: {String.t(), non_neg_integer()}
 
-  # ── Languages ──────────────────────────────────────────────────────────────
+  # ── Special buffer types (not languages, no Language definition) ───────────
 
-  # Elixir (nf-custom-elixir)
-  def icon_and_color(:elixir), do: {"\u{E62D}", 0x9B59B6}
-  # Erlang (nf-dev-erlang)
-  def icon_and_color(:erlang), do: {"\u{E7B1}", 0xA90533}
-  # HEEx (same as Elixir)
-  def icon_and_color(:heex), do: {"\u{E62D}", 0x9B59B6}
-  # LFE (Erlang family)
-  def icon_and_color(:lfe), do: {"\u{E7B1}", 0xA90533}
-  # Zig (nf-seti-zig)
-  def icon_and_color(:zig), do: {"\u{E6A9}", 0xF69A1B}
-  # Rust (nf-dev-rust)
-  def icon_and_color(:rust), do: {"\u{E7A8}", 0xDEA584}
-  # Go (nf-seti-go)
-  def icon_and_color(:go), do: {"\u{E626}", 0x00ADD8}
-  # JavaScript (nf-seti-javascript)
-  def icon_and_color(:javascript), do: {"\u{E781}", 0xF7DF1E}
-  # JSX (nf-seti-react)
-  def icon_and_color(:javascript_react), do: {"\u{E7BA}", 0x61DAFB}
-  # TypeScript (nf-seti-typescript)
-  def icon_and_color(:typescript), do: {"\u{E628}", 0x3178C6}
-  # TSX (nf-seti-react)
-  def icon_and_color(:typescript_react), do: {"\u{E7BA}", 0x3178C6}
-  # Python (nf-dev-python)
-  def icon_and_color(:python), do: {"\u{E73C}", 0x3776AB}
-  # Ruby (nf-dev-ruby)
-  def icon_and_color(:ruby), do: {"\u{E739}", 0xCC342D}
-  # C (nf-custom-c)
-  def icon_and_color(:c), do: {"\u{E61E}", 0x599EFF}
-  # C++ (nf-custom-cpp)
-  def icon_and_color(:cpp), do: {"\u{E61D}", 0xF34B7D}
-  # C# (nf-md-language_csharp)
-  def icon_and_color(:c_sharp), do: {"\u{F031B}", 0x68217A}
-  # Java (nf-dev-java)
-  def icon_and_color(:java), do: {"\u{E738}", 0xCC3E44}
-  # Kotlin (nf-seti-kotlin)
-  def icon_and_color(:kotlin), do: {"\u{E634}", 0x7F52FF}
-  # Scala (nf-dev-scala)
-  def icon_and_color(:scala), do: {"\u{E737}", 0xCC3E44}
-  # Swift (nf-dev-swift)
-  def icon_and_color(:swift), do: {"\u{E755}", 0xF05138}
-  # Dart (nf-dev-dart)
-  def icon_and_color(:dart), do: {"\u{E798}", 0x03589C}
-  # Lua (nf-seti-lua)
-  def icon_and_color(:lua), do: {"\u{E620}", 0x000080}
-  # PHP (nf-dev-php)
-  def icon_and_color(:php), do: {"\u{E73D}", 0x777BB3}
-  # Perl (nf-dev-perl)
-  def icon_and_color(:perl), do: {"\u{E769}", 0x39457E}
-  # R (nf-seti-r)
-  def icon_and_color(:r), do: {"\u{E68A}", 0x276DC3}
-  # Haskell (nf-dev-haskell)
-  def icon_and_color(:haskell), do: {"\u{E777}", 0x5E5086}
-  # OCaml (nf-seti-ocaml)
-  def icon_and_color(:ocaml), do: {"\u{E67F}", 0xEC6813}
-  # Gleam (star/sparkle)
-  def icon_and_color(:gleam), do: {"\u{F0E7}", 0xFFAFEF}
-  # Nix (nf-md-nix)
-  def icon_and_color(:nix), do: {"\u{F0313}", 0x7EBAE4}
-  # Emacs Lisp (nf-custom-emacs)
-  def icon_and_color(:emacs_lisp), do: {"\u{E632}", 0x7F5AB6}
-  # Vim (nf-dev-vim)
-  def icon_and_color(:vim), do: {"\u{E62B}", 0x019833}
-  # Fish (nf-dev-terminal)
-  def icon_and_color(:fish), do: {"\u{E795}", 0x89E051}
-  # Bash/Shell (nf-dev-terminal)
-  def icon_and_color(:bash), do: {"\u{E795}", 0x89E051}
-
-  # ── Web / markup ───────────────────────────────────────────────────────────
-
-  # HTML (nf-seti-html)
-  def icon_and_color(:html), do: {"\u{E736}", 0xE34C26}
-  # CSS (nf-dev-css3)
-  def icon_and_color(:css), do: {"\u{E749}", 0x563D7C}
-  # SCSS (nf-dev-sass)
-  def icon_and_color(:scss), do: {"\u{E74B}", 0xCD6799}
-  # GraphQL (nf-md-graphql)
-  def icon_and_color(:graphql), do: {"\u{F0877}", 0xE10098}
-
-  # ── Data / config ──────────────────────────────────────────────────────────
-
-  # JSON (nf-seti-json)
-  def icon_and_color(:json), do: {"\u{E60B}", 0xCBCB41}
-  # YAML (nf-seti-yml)
-  def icon_and_color(:yaml), do: {"\u{E6A8}", 0xCB171E}
-  # TOML (nf-seti-config)
-  def icon_and_color(:toml), do: {"\u{E615}", 0x9C4221}
-  # XML (nf-md-xml)
-  def icon_and_color(:xml), do: {"\u{F05C0}", 0xE37933}
-  # CSV (nf-fa-table)
-  def icon_and_color(:csv), do: {"\u{F0CE}", 0x89E051}
-  # SQL (nf-dev-database)
-  def icon_and_color(:sql), do: {"\u{E706}", 0xDAD8D8}
-  # Protobuf (nf-md-code_braces)
-  def icon_and_color(:protobuf), do: {"\u{F0614}", 0x6A9FB5}
-  # INI/Config (nf-seti-config)
-  def icon_and_color(:ini), do: {"\u{E615}", 0x6D8086}
-  def icon_and_color(:conf), do: {"\u{E615}", 0x6D8086}
-  def icon_and_color(:editorconfig), do: {"\u{E615}", 0x6D8086}
-  # HCL/Terraform (nf-md-terraform)
-  def icon_and_color(:hcl), do: {"\u{F1062}", 0x7B42BC}
-
-  # ── Markdown / docs ────────────────────────────────────────────────────────
-
-  # Markdown (nf-dev-markdown)
-  def icon_and_color(:markdown), do: {"\u{E73E}", 0x519ABA}
-  # Text (nf-seti-text)
-  def icon_and_color(:text), do: {"\u{E612}", 0x89E051}
-
-  # ── DevOps ─────────────────────────────────────────────────────────────────
-
-  # Docker (nf-md-docker)
-  def icon_and_color(:dockerfile), do: {"\u{F0868}", 0x0DB7ED}
-  # Makefile (nf-seti-makefile)
-  def icon_and_color(:make), do: {"\u{E673}", 0x6D8086}
-  # Diff (nf-md-compare)
-  def icon_and_color(:diff), do: {"\u{F1492}", 0x41535B}
-  # Git (nf-dev-git)
-  def icon_and_color(:gitconfig), do: {"\u{E702}", 0xF14C28}
-
-  # ── Special buffer types ───────────────────────────────────────────────────
-
-  # Agent (nf-md-robot)
   def icon_and_color(:agent), do: {"\u{F06A9}", 0x7EC8E3}
-  # Messages (nf-md-message_text)
   def icon_and_color(:messages), do: {"\u{F0369}", 0x519ABA}
-  # Scratch (nf-md-note_edit)
   def icon_and_color(:scratch), do: {"\u{F03EB}", 0xCBCB41}
-  # Help (nf-md-help_circle)
   def icon_and_color(:help), do: {"\u{F02D7}", 0x00ADD8}
 
-  # ── Fallback ───────────────────────────────────────────────────────────────
+  # ── Language-backed lookup ─────────────────────────────────────────────────
 
-  # Generic file (nf-seti-default)
-  def icon_and_color(_), do: {"\u{E612}", 0x6D8086}
+  def icon_and_color(filetype) when is_atom(filetype) do
+    case LangRegistry.get(filetype) do
+      %{icon: icon, icon_color: color} when is_binary(icon) and is_integer(color) ->
+        {icon, color}
+
+      _ ->
+        {@default_icon, @default_color}
+    end
+  end
 end

--- a/lib/minga/editor/modeline.ex
+++ b/lib/minga/editor/modeline.ex
@@ -184,40 +184,10 @@ defmodule Minga.Editor.Modeline do
   defp mode_badge(:extension_confirm, _state), do: "UPDATE"
 
   @spec filetype_label(atom()) :: String.t()
-  defp filetype_label(:text), do: "Text"
-  defp filetype_label(:elixir), do: "Elixir"
-  defp filetype_label(:erlang), do: "Erlang"
-  defp filetype_label(:heex), do: "HEEx"
-  defp filetype_label(:ruby), do: "Ruby"
-  defp filetype_label(:javascript), do: "JavaScript"
-  defp filetype_label(:typescript), do: "TypeScript"
-  defp filetype_label(:javascript_react), do: "JSX"
-  defp filetype_label(:typescript_react), do: "TSX"
-  defp filetype_label(:go), do: "Go"
-  defp filetype_label(:rust), do: "Rust"
-  defp filetype_label(:zig), do: "Zig"
-  defp filetype_label(:c), do: "C"
-  defp filetype_label(:cpp), do: "C++"
-  defp filetype_label(:lua), do: "Lua"
-  defp filetype_label(:python), do: "Python"
-  defp filetype_label(:bash), do: "Shell"
-  defp filetype_label(:html), do: "HTML"
-  defp filetype_label(:css), do: "CSS"
-  defp filetype_label(:json), do: "JSON"
-  defp filetype_label(:yaml), do: "YAML"
-  defp filetype_label(:toml), do: "TOML"
-  defp filetype_label(:markdown), do: "Markdown"
-  defp filetype_label(:sql), do: "SQL"
-  defp filetype_label(:graphql), do: "GraphQL"
-  defp filetype_label(:kotlin), do: "Kotlin"
-  defp filetype_label(:gleam), do: "Gleam"
-  defp filetype_label(:dockerfile), do: "Dockerfile"
-  defp filetype_label(:make), do: "Makefile"
-  defp filetype_label(:emacs_lisp), do: "Emacs Lisp"
-  defp filetype_label(:lfe), do: "LFE"
-  defp filetype_label(:nix), do: "Nix"
-  defp filetype_label(:java), do: "Java"
-  defp filetype_label(:swift), do: "Swift"
-  defp filetype_label(:fish), do: "Fish"
-  defp filetype_label(other), do: other |> Atom.to_string() |> String.capitalize()
+  defp filetype_label(filetype) do
+    case Minga.Language.Registry.get(filetype) do
+      %{label: label} when is_binary(label) -> label
+      _ -> filetype |> Atom.to_string() |> String.capitalize()
+    end
+  end
 end

--- a/lib/minga/filetype.ex
+++ b/lib/minga/filetype.ex
@@ -153,6 +153,8 @@ defmodule Minga.Filetype do
   Checks exact filename (case-sensitive), then extension (case-insensitive),
   then `.env*`/`.envrc*` patterns. Returns `:text` if nothing matches.
   """
+  alias Minga.Language.Registry, as: LangRegistry
+
   @spec detect(String.t() | nil) :: filetype()
   def detect(nil), do: :text
 
@@ -161,8 +163,8 @@ defmodule Minga.Filetype do
 
     with :miss <- lookup_registry_filename(basename),
          :miss <- lookup_registry_extension(basename),
-         :miss <- lookup_filename(basename),
-         :miss <- lookup_extension(basename),
+         :miss <- lookup_lang_registry_filename(basename),
+         :miss <- lookup_lang_registry_extension(basename),
          :miss <- detect_env_pattern(basename) do
       :text
     end
@@ -196,6 +198,32 @@ defmodule Minga.Filetype do
 
   # ── Private ────────────────────────────────────────────────────────────────
 
+  @spec lookup_lang_registry_filename(String.t()) :: filetype() | :miss
+  defp lookup_lang_registry_filename(basename) do
+    case LangRegistry.for_filename(basename) do
+      %{name: name} -> name
+      nil -> :miss
+    end
+  rescue
+    ArgumentError -> :miss
+  end
+
+  @spec lookup_lang_registry_extension(String.t()) :: filetype() | :miss
+  defp lookup_lang_registry_extension(basename) do
+    case Path.extname(basename) do
+      "" ->
+        :miss
+
+      "." <> ext ->
+        case LangRegistry.for_extension(String.downcase(ext)) do
+          %{name: name} -> name
+          nil -> :miss
+        end
+    end
+  rescue
+    ArgumentError -> :miss
+  end
+
   @spec lookup_registry_filename(String.t()) :: filetype() | :miss
   defp lookup_registry_filename(basename) do
     case Minga.Filetype.Registry.lookup_filename(basename) do
@@ -222,24 +250,6 @@ defmodule Minga.Filetype do
     ArgumentError -> :miss
   end
 
-  @spec lookup_filename(String.t()) :: filetype() | :miss
-  defp lookup_filename(basename) do
-    Map.get(@filenames, basename, :miss)
-  end
-
-  @spec lookup_extension(String.t()) :: filetype() | :miss
-  defp lookup_extension(basename) do
-    case Path.extname(basename) do
-      "" ->
-        :miss
-
-      "." <> ext ->
-        ext
-        |> String.downcase()
-        |> then(&Map.get(@extensions, &1, :miss))
-    end
-  end
-
   @spec detect_env_pattern(String.t()) :: filetype() | :miss
   defp detect_env_pattern(basename) do
     cond do
@@ -259,7 +269,18 @@ defmodule Minga.Filetype do
       |> String.trim()
       |> extract_interpreter()
 
-    Map.get(@shebang_interpreters, interpreter, :text)
+    # Check Filetype.Registry first (runtime overrides), then Language registry,
+    # then fall back to the compile-time map for any stragglers
+    case Minga.Filetype.Registry.lookup_shebang(interpreter) do
+      nil ->
+        case LangRegistry.for_shebang(interpreter) do
+          %{name: name} -> name
+          nil -> Map.get(@shebang_interpreters, interpreter, :text)
+        end
+
+      filetype ->
+        filetype
+    end
   end
 
   defp parse_shebang(_), do: :text

--- a/lib/minga/formatter.ex
+++ b/lib/minga/formatter.ex
@@ -25,27 +25,18 @@ defmodule Minga.Formatter do
   """
 
   alias Minga.Config.Options
+  alias Minga.Language.Registry, as: LangRegistry
 
   @typedoc "A shell command string, optionally containing `{file}`."
   @type formatter_spec :: String.t()
 
-  @default_formatters %{
-    elixir: "mix format --stdin-filename {file} -",
-    go: "gofmt",
-    rust: "rustfmt --edition 2021",
-    python: "python3 -m black --quiet -",
-    zig: "zig fmt --stdin",
-    c: "clang-format",
-    cpp: "clang-format",
-    javascript: "prettier --stdin-filepath {file}",
-    typescript: "prettier --stdin-filepath {file}",
-    javascript_react: "prettier --stdin-filepath {file}",
-    typescript_react: "prettier --stdin-filepath {file}"
-  }
-
   @doc "Returns the default formatter map (filetype atom to command string)."
   @spec default_formatters() :: %{atom() => formatter_spec()}
-  def default_formatters, do: @default_formatters
+  def default_formatters do
+    LangRegistry.all()
+    |> Enum.filter(fn lang -> lang.formatter != nil end)
+    |> Map.new(fn lang -> {lang.name, lang.formatter} end)
+  end
 
   @doc """
   Resolves the formatter command for a filetype.
@@ -58,7 +49,13 @@ defmodule Minga.Formatter do
   def resolve_formatter(filetype, file_path \\ nil) do
     user_formatter = Options.get_for_filetype(:formatter, filetype)
 
-    spec = user_formatter || Map.get(@default_formatters, filetype)
+    default =
+      case LangRegistry.get(filetype) do
+        %{formatter: fmt} when is_binary(fmt) -> fmt
+        _ -> nil
+      end
+
+    spec = user_formatter || default
 
     if spec && file_path do
       String.replace(spec, "{file}", file_path)

--- a/lib/minga/highlight/grammar.ex
+++ b/lib/minga/highlight/grammar.ex
@@ -8,48 +8,7 @@ defmodule Minga.Highlight.Grammar do
   in `~/.config/minga/queries/{language}/highlights.scm`.
   """
 
-  @filetype_to_language %{
-    elixir: "elixir",
-    erlang: "erlang",
-    heex: "heex",
-    ruby: "ruby",
-    javascript: "javascript",
-    javascript_react: "javascript",
-    typescript: "typescript",
-    typescript_react: "tsx",
-    go: "go",
-    rust: "rust",
-    zig: "zig",
-    c: "c",
-    cpp: "cpp",
-    python: "python",
-    lua: "lua",
-    bash: "bash",
-    html: "html",
-    css: "css",
-    json: "json",
-    yaml: "yaml",
-    toml: "toml",
-    markdown: "markdown",
-    kotlin: "kotlin",
-    gleam: "gleam",
-    java: "java",
-    c_sharp: "c_sharp",
-    php: "php",
-    dockerfile: "dockerfile",
-    hcl: "hcl",
-    scss: "scss",
-    graphql: "graphql",
-    nix: "nix",
-    ocaml: "ocaml",
-    haskell: "haskell",
-    scala: "scala",
-    r: "r",
-    dart: "dart",
-    make: "make",
-    diff: "diff",
-    emacs_lisp: "elisp"
-  }
+  alias Minga.Language.Registry, as: LangRegistry
 
   @typedoc "A tree-sitter language name."
   @type language :: String.t()
@@ -205,7 +164,12 @@ defmodule Minga.Highlight.Grammar do
         ArgumentError -> %{}
       end
 
-    Map.merge(@filetype_to_language, dynamic)
+    static =
+      LangRegistry.all()
+      |> Enum.filter(fn lang -> lang.grammar != nil end)
+      |> Map.new(fn lang -> {lang.name, lang.grammar} end)
+
+    Map.merge(static, dynamic)
   end
 
   # ── Private ──
@@ -224,9 +188,9 @@ defmodule Minga.Highlight.Grammar do
 
   @spec lookup_static(atom()) :: {:ok, language()} | :unsupported
   defp lookup_static(filetype) do
-    case Map.get(@filetype_to_language, filetype) do
-      nil -> :unsupported
-      lang -> {:ok, lang}
+    case LangRegistry.get(filetype) do
+      %{grammar: grammar} when is_binary(grammar) -> {:ok, grammar}
+      _ -> :unsupported
     end
   end
 

--- a/lib/minga/language.ex
+++ b/lib/minga/language.ex
@@ -1,0 +1,67 @@
+defmodule Minga.Language do
+  @moduledoc """
+  Unified per-language configuration struct.
+
+  Every supported language is described by a single `%Language{}` struct
+  that consolidates data previously spread across `Filetype`, `Comment`,
+  `Formatter`, `LSP.ServerRegistry`, `Highlight.Grammar`, `Devicon`,
+  `Modeline`, and `Project.Detector`.
+
+  Language definitions live in `lib/minga/language/*.ex`, one module per
+  language. Each module exports a `definition/0` function returning a
+  `%Language{}` struct. The `Language.Registry` collects them at startup
+  and provides O(1) lookups by name, extension, and filename.
+
+  ## Adding a new language
+
+  Create a new module under `Minga.Language.*` (e.g., `Minga.Language.Dart`)
+  and return a `%Language{}` from `definition/0`. Register the module in
+  `Minga.Language.Registry.@language_modules`. That's it: one file, one place.
+
+  ## Extension languages
+
+  Extensions register languages at runtime via
+  `Minga.Language.Registry.register/1`, passing a `%Language{}` struct.
+  Runtime registrations override built-in definitions for the same name.
+  """
+
+  alias Minga.LSP.ServerConfig
+
+  @typedoc "A per-language configuration."
+  @type t :: %__MODULE__{
+          name: atom(),
+          label: String.t(),
+          comment_token: String.t(),
+          extensions: [String.t()],
+          filenames: [String.t()],
+          shebangs: [String.t()],
+          icon: String.t() | nil,
+          icon_color: non_neg_integer() | nil,
+          tab_width: pos_integer(),
+          indent_with: :spaces | :tabs,
+          grammar: String.t() | nil,
+          formatter: String.t() | nil,
+          language_servers: [ServerConfig.t()],
+          root_markers: [String.t()],
+          project_type: atom() | nil
+        }
+
+  @enforce_keys [:name, :label, :comment_token]
+  defstruct [
+    :name,
+    :label,
+    :comment_token,
+    :grammar,
+    :formatter,
+    :project_type,
+    :icon,
+    :icon_color,
+    extensions: [],
+    filenames: [],
+    shebangs: [],
+    tab_width: 2,
+    indent_with: :spaces,
+    language_servers: [],
+    root_markers: []
+  ]
+end

--- a/lib/minga/language/bash.ex
+++ b/lib/minga/language/bash.ex
@@ -1,0 +1,27 @@
+defmodule Minga.Language.Bash do
+  @moduledoc "Shell language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :bash,
+      label: "Shell",
+      comment_token: "# ",
+      extensions: ["sh", "bash", "zsh"],
+      shebangs: ["bash", "sh", "zsh"],
+      icon: "\u{E795}",
+      icon_color: 0x89E051,
+      grammar: "bash",
+      language_servers: [
+        %ServerConfig{
+          name: :bash_language_server,
+          command: "bash-language-server",
+          args: ["start"]
+        }
+      ]
+    }
+  end
+end

--- a/lib/minga/language/c.ex
+++ b/lib/minga/language/c.ex
@@ -1,0 +1,27 @@
+defmodule Minga.Language.C do
+  @moduledoc "C language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :c,
+      label: "C",
+      comment_token: "// ",
+      extensions: ["c", "h"],
+      icon: "\u{E61E}",
+      icon_color: 0x599EFF,
+      grammar: "c",
+      formatter: "clang-format",
+      language_servers: [
+        %ServerConfig{
+          name: :clangd,
+          command: "clangd",
+          root_markers: ["compile_commands.json", "CMakeLists.txt", ".clangd"]
+        }
+      ]
+    }
+  end
+end

--- a/lib/minga/language/c_sharp.ex
+++ b/lib/minga/language/c_sharp.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.CSharp do
+  @moduledoc "C# language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :c_sharp,
+      label: "C#",
+      comment_token: "// ",
+      extensions: ["cs", "csx"],
+      icon: "\u{F031B}",
+      icon_color: 0x68217A,
+      grammar: "c_sharp"
+    }
+  end
+end

--- a/lib/minga/language/conf.ex
+++ b/lib/minga/language/conf.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.Conf do
+  @moduledoc "Config language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :conf,
+      label: "Config",
+      comment_token: "# ",
+      extensions: ["conf", "cfg"],
+      icon: "\u{E615}",
+      icon_color: 0x6D8086
+    }
+  end
+end

--- a/lib/minga/language/cpp.ex
+++ b/lib/minga/language/cpp.ex
@@ -1,0 +1,27 @@
+defmodule Minga.Language.Cpp do
+  @moduledoc "C++ language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :cpp,
+      label: "C++",
+      comment_token: "// ",
+      extensions: ["cpp", "cc", "cxx", "hpp"],
+      icon: "\u{E61D}",
+      icon_color: 0xF34B7D,
+      grammar: "cpp",
+      formatter: "clang-format",
+      language_servers: [
+        %ServerConfig{
+          name: :clangd,
+          command: "clangd",
+          root_markers: ["compile_commands.json", "CMakeLists.txt", ".clangd"]
+        }
+      ]
+    }
+  end
+end

--- a/lib/minga/language/css.ex
+++ b/lib/minga/language/css.ex
@@ -1,0 +1,27 @@
+defmodule Minga.Language.Css do
+  @moduledoc "CSS language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :css,
+      label: "CSS",
+      comment_token: "/* ",
+      extensions: ["css"],
+      icon: "\u{E749}",
+      icon_color: 0x563D7C,
+      grammar: "css",
+      language_servers: [
+        %ServerConfig{
+          name: :vscode_css_languageserver,
+          command: "vscode-css-language-server",
+          args: ["--stdio"],
+          root_markers: ["package.json"]
+        }
+      ]
+    }
+  end
+end

--- a/lib/minga/language/csv.ex
+++ b/lib/minga/language/csv.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.Csv do
+  @moduledoc "CSV language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :csv,
+      label: "CSV",
+      comment_token: "# ",
+      extensions: ["csv", "tsv"],
+      icon: "\u{F0CE}",
+      icon_color: 0x89E051
+    }
+  end
+end

--- a/lib/minga/language/dart.ex
+++ b/lib/minga/language/dart.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Dart do
+  @moduledoc "Dart language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :dart,
+      label: "Dart",
+      comment_token: "// ",
+      extensions: ["dart"],
+      icon: "\u{E798}",
+      icon_color: 0x03589C,
+      grammar: "dart"
+    }
+  end
+end

--- a/lib/minga/language/diff.ex
+++ b/lib/minga/language/diff.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Diff do
+  @moduledoc "Diff language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :diff,
+      label: "Diff",
+      comment_token: "# ",
+      extensions: ["diff", "patch"],
+      icon: "\u{F1492}",
+      icon_color: 0x41535B,
+      grammar: "diff"
+    }
+  end
+end

--- a/lib/minga/language/dockerfile.ex
+++ b/lib/minga/language/dockerfile.ex
@@ -1,0 +1,19 @@
+defmodule Minga.Language.Dockerfile do
+  @moduledoc "Dockerfile language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :dockerfile,
+      label: "Dockerfile",
+      comment_token: "# ",
+      extensions: ["dockerfile"],
+      filenames: ["Dockerfile"],
+      icon: "\u{F0868}",
+      icon_color: 0x0DB7ED,
+      grammar: "dockerfile"
+    }
+  end
+end

--- a/lib/minga/language/editor_config.ex
+++ b/lib/minga/language/editor_config.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.EditorConfig do
+  @moduledoc "EditorConfig language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :editorconfig,
+      label: "EditorConfig",
+      comment_token: "# ",
+      filenames: [".editorconfig"],
+      icon: "\u{E615}",
+      icon_color: 0x6D8086
+    }
+  end
+end

--- a/lib/minga/language/elixir.ex
+++ b/lib/minga/language/elixir.ex
@@ -1,0 +1,31 @@
+defmodule Minga.Language.Elixir do
+  @moduledoc "Elixir language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :elixir,
+      label: "Elixir",
+      comment_token: "# ",
+      extensions: ["ex", "exs"],
+      filenames: ["mix.lock"],
+      shebangs: ["elixir"],
+      icon: "\u{E62D}",
+      icon_color: 0x9B59B6,
+      grammar: "elixir",
+      formatter: "mix format --stdin-filename {file} -",
+      language_servers: [
+        %ServerConfig{
+          name: :lexical,
+          command: "lexical",
+          root_markers: ["mix.exs"]
+        }
+      ],
+      root_markers: ["mix.exs", "mix.lock"],
+      project_type: :mix
+    }
+  end
+end

--- a/lib/minga/language/emacs_lisp.ex
+++ b/lib/minga/language/emacs_lisp.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.EmacsLisp do
+  @moduledoc "Emacs Lisp language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :emacs_lisp,
+      label: "Emacs Lisp",
+      comment_token: ";; ",
+      extensions: ["el"],
+      icon: "\u{E632}",
+      icon_color: 0x7F5AB6,
+      grammar: "elisp"
+    }
+  end
+end

--- a/lib/minga/language/erlang.ex
+++ b/lib/minga/language/erlang.ex
@@ -1,0 +1,20 @@
+defmodule Minga.Language.Erlang do
+  @moduledoc "Erlang language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :erlang,
+      label: "Erlang",
+      comment_token: "% ",
+      extensions: ["erl", "hrl"],
+      filenames: ["rebar.config", "rebar.lock"],
+      shebangs: ["escript"],
+      icon: "\u{E7B1}",
+      icon_color: 0xA90533,
+      grammar: "erlang"
+    }
+  end
+end

--- a/lib/minga/language/fish.ex
+++ b/lib/minga/language/fish.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Fish do
+  @moduledoc "Fish language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :fish,
+      label: "Fish",
+      comment_token: "# ",
+      extensions: ["fish"],
+      shebangs: ["fish"],
+      icon: "\u{E795}",
+      icon_color: 0x89E051
+    }
+  end
+end

--- a/lib/minga/language/git_config.ex
+++ b/lib/minga/language/git_config.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.GitConfig do
+  @moduledoc "Git Config language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :gitconfig,
+      label: "Git Config",
+      comment_token: "# ",
+      filenames: [".gitignore", ".gitattributes", ".gitmodules"],
+      icon: "\u{E702}",
+      icon_color: 0xF14C28
+    }
+  end
+end

--- a/lib/minga/language/gleam.ex
+++ b/lib/minga/language/gleam.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Gleam do
+  @moduledoc "Gleam language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :gleam,
+      label: "Gleam",
+      comment_token: "// ",
+      extensions: ["gleam"],
+      icon: "\u{F0E7}",
+      icon_color: 0xFFAFEF,
+      grammar: "gleam"
+    }
+  end
+end

--- a/lib/minga/language/go.ex
+++ b/lib/minga/language/go.ex
@@ -1,0 +1,31 @@
+defmodule Minga.Language.Go do
+  @moduledoc "Go language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :go,
+      label: "Go",
+      comment_token: "// ",
+      extensions: ["go"],
+      icon: "\u{E626}",
+      icon_color: 0x00ADD8,
+      tab_width: 4,
+      indent_with: :tabs,
+      grammar: "go",
+      formatter: "gofmt",
+      language_servers: [
+        %ServerConfig{
+          name: :gopls,
+          command: "gopls",
+          root_markers: ["go.mod", "go.sum"]
+        }
+      ],
+      root_markers: ["go.mod"],
+      project_type: :go
+    }
+  end
+end

--- a/lib/minga/language/graphql.ex
+++ b/lib/minga/language/graphql.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.GraphQL do
+  @moduledoc "GraphQL language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :graphql,
+      label: "GraphQL",
+      comment_token: "# ",
+      extensions: ["graphql", "gql"],
+      icon: "\u{F0877}",
+      icon_color: 0xE10098,
+      grammar: "graphql"
+    }
+  end
+end

--- a/lib/minga/language/haskell.ex
+++ b/lib/minga/language/haskell.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Haskell do
+  @moduledoc "Haskell language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :haskell,
+      label: "Haskell",
+      comment_token: "-- ",
+      extensions: ["hs", "lhs"],
+      icon: "\u{E777}",
+      icon_color: 0x5E5086,
+      grammar: "haskell"
+    }
+  end
+end

--- a/lib/minga/language/hcl.ex
+++ b/lib/minga/language/hcl.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Hcl do
+  @moduledoc "HCL language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :hcl,
+      label: "HCL",
+      comment_token: "// ",
+      extensions: ["tf", "tfvars", "hcl"],
+      icon: "\u{F1062}",
+      icon_color: 0x7B42BC,
+      grammar: "hcl"
+    }
+  end
+end

--- a/lib/minga/language/heex.ex
+++ b/lib/minga/language/heex.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Heex do
+  @moduledoc "HEEx language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :heex,
+      label: "HEEx",
+      comment_token: "<%!-- ",
+      extensions: ["heex", "leex"],
+      icon: "\u{E62D}",
+      icon_color: 0x9B59B6,
+      grammar: "heex"
+    }
+  end
+end

--- a/lib/minga/language/html.ex
+++ b/lib/minga/language/html.ex
@@ -1,0 +1,27 @@
+defmodule Minga.Language.Html do
+  @moduledoc "HTML language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :html,
+      label: "HTML",
+      comment_token: "<!-- ",
+      extensions: ["html", "htm"],
+      icon: "\u{E736}",
+      icon_color: 0xE34C26,
+      grammar: "html",
+      language_servers: [
+        %ServerConfig{
+          name: :vscode_html_languageserver,
+          command: "vscode-html-language-server",
+          args: ["--stdio"],
+          root_markers: ["package.json"]
+        }
+      ]
+    }
+  end
+end

--- a/lib/minga/language/ini.ex
+++ b/lib/minga/language/ini.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.Ini do
+  @moduledoc "INI language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :ini,
+      label: "INI",
+      comment_token: "; ",
+      extensions: ["ini"],
+      icon: "\u{E615}",
+      icon_color: 0x6D8086
+    }
+  end
+end

--- a/lib/minga/language/java.ex
+++ b/lib/minga/language/java.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Java do
+  @moduledoc "Java language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :java,
+      label: "Java",
+      comment_token: "// ",
+      extensions: ["java"],
+      icon: "\u{E738}",
+      icon_color: 0xCC3E44,
+      grammar: "java"
+    }
+  end
+end

--- a/lib/minga/language/javascript.ex
+++ b/lib/minga/language/javascript.ex
@@ -1,0 +1,31 @@
+defmodule Minga.Language.JavaScript do
+  @moduledoc "JavaScript language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :javascript,
+      label: "JavaScript",
+      comment_token: "// ",
+      extensions: ["js", "mjs", "cjs"],
+      shebangs: ["node"],
+      icon: "\u{E781}",
+      icon_color: 0xF7DF1E,
+      grammar: "javascript",
+      formatter: "prettier --stdin-filepath {file}",
+      language_servers: [
+        %ServerConfig{
+          name: :typescript_language_server,
+          command: "typescript-language-server",
+          args: ["--stdio"],
+          root_markers: ["package.json", "tsconfig.json", "jsconfig.json"]
+        }
+      ],
+      root_markers: ["package.json"],
+      project_type: :node
+    }
+  end
+end

--- a/lib/minga/language/javascript_react.ex
+++ b/lib/minga/language/javascript_react.ex
@@ -1,0 +1,19 @@
+defmodule Minga.Language.JavaScriptReact do
+  @moduledoc "JSX language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :javascript_react,
+      label: "JSX",
+      comment_token: "// ",
+      extensions: ["jsx"],
+      icon: "\u{E7BA}",
+      icon_color: 0x61DAFB,
+      grammar: "javascript",
+      formatter: "prettier --stdin-filepath {file}"
+    }
+  end
+end

--- a/lib/minga/language/json.ex
+++ b/lib/minga/language/json.ex
@@ -1,0 +1,26 @@
+defmodule Minga.Language.Json do
+  @moduledoc "JSON language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :json,
+      label: "JSON",
+      comment_token: "// ",
+      extensions: ["json", "jsonc"],
+      icon: "\u{E60B}",
+      icon_color: 0xCBCB41,
+      grammar: "json",
+      language_servers: [
+        %ServerConfig{
+          name: :vscode_json_languageserver,
+          command: "vscode-json-language-server",
+          args: ["--stdio"]
+        }
+      ]
+    }
+  end
+end

--- a/lib/minga/language/kotlin.ex
+++ b/lib/minga/language/kotlin.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Kotlin do
+  @moduledoc "Kotlin language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :kotlin,
+      label: "Kotlin",
+      comment_token: "// ",
+      extensions: ["kt", "kts"],
+      icon: "\u{E634}",
+      icon_color: 0x7F52FF,
+      grammar: "kotlin"
+    }
+  end
+end

--- a/lib/minga/language/lfe.ex
+++ b/lib/minga/language/lfe.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.Lfe do
+  @moduledoc "LFE language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :lfe,
+      label: "LFE",
+      comment_token: ";; ",
+      extensions: ["lfe"],
+      icon: "\u{E7B1}",
+      icon_color: 0xA90533
+    }
+  end
+end

--- a/lib/minga/language/lua.ex
+++ b/lib/minga/language/lua.ex
@@ -1,0 +1,27 @@
+defmodule Minga.Language.Lua do
+  @moduledoc "Lua language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :lua,
+      label: "Lua",
+      comment_token: "-- ",
+      extensions: ["lua"],
+      shebangs: ["lua"],
+      icon: "\u{E620}",
+      icon_color: 0x000080,
+      grammar: "lua",
+      language_servers: [
+        %ServerConfig{
+          name: :lua_ls,
+          command: "lua-language-server",
+          root_markers: [".luarc.json", ".luarc.jsonc", ".stylua.toml"]
+        }
+      ]
+    }
+  end
+end

--- a/lib/minga/language/make.ex
+++ b/lib/minga/language/make.ex
@@ -1,0 +1,21 @@
+defmodule Minga.Language.Make do
+  @moduledoc "Makefile language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :make,
+      label: "Makefile",
+      comment_token: "# ",
+      extensions: ["mk", "mak"],
+      filenames: ["Makefile", "GNUmakefile"],
+      icon: "\u{E673}",
+      icon_color: 0x6D8086,
+      tab_width: 4,
+      indent_with: :tabs,
+      grammar: "make"
+    }
+  end
+end

--- a/lib/minga/language/markdown.ex
+++ b/lib/minga/language/markdown.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Markdown do
+  @moduledoc "Markdown language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :markdown,
+      label: "Markdown",
+      comment_token: "<!-- ",
+      extensions: ["md", "markdown"],
+      icon: "\u{E73E}",
+      icon_color: 0x519ABA,
+      grammar: "markdown"
+    }
+  end
+end

--- a/lib/minga/language/nix.ex
+++ b/lib/minga/language/nix.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Nix do
+  @moduledoc "Nix language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :nix,
+      label: "Nix",
+      comment_token: "# ",
+      extensions: ["nix"],
+      icon: "\u{F0313}",
+      icon_color: 0x7EBAE4,
+      grammar: "nix"
+    }
+  end
+end

--- a/lib/minga/language/ocaml.ex
+++ b/lib/minga/language/ocaml.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.OCaml do
+  @moduledoc "OCaml language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :ocaml,
+      label: "OCaml",
+      comment_token: "(* ",
+      extensions: ["ml", "mli"],
+      icon: "\u{E67F}",
+      icon_color: 0xEC6813,
+      grammar: "ocaml"
+    }
+  end
+end

--- a/lib/minga/language/perl.ex
+++ b/lib/minga/language/perl.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.Perl do
+  @moduledoc "Perl language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :perl,
+      label: "Perl",
+      comment_token: "# ",
+      shebangs: ["perl"],
+      icon: "\u{E769}",
+      icon_color: 0x39457E
+    }
+  end
+end

--- a/lib/minga/language/php.ex
+++ b/lib/minga/language/php.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Php do
+  @moduledoc "PHP language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :php,
+      label: "PHP",
+      comment_token: "// ",
+      extensions: ["php", "phtml"],
+      icon: "\u{E73D}",
+      icon_color: 0x777BB3,
+      grammar: "php"
+    }
+  end
+end

--- a/lib/minga/language/protobuf.ex
+++ b/lib/minga/language/protobuf.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.Protobuf do
+  @moduledoc "Protobuf language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :protobuf,
+      label: "Protobuf",
+      comment_token: "// ",
+      extensions: ["proto"],
+      icon: "\u{F0614}",
+      icon_color: 0x6A9FB5
+    }
+  end
+end

--- a/lib/minga/language/python.ex
+++ b/lib/minga/language/python.ex
@@ -1,0 +1,32 @@
+defmodule Minga.Language.Python do
+  @moduledoc "Python language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :python,
+      label: "Python",
+      comment_token: "# ",
+      extensions: ["py", "pyi"],
+      shebangs: ["python", "python3"],
+      icon: "\u{E73C}",
+      icon_color: 0x3776AB,
+      tab_width: 4,
+      grammar: "python",
+      formatter: "python3 -m black --quiet -",
+      language_servers: [
+        %ServerConfig{
+          name: :pyright,
+          command: "pyright-langserver",
+          args: ["--stdio"],
+          root_markers: ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt"]
+        }
+      ],
+      root_markers: ["pyproject.toml", "setup.py"],
+      project_type: :python
+    }
+  end
+end

--- a/lib/minga/language/r.ex
+++ b/lib/minga/language/r.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.R do
+  @moduledoc "R language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :r,
+      label: "R",
+      comment_token: "# ",
+      extensions: ["r", "rmd"],
+      icon: "\u{E68A}",
+      icon_color: 0x276DC3,
+      grammar: "r"
+    }
+  end
+end

--- a/lib/minga/language/registry.ex
+++ b/lib/minga/language/registry.ex
@@ -1,0 +1,271 @@
+defmodule Minga.Language.Registry do
+  @moduledoc """
+  Collects all language definitions at startup and provides O(1) lookups.
+
+  Backed by ETS with `read_concurrency: true` for lock-free reads on
+  every keystroke, render frame, and comment toggle. The GenServer exists
+  only to own the ETS table lifecycle. All reads go directly to ETS.
+
+  ## Lookup functions
+
+  - `get/1` — lookup by language name atom (e.g., `:elixir`)
+  - `for_extension/1` — lookup by file extension string (e.g., `"ex"`)
+  - `for_filename/1` — lookup by exact filename (e.g., `"Makefile"`)
+  - `for_shebang/1` — lookup by shebang interpreter (e.g., `"python3"`)
+
+  ## Runtime registration
+
+  Extensions register new languages via `register/1`. Runtime
+  registrations override built-in definitions for the same name.
+  """
+
+  use GenServer
+
+  alias Minga.Language
+
+  @table :minga_language_registry
+
+  # All built-in language definition modules. Add new languages here.
+  @language_modules [
+    Minga.Language.Bash,
+    Minga.Language.C,
+    Minga.Language.Conf,
+    Minga.Language.Cpp,
+    Minga.Language.CSharp,
+    Minga.Language.Css,
+    Minga.Language.Csv,
+    Minga.Language.Dart,
+    Minga.Language.Diff,
+    Minga.Language.Dockerfile,
+    Minga.Language.EditorConfig,
+    Minga.Language.Elixir,
+    Minga.Language.EmacsLisp,
+    Minga.Language.Erlang,
+    Minga.Language.Fish,
+    Minga.Language.GitConfig,
+    Minga.Language.Gleam,
+    Minga.Language.Go,
+    Minga.Language.GraphQL,
+    Minga.Language.Haskell,
+    Minga.Language.Hcl,
+    Minga.Language.Heex,
+    Minga.Language.Html,
+    Minga.Language.Ini,
+    Minga.Language.Java,
+    Minga.Language.JavaScript,
+    Minga.Language.JavaScriptReact,
+    Minga.Language.Json,
+    Minga.Language.Kotlin,
+    Minga.Language.Lfe,
+    Minga.Language.Lua,
+    Minga.Language.Make,
+    Minga.Language.Markdown,
+    Minga.Language.Nix,
+    Minga.Language.OCaml,
+    Minga.Language.Perl,
+    Minga.Language.Php,
+    Minga.Language.Protobuf,
+    Minga.Language.Python,
+    Minga.Language.R,
+    Minga.Language.Ruby,
+    Minga.Language.Rust,
+    Minga.Language.Scala,
+    Minga.Language.Scss,
+    Minga.Language.Sql,
+    Minga.Language.Swift,
+    Minga.Language.Text,
+    Minga.Language.Toml,
+    Minga.Language.TypeScript,
+    Minga.Language.TypeScriptReact,
+    Minga.Language.Vim,
+    Minga.Language.Xml,
+    Minga.Language.Yaml,
+    Minga.Language.Zig
+  ]
+
+  # ── Client API ─────────────────────────────────────────────────────────────
+
+  @doc "Starts the language registry."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Returns the language definition for a name atom, or `nil` if unknown.
+
+  ## Examples
+
+      iex> lang = Minga.Language.Registry.get(:elixir)
+      iex> lang.label
+      "Elixir"
+
+      iex> Minga.Language.Registry.get(:unknown_language)
+      nil
+  """
+  @spec get(atom()) :: Language.t() | nil
+  def get(name) when is_atom(name) do
+    case :ets.lookup(@table, {:name, name}) do
+      [{_, lang}] -> lang
+      [] -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  @doc """
+  Returns the language definition for a file extension, or `nil`.
+
+  The extension should not include the leading dot and is matched
+  case-insensitively.
+
+  ## Examples
+
+      iex> lang = Minga.Language.Registry.for_extension("ex")
+      iex> lang.name
+      :elixir
+  """
+  @spec for_extension(String.t()) :: Language.t() | nil
+  def for_extension(ext) when is_binary(ext) do
+    case :ets.lookup(@table, {:ext, String.downcase(ext)}) do
+      [{_, lang}] -> lang
+      [] -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  @doc """
+  Returns the language definition for an exact filename, or `nil`.
+
+  ## Examples
+
+      iex> lang = Minga.Language.Registry.for_filename("Makefile")
+      iex> lang.name
+      :make
+  """
+  @spec for_filename(String.t()) :: Language.t() | nil
+  def for_filename(filename) when is_binary(filename) do
+    case :ets.lookup(@table, {:filename, filename}) do
+      [{_, lang}] -> lang
+      [] -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  @doc """
+  Returns the language definition for a shebang interpreter, or `nil`.
+
+  ## Examples
+
+      iex> lang = Minga.Language.Registry.for_shebang("python3")
+      iex> lang.name
+      :python
+  """
+  @spec for_shebang(String.t()) :: Language.t() | nil
+  def for_shebang(interpreter) when is_binary(interpreter) do
+    case :ets.lookup(@table, {:shebang, interpreter}) do
+      [{_, lang}] -> lang
+      [] -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  @doc """
+  Returns all registered language definitions.
+  """
+  @spec all() :: [Language.t()]
+  def all do
+    @table
+    |> :ets.match({{:name, :_}, :"$1"})
+    |> List.flatten()
+  rescue
+    ArgumentError -> []
+  end
+
+  @doc """
+  Returns all language names that have definitions.
+  """
+  @spec supported_names() :: [atom()]
+  def supported_names do
+    @table
+    |> :ets.match({{:name, :"$1"}, :_})
+    |> List.flatten()
+  rescue
+    ArgumentError -> []
+  end
+
+  @doc """
+  Registers a language at runtime (for extensions).
+
+  Overwrites any existing definition for the same name. Rebuilds
+  the extension, filename, and shebang index entries.
+  """
+  @spec register(Language.t()) :: :ok
+  def register(%Language{} = lang) do
+    # Remove stale index entries from the old definition before inserting
+    case get(lang.name) do
+      %Language{} = old -> remove_index_entries(old)
+      nil -> :ok
+    end
+
+    insert_language(lang)
+    :ok
+  end
+
+  # ── GenServer callbacks ────────────────────────────────────────────────────
+
+  @impl true
+  @spec init(keyword()) :: {:ok, :no_state}
+  def init(_opts) do
+    :ets.new(@table, [
+      :named_table,
+      :set,
+      :public,
+      read_concurrency: true
+    ])
+
+    for mod <- @language_modules do
+      lang = mod.definition()
+      insert_language(lang)
+    end
+
+    {:ok, :no_state}
+  end
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec remove_index_entries(Language.t()) :: :ok
+  defp remove_index_entries(%Language{} = lang) do
+    for ext <- lang.extensions, do: :ets.delete(@table, {:ext, String.downcase(ext)})
+    for filename <- lang.filenames, do: :ets.delete(@table, {:filename, filename})
+    for interpreter <- lang.shebangs, do: :ets.delete(@table, {:shebang, interpreter})
+    :ok
+  end
+
+  @spec insert_language(Language.t()) :: :ok
+  defp insert_language(%Language{} = lang) do
+    # Primary lookup by name
+    :ets.insert(@table, {{:name, lang.name}, lang})
+
+    # Index by extension
+    for ext <- lang.extensions do
+      :ets.insert(@table, {{:ext, String.downcase(ext)}, lang})
+    end
+
+    # Index by filename
+    for filename <- lang.filenames do
+      :ets.insert(@table, {{:filename, filename}, lang})
+    end
+
+    # Index by shebang interpreter
+    for interpreter <- lang.shebangs do
+      :ets.insert(@table, {{:shebang, interpreter}, lang})
+    end
+
+    :ok
+  end
+end

--- a/lib/minga/language/ruby.ex
+++ b/lib/minga/language/ruby.ex
@@ -1,0 +1,31 @@
+defmodule Minga.Language.Ruby do
+  @moduledoc "Ruby language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :ruby,
+      label: "Ruby",
+      comment_token: "# ",
+      extensions: ["rb", "rake", "gemspec"],
+      filenames: ["Gemfile", "Rakefile", "Brewfile"],
+      shebangs: ["ruby"],
+      icon: "\u{E739}",
+      icon_color: 0xCC342D,
+      grammar: "ruby",
+      language_servers: [
+        %ServerConfig{
+          name: :solargraph,
+          command: "solargraph",
+          args: ["stdio"],
+          root_markers: ["Gemfile", ".solargraph.yml"]
+        }
+      ],
+      root_markers: ["Gemfile"],
+      project_type: :ruby
+    }
+  end
+end

--- a/lib/minga/language/rust.ex
+++ b/lib/minga/language/rust.ex
@@ -1,0 +1,29 @@
+defmodule Minga.Language.Rust do
+  @moduledoc "Rust language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :rust,
+      label: "Rust",
+      comment_token: "// ",
+      extensions: ["rs"],
+      icon: "\u{E7A8}",
+      icon_color: 0xDEA584,
+      grammar: "rust",
+      formatter: "rustfmt --edition 2021",
+      language_servers: [
+        %ServerConfig{
+          name: :rust_analyzer,
+          command: "rust-analyzer",
+          root_markers: ["Cargo.toml"]
+        }
+      ],
+      root_markers: ["Cargo.toml"],
+      project_type: :cargo
+    }
+  end
+end

--- a/lib/minga/language/scala.ex
+++ b/lib/minga/language/scala.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Scala do
+  @moduledoc "Scala language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :scala,
+      label: "Scala",
+      comment_token: "// ",
+      extensions: ["scala", "sbt", "sc"],
+      icon: "\u{E737}",
+      icon_color: 0xCC3E44,
+      grammar: "scala"
+    }
+  end
+end

--- a/lib/minga/language/scss.ex
+++ b/lib/minga/language/scss.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Scss do
+  @moduledoc "SCSS language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :scss,
+      label: "SCSS",
+      comment_token: "// ",
+      extensions: ["scss", "sass"],
+      icon: "\u{E74B}",
+      icon_color: 0xCD6799,
+      grammar: "scss"
+    }
+  end
+end

--- a/lib/minga/language/sql.ex
+++ b/lib/minga/language/sql.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.Sql do
+  @moduledoc "SQL language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :sql,
+      label: "SQL",
+      comment_token: "-- ",
+      extensions: ["sql"],
+      icon: "\u{E706}",
+      icon_color: 0xDAD8D8
+    }
+  end
+end

--- a/lib/minga/language/swift.ex
+++ b/lib/minga/language/swift.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.Swift do
+  @moduledoc "Swift language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :swift,
+      label: "Swift",
+      comment_token: "// ",
+      extensions: ["swift"],
+      icon: "\u{E755}",
+      icon_color: 0xF05138
+    }
+  end
+end

--- a/lib/minga/language/text.ex
+++ b/lib/minga/language/text.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.Text do
+  @moduledoc "Text language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :text,
+      label: "Text",
+      comment_token: "# ",
+      extensions: ["txt"],
+      icon: "\u{E612}",
+      icon_color: 0x89E051
+    }
+  end
+end

--- a/lib/minga/language/toml.ex
+++ b/lib/minga/language/toml.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Language.Toml do
+  @moduledoc "TOML language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :toml,
+      label: "TOML",
+      comment_token: "# ",
+      extensions: ["toml"],
+      icon: "\u{E615}",
+      icon_color: 0x9C4221,
+      grammar: "toml"
+    }
+  end
+end

--- a/lib/minga/language/typescript.ex
+++ b/lib/minga/language/typescript.ex
@@ -1,0 +1,28 @@
+defmodule Minga.Language.TypeScript do
+  @moduledoc "TypeScript language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :typescript,
+      label: "TypeScript",
+      comment_token: "// ",
+      extensions: ["ts", "mts", "cts"],
+      icon: "\u{E628}",
+      icon_color: 0x3178C6,
+      grammar: "typescript",
+      formatter: "prettier --stdin-filepath {file}",
+      language_servers: [
+        %ServerConfig{
+          name: :typescript_language_server,
+          command: "typescript-language-server",
+          args: ["--stdio"],
+          root_markers: ["package.json", "tsconfig.json"]
+        }
+      ]
+    }
+  end
+end

--- a/lib/minga/language/typescript_react.ex
+++ b/lib/minga/language/typescript_react.ex
@@ -1,0 +1,19 @@
+defmodule Minga.Language.TypeScriptReact do
+  @moduledoc "TSX language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :typescript_react,
+      label: "TSX",
+      comment_token: "// ",
+      extensions: ["tsx"],
+      icon: "\u{E7BA}",
+      icon_color: 0x3178C6,
+      grammar: "tsx",
+      formatter: "prettier --stdin-filepath {file}"
+    }
+  end
+end

--- a/lib/minga/language/vim.ex
+++ b/lib/minga/language/vim.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.Vim do
+  @moduledoc "Vim language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :vim,
+      label: "Vim",
+      comment_token: "\" ",
+      extensions: ["vim"],
+      icon: "\u{E62B}",
+      icon_color: 0x019833
+    }
+  end
+end

--- a/lib/minga/language/xml.ex
+++ b/lib/minga/language/xml.ex
@@ -1,0 +1,17 @@
+defmodule Minga.Language.Xml do
+  @moduledoc "XML language definition"
+
+  alias Minga.Language
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :xml,
+      label: "XML",
+      comment_token: "<!-- ",
+      extensions: ["xml", "svg"],
+      icon: "\u{F05C0}",
+      icon_color: 0xE37933
+    }
+  end
+end

--- a/lib/minga/language/yaml.ex
+++ b/lib/minga/language/yaml.ex
@@ -1,0 +1,26 @@
+defmodule Minga.Language.Yaml do
+  @moduledoc "YAML language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :yaml,
+      label: "YAML",
+      comment_token: "# ",
+      extensions: ["yaml", "yml"],
+      icon: "\u{E6A8}",
+      icon_color: 0xCB171E,
+      grammar: "yaml",
+      language_servers: [
+        %ServerConfig{
+          name: :yaml_language_server,
+          command: "yaml-language-server",
+          args: ["--stdio"]
+        }
+      ]
+    }
+  end
+end

--- a/lib/minga/language/zig.ex
+++ b/lib/minga/language/zig.ex
@@ -1,0 +1,29 @@
+defmodule Minga.Language.Zig do
+  @moduledoc "Zig language definition"
+
+  alias Minga.Language
+  alias Minga.LSP.ServerConfig
+
+  @spec definition() :: Language.t()
+  def definition do
+    %Language{
+      name: :zig,
+      label: "Zig",
+      comment_token: "// ",
+      extensions: ["zig", "zon"],
+      icon: "\u{E6A9}",
+      icon_color: 0xF69A1B,
+      grammar: "zig",
+      formatter: "zig fmt --stdin",
+      language_servers: [
+        %ServerConfig{
+          name: :zls,
+          command: "zls",
+          root_markers: ["build.zig", "build.zig.zon"]
+        }
+      ],
+      root_markers: ["build.zig"],
+      project_type: :zig
+    }
+  end
+end

--- a/lib/minga/lsp/server_registry.ex
+++ b/lib/minga/lsp/server_registry.ex
@@ -19,131 +19,11 @@ defmodule Minga.LSP.ServerRegistry do
   or extend these defaults without modifying source code.
   """
 
+  alias Minga.Language.Registry, as: LangRegistry
   alias Minga.LSP.ServerConfig
 
   @typedoc "Configuration for a single language server."
   @type server_config :: ServerConfig.t()
-
-  @servers %{
-    elixir: [
-      %ServerConfig{
-        name: :lexical,
-        command: "lexical",
-        root_markers: ["mix.exs"]
-      }
-    ],
-    go: [
-      %ServerConfig{
-        name: :gopls,
-        command: "gopls",
-        root_markers: ["go.mod", "go.sum"]
-      }
-    ],
-    rust: [
-      %ServerConfig{
-        name: :rust_analyzer,
-        command: "rust-analyzer",
-        root_markers: ["Cargo.toml"]
-      }
-    ],
-    c: [
-      %ServerConfig{
-        name: :clangd,
-        command: "clangd",
-        root_markers: ["compile_commands.json", "CMakeLists.txt", ".clangd"]
-      }
-    ],
-    cpp: [
-      %ServerConfig{
-        name: :clangd,
-        command: "clangd",
-        root_markers: ["compile_commands.json", "CMakeLists.txt", ".clangd"]
-      }
-    ],
-    javascript: [
-      %ServerConfig{
-        name: :typescript_language_server,
-        command: "typescript-language-server",
-        args: ["--stdio"],
-        root_markers: ["package.json", "tsconfig.json", "jsconfig.json"]
-      }
-    ],
-    typescript: [
-      %ServerConfig{
-        name: :typescript_language_server,
-        command: "typescript-language-server",
-        args: ["--stdio"],
-        root_markers: ["package.json", "tsconfig.json"]
-      }
-    ],
-    python: [
-      %ServerConfig{
-        name: :pyright,
-        command: "pyright-langserver",
-        args: ["--stdio"],
-        root_markers: ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt"]
-      }
-    ],
-    ruby: [
-      %ServerConfig{
-        name: :solargraph,
-        command: "solargraph",
-        args: ["stdio"],
-        root_markers: ["Gemfile", ".solargraph.yml"]
-      }
-    ],
-    zig: [
-      %ServerConfig{
-        name: :zls,
-        command: "zls",
-        root_markers: ["build.zig", "build.zig.zon"]
-      }
-    ],
-    lua: [
-      %ServerConfig{
-        name: :lua_ls,
-        command: "lua-language-server",
-        root_markers: [".luarc.json", ".luarc.jsonc", ".stylua.toml"]
-      }
-    ],
-    json: [
-      %ServerConfig{
-        name: :vscode_json_languageserver,
-        command: "vscode-json-language-server",
-        args: ["--stdio"]
-      }
-    ],
-    yaml: [
-      %ServerConfig{
-        name: :yaml_language_server,
-        command: "yaml-language-server",
-        args: ["--stdio"]
-      }
-    ],
-    css: [
-      %ServerConfig{
-        name: :vscode_css_languageserver,
-        command: "vscode-css-language-server",
-        args: ["--stdio"],
-        root_markers: ["package.json"]
-      }
-    ],
-    html: [
-      %ServerConfig{
-        name: :vscode_html_languageserver,
-        command: "vscode-html-language-server",
-        args: ["--stdio"],
-        root_markers: ["package.json"]
-      }
-    ],
-    bash: [
-      %ServerConfig{
-        name: :bash_language_server,
-        command: "bash-language-server",
-        args: ["start"]
-      }
-    ]
-  }
 
   @doc """
   Returns the list of language server configs for a filetype.
@@ -163,7 +43,10 @@ defmodule Minga.LSP.ServerRegistry do
   """
   @spec servers_for(atom()) :: [server_config()]
   def servers_for(filetype) when is_atom(filetype) do
-    Map.get(@servers, filetype, [])
+    case LangRegistry.get(filetype) do
+      %{language_servers: servers} when is_list(servers) -> servers
+      _ -> []
+    end
   end
 
   @doc """
@@ -177,7 +60,9 @@ defmodule Minga.LSP.ServerRegistry do
   """
   @spec supported_filetypes() :: [atom()]
   def supported_filetypes do
-    Map.keys(@servers)
+    LangRegistry.all()
+    |> Enum.filter(fn lang -> lang.language_servers != [] end)
+    |> Enum.map(fn lang -> lang.name end)
   end
 
   @doc """

--- a/lib/minga/project/detector.ex
+++ b/lib/minga/project/detector.ex
@@ -23,42 +23,36 @@ defmodule Minga.Project.Detector do
   """
 
   @typedoc "Project type inferred from the marker that matched."
-  @type project_type ::
-          :git
-          | :mix
-          | :cargo
-          | :node
-          | :go
-          | :python
-          | :ruby
-          | :zig
-          | :minga
-          | :unknown
+  @type project_type :: atom()
 
   @typedoc "Detection result."
   @type result :: {:ok, root :: String.t(), project_type()} | :none
 
-  @default_markers [
+  # Non-language sentinel markers (always present regardless of Language registry)
+  @sentinel_markers [
     {".git", :git},
-    {"mix.exs", :mix},
-    {"Cargo.toml", :cargo},
-    {"package.json", :node},
-    {"go.mod", :go},
-    {"pyproject.toml", :python},
-    {"setup.py", :python},
-    {"Gemfile", :ruby},
-    {"build.zig", :zig},
     {".minga", :minga}
   ]
 
   @doc """
   Returns the default marker list as `{filename, project_type}` tuples.
 
-  These cover the most common project types. Pass a custom list to
-  `detect/2` if you need different markers.
+  Combines sentinel markers (`.git`, `.minga`) with root markers from
+  all registered languages. Pass a custom list to `detect/2` if you
+  need different markers.
   """
   @spec default_markers() :: [{String.t(), project_type()}]
-  def default_markers, do: @default_markers
+  def default_markers do
+    lang_markers =
+      Minga.Language.Registry.all()
+      |> Enum.flat_map(fn lang ->
+        type = lang.project_type || :unknown
+        Enum.map(lang.root_markers, fn marker -> {marker, type} end)
+      end)
+      |> Enum.uniq_by(fn {marker, _} -> marker end)
+
+    @sentinel_markers ++ lang_markers
+  end
 
   @doc """
   Detects the project root for a file using the default marker list.
@@ -73,7 +67,7 @@ defmodule Minga.Project.Detector do
   """
   @spec detect(String.t()) :: result()
   def detect(file_path) when is_binary(file_path) do
-    detect(file_path, @default_markers)
+    detect(file_path, default_markers())
   end
 
   @doc """

--- a/test/minga/language/registry_test.exs
+++ b/test/minga/language/registry_test.exs
@@ -1,0 +1,160 @@
+defmodule Minga.Language.RegistryTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Language
+  alias Minga.Language.Registry
+
+  describe "get/1" do
+    test "returns language definition by name" do
+      lang = Registry.get(:elixir)
+      assert %Language{} = lang
+      assert lang.name == :elixir
+      assert lang.label == "Elixir"
+      assert lang.comment_token == "# "
+      assert lang.grammar == "elixir"
+    end
+
+    test "returns nil for unknown language" do
+      assert Registry.get(:nonexistent_language_xyz) == nil
+    end
+
+    test "all priority languages are registered" do
+      for name <- [:elixir, :ruby, :typescript, :c, :cpp, :swift] do
+        assert %Language{name: ^name} = Registry.get(name)
+      end
+    end
+  end
+
+  describe "for_extension/1" do
+    test "looks up language by extension" do
+      lang = Registry.for_extension("ex")
+      assert lang.name == :elixir
+    end
+
+    test "case-insensitive extension lookup" do
+      lang = Registry.for_extension("EX")
+      assert lang.name == :elixir
+    end
+
+    test "returns nil for unknown extension" do
+      assert Registry.for_extension("zzzzz") == nil
+    end
+
+    test "multiple extensions map to the same language" do
+      assert Registry.for_extension("ts").name == :typescript
+      assert Registry.for_extension("mts").name == :typescript
+      assert Registry.for_extension("cts").name == :typescript
+    end
+  end
+
+  describe "for_filename/1" do
+    test "looks up language by exact filename" do
+      lang = Registry.for_filename("Makefile")
+      assert lang.name == :make
+    end
+
+    test "returns nil for unknown filename" do
+      assert Registry.for_filename("nonexistent_file_xyz") == nil
+    end
+
+    test "filename match is case-sensitive" do
+      assert Registry.for_filename("Makefile") != nil
+      assert Registry.for_filename("makefile") == nil
+    end
+  end
+
+  describe "for_shebang/1" do
+    test "looks up language by shebang interpreter" do
+      lang = Registry.for_shebang("python3")
+      assert lang.name == :python
+    end
+
+    test "returns nil for unknown interpreter" do
+      assert Registry.for_shebang("nonexistent_interp") == nil
+    end
+  end
+
+  describe "all/0" do
+    test "returns all registered languages" do
+      langs = Registry.all()
+      assert is_list(langs)
+      assert length(langs) > 40
+      names = Enum.map(langs, & &1.name)
+      assert :elixir in names
+      assert :ruby in names
+      assert :typescript in names
+    end
+  end
+
+  describe "supported_names/0" do
+    test "returns all registered language names" do
+      names = Registry.supported_names()
+      assert :elixir in names
+      assert :text in names
+      assert :go in names
+    end
+  end
+
+  describe "register/1" do
+    test "registers a new language at runtime" do
+      lang = %Language{
+        name: :test_lang_xyz,
+        label: "Test Lang",
+        comment_token: "// ",
+        extensions: ["xyz_test_ext"]
+      }
+
+      assert :ok = Registry.register(lang)
+      assert Registry.get(:test_lang_xyz).label == "Test Lang"
+      assert Registry.for_extension("xyz_test_ext").name == :test_lang_xyz
+    end
+
+    test "runtime registration overrides existing definition" do
+      original = Registry.get(:elixir)
+      assert original.label == "Elixir"
+
+      override = %Language{
+        name: :elixir,
+        label: "Elixir Override",
+        comment_token: "## ",
+        extensions: ["ex", "exs"]
+      }
+
+      Registry.register(override)
+      assert Registry.get(:elixir).label == "Elixir Override"
+
+      # Restore original
+      Registry.register(original)
+      assert Registry.get(:elixir).label == "Elixir"
+    end
+  end
+
+  describe "language data completeness" do
+    test "all languages with LSP servers have valid ServerConfig structs" do
+      for lang <- Registry.all(), server <- lang.language_servers do
+        assert is_atom(server.name), "#{lang.name}: server name should be atom"
+        assert is_binary(server.command), "#{lang.name}: server command should be string"
+      end
+    end
+
+    test "all languages have non-empty comment tokens" do
+      for lang <- Registry.all() do
+        assert is_binary(lang.comment_token), "#{lang.name}: comment_token should be string"
+        assert lang.comment_token != "", "#{lang.name}: comment_token should not be empty"
+      end
+    end
+
+    test "languages with grammars have string grammar names" do
+      for lang <- Registry.all(), lang.grammar != nil do
+        assert is_binary(lang.grammar), "#{lang.name}: grammar should be string"
+      end
+    end
+
+    test "languages with icons have both icon and icon_color" do
+      for lang <- Registry.all(), lang.icon != nil do
+        assert is_binary(lang.icon), "#{lang.name}: icon should be string"
+        assert is_integer(lang.icon_color), "#{lang.name}: icon_color should be integer"
+      end
+    end
+  end
+end

--- a/test/minga/language_test.exs
+++ b/test/minga/language_test.exs
@@ -1,0 +1,36 @@
+defmodule Minga.LanguageTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Language
+
+  describe "struct" do
+    test "enforces required keys" do
+      assert_raise ArgumentError, ~r/the following keys must also be given/, fn ->
+        struct!(Language, %{name: :test})
+      end
+    end
+
+    test "creates with required keys" do
+      lang = %Language{name: :test, label: "Test", comment_token: "# "}
+      assert lang.name == :test
+      assert lang.label == "Test"
+      assert lang.comment_token == "# "
+    end
+
+    test "defaults are applied" do
+      lang = %Language{name: :test, label: "Test", comment_token: "# "}
+      assert lang.extensions == []
+      assert lang.filenames == []
+      assert lang.shebangs == []
+      assert lang.tab_width == 2
+      assert lang.indent_with == :spaces
+      assert lang.language_servers == []
+      assert lang.root_markers == []
+      assert lang.icon == nil
+      assert lang.icon_color == nil
+      assert lang.grammar == nil
+      assert lang.formatter == nil
+      assert lang.project_type == nil
+    end
+  end
+end


### PR DESCRIPTION
## What

Per-language configuration was spread across 8 separate modules. Adding a new language meant touching all of them, and there was no way to tell if a language was fully configured without checking each file individually.

Now each language has a single definition module under `lib/minga/language/` returning a `%Language{}` struct with all config in one place.

Closes #491

## Why

This was already painful at 8 files per language. With #486 (alternate file) and #487 (test runners) about to add two more per-language data sources, it would have been 10 files. Consolidating first means those tickets add their data to the right place from the start.

## Changes

**New modules:**
- `Minga.Language` — struct with `@enforce_keys [:name, :label, :comment_token]` covering 15 fields (extensions, filenames, shebangs, icon, icon_color, tab_width, indent_with, grammar, formatter, language_servers, root_markers, project_type)
- `Minga.Language.Registry` — ETS-backed GenServer with `read_concurrency: true`, O(1) lookups by name, extension, filename, shebang. Handles stale index cleanup on runtime re-registration.
- 54 language definition modules (`Minga.Language.Elixir`, `Minga.Language.Ruby`, etc.)

**Migrated consumers:**
- `Comment.comment_string/1` → reads `LangRegistry.get(filetype).comment_token`
- `Formatter.resolve_formatter/2` → reads `LangRegistry.get(filetype).formatter`
- `LSP.ServerRegistry.servers_for/1` → reads `LangRegistry.get(filetype).language_servers`
- `Highlight.Grammar` → reads `LangRegistry.get(filetype).grammar`
- `Devicon.icon_and_color/1` → reads icon/color from LangRegistry (special buffer types stay hardcoded)
- `Modeline.filetype_label/1` → reads `LangRegistry.get(filetype).label`
- `Filetype.detect/1` → checks LangRegistry for extension/filename/shebang detection
- `Project.Detector.default_markers/0` → built dynamically from all languages' root_markers

All behavioral logic (comment toggling algorithm, formatter piping, LSP client lifecycle, etc.) is unchanged.

## Testing

- 23 new tests for Language struct and Registry (lookups, runtime registration, data completeness invariants)
- 179 tests across all migrated modules pass (0 failures)
- `mix lint` clean (format, credo, compile warnings, dialyzer)