### PR TITLE
refactor(editor): migrate fire-and-forget buffer-open side effects to event bus

### DIFF
--- a/lib/minga/config/hooks.ex
+++ b/lib/minga/config/hooks.ex
@@ -144,14 +144,10 @@ defmodule Minga.Config.Hooks do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
-  # Guard for test environments where EventBus may not be running.
-  # In production, Events starts before Hooks in the supervision tree.
   @spec subscribe_to_events() :: :ok
   defp subscribe_to_events do
-    if Process.whereis(Minga.EventBus) do
-      for topic <- Map.keys(@topic_to_event) do
-        Minga.Events.subscribe(topic)
-      end
+    for topic <- Map.keys(@topic_to_event) do
+      Minga.Events.subscribe(topic)
     end
 
     :ok

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -46,7 +46,6 @@ defmodule Minga.Editor do
 
   alias Minga.Port.Manager, as: PortManager
 
-  alias Minga.Project
   @typedoc "Options for starting the editor."
   @type start_opt ::
           {:name, GenServer.name()}
@@ -165,9 +164,6 @@ defmodule Minga.Editor do
   def handle_call({:open_file, file_path}, _from, state) do
     case Commands.start_buffer(file_path) do
       {:ok, pid} ->
-        FileWatcherHelpers.maybe_watch_buffer(pid)
-        maybe_detect_project(file_path)
-        maybe_record_file(file_path)
         new_state = Commands.add_buffer(state, pid)
         new_state = log_message(new_state, "Opened: #{file_path}")
         new_state = BufferLifecycle.lsp_buffer_opened(new_state, pid)
@@ -870,22 +866,6 @@ defmodule Minga.Editor do
   @spec dispatch_command(state(), Mode.command()) :: state()
   defdelegate dispatch_command(state, cmd), to: KeyDispatch
 
-  # ── Project detection ───────────────────────────────────────────────────────
-
-  @spec maybe_detect_project(String.t()) :: :ok
-  defp maybe_detect_project(file_path) do
-    Project.detect_and_set(file_path)
-  catch
-    :exit, _ -> :ok
-  end
-
-  @spec maybe_record_file(String.t()) :: :ok
-  defp maybe_record_file(file_path) do
-    Project.record_file(file_path)
-  catch
-    :exit, _ -> :ok
-  end
-
   # ── Paste event routing ───────────────────────────────────────────────────
 
   @spec handle_paste_event(state(), String.t()) :: state()
@@ -915,9 +895,6 @@ defmodule Minga.Editor do
   @doc false
   @spec do_file_tree_open(state(), pid(), String.t(), FileTree.t()) :: state()
   def do_file_tree_open(state, pid, path, tree) do
-    FileWatcherHelpers.maybe_watch_buffer(pid)
-    maybe_detect_project(path)
-    maybe_record_file(path)
     new_state = Commands.add_buffer(state, pid)
     new_state = log_message(new_state, "Opened: #{path}")
     new_state = BufferLifecycle.lsp_buffer_opened(new_state, pid)

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -59,7 +59,10 @@ defmodule Minga.Events do
   """
   @spec subscribe(topic()) :: :ok
   def subscribe(topic) when is_atom(topic) do
-    {:ok, _} = Registry.register(@registry, topic, [])
+    if Process.whereis(@registry) do
+      {:ok, _} = Registry.register(@registry, topic, [])
+    end
+
     :ok
   end
 
@@ -71,7 +74,10 @@ defmodule Minga.Events do
   """
   @spec subscribe(topic(), term()) :: :ok
   def subscribe(topic, value) when is_atom(topic) do
-    {:ok, _} = Registry.register(@registry, topic, value)
+    if Process.whereis(@registry) do
+      {:ok, _} = Registry.register(@registry, topic, value)
+    end
+
     :ok
   end
 

--- a/lib/minga/file_watcher.ex
+++ b/lib/minga/file_watcher.ex
@@ -80,6 +80,9 @@ defmodule Minga.FileWatcher do
     debounce_ms = Keyword.get(opts, :debounce_ms, @default_debounce_ms)
     subscriber = Keyword.get(opts, :subscriber)
 
