### PR TITLE
feat(editor): internal event bus via Registry

### DIFF
--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -9,6 +9,7 @@ defmodule Minga.Application do
   ## Supervision Tree
 
       Minga.Supervisor (rest_for_one)
+      ├── Minga.Events (Registry, :duplicate)
       ├── Minga.Config.Options
       ├── Minga.Keymap.Active
       ├── Minga.Config.Hooks
@@ -45,6 +46,7 @@ defmodule Minga.Application do
 
     base_children = [
       Minga.Language.Registry,
+      Minga.Events,
       Minga.Config.Options,
       Minga.Keymap.Active,
       Minga.Config.Hooks,

--- a/lib/minga/config/hooks.ex
+++ b/lib/minga/config/hooks.ex
@@ -7,6 +7,11 @@ defmodule Minga.Config.Hooks do
   under `Minga.Eval.TaskSupervisor`, so a slow or crashing hook never blocks
   editing.
 
+  Hooks subscribes to the `Minga.Events` bus on startup. When a bus event
+  arrives (e.g. `:buffer_saved`), it maps the topic to the corresponding
+  hook event (`:after_save`) and fires all registered hooks. Direct
+  invocation via `run/2` is still supported for backward compatibility.
+
   ## Supported events
 
   | Event            | Arguments                  | Fires when                |
@@ -22,9 +27,16 @@ defmodule Minga.Config.Hooks do
       end)
   """
 
-  use Agent
+  use GenServer
 
   @valid_events [:after_save, :after_open, :on_mode_change]
+
+  # Maps event bus topics to hook event names.
+  @topic_to_event %{
+    buffer_saved: :after_save,
+    buffer_opened: :after_open,
+    mode_changed: :on_mode_change
+  }
 
   @typedoc "Valid event names."
   @type event :: :after_save | :after_open | :on_mode_change
@@ -34,11 +46,11 @@ defmodule Minga.Config.Hooks do
 
   # ── Client API ──────────────────────────────────────────────────────────────
 
-  @doc "Starts the hooks registry."
-  @spec start_link(keyword()) :: Agent.on_start()
+  @doc "Starts the hooks registry and subscribes to the event bus."
+  @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     {name, _opts} = Keyword.pop(opts, :name, __MODULE__)
-    Agent.start_link(fn -> initial_state() end, name: name)
+    GenServer.start_link(__MODULE__, [], name: name)
   end
 
   @doc """
@@ -53,9 +65,7 @@ defmodule Minga.Config.Hooks do
 
   def register(server, event, fun) when is_atom(event) and is_function(fun) do
     if event in @valid_events do
-      Agent.update(server, fn state ->
-        Map.update!(state, event, &[fun | &1])
-      end)
+      GenServer.call(server, {:register, event, fun})
     else
       {:error, "unknown event: #{inspect(event)}. Valid events: #{inspect(@valid_events)}"}
     end
@@ -65,7 +75,9 @@ defmodule Minga.Config.Hooks do
   Fires all hooks for an event asynchronously.
 
   Each hook runs in a separate Task under `Minga.Eval.TaskSupervisor`.
