### PR TITLE
refactor(editor): restructure supervision tree with nested supervisors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@ lib/
   minga.ex                    # Root module
   minga/
     application.ex            # OTP application / supervisor tree
+    foundation/
+      supervisor.ex           # Foundation supervisor (Events, Config, Keymap, etc.)
+    services/
+      supervisor.ex           # Services supervisor (Git, Extensions, LSP, Diagnostics, etc.)
+    runtime/
+      supervisor.ex           # Runtime supervisor (Watchdog, FileWatcher, Editor.Supervisor)
     buffer/
       document.ex           # Pure data structure (no GenServer)
       server.ex               # GenServer wrapper for gap buffer
@@ -32,6 +38,7 @@ lib/
       manager.ex              # GenServer managing the tree-sitter parser Port
     editor.ex                 # Editor orchestration GenServer
     editor/
+      supervisor.ex           # Editor supervisor (Parser, Port, Editor)
       layout.ex               # Pure layout computation (single source of truth for all rects)
       viewport.ex             # Viewport scrolling logic
     mode/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,32 +96,46 @@ BEAM processes are organized into supervision trees that encode dependency relat
 
 ```
 Minga.Supervisor (rest_for_one)
-├── Config.Options           ← typed option registry (ETS, read_concurrency)
-├── Keymap.Active            ← mutable keymap store (ETS, read_concurrency)
-├── Config.Hooks             ← lifecycle hook registry (Agent)
-├── Config.Advice            ← before/after command advice (ETS, read_concurrency)
-├── Config.Loader            ← config file discovery and evaluation
-├── Filetype.Registry        ← static data, rarely fails
-├── Buffer.Supervisor        ← if this restarts, buffers survive
-│    ├── Buffer processes    ← one per open file/scratch buffer
+├── Foundation.Supervisor (rest_for_one)
+│    ├── Language.Registry    ← ETS, language definitions
+│    ├── Events               ← Registry(:duplicate), pub/sub bus
+│    ├── Config.Options       ← typed option registry (ETS, read_concurrency)
+│    ├── Keymap.Active        ← mutable keymap store (ETS, read_concurrency)
+│    ├── Config.Hooks         ← lifecycle hook registry (Agent)
+│    ├── Config.Advice        ← before/after command advice (ETS, read_concurrency)
+│    └── Filetype.Registry    ← static data, rarely fails
+├── Buffer.Supervisor (DynamicSupervisor, one_for_one)
+│    ├── Buffer processes     ← one per open file/scratch buffer
 │    ├── Git.Buffer processes ← one per buffer in a git repo (caches HEAD, computes diffs)
 │    └── Buffer.Fork processes ← (planned) per-agent forks for concurrent editing
-├── Eval.TaskSupervisor      ← supervised tasks for user code
-├── Command.Registry         ← ETS-backed, aggregates commands from Provider modules on restart
-├── Extension.Registry       ← extension metadata store
-├── Extension.Supervisor     ← DynamicSupervisor for extension processes
-├── Diagnostics              ← source-agnostic diagnostic aggregation (ETS reads, GenServer writes)
-├── LSP.Supervisor           ← DynamicSupervisor for LSP client processes
-├── Agent.Supervisor         ← DynamicSupervisor for agent session process trees
-│    └── Agent.Session       ← one per active agent session (provider, conversation, tools)
-├── Project                  ← project root detection, known-projects persistence, file cache
-├── FileWatcher              ← OS file notifications
-├── Parser.Manager           ← owns the tree-sitter parser process
-├── Port.Manager             ← owns the Zig renderer process
-└── Editor                   ← orchestration, depends on everything above
+├── Services.Supervisor (rest_for_one)
+│    ├── Services.Independent (one_for_one)
+│    │    ├── Git.Tracker     ← subscribes to buffer events, ETS registry
+│    │    ├── CommandOutput.Registry ← Registry(:unique)
+│    │    ├── Eval.TaskSupervisor ← supervised tasks for user code
+│    │    ├── Command.Registry ← ETS-backed, aggregates commands from Provider modules
+│    │    ├── Fold.Registry   ← fold state
+│    │    └── Diagnostics     ← source-agnostic diagnostic aggregation (ETS reads, GenServer writes)
+│    ├── Extension.Registry   ← extension metadata store (Agent)
+│    ├── Extension.Supervisor ← DynamicSupervisor for extension processes
+│    ├── Config.Loader        ← config file discovery and evaluation
+│    ├── LSP.Supervisor       ← DynamicSupervisor for LSP client processes
+│    ├── LSP.SyncServer       ← subscribes to buffer events, manages LSP sync
+│    ├── Project              ← project root detection, known-projects persistence, file cache
+│    └── Agent.Supervisor     ← DynamicSupervisor for agent session process trees
+│         └── Agent.Session   ← one per active agent session (provider, conversation, tools)
+└── Runtime.Supervisor (one_for_one, conditional)
+     ├── Editor.Watchdog      ← SIGUSR1 recovery (independent leaf)
+     ├── FileWatcher          ← OS file notifications (independent leaf)
+     └── Editor.Supervisor (rest_for_one)
+          ├── Parser.Manager  ← owns the tree-sitter parser process
+          ├── Port.Manager    ← owns the Zig renderer process
+          └── Editor          ← orchestration, depends on Parser + Port
 ```
 
