### PR TITLE
feat(agent): message queue with steer/follow-up semantics and Ctrl-C cancel

### DIFF
--- a/lib/minga/agent/events.ex
+++ b/lib/minga/agent/events.ex
@@ -205,6 +205,19 @@ defmodule Minga.Agent.Events do
     {state, [{:render, 16}]}
   end
 
+  # A message was queued (steer or follow-up): trigger render so the pending
+  # display can update. The queue contents live in Session, not EditorState,
+  # so no state mutation is needed here.
+  def handle(state, {:prompt_queued, _content, _type}) do
+    {state, [{:render, 16}]}
+  end
+
+  # Both queues were recalled (dequeue or abort+restore). Trigger a render to
+  # clear the pending display.
+  def handle(state, :queues_recalled) do
+    {state, [{:render, 16}]}
+  end
+
   def handle(state, _unknown) do
     {state, []}
   end

--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -43,6 +43,7 @@ defmodule Minga.Agent.Providers.Native do
   alias Minga.Agent.ModelCatalog
   alias Minga.Agent.ModelLimits
   alias Minga.Agent.Retry
+  alias Minga.Agent.Session
   alias Minga.Agent.Skills
   alias Minga.Agent.TokenEstimator
   alias Minga.Agent.Tools
@@ -90,6 +91,7 @@ defmodule Minga.Agent.Providers.Native do
       :llm_client,
       :max_turns,
       :max_cost,
+      :session_pid,
       turn_count: 0,
       session_cost: 0.0
     ]
@@ -105,6 +107,7 @@ defmodule Minga.Agent.Providers.Native do
             llm_client: term(),
             max_turns: pos_integer(),
             max_cost: float() | nil,
+            session_pid: pid() | nil,
             turn_count: non_neg_integer(),
             session_cost: float()
           }
@@ -303,6 +306,7 @@ defmodule Minga.Agent.Providers.Native do
       # Spawn the agent turn loop in a linked task
       lctx = %LoopCtx{
         provider_pid: self(),
+        session_pid: state.subscriber,
         model: state.model,
         config: state.config,
         tools: state.tools,
@@ -357,6 +361,7 @@ defmodule Minga.Agent.Providers.Native do
 
     lctx = %LoopCtx{
       provider_pid: self(),
+      session_pid: state.subscriber,
       model: state.model,
       config: state.config,
       tools: state.tools,
@@ -852,6 +857,10 @@ defmodule Minga.Agent.Providers.Native do
     context = Context.append(context, assistant_msg)
 
     context = execute_tools(lctx.provider_pid, context, tool_calls, lctx.tools, lctx.config)
+
+    # Inject any steering messages queued by the user while tools were executing.
+    context = inject_steering_messages(lctx, context)
+
     send(lctx.provider_pid, {:agent_context_update, context})
 
     # Track cost from this turn and increment turn count for safety checks
@@ -867,6 +876,31 @@ defmodule Minga.Agent.Providers.Native do
 
     # Continue the loop with updated context and incremented turn count
     run_agent_loop(lctx, context)
+  end
+
+  # Dequeues any steering messages from the Session and appends them to the
+  # LLM context so the model sees them on its next turn. Returns the context
+  # unchanged when there are no pending steering messages or no session_pid.
+  @spec inject_steering_messages(loop_ctx(), Context.t()) :: Context.t()
+  defp inject_steering_messages(%{session_pid: nil}, context), do: context
+
+  defp inject_steering_messages(lctx, context) do
+    # Use a short timeout: Session.dequeue_steering is a simple queue pop and
+    # should respond in microseconds. 200ms guards against a slow/dead session
+    # without blocking the agent loop meaningfully.
+    steering =
+      try do
+        GenServer.call(lctx.session_pid, :dequeue_steering, 200)
+      catch
+        :exit, _ -> []
+      end
+
+    if steering == [] do
+      context
+    else
+      combined = Session.combine_queue_entries_to_text(steering)
+      Context.append(context, Context.user(combined))
+    end
   end
 
   @spec execute_tools(pid(), Context.t(), [map()], [ReqLLM.Tool.t()], AgentConfig.t()) ::

--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -59,7 +59,9 @@ defmodule Minga.Agent.Session do
           model_name: String.t(),
           provider_name: String.t(),
           save_timer: reference() | nil,
-          branches: [Branch.t()]
+          branches: [Branch.t()],
+          steering_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
+          follow_up_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]]
         }
 
   # ── Public API ──────────────────────────────────────────────────────────────