-  Crashes are logged but don't propagate.
+  Crashes are logged but don't propagate. This is a fire-and-forget cast:
+  it returns `:ok` immediately before hooks are dispatched. Prefer
+  broadcasting through `Minga.Events` over calling this directly.
   """
   @spec run(event(), [term()]) :: :ok
   @spec run(GenServer.server(), event(), [term()]) :: :ok
@@ -73,7 +85,86 @@ defmodule Minga.Config.Hooks do
     do: run(__MODULE__, event, args)
 
   def run(server, event, args) when is_atom(event) and is_list(args) do
-    hooks = Agent.get(server, &Map.get(&1, event, [])) |> Enum.reverse()
+    GenServer.cast(server, {:run, event, args})
+  end
+
+  @doc "Returns the list of valid event names."
+  @spec valid_events() :: [event()]
+  def valid_events, do: @valid_events
+
+  @doc "Removes all registered hooks."
+  @spec reset() :: :ok
+  @spec reset(GenServer.server()) :: :ok
+  def reset, do: reset(__MODULE__)
+
+  def reset(server) do
+    GenServer.call(server, :reset)
+  end
+
+  # ── GenServer callbacks ─────────────────────────────────────────────────────
+
+  @impl true
+  @spec init(keyword()) :: {:ok, state()}
+  def init(_opts) do
+    subscribe_to_events()
+    {:ok, initial_state()}
+  end
+
+  @impl true
+  def handle_call({:register, event, fun}, _from, state) do
+    new_state = Map.update!(state, event, &[fun | &1])
+    {:reply, :ok, new_state}
+  end
+
+  def handle_call(:reset, _from, _state) do
+    {:reply, :ok, initial_state()}
+  end
+
+  @impl true
+  def handle_cast({:run, event, args}, state) do
+    do_run(state, event, args)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:minga_event, topic, payload}, state) do
+    case Map.fetch(@topic_to_event, topic) do
+      {:ok, event} ->
+        args = payload_to_args(topic, payload)
+        do_run(state, event, args)
+
+      :error ->
+        :ok
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  # Guard for test environments where EventBus may not be running.
+  # In production, Events starts before Hooks in the supervision tree.
+  @spec subscribe_to_events() :: :ok
+  defp subscribe_to_events do
+    if Process.whereis(Minga.EventBus) do
+      for topic <- Map.keys(@topic_to_event) do
+        Minga.Events.subscribe(topic)
+      end
+    end
+
+    :ok
+  end
+
+  @spec payload_to_args(Minga.Events.topic(), Minga.Events.payload()) :: [term()]
+  defp payload_to_args(:buffer_saved, %{buffer: buf, path: path}), do: [buf, path]
+  defp payload_to_args(:buffer_opened, %{buffer: buf, path: path}), do: [buf, path]
+  defp payload_to_args(:mode_changed, %{old: old_mode, new: new_mode}), do: [old_mode, new_mode]
+
+  @spec do_run(state(), event(), [term()]) :: :ok
+  defp do_run(state, event, args) do
+    hooks = Map.get(state, event, []) |> Enum.reverse()
 
     for hook <- hooks do
       Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
@@ -94,18 +185,6 @@ defmodule Minga.Config.Hooks do
 
     :ok
   end
-
-  @doc "Returns the list of valid event names."
-  @spec valid_events() :: [event()]
-  def valid_events, do: @valid_events
-
-  @doc "Removes all registered hooks."
-  @spec reset() :: :ok
-  @spec reset(GenServer.server()) :: :ok
-  def reset, do: reset(__MODULE__)
-  def reset(server), do: Agent.update(server, fn _ -> initial_state() end)
-
-  # ── Private ─────────────────────────────────────────────────────────────────
 
   @spec initial_state() :: state()
   defp initial_state do

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -172,7 +172,7 @@ defmodule Minga.Editor do
         new_state = log_message(new_state, "Opened: #{file_path}")
         new_state = BufferLifecycle.lsp_buffer_opened(new_state, pid)
         new_state = BufferLifecycle.git_buffer_opened(new_state, pid)
-        fire_hook(:after_open, [pid, file_path])
+        Minga.Events.broadcast(:buffer_opened, %{buffer: pid, path: file_path})
         new_state = AgentLifecycle.maybe_set_auto_context(new_state, file_path, pid)
         new_state = Renderer.render(new_state)
         {:reply, :ok, new_state}
@@ -923,7 +923,7 @@ defmodule Minga.Editor do
     new_state = log_message(new_state, "Opened: #{path}")
     new_state = BufferLifecycle.lsp_buffer_opened(new_state, pid)
     new_state = BufferLifecycle.git_buffer_opened(new_state, pid)
-    fire_hook(:after_open, [pid, path])
+    Minga.Events.broadcast(:buffer_opened, %{buffer: pid, path: path})
     put_in(new_state.file_tree.tree, FileTree.reveal(tree, path))
   end
 
@@ -1004,15 +1004,6 @@ defmodule Minga.Editor do
   end
 
   # ── Config options ──────────────────────────────────────────────────────
-
-  alias Minga.Config.Hooks, as: ConfigHooks
-
-  @spec fire_hook(ConfigHooks.event(), [term()]) :: :ok
-  defp fire_hook(event, args) do
-    ConfigHooks.run(event, args)
-  catch
-    :exit, _ -> :ok
-  end
 
   # ── Public housekeeping API for Input.Router ───────────────────────────────
 

--- a/lib/minga/editor/buffer_lifecycle.ex
+++ b/lib/minga/editor/buffer_lifecycle.ex
@@ -8,7 +8,7 @@ defmodule Minga.Editor.BufferLifecycle do
   """
 
   alias Minga.Buffer.Server, as: BufferServer
