### PR TITLE
docs(agents): add "Build It Right or Don't Build It" principle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,14 @@ Rules:
 3. Never stack a second speculative fix on top of an untested first fix.
 4. Never revert or replace a working fix with a "cleaner" version without user confirmation that the new version also works.
 
+## Build It Right or Don't Build It
+
+Never scope foundational infrastructure to a "V1" that deliberately skips known requirements. If a data structure needs to handle 10,000 entries in production (e.g., LSP diagnostics), build it with the right algorithm from the start (interval tree, not linear scan). If a system needs incremental updates, don't ship clear-and-reapply and plan to "optimize later." The optimization never happens, and every feature built on top inherits the limitation.
+
+This applies to internal infrastructure like data structures, coordinate mapping systems, rendering pipelines, and protocol layers. It does not apply to user-facing features, where shipping a subset of functionality (e.g., keyboard selection before mouse selection) is a legitimate scoping choice.
+
+The test: if cutting the corner means the next team building on this code has to work around the limitation or refactor the foundation, it's not a valid shortcut. Build the foundation once, correctly.
+
 ## Coding Standards
 
 ### Elixir Types (mandatory)


### PR DESCRIPTION
## What

Adds a new section to AGENTS.md establishing a project-wide principle: foundational infrastructure must be built with the correct algorithms and architecture from the start. No scoping to a compromised "V1" that deliberately skips known requirements.

## Why

During the buffer decoration system planning (#519, #520-#524), we repeatedly caught ourselves defaulting to "defer it for V1" on things that were clearly foundational: using a flat list instead of an interval tree for decoration storage, skipping incremental anchor adjustment, omitting virtual line support. Each of these shortcuts would have forced every downstream consumer to work around the limitation or wait for a refactor.

The principle draws a clear line: foundational infra (data structures, coordinate mapping, rendering pipelines, protocol layers) gets built right. User-facing feature scoping (ship keyboard selection before mouse selection) is still a legitimate choice. The test: if the shortcut forces downstream code to work around the limitation, it is not valid.

## Changes

- Added "Build It Right or Don't Build It" section to AGENTS.md between "Iterative Fixes" and "Coding Standards"