### PR TITLE
feat(modeline): diagnostic counts with Nerd Font icons (#584)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ PLAN.md
 test/tmp/
 autoresearch.jsonl
 autoresearch.ideas.md
+macos/build/

--- a/lib/minga/diagnostics.ex
+++ b/lib/minga/diagnostics.ex
@@ -188,6 +188,22 @@ defmodule Minga.Diagnostics do
   end
 
   @doc """
+  Returns diagnostic counts as a tuple for the modeline, or nil if none.
+
+  Returns `{errors, warnings, info, hints}` when any diagnostics exist,
+  or `nil` when there are none. Used by both the TUI modeline and the
+  GUI status bar protocol encoder.
+  """
+  @spec count_tuple(GenServer.server(), uri()) ::
+          {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil
+  def count_tuple(server \\ __MODULE__, uri) when is_binary(uri) do
+    case count(server, uri) do
+      %{error: 0, warning: 0, info: 0, hint: 0} -> nil
+      %{error: e, warning: w, info: i, hint: h} -> {e, w, i, h}
+    end
+  end
+
+  @doc """
   Returns all diagnostics on a specific line for a URI, from all sources.
 
   Useful for showing diagnostic messages in the minibuffer when the cursor

--- a/lib/minga/editor/commands/diagnostics.ex
+++ b/lib/minga/editor/commands/diagnostics.ex
@@ -17,13 +17,20 @@ defmodule Minga.Editor.Commands.Diagnostics do
 
   @command_specs [
     {:next_diagnostic, "Jump to next diagnostic", true},
-    {:prev_diagnostic, "Jump to previous diagnostic", true}
+    {:prev_diagnostic, "Jump to previous diagnostic", true},
+    {:diagnostic_list, "Show diagnostic list picker", true}
   ]
 
   @doc "Executes a diagnostic or LSP command."
-  @spec execute(EditorState.t(), :next_diagnostic | :prev_diagnostic | :lsp_info) ::
-          EditorState.t()
+  @spec execute(
+          EditorState.t(),
+          :next_diagnostic | :prev_diagnostic | :diagnostic_list | :lsp_info
+        ) :: EditorState.t()
   def execute(%{buffers: %{active: nil}} = state, _cmd), do: state
+
+  def execute(state, :diagnostic_list) do
+    Minga.Editor.PickerUI.open(state, Minga.Diagnostics.PickerSource)
+  end
 
   def execute(%{buffers: %{active: buf}} = state, :next_diagnostic) do
     navigate(state, buf, &Diagnostics.next/2)

--- a/lib/minga/editor/modeline.ex
+++ b/lib/minga/editor/modeline.ex
@@ -56,7 +56,9 @@ defmodule Minga.Editor.Modeline do
           optional(:lsp_status) => lsp_status(),
           optional(:parser_status) => parser_status(),
           optional(:git_branch) => String.t() | nil,
-          optional(:git_diff_summary) => git_diff_summary()
+          optional(:git_diff_summary) => git_diff_summary(),
+          optional(:diagnostic_counts) =>
+            {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil
         }
 
   @doc """
@@ -111,6 +113,7 @@ defmodule Minga.Editor.Modeline do
     lsp_segments = build_lsp_segments(data, bar_bg, ml)
     parser_segments = build_parser_segments(data, bar_bg, ml)
     git_segments = build_git_segments(data, bar_bg, theme)
+    diagnostic_segments = build_diagnostic_segments(data, bar_bg, theme)
 
     # Segments are {text, fg, bg, opts, click_target}
     # click_target is an atom command or nil for non-clickable segments
@@ -125,7 +128,8 @@ defmodule Minga.Editor.Modeline do
         Enum.map(agent_segments, fn {text, fg, bg, opts} -> {text, fg, bg, opts, nil} end)
 
     right_segments =
-      parser_segments ++
+      diagnostic_segments ++
+        parser_segments ++
         lsp_segments ++
         [
           {" #{devicon}", devicon_color, filetype_bg, [], nil},
@@ -252,6 +256,58 @@ defmodule Minga.Editor.Modeline do
 
   @spec build_lsp_segments(modeline_data(), non_neg_integer(), Theme.Modeline.t()) ::
           [{String.t(), non_neg_integer(), non_neg_integer(), keyword(), atom() | nil}]
+  # Nerd Font diagnostic icons
+  @diag_error_icon "\u{F057}"
+  @diag_warning_icon "\u{F071}"
+  @diag_info_icon "\u{F05A}"
+
+  @spec build_diagnostic_segments(modeline_data(), non_neg_integer(), Theme.t()) ::
+          [{String.t(), non_neg_integer(), non_neg_integer(), keyword(), atom() | nil}]
+  defp build_diagnostic_segments(%{diagnostic_counts: nil}, _bar_bg, _theme), do: []
+  defp build_diagnostic_segments(%{diagnostic_counts: {0, 0, 0, 0}}, _bar_bg, _theme), do: []
+
+  defp build_diagnostic_segments(
+         %{diagnostic_counts: {errors, warnings, info, _hints}},
+         bar_bg,
+         theme
+       ) do
+    gutter = theme.gutter
+    segments = []
+
+    segments =
+      if errors > 0 do
+        [
+          {" #{@diag_error_icon} #{errors}", gutter.error_fg, bar_bg, [], :diagnostic_list}
+          | segments
+        ]
+      else
+        segments
+      end
+
+    segments =
+      if warnings > 0 do
+        [
+          {" #{@diag_warning_icon} #{warnings}", gutter.warning_fg, bar_bg, [], :diagnostic_list}
+          | segments
+        ]
+      else
+        segments
+      end
+
+    segments =
+      if info > 0 do
+        [{" #{@diag_info_icon} #{info}", gutter.info_fg, bar_bg, [], :diagnostic_list} | segments]
+      else
+        segments
+      end
+
+    # Hints are intentionally omitted from the modeline (too noisy).
+    # Reverse because we prepended.
+    Enum.reverse(segments)
+  end
+
+  defp build_diagnostic_segments(_data, _bar_bg, _theme), do: []
+
   defp build_lsp_segments(data, bar_bg, ml) do
     case Map.get(data, :lsp_status) do
       :ready -> [{"●", ml.lsp_ready || 0x98BE65, bar_bg, [], :lsp_info}]

--- a/lib/minga/editor/render_pipeline/chrome_helpers.ex
+++ b/lib/minga/editor/render_pipeline/chrome_helpers.ex
@@ -9,7 +9,9 @@ defmodule Minga.Editor.RenderPipeline.ChromeHelpers do
   """
 
   alias Minga.Agent.Session
+  alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Config.Options
+  alias Minga.Diagnostics
   alias Minga.Editor.DisplayList
   alias Minga.Editor.FloatingWindow
   alias Minga.Editor.Layout
@@ -22,6 +24,7 @@ defmodule Minga.Editor.RenderPipeline.ChromeHelpers do
   alias Minga.Editor.WindowTree
   alias Minga.Git.Buffer, as: GitBuffer
   alias Minga.Git.Tracker, as: GitTracker
+  alias Minga.LSP.SyncServer
   alias Minga.Theme
   alias Minga.WhichKey
 
@@ -79,6 +82,7 @@ defmodule Minga.Editor.RenderPipeline.ChromeHelpers do
 
     buf = scroll.window.buffer
     {git_branch, git_diff_summary} = git_modeline_data(buf)
+    diagnostic_counts = diagnostic_modeline_data(buf)
 
     Modeline.render(
       modeline_row,
@@ -105,7 +109,8 @@ defmodule Minga.Editor.RenderPipeline.ChromeHelpers do
         lsp_status: lsp_status,
         parser_status: state.parser_status,
         git_branch: git_branch,
-        git_diff_summary: git_diff_summary
+        git_diff_summary: git_diff_summary,
+        diagnostic_counts: diagnostic_counts
       },
       state.theme,
       col_off
@@ -516,6 +521,24 @@ defmodule Minga.Editor.RenderPipeline.ChromeHelpers do
         catch
           :exit, _ -> {nil, nil}
         end
+    end
+  end
+
+  @spec diagnostic_modeline_data(pid() | nil) ::
+          {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil
+  defp diagnostic_modeline_data(nil), do: nil
+
+  defp diagnostic_modeline_data(buf) when is_pid(buf) do
+    path =
+      try do
+        BufferServer.file_path(buf)
+      catch
+        :exit, _ -> nil
+      end
+
+    case path do
+      nil -> nil
+      path -> Diagnostics.count_tuple(SyncServer.path_to_uri(path))
     end
   end
 end

--- a/lib/minga/editor/render_pipeline/emit/gui.ex
+++ b/lib/minga/editor/render_pipeline/emit/gui.ex
@@ -181,6 +181,8 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
     line_count = if buf, do: BufferServer.line_count(buf), else: 1
     file_name = if buf, do: BufferServer.file_path(buf) || "", else: ""
 
+    diagnostic_counts = diagnostic_counts_for_gui(buf)
+
     %{
       mode: state.vim.mode,
       cursor_line: line + 1,
@@ -190,7 +192,8 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
       dirty_marker: if(buf && BufferServer.dirty?(buf), do: "●", else: ""),
       lsp_status: state.lsp_status,
       git_branch: resolve_git_branch(state),
-      status_msg: state.status_msg
+      status_msg: state.status_msg,
+      diagnostic_counts: diagnostic_counts
     }
   end
 
@@ -203,6 +206,24 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
   end
 
   defp resolve_git_branch(_state), do: nil
+
+  @spec diagnostic_counts_for_gui(pid() | nil) ::
+          {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil
+  defp diagnostic_counts_for_gui(nil), do: nil
+
+  defp diagnostic_counts_for_gui(buf) do
+    path =
+      try do
+        BufferServer.file_path(buf)
+      catch
+        :exit, _ -> nil
+      end
+
+    case path do
+      nil -> nil
+      path -> Minga.Diagnostics.count_tuple(Minga.LSP.SyncServer.path_to_uri(path))
+    end
+  end
 
   # ── Picker ──
 

--- a/lib/minga/port/protocol/gui.ex
+++ b/lib/minga/port/protocol/gui.ex
@@ -392,9 +392,12 @@ defmodule Minga.Port.Protocol.GUI do
     message = :erlang.iolist_to_binary([data[:status_msg] || ""])
     filetype = :erlang.iolist_to_binary([Atom.to_string(data[:filetype] || :text)])
 
+    {error_count, warning_count} = diagnostic_counts_for_status(data)
+
     <<@op_gui_status_bar, mode_byte::8, data.cursor_line::32, data.cursor_col::32,
       data.line_count::32, flags::8, lsp_byte::8, byte_size(git_branch)::8, git_branch::binary,
-      byte_size(message)::16, message::binary, byte_size(filetype)::8, filetype::binary>>
+      byte_size(message)::16, message::binary, byte_size(filetype)::8, filetype::binary,
+      error_count::16, warning_count::16>>
   end
 
   @spec encode_vim_mode(atom()) :: non_neg_integer()
@@ -414,6 +417,14 @@ defmodule Minga.Port.Protocol.GUI do
   defp encode_lsp_status(:starting), do: 3
   defp encode_lsp_status(:error), do: 4
   defp encode_lsp_status(_), do: 0
+
+  @spec diagnostic_counts_for_status(map()) :: {non_neg_integer(), non_neg_integer()}
+  defp diagnostic_counts_for_status(data) do
+    case data[:diagnostic_counts] do
+      {errors, warnings, _info, _hints} -> {errors, warnings}
+      _ -> {0, 0}
+    end
+  end
 
   @spec build_status_flags(map()) :: non_neg_integer()
   defp build_status_flags(data) do

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -27,7 +27,7 @@ enum RenderCommand: Sendable {
     case guiCompletion(visible: Bool, anchorRow: UInt16, anchorCol: UInt16, selectedIndex: UInt16, items: [GUICompletionItem])
     case guiWhichKey(visible: Bool, prefix: String, page: UInt8, pageCount: UInt8, bindings: [GUIWhichKeyBinding])
     case guiBreadcrumb(segments: [String])
-    case guiStatusBar(mode: UInt8, cursorLine: UInt32, cursorCol: UInt32, lineCount: UInt32, flags: UInt8, lspStatus: UInt8, gitBranch: String, message: String, filetype: String)
+    case guiStatusBar(mode: UInt8, cursorLine: UInt32, cursorCol: UInt32, lineCount: UInt32, flags: UInt8, lspStatus: UInt8, gitBranch: String, message: String, filetype: String, errorCount: UInt16, warningCount: UInt16)
     case guiPicker(visible: Bool, selectedIndex: UInt16, title: String, query: String, items: [GUIPickerItem])
     case guiAgentChat(visible: Bool, status: UInt8, model: String, prompt: String, pendingToolName: String?, pendingToolSummary: String, messages: [GUIChatMessage])
     case guiGutterSeparator(col: UInt16, r: UInt8, g: UInt8, b: UInt8)
@@ -451,7 +451,11 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         let ftLen = Int(data[rest + 18 + gitLen + msgLen])
         guard data.count >= rest + 19 + gitLen + msgLen + ftLen else { throw ProtocolDecodeError.malformed }
         let filetype = String(data: data[(rest + 19 + gitLen + msgLen)..<(rest + 19 + gitLen + msgLen + ftLen)], encoding: .utf8) ?? ""
-        return (.guiStatusBar(mode: mode, cursorLine: cursorLine, cursorCol: cursorCol, lineCount: lineCount, flags: flags, lspStatus: lspStatus, gitBranch: gitBranch, message: message, filetype: filetype), rest + 19 + gitLen + msgLen + ftLen - offset)
+        let diagBase = rest + 19 + gitLen + msgLen + ftLen
+        let errorCount: UInt16 = data.count >= diagBase + 4 ? readU16(data, diagBase) : 0
+        let warningCount: UInt16 = data.count >= diagBase + 4 ? readU16(data, diagBase + 2) : 0
+        let totalConsumed = data.count >= diagBase + 4 ? diagBase + 4 : diagBase
+        return (.guiStatusBar(mode: mode, cursorLine: cursorLine, cursorCol: cursorCol, lineCount: lineCount, flags: flags, lspStatus: lspStatus, gitBranch: gitBranch, message: message, filetype: filetype, errorCount: errorCount, warningCount: warningCount), totalConsumed - offset)
 
     case OP_GUI_PICKER:
         guard data.count >= rest + 1 else { throw ProtocolDecodeError.malformed }

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -151,8 +151,8 @@ final class CommandDispatcher {
         case .guiBreadcrumb(let segments):
             guiState.breadcrumbState.update(segments: segments)
 
-        case .guiStatusBar(let mode, let cursorLine, let cursorCol, let lineCount, let flags, let lspStatus, let gitBranch, let message, let filetype):
-            guiState.statusBarState.update(mode: mode, cursorLine: cursorLine, cursorCol: cursorCol, lineCount: lineCount, flags: flags, lspStatus: lspStatus, gitBranch: gitBranch, message: message, filetype: filetype)
+        case .guiStatusBar(let mode, let cursorLine, let cursorCol, let lineCount, let flags, let lspStatus, let gitBranch, let message, let filetype, let errorCount, let warningCount):
+            guiState.statusBarState.update(mode: mode, cursorLine: cursorLine, cursorCol: cursorCol, lineCount: lineCount, flags: flags, lspStatus: lspStatus, gitBranch: gitBranch, message: message, filetype: filetype, errorCount: errorCount, warningCount: warningCount)
 
         case .guiPicker(let visible, let selectedIndex, let title, let query, let items):
             if visible {

--- a/macos/Sources/Views/StatusBarView.swift
+++ b/macos/Sources/Views/StatusBarView.swift
@@ -17,9 +17,12 @@ final class StatusBarState {
     var gitBranch: String = ""
     var message: String = ""
     var filetype: String = ""
+    var errorCount: UInt16 = 0
+    var warningCount: UInt16 = 0
 
     func update(mode: UInt8, cursorLine: UInt32, cursorCol: UInt32, lineCount: UInt32,
-                flags: UInt8, lspStatus: UInt8, gitBranch: String, message: String, filetype: String) {
+                flags: UInt8, lspStatus: UInt8, gitBranch: String, message: String, filetype: String,
+                errorCount: UInt16, warningCount: UInt16) {
         self.mode = mode
         self.cursorLine = cursorLine
         self.cursorCol = cursorCol
@@ -29,6 +32,8 @@ final class StatusBarState {
         self.gitBranch = gitBranch
         self.message = message
         self.filetype = filetype
+        self.errorCount = errorCount
+        self.warningCount = warningCount
     }
 
     var modeName: String {
@@ -110,6 +115,11 @@ struct StatusBarView: View {
             if state.hasLsp {
                 lspIndicator
             }
+
+            // Diagnostic counts
+            if state.errorCount > 0 || state.warningCount > 0 {
+                diagnosticIndicators
+            }
         }
     }
 
@@ -120,6 +130,31 @@ struct StatusBarView: View {
             .font(.system(size: 9))
             .foregroundStyle(color)
             .padding(.horizontal, 4)
+    }
+
+    @ViewBuilder
+    private var diagnosticIndicators: some View {
+        HStack(spacing: 6) {
+            if state.errorCount > 0 {
+                HStack(spacing: 2) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 9))
+                    Text("\(state.errorCount)")
+                        .font(.system(size: 11))
+                }
+                .foregroundStyle(Color(red: 1.0, green: 0.42, blue: 0.42))
+            }
+            if state.warningCount > 0 {
+                HStack(spacing: 2) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 9))
+                    Text("\(state.warningCount)")
+                        .font(.system(size: 11))
+                }
+                .foregroundStyle(Color(red: 0.92, green: 0.74, blue: 0.48))
+            }
+        }
+        .padding(.horizontal, 4)
     }
 
     private func lspDisplay(_ status: UInt8) -> (String, Color) {

--- a/test/minga/agent/markdown_highlight_test.exs
+++ b/test/minga/agent/markdown_highlight_test.exs
@@ -2,7 +2,20 @@ defmodule Minga.Agent.MarkdownHighlightTest do
   use ExUnit.Case, async: true
 
   alias Minga.Agent.MarkdownHighlight
+  alias Minga.Face
   alias Minga.Highlight
+
+  defp make_highlight(attrs) do
+    theme = Keyword.get(attrs, :theme, %{})
+
+    %Highlight{
+      version: Keyword.get(attrs, :version, 1),
+      spans: Keyword.get(attrs, :spans, {}),
+      capture_names: attrs |> Keyword.get(:capture_names, []) |> List.to_tuple(),
+      theme: theme,
+      face_registry: Face.Registry.from_syntax(theme)
+    }
+  end
 
   @theme_syntax %{
     "keyword" => [fg: 0x51AFEF],
@@ -89,12 +102,12 @@ defmodule Minga.Agent.MarkdownHighlightTest do
 
       # Tree-sitter would highlight "def" in the code line.
       # The code line "def hello" starts at byte 10 (after "```elixir\n")
-      highlight = %Highlight{
-        version: 1,
-        spans: {%{start_byte: 10, end_byte: 13, capture_id: 0}},
-        capture_names: ["keyword"],
-        theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
-      }
+      highlight =
+        make_highlight(
+          spans: {%{start_byte: 10, end_byte: 13, capture_id: 0}},
+          capture_names: ["keyword"],
+          theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
+        )
 
       result = MarkdownHighlight.stylize(text, highlight, @theme_syntax, 0)
 
@@ -120,12 +133,12 @@ defmodule Minga.Agent.MarkdownHighlightTest do
 
       # "def hello" is 10 bytes into this message's text.
       # With buffer_byte_offset=100, the "def" keyword is at bytes 110-113.
-      highlight = %Highlight{
-        version: 1,
-        spans: {%{start_byte: 110, end_byte: 113, capture_id: 0}},
-        capture_names: ["keyword"],
-        theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
-      }
+      highlight =
+        make_highlight(
+          spans: {%{start_byte: 110, end_byte: 113, capture_id: 0}},
+          capture_names: ["keyword"],
+          theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
+        )
 
       result = MarkdownHighlight.stylize(text, highlight, @theme_syntax, 100)
 
@@ -141,12 +154,7 @@ defmodule Minga.Agent.MarkdownHighlightTest do
       # A header line should NOT be overridden by tree-sitter
       text = "# My Header"
 
-      highlight = %Highlight{
-        version: 1,
-        spans: {},
-        capture_names: [],
-        theme: %{}
-      }
+      highlight = make_highlight(spans: {}, capture_names: [], theme: %{})
 
       result = MarkdownHighlight.stylize(text, highlight, @theme_syntax, 0)
 
@@ -161,12 +169,7 @@ defmodule Minga.Agent.MarkdownHighlightTest do
     test "falls back when highlight has no spans" do
       text = "**bold**"
 
-      highlight = %Highlight{
-        version: 0,
-        spans: {},
-        capture_names: [],
-        theme: %{}
-      }
+      highlight = make_highlight(version: 0, spans: {}, capture_names: [], theme: %{})
 
       result = MarkdownHighlight.stylize(text, highlight, @theme_syntax)
 

--- a/test/minga/editor/modeline_test.exs
+++ b/test/minga/editor/modeline_test.exs
@@ -275,4 +275,42 @@ defmodule Minga.Editor.ModelineTest do
       assert Enum.any?(regions, fn {_start, _end, cmd} -> cmd == :parser_restart end)
     end
   end
+
+  describe "diagnostic counts" do
+    test "shows error count with icon when errors present" do
+      data = Map.put(@base_data, :diagnostic_counts, {3, 0, 0, 0})
+      {commands, _regions} = Modeline.render(0, 120, data)
+      texts = Enum.map(commands, fn {_r, _c, text, _s} -> text end)
+      assert Enum.any?(texts, &String.contains?(&1, "3"))
+    end
+
+    test "shows warning count with icon when warnings present" do
+      data = Map.put(@base_data, :diagnostic_counts, {0, 5, 0, 0})
+      {commands, _regions} = Modeline.render(0, 120, data)
+      texts = Enum.map(commands, fn {_r, _c, text, _s} -> text end)
+      assert Enum.any?(texts, &String.contains?(&1, "5"))
+    end
+
+    test "shows both error and warning counts" do
+      data = Map.put(@base_data, :diagnostic_counts, {2, 3, 0, 0})
+      {commands, _regions} = Modeline.render(0, 120, data)
+      texts = Enum.map(commands, fn {_r, _c, text, _s} -> text end)
+      assert Enum.any?(texts, &String.contains?(&1, "2"))
+      assert Enum.any?(texts, &String.contains?(&1, "3"))
+    end
+
+    test "shows nothing when no diagnostics" do
+      data = Map.put(@base_data, :diagnostic_counts, nil)
+      {commands_with, _} = Modeline.render(0, 120, data)
+      {commands_without, _} = Modeline.render(0, 120, @base_data)
+      # Both should produce the same output (no diagnostic segment)
+      assert length(commands_with) == length(commands_without)
+    end
+
+    test "diagnostic counts are clickable to diagnostic_list" do
+      data = Map.put(@base_data, :diagnostic_counts, {1, 0, 0, 0})
+      {_commands, regions} = Modeline.render(0, 120, data)
+      assert Enum.any?(regions, fn {_start, _end, cmd} -> cmd == :diagnostic_list end)
+    end
+  end
 end


### PR DESCRIPTION
## What

Shows diagnostic error/warning/info counts in the TUI modeline and macOS GUI status bar using Nerd Font devicons colored by severity.

## TUI Modeline

` 3  1` — errors in red, warnings in yellow, info in blue. Hints are intentionally omitted (too noisy). Hidden when no diagnostics. Clickable to open the diagnostic picker via new `:diagnostic_list` command.

## GUI Status Bar

Protocol extended with `error_count:u16, warning_count:u16` appended to `gui_status_bar` opcode (0x76). Swift `StatusBarView` renders SF Symbol indicators (`xmark.circle.fill` for errors, `exclamationmark.triangle.fill` for warnings) with severity colors. Backward compatible (defaults to 0 if counts aren't present).

## New command

`:diagnostic_list` registered in `Commands.Diagnostics`, opens `PickerUI` with `Diagnostics.PickerSource`.

## Shared helper

`Diagnostics.count_tuple/2` returns `{errors, warnings, info, hints}` or `nil`, eliminating duplicated count logic between TUI and GUI code paths.

## Tests

5 new modeline tests (error count, warning count, both, nil, click region). Swift build succeeds. Full Elixir suite: 5630 tests, 0 failures.

Partial implementation of #584 (diagnostic counts only).