### PR TITLE
feat(buffer): block decorations with DisplayMap and mouse dispatch (#523)

### DIFF
--- a/lib/minga/buffer/decorations.ex
+++ b/lib/minga/buffer/decorations.ex
@@ -37,6 +37,7 @@ defmodule Minga.Buffer.Decorations do
   at once (e.g., agent chat sync or LSP diagnostic refresh).
   """
 
+  alias Minga.Buffer.Decorations.BlockDecoration
   alias Minga.Buffer.Decorations.FoldRegion
   alias Minga.Buffer.Decorations.HighlightRange
   alias Minga.Buffer.Decorations.VirtualText
@@ -72,6 +73,7 @@ defmodule Minga.Buffer.Decorations do
   - `highlights`: interval tree of highlight ranges
   - `virtual_texts`: list of virtual text decorations (queried by line, not range)
   - `fold_regions`: list of buffer-level fold regions (per-buffer, not per-window)
+  - `block_decorations`: list of block decorations (custom-rendered lines between buffer lines)
   - `pending`: list of pending operations during a batch (nil when not batching)
   - `version`: monotonically increasing version for change detection by the render pipeline
   """
@@ -79,6 +81,7 @@ defmodule Minga.Buffer.Decorations do
           highlights: IntervalTree.t(),
           virtual_texts: [VirtualText.t()],
           fold_regions: [FoldRegion.t()],
+          block_decorations: [BlockDecoration.t()],
           pending:
             [{:add, highlight_range()} | {:remove, reference()} | {:remove_group, atom()}] | nil,
           version: non_neg_integer()
@@ -88,6 +91,7 @@ defmodule Minga.Buffer.Decorations do
   defstruct highlights: nil,
             virtual_texts: [],
             fold_regions: [],
+            block_decorations: [],
             pending: nil,
             version: 0
 
@@ -384,6 +388,79 @@ defmodule Minga.Buffer.Decorations do
   def has_fold_regions?(%__MODULE__{fold_regions: []}), do: false
   def has_fold_regions?(%__MODULE__{}), do: true
 
+  # ── Block decoration API ─────────────────────────────────────────────────
+
+  @doc """
+  Adds a block decoration to the buffer. Returns `{id, updated_decorations}`.
+
+  ## Options
+
+  - `:placement` (required) - `:above` or `:below` the anchor line
+  - `:render` (required) - callback `(width -> [{text, style}] | [[{text, style}]])`
+  - `:height` (optional, default 1) - number of display lines, or `:dynamic`
+  - `:on_click` (optional) - callback `(row, col) -> :ok` for interactive blocks
+  - `:priority` (optional, default 0) - ordering when multiple blocks share an anchor
+  """
+  @spec add_block_decoration(t(), non_neg_integer(), keyword()) :: {reference(), t()}
+  def add_block_decoration(%__MODULE__{} = decs, anchor_line, opts) do
+    id = make_ref()
+
+    block = %BlockDecoration{
+      id: id,
+      anchor_line: anchor_line,
+      placement: Keyword.fetch!(opts, :placement),
+      render: Keyword.fetch!(opts, :render),
+      height: Keyword.get(opts, :height, 1),
+      on_click: Keyword.get(opts, :on_click),
+      priority: Keyword.get(opts, :priority, 0)
+    }
+
+    new_blocks = [block | decs.block_decorations]
+    {id, %{decs | block_decorations: new_blocks, version: decs.version + 1}}
+  end
+
+  @doc "Removes a block decoration by ID."
+  @spec remove_block_decoration(t(), reference()) :: t()
+  def remove_block_decoration(%__MODULE__{} = decs, id) do
+    new_blocks = Enum.reject(decs.block_decorations, fn b -> b.id == id end)
+
+    if length(new_blocks) == length(decs.block_decorations) do
+      decs
+    else
+      %{decs | block_decorations: new_blocks, version: decs.version + 1}
+    end
+  end
+
+  @doc """
+  Returns block decorations for a specific anchor line, sorted by priority.
+  Returns `{above, below}` tuple.
+  """
+  @spec blocks_for_line(t(), non_neg_integer()) ::
+          {above :: [BlockDecoration.t()], below :: [BlockDecoration.t()]}
+  def blocks_for_line(%__MODULE__{block_decorations: []}, _line), do: {[], []}
+
+  def blocks_for_line(%__MODULE__{block_decorations: blocks}, line) do
+    line_blocks =
+      blocks
+      |> Enum.filter(fn b -> b.anchor_line == line end)
+      |> Enum.sort_by(fn b -> b.priority end)
+
+    above = Enum.filter(line_blocks, fn b -> b.placement == :above end)
+    below = Enum.filter(line_blocks, fn b -> b.placement == :below end)
+    {above, below}
+  end
+
+  @doc "Returns true if there are any block decorations."
+  @spec has_block_decorations?(t()) :: boolean()
+  def has_block_decorations?(%__MODULE__{block_decorations: []}), do: false
+  def has_block_decorations?(%__MODULE__{}), do: true
+
+  @doc "Returns the block decoration with the given ID, or nil."
+  @spec block_decoration_by_id(t(), reference()) :: BlockDecoration.t() | nil
+  def block_decoration_by_id(%__MODULE__{block_decorations: blocks}, id) do
+    Enum.find(blocks, fn b -> b.id == id end)
+  end
+
   # ── Column mapping (inline virtual text) ─────────────────────────────────
 
   @doc """
@@ -575,10 +652,21 @@ defmodule Minga.Buffer.Decorations do
   Returns true if there are no decorations of any kind.
   """
   @spec empty?(t()) :: boolean()
-  def empty?(%__MODULE__{highlights: nil, virtual_texts: [], fold_regions: []}), do: true
+  def empty?(%__MODULE__{
+        highlights: nil,
+        virtual_texts: [],
+        fold_regions: [],
+        block_decorations: []
+      }),
+      do: true
 
-  def empty?(%__MODULE__{highlights: hl, virtual_texts: vts, fold_regions: folds}) do
-    (hl == nil or IntervalTree.empty?(hl)) and vts == [] and folds == []
+  def empty?(%__MODULE__{
+        highlights: hl,
+        virtual_texts: vts,
+        fold_regions: folds,
+        block_decorations: blocks
+      }) do
+    (hl == nil or IntervalTree.empty?(hl)) and vts == [] and folds == [] and blocks == []
   end
 
   # ── Anchor adjustment ───────────────────────────────────────────────────
@@ -606,7 +694,8 @@ defmodule Minga.Buffer.Decorations do
           IntervalTree.position()
         ) :: t()
   def adjust_for_edit(%__MODULE__{} = decs, _edit_start, _edit_end, _new_end)
-      when decs.highlights == nil and decs.virtual_texts == [] and decs.fold_regions == [],
+      when decs.highlights == nil and decs.virtual_texts == [] and decs.fold_regions == [] and
+             decs.block_decorations == [],
       do: decs
 
   def adjust_for_edit(%__MODULE__{} = decs, edit_start, edit_end, new_end) do
@@ -629,11 +718,14 @@ defmodule Minga.Buffer.Decorations do
     new_vts = adjust_virtual_texts(decs.virtual_texts, ctx)
     new_folds = adjust_fold_regions(decs.fold_regions, ctx)
 
+    new_blocks = adjust_block_decorations(decs.block_decorations, ctx)
+
     %{
       decs
       | highlights: new_highlights,
         virtual_texts: new_vts,
         fold_regions: new_folds,
+        block_decorations: new_blocks,
         version: decs.version + 1
     }
   end
@@ -662,6 +754,35 @@ defmodule Minga.Buffer.Decorations do
   defp adjust_anchor_position(_anchor, ctx), do: ctx.new_end
 
   @spec adjust_fold_regions([FoldRegion.t()], edit_ctx()) :: [FoldRegion.t()]