-  alias Minga.Config.Hooks, as: ConfigHooks
+
   alias Minga.Editor.DocumentSync
   alias Minga.Editor.Modeline
   alias Minga.Editor.State, as: EditorState
@@ -123,7 +123,7 @@ defmodule Minga.Editor.BufferLifecycle do
          {:execute_ex_command, {:save_quit, []}}
        ] do
       path = BufferServer.file_path(buf)
-      if path, do: ConfigHooks.run(:after_save, [buf, path])
+      if path, do: Minga.Events.broadcast(:buffer_saved, %{buffer: buf, path: path})
 
       new_lsp = DocumentSync.on_buffer_save(state.lsp, buf)
       %{state | lsp: new_lsp}

--- a/lib/minga/editor/key_dispatch.ex
+++ b/lib/minga/editor/key_dispatch.ex
@@ -11,7 +11,7 @@ defmodule Minga.Editor.KeyDispatch do
 
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Config.Advice, as: ConfigAdvice
-  alias Minga.Config.Hooks, as: ConfigHooks
+
   alias Minga.EditingModel.Vim, as: VimModel
   alias Minga.Editor.BufferLifecycle
   alias Minga.Editor.ChangeTracking
@@ -69,7 +69,7 @@ defmodule Minga.Editor.KeyDispatch do
       if base_state.buffers.active,
         do: BufferServer.break_undo_coalescing(base_state.buffers.active)
 
-      fire_hook(:on_mode_change, [old_mode, new_mode])
+      Minga.Events.broadcast(:mode_changed, %{old: old_mode, new: new_mode})
     end
 
     after_commands =
@@ -134,12 +134,5 @@ defmodule Minga.Editor.KeyDispatch do
     _ -> false
   catch
     :exit, _ -> false
