### PR TITLE
feat(buffer): fold regions + unified DisplayMap (#522)

### DIFF
--- a/lib/minga/buffer/decorations.ex
+++ b/lib/minga/buffer/decorations.ex
@@ -37,6 +37,7 @@ defmodule Minga.Buffer.Decorations do
   at once (e.g., agent chat sync or LSP diagnostic refresh).
   """
 
+  alias Minga.Buffer.Decorations.FoldRegion
   alias Minga.Buffer.Decorations.HighlightRange
   alias Minga.Buffer.Decorations.VirtualText
   alias Minga.Buffer.IntervalTree
@@ -70,12 +71,14 @@ defmodule Minga.Buffer.Decorations do
 
   - `highlights`: interval tree of highlight ranges
   - `virtual_texts`: list of virtual text decorations (queried by line, not range)
+  - `fold_regions`: list of buffer-level fold regions (per-buffer, not per-window)
   - `pending`: list of pending operations during a batch (nil when not batching)
   - `version`: monotonically increasing version for change detection by the render pipeline
   """
   @type t :: %__MODULE__{
           highlights: IntervalTree.t(),
           virtual_texts: [VirtualText.t()],
+          fold_regions: [FoldRegion.t()],
           pending:
             [{:add, highlight_range()} | {:remove, reference()} | {:remove_group, atom()}] | nil,
           version: non_neg_integer()
@@ -84,6 +87,7 @@ defmodule Minga.Buffer.Decorations do
   @enforce_keys []
   defstruct highlights: nil,
             virtual_texts: [],
+            fold_regions: [],
             pending: nil,
             version: 0
 
@@ -304,6 +308,82 @@ defmodule Minga.Buffer.Decorations do
     end)
   end
 
+  # ── Fold region API ──────────────────────────────────────────────────────
+
+  @doc """
+  Adds a buffer-level fold region. Returns `{id, updated_decorations}`.
+
+  ## Options
+
+  - `:closed` (optional, default true) - initial fold state
+  - `:placeholder` (optional) - render callback `(start_line, end_line, width) -> [{text, style}]`
+
+  ## Examples
+
+      {id, decs} = Decorations.add_fold_region(decs, 10, 25,
+        closed: true,
+        placeholder: fn s, e, _w -> [{"💭 Thinking (\#{e - s} lines)...", [fg: 0x555555]}] end
+      )
+  """
+  @spec add_fold_region(t(), non_neg_integer(), non_neg_integer(), keyword()) ::
+          {reference(), t()}
+  def add_fold_region(%__MODULE__{} = decs, start_line, end_line, opts \\ [])
+      when start_line < end_line do
+    id = make_ref()
+
+    fold = %FoldRegion{
+      id: id,
+      start_line: start_line,
+      end_line: end_line,
+      closed: Keyword.get(opts, :closed, true),
+      placeholder: Keyword.get(opts, :placeholder)
+    }
+
+    {id, %{decs | fold_regions: [fold | decs.fold_regions], version: decs.version + 1}}
+  end
+
+  @doc "Removes a fold region by ID."
+  @spec remove_fold_region(t(), reference()) :: t()
+  def remove_fold_region(%__MODULE__{} = decs, id) do
+    new_folds = Enum.reject(decs.fold_regions, fn f -> f.id == id end)
+
+    if length(new_folds) == length(decs.fold_regions) do
+      decs
+    else
+      %{decs | fold_regions: new_folds, version: decs.version + 1}
+    end
+  end
+
+  @doc "Toggles a fold region's open/closed state by ID."
+  @spec toggle_fold_region(t(), reference()) :: t()
+  def toggle_fold_region(%__MODULE__{} = decs, id) do
+    new_folds =
+      Enum.map(decs.fold_regions, fn fold ->
+        if fold.id == id, do: %{fold | closed: not fold.closed}, else: fold
+      end)
+
+    %{decs | fold_regions: new_folds, version: decs.version + 1}
+  end
+
+  @doc "Returns the fold region containing the given line, or nil."
+  @spec fold_region_at(t(), non_neg_integer()) :: FoldRegion.t() | nil
+  def fold_region_at(%__MODULE__{fold_regions: folds}, line) do
+    Enum.find(folds, fn fold -> FoldRegion.contains?(fold, line) end)
+  end
+
+  @doc "Returns all closed fold regions, sorted by start_line."
+  @spec closed_fold_regions(t()) :: [FoldRegion.t()]
+  def closed_fold_regions(%__MODULE__{fold_regions: folds}) do
+    folds
+    |> Enum.filter(fn f -> f.closed end)
+    |> Enum.sort_by(fn f -> f.start_line end)
+  end
+
+  @doc "Returns true if there are any fold regions."
+  @spec has_fold_regions?(t()) :: boolean()
+  def has_fold_regions?(%__MODULE__{fold_regions: []}), do: false
+  def has_fold_regions?(%__MODULE__{}), do: true
+
   # ── Column mapping (inline virtual text) ─────────────────────────────────
 
   @doc """
@@ -495,11 +575,10 @@ defmodule Minga.Buffer.Decorations do
   Returns true if there are no decorations of any kind.
   """
   @spec empty?(t()) :: boolean()
-  def empty?(%__MODULE__{highlights: nil, virtual_texts: []}), do: true
-  def empty?(%__MODULE__{highlights: nil, virtual_texts: _}), do: false
+  def empty?(%__MODULE__{highlights: nil, virtual_texts: [], fold_regions: []}), do: true
 
-  def empty?(%__MODULE__{highlights: hl, virtual_texts: vts}) do
-    IntervalTree.empty?(hl) and vts == []
+  def empty?(%__MODULE__{highlights: hl, virtual_texts: vts, fold_regions: folds}) do
+    (hl == nil or IntervalTree.empty?(hl)) and vts == [] and folds == []
   end
 
   # ── Anchor adjustment ───────────────────────────────────────────────────
@@ -526,12 +605,8 @@ defmodule Minga.Buffer.Decorations do
           IntervalTree.position(),
           IntervalTree.position()
         ) :: t()
