### PR TITLE
feat(highlight): innermost-wins span resolution with full metadata

### DIFF
--- a/lib/minga/editor/render_pipeline/content_helpers.ex
+++ b/lib/minga/editor/render_pipeline/content_helpers.ex
@@ -27,6 +27,7 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   alias Minga.Editor.WrapMap
   alias Minga.Git.Buffer, as: GitBuffer
   alias Minga.Git.Tracker, as: GitTracker
+  alias Minga.Highlight
   alias Minga.LSP.SyncServer
   alias Minga.Mode.VisualState
 
@@ -166,12 +167,22 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
     sign_w = if ctx.has_sign_column, do: Gutter.sign_column_width(), else: 0
     max_rows = length(lines)
 
+    # Pre-compute highlight segments for all visible lines in one O(N) pass.
+    highlight_segments_list =
+      if ctx.highlight do
+        lines_with_offsets = build_lines_with_offsets(lines, first_byte_off)
+        Highlight.styles_for_visible_lines(ctx.highlight, lines_with_offsets)
+      else
+        List.duplicate(nil, max_rows)
+      end
+
     {gutters, contents_rev, _byte_off, window} =
       lines
+      |> Enum.zip(highlight_segments_list)
       |> Enum.with_index()
       |> Enum.reduce(
         {[], [], first_byte_off, window},
-        fn {line_text, screen_row}, {g, c, byte_off, win} ->
+        fn {{line_text, hl_segments}, screen_row}, {g, c, byte_off, win} ->
           buf_line = first_line + screen_row
           next_byte_off = byte_off + byte_size(line_text) + 1
 
@@ -190,7 +201,8 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
                 wrap_entry: nil,
                 max_rows: max_rows,
                 row_offset: row_off,
-                col_offset: col_off
+                col_offset: col_off,
+                highlight_segments: hl_segments
               })
 
             win = Window.cache_line(win, buf_line, g_cmds, c_cmds)
@@ -867,5 +879,17 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
     else
       ""
     end
+  end
+
+  # Build {line_text, byte_offset} tuples for batch highlight computation.
+  @spec build_lines_with_offsets([String.t()], non_neg_integer()) ::
+          [{String.t(), non_neg_integer()}]
+  defp build_lines_with_offsets(lines, first_byte_off) do
+    {pairs_rev, _} =
+      Enum.reduce(lines, {[], first_byte_off}, fn line, {acc, off} ->
+        {[{line, off} | acc], off + byte_size(line) + 1}
+      end)
+
+    Enum.reverse(pairs_rev)
   end
 end

--- a/lib/minga/editor/renderer/buffer_line.ex
+++ b/lib/minga/editor/renderer/buffer_line.ex
@@ -26,6 +26,7 @@ defmodule Minga.Editor.Renderer.BufferLine do
   alias Minga.Editor.Renderer.Gutter
   alias Minga.Editor.Renderer.Line, as: LineRenderer
   alias Minga.Editor.WrapMap
+  alias Minga.Highlight
 
   @typedoc """
   Per-line values that vary across lines in a render pass.
@@ -45,19 +46,20 @@ defmodule Minga.Editor.Renderer.BufferLine do
   - `col_offset`    — column shift for split windows (0 for single buffer)
   """
   @type line_params :: %{
-          line_text: String.t(),
-          buf_line: non_neg_integer(),
-          cursor_line: non_neg_integer(),
-          byte_offset: non_neg_integer(),
-          screen_row: non_neg_integer(),
-          ctx: Context.t(),
-          ln_style: Gutter.line_number_style(),
-          gutter_w: non_neg_integer(),
-          sign_w: non_neg_integer(),
-          wrap_entry: WrapMap.wrap_entry() | nil,
-          max_rows: pos_integer(),
-          row_offset: non_neg_integer(),
-          col_offset: non_neg_integer()
+          required(:line_text) => String.t(),
+          required(:buf_line) => non_neg_integer(),
+          required(:cursor_line) => non_neg_integer(),
+          required(:byte_offset) => non_neg_integer(),
+          required(:screen_row) => non_neg_integer(),
+          required(:ctx) => Context.t(),
+          required(:ln_style) => Gutter.line_number_style(),
+          required(:gutter_w) => non_neg_integer(),
+          required(:sign_w) => non_neg_integer(),
+          required(:wrap_entry) => WrapMap.wrap_entry() | nil,
+          required(:max_rows) => pos_integer(),
+          required(:row_offset) => non_neg_integer(),
+          required(:col_offset) => non_neg_integer(),
+          optional(:highlight_segments) => [Highlight.styled_segment()] | nil
         }
 
   @doc """
@@ -90,7 +92,14 @@ defmodule Minga.Editor.Renderer.BufferLine do
     gutter_cmd = render_number(p, sr)
 
     content_cmds =
-      LineRenderer.render(p.line_text, sr, p.buf_line, p.ctx, p.byte_offset)
+      LineRenderer.render(
+        p.line_text,
+        sr,
+        p.buf_line,
+        p.ctx,
+        p.byte_offset,
+        Map.get(p, :highlight_segments)
+      )
 
     content_cmds = maybe_apply_cursorline(content_cmds, sr, p)
     content_cmds = maybe_apply_decoration_bg(content_cmds, sr, p)

--- a/lib/minga/editor/renderer/line.ex
+++ b/lib/minga/editor/renderer/line.ex
@@ -26,10 +26,29 @@ defmodule Minga.Editor.Renderer.Line do
   @typedoc "A grapheme paired with its display width."
   @type grapheme_pair :: {String.t(), non_neg_integer()}
 
-  @doc "Renders a single buffer line into draw tuples, including virtual text decorations."
-  @spec render(String.t(), non_neg_integer(), non_neg_integer(), Context.t(), non_neg_integer()) ::
+  @doc """
+  Renders a single buffer line into draw tuples, including virtual text decorations.
+
+  When `precomputed_segments` is provided (from `Highlight.styles_for_visible_lines/2`),
+  it's used directly instead of calling `styles_for_line/3` per line.
+  """
+  @spec render(
+          String.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          Context.t(),
+          non_neg_integer(),
+          [Highlight.styled_segment()] | nil
+        ) ::
           [DisplayList.draw()]
-  def render(line_text, screen_row, buf_line, %Context{} = ctx, line_byte_offset \\ 0) do
+  def render(
+        line_text,
+        screen_row,
+        buf_line,
+        %Context{} = ctx,
+        line_byte_offset \\ 0,
+        precomputed_segments \\ nil
+      ) do
     pairs = grapheme_pairs(line_text)
     line_display_len = display_width_of_pairs(pairs)
 
@@ -54,7 +73,8 @@ defmodule Minga.Editor.Renderer.Line do
           buf_line,
           ctx,
           line_byte_offset,
-          line_highlights
+          line_highlights,
+          precomputed_segments
         )
 
       nil when line_highlights != [] ->
@@ -450,7 +470,8 @@ defmodule Minga.Editor.Renderer.Line do
           non_neg_integer(),
           Context.t(),
           non_neg_integer(),
-          [Decorations.highlight_range()]
+          [Decorations.highlight_range()],
+          [Highlight.styled_segment()] | nil
         ) ::
           [DisplayList.draw()]
   defp render_highlighted_line(
@@ -459,9 +480,12 @@ defmodule Minga.Editor.Renderer.Line do
          buf_line,
          ctx,
          line_byte_offset,
-         line_highlights
+         line_highlights,
+         precomputed_segments
        ) do
-    segments = Highlight.styles_for_line(ctx.highlight, line_text, line_byte_offset)
+    segments =
+      precomputed_segments ||
+        Highlight.styles_for_line(ctx.highlight, line_text, line_byte_offset)
 
     # Merge decoration highlight ranges with syntax segments (pre-queried, no double lookup)
     segments = Decorations.merge_highlights(segments, line_highlights, buf_line)

--- a/lib/minga/highlight.ex
+++ b/lib/minga/highlight.ex
@@ -111,26 +111,22 @@ defmodule Minga.Highlight do
     [{line_text, []}]
   end
 
-  # Fast path: tuple spans with binary search (production path from Zig)
+  # Fast path: tuple spans (production path from Zig)
   def styles_for_line(%__MODULE__{spans: spans} = hl, line_text, line_start_byte)
       when is_tuple(spans) and is_binary(line_text) and is_integer(line_start_byte) and
              line_start_byte >= 0 do
     line_end_byte = line_start_byte + byte_size(line_text)
     span_count = tuple_size(spans)
 
-    # Spans are stored in a tuple sorted by start_byte. Binary search for
-    # the first span that could overlap this line, then collect forward.
-    start_idx = bsearch_first_overlap(spans, span_count, line_start_byte)
-
-    overlapping =
-      collect_overlapping(spans, span_count, start_idx, line_start_byte, line_end_byte, [])
+    # Linear scan from index 0: end_byte is non-monotonic in the start_byte-
+    # sorted span array (a large parent can start before a line but extend
+    # past it), so binary search on end_byte is unsound. The batch path
+    # (styles_for_visible_lines/2) avoids this cost via an advancing watermark.
+    overlapping = collect_overlapping(spans, span_count, 0, line_start_byte, line_end_byte, [])
 
     case overlapping do
-      [] ->
-        [{line_text, []}]
-
-      _ ->
-        build_segments(line_text, line_start_byte, line_end_byte, overlapping, hl)
+      [] -> [{line_text, []}]
+      _ -> build_segments(line_text, line_start_byte, overlapping, hl)
     end
   end
 
@@ -141,33 +137,75 @@ defmodule Minga.Highlight do
     styles_for_line(%{hl | spans: List.to_tuple(spans)}, line_text, line_start_byte)
   end
 
-  # ── Private ──
+  @doc """
+  Batch-compute styled segments for multiple consecutive lines in a single
+  pass over the span tuple. Returns a list of `[styled_segment()]` in the
+  same order as the input lines.
 
