### PR TITLE
refactor(editor): migrate file tree git status refresh to event bus

### DIFF
--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -143,6 +143,9 @@ defmodule Minga.Editor do
     state = Startup.apply_config_options(state)
     Minga.Diagnostics.subscribe()
 
+    # Refresh file tree git status when any buffer is saved.
+    Minga.Events.subscribe(:buffer_saved)
+
     {:ok, state}
   end
 
@@ -585,6 +588,10 @@ defmodule Minga.Editor do
     {:noreply, state}
   end
 
+  def handle_info({:minga_event, :buffer_saved, _payload}, state) do
+    {:noreply, refresh_tree_git_status(state)}
+  end
+
   def handle_info(_msg, state) do
     {:noreply, state}
   end
@@ -978,7 +985,15 @@ defmodule Minga.Editor do
     end)
   end
 
-  # ── Config options ──────────────────────────────────────────────────────
+  # ── File tree helpers ────────────────────────────────────────────────────
+
+  @spec refresh_tree_git_status(state()) :: state()
+  defp refresh_tree_git_status(%{file_tree: %{tree: nil}} = state), do: state
+
+  defp refresh_tree_git_status(%{file_tree: %{tree: tree}} = state) do
+    updated_tree = Minga.FileTree.refresh_git_status(tree)
+    put_in(state.file_tree.tree, updated_tree)
+  end
 
   # ── Public housekeeping API for Input.Router ───────────────────────────────
 

--- a/lib/minga/editor/commands/buffer_management.ex
+++ b/lib/minga/editor/commands/buffer_management.ex
@@ -40,7 +40,6 @@ defmodule Minga.Editor.Commands.BufferManagement do
         name = Helpers.buffer_display_name(buf)
 
         %{state | status_msg: "Wrote #{name}"}
-        |> refresh_tree_git_status()
 
       {:error, :file_changed} ->
         %{state | status_msg: "WARNING: File changed on disk. Use :w! to force save."}
@@ -957,15 +956,6 @@ defmodule Minga.Editor.Commands.BufferManagement do
       {id, _window} -> {:ok, id}
       nil -> :none
     end
-  end
-
-  # Refreshes git status in the file tree (if open) after file operations.
-  @spec refresh_tree_git_status(EditorState.t()) :: EditorState.t()
-  defp refresh_tree_git_status(%{file_tree: %{tree: nil}} = state), do: state
-
-  defp refresh_tree_git_status(%{file_tree: %{tree: tree}} = state) do
-    updated_tree = Minga.FileTree.refresh_git_status(tree)
-    put_in(state.file_tree.tree, updated_tree)
   end
 
   # Creates an empty buffer when the last buffer is killed.

--- a/test/minga/editor/file_tree_integration_test.exs
+++ b/test/minga/editor/file_tree_integration_test.exs
@@ -240,6 +240,28 @@ defmodule Minga.Editor.FileTreeIntegrationTest do
     end
   end
 
+  describe "file tree git status refresh on save" do
+    test "Editor subscribes to :buffer_saved and refreshes file tree git status", %{tmp_dir: dir} do
+      file = Path.join(dir, "save_test.ex")
+      File.write!(file, "x = 1\n")
+      ctx = start_editor(file)
+
+      # Open the file tree
+      state = send_keys_sync(ctx, "<SPC>op")
+      assert state.file_tree.tree != nil
+
+      # Broadcast a :buffer_saved event (simulating what lsp_after_save does)
+      Minga.Events.broadcast(:buffer_saved, %{buffer: state.buffers.active, path: file})
+
+      # A synchronous call to the Editor flushes its mailbox, guaranteeing
+      # the :minga_event handle_info has been processed before we inspect state.
+      state = :sys.get_state(ctx.editor)
+
+      # The tree should still be present (refresh didn't crash or nil it out)
+      assert state.file_tree.tree != nil
+    end
+  end
+
   defp poll_until(condition, timeout, interval) do
     deadline = System.monotonic_time(:millisecond) + timeout
     do_poll_until(condition, interval, deadline)


### PR DESCRIPTION
# TL;DR

File tree git status now refreshes via the event bus when any buffer is saved, instead of being called inline from the save command. Any new save path automatically triggers the refresh.

Closes #595

## Context

Stacked on #600. The save command in `buffer_management.ex` used to call `refresh_tree_git_status()` inline after a successful save. This meant every new save path had to remember the call or the file tree would show stale git indicators.

## Changes

- **`lib/minga/editor.ex`:** Subscribes to `:buffer_saved` in init. `handle_info` calls `refresh_tree_git_status/1` (moved here from buffer_management.ex). Nil-tree guard handles the no-op case.
- **`lib/minga/editor/commands/buffer_management.ex`:** Removed `refresh_tree_git_status` call and private function.
- **`test/minga/editor/file_tree_integration_test.exs`:** New test verifies the event-driven wiring works (broadcasts `:buffer_saved`, uses `:sys.get_state` for synchronization, no `Process.sleep`).

## Verification

```bash
mix test --warnings-as-errors    # 5249 tests, 0 failures
mix lint                          # format + credo + compile + dialyzer clean
```

## Acceptance Criteria Addressed

- refresh_tree_git_status removed from buffer_management.ex ✅
- File tree refreshes on :buffer_saved broadcast ✅
- No-op when file tree is not open ✅
- All tests pass ✅