### PR TITLE
feat(lsp): hover tooltips in floating windows with markdown rendering

### DIFF
--- a/lib/minga/editor/floating_window.ex
+++ b/lib/minga/editor/floating_window.ex
@@ -67,7 +67,19 @@ defmodule Minga.Editor.FloatingWindow do
 
     @type size :: {:cols, pos_integer()} | {:rows, pos_integer()} | {:percent, 1..100}
 
-    @type position :: :center | {row_offset :: integer(), col_offset :: integer()}
+    @typedoc """
+    Position for the floating window.
+
+    - `:center` — centered in the viewport
+    - `{row_offset, col_offset}` — offset from center
+    - `{:anchor, row, col, :above | :below}` — anchored to a cursor position,
+      appearing above or below. Flips if there isn't enough room.
+    """
+    @type position ::
+            :center
+            | {row_offset :: integer(), col_offset :: integer()}
+            | {:anchor, row :: non_neg_integer(), col :: non_neg_integer(),
+               preferred :: :above | :below}
 
     @type t :: %__MODULE__{
             title: String.t() | nil,
@@ -166,6 +178,33 @@ defmodule Minga.Editor.FloatingWindow do
     center_col = max(div(vp_cols - w, 2), 0)
     row = clamp(center_row + row_off, 0, max(vp_rows - h, 0))
     col = clamp(center_col + col_off, 0, max(vp_cols - w, 0))
+    {row, col}
+  end
+
+  # Anchor positioning: place the window near a cursor position.
+  # Tries the preferred direction first, flips if there isn't room.
+  defp resolve_position({:anchor, anchor_row, anchor_col, preferred}, h, w, vp_rows, vp_cols) do
+    col = clamp(anchor_col, 0, max(vp_cols - w, 0))
+
+    row =
+      case preferred do
+        :above ->
+          if anchor_row - h >= 0 do
+            anchor_row - h
+          else
+            # Not enough room above, try below
+            min(anchor_row + 1, max(vp_rows - h, 0))
+          end
+
+        :below ->
+          if anchor_row + 1 + h <= vp_rows do
+            anchor_row + 1
+          else
+            # Not enough room below, try above
+            max(anchor_row - h, 0)
+          end
+      end
+
     {row, col}
   end
 

--- a/lib/minga/editor/hover_popup.ex
+++ b/lib/minga/editor/hover_popup.ex
@@ -1,0 +1,214 @@
+defmodule Minga.Editor.HoverPopup do
+  @moduledoc """
+  State and rendering for LSP hover tooltips.
+
+  Parses LSP hover markdown content into styled display list draws and
+  renders them in a cursor-anchored floating window. Supports scrolling
+  for long content (j/k when focused) and the LazyVim pattern of
+  pressing K once to show, K again to focus into the hover for scrolling.
+
+  ## Lifecycle
+
+  1. LSP hover response arrives with markdown content
+  2. `new/3` creates the popup state with parsed content
+  3. The render pipeline renders it as an overlay via `render/3`
+  4. Any keypress (except K/j/k when focused) dismisses the popup
+  """
+
+  alias Minga.Agent.Markdown
+  alias Minga.Editor.DisplayList
+  alias Minga.Editor.FloatingWindow
+
+  @enforce_keys [:content_lines, :anchor_row, :anchor_col]
+  defstruct content_lines: [],
+            anchor_row: 0,
+            anchor_col: 0,
+            scroll_offset: 0,
+            focused: false
+
+  @typedoc "A hover popup state."
+  @type t :: %__MODULE__{
+          content_lines: [Markdown.parsed_line()],
+          anchor_row: non_neg_integer(),
+          anchor_col: non_neg_integer(),
+          scroll_offset: non_neg_integer(),
+          focused: boolean()
+        }
+
+  @max_width 80
+  @max_height 20
+  @min_width 30
+
+  @doc """
+  Creates a new hover popup from LSP hover content.
+
+  Parses the markdown content and anchors the popup at the given
+  cursor position.
+  """
+  @spec new(String.t(), non_neg_integer(), non_neg_integer()) :: t()
+  def new(markdown_text, cursor_row, cursor_col) do
+    content_lines = Markdown.parse(markdown_text)
+
+    %__MODULE__{
+      content_lines: content_lines,
+      anchor_row: cursor_row,
+      anchor_col: cursor_col
+    }
+  end
+
+  @doc "Focus into the hover popup for scrolling."
+  @spec focus(t()) :: t()
+  def focus(%__MODULE__{} = popup), do: %{popup | focused: true}
+
+  @doc "Scroll content down (later lines visible)."
+  @spec scroll_down(t()) :: t()
+  def scroll_down(%__MODULE__{} = popup) do
+    max_offset = max(length(popup.content_lines) - 3, 0)
+    %{popup | scroll_offset: min(popup.scroll_offset + 3, max_offset)}
+  end
+
+  @doc "Scroll content up."
+  @spec scroll_up(t()) :: t()
+  def scroll_up(%__MODULE__{} = popup) do
+    %{popup | scroll_offset: max(popup.scroll_offset - 3, 0)}
+  end
+
+  @doc """
+  Renders the hover popup as a list of display list draws.
+
+  Returns an empty list if the content is empty. The draws are
+  absolute screen coordinates ready for an Overlay.
+  """
+  @spec render(t(), {pos_integer(), pos_integer()}, map()) :: [DisplayList.draw()]
+  def render(%__MODULE__{content_lines: []}, _viewport, _theme), do: []
+
+  def render(%__MODULE__{} = popup, viewport, theme) do
+    {vp_rows, vp_cols} = viewport
+    popup_theme = Map.get(theme, :popup, default_popup_theme())
+
+    # Compute content draws with styling
+    {content_draws, content_width, content_height} =
+      build_content_draws(popup.content_lines, popup.scroll_offset, vp_cols, theme)
+
+    # Size the window to fit content, clamped to limits
+    width = content_width |> max(@min_width) |> min(@max_width) |> min(vp_cols - 2)
+    height = content_height |> min(@max_height) |> min(vp_rows - 4)
+
+    # Add 2 for border
+    total_width = width + 2
+    total_height = height + 2
+
+    # Scrollbar indicator in footer
+    total_lines = length(popup.content_lines)
+
+    footer =
+      if total_lines > height do
+        visible_end = min(popup.scroll_offset + height, total_lines)
+        "#{popup.scroll_offset + 1}-#{visible_end}/#{total_lines}"
+      else
+        nil
+      end
+
+    # Focus indicator in border
+    border_style = if popup.focused, do: :single, else: :rounded
+
+    spec = %FloatingWindow.Spec{
+      content: content_draws,
+      width: {:cols, total_width},
+      height: {:rows, total_height},
+      position: {:anchor, popup.anchor_row, popup.anchor_col, :above},
+      border: border_style,
+      footer: footer,
+      theme: popup_theme,
+      viewport: viewport
+    }
+
+    FloatingWindow.render(spec)
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────────
+
+  @spec build_content_draws(
+          [Markdown.parsed_line()],
+          non_neg_integer(),
+          pos_integer(),
+          map()
+        ) :: {[DisplayList.draw()], non_neg_integer(), non_neg_integer()}
+  defp build_content_draws(lines, scroll_offset, max_width, theme) do
+    # Take lines from scroll_offset, limit to a reasonable max
+    visible_lines = Enum.drop(lines, scroll_offset)
+
+    {draws, max_col, row} =
+      Enum.reduce(visible_lines, {[], 0, 0}, fn {segments, line_type}, {acc, max_w, row} ->
+        line_draws = render_line_segments(segments, line_type, row, max_width, theme)
+
+        line_width =
+          segments
+          |> Enum.map(fn {text, _style} -> String.length(text) end)
+          |> Enum.sum()
+
+        {line_draws ++ acc, max(max_w, line_width), row + 1}
+      end)
+
+    {Enum.reverse(draws), max_col, row}
+  end
+
+  @spec render_line_segments(
+          [Markdown.segment()],
+          Markdown.line_type(),
+          non_neg_integer(),
+          pos_integer(),
+          map()
+        ) :: [DisplayList.draw()]
+  defp render_line_segments(segments, _line_type, row, max_width, theme) do
+    syntax = Map.get(theme, :syntax, %{})
+    editor = Map.get(theme, :editor, %{})
+    base_fg = Map.get(editor, :fg, 0xBBC2CF)
+
+    {draws, _col} =
+      Enum.reduce(segments, {[], 0}, fn {text, style}, {acc, col} ->
+        text_len = String.length(text)
+
+        if col >= max_width - 2 do
+          {acc, col}
+        else
+          clipped = String.slice(text, 0, max(max_width - 2 - col, 0))
+          draw_style = style_to_opts(style, syntax, base_fg)
+          draw = DisplayList.draw(row, col, clipped, draw_style)
+          {[draw | acc], col + text_len}
+        end
+      end)
+
+    Enum.reverse(draws)
+  end
+
+  @spec style_to_opts(Markdown.style(), map(), non_neg_integer()) :: keyword()
+  defp style_to_opts(:plain, _syntax, fg), do: [fg: fg]
+  defp style_to_opts(:bold, _syntax, fg), do: [fg: fg, bold: true]
+  defp style_to_opts(:italic, _syntax, fg), do: [fg: fg, italic: true]
+  defp style_to_opts(:bold_italic, _syntax, fg), do: [fg: fg, bold: true, italic: true]
+  defp style_to_opts(:code, syntax, _fg), do: [fg: Map.get(syntax, :string, 0x98BE65)]
+  defp style_to_opts(:code_block, syntax, _fg), do: [fg: Map.get(syntax, :string, 0x98BE65)]
+
+  defp style_to_opts({:code_content, _lang}, syntax, _fg),
+    do: [fg: Map.get(syntax, :string, 0x98BE65)]
+
+  defp style_to_opts(:header1, syntax, _fg),
+    do: [fg: Map.get(syntax, :keyword, 0x51AFEF), bold: true]
+
+  defp style_to_opts(:header2, syntax, _fg),
+    do: [fg: Map.get(syntax, :keyword, 0x51AFEF), bold: true]
+
+  defp style_to_opts(:header3, syntax, _fg),
+    do: [fg: Map.get(syntax, :keyword, 0x51AFEF)]
+
+  defp style_to_opts(:blockquote, _syntax, _fg), do: [fg: 0x5B6268, italic: true]
+  defp style_to_opts(:list_bullet, syntax, _fg), do: [fg: Map.get(syntax, :keyword, 0x51AFEF)]
+  defp style_to_opts(:rule, _syntax, _fg), do: [fg: 0x5B6268]
+  defp style_to_opts(_other, _syntax, fg), do: [fg: fg]
+
+  @spec default_popup_theme() :: map()
+  defp default_popup_theme do
+    %{bg: 0x21242B, border_fg: 0x5B6268, title_fg: 0xBBC2CF}
+  end
+end

--- a/lib/minga/editor/lsp_actions.ex
+++ b/lib/minga/editor/lsp_actions.ex
@@ -10,6 +10,7 @@ defmodule Minga.Editor.LspActions do
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.Commands
   alias Minga.Editor.DocumentSync
+  alias Minga.Editor.HoverPopup
   alias Minga.Editor.State, as: EditorState
   alias Minga.LSP.Client
 
@@ -84,7 +85,9 @@ defmodule Minga.Editor.LspActions do
   @doc """
   Handles a textDocument/hover response.
 
-  Extracts plain text content and displays it in the minibuffer.
+  Creates a floating hover popup with markdown-rendered content anchored
+  at the cursor position. Falls back to a minibuffer message if the
+  content is very short (single line, no markdown).
   """
   @spec handle_hover_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_hover_response(state, {:error, error}) do
@@ -97,11 +100,16 @@ defmodule Minga.Editor.LspActions do
   end
 
   def handle_hover_response(state, {:ok, %{"contents" => contents}}) do
-    text = extract_hover_text(contents)
+    markdown = extract_hover_markdown(contents)
 
-    case text do
-      "" -> %{state | status_msg: "No hover information"}
-      _ -> %{state | status_msg: text}
+    case markdown do
+      "" ->
+        %{state | status_msg: "No hover information"}
+
+      text ->
+        {cursor_row, cursor_col} = hover_cursor_screen_position(state)
+        popup = HoverPopup.new(text, cursor_row, cursor_col)
+        %{state | hover_popup: popup}
     end
   end
 
@@ -262,6 +270,64 @@ defmodule Minga.Editor.LspActions do
   end
 
   defp set_jump_mark(state), do: state
+
+  @doc """
+  Extracts raw markdown text from LSP hover contents.
+
+  Preserves markdown formatting for floating window rendering.
+  Handles MarkupContent, plain strings, and MarkedString arrays.
+  """
+  @spec extract_hover_markdown(term()) :: String.t()
+  def extract_hover_markdown(%{"kind" => "markdown", "value" => value}) when is_binary(value) do
+    String.trim(value)
+  end
+
+  def extract_hover_markdown(%{"kind" => "plaintext", "value" => value}) when is_binary(value) do
+    String.trim(value)
+  end
+
+  def extract_hover_markdown(%{"kind" => _, "value" => value}) when is_binary(value) do
+    String.trim(value)
+  end
+
+  def extract_hover_markdown(text) when is_binary(text) do
+    String.trim(text)
+  end
+
+  def extract_hover_markdown(items) when is_list(items) do
+    items
+    |> Enum.map(&extract_hover_markdown/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n\n")
+  end
+
+  def extract_hover_markdown(%{"language" => lang, "value" => value}) when is_binary(value) do
+    "```#{lang}\n#{String.trim(value)}\n```"
+  end
+
+  def extract_hover_markdown(_), do: ""
+
+  # Computes the cursor's screen position for anchoring the hover popup.
+  # Uses the last rendered cursor position from the compose stage.
+  @spec hover_cursor_screen_position(state()) :: {non_neg_integer(), non_neg_integer()}
+  defp hover_cursor_screen_position(state) do
+    # Use the viewport cursor position from the active window
+    buf = state.buffers.active
+
+    if buf do
+      {line, col} = BufferServer.cursor(buf)
+      # Approximate screen position: line offset from viewport top + gutter
+      vp = state.viewport
+      screen_row = line - vp.top + 1
+      screen_col = col + 4
+      {clamp(screen_row, 1, vp.rows - 2), clamp(screen_col, 0, vp.cols - 1)}
+    else
+      {div(state.viewport.rows, 2), div(state.viewport.cols, 2)}
+    end
+  end
+
+  @spec clamp(integer(), integer(), integer()) :: integer()
+  defp clamp(val, lo, hi), do: max(lo, min(val, hi))
 
   @spec strip_markdown(String.t()) :: String.t()
   defp strip_markdown(text) do

--- a/lib/minga/editor/render_pipeline/chrome.ex
+++ b/lib/minga/editor/render_pipeline/chrome.ex
@@ -13,6 +13,7 @@ defmodule Minga.Editor.RenderPipeline.Chrome do
   alias Minga.Editor.CompletionUI
   alias Minga.Editor.DisplayList
   alias Minga.Editor.DisplayList.{Cursor, Overlay}
+  alias Minga.Editor.HoverPopup
   alias Minga.Editor.Layout
   alias Minga.Editor.PickerUI
   alias Minga.Editor.Renderer.Caps
@@ -141,12 +142,16 @@ defmodule Minga.Editor.RenderPipeline.Chrome do
           []
       end
 
+    # Hover popup overlay
+    hover_draws = render_hover_popup(state)
+
     # Float popup overlays (from the popup system)
     float_overlays = PopupLifecycle.render_float_overlays(state)
 
     overlays =
       (float_overlays ++
          [
+           %Overlay{draws: hover_draws},
            %Overlay{draws: whichkey_draws},
            %Overlay{draws: completion_draws},
            %Overlay{draws: picker_draws, cursor: picker_cursor}
@@ -171,5 +176,14 @@ defmodule Minga.Editor.RenderPipeline.Chrome do
       overlays: overlays,
       regions: regions
     }
+  end
+
+  # ── Hover popup ──────────────────────────────────────────────────────────
+
+  @spec render_hover_popup(state()) :: [DisplayList.draw()]
+  defp render_hover_popup(%{hover_popup: nil}), do: []
+
+  defp render_hover_popup(%{hover_popup: popup, viewport: vp, theme: theme}) do
+    HoverPopup.render(popup, {vp.rows, vp.cols}, theme)
   end
 end

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -107,6 +107,7 @@ defmodule Minga.Editor.State do
             file_tree: %FileTreeState{},
             git_buffers: %{},
             lsp_status: :none,
+            hover_popup: nil,
             injection_ranges: %{},
             focus_stack: [],
             keymap_scope: :editor,
@@ -145,6 +146,7 @@ defmodule Minga.Editor.State do
           file_tree: FileTreeState.t(),
           git_buffers: %{pid() => pid()},
           lsp_status: Minga.Editor.Modeline.lsp_status(),
+          hover_popup: Minga.Editor.HoverPopup.t() | nil,
           injection_ranges: %{
             pid() => [
               %{start_byte: non_neg_integer(), end_byte: non_neg_integer(), language: String.t()}

--- a/lib/minga/input.ex
+++ b/lib/minga/input.ex
@@ -28,6 +28,7 @@ defmodule Minga.Input do
   alias Minga.Input.DiffReview
   alias Minga.Input.FileTreeHandler
   alias Minga.Input.GlobalBindings
+  alias Minga.Input.Hover
   alias Minga.Input.Interrupt
   alias Minga.Input.MentionCompletion
   alias Minga.Input.ModeFSM
@@ -61,6 +62,7 @@ defmodule Minga.Input do
       Dashboard,
       ConflictPrompt,
       Picker,
+      Hover,
       Completion,
       Scoped,
       GlobalBindings,

--- a/lib/minga/input/hover.ex
+++ b/lib/minga/input/hover.ex
@@ -1,0 +1,66 @@
+defmodule Minga.Input.Hover do
+  @moduledoc """
+  Input handler for the hover popup.
+
+  When a hover popup is visible, this handler intercepts keys:
+
+  - **K** (when not focused): focuses into the hover for scrolling
+  - **j/k** (when focused): scrolls the hover content
+  - **q/Escape** (when focused): dismisses the hover
+  - **Any other key** (when not focused): dismisses the hover and passes through
+
+  Follows the LazyVim pattern: press K once to show hover, press K
+  again to focus into it for scrolling, press q to dismiss.
+  """
+
+  @behaviour Minga.Input.Handler
+
+  alias Minga.Editor.HoverPopup
+  alias Minga.Editor.State, as: EditorState
+
+  # Escape codepoint from the port protocol
+  @key_escape 27
+
+  @impl true
+  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          Minga.Input.Handler.result()
+  def handle_key(%{hover_popup: nil} = state, _codepoint, _modifiers) do
+    {:passthrough, state}
+  end
+
+  # K pressed while hover is visible but not focused: focus into it.
+  # The frontend sends uppercase K as codepoint ?K (75) with no shift modifier,
+  # matching how normal.ex binds {?K, 0} to :hover.
+  def handle_key(%{hover_popup: %HoverPopup{focused: false}} = state, ?K, 0) do
+    {:handled, %{state | hover_popup: HoverPopup.focus(state.hover_popup)}}
+  end
+
+  # When focused, j scrolls down
+  def handle_key(%{hover_popup: %HoverPopup{focused: true}} = state, ?j, 0) do
+    {:handled, %{state | hover_popup: HoverPopup.scroll_down(state.hover_popup)}}
+  end
+
+  # When focused, k scrolls up
+  def handle_key(%{hover_popup: %HoverPopup{focused: true}} = state, ?k, 0) do
+    {:handled, %{state | hover_popup: HoverPopup.scroll_up(state.hover_popup)}}
+  end
+
+  # When focused, q or Escape dismisses
+  def handle_key(%{hover_popup: %HoverPopup{focused: true}} = state, ?q, 0) do
+    {:handled, %{state | hover_popup: nil}}
+  end
+
+  def handle_key(%{hover_popup: %HoverPopup{focused: true}} = state, @key_escape, _mods) do
+    {:handled, %{state | hover_popup: nil}}
+  end
+
+  # When focused, any other key dismisses and passes through
+  def handle_key(%{hover_popup: %HoverPopup{focused: true}} = state, _cp, _mods) do
+    {:passthrough, %{state | hover_popup: nil}}
+  end
+
+  # Not focused: any key dismisses and passes through
+  def handle_key(%{hover_popup: %HoverPopup{focused: false}} = state, _cp, _mods) do
+    {:passthrough, %{state | hover_popup: nil}}
+  end
+end

--- a/lib/minga/lsp/client.ex
+++ b/lib/minga/lsp/client.ex
@@ -657,7 +657,7 @@ defmodule Minga.LSP.Client do
         },
         "hover" => %{
           "dynamicRegistration" => false,
-          "contentFormat" => ["plaintext"]
+          "contentFormat" => ["markdown", "plaintext"]
         }
       }
     }

--- a/test/minga/editor/floating_window_test.exs
+++ b/test/minga/editor/floating_window_test.exs
@@ -317,4 +317,48 @@ defmodule Minga.Editor.FloatingWindowTest do
       assert length(bg_draws) == 5
     end
   end
+
+  # ── Anchor positioning ─────────────────────────────────────────────────────
+
+  describe "anchor positioning" do
+    test "positions above cursor when there is room" do
+      s = spec(position: {:anchor, 15, 10, :above}, height: {:rows, 5}, width: {:cols, 20})
+      draws = FloatingWindow.render(s)
+      rows = Enum.map(draws, fn {r, _c, _text, _s} -> r end)
+      max_row = Enum.max(rows)
+      assert max_row < 15
+    end
+
+    test "flips below cursor when not enough room above" do
+      s = spec(position: {:anchor, 2, 10, :above}, height: {:rows, 5}, width: {:cols, 20})
+      draws = FloatingWindow.render(s)
+      rows = Enum.map(draws, fn {r, _c, _text, _s} -> r end)
+      min_row = Enum.min(rows)
+      assert min_row >= 2
+    end
+
+    test "positions below cursor when preferred" do
+      s = spec(position: {:anchor, 5, 10, :below}, height: {:rows, 5}, width: {:cols, 20})
+      draws = FloatingWindow.render(s)
+      rows = Enum.map(draws, fn {r, _c, _text, _s} -> r end)
+      min_row = Enum.min(rows)
+      assert min_row > 5
+    end
+
+    test "flips above when not enough room below" do
+      s = spec(position: {:anchor, 21, 10, :below}, height: {:rows, 5}, width: {:cols, 20})
+      draws = FloatingWindow.render(s)
+      rows = Enum.map(draws, fn {r, _c, _text, _s} -> r end)
+      max_row = Enum.max(rows)
+      assert max_row <= 21
+    end
+
+    test "clamps column to viewport" do
+      s = spec(position: {:anchor, 10, 70, :above}, height: {:rows, 3}, width: {:cols, 20})
+      draws = FloatingWindow.render(s)
+      cols = Enum.map(draws, fn {_r, c, _text, _s} -> c end)
+      max_col = Enum.max(cols)
+      assert max_col < 80
+    end
+  end
 end

--- a/test/minga/editor/hover_popup_test.exs
+++ b/test/minga/editor/hover_popup_test.exs
@@ -1,0 +1,149 @@
+defmodule Minga.Editor.HoverPopupTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.HoverPopup
+  alias Minga.Theme
+
+  @theme Theme.get!(:doom_one)
+  @viewport {24, 80}
+
+  describe "new/3" do
+    test "creates a popup with parsed markdown content" do
+      popup = HoverPopup.new("**bold** text", 10, 20)
+      assert %HoverPopup{} = popup
+      assert popup.anchor_row == 10
+      assert popup.anchor_col == 20
+      assert popup.scroll_offset == 0
+      assert popup.focused == false
+      assert popup.content_lines != []
+    end
+
+    test "handles multi-line markdown" do
+      text = "# Header\n\nSome text\n\n```elixir\ndefmodule Foo do\nend\n```"
+      popup = HoverPopup.new(text, 5, 10)
+      assert [_, _, _, _ | _] = popup.content_lines
+    end
+
+    test "handles plain text" do
+      popup = HoverPopup.new("just plain text", 5, 10)
+      assert [_] = popup.content_lines
+    end
+  end
+
+  describe "focus/1" do
+    test "sets focused to true" do
+      popup = HoverPopup.new("text", 5, 10)
+      assert popup.focused == false
+      focused = HoverPopup.focus(popup)
+      assert focused.focused == true
+    end
+  end
+
+  describe "scroll_down/1" do
+    test "increases scroll offset" do
+      popup = HoverPopup.new("line1\nline2\nline3\nline4\nline5\nline6", 5, 10)
+      scrolled = HoverPopup.scroll_down(popup)
+      assert scrolled.scroll_offset == 3
+    end
+
+    test "clamps at max offset" do
+      popup = HoverPopup.new("short", 5, 10)
+      scrolled = popup |> HoverPopup.scroll_down() |> HoverPopup.scroll_down()
+      assert scrolled.scroll_offset >= 0
+    end
+  end
+
+  describe "scroll_up/1" do
+    test "decreases scroll offset" do
+      popup = HoverPopup.new("line1\nline2\nline3\nline4\nline5", 5, 10)
+      scrolled = popup |> HoverPopup.scroll_down() |> HoverPopup.scroll_up()
+      assert scrolled.scroll_offset == 0
+    end
+
+    test "clamps at zero" do
+      popup = HoverPopup.new("text", 5, 10)
+      scrolled = HoverPopup.scroll_up(popup)
+      assert scrolled.scroll_offset == 0
+    end
+  end
+
+  describe "render/3" do
+    test "returns empty list for empty content" do
+      popup = %HoverPopup{content_lines: [], anchor_row: 5, anchor_col: 10}
+      assert HoverPopup.render(popup, @viewport, @theme) == []
+    end
+
+    test "returns draw commands for non-empty content" do
+      popup = HoverPopup.new("Hello world\n\nSome documentation", 10, 20)
+      draws = HoverPopup.render(popup, @viewport, @theme)
+      assert is_list(draws)
+      assert draws != []
+      assert Enum.all?(draws, &is_tuple/1)
+    end
+
+    test "produces draws with valid screen coordinates" do
+      popup = HoverPopup.new("Type: `String.t()`", 10, 20)
+      draws = HoverPopup.render(popup, @viewport, @theme)
+
+      Enum.each(draws, fn {row, col, _text, _style} ->
+        assert row >= 0 and row < 24, "row #{row} out of viewport"
+        assert col >= 0 and col < 80, "col #{col} out of viewport"
+      end)
+    end
+
+    test "renders markdown code blocks with styling" do
+      text = "```elixir\ndef hello, do: :world\n```"
+      popup = HoverPopup.new(text, 15, 10)
+      draws = HoverPopup.render(popup, @viewport, @theme)
+      assert draws != []
+    end
+
+    test "uses rounded border when not focused, single when focused" do
+      popup = HoverPopup.new("text", 10, 10)
+
+      # Not focused: rounded border chars (╭, ╮)
+      draws = HoverPopup.render(popup, @viewport, @theme)
+      texts = Enum.map(draws, fn {_r, _c, text, _s} -> text end)
+      combined = Enum.join(texts)
+      assert String.contains?(combined, "╭") or String.contains?(combined, "┌")
+
+      # Focused: single border chars (┌, ┐)
+      focused = HoverPopup.focus(popup)
+      focused_draws = HoverPopup.render(focused, @viewport, @theme)
+      focused_texts = Enum.map(focused_draws, fn {_r, _c, text, _s} -> text end)
+      focused_combined = Enum.join(focused_texts)
+      assert String.contains?(focused_combined, "┌")
+    end
+
+    test "positions above cursor when there is room" do
+      popup = HoverPopup.new("text", 15, 10)
+      draws = HoverPopup.render(popup, @viewport, @theme)
+
+      # All draws should be above row 15 (the anchor)
+      rows = Enum.map(draws, fn {r, _c, _text, _s} -> r end)
+      max_row = Enum.max(rows)
+      assert max_row < 15, "Expected hover above cursor row 15, got max row #{max_row}"
+    end
+
+    test "flips below cursor when near top of screen" do
+      popup = HoverPopup.new("text", 1, 10)
+      draws = HoverPopup.render(popup, @viewport, @theme)
+
+      # Some draws should be below row 1
+      rows = Enum.map(draws, fn {r, _c, _text, _s} -> r end)
+      min_row = Enum.min(rows)
+      assert min_row >= 0
+    end
+
+    test "shows scroll indicator when content exceeds window" do
+      lines = Enum.map_join(1..30, "\n", &"Line #{&1} of documentation")
+      popup = HoverPopup.new(lines, 15, 10)
+      draws = HoverPopup.render(popup, @viewport, @theme)
+
+      texts = Enum.map(draws, fn {_r, _c, text, _s} -> text end)
+      combined = Enum.join(texts)
+      # Footer should show scroll position like "1-20/30"
+      assert String.contains?(combined, "/")
+    end
+  end
+end

--- a/test/minga/editor/lsp_actions_test.exs
+++ b/test/minga/editor/lsp_actions_test.exs
@@ -154,14 +154,15 @@ defmodule Minga.Editor.LspActionsTest do
       assert result.status_msg == "No hover information"
     end
 
-    test "displays hover content in status_msg" do
+    test "creates hover popup for content" do
       state = fake_state()
       hover = %{"contents" => %{"kind" => "plaintext", "value" => "Returns :ok"}}
       result = LspActions.handle_hover_response(state, {:ok, hover})
-      assert result.status_msg == "Returns :ok"
+      assert %Minga.Editor.HoverPopup{} = result.hover_popup
+      assert result.hover_popup.focused == false
     end
 
-    test "strips markdown fences from hover content" do
+    test "creates hover popup for markdown content" do
       state = fake_state()
 
       hover = %{
@@ -172,7 +173,8 @@ defmodule Minga.Editor.LspActionsTest do
       }
 
       result = LspActions.handle_hover_response(state, {:ok, hover})
-      assert result.status_msg == "@spec foo() :: :ok"
+      assert %Minga.Editor.HoverPopup{} = result.hover_popup
+      assert result.hover_popup.content_lines != []
     end
 
     test "handles hover with no contents key" do
@@ -185,6 +187,12 @@ defmodule Minga.Editor.LspActionsTest do
   # ── Helpers ────────────────────────────────────────────────────────────────
 
   defp fake_state do
-    %{status_msg: nil, last_jump_pos: nil}
+    %{
+      status_msg: nil,
+      last_jump_pos: nil,
+      hover_popup: nil,
+      buffers: %{active: nil},
+      viewport: %{rows: 24, cols: 80, top: 0}
+    }
   end
 end

--- a/test/minga/input/hover_test.exs
+++ b/test/minga/input/hover_test.exs
@@ -1,0 +1,85 @@
+defmodule Minga.Input.HoverTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.HoverPopup
+  alias Minga.Input.Hover
+
+  import Minga.Editor.RenderPipeline.TestHelpers
+
+  # Key constants (character literals, matching how the frontend sends them)
+  @key_j ?j
+  @key_k ?k
+  @key_upper_k ?K
+  @key_q ?q
+  @key_escape 27
+  @key_h ?h
+  @none 0
+
+  defp state_with_hover(opts \\ []) do
+    state = base_state()
+    lines = Enum.map_join(1..20, "\n", &"Documentation line #{&1}")
+    popup = HoverPopup.new(lines, 10, 20)
+
+    popup =
+      if Keyword.get(opts, :focused, false),
+        do: HoverPopup.focus(popup),
+        else: popup
+
+    %{state | hover_popup: popup}
+  end
+
+  describe "handle_key/3 with no hover popup" do
+    test "passes through when no hover popup" do
+      state = base_state()
+      assert {:passthrough, ^state} = Hover.handle_key(state, @key_h, @none)
+    end
+  end
+
+  describe "handle_key/3 with unfocused hover" do
+    test "K focuses into the hover" do
+      state = state_with_hover()
+      assert {:handled, new_state} = Hover.handle_key(state, @key_upper_k, @none)
+      assert new_state.hover_popup.focused == true
+    end
+
+    test "any other key dismisses hover and passes through" do
+      state = state_with_hover()
+      assert {:passthrough, new_state} = Hover.handle_key(state, @key_h, @none)
+      assert new_state.hover_popup == nil
+    end
+  end
+
+  describe "handle_key/3 with focused hover" do
+    test "j scrolls down" do
+      state = state_with_hover(focused: true)
+      assert {:handled, new_state} = Hover.handle_key(state, @key_j, @none)
+      assert new_state.hover_popup.scroll_offset > 0
+    end
+
+    test "k scrolls up" do
+      state = state_with_hover(focused: true)
+      # Scroll down first so we can scroll up
+      state = %{state | hover_popup: HoverPopup.scroll_down(state.hover_popup)}
+      assert {:handled, new_state} = Hover.handle_key(state, @key_k, @none)
+      assert new_state.hover_popup.scroll_offset == 0
+    end
+
+    test "q dismisses" do
+      state = state_with_hover(focused: true)
+      assert {:handled, new_state} = Hover.handle_key(state, @key_q, @none)
+      assert new_state.hover_popup == nil
+    end
+
+    test "Escape dismisses" do
+      state = state_with_hover(focused: true)
+      assert {:handled, new_state} = Hover.handle_key(state, @key_escape, @none)
+      assert new_state.hover_popup == nil
+    end
+
+    test "other keys dismiss and pass through" do
+      state = state_with_hover(focused: true)
+      assert {:passthrough, new_state} = Hover.handle_key(state, @key_h, @none)
+      assert new_state.hover_popup == nil
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

Pressing `K` now shows LSP hover documentation in a bordered floating window with markdown rendering, positioned above the cursor. Press `K` again to focus into the hover for scrolling with `j`/`k`. Press `q` or `Escape` to dismiss.

Closes #547

## Context

Previously, hover dumped the LSP response into a single minibuffer line, stripping all markdown formatting. For a function with a multi-paragraph docstring, code examples, and parameter descriptions, it was unreadable. This is step 3 of the LSP experience (after #489 modeline indicator and #551 control commands).

## Changes

- **`FloatingWindow` cursor-anchored positioning**: New `{:anchor, row, col, :above | :below}` position variant with smart flipping. This is shared infrastructure that #545 (completion docs) and #546 (signature help) will reuse.

- **`HoverPopup` module**: Pure state struct + renderer. Parses LSP markdown via `Agent.Markdown`, converts styled segments to themed display list draws. Supports scrolling with scroll offset and footer indicator. Border changes from rounded (unfocused) to single (focused) for visual feedback.

- **`Input.Hover` handler**: LazyVim-style focus pattern. Uses `?K`/`?j`/`?k` character literals matching the frontend protocol. Sits in the focus stack above `Completion` so hover intercepts K before completion processes it.

- **`LspActions.handle_hover_response`**: Creates a `HoverPopup` instead of setting `status_msg`. New `extract_hover_markdown/1` preserves raw markdown for floating window rendering (the old `extract_hover_text` remains for backward compat).

- **LSP capability**: Hover `contentFormat` changed from `["plaintext"]` to `["markdown", "plaintext"]` so servers send markdown when available.

## Verification

```bash
mix test test/minga/editor/hover_popup_test.exs     # 16 tests
mix test test/minga/input/hover_test.exs            # 9 tests
mix test test/minga/editor/floating_window_test.exs # 30 tests (original + 5 anchor)
mix test test/minga/editor/lsp_actions_test.exs     # 21 tests
mix test --warnings-as-errors                       # 5,125 tests, 0 failures
mix lint                                            # passed
```

## Acceptance Criteria Addressed

- Pressing K shows hover in a bordered floating window near the cursor ✅
- Hover content rendered as formatted markdown ✅
- Window sized to fit content, max 80x20 ✅
- Positioned above cursor if room, below if not ✅
- K again focuses, Escape/q dismisses, any key dismisses when unfocused ✅
- MarkupContent markdown/plaintext handled correctly ✅
- contentFormat declares ["markdown", "plaintext"] ✅
- Long content scrollable with j/k when focused ✅