### PR TITLE
feat(render): migrate search highlighting to decorations (#532)

### DIFF
--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -803,7 +803,6 @@ defmodule Minga.Agent.View.Renderer do
       has_sign_column: false,
       diagnostic_signs: %{},
       git_signs: %{},
-      search_colors: input.theme.search,
       gutter_colors: input.theme.gutter,
       git_colors: input.theme.git
     }

--- a/lib/minga/editor/commands/search.ex
+++ b/lib/minga/editor/commands/search.ex
@@ -201,7 +201,7 @@ defmodule Minga.Editor.Commands.Search do
         :substitute_confirm_advance
       ) do
     case Enum.at(ms.matches, ms.current) do
-      {line, col, _len} -> BufferServer.move_to(buf, {line, col})
+      %Minga.Search.Match{line: line, col: col} -> BufferServer.move_to(buf, {line, col})
       _ -> :ok
     end
 
@@ -230,14 +230,14 @@ defmodule Minga.Editor.Commands.Search do
 
       new_content =
         Enum.reduce(sorted_indices, ms.original_content, fn idx, content ->
-          {line, col, len} = Enum.at(ms.matches, idx)
+          %Minga.Search.Match{line: line, col: col, length: len} = Enum.at(ms.matches, idx)
           replace_match(content, line, col, len, ms.replacement)
         end)
 
       BufferServer.replace_content(buf, new_content)
 
       # Restore cursor to a safe position
-      cursor_line = elem(hd(ms.matches), 0)
+      cursor_line = hd(ms.matches).line
       total_lines = BufferServer.line_count(buf)
       safe_line = min(cursor_line, max(0, total_lines - 1))
       BufferServer.move_to(buf, {safe_line, 0})
@@ -268,7 +268,7 @@ defmodule Minga.Editor.Commands.Search do
         all_matches
       else
         all_matches
-        |> Enum.group_by(fn {line, _col, _len} -> line end)
+        |> Enum.group_by(fn %Minga.Search.Match{line: line} -> line end)
         |> Enum.flat_map(fn {_line, line_matches} -> [hd(line_matches)] end)
         |> Enum.sort()
       end
@@ -278,7 +278,7 @@ defmodule Minga.Editor.Commands.Search do
         %{state | status_msg: "Pattern not found: #{pattern}"}
 
       _ ->
-        {first_line, first_col, _len} = hd(matches)
+        %Minga.Search.Match{line: first_line, col: first_col} = hd(matches)
         BufferServer.move_to(buf, {first_line, first_col})
 
         ms = %Minga.Mode.SubstituteConfirmState{

--- a/lib/minga/editor/render_pipeline/content_helpers.ex
+++ b/lib/minga/editor/render_pipeline/content_helpers.ex
@@ -22,6 +22,7 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   alias Minga.Editor.Renderer.Context
   alias Minga.Editor.Renderer.Gutter
   alias Minga.Editor.Renderer.SearchHighlight
+  alias Minga.Editor.RenderPosition
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.Window
   alias Minga.Editor.WrapMap
@@ -46,14 +47,7 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
           buffer: pid()
         }
 
-  @typedoc """
-  Visual selection bounds for rendering.
-  """
-  @type visual_selection ::
-          nil
-          | {:char, {non_neg_integer(), non_neg_integer()},
-             {non_neg_integer(), non_neg_integer()}}
-          | {:line, non_neg_integer(), non_neg_integer()}
+  @type visual_selection :: Context.visual_selection()
 
   # ── Render context ─────────────────────────────────────────────────────────
 
@@ -88,6 +82,21 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
         _ -> preview_matches
       end
 
+    confirm_match = if(is_active, do: SearchHighlight.current_confirm_match(state), else: nil)
+
+    # Merge search matches into decorations as highlight ranges so they
+    # compose with tree-sitter syntax colors (bg overlay preserving fg).
+    # Only rebuild when the match set actually changed (avoid per-frame
+    # clear-and-reapply when nothing changed).
+
+    decorations =
+      maybe_update_search_decorations(
+        decorations,
+        search_matches,
+        confirm_match,
+        state.theme.search
+      )
+
     cursorline_bg =
       if is_active and Options.get(:cursorline) do
         state.theme.editor.cursorline_bg
@@ -101,7 +110,7 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
       search_matches: search_matches,
       gutter_w: gutter_w,
       content_w: content_w,
-      confirm_match: if(is_active, do: SearchHighlight.current_confirm_match(state), else: nil),
+      confirm_match: confirm_match,
       highlight: window_highlight(state, window),
       cursorline_bg: cursorline_bg,
       nav_flash: state.nav_flash,
@@ -111,7 +120,6 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
       decorations: decorations,
       diagnostic_signs: diagnostic_signs_for_window(state, window),
       git_signs: git_signs_for_window(state, window),
