### PR TITLE
refactor(picker): extract shared start_buffer and on_cancel helpers

### DIFF
--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -207,6 +207,15 @@ defmodule Minga.Editor.State do
     end)
   end
 
+  @doc "Starts a new buffer under the buffer supervisor for the given file path."
+  @spec start_buffer(String.t()) :: {:ok, pid()} | {:error, term()}
+  def start_buffer(file_path) do
+    DynamicSupervisor.start_child(
+      Minga.Buffer.Supervisor,
+      {BufferServer, file_path: file_path}
+    )
+  end
+
   # ── Buffer monitoring ──────────────────────────────────────────────────────
 
   @doc """

--- a/lib/minga/picker/buffer_source.ex
+++ b/lib/minga/picker/buffer_source.ex
@@ -10,6 +10,7 @@ defmodule Minga.Picker.BufferSource do
   @behaviour Minga.Picker.Source
 
   alias Minga.Picker.Item
+  alias Minga.Picker.Source
 
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Devicon
@@ -89,12 +90,7 @@ defmodule Minga.Picker.BufferSource do
   end
 
   @impl true
-  @spec on_cancel(term()) :: term()
-  def on_cancel(%{picker_ui: %{restore: restore_idx}} = state) when is_integer(restore_idx) do
-    EditorState.switch_buffer(state, restore_idx)
-  end
-
-  def on_cancel(state), do: state
+  def on_cancel(state), do: Source.restore_or_keep(state)
 
   @impl true
   @spec actions(Item.t()) :: [Minga.Picker.Source.action_entry()]

--- a/lib/minga/picker/file_source.ex
+++ b/lib/minga/picker/file_source.ex
@@ -8,12 +8,12 @@ defmodule Minga.Picker.FileSource do
 
   @behaviour Minga.Picker.Source
 
-  alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Devicon
   alias Minga.Editor.State, as: EditorState
   alias Minga.Filetype
   alias Minga.Log
   alias Minga.Picker.Item
+  alias Minga.Picker.Source
 
   @impl true
   @spec title() :: String.t()
@@ -61,7 +61,7 @@ defmodule Minga.Picker.FileSource do
 
     case EditorState.find_buffer_by_path(state, abs_path) do
       nil ->
-        case start_buffer(abs_path) do
+        case EditorState.start_buffer(abs_path) do
           {:ok, pid} ->
             Log.debug(:editor, "[file_picker] new buffer pid=#{inspect(pid)}")
             EditorState.add_buffer(state, pid)
@@ -92,12 +92,7 @@ defmodule Minga.Picker.FileSource do
   end
 
   @impl true
-  @spec on_cancel(term()) :: term()
-  def on_cancel(%{picker_ui: %{restore: restore_idx}} = state) when is_integer(restore_idx) do
-    EditorState.switch_buffer(state, restore_idx)
-  end
-
-  def on_cancel(state), do: state
+  def on_cancel(state), do: Source.restore_or_keep(state)
 
   @impl true
   @spec actions(Item.t()) :: [Minga.Picker.Source.action_entry()]
@@ -128,12 +123,4 @@ defmodule Minga.Picker.FileSource do
   # ── Private ─────────────────────────────────────────────────────────────────
 
   defdelegate project_root, to: Minga.Project, as: :resolve_root
-
-  @spec start_buffer(String.t()) :: {:ok, pid()} | {:error, term()}
-  defp start_buffer(file_path) do
-    DynamicSupervisor.start_child(
-      Minga.Buffer.Supervisor,
-      {BufferServer, file_path: file_path}
-    )
-  end
 end

--- a/lib/minga/picker/project_search_source.ex
+++ b/lib/minga/picker/project_search_source.ex
@@ -14,6 +14,7 @@ defmodule Minga.Picker.ProjectSearchSource do
   alias Minga.Devicon
   alias Minga.Editor.State, as: EditorState
   alias Minga.Filetype
+  alias Minga.Picker.Source
 
   @impl true
   @spec title() :: String.t()
@@ -66,7 +67,7 @@ defmodule Minga.Picker.ProjectSearchSource do
 
   @spec open_new_buffer(map(), String.t(), non_neg_integer(), non_neg_integer()) :: map()
   defp open_new_buffer(state, abs_path, line, col) do
-    case start_buffer(abs_path) do
+    case EditorState.start_buffer(abs_path) do
       {:ok, pid} ->
         new_state = EditorState.add_buffer(state, pid)
         BufferServer.move_to(pid, {line, col})
@@ -87,20 +88,7 @@ defmodule Minga.Picker.ProjectSearchSource do
   end
 
   @impl true
-  @spec on_cancel(term()) :: term()
-  def on_cancel(%{picker_ui: %{restore: restore_idx}} = state) when is_integer(restore_idx) do
-    EditorState.switch_buffer(state, restore_idx)
-  end
-
-  def on_cancel(state), do: state
+  def on_cancel(state), do: Source.restore_or_keep(state)
 
   # ── Private ─────────────────────────────────────────────────────────────────
-
-  @spec start_buffer(String.t()) :: {:ok, pid()} | {:error, term()}
-  defp start_buffer(file_path) do
-    DynamicSupervisor.start_child(
-      Minga.Buffer.Supervisor,
-      {BufferServer, file_path: file_path}
-    )
-  end
 end

--- a/lib/minga/picker/recent_file_source.ex
+++ b/lib/minga/picker/recent_file_source.ex
@@ -13,6 +13,7 @@ defmodule Minga.Picker.RecentFileSource do
   alias Minga.Devicon
   alias Minga.Editor.State, as: EditorState
   alias Minga.Filetype
+  alias Minga.Picker.Source
   alias Minga.Project
 
   @impl true
@@ -50,7 +51,7 @@ defmodule Minga.Picker.RecentFileSource do
 
     case EditorState.find_buffer_by_path(state, abs_path) do
       nil ->
-        case start_buffer(abs_path) do
+        case EditorState.start_buffer(abs_path) do
           {:ok, pid} ->
             EditorState.add_buffer(state, pid)
 
@@ -65,22 +66,9 @@ defmodule Minga.Picker.RecentFileSource do
   end
 
   @impl true
-  @spec on_cancel(term()) :: term()
-  def on_cancel(%{picker_ui: %{restore: restore_idx}} = state) when is_integer(restore_idx) do
-    EditorState.switch_buffer(state, restore_idx)
-  end
-
-  def on_cancel(state), do: state
+  def on_cancel(state), do: Source.restore_or_keep(state)
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
   defdelegate project_root, to: Minga.Project, as: :resolve_root
-
-  @spec start_buffer(String.t()) :: {:ok, pid()} | {:error, term()}
-  defp start_buffer(file_path) do
-    DynamicSupervisor.start_child(
-      Minga.Buffer.Supervisor,
-      {BufferServer, file_path: file_path}
-    )
-  end
 end

--- a/lib/minga/picker/source.ex
+++ b/lib/minga/picker/source.ex
@@ -33,6 +33,7 @@ defmodule Minga.Picker.Source do
       end
   """
 
