### PR TITLE
refactor(editor): deduplicate find_buffer_by_path into EditorState

### DIFF
--- a/lib/minga/editor/commands/buffer_management.ex
+++ b/lib/minga/editor/commands/buffer_management.ex
@@ -232,7 +232,7 @@ defmodule Minga.Editor.Commands.BufferManagement do
   end
 
   def execute(state, {:execute_ex_command, {:edit, file_path}}) do
-    case find_buffer_by_path(state, file_path) do
+    case EditorState.find_buffer_by_path(state, file_path) do
       nil ->
         case Commands.start_buffer(file_path) do
           {:ok, pid} ->
@@ -922,17 +922,6 @@ defmodule Minga.Editor.Commands.BufferManagement do
       _ ->
         state
     end
-  end
-
-  @spec find_buffer_by_path(state(), String.t()) :: non_neg_integer() | nil
-  defp find_buffer_by_path(%{buffers: %{list: buffers}}, file_path) do
-    Enum.find_index(buffers, fn buf ->
-      try do
-        BufferServer.file_path(buf) == file_path
-      catch
-        :exit, _ -> false
-      end
-    end)
   end
 
   @spec next_new_buffer_number([pid()]) :: pos_integer()

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -188,6 +188,23 @@ defmodule Minga.Editor.State do
   @spec active_buffer(t()) :: non_neg_integer()
   def active_buffer(%__MODULE__{buffers: %{active_index: idx}}), do: idx
 
