### PR TITLE
fix(popup): close only the active popup, not all popups

### DIFF
--- a/lib/minga/popup/active.ex
+++ b/lib/minga/popup/active.ex
@@ -4,28 +4,29 @@ defmodule Minga.Popup.Active do
 
   When a popup rule fires and creates a managed split (or floating overlay),
   an `Active` struct is stored on the window to record the rule that created
-  it and the layout state needed to restore the previous arrangement when
-  the popup is closed.
+  it and the previous active window id so focus can be restored when the
+  popup is closed.
 
   ## Lifecycle
 
   1. A buffer name matches a `Popup.Rule` in the registry.
-  2. `Popup.Lifecycle.open_popup/3` snapshots the current window tree
-     and active window id, creates the popup split/float, and attaches
-     this struct to the new window's `popup_meta` field.
+  2. `Popup.Lifecycle.open_popup/3` creates the popup split/float and
+     attaches this struct to the new window's `popup_meta` field.
   3. When the user dismisses the popup (quit key, auto-close, or explicit
-     close), `Popup.Lifecycle.close_popup/2` reads this struct to restore
-     the previous layout.
+     close), `Popup.Lifecycle.close_popup/2` removes the popup's window
+     from the current tree via `WindowTree.close/2` (like `delete-window`
+     in Emacs) and restores focus using `previous_active`.
+
+  This approach lets multiple popups coexist: closing one only removes its
+  own window from the tree without affecting other popups.
   """
 
   alias Minga.Editor.Window
-  alias Minga.Editor.WindowTree
   alias Minga.Popup.Rule
 
   @type t :: %__MODULE__{
           rule: Rule.t(),
           window_id: Window.id(),
-          previous_tree: WindowTree.t() | nil,
           previous_active: Window.id()
         }
 
@@ -33,7 +34,6 @@ defmodule Minga.Popup.Active do
   defstruct [
     :rule,
     :window_id,
-    :previous_tree,
     previous_active: 1
   ]
 
@@ -41,15 +41,14 @@ defmodule Minga.Popup.Active do
   Creates a new active popup record.
 
   Captures the rule that matched, the window id of the new popup window,
-  and the layout state from before the popup was opened.
+  and the previously active window id for focus restoration on close.
   """
-  @spec new(Rule.t(), Window.id(), WindowTree.t() | nil, Window.id()) :: t()
-  def new(%Rule{} = rule, window_id, previous_tree, previous_active)
+  @spec new(Rule.t(), Window.id(), Window.id()) :: t()
+  def new(%Rule{} = rule, window_id, previous_active)
       when is_integer(window_id) and is_integer(previous_active) do
     %__MODULE__{
       rule: rule,
       window_id: window_id,
-      previous_tree: previous_tree,
       previous_active: previous_active
     }
   end

--- a/lib/minga/popup/lifecycle.ex
+++ b/lib/minga/popup/lifecycle.ex
@@ -3,8 +3,9 @@ defmodule Minga.Popup.Lifecycle do
   Pure state transformations for opening and closing popup windows.
 
   Popup windows are managed splits (or floating overlays) governed by
-  `Popup.Rule` structs. Opening a popup snapshots the current window tree
-  so closing it restores the original layout.
+  `Popup.Rule` structs. Closing a popup surgically removes its window
+  from the current tree via `WindowTree.close/2`, so multiple popups
+  can coexist without interfering with each other.
 
   All functions are `state -> state` transformations with no side effects.
   The Editor GenServer calls these and handles rendering afterward.
@@ -20,9 +21,13 @@ defmodule Minga.Popup.Lifecycle do
 
   ## Close flow
 
-  1. `close_popup/2` reads the window's `popup_meta` to find the saved tree.
-  2. Restores the window tree to the snapshot, removes the popup window
-     from the map, and returns focus to the previously active window.
+  1. `close_popup/2` removes the popup window from the current tree via
+     `WindowTree.close/2` (like `delete-window` in Emacs).
+  2. Removes the popup window from the map and returns focus to the
+     previously active window.
+
+  This surgical approach lets multiple popups coexist: closing one only
+  removes its own window without affecting other open popups.
   """
 
   alias Minga.Buffer.Server, as: BufferServer
@@ -65,8 +70,8 @@ defmodule Minga.Popup.Lifecycle do
   @doc """
   Closes the popup window with the given id.
 
-  Restores the window tree to the snapshot taken when the popup was opened,
-  removes the popup window from the map, and returns focus to the previously
+  Removes the popup's window from the current tree via `WindowTree.close/2`,
+  removes it from the window map, and returns focus to the previously
   active window. The underlying buffer is kept alive (not killed).
 
   Returns state unchanged if the window id doesn't exist or isn't a popup.