-The `rest_for_one` strategy means: if the Port Manager fails, the Editor restarts too (since it depends on the renderer), but buffers are untouched. Your undo history, cursor positions, unsaved changes: all preserved. The renderer comes back up, re-renders the current viewport, and you're exactly where you were.
+The tree uses nested supervisors to constrain blast radius. A filesystem watcher flake restarts only FileWatcher, not the renderer. A git tracking crash restarts only Git.Tracker, not its sibling services. The `rest_for_one` chains within Foundation and Services preserve real dependency ordering (Events → Config subscribers, Extension.Registry → Config.Loader) while preventing unrelated siblings from cascading into each other.
+
+The tightly-coupled trio (Parser → Port → Editor) lives in its own `rest_for_one` supervisor: if the Port Manager fails, the Editor restarts too (since it depends on the renderer), but buffers are untouched. Your undo history, cursor positions, unsaved changes: all preserved. The renderer comes back up, re-renders the current viewport, and you're exactly where you were.
 
 This is graceful degradation. Individual features can fail and recover independently. Losing your LSP connection doesn't affect your editing. A plugin that hits an error doesn't corrupt your buffers. The system degrades in pieces rather than failing all at once.
 

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -4,41 +4,63 @@ Interactive diagrams of how Minga's processes, data, and communication are struc
 
 ## Supervision Tree
 
