### PR TITLE
feat(face): per-face font_family with shared atlas (#91)

### DIFF
--- a/lib/minga/editor/display_list.ex
+++ b/lib/minga/editor/display_list.ex
@@ -308,9 +308,31 @@ defmodule Minga.Editor.DisplayList do
   """
   @spec draws_to_commands([draw()]) :: [binary()]
   def draws_to_commands(draws) do
-    Enum.map(draws, fn {row, col, text, %Face{} = face} ->
-      Protocol.encode_draw_smart(row, col, text, Face.to_style(face))
+    Enum.flat_map(draws, fn {row, col, text, %Face{} = face} ->
+      style = Face.to_style(face)
+      {style, registration_cmds} = resolve_font_family(style)
+      registration_cmds ++ [Protocol.encode_draw_smart(row, col, text, style)]
     end)
+  end
+
+  # Resolves font_family in a style keyword list to a font_id.
+  # Uses the font registry from the process dictionary (set by Emit).
+  # Returns {updated_style, [register_font_commands]}.
+  @spec resolve_font_family(keyword()) :: {keyword(), [binary()]}
+  defp resolve_font_family(style) do
+    case Keyword.pop(style, :font_family) do
+      {nil, _} ->
+        {style, []}
+
+      {family, rest} ->
+        registry = Process.get(:emit_font_registry) || Minga.FontRegistry.new()
+        {font_id, updated_registry, new?} = Minga.FontRegistry.get_or_register(registry, family)
+        Process.put(:emit_font_registry, updated_registry)
+
+        style_with_id = if font_id > 0, do: [{:font_id, font_id} | rest], else: rest
+        reg_cmds = if new?, do: [Protocol.encode_register_font(font_id, family)], else: []
+        {style_with_id, reg_cmds}
+    end
   end
 
   # ── Layer ↔ draws ──────────────────────────────────────────────────────────

--- a/lib/minga/editor/render_pipeline/emit.ex
+++ b/lib/minga/editor/render_pipeline/emit.ex
@@ -53,6 +53,14 @@ defmodule Minga.Editor.RenderPipeline.Emit do
   def emit(frame, state) do
     scroll_deltas = detect_scroll_regions(state)
 
+    # Make the font registry available for font_family → font_id resolution
+    # during draws_to_commands. Initialize only on first frame; subsequent
+    # frames reuse the accumulated registry so IDs are stable and register_font
+    # commands are only sent once per font family.
+    if Process.get(:emit_font_registry) == nil do
+      Process.put(:emit_font_registry, state.font_registry)
+    end
+
     commands =
       if Capabilities.gui?(state.capabilities) do
         frame

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -124,7 +124,8 @@ defmodule Minga.Editor.State do
             last_test_command: nil,
             pending_quit: nil,
             buffer_monitors: %{},
-            face_override_registries: %{}
+            face_override_registries: %{},
+            font_registry: Minga.FontRegistry.new()
 
   @type t :: %__MODULE__{
           port_manager: GenServer.server() | nil,
@@ -171,7 +172,8 @@ defmodule Minga.Editor.State do
           last_test_command: {String.t(), String.t()} | nil,
           pending_quit: :quit | :quit_all | nil,
           buffer_monitors: %{pid() => reference()},
-          face_override_registries: %{pid() => Minga.Face.Registry.t()}
+          face_override_registries: %{pid() => Minga.Face.Registry.t()},
+          font_registry: Minga.FontRegistry.t()
         }
 
   # ── Convenience accessors ─────────────────────────────────────────────────

--- a/lib/minga/face.ex
+++ b/lib/minga/face.ex
@@ -271,8 +271,13 @@ defmodule Minga.Face do
         do: [{:blend, face.blend} | style],
         else: style
 
-    if face.font_weight && face.font_weight != :regular,
-      do: [{:font_weight, face.font_weight} | style],
+    style =
+      if face.font_weight && face.font_weight != :regular,
+        do: [{:font_weight, face.font_weight} | style],
+        else: style
+
+    if face.font_family,
+      do: [{:font_family, face.font_family} | style],
       else: style
   end
 

--- a/lib/minga/font_registry.ex
+++ b/lib/minga/font_registry.ex
@@ -1,0 +1,59 @@
+defmodule Minga.FontRegistry do
+  @moduledoc """
+  Maps font family names to protocol font IDs (0-255).
+
+  Font ID 0 is always the primary font (configured via `:font_family`).
+  IDs 1-255 are assigned on demand when a Face with a non-nil `font_family`
+  is first rendered. The registry sends `register_font` protocol commands
+  to the GUI frontend so it can load the corresponding FontFace instances.
+
+  The registry is process-local state stored in the Editor GenServer's state.
+  It resets when the editor restarts or the font config changes.
+  """
+
+  @enforce_keys [:families, :next_id]
+  defstruct families: %{},
+            next_id: 1
+
+  @type t :: %__MODULE__{
+          families: %{String.t() => non_neg_integer()},
+          next_id: non_neg_integer()
+        }
+
+  @doc "Creates a new empty font registry."
+  @spec new() :: t()
+  def new, do: %__MODULE__{families: %{}, next_id: 1}
+
+  @doc """
+  Returns the font_id for a font family, allocating a new ID if needed.
+
+  Returns `{font_id, updated_registry, new?}` where `new?` is true if
+  a new ID was allocated (caller should send `register_font` to the GUI).
+
+  The primary font (ID 0) is never registered here; it's set via `set_font`.
+  """
+  @spec get_or_register(t(), String.t()) :: {non_neg_integer(), t(), boolean()}
+  def get_or_register(%__MODULE__{} = reg, family) when is_binary(family) do
+    case Map.get(reg.families, family) do
+      nil ->
+        id = reg.next_id
+
+        if id > 255 do
+          # Too many fonts registered; fall back to primary (0).
+          {0, reg, false}
+        else
+          updated = %{reg | families: Map.put(reg.families, family, id), next_id: id + 1}
+          {id, updated, true}
+        end
+
+      id ->
+        {id, reg, false}
+    end
+  end
+
+  @doc "Returns the font_id for a family, or 0 if not registered."
+  @spec lookup(t(), String.t()) :: non_neg_integer()
+  def lookup(%__MODULE__{families: families}, family) do
+    Map.get(families, family, 0)
+  end
+end

--- a/lib/minga/port/protocol.ex
+++ b/lib/minga/port/protocol.ex
@@ -20,7 +20,7 @@ defmodule Minga.Port.Protocol do
   | Opcode | Name             | Payload                                                              |
   |--------|------------------|----------------------------------------------------------------------|
   | 0x10   | draw_text        | `row::16, col::16, fg::24, bg::24, attrs::8, text_len::16, text`     |
-  | 0x1C   | draw_styled_text | `row::16, col::16, fg::24, bg::24, attrs::16, ul_color::24, blend::8, font_weight::8, text_len::16, text` |
+  | 0x1C   | draw_styled_text | `row::16, col::16, fg::24, bg::24, attrs::16, ul_color::24, blend::8, font_weight::8, font_id::8, text_len::16, text` |
   | 0x11   | set_cursor       | `row::16, col::16`                                                   |
   | 0x12   | clear            | (empty)                                                              |
   | 0x13   | batch_end        | (empty)                                                              |
@@ -120,6 +120,7 @@ defmodule Minga.Port.Protocol do
   # Config commands (BEAM → frontend)
   @op_set_font 0x50
   @op_set_font_fallback 0x51
+  @op_register_font 0x52
 
   # Log messages (Zig → BEAM)
   @op_log_message 0x60
@@ -231,6 +232,7 @@ defmodule Minga.Port.Protocol do
           | {:blend, 0..100}
           | {:font_weight,
              :thin | :light | :regular | :medium | :semibold | :bold | :heavy | :black}
+          | {:font_id, non_neg_integer()}
         ]
 
   # ── Modifier helpers ──
@@ -294,10 +296,11 @@ defmodule Minga.Port.Protocol do
     ul_color = Keyword.get(style, :underline_color, 0x000000)
     blend = Keyword.get(style, :blend, 100)
     font_weight = Map.get(@font_weight_map, Keyword.get(style, :font_weight, :regular), 2)
+    font_id = Keyword.get(style, :font_id, 0)
     text_len = byte_size(text)
 
     <<@op_draw_styled_text, row::16, col::16, fg::24, bg::24, attrs::16, ul_color::24, blend::8,
-      font_weight::8, text_len::16, text::binary>>
+      font_weight::8, font_id::8, text_len::16, text::binary>>
   end
 
   @doc """
@@ -319,7 +322,8 @@ defmodule Minga.Port.Protocol do
       Keyword.has_key?(style, :underline_style) ||
       Keyword.has_key?(style, :underline_color) ||
       Keyword.has_key?(style, :blend) ||
-      Keyword.has_key?(style, :font_weight)
+      Keyword.has_key?(style, :font_weight) ||
+      Keyword.has_key?(style, :font_id)
   end
 
   @doc "Encodes a set_cursor command."
@@ -409,6 +413,23 @@ defmodule Minga.Port.Protocol do
       end)
 
     IO.iodata_to_binary([@op_set_font_fallback, count | entries])
