### PR TITLE
refactor(editor): extract Emit.GUI module for structured chrome data sends

### DIFF
--- a/lib/minga/editor/render_pipeline/emit.ex
+++ b/lib/minga/editor/render_pipeline/emit.ex
@@ -16,21 +16,17 @@ defmodule Minga.Editor.RenderPipeline.Emit do
   for the most common scroll case (Ctrl-e/y, mouse wheel, cursor near edges).
   """
 
-  alias Minga.Agent.Session, as: AgentSession
-  alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Config.Options
   alias Minga.Editor.DisplayList
   alias Minga.Editor.DisplayList.{Frame, Overlay, WindowFrame}
   alias Minga.Editor.Layout
+  alias Minga.Editor.RenderPipeline.Emit.GUI, as: EmitGUI
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.TabBar
   alias Minga.Editor.Title
-  alias Minga.Filetype
-  alias Minga.Git
   alias Minga.Port.Capabilities
   alias Minga.Port.Manager, as: PortManager
   alias Minga.Port.Protocol
-  alias Minga.Port.Protocol.GUI, as: ProtocolGUI
   alias Minga.Telemetry
 
   @typedoc "Internal editor state."
@@ -72,15 +68,11 @@ defmodule Minga.Editor.RenderPipeline.Emit do
       PortManager.send_commands(state.port_manager, commands)
       send_title(state)
       send_window_bg(state)
-      send_gui_theme(state)
-      send_gui_tab_bar(state)
-      send_gui_file_tree(state)
-      send_gui_which_key(state)
-      send_gui_completion(state)
-      send_gui_breadcrumb(state)
-      send_gui_status_bar(state)
-      send_gui_picker(state)
-      send_gui_agent_chat(state)
+
+      if Capabilities.gui?(state.capabilities) do
+        EmitGUI.sync_chrome(state)
+      end
+
       :ok
     end)
   end
@@ -453,236 +445,6 @@ defmodule Minga.Editor.RenderPipeline.Emit do
     if bg != Process.get(:last_window_bg) do
       Process.put(:last_window_bg, bg)
       PortManager.send_commands([Protocol.encode_set_window_bg(bg)])
-    end
-
-    :ok
-  end
-
-  @spec send_gui_tab_bar(state()) :: :ok
-  defp send_gui_tab_bar(%{capabilities: caps, tab_bar: %TabBar{} = tb} = state) do
-    if Capabilities.gui?(caps) do
-      active_buf = active_window_buffer(state)
-      cmd = ProtocolGUI.encode_gui_tab_bar(tb, active_buf)
-      PortManager.send_commands(state.port_manager, [cmd])
-    end
-
-    :ok
-  end
-
-  defp send_gui_tab_bar(%{tab_bar: nil}), do: :ok
-
-  @spec active_window_buffer(state()) :: pid() | nil
-  defp active_window_buffer(%{windows: %{active: win_id, map: map}}) do
-    case Map.get(map, win_id) do
-      %{buffer: buf} when is_pid(buf) -> buf
-      _ -> nil
-    end
-  end
-
-  @spec send_gui_file_tree(state()) :: :ok
-  defp send_gui_file_tree(%{
-         capabilities: caps,
-         file_tree: %{tree: %Minga.FileTree{} = tree},
-         port_manager: pm
-       }) do
-    if Capabilities.gui?(caps) do
-      cmd = ProtocolGUI.encode_gui_file_tree(tree)
-      PortManager.send_commands(pm, [cmd])
-    end
-
-    :ok
-  end
-
-  defp send_gui_file_tree(%{capabilities: caps, port_manager: pm}) do
-    if Capabilities.gui?(caps) do
-      cmd = ProtocolGUI.encode_gui_file_tree(nil)
-      PortManager.send_commands(pm, [cmd])
-    end
-
-    :ok
-  end
-
-  @spec send_gui_which_key(state()) :: :ok
-  defp send_gui_which_key(%{capabilities: caps, whichkey: wk, port_manager: pm}) do
-    if Capabilities.gui?(caps) do
-      cmd = ProtocolGUI.encode_gui_which_key(wk)
-      PortManager.send_commands(pm, [cmd])
-    end
-
-    :ok
-  end
-
-  @spec send_gui_completion(state()) :: :ok
-  defp send_gui_completion(%{capabilities: caps, completion: comp, port_manager: pm} = state) do
-    if Capabilities.gui?(caps) do
-      {cursor_row, cursor_col} = current_cursor_screen_pos(state)
-      cmd = ProtocolGUI.encode_gui_completion(comp, cursor_row, cursor_col)
-      PortManager.send_commands(pm, [cmd])
-    end
-
-    :ok
-  end
-
-  @spec send_gui_breadcrumb(state()) :: :ok
-  defp send_gui_breadcrumb(%{capabilities: caps, port_manager: pm} = state) do
-    if Capabilities.gui?(caps) do
-      file_path = active_buffer_path(state)
-
-      root =
-        case state.file_tree do
-          %{tree: %{root: r}} -> r
-          _ -> ""
-        end
-
-      cmd = ProtocolGUI.encode_gui_breadcrumb(file_path, root)
-      PortManager.send_commands(pm, [cmd])
-    end
-
-    :ok
-  end
-
-  @spec send_gui_status_bar(state()) :: :ok
-  defp send_gui_status_bar(%{capabilities: caps, port_manager: pm} = state) do
-    if Capabilities.gui?(caps) do
-      data = build_status_bar_data(state)
-      cmd = ProtocolGUI.encode_gui_status_bar(data)
-      PortManager.send_commands(pm, [cmd])
-    end
-
-    :ok
-  end
-
-  @spec current_cursor_screen_pos(state()) :: {non_neg_integer(), non_neg_integer()}
-  defp current_cursor_screen_pos(state) do
-    layout = Layout.get(state)
-
-    case Layout.active_window_layout(layout, state) do
-      %{content: {row, col, _w, _h}} ->
-        buf = state.buffers.active
-
-        if buf do
-          {line, column} = BufferServer.cursor(buf)
-          vp = state.viewport
-          {row + line - vp.top, col + column}
-        else
-          {row, col}
-        end
-
-      nil ->
-        {0, 0}
-    end
-  end
-
-  @spec active_buffer_path(state()) :: String.t() | nil
-  defp active_buffer_path(state) do
-    case state.buffers.active do
-      nil -> nil
-      buf -> BufferServer.file_path(buf)
-    end
-  end
-
-  @spec build_status_bar_data(state()) :: map()
-  defp build_status_bar_data(state) do
-    buf = state.buffers.active
-    {line, col} = if buf, do: BufferServer.cursor(buf), else: {1, 0}
-    line_count = if buf, do: BufferServer.line_count(buf), else: 1
-    file_name = if buf, do: BufferServer.file_path(buf) || "", else: ""
-
-    %{
-      mode: state.vim.mode,
-      cursor_line: line + 1,
-      cursor_col: col + 1,
-      line_count: line_count,
-      filetype: Filetype.detect(file_name),
-      dirty_marker: if(buf && BufferServer.dirty?(buf), do: "●", else: ""),
-      lsp_status: state.lsp_status,
-      git_branch: resolve_git_branch(state),
-      status_msg: state.status_msg
-    }
-  end
-
-  @spec send_gui_picker(state()) :: :ok
-  defp send_gui_picker(%{capabilities: caps, picker_ui: %{picker: picker}, port_manager: pm}) do
-    if Capabilities.gui?(caps) do
-      cmd = ProtocolGUI.encode_gui_picker(picker)
-      PortManager.send_commands(pm, [cmd])
-    end
-
-    :ok
-  end
-
-  @spec send_gui_agent_chat(state()) :: :ok
-  defp send_gui_agent_chat(%{capabilities: caps, port_manager: pm} = state) do
-    if Capabilities.gui?(caps) do
-      data = build_agent_chat_data(state)
-
-      if data.visible do
-        Minga.Log.debug(:render, "[gui] sending agent chat: #{length(data.messages)} messages")
-      end
-
-      cmd = ProtocolGUI.encode_gui_agent_chat(data)
-      PortManager.send_commands(pm, [cmd])
-    end
-
-    :ok
-  end
-
-  @spec build_agent_chat_data(state()) :: map()
-  defp build_agent_chat_data(state) do
-    alias Minga.Editor.Window.Content
-
-    active_window = Map.get(state.windows.map, state.windows.active)
-    is_agent_chat = active_window != nil && Content.agent_chat?(active_window.content)
-    session = state.agent.session
-
-    if is_agent_chat && session do
-      messages =
-        try do
-          AgentSession.messages(session)
-        catch
-          :exit, _ -> []
-        end
-
-      prompt_text =
-        case state.agent_ui.prompt_buffer do
-          nil -> ""
-          buf -> BufferServer.content(buf) |> String.trim_trailing("\n")
-        end
-
-      pending = state.agent.pending_approval
-
-      %{
-        visible: true,
-        messages: messages,
-        status: state.agent.status || :idle,
-        model: state.agent_ui.model_name,
-        prompt: prompt_text,
-        pending_approval: pending
-      }
-    else
-      %{visible: false}
-    end
-  end
-
-  @spec resolve_git_branch(state()) :: String.t() | nil
-  defp resolve_git_branch(%{file_tree: %{tree: %{root: root}}}) do
-    case Git.current_branch(root) do
-      {:ok, branch} -> branch
-      _ -> nil
-    end
-  end
-
-  defp resolve_git_branch(_state), do: nil
-
-  @spec send_gui_theme(state()) :: :ok
-  defp send_gui_theme(state) do
-    if Capabilities.gui?(state.capabilities) do
-      theme_name = state.theme.name
-
-      if theme_name != Process.get(:last_gui_theme) do
-        Process.put(:last_gui_theme, theme_name)
-        PortManager.send_commands(state.port_manager, [ProtocolGUI.encode_gui_theme(state.theme)])
-      end
     end
 
     :ok

--- a/lib/minga/editor/render_pipeline/emit/gui.ex
+++ b/lib/minga/editor/render_pipeline/emit/gui.ex
@@ -1,0 +1,266 @@
+defmodule Minga.Editor.RenderPipeline.Emit.GUI do
+  @moduledoc """
+  GUI chrome synchronization for the Emit stage.
+
+  Sends structured chrome data (tab bar, file tree, which-key, completion,
+  breadcrumb, status bar, picker, agent chat, theme) to the native GUI
+  frontend. These are separate from the TUI cell-grid rendering commands
+  and from the frame-to-commands conversion in `Emit`.
+
+  Called from `Emit.emit/2` only when the frontend has GUI capabilities.
+  Each function independently gathers state, encodes to protocol binary,
+  and sends to the port manager.
+  """
+
+  alias Minga.Agent.Session, as: AgentSession
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Editor.Layout
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.TabBar
+  alias Minga.Filetype
+  alias Minga.Git
+  alias Minga.Port.Manager, as: PortManager
+  alias Minga.Port.Protocol.GUI, as: ProtocolGUI
+
+  @typedoc "Internal editor state."
+  @type state :: EditorState.t()
+
+  @doc """
+  Sends all GUI chrome data to the native frontend.
+
+  Each chrome element is gathered from editor state, encoded to protocol
+  binary, and sent to the port manager. The caller has already verified
+  that the frontend has GUI capabilities.
+  """
+  @spec sync_chrome(state()) :: :ok
+  def sync_chrome(state) do
+    send_gui_theme(state)
+    send_gui_tab_bar(state)
+    send_gui_file_tree(state)
+    send_gui_which_key(state)
+    send_gui_completion(state)
+    send_gui_breadcrumb(state)
+    send_gui_status_bar(state)
+    send_gui_picker(state)
+    send_gui_agent_chat(state)
+    :ok
+  end
+
+  # ── Theme ──
+
+  @spec send_gui_theme(state()) :: :ok
+  defp send_gui_theme(state) do
+    theme_name = state.theme.name
+
+    if theme_name != Process.get(:last_gui_theme) do
+      Process.put(:last_gui_theme, theme_name)
+      PortManager.send_commands(state.port_manager, [ProtocolGUI.encode_gui_theme(state.theme)])
+    end
+
+    :ok
+  end
+
+  # ── Tab bar ──
+
+  @spec send_gui_tab_bar(state()) :: :ok
+  defp send_gui_tab_bar(%{tab_bar: %TabBar{} = tb} = state) do
+    active_buf = active_window_buffer(state)
+    cmd = ProtocolGUI.encode_gui_tab_bar(tb, active_buf)
+    PortManager.send_commands(state.port_manager, [cmd])
+    :ok
+  end
+
+  defp send_gui_tab_bar(%{tab_bar: nil}), do: :ok
+
+  @spec active_window_buffer(state()) :: pid() | nil
+  defp active_window_buffer(%{windows: %{active: win_id, map: map}}) do
+    case Map.get(map, win_id) do
+      %{buffer: buf} when is_pid(buf) -> buf
+      _ -> nil
+    end
+  end
+
+  # ── File tree ──
+
+  @spec send_gui_file_tree(state()) :: :ok
+  defp send_gui_file_tree(%{
+         file_tree: %{tree: %Minga.FileTree{} = tree},
+         port_manager: pm
+       }) do
+    cmd = ProtocolGUI.encode_gui_file_tree(tree)
+    PortManager.send_commands(pm, [cmd])
+    :ok
+  end
+
+  defp send_gui_file_tree(%{port_manager: pm}) do
+    cmd = ProtocolGUI.encode_gui_file_tree(nil)
+    PortManager.send_commands(pm, [cmd])
+    :ok
+  end
+
+  # ── Which-key ──
+
+  @spec send_gui_which_key(state()) :: :ok
+  defp send_gui_which_key(%{whichkey: wk, port_manager: pm}) do
+    cmd = ProtocolGUI.encode_gui_which_key(wk)
+    PortManager.send_commands(pm, [cmd])
+    :ok
+  end
+
+  # ── Completion ──
+
+  @spec send_gui_completion(state()) :: :ok
+  defp send_gui_completion(%{completion: comp, port_manager: pm} = state) do
+    {cursor_row, cursor_col} = current_cursor_screen_pos(state)
+    cmd = ProtocolGUI.encode_gui_completion(comp, cursor_row, cursor_col)
+    PortManager.send_commands(pm, [cmd])
+    :ok
+  end
+
+  @spec current_cursor_screen_pos(state()) :: {non_neg_integer(), non_neg_integer()}
+  defp current_cursor_screen_pos(state) do
+    layout = Layout.get(state)
+
+    case Layout.active_window_layout(layout, state) do
+      %{content: {row, col, _w, _h}} ->
+        buf = state.buffers.active
+
+        if buf do
+          {line, column} = BufferServer.cursor(buf)
+          vp = state.viewport
+          {row + line - vp.top, col + column}
+        else
+          {row, col}
+        end
+
+      nil ->
+        {0, 0}
+    end
+  end
+
+  # ── Breadcrumb ──
+
+  @spec send_gui_breadcrumb(state()) :: :ok
+  defp send_gui_breadcrumb(%{port_manager: pm} = state) do
+    file_path = active_buffer_path(state)
+
+    root =
+      case state.file_tree do
+        %{tree: %{root: r}} -> r
+        _ -> ""
+      end
+
+    cmd = ProtocolGUI.encode_gui_breadcrumb(file_path, root)
+    PortManager.send_commands(pm, [cmd])
+    :ok
+  end
+
+  @spec active_buffer_path(state()) :: String.t() | nil
+  defp active_buffer_path(state) do
+    case state.buffers.active do
+      nil -> nil
+      buf -> BufferServer.file_path(buf)
+    end
+  end
+
+  # ── Status bar ──
+
+  @spec send_gui_status_bar(state()) :: :ok
+  defp send_gui_status_bar(%{port_manager: pm} = state) do
+    data = build_status_bar_data(state)
+    cmd = ProtocolGUI.encode_gui_status_bar(data)
+    PortManager.send_commands(pm, [cmd])
+    :ok
+  end
+
+  @spec build_status_bar_data(state()) :: map()
+  defp build_status_bar_data(state) do
+    buf = state.buffers.active
+    {line, col} = if buf, do: BufferServer.cursor(buf), else: {1, 0}
+    line_count = if buf, do: BufferServer.line_count(buf), else: 1
+    file_name = if buf, do: BufferServer.file_path(buf) || "", else: ""
+
+    %{
+      mode: state.vim.mode,
+      cursor_line: line + 1,
+      cursor_col: col + 1,
+      line_count: line_count,
+      filetype: Filetype.detect(file_name),
+      dirty_marker: if(buf && BufferServer.dirty?(buf), do: "●", else: ""),
+      lsp_status: state.lsp_status,
+      git_branch: resolve_git_branch(state),
+      status_msg: state.status_msg
+    }
+  end
+
+  @spec resolve_git_branch(state()) :: String.t() | nil
+  defp resolve_git_branch(%{file_tree: %{tree: %{root: root}}}) do
+    case Git.current_branch(root) do
+      {:ok, branch} -> branch
+      _ -> nil
+    end
+  end
+
+  defp resolve_git_branch(_state), do: nil
+
+  # ── Picker ──
+
+  @spec send_gui_picker(state()) :: :ok
+  defp send_gui_picker(%{picker_ui: %{picker: picker}, port_manager: pm}) do
+    cmd = ProtocolGUI.encode_gui_picker(picker)
+    PortManager.send_commands(pm, [cmd])
+    :ok
+  end
+
+  # ── Agent chat ──
+
+  @spec send_gui_agent_chat(state()) :: :ok
+  defp send_gui_agent_chat(%{port_manager: pm} = state) do
+    data = build_agent_chat_data(state)
+
+    if data.visible do
+      Minga.Log.debug(:render, "[gui] sending agent chat: #{length(data.messages)} messages")
+    end
+
+    cmd = ProtocolGUI.encode_gui_agent_chat(data)
+    PortManager.send_commands(pm, [cmd])
+    :ok
+  end
+
+  @spec build_agent_chat_data(state()) :: map()
+  defp build_agent_chat_data(state) do
+    alias Minga.Editor.Window.Content
+
+    active_window = Map.get(state.windows.map, state.windows.active)
+    is_agent_chat = active_window != nil && Content.agent_chat?(active_window.content)
+    session = state.agent.session
+
+    if is_agent_chat && session do
+      messages =
+        try do
+          AgentSession.messages(session)
+        catch
+          :exit, _ -> []
+        end
+
+      prompt_text =
+        case state.agent_ui.prompt_buffer do
+          nil -> ""
+          buf -> BufferServer.content(buf) |> String.trim_trailing("\n")
+        end
+
+      pending = state.agent.pending_approval
+
+      %{
+        visible: true,
+        messages: messages,
+        status: state.agent.status || :idle,
+        model: state.agent_ui.model_name,
+        prompt: prompt_text,
+        pending_approval: pending
+      }
+    else
+      %{visible: false}
+    end
+  end
+end


### PR DESCRIPTION
## What

Extracts the 9 `send_gui_*` functions and their business logic helpers from `Minga.Editor.RenderPipeline.Emit` into a new `Emit.GUI` module with a single public `sync_chrome/1` entry point.

## Why

The Emit stage grew from ~450 to ~690 lines by mixing TUI frame-to-commands conversion with GUI chrome data sends. The 9 GUI send functions each independently checked `Capabilities.gui?`, gathered domain data, encoded it, and sent to the port manager. This is a separate concern from frame rendering.

## Changes

**New module:**
- `lib/minga/editor/render_pipeline/emit/gui.ex` (266 lines) — single public `sync_chrome(state)` function, 9 private send functions, 5 business logic helpers

**Updated module:**
- `lib/minga/editor/render_pipeline/emit.ex` — 690 → 452 lines. Now focused on frame-to-commands conversion. Calls `EmitGUI.sync_chrome(state)` inside the telemetry span after a single `Capabilities.gui?` check.

**Business logic moved:**
- `build_status_bar_data`, `build_agent_chat_data`, `current_cursor_screen_pos`, `resolve_git_branch`, `active_buffer_path`, `active_window_buffer`

**Kept in Emit:**
- `build_gui_commands/1` (GUI variant of frame-to-commands, per developer notes)
- `send_title/1`, `send_window_bg/1` (TUI side-channel writes, not GUI chrome)

## Test Results

```
PASS: 48 doctests, 62 properties, 5462 tests, 0 failures, 5 skipped, 1 excluded
```

Closes #691
Part of epic #689
Depends on #698 (Protocol.GUI extraction)