### PR TITLE
fix(editor): add spacing around agent prompt box

### DIFF
--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -53,6 +53,8 @@ defmodule Minga.Agent.View.Renderer do
   @type state :: EditorState.t()
 
   @max_input_lines 8
+  @input_h_margin 2
+  @input_v_gap 1
 
   # ── Focused input type ─────────────────────────────────────────────────────
 
@@ -144,16 +146,19 @@ defmodule Minga.Agent.View.Renderer do
   def render_in_rect(%EditorState{} = state, {row, col, width, height}) do
     input = extract_input(state)
 
-    input_height =
-      compute_input_height(input.panel.input_lines, input_inner_width(width))
+    box_width = max(width - 2 * @input_h_margin, 10)
+    box_col = col + @input_h_margin
 
-    chat_height = max(height - input_height, 1)
-    input_row = row + chat_height
+    input_height =
+      compute_input_height(input.panel.input_lines, input_inner_width(box_width))
+
+    chat_height = max(height - input_height - @input_v_gap, 1)
+    input_row = row + chat_height + @input_v_gap
 
     {chat_draws, _metrics} =
       render_chat_from_input(input, {row, col, width, chat_height})
 
-    input_draws = render_input_from_input(input, input_row, width)
+    input_draws = render_input_from_input(input, input_row, box_col, box_width)
 
     chat_draws ++ input_draws
   end
@@ -176,11 +181,14 @@ defmodule Minga.Agent.View.Renderer do
     {row_off, col_off, chat_width, height} = content_rect
     {_sr, sidebar_col, sidebar_width, sidebar_height} = sidebar_rect
 
-    input_height =
-      compute_input_height(input.panel.input_lines, input_inner_width(chat_width))
+    box_width = max(chat_width - 2 * @input_h_margin, 10)
+    box_col = col_off + @input_h_margin
 
-    chat_height = max(height - input_height, 1)
-    input_row = row_off + chat_height
+    input_height =
+      compute_input_height(input.panel.input_lines, input_inner_width(box_width))
+
+    chat_height = max(height - input_height - @input_v_gap, 1)
+    input_row = row_off + chat_height + @input_v_gap
     separator_col = col_off + chat_width
 
     {chat_commands, _metrics} =
@@ -195,7 +203,7 @@ defmodule Minga.Agent.View.Renderer do
         {row_off, sidebar_col, sidebar_width, sidebar_height}
       )
 
-    input_commands = render_input_from_input(input, input_row, chat_width)
+    input_commands = render_input_from_input(input, input_row, box_col, box_width)
 
     total_width = chat_width + 1 + sidebar_width
 
