### PR TITLE
fix(render): disable scroll region optimization to fix content corruption

### DIFF
--- a/lib/minga/editor/render_pipeline/emit.ex
+++ b/lib/minga/editor/render_pipeline/emit.ex
@@ -67,6 +67,24 @@ defmodule Minga.Editor.RenderPipeline.Emit do
 
   @spec detect_scroll_regions(state()) :: [scroll_delta()] | nil
   defp detect_scroll_regions(state) do
+    # Scroll region optimization disabled: the interaction between ANSI
+    # scroll regions, libvaxis internal buffer sync, and partial content
+    # redraws causes content corruption on shifted rows. Full redraw on
+    # every frame until this is properly debugged.
+    if scroll_optimization_enabled?() do
+      detect_scroll_regions_impl(state)
+    else
+      nil
+    end
+  end
+
+  # Kill switch for the scroll region optimization. Set to true to re-enable
+  # once the libvaxis buffer sync issue is resolved.
+  @spec scroll_optimization_enabled?() :: boolean()
+  defp scroll_optimization_enabled?, do: false
+
+  @spec detect_scroll_regions_impl(state()) :: [scroll_delta()] | nil
+  defp detect_scroll_regions_impl(state) do
     prev_tops = Process.get(:emit_prev_viewport_tops)
     prev_rects = Process.get(:emit_prev_content_rects)
     prev_gutter_ws = Process.get(:emit_prev_gutter_ws)

--- a/test/minga/editor/render_pipeline/emit_test.exs
+++ b/test/minga/editor/render_pipeline/emit_test.exs
@@ -56,6 +56,7 @@ defmodule Minga.Editor.RenderPipeline.EmitTest do
       :ok
     end
 
+    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
     test "uses scroll_region when viewport shifts by 1 line" do
       state = base_state(rows: 24, cols: 80, content: long_content(100))
 
@@ -79,6 +80,7 @@ defmodule Minga.Editor.RenderPipeline.EmitTest do
              end)
     end
 
+    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
     test "uses scroll_region when viewport shifts by 3 lines" do
       state = base_state(rows: 24, cols: 80, content: long_content(100))
 
@@ -134,6 +136,7 @@ defmodule Minga.Editor.RenderPipeline.EmitTest do
       assert [<<0x12>> | _] = commands
     end
 
+    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
     test "scroll_region uses negative delta for scrolling up" do
       state = base_state(rows: 24, cols: 80, content: long_content(100))
 
@@ -158,6 +161,7 @@ defmodule Minga.Editor.RenderPipeline.EmitTest do
       assert delta == -2
     end
 
+    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
     test "always includes batch_end in scroll region commands" do
       state = base_state(rows: 24, cols: 80, content: long_content(100))
 
@@ -175,6 +179,7 @@ defmodule Minga.Editor.RenderPipeline.EmitTest do
       assert <<0x13>> = List.last(commands)
     end
 
+    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
     test "always includes cursor commands in scroll region output" do
       state = base_state(rows: 24, cols: 80, content: long_content(100))
 


### PR DESCRIPTION
# TL;DR

Disables the scroll region optimization to fix content corruption when scrolling. Full redraw on every frame eliminates the garbled text, stale gutter numbers, and broken backgrounds.

Fixes a rendering bug visible on main.

## Context

The scroll region optimization sends ANSI scroll region sequences to shift terminal content, then only redraws newly revealed rows. This avoids full redraws for the common 1-3 line scroll case.

The optimization has a bug: shifted rows show corrupted content (fragments of different lines overlapping, wrong backgrounds). The root cause is in the interaction between ANSI scroll regions, libvaxis internal buffer sync (`syncScreenAfterScroll`), and partial content redraws. The exact failure mode needs deeper investigation.

## Changes

- `detect_scroll_regions/1` now checks a `scroll_optimization_enabled?/0` kill switch (hardcoded to `false`) before running the detection logic
- All scroll optimization infrastructure code is preserved in `detect_scroll_regions_impl/1` for future re-enablement
- 5 scroll optimization tests tagged with `@tag skip:` and a reason string

## Verification

```bash
mix test    # 5,340 tests, 0 failures, 5 skipped
mix lint    # clean
```

Manual: rebuild and scroll through any file. Content renders correctly on every scroll.