@@ -257,8 +262,6 @@ defmodule Minga.Popup.Lifecycle do
 
   @spec apply_rule(state(), Rule.t(), pid()) :: state()
   defp apply_rule(%{windows: ws} = state, %Rule{display: :split} = rule, buffer_pid) do
-    # Snapshot current layout for restore
-    previous_tree = ws.tree
     previous_active = ws.active
 
     # Create the popup window
@@ -284,7 +287,7 @@ defmodule Minga.Popup.Lifecycle do
         new_tree = apply_split_size(new_tree, next_id, rule, state)
 
         # Attach popup metadata to the new window
-        active = PopupActive.new(rule, next_id, previous_tree, previous_active)
+        active = PopupActive.new(rule, next_id, previous_active)
         popup_window = %{popup_window | popup_meta: active}
 
         # Update state
@@ -309,8 +312,6 @@ defmodule Minga.Popup.Lifecycle do
   end
 
   defp apply_rule(%{windows: ws} = state, %Rule{display: :float} = rule, buffer_pid) do
-    # Snapshot current layout for restore (tree stays unchanged for floats)
-    previous_tree = ws.tree
     previous_active = ws.active
 
     # Create the popup window (not added to the tree, only the map)
@@ -319,7 +320,7 @@ defmodule Minga.Popup.Lifecycle do
     popup_window = Window.new(next_id, buffer_pid, rows, cols)
 
     # Attach popup metadata
-    active = PopupActive.new(rule, next_id, previous_tree, previous_active)
+    active = PopupActive.new(rule, next_id, previous_active)
     popup_window = %{popup_window | popup_meta: active}
 
     # Add window to map but NOT to the tree (floats overlay the layout)
@@ -360,18 +361,13 @@ defmodule Minga.Popup.Lifecycle do
 
     ws = state.windows
 
-    # Restore the tree snapshot if available, otherwise just remove the split
+    # Remove just this popup's window from the current tree (like
+    # delete-window in Emacs). We used to restore a full tree snapshot,
+    # but that clobbers any other popups that were opened after this one.
     new_tree =
-      case meta.previous_tree do
-        nil ->
-          # No snapshot (edge case). Just remove the split.
-          case WindowTree.close(ws.tree, window_id) do
-            {:ok, tree} -> tree
-            :error -> ws.tree
-          end
-
-        tree ->
-          tree
+      case WindowTree.close(ws.tree, window_id) do
+        {:ok, tree} -> tree
+        :error -> ws.tree
       end
 
     # Remove the popup window from the map

--- a/test/minga/editor/window_test.exs
+++ b/test/minga/editor/window_test.exs
@@ -413,7 +413,7 @@ defmodule Minga.Editor.WindowTest do
 
     test "returns true for a window with popup metadata" do
       rule = PopupRule.new("*test*")
-      active = PopupActive.new(rule, 2, nil, 1)
+      active = PopupActive.new(rule, 2, 1)
       window = %{make_window() | popup_meta: active}
       assert Window.popup?(window)
     end

--- a/test/minga/input/popup_test.exs
+++ b/test/minga/input/popup_test.exs
@@ -27,7 +27,7 @@ defmodule Minga.Input.PopupTest do
     main_window = Window.new(1, main_buf, 24, 80)
 
     rule = Rule.new("*test*", quit_key: quit_key)
-    active = PopupActive.new(rule, 2, WindowTree.new(1), 1)
+    active = PopupActive.new(rule, 2, 1)
     popup_window = %{Window.new(2, popup_buf, 24, 80) | popup_meta: active}
 
     vim = %VimState{VimState.new() | mode: mode}
@@ -133,7 +133,7 @@ defmodule Minga.Input.PopupTest do
           height: {:percent, 70}
         )
 
