### PR TITLE
fix(agent): use full model spec in UIState and improve :invalid_format logging

### DIFF
--- a/lib/minga/agent/compaction.ex
+++ b/lib/minga/agent/compaction.ex
@@ -178,13 +178,7 @@ defmodule Minga.Agent.Compaction do
     end
   end
 
-  @spec strip_provider_prefix(String.t()) :: String.t()
-  defp strip_provider_prefix(model) do
-    case String.split(model, ":", parts: 2) do
-      [_provider, name] -> name
-      _ -> model
-    end
-  end
+  defdelegate strip_provider_prefix(model), to: Minga.Agent.Config
 
   @spec format_tokens(non_neg_integer()) :: String.t()
   defp format_tokens(tokens) when tokens >= 1000 do

--- a/lib/minga/agent/config.ex
+++ b/lib/minga/agent/config.ex
@@ -165,6 +165,27 @@ defmodule Minga.Agent.Config do
   @spec default_model() :: String.t()
   def default_model, do: @default_model
 
+  @doc """
+  Strips the "provider:" prefix from a model spec string.
+
+  Returns the bare model name. If there's no prefix, returns the string unchanged.
+
+  ## Examples
+
+      iex> Minga.Agent.Config.strip_provider_prefix("anthropic:claude-sonnet-4")
+      "claude-sonnet-4"
+
+      iex> Minga.Agent.Config.strip_provider_prefix("claude-sonnet-4")
+      "claude-sonnet-4"
+  """
+  @spec strip_provider_prefix(String.t()) :: String.t()
+  def strip_provider_prefix(model) when is_binary(model) do
+    case String.split(model, ":", parts: 2) do
+      [_provider, name] -> name
+      [name] -> name
+    end
+  end
+
   # Reads a single option from the Options ETS table, falling back to the
   # given default when the table doesn't exist yet (tests, standalone).
   @spec get(atom(), term()) :: term()

--- a/lib/minga/agent/file_mention.ex
+++ b/lib/minga/agent/file_mention.ex
@@ -41,6 +41,7 @@ defmodule Minga.Agent.FileMention do
           anchor_col: non_neg_integer()
         }
 
+  alias Minga.Agent.Config, as: AgentConfig
   alias Minga.Agent.ModelLimits
   alias ReqLLM.Message.ContentPart
 
@@ -134,7 +135,9 @@ defmodule Minga.Agent.FileMention do
     has_images = Enum.any?(mentions, fn %{path: path} -> image_path?(path) end)
     model = Keyword.get(opts, :model)
 
-    if has_images and model != nil and not ModelLimits.vision_capable?(model) do
+    bare_model = if model, do: AgentConfig.strip_provider_prefix(model), else: nil
+
+    if has_images and bare_model != nil and not ModelLimits.vision_capable?(bare_model) do
       {:error,
        "Model #{model} does not support image input. Use a vision-capable model (Claude, GPT-4o, Gemini)."}
     else

--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -611,8 +611,9 @@ defmodule Minga.Agent.Providers.Native do
   def handle_info({ref, {:error, reason}}, %{task: %Task{ref: ref}} = state) do
     # Task completed with an error
     Process.demonitor(ref, [:flush])
-    Minga.Log.error(:agent, "[Agent.Native] agent loop error: #{inspect(reason)}")
-    notify(state.subscriber, %Event.Error{message: format_error(reason)})
+    formatted = format_error(reason)
+    Minga.Log.error(:agent, "[Agent.Native] agent loop error: #{formatted}")
+    notify(state.subscriber, %Event.Error{message: formatted})
     notify(state.subscriber, %Event.AgentEnd{usage: nil})
     {:noreply, %{state | task: nil, streaming: false}}
   end
@@ -675,6 +676,25 @@ defmodule Minga.Agent.Providers.Native do
 
   @spec do_agent_loop(loop_ctx(), Context.t()) :: :ok | {:error, term()}
   defp do_agent_loop(lctx, context) do
