### PR TITLE
fix(gui): cursor blanking text and column alignment in CoreText renderer

### DIFF
--- a/macos/Sources/Renderer/CoreTextLineRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextLineRenderer.swift
@@ -214,7 +214,25 @@ final class CoreTextLineRenderer {
     private func buildAttributedString(runs: [StyledRun]) -> NSAttributedString {
         let result = NSMutableAttributedString()
 
+        // Track the current column position to insert gap-filling spaces
+        // when runs aren't contiguous. This ensures each run's text starts
+        // at its declared column position in the final CTLine.
+        var currentCol: UInt16 = runs.first?.col ?? 0
+
         for run in runs {
+            // Fill gaps between runs with transparent spaces using the
+            // primary font so CoreText advances by exactly the right amount.
+            if run.col > currentCol {
+                let gapCount = Int(run.col - currentCol)
+                let gapText = String(repeating: " ", count: gapCount)
+                let gapAttrs: [NSAttributedString.Key: Any] = [
+                    .font: fontManager.primary.ctFont,
+                    .foregroundColor: NSColor.clear,
+                    .ligature: 0
+                ]
+                result.append(NSAttributedString(string: gapText, attributes: gapAttrs))
+            }
+
             let font = resolveFont(for: run)
 
             // Handle reverse attribute: swap fg and bg colors for text rendering.
@@ -251,6 +269,9 @@ final class CoreTextLineRenderer {
 
             let attrStr = NSAttributedString(string: run.text, attributes: attrs)
             result.append(attrStr)
+
+            // Advance current column past this run's text.
+            currentCol = run.col + UInt16(run.text.count)
         }
 
         return result
@@ -325,17 +346,16 @@ final class CoreTextLineRenderer {
         ctx.setAllowsAntialiasing(true)
         ctx.setShouldAntialias(true)
 
-        // Position each run at its column offset.
         // CoreText uses a bottom-up coordinate system.
         let baselineY = descent
 
-        // Position the CTLine. Each run's text starts at col * cellWidth.
-        // Since we built the attributed string by concatenating runs,
-        // we need to position the entire line at the first run's column.
-        let firstCol = runs.first.map { CGFloat($0.col) * cellWidth } ?? 0
-        ctx.textPosition = CGPoint(x: firstCol, y: baselineY)
+        // The CTLine starts at x=0 within the texture. Column positioning
+        // is handled by CoreTextMetalRenderer when it places the texture
+        // quad. The gap-filling spaces in buildAttributedString ensure
+        // each run's text appears at the correct relative offset.
+        ctx.textPosition = CGPoint(x: 0, y: baselineY)
 
-        // Draw the complete CTLine (CoreText handles all run positioning internally).
+        // Draw the complete CTLine.
         CTLineDraw(ctLine, ctx)
 
         return buffer

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -6,9 +6,11 @@
 ///
 /// Passes:
 /// 1. Background fill: one colored quad per line (using run bg colors)
-/// 2. Line texture blit: one textured quad per line (CoreText-rendered text)
-/// 3. Cursor overlay: single colored quad (block/beam/underline)
-/// 4. Gutter fill: colored rect to cover gutter padding gap
+/// 2. Block cursor background (drawn before text so text shows on top)
+/// 3. Line texture blit: one textured quad per line (CoreText-rendered text)
+/// 4. Gutter gap fill: colored rect to cover gutter padding gap
+/// 5. Gutter separator line
+/// 6. Beam/underline cursor overlay (drawn after text)
 
 import Metal
 import QuartzCore
@@ -166,10 +168,12 @@ final class CoreTextMetalRenderer {
             if !runs.isEmpty {
                 let contentHash = lineBuffer.computeLineHash(row: row)
                 if let cached = lineRenderer.renderLine(row: row, runs: runs, contentHash: contentHash) {
-                    let xPos = runs.first.map { r -> Float in
-                        let colPx = Float(r.col) * cellW * scale
-                        return r.col >= lineBuffer.gutterCol ? colPx + gutterPaddingPx : colPx
-                    } ?? 0
+                    // The texture starts at the first run's column. Gap-filling
+                    // spaces in the attributed string handle intra-line positioning.
+                    let firstCol = runs.first.map { Float($0.col) } ?? 0
+                    let colPx = firstCol * cellW * scale
+                    let xPos = firstCol >= Float(lineBuffer.gutterCol)
+                        ? colPx + gutterPaddingPx : colPx
 
                     var lineGPU = LineGPU()
                     lineGPU.position = SIMD2<Float>(xPos, yPos)
@@ -204,7 +208,28 @@ final class CoreTextMetalRenderer {
             encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: bgQuads.count)
         }
 
-        // Pass 2: Line textures (one draw call per line since each has its own texture).
+        // Pass 2: Cursor background (drawn BEFORE text so text is visible on top).
+        // For block cursors, draw the cursor bg here so the text pass composites over it.
+        // Beam and underline cursors are drawn AFTER text (pass 5).
+        if lineBuffer.cursorVisible && lineBuffer.cursorShape == .block {
+            let cursorRow = Float(lineBuffer.cursorRow)
+            let cursorCol = Float(lineBuffer.cursorCol)
+            let cursorPadding: Float = (lineBuffer.gutterCol > 0 && lineBuffer.cursorCol >= lineBuffer.gutterCol)
+                ? gutterPaddingPx : 0
+
+            var cursorQuad = QuadGPU()
+            cursorQuad.position = SIMD2<Float>(cursorCol * cellW * scale + cursorPadding, cursorRow * cellH * scale)
+            cursorQuad.size = SIMD2<Float>(cellW * scale, cellH * scale)
+            cursorQuad.color = SIMD3<Float>(0.8, 0.8, 0.8)
+            cursorQuad.alpha = 1.0
+
+            encoder.setRenderPipelineState(bgPipeline)
+            encoder.setVertexBytes(&cursorQuad, length: MemoryLayout<QuadGPU>.stride, index: 0)
+            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+        }
+
+        // Pass 3: Line textures (one draw call per line since each has its own texture).
         if !lineInstances.isEmpty {
             encoder.setRenderPipelineState(linePipeline)
             for var (lineGPU, texture) in lineInstances {
@@ -215,7 +240,7 @@ final class CoreTextMetalRenderer {
             }
         }
 
-        // Pass 3: Gutter gap fill.
+        // Pass 4: Gutter gap fill.
         if lineBuffer.gutterCol > 0 && gutterPaddingPx > 0 {
             var fillQuad = QuadGPU()
             fillQuad.position = SIMD2<Float>(Float(lineBuffer.gutterCol) * cellW * scale, 0)
@@ -229,7 +254,7 @@ final class CoreTextMetalRenderer {
             encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
         }
 
-        // Pass 4: Gutter separator line.
+        // Pass 5: Gutter separator line.
         if lineBuffer.gutterCol > 0 && lineBuffer.gutterSeparatorColor != 0 {
             var sepQuad = QuadGPU()
             let sepX = (Float(lineBuffer.gutterCol) * cellW + gutterPaddingPt) * scale - 1.0
@@ -244,8 +269,10 @@ final class CoreTextMetalRenderer {
             encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
         }
 
-        // Pass 5: Cursor overlay.
-        if lineBuffer.cursorVisible {
+        // Pass 6: Cursor overlay for beam and underline shapes.
+        // Block cursor is drawn in pass 2 (before text) so text shows on top.
+        // Beam and underline are drawn AFTER text so they overlay it.
+        if lineBuffer.cursorVisible && lineBuffer.cursorShape != .block {
             let cursorRow = Float(lineBuffer.cursorRow)
             let cursorCol = Float(lineBuffer.cursorCol)
             let cursorPadding: Float = (lineBuffer.gutterCol > 0 && lineBuffer.cursorCol >= lineBuffer.gutterCol)
@@ -257,8 +284,7 @@ final class CoreTextMetalRenderer {
 
             switch lineBuffer.cursorShape {
             case .block:
-                cursorQuad.position = SIMD2<Float>(cursorCol * cellW * scale + cursorPadding, cursorRow * cellH * scale)
-                cursorQuad.size = SIMD2<Float>(cellW * scale, cellH * scale)
+                break  // Handled in pass 2.
 
             case .beam:
                 let beamWidth: Float = 2.0 * scale


### PR DESCRIPTION
## Problem

Two rendering bugs after the CoreText migration (#817):

1. **Block cursor hides text**: The cursor was an opaque quad drawn AFTER the text pass, completely covering the character at the cursor position. The cursor line appeared blank where the cursor sat.

2. **Column misalignment**: `buildAttributedString` concatenated styled runs without filling column gaps. Non-contiguous runs (line number at col 0, content at col 4) had their text squeezed together. Additionally, `rasterizeLine` double-offset the CTLine by positioning it at the first run's column inside the texture, when the texture was already positioned there by CoreTextMetalRenderer.

## Fix

1. **Cursor draw order**: Block cursor background is now drawn in pass 2 (before text in pass 3), so CoreText text composites on top of it. Beam and underline cursors remain in pass 6 (after text) since they don't cover glyphs.

2. **Gap-filling spaces**: `buildAttributedString` now tracks the current column and inserts transparent space characters between non-contiguous runs. This preserves column positions through CoreText's layout engine. The CTLine now starts at x=0 within the texture (no double-offset).

## Testing

- 103 Swift tests pass
- `mix lint` passes (no BEAM/Zig changes)