### PR TITLE
Language picker: change buffer filetype via SPC b l, :set ft=, or modeline click

### DIFF
--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -257,6 +257,18 @@ defmodule Minga.Buffer.Server do
     GenServer.call(server, :filetype)
   end
 
+  @doc """
+  Changes the buffer's filetype and re-seeds per-filetype options.
+
+  The buffer content is not modified; only metadata (filetype, tab_width,
+  indent_with, etc.) changes. The caller is responsible for triggering
+  a highlight reparse after this call.
+  """
+  @spec set_filetype(GenServer.server(), atom()) :: :ok
+  def set_filetype(server, filetype) when is_atom(filetype) do
+    GenServer.call(server, {:set_filetype, filetype})
+  end
+
   @doc "Returns the buffer name (e.g. `*Messages*`), or `nil` for file buffers."
   @spec buffer_name(GenServer.server()) :: String.t() | nil
   def buffer_name(server) do
@@ -967,6 +979,11 @@ defmodule Minga.Buffer.Server do
 
   def handle_call(:filetype, _from, state) do
     {:reply, state.filetype, state}
+  end
+
+  def handle_call({:set_filetype, filetype}, _from, state) do
+    new_state = %{state | filetype: filetype, options: seed_options(filetype)}
+    {:reply, :ok, new_state}
   end
 
   def handle_call(:buffer_name, _from, state) do

--- a/lib/minga/command/parser.ex
+++ b/lib/minga/command/parser.ex
@@ -164,6 +164,11 @@ defmodule Minga.Command.Parser do
   defp do_parse("set wrap"), do: {:set, :wrap}
   defp do_parse("set nowrap"), do: {:set, :nowrap}
 
+  defp do_parse("set ft=" <> name), do: {:set_filetype, [String.trim(name)]}
+  defp do_parse("set filetype=" <> name), do: {:set_filetype, [String.trim(name)]}
+  defp do_parse("setf " <> name), do: {:set_filetype, [String.trim(name)]}
+  defp do_parse("setfiletype " <> name), do: {:set_filetype, [String.trim(name)]}
+
   defp do_parse("setglobal number"), do: {:setglobal, :number}
   defp do_parse("setglobal nu"), do: {:setglobal, :number}
   defp do_parse("setglobal nonumber"), do: {:setglobal, :nonumber}

--- a/lib/minga/command/registry.ex
+++ b/lib/minga/command/registry.ex
@@ -63,6 +63,7 @@ defmodule Minga.Command.Registry do
     {:view_messages, "View *Messages* buffer"},
     {:view_warnings, "View *Warnings* buffer"},
     {:new_buffer, "Create new empty buffer"},
+    {:set_language, "Set buffer language"},
     {:command_palette, "Execute command"},
     {:theme_picker, "Pick theme"},
     {:delete_line, "Delete current line"},

--- a/lib/minga/editor/commands.ex
+++ b/lib/minga/editor/commands.ex
@@ -85,6 +85,10 @@ defmodule Minga.Editor.Commands do
     PickerUI.open(state, Minga.Picker.ThemeSource)
   end
 
