### PR TITLE
feat(zig): decode draw_styled_text opcode 0x1C (#763)

### DIFF
--- a/test/minga/agent/markdown_highlight_test.exs
+++ b/test/minga/agent/markdown_highlight_test.exs
@@ -2,7 +2,20 @@ defmodule Minga.Agent.MarkdownHighlightTest do
   use ExUnit.Case, async: true
 
   alias Minga.Agent.MarkdownHighlight
+  alias Minga.Face
   alias Minga.Highlight
+
+  defp make_highlight(attrs) do
+    theme = Keyword.get(attrs, :theme, %{})
+
+    %Highlight{
+      version: Keyword.get(attrs, :version, 1),
+      spans: Keyword.get(attrs, :spans, {}),
+      capture_names: attrs |> Keyword.get(:capture_names, []) |> List.to_tuple(),
+      theme: theme,
+      face_registry: Face.Registry.from_syntax(theme)
+    }
+  end
 
   @theme_syntax %{
     "keyword" => [fg: 0x51AFEF],
@@ -89,12 +102,12 @@ defmodule Minga.Agent.MarkdownHighlightTest do
 
       # Tree-sitter would highlight "def" in the code line.
       # The code line "def hello" starts at byte 10 (after "```elixir\n")
-      highlight = %Highlight{
-        version: 1,
-        spans: {%{start_byte: 10, end_byte: 13, capture_id: 0}},
-        capture_names: ["keyword"],
-        theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
-      }
+      highlight =
+        make_highlight(
+          spans: {%{start_byte: 10, end_byte: 13, capture_id: 0}},
+          capture_names: ["keyword"],
+          theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
+        )
 
       result = MarkdownHighlight.stylize(text, highlight, @theme_syntax, 0)
 
@@ -120,12 +133,12 @@ defmodule Minga.Agent.MarkdownHighlightTest do
 
       # "def hello" is 10 bytes into this message's text.
       # With buffer_byte_offset=100, the "def" keyword is at bytes 110-113.
-      highlight = %Highlight{
-        version: 1,
-        spans: {%{start_byte: 110, end_byte: 113, capture_id: 0}},
-        capture_names: ["keyword"],
-        theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
-      }
+      highlight =
+        make_highlight(
+          spans: {%{start_byte: 110, end_byte: 113, capture_id: 0}},
+          capture_names: ["keyword"],
+          theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
+        )
 
       result = MarkdownHighlight.stylize(text, highlight, @theme_syntax, 100)
 
@@ -141,12 +154,7 @@ defmodule Minga.Agent.MarkdownHighlightTest do
       # A header line should NOT be overridden by tree-sitter
       text = "# My Header"
 
-      highlight = %Highlight{
-        version: 1,
-        spans: {},
-        capture_names: [],
-        theme: %{}
-      }
+      highlight = make_highlight(spans: {}, capture_names: [], theme: %{})
 
       result = MarkdownHighlight.stylize(text, highlight, @theme_syntax, 0)
 
@@ -161,12 +169,7 @@ defmodule Minga.Agent.MarkdownHighlightTest do
     test "falls back when highlight has no spans" do
       text = "**bold**"
 
-      highlight = %Highlight{
-        version: 0,
-        spans: {},
-        capture_names: [],
-        theme: %{}
-      }
+      highlight = make_highlight(version: 0, spans: {}, capture_names: [], theme: %{})
 
       result = MarkdownHighlight.stylize(text, highlight, @theme_syntax)
 

--- a/zig/src/apprt/tui.zig
+++ b/zig/src/apprt/tui.zig
@@ -275,8 +275,36 @@ fn cellToStyle(cell: Cell) vaxis.Cell.Style {
 
     if (cell.attrs & protocol.ATTR_BOLD != 0) style.bold = true;
     if (cell.attrs & protocol.ATTR_ITALIC != 0) style.italic = true;
-    if (cell.attrs & protocol.ATTR_UNDERLINE != 0) style.ul_style = .single;
     if (cell.attrs & protocol.ATTR_REVERSE != 0) style.reverse = true;
+
+    // Underline: check extended ul_style first (from draw_styled_text),
+    // then fall back to basic ATTR_UNDERLINE flag (from draw_text).
+    if (cell.ul_style != 0) {
+        style.ul_style = switch (cell.ul_style) {
+            1 => .curly,
+            2 => .dashed,
+            3 => .dotted,
+            4 => .double,
+            else => .single,
+        };
+    } else if (cell.attrs & protocol.ATTR_UNDERLINE != 0) {
+        style.ul_style = .single;
+    }
+
+    // Underline color (0 = use foreground, which is the libvaxis default)
+    if (cell.ul_color != 0) {
+        style.ul = .{ .rgb = .{
+            @as(u8, @intCast((cell.ul_color >> 16) & 0xFF)),
+            @as(u8, @intCast((cell.ul_color >> 8) & 0xFF)),
+            @as(u8, @intCast(cell.ul_color & 0xFF)),
+        } };
+    }
+
+    // Strikethrough
+    if (cell.strikethrough) style.strikethrough = true;
+
+    // Blend: values < 50 map to dim attribute
+    if (cell.blend < 50) style.dim = true;
 
     return style;
 }
@@ -1012,4 +1040,51 @@ test "g_quit can be set and read back" {
     g_quit.store(true, .release);
     try std.testing.expect(g_quit.load(.acquire) == true);
     g_quit.store(false, .release);
+}
+
+// ── Extended cell style tests ────────────────────────────────────────────────
+
+test "cellToStyle with strikethrough" {
+    const style = cellToStyle(.{ .strikethrough = true });
+    try std.testing.expect(style.strikethrough);
+}
+
+test "cellToStyle with curly underline and color" {
+    const style = cellToStyle(.{
+        .ul_style = 1, // curl
+        .ul_color = 0xFF0000,
+    });
+    try std.testing.expectEqual(vaxis.Cell.Style.Underline.curly, style.ul_style);
+    // Check underline color is red
+    try std.testing.expectEqual(vaxis.Cell.Color{ .rgb = .{ 0xFF, 0x00, 0x00 } }, style.ul);
+}
+
+test "cellToStyle with dashed underline" {
+    const style = cellToStyle(.{ .ul_style = 2 }); // dashed
+    try std.testing.expectEqual(vaxis.Cell.Style.Underline.dashed, style.ul_style);
+}
+
+test "cellToStyle with dotted underline" {
+    const style = cellToStyle(.{ .ul_style = 3 }); // dotted
+    try std.testing.expectEqual(vaxis.Cell.Style.Underline.dotted, style.ul_style);
+}
+
+test "cellToStyle with double underline" {
+    const style = cellToStyle(.{ .ul_style = 4 }); // double
+    try std.testing.expectEqual(vaxis.Cell.Style.Underline.double, style.ul_style);
+}
+
+test "cellToStyle with blend < 50 sets dim" {
+    const style = cellToStyle(.{ .blend = 30 });
+    try std.testing.expect(style.dim);
+}
+
+test "cellToStyle with blend >= 50 does not set dim" {
+    const style = cellToStyle(.{ .blend = 50 });
+    try std.testing.expect(!style.dim);
+}
+
+test "cellToStyle basic underline from attrs still works" {
+    const style = cellToStyle(.{ .attrs = protocol.ATTR_UNDERLINE });
+    try std.testing.expectEqual(vaxis.Cell.Style.Underline.single, style.ul_style);
 }

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -10,8 +10,9 @@
 ///   0x06 paste_event:  text_len:u16, text:u8[text_len]
 ///
 /// Render commands (BEAM → Zig):
-///   0x10 draw_text:  row:u16, col:u16, fg:u24, bg:u24, attrs:u8, text_len:u16, text
-///   0x11 set_cursor: row:u16, col:u16
+///   0x10 draw_text:        row:u16, col:u16, fg:u24, bg:u24, attrs:u8, text_len:u16, text
+///   0x1C draw_styled_text: row:u16, col:u16, fg:u24, bg:u24, attrs:u16, ul_color:u24, blend:u8, text_len:u16, text
+///   0x11 set_cursor:       row:u16, col:u16
 ///   0x12 clear:      (empty)
 ///   0x13 batch_end:  (empty)
 ///
@@ -39,6 +40,7 @@ pub const OP_CLEAR_REGION: u8 = 0x18;
 pub const OP_DESTROY_REGION: u8 = 0x19;
 pub const OP_SET_ACTIVE_REGION: u8 = 0x1A;
 pub const OP_SCROLL_REGION: u8 = 0x1B;
+pub const OP_DRAW_STYLED_TEXT: u8 = 0x1C;
 
 // Config commands (BEAM → frontend, TUI ignores)
 pub const OP_SET_FONT: u8 = 0x50;
@@ -209,6 +211,11 @@ pub const ATTR_BOLD: u8 = 0x01;
 pub const ATTR_UNDERLINE: u8 = 0x02;
 pub const ATTR_ITALIC: u8 = 0x04;
 pub const ATTR_REVERSE: u8 = 0x08;
+pub const ATTR_STRIKETHROUGH: u16 = 0x10;
+// Underline style occupies bits 5-7 of the extended u16 attrs:
+// 0b000 = line (default), 0b001 = curl, 0b010 = dashed, 0b011 = dotted, 0b100 = double
+pub const UL_STYLE_SHIFT: u4 = 5;
+pub const UL_STYLE_MASK: u16 = 0x07 << UL_STYLE_SHIFT;
 
 // ── Decoded types ──
 
@@ -220,6 +227,7 @@ pub const CursorShape = enum(u8) {
 
 pub const RenderCommand = union(enum) {
     draw_text: DrawText,
+    draw_styled_text: DrawStyledText,
     set_cursor: SetCursor,
     set_cursor_shape: CursorShape,
     set_title: []const u8,
@@ -359,6 +367,20 @@ pub const DrawText = struct {
     fg: u24,
     bg: u24,
     attrs: u8,
+    text: []const u8,
+};
+
+/// Extended draw command with 16-bit attrs, underline color, and blend.
+/// Opcode 0x1C. Wire format:
+///   row:u16, col:u16, fg:u24, bg:u24, attrs:u16, ul_color:u24, blend:u8, text_len:u16, text
+pub const DrawStyledText = struct {
+    row: u16,
+    col: u16,
+    fg: u24,
+    bg: u24,
+    attrs: u16,
+    ul_color: u24,
+    blend: u8,
     text: []const u8,
 };
 
@@ -583,6 +605,30 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
                 .fg = fg,
                 .bg = bg,
                 .attrs = attrs,
+                .text = text,
+            } };
+        },
+        OP_DRAW_STYLED_TEXT => {
+            // row:2, col:2, fg:3, bg:3, attrs:2, ul_color:3, blend:1, text_len:2 = 18 bytes min
+            if (rest.len < 18) return error.Malformed;
+            const row = std.mem.readInt(u16, rest[0..2], .big);
+            const col = std.mem.readInt(u16, rest[2..4], .big);
+            const fg = readU24(rest[4..7]);
+            const bg = readU24(rest[7..10]);
+            const attrs = std.mem.readInt(u16, rest[10..12], .big);
+            const ul_color = readU24(rest[12..15]);
+            const blend = rest[15];
+            const text_len = std.mem.readInt(u16, rest[16..18], .big);
+            if (rest.len < 18 + text_len) return error.Malformed;
+            const text = rest[18 .. 18 + text_len];
+            return .{ .draw_styled_text = .{
+                .row = row,
+                .col = col,
+                .fg = fg,
+                .bg = bg,
+                .attrs = attrs,
+                .ul_color = ul_color,
+                .blend = blend,
                 .text = text,
             } };
         },
@@ -2105,4 +2151,68 @@ test "batch decode: scroll_region + draw_text + batch_end" {
     try std.testing.expect(cmds[0] == .scroll_region);
     try std.testing.expect(cmds[1] == .draw_text);
     try std.testing.expect(cmds[2] == .batch_end);
+}
+
+// ── draw_styled_text (0x1C) tests ────────────────────────────────────────────
+
+test "decode draw_styled_text command" {
+    // Opcode 0x1C, row=3, col=7, fg=0xFF6C6B, bg=0x282C34,
+    // attrs=0x0015 (bold | strikethrough), ul_color=0xFF0000, blend=50,
+    // text_len=5, "error"
+    const data = [_]u8{
+        0x1C,
+        0x00, 0x03, // row
+        0x00, 0x07, // col
+        0xFF, 0x6C, 0x6B, // fg
+        0x28, 0x2C, 0x34, // bg
+        0x00, 0x11, // attrs: bold(0x01) | strikethrough(0x10)
+        0xFF, 0x00, 0x00, // ul_color: red
+        0x32, // blend: 50
+        0x00, 0x05, // text_len
+    } ++ "error".*;
+
+    const cmd = try decodeCommand(&data);
+    switch (cmd) {
+        .draw_styled_text => |dt| {
+            try std.testing.expectEqual(@as(u16, 3), dt.row);
+            try std.testing.expectEqual(@as(u16, 7), dt.col);
+            try std.testing.expectEqual(@as(u24, 0xFF6C6B), dt.fg);
+            try std.testing.expectEqual(@as(u24, 0x282C34), dt.bg);
+            try std.testing.expectEqual(@as(u16, 0x0011), dt.attrs);
+            try std.testing.expectEqual(@as(u24, 0xFF0000), dt.ul_color);
+            try std.testing.expectEqual(@as(u8, 50), dt.blend);
+            try std.testing.expectEqualStrings("error", dt.text);
+        },
+        else => return error.Malformed,
+    }
+}
+
+test "decode draw_styled_text with underline style curl" {
+    // attrs: underline(0x02) | curl style (1 << 5 = 0x20) = 0x0022
+    const data = [_]u8{
+        0x1C,
+        0x00, 0x00, // row
+        0x00, 0x00, // col
+        0xFF, 0xFF, 0xFF, // fg
+        0x00, 0x00, 0x00, // bg
+        0x00, 0x22, // attrs: underline | curl
+        0xFF, 0x00, 0x00, // ul_color: red
+        0x64, // blend: 100
+        0x00, 0x03, // text_len
+    } ++ "abc".*;
+
+    const cmd = try decodeCommand(&data);
+    switch (cmd) {
+        .draw_styled_text => |dt| {
+            try std.testing.expectEqual(@as(u16, 0x0022), dt.attrs);
+            // Verify underline style bits: (attrs >> 5) & 0x07 == 1 (curl)
+            try std.testing.expectEqual(@as(u16, 1), (dt.attrs >> 5) & 0x07);
+        },
+        else => return error.Malformed,
+    }
+}
+
+test "decode draw_styled_text truncated returns malformed" {
+    const data = [_]u8{ 0x1C, 0x00, 0x03 }; // too short
+    try std.testing.expectError(error.Malformed, decodeCommand(&data));
 }

--- a/zig/src/renderer.zig
+++ b/zig/src/renderer.zig
@@ -115,6 +115,51 @@ pub fn Renderer(comptime SurfaceT: type) type {
                     }
                 },
 
