### PR TITLE
fix(agent): drain steering queue at AgentEnd to prevent lost messages

### DIFF
--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -946,18 +946,24 @@ defmodule Minga.Agent.Session do
         state
       end
 
-    case state.follow_up_queue do
+    # Collect pending messages from both queues. Steering messages that arrived
+    # after the last tool call (or just before AgentEnd) would otherwise be
+    # orphaned because dequeue_steering is only called between tool calls during
+    # an active agent loop. Merge them with follow-ups so nothing gets lost.
+    all_pending = state.steering_queue ++ state.follow_up_queue
+
+    case all_pending do
       [] ->
         set_status(state, :idle)
 
-      follow_ups ->
-        # Auto-send queued follow-up messages as a new turn. Combine all pending
-        # follow-ups into a single prompt so they arrive as one user message.
-        combined = combine_queue_entries_to_text(follow_ups)
+      pending ->
+        # Auto-send queued messages as a new turn. Combine all pending
+        # messages into a single prompt so they arrive as one user message.
+        combined = combine_queue_entries_to_text(pending)
         {user_msg, send_content} = build_user_message(combined)
 
         messages = state.messages ++ [user_msg]
-        state = %{state | messages: messages, follow_up_queue: []}
+        state = %{state | messages: messages, steering_queue: [], follow_up_queue: []}
         state = notify_messages_changed(state)
 
         case state.provider_module.send_prompt(state.provider, send_content) do

--- a/test/minga/agent/session_test.exs
+++ b/test/minga/agent/session_test.exs
@@ -709,6 +709,10 @@ defmodule Minga.Agent.SessionTest do
       assert steering == ["steer me"]
       assert follow_up == []
 
+      # Clear queues before proceeding so the auto-send doesn't trigger.
+      # The auto-send behaviour is covered by the "follow-up auto-send" tests.
+      Session.clear_queues(session)
+
       # Let the run finish
       SlowMockProvider.proceed(Session.get_provider(session))
 
@@ -724,6 +728,9 @@ defmodule Minga.Agent.SessionTest do
 
       {steering, _} = Session.get_queued_messages(session)
       assert steering == ["steer 1", "steer 2"]
+
+      # Clear queues before proceeding so the auto-send doesn't trigger.
+      Session.clear_queues(session)
 
       SlowMockProvider.proceed(Session.get_provider(session))
       assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
@@ -914,6 +921,75 @@ defmodule Minga.Agent.SessionTest do
       assert :ok = Session.send_prompt(session, "simple")
       assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
 
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+
+    test "queued steering messages are auto-sent when agent finishes", %{slow_session: session} do
+      assert :ok = Session.send_prompt(session, "first")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      # Queue a steering message (this is what happens when a user sends a prompt
+      # while the agent is busy)
+      assert {:queued, :steering} = Session.send_prompt(session, "steering msg")
+
+      # Complete the first run. The steering message should be auto-sent as a new
+      # turn instead of being orphaned.
+      SlowMockProvider.proceed(Session.get_provider(session))
+
+      # Session should start a new turn (not go idle) because the steering queue
+      # had a pending message.
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      # Steering message should appear in conversation history
+      messages = Session.messages(session)
+      assert Enum.any?(messages, &match?({:user, "steering msg"}, &1))
+
+      # Steering queue should be cleared
+      {steering, _} = Session.get_queued_messages(session)
+      assert steering == []
+
+      # Complete the follow-up run
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+
+    test "mixed steering and follow-up messages are combined at AgentEnd", %{
+      slow_session: session
+    } do
+      assert :ok = Session.send_prompt(session, "first")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      # Queue both types
+      assert {:queued, :steering} = Session.send_prompt(session, "steer this")
+      assert {:queued, :follow_up} = Session.queue_follow_up(session, "and follow up")
+
+      # Complete the first run. Both messages should be combined into one prompt.
+      SlowMockProvider.proceed(Session.get_provider(session))
+
+      # Should start a new turn
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      # Both queues should be cleared
+      {steering, follow_up} = Session.get_queued_messages(session)
+      assert steering == []
+      assert follow_up == []
+
+      # Both messages should appear in the combined user message
+      messages = Session.messages(session)
+
+      combined_msg =
+        Enum.find(messages, fn
+          {:user, text} ->
+            String.contains?(text, "steer this") and String.contains?(text, "and follow up")
+
+          _ ->
+            false
+        end)
+
+      assert combined_msg != nil
+
+      # Complete the second run
       SlowMockProvider.proceed(Session.get_provider(session))
       assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
     end


### PR DESCRIPTION
# TL;DR
Messages sent just as the agent finishes streaming were silently lost. The `AgentEnd` handler now drains both the steering and follow-up queues, so no queued message is orphaned.

## Context
When a user sends a message while the agent is in `:thinking` status, it gets queued as a "steering" message (intended for injection between tool calls). If the agent finishes its loop before the provider can call `dequeue_steering`, the message stays in the queue forever. The `AgentEnd` handler only checked `follow_up_queue`, so steering messages were never picked up.

## Changes
- **`lib/minga/agent/session.ex`**: The `AgentEnd` handler now merges `steering_queue ++ follow_up_queue` into a single `all_pending` list before deciding whether to go idle or start a new turn. Both queues are cleared when the combined message is sent. This is a two-line root-cause fix, not a workaround.
- **`test/minga/agent/session_test.exs`**: Added two new tests ("queued steering messages are auto-sent when agent finishes" and "mixed steering and follow-up messages are combined at AgentEnd"). Updated two existing tests to clear queues before proceeding, since they were testing queueing mechanics rather than auto-send behavior.

## Verification
```bash
mix test test/minga/agent/session_test.exs    # 53 tests, 0 failures
mix test                                       # 5342 tests, 0 failures
```

To reproduce the original bug (on `main`): open the agent panel, send a prompt, then quickly type and submit a second message as the agent finishes streaming. The second message vanishes. On this branch, it triggers a new agent turn.

## Acceptance Criteria Addressed
- Messages sent while the agent is finishing are not lost ✅
- Orphaned steering messages at AgentEnd are auto-sent as a new turn ✅
- Mixed steering + follow-up messages are both delivered ✅
- Existing behavior (follow-up auto-send, normal idle transition) does not regress ✅