+  def execute(state, :set_language) do
+    PickerUI.open(state, Minga.Picker.LanguageSource)
+  end
+
   def execute(state, :search_project) do
     %{
       state
@@ -579,8 +583,7 @@ defmodule Minga.Editor.Commands do
   def execute(state, :lsp_start), do: LspCommands.execute(state, :lsp_start)
 
   def execute(state, :filetype_menu) do
-    # TODO: open SPC m which-key popup for the active buffer's filetype
-    %{state | status_msg: "Filetype actions not yet implemented (SPC m)"}
+    PickerUI.open(state, Minga.Picker.LanguageSource)
   end
 
   def execute(state, :goto_definition), do: LspActions.goto_definition(state)

--- a/lib/minga/editor/commands/buffer_management.ex
+++ b/lib/minga/editor/commands/buffer_management.ex
@@ -394,6 +394,13 @@ defmodule Minga.Editor.Commands.BufferManagement do
     Movement.execute(state, :window_close)
   end
 
+  def execute(state, {:execute_ex_command, {:set_filetype, [name]}}) do
+    case resolve_filetype(name) do
+      {:ok, filetype} -> apply_filetype_change(state, filetype)
+      {:error, message} -> %{state | status_msg: message}
+    end
+  end
+
   def execute(state, {:execute_ex_command, {:unknown, raw}}) do
     Minga.Log.debug(:editor, "Unknown ex command: #{raw}")
     state
@@ -457,6 +464,27 @@ defmodule Minga.Editor.Commands.BufferManagement do
       {:error, reason} ->
         Minga.Log.warning(:editor, "Failed to open config: #{inspect(reason)}")
         state
+    end
+  end
+
+  # ── Filetype change ──────────────────────────────────────────────────────
+
+  @doc """
+  Changes the active buffer's filetype and triggers a highlight reparse.
+
+  Used by the language picker (`LanguageSource.on_select`) and the `:set ft=`
+  ex command. Centralizes the side effects so both paths stay in sync.
+  """
+  @spec apply_filetype_change(state(), atom()) :: state()
+  def apply_filetype_change(state, filetype) when is_atom(filetype) do
+    buf = state.buffers.active
+
+    if is_pid(buf) and Process.alive?(buf) do
+      BufferServer.set_filetype(buf, filetype)
+      send(self(), :setup_highlight)
+      %{state | status_msg: "Language: #{filetype}"}
+    else
+      %{state | status_msg: "No active buffer"}
     end
   end
 
@@ -692,6 +720,20 @@ defmodule Minga.Editor.Commands.BufferManagement do
   end
 
   @spec last_tab?(state()) :: boolean()
+  # Validates a filetype name string against the Language registry.
+  # Uses String.to_existing_atom to avoid atom table pollution from typos.
+  @spec resolve_filetype(String.t()) :: {:ok, atom()} | {:error, String.t()}
+  defp resolve_filetype(name) do
+    atom = String.to_existing_atom(name)
+
+    case Minga.Language.Registry.get(atom) do
+      %Minga.Language{} -> {:ok, atom}
+      nil -> {:error, "Unknown language: #{name}"}
+    end
+  rescue
+    ArgumentError -> {:error, "Unknown language: #{name}"}
+  end
+
   defp last_tab?(%{tab_bar: %TabBar{tabs: [_]}}), do: true
   defp last_tab?(%{tab_bar: nil}), do: true
   defp last_tab?(_state), do: false

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -49,6 +49,7 @@ defmodule Minga.Keymap.Defaults do
     {[{?b, @none}, {?m, @none}], :view_messages, "View messages"},
     {[{?b, @none}, {?W, @none}], :view_warnings, "View warnings"},
     {[{?b, @none}, {?N, @none}], :new_buffer, "New buffer"},
+    {[{?b, @none}, {?l, @none}], :set_language, "Set language"},
 
     # ── Window ────────────────────────────────────────────────────────────────
     {[{?w, @none}, {?h, @none}], :window_left, "Window left"},

--- a/lib/minga/picker/language_source.ex
+++ b/lib/minga/picker/language_source.ex
@@ -1,0 +1,75 @@
+defmodule Minga.Picker.LanguageSource do
+  @moduledoc """
+  Picker source for changing the active buffer's language (major mode).
+
+  Lists all registered languages from the Language registry with icons,
+  extensions, and the current language highlighted. Selecting a language
+  changes the buffer's filetype, re-seeds per-filetype options, and
+  triggers a tree-sitter reparse.
+  """
+
+  @behaviour Minga.Picker.Source
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Devicon
+  alias Minga.Editor.Commands.BufferManagement
+  alias Minga.Language
+  alias Minga.Language.Registry, as: LangRegistry
+  alias Minga.Picker.Item
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Set language"
+
+  @impl true
+  @spec candidates(term()) :: [Item.t()]
+  def candidates(state) do
+    current_ft = current_filetype(state)
+
+    LangRegistry.all()
+    |> Enum.map(fn %Language{} = lang -> format_candidate(lang, current_ft) end)
+    |> Enum.sort_by(& &1.label)
+  end
+
+  @impl true
+  @spec on_select(Item.t(), term()) :: term()
+  def on_select(%Item{id: filetype}, state) when is_atom(filetype) do
+    BufferManagement.apply_filetype_change(state, filetype)
+  end
+
+  @impl true
+  @spec on_cancel(term()) :: term()
+  def on_cancel(state), do: state
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec format_candidate(Language.t(), atom()) :: Item.t()
+  defp format_candidate(%Language{} = lang, current_ft) do
+    {icon, color} = Devicon.icon_and_color(lang.name)
+    exts = format_extensions(lang.extensions)
+    current = if lang.name == current_ft, do: " •", else: ""
+
+    %Item{
+      id: lang.name,
+      label: "#{icon} #{lang.label}#{current}",
+      description: exts,
+      icon_color: color
+    }
+  end
+
+  @spec format_extensions([String.t()]) :: String.t()
+  defp format_extensions([]), do: ""
+
+  defp format_extensions(exts) do
+    exts
+    |> Enum.take(4)
+    |> Enum.map_join(", ", &".#{&1}")
+  end
+
+  @spec current_filetype(term()) :: atom()
+  defp current_filetype(%{buffers: %{active: buf}}) when is_pid(buf) do
+    if Process.alive?(buf), do: BufferServer.filetype(buf), else: :text
+  end
+
+  defp current_filetype(_state), do: :text
+end

--- a/test/minga/command/parser_test.exs
+++ b/test/minga/command/parser_test.exs
@@ -185,4 +185,26 @@ defmodule Minga.Command.ParserTest do
       assert {:unknown, "wo"} = Parser.parse("wo")
     end
   end
+
+  describe "set filetype commands" do
+    test ":set ft=python parses to set_filetype" do
+      assert {:set_filetype, ["python"]} = Parser.parse("set ft=python")
+    end
+
+    test ":set filetype=elixir parses to set_filetype" do
+      assert {:set_filetype, ["elixir"]} = Parser.parse("set filetype=elixir")
+    end
+
+    test ":setf ruby parses to set_filetype" do
+      assert {:set_filetype, ["ruby"]} = Parser.parse("setf ruby")
+    end
+
+    test ":setfiletype go parses to set_filetype" do
+      assert {:set_filetype, ["go"]} = Parser.parse("setfiletype go")
+    end
+
+    test "trims whitespace from filetype name" do
+      assert {:set_filetype, ["python"]} = Parser.parse("set ft=  python  ")
+    end
+  end
 end

--- a/test/minga/command/registry_test.exs
+++ b/test/minga/command/registry_test.exs
@@ -36,6 +36,7 @@ defmodule Minga.Command.RegistryTest do
           :filetype_menu,
           :find_file,
           :search_project,
+          :set_language,
           :buffer_list,
           :buffer_list_all,
           :buffer_next,

--- a/test/minga/picker/language_source_test.exs
+++ b/test/minga/picker/language_source_test.exs
@@ -1,0 +1,103 @@
+defmodule Minga.Picker.LanguageSourceTest do
+  @moduledoc "Tests for the language picker source."
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Picker.Item
+  alias Minga.Picker.LanguageSource
+
+  describe "title/0" do
+    test "returns Set language" do
+      assert LanguageSource.title() == "Set language"
+    end
+  end
+
+  describe "candidates/1" do
+    test "returns all registered languages" do
+      state = state_with_buffer("hello", :elixir)
+      candidates = LanguageSource.candidates(state)
+
+      assert candidates != []
+      assert Enum.all?(candidates, &match?(%Item{}, &1))
+    end
+
+    test "each candidate has an icon and label" do
+      state = state_with_buffer("hello", :elixir)
+      candidates = LanguageSource.candidates(state)
+
+      elixir = Enum.find(candidates, fn %Item{id: id} -> id == :elixir end)
+      assert elixir != nil
+      assert elixir.label =~ "Elixir"
+    end
+
+    test "current filetype is marked with a bullet" do
+      state = state_with_buffer("hello", :elixir)
+      candidates = LanguageSource.candidates(state)
+
+      elixir = Enum.find(candidates, fn %Item{id: id} -> id == :elixir end)
+      assert elixir.label =~ "•"
+
+      python = Enum.find(candidates, fn %Item{id: id} -> id == :python end)
+      refute python.label =~ "•"
+    end
+
+    test "shows file extensions in description" do
+      state = state_with_buffer("hello", :text)
+      candidates = LanguageSource.candidates(state)
+
+      elixir = Enum.find(candidates, fn %Item{id: id} -> id == :elixir end)
+      assert elixir.description =~ ".ex"
+    end
+
+    test "candidates are sorted by label" do
+      state = state_with_buffer("hello", :text)
+      candidates = LanguageSource.candidates(state)
+      labels = Enum.map(candidates, & &1.label)
+      assert labels == Enum.sort(labels)
+    end
+  end
+
+  describe "on_select/2" do
+    test "changes the buffer filetype" do
+      state = state_with_buffer("hello world", :text)
+      buf = state.buffers.active
+      assert BufferServer.filetype(buf) == :text
+
+      item = %Item{id: :python, label: "Python"}
+      _new_state = LanguageSource.on_select(item, state)
+
+      assert BufferServer.filetype(buf) == :python
+    end
+  end
+
+  describe "apply_filetype_change/2" do
+    alias Minga.Editor.Commands.BufferManagement
+
+    test "changes the buffer filetype via shared function" do
+      state = state_with_buffer("hello", :text)
+      buf = state.buffers.active
+      assert BufferServer.filetype(buf) == :text
+
+      new_state = BufferManagement.apply_filetype_change(state, :python)
+      assert BufferServer.filetype(buf) == :python
+      assert new_state.status_msg =~ "python"
+    end
+
+    test "returns error message when no active buffer" do
+      state = %{buffers: %{active: nil}, status_msg: nil}
+      new_state = BufferManagement.apply_filetype_change(state, :python)
+      assert new_state.status_msg =~ "No active buffer"
+    end
+  end
+
+  # ── Helpers ─────────────────────────────────────────────────────────────────
+
+  defp state_with_buffer(content, filetype) do
+    {:ok, buf} = BufferServer.start_link(content: content, filetype: filetype)
+
+    %{
+      buffers: %{active: buf, list: [buf], active_index: 0},
+      status_msg: nil
+    }
+  end
+end

--- a/test/snapshots/minga/integration/which_key_test/whichkey_buffer_prefix.snap
+++ b/test/snapshots/minga/integration/which_key_test/whichkey_buffer_prefix.snap
@@ -20,9 +20,9 @@
 15│   ~
 16│   ~
 17│╭─────────────────────────────────── SPC b ────────────────────────────────────╮
-18││B : Switch buffer (all)  b : Switch buffer        n : Next buffer             │
-19││N : New buffer           d : Kill buffer          p : Previous buffer         │
-20││W : View warnings        m : View messages                                    │
+18││B : Switch buffer (all)  b : Switch buffer        m : View messages           │
+19││N : New buffer           d : Kill buffer          n : Next buffer             │
+20││W : View warnings        l : Set language         p : Previous buffer         │
 21│╰──────────────────────────────────────────────────────────────────────────────╯
 22│ NORMAL  [no file]                                              Text  1:1  Top
 23│


### PR DESCRIPTION
# TL;DR

Users can change a buffer's language through a fuzzy picker (`SPC b l`), ex commands (`:set ft=python`, `:setf ruby`), or clicking the filetype in the modeline. Syntax highlighting, comment toggling, and per-filetype options update immediately.

Closes #543

## Context

There was no way to manually set a buffer's filetype after opening it. Filetype was detected automatically and locked in. If detection was wrong, or you wanted to view a `.txt` file as JSON, you were stuck. Every editor users compare Minga against has this feature.

## Changes

**New picker source**: `Minga.Picker.LanguageSource` lists all 54 registered languages with devicons, file extensions, and the current language marked with a bullet. Selecting a language calls the shared `apply_filetype_change/2`.

**New buffer API**: `BufferServer.set_filetype/2` updates `state.filetype` and re-seeds per-filetype options (`tab_width`, `indent_with`) via `seed_options/1`.

**Ex commands**: `:set ft=python`, `:set filetype=elixir`, `:setf ruby`, `:setfiletype go` all parse to `{:set_filetype, [name]}`. The name is validated against the Language registry via `String.to_existing_atom/1` to prevent atom table pollution from typos.

**Modeline click**: The `:filetype_menu` click command (which was a TODO stub) now opens the language picker.

**Shared function**: `BufferManagement.apply_filetype_change/2` centralizes the side effects (set filetype, trigger reparse, set status message) so the picker and ex-command paths stay in sync.

## Verification

```bash
mix test --warnings-as-errors   # 5169 tests, 0 failures
mix lint                        # passes

# Specific tests:
mix test test/minga/picker/language_source_test.exs   # 9 tests
mix test test/minga/command/parser_test.exs            # 49 tests
```