### PR TITLE
fix(editor): add missing scroll invalidation for agent chat window

### DIFF
--- a/lib/minga/editor/render_pipeline/content.ex
+++ b/lib/minga/editor/render_pipeline/content.ex
@@ -321,6 +321,12 @@ defmodule Minga.Editor.RenderPipeline.Content do
         %DisplayMap{} = dm -> DisplayMap.to_visible_line_map(dm)
       end
 
+    # Detect scroll/structural invalidation (viewport_top, gutter, line count,
+    # buffer version). The normal buffer path does this in the Scroll stage;
+    # agent chat skips that stage, so we must do it here.
+    buf_version = BufferServer.version(buf)
+    window = Window.detect_invalidation(window, viewport.top, gutter_w, line_count, buf_version)
+
     # Detect context changes to invalidate dirty-line cache
     ctx_fp = ContentHelpers.context_fingerprint(render_ctx, is_active)
     window = Window.detect_context_change(window, ctx_fp)
@@ -349,7 +355,7 @@ defmodule Minga.Editor.RenderPipeline.Content do
 
     # Snapshot render state so future frames can detect changes.
     # Without this, dirty_lines stays empty and content is never re-rendered.
-    buf_version = BufferServer.version(buf)
+    # buf_version was already fetched above for detect_invalidation.
     last_visible = first_line + length(snapshot.lines) - 1
 
     window =


### PR DESCRIPTION
## Problem

When scrolling the agent chat pane, block decorations (headers like "▎ You", "▎ Agent", tool call borders) scrolled correctly, but the actual buffer line text stayed in place. Only the top portion of the chat appeared to scroll while the bottom portion remained fixed.

## Root Cause

The agent chat window's render path (`build_agent_chat_content`) skips the Scroll stage that normal buffer windows go through. That stage calls `Window.detect_invalidation` to mark all lines dirty when `viewport_top` changes. Without it, the line cache served stale draw commands with old absolute screen positions.

Block decorations rendered fresh every frame (no cache lookup in the reduce loop), so they scrolled correctly. Normal buffer line text went through `Window.dirty?` and used cached draws with stale row positions.

## Fix

Added `Window.detect_invalidation` before `detect_context_change` in `render_agent_chat_window`, mirroring what the Scroll stage does for normal buffer windows. Moved `buf_version` computation earlier (was already being fetched, just later in the function) to supply it to the invalidation check.

7-line change. No new dependencies, no behavioral change to other code paths.