### PR TITLE
feat: terminal scroll regions for single-line viewport shifts

### DIFF
--- a/lib/minga/editor/render_pipeline/emit.ex
+++ b/lib/minga/editor/render_pipeline/emit.ex
@@ -5,11 +5,21 @@ defmodule Minga.Editor.RenderPipeline.Emit do
   Converts the composed `Frame` into protocol command binaries and
   sends them to the Zig renderer port. Also sends title and window
   background color when they change (side-channel writes).
+
+  ## Scroll region optimization
+
+  When the viewport shifts by 1-3 lines between frames and no structural
+  changes occurred (layout, gutter width, window set), the emit stage
+  sends a `scroll_region` command instead of a full `clear + redraw`.
+  The terminal emulator shifts its internal buffer, then only the newly
+  revealed lines are drawn. This eliminates the majority of cell writes
+  for the most common scroll case (Ctrl-e/y, mouse wheel, cursor near edges).
   """
 
   alias Minga.Config.Options
   alias Minga.Editor.DisplayList
-  alias Minga.Editor.DisplayList.Frame
+  alias Minga.Editor.DisplayList.{Frame, Overlay, WindowFrame}
+  alias Minga.Editor.Layout
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.TabBar
   alias Minga.Editor.Title
@@ -20,14 +30,29 @@ defmodule Minga.Editor.RenderPipeline.Emit do
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
 
+  @typedoc "Scroll delta info for one window."
+  @type scroll_delta :: %{
+          win_id: pos_integer(),
+          delta: integer(),
+          content_rect: Layout.rect()
+        }
+
+  # Maximum viewport delta for scroll region optimization.
+  @max_scroll_delta 3
+
   @doc """
   Converts the frame to protocol command binaries and sends them to