+  end
+
+  @doc """
+  Encodes a register_font command to associate a font_id with a font family.
+
+  Font ID 0 is the primary font (set via `set_font`). IDs 1-255 are
+  secondary fonts that can be referenced by `font_id` in `draw_styled_text`.
+  The GUI creates a FontFace for each registered font at the same size as
+  the primary. If the secondary font's cell metrics differ from the primary,
+  the GUI logs a warning and falls back to the primary for those glyphs.
+
+  Format: `opcode:8, font_id:8, name_len:16, name:bytes`
+  """
+  @spec encode_register_font(non_neg_integer(), String.t()) :: binary()
+  def encode_register_font(font_id, family)
+      when is_integer(font_id) and font_id >= 0 and font_id <= 255 and is_binary(family) do
+    <<@op_register_font, font_id::8, byte_size(family)::16, family::binary>>
   end
 
   # ── Encoding: region commands (BEAM → Zig) ──
@@ -808,7 +829,7 @@ defmodule Minga.Port.Protocol do
 
   def decode_command(
         <<@op_draw_styled_text, row::16, col::16, fg::24, bg::24, attrs::16, ul_color::24,
-          blend::8, font_weight_byte::8, text_len::16, text::binary-size(text_len)>>
+          blend::8, font_weight_byte::8, font_id::8, text_len::16, text::binary-size(text_len)>>
       ) do
     decoded_attrs = decode_attrs_extended(attrs)
     font_weight = Map.get(@font_weight_reverse, font_weight_byte, :regular)
@@ -820,6 +841,7 @@ defmodule Minga.Port.Protocol do
       |> then(fn a ->
         if font_weight != :regular, do: [{:font_weight, font_weight} | a], else: a
       end)
+      |> then(fn a -> if font_id != 0, do: [{:font_id, font_id} | a], else: a end)
 
     {:ok, {:draw_styled_text, %{row: row, col: col, fg: fg, bg: bg, attrs: style, text: text}}}
   end

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -19,22 +19,23 @@
 		16E32CF32A4AE261F717B823 /* MingaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A647814918768E62822D4A1 /* MingaApp.swift */; };
 		1DF2EE070C5D3722084CBFFE /* MetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57909975ED8C2222150ABE2 /* MetalRenderer.swift */; };
 		1F9F7B302A2A8598C1391FA0 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
-		A1B2C3D4E5F6A7B8C9D0E1F2 /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E2D3C4B5A6978869574031 /* GUIState.swift */; };
-		A1B2C3D4E5F6A7B8C9D0E1F3 /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E2D3C4B5A6978869574031 /* GUIState.swift */; };
 		2534C98EBC14F9F08600AE7A /* SymbolsNerdFontMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FD66FBCBFC20D50D22A969C8 /* SymbolsNerdFontMono-Regular.ttf */; };
 		27236A210603A4548A56F072 /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */; };
 		2A14A36D7CB3580A73355970 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7C3564C27A7E14D894539 /* TabBarView.swift */; };
 		2E40B27FA890123D325C4346 /* TabBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7AA0437B5C38BA8A8A80D5 /* TabBarState.swift */; };
 		31E0D1C2347322703DA6CC71 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5458552EC58E44C7CD15A98A /* FileTreeView.swift */; };
 		32171233224FC90E1E956631 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C0836F0D4150126F181C05 /* PickerState.swift */; };