+    # Validate model format before making the API call. A bare model name
+    # like "claude-sonnet-4" will fail with :invalid_format deep in LLMDB.
+    # Return early with a clear error instead of letting it fail cryptically.
+    if not String.contains?(lctx.model, ":") and not String.contains?(lctx.model, "@") do
+      message =
+        ~s|Model "#{lctx.model}" is missing a provider prefix. | <>
+          ~s|Expected "provider:model" (e.g., "anthropic:#{lctx.model}"). | <>
+          "Check :agent_model in your config."
+
+      Minga.Log.error(:agent, "[Agent.Native] #{message}")
+      emit_error_and_end(lctx.provider_pid, message)
+      {:error, :invalid_format}
+    else
+      do_agent_loop_validated(lctx, context)
+    end
+  end
+
+  @spec do_agent_loop_validated(loop_ctx(), Context.t()) :: :ok | {:error, term()}
+  defp do_agent_loop_validated(lctx, context) do
     # Check if context needs compaction before the API call
     context = maybe_compact_context(lctx, context)
 
@@ -1577,13 +1597,7 @@ defmodule Minga.Agent.Providers.Native do
     :ok
   end
 
-  @spec strip_provider_prefix(String.t()) :: String.t()
-  defp strip_provider_prefix(model) do
-    case String.split(model, ":", parts: 2) do
-      [_provider, name] -> name
-      [name] -> name
-    end
-  end
+  defdelegate strip_provider_prefix(model), to: Minga.Agent.Config
 
   @spec emit_error_and_end(pid(), String.t()) :: :ok
   defp emit_error_and_end(provider_pid, message) do
@@ -1652,6 +1666,12 @@ defmodule Minga.Agent.Providers.Native do
   @spec format_error(term()) :: String.t()
   defp format_error(reason) when is_binary(reason), do: reason
   defp format_error(%{message: msg}) when is_binary(msg), do: msg
+
+  defp format_error(:invalid_format) do
+    ~s|Invalid model format. Expected "provider:model" (e.g., "anthropic:claude-sonnet-4"), | <>
+      "got a bare model name without a provider prefix."
+  end
+
   defp format_error(reason), do: inspect(reason)
 
   @spec notify(pid(), Event.t()) :: Event.t()

--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -22,6 +22,7 @@ defmodule Minga.Agent.Session do
   use GenServer
 
   alias Minga.Agent.Branch
+  alias Minga.Agent.Config, as: AgentConfig
   alias Minga.Agent.Credentials
   alias Minga.Agent.Event
   alias Minga.Agent.Message
@@ -1128,7 +1129,7 @@ defmodule Minga.Agent.Session do
     cost = Map.get(usage, :cost, 0.0)
 
     provider = titleize(state.provider_name)
-    model = titleize(state.model_name)
+    model = state.model_name |> AgentConfig.strip_provider_prefix() |> titleize()
 
     cache_part =
       if cr > 0 or cw > 0 do

--- a/lib/minga/agent/ui_state.ex
+++ b/lib/minga/agent/ui_state.ex
@@ -17,6 +17,7 @@ defmodule Minga.Agent.UIState do
   """
 
   alias Minga.Agent.BufferSync
+  alias Minga.Agent.Config, as: AgentConfig
   alias Minga.Agent.View.Preview
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Config.Options
@@ -104,7 +105,7 @@ defmodule Minga.Agent.UIState do
             history_index: -1,
             spinner_frame: 0,
             provider_name: "anthropic",
-            model_name: "claude-sonnet-4",
+            model_name: AgentConfig.default_model(),
             thinking_level: "medium",
             input_focused: false,
             display_start_index: 0,

--- a/lib/minga/agent/view/renderer.ex
+++ b/lib/minga/agent/view/renderer.ex
@@ -14,6 +14,7 @@ defmodule Minga.Agent.View.Renderer do
   Called by `Minga.Editor.RenderPipeline.Content` when rendering agent chat windows.
   """
 
