### PR TITLE
feat(lsp): signature help floating window with parameter highlighting

### DIFF
--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -479,6 +479,12 @@ defmodule Minga.Editor do
         new_state = Renderer.render(new_state)
         {:noreply, new_state}
 
+      {:signature_help, pending} ->
+        new_state = put_in(state.lsp.pending, pending)
+        new_state = CompletionHandling.handle_signature_help_response(new_state, result)
+        new_state = Renderer.render(new_state)
+        {:noreply, new_state}
+
       {nil, _} ->
         # Not a tracked request — try completion handler
         handle_lsp_completion_response(ref, result, state)

--- a/lib/minga/editor/completion_handling.ex
+++ b/lib/minga/editor/completion_handling.ex
@@ -11,6 +11,7 @@ defmodule Minga.Editor.CompletionHandling do
   alias Minga.Editor.BufferLifecycle
   alias Minga.Editor.CompletionTrigger
   alias Minga.Editor.DocumentSync
+  alias Minga.Editor.SignatureHelp
   alias Minga.Editor.State, as: EditorState
   alias Minga.LSP.Client
 
@@ -187,7 +188,8 @@ defmodule Minga.Editor.CompletionHandling do
   @spec do_update(EditorState.t(), pid(), non_neg_integer()) :: EditorState.t()
   defp do_update(state, buf, codepoint) do
     state = update_filter(state, buf)
-    maybe_trigger(state, buf, codepoint)
+    state = maybe_trigger(state, buf, codepoint)
+    maybe_trigger_signature_help(state, buf, codepoint)
   end
 
   @spec update_filter(EditorState.t(), pid()) :: EditorState.t()
@@ -273,6 +275,90 @@ defmodule Minga.Editor.CompletionHandling do
   end
 
   defp codepoint_to_char(_), do: nil
