### PR TITLE
feat(lsp): completion documentation preview pane with completionItem/resolve

### DIFF
--- a/lib/minga/completion.ex
+++ b/lib/minga/completion.ex
@@ -21,7 +21,9 @@ defmodule Minga.Completion do
             selected: 0,
             filter_text: "",
             trigger_position: {0, 0},
-            max_visible: 10
+            max_visible: 10,
+            resolve_timer: nil,
+            last_resolved_index: -1
 
   @typedoc "LSP CompletionItemKind as an atom."
   @type item_kind ::
@@ -69,8 +71,10 @@ defmodule Minga.Completion do
           insert_text: String.t(),
           filter_text: String.t(),
           detail: String.t(),
+          documentation: String.t(),
           sort_text: String.t(),
-          text_edit: text_edit() | nil
+          text_edit: text_edit() | nil,
+          raw: map() | nil
         }
 
   @type t :: %__MODULE__{
@@ -79,7 +83,9 @@ defmodule Minga.Completion do
           selected: non_neg_integer(),
           filter_text: String.t(),
           trigger_position: {non_neg_integer(), non_neg_integer()},
-          max_visible: pos_integer()
+          max_visible: pos_integer(),
+          resolve_timer: reference() | nil,
+          last_resolved_index: integer()
         }
 
   # ── Constructor ──────────────────────────────────────────────────────────────
@@ -246,10 +252,50 @@ defmodule Minga.Completion do
       insert_text: insert_text,
       filter_text: Map.get(raw, "filterText", label),
       detail: Map.get(raw, "detail", ""),
+      documentation: extract_documentation(Map.get(raw, "documentation")),
       sort_text: Map.get(raw, "sortText", label),
-      text_edit: parse_text_edit(Map.get(raw, "textEdit"))
+      text_edit: parse_text_edit(Map.get(raw, "textEdit")),
+      raw: raw
     }
   end
+
+  @doc """
+  Updates the documentation for the currently selected item.
+
+  Called when a `completionItem/resolve` response arrives with
+  the full documentation text.
+  """
+  @spec update_selected_documentation(t(), String.t()) :: t()
+  def update_selected_documentation(%__MODULE__{} = completion, doc_text) do
+    item = selected_item(completion)
+
+    if item do
+      updated = %{item | documentation: doc_text}
+      idx = absolute_selected_index(completion)
+
+      filtered =
+        List.update_at(completion.filtered, idx, fn _ -> updated end)
+
+      %{completion | filtered: filtered}
+    else
+      completion
+    end
+  end
+
+  @spec absolute_selected_index(t()) :: non_neg_integer()
+  defp absolute_selected_index(%__MODULE__{selected: sel}), do: sel
+
+  @spec extract_documentation(term()) :: String.t()
+  defp extract_documentation(nil), do: ""
+  defp extract_documentation(text) when is_binary(text), do: String.trim(text)
+
+  defp extract_documentation(%{"kind" => _, "value" => value}) when is_binary(value),
+    do: String.trim(value)
+
+  defp extract_documentation(%{"value" => value}) when is_binary(value),
+    do: String.trim(value)
+
+  defp extract_documentation(_), do: ""
 
   @spec strip_snippet_markers(String.t()) :: String.t()
   defp strip_snippet_markers(text) do

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -473,10 +473,22 @@ defmodule Minga.Editor do
         new_state = Renderer.render(new_state)
         {:noreply, new_state}
 
+      {:completion_resolve, pending} ->
+        new_state = put_in(state.lsp.pending, pending)
+        new_state = CompletionHandling.handle_resolve_response(new_state, result)
+        new_state = Renderer.render(new_state)
+        {:noreply, new_state}
+
       {nil, _} ->
         # Not a tracked request — try completion handler
         handle_lsp_completion_response(ref, result, state)
     end
+  end
+
+  # Completion resolve debounce timer fired — send the actual resolve request
+  def handle_info({:completion_resolve, index}, state) do
+    state = CompletionHandling.flush_resolve(state, index)
+    {:noreply, state}
   end
 
   # Refresh the cached LSP status for the modeline indicator.