+		36E0C059965477465E15CC02 /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */; };
 		3DF3937E460A624254F647BC /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
 		48842D6AE71AA7EB08B9ED03 /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83165B89231936674C54B513 /* EditorNSView.swift */; };
 		49CE8F263AD2A900F0894F32 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
 		50D6C9CF0A874431A7969CD4 /* MetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57909975ED8C2222150ABE2 /* MetalRenderer.swift */; };
 		531166B714D49278BA811033 /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E892F827AFBE959F9DF25C05 /* StatusBarView.swift */; };
+		538E6D52EBF51B7D360A5A0A /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */; };
 		5CADBD593C49EE44EBBD854E /* PortLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E23DC6E0ACB156F21293E87 /* PortLogger.swift */; };
 		613F5EE586EE20F4E2F163E0 /* CompletionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA9C2BB0C840BE88B0FEA52 /* CompletionState.swift */; };
 		614587A457DCB2C3A316BD0B /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 4E24F882E54DB6D88ABEBBC6 /* Shaders.metal */; };
+		6442AF895C03F5AEF2D4500F /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
 		6474095F95F4DA480AFE91B7 /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
 		6537088048F398D30737E6C3 /* GlyphAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F56CBF3A086193F8775262B /* GlyphAtlas.swift */; };
 		686DD6EB8AFDCAFC79EA100A /* ProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F220A60775A252A728477659 /* ProtocolTests.swift */; };
@@ -49,6 +50,7 @@
 		8A49BB76E6FF8EF18632DD4C /* CellGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0968F397CDDD3F99C06F5BC9 /* CellGrid.swift */; };
 		8B944E100C80DFF282D25D4C /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */; };
 		8F6865441CD813045F071273 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
+		939991DD65293C6C796EAA66 /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
 		93E7D214A27256CF06571EFE /* ProtocolDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */; };
 		9BAECBE2506FC3893151FD6C /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		A78FBA1CD5BB02EEBA8ACB45 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
@@ -95,6 +97,7 @@
 		56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolDecoder.swift; sourceTree = "<group>"; };
 		64CEFB02A774E5E8EF19029F /* MingaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MingaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		70D5765529645C5D860576B7 /* WhichKeyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhichKeyState.swift; sourceTree = "<group>"; };
+		79F5D551302873BE8F7240ED /* FontManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontManager.swift; sourceTree = "<group>"; };
 		7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolEncoder.swift; sourceTree = "<group>"; };
 		83165B89231936674C54B513 /* EditorNSView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorNSView.swift; sourceTree = "<group>"; };
 		89DAA6AEFA6A62A1172EABF2 /* minga-mac */ = {isa = PBXFileReference; includeInIndex = 0; path = "minga-mac"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -103,6 +106,7 @@
 		BEA9C2BB0C840BE88B0FEA52 /* CompletionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionState.swift; sourceTree = "<group>"; };
 		BEFD30A2572AE2608F099407 /* ScrollAccumulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollAccumulator.swift; sourceTree = "<group>"; };
 		C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandDispatcher.swift; sourceTree = "<group>"; };
+		C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIState.swift; sourceTree = "<group>"; };
 		C441427A427E23B912F70092 /* ProtocolConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolConstants.swift; sourceTree = "<group>"; };
 		CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeState.swift; sourceTree = "<group>"; };
 		CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhichKeyOverlay.swift; sourceTree = "<group>"; };
@@ -110,7 +114,6 @@
 		DD14027C8C7BD17057DE820B /* AgentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatView.swift; sourceTree = "<group>"; };
 		DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionOverlay.swift; sourceTree = "<group>"; };
 		E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatState.swift; sourceTree = "<group>"; };
-		F1E2D3C4B5A6978869574031 /* GUIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIState.swift; sourceTree = "<group>"; };
 		E892F827AFBE959F9DF25C05 /* StatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarView.swift; sourceTree = "<group>"; };
 		F220A60775A252A728477659 /* ProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolTests.swift; sourceTree = "<group>"; };
 		F57909975ED8C2222150ABE2 /* MetalRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalRenderer.swift; sourceTree = "<group>"; };
@@ -141,6 +144,7 @@
 			isa = PBXGroup;
 			children = (
 				4BC98120D82BD7548347875E /* FontFace.swift */,
+				79F5D551302873BE8F7240ED /* FontManager.swift */,
 				3F56CBF3A086193F8775262B /* GlyphAtlas.swift */,
 			);
 			path = Font;