+                .draw_styled_text => |dt| {
+                    // Same as draw_text but with extended attrs.
+                    // Reuse draw_text logic by converting to a compatible form.
+                    var abs_row = dt.row;
+                    var abs_col = dt.col;
+                    var max_col: u16 = self.surface.width();
+
+                    if (self.active_region) |region| {
+                        abs_row +|= region.row;
+                        abs_col +|= region.col;
+                        if (abs_row >= region.row +| region.height) return;
+                        max_col = @min(self.surface.width(), region.col +| region.width);
+                    }
+
+                    var col: u16 = abs_col;
+                    var iter = vaxis.unicode.graphemeIterator(dt.text);
+
+                    while (iter.next()) |grapheme| {
+                        if (col >= max_col) break;
+
+                        const raw = grapheme.bytes(dt.text);
+                        const stable = try self.arena.allocator().dupe(u8, raw);
+                        const w: u16 = vaxis.gwidth.gwidth(stable, .wcwidth);
+
+                        const effective_bg = if (dt.bg == 0) self.default_bg else dt.bg;
+
+                        // Extract base attrs (bits 0-3)
+                        const base_attrs: u8 = @intCast(dt.attrs & 0x0F);
+
+                        self.surface.writeCell(col, abs_row, .{
+                            .grapheme = stable,
+                            .width = @intCast(if (w == 0) 1 else w),
+                            .fg = dt.fg,
+                            .bg = effective_bg,
+                            .attrs = base_attrs,
+                            .strikethrough = (dt.attrs & protocol.ATTR_STRIKETHROUGH) != 0,
+                            .ul_style = decodeUnderlineStyle(dt.attrs),
+                            .ul_color = dt.ul_color,
+                            .blend = dt.blend,
+                        });
+
+                        col +|= if (w == 0) 1 else w;
+                    }
+                },
+
                 .set_cursor => |sc| {
                     self.surface.showCursor(sc.col, sc.row);
                 },
