### PR TITLE
fix(editor): prevent garbled text on buffer switch from file tree

### DIFF
--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -415,17 +415,25 @@ defmodule Minga.Editor do
 
   def handle_info({tag, {:highlight_names, buffer_id, names}}, state)
       when tag in [:minga_highlight, :minga_input] do
-    # Resolve buffer_id to PID; fall back to active buffer for unregistered IDs
-    # (e.g., buffer_id 0 from test injection or legacy code paths).
-    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id)
 
     new_state =
-      if pid == state.buffers.active do
-        HighlightEvents.handle_names(state, names)
-      else
-        existing = HighlightSync.get_highlight(state, pid)
-        updated = Minga.Highlight.put_names(existing, names)
-        HighlightSync.put_highlight(state, pid, updated)
+      case pid do
+        nil ->
+          Minga.Log.warning(
+            :editor,
+            "highlight_names for unknown buffer_id=#{buffer_id}, discarding"
+          )
+
+          state
+
+        ^pid when pid == state.buffers.active ->
+          HighlightEvents.handle_names(state, names)
+
+        _ ->
+          existing = HighlightSync.get_highlight(state, pid)
+          updated = Minga.Highlight.put_names(existing, names)
+          HighlightSync.put_highlight(state, pid, updated)
       end
 
     {:noreply, new_state}
@@ -433,12 +441,17 @@ defmodule Minga.Editor do
 
   def handle_info({tag, {:injection_ranges, buffer_id, ranges}}, state)
       when tag in [:minga_highlight, :minga_input] do
-    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id)
 
     new_state =
       if pid do
         %{state | injection_ranges: Map.put(state.injection_ranges, pid, ranges)}
       else
+        Minga.Log.warning(
+          :editor,
+          "injection_ranges for unknown buffer_id=#{buffer_id}, discarding"
+        )
+
         state
       end
 
@@ -452,31 +465,41 @@ defmodule Minga.Editor do
 
   def handle_info({tag, {:highlight_spans, buffer_id, version, spans}}, state)
       when tag in [:minga_highlight, :minga_input] do
-    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id)
 
     new_state =
-      if pid == state.buffers.active do
-        HighlightEvents.handle_spans(state, version, spans)
-      else
-        # Non-active buffer: store spans in highlights map.
-        existing = HighlightSync.get_highlight(state, pid)
-        updated = Minga.Highlight.put_spans(existing, version, spans)
-        state_with_hl = HighlightSync.put_highlight(state, pid, updated)
+      case pid do
+        nil ->
+          Minga.Log.warning(
+            :editor,
+            "highlight_spans for unknown buffer_id=#{buffer_id}, discarding"
+          )
 
-        # If this buffer is visible in any window (e.g., agent panel),
-        # trigger a render so the highlights appear immediately.
-        if buffer_visible_in_window?(state_with_hl, pid) do
-          Renderer.render(state_with_hl)
-        else
-          state_with_hl
-        end
+          state
+
+        ^pid when pid == state.buffers.active ->
+          HighlightEvents.handle_spans(state, version, spans)
+
+        _ ->
+          # Non-active buffer: store spans in highlights map.
+          existing = HighlightSync.get_highlight(state, pid)
+          updated = Minga.Highlight.put_spans(existing, version, spans)
+          state_with_hl = HighlightSync.put_highlight(state, pid, updated)
+
+          # If this buffer is visible in any window (e.g., agent panel),
+          # trigger a render so the highlights appear immediately.
+          if buffer_visible_in_window?(state_with_hl, pid) do
+            Renderer.render(state_with_hl)
+          else
+            state_with_hl
+          end
       end
 
     # Re-cache GUI styled messages whenever the agent buffer gets new
     # tree-sitter highlights, regardless of whether it's the active
     # buffer or not.
     new_state =
-      if pid == new_state.agent.buffer do
+      if pid != nil and pid == new_state.agent.buffer do
         AgentLifecycle.update_styled_cache(new_state)
       else
         new_state
@@ -487,10 +510,12 @@ defmodule Minga.Editor do
 
   def handle_info({tag, {:conceal_spans, buffer_id, _version, spans}}, state)
       when tag in [:minga_highlight, :minga_input] do
-    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id)
 
     if pid do
       HighlightEvents.handle_conceal_spans(state, pid, spans)
