### PR TITLE
feat(port): build headless Swift test harness for GUI protocol integration testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ macos/Minga.xcodeproj/project.xcworkspace/xcuserdata/
 erl_crash.dump
 /priv/minga-renderer
 /priv/minga-parser
+/priv/minga-test-harness
 /burrito_out/
 
 # Editor / OS

--- a/lib/mix/tasks/swift_harness.ex
+++ b/lib/mix/tasks/swift_harness.ex
@@ -1,0 +1,44 @@
+defmodule Mix.Tasks.Swift.Harness do
+  @moduledoc """
+  Builds the headless Swift test harness for GUI protocol integration testing.
+
+  ## Usage
+
+      mix swift.harness
+
+  Compiles `macos/Sources/TestHarness/main.swift` along with the shared
+  protocol files into `priv/minga-test-harness`. Required before running
+  `test/minga/integration/gui_protocol_test.exs`.
+  """
+
+  use Mix.Task
+
+  @shortdoc "Build the Swift GUI protocol test harness"
+
+  @impl Mix.Task
+  @spec run(list()) :: :ok
+  def run(_args) do
+    sources = [
+      "macos/Sources/Protocol/ProtocolConstants.swift",
+      "macos/Sources/Protocol/ProtocolDecoder.swift",
+      "macos/Sources/TestHarness/main.swift"
+    ]
+
+    priv_dir = Path.join(Mix.Project.app_path(), "priv")
+    File.mkdir_p!(priv_dir)
+    output = Path.join(priv_dir, "minga-test-harness")
+
+    args = sources ++ ["-o", output]
+
+    Mix.shell().info("Building Swift test harness...")
+
+    case System.cmd("swiftc", args, stderr_to_stdout: true) do
+      {_output, 0} ->
+        Mix.shell().info("Swift test harness built: #{output}")
+        :ok
+
+      {error_output, code} ->
+        Mix.raise("swiftc failed (exit #{code}):\n#{error_output}")
+    end
+  end
+end