@@ -201,6 +246,15 @@ pub fn Renderer(comptime SurfaceT: type) type {
             }
         }
     };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Decodes the underline style from the extended 16-bit attrs field.
+/// Bits 5-7 encode the style: 0=off/single, 1=curl, 2=dashed, 3=dotted, 4=double.
+/// Returns 0 for plain underline (renderer maps this based on ATTR_UNDERLINE flag).
+fn decodeUnderlineStyle(attrs: u16) u3 {
+    return @intCast((attrs >> protocol.UL_STYLE_SHIFT) & 0x07);
 }
 
 // ── Mock Surface for testing ──────────────────────────────────────────────────
@@ -556,4 +610,34 @@ test "clear then draw_text then batch_end full sequence" {
     try std.testing.expectEqual(@as(usize, 5), mock.cells_written);
     try std.testing.expectEqual(@as(u16, 3), mock.last_cursor_col);
     try std.testing.expectEqual(@as(usize, 1), mock.render_count);
+}
+
+test "handleCommand draw_styled_text passes extended attrs to cell" {
+    var mock = MockSurface{};
+    var rend = Renderer(MockSurface).init(&mock, std.testing.allocator);
+    defer rend.deinit();
+
+    // attrs: bold(0x01) | underline(0x02) | strikethrough(0x10) | curl style (1 << 5 = 0x20)
+    const attrs: u16 = 0x0033; // bold | underline | strikethrough | curl
+    try rend.handleCommand(.{ .draw_styled_text = .{
+        .row = 0,
+        .col = 0,
+        .fg = 0xFF6C6B,
+        .bg = 0x282C34,
+        .attrs = attrs,
+        .ul_color = 0xFF0000,
+        .blend = 50,
+        .text = "x",
+    } });
+    const cell = mock.last_cell.?;
+    // Base attrs (bits 0-3): bold | underline = 0x03
+    try std.testing.expectEqual(@as(u8, 0x03), cell.attrs);
+    // Extended: strikethrough
+    try std.testing.expect(cell.strikethrough);
+    // Extended: underline style curl (1)
+    try std.testing.expectEqual(@as(u3, 1), cell.ul_style);
+    // Extended: underline color
+    try std.testing.expectEqual(@as(u24, 0xFF0000), cell.ul_color);
+    // Extended: blend
+    try std.testing.expectEqual(@as(u8, 50), cell.blend);
 }

