### PR TITLE
feat(editor): test runners under SPC m t

### DIFF
--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -50,6 +50,7 @@ defmodule Minga.Application do
       Minga.Config.Advice,
       Minga.Filetype.Registry,
       {DynamicSupervisor, name: Minga.Buffer.Supervisor, strategy: :one_for_one},
+      {Registry, keys: :unique, name: Minga.CommandOutput.Registry},
       {Task.Supervisor, name: Minga.Eval.TaskSupervisor},
       Minga.Command.Registry,
       Minga.Fold.Registry,

--- a/lib/minga/command/registry.ex
+++ b/lib/minga/command/registry.ex
@@ -106,7 +106,12 @@ defmodule Minga.Command.Registry do
     {:fold_close, "Close fold at cursor (zc)"},
     {:fold_open, "Open fold at cursor (zo)"},
     {:fold_close_all, "Close all folds (zM)"},
-    {:fold_open_all, "Open all folds (zR)"}
+    {:fold_open_all, "Open all folds (zR)"},
+    {:test_file, "Run tests for current file"},
+    {:test_all, "Run all tests"},
+    {:test_at_point, "Run test at cursor"},
+    {:test_rerun, "Rerun last test"},
+    {:test_output, "Show test output"}
   ]
 
   # ── Client API ──────────────────────────────────────────────────────────────