--- a/lib/minga/editor/completion_handling.ex
+++ b/lib/minga/editor/completion_handling.ex
@@ -10,7 +10,87 @@ defmodule Minga.Editor.CompletionHandling do
   alias Minga.Completion
   alias Minga.Editor.BufferLifecycle
   alias Minga.Editor.CompletionTrigger
+  alias Minga.Editor.DocumentSync
   alias Minga.Editor.State, as: EditorState
+  alias Minga.LSP.Client
+
+  @resolve_debounce_ms 150
+
+  @doc """
+  Triggers a `completionItem/resolve` request for the selected item.
+
+  Called when C-n/C-p moves the selection. Debounces to avoid flooding
+  the server when navigating rapidly. Only triggers if the selected
+  item doesn't already have documentation and the server supports resolve.
+  """
+  @spec maybe_resolve_selected(EditorState.t()) :: EditorState.t()
+  def maybe_resolve_selected(%{completion: nil} = state), do: state
+
+  def maybe_resolve_selected(%{completion: completion} = state) do
+    item = Completion.selected_item(completion)
+    selected_idx = completion.selected
+
+    # Skip if already resolved for this index, or if doc is already present
+    if item == nil or selected_idx == completion.last_resolved_index or
+         (item.documentation != "" and item.documentation != nil) do
+      state
+    else
+      # Cancel previous resolve timer
+      if completion.resolve_timer do
+        Process.cancel_timer(completion.resolve_timer)
+      end
+
+      timer =
+        Process.send_after(self(), {:completion_resolve, selected_idx}, @resolve_debounce_ms)
+
+      completion = %{completion | resolve_timer: timer}
+      %{state | completion: completion}
+    end
+  end
+
+  @doc """
+  Sends the actual `completionItem/resolve` request after debounce.
+
+  Called from Editor.handle_info({:completion_resolve, index}).
+  """
+  @spec flush_resolve(EditorState.t(), non_neg_integer()) :: EditorState.t()
+  def flush_resolve(%{completion: nil} = state, _index), do: state
+
+  def flush_resolve(%{completion: completion, buffers: %{active: buf}} = state, index) do
+    item = Enum.at(completion.filtered, index)
+
+    if item == nil or item.raw == nil do
+      state
+    else
+      case lsp_client_for(state, buf) do
+        nil ->
+          state
+
+        client ->
+          ref = Client.request(client, "completionItem/resolve", item.raw)
+          put_in(state.lsp.pending, Map.put(state.lsp.pending, ref, :completion_resolve))
+      end
+    end
+  end
+
+  @doc """
+  Handles a `completionItem/resolve` response.
+
+  Updates the selected completion item's documentation with the
+  resolved content.
+  """
+  @spec handle_resolve_response(EditorState.t(), {:ok, term()} | {:error, term()}) ::
+          EditorState.t()
+  def handle_resolve_response(%{completion: nil} = state, _result), do: state
+
+  def handle_resolve_response(state, {:error, _error}), do: state
+
+  def handle_resolve_response(%{completion: completion} = state, {:ok, resolved}) do
+    doc_text = extract_resolve_documentation(resolved)
+    completion = Completion.update_selected_documentation(completion, doc_text)
+    completion = %{completion | last_resolved_index: completion.selected}
+    %{state | completion: completion}
+  end
 
   @doc """
   Accepts the currently selected completion item.
@@ -54,6 +134,11 @@ defmodule Minga.Editor.CompletionHandling do
   """
   @spec dismiss(EditorState.t()) :: EditorState.t()
   def dismiss(state) do
+    # Cancel any pending resolve timer to avoid stale messages
+    if state.completion && state.completion.resolve_timer do
+      Process.cancel_timer(state.completion.resolve_timer)
+    end
+
     new_bridge = CompletionTrigger.dismiss(state.completion_trigger)
     %{state | completion: nil, completion_trigger: new_bridge}
   end
@@ -188,4 +273,22 @@ defmodule Minga.Editor.CompletionHandling do
   end
 
   defp codepoint_to_char(_), do: nil
