### PR TITLE
feat(port): per-buffer tree-sitter parsing with protocol multiplexing

### DIFF
--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -139,6 +139,7 @@ defmodule Minga.Config.Options do
           | :nav_flash_threshold
           | :log_level_config
           | :log_level_port
+          | :parser_tree_ttl
 
   @typedoc "Line number display style."
   @type line_number_style :: :hybrid | :absolute | :relative | :none
@@ -225,7 +226,8 @@ defmodule Minga.Config.Options do
     {:log_level_agent, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
     {:log_level_editor, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
     {:log_level_config, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
-    {:log_level_port, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default}
+    {:log_level_port, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
+    {:parser_tree_ttl, :integer, 300}
   ]
 
   @valid_names Enum.map(@option_specs, &elem(&1, 0))

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -161,6 +161,9 @@ defmodule Minga.Editor do
 
     state = EditorState.monitor_buffers(state, all_initial_pids)
 
+    # Schedule periodic eviction of inactive tree-sitter parse trees.
+    Process.send_after(self(), :evict_parser_trees, HighlightSync.eviction_check_interval_ms())
+
     {:ok, state}
   end
 
@@ -387,14 +390,36 @@ defmodule Minga.Editor do
   # Legacy {:minga_input, event} forms are also accepted for backward
   # compatibility during the transition (headless tests, etc.).
 
-  def handle_info({tag, {:highlight_names, names}}, state)
+  def handle_info({tag, {:highlight_names, buffer_id, names}}, state)
       when tag in [:minga_highlight, :minga_input] do
-    {:noreply, HighlightEvents.handle_names(state, names)}
+    # Resolve buffer_id to PID; fall back to active buffer for unregistered IDs
+    # (e.g., buffer_id 0 from test injection or legacy code paths).
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
+
+    new_state =
+      if pid == state.buffers.active do
+        HighlightEvents.handle_names(state, names)
+      else
+        existing = HighlightSync.get_highlight(state, pid)
+        updated = Minga.Highlight.put_names(existing, names)
+        HighlightSync.put_highlight(state, pid, updated)
+      end
+
+    {:noreply, new_state}
   end
 
-  def handle_info({tag, {:injection_ranges, ranges}}, state)
+  def handle_info({tag, {:injection_ranges, buffer_id, ranges}}, state)
       when tag in [:minga_highlight, :minga_input] do
-    {:noreply, HighlightEvents.handle_injection_ranges(state, ranges)}
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
+
+    new_state =
+      if pid do
+        %{state | injection_ranges: Map.put(state.injection_ranges, pid, ranges)}
+      else
+        state
+      end
+
+    {:noreply, new_state}
   end
 
   def handle_info({tag, {:language_at_response, _request_id, _language}}, state)
@@ -402,42 +427,59 @@ defmodule Minga.Editor do
     {:noreply, state}
   end
 
-  def handle_info({tag, {:highlight_spans, version, spans}}, state)
+  def handle_info({tag, {:highlight_spans, buffer_id, version, spans}}, state)
       when tag in [:minga_highlight, :minga_input] do
-    new_state = HighlightEvents.handle_spans(state, version, spans)
-    {:noreply, new_state}
-  end
-
-  def handle_info({tag, {:fold_ranges, _version, ranges}}, state)
-      when tag in [:minga_highlight, :minga_input] do
-    fold_ranges =
-      Enum.map(ranges, fn {start_line, end_line} ->
-        FoldRange.new!(start_line, end_line)
-      end)
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
 
     new_state =
-      case EditorState.active_window_struct(state) do
-        nil ->
-          state
-
-        %Window{id: id} ->
-          EditorState.update_window(state, id, &Window.set_fold_ranges(&1, fold_ranges))
+      if pid == state.buffers.active do
+        HighlightEvents.handle_spans(state, version, spans)
+      else
+        # Non-active buffer: store spans in highlights map, no render.
+        existing = HighlightSync.get_highlight(state, pid)
+        updated = Minga.Highlight.put_spans(existing, version, spans)
+        HighlightSync.put_highlight(state, pid, updated)
       end
 
     {:noreply, new_state}
   end
 
-  def handle_info({tag, {:textobject_positions, _version, positions}}, state)
+  def handle_info({tag, {:fold_ranges, buffer_id, _version, ranges}}, state)
       when tag in [:minga_highlight, :minga_input] do
-    new_state =
-      case EditorState.active_window_struct(state) do
-        nil ->
-          state
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
 
-        %Window{id: id} ->
-          EditorState.update_window(state, id, fn w ->
-            %{w | textobject_positions: positions}
+    new_state =
+      if pid == state.buffers.active do
+        fold_ranges =
+          Enum.map(ranges, fn {start_line, end_line} ->
+            FoldRange.new!(start_line, end_line)
           end)
+
+        case EditorState.active_window_struct(state) do
+          nil ->
+            state
+
+          %Window{id: id} ->
+            EditorState.update_window(state, id, &Window.set_fold_ranges(&1, fold_ranges))
+        end
+      else
+        # Stale response for a non-active buffer; discard.
+        state
+      end
+
+    {:noreply, new_state}
+  end
+
+  def handle_info({tag, {:textobject_positions, buffer_id, _version, positions}}, state)
+      when tag in [:minga_highlight, :minga_input] do
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
+
+    new_state =
+      if pid == state.buffers.active do
+        apply_textobject_positions(state, positions)
+      else
+        # Stale response for a non-active buffer; discard.
+        state
       end
 
     {:noreply, new_state}
@@ -459,6 +501,15 @@ defmodule Minga.Editor do
     prefix = MessageLog.frontend_prefix(state)
     new_state = log_message(state, "[#{prefix}/#{level}] #{text}")
     {:noreply, new_state}
+  end
+
+  # ── LRU eviction of inactive parser trees ─────────────────────────────────────
+
+  def handle_info(:evict_parser_trees, state) do
+    ttl_seconds = Options.get(:parser_tree_ttl)
+    state = HighlightSync.evict_inactive(state, ttl_ms: ttl_seconds * 1_000)
+    Process.send_after(self(), :evict_parser_trees, HighlightSync.eviction_check_interval_ms())
+    {:noreply, state}
   end
 
   # Completion debounce timer fired — send the actual completion request
@@ -790,6 +841,17 @@ defmodule Minga.Editor do
   # 2. Deltas arriving mid-window are picked up by the pending timer.
   # 3. The timer fires, renders the latest state, and clears the guard
   #    so the next delta can schedule again.
+  @spec apply_textobject_positions(state(), map()) :: state()
+  defp apply_textobject_positions(state, positions) do
+    case EditorState.active_window_struct(state) do
+      nil ->
+        state
+
+      %Window{id: id} ->
+        EditorState.update_window(state, id, &%{&1 | textobject_positions: positions})
+    end
+  end
+
   @spec schedule_render(state(), non_neg_integer()) :: state()
   defp schedule_render(%{render_timer: ref} = state, _delay_ms) when is_reference(ref), do: state
 

--- a/lib/minga/editor/commands/buffer_management.ex
+++ b/lib/minga/editor/commands/buffer_management.ex
@@ -724,6 +724,9 @@ defmodule Minga.Editor.Commands.BufferManagement do
         end
       end
 
+      # Free the buffer's tree-sitter parse tree in the Zig parser process.
+      state = HighlightSync.close_buffer(state, buf)
+
       Minga.Editor.log_to_messages("Closed: #{buf_name}")
 
       new_buffers = List.delete_at(buffers, idx)

--- a/lib/minga/editor/commands/editing.ex
+++ b/lib/minga/editor/commands/editing.ex
@@ -11,6 +11,7 @@ defmodule Minga.Editor.Commands.Editing do
   alias Minga.Comment
 
   alias Minga.Editor.Commands.Helpers
+  alias Minga.Editor.HighlightSync
   alias Minga.Editor.Indent
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Registers
@@ -447,7 +448,8 @@ defmodule Minga.Editor.Commands.Editing do
       when is_pid(buf) do
     gb = BufferServer.snapshot(buf)
     cursor = Document.cursor(gb)
-    range = Helpers.compute_text_object_range(gb, cursor, modifier, spec)
+    buffer_id = HighlightSync.buffer_id_for(state, buf)
+    range = Helpers.compute_text_object_range(gb, cursor, modifier, spec, buffer_id)
 
     case range do
       nil ->

--- a/lib/minga/editor/commands/helpers.ex
+++ b/lib/minga/editor/commands/helpers.ex
@@ -11,6 +11,7 @@ defmodule Minga.Editor.Commands.Helpers do
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Buffer.Unicode
   alias Minga.Clipboard
+  alias Minga.Editor.HighlightSync
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Registers
   alias Minga.Editor.Viewport
@@ -391,7 +392,8 @@ defmodule Minga.Editor.Commands.Helpers do
   def apply_text_object(%{buffers: %{active: buf}} = state, modifier, spec, action) do
     gb = BufferServer.snapshot(buf)
     cursor = Document.cursor(gb)
-    range = compute_text_object_range(gb, cursor, modifier, spec)
+    buffer_id = HighlightSync.buffer_id_for(state, buf)
+    range = compute_text_object_range(gb, cursor, modifier, spec, buffer_id)
 
     case {action, range} do
       {_, nil} ->
@@ -409,30 +411,39 @@ defmodule Minga.Editor.Commands.Helpers do
   end
 
   @doc "Computes the range for a text object modifier + spec pair."
-  @spec compute_text_object_range(Document.t(), TextObject.position(), atom(), term()) ::
+  @spec compute_text_object_range(
+          Document.t(),
+          TextObject.position(),
+          atom(),
+          term(),
+          non_neg_integer()
+        ) ::
           TextObject.range()
-  def compute_text_object_range(buf, pos, :inner, :word), do: TextObject.inner_word(buf, pos)
-  def compute_text_object_range(buf, pos, :around, :word), do: TextObject.a_word(buf, pos)
+  def compute_text_object_range(buf, pos, :inner, :word, _bid),
+    do: TextObject.inner_word(buf, pos)
 
-  def compute_text_object_range(buf, pos, :inner, {:quote, q}),
+  def compute_text_object_range(buf, pos, :around, :word, _bid),
+    do: TextObject.a_word(buf, pos)
+
+  def compute_text_object_range(buf, pos, :inner, {:quote, q}, _bid),
     do: TextObject.inner_quotes(buf, pos, q)
 
-  def compute_text_object_range(buf, pos, :around, {:quote, q}),
+  def compute_text_object_range(buf, pos, :around, {:quote, q}, _bid),
     do: TextObject.a_quotes(buf, pos, q)
 
-  def compute_text_object_range(buf, pos, :inner, {:paren, open, close}),
+  def compute_text_object_range(buf, pos, :inner, {:paren, open, close}, _bid),
     do: TextObject.inner_parens(buf, pos, open, close)
 
-  def compute_text_object_range(buf, pos, :around, {:paren, open, close}),
+  def compute_text_object_range(buf, pos, :around, {:paren, open, close}, _bid),
     do: TextObject.a_parens(buf, pos, open, close)
 
-  def compute_text_object_range(_buf, pos, :inner, {:structural, type}),
-    do: TextObject.structural_inner(type, pos)
+  def compute_text_object_range(_buf, pos, :inner, {:structural, type}, bid),
+    do: TextObject.structural_inner(type, pos, bid)
 
-  def compute_text_object_range(_buf, pos, :around, {:structural, type}),
-    do: TextObject.structural_around(type, pos)
+  def compute_text_object_range(_buf, pos, :around, {:structural, type}, bid),
+    do: TextObject.structural_around(type, pos, bid)
 
-  def compute_text_object_range(_buf, _pos, _modifier, _spec), do: nil
+  def compute_text_object_range(_buf, _pos, _modifier, _spec, _bid), do: nil
 
   @doc "Scrolls the buffer cursor by `delta` lines, clamping to bounds."
   @spec page_move(pid(), Viewport.t(), integer()) :: :ok

--- a/lib/minga/editor/commands/visual.ex
+++ b/lib/minga/editor/commands/visual.ex
@@ -9,6 +9,7 @@ defmodule Minga.Editor.Commands.Visual do
   alias Minga.Buffer.Document
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.Commands.Helpers
+  alias Minga.Editor.HighlightSync
   alias Minga.Editor.State, as: EditorState
   alias Minga.Mode
   alias Minga.Mode.VisualState
@@ -106,7 +107,8 @@ defmodule Minga.Editor.Commands.Visual do
       ) do
     gb = BufferServer.snapshot(buf)
     cursor = Document.cursor(gb)
-    range = Helpers.compute_text_object_range(gb, cursor, modifier, spec)
+    buffer_id = HighlightSync.buffer_id_for(state, buf)
+    range = Helpers.compute_text_object_range(gb, cursor, modifier, spec, buffer_id)
 
     case range do
       nil ->

--- a/lib/minga/editor/highlight_events.ex
+++ b/lib/minga/editor/highlight_events.ex
@@ -3,7 +3,10 @@ defmodule Minga.Editor.HighlightEvents do
   Handles highlight-related messages from the Parser.Manager.
 
   Extracted from `Minga.Editor` to keep the GenServer module focused on
-  orchestration. Each function takes state and returns `{:noreply, state}`.
+  orchestration. Each function takes state and returns updated state.
+
+  With per-buffer tree-sitter parsing, highlight data is stored per-buffer
+  in `highlight.highlights`. There is no separate "current" field.
   """
 
   alias Minga.Buffer.Server, as: BufferServer
@@ -15,7 +18,7 @@ defmodule Minga.Editor.HighlightEvents do
   alias Minga.LSP.SyncServer
 
   @doc """
-  Handles `:highlight_names` events from the parser.
+  Handles `:highlight_names` events from the parser (for the active buffer).
   """
   @spec handle_names(EditorState.t(), [String.t()]) :: EditorState.t()
   def handle_names(state, names) do
@@ -23,47 +26,24 @@ defmodule Minga.Editor.HighlightEvents do
   end
 
   @doc """
-  Handles `:injection_ranges` events from the parser.
-  """
-  @spec handle_injection_ranges(EditorState.t(), term()) :: EditorState.t()
-  def handle_injection_ranges(state, ranges) do
-    if state.buffers.active do
-      %{state | injection_ranges: Map.put(state.injection_ranges, state.buffers.active, ranges)}
-    else
-      state
-    end
-  end
+  Handles `:highlight_spans` events from the parser (for the active buffer).
 
-  @doc """
-  Handles `:highlight_spans` events from the parser.
-
-  Updates the highlight state, caches spans for the active buffer,
-  and triggers a render.
+  Updates the buffer's highlight data and triggers a render.
   """
   @spec handle_spans(EditorState.t(), non_neg_integer(), term()) :: EditorState.t()
   def handle_spans(state, version, spans) do
     new_state = HighlightSync.handle_spans(state, version, spans)
-
-    new_state =
-      if new_state.buffers.active do
-        hl = new_state.highlight
-
-        %{
-          new_state
-          | highlight: %{hl | cache: Map.put(hl.cache, new_state.buffers.active, hl.current)}
-        }
-      else
-        new_state
-      end
-
     Renderer.render(new_state)
   end
 
   @doc """
-  Detects buffer switch and restores/caches highlights accordingly.
+  Detects buffer switch and schedules highlight setup if the new buffer
+  has no cached highlights.
 
-  Saves current highlights for the old buffer, restores cached highlights
-  for the new buffer, or schedules highlight setup if no cache exists.
+  With per-buffer parsing, buffer switches don't need to swap data in
+  and out of a "current" field. Each buffer's highlights live in the
+  `highlights` map permanently. We just need to trigger setup if the
+  buffer has never been highlighted before.
   """
   @spec maybe_reset_highlight(EditorState.t(), pid() | nil) :: EditorState.t()
   def maybe_reset_highlight(state, old_buffer) do
@@ -72,24 +52,17 @@ defmodule Minga.Editor.HighlightEvents do
     if new_buffer != old_buffer and new_buffer != nil do
       hl = state.highlight
 
-      cache =
-        if old_buffer != nil and hl.current.capture_names != [] do
-          Map.put(hl.cache, old_buffer, hl.current)
-        else
-          hl.cache
-        end
-
-      case Map.get(cache, new_buffer) do
+      case Map.get(hl.highlights, new_buffer) do
         nil ->
+          # New buffer with no highlights: schedule setup.
           send(self(), :setup_highlight)
+          state
 
-          %{
-            state
-            | highlight: %{hl | current: Minga.Highlight.from_theme(state.theme), cache: cache}
-          }
-
-        cached ->
-          %{state | highlight: %{hl | current: cached, cache: cache}}
+        _cached ->
+          # Buffer has cached highlights: nothing to do, they're already
+          # in the highlights map and will be read by the render pipeline.
+          # Refresh the LRU timestamp so actively-viewed buffers aren't evicted.
+          HighlightSync.touch_active(state)
       end
     else
       state
@@ -121,8 +94,14 @@ defmodule Minga.Editor.HighlightEvents do
         state
       end
 
-    if content_changed and state.highlight.current.capture_names != [] do
-      HighlightSync.request_reparse(state)
+    if content_changed do
+      active_hl = HighlightSync.get_active_highlight(state)
+
+      if active_hl.capture_names != [] do
+        HighlightSync.request_reparse(state)
+      else
+        state
+      end
     else
       state
     end

--- a/lib/minga/editor/highlight_sync.ex
+++ b/lib/minga/editor/highlight_sync.ex
@@ -32,27 +32,27 @@ defmodule Minga.Editor.HighlightSync do
         send_parse_only(state, language)
 
       :unsupported ->
-        hl = state.highlight
-        %{state | highlight: %{hl | current: Highlight.from_theme(state.theme)}}
+        put_active_highlight(state, Highlight.from_theme(state.theme))
     end
   end
 
   @spec send_parse_only(EditorState.t(), String.t()) :: EditorState.t()
   defp send_parse_only(state, language) do
+    {buffer_id, state} = ensure_buffer_id(state)
     hl = state.highlight
     version = hl.version + 1
     content = BufferServer.content(state.buffers.active)
 
-    query_override = user_query_override(language)
-    injection_override = user_injection_query_override(language)
-    fold_override = user_fold_query_override(language)
-    textobject_override = user_textobject_query_override(language)
+    query_override = user_query_override(buffer_id, language)
+    injection_override = user_injection_query_override(buffer_id, language)
+    fold_override = user_fold_query_override(buffer_id, language)
+    textobject_override = user_textobject_query_override(buffer_id, language)
 
-    parse_cmd = Protocol.encode_parse_buffer(version, content)
+    parse_cmd = Protocol.encode_parse_buffer(buffer_id, version, content)
 
     commands =
       Enum.concat([
-        [Protocol.encode_set_language(language)],
+        [Protocol.encode_set_language(buffer_id, language)],
         query_override,
         injection_override,
         fold_override,
@@ -62,18 +62,83 @@ defmodule Minga.Editor.HighlightSync do
 
     ParserManager.send_commands(commands)
 
-    %{state | highlight: %{hl | current: Highlight.from_theme(state.theme), version: version}}
+    state = put_active_highlight(state, Highlight.from_theme(state.theme))
+    hl2 = state.highlight
+    state = %{state | highlight: %{hl2 | version: version}}
+    touch_active(state)
+  end
+
+  @doc """
+  Returns the parser buffer_id for the active buffer, assigning one if needed.
+
+  Returns `{buffer_id, updated_state}`. The buffer_id is a monotonically
+  incrementing u32 stored in `highlight.buffer_ids`.
+  """
+  @spec ensure_buffer_id(EditorState.t()) :: {non_neg_integer(), EditorState.t()}
+  def ensure_buffer_id(%EditorState{buffers: %{active: nil}} = state), do: {0, state}
+
+  def ensure_buffer_id(%EditorState{highlight: hl, buffers: %{active: buf}} = state) do
+    case Map.fetch(hl.buffer_ids, buf) do
+      {:ok, id} ->
+        {id, state}
+
+      :error ->
+        assign_new_buffer_id(state, hl, buf)
+    end
+  end
+
+  @spec assign_new_buffer_id(EditorState.t(), Minga.Editor.State.Highlighting.t(), pid()) ::
+          {non_neg_integer(), EditorState.t()}
+  defp assign_new_buffer_id(state, hl, buf) do
+    id = hl.next_buffer_id
+
+    new_hl = %{
+      hl
+      | buffer_ids: Map.put(hl.buffer_ids, buf, id),
+        reverse_buffer_ids: Map.put(hl.reverse_buffer_ids, id, buf),
+        next_buffer_id: id + 1
+    }
+
+    {id, %{state | highlight: new_hl}}
+  end
+
+  @doc """
+  Sends a close_buffer command to the parser for a buffer that's being closed.
+  Removes the buffer ID mapping.
+  """
+  @spec close_buffer(EditorState.t(), pid()) :: EditorState.t()
+  def close_buffer(%EditorState{} = state, buffer_pid) do
+    hl = state.highlight
+
+    case Map.pop(hl.buffer_ids, buffer_pid) do
+      {nil, _ids} ->
+        state
+
+      {buffer_id, remaining_ids} ->
+        ParserManager.close_buffer(buffer_id)
+
+        %{
+          state
+          | highlight: %{
+              hl
+              | buffer_ids: remaining_ids,
+                reverse_buffer_ids: Map.delete(hl.reverse_buffer_ids, buffer_id),
+                highlights: Map.delete(hl.highlights, buffer_pid),
+                last_active_at: Map.delete(hl.last_active_at, buffer_pid)
+            }
+        }
+    end
   end
 
   # Returns a list with a set_highlight_query command if the user has a custom
   # query file for this language, or an empty list to use the Zig built-in.
-  @spec user_query_override(String.t()) :: [binary()]
-  defp user_query_override(language) do
+  @spec user_query_override(non_neg_integer(), String.t()) :: [binary()]
+  defp user_query_override(buffer_id, language) do
     user_path = user_query_path(language)
 
     if user_path != nil and File.exists?(user_path) do
       case File.read(user_path) do
-        {:ok, query_text} -> [Protocol.encode_set_highlight_query(query_text)]
+        {:ok, query_text} -> [Protocol.encode_set_highlight_query(buffer_id, query_text)]
         {:error, _} -> []
       end
     else
@@ -83,13 +148,13 @@ defmodule Minga.Editor.HighlightSync do
 
   # Returns a list with a set_injection_query command if the user has a custom
   # injection query file for this language, or an empty list to use the Zig built-in.
-  @spec user_injection_query_override(String.t()) :: [binary()]
-  defp user_injection_query_override(language) do
+  @spec user_injection_query_override(non_neg_integer(), String.t()) :: [binary()]
+  defp user_injection_query_override(buffer_id, language) do
     user_path = user_injection_query_path(language)
 
     if user_path != nil and File.exists?(user_path) do
       case File.read(user_path) do
-        {:ok, query_text} -> [Protocol.encode_set_injection_query(query_text)]
+        {:ok, query_text} -> [Protocol.encode_set_injection_query(buffer_id, query_text)]
         {:error, _} -> []
       end
     else
@@ -115,13 +180,13 @@ defmodule Minga.Editor.HighlightSync do
 
   # Returns a list with a set_fold_query command if the user has a custom
   # fold query file for this language, or an empty list to use the Zig built-in.
-  @spec user_fold_query_override(String.t()) :: [binary()]
-  defp user_fold_query_override(language) do
+  @spec user_fold_query_override(non_neg_integer(), String.t()) :: [binary()]
+  defp user_fold_query_override(buffer_id, language) do
     user_path = user_fold_query_path(language)
 
     if user_path != nil and File.exists?(user_path) do
       case File.read(user_path) do
-        {:ok, query_text} -> [Protocol.encode_set_fold_query(query_text)]
+        {:ok, query_text} -> [Protocol.encode_set_fold_query(buffer_id, query_text)]
         {:error, _} -> []
       end
     else
@@ -139,13 +204,13 @@ defmodule Minga.Editor.HighlightSync do
 
   # Returns a list with a set_textobject_query command if the user has a custom
   # textobject query file for this language, or an empty list to use the Zig built-in.
-  @spec user_textobject_query_override(String.t()) :: [binary()]
-  defp user_textobject_query_override(language) do
+  @spec user_textobject_query_override(non_neg_integer(), String.t()) :: [binary()]
+  defp user_textobject_query_override(buffer_id, language) do
     user_path = user_textobject_query_path(language)
 
     if user_path != nil and File.exists?(user_path) do
       case File.read(user_path) do
-        {:ok, query_text} -> [Protocol.encode_set_textobject_query(query_text)]
+        {:ok, query_text} -> [Protocol.encode_set_textobject_query(buffer_id, query_text)]
         {:error, _} -> []
       end
     else
@@ -169,14 +234,19 @@ defmodule Minga.Editor.HighlightSync do
   @spec request_reparse(EditorState.t()) :: EditorState.t()
   def request_reparse(%EditorState{buffers: %{active: nil}} = state), do: state
 
-  def request_reparse(
-        %EditorState{highlight: %{current: %{spans: {}, capture_names: []}}} = state
-      ) do
-    # No highlighting active — skip
-    state
+  def request_reparse(%EditorState{} = state) when state.buffers.active != nil do
+    active_hl = get_active_highlight(state)
+
+    if active_hl.spans == {} and active_hl.capture_names == [] do
+      # No highlighting active for this buffer — skip
+      state
+    else
+      do_request_reparse(state)
+    end
   end
 
-  def request_reparse(%EditorState{} = state) do
+  defp do_request_reparse(%EditorState{} = state) do
+    {buffer_id, state} = ensure_buffer_id(state)
     hl = state.highlight
     version = hl.version + 1
 
@@ -187,30 +257,212 @@ defmodule Minga.Editor.HighlightSync do
     commands =
       if edits != [] do
         delta_maps = Enum.map(edits, &Map.from_struct/1)
-        [Protocol.encode_edit_buffer(version, delta_maps)]
+        [Protocol.encode_edit_buffer(buffer_id, version, delta_maps)]
       else
         # No deltas (e.g., undo/redo, content replaced externally): full sync
         content = BufferServer.content(state.buffers.active)
-        [Protocol.encode_parse_buffer(version, content)]
+        [Protocol.encode_parse_buffer(buffer_id, version, content)]
       end
 
     ParserManager.send_commands(commands)
 
-    %{state | highlight: %{hl | version: version}}
+    state = %{state | highlight: %{hl | version: version}}
+    touch_active(state)
   end
 
-  @doc "Handles a highlight_names event from the parser."
+  # ── LRU eviction ──────────────────────────────────────────────────────────────
+
+  # How often the eviction sweep runs (60 seconds).
+  @eviction_check_interval_ms 60_000
+
+  @doc """
+  Returns the eviction check interval in milliseconds.
+  Used by the Editor to schedule periodic `Process.send_after`.
+  """
+  @spec eviction_check_interval_ms() :: non_neg_integer()
+  def eviction_check_interval_ms, do: @eviction_check_interval_ms
+
+  @doc """
+  Touches the last_active_at timestamp for the active buffer.
+  Call on every parse, edit, or buffer focus.
+  """
+  @spec touch_active(EditorState.t()) :: EditorState.t()
+  def touch_active(%EditorState{buffers: %{active: nil}} = state), do: state
+
+  def touch_active(%EditorState{} = state) do
+    hl = state.highlight
+    now = System.monotonic_time(:millisecond)
+    timestamps = Map.put(hl.last_active_at, state.buffers.active, now)
+    %{state | highlight: %{hl | last_active_at: timestamps}}
+  end
+
+  @doc """
+  Evicts inactive buffer trees from the Zig parser.
+
+  Buffers whose last_active_at exceeds the TTL are evicted by sending
+  close_buffer to the parser (frees tree + source on the Zig side).
+  The buffer_id mapping is removed; on next access, `ensure_buffer_id`
+  assigns a fresh ID and `setup_for_buffer` sends set_language + parse_buffer.
+
+  The active buffer and any PIDs in `protected_pids` are never evicted.
+  """
+  @typedoc "Options for `evict_inactive/2`."
+  @type evict_opt :: {:protected_pids, [pid()]} | {:ttl_ms, non_neg_integer()}
+
+  @spec evict_inactive(EditorState.t(), [evict_opt()]) :: EditorState.t()
+  def evict_inactive(%EditorState{} = state, opts \\ []) do
+    hl = state.highlight
+    now = System.monotonic_time(:millisecond)
+    ttl_ms = Keyword.get(opts, :ttl_ms, 300_000)
+    protected_pids = Keyword.get(opts, :protected_pids, [])
+
+    active = state.buffers.active
+    protected = MapSet.new([active | protected_pids] |> Enum.reject(&is_nil/1))
+
+    {evicted_ids, remaining_timestamps} =
+      find_stale_buffers(hl, now, ttl_ms, protected)
+
+    apply_evictions(state, evicted_ids, remaining_timestamps)
+  end
+
+  @spec find_stale_buffers(
+          Minga.Editor.State.Highlighting.t(),
+          integer(),
+          non_neg_integer(),
+          MapSet.t()
+        ) ::
+          {[{pid(), non_neg_integer()}], %{pid() => integer()}}
+  defp find_stale_buffers(hl, now, ttl, protected) do
+    Enum.reduce(hl.last_active_at, {[], %{}}, fn {pid, last_ts}, {evicted, kept} ->
+      stale? = now - last_ts > ttl
+      guarded? = MapSet.member?(protected, pid)
+
+      if stale? and not guarded? do
+        classify_stale_buffer(hl, pid, evicted, kept)
+      else
+        {evicted, Map.put(kept, pid, last_ts)}
+      end
+    end)
+  end
+
+  @spec classify_stale_buffer(
+          Minga.Editor.State.Highlighting.t(),
+          pid(),
+          [{pid(), non_neg_integer()}],
+          %{pid() => integer()}
+        ) :: {[{pid(), non_neg_integer()}], %{pid() => integer()}}
+  defp classify_stale_buffer(hl, pid, evicted, kept) do
+    case Map.get(hl.buffer_ids, pid) do
+      nil -> {evicted, kept}
+      id -> {[{pid, id} | evicted], kept}
+    end
+  end
+
+  @spec apply_evictions(EditorState.t(), [{pid(), non_neg_integer()}], %{pid() => integer()}) ::
+          EditorState.t()
+  defp apply_evictions(state, [], _remaining_timestamps), do: state
+
+  defp apply_evictions(state, evicted_ids, remaining_timestamps) do
+    # Action: send close_buffer commands to the Zig parser.
+    Enum.each(evicted_ids, fn {_pid, id} -> ParserManager.close_buffer(id) end)
+
+    Minga.Log.debug(
+      :editor,
+      "Parser LRU: evicted #{length(evicted_ids)} inactive buffer tree(s)"
+    )
+
+    # Calculation: compute the new highlighting state with evicted entries removed.
+    new_hl = compute_post_eviction_state(state.highlight, evicted_ids, remaining_timestamps)
+    %{state | highlight: new_hl}
+  end
+
+  # Pure calculation: produces the new Highlighting struct with evicted entries removed.
+  @spec compute_post_eviction_state(
+          Minga.Editor.State.Highlighting.t(),
+          [{pid(), non_neg_integer()}],
+          %{pid() => integer()}
+        ) :: Minga.Editor.State.Highlighting.t()
+  defp compute_post_eviction_state(hl, evicted_ids, remaining_timestamps) do
+    evicted_pids = MapSet.new(evicted_ids, fn {pid, _id} -> pid end)
+    evicted_id_set = MapSet.new(evicted_ids, fn {_pid, id} -> id end)
+
+    %{
+      hl
+      | buffer_ids:
+          Map.reject(hl.buffer_ids, fn {pid, _} -> MapSet.member?(evicted_pids, pid) end),
+        reverse_buffer_ids:
+          Map.reject(hl.reverse_buffer_ids, fn {id, _} -> MapSet.member?(evicted_id_set, id) end),
+        highlights:
+          Map.reject(hl.highlights, fn {pid, _} -> MapSet.member?(evicted_pids, pid) end),
+        last_active_at: remaining_timestamps
+    }
+  end
+
+  @doc """
+  Resolves a parser buffer_id to the buffer PID that owns it.
+  Returns nil if the buffer_id is unknown (e.g., the buffer was closed).
+  """
+  @spec resolve_buffer_pid(EditorState.t(), non_neg_integer()) :: pid() | nil
+  def resolve_buffer_pid(%EditorState{highlight: hl}, buffer_id) do
+    Map.get(hl.reverse_buffer_ids, buffer_id)
+  end
+
+  @doc "Handles a highlight_names event for the active buffer."
   @spec handle_names(EditorState.t(), [String.t()]) :: EditorState.t()
   def handle_names(%EditorState{} = state, names) do
-    hl = state.highlight
-    %{state | highlight: %{hl | current: Highlight.put_names(hl.current, names)}}
+    update_active_highlight(state, &Highlight.put_names(&1, names))
   end
 
-  @doc "Handles a highlight_spans event from Zig."
+  @doc "Handles a highlight_spans event for the active buffer."
   @spec handle_spans(EditorState.t(), non_neg_integer(), [Minga.Port.Protocol.highlight_span()]) ::
           EditorState.t()
   def handle_spans(%EditorState{} = state, version, spans) do
-    hl = state.highlight
-    %{state | highlight: %{hl | current: Highlight.put_spans(hl.current, version, spans)}}
+    update_active_highlight(state, &Highlight.put_spans(&1, version, spans))
+  end
+
+  # ── Per-buffer highlight helpers ─────────────────────────────────────────────
+
+  @doc "Returns the parser buffer_id for a given buffer PID (read-only, no allocation)."
+  @spec buffer_id_for(EditorState.t(), pid()) :: non_neg_integer()
+  def buffer_id_for(%EditorState{highlight: hl}, buf_pid) do
+    Map.get(hl.buffer_ids, buf_pid, 0)
+  end
+
+  @doc "Returns the highlight data for the active buffer."
+  @spec get_active_highlight(EditorState.t()) :: Highlight.t()
+  def get_active_highlight(%EditorState{buffers: %{active: nil}}), do: Highlight.new()
+
+  def get_active_highlight(%EditorState{highlight: hl, buffers: %{active: buf}}) do
+    Map.get(hl.highlights, buf, Highlight.new())
+  end
+
+  @doc "Returns the highlight data for a specific buffer PID."
+  @spec get_highlight(EditorState.t(), pid()) :: Highlight.t()
+  def get_highlight(%EditorState{highlight: hl}, buf_pid) do
+    Map.get(hl.highlights, buf_pid, Highlight.new())
+  end
+
+  @doc "Stores highlight data for the active buffer."
+  @spec put_active_highlight(EditorState.t(), Highlight.t()) :: EditorState.t()
+  def put_active_highlight(%EditorState{buffers: %{active: nil}} = state, _hl_data), do: state
+
+  def put_active_highlight(%EditorState{highlight: hl, buffers: %{active: buf}} = state, hl_data) do
+    %{state | highlight: %{hl | highlights: Map.put(hl.highlights, buf, hl_data)}}
+  end
+
+  @doc "Stores highlight data for a specific buffer PID."
+  @spec put_highlight(EditorState.t(), pid(), Highlight.t()) :: EditorState.t()
+  def put_highlight(%EditorState{highlight: hl} = state, buf_pid, hl_data) do
+    %{state | highlight: %{hl | highlights: Map.put(hl.highlights, buf_pid, hl_data)}}
+  end
+
+  # Updates the active buffer's highlight via a function.
+  @spec update_active_highlight(EditorState.t(), (Highlight.t() -> Highlight.t())) ::
+          EditorState.t()
+  defp update_active_highlight(%EditorState{buffers: %{active: nil}} = state, _fun), do: state
+
+  defp update_active_highlight(%EditorState{} = state, fun) do
+    current = get_active_highlight(state)
+    put_active_highlight(state, fun.(current))
   end
 end

--- a/lib/minga/editor/render_pipeline/content_helpers.ex
+++ b/lib/minga/editor/render_pipeline/content_helpers.ex
@@ -718,11 +718,7 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   @spec window_highlight(state(), Window.t()) :: Minga.Highlight.t() | nil
   def window_highlight(state, window) do
     hl =
-      if window.buffer == state.buffers.active do
-        state.highlight.current
-      else
-        Map.get(state.highlight.cache, window.buffer, Minga.Highlight.from_theme(state.theme))
-      end
+      Map.get(state.highlight.highlights, window.buffer, Minga.Highlight.from_theme(state.theme))
 
     if hl.capture_names != [], do: hl, else: nil
   end

--- a/lib/minga/editor/state/highlighting.ex
+++ b/lib/minga/editor/state/highlighting.ex
@@ -2,19 +2,31 @@ defmodule Minga.Editor.State.Highlighting do
   @moduledoc """
   Groups syntax-highlighting fields from EditorState.
 
-  Tracks the current highlight state, a monotonic version counter for
-  invalidation, and a per-buffer cache of highlight data.
+  Tracks per-buffer highlight data, a monotonic version counter for
+  invalidation, the mapping from buffer PIDs to parser buffer IDs
+  (monotonically incrementing u32s), and LRU timestamps for inactive
+  tree eviction.
+
+  Highlight spans are stored per-buffer in `highlights`. There is no
+  separate "current" field; the active buffer's highlight is just
+  `Map.get(highlights, active_pid)`.
   """
 
   alias Minga.Highlight
 
   @type t :: %__MODULE__{
-          current: Highlight.t(),
+          highlights: %{pid() => Highlight.t()},
           version: non_neg_integer(),
-          cache: %{pid() => Highlight.t()}
+          buffer_ids: %{pid() => non_neg_integer()},
+          reverse_buffer_ids: %{non_neg_integer() => pid()},
+          next_buffer_id: non_neg_integer(),
+          last_active_at: %{pid() => integer()}
         }
 
-  defstruct current: Highlight.new(),
+  defstruct highlights: %{},
             version: 0,
-            cache: %{}
+            buffer_ids: %{},
+            reverse_buffer_ids: %{},
+            next_buffer_id: 1,
+            last_active_at: %{}
 end

--- a/lib/minga/parser/manager.ex
+++ b/lib/minga/parser/manager.ex
@@ -95,39 +95,53 @@ defmodule Minga.Parser.Manager do
   @spec request_textobject(
           non_neg_integer(),
           non_neg_integer(),
+          non_neg_integer(),
           String.t(),
           GenServer.server()
         ) ::
           {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil
-  def request_textobject(row, col, capture_name, server \\ __MODULE__)
-      when is_integer(row) and is_integer(col) and is_binary(capture_name) do
-    GenServer.call(server, {:request_textobject, row, col, capture_name}, 2_000)
+  def request_textobject(buffer_id, row, col, capture_name, server \\ __MODULE__)
+      when is_integer(buffer_id) and is_integer(row) and is_integer(col) and
+             is_binary(capture_name) do
+    GenServer.call(server, {:request_textobject, buffer_id, row, col, capture_name}, 2_000)
   catch
     :exit, _ -> nil
   end
 
   @doc """
-  Sets the active tree-sitter language for subsequent parse/query commands.
+  Sets the active tree-sitter language for a buffer.
   """
-  @spec set_language(String.t(), GenServer.server()) :: :ok
-  def set_language(name, server \\ __MODULE__) when is_binary(name) do
-    send_commands(server, [Protocol.encode_set_language(name)])
+  @spec set_language(non_neg_integer(), String.t(), GenServer.server()) :: :ok
+  def set_language(buffer_id, name, server \\ __MODULE__)
+      when is_integer(buffer_id) and is_binary(name) do
+    send_commands(server, [Protocol.encode_set_language(buffer_id, name)])
   end
 
   @doc """
-  Sets a custom highlight query for the currently active language.
+  Sets a custom highlight query for a buffer.
   """
-  @spec set_highlight_query(String.t(), GenServer.server()) :: :ok
-  def set_highlight_query(query, server \\ __MODULE__) when is_binary(query) do
-    send_commands(server, [Protocol.encode_set_highlight_query(query)])
+  @spec set_highlight_query(non_neg_integer(), String.t(), GenServer.server()) :: :ok
+  def set_highlight_query(buffer_id, query, server \\ __MODULE__)
+      when is_integer(buffer_id) and is_binary(query) do
+    send_commands(server, [Protocol.encode_set_highlight_query(buffer_id, query)])
   end
 
   @doc """
-  Sets a custom injection query for the currently active language.
+  Sets a custom injection query for a buffer.
   """
-  @spec set_injection_query(String.t(), GenServer.server()) :: :ok
-  def set_injection_query(query, server \\ __MODULE__) when is_binary(query) do
-    send_commands(server, [Protocol.encode_set_injection_query(query)])
+  @spec set_injection_query(non_neg_integer(), String.t(), GenServer.server()) :: :ok
+  def set_injection_query(buffer_id, query, server \\ __MODULE__)
+      when is_integer(buffer_id) and is_binary(query) do
+    send_commands(server, [Protocol.encode_set_injection_query(buffer_id, query)])
+  end
+
+  @doc """
+  Closes a buffer in the parser, freeing its tree and source.
+  """
+  @spec close_buffer(non_neg_integer(), GenServer.server()) :: :ok
+  def close_buffer(buffer_id, server \\ __MODULE__)
+      when is_integer(buffer_id) do
+    send_commands(server, [Protocol.encode_close_buffer(buffer_id)])
   end
 
   # ── Server Callbacks ──
@@ -148,13 +162,17 @@ defmodule Minga.Parser.Manager do
     {:reply, :ok, %{state | subscribers: subscribers}}
   end
 
-  def handle_call({:request_textobject, _row, _col, _capture}, _from, %{port: nil} = state) do
+  def handle_call(
+        {:request_textobject, _buffer_id, _row, _col, _capture},
+        _from,
+        %{port: nil} = state
+      ) do
     {:reply, nil, state}
   end
 
-  def handle_call({:request_textobject, row, col, capture_name}, from, state) do
+  def handle_call({:request_textobject, buffer_id, row, col, capture_name}, from, state) do
     request_id = state.next_request_id
-    cmd = Protocol.encode_request_textobject(request_id, row, col, capture_name)
+    cmd = Protocol.encode_request_textobject(buffer_id, request_id, row, col, capture_name)
     Port.command(state.port, cmd)
 
     pending = Map.put(state.pending_requests, request_id, from)

--- a/lib/minga/port/protocol.ex
+++ b/lib/minga/port/protocol.ex
@@ -74,6 +74,7 @@ defmodule Minga.Port.Protocol do
   @op_request_indent 0x2A
   @op_set_textobject_query 0x2B
   @op_request_textobject 0x2C
+  @op_close_buffer 0x2D
 
   # Well-known textobject type IDs (match Zig constants)
   @textobj_function 0
@@ -161,14 +162,15 @@ defmodule Minga.Port.Protocol do
           | {:paste_event, text :: String.t()}
           | {:mouse_event, row :: integer(), col :: integer(), mouse_button(), modifiers(),
              mouse_event_type(), click_count :: pos_integer()}
-          | {:highlight_spans, version :: non_neg_integer(), [highlight_span()]}
-          | {:highlight_names, [String.t()]}
+          | {:highlight_spans, buffer_id :: non_neg_integer(), version :: non_neg_integer(),
+             [highlight_span()]}
+          | {:highlight_names, buffer_id :: non_neg_integer(), [String.t()]}
           | {:grammar_loaded, success :: boolean(), name :: String.t()}
-          | {:injection_ranges,
+          | {:injection_ranges, buffer_id :: non_neg_integer(),
              [%{start_byte: non_neg_integer(), end_byte: non_neg_integer(), language: String.t()}]}
           | {:language_at_response, request_id :: non_neg_integer(), language :: String.t()}
           | {:text_width, request_id :: non_neg_integer(), width :: non_neg_integer()}
-          | {:fold_ranges, version :: non_neg_integer(),
+          | {:fold_ranges, buffer_id :: non_neg_integer(), version :: non_neg_integer(),
              [{start_line :: non_neg_integer(), end_line :: non_neg_integer()}]}
           | {:indent_result, request_id :: non_neg_integer(), line :: non_neg_integer(),
              indent_level :: integer()}
@@ -176,7 +178,7 @@ defmodule Minga.Port.Protocol do
              result ::
                {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
                | nil}
-          | {:textobject_positions, version :: non_neg_integer(),
+          | {:textobject_positions, buffer_id :: non_neg_integer(), version :: non_neg_integer(),
              %{atom() => [{non_neg_integer(), non_neg_integer()}]}}
           | {:log_message, level :: String.t(), text :: String.t()}
 
@@ -407,14 +409,16 @@ defmodule Minga.Port.Protocol do
         }
 
   @doc """
-  Encodes an edit_buffer command with a version and a list of edit deltas.
+  Encodes an edit_buffer command with buffer_id, version, and a list of edit deltas.
 
   Each delta describes a replacement: the range [start_byte, old_end_byte) is
   replaced with `inserted_text`, producing a range [start_byte, new_end_byte).
   """
-  @spec encode_edit_buffer(non_neg_integer(), [edit_delta()]) :: binary()
-  def encode_edit_buffer(version, edits) when is_integer(version) and is_list(edits) do
-    header = <<@op_edit_buffer, version::32, length(edits)::16>>
+  @spec encode_edit_buffer(non_neg_integer(), non_neg_integer(), [edit_delta()]) :: binary()
+  def encode_edit_buffer(buffer_id, version, edits)
+      when is_integer(buffer_id) and buffer_id >= 0 and
+             is_integer(version) and is_list(edits) do
+    header = <<@op_edit_buffer, buffer_id::32, version::32, length(edits)::16>>
 
     edit_data =
       for edit <- edits, into: <<>> do
@@ -443,69 +447,79 @@ defmodule Minga.Port.Protocol do
 
   # ── Encoding: highlight commands (BEAM → Zig) ──
 
-  @doc "Encodes a set_language command."
-  @spec encode_set_language(String.t()) :: binary()
-  def encode_set_language(name) when is_binary(name) do
-    <<@op_set_language, byte_size(name)::16, name::binary>>
+  @doc "Encodes a set_language command with buffer_id."
+  @spec encode_set_language(non_neg_integer(), String.t()) :: binary()
+  def encode_set_language(buffer_id, name)
+      when is_integer(buffer_id) and buffer_id >= 0 and is_binary(name) do
+    <<@op_set_language, buffer_id::32, byte_size(name)::16, name::binary>>
   end
 
-  @doc "Encodes a parse_buffer command with a version counter."
-  @spec encode_parse_buffer(non_neg_integer(), String.t()) :: binary()
-  def encode_parse_buffer(version, source)
-      when is_integer(version) and version >= 0 and is_binary(source) do
-    <<@op_parse_buffer, version::32, byte_size(source)::32, source::binary>>
+  @doc "Encodes a parse_buffer command with buffer_id and version counter."
+  @spec encode_parse_buffer(non_neg_integer(), non_neg_integer(), String.t()) :: binary()
+  def encode_parse_buffer(buffer_id, version, source)
+      when is_integer(buffer_id) and buffer_id >= 0 and
+             is_integer(version) and version >= 0 and is_binary(source) do
+    <<@op_parse_buffer, buffer_id::32, version::32, byte_size(source)::32, source::binary>>
   end
 
-  @doc "Encodes a set_highlight_query command."
-  @spec encode_set_highlight_query(String.t()) :: binary()
-  def encode_set_highlight_query(query) when is_binary(query) do
-    <<@op_set_highlight_query, byte_size(query)::32, query::binary>>
+  @doc "Encodes a set_highlight_query command with buffer_id."
+  @spec encode_set_highlight_query(non_neg_integer(), String.t()) :: binary()
+  def encode_set_highlight_query(buffer_id, query)
+      when is_integer(buffer_id) and buffer_id >= 0 and is_binary(query) do
+    <<@op_set_highlight_query, buffer_id::32, byte_size(query)::32, query::binary>>
   end
 
-  @doc "Encodes a set_injection_query command."
-  @spec encode_set_injection_query(String.t()) :: binary()
-  def encode_set_injection_query(query) when is_binary(query) do
-    <<@op_set_injection_query, byte_size(query)::32, query::binary>>
+  @doc "Encodes a set_injection_query command with buffer_id."
+  @spec encode_set_injection_query(non_neg_integer(), String.t()) :: binary()
+  def encode_set_injection_query(buffer_id, query)
+      when is_integer(buffer_id) and buffer_id >= 0 and is_binary(query) do
+    <<@op_set_injection_query, buffer_id::32, byte_size(query)::32, query::binary>>
   end
 
-  @doc "Encodes a set_fold_query command."
-  @spec encode_set_fold_query(String.t()) :: binary()
-  def encode_set_fold_query(query) when is_binary(query) do
-    <<@op_set_fold_query, byte_size(query)::32, query::binary>>
+  @doc "Encodes a set_fold_query command with buffer_id."
+  @spec encode_set_fold_query(non_neg_integer(), String.t()) :: binary()
+  def encode_set_fold_query(buffer_id, query)
+      when is_integer(buffer_id) and buffer_id >= 0 and is_binary(query) do
+    <<@op_set_fold_query, buffer_id::32, byte_size(query)::32, query::binary>>
   end
 
-  @doc "Encodes a set_indent_query command."
-  @spec encode_set_indent_query(String.t()) :: binary()
-  def encode_set_indent_query(query) when is_binary(query) do
-    <<@op_set_indent_query, byte_size(query)::32, query::binary>>
+  @doc "Encodes a set_indent_query command with buffer_id."
+  @spec encode_set_indent_query(non_neg_integer(), String.t()) :: binary()
+  def encode_set_indent_query(buffer_id, query)
+      when is_integer(buffer_id) and buffer_id >= 0 and is_binary(query) do
+    <<@op_set_indent_query, buffer_id::32, byte_size(query)::32, query::binary>>
   end
 
-  @doc "Encodes a request_indent command: request_id(4) + line(4)."
-  @spec encode_request_indent(non_neg_integer(), non_neg_integer()) :: binary()
-  def encode_request_indent(request_id, line)
-      when is_integer(request_id) and is_integer(line) do
-    <<@op_request_indent, request_id::32, line::32>>
+  @doc "Encodes a request_indent command: buffer_id(4) + request_id(4) + line(4)."
+  @spec encode_request_indent(non_neg_integer(), non_neg_integer(), non_neg_integer()) :: binary()
+  def encode_request_indent(buffer_id, request_id, line)
+      when is_integer(buffer_id) and buffer_id >= 0 and
+             is_integer(request_id) and is_integer(line) do
+    <<@op_request_indent, buffer_id::32, request_id::32, line::32>>
   end
 
-  @doc "Encodes a set_textobject_query command."
-  @spec encode_set_textobject_query(String.t()) :: binary()
-  def encode_set_textobject_query(query) when is_binary(query) do
-    <<@op_set_textobject_query, byte_size(query)::32, query::binary>>
+  @doc "Encodes a set_textobject_query command with buffer_id."
+  @spec encode_set_textobject_query(non_neg_integer(), String.t()) :: binary()
+  def encode_set_textobject_query(buffer_id, query)
+      when is_integer(buffer_id) and buffer_id >= 0 and is_binary(query) do
+    <<@op_set_textobject_query, buffer_id::32, byte_size(query)::32, query::binary>>
   end
 
-  @doc "Encodes a request_textobject command: request_id(4) + row(4) + col(4) + name_len(2) + name."
+  @doc "Encodes a request_textobject command: buffer_id(4) + request_id(4) + row(4) + col(4) + name_len(2) + name."
   @spec encode_request_textobject(
+          non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
           String.t()
         ) ::
           binary()
-  def encode_request_textobject(request_id, row, col, capture_name)
-      when is_integer(request_id) and is_integer(row) and is_integer(col) and
+  def encode_request_textobject(buffer_id, request_id, row, col, capture_name)
+      when is_integer(buffer_id) and buffer_id >= 0 and
+             is_integer(request_id) and is_integer(row) and is_integer(col) and
              is_binary(capture_name) do
-    <<@op_request_textobject, request_id::32, row::32, col::32, byte_size(capture_name)::16,
-      capture_name::binary>>
+    <<@op_request_textobject, buffer_id::32, request_id::32, row::32, col::32,
+      byte_size(capture_name)::16, capture_name::binary>>
   end
 
   @doc "Encodes a load_grammar command."
@@ -514,11 +528,20 @@ defmodule Minga.Port.Protocol do
     <<@op_load_grammar, byte_size(name)::16, name::binary, byte_size(path)::16, path::binary>>
   end
 
-  @doc "Encodes a query_language_at request: request_id(4) + byte_offset(4)."
-  @spec encode_query_language_at(non_neg_integer(), non_neg_integer()) :: binary()
-  def encode_query_language_at(request_id, byte_offset)
-      when is_integer(request_id) and is_integer(byte_offset) do
-    <<@op_query_language_at, request_id::32, byte_offset::32>>
+  @doc "Encodes a query_language_at request: buffer_id(4) + request_id(4) + byte_offset(4)."
+  @spec encode_query_language_at(non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          binary()
+  def encode_query_language_at(buffer_id, request_id, byte_offset)
+      when is_integer(buffer_id) and buffer_id >= 0 and
+             is_integer(request_id) and is_integer(byte_offset) do
+    <<@op_query_language_at, buffer_id::32, request_id::32, byte_offset::32>>
+  end
+
+  @doc "Encodes a close_buffer command: buffer_id(4)."
+  @spec encode_close_buffer(non_neg_integer()) :: binary()
+  def encode_close_buffer(buffer_id)
+      when is_integer(buffer_id) and buffer_id >= 0 do
+    <<@op_close_buffer, buffer_id::32>>
   end
 
   # ── Decoding (Zig → BEAM) ──
@@ -580,16 +603,16 @@ defmodule Minga.Port.Protocol do
     {:ok, {:paste_event, text}}
   end
 
-  def decode_event(<<@op_highlight_spans, version::32, count::32, rest::binary>>) do
+  def decode_event(<<@op_highlight_spans, buffer_id::32, version::32, count::32, rest::binary>>) do
     case decode_spans(rest, count, []) do
-      {:ok, spans} -> {:ok, {:highlight_spans, version, spans}}
+      {:ok, spans} -> {:ok, {:highlight_spans, buffer_id, version, spans}}
       :error -> {:error, :malformed}
     end
   end
 
-  def decode_event(<<@op_highlight_names, count::16, rest::binary>>) do
+  def decode_event(<<@op_highlight_names, buffer_id::32, count::16, rest::binary>>) do
     case decode_names(rest, count, []) do
-      {:ok, names} -> {:ok, {:highlight_names, names}}
+      {:ok, names} -> {:ok, {:highlight_names, buffer_id, names}}
       :error -> {:error, :malformed}
     end
   end
@@ -604,17 +627,17 @@ defmodule Minga.Port.Protocol do
     {:ok, {:language_at_response, request_id, name}}
   end
 
-  def decode_event(<<@op_injection_ranges, count::16, rest::binary>>) do
-    {:ok, {:injection_ranges, decode_injection_ranges(rest, count, [])}}
+  def decode_event(<<@op_injection_ranges, buffer_id::32, count::16, rest::binary>>) do
+    {:ok, {:injection_ranges, buffer_id, decode_injection_ranges(rest, count, [])}}
   end
 
   def decode_event(<<@op_text_width, request_id::32, width::16>>) do
     {:ok, {:text_width, request_id, width}}
   end
 
-  def decode_event(<<@op_fold_ranges, version::32, count::32, rest::binary>>) do
+  def decode_event(<<@op_fold_ranges, buffer_id::32, version::32, count::32, rest::binary>>) do
     case decode_fold_ranges(rest, count, []) do
-      {:ok, ranges} -> {:ok, {:fold_ranges, version, ranges}}
+      {:ok, ranges} -> {:ok, {:fold_ranges, buffer_id, version, ranges}}
       :error -> {:error, :malformed}
     end
   end
@@ -634,9 +657,11 @@ defmodule Minga.Port.Protocol do
     {:ok, {:textobject_result, request_id, nil}}
   end
 
-  def decode_event(<<@op_textobject_positions, version::32, count::32, entries::binary>>) do
+  def decode_event(
+        <<@op_textobject_positions, buffer_id::32, version::32, count::32, entries::binary>>
+      ) do
     positions = decode_textobject_entries(entries, count, %{})
-    {:ok, {:textobject_positions, version, positions}}
+    {:ok, {:textobject_positions, buffer_id, version, positions}}
   end
 
   def decode_event(<<@op_log_message, level_byte::8, msg_len::16, msg::binary-size(msg_len)>>) do

--- a/lib/minga/text_object.ex
+++ b/lib/minga/text_object.ex
@@ -241,10 +241,10 @@ defmodule Minga.TextObject do
   Uses tree-sitter textobjects.scm queries. Returns `nil` if no text object
   of the requested type contains the cursor, or if tree-sitter is unavailable.
   """
-  @spec structural_inner(structural_type(), position()) :: range()
-  def structural_inner(type, {line, col}) when is_atom(type) do
+  @spec structural_inner(structural_type(), position(), non_neg_integer()) :: range()
+  def structural_inner(type, {line, col}, buffer_id) when is_atom(type) do
     capture = Atom.to_string(type) <> ".inside"
-    query_structural(line, col, capture)
+    query_structural(line, col, capture, buffer_id)
   end
 
   @doc """
@@ -252,15 +252,16 @@ defmodule Minga.TextObject do
 
   Includes the structural delimiters (e.g., `def...end`, braces, etc.).
   """
-  @spec structural_around(structural_type(), position()) :: range()
-  def structural_around(type, {line, col}) when is_atom(type) do
+  @spec structural_around(structural_type(), position(), non_neg_integer()) :: range()
+  def structural_around(type, {line, col}, buffer_id) when is_atom(type) do
     capture = Atom.to_string(type) <> ".around"
-    query_structural(line, col, capture)
+    query_structural(line, col, capture, buffer_id)
   end
 
-  @spec query_structural(non_neg_integer(), non_neg_integer(), String.t()) :: range()
-  defp query_structural(row, col, capture_name) do
-    case ParserManager.request_textobject(row, col, capture_name) do
+  @spec query_structural(non_neg_integer(), non_neg_integer(), String.t(), non_neg_integer()) ::
+          range()
+  defp query_structural(row, col, capture_name, buffer_id) do
+    case ParserManager.request_textobject(buffer_id, row, col, capture_name) do
       {start_row, start_col, end_row, end_col} ->
         # Zig returns byte columns. The end position from tree-sitter is
         # exclusive, so we subtract 1 to make it inclusive for Vim semantics.

--- a/lib/minga/tree_sitter.ex
+++ b/lib/minga/tree_sitter.ex
@@ -284,11 +284,12 @@ defmodule Minga.TreeSitter do
 
   @spec send_queries(String.t(), keyword()) :: :ok
   defp send_queries(name, opts) do
-    # Set the language first so queries are associated with it
-    ParserManager.set_language(name)
+    # Set the language first so queries are associated with it.
+    # Dynamic grammar loading uses buffer_id 0 (global/default).
+    ParserManager.set_language(0, name)
 
-    send_query(name, opts, :highlights, &ParserManager.set_highlight_query/1)
-    send_query(name, opts, :injections, &ParserManager.set_injection_query/1)
+    send_query(name, opts, :highlights, &ParserManager.set_highlight_query(0, &1))
+    send_query(name, opts, :injections, &ParserManager.set_injection_query(0, &1))
 
     :ok
   end

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -88,7 +88,8 @@ defmodule Minga.Config.OptionsTest do
                nav_flash: true,
                nav_flash_threshold: 5,
                log_level_config: :default,
-               log_level_port: :default
+               log_level_port: :default,
+               parser_tree_ttl: 300
              }
     end
   end

--- a/test/minga/editor/highlight_integration_test.exs
+++ b/test/minga/editor/highlight_integration_test.exs
@@ -31,14 +31,16 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       inject_highlights(ctx, ["keyword"], 1, spans)
 
       state = :sys.get_state(ctx.editor)
-      assert state.highlight.current.spans != {}, "Pre-condition: file1 should have spans"
+
+      assert HighlightSync.get_active_highlight(state).spans != {},
+             "Pre-condition: file1 should have spans"
 
       # Open second file via :e — triggers buffer switch
       send_keys(ctx, ":e #{path2}<CR>")
 
       state = :sys.get_state(ctx.editor)
 
-      assert state.highlight.current.spans == {},
+      assert HighlightSync.get_active_highlight(state).spans == {},
              "Stale spans from file1 persisted after :e to file2"
     end
 
@@ -59,14 +61,16 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       inject_highlights(ctx, ["keyword"], 1, spans)
 
       state = :sys.get_state(ctx.editor)
-      assert state.highlight.current.spans != {}, "Pre-condition: file2 should have spans"
+
+      assert HighlightSync.get_active_highlight(state).spans != {},
+             "Pre-condition: file2 should have spans"
 
       # Switch to previous buffer via SPC b n
       send_keys(ctx, "<Space>bn")
 
       state = :sys.get_state(ctx.editor)
 
-      assert state.highlight.current.spans == {},
+      assert HighlightSync.get_active_highlight(state).spans == {},
              "Stale spans from file2 persisted after SPC b n"
     end
   end
@@ -86,14 +90,14 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       inject_highlights(ctx, ["keyword"], 1, spans_a)
 
       state = :sys.get_state(ctx.editor)
-      assert state.highlight.current.spans == List.to_tuple(spans_a)
+      assert HighlightSync.get_active_highlight(state).spans == List.to_tuple(spans_a)
 
       # Open file2 via :e command (deterministic, no CWD dependency)
       send_keys(ctx, ":e #{path2}<CR>")
 
       state = :sys.get_state(ctx.editor)
 
-      assert state.highlight.current.spans == {},
+      assert HighlightSync.get_active_highlight(state).spans == {},
              "Stale spans from file1 persisted after :e to file2"
     end
 
@@ -118,10 +122,10 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       state = :sys.get_state(ctx.editor)
 
       # Verify cache was populated for file1
-      assert Map.has_key?(state.highlight.cache, buf1_pid),
+      assert Map.has_key?(state.highlight.highlights, buf1_pid),
              "Expected file1 highlights to be cached after buffer switch"
 
-      cached = state.highlight.cache[buf1_pid]
+      cached = state.highlight.highlights[buf1_pid]
       assert cached.spans == List.to_tuple(spans_a)
     end
   end
@@ -202,15 +206,16 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       # Switch to file2
       send_keys(ctx, ":e #{path2}<CR>")
 
-      assert :sys.get_state(ctx.editor).highlight.current.spans == {}
+      state2 = :sys.get_state(ctx.editor)
+      assert HighlightSync.get_active_highlight(state2).spans == {}
 
       # Switch back to file1 via :e (should already be in buffer list)
       send_keys(ctx, ":e #{path1}<CR>")
 
       state = :sys.get_state(ctx.editor)
 
-      assert state.highlight.current.spans == List.to_tuple(spans_a),
-             "Expected cached spans restored via :e, got: #{inspect(state.highlight.current.spans)}"
+      assert HighlightSync.get_active_highlight(state).spans == List.to_tuple(spans_a),
+             "Expected cached spans restored via :e, got: #{inspect(HighlightSync.get_active_highlight(state).spans)}"
     end
   end
 
@@ -230,21 +235,23 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       inject_highlights(ctx, ["keyword"], 1, spans_a)
 
       state = :sys.get_state(ctx.editor)
-      assert state.highlight.current.spans == List.to_tuple(spans_a)
+      assert HighlightSync.get_active_highlight(state).spans == List.to_tuple(spans_a)
 
       # Open file2 and switch to it
       send_keys(ctx, ":e #{path2}<CR>")
 
       state = :sys.get_state(ctx.editor)
-      assert state.highlight.current.spans == {}, "File2 should start with empty spans"
+
+      assert HighlightSync.get_active_highlight(state).spans == {},
+             "File2 should start with empty spans"
 
       # Switch back to file1 — should restore cached highlights instantly
       send_keys(ctx, "<Space>bn")
 
       state = :sys.get_state(ctx.editor)
 
-      assert state.highlight.current.spans == List.to_tuple(spans_a),
-             "Expected cached spans from file1 to be restored, got: #{inspect(state.highlight.current.spans)}"
+      assert HighlightSync.get_active_highlight(state).spans == List.to_tuple(spans_a),
+             "Expected cached spans from file1 to be restored, got: #{inspect(HighlightSync.get_active_highlight(state).spans)}"
     end
   end
 
@@ -264,8 +271,8 @@ defmodule Minga.Editor.HighlightIntegrationTest do
         )
 
       state = :sys.get_state(editor)
-      assert state.highlight.current.spans == {}
-      assert state.highlight.current.capture_names == []
+      assert HighlightSync.get_active_highlight(state).spans == {}
+      assert HighlightSync.get_active_highlight(state).capture_names == []
     end
   end
 
@@ -279,9 +286,14 @@ defmodule Minga.Editor.HighlightIntegrationTest do
           %{start_byte: 10, end_byte: 15, capture_id: 1}
         ])
 