@@ -158,7 +162,6 @@
 			isa = PBXGroup;
 			children = (
 				E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */,
-				F1E2D3C4B5A6978869574031 /* GUIState.swift */,
 				DD14027C8C7BD17057DE820B /* AgentChatView.swift */,
 				CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */,
 				DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */,
@@ -167,6 +170,7 @@
 				0C26E064D810299C0302F439 /* EditorView.swift */,
 				CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */,
 				5458552EC58E44C7CD15A98A /* FileTreeView.swift */,
+				C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */,
 				4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */,
 				52F606681DE9AA9D502A42AA /* PickerOverlay.swift */,
 				92C0836F0D4150126F181C05 /* PickerState.swift */,
@@ -351,7 +355,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				49CE8F263AD2A900F0894F32 /* AgentChatState.swift in Sources */,
-				A1B2C3D4E5F6A7B8C9D0E1F2 /* GUIState.swift in Sources */,
 				0A5FA884302FD99B07B78852 /* AgentChatView.swift in Sources */,
 				6C386E10E81099D724B28984 /* BreadcrumbBar.swift in Sources */,
 				8A49BB76E6FF8EF18632DD4C /* CellGrid.swift in Sources */,
@@ -363,6 +366,8 @@
 				7FD39613E25BB0588ADBECCC /* FileTreeState.swift in Sources */,
 				B6F7BAB1912B12C5D59B6290 /* FileTreeView.swift in Sources */,
 				9BAECBE2506FC3893151FD6C /* FontFace.swift in Sources */,
+				6442AF895C03F5AEF2D4500F /* FontManager.swift in Sources */,
+				538E6D52EBF51B7D360A5A0A /* GUIState.swift in Sources */,
 				6537088048F398D30737E6C3 /* GlyphAtlas.swift in Sources */,
 				50D6C9CF0A874431A7969CD4 /* MetalRenderer.swift in Sources */,
 				16E32CF32A4AE261F717B823 /* MingaApp.swift in Sources */,
@@ -390,7 +395,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F9F7B302A2A8598C1391FA0 /* AgentChatState.swift in Sources */,
-				A1B2C3D4E5F6A7B8C9D0E1F3 /* GUIState.swift in Sources */,
 				0D5DFD181E86D51707D3A59E /* AgentChatView.swift in Sources */,
 				8F6865441CD813045F071273 /* BreadcrumbBar.swift in Sources */,
 				0507E71BCDE82EBBDD37DAEA /* CellGrid.swift in Sources */,
@@ -402,7 +406,9 @@
 				C8FAD7BE37506758A1DBF8F6 /* FileTreeState.swift in Sources */,
 				31E0D1C2347322703DA6CC71 /* FileTreeView.swift in Sources */,
 				78F06B9BFB553B50D9BDD50F /* FontFace.swift in Sources */,
+				939991DD65293C6C796EAA66 /* FontManager.swift in Sources */,
 				C715D937E8591D8BA46A29CD /* FontTests.swift in Sources */,
+				36E0C059965477465E15CC02 /* GUIState.swift in Sources */,
 				F63E0FDECD3B636C893B164E /* GlyphAtlas.swift in Sources */,
 				1DF2EE070C5D3722084CBFFE /* MetalRenderer.swift in Sources */,
 				8B944E100C80DFF282D25D4C /* MingaWindow.swift in Sources */,

--- a/macos/Sources/Font/FontFace.swift
+++ b/macos/Sources/Font/FontFace.swift
@@ -41,6 +41,10 @@ struct Glyph {
 /// The key uses the protocol weight byte (0-7) and a boolean italic flag
 /// rather than the old bold/italic style bits. This allows per-span font
 /// weight selection beyond binary bold/regular.
+///
+/// When multiple FontFace instances share an atlas, each instance uses
+/// its own glyph cache, so there's no collision between fonts. The fontId
+/// is not part of the key because each FontFace manages its own cache.
 struct GlyphKey: Hashable {
     let codepoint: UInt32
     /// Protocol font weight (0=thin, 1=light, 2=regular, 3=medium, 4=semibold, 5=bold, 6=heavy, 7=black).
@@ -132,7 +136,9 @@ final class FontFace {
     /// `scale` is the backing scale factor (2.0 for Retina).
     /// `ligatures` enables programming ligature shaping via CoreText.
     /// `weight` is the protocol weight byte (0-7), mapped to NSFontManager's scale.
-    init(name: String, size: CGFloat, scale: CGFloat, ligatures: Bool = true, weight: UInt8 = 2) {
+    /// Initialize with an externally-owned atlas (shared across FontFace instances).
+    /// When `atlas` is nil, creates a private atlas (backward compatible).
+    init(name: String, size: CGFloat, scale: CGFloat, ligatures: Bool = true, weight: UInt8 = 2, atlas: GlyphAtlas? = nil) {
         let nsFontWeight = FontFace.weightMap[weight] ?? 5
         self.fontWeight = nsFontWeight
         self.familyName = name
@@ -167,7 +173,7 @@ final class FontFace {
         self.cellWidth = Int(ceil(advanceWidth))
         self.cellHeight = Int(ceil(asc + desc + lead))
 
-        self.atlas = GlyphAtlas(initialSize: 512)
+        self.atlas = atlas ?? GlyphAtlas(initialSize: 512)
 
         // Pre-populate the weighted font cache with the base weight.
         self.weightedFonts[weight] = font

--- a/macos/Sources/Font/FontManager.swift
+++ b/macos/Sources/Font/FontManager.swift
@@ -1,0 +1,110 @@
+/// Manages multiple font faces sharing a single glyph atlas.
+///
+/// The primary font (ID 0) is loaded at startup. Secondary fonts (IDs 1-255)
+/// are registered dynamically via the `register_font` protocol command.
+/// All fonts share one GlyphAtlas to avoid multiple GPU texture binds.
+///
+/// Cell metrics (cellWidth, cellHeight) are determined by the primary font.
+/// Secondary fonts with incompatible metrics log a warning but are still
+/// loaded; glyphs are rasterized at the correct weight/style and positioned
+/// within the primary font's cell grid.
+
+import Foundation
+import AppKit
+
+/// Manages font faces and a shared glyph atlas.
+final class FontManager {
+    /// The shared atlas used by all font faces.
+    let atlas: GlyphAtlas
+
+    /// The primary font (ID 0). Always set after init.
+    private(set) var primary: FontFace
+
+    /// Secondary fonts keyed by font_id (1-255).
+    private var secondaryFonts: [UInt8: FontFace] = [:]
+
+    /// Cell dimensions from the primary font (all fonts use these for layout).
+    var cellWidth: Int { primary.cellWidth }
+    var cellHeight: Int { primary.cellHeight }
+    var ascent: CGFloat { primary.ascent }
+    var descent: CGFloat { primary.descent }
+    var scale: CGFloat { primary.scale }
+
+    init(name: String, size: CGFloat, scale: CGFloat, ligatures: Bool = true, weight: UInt8 = 2) {
+        self.atlas = GlyphAtlas(initialSize: 512)
+        self.primary = FontFace(name: name, size: size, scale: scale,
+                                 ligatures: ligatures, weight: weight, atlas: atlas)
+    }
+
+    /// Replace the primary font (e.g., after a set_font command).
+    func setPrimaryFont(name: String, size: CGFloat, scale: CGFloat,
+                        ligatures: Bool, weight: UInt8) {
+        self.primary = FontFace(name: name, size: size, scale: scale,
+                                 ligatures: ligatures, weight: weight, atlas: atlas)
+        // Clear secondary fonts since the primary metrics may have changed.
+        secondaryFonts.removeAll()
+    }
+
+    /// Register a secondary font at the given ID.
+    ///
+    /// The font is loaded at the same size and scale as the primary.
+    /// If the secondary font's cell metrics differ from the primary,
+    /// a warning is logged but the font is still usable (glyphs will
+    /// be positioned using primary metrics).
+    func registerFont(id: UInt8, name: String) {
+        guard id != 0 else {
+            PortLogger.warn("Cannot register font at ID 0 (reserved for primary)")
+            return
+        }
+
+        let size = CTFontGetSize(primary.ctFont)
+        let secondary = FontFace(name: name, size: size, scale: primary.scale,
+                                  ligatures: primary.ligaturesEnabled, weight: 2,
+                                  atlas: atlas)
+
+        if secondary.cellWidth != primary.cellWidth ||
+           secondary.cellHeight != primary.cellHeight {
+            PortLogger.warn(
+                "Font '\(name)' (id=\(id)) has different metrics " +
+                "(\(secondary.cellWidth)x\(secondary.cellHeight)) than primary " +
+                "(\(primary.cellWidth)x\(primary.cellHeight)). " +
+                "Glyphs will use primary cell layout."
+            )
+        }
+
+        secondaryFonts[id] = secondary
+        PortLogger.info("Registered font '\(name)' at id=\(id)")
+    }
+
+    /// Returns the FontFace for a given font_id. Falls back to primary if not found.
+    func fontFace(for fontId: UInt8) -> FontFace {
+        if fontId == 0 { return primary }
+        return secondaryFonts[fontId] ?? primary
+    }
+
+    /// Look up a glyph by codepoint, weight, italic flag, and font_id.
+    ///
+    /// Routes to the correct FontFace for rasterization. All glyphs are
+    /// packed into the shared atlas regardless of which font produced them.
+    func getGlyph(_ codepoint: UInt32, weight: UInt8, italic: Bool, fontId: UInt8 = 0) -> Glyph? {
+        let face = fontFace(for: fontId)
+        return face.getGlyph(codepoint, weight: weight, italic: italic)
+    }
+
+    /// Look up a glyph using legacy style bits.
+    func getGlyph(_ codepoint: UInt32, style: UInt8 = 0, fontId: UInt8 = 0) -> Glyph? {
+        let face = fontFace(for: fontId)
+        return face.getGlyph(codepoint, style: style)
+    }
+
+    /// Attempt to shape a ligature with the correct font face.
+    func shapeLigature(_ text: String, weight: UInt8, italic: Bool, fontId: UInt8 = 0) -> FontFace.LigatureResult? {
+        let face = fontFace(for: fontId)
+        return face.shapeLigature(text, weight: weight, italic: italic)
+    }
+
+    /// Pre-rasterize ASCII glyphs for the primary font.
+    func preloadAscii() {
+        primary.preloadAscii()
+    }
+}

--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -90,6 +90,7 @@ let GUI_COLOR_ACCENT: UInt8 = 0x40
 
 let OP_SET_FONT: UInt8 = 0x50
 let OP_SET_FONT_FALLBACK: UInt8 = 0x51
+let OP_REGISTER_FONT: UInt8 = 0x52
 
 // MARK: - Highlight opcodes (ignored by GUI, handled by minga-parser)
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -12,7 +12,7 @@ enum RenderCommand: Sendable {
     case clear
     case batchEnd
     case drawText(row: UInt16, col: UInt16, fg: UInt32, bg: UInt32, attrs: UInt8, text: String)
-    case drawStyledText(row: UInt16, col: UInt16, fg: UInt32, bg: UInt32, attrs: UInt16, underlineColor: UInt32, blend: UInt8, fontWeight: UInt8, text: String)
+    case drawStyledText(row: UInt16, col: UInt16, fg: UInt32, bg: UInt32, attrs: UInt16, underlineColor: UInt32, blend: UInt8, fontWeight: UInt8, fontId: UInt8, text: String)
     case setCursor(row: UInt16, col: UInt16)
     case setCursorShape(CursorShape)
     case setTitle(String)
@@ -23,6 +23,7 @@ enum RenderCommand: Sendable {
     case setActiveRegion(id: UInt16)
     case setFont(family: String, size: UInt16, ligatures: Bool, weight: UInt8)
     case setFontFallback(families: [String])
+    case registerFont(id: UInt8, family: String)
     case guiTheme(slots: [(slotId: UInt8, r: UInt8, g: UInt8, b: UInt8)])
     case guiTabBar(activeIndex: UInt8, tabs: [GUITabEntry])
     case guiFileTree(selectedIndex: UInt16, treeWidth: UInt16, entries: [GUIFileTreeEntry])
@@ -169,8 +170,8 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         return (.drawText(row: row, col: col, fg: fg, bg: bg, attrs: attrs, text: text), 1 + 13 + textLen)
 
     case OP_DRAW_STYLED_TEXT:
-        // row:2, col:2, fg:3, bg:3, attrs:2(16-bit), ul_color:3, blend:1, font_weight:1, text_len:2 = 19 bytes after opcode
-        guard data.count >= rest + 19 else { throw ProtocolDecodeError.malformed }
+        // row:2, col:2, fg:3, bg:3, attrs:2(16-bit), ul_color:3, blend:1, font_weight:1, font_id:1, text_len:2 = 20 bytes after opcode
+        guard data.count >= rest + 20 else { throw ProtocolDecodeError.malformed }
         let row = readU16(data, rest)
         let col = readU16(data, rest + 2)
         let fg = readU24(data, rest + 4)
@@ -179,11 +180,12 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         let ulColor = readU24(data, rest + 12)
         let blend = data[rest + 15]
         let fontWeight = data[rest + 16]
-        let textLen = Int(readU16(data, rest + 17))
-        guard data.count >= rest + 19 + textLen else { throw ProtocolDecodeError.malformed }
-        let textData = data[(rest + 19)..<(rest + 19 + textLen)]
+        let fontId = data[rest + 17]
+        let textLen = Int(readU16(data, rest + 18))
+        guard data.count >= rest + 20 + textLen else { throw ProtocolDecodeError.malformed }
+        let textData = data[(rest + 20)..<(rest + 20 + textLen)]
         let text = String(data: textData, encoding: .utf8) ?? ""
-        return (.drawStyledText(row: row, col: col, fg: fg, bg: bg, attrs: attrs16, underlineColor: ulColor, blend: blend, fontWeight: fontWeight, text: text), 1 + 19 + textLen)
+        return (.drawStyledText(row: row, col: col, fg: fg, bg: bg, attrs: attrs16, underlineColor: ulColor, blend: blend, fontWeight: fontWeight, fontId: fontId, text: text), 1 + 20 + textLen)
 
     case OP_SET_CURSOR:
         guard data.count >= rest + 4 else { throw ProtocolDecodeError.malformed }
@@ -263,6 +265,16 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             offset += nameLen
         }
         return (.setFontFallback(families: families), offset - rest + 1)
+
+    case OP_REGISTER_FONT:
+        // font_id:1, name_len:2, name:bytes
+        guard data.count >= rest + 3 else { throw ProtocolDecodeError.malformed }
+        let fontId = data[rest]
+        let nameLen = Int(readU16(data, rest + 1))
+        guard data.count >= rest + 3 + nameLen else { throw ProtocolDecodeError.malformed }
+        let nameData = data[(rest + 3)..<(rest + 3 + nameLen)]
+        let family = String(data: nameData, encoding: .utf8) ?? "Menlo"
+        return (.registerFont(id: fontId, family: family), 1 + 3 + nameLen)
 
     // Highlight and parser opcodes: skip them (variable length).
     case OP_SET_LANGUAGE:

--- a/macos/Sources/Renderer/CellGrid.swift
+++ b/macos/Sources/Renderer/CellGrid.swift
@@ -28,6 +28,9 @@ struct Cell {
     /// Font weight for per-span weight variation (0-7, maps thin through black).
     /// 2 = regular (default). Set by draw_styled_text; plain draw_text leaves this at 2.
     var fontWeight: UInt8 = 2
+    /// Font ID for per-span font family (0 = primary, 1-255 = registered secondary fonts).
+    /// Set by draw_styled_text; plain draw_text leaves this at 0.
+    var fontId: UInt8 = 0
     /// For ligature head cells: the full source text that was shaped (e.g., "->").
     /// Empty for non-ligature cells.
     var ligatureText: String = ""

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -29,6 +29,11 @@ final class CommandDispatcher {
     /// on init and updated when a set_font command arrives.
     var fontFace: FontFace?
 
+    /// Font manager for per-span font family support. When set, glyph
+    /// lookups route through the manager (which handles font_id routing).
+    /// Set by the AppDelegate alongside fontFace.
+    var fontManager: FontManager?
+
     /// Called after each `batch_end` command. The MetalRenderer hooks into
     /// this to trigger a GPU frame.
     var onFrameReady: (() -> Void)?
@@ -61,13 +66,14 @@ final class CommandDispatcher {
         case .drawText(let row, let col, let fg, let bg, let attrs, let text):
             drawText(row: row, col: col, fg: fg, bg: bg, attrs: attrs, text: text)
 
-        case .drawStyledText(let row, let col, let fg, let bg, let attrs16, let ulColor, _, let fontWeight, let text):
+        case .drawStyledText(let row, let col, let fg, let bg, let attrs16, let ulColor, _, let fontWeight, let fontId, let text):
             // Extended draw: 16-bit attrs with underline style, strikethrough, and underline color.
             // The low 8 bits of attrs16 match the regular attrs byte layout.
             let attrs8 = UInt8(attrs16 & 0xFF)
             let ulStyle = UInt8((attrs16 >> UL_STYLE_SHIFT) & UL_STYLE_MASK)
             drawText(row: row, col: col, fg: fg, bg: bg, attrs: attrs8, text: text,
-                     underlineColor: ulColor, underlineStyle: ulStyle, fontWeight: fontWeight)
+                     underlineColor: ulColor, underlineStyle: ulStyle, fontWeight: fontWeight,
+                     fontId: fontId)
 
         case .setCursor(let row, let col):
             var absRow = row
@@ -131,6 +137,9 @@ final class CommandDispatcher {
 
         case .setFontFallback(let families):
             fontFace?.setFallbackFonts(families)
+
+        case .registerFont(let id, let family):
+            fontManager?.registerFont(id: id, name: family)
 
         case .guiTheme(let slots):
             guiState.themeColors.applySlots(slots)
@@ -224,7 +233,8 @@ final class CommandDispatcher {
     }()
 
     private func drawText(row: UInt16, col: UInt16, fg: UInt32, bg: UInt32, attrs: UInt8, text: String,
-                          underlineColor: UInt32 = 0, underlineStyle: UInt8 = 0, fontWeight: UInt8 = 2) {
+                          underlineColor: UInt32 = 0, underlineStyle: UInt8 = 0, fontWeight: UInt8 = 2,
+                          fontId: UInt8 = 0) {
         var absRow = row
         var absCol = col
         var maxCol = grid.cols
@@ -248,7 +258,8 @@ final class CommandDispatcher {
                 grid.writeCell(col: currentCol, row: absRow, cell: Cell(
                     grapheme: grapheme, width: UInt8(w),
                     fg: fg, bg: bg, attrs: attrs, underlineColor: underlineColor, underlineStyle: underlineStyle,
-                    fontWeight: fontWeight
+                    fontWeight: fontWeight,
+                    fontId: fontId
                 ))
                 currentCol &+= UInt16(w)
             }
@@ -284,6 +295,7 @@ final class CommandDispatcher {
                             fg: fg, bg: bg, attrs: attrs,
                             underlineColor: underlineColor, underlineStyle: underlineStyle,
                             fontWeight: fontWeight,
+                            fontId: fontId,
                             ligatureText: candidate,
                             ligatureCellCount: UInt8(lig.cellCount),
                             isContinuation: false
@@ -294,6 +306,7 @@ final class CommandDispatcher {
                                 fg: fg, bg: bg, attrs: attrs,
                                 underlineColor: underlineColor, underlineStyle: underlineStyle,
                                 fontWeight: fontWeight,
+                                fontId: fontId,
                                 isContinuation: true
                             ))
                         }
@@ -311,7 +324,8 @@ final class CommandDispatcher {
                 grid.writeCell(col: currentCol, row: absRow, cell: Cell(
                     grapheme: grapheme, width: UInt8(w),
                     fg: fg, bg: bg, attrs: attrs, underlineColor: underlineColor, underlineStyle: underlineStyle,
-                    fontWeight: fontWeight
+                    fontWeight: fontWeight,
+                    fontId: fontId
                 ))
                 currentCol &+= UInt16(w)
                 i += 1

--- a/macos/Sources/Renderer/MetalRenderer.swift
+++ b/macos/Sources/Renderer/MetalRenderer.swift
@@ -130,16 +130,33 @@ final class MetalRenderer {
     /// `layer.nextDrawable()` call that caused scroll lag.
     ///
     /// `scrollOffset` is the sub-cell-height pixel offset for smooth scrolling.
+    /// Render using a FontManager (supports per-cell font_id).
+    func render(grid: CellGrid, fontManager: FontManager, drawable: CAMetalDrawable,
+                viewportSize: CGSize, contentScale: Float, scrollOffset: SIMD2<Float> = .zero) {
+        renderImpl(grid: grid, fontManager: fontManager, drawable: drawable,
+                   viewportSize: viewportSize, contentScale: contentScale, scrollOffset: scrollOffset)
+    }
+
+    /// Render using a single FontFace (backward compatible).
     func render(grid: CellGrid, face: FontFace, drawable: CAMetalDrawable,
                 viewportSize: CGSize, contentScale: Float, scrollOffset: SIMD2<Float> = .zero) {
+        renderImpl(grid: grid, fontManager: nil, primaryFace: face, drawable: drawable,
+                   viewportSize: viewportSize, contentScale: contentScale, scrollOffset: scrollOffset)
+    }
+
+    private func renderImpl(grid: CellGrid, fontManager: FontManager? = nil, primaryFace: FontFace? = nil,
+                            drawable: CAMetalDrawable, viewportSize: CGSize, contentScale: Float,
+                            scrollOffset: SIMD2<Float> = .zero) {
+        let face = primaryFace ?? fontManager!.primary
+        let atlas = fontManager?.atlas ?? face.atlas
         let cellW = Float(face.cellWidth)
         let cellH = Float(face.cellHeight)
-        let atlasSize = Float(face.atlas.size)
+        let atlasSize = Float(atlas.size)
 
         // Re-upload atlas if it changed.
-        if face.atlas.modified != atlasVersion {
-            uploadAtlas(face.atlas)
-            atlasVersion = face.atlas.modified
+        if atlas.modified != atlasVersion {
+            uploadAtlas(atlas)
+            atlasVersion = atlas.modified
         }
 
         // Build GPU cell data.
@@ -186,10 +203,14 @@ final class MetalRenderer {
             let isBold = (cell.attrs & ATTR_BOLD) != 0
             let cellWeight: UInt8 = (cell.fontWeight == 2 && isBold) ? 5 : cell.fontWeight
             let cellItalic = (cell.attrs & ATTR_ITALIC) != 0
+            let cellFontId = cell.fontId
+
+            // Select the correct font face for this cell's font_id.
+            let cellFace = fontManager?.fontFace(for: cellFontId) ?? face
 
             // Ligature head cell: use the shaped ligature glyph.
             if cell.ligatureCellCount > 1, !cell.ligatureText.isEmpty,
-               let lig = face.shapeLigature(cell.ligatureText, weight: cellWeight, italic: cellItalic) {
+               let lig = cellFace.shapeLigature(cell.ligatureText, weight: cellWeight, italic: cellItalic) {
                 gpu.hasGlyph = 1.0
                 gpu.isColor = 0.0
                 gpu.uvOrigin = SIMD2<Float>(Float(lig.glyph.atlasX) / atlasSize,
@@ -206,7 +227,7 @@ final class MetalRenderer {
             // Normal single-cell glyph.
             else if !cell.grapheme.isEmpty, cell.grapheme != " " {
                 if let scalar = cell.grapheme.unicodeScalars.first,
-                   let glyph = face.getGlyph(scalar.value, weight: cellWeight, italic: cellItalic) {
+                   let glyph = cellFace.getGlyph(scalar.value, weight: cellWeight, italic: cellItalic) {
                     gpu.hasGlyph = 1.0
                     gpu.isColor = glyph.isColor ? 1.0 : 0.0
                     gpu.uvOrigin = SIMD2<Float>(Float(glyph.atlasX) / atlasSize,

--- a/test/minga/font_registry_test.exs
+++ b/test/minga/font_registry_test.exs
@@ -1,0 +1,51 @@
+defmodule Minga.FontRegistryTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.FontRegistry
+
+  describe "new/0" do
+    test "creates empty registry with next_id 1" do
+      reg = FontRegistry.new()
+      assert reg.families == %{}
+      assert reg.next_id == 1
+    end
+  end
+
+  describe "get_or_register/2" do
+    test "assigns incrementing IDs to new families" do
+      reg = FontRegistry.new()
+      {id1, reg, true} = FontRegistry.get_or_register(reg, "Fira Code")
+      {id2, reg, true} = FontRegistry.get_or_register(reg, "Source Code Pro")
+      assert id1 == 1
+      assert id2 == 2
+      assert reg.next_id == 3
+    end
+
+    test "returns existing ID for already-registered family" do
+      reg = FontRegistry.new()
+      {id1, reg, true} = FontRegistry.get_or_register(reg, "Fira Code")
+      {id2, _reg, false} = FontRegistry.get_or_register(reg, "Fira Code")
+      assert id1 == id2
+      assert id1 == 1
+    end
+
+    test "caps at 255 and falls back to 0" do
+      reg = %FontRegistry{families: %{}, next_id: 256}
+      {id, _reg, false} = FontRegistry.get_or_register(reg, "Overflow Font")
+      assert id == 0
+    end
+  end
+
+  describe "lookup/2" do
+    test "returns 0 for unknown family" do
+      reg = FontRegistry.new()
+      assert FontRegistry.lookup(reg, "Unknown") == 0
+    end
+
+    test "returns registered ID" do
+      reg = FontRegistry.new()
+      {_id, reg, _} = FontRegistry.get_or_register(reg, "Fira Code")
+      assert FontRegistry.lookup(reg, "Fira Code") == 1
+    end
+  end
+end

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -45,6 +45,7 @@ pub const OP_DRAW_STYLED_TEXT: u8 = 0x1C;
 // Config commands (BEAM → frontend, TUI ignores)
 pub const OP_SET_FONT: u8 = 0x50;
 pub const OP_SET_FONT_FALLBACK: u8 = 0x51;
+pub const OP_REGISTER_FONT: u8 = 0x52;
 
 // Incremental content sync (BEAM → Zig)
 pub const OP_EDIT_BUFFER: u8 = 0x26;
@@ -371,9 +372,10 @@ pub const DrawText = struct {
     text: []const u8,
 };
 
-/// Extended draw command with 16-bit attrs, underline color, blend, and font weight.
+/// Extended draw command with 16-bit attrs, underline color, blend, font weight, and font ID.
 /// Opcode 0x1C. Wire format:
-///   row:u16, col:u16, fg:u24, bg:u24, attrs:u16, ul_color:u24, blend:u8, font_weight:u8, text_len:u16, text
+///   row:u16, col:u16, fg:u24, bg:u24, attrs:u16, ul_color:u24, blend:u8, font_weight:u8, font_id:u8, text_len:u16, text
+/// The TUI ignores font_id (not stored in DrawStyledText).
 pub const DrawStyledText = struct {
     row: u16,
     col: u16,
@@ -611,8 +613,8 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
             } };
         },
         OP_DRAW_STYLED_TEXT => {
-            // row:2, col:2, fg:3, bg:3, attrs:2, ul_color:3, blend:1, font_weight:1, text_len:2 = 19 bytes min
-            if (rest.len < 19) return error.Malformed;
+            // row:2, col:2, fg:3, bg:3, attrs:2, ul_color:3, blend:1, font_weight:1, font_id:1, text_len:2 = 20 bytes min
+            if (rest.len < 20) return error.Malformed;
             const row = std.mem.readInt(u16, rest[0..2], .big);
             const col = std.mem.readInt(u16, rest[2..4], .big);
             const fg = readU24(rest[4..7]);
@@ -621,9 +623,10 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
             const ul_color = readU24(rest[12..15]);
             const blend = rest[15];
             const font_weight = rest[16];
-            const text_len = std.mem.readInt(u16, rest[17..19], .big);
-            if (rest.len < 19 + text_len) return error.Malformed;
-            const text = rest[19 .. 19 + text_len];
+            // font_id at rest[17] (ignored by TUI)
+            const text_len = std.mem.readInt(u16, rest[18..20], .big);
+            if (rest.len < 20 + text_len) return error.Malformed;
+            const text = rest[20 .. 20 + text_len];
             return .{ .draw_styled_text = .{
                 .row = row,
                 .col = col,
@@ -855,6 +858,14 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
             // TUI ignores font config; just return a no-op clear.
             return .clear;
         },
+        OP_REGISTER_FONT => {
+            // font_id:1, name_len:2, name:bytes
+            if (rest.len < 3) return error.Malformed;
+            const name_len = std.mem.readInt(u16, rest[1..3], .big);
+            if (rest.len < 3 + name_len) return error.Malformed;
+            // TUI ignores font registration; return no-op.
+            return .clear;
+        },
         OP_SET_FONT_FALLBACK => {
             // count:1, then count * (name_len:2, name:bytes)
             if (rest.len < 1) return error.Malformed;
@@ -968,6 +979,12 @@ pub fn commandSize(payload: []const u8) usize {
             if (payload.len < 7) break :blk payload.len;
             const name_len = std.mem.readInt(u16, payload[5..7], .big);
             break :blk 7 + name_len;
+        },
+        OP_REGISTER_FONT => blk: {
+            // opcode(1) + font_id(1) + name_len(2) + name
+            if (payload.len < 4) break :blk payload.len;
+            const name_len = std.mem.readInt(u16, payload[2..4], .big);
+            break :blk 4 + name_len;
         },
         OP_SET_FONT_FALLBACK => blk: {
             // opcode(1) + count(1), then count * (name_len:2, name:bytes)
@@ -2201,6 +2218,7 @@ test "decode draw_styled_text command" {
         0xFF, 0x00, 0x00, // ul_color: red
         0x32, // blend: 50
         0x05, // font_weight: bold
+        0x00, // font_id: primary
         0x00, 0x05, // text_len
     } ++ "error".*;
 
@@ -2233,6 +2251,7 @@ test "decode draw_styled_text with underline style curl" {
         0xFF, 0x00, 0x00, // ul_color: red
         0x64, // blend: 100
         0x02, // font_weight: regular
+        0x00, // font_id: primary
         0x00, 0x03, // text_len
     } ++ "abc".*;
 


### PR DESCRIPTION
## Summary

Wires the Face struct's `font_family` field through the protocol to the GUI renderer, completing Phase 3 of #91. Different syntax elements can now use different fonts (e.g., comments in a different monospace font).

## Architecture: Shared Atlas (Option A)

The user explicitly chose Option A over Option C (same-metrics enforcement) because Phase 5 (variable-pitch fonts) is coming and the atlas refactoring would be needed anyway. Building the foundation now avoids a retrofit later.

**Key design:**
- `GlyphAtlas` is separated from `FontFace` ownership
- New `FontManager` class owns the shared atlas and manages multiple `FontFace` instances by font_id
- All fonts pack glyphs into one GPU texture (single texture bind per frame)
- Cell metrics come from the primary font; secondary fonts with different metrics log a warning but still work

## Changes

### Protocol
- `draw_styled_text` gains `font_id:8` byte (header 19→20 bytes). ID 0 = primary font.
- New `register_font` command (0x52): maps font_id → font family name

### Swift
- `FontManager`: owns shared `GlyphAtlas`, routes glyph lookups by font_id, registers secondary fonts
- `FontFace`: accepts optional external atlas (backward compatible)
- `MetalRenderer`: routes through `FontManager` when available, selecting per-cell `FontFace`

### Elixir
- `FontRegistry`: maps font_family strings to protocol font_ids (1-255)
- `Face.to_style/2`: includes `font_family` when non-nil
- `DisplayList.draws_to_commands`: resolves font_family → font_id, sends `register_font` on first use
- Font registry persists in process dictionary across frames (IDs stable, registration one-time)

### Zig
- Decoder updated for 20-byte draw_styled_text (ignores font_id)
- `register_font` decoded and skipped (TUI doesn't use font families)

## Testing
- All 5,647 Elixir tests pass (6 new FontRegistry tests)
- All Zig tests pass
- Swift GUI builds clean
- `mix lint` + `mix zig.lint` clean

## Related
Completes Phase 3 of #91. Stacks on #787 (merged) and #802.