-      active = PopupActive.new(rule, 2, WindowTree.new(1), 1)
+      active = PopupActive.new(rule, 2, 1)
       popup_window = %{Window.new(2, popup_buf, 24, 80) | popup_meta: active}
 
       %EditorState{

--- a/test/minga/popup/lifecycle_test.exs
+++ b/test/minga/popup/lifecycle_test.exs
@@ -72,7 +72,6 @@ defmodule Minga.Popup.LifecycleTest do
       assert Window.popup?(popup_window)
       assert popup_window.popup_meta.rule.side == :bottom
       assert popup_window.popup_meta.previous_active == 1
-      assert popup_window.popup_meta.previous_tree == WindowTree.new(1)
 
       # The tree should be a horizontal split
       assert {:split, :horizontal, _, _, _} = new_state.windows.tree
@@ -185,6 +184,63 @@ defmodule Minga.Popup.LifecycleTest do
     test "is a no-op when active window is not a popup", %{state: state} do
       result = Lifecycle.close_active_popup(state)
       assert result.windows.tree == state.windows.tree
+    end
+  end
+
+  describe "closing one popup preserves other popups" do
+    test "closing the first-opened popup does not clobber the second", %{
+      state: state,
+      popup_buf: popup_buf
+    } do
+      popup_buf2 = fake_pid()
+      on_exit(fn -> if Process.alive?(popup_buf2), do: Process.exit(popup_buf2, :kill) end)
+
+      PopupRegistry.register(Rule.new("*Messages*", side: :bottom, size: {:percent, 25}))
+      PopupRegistry.register(Rule.new("*Warnings*", side: :bottom, size: {:percent, 30}))
+
+      # Open both popups
+      {:ok, with_messages} = Lifecycle.open_popup(state, "*Messages*", popup_buf)
+      {:ok, with_both} = Lifecycle.open_popup(with_messages, "*Warnings*", popup_buf2)
+
+      # Should have 3 windows: main + Messages + Warnings
+      assert map_size(with_both.windows.map) == 3
+
+      # Close Messages (the first-opened popup, window 2)
+      after_close = Lifecycle.close_popup(with_both, 2)
+
+      # Warnings popup (window 3) should still exist
+      assert map_size(after_close.windows.map) == 2
+      assert Map.has_key?(after_close.windows.map, 1), "main window missing"
+      assert Map.has_key?(after_close.windows.map, 3), "Warnings popup was clobbered"
+
+      # Window 3 should still be in the tree
+      leaves = WindowTree.leaves(after_close.windows.tree)
+      assert 3 in leaves, "Warnings popup window not in tree"
+    end
+
+    test "closing the second-opened popup does not affect the first", %{
+      state: state,
+      popup_buf: popup_buf
+    } do
+      popup_buf2 = fake_pid()
+      on_exit(fn -> if Process.alive?(popup_buf2), do: Process.exit(popup_buf2, :kill) end)
+
+      PopupRegistry.register(Rule.new("*Messages*", side: :bottom, size: {:percent, 25}))
+      PopupRegistry.register(Rule.new("*Warnings*", side: :bottom, size: {:percent, 30}))
+
+      {:ok, with_messages} = Lifecycle.open_popup(state, "*Messages*", popup_buf)
+      {:ok, with_both} = Lifecycle.open_popup(with_messages, "*Warnings*", popup_buf2)
+
+      # Close Warnings (the second-opened popup, window 3)
+      after_close = Lifecycle.close_popup(with_both, 3)
+
+      # Messages popup (window 2) should still exist
+      assert map_size(after_close.windows.map) == 2
+      assert Map.has_key?(after_close.windows.map, 1), "main window missing"
+      assert Map.has_key?(after_close.windows.map, 2), "Messages popup was clobbered"
+
+      leaves = WindowTree.leaves(after_close.windows.tree)
+      assert 2 in leaves, "Messages popup window not in tree"
     end
   end
 


### PR DESCRIPTION
# TL;DR

Pressing `q` on a popup split now closes only that popup, not every popup. Previously, having both `*Messages*` and `*Warnings*` open and pressing `q` on one would close both.

## Context

When a popup opens, `Popup.Lifecycle` used to snapshot the entire `WindowTree` and restore it on close. This works fine for a single popup, but breaks when two popups are open: closing the first-opened popup restores a tree that predates the second, clobbering it. The result is a single `q` keystroke closing both popups, which is not how Doom Emacs works.

## Changes

- **Replaced snapshot-restore with surgical tree removal.** `do_close/3` now calls `WindowTree.close/2` to remove just the popup's leaf from the current tree (like `delete-window` in Emacs). Other popup windows are untouched.
- **Removed the `previous_tree` field from `PopupActive`.** It was only used for the snapshot-restore approach. `previous_active` is kept for focus restoration. `PopupActive.new/4` simplified to `new/3`.
- **Updated all docs.** Moduledoc, function docs, and struct docs now accurately describe the surgical removal approach.

## Verification

```bash
mix test.debug test/minga/popup/lifecycle_test.exs
# 26 tests, 0 failures
```

Two new regression tests cover the exact bug:
- "closing the first-opened popup does not clobber the second"
- "closing the second-opened popup does not affect the first"

Manual verification: open Minga, trigger both `*Messages*` and `*Warnings*` popups (e.g. via `SPC b m` and `:warnings`), press `q` on one, confirm the other stays open.

## Acceptance Criteria Addressed

- Pressing `q` on one popup closes only that popup ✅
- Closing the first-opened popup does not clobber the second ✅
- Closing the second-opened popup does not affect the first ✅
- Existing single-popup behavior unchanged (20 pre-existing tests pass) ✅
- Float popups still work correctly (7 float tests pass) ✅