--- a/lib/minga/command_output.ex
+++ b/lib/minga/command_output.ex
@@ -1,0 +1,222 @@
+defmodule Minga.CommandOutput do
+  @moduledoc """
+  Runs a shell command and streams its output into a dedicated buffer.
+
+  Each named output (e.g., `"*test*"`) is a GenServer that owns an Erlang
+  Port running the command. stdout and stderr are streamed line-by-line
+  into a `:nowrite` BufferServer. If a command with the same name is already
+  running, it is killed before starting the new one.
+
+  This is a generic primitive reusable for test runners, build commands,
+  lint, or any "run a shell command, show output in a buffer" workflow.
+  """
+
+  use GenServer
+
+  alias Minga.Buffer.Server, as: BufferServer
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          buffer: pid() | nil,
+          port: port() | nil,
+          command: String.t() | nil,
+          cwd: String.t() | nil,
+          exit_code: non_neg_integer() | nil,
+          running?: boolean()
+        }
+
+  defstruct name: nil,
+            buffer: nil,
+            port: nil,
+            command: nil,
+            cwd: nil,
+            exit_code: nil,
+            running?: false
+
+  # ── Public API ─────────────────────────────────────────────────────────────
+
+  @doc """
+  Starts a CommandOutput server with the given name.
+
+  The name is used as both the GenServer registration name and the
+  buffer label (e.g., `"*test*"`).
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+    GenServer.start_link(__MODULE__, opts, name: via(name))
+  end
+
+  @doc """
+  Runs a command, streaming output into the named buffer.
+
+  If a command is already running under this name, it is killed first.
+  The buffer is cleared before the new command starts.
+
+  Options:
+    - `:cwd` - working directory for the command (default: project root)
+  """
+  @spec run(String.t(), String.t(), keyword()) :: :ok
+  def run(name, command, opts \\ []) do
+    case lookup(name) do
+      {:ok, pid} ->
+        GenServer.call(pid, {:run, command, opts})
+
+      :error ->
+        {:ok, pid} =
+          DynamicSupervisor.start_child(
+            Minga.Buffer.Supervisor,
+            {__MODULE__, name: name}
+          )
+
+        GenServer.call(pid, {:run, command, opts})
+    end
+  end
+
+  @doc "Returns the buffer pid for the named output, or nil."
+  @spec buffer(String.t()) :: pid() | nil
+  def buffer(name) do
+    case lookup(name) do
+      {:ok, pid} -> GenServer.call(pid, :buffer)
+      :error -> nil
+    end
+  end
+
+  @doc "Returns true if the named output has a command currently running."
+  @spec running?(String.t()) :: boolean()
+  def running?(name) do
+    case lookup(name) do
+      {:ok, pid} -> GenServer.call(pid, :running?)
+      :error -> false
+    end
+  end
+
+  @doc "Kills the running command (if any) for the named output."
+  @spec kill(String.t()) :: :ok
+  def kill(name) do
+    case lookup(name) do
+      {:ok, pid} -> GenServer.call(pid, :kill)
+      :error -> :ok
+    end
+  end
+
+  # ── GenServer Callbacks ────────────────────────────────────────────────────
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(opts) do
+    name = Keyword.fetch!(opts, :name)
+    {:ok, %__MODULE__{name: name}}
+  end
+
+  @impl true
+  def handle_call({:run, command, opts}, _from, state) do
+    state = kill_if_running(state)
+    state = ensure_buffer(state)
+
+    # Clear the buffer and write a header
+    cwd = Keyword.get(opts, :cwd, Minga.Project.root() || ".")
+    BufferServer.replace_content_force(state.buffer, "$ #{command}\n\n")
+
+    port =
+      Port.open({:spawn, command}, [
+        :binary,
+        :exit_status,
+        :stderr_to_stdout,
+        :use_stdio,
+        {:cd, cwd},
+        {:env, []}
+      ])
+
+    {:reply, :ok,
+     %{state | port: port, command: command, cwd: cwd, exit_code: nil, running?: true}}
+  end
+
+  def handle_call(:buffer, _from, state) do
+    state = ensure_buffer(state)
+    {:reply, state.buffer, state}
+  end
+
+  def handle_call(:running?, _from, state) do
+    {:reply, state.running?, state}
+  end
+
+  def handle_call(:kill, _from, state) do
+    {:reply, :ok, kill_if_running(state)}
+  end
+
+  @impl true
+  def handle_info({port, {:data, data}}, %{port: port} = state) when is_binary(data) do
+    if state.buffer && Process.alive?(state.buffer) do
+      BufferServer.append(state.buffer, data)
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info({port, {:exit_status, code}}, %{port: port} = state) do
+    status_line = "\n\n[Process exited with code #{code}]"
+
+    if state.buffer && Process.alive?(state.buffer) do
+      BufferServer.append(state.buffer, status_line)
+    end
+
+    {:noreply, %{state | port: nil, exit_code: code, running?: false}}
+  end
+
+  # Ignore messages from old ports
+  def handle_info({_port, _}, state), do: {:noreply, state}
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec kill_if_running(t()) :: t()
+  defp kill_if_running(%{port: nil} = state), do: state
+
+  defp kill_if_running(%{port: port} = state) do
+    try do
+      Port.close(port)
+    catch
+      :error, :badarg -> :ok
+    end
+
+    %{state | port: nil, running?: false}
+  end
+
+  @spec ensure_buffer(t()) :: t()
+  defp ensure_buffer(%{buffer: buf} = state) when is_pid(buf) do
+    if Process.alive?(buf) do
+      state
+    else
+      create_buffer(state)
+    end
+  end
+
+  defp ensure_buffer(state), do: create_buffer(state)
+
+  @spec create_buffer(t()) :: t()
+  defp create_buffer(state) do
+    case DynamicSupervisor.start_child(
+           Minga.Buffer.Supervisor,
+           {BufferServer,
+            buffer_name: state.name,
+            content: "",
+            read_only: true,
+            unlisted: true,
+            persistent: true}
+         ) do
+      {:ok, pid} -> %{state | buffer: pid}
+      _ -> state
+    end
+  end
+
+  @spec via(String.t()) :: {:via, Registry, {Minga.CommandOutput.Registry, String.t()}}
+  defp via(name), do: {:via, Registry, {Minga.CommandOutput.Registry, name}}
+
+  @spec lookup(String.t()) :: {:ok, pid()} | :error
+  defp lookup(name) do
+    case Registry.lookup(Minga.CommandOutput.Registry, name) do
+      [{pid, _}] -> {:ok, pid}
+      [] -> :error
+    end
+  end
+end

--- a/lib/minga/editor/commands.ex
+++ b/lib/minga/editor/commands.ex
@@ -590,6 +590,32 @@ defmodule Minga.Editor.Commands do
   def execute(state, :git_preview_hunk), do: GitCommands.execute(state, :git_preview_hunk)
   def execute(state, :git_blame_line), do: GitCommands.execute(state, :git_blame_line)
 
+  # ── Test runners ─────────────────────────────────────────────────────────
+
+  def execute(%{buffers: %{active: buf}} = state, :test_file) when is_pid(buf) do
+    run_test_command(state, buf, :file)
+  end
+
+  def execute(state, :test_file), do: %{state | status_msg: "No active buffer"}
+
+  def execute(state, :test_all) do
+    run_test_command(state, nil, :all)
+  end
+
+  def execute(%{buffers: %{active: buf}} = state, :test_at_point) when is_pid(buf) do
+    run_test_command(state, buf, :at_point)
+  end
+
+  def execute(state, :test_at_point), do: %{state | status_msg: "No active buffer"}
+
+  def execute(state, :test_rerun) do
+    rerun_last_test(state)
+  end
+
+  def execute(state, :test_output) do
+    show_test_output(state)
+  end
+
   # ── Macro recording ──────────────────────────────────────────────────────
 
   def execute(state, :toggle_macro_recording) do
@@ -770,6 +796,86 @@ defmodule Minga.Editor.Commands do
       alt_path ->
         execute(state, {:execute_ex_command, {:edit, alt_path}})
     end
+  end
+
+  # ── Private test runner helpers ────────────────────────────────────────────
+
+  @spec run_test_command(state(), pid() | nil, :file | :all | :at_point) :: state()
+  defp run_test_command(state, buf, kind) do
+    filetype = if buf, do: BufferServer.filetype(buf), else: detect_project_filetype()
+    project_root = Minga.Project.root() || "."
+
+    case Minga.TestRunner.detect(filetype, project_root) do
+      {:ok, runner} ->
+        command = build_test_command(runner, buf, kind)
+        execute_test(state, command, project_root)
+
+      :none ->
+        %{state | status_msg: "No test runner configured for #{filetype}"}
+    end
+  end
+
+  @spec build_test_command(Minga.TestRunner.Runner.t(), pid() | nil, :file | :all | :at_point) ::
+          String.t() | nil
+  defp build_test_command(runner, _buf, :all) do
+    Minga.TestRunner.all_command(runner)
+  end
+
+  defp build_test_command(runner, buf, :file) when is_pid(buf) do
+    case BufferServer.file_path(buf) do
+      nil -> nil
+      path -> Minga.TestRunner.file_command(runner, path)
+    end
+  end
+
+  defp build_test_command(runner, buf, :at_point) when is_pid(buf) do
+    file_path = BufferServer.file_path(buf)
+    {cursor_line, _col} = BufferServer.cursor(buf)
+
+    if file_path do
+      Minga.TestRunner.at_point_command(runner, file_path, cursor_line + 1)
+    else
+      nil
+    end
+  end
+
+  defp build_test_command(_runner, _buf, _kind), do: nil
+
+  @spec execute_test(state(), String.t() | nil, String.t()) :: state()
+  defp execute_test(state, nil, _project_root) do
+    %{state | status_msg: "Cannot determine test command"}
+  end
+
+  defp execute_test(state, command, project_root) do
+    state = %{state | last_test_command: {command, project_root}}
+    Minga.CommandOutput.run("*test*", command, cwd: project_root)
+    show_test_output(state)
+  end
+
+  @spec rerun_last_test(state()) :: state()
+  defp rerun_last_test(%{last_test_command: {command, project_root}} = state) do
+    Minga.CommandOutput.run("*test*", command, cwd: project_root)
+    show_test_output(state)
+  end
+
+  defp rerun_last_test(state) do
+    %{state | status_msg: "No previous test command"}
+  end
+
+  @spec show_test_output(state()) :: state()
+  defp show_test_output(state) do
+    case Minga.CommandOutput.buffer("*test*") do
+      nil ->
+        %{state | status_msg: "No test output"}
+
+      buf_pid ->
+        BufferManagement.execute(state, {:open_special_buffer, "*test*", buf_pid})
+    end
+  end
+
+  @spec detect_project_filetype() :: atom()
+  defp detect_project_filetype do
+    Minga.TestRunner.detect_project_filetype(Minga.Project.root() || ".")
   end
 
   # ── Private formatting helpers ─────────────────────────────────────────────

--- a/lib/minga/editor/commands/buffer_management.ex
+++ b/lib/minga/editor/commands/buffer_management.ex
@@ -148,6 +148,11 @@ defmodule Minga.Editor.Commands.BufferManagement do
     open_special_buffer(state, "*Warnings*", warn_buf)
   end
 
+  def execute(state, {:open_special_buffer, buffer_name, buffer_pid})
+      when is_binary(buffer_name) and is_pid(buffer_pid) do
+    open_special_buffer(state, buffer_name, buffer_pid)
+  end
+
   # ── Line number style ─────────────────────────────────────────────────────
 
   def execute(%{buffers: %{active: buf}} = state, :cycle_line_numbers) when is_pid(buf) do

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -116,7 +116,8 @@ defmodule Minga.Editor.State do
             agent: %AgentState{},
             agentic: ViewState.new(),
             nav_flash: nil,
-            last_cursor_line: nil
+            last_cursor_line: nil,
+            last_test_command: nil
 
   @type t :: %__MODULE__{
           port_manager: GenServer.server() | nil,
@@ -154,7 +155,8 @@ defmodule Minga.Editor.State do
           agent: AgentState.t(),
           agentic: ViewState.t(),
           nav_flash: NavFlash.t() | nil,
-          last_cursor_line: non_neg_integer() | nil
+          last_cursor_line: non_neg_integer() | nil,
+          last_test_command: {String.t(), String.t()} | nil
         }
 
   # ── Convenience accessors ─────────────────────────────────────────────────

--- a/lib/minga/keymap/active.ex
+++ b/lib/minga/keymap/active.ex
@@ -278,24 +278,34 @@ defmodule Minga.Keymap.Active do
 
   @spec seed_defaults(:ets.table()) :: true
   defp seed_defaults(table) do
-    filetype_tries = build_default_filetype_tries()
-
     :ets.insert(table, [
       {@leader_trie_key, Defaults.leader_trie()},
       {@normal_overrides_key, %{}},
       {@scope_overrides_key, %{}},
-      {@filetype_tries_key, filetype_tries},
+      {@filetype_tries_key, build_default_filetype_tries()},
       {@mode_tries_key, %{}}
     ])
   end
 
   @spec build_default_filetype_tries() :: filetype_tries()
   defp build_default_filetype_tries do
-    Defaults.filetype_bindings()
-    |> Enum.reduce(%{}, fn {filetype, keys, command, description}, tries ->
-      trie = Map.get(tries, filetype, Bindings.new())
-      updated = Bindings.bind(trie, keys, command, description)
-      Map.put(tries, filetype, updated)
+    bindings = Defaults.filetype_bindings()
+    group_prefixes = Defaults.filetype_group_prefixes()
+
+    bindings
+    |> Enum.group_by(fn {ft, _keys, _cmd, _desc} -> ft end)
+    |> Enum.into(%{}, fn {ft, ft_bindings} ->
+      trie =
+        Enum.reduce(ft_bindings, Bindings.new(), fn {_ft, keys, cmd, desc}, acc ->
+          Bindings.bind(acc, keys, cmd, desc)
+        end)
+
+      trie =
+        Enum.reduce(group_prefixes, trie, fn {keys, desc}, acc ->
+          Bindings.bind_prefix(acc, keys, desc)
+        end)
+
+      {ft, trie}
     end)
   end
 

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -181,30 +181,7 @@ defmodule Minga.Keymap.Defaults do
   @spec all_bindings() :: [{[Bindings.key()], atom(), String.t()}]
   def all_bindings, do: @leader_bindings
 
-  @doc """
-  Returns default filetype-scoped bindings for `SPC m`.
-
-  Each entry is `{filetype, key_sequence, command, description}` where key_sequence
-  is relative to the `SPC m` prefix (i.e., just the sub-keys).
-  """
-  @spec filetype_bindings() :: [{atom(), [Bindings.key()], atom(), String.t()}]
-  def filetype_bindings do
-    filetypes = [
-      :elixir,
-      :ruby,
-      :typescript,
-      :typescript_react,
-      :javascript,
-      :javascript_react,
-      :c,
-      :cpp,
-      :swift
-    ]
-
-    Enum.map(filetypes, fn ft ->
-      {ft, [{?a, @none}], :alternate_file, "Alternate file"}
-    end)
-  end
+  # filetype_bindings/0 is defined below with all SPC m bindings
 
   @doc """
   Returns a map of Normal mode key bindings: `{codepoint, modifiers} => {command, description}`.
