### PR TITLE
feat(buffer): add conceal decoration primitive

### DIFF
--- a/lib/minga/buffer/decorations.ex
+++ b/lib/minga/buffer/decorations.ex
@@ -38,6 +38,7 @@ defmodule Minga.Buffer.Decorations do
   """
 
   alias Minga.Buffer.Decorations.BlockDecoration
+  alias Minga.Buffer.Decorations.ConcealRange
   alias Minga.Buffer.Decorations.FoldRegion
   alias Minga.Buffer.Decorations.HighlightRange
   alias Minga.Buffer.Decorations.VirtualText
@@ -74,6 +75,7 @@ defmodule Minga.Buffer.Decorations do
   - `virtual_texts`: list of virtual text decorations (queried by line, not range)
   - `fold_regions`: list of buffer-level fold regions (per-buffer, not per-window)
   - `block_decorations`: list of block decorations (custom-rendered lines between buffer lines)
+  - `conceal_ranges`: list of conceal ranges (hidden buffer text with optional replacement)
   - `pending`: list of pending operations during a batch (nil when not batching)
   - `version`: monotonically increasing version for change detection by the render pipeline
   """
@@ -82,6 +84,7 @@ defmodule Minga.Buffer.Decorations do
           virtual_texts: [VirtualText.t()],
           fold_regions: [FoldRegion.t()],
           block_decorations: [BlockDecoration.t()],
+          conceal_ranges: [ConcealRange.t()],
           pending:
             [{:add, highlight_range()} | {:remove, reference()} | {:remove_group, atom()}] | nil,
           version: non_neg_integer()
@@ -92,6 +95,7 @@ defmodule Minga.Buffer.Decorations do
             virtual_texts: [],
             fold_regions: [],
             block_decorations: [],
+            conceal_ranges: [],
             pending: nil,
             version: 0
 
@@ -468,21 +472,124 @@ defmodule Minga.Buffer.Decorations do
     Enum.find(blocks, fn b -> b.id == id end)
   end
 
