### PR TITLE
fix(editor): enable text selection and copy in GUI agent chat view

### DIFF
--- a/lib/minga/buffer/document.ex
+++ b/lib/minga/buffer/document.ex
@@ -175,8 +175,8 @@ defmodule Minga.Buffer.Document do
   @spec position_to_offset(t(), position()) :: non_neg_integer()
   def position_to_offset(%__MODULE__{} = buf, {line, col})
       when is_integer(line) and line >= 0 and is_integer(col) and col >= 0 do
-    {offsets, _text} = ensure_line_offsets(buf)
-    offset_for_position(offsets, line, col)
+    {offsets, text} = ensure_line_offsets(buf)
+    offset_for_position(offsets, line, col, byte_size(text))
   end
 
   @doc """
@@ -383,8 +383,8 @@ defmodule Minga.Buffer.Document do
   def content_range(%__MODULE__{} = buf, from_pos, to_pos) do
     {offsets, text} = ensure_line_offsets(buf)
     text_size = byte_size(text)
-    from_off = offset_for_position(offsets, elem(from_pos, 0), elem(from_pos, 1))
-    to_off = offset_for_position(offsets, elem(to_pos, 0), elem(to_pos, 1))
+    from_off = offset_for_position(offsets, elem(from_pos, 0), elem(from_pos, 1), text_size)
+    to_off = offset_for_position(offsets, elem(to_pos, 0), elem(to_pos, 1), text_size)
     {start_off, end_off} = if from_off <= to_off, do: {from_off, to_off}, else: {to_off, from_off}
 
     # end_off points to the start of the last character. Find its byte length.
@@ -404,8 +404,8 @@ defmodule Minga.Buffer.Document do
   def delete_range(%__MODULE__{} = buf, from_pos, to_pos) do
     {offsets, text} = ensure_line_offsets(buf)
     text_size = byte_size(text)
-    from_off = offset_for_position(offsets, elem(from_pos, 0), elem(from_pos, 1))
-    to_off = offset_for_position(offsets, elem(to_pos, 0), elem(to_pos, 1))
+    from_off = offset_for_position(offsets, elem(from_pos, 0), elem(from_pos, 1), text_size)
+    to_off = offset_for_position(offsets, elem(to_pos, 0), elem(to_pos, 1), text_size)
 
     {start_off, end_off, cursor_pos} =
       if from_off <= to_off,
@@ -435,8 +435,8 @@ defmodule Minga.Buffer.Document do
     text_size = byte_size(text)
 
     {s, e} = sort_positions(start_pos, end_pos)
-    s_off = offset_for_position(offsets, elem(s, 0), elem(s, 1))
-    e_off = offset_for_position(offsets, elem(e, 0), elem(e, 1))
+    s_off = offset_for_position(offsets, elem(s, 0), elem(s, 1), text_size)
+    e_off = offset_for_position(offsets, elem(e, 0), elem(e, 1), text_size)
 
     # e_off points to the start of the last character. Find its byte length.
     remaining = binary_part(text, e_off, text_size - e_off)
@@ -767,12 +767,13 @@ defmodule Minga.Buffer.Document do
 
   # Computes the byte offset from start of text for a {line, byte_col} position
   # using the line offset tuple. O(1) lookup instead of O(lines) iteration.
-  @spec offset_for_position(tuple(), non_neg_integer(), non_neg_integer()) ::
+  @spec offset_for_position(tuple(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
           non_neg_integer()
-  defp offset_for_position(offsets, line, col) do
+  defp offset_for_position(offsets, line, col, text_size) do
     max_line = tuple_size(offsets) - 1
     clamped_line = min(line, max_line)
-    elem(offsets, clamped_line) + col
+    offset = elem(offsets, clamped_line) + col
+    min(offset, text_size)
   end
 
   # Returns the byte size of the next grapheme in `text`, or 0 for empty.

--- a/lib/minga/editor/render_pipeline/content.ex
+++ b/lib/minga/editor/render_pipeline/content.ex
@@ -280,6 +280,14 @@ defmodule Minga.Editor.RenderPipeline.Content do
     line_count = BufferServer.line_count(buf)
     viewport = agent_chat_viewport(window, chat_height, chat_width, cursor_line, line_count, buf)
 
+    # Store the computed viewport back on the window so the mouse handler
+    # uses the same scroll offset as the renderer. Without this, the mouse
+    # handler reads window.viewport.top (stale) while the renderer computes
+    # a different viewport (e.g., snapped to bottom when pinned), causing
+    # clicks to land on wrong buffer lines and visual selections to appear
+    # off-screen.
+    window = %{window | viewport: viewport}
+
     visible_rows = Viewport.content_rows(viewport)
     {first_line, _} = Viewport.visible_range(viewport)
 

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -629,6 +629,8 @@ defmodule Minga.Editor.State do
       :error ->
         state
     end
+  catch
+    :exit, _ -> state
   end
 
   @doc """