@@ -77,7 +79,7 @@ defmodule Minga.Agent.Session do
   (for multi-modal messages with images).
   """
   @spec send_prompt(GenServer.server(), String.t() | [ReqLLM.Message.ContentPart.t()]) ::
-          :ok | {:error, term()}
+          :ok | {:queued, :steering} | {:error, term()}
   def send_prompt(session, content) when is_binary(content) or is_list(content) do
     GenServer.call(session, {:send_prompt, content})
   end
@@ -293,6 +295,83 @@ defmodule Minga.Agent.Session do
     GenServer.cast(session, {:add_system_message, text, level})
   end
 
+  @doc """
+  Queues a message as a steering prompt (injected between tool calls on the next turn).
+
+  When the agent is idle, behaves identically to `send_prompt/2`.
+  Returns `{:queued, :steering}` when the message was queued.
+  """
+  @spec queue_steering(GenServer.server(), String.t() | [ReqLLM.Message.ContentPart.t()]) ::
+          :ok | {:queued, :steering} | {:error, term()}
+  def queue_steering(session, content) when is_binary(content) or is_list(content) do
+    GenServer.call(session, {:send_prompt, content})
+  end
+
+  @doc """
+  Queues a message as a follow-up (sent automatically once the current agent run finishes).
+
+  When the agent is idle, behaves identically to `send_prompt/2`.
+  Returns `{:queued, :follow_up}` when the message was queued.
+  """
+  @spec queue_follow_up(GenServer.server(), String.t() | [ReqLLM.Message.ContentPart.t()]) ::
+          :ok | {:queued, :follow_up} | {:error, term()}
+  def queue_follow_up(session, content) when is_binary(content) or is_list(content) do
+    GenServer.call(session, {:send_follow_up, content})
+  end
+
+  @doc "Pops and returns all pending steering messages, clearing the steering queue."
+  @spec dequeue_steering(GenServer.server()) ::
+          [String.t() | [ReqLLM.Message.ContentPart.t()]]
+  def dequeue_steering(session) do
+    GenServer.call(session, :dequeue_steering)
+  end
+
+  @doc """
+  Returns both queues and clears them. Used by abort (Ctrl-C) and dequeue (Alt+Up)
+  so pending messages can be restored to the prompt input.
+  """
+  @spec recall_queues(GenServer.server()) ::
+          {[String.t() | [ReqLLM.Message.ContentPart.t()]],
+           [String.t() | [ReqLLM.Message.ContentPart.t()]]}
+  def recall_queues(session) do
+    GenServer.call(session, :recall_queues)
+  end
+
+  @doc "Clears both queues without returning their contents."
+  @spec clear_queues(GenServer.server()) :: :ok
+  def clear_queues(session) do
+    GenServer.call(session, :clear_queues)
+  end
+
+  @doc "Returns both queues without modifying them (for pending message display)."
+  @spec get_queued_messages(GenServer.server()) ::
+          {[String.t() | [ReqLLM.Message.ContentPart.t()]],
+           [String.t() | [ReqLLM.Message.ContentPart.t()]]}
+  def get_queued_messages(session) do
+    GenServer.call(session, :get_queued_messages)
+  end
+
+  @doc """
+  Converts a list of queue entries (strings or ContentPart lists) into a single
+  string suitable for display or restoring to the prompt input.
+  """
+  @spec combine_queue_entries_to_text([String.t() | [ReqLLM.Message.ContentPart.t()]]) ::
+          String.t()
+  def combine_queue_entries_to_text(entries) do
+    entries
+    |> Enum.map(fn
+      text when is_binary(text) ->
+        text
+
+      parts when is_list(parts) ->
+        parts
+        |> Enum.filter(&(&1.type == :text))
+        |> Enum.map_join("", & &1.text)
+    end)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n\n")
+  end
+
   @doc "Returns the provider pid for direct provider-specific calls."
   @spec get_provider(GenServer.server()) :: pid() | nil
   def get_provider(session) do
@@ -340,7 +419,9 @@ defmodule Minga.Agent.Session do
       provider_name: provider_name,
       save_timer: nil,
       created_at: DateTime.utc_now(),
-      branches: []
+      branches: [],
+      steering_queue: [],
+      follow_up_queue: []
     }
 
     # Start provider asynchronously so init doesn't block
@@ -352,6 +433,15 @@ defmodule Minga.Agent.Session do
   @impl GenServer
   def handle_call({:send_prompt, _text}, _from, %{provider: nil} = state) do
     {:reply, {:error, :provider_not_ready}, state}
+  end
+
+  def handle_call({:send_prompt, content}, _from, %{status: status} = state)
+      when status in [:thinking, :tool_executing] do
+    # Agent is busy: queue the message as a steering prompt. It will be injected
+    # into the agent's context between tool calls.
+    state = %{state | steering_queue: state.steering_queue ++ [content]}
+    broadcast(state, {:prompt_queued, content, :steering})
+    {:reply, {:queued, :steering}, state}
   end
 
   def handle_call({:send_prompt, content}, _from, state) do
@@ -369,6 +459,66 @@ defmodule Minga.Agent.Session do
       {:error, _} = err ->
         {:reply, err, state}
     end
+  end
+
+  def handle_call({:send_follow_up, _content}, _from, %{provider: nil} = state) do
+    {:reply, {:error, :provider_not_ready}, state}
+  end
+
+  def handle_call({:send_follow_up, content}, _from, %{status: status} = state)
+      when status in [:thinking, :tool_executing] do
+    # Agent is busy: queue as a follow-up that sends automatically once the current run finishes.
+    state = %{state | follow_up_queue: state.follow_up_queue ++ [content]}
+    broadcast(state, {:prompt_queued, content, :follow_up})
+    {:reply, {:queued, :follow_up}, state}
+  end
+
+  def handle_call({:send_follow_up, content}, _from, state) do
+    # Agent is idle: treat follow-up as a regular prompt.
+    {user_msg, send_content} = build_user_message(content)
+    state = %{state | messages: state.messages ++ [user_msg]}
+    state = notify_messages_changed(state)
+
+    case state.provider_module.send_prompt(state.provider, send_content) do
+      :ok -> {:reply, :ok, state}
+      {:error, _} = err -> {:reply, err, state}
+    end
+  end
+
+  def handle_call(:dequeue_steering, _from, state) do
+    steering = state.steering_queue
+
+    if steering == [] do
+      {:reply, [], state}
+    else
+      # Add each steering message to conversation history so it appears in chat.
+      messages =
+        Enum.reduce(steering, state.messages, fn content, msgs ->
+          {user_msg, _} = build_user_message(content)
+          msgs ++ [user_msg]
+        end)
+
+      state = %{state | steering_queue: [], messages: messages}
+      state = notify_messages_changed(state)
+      {:reply, steering, state}
+    end
+  end
+
+  def handle_call(:recall_queues, _from, state) do
+    result = {state.steering_queue, state.follow_up_queue}
+    state = %{state | steering_queue: [], follow_up_queue: []}
+    broadcast(state, :queues_recalled)
+    {:reply, result, state}
+  end
+
+  def handle_call(:clear_queues, _from, state) do
+    state = %{state | steering_queue: [], follow_up_queue: []}
+    broadcast(state, :queues_recalled)
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:get_queued_messages, _from, state) do
+    {:reply, {state.steering_queue, state.follow_up_queue}, state}
   end
 
   def handle_call(:abort, _from, %{provider: nil} = state) do
@@ -412,7 +562,9 @@ defmodule Minga.Agent.Session do
         status: :idle,
         total_usage: %{input: 0, output: 0, cache_read: 0, cache_write: 0, cost: 0.0},
         error_message: nil,
-        pending_approval: nil
+        pending_approval: nil,
+        steering_queue: [],
+        follow_up_queue: []
     }
 
     broadcast(state, {:status_changed, :idle})
@@ -437,7 +589,9 @@ defmodule Minga.Agent.Session do
             model_name: data.model_name,
             status: :idle,
             error_message: nil,
-            pending_approval: nil
+            pending_approval: nil,
+            steering_queue: [],
+            follow_up_queue: []
         }
 
         broadcast(state, {:status_changed, :idle})
@@ -792,7 +946,29 @@ defmodule Minga.Agent.Session do
         state
       end
 
-    set_status(state, :idle)
+    case state.follow_up_queue do
+      [] ->
+        set_status(state, :idle)
+
+      follow_ups ->
+        # Auto-send queued follow-up messages as a new turn. Combine all pending
+        # follow-ups into a single prompt so they arrive as one user message.
+        combined = combine_queue_entries_to_text(follow_ups)
+        {user_msg, send_content} = build_user_message(combined)
+
+        messages = state.messages ++ [user_msg]
+        state = %{state | messages: messages, follow_up_queue: []}
+        state = notify_messages_changed(state)
+
+        case state.provider_module.send_prompt(state.provider, send_content) do
+          :ok ->
+            # AgentStart event from the provider will transition us to :thinking.
+            state
+
+          {:error, _reason} ->
+            set_status(state, :idle)
+        end
+    end
   end
 
   defp handle_provider_event(%Event.TextDelta{delta: delta}, state) do

--- a/lib/minga/agent/ui_state.ex
+++ b/lib/minga/agent/ui_state.ex
@@ -276,6 +276,15 @@ defmodule Minga.Agent.UIState do
     delete_char(state)
   end
 
+  @doc "Replaces the input content with the given text. Does not save to history."
+  @spec set_prompt_text(t(), String.t()) :: t()
+  def set_prompt_text(%__MODULE__{prompt_buffer: pid} = state, text) when is_pid(pid) do
+    BufferServer.replace_content(pid, text)
+    %{state | pasted_blocks: []}
+  end
+
+  def set_prompt_text(%__MODULE__{} = state, _text), do: state
+
   @doc "Clears the input (after submission). Saves current text to history first."
   @spec clear_input(t()) :: t()
   def clear_input(%__MODULE__{} = state) do

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -239,14 +239,45 @@ defmodule Minga.Editor.Commands.Agent do
     # Returns either a string (text only) or a list of ContentPart (when images are present).
     model = AgentAccess.panel(state).model_name
 
-    with {:ok, resolved} <- resolve_mentions(text, model: model),
-         :ok <- Session.send_prompt(AgentAccess.session(state), resolved) do
-      state = update_agent_ui(state, &UIState.clear_input_and_scroll/1)
+    case resolve_mentions(text, model: model) do
+      {:ok, resolved} ->
+        state
+        |> clear_input_after_submit()
+        |> deliver_prompt(resolved)
 
-      AgentAccess.update_agent_ui(state, fn _ ->
-        UIState.clear_baselines(AgentAccess.agent_ui(state))
-      end)
-    else
+      {:error, msg} ->
+        %{state | status_msg: msg}
+    end
+  catch
+    # The :DOWN monitor clears stale session PIDs, but there's a race window:
+    # the session can die while we're mid-call (before :DOWN is processed).
+    # This is the user-facing hot path (Enter to send), so catch it here.
+    :exit, _ -> %{state | status_msg: "Agent session crashed, SPC a n to restart"}
+  end
+
+  # Clears the input and resets diff baselines after a prompt is submitted.
+  @spec clear_input_after_submit(state()) :: state()
+  defp clear_input_after_submit(state) do
+    state = update_agent_ui(state, &UIState.clear_input_and_scroll/1)
+
+    AgentAccess.update_agent_ui(state, fn _ ->
+      UIState.clear_baselines(AgentAccess.agent_ui(state))
+    end)
+  end
+
+  # Sends the resolved content to the LLM and handles steering queue feedback.
+  @spec deliver_prompt(state(), String.t() | [ReqLLM.Message.ContentPart.t()]) :: state()
+  defp deliver_prompt(state, resolved) do
+    case Session.send_prompt(AgentAccess.session(state), resolved) do
+      :ok ->
+        state
+
+      {:queued, :steering} ->
+        update_agent_ui(
+          state,
+          &UIState.push_toast(&1, "⏳ Queued (steer). Ctrl-C to cancel.", :info)
+        )
+
       {:error, :provider_not_ready} ->
         %{state | status_msg: "Agent provider still starting, try again in a moment"}
 
@@ -256,11 +287,46 @@ defmodule Minga.Editor.Commands.Agent do
       {:error, reason} ->
         %{state | status_msg: "Agent error: #{inspect(reason)}"}
     end
+  end
+
+  @spec send_follow_up_to_llm(state(), String.t()) :: state()
+  defp send_follow_up_to_llm(state, text) do
+    model = AgentAccess.panel(state).model_name
+
+    case resolve_mentions(text, model: model) do
+      {:ok, resolved} ->
+        state
+        |> update_agent_ui(&UIState.clear_input_and_scroll/1)
+        |> deliver_follow_up(resolved)
+
+      {:error, msg} ->
+        %{state | status_msg: msg}
+    end
   catch
-    # The :DOWN monitor clears stale session PIDs, but there's a race window:
-    # the session can die while we're mid-call (before :DOWN is processed).
-    # This is the user-facing hot path (Enter to send), so catch it here.
     :exit, _ -> %{state | status_msg: "Agent session crashed, SPC a n to restart"}
+  end
+
+  @spec deliver_follow_up(state(), String.t() | [ReqLLM.Message.ContentPart.t()]) :: state()
+  defp deliver_follow_up(state, resolved) do
+    case Session.queue_follow_up(AgentAccess.session(state), resolved) do
+      :ok ->
+        state
+
+      {:queued, :follow_up} ->
+        update_agent_ui(
+          state,
+          &UIState.push_toast(&1, "⏳ Queued (follow-up). Ctrl-C to cancel.", :info)
+        )
+
+      {:error, :provider_not_ready} ->
+        %{state | status_msg: "Agent provider still starting, try again in a moment"}
+
+      {:error, msg} when is_binary(msg) ->
+        %{state | status_msg: msg}
+
+      {:error, reason} ->
+        %{state | status_msg: "Agent error: #{inspect(reason)}"}
+    end
   end
 
   @spec resolve_mentions(String.t(), keyword()) ::
@@ -303,17 +369,94 @@ defmodule Minga.Editor.Commands.Agent do
     state
   end
 
-  @doc "Aborts the current agent operation."
+  @doc """
+  Aborts the current agent operation and restores any queued messages to the prompt input.
+
+  Queued steering and follow-up messages are recalled from the Session and placed
+  back in the prompt buffer so nothing is lost.
+  """
   @spec abort_agent(state()) :: state()
   def abort_agent(state) do
-    if AgentAccess.session(state) == nil do
-      state
-    else
-      Session.abort(AgentAccess.session(state))
-      state
+    case AgentAccess.session(state) do
+      nil ->
+        state
+
+      session ->
+        {steering, follow_up} = safe_recall_queues(session)
+
+        try do
+          Session.abort(session)
+        catch
+          :exit, _ -> :ok
+        end
+
+        restore_queued_to_prompt(state, steering ++ follow_up)
     end
-  catch
-    :exit, _ -> state
+  end
+
+  @doc """
+  Pulls all queued messages back into the prompt input without aborting the agent.
+
+  Useful when you want to re-read or edit your queued messages. Does not stop streaming.
+  """
+  @spec dequeue_to_editor(state()) :: state()
+  def dequeue_to_editor(state) do
+    case AgentAccess.session(state) do
+      nil ->
+        state
+
+      session ->
+        {steering, follow_up} = safe_recall_queues(session)
+        do_dequeue_to_editor(state, steering ++ follow_up)
+    end
+  end
+
+  @doc "Queues the current input as a follow-up; submits normally when agent is idle."
+  @spec scope_queue_follow_up(state()) :: state()
+  def scope_queue_follow_up(state) do
+    panel = AgentAccess.panel(state)
+
+    cond do
+      UIState.input_empty?(panel) ->
+        state
+
+      AgentAccess.session(state) == nil ->
+        %{state | status_msg: "No agent session, try closing and reopening the panel"}
+
+      AgentAccess.agent(state).status in [:thinking, :tool_executing] ->
+        text = UIState.prompt_text(panel)
+
+        if SlashCommand.slash_command?(text) do
+          state = update_agent_ui(state, &UIState.clear_input_and_scroll/1)
+          execute_slash_command(state, text)
+        else
+          send_follow_up_to_llm(state, text)
+        end
+
+      true ->
+        # Agent is idle: Ctrl+Enter behaves like regular Enter.
+        submit_prompt(state)
+    end
+  end
+
+  @doc "Dequeues all pending messages back into the prompt input without aborting."
+  @spec scope_dequeue(state()) :: state()
+  def scope_dequeue(state), do: dequeue_to_editor(state)
+
+  @doc """
+  Context-sensitive Ctrl-C handler.
+
+  During streaming: aborts the agent and restores queued messages to the prompt.
+  When idle in insert mode: returns to normal mode (vim convention).
+  When idle in normal mode: no-op.
+  """
+  @spec scope_ctrl_c(state()) :: state()
+  def scope_ctrl_c(state) do
+    if AgentAccess.agent(state).status in [:thinking, :tool_executing] do
+      abort_agent(state)
+    else
+      input_to_normal(state)
+    end
   end
 
   @doc "Starts an agent session if one isn't already running. No-op otherwise."
@@ -874,6 +1017,42 @@ defmodule Minga.Editor.Commands.Agent do
 
   # ── Private helpers ─────────────────────────────────────────────────────────
 
+  @spec safe_recall_queues(pid()) ::
+          {[String.t() | [ReqLLM.Message.ContentPart.t()]],
+           [String.t() | [ReqLLM.Message.ContentPart.t()]]}
+  defp safe_recall_queues(session) do
+    Session.recall_queues(session)
+  catch
+    :exit, _ -> {[], []}
+  end
+
+  @spec restore_queued_to_prompt(state(), [String.t() | [ReqLLM.Message.ContentPart.t()]]) ::
+          state()
+  defp restore_queued_to_prompt(state, []), do: state
+
+  defp restore_queued_to_prompt(state, all_queued) do
+    current_text = UIState.prompt_text(AgentAccess.panel(state))
+    combined = Session.combine_queue_entries_to_text(all_queued)
+
+    restored =
+      if current_text != "",
+        do: combined <> "\n\n" <> current_text,
+        else: combined
+
+    update_agent_ui(state, &UIState.set_prompt_text(&1, restored))
+  end
+
+  @spec do_dequeue_to_editor(state(), [String.t() | [ReqLLM.Message.ContentPart.t()]]) ::
+          state()
+  defp do_dequeue_to_editor(state, []), do: %{state | status_msg: "No queued messages"}
+
+  defp do_dequeue_to_editor(state, all_queued) do
+    count = length(all_queued)
+    label = if count == 1, do: "message", else: "messages"
+    state = restore_queued_to_prompt(state, all_queued)
+    %{state | status_msg: "Restored #{count} queued #{label} to editor"}
+  end
+
   # Returns true when no agent UI is visible (panel or split pane),
   # meaning agent input/scroll commands should be no-ops.
   @spec no_agent_ui?(state()) :: boolean()
@@ -1097,6 +1276,9 @@ defmodule Minga.Editor.Commands.Agent do
     {:agent_submit_or_newline, "Submit or newline", :scope_submit_or_newline},
     {:agent_insert_newline, "Insert newline in agent input", :scope_insert_newline},
     {:agent_submit_or_abort, "Submit or abort agent", :scope_submit_or_abort},
+    {:agent_ctrl_c, "Abort (streaming) or normal mode (idle)", :scope_ctrl_c},
+    {:agent_queue_follow_up, "Queue as follow-up or submit if idle", :scope_queue_follow_up},
+    {:agent_dequeue, "Dequeue messages back to editor", :scope_dequeue},
     {:agent_input_backspace, "Agent input backspace", :input_backspace},
     {:agent_input_up, "Agent input up", :scope_input_up},
     {:agent_input_down, "Agent input down", :scope_input_down},

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -109,6 +109,8 @@ defmodule Minga.Keymap.Defaults do
     {[{?a, @none}, {?h, @none}], :agent_session_history, "Session history"},
     {[{?a, @none}, {?T, @none}], :agent_cycle_thinking, "Cycle thinking level"},
     {[{?a, @none}, {?e, @none}], :agent_summarize, "Summarize session to artifact"},
+    {[{?a, @none}, {?q, @none}], :agent_dequeue, "Dequeue queued messages to editor"},
+    {[{?a, @none}, {?f, @none}], :agent_queue_follow_up, "Queue current input as follow-up"},
 
     # ── Tab ──────────────────────────────────────────────────────────────────
     {[{9, @none}, {?n, @none}], :tab_next, "Next tab"},

--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -172,8 +172,17 @@ defmodule Minga.Keymap.Scope.Agent do
     |> Bindings.bind([{0xF701, 0}], :agent_input_down, "Move down / history next")
     |> Bindings.bind([{57_352, 0}], :agent_input_up, "Move up / history prev")
     |> Bindings.bind([{57_353, 0}], :agent_input_down, "Move down / history next")
+    # Ctrl+Enter queues as follow-up during streaming; submits normally when idle.
+    # Uses the same multi-encoding strategy as Shift+Enter:
+    # 1. Kitty protocol (CSI 13;5 u)
+    # 2. Some terminals send plain Enter for Ctrl+Enter — no reliable legacy fallback.
+    |> Bindings.bind([{@enter, @ctrl}], :agent_queue_follow_up, "Queue as follow-up")
+    # Alt+Up dequeues pending messages back into the prompt buffer.
+    |> Bindings.bind([{0xF700, @alt}], :agent_dequeue, "Dequeue to editor")
+    |> Bindings.bind([{57_352, @alt}], :agent_dequeue, "Dequeue to editor")
     # Ctrl modifiers
-    |> Bindings.bind([{?c, @ctrl}], :agent_submit_or_abort, "Submit or abort")
+    # Ctrl-C: abort+restore queues if streaming, else return to normal mode.
+    |> Bindings.bind([{?c, @ctrl}], :agent_ctrl_c, "Abort (streaming) or normal mode (idle)")
     |> Bindings.bind([{?d, @ctrl}], :agent_scroll_half_down, "Scroll down (while typing)")
     |> Bindings.bind([{?u, @ctrl}], :agent_scroll_half_up, "Scroll up (while typing)")
     |> Bindings.bind([{?l, @ctrl}], :agent_clear_chat, "Clear chat display")
@@ -192,7 +201,7 @@ defmodule Minga.Keymap.Scope.Agent do
     # No Escape binding: in normal mode, Escape is a no-op (vim semantics).
     # Use `q` or Ctrl+Q to leave the input field.
     |> Bindings.bind([{?q, 0}], :agent_unfocus_input, "Back to chat nav")
-    |> Bindings.bind([{?c, @ctrl}], :agent_submit_or_abort, "Submit or abort")
+    |> Bindings.bind([{?c, @ctrl}], :agent_ctrl_c, "Abort (streaming) or normal mode (idle)")
     |> Bindings.bind([{?d, @ctrl}], :agent_scroll_half_down, "Scroll down")
     |> Bindings.bind([{?u, @ctrl}], :agent_scroll_half_up, "Scroll up")
     |> Bindings.bind([{?l, @ctrl}], :agent_clear_chat, "Clear chat")
@@ -247,11 +256,15 @@ defmodule Minga.Keymap.Scope.Agent do
        ]},
       {"Session",
        [
-         {"Ctrl-c", "Abort agent"},
+         {"Ctrl-c", "Abort + restore queued (streaming) / normal mode (idle)"},
+         {"Ctrl+Enter", "Queue as follow-up (or submit if idle)"},
+         {"Alt+Up", "Dequeue messages back to editor"},
          {"Ctrl-l", "Clear display"},
          {"s", "Session switcher"},
          {"SPC a n", "New session"},
          {"SPC a s", "Stop agent"},
+         {"SPC a q", "Dequeue to editor"},
+         {"SPC a f", "Queue follow-up from input"},
          {"SPC a m", "Pick model"},
          {"SPC a T", "Cycle thinking level"}
        ]},

--- a/test/minga/agent/session_test.exs
+++ b/test/minga/agent/session_test.exs
@@ -7,6 +7,56 @@ defmodule Minga.Agent.SessionTest do
 
   # ── Mock provider ──────────────────────────────────────────────────────────
 
+  # A provider that starts an agent run but waits for an explicit :proceed
+  # message before sending AgentEnd. Allows tests to inspect Session state
+  # while the agent is "streaming" (i.e., status is :thinking).
+  defmodule SlowMockProvider do
+    @behaviour Minga.Agent.Provider
+
+    use GenServer
+
+    @impl Minga.Agent.Provider
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl Minga.Agent.Provider
+    def send_prompt(pid, text), do: GenServer.cast(pid, {:prompt, text})
+
+    @impl Minga.Agent.Provider
+    def abort(pid), do: GenServer.cast(pid, :abort)
+
+    @impl Minga.Agent.Provider
+    def new_session(pid), do: GenServer.cast(pid, :new_session)
+
+    @impl Minga.Agent.Provider
+    def get_state(_pid), do: {:ok, %{model: nil, is_streaming: false, token_usage: nil}}
+
+    @doc false
+    @spec proceed(GenServer.server()) :: :ok
+    def proceed(pid), do: GenServer.cast(pid, :proceed)
+
+    @impl GenServer
+    def init(opts) do
+      subscriber = Keyword.fetch!(opts, :subscriber)
+      {:ok, %{subscriber: subscriber, pending: nil}}
+    end
+
+    @impl GenServer
+    def handle_cast({:prompt, text}, state) do
+      send(state.subscriber, {:agent_provider_event, %Event.AgentStart{}})
+      send(state.subscriber, {:agent_provider_event, %Event.TextDelta{delta: text}})
+      {:noreply, %{state | pending: text}}
+    end
+
+    def handle_cast(:proceed, state) do
+      usage = %{input: 10, output: 5, cache_read: 0, cache_write: 0, cost: 0.001}
+      send(state.subscriber, {:agent_provider_event, %Event.AgentEnd{usage: usage}})
+      {:noreply, %{state | pending: nil}}
+    end
+
+    def handle_cast(:abort, state), do: {:noreply, state}
+    def handle_cast(:new_session, state), do: {:noreply, state}
+  end
+
   defmodule MockProvider do
     @behaviour Minga.Agent.Provider
 
@@ -585,6 +635,287 @@ defmodule Minga.Agent.SessionTest do
 
       meta = Session.metadata(session)
       assert meta.first_prompt == "Hello there"
+    end
+  end
+
+  # ── Queue API ──────────────────────────────────────────────────────────────
+
+  describe "combine_queue_entries_to_text/1" do
+    test "returns empty string for empty list" do
+      assert Session.combine_queue_entries_to_text([]) == ""
+    end
+
+    test "returns a single string unchanged" do
+      assert Session.combine_queue_entries_to_text(["hello"]) == "hello"
+    end
+
+    test "joins multiple strings with double newlines" do
+      result = Session.combine_queue_entries_to_text(["first", "second", "third"])
+      assert result == "first\n\nsecond\n\nthird"
+    end
+
+    test "extracts text from ContentPart lists" do
+      parts = [
+        %ReqLLM.Message.ContentPart{type: :text, text: "hello "},
+        %ReqLLM.Message.ContentPart{type: :text, text: "world"}
+      ]
+
+      assert Session.combine_queue_entries_to_text([parts]) == "hello world"
+    end
+
+    test "skips image ContentParts when extracting text" do
+      parts = [
+        %ReqLLM.Message.ContentPart{type: :text, text: "describe this"},
+        %ReqLLM.Message.ContentPart{type: :image, text: nil}
+      ]
+
+      assert Session.combine_queue_entries_to_text([parts]) == "describe this"
+    end
+
+    test "mixes strings and ContentPart lists" do
+      parts = [%ReqLLM.Message.ContentPart{type: :text, text: "part text"}]
+      result = Session.combine_queue_entries_to_text(["string entry", parts])
+      assert result == "string entry\n\npart text"
+    end
+  end
+
+  describe "message queuing during streaming" do
+    setup do
+      {:ok, slow_session} =
+        Session.start_link(
+          provider: SlowMockProvider,
+          provider_opts: []
+        )
+
+      Session.subscribe(slow_session)
+
+      # Wait for provider to start
+      :sys.get_state(slow_session)
+
+      %{slow_session: slow_session}
+    end
+
+    test "send_prompt while streaming queues message as steering", %{slow_session: session} do
+      assert :ok = Session.send_prompt(session, "first message")
+      # Wait for AgentStart to be processed (status becomes :thinking)
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      # Second send_prompt while streaming: should queue, not submit
+      result = Session.send_prompt(session, "steer me")
+      assert result == {:queued, :steering}
+
+      # Steering queue should hold the message
+      {steering, follow_up} = Session.get_queued_messages(session)
+      assert steering == ["steer me"]
+      assert follow_up == []
+
+      # Let the run finish
+      SlowMockProvider.proceed(Session.get_provider(session))
+
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+
+    test "multiple messages accumulate in the steering queue", %{slow_session: session} do
+      assert :ok = Session.send_prompt(session, "first")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      assert {:queued, :steering} = Session.send_prompt(session, "steer 1")
+      assert {:queued, :steering} = Session.send_prompt(session, "steer 2")
+
+      {steering, _} = Session.get_queued_messages(session)
+      assert steering == ["steer 1", "steer 2"]
+
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+
+    test "queue_follow_up while streaming queues message as follow_up", %{slow_session: session} do
+      assert :ok = Session.send_prompt(session, "first")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      result = Session.queue_follow_up(session, "follow this up")
+      assert result == {:queued, :follow_up}
+
+      {steering, follow_up} = Session.get_queued_messages(session)
+      assert steering == []
+      assert follow_up == ["follow this up"]
+
+      # Clear the follow-up before proceeding so the auto-send doesn't trigger.
+      # The follow-up auto-send behaviour is covered by the dedicated describe block.
+      Session.clear_queues(session)
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+
+    test "dequeue_steering returns and clears only the steering queue", %{slow_session: session} do
+      assert :ok = Session.send_prompt(session, "first")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      Session.send_prompt(session, "steer me")
+      Session.queue_follow_up(session, "follow up later")
+
+      steering = Session.dequeue_steering(session)
+      assert steering == ["steer me"]
+
+      # Follow-up queue is untouched
+      {remaining_steering, follow_up} = Session.get_queued_messages(session)
+      assert remaining_steering == []
+      assert follow_up == ["follow up later"]
+
+      # Steering messages are added to conversation history on dequeue
+      messages = Session.messages(session)
+      assert Enum.any?(messages, &match?({:user, "steer me"}, &1))
+
+      # Clear the follow-up so it doesn't auto-send during cleanup.
+      Session.clear_queues(session)
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+
+    test "recall_queues returns both queues and clears them", %{slow_session: session} do
+      assert :ok = Session.send_prompt(session, "first")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      Session.send_prompt(session, "steer")
+      Session.queue_follow_up(session, "follow")
+
+      {steering, follow_up} = Session.recall_queues(session)
+      assert steering == ["steer"]
+      assert follow_up == ["follow"]
+
+      # Both queues are now empty
+      {s2, f2} = Session.get_queued_messages(session)
+      assert s2 == []
+      assert f2 == []
+
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+
+    test "clear_queues empties both queues", %{slow_session: session} do
+      assert :ok = Session.send_prompt(session, "first")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      Session.send_prompt(session, "steer")
+      Session.queue_follow_up(session, "follow")
+
+      :ok = Session.clear_queues(session)
+
+      {steering, follow_up} = Session.get_queued_messages(session)
+      assert steering == []
+      assert follow_up == []
+
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+
+    test "queue_follow_up when idle sends immediately like send_prompt", %{slow_session: session} do
+      result = Session.queue_follow_up(session, "immediate follow-up")
+      assert result == :ok
+
+      # Message should be in conversation history right away
+      assert_receive {:agent_event, _, :messages_changed}, 500
+      messages = Session.messages(session)
+      assert Enum.any?(messages, &match?({:user, "immediate follow-up"}, &1))
+
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+
+    test "new_session clears both queues", %{slow_session: session} do
+      assert :ok = Session.send_prompt(session, "first")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      Session.send_prompt(session, "steer")
+      Session.queue_follow_up(session, "follow")
+
+      # Clear queues before proceeding so follow-up auto-send doesn't trigger.
+      Session.clear_queues(session)
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+
+      # Re-queue to verify new_session clears them
+      Session.send_prompt(session, "second run")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      Session.send_prompt(session, "steer2")
+      Session.queue_follow_up(session, "follow2")
+
+      # new_session while idle-ish (we clear queues first then call new_session)
+      Session.clear_queues(session)
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+
+      Session.new_session(session)
+      {steering, follow_up} = Session.get_queued_messages(session)
+      assert steering == []
+      assert follow_up == []
+    end
+
+    test "prompt_queued event is broadcast when queuing during streaming",
+         %{slow_session: session} do
+      assert :ok = Session.send_prompt(session, "first")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      Session.send_prompt(session, "steer me")
+      assert_receive {:agent_event, _, {:prompt_queued, "steer me", :steering}}, 500
+
+      Session.queue_follow_up(session, "follow")
+      assert_receive {:agent_event, _, {:prompt_queued, "follow", :follow_up}}, 500
+
+      # Clear queues so neither the steering (already dequeued by time proceed is called)
+      # nor the follow-up triggers an extra run during cleanup.
+      Session.clear_queues(session)
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+  end
+
+  describe "follow-up auto-send at AgentEnd" do
+    setup do
+      {:ok, slow_session} =
+        Session.start_link(
+          provider: SlowMockProvider,
+          provider_opts: []
+        )
+
+      Session.subscribe(slow_session)
+      :sys.get_state(slow_session)
+
+      %{slow_session: slow_session}
+    end
+
+    test "queued follow-up is auto-sent when agent finishes", %{slow_session: session} do
+      assert :ok = Session.send_prompt(session, "first")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      Session.queue_follow_up(session, "now follow up")
+
+      # Complete the first run - should trigger the follow-up
+      SlowMockProvider.proceed(Session.get_provider(session))
+
+      # Session should NOT go idle yet - it should start a new turn
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      # Follow-up message should appear in conversation history
+      messages = Session.messages(session)
+      assert Enum.any?(messages, &match?({:user, "now follow up"}, &1))
+
+      # Follow-up queue should be cleared
+      {_, follow_up} = Session.get_queued_messages(session)
+      assert follow_up == []
+
+      # Complete the follow-up run
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+
+    test "no follow-ups means normal idle transition", %{slow_session: session} do
+      assert :ok = Session.send_prompt(session, "simple")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
     end
   end
 end

--- a/test/minga/keymap/scope_test.exs
+++ b/test/minga/keymap/scope_test.exs
@@ -127,8 +127,8 @@ defmodule Minga.Keymap.ScopeTest do
       assert {:command, :agent_input_backspace} = Scope.resolve_key(:agent, :insert, {127, 0})
     end
 
-    test "Ctrl+C resolves to agent_submit_or_abort in insert mode" do
-      assert {:command, :agent_submit_or_abort} = Scope.resolve_key(:agent, :insert, {?c, 0x02})
+    test "Ctrl+C resolves to agent_ctrl_c in insert mode" do
+      assert {:command, :agent_ctrl_c} = Scope.resolve_key(:agent, :insert, {?c, 0x02})
     end
 
     test "unknown key returns :not_found in normal mode" do


### PR DESCRIPTION
# TL;DR
Agent chat no longer drops messages submitted during streaming. Enter queues a steer (injected between tool calls), Ctrl+Enter queues a follow-up (auto-sent after the run), and Ctrl-C aborts with full queue restore so nothing is lost.

Closes #658

## Context

When the agent was streaming and the user hit Enter, Minga showed a raw `Agent error: :already_streaming` in the status bar. There was no way to queue, no visual feedback, and no way to cancel without losing whatever you had typed. This PR implements the full pi-agent queue UX: two-level queuing, pending message display, dequeue-to-edit, and context-sensitive Ctrl-C.

## Changes

- **Two-level queue in Session.** `steering_queue` and `follow_up_queue` added to session state. `send_prompt/2` during `[:thinking, :tool_executing]` now returns `{:queued, :steering}` instead of letting the provider return `:already_streaming`. `send_follow_up/2` queues as follow-up. Both queues are cleared on `new_session` and `load_session`.

- **Steering injection in Native provider.** `LoopCtx` carries `session_pid`. After `execute_tools` returns, `inject_steering_messages/2` dequeues steering messages and appends them as user context before the next LLM call. Uses a 200ms timeout on the GenServer call to guard against non-Session pids in tests.

- **Follow-up auto-send at AgentEnd.** `handle_provider_event(AgentEnd)` checks `follow_up_queue`. If non-empty, combines all follow-up messages, appends as a user message, and calls `provider_module.send_prompt` — the resulting `AgentStart` event keeps the session in `:thinking` without touching `:idle`.

- **Ctrl-C redesigned.** `scope_ctrl_c` replaces `scope_submit_or_abort`. During streaming it calls `abort_agent` which now calls `Session.recall_queues` before aborting, then restores all queued text (prepended, joined with `\n\n`) to the prompt buffer. During idle it calls `input_to_normal`, matching vim convention.

- **Dequeue (Alt+Up / SPC a q).** `dequeue_to_editor` recalls queues without aborting and restores them to the prompt buffer combined with any current draft.

- **Ctrl+Enter for follow-up.** `scope_queue_follow_up` queues as follow-up during streaming; submits normally when idle. Bound to `{@enter, @ctrl}` in the insert trie (Kitty protocol) with `SPC a f` as the universal normal-mode fallback.

- **Pending message display in renderer.** `extract_input` fetches `Session.get_queued_messages` and stores them in `RenderInput.queued_messages`. `render_prompt_only` renders dimmed `Steer: ...` / `Follow-up: ...` lines above the input box with a `↳ Alt+Up to edit queued messages` hint. `prompt_height` and `cursor_position_in_rect` account for the pending area height.

- **Events.** `{:prompt_queued, content, type}` and `:queues_recalled` handled to trigger renders when queue state changes.

- **StubServer** updated with `:recall_queues` and `:get_queued_messages` handlers so existing tests continue working.

## Verification

```
mix test test/minga/agent/session_test.exs
mix test test/minga/editor/commands/agent_commands_test.exs
mix test test/minga/agent/providers/native_test.exs
mix test.llm   # all 5334 pass
mix lint       # clean
```

Manual flow (requires a running agent session):
1. Open agent chat with `SPC a a`
2. Start a slow prompt (e.g., one that triggers multiple tool calls)
3. While the agent is streaming, type a correction and press Enter — input clears, toast shows "⏳ Queued (steer)"
4. Press Ctrl+Enter to add a follow-up — toast shows "⏳ Queued (follow-up)"
5. Observe pending lines above the input box: "Steer: ..." / "Follow-up: ..." with hint
6. Press Ctrl-C — agent aborts, queued text restored to prompt, nothing lost
7. Press Alt+Up while streaming — queued text pulled back to editor without aborting
8. Use `SPC a q` / `SPC a f` from normal mode to manage the queue without entering insert mode

## Acceptance Criteria Addressed

- When user submits during streaming, message queued as steer, input clears, toast confirms ✅
- Steering injected between tool calls before next LLM turn ✅
- Ctrl+Enter queues follow-up; auto-sent once current run finishes ✅
- Multiple messages accumulate in both queues ✅
- Pending message display with dimmed type labels and dequeue hint ✅
- Alt+Up / SPC a q dequeue to editor without aborting ✅
- Ctrl-C during streaming aborts and restores all queued messages ✅
- Ctrl-C when idle returns to normal mode (insert) / no-op (normal) ✅
- Queued messages move to chat as user messages on send ✅
- New session / load session clears queues ✅
- Raw `:already_streaming` error never surfaces to user ✅
- Normal-mode leader equivalents (SPC a q, SPC a f, SPC a s) ✅