### PR TITLE
fix(agent): render tool approval prompt that was never displayed

### DIFF
--- a/lib/minga/agent/chat_decorations.ex
+++ b/lib/minga/agent/chat_decorations.ex
@@ -45,6 +45,7 @@ defmodule Minga.Agent.ChatDecorations do
         ) :: Decorations.t()
   def build_decorations(decs, messages, line_offsets, theme, opts \\ []) do
     streaming = Keyword.get(opts, :streaming, false)
+    pending_approval = Keyword.get(opts, :pending_approval)
     offset_map = Map.new(line_offsets, fn {idx, start, count} -> {idx, {start, count}} end)
 
     last_idx = length(messages) - 1
@@ -56,7 +57,16 @@ defmodule Minga.Agent.ChatDecorations do
         {start_line, line_count} ->
           log_decoration(msg, idx, start_line, line_count)
           is_last = idx == last_idx
-          apply_message_decorations(d, msg, start_line, line_count, theme, streaming and is_last)
+
+          apply_message_decorations(
+            d,
+            msg,
+            start_line,
+            line_count,
+            theme,
+            streaming and is_last,
+            pending_approval
+          )
 
         nil ->
           Minga.Log.warning(:agent, "[chat_decs] no offset for msg idx=#{idx}")
@@ -87,16 +97,33 @@ defmodule Minga.Agent.ChatDecorations do
          line,
          line_count,
          theme,
-         _streaming
+         _streaming,
+         _pending_approval
        ) do
     apply_user_decorations(decs, line, line_count, theme)
   end
 
-  defp apply_message_decorations(decs, {:user, _text}, line, line_count, theme, _streaming) do
+  defp apply_message_decorations(
+         decs,
+         {:user, _text},
+         line,
+         line_count,
+         theme,
+         _streaming,
+         _pending_approval
+       ) do
     apply_user_decorations(decs, line, line_count, theme)
   end
 
-  defp apply_message_decorations(decs, {:assistant, text}, line, line_count, theme, streaming) do
+  defp apply_message_decorations(
+         decs,
+         {:assistant, text},
+         line,
+         line_count,
+         theme,
+         streaming,
+         _pending_approval
+       ) do
     {_id, decs} =
       Decorations.add_block_decoration(decs, line,
         placement: :above,
@@ -135,7 +162,8 @@ defmodule Minga.Agent.ChatDecorations do
          line,
          line_count,
          theme,
-         _streaming
+         _streaming,
+         _pending_approval
        ) do
     # Header
     {_id, decs} =
@@ -187,20 +215,100 @@ defmodule Minga.Agent.ChatDecorations do
     decs
   end
 
-  defp apply_message_decorations(decs, {:tool_call, tc}, line, line_count, theme, _streaming) do
-    status_icon =
-      case tc.status do
-        :running -> "⟳"
-        :complete -> "✓"
-        :error -> "✗"
-      end
+  defp apply_message_decorations(
+         decs,
+         {:tool_call, tc},
+         line,
+         line_count,
+         theme,
+         _streaming,
+         pending_approval
+       ) do
+    awaiting_approval = tool_awaiting_approval?(tc, pending_approval)
+    apply_tool_call_decorations(decs, tc, line, line_count, theme, awaiting_approval)
+  end
 
