### PR TITLE
fix(parser): add missing modeline indicator and per-buffer version reset

### DIFF
--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -534,21 +534,41 @@ defmodule Minga.Editor do
     {:noreply, new_state}
   end
 
+  # Parser process crashed; Manager is scheduling a restart.
+  def handle_info({:minga_highlight, :parser_crashed}, state) do
+    {:noreply, %{state | parser_status: :restarting}}
+  end
+
   # Parser recovered after a crash; buffer re-sync already happened in Manager.
-  # Reset the highlight version so resync spans (sent at version 0) pass
-  # the version guard in Highlight.put_spans/3.
+  # Reset both the global highlight version AND each per-buffer highlight's
+  # version to 0 so resync spans (sent at version 0) pass the version guard
+  # in Highlight.put_spans/3. Without resetting per-buffer versions, the
+  # resync spans would be silently discarded (0 < previous_version).
   def handle_info({:minga_highlight, :parser_restarted}, state) do
     hl = state.highlight
-    new_state = %{state | highlight: %{hl | version: 0}}
+
+    reset_highlights =
+      Map.new(hl.highlights, fn {pid, buf_hl} ->
+        {pid, %{buf_hl | version: 0}}
+      end)
+
+    new_state = %{
+      state
+      | highlight: %{hl | version: 0, highlights: reset_highlights},
+        parser_status: :available
+    }
+
     new_state = log_message(new_state, "Parser restarted, syntax highlighting recovered")
     {:noreply, new_state}
   end
 
   # Parser gave up retrying after repeated crashes.
   def handle_info({:minga_highlight, :parser_gave_up}, state) do
+    new_state = %{state | parser_status: :unavailable}
+
     new_state =
       log_message(
-        state,
+        new_state,
         "Parser crashed repeatedly, syntax highlighting disabled. Use :parser-restart to retry."
       )
 

--- a/lib/minga/editor/commands/ui.ex
+++ b/lib/minga/editor/commands/ui.ex
@@ -63,10 +63,14 @@ defmodule Minga.Editor.Commands.UI do
   defp execute_parser_restart(state) do
     case ParserManager.restart() do
       :ok ->
-        %{state | status_msg: "Parser restarted"}
+        %{state | status_msg: "Parser restarted", parser_status: :available}
 
       {:error, :binary_not_found} ->
-        %{state | status_msg: "Parser restart failed: binary not found"}
+        %{
+          state
+          | status_msg: "Parser restart failed: binary not found",
+            parser_status: :unavailable
+        }
     end
   catch
     :exit, _ ->

--- a/lib/minga/editor/modeline.ex
+++ b/lib/minga/editor/modeline.ex
@@ -31,6 +31,9 @@ defmodule Minga.Editor.Modeline do
   @typedoc "LSP connection status for the modeline indicator."
   @type lsp_status :: :ready | :initializing | :starting | :error | :none
 
+  @typedoc "Parser availability status for the modeline indicator."
+  @type parser_status :: :available | :unavailable | :restarting
+
   @typedoc "Git diff summary: {added, modified, deleted} line counts."
   @type git_diff_summary :: {non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil
 
@@ -51,6 +54,7 @@ defmodule Minga.Editor.Modeline do
           optional(:agent_theme_colors) => Minga.Theme.Agent.t() | nil,
           optional(:mode_override) => String.t() | nil,
           optional(:lsp_status) => lsp_status(),
+          optional(:parser_status) => parser_status(),
           optional(:git_branch) => String.t() | nil,
           optional(:git_diff_summary) => git_diff_summary()
         }
@@ -105,6 +109,7 @@ defmodule Minga.Editor.Modeline do
 
     agent_segments = build_agent_segments(data, bar_bg)
     lsp_segments = build_lsp_segments(data, bar_bg, ml)
+    parser_segments = build_parser_segments(data, bar_bg, ml)
     git_segments = build_git_segments(data, bar_bg, theme)
 
     # Segments are {text, fg, bg, opts, click_target}
