### PR TITLE
refactor(editor): replace all Process.alive? with catch :exit

### DIFF
--- a/lib/minga/agent/panel_state.ex
+++ b/lib/minga/agent/panel_state.ex
@@ -84,7 +84,10 @@ defmodule Minga.Agent.PanelState do
   @spec ensure_prompt_buffer(t()) :: t()
   def ensure_prompt_buffer(%__MODULE__{prompt_buffer: pid} = state)
       when is_pid(pid) do
-    if Process.alive?(pid), do: state, else: start_prompt_buffer(state, "")
+    BufferServer.buffer_name(pid)
+    state
+  catch
+    :exit, _ -> start_prompt_buffer(state, "")
   end
 
   def ensure_prompt_buffer(%__MODULE__{} = state), do: start_prompt_buffer(state, "")

--- a/lib/minga/command_output.ex
+++ b/lib/minga/command_output.ex
@@ -147,8 +147,12 @@ defmodule Minga.CommandOutput do
 
   @impl true
   def handle_info({port, {:data, data}}, %{port: port} = state) when is_binary(data) do
-    if state.buffer && Process.alive?(state.buffer) do
-      BufferServer.append(state.buffer, data)
+    if state.buffer do
+      try do
+        BufferServer.append(state.buffer, data)
+      catch
+        :exit, _ -> :ok
+      end
     end
 
     {:noreply, state}
@@ -157,8 +161,12 @@ defmodule Minga.CommandOutput do
   def handle_info({port, {:exit_status, code}}, %{port: port} = state) do
     status_line = "\n\n[Process exited with code #{code}]"
 
-    if state.buffer && Process.alive?(state.buffer) do
-      BufferServer.append(state.buffer, status_line)
+    if state.buffer do
+      try do
+        BufferServer.append(state.buffer, status_line)
+      catch
+        :exit, _ -> :ok
+      end
     end
 
     {:noreply, %{state | port: nil, exit_code: code, running?: false}}
@@ -184,11 +192,10 @@ defmodule Minga.CommandOutput do
 
   @spec ensure_buffer(t()) :: t()
   defp ensure_buffer(%{buffer: buf} = state) when is_pid(buf) do
-    if Process.alive?(buf) do
-      state
-    else
-      create_buffer(state)
-    end
+    BufferServer.buffer_name(buf)
+    state
+  catch
+    :exit, _ -> create_buffer(state)
   end
 
   defp ensure_buffer(state), do: create_buffer(state)

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -20,6 +20,7 @@ defmodule Minga.Editor.Commands.Agent do
   alias Minga.Agent.SlashCommand
   alias Minga.Agent.View.Preview
   alias Minga.Agent.View.State, as: ViewState
+  alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Clipboard
   alias Minga.Editor.Commands
   alias Minga.Editor.Commands.AgentSession
@@ -99,11 +100,16 @@ defmodule Minga.Editor.Commands.Agent do
   defp ensure_agent_state(state) do
     agent = AgentAccess.agent(state)
 
-    if agent.buffer == nil or not is_pid(agent.buffer) or not Process.alive?(agent.buffer) do
-      # Create the agent buffer and ensure agent tab exists for state storage
+    if agent.buffer == nil or not is_pid(agent.buffer) do
       ensure_agent_tab(state)
     else
-      state
+      try do
+        # Verify the buffer is responsive
+        BufferServer.buffer_name(agent.buffer)
+        state
+      catch
+        :exit, _ -> ensure_agent_tab(state)
+      end
     end
   end
 
@@ -131,8 +137,13 @@ defmodule Minga.Editor.Commands.Agent do
   defp ensure_agent_buffer(state) do
     agent = AgentAccess.agent(state)
 
-    if is_pid(agent.buffer) and Process.alive?(agent.buffer) do
-      state
+    if is_pid(agent.buffer) do
+      try do
+        BufferServer.buffer_name(agent.buffer)
+        state
+      catch
+        :exit, _ -> create_agent_buffer(state)
+      end
     else
       create_agent_buffer(state)
     end
@@ -153,13 +164,19 @@ defmodule Minga.Editor.Commands.Agent do
   defp apply_agent_split(state) do
     agent = AgentAccess.agent(state)
 