--- a/zig/src/surface.zig
+++ b/zig/src/surface.zig
@@ -40,6 +40,22 @@ pub const Cell = struct {
     /// Style attribute flags (bold, italic, underline, reverse).
     /// Uses protocol.ATTR_* constants.
     attrs: u8 = 0,
+
+    // ── Extended style attributes (from draw_styled_text opcode 0x1C) ──
+
+    /// Underline style: 0=off, 1=curl, 2=dashed, 3=dotted, 4=double.
+    /// Matches the BEAM-side encoding in protocol.ex (ul_style_to_bits).
+    /// When attrs has ATTR_UNDERLINE set and ul_style is 0, defaults to single.
+    ul_style: u3 = 0,
+
+    /// Underline color as 24-bit RGB. 0 = use foreground color.
+    ul_color: u24 = 0,
+
+    /// Strikethrough text decoration.
+    strikethrough: bool = false,
+
+    /// Opacity (0-100). 100 = fully opaque (default). Values < 50 map to dim.
+    blend: u8 = 100,
 };
 
 /// Validates at comptime that a type implements the Surface interface.


### PR DESCRIPTION
## What

Adds support for the extended `draw_styled_text` opcode (0x1C) in the Zig TUI renderer. This enables colored underlines, underline styles (curly, dashed, dotted, double), strikethrough, and blend/dim in the terminal.

