### PR TITLE
feat(agent): add :agent-clear-history ex command (#621)

### DIFF
--- a/lib/minga/command/parser.ex
+++ b/lib/minga/command/parser.ex
@@ -143,6 +143,7 @@ defmodule Minga.Command.Parser do
   defp do_parse("ParserRestart"), do: {:parser_restart, []}
   defp do_parse("agent-stop"), do: {:agent_abort, []}
   defp do_parse("agent-new"), do: {:agent_new_session, []}
+  defp do_parse("agent-clear-history"), do: {:agent_clear_history, []}
   defp do_parse("agent-provider " <> provider), do: {:agent_set_provider, [String.trim(provider)]}
   defp do_parse("agent-model " <> model), do: {:agent_set_model, [String.trim(model)]}
   defp do_parse("agent-models"), do: {:agent_pick_model, []}

--- a/lib/minga/editor/commands/agent.ex
+++ b/lib/minga/editor/commands/agent.ex
@@ -491,6 +491,22 @@ defmodule Minga.Editor.Commands.Agent do
     AgentSession.start_agent_session(state)
   end
 
+  @doc "Clears all saved agent sessions from disk."
+  @spec clear_session_history(state()) :: state()
+  def clear_session_history(state) do
+    count = length(Minga.Agent.SessionStore.list())
+    Minga.Agent.SessionStore.clear_all()
+
+    msg =
+      case count do
+        0 -> "No saved agent sessions"
+        1 -> "Cleared 1 agent session"
+        n -> "Cleared #{n} agent sessions"
+      end
+
+    %{state | status_msg: msg}
+  end
+
   @doc "Switches to an existing session by pid."
   @spec switch_to_session(state(), pid()) :: state()
   def switch_to_session(state, pid) when is_pid(pid) do
@@ -1275,6 +1291,7 @@ defmodule Minga.Editor.Commands.Agent do
     {:agent_toggle_help, "Toggle agent help", :scope_toggle_help},
     {:agent_close, "Close agent panel", :scope_close},
     {:agent_dismiss_or_noop, "Dismiss agent or no-op", :scope_dismiss_or_noop},
+    {:agent_clear_history, "Clear all saved agent sessions", :clear_session_history},
     {:agent_clear_chat, "Clear agent chat", :scope_clear_chat},
     {:agent_submit_or_newline, "Submit or newline", :scope_submit_or_newline},
     {:agent_insert_newline, "Insert newline in agent input", :scope_insert_newline},

--- a/test/minga/command/parser_test.exs
+++ b/test/minga/command/parser_test.exs
@@ -208,6 +208,20 @@ defmodule Minga.Command.ParserTest do
     end
   end
 
+  describe "parse/1 — agent commands" do
+    test ":agent-clear-history parses to {:agent_clear_history, []}" do
+      assert {:agent_clear_history, []} = Parser.parse("agent-clear-history")
+    end
+
+    test ":agent-stop parses to {:agent_abort, []}" do
+      assert {:agent_abort, []} = Parser.parse("agent-stop")
+    end
+
+    test ":agent-new parses to {:agent_new_session, []}" do
+      assert {:agent_new_session, []} = Parser.parse("agent-new")
+    end
+  end
+
   describe "parse/1 — parser commands" do
     test ":parser-restart parses to {:parser_restart, []}" do
       assert {:parser_restart, []} = Parser.parse("parser-restart")


### PR DESCRIPTION
## TL;DR

Wires the existing `SessionStore.clear_all/0` to a new `:agent-clear-history` ex command. Users can now clear all saved agent sessions from within the editor.

## Context

Ticket #139 (session persistence) was closed as complete, but the `:agent-clear-history` acceptance criterion was never implemented. The backend `SessionStore.clear_all/0` works correctly — it just had no ex command pointing to it. Users had to manually delete files from `~/.config/minga/agent/sessions/`.

## Changes

| File | Change |
|------|--------|
| `lib/minga/command/parser.ex` | `agent-clear-history` → `{:agent_clear_history, []}` |
| `lib/minga/editor/commands/agent.ex` | `clear_session_history/1` — counts sessions, calls `clear_all`, shows status message |
| `test/minga/command/parser_test.exs` | Regression test + coverage for existing agent commands |

## Verification

```bash
mix compile --warnings-as-errors            # clean
mix format --check-formatted                # clean
mix test test/minga/command/parser_test.exs  # 49 tests, 0 failures (3 new)
mix test                                     # 5633 tests, 0 new failures
```

## Acceptance Criteria

- [x] `:agent-clear-history` is a valid ex command
- [x] Running it calls `SessionStore.clear_all/0`
- [x] Status message confirms count ("Cleared 14 agent sessions")
- [ ] Confirmation prompt before deletion (deferred — requires `pending_*` state pattern used by quit confirmation; follow-up ticket)

Closes #621.