+
+  @spec lsp_client_for(EditorState.t(), pid()) :: pid() | nil
+  defp lsp_client_for(state, buffer_pid) do
+    case DocumentSync.clients_for_buffer(state.lsp, buffer_pid) do
+      [client | _] -> client
+      [] -> nil
+    end
+  end
+
+  @spec extract_resolve_documentation(map()) :: String.t()
+  defp extract_resolve_documentation(%{"documentation" => %{"value" => value}})
+       when is_binary(value),
+       do: String.trim(value)
+
+  defp extract_resolve_documentation(%{"documentation" => doc}) when is_binary(doc),
+    do: String.trim(doc)
+
+  defp extract_resolve_documentation(_), do: ""
 end

--- a/lib/minga/editor/completion_ui.ex
+++ b/lib/minga/editor/completion_ui.ex
@@ -2,13 +2,20 @@ defmodule Minga.Editor.CompletionUI do
   @moduledoc """
   Renders the LSP completion popup as an overlay near the cursor.
 
-  Produces a list of `DisplayList.draw()` tuples for the completion menu.
+  Produces a list of `DisplayList.draw()` tuples for the completion menu
+  and an optional documentation preview pane beside it. The preview pane
+  shows the selected item's documentation rendered as formatted markdown.
+
   The popup is positioned below the cursor if there's room, above if not.
   Sized to fit the visible items up to a maximum of 10 rows and 50 columns.
+  The doc preview appears to the right if there's room, to the left if not.
   """
 
+  alias Minga.Agent.Markdown
   alias Minga.Completion
   alias Minga.Editor.DisplayList
+  alias Minga.Editor.FloatingWindow
+  alias Minga.Editor.MarkdownStyles
 
   @max_rows 10
   @max_width 50
@@ -38,7 +45,10 @@ defmodule Minga.Editor.CompletionUI do
         []
 
       items ->
-        do_render(items, selected_offset, opts, theme)
+        menu_draws = do_render(items, selected_offset, opts, theme)
+        selected_item = Enum.at(visible, selected_offset)
+        doc_draws = render_doc_preview(selected_item, items, selected_offset, opts, theme)
+        menu_draws ++ doc_draws
     end
   end
 
@@ -153,5 +163,134 @@ defmodule Minga.Editor.CompletionUI do
       end
 
     [kind_cmd | cmds] ++ detail_cmds
