### PR TITLE
fix(agent): remove explicit background highlight from chat messages

### DIFF
--- a/lib/minga/agent/chat_decorations.ex
+++ b/lib/minga/agent/chat_decorations.ex
@@ -106,13 +106,6 @@ defmodule Minga.Agent.ChatDecorations do
         priority: 10
       )
 
-    {_id, decs} =
-      Decorations.add_highlight(decs, {line, 0}, {line + line_count, 0},
-        style: [bg: theme.header_bg],
-        priority: -20,
-        group: :chat_bg
-      )
-
     # Spinner as EOL virtual text when streaming (updates on each sync call)
     decs =
       if streaming do
@@ -414,13 +407,6 @@ defmodule Minga.Agent.ChatDecorations do
         placement: :above,
         render: fn _w -> [{"▎ You", [fg: theme.user_border, bold: true, bg: theme.header_bg]}] end,
         priority: 10
-      )
-
-    {_id, decs} =
-      Decorations.add_highlight(decs, {line, 0}, {line + line_count, 0},
-        style: [bg: theme.header_bg],
-        priority: -20,
-        group: :chat_bg
       )
 
     # Colored border prefix on each content line

--- a/test/minga/agent/chat_decorations_test.exs
+++ b/test/minga/agent/chat_decorations_test.exs
@@ -9,7 +9,7 @@ defmodule Minga.Agent.ChatDecorationsTest do
   end
 
   describe "build_decorations/3" do
-    test "user message gets header block and background highlight" do
+    test "user message gets header block decoration" do
       decs = Decorations.new()
       messages = [{:user, "hello world"}]
       offsets = [{0, 0, 3}]
@@ -17,10 +17,9 @@ defmodule Minga.Agent.ChatDecorationsTest do
       result = ChatDecorations.build_decorations(decs, messages, offsets, test_theme())
 
       assert Decorations.has_block_decorations?(result)
-      assert Decorations.highlight_count(result) > 0
     end
 
-    test "assistant message gets header block and background highlight" do
+    test "assistant message gets header block decoration" do
       decs = Decorations.new()
       messages = [{:assistant, "I can help with that."}]
       offsets = [{0, 0, 3}]
@@ -28,7 +27,6 @@ defmodule Minga.Agent.ChatDecorationsTest do
       result = ChatDecorations.build_decorations(decs, messages, offsets, test_theme())
 
       assert Decorations.has_block_decorations?(result)
-      assert Decorations.highlight_count(result) > 0
     end
 
     test "collapsed thinking gets fold region" do


### PR DESCRIPTION
## Problem

Agent reply text (and user message text) in the chat panel had a visible dark/black background that didn't match the surrounding buffer background.

## Root Cause

Both assistant and user messages had an `add_highlight` call painting `bg: theme.header_bg` across the entire message body. That color (`0x1E2127` in doom_one) is noticeably darker than the buffer background (`0x282C34`), creating a visible dark band behind all chat text.

## Fix

Removed the two body-level background highlights in `chat_decorations.ex`. Message text now inherits the buffer's default background color. The header labels ("▎ Agent", "▎ You") still keep their `header_bg` background on the label line only. Code block highlights are unaffected.

## Testing

- Updated tests in `chat_decorations_test.exs` to reflect the removed highlights
- `mix lint` passes clean
- Visual verification needed to confirm the background matches