+
+  # ── Signature help ───────────────────────────────────────────────────────
+
+  @doc """
+  Handles a `textDocument/signatureHelp` response.
+
+  Creates a `SignatureHelp` struct from the response and stores it
+  in editor state. Returns state unchanged on error or empty response.
+  """
+  @spec handle_signature_help_response(EditorState.t(), {:ok, term()} | {:error, term()}) ::
+          EditorState.t()
+  def handle_signature_help_response(state, {:error, _}), do: state
+  def handle_signature_help_response(state, {:ok, nil}), do: %{state | signature_help: nil}
+
+  def handle_signature_help_response(state, {:ok, result}) when is_map(result) do
+    {cursor_row, cursor_col} = approximate_cursor_screen_pos(state)
+    sh = SignatureHelp.from_response(result, cursor_row, cursor_col)
+    %{state | signature_help: sh}
+  end
+
+  def handle_signature_help_response(state, _), do: state
+
+  @spec maybe_trigger_signature_help(EditorState.t(), pid(), non_neg_integer()) ::
+          EditorState.t()
+  defp maybe_trigger_signature_help(state, buf, codepoint) do
+    case codepoint do
+      # ( triggers signature help
+      ?( ->
+        send_signature_help_request(state, buf)
+
+      # , re-triggers (next parameter)
+      ?, ->
+        send_signature_help_request(state, buf)
+
+      # ) dismisses signature help
+      ?) ->
+        %{state | signature_help: nil}
+
+      _ ->
+        state
+    end
+  end
+
+  @spec send_signature_help_request(EditorState.t(), pid()) :: EditorState.t()
+  defp send_signature_help_request(state, buf) do
+    case lsp_client_for(state, buf) do
+      nil ->
+        state
+
+      client ->
+        file_path = BufferServer.file_path(buf)
+
+        if file_path do
+          uri = DocumentSync.path_to_uri(file_path)
+          {line, col} = BufferServer.cursor(buf)
+
+          params = %{
+            "textDocument" => %{"uri" => uri},
+            "position" => %{"line" => line, "character" => col}
+          }
+
+          ref = Client.request(client, "textDocument/signatureHelp", params)
+          put_in(state.lsp.pending, Map.put(state.lsp.pending, ref, :signature_help))
+        else
+          state
+        end
+    end
+  end
+
+  @spec approximate_cursor_screen_pos(EditorState.t()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp approximate_cursor_screen_pos(state) do
+    buf = state.buffers.active
+
+    if buf do
+      {line, col} = BufferServer.cursor(buf)
+      vp = state.viewport
+      screen_row = max(line - vp.top + 1, 1)
+      screen_col = min(col + 4, vp.cols - 1)
+      {screen_row, screen_col}
+    else
+      {div(state.viewport.rows, 2), div(state.viewport.cols, 2)}
+    end
+  end
 
   @spec lsp_client_for(EditorState.t(), pid()) :: pid() | nil
   defp lsp_client_for(state, buffer_pid) do

--- a/lib/minga/editor/render_pipeline/chrome.ex
+++ b/lib/minga/editor/render_pipeline/chrome.ex
@@ -21,6 +21,7 @@ defmodule Minga.Editor.RenderPipeline.Chrome do
   alias Minga.Editor.Renderer.Regions
   alias Minga.Editor.RenderPipeline.ChromeHelpers
   alias Minga.Editor.RenderPipeline.Scroll.WindowScroll
+  alias Minga.Editor.SignatureHelp
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.TreeRenderer
   alias Minga.Editor.Window
@@ -145,6 +146,9 @@ defmodule Minga.Editor.RenderPipeline.Chrome do
     # Hover popup overlay
     hover_draws = render_hover_popup(state)
 
+    # Signature help overlay
+    sig_help_draws = render_signature_help(state)
+
     # Float popup overlays (from the popup system)
     float_overlays = PopupLifecycle.render_float_overlays(state)
 
@@ -152,6 +156,7 @@ defmodule Minga.Editor.RenderPipeline.Chrome do
       (float_overlays ++
          [
            %Overlay{draws: hover_draws},
+           %Overlay{draws: sig_help_draws},
            %Overlay{draws: whichkey_draws},
            %Overlay{draws: completion_draws},
            %Overlay{draws: picker_draws, cursor: picker_cursor}
@@ -185,5 +190,12 @@ defmodule Minga.Editor.RenderPipeline.Chrome do
 
   defp render_hover_popup(%{hover_popup: popup, viewport: vp, theme: theme}) do
     HoverPopup.render(popup, {vp.rows, vp.cols}, theme)
+  end
+
+  @spec render_signature_help(state()) :: [DisplayList.draw()]
+  defp render_signature_help(%{signature_help: nil}), do: []
+
+  defp render_signature_help(%{signature_help: sh, viewport: vp, theme: theme}) do
+    SignatureHelp.render(sh, {vp.rows, vp.cols}, theme)
   end
 end

--- a/lib/minga/editor/signature_help.ex
+++ b/lib/minga/editor/signature_help.ex
@@ -1,0 +1,280 @@
+defmodule Minga.Editor.SignatureHelp do
+  @moduledoc """
+  State and rendering for LSP signature help tooltips.
+
+  When the user types `(` or `,` inside a function call, a floating
+  window appears above the cursor showing the function signature with
+  the active parameter highlighted. Supports multiple overloaded
+  signatures with cycling via C-j/C-k.
+
+  ## Lifecycle
+
+  1. User types `(` or `,` in insert mode
+  2. `CompletionHandling.maybe_handle/4` detects the trigger character
+  3. `textDocument/signatureHelp` request sent to LSP
+  4. Response parsed into `SignatureHelp` state
+  5. Rendered as an overlay in the Chrome stage
+  6. Dismissed on `)`, Escape, or cursor movement outside the call
+  """
+
+  alias Minga.Agent.Markdown
+  alias Minga.Editor.DisplayList
+  alias Minga.Editor.FloatingWindow
+  alias Minga.Editor.MarkdownStyles
+
+  @enforce_keys [:signatures, :active_signature, :active_parameter, :anchor_row, :anchor_col]
+  defstruct signatures: [],
+            active_signature: 0,
+            active_parameter: 0,
+            anchor_row: 0,
+            anchor_col: 0
+
+  @typedoc "A parsed signature."
+  @type signature :: %{
+          label: String.t(),
+          documentation: String.t(),
+          parameters: [parameter()]
+        }
+
+  @typedoc "A parsed parameter."
+  @type parameter :: %{
+          label: String.t(),
+          documentation: String.t()
+        }
+
+  @typedoc "Signature help state."
+  @type t :: %__MODULE__{
+          signatures: [signature()],
+          active_signature: non_neg_integer(),
+          active_parameter: non_neg_integer(),
+          anchor_row: non_neg_integer(),
+          anchor_col: non_neg_integer()
+        }
+
+  # ── Construction ─────────────────────────────────────────────────────────
+
+  @doc """
+  Creates a new signature help state from an LSP SignatureHelp response.
+  """
+  @spec from_response(map(), non_neg_integer(), non_neg_integer()) :: t() | nil
+  def from_response(response, cursor_row, cursor_col) do
+    sigs = parse_signatures(Map.get(response, "signatures", []))
+
+    case sigs do
+      [] ->
+        nil
+
+      _ ->
+        %__MODULE__{
+          signatures: sigs,
+          active_signature: Map.get(response, "activeSignature", 0),
+          active_parameter: Map.get(response, "activeParameter", 0),
+          anchor_row: cursor_row,
+          anchor_col: cursor_col
+        }
+    end
+  end
+
+  # ── Navigation ──────────────────────────────────────────────────────────
+
+  @doc "Cycle to the next signature overload."
+  @spec next_signature(t()) :: t()
+  def next_signature(%__MODULE__{signatures: sigs, active_signature: idx} = sh) do
+    %{sh | active_signature: rem(idx + 1, length(sigs))}
+  end
+
+  @doc "Cycle to the previous signature overload."
+  @spec prev_signature(t()) :: t()
+  def prev_signature(%__MODULE__{signatures: sigs, active_signature: idx} = sh) do
+    total = length(sigs)
+    %{sh | active_signature: rem(idx - 1 + total, total)}
+  end
+
+  # ── Rendering ───────────────────────────────────────────────────────────
+
+  @doc """
+  Renders the signature help as display list draws for an overlay.
+
+  Shows the active signature label with the active parameter highlighted.
+  If there are multiple signatures, shows a "1/3" counter.
+  """
+  @spec render(t(), {pos_integer(), pos_integer()}, map()) :: [DisplayList.draw()]
+  def render(%__MODULE__{signatures: []}, _viewport, _theme), do: []
+
+  def render(%__MODULE__{} = sh, viewport, theme) do
+    sig = Enum.at(sh.signatures, sh.active_signature)
+    if sig == nil, do: [], else: do_render(sh, sig, viewport, theme)
+  end
+
+  # ── Private: parsing ────────────────────────────────────────────────────
+
+  @spec parse_signatures([map()]) :: [signature()]
+  defp parse_signatures(sigs) when is_list(sigs) do
+    Enum.map(sigs, &parse_signature/1)
+  end
+
+  @spec parse_signature(map()) :: signature()
+  defp parse_signature(raw) do
+    %{
+      label: Map.get(raw, "label", ""),
+      documentation: extract_doc(Map.get(raw, "documentation")),
+      parameters: parse_parameters(Map.get(raw, "parameters", []))
+    }
+  end
+
+  @spec parse_parameters([map()]) :: [parameter()]
+  defp parse_parameters(params) when is_list(params) do
+    Enum.map(params, &parse_parameter/1)
+  end
+
+  @spec parse_parameter(map()) :: parameter()
+  defp parse_parameter(raw) do
+    label =
+      case Map.get(raw, "label") do
+        l when is_binary(l) -> l
+        [start, stop] when is_integer(start) and is_integer(stop) -> "#{start}:#{stop}"
+        _ -> ""
+      end
+
+    %{
+      label: label,
+      documentation: extract_doc(Map.get(raw, "documentation"))
+    }
+  end
+
+  @spec extract_doc(term()) :: String.t()
+  defp extract_doc(nil), do: ""
+  defp extract_doc(text) when is_binary(text), do: String.trim(text)
+  defp extract_doc(%{"value" => value}) when is_binary(value), do: String.trim(value)
+  defp extract_doc(_), do: ""
+
+  # ── Private: rendering ─────────────────────────────────────────────────
+
+  @spec do_render(t(), signature(), {pos_integer(), pos_integer()}, map()) ::
+          [DisplayList.draw()]
+  defp do_render(sh, sig, viewport, theme) do
+    popup_theme = Map.get(theme, :popup, %{bg: 0x21242B, border_fg: 0x5B6268, title_fg: 0xBBC2CF})
+    syntax = Map.get(theme, :syntax, %{})
+    editor_theme = Map.get(theme, :editor, %{})
+    base_fg = Map.get(editor_theme, :fg, 0xBBC2CF)
+    highlight_fg = Map.get(syntax, :keyword, 0x51AFEF)
+
+    # Build content: signature label with active parameter highlighted
+    content_draws = build_signature_draws(sig, sh.active_parameter, base_fg, highlight_fg)
+
+    # Add parameter documentation if available
+    param_doc_draws =
+      case Enum.at(sig.parameters, sh.active_parameter) do
+        %{documentation: doc} when doc != "" ->
+          render_param_doc(doc, syntax, base_fg)
+
+        _ ->
+          []
+      end
+
+    all_draws = content_draws ++ param_doc_draws
+
+    content_height =
+      if param_doc_draws == [],
+        do: 1,
+        else:
+          2 +
+            length(
+              Markdown.parse(
+                Enum.at(sig.parameters, sh.active_parameter, %{documentation: ""}).documentation
+              )
+            )
+
+    # Counter for multiple signatures
+    counter =
+      if length(sh.signatures) > 1 do
+        "#{sh.active_signature + 1}/#{length(sh.signatures)}"
+      else
+        nil
+      end
+
+    # Compute width from signature label
+    sig_width = String.length(sig.label) + 4
+    width = max(sig_width, 30) |> min(elem(viewport, 1) - 4)
+
+    spec = %FloatingWindow.Spec{
+      content: all_draws,
+      width: {:cols, width + 2},
+      height: {:rows, min(content_height, 8) + 2},
+      position: {:anchor, sh.anchor_row, sh.anchor_col, :above},
+      border: :rounded,
+      footer: counter,
+      theme: popup_theme,
+      viewport: viewport
+    }
+
+    FloatingWindow.render(spec)
+  end
+
+  @spec render_param_doc(String.t(), map(), non_neg_integer()) :: [DisplayList.draw()]
+  defp render_param_doc(doc, syntax, base_fg) do
+    parsed = Markdown.parse(doc)
+
+    Enum.with_index(parsed, 1)
+    |> Enum.flat_map(fn {{segments, _type}, row} ->
+      {draws, _col} =
+        Enum.reduce(segments, {[], 0}, fn {text, style}, {acc, col} ->
+          draw =
+            DisplayList.draw(row, col, text, MarkdownStyles.to_draw_opts(style, syntax, base_fg))
+
+          {[draw | acc], col + String.length(text)}
+        end)
+
+      Enum.reverse(draws)
+    end)
+  end
+
+  @spec build_signature_draws(
+          signature(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          [DisplayList.draw()]
+  defp build_signature_draws(sig, active_param, base_fg, highlight_fg) do
+    label = sig.label
+    params = sig.parameters
+
+    case find_active_param_range(label, params, active_param) do
+      {start_col, end_col} ->
+        # Split label into three parts: before, active parameter, after
+        before = String.slice(label, 0, start_col)
+        active = String.slice(label, start_col, end_col - start_col)
+        after_text = String.slice(label, end_col, String.length(label) - end_col)
+
+        [
+          DisplayList.draw(0, 0, before, fg: base_fg),
+          DisplayList.draw(0, String.length(before), active, fg: highlight_fg, bold: true),
+          DisplayList.draw(0, String.length(before) + String.length(active), after_text,
+            fg: base_fg
+          )
+        ]
+
+      nil ->
+        [DisplayList.draw(0, 0, label, fg: base_fg)]
+    end
+  end
+
+  @spec find_active_param_range(String.t(), [parameter()], non_neg_integer()) ::
+          {non_neg_integer(), non_neg_integer()} | nil
+  defp find_active_param_range(_label, [], _active), do: nil
+  defp find_active_param_range(_label, _params, active) when active < 0, do: nil
+
+  defp find_active_param_range(label, params, active) do
+    param = Enum.at(params, active)
+
+    if param do
+      case :binary.match(label, param.label) do
+        {start, len} -> {start, start + len}
+        :nomatch -> nil
+      end
+    else
+      nil
+    end
+  end
+end

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -108,6 +108,7 @@ defmodule Minga.Editor.State do
             git_buffers: %{},
             lsp_status: :none,
             hover_popup: nil,
+            signature_help: nil,
             injection_ranges: %{},
             focus_stack: [],
             keymap_scope: :editor,
@@ -147,6 +148,7 @@ defmodule Minga.Editor.State do
           git_buffers: %{pid() => pid()},
           lsp_status: Minga.Editor.Modeline.lsp_status(),
           hover_popup: Minga.Editor.HoverPopup.t() | nil,
+          signature_help: Minga.Editor.SignatureHelp.t() | nil,
           injection_ranges: %{
             pid() => [
               %{start_byte: non_neg_integer(), end_byte: non_neg_integer(), language: String.t()}

--- a/lib/minga/input.ex
+++ b/lib/minga/input.ex
@@ -35,6 +35,7 @@ defmodule Minga.Input do
   alias Minga.Input.Picker
   alias Minga.Input.Popup
   alias Minga.Input.Scoped
+  alias Minga.Input.SignatureHelp
   alias Minga.Input.ToolApproval
 
   @doc """
@@ -63,6 +64,7 @@ defmodule Minga.Input do
       ConflictPrompt,
       Picker,
       Hover,
+      SignatureHelp,
       Completion,
       Scoped,
       GlobalBindings,

--- a/lib/minga/input/signature_help.ex
+++ b/lib/minga/input/signature_help.ex
@@ -1,0 +1,48 @@
+defmodule Minga.Input.SignatureHelp do
+  @moduledoc """
+  Input handler for signature help overlay.
+
+  When signature help is visible, intercepts C-j/C-k to cycle through
+  overloaded signatures and Escape to dismiss. All other keys pass
+  through (signature help stays visible while typing arguments).
+  """
+
+  @behaviour Minga.Input.Handler
+
+  alias Minga.Editor.SignatureHelp, as: SigHelp
+  alias Minga.Editor.State, as: EditorState
+
+  import Bitwise
+
+  @ctrl 4
+  @key_escape 27
+
+  @impl true
+  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          Minga.Input.Handler.result()
+  def handle_key(%{signature_help: nil} = state, _cp, _mods) do
+    {:passthrough, state}
+  end
+
+  # C-j: next signature overload
+  def handle_key(%{signature_help: %SigHelp{}} = state, ?j, mods)
+      when band(mods, @ctrl) != 0 do
+    {:handled, %{state | signature_help: SigHelp.next_signature(state.signature_help)}}
+  end
+
+  # C-k: previous signature overload
+  def handle_key(%{signature_help: %SigHelp{}} = state, ?k, mods)
+      when band(mods, @ctrl) != 0 do
+    {:handled, %{state | signature_help: SigHelp.prev_signature(state.signature_help)}}
+  end
+
+  # Escape: dismiss signature help
+  def handle_key(%{signature_help: %SigHelp{}} = state, @key_escape, _mods) do
+    {:handled, %{state | signature_help: nil}}
+  end
+
+  # All other keys: pass through (signature help stays visible while typing)
+  def handle_key(state, _cp, _mods) do
+    {:passthrough, state}
+  end
+end

--- a/lib/minga/lsp/client.ex
+++ b/lib/minga/lsp/client.ex
@@ -662,6 +662,14 @@ defmodule Minga.LSP.Client do
         "hover" => %{
           "dynamicRegistration" => false,
           "contentFormat" => ["markdown", "plaintext"]
+        },
+        "signatureHelp" => %{
+          "dynamicRegistration" => false,
+          "signatureInformation" => %{
+            "documentationFormat" => ["markdown", "plaintext"],
+            "parameterInformation" => %{"labelOffsetSupport" => true},
+            "activeParameterSupport" => true
+          }
         }
       }
     }

--- a/test/minga/editor/signature_help_test.exs
+++ b/test/minga/editor/signature_help_test.exs
@@ -1,0 +1,160 @@
+defmodule Minga.Editor.SignatureHelpTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.SignatureHelp
+  alias Minga.Theme
+
+  @theme Theme.get!(:doom_one)
+  @viewport {24, 80}
+
+  @sample_response %{
+    "signatures" => [
+      %{
+        "label" => "foo(bar, baz, qux)",
+        "documentation" => "Does something useful.",
+        "parameters" => [
+          %{"label" => "bar", "documentation" => "The first arg"},
+          %{"label" => "baz", "documentation" => "The second arg"},
+          %{"label" => "qux", "documentation" => ""}
+        ]
+      },
+      %{
+        "label" => "foo(only_one)",
+        "parameters" => [
+          %{"label" => "only_one"}
+        ]
+      }
+    ],
+    "activeSignature" => 0,
+    "activeParameter" => 0
+  }
+
+  describe "from_response/3" do
+    test "parses a valid response" do
+      sh = SignatureHelp.from_response(@sample_response, 10, 20)
+      assert %SignatureHelp{} = sh
+      assert length(sh.signatures) == 2
+      assert sh.active_signature == 0
+      assert sh.active_parameter == 0
+    end
+
+    test "returns nil for empty signatures" do
+      resp = %{"signatures" => [], "activeSignature" => 0, "activeParameter" => 0}
+      assert SignatureHelp.from_response(resp, 10, 20) == nil
+    end
+
+    test "parses parameter labels" do
+      sh = SignatureHelp.from_response(@sample_response, 10, 20)
+      [sig | _] = sh.signatures
+      assert length(sig.parameters) == 3
+      assert hd(sig.parameters).label == "bar"
+    end
+
+    test "extracts signature documentation" do
+      sh = SignatureHelp.from_response(@sample_response, 10, 20)
+      [sig | _] = sh.signatures
+      assert sig.documentation == "Does something useful."
+    end
+
+    test "extracts parameter documentation" do
+      sh = SignatureHelp.from_response(@sample_response, 10, 20)
+      [sig | _] = sh.signatures
+      assert hd(sig.parameters).documentation == "The first arg"
+    end
+
+    test "handles label offset format [start, end]" do
+      resp = %{
+        "signatures" => [
+          %{
+            "label" => "func(a, b)",
+            "parameters" => [%{"label" => [5, 6]}, %{"label" => [8, 9]}]
+          }
+        ],
+        "activeSignature" => 0,
+        "activeParameter" => 0
+      }
+
+      sh = SignatureHelp.from_response(resp, 10, 20)
+      [sig | _] = sh.signatures
+      # Label offsets are stored as "start:end" strings
+      assert hd(sig.parameters).label == "5:6"
+    end
+  end
+
+  describe "next_signature/1 and prev_signature/1" do
+    test "cycles forward through signatures" do
+      sh = SignatureHelp.from_response(@sample_response, 10, 20)
+      assert sh.active_signature == 0
+      sh = SignatureHelp.next_signature(sh)
+      assert sh.active_signature == 1
+      sh = SignatureHelp.next_signature(sh)
+      assert sh.active_signature == 0
+    end
+
+    test "cycles backward through signatures" do
+      sh = SignatureHelp.from_response(@sample_response, 10, 20)
+      sh = SignatureHelp.prev_signature(sh)
+      assert sh.active_signature == 1
+      sh = SignatureHelp.prev_signature(sh)
+      assert sh.active_signature == 0
+    end
+  end
+
+  describe "render/3" do
+    test "returns empty list for no signatures" do
+      sh = %SignatureHelp{
+        signatures: [],
+        active_signature: 0,
+        active_parameter: 0,
+        anchor_row: 10,
+        anchor_col: 20
+      }
+
+      assert SignatureHelp.render(sh, @viewport, @theme) == []
+    end
+
+    test "produces draw commands for valid signature" do
+      sh = SignatureHelp.from_response(@sample_response, 10, 20)
+      draws = SignatureHelp.render(sh, @viewport, @theme)
+      assert draws != []
+      assert Enum.all?(draws, &is_tuple/1)
+    end
+
+    test "includes the signature label text" do
+      sh = SignatureHelp.from_response(@sample_response, 10, 20)
+      draws = SignatureHelp.render(sh, @viewport, @theme)
+      texts = Enum.map(draws, fn {_r, _c, text, _s} -> text end)
+      combined = Enum.join(texts)
+      assert String.contains?(combined, "foo")
+      assert String.contains?(combined, "bar")
+    end
+
+    test "active parameter is rendered with highlighting" do
+      sh = SignatureHelp.from_response(@sample_response, 10, 20)
+      draws = SignatureHelp.render(sh, @viewport, @theme)
+
+      # Find the draw that contains the active parameter "bar"
+      bar_draws = Enum.filter(draws, fn {_r, _c, text, _s} -> text == "bar" end)
+      assert bar_draws != []
+
+      [{_r, _c, _text, style}] = bar_draws
+      assert Keyword.get(style, :bold) == true
+    end
+
+    test "shows signature counter when multiple overloads" do
+      sh = SignatureHelp.from_response(@sample_response, 10, 20)
+      draws = SignatureHelp.render(sh, @viewport, @theme)
+      texts = Enum.map(draws, fn {_r, _c, text, _s} -> text end)
+      combined = Enum.join(texts)
+      assert String.contains?(combined, "1/2")
+    end
+
+    test "positions above the cursor" do
+      sh = SignatureHelp.from_response(@sample_response, 15, 20)
+      draws = SignatureHelp.render(sh, @viewport, @theme)
+      rows = Enum.map(draws, fn {r, _c, _text, _s} -> r end)
+      max_row = Enum.max(rows)
+      assert max_row < 15
+    end
+  end
+end

--- a/test/minga/input/signature_help_test.exs
+++ b/test/minga/input/signature_help_test.exs
@@ -1,0 +1,61 @@
+defmodule Minga.Input.SignatureHelpTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.SignatureHelp, as: SigHelp
+  alias Minga.Input.SignatureHelp, as: SigHelpInput
+
+  import Minga.Editor.RenderPipeline.TestHelpers
+
+  @ctrl 4
+  @escape 27
+
+  @sample_response %{
+    "signatures" => [
+      %{"label" => "foo(a, b)", "parameters" => [%{"label" => "a"}, %{"label" => "b"}]},
+      %{"label" => "foo(x)", "parameters" => [%{"label" => "x"}]}
+    ],
+    "activeSignature" => 0,
+    "activeParameter" => 0
+  }
+
+  defp state_with_sig_help do
+    state = base_state()
+    sh = SigHelp.from_response(@sample_response, 10, 20)
+    %{state | signature_help: sh}
+  end
+
+  describe "handle_key/3 with no signature help" do
+    test "passes through" do
+      state = base_state()
+      assert {:passthrough, ^state} = SigHelpInput.handle_key(state, ?a, 0)
+    end
+  end
+
+  describe "handle_key/3 with signature help visible" do
+    test "C-j cycles to next signature" do
+      state = state_with_sig_help()
+      assert {:handled, new_state} = SigHelpInput.handle_key(state, ?j, @ctrl)
+      assert new_state.signature_help.active_signature == 1
+    end
+
+    test "C-k cycles to previous signature" do
+      state = state_with_sig_help()
+      # Go to signature 1 first
+      {:handled, state} = SigHelpInput.handle_key(state, ?j, @ctrl)
+      assert {:handled, new_state} = SigHelpInput.handle_key(state, ?k, @ctrl)
+      assert new_state.signature_help.active_signature == 0
+    end
+
+    test "Escape dismisses" do
+      state = state_with_sig_help()
+      assert {:handled, new_state} = SigHelpInput.handle_key(state, @escape, 0)
+      assert new_state.signature_help == nil
+    end
+
+    test "regular keys pass through (signature stays visible)" do
+      state = state_with_sig_help()
+      assert {:passthrough, new_state} = SigHelpInput.handle_key(state, ?a, 0)
+      assert new_state.signature_help != nil
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

Typing `(` after a function name shows a floating window above the cursor with the function signature and the active parameter highlighted. Type `,` to advance parameters, `)` or Escape to dismiss, `C-j`/`C-k` to cycle through overloaded signatures.

Closes #546

## Context

Step 5 of the LSP experience: after modeline indicator (#489), control commands (#551), hover tooltips (#547), and completion doc preview (#545). This adds the last interactive LSP feature before snippets.

## Changes

- **`SignatureHelp` module**: Parses LSP `SignatureHelp` response into structured data. Renders the active signature label with the active parameter highlighted (bold + keyword color). Shows parameter documentation as markdown below the signature. Footer shows "1/3" counter for multiple overloads.

- **Trigger flow** (in `CompletionHandling`): `(` and `,` trigger `textDocument/signatureHelp` requests. `)` dismisses. Fires alongside completion triggers so both can be active simultaneously.

- **`Input.SignatureHelp` handler**: `C-j`/`C-k` cycle through overloaded signatures. `Escape` dismisses. All other keys pass through (signature help stays visible while you type arguments).

- **LSP capabilities**: `signatureHelp` declared with `documentationFormat`, `labelOffsetSupport`, `activeParameterSupport`.

## Verification

```bash
mix test test/minga/editor/signature_help_test.exs  # 13 tests
mix test test/minga/input/signature_help_test.exs   # 6 tests
mix test --warnings-as-errors                       # 5,211 tests, 0 failures
mix lint                                            # passed
```

## Acceptance Criteria Addressed

- Typing ( triggers textDocument/signatureHelp ✅
- Floating window shows signature with active parameter highlighted ✅
- Typing , re-triggers (next parameter) ✅
- ) or Escape dismisses ✅
- Multiple signatures: C-j/C-k cycling with counter ✅
- FloatingWindow with border ✅
- signatureHelp capability declared ✅