### PR TITLE
feat(gui): bold, italic, underline font rendering

### DIFF
--- a/macos/Sources/Font/FontFace.swift
+++ b/macos/Sources/Font/FontFace.swift
@@ -36,9 +36,34 @@ struct Glyph {
     var isColor: Bool
 }
 
+/// Cache key for glyphs: codepoint + font style (bold/italic bits).
+struct GlyphKey: Hashable {
+    let codepoint: UInt32
+    /// Bold/italic bits from attrs (0x00=regular, 0x01=bold, 0x04=italic, 0x05=bold+italic).
+    let style: UInt8
+}
+
+/// Cache key for ligatures: text + font style.
+struct LigatureKey: Hashable {
+    let text: String
+    /// Bold/italic bits from attrs (0x00=regular, 0x01=bold, 0x04=italic, 0x05=bold+italic).
+    let style: UInt8
+}
+
 /// Font face with glyph cache and atlas.
+///
+/// Holds up to four CTFont variants (regular, bold, italic, bold-italic)
+/// sharing a single glyph atlas. The glyph cache uses a compound key
+/// (codepoint + style bits) so each variant's glyphs are cached separately
+/// but packed into the same GPU texture.
 final class FontFace {
     let ctFont: CTFont
+    /// Bold variant, or nil if the font family doesn't have one.
+    let ctFontBold: CTFont?
+    /// Italic variant, or nil if the font family doesn't have one.
+    let ctFontItalic: CTFont?
+    /// Bold-italic variant, or nil if the font family doesn't have one.
+    let ctFontBoldItalic: CTFont?
     /// Cell dimensions in points (for grid layout).
     let cellWidth: Int
     let cellHeight: Int
@@ -50,16 +75,16 @@ final class FontFace {
     let scale: CGFloat
 
     let atlas: GlyphAtlas
-    private var cache: [UInt32: Glyph] = [:]
+    private var cache: [GlyphKey: Glyph] = [:]
 
     /// Whether programming ligatures are enabled. When true, multi-character
     /// sequences like `->`, `!=`, `=>` are shaped via CoreText and rendered
     /// as a single wide glyph spanning multiple cells.
     let ligaturesEnabled: Bool
 
-    /// Cache of shaped ligature glyphs keyed by the input string.
+    /// Cache of shaped ligature glyphs keyed by text + style.
     /// A nil value means "no ligature for this sequence."
-    private var ligatureCache: [String: LigatureResult?] = [:]
+    private var ligatureCache: [LigatureKey: LigatureResult?] = [:]
 
     /// Protocol weight byte → NSFontManager weight (0-15 scale).
     /// NSFontManager uses: 2=ultralight, 3=thin, 4=light, 5=regular,
@@ -95,6 +120,21 @@ final class FontFace {
         self.scale = scale
         self.ligaturesEnabled = ligatures
 
+        // Derive bold, italic, and bold-italic variants from the base font.
+        // CTFontCreateCopyWithSymbolicTraits returns nil if the variant doesn't
+        // exist in the font family. We fall back to the regular font at
+        // rasterization time when a variant is missing.
+        self.ctFontBold = FontFace.deriveVariant(font, traits: .boldTrait)
+        self.ctFontItalic = FontFace.deriveVariant(font, traits: .italicTrait)
+        self.ctFontBoldItalic = FontFace.deriveVariant(font, traits: [.boldTrait, .italicTrait])
+
+        if ctFontBold == nil {
+            PortLogger.warn("Font '\(name)' has no bold variant; bold text will render as regular")
+        }
+        if ctFontItalic == nil {
+            PortLogger.warn("Font '\(name)' has no italic variant; italic text will render as regular")
+        }
+
         let asc = CTFontGetAscent(font)
         let desc = CTFontGetDescent(font)
         let lead = CTFontGetLeading(font)
@@ -107,6 +147,29 @@ final class FontFace {
         self.cellHeight = Int(ceil(asc + desc + lead))
 
         self.atlas = GlyphAtlas(initialSize: 512)
+    }
+
+    /// Derive a font variant using CTFontCreateCopyWithSymbolicTraits.
+    /// Returns nil if the font family doesn't have the requested variant.
+    private static func deriveVariant(_ base: CTFont, traits: CTFontSymbolicTraits) -> CTFont? {
+        let size = CTFontGetSize(base)
+        // Pass the desired traits as both the value and the mask so only
+        // the requested bits are changed.
+        guard let derived = CTFontCreateCopyWithSymbolicTraits(base, size, nil, traits, traits) else {
+            return nil
+        }
+        return derived
+    }
+
+    /// Returns the CTFont for the given style bits (bold=0x01, italic=0x04).
+    /// Falls back to regular if the requested variant is unavailable.
+    func fontForStyle(_ style: UInt8) -> CTFont {
+        switch style & FONT_STYLE_MASK {
+        case 0x05: return ctFontBoldItalic ?? ctFont  // bold(0x01) | italic(0x04)
+        case 0x01: return ctFontBold ?? ctFont        // bold only
+        case 0x04: return ctFontItalic ?? ctFont      // italic only
+        default:   return ctFont                      // regular
+        }
     }
 
     /// Resolve a font name to a CTFont, trying multiple strategies:
@@ -140,13 +203,19 @@ final class FontFace {
         return CTFontCreateUIFontForLanguage(.userFixedPitch, size, nil)!
     }
 
-    /// Look up a glyph by codepoint, rasterizing on first access.
-    func getGlyph(_ codepoint: UInt32) -> Glyph? {
-        if let cached = cache[codepoint] {
+    /// Look up a glyph by codepoint and style, rasterizing on first access.
+    ///
+    /// `style` is the bold/italic bits (0x00=regular, 0x01=bold, 0x04=italic,
+    /// 0x05=bold+italic). The glyph is rasterized using the appropriate font
+    /// variant and cached with a compound key.
+    func getGlyph(_ codepoint: UInt32, style: UInt8 = 0) -> Glyph? {
+        let key = GlyphKey(codepoint: codepoint, style: style & FONT_STYLE_MASK)
+        if let cached = cache[key] {
             return cached
         }
 
-        guard let info = rasterizeGlyph(codepoint) else { return nil }
+        let font = fontForStyle(style)
+        guard let info = rasterizeGlyph(codepoint, using: font) else { return nil }
 
         let glyph = Glyph(
             atlasX: info.atlasX, atlasY: info.atlasY,
@@ -154,14 +223,15 @@ final class FontFace {
             offsetX: info.offsetX, offsetY: info.offsetY,
             isColor: info.isColor
         )
-        cache[codepoint] = glyph
+        cache[key] = glyph
         return glyph
     }
 
-    /// Pre-rasterize all printable ASCII glyphs to avoid hitches during rendering.
+    /// Pre-rasterize all printable ASCII glyphs for the regular variant.
+    /// Other variants are rasterized lazily on first use.
     func preloadAscii() {
         for cp: UInt32 in 0x20...0x7E {
-            _ = getGlyph(cp)
+            _ = getGlyph(cp, style: 0)
         }
     }
 
@@ -181,28 +251,30 @@ final class FontFace {
     /// input characters (indicating a ligature substitution happened).
     /// Returns nil if no ligature was produced or ligatures are disabled.
     ///
-    /// The result is cached, so repeated calls with the same string are cheap.
-    func shapeLigature(_ text: String) -> LigatureResult? {
+    /// `style` is the bold/italic bits. The correct font variant is used
+    /// for shaping so bold ligatures render at the right weight.
+    func shapeLigature(_ text: String, style: UInt8 = 0) -> LigatureResult? {
         guard ligaturesEnabled, text.count >= 2 else { return nil }
 
-        // Check cache first.
-        if let cached = ligatureCache[text] {
+        let key = LigatureKey(text: text, style: style & FONT_STYLE_MASK)
+        if let cached = ligatureCache[key] {
             return cached
         }
 
-        let result = detectAndRasterizeLigature(text)
-        ligatureCache[text] = result
+        let font = fontForStyle(style)
+        let result = detectAndRasterizeLigature(text, using: font)
+        ligatureCache[key] = result
         return result
     }
 
     /// Core ligature detection using CTLine shaping.
     ///
-    /// Creates an attributed string with the font, asks CoreText to shape it,
-    /// then inspects the glyph runs. If the number of glyphs is less than
+    /// Creates an attributed string with the given font, asks CoreText to shape
+    /// it, then inspects the glyph runs. If the number of glyphs is less than
     /// the number of characters, a ligature substitution occurred.
-    private func detectAndRasterizeLigature(_ text: String) -> LigatureResult? {
+    private func detectAndRasterizeLigature(_ text: String, using font: CTFont) -> LigatureResult? {
         let attrs: [NSAttributedString.Key: Any] = [
-            .font: ctFont as Any,
+            .font: font as Any,
             // Enable all ligatures (1 = standard, 2 = all including rare ones).
             .ligature: 2
         ]
@@ -318,8 +390,9 @@ final class FontFace {
         return advance.width
     }
 
-    /// Rasterize a single codepoint into the atlas.
-    private func rasterizeGlyph(_ codepoint: UInt32) -> GlyphInfo? {
+    /// Rasterize a single codepoint into the atlas using the given font variant.
+    private func rasterizeGlyph(_ codepoint: UInt32, using baseFont: CTFont? = nil) -> GlyphInfo? {
+        let primaryFont = baseFont ?? ctFont
         // Convert codepoint to UTF-16 for CoreText.
         var utf16: [UniChar] = []
         if codepoint <= 0xFFFF {
@@ -330,16 +403,16 @@ final class FontFace {
             utf16 = [UniChar(0xD800 + (cp >> 10)), UniChar(0xDC00 + (cp & 0x3FF))]
         }
 
-        // Look up glyph ID, with font fallback for emoji.
+        // Look up glyph ID using the requested font variant, with fallback for emoji.
         var glyphs: [CGGlyph] = Array(repeating: 0, count: utf16.count)
-        var renderFont = ctFont
+        var renderFont = primaryFont
         var ownsFallback = false
 
-        if !CTFontGetGlyphsForCharacters(ctFont, &utf16, &glyphs, utf16.count) {
-            // Primary font doesn't have this glyph; ask CoreText for a fallback.
+        if !CTFontGetGlyphsForCharacters(primaryFont, &utf16, &glyphs, utf16.count) {
+            // Variant font doesn't have this glyph; ask CoreText for a fallback.
             let cfStr = CFStringCreateWithCharacters(nil, &utf16, utf16.count)!
             let range = CFRange(location: 0, length: utf16.count)
-            let fallback = CTFontCreateForString(ctFont, cfStr, range)
+            let fallback = CTFontCreateForString(primaryFont, cfStr, range)
             if CTFontGetGlyphsForCharacters(fallback, &utf16, &glyphs, utf16.count) {
                 renderFont = fallback
                 ownsFallback = true

--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -24,6 +24,7 @@ let OP_SET_WINDOW_BG: UInt8 = 0x17
 let OP_CLEAR_REGION: UInt8 = 0x18
 let OP_DESTROY_REGION: UInt8 = 0x19
 let OP_SET_ACTIVE_REGION: UInt8 = 0x1A
+let OP_DRAW_STYLED_TEXT: UInt8 = 0x1C
 
 // MARK: - GUI chrome opcodes (BEAM → frontend, contiguous range 0x70-0x78)
 
@@ -122,9 +123,22 @@ let TEXT_PROPORTIONAL: UInt8 = 1
 // MARK: - Text attribute bits
 
 let ATTR_BOLD: UInt8 = 0x01
-let ATTR_ITALIC: UInt8 = 0x02
-let ATTR_UNDERLINE: UInt8 = 0x04
+let ATTR_UNDERLINE: UInt8 = 0x02
+let ATTR_ITALIC: UInt8 = 0x04
 let ATTR_REVERSE: UInt8 = 0x08
+let ATTR_STRIKETHROUGH: UInt16 = 0x10
+
+// Underline style (3 bits at position 5-7 in extended 16-bit attrs)
+let UL_STYLE_SHIFT: UInt16 = 5
+let UL_STYLE_MASK: UInt16 = 0x07  // 3 bits
+let UL_STYLE_LINE: UInt16 = 0
+let UL_STYLE_CURL: UInt16 = 1
+let UL_STYLE_DASHED: UInt16 = 2
+let UL_STYLE_DOTTED: UInt16 = 3
+let UL_STYLE_DOUBLE: UInt16 = 4
+
+// Bold/italic style mask for font variant selection (bits 0 and 2 of attrs)
+let FONT_STYLE_MASK: UInt8 = 0x05
 
 // MARK: - Mouse button constants
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -12,6 +12,7 @@ enum RenderCommand: Sendable {
     case clear
     case batchEnd
     case drawText(row: UInt16, col: UInt16, fg: UInt32, bg: UInt32, attrs: UInt8, text: String)
+    case drawStyledText(row: UInt16, col: UInt16, fg: UInt32, bg: UInt32, attrs: UInt16, underlineColor: UInt32, blend: UInt8, text: String)
     case setCursor(row: UInt16, col: UInt16)
     case setCursorShape(CursorShape)
     case setTitle(String)
@@ -165,6 +166,22 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         let textData = data[(rest + 13)..<(rest + 13 + textLen)]
         let text = String(data: textData, encoding: .utf8) ?? ""
         return (.drawText(row: row, col: col, fg: fg, bg: bg, attrs: attrs, text: text), 1 + 13 + textLen)
+
+    case OP_DRAW_STYLED_TEXT:
+        // row:2, col:2, fg:3, bg:3, attrs:2(16-bit), ul_color:3, blend:1, text_len:2 = 18 bytes after opcode
+        guard data.count >= rest + 18 else { throw ProtocolDecodeError.malformed }
+        let row = readU16(data, rest)
+        let col = readU16(data, rest + 2)
+        let fg = readU24(data, rest + 4)
+        let bg = readU24(data, rest + 7)
+        let attrs16 = UInt16(data[rest + 10]) << 8 | UInt16(data[rest + 11])
+        let ulColor = readU24(data, rest + 12)
+        let blend = data[rest + 15]
+        let textLen = Int(readU16(data, rest + 16))
+        guard data.count >= rest + 18 + textLen else { throw ProtocolDecodeError.malformed }
+        let textData = data[(rest + 18)..<(rest + 18 + textLen)]
+        let text = String(data: textData, encoding: .utf8) ?? ""
+        return (.drawStyledText(row: row, col: col, fg: fg, bg: bg, attrs: attrs16, underlineColor: ulColor, blend: blend, text: text), 1 + 18 + textLen)
 
     case OP_SET_CURSOR:
         guard data.count >= rest + 4 else { throw ProtocolDecodeError.malformed }

--- a/macos/Sources/Renderer/CellGrid.swift
+++ b/macos/Sources/Renderer/CellGrid.swift
@@ -17,8 +17,14 @@ struct Cell {
     var fg: UInt32 = 0
     /// Background color as 24-bit RGB (0 = default).
     var bg: UInt32 = 0
-    /// Text attributes bitmask (bold, italic, underline, reverse).
+    /// Text attributes bitmask (bold, italic, underline, reverse, strikethrough).
     var attrs: UInt8 = 0
+    /// Underline color as 24-bit RGB (0 = use fg color).
+    /// Set by draw_styled_text; plain draw_text leaves this at 0.
+    var underlineColor: UInt32 = 0
+    /// Underline style (0=line, 1=curl, 2=dashed, 3=dotted, 4=double).
+    /// Only meaningful when ATTR_UNDERLINE is set.
+    var underlineStyle: UInt8 = 0
     /// For ligature head cells: the full source text that was shaped (e.g., "->").
     /// Empty for non-ligature cells.
     var ligatureText: String = ""

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -61,6 +61,14 @@ final class CommandDispatcher {
         case .drawText(let row, let col, let fg, let bg, let attrs, let text):
             drawText(row: row, col: col, fg: fg, bg: bg, attrs: attrs, text: text)
 
+        case .drawStyledText(let row, let col, let fg, let bg, let attrs16, let ulColor, _, let text):
+            // Extended draw: 16-bit attrs with underline style, strikethrough, and underline color.
+            // The low 8 bits of attrs16 match the regular attrs byte layout.
+            let attrs8 = UInt8(attrs16 & 0xFF)
+            let ulStyle = UInt8((attrs16 >> UL_STYLE_SHIFT) & UL_STYLE_MASK)
+            drawText(row: row, col: col, fg: fg, bg: bg, attrs: attrs8, text: text,
+                     underlineColor: ulColor, underlineStyle: ulStyle)
+
         case .setCursor(let row, let col):
             var absRow = row
             var absCol = col
@@ -212,7 +220,8 @@ final class CommandDispatcher {
         return byLen.sorted { $0.key > $1.key }.map { ($0.key, $0.value) }
     }()
 
-    private func drawText(row: UInt16, col: UInt16, fg: UInt32, bg: UInt32, attrs: UInt8, text: String) {
+    private func drawText(row: UInt16, col: UInt16, fg: UInt32, bg: UInt32, attrs: UInt8, text: String,
+                          underlineColor: UInt32 = 0, underlineStyle: UInt8 = 0) {
         var absRow = row
         var absCol = col
         var maxCol = grid.cols
@@ -235,7 +244,7 @@ final class CommandDispatcher {
                 let w = graphemeWidth(grapheme)
                 grid.writeCell(col: currentCol, row: absRow, cell: Cell(
                     grapheme: grapheme, width: UInt8(w),
-                    fg: fg, bg: bg, attrs: attrs
+                    fg: fg, bg: bg, attrs: attrs, underlineColor: underlineColor, underlineStyle: underlineStyle
                 ))
                 currentCol &+= UInt16(w)
             }
@@ -265,10 +274,11 @@ final class CommandDispatcher {
                     let candidate = String(chars[i..<(i + seqLen)])
                     guard candidates.contains(candidate) else { continue }
 
-                    if let lig = face.shapeLigature(candidate) {
+                    if let lig = face.shapeLigature(candidate, style: attrs) {
                         grid.writeCell(col: currentCol, row: absRow, cell: Cell(
                             grapheme: candidate, width: UInt8(lig.cellCount),
                             fg: fg, bg: bg, attrs: attrs,
+                            underlineColor: underlineColor, underlineStyle: underlineStyle,
                             ligatureText: candidate,
                             ligatureCellCount: UInt8(lig.cellCount),
                             isContinuation: false
@@ -277,6 +287,7 @@ final class CommandDispatcher {
                             grid.writeCell(col: currentCol &+ offset, row: absRow, cell: Cell(
                                 grapheme: "", width: 1,
                                 fg: fg, bg: bg, attrs: attrs,
+                                underlineColor: underlineColor, underlineStyle: underlineStyle,
                                 isContinuation: true
                             ))
                         }
@@ -293,7 +304,7 @@ final class CommandDispatcher {
                 let w = graphemeWidth(grapheme)
                 grid.writeCell(col: currentCol, row: absRow, cell: Cell(
                     grapheme: grapheme, width: UInt8(w),
-                    fg: fg, bg: bg, attrs: attrs
+                    fg: fg, bg: bg, attrs: attrs, underlineColor: underlineColor, underlineStyle: underlineStyle
                 ))
                 currentCol &+= UInt16(w)
                 i += 1

--- a/macos/Sources/Renderer/MetalRenderer.swift
+++ b/macos/Sources/Renderer/MetalRenderer.swift
@@ -24,6 +24,18 @@ struct CellGPU {
     var isColor: Float = 0
 }
 
+/// GPU data for an underlined cell (must match UnderlineData in Shaders.metal).
+struct UnderlineGPU {
+    /// Grid position (column, row).
+    var gridPos: SIMD2<Float> = .zero
+    /// Underline color (RGB, 0..1).
+    var color: SIMD3<Float> = .init(1, 1, 1)
+    /// Underline style: 0=line, 1=curl, 2=dashed, 3=dotted, 4=double.
+    var style: Float = 0
+    /// Cell width in grid units (>1 for wide characters).
+    var cellSpan: Float = 1
+}
+
 /// Uniforms shared across all cells (must match Uniforms in Shaders.metal).
 struct Uniforms {
     var cellSize: SIMD2<Float>
@@ -43,6 +55,7 @@ final class MetalRenderer {
     let commandQueue: MTLCommandQueue
     private let bgPipeline: MTLRenderPipelineState
     private let glyphPipeline: MTLRenderPipelineState
+    private let underlinePipeline: MTLRenderPipelineState
 
     /// Reusable Metal buffer for cell data (avoids setVertexBytes 4KB limit).
     private var cellBuffer: MTLBuffer?
@@ -87,9 +100,21 @@ final class MetalRenderer {
         glyphDesc.colorAttachments[0].sourceAlphaBlendFactor = .one
         glyphDesc.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
 
+        // Underline pipeline (alpha blending for anti-aliased curl underlines).
+        let ulDesc = MTLRenderPipelineDescriptor()
+        ulDesc.vertexFunction = library.makeFunction(name: "underline_vertex")
+        ulDesc.fragmentFunction = library.makeFunction(name: "underline_fragment")
+        ulDesc.colorAttachments[0].pixelFormat = .bgra8Unorm_srgb
+        ulDesc.colorAttachments[0].isBlendingEnabled = true
+        ulDesc.colorAttachments[0].sourceRGBBlendFactor = .one
+        ulDesc.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
+        ulDesc.colorAttachments[0].sourceAlphaBlendFactor = .one
+        ulDesc.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
+
         do {
             self.bgPipeline = try device.makeRenderPipelineState(descriptor: bgDesc)
             self.glyphPipeline = try device.makeRenderPipelineState(descriptor: glyphDesc)
+            self.underlinePipeline = try device.makeRenderPipelineState(descriptor: ulDesc)
         } catch {
             NSLog("Failed to create Metal pipeline: \(error)")
             return nil
@@ -156,9 +181,11 @@ final class MetalRenderer {
                 continue
             }
 
+            let fontStyle = cell.attrs & FONT_STYLE_MASK
+
             // Ligature head cell: use the shaped ligature glyph.
             if cell.ligatureCellCount > 1, !cell.ligatureText.isEmpty,
-               let lig = face.shapeLigature(cell.ligatureText) {
+               let lig = face.shapeLigature(cell.ligatureText, style: fontStyle) {
                 gpu.hasGlyph = 1.0
                 gpu.isColor = 0.0
                 gpu.uvOrigin = SIMD2<Float>(Float(lig.glyph.atlasX) / atlasSize,
@@ -175,7 +202,7 @@ final class MetalRenderer {
             // Normal single-cell glyph.
             else if !cell.grapheme.isEmpty, cell.grapheme != " " {
                 if let scalar = cell.grapheme.unicodeScalars.first,
-                   let glyph = face.getGlyph(scalar.value) {
+                   let glyph = face.getGlyph(scalar.value, style: fontStyle) {
                     gpu.hasGlyph = 1.0
                     gpu.isColor = glyph.isColor ? 1.0 : 0.0
                     gpu.uvOrigin = SIMD2<Float>(Float(glyph.atlasX) / atlasSize,
@@ -192,6 +219,35 @@ final class MetalRenderer {
             }
 
             gpuCells[i] = gpu
+        }
+
+        // Collect underlined cells for the underline pass.
+        var underlineCells: [UnderlineGPU] = []
+        for i in 0..<count {
+            let cell = grid.cells[i]
+            guard (cell.attrs & ATTR_UNDERLINE) != 0 else { continue }
+            guard !cell.isContinuation else { continue }
+
+            let col = UInt16(i % Int(grid.cols))
+            let row = UInt16(i / Int(grid.cols))
+
+            let ulColorRaw = cell.underlineColor
+            let ulColor: SIMD3<Float>
+            if ulColorRaw != 0 {
+                ulColor = colorFromU24(ulColorRaw, default: gpuCells[i].fgColor)
+            } else {
+                ulColor = gpuCells[i].fgColor
+            }
+
+            var ul = UnderlineGPU()
+            ul.gridPos = SIMD2<Float>(
+                col >= grid.gutterCol ? Float(col) + gutterPaddingCells : Float(col),
+                Float(row)
+            )
+            ul.color = ulColor
+            ul.style = Float(cell.underlineStyle)
+            ul.cellSpan = Float(cell.width)
+            underlineCells.append(ul)
         }
 
         // Ensure the Metal buffer is large enough.
@@ -236,6 +292,14 @@ final class MetalRenderer {
                 encoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
                 encoder.setFragmentTexture(atlas, index: 0)
                 encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: count)
+            }
+
+            // Underline pass: draw underlines for cells with ATTR_UNDERLINE set.
+            if !underlineCells.isEmpty {
+                encoder.setRenderPipelineState(underlinePipeline)
+                encoder.setVertexBytes(&underlineCells, length: underlineCells.count * MemoryLayout<UnderlineGPU>.stride, index: 0)
+                encoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
+                encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: underlineCells.count)
             }
 
             // Gutter gap fill: draw a background-colored rect to cover the

--- a/macos/Sources/Renderer/Shaders.metal
+++ b/macos/Sources/Renderer/Shaders.metal
@@ -160,3 +160,89 @@ fragment float4 glyph_fragment(
     float3 linear_fg = srgbToLinear(in.fg_color);
     return alpha < 0.01 ? float4(0.0) : float4(linear_fg * alpha, alpha);
 }
+
+// ── Underline pass ────────────────────────────────────────────────────────────
+
+/// Per-underline instance data.
+struct UnderlineData {
+    float2 grid_pos;    // Column, row in grid units.
+    float3 color;       // Underline color (RGB, 0..1).
+    float  style;       // 0=line, 1=curl, 2=dashed, 3=dotted, 4=double.
+    float  cell_span;   // Width in cells (1 for normal, 2 for wide chars).
+};
+
+struct UnderlineOut {
+    float4 position [[position]];
+    float3 color;
+    float  style;
+    float2 uv;         // Normalized position within the underline quad.
+};
+
+vertex UnderlineOut underline_vertex(
+    uint vertex_id [[vertex_id]],
+    uint instance_id [[instance_id]],
+    constant UnderlineData* underlines [[buffer(0)]],
+    constant Uniforms& uniforms [[buffer(1)]]
+) {
+    constant UnderlineData& ul = underlines[instance_id];
+    float2 pos = quadPositions[vertex_id];
+
+    // Underline is drawn at the bottom of the cell (last 2px at content scale).
+    float underline_height = 2.0;
+    float cell_width = uniforms.cell_size.x * ul.cell_span;
+    float cell_height = uniforms.cell_size.y;
+
+    // Position at bottom of cell.
+    float2 cell_origin = ul.grid_pos * uniforms.cell_size - uniforms.scroll_offset;
+    float2 ul_origin = float2(cell_origin.x, cell_origin.y + cell_height - underline_height);
+    float2 ul_size = float2(cell_width, underline_height);
+    float2 pixel_pos = ul_origin + pos * ul_size;
+
+    UnderlineOut out;
+    out.position = float4(pixelToNDC(pixel_pos, uniforms.viewport_size), 0.0, 1.0);
+    out.color = ul.color;
+    out.style = ul.style;
+    out.uv = pos;
+    return out;
+}
+
+fragment float4 underline_fragment(UnderlineOut in [[stage_in]]) {
+    float3 linear_color = srgbToLinear(in.color);
+    int style = int(in.style + 0.5);
+
+    // Style 0: solid line (full coverage).
+    if (style == 0) {
+        return float4(linear_color, 1.0);
+    }
+
+    // Style 1: curl (sine wave).
+    if (style == 1) {
+        float wave = sin(in.uv.x * 3.14159 * 4.0) * 0.5 + 0.5;
+        float dist = abs(in.uv.y - wave);
+        float alpha = smoothstep(0.4, 0.0, dist);
+        return float4(linear_color * alpha, alpha);
+    }
+
+    // Style 2: dashed (4 dashes per cell).
+    if (style == 2) {
+        float pattern = step(0.5, fract(in.uv.x * 4.0));
+        return float4(linear_color * pattern, pattern);
+    }
+
+    // Style 3: dotted (8 dots per cell).
+    if (style == 3) {
+        float pattern = step(0.5, fract(in.uv.x * 8.0));
+        return float4(linear_color * pattern, pattern);
+    }
+
+    // Style 4: double (two thin lines).
+    if (style == 4) {
+        float line1 = step(in.uv.y, 0.3);
+        float line2 = step(0.7, in.uv.y);
+        float alpha = max(line1, line2);
+        return float4(linear_color * alpha, alpha);
+    }
+
+    // Fallback: solid.
+    return float4(linear_color, 1.0);
+}

--- a/macos/Tests/MingaTests/FontTests.swift
+++ b/macos/Tests/MingaTests/FontTests.swift
@@ -96,6 +96,90 @@ struct FontResolutionTests {
     }
 }
 
+@Suite("FontFace variants")
+struct FontVariantTests {
+    @Test("Menlo has bold, italic, and bold-italic variants")
+    func menloHasAllVariants() {
+        let face = FontFace(name: "Menlo", size: 13, scale: 2.0)
+        #expect(face.ctFontBold != nil, "Menlo should have a bold variant")
+        #expect(face.ctFontItalic != nil, "Menlo should have an italic variant")
+        #expect(face.ctFontBoldItalic != nil, "Menlo should have a bold-italic variant")
+    }
+
+    @Test("fontForStyle returns correct variant")
+    func fontForStyleReturnsCorrectVariant() {
+        let face = FontFace(name: "Menlo", size: 13, scale: 2.0)
+        let regular = face.fontForStyle(0x00)
+        let bold = face.fontForStyle(0x01)
+        let italic = face.fontForStyle(0x04)
+        let boldItalic = face.fontForStyle(0x05)
+
+        // Regular should be the base font.
+        let regularName = CTFontCopyPostScriptName(regular) as String
+        #expect(regularName.contains("Menlo"))
+
+        // Bold variant should differ from regular.
+        if let boldFont = face.ctFontBold {
+            let boldName = CTFontCopyPostScriptName(boldFont) as String
+            #expect(boldName != regularName || boldName.contains("Bold"))
+            #expect(bold as CTFont === boldFont as CTFont)
+        }
+
+        // Italic variant should differ from regular.
+        if let italicFont = face.ctFontItalic {
+            let italicName = CTFontCopyPostScriptName(italicFont) as String
+            #expect(italicName != regularName || italicName.contains("Italic"))
+            #expect(italic as CTFont === italicFont as CTFont)
+        }
+
+        // Bold-italic should be set.
+        if face.ctFontBoldItalic != nil {
+            #expect(boldItalic as CTFont === face.ctFontBoldItalic! as CTFont)
+        }
+    }
+
+    @Test("Bold glyph is rasterized separately from regular")
+    func boldGlyphIsSeparate() {
+        let face = FontFace(name: "Menlo", size: 13, scale: 2.0)
+        let regularA = face.getGlyph(0x41, style: 0)
+        let boldA = face.getGlyph(0x41, style: 0x01)
+        #expect(regularA != nil)
+        #expect(boldA != nil)
+        // They should be at different atlas positions (different rasterizations).
+        if let r = regularA, let b = boldA {
+            #expect(r.atlasX != b.atlasX || r.atlasY != b.atlasY,
+                    "Bold and regular 'A' should occupy different atlas positions")
+        }
+    }
+
+    @Test("Italic glyph is rasterized separately from regular")
+    func italicGlyphIsSeparate() {
+        let face = FontFace(name: "Menlo", size: 13, scale: 2.0)
+        let regularA = face.getGlyph(0x41, style: 0)
+        let italicA = face.getGlyph(0x41, style: 0x04)
+        #expect(regularA != nil)
+        #expect(italicA != nil)
+        if let r = regularA, let i = italicA {
+            #expect(r.atlasX != i.atlasX || r.atlasY != i.atlasY,
+                    "Italic and regular 'A' should occupy different atlas positions")
+        }
+    }
+
+    @Test("Style bits beyond bold/italic are masked out")
+    func styleMaskIgnoresOtherBits() {
+        let face = FontFace(name: "Menlo", size: 13, scale: 2.0)
+        // 0x03 = bold(0x01) | underline(0x02). Only bold should affect glyph lookup.
+        let boldA = face.getGlyph(0x41, style: 0x01)
+        let boldUnderlineA = face.getGlyph(0x41, style: 0x03)
+        #expect(boldA != nil)
+        #expect(boldUnderlineA != nil)
+        // Same glyph (underline bit is masked out for font selection).
+        if let b = boldA, let bu = boldUnderlineA {
+            #expect(b.atlasX == bu.atlasX && b.atlasY == bu.atlasY)
+        }
+    }
+}
+
 @Suite("FontFace ligature shaping")
 struct FontLigatureTests {
     @Test("Ligatures disabled returns nil")


### PR DESCRIPTION
# TL;DR

Bold keywords, italic comments, and underlined diagnostics now render with proper font variants in the macOS GUI. Also fixes a pre-existing bug where italic and underline attribute bits were swapped in the Swift protocol constants.

Part of #91. Closes #558.

## Context

The GUI renderer has been ignoring the `attrs` byte on every `draw_text` command since day one. All text rendered in the regular font weight regardless of bold/italic/underline flags. This made the GUI look like a flat wall of colored text compared to the TUI, which has always honored these attributes.

This is the last Phase 1 item on the face system epic (#91).

## Changes

**Font variant system (FontFace.swift):**
- Derives bold, italic, and bold-italic CTFont variants from the base font in init via `CTFontCreateCopyWithSymbolicTraits`. Falls back to regular with a warning if a variant is unavailable (no synthetic oblique per archie's recommendation).
- `GlyphKey` struct replaces plain `UInt32` cache key with `(codepoint, style)`. All four variants share one atlas texture, matching the #91 shared atlas strategy (zero memory increase).
- `LigatureKey` adds style bits so bold `->` ligatures shape with the bold font.

**Critical bug fix (ProtocolConstants.swift):**
- `ATTR_ITALIC` was 0x02 and `ATTR_UNDERLINE` was 0x04 in Swift, but the BEAM and Zig both use italic=0x04, underline=0x02. This meant italic text was being treated as underlined and vice versa. Fixed to match the authoritative protocol spec.

**Underline render pass (Shaders.metal + MetalRenderer.swift):**
- Third instanced render pass (bg → glyph → underline) with dedicated `underline_vertex`/`underline_fragment` shaders. Designed for all 5 underline styles from day one per archie's recommendation: line, curl, dashed, dotted, double.
- `UnderlineGPU` struct carries grid position, color, style, and cell span.
- `draw_styled_text` (0x1C) decoder added to Swift protocol so underline color and style flow through from the BEAM.

## Verification

```bash
# Build GUI app
xcodebuild -project macos/Minga.xcodeproj -target minga-mac -configuration Debug build

# Run tests (66 pass, including 5 new variant tests)
xcrun xctest macos/build/Debug/MingaTests.xctest
```

Visual verification needed: open the GUI app on a syntax-highlighted file and confirm bold keywords and italic comments are visually distinct from regular text.

## Acceptance Criteria Addressed

- BOLD (0x01) renders using bold font variant ✅
- ITALIC (0x04) renders using italic variant ✅
- BOLD|ITALIC (0x05) renders bold-italic variant ✅
- UNDERLINE (0x02) renders with underline at baseline ✅
- Font variants resolved once, cached in same atlas ✅
- Bold variant same cell width as regular (monospace preserved) ✅