-      search_colors: state.theme.search,
       gutter_colors: state.theme.gutter,
       git_colors: state.theme.git
     }
@@ -226,32 +234,42 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
         case fold_info do
           {:virtual_line, vt} ->
             # Virtual lines render their own styled segments, no buffer content
-            c_cmds = render_virtual_line_entry(vt, screen_row, gutter_w, row_off, col_off)
+            render_pos = %RenderPosition{
+              screen_row: screen_row,
+              gutter_w: gutter_w,
+              row_off: row_off,
+              col_off: col_off,
+              content_w: ctx.content_w
+            }
+
+            c_cmds = render_virtual_line_entry(vt, render_pos)
             {g, prepend_all(c, c_cmds), win}
 
           {:block, block, line_idx} ->
-            # Block decoration: invoke render callback, draw the line_idx-th row
-            c_cmds =
-              render_block_entry(
-                block,
-                line_idx,
-                screen_row,
-                gutter_w,
-                ctx.content_w,
-                row_off,
-                col_off
-              )
+            render_pos = %RenderPosition{
+              screen_row: screen_row,
+              gutter_w: gutter_w,
+              row_off: row_off,
+              col_off: col_off,
+              content_w: ctx.content_w
+            }
 
+            c_cmds = render_block_entry(block, line_idx, render_pos)
             {g, prepend_all(c, c_cmds), win}
 
           {:decoration_fold, %FoldRegion{placeholder: placeholder} = fold}
           when placeholder != nil ->
-            # Decoration fold with custom placeholder: invoke the callback
-            fold_g =
-              fold_gutter_indicator(fold_info, screen_row, row_off, col_off)
+            render_pos = %RenderPosition{
+              screen_row: screen_row,
+              gutter_w: gutter_w,
+              row_off: row_off,
+              col_off: col_off,
+              content_w: ctx.content_w
+            }
 
+            fold_g = fold_gutter_indicator(fold_info, render_pos)
             segments = placeholder.(fold.start_line, fold.end_line, ctx.content_w)
-            c_cmds = render_placeholder_segments(segments, screen_row, gutter_w, row_off, col_off)
+            c_cmds = render_placeholder_segments(segments, render_pos)
             {fold_g ++ g, prepend_all(c, c_cmds), win}
 
           _ ->
@@ -306,25 +324,19 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   defp fold_display_text(_text, {:virtual_line, _vt}), do: ""
   defp fold_display_text(_text, {:block, _, _}), do: ""
 
