### PR TITLE
feat(face): tree-sitter @conceal captures for prettify-symbols (#91)

### DIFF
--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -486,6 +486,17 @@ defmodule Minga.Editor do
     {:noreply, new_state}
   end
 
+  def handle_info({tag, {:conceal_spans, buffer_id, _version, spans}}, state)
+      when tag in [:minga_highlight, :minga_input] do
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
+
+    if pid do
+      HighlightEvents.handle_conceal_spans(state, pid, spans)
+    end
+
+    {:noreply, state}
+  end
+
   def handle_info({tag, {:fold_ranges, buffer_id, _version, ranges}}, state)
       when tag in [:minga_highlight, :minga_input] do
     Minga.Log.debug(:editor, "Fold ranges received: buffer=#{buffer_id}, count=#{length(ranges)}")

--- a/lib/minga/editor/highlight_events.ex
+++ b/lib/minga/editor/highlight_events.ex
@@ -9,11 +9,12 @@ defmodule Minga.Editor.HighlightEvents do
   in `highlight.highlights`. There is no separate "current" field.
   """
 
+  alias Minga.Buffer.Decorations
   alias Minga.Buffer.Server, as: BufferServer
-
   alias Minga.Editor.HighlightSync
   alias Minga.Editor.Renderer
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Face
   alias Minga.Filetype
   alias Minga.Git.Tracker, as: GitTracker
   alias Minga.LSP.SyncServer
@@ -108,6 +109,75 @@ defmodule Minga.Editor.HighlightEvents do
     else
       state
     end
+  end
+
+  @doc """
+  Handles `:conceal_spans` events from the parser.
+
+  Applies ConcealRange decorations from tree-sitter @conceal captures with
+  `#set! conceal "X"` directives. Clears the `:ts_conceal` group before
+  applying new conceals to handle re-parses correctly.
+  """
+  @spec handle_conceal_spans(EditorState.t(), pid(), [map()]) :: :ok
+  def handle_conceal_spans(_state, buf, spans) when is_pid(buf) do
+    content = BufferServer.content(buf)
+    lines = String.split(content, "\n")
+
+    BufferServer.batch_decorations(buf, fn decs ->
+      decs
+      |> Decorations.remove_conceal_group(:ts_conceal)
+      |> add_conceal_spans(spans, lines)
+    end)
+
+    :ok
+  end
+
+  @spec add_conceal_spans(Decorations.t(), [map()], [String.t()]) :: Decorations.t()
+  defp add_conceal_spans(decs, spans, lines) do
+    Enum.reduce(spans, decs, fn span, acc ->
+      {start_line, start_col} = byte_to_position(lines, span.start_byte)
+      {end_line, end_col} = byte_to_position(lines, span.end_byte)
+      replacement = if span.replacement == "", do: nil, else: span.replacement
+
+      {_id, new_decs} =
+        Decorations.add_conceal(acc, {start_line, start_col}, {end_line, end_col},
+          replacement: replacement,
+          replacement_style: %Face{name: "_"},
+          group: :ts_conceal,
+          priority: 5
+        )
+
+      new_decs
+    end)
+  end
+
+  # Converts a byte offset to {line, col} position.
+  @spec byte_to_position([String.t()], non_neg_integer()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp byte_to_position(lines, byte_offset) do
+    do_byte_to_position(lines, byte_offset, 0)
+  end
+
+  @spec do_byte_to_position([String.t()], non_neg_integer(), non_neg_integer()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp do_byte_to_position([], _remaining, line_idx), do: {max(line_idx - 1, 0), 0}
+
+  defp do_byte_to_position([line | rest], remaining, line_idx) do
+    line_bytes = byte_size(line) + 1
+
+    if remaining < line_bytes do
+      col = grapheme_col(line, remaining)
+      {line_idx, col}
+    else
+      do_byte_to_position(rest, remaining - line_bytes, line_idx + 1)
+    end
+  end
+
+  # Converts a byte offset within a line to a grapheme column.
+  @spec grapheme_col(String.t(), non_neg_integer()) :: non_neg_integer()
+  defp grapheme_col(line, byte_offset) do
+    prefix = binary_part(line, 0, min(byte_offset, byte_size(line)))
+    String.length(prefix)
   end
 
   # Applies prettify-symbol conceals after highlights update.

--- a/lib/minga/port/protocol.ex
+++ b/lib/minga/port/protocol.ex
@@ -116,6 +116,7 @@ defmodule Minga.Port.Protocol do
   @op_indent_result 0x37
   @op_textobject_result 0x38
   @op_textobject_positions 0x39
+  @op_conceal_spans 0x3A
 
   # Config commands (BEAM → frontend)
   @op_set_font 0x50
@@ -187,6 +188,8 @@ defmodule Minga.Port.Protocol do
           | {:highlight_spans, buffer_id :: non_neg_integer(), version :: non_neg_integer(),
              [highlight_span()]}
           | {:highlight_names, buffer_id :: non_neg_integer(), [String.t()]}
+          | {:conceal_spans, buffer_id :: non_neg_integer(), version :: non_neg_integer(),
+             [conceal_span()]}
           | {:grammar_loaded, success :: boolean(), name :: String.t()}
           | {:injection_ranges, buffer_id :: non_neg_integer(),
              [%{start_byte: non_neg_integer(), end_byte: non_neg_integer(), language: String.t()}]}
@@ -762,6 +765,13 @@ defmodule Minga.Port.Protocol do
     {:ok, {:textobject_positions, buffer_id, version, positions}}
   end
 
+  def decode_event(<<@op_conceal_spans, buffer_id::32, version::32, count::32, rest::binary>>) do
+    case decode_conceal_spans(rest, count, []) do
+      {:ok, spans} -> {:ok, {:conceal_spans, buffer_id, version, spans}}
+      :error -> {:error, :malformed}
+    end
+  end
+
   def decode_event(<<@op_log_message, level_byte::8, msg_len::16, msg::binary-size(msg_len)>>) do
     level = decode_log_level(level_byte)
     {:ok, {:log_message, level, msg}}
@@ -978,6 +988,29 @@ defmodule Minga.Port.Protocol do
   end
 
   defp decode_font_fallback_entries(_rest, _remaining, _acc), do: :error
+
+  @typedoc "A conceal span from tree-sitter: byte range + replacement text."
+  @type conceal_span :: %{
+          start_byte: non_neg_integer(),
+          end_byte: non_neg_integer(),
+          replacement: String.t()
+        }
+
+  @spec decode_conceal_spans(binary(), non_neg_integer(), [conceal_span()]) ::
+          {:ok, [conceal_span()]} | :error
+  defp decode_conceal_spans(_rest, 0, acc), do: {:ok, Enum.reverse(acc)}
+
+  defp decode_conceal_spans(
+         <<start_byte::32, end_byte::32, rep_len::16, rep::binary-size(rep_len), rest::binary>>,
+         remaining,
+         acc
+       )
+       when remaining > 0 do
+    span = %{start_byte: start_byte, end_byte: end_byte, replacement: rep}
+    decode_conceal_spans(rest, remaining - 1, [span | acc])
+  end
+
+  defp decode_conceal_spans(_rest, _remaining, _acc), do: :error
 
   @spec decode_attrs(non_neg_integer()) :: [atom()]
   defp decode_attrs(attrs) do

--- a/lib/mix/tasks/queries.sync.ex
+++ b/lib/mix/tasks/queries.sync.ex
@@ -6,11 +6,14 @@ defmodule Mix.Tasks.Queries.Sync do
   languages Minga ships, and applies these transformations:
 
   1. `#lua-match?` → `#match?` with Lua pattern → regex conversion
-  2. Strips `@spell`, `@nospell`, `@conceal`, `@none` captures
-  3. Strips `#set! conceal`, `#set! priority`, `#set! conceal_lines` directives
+  2. Strips `@spell`, `@nospell`, `@none` captures (but preserves `@conceal`)
+  3. Strips `#set! priority`, `#set! conceal_lines` directives
      (moves trailing closing parens to the previous line to keep S-expressions valid)
   4. Strips `#set! ... url ...` directives
   5. Cleans up empty patterns and excess blank lines
+
+  `@conceal` captures and `#set! conceal` directives are preserved so the
+  Zig highlighter can emit conceal spans for prettify-symbols rendering.
 
   Records the source commit in `priv/queries/VERSION`.
 
@@ -118,7 +121,6 @@ defmodule Mix.Tasks.Queries.Sync do
   @spec transform_query(String.t()) :: String.t()
   defp transform_query(content) do
     content
-    |> remove_conceal_only_blocks()
     |> String.split("\n")
     |> process_lines([])
     |> Enum.reverse()
@@ -126,62 +128,6 @@ defmodule Mix.Tasks.Queries.Sync do
     |> Enum.join("\n")
     |> String.trim_trailing()
     |> Kernel.<>("\n")
-  end
-
-  # Remove entire top-level S-expression blocks where @conceal is the only
-  # meaningful capture. These patterns exist solely for nvim's conceal feature
-  # and become broken (or no-ops) when @conceal is stripped. Example:
-  #
-  #   ("\"" @conceal
-  #     (#set! conceal ""))
-  #
-  # We split the file into blocks (separated by blank lines), check each
-  # block, and drop the conceal-only ones before line-level processing.
-  @spec remove_conceal_only_blocks(String.t()) :: String.t()
-  defp remove_conceal_only_blocks(content) do
-    lines = String.split(content, "\n")
-    {blocks, current} = chunk_into_blocks(lines, [], [])
-    blocks = if current != [], do: blocks ++ [Enum.reverse(current)], else: blocks
-
-    blocks
-    |> Enum.reject(&conceal_only_block?/1)
-    |> Enum.intersperse([""])
-    |> List.flatten()
-    |> Enum.join("\n")
-  end
-
-  @spec chunk_into_blocks([String.t()], [[String.t()]], [String.t()]) ::
-          {[[String.t()]], [String.t()]}
-  defp chunk_into_blocks([], blocks, current), do: {blocks, current}
-
-  defp chunk_into_blocks([line | rest], blocks, current) do
-    if String.trim(line) == "" and current != [] do
-      chunk_into_blocks(rest, blocks ++ [Enum.reverse(current)], [])
-    else
-      chunk_into_blocks(rest, blocks, [line | current])
-    end
-  end
-
-  # A block is conceal-only if it contains @conceal as a capture AND
-  # #set! conceal, AND no other meaningful captures (non-@conceal, non-nvim).
-  @spec conceal_only_block?([String.t()]) :: boolean()
-  defp conceal_only_block?(block) do
-    text = Enum.join(block, "\n")
-    has_conceal_capture = String.contains?(text, "@conceal")
-    has_set_conceal = Regex.match?(~r/#set!\s+conceal/, text)
-
-    if has_conceal_capture and has_set_conceal do
-      captures =
-        Regex.scan(~r/@(\w[\w.]*)/, text)
-        |> Enum.map(fn [_, name] -> name end)
-        |> Enum.reject(fn name ->
-          name in ~w(conceal spell nospell none) or String.starts_with?(name, "_")
-        end)
-
-      captures == []
-    else
-      false
-    end
   end
 
   @spec process_lines([String.t()], [String.t()]) :: [String.t()]
@@ -220,12 +166,15 @@ defmodule Mix.Tasks.Queries.Sync do
 
   @spec strip_nvim_captures(String.t()) :: String.t()
   defp strip_nvim_captures(line) do
-    Regex.replace(~r/\s+@(?:spell|nospell|conceal|none)\b/, line, "")
+    # Preserve @conceal captures (used by the Zig highlighter for prettify-symbols).
+    Regex.replace(~r/\s+@(?:spell|nospell|none)\b/, line, "")
   end
 
   @spec removable_set_directive?(String.t()) :: boolean()
   defp removable_set_directive?(trimmed) do
-    Regex.match?(~r/^\(#set!\s+(?:conceal|conceal_lines|priority)\b/, trimmed) or
+    # Preserve #set! conceal (used by the Zig highlighter for prettify-symbols).
+    # Only strip conceal_lines, priority, and url directives.
+    Regex.match?(~r/^\(#set!\s+(?:conceal_lines|priority)\b/, trimmed) or
       Regex.match?(~r/^\(#set!\s+@\w+\s+url\b/, trimmed)
   end
 

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -12,15 +12,26 @@ const query_loader = @import("query_loader.zig");
 const protocol = @import("protocol.zig");
 pub const Span = protocol.Span;
 
+/// A conceal span: byte range + replacement text from `#set! conceal "X"`.
+pub const ConcealSpan = struct {
+    start_byte: u32,
+    end_byte: u32,
+    /// Replacement text (from the query's string table, not owned).
+    /// Empty string means hide entirely (no replacement character).
+    replacement: []const u8,
+};
+
 /// Result of a highlight operation.
 pub const HighlightResult = struct {
     spans: []Span,
     capture_names: [][]const u8,
+    conceal_spans: []ConcealSpan,
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *HighlightResult) void {
         self.allocator.free(self.spans);
         self.allocator.free(self.capture_names);
+        self.allocator.free(self.conceal_spans);
     }
 };
 
@@ -885,7 +896,7 @@ pub const Highlighter = struct {
         self.current_source = new_source;
     }
 
-    /// Run highlight query on the current tree, returning spans.
+    /// Run highlight query on the current tree, returning spans and conceal spans.
     pub fn highlight(self: *Highlighter) !HighlightResult {
         const tree = self.tree orelse return error.NoTree;
         const query = self.query orelse return error.NoQuery;
@@ -897,9 +908,11 @@ pub const Highlighter = struct {
 
         c.ts_query_cursor_exec(cursor, query, root);
 
-        // Collect spans
+        // Collect spans and conceal spans
         var spans: std.ArrayListUnmanaged(Span) = .empty;
         errdefer spans.deinit(alloc);
+        var conceals: std.ArrayListUnmanaged(ConcealSpan) = .empty;
+        errdefer conceals.deinit(alloc);
 
         const source = self.current_source orelse &.{};
 
@@ -909,24 +922,43 @@ pub const Highlighter = struct {
             if (self.current_predicates) |preds| {
                 if (!preds.evaluate(match, source)) continue;
             }
+
+            // Check for #set! conceal directive on this pattern.
+            const conceal_replacement: ?[]const u8 = if (self.current_predicates) |preds|
+                preds.getConcealReplacement(@intCast(match.pattern_index))
+            else
+                null;
+
             const captures = if (match.captures == null) continue else match.captures[0..match.capture_count];
             for (captures) |cap| {
                 const node = cap.node;
                 const start = c.ts_node_start_byte(node);
                 const end = c.ts_node_end_byte(node);
-                try spans.append(alloc, .{
-                    .start_byte = start,
-                    .end_byte = end,
-                    .capture_id = @intCast(cap.index),
-                    .pattern_index = @intCast(match.pattern_index),
-                });
+
+                // Check if this capture is @conceal (or has a conceal directive).
+                var cap_len: u32 = 0;
+                const cap_name = c.ts_query_capture_name_for_id(query, @intCast(cap.index), &cap_len);
+                const is_conceal_capture = std.mem.eql(u8, cap_name[0..cap_len], "conceal");
+
+                if (is_conceal_capture and conceal_replacement != null) {
+                    // Emit a conceal span instead of a regular highlight span.
+                    try conceals.append(alloc, .{
+                        .start_byte = start,
+                        .end_byte = end,
+                        .replacement = conceal_replacement.?,
+                    });
+                } else {
+                    try spans.append(alloc, .{
+                        .start_byte = start,
+                        .end_byte = end,
+                        .capture_id = @intCast(cap.index),
+                        .pattern_index = @intCast(match.pattern_index),
+                    });
+                }
             }
         }
 
         // Sort by (start_byte ASC, layer DESC, pattern_index DESC, end_byte ASC).
-        // Layer ensures injection spans always win over outer spans at the
-        // same byte position. Within a layer, higher pattern_index = more
-        // specific rule. The BEAM side's first-wins walk picks the correct span.
         std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
 
         // Collect capture names
@@ -941,6 +973,7 @@ pub const Highlighter = struct {
         return .{
             .spans = try spans.toOwnedSlice(alloc),
             .capture_names = names,
+            .conceal_spans = try conceals.toOwnedSlice(alloc),
             .allocator = alloc,
         };
     }
@@ -966,6 +999,8 @@ pub const Highlighter = struct {
 
         var spans: std.ArrayListUnmanaged(Span) = .empty;
         errdefer spans.deinit(alloc);
+        var conceals: std.ArrayListUnmanaged(ConcealSpan) = .empty;
+        errdefer conceals.deinit(alloc);
 
         var match: c.TSQueryMatch = undefined;
         while (c.ts_query_cursor_next_match(cursor, &match)) {
@@ -973,15 +1008,38 @@ pub const Highlighter = struct {
             if (self.current_predicates) |preds| {
                 if (!preds.evaluate(match, source)) continue;
             }
+
+            // Check for #set! conceal directive on this pattern.
+            const conceal_replacement: ?[]const u8 = if (self.current_predicates) |preds|
+                preds.getConcealReplacement(@intCast(match.pattern_index))
+            else
+                null;
+
             const captures = if (match.captures == null) continue else match.captures[0..match.capture_count];
             for (captures) |cap| {
-                try spans.append(alloc, .{
-                    .start_byte = c.ts_node_start_byte(cap.node),
-                    .end_byte = c.ts_node_end_byte(cap.node),
-                    .capture_id = @intCast(cap.index),
-                    .pattern_index = @intCast(match.pattern_index),
-                    .layer = 0,
-                });
+                const start = c.ts_node_start_byte(cap.node);
+                const end = c.ts_node_end_byte(cap.node);
+
+                // Check if this is a @conceal capture with a replacement directive.
+                var cap_len: u32 = 0;
+                const cap_name = c.ts_query_capture_name_for_id(query, @intCast(cap.index), &cap_len);
+                const is_conceal = std.mem.eql(u8, cap_name[0..cap_len], "conceal");
+
+                if (is_conceal and conceal_replacement != null) {
+                    try conceals.append(alloc, .{
+                        .start_byte = start,
+                        .end_byte = end,
+                        .replacement = conceal_replacement.?,
+                    });
+                } else {
+                    try spans.append(alloc, .{
+                        .start_byte = start,
+                        .end_byte = end,
+                        .capture_id = @intCast(cap.index),
+                        .pattern_index = @intCast(match.pattern_index),
+                        .layer = 0,
+                    });
+                }
             }
         }
 
@@ -1026,6 +1084,7 @@ pub const Highlighter = struct {
             return .{
                 .spans = try spans.toOwnedSlice(alloc),
                 .capture_names = names,
+                .conceal_spans = try conceals.toOwnedSlice(alloc),
                 .allocator = alloc,
             };
         }
@@ -1265,6 +1324,7 @@ pub const Highlighter = struct {
         return .{
             .spans = try spans.toOwnedSlice(alloc),
             .capture_names = names,
+            .conceal_spans = try conceals.toOwnedSlice(alloc),
             .allocator = alloc,
         };
     }

--- a/zig/src/parser_main.zig
+++ b/zig/src/parser_main.zig
@@ -475,7 +475,7 @@ fn sendFoldResults(
     try stdout.flush();
 }
 
-/// Send highlight results (names, spans, injection ranges) to stdout.
+/// Send highlight results (names, spans, conceal spans, injection ranges) to stdout.
 fn sendHighlightResults(
     hl: *highlighter_mod.Highlighter,
     buffer_id: u32,
@@ -493,6 +493,12 @@ fn sendHighlightResults(
     const spans_buf = try protocol.encodeHighlightSpans(alloc, buffer_id, version, result.spans);
     defer alloc.free(spans_buf);
     try protocol.writeMessage(stdout, spans_buf);
+
+    if (result.conceal_spans.len > 0) {
+        const conceal_buf = try protocol.encodeConcealSpans(alloc, buffer_id, version, result.conceal_spans);
+        defer alloc.free(conceal_buf);
+        try protocol.writeMessage(stdout, conceal_buf);
+    }
 
     if (hl.injection_ranges.len > 0) {
         const inj_buf = try protocol.encodeInjectionRanges(alloc, buffer_id, hl.injection_ranges);

--- a/zig/src/predicates.zig
+++ b/zig/src/predicates.zig
@@ -41,9 +41,14 @@ pub const Predicate = union(enum) {
 /// Pre-parsed predicate table for a query. Indexed by pattern_index.
 /// Each entry is null (no predicates) or a slice of predicates that
 /// must ALL pass for a match to be accepted.
+///
+/// Also stores `#set! conceal "X"` metadata per pattern. These are not
+/// filter predicates; they attach replacement text to matched captures.
 pub const PredicateTable = struct {
     /// One entry per pattern. null = no predicates (always passes).
     entries: []?[]const Predicate,
+    /// Conceal replacement per pattern. null = no conceal, empty = hide entirely.
+    conceal_replacements: []?[]const u8,
     allocator: std.mem.Allocator,
     /// Track compiled regexes for cleanup
     regexes: std.ArrayListUnmanaged(*posix_regex.CompiledRegex),
@@ -52,16 +57,21 @@ pub const PredicateTable = struct {
     pub fn init(query: *c.TSQuery, allocator: std.mem.Allocator) PredicateTable {
         const pattern_count = c.ts_query_pattern_count(query);
         const entries = allocator.alloc(?[]const Predicate, pattern_count) catch
-            return .{ .entries = &.{}, .allocator = allocator, .regexes = .empty };
+            return .{ .entries = &.{}, .conceal_replacements = &.{}, .allocator = allocator, .regexes = .empty };
+
+        const conceal_reps = allocator.alloc(?[]const u8, pattern_count) catch
+            return .{ .entries = &.{}, .conceal_replacements = &.{}, .allocator = allocator, .regexes = .empty };
 
         var regexes: std.ArrayListUnmanaged(*posix_regex.CompiledRegex) = .empty;
 
         for (0..pattern_count) |i| {
             entries[i] = parsePattern(query, @intCast(i), allocator, &regexes);
+            conceal_reps[i] = parseConcealDirective(query, @intCast(i));
         }
 
         return .{
             .entries = entries,
+            .conceal_replacements = conceal_reps,
             .allocator = allocator,
             .regexes = regexes,
         };
@@ -87,6 +97,18 @@ pub const PredicateTable = struct {
             }
         }
         self.allocator.free(self.entries);
+
+        // conceal_replacements are string slices pointing into the query's
+        // string table (owned by TSQuery), so we only free the slice itself.
+        if (self.conceal_replacements.len > 0) {
+            self.allocator.free(self.conceal_replacements);
+        }
+    }
+
+    /// Returns the conceal replacement for a pattern, or null if no conceal directive.
+    pub fn getConcealReplacement(self: *const PredicateTable, pattern_index: u32) ?[]const u8 {
+        if (pattern_index >= self.conceal_replacements.len) return null;
+        return self.conceal_replacements[pattern_index];
     }
 
     /// Evaluate all predicates for a given match. Returns true if all pass.
@@ -290,6 +312,54 @@ fn parsePredicate(
     }
 
     // Unknown predicate: ignore (e.g., #set!, #offset!, etc.)
+    return null;
+}
+
+/// Parse a `#set! conceal "X"` directive from a pattern's predicates.
+/// Returns the replacement string (from the query's string table) or null.
+fn parseConcealDirective(query: *c.TSQuery, pattern_index: u32) ?[]const u8 {
+    var step_count: u32 = 0;
+    const steps = c.ts_query_predicates_for_pattern(query, pattern_index, &step_count);
+    if (step_count == 0) return null;
+
+    var i: u32 = 0;
+    while (i < step_count) {
+        // First step must be the directive name (string type)
+        if (steps[i].type != c.TSQueryPredicateStepTypeString) {
+            while (i < step_count and steps[i].type != c.TSQueryPredicateStepTypeDone) : (i += 1) {}
+            if (i < step_count) i += 1;
+            continue;
+        }
+
+        var name_len: u32 = 0;
+        const name_ptr = c.ts_query_string_value_for_id(query, steps[i].value_id, &name_len);
+        const name = name_ptr[0..name_len];
+        i += 1;
+
+        // Look for: set! conceal "replacement"
+        if (std.mem.eql(u8, name, "set!")) {
+            // Need at least 2 more args before Done: property_name and value
+            if (i + 2 <= step_count and
+                steps[i].type == c.TSQueryPredicateStepTypeString and
+                steps[i + 1].type == c.TSQueryPredicateStepTypeString)
+            {
+                var prop_len: u32 = 0;
+                const prop_ptr = c.ts_query_string_value_for_id(query, steps[i].value_id, &prop_len);
+                const prop_name = prop_ptr[0..prop_len];
+
+                if (std.mem.eql(u8, prop_name, "conceal")) {
+                    var val_len: u32 = 0;
+                    const val_ptr = c.ts_query_string_value_for_id(query, steps[i + 1].value_id, &val_len);
+                    return val_ptr[0..val_len];
+                }
+            }
+        }
+
+        // Skip to next Done
+        while (i < step_count and steps[i].type != c.TSQueryPredicateStepTypeDone) : (i += 1) {}
+        if (i < step_count) i += 1;
+    }
+
     return null;
 }
 

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -85,6 +85,7 @@ pub const OP_INDENT_RESULT: u8 = 0x37;
 // Textobject responses (Zig → BEAM)
 pub const OP_TEXTOBJECT_RESULT: u8 = 0x38;
 pub const OP_TEXTOBJECT_POSITIONS: u8 = 0x39;
+pub const OP_CONCEAL_SPANS: u8 = 0x3A;
 
 // Log messages (Zig → BEAM)
 pub const OP_LOG_MESSAGE: u8 = 0x60;
@@ -529,6 +530,38 @@ pub fn encodeHighlightSpans(allocator: std.mem.Allocator, buffer_id: u32, versio
         std.mem.writeInt(u16, buf[off + 8 ..][0..2], span.capture_id, .big);
         std.mem.writeInt(u16, buf[off + 10 ..][0..2], span.pattern_index, .big);
         std.mem.writeInt(u16, buf[off + 12 ..][0..2], span.layer, .big);
+    }
+
+    return buf;
+}
+
+/// Encodes conceal_spans: opcode(1) + buffer_id(4) + version(4) + count(4) +
+/// (start_byte:4 + end_byte:4 + replacement_len:2 + replacement) for each.
+pub fn encodeConcealSpans(
+    allocator: std.mem.Allocator,
+    buffer_id: u32,
+    version: u32,
+    spans: []const @import("highlighter.zig").ConcealSpan,
+) ![]u8 {
+    const header_size = 1 + 4 + 4 + 4; // opcode + buffer_id + version + count
+    var total: usize = header_size;
+    for (spans) |span| {
+        total += 4 + 4 + 2 + span.replacement.len; // start + end + rep_len + rep
+    }
+
+    const buf = try allocator.alloc(u8, total);
+    buf[0] = OP_CONCEAL_SPANS;
+    std.mem.writeInt(u32, buf[1..5], buffer_id, .big);
+    std.mem.writeInt(u32, buf[5..9], version, .big);
+    std.mem.writeInt(u32, buf[9..13], @intCast(spans.len), .big);
+
+    var off: usize = header_size;
+    for (spans) |span| {
+        std.mem.writeInt(u32, buf[off..][0..4], span.start_byte, .big);
+        std.mem.writeInt(u32, buf[off + 4 ..][0..4], span.end_byte, .big);
+        std.mem.writeInt(u16, buf[off + 8 ..][0..2], @intCast(span.replacement.len), .big);
+        @memcpy(buf[off + 10 .. off + 10 + span.replacement.len], span.replacement);
+        off += 10 + span.replacement.len;
     }
 
     return buf;


### PR DESCRIPTION
## Summary

Adds native tree-sitter conceal support to the Zig highlighter. When a highlight query contains `@conceal` captures with `#set! conceal "X"` directives, the highlighter emits conceal spans (separate from regular highlight spans) that the BEAM converts into ConcealRange decorations.

This is the "build it right" replacement for the BEAM-side substitution registry from PR #787. Languages with upstream `@conceal` queries in their `highlights.scm` get automatic conceal rendering without any Elixir-side rule definitions. Both mechanisms coexist (different groups: `:prettify_symbols` vs `:ts_conceal`).

## Changes

### Zig

- **predicates.zig**: `PredicateTable` gains `conceal_replacements` field. `parseConcealDirective()` extracts `#set! conceal "X"` per pattern. `getConcealReplacement()` provides O(1) lookup.
- **highlighter.zig**: New `ConcealSpan` struct. Both `highlight()` and `highlightWithInjections()` detect `@conceal` captures and emit `ConcealSpan` instead of regular `Span`.
- **protocol.zig**: New `OP_CONCEAL_SPANS` (0x3A) with `encodeConcealSpans()`.
- **parser_main.zig**: `sendHighlightResults` sends conceal spans alongside highlight spans.

### Elixir

- **protocol.ex**: Decoder for `conceal_spans` event, `conceal_span` type.
- **editor.ex**: `handle_info` clause routes conceal_spans to HighlightEvents.
- **highlight_events.ex**: `handle_conceal_spans/3` creates ConcealRange decorations with `:ts_conceal` group.

### queries.sync

- Stops stripping `@conceal` captures from upstream grammars.
- Stops stripping `#set! conceal` directives.
- Removes the `conceal_only_block?` filter (conceal-only patterns are now preserved).

## Testing

- All 5,641 Elixir tests pass
- All Zig tests pass
- `mix lint` + `mix zig.lint` clean

## Related

Part of #91 Phase 4. Stacks on #787 (merged).