+    else
+      Minga.Log.warning(:editor, "conceal_spans for unknown buffer_id=#{buffer_id}, discarding")
     end
 
     {:noreply, state}
@@ -500,25 +525,31 @@ defmodule Minga.Editor do
       when tag in [:minga_highlight, :minga_input] do
     Minga.Log.debug(:editor, "Fold ranges received: buffer=#{buffer_id}, count=#{length(ranges)}")
 
-    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id)
 
     new_state =
-      if pid == state.buffers.active do
-        fold_ranges =
-          Enum.map(ranges, fn {start_line, end_line} ->
-            FoldRange.new!(start_line, end_line)
-          end)
+      case pid do
+        nil ->
+          Minga.Log.warning(:editor, "fold_ranges for unknown buffer_id=#{buffer_id}, discarding")
+          state
 
-        case EditorState.active_window_struct(state) do
-          nil ->
-            state
+        ^pid when pid == state.buffers.active ->
+          fold_ranges =
+            Enum.map(ranges, fn {start_line, end_line} ->
+              FoldRange.new!(start_line, end_line)
+            end)
 
-          %Window{id: id} ->
-            EditorState.update_window(state, id, &Window.set_fold_ranges(&1, fold_ranges))
-        end
-      else
-        # Stale response for a non-active buffer; discard.
-        state
+          case EditorState.active_window_struct(state) do
+            nil ->
+              state
+
+            %Window{id: id} ->
+              EditorState.update_window(state, id, &Window.set_fold_ranges(&1, fold_ranges))
+          end
+
+        _ ->
+          # Response for a non-active buffer; discard.
+          state
       end
 
     {:noreply, new_state}
@@ -526,14 +557,24 @@ defmodule Minga.Editor do
 
   def handle_info({tag, {:textobject_positions, buffer_id, _version, positions}}, state)
       when tag in [:minga_highlight, :minga_input] do
-    pid = HighlightSync.resolve_buffer_pid(state, buffer_id) || state.buffers.active
+    pid = HighlightSync.resolve_buffer_pid(state, buffer_id)
 
     new_state =
-      if pid == state.buffers.active do
-        apply_textobject_positions(state, positions)
-      else
-        # Stale response for a non-active buffer; discard.
-        state
+      case pid do
+        nil ->
+          Minga.Log.warning(
+            :editor,
+            "textobject_positions for unknown buffer_id=#{buffer_id}, discarding"
+          )
+
+          state
+
+        ^pid when pid == state.buffers.active ->
+          apply_textobject_positions(state, positions)
+
+        _ ->
+          # Response for a non-active buffer; discard.
+          state
       end
 
     {:noreply, new_state}

--- a/lib/minga/editor/commands/file_tree.ex
+++ b/lib/minga/editor/commands/file_tree.ex
@@ -51,11 +51,7 @@ defmodule Minga.Editor.Commands.FileTree do
         # Opening a file buffer always uses :editor scope (not restore_scope)
         # because the new buffer becomes the active window content.
         state = %{state | keymap_scope: :editor}
-
-        case Commands.start_buffer(path) do
-          {:ok, pid} -> Minga.Editor.do_file_tree_open(state, pid, path, tree)
-          {:error, _} -> state
-        end
+        open_file_from_tree(state, path, tree)
 
       nil ->
         state
@@ -109,6 +105,26 @@ defmodule Minga.Editor.Commands.FileTree do
     }
 
   # ── Private helpers ───────────────────────────────────────────────────────
+
+  # Opens a file from the tree, reusing an existing buffer when one exists
+  # for the same path. Without the dedup check, the file tree creates
+  # duplicate Buffer.Server processes for the same file, which causes stale
+  # tree-sitter highlight spans from the old buffer's parse to be misrouted
+  # to the new buffer (garbled text on first render).
+  @spec open_file_from_tree(state(), String.t(), FileTree.t()) :: state()
+  defp open_file_from_tree(state, path, tree) do
+    case EditorState.find_buffer_by_path(state, path) do
+      nil ->
+        case Commands.start_buffer(path) do
+          {:ok, pid} -> Minga.Editor.do_file_tree_open(state, pid, path, tree)
+          {:error, _} -> state
+        end
+
+      idx ->
+        state = EditorState.switch_buffer(state, idx)
+        put_in(state.file_tree.tree, FileTree.reveal(tree, path))
+    end
+  end
 
   @spec open(state()) :: state()
   defp open(state) do

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -128,12 +128,62 @@ defmodule Minga.Test.EditorCase do
   def inject_highlights(ctx, capture_names, version \\ 1, spans) do
     # Flush pending messages (e.g. :setup_highlight from :ready)
     _ = :sys.get_state(ctx.editor)