-    status_fg =
-      case tc.status do
-        :running -> theme.status_tool
-        :complete -> theme.tool_header
-        :error -> theme.status_error
-      end
+  defp apply_message_decorations(
+         decs,
+         {:usage, _usage},
+         line,
+         line_count,
+         theme,
+         _streaming,
+         _pending_approval
+       ) do
+    # Dim the usage stats line
+    {_id, decs} =
+      Decorations.add_highlight(decs, {line, 0}, {line + line_count, 0},
+        style: [fg: theme.usage_fg],
+        priority: 10,
+        group: :chat_usage
+      )
+
+    decs
+  end
+
+  defp apply_message_decorations(
+         decs,
+         {:system, _text, level},
+         line,
+         line_count,
+         theme,
+         _streaming,
+         _pending_approval
+       ) do
+    label_fg = if level == :error, do: theme.status_error, else: theme.system_fg
+
+    {_id, decs} =
+      Decorations.add_block_decoration(decs, line,
+        placement: :above,
+        render: fn _w ->
+          [{"System", [fg: label_fg, bold: true, bg: theme.header_bg]}]
+        end,
+        priority: 5
+      )
+
+    # Dim the system message text
+    {_id, decs} =
+      Decorations.add_highlight(decs, {line, 0}, {line + line_count, 0},
+        style: [fg: theme.system_fg],
+        priority: 5,
+        group: :chat_system
+      )
+
+    decs
+  end
+
+  defp apply_message_decorations(
+         decs,
+         _other,
+         _line,
+         _line_count,
+         _theme,
+         _streaming,
+         _pending_approval
+       ),
+       do: decs
+
+  # ── Tool call decorations ────────────────────────────────────────────────────
+
+  @spec tool_awaiting_approval?(map(), map() | nil) :: boolean()
+  defp tool_awaiting_approval?(_tc, nil), do: false
+
+  defp tool_awaiting_approval?(tc, approval) when is_map(approval) do
+    Map.get(approval, :tool_call_id) == tc.id
+  end
+
+  @spec apply_tool_call_decorations(
+          Decorations.t(),
+          map(),
+          non_neg_integer(),
+          non_neg_integer(),
+          Minga.Theme.Agent.t(),
+          boolean()
+        ) :: Decorations.t()
+  defp apply_tool_call_decorations(decs, tc, line, line_count, theme, awaiting_approval) do
+    {status_icon, status_fg} = tool_status_display(tc, theme, awaiting_approval)
 
     has_result = tc.result != ""
 
@@ -209,13 +317,11 @@ defmodule Minga.Agent.ChatDecorations do
     command_text = format_tool_command(tc)
     header_text = "┌─ #{status_icon} #{tc.name}#{duration_text}#{command_text}"
 
-    # Block decoration: tool header
+    # Block decoration: tool header (with approval prompt when awaiting)
     {_id, decs} =
       Decorations.add_block_decoration(decs, line,
         placement: :above,
-        render: fn _w ->
-          [{header_text, [fg: status_fg, bold: true]}]
-        end,
+        render: tool_header_render(header_text, status_fg, theme, awaiting_approval),
         priority: 5
       )
 
@@ -254,58 +360,50 @@ defmodule Minga.Agent.ChatDecorations do
     {_id, decs} =
       Decorations.add_block_decoration(decs, last_line,
         placement: :below,
-        render: fn _w ->
-          [{"└─", [fg: status_fg]}]
-        end,
+        render: fn _w -> [{"└─", [fg: status_fg]}] end,
         priority: 5
       )
 
     decs
   end
 
-  defp apply_message_decorations(decs, {:usage, _usage}, line, line_count, theme, _streaming) do
-    # Dim the usage stats line
-    {_id, decs} =
-      Decorations.add_highlight(decs, {line, 0}, {line + line_count, 0},
-        style: [fg: theme.usage_fg],
-        priority: 10,
-        group: :chat_usage
-      )
-
-    decs
+  @spec tool_status_display(map(), Minga.Theme.Agent.t(), boolean()) ::
+          {String.t(), non_neg_integer()}
+  defp tool_status_display(_tc, theme, true = _awaiting) do
+    {"?", theme.status_thinking}
   end
 
-  defp apply_message_decorations(
-         decs,
-         {:system, _text, level},
-         line,
-         line_count,
-         theme,
-         _streaming
-       ) do
-    label_fg = if level == :error, do: theme.status_error, else: theme.system_fg
-
-    {_id, decs} =
-      Decorations.add_block_decoration(decs, line,
-        placement: :above,
-        render: fn _w ->
-          [{"System", [fg: label_fg, bold: true, bg: theme.header_bg]}]
-        end,
-        priority: 5
-      )
-
-    # Dim the system message text
-    {_id, decs} =
-      Decorations.add_highlight(decs, {line, 0}, {line + line_count, 0},
-        style: [fg: theme.system_fg],
-        priority: 5,
-        group: :chat_system
-      )
-
-    decs
+  defp tool_status_display(tc, theme, false) do
+    case tc.status do
+      :running -> {"⟳", theme.status_tool}
+      :complete -> {"✓", theme.tool_header}
+      :error -> {"✗", theme.status_error}
+    end
   end
 