+  @spec adjust_block_decorations([BlockDecoration.t()], edit_ctx()) :: [BlockDecoration.t()]
+  defp adjust_block_decorations([], _ctx), do: []
+
+  defp adjust_block_decorations(blocks, ctx) do
+    {edit_start_line, _} = ctx.edit_start
+    {edit_end_line, _} = ctx.edit_end
+
+    Enum.map(blocks, fn block ->
+      adjust_block_anchor(block, edit_start_line, edit_end_line, ctx.line_delta)
+    end)
+  end
+
+  @spec adjust_block_anchor(BlockDecoration.t(), non_neg_integer(), non_neg_integer(), integer()) ::
+          BlockDecoration.t()
+  defp adjust_block_anchor(block, _edit_start, edit_end, line_delta)
+       when block.anchor_line > edit_end do
+    %{block | anchor_line: block.anchor_line + line_delta}
+  end
+
+  defp adjust_block_anchor(block, edit_start, _edit_end, _line_delta)
+       when block.anchor_line < edit_start do
+    block
+  end
+
+  defp adjust_block_anchor(block, edit_start, _edit_end, _line_delta) do
+    # Block anchor is within the edited region: clamp to edit start
+    %{block | anchor_line: edit_start}
+  end
+
   defp adjust_fold_regions([], _ctx), do: []
 
   defp adjust_fold_regions(folds, ctx) do

--- a/lib/minga/buffer/decorations/block_decoration.ex
+++ b/lib/minga/buffer/decorations/block_decoration.ex
@@ -1,0 +1,101 @@
+defmodule Minga.Buffer.Decorations.BlockDecoration do
+  @moduledoc """
+  A block decoration: fully custom-rendered lines injected between buffer lines.
+
+  Block decorations produce styled content from a render callback. That content
+  is inserted into the display line stream at an anchor position. They scroll
+  with the buffer, occupy display rows, and participate in viewport height
+  calculations, but have no buffer line number and no gutter.
+
+  This is the equivalent of Zed's `BlockProperties` (message headers, image
+  previews, slash command output in the AI chat).
+
+  ## Render callback
+
+  The render callback receives the available width and returns styled content
+  in one of three forms:
+
+  - `[{text, style}]` — single-line block (most common: headers, separators)
+  - `[[{text, style}]]` — multi-line block (list of segment lists, one per row)
+  - `[DisplayList.draw()]` — raw draw tuples for maximum control
+
+  The content renderer normalizes the first two forms into draw tuples
+  positioned at the correct screen rows.
+
+  ## Height
+
+  Set `height` to an explicit integer for blocks with a known, stable height.
+  Set `height` to `:dynamic` for blocks whose height depends on the render
+  callback output. Dynamic heights are resolved by invoking the callback
+  during DisplayMap construction. The callback is cached per block per frame,
+  so it's only called once regardless of height.
+  """
+
+  @enforce_keys [:id, :anchor_line, :placement, :render]
+  defstruct id: nil,
+            anchor_line: 0,
+            placement: :above,
+            height: 1,
+            render: nil,
+            on_click: nil,
+            priority: 0
+
+  @typedoc "Render callback: receives available width, returns styled content."
+  @type render_fn :: (width :: pos_integer() -> render_result())
+
+  @typedoc """
+  Result from a render callback.
+
+  - `[{text, style}]` — single-line block
+  - `[[{text, style}]]` — multi-line block (list of lines, each a list of segments)
+  """
+  @type render_result :: [{String.t(), keyword()}] | [[{String.t(), keyword()}]]
+
+  @typedoc "Click callback: receives row offset within block and column."
+  @type click_fn :: (row :: non_neg_integer(), col :: non_neg_integer() -> :ok) | nil
+
+  @type t :: %__MODULE__{
+          id: reference(),
+          anchor_line: non_neg_integer(),
+          placement: :above | :below,
+          height: pos_integer() | :dynamic,
+          render: render_fn(),
+          on_click: click_fn(),
+          priority: integer()
+        }
+
+  @doc """
+  Returns the height of the block decoration in display lines.
+
+  For explicit heights, returns the stored value. For `:dynamic` heights,
+  invokes the render callback with the given width to determine the height
+  from the result.
+  """
+  @spec resolve_height(t(), pos_integer()) :: pos_integer()
+  def resolve_height(%__MODULE__{height: :dynamic, render: render_fn}, width) do
+    result = render_fn.(width)
+    compute_height(result)
+  end
+
+  def resolve_height(%__MODULE__{height: h}, _width) when is_integer(h), do: h
+
+  @doc """
+  Normalizes the render callback result into a list of segment lists
+  (one per display line).
+  """
+  @spec normalize_render_result(render_result()) :: [[{String.t(), keyword()}]]
+  def normalize_render_result([]), do: [[]]
+
+  def normalize_render_result([[_ | _] | _] = multi_line), do: multi_line
+
+  def normalize_render_result([{text, _style} | _] = single_line) when is_binary(text) do
+    [single_line]
+  end
+
+  def normalize_render_result(_other), do: [[]]
+
+  @spec compute_height(render_result()) :: pos_integer()
+  defp compute_height([[_ | _] | _] = multi_line), do: length(multi_line)
+  defp compute_height([{text, _} | _]) when is_binary(text), do: 1
+  defp compute_height(_), do: 1
+end

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -544,6 +544,23 @@ defmodule Minga.Buffer.Server do
     GenServer.call(server, {:remove_virtual_text, id})
   end
 
+  @doc """
+  Adds a block decoration to the buffer.
+
+  Returns the decoration ID for later removal.
+  See `Minga.Buffer.Decorations.add_block_decoration/3` for options.
+  """
+  @spec add_block_decoration(GenServer.server(), non_neg_integer(), keyword()) :: reference()
+  def add_block_decoration(server, anchor_line, opts) do
+    GenServer.call(server, {:add_block_decoration, anchor_line, opts})
+  end
+
+  @doc "Removes a block decoration by ID."
+  @spec remove_block_decoration(GenServer.server(), reference()) :: :ok
+  def remove_block_decoration(server, id) do
+    GenServer.call(server, {:remove_block_decoration, id})
+  end
+
   @doc "Returns the decorations struct for read-only access (e.g., by the render pipeline)."
   @spec decorations(GenServer.server()) :: Decorations.t()
   def decorations(server) do
@@ -1236,6 +1253,16 @@ defmodule Minga.Buffer.Server do
 
   def handle_call({:remove_virtual_text, id}, _from, state) do
     decs = Decorations.remove_virtual_text(state.decorations, id)
+    {:reply, :ok, %{state | decorations: decs}}
+  end
+
+  def handle_call({:add_block_decoration, anchor_line, opts}, _from, state) do
+    {id, decs} = Decorations.add_block_decoration(state.decorations, anchor_line, opts)
+    {:reply, id, %{state | decorations: decs}}
+  end
+
+  def handle_call({:remove_block_decoration, id}, _from, state) do
+    decs = Decorations.remove_block_decoration(state.decorations, id)
     {:reply, :ok, %{state | decorations: decs}}
   end
 

--- a/lib/minga/editor/commands/folding.ex
+++ b/lib/minga/editor/commands/folding.ex
@@ -2,8 +2,9 @@ defmodule Minga.Editor.Commands.Folding do
   @moduledoc """
   Fold commands: toggle, open, close, open all, close all.
 
-  All commands operate on the active window's fold state. The fold map
-  and available fold ranges live in the Window struct, not the buffer.
+  Operates on both per-window folds (code folds from `FoldMap`) and
+  per-buffer decoration folds (from `Decorations`). Per-window folds
+  take precedence when both types exist at the cursor line.
   """
 
   alias Minga.Buffer.Decorations