-  # ── Column mapping (inline virtual text) ─────────────────────────────────
+  # ── Conceal range API ─────────────────────────────────────────────────────
+
+  @doc """
+  Adds a conceal range. Returns `{id, updated_decorations}`.
+
+  Concealed text is hidden from the display without modifying the buffer.
+  When a replacement string is provided, the entire concealed range is
+  shown as that single replacement character.
+
+  ## Options
+
+  - `:replacement` (optional) - string to show in place of concealed text (nil = invisible)
+  - `:replacement_style` (optional) - style keyword list for the replacement character
+  - `:priority` (optional, default 0) - higher values take precedence on overlap
+  - `:group` (optional) - atom for bulk removal (e.g., `:markdown`, `:agent`)
+
+  ## Examples
+
+      {id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+      {id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2},
+        replacement: "·",
+        group: :markdown
+      )
+  """
+  @spec add_conceal(t(), IntervalTree.position(), IntervalTree.position(), keyword()) ::
+          {reference(), t()}
+  def add_conceal(%__MODULE__{} = decs, start_pos, end_pos, opts \\ []) do
+    id = make_ref()
+
+    range = %ConcealRange{
+      id: id,
+      start_pos: start_pos,
+      end_pos: end_pos,
+      replacement: Keyword.get(opts, :replacement),
+      replacement_style: Keyword.get(opts, :replacement_style, []),
+      priority: Keyword.get(opts, :priority, 0),
+      group: Keyword.get(opts, :group)
+    }
+
+    {id, %{decs | conceal_ranges: [range | decs.conceal_ranges], version: decs.version + 1}}
+  end
+
+  @doc "Removes a conceal range by ID."
+  @spec remove_conceal(t(), reference()) :: t()
+  def remove_conceal(%__MODULE__{} = decs, id) do
+    new_conceals = Enum.reject(decs.conceal_ranges, fn c -> c.id == id end)
+
+    if length(new_conceals) == length(decs.conceal_ranges) do
+      decs
+    else
+      %{decs | conceal_ranges: new_conceals, version: decs.version + 1}
+    end
+  end
+
+  @doc "Removes all conceal ranges belonging to a group."
+  @spec remove_conceal_group(t(), atom()) :: t()
+  def remove_conceal_group(%__MODULE__{} = decs, group) when is_atom(group) do
+    new_conceals = Enum.reject(decs.conceal_ranges, fn c -> c.group == group end)
+
+    if length(new_conceals) == length(decs.conceal_ranges) do
+      decs
+    else
+      %{decs | conceal_ranges: new_conceals, version: decs.version + 1}
+    end
+  end
+
+  @doc "Returns true if there are any conceal ranges."
+  @spec has_conceal_ranges?(t()) :: boolean()
+  def has_conceal_ranges?(%__MODULE__{conceal_ranges: []}), do: false
+  def has_conceal_ranges?(%__MODULE__{}), do: true
+
+  @doc """
+  Returns conceal ranges that intersect the given line, sorted by start column.
+
+  Used by the rendering pipeline to know which graphemes to skip during
+  the line rendering walk.
+  """
+  @spec conceals_for_line(t(), non_neg_integer()) :: [ConcealRange.t()]
+  def conceals_for_line(%__MODULE__{conceal_ranges: []}, _line), do: []
+
+  def conceals_for_line(%__MODULE__{conceal_ranges: ranges}, line) do
+    ranges
+    |> Enum.filter(fn c -> ConcealRange.spans_line?(c, line) end)
+    |> Enum.sort_by(fn %ConcealRange{start_pos: {sl, sc}} ->
+      if sl < line, do: 0, else: sc
+    end)
+  end
+
+  # ── Column mapping (inline virtual text + conceals) ──────────────────────
 
   @doc """
   Converts a buffer column to a display column on the given line,
-  accounting for inline virtual text that shifts content rightward.
+  accounting for inline virtual text that shifts content rightward
+  and conceal ranges that reduce display width.
 
   Virtual texts anchored at or before `buf_col` add their display width
-  to the result. Virtual texts after `buf_col` don't affect it.
+  to the result. Conceal ranges before `buf_col` subtract their concealed
+  width and add replacement width (0 or 1). Virtual texts after `buf_col`
+  don't affect it.
   """
   @spec buf_col_to_display_col(t(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
-  def buf_col_to_display_col(%__MODULE__{virtual_texts: []}, _line, buf_col), do: buf_col
+  def buf_col_to_display_col(
+        %__MODULE__{virtual_texts: [], conceal_ranges: []} = _decs,
+        _line,
+        buf_col
+      ),
+      do: buf_col
 
   def buf_col_to_display_col(%__MODULE__{} = decs, line, buf_col) do
+    display_col = buf_col
+
+    # Add virtual text widths
     inline_vts = inline_virtual_texts_for_line(decs, line)
-    add_virtual_widths(inline_vts, buf_col)
+    display_col = add_virtual_widths(inline_vts, display_col)
+
+    # Subtract conceal widths
+    conceals = conceals_for_line(decs, line)
+    apply_conceal_offset_to_display(conceals, line, buf_col, display_col)
   end
 
   @doc """
@@ -494,11 +601,21 @@ defmodule Minga.Buffer.Decorations do
   display column that may be offset by virtual text.
   """
   @spec display_col_to_buf_col(t(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
-  def display_col_to_buf_col(%__MODULE__{virtual_texts: []}, _line, display_col), do: display_col
+  def display_col_to_buf_col(
+        %__MODULE__{virtual_texts: [], conceal_ranges: []},
+        _line,
+        display_col
+      ),
+      do: display_col
 
   def display_col_to_buf_col(%__MODULE__{} = decs, line, display_col) do
     inline_vts = inline_virtual_texts_for_line(decs, line)
-    subtract_virtual_widths(inline_vts, display_col)
+    buf_col = subtract_virtual_widths(inline_vts, display_col)
+
+    # Reverse the conceal offset: a display col maps to a higher buf col
+    # because concealed characters don't appear on screen.
+    conceals = conceals_for_line(decs, line)
+    apply_conceal_offset_to_buf(conceals, line, buf_col)
   end
 
   @spec add_virtual_widths([VirtualText.t()], non_neg_integer()) :: non_neg_integer()
@@ -558,6 +675,67 @@ defmodule Minga.Buffer.Decorations do
       # Click is past this virtual text: accumulate its width
       {:cont, {vt_width_sum + vt_w, nil}}
     end
+  end
+
+  # ── Conceal column offset helpers ──────────────────────────────────────────
+
+  # Adjusts a display column by subtracting the width of concealed ranges
+  # that fall before the given buffer column. Each conceal range reduces
+  # display width by (concealed_width - replacement_width).
+  @spec apply_conceal_offset_to_display(
+          [ConcealRange.t()],
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: non_neg_integer()
+  defp apply_conceal_offset_to_display([], _line, _buf_col, display_col), do: display_col
+
+  defp apply_conceal_offset_to_display(conceals, line, buf_col, display_col) do
+    Enum.reduce(conceals, display_col, fn conceal, acc ->
+      {_sl, sc} = conceal.start_pos
+      {el, ec} = conceal.end_pos
+      conceal_start = if elem(conceal.start_pos, 0) < line, do: 0, else: sc
+      conceal_end = if el > line, do: buf_col, else: ec
+
+      if conceal_start < buf_col do
+        # How much of this conceal is before our buf_col?
+        effective_end = min(conceal_end, buf_col)
+        concealed_width = max(effective_end - conceal_start, 0)
+        replacement_width = ConcealRange.display_width(conceal)
+        acc - concealed_width + replacement_width
+      else
+        acc
+      end
+    end)
+  end
+
+  # Inverse of apply_conceal_offset_to_display: given a buf_col that was
+  # derived from a display_col (after removing VT offsets), add back the
+  # concealed widths to find the true buffer column.
+  @spec apply_conceal_offset_to_buf([ConcealRange.t()], non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  defp apply_conceal_offset_to_buf([], _line, buf_col), do: buf_col
+
+  defp apply_conceal_offset_to_buf(conceals, line, buf_col) do
+    # Walk through conceals in order. Each conceal at or before the current
+    # position shifts the buffer column forward by the concealed width
+    # minus the replacement width. We use <= because a display_col that
+    # lands where a conceal starts means the first visible character after
+    # the conceal.
+    Enum.reduce(conceals, buf_col, fn conceal, acc ->
+      {_sl, sc} = conceal.start_pos
+      {el, ec} = conceal.end_pos
+      conceal_start = if elem(conceal.start_pos, 0) < line, do: 0, else: sc
+      conceal_end = if el > line, do: acc, else: ec
+
+      if conceal_start <= acc do
+        concealed_width = max(conceal_end - conceal_start, 0)
+        replacement_width = ConcealRange.display_width(conceal)
+        acc + concealed_width - replacement_width
+      else
+        acc
+      end
+    end)
   end
 
   # ── Batch operations ─────────────────────────────────────────────────────
@@ -663,7 +841,8 @@ defmodule Minga.Buffer.Decorations do
         highlights: nil,
         virtual_texts: [],
         fold_regions: [],
-        block_decorations: []
+        block_decorations: [],
+        conceal_ranges: []
       }),
       do: true
 
@@ -671,9 +850,11 @@ defmodule Minga.Buffer.Decorations do
         highlights: hl,
         virtual_texts: vts,
         fold_regions: folds,
-        block_decorations: blocks
+        block_decorations: blocks,
+        conceal_ranges: conceals
       }) do
-    (hl == nil or IntervalTree.empty?(hl)) and vts == [] and folds == [] and blocks == []
+    (hl == nil or IntervalTree.empty?(hl)) and vts == [] and folds == [] and blocks == [] and
+      conceals == []
   end
 
   # ── Anchor adjustment ───────────────────────────────────────────────────
@@ -702,7 +883,7 @@ defmodule Minga.Buffer.Decorations do
         ) :: t()
   def adjust_for_edit(%__MODULE__{} = decs, _edit_start, _edit_end, _new_end)
       when decs.highlights == nil and decs.virtual_texts == [] and decs.fold_regions == [] and
-             decs.block_decorations == [],
+             decs.block_decorations == [] and decs.conceal_ranges == [],
       do: decs
 
   def adjust_for_edit(%__MODULE__{} = decs, edit_start, edit_end, new_end) do
@@ -726,6 +907,7 @@ defmodule Minga.Buffer.Decorations do
     new_folds = adjust_fold_regions(decs.fold_regions, ctx)
 
     new_blocks = adjust_block_decorations(decs.block_decorations, ctx)
+    new_conceals = adjust_conceal_ranges(decs.conceal_ranges, ctx)
 
     %{
       decs
@@ -733,6 +915,7 @@ defmodule Minga.Buffer.Decorations do
         virtual_texts: new_vts,
         fold_regions: new_folds,
         block_decorations: new_blocks,
+        conceal_ranges: new_conceals,
         version: decs.version + 1
     }
   end
@@ -759,6 +942,67 @@ defmodule Minga.Buffer.Decorations do
   end
 
   defp adjust_anchor_position(_anchor, ctx), do: ctx.new_end
+
+  @spec adjust_conceal_ranges([ConcealRange.t()], edit_ctx()) :: [ConcealRange.t()]
+  defp adjust_conceal_ranges([], _ctx), do: []
+
+  defp adjust_conceal_ranges(conceals, ctx) do
+    Enum.reduce(conceals, [], fn conceal, acc ->
+      case adjust_conceal_range(conceal, ctx) do
+        nil -> acc
+        adjusted -> [adjusted | acc]
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  @spec adjust_conceal_range(ConcealRange.t(), edit_ctx()) :: ConcealRange.t() | nil
+  defp adjust_conceal_range(%ConcealRange{start_pos: start_pos, end_pos: end_pos} = conceal, ctx) do
+    # Entirely before the edit: no change
+    if end_pos <= ctx.edit_start do
+      conceal
+    else
+      if start_pos >= ctx.edit_end do
+        # Entirely after the edit: shift both endpoints
+        new_start = shift_position(start_pos, ctx.edit_end, ctx.line_delta, ctx.col_delta)
+        new_end = shift_position(end_pos, ctx.edit_end, ctx.line_delta, ctx.col_delta)
+        %{conceal | start_pos: new_start, end_pos: new_end}
+      else
+        adjust_conceal_overlap(conceal, ctx)
+      end
+    end
+  end
+
+  # Edit overlaps the conceal range: dispatch to multi-clause handler
+  @spec adjust_conceal_overlap(ConcealRange.t(), edit_ctx()) :: ConcealRange.t() | nil
+
+  # Edit spans entire range: remove
+  defp adjust_conceal_overlap(%ConcealRange{start_pos: sp, end_pos: ep}, ctx)
+       when ctx.edit_start <= sp and ctx.edit_end >= ep do
+    nil
+  end
+
+  # Edit overlaps start: shrink from left
+  defp adjust_conceal_overlap(%ConcealRange{start_pos: sp, end_pos: ep} = conceal, ctx)
+       when ctx.edit_start <= sp do
+    new_end = shift_position(ep, ctx.edit_end, ctx.line_delta, ctx.col_delta)
+
+    if ctx.edit_start >= new_end,
+      do: nil,
+      else: %{conceal | start_pos: ctx.edit_start, end_pos: new_end}
+  end
+
+  # Edit overlaps end: shrink from right
+  defp adjust_conceal_overlap(%ConcealRange{start_pos: sp, end_pos: ep} = conceal, ctx)
+       when ctx.edit_end >= ep do
+    if sp >= ctx.edit_start, do: nil, else: %{conceal | end_pos: ctx.edit_start}
+  end
+
+  # Edit entirely within range: adjust end
+  defp adjust_conceal_overlap(%ConcealRange{end_pos: ep} = conceal, ctx) do
+    new_end = shift_position(ep, ctx.edit_end, ctx.line_delta, ctx.col_delta)
+    %{conceal | end_pos: new_end}
+  end
 
   @spec adjust_fold_regions([FoldRegion.t()], edit_ctx()) :: [FoldRegion.t()]
   @spec adjust_block_decorations([BlockDecoration.t()], edit_ctx()) :: [BlockDecoration.t()]

--- a/lib/minga/buffer/decorations/conceal_range.ex
+++ b/lib/minga/buffer/decorations/conceal_range.ex
@@ -1,0 +1,104 @@
+defmodule Minga.Buffer.Decorations.ConcealRange do
+  @moduledoc """
+  A conceal range decoration: hides buffer characters from the display
+  without removing them from the buffer.
+
+  Concealed text occupies zero display columns (or one column if a
+  replacement character is specified). The buffer content is never
+  modified; `BufferServer.content/1` always returns the raw text
+  including concealed characters.
+
+  ## Replacement character
+
+  When `replacement` is nil, the concealed range is invisible. When
+  `replacement` is a string (typically a single character like "·"),
+  the entire concealed range is replaced by that single character in
+  the display. The replacement inherits the style of the first
+  concealed character.
+
+  ## Cursor behavior
+
+  In normal mode, the cursor skips over concealed ranges. In insert
+  mode, entering a concealed range expands it (reveals the raw
+  characters) so the user can edit. For V1, concealment follows
+  Neovim's conceallevel=2 equivalent: conceal when the cursor is
+  not on the line.
+
+  ## Column mapping
+
+  Concealed ranges affect the mapping between buffer columns and
+  display columns. `buf_col_to_display_col` subtracts concealed
+  width (and adds replacement width). `display_col_to_buf_col`
+  reverses the mapping. These are the central functions that the
+  rendering pipeline, mouse handling, and selection logic depend on.
+  """
+
+  alias Minga.Buffer.IntervalTree
+
+  @enforce_keys [:id, :start_pos, :end_pos]
+  defstruct [
+    :id,
+    :start_pos,
+    :end_pos,
+    :group,
+    replacement: nil,
+    replacement_style: [],
+    priority: 0
+  ]
+
+  @typedoc """
+  A conceal range decoration.
+
+  - `id` - unique reference for removal
+  - `start_pos` - inclusive start position `{line, col}` (display columns)
+  - `end_pos` - exclusive end position `{line, col}` (display columns)
+  - `replacement` - nil for invisible, or a string shown in place of the concealed text
+  - `replacement_style` - style keyword list for the replacement character
+  - `priority` - higher values take precedence on overlap (default 0)
+  - `group` - optional atom for bulk removal (e.g., `:markdown`, `:agent`)
+  """
+  @type t :: %__MODULE__{
+          id: reference(),
+          start_pos: IntervalTree.position(),
+          end_pos: IntervalTree.position(),
+          replacement: String.t() | nil,
+          replacement_style: keyword(),
+          priority: integer(),
+          group: atom() | nil
+        }
+
+  @doc """
+  Returns the display width contribution of this conceal range.
+
+  When replacement is nil, the concealed text contributes 0 display columns.
+  When replacement is a string, it contributes 1 display column (the
+  replacement character).
+  """
+  @spec display_width(t()) :: non_neg_integer()
+  def display_width(%__MODULE__{replacement: nil}), do: 0
+  def display_width(%__MODULE__{replacement: _}), do: 1
+
+  @doc """
+  Returns the concealed width: the number of buffer columns hidden by this range
+  on the given line. For multi-line conceals, returns the portion relevant to
+  the specified line.
+  """
+  @spec concealed_width_on_line(t(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  def concealed_width_on_line(%__MODULE__{start_pos: {sl, sc}, end_pos: {el, ec}}, line, line_len) do
+    start_col = if sl < line, do: 0, else: sc
+    end_col = if el > line, do: line_len, else: ec
+    max(end_col - start_col, 0)
+  end
+
+  @doc "Returns true if this conceal range spans the given line."
+  @spec spans_line?(t(), non_neg_integer()) :: boolean()
+  def spans_line?(%__MODULE__{start_pos: {sl, _}, end_pos: {el, _}}, line) do
+    line >= sl and line <= el
+  end
+
+  @doc "Returns true if the given position is inside the conceal range."
+  @spec contains?(t(), IntervalTree.position()) :: boolean()
+  def contains?(%__MODULE__{start_pos: start_pos, end_pos: end_pos}, pos) do
+    pos >= start_pos and pos < end_pos
+  end
+end

--- a/lib/minga/editor/render_pipeline/content_helpers.ex
+++ b/lib/minga/editor/render_pipeline/content_helpers.ex
@@ -10,6 +10,7 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   """
 
   alias Minga.Buffer.Decorations
+  alias Minga.Buffer.Decorations.ConcealRange
   alias Minga.Buffer.Decorations.FoldRegion
   alias Minga.Buffer.Document
   alias Minga.Buffer.Server, as: BufferServer
@@ -361,13 +362,15 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
         {buf_line, display_text}
       end)
 
-    # Compute wrap entries per-line, adjusting width for inline virtual text.
-    # Inline VTs (e.g., "▎ " border) displace content rightward, so the
-    # available text width is content_w minus the VT display width.
+    # Compute wrap entries per-line, adjusting width for inline virtual text
+    # and conceal ranges. Inline VTs displace content rightward; conceals
+    # reduce visible width. Both affect where line breaks should occur.
     wrap_entries =
       Enum.map(buffer_entries, fn {buf_line, text} ->
         vt_width = inline_vt_width(decorations, buf_line)
-        wrap_w = max(width - vt_width, 10)
+        line_len = Unicode.display_width(text)
+        conceal_width = conceal_hidden_width(decorations, buf_line, line_len)
+        wrap_w = max(width - vt_width + conceal_width, 10)
 
         [entry] = WrapMap.compute([text], wrap_w)
         entry
@@ -388,6 +391,22 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
     |> Enum.reduce(0, fn vt, acc ->
       seg_width = Enum.reduce(vt.segments, 0, fn {text, _style}, w -> w + String.length(text) end)
       acc + seg_width
+    end)
+  end
+
+  # Returns the total number of buffer columns hidden by conceals on a line.
+  # This is the concealed width minus replacement width (0 or 1 per range).
+  # Used by the wrap map to compensate: concealed text doesn't consume
+  # display width, so the effective wrap width is larger than content_w.
+  @spec conceal_hidden_width(Decorations.t(), non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  defp conceal_hidden_width(decorations, buf_line, line_len) do
+    conceals = Decorations.conceals_for_line(decorations, buf_line)
+
+    Enum.reduce(conceals, 0, fn conceal, acc ->
+      concealed = ConcealRange.concealed_width_on_line(conceal, buf_line, line_len)
+      replacement = ConcealRange.display_width(conceal)
+      acc + max(concealed - replacement, 0)
     end)
   end
 

--- a/lib/minga/editor/renderer/buffer_line.ex
+++ b/lib/minga/editor/renderer/buffer_line.ex
@@ -89,8 +89,12 @@ defmodule Minga.Editor.Renderer.BufferLine do
     sign_cmd = render_sign(p, sr)
     gutter_cmd = render_number(p, sr)
 
+    # On the cursor line, reveal concealed text (Neovim concealcursor behavior).
+    # This lets the user see raw delimiters when the cursor is on the line.
+    ctx = maybe_reveal_conceals(p.ctx, p.buf_line, p.cursor_line)
+
     content_cmds =
-      LineRenderer.render(p.line_text, sr, p.buf_line, p.ctx, p.byte_offset)
+      LineRenderer.render(p.line_text, sr, p.buf_line, ctx, p.byte_offset)
 
     content_cmds = maybe_apply_cursorline(content_cmds, sr, p)
     content_cmds = maybe_apply_decoration_bg(content_cmds, sr, p)
@@ -383,6 +387,21 @@ defmodule Minga.Editor.Renderer.BufferLine do
   @spec prepend_if([DisplayList.draw()], DisplayList.draw() | []) :: [DisplayList.draw()]
   defp prepend_if(list, []), do: list
   defp prepend_if(list, cmd) when is_tuple(cmd), do: [cmd | list]
+
+  # Strips conceal ranges for the cursor line so that raw text is revealed.
+  # This implements Neovim's concealcursor behavior: concealed text is
+  # visible when the cursor is on the line, hidden on all other lines.
+  @spec maybe_reveal_conceals(Context.t(), non_neg_integer(), non_neg_integer()) :: Context.t()
+  defp maybe_reveal_conceals(ctx, buf_line, cursor_line) when buf_line == cursor_line do
+    if Decorations.has_conceal_ranges?(ctx.decorations) do
+      revealed = %{ctx.decorations | conceal_ranges: []}
+      %{ctx | decorations: revealed}
+    else
+      ctx
+    end
+  end
+
+  defp maybe_reveal_conceals(ctx, _buf_line, _cursor_line), do: ctx
 
   @spec prepend_all([DisplayList.draw()], [DisplayList.draw()]) :: [DisplayList.draw()]
   defp prepend_all(acc, []), do: acc

--- a/lib/minga/editor/renderer/line.ex
+++ b/lib/minga/editor/renderer/line.ex
@@ -15,6 +15,7 @@ defmodule Minga.Editor.Renderer.Line do
   """
 
   alias Minga.Buffer.Decorations
+  alias Minga.Buffer.Decorations.ConcealRange
   alias Minga.Buffer.Unicode
   alias Minga.Editor.DisplayList
   alias Minga.Editor.Renderer.Context
@@ -46,7 +47,32 @@ defmodule Minga.Editor.Renderer.Line do
         Decorations.highlights_for_line(ctx.decorations, buf_line)
       end
 
-    case selection_cols_for_line(buf_line, line_display_len, ctx.visual_selection) do
+    has_conceals = Decorations.has_conceal_ranges?(ctx.decorations)
+
+    # When conceals are active, apply them to visible_pairs for selection paths.
+    # Without this, selection rendering would show raw text (including concealed
+    # characters) while selection coordinates are conceal-adjusted.
+    concealed_pairs =
+      if has_conceals do
+        apply_conceals_to_pairs(pairs, ctx.decorations, buf_line)
+      else
+        nil
+      end
+
+    # Recompute display len and visible pairs from concealed pairs when active
+    {effective_pairs, effective_display_len} =
+      if concealed_pairs do
+        {concealed_pairs, display_width_of_pairs(concealed_pairs)}
+      else
+        {pairs, line_display_len}
+      end
+
+    effective_visible =
+      effective_pairs
+      |> display_drop(ctx.viewport.left)
+      |> display_take(ctx.content_w)
+
+    case selection_cols_for_line(buf_line, effective_display_len, ctx.visual_selection) do
       nil when ctx.highlight != nil ->
         render_highlighted_line(
           line_text,
@@ -57,23 +83,23 @@ defmodule Minga.Editor.Renderer.Line do
           line_highlights
         )
 
-      nil when line_highlights != [] ->
-        # No syntax highlighting but has decorations (including search):
+      nil when line_highlights != [] or has_conceals ->
+        # No syntax highlighting but has decorations or conceals:
         # render through the styled-segment path
         render_decorated_plain_line(line_text, screen_row, buf_line, ctx, line_highlights)
 
       nil ->
-        # Plain text, no decorations, no syntax highlighting
+        # Plain text, no decorations, no syntax highlighting, no conceals
         visible_text = join_pairs(visible_pairs)
         [DisplayList.draw(screen_row, ctx.gutter_w, visible_text)]
 
       :full ->
-        visible_text = join_pairs(visible_pairs)
+        visible_text = join_pairs(effective_visible)
         [DisplayList.draw(screen_row, ctx.gutter_w, visible_text, reverse: true)]
 
       {sel_start, sel_end} ->
         render_partial_selection(
-          visible_pairs,
+          effective_visible,
           screen_row,
           ctx.gutter_w,
           ctx.viewport.left,
@@ -292,6 +318,7 @@ defmodule Minga.Editor.Renderer.Line do
   defp render_decorated_plain_line(line_text, screen_row, buf_line, ctx, line_highlights) do
     segments = [{line_text, []}]
     segments = Decorations.merge_highlights(segments, line_highlights, buf_line)
+    segments = apply_conceals_to_segments(segments, ctx.decorations, buf_line)
     segments = inject_inline_virtual_text(segments, ctx.decorations, buf_line)
     render_segments_with_scroll(segments, screen_row, ctx)
   end
@@ -442,6 +469,316 @@ defmodule Minga.Editor.Renderer.Line do
     {before_acc |> Enum.reverse() |> Enum.join(), after_acc |> Enum.reverse() |> Enum.join()}
   end
 
+  # ── Conceal application to grapheme pairs (for selection paths) ──────────────
+
+  # Applies conceals to a list of grapheme pairs, removing concealed graphemes
+  # and optionally inserting replacement characters. Used by the selection
+  # rendering paths which work with pairs instead of styled segments.
+  @spec apply_conceals_to_pairs([grapheme_pair()], Decorations.t(), non_neg_integer()) ::
+          [grapheme_pair()]
+  defp apply_conceals_to_pairs(pairs, decorations, buf_line) do
+    conceals = Decorations.conceals_for_line(decorations, buf_line)
+    if conceals == [], do: pairs, else: do_apply_conceals_to_pairs(pairs, conceals, buf_line, 0)
+  end
+
+  @spec do_apply_conceals_to_pairs(
+          [grapheme_pair()],
+          [ConcealRange.t()],
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [grapheme_pair()]
+  defp do_apply_conceals_to_pairs([], _conceals, _line, _col), do: []
+  defp do_apply_conceals_to_pairs(pairs, [], _line, _col), do: pairs
+
+  defp do_apply_conceals_to_pairs(
+         [{_g, w} = pair | rest],
+         [%ConcealRange{} = conceal | rest_conceals] = conceals,
+         line,
+         col
+       ) do
+    {_sl, sc} = conceal.start_pos
+    {el, ec} = conceal.end_pos
+    cs = if elem(conceal.start_pos, 0) < line, do: 0, else: sc
+    ce = if el > line, do: col + w + 1, else: ec
+
+    pair_conceal_action(col, w, cs, ce)
+    |> apply_pair_action(pair, rest, conceal, rest_conceals, conceals, line, col)
+  end
+
+  @spec pair_conceal_action(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: :past | :inside | :before
+  defp pair_conceal_action(col, w, cs, _ce) when cs >= col + w, do: :past
+  defp pair_conceal_action(col, _w, cs, ce) when col >= cs and col < ce, do: :inside
+  defp pair_conceal_action(_col, _w, _cs, _ce), do: :before
+
+  # Dispatches on the pair's position relative to the conceal.
+  # `w` is extracted from `pair` instead of passed separately (it's redundant).
+  # :past and :before have identical behavior (emit pair, continue), so
+  # they share the catch-all clause.
+  @spec apply_pair_action(
+          :past | :inside | :before,
+          grapheme_pair(),
+          [grapheme_pair()],
+          ConcealRange.t(),
+          [ConcealRange.t()],
+          [ConcealRange.t()],
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [grapheme_pair()]
+  defp apply_pair_action(:inside, {_g, w}, rest, conceal, rest_conceals, conceals, line, col) do
+    {_sl, sc} = conceal.start_pos
+    cs = if elem(conceal.start_pos, 0) < line, do: 0, else: sc
+    {el, ec} = conceal.end_pos
+    ce = if el > line, do: col + w + 1, else: ec
+
+    replacement =
+      if col == cs and conceal.replacement != nil,
+        do: [{conceal.replacement, 1}],
+        else: []
+
+    if col + w >= ce do
+      replacement ++ do_apply_conceals_to_pairs(rest, rest_conceals, line, col + w)
+    else
+      replacement ++ do_apply_conceals_to_pairs(rest, conceals, line, col + w)
+    end
+  end
+
+  # :past and :before both pass through the pair unchanged
+  defp apply_pair_action(
+         _action,
+         {_g, w} = pair,
+         rest,
+         _conceal,
+         _rest_conceals,
+         conceals,
+         line,
+         col
+       ) do
+    [pair | do_apply_conceals_to_pairs(rest, conceals, line, col + w)]
+  end
+
+  # ── Conceal range application ─────────────────────────────────────────────────
+
+  # Applies conceal ranges to a styled segment list. Concealed graphemes are
+  # removed from the output; if a conceal has a replacement character, that
+  # replacement is emitted once in place of the entire concealed range.
+  #
+  # Operates in buffer column space (before inline virtual text shifts).
+  # Walks the segment list tracking the current buffer column, and for each
+  # conceal range on this line, excises the concealed graphemes and optionally
+  # inserts the replacement.
+  @spec apply_conceals_to_segments(
+          [{String.t(), keyword()}],
+          Decorations.t(),
+          non_neg_integer()
+        ) :: [{String.t(), keyword()}]
+  defp apply_conceals_to_segments(segments, decorations, buf_line) do
+    conceals = Decorations.conceals_for_line(decorations, buf_line)
+
+    if conceals == [] do
+      segments
+    else
+      do_apply_conceals(segments, conceals, %{line: buf_line, col: 0, acc: []})
+    end
+  end
+
+  # Walk segments and conceals together. Both are sorted by column position.
+  # Uses a conceal_ctx map to bundle line/col/acc and avoid high arity helpers.
+  @typep conceal_ctx :: %{
+           line: non_neg_integer(),
+           col: non_neg_integer(),
+           acc: [{String.t(), keyword()}]
+         }
+
+  @spec do_apply_conceals(
+          [{String.t(), keyword()}],
+          [ConcealRange.t()],
+          conceal_ctx()
+        ) :: [{String.t(), keyword()}]
+  defp do_apply_conceals([], _conceals, ctx), do: Enum.reverse(ctx.acc)
+  defp do_apply_conceals(segments, [], ctx), do: Enum.reverse(ctx.acc, segments)
+
+  defp do_apply_conceals(
+         [{seg_text, seg_style} | rest_segs],
+         [%ConcealRange{} = conceal | rest_conceals] = conceals,
+         ctx
+       ) do
+    seg_width = Unicode.display_width(seg_text)
+    seg_end = ctx.col + seg_width
+
+    # Determine conceal start/end on this line
+    {_sl, sc} = conceal.start_pos
+    {el, ec} = conceal.end_pos
+    conceal_start = if elem(conceal.start_pos, 0) < ctx.line, do: 0, else: sc
+    conceal_end = if el > ctx.line, do: seg_end + 1, else: ec
+
+    # Dispatch based on the relationship between segment and conceal.
+    # Uses if/else instead of separate function to avoid high arity.
+    if conceal_start >= seg_end do
+      # Conceal is entirely past this segment: emit segment, keep going
+      do_apply_conceals(
+        rest_segs,
+        conceals,
+        %{ctx | col: seg_end, acc: [{seg_text, seg_style} | ctx.acc]}
+      )
+    else
+      if conceal_start <= ctx.col do
+        apply_conceal_from_start(
+          {seg_text, seg_style},
+          rest_segs,
+          conceal,
+          rest_conceals,
+          seg_end,
+          conceal_end,
+          ctx
+        )
+      else
+        apply_conceal_mid_segment(
+          {seg_text, seg_style},
+          rest_segs,
+          conceal,
+          rest_conceals,
+          seg_end,
+          conceal_start,
+          ctx
+        )
+      end
+    end
+  end
+
+  # Conceal starts at or before segment start: skip concealed portion
+  @spec apply_conceal_from_start(
+          {String.t(), keyword()},
+          [{String.t(), keyword()}],
+          ConcealRange.t(),
+          [ConcealRange.t()],
+          non_neg_integer(),
+          non_neg_integer(),
+          conceal_ctx()
+        ) :: [{String.t(), keyword()}]
+  defp apply_conceal_from_start(
+         {seg_text, seg_style},
+         rest_segs,
+         conceal,
+         rest_conceals,
+         seg_end,
+         conceal_end,
+         ctx
+       ) do
+    if conceal_end >= seg_end do
+      # Entire segment is concealed. Emit replacement on first concealed segment
+      # only (when col == conceal_start or conceal started on a previous segment).
+      replacement_acc = maybe_emit_replacement(ctx.acc, conceal, ctx.col, ctx.line, seg_style)
+
+      if conceal_end == seg_end do
+        # Conceal ends exactly at segment end: move to next conceal
+        do_apply_conceals(rest_segs, rest_conceals, %{ctx | col: seg_end, acc: replacement_acc})
+      else
+        # Conceal extends past this segment: continue with same conceal
+        do_apply_conceals(
+          rest_segs,
+          [conceal | rest_conceals],
+          %{ctx | col: seg_end, acc: replacement_acc}
+        )
+      end
+    else
+      # Conceal ends within this segment: split and emit the non-concealed tail
+      replacement_acc = maybe_emit_replacement(ctx.acc, conceal, ctx.col, ctx.line, seg_style)
+      drop_cols = conceal_end - ctx.col
+      {_before, after_text} = split_text_at_display_col(seg_text, drop_cols)
+
+      if after_text != "" do
+        do_apply_conceals(
+          [{after_text, seg_style} | rest_segs],
+          rest_conceals,
+          %{ctx | col: conceal_end, acc: replacement_acc}
+        )
+      else
+        do_apply_conceals(
+          rest_segs,
+          rest_conceals,
+          %{ctx | col: seg_end, acc: replacement_acc}
+        )
+      end
+    end
+  end
+
+  # Conceal starts within this segment: emit the before portion, then handle concealed part
+  @spec apply_conceal_mid_segment(
+          {String.t(), keyword()},
+          [{String.t(), keyword()}],
+          ConcealRange.t(),
+          [ConcealRange.t()],
+          non_neg_integer(),
+          non_neg_integer(),
+          conceal_ctx()
+        ) :: [{String.t(), keyword()}]
+  defp apply_conceal_mid_segment(
+         {seg_text, seg_style},
+         rest_segs,
+         conceal,
+         rest_conceals,
+         seg_end,
+         conceal_start,
+         ctx
+       ) do
+    split_at = conceal_start - ctx.col
+    {before_text, after_text} = split_text_at_display_col(seg_text, split_at)
+
+    before_acc = if before_text != "", do: [{before_text, seg_style} | ctx.acc], else: ctx.acc
+
+    if after_text != "" do
+      # Re-process the remainder (which now starts at the conceal)
+      do_apply_conceals(
+        [{after_text, seg_style} | rest_segs],
+        [conceal | rest_conceals],
+        %{ctx | col: conceal_start, acc: before_acc}
+      )
+    else
+      # Before text consumed everything (edge case with wide chars)
+      do_apply_conceals(
+        rest_segs,
+        [conceal | rest_conceals],
+        %{ctx | col: seg_end, acc: before_acc}
+      )
+    end
+  end
+
+  # Emits the replacement character for a conceal range, but only once
+  # (at the start of the conceal). We detect "first concealed segment"
+  # by checking if we're at the conceal's start column on this line.
+  #
+  # The seg_style from the concealed text is merged onto the replacement
+  # style so that overlapping decorations (e.g., search highlight bg)
+  # carry through to the replacement character.
+  @spec maybe_emit_replacement(
+          [{String.t(), keyword()}],
+          ConcealRange.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          keyword()
+        ) :: [{String.t(), keyword()}]
+  defp maybe_emit_replacement(acc, %ConcealRange{replacement: nil}, _col, _line, _seg_style),
+    do: acc
+
+  defp maybe_emit_replacement(acc, conceal, col, line, seg_style) do
+    {sl, sc} = conceal.start_pos
+    conceal_start_on_line = if sl < line, do: 0, else: sc
+
+    if col <= conceal_start_on_line do
+      # Merge: conceal replacement_style wins over the segment's style,
+      # but the segment's style provides bg/fg from overlapping decorations.
+      merged_style = Keyword.merge(seg_style, conceal.replacement_style)
+      [{conceal.replacement, merged_style} | acc]
+    else
+      acc
+    end
+  end
+
   # ── Syntax highlighting ──────────────────────────────────────────────────────
 
   @spec render_highlighted_line(
@@ -465,6 +802,7 @@ defmodule Minga.Editor.Renderer.Line do
 
     # Merge decoration highlight ranges with syntax segments (pre-queried, no double lookup)
     segments = Decorations.merge_highlights(segments, line_highlights, buf_line)
+    segments = apply_conceals_to_segments(segments, ctx.decorations, buf_line)
     segments = inject_inline_virtual_text(segments, ctx.decorations, buf_line)
 
     render_segments_with_scroll(segments, screen_row, ctx)

--- a/test/minga/buffer/conceal_range_test.exs
+++ b/test/minga/buffer/conceal_range_test.exs
@@ -1,0 +1,463 @@
+defmodule Minga.Buffer.ConcealRangeTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Minga.Buffer.Decorations
+  alias Minga.Buffer.Decorations.ConcealRange
+
+  # ── ConcealRange struct ─────────────────────────────────────────────────
+
+  describe "ConcealRange struct" do
+    test "creates a conceal range with required fields" do
+      range = %ConcealRange{
+        id: make_ref(),
+        start_pos: {0, 0},
+        end_pos: {0, 2}
+      }
+
+      assert range.replacement == nil
+      assert range.replacement_style == []
+      assert range.priority == 0
+      assert range.group == nil
+    end
+
+    test "creates a conceal range with replacement" do
+      range = %ConcealRange{
+        id: make_ref(),
+        start_pos: {0, 0},
+        end_pos: {0, 5},
+        replacement: "·",
+        replacement_style: [fg: 0x555555]
+      }
+
+      assert range.replacement == "·"
+      assert range.replacement_style == [fg: 0x555555]
+    end
+  end
+
+  describe "display_width/1" do
+    test "returns 0 when no replacement" do
+      range = %ConcealRange{id: make_ref(), start_pos: {0, 0}, end_pos: {0, 5}}
+      assert ConcealRange.display_width(range) == 0
+    end
+
+    test "returns 1 when replacement is set" do
+      range = %ConcealRange{
+        id: make_ref(),
+        start_pos: {0, 0},
+        end_pos: {0, 5},
+        replacement: "·"
+      }
+
+      assert ConcealRange.display_width(range) == 1
+    end
+  end
+
+  describe "spans_line?/2" do
+    test "returns true for lines within the range" do
+      range = %ConcealRange{id: make_ref(), start_pos: {2, 0}, end_pos: {5, 3}}
+      assert ConcealRange.spans_line?(range, 2)
+      assert ConcealRange.spans_line?(range, 3)
+      assert ConcealRange.spans_line?(range, 5)
+    end
+
+    test "returns false for lines outside the range" do
+      range = %ConcealRange{id: make_ref(), start_pos: {2, 0}, end_pos: {5, 3}}
+      refute ConcealRange.spans_line?(range, 1)
+      refute ConcealRange.spans_line?(range, 6)
+    end
+  end
+
+  describe "contains?/2" do
+    test "returns true for positions inside the range" do
+      range = %ConcealRange{id: make_ref(), start_pos: {0, 2}, end_pos: {0, 5}}
+      assert ConcealRange.contains?(range, {0, 2})
+      assert ConcealRange.contains?(range, {0, 3})
+      assert ConcealRange.contains?(range, {0, 4})
+    end
+
+    test "returns false for end position (exclusive)" do
+      range = %ConcealRange{id: make_ref(), start_pos: {0, 2}, end_pos: {0, 5}}
+      refute ConcealRange.contains?(range, {0, 5})
+    end
+
+    test "returns false for positions outside" do
+      range = %ConcealRange{id: make_ref(), start_pos: {0, 2}, end_pos: {0, 5}}
+      refute ConcealRange.contains?(range, {0, 1})
+      refute ConcealRange.contains?(range, {0, 6})
+    end
+  end
+
+  # ── Decorations API ────────────────────────────────────────────────────
+
+  describe "add_conceal/4" do
+    test "adds a conceal range and returns id" do
+      decs = Decorations.new()
+      {id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+
+      assert is_reference(id)
+      assert length(decs.conceal_ranges) == 1
+      assert decs.version == 1
+    end
+
+    test "adds a conceal range with replacement" do
+      decs = Decorations.new()
+
+      {_id, decs} =
+        Decorations.add_conceal(decs, {0, 0}, {0, 2},
+          replacement: "·",
+          replacement_style: [fg: 0x555555],
+          group: :markdown
+        )
+
+      [range] = decs.conceal_ranges
+      assert range.replacement == "·"
+      assert range.replacement_style == [fg: 0x555555]
+      assert range.group == :markdown
+    end
+
+    test "adds multiple conceal ranges" do
+      decs = Decorations.new()
+      {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+      {_id2, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 7})
+
+      assert length(decs.conceal_ranges) == 2
+      assert decs.version == 2
+    end
+  end
+
+  describe "remove_conceal/2" do
+    test "removes a conceal range by id" do
+      decs = Decorations.new()
+      {id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+      decs = Decorations.remove_conceal(decs, id)
+
+      assert decs.conceal_ranges == []
+      assert decs.version == 2
+    end
+
+    test "no-op when id doesn't exist" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+      old_version = decs.version
+      decs = Decorations.remove_conceal(decs, make_ref())
+
+      assert length(decs.conceal_ranges) == 1
+      assert decs.version == old_version
+    end
+  end
+
+  describe "remove_conceal_group/2" do
+    test "removes all conceals in a group" do
+      decs = Decorations.new()
+      {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :markdown)
+      {_id2, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 7}, group: :markdown)
+      {_id3, decs} = Decorations.add_conceal(decs, {1, 0}, {1, 3}, group: :other)
+
+      decs = Decorations.remove_conceal_group(decs, :markdown)
+      assert length(decs.conceal_ranges) == 1
+      assert hd(decs.conceal_ranges).group == :other
+    end
+  end
+
+  describe "conceals_for_line/2" do
+    test "returns conceals for the given line sorted by start col" do
+      decs = Decorations.new()
+      {_id1, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 7})
+      {_id2, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+      {_id3, decs} = Decorations.add_conceal(decs, {1, 0}, {1, 3})
+
+      line_conceals = Decorations.conceals_for_line(decs, 0)
+      assert length(line_conceals) == 2
+      [first, second] = line_conceals
+      assert elem(first.start_pos, 1) <= elem(second.start_pos, 1)
+    end
+
+    test "returns empty list when no conceals exist" do
+      decs = Decorations.new()
+      assert Decorations.conceals_for_line(decs, 0) == []
+    end
+
+    test "returns empty list for line with no conceals" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+      assert Decorations.conceals_for_line(decs, 1) == []
+    end
+  end
+
+  describe "has_conceal_ranges?/1" do
+    test "returns false for empty" do
+      refute Decorations.has_conceal_ranges?(Decorations.new())
+    end
+
+    test "returns true when conceals exist" do
+      {_id, decs} = Decorations.add_conceal(Decorations.new(), {0, 0}, {0, 2})
+      assert Decorations.has_conceal_ranges?(decs)
+    end
+  end
+
+  # ── Column mapping ────────────────────────────────────────────────────────
+
+  describe "buf_col_to_display_col with conceals" do
+    test "no conceals: identity mapping" do
+      decs = Decorations.new()
+      assert Decorations.buf_col_to_display_col(decs, 0, 5) == 5
+    end
+
+    test "conceal before position shifts display left" do
+      # Line: "**bold**" concealing first **
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+
+      # buf_col 0 is at the start of the conceal, display_col is 0
+      assert Decorations.buf_col_to_display_col(decs, 0, 0) == 0
+      # buf_col 2 (after "**") maps to display_col 0 (conceal width 2, replacement 0)
+      assert Decorations.buf_col_to_display_col(decs, 0, 2) == 0
+      # buf_col 6 ("bold" ends at 6) maps to display_col 4
+      assert Decorations.buf_col_to_display_col(decs, 0, 6) == 4
+    end
+
+    test "conceal with replacement: shifts by (concealed_width - 1)" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, replacement: "·")
+
+      # buf_col 2 maps to display_col 1 (concealed 2 chars, replaced by 1)
+      assert Decorations.buf_col_to_display_col(decs, 0, 2) == 1
+      # buf_col 6 maps to display_col 5
+      assert Decorations.buf_col_to_display_col(decs, 0, 6) == 5
+    end
+
+    test "multiple conceals accumulate offsets" do
+      # "**bold** and **more**"
+      # Conceal ** at 0..2 and ** at 6..8
+      decs = Decorations.new()
+      {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+      {_id2, decs} = Decorations.add_conceal(decs, {0, 6}, {0, 8})
+
+      # After first **: buf_col 2 -> display 0
+      assert Decorations.buf_col_to_display_col(decs, 0, 2) == 0
+      # "bold" starts at buf_col 2, ends at 6: display 0..4
+      assert Decorations.buf_col_to_display_col(decs, 0, 6) == 4
+      # After second **: buf_col 8 -> display 4 (both conceals removed 4 total)
+      assert Decorations.buf_col_to_display_col(decs, 0, 8) == 4
+      # buf_col 10 -> display 6
+      assert Decorations.buf_col_to_display_col(decs, 0, 10) == 6
+    end
+
+    test "conceal on different line doesn't affect mapping" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_conceal(decs, {1, 0}, {1, 2})
+
+      assert Decorations.buf_col_to_display_col(decs, 0, 5) == 5
+    end
+  end
+
+  describe "display_col_to_buf_col with conceals" do
+    test "no conceals: identity mapping" do
+      decs = Decorations.new()
+      assert Decorations.display_col_to_buf_col(decs, 0, 5) == 5
+    end
+
+    test "conceal before position shifts buffer right" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+
+      # display_col 0 maps to buf_col 2 (the "b" in "bold" after hidden "**")
+      assert Decorations.display_col_to_buf_col(decs, 0, 0) == 2
+      # display_col 4 maps to buf_col 6
+      assert Decorations.display_col_to_buf_col(decs, 0, 4) == 6
+    end
+
+    test "conceal with replacement" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, replacement: "·")
+
+      # display_col 0 is the replacement char, maps to buf_col 0
+      # display_col 1 maps to buf_col 2 (after the concealed range)
+      assert Decorations.display_col_to_buf_col(decs, 0, 1) == 2
+    end
+  end
+
+  # ── Anchor adjustment ────────────────────────────────────────────────────
+
+  describe "adjust_for_edit with conceals" do
+    test "insertion before conceal shifts it right" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 7})
+
+      # Insert 2 chars at col 0
+      decs = Decorations.adjust_for_edit(decs, {0, 0}, {0, 0}, {0, 2})
+
+      [conceal] = decs.conceal_ranges
+      assert conceal.start_pos == {0, 7}
+      assert conceal.end_pos == {0, 9}
+    end
+
+    test "insertion after conceal doesn't move it" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+
+      decs = Decorations.adjust_for_edit(decs, {0, 5}, {0, 5}, {0, 8})
+
+      [conceal] = decs.conceal_ranges
+      assert conceal.start_pos == {0, 0}
+      assert conceal.end_pos == {0, 2}
+    end
+
+    test "deletion spanning conceal removes it" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_conceal(decs, {0, 2}, {0, 5})
+
+      # Delete from col 0 to col 6 (spans the conceal)
+      decs = Decorations.adjust_for_edit(decs, {0, 0}, {0, 6}, {0, 0})
+
+      assert decs.conceal_ranges == []
+    end
+
+    test "deletion within conceal shrinks it" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_conceal(decs, {0, 2}, {0, 8})
+
+      # Delete 2 chars inside the conceal (col 4 to 6)
+      decs = Decorations.adjust_for_edit(decs, {0, 4}, {0, 6}, {0, 4})
+
+      [conceal] = decs.conceal_ranges
+      assert conceal.start_pos == {0, 2}
+      assert conceal.end_pos == {0, 6}
+    end
+  end
+
+  # ── empty?/1 with conceals ──────────────────────────────────────────────
+
+  describe "empty?/1" do
+    test "returns false when conceals exist" do
+      {_id, decs} = Decorations.add_conceal(Decorations.new(), {0, 0}, {0, 2})
+      refute Decorations.empty?(decs)
+    end
+  end
+
+  # ── clear/1 with conceals ──────────────────────────────────────────────
+
+  describe "clear/1" do
+    test "clears conceal ranges" do
+      {_id, decs} = Decorations.add_conceal(Decorations.new(), {0, 0}, {0, 2})
+      decs = Decorations.clear(decs)
+      assert decs.conceal_ranges == []
+    end
+  end
+
+  # ── Property tests ──────────────────────────────────────────────────────
+
+  describe "column mapping roundtrip" do
+    property "buf_col outside conceals roundtrips through display_col" do
+      # For buffer positions NOT inside concealed ranges, the roundtrip
+      # buf_col -> display_col -> buf_col should be exact.
+      check all(
+              line_len <- integer(5..50),
+              conceal_count <- integer(0..3),
+              conceals <- conceal_ranges_gen(line_len, conceal_count)
+            ) do
+        decs = build_decs_with_conceals(conceals)
+
+        # Test every buf_col that's not inside a concealed range
+        for buf_col <- 0..line_len, not inside_any_conceal?(buf_col, conceals) do
+          display_col = Decorations.buf_col_to_display_col(decs, 0, buf_col)
+          roundtrip = Decorations.display_col_to_buf_col(decs, 0, display_col)
+
+          assert roundtrip == buf_col,
+                 "Roundtrip failed: buf_col=#{buf_col} -> display_col=#{display_col} -> #{roundtrip}, " <>
+                   "conceals=#{inspect(conceals)}"
+        end
+      end
+    end
+
+    property "buf_col_to_display_col is monotonically non-decreasing" do
+      check all(
+              line_len <- integer(5..50),
+              conceal_count <- integer(0..3),
+              conceals <- conceal_ranges_gen(line_len, conceal_count)
+            ) do
+        decs = build_decs_with_conceals(conceals)
+
+        display_cols = for b <- 0..line_len, do: Decorations.buf_col_to_display_col(decs, 0, b)
+
+        # Each display_col should be >= the previous one
+        display_cols
+        |> Enum.chunk_every(2, 1, :discard)
+        |> Enum.each(fn [prev, curr] ->
+          assert curr >= prev, "Display cols not monotonic: #{prev} -> #{curr}"
+        end)
+      end
+    end
+
+    property "display_col always <= buf_col when conceals have no replacement" do
+      check all(
+              line_len <- integer(5..50),
+              conceal_count <- integer(1..3),
+              conceals <- conceal_ranges_gen(line_len, conceal_count, false)
+            ) do
+        decs = build_decs_with_conceals(conceals)
+
+        for buf_col <- 0..line_len do
+          display_col = Decorations.buf_col_to_display_col(decs, 0, buf_col)
+          assert display_col <= buf_col
+        end
+      end
+    end
+  end
+
+  # ── Generators ─────────────────────────────────────────────────────────
+
+  defp conceal_ranges_gen(line_len, count, with_replacement \\ true) do
+    if count == 0 do
+      constant([])
+    else
+      bind(non_overlapping_ranges(line_len, count), fn ranges ->
+        constant(add_replacements(ranges, with_replacement))
+      end)
+    end
+  end
+
+  defp add_replacements(ranges, with_replacement) do
+    Enum.map(ranges, fn {s, e} ->
+      replacement = if with_replacement and :rand.uniform(2) == 1, do: "·", else: nil
+      {s, e, replacement}
+    end)
+  end
+
+  defp non_overlapping_ranges(line_len, count) do
+    bind(list_of(integer(1..max(line_len - 1, 2)), length: count), fn widths ->
+      constant(build_ranges(widths, line_len, count))
+    end)
+  end
+
+  defp build_ranges(widths, line_len, count) do
+    widths = Enum.map(widths, &min(&1, 3))
+    total = Enum.sum(widths)
+
+    if total >= line_len do
+      [{0, min(2, line_len)}]
+    else
+      gap_each = max(div(line_len - total, count + 1), 1)
+
+      {ranges, _pos} =
+        Enum.reduce(widths, {[], gap_each}, fn w, {acc, pos} ->
+          {[{min(pos, line_len - 1), min(pos + w, line_len)} | acc], pos + w + gap_each}
+        end)
+
+      Enum.reverse(ranges)
+    end
+  end
+
+  defp build_decs_with_conceals(conceals) do
+    Enum.reduce(conceals, Decorations.new(), fn {s, e, replacement}, decs ->
+      opts = if replacement, do: [replacement: replacement], else: []
+      {_id, decs} = Decorations.add_conceal(decs, {0, s}, {0, e}, opts)
+      decs
+    end)
+  end
+
+  defp inside_any_conceal?(buf_col, conceals) do
+    Enum.any?(conceals, fn {s, e, _} -> buf_col >= s and buf_col < e end)
+  end
+end

--- a/test/minga/editor/renderer/conceal_render_test.exs
+++ b/test/minga/editor/renderer/conceal_render_test.exs
@@ -1,0 +1,176 @@
+defmodule Minga.Editor.Renderer.ConcealRenderTest do
+  @moduledoc """
+  Tests that conceal ranges actually affect rendering output.
+
+  Uses the headless editor to verify that concealed characters disappear
+  from the display and replacement characters appear when specified.
+  Conceals are revealed on the cursor line (Neovim concealcursor behavior).
+  """
+
+  use Minga.Test.EditorCase, async: true
+
+  alias Minga.Buffer.Decorations
+  alias Minga.Buffer.Server, as: BufferServer
+
+  # Content starts at row 1 because the tab bar occupies row 0.
+  @content_row 1
+
+  describe "conceal rendering" do
+    test "concealed characters are hidden on non-cursor line" do
+      # Conceals on line 0, cursor on line 1
+      ctx = start_editor("**bold**\nsecond line")
+
+      BufferServer.batch_decorations(ctx.buffer, fn decs ->
+        {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
+        {_id2, decs} = Decorations.add_conceal(decs, {0, 6}, {0, 8}, group: :test)
+        decs
+      end)
+
+      # Move cursor to line 1 so line 0 conceals are active
+      send_key(ctx, ?j)
+
+      row_text = screen_row(ctx, @content_row)
+
+      refute String.contains?(row_text, "**"),
+             "Expected ** to be concealed on non-cursor line, got: #{inspect(row_text)}"
+
+      assert String.contains?(row_text, "bold"),
+             "Expected 'bold' to be visible, got: #{inspect(row_text)}"
+    end
+
+    test "conceal with replacement character shows replacement on non-cursor line" do
+      ctx = start_editor("**bold**\nsecond line")
+
+      BufferServer.batch_decorations(ctx.buffer, fn decs ->
+        {_id1, decs} =
+          Decorations.add_conceal(decs, {0, 0}, {0, 2}, replacement: "·", group: :test)
+
+        {_id2, decs} =
+          Decorations.add_conceal(decs, {0, 6}, {0, 8}, replacement: "·", group: :test)
+
+        decs
+      end)
+
+      # Move cursor to line 1
+      send_key(ctx, ?j)
+
+      row_text = screen_row(ctx, @content_row)
+
+      assert String.contains?(row_text, "·"),
+             "Expected replacement char on non-cursor line, got: #{inspect(row_text)}"
+
+      assert String.contains?(row_text, "bold"),
+             "Expected 'bold' to be visible, got: #{inspect(row_text)}"
+    end
+
+    test "buffer content is not modified by concealment" do
+      ctx = start_editor("**bold**")
+
+      BufferServer.batch_decorations(ctx.buffer, fn decs ->
+        {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
+        decs
+      end)
+
+      content = BufferServer.content(ctx.buffer)
+      assert content == "**bold**"
+    end
+
+    test "removing conceals restores display" do
+      ctx = start_editor("**bold**\nsecond line")
+
+      BufferServer.batch_decorations(ctx.buffer, fn decs ->
+        {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
+        decs
+      end)
+
+      # Move cursor off line 0, then remove conceals
+      send_key(ctx, ?j)
+
+      BufferServer.batch_decorations(ctx.buffer, fn decs ->
+        Decorations.remove_conceal_group(decs, :test)
+      end)
+
+      # Move back to line 0 to re-render
+      send_key(ctx, ?k)
+
+      row_text = screen_row(ctx, @content_row)
+
+      assert String.contains?(row_text, "**bold"),
+             "Expected ** to be visible after removal, got: #{inspect(row_text)}"
+    end
+
+    test "multiple conceals on one line" do
+      ctx = start_editor("# Heading\nsecond line")
+
+      BufferServer.batch_decorations(ctx.buffer, fn decs ->
+        {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
+        decs
+      end)
+
+      # Move cursor to line 1 so line 0 conceals are active
+      send_key(ctx, ?j)
+
+      row_text = screen_row(ctx, @content_row)
+
+      assert String.contains?(row_text, "Heading"),
+             "Expected 'Heading' to be visible, got: #{inspect(row_text)}"
+    end
+
+    test "cursor line reveals concealed text" do
+      ctx = start_editor("**bold**\nnormal line")
+
+      BufferServer.batch_decorations(ctx.buffer, fn decs ->
+        {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
+        {_id2, decs} = Decorations.add_conceal(decs, {0, 6}, {0, 8}, group: :test)
+        decs
+      end)
+
+      send_key(ctx, 0)
+
+      # Cursor is on line 0, so conceals should be revealed
+      row_text = screen_row(ctx, @content_row)
+
+      assert String.contains?(row_text, "**"),
+             "Expected ** to be revealed on cursor line, got: #{inspect(row_text)}"
+    end
+
+    test "non-cursor line hides concealed text while cursor line reveals" do
+      ctx = start_editor("**bold**\n**italic**")
+
+      BufferServer.batch_decorations(ctx.buffer, fn decs ->
+        {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
+        {_id2, decs} = Decorations.add_conceal(decs, {0, 6}, {0, 8}, group: :test)
+        {_id3, decs} = Decorations.add_conceal(decs, {1, 0}, {1, 2}, group: :test)
+        {_id4, decs} = Decorations.add_conceal(decs, {1, 8}, {1, 10}, group: :test)
+        decs
+      end)
+
+      send_key(ctx, 0)
+
+      # Cursor is on line 0: line 0 reveals, line 1 conceals
+      row_text_line1 = screen_row(ctx, @content_row + 1)
+
+      refute String.contains?(row_text_line1, "**"),
+             "Expected ** to be hidden on non-cursor line, got: #{inspect(row_text_line1)}"
+
+      assert String.contains?(row_text_line1, "italic"),
+             "Expected 'italic' to be visible, got: #{inspect(row_text_line1)}"
+    end
+
+    test "yank across concealed range produces raw text" do
+      ctx = start_editor("**bold**", clipboard: :none)
+
+      BufferServer.batch_decorations(ctx.buffer, fn decs ->
+        {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :test)
+        {_id2, decs} = Decorations.add_conceal(decs, {0, 6}, {0, 8}, group: :test)
+        decs
+      end)
+
+      # Yank the line
+      send_keys(ctx, "Vy")
+
+      content = BufferServer.content(ctx.buffer)
+      assert content == "**bold**"
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a new `ConcealRange` decoration type that hides buffer characters from the display without removing them from the buffer. Optionally replaces concealed text with a single replacement character. This is the same primitive that Neovim (`conceal`) and Emacs (`display` text properties) provide.

Part of epic #659. Closes #662.

## Changes

### New files
- `lib/minga/buffer/decorations/conceal_range.ex` - ConcealRange struct with display_width, concealed_width_on_line, spans_line?, contains?
- `test/minga/buffer/conceal_range_test.exs` - 34 unit tests + 3 property tests
- `test/minga/editor/renderer/conceal_render_test.exs` - 8 integration tests with headless editor

### Modified files
- `lib/minga/buffer/decorations.ex` - add_conceal/4, remove_conceal/2, remove_conceal_group/2, conceals_for_line/2, column mapping with conceal awareness, anchor adjustment for conceals
- `lib/minga/editor/renderer/line.ex` - apply_conceals_to_segments (segment pipeline), apply_conceals_to_pairs (selection path), conceal-aware selection rendering
- `lib/minga/editor/renderer/buffer_line.ex` - maybe_reveal_conceals (cursor-line reveal, Neovim concealcursor behavior)
- `lib/minga/editor/render_pipeline/content_helpers.ex` - WrapMap conceal width compensation via ConcealRange.concealed_width_on_line/3

## How it works

Conceals integrate into the existing rendering pipeline at three levels:

1. **Column mapping** - `buf_col_to_display_col` and `display_col_to_buf_col` now subtract/add concealed widths. This is the foundation that mouse clicks, visual selection bounds, and cursor positioning depend on.

2. **Segment pipeline** - After highlight merging and before inline VT injection, `apply_conceals_to_segments` walks styled segments and excises concealed graphemes. Replacement chars inherit the segment's style (so search highlight bg carries through).

3. **Selection pairs** - The selection rendering paths (`:full` and partial) use `apply_conceals_to_pairs` so concealed graphemes don't appear in visually selected text.

Cursor-line reveal: on the cursor line, conceals are stripped from the decorations before rendering, showing raw text (like Neovim's concealcursor behavior). This lets users see and edit delimiters when the cursor is on that line.

## Testing

- 34 unit tests covering struct, API, column mapping, anchor adjustment
- 3 property tests: roundtrip correctness for non-concealed positions, monotonicity of display columns, display_col ordering
- 8 integration tests with headless editor: hiding, replacement chars, cursor-line reveal, removal, yank across conceals
- Full suite: 5396 tests, 0 failures