--- a/macos/Sources/TestHarness/main.swift
+++ b/macos/Sources/TestHarness/main.swift
@@ -1,0 +1,185 @@
+/// Headless Swift test harness for GUI protocol integration testing.
+///
+/// Reads {:packet, 4} framed protocol data from stdin, decodes all GUI
+/// chrome opcodes, and reports decoded data on stdout as {:packet, 4}
+/// framed JSON (one message per opcode received). Can also send synthetic
+/// input events (gui_action, key_press) back to the BEAM.
+///
+/// No Metal, SwiftUI, or UI framework needed. Purely a command-line tool
+/// for CI-friendly protocol round-trip testing.
+
+import Foundation
+
+// MARK: - I/O helpers
+
+let stdin = FileHandle.standardInput
+let stdout = FileHandle.standardOutput
+let lock = NSLock()
+
+/// Writes a {:packet, 4} framed message to stdout.
+func writeFramed(_ data: Data) {
+    var header = Data(count: 4)
+    let len = UInt32(data.count)
+    header[0] = UInt8((len >> 24) & 0xFF)
+    header[1] = UInt8((len >> 16) & 0xFF)
+    header[2] = UInt8((len >> 8) & 0xFF)
+    header[3] = UInt8(len & 0xFF)
+    lock.lock()
+    stdout.write(header)
+    stdout.write(data)
+    lock.unlock()
+}
+
+/// Writes a JSON object as a {:packet, 4} framed message.
+func writeJSON(_ dict: [String: Any]) {
+    if let data = try? JSONSerialization.data(withJSONObject: dict) {
+        writeFramed(data)
+    }
+}
+
+/// Sends a gui_action: select_tab back to the BEAM.
+/// Layout: opcode(1) + action_type(1) + tab_id(4) = 6 bytes.
+func sendSelectTab(id: UInt32) {
+    var buf = Data(count: 6)
+    buf[0] = OP_GUI_ACTION
+    buf[1] = GUI_ACTION_SELECT_TAB
+    buf[2] = UInt8((id >> 24) & 0xFF)
+    buf[3] = UInt8((id >> 16) & 0xFF)
+    buf[4] = UInt8((id >> 8) & 0xFF)
+    buf[5] = UInt8(id & 0xFF)
+    writeFramed(buf)
+}
+
+// MARK: - Command to JSON conversion
+
+func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
+    switch command {
+    case .guiTheme(let slots):
+        let slotArray = slots.map { ["slot": Int($0.slotId), "r": Int($0.r), "g": Int($0.g), "b": Int($0.b)] }
+        return ["type": "gui_theme", "slots": slotArray]
+
+    case .guiTabBar(let activeIndex, let tabs):
+        let tabArray = tabs.map { tab -> [String: Any] in
+            ["id": Int(tab.id), "label": tab.label, "icon": tab.icon,
+             "is_active": tab.isActive, "is_dirty": tab.isDirty,
+             "is_agent": tab.isAgent, "has_attention": tab.hasAttention,
+             "agent_status": Int(tab.agentStatus)]
+        }
+        // If there are 2+ tabs, auto-send a select_tab gui_action for the
+        // second tab. This enables round-trip testing: BEAM sends gui_tab_bar,
+        // harness decodes it and sends gui_action select_tab back.
+        if tabs.count >= 2 {
+            let secondTabId = tabs[1].id
+            sendSelectTab(id: secondTabId)
+        }
+        return ["type": "gui_tab_bar", "active_index": Int(activeIndex), "tabs": tabArray]
+
+    case .guiFileTree(let selectedIndex, let treeWidth, let entries):
+        let entryArray = entries.map { e -> [String: Any] in
+            ["name": e.name, "depth": Int(e.depth),
+             "is_dir": e.isDir, "is_expanded": e.isExpanded, "is_selected": e.isSelected,
+             "git_status": Int(e.gitStatus), "icon": e.icon]
+        }
+        return ["type": "gui_file_tree", "selected_index": Int(selectedIndex), "tree_width": Int(treeWidth), "entries": entryArray]
+
+    case .guiCompletion(let visible, let anchorRow, let anchorCol, let selectedIndex, let items):
+        let itemArray = items.map { i -> [String: Any] in
+            ["label": i.label, "detail": i.detail, "kind": Int(i.kind)]
+        }
+        return ["type": "gui_completion", "visible": visible, "anchor_row": Int(anchorRow), "anchor_col": Int(anchorCol), "selected_index": Int(selectedIndex), "items": itemArray]
+
+    case .guiWhichKey(let visible, let prefix, let page, let pageCount, let bindings):
+        let bindingArray = bindings.map { b -> [String: Any] in
+            ["key": b.key, "description": b.description, "icon": b.icon, "kind": Int(b.kind)]
+        }
+        return ["type": "gui_which_key", "visible": visible, "prefix": prefix, "page": Int(page), "page_count": Int(pageCount), "bindings": bindingArray]
+
+    case .guiBreadcrumb(let segments):
+        return ["type": "gui_breadcrumb", "segments": segments]
+
+    case .guiStatusBar(let mode, let cursorLine, let cursorCol, let lineCount, let flags, let lspStatus, let gitBranch, let message, let filetype):
+        return ["type": "gui_status_bar", "mode": Int(mode), "cursor_line": Int(cursorLine), "cursor_col": Int(cursorCol), "line_count": Int(lineCount), "flags": Int(flags), "lsp_status": Int(lspStatus), "git_branch": gitBranch, "message": message, "filetype": filetype]
+
+    case .guiPicker(let visible, let selectedIndex, let title, let query, let items):
+        let itemArray = items.map { i -> [String: Any] in
+            ["label": i.label, "description": i.description, "icon_color": Int(i.iconColor)]
+        }
+        return ["type": "gui_picker", "visible": visible, "selected_index": Int(selectedIndex), "title": title, "query": query, "items": itemArray]
+
+    case .guiAgentChat(let visible, let status, let model, let prompt, let pendingToolName, let pendingToolSummary, let messages):
+        let msgArray = messages.map { chatMessageToJSON($0) }
+        return ["type": "gui_agent_chat", "visible": visible, "status": Int(status), "model": model, "prompt": prompt, "pending_tool_name": pendingToolName ?? "", "pending_tool_summary": pendingToolSummary, "messages": msgArray]
+
+    case .batchEnd:
+        return ["type": "batch_end"]
+
+    case .clear:
+        return ["type": "clear"]
+
+    default:
+        return nil
+    }
+}
+
+func chatMessageToJSON(_ msg: GUIChatMessage) -> [String: Any] {
+    switch msg {
+    case .user(let text):
+        return ["kind": "user", "text": text]
+    case .assistant(let text):
+        return ["kind": "assistant", "text": text]
+    case .thinking(let text, let collapsed):
+        return ["kind": "thinking", "text": text, "collapsed": collapsed]
+    case .toolCall(let name, let status, let isError, let collapsed, let durationMs, let result):
+        return ["kind": "tool_call", "name": name, "status": Int(status), "is_error": isError, "collapsed": collapsed, "duration_ms": Int(durationMs), "result": result]
+    case .system(let text, let isError):
+        return ["kind": "system", "text": text, "is_error": isError]
+    case .usage(let input, let output, let cacheRead, let cacheWrite, let costMicros):
+        return ["kind": "usage", "input": Int(input), "output": Int(output), "cache_read": Int(cacheRead), "cache_write": Int(cacheWrite), "cost_micros": Int(costMicros)]
+    }
+}
+
+// MARK: - Main loop
+
+/// Send a ready signal so the BEAM knows we're alive.
+func sendReady() {
+    writeJSON(["type": "ready"])
+}
+
+sendReady()
+
+// Read {:packet, 4} framed messages from stdin.
+while true {
+    // Read 4-byte length header.
+    let headerData = stdin.readData(ofLength: 4)
+    if headerData.count < 4 {
+        break // stdin closed
+    }
+
+    let len = Int(headerData[0]) << 24
+        | Int(headerData[1]) << 16
+        | Int(headerData[2]) << 8
+        | Int(headerData[3])
+
+    if len == 0 { continue }
+
+    // Read the payload.
+    var payload = Data()
+    while payload.count < len {
+        let chunk = stdin.readData(ofLength: len - payload.count)
+        if chunk.isEmpty { break }
+        payload.append(chunk)
+    }
+
+    if payload.count < len { break }
+
+    // Decode and report.
+    do {
+        try decodeCommands(from: payload) { command in
+            if let json = commandToJSON(command) {
+                writeJSON(json)
+            }
+        }
+    } catch {
+        writeJSON(["type": "error", "message": "\(error)"])
+    }
+}