@@ -28,34 +29,34 @@ defmodule Minga.Editor.Commands.Folding do
   """
   @spec execute(state(), fold_command()) :: state()
   def execute(state, :fold_toggle) do
-    # Per-window folds take precedence. If the cursor is on a per-window
-    # fold, toggle that. Otherwise check for a decoration fold.
     case EditorState.active_window_struct(state) do
       nil -> state
-      window -> toggle_fold_at_cursor(state, window)
+      window -> dispatch_fold_command(state, window, :toggle)
     end
   end
 
   def execute(state, :fold_close) do
-    update_active_window(state, fn window ->
-      {cursor_line, _col} = window.cursor
-      Window.fold_at(window, cursor_line)
-    end)
+    case EditorState.active_window_struct(state) do
+      nil -> state
+      window -> dispatch_fold_command(state, window, :close)
+    end
   end
 
   def execute(state, :fold_open) do
-    update_active_window(state, fn window ->
-      {cursor_line, _col} = window.cursor
-      Window.unfold_at(window, cursor_line)
-    end)
+    case EditorState.active_window_struct(state) do
+      nil -> state
+      window -> dispatch_fold_command(state, window, :open)
+    end
   end
 
   def execute(state, :fold_close_all) do
-    update_active_window(state, &Window.fold_all/1)
+    state = update_active_window(state, &Window.fold_all/1)
+    close_all_decoration_folds(state)
   end
 
   def execute(state, :fold_open_all) do
-    update_active_window(state, &Window.unfold_all/1)
+    state = update_active_window(state, &Window.unfold_all/1)
+    open_all_decoration_folds(state)
   end
 
   # ── Private ────────────────────────────────────────────────────────────────
@@ -67,33 +68,91 @@ defmodule Minga.Editor.Commands.Folding do
 
   defp update_active_window(state, _fun), do: state
 
-  @spec toggle_fold_at_cursor(state(), Window.t()) :: state()
-  defp toggle_fold_at_cursor(state, window) do
+  # Dispatches a fold command at the cursor line. Per-window folds take
+  # precedence. If no per-window fold exists, falls back to decoration folds.
+  @spec dispatch_fold_command(state(), Window.t(), :toggle | :close | :open) :: state()
+  defp dispatch_fold_command(state, window, action) do
     {cursor_line, _col} = window.cursor
 
     case FoldMap.fold_at(window.fold_map, cursor_line) do
       {:ok, _range} ->
-        update_active_window(state, fn w -> Window.toggle_fold(w, cursor_line) end)
+        apply_window_fold(state, window, cursor_line, action)
 
       :none ->
-        toggle_decoration_fold_on_buffer(window.buffer)
-        state
+        apply_decoration_fold(state, window.buffer, cursor_line, action)
     end
   end
 
-  @spec toggle_decoration_fold_on_buffer(pid()) :: :ok
-  defp toggle_decoration_fold_on_buffer(buf) do
-    {cursor_line, _} = BufferServer.cursor(buf)
+  @spec apply_window_fold(state(), Window.t(), non_neg_integer(), :toggle | :close | :open) ::
+          state()
+  defp apply_window_fold(state, _window, cursor_line, :toggle) do
+    update_active_window(state, fn w -> Window.toggle_fold(w, cursor_line) end)
+  end
+
+  defp apply_window_fold(state, _window, cursor_line, :close) do
+    update_active_window(state, fn w -> Window.fold_at(w, cursor_line) end)
+  end
+
+  defp apply_window_fold(state, _window, cursor_line, :open) do
+    update_active_window(state, fn w -> Window.unfold_at(w, cursor_line) end)
+  end
+
+  @spec apply_decoration_fold(state(), pid(), non_neg_integer(), :toggle | :close | :open) ::
+          state()
+  defp apply_decoration_fold(state, buf, cursor_line, action) do
     decs = BufferServer.decorations(buf)
 
     case Decorations.fold_region_at(decs, cursor_line) do
-      nil ->
-        :ok
-
-      fold ->
-        BufferServer.batch_decorations(buf, fn d -> Decorations.toggle_fold_region(d, fold.id) end)
+      nil -> state
+      fold -> maybe_toggle_decoration(state, buf, fold, action)
     end
   catch
-    :exit, _ -> :ok
+    :exit, _ -> state
+  end
+
+  defp maybe_toggle_decoration(state, buf, %{id: id, closed: closed}, action) do
+    should_act = should_toggle?(action, closed)
+
+    if should_act do
+      BufferServer.batch_decorations(buf, fn d -> Decorations.toggle_fold_region(d, id) end)
+    end
+
+    state
+  end
+
+  defp should_toggle?(:toggle, _closed), do: true
+  defp should_toggle?(:close, closed), do: not closed
+  defp should_toggle?(:open, closed), do: closed
+
+  @spec close_all_decoration_folds(state()) :: state()
+  defp close_all_decoration_folds(state) do
+    set_all_decoration_folds(state, :close)
+  end
+
+  @spec open_all_decoration_folds(state()) :: state()
+  defp open_all_decoration_folds(state) do
+    set_all_decoration_folds(state, :open)
+  end
+
+  defp set_all_decoration_folds(state, direction) do
+    buf = state.buffers.active
+
+    BufferServer.batch_decorations(buf, fn decs ->
+      Enum.reduce(decs.fold_regions, decs, fn fold, d ->
+        toggle_if_needed(d, fold, direction)
+      end)
+    end)
+
+    state
+  catch
+    :exit, _ -> state
+  end
+
+  defp toggle_if_needed(decs, fold, :close) do
+    if fold.closed, do: decs, else: Decorations.toggle_fold_region(decs, fold.id)
+  end
+
+  defp toggle_if_needed(decs, fold, :open) do
+    if fold.closed, do: Decorations.toggle_fold_region(decs, fold.id), else: decs
   end
 end

--- a/lib/minga/editor/display_map.ex
+++ b/lib/minga/editor/display_map.ex
@@ -3,8 +3,9 @@ defmodule Minga.Editor.DisplayMap do
   Unified buffer-line-to-display-row mapping.
 
   Merges per-window folds (`FoldMap`), per-buffer decoration folds
-  (`Decorations.FoldRegion`), and virtual lines (`Decorations.VirtualText`
-  with `:above`/`:below` placement) into a single authoritative mapping.
+  (`Decorations.FoldRegion`), virtual lines (`Decorations.VirtualText`
+  with `:above`/`:below` placement), and block decorations into a single
+  authoritative mapping.
 
   The DisplayMap is the single source of truth for translating between
   buffer line numbers and screen row positions. It replaces
@@ -16,8 +17,7 @@ defmodule Minga.Editor.DisplayMap do
   1. Per-window `FoldMap` folds (code folds, per-window)
   2. Per-buffer decoration folds (closed fold regions from `Decorations`)
   3. Virtual lines from decorations (`:above`/`:below`)
-
-  Block decoration heights (#523) will be added in a future PR.
+  4. Block decorations (custom-rendered lines between buffer lines)
 
   The map produces a list of `entry()` tuples describing what to render
   at each display row, compatible with the existing content rendering
@@ -25,6 +25,7 @@ defmodule Minga.Editor.DisplayMap do
   """
 
   alias Minga.Buffer.Decorations
+  alias Minga.Buffer.Decorations.BlockDecoration
   alias Minga.Buffer.Decorations.FoldRegion
   alias Minga.Buffer.Decorations.VirtualText
   alias Minga.Editor.FoldMap
@@ -37,12 +38,14 @@ defmodule Minga.Editor.DisplayMap do
   - `{buf_line, {:fold_start, hidden_count}}` — render with fold summary
   - `{buf_line, {:decoration_fold, fold_region}}` — render with custom placeholder
   - `{buf_line, {:virtual_line, virtual_text}}` — render a virtual line (no buffer line)
+  - `{buf_line, {:block, block_decoration, line_index}}` — render a block decoration row
   """
   @type entry ::
           {non_neg_integer(), :normal}
           | {non_neg_integer(), {:fold_start, pos_integer()}}
           | {non_neg_integer(), {:decoration_fold, FoldRegion.t()}}
           | {non_neg_integer(), {:virtual_line, VirtualText.t()}}
+          | {non_neg_integer(), {:block, BlockDecoration.t(), non_neg_integer()}}
 
   @typedoc "The computed display map for a viewport."
   @type t :: %__MODULE__{
@@ -54,43 +57,65 @@ defmodule Minga.Editor.DisplayMap do
   defstruct entries: [],
             total_display_lines: 0
 
+  # Frame-level constants bundled to avoid threading 5+ args through every
+  # recursive call. Only `buf_line`, `remaining`, and `acc` change per step.
+  @typep build_ctx :: %{
+           fold_map: FoldMap.t(),
+           dec_folds: [FoldRegion.t()],
+           decorations: Decorations.t(),
+           total_lines: non_neg_integer(),
+           content_width: pos_integer()
+         }
+
   @doc """
   Computes the display map for a viewport.
 