-  end
-
-  @spec fire_hook(ConfigHooks.event(), [term()]) :: :ok
-  defp fire_hook(event, args) do
-    ConfigHooks.run(event, args)
-  catch
-    :exit, _ -> :ok
   end
 end

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -1,0 +1,118 @@
+defmodule Minga.Events do
+  @moduledoc """
+  Internal event bus for cross-component notifications.
+
+  Wraps an Elixir `Registry` in `:duplicate` mode so multiple processes
+  can subscribe to the same topic and receive broadcasts without knowing
+  about each other. The Editor (or any event source) calls `broadcast/2`;
+  subscribers receive the payload in `Registry.dispatch/3` callbacks.
+
+  ## Usage
+
+      # In a subscriber (GenServer init, or any long-lived process):
+      Minga.Events.subscribe(:buffer_saved)
+
+      # In an event source:
+      Minga.Events.broadcast(:buffer_saved, %{buffer: buf, path: path})
+
+  Subscribers receive the event synchronously in the dispatch callback,
+  which runs in the broadcaster's process. For heavy work, subscribers
+  should send themselves a message and handle it asynchronously.
+
+  ## Why Registry?
+
+  `Registry` ships with OTP (no dependencies), supports pattern-based
+  dispatch, and has zero overhead for topics with no subscribers. It is
+  the same primitive that Phoenix.PubSub builds on, without the Phoenix
+  dependency. The wrapper module makes swapping to PubSub or `:pg`
+  a one-file change if distributed events are ever needed.
+  """
+
+  @registry Minga.EventBus
+
+  @typedoc "Known event topics."
+  @type topic ::
+          :buffer_saved
+          | :buffer_opened
+          | :mode_changed
+
+  @typedoc "Event payload. A map with topic-specific keys."
+  @type payload :: map()
+
+  @doc """
+  Returns the child spec for the event bus Registry.
+
+  Add this to your supervision tree before any process that subscribes.
+  """
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(_opts) do
+    Registry.child_spec(keys: :duplicate, name: @registry)
+  end
+
+  @doc """
+  Subscribes the calling process to a topic.
+
+  The process will be included in `Registry.dispatch/3` callbacks when
+  `broadcast/2` is called for this topic. A process can subscribe to
+  multiple topics. Subscribing to the same topic twice is allowed and
+  results in the callback being invoked twice per broadcast.
+  """
+  @spec subscribe(topic()) :: :ok
+  def subscribe(topic) when is_atom(topic) do
+    {:ok, _} = Registry.register(@registry, topic, [])
+    :ok
+  end
+
+  @doc """
+  Subscribes the calling process to a topic with metadata.
+
+  The metadata value is passed to the dispatch callback alongside the pid,
+  which lets subscribers filter or tag their registrations.
+  """
+  @spec subscribe(topic(), term()) :: :ok
+  def subscribe(topic, value) when is_atom(topic) do
+    {:ok, _} = Registry.register(@registry, topic, value)
+    :ok
+  end
+
+  @doc """
+  Broadcasts a payload to all subscribers of a topic.
+
+  Each subscriber's callback receives `{pid, value}` where `value` is
+  whatever was passed to `subscribe/2` (default `[]`). The callback runs
+  in the caller's process, so keep it lightweight. For async work, have
+  the callback send a message to the subscriber pid.
+
+  Returns `:ok`. If no processes are subscribed to the topic, this is a
+  no-op with negligible cost.
+  """
+  @spec broadcast(topic(), payload()) :: :ok
+  def broadcast(topic, payload) when is_atom(topic) and is_map(payload) do
+    Registry.dispatch(@registry, topic, fn entries ->
+      for {pid, _value} <- entries do
+        send(pid, {:minga_event, topic, payload})
+      end
+    end)
+  end
+
+  @doc """
+  Unsubscribes the calling process from a topic.
+
+  Removes all registrations for this process under the given topic key.
+  """
+  @spec unsubscribe(topic()) :: :ok
+  def unsubscribe(topic) when is_atom(topic) do
+    Registry.unregister(@registry, topic)
+  end
+
+  @doc """
+  Returns the list of pids subscribed to a topic.
+
+  Useful for debugging and testing. Not intended for production dispatch
+  (use `broadcast/2` instead).
+  """
+  @spec subscribers(topic()) :: [pid()]
+  def subscribers(topic) when is_atom(topic) do
+    Registry.lookup(@registry, topic) |> Enum.map(fn {pid, _} -> pid end)
+  end
+end