@@ -304,5 +281,65 @@ defmodule Minga.Keymap.Defaults do
       # ── Multi-key ─────────────────────────────────────────────────────────
       {?g, 0} => {:prefix_g, "g prefix (gg = go to start)"}
     }
+  end
+
+  @doc """
+  Returns filetype-scoped bindings for the `SPC m` major mode prefix.
+
+  Each entry is `{filetype, key_sequence, command, description}` where
+  key_sequence is relative to the `SPC m` prefix.
+
+  These bindings are grouped by filetype and built into per-filetype
+  tries at startup by `Minga.Keymap.Active`.
+  """
+  @type filetype_binding ::
+          {atom(), [Bindings.key()], atom(), String.t()}
+
+  @spec filetype_bindings() :: [filetype_binding()]
+  def filetype_bindings do
+    supported_filetypes = [
+      :elixir,
+      :ruby,
+      :typescript,
+      :typescript_react,
+      :javascript,
+      :javascript_react,
+      :c,
+      :cpp,
+      :swift
+    ]
+
+    # SPC m a → alternate file for all supported filetypes
+    alternate_bindings =
+      Enum.map(supported_filetypes, fn ft ->
+        {ft, [{?a, @none}], :alternate_file, "Alternate file"}
+      end)
+
+    # SPC m t → +test submenu for all supported filetypes
+    test_bindings =
+      for ft <- supported_filetypes do
+        [
+          {ft, [{?t, 0}, {?t, 0}], :test_file, "Test file"},
+          {ft, [{?t, 0}, {?a, 0}], :test_all, "Test all"},
+          {ft, [{?t, 0}, {?p, 0}], :test_at_point, "Test at point"},
+          {ft, [{?t, 0}, {?r, 0}], :test_rerun, "Rerun last test"},
+          {ft, [{?t, 0}, {?o, 0}], :test_output, "Show test output"}
+        ]
+      end
+
+    alternate_bindings ++ List.flatten(test_bindings)
+  end
+
+  @doc """
+  Returns group prefixes for filetype-scoped bindings.
+
+  These add labels to intermediate keys so which-key shows them
+  (e.g., `t` → `+test` under `SPC m`).
+  """
+  @spec filetype_group_prefixes() :: [{[Bindings.key()], String.t()}]
+  def filetype_group_prefixes do
+    [
+      {[{?t, 0}], "+test"}
+    ]
   end
 end