-  defp apply_message_decorations(decs, _other, _line, _line_count, _theme, _streaming), do: decs
+  @spec tool_header_render(String.t(), non_neg_integer(), Minga.Theme.Agent.t(), boolean()) ::
+          (non_neg_integer() -> [{String.t(), keyword()}])
+  defp tool_header_render(header_text, status_fg, theme, true = _awaiting) do
+    fn _w ->
+      [
+        {header_text, [fg: status_fg, bold: true]},
+        {" ", []},
+        {"Approve? ", [fg: status_fg, bold: true]},
+        {"[y]", [fg: theme.tool_header, bold: true]},
+        {"es ", [fg: status_fg]},
+        {"[n]", [fg: theme.status_error, bold: true]},
+        {"o ", [fg: status_fg]},
+        {"[Y]", [fg: theme.tool_header, bold: true]},
+        {"es-all", [fg: status_fg]}
+      ]
+    end
+  end
+
+  defp tool_header_render(header_text, status_fg, _theme, false) do
+    fn _w ->
+      [{header_text, [fg: status_fg, bold: true]}]
+    end
+  end
 
   # ── Markdown delimiter dimming ──────────────────────────────────────────────
 

--- a/lib/minga/agent/events.ex
+++ b/lib/minga/agent/events.ex
@@ -170,12 +170,18 @@ defmodule Minga.Agent.Events do
   def handle(state, {:approval_pending, approval}) do
     cached = Map.take(approval, [:tool_call_id, :name, :args])
     state = AgentAccess.update_agent(state, &AgentState.set_pending_approval(&1, cached))
-    {state, [:render]}
+
+    # Unfocus the prompt input so the ToolApproval input handler can
+    # intercept y/n keys. The user needs to see and respond to the
+    # approval prompt, not keep typing in the input field.
+    state = AgentAccess.update_agent_ui(state, &UIState.set_input_focused(&1, false))
+
+    {state, [:render, :sync_agent_buffer]}
   end
 
   def handle(state, {:approval_resolved, _decision}) do
     state = AgentAccess.update_agent(state, &AgentState.clear_pending_approval/1)
-    {state, [{:render, 16}]}
+    {state, [{:render, 16}, :sync_agent_buffer]}
   end
 
   def handle(state, {:error, message}) do

--- a/lib/minga/editor/agent_lifecycle.ex
+++ b/lib/minga/editor/agent_lifecycle.ex
@@ -113,7 +113,14 @@ defmodule Minga.Editor.AgentLifecycle do
   defp sync_buffer_content(state, _buffer, []), do: state
 
   defp sync_buffer_content(state, buffer, messages) do
-    line_index = AgentBufferSync.sync(buffer, messages)
+    # Pass pending_approval to the sync pipeline so ChatDecorations can
+    # render an approval prompt on the matching tool call.
+    agent = AgentAccess.agent(state)
+
+    sync_opts =
+      if agent.pending_approval, do: [pending_approval: agent.pending_approval], else: []
+
+    line_index = AgentBufferSync.sync(buffer, messages, sync_opts)
 
     # Cache the line index in the panel state so callers (scroll_context,
     # code_block_index_for_scroll) can read it without recomputing.

--- a/test/minga/agent/chat_decorations_test.exs
+++ b/test/minga/agent/chat_decorations_test.exs
@@ -82,6 +82,56 @@ defmodule Minga.Agent.ChatDecorationsTest do
       refute Decorations.has_fold_regions?(result)
     end
 