-The BEAM side of Minga is organized as a `rest_for_one` supervision tree. If a process crashes, everything below it in the tree restarts, but everything above it stays untouched.
+The BEAM side of Minga uses nested supervisors to constrain blast radius. The top-level `rest_for_one` preserves the Foundation → Services → Editor cascade. Inner supervisors use strategies matched to their children's actual dependency profiles.
 
 ```mermaid
 graph TD
     SUP["Minga.Supervisor<br/><i>rest_for_one</i>"]
 
-    SUP --> OPTS["Config.Options"]
-    SUP --> LOADER["Config.Loader"]
-    SUP --> FT["Filetype.Registry"]
-    SUP --> BUFSUP["Buffer.Supervisor<br/><i>DynamicSupervisor, one_for_one</i>"]
-    SUP --> TASKSUP["Eval.TaskSupervisor<br/><i>Task.Supervisor</i>"]
-    SUP --> CMDREG["Command.Registry"]
-    SUP --> DIAG["Diagnostics"]
-    SUP --> LSPSUP["LSP.Supervisor<br/><i>DynamicSupervisor</i>"]
-    SUP --> FW["FileWatcher"]
-    SUP --> PM["Port.Manager"]
-    SUP --> ED["Editor"]
+    SUP --> FOUND["Foundation.Supervisor<br/><i>rest_for_one</i>"]
+    FOUND --> LANG["Language.Registry"]
+    FOUND --> EVENTS["Events"]
+    FOUND --> OPTS["Config.Options"]
+    FOUND --> KEYMAP["Keymap.Active"]
+    FOUND --> HOOKS["Config.Hooks"]
+    FOUND --> ADVICE["Config.Advice"]
+    FOUND --> FT["Filetype.Registry"]
 
+    SUP --> BUFSUP["Buffer.Supervisor<br/><i>DynamicSupervisor, one_for_one</i>"]
     BUFSUP --> B1["Buffer: main.ex"]
     BUFSUP --> B2["Buffer: router.ex"]
     BUFSUP --> B3["Buffer: schema.ex"]
     BUFSUP --> BF1["Buffer.Fork: main.ex<br/><i>(agent session A)</i>"]
 
-    SUP --> AGENTSUP["Agent.Supervisor<br/><i>DynamicSupervisor</i>"]
+    SUP --> SVC["Services.Supervisor<br/><i>rest_for_one</i>"]
+    SVC --> INDEP["Services.Independent<br/><i>one_for_one</i>"]
+    INDEP --> GIT["Git.Tracker"]
+    INDEP --> TASKSUP["Eval.TaskSupervisor"]
+    INDEP --> CMDREG["Command.Registry"]
+    INDEP --> DIAG["Diagnostics"]
+    SVC --> EXTREG["Extension.Registry"]
+    SVC --> EXTSUP["Extension.Supervisor"]
+    SVC --> LOADER["Config.Loader"]
+    SVC --> LSPSUP["LSP.Supervisor<br/><i>DynamicSupervisor</i>"]
+    SVC --> SYNC["LSP.SyncServer"]
+    SVC --> PROJ["Project"]
+    SVC --> AGENTSUP["Agent.Supervisor<br/><i>DynamicSupervisor</i>"]
     AGENTSUP --> AS1["Agent.Session<br/><i>Claude (refactoring)</i>"]
     AGENTSUP --> AS2["Agent.Session<br/><i>Claude (tests)</i>"]
-
     LSPSUP --> LSP1["LSP Client: elixir-ls"]
     LSPSUP --> LSP2["LSP Client: lua-ls"]
+
+    SUP --> RT["Runtime.Supervisor<br/><i>one_for_one</i>"]
+    RT --> WD["Editor.Watchdog"]
+    RT --> FW["FileWatcher"]
+    RT --> EDSUP["Editor.Supervisor<br/><i>rest_for_one</i>"]
+    EDSUP --> PARSER["Parser.Manager"]
+    EDSUP --> PM["Port.Manager"]
+    EDSUP --> ED["Editor"]
 
     PM -. "stdin/stdout<br/>Port protocol" .-> ZIG["Zig Process<br/><i>libvaxis + tree-sitter</i>"]
 
     AS1 -. "apply_text_edits<br/>(message passing)" .-> BF1
 
     style SUP fill:#6c3483,stroke:#4a235a,color:#fff
+    style FOUND fill:#6c3483,stroke:#4a235a,color:#fff
+    style SVC fill:#6c3483,stroke:#4a235a,color:#fff
+    style RT fill:#6c3483,stroke:#4a235a,color:#fff
+    style EDSUP fill:#6c3483,stroke:#4a235a,color:#fff
+    style INDEP fill:#6c3483,stroke:#4a235a,color:#fff
     style BUFSUP fill:#1a5276,stroke:#154360,color:#fff
     style LSPSUP fill:#1a5276,stroke:#154360,color:#fff
     style AGENTSUP fill:#1a5276,stroke:#154360,color:#fff
@@ -46,6 +68,8 @@ graph TD
     style ZIG fill:#1e8449,stroke:#196f3d,color:#fff
     style PM fill:#b7950b,stroke:#9a7d0a,color:#fff
     style ED fill:#b7950b,stroke:#9a7d0a,color:#fff
+    style WD fill:#b7950b,stroke:#9a7d0a,color:#fff
+    style FW fill:#b7950b,stroke:#9a7d0a,color:#fff
     style B1 fill:#2471a3,stroke:#1a5276,color:#fff
     style B2 fill:#2471a3,stroke:#1a5276,color:#fff
     style B3 fill:#2471a3,stroke:#1a5276,color:#fff

--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -3,27 +3,44 @@ defmodule Minga.Application do
   The Minga OTP Application.
 
   Starts the supervision tree (the "Stamm") that manages all editor
-  processes. Uses `rest_for_one` strategy: if the Port Manager crashes,
-  the Editor restarts too (since it depends on the renderer).
+  processes. The top-level supervisor uses `rest_for_one` so that a
+  Foundation crash cascades to Services and the Editor, but not the
+  other way around.
 
   ## Supervision Tree
 
       Minga.Supervisor (rest_for_one)
-      ├── Minga.Events (Registry, :duplicate)
-      ├── Minga.Config.Options
-      ├── Minga.Keymap.Active
-      ├── Minga.Config.Hooks
-      ├── Minga.Config.Advice
-      ├── Minga.Config.Loader
-      ├── Minga.Buffer.Supervisor (DynamicSupervisor)
-      ├── Minga.Fold.Registry
-      ├── Minga.Extension.Registry
-      ├── Minga.Extension.Supervisor (DynamicSupervisor)
-      ├── Minga.Agent.Supervisor (DynamicSupervisor)
-      ├── Minga.Parser.Manager
-      ├── Minga.Port.Manager
-      ├── Minga.Editor.Watchdog
-      └── Minga.Editor
+      ├── Minga.Foundation.Supervisor (rest_for_one)
+      │   ├── Minga.Language.Registry
+      │   ├── Minga.Events (Registry, :duplicate)
+      │   ├── Minga.Config.Options
+      │   ├── Minga.Keymap.Active
+      │   ├── Minga.Config.Hooks
+      │   ├── Minga.Config.Advice
+      │   └── Minga.Filetype.Registry
+      ├── Minga.Buffer.Supervisor (DynamicSupervisor, one_for_one)
+      ├── Minga.Services.Supervisor (rest_for_one)
+      │   ├── Minga.Services.Independent (one_for_one)
+      │   │   ├── Minga.Git.Tracker
+      │   │   ├── Minga.CommandOutput.Registry
+      │   │   ├── Minga.Eval.TaskSupervisor
+      │   │   ├── Minga.Command.Registry
+      │   │   ├── Minga.Fold.Registry
+      │   │   └── Minga.Diagnostics
+      │   ├── Minga.Extension.Registry
+      │   ├── Minga.Extension.Supervisor
+      │   ├── Minga.Config.Loader
+      │   ├── Minga.LSP.Supervisor
+      │   ├── Minga.LSP.SyncServer
+      │   ├── Minga.Project
+      │   └── Minga.Agent.Supervisor
+      └── Minga.Runtime.Supervisor (one_for_one, conditional)
+          ├── Minga.Editor.Watchdog          (independent leaf)
+          ├── Minga.FileWatcher              (independent leaf)
+          └── Minga.Editor.Supervisor (rest_for_one)
+              ├── Minga.Parser.Manager
+              ├── Minga.Port.Manager
+              └── Minga.Editor
 
   In standalone (Burrito) mode, automatically processes CLI arguments
   after the supervision tree is up.
@@ -47,27 +64,9 @@ defmodule Minga.Application do
     DevHandler.attach()
 
     base_children = [
-      Minga.Language.Registry,
-      Minga.Events,
-      Minga.Config.Options,
-      Minga.Keymap.Active,
-      Minga.Config.Hooks,
-      Minga.Config.Advice,
-      Minga.Filetype.Registry,
+      Minga.Foundation.Supervisor,
       {DynamicSupervisor, name: Minga.Buffer.Supervisor, strategy: :one_for_one},
-      Minga.Git.Tracker,
-      {Registry, keys: :unique, name: Minga.CommandOutput.Registry},
-      {Task.Supervisor, name: Minga.Eval.TaskSupervisor},
-      Minga.Command.Registry,
-      Minga.Fold.Registry,
-      Minga.Extension.Registry,
-      Minga.Extension.Supervisor,
-      Minga.Config.Loader,
-      Minga.Diagnostics,
-      Minga.LSP.Supervisor,
-      Minga.LSP.SyncServer,
-      Minga.Project,
-      Minga.Agent.Supervisor
+      Minga.Services.Supervisor
     ]
 
     editor_children =
@@ -76,11 +75,10 @@ defmodule Minga.Application do
         backend = Application.get_env(:minga, :backend, :tui)
 
         [
-          Minga.FileWatcher,
-          Minga.Parser.Manager,
-          {Minga.Port.Manager, [backend: backend]},
-          Minga.Editor.Watchdog,
-          Minga.Editor
+          # Runtime.Supervisor wraps Watchdog, FileWatcher, and Editor.Supervisor
+          # under one_for_one so leaf processes restart independently. A FileWatcher
+          # crash restarts only FileWatcher, not the renderer.
+          {Minga.Runtime.Supervisor, [backend: backend]}
         ]
       else
         []
@@ -91,14 +89,17 @@ defmodule Minga.Application do
     opts = [strategy: :rest_for_one, name: Minga.Supervisor]
     result = Supervisor.start_link(children, opts)
 
-    # Prune old agent sessions in the background
+    # Prune old agent sessions using the supervised Task.Supervisor
+    # (not fire-and-forget Task.start) so crashes are visible.
     if match?({:ok, _}, result) do
-      Task.start(fn -> prune_old_sessions() end)
+      Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, &prune_old_sessions/0)
     end
 
     # In Burrito standalone mode, kick off the CLI
     if Burrito.Util.running_standalone?() do
-      Task.start(fn -> Minga.CLI.start_from_cli() end)
+      Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
+        Minga.CLI.start_from_cli()
+      end)
     end
 
     result

--- a/lib/minga/editor/supervisor.ex
+++ b/lib/minga/editor/supervisor.ex
@@ -1,0 +1,45 @@
+defmodule Minga.Editor.Supervisor do
+  @moduledoc """
+  Supervises the editor runtime: tree-sitter parser, renderer, and Editor GenServer.
+
+  Uses `rest_for_one` to enforce the dependency chain:
+
+      Editor.Supervisor (rest_for_one)
+      ├── Minga.Parser.Manager     Tree-sitter parser Port
+      ├── Minga.Port.Manager       Zig renderer Port
+      └── Minga.Editor             Editor orchestration GenServer
+
+  If Parser.Manager crashes, Port.Manager and Editor restart (Editor has
+  stale highlight state). If Port.Manager crashes, Editor restarts (Editor
+  can't render without the Port). An Editor crash restarts only the Editor.
+
+  This supervisor is conditionally started: it only appears in the
+  supervision tree when the editor UI is active (not in test mode or
+  headless operation).
+  """
+
+  use Supervisor
+
+  @typedoc "Options for starting the editor supervisor."
+  @type start_opt :: {:name, GenServer.name()} | {:backend, Minga.Port.Manager.backend()}
+
+  @spec start_link([start_opt()]) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    Supervisor.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, {Supervisor.sup_flags(), [Supervisor.child_spec()]}}
+  def init(opts) do
+    backend = Keyword.get(opts, :backend, :tui)
+
+    children = [
+      Minga.Parser.Manager,
+      {Minga.Port.Manager, [backend: backend]},
+      Minga.Editor
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+end

--- a/lib/minga/editor/watchdog.ex
+++ b/lib/minga/editor/watchdog.ex
@@ -20,11 +20,11 @@ defmodule Minga.Editor.Watchdog do
 
   ## Supervision placement
 
-  The Watchdog must start before the Editor in the supervision tree
-  so it's ready to receive signals from the moment the Editor boots.
-  It sits alongside the Editor under the `rest_for_one` supervisor.
-  If the Watchdog itself crashes, it gets restarted independently
-  (it has no dependencies on other processes).
+  The Watchdog is an independent leaf child of `Runtime.Supervisor`
+  (`one_for_one`), placed before `Editor.Supervisor` so it's ready to
+  receive signals from the moment the Editor boots. Under `one_for_one`,
+  a Watchdog crash restarts only itself without affecting FileWatcher
+  or Editor.Supervisor.
   """
 
   use GenServer

--- a/lib/minga/foundation/supervisor.ex
+++ b/lib/minga/foundation/supervisor.ex
@@ -1,0 +1,50 @@
+defmodule Minga.Foundation.Supervisor do
+  @moduledoc """
+  Supervises foundational infrastructure that the rest of the application depends on.
+
+  Uses `rest_for_one` because Events (an Elixir Registry) is the pub/sub
+  bus for the entire application. If Events crashes under `one_for_one`,
+  every subscriber silently loses its registration with no error and no
+  crash. `rest_for_one` ensures all children after Events re-initialize
+  and re-subscribe.
+
+  ## Children
+
+      Foundation.Supervisor (rest_for_one)
+      ├── Minga.Language.Registry      ETS, language definitions
+      ├── Minga.Events                 Registry(:duplicate), pub/sub bus
+      ├── Minga.Config.Options         GenServer, typed options
+      ├── Minga.Keymap.Active          Active keymap state
+      ├── Minga.Config.Hooks           Lifecycle hooks
+      ├── Minga.Config.Advice          Before/after command advice (ETS)
+      └── Minga.Filetype.Registry      Filetype detection
+
+  Language.Registry is first because it has no dependencies and nothing
+  depends on it within this group. Events is second so that everything
+  after it re-subscribes on Events restart.
+  """
+
+  use Supervisor
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    Supervisor.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, {Supervisor.sup_flags(), [Supervisor.child_spec()]}}
+  def init(_opts) do
+    children = [
+      Minga.Language.Registry,
+      Minga.Events,
+      Minga.Config.Options,
+      Minga.Keymap.Active,
+      Minga.Config.Hooks,
+      Minga.Config.Advice,
+      Minga.Filetype.Registry
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+end

--- a/lib/minga/runtime/supervisor.ex
+++ b/lib/minga/runtime/supervisor.ex
@@ -1,0 +1,53 @@
+defmodule Minga.Runtime.Supervisor do
+  @moduledoc """
+  Supervises the interactive editor runtime: watchdog, file watcher, and the editor core.
+
+  Uses `one_for_one` so that each child restarts independently:
+
+      Runtime.Supervisor (one_for_one)
+      ├── Minga.Editor.Watchdog      SIGUSR1 recovery (independent leaf)
+      ├── Minga.FileWatcher          FSEvents/inotify watcher (independent leaf)
+      └── Minga.Editor.Supervisor    Parser → Port → Editor (rest_for_one)
+
+  A FileWatcher crash restarts only FileWatcher. A Watchdog crash restarts
+  only Watchdog. Neither cascades into the Editor.Supervisor or each other.
+  The tight Parser → Port → Editor cascade is handled internally by
+  Editor.Supervisor's own `rest_for_one` strategy.
+
+  This supervisor is conditionally started: it only appears in the tree
+  when the editor UI is active (not in test mode or headless operation).
+  """
+
+  use Supervisor
+
+  @typedoc "Options for starting the runtime supervisor."
+  @type start_opt :: {:name, GenServer.name()} | {:backend, Minga.Port.Manager.backend()}
+
+  @spec start_link([start_opt()]) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    Supervisor.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, {Supervisor.sup_flags(), [Supervisor.child_spec()]}}
+  def init(opts) do
+    backend = Keyword.get(opts, :backend, :tui)
+
+    children = [
+      # Watchdog starts first so it's ready to receive SIGUSR1 from the
+      # moment the Editor boots. It's an independent leaf: its crash
+      # restarts only itself under one_for_one.
+      Minga.Editor.Watchdog,
+      # FileWatcher is a leaf: Editor receives messages from it but doesn't
+      # depend on it structurally. A filesystem watcher flake restarts only
+      # FileWatcher, not the renderer.
+      Minga.FileWatcher,
+      # Editor.Supervisor groups the tightly-coupled trio with rest_for_one:
+      # Parser crash → Port + Editor restart, Port crash → Editor restart.
+      {Minga.Editor.Supervisor, [backend: backend]}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/minga/services/independent.ex
+++ b/lib/minga/services/independent.ex
@@ -1,0 +1,42 @@
+defmodule Minga.Services.Independent do
+  @moduledoc """
+  Supervises independent services that have no ordering dependencies.
+
+  Uses `one_for_one` so that a single service crash (e.g., Git.Tracker,
+  Diagnostics) restarts only that service without cascading into siblings
+  or the dependency chains in `Services.Supervisor`.
+
+  ## Children
+
+      Services.Independent (one_for_one)
+      ├── Minga.Git.Tracker              Subscribes to buffer events, ETS registry
+      ├── Minga.CommandOutput.Registry    Registry(:unique)
+      ├── Minga.Eval.TaskSupervisor      Task.Supervisor for eval/async work
+      ├── Minga.Command.Registry         Named command lookup
+      ├── Minga.Fold.Registry            Fold state
+      └── Minga.Diagnostics              ETS-backed diagnostics store
+  """
+
+  use Supervisor
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    Supervisor.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, {Supervisor.sup_flags(), [Supervisor.child_spec()]}}
+  def init(_opts) do
+    children = [
+      Minga.Git.Tracker,
+      {Registry, keys: :unique, name: Minga.CommandOutput.Registry},
+      {Task.Supervisor, name: Minga.Eval.TaskSupervisor},
+      Minga.Command.Registry,
+      Minga.Fold.Registry,
+      Minga.Diagnostics
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/minga/services/supervisor.ex
+++ b/lib/minga/services/supervisor.ex
@@ -1,0 +1,76 @@
+defmodule Minga.Services.Supervisor do
+  @moduledoc """
+  Supervises application services: git tracking, extensions, LSP, diagnostics, and more.
+
+  Uses `rest_for_one` at this level to preserve two dependency chains:
+
+  1. Extension.Registry → Extension.Supervisor → Config.Loader
+     (Loader evaluates user config that registers and starts extensions)
+  2. LSP.Supervisor → LSP.SyncServer
+     (SyncServer calls into LSP.Supervisor to ensure clients)
+
+  Independent services (Git.Tracker, Diagnostics, Command.Registry, etc.)
+  are grouped under a nested `one_for_one` supervisor so that a single
+  service crash restarts only that service without cascading into its
+  siblings or the dependency chains below.
+
+  ## Children
+
+      Services.Supervisor (rest_for_one)
+      ├── Services.Independent (one_for_one)
+      │   ├── Minga.Git.Tracker              Subscribes to buffer events, ETS registry
+      │   ├── Minga.CommandOutput.Registry    Registry(:unique)
+      │   ├── Minga.Eval.TaskSupervisor      Task.Supervisor for eval/async work
+      │   ├── Minga.Command.Registry         Named command lookup
+      │   ├── Minga.Fold.Registry            Fold state
+      │   └── Minga.Diagnostics              ETS-backed diagnostics store
+      ├── Minga.Extension.Registry           Extension metadata (Agent)
+      ├── Minga.Extension.Supervisor         DynamicSupervisor for extension processes
+      ├── Minga.Config.Loader                Evaluates user config on init
+      ├── Minga.LSP.Supervisor               DynamicSupervisor for LSP clients
+      ├── Minga.LSP.SyncServer               Subscribes to buffer events, manages LSP sync
+      ├── Minga.Project                      Project root detection, file cache
+      └── Minga.Agent.Supervisor             DynamicSupervisor for agent sessions
+
+  Project is placed after LSP.SyncServer (not before) to match the
+  dependency direction: SyncServer uses RootDetector which may consult
+  Project, but a SyncServer crash should not restart Project. With
+  `rest_for_one`, Project comes after SyncServer so a SyncServer crash
+  cascades to Project and Agent.Supervisor (acceptable: LSP clients need
+  project root re-detection). A Project crash cascades only to
+  Agent.Supervisor.
+  """
+
+  use Supervisor
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    Supervisor.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, {Supervisor.sup_flags(), [Supervisor.child_spec()]}}
+  def init(_opts) do
+    children = [
+      # Independent services under one_for_one: a single service crash
+      # restarts only that service, not its siblings or the chains below.
+      Minga.Services.Independent,
+
+      # Extension chain: Registry → Supervisor → Loader
+      Minga.Extension.Registry,
+      Minga.Extension.Supervisor,
+      Minga.Config.Loader,
+
+      # LSP chain: Supervisor → SyncServer
+      Minga.LSP.Supervisor,
+      Minga.LSP.SyncServer,
+
+      # Project and agents (end of chain, minimal cascade)
+      Minga.Project,
+      Minga.Agent.Supervisor
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+end


### PR DESCRIPTION
# TL;DR

Replaces the flat 26-child `rest_for_one` supervision tree with nested supervisors so that independent subsystem crashes have constrained blast radius. A FileWatcher hiccup no longer kills the Zig renderer and forces a full Editor restart.

Closes #619

## Context

The supervision tree was a single flat `rest_for_one` with 26 children. Any crash in an early child (Config.Options, Events) restarted everything downstream: all buffers, all LSP connections, all agent sessions, and the renderer. Leaf processes like FileWatcher and Watchdog cascaded into the Editor unnecessarily. See #619 for the full analysis, including Archie's review of strategy choices.

## Changes

- **`Minga.Foundation.Supervisor`** (`rest_for_one`): Groups Events, Config, Keymap, and Filetype infrastructure. Uses `rest_for_one` (not `one_for_one`) because an Events crash silently drops all pub/sub subscriptions; downstream children must re-init to re-subscribe.

- **`Minga.Services.Supervisor`** (`rest_for_one`) with **`Minga.Services.Independent`** (`one_for_one`): Independent services (Git.Tracker, Diagnostics, Command.Registry, Fold.Registry, etc.) are nested under `one_for_one` so a single service crash restarts only that service. The Extension.Registry → Extension.Supervisor → Config.Loader chain stays in the outer `rest_for_one` to preserve ordered restart. LSP.SyncServer moved after Project to reduce unnecessary cascade.

- **`Minga.Runtime.Supervisor`** (`one_for_one`): Wraps Watchdog, FileWatcher, and Editor.Supervisor as siblings. FileWatcher and Watchdog are independent leaves whose crashes restart only themselves.

- **`Minga.Editor.Supervisor`** (`rest_for_one`): The tightly-coupled Parser → Port → Editor trio. Port crash cascades to Editor (correct). Parser crash cascades to Port + Editor (correct).

- **Supervised post-startup tasks**: `Task.start/1` (fire-and-forget) replaced with `Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, ...)` for session pruning and Burrito CLI boot. Crashes are now visible.

- **Documentation updated**: `application.ex` moduledoc tree, `ARCHITECTURE.md` supervision tree, `DIAGRAMS.md` Mermaid diagram, `AGENTS.md` project structure, and `watchdog.ex` moduledoc all reflect the new structure.

## Verification

```bash
# All 5296 tests pass, 0 failures
mix test --warnings-as-errors

# Lint (format + credo + compile + dialyzer) passes clean
mix lint
```

For manual verification of fault isolation (with `:observer` or `Process.exit/2`):
- Kill FileWatcher → confirm Editor stays running, no renderer flash
- Kill Git.Tracker → confirm Diagnostics and other services stay up
- Kill Config.Options → confirm Foundation children restart but Services/Runtime stay up

## Acceptance Criteria Addressed

- A FileWatcher crash restarts only FileWatcher, not the Parser, Port.Manager, or Editor ✅
- A Watchdog crash restarts only Watchdog, not the Editor ✅
- An individual service crash (Git.Tracker, Diagnostics, Fold.Registry) restarts only that service, not its siblings ✅
- The Extension.Registry → Extension.Supervisor → Config.Loader dependency chain is preserved ✅
- An Events crash restarts all Foundation children so subscribers re-register, but does not restart Buffers, Services, or the Editor directly ✅
- Parser.Manager crash still restarts Port.Manager and Editor ✅
- Port.Manager crash still restarts Editor ✅
- Post-startup tasks use supervised tasks, not fire-and-forget Task.start/1 ✅
- All existing tests pass without modification ✅
- The @moduledoc ASCII tree in application.ex reflects the new structure ✅