--- a/lib/minga/test_runner.ex
+++ b/lib/minga/test_runner.ex
@@ -1,0 +1,303 @@
+defmodule Minga.TestRunner do
+  @moduledoc """
+  Detects test frameworks and generates test commands for each language.
+
+  Detection (`detect/2`) examines the filesystem for framework markers
+  (files, directories, package.json entries). Command generation
+  (`file_command/2`, `all_command/1`, `at_point_command/3`) is pure:
+  given a `Runner` struct, it returns the shell command string with
+  properly escaped file paths.
+
+  ## Supported Frameworks
+
+  | Language | Frameworks |
+  |---|---|
+  | Elixir | ExUnit (`mix test`) |
+  | Ruby | RSpec, Minitest |
+  | TypeScript/JS | Vitest, Jest, npm test |
+  | C/C++ | CTest, Make |
+  | Swift | Swift Package Manager |
+  """
+
+  defmodule Runner do
+    @moduledoc "Describes a detected test framework and its base command."
+
+    @type t :: %__MODULE__{
+            framework: atom(),
+            filetype: atom(),
+            base_command: String.t()
+          }
+
+    @enforce_keys [:framework, :filetype, :base_command]
+    defstruct [:framework, :filetype, :base_command]
+  end
+
+  @type runner :: Runner.t()
+
+  @doc """
+  Detects the test framework for the given filetype and project root.
+
+  Returns `{:ok, runner}` with the detected framework, or `:none` if
+  no test framework could be detected.
+  """
+  @spec detect(atom(), String.t()) :: {:ok, runner()} | :none
+  def detect(filetype, project_root) when is_atom(filetype) and is_binary(project_root) do
+    do_detect(filetype, project_root)
+  end
+
+  @doc """
+  Returns the shell command to run tests for a specific file.
+  """
+  @spec file_command(runner(), String.t()) :: String.t()
+  def file_command(runner, file_path) when is_map(runner) and is_binary(file_path) do
+    build_file_command(runner, file_path)
+  end
+
+  @doc """
+  Returns the shell command to run all tests in the project.
+  """
+  @spec all_command(runner()) :: String.t()
+  def all_command(runner) when is_map(runner) do
+    runner.base_command
+  end
+
+  @doc """
+  Returns the shell command to run a test at a specific line, or nil
+  if the framework doesn't support line-specific test execution.
+  """
+  @spec at_point_command(runner(), String.t(), non_neg_integer()) :: String.t() | nil
+  def at_point_command(runner, file_path, line)
+      when is_map(runner) and is_binary(file_path) and is_integer(line) do
+    build_at_point_command(runner, file_path, line)
+  end
+
+  # ── Elixir ─────────────────────────────────────────────────────────────────
+
+  @spec do_detect(atom(), String.t()) :: {:ok, runner()} | :none
+  defp do_detect(:elixir, project_root) do
+    if File.exists?(Path.join(project_root, "mix.exs")) do
+      {:ok, %Runner{framework: :exunit, filetype: :elixir, base_command: "mix test"}}
+    else
+      :none
+    end
+  end
+
+  # ── Ruby ───────────────────────────────────────────────────────────────────
+
+  defp do_detect(:ruby, project_root) do
+    detect_ruby_framework(project_root)
+  end
+
+  # ── TypeScript / JavaScript ────────────────────────────────────────────────
+
+  defp do_detect(filetype, project_root)
+       when filetype in [:typescript, :typescript_react, :javascript, :javascript_react] do
+    detect_ts_framework(filetype, project_root)
+  end
+
+  # ── C / C++ ────────────────────────────────────────────────────────────────
+
+  defp do_detect(filetype, project_root) when filetype in [:c, :cpp] do
+    detect_c_framework(filetype, project_root)
+  end
+
+  # ── Swift ──────────────────────────────────────────────────────────────────
+
+  defp do_detect(:swift, project_root) do
+    if File.exists?(Path.join(project_root, "Package.swift")) do
+      {:ok, %Runner{framework: :swift_pm, filetype: :swift, base_command: "swift test"}}
+    else
+      :none
+    end
+  end
+
+  defp do_detect(_filetype, _project_root), do: :none
+
+  @doc """
+  Guesses the project's primary filetype from root markers.
+
+  Used as a fallback when `SPC m t a` is invoked without an active
+  buffer that has a known filetype.
+  """
+  @spec detect_project_filetype(String.t()) :: atom()
+  def detect_project_filetype(project_root) when is_binary(project_root) do
+    do_detect_project_filetype(project_root)
+  end
+
+  @spec do_detect_project_filetype(String.t()) :: atom()
+  defp do_detect_project_filetype(root) do
+    markers = [
+      {"mix.exs", :elixir},
+      {"Gemfile", :ruby},
+      {"package.json", :typescript},
+      {"Package.swift", :swift},
+      {"CMakeLists.txt", :c},
+      {"Makefile", :c}
+    ]
+
+    Enum.find_value(markers, :text, fn {file, filetype} ->
+      if File.exists?(Path.join(root, file)), do: filetype
+    end)
+  end
+
+  # ── File commands ──────────────────────────────────────────────────────────
+
+  @spec build_file_command(runner(), String.t()) :: String.t()
+  defp build_file_command(%Runner{framework: :exunit}, file_path) do
+    "mix test #{shell_escape(file_path)}"
+  end
+
+  defp build_file_command(%Runner{framework: :rspec}, file_path) do
+    "bundle exec rspec #{shell_escape(file_path)}"
+  end
+
+  defp build_file_command(%Runner{framework: :minitest}, file_path) do
+    "bundle exec ruby -Itest #{shell_escape(file_path)}"
+  end
+
+  defp build_file_command(%Runner{framework: :vitest}, file_path) do
+    "npx vitest run #{shell_escape(file_path)}"
+  end
+
+  defp build_file_command(%Runner{framework: :jest}, file_path) do
+    "npx jest #{shell_escape(file_path)}"
+  end
+
+  defp build_file_command(%Runner{framework: :npm_test}, _file_path) do
+    "npm test"
+  end
+
+  defp build_file_command(%Runner{framework: :ctest}, _file_path) do
+    "ctest --test-dir build"
+  end
+
+  defp build_file_command(%Runner{framework: :make_test}, _file_path) do
+    "make test"
+  end
+
+  defp build_file_command(%Runner{framework: :swift_pm}, file_path) do
+    # Extract module name from file path for filtering
+    module = file_path |> Path.basename(".swift") |> String.replace("Tests", "")
+    "swift test --filter #{shell_escape(module)}"
+  end
+
+  # ── At-point commands ──────────────────────────────────────────────────────
+
+  @spec build_at_point_command(runner(), String.t(), non_neg_integer()) :: String.t() | nil
+  defp build_at_point_command(%Runner{framework: :exunit}, file_path, line) do
+    "mix test #{shell_escape(file_path)}:#{line}"
+  end
+
+  defp build_at_point_command(%Runner{framework: :rspec}, file_path, line) do
+    "bundle exec rspec #{shell_escape(file_path)}:#{line}"
+  end
+
+  # Minitest doesn't support line-specific execution
+  defp build_at_point_command(%Runner{framework: :minitest}, _file_path, _line), do: nil
+
+  # JS/TS test runners don't have standard line-specific execution
+  defp build_at_point_command(%Runner{framework: fw}, _file_path, _line)
+       when fw in [:vitest, :jest, :npm_test],
+       do: nil
+
+  # C/C++ build systems don't support line-specific execution
+  defp build_at_point_command(%Runner{framework: fw}, _file_path, _line)
+       when fw in [:ctest, :make_test],
+       do: nil
+
+  # Swift doesn't support line-specific execution
+  defp build_at_point_command(%Runner{framework: :swift_pm}, _file_path, _line), do: nil
+
+  # ── Ruby detection ─────────────────────────────────────────────────────────
+
+  @spec detect_ruby_framework(String.t()) :: {:ok, runner()} | :none
+  defp detect_ruby_framework(project_root) do
+    has_spec_dir = File.dir?(Path.join(project_root, "spec"))
+    has_test_dir = File.dir?(Path.join(project_root, "test"))
+
+    case {has_spec_dir, has_test_dir} do
+      {true, _} ->
+        {:ok, %Runner{framework: :rspec, filetype: :ruby, base_command: "bundle exec rspec"}}
+
+      {false, true} ->
+        {:ok,
+         %Runner{framework: :minitest, filetype: :ruby, base_command: "bundle exec ruby -Itest"}}
+
+      {false, false} ->
+        :none
+    end
+  end
+
+  # ── TypeScript detection ───────────────────────────────────────────────────
+
+  @spec detect_ts_framework(atom(), String.t()) :: {:ok, runner()} | :none
+  defp detect_ts_framework(filetype, project_root) do
+    pkg_json_path = Path.join(project_root, "package.json")
+
+    if File.exists?(pkg_json_path) do
+      detect_ts_from_package_json(filetype, pkg_json_path)
+    else
+      :none
+    end
+  end
+
+  @spec detect_ts_from_package_json(atom(), String.t()) :: {:ok, runner()} | :none
+  defp detect_ts_from_package_json(filetype, pkg_json_path) do
+    case File.read(pkg_json_path) do
+      {:ok, contents} ->
+        detect_ts_from_contents(filetype, contents)
+
+      {:error, _} ->
+        :none
+    end
+  end
+
+  @spec detect_ts_from_contents(atom(), String.t()) :: {:ok, runner()} | :none
+  defp detect_ts_from_contents(filetype, contents) do
+    has_vitest = String.contains?(contents, "\"vitest\"")
+    has_jest = String.contains?(contents, "\"jest\"")
+    has_test_script = String.contains?(contents, "\"test\"")
+
+    case {has_vitest, has_jest, has_test_script} do
+      {true, _, _} ->
+        {:ok, %Runner{framework: :vitest, filetype: filetype, base_command: "npx vitest run"}}
+
+      {false, true, _} ->
+        {:ok, %Runner{framework: :jest, filetype: filetype, base_command: "npx jest"}}
+
+      {false, false, true} ->
+        {:ok, %Runner{framework: :npm_test, filetype: filetype, base_command: "npm test"}}
+
+      {false, false, false} ->
+        :none
+    end
+  end
+
+  # ── C/C++ detection ────────────────────────────────────────────────────────
+
+  @spec detect_c_framework(atom(), String.t()) :: {:ok, runner()} | :none
+  defp detect_c_framework(filetype, project_root) do
+    has_cmake = File.exists?(Path.join(project_root, "CMakeLists.txt"))
+    has_makefile = File.exists?(Path.join(project_root, "Makefile"))
+
+    case {has_cmake, has_makefile} do
+      {true, _} ->
+        {:ok,
+         %Runner{framework: :ctest, filetype: filetype, base_command: "ctest --test-dir build"}}
+
+      {false, true} ->
+        {:ok, %Runner{framework: :make_test, filetype: filetype, base_command: "make test"}}
+
+      {false, false} ->
+        :none
+    end
+  end
+
+  # ── Shell escaping ─────────────────────────────────────────────────────────
+
+  @doc false
+  @spec shell_escape(String.t()) :: String.t()
+  def shell_escape(arg) when is_binary(arg) do
+    "'" <> String.replace(arg, "'", "'\\''") <> "'"
+  end
+end