-    # buffer_id 0 is used in test injection since no real parser is involved
-    send(ctx.editor, {:minga_input, {:highlight_names, 0, capture_names}})
-    send(ctx.editor, {:minga_input, {:highlight_spans, 0, version, spans}})
+
+    # Ensure the active buffer has a registered parser buffer_id so the
+    # highlight event handlers can route the message correctly. Previously
+    # this used a hardcoded buffer_id=0 with a fallback to active buffer,
+    # but that fallback was removed (it could misroute spans to the wrong
+    # buffer after a buffer switch).
+    #
+    # For test buffers that don't have a recognized filetype (no tree-sitter
+    # grammar), setup_highlight won't assign a buffer_id. We use
+    # :sys.replace_state to directly assign one, which is safe in tests.
+    buffer_id = ensure_test_buffer_id(ctx.editor)
+
+    send(ctx.editor, {:minga_input, {:highlight_names, buffer_id, capture_names}})
+    send(ctx.editor, {:minga_input, {:highlight_spans, buffer_id, version, spans}})
     # Sync: ensure both messages have been processed before returning
     _ = :sys.get_state(ctx.editor)
     ctx
+  end
+
+  # Ensures the active buffer has a registered parser buffer_id.
+  # Returns the buffer_id (existing or newly assigned).
+  @spec ensure_test_buffer_id(pid()) :: non_neg_integer()
+  defp ensure_test_buffer_id(editor) do
+    state = :sys.get_state(editor)
+    buf = state.buffers.active
+
+    if buf == nil do
+      0
+    else
+      hl = state.highlight
+
+      case Map.fetch(hl.buffer_ids, buf) do
+        {:ok, id} ->
+          id
+
+        :error ->
+          # Assign a buffer_id directly via :sys.replace_state
+          id = hl.next_buffer_id
+
+          :sys.replace_state(editor, fn st ->
+            h = st.highlight
+
+            %{
+              st
+              | highlight: %{
+                  h
+                  | buffer_ids: Map.put(h.buffer_ids, buf, id),
+                    reverse_buffer_ids: Map.put(h.reverse_buffer_ids, id, buf),
+                    next_buffer_id: id + 1
+                }
+            }
+          end)
+
+          id
+      end
+    end
   end
 
   # ── Key sending helpers ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When opening a file from the file tree that was previously opened in the same session, the first render showed garbled text: characters were missing throughout the buffer (e.g., `ef odule` instead of `defmodule`), but syntax coloring was present. The text fixed itself on the first interaction.

## Root Cause

Two bugs combined:

1. **File tree created duplicate buffers.** `open_or_toggle` called `Commands.start_buffer(path)` unconditionally, creating a new `Buffer.Server` even when one already existed for that file. The `:edit` command correctly checks `find_buffer_by_path` first; the file tree didn't.

2. **Highlight event handlers silently misrouted parser responses.** All 6 handlers (`highlight_names`, `highlight_spans`, `conceal_spans`, `fold_ranges`, `injection_ranges`, `textobject_positions`) used `|| state.buffers.active` as a fallback when `resolve_buffer_pid` returned nil. This applied byte-offset spans from one file's parse tree to another file's content. The `safe_binary_slice` function in `Highlight.ex` then returned empty strings for misaligned byte ranges, dropping characters.

## Fix

1. `open_file_from_tree` now calls `find_buffer_by_path` and switches to the existing buffer when one exists (matching `:edit` behavior).

2. All `|| state.buffers.active` fallbacks replaced with explicit nil checks that log a warning and discard the event.

3. Test helper `inject_highlights` updated to register proper parser buffer_ids instead of relying on the removed fallback.

## Testing

- All 5647 tests pass, 0 failures
- `mix lint` passes (format, credo, compile --warnings-as-errors, dialyzer)