@@ -222,14 +230,16 @@ defmodule Minga.Agent.View.Renderer do
   Returns nil when input is not focused (cursor hidden).
   """
   @spec cursor_position_in_rect(state(), rect()) :: {non_neg_integer(), non_neg_integer()} | nil
-  def cursor_position_in_rect(state, {row_off, _col_off, width, height}) do
+  def cursor_position_in_rect(state, {row_off, col_off, width, height}) do
     panel = AgentAccess.panel(state)
 
     if panel.input_focused do
       agentic = AgentAccess.agentic(state)
       chat_width_pct = agentic.chat_width_pct
       chat_width = max(div(width * chat_width_pct, 100), 20)
-      inner_width = input_inner_width(chat_width)
+      box_width = max(chat_width - 2 * @input_h_margin, 10)
+      box_col = col_off + @input_h_margin
+      inner_width = input_inner_width(box_width)
 
       lines = PanelState.input_lines(panel)
       cursor = PanelState.input_cursor(panel)
@@ -237,8 +247,8 @@ defmodule Minga.Agent.View.Renderer do
       total_visual = InputWrap.visual_line_count(lines, inner_width)
       visible_lines = max(min(total_visual, @max_input_lines), 1)
       input_height = compute_input_height(lines, inner_width)
-      chat_height = max(height - input_height, 1)
-      input_row = row_off + chat_height
+      chat_height = max(height - input_height - @input_v_gap, 1)
+      input_row = row_off + chat_height + @input_v_gap
 
       {visual_line, visual_col} =
         InputWrap.logical_to_visual(lines, inner_width, cursor)
@@ -247,7 +257,7 @@ defmodule Minga.Agent.View.Renderer do
       visible_offset = visual_line - scroll
 
       input_text_row = input_row + 1 + min(visible_offset, visible_lines - 1)
-      input_col = 1 + 3 + visual_col
+      input_col = box_col + 1 + 3 + visual_col
       {input_text_row, input_col}
     else
       nil
@@ -300,8 +310,9 @@ defmodule Minga.Agent.View.Renderer do
     cols = state.viewport.cols
     pct = agentic.chat_width_pct
     chat_w = max(div(cols * pct, 100), 20)
-    input_h = compute_input_height(PanelState.input_lines(panel), input_inner_width(chat_w))
-    content_rows = max(rows - 1 - 1 - input_h - 1 - 1, 1)
+    box_w = max(chat_w - 2 * @input_h_margin, 10)
+    input_h = compute_input_height(PanelState.input_lines(panel), input_inner_width(box_w))
+    content_rows = max(rows - 1 - 1 - input_h - @input_v_gap - 1 - 1, 1)
 
     buffer_snapshot =
       case state.buffers.active do
@@ -849,9 +860,14 @@ defmodule Minga.Agent.View.Renderer do
 
   # ── Input area (left column) ──────────────────────────────────────────────
 
-  @spec render_input_from_input(RenderInput.t(), non_neg_integer(), pos_integer()) ::
+  @spec render_input_from_input(
+          RenderInput.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pos_integer()
+        ) ::
           [DisplayList.draw()]
-  defp render_input_from_input(input, row, width) do
+  defp render_input_from_input(input, row, col_off, width) do
     at = Theme.agent_theme(input.theme)
     panel = input.panel
     border_style = [fg: at.input_border, bg: at.panel_bg]
@@ -873,7 +889,7 @@ defmodule Minga.Agent.View.Renderer do
     right_tag = if mode_tag != "", do: " " <> mode_tag <> " ─", else: ""
     fill_len = max(width - 2 - String.length(label) - String.length(right_tag), 0)
     top_line = "╭" <> label <> String.duplicate("─", fill_len) <> right_tag <> "╮"
-    top_cmd = DisplayList.draw(row, 0, top_line, border_style)
+    top_cmd = DisplayList.draw(row, col_off, top_line, border_style)
 
     # ── Content rows: │   text            │
     content_start = row + 1
@@ -886,10 +902,10 @@ defmodule Minga.Agent.View.Renderer do
         fill = String.pad_trailing(inner, max(width - 2, 0))
 
         [
-          DisplayList.draw(content_start, 0, "│" <> fill <> "│", bg: at.input_bg),
-          DisplayList.draw(content_start, 0, "│", border_style),
-          DisplayList.draw(content_start, width - 1, "│", border_style),
-          DisplayList.draw(content_start, 1 + pad_left, padded,
+          DisplayList.draw(content_start, col_off, "│" <> fill <> "│", bg: at.input_bg),
+          DisplayList.draw(content_start, col_off, "│", border_style),
+          DisplayList.draw(content_start, col_off + width - 1, "│", border_style),
+          DisplayList.draw(content_start, col_off + 1 + pad_left, padded,
             fg: at.input_placeholder,
             bg: at.input_bg
           )
@@ -907,6 +923,7 @@ defmodule Minga.Agent.View.Renderer do
         sel_range = vim_visual_range(panel)
 
         chrome = %{
+          col_off: col_off,
           inner_width: inner_width,
           width: width,
           left_pad: left_pad,
@@ -937,7 +954,7 @@ defmodule Minga.Agent.View.Renderer do
     model_prefix = "─ " <> model_label <> " "
     model_fill_len = max(width - 2 - String.length(model_prefix), 0)
     bottom_line = "╰" <> model_prefix <> String.duplicate("─", model_fill_len) <> "╯"
-    bottom_cmd = DisplayList.draw(bottom_row, 0, bottom_line, border_style)
+    bottom_cmd = DisplayList.draw(bottom_row, col_off, bottom_line, border_style)
 
     [top_cmd | line_cmds] ++ [bottom_cmd]
   end
@@ -991,15 +1008,16 @@ defmodule Minga.Agent.View.Renderer do
           {{non_neg_integer(), non_neg_integer()}, {non_neg_integer(), non_neg_integer()}} | nil
         ) :: [DisplayList.draw()]
   defp render_input_row(row, display_text, fg_color, chrome, logical_idx, vl, sel_range) do
+    c = Map.get(chrome, :col_off, 0)
     padded = String.pad_trailing(display_text, chrome.inner_width)
     inner = chrome.left_pad <> padded <> chrome.right_pad
     fill = String.pad_trailing(inner, max(chrome.width - 2, 0))
-    text_col = 1 + chrome.pad_left
+    text_col = c + 1 + chrome.pad_left
 
     base = [
-      DisplayList.draw(row, 0, "│" <> fill <> "│", bg: chrome.input_bg),
-      DisplayList.draw(row, 0, "│", chrome.border_style),
-      DisplayList.draw(row, chrome.width - 1, "│", chrome.border_style),
+      DisplayList.draw(row, c, "│" <> fill <> "│", bg: chrome.input_bg),
+      DisplayList.draw(row, c, "│", chrome.border_style),
+      DisplayList.draw(row, c + chrome.width - 1, "│", chrome.border_style),
       DisplayList.draw(row, text_col, padded, fg: fg_color, bg: chrome.input_bg)
     ]
 
@@ -1087,6 +1105,23 @@ defmodule Minga.Agent.View.Renderer do
   """
   @spec input_inner_width(pos_integer()) :: pos_integer()
   def input_inner_width(box_width), do: max(box_width - 6, 1)
