### PR TITLE
fix(editor): add missing BufferServer alias in FileSource

### DIFF
--- a/lib/minga/picker/file_source.ex
+++ b/lib/minga/picker/file_source.ex
@@ -8,6 +8,7 @@ defmodule Minga.Picker.FileSource do
 
   @behaviour Minga.Picker.Source
 
+  alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Devicon
   alias Minga.Editor.State, as: EditorState
   alias Minga.Filetype


### PR DESCRIPTION
## What

Adds the missing `alias Minga.Buffer.Server, as: BufferServer` to `Minga.Picker.FileSource`.

## Why

Selecting any file from the file picker (`SPC f f`) crashed the Editor GenServer with:

```
ArgumentError: The module BufferServer was given as a child to a supervisor but it does not exist
```

`FileSource.start_buffer/1` referenced bare `BufferServer` without the alias that every other module in the codebase has.

## Testing

All 73 picker tests pass. The fix is a single alias addition, no behavior change.

Fixes the immediate trigger for #803. The systemic fix (LoggerHandler lifecycle + picker callback resilience) is tracked separately on that ticket.