+  alias Minga.Editor.State, as: EditorState
   alias Minga.Picker
 
   @typedoc "Context passed to `candidates/1` — typically editor state or options."
@@ -79,6 +80,18 @@ defmodule Minga.Picker.Source do
   @callback layout() :: layout()
 
   @optional_callbacks [preview?: 0, actions: 1, on_action: 3, layout: 0]
+
+  @doc """
+  Default `on_cancel` implementation: restores the buffer that was active
+  when the picker opened (stored in `picker_ui.restore`), or returns state
+  unchanged if no restore index was saved.
+  """
+  @spec restore_or_keep(term()) :: term()
+  def restore_or_keep(%{picker_ui: %{restore: idx}} = state) when is_integer(idx) do
+    EditorState.switch_buffer(state, idx)
+  end
+
+  def restore_or_keep(state), do: state
 
   @doc """
   Returns whether a source module supports preview.


### PR DESCRIPTION
## TL;DR

Consolidates two duplicated patterns across picker sources: `start_buffer/1` (3 copies) and the restore-index `on_cancel` pattern (4 copies). Pure deduplication, no behavior change.

## Context

Picker sources that open files (`FileSource`, `RecentFileSource`, `ProjectSearchSource`) each had their own private `start_buffer/1`:

```elixir
defp start_buffer(file_path) do
  DynamicSupervisor.start_child(
    Minga.Buffer.Supervisor,
    {BufferServer, file_path: file_path}
  )
end
```

And four sources (`FileSource`, `RecentFileSource`, `ProjectSearchSource`, `BufferSource`) had identical multi-clause `on_cancel` implementations:

```elixir
def on_cancel(%{picker_ui: %{restore: restore_idx}} = state) when is_integer(restore_idx) do
  EditorState.switch_buffer(state, restore_idx)
end
def on_cancel(state), do: state
```

## Changes

| File | Change |
|------|--------|
| `lib/minga/editor/state.ex` | New `start_buffer/1` — starts supervised buffer for a file path |
| `lib/minga/picker/source.ex` | New `restore_or_keep/1` — shared restore-index on_cancel helper |
| `lib/minga/picker/file_source.ex` | Removed private `start_buffer`, simplified `on_cancel` |
| `lib/minga/picker/recent_file_source.ex` | Removed private `start_buffer`, simplified `on_cancel` |
| `lib/minga/picker/project_search_source.ex` | Removed private `start_buffer`, simplified `on_cancel` |
| `lib/minga/picker/buffer_source.ex` | Simplified `on_cancel` |

**Not changed:**
- `editor/startup.ex` calls `DynamicSupervisor.start_child` with different opts (extra config beyond `file_path`) — not a duplicate.

## Verification

```bash
mix compile --warnings-as-errors   # clean
mix format --check-formatted       # clean
mix test                           # 5630 tests, 0 new failures
```

## Acceptance Criteria

- [x] Single `start_buffer/1` on EditorState (natural home alongside `buffer/1`, `buffers/1`)
- [x] All 3 private `start_buffer` copies removed
- [x] Single `restore_or_keep/1` on Source with `@doc` explaining usage
- [x] All 4 multi-clause `on_cancel` patterns collapsed to one-liners
- [x] No behavior change — identical semantics
- [x] `startup.ex` variant left alone (different child spec)