### PR TITLE
docs(editor): fix FoldMap moduledoc claiming O(log n) binary search

### DIFF
--- a/lib/minga/editor/fold_map.ex
+++ b/lib/minga/editor/fold_map.ex
@@ -7,9 +7,11 @@ defmodule Minga.Editor.FoldMap do
   Neovim's per-window folds).
 
   Internally stores a sorted list of non-overlapping `FoldRange` structs.
-  Lookups use binary search for O(log n) performance. When the list is
-  empty, all translation functions are O(1) via guard clauses (zero
-  overhead for buffers without folds).
+  Lookups are linear scans over the sorted list. When the list is empty,
+  all translation functions are O(1) via guard clauses (zero overhead
+  for buffers without folds). This is adequate for typical fold counts
+  (tens, not thousands). The planned `DisplayMap` (#522) will replace
+  this module with an interval-tree-backed unified coordinate mapping.
 
   ## Coordinate translation
 


### PR DESCRIPTION
## What

The FoldMap moduledoc claimed "Lookups use binary search for O(log n) performance." The implementation uses `Enum.find` and `Enum.any?` (linear scans). Updated to accurately describe the current behavior.

## Why

Found during a codebase audit against the new "Build It Right or Don't Build It" principle (#526). The intent-reviewer flagged: "The moduledoc is lying. Fix the doc, don't fix the algorithm." The algorithm is fine for current fold counts (tens, not thousands), and the planned DisplayMap (#522) will replace this module entirely with interval-tree-backed lookups.

## Changes

- Replaced "binary search for O(log n)" with "linear scans over the sorted list"
- Added note that this is adequate for typical fold counts
- Added forward reference to DisplayMap (#522) as the planned replacement