-  Merges per-window folds, decoration folds, and virtual lines into a
-  unified list of display entries.
-
-  Returns `nil` when there are no folds, decoration folds, or virtual
-  lines, signaling the caller to use the faster sequential path.
+  Returns `nil` when there are no folds, decoration folds, virtual lines,
+  or block decorations, signaling the caller to use the faster sequential path.
 
   ## Arguments
 
   - `fold_map` — per-window `FoldMap` (code folds)
-  - `decorations` — per-buffer `Decorations` (decoration folds + virtual lines)
+  - `decorations` — per-buffer `Decorations`
   - `first_buf_line` — first buffer line to display (from viewport scroll)
   - `visible_rows` — number of screen rows available
   - `total_lines` — total lines in the buffer
+  - `content_width` — available width for block decoration render callbacks (default 80)
   """
-  @spec compute(FoldMap.t(), Decorations.t(), non_neg_integer(), pos_integer(), non_neg_integer()) ::
-          t() | nil
-  def compute(fold_map, decorations, first_buf_line, visible_rows, total_lines) do
+  @spec compute(
+          FoldMap.t(),
+          Decorations.t(),
+          non_neg_integer(),
+          pos_integer(),
+          non_neg_integer(),
+          pos_integer()
+        ) :: t() | nil
+  def compute(
+        fold_map,
+        decorations,
+        first_buf_line,
+        visible_rows,
+        total_lines,
+        content_width \\ 80
+      ) do
     has_window_folds = not FoldMap.empty?(fold_map)
     closed_dec_folds = Decorations.closed_fold_regions(decorations)
     has_virtual_lines = has_virtual_lines?(decorations)
+    has_blocks = Decorations.has_block_decorations?(decorations)
 
-    if not has_window_folds and closed_dec_folds == [] and not has_virtual_lines do
+    if not has_window_folds and closed_dec_folds == [] and not has_virtual_lines and
+         not has_blocks do
       nil
     else
-      entries =
-        build_entries(
-          fold_map,
-          closed_dec_folds,
-          decorations,
-          first_buf_line,
-          visible_rows,
-          total_lines,
-          []
-        )
+      ctx = %{
+        fold_map: fold_map,
+        dec_folds: closed_dec_folds,
+        decorations: decorations,
+        total_lines: total_lines,
+        content_width: content_width
+      }
+
+      entries = build_entries(ctx, first_buf_line, visible_rows, [])
 
       %__MODULE__{
         entries: entries,
@@ -99,50 +124,28 @@ defmodule Minga.Editor.DisplayMap do
     end
   end
 
-  @doc """
-  Returns the buffer line range needed to fetch all visible lines.
+  # ── Public query API ─────────────────────────────────────────────────────
 