--- a/test/minga/command/registry_test.exs
+++ b/test/minga/command/registry_test.exs
@@ -98,7 +98,12 @@ defmodule Minga.Command.RegistryTest do
           :fold_open,
           :fold_close_all,
           :fold_open_all,
-          :alternate_file
+          :alternate_file,
+          :test_file,
+          :test_all,
+          :test_at_point,
+          :test_rerun,
+          :test_output
         ]
         |> Enum.sort()
 

--- a/test/minga/command_output_test.exs
+++ b/test/minga/command_output_test.exs
@@ -1,0 +1,123 @@
+defmodule Minga.CommandOutputTest do
+  use ExUnit.Case, async: false
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.CommandOutput
+
+  # Give processes time to stream output
+  @stream_wait 200
+
+  describe "run/3" do
+    test "creates a buffer and streams command output" do
+      name = "test_output_#{System.unique_integer([:positive])}"
+      :ok = CommandOutput.run(name, "echo hello")
+      Process.sleep(@stream_wait)
+
+      buf = CommandOutput.buffer(name)
+      assert is_pid(buf)
+
+      content = BufferServer.content(buf)
+      assert content =~ "$ echo hello"
+      assert content =~ "hello"
+    end
+
+    test "includes exit code in output" do
+      name = "test_exit_#{System.unique_integer([:positive])}"
+      :ok = CommandOutput.run(name, "echo done")
+      Process.sleep(@stream_wait)
+
+      buf = CommandOutput.buffer(name)
+      content = BufferServer.content(buf)
+      assert content =~ "[Process exited with code 0]"
+    end
+
+    test "captures non-zero exit code" do
+      name = "test_fail_#{System.unique_integer([:positive])}"
+      :ok = CommandOutput.run(name, "bash -c 'exit 42'")
+      Process.sleep(@stream_wait)
+
+      buf = CommandOutput.buffer(name)
+      content = BufferServer.content(buf)
+      assert content =~ "[Process exited with code 42]"
+    end
+
+    test "clears buffer on re-run" do
+      name = "test_rerun_#{System.unique_integer([:positive])}"
+      :ok = CommandOutput.run(name, "echo first")
+      Process.sleep(@stream_wait)
+
+      :ok = CommandOutput.run(name, "echo second")
+      Process.sleep(@stream_wait)
+
+      buf = CommandOutput.buffer(name)
+      content = BufferServer.content(buf)
+      refute content =~ "first"
+      assert content =~ "second"
+    end
+
+    test "streams stderr alongside stdout" do
+      name = "test_stderr_#{System.unique_integer([:positive])}"
+      :ok = CommandOutput.run(name, "echo out; echo err >&2")
+      Process.sleep(@stream_wait)
+
+      buf = CommandOutput.buffer(name)
+      content = BufferServer.content(buf)
+      assert content =~ "out"
+      assert content =~ "err"
+    end
+  end
+
+  describe "running?/1" do
+    test "returns true while command is executing" do
+      name = "test_running_#{System.unique_integer([:positive])}"
+      :ok = CommandOutput.run(name, "sleep 5")
+
+      assert CommandOutput.running?(name)
+
+      CommandOutput.kill(name)
+    end
+
+    test "returns false after command exits" do
+      name = "test_done_#{System.unique_integer([:positive])}"
+      :ok = CommandOutput.run(name, "echo fast")
+      Process.sleep(@stream_wait)
+
+      refute CommandOutput.running?(name)
+    end
+
+    test "returns false for unknown name" do
+      refute CommandOutput.running?("nonexistent_#{System.unique_integer([:positive])}")
+    end
+  end
+
+  describe "kill/1" do
+    test "stops a running command" do
+      name = "test_kill_#{System.unique_integer([:positive])}"
+      :ok = CommandOutput.run(name, "sleep 60")
+      assert CommandOutput.running?(name)
+
+      :ok = CommandOutput.kill(name)
+      refute CommandOutput.running?(name)
+    end
+
+    test "is a no-op for unknown name" do
+      assert :ok = CommandOutput.kill("nonexistent_#{System.unique_integer([:positive])}")
+    end
+  end
+
+  describe "buffer/1" do
+    test "returns nil for unknown name" do
+      assert nil == CommandOutput.buffer("nonexistent_#{System.unique_integer([:positive])}")
+    end
+
+    test "returns the buffer pid after run" do
+      name = "test_buf_#{System.unique_integer([:positive])}"
+      :ok = CommandOutput.run(name, "echo hi")
+      Process.sleep(@stream_wait)
+
+      buf = CommandOutput.buffer(name)
+      assert is_pid(buf)
+      assert Process.alive?(buf)
+    end
+  end
+end