--- a/test/minga/events_test.exs
+++ b/test/minga/events_test.exs
@@ -1,0 +1,150 @@
+defmodule Minga.EventsTest do
+  use ExUnit.Case, async: false
+
+  alias Minga.Config.Hooks
+  alias Minga.Events
+
+  setup do
+    # Start the EventBus Registry if not already running.
+    case Registry.start_link(keys: :duplicate, name: Minga.EventBus) do
+      {:ok, pid} ->
+        on_exit(fn -> Process.exit(pid, :shutdown) end)
+
+      {:error, {:already_started, _}} ->
+        :ok
+    end
+
+    :ok
+  end
+
+  describe "subscribe/1 and broadcast/2" do
+    test "subscriber receives broadcast payload" do
+      Events.subscribe(:buffer_saved)
+      Events.broadcast(:buffer_saved, %{buffer: :fake_buf, path: "/tmp/test.ex"})
+
+      assert_receive {:minga_event, :buffer_saved, %{buffer: :fake_buf, path: "/tmp/test.ex"}}
+    end
+
+    test "multiple subscribers all receive the broadcast" do
+      parent = self()
+
+      pids =
+        for i <- 1..3 do
+          spawn(fn ->
+            Events.subscribe(:buffer_saved)
+            send(parent, {:subscribed, i})
+
+            receive do
+              {:minga_event, :buffer_saved, payload} ->
+                send(parent, {:received, i, payload})
+            end
+          end)
+        end
+
+      # Wait for all to subscribe before broadcasting.
+      for i <- 1..3, do: assert_receive({:subscribed, ^i}, 500)
+
+      Events.broadcast(:buffer_saved, %{buffer: :buf, path: "/test"})
+
+      for i <- 1..3 do
+        assert_receive {:received, ^i, %{buffer: :buf, path: "/test"}}, 500
+      end
+
+      # Clean up spawned processes.
+      for pid <- pids, Process.alive?(pid), do: Process.exit(pid, :kill)
+    end
+
+    test "broadcast with no subscribers is a no-op" do
+      assert :ok = Events.broadcast(:buffer_saved, %{buffer: :buf, path: "/test"})
+      refute_receive {:minga_event, _, _}, 50
+    end
+
+    test "subscribing to different topics only receives matching events" do
+      Events.subscribe(:buffer_opened)
+
+      Events.broadcast(:buffer_saved, %{buffer: :buf, path: "/test"})
+      Events.broadcast(:buffer_opened, %{buffer: :buf, path: "/test"})
+
+      refute_receive {:minga_event, :buffer_saved, _}, 50
+      assert_receive {:minga_event, :buffer_opened, %{buffer: :buf, path: "/test"}}
+    end
+  end
+
+  describe "subscribe/2 with metadata" do
+    test "subscribe with metadata value" do
+      Events.subscribe(:mode_changed, :my_component)
+      Events.broadcast(:mode_changed, %{old: :normal, new: :insert})
+
+      assert_receive {:minga_event, :mode_changed, %{old: :normal, new: :insert}}
+    end
+  end
+
+  describe "unsubscribe/1" do
+    test "unsubscribed process no longer receives broadcasts" do
+      Events.subscribe(:buffer_saved)
+      Events.unsubscribe(:buffer_saved)
+
+      Events.broadcast(:buffer_saved, %{buffer: :buf, path: "/test"})
+
+      refute_receive {:minga_event, :buffer_saved, _}, 50
+    end
+  end
+
+  describe "subscribers/1" do
+    test "returns pids subscribed to a topic" do
+      Events.subscribe(:buffer_saved)
+      assert self() in Events.subscribers(:buffer_saved)
+    end
+
+    test "process not subscribed is not in the subscribers list" do
+      refute self() in Events.subscribers(:buffer_opened)
+    end
+  end
+
+  describe "integration with Config.Hooks" do
+    setup do
+      # Hooks and TaskSupervisor are started by the application.
+      # Reset hooks between tests to avoid cross-test bleed.
+      Hooks.reset()
+      on_exit(fn -> Hooks.reset() end)
+
+      :ok
+    end
+
+    test "hooks fire when event is broadcast through the bus" do
+      test_pid = self()
+
+      Hooks.register(:after_save, fn buf, path ->
+        send(test_pid, {:hook_via_bus, buf, path})
+      end)
+
+      Events.broadcast(:buffer_saved, %{buffer: :my_buf, path: "/via/bus.ex"})
+
+      assert_receive {:hook_via_bus, :my_buf, "/via/bus.ex"}, 500
+    end
+
+    test "mode_changed event triggers on_mode_change hooks" do
+      test_pid = self()
+
+      Hooks.register(:on_mode_change, fn old, new ->
+        send(test_pid, {:mode_hook, old, new})
+      end)
+
+      Events.broadcast(:mode_changed, %{old: :normal, new: :visual})
+
+      assert_receive {:mode_hook, :normal, :visual}, 500
+    end
+
+    test "buffer_opened event triggers after_open hooks" do
+      test_pid = self()
+
+      Hooks.register(:after_open, fn buf, path ->
+        send(test_pid, {:open_hook, buf, path})
+      end)
+
+      Events.broadcast(:buffer_opened, %{buffer: :buf, path: "/opened.ex"})
+
+      assert_receive {:open_hook, :buf, "/opened.ex"}, 500
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