-  Used to request the right slice from the buffer.
-  """
+  @doc "Returns the buffer line range needed to fetch all visible lines."
   @spec buffer_range(t()) :: {non_neg_integer(), non_neg_integer()} | nil
   def buffer_range(%__MODULE__{entries: []}), do: nil
 
   def buffer_range(%__MODULE__{entries: entries}) do
-    buf_lines =
-      entries
-      |> Enum.map(fn {line, _} -> line end)
-      |> Enum.uniq()
-
+    buf_lines = entries |> Enum.map(fn {line, _} -> line end) |> Enum.uniq()
     {Enum.min(buf_lines), Enum.max(buf_lines)}
   end
 
-  @doc """
-  Converts the display map entries to the format expected by
-  `ContentHelpers.render_lines_nowrap_folded/3`.
-
-  Returns a list compatible with `FoldMap.VisibleLines.line_entry()`.
-  Virtual lines and decoration folds are included as additional entry types.
-  """
+  @doc "Returns the entry list for the content renderer."
   @spec to_visible_line_map(t()) :: [entry()]
   def to_visible_line_map(%__MODULE__{entries: entries}), do: entries
 
-  @doc """
-  Returns the display row for a given buffer line, or nil if the line
-  is hidden by a fold.
-  """
+  @doc "Returns the display row for a buffer line, or nil if hidden."
   @spec display_row_for_buf_line(t(), non_neg_integer()) :: non_neg_integer() | nil
   def display_row_for_buf_line(%__MODULE__{entries: entries}, buf_line) do
-    Enum.find_index(entries, fn
-      {line, :normal} -> line == buf_line
-      {line, {:fold_start, _}} -> line == buf_line
-      {line, {:decoration_fold, _}} -> line == buf_line
-      _ -> false
-    end)
+    Enum.find_index(entries, fn {line, type} -> line == buf_line and buffer_line_entry?(type) end)
   end
 
-  @doc """
-  Returns the buffer line at the given display row.
-  """
+  @doc "Returns the buffer line at the given display row."
   @spec buf_line_for_display_row(t(), non_neg_integer()) :: non_neg_integer() | nil
   def buf_line_for_display_row(%__MODULE__{entries: entries}, display_row) do
     case Enum.at(entries, display_row) do
@@ -151,29 +154,19 @@ defmodule Minga.Editor.DisplayMap do
     end
   end
 
-  @doc """
-  Returns the next visible buffer line after the given buffer line.
-
-  Skips over lines hidden by folds (both per-window and decoration).
-  Falls back to `FoldMap.next_visible/2` when no DisplayMap is available.
-  """
+  @doc "Returns the next visible buffer line after the given line."
   @spec next_visible_line(t(), non_neg_integer()) :: non_neg_integer()
   def next_visible_line(%__MODULE__{entries: entries}, line) do
-    # Find the entry after the one for `line`
-    idx = Enum.find_index(entries, fn {l, type} -> l == line and type != {:virtual_line, nil} end)
+    idx = Enum.find_index(entries, fn {l, type} -> l == line and buffer_line_entry?(type) end)
 
     case idx do
       nil ->
-        # Line not in current viewport entries, return line + 1
         line + 1
 
       i ->
-        # Find the next entry that's a real buffer line (not a virtual line)
         entries
         |> Enum.drop(i + 1)
-        |> Enum.find(fn {_l, type} ->
-          type != {:virtual_line, nil} and not match?({:virtual_line, _}, type)
-        end)
+        |> Enum.find(fn {_l, type} -> buffer_line_entry?(type) end)
         |> case do
           nil -> line + 1
           {next_line, _} -> next_line
@@ -181,18 +174,10 @@ defmodule Minga.Editor.DisplayMap do
     end
   end
 
-  @doc """
-  Returns the previous visible buffer line before the given buffer line.
-
-  Skips over lines hidden by folds. Falls back to `FoldMap.prev_visible/2`
-  when no DisplayMap is available.
-  """
+  @doc "Returns the previous visible buffer line before the given line."
   @spec prev_visible_line(t(), non_neg_integer()) :: non_neg_integer()
   def prev_visible_line(%__MODULE__{entries: entries}, line) do
-    idx =
-      Enum.find_index(entries, fn {l, type} ->
-        l == line and not match?({:virtual_line, _}, type)
-      end)
+    idx = Enum.find_index(entries, fn {l, type} -> l == line and buffer_line_entry?(type) end)
 
     case idx do
       nil ->
@@ -205,7 +190,7 @@ defmodule Minga.Editor.DisplayMap do
         entries
         |> Enum.take(i)
         |> Enum.reverse()
-        |> Enum.find(fn {_l, type} -> not match?({:virtual_line, _}, type) end)
+        |> Enum.find(fn {_l, type} -> buffer_line_entry?(type) end)
         |> case do
           nil -> max(line - 1, 0)
           {prev_line, _} -> prev_line
@@ -213,16 +198,10 @@ defmodule Minga.Editor.DisplayMap do
     end
   end
 
-  @doc """
-  Computes the total number of display lines for the entire buffer
-  (not just the viewport). Used for scrollbar calculations.
-  """
-  @spec total_display_lines(
-          FoldMap.t(),
-          Decorations.t(),
+  @doc "Total display lines for the entire buffer (scrollbar calculations)."
+  @spec total_display_lines(FoldMap.t(), Decorations.t(), non_neg_integer(), pos_integer()) ::
           non_neg_integer()
-        ) :: non_neg_integer()
-  def total_display_lines(fold_map, decorations, total_buf_lines) do
+  def total_display_lines(fold_map, decorations, total_buf_lines, content_width \\ 80) do
     window_hidden =
       FoldMap.folds(fold_map)
       |> Enum.reduce(0, fn f, acc -> acc + (f.end_line - f.start_line) end)
@@ -233,117 +212,134 @@ defmodule Minga.Editor.DisplayMap do
 
     virt_lines = Decorations.virtual_line_count(decorations, 0, total_buf_lines)
 
-    max(total_buf_lines - window_hidden - dec_hidden + virt_lines, 0)
+    all_folds = FoldMap.folds(fold_map) ++ Decorations.closed_fold_regions(decorations)
+
+    block_rows =
+      decorations.block_decorations
+      |> Enum.reject(fn b -> line_inside_fold?(b.anchor_line, all_folds) end)
+      |> Enum.reduce(0, fn b, acc -> acc + BlockDecoration.resolve_height(b, content_width) end)
+
+    max(total_buf_lines - window_hidden - dec_hidden + virt_lines + block_rows, 0)
   end
 
-  # ── Private ──────────────────────────────────────────────────────────────
+  # ── Private: entry classification ────────────────────────────────────────
+
+  # Returns true for entry types that represent real buffer lines (cursor targets).
+  # Virtual lines and block decorations are not cursor targets.
+  @spec buffer_line_entry?(term()) :: boolean()
+  defp buffer_line_entry?(:normal), do: true
+  defp buffer_line_entry?({:fold_start, _}), do: true
+  defp buffer_line_entry?({:decoration_fold, _}), do: true
+  defp buffer_line_entry?(_), do: false
 
   @spec has_virtual_lines?(Decorations.t()) :: boolean()
   defp has_virtual_lines?(%Decorations{virtual_texts: vts}) do
     Enum.any?(vts, fn %VirtualText{placement: p} -> p in [:above, :below] end)
   end
 
-  @spec build_entries(
-          FoldMap.t(),
-          [FoldRegion.t()],
-          Decorations.t(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer(),
-          [entry()]
-        ) :: [entry()]
-  defp build_entries(_fm, _dec_folds, _decs, _buf_line, 0, _total, acc) do
-    Enum.reverse(acc)
-  end
+  # ── Private: entry building ──────────────────────────────────────────────
 
-  defp build_entries(_fm, _dec_folds, _decs, buf_line, _remaining, total, acc)
+  @spec build_entries(build_ctx(), non_neg_integer(), non_neg_integer(), [entry()]) :: [entry()]
+  defp build_entries(_ctx, _buf_line, 0, acc), do: Enum.reverse(acc)
+
+  defp build_entries(%{total_lines: total}, buf_line, _remaining, acc)
        when buf_line >= total do
     Enum.reverse(acc)
   end
 
-  defp build_entries(fm, dec_folds, decs, buf_line, remaining, total, acc) do
-    # Query virtual lines once for this buffer line
-    {above_vts, below_vts} = Decorations.virtual_lines_for_line(decs, buf_line)
+  defp build_entries(ctx, buf_line, remaining, acc) do
+    {above_vts, below_vts} = Decorations.virtual_lines_for_line(ctx.decorations, buf_line)
+    {above_blocks, below_blocks} = Decorations.blocks_for_line(ctx.decorations, buf_line)
 
-    {acc, remaining} =
-      Enum.reduce(above_vts, {acc, remaining}, fn vt, {a, r} ->
-        if r > 0 do
-          {[{buf_line, {:virtual_line, vt}} | a], r - 1}
-        else
-          {a, r}
-        end
-      end)
+    {acc, remaining} = append_block_entries(acc, above_blocks, buf_line, remaining, ctx)
+    {acc, remaining} = append_vt_entries(acc, above_vts, buf_line, remaining)
 
     if remaining <= 0 do
       Enum.reverse(acc)
     else
-      # Classify what's at this buffer line and handle it
-      handle_buf_line(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc)
+      below = {below_vts, below_blocks}
+      classify_line(ctx, buf_line, below, remaining, acc)
     end
   end
 
-  # Classifies and handles a single buffer line: window fold, decoration fold, or normal.
-  @spec handle_buf_line(
-          FoldMap.t(),
-          [FoldRegion.t()],
-          Decorations.t(),
+  # Classify what's at a buffer line: window fold, decoration fold, or normal.
+  @spec classify_line(
+          build_ctx(),
           non_neg_integer(),
-          [VirtualText.t()],
-          non_neg_integer(),
+          {[VirtualText.t()], [BlockDecoration.t()]},
           non_neg_integer(),
           [entry()]
         ) :: [entry()]
-  defp handle_buf_line(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc) do
-    case FoldMap.fold_at(fm, buf_line) do
+  defp classify_line(ctx, buf_line, below, remaining, acc) do
+    case FoldMap.fold_at(ctx.fold_map, buf_line) do
       {:ok, %FoldRange{start_line: ^buf_line, end_line: end_line}} ->
-        # Window fold start: emit fold entry, append below virtual lines, skip to after fold
-        hidden = end_line - buf_line
-        entry = {buf_line, {:fold_start, hidden}}
-        {acc, remaining} = append_vt_entries([entry | acc], below_vts, buf_line, remaining - 1)
-        build_entries(fm, dec_folds, decs, end_line + 1, remaining, total, acc)
+        entry = {buf_line, {:fold_start, end_line - buf_line}}
+        {acc, remaining} = append_below([entry | acc], below, buf_line, remaining - 1, ctx)
+        build_entries(ctx, end_line + 1, remaining, acc)
 
       {:ok, %FoldRange{end_line: end_line}} ->
-        build_entries(fm, dec_folds, decs, end_line + 1, remaining, total, acc)
+        build_entries(ctx, end_line + 1, remaining, acc)
 
       :none ->
-        handle_no_window_fold(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc)
+        classify_no_window_fold(ctx, buf_line, below, remaining, acc)
     end
   end
 
-  defp handle_no_window_fold(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc) do
-    case find_dec_fold(dec_folds, buf_line) do
+  defp classify_no_window_fold(ctx, buf_line, below, remaining, acc) do
+    case find_dec_fold(ctx.dec_folds, buf_line) do
       %FoldRegion{start_line: ^buf_line} = fold ->
         entry = {buf_line, {:decoration_fold, fold}}
-        {acc, remaining} = append_vt_entries([entry | acc], below_vts, buf_line, remaining - 1)
-        build_entries(fm, dec_folds, decs, fold.end_line + 1, remaining, total, acc)
+        {acc, remaining} = append_below([entry | acc], below, buf_line, remaining - 1, ctx)
+        build_entries(ctx, fold.end_line + 1, remaining, acc)
 
       _ ->
-        handle_normal_line(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc)
+        entry = {buf_line, :normal}
+        {acc, remaining} = append_below([entry | acc], below, buf_line, remaining - 1, ctx)
+        build_entries(ctx, buf_line + 1, remaining, acc)
     end
   end
 
-  defp handle_normal_line(fm, dec_folds, decs, buf_line, below_vts, remaining, total, acc) do
-    entry = {buf_line, :normal}
-    {acc, remaining} = append_vt_entries([entry | acc], below_vts, buf_line, remaining - 1)
-    build_entries(fm, dec_folds, decs, buf_line + 1, remaining, total, acc)
+  # ── Private: append helpers ──────────────────────────────────────────────
+
+  defp append_below(acc, {below_vts, below_blocks}, buf_line, remaining, ctx) do
+    {acc, remaining} = append_vt_entries(acc, below_vts, buf_line, remaining)
+    append_block_entries(acc, below_blocks, buf_line, remaining, ctx)
   end
 
-  @spec append_vt_entries([entry()], [VirtualText.t()], non_neg_integer(), non_neg_integer()) ::
-          {[entry()], non_neg_integer()}
   defp append_vt_entries(acc, [], _buf_line, remaining), do: {acc, remaining}
 
-  defp append_vt_entries(acc, below_vts, buf_line, remaining) do
-    Enum.reduce(below_vts, {acc, remaining}, fn vt, {a, r} ->
-      if r > 0 do
-        {[{buf_line, {:virtual_line, vt}} | a], r - 1}
-      else
-        {a, r}
-      end
+  defp append_vt_entries(acc, vts, buf_line, remaining) do
+    Enum.reduce(vts, {acc, remaining}, fn vt, {a, r} ->
+      if r > 0, do: {[{buf_line, {:virtual_line, vt}} | a], r - 1}, else: {a, r}
     end)
   end
 
-  @spec find_dec_fold([FoldRegion.t()], non_neg_integer()) :: FoldRegion.t() | nil
+  defp append_block_entries(acc, [], _buf_line, remaining, _ctx), do: {acc, remaining}
+
+  defp append_block_entries(acc, blocks, buf_line, remaining, ctx) do
+    Enum.reduce(blocks, {acc, remaining}, fn block, {a, r} ->
+      append_single_block(a, block, buf_line, r, ctx.content_width)
+    end)
+  end
+
+  defp append_single_block(acc, block, buf_line, remaining, content_width) do
+    height = BlockDecoration.resolve_height(block, content_width)
+
+    Enum.reduce(0..(height - 1), {acc, remaining}, fn line_idx, {a, r} ->
+      if r > 0, do: {[{buf_line, {:block, block, line_idx}} | a], r - 1}, else: {a, r}
+    end)
+  end
+
+  # ── Private: lookups ─────────────────────────────────────────────────────
+
   defp find_dec_fold(dec_folds, line) do
     Enum.find(dec_folds, fn fold -> fold.start_line == line end)
+  end
+
+  defp line_inside_fold?(line, folds) do
+    Enum.any?(folds, fn
+      %FoldRange{start_line: s, end_line: e} -> line > s and line <= e
+      %FoldRegion{start_line: s, end_line: e} -> line > s and line <= e
+    end)
   end
 end

--- a/lib/minga/editor/mouse.ex
+++ b/lib/minga/editor/mouse.ex
@@ -30,6 +30,8 @@ defmodule Minga.Editor.Mouse do
   alias Minga.Buffer.Decorations
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Buffer.Unicode
+  alias Minga.Editor.DisplayMap
+  alias Minga.Editor.FoldMap
   alias Minga.Editor.Layout
   alias Minga.Editor.Renderer.Gutter
   alias Minga.Editor.State, as: EditorState
@@ -692,15 +694,24 @@ defmodule Minga.Editor.Mouse do
 
     case Layout.active_window_layout(layout, state) do
       %{content: {win_row, win_col, content_w, win_h}} ->
+        window = EditorState.active_window_struct(state)
         total_lines = BufferServer.line_count(buf)
         gutter_w = gutter_width(state, total_lines)
         {cursor_line, _} = BufferServer.cursor(buf)
         scroll_top = render_scroll_top(win_h, content_w, cursor_line, buf)
         local_row = row - win_row
         local_col = max(col - win_col - gutter_w, 0) + scroll_left(state, buf)
-        target_line = local_row + scroll_top
 
-        resolve_buffer_pos(buf, local_row, win_h, target_line, local_col, total_lines)
+        resolve_with_display_map(
+          buf,
+          window,
+          local_row,
+          local_col,
+          scroll_top,
+          win_h,
+          content_w,
+          total_lines
+        )
 
       nil ->
         nil
@@ -724,13 +735,116 @@ defmodule Minga.Editor.Mouse do
         scroll_top = render_scroll_top(content_h, content_w, cursor_line, buf)
         local_row = row - win_row
         local_col = max(col - win_col - gutter_w, 0)
-        target_line = local_row + scroll_top
 
-        resolve_buffer_pos(buf, local_row, content_h, target_line, local_col, total_lines)
+        resolve_with_display_map(
+          buf,
+          window,
+          local_row,
+          local_col,
+          scroll_top,
+          content_h,
+          content_w,
+          total_lines
+        )
 
       :error ->
         nil
     end
+  end
+
+  # Resolves a click position using the DisplayMap to correctly handle
+  # block decorations, virtual lines, and folds. If the clicked display
+  # row is a block decoration, dispatches on_click and returns nil.
+  @spec resolve_with_display_map(
+          pid(),
+          Window.t() | nil,
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pos_integer(),
+          pos_integer(),
+          non_neg_integer()
+        ) :: {non_neg_integer(), non_neg_integer()} | nil
+  defp resolve_with_display_map(
+         buf,
+         window,
+         local_row,
+         local_col,
+         scroll_top,
+         win_h,
+         content_w,
+         total_lines
+       ) do
+    decs = BufferServer.decorations(buf)
+    fold_map = if window, do: window.fold_map, else: FoldMap.new()
+
+    case DisplayMap.compute(fold_map, decs, scroll_top, win_h, total_lines, content_w) do
+      nil ->
+        # No display map needed, use direct line mapping
+        target_line = local_row + scroll_top
+        resolve_buffer_pos(buf, local_row, win_h, target_line, local_col, total_lines)
+
+      %DisplayMap{} = dm ->
+        # Look up what's at this display row
+        case DisplayMap.buf_line_for_display_row(dm, local_row) do
+          nil ->
+            nil
+
+          target_line ->
+            entry = Enum.at(dm.entries, local_row)
+
+            handle_display_row_click(
+              entry,
+              buf,
+              local_row,
+              local_col,
+              win_h,
+              target_line,
+              total_lines
+            )
+        end
+    end
+  catch
+    :exit, _ ->
+      target_line = local_row + scroll_top
+      resolve_buffer_pos(buf, local_row, win_h, target_line, local_col, total_lines)
+  end
+
+  defp handle_display_row_click(
+         {_line, {:block, block, line_idx}},
+         _buf,
+         _row,
+         col,
+         _win_h,
+         _target,
+         _total
+       ) do
+    if block.on_click, do: block.on_click.(line_idx, col)
+    nil
+  end
+
+  defp handle_display_row_click(
+         {_line, {:virtual_line, _}},
+         _buf,
+         _row,
+         _col,
+         _win_h,
+         _target,
+         _total
+       ) do
+    nil
+  end
+
+  defp handle_display_row_click(
+         _entry,
+         buf,
+         local_row,
+         local_col,
+         win_h,
+         target_line,
+         total_lines
+       ) do
+    resolve_buffer_pos(buf, local_row, win_h, target_line, local_col, total_lines)
   end
 
   defp resolve_buffer_pos(_buf, row, visible_rows, _line, _col, _total)

--- a/lib/minga/editor/render_pipeline/content_helpers.ex
+++ b/lib/minga/editor/render_pipeline/content_helpers.ex
@@ -229,6 +229,21 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
             c_cmds = render_virtual_line_entry(vt, screen_row, gutter_w, row_off, col_off)
             {g, prepend_all(c, c_cmds), win}
 
+          {:block, block, line_idx} ->
+            # Block decoration: invoke render callback, draw the line_idx-th row
+            c_cmds =
+              render_block_entry(
+                block,
+                line_idx,
+                screen_row,
+                gutter_w,
+                ctx.content_w,
+                row_off,
+                col_off
+              )
+
+            {g, prepend_all(c, c_cmds), win}
+
           {:decoration_fold, %FoldRegion{placeholder: placeholder} = fold}
           when placeholder != nil ->
             # Decoration fold with custom placeholder: invoke the callback
@@ -265,7 +280,18 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
         end
       end)
 
+    # Clean up per-frame block render cache from process dictionary
+    clear_block_render_cache()
+
     {Enum.reverse(gutters), Enum.reverse(contents_rev), length(visible_line_map), window}
+  end
+
+  defp clear_block_render_cache do
+    Process.get_keys()
+    |> Enum.each(fn
+      {:block_render_cache, _} = key -> Process.delete(key)
+      _ -> :ok
+    end)
   end
 
   @spec fold_display_text(String.t(), term()) :: String.t()
@@ -278,6 +304,7 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   end
 
   defp fold_display_text(_text, {:virtual_line, _vt}), do: ""
+  defp fold_display_text(_text, {:block, _, _}), do: ""
 
   @spec fold_gutter_indicator(
           term(),
@@ -297,6 +324,7 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   end
 
   defp fold_gutter_indicator({:virtual_line, _}, _screen_row, _row_off, _col_off), do: []
+  defp fold_gutter_indicator({:block, _, _}, _screen_row, _row_off, _col_off), do: []
 
   @spec render_folded_line(
           Window.t(),
@@ -431,6 +459,47 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
           non_neg_integer()
         ) :: [DisplayList.draw()]
   defp render_placeholder_segments(segments, screen_row, gutter_w, row_off, col_off) do
+    row = screen_row + row_off
+
+    {draws, _col} =
+      Enum.reduce(segments, {[], gutter_w + col_off}, fn {text, style}, {acc, col} ->
+        width = Unicode.display_width(text)
+        draw = DisplayList.draw(row, col, text, style)
+        {[draw | acc], col + width}
+      end)
+
+    Enum.reverse(draws)
+  end
+
+  # Renders a single row of a block decoration by invoking its render callback
+  # and extracting the line_idx-th row from the result.
+  @spec render_block_entry(
+          Decorations.BlockDecoration.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [DisplayList.draw()]
+  defp render_block_entry(block, line_idx, screen_row, gutter_w, content_w, row_off, col_off) do
+    # Cache render callback result per block ID to avoid re-invoking
+    # for each line_idx of a multi-line block.
+    cache_key = {:block_render_cache, block.id}
+
+    lines =
+      case Process.get(cache_key) do
+        nil ->
+          result = block.render.(content_w)
+          normalized = Decorations.BlockDecoration.normalize_render_result(result)
+          Process.put(cache_key, normalized)
+          normalized
+
+        cached ->
+          cached
+      end
+
+    segments = Enum.at(lines, line_idx, [])
     row = screen_row + row_off
 
     {draws, _col} =

--- a/lib/minga/editor/render_pipeline/scroll.ex
+++ b/lib/minga/editor/render_pipeline/scroll.ex
@@ -207,7 +207,14 @@ defmodule Minga.Editor.RenderPipeline.Scroll do
     decorations = fetch_decorations(window.buffer)
 
     visible_line_map =
-      case DisplayMap.compute(fold_map, decorations, first_line, visible_rows, line_count_approx) do
+      case DisplayMap.compute(
+             fold_map,
+             decorations,
+             first_line,
+             visible_rows,
+             line_count_approx,
+             content_width
+           ) do
         nil ->
           # No decoration folds or virtual lines. Use the existing VisibleLines
           # for per-window folds (or nil for the no-fold fast path).

--- a/test/minga/buffer/block_decoration_test.exs
+++ b/test/minga/buffer/block_decoration_test.exs
@@ -1,0 +1,460 @@
+defmodule Minga.Buffer.BlockDecorationTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Decorations
+  alias Minga.Buffer.Decorations.BlockDecoration
+  alias Minga.Editor.DisplayMap
+  alias Minga.Editor.FoldMap
+  alias Minga.Editor.FoldRange
+
+  # ── CRUD ─────────────────────────────────────────────────────────────────
+
+  describe "add_block_decoration/3" do
+    test "adds a block decoration and returns its ID" do
+      decs = Decorations.new()
+
+      {id, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :above,
+          render: fn _w -> [{"▎ Agent", [fg: 0x51AFEF, bold: true]}] end
+        )
+
+      assert is_reference(id)
+      assert Decorations.has_block_decorations?(decs)
+    end
+
+    test "adds multiple blocks to same anchor line" do
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :above,
+          render: fn _w -> [{"header", []}] end,
+          priority: 1
+        )
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :below,
+          render: fn _w -> [{"separator", []}] end,
+          priority: 2
+        )
+
+      {above, below} = Decorations.blocks_for_line(decs, 5)
+      assert length(above) == 1
+      assert length(below) == 1
+    end
+
+    test "increments version" do
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 0,
+          placement: :above,
+          render: fn _w -> [{"x", []}] end
+        )
+
+      assert decs.version == 1
+    end
+  end
+
+  describe "remove_block_decoration/2" do
+    test "removes by ID" do
+      decs = Decorations.new()
+
+      {id, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :above,
+          render: fn _w -> [{"x", []}] end
+        )
+
+      decs = Decorations.remove_block_decoration(decs, id)
+      refute Decorations.has_block_decorations?(decs)
+    end
+
+    test "no-op for non-existent ID" do
+      decs = Decorations.new()
+
+      {_id, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :above,
+          render: fn _w -> [{"x", []}] end
+        )
+
+      decs2 = Decorations.remove_block_decoration(decs, make_ref())
+      assert Decorations.has_block_decorations?(decs2)
+      assert decs2.version == decs.version
+    end
+  end
+
+  # ── BlockDecoration struct ──────────────────────────────────────────────
+
+  describe "resolve_height/2" do
+    test "explicit height returns stored value" do
+      block = %BlockDecoration{
+        id: make_ref(),
+        anchor_line: 0,
+        placement: :above,
+        height: 3,
+        render: fn _w -> [[{"line1", []}], [{"line2", []}], [{"line3", []}]] end
+      }
+
+      assert BlockDecoration.resolve_height(block, 80) == 3
+    end
+
+    test "dynamic height invokes callback and measures result" do
+      block = %BlockDecoration{
+        id: make_ref(),
+        anchor_line: 0,
+        placement: :above,
+        height: :dynamic,
+        render: fn _w -> [[{"line1", []}], [{"line2", []}]] end
+      }
+
+      assert BlockDecoration.resolve_height(block, 80) == 2
+    end
+
+    test "dynamic single-line returns 1" do
+      block = %BlockDecoration{
+        id: make_ref(),
+        anchor_line: 0,
+        placement: :above,
+        height: :dynamic,
+        render: fn _w -> [{"single", []}] end
+      }
+
+      assert BlockDecoration.resolve_height(block, 80) == 1
+    end
+  end
+
+  describe "normalize_render_result/1" do
+    test "single-line segments wrapped in list" do
+      result = BlockDecoration.normalize_render_result([{"hello", [bold: true]}])
+      assert result == [[{"hello", [bold: true]}]]
+    end
+
+    test "multi-line segments returned as-is" do
+      input = [[{"line1", []}], [{"line2", []}]]
+      assert BlockDecoration.normalize_render_result(input) == input
+    end
+
+    test "empty list returns empty line" do
+      assert BlockDecoration.normalize_render_result([]) == [[]]
+    end
+  end
+
+  # ── DisplayMap integration ──────────────────────────────────────────────
+
+  describe "DisplayMap with block decorations" do
+    test "block above appears before the buffer line" do
+      fm = FoldMap.new()
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :above,
+          render: fn _w -> [{"▎ Agent", []}] end
+        )
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+      assert dm != nil
+
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      block_idx =
+        Enum.find_index(entries, fn {_, type} -> match?({:block, _, _}, type) end)
+
+      normal_5_idx =
+        Enum.find_index(entries, fn
+          {5, :normal} -> true
+          _ -> false
+        end)
+
+      assert block_idx != nil
+      assert block_idx < normal_5_idx
+    end
+
+    test "block below appears after the buffer line" do
+      fm = FoldMap.new()
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :below,
+          render: fn _w -> [{"separator", []}] end
+        )
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      block_idx =
+        Enum.find_index(entries, fn {_, type} -> match?({:block, _, _}, type) end)
+
+      normal_5_idx =
+        Enum.find_index(entries, fn
+          {5, :normal} -> true
+          _ -> false
+        end)
+
+      assert block_idx > normal_5_idx
+    end
+
+    test "multi-line block occupies multiple display rows" do
+      fm = FoldMap.new()
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 3,
+          placement: :above,
+          height: 3,
+          render: fn _w -> [[{"line1", []}], [{"line2", []}], [{"line3", []}]] end
+        )
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      block_entries =
+        Enum.filter(entries, fn {_, type} -> match?({:block, _, _}, type) end)
+
+      assert length(block_entries) == 3
+
+      # Each entry has a different line_index
+      indices = Enum.map(block_entries, fn {_, {:block, _, idx}} -> idx end)
+      assert indices == [0, 1, 2]
+    end
+
+    test "block inside closed fold is hidden" do
+      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(5, 10))
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 7,
+          placement: :above,
+          render: fn _w -> [{"hidden", []}] end
+        )
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      block_entries =
+        Enum.filter(entries, fn {_, type} -> match?({:block, _, _}, type) end)
+
+      # Block at line 7 is inside fold 5-10, so it should be hidden
+      assert block_entries == []
+    end
+
+    test "above block on fold start line remains visible when fold is closed" do
+      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(5, 10))
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :above,
+          render: fn _w -> [{"▎ Agent", [bold: true]}] end
+        )
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      # The block above line 5 should be visible even though the fold hides 6-10
+      block_entries =
+        Enum.filter(entries, fn {_, type} -> match?({:block, _, _}, type) end)
+
+      assert length(block_entries) == 1
+      {5, {:block, _, 0}} = hd(block_entries)
+
+      # And line 5 shows as fold start
+      fold_entries =
+        Enum.filter(entries, fn {_, type} -> match?({:fold_start, _}, type) end)
+
+      assert length(fold_entries) == 1
+    end
+
+    test "next_visible_line skips block entries" do
+      fm = FoldMap.new()
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :above,
+          render: fn _w -> [{"header", []}] end
+        )
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+
+      # Line 4 → next should be 5 (skipping the block entry)
+      assert DisplayMap.next_visible_line(dm, 4) == 5
+      # Line 5 → next should be 6 (block is above 5, doesn't affect forward nav)
+      assert DisplayMap.next_visible_line(dm, 5) == 6
+    end
+
+    test "prev_visible_line skips block entries" do
+      fm = FoldMap.new()
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :below,
+          render: fn _w -> [{"separator", []}] end
+        )
+
+      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+
+      # Line 6 → prev should be 5 (skipping the block below 5)
+      assert DisplayMap.prev_visible_line(dm, 6) == 5
+    end
+
+    test "block consumes display rows" do
+      fm = FoldMap.new()
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 0,
+          placement: :above,
+          render: fn _w -> [{"header", []}] end
+        )
+
+      dm = DisplayMap.compute(fm, decs, 0, 10, 20)
+      entries = DisplayMap.to_visible_line_map(dm)
+
+      # 10 display rows: 1 block + 9 normal lines (0-8)
+      assert length(entries) == 10
+    end
+  end
+
+  # ── Anchor adjustment ───────────────────────────────────────────────────
+
+  describe "anchor adjustment for block decorations" do
+    test "insertion before anchor shifts it" do
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 10,
+          placement: :above,
+          render: fn _w -> [{"header", []}] end
+        )
+
+      decs = Decorations.adjust_for_edit(decs, {5, 0}, {5, 0}, {8, 0})
+      block = hd(decs.block_decorations)
+      assert block.anchor_line == 13
+    end
+
+    test "deletion after anchor leaves it unchanged" do
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :above,
+          render: fn _w -> [{"header", []}] end
+        )
+
+      decs = Decorations.adjust_for_edit(decs, {10, 0}, {15, 0}, {10, 0})
+      block = hd(decs.block_decorations)
+      assert block.anchor_line == 5
+    end
+
+    test "deletion spanning anchor clamps to edit start" do
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 10,
+          placement: :above,
+          render: fn _w -> [{"header", []}] end
+        )
+
+      decs = Decorations.adjust_for_edit(decs, {5, 0}, {15, 0}, {5, 0})
+      block = hd(decs.block_decorations)
+      assert block.anchor_line == 5
+    end
+  end
+
+  # ── Render callback ─────────────────────────────────────────────────────
+
+  describe "render callback invocation" do
+    test "callback receives available width" do
+      :persistent_term.put(:test_block_width, nil)
+
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 0,
+          placement: :above,
+          render: fn w ->
+            :persistent_term.put(:test_block_width, w)
+            [{"header", []}]
+          end
+        )
+
+      # Invoke the render callback directly to verify it receives width
+      block = hd(decs.block_decorations)
+      block.render.(80)
+      assert :persistent_term.get(:test_block_width) == 80
+    after
+      :persistent_term.erase(:test_block_width)
+    end
+  end
+
+  # ── on_click dispatch ────────────────────────────────────────────────────
+
+  describe "on_click field" do
+    test "on_click callback is stored and callable" do
+      test_pid = self()
+
+      decs = Decorations.new()
+
+      {_id, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :above,
+          render: fn _w -> [{"clickable", []}] end,
+          on_click: fn row, col -> send(test_pid, {:block_clicked, row, col}) end
+        )
+
+      block = hd(decs.block_decorations)
+      block.on_click.(0, 15)
+
+      assert_receive {:block_clicked, 0, 15}
+    end
+
+    test "on_click is nil by default" do
+      decs = Decorations.new()
+
+      {_id, decs} =
+        Decorations.add_block_decoration(decs, 5,
+          placement: :above,
+          render: fn _w -> [{"header", []}] end
+        )
+
+      block = hd(decs.block_decorations)
+      assert block.on_click == nil
+    end
+  end
+
+  # ── empty? integration ─────────────────────────────────────────────────
+
+  describe "empty? with block decorations" do
+    test "not empty with only block decorations" do
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 0,
+          placement: :above,
+          render: fn _w -> [{"x", []}] end
+        )
+
+      refute Decorations.empty?(decs)
+    end
+
+    test "clear removes block decorations" do
+      decs = Decorations.new()
+
+      {_, decs} =
+        Decorations.add_block_decoration(decs, 0,
+          placement: :above,
+          render: fn _w -> [{"x", []}] end
+        )
+
+      decs = Decorations.clear(decs)
+      assert Decorations.empty?(decs)
+    end
+  end
+end


### PR DESCRIPTION
## What

PR 4 of the decoration epic. Adds block decorations: custom-rendered display lines injected between buffer lines. This is the equivalent of Zed's `BlockProperties` for agent chat message headers, tool call blocks, separators, and interactive UI elements.

### New module

**`Minga.Buffer.Decorations.BlockDecoration`**: Struct with anchor line, placement (above/below), explicit height, render callback, optional on_click callback, and priority ordering.

### Key features

- **DisplayMap integration**: Block entries appear at correct display rows, above blocks before anchor line, below after. Multi-line blocks produce one entry per row. Blocks inside closed folds are hidden. Above blocks on fold start lines remain visible.
- **Lazy render callbacks**: Invoked during the render pass, cached per block ID per frame to avoid redundant calls for multi-line blocks.
- **Mouse on_click dispatch**: `resolve_with_display_map` computes the DisplayMap for click position, dispatches `on_click(line_idx, col)` for block rows, returns nil (no cursor positioning on decoration rows).
- **Cursor skipping**: `buffer_line_entry?` helper ensures `next_visible_line`/`prev_visible_line` skip both virtual lines and block decoration entries.
- **Anchor adjustment**: Block anchors shift on buffer edits (insert shifts, delete clamps to edit start).

### Testing

23 tests covering CRUD, DisplayMap integration (ordering, multi-line, fold hiding, fold-start visibility, row budget), anchor adjustment, render callback invocation, on_click dispatch, empty?/clear.

### PR stack

1. ~~`#520` Highlight ranges~~ ✅
2. ~~`#521` Virtual text~~ ✅
3. ~~`#522` Fold regions + DisplayMap~~ ✅
4. **`#523` Block decorations** ← this PR
5. `#532` Migrate search highlighting
6. `#524` Refactor agent chat

Closes #523