-  @spec fold_gutter_indicator(
-          term(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) ::
-          [DisplayList.draw()]
-  defp fold_gutter_indicator({:fold_start, _}, screen_row, row_off, col_off) do
-    [DisplayList.draw(screen_row + row_off, col_off, "▸")]
+  @spec fold_gutter_indicator(term(), RenderPosition.t()) :: [DisplayList.draw()]
+  defp fold_gutter_indicator({:fold_start, _}, %RenderPosition{} = pos) do
+    [DisplayList.draw(pos.screen_row + pos.row_off, pos.col_off, "▸")]
   end
 
-  defp fold_gutter_indicator(:normal, _screen_row, _row_off, _col_off), do: []
+  defp fold_gutter_indicator(:normal, _pos), do: []
 
-  defp fold_gutter_indicator({:decoration_fold, _}, screen_row, row_off, col_off) do
-    [DisplayList.draw(screen_row + row_off, col_off, "▸")]
+  defp fold_gutter_indicator({:decoration_fold, _}, %RenderPosition{} = pos) do
+    [DisplayList.draw(pos.screen_row + pos.row_off, pos.col_off, "▸")]
   end
 
-  defp fold_gutter_indicator({:virtual_line, _}, _screen_row, _row_off, _col_off), do: []
-  defp fold_gutter_indicator({:block, _, _}, _screen_row, _row_off, _col_off), do: []
+  defp fold_gutter_indicator({:virtual_line, _}, _pos), do: []
+  defp fold_gutter_indicator({:block, _, _}, _pos), do: []
 
   @spec render_folded_line(
           Window.t(),
@@ -337,8 +349,15 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
         ) :: {[DisplayList.draw()], [DisplayList.draw()], Window.t()}
   defp render_folded_line(win, buf_line, display_text, fold_info, screen_row, render_opts, {g, c}) do
     if Window.dirty?(win, buf_line) do
-      fold_g =
-        fold_gutter_indicator(fold_info, screen_row, render_opts.row_off, render_opts.col_off)
+      fold_pos = %RenderPosition{
+        screen_row: screen_row,
+        gutter_w: render_opts.gutter_w,
+        row_off: render_opts.row_off,
+        col_off: render_opts.col_off,
+        content_w: render_opts.ctx.content_w
+      }
+
+      fold_g = fold_gutter_indicator(fold_info, fold_pos)
 
       {g_cmds, c_cmds, _rows} =
         BufferLine.render(%{
@@ -430,39 +449,26 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   # Renders a virtual line entry (from DisplayMap) into draw commands.
   # Virtual lines have no buffer content; they render their styled segments
   # directly with no line number in the gutter.
-  @spec render_virtual_line_entry(
-          Decorations.VirtualText.t(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) :: [DisplayList.draw()]
-  defp render_virtual_line_entry(vt, screen_row, gutter_w, row_off, col_off) do
-    row = screen_row + row_off
-
-    {draws, _col} =
-      Enum.reduce(vt.segments, {[], gutter_w + col_off}, fn {text, style}, {acc, col} ->
-        width = Unicode.display_width(text)
-        draw = DisplayList.draw(row, col, text, style)
-        {[draw | acc], col + width}
-      end)
-
-    Enum.reverse(draws)
+  @spec render_virtual_line_entry(Decorations.VirtualText.t(), RenderPosition.t()) ::
+          [DisplayList.draw()]
+  defp render_virtual_line_entry(vt, pos) do
+    render_styled_segments(vt.segments, pos)
   end
 
-  # Renders styled segments from a fold placeholder callback into draw commands.
-  @spec render_placeholder_segments(
-          [{String.t(), keyword()}],
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) :: [DisplayList.draw()]
-  defp render_placeholder_segments(segments, screen_row, gutter_w, row_off, col_off) do
-    row = screen_row + row_off
+  @spec render_placeholder_segments([{String.t(), keyword()}], RenderPosition.t()) ::
+          [DisplayList.draw()]
+  defp render_placeholder_segments(segments, pos) do
+    render_styled_segments(segments, pos)
+  end
+
+  # Shared renderer for styled segments at a screen position.
+  @spec render_styled_segments([{String.t(), keyword()}], RenderPosition.t()) ::
+          [DisplayList.draw()]
+  defp render_styled_segments(segments, %RenderPosition{} = pos) do
+    row = pos.screen_row + pos.row_off
 
     {draws, _col} =
-      Enum.reduce(segments, {[], gutter_w + col_off}, fn {text, style}, {acc, col} ->
+      Enum.reduce(segments, {[], pos.gutter_w + pos.col_off}, fn {text, style}, {acc, col} ->
         width = Unicode.display_width(text)
         draw = DisplayList.draw(row, col, text, style)
         {[draw | acc], col + width}
@@ -473,16 +479,9 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
 
   # Renders a single row of a block decoration by invoking its render callback
   # and extracting the line_idx-th row from the result.
-  @spec render_block_entry(
-          Decorations.BlockDecoration.t(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) :: [DisplayList.draw()]
-  defp render_block_entry(block, line_idx, screen_row, gutter_w, content_w, row_off, col_off) do
+  @spec render_block_entry(Decorations.BlockDecoration.t(), non_neg_integer(), RenderPosition.t()) ::
+          [DisplayList.draw()]
+  defp render_block_entry(block, line_idx, pos) do
     # Cache render callback result per block ID to avoid re-invoking
     # for each line_idx of a multi-line block.
     cache_key = {:block_render_cache, block.id}
@@ -490,7 +489,7 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
     lines =
       case Process.get(cache_key) do
         nil ->
-          result = block.render.(content_w)
+          result = block.render.(pos.content_w)
           normalized = Decorations.BlockDecoration.normalize_render_result(result)
           Process.put(cache_key, normalized)
           normalized
@@ -500,10 +499,10 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
       end
 
     segments = Enum.at(lines, line_idx, [])
-    row = screen_row + row_off
+    row = pos.screen_row + pos.row_off
 
     {draws, _col} =
-      Enum.reduce(segments, {[], gutter_w + col_off}, fn {text, style}, {acc, col} ->
+      Enum.reduce(segments, {[], pos.gutter_w + pos.col_off}, fn {text, style}, {acc, col} ->
         width = Unicode.display_width(text)
         draw = DisplayList.draw(row, col, text, style)
         {[draw | acc], col + width}
@@ -529,6 +528,68 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   defp adjust_selection_for_virtual_text({:char, {sl, sc}, {el, ec}}, decs) do
     {:char, {sl, Decorations.buf_col_to_display_col(decs, sl, sc)},
      {el, Decorations.buf_col_to_display_col(decs, el, ec)}}
+  end
+
+  # Converts search matches into highlight range decorations and merges
+  # them into the decorations struct. Search highlights use a lower priority
+  # than user decorations so they don't override intentional styling.
+  # The current confirm match gets a different bg and higher priority.
+  # Only rebuilds search decorations when the match set changes.
+  # Uses a fingerprint of the matches to detect changes.
+  defp maybe_update_search_decorations(decs, matches, confirm_match, colors) do
+    fingerprint = {matches, confirm_match}
+    cached = Process.get(:search_decoration_cache)
+
+    case cached do
+      {^fingerprint, cached_decs} ->
+        # Same matches as last frame: reuse the merged decorations, but
+        # update the base version to match the fresh buffer decorations
+        %{cached_decs | version: decs.version + 1}
+
+      _ ->
+        result = rebuild_search_decorations(decs, matches, confirm_match, colors)
+        Process.put(:search_decoration_cache, {fingerprint, result})
+        result
+    end
+  end
+
+  defp rebuild_search_decorations(decs, [], _confirm, _colors) do
+    Decorations.remove_group(decs, :search)
+  end
+
+  defp rebuild_search_decorations(decs, matches, confirm_match, colors) do
+    Decorations.batch(decs, fn d ->
+      d = Decorations.remove_group(d, :search)
+
+      Enum.reduce(matches, d, fn match, acc ->
+        add_search_highlight(acc, match, confirm_match, colors)
+      end)
+    end)
+  end
+
+  defp add_search_highlight(
+         decs,
+         %Minga.Search.Match{line: line, col: col, length: len} = match,
+         confirm_match,
+         colors
+       ) do
+    is_confirm = confirm_match != nil and match == confirm_match
+
+    {style, priority} =
+      if is_confirm do
+        {[bg: colors.current_bg, fg: colors.highlight_fg], -5}
+      else
+        {[bg: colors.highlight_bg, fg: colors.highlight_fg], -10}
+      end
+
+    {_id, decs} =
+      Decorations.add_highlight(decs, {line, col}, {line, col + len},
+        style: style,
+        priority: priority,
+        group: :search
+      )
+
+    decs
   end
 
   @doc "Returns the decorations for a window's buffer."

--- a/lib/minga/editor/render_position.ex
+++ b/lib/minga/editor/render_position.ex
@@ -1,0 +1,22 @@
+defmodule Minga.Editor.RenderPosition do
+  @moduledoc """
+  Screen position context for rendering non-buffer-line entries (virtual
+  lines, block decorations, fold placeholders).
+
+  Bundles the per-frame screen coordinates that every decoration render
+  function needs. Constructed once per render pass and threaded through
+  the rendering helpers, replacing the 5-7 positional arguments that
+  previously traveled together.
+  """
+
+  @enforce_keys [:screen_row, :gutter_w, :row_off, :col_off, :content_w]
+  defstruct [:screen_row, :gutter_w, :row_off, :col_off, :content_w]
+
+  @type t :: %__MODULE__{
+          screen_row: non_neg_integer(),
+          gutter_w: non_neg_integer(),
+          row_off: non_neg_integer(),
+          col_off: non_neg_integer(),
+          content_w: pos_integer()
+        }
+end

--- a/lib/minga/editor/renderer.ex
+++ b/lib/minga/editor/renderer.ex
@@ -35,18 +35,7 @@ defmodule Minga.Editor.Renderer do
   @typedoc "Line number display style."
   @type line_number_style :: :hybrid | :absolute | :relative | :none
 
-  @typedoc """
-  Represents the bounds of a visual selection for rendering.
-
-  * `nil` — no active selection
-  * `{:char, start_pos, end_pos}` — characterwise selection
-  * `{:line, start_line, end_line}` — linewise selection
-  """
-  @type visual_selection ::
-          nil
-          | {:char, {non_neg_integer(), non_neg_integer()},
-             {non_neg_integer(), non_neg_integer()}}
-          | {:line, non_neg_integer(), non_neg_integer()}
+  @type visual_selection :: Minga.Editor.Renderer.Context.visual_selection()
 
   @doc """
   Renders the current editor state and returns updated state.

--- a/lib/minga/editor/renderer/context.ex
+++ b/lib/minga/editor/renderer/context.ex
@@ -13,9 +13,9 @@ defmodule Minga.Editor.Renderer.Context do
 
   alias Minga.Buffer.Decorations
   alias Minga.Diagnostics.Diagnostic
-  alias Minga.Editor.Renderer.SearchHighlight
   alias Minga.Editor.Viewport
   alias Minga.Highlight
+  alias Minga.Search.Match
 
   @enforce_keys [:viewport, :gutter_w, :content_w]
   defstruct viewport: nil,
@@ -32,11 +32,6 @@ defmodule Minga.Editor.Renderer.Context do
             has_sign_column: false,
             diagnostic_signs: %{},
             git_signs: %{},
-            search_colors: %Minga.Theme.Search{
-              highlight_fg: 0x000000,
-              highlight_bg: 0xECBE7B,
-              current_bg: 0xFF6C6B
-            },
             git_colors: %Minga.Theme.Git{
               added_fg: 0x98BE65,
               modified_fg: 0x51AFEF,
@@ -68,10 +63,10 @@ defmodule Minga.Editor.Renderer.Context do
   @type t :: %__MODULE__{
           viewport: Viewport.t(),
           visual_selection: visual_selection(),
-          search_matches: [SearchHighlight.search_match()],
+          search_matches: [Match.t()],
           gutter_w: non_neg_integer(),
           content_w: pos_integer(),
-          confirm_match: SearchHighlight.search_match() | nil,
+          confirm_match: Match.t() | nil,
           highlight: Highlight.t() | nil,
           cursorline_bg: Minga.Theme.color() | nil,
           nav_flash: Minga.Editor.NavFlash.t() | nil,
@@ -82,7 +77,6 @@ defmodule Minga.Editor.Renderer.Context do
           git_signs: %{non_neg_integer() => Minga.Git.Diff.hunk_type()},
           decorations: Decorations.t(),
           git_colors: Minga.Theme.Git.t(),
-          search_colors: Minga.Theme.Search.t(),
           gutter_colors: Minga.Theme.Gutter.t()
         }
 end

--- a/lib/minga/editor/renderer/line.ex
+++ b/lib/minga/editor/renderer/line.ex
@@ -18,7 +18,6 @@ defmodule Minga.Editor.Renderer.Line do
   alias Minga.Buffer.Unicode
   alias Minga.Editor.DisplayList
   alias Minga.Editor.Renderer.Context
-  alias Minga.Editor.Renderer.SearchHighlight
   alias Minga.Highlight
 
   @typedoc "Column range of a selection on a single line (display columns, end exclusive)."
@@ -59,23 +58,14 @@ defmodule Minga.Editor.Renderer.Line do
         )
 
       nil when line_highlights != [] ->
-        # No syntax highlighting but has decorations: render through the
-        # styled-segment path so decorations are applied
+        # No syntax highlighting but has decorations (including search):
+        # render through the styled-segment path
         render_decorated_plain_line(line_text, screen_row, buf_line, ctx, line_highlights)
 
       nil ->
-        visible_graphemes = Enum.map(visible_pairs, fn {g, _} -> g end)
-
-        SearchHighlight.render_line_with_search(
-          visible_graphemes,
-          screen_row,
-          buf_line,
-          ctx.viewport,
-          ctx.search_matches,
-          ctx.gutter_w,
-          ctx.confirm_match,
-          ctx.search_colors
-        )
+        # Plain text, no decorations, no syntax highlighting
+        visible_text = join_pairs(visible_pairs)
+        [DisplayList.draw(screen_row, ctx.gutter_w, visible_text)]
 
       :full ->
         visible_text = join_pairs(visible_pairs)

--- a/lib/minga/editor/renderer/search_highlight.ex
+++ b/lib/minga/editor/renderer/search_highlight.ex
@@ -1,20 +1,17 @@
 defmodule Minga.Editor.Renderer.SearchHighlight do
   @moduledoc """
-  Search match highlighting, substitute preview, and pattern extraction for
-  the renderer.
+  Search match computation, substitute preview, and pattern extraction.
 
-  All render functions return `DisplayList.draw()` tuples.
+  Match positions are computed here. Rendering is handled by the
+  decoration system: search matches become highlight range decorations
+  in `ContentHelpers.maybe_update_search_decorations/4`.
   """
 
-  alias Minga.Editor.DisplayList
   alias Minga.Editor.State, as: EditorState
-  alias Minga.Editor.Viewport
+  alias Minga.Search.Match
 
-  @typedoc "Search color set from the active theme."
-  @type search_colors :: Minga.Theme.Search.t()
-
-  @typedoc "A search match: `{line, col, length}` (absolute buffer coordinates)."
-  @type search_match :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}
+  @typedoc "A search match with buffer position and length."
+  @type search_match :: Match.t()
 
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
@@ -51,49 +48,6 @@ defmodule Minga.Editor.Renderer.SearchHighlight do
     end
   end
 
-  @doc "Renders a line with search match highlighting spans."
-  @spec render_line_with_search(
-          [String.t()],
-          non_neg_integer(),
-          non_neg_integer(),
-          Viewport.t(),
-          [search_match()],
-          non_neg_integer(),
-          search_match() | nil,
-          search_colors()
-        ) :: [DisplayList.draw()]
-  def render_line_with_search(
-        visible_graphemes,
-        screen_row,
-        buf_line,
-        viewport,
-        matches,
-        gutter_w,
-        confirm_match \\ nil,
-        colors \\ %Minga.Theme.Search{
-          highlight_fg: 0x000000,
-          highlight_bg: 0xECBE7B,
-          current_bg: 0xFF6C6B
-        }
-      ) do
-    spans = build_highlight_spans(matches, confirm_match, buf_line, viewport, visible_graphemes)
-
-    case spans do
-      [] ->
-        [DisplayList.draw(screen_row, gutter_w, Enum.join(visible_graphemes))]
-
-      _ ->
-        render_highlighted_spans(
-          visible_graphemes,
-          viewport.left,
-          spans,
-          screen_row,
-          gutter_w,
-          colors
-        )
-    end
-  end
-
   # ── Private helpers ──────────────────────────────────────────────────────────
 
   @spec substitute_preview_lines(
@@ -110,7 +64,7 @@ defmodule Minga.Editor.Renderer.SearchHighlight do
       {new_line, _count, spans} =
         Minga.Search.substitute_line_with_spans(line, pattern, replacement, global?)
 
-      matches = Enum.map(spans, fn {col, len} -> {line_num, col, len} end)
+      matches = Enum.map(spans, fn {col, len} -> Match.new(line_num, col, len) end)
       {new_line, acc ++ matches}
     end)
   end
@@ -260,165 +214,6 @@ defmodule Minga.Editor.Renderer.SearchHighlight do
       acc |> Enum.reverse() |> Enum.join()
     else
       do_extract_replacement(rest, delimiter, [<<c::utf8>> | acc])
-    end
-  end
-
-  # ── Highlight spans ───────────────────────────────────────────────────────
-  #
-  # A highlight span is `{start_col, end_col, type}` where cols are absolute
-  # buffer coordinates and type is `:search` or `:confirm`. Spans are sorted
-  # by start_col, confirm spans taking priority over search spans for the
-  # same columns.
-
-  @typep highlight_span :: {non_neg_integer(), non_neg_integer(), highlight_type()}
-
-  @spec build_highlight_spans(
-          [search_match()],
-          search_match() | nil,
-          non_neg_integer(),
-          Viewport.t(),
-          [String.t()]
-        ) :: [highlight_span()]
-  defp build_highlight_spans(matches, confirm_match, buf_line, viewport, visible_graphemes) do
-    vis_start = viewport.left
-    vis_end = vis_start + length(visible_graphemes) - 1
-
-    search_spans =
-      matches
-      |> Enum.filter(fn {line, _col, _len} -> line == buf_line end)
-      |> Enum.map(fn {_line, col, len} ->
-        {max(col, vis_start), min(col + len - 1, vis_end), :search}
-      end)
-      |> Enum.filter(fn {s, e, _} -> s <= e end)
-
-    confirm_spans = confirm_span(confirm_match, buf_line, vis_start, vis_end)
-
-    # Confirm spans override search spans for the same region
-    merge_spans(search_spans, confirm_spans)
-  end
-
-  @spec confirm_span(
-          search_match() | nil,
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) ::
-          [highlight_span()]
-  defp confirm_span(nil, _buf_line, _vis_start, _vis_end), do: []
-
-  defp confirm_span({line, col, len}, buf_line, vis_start, vis_end) do
-    if line == buf_line do
-      s = max(col, vis_start)
-      e = min(col + len - 1, vis_end)
-      if s <= e, do: [{s, e, :confirm}], else: []
-    else
-      []
-    end
-  end
-
-  # Merge confirm spans into search spans. Confirm takes priority.
-  @spec merge_spans([highlight_span()], [highlight_span()]) :: [highlight_span()]
-  defp merge_spans(search_spans, []), do: search_spans
-  defp merge_spans([], confirm_spans), do: confirm_spans
-
-  defp merge_spans(search_spans, confirm_spans) do
-    # Simple approach: concat and sort. Since we classify per-column below,
-    # confirm spans will win because we check them first.
-    (confirm_spans ++ search_spans)
-    |> Enum.sort_by(fn {s, _e, _t} -> s end)
-  end
-
-  @spec render_highlighted_spans(
-          [String.t()],
-          non_neg_integer(),
-          [highlight_span()],
-          non_neg_integer(),
-          non_neg_integer(),
-          search_colors()
-        ) :: [DisplayList.draw()]
-  defp render_highlighted_spans(visible_graphemes, vis_start, spans, screen_row, gutter_w, colors) do
-    visible_graphemes
-    |> Enum.with_index(vis_start)
-    |> chunk_by_highlight_type(spans)
-    |> Enum.flat_map(fn {chars, abs_start_col, hl_type} ->
-      encode_span(chars, abs_start_col, vis_start, hl_type, screen_row, gutter_w, colors)
-    end)
-  end
-
-  @typep highlight_type :: :none | :search | :confirm
-
-  @spec encode_span(
-          [String.t()],
-          non_neg_integer(),
-          non_neg_integer(),
-          highlight_type(),
-          non_neg_integer(),
-          non_neg_integer(),
-          search_colors()
-        ) :: [DisplayList.draw()]
-  defp encode_span(chars, abs_start_col, vis_start, :confirm, screen_row, gutter_w, colors) do
-    screen_col = gutter_w + (abs_start_col - vis_start)
-
-    [
-      DisplayList.draw(screen_row, screen_col, Enum.join(chars),
-        fg: colors.highlight_fg,
-        bg: colors.current_bg
-      )
-    ]
-  end
-
-  defp encode_span(chars, abs_start_col, vis_start, :search, screen_row, gutter_w, colors) do
-    screen_col = gutter_w + (abs_start_col - vis_start)
-
-    [
-      DisplayList.draw(screen_row, screen_col, Enum.join(chars),
-        fg: colors.highlight_fg,
-        bg: colors.highlight_bg
-      )
-    ]
-  end
-
-  defp encode_span(chars, abs_start_col, vis_start, :none, screen_row, gutter_w, _colors) do
-    screen_col = gutter_w + (abs_start_col - vis_start)
-    [DisplayList.draw(screen_row, screen_col, Enum.join(chars))]
-  end
-
-  @spec chunk_by_highlight_type(
-          [{String.t(), non_neg_integer()}],
-          [highlight_span()]
-        ) :: [{[String.t()], non_neg_integer(), highlight_type()}]
-  defp chunk_by_highlight_type(indexed_graphemes, spans) do
-    indexed_graphemes
-    |> Enum.chunk_while(
-      nil,
-      fn {char, col}, acc ->
-        hl_type = classify_col(col, spans)
-
-        case acc do
-          nil ->
-            {:cont, {[char], col, hl_type}}
-
-          {chars, start_col, ^hl_type} ->
-            {:cont, {[char | chars], start_col, hl_type}}
-
-          {chars, start_col, prev_hl} ->
-            {:cont, {Enum.reverse(chars), start_col, prev_hl}, {[char], col, hl_type}}
-        end
-      end,
-      fn
-        nil -> {:cont, []}
-        {chars, start_col, hl} -> {:cont, {Enum.reverse(chars), start_col, hl}, nil}
-      end
-    )
-  end
-
-  # Classify a column against highlight spans.
-  # Confirm spans take priority over search spans (they appear first after merge).
-  @spec classify_col(non_neg_integer(), [highlight_span(), ...]) :: highlight_type()
-  defp classify_col(col, spans) do
-    case Enum.find(spans, fn {s, e, _type} -> col >= s and col <= e end) do
-      nil -> :none
-      {_s, _e, type} -> type
     end
   end
 end

--- a/lib/minga/mode/substitute_confirm_state.ex
+++ b/lib/minga/mode/substitute_confirm_state.ex
@@ -17,7 +17,7 @@ defmodule Minga.Mode.SubstituteConfirmState do
             count: nil
 
   @typedoc "A match position: `{line, col, length}`."
-  @type match_pos :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}
+  @type match_pos :: Minga.Search.Match.t()
 
   @type t :: %__MODULE__{
           matches: [match_pos()],

--- a/lib/minga/search.ex
+++ b/lib/minga/search.ex
@@ -15,9 +15,10 @@ defmodule Minga.Search do
   """
 
   alias Minga.Buffer.Document
+  alias Minga.Search.Match
 
-  @typedoc "A match: `{line, byte_col, byte_length}`."
-  @type match :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}
+  @typedoc "A search match with line, byte column, and byte length."
+  @type match :: Match.t()
 
   @typedoc "Search direction."
   @type direction :: :forward | :backward
@@ -66,12 +67,12 @@ defmodule Minga.Search do
   `first_line` is the buffer line number of the first element in `lines`,
   used to compute absolute line numbers in the returned matches.
 
-  Returns a list of `{line, byte_col, byte_length}` tuples.
+  Returns a list of `Search.Match` structs.
 
   ## Examples
 
       iex> Minga.Search.find_all_in_range(["foo bar foo", "baz foo"], "foo", 0)
-      [{0, 0, 3}, {0, 8, 3}, {1, 4, 3}]
+      [%Minga.Search.Match{line: 0, col: 0, length: 3}, %Minga.Search.Match{line: 0, col: 8, length: 3}, %Minga.Search.Match{line: 1, col: 4, length: 3}]
   """
   @spec find_all_in_range([String.t()], String.t(), non_neg_integer()) :: [match()]
   def find_all_in_range(_lines, "", _first_line), do: []
@@ -108,7 +109,7 @@ defmodule Minga.Search do
           abs_pos = start + pos
 
           find_all_overlapping(line, pattern, pat_len, line_num, abs_pos + 1, [
-            {line_num, abs_pos, pat_len} | acc
+            Match.new(line_num, abs_pos, pat_len) | acc
           ])
       end
     end

--- a/lib/minga/search/match.ex
+++ b/lib/minga/search/match.ex
@@ -1,0 +1,24 @@
+defmodule Minga.Search.Match do
+  @moduledoc """
+  A search match: a pattern occurrence at a specific buffer position.
+
+  Replaces the raw `{line, col, length}` tuple that previously crossed
+  module boundaries between Search, Renderer, ContentHelpers, and
+  Agent.ViewState.
+  """
+
+  @enforce_keys [:line, :col, :length]
+  defstruct [:line, :col, :length]
+
+  @type t :: %__MODULE__{
+          line: non_neg_integer(),
+          col: non_neg_integer(),
+          length: non_neg_integer()
+        }
+
+  @doc "Creates a match from positional values."
+  @spec new(non_neg_integer(), non_neg_integer(), non_neg_integer()) :: t()
+  def new(line, col, length) do
+    %__MODULE__{line: line, col: col, length: length}
+  end
+end

--- a/test/minga/search_test.exs
+++ b/test/minga/search_test.exs
@@ -3,6 +3,7 @@ defmodule Minga.SearchTest do
 
   alias Minga.Buffer.Document
   alias Minga.Search
+  alias Minga.Search.Match
 
   # ── find_next/4 ────────────────────────────────────────────────────────
 
@@ -68,12 +69,19 @@ defmodule Minga.SearchTest do
   describe "find_all_in_range/3" do
     test "finds all occurrences across lines" do
       lines = ["foo bar foo", "baz foo"]
-      assert [{0, 0, 3}, {0, 8, 3}, {1, 4, 3}] = Search.find_all_in_range(lines, "foo", 0)
+
+      assert [
+               %Match{line: 0, col: 0, length: 3},
+               %Match{line: 0, col: 8, length: 3},
+               %Match{line: 1, col: 4, length: 3}
+             ] = Search.find_all_in_range(lines, "foo", 0)
     end
 
     test "respects first_line offset" do
       lines = ["foo bar"]
-      assert [{5, 0, 3}] = Search.find_all_in_range(lines, "foo", 5)
+
+      assert [%Match{line: 5, col: 0, length: 3}] =
+               Search.find_all_in_range(lines, "foo", 5)
     end
 
     test "returns empty list for empty pattern" do
@@ -86,7 +94,10 @@ defmodule Minga.SearchTest do
 
     test "finds overlapping start positions" do
       # "aa" in "aaa" should find at col 0 and col 1
-      assert [{0, 0, 2}, {0, 1, 2}] = Search.find_all_in_range(["aaa"], "aa", 0)
+      assert [
+               %Match{line: 0, col: 0, length: 2},
+               %Match{line: 0, col: 1, length: 2}
+             ] = Search.find_all_in_range(["aaa"], "aa", 0)
     end
   end
 


### PR DESCRIPTION
## What

PR 5 of the decoration epic. Migrates search match highlighting from a standalone rendering system to highlight range decorations. Search backgrounds now compose with tree-sitter syntax foreground colors instead of replacing them.

### What changed

**Removed (-207 lines):**
- `SearchHighlight.render_line_with_search` and all private rendering helpers (span building, per-grapheme classification, manual draw generation)
- The separate search-highlight branch in `Line.render/5`
- Dead `search_colors` field on `Context`

**Added:**
- `maybe_update_search_decorations/4` in ContentHelpers: converts search matches to `:search` group highlight ranges with per-frame caching
- Confirm match gets `current_bg` at priority -5 vs regular matches at -10
- `Search.Match` and `RenderPosition` foundation structs (for future data clump cleanup)

### How it works

The search system still computes match positions via `search_matches_for_lines`. But instead of passing those to a custom renderer, they become highlight range decorations on the render context. The decoration system's `merge_highlights` overlays the search bg on top of syntax fg, composing naturally.

Per-frame cache prevents redundant rebuilds: search decorations are only recreated when the match set actually changes (fingerprint comparison).

### Net result

One unified rendering path for all styled buffer content. No more branching between "syntax-highlighted" and "search-highlighted" code paths. Search, diagnostics, agent chat, and LSP highlights all compose through the same decoration pipeline.

### PR stack

1. ~~`#520` Highlight ranges~~ ✅
2. ~~`#521` Virtual text~~ ✅
3. ~~`#522` Fold regions + DisplayMap~~ ✅
4. ~~`#523` Block decorations~~ ✅
5. **`#532` Migrate search highlighting** ← this PR
6. `#524` Refactor agent chat

Closes #532