+  alias Minga.Agent.Config, as: AgentConfig
   alias Minga.Agent.ModelLimits
   alias Minga.Agent.Session
   alias Minga.Agent.UIState
@@ -320,6 +321,7 @@ defmodule Minga.Agent.View.Renderer do
   defp dashboard_sections(input, width, at) do
     panel = input.panel
     usage = input.usage
+    bare_model = AgentConfig.strip_provider_prefix(panel.model_name)
 
     # ── Session title section ──
     title_lines = [
@@ -335,7 +337,7 @@ defmodule Minga.Agent.View.Renderer do
     total_tokens = Map.get(usage, :input, 0) + Map.get(usage, :output, 0)
     estimate = input.agent_ui.context_estimate
     display_tokens = max(total_tokens, estimate)
-    limit = ModelLimits.context_limit(panel.model_name)
+    limit = ModelLimits.context_limit(bare_model)
 
     context_lines = [
       dashboard_text(" Context", width, fg: at.dashboard_label, bg: at.panel_bg, bold: true)
@@ -345,7 +347,7 @@ defmodule Minga.Agent.View.Renderer do
       if display_tokens > 0 do
         pct_text =
           if limit,
-            do: " (#{context_fill_pct(usage, panel.model_name, estimate) || 0}% used)",
+            do: " (#{context_fill_pct(usage, bare_model, estimate) || 0}% used)",
             else: ""
 
         cost_text = if usage.cost > 0, do: "$#{Float.round(usage.cost, 4)}", else: "$0.00"
@@ -391,7 +393,7 @@ defmodule Minga.Agent.View.Renderer do
 
     model_lines = [
       dashboard_text(" Model", width, fg: at.dashboard_label, bg: at.panel_bg, bold: true),
-      dashboard_text("  #{panel.model_name}#{thinking}", width,
+      dashboard_text("  #{bare_model}#{thinking}", width,
         fg: at.text_fg,
         bg: at.panel_bg
       ),
@@ -557,7 +559,7 @@ defmodule Minga.Agent.View.Renderer do
   @spec model_info_text(RenderInput.t()) :: String.t()
   defp model_info_text(input) do
     panel = input.panel
-    model = titleize(panel.model_name)
+    model = panel.model_name |> AgentConfig.strip_provider_prefix() |> titleize()
     provider = if panel.provider_name != "", do: " · #{titleize(panel.provider_name)}", else: ""
     thinking = if panel.thinking_level != "", do: " · #{panel.thinking_level}", else: ""
     "󰚩 #{model}#{provider}#{thinking}"

--- a/test/minga/agent/providers/native_test.exs
+++ b/test/minga/agent/providers/native_test.exs
@@ -951,4 +951,31 @@ defmodule Minga.Agent.Providers.NativeTest do
       Options.set(:agent_api_endpoints, nil)
     end
   end
+
+  # ── Model format validation ──────────────────────────────────────────────────
+
+  describe "model format validation" do
+    test "bare model name without provider prefix returns :invalid_format error", %{
+      tmp_dir: tmp_dir
+    } do
+      # A model name like "claude-sonnet-4" (no provider prefix) should
+      # fail with a clear error, not a cryptic :invalid_format atom.
+      {:ok, pid} =
+        start_provider(
+          model: "claude-sonnet-4",
+          llm_client: fake_llm_client([]),
+          tmp_dir: tmp_dir
+        )
+
+      Native.send_prompt(pid, "hello")
+      events = collect_events(2_000)
+
+      error_events = Enum.filter(events, &match?(%Event.Error{}, &1))
+      assert error_events != []
+
+      error = hd(error_events)
+      assert error.message =~ "missing a provider prefix"
+      assert error.message =~ "provider:model"
+    end
+  end
 end

--- a/test/minga/agent/ui_state_test.exs
+++ b/test/minga/agent/ui_state_test.exs
@@ -1,6 +1,7 @@
 defmodule Minga.Agent.UIStateTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Agent.Config, as: AgentConfig
   alias Minga.Agent.UIState
   alias Minga.Buffer.Server, as: BufferServer
 
@@ -41,6 +42,12 @@ defmodule Minga.Agent.UIStateTest do
       panel = UIState.new()
       assert panel.prompt_history == []
       assert panel.history_index == -1
+    end
+
+    test "default model_name includes provider prefix" do
+      panel = UIState.new()
+      assert String.contains?(panel.model_name, ":")
+      assert panel.model_name == AgentConfig.default_model()
     end
   end
 

--- a/test/minga/agent/view/renderer_test.exs
+++ b/test/minga/agent/view/renderer_test.exs
@@ -201,4 +201,33 @@ defmodule Minga.Agent.View.RendererTest do
       end
     end
   end
+
+  describe "model name display with provider prefix" do
+    test "prompt bar strips provider prefix from model name" do
+      state = base_state()
+      commands = Renderer.render_prompt_only(state, {30, 0, 80, 5})
+      texts = Enum.map(commands, fn d -> elem(d, 2) end)
+
+      # model_name defaults to "anthropic:claude-sonnet-4" but the display
+      # should strip the prefix and titleize to "Claude Sonnet 4"
+      bottom_border =
+        Enum.find(texts, fn text ->
+          String.starts_with?(text, "╰─")
+        end)
+
+      assert bottom_border != nil
+      assert String.contains?(bottom_border, "Claude Sonnet 4")
+      refute String.contains?(bottom_border, "Anthropic:claude")
+    end
+
+    test "dashboard model section strips provider prefix" do
+      state = base_state()
+      commands = Renderer.render_dashboard_only(state, {0, 80, 40, 30})
+      texts = Enum.map(commands, fn d -> elem(d, 2) end)
+
+      # The model section should show bare model name, not the prefixed spec
+      assert Enum.any?(texts, &String.contains?(&1, "claude-sonnet-4"))
+      refute Enum.any?(texts, &String.contains?(&1, "anthropic:claude-sonnet-4"))
+    end
+  end
 end


### PR DESCRIPTION
## Problem

When using the Native provider with an Anthropic key, the agent immediately fails with a cryptic `:invalid_format` error. The `*Messages*` buffer shows:

```
[error] [Agent.Native] agent loop error: :invalid_format
Agent: error
[warning] Agent error: :invalid_format
```

**Root cause:** `UIState.model_name` defaulted to `"claude-sonnet-4"` (bare name, no provider prefix). When passed to ReqLLM/LLMDB, `parse_spec` fails because it expects `"provider:model"` format.

## Changes

**Root cause fix:** `UIState.model_name` now defaults to `AgentConfig.default_model()` which returns `"anthropic:claude-sonnet-4"` (the full spec). All display sites strip the provider prefix before rendering so the UI looks the same.

**Better logging:** `format_error(:invalid_format)` returns a descriptive message explaining the expected format. The `do_agent_loop` validation returns early with a clear error when the model is missing a provider prefix, instead of letting it fail cryptically deep in LLMDB.

**DRY cleanup:** Extracted `strip_provider_prefix/1` to `AgentConfig` as a single public function, replacing four identical private copies across native.ex, session.ex, renderer.ex, and compaction.ex.

**Latent bug fix:** `file_mention.ex` was passing a prefixed model to `ModelLimits.vision_capable?/1` without stripping the prefix. This worked by accident via a catch-all fallback but would fail for non-vision models.

## Files Changed

- `lib/minga/agent/config.ex` — public `strip_provider_prefix/1` + doctests
- `lib/minga/agent/ui_state.ex` — default model_name uses AgentConfig
- `lib/minga/agent/providers/native.ex` — early validation, format_error clause, defdelegate
- `lib/minga/agent/view/renderer.ex` — strip prefix in all display sites
- `lib/minga/agent/session.ex` — strip prefix in usage summary
- `lib/minga/agent/compaction.ex` — defdelegate to AgentConfig
- `lib/minga/agent/file_mention.ex` — strip prefix before vision check
- Tests for all new behavior