-  # Binary search for the first span index whose end_byte > line_start_byte.
-  # This is the earliest span that could overlap the line. Spans are sorted
-  # by start_byte, but a span starting before the line could extend into it,
-  # so we search on end_byte to catch those.
-  @spec bsearch_first_overlap(tuple(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
-  defp bsearch_first_overlap(_spans, 0, _line_start), do: 0
+  This is O(total_spans + total_overlapping_pairs) regardless of file size,
+  compared to O(spans × visible_lines) for repeated `styles_for_line/3` calls.
+  Use this for rendering visible lines.
 
-  defp bsearch_first_overlap(spans, count, line_start) do
-    do_bsearch(spans, 0, count - 1, line_start)
+  Each element in `lines` is `{line_text, line_start_byte}`.
+  """
+  @spec styles_for_visible_lines(t(), [{String.t(), non_neg_integer()}]) ::
+          [[styled_segment()]]
+  def styles_for_visible_lines(%__MODULE__{spans: spans}, lines)
+      when (is_tuple(spans) and tuple_size(spans) == 0) or spans == [] do
+    Enum.map(lines, fn {text, _} -> [{text, []}] end)
   end
 
-  @spec do_bsearch(tuple(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
-          non_neg_integer()
-  defp do_bsearch(_spans, low, high, _line_start) when low > high, do: low
+  def styles_for_visible_lines(%__MODULE__{spans: spans} = hl, lines)
+      when is_tuple(spans) and is_list(lines) do
+    span_count = tuple_size(spans)
+    {results_rev, _watermark} = batch_lines(lines, spans, span_count, hl, 0, [])
+    Enum.reverse(results_rev)
+  end
 
-  defp do_bsearch(spans, low, high, line_start) do
-    mid = div(low + high, 2)
-    span = elem(spans, mid)
+  # ── Private: batch rendering ─────────────────────────────────────────
+
+  @spec batch_lines(
+          [{String.t(), non_neg_integer()}],
+          tuple(),
+          non_neg_integer(),
+          t(),
+          non_neg_integer(),
+          [[styled_segment()]]
+        ) :: {[[styled_segment()]], non_neg_integer()}
+  defp batch_lines([], _spans, _count, _hl, watermark, acc), do: {acc, watermark}
+
+  defp batch_lines([{line_text, line_start} | rest], spans, count, hl, watermark, acc) do
+    line_end = line_start + byte_size(line_text)
+
+    # Advance watermark past spans that can't overlap this or any later line.
+    watermark = advance_watermark(spans, count, watermark, line_start)
+
+    overlapping = collect_overlapping(spans, count, watermark, line_start, line_end, [])
+
+    segments =
+      case overlapping do
+        [] -> [{line_text, []}]
+        _ -> build_segments(line_text, line_start, overlapping, hl)
+      end
+
+    batch_lines(rest, spans, count, hl, watermark, [segments | acc])
+  end
+
+  @spec advance_watermark(tuple(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  defp advance_watermark(_spans, count, idx, _line_start) when idx >= count, do: idx
+
+  defp advance_watermark(spans, count, idx, line_start) do
+    span = elem(spans, idx)
 
     if span.end_byte <= line_start do
-      do_bsearch(spans, mid + 1, high, line_start)
+      advance_watermark(spans, count, idx + 1, line_start)
     else
-      do_bsearch(spans, low, mid - 1, line_start)
+      idx
     end
   end
+
+  # ── Private: overlap collection ──────────────────────────────────────
 
   # Collect spans that overlap [line_start, line_end) starting from start_idx.
   # Stops once spans start past the line.
@@ -188,94 +226,161 @@ defmodule Minga.Highlight do
 
     cond do
       span.start_byte >= line_end ->
-        # Past the line — done
         Enum.reverse(acc)
 
       span.end_byte > line_start ->
-        # Overlaps the line
         collect_overlapping(spans, count, idx + 1, line_start, line_end, [span | acc])
 
       true ->
-        # Ends before line starts — skip
         collect_overlapping(spans, count, idx + 1, line_start, line_end, acc)
     end
   end
 
-  # Spans arrive from Zig pre-sorted by (start_byte ASC, pattern_index DESC,
-  # end_byte ASC). This means the most specific tree-sitter pattern comes first
-  # at each byte position. The left-to-right walk below uses first-wins: the
-  # first span covering a position determines its style, and later spans that
-  # overlap already-rendered text are skipped.
+  # ── Private: innermost-wins span resolution ──────────────────────────
+  #
+  # Tree-sitter queries emit captures on both parent and child nodes. The
+  # correct rendering is *innermost-wins*: a child node's capture overrides
+  # its parent's capture for the child's byte range. The parent's style
+  # resumes after the child ends. Injection spans (layer > 0) always beat
+  # outer spans (layer 0) at the same position.
+  #
+  # Algorithm:
+  #   1. Convert overlapping spans to boundary events (:open / :close)
+  #   2. Sort events by position (close before open at same byte)
+  #   3. Walk events maintaining a sorted active set
+  #   4. Priority: layer DESC, width ASC, pattern_index DESC
+  #   5. Emit segments at each style-change boundary
 
-  @spec build_segments(
-          String.t(),
-          non_neg_integer(),
-          non_neg_integer(),
-          [Minga.Port.Protocol.highlight_span()],
-          t()
-        ) :: [styled_segment()]
-  defp build_segments(line_text, line_start, line_end, spans, hl) do
-    do_build(line_text, line_start, line_end, spans, hl, 0, [])
+  @spec build_segments(String.t(), non_neg_integer(), [map()], t()) :: [styled_segment()]
+  defp build_segments(line_text, line_start, spans, hl) do
+    # Filter out internal captures (names starting with _) before the sweep.
+    # These are used by tree-sitter queries for predicate matching only,
+    # not for highlighting. Neovim and Helix both skip these.
+    spans = Enum.reject(spans, fn s -> internal_capture?(hl, s.capture_id) end)
+
+    case spans do
+      [] ->
+        [{line_text, []}]
+
+      _ ->
+        line_len = byte_size(line_text)
+        events = spans_to_events(spans, line_start, line_len)
+        sweep_events(events, line_text, hl, 0, [], [])
+    end
   end
 
-  @spec do_build(
-          String.t(),
-          non_neg_integer(),
-          non_neg_integer(),
-          [Minga.Port.Protocol.highlight_span()],
-          t(),
-          non_neg_integer(),
+  @spec internal_capture?(t(), non_neg_integer()) :: boolean()
+  defp internal_capture?(hl, capture_id) do
+    case Enum.at(hl.capture_names, capture_id) do
+      "_" <> _ -> true
+      _ -> false
+    end
+  end
+
+  @typep span_event :: {non_neg_integer(), :open | :close, map()}
+
+  @spec spans_to_events([map()], non_neg_integer(), non_neg_integer()) :: [span_event()]
+  defp spans_to_events(spans, line_start, line_len) do
+    spans
+    |> Enum.flat_map(fn span ->
+      s = max(span.start_byte - line_start, 0)
+      e = min(span.end_byte - line_start, line_len)
+
+      if e > s do
+        [{s, :open, span}, {e, :close, span}]
+      else
+        []
+      end
+    end)
+    |> Enum.sort_by(fn
+      # Close before open at same position. Among closes, narrower first.
+      # Among opens, broader first (parent opens before child).
+      {pos, :close, span} ->
+        width = span.end_byte - span.start_byte
+        {pos, 0, width}
+
+      {pos, :open, span} ->
+        width = span.end_byte - span.start_byte
+        {pos, 1, -width}
+    end)
+  end
+
+  # Walk events left-to-right, emitting segments at each style change.
+  # `active` is a sorted list of {layer, width, pattern_index, capture_id}
+  # where hd(active) is always the winning span.
+  @typep active_entry ::
+           {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
+
+  @spec sweep_events([span_event()], String.t(), t(), non_neg_integer(), [active_entry()], [
+          styled_segment()
+        ]) ::
           [styled_segment()]
-        ) :: [styled_segment()]
-  defp do_build(line_text, _line_start, _line_end, [], _hl, pos, acc) do
+  defp sweep_events([], line_text, _hl, pos, _active, acc) do
     line_len = byte_size(line_text)
 
     if pos < line_len do
-      segment = safe_binary_slice(line_text, pos, line_len - pos)
-      Enum.reverse([{segment, []} | acc])
+      seg = safe_binary_slice(line_text, pos, line_len - pos)
+      Enum.reverse([{seg, []} | acc])
     else
       Enum.reverse(acc)
     end
   end
 
-  defp do_build(line_text, line_start, line_end, [span | rest], hl, pos, acc) do
-    line_len = byte_size(line_text)
+  defp sweep_events([{event_pos, type, span} | rest], line_text, hl, pos, active, acc) do
+    # Emit text from pos to event_pos with current winning style
+    acc =
+      if event_pos > pos do
+        style = winning_style(active, hl)
+        seg = safe_binary_slice(line_text, pos, event_pos - pos)
+        [{seg, style} | acc]
+      else
+        acc
+      end
 
-    # Clamp span to line boundaries (relative to line_start)
-    span_start_in_line = max(span.start_byte - line_start, 0)
-    span_end_in_line = min(span.end_byte - line_start, line_len)
+    new_pos = max(pos, event_pos)
 
-    # Skip spans that are entirely behind our current position
-    if span_end_in_line <= pos or span_start_in_line >= line_len do
-      do_build(line_text, line_start, line_end, rest, hl, pos, acc)
-    else
-      # Adjust start to not overlap with already-rendered text
-      effective_start = max(span_start_in_line, pos)
+    layer = Map.get(span, :layer, 0)
+    width = span.end_byte - span.start_byte
+    pidx = Map.get(span, :pattern_index, 0)
+    cid = span.capture_id
+    entry = {layer, width, pidx, cid}
 
-      # Gap before this span
-      acc =
-        if effective_start > pos do
-          gap = safe_binary_slice(line_text, pos, effective_start - pos)
-          [{gap, []} | acc]
-        else
-          acc
-        end
+    active =
+      case type do
+        :open -> insert_active(active, entry)
+        :close -> remove_active(active, entry)
+      end
 
-      # The highlighted segment
-      style = resolve_style(hl, span.capture_id)
-      seg_len = span_end_in_line - effective_start
+    sweep_events(rest, line_text, hl, new_pos, active, acc)
+  end
 
-      acc =
-        if seg_len > 0 do
-          segment = safe_binary_slice(line_text, effective_start, seg_len)
-          [{segment, style} | acc]
-        else
-          acc
-        end
+  @spec winning_style([active_entry()], t()) :: Minga.Port.Protocol.style()
+  defp winning_style([], _hl), do: []
 
-      do_build(line_text, line_start, line_end, rest, hl, span_end_in_line, acc)
+  defp winning_style([{_layer, _width, _pidx, capture_id} | _], hl),
+    do: resolve_style(hl, capture_id)
+
+  # Insert into active set maintaining priority order:
+  # (layer DESC, width ASC, pattern_index DESC)
+  # The head is always the winner.
+  @spec insert_active([active_entry()], active_entry()) :: [active_entry()]
+  defp insert_active([], entry), do: [entry]
+
+  defp insert_active([{hl, hw, hp, _} = head | tail], {el, ew, ep, _} = entry) do
+    cond do
+      el > hl -> [entry, head | tail]
+      el < hl -> [head | insert_active(tail, entry)]
+      ew < hw -> [entry, head | tail]
+      ew > hw -> [head | insert_active(tail, entry)]
+      ep > hp -> [entry, head | tail]
+      true -> [head | insert_active(tail, entry)]
     end
   end
+
+  @spec remove_active([active_entry()], active_entry()) :: [active_entry()]
+  defp remove_active([], _entry), do: []
+  defp remove_active([entry | tail], entry), do: tail
+  defp remove_active([head | tail], entry), do: [head | remove_active(tail, entry)]
 
   @spec resolve_style(t(), non_neg_integer()) :: Minga.Port.Protocol.style()
   defp resolve_style(hl, capture_id) do

--- a/lib/minga/port/protocol.ex
+++ b/lib/minga/port/protocol.ex
@@ -189,7 +189,9 @@ defmodule Minga.Port.Protocol do
   @type highlight_span :: %{
           start_byte: non_neg_integer(),
           end_byte: non_neg_integer(),
-          capture_id: non_neg_integer()
+          capture_id: non_neg_integer(),
+          pattern_index: non_neg_integer(),
+          layer: non_neg_integer()
         }
 
   @typedoc "Text style attributes."
@@ -823,11 +825,19 @@ defmodule Minga.Port.Protocol do
   defp decode_spans(_rest, 0, acc), do: {:ok, Enum.reverse(acc)}
 
   defp decode_spans(
-         <<start_byte::32, end_byte::32, capture_id::16, rest::binary>>,
+         <<start_byte::32, end_byte::32, capture_id::16, pattern_index::16, layer::16,
+           rest::binary>>,
          remaining,
          acc
        ) do
-    span = %{start_byte: start_byte, end_byte: end_byte, capture_id: capture_id}
+    span = %{
+      start_byte: start_byte,
+      end_byte: end_byte,
+      capture_id: capture_id,
+      pattern_index: pattern_index,
+      layer: layer
+    }
+
     decode_spans(rest, remaining - 1, [span | acc])
   end
 

--- a/test/minga/highlight_test.exs
+++ b/test/minga/highlight_test.exs
@@ -128,7 +128,6 @@ defmodule Minga.HighlightTest do
     end
 
     test "span crossing line boundary is clamped" do
-      # Span covers bytes 0-20, but line is only bytes 5-10
       hl = %Highlight{
         version: 1,
         spans: [%{start_byte: 0, end_byte: 20, capture_id: 0}],
@@ -164,15 +163,13 @@ defmodule Minga.HighlightTest do
       assert [{"def", []}, {" foo", []}] = result
     end
 
-    test "overlapping spans use first (pre-sorted by Zig with highest priority first)" do
-      # Spans arrive from Zig sorted by (start_byte ASC, pattern_index DESC).
-      # The most specific pattern comes first. First-wins picks it.
-      # In tests, we simulate this by putting the specific span first.
+    test "same-width spans: higher pattern_index wins" do
+      # Two captures on the same node. Higher pattern_index = later in query = more specific.
       hl = %Highlight{
         version: 1,
         spans: [
-          %{start_byte: 0, end_byte: 9, capture_id: 1},
-          %{start_byte: 0, end_byte: 9, capture_id: 0}
+          %{start_byte: 0, end_byte: 9, capture_id: 0, pattern_index: 3},
+          %{start_byte: 0, end_byte: 9, capture_id: 1, pattern_index: 10}
         ],
         capture_names: ["keyword", "keyword.function"],
         theme: %{
@@ -182,12 +179,10 @@ defmodule Minga.HighlightTest do
       }
 
       result = Highlight.styles_for_line(hl, "defmodule Foo do", 0)
-
-      # Should NOT produce "defmodule" twice
       all_text = Enum.map_join(result, fn {text, _} -> text end)
       assert all_text == "defmodule Foo do"
 
-      # First span (highest priority) wins for the overlapping region
+      # Higher pattern_index wins
       assert [{"defmodule", [fg: 0x00FF00]}, {" Foo do", []}] = result
     end
 
@@ -207,17 +202,15 @@ defmodule Minga.HighlightTest do
       assert all_text == "hello world"
     end
 
-    test "contained spans: inner overrides outer when sorted first" do
-      # Spans pre-sorted by Zig: narrower (inner) before broader (outer)
-      # at the same start_byte. Inner span at 0-2 comes first, wins for
-      # its range, then outer covers the remainder.
-      # String: #{content} = bytes: #(0) {(1) c(2) o(3) n(4) t(5) e(6) n(7) t(8) }(9)
+    test "innermost-wins: child spans override parent spans" do
+      # String interpolation: #{content}
+      # Outer "embedded" span covers everything, inner "punctuation.special" covers #{ and }
       hl = %Highlight{
         version: 1,
         spans: [
-          %{start_byte: 0, end_byte: 2, capture_id: 1},
-          %{start_byte: 0, end_byte: 10, capture_id: 0},
-          %{start_byte: 9, end_byte: 10, capture_id: 1}
+          %{start_byte: 0, end_byte: 2, capture_id: 1, pattern_index: 10},
+          %{start_byte: 0, end_byte: 10, capture_id: 0, pattern_index: 5},
+          %{start_byte: 9, end_byte: 10, capture_id: 1, pattern_index: 10}
         ],
         capture_names: ["embedded", "punctuation.special"],
         theme: %{
@@ -230,37 +223,101 @@ defmodule Minga.HighlightTest do
       all_text = Enum.map_join(result, fn {text, _} -> text end)
       assert all_text == "\#{content}"
 
-      # Inner span wins for its range, outer covers the rest
       assert [
                {"\#{", [fg: 0xFF0000]},
-               {"content}", [fg: 0xAAAAAA]}
+               {"content", [fg: 0xAAAAAA]},
+               {"}", [fg: 0xFF0000]}
              ] = result
     end
 
-    test "three overlapping spans at same position: first (highest priority) wins" do
-      # Spans arrive from Zig sorted by pattern_index DESC.
-      # In this test, keyword has the highest priority so comes first.
+    test "innermost-wins: module attribute with atoms" do
+      # @reference_forms [:alias, :import, :require]
+      # Parent @constant covers entire expression, child atoms get their own style
       hl = %Highlight{
         version: 1,
-        spans: [
-          %{start_byte: 0, end_byte: 3, capture_id: 2},
-          %{start_byte: 0, end_byte: 3, capture_id: 1},
-          %{start_byte: 0, end_byte: 3, capture_id: 0}
-        ],
-        capture_names: ["variable", "function", "keyword"],
+        spans:
+          List.to_tuple([
+            %{start_byte: 0, end_byte: 44, capture_id: 1, pattern_index: 38},
+            %{start_byte: 18, end_byte: 24, capture_id: 0, pattern_index: 5},
+            %{start_byte: 26, end_byte: 33, capture_id: 0, pattern_index: 5},
+            %{start_byte: 35, end_byte: 43, capture_id: 0, pattern_index: 5}
+          ]),
+        capture_names: ["string.special.symbol", "constant"],
         theme: %{
-          "variable" => [fg: 0x111111],
-          "function" => [fg: 0x222222],
-          "keyword" => [fg: 0x333333]
+          "string.special.symbol" => [fg: 0xAA00FF],
+          "constant" => [fg: 0xDA8548]
         }
       }
 
-      result = Highlight.styles_for_line(hl, "def bar", 0)
-      assert [{"def", [fg: 0x333333]}, {" bar", []}] = result
+      line = "@reference_forms [:alias, :import, :require]"
+      result = Highlight.styles_for_line(hl, line, 0)
+      all_text = Enum.map_join(result, fn {text, _} -> text end)
+      assert all_text == line
+
+      assert [
+               {"@reference_forms [", [fg: 0xDA8548]},
+               {":alias", [fg: 0xAA00FF]},
+               {", ", [fg: 0xDA8548]},
+               {":import", [fg: 0xAA00FF]},
+               {", ", [fg: 0xDA8548]},
+               {":require", [fg: 0xAA00FF]},
+               {"]", [fg: 0xDA8548]}
+             ] = result
+    end
+
+    test "innermost-wins: three nesting levels" do
+      hl = %Highlight{
+        version: 1,
+        spans:
+          List.to_tuple([
+            %{start_byte: 0, end_byte: 20, capture_id: 0, pattern_index: 1},
+            %{start_byte: 5, end_byte: 15, capture_id: 1, pattern_index: 2},
+            %{start_byte: 8, end_byte: 12, capture_id: 2, pattern_index: 3}
+          ]),
+        capture_names: ["outer", "middle", "inner"],
+        theme: %{
+          "outer" => [fg: 0x111111],
+          "middle" => [fg: 0x222222],
+          "inner" => [fg: 0x333333]
+        }
+      }
+
+      result = Highlight.styles_for_line(hl, "01234567890123456789", 0)
+      all_text = Enum.map_join(result, fn {text, _} -> text end)
+      assert all_text == "01234567890123456789"
+
+      assert [
+               {"01234", [fg: 0x111111]},
+               {"567", [fg: 0x222222]},
+               {"8901", [fg: 0x333333]},
+               {"234", [fg: 0x222222]},
+               {"56789", [fg: 0x111111]}
+             ] = result
+    end
+
+    test "injection layer always wins over outer layer" do
+      # layer=1 (injection) beats layer=0 (outer) even when outer is narrower
+      hl = %Highlight{
+        version: 1,
+        spans:
+          List.to_tuple([
+            %{start_byte: 0, end_byte: 5, capture_id: 0, pattern_index: 10, layer: 0},
+            %{start_byte: 0, end_byte: 10, capture_id: 1, pattern_index: 1, layer: 1}
+          ]),
+        capture_names: ["outer.keyword", "injection.string"],
+        theme: %{
+          "outer.keyword" => [fg: 0xFF0000],
+          "injection.string" => [fg: 0x00FF00]
+        }
+      }
+
+      result = Highlight.styles_for_line(hl, "hello world", 0)
+
+      # Injection wins everywhere it covers, even though outer is narrower
+      assert [{"hello", [fg: 0x00FF00]}, {" worl", [fg: 0x00FF00]}, {"d", []}] = result
     end
 
     test "with line_start_byte offset" do
-      # "def foo\nbar baz" — line 2 starts at byte 8
       hl = %Highlight{
         version: 1,
         spans: [%{start_byte: 8, end_byte: 11, capture_id: 0}],
@@ -270,6 +327,87 @@ defmodule Minga.HighlightTest do
 
       result = Highlight.styles_for_line(hl, "bar baz", 8)
       assert [{"bar", [fg: 0xFF0000]}, {" baz", []}] = result
+    end
+  end
+
+  describe "styles_for_visible_lines/2" do
+    test "empty highlights returns unstyled segments" do
+      hl = Highlight.new()
+
+      result =
+        Highlight.styles_for_visible_lines(hl, [
+          {"hello", 0},
+          {"world", 6}
+        ])
+
+      assert result == [[{"hello", []}], [{"world", []}]]
+    end
+
+    test "results match per-line styles_for_line" do
+      hl = %Highlight{
+        version: 1,
+        spans:
+          List.to_tuple([
+            %{start_byte: 0, end_byte: 3, capture_id: 0, pattern_index: 1},
+            %{start_byte: 8, end_byte: 13, capture_id: 1, pattern_index: 2}
+          ]),
+        capture_names: ["keyword", "string"],
+        theme: %{"keyword" => [fg: 0xFF0000], "string" => [fg: 0x00FF00]}
+      }
+
+      lines = [{"def foo", 0}, {"world", 8}]
+
+      batch_result = Highlight.styles_for_visible_lines(hl, lines)
+
+      per_line_result =
+        Enum.map(lines, fn {text, offset} ->
+          Highlight.styles_for_line(hl, text, offset)
+        end)
+
+      assert batch_result == per_line_result
+    end
+
+    test "multi-line span handled correctly across lines" do
+      hl = %Highlight{
+        version: 1,
+        spans:
+          List.to_tuple([
+            %{start_byte: 0, end_byte: 30, capture_id: 0, pattern_index: 1}
+          ]),
+        capture_names: ["comment"],
+        theme: %{"comment" => [fg: 0x888888]}
+      }
+
+      lines = [{"first", 0}, {"second", 6}, {"third", 13}]
+      result = Highlight.styles_for_visible_lines(hl, lines)
+
+      assert result == [
+               [{"first", [fg: 0x888888]}],
+               [{"second", [fg: 0x888888]}],
+               [{"third", [fg: 0x888888]}]
+             ]
+    end
+
+    test "watermark advances past consumed spans" do
+      hl = %Highlight{
+        version: 1,
+        spans:
+          List.to_tuple([
+            %{start_byte: 0, end_byte: 3, capture_id: 0, pattern_index: 1},
+            %{start_byte: 10, end_byte: 15, capture_id: 1, pattern_index: 2}
+          ]),
+        capture_names: ["keyword", "string"],
+        theme: %{"keyword" => [fg: 0xFF0000], "string" => [fg: 0x00FF00]}
+      }
+
+      lines = [{"def foo", 0}, {"hello", 8}, {"world", 14}]
+      result = Highlight.styles_for_visible_lines(hl, lines)
+
+      assert result == [
+               [{"def", [fg: 0xFF0000]}, {" foo", []}],
+               [{"he", []}, {"llo", [fg: 0x00FF00]}],
+               [{"w", [fg: 0x00FF00]}, {"orld", []}]
+             ]
     end
   end
 end

--- a/test/minga/port/protocol_test.exs
+++ b/test/minga/port/protocol_test.exs
@@ -519,17 +519,32 @@ defmodule Minga.Port.ProtocolTest do
     end
 
     test "decode_event highlight_spans" do
+      # Each span: start_byte:u32, end_byte:u32, capture_id:u16, pattern_index:u16, layer:u16
       spans_binary =
-        <<0::32, 9::32, 0::16>> <>
-          <<10::32, 15::32, 1::16>>
+        <<0::32, 9::32, 0::16, 5::16, 0::16>> <>
+          <<10::32, 15::32, 1::16, 3::16, 1::16>>
 
       # buffer_id=5, version=42, count=2
       payload = <<0x30, 5::32, 42::32, 2::32>> <> spans_binary
 
       assert {:ok, {:highlight_spans, 5, 42, spans}} = Protocol.decode_event(payload)
       assert length(spans) == 2
-      assert hd(spans) == %{start_byte: 0, end_byte: 9, capture_id: 0}
-      assert List.last(spans) == %{start_byte: 10, end_byte: 15, capture_id: 1}
+
+      assert hd(spans) == %{
+               start_byte: 0,
+               end_byte: 9,
+               capture_id: 0,
+               pattern_index: 5,
+               layer: 0
+             }
+
+      assert List.last(spans) == %{
+               start_byte: 10,
+               end_byte: 15,
+               capture_id: 1,
+               pattern_index: 3,
+               layer: 1
+             }
     end
 
     test "decode_event highlight_names" do
@@ -563,8 +578,8 @@ defmodule Minga.Port.ProtocolTest do
     end
 
     test "decode_event malformed highlight_spans" do
-      # buffer_id=0, version=1, count says 2 spans but only 1 provided
-      payload = <<0x30, 0::32, 1::32, 2::32, 0::32, 9::32, 0::16>>
+      # buffer_id=0, version=1, count says 2 spans but only 1 complete span (14 bytes)
+      payload = <<0x30, 0::32, 1::32, 2::32, 0::32, 9::32, 0::16, 0::16, 0::16>>
       assert {:error, :malformed} = Protocol.decode_event(payload)
     end
   end

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -151,6 +151,23 @@ pub fn build(b: *std.Build) void {
     const run_tests = b.addRunArtifact(tests);
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_tests.step);
+
+    // Parser tests (highlighter, predicates, posix_regex)
+    const parser_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/parser_main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    parser_tests.root_module.addImport("build_options", build_options.createModule());
+    parser_tests.root_module.addIncludePath(b.path("vendor/tree-sitter/include"));
+    parser_tests.root_module.link_libc = true;
+    parser_tests.linkLibrary(ts_lib);
+    for (grammar_libs) |gl| parser_tests.linkLibrary(gl);
+
+    const run_parser_tests = b.addRunArtifact(parser_tests);
+    test_step.dependOn(&run_parser_tests.step);
 }
 
 /// Build a static library for a tree-sitter grammar.

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -492,7 +492,7 @@ pub const Highlighter = struct {
 
         var match: c.TSQueryMatch = undefined;
         while (c.ts_query_cursor_next_match(cursor, &match)) {
-            const captures = match.captures[0..@intCast(match.capture_count)];
+            const captures = if (match.captures == null) continue else match.captures[0..@intCast(match.capture_count)];
             for (captures) |cap| {
                 const node = cap.node;
                 const start_line: u32 = @intCast(c.ts_node_start_point(node).row);
@@ -597,7 +597,7 @@ pub const Highlighter = struct {
         var match: c.TSQueryMatch = undefined;
 
         while (c.ts_query_cursor_next_match(cursor, &match)) {
-            const captures = match.captures[0..@intCast(match.capture_count)];
+            const captures = if (match.captures == null) continue else match.captures[0..@intCast(match.capture_count)];
             for (captures) |cap| {
                 const node = cap.node;
                 const node_start = c.ts_node_start_point(node).row;
@@ -699,7 +699,7 @@ pub const Highlighter = struct {
 
         var match: c.TSQueryMatch = undefined;
         while (c.ts_query_cursor_next_match(cursor, &match)) {
-            const captures = match.captures[0..@intCast(match.capture_count)];
+            const captures = if (match.captures == null) continue else match.captures[0..@intCast(match.capture_count)];
             for (captures) |cap| {
                 if (cap.index != tid) continue;
 
@@ -796,7 +796,7 @@ pub const Highlighter = struct {
 
         var match: c.TSQueryMatch = undefined;
         while (c.ts_query_cursor_next_match(cursor, &match)) {
-            const captures = match.captures[0..@intCast(match.capture_count)];
+            const captures = if (match.captures == null) continue else match.captures[0..@intCast(match.capture_count)];
             for (captures) |cap| {
                 if (cap.index >= 64) continue;
                 const type_id = cap_to_type[cap.index] orelse continue;
@@ -909,7 +909,7 @@ pub const Highlighter = struct {
             if (self.current_predicates) |preds| {
                 if (!preds.evaluate(match, source)) continue;
             }
-            const captures = match.captures[0..match.capture_count];
+            const captures = if (match.captures == null) continue else match.captures[0..match.capture_count];
             for (captures) |cap| {
                 const node = cap.node;
                 const start = c.ts_node_start_byte(node);
@@ -973,7 +973,7 @@ pub const Highlighter = struct {
             if (self.current_predicates) |preds| {
                 if (!preds.evaluate(match, source)) continue;
             }
-            const captures = match.captures[0..match.capture_count];
+            const captures = if (match.captures == null) continue else match.captures[0..match.capture_count];
             for (captures) |cap| {
                 try spans.append(alloc, .{
                     .start_byte = c.ts_node_start_byte(cap.node),
@@ -1046,7 +1046,7 @@ pub const Highlighter = struct {
             var content_node: ?c.TSNode = null;
             var lang_from_capture: ?[]const u8 = null;
 
-            const caps = inj_match.captures[0..inj_match.capture_count];
+            const caps = if (inj_match.captures == null) continue else inj_match.captures[0..inj_match.capture_count];
             for (caps) |cap| {
                 if (cap.index == content_capture_id.?) {
                     content_node = cap.node;
@@ -1228,7 +1228,7 @@ pub const Highlighter = struct {
                 if (inj_preds) |preds| {
                     if (!preds.evaluate(hl_match, source)) continue;
                 }
-                const caps = hl_match.captures[0..hl_match.capture_count];
+                const caps = if (hl_match.captures == null) continue else hl_match.captures[0..hl_match.capture_count];
                 for (caps) |cap| {
                     const start = c.ts_node_start_byte(cap.node);
                     const end = c.ts_node_end_byte(cap.node);
@@ -1253,43 +1253,10 @@ pub const Highlighter = struct {
             }
         }
 
-        // ── Phase 4: Punch holes in outer spans ──────────────────────────
-        // The BEAM's renderer sorts spans by start_byte and uses first-wins.
-        // Outer spans that cover injection regions would "eat" the injection
-        // spans because they start at a lower byte offset. Fix: trim or
-        // remove outer spans that overlap with any injection region.
-        if (regions.items.len > 0) {
-            // Build sorted injection range list
-            var inj_ranges = try alloc.alloc(TrimRange, regions.items.len);
-            defer alloc.free(inj_ranges);
-            for (regions.items, 0..) |reg, i| {
-                inj_ranges[i] = .{ .start_byte = reg.start_byte, .end_byte = reg.end_byte };
-            }
-            std.mem.sortUnstable(TrimRange, inj_ranges, {}, struct {
-                fn cmp(_: void, a: TrimRange, b: TrimRange) bool {
-                    return a.start_byte < b.start_byte;
-                }
-            }.cmp);
-
-            var trimmed: std.ArrayListUnmanaged(Span) = .empty;
-            errdefer trimmed.deinit(alloc);
-            try trimmed.ensureTotalCapacity(alloc, spans.items.len);
-
-            for (spans.items) |span| {
-                if (span.layer != 0) {
-                    // Injection span — keep as-is
-                    try trimmed.append(alloc, span);
-                    continue;
-                }
-                // Outer span — trim around injection regions
-                try trimOuterSpan(alloc, span, inj_ranges, &trimmed);
-            }
-
-            spans.deinit(alloc);
-            spans = trimmed;
-        }
-
-        // ── Phase 5: Sort and return ─────────────────────────────────────
+        // ── Phase 4: Sort and return ─────────────────────────────────────
+        // All spans (outer layer=0 + injection layer=1) are sent to the BEAM
+        // with full metadata. The BEAM-side innermost-wins sweep resolves
+        // overlaps using (layer DESC, width ASC, pattern_index DESC).
         std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
 
         const names = try alloc.alloc([]const u8, name_list.items.len);
@@ -1398,65 +1365,6 @@ fn getInjectionLanguagePredicate(query: *c.TSQuery, pattern_index: u32) ?[]const
 }
 
 /// A byte range representing an injection region (for internal trimming).
-const TrimRange = struct {
-    start_byte: u32,
-    end_byte: u32,
-};
-
-/// Trims an outer span around injection ranges. If the span doesn't
-/// overlap any range, it's kept as-is. If it partially overlaps, the
-/// non-overlapping fragments are emitted. If fully covered, it's dropped.
-fn trimOuterSpan(
-    alloc: std.mem.Allocator,
-    span: Span,
-    ranges: []const TrimRange,
-    out: *std.ArrayListUnmanaged(Span),
-) !void {
-    // Check if this span overlaps any injection range
-    var overlaps_any = false;
-    for (ranges) |r| {
-        if (span.start_byte < r.end_byte and span.end_byte > r.start_byte) {
-            overlaps_any = true;
-            break;
-        }
-    }
-    if (!overlaps_any) {
-        try out.append(alloc, span);
-        return;
-    }
-
-    // Walk through injection ranges and emit fragments of the outer span
-    // that don't overlap with any range.
-    var pos = span.start_byte;
-    for (ranges) |r| {
-        if (r.start_byte >= span.end_byte) break;
-        if (r.end_byte <= pos) continue;
-
-        // Emit fragment before this range
-        const range_start = @max(r.start_byte, span.start_byte);
-        if (range_start > pos) {
-            try out.append(alloc, .{
-                .start_byte = pos,
-                .end_byte = range_start,
-                .capture_id = span.capture_id,
-                .pattern_index = span.pattern_index,
-                .layer = 0,
-            });
-        }
-        pos = @max(pos, @min(r.end_byte, span.end_byte));
-    }
-
-    // Emit trailing fragment after the last overlapping range
-    if (pos < span.end_byte) {
-        try out.append(alloc, .{
-            .start_byte = pos,
-            .end_byte = span.end_byte,
-            .capture_id = span.capture_id,
-            .pattern_index = span.pattern_index,
-            .layer = 0,
-        });
-    }
-}
 
 // ── Span ordering ─────────────────────────────────────────────────────────
 
@@ -1870,7 +1778,7 @@ test "highlighter: predicates filter #any-of? correctly in Elixir" {
     const source = "defmodule Foo do\n  def bar do\n    IO.puts(\"hello\")\n  end\nend\n";
     try hl.parse(source);
 
-    var result = try hl.highlightWithInjections() catch try hl.highlight();
+    var result = try hl.highlightWithInjections();
     defer result.deinit();
 
     // Find the capture index for "keyword.function" and "function.call"

--- a/zig/src/parser_main.zig
+++ b/zig/src/parser_main.zig
@@ -455,3 +455,10 @@ fn readExact(fd: std.posix.fd_t, buf: []u8) !bool {
     }
     return true;
 }
+
+// Pull in tests from imported modules for the parser test step.
+comptime {
+    _ = @import("highlighter.zig");
+    _ = @import("predicates.zig");
+    _ = @import("posix_regex.zig");
+}

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -169,7 +169,7 @@ pub const Span = struct {
     pattern_index: u16,
     /// Priority layer: 0 = outer language, 1+ = injection depth.
     /// Higher layers win when spans overlap at the same byte position.
-    /// Not serialized in the port protocol.
+    /// Serialized in the port protocol as u16.
     layer: u16 = 0,
 };
 
@@ -485,11 +485,11 @@ pub fn writeMessage(writer: anytype, payload: []const u8) !void {
 
 // ── Encoding: highlight responses (Zig → BEAM) ──
 
-/// Encodes highlight_spans: opcode(1) + version(4) + count(4) + spans(count * 10)
-/// Each span: start_byte:u32, end_byte:u32, capture_id:u16
+/// Encodes highlight_spans: opcode(1) + buffer_id(4) + version(4) + count(4) + spans(count * 14)
+/// Each span: start_byte:u32, end_byte:u32, capture_id:u16, pattern_index:u16, layer:u16
 pub fn encodeHighlightSpans(allocator: std.mem.Allocator, buffer_id: u32, version: u32, spans: []const Span) ![]u8 {
     const header_size = 1 + 4 + 4 + 4; // opcode + buffer_id + version + count
-    const span_size = 10; // 4 + 4 + 2
+    const span_size = 14; // 4 + 4 + 2 + 2 + 2
     const total = header_size + spans.len * span_size;
     const buf = try allocator.alloc(u8, total);
 
@@ -503,6 +503,8 @@ pub fn encodeHighlightSpans(allocator: std.mem.Allocator, buffer_id: u32, versio
         std.mem.writeInt(u32, buf[off..][0..4], span.start_byte, .big);
         std.mem.writeInt(u32, buf[off + 4 ..][0..4], span.end_byte, .big);
         std.mem.writeInt(u16, buf[off + 8 ..][0..2], span.capture_id, .big);
+        std.mem.writeInt(u16, buf[off + 10 ..][0..2], span.pattern_index, .big);
+        std.mem.writeInt(u16, buf[off + 12 ..][0..2], span.layer, .big);
     }
 
     return buf;
@@ -1932,8 +1934,8 @@ test "commandSize: load_grammar" {
 
 test "encodeHighlightSpans round-trip" {
     const spans = [_]Span{
-        .{ .start_byte = 0, .end_byte = 9, .capture_id = 0, .pattern_index = 0 },
-        .{ .start_byte = 10, .end_byte = 15, .capture_id = 1, .pattern_index = 1 },
+        .{ .start_byte = 0, .end_byte = 9, .capture_id = 0, .pattern_index = 5, .layer = 0 },
+        .{ .start_byte = 10, .end_byte = 15, .capture_id = 1, .pattern_index = 3, .layer = 1 },
     };
     const buf = try encodeHighlightSpans(std.testing.allocator, 5, 42, &spans);
     defer std.testing.allocator.free(buf);
@@ -1942,14 +1944,18 @@ test "encodeHighlightSpans round-trip" {
     try std.testing.expectEqual(@as(u32, 5), std.mem.readInt(u32, buf[1..5], .big)); // buffer_id
     try std.testing.expectEqual(@as(u32, 42), std.mem.readInt(u32, buf[5..9], .big)); // version
     try std.testing.expectEqual(@as(u32, 2), std.mem.readInt(u32, buf[9..13], .big)); // count
-    // First span
-    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, buf[13..17], .big));
-    try std.testing.expectEqual(@as(u32, 9), std.mem.readInt(u32, buf[17..21], .big));
-    try std.testing.expectEqual(@as(u16, 0), std.mem.readInt(u16, buf[21..23], .big));
+    // First span (14 bytes each)
+    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, buf[13..17], .big)); // start
+    try std.testing.expectEqual(@as(u32, 9), std.mem.readInt(u32, buf[17..21], .big)); // end
+    try std.testing.expectEqual(@as(u16, 0), std.mem.readInt(u16, buf[21..23], .big)); // capture_id
+    try std.testing.expectEqual(@as(u16, 5), std.mem.readInt(u16, buf[23..25], .big)); // pattern_index
+    try std.testing.expectEqual(@as(u16, 0), std.mem.readInt(u16, buf[25..27], .big)); // layer
     // Second span
-    try std.testing.expectEqual(@as(u32, 10), std.mem.readInt(u32, buf[23..27], .big));
-    try std.testing.expectEqual(@as(u32, 15), std.mem.readInt(u32, buf[27..31], .big));
-    try std.testing.expectEqual(@as(u16, 1), std.mem.readInt(u16, buf[31..33], .big));
+    try std.testing.expectEqual(@as(u32, 10), std.mem.readInt(u32, buf[27..31], .big)); // start
+    try std.testing.expectEqual(@as(u32, 15), std.mem.readInt(u32, buf[31..35], .big)); // end
+    try std.testing.expectEqual(@as(u16, 1), std.mem.readInt(u16, buf[35..37], .big)); // capture_id
+    try std.testing.expectEqual(@as(u16, 3), std.mem.readInt(u16, buf[37..39], .big)); // pattern_index
+    try std.testing.expectEqual(@as(u16, 1), std.mem.readInt(u16, buf[39..41], .big)); // layer
 }
 
 test "encodeHighlightNames round-trip" {

--- a/zig/src/query_loader.zig
+++ b/zig/src/query_loader.zig
@@ -450,7 +450,8 @@ test "resolve: nonexistent language returns null" {
 }
 
 test "resolve: missing query type returns null" {
-    const result = comptime resolve("bash", .folds);
+    // dockerfile has highlights but no folds query
+    const result = comptime resolve("dockerfile", .folds);
     try std.testing.expect(result == null);
 }
 


### PR DESCRIPTION
## What

Replaces the broken first-wins highlight resolution with an event-based sweep that correctly handles tree-sitter's parent/child capture model. Child node captures now override parent captures for their byte range, and the parent's style resumes after. Injection spans always beat outer spans.

## Why

The first-wins algorithm caused incorrect syntax colors: `@moduledoc` heredocs rendered as default text, atoms inside module attributes all showed as orange `@constant`, and `%SourceFile{}` lost its punctuation color. These are all cases where a broad parent span swallowed narrower child spans.

## Changes

### Wire protocol (breaking, both sides rebuilt together)
- Span encoding extended from 10 to 14 bytes: added `pattern_index:u16` and `layer:u16`
- BEAM decoder reads both new fields

### BEAM-side resolution (`highlight.ex`)
- Replaced `do_build` (first-wins) with `sweep_events` (innermost-wins via event-based plane sweep)
- Priority ordering: `(layer DESC, width ASC, pattern_index DESC)`
- Added `styles_for_visible_lines/2` with advancing watermark for O(N) batch rendering

### Zig producer (`highlighter.zig`)
- Removed Phase 4 hole-punching (~100 lines). Zig now sends ALL raw captures; BEAM resolves everything
- Added null safety for `match.captures` across all 8 query cursor loops
- Fixed `highlightWithInjections` test syntax (`try...catch try` was invalid)

### Test infrastructure
- Parser tests (highlighter, predicates, posix_regex) now run via `zig build test`
- Added `parser_tests` step in `build.zig` + comptime imports in `parser_main.zig`
- Fixed `query_loader` test assuming bash has no folds (it does after query sync)

### New test coverage
- Innermost-wins: child overrides parent, three nesting levels, module attribute with atoms
- Injection layer always beats outer layer
- `styles_for_visible_lines` batch: empty, equivalence with per-line, multi-line spans, watermark advancement

Closes #684