### PR TITLE
fix(editor): disable dashboard, create empty buffer on startup

### DIFF
--- a/lib/minga/editor/commands/buffer_management.ex
+++ b/lib/minga/editor/commands/buffer_management.ex
@@ -14,7 +14,7 @@ defmodule Minga.Editor.Commands.BufferManagement do
   alias Minga.Editor.Commands.Helpers
   alias Minga.Editor.Commands.Movement
   alias Minga.Editor.Commands.Search, as: SearchCommands
-  alias Minga.Editor.Dashboard
+
   alias Minga.Editor.HighlightSync
   alias Minga.Editor.PickerUI
   alias Minga.Editor.State, as: EditorState
@@ -568,12 +568,7 @@ defmodule Minga.Editor.Commands.BufferManagement do
 
       case new_buffers do
         [] ->
-          # No buffers left — initialize dashboard and let it render
-          recent = fetch_recent_files()
-          dash = Dashboard.new_state(recent)
-
-          %{state | buffers: %{bs | list: [], active_index: 0, active: nil}, dashboard: dash}
-          |> EditorState.sync_active_window_buffer()
+          create_fallback_buffer(state, bs)
 
         _ ->
           new_idx = min(idx, Enum.count(new_buffers) - 1)
@@ -858,10 +853,20 @@ defmodule Minga.Editor.Commands.BufferManagement do
     put_in(state.file_tree.tree, updated_tree)
   end
 
-  @spec fetch_recent_files() :: [String.t()]
-  defp fetch_recent_files do
-    Minga.Project.recent_files()
-  catch
-    :exit, _ -> []
+  # Creates an empty buffer when the last buffer is killed.
+  # Dashboard is disabled pending rewrite as a special buffer.
+  @spec create_fallback_buffer(state(), EditorState.Buffers.t()) :: state()
+  defp create_fallback_buffer(state, bs) do
+    case DynamicSupervisor.start_child(
+           Minga.Buffer.Supervisor,
+           {BufferServer, content: "", buffer_name: "[new 1]"}
+         ) do
+      {:ok, new_buf} ->
+        %{state | buffers: %{bs | list: [new_buf], active_index: 0, active: new_buf}}
+        |> EditorState.sync_active_window_buffer()
+
+      {:error, _} ->
+        %{state | buffers: %{bs | list: [], active_index: 0, active: nil}}
+    end
   end
 end

--- a/lib/minga/editor/startup.ex
+++ b/lib/minga/editor/startup.ex
@@ -12,7 +12,6 @@ defmodule Minga.Editor.Startup do
   alias Minga.Config.Loader, as: ConfigLoader
   alias Minga.Config.Options, as: ConfigOptions
   alias Minga.Editor.Commands
-  alias Minga.Editor.Dashboard
   alias Minga.Editor.FileWatcherHelpers
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.AgentAccess
@@ -51,15 +50,26 @@ defmodule Minga.Editor.Startup do
 
     {messages_buf, warnings_buf} = start_special_buffers()
 
-    {active_buf, buffers, dashboard} =
+    # Always ensure an active buffer exists. The editor's render pipeline,
+    # command dispatch, and input routing all assume buffers.active is a
+    # pid. The dashboard feature (which set active to nil) is disabled
+    # until it can be reimplemented as a special buffer. See #XXX.
+    {active_buf, buffers} =
       case buffer do
         pid when is_pid(pid) ->
-          {pid, [pid], nil}
+          {pid, [pid]}
 
         _ ->
-          recent = safe_recent_files()
-          {nil, [], Dashboard.new_state(recent)}
+          {:ok, buf} =
+            DynamicSupervisor.start_child(
+              Minga.Buffer.Supervisor,
+              {BufferServer, content: "", buffer_name: "[new 1]"}
+            )
+
+          {buf, [buf]}
       end
+
+    dashboard = nil
 
     # Decide mode FIRST, then create the right window type.
     {keymap_scope, _agentic_state} = startup_view_state(port_manager)
@@ -293,10 +303,6 @@ defmodule Minga.Editor.Startup do
     :exit, _ -> :ok
   end
 