+
+  @doc """
+  Returns the prompt box width after applying horizontal margins.
+
+  The box is inset by `@input_h_margin` on each side of the chat column.
+  Public so that `Input.AgentMouse` can use the same layout math for hit-testing.
+  """
+  @spec input_box_width(pos_integer()) :: pos_integer()
+  def input_box_width(chat_width), do: max(chat_width - 2 * @input_h_margin, 10)
+
+  @doc """
+  Returns the vertical gap (in rows) between the prompt box and the modeline.
+
+  Public so that `Input.AgentMouse` can use the same layout math for hit-testing.
+  """
+  @spec input_v_gap() :: non_neg_integer()
+  def input_v_gap, do: @input_v_gap
 
   # Returns the visual selection range from Vim state, or nil.
   @spec vim_visual_range(map()) ::

--- a/lib/minga/input/agent_mouse.ex
+++ b/lib/minga/input/agent_mouse.ex
@@ -215,11 +215,12 @@ defmodule Minga.Input.AgentMouse do
   defp handle_agent_click(state, {cr, _cc, cw, ch}, row, _col) do
     panel = AgentAccess.panel(state)
     input_lines = PanelState.input_lines(panel)
-    inner_width = ViewRenderer.input_inner_width(cw)
+    box_width = ViewRenderer.input_box_width(cw)
+    inner_width = ViewRenderer.input_inner_width(box_width)
     input_height = ViewRenderer.compute_input_height(input_lines, inner_width)
 
-    # Input area occupies the bottom `input_height` rows of the content rect
-    input_start_row = cr + ch - input_height
+    # Input area occupies the bottom `input_height + v_gap` rows of the content rect
+    input_start_row = cr + ch - input_height - ViewRenderer.input_v_gap()
 
     if row >= input_start_row do
       state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, true))

--- a/test/minga/agent/view/renderer_test.exs
+++ b/test/minga/agent/view/renderer_test.exs
@@ -192,36 +192,40 @@ defmodule Minga.Agent.View.RendererTest do
   end
 
   describe "input area inside left column" do
-    test "input border renders at col 0 within the left panel" do
+    test "input border renders with horizontal margin" do
       state = base_state(rows: 30, cols: 100)
       commands = render_sidebar(state)
 
-      # Input box should have a top border starting at col 0
+      h_margin = 2
+
+      # Input box should have a top border starting at the margin offset
       input_cmds =
         Enum.filter(commands, fn {_row, col, text, _style} ->
-          col == 0 and String.starts_with?(text, "╭─ Prompt")
+          col == h_margin and String.starts_with?(text, "╭─ Prompt")
         end)
 
-      assert input_cmds != [], "expected input border at col 0"
+      assert input_cmds != [], "expected input border at col #{h_margin}"
     end
 
-    test "input box width is constrained to left column (chat_width)" do
+    test "input box width is constrained to left column minus margins" do
       cols = 100
       state = base_state(rows: 30, cols: cols)
       commands = render_sidebar(state)
 
+      h_margin = 2
       chat_width = div(cols * 65, 100)
+      expected_box_width = chat_width - 2 * h_margin
 
       top_border_cmds =
         Enum.filter(commands, fn {_row, col, text, _style} ->
-          col == 0 and String.starts_with?(text, "╭─ Prompt")
+          col == h_margin and String.starts_with?(text, "╭─ Prompt")
         end)
 
       assert [top_cmd | _] = top_border_cmds
       {_row, _col, top_text, _style} = top_cmd
 
-      assert String.length(top_text) <= chat_width,
-             "input box should be ≤ chat_width (#{chat_width}), got #{String.length(top_text)}"
+      assert String.length(top_text) == expected_box_width,
+             "input box should be #{expected_box_width}, got #{String.length(top_text)}"
     end
 
     test "right panel extends alongside the input area" do
@@ -229,6 +233,7 @@ defmodule Minga.Agent.View.RendererTest do
       state = base_state(rows: 30, cols: cols)
       commands = render_sidebar(state)
 
+      h_margin = 2
       chat_width = div(cols * 65, 100)
       viewer_col = chat_width + 1
 
@@ -236,7 +241,7 @@ defmodule Minga.Agent.View.RendererTest do
       input_row =
         commands
         |> Enum.find(fn {_r, col, text, _s} ->
-          col == 0 and String.starts_with?(text, "╭─ Prompt")
+          col == h_margin and String.starts_with?(text, "╭─ Prompt")
         end)
         |> elem(0)
 


### PR DESCRIPTION
## What

Adds breathing room around the agent prompt box in the agentic view:

- **1 row vertical gap** between the prompt box bottom border and the modeline
- **2 columns horizontal margin** on each side so the box doesn't go edge-to-edge

## Why

The prompt box was visually cramped, sitting flush against both the modeline and the panel edges.

## Changes

- `lib/minga/agent/view/renderer.ex`: Added `@input_h_margin` (2) and `@input_v_gap` (1) constants. Updated `render_in_rect`, `render_with_sidebar`, `cursor_position_in_rect`, `render_input_from_input`, and `render_input_row` to use `col_off` and account for the gap/margins. Exposed `input_box_width/1` and `input_v_gap/0` as public helpers.
- `lib/minga/input/agent_mouse.ex`: Updated click hit-testing to use the new box width and vertical gap.
- `test/minga/agent/view/renderer_test.exs`: Updated 3 tests that expected column 0 to expect the new margin offset.

## Testing

All 4859 tests pass. Dialyzer clean. Lint clean.