-      assert state.highlight.current.capture_names == ["keyword", "string", "comment"]
-      assert tuple_size(state.highlight.current.spans) == 2
-      assert state.highlight.current.version == 1
+      assert HighlightSync.get_active_highlight(state).capture_names == [
+               "keyword",
+               "string",
+               "comment"
+             ]
+
+      assert tuple_size(HighlightSync.get_active_highlight(state).spans) == 2
+      assert HighlightSync.get_active_highlight(state).version == 1
     end
 
     test "receiving new names clears old names without affecting spans" do
@@ -291,8 +303,12 @@ defmodule Minga.Editor.HighlightIntegrationTest do
         |> HighlightSync.handle_spans(1, [%{start_byte: 0, end_byte: 5, capture_id: 0}])
         |> HighlightSync.handle_names(["new_keyword", "new_string"])
 
-      assert state.highlight.current.capture_names == ["new_keyword", "new_string"]
-      assert tuple_size(state.highlight.current.spans) == 1
+      assert HighlightSync.get_active_highlight(state).capture_names == [
+               "new_keyword",
+               "new_string"
+             ]
+
+      assert tuple_size(HighlightSync.get_active_highlight(state).spans) == 1
     end
   end
 
@@ -394,8 +410,8 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       assert_row_contains(ctx, 1, "just plain text")
 
       state = :sys.get_state(ctx.editor)