--- a/test/minga/integration/gui_protocol_test.exs
+++ b/test/minga/integration/gui_protocol_test.exs
@@ -1,0 +1,207 @@
+defmodule Minga.Integration.GUIProtocolTest do
+  @moduledoc """
+  Integration tests for the BEAM to Swift GUI protocol round-trip.
+
+  Spawns the headless Swift test harness as an Erlang Port, sends encoded
+  GUI protocol opcodes, and asserts the harness decoded them correctly by
+  checking its JSON output.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Minga.Port.Protocol.GUI, as: ProtocolGUI
+
+  @harness_path Path.join(:code.priv_dir(:minga), "minga-test-harness")
+
+  setup do
+    if not File.exists?(@harness_path) do
+      flunk(
+        "Test harness not found at #{@harness_path}. Build with: swiftc -o priv/minga-test-harness macos/Sources/Protocol/ProtocolConstants.swift macos/Sources/Protocol/ProtocolDecoder.swift macos/Sources/TestHarness/main.swift"
+      )
+    end
+
+    port = Port.open({:spawn_executable, @harness_path}, [:binary, {:packet, 4}])
+
+    # Wait for the ready signal from the harness.
+    assert_receive {^port, {:data, ready_json}}, 5_000
+    assert %{"type" => "ready"} = Jason.decode!(ready_json)
+
+    on_exit(fn ->
+      if Port.info(port) != nil do
+        Port.close(port)
+      end
+    end)
+
+    %{port: port}
+  end
+
+  describe "GUI chrome opcode round-trip" do
+    test "gui_theme encodes and decodes correctly", %{port: port} do
+      theme = Minga.Theme.get!(:doom_one)
+      cmd = ProtocolGUI.encode_gui_theme(theme)
+
+      Port.command(port, cmd)
+      assert_receive {^port, {:data, json}}, 5_000
+      decoded = Jason.decode!(json)
+
+      assert decoded["type"] == "gui_theme"
+      assert is_list(decoded["slots"])
+      assert length(decoded["slots"]) > 20
+
+      # Verify a specific slot (editor_bg = slot 0x01)
+      editor_bg_slot = Enum.find(decoded["slots"], fn s -> s["slot"] == 1 end)
+      assert editor_bg_slot != nil
+      assert is_integer(editor_bg_slot["r"])
+      assert is_integer(editor_bg_slot["g"])
+      assert is_integer(editor_bg_slot["b"])
+    end
+
+    test "gui_tab_bar encodes and decodes correctly", %{port: port} do
+      tab1 = %Minga.Editor.State.Tab{id: 1, kind: :file, label: "editor.ex"}
+      tab2 = %Minga.Editor.State.Tab{id: 2, kind: :agent, label: "Agent", agent_status: :thinking}
+      tb = %Minga.Editor.State.TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
+
+      cmd = ProtocolGUI.encode_gui_tab_bar(tb)
+      Port.command(port, cmd)
+
+      # With 2 tabs, the harness sends both a JSON report and a gui_action.
+      # Find the JSON one.
+      messages =
+        for _ <- 1..2,
+            do:
+              (
+                assert_receive {^port, {:data, d}}, 5_000
+                d
+              )
+
+      json = Enum.find(messages, &String.starts_with?(&1, "{"))
+      decoded = Jason.decode!(json)
+
+      assert decoded["type"] == "gui_tab_bar"
+      assert decoded["active_index"] == 0
+      assert length(decoded["tabs"]) == 2
+
+      [t1, t2] = decoded["tabs"]
+      assert t1["id"] == 1
+      assert t1["label"] == "editor.ex"
+      assert t1["is_active"] == true
+      assert t2["id"] == 2
+      assert t2["label"] == "Agent"
+      assert t2["is_agent"] == true
+    end
+
+    test "gui_breadcrumb encodes and decodes correctly", %{port: port} do
+      cmd =
+        ProtocolGUI.encode_gui_breadcrumb("/home/user/project/lib/foo.ex", "/home/user/project")
+
+      Port.command(port, cmd)
+      assert_receive {^port, {:data, json}}, 5_000
+      decoded = Jason.decode!(json)
+
+      assert decoded["type"] == "gui_breadcrumb"
+      assert decoded["segments"] == ["lib", "foo.ex"]
+    end
+
+    test "gui_status_bar encodes and decodes correctly", %{port: port} do
+      data = %{
+        mode: :normal,
+        cursor_line: 42,
+        cursor_col: 10,
+        line_count: 200,
+        filetype: :elixir,
+        dirty_marker: "●",
+        lsp_status: :ready,
+        git_branch: "main",
+        status_msg: ""
+      }
+
+      cmd = ProtocolGUI.encode_gui_status_bar(data)
+      Port.command(port, cmd)
+      assert_receive {^port, {:data, json}}, 5_000
+      decoded = Jason.decode!(json)
+
+      assert decoded["type"] == "gui_status_bar"
+      assert decoded["mode"] == 0
+      assert decoded["cursor_line"] == 42
+      assert decoded["cursor_col"] == 10
+      assert decoded["line_count"] == 200
+      assert decoded["git_branch"] == "main"
+      assert decoded["filetype"] == "elixir"
+    end
+
+    test "gui_agent_chat hidden encodes and decodes correctly", %{port: port} do
+      cmd = ProtocolGUI.encode_gui_agent_chat(%{visible: false})
+      Port.command(port, cmd)
+      assert_receive {^port, {:data, json}}, 5_000
+      decoded = Jason.decode!(json)
+
+      assert decoded["type"] == "gui_agent_chat"
+      assert decoded["visible"] == false
+    end
+
+    test "gui_agent_chat visible with messages", %{port: port} do
+      data = %{
+        visible: true,
+        messages: [{:user, "hello"}, {:assistant, "hi there"}],
+        status: :idle,
+        model: "claude",
+        prompt: "test prompt",
+        pending_approval: nil
+      }
+
+      cmd = ProtocolGUI.encode_gui_agent_chat(data)
+      Port.command(port, cmd)
+      assert_receive {^port, {:data, json}}, 5_000
+      decoded = Jason.decode!(json)
+
+      assert decoded["type"] == "gui_agent_chat"
+      assert decoded["visible"] == true
+      assert decoded["model"] == "claude"
+      assert decoded["prompt"] == "test prompt"
+      assert length(decoded["messages"]) == 2
+
+      [msg1, msg2] = decoded["messages"]
+      assert msg1["kind"] == "user"
+      assert msg1["text"] == "hello"
+      assert msg2["kind"] == "assistant"
+      assert msg2["text"] == "hi there"
+    end
+  end
+
+  describe "round-trip: BEAM encode → harness decode → harness sends gui_action → BEAM receives" do
+    test "tab bar triggers harness to send select_tab gui_action back", %{port: port} do
+      alias Minga.Port.Protocol
+
+      # Step 1: Send a gui_tab_bar with 2 tabs. The harness will decode it
+      # and automatically send a gui_action select_tab for the second tab.
+      tab1 = %Minga.Editor.State.Tab{id: 1, kind: :file, label: "main.ex"}
+      tab2 = %Minga.Editor.State.Tab{id: 2, kind: :file, label: "test.ex"}
+      tb = %Minga.Editor.State.TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
+
+      cmd = ProtocolGUI.encode_gui_tab_bar(tb)
+      Port.command(port, cmd)
+
+      # Step 2: We should receive two messages:
+      # (a) The JSON report of the decoded gui_tab_bar
+      # (b) The raw gui_action binary (select_tab for tab id=2)
+      # Order may vary, so collect both.
+      messages =
+        Enum.map(1..2, fn _ ->
+          assert_receive {^port, {:data, data}}, 5_000
+          data
+        end)
+
+      # Find the JSON report.
+      json_msg = Enum.find(messages, fn d -> String.starts_with?(d, "{") end)
+      assert json_msg != nil
+      tab_decoded = Jason.decode!(json_msg)
+      assert tab_decoded["type"] == "gui_tab_bar"
+      assert length(tab_decoded["tabs"]) == 2
+
+      # Find the gui_action binary and decode it on the BEAM side.
+      action_msg = Enum.find(messages, fn d -> not String.starts_with?(d, "{") end)
+      assert action_msg != nil
+      assert {:ok, {:gui_action, {:select_tab, 2}}} = Protocol.decode_event(action_msg)
+    end
+  end
+end


### PR DESCRIPTION
## What

New headless Swift CLI that speaks the port protocol for automated GUI protocol testing. Reads `{:packet, 4}` framed data from stdin, decodes all 9 GUI chrome opcodes, reports decoded data as JSON on stdout.

## Why

The prototype's BEAM/Swift integration was tested manually. Protocol encoding bugs (byte offsets, field ordering) corrupt all downstream data. This harness enables automated ExUnit tests for the full encode/decode/round-trip cycle.

## Changes

**New files:**
- `macos/Sources/TestHarness/main.swift` — Swift CLI harness. Decodes all GUI opcodes, outputs `{:packet, 4}` framed JSON. Auto-sends `select_tab` gui_action when it receives a 2+ tab gui_tab_bar (for round-trip testing).
- `test/minga/integration/gui_protocol_test.exs` — 7 ExUnit integration tests
- `lib/mix/tasks/swift_harness.ex` — `mix swift.harness` build task

**Tests:**
- gui_theme: slot count, specific slot values
- gui_tab_bar: tab count, fields, is_active/is_agent flags
- gui_breadcrumb: path segments
- gui_status_bar: mode, cursor position, line count, git branch
- gui_agent_chat: hidden state, visible with messages (user + assistant)
- **Round-trip**: BEAM encodes gui_tab_bar → harness decodes → harness sends gui_action select_tab → BEAM receives and decodes `{:select_tab, 2}`

## Build

```bash
mix swift.harness  # compiles to priv/minga-test-harness
```

Uses standalone `swiftc` instead of an Xcode target for CI simplicity.

## Test Results

```
PASS: 48 doctests, 62 properties, 5477 tests, 0 failures
```

Closes #696
Part of epic #689
Depends on #703