+    # Subscribe to buffer-open events so we automatically watch new files.
+    Minga.Events.subscribe(:buffer_opened)
+
     state = %__MODULE__{
       subscriber: subscriber,
       debounce_ms: debounce_ms
@@ -96,17 +99,7 @@ defmodule Minga.FileWatcher do
   end
 
   def handle_call({:watch_path, path}, _from, %__MODULE__{} = state) do
-    dir = Path.dirname(path)
-
-    new_dirs =
-      Map.update(state.watched_dirs, dir, 1, &(&1 + 1))
-
-    new_files = MapSet.put(state.watched_files, path)
-
-    new_watcher = ensure_watcher(state.watcher, new_dirs)
-
-    {:reply, :ok,
-     %__MODULE__{state | watched_dirs: new_dirs, watched_files: new_files, watcher: new_watcher}}
+    {:reply, :ok, do_watch_path(state, path)}
   end
 
   def handle_call({:unwatch_path, path}, _from, %__MODULE__{} = state) do
@@ -158,11 +151,24 @@ defmodule Minga.FileWatcher do
     {:noreply, %__MODULE__{state | subscriber: nil}}
   end
 
+  def handle_info({:minga_event, :buffer_opened, %{path: path}}, %__MODULE__{} = state) do
+    {:noreply, do_watch_path(state, Path.expand(path))}
+  end
+
   def handle_info(_msg, %__MODULE__{} = state) do
     {:noreply, state}
   end
 
   # ── Private helpers ─────────────────────────────────────────────────────────
+
+  @spec do_watch_path(state(), String.t()) :: state()
+  defp do_watch_path(%__MODULE__{} = state, path) do
+    dir = Path.dirname(path)
+    new_dirs = Map.update(state.watched_dirs, dir, 1, &(&1 + 1))
+    new_files = MapSet.put(state.watched_files, path)
+    new_watcher = ensure_watcher(state.watcher, new_dirs)
+    %__MODULE__{state | watched_dirs: new_dirs, watched_files: new_files, watcher: new_watcher}
+  end
 
   @spec ensure_watcher(pid() | nil, %{String.t() => pos_integer()}) :: pid() | nil
   defp ensure_watcher(existing_watcher, dirs) when map_size(dirs) == 0 do

--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -141,6 +141,10 @@ defmodule Minga.Project do
   @impl true
   @spec init(keyword()) :: {:ok, t()}
   def init(_opts) do
+    # Subscribe to buffer-open events so we detect projects and record
+    # recent files automatically, without the Editor wiring it up.
+    Minga.Events.subscribe(:buffer_opened)
+
     known = load_known_projects()
     recent = if persist_recent_files?(), do: load_recent_files(), else: %{}
     {:ok, %__MODULE__{known_projects: known, recent_files: recent}}
@@ -172,23 +176,7 @@ defmodule Minga.Project do
   @impl true
   @spec handle_cast(term(), t()) :: {:noreply, t()}
   def handle_cast({:detect_and_set, file_path}, state) do
-    case Detector.detect(file_path) do
-      {:ok, root, type} ->
-        if root == state.current_root do
-          {:noreply, state}
-        else
-          state =
-            state
-            |> set_project(root, type)
-            |> add_to_known(root)
-            |> start_rebuild()
-
-          {:noreply, state}
-        end
-
-      :none ->
-        {:noreply, state}
-    end
+    {:noreply, do_detect_and_set(state, file_path)}
   end
 
   def handle_cast({:switch, root_path}, state) do
@@ -230,23 +218,7 @@ defmodule Minga.Project do
   end
 
   def handle_cast({:record_file, file_path}, state) do
-    expanded = Path.expand(file_path)
-    root = state.current_root
-
-    case make_relative(expanded, root) do
-      nil ->
-        {:noreply, state}
-
-      rel_path ->
-        limit = recent_files_limit()
-        existing = Map.get(state.recent_files, root, [])
-        updated = [rel_path | Enum.reject(existing, &(&1 == rel_path))]
-        updated = Enum.take(updated, limit)
-        new_recent = Map.put(state.recent_files, root, updated)
-        state = %{state | recent_files: new_recent}
-        if persist_recent_files?(), do: persist_recent_files(new_recent)
-        {:noreply, state}
-    end
+    {:noreply, do_record_file(state, file_path)}
   end
 
   def handle_cast({:remove, root_path}, state) do
@@ -279,11 +251,58 @@ defmodule Minga.Project do
     {:noreply, %{state | rebuilding?: false, rebuild_ref: nil}}
   end
 
+  def handle_info({:minga_event, :buffer_opened, %{path: path}}, state) do
+    state = do_detect_and_set(state, path)
+    state = do_record_file(state, path)
+    {:noreply, state}
+  end
+
   def handle_info(_msg, state) do
     {:noreply, state}
   end
 
   # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec do_detect_and_set(t(), String.t()) :: t()
+  defp do_detect_and_set(state, file_path) do
+    case Detector.detect(file_path) do
+      {:ok, root, type} ->
+        if root == state.current_root do
+          state
+        else
+          state
+          |> set_project(root, type)
+          |> add_to_known(root)
+          |> start_rebuild()
+        end
+
+      :none ->
+        state
+    end
+  end
+
+  @spec do_record_file(t(), String.t()) :: t()
+  defp do_record_file(%{current_root: nil} = state, _file_path), do: state
+
+  defp do_record_file(state, file_path) do
+    expanded = Path.expand(file_path)
+    root = state.current_root
+
+    case make_relative(expanded, root) do
+      nil ->
+        state
+
+      rel_path ->
+        limit = recent_files_limit()
+        existing = Map.get(state.recent_files, root, [])
+        updated = [rel_path | Enum.reject(existing, &(&1 == rel_path))]
+        updated = Enum.take(updated, limit)
+        new_recent = Map.put(state.recent_files, root, updated)
+        state = %{state | recent_files: new_recent}
+        if persist_recent_files?(), do: persist_recent_files(new_recent)
+        state
+    end
+  end
 
   @spec set_project(t(), String.t(), Detector.project_type() | nil) :: t()
   defp set_project(state, root, type) do


### PR DESCRIPTION
# TL;DR

FileWatcher and Project now subscribe to `:buffer_opened` on the event bus instead of being called inline from the Editor. Removes three private helpers from editor.ex and centralizes the `Process.whereis` guard in `Events.subscribe/1`.

Closes #593

## Context

Stacked on #592. The event bus foundation and git buffer extraction proved the pattern works. This PR migrates the three fire-and-forget side effects that run when a buffer opens: file watching, project detection, and recent file recording.

`AgentLifecycle.maybe_set_auto_context` stays inline because it modifies Editor state. Extracting agent state to its own process is a separate effort.

## Changes

- **`lib/minga/file_watcher.ex`:** Subscribes to `:buffer_opened` in init. Extracts `do_watch_path/2` private function. Handles event in `handle_info`.
- **`lib/minga/project.ex`:** Subscribes to `:buffer_opened` in init. Extracts `do_detect_and_set/2` and `do_record_file/2` private functions. Handles event in `handle_info`.
- **`lib/minga/editor.ex`:** Removes `maybe_detect_project/1`, `maybe_record_file/1`, `Project` alias, and `FileWatcherHelpers.maybe_watch_buffer` calls from both open-buffer sequences.
- **`lib/minga/events.ex`:** Centralizes `Process.whereis` guard in `subscribe/1` and `subscribe/2`.
- **`lib/minga/config/hooks.ex`:** Removes now-redundant `Process.whereis` guard.

## Verification

```bash
mix test --warnings-as-errors    # 5248 tests, 0 failures
mix lint                          # format + credo + compile + dialyzer clean
```

## Acceptance Criteria Addressed

- FileWatcher subscribes to :buffer_opened, removed from editor.ex ✅
- Project.detect_and_set subscribes to :buffer_opened, maybe_detect_project removed ✅
- Project.record_file subscribes to :buffer_opened, maybe_record_file removed ✅
- AgentLifecycle.maybe_set_auto_context stays inline (modifies Editor state) ✅
- Open-buffer sequences reduced ✅
- All tests pass ✅