### PR TITLE
refactor(events): extract notify_buffer_changed/1 to deduplicate broadcast+sync sequence

### DIFF
--- a/lib/minga/editor/completion_handling.ex
+++ b/lib/minga/editor/completion_handling.ex
@@ -11,7 +11,6 @@ defmodule Minga.Editor.CompletionHandling do
   alias Minga.Editor.CompletionTrigger
   alias Minga.Editor.SignatureHelp
   alias Minga.Editor.State, as: EditorState
-  alias Minga.Git.Tracker, as: GitTracker
   alias Minga.LSP.Client
   alias Minga.LSP.SyncServer
 
@@ -160,9 +159,7 @@ defmodule Minga.Editor.CompletionHandling do
       BufferServer.insert_text(buf, text)
     end
 
-    Minga.Events.broadcast(:buffer_changed, %Minga.Events.BufferChangedEvent{buffer: buf})
-    SyncServer.notify_change(buf)
-    GitTracker.notify_change(buf)
+    Minga.Events.notify_buffer_changed(buf)
     state
   end
 
@@ -179,9 +176,7 @@ defmodule Minga.Editor.CompletionHandling do
       edit.new_text
     )
 
-    Minga.Events.broadcast(:buffer_changed, %Minga.Events.BufferChangedEvent{buffer: buf})
-    SyncServer.notify_change(buf)
-    GitTracker.notify_change(buf)
+    Minga.Events.notify_buffer_changed(buf)
     state
   end
 

--- a/lib/minga/editor/highlight_events.ex
+++ b/lib/minga/editor/highlight_events.ex
@@ -15,8 +15,6 @@ defmodule Minga.Editor.HighlightEvents do
   alias Minga.Editor.Renderer
   alias Minga.Editor.State, as: EditorState
   alias Minga.Filetype
-  alias Minga.Git.Tracker, as: GitTracker
-  alias Minga.LSP.SyncServer
   alias Minga.PrettifySymbols
 
   @doc """
@@ -87,9 +85,7 @@ defmodule Minga.Editor.HighlightEvents do
         buf = state.buffers.active
 
         if buf do
-          Minga.Events.broadcast(:buffer_changed, %Minga.Events.BufferChangedEvent{buffer: buf})
-          SyncServer.notify_change(buf)
-          GitTracker.notify_change(buf)
+          Minga.Events.notify_buffer_changed(buf)
         end
 
         state

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -79,6 +79,9 @@ defmodule Minga.Events do
     @type t :: %__MODULE__{old: atom(), new: atom()}
   end
 
+  alias Minga.Git.Tracker, as: GitTracker
+  alias Minga.LSP.SyncServer
+
   # ── Types ───────────────────────────────────────────────────────────────────
 
   @typedoc "Known event topics."
@@ -173,6 +176,20 @@ defmodule Minga.Events do
         send(pid, {:minga_event, topic, payload})
       end
     end)
+  end
+
+  @doc """
+  Broadcasts `:buffer_changed` and notifies LSP sync and Git tracker.
+
+  This is the single call site for the buffer-changed notification sequence.
+  Callers that modify buffer content should call this instead of manually
+  broadcasting + notifying each subscriber.
+  """
+  @spec notify_buffer_changed(pid()) :: :ok
+  def notify_buffer_changed(buf) when is_pid(buf) do
+    broadcast(:buffer_changed, %BufferChangedEvent{buffer: buf})
+    SyncServer.notify_change(buf)
+    GitTracker.notify_change(buf)
   end
 
   # ── Query ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

Extracts the 3-line buffer-changed notification sequence into a single `Events.notify_buffer_changed/1`. Replaces 3 inline copies.

## Context

Three call sites independently ran the same sequence after modifying buffer content:

```elixir
Events.broadcast(:buffer_changed, %BufferChangedEvent{buffer: buf})
SyncServer.notify_change(buf)
GitTracker.notify_change(buf)
```

This is coupling that should eventually become event subscriptions (SyncServer and GitTracker subscribing to `:buffer_changed`), but extracting the sequence is the right first step — it makes the coupling explicit in one place.

## Changes

| File | Change |
|------|--------|
| `lib/minga/events.ex` | New `notify_buffer_changed/1` with `@doc`, `@spec` |
| `lib/minga/editor/highlight_events.ex` | Replaced 3-line sequence, removed unused aliases |
| `lib/minga/editor/completion_handling.ex` | Replaced 3-line sequence (2 sites), removed unused alias |

## Verification

```bash
mix compile --warnings-as-errors   # clean
mix format --check-formatted       # clean
mix test                           # 5630 tests, 0 new failures
```

## Acceptance Criteria

- [x] Single `notify_buffer_changed/1` owns the broadcast+sync+tracker sequence
- [x] All 3 inline copies replaced
- [x] Unused aliases cleaned up
- [x] No behavior change
- [x] All existing tests pass