+  end
+
+  # ── Documentation preview pane ────────────────────────────────────────────
+
+  @doc_max_width 50
+  @doc_max_height 15
+
+  @spec render_doc_preview(
+          Completion.item() | nil,
+          [Completion.item()],
+          non_neg_integer(),
+          render_opts(),
+          map()
+        ) :: [DisplayList.draw()]
+  defp render_doc_preview(nil, _items, _sel_offset, _opts, _theme), do: []
+
+  defp render_doc_preview(item, items, _sel_offset, opts, theme) do
+    doc_text = item.documentation
+
+    if doc_text == "" do
+      []
+    else
+      render_doc_pane(doc_text, items, opts, theme)
+    end
+  end
+
+  @spec render_doc_pane(
+          String.t(),
+          [Completion.item()],
+          render_opts(),
+          map()
+        ) :: [DisplayList.draw()]
+  defp render_doc_pane(doc_text, items, opts, theme) do
+    # Parse markdown
+    parsed_lines = Markdown.parse(doc_text)
+
+    if parsed_lines == [] do
+      []
+    else
+      # Compute the completion popup's position and dimensions
+      item_count = min(length(items), @max_rows)
+
+      label_widths = Enum.map(items, fn i -> String.length(i.label) + 4 end)
+      popup_width = label_widths |> Enum.max() |> max(@min_width) |> min(@max_width)
+      popup_width = min(popup_width, opts.viewport_cols - opts.cursor_col)
+      popup_col = min(opts.cursor_col, max(0, opts.viewport_cols - popup_width))
+
+      space_below = opts.viewport_rows - opts.cursor_row - 2
+
+      popup_row =
+        if space_below >= item_count, do: opts.cursor_row + 1, else: opts.cursor_row - item_count
+
+      # Position the doc pane beside the completion popup
+      doc_width = min(@doc_max_width, opts.viewport_cols - popup_col - popup_width - 1)
+      space_right = opts.viewport_cols - popup_col - popup_width
+
+      {doc_col, effective_width} =
+        if space_right >= 25 do
+          # Right side of popup
+          {popup_col + popup_width, min(doc_width, space_right)}
+        else
+          # Left side of popup
+          left_space = popup_col
+          {max(popup_col - min(@doc_max_width, left_space), 0), min(@doc_max_width, left_space)}
+        end
+
+      if effective_width < 20 do
+        # Not enough room for a doc pane
+        []
+      else
+        doc_height = min(length(parsed_lines) + 2, min(@doc_max_height, item_count))
+
+        # Build content draws (relative coordinates for FloatingWindow)
+        content_draws = build_doc_content(parsed_lines, effective_width - 2, theme)
+
+        popup_theme =
+          Map.get(theme, :popup, %{bg: 0x21242B, border_fg: 0x5B6268, title_fg: 0xBBC2CF})
+
+        spec = %FloatingWindow.Spec{
+          content: content_draws,
+          width: {:cols, effective_width},
+          height: {:rows, doc_height},
+          position: {:anchor, popup_row - 1, doc_col, :below},
+          border: :rounded,
+          theme: popup_theme,
+          viewport: {opts.viewport_rows, opts.viewport_cols}
+        }
+
+        FloatingWindow.render(spec)
+      end
+    end
+  end
+
+  @spec build_doc_content([Markdown.parsed_line()], pos_integer(), map()) ::
+          [DisplayList.draw()]
+  defp build_doc_content(lines, max_width, theme) do
+    syntax = Map.get(theme, :syntax, %{})
+    editor = Map.get(theme, :editor, %{})
+    base_fg = Map.get(editor, :fg, 0xBBC2CF)
+
+    lines
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {{segments, _line_type}, row} ->
+      render_doc_line(segments, row, max_width, syntax, base_fg)
+    end)
+  end
+
+  @spec render_doc_line(
+          [Markdown.segment()],
+          non_neg_integer(),
+          pos_integer(),
+          map(),
+          non_neg_integer()
+        ) ::
+          [DisplayList.draw()]
+  defp render_doc_line(segments, row, max_width, syntax, base_fg) do
+    {draws, _col} =
+      Enum.reduce(segments, {[], 0}, fn {text, style}, {acc, col} ->
+        if col >= max_width do
+          {acc, col}
+        else
+          clipped = String.slice(text, 0, max(max_width - col, 0))
+          draw_style = MarkdownStyles.to_draw_opts(style, syntax, base_fg)
+          draw = DisplayList.draw(row, col, clipped, draw_style)
+          {[draw | acc], col + String.length(text)}
+        end
+      end)
+
+    Enum.reverse(draws)
   end
 end

--- a/lib/minga/editor/hover_popup.ex
+++ b/lib/minga/editor/hover_popup.ex
@@ -18,6 +18,7 @@ defmodule Minga.Editor.HoverPopup do
   alias Minga.Agent.Markdown
   alias Minga.Editor.DisplayList
   alias Minga.Editor.FloatingWindow
+  alias Minga.Editor.MarkdownStyles
 
   @enforce_keys [:content_lines, :anchor_row, :anchor_col]
   defstruct content_lines: [],
@@ -173,7 +174,7 @@ defmodule Minga.Editor.HoverPopup do
           {acc, col}
         else
           clipped = String.slice(text, 0, max(max_width - 2 - col, 0))
-          draw_style = style_to_opts(style, syntax, base_fg)
+          draw_style = MarkdownStyles.to_draw_opts(style, syntax, base_fg)
           draw = DisplayList.draw(row, col, clipped, draw_style)
           {[draw | acc], col + text_len}
         end
@@ -181,31 +182,6 @@ defmodule Minga.Editor.HoverPopup do
 
     Enum.reverse(draws)
   end