--- a/test/minga/keymap/active_test.exs
+++ b/test/minga/keymap/active_test.exs
@@ -248,9 +248,11 @@ defmodule Minga.Keymap.ActiveTest do
       trie = Active.mode_trie(s, :insert)
       assert :not_found = Bindings.lookup(trie, {?j, 0x02})
 
-      # Filetype tries cleared
+      # Filetype tries reset to defaults (user override for SPC m t → :test removed,
+      # but default +test prefix for :elixir remains from build_default_filetype_tries)
       ft_trie = Active.filetype_trie(s, :elixir)
-      assert :not_found = Bindings.lookup(ft_trie, {?t, 0})
+      # The user's :test command should be gone; the key is now a +test prefix from defaults
+      assert {:prefix, _} = Bindings.lookup(ft_trie, {?t, 0})
 
       # Scope overrides cleared
       assert Active.scope_overrides(s) == %{}

--- a/test/minga/test_runner_test.exs
+++ b/test/minga/test_runner_test.exs
@@ -1,0 +1,362 @@
+defmodule Minga.TestRunnerTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.TestRunner
+  alias Minga.TestRunner.Runner
+
+  # Creates a temp project directory with the given files/dirs
+  defp with_project(files, dirs, fun) do
+    tmp = Path.join(System.tmp_dir!(), "minga_test_runner_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+
+    try do
+      for dir <- dirs do
+        File.mkdir_p!(Path.join(tmp, dir))
+      end
+
+      for file <- files do
+        path = Path.join(tmp, file)
+        File.mkdir_p!(Path.dirname(path))
+        File.write!(path, "")
+      end
+
+      fun.(tmp)
+    after
+      File.rm_rf!(tmp)
+    end
+  end
+
+  # ── Detection ────────────────────────────────────────────────────────────
+
+  describe "detect/2 Elixir" do
+    test "detects ExUnit when mix.exs exists" do
+      with_project(["mix.exs"], [], fn root ->
+        assert {:ok, %{framework: :exunit}} = TestRunner.detect(:elixir, root)
+      end)
+    end
+
+    test "returns :none when mix.exs is missing" do
+      with_project([], [], fn root ->
+        assert :none = TestRunner.detect(:elixir, root)
+      end)
+    end
+  end
+
+  describe "detect/2 Ruby" do
+    test "detects RSpec when spec/ directory exists" do
+      with_project([], ["spec"], fn root ->
+        assert {:ok, %{framework: :rspec}} = TestRunner.detect(:ruby, root)
+      end)
+    end
+
+    test "detects Minitest when test/ directory exists (no spec/)" do
+      with_project([], ["test"], fn root ->
+        assert {:ok, %{framework: :minitest}} = TestRunner.detect(:ruby, root)
+      end)
+    end
+
+    test "prefers RSpec when both spec/ and test/ exist" do
+      with_project([], ["spec", "test"], fn root ->
+        assert {:ok, %{framework: :rspec}} = TestRunner.detect(:ruby, root)
+      end)
+    end
+
+    test "returns :none when neither spec/ nor test/ exist" do
+      with_project([], [], fn root ->
+        assert :none = TestRunner.detect(:ruby, root)
+      end)
+    end
+  end
+
+  describe "detect/2 TypeScript" do
+    test "detects Vitest when package.json mentions vitest" do
+      with_project([], [], fn root ->
+        File.write!(Path.join(root, "package.json"), ~s({"devDependencies": {"vitest": "^1.0"}}))
+        assert {:ok, %{framework: :vitest}} = TestRunner.detect(:typescript, root)
+      end)
+    end
+
+    test "detects Jest when package.json mentions jest (no vitest)" do
+      with_project([], [], fn root ->
+        File.write!(Path.join(root, "package.json"), ~s({"devDependencies": {"jest": "^29.0"}}))
+        assert {:ok, %{framework: :jest}} = TestRunner.detect(:typescript, root)
+      end)
+    end
+
+    test "detects npm test when package.json has test script (no vitest/jest)" do
+      with_project([], [], fn root ->
+        File.write!(Path.join(root, "package.json"), ~s({"scripts": {"test": "mocha"}}))
+        assert {:ok, %{framework: :npm_test}} = TestRunner.detect(:typescript, root)
+      end)
+    end
+
+    test "prefers Vitest over Jest" do
+      with_project([], [], fn root ->
+        File.write!(
+          Path.join(root, "package.json"),
+          ~s({"devDependencies": {"vitest": "^1.0", "jest": "^29.0"}})
+        )
+
+        assert {:ok, %{framework: :vitest}} = TestRunner.detect(:typescript, root)
+      end)
+    end
+
+    test "returns :none when package.json is missing" do
+      with_project([], [], fn root ->
+        assert :none = TestRunner.detect(:typescript, root)
+      end)
+    end
+
+    test "works for javascript filetype" do
+      with_project([], [], fn root ->
+        File.write!(Path.join(root, "package.json"), ~s({"devDependencies": {"jest": "^29.0"}}))
+        assert {:ok, %{framework: :jest}} = TestRunner.detect(:javascript, root)
+      end)
+    end
+
+    test "works for typescript_react filetype" do
+      with_project([], [], fn root ->
+        File.write!(Path.join(root, "package.json"), ~s({"devDependencies": {"vitest": "^1.0"}}))
+        assert {:ok, %{framework: :vitest}} = TestRunner.detect(:typescript_react, root)
+      end)
+    end
+  end
+
+  describe "detect/2 C/C++" do
+    test "detects CTest when CMakeLists.txt exists" do
+      with_project(["CMakeLists.txt"], [], fn root ->
+        assert {:ok, %{framework: :ctest}} = TestRunner.detect(:c, root)
+      end)
+    end
+
+    test "detects Make when Makefile exists (no CMakeLists.txt)" do
+      with_project(["Makefile"], [], fn root ->
+        assert {:ok, %{framework: :make_test}} = TestRunner.detect(:c, root)
+      end)
+    end
+
+    test "prefers CTest over Make" do
+      with_project(["CMakeLists.txt", "Makefile"], [], fn root ->
+        assert {:ok, %{framework: :ctest}} = TestRunner.detect(:c, root)
+      end)
+    end
+
+    test "works for cpp filetype" do
+      with_project(["CMakeLists.txt"], [], fn root ->
+        assert {:ok, %{framework: :ctest}} = TestRunner.detect(:cpp, root)
+      end)
+    end
+
+    test "returns :none when neither exists" do
+      with_project([], [], fn root ->
+        assert :none = TestRunner.detect(:c, root)
+      end)
+    end
+  end
+
+  describe "detect/2 Swift" do
+    test "detects Swift PM when Package.swift exists" do
+      with_project(["Package.swift"], [], fn root ->
+        assert {:ok, %{framework: :swift_pm}} = TestRunner.detect(:swift, root)
+      end)
+    end
+
+    test "returns :none when Package.swift is missing" do
+      with_project([], [], fn root ->
+        assert :none = TestRunner.detect(:swift, root)
+      end)
+    end
+  end
+
+  describe "detect/2 unsupported" do
+    test "returns :none for unknown filetypes" do
+      with_project([], [], fn root ->
+        assert :none = TestRunner.detect(:text, root)
+        assert :none = TestRunner.detect(:markdown, root)
+      end)
+    end
+  end
+
+  describe "detect_project_filetype/1" do
+    test "detects Elixir project" do
+      with_project(["mix.exs"], [], fn root ->
+        assert TestRunner.detect_project_filetype(root) == :elixir
+      end)
+    end
+
+    test "detects Ruby project" do
+      with_project(["Gemfile"], [], fn root ->
+        assert TestRunner.detect_project_filetype(root) == :ruby
+      end)
+    end
+
+    test "detects TypeScript project" do
+      with_project(["package.json"], [], fn root ->
+        assert TestRunner.detect_project_filetype(root) == :typescript
+      end)
+    end
+
+    test "detects Swift project" do
+      with_project(["Package.swift"], [], fn root ->
+        assert TestRunner.detect_project_filetype(root) == :swift
+      end)
+    end
+
+    test "detects C project from CMakeLists.txt" do
+      with_project(["CMakeLists.txt"], [], fn root ->
+        assert TestRunner.detect_project_filetype(root) == :c
+      end)
+    end
+
+    test "returns :text for unknown project" do
+      with_project([], [], fn root ->
+        assert TestRunner.detect_project_filetype(root) == :text
+      end)
+    end
+  end
+
+  # ── Command generation ─────────────────────────────────────────────────
+
+  describe "file_command/2" do
+    test "Elixir" do
+      runner = %Runner{framework: :exunit, filetype: :elixir, base_command: "mix test"}
+      assert TestRunner.file_command(runner, "test/my_test.exs") == "mix test 'test/my_test.exs'"
+    end
+
+    test "Ruby RSpec" do
+      runner = %Runner{framework: :rspec, filetype: :ruby, base_command: "bundle exec rspec"}
+
+      assert TestRunner.file_command(runner, "spec/models/user_spec.rb") ==
+               "bundle exec rspec 'spec/models/user_spec.rb'"
+    end
+
+    test "Ruby Minitest" do
+      runner = %Runner{
+        framework: :minitest,
+        filetype: :ruby,
+        base_command: "bundle exec ruby -Itest"
+      }
+
+      assert TestRunner.file_command(runner, "test/models/user_test.rb") ==
+               "bundle exec ruby -Itest 'test/models/user_test.rb'"
+    end
+
+    test "Vitest" do
+      runner = %Runner{framework: :vitest, filetype: :typescript, base_command: "npx vitest run"}
+
+      assert TestRunner.file_command(runner, "src/utils.test.ts") ==
+               "npx vitest run 'src/utils.test.ts'"
+    end
+
+    test "Jest" do
+      runner = %Runner{framework: :jest, filetype: :typescript, base_command: "npx jest"}
+
+      assert TestRunner.file_command(runner, "src/utils.test.ts") ==
+               "npx jest 'src/utils.test.ts'"
+    end
+
+    test "npm test ignores file path" do
+      runner = %Runner{framework: :npm_test, filetype: :typescript, base_command: "npm test"}
+      assert TestRunner.file_command(runner, "src/utils.test.ts") == "npm test"
+    end
+
+    test "CTest ignores file path" do
+      runner = %Runner{framework: :ctest, filetype: :c, base_command: "ctest --test-dir build"}
+      assert TestRunner.file_command(runner, "test/test_buffer.c") == "ctest --test-dir build"
+    end
+
+    test "Make test ignores file path" do
+      runner = %Runner{framework: :make_test, filetype: :c, base_command: "make test"}
+      assert TestRunner.file_command(runner, "test/test_buffer.c") == "make test"
+    end
+
+    test "Swift PM uses filter" do
+      runner = %Runner{framework: :swift_pm, filetype: :swift, base_command: "swift test"}
+
+      assert TestRunner.file_command(runner, "Tests/BufferTests.swift") ==
+               "swift test --filter 'Buffer'"
+    end
+
+    test "escapes paths with spaces" do
+      runner = %Runner{framework: :exunit, filetype: :elixir, base_command: "mix test"}
+      assert TestRunner.file_command(runner, "test/my test.exs") == "mix test 'test/my test.exs'"
+    end
+
+    test "escapes paths with single quotes" do
+      runner = %Runner{framework: :exunit, filetype: :elixir, base_command: "mix test"}
+
+      assert TestRunner.file_command(runner, "test/it's_a_test.exs") ==
+               "mix test 'test/it'\\''s_a_test.exs'"
+    end
+  end
+
+  describe "all_command/1" do
+    test "returns the base command for all frameworks" do
+      assert TestRunner.all_command(%Runner{
+               framework: :exunit,
+               filetype: :elixir,
+               base_command: "mix test"
+             }) == "mix test"
+
+      assert TestRunner.all_command(%Runner{
+               framework: :rspec,
+               filetype: :ruby,
+               base_command: "bundle exec rspec"
+             }) ==
+               "bundle exec rspec"
+
+      assert TestRunner.all_command(%Runner{
+               framework: :vitest,
+               filetype: :typescript,
+               base_command: "npx vitest run"
+             }) ==
+               "npx vitest run"
+    end
+  end
+
+  describe "at_point_command/3" do
+    test "Elixir supports line-specific tests" do
+      runner = %Runner{framework: :exunit, filetype: :elixir, base_command: "mix test"}
+
+      assert TestRunner.at_point_command(runner, "test/my_test.exs", 42) ==
+               "mix test 'test/my_test.exs':42"
+    end
+
+    test "Ruby RSpec supports line-specific tests" do
+      runner = %Runner{framework: :rspec, filetype: :ruby, base_command: "bundle exec rspec"}
+
+      assert TestRunner.at_point_command(runner, "spec/user_spec.rb", 10) ==
+               "bundle exec rspec 'spec/user_spec.rb':10"
+    end
+
+    test "Minitest does not support line-specific tests" do
+      runner = %Runner{
+        framework: :minitest,
+        filetype: :ruby,
+        base_command: "bundle exec ruby -Itest"
+      }
+
+      assert TestRunner.at_point_command(runner, "test/user_test.rb", 10) == nil
+    end
+
+    test "Vitest does not support line-specific tests" do
+      runner = %Runner{framework: :vitest, filetype: :typescript, base_command: "npx vitest run"}
+      assert TestRunner.at_point_command(runner, "src/utils.test.ts", 10) == nil
+    end
+
+    test "Jest does not support line-specific tests" do
+      runner = %Runner{framework: :jest, filetype: :typescript, base_command: "npx jest"}
+      assert TestRunner.at_point_command(runner, "src/utils.test.ts", 10) == nil
+    end
+
+    test "CTest does not support line-specific tests" do
+      runner = %Runner{framework: :ctest, filetype: :c, base_command: "ctest --test-dir build"}
+      assert TestRunner.at_point_command(runner, "test/test_buffer.c", 10) == nil
+    end
+
+    test "Swift PM does not support line-specific tests" do
+      runner = %Runner{framework: :swift_pm, filetype: :swift, base_command: "swift test"}
+      assert TestRunner.at_point_command(runner, "Tests/BufferTests.swift", 10) == nil
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `SPC m t` submenu with test runner commands for Elixir, Ruby, TypeScript/JS, C/C++, and Swift.

Closes #487

## Why

Test runners are the #1 reason Doom users press `SPC m`. Running tests without leaving the editor, seeing output inline, and rerunning the last test on a keybinding is a core workflow. This makes `SPC m` immediately practical for all 5 daily-driver languages.

## Changes

### New: `Minga.CommandOutput`
GenServer that owns an Erlang Port running a shell command and streams stdout/stderr into a read-only `BufferServer`. Reusable for any "run command, show output in a buffer" workflow (build, lint, etc.). Uses a process `Registry` for named lookups (e.g., `"*test*"`).

### New: `Minga.TestRunner`
Framework detection from project markers + shell command generation. Returns a `%Runner{}` struct (not a bare map) with `@enforce_keys`. File paths are shell-escaped to prevent injection.

**Detected frameworks:**

| Language | Frameworks | At-point? |
|---|---|---|
| Elixir | ExUnit | ✅ `mix test file:line` |
| Ruby | RSpec, Minitest | ✅ RSpec only |
| TypeScript/JS | Vitest > Jest > npm test | ❌ |
| C/C++ | CTest, Make | ❌ |
| Swift | Swift PM | ❌ |

### Keybindings

| Key | Command | Description |
|---|---|---|
| `SPC m t t` | `:test_file` | Run tests for current file |
| `SPC m t a` | `:test_all` | Run all project tests |
| `SPC m t p` | `:test_at_point` | Run test at cursor line |
| `SPC m t r` | `:test_rerun` | Rerun last test command |
| `SPC m t o` | `:test_output` | Show `*test*` buffer |

### Other changes
- `last_test_command` field added to `Editor.State` (replaces `:persistent_term`)
- `detect_project_filetype/1` in `TestRunner` (not in `commands.ex`)
- `{:open_special_buffer, name, pid}` clause in `BufferManagement`
- `Minga.CommandOutput.Registry` added to supervision tree
- `filetype_bindings/0` now returns both alternate file and test bindings

## Testing

- 46 TestRunner tests (detection, command generation, shell escaping, project filetype detection)
- 12 CommandOutput tests (streaming, exit codes, kill, rerun)
- 17 Registry tests updated
- All 4907 non-integration tests pass