--- a/lib/minga/mode/visual.ex
+++ b/lib/minga/mode/visual.ex
@@ -62,6 +62,7 @@ defmodule Minga.Mode.Visual do
 
   # Modifier flags (mirrors Minga.Port.Protocol)
   @ctrl 0x02
+  @super 0x08
 
   # Arrow key codepoints sent by libvaxis
   @arrow_up 57_352
@@ -340,6 +341,11 @@ defmodule Minga.Mode.Visual do
   # d — delete selection, return to Normal
   def handle_key({?d, 0}, state) do
     {:execute_then_transition, [:delete_visual_selection], :normal, state}
+  end
+
+  # Cmd+C (GUI) / Super+C — copy selection to system clipboard, return to Normal
+  def handle_key({?c, mods}, state) when band(mods, @super) != 0 do
+    {:execute_then_transition, [:yank_visual_selection], :normal, state}
   end
 
   # c — delete selection, enter Insert

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -96,6 +96,9 @@ struct ContentView: View {
                     // metal view underneath means EditorNSView stays in the
                     // responder chain for keyboard input.
                     .opacity(appState.gui.agentChatState.visible ? 0 : 1)
+                    .onChange(of: appState.gui.agentChatState.visible) { _, visible in
+                        appState.editorNSView?.setAgentChatVisible(visible)
+                    }
 
                     if appState.gui.agentChatState.visible {
                         AgentChatView(

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -113,6 +113,7 @@ struct AgentChatView: View {
             Text(text)
                 .font(.system(size: 13))
                 .foregroundStyle(theme.popupFg)
+                .textSelection(.enabled)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
                 .background(
@@ -150,6 +151,7 @@ struct AgentChatView: View {
                 Text(text)
                     .font(.system(size: 12))
                     .foregroundStyle(theme.popupFg.opacity(0.35))
+                    .textSelection(.enabled)
                     .lineSpacing(3)
                     .padding(.leading, 14)
             }
@@ -215,6 +217,7 @@ struct AgentChatView: View {
                 .font(.system(size: 10))
             Text(text)
                 .font(.system(size: 11))
+                .textSelection(.enabled)
         }
         .foregroundStyle(isError ? Color.red.opacity(0.7) : theme.popupFg.opacity(0.4))
         .frame(maxWidth: .infinity, alignment: .center)

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -37,6 +37,13 @@ final class EditorNSView: MTKView {
     /// Installed when the view moves to a window.
     private var firstResponderGuard: FirstResponderGuard?
 
+    /// When true, the agent chat SwiftUI overlay is visible. A local key
+    /// event monitor intercepts all keyboard input and forwards it to
+    /// `keyDown` so the BEAM still receives keys even though the
+    /// FirstResponderGuard is suspended (needed for SwiftUI text selection).
+    private(set) var agentChatVisible: Bool = false
+    private var agentKeyMonitor: Any?
+
     init(encoder: InputEncoder, metalRenderer: MetalRenderer, fontFace: FontFace, cellGrid: CellGrid) {
         self.encoder = encoder
         self.metalRenderer = metalRenderer
@@ -191,6 +198,60 @@ final class EditorNSView: MTKView {
         )
         addTrackingArea(area)
         trackingArea = area
+    }
+
+    // MARK: - Agent chat key forwarding
+
+    /// Activates the agent chat overlay mode: suspends the first responder
+    /// guard (so SwiftUI text selection works) and installs a local key
+    /// monitor that forwards all keyboard input to `keyDown` (so the BEAM
+    /// still receives keys for vim navigation and prompt typing).
+    func setAgentChatVisible(_ visible: Bool) {
+        agentChatVisible = visible
+        firstResponderGuard?.suspended = visible
+
+        if visible {
+            installAgentKeyMonitor()
+        } else {
+            removeAgentKeyMonitor()
+            claimFirstResponder()
+        }
+    }
+
+    private func installAgentKeyMonitor() {
+        guard agentKeyMonitor == nil else { return }
+        agentKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+
+            // CMD+C: trigger system copy for SwiftUI text selection
+            if event.modifierFlags.contains(.command),
+               let chars = event.charactersIgnoringModifiers,
+               chars == "c"
+            {
+                NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: nil)
+                return nil
+            }
+
+            // `y` with no modifiers: trigger copy, swallow the event.
+            // Without swallowing, the BEAM enters operator-pending yank
+            // mode and the next keypress is misinterpreted as a motion.
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if event.characters == "y" && flags.isEmpty {
+                NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: nil)
+                return nil
+            }
+
+            // Forward all other keys to keyDown so the BEAM receives them
+            self.keyDown(with: event)
+            return nil
+        }
+    }
+
+    private func removeAgentKeyMonitor() {
+        if let monitor = agentKeyMonitor {
+            NSEvent.removeMonitor(monitor)
+            agentKeyMonitor = nil
+        }
     }
 
     // MARK: - Keyboard

--- a/macos/Sources/Views/MingaWindow.swift
+++ b/macos/Sources/Views/MingaWindow.swift
@@ -29,6 +29,11 @@ final class FirstResponderGuard {
     private weak var editorView: EditorNSView?
     private nonisolated(unsafe) var observer: NSObjectProtocol?
 
+    /// When true, the guard does not reclaim first responder. Set this
+    /// when a SwiftUI overlay (like the agent chat view) needs to handle
+    /// its own text selection without the guard stealing focus back.
+    var suspended: Bool = false
+
     init(window: NSWindow, editorView: EditorNSView) {
         self.window = window
         self.editorView = editorView
@@ -48,6 +53,7 @@ final class FirstResponderGuard {
     }
 
     private func checkFirstResponder() {
+        guard !suspended else { return }
         guard let window, let editor = editorView else { return }
         if window.firstResponder !== editor {
             window.makeFirstResponder(editor)

--- a/test/minga/buffer/document_test.exs
+++ b/test/minga/buffer/document_test.exs
@@ -831,6 +831,40 @@ defmodule Minga.Buffer.DocumentTest do
       assert Document.position_to_offset(buf, {2, 0}) == 12
       assert Document.position_to_offset(buf, {2, 2}) == 14
     end
+
+    test "position_to_offset clamps column beyond line length to text_size" do
+      buf = Document.new("ab\ncd")
+      # Total text_size = 5. Line 0 starts at 0, line 1 starts at 3.
+      # Column 50 on line 0 would be 0 + 50 = 50, but clamps to 5.
+      assert Document.position_to_offset(buf, {0, 50}) == 5
+    end
+
+    test "position_to_offset clamps line beyond last line" do
+      buf = Document.new("ab\ncd")
+      # Only lines 0 and 1. Line 99 clamps to line 1 (offset 3) + col 0.
+      assert Document.position_to_offset(buf, {99, 0}) == 3
+    end
+
+    test "get_range with out-of-bounds coordinates does not crash" do
+      buf = Document.new("hello\n\nworld")
+      # Line 1 is empty. Anchor at {1, 43} is beyond the line.
+      # This previously crashed with binary_part("", 43, -43).
+      result = Document.get_range(buf, {1, 43}, {0, 0})
+      assert is_binary(result)
+    end
+
+    test "get_range with both positions beyond text_size returns empty" do
+      buf = Document.new("ab")
+      result = Document.get_range(buf, {99, 99}, {99, 99})
+      assert result == ""
+    end
+
+    test "content_range with stale coordinates clamps gracefully" do
+      buf = Document.new("line1\n\nline3")
+      # Line 1 is empty, col 20 is beyond it.
+      result = Document.content_range(buf, {0, 0}, {1, 20})
+      assert is_binary(result)
+    end
   end
 
   # Convert a byte offset in text to a {line, byte_col} position.


### PR DESCRIPTION
# TL;DR

Mouse text selection in the macOS GUI agent chat view now works. Users can highlight text, and copy it with CMD+C or `y`.

## Context

The agent chat in the macOS GUI is a native SwiftUI view (`AgentChatView`), not the Metal-rendered cell grid. Mouse events went to SwiftUI and never reached the BEAM, making vim-style visual mode selection impossible. The `FirstResponderGuard` also stole focus back from SwiftUI's text selection system on every event cycle, killing any selection the instant the user released the mouse button.

During investigation, a buffer crash was found: `Document.get_range` would crash the buffer process when the agent buffer sync reshuffled lines between mouse press and release, leaving stale anchor coordinates that caused `binary_part` on out-of-bounds offsets.

## Changes

**Swift GUI (root cause):**
- `EditorNSView.setAgentChatVisible()` suspends the `FirstResponderGuard` and installs a local key event monitor that forwards all keyboard input to the BEAM. This lets SwiftUI handle text selection (guard suspended) while the BEAM still receives keystrokes for vim navigation and prompt typing (monitor forwarding).
- The key monitor intercepts CMD+C (triggers system copy, swallows event) and `y` with no modifiers (triggers system copy, swallows event to prevent operator-pending yank mode).
- Added `.textSelection(.enabled)` to user bubbles, thinking blocks, and system messages. Assistant blocks and tool results already had it.
- `MingaApp` wires agent chat visibility changes to `setAgentChatVisible()`.
- `FirstResponderGuard` gains a `suspended` flag that pauses focus reclamation.

**BEAM defensive fixes:**
- `Document.offset_for_position` now clamps the computed offset to `text_size`, preventing the `binary_part("", 43, -43)` crash. All 6 call sites updated. Regression tests added.
- `EditorState.sync_active_window_cursor` catches `:exit` from dead buffer processes so the render pipeline doesn't crash.
- `Mode.Visual` adds a CMD+C (super+c) binding that triggers `yank_visual_selection`, matching `y` behavior for the Metal-rendered editor.
- The render pipeline syncs the computed viewport back to the agent chat window so the mouse handler uses the same scroll offset as the renderer.

## Verification

1. Build the macOS GUI app (`bin/minga-mac`)
2. Open the agent view (switch to the agent tab)
3. Have a conversation with some assistant responses visible
4. Click and drag to select text in an assistant response
5. Verify the selection highlight persists after releasing the mouse
6. Press CMD+C, then paste elsewhere to verify the text was copied
7. Select text again, press `y`, then paste to verify copy works
8. Click in the prompt area, type text, verify typing still works after having selected text
9. Switch back to a code buffer tab, verify normal editing works

## Acceptance Criteria Addressed

- Mouse text selection in GUI agent chat ✅
- Selection persists after mouse release ✅
- CMD+C copies selected text ✅
- `y` copies selected text ✅
- Typing in prompt still works after selecting ✅
- No crashes during selection/copy flow ✅