+    test "tool call awaiting approval shows approval prompt in header" do
+      tc = %{id: "tc_123", name: "write_file", status: :running, result: "", collapsed: false}
+      decs = Decorations.new()
+      messages = [{:tool_call, tc}]
+      offsets = [{0, 0, 1}]
+
+      pending_approval = %{tool_call_id: "tc_123", name: "write_file", args: %{}}
+
+      result =
+        ChatDecorations.build_decorations(decs, messages, offsets, test_theme(),
+          pending_approval: pending_approval
+        )
+
+      # Header block decoration should contain approval prompt text
+      {above, _below} = Decorations.blocks_for_line(result, 0)
+      assert length(above) == 1
+
+      [block_dec] = above
+      rendered = block_dec.render.(80)
+
+      # The rendered output should contain the approval prompt segments
+      rendered_text = Enum.map_join(rendered, "", fn {text, _style} -> text end)
+      assert rendered_text =~ "Approve?"
+      assert rendered_text =~ "[y]"
+      assert rendered_text =~ "[n]"
+    end
+
+    test "tool call without matching approval shows normal header" do
+      tc = %{id: "tc_456", name: "read_file", status: :running, result: "", collapsed: false}
+      decs = Decorations.new()
+      messages = [{:tool_call, tc}]
+      offsets = [{0, 0, 1}]
+
+      # Different tool_call_id, should not show approval
+      pending_approval = %{tool_call_id: "tc_999", name: "other_tool", args: %{}}
+
+      result =
+        ChatDecorations.build_decorations(decs, messages, offsets, test_theme(),
+          pending_approval: pending_approval
+        )
+
+      {above, _below} = Decorations.blocks_for_line(result, 0)
+      assert length(above) == 1
+
+      [block_dec] = above
+      rendered = block_dec.render.(80)
+      rendered_text = Enum.map_join(rendered, "", fn {text, _style} -> text end)
+      refute rendered_text =~ "Approve?"
+    end
+
     test "multiple messages get independent decorations" do
       decs = Decorations.new()
 

--- a/test/minga/editor/state/event_routing_test.exs
+++ b/test/minga/editor/state/event_routing_test.exs
@@ -142,17 +142,33 @@ defmodule Minga.Editor.State.EventRoutingTest do
              }
 
       assert :render in effects
+      assert :sync_agent_buffer in effects
     end
 
-    test "approval_resolved clears pending approval" do
+    test "approval_pending unfocuses the prompt input" do
+      %{state: state} = make_state()
+
+      # Simulate the user typing in the prompt (input focused)
+      state = AgentAccess.update_agent_ui(state, &UIState.set_input_focused(&1, true))
+      assert AgentAccess.input_focused?(state)
+
+      approval = %{tool_call_id: "456", name: "write_file", args: %{}}
+      {new_state, _effects} = AgentEvents.handle(state, {:approval_pending, approval})
+
+      # Input must be unfocused so the ToolApproval handler can intercept y/n
+      refute AgentAccess.input_focused?(new_state)
+    end
+
+    test "approval_resolved clears pending approval and syncs buffer" do
       %{state: state} = make_state()
 
       state =
         AgentAccess.update_agent(state, &AgentState.set_pending_approval(&1, %{name: "shell"}))
 
-      {new_state, _effects} = AgentEvents.handle(state, {:approval_resolved, :approved})
+      {new_state, effects} = AgentEvents.handle(state, {:approval_resolved, :approved})
 
       assert AgentAccess.agent(new_state).pending_approval == nil
+      assert :sync_agent_buffer in effects
     end
   end
 


### PR DESCRIPTION
## Problem

Destructive tools (`write_file`, `edit_file`, `shell`, etc.) appeared to hang when the agent used them. The tool call showed a spinner with no indication the user needed to approve it.

**Root cause:** `pending_approval` was tracked in state but never wired to any visual output. The approval prompt was simply never rendered.

## Fix

- Thread `pending_approval` from editor state through the sync pipeline (`agent_lifecycle` → `buffer_sync` → `ChatDecorations`) via opts
- Render approval prompt inline on the tool call header decoration: `? write_file Approve? [y]es [n]o [Y]es-all`
- Auto-unfocus the prompt input when an approval arrives so the `ToolApproval` input handler can intercept y/n keys immediately
- Trigger `sync_agent_buffer` on both `approval_pending` and `approval_resolved` events so decorations update correctly
- Extract tool call decoration logic into helper functions to keep cyclomatic complexity within credo limits

## Tests

- Approval prompt renders on matching tool call header
- Non-matching tool call shows normal header
- `approval_pending` event unfocuses prompt input
- `approval_resolved` event includes `sync_agent_buffer` effect

All 820 agent tests + 18 event routing tests pass.