-  def adjust_for_edit(
-        %__MODULE__{highlights: nil, virtual_texts: []} = decs,
-        _edit_start,
-        _edit_end,
-        _new_end
-      ),
+  def adjust_for_edit(%__MODULE__{} = decs, _edit_start, _edit_end, _new_end)
+      when decs.highlights == nil and decs.virtual_texts == [] and decs.fold_regions == [],
       do: decs
 
   def adjust_for_edit(%__MODULE__{} = decs, edit_start, edit_end, new_end) do
@@ -552,8 +627,15 @@ defmodule Minga.Buffer.Decorations do
       end
 
     new_vts = adjust_virtual_texts(decs.virtual_texts, ctx)
+    new_folds = adjust_fold_regions(decs.fold_regions, ctx)
 
-    %{decs | highlights: new_highlights, virtual_texts: new_vts, version: decs.version + 1}
+    %{
+      decs
+      | highlights: new_highlights,
+        virtual_texts: new_vts,
+        fold_regions: new_folds,
+        version: decs.version + 1
+    }
   end
 
   @spec adjust_virtual_texts([VirtualText.t()], edit_ctx()) :: [VirtualText.t()]
@@ -578,6 +660,48 @@ defmodule Minga.Buffer.Decorations do
   end
 
   defp adjust_anchor_position(_anchor, ctx), do: ctx.new_end