@@ -120,7 +125,8 @@ defmodule Minga.Editor.Modeline do
         Enum.map(agent_segments, fn {text, fg, bg, opts} -> {text, fg, bg, opts, nil} end)
 
     right_segments =
-      lsp_segments ++
+      parser_segments ++
+        lsp_segments ++
         [
           {" #{devicon}", devicon_color, filetype_bg, [], nil},
           {" #{filetype_label} ", filetype_fg, filetype_bg, [], :filetype_menu},
@@ -253,6 +259,24 @@ defmodule Minga.Editor.Modeline do
       :starting -> [{"◯", ml.lsp_starting || 0x5B6268, bar_bg, [], :lsp_info}]
       :error -> [{"✗", ml.lsp_error || 0xFF6C6B, bar_bg, [bold: true], :lsp_info}]
       _ -> []
+    end
+  end
+
+  @spec build_parser_segments(modeline_data(), non_neg_integer(), Theme.Modeline.t()) ::
+          [{String.t(), non_neg_integer(), non_neg_integer(), keyword(), atom() | nil}]
+  defp build_parser_segments(data, bar_bg, ml) do
+    case Map.get(data, :parser_status) do
+      :unavailable ->
+        # Red warning: parser is down, highlighting disabled
+        [{"🌳✗", ml.lsp_error || 0xFF6C6B, bar_bg, [bold: true], :parser_restart}]
+
+      :restarting ->
+        # Yellow: parser is restarting
+        [{"🌳⟳", ml.lsp_initializing || 0xECBE7B, bar_bg, [bold: true], :parser_restart}]
+
+      _ ->
+        # :available or nil — normal state, show nothing
+        []
     end
   end
 

--- a/lib/minga/editor/render_pipeline/chrome_helpers.ex
+++ b/lib/minga/editor/render_pipeline/chrome_helpers.ex
@@ -103,6 +103,7 @@ defmodule Minga.Editor.RenderPipeline.ChromeHelpers do
             else: nil
           ),
         lsp_status: lsp_status,
+        parser_status: state.parser_status,
         git_branch: git_branch,
         git_diff_summary: git_diff_summary
       },

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -105,6 +105,7 @@ defmodule Minga.Editor.State do
             windows: %Windows{},
             file_tree: %FileTreeState{},
             lsp_status: :none,
+            parser_status: :available,
             hover_popup: nil,
             signature_help: nil,
             injection_ranges: %{},
@@ -146,6 +147,7 @@ defmodule Minga.Editor.State do
           windows: Windows.t(),
           file_tree: FileTreeState.t(),
           lsp_status: Minga.Editor.Modeline.lsp_status(),
