### PR TITLE
fix(editor): render picker overlay on dashboard to prevent freeze

### DIFF
--- a/lib/minga/editor/renderer.ex
+++ b/lib/minga/editor/renderer.ex
@@ -23,7 +23,8 @@ defmodule Minga.Editor.Renderer do
 
   alias Minga.Editor.Dashboard
   alias Minga.Editor.DisplayList
-  alias Minga.Editor.DisplayList.{Cursor, Frame}
+  alias Minga.Editor.DisplayList.{Cursor, Frame, Overlay}
+  alias Minga.Editor.PickerUI
   alias Minga.Editor.RenderPipeline
   alias Minga.Editor.State, as: EditorState
   alias Minga.Port.Manager, as: PortManager
@@ -61,6 +62,7 @@ defmodule Minga.Editor.Renderer do
   def render(%{buffers: %{active: nil}} = state) do
     rows = state.viewport.rows
     cols = state.viewport.cols
+    viewport = state.viewport
 
     # Dashboard state is initialized by the editor when buffers empty,
     # but fall back to an empty state if somehow nil.
@@ -68,9 +70,29 @@ defmodule Minga.Editor.Renderer do
 
     splash_draws = Dashboard.render(cols, rows, state.theme, dash_state)
 
+    # Render picker overlay on top of the dashboard if one is open
+    # (e.g. :find_file or :project_switch from a dashboard quick action).
+    {picker_draws, picker_cursor} = PickerUI.render(state, viewport)
+
+    overlays =
+      if picker_draws == [] do
+        []
+      else
+        [%Overlay{draws: picker_draws, cursor: picker_cursor}]
+      end
+
+    # Use the picker cursor when a picker is open, otherwise park
+    # the cursor at 0,0 (invisible behind the dashboard).
+    cursor =
+      case picker_cursor do
+        {row, col} -> Cursor.new(row, col, :beam)
+        nil -> Cursor.new(0, 0, :block)
+      end
+
     frame = %Frame{
-      cursor: Cursor.new(0, 0, :block),
-      splash: splash_draws
+      cursor: cursor,
+      splash: splash_draws,
+      overlays: overlays
     }
 
     commands = DisplayList.to_commands(frame)

--- a/test/minga/editor/dashboard_test.exs
+++ b/test/minga/editor/dashboard_test.exs
@@ -2,6 +2,12 @@ defmodule Minga.Editor.DashboardTest do
   use ExUnit.Case, async: true
 
   alias Minga.Editor.Dashboard
+  alias Minga.Editor.Renderer
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.Buffers
+  alias Minga.Editor.State.Picker, as: PickerState
+  alias Minga.Editor.Viewport
+  alias Minga.Picker
 
   describe "new_state/1" do
     test "creates state with quick actions when no recent files" do
@@ -159,6 +165,45 @@ defmodule Minga.Editor.DashboardTest do
         end)
 
       assert active_bg_draws != [], "expected active item to have highlight background"
+    end
+  end
+
+  describe "dashboard renderer with picker overlay" do
+    test "renders picker overlay when a picker is open with no active buffer" do
+      # Build state: dashboard visible, no active buffer, picker open
+      items = [{"1", "file_a.ex", ""}, {"2", "file_b.ex", ""}]
+      picker = Picker.new(items, title: "Find File", max_visible: 10)
+
+      state = %EditorState{
+        port_manager: self(),
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{active: nil},
+        focus_stack: Minga.Input.default_stack(),
+        dashboard: Dashboard.new_state(),
+        theme: Minga.Theme.get!(:doom_one),
+        picker_ui: %PickerState{picker: picker, source: Minga.Picker.FileSource}
+      }
+
+      # Render returns state; side effect is a GenServer.cast to port_manager
+      _new_state = Renderer.render(state)
+
+      # Receive the cast sent to self() (port_manager)
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+
+      # The commands should contain picker content ("> " is the prompt prefix)
+      # encoded as binary protocol commands. Verify the list is non-empty
+      # and longer than a bare dashboard render (which has no overlays).
+      assert is_list(commands)
+      assert commands != []
+
+      # Re-render without the picker to compare command counts
+      bare_state = %{state | picker_ui: %PickerState{}}
+      _new_bare = Renderer.render(bare_state)
+      assert_receive {:"$gen_cast", {:send_commands, bare_commands}}
+
+      # With a picker, we should have more draw commands (the overlay draws)
+      assert length(commands) > length(bare_commands),
+             "picker overlay should add draw commands to the dashboard frame"
     end
   end
 end


### PR DESCRIPTION
# TL;DR
Pickers opened from the dashboard (Find file, Recent files, Switch project) were invisible, making the editor appear frozen. The dashboard render path now includes picker overlays.

Closes the remaining freeze from #525.

## Context
After #525 fixed command routing and SPC selection, Enter-based selection still froze the editor. The root cause: `Renderer.render/1` has two codepaths. The `buffers.active == nil` path (dashboard) created a `Frame` with only `splash` draws and no `overlays`. When a dashboard action opened a picker, the picker was active in state but invisible on screen. Keys went to the invisible picker handler while the user saw a static dashboard.

## Changes
- **`lib/minga/editor/renderer.ex`**: The dashboard render clause now calls `PickerUI.render(state, viewport)` and includes the result as a `Frame` overlay. The cursor repositions to the picker prompt when a picker is open (`:beam` shape, matching the normal pipeline).
- **`test/minga/editor/dashboard_test.exs`**: Added regression test that constructs a state with `buffers.active == nil` + an open picker, renders it, and asserts the frame contains more draw commands than a bare dashboard (proving the overlay draws are included).

## Verification
```bash
mix compile --warnings-as-errors  # clean
mix lint                          # passes (format, credo, dialyzer)
mix test test/minga/editor/dashboard_test.exs test/minga/input/dashboard_test.exs
# 28 tests, 0 failures
```

Manual verification:
1. Launch `minga` with no file arguments
2. Press Enter on "Find file" (or arrow to any picker-based item and press Enter)
3. The file picker should appear over the dashboard and accept typed input
4. Escape closes the picker, returning to the dashboard

## Acceptance Criteria Addressed
- Dashboard does not freeze when selecting a picker-based item with Enter ✅
- Picker overlay is visible over the dashboard ✅
- Cursor positions in the picker prompt correctly ✅