+  @doc """
+  Returns the index of the buffer whose file path matches `file_path`, or nil.
+
+  Catches `:exit` for each buffer in case a process has died but not yet been
+  removed from the buffer list.
+  """
+  @spec find_buffer_by_path(t() | map(), String.t()) :: non_neg_integer() | nil
+  def find_buffer_by_path(%{buffers: %{list: buffers}}, file_path) do
+    Enum.find_index(buffers, fn buf ->
+      try do
+        BufferServer.file_path(buf) == file_path
+      catch
+        :exit, _ -> false
+      end
+    end)
+  end
+
   # ── Buffer monitoring ──────────────────────────────────────────────────────
 
   @doc """

--- a/lib/minga/picker/file_source.ex
+++ b/lib/minga/picker/file_source.ex
@@ -8,7 +8,6 @@ defmodule Minga.Picker.FileSource do
 
   @behaviour Minga.Picker.Source
 
-  alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Devicon
   alias Minga.Editor.State, as: EditorState
   alias Minga.Filetype
@@ -59,7 +58,7 @@ defmodule Minga.Picker.FileSource do
 
     Log.debug(:editor, "[file_picker] on_select path=#{rel_path}")
 
-    case find_buffer_by_path(state, abs_path) do
+    case EditorState.find_buffer_by_path(state, abs_path) do
       nil ->
         case start_buffer(abs_path) do
           {:ok, pid} ->
@@ -135,17 +134,6 @@ defmodule Minga.Picker.FileSource do
     end
   catch
     :exit, _ -> File.cwd!()
-  end
-
-  @spec find_buffer_by_path(map(), String.t()) :: non_neg_integer() | nil
-  defp find_buffer_by_path(%{buffers: %{list: buffers}}, file_path) do
-    Enum.find_index(buffers, fn buf ->
-      try do
-        BufferServer.file_path(buf) == file_path
-      catch
-        :exit, _ -> false
-      end
-    end)
   end
 
   @spec start_buffer(String.t()) :: {:ok, pid()} | {:error, term()}

--- a/lib/minga/picker/project_search_source.ex
+++ b/lib/minga/picker/project_search_source.ex
@@ -58,7 +58,7 @@ defmodule Minga.Picker.ProjectSearchSource do
     line = max(match.line - 1, 0)
     col = match.col
 
-    case find_buffer_by_path(state, abs_path) do
+    case EditorState.find_buffer_by_path(state, abs_path) do
       nil -> open_new_buffer(state, abs_path, line, col)
       buf_idx -> jump_to_buffer(state, buf_idx, line, col)
     end
@@ -95,17 +95,6 @@ defmodule Minga.Picker.ProjectSearchSource do
   def on_cancel(state), do: state
 
   # ── Private ─────────────────────────────────────────────────────────────────
-
-  @spec find_buffer_by_path(map(), String.t()) :: non_neg_integer() | nil
-  defp find_buffer_by_path(%{buffers: %{list: buffers}}, file_path) do
-    Enum.find_index(buffers, fn buf ->
-      try do
-        BufferServer.file_path(buf) == file_path
-      catch
-        :exit, _ -> false
-      end
-    end)
-  end
 
   @spec start_buffer(String.t()) :: {:ok, pid()} | {:error, term()}
   defp start_buffer(file_path) do

--- a/lib/minga/picker/recent_file_source.ex
+++ b/lib/minga/picker/recent_file_source.ex
@@ -10,7 +10,6 @@ defmodule Minga.Picker.RecentFileSource do
 
   alias Minga.Picker.Item
 
-  alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Devicon
   alias Minga.Editor.State, as: EditorState
   alias Minga.Filetype
@@ -49,7 +48,7 @@ defmodule Minga.Picker.RecentFileSource do
     root = project_root()
     abs_path = Path.join(root, rel_path)
 
-    case find_buffer_by_path(state, abs_path) do
+    case EditorState.find_buffer_by_path(state, abs_path) do
       nil ->
         case start_buffer(abs_path) do
           {:ok, pid} ->
@@ -83,17 +82,6 @@ defmodule Minga.Picker.RecentFileSource do
     end
   catch
     :exit, _ -> File.cwd!()
-  end
-
-  @spec find_buffer_by_path(map(), String.t()) :: non_neg_integer() | nil
-  defp find_buffer_by_path(%{buffers: %{list: buffers}}, file_path) do
-    Enum.find_index(buffers, fn buf ->
-      try do
-        BufferServer.file_path(buf) == file_path
-      catch
-        :exit, _ -> false
-      end
-    end)
   end
 
   @spec start_buffer(String.t()) :: {:ok, pid()} | {:error, term()}


### PR DESCRIPTION
## TL;DR

Extracts 4 identical private `find_buffer_by_path/2` functions into a single public function on `EditorState`. Pure deduplication, no behavior change.

## Context

Four modules independently implemented the same buffer-by-path lookup:

```elixir
defp find_buffer_by_path(%{buffers: %{list: buffers}}, file_path) do
  Enum.find_index(buffers, fn buf ->
    try do
      BufferServer.file_path(buf) == file_path
    catch
      :exit, _ -> false
    end
  end)
end
```

All identical, including the `try/catch :exit` for dead-but-unlisted buffer pids. `EditorState` already hosts buffer query functions (`buffer/1`, `buffers/1`, `active_buffer/1`), so this is the natural home.

## Changes

| File | Change |
|------|--------|
| `lib/minga/editor/state.ex` | New `find_buffer_by_path/2` with `@doc`, `@spec` |
| `lib/minga/picker/file_source.ex` | Removed private copy, removed unused `BufferServer` alias |
| `lib/minga/picker/recent_file_source.ex` | Removed private copy, removed unused `BufferServer` alias |
| `lib/minga/picker/project_search_source.ex` | Removed private copy |
| `lib/minga/editor/commands/buffer_management.ex` | Removed private copy |

**Not changed:**
- `editor/file_watcher_helpers.ex` has `find_buffer_for_path/2` which returns the **pid** (not index) and does `Path.expand` — different semantics, not a duplicate.

## Verification

```bash
mix compile --warnings-as-errors   # clean
mix format --check-formatted       # clean
mix test                           # 5630 tests, 0 new failures
```

## Acceptance Criteria

- [x] Single source of truth for buffer-by-path index lookup
- [x] All 4 identical private copies removed
- [x] `@spec` and `@doc` on the new public function
- [x] Unused aliases cleaned up (no compile warnings)
- [x] No behavior change — identical semantics to all replaced functions
- [x] `file_watcher_helpers.ex` variant left alone (different return type)