-    if is_pid(agent.buffer) and Process.alive?(agent.buffer) do
-      state
-      |> LayoutPreset.apply(:agent_right, agent.buffer)
-      |> Layout.invalidate()
-      |> EditorState.invalidate_all_windows()
-      |> maybe_start_session()
-      |> then(&update_agent(&1, fn a -> AgentState.focus_input(a, true) end))
+    if is_pid(agent.buffer) do
+      try do
+        BufferServer.buffer_name(agent.buffer)
+
+        state
+        |> LayoutPreset.apply(:agent_right, agent.buffer)
+        |> Layout.invalidate()
+        |> EditorState.invalidate_all_windows()
+        |> maybe_start_session()
+        |> then(&update_agent(&1, fn a -> AgentState.focus_input(a, true) end))
+      catch
+        :exit, _ -> state
+      end
     else
       state
     end

--- a/lib/minga/editor/commands/buffer_management.ex
+++ b/lib/minga/editor/commands/buffer_management.ex
@@ -481,10 +481,14 @@ defmodule Minga.Editor.Commands.BufferManagement do
   def apply_filetype_change(state, filetype) when is_atom(filetype) do
     buf = state.buffers.active
 
-    if is_pid(buf) and Process.alive?(buf) do
-      BufferServer.set_filetype(buf, filetype)
-      send(self(), :setup_highlight)
-      %{state | status_msg: "Language: #{filetype}"}
+    if is_pid(buf) do
+      try do
+        BufferServer.set_filetype(buf, filetype)
+        send(self(), :setup_highlight)
+        %{state | status_msg: "Language: #{filetype}"}
+      catch
+        :exit, _ -> %{state | status_msg: "No active buffer"}
+      end
     else
       %{state | status_msg: "No active buffer"}
     end
@@ -676,7 +680,18 @@ defmodule Minga.Editor.Commands.BufferManagement do
     buf = Enum.at(buffers, idx)
 
     # Check if persistent — if so, recreate instead of removing
