### PR TITLE
fix(editor): match prompt input background to panel background

### DIFF
--- a/lib/minga/theme.ex
+++ b/lib/minga/theme.ex
@@ -499,7 +499,7 @@ defmodule Minga.Theme do
       code_bg: 0x1E2127,
       code_border: 0x5B6268,
       input_border: 0x51AFEF,
-      input_bg: 0x1E2127,
+      input_bg: 0x23272E,
       input_placeholder: 0x5B6268,
       thinking_fg: 0xECBE7B,
       status_thinking: 0xECBE7B,

--- a/lib/minga/theme/catppuccin.ex
+++ b/lib/minga/theme/catppuccin.ex
@@ -115,7 +115,7 @@ defmodule Minga.Theme.Catppuccin do
         code_bg: p.mantle,
         code_border: p.surface1,
         input_border: p.blue,
-        input_bg: p.mantle,
+        input_bg: p.base,
         input_placeholder: p.overlay0,
         thinking_fg: p.yellow,
         status_thinking: p.yellow,

--- a/lib/minga/theme/doom_one.ex
+++ b/lib/minga/theme/doom_one.ex
@@ -133,7 +133,7 @@ defmodule Minga.Theme.DoomOne do
         code_bg: 0x1E2127,
         code_border: @base5,
         input_border: @blue,
-        input_bg: 0x1E2127,
+        input_bg: @bg,
         input_placeholder: @base5,
         thinking_fg: @yellow,
         status_thinking: @yellow,

--- a/lib/minga/theme/one_dark.ex
+++ b/lib/minga/theme/one_dark.ex
@@ -130,7 +130,7 @@ defmodule Minga.Theme.OneDark do
         code_bg: @ui_bg,
         code_border: @syntax_guide,
         input_border: @hue_2,
-        input_bg: @ui_bg,
+        input_bg: @syntax_bg,
         input_placeholder: @mono_3,
         thinking_fg: @hue_6_2,
         status_thinking: @hue_6_2,

--- a/lib/minga/theme/one_light.ex
+++ b/lib/minga/theme/one_light.ex
@@ -130,7 +130,7 @@ defmodule Minga.Theme.OneLight do
         code_bg: @ui_bg,
         code_border: @syntax_guide,
         input_border: @hue_2,
-        input_bg: @ui_bg,
+        input_bg: @syntax_bg,
         input_placeholder: @mono_3,
         thinking_fg: @hue_6,
         status_thinking: @hue_6,


### PR DESCRIPTION
## What

Sets `input_bg` to match `panel_bg` in all themes so the prompt input area blends with the rest of the chat panel.

## Why

The prompt input had a slightly different (darker) background from the surrounding chat area. The bordered box already provides visual separation for the input; the background color difference just looked off.

## Changes

- `lib/minga/theme/doom_one.ex`: `input_bg: 0x1E2127` → `input_bg: @bg`
- `lib/minga/theme/catppuccin.ex`: `input_bg: p.mantle` → `input_bg: p.base`
- `lib/minga/theme/one_dark.ex`: `input_bg: @ui_bg` → `input_bg: @syntax_bg`
- `lib/minga/theme/one_light.ex`: `input_bg: @ui_bg` → `input_bg: @syntax_bg`
- `lib/minga/theme.ex`: fallback default `input_bg: 0x1E2127` → `input_bg: 0x23272E`