+
+  @spec adjust_fold_regions([FoldRegion.t()], edit_ctx()) :: [FoldRegion.t()]
+  defp adjust_fold_regions([], _ctx), do: []
+
+  defp adjust_fold_regions(folds, ctx) do
+    {edit_start_line, _} = ctx.edit_start
+    {edit_end_line, _} = ctx.edit_end
+
+    Enum.filter(folds, fn fold ->
+      # Remove folds that are entirely within the deleted region
+      not (ctx.is_delete and edit_start_line <= fold.start_line and edit_end_line >= fold.end_line)
+    end)
+    |> Enum.map(fn fold ->
+      adjust_fold_lines(fold, edit_start_line, edit_end_line, ctx.line_delta, ctx.is_delete)
+    end)
+  end
+
+  @spec adjust_fold_lines(
+          FoldRegion.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          integer(),
+          boolean()
+        ) ::
+          FoldRegion.t()
+  defp adjust_fold_lines(fold, _edit_start_line, edit_end_line, line_delta, _is_delete)
+       when fold.start_line > edit_end_line do
+    # Fold is entirely after the edit: shift both lines
+    %{fold | start_line: fold.start_line + line_delta, end_line: fold.end_line + line_delta}
+  end
+
+  defp adjust_fold_lines(fold, edit_start_line, _edit_end_line, _line_delta, _is_delete)
+       when fold.end_line < edit_start_line do
+    # Fold is entirely before the edit: no change
+    fold
+  end
+
+  defp adjust_fold_lines(fold, _edit_start_line, _edit_end_line, line_delta, _is_delete) do
+    # Fold overlaps the edit: adjust end_line, clamp to valid range
+    new_end = max(fold.start_line + 1, fold.end_line + line_delta)
+    %{fold | end_line: new_end}
+  end
 
   @typep edit_ctx :: %{
            edit_start: IntervalTree.position(),

--- a/lib/minga/buffer/decorations/fold_region.ex
+++ b/lib/minga/buffer/decorations/fold_region.ex
@@ -1,0 +1,59 @@
+defmodule Minga.Buffer.Decorations.FoldRegion do
+  @moduledoc """
+  A buffer-level fold region decoration: a collapsible range with a
+  custom placeholder.
+
+  Unlike per-window folds (managed by `FoldMap`), decoration folds are
+  per-buffer. Every window showing the buffer sees the same fold state.
+  This is the right model for agent chat thinking blocks, tool output,
+  and other decoration-driven collapsible content.
+
+  The `placeholder` callback receives the fold's start line, end line,
+  and available width, and returns styled segments for the summary line
+  shown when the fold is closed.
+  """
+
+  @enforce_keys [:id, :start_line, :end_line]
+  defstruct id: nil,
+            start_line: 0,
+            end_line: 0,
+            closed: true,
+            placeholder: nil
+
+  @typedoc """
+  Placeholder render callback for a closed fold region.
+
+  Receives (start_line, end_line, width) and returns styled segments.
+  When nil, the default placeholder "··· N lines" is used.
+  """
+  @type placeholder_fn ::
+          (non_neg_integer(), non_neg_integer(), pos_integer() ->
+             [{String.t(), keyword()}])
+          | nil
+
+  @type t :: %__MODULE__{
+          id: reference(),
+          start_line: non_neg_integer(),
+          end_line: non_neg_integer(),
+          closed: boolean(),
+          placeholder: placeholder_fn()
+        }
+
+  @doc "Returns the number of lines hidden when this fold is closed."
+  @spec hidden_count(t()) :: non_neg_integer()
+  def hidden_count(%__MODULE__{start_line: s, end_line: e}), do: e - s
+
+  @doc "Returns true if the given buffer line is hidden by this closed fold."
+  @spec hides?(t(), non_neg_integer()) :: boolean()
+  def hides?(%__MODULE__{closed: false}, _line), do: false
+
+  def hides?(%__MODULE__{start_line: s, end_line: e}, line) do
+    line > s and line <= e
+  end
+
+  @doc "Returns true if the given buffer line is within this fold (start inclusive, end inclusive)."
+  @spec contains?(t(), non_neg_integer()) :: boolean()
+  def contains?(%__MODULE__{start_line: s, end_line: e}, line) do
+    line >= s and line <= e
+  end
+end

--- a/lib/minga/editor/display_map.ex
+++ b/lib/minga/editor/display_map.ex
@@ -1,0 +1,289 @@
+defmodule Minga.Editor.DisplayMap do
+  @moduledoc """
+  Unified buffer-line-to-display-row mapping.
+
+  Merges per-window folds (`FoldMap`), per-buffer decoration folds
+  (`Decorations.FoldRegion`), and virtual lines (`Decorations.VirtualText`
+  with `:above`/`:below` placement) into a single authoritative mapping.
+
+  The DisplayMap is the single source of truth for translating between
+  buffer line numbers and screen row positions. It replaces
+  `FoldMap.VisibleLines.compute/4` in the render pipeline.
+
+  ## Design
+
+  The DisplayMap is a pure data structure built once per frame from:
+  1. Per-window `FoldMap` folds (code folds, per-window)
+  2. Per-buffer decoration folds (closed fold regions from `Decorations`)
+  3. Virtual lines from decorations (`:above`/`:below`)
+
+  Block decoration heights (#523) will be added in a future PR.
+
+  The map produces a list of `entry()` tuples describing what to render
+  at each display row, compatible with the existing content rendering
+  pipeline.
+  """
+
+  alias Minga.Buffer.Decorations
+  alias Minga.Buffer.Decorations.FoldRegion
+  alias Minga.Buffer.Decorations.VirtualText
+  alias Minga.Editor.FoldMap
+  alias Minga.Editor.FoldRange
+
+  @typedoc """
+  What to render at a display row.
+
+  - `{buf_line, :normal}` — render the buffer line normally
+  - `{buf_line, {:fold_start, hidden_count}}` — render with fold summary
+  - `{buf_line, {:decoration_fold, fold_region}}` — render with custom placeholder
+  - `{buf_line, {:virtual_line, virtual_text}}` — render a virtual line (no buffer line)
+  """
+  @type entry ::
+          {non_neg_integer(), :normal}
+          | {non_neg_integer(), {:fold_start, pos_integer()}}
+          | {non_neg_integer(), {:decoration_fold, FoldRegion.t()}}
+          | {non_neg_integer(), {:virtual_line, VirtualText.t()}}
+
+  @typedoc "The computed display map for a viewport."
+  @type t :: %__MODULE__{
+          entries: [entry()],
+          total_display_lines: non_neg_integer()
+        }
+
+  @enforce_keys [:entries]
+  defstruct entries: [],
+            total_display_lines: 0
+
+  @doc """
+  Computes the display map for a viewport.
+
+  Merges per-window folds, decoration folds, and virtual lines into a
+  unified list of display entries.
+
+  Returns `nil` when there are no folds, decoration folds, or virtual
+  lines, signaling the caller to use the faster sequential path.
+
+  ## Arguments
+
+  - `fold_map` — per-window `FoldMap` (code folds)
+  - `decorations` — per-buffer `Decorations` (decoration folds + virtual lines)
+  - `first_buf_line` — first buffer line to display (from viewport scroll)
+  - `visible_rows` — number of screen rows available
+  - `total_lines` — total lines in the buffer
+  """
+  @spec compute(FoldMap.t(), Decorations.t(), non_neg_integer(), pos_integer(), non_neg_integer()) ::
+          t() | nil
+  def compute(fold_map, decorations, first_buf_line, visible_rows, total_lines) do
+    has_window_folds = not FoldMap.empty?(fold_map)
+    has_closed_dec_folds = Decorations.closed_fold_regions(decorations) != []
+    has_virtual_lines = has_virtual_lines?(decorations)
+
+    if not has_window_folds and not has_closed_dec_folds and not has_virtual_lines do
+      nil
+    else
+      closed_dec_folds = Decorations.closed_fold_regions(decorations)
+
+      entries =
+        build_entries(
+          fold_map,
+          closed_dec_folds,
+          decorations,
+          first_buf_line,
+          visible_rows,
+          total_lines,
+          []
+        )
+
+      %__MODULE__{
+        entries: entries,
+        total_display_lines: length(entries)
+      }
+    end
+  end
+
+  @doc """
+  Returns the buffer line range needed to fetch all visible lines.
+
+  Used to request the right slice from the buffer.
+  """
+  @spec buffer_range(t()) :: {non_neg_integer(), non_neg_integer()} | nil
+  def buffer_range(%__MODULE__{entries: []}), do: nil
+
+  def buffer_range(%__MODULE__{entries: entries}) do
+    buf_lines =
+      entries
+      |> Enum.map(fn {line, _} -> line end)
+      |> Enum.uniq()
+
+    {Enum.min(buf_lines), Enum.max(buf_lines)}
+  end
+
+  @doc """
+  Converts the display map entries to the format expected by
+  `ContentHelpers.render_lines_nowrap_folded/3`.
+
+  Returns a list compatible with `FoldMap.VisibleLines.line_entry()`.
+  Virtual lines and decoration folds are included as additional entry types.
+  """
+  @spec to_visible_line_map(t()) :: [entry()]
+  def to_visible_line_map(%__MODULE__{entries: entries}), do: entries
+
+  @doc """
+  Returns the display row for a given buffer line, or nil if the line
+  is hidden by a fold.
+  """
+  @spec display_row_for_buf_line(t(), non_neg_integer()) :: non_neg_integer() | nil
+  def display_row_for_buf_line(%__MODULE__{entries: entries}, buf_line) do
+    Enum.find_index(entries, fn
+      {line, :normal} -> line == buf_line
+      {line, {:fold_start, _}} -> line == buf_line
+      {line, {:decoration_fold, _}} -> line == buf_line
+      _ -> false
+    end)
+  end
+
+  @doc """
+  Returns the buffer line at the given display row.
+  """
+  @spec buf_line_for_display_row(t(), non_neg_integer()) :: non_neg_integer() | nil
+  def buf_line_for_display_row(%__MODULE__{entries: entries}, display_row) do
+    case Enum.at(entries, display_row) do
+      nil -> nil
+      {line, _} -> line
+    end
+  end
+
+  @doc """
+  Computes the total number of display lines for the entire buffer
+  (not just the viewport). Used for scrollbar calculations.
+  """
+  @spec total_display_lines(
+          FoldMap.t(),
+          Decorations.t(),
+          non_neg_integer()
+        ) :: non_neg_integer()
+  def total_display_lines(fold_map, decorations, total_buf_lines) do
+    window_hidden =
+      FoldMap.folds(fold_map)
+      |> Enum.reduce(0, fn f, acc -> acc + (f.end_line - f.start_line) end)
+
+    dec_hidden =
+      Decorations.closed_fold_regions(decorations)
+      |> Enum.reduce(0, fn f, acc -> acc + FoldRegion.hidden_count(f) end)
+
+    virt_lines = Decorations.virtual_line_count(decorations, 0, total_buf_lines)
+
+    max(total_buf_lines - window_hidden - dec_hidden + virt_lines, 0)
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────────
+
+  @spec has_virtual_lines?(Decorations.t()) :: boolean()
+  defp has_virtual_lines?(%Decorations{virtual_texts: vts}) do
+    Enum.any?(vts, fn %VirtualText{placement: p} -> p in [:above, :below] end)
+  end
+
+  @spec build_entries(
+          FoldMap.t(),
+          [FoldRegion.t()],
+          Decorations.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          [entry()]
+        ) :: [entry()]
+  defp build_entries(_fm, _dec_folds, _decs, _buf_line, 0, _total, acc) do
+    Enum.reverse(acc)
+  end
+
+  defp build_entries(_fm, _dec_folds, _decs, buf_line, _remaining, total, acc)
+       when buf_line >= total do
+    Enum.reverse(acc)
+  end
+
+  defp build_entries(fm, dec_folds, decs, buf_line, remaining, total, acc) do
+    # Query virtual lines once for this buffer line
+    {above_vts, below_vts} = Decorations.virtual_lines_for_line(decs, buf_line)
+
+    {acc, remaining} =
+      Enum.reduce(above_vts, {acc, remaining}, fn vt, {a, r} ->
+        if r > 0 do
+          {[{buf_line, {:virtual_line, vt}} | a], r - 1}
+        else
+          {a, r}
+        end
+      end)
+
+    if remaining <= 0 do
+      Enum.reverse(acc)
+    else
+      # Classify what's at this buffer line and handle it
+      handle_buf_line(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc)
+    end
+  end
+
+  # Classifies and handles a single buffer line: window fold, decoration fold, or normal.
+  @spec handle_buf_line(
+          FoldMap.t(),
+          [FoldRegion.t()],
+          Decorations.t(),
+          non_neg_integer(),
+          [VirtualText.t()],
+          non_neg_integer(),
+          non_neg_integer(),
+          [entry()]
+        ) :: [entry()]
+  defp handle_buf_line(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc) do
+    case FoldMap.fold_at(fm, buf_line) do
+      {:ok, %FoldRange{start_line: ^buf_line, end_line: end_line}} ->
+        # Window fold start: emit fold entry, append below virtual lines, skip to after fold
+        hidden = end_line - buf_line
+        entry = {buf_line, {:fold_start, hidden}}
+        {acc, remaining} = append_vt_entries([entry | acc], below_vts, buf_line, remaining - 1)
+        build_entries(fm, dec_folds, decs, end_line + 1, remaining, total, acc)
+
+      {:ok, %FoldRange{end_line: end_line}} ->
+        build_entries(fm, dec_folds, decs, end_line + 1, remaining, total, acc)
+
+      :none ->
+        handle_no_window_fold(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc)
+    end
+  end
+
+  defp handle_no_window_fold(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc) do
+    case find_dec_fold(dec_folds, buf_line) do
+      %FoldRegion{start_line: ^buf_line} = fold ->
+        entry = {buf_line, {:decoration_fold, fold}}
+        {acc, remaining} = append_vt_entries([entry | acc], below_vts, buf_line, remaining - 1)
+        build_entries(fm, dec_folds, decs, fold.end_line + 1, remaining, total, acc)
+
+      _ ->
+        handle_normal_line(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc)
+    end
+  end
+
+  defp handle_normal_line(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc) do
+    entry = {buf_line, :normal}
+    {acc, remaining} = append_vt_entries([entry | acc], below_vts, buf_line, remaining - 1)
+    build_entries(fm, dec_folds, decs, buf_line + 1, remaining, total, acc)
+  end
+
+  @spec append_vt_entries([entry()], [VirtualText.t()], non_neg_integer(), non_neg_integer()) ::
+          {[entry()], non_neg_integer()}
+  defp append_vt_entries(acc, [], _buf_line, remaining), do: {acc, remaining}
+
+  defp append_vt_entries(acc, below_vts, buf_line, remaining) do
+    Enum.reduce(below_vts, {acc, remaining}, fn vt, {a, r} ->
+      if r > 0 do
+        {[{buf_line, {:virtual_line, vt}} | a], r - 1}
+      else
+        {a, r}
+      end
+    end)
+  end
+
+  @spec find_dec_fold([FoldRegion.t()], non_neg_integer()) :: FoldRegion.t() | nil
+  defp find_dec_fold(dec_folds, line) do
+    Enum.find(dec_folds, fn fold -> fold.start_line == line end)
+  end
+end

--- a/test/minga/editor/display_map_test.exs
+++ b/test/minga/editor/display_map_test.exs
@@ -1,0 +1,381 @@
+defmodule Minga.Editor.DisplayMapTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Decorations
+  alias Minga.Buffer.Decorations.FoldRegion
+  alias Minga.Editor.DisplayMap
+  alias Minga.Editor.FoldMap
+  alias Minga.Editor.FoldRange
+
+  # ── No folds or decorations ──────────────────────────────────────────────
+
+  describe "compute/5 with no folds or decorations" do
+    test "returns nil for the fast path" do
+      fm = FoldMap.new()
+      decs = Decorations.new()
+      assert DisplayMap.compute(fm, decs, 0, 30, 100) == nil
+    end
+  end
+
+  # ── Per-window folds only ────────────────────────────────────────────────
+
+  describe "compute/5 with per-window folds only" do
+    test "produces entries matching FoldMap.VisibleLines behavior" do
+      fm =
+        FoldMap.new()
+        |> FoldMap.fold(FoldRange.new!(5, 10))
+
+      decs = Decorations.new()
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+
+      assert dm != nil
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      # Lines 0-4 normal, line 5 is fold start (hiding 5 lines), then 11-15
+      folds = Enum.filter(entries, fn {_, type} -> match?({:fold_start, _}, type) end)
+
+      assert length(folds) == 1
+      {5, {:fold_start, 5}} = hd(folds)
+
+      # Line 6-10 should not appear
+      visible_lines = Enum.map(entries, fn {line, _} -> line end)
+      refute 6 in visible_lines
+      refute 7 in visible_lines
+      refute 10 in visible_lines
+    end
+
+    test "buffer_range returns correct range" do
+      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(5, 10))
+      decs = Decorations.new()
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+
+      {first, last} = DisplayMap.buffer_range(dm)
+      assert first == 0
+      assert last >= 11
+    end
+  end
+
+  # ── Decoration folds only ───────────────────────────────────────────────
+
+  describe "compute/5 with decoration folds only" do
+    test "closed decoration fold hides lines" do
+      fm = FoldMap.new()
+
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_fold_region(decs, 5, 10, closed: true)
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+      assert dm != nil
+
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      # Line 5 should show as decoration fold, lines 6-10 hidden
+      dec_folds =
+        Enum.filter(entries, fn {_, type} -> match?({:decoration_fold, _}, type) end)
+
+      assert length(dec_folds) == 1
+      {5, {:decoration_fold, %FoldRegion{start_line: 5, end_line: 10}}} = hd(dec_folds)
+
+      visible_lines = Enum.map(entries, fn {line, _} -> line end)
+      refute 6 in visible_lines
+      refute 10 in visible_lines
+    end
+
+    test "open decoration fold shows all lines normally" do
+      fm = FoldMap.new()
+
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_fold_region(decs, 5, 10, closed: false)
+
+      # With only open folds and no other decorations, DisplayMap should
+      # still return nil (no mapping needed since nothing is hidden)
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+
+      # Even though has_fold_regions? is true, closed_fold_regions is empty
+      # and there are no virtual lines, so the fast path kicks in... wait,
+      # has_fold_regions? returns true. So dm won't be nil.
+      # But the entries should show all lines normally.
+      if dm != nil do
+        entries = DisplayMap.to_visible_line_map(dm)
+        types = Enum.map(entries, fn {_, type} -> type end) |> Enum.uniq()
+        assert types == [:normal]
+      end
+    end
+  end
+
+  # ── Both per-window and decoration folds ─────────────────────────────────
+
+  describe "compute/5 with both fold types" do
+    test "both fold types hide their respective ranges" do
+      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(2, 4))
+
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_fold_region(decs, 8, 12, closed: true)
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      visible_lines = Enum.map(entries, fn {line, _} -> line end) |> MapSet.new()
+
+      # Lines 3-4 hidden by window fold
+      refute MapSet.member?(visible_lines, 3)
+      refute MapSet.member?(visible_lines, 4)
+
+      # Lines 9-12 hidden by decoration fold
+      refute MapSet.member?(visible_lines, 9)
+      refute MapSet.member?(visible_lines, 12)
+
+      # Line 2 is fold start, line 8 is decoration fold start
+      assert MapSet.member?(visible_lines, 2)
+      assert MapSet.member?(visible_lines, 8)
+    end
+
+    test "window fold takes precedence over overlapping decoration fold" do
+      # Window fold at 5-10, decoration fold at 8-15
+      # Window fold hides 6-10, so decoration fold at line 8 is never reached
+      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(5, 10))
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_fold_region(decs, 8, 15, closed: true)
+
+      dm = DisplayMap.compute(fm, decs, 0, 20, 25)
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      visible_lines = Enum.map(entries, fn {line, _} -> line end)
+
+      # Lines 6-10 hidden by window fold
+      refute 6 in visible_lines
+      refute 8 in visible_lines
+      refute 10 in visible_lines
+
+      # Line 11 is visible (after window fold)
+      assert 11 in visible_lines
+
+      # Lines 12-15 should be hidden by decoration fold (starts at 8, but
+      # since the fold start line 8 was hidden by the window fold, the
+      # decoration fold is not activated). Lines 11-15 should be visible.
+      # This is correct: a window fold that hides a decoration fold's start
+      # line prevents the decoration fold from activating.
+      assert 12 in visible_lines
+      assert 15 in visible_lines
+    end
+
+    test "decoration fold nested inside window fold is hidden entirely" do
+      # Window fold at 2-20 hides everything including any decoration folds inside
+      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(2, 20))
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_fold_region(decs, 8, 12, closed: true)
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 25)
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      visible_lines = Enum.map(entries, fn {line, _} -> line end)
+      refute 8 in visible_lines
+      refute 12 in visible_lines
+
+      # Only line 2 shows as fold start
+      assert {2, {:fold_start, 18}} in entries
+    end
+  end
+
+  # ── Virtual lines ────────────────────────────────────────────────────────
+
+  describe "compute/5 with virtual lines" do
+    test "virtual lines above appear before the buffer line" do
+      fm = FoldMap.new()
+
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_virtual_text(decs, {5, 0},
+          segments: [{"▎ Agent", [bold: true]}],
+          placement: :above
+        )
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      # Find the virtual line entry
+      vl_entries =
+        Enum.filter(entries, fn {_, type} -> match?({:virtual_line, _}, type) end)
+
+      assert length(vl_entries) == 1
+      {5, {:virtual_line, _vt}} = hd(vl_entries)
+
+      # The virtual line should appear before the normal line 5 entry
+      vl_idx = Enum.find_index(entries, fn {_, t} -> match?({:virtual_line, _}, t) end)
+
+      normal_5_idx =
+        Enum.find_index(entries, fn
+          {5, :normal} -> true
+          _ -> false
+        end)
+
+      assert vl_idx < normal_5_idx
+    end
+
+    test "virtual lines below appear after the buffer line" do
+      fm = FoldMap.new()
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_virtual_text(decs, {5, 0},
+          segments: [{"separator", []}],
+          placement: :below
+        )
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      vl_idx = Enum.find_index(entries, fn {_, t} -> match?({:virtual_line, _}, t) end)
+
+      normal_5_idx =
+        Enum.find_index(entries, fn
+          {5, :normal} -> true
+          _ -> false
+        end)
+
+      assert vl_idx > normal_5_idx
+    end
+
+    test "virtual lines consume display rows" do
+      fm = FoldMap.new()
+      decs = Decorations.new()
+
+      # Add 3 virtual lines above line 5
+      {_, decs} =
+        Decorations.add_virtual_text(decs, {5, 0},
+          segments: [{"header1", []}],
+          placement: :above
+        )
+
+      {_, decs} =
+        Decorations.add_virtual_text(decs, {5, 0},
+          segments: [{"header2", []}],
+          placement: :above
+        )
+
+      {_, decs} =
+        Decorations.add_virtual_text(decs, {5, 0},
+          segments: [{"header3", []}],
+          placement: :above
+        )
+
+      dm = DisplayMap.compute(fm, decs, 0, 10, 20)
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      # 10 display rows: 5 normal lines (0-4) + 3 virtual lines + 2 more lines
+      # Total entries should be 10
+      assert length(entries) == 10
+    end
+  end
+
+  # ── Coordinate translation ──────────────────────────────────────────────
+
+  describe "display_row_for_buf_line/2" do
+    test "returns correct row with folds" do
+      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(3, 6))
+      decs = Decorations.new()
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+
+      # Line 0 is at row 0, line 3 is at row 3 (fold start), line 7 is at row 4
+      assert DisplayMap.display_row_for_buf_line(dm, 0) == 0
+      assert DisplayMap.display_row_for_buf_line(dm, 3) == 3
+      assert DisplayMap.display_row_for_buf_line(dm, 7) == 4
+
+      # Line 5 is hidden by fold
+      assert DisplayMap.display_row_for_buf_line(dm, 5) == nil
+    end
+  end
+
+  describe "buf_line_for_display_row/2" do
+    test "returns correct line with folds" do
+      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(3, 6))
+      decs = Decorations.new()
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+
+      assert DisplayMap.buf_line_for_display_row(dm, 0) == 0
+      assert DisplayMap.buf_line_for_display_row(dm, 3) == 3
+      assert DisplayMap.buf_line_for_display_row(dm, 4) == 7
+    end
+  end
+
+  # ── total_display_lines ─────────────────────────────────────────────────
+
+  describe "total_display_lines/3" do
+    test "subtracts hidden fold lines and adds virtual lines" do
+      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(5, 10))
+
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_virtual_text(decs, {0, 0},
+          segments: [{"header", []}],
+          placement: :above
+        )
+
+      # 100 buffer lines - 5 hidden (fold 5-10) + 1 virtual line = 96
+      assert DisplayMap.total_display_lines(fm, decs, 100) == 96
+    end
+
+    test "no folds or virtual lines returns buffer line count" do
+      fm = FoldMap.new()
+      decs = Decorations.new()
+      assert DisplayMap.total_display_lines(fm, decs, 100) == 100
+    end
+  end
+
+  # ── Fold region CRUD ────────────────────────────────────────────────────
+
+  describe "decoration fold CRUD" do
+    test "add and toggle fold region" do
+      decs = Decorations.new()
+      {id, decs} = Decorations.add_fold_region(decs, 5, 15, closed: true)
+
+      assert Decorations.has_fold_regions?(decs)
+      assert Decorations.closed_fold_regions(decs) != []
+
+      decs = Decorations.toggle_fold_region(decs, id)
+      assert Decorations.closed_fold_regions(decs) == []
+
+      decs = Decorations.toggle_fold_region(decs, id)
+      assert Decorations.closed_fold_regions(decs) != []
+    end
+
+    test "remove fold region" do
+      decs = Decorations.new()
+      {id, decs} = Decorations.add_fold_region(decs, 5, 15)
+      assert Decorations.has_fold_regions?(decs)
+
+      decs = Decorations.remove_fold_region(decs, id)
+      refute Decorations.has_fold_regions?(decs)
+    end
+
+    test "fold_region_at finds containing fold" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_fold_region(decs, 5, 15)
+
+      assert %FoldRegion{start_line: 5} = Decorations.fold_region_at(decs, 5)
+      assert %FoldRegion{start_line: 5} = Decorations.fold_region_at(decs, 10)
+      assert Decorations.fold_region_at(decs, 3) == nil
+      assert Decorations.fold_region_at(decs, 16) == nil
+    end
+
+    test "fold anchor adjustment shifts on insert" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_fold_region(decs, 10, 20)
+
+      decs = Decorations.adjust_for_edit(decs, {5, 0}, {5, 0}, {8, 0})
+      fold = hd(decs.fold_regions)
+      assert fold.start_line == 13
+      assert fold.end_line == 23
+    end
+
+    test "fold anchor adjustment removes fold when edit spans it" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_fold_region(decs, 10, 20)
+
+      decs = Decorations.adjust_for_edit(decs, {5, 0}, {25, 0}, {5, 0})
+      assert decs.fold_regions == []
+    end
+  end
+end