-  @spec safe_recent_files() :: [String.t()]
-  defp safe_recent_files do
-    Minga.Project.recent_files()
-  catch
-    :exit, _ -> []
-  end
+  # NOTE: safe_recent_files/0 removed with dashboard disable.
+  # Will be restored when dashboard is reimplemented as a buffer.
 end

--- a/test/minga/buffer_management_test.exs
+++ b/test/minga/buffer_management_test.exs
@@ -149,17 +149,17 @@ defmodule Minga.BufferManagementTest do
     end
 
     @tag :tmp_dir
-    test "killing the only buffer shows dashboard", %{tmp_dir: tmp_dir} do
+    test "killing the only buffer shows empty buffer", %{tmp_dir: tmp_dir} do
       path = Path.join(tmp_dir, "solo.txt")
       File.write!(path, "alone")
 
       ctx = start_editor("alone", file_path: path)
       send_keys(ctx, "<SPC>bd")
 
-      # Should show dashboard (version string visible)
+      # Should show an empty buffer (dashboard disabled pending rewrite)
       screen = screen_text(ctx)
       all_text = Enum.join(screen, "\n")
-      assert String.contains?(all_text, "Minga v")
+      assert String.contains?(all_text, "[new 1]")
     end
 
     @tag :tmp_dir

--- a/test/minga/editor/renderer/line_test.exs
+++ b/test/minga/editor/renderer/line_test.exs
@@ -185,7 +185,7 @@ defmodule Minga.Editor.Renderer.LineTest do
   end
 
   describe "no file open" do
-    test "shows dashboard when no file is loaded" do
+    test "shows empty buffer when no file is loaded" do
       id = :erlang.unique_integer([:positive])
       {:ok, port} = HeadlessPort.start_link(width: 80, height: 24)
 
@@ -201,10 +201,10 @@ defmodule Minga.Editor.Renderer.LineTest do
       send(editor, {:minga_input, {:ready, 80, 24}})
       :ok = HeadlessPort.await_frame(port)
 
-      # Dashboard should show version string somewhere on screen
+      # Should show a normal editor with an empty buffer, not a dashboard
       screen = for row <- 0..23, do: HeadlessPort.get_row_text(port, row)
       all_text = Enum.join(screen, "\n")
-      assert String.contains?(all_text, "Minga v")
+      assert String.contains?(all_text, "[new 1]")
     end
   end
 end


### PR DESCRIPTION
# TL;DR
Disables the dashboard home screen as a hotfix for the freeze bugs. The editor now creates an empty `[new 1]` buffer on startup instead of entering the `buffers.active == nil` state that causes crashes.

## Context
The dashboard (#505) introduced `buffers.active == nil` as a valid editor state, but the render pipeline, command dispatch, input routing, and window tree all assume `active` is always a pid. This caused a cascade of bugs (#525, #534) that required increasingly invasive patches. After three rounds of fixes, the agent session action still did not work, and the architectural review found 28 locations across the codebase with defensive `active == nil` guards.

The proper fix is reimplementing the dashboard as a special buffer (like `*Messages*`), which eliminates the nil state entirely. That work is tracked in a separate ticket. This PR is the stopgap to unfreeze main.

## Changes
- **`lib/minga/editor/startup.ex`**: When no file is specified, creates a `BufferServer` with `buffer_name: "[new 1]"` instead of setting `active: nil` and `dashboard: Dashboard.new_state()`
- **`lib/minga/editor/commands/buffer_management.ex`**: When the last buffer is killed, creates a `[new 1]` fallback buffer instead of entering dashboard/nil state. Extracted into `create_fallback_buffer/2` to satisfy credo nesting depth.
- **Tests updated**: "shows dashboard" → "shows empty buffer" for the two integration tests that verified dashboard rendering

## Verification
```bash
mix compile --warnings-as-errors  # clean
mix lint                          # passes
mix test test/minga/editor/ test/minga/input/ test/minga/buffer/ test/minga/buffer_management_test.exs
# 1716 tests, 0 failures
```