### PR TITLE
fix(editor): keep LoggerHandler installed across Editor restarts

### DIFF
--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -105,6 +105,21 @@ defmodule Minga.Application do
     result
   end
 
+  @impl true
+  @spec stop(term()) :: :ok
+  def stop(_state) do
+    # Clean shutdown: restore the default console logger and stderr device.
+    # This only runs when the application is stopping gracefully, not on
+    # Editor crashes (where the LoggerHandler stays installed so crash
+    # reports flow through the ETS buffer and get replayed on restart).
+    case :logger.get_handler_config(:minga_messages) do
+      {:ok, _} -> Minga.LoggerHandler.uninstall()
+      _ -> :ok
+    end
+
+    :ok
+  end
+
   @spec prune_old_sessions() :: :ok
   defp prune_old_sessions do
     retention_days =

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -184,13 +184,12 @@ defmodule Minga.Editor do
   @impl true
   @spec terminate(term(), state()) :: :ok
   def terminate(_reason, _state) do
-    # Only uninstall if we installed (i.e. real TUI, not headless test).
-    # Check for our handler presence rather than storing state.
-    case :logger.get_handler_config(:minga_messages) do
-      {:ok, _} -> Minga.LoggerHandler.uninstall()
-      _ -> :ok
-    end
-
+    # Do NOT uninstall the LoggerHandler here. OTP emits crash reports
+    # AFTER terminate returns, so uninstalling would restore the default
+    # stderr handler and the crash report would corrupt the TUI. The
+    # LoggerHandler stays installed across Editor restarts; its ETS buffer
+    # captures crash reports and flush_buffer/0 replays them on the next
+    # init. Cleanup happens in Application.stop/1 (clean shutdown only).
     :ok
   end
 

--- a/lib/minga/logger_handler.ex
+++ b/lib/minga/logger_handler.ex
@@ -26,7 +26,12 @@ defmodule Minga.LoggerHandler do
 
       Minga.LoggerHandler.install()
 
-  The editor's `terminate/2` calls `uninstall/0` to restore defaults.
+  The handler stays installed across Editor restarts so that crash reports
+  are captured in the ETS buffer. `uninstall/0` is called only during
+  clean application shutdown (`Application.stop/1`).
+
+  `install/0` is idempotent: safe to call on every `Editor.init/1` even
+  when the handlers are already in place from a previous Editor lifetime.
   """
 
   @handler_id :minga_messages
@@ -57,6 +62,10 @@ defmodule Minga.LoggerHandler do
   @doc """
   Install the custom handlers and redirect stderr to a log file.
 
+  Idempotent: skips any handler or redirect that is already in place.
+  Safe to call on every `Editor.init/1`, including restarts after a crash
+  where the handlers survived because `terminate/2` no longer tears them down.
+
   Returns the log file path for display in `*Messages*`.
   """
   @spec install() :: String.t()
@@ -65,21 +74,29 @@ defmodule Minga.LoggerHandler do
     File.mkdir_p!(@log_dir)
 
     # 1. Replace the default handler with a file-based one.
-    #    Can't change type on a live handler, so remove + re-add.
-    :logger.remove_handler(:default)
+    #    Idempotent: skip if already installed (Editor restarting after a
+    #    crash while the LoggerHandler stayed in place).
+    unless handler_installed?(@file_handler_id) do
+      :logger.remove_handler(:default)
 
-    :logger.add_handler(@file_handler_id, :logger_std_h, %{
-      config: %{type: {:file, String.to_charlist(log_path)}},
-      level: :all
-    })
+      :logger.add_handler(@file_handler_id, :logger_std_h, %{
+        config: %{type: {:file, String.to_charlist(log_path)}},
+        level: :all
+      })
+    end
 
     # 2. Add our custom handler that sends to *Messages*.
-    :logger.add_handler(@handler_id, __MODULE__, %{level: :all})
+    unless handler_installed?(@handler_id) do
+      :logger.add_handler(@handler_id, __MODULE__, %{level: :all})
+    end
 
     # 3. Redirect :standard_error to the log file so IO.warn and raw BEAM
     #    warnings don't paint over the TUI. We open a unicode-mode file device
     #    and register it as :standard_error (the OTP IO protocol convention).
-    redirect_standard_error(log_path)
+    #    Idempotent: skip if already redirected.
+    unless stderr_redirected?() do
+      redirect_standard_error(log_path)
+    end
 
     log_path
   end
@@ -260,5 +277,17 @@ defmodule Minga.LoggerHandler do
 
   defp format_message(level, {format, args}, _meta) do
     "[#{level}] #{:io_lib.format(format, args) |> IO.iodata_to_binary()}"
+  end
+
+  # ── Idempotency helpers ────────────────────────────────────────────────────
+
+  @spec handler_installed?(atom()) :: boolean()
+  defp handler_installed?(handler_id) do
+    match?({:ok, _}, :logger.get_handler_config(handler_id))
+  end
+
+  @spec stderr_redirected?() :: boolean()
+  defp stderr_redirected? do
+    :persistent_term.get(:minga_original_stderr, nil) != nil
   end
 end


### PR DESCRIPTION
## What

Fixes the LoggerHandler lifecycle so crash reports go to `*Messages*` instead of stderr.

## Why

When the Editor GenServer crashed, `terminate/2` called `LoggerHandler.uninstall()`, which restored the default stderr console handler. OTP emits crash reports *after* `terminate` returns, so the report bypassed the custom handler entirely and went straight to stderr, corrupting the TUI.

The ETS buffering mechanism was already built to handle exactly this scenario (buffer during Editor downtime, replay on restart), but it never got the chance because the handler was torn down too early.

## Changes

1. **`LoggerHandler.install()` is now idempotent.** Checks whether each handler and the stderr redirect are already in place before adding them. Safe to call on every `Editor.init/1`, including restarts after a crash.

2. **Removed `uninstall()` from `Editor.terminate/2`.** The handler stays installed across Editor restarts so crash reports flow through the ETS buffer.

3. **Added `Application.stop/1`.** `uninstall()` now runs only during clean application shutdown, restoring the default console handler and stderr device.

## Testing

All 1443 tests pass (including 12 LoggerHandler tests). Lint clean. No test changes needed since the implementation is backward-compatible (idempotent guards don't change behavior on first call).

Closes #803