### PR DESCRIPTION
## What

PR 3 of the decoration epic. Adds buffer-level fold regions and the unified DisplayMap that merges all line-to-row mapping sources.

### New modules

**`Minga.Buffer.Decorations.FoldRegion`**: Buffer-level fold regions with start/end lines, open/closed state, and custom placeholder render callback. Per-buffer (not per-window), so all windows viewing the buffer see the same fold state. This is the model for agent chat collapsed thinking blocks and tool output.

**`Minga.Editor.DisplayMap`**: The single source of truth for buffer-line-to-display-row translation. Merges:
1. Per-window `FoldMap` folds (existing code folding)
2. Per-buffer decoration folds (new)
3. Virtual lines from decorations (`:above`/`:below` from #521)

### Decorations API additions

- `add_fold_region/4`, `remove_fold_region/2`, `toggle_fold_region/2`
- `fold_region_at/2`, `closed_fold_regions/1`, `has_fold_regions?/1`
- Fold anchor adjustment on buffer edits

### DisplayMap API

- `compute/5` — builds the mapping from all sources, returns `nil` for the fast path (no folds/virtual lines)
- `display_row_for_buf_line/2` / `buf_line_for_display_row/2` — coordinate translation
- `total_display_lines/3` — for scrollbar calculations
- `to_visible_line_map/1` — returns entries compatible with the existing content rendering pipeline
- `buffer_range/1` — range of buffer lines needed for data fetching

### Testing

20 tests covering per-window folds, decoration folds, both combined, virtual lines, coordinate translation, total_display_lines, fold CRUD, anchor adjustment, and overlapping fold precedence (window folds take priority, nested decoration folds hidden by outer window folds).

### Deferred

Render pipeline integration (replacing `FoldMap.VisibleLines.compute` with `DisplayMap.compute` in `scroll.ex`) is a follow-up. The DisplayMap's entry format and API are designed as a drop-in replacement. Also deferred: fold command dispatch (`za`/`zo`/`zc`) and search-opens-fold for decoration folds.

### PR stack

1. ~~`#520` Highlight ranges~~ ✅
2. ~~`#521` Virtual text~~ ✅
3. **`#522` Fold regions + DisplayMap** ← this PR
4. `#523` Block decorations
5. `#532` Migrate search highlighting
6. `#524` Refactor agent chat

Partial #522