-  the Zig port. Also sends title and window background color when they
-  change (side-channel writes).
+  the Zig port. Uses scroll region optimization when possible.
+
+  Also sends title and window background color when they change
+  (side-channel writes).
   """
   @spec emit(Frame.t(), state()) :: :ok
   def emit(frame, state) do
-    commands = DisplayList.to_commands(frame)
+    scroll_deltas = detect_scroll_regions(state)
+    commands = build_commands(frame, scroll_deltas)
+    update_tracking(state)
+
     byte_count = IO.iodata_length(commands)
 
     Telemetry.span([:minga, :port, :emit], %{byte_count: byte_count}, fn ->
@@ -37,6 +62,298 @@ defmodule Minga.Editor.RenderPipeline.Emit do
       :ok
     end)
   end
+
+  # ── Scroll region detection ──────────────────────────────────────────────
+
+  @spec detect_scroll_regions(state()) :: [scroll_delta()] | nil
+  defp detect_scroll_regions(state) do
+    prev_tops = Process.get(:emit_prev_viewport_tops)
+    prev_rects = Process.get(:emit_prev_content_rects)
+    prev_gutter_ws = Process.get(:emit_prev_gutter_ws)
+
+    # First frame or no previous data: full redraw
+    if is_nil(prev_tops) or is_nil(prev_rects) or is_nil(prev_gutter_ws) do
+      nil
+    else
+      layout = Layout.get(state)
+      collect_scroll_deltas(state, layout, prev_tops, prev_rects, prev_gutter_ws)
+    end
+  end
+
+  @spec collect_scroll_deltas(
+          state(),
+          Layout.t(),
+          %{pos_integer() => non_neg_integer()},
+          %{pos_integer() => Layout.rect()},
+          %{pos_integer() => non_neg_integer()}
+        ) :: [scroll_delta()] | nil
+  defp collect_scroll_deltas(state, layout, prev_tops, prev_rects, prev_gutter_ws) do
+    current_win_ids = MapSet.new(Map.keys(layout.window_layouts))
+    prev_win_ids = MapSet.new(Map.keys(prev_tops))
+
+    # Window set changed (split/close): full redraw
+    if current_win_ids != prev_win_ids do
+      nil
+    else
+      prev_versions = Process.get(:emit_prev_buf_versions, %{})
+
+      prev = %{
+        tops: prev_tops,
+        rects: prev_rects,
+        gutter_ws: prev_gutter_ws,
+        buf_versions: prev_versions
+      }
+
+      deltas =
+        Enum.reduce_while(layout.window_layouts, [], fn {win_id, win_layout}, acc ->
+          window = Map.get(state.windows.map, win_id)
+          check_window_scroll(window, win_id, win_layout, prev, acc)
+        end)
+
+      case deltas do
+        list when is_list(list) and list != [] -> Enum.reverse(list)
+        _ -> nil
+      end
+    end
+  end
+
+  @spec check_window_scroll(
+          Minga.Editor.Window.t() | nil,
+          pos_integer(),
+          Layout.window_layout(),
+          map(),
+          list()
+        ) :: {:cont, list()} | {:halt, atom()}
+  defp check_window_scroll(nil, _win_id, _win_layout, _prev, acc), do: {:cont, acc}
+
+  defp check_window_scroll(window, win_id, win_layout, prev, acc) do
+    if match?({:agent_chat, _}, window.content) do
+      {:cont, acc}
+    else
+      compare_window_scroll(window, win_id, win_layout, prev, acc)
+    end
+  end
+
+  @spec compare_window_scroll(
+          Minga.Editor.Window.t(),
+          pos_integer(),
+          Layout.window_layout(),
+          map(),
+          list()
+        ) :: {:cont, list()} | {:halt, atom()}
+  defp compare_window_scroll(window, win_id, win_layout, prev, acc) do
+    prev_rect = Map.get(prev.rects, win_id)
+    current_rect = win_layout.content
+
+    prev_gutter_w = Map.get(prev.gutter_ws, win_id)
+    current_gutter_w = window.last_gutter_w
+
+    prev_top = Map.get(prev.tops, win_id)
+    current_top = window.last_viewport_top
+
+    prev_version = Map.get(prev.buf_versions, win_id)
+    current_version = window.last_buf_version
+
+    classify_scroll_delta(
+      %{
+        prev_rect: prev_rect,
+        cur_rect: current_rect,
+        prev_gw: prev_gutter_w,
+        cur_gw: current_gutter_w,
+        prev_top: prev_top,
+        cur_top: current_top,
+        prev_ver: prev_version,
+        cur_ver: current_version
+      },
+      win_id,
+      acc
+    )
+  end
+
+  # Multi-clause function replacing the cond block (project coding standards).
+  @spec classify_scroll_delta(map(), pos_integer(), list()) ::
+          {:cont, list()} | {:halt, atom()}
+  defp classify_scroll_delta(%{prev_rect: pr, cur_rect: cr}, _, _) when pr != cr,
+    do: {:halt, :layout_changed}
+
+  defp classify_scroll_delta(%{prev_gw: pg, cur_gw: cg}, _, _) when pg != cg,
+    do: {:halt, :gutter_changed}
+
+  defp classify_scroll_delta(%{prev_top: pt, cur_top: ct}, _, acc) when pt == ct,
+    do: {:cont, acc}
+
+  defp classify_scroll_delta(%{prev_top: pt, cur_top: ct}, _, _)
+       when abs(ct - pt) > @max_scroll_delta,
+       do: {:halt, :delta_too_large}
+
+  # Buffer content changed (edits, highlight updates, decorations) during scroll.
+  # Fall back to full redraw so shifted rows show correct content.
+  defp classify_scroll_delta(%{prev_ver: pv, cur_ver: cv}, _, _) when pv != cv,
+    do: {:halt, :content_changed}
+
+  defp classify_scroll_delta(%{cur_rect: rect, prev_top: pt, cur_top: ct}, win_id, acc) do
+    {:cont, [%{win_id: win_id, delta: ct - pt, content_rect: rect} | acc]}
+  end
+
+  # ── Command building ─────────────────────────────────────────────────────
+
+  @spec build_commands(Frame.t(), [scroll_delta()] | nil) :: [binary()]
+  defp build_commands(frame, nil) do
+    # Full redraw path (existing behavior)
+    DisplayList.to_commands(frame)
+  end
+
+  defp build_commands(frame, scroll_deltas) do
+    # Scroll region path: skip clear, send scroll_region + partial content + all chrome
+    scroll_cmds = build_scroll_commands(scroll_deltas)
+    new_content_draws = collect_new_content_draws(frame, scroll_deltas)
+    chrome_draws = collect_chrome_draws(frame)
+    overlay_draws = collect_overlay_draws(frame)
+
+    scroll_cmds ++
+      frame.regions ++
+      DisplayList.draws_to_commands(chrome_draws) ++
+      DisplayList.draws_to_commands(new_content_draws) ++
+      DisplayList.draws_to_commands(overlay_draws) ++
+      [
+        Protocol.encode_cursor_shape(frame.cursor.shape),
+        Protocol.encode_cursor(frame.cursor.row, frame.cursor.col),
+        Protocol.encode_batch_end()
+      ]
+  end
+
+  @spec build_scroll_commands([scroll_delta()]) :: [binary()]
+  defp build_scroll_commands(scroll_deltas) do
+    Enum.map(scroll_deltas, fn %{delta: delta, content_rect: {row, _col, _w, height}} ->
+      top_row = row
+      bottom_row = row + height - 1
+      Protocol.encode_scroll_region(top_row, bottom_row, delta)
+    end)
+  end
+
+  @spec collect_new_content_draws(Frame.t(), [scroll_delta()]) :: [DisplayList.draw()]
+  defp collect_new_content_draws(frame, scroll_deltas) do
+    # Build new_rows ranges from scroll deltas. Since WindowFrame.rect is
+    # always {0, 0, w, h} (draws use absolute screen coords), we can't key
+    # by rect. Instead, build a list of new_rows ranges from the content_rects
+    # and match layer row keys against them.
+    all_new_rows = Enum.map(scroll_deltas, &compute_new_rows/1)
+
+    Enum.flat_map(frame.windows, fn wf ->
+      filter_window_draws_for_new_rows(wf, all_new_rows)
+    end)
+  end
+
+  @spec compute_new_rows(scroll_delta()) :: Range.t()
+  defp compute_new_rows(%{delta: delta, content_rect: {row, _col, _w, height}}) do
+    if delta > 0 do
+      # Scrolled down: new content at the bottom
+      bottom = row + height - 1
+      (bottom - delta + 1)..bottom
+    else
+      # Scrolled up: new content at the top
+      row..(row + abs(delta) - 1)
+    end
+  end
+
+  @spec filter_window_draws_for_new_rows(WindowFrame.t(), [Range.t()]) :: [DisplayList.draw()]
+  defp filter_window_draws_for_new_rows(wf, all_new_rows) do
+    # Draws in layers already use absolute screen coordinates (wf.rect is {0,0,...}).
+    # Filter layer entries whose row falls into any of the new_rows ranges.
+    gutter = filter_layer_by_ranges(wf.gutter, all_new_rows)
+    lines = filter_layer_by_ranges(wf.lines, all_new_rows)
+    tildes = filter_layer_by_ranges(wf.tilde_lines, all_new_rows)
+
+    gutter ++ lines ++ tildes
+  end
+
+  @spec filter_layer_by_ranges(DisplayList.render_layer(), [Range.t()]) :: [DisplayList.draw()]
+  defp filter_layer_by_ranges(layer, ranges) do
+    layer
+    |> Enum.filter(fn {row, _runs} -> Enum.any?(ranges, fn r -> row in r end) end)
+    |> Enum.flat_map(fn {row, runs} ->
+      Enum.map(runs, fn {col, text, style} -> {row, col, text, style} end)
+    end)
+  end
+
+  @spec collect_chrome_draws(Frame.t()) :: [DisplayList.draw()]
+  defp collect_chrome_draws(frame) do
+    # Modeline draws are inside window frames; extract them all
+    modeline_draws =
+      Enum.flat_map(frame.windows, fn wf ->
+        {row_off, col_off, _w, _h} = wf.rect
+
+        DisplayList.layer_to_draws(wf.modeline)
+        |> DisplayList.offset_draws(row_off, col_off)
+      end)
+
+    frame.tab_bar ++
+      frame.file_tree ++
+      frame.agentic_view ++
+      frame.separators ++
+      frame.agent_panel ++
+      frame.minibuffer ++
+      modeline_draws ++
+      (frame.splash || [])
+  end
+
+  @spec collect_overlay_draws(Frame.t()) :: [DisplayList.draw()]
+  defp collect_overlay_draws(frame) do
+    Enum.flat_map(frame.overlays, fn %Overlay{draws: draws} -> draws end)
+  end
+
+  # ── Tracking state ───────────────────────────────────────────────────────
+
+  @spec update_tracking(state()) :: :ok
+  defp update_tracking(state) do
+    layout = Layout.get(state)
+
+    tops =
+      Map.new(layout.window_layouts, fn {win_id, _wl} ->
+        window = Map.get(state.windows.map, win_id)
+
+        if window do
+          {win_id, window.last_viewport_top}
+        else
+          {win_id, -1}
+        end
+      end)
+
+    rects =
+      Map.new(layout.window_layouts, fn {win_id, wl} ->
+        {win_id, wl.content}
+      end)
+
+    gutter_ws =
+      Map.new(layout.window_layouts, fn {win_id, _wl} ->
+        window = Map.get(state.windows.map, win_id)
+
+        if window do
+          {win_id, window.last_gutter_w}
+        else
+          {win_id, -1}
+        end
+      end)
+
+    buf_versions =
+      Map.new(layout.window_layouts, fn {win_id, _wl} ->
+        window = Map.get(state.windows.map, win_id)
+
+        if window do
+          {win_id, window.last_buf_version}
+        else
+          {win_id, -1}
+        end
+      end)
+
+    Process.put(:emit_prev_viewport_tops, tops)
+    Process.put(:emit_prev_content_rects, rects)
+    Process.put(:emit_prev_gutter_ws, gutter_ws)
+    Process.put(:emit_prev_buf_versions, buf_versions)
+    :ok
+  end
+
+  # ── Side-channel writes ──────────────────────────────────────────────────
 
   @spec send_title(state()) :: :ok
   defp send_title(state) do

--- a/lib/minga/port/protocol.ex
+++ b/lib/minga/port/protocol.ex
@@ -24,6 +24,7 @@ defmodule Minga.Port.Protocol do
   | 0x12   | clear            | (empty)                                                              |
   | 0x13   | batch_end        | (empty)                                                              |
   | 0x15   | set_cursor_shape | `shape::8` (BLOCK=0, BEAM=1, UNDERLINE=2)                           |
+  | 0x1B   | scroll_region    | `top_row::16, bottom_row::16, delta::16-signed`                      |
 
   ## Modifier Flags
 
@@ -59,6 +60,7 @@ defmodule Minga.Port.Protocol do
   @op_clear_region 0x18
   @op_destroy_region 0x19
   @op_set_active_region 0x1A
+  @op_scroll_region 0x1B
 
   # Highlight commands (BEAM → Zig)
   @op_set_language 0x20
@@ -358,6 +360,27 @@ defmodule Minga.Port.Protocol do
   @doc "Encodes a set_active_region command. Pass 0 to reset to root."
   @spec encode_set_active_region(non_neg_integer()) :: binary()
   def encode_set_active_region(id), do: <<@op_set_active_region, id::16>>
+
+  @doc """
+  Encodes a scroll_region command for terminal scroll optimization.
+
+  Tells the Zig renderer to use ANSI scroll region sequences to shift
+  content within the given screen row range by `delta` lines, avoiding
+  a full redraw.
+
+  * `top_row` / `bottom_row` — screen row range (inclusive) for the scroll region.
+  * `delta` — positive = scroll up (content moves up, new lines at bottom),
+              negative = scroll down (content moves down, new lines at top).
+
+  Wire format: `opcode(1) + top_row(2) + bottom_row(2) + delta(2, signed)` = 7 bytes.
+  """
+  @spec encode_scroll_region(non_neg_integer(), non_neg_integer(), integer()) :: binary()
+  def encode_scroll_region(top_row, bottom_row, delta)
+      when is_integer(top_row) and top_row >= 0 and
+             is_integer(bottom_row) and bottom_row >= 0 and
+             is_integer(delta) do
+    <<@op_scroll_region, top_row::16, bottom_row::16, delta::16-signed>>
+  end
 
   @spec encode_region_role(region_role()) :: non_neg_integer()
   defp encode_region_role(:editor), do: @region_editor
@@ -685,6 +708,10 @@ defmodule Minga.Port.Protocol do
 
   def decode_command(<<@op_set_title, len::16, title::binary-size(len)>>) do
     {:ok, {:set_title, title}}
+  end
+
+  def decode_command(<<@op_scroll_region, top_row::16, bottom_row::16, delta::16-signed>>) do
+    {:ok, {:scroll_region, top_row, bottom_row, delta}}
   end
 
   def decode_command(

--- a/test/minga/editor/render_pipeline/emit_test.exs
+++ b/test/minga/editor/render_pipeline/emit_test.exs
@@ -6,7 +6,8 @@ defmodule Minga.Editor.RenderPipeline.EmitTest do
   use ExUnit.Case, async: true
 
   alias Minga.Editor.DisplayList
-  alias Minga.Editor.DisplayList.{Cursor, Frame}
+  alias Minga.Editor.DisplayList.{Cursor, Frame, WindowFrame}
+  alias Minga.Editor.Layout
   alias Minga.Editor.RenderPipeline.Emit
 
   import Minga.Editor.RenderPipeline.TestHelpers
@@ -25,5 +26,243 @@ defmodule Minga.Editor.RenderPipeline.EmitTest do
       assert is_list(commands)
       assert Enum.all?(commands, &is_binary/1)
     end
+
+    test "first frame always does full redraw (clear command present)" do
+      # Clear any previous tracking state
+      Process.delete(:emit_prev_viewport_tops)
+      Process.delete(:emit_prev_content_rects)
+      Process.delete(:emit_prev_gutter_ws)
+
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        splash: [DisplayList.draw(0, 0, "hello")]
+      }
+
+      state = base_state()
+      assert :ok = Emit.emit(frame, state)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      # First command should be clear (0x12)
+      assert [<<0x12>> | _] = commands
+    end
+  end
+
+  describe "scroll region optimization" do
+    setup do
+      # Clear tracking state between tests
+      Process.delete(:emit_prev_viewport_tops)
+      Process.delete(:emit_prev_content_rects)
+      Process.delete(:emit_prev_gutter_ws)
+      :ok
+    end
+
+    test "uses scroll_region when viewport shifts by 1 line" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      # First emit: establishes tracking state (full redraw)
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      assert :ok = Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _first_commands}}
+
+      # Simulate scrolling down by 1 line
+      state2 = simulate_scroll(state, 1)
+      frame2 = build_frame_with_window(state2, viewport_top: 1)
+      assert :ok = Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
+      # Should NOT start with clear (0x12)
+      refute match?([<<0x12>> | _], scroll_commands)
+      # Should contain a scroll_region command (0x1B)
+      assert Enum.any?(scroll_commands, fn cmd ->
+               match?(<<0x1B, _::binary>>, cmd)
+             end)
+    end
+
+    test "uses scroll_region when viewport shifts by 3 lines" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      assert :ok = Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 3)
+      frame2 = build_frame_with_window(state2, viewport_top: 3)
+      assert :ok = Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
+      refute match?([<<0x12>> | _], scroll_commands)
+
+      # Verify the scroll_region delta is 3
+      scroll_cmd =
+        Enum.find(scroll_commands, fn cmd -> match?(<<0x1B, _::binary>>, cmd) end)
+
+      assert <<0x1B, _top::16, _bottom::16, 3::16-signed>> = scroll_cmd
+    end
+
+    test "falls back to full redraw when delta exceeds 3 lines" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      assert :ok = Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 4)
+      frame2 = build_frame_with_window(state2, viewport_top: 4)
+      assert :ok = Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      # Should start with clear (full redraw)
+      assert [<<0x12>> | _] = commands
+    end
+
+    test "falls back to full redraw when no scroll happened" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 5)
+      frame1 = build_frame_with_window(state1, viewport_top: 5)
+      assert :ok = Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      # Same viewport top: no scroll, full redraw (no deltas collected)
+      frame2 = build_frame_with_window(state1, viewport_top: 5)
+      assert :ok = Emit.emit(frame2, state1)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert [<<0x12>> | _] = commands
+    end
+
+    test "scroll_region uses negative delta for scrolling up" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      # Start at line 10
+      state1 = seed_state(state, 10)
+      frame1 = build_frame_with_window(state1, viewport_top: 10)
+      assert :ok = Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      # Scroll up by 2
+      state2 = simulate_scroll(state, 8)
+      frame2 = build_frame_with_window(state2, viewport_top: 8)
+      assert :ok = Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
+      refute match?([<<0x12>> | _], scroll_commands)
+
+      scroll_cmd =
+        Enum.find(scroll_commands, fn cmd -> match?(<<0x1B, _::binary>>, cmd) end)
+
+      assert <<0x1B, _top::16, _bottom::16, delta::16-signed>> = scroll_cmd
+      assert delta == -2
+    end
+
+    test "always includes batch_end in scroll region commands" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      assert :ok = Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 1)
+      frame2 = build_frame_with_window(state2, viewport_top: 1)
+      assert :ok = Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      # Last command should be batch_end (0x13)
+      assert <<0x13>> = List.last(commands)
+    end
+
+    test "always includes cursor commands in scroll region output" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      assert :ok = Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 1)
+      frame2 = build_frame_with_window(state2, viewport_top: 1)
+      assert :ok = Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      # Should contain set_cursor (0x11) and set_cursor_shape (0x15)
+      assert Enum.any?(commands, fn cmd -> match?(<<0x11, _::binary>>, cmd) end)
+      assert Enum.any?(commands, fn cmd -> match?(<<0x15, _::binary>>, cmd) end)
+    end
+  end
+
+  # ── Test helpers ──────────────────────────────────────────────────────────
+
+  defp long_content(n) do
+    Enum.map_join(1..n, "\n", fn i -> "line #{i}: content here for testing" end)
+  end
+
+  # Sets up the window tracking fields as if a render pass completed at the given
+  # viewport top. Ensures gutter_w and buf_version are consistent across frames.
+  defp simulate_scroll(state, new_top) do
+    win_id = state.windows.active
+    window = Map.get(state.windows.map, win_id)
+
+    updated_window = %{
+      window
+      | last_viewport_top: new_top,
+        last_gutter_w: 4,
+        last_buf_version: 1,
+        last_line_count: 100,
+        last_cursor_line: new_top
+    }
+
+    new_map = Map.put(state.windows.map, win_id, updated_window)
+    %{state | windows: %{state.windows | map: new_map}}
+  end
+
+  # Seeds the initial tracking state so the first frame has consistent values.
+  # Without this, the sentinel values (-1) cause spurious gutter-width mismatches.
+  defp seed_state(state, viewport_top) do
+    simulate_scroll(state, viewport_top)
+  end
+
+  defp build_frame_with_window(state, opts) do
+    viewport_top = Keyword.get(opts, :viewport_top, 0)
+    layout = Layout.put(state) |> Layout.get()
+
+    win_id = state.windows.active
+    win_layout = Map.get(layout.window_layouts, win_id)
+    {_row, _col, width, height} = win_layout.content
+
+    # Build some content draws for the visible area
+    content_draws =
+      for row <- 0..(height - 1) do
+        DisplayList.draw(row, 4, "line #{viewport_top + row}: content",
+          fg: 0xBBC2CF,
+          bg: 0x282C34
+        )
+      end
+
+    gutter_draws =
+      for row <- 0..(height - 1) do
+        DisplayList.draw(row, 0, String.pad_leading("#{viewport_top + row + 1}", 3) <> " ",
+          fg: 0x5B6268,
+          bg: 0x282C34
+        )
+      end
+
+    win_frame = %WindowFrame{
+      rect: {0, 0, width, height},
+      gutter: DisplayList.draws_to_layer(gutter_draws),
+      lines: DisplayList.draws_to_layer(content_draws),
+      tilde_lines: %{},
+      modeline: %{},
+      cursor: nil
+    }
+
+    %Frame{
+      cursor: Cursor.new(0, 4, :block),
+      windows: [win_frame],
+      minibuffer: [DisplayList.draw(height + 1, 0, " ", fg: 0xBBC2CF, bg: 0x282C34)]
+    }
   end
 end

--- a/test/minga/port/protocol_test.exs
+++ b/test/minga/port/protocol_test.exs
@@ -697,4 +697,40 @@ defmodule Minga.Port.ProtocolTest do
       assert length(Enum.uniq(values)) == length(roles)
     end
   end
+
+  # ── Scroll region command ──
+
+  describe "scroll_region" do
+    test "encode_scroll_region produces 7-byte binary with correct layout" do
+      result = Protocol.encode_scroll_region(2, 20, 1)
+      assert <<0x1B, 2::16, 20::16, 1::16-signed>> = result
+      assert byte_size(result) == 7
+    end
+
+    test "encode_scroll_region with negative delta (scroll down)" do
+      result = Protocol.encode_scroll_region(5, 30, -3)
+      assert <<0x1B, 5::16, 30::16, delta::16-signed>> = result
+      assert delta == -3
+    end
+
+    test "encode_scroll_region with zero delta" do
+      result = Protocol.encode_scroll_region(0, 10, 0)
+      assert <<0x1B, 0::16, 10::16, 0::16-signed>> = result
+    end
+
+    test "encode_scroll_region round-trips through decode_command" do
+      encoded = Protocol.encode_scroll_region(3, 22, 2)
+      assert {:ok, {:scroll_region, 3, 22, 2}} = Protocol.decode_command(encoded)
+    end
+
+    test "encode_scroll_region round-trips with negative delta" do
+      encoded = Protocol.encode_scroll_region(1, 19, -1)
+      assert {:ok, {:scroll_region, 1, 19, -1}} = Protocol.decode_command(encoded)
+    end
+
+    test "encode_scroll_region with large row values" do
+      encoded = Protocol.encode_scroll_region(0, 65_535, 3)
+      assert {:ok, {:scroll_region, 0, 65_535, 3}} = Protocol.decode_command(encoded)
+    end
+  end
 end

--- a/test/support/headless_port.ex
+++ b/test/support/headless_port.ex
@@ -382,6 +382,10 @@ defmodule Minga.Test.HeadlessPort do
 
         %{state | waiters: [], frame_count: state.frame_count + 1}
 
+      {:ok, {:scroll_region, top_row, bottom_row, delta}} ->
+        # Simulate terminal scroll region: shift grid rows within the range.
+        scroll_grid_region(state, top_row, bottom_row, delta)
+
       {:ok, {:set_font, _family, _size, _weight, _ligatures}} ->
         # Font config is GUI-only; headless port ignores it.
         state
@@ -420,6 +424,35 @@ defmodule Minga.Test.HeadlessPort do
 
       %{state | grid: List.replace_at(state.grid, row, new_row)}
     end
+  end
+
+  # Simulates ANSI scroll region behavior: shift rows within [top, bottom]
+  # by `delta` positions. Positive delta scrolls up (content moves up, blank
+  # rows appear at the bottom). Negative scrolls down.
+  @spec scroll_grid_region(State.t(), non_neg_integer(), non_neg_integer(), integer()) ::
+          State.t()
+  defp scroll_grid_region(state, top_row, bottom_row, delta) do
+    top = min(top_row, state.height - 1)
+    bottom = min(bottom_row, state.height - 1)
+    blank_row = for _c <- 1..state.width, do: %{char: " ", fg: 0xFFFFFF, bg: 0x000000, attrs: []}
+
+    region = Enum.slice(state.grid, top..bottom)
+    abs_delta = abs(delta)
+
+    shifted =
+      if delta > 0 do
+        # Scroll up: drop first `delta` rows, add blanks at bottom
+        Enum.drop(region, abs_delta) ++ List.duplicate(blank_row, min(abs_delta, length(region)))
+      else
+        # Scroll down: add blanks at top, drop last `delta` rows
+        List.duplicate(blank_row, min(abs_delta, length(region))) ++
+          Enum.take(region, length(region) - abs_delta)
+      end
+
+    # Splice the shifted region back into the grid
+    before = Enum.take(state.grid, top)
+    after_region = Enum.drop(state.grid, bottom + 1)
+    %{state | grid: before ++ Enum.take(shifted, bottom - top + 1) ++ after_region}
   end
 
   @spec blank_grid(pos_integer(), pos_integer()) :: grid()

--- a/zig/src/apprt/tui.zig
+++ b/zig/src/apprt/tui.zig
@@ -75,6 +75,169 @@ pub const VaxisSurface = struct {
         });
     }
 
+    /// Uses ANSI scroll region sequences to shift content within a row range.
+    ///
+    /// This avoids rewriting every cell when the viewport shifts by a few lines.
+    /// The terminal emulator shifts its internal buffer, then the renderer only
+    /// draws the newly revealed lines.
+    ///
+    /// `delta` > 0: scroll up (content moves up, new lines at bottom).
+    /// `delta` < 0: scroll down (content moves down, new lines at top).
+    ///
+    /// After issuing the ANSI sequences, this method syncs libvaxis's
+    /// internal screen buffers (`screen` and `screen_last`) so that the
+    /// subsequent `render()` diff only repaints the newly revealed rows
+    /// instead of the entire screen.
+    pub fn scrollRegion(self: *VaxisSurface, top: u16, bottom: u16, delta: i16) void {
+        const writer = self.tty_writer;
+        if (delta == 0) return;
+        if (top >= bottom) return;
+
+        // Set the scroll region: CSI top;bottom r (1-based rows)
+        writer.print("\x1b[{d};{d}r", .{ @as(u32, top) + 1, @as(u32, bottom) + 1 }) catch return;
+
+        if (delta > 0) {
+            // Scroll up: CSI n S
+            writer.print("\x1b[{d}S", .{@as(u32, @intCast(delta))}) catch return;
+        } else {
+            // Scroll down: CSI n T
+            writer.print("\x1b[{d}T", .{@as(u32, @intCast(-delta))}) catch return;
+        }
+
+        // Reset scroll region to full screen: CSI r
+        writer.writeAll("\x1b[r") catch return;
+
+        // Sync libvaxis screen buffers to match the terminal's post-scroll state.
+        // Without this, render() would diff against stale buffers and repaint
+        // every shifted row (negating the scroll region optimization).
+        syncScreenAfterScroll(self.vx, top, bottom, delta);
+    }
+
+    /// Shifts cells in both `screen` (desired state) and `screen_last`
+    /// (terminal tracking) to match what the terminal did with the scroll
+    /// region sequences. Newly revealed rows are blanked so that
+    /// libvaxis's diff repaints only those rows.
+    fn syncScreenAfterScroll(vx: *vaxis.Vaxis, top: u16, bottom: u16, delta: i16) void {
+        const w: usize = @intCast(vx.screen.width);
+        if (w == 0) return;
+
+        const abs_delta: usize = @intCast(if (delta < 0) -delta else delta);
+        const region_height: usize = @as(usize, bottom) - @as(usize, top) + 1;
+        if (abs_delta >= region_height) return;
+
+        // Shift screen.buf (Cell structs, no owned data, safe to memcpy).
+        shiftScreenBuf(vx.screen.buf, w, top, bottom, delta, abs_delta);
+
+        // Shift screen_last.buf (InternalCell with owned char data).
+        shiftScreenLastBuf(&vx.screen_last, w, top, bottom, delta, abs_delta);
+    }
+
+    /// Shifts Cell structs in the Screen buffer (desired state).
+    /// Cell.grapheme is a slice pointer (not owned); struct copy is safe.
+    fn shiftScreenBuf(buf: []vaxis.Cell, w: usize, top: u16, bottom: u16, delta: i16, abs_delta: usize) void {
+        const t: usize = @intCast(top);
+        const b: usize = @intCast(bottom);
+
+        if (delta > 0) {
+            // Scroll up: shift rows [top+delta..bottom] to [top..bottom-delta]
+            var r: usize = t;
+            while (r <= b - abs_delta) : (r += 1) {
+                const dst_start = r * w;
+                const src_start = (r + abs_delta) * w;
+                @memcpy(buf[dst_start .. dst_start + w], buf[src_start .. src_start + w]);
+            }
+            // Blank newly revealed rows at bottom
+            while (r <= b) : (r += 1) {
+                const start = r * w;
+                for (buf[start .. start + w]) |*cell| {
+                    cell.* = .{};
+                }
+            }
+        } else {
+            // Scroll down: shift rows [top..bottom-delta] to [top+delta..bottom]
+            var r: usize = b;
+            while (r >= t + abs_delta) : (r -= 1) {
+                const dst_start = r * w;
+                const src_start = (r - abs_delta) * w;
+                @memcpy(buf[dst_start .. dst_start + w], buf[src_start .. src_start + w]);
+                if (r == t + abs_delta) break;
+            }
+            // Blank newly revealed rows at top
+            r = t;
+            while (r < t + abs_delta) : (r += 1) {
+                const start = r * w;
+                for (buf[start .. start + w]) |*cell| {
+                    cell.* = .{};
+                }
+            }
+        }
+    }
+
+    /// Shifts InternalCell data in screen_last (terminal tracking buffer).
+    /// InternalCell.char is an ArrayListUnmanaged that owns its bytes via
+    /// the screen_last arena, so we copy character bytes rather than
+    /// struct-copying.
+    fn shiftScreenLastBuf(screen_last: *vaxis.AllocatingScreen, w: usize, top: u16, bottom: u16, delta: i16, abs_delta: usize) void {
+        const t: usize = @intCast(top);
+        const b: usize = @intCast(bottom);
+        const alloc = screen_last.arena.allocator();
+
+        if (delta > 0) {
+            // Scroll up: copy from [top+delta..] to [top..]
+            var r: usize = t;
+            while (r <= b - abs_delta) : (r += 1) {
+                copyInternalRow(screen_last.buf, r, r + abs_delta, w, alloc);
+            }
+            // Blank newly revealed rows at bottom
+            while (r <= b) : (r += 1) {
+                blankInternalRow(screen_last.buf, r, w, alloc);
+            }
+        } else {
+            // Scroll down: copy from [..bottom-delta] to [..+delta]
+            var r: usize = b;
+            while (r >= t + abs_delta) : (r -= 1) {
+                copyInternalRow(screen_last.buf, r, r - abs_delta, w, alloc);
+                if (r == t + abs_delta) break;
+            }
+            // Blank newly revealed rows at top
+            r = t;
+            while (r < t + abs_delta) : (r += 1) {
+                blankInternalRow(screen_last.buf, r, w, alloc);
+            }
+        }
+    }
+
+    /// Copies character data from src_row to dst_row in the InternalCell buffer.
+    fn copyInternalRow(buf: []vaxis.AllocatingScreen.InternalCell, dst_row: usize, src_row: usize, w: usize, alloc: std.mem.Allocator) void {
+        const dst_start = dst_row * w;
+        const src_start = src_row * w;
+
+        for (0..w) |c| {
+            const dst = &buf[dst_start + c];
+            const src = &buf[src_start + c];
+
+            dst.char.clearRetainingCapacity();
+            dst.char.appendSlice(alloc, src.char.items) catch {};
+            dst.style = src.style;
+            dst.skipped = src.skipped;
+            dst.default = src.default;
+        }
+    }
+
+    /// Blanks a row in the InternalCell buffer (space character, default style).
+    fn blankInternalRow(buf: []vaxis.AllocatingScreen.InternalCell, row: usize, w: usize, alloc: std.mem.Allocator) void {
+        const start = row * w;
+
+        for (0..w) |c| {
+            const cell = &buf[start + c];
+            cell.char.clearRetainingCapacity();
+            cell.char.appendSlice(alloc, " ") catch {};
+            cell.style = .{};
+            cell.skipped = false;
+            cell.default = true;
+        }
+    }
+
     pub fn render(self: *VaxisSurface) !void {
         try self.vx.render(self.tty_writer);
     }

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -38,6 +38,7 @@ pub const OP_SET_WINDOW_BG: u8 = 0x17;
 pub const OP_CLEAR_REGION: u8 = 0x18;
 pub const OP_DESTROY_REGION: u8 = 0x19;
 pub const OP_SET_ACTIVE_REGION: u8 = 0x1A;
+pub const OP_SCROLL_REGION: u8 = 0x1B;
 
 // Config commands (BEAM → frontend, TUI ignores)
 pub const OP_SET_FONT: u8 = 0x50;
@@ -228,6 +229,8 @@ pub const RenderCommand = union(enum) {
     clear_region: u16,
     destroy_region: u16,
     set_active_region: u16,
+    // Scroll region (terminal scroll optimization)
+    scroll_region: ScrollRegion,
     // Incremental content sync
     edit_buffer: EditBuffer,
     // Text measurement
@@ -300,6 +303,17 @@ pub const RequestTextobject = struct {
 pub const LoadGrammar = struct {
     name: []const u8,
     path: []const u8,
+};
+
+/// A scroll region command: tells the renderer to use ANSI scroll
+/// region sequences to shift content within a screen row range.
+///
+/// `delta` > 0: scroll up (content moves up, new lines revealed at bottom).
+/// `delta` < 0: scroll down (content moves down, new lines revealed at top).
+pub const ScrollRegion = struct {
+    top_row: u16,
+    bottom_row: u16,
+    delta: i16,
 };
 
 pub const DrawText = struct {
@@ -697,6 +711,15 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
             if (rest.len < 2) return error.Malformed;
             return .{ .set_active_region = std.mem.readInt(u16, rest[0..2], .big) };
         },
+        OP_SCROLL_REGION => {
+            // top_row:2, bottom_row:2, delta:2(signed) = 6 bytes
+            if (rest.len < 6) return error.Malformed;
+            return .{ .scroll_region = .{
+                .top_row = std.mem.readInt(u16, rest[0..2], .big),
+                .bottom_row = std.mem.readInt(u16, rest[2..4], .big),
+                .delta = std.mem.readInt(i16, rest[4..6], .big),
+            } };
+        },
         OP_SET_FONT => {
             // size:2, weight:1, ligatures:1, name_len:2 = 6 bytes after opcode
             if (rest.len < 6) return error.Malformed;
@@ -793,6 +816,7 @@ pub fn commandSize(payload: []const u8) usize {
         OP_CLEAR_REGION => 3, // opcode(1) + id(2)
         OP_DESTROY_REGION => 3, // opcode(1) + id(2)
         OP_SET_ACTIVE_REGION => 3, // opcode(1) + id(2)
+        OP_SCROLL_REGION => 7, // opcode(1) + top_row(2) + bottom_row(2) + delta(2)
         OP_SET_FONT => blk: {
             // opcode(1) + size(2) + weight(1) + ligatures(1) + name_len(2) + name
             if (payload.len < 7) break :blk payload.len;
@@ -1851,4 +1875,93 @@ test "encodeLogMessage buffer too small returns error" {
     var buf: [3]u8 = undefined; // needs at least 4
     const result = encodeLogMessage(&buf, LOG_LEVEL_ERR, "");
     try std.testing.expectError(error.Malformed, result);
+}
+
+// ── Scroll region protocol tests ──────────────────────────────────────────────
+
+test "decode scroll_region with positive delta (scroll up)" {
+    var data: [7]u8 = undefined;
+    data[0] = OP_SCROLL_REGION;
+    std.mem.writeInt(u16, data[1..3], 2, .big); // top_row
+    std.mem.writeInt(u16, data[3..5], 20, .big); // bottom_row
+    std.mem.writeInt(i16, data[5..7], 1, .big); // delta
+    const cmd = try decodeCommand(&data);
+    switch (cmd) {
+        .scroll_region => |sr| {
+            try std.testing.expectEqual(@as(u16, 2), sr.top_row);
+            try std.testing.expectEqual(@as(u16, 20), sr.bottom_row);
+            try std.testing.expectEqual(@as(i16, 1), sr.delta);
+        },
+        else => return error.WrongVariant,
+    }
+}
+
+test "decode scroll_region with negative delta (scroll down)" {
+    var data: [7]u8 = undefined;
+    data[0] = OP_SCROLL_REGION;
+    std.mem.writeInt(u16, data[1..3], 0, .big);
+    std.mem.writeInt(u16, data[3..5], 30, .big);
+    std.mem.writeInt(i16, data[5..7], -3, .big);
+    const cmd = try decodeCommand(&data);
+    switch (cmd) {
+        .scroll_region => |sr| {
+            try std.testing.expectEqual(@as(u16, 0), sr.top_row);
+            try std.testing.expectEqual(@as(u16, 30), sr.bottom_row);
+            try std.testing.expectEqual(@as(i16, -3), sr.delta);
+        },
+        else => return error.WrongVariant,
+    }
+}
+
+test "decode scroll_region truncated returns malformed" {
+    const data = [_]u8{ OP_SCROLL_REGION, 0x00, 0x02, 0x00 }; // only 4 bytes, need 7
+    const result = decodeCommand(&data);
+    try std.testing.expectError(error.Malformed, result);
+}
+
+test "commandSize: scroll_region is 7 bytes" {
+    var data: [7]u8 = undefined;
+    data[0] = OP_SCROLL_REGION;
+    std.mem.writeInt(u16, data[1..3], 0, .big);
+    std.mem.writeInt(u16, data[3..5], 20, .big);
+    std.mem.writeInt(i16, data[5..7], 1, .big);
+    try std.testing.expectEqual(@as(usize, 7), commandSize(&data));
+}
+
+test "batch decode: scroll_region + draw_text + batch_end" {
+    var payload: [7 + 19 + 1]u8 = undefined;
+    // scroll_region: top=1, bottom=20, delta=1
+    payload[0] = OP_SCROLL_REGION;
+    std.mem.writeInt(u16, payload[1..3], 1, .big);
+    std.mem.writeInt(u16, payload[3..5], 20, .big);
+    std.mem.writeInt(i16, payload[5..7], 1, .big);
+    // draw_text: row=20, col=0, "hello"
+    payload[7] = OP_DRAW_TEXT;
+    std.mem.writeInt(u16, payload[8..10], 20, .big); // row
+    std.mem.writeInt(u16, payload[10..12], 0, .big); // col
+    payload[12] = 0xFF;
+    payload[13] = 0xFF;
+    payload[14] = 0xFF; // fg
+    payload[15] = 0x00;
+    payload[16] = 0x00;
+    payload[17] = 0x00; // bg
+    payload[18] = 0x00; // attrs
+    std.mem.writeInt(u16, payload[19..21], 5, .big); // text_len
+    @memcpy(payload[21..26], "hello");
+    // batch_end
+    payload[26] = OP_BATCH_END;
+
+    var offset: usize = 0;
+    var cmds: [3]RenderCommand = undefined;
+    var count: usize = 0;
+    while (offset < payload.len) {
+        const remaining = payload[offset..];
+        cmds[count] = try decodeCommand(remaining);
+        count += 1;
+        offset += commandSize(remaining);
+    }
+    try std.testing.expectEqual(@as(usize, 3), count);
+    try std.testing.expect(cmds[0] == .scroll_region);
+    try std.testing.expect(cmds[1] == .draw_text);
+    try std.testing.expect(cmds[2] == .batch_end);
 }

--- a/zig/src/renderer.zig
+++ b/zig/src/renderer.zig
@@ -164,6 +164,10 @@ pub fn Renderer(comptime SurfaceT: type) type {
                     }
                 },
 
+                .scroll_region => |sr| {
+                    self.surface.scrollRegion(sr.top_row, sr.bottom_row, sr.delta);
+                },
+
                 .set_default_bg => |bg| {
                     self.default_bg = bg;
                     // Fill immediately so the theme background takes effect
@@ -214,6 +218,10 @@ const MockSurface = struct {
     last_cell: ?Cell = null,
     mock_width: u16 = 80,
     mock_height: u16 = 24,
+    scroll_region_count: usize = 0,
+    last_scroll_top: u16 = 0,
+    last_scroll_bottom: u16 = 0,
+    last_scroll_delta: i16 = 0,
     /// No-op writer that discards all output (satisfies set_title).
     tty_writer: NullWriter = .{},
 
@@ -246,6 +254,13 @@ const MockSurface = struct {
 
     pub fn setCursorShape(self: *MockSurface, shape: surface_mod.CursorShape) void {
         self.last_cursor_shape = shape;
+    }
+
+    pub fn scrollRegion(self: *MockSurface, top: u16, bottom: u16, delta: i16) void {
+        self.scroll_region_count += 1;
+        self.last_scroll_top = top;
+        self.last_scroll_bottom = bottom;
+        self.last_scroll_delta = delta;
     }
 
     pub fn render(self: *MockSurface) !void {
@@ -462,6 +477,62 @@ test "draw_text with explicit bg ignores default_bg" {
     const cell = mock.last_cell.?;
     // Cell should use the explicit bg, not default
     try std.testing.expectEqual(@as(u24, 0x123456), cell.bg);
+}
+
+test "handleCommand scroll_region calls surface.scrollRegion" {
+    var mock = MockSurface{};
+    var rend = Renderer(MockSurface).init(&mock, std.testing.allocator);
+    defer rend.deinit();
+
+    try rend.handleCommand(.{ .scroll_region = .{
+        .top_row = 2,
+        .bottom_row = 20,
+        .delta = 1,
+    } });
+    try std.testing.expectEqual(@as(usize, 1), mock.scroll_region_count);
+    try std.testing.expectEqual(@as(u16, 2), mock.last_scroll_top);
+    try std.testing.expectEqual(@as(u16, 20), mock.last_scroll_bottom);
+    try std.testing.expectEqual(@as(i16, 1), mock.last_scroll_delta);
+}
+
+test "handleCommand scroll_region with negative delta" {
+    var mock = MockSurface{};
+    var rend = Renderer(MockSurface).init(&mock, std.testing.allocator);
+    defer rend.deinit();
+
+    try rend.handleCommand(.{ .scroll_region = .{
+        .top_row = 0,
+        .bottom_row = 30,
+        .delta = -3,
+    } });
+    try std.testing.expectEqual(@as(i16, -3), mock.last_scroll_delta);
+}
+
+test "scroll_region then draw_text then batch_end sequence" {
+    var mock = MockSurface{};
+    var rend = Renderer(MockSurface).init(&mock, std.testing.allocator);
+    defer rend.deinit();
+
+    // Scroll region (shift existing content)
+    try rend.handleCommand(.{ .scroll_region = .{
+        .top_row = 0,
+        .bottom_row = 20,
+        .delta = 1,
+    } });
+    // Draw the newly revealed line
+    try rend.handleCommand(.{ .draw_text = .{
+        .row = 20,
+        .col = 0,
+        .fg = 0xFFFFFF,
+        .bg = 0x000000,
+        .attrs = 0,
+        .text = "new line",
+    } });
+    try rend.handleCommand(.batch_end);
+
+    try std.testing.expectEqual(@as(usize, 1), mock.scroll_region_count);
+    try std.testing.expectEqual(@as(usize, 8), mock.cells_written);
+    try std.testing.expectEqual(@as(usize, 1), mock.render_count);
 }
 
 test "clear then draw_text then batch_end full sequence" {

--- a/zig/src/surface.zig
+++ b/zig/src/surface.zig
@@ -50,6 +50,7 @@ pub fn assertSurface(comptime T: type) void {
     if (!@hasDecl(T, "writeCell")) @compileError("Surface missing method: writeCell");
     if (!@hasDecl(T, "showCursor")) @compileError("Surface missing method: showCursor");
     if (!@hasDecl(T, "setCursorShape")) @compileError("Surface missing method: setCursorShape");
+    if (!@hasDecl(T, "scrollRegion")) @compileError("Surface missing method: scrollRegion");
     if (!@hasDecl(T, "render")) @compileError("Surface missing method: render");
     if (!@hasDecl(T, "width")) @compileError("Surface missing method: width");
     if (!@hasDecl(T, "height")) @compileError("Surface missing method: height");


### PR DESCRIPTION
## What

When the viewport shifts by 1-3 lines between frames, the Emit stage now sends a `scroll_region` command instead of `clear + full redraw`. The terminal emulator shifts its internal buffer, then only the newly revealed lines are drawn. This eliminates the majority of cell writes for the most common scroll case (Ctrl-e/y, mouse wheel, cursor near edges).

## How

**Protocol:** New opcode `0x1B scroll_region(top_row:u16, bottom_row:u16, delta:i16-signed)`. Positive delta scrolls up (content moves up, new lines at bottom), negative scrolls down.

**BEAM (Emit stage):** Tracks per-window viewport top, content rect, gutter width, and buffer version across frames. When a small delta (1-3 lines) is detected with no structural changes, emits `scroll_region` + partial content draws + full chrome. Falls back to full redraw for large jumps, layout changes, content edits, or first frame.

**Zig (TUI surface):** Issues ANSI escape sequences (`CSI n;m r` to set scroll region, `CSI n S`/`CSI n T` to scroll, `CSI r` to reset). After the ANSI scroll, syncs libvaxis internal screen buffers (`screen` + `screen_last`) so the subsequent `render()` diff only repaints newly revealed rows.

**Surface interface:** `scrollRegion` added to the comptime interface check. MockSurface tracks scroll calls for testing.

## Files changed

- `lib/minga/port/protocol.ex` - `scroll_region` opcode encoder/decoder
- `lib/minga/editor/render_pipeline/emit.ex` - scroll delta detection, partial draw emission
- `zig/src/protocol.zig` - `scroll_region` opcode decoder, `commandSize`, `RenderCommand` union
- `zig/src/renderer.zig` - handle `scroll_region` command
- `zig/src/surface.zig` - `scrollRegion` in Surface interface
- `zig/src/apprt/tui.zig` - ANSI sequences + libvaxis screen buffer sync
- `test/` - protocol round-trips, emit stage tests, headless port simulation

## Not in scope

- Agent chat scroll regions (separate rendering pipeline, follow-up)
- Capability flag for terminals without CSI scroll support (VT220+ standard, all modern terminals support it)

## Testing

- Protocol round-trip tests for new opcode (BEAM + Zig)
- Emit stage unit tests: delta=1, delta=3, delta>3 fallback, no-scroll fallback, negative delta, batch_end/cursor presence
- Integration test: `line_test.exs:166` (content scrolls when cursor moves past viewport)
- Manual testing on real terminals needed for visual verification

Closes #646