Adds an internal event bus (`Minga.Events`) using Elixir's `Registry` in `:duplicate` mode, replacing manual `fire_hook` / `ConfigHooks.run` wiring. Components subscribe to topics and receive broadcasts without the Editor orchestrating every notification.

Closes #530

## Context

The Editor GenServer handled cross-component notifications manually: after a buffer save it called `ConfigHooks.run(:after_save, ...)`, and each new subscriber required adding wiring code to the Editor. This PR introduces a thin event bus layer so event sources broadcast once and any number of subscribers react independently.

See #589 for future evaluation of Phoenix.PubSub / `:pg` if distributed events are ever needed.

## Changes

- **`lib/minga/events.ex` (new):** Wraps `Registry` with `subscribe/1`, `subscribe/2`, `broadcast/2`, `unsubscribe/1`, and `subscribers/1`. Full `@spec` and `@doc` coverage. The `@type topic` union documents known events (`:buffer_saved`, `:buffer_opened`, `:mode_changed`).

- **`lib/minga/application.ex`:** Added `Minga.Events` to the supervision tree before `Config.Hooks`, so the Registry is available when Hooks starts.

- **`lib/minga/config/hooks.ex`:** Converted from `Agent` to `GenServer`. On init, subscribes to all three event bus topics. When a `{:minga_event, topic, payload}` message arrives, it maps the topic to the legacy hook event name and fires registered hooks via `Task.Supervisor`. Direct `run/2` is preserved (now as a cast) for backward compatibility. `run/2`'s docs note the fire-and-forget semantic.

- **`lib/minga/editor.ex`, `buffer_lifecycle.ex`, `key_dispatch.ex`:** Replaced all `fire_hook` and `ConfigHooks.run` calls with `Minga.Events.broadcast`. Removed the `fire_hook/2` private functions and `ConfigHooks` aliases.

**Design decisions:**
- Registry over Phoenix.PubSub: no new dependency, already used in the project (`CommandOutput.Registry`), local-only (no distributed overhead). The wrapper module makes swapping trivial.
- Hooks converted to GenServer (not kept as Agent) so it can subscribe to the bus and receive messages. The alternative was a separate bridge process, but that added complexity with no benefit.
- `payload_to_args/2` bridge maps structured event payloads (`%{buffer: buf, path: path}`) back to the positional `[buf, path]` lists that existing hook functions expect. This preserves backward compatibility without changing the hook registration API.

## Verification

```bash
# All tests pass (5241 tests, 0 failures)
mix test --warnings-as-errors

# Specific test files
mix test test/minga/events_test.exs test/minga/config/hooks_test.exs

# Lint clean (format + credo --strict + compile --warnings-as-errors + dialyzer)
mix lint
```

## Acceptance Criteria Addressed

- Registry process exists in the supervision tree ✅
- Components can subscribe to topics ✅
- Event sources can broadcast ✅
- At least one existing manual notification migrated as proof of concept ✅ (all three hook events migrated)
- Editor has fewer direct calls to downstream notification targets ✅
- Existing hook and advice systems continue to work ✅