-
-  @spec style_to_opts(Markdown.style(), map(), non_neg_integer()) :: keyword()
-  defp style_to_opts(:plain, _syntax, fg), do: [fg: fg]
-  defp style_to_opts(:bold, _syntax, fg), do: [fg: fg, bold: true]
-  defp style_to_opts(:italic, _syntax, fg), do: [fg: fg, italic: true]
-  defp style_to_opts(:bold_italic, _syntax, fg), do: [fg: fg, bold: true, italic: true]
-  defp style_to_opts(:code, syntax, _fg), do: [fg: Map.get(syntax, :string, 0x98BE65)]
-  defp style_to_opts(:code_block, syntax, _fg), do: [fg: Map.get(syntax, :string, 0x98BE65)]
-
-  defp style_to_opts({:code_content, _lang}, syntax, _fg),
-    do: [fg: Map.get(syntax, :string, 0x98BE65)]
-
-  defp style_to_opts(:header1, syntax, _fg),
-    do: [fg: Map.get(syntax, :keyword, 0x51AFEF), bold: true]
-
-  defp style_to_opts(:header2, syntax, _fg),
-    do: [fg: Map.get(syntax, :keyword, 0x51AFEF), bold: true]
-
-  defp style_to_opts(:header3, syntax, _fg),
-    do: [fg: Map.get(syntax, :keyword, 0x51AFEF)]
-
-  defp style_to_opts(:blockquote, _syntax, _fg), do: [fg: 0x5B6268, italic: true]
-  defp style_to_opts(:list_bullet, syntax, _fg), do: [fg: Map.get(syntax, :keyword, 0x51AFEF)]
-  defp style_to_opts(:rule, _syntax, _fg), do: [fg: 0x5B6268]
-  defp style_to_opts(_other, _syntax, fg), do: [fg: fg]
 
   @spec default_popup_theme() :: map()
   defp default_popup_theme do

--- a/lib/minga/editor/markdown_styles.ex
+++ b/lib/minga/editor/markdown_styles.ex
@@ -1,0 +1,42 @@
+defmodule Minga.Editor.MarkdownStyles do
+  @moduledoc """
+  Maps `Minga.Agent.Markdown` style atoms to display list draw options.
+
+  Shared by all UI components that render markdown content: hover popup,
+  completion doc preview, and future signature help. Centralizes the
+  style-to-theme-color mapping so it doesn't drift across consumers.
+  """
+
+  alias Minga.Agent.Markdown
+
+  @doc """
+  Converts a markdown style atom to display list keyword options.
+
+  Uses the theme's syntax colors for code and keywords, falling back
+  to `base_fg` for plain text.
+  """
+  @spec to_draw_opts(Markdown.style(), map(), non_neg_integer()) :: keyword()
+  def to_draw_opts(:plain, _syntax, fg), do: [fg: fg]
+  def to_draw_opts(:bold, _syntax, fg), do: [fg: fg, bold: true]
+  def to_draw_opts(:italic, _syntax, fg), do: [fg: fg, italic: true]
+  def to_draw_opts(:bold_italic, _syntax, fg), do: [fg: fg, bold: true, italic: true]
+  def to_draw_opts(:code, syntax, _fg), do: [fg: Map.get(syntax, :string, 0x98BE65)]
+  def to_draw_opts(:code_block, syntax, _fg), do: [fg: Map.get(syntax, :string, 0x98BE65)]
+
+  def to_draw_opts({:code_content, _lang}, syntax, _fg),
+    do: [fg: Map.get(syntax, :string, 0x98BE65)]
+
+  def to_draw_opts(:header1, syntax, _fg),
+    do: [fg: Map.get(syntax, :keyword, 0x51AFEF), bold: true]
+
+  def to_draw_opts(:header2, syntax, _fg),
+    do: [fg: Map.get(syntax, :keyword, 0x51AFEF), bold: true]
+
+  def to_draw_opts(:header3, syntax, _fg),
+    do: [fg: Map.get(syntax, :keyword, 0x51AFEF)]
+
+  def to_draw_opts(:blockquote, _syntax, _fg), do: [fg: 0x5B6268, italic: true]
+  def to_draw_opts(:list_bullet, syntax, _fg), do: [fg: Map.get(syntax, :keyword, 0x51AFEF)]
+  def to_draw_opts(:rule, _syntax, _fg), do: [fg: 0x5B6268]
+  def to_draw_opts(_other, _syntax, fg), do: [fg: fg]
+end