-    if buf && Process.alive?(buf) && BufferServer.persistent?(buf) do
+    persistent? =
+      if buf do
+        try do
+          BufferServer.persistent?(buf)
+        catch
+          :exit, _ -> false
+        end
+      else
+        false
+      end
+
+    if persistent? do
       # Clear buffer content instead of killing it
       :sys.replace_state(buf, fn s ->
         %{s | document: Document.new("")}
@@ -685,21 +700,29 @@ defmodule Minga.Editor.Commands.BufferManagement do
       %{state | status_msg: "Buffer is persistent — content cleared"}
     else
       buf_name =
-        if buf && Process.alive?(buf) do
-          Helpers.buffer_display_name(buf)
+        if buf do
+          try do
+            Helpers.buffer_display_name(buf)
+          catch
+            :exit, _ -> "[unknown]"
+          end
         else
           "[unknown]"
         end
 
-      if buf && Process.alive?(buf) do
-        path = BufferServer.file_path(buf) || :scratch
+      if buf do
+        try do
+          path = BufferServer.file_path(buf) || :scratch
 
-        Minga.Events.broadcast(
-          :buffer_closed,
-          %Minga.Events.BufferClosedEvent{buffer: buf, path: path}
-        )
+          Minga.Events.broadcast(
+            :buffer_closed,
+            %Minga.Events.BufferClosedEvent{buffer: buf, path: path}
+          )
 
-        GenServer.stop(buf, :normal)
+          GenServer.stop(buf, :normal)
+        catch
+          :exit, _ -> :ok
+        end
       end
 
       Minga.Editor.log_to_messages("Closed: #{buf_name}")
@@ -744,12 +767,10 @@ defmodule Minga.Editor.Commands.BufferManagement do
         :exit, _ -> :ok
       end
 
-      if Process.alive?(session) do
-        try do
-          GenServer.stop(session, :normal)
-        catch
-          :exit, _ -> :ok
-        end
+      try do
+        GenServer.stop(session, :normal)
+      catch
+        :exit, _ -> :ok
       end
     end
 
@@ -798,7 +819,11 @@ defmodule Minga.Editor.Commands.BufferManagement do
   @spec any_buffer_dirty?(state()) :: boolean()
   defp any_buffer_dirty?(state) do
     Enum.any?(state.buffers.list, fn pid ->
-      Process.alive?(pid) and BufferServer.dirty?(pid)
+      try do
+        BufferServer.dirty?(pid)
+      catch
+        :exit, _ -> false
+      end
     end)
   end
 
@@ -841,8 +866,10 @@ defmodule Minga.Editor.Commands.BufferManagement do
   @spec save_all_buffers(state()) :: state()
   defp save_all_buffers(state) do
     Enum.each(state.buffers.list, fn buf ->
-      if Process.alive?(buf) and BufferServer.dirty?(buf) do
-        BufferServer.save(buf)
+      try do
+        if BufferServer.dirty?(buf), do: BufferServer.save(buf)
+      catch
+        :exit, _ -> :ok
       end
     end)
 
@@ -898,7 +925,11 @@ defmodule Minga.Editor.Commands.BufferManagement do
   @spec find_buffer_by_path(state(), String.t()) :: non_neg_integer() | nil
   defp find_buffer_by_path(%{buffers: %{list: buffers}}, file_path) do
     Enum.find_index(buffers, fn buf ->
-      Process.alive?(buf) && BufferServer.file_path(buf) == file_path
+      try do
+        BufferServer.file_path(buf) == file_path
+      catch
+        :exit, _ -> false
+      end
     end)
   end
 
@@ -906,8 +937,13 @@ defmodule Minga.Editor.Commands.BufferManagement do
   defp next_new_buffer_number(buffers) do
     existing =
       buffers
-      |> Enum.filter(&Process.alive?/1)
-      |> Enum.map(&BufferServer.buffer_name/1)
+      |> Enum.flat_map(fn buf ->
+        try do
+          [BufferServer.buffer_name(buf)]
+        catch
+          :exit, _ -> []
+        end
+      end)
       |> Enum.flat_map(fn
         "[new " <> rest ->
           case Integer.parse(String.trim_trailing(rest, "]")) do

--- a/lib/minga/editor/commands/git.ex
+++ b/lib/minga/editor/commands/git.ex
@@ -158,8 +158,15 @@ defmodule Minga.Editor.Commands.Git do
   defp with_git_buffer(%{buffers: %{active: buf}} = state, fun)
        when is_pid(buf) do
     case GitTracker.lookup(buf) do
-      nil -> %{state | status_msg: "Not in a git repository"}
-      git_pid -> if Process.alive?(git_pid), do: fun.(git_pid, buf), else: state
+      nil ->
+        %{state | status_msg: "Not in a git repository"}
+
+      git_pid ->
+        try do
+          fun.(git_pid, buf)
+        catch
+          :exit, _ -> state
+        end
     end
   end
 

--- a/lib/minga/editor/commands/help.ex
+++ b/lib/minga/editor/commands/help.ex
@@ -61,11 +61,10 @@ defmodule Minga.Editor.Commands.Help do
   @spec ensure_help_buffer(state()) :: {state(), pid()}
   defp ensure_help_buffer(%{buffers: %{help: buf}} = state)
        when is_pid(buf) and buf != nil do
-    if Process.alive?(buf) do
-      {state, buf}
-    else
-      start_help_buffer(state)
-    end
+    BufferServer.buffer_name(buf)
+    {state, buf}
+  catch
+    :exit, _ -> start_help_buffer(state)
   end
 
   defp ensure_help_buffer(state) do

--- a/lib/minga/editor/file_watcher_helpers.ex
+++ b/lib/minga/editor/file_watcher_helpers.ex
@@ -85,7 +85,11 @@ defmodule Minga.Editor.FileWatcherHelpers do
     expanded = Path.expand(path)
 
     Enum.find(buffers, fn buf ->
-      Process.alive?(buf) and BufferServer.file_path(buf) == expanded
+      try do
+        BufferServer.file_path(buf) == expanded
+      catch
+        :exit, _ -> false
+      end
     end)
   end
 

--- a/lib/minga/editor/lsp_actions.ex
+++ b/lib/minga/editor/lsp_actions.ex
@@ -248,7 +248,11 @@ defmodule Minga.Editor.LspActions do
     # Check if already open
     idx =
       Enum.find_index(state.buffers.list, fn buf ->
-        Process.alive?(buf) and BufferServer.file_path(buf) == file_path
+        try do
+          BufferServer.file_path(buf) == file_path
+        catch
+          :exit, _ -> false
+        end
       end)
 
     case idx do

--- a/lib/minga/editor/render_pipeline/content_helpers.ex
+++ b/lib/minga/editor/render_pipeline/content_helpers.ex
@@ -596,11 +596,7 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   @doc "Returns the decorations for a window's buffer."
   @spec window_decorations(Window.t()) :: Decorations.t()
   def window_decorations(%{buffer: buf}) when is_pid(buf) do
-    if Process.alive?(buf) do
-      BufferServer.decorations(buf)
-    else
-      Decorations.new()
-    end
+    BufferServer.decorations(buf)
   catch
     :exit, _ -> Decorations.new()
   end
@@ -624,8 +620,15 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   @spec git_signs_for_window(state(), Window.t()) :: %{non_neg_integer() => atom()}
   def git_signs_for_window(_state, %{buffer: buf}) when is_pid(buf) do
     case GitTracker.lookup(buf) do
-      nil -> %{}
-      git_pid -> if Process.alive?(git_pid), do: GitBuffer.signs(git_pid), else: %{}
+      nil ->
+        %{}
+
+      git_pid ->
+        try do
+          GitBuffer.signs(git_pid)
+        catch
+          :exit, _ -> %{}
+        end
     end
   end
 

--- a/lib/minga/editor/startup.ex
+++ b/lib/minga/editor/startup.ex
@@ -165,8 +165,12 @@ defmodule Minga.Editor.Startup do
 
   def initial_tab_bar(active_buf, _scope) do
     file_label =
-      if active_buf && Process.alive?(active_buf) do
-        Commands.Helpers.buffer_display_name(active_buf)
+      if active_buf do
+        try do
+          Commands.Helpers.buffer_display_name(active_buf)
+        catch
+          :exit, _ -> "[no file]"
+        end
       else
         "[no file]"
       end

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -546,7 +546,9 @@ defmodule Minga.Editor.State do
 
   @spec buffer_label(pid()) :: String.t()
   defp buffer_label(pid) when is_pid(pid) do
-    if Process.alive?(pid), do: live_buffer_label(pid), else: "[dead]"
+    live_buffer_label(pid)
+  catch
+    :exit, _ -> "[dead]"
   end
 
   defp buffer_label(_), do: "[unknown]"
@@ -626,15 +628,19 @@ defmodule Minga.Editor.State do
     buf = state.buffers.active
 
     windows =
-      if buf && Process.alive?(buf) do
-        window = Window.new(win_id, buf, max(rows, 1), max(cols, 1))
+      if buf do
+        try do
+          window = Window.new(win_id, buf, max(rows, 1), max(cols, 1))
 
-        %Windows{
-          tree: WindowTree.new(win_id),
-          map: %{win_id => window},
-          active: win_id,
-          next_id: win_id + 1
-        }
+          %Windows{
+            tree: WindowTree.new(win_id),
+            map: %{win_id => window},
+            active: win_id,
+            next_id: win_id + 1
+          }
+        catch
+          :exit, _ -> %Windows{}
+        end
       else
         %Windows{}
       end

--- a/lib/minga/editor/tab_bar_renderer.ex
+++ b/lib/minga/editor/tab_bar_renderer.ex
@@ -418,7 +418,15 @@ defmodule Minga.Editor.TabBarRenderer do
   defp tab_dirty_marker(%Tab{kind: :file} = tab, _colors) do
     buf = tab_active_buffer(tab)
 
-    if is_pid(buf) and Process.alive?(buf) and BufferServer.dirty?(buf), do: " ●", else: ""
+    if is_pid(buf) do
+      try do
+        if BufferServer.dirty?(buf), do: " ●", else: ""
+      catch
+        :exit, _ -> ""
+      end
+    else
+      ""
+    end
   end
 
   defp tab_dirty_marker(_, _), do: ""

--- a/lib/minga/editor/tree_renderer.ex
+++ b/lib/minga/editor/tree_renderer.ex
@@ -485,8 +485,13 @@ defmodule Minga.Editor.TreeRenderer do
   @spec compute_dirty_paths(EditorState.t()) :: MapSet.t(String.t())
   defp compute_dirty_paths(%{buffers: %{list: buffer_list}}) do
     buffer_list
-    |> Enum.filter(fn pid -> Process.alive?(pid) and BufferServer.dirty?(pid) end)
-    |> Enum.map(fn pid -> BufferServer.file_path(pid) end)
+    |> Enum.flat_map(fn pid ->
+      try do
+        if BufferServer.dirty?(pid), do: [BufferServer.file_path(pid)], else: []
+      catch
+        :exit, _ -> []
+      end
+    end)
     |> Enum.reject(&is_nil/1)
     |> Enum.map(&Path.expand/1)
     |> MapSet.new()

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -148,8 +148,12 @@ defmodule Minga.Extension.Supervisor do
   """
   @spec stop_extension(GenServer.server(), GenServer.server(), atom(), ExtRegistry.entry()) :: :ok
   def stop_extension(supervisor, registry, name, entry) do
-    if is_pid(entry.pid) and Process.alive?(entry.pid) do
-      DynamicSupervisor.terminate_child(supervisor, entry.pid)
+    if is_pid(entry.pid) do
+      try do
+        DynamicSupervisor.terminate_child(supervisor, entry.pid)
+      catch
+        :exit, _ -> :ok
+      end
     end
 
     if entry.module do

--- a/lib/minga/file_watcher.ex
+++ b/lib/minga/file_watcher.ex
@@ -175,17 +175,24 @@ defmodule Minga.FileWatcher do
 
   @spec ensure_watcher(pid() | nil, %{String.t() => pos_integer()}) :: pid() | nil
   defp ensure_watcher(existing_watcher, dirs) when map_size(dirs) == 0 do
-    if existing_watcher && Process.alive?(existing_watcher) do
-      GenServer.stop(existing_watcher)
+    if existing_watcher do
+      try do
+        GenServer.stop(existing_watcher)
+      catch
+        :exit, _ -> :ok
+      end
     end
 
     nil
   end
 
   defp ensure_watcher(existing_watcher, dirs) do
-    if existing_watcher && Process.alive?(existing_watcher) do
-      # Restart watcher with updated directory list
-      GenServer.stop(existing_watcher)
+    if existing_watcher do
+      try do
+        GenServer.stop(existing_watcher)
+      catch
+        :exit, _ -> :ok
+      end
     end
 
     dir_list = Map.keys(dirs)

--- a/lib/minga/git/tracker.ex
+++ b/lib/minga/git/tracker.ex
@@ -83,11 +83,8 @@ defmodule Minga.Git.Tracker do
         :ok
 
       git_pid ->
-        if Process.alive?(git_pid) do
-          {content, _cursor} = BufferServer.content_and_cursor(buffer_pid)
-          GitBuffer.update(git_pid, content)
-        end
-
+        {content, _cursor} = BufferServer.content_and_cursor(buffer_pid)
+        GitBuffer.update(git_pid, content)
         :ok
     end
   catch
@@ -174,11 +171,8 @@ defmodule Minga.Git.Tracker do
         :ok
 
       git_pid ->
-        if Process.alive?(git_pid) do
-          {content, _cursor} = BufferServer.content_and_cursor(buf)
-          GitBuffer.invalidate_base(git_pid, content)
-        end
-
+        {content, _cursor} = BufferServer.content_and_cursor(buf)
+        GitBuffer.invalidate_base(git_pid, content)
         :ok
     end
   catch

--- a/lib/minga/input/agent_chat_nav.ex
+++ b/lib/minga/input/agent_chat_nav.ex
@@ -80,8 +80,12 @@ defmodule Minga.Input.AgentChatNav do
   defp handle_chat_nav(state, cp, mods) do
     agent = AgentAccess.agent(state)
 
-    if is_pid(agent.buffer) and Process.alive?(agent.buffer) do
-      {:handled, delegate_to_mode_fsm(state, agent.buffer, cp, mods)}
+    if is_pid(agent.buffer) do
+      try do
+        {:handled, delegate_to_mode_fsm(state, agent.buffer, cp, mods)}
+      catch
+        :exit, _ -> {:passthrough, state}
+      end
     else
       {:passthrough, state}
     end

--- a/lib/minga/input/agent_panel.ex
+++ b/lib/minga/input/agent_panel.ex
@@ -156,17 +156,21 @@ defmodule Minga.Input.AgentPanel do
     panel = AgentAccess.panel(state)
     prompt_pid = panel.prompt_buffer
 
-    if is_pid(prompt_pid) and Process.alive?(prompt_pid) do
-      real_active = state.buffers.active
-      state = put_in(state.buffers.active, prompt_pid)
-      state = Minga.Editor.do_handle_key(state, cp, mods)
+    if is_pid(prompt_pid) do
+      try do
+        real_active = state.buffers.active
+        state = put_in(state.buffers.active, prompt_pid)
+        state = Minga.Editor.do_handle_key(state, cp, mods)
 
-      # Only restore if a command didn't legitimately change buffers.active.
-      # Same guard as AgentChatNav.delegate_to_mode_fsm/4.
-      if state.buffers.active == prompt_pid do
-        put_in(state.buffers.active, real_active)
-      else
-        state
+        # Only restore if a command didn't legitimately change buffers.active.
+        # Same guard as AgentChatNav.delegate_to_mode_fsm/4.
+        if state.buffers.active == prompt_pid do
+          put_in(state.buffers.active, real_active)
+        else
+          state
+        end
+      catch
+        :exit, _ -> state
       end
     else
       # No prompt buffer, try scope bindings
@@ -188,8 +192,12 @@ defmodule Minga.Input.AgentPanel do
   defp delegate_to_mode_fsm(state, cp, mods) do
     buf = AgentAccess.agent(state).buffer
 
-    if is_pid(buf) and Process.alive?(buf) do
-      AgentChatNav.delegate_to_mode_fsm(state, buf, cp, mods)
+    if is_pid(buf) do
+      try do
+        AgentChatNav.delegate_to_mode_fsm(state, buf, cp, mods)
+      catch
+        :exit, _ -> state
+      end
     else
       state
     end

--- a/lib/minga/lsp/supervisor.ex
+++ b/lib/minga/lsp/supervisor.ex
@@ -65,7 +65,7 @@ defmodule Minga.LSP.Supervisor do
     supervisor
     |> DynamicSupervisor.which_children()
     |> Enum.find_value(:not_found, fn {_, pid, _, _} ->
-      if is_pid(pid) and Process.alive?(pid) do
+      if is_pid(pid) do
         try do
           if Client.server_name(pid) == server_name and
                GenServer.call(pid, :root_path) == root_path do
@@ -85,7 +85,7 @@ defmodule Minga.LSP.Supervisor do
   def all_clients(supervisor \\ __MODULE__) do
     supervisor
     |> DynamicSupervisor.which_children()
-    |> Enum.filter(fn {_, pid, _, _} -> is_pid(pid) and Process.alive?(pid) end)
+    |> Enum.filter(fn {_, pid, _, _} -> is_pid(pid) end)
     |> Enum.map(fn {_, pid, _, _} -> pid end)
   end
 

--- a/lib/minga/lsp/sync_server.ex
+++ b/lib/minga/lsp/sync_server.ex
@@ -252,13 +252,14 @@ defmodule Minga.LSP.SyncServer do
   defp notify_clients_change([], _buffer_pid), do: :ok
 
   defp notify_clients_change(clients, buffer_pid) do
-    with true <- Process.alive?(buffer_pid),
-         uri when is_binary(uri) <- buffer_uri(buffer_pid) do
+    with uri when is_binary(uri) <- buffer_uri(buffer_pid) do
       {content, _cursor} = BufferServer.content_and_cursor(buffer_pid)
       send_to_alive_clients(clients, fn c -> Client.did_change(c, uri, content) end)
     end
 
     :ok
+  catch
+    :exit, _ -> :ok
   end
 
   @spec buffer_uri(pid()) :: String.t() | nil
@@ -272,7 +273,11 @@ defmodule Minga.LSP.SyncServer do
   @spec send_to_alive_clients([pid()], (pid() -> term())) :: :ok
   defp send_to_alive_clients(clients, fun) do
     Enum.each(clients, fn client ->
-      if Process.alive?(client), do: fun.(client)
+      try do
+        fun.(client)
+      catch
+        :exit, _ -> :ok
+      end
     end)
   end
 

--- a/lib/minga/picker/buffer_source.ex
+++ b/lib/minga/picker/buffer_source.ex
@@ -67,10 +67,14 @@ defmodule Minga.Picker.BufferSource do
     special_fields = [bs.messages, bs.warnings]
 
     special_fields
-    |> Enum.reject(&is_nil/1)
-    |> Enum.filter(&Process.alive?/1)
-    |> Enum.reject(fn pid -> Enum.member?(list, pid) end)
-    |> Enum.map(fn pid -> format_candidate(pid, {:pid, pid}) end)
+    |> Enum.reject(fn pid -> is_nil(pid) or Enum.member?(list, pid) end)
+    |> Enum.flat_map(fn pid ->
+      try do
+        [format_candidate(pid, {:pid, pid})]
+      catch
+        :exit, _ -> []
+      end
+    end)
   end
 
   @impl true
@@ -112,8 +116,10 @@ defmodule Minga.Picker.BufferSource do
 
     pid = Enum.at(buffers, idx)
 
-    if Process.alive?(pid) do
+    try do
       DynamicSupervisor.terminate_child(Minga.Buffer.Supervisor, pid)
+    catch
+      :exit, _ -> :ok
     end
 
     new_buffers = List.delete_at(buffers, idx)
@@ -149,7 +155,9 @@ defmodule Minga.Picker.BufferSource do
   # appear when include_special is true.
   @spec reject_buffer?(pid(), boolean()) :: boolean()
   defp reject_buffer?(buf, include_special) do
-    Process.alive?(buf) and do_reject?(buf, include_special)
+    do_reject?(buf, include_special)
+  catch
+    :exit, _ -> true
   end
 
   @spec do_reject?(pid(), boolean()) :: boolean()

--- a/lib/minga/picker/file_source.ex
+++ b/lib/minga/picker/file_source.ex
@@ -140,7 +140,11 @@ defmodule Minga.Picker.FileSource do
   @spec find_buffer_by_path(map(), String.t()) :: non_neg_integer() | nil
   defp find_buffer_by_path(%{buffers: %{list: buffers}}, file_path) do
     Enum.find_index(buffers, fn buf ->
-      Process.alive?(buf) && BufferServer.file_path(buf) == file_path
+      try do
+        BufferServer.file_path(buf) == file_path
+      catch
+        :exit, _ -> false
+      end
     end)
   end
 

--- a/lib/minga/picker/language_source.ex
+++ b/lib/minga/picker/language_source.ex
@@ -68,7 +68,9 @@ defmodule Minga.Picker.LanguageSource do
 
   @spec current_filetype(term()) :: atom()
   defp current_filetype(%{buffers: %{active: buf}}) when is_pid(buf) do
-    if Process.alive?(buf), do: BufferServer.filetype(buf), else: :text
+    BufferServer.filetype(buf)
+  catch
+    :exit, _ -> :text
   end
 
   defp current_filetype(_state), do: :text

--- a/lib/minga/picker/project_search_source.ex
+++ b/lib/minga/picker/project_search_source.ex
@@ -99,7 +99,11 @@ defmodule Minga.Picker.ProjectSearchSource do
   @spec find_buffer_by_path(map(), String.t()) :: non_neg_integer() | nil
   defp find_buffer_by_path(%{buffers: %{list: buffers}}, file_path) do
     Enum.find_index(buffers, fn buf ->
-      Process.alive?(buf) && BufferServer.file_path(buf) == file_path
+      try do
+        BufferServer.file_path(buf) == file_path
+      catch
+        :exit, _ -> false
+      end
     end)
   end
 

--- a/lib/minga/picker/recent_file_source.ex
+++ b/lib/minga/picker/recent_file_source.ex
@@ -88,7 +88,11 @@ defmodule Minga.Picker.RecentFileSource do
   @spec find_buffer_by_path(map(), String.t()) :: non_neg_integer() | nil
   defp find_buffer_by_path(%{buffers: %{list: buffers}}, file_path) do
     Enum.find_index(buffers, fn buf ->
-      Process.alive?(buf) && BufferServer.file_path(buf) == file_path
+      try do
+        BufferServer.file_path(buf) == file_path
+      catch
+        :exit, _ -> false
+      end
     end)
   end
 

--- a/lib/minga/popup/lifecycle.ex
+++ b/lib/minga/popup/lifecycle.ex
@@ -212,7 +212,7 @@ defmodule Minga.Popup.Lifecycle do
 
     # Fetch buffer lines (with a short timeout to avoid blocking the render)
     lines =
-      if is_pid(buffer_pid) and Process.alive?(buffer_pid) do
+      if is_pid(buffer_pid) do
         try do
           snapshot = BufferServer.render_snapshot(buffer_pid, 0, interior_h)
           snapshot.lines
@@ -238,7 +238,9 @@ defmodule Minga.Popup.Lifecycle do
 
   @spec buffer_title(pid()) :: String.t() | nil
   defp buffer_title(pid) when is_pid(pid) do
-    if Process.alive?(pid), do: BufferServer.buffer_name(pid), else: nil
+    BufferServer.buffer_name(pid)
+  catch
+    :exit, _ -> nil
   end
 
   defp buffer_title(_), do: nil


### PR DESCRIPTION
# TL;DR

Eliminates the TOCTOU race condition in 40+ call sites across 27 files by replacing every `Process.alive?` guard with `catch :exit, _`. Zero `Process.alive?` calls remain in `lib/`.

Part of #624

## Context

`Process.alive?` is a race condition. Between the moment you check and the moment you call the GenServer, the process can die. The `catch :exit` pattern is already established in ~15 places in the codebase (lsp/sync_server.ex, git/tracker.ex, editor/commands.ex). This PR extends it to all remaining sites for consistency and correctness.

Identified during the "let it crash" audit (#624), validated by Archie. This is the mechanical replacement workstream; the Editor buffer monitoring workstream (adding `:DOWN` handlers to clean dead pids from state) remains tracked in #624.

## Changes

Three replacement patterns applied based on call site shape:

- **Single calls** (`if Process.alive?(buf), do: BufferServer.foo(buf)`): Replaced with `try do BufferServer.foo(buf) catch :exit, _ -> fallback end` or function-level `catch` where credo prefers implicit try.

- **List filtering** (`Enum.filter(&Process.alive?/1)`): Replaced with `Enum.flat_map` wrapping the GenServer call in `try/catch`, combining the liveness check with the data fetch in one pass.

- **Redundant guards** (`DynamicSupervisor.which_children` in `lsp/supervisor.ex`): Removed entirely. The supervisor only returns managed children; if it lists a pid, it's alive.

Key files with the most changes: `buffer_management.ex` (9 sites), `picker/buffer_source.ex` (3 sites), `commands/agent.ex` (3 sites), `command_output.ex` (3 sites).

The intent-reviewer caught a bug during review: `lsp/sync_server.ex` had the `Process.alive?` guard removed from `notify_clients_change/2` without adding `catch :exit`. A dead buffer would have crashed SyncServer and cascaded through `rest_for_one` supervision. Fixed before merge.

## Verification

```bash
mix test --warnings-as-errors   # 5297 tests, 0 failures
mix compile --warnings-as-errors # clean
mix dialyzer                    # Total errors: 0
rg "Process\.alive?" lib/       # 0 results
```

## Acceptance Criteria Addressed

- ✅ Zero uses of `Process.alive?` in `lib/`
- ✅ All existing tests pass
- ⏭️ Editor monitors buffer pids on `:DOWN` (deferred, tracked in #624)