+          parser_status: Minga.Editor.Modeline.parser_status(),
           hover_popup: Minga.Editor.HoverPopup.t() | nil,
           signature_help: Minga.Editor.SignatureHelp.t() | nil,
           injection_ranges: %{

--- a/lib/minga/parser/manager.ex
+++ b/lib/minga/parser/manager.ex
@@ -274,7 +274,12 @@ defmodule Minga.Parser.Manager do
   end
 
   def handle_call(:restart, _from, state) do
-    state = %{state | gave_up: false, current_backoff_ms: @initial_backoff_ms}
+    state = %{
+      state
+      | gave_up: false,
+        current_backoff_ms: @initial_backoff_ms,
+        restart_timestamps: []
+    }
 
     # Close existing port if still open
     state = close_port(state)
@@ -356,6 +361,7 @@ defmodule Minga.Parser.Manager do
     # Fail any pending synchronous requests so callers don't hang.
     state = fail_pending_requests(state)
     state = %{state | port: nil, ready: false}
+    broadcast(state.subscribers, {:minga_highlight, :parser_crashed})
     state = schedule_restart(state)
     {:noreply, state}
   end

--- a/test/minga/editor/modeline_test.exs
+++ b/test/minga/editor/modeline_test.exs
@@ -246,4 +246,33 @@ defmodule Minga.Editor.ModelineTest do
       assert Modeline.cursor_shape(:operator_pending) == :block
     end
   end
+
+  describe "parser status indicator" do
+    test "shows nothing when parser is available" do
+      data = Map.put(@base_data, :parser_status, :available)
+      {commands, _regions} = Modeline.render(0, 120, data)
+      texts = Enum.map(commands, fn {_row, _col, text, _opts} -> text end)
+      refute Enum.any?(texts, &String.contains?(&1, "🌳"))
+    end
+
+    test "shows tree icon with ✗ when parser is unavailable" do
+      data = Map.put(@base_data, :parser_status, :unavailable)
+      {commands, _regions} = Modeline.render(0, 120, data)
+      texts = Enum.map(commands, fn {_row, _col, text, _opts} -> text end)
+      assert Enum.any?(texts, &String.contains?(&1, "🌳✗"))
+    end
+
+    test "shows tree icon with spinner when parser is restarting" do
+      data = Map.put(@base_data, :parser_status, :restarting)
+      {commands, _regions} = Modeline.render(0, 120, data)
+      texts = Enum.map(commands, fn {_row, _col, text, _opts} -> text end)
+      assert Enum.any?(texts, &String.contains?(&1, "🌳⟳"))
+    end
+
+    test "parser unavailable indicator is clickable to parser_restart" do
+      data = Map.put(@base_data, :parser_status, :unavailable)
+      {_commands, regions} = Modeline.render(0, 120, data)
+      assert Enum.any?(regions, fn {_start, _end, cmd} -> cmd == :parser_restart end)
+    end
+  end
 end

--- a/test/support/crash_parser.sh
+++ b/test/support/crash_parser.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# A fake parser binary that immediately exits with status 1.
+# Used in crash recovery tests to trigger the give-up path.
+exit 1


### PR DESCRIPTION
# TL;DR

Adds the files that were lost from the #745 commit due to a staging mishap: modeline parser status indicator, per-buffer highlight version reset, and crash_parser.sh test helper.

Part of #745

## Context

PR #749 (commit fb644585) was merged with 9 of the intended 14 files. The commit-gate extension blocked the commit twice, and the final successful attempt did not re-stage files that were added between block attempts. The worktree was then force-removed, destroying the unstaged changes. This follow-up restores all missing code.

## Changes

- **EditorState.parser_status** field (`:available`, `:restarting`, `:unavailable`) on the struct and typespec
- **Modeline indicator**: 🌳✗ (red, bold, clickable to `:parser_restart`) when parser is down, 🌳⟳ (yellow) when restarting, hidden when available. Uses existing LSP theme colors.
- **`:parser_crashed` broadcast** from Manager on non-zero exit so the Editor sets the modeline to `:restarting` immediately
- **Per-buffer highlight version reset** in the `:parser_restarted` handler. Without this, resync spans at version 0 were silently dropped by `Highlight.put_spans` (which checks `version < current` per-buffer, not just the global counter)
- **`restart_timestamps` cleared** on manual restart so a single crash after recovery does not immediately re-trigger give-up
- **`test/support/crash_parser.sh`** executable that exits 1 immediately, used by the give-up integration test
- **4 modeline tests**: available (hidden), unavailable (🌳✗), restarting (🌳⟳), clickable region

## Verification

```bash
mix test test/minga/editor/modeline_test.exs     # 33 tests, 4 new parser status
mix test test/minga/parser/crash_recovery_test.exs  # 7 tests (give-up now uses crash_parser.sh)
mix lint                                           # clean
mix test                                           # 5520 tests, 0 failures
```

## Acceptance Criteria Addressed

- The modeline or status area indicates when syntax highlighting is unavailable due to parser failure ✅
- Per-buffer highlight versions properly reset so resync actually works ✅ (bugfix from intent review)