--- a/lib/minga/input/completion.ex
+++ b/lib/minga/input/completion.ex
@@ -15,6 +15,7 @@ defmodule Minga.Input.Completion do
 
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Completion
+  alias Minga.Editor.CompletionHandling
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.Viewport
 
@@ -181,13 +182,15 @@ defmodule Minga.Input.Completion do
   # C-n or arrow down: move selection down
   defp do_handle(state, completion, cp, mods)
        when (cp == ?n and band(mods, @ctrl) != 0) or cp == @arrow_down do
-    {:handled, %{state | completion: Completion.move_down(completion)}}
+    state = %{state | completion: Completion.move_down(completion)}
+    {:handled, CompletionHandling.maybe_resolve_selected(state)}
   end
 
   # C-p or arrow up: move selection up
   defp do_handle(state, completion, cp, mods)
        when (cp == ?p and band(mods, @ctrl) != 0) or cp == @arrow_up do
-    {:handled, %{state | completion: Completion.move_up(completion)}}
+    state = %{state | completion: Completion.move_up(completion)}
+    {:handled, CompletionHandling.maybe_resolve_selected(state)}
   end
 
   # Tab or Enter: accept the selected completion

--- a/lib/minga/lsp/client.ex
+++ b/lib/minga/lsp/client.ex
@@ -646,7 +646,11 @@ defmodule Minga.LSP.Client do
           "dynamicRegistration" => false,
           "completionItem" => %{
             "snippetSupport" => false,
-            "insertReplaceSupport" => true
+            "insertReplaceSupport" => true,
+            "documentationFormat" => ["markdown", "plaintext"],
+            "resolveSupport" => %{
+              "properties" => ["documentation", "detail", "additionalTextEdits"]
+            }
           },
           "completionItemKind" => %{
             "valueSet" => Enum.to_list(1..25)

--- a/test/minga/editor/completion_doc_preview_test.exs
+++ b/test/minga/editor/completion_doc_preview_test.exs
@@ -1,0 +1,222 @@
+defmodule Minga.Editor.CompletionDocPreviewTest do
+  @moduledoc """
+  Tests for the completion documentation preview pane and
+  completionItem/resolve flow.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Completion
+  alias Minga.Editor.CompletionHandling
+  alias Minga.Editor.CompletionUI
+  alias Minga.Theme
+
+  @theme Theme.get!(:doom_one)
+
+  # ── Completion item parsing ──────────────────────────────────────────────
+
+  describe "parse_item/1 documentation extraction" do
+    test "extracts plaintext documentation" do
+      raw = %{"label" => "foo", "documentation" => "Some docs"}
+      item = Completion.parse_item(raw)
+      assert item.documentation == "Some docs"
+    end
+
+    test "extracts MarkupContent documentation" do
+      raw = %{
+        "label" => "foo",
+        "documentation" => %{"kind" => "markdown", "value" => "**bold** docs"}
+      }
+
+      item = Completion.parse_item(raw)
+      assert item.documentation == "**bold** docs"
+    end
+
+    test "handles missing documentation" do
+      raw = %{"label" => "foo"}
+      item = Completion.parse_item(raw)
+      assert item.documentation == ""
+    end
+
+    test "preserves raw item for resolve" do
+      raw = %{"label" => "foo", "kind" => 3, "detail" => "Function"}
+      item = Completion.parse_item(raw)
+      assert item.raw == raw
+    end
+  end
+
+  # ── Documentation update ─────────────────────────────────────────────────
+
+  describe "update_selected_documentation/2" do
+    test "updates the selected item's documentation" do
+      items = [
+        Completion.parse_item(%{"label" => "a"}),
+        Completion.parse_item(%{"label" => "b"}),
+        Completion.parse_item(%{"label" => "c"})
+      ]
+
+      completion = Completion.new(items, {0, 0})
+      updated = Completion.update_selected_documentation(completion, "New docs for a")
+      selected = Completion.selected_item(updated)
+      assert selected.documentation == "New docs for a"
+    end
+
+    test "returns unchanged when no selected item" do
+      completion = Completion.new([], {0, 0})
+      result = Completion.update_selected_documentation(completion, "docs")
+      assert result == completion
+    end
+  end
+
+  # ── Resolve debounce ─────────────────────────────────────────────────────
+
+  describe "maybe_resolve_selected/1" do
+    test "returns state unchanged when completion is nil" do
+      state = %{completion: nil}
+      assert CompletionHandling.maybe_resolve_selected(state) == state
+    end
+
+    test "skips resolve when documentation already present" do
+      items = [Completion.parse_item(%{"label" => "a", "documentation" => "Already here"})]
+      completion = Completion.new(items, {0, 0})
+      state = %{completion: completion}
+      result = CompletionHandling.maybe_resolve_selected(state)
+      # No timer set because documentation is already present
+      assert result.completion.resolve_timer == nil
+    end
+
+    test "sets a resolve timer when documentation is empty" do
+      items = [Completion.parse_item(%{"label" => "a"})]
+      completion = Completion.new(items, {0, 0})
+      state = %{completion: completion}
+      result = CompletionHandling.maybe_resolve_selected(state)
+      assert result.completion.resolve_timer != nil
+    end
+
+    test "skips when already resolved for this index" do
+      items = [Completion.parse_item(%{"label" => "a"})]
+      completion = %{Completion.new(items, {0, 0}) | last_resolved_index: 0}
+      state = %{completion: completion}
+      result = CompletionHandling.maybe_resolve_selected(state)
+      assert result.completion.resolve_timer == nil
+    end
+  end
+
+  # ── Resolve response handling ───────────────────────────────────────────
+
+  describe "handle_resolve_response/2" do
+    test "updates selected item documentation on success" do
+      items = [Completion.parse_item(%{"label" => "a"})]
+      completion = Completion.new(items, {0, 0})
+      state = %{completion: completion}
+
+      resolved = %{"documentation" => %{"kind" => "markdown", "value" => "Full docs"}}
+      result = CompletionHandling.handle_resolve_response(state, {:ok, resolved})
+
+      selected = Completion.selected_item(result.completion)
+      assert selected.documentation == "Full docs"
+      assert result.completion.last_resolved_index == 0
+    end
+
+    test "handles plain string documentation in resolve response" do
+      items = [Completion.parse_item(%{"label" => "a"})]
+      completion = Completion.new(items, {0, 0})
+      state = %{completion: completion}
+
+      resolved = %{"documentation" => "Plain text docs"}
+      result = CompletionHandling.handle_resolve_response(state, {:ok, resolved})
+
+      selected = Completion.selected_item(result.completion)
+      assert selected.documentation == "Plain text docs"
+    end
+
+    test "returns state unchanged on error" do
+      items = [Completion.parse_item(%{"label" => "a"})]
+      completion = Completion.new(items, {0, 0})
+      state = %{completion: completion}
+
+      result = CompletionHandling.handle_resolve_response(state, {:error, "timeout"})
+      assert result == state
+    end
+
+    test "returns state unchanged when completion is nil" do
+      state = %{completion: nil}
+      result = CompletionHandling.handle_resolve_response(state, {:ok, %{}})
+      assert result == state
+    end
+  end
+
+  # ── Doc preview rendering ──────────────────────────────────────────────
+
+  describe "CompletionUI doc preview rendering" do
+    test "renders doc pane when selected item has documentation" do
+      items = [
+        Completion.parse_item(%{
+          "label" => "my_function",
+          "kind" => 3,
+          "documentation" => "Returns the **result** of the computation."
+        })
+      ]
+
+      completion = Completion.new(items, {0, 0})
+
+      opts = %{
+        cursor_row: 10,
+        cursor_col: 5,
+        viewport_rows: 24,
+        viewport_cols: 120
+      }
+
+      draws = CompletionUI.render(completion, opts, @theme)
+      # Should have draws for both the completion popup AND the doc pane
+      assert draws != []
+      # The doc pane draws should be at a different column than the popup
+      cols = Enum.map(draws, fn {_r, c, _text, _s} -> c end) |> Enum.uniq()
+      # Multiple column groups indicate popup + doc pane
+      assert Enum.count(cols) > 2
+    end
+
+    test "does not render doc pane when documentation is empty" do
+      items = [Completion.parse_item(%{"label" => "no_docs", "kind" => 3})]
+      completion = Completion.new(items, {0, 0})
+
+      opts = %{
+        cursor_row: 10,
+        cursor_col: 5,
+        viewport_rows: 24,
+        viewport_cols: 120
+      }
+
+      draws = CompletionUI.render(completion, opts, @theme)
+      # Should only have popup draws, no doc pane
+      assert draws != []
+      # All draws should be near the cursor column (no side panel)
+      cols = Enum.map(draws, fn {_r, c, _text, _s} -> c end)
+      max_col = Enum.max(cols)
+      # Without doc pane, nothing should extend far right
+      assert max_col < 60
+    end
+
+    test "does not render doc pane when viewport too narrow" do
+      items = [
+        Completion.parse_item(%{
+          "label" => "func",
+          "kind" => 3,
+          "documentation" => "Some docs"
+        })
+      ]
+
+      completion = Completion.new(items, {0, 0})
+
+      opts = %{
+        cursor_row: 10,
+        cursor_col: 30,
+        viewport_rows: 24,
+        viewport_cols: 60
+      }
+
+      draws = CompletionUI.render(completion, opts, @theme)
+      assert draws != []
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

When navigating the LSP completion popup with C-n/C-p, a documentation preview pane appears beside it showing the selected item's full documentation, rendered as formatted markdown. Documentation is fetched lazily via `completionItem/resolve` with 150ms debounce.

Closes #545

## Context

The completion popup previously showed only a truncated `detail` string (one line, max 50 chars). In LazyVim, Zed, and VS Code, selecting a completion item shows a full documentation window beside the popup. This is step 4 of the LSP experience (after #489 modeline indicator, #551 control commands, #547 hover tooltips).

## Changes

- **Completion item struct** extended with `documentation` (extracted from LSP response) and `raw` (original LSP item for resolve requests). `resolve_timer` and `last_resolved_index` track debounce state.

- **`completionItem/resolve` flow**: `CompletionHandling.maybe_resolve_selected/1` fires on C-n/C-p navigation with 150ms debounce. `flush_resolve/2` sends the resolve request. `handle_resolve_response/2` updates the selected item's documentation. Timer cancelled on completion dismiss.

- **Doc preview pane** (CompletionUI): positioned to the right of the completion popup if there's room (25+ cols), to the left if not. Uses `FloatingWindow` with `:anchor` positioning. Skipped entirely if viewport is too narrow (<20 cols available).

- **LSP capabilities**: `documentationFormat: ["markdown", "plaintext"]` and `resolveSupport: { properties: ["documentation", "detail", "additionalTextEdits"] }` declared.

- **Shared `MarkdownStyles` module**: Extracted the duplicate markdown-to-draw-opts mapping from `HoverPopup` into `Minga.Editor.MarkdownStyles`. Used by both hover and completion doc preview for consistent styling.

## Verification

```bash
mix test test/minga/editor/completion_doc_preview_test.exs  # 17 tests
mix test test/minga/completion_test.exs                     # 33 tests  
mix test --warnings-as-errors                               # 5,172 tests, 0 failures
mix lint                                                    # passed
```

## Acceptance Criteria Addressed

- Doc preview pane appears beside the completion popup on C-n/C-p ✅
- Documentation fetched via completionItem/resolve (lazy, selected item only) ✅
- Documentation rendered as formatted markdown ✅
- Pane positioned right of popup if room, left if not ✅
- Uses FloatingWindow infrastructure ✅
- Auto-dismisses when completion is dismissed ✅
- Falls back to inline documentation when resolve not available ✅
- contentFormat and resolveSupport declared in capabilities ✅
- Debounced (150ms) ✅