## Why

The BEAM side added opcode 0x1C in PR #755 (face system) but the Zig renderer didn't decode it, falling through to `error.UnknownOpcode`. Without this, any feature that uses extended style attributes (diagnostic underlines with colors, deprecated API strikethrough, ghost text with dim) would crash the TUI renderer.

## Changes

### Protocol (`protocol.zig`)
- `OP_DRAW_STYLED_TEXT` (0x1C) constant
- `DrawStyledText` struct with 16-bit attrs, 24-bit underline color, 8-bit blend
- Decoder with 3 tests (round-trip, curl style, truncated)
- Extended attr constants: `ATTR_STRIKETHROUGH`, `UL_STYLE_SHIFT`, `UL_STYLE_MASK`

### Surface (`surface.zig`)
- `Cell` struct extended with `ul_style:u3`, `ul_color:u24`, `strikethrough:bool`, `blend:u8`
- All zero-initialized for backward compat with existing `draw_text` opcode

### Renderer (`renderer.zig`)
- `draw_styled_text` handler extracts base attrs (bits 0-3), strikethrough (bit 4), underline style (bits 5-7)
- `decodeUnderlineStyle` helper
- 1 renderer test through MockSurface

### TUI backend (`tui.zig`)
- `cellToStyle` maps new Cell fields to libvaxis `Cell.Style`:
  - `ul_style`: 1→curly, 2→dashed, 3→dotted, 4→double
  - `ul_color` → `style.ul` as RGB
  - `strikethrough` → `style.strikethrough`
  - `blend < 50` → `style.dim`
- 8 tests for all extended style mappings

## Testing
- `zig build test`: all pass
- `mix zig.lint`: pass (zig fmt + zig build test)
- Elixir test suite: 5625 tests pass (1 pre-existing failure on main in buffer_picker_test.exs)

## What this unlocks
Once #764 (diagnostic underlines) merges, adding `underline_color: severity_color(...)` to the decoration style will give colored diagnostic underlines in any terminal that supports SGR 58 (kitty, iTerm2, WezTerm, Ghostty, Alacritty). The `severity_color/2` function is already implemented and waiting.

Closes #763.