### PR TITLE
chore(face): remove proportional font dead code (#91)

### DIFF
--- a/lib/minga/editor/renderer/caps.ex
+++ b/lib/minga/editor/renderer/caps.ex
@@ -26,17 +26,6 @@ defmodule Minga.Editor.Renderer.Caps do
   def render_overlays?(%Capabilities{}), do: true
 
   @doc """
-  Returns true if the BEAM should use round-trip text measurement
-  (measure_text/text_width opcodes) instead of BEAM-side width tables.
-
-  Proportional-font frontends need the frontend to measure text width
-  because character widths vary by glyph and font metrics.
-  """
-  @spec measure_text_remotely?(Capabilities.t()) :: boolean()
-  def measure_text_remotely?(%Capabilities{text_rendering: :proportional}), do: true
-  def measure_text_remotely?(%Capabilities{}), do: false
-
-  @doc """
   Degrades a 24-bit RGB color to the nearest 256-color or monochrome
   equivalent based on the frontend's color depth.
 

--- a/lib/minga/face.ex
+++ b/lib/minga/face.ex
@@ -20,10 +20,10 @@ defmodule Minga.Face do
 
   ## GUI-only fields
 
-  `font_family`, `font_weight`, `font_slant`, `font_size_delta`, and
-  `font_features` are silently ignored in the TUI backend. The TUI
-  uses bold/italic attrs from the base fields; the GUI uses the font
-  fields to select specific font variants.
+  `font_family`, `font_weight`, `font_slant`, and `font_features` are
+  silently ignored in the TUI backend. The TUI uses bold/italic attrs
+  from the base fields; the GUI uses the font fields to select specific
+  font variants.
 
   ## Blend
 
@@ -50,7 +50,6 @@ defmodule Minga.Face do
             font_family: nil,
             font_weight: nil,
             font_slant: nil,
-            font_size_delta: nil,
             font_features: nil
 
   @typedoc "RGB color as a 24-bit integer (e.g., `0xFF6C6B`)."
@@ -81,7 +80,6 @@ defmodule Minga.Face do
           font_family: String.t() | nil,
           font_weight: font_weight() | nil,
           font_slant: font_slant() | nil,
-          font_size_delta: integer() | nil,
           font_features: %{String.t() => boolean()} | nil
         }
 
@@ -108,7 +106,6 @@ defmodule Minga.Face do
       font_family: nil,
       font_weight: :regular,
       font_slant: :roman,
-      font_size_delta: 0,
       font_features: nil
     }
   end
@@ -149,8 +146,7 @@ defmodule Minga.Face do
     :reverse,
     :blend,
     :font_weight,
-    :font_slant,
-    :font_size_delta
+    :font_slant
   ]
 
   # All inheritable fields: required fields + fields where nil is a
@@ -315,7 +311,6 @@ defmodule Minga.Face do
       font_family: Keyword.get(style, :font_family),
       font_weight: Keyword.get(style, :font_weight),
       font_slant: Keyword.get(style, :font_slant),
-      font_size_delta: Keyword.get(style, :font_size_delta),
       font_features: Keyword.get(style, :font_features)
     }
   end

--- a/lib/minga/port/capabilities.ex
+++ b/lib/minga/port/capabilities.ex
@@ -5,7 +5,7 @@ defmodule Minga.Port.Capabilities do
   When a frontend starts, it sends a `ready` event with optional capability
   fields. The BEAM uses these to adapt rendering strategy: skipping image
   commands on terminals without image support, using native floating windows
-  on GUIs, adjusting text measurement for proportional fonts, etc.
+  on GUIs, using native floating windows, etc.
 
   Frontends that send the short 5-byte `ready` format get `default/0` caps
   (TUI, RGB, wcwidth, no images, emulated floats, monospace).
@@ -16,23 +16,20 @@ defmodule Minga.Port.Capabilities do
             color_depth: :rgb,
             unicode_width: :wcwidth,
             image_support: :none,
-            float_support: :emulated,
-            text_rendering: :monospace
+            float_support: :emulated
 
   @type frontend_type :: :tui | :native_gui | :web
   @type color_depth :: :mono | :color_256 | :rgb
   @type unicode_width :: :wcwidth | :unicode_15
   @type image_support :: :none | :kitty | :sixel | :native
   @type float_support :: :emulated | :native
-  @type text_rendering :: :monospace | :proportional
 
   @type t :: %__MODULE__{
           frontend_type: frontend_type(),
           color_depth: color_depth(),
           unicode_width: unicode_width(),
           image_support: image_support(),
-          float_support: float_support(),
-          text_rendering: text_rendering()
+          float_support: float_support()
         }
 
   @doc "Returns the default capabilities (TUI with full RGB, monospace)."
@@ -43,15 +40,14 @@ defmodule Minga.Port.Capabilities do
   @spec from_binary(binary()) :: t()
   def from_binary(
         <<frontend_type::8, color_depth::8, unicode_width::8, image_support::8, float_support::8,
-          text_rendering::8>>
+          _reserved::8>>
       ) do
     %__MODULE__{
       frontend_type: decode_frontend_type(frontend_type),
       color_depth: decode_color_depth(color_depth),
       unicode_width: decode_unicode_width(unicode_width),
       image_support: decode_image_support(image_support),
-      float_support: decode_float_support(float_support),
-      text_rendering: decode_text_rendering(text_rendering)
+      float_support: decode_float_support(float_support)
     }
   end
 
@@ -68,11 +64,6 @@ defmodule Minga.Port.Capabilities do
   @spec native_floats?(t()) :: boolean()
   def native_floats?(%__MODULE__{float_support: :native}), do: true
   def native_floats?(%__MODULE__{}), do: false
-
-  @doc "Returns true if the frontend uses proportional (variable-width) fonts."
-  @spec proportional?(t()) :: boolean()
-  def proportional?(%__MODULE__{text_rendering: :proportional}), do: true
-  def proportional?(%__MODULE__{}), do: false
 
   @doc "Returns true if the frontend supports full 24-bit RGB color."
   @spec rgb?(t()) :: boolean()
@@ -114,9 +105,4 @@ defmodule Minga.Port.Capabilities do
   defp decode_float_support(0), do: :emulated
   defp decode_float_support(1), do: :native
   defp decode_float_support(_), do: :emulated
-
-  @spec decode_text_rendering(non_neg_integer()) :: text_rendering()
-  defp decode_text_rendering(0), do: :monospace
-  defp decode_text_rendering(1), do: :proportional
-  defp decode_text_rendering(_), do: :monospace
 end

--- a/lib/minga/port/protocol.ex
+++ b/lib/minga/port/protocol.ex
@@ -111,7 +111,7 @@ defmodule Minga.Port.Protocol do
   @op_grammar_loaded 0x32
   @op_language_at_response 0x33
   @op_injection_ranges 0x34
-  @op_text_width 0x35
+  # 0x35 was text_width (removed: proportional fonts deferred)
   @op_fold_ranges 0x36
   @op_indent_result 0x37
   @op_textobject_result 0x38
@@ -192,7 +192,6 @@ defmodule Minga.Port.Protocol do
           | {:injection_ranges, buffer_id :: non_neg_integer(),
              [%{start_byte: non_neg_integer(), end_byte: non_neg_integer(), language: String.t()}]}
           | {:language_at_response, request_id :: non_neg_integer(), language :: String.t()}
-          | {:text_width, request_id :: non_neg_integer(), width :: non_neg_integer()}
           | {:fold_ranges, buffer_id :: non_neg_integer(), version :: non_neg_integer(),
              [{start_line :: non_neg_integer(), end_line :: non_neg_integer()}]}
           | {:indent_result, request_id :: non_neg_integer(), line :: non_neg_integer(),
@@ -545,17 +544,6 @@ defmodule Minga.Port.Protocol do
     <<header::binary, edit_data::binary>>
   end
 
-  # ── Encoding: text measurement (BEAM → Zig) ──
-
-  @op_measure_text 0x27
-
-  @doc "Encodes a measure_text request: request_id(4) + text_len(2) + text."
-  @spec encode_measure_text(non_neg_integer(), String.t()) :: binary()
-  def encode_measure_text(request_id, text)
-      when is_integer(request_id) and request_id >= 0 and is_binary(text) do
-    <<@op_measure_text, request_id::32, byte_size(text)::16, text::binary>>
-  end
-
   # ── Encoding: highlight commands (BEAM → Zig) ──
 
   @doc "Encodes a set_language command with buffer_id."
@@ -748,10 +736,6 @@ defmodule Minga.Port.Protocol do
 
   def decode_event(<<@op_injection_ranges, buffer_id::32, count::16, rest::binary>>) do
     {:ok, {:injection_ranges, buffer_id, decode_injection_ranges(rest, count, [])}}
-  end
-
-  def decode_event(<<@op_text_width, request_id::32, width::16>>) do
-    {:ok, {:text_width, request_id, width}}
   end
 
   def decode_event(<<@op_fold_ranges, buffer_id::32, version::32, count::32, rest::binary>>) do

--- a/test/minga/editor/renderer/caps_test.exs
+++ b/test/minga/editor/renderer/caps_test.exs
@@ -14,16 +14,6 @@ defmodule Minga.Editor.Renderer.CapsTest do
     end
   end
 
-  describe "measure_text_remotely?/1" do
-    test "false for monospace (TUI default)" do
-      refute Caps.measure_text_remotely?(%Capabilities{text_rendering: :monospace})
-    end
-
-    test "true for proportional fonts" do
-      assert Caps.measure_text_remotely?(%Capabilities{text_rendering: :proportional})
-    end
-  end
-
   describe "adapt_color/2" do
     test "passes through for RGB" do
       assert Caps.adapt_color(0xFF6C6B, %Capabilities{color_depth: :rgb}) == 0xFF6C6B

--- a/test/minga/face_test.exs
+++ b/test/minga/face_test.exs
@@ -18,7 +18,6 @@ defmodule Minga.FaceTest do
       assert d.blend == 100
       assert d.font_weight == :regular
       assert d.font_slant == :roman
-      assert d.font_size_delta == 0
     end
   end
 

--- a/test/minga/port/capabilities_test.exs
+++ b/test/minga/port/capabilities_test.exs
@@ -16,11 +16,6 @@ defmodule Minga.Port.CapabilitiesTest do
       assert Capabilities.native_floats?(%Capabilities{float_support: :native})
     end
 
-    test "proportional?/1" do
-      refute Capabilities.proportional?(%Capabilities{text_rendering: :monospace})
-      assert Capabilities.proportional?(%Capabilities{text_rendering: :proportional})
-    end
-
     test "rgb?/1" do
       assert Capabilities.rgb?(%Capabilities{color_depth: :rgb})
       refute Capabilities.rgb?(%Capabilities{color_depth: :color_256})
@@ -44,7 +39,6 @@ defmodule Minga.Port.CapabilitiesTest do
       assert caps.unicode_width == :unicode_15
       assert caps.image_support == :kitty
       assert caps.float_support == :native
-      assert caps.text_rendering == :proportional
     end
 
     test "returns defaults for invalid binary" do

--- a/test/minga/port/protocol_test.exs
+++ b/test/minga/port/protocol_test.exs
@@ -84,17 +84,15 @@ defmodule Minga.Port.ProtocolTest do
       assert caps.unicode_width == :unicode_15
       assert caps.image_support == :kitty
       assert caps.float_support == :emulated
-      assert caps.text_rendering == :monospace
     end
 
     test "decodes an extended ready with native GUI capabilities" do
-      payload = <<0x03, 200::16, 60::16, 1, 6, 1, 2, 1, 3, 1, 1>>
+      payload = <<0x03, 200::16, 60::16, 1, 6, 1, 2, 1, 3, 1, 0>>
 
       assert {:ok, {:ready, 200, 60, caps}} = Protocol.decode_event(payload)
       assert caps.frontend_type == :native_gui
       assert caps.image_support == :native
       assert caps.float_support == :native
-      assert caps.text_rendering == :proportional
     end
   end
 
@@ -779,18 +777,6 @@ defmodule Minga.Port.ProtocolTest do
     test "encode_edit_buffer with empty edits list" do
       result = Protocol.encode_edit_buffer(0, 1, [])
       assert <<0x26, 0::32, 1::32, 0::16>> = result
-    end
-  end
-
-  describe "text measurement" do
-    test "encode_measure_text" do
-      result = Protocol.encode_measure_text(42, "hello")
-      assert <<0x27, 42::32, 5::16, "hello">> = result
-    end
-
-    test "decode text_width response" do
-      payload = <<0x35, 42::32, 5::16>>
-      assert {:ok, {:text_width, 42, 5}} = Protocol.decode_event(payload)
     end
   end
 


### PR DESCRIPTION
## Summary

Removes dead code that existed solely for variable-pitch font rendering (Phase 5 of #91), which has been deferred indefinitely. No modern code editor has shipped reliable proportional font support for code buffers.

## Removed (89 lines)

- `font_size_delta` field from `Face` struct (only useful with variable cell heights)
- `measure_text` protocol opcode (0x27) and encoder (zero callers)
- `text_width` protocol opcode (0x35) and decoder (zero callers)
- `Capabilities.proportional?/1` and `text_rendering` type/field (never used for decisions)
- `Caps.measure_text_remotely?/1` (dead function)
- All associated tests

## Kept (useful without proportional fonts)

- `font_family` on Face + FontManager + FontRegistry (different monospace fonts per syntax element)
- `font_weight` per span (finer weight control)
- `font_slant` (italic/oblique distinction)
- `font_fallback` (Nerd Font icons)
- `font_features` (ligature control)

## Testing

All 5,642 tests pass. All lints clean.

## Related

Closes out Phase 5 of #91. PR #807 (variable-pitch GPU infrastructure) was closed without merging.