-      assert state.highlight.current.capture_names == []
-      assert state.highlight.current.spans == {}
+      assert HighlightSync.get_active_highlight(state).capture_names == []
+      assert HighlightSync.get_active_highlight(state).spans == {}
     end
 
     test "empty file renders without crash" do
@@ -403,7 +419,7 @@ defmodule Minga.Editor.HighlightIntegrationTest do
 
       # Should show empty first line and tildes
       state = :sys.get_state(ctx.editor)
-      assert state.highlight.current.spans == {}
+      assert HighlightSync.get_active_highlight(state).spans == {}
     end
 
     test "file with syntax errors still renders partial highlights" do
@@ -465,10 +481,13 @@ defmodule Minga.Editor.HighlightIntegrationTest do
   # ── Helpers ──
 
   defp base_state do
+    pid = spawn(fn -> Process.sleep(:infinity) end)
+
     %EditorState{
       port_manager: nil,
       viewport: Viewport.new(24, 80),
       vim: VimState.new()
     }
+    |> then(fn s -> %{s | buffers: %{s.buffers | active: pid}} end)
   end
 end

--- a/test/minga/editor/highlight_sync_eviction_test.exs
+++ b/test/minga/editor/highlight_sync_eviction_test.exs
@@ -1,0 +1,219 @@
+defmodule Minga.Editor.HighlightSyncEvictionTest do
+  @moduledoc """
+  Tests for LRU eviction of inactive parser buffer trees.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.HighlightSync
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.Viewport
+  alias Minga.Editor.VimState
+
+  # Build a minimal state with buffer_ids and last_active_at set up.
+  defp base_state do
+    %EditorState{
+      port_manager: nil,
+      viewport: Viewport.new(24, 80),
+      vim: VimState.new()
+    }
+  end
+
+  defp with_buffer_tracking(state, pid, buffer_id, last_active_ms_ago) do
+    hl = state.highlight
+    now = System.monotonic_time(:millisecond)
+
+    %{
+      state
+      | highlight: %{
+          hl
+          | buffer_ids: Map.put(hl.buffer_ids, pid, buffer_id),
+            reverse_buffer_ids: Map.put(hl.reverse_buffer_ids, buffer_id, pid),
+            last_active_at: Map.put(hl.last_active_at, pid, now - last_active_ms_ago),
+            next_buffer_id: max(hl.next_buffer_id, buffer_id + 1)
+        }
+    }
+  end
+
+  describe "evict_inactive/2" do
+    test "does not evict recently active buffers" do
+      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+      state = base_state() |> with_buffer_tracking(pid1, 1, 1_000)
+
+      new_state = HighlightSync.evict_inactive(state)
+
+      assert Map.has_key?(new_state.highlight.buffer_ids, pid1)
+      assert Map.has_key?(new_state.highlight.reverse_buffer_ids, 1)
+      assert Map.has_key?(new_state.highlight.last_active_at, pid1)
+    end
+
+    test "evicts buffers inactive longer than TTL" do
+      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+      # 10 minutes ago (well past the 5-minute default TTL)
+      state = base_state() |> with_buffer_tracking(pid1, 1, 10 * 60 * 1_000)
+
+      new_state = HighlightSync.evict_inactive(state)
+
+      refute Map.has_key?(new_state.highlight.buffer_ids, pid1)
+      refute Map.has_key?(new_state.highlight.reverse_buffer_ids, 1)
+      refute Map.has_key?(new_state.highlight.last_active_at, pid1)
+    end
+
+    test "does not evict the active buffer even if stale" do
+      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+
+      state =
+        base_state()
+        |> with_buffer_tracking(pid1, 1, 10 * 60 * 1_000)
+        |> then(fn s -> %{s | buffers: %{s.buffers | active: pid1}} end)
+
+      new_state = HighlightSync.evict_inactive(state)
+
+      # Active buffer is protected
+      assert Map.has_key?(new_state.highlight.buffer_ids, pid1)
+    end
+
+    test "does not evict protected PIDs" do
+      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+      state = base_state() |> with_buffer_tracking(pid1, 1, 10 * 60 * 1_000)
+
+      new_state = HighlightSync.evict_inactive(state, protected_pids: [pid1])
+
+      assert Map.has_key?(new_state.highlight.buffer_ids, pid1)
+    end
+
+    test "evicts only stale buffers, keeps fresh ones" do
+      pid_fresh = spawn(fn -> Process.sleep(:infinity) end)
+      pid_stale = spawn(fn -> Process.sleep(:infinity) end)
+
+      state =
+        base_state()
+        |> with_buffer_tracking(pid_fresh, 1, 1_000)
+        |> with_buffer_tracking(pid_stale, 2, 10 * 60 * 1_000)
+
+      new_state = HighlightSync.evict_inactive(state)
+
+      assert Map.has_key?(new_state.highlight.buffer_ids, pid_fresh)
+      refute Map.has_key?(new_state.highlight.buffer_ids, pid_stale)
+    end
+
+    test "returns state unchanged when no buffers are tracked" do
+      state = base_state()
+      assert HighlightSync.evict_inactive(state) == state
+    end
+
+    test "clears highlight cache for evicted buffers" do
+      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+
+      state =
+        base_state()
+        |> with_buffer_tracking(pid1, 1, 10 * 60 * 1_000)
+
+      hl = state.highlight
+
+      state = %{
+        state
+        | highlight: %{hl | highlights: Map.put(hl.highlights, pid1, Minga.Highlight.new())}
+      }
+
+      new_state = HighlightSync.evict_inactive(state)
+
+      refute Map.has_key?(new_state.highlight.highlights, pid1)
+    end
+  end
+
+  describe "touch_active/1" do
+    test "sets last_active_at for the active buffer" do
+      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+
+      state =
+        base_state()
+        |> then(fn s -> %{s | buffers: %{s.buffers | active: pid1}} end)
+
+      new_state = HighlightSync.touch_active(state)
+
+      assert Map.has_key?(new_state.highlight.last_active_at, pid1)
+      ts = new_state.highlight.last_active_at[pid1]
+      now = System.monotonic_time(:millisecond)
+      assert abs(now - ts) < 100
+    end
+
+    test "returns state unchanged when no active buffer" do
+      state = base_state()
+      assert HighlightSync.touch_active(state) == state
+    end
+  end
+
+  describe "ensure_buffer_id/1" do
+    test "assigns a new buffer_id on first call" do
+      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+
+      state =
+        base_state()
+        |> then(fn s -> %{s | buffers: %{s.buffers | active: pid1}} end)
+
+      {id, new_state} = HighlightSync.ensure_buffer_id(state)
+
+      assert id == 1
+      assert new_state.highlight.buffer_ids[pid1] == 1
+      assert new_state.highlight.next_buffer_id == 2
+    end
+
+    test "returns existing buffer_id on subsequent calls" do
+      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+
+      state =
+        base_state()
+        |> then(fn s -> %{s | buffers: %{s.buffers | active: pid1}} end)
+
+      {id1, state} = HighlightSync.ensure_buffer_id(state)
+      {id2, _state} = HighlightSync.ensure_buffer_id(state)
+
+      assert id1 == id2
+    end
+
+    test "assigns monotonically incrementing IDs for different buffers" do
+      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+      pid2 = spawn(fn -> Process.sleep(:infinity) end)
+
+      state =
+        base_state()
+        |> then(fn s -> %{s | buffers: %{s.buffers | active: pid1}} end)
+
+      {id1, state} = HighlightSync.ensure_buffer_id(state)
+      state = %{state | buffers: %{state.buffers | active: pid2}}
+      {id2, _state} = HighlightSync.ensure_buffer_id(state)
+
+      assert id2 == id1 + 1
+    end
+  end
+
+  describe "close_buffer/2" do
+    test "removes buffer_id mapping and cache" do
+      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+
+      state =
+        base_state()
+        |> with_buffer_tracking(pid1, 1, 1_000)
+
+      hl = state.highlight
+
+      state = %{
+        state
+        | highlight: %{hl | highlights: Map.put(hl.highlights, pid1, Minga.Highlight.new())}
+      }
+
+      new_state = HighlightSync.close_buffer(state, pid1)
+
+      refute Map.has_key?(new_state.highlight.buffer_ids, pid1)
+      refute Map.has_key?(new_state.highlight.highlights, pid1)
+    end
+
+    test "no-op for unknown buffer PID" do
+      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+      state = base_state()
+
+      new_state = HighlightSync.close_buffer(state, pid1)
+      assert new_state == state
+    end
+  end
+end

--- a/test/minga/editor/highlight_sync_test.exs
+++ b/test/minga/editor/highlight_sync_test.exs
@@ -6,14 +6,20 @@ defmodule Minga.Editor.HighlightSyncTest do
   alias Minga.Editor.Viewport
   alias Minga.Editor.VimState
 
-  # Minimal state for testing — no real port or buffer needed for
-  # handle_names and handle_spans.
+  # Minimal state for testing with a fake active buffer PID.
   defp base_state do
+    pid = spawn(fn -> Process.sleep(:infinity) end)
+
     %EditorState{
       port_manager: nil,
       viewport: Viewport.new(24, 80),
       vim: VimState.new()
     }
+    |> then(fn s -> %{s | buffers: %{s.buffers | active: pid}} end)
+  end
+
+  defp get_hl(state) do
+    HighlightSync.get_active_highlight(state)
   end
 
   describe "handle_names/2" do
@@ -22,7 +28,7 @@ defmodule Minga.Editor.HighlightSyncTest do
       names = ["keyword", "string", "comment"]
       new_state = HighlightSync.handle_names(state, names)
 
-      assert new_state.highlight.current.capture_names == names
+      assert get_hl(new_state).capture_names == names
     end
 
     test "replaces previous capture names" do
@@ -31,7 +37,7 @@ defmodule Minga.Editor.HighlightSyncTest do
         |> HighlightSync.handle_names(["old"])
         |> HighlightSync.handle_names(["new1", "new2"])
 
-      assert state.highlight.current.capture_names == ["new1", "new2"]
+      assert get_hl(state).capture_names == ["new1", "new2"]
     end
   end
 
@@ -46,8 +52,8 @@ defmodule Minga.Editor.HighlightSyncTest do
         base_state()
         |> HighlightSync.handle_spans(1, spans)
 
-      assert state.highlight.current.version == 1
-      assert state.highlight.current.spans == List.to_tuple(spans)
+      assert get_hl(state).version == 1
+      assert get_hl(state).spans == List.to_tuple(spans)
     end
 
     test "rejects stale spans with older version" do
@@ -59,8 +65,8 @@ defmodule Minga.Editor.HighlightSyncTest do
         |> HighlightSync.handle_spans(5, spans1)
         |> HighlightSync.handle_spans(3, spans2)
 
-      assert state.highlight.current.version == 5
-      assert state.highlight.current.spans == List.to_tuple(spans1)
+      assert get_hl(state).version == 5
+      assert get_hl(state).spans == List.to_tuple(spans1)
     end
 
     test "accepts spans with equal version" do
@@ -72,26 +78,36 @@ defmodule Minga.Editor.HighlightSyncTest do
         |> HighlightSync.handle_spans(5, spans1)
         |> HighlightSync.handle_spans(5, spans2)
 
-      assert state.highlight.current.spans == List.to_tuple(spans2)
+      assert get_hl(state).spans == List.to_tuple(spans2)
     end
   end
 
   describe "setup_for_buffer/1" do
     test "returns state unchanged when no buffer" do
-      state = base_state()
+      state = %EditorState{
+        port_manager: nil,
+        viewport: Viewport.new(24, 80),
+        vim: VimState.new()
+      }
+
       assert HighlightSync.setup_for_buffer(state) == state
     end
   end
 
   describe "request_reparse/1" do
     test "returns state unchanged when no buffer" do
-      state = base_state()
+      state = %EditorState{
+        port_manager: nil,
+        viewport: Viewport.new(24, 80),
+        vim: VimState.new()
+      }
+
       assert HighlightSync.request_reparse(state) == state
     end
 
     test "returns state unchanged when no highlighting active" do
       state = base_state()
-      assert state.highlight.current.capture_names == []
+      assert get_hl(state).capture_names == []
       assert HighlightSync.request_reparse(state) == state
     end
   end

--- a/test/minga/editor/user_query_override_test.exs
+++ b/test/minga/editor/user_query_override_test.exs
@@ -8,6 +8,7 @@ defmodule Minga.Editor.UserQueryOverrideTest do
 
   use Minga.Test.EditorCase, async: true
 
+  alias Minga.Editor.HighlightSync
   alias Minga.Highlight.Grammar
 
   alias Minga.Command.Parser
@@ -38,7 +39,7 @@ defmodule Minga.Editor.UserQueryOverrideTest do
       )
 
       state = :sys.get_state(ctx.editor)
-      assert state.highlight.current.spans != []
+      assert HighlightSync.get_active_highlight(state).spans != []
 
       version_before = state.highlight.version
 
@@ -49,7 +50,7 @@ defmodule Minga.Editor.UserQueryOverrideTest do
 
       # Highlight state should be reset (new Highlight struct with empty spans)
       # and a new parse should be in-flight (version incremented)
-      assert state.highlight.current.spans == {}
+      assert HighlightSync.get_active_highlight(state).spans == {}
       assert state.highlight.version > version_before
     end
 
@@ -71,7 +72,7 @@ defmodule Minga.Editor.UserQueryOverrideTest do
       send_keys(ctx, ":rh<CR>")
 
       state = :sys.get_state(ctx.editor)
-      assert state.highlight.current.spans == {}
+      assert HighlightSync.get_active_highlight(state).spans == {}
       assert state.highlight.version > version_before
     end
   end

--- a/test/minga/parser/bandwidth_test.exs
+++ b/test/minga/parser/bandwidth_test.exs
@@ -19,7 +19,7 @@ defmodule Minga.Parser.BandwidthTest do
       assert byte_size(large_content) > 50_000
 
       # Full sync: encode the entire content
-      full_sync = Protocol.encode_parse_buffer(1, large_content)
+      full_sync = Protocol.encode_parse_buffer(0, 1, large_content)
       full_size = byte_size(full_sync)
 
       # Incremental sync: single character insertion
@@ -33,7 +33,7 @@ defmodule Minga.Parser.BandwidthTest do
         inserted_text: "x"
       }
 
-      incremental_sync = Protocol.encode_edit_buffer(1, [edit])
+      incremental_sync = Protocol.encode_edit_buffer(0, 1, [edit])
       incremental_size = byte_size(incremental_sync)
 
       # Full sync should be ~50KB, incremental should be ~50 bytes
@@ -51,7 +51,7 @@ defmodule Minga.Parser.BandwidthTest do
     test "edit_buffer is small for multi-character paste" do
       large_content = String.duplicate("line of code\n", 5000)
 
-      full_sync = Protocol.encode_parse_buffer(1, large_content)
+      full_sync = Protocol.encode_parse_buffer(0, 1, large_content)
       full_size = byte_size(full_sync)
 
       # Paste 100 characters
@@ -67,7 +67,7 @@ defmodule Minga.Parser.BandwidthTest do
         inserted_text: pasted
       }
 
-      incremental_sync = Protocol.encode_edit_buffer(1, [edit])
+      incremental_sync = Protocol.encode_edit_buffer(0, 1, [edit])
       incremental_size = byte_size(incremental_sync)
 
       # Even a 100-char paste should be << full file
@@ -86,7 +86,7 @@ defmodule Minga.Parser.BandwidthTest do
         inserted_text: ""
       }
 
-      deletion_sync = Protocol.encode_edit_buffer(1, [edit])
+      deletion_sync = Protocol.encode_edit_buffer(0, 1, [edit])
       # Deletion: no inserted text, just metadata
       assert byte_size(deletion_sync) < 60
     end

--- a/test/minga/parser/incremental_test.exs
+++ b/test/minga/parser/incremental_test.exs
@@ -27,18 +27,24 @@ defmodule Minga.Parser.IncrementalTest do
 
   # ── Helpers ──────────────────────────────────────────────────────────────────
 
+  # All tests use buffer_id 0 for simplicity.
+  @buffer_id 0
+
   defp setup_elixir(parser) do
-    ParserManager.send_commands(parser, [Protocol.encode_set_language("elixir")])
+    ParserManager.send_commands(parser, [Protocol.encode_set_language(@buffer_id, "elixir")])
     Process.sleep(20)
   end
 
   defp full_parse(parser, version, content) do
-    ParserManager.send_commands(parser, [Protocol.encode_parse_buffer(version, content)])
+    ParserManager.send_commands(parser, [
+      Protocol.encode_parse_buffer(@buffer_id, version, content)
+    ])
+
     receive_spans(version)
   end
 
   defp incremental_parse(parser, version, edits) do
-    ParserManager.send_commands(parser, [Protocol.encode_edit_buffer(version, edits)])
+    ParserManager.send_commands(parser, [Protocol.encode_edit_buffer(@buffer_id, version, edits)])
     receive_spans(version)
   end
 
@@ -48,13 +54,13 @@ defmodule Minga.Parser.IncrementalTest do
 
   defp receive_spans_loop(version, timeout) do
     receive do
-      {:minga_highlight, {:highlight_spans, ^version, spans}} ->
+      {:minga_highlight, {:highlight_spans, _buffer_id, ^version, spans}} ->
         spans
 
-      {:minga_highlight, {:highlight_names, _names}} ->
+      {:minga_highlight, {:highlight_names, _buffer_id, _names}} ->
         receive_spans_loop(version, timeout)
 
-      {:minga_highlight, {:highlight_spans, _other_version, _spans}} ->
+      {:minga_highlight, {:highlight_spans, _buffer_id, _other_version, _spans}} ->
         receive_spans_loop(version, timeout)
 
       {:minga_highlight, _other} ->

--- a/test/minga/parser/multi_buffer_test.exs
+++ b/test/minga/parser/multi_buffer_test.exs
@@ -1,0 +1,158 @@
+defmodule Minga.Parser.MultiBufferTest do
+  @moduledoc """
+  Integration tests verifying that the parser can handle multiple buffers
+  with different languages simultaneously. Each buffer maintains independent
+  parse trees, source mirrors, and highlight spans.
+
+  These tests start a real minga-parser process and send protocol commands
+  with distinct buffer IDs.
+  """
+  use ExUnit.Case, async: false
+
+  alias Minga.Parser.Manager, as: ParserManager
+  alias Minga.Port.Protocol
+
+  @moduletag :parser_integration
+  @parser_path Path.join([File.cwd!(), "priv", "minga-parser"])
+
+  setup do
+    name = :"parser_multi_#{:erlang.unique_integer([:positive])}"
+    {:ok, pid} = ParserManager.start_link(name: name, parser_path: @parser_path)
+    ParserManager.subscribe(pid)
+    Process.sleep(50)
+    {:ok, parser: pid}
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────────────────
+
+  defp setup_buffer(parser, buffer_id, language, version, content) do
+    ParserManager.send_commands(parser, [
+      Protocol.encode_set_language(buffer_id, language),
+      Protocol.encode_parse_buffer(buffer_id, version, content)
+    ])
+
+    receive_spans(buffer_id, version)
+  end
+
+  defp incremental_edit(parser, buffer_id, version, edits) do
+    ParserManager.send_commands(parser, [
+      Protocol.encode_edit_buffer(buffer_id, version, edits)
+    ])
+
+    receive_spans(buffer_id, version)
+  end
+
+  defp receive_spans(expected_buffer_id, expected_version) do
+    receive_spans_loop(expected_buffer_id, expected_version, 3000)
+  end
+
+  defp receive_spans_loop(buffer_id, version, timeout) do
+    receive do
+      {:minga_highlight, {:highlight_spans, ^buffer_id, ^version, spans}} ->
+        spans
+
+      {:minga_highlight, {:highlight_names, ^buffer_id, _names}} ->
+        receive_spans_loop(buffer_id, version, timeout)
+
+      {:minga_highlight, {:highlight_spans, _other_bid, _other_ver, _spans}} ->
+        receive_spans_loop(buffer_id, version, timeout)
+
+      {:minga_highlight, _other} ->
+        receive_spans_loop(buffer_id, version, timeout)
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  defp make_edit(
+         start_byte,
+         old_end_byte,
+         new_end_byte,
+         start_pos,
+         old_end_pos,
+         new_end_pos,
+         text
+       ) do
+    %{
+      start_byte: start_byte,
+      old_end_byte: old_end_byte,
+      new_end_byte: new_end_byte,
+      start_position: start_pos,
+      old_end_position: old_end_pos,
+      new_end_position: new_end_pos,
+      inserted_text: text
+    }
+  end
+
+  # ── Tests ────────────────────────────────────────────────────────────────────
+
+  describe "multiple buffers with different languages" do
+    @tag timeout: 30_000
+    test "two buffers with different languages produce independent highlights", ctx do
+      parser = ctx.parser
+
+      elixir_source = "defmodule Foo do\n  def bar, do: :ok\nend\n"
+      json_source = ~s({"key": "value", "num": 42}\n)
+
+      # Parse buffer 1 as Elixir
+      spans_elixir = setup_buffer(parser, 1, "elixir", 1, elixir_source)
+      assert is_list(spans_elixir), "Expected Elixir spans, got: #{inspect(spans_elixir)}"
+      assert spans_elixir != [], "Elixir source should produce highlight spans"
+
+      # Parse buffer 2 as JSON
+      spans_json = setup_buffer(parser, 2, "json", 1, json_source)
+      assert is_list(spans_json), "Expected JSON spans, got: #{inspect(spans_json)}"
+      assert spans_json != [], "JSON source should produce highlight spans"
+
+      # Spans should be different (different languages, different source)
+      refute spans_elixir == spans_json,
+             "Elixir and JSON spans should differ"
+    end
+
+    @tag timeout: 30_000
+    test "incremental edit on buffer A does not affect buffer B's spans", ctx do
+      parser = ctx.parser
+
+      elixir_source = "defmodule Foo do\n  def bar, do: :ok\nend\n"
+      json_source = ~s({"key": "value"}\n)
+
+      # Parse both buffers
+      _spans_elixir_v1 = setup_buffer(parser, 1, "elixir", 1, elixir_source)
+      spans_json_v1 = setup_buffer(parser, 2, "json", 1, json_source)
+
+      # Edit buffer 1 (Elixir): insert "!" after :ok
+      insert_pos = byte_size("defmodule Foo do\n  def bar, do: :ok")
+      edit = make_edit(insert_pos, insert_pos, insert_pos + 1, {1, 20}, {1, 20}, {1, 21}, "!")
+
+      _spans_elixir_v2 = incremental_edit(parser, 1, 2, [edit])
+
+      # Re-parse buffer 2 to get its current spans (should be unchanged)
+      spans_json_v2 = setup_buffer(parser, 2, "json", 2, json_source)
+
+      assert spans_json_v1 == spans_json_v2,
+             "JSON buffer spans changed after editing Elixir buffer"
+    end
+
+    @tag timeout: 30_000
+    test "close_buffer frees resources without affecting other buffers", ctx do
+      parser = ctx.parser
+
+      elixir_source = "defmodule A do\nend\n"
+      json_source = ~s({"a": 1}\n)
+
+      # Parse two buffers
+      _spans1 = setup_buffer(parser, 1, "elixir", 1, elixir_source)
+      spans2_v1 = setup_buffer(parser, 2, "json", 1, json_source)
+
+      # Close buffer 1
+      ParserManager.send_commands(parser, [Protocol.encode_close_buffer(1)])
+      Process.sleep(50)
+
+      # Buffer 2 should still work fine
+      spans2_v2 = setup_buffer(parser, 2, "json", 2, json_source)
+
+      assert spans2_v1 == spans2_v2,
+             "Buffer 2 spans changed after closing buffer 1"
+    end
+  end
+end

--- a/test/minga/port/protocol_test.exs
+++ b/test/minga/port/protocol_test.exs
@@ -480,30 +480,30 @@ defmodule Minga.Port.ProtocolTest do
 
   describe "highlight protocol" do
     test "encode_set_language produces correct binary" do
-      encoded = Protocol.encode_set_language("elixir")
-      assert <<0x20, 6::16, rest::binary>> = encoded
+      encoded = Protocol.encode_set_language(7, "elixir")
+      assert <<0x20, 7::32, 6::16, rest::binary>> = encoded
       assert rest == "elixir"
     end
 
     test "encode_parse_buffer produces correct binary" do
-      encoded = Protocol.encode_parse_buffer(42, "hello")
-      assert <<0x21, 42::32, 5::32, rest::binary>> = encoded
+      encoded = Protocol.encode_parse_buffer(3, 42, "hello")
+      assert <<0x21, 3::32, 42::32, 5::32, rest::binary>> = encoded
       assert rest == "hello"
     end
 
     test "encode_set_highlight_query produces correct binary" do
       query = "(atom) @string"
-      encoded = Protocol.encode_set_highlight_query(query)
+      encoded = Protocol.encode_set_highlight_query(1, query)
       qlen = byte_size(query)
-      assert <<0x22, ^qlen::32, rest::binary>> = encoded
+      assert <<0x22, 1::32, ^qlen::32, rest::binary>> = encoded
       assert rest == query
     end
 
     test "encode_set_injection_query produces correct binary" do
       query = "(content) @injection.content"
-      encoded = Protocol.encode_set_injection_query(query)
+      encoded = Protocol.encode_set_injection_query(2, query)
       qlen = byte_size(query)
-      assert <<0x24, ^qlen::32, rest::binary>> = encoded
+      assert <<0x24, 2::32, ^qlen::32, rest::binary>> = encoded
       assert rest == query
     end
 
@@ -513,23 +513,31 @@ defmodule Minga.Port.ProtocolTest do
       assert rest == "/tmp/lua.so"
     end
 
+    test "encode_close_buffer produces correct binary" do
+      encoded = Protocol.encode_close_buffer(42)
+      assert <<0x2D, 42::32>> = encoded
+    end
+
     test "decode_event highlight_spans" do
       spans_binary =
         <<0::32, 9::32, 0::16>> <>
           <<10::32, 15::32, 1::16>>
 
-      payload = <<0x30, 42::32, 2::32>> <> spans_binary
+      # buffer_id=5, version=42, count=2
+      payload = <<0x30, 5::32, 42::32, 2::32>> <> spans_binary
 
-      assert {:ok, {:highlight_spans, 42, spans}} = Protocol.decode_event(payload)
+      assert {:ok, {:highlight_spans, 5, 42, spans}} = Protocol.decode_event(payload)
       assert length(spans) == 2
       assert hd(spans) == %{start_byte: 0, end_byte: 9, capture_id: 0}
       assert List.last(spans) == %{start_byte: 10, end_byte: 15, capture_id: 1}
     end
 
     test "decode_event highlight_names" do
-      payload = <<0x31, 2::16, 7::16, "keyword", 6::16, "string">>
+      # buffer_id=3, count=2
+      payload = <<0x31, 3::32, 2::16, 7::16, "keyword", 6::16, "string">>
 
-      assert {:ok, {:highlight_names, ["keyword", "string"]}} = Protocol.decode_event(payload)
+      assert {:ok, {:highlight_names, 3, ["keyword", "string"]}} =
+               Protocol.decode_event(payload)
     end
 
     test "decode_event grammar_loaded success" do
@@ -543,18 +551,20 @@ defmodule Minga.Port.ProtocolTest do
     end
 
     test "decode_event highlight_spans with zero spans" do
-      payload = <<0x30, 1::32, 0::32>>
-      assert {:ok, {:highlight_spans, 1, []}} = Protocol.decode_event(payload)
+      # buffer_id=0, version=1, count=0
+      payload = <<0x30, 0::32, 1::32, 0::32>>
+      assert {:ok, {:highlight_spans, 0, 1, []}} = Protocol.decode_event(payload)
     end
 
     test "decode_event highlight_names with zero names" do
-      payload = <<0x31, 0::16>>
-      assert {:ok, {:highlight_names, []}} = Protocol.decode_event(payload)
+      # buffer_id=0, count=0
+      payload = <<0x31, 0::32, 0::16>>
+      assert {:ok, {:highlight_names, 0, []}} = Protocol.decode_event(payload)
     end
 
     test "decode_event malformed highlight_spans" do
-      # Count says 2 spans but only 1 provided
-      payload = <<0x30, 1::32, 2::32, 0::32, 9::32, 0::16>>
+      # buffer_id=0, version=1, count says 2 spans but only 1 provided
+      payload = <<0x30, 0::32, 1::32, 2::32, 0::32, 9::32, 0::16>>
       assert {:error, :malformed} = Protocol.decode_event(payload)
     end
   end
@@ -611,10 +621,10 @@ defmodule Minga.Port.ProtocolTest do
         }
       ]
 
-      result = Protocol.encode_edit_buffer(1, edits)
+      result = Protocol.encode_edit_buffer(5, 1, edits)
 
-      assert <<0x26, 1::32, 1::16, 10::32, 10::32, 11::32, 2::32, 5::32, 2::32, 5::32, 2::32,
-               6::32, 1::32, "x">> = result
+      assert <<0x26, 5::32, 1::32, 1::16, 10::32, 10::32, 11::32, 2::32, 5::32, 2::32, 5::32,
+               2::32, 6::32, 1::32, "x">> = result
     end
 
     test "encode_edit_buffer with multiple edits" do
@@ -639,13 +649,13 @@ defmodule Minga.Port.ProtocolTest do
         }
       ]
 
-      result = Protocol.encode_edit_buffer(42, edits)
-      assert <<0x26, 42::32, 2::16, _rest::binary>> = result
+      result = Protocol.encode_edit_buffer(0, 42, edits)
+      assert <<0x26, 0::32, 42::32, 2::16, _rest::binary>> = result
     end
 
     test "encode_edit_buffer with empty edits list" do
-      result = Protocol.encode_edit_buffer(1, [])
-      assert <<0x26, 1::32, 0::16>> = result
+      result = Protocol.encode_edit_buffer(0, 1, [])
+      assert <<0x26, 0::32, 1::32, 0::16>> = result
     end
   end
 

--- a/test/minga/port/protocol_textobject_positions_test.exs
+++ b/test/minga/port/protocol_textobject_positions_test.exs
@@ -22,17 +22,18 @@ defmodule Minga.Port.ProtocolTextobjectPositionsTest do
 
   describe "decode_event/1 — textobject_positions (0x39)" do
     test "decodes empty positions" do
-      payload = <<@op_textobject_positions, 1::32, 0::32>>
+      # buffer_id=0, version=1, count=0
+      payload = <<@op_textobject_positions, 0::32, 1::32, 0::32>>
 
-      assert {:ok, {:textobject_positions, 1, positions}} = Protocol.decode_event(payload)
+      assert {:ok, {:textobject_positions, 0, 1, positions}} = Protocol.decode_event(payload)
       assert positions == %{}
     end
 
     test "decodes single function entry" do
       entry = encode_entry(@textobj_function, 5, 0)
-      payload = <<@op_textobject_positions, 42::32, 1::32, entry::binary>>
+      payload = <<@op_textobject_positions, 3::32, 42::32, 1::32, entry::binary>>
 
-      assert {:ok, {:textobject_positions, 42, positions}} = Protocol.decode_event(payload)
+      assert {:ok, {:textobject_positions, 3, 42, positions}} = Protocol.decode_event(payload)
       assert positions == %{function: [{5, 0}]}
     end
 
@@ -42,9 +43,9 @@ defmodule Minga.Port.ProtocolTextobjectPositionsTest do
           encode_entry(@textobj_function, 5, 0) <>
           encode_entry(@textobj_function, 10, 4)
 
-      payload = <<@op_textobject_positions, 1::32, 3::32, entries::binary>>
+      payload = <<@op_textobject_positions, 0::32, 1::32, 3::32, entries::binary>>
 
-      assert {:ok, {:textobject_positions, 1, positions}} = Protocol.decode_event(payload)
+      assert {:ok, {:textobject_positions, 0, 1, positions}} = Protocol.decode_event(payload)
       assert positions == %{function: [{0, 0}, {5, 0}, {10, 4}]}
     end
 
@@ -54,9 +55,9 @@ defmodule Minga.Port.ProtocolTextobjectPositionsTest do
           encode_entry(@textobj_class, 5, 2) <>
           encode_entry(@textobj_parameter, 3, 10)
 
-      payload = <<@op_textobject_positions, 7::32, 3::32, entries::binary>>
+      payload = <<@op_textobject_positions, 2::32, 7::32, 3::32, entries::binary>>
 
-      assert {:ok, {:textobject_positions, 7, positions}} = Protocol.decode_event(payload)
+      assert {:ok, {:textobject_positions, 2, 7, positions}} = Protocol.decode_event(payload)
       assert positions == %{function: [{1, 0}], class: [{5, 2}], parameter: [{3, 10}]}
     end
 
@@ -69,9 +70,9 @@ defmodule Minga.Port.ProtocolTextobjectPositionsTest do
           encode_entry(@textobj_comment, 4, 0) <>
           encode_entry(@textobj_test, 5, 0)
 
-      payload = <<@op_textobject_positions, 1::32, 6::32, entries::binary>>
+      payload = <<@op_textobject_positions, 0::32, 1::32, 6::32, entries::binary>>
 
-      assert {:ok, {:textobject_positions, 1, positions}} = Protocol.decode_event(payload)
+      assert {:ok, {:textobject_positions, 0, 1, positions}} = Protocol.decode_event(payload)
       assert Map.has_key?(positions, :function)
       assert Map.has_key?(positions, :class)
       assert Map.has_key?(positions, :parameter)
@@ -82,9 +83,9 @@ defmodule Minga.Port.ProtocolTextobjectPositionsTest do
 
     test "unknown type ID decodes as :unknown" do
       entry = encode_entry(255, 0, 0)
-      payload = <<@op_textobject_positions, 1::32, 1::32, entry::binary>>
+      payload = <<@op_textobject_positions, 0::32, 1::32, 1::32, entry::binary>>
 
-      assert {:ok, {:textobject_positions, 1, positions}} = Protocol.decode_event(payload)
+      assert {:ok, {:textobject_positions, 0, 1, positions}} = Protocol.decode_event(payload)
       assert Map.has_key?(positions, :unknown)
     end
 
@@ -95,16 +96,16 @@ defmodule Minga.Port.ProtocolTextobjectPositionsTest do
           encode_entry(@textobj_function, 3, 0) <>
           encode_entry(@textobj_function, 10, 2)
 
-      payload = <<@op_textobject_positions, 1::32, 4::32, entries::binary>>
+      payload = <<@op_textobject_positions, 0::32, 1::32, 4::32, entries::binary>>
 
-      assert {:ok, {:textobject_positions, 1, positions}} = Protocol.decode_event(payload)
+      assert {:ok, {:textobject_positions, 0, 1, positions}} = Protocol.decode_event(payload)
       assert positions[:function] == [{0, 5}, {0, 15}, {3, 0}, {10, 2}]
     end
 
-    test "version counter is preserved" do
-      payload = <<@op_textobject_positions, 999::32, 0::32>>
+    test "buffer_id and version are preserved" do
+      payload = <<@op_textobject_positions, 7::32, 999::32, 0::32>>
 
-      assert {:ok, {:textobject_positions, 999, _positions}} = Protocol.decode_event(payload)
+      assert {:ok, {:textobject_positions, 7, 999, _positions}} = Protocol.decode_event(payload)
     end
   end
 end

--- a/test/minga/text_object/structural_test.exs
+++ b/test/minga/text_object/structural_test.exs
@@ -3,41 +3,40 @@ defmodule Minga.TextObject.StructuralTest do
 
   alias Minga.TextObject
 
-  describe "structural_inner/2" do
+  # All tests use buffer_id 0 since no real parser is running.
+  @buffer_id 0
+
+  describe "structural_inner/3" do
     test "returns nil when parser is not running" do
       # Without a live parser process, the request times out and returns nil.
       # This tests the graceful fallback path.
-      assert TextObject.structural_inner(:function, {5, 10}) == nil
+      assert TextObject.structural_inner(:function, {5, 10}, @buffer_id) == nil
     end
 
     test "returns nil for unknown structural type" do
-      assert TextObject.structural_inner(:nonexistent, {0, 0}) == nil
+      assert TextObject.structural_inner(:nonexistent, {0, 0}, @buffer_id) == nil
     end
   end
 
-  describe "structural_around/2" do
+  describe "structural_around/3" do
     test "returns nil when parser is not running" do
-      assert TextObject.structural_around(:function, {5, 10}) == nil
+      assert TextObject.structural_around(:function, {5, 10}, @buffer_id) == nil
     end
 
     test "returns nil for unknown structural type" do
-      assert TextObject.structural_around(:nonexistent, {0, 0}) == nil
+      assert TextObject.structural_around(:nonexistent, {0, 0}, @buffer_id) == nil
     end
   end
 
   describe "adjust_end_position (via structural queries)" do
-    # The private adjust_end_position is tested indirectly via structural queries.
-    # Direct unit tests would require exposing it; instead we verify the
-    # boundary cases produce expected results through the public API.
-
     test "all structural types gracefully handle no parser" do
       types = [:function, :class, :parameter, :block, :comment, :test]
 
       for type <- types do
-        assert TextObject.structural_inner(type, {0, 0}) == nil,
+        assert TextObject.structural_inner(type, {0, 0}, @buffer_id) == nil,
                "Expected nil for #{type} inner"
 
-        assert TextObject.structural_around(type, {0, 0}) == nil,
+        assert TextObject.structural_around(type, {0, 0}, @buffer_id) == nil,
                "Expected nil for #{type} around"
       end
     end

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -128,8 +128,9 @@ defmodule Minga.Test.EditorCase do
   def inject_highlights(ctx, capture_names, version \\ 1, spans) do
     # Flush pending messages (e.g. :setup_highlight from :ready)
     _ = :sys.get_state(ctx.editor)
-    send(ctx.editor, {:minga_input, {:highlight_names, capture_names}})
-    send(ctx.editor, {:minga_input, {:highlight_spans, version, spans}})
+    # buffer_id 0 is used in test injection since no real parser is involved
+    send(ctx.editor, {:minga_input, {:highlight_names, 0, capture_names}})
+    send(ctx.editor, {:minga_input, {:highlight_spans, 0, version, spans}})
     # Sync: ensure both messages have been processed before returning
     _ = :sys.get_state(ctx.editor)
     ctx

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const c = @cImport({
+pub const c = @cImport({
     @cInclude("tree_sitter/api.h");
 });
 const query_loader = @import("query_loader.zig");

--- a/zig/src/parser_main.zig
+++ b/zig/src/parser_main.zig
@@ -6,9 +6,13 @@
 ///
 /// This process handles only tree-sitter operations. It does not render
 /// anything or interact with a terminal. All grammars are compiled in.
+///
+/// Supports multiple buffers simultaneously via buffer IDs in the protocol.
+/// Each buffer maintains independent source content, parse tree, and language.
 const std = @import("std");
 const protocol = @import("protocol.zig");
 const highlighter_mod = @import("highlighter.zig");
+const c = highlighter_mod.c;
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -26,8 +30,16 @@ pub fn main() !void {
 
     const stdin_fd = std.posix.STDIN_FILENO;
     var msg_buf: [65536]u8 = undefined;
-    var ps = ParserState.init(alloc);
-    defer ps.deinit();
+
+    // Per-buffer state: each buffer_id maps to its own source mirror.
+    var buffers = BufferMap{};
+    defer {
+        var it = buffers.iterator();
+        while (it.next()) |entry| {
+            entry.value_ptr.deinit(alloc);
+        }
+        buffers.deinit(alloc);
+    }
 
     while (true) {
         // Read the 4-byte length header.
@@ -58,38 +70,38 @@ pub fn main() !void {
 
             // edit_buffer needs special handling: decode full edits from raw payload.
             if (remaining[0] == protocol.OP_EDIT_BUFFER) {
-                handleEditBuffer(&hl, remaining[1..cmd_size], stdout, alloc, &ps) catch {};
+                handleEditBuffer(&hl, remaining[1..cmd_size], stdout, alloc, &buffers) catch {};
+            } else if (remaining[0] == protocol.OP_CLOSE_BUFFER) {
+                handleCloseBuffer(remaining[1..cmd_size], alloc, &buffers);
             } else {
                 const cmd = protocol.decodeCommand(remaining) catch break;
-                handleCommand(&hl, cmd, stdout, alloc, &ps) catch {};
+                handleCommand(&hl, cmd, stdout, alloc, &buffers) catch {};
             }
             offset += cmd_size;
         }
     }
 }
 
-/// Parser state: keeps a mutable copy of the source so edit_buffer can
-/// patch it in-place instead of receiving the full content each time.
-const ParserState = struct {
+/// Map from buffer_id to per-buffer state.
+const BufferMap = std.AutoHashMapUnmanaged(u32, BufferState);
+
+/// Per-buffer state: keeps a mutable copy of the source, the parse tree,
+/// and the language name. Each buffer owns its tree independently so
+/// parsing buffer A never destroys buffer B's tree.
+const BufferState = struct {
     source: std.ArrayListUnmanaged(u8) = .empty,
-    alloc: std.mem.Allocator,
-
-    fn init(alloc: std.mem.Allocator) ParserState {
-        return .{ .alloc = alloc };
-    }
-
-    fn deinit(self: *ParserState) void {
-        self.source.deinit(self.alloc);
-    }
+    /// Owned copy of the language name (allocated from `alloc`).
+    language_name: ?[]u8 = null,
+    tree: ?*c.TSTree = null,
 
     /// Replace the entire source (used by parse_buffer).
-    fn setSource(self: *ParserState, content: []const u8) !void {
+    fn setSource(self: *BufferState, alloc: std.mem.Allocator, content: []const u8) !void {
         self.source.clearRetainingCapacity();
-        try self.source.appendSlice(self.alloc, content);
+        try self.source.appendSlice(alloc, content);
     }
 
     /// Apply edit deltas to the stored source, in order.
-    fn applyEdits(self: *ParserState, edits: []const protocol.EditDelta) !void {
+    fn applyEdits(self: *BufferState, alloc: std.mem.Allocator, edits: []const protocol.EditDelta) !void {
         for (edits) |edit| {
             const start: usize = @intCast(edit.start_byte);
             const old_end: usize = @intCast(edit.old_end_byte);
@@ -98,10 +110,67 @@ const ParserState = struct {
             const clamped_old_end = @min(old_end, self.source.items.len);
 
             // Replace [start..old_end) with inserted_text.
-            try self.source.replaceRange(self.alloc, start, clamped_old_end - start, edit.inserted_text);
+            try self.source.replaceRange(alloc, start, clamped_old_end - start, edit.inserted_text);
         }
     }
+
+    /// Set the language name, taking an owned copy.
+    fn setLanguageName(self: *BufferState, alloc: std.mem.Allocator, name: []const u8) !void {
+        if (self.language_name) |old| alloc.free(old);
+        const copy = try alloc.alloc(u8, name.len);
+        @memcpy(copy, name);
+        self.language_name = copy;
+    }
+
+    fn deinit(self: *BufferState, alloc: std.mem.Allocator) void {
+        if (self.tree) |t| c.ts_tree_delete(t);
+        if (self.language_name) |name| alloc.free(name);
+        self.source.deinit(alloc);
+    }
 };
+
+/// Get or create a BufferState for the given buffer_id.
+fn getOrCreateBuffer(buffers: *BufferMap, alloc: std.mem.Allocator, buffer_id: u32) !*BufferState {
+    const gop = try buffers.getOrPut(alloc, buffer_id);
+    if (!gop.found_existing) {
+        gop.value_ptr.* = .{};
+    }
+    return gop.value_ptr;
+}
+
+/// Switch the highlighter's active language to match a buffer's language
+/// and install the buffer's tree (so incremental parsing works correctly).
+/// Returns true if the highlighter is ready (language set), false otherwise.
+fn activateBuffer(hl: *highlighter_mod.Highlighter, bs: *BufferState) bool {
+    const lang_name = bs.language_name orelse return false;
+
+    // Switch language if needed (this loads cached queries).
+    const lang_changed = if (hl.current_language_name) |current|
+        !std.mem.eql(u8, current, lang_name)
+    else
+        true;
+
+    if (lang_changed) {
+        // setLanguage deletes hl.tree, but we're about to replace it
+        // with the buffer's tree anyway.
+        _ = hl.setLanguage(lang_name);
+    }
+
+    // Install this buffer's tree into the highlighter (may be null for first parse).
+    // We transfer ownership: the highlighter holds it during the operation,
+    // and we save it back to BufferState after.
+    hl.tree = bs.tree;
+    bs.tree = null;
+    hl.current_source = if (bs.source.items.len > 0) bs.source.items else null;
+
+    return hl.current_language != null;
+}
+
+/// Save the highlighter's tree back to the buffer state after a parse/query operation.
+fn saveTreeToBuffer(hl: *highlighter_mod.Highlighter, bs: *BufferState) void {
+    bs.tree = hl.tree;
+    hl.tree = null;
+}
 
 /// Dispatch a highlight-related command to the Highlighter and send responses.
 fn handleCommand(
@@ -109,56 +178,109 @@ fn handleCommand(
     cmd: protocol.RenderCommand,
     stdout: *std.Io.Writer,
     alloc: std.mem.Allocator,
-    ps: *ParserState,
+    buffers: *BufferMap,
 ) !void {
     switch (cmd) {
-        .set_language => |name| {
-            if (!hl.setLanguage(name)) {
-                // Unknown language; silently ignore.
-            }
+        .set_language => |sl| {
+            const bs = try getOrCreateBuffer(buffers, alloc, sl.buffer_id);
+            bs.setLanguageName(alloc, sl.name) catch return;
+            // Set the highlighter's active language so queries get loaded.
+            _ = hl.setLanguage(sl.name);
         },
         .parse_buffer => |pb| {
-            // Full content sync: update stored source and do a full parse.
-            ps.setSource(pb.source) catch return;
-            hl.parse(ps.source.items) catch return;
+            const bs = try getOrCreateBuffer(buffers, alloc, pb.buffer_id);
+            bs.setSource(alloc, pb.source) catch return;
+
+            // Activate this buffer (sets language, installs its tree).
+            if (!activateBuffer(hl, bs)) return;
+
+            hl.parse(bs.source.items) catch {
+                saveTreeToBuffer(hl, bs);
+                return;
+            };
 
             if (hl.query != null) {
-                try sendHighlightResults(hl, pb.version, stdout, alloc);
+                sendHighlightResults(hl, pb.buffer_id, pb.version, stdout, alloc) catch {};
             }
             if (hl.fold_query != null) {
-                try sendFoldResults(hl, pb.version, stdout, alloc);
+                sendFoldResults(hl, pb.buffer_id, pb.version, stdout, alloc) catch {};
             }
             if (hl.textobject_query != null) {
-                try sendTextobjectPositions(hl, pb.version, stdout, alloc);
+                sendTextobjectPositions(hl, pb.buffer_id, pb.version, stdout, alloc) catch {};
             }
+
+            // Save tree back to buffer state.
+            saveTreeToBuffer(hl, bs);
         },
         .edit_buffer => {
             // Handled at dispatch level via handleEditBuffer().
         },
-        .set_highlight_query => |source| {
-            hl.setHighlightQuery(source) catch {};
+        .set_highlight_query => |shq| {
+            if (buffers.getPtr(shq.buffer_id)) |bs| {
+                _ = activateBuffer(hl, bs);
+                hl.setHighlightQuery(shq.source) catch {};
+                saveTreeToBuffer(hl, bs);
+            } else {
+                hl.setHighlightQuery(shq.source) catch {};
+            }
         },
-        .set_injection_query => |source| {
-            hl.setInjectionQuery(source) catch {};
+        .set_injection_query => |siq| {
+            if (buffers.getPtr(siq.buffer_id)) |bs| {
+                _ = activateBuffer(hl, bs);
+                hl.setInjectionQuery(siq.source) catch {};
+                saveTreeToBuffer(hl, bs);
+            } else {
+                hl.setInjectionQuery(siq.source) catch {};
+            }
         },
-        .set_fold_query => |source| {
-            hl.setFoldQuery(source) catch {};
+        .set_fold_query => |sfq| {
+            if (buffers.getPtr(sfq.buffer_id)) |bs| {
+                _ = activateBuffer(hl, bs);
+                hl.setFoldQuery(sfq.source) catch {};
+                saveTreeToBuffer(hl, bs);
+            } else {
+                hl.setFoldQuery(sfq.source) catch {};
+            }
         },
-        .set_indent_query => |source| {
-            hl.setIndentQuery(source) catch {};
+        .set_indent_query => |siq_cmd| {
+            if (buffers.getPtr(siq_cmd.buffer_id)) |bs| {
+                _ = activateBuffer(hl, bs);
+                hl.setIndentQuery(siq_cmd.source) catch {};
+                saveTreeToBuffer(hl, bs);
+            } else {
+                hl.setIndentQuery(siq_cmd.source) catch {};
+            }
         },
         .request_indent => |req| {
-            const level = hl.computeIndent(req.line, ps.source.items);
+            const bs = buffers.getPtr(req.buffer_id) orelse return;
+            if (!activateBuffer(hl, bs)) return;
+            const level = hl.computeIndent(req.line, bs.source.items);
+            saveTreeToBuffer(hl, bs);
             var rbuf: [13]u8 = undefined;
             const rlen = protocol.encodeIndentResult(&rbuf, req.request_id, req.line, level);
             try protocol.writeMessage(stdout, rbuf[0..rlen]);
             try stdout.flush();
         },
-        .set_textobject_query => |source| {
-            hl.setTextobjectQuery(source) catch {};
+        .set_textobject_query => |stq| {
+            if (buffers.getPtr(stq.buffer_id)) |bs| {
+                _ = activateBuffer(hl, bs);
+                hl.setTextobjectQuery(stq.source) catch {};
+                saveTreeToBuffer(hl, bs);
+            } else {
+                hl.setTextobjectQuery(stq.source) catch {};
+            }
         },
         .request_textobject => |req| {
+            const bs = buffers.getPtr(req.buffer_id) orelse {
+                var rbuf: [22]u8 = undefined;
+                const rlen = protocol.encodeTextobjectResult(&rbuf, req.request_id, null);
+                try protocol.writeMessage(stdout, rbuf[0..rlen]);
+                try stdout.flush();
+                return;
+            };
+            if (!activateBuffer(hl, bs)) return;
             const result = hl.findTextobject(req.row, req.col, req.capture_name);
+            saveTreeToBuffer(hl, bs);
             var rbuf: [22]u8 = undefined;
             const rlen = protocol.encodeTextobjectResult(&rbuf, req.request_id, result);
             try protocol.writeMessage(stdout, rbuf[0..rlen]);
@@ -178,11 +300,23 @@ fn handleCommand(
             try stdout.flush();
         },
         .query_language_at => |q| {
-            const lang = hl.languageAt(q.byte_offset);
-            var rbuf: [260]u8 = undefined;
-            const rlen = protocol.encodeLanguageAtResponse(&rbuf, q.request_id, lang) catch return;
-            try protocol.writeMessage(stdout, rbuf[0..rlen]);
-            try stdout.flush();
+            if (buffers.getPtr(q.buffer_id)) |bs| {
+                _ = activateBuffer(hl, bs);
+                const lang = hl.languageAt(q.byte_offset);
+                saveTreeToBuffer(hl, bs);
+                var rbuf: [260]u8 = undefined;
+                const rlen = protocol.encodeLanguageAtResponse(&rbuf, q.request_id, lang) catch return;
+                try protocol.writeMessage(stdout, rbuf[0..rlen]);
+                try stdout.flush();
+            } else {
+                var rbuf: [260]u8 = undefined;
+                const rlen = protocol.encodeLanguageAtResponse(&rbuf, q.request_id, null) catch return;
+                try protocol.writeMessage(stdout, rbuf[0..rlen]);
+                try stdout.flush();
+            }
+        },
+        .close_buffer => {
+            // Handled at dispatch level via handleCloseBuffer().
         },
         // Render commands are not handled by the parser process.
         else => {},
@@ -196,34 +330,62 @@ fn handleEditBuffer(
     data: []const u8,
     stdout: *std.Io.Writer,
     alloc: std.mem.Allocator,
-    ps: *ParserState,
+    buffers: *BufferMap,
 ) !void {
     const decoded = protocol.decodeEditBuffer(data, alloc) catch return;
     defer alloc.free(decoded.edits);
 
+    const bs = try getOrCreateBuffer(buffers, alloc, decoded.buffer_id);
+
     // Apply edits to stored source.
-    ps.applyEdits(decoded.edits) catch return;
+    bs.applyEdits(alloc, decoded.edits) catch return;
+
+    // Activate this buffer (sets language, installs its tree for incremental parsing).
+    if (!activateBuffer(hl, bs)) return;
 
     // Incremental parse using the patched source.
-    hl.parseIncremental(decoded.edits, ps.source.items) catch {
+    hl.parseIncremental(decoded.edits, bs.source.items) catch {
         // Fallback: full parse on the patched source.
-        hl.parse(ps.source.items) catch return;
+        hl.parse(bs.source.items) catch {
+            saveTreeToBuffer(hl, bs);
+            return;
+        };
     };
 
     if (hl.query != null) {
-        try sendHighlightResults(hl, decoded.version, stdout, alloc);
+        sendHighlightResults(hl, decoded.buffer_id, decoded.version, stdout, alloc) catch {};
     }
     if (hl.fold_query != null) {
-        try sendFoldResults(hl, decoded.version, stdout, alloc);
+        sendFoldResults(hl, decoded.buffer_id, decoded.version, stdout, alloc) catch {};
     }
     if (hl.textobject_query != null) {
-        try sendTextobjectPositions(hl, decoded.version, stdout, alloc);
+        sendTextobjectPositions(hl, decoded.buffer_id, decoded.version, stdout, alloc) catch {};
+    }
+
+    // Save tree back to buffer state.
+    saveTreeToBuffer(hl, bs);
+}
+
+/// Handle a close_buffer command: free the buffer's state and tree.
+fn handleCloseBuffer(
+    data: []const u8,
+    alloc: std.mem.Allocator,
+    buffers: *BufferMap,
+) void {
+    if (data.len < 4) return;
+    const buffer_id = std.mem.readInt(u32, data[0..4], .big);
+
+    if (buffers.fetchRemove(buffer_id)) |kv| {
+        var bs = kv.value;
+        // BufferState.deinit frees the tree (if any) and source.
+        bs.deinit(alloc);
     }
 }
 
 /// Send textobject positions to stdout.
 fn sendTextobjectPositions(
     hl: *highlighter_mod.Highlighter,
+    buffer_id: u32,
     version: u32,
     stdout: *std.Io.Writer,
     alloc: std.mem.Allocator,
@@ -231,7 +393,7 @@ fn sendTextobjectPositions(
     const entries = hl.collectTextobjectPositions(alloc);
     defer if (entries.len > 0) alloc.free(entries);
 
-    const buf = try protocol.encodeTextobjectPositions(alloc, version, entries);
+    const buf = try protocol.encodeTextobjectPositions(alloc, buffer_id, version, entries);
     defer alloc.free(buf);
     try protocol.writeMessage(stdout, buf);
     try stdout.flush();
@@ -240,6 +402,7 @@ fn sendTextobjectPositions(
 /// Send fold range results to stdout.
 fn sendFoldResults(
     hl: *highlighter_mod.Highlighter,
+    buffer_id: u32,
     version: u32,
     stdout: *std.Io.Writer,
     alloc: std.mem.Allocator,
@@ -247,7 +410,7 @@ fn sendFoldResults(
     const ranges = hl.runFoldQuery(alloc) catch return orelse return;
     defer alloc.free(ranges);
 
-    const buf = try protocol.encodeFoldRanges(alloc, version, ranges);
+    const buf = try protocol.encodeFoldRanges(alloc, buffer_id, version, ranges);
     defer alloc.free(buf);
     try protocol.writeMessage(stdout, buf);
     try stdout.flush();
@@ -256,6 +419,7 @@ fn sendFoldResults(
 /// Send highlight results (names, spans, injection ranges) to stdout.
 fn sendHighlightResults(
     hl: *highlighter_mod.Highlighter,
+    buffer_id: u32,
     version: u32,
     stdout: *std.Io.Writer,
     alloc: std.mem.Allocator,
@@ -263,16 +427,16 @@ fn sendHighlightResults(
     var result = hl.highlightWithInjections() catch return;
     defer result.deinit();
 
-    const names_buf = try protocol.encodeHighlightNames(alloc, result.capture_names);
+    const names_buf = try protocol.encodeHighlightNames(alloc, buffer_id, result.capture_names);
     defer alloc.free(names_buf);
     try protocol.writeMessage(stdout, names_buf);
 
-    const spans_buf = try protocol.encodeHighlightSpans(alloc, version, result.spans);
+    const spans_buf = try protocol.encodeHighlightSpans(alloc, buffer_id, version, result.spans);
     defer alloc.free(spans_buf);
     try protocol.writeMessage(stdout, spans_buf);
 
     if (hl.injection_ranges.len > 0) {
-        const inj_buf = try protocol.encodeInjectionRanges(alloc, hl.injection_ranges);
+        const inj_buf = try protocol.encodeInjectionRanges(alloc, buffer_id, hl.injection_ranges);
         defer alloc.free(inj_buf);
         try protocol.writeMessage(stdout, inj_buf);
     }

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -61,6 +61,7 @@ pub const OP_SET_INDENT_QUERY: u8 = 0x29;
 pub const OP_REQUEST_INDENT: u8 = 0x2A;
 pub const OP_SET_TEXTOBJECT_QUERY: u8 = 0x2B;
 pub const OP_REQUEST_TEXTOBJECT: u8 = 0x2C;
+pub const OP_CLOSE_BUFFER: u8 = 0x2D;
 
 // Highlight responses (Zig → BEAM)
 pub const OP_HIGHLIGHT_SPANS: u8 = 0x30;
@@ -240,17 +241,18 @@ pub const RenderCommand = union(enum) {
     // No-op (command was decoded and skipped; GUI-only opcodes, etc.)
     noop: void,
     // Highlight commands
-    set_language: []const u8,
+    set_language: SetLanguage,
     parse_buffer: ParseBuffer,
-    set_highlight_query: []const u8,
-    set_injection_query: []const u8,
-    set_fold_query: []const u8,
-    set_indent_query: []const u8,
+    set_highlight_query: SetHighlightQuery,
+    set_injection_query: SetInjectionQuery,
+    set_fold_query: SetFoldQuery,
+    set_indent_query: SetIndentQuery,
     request_indent: RequestIndent,
-    set_textobject_query: []const u8,
+    set_textobject_query: SetTextobjectQuery,
     request_textobject: RequestTextobject,
     load_grammar: LoadGrammar,
     query_language_at: QueryLanguageAt,
+    close_buffer: u32, // buffer_id
 };
 
 /// A single edit delta for incremental content sync.
@@ -269,6 +271,7 @@ pub const EditDelta = struct {
 
 /// An edit_buffer command containing one or more edit deltas.
 pub const EditBuffer = struct {
+    buffer_id: u32 = 0,
     version: u32,
     edits: []const EditDelta,
 };
@@ -279,21 +282,55 @@ pub const MeasureText = struct {
 };
 
 pub const QueryLanguageAt = struct {
+    buffer_id: u32 = 0,
     request_id: u32,
     byte_offset: u32,
 };
 
 pub const ParseBuffer = struct {
+    buffer_id: u32 = 0,
     version: u32,
     source: []const u8,
 };
 
+pub const SetLanguage = struct {
+    buffer_id: u32 = 0,
+    name: []const u8,
+};
+
+pub const SetHighlightQuery = struct {
+    buffer_id: u32 = 0,
+    source: []const u8,
+};
+
+pub const SetInjectionQuery = struct {
+    buffer_id: u32 = 0,
+    source: []const u8,
+};
+
+pub const SetFoldQuery = struct {
+    buffer_id: u32 = 0,
+    source: []const u8,
+};
+
+pub const SetIndentQuery = struct {
+    buffer_id: u32 = 0,
+    source: []const u8,
+};
+
+pub const SetTextobjectQuery = struct {
+    buffer_id: u32 = 0,
+    source: []const u8,
+};
+
 pub const RequestIndent = struct {
+    buffer_id: u32 = 0,
     request_id: u32,
     line: u32,
 };
 
 pub const RequestTextobject = struct {
+    buffer_id: u32 = 0,
     request_id: u32,
     row: u32,
     col: u32,
@@ -450,15 +487,16 @@ pub fn writeMessage(writer: anytype, payload: []const u8) !void {
 
 /// Encodes highlight_spans: opcode(1) + version(4) + count(4) + spans(count * 10)
 /// Each span: start_byte:u32, end_byte:u32, capture_id:u16
-pub fn encodeHighlightSpans(allocator: std.mem.Allocator, version: u32, spans: []const Span) ![]u8 {
-    const header_size = 1 + 4 + 4; // opcode + version + count
+pub fn encodeHighlightSpans(allocator: std.mem.Allocator, buffer_id: u32, version: u32, spans: []const Span) ![]u8 {
+    const header_size = 1 + 4 + 4 + 4; // opcode + buffer_id + version + count
     const span_size = 10; // 4 + 4 + 2
     const total = header_size + spans.len * span_size;
     const buf = try allocator.alloc(u8, total);
 
     buf[0] = OP_HIGHLIGHT_SPANS;
-    std.mem.writeInt(u32, buf[1..5], version, .big);
-    std.mem.writeInt(u32, buf[5..9], @intCast(spans.len), .big);
+    std.mem.writeInt(u32, buf[1..5], buffer_id, .big);
+    std.mem.writeInt(u32, buf[5..9], version, .big);
+    std.mem.writeInt(u32, buf[9..13], @intCast(spans.len), .big);
 
     for (spans, 0..) |span, i| {
         const off = header_size + i * span_size;
@@ -470,18 +508,19 @@ pub fn encodeHighlightSpans(allocator: std.mem.Allocator, version: u32, spans: [
     return buf;
 }
 
-/// Encodes highlight_names: opcode(1) + count(2) + (name_len:2 + name) for each
-pub fn encodeHighlightNames(allocator: std.mem.Allocator, names: []const []const u8) ![]u8 {
-    var total: usize = 1 + 2; // opcode + count
+/// Encodes highlight_names: opcode(1) + buffer_id(4) + count(2) + (name_len:2 + name) for each
+pub fn encodeHighlightNames(allocator: std.mem.Allocator, buffer_id: u32, names: []const []const u8) ![]u8 {
+    var total: usize = 1 + 4 + 2; // opcode + buffer_id + count
     for (names) |name| {
         total += 2 + name.len;
     }
 
     const buf = try allocator.alloc(u8, total);
     buf[0] = OP_HIGHLIGHT_NAMES;
-    std.mem.writeInt(u16, buf[1..3], @intCast(names.len), .big);
+    std.mem.writeInt(u32, buf[1..5], buffer_id, .big);
+    std.mem.writeInt(u16, buf[5..7], @intCast(names.len), .big);
 
-    var off: usize = 3;
+    var off: usize = 7;
     for (names) |name| {
         std.mem.writeInt(u16, buf[off..][0..2], @intCast(name.len), .big);
         @memcpy(buf[off + 2 .. off + 2 + name.len], name);
@@ -571,74 +610,105 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
             return .{ .set_default_bg = rgb };
         },
         OP_SET_LANGUAGE => {
-            // name_len:2, name
-            if (rest.len < 2) return error.Malformed;
-            const name_len = std.mem.readInt(u16, rest[0..2], .big);
-            if (rest.len < 2 + name_len) return error.Malformed;
-            return .{ .set_language = rest[2 .. 2 + name_len] };
+            // buffer_id:4, name_len:2, name
+            if (rest.len < 6) return error.Malformed;
+            const buffer_id = std.mem.readInt(u32, rest[0..4], .big);
+            const name_len = std.mem.readInt(u16, rest[4..6], .big);
+            if (rest.len < 6 + name_len) return error.Malformed;
+            return .{ .set_language = .{
+                .buffer_id = buffer_id,
+                .name = rest[6 .. 6 + name_len],
+            } };
         },
         OP_PARSE_BUFFER => {
-            // version:4, source_len:4, source
-            if (rest.len < 8) return error.Malformed;
-            const version = std.mem.readInt(u32, rest[0..4], .big);
-            const source_len = std.mem.readInt(u32, rest[4..8], .big);
-            if (rest.len < 8 + source_len) return error.Malformed;
+            // buffer_id:4, version:4, source_len:4, source
+            if (rest.len < 12) return error.Malformed;
+            const buffer_id = std.mem.readInt(u32, rest[0..4], .big);
+            const version = std.mem.readInt(u32, rest[4..8], .big);
+            const source_len = std.mem.readInt(u32, rest[8..12], .big);
+            if (rest.len < 12 + source_len) return error.Malformed;
             return .{ .parse_buffer = .{
+                .buffer_id = buffer_id,
                 .version = version,
-                .source = rest[8 .. 8 + source_len],
+                .source = rest[12 .. 12 + source_len],
             } };
         },
         OP_SET_HIGHLIGHT_QUERY => {
-            // query_len:4, query
-            if (rest.len < 4) return error.Malformed;
-            const query_len = std.mem.readInt(u32, rest[0..4], .big);
-            if (rest.len < 4 + query_len) return error.Malformed;
-            return .{ .set_highlight_query = rest[4 .. 4 + query_len] };
+            // buffer_id:4, query_len:4, query
+            if (rest.len < 8) return error.Malformed;
+            const buffer_id = std.mem.readInt(u32, rest[0..4], .big);
+            const query_len = std.mem.readInt(u32, rest[4..8], .big);
+            if (rest.len < 8 + query_len) return error.Malformed;
+            return .{ .set_highlight_query = .{
+                .buffer_id = buffer_id,
+                .source = rest[8 .. 8 + query_len],
+            } };
         },
         OP_SET_INJECTION_QUERY => {
-            // query_len:4, query (same wire format as set_highlight_query)
-            if (rest.len < 4) return error.Malformed;
-            const query_len = std.mem.readInt(u32, rest[0..4], .big);
-            if (rest.len < 4 + query_len) return error.Malformed;
-            return .{ .set_injection_query = rest[4 .. 4 + query_len] };
+            // buffer_id:4, query_len:4, query
+            if (rest.len < 8) return error.Malformed;
+            const buffer_id = std.mem.readInt(u32, rest[0..4], .big);
+            const query_len = std.mem.readInt(u32, rest[4..8], .big);
+            if (rest.len < 8 + query_len) return error.Malformed;
+            return .{ .set_injection_query = .{
+                .buffer_id = buffer_id,
+                .source = rest[8 .. 8 + query_len],
+            } };
         },
         OP_SET_FOLD_QUERY => {
-            // query_len:4, query (same wire format as set_highlight_query)
-            if (rest.len < 4) return error.Malformed;
-            const query_len = std.mem.readInt(u32, rest[0..4], .big);
-            if (rest.len < 4 + query_len) return error.Malformed;
-            return .{ .set_fold_query = rest[4 .. 4 + query_len] };
+            // buffer_id:4, query_len:4, query
+            if (rest.len < 8) return error.Malformed;
+            const buffer_id = std.mem.readInt(u32, rest[0..4], .big);
+            const query_len = std.mem.readInt(u32, rest[4..8], .big);
+            if (rest.len < 8 + query_len) return error.Malformed;
+            return .{ .set_fold_query = .{
+                .buffer_id = buffer_id,
+                .source = rest[8 .. 8 + query_len],
+            } };
         },
         OP_SET_INDENT_QUERY => {
-            if (rest.len < 4) return error.Malformed;
-            const query_len = std.mem.readInt(u32, rest[0..4], .big);
-            if (rest.len < 4 + query_len) return error.Malformed;
-            return .{ .set_indent_query = rest[4 .. 4 + query_len] };
+            // buffer_id:4, query_len:4, query
+            if (rest.len < 8) return error.Malformed;
+            const buffer_id = std.mem.readInt(u32, rest[0..4], .big);
+            const query_len = std.mem.readInt(u32, rest[4..8], .big);
+            if (rest.len < 8 + query_len) return error.Malformed;
+            return .{ .set_indent_query = .{
+                .buffer_id = buffer_id,
+                .source = rest[8 .. 8 + query_len],
+            } };
         },
         OP_REQUEST_INDENT => {
-            // request_id:4, line:4
-            if (rest.len < 8) return error.Malformed;
+            // buffer_id:4, request_id:4, line:4
+            if (rest.len < 12) return error.Malformed;
             return .{ .request_indent = .{
-                .request_id = std.mem.readInt(u32, rest[0..4], .big),
-                .line = std.mem.readInt(u32, rest[4..8], .big),
+                .buffer_id = std.mem.readInt(u32, rest[0..4], .big),
+                .request_id = std.mem.readInt(u32, rest[4..8], .big),
+                .line = std.mem.readInt(u32, rest[8..12], .big),
             } };
         },
         OP_SET_TEXTOBJECT_QUERY => {
-            if (rest.len < 4) return error.Malformed;
-            const query_len = std.mem.readInt(u32, rest[0..4], .big);
-            if (rest.len < 4 + query_len) return error.Malformed;
-            return .{ .set_textobject_query = rest[4 .. 4 + query_len] };
+            // buffer_id:4, query_len:4, query
+            if (rest.len < 8) return error.Malformed;
+            const buffer_id = std.mem.readInt(u32, rest[0..4], .big);
+            const query_len = std.mem.readInt(u32, rest[4..8], .big);
+            if (rest.len < 8 + query_len) return error.Malformed;
+            return .{ .set_textobject_query = .{
+                .buffer_id = buffer_id,
+                .source = rest[8 .. 8 + query_len],
+            } };
         },
         OP_REQUEST_TEXTOBJECT => {
-            // request_id:4, row:4, col:4, name_len:2, name
-            if (rest.len < 14) return error.Malformed;
-            const name_len = std.mem.readInt(u16, rest[12..14], .big);
-            if (rest.len < 14 + name_len) return error.Malformed;
+            // buffer_id:4, request_id:4, row:4, col:4, name_len:2, name
+            if (rest.len < 18) return error.Malformed;
+            const buffer_id = std.mem.readInt(u32, rest[0..4], .big);
+            const name_len = std.mem.readInt(u16, rest[16..18], .big);
+            if (rest.len < 18 + name_len) return error.Malformed;
             return .{ .request_textobject = .{
-                .request_id = std.mem.readInt(u32, rest[0..4], .big),
-                .row = std.mem.readInt(u32, rest[4..8], .big),
-                .col = std.mem.readInt(u32, rest[8..12], .big),
-                .capture_name = rest[14 .. 14 + name_len],
+                .buffer_id = buffer_id,
+                .request_id = std.mem.readInt(u32, rest[4..8], .big),
+                .row = std.mem.readInt(u32, rest[8..12], .big),
+                .col = std.mem.readInt(u32, rest[12..16], .big),
+                .capture_name = rest[18 .. 18 + name_len],
             } };
         },
         OP_LOAD_GRAMMAR => {
@@ -656,23 +726,28 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
             } };
         },
         OP_QUERY_LANGUAGE_AT => {
-            // request_id:4, byte_offset:4
-            if (rest.len < 8) return error.Malformed;
-            const request_id = std.mem.readInt(u32, rest[0..4], .big);
-            const byte_offset = std.mem.readInt(u32, rest[4..8], .big);
+            // buffer_id:4, request_id:4, byte_offset:4
+            if (rest.len < 12) return error.Malformed;
             return .{ .query_language_at = .{
-                .request_id = request_id,
-                .byte_offset = byte_offset,
+                .buffer_id = std.mem.readInt(u32, rest[0..4], .big),
+                .request_id = std.mem.readInt(u32, rest[4..8], .big),
+                .byte_offset = std.mem.readInt(u32, rest[8..12], .big),
             } };
         },
         OP_EDIT_BUFFER => {
             // Variable-length command. Decoded via decodeEditBuffer() with an allocator.
-            // Here we just validate the header and return the version + empty edits.
-            if (rest.len < 6) return error.Malformed;
+            // Here we just validate the header and return the buffer_id + version + empty edits.
+            if (rest.len < 10) return error.Malformed;
             return .{ .edit_buffer = .{
-                .version = std.mem.readInt(u32, rest[0..4], .big),
+                .buffer_id = std.mem.readInt(u32, rest[0..4], .big),
+                .version = std.mem.readInt(u32, rest[4..8], .big),
                 .edits = &.{},
             } };
+        },
+        OP_CLOSE_BUFFER => {
+            // buffer_id:4
+            if (rest.len < 4) return error.Malformed;
+            return .{ .close_buffer = std.mem.readInt(u32, rest[0..4], .big) };
         },
         OP_MEASURE_TEXT => {
             // request_id:4, text_len:2, text
@@ -758,19 +833,22 @@ pub fn commandSize(payload: []const u8) usize {
             break :blk 14 + text_len;
         },
         OP_SET_LANGUAGE => blk: {
-            if (payload.len < 3) break :blk payload.len;
-            const name_len = std.mem.readInt(u16, payload[1..3], .big);
-            break :blk 3 + name_len;
+            // opcode(1) + buffer_id(4) + name_len(2) + name
+            if (payload.len < 7) break :blk payload.len;
+            const name_len = std.mem.readInt(u16, payload[5..7], .big);
+            break :blk 7 + name_len;
         },
         OP_PARSE_BUFFER => blk: {
-            if (payload.len < 9) break :blk payload.len;
-            const source_len = std.mem.readInt(u32, payload[5..9], .big);
-            break :blk 9 + source_len;
+            // opcode(1) + buffer_id(4) + version(4) + source_len(4) + source
+            if (payload.len < 13) break :blk payload.len;
+            const source_len = std.mem.readInt(u32, payload[9..13], .big);
+            break :blk 13 + source_len;
         },
         OP_SET_HIGHLIGHT_QUERY, OP_SET_INJECTION_QUERY, OP_SET_FOLD_QUERY, OP_SET_INDENT_QUERY, OP_SET_TEXTOBJECT_QUERY => blk: {
-            if (payload.len < 5) break :blk payload.len;
-            const query_len = std.mem.readInt(u32, payload[1..5], .big);
-            break :blk 5 + query_len;
+            // opcode(1) + buffer_id(4) + query_len(4) + query
+            if (payload.len < 9) break :blk payload.len;
+            const query_len = std.mem.readInt(u32, payload[5..9], .big);
+            break :blk 9 + query_len;
         },
         OP_LOAD_GRAMMAR => blk: {
             if (payload.len < 3) break :blk payload.len;
@@ -785,19 +863,20 @@ pub fn commandSize(payload: []const u8) usize {
             const title_len = std.mem.readInt(u16, payload[1..3], .big);
             break :blk 3 + title_len;
         },
-        OP_QUERY_LANGUAGE_AT => 9, // opcode(1) + request_id(4) + byte_offset(4)
-        OP_REQUEST_INDENT => 9, // opcode(1) + request_id(4) + line(4)
+        OP_QUERY_LANGUAGE_AT => 13, // opcode(1) + buffer_id(4) + request_id(4) + byte_offset(4)
+        OP_REQUEST_INDENT => 13, // opcode(1) + buffer_id(4) + request_id(4) + line(4)
         OP_REQUEST_TEXTOBJECT => blk: {
-            // opcode(1) + request_id(4) + row(4) + col(4) + name_len(2) + name
-            if (payload.len < 15) break :blk payload.len;
-            const nl = std.mem.readInt(u16, payload[13..15], .big);
-            break :blk 15 + nl;
+            // opcode(1) + buffer_id(4) + request_id(4) + row(4) + col(4) + name_len(2) + name
+            if (payload.len < 19) break :blk payload.len;
+            const nl = std.mem.readInt(u16, payload[17..19], .big);
+            break :blk 19 + nl;
         },
+        OP_CLOSE_BUFFER => 5, // opcode(1) + buffer_id(4)
         OP_EDIT_BUFFER => blk: {
-            // opcode(1) + version(4) + edit_count(2) + variable per edit
-            if (payload.len < 7) break :blk payload.len;
-            const edit_count = std.mem.readInt(u16, payload[5..7], .big);
-            var off: usize = 7;
+            // opcode(1) + buffer_id(4) + version(4) + edit_count(2) + variable per edit
+            if (payload.len < 11) break :blk payload.len;
+            const edit_count = std.mem.readInt(u16, payload[9..11], .big);
+            var off: usize = 11;
             for (0..edit_count) |_| {
                 // 9 × u32 fields + text_len:u32 = 40 bytes header per edit
                 if (off + 40 > payload.len) break :blk payload.len;
@@ -829,17 +908,18 @@ pub fn commandSize(payload: []const u8) usize {
 }
 
 /// Fully decodes an edit_buffer command payload (after the opcode byte).
-/// Returns the version and an allocated slice of EditDelta structs.
+/// Returns the buffer_id, version, and an allocated slice of EditDelta structs.
 /// Caller owns the returned slice and must free it.
-pub fn decodeEditBuffer(data: []const u8, alloc: std.mem.Allocator) !struct { version: u32, edits: []EditDelta } {
-    if (data.len < 6) return error.Malformed;
-    const version = std.mem.readInt(u32, data[0..4], .big);
-    const edit_count = std.mem.readInt(u16, data[4..6], .big);
+pub fn decodeEditBuffer(data: []const u8, alloc: std.mem.Allocator) !struct { buffer_id: u32, version: u32, edits: []EditDelta } {
+    if (data.len < 10) return error.Malformed;
+    const buffer_id = std.mem.readInt(u32, data[0..4], .big);
+    const version = std.mem.readInt(u32, data[4..8], .big);
+    const edit_count = std.mem.readInt(u16, data[8..10], .big);
 
     const edits = try alloc.alloc(EditDelta, edit_count);
     errdefer alloc.free(edits);
 
-    var off: usize = 6;
+    var off: usize = 10;
     for (0..edit_count) |i| {
         if (off + 40 > data.len) return error.Malformed;
         edits[i] = .{
@@ -862,7 +942,7 @@ pub fn decodeEditBuffer(data: []const u8, alloc: std.mem.Allocator) !struct { ve
         off += 40 + text_len;
     }
 
-    return .{ .version = version, .edits = edits };
+    return .{ .buffer_id = buffer_id, .version = version, .edits = edits };
 }
 
 /// Encodes a text_width response: opcode(1) + request_id(4) + width(2) = 7 bytes.
@@ -889,16 +969,17 @@ pub fn encodeLanguageAtResponse(buf: []u8, request_id: u32, language: ?[]const u
 }
 
 /// Encodes injection_ranges: opcode(1) + count(2) + (start_byte:4, end_byte:4, name_len:2, name) for each
-pub fn encodeInjectionRanges(allocator: std.mem.Allocator, ranges: []const InjectionRange) ![]u8 {
-    var total: usize = 1 + 2; // opcode + count
+pub fn encodeInjectionRanges(allocator: std.mem.Allocator, buffer_id: u32, ranges: []const InjectionRange) ![]u8 {
+    var total: usize = 1 + 4 + 2; // opcode + buffer_id + count
     for (ranges) |r| {
         total += 4 + 4 + 2 + r.language.len;
     }
     const buf = try allocator.alloc(u8, total);
     buf[0] = OP_INJECTION_RANGES;
-    std.mem.writeInt(u16, buf[1..3], @intCast(ranges.len), .big);
+    std.mem.writeInt(u32, buf[1..5], buffer_id, .big);
+    std.mem.writeInt(u16, buf[5..7], @intCast(ranges.len), .big);
 
-    var off: usize = 3;
+    var off: usize = 7;
     for (ranges) |r| {
         std.mem.writeInt(u32, buf[off..][0..4], r.start_byte, .big);
         std.mem.writeInt(u32, buf[off + 4 ..][0..4], r.end_byte, .big);
@@ -916,16 +997,17 @@ pub const FoldRange = struct {
     end_line: u32,
 };
 
-/// Encodes fold_ranges: opcode(1) + version(4) + count(4) + (start_line:4, end_line:4) for each
-pub fn encodeFoldRanges(allocator: std.mem.Allocator, version: u32, ranges: []const FoldRange) ![]u8 {
-    const header_size = 1 + 4 + 4; // opcode + version + count
+/// Encodes fold_ranges: opcode(1) + buffer_id(4) + version(4) + count(4) + (start_line:4, end_line:4) for each
+pub fn encodeFoldRanges(allocator: std.mem.Allocator, buffer_id: u32, version: u32, ranges: []const FoldRange) ![]u8 {
+    const header_size = 1 + 4 + 4 + 4; // opcode + buffer_id + version + count
     const range_size = 8; // start_line:4 + end_line:4
     const total = header_size + ranges.len * range_size;
     const buf = try allocator.alloc(u8, total);
 
     buf[0] = OP_FOLD_RANGES;
-    std.mem.writeInt(u32, buf[1..5], version, .big);
-    std.mem.writeInt(u32, buf[5..9], @intCast(ranges.len), .big);
+    std.mem.writeInt(u32, buf[1..5], buffer_id, .big);
+    std.mem.writeInt(u32, buf[5..9], version, .big);
+    std.mem.writeInt(u32, buf[9..13], @intCast(ranges.len), .big);
 
     for (ranges, 0..) |r, i| {
         const off = header_size + i * range_size;
@@ -968,16 +1050,17 @@ pub const TextobjectEntry = struct {
     col: u32,
 };
 
-/// Encodes textobject_positions: opcode(1) + version(4) + count(4) + [type_id(1) + row(4) + col(4)] * count
-pub fn encodeTextobjectPositions(allocator: std.mem.Allocator, version: u32, entries: []const TextobjectEntry) ![]u8 {
+/// Encodes textobject_positions: opcode(1) + buffer_id(4) + version(4) + count(4) + [type_id(1) + row(4) + col(4)] * count
+pub fn encodeTextobjectPositions(allocator: std.mem.Allocator, buffer_id: u32, version: u32, entries: []const TextobjectEntry) ![]u8 {
     const entry_size: usize = 9; // type_id(1) + row(4) + col(4)
-    const header_size: usize = 9; // opcode(1) + version(4) + count(4)
+    const header_size: usize = 13; // opcode(1) + buffer_id(4) + version(4) + count(4)
     const total_size = header_size + entries.len * entry_size;
 
     const buf = try allocator.alloc(u8, total_size);
     buf[0] = OP_TEXTOBJECT_POSITIONS;
-    std.mem.writeInt(u32, buf[1..5], version, .big);
-    std.mem.writeInt(u32, buf[5..9], @intCast(entries.len), .big);
+    std.mem.writeInt(u32, buf[1..5], buffer_id, .big);
+    std.mem.writeInt(u32, buf[5..9], version, .big);
+    std.mem.writeInt(u32, buf[9..13], @intCast(entries.len), .big);
 
     var pos: usize = header_size;
     for (entries) |e| {
@@ -1691,29 +1774,41 @@ test "encodeResize byte layout: self-consistent encoding" {
 // ── Highlight protocol tests ──────────────────────────────────────────────────
 
 test "decode set_language" {
-    // opcode(1) + name_len:2 + "elixir"(6) = 9 bytes
-    const data = [_]u8{ OP_SET_LANGUAGE, 0x00, 0x06 } ++ "elixir".*;
+    // opcode(1) + buffer_id:4 + name_len:2 + "elixir"(6) = 13 bytes
+    var data: [13]u8 = undefined;
+    data[0] = OP_SET_LANGUAGE;
+    std.mem.writeInt(u32, data[1..5], 7, .big); // buffer_id = 7
+    std.mem.writeInt(u16, data[5..7], 6, .big); // name_len = 6
+    @memcpy(data[7..13], "elixir");
     const cmd = try decodeCommand(&data);
-    try std.testing.expect(cmd == .set_language);
-    try std.testing.expectEqualStrings("elixir", cmd.set_language);
+    switch (cmd) {
+        .set_language => |sl| {
+            try std.testing.expectEqual(@as(u32, 7), sl.buffer_id);
+            try std.testing.expectEqualStrings("elixir", sl.name);
+        },
+        else => return error.Malformed,
+    }
 }
 
 test "decode set_language truncated returns malformed" {
-    const data = [_]u8{ OP_SET_LANGUAGE, 0x00, 0x06, 'e', 'l' }; // only 2 of 6 name bytes
+    // opcode(1) + buffer_id:4 + name_len:2 + only 2 of 6 name bytes
+    const data = [_]u8{ OP_SET_LANGUAGE, 0x00, 0x00, 0x00, 0x01, 0x00, 0x06, 'e', 'l' };
     const result = decodeCommand(&data);
     try std.testing.expectError(error.Malformed, result);
 }
 
 test "decode parse_buffer" {
-    // opcode(1) + version:4 + source_len:4 + "hello"(5) = 14 bytes
-    const data = [_]u8{
-        OP_PARSE_BUFFER,
-        0x00, 0x00, 0x00, 0x01, // version = 1
-        0x00, 0x00, 0x00, 0x05, // source_len = 5
-    } ++ "hello".*;
+    // opcode(1) + buffer_id:4 + version:4 + source_len:4 + "hello"(5) = 18 bytes
+    var data: [18]u8 = undefined;
+    data[0] = OP_PARSE_BUFFER;
+    std.mem.writeInt(u32, data[1..5], 3, .big); // buffer_id = 3
+    std.mem.writeInt(u32, data[5..9], 1, .big); // version = 1
+    std.mem.writeInt(u32, data[9..13], 5, .big); // source_len = 5
+    @memcpy(data[13..18], "hello");
     const cmd = try decodeCommand(&data);
     switch (cmd) {
         .parse_buffer => |pb| {
+            try std.testing.expectEqual(@as(u32, 3), pb.buffer_id);
             try std.testing.expectEqual(@as(u32, 1), pb.version);
             try std.testing.expectEqualStrings("hello", pb.source);
         },
@@ -1723,13 +1818,19 @@ test "decode parse_buffer" {
 
 test "decode set_highlight_query" {
     const query = "(atom) @string";
-    var data: [1 + 4 + query.len]u8 = undefined;
+    // opcode(1) + buffer_id(4) + query_len(4) + query
+    var data: [1 + 4 + 4 + query.len]u8 = undefined;
     data[0] = OP_SET_HIGHLIGHT_QUERY;
-    std.mem.writeInt(u32, data[1..5], query.len, .big);
-    @memcpy(data[5..], query);
+    std.mem.writeInt(u32, data[1..5], 0, .big); // buffer_id = 0
+    std.mem.writeInt(u32, data[5..9], query.len, .big);
+    @memcpy(data[9..], query);
     const cmd = try decodeCommand(&data);
-    try std.testing.expect(cmd == .set_highlight_query);
-    try std.testing.expectEqualStrings(query, cmd.set_highlight_query);
+    switch (cmd) {
+        .set_highlight_query => |shq| {
+            try std.testing.expectEqualStrings(query, shq.source);
+        },
+        else => return error.Malformed,
+    }
 }
 
 test "decode load_grammar" {
@@ -1746,50 +1847,82 @@ test "decode load_grammar" {
 }
 
 test "commandSize: set_language" {
-    const data = [_]u8{ OP_SET_LANGUAGE, 0x00, 0x06 } ++ "elixir".*;
-    try std.testing.expectEqual(@as(usize, 9), commandSize(&data));
+    // opcode(1) + buffer_id(4) + name_len(2) + "elixir"(6) = 13 bytes
+    var data: [13]u8 = undefined;
+    data[0] = OP_SET_LANGUAGE;
+    std.mem.writeInt(u32, data[1..5], 0, .big);
+    std.mem.writeInt(u16, data[5..7], 6, .big);
+    @memcpy(data[7..13], "elixir");
+    try std.testing.expectEqual(@as(usize, 13), commandSize(&data));
 }
 
 test "commandSize: parse_buffer" {
-    const data = [_]u8{
-        OP_PARSE_BUFFER,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x03,
-    } ++ "abc".*;
-    try std.testing.expectEqual(@as(usize, 12), commandSize(&data));
+    // opcode(1) + buffer_id(4) + version(4) + source_len(4) + "abc"(3) = 16 bytes
+    var data: [16]u8 = undefined;
+    data[0] = OP_PARSE_BUFFER;
+    std.mem.writeInt(u32, data[1..5], 0, .big); // buffer_id
+    std.mem.writeInt(u32, data[5..9], 1, .big); // version
+    std.mem.writeInt(u32, data[9..13], 3, .big); // source_len
+    @memcpy(data[13..16], "abc");
+    try std.testing.expectEqual(@as(usize, 16), commandSize(&data));
 }
 
 test "commandSize: set_highlight_query" {
-    var data: [1 + 4 + 5]u8 = undefined;
+    // opcode(1) + buffer_id(4) + query_len(4) + "query"(5) = 14 bytes
+    var data: [1 + 4 + 4 + 5]u8 = undefined;
     data[0] = OP_SET_HIGHLIGHT_QUERY;
-    std.mem.writeInt(u32, data[1..5], 5, .big);
-    @memcpy(data[5..10], "query");
-    try std.testing.expectEqual(@as(usize, 10), commandSize(&data));
+    std.mem.writeInt(u32, data[1..5], 0, .big); // buffer_id
+    std.mem.writeInt(u32, data[5..9], 5, .big); // query_len
+    @memcpy(data[9..14], "query");
+    try std.testing.expectEqual(@as(usize, 14), commandSize(&data));
 }
 
 test "decode set_injection_query" {
     const query = "(content) @injection.content";
-    var data: [1 + 4 + query.len]u8 = undefined;
+    // opcode(1) + buffer_id(4) + query_len(4) + query
+    var data: [1 + 4 + 4 + query.len]u8 = undefined;
     data[0] = OP_SET_INJECTION_QUERY;
-    std.mem.writeInt(u32, data[1..5], query.len, .big);
-    @memcpy(data[5..], query);
+    std.mem.writeInt(u32, data[1..5], 2, .big); // buffer_id = 2
+    std.mem.writeInt(u32, data[5..9], query.len, .big);
+    @memcpy(data[9..], query);
     const cmd = try decodeCommand(&data);
-    try std.testing.expect(cmd == .set_injection_query);
-    try std.testing.expectEqualStrings(query, cmd.set_injection_query);
+    switch (cmd) {
+        .set_injection_query => |siq| {
+            try std.testing.expectEqual(@as(u32, 2), siq.buffer_id);
+            try std.testing.expectEqualStrings(query, siq.source);
+        },
+        else => return error.Malformed,
+    }
 }
 
 test "commandSize: set_injection_query" {
-    var data: [1 + 4 + 5]u8 = undefined;
+    // opcode(1) + buffer_id(4) + query_len(4) + "query"(5) = 14 bytes
+    var data: [1 + 4 + 4 + 5]u8 = undefined;
     data[0] = OP_SET_INJECTION_QUERY;
-    std.mem.writeInt(u32, data[1..5], 5, .big);
-    @memcpy(data[5..10], "query");
-    try std.testing.expectEqual(@as(usize, 10), commandSize(&data));
+    std.mem.writeInt(u32, data[1..5], 0, .big);
+    std.mem.writeInt(u32, data[5..9], 5, .big);
+    @memcpy(data[9..14], "query");
+    try std.testing.expectEqual(@as(usize, 14), commandSize(&data));
+}
+
+test "decode close_buffer" {
+    var data: [5]u8 = undefined;
+    data[0] = OP_CLOSE_BUFFER;
+    std.mem.writeInt(u32, data[1..5], 42, .big);
+    const cmd = try decodeCommand(&data);
+    switch (cmd) {
+        .close_buffer => |buffer_id| {
+            try std.testing.expectEqual(@as(u32, 42), buffer_id);
+        },
+        else => return error.Malformed,
+    }
+}
+
+test "commandSize: close_buffer" {
+    var data: [5]u8 = undefined;
+    data[0] = OP_CLOSE_BUFFER;
+    std.mem.writeInt(u32, data[1..5], 0, .big);
+    try std.testing.expectEqual(@as(usize, 5), commandSize(&data));
 }
 
 test "commandSize: load_grammar" {
@@ -1802,35 +1935,37 @@ test "encodeHighlightSpans round-trip" {
         .{ .start_byte = 0, .end_byte = 9, .capture_id = 0, .pattern_index = 0 },
         .{ .start_byte = 10, .end_byte = 15, .capture_id = 1, .pattern_index = 1 },
     };
-    const buf = try encodeHighlightSpans(std.testing.allocator, 42, &spans);
+    const buf = try encodeHighlightSpans(std.testing.allocator, 5, 42, &spans);
     defer std.testing.allocator.free(buf);
 
     try std.testing.expectEqual(OP_HIGHLIGHT_SPANS, buf[0]);
-    try std.testing.expectEqual(@as(u32, 42), std.mem.readInt(u32, buf[1..5], .big));
-    try std.testing.expectEqual(@as(u32, 2), std.mem.readInt(u32, buf[5..9], .big));
+    try std.testing.expectEqual(@as(u32, 5), std.mem.readInt(u32, buf[1..5], .big)); // buffer_id
+    try std.testing.expectEqual(@as(u32, 42), std.mem.readInt(u32, buf[5..9], .big)); // version
+    try std.testing.expectEqual(@as(u32, 2), std.mem.readInt(u32, buf[9..13], .big)); // count
     // First span
-    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, buf[9..13], .big));
-    try std.testing.expectEqual(@as(u32, 9), std.mem.readInt(u32, buf[13..17], .big));
-    try std.testing.expectEqual(@as(u16, 0), std.mem.readInt(u16, buf[17..19], .big));
+    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, buf[13..17], .big));
+    try std.testing.expectEqual(@as(u32, 9), std.mem.readInt(u32, buf[17..21], .big));
+    try std.testing.expectEqual(@as(u16, 0), std.mem.readInt(u16, buf[21..23], .big));
     // Second span
-    try std.testing.expectEqual(@as(u32, 10), std.mem.readInt(u32, buf[19..23], .big));
-    try std.testing.expectEqual(@as(u32, 15), std.mem.readInt(u32, buf[23..27], .big));
-    try std.testing.expectEqual(@as(u16, 1), std.mem.readInt(u16, buf[27..29], .big));
+    try std.testing.expectEqual(@as(u32, 10), std.mem.readInt(u32, buf[23..27], .big));
+    try std.testing.expectEqual(@as(u32, 15), std.mem.readInt(u32, buf[27..31], .big));
+    try std.testing.expectEqual(@as(u16, 1), std.mem.readInt(u16, buf[31..33], .big));
 }
 
 test "encodeHighlightNames round-trip" {
     const names = [_][]const u8{ "keyword", "string" };
-    const buf = try encodeHighlightNames(std.testing.allocator, &names);
+    const buf = try encodeHighlightNames(std.testing.allocator, 3, &names);
     defer std.testing.allocator.free(buf);
 
     try std.testing.expectEqual(OP_HIGHLIGHT_NAMES, buf[0]);
-    try std.testing.expectEqual(@as(u16, 2), std.mem.readInt(u16, buf[1..3], .big));
+    try std.testing.expectEqual(@as(u32, 3), std.mem.readInt(u32, buf[1..5], .big)); // buffer_id
+    try std.testing.expectEqual(@as(u16, 2), std.mem.readInt(u16, buf[5..7], .big)); // count
     // "keyword" (7)
-    try std.testing.expectEqual(@as(u16, 7), std.mem.readInt(u16, buf[3..5], .big));
-    try std.testing.expectEqualStrings("keyword", buf[5..12]);
+    try std.testing.expectEqual(@as(u16, 7), std.mem.readInt(u16, buf[7..9], .big));
+    try std.testing.expectEqualStrings("keyword", buf[9..16]);
     // "string" (6)
-    try std.testing.expectEqual(@as(u16, 6), std.mem.readInt(u16, buf[12..14], .big));
-    try std.testing.expectEqualStrings("string", buf[14..20]);
+    try std.testing.expectEqual(@as(u16, 6), std.mem.readInt(u16, buf[16..18], .big));
+    try std.testing.expectEqualStrings("string", buf[18..24]);
 }
 
 test "encodeGrammarLoaded" {

--- a/zig/src/renderer.zig
+++ b/zig/src/renderer.zig
@@ -178,7 +178,7 @@ pub fn Renderer(comptime SurfaceT: type) type {
                 },
 
                 // edit_buffer, measure_text and highlight commands are handled by the event loop, not the renderer.
-                .noop, .edit_buffer, .measure_text, .set_language, .parse_buffer, .set_highlight_query, .set_injection_query, .set_fold_query, .set_indent_query, .request_indent, .set_textobject_query, .request_textobject, .load_grammar, .query_language_at => {},
+                .noop, .edit_buffer, .measure_text, .set_language, .parse_buffer, .set_highlight_query, .set_injection_query, .set_fold_query, .set_indent_query, .request_indent, .set_textobject_query, .request_textobject, .load_grammar, .query_language_at, .close_buffer => {},
             }
         }
 


### PR DESCRIPTION
# TL;DR

The tree-sitter parser process now supports multiple buffers simultaneously. Each buffer maintains its own parse tree, source mirror, and language assignment via protocol-level multiplexing with buffer IDs. Switching between buffers no longer destroys the other buffer's tree or triggers a full reparse.

Closes #660

## Context

Part of the tree-sitter epic (#659). This is the foundational infrastructure that unblocks agent chat markdown highlighting alongside code editing, split views with different languages, instant buffer switching without reparsing, and background tree updates when tools edit non-active files.

## Changes

**Protocol (Zig + Elixir):**
- Added `buffer_id:u32` to all 13 buffer-specific commands (`set_language`, `parse_buffer`, `edit_buffer`, all `set_*_query`, `request_*`) and all 5 response types (`highlight_spans`, `highlight_names`, `fold_ranges`, `injection_ranges`, `textobject_positions`)
- New `close_buffer` command (opcode `0x2D`) frees per-buffer state in the Zig parser

**Zig parser (`parser_main.zig`):**
- Replaced single `ParserState` with `BufferMap = HashMap(u32, BufferState)` where each entry owns its source, language name (allocated copy to avoid dangling pointers into the message buffer), and parse tree
- `activateBuffer`/`saveTreeToBuffer` pattern transfers tree ownership between the shared `Highlighter` and per-buffer state for each operation. This is the key design decision: the `TSParser` and query caches stay shared (they're stateless between parses), but each buffer's `TSTree` is independent
- Made `c` import pub in `highlighter.zig` so both files share the same tree-sitter C types (avoids Zig's opaque type incompatibility between separate `@cImport` calls)

**BEAM side:**
- `EditorState.Highlighting`: replaced `current`/`cache` split with a single `highlights: %{pid => Highlight.t()}` map. No more swap dance on buffer switch.
- Buffer ID scheme: monotonic `u32` via `ensure_buffer_id`, with bidirectional `buffer_ids`/`reverse_buffer_ids` maps for O(1) lookup in both directions
- Response routing: all five response types in `Editor.handle_info` resolve `buffer_id` to PID and route to the correct buffer's highlight entry (or discard stale responses for non-active buffers)
- `close_buffer` lifecycle: cleans up all state maps (`buffer_ids`, `reverse_buffer_ids`, `highlights`, `last_active_at`) when a buffer is killed
- LRU eviction: configurable via `:parser_tree_ttl` config option (default 300s). `evict_inactive/2` takes TTL via keyword opts (DI-friendly for tests). Periodic sweep every 60s. Active buffer and split-view buffers protected. Eviction computation separated from side effects.
- `TextObject` buffer_id threaded through the full call chain via `buffer_id_for` helper (no more hardcoded 0)
- Buffer focus refreshes LRU timestamp to prevent premature eviction of actively-viewed buffers

## Verification

```bash
# All tests pass
mix test                    # 5,340 tests, 0 failures
mix zig.lint                # zig fmt + zig build test
mix lint                    # format + credo + compile + dialyzer

# Multi-buffer integration tests specifically
mix test test/minga/parser/multi_buffer_test.exs     # 3 tests
mix test test/minga/editor/highlight_sync_eviction_test.exs  # 14 tests
```

## Acceptance Criteria Addressed

- Protocol includes buffer_id on all buffer-specific commands and responses ✅
- Zig parser maintains independent parse trees, source mirrors, and language per buffer ID ✅
- Multiple buffers with different languages can have active parse trees simultaneously ✅
- Incremental edits target a specific buffer without affecting others ✅
- BEAM-side routes responses by buffer_id ✅
- Buffer switching no longer triggers set_language + full reparse (when cached) ✅
- EditorState.Highlighting stores per buffer natively (no current/cache split) ✅
- Buffer can be removed from parser when closed ✅
- LRU eviction with configurable inactivity timeout ✅
- No regression in single-buffer highlighting ✅
- Existing tests pass; Zig tests pass ✅