### PR TITLE
docs: GUI-first strategic direction across architecture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,20 @@
 
 ## Project Overview
 
-Minga is a BEAM-powered modal text editor with a Zig terminal renderer. Read `PLAN.md` for full architecture and implementation roadmap. Read `docs/ARCHITECTURE.md` for the two-process design and its benefits.
+Minga is a BEAM-powered modal text editor with native GUI frontends. The editor core runs on the Erlang VM (Elixir), and platform-native frontends handle rendering and input. Read `docs/ARCHITECTURE.md` for the multi-frontend design and its benefits.
+
+## Strategic Direction: GUI-First
+
+Native GUI experiences lead the design. The macOS frontend (Swift/Metal) is the most mature and sets the quality bar. A Linux frontend (GTK4) is planned. The TUI frontend (Zig/libvaxis) continues to ship features, but new work is designed for GUI frontends first. Think Emacs: the GUI is the primary experience, the terminal mode is a capable fallback that benefits from the same core improvements.
+
+When building new features, design for the GUI rendering path first, then ensure the TUI has a reasonable equivalent.
 
 ## Tech Stack
 
 - **Elixir 1.19** / OTP 28 — editor core (buffers, modes, commands, orchestration)
-- **Zig 0.15** with libvaxis — terminal rendering (runs as BEAM Port)
+- **Swift 6 / Metal 3.1** — macOS native GUI frontend (primary)
+- **GTK4** — Linux native GUI frontend (planned)
+- **Zig 0.15** with libvaxis — TUI frontend + tree-sitter parser
 - **ExUnit** + **StreamData** — testing
 - Pinned versions in `.tool-versions`
 
@@ -31,7 +39,8 @@ lib/
       state.ex                # Buffer GenServer internal state
     port/
       protocol.ex             # Port protocol encoder/decoder
-      manager.ex              # GenServer managing the Zig renderer Port
+      protocol/gui.ex         # GUI chrome protocol encoder (native frontends only)
+      manager.ex              # GenServer managing the frontend Port
       frontend.ex             # Behaviour for pluggable rendering backends
       capabilities.ex         # Frontend capabilities struct
     parser/
@@ -79,13 +88,24 @@ lib/
     compilers/
       zig.ex                  # Custom Mix compiler for Zig builds
 
-zig/
+macos/                        # macOS native GUI frontend (primary)
+  project.yml                 # XcodeGen project definition
+  Sources/
+    MingaApp.swift            # App entry point, SwiftUI wiring
+    Protocol/                 # Binary protocol decoder/encoder
+    Renderer/                 # Metal cell grid renderer
+    Font/                     # CoreText font loading, glyph atlas
+    Views/                    # SwiftUI + NSView wrappers
+  Tests/                      # Protocol round-trip tests
+
+zig/                          # TUI frontend + tree-sitter parser
   build.zig                   # Zig build configuration
   build.zig.zon               # Zig package manifest (libvaxis dep)
   src/
     main.zig                  # Entry point, event loop
     protocol.zig              # Port protocol encoder/decoder
     renderer.zig              # libvaxis render command handler
+    highlighter.zig           # Tree-sitter highlighter (shared by all frontends via parser Port)
 
 test/                         # Mirrors lib/ structure
 ```
@@ -122,9 +142,9 @@ When a feature is done and the PR is merged:
 
 **After the first worktree experience, ask the user:** "How did the worktree workflow feel? Worth keeping, or would you rather go back to one branch at a time?" Update this section based on their answer.
 
-## Iterative Fixes (especially TUI/rendering)
+## Iterative Fixes (especially rendering)
 
-When a fix improves visible behavior (user confirms it's better), **commit it and stop**. Do not immediately try to "refine" or "optimize" the fix in the same session. The TUI rendering pipeline has race conditions between the BEAM, the Zig Port, and the physical terminal that are impossible to fully reason about without seeing real output. What looks like an obvious improvement in theory (e.g., "skip the stale frame") can make things worse because your mental model of the frame ordering is wrong.
+When a fix improves visible behavior (user confirms it's better), **commit it and stop**. Do not immediately try to "refine" or "optimize" the fix in the same session. The rendering pipeline has timing dependencies between the BEAM, the frontend Port, and the display surface that are impossible to fully reason about without seeing real output. What looks like an obvious improvement in theory (e.g., "skip the stale frame") can make things worse because your mental model of the frame ordering is wrong.
 
 Rules:
 1. Make one change. Rebuild. Have the user test.
@@ -354,38 +374,40 @@ type(scope): short description
 Longer body if needed.
 ```
 
-Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore` Scopes: `buffer`, `port`, `editor`, `mode`, `keymap`, `zig`, `cli`
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore` Scopes: `buffer`, `port`, `editor`, `mode`, `keymap`, `zig`, `macos`, `gtk`, `cli`
 
 Examples:
 - `feat(buffer): implement gap buffer with cursor movement`
+- `feat(macos): add native hover tooltips for LSP content`
 - `feat(zig): scaffold libvaxis renderer with port protocol`
 - `test(buffer): add property-based tests for insert/delete`
 
 ## Port Protocol
 
-BEAM ↔ Zig communication uses length-prefixed binary messages over stdin/stdout of the Zig process. The Zig process uses `/dev/tty` for terminal I/O (not stdout).
+BEAM ↔ frontend communication uses length-prefixed binary messages over stdin/stdout of the frontend process. All frontends (Swift, GTK4, Zig TUI) speak the same protocol. The TUI's Zig process uses `/dev/tty` for terminal I/O (not stdout).
 
-See `PLAN.md` § "Port Protocol" for the full message specification.
+See `docs/PROTOCOL.md` for the full message specification and `docs/GUI_PROTOCOL.md` for the additional GUI chrome opcodes sent only to native GUI frontends.
 
 ## Rendering Architecture
 
-The rendering pipeline is being refactored to support multiple frontends (TUI, macOS GUI, Linux GUI). Read `docs/RENDERING_GAPS.md` for the full analysis and ticket links.
+The rendering pipeline supports multiple frontends through a shared display list IR and a binary port protocol. The BEAM owns all rendering decisions; frontends are "dumb" renderers.
 
 Key design decisions:
 - **Display list IR:** The BEAM side owns a display list of styled text runs (not a cell grid) that sits between editor state and protocol encoding. All frontends consume this shared IR. See `docs/ARCHITECTURE.md` § "Display List (Rendering IR)" for the type definitions.
 - **Styled text runs over cell grids:** GUIs don't think in terminal cells. The IR uses `{col, text, style}` tuples organized by line within positioned rectangles. The TUI quantizes runs to cells; a GUI renders runs with its font engine.
+- **GUI chrome protocol:** Native GUI frontends receive structured data opcodes (0x70-0x78) for chrome elements like tab bars, file trees, status bars, and popups. These are rendered with platform-native widgets (SwiftUI, GTK4), not painted as cells. See `docs/GUI_PROTOCOL.md`.
 - **Per-window render state:** Each `Window` carries cached draw commands and a dirty-line set for incremental rendering.
-- **Pipeline stages:** The renderer is being split into named stages (Invalidation, Layout, Scroll, Content, Chrome, Compose, Emit) for debuggability and per-stage caching.
+- **Pipeline stages:** Seven named stages (Invalidation, Layout, Scroll, Content, Chrome, Compose, Emit) with per-stage timing via telemetry.
 
 ## Mouse Support (first-class citizen)
 
-Mouse support is not optional or secondary to keyboard input. Minga ships two frontends (TUI via Zig/libvaxis, macOS GUI via Swift/Metal), and both must handle mouse interactions properly. The bar is **Doom Emacs**: if Doom supports a mouse interaction, Minga should too.
+Mouse support is not optional or secondary to keyboard input. Minga ships multiple frontends (macOS GUI via Swift/Metal, TUI via Zig/libvaxis, Linux GUI via GTK4 planned), and all must handle mouse interactions properly. The bar is **Doom Emacs**: if Doom supports a mouse interaction, Minga should too.
 
 See [#217](https://github.com/jsmestad/minga/issues/217) for the full tracker.
 
 ### Architecture
 
-Mouse events flow through the same protocol as keyboard events. Both frontends encode mouse events as `mouse_event` messages (opcode `0x04`) with row, col, button, modifiers, event type, and click count. The BEAM side decodes them in `Minga.Port.Protocol` and dispatches them to `Minga.Editor.Mouse`.
+Mouse events flow through the same protocol as keyboard events. All frontends encode mouse events as `mouse_event` messages (opcode `0x04`) with row, col, button, modifiers, event type, and click count. The BEAM side decodes them in `Minga.Port.Protocol` and dispatches them to `Minga.Editor.Mouse`.
 
 Key rules for mouse work:
 
@@ -450,10 +472,12 @@ Agent tools live in `lib/minga/agent/tools/`. When adding or modifying a tool th
 
 > **Note:** Buffer routing is being implemented in phases. Today, tools still use `File.read/write` directly. When wiring a tool to use buffers, follow the pattern in `BUFFER-AWARE-AGENTS.md` Phase 1.
 
-### New render command (requires both sides)
-1. Add opcode constant and encoder in `Minga.Port.Protocol`
-2. Add decoder and handler in `zig/src/protocol.zig` + `zig/src/renderer.zig`
-3. Test encode/decode round-trip on both sides
+### New render command (requires BEAM + frontend changes)
+1. Add opcode constant and encoder in `Minga.Port.Protocol` (BEAM side, canonical source of truth)
+2. **macOS GUI:** Add decoder in `macos/Sources/Protocol/ProtocolDecoder.swift`, constant in `ProtocolConstants.swift`, handler in `CommandDispatcher.swift`
+3. **TUI:** Add decoder and handler in `zig/src/protocol.zig` + `zig/src/renderer.zig`
+4. **Linux GUI:** (when it exists) Add decoder and handler in the GTK4 frontend
+5. Test encode/decode round-trip on all sides. GUI chrome opcodes (0x70-0x78) only need GUI frontend support; the TUI ignores them.
 
 ### New tree-sitter grammar
 Adding syntax highlighting for a new language touches four places:
@@ -467,4 +491,3 @@ Adding syntax highlighting for a new language touches four places:
 After rebuilding (`zig build` or `mix compile`), the grammar is compiled into the binary and available immediately. No runtime loading needed.
 
 Users can override highlight queries without recompiling by placing `.scm` files at `~/.config/minga/queries/{lang}/highlights.scm`.
-mpiling by placing `.scm` files at `~/.config/minga/queries/{lang}/highlights.scm`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ How a text editor built on process isolation and preemptive concurrency actually
 
 Most text editors are single-threaded programs with shared state. Buffers, rendering, input handling, plugin execution, AI agents: all living in one address space, contending for one event loop. When a background task does heavy work, your keystrokes queue up. When two things modify the same buffer, you get race conditions. When you want to know what a plugin is doing, you add `print` statements and restart.
 
-Minga splits the editor into **two OS processes** with completely isolated memory:
+Minga splits the editor into **separate OS processes** with completely isolated memory: a BEAM process for all editor logic, and one or more frontend processes for rendering and input.
 
 ```mermaid
 graph LR
@@ -25,27 +25,54 @@ graph LR
         ED2 --> PORT
     end
 
-    subgraph ZIG["Zig + libvaxis"]
-        EVLOOP["Event Loop"]
-        PROTO["Protocol<br/>decoder/encoder"]
-        RENDER["Renderer<br/>cell grid"]
-        TS["Tree-sitter<br/>parser"]
-        TTY["/dev/tty<br/>terminal I/O"]
+    subgraph SWIFT["Swift + Metal (macOS)"]
+        SW_PROTO["Protocol<br/>decoder/encoder"]
+        SW_CHROME["SwiftUI<br/>native chrome"]
+        SW_RENDER["Metal<br/>editor surface"]
+        SW_WIN["NSWindow"]
 
-        EVLOOP <--> PROTO
+        SW_PROTO --> SW_CHROME
+        SW_PROTO --> SW_RENDER
+        SW_CHROME --> SW_WIN
+        SW_RENDER --> SW_WIN
+    end
+
+    subgraph GTK["GTK4 (Linux, planned)"]
+        GTK_PROTO["Protocol<br/>decoder/encoder"]
+        GTK_CHROME["GTK4<br/>native chrome"]
+        GTK_RENDER["Cairo/GL<br/>editor surface"]
+
+        GTK_PROTO --> GTK_CHROME
+        GTK_PROTO --> GTK_RENDER
+    end
+
+    subgraph ZIG["Zig + libvaxis (TUI)"]
+        EVLOOP["Event Loop"]
+        ZIG_PROTO["Protocol<br/>decoder/encoder"]
+        RENDER["Renderer<br/>cell grid"]
+        TTY["/dev/tty"]
+
+        EVLOOP <--> ZIG_PROTO
         EVLOOP <--> RENDER
-        EVLOOP <--> TS
         RENDER <--> TTY
     end
 
-    PORT -- "render commands<br/>(draw_text, set_cursor, clear)" --> PROTO
-    PROTO -- "input events<br/>(key_press, resize, highlights)" --> PORT
+    PORT -- "render commands + GUI chrome" --> SW_PROTO
+    SW_PROTO -- "input events" --> PORT
+
+    PORT -. "render commands + GUI chrome" .-> GTK_PROTO
+    GTK_PROTO -. "input events" .-> PORT
+
+    PORT -- "render commands" --> ZIG_PROTO
+    ZIG_PROTO -- "input events + highlights" --> PORT
 
     style BEAM fill:#1a1a2e,stroke:#6c3483,color:#fff
-    style ZIG fill:#1a2e1a,stroke:#1e8449,color:#fff
+    style SWIFT fill:#1a2e1a,stroke:#1e8449,color:#fff
+    style GTK fill:#2e1a1a,stroke:#844935,color:#fff
+    style ZIG fill:#1a1a1a,stroke:#666666,color:#fff
 ```
 
-The two processes communicate over a binary protocol on stdin/stdout. They share no memory. Every internal component (each buffer, the editor, the port manager, each future plugin) runs as its own lightweight BEAM process with its own state. They can't interfere with each other because the VM enforces the boundaries.
+All frontends communicate with the BEAM over the same binary protocol on stdin/stdout. They share no memory. The BEAM is the single source of truth for all editor state; frontends are "dumb" renderers and input sources. Every internal component (each buffer, the editor, the port manager, each future plugin) runs as its own lightweight BEAM process with its own state. They can't interfere with each other because the VM enforces the boundaries.
 
 This isn't a workaround for a limitation. It's the whole point.
 
@@ -117,14 +144,16 @@ graph TD
     SUP --> SVC["Services.Supervisor<br/><i>LSP, extensions, diagnostics, agents</i>"]
     SUP --> RT["Runtime.Supervisor<br/><i>renderer, parser, editor orchestration</i>"]
 
-    RT -. "stdin/stdout" .-> ZIG["Zig Processes<br/><i>renderer + parser</i>"]
+    RT -. "stdin/stdout" .-> FE["Frontend Process<br/><i>Swift/Metal, GTK4, or Zig/libvaxis</i>"]
+    RT -. "stdin/stdout" .-> PARSER["Parser Process<br/><i>Zig + tree-sitter</i>"]
 
     style SUP fill:#6c3483,stroke:#4a235a,color:#fff
     style FOUND fill:#6c3483,stroke:#4a235a,color:#fff
     style BUFSUP fill:#1a5276,stroke:#154360,color:#fff
     style SVC fill:#6c3483,stroke:#4a235a,color:#fff
     style RT fill:#b7950b,stroke:#9a7d0a,color:#fff
-    style ZIG fill:#1e8449,stroke:#196f3d,color:#fff
+    style FE fill:#1e8449,stroke:#196f3d,color:#fff
+    style PARSER fill:#1e8449,stroke:#196f3d,color:#fff
 ```
 
 ### Foundation tier
@@ -219,7 +248,7 @@ graph TD
     EDSUP --> PM["Port.Manager"]
     EDSUP --> ED["Editor"]
 
-    PM -. "stdin/stdout<br/>Port protocol" .-> ZIG_R["minga-renderer<br/><i>Zig + libvaxis</i>"]
+    PM -. "stdin/stdout<br/>Port protocol" .-> FE["Frontend<br/><i>Swift/Metal, GTK4, or Zig/libvaxis</i>"]
     PARSER -. "stdin/stdout<br/>Port protocol" .-> ZIG_P["minga-parser<br/><i>Zig + tree-sitter</i>"]
 
     style RT fill:#b7950b,stroke:#9a7d0a,color:#fff
@@ -228,7 +257,7 @@ graph TD
     style ED fill:#b7950b,stroke:#9a7d0a,color:#fff
     style WD fill:#b7950b,stroke:#9a7d0a,color:#fff
     style FW fill:#b7950b,stroke:#9a7d0a,color:#fff
-    style ZIG_R fill:#1e8449,stroke:#196f3d,color:#fff
+    style FE fill:#1e8449,stroke:#196f3d,color:#fff
     style ZIG_P fill:#1e8449,stroke:#196f3d,color:#fff
 ```
 
@@ -240,24 +269,33 @@ The system degrades in pieces rather than failing all at once. The BEAM was desi
 
 ---
 
-## Why Zig for Rendering?
+## Why Native Frontends?
 
-The BEAM is excellent at concurrency and isolation. It is terrible at drawing characters on a terminal. It has no concept of raw terminal mode, ANSI escape sequences, or low-level input decoding.
+The BEAM is excellent at concurrency and isolation. It is terrible at putting pixels on screen. It has no concept of terminal modes, GPU rendering, or native window systems. Minga solves this by running frontends as separate OS processes that communicate with the BEAM over a binary protocol.
 
-Rather than fight this with NIFs (which run inside the BEAM process and compromise isolation when they fail) or Ports to C (which require manual memory management), Minga uses **Zig**:
+### Platform-native rendering (GUI-first)
 
-- **No hidden allocations:** every byte of memory is explicit
+Minga's primary frontends use platform-native toolkits for the best possible user experience:
+
+- **macOS: Swift + Metal.** SwiftUI renders chrome (tab bar, file tree, status bar, popups) as native views. Metal renders the editor text surface with GPU-accelerated glyph rasterization via CoreText. This gives macOS users native scrolling, system fonts, trackpad gestures, and full accessibility support.
+- **Linux: GTK4 (planned).** GTK4 widgets for chrome, Cairo or OpenGL for the text surface. Native Wayland/X11 integration, IME support, system theming.
+- **TUI: Zig + libvaxis.** For terminal users. [libvaxis](https://github.com/rockorager/libvaxis) handles terminal differences, Unicode width calculation, and cell-level diffing.
+
+Each frontend is a "dumb" renderer: it reads binary commands from stdin, draws them, and writes input events back to stdout. All intelligence lives in the BEAM.
+
+### Why Zig for the TUI and parser?
+
+Zig fills two roles: the TUI terminal renderer and the tree-sitter parser process. It's a good fit for both because:
+
 - **Compiles C natively:** tree-sitter grammars (written in C) compile as part of the Zig build with zero FFI overhead
-- **Safety without runtime cost:** bounds checking, null safety in debug; zero overhead in release
+- **No hidden allocations:** important for the parser's memory-sensitive hot loop
 - **Single binary output:** no dynamic linking, no runtime dependencies
-
-The Zig process uses [libvaxis](https://github.com/rockorager/libvaxis) for terminal rendering, a modern library that handles the enormous complexity of terminal emulator differences, Unicode width calculation, and efficient screen updates.
 
 ### Why not a NIF?
 
 NIFs (Native Implemented Functions) run inside the BEAM process. A failure in a NIF takes down the entire Erlang VM: every buffer, every process, everything. This directly contradicts Minga's isolation model.
 
-A Port is an OS-level process boundary. The Zig renderer can fail completely, and the BEAM keeps running. The supervisor detects the Port died, restarts the Port Manager, and the Editor re-renders. Your data stays intact because it lives in completely separate processes.
+A Port is an OS-level process boundary. A frontend can crash completely, and the BEAM keeps running. The supervisor detects the Port died, restarts the Port Manager, and the Editor re-renders. Your data stays intact because it lives in completely separate processes.
 
 ---
 
@@ -271,39 +309,36 @@ The protocol has 20+ opcodes covering rendering, input, syntax highlighting, and
 
 ```mermaid
 graph LR
-    subgraph ZigToBEAM["Zig → BEAM"]
+    subgraph FrontendToBEAM["Frontend → BEAM"]
         K["0x01 Key Press<br/>codepoint::32, mods::8"]
         R["0x02 Resize<br/>width::16, height::16"]
-        RDY["0x03 Ready<br/>width::16, height::16"]
-        M["0x04 Mouse<br/>row, col, button, mods, type"]
+        RDY["0x03 Ready<br/>width::16, height::16, capabilities"]
+        M["0x04 Mouse<br/>row, col, button, mods, type, clicks"]
+        GA["0x07 GUI Action<br/>tab click, tree click, etc."]
         HS["0x30 Highlight Spans<br/>version, count, [start, end, id]"]
         HN["0x31 Highlight Names<br/>count, [len, name]"]
-        GL["0x32 Grammar Loaded<br/>success, name"]
     end
 
-    subgraph BEAMToZig["BEAM → Zig"]
+    subgraph BEAMToFrontend["BEAM → Frontend"]
         DT["0x10 Draw Text<br/>row, col, fg, bg, attrs, text"]
         SC["0x11 Set Cursor<br/>row::16, col::16"]
         CL["0x12 Clear"]
         BE["0x13 Batch End<br/>(flush frame)"]
         CS["0x15 Cursor Shape<br/>block/beam/underline"]
-        SL["0x20 Set Language"]
-        PB["0x21 Parse Buffer"]
-        SH["0x22 Set Highlight Query"]
-        LG["0x23 Load Grammar"]
+        GUI["0x70-0x78 GUI Chrome<br/>tabs, tree, status, popups"]
     end
 
-    style ZigToBEAM fill:#1a2e1a,stroke:#1e8449,color:#fff
-    style BEAMToZig fill:#1a1a2e,stroke:#6c3483,color:#fff
+    style FrontendToBEAM fill:#1a2e1a,stroke:#1e8449,color:#fff
+    style BEAMToFrontend fill:#1a1a2e,stroke:#6c3483,color:#fff
 ```
 
-For the full specification with byte-level field descriptions, sequencing rules, and implementation guidance, see **[docs/PROTOCOL.md](PROTOCOL.md)**. That document is the authoritative reference for anyone implementing a Minga frontend.
+For the full specification with byte-level field descriptions, sequencing rules, and implementation guidance, see **[docs/PROTOCOL.md](PROTOCOL.md)**. For the GUI chrome opcodes sent only to native frontends (SwiftUI, GTK4), see **[docs/GUI_PROTOCOL.md](GUI_PROTOCOL.md)**.
 
-Any process that implements the `Minga.Port.Frontend` behaviour (see `lib/minga/port/frontend.ex`) and speaks this protocol can serve as a Minga rendering backend.
+Any process that implements the `Minga.Port.Frontend` behaviour (see `lib/minga/port/frontend.ex`) and speaks this protocol can serve as a Minga rendering backend. The macOS Swift frontend and Zig TUI are the current implementations; a GTK4 Linux frontend is planned.
 
 ### Display List (Rendering IR)
 
-The BEAM side owns a **display list** of styled text runs that sits between editor state and protocol encoding. This intermediate representation is the single source of truth for "what's on screen" and is consumed by all frontends (TUI, future macOS GUI, future Linux GUI).
+The BEAM side owns a **display list** of styled text runs that sits between editor state and protocol encoding. This intermediate representation is the single source of truth for "what's on screen" and is consumed by all frontends (macOS GUI, Linux GUI, TUI).
 
 The display list uses **styled text runs**, not a cell grid. A cell grid is terminal-shaped and would force GUI frontends to fake a terminal. Styled text runs stay line-and-column based (monospaced editing model) while being abstract enough for both TUI and GUI frontends:
 
@@ -323,11 +358,11 @@ The display list uses **styled text runs**, not a cell grid. A cell grid is term
 }
 ```
 
-Each frontend does the last-mile translation. The TUI frontend converts text runs into terminal cells (a run `{5, "hello", green}` becomes five green cells at columns 5-9). A GUI frontend converts the same run into an attributed string draw at a pixel position derived from the monospaced font metrics. The IR doesn't change; only the frontend's interpretation does.
+Each frontend does the last-mile translation. The macOS GUI converts text runs into CoreText attributed strings drawn on a Metal surface at pixel positions derived from the font metrics. The TUI frontend converts text runs into terminal cells (a run `{5, "hello", green}` becomes five green cells at columns 5-9). The IR doesn't change; only the frontend's interpretation does.
 
-This design also keeps the door open for variable-width font support in future GUI frontends. The IR uses character offsets, not pixel positions. A monospaced frontend multiplies by cell width; a proportional frontend measures the preceding characters to find the pixel X. The `measure_text` / `text_width` protocol opcodes handle the cases where the BEAM needs to query the frontend for precise measurements.
+GUI frontends also receive **structured chrome data** (opcodes 0x70-0x78) for native UI elements: tab bars, file trees, status bars, which-key popups, completion menus, and agent chat views. These are rendered as platform-native widgets (SwiftUI views, GTK4 widgets) rather than painted as cells. See **[docs/GUI_PROTOCOL.md](GUI_PROTOCOL.md)** for the full specification.
 
-See **[docs/RENDERING_GAPS.md](RENDERING_GAPS.md)** for the full rendering pipeline analysis and implementation plan.
+This design also supports variable-width font rendering in GUI frontends. The IR uses character offsets, not pixel positions. A monospaced frontend multiplies by cell width; a proportional frontend measures the preceding characters to find the pixel X. The `measure_text` / `text_width` protocol opcodes handle the cases where the BEAM needs to query the frontend for precise measurements.
 
 ---
 
@@ -337,16 +372,14 @@ Here's what happens when you press `dd` (delete a line) in normal mode. The enti
 
 ```mermaid
 sequenceDiagram
-    participant Term as Terminal
-    participant Zig as Zig Process
+    participant FE as Frontend<br/>(Swift, GTK4, or Zig)
     participant PM as Port.Manager
     participant Ed as Editor
     participant Mode as Mode.Normal
     participant Buf as Buffer.Server
 
-    Term->>Zig: raw key bytes
-    Zig->>Zig: libvaxis decodes key
-    Zig->>PM: key_press(0x01) via stdout
+    FE->>FE: decode platform input event
+    FE->>PM: key_press(0x01) via stdout
 
     Note over Ed,Mode: First 'd'
     PM->>Ed: {:key_event, :d}
@@ -364,9 +397,8 @@ sequenceDiagram
     Note over Ed,Term: Render cycle
     Ed->>Ed: build render snapshot
     Ed->>PM: [clear, draw_text x N, set_cursor, batch_end]
-    PM->>Zig: render commands via stdin
-    Zig->>Zig: update cell grid (double-buffered)
-    Zig->>Term: write changed cells
+    PM->>FE: render commands via stdin
+    FE->>FE: render to screen (Metal/GTK4/terminal)
 ```
 
 ### Keymap Scopes
@@ -621,10 +653,11 @@ LSP communication, file indexing, git operations: these can run as separate BEAM
 
 These guide what we build and how:
 
+- **GUI-first, TUI-capable** — Design for native GUI frontends (Swift/Metal, GTK4) first. The TUI is a capable fallback, like Emacs's terminal mode, not the primary target.
 - **Fault tolerance over speed** — The BEAM's supervision model means crashes are recoverable events, not catastrophes.
-- **Two-process isolation** — Editor state and rendering never share memory; either can fail independently.
+- **Process isolation** — Editor state and rendering never share memory; either can fail independently. Multiple frontends can exist because the protocol enforces this boundary.
 - **Vim grammar, modern UX** — Modal editing with discoverable leader-key menus.
-- **Elixir for logic, Zig for pixels** — Each language where it excels.
+- **Elixir for logic, platform-native rendering** — The BEAM handles everything a text editor needs to think about. Swift, GTK4, and Zig handle everything a display needs to draw.
 - **Test everything** — Property-based tests for data structures, snapshot tests for UI, integration tests for the full pipeline.
 - **Convention over configuration** — Minga ships working defaults for everything: theme, keybindings, tab width, formatters, LSP servers. A fresh install with no config file should feel like Doom Emacs on day one. Your `config.exs` is a diff, not a manifest; it contains only what you've changed. Defaults are inspectable (`:set` shows current values, `SPC h k` shows bindings and whether they're defaults or overrides) and never hidden so deep that users can't find them.
 - **Core vs. extension** — If a Doom Emacs user installs Minga with zero configuration, would they expect this feature to work? If yes, it ships built-in. If it's a power-user addition, a niche workflow, or a matter of taste, it's an extension. Built-in features that touch only public APIs should be architected as if they were extensions (clean boundary, no internal coupling) so extraction is possible later. See `docs/AUTHORING_EXTENSIONS.md` for the full philosophy.
@@ -638,7 +671,7 @@ Honest accounting of what this architecture costs:
 | Trade-off | Why we accept it |
 |-----------|-----------------|
 | **Serialization overhead** (every render frame crosses a process boundary) | The protocol is ~50 bytes per draw command. At 60fps with 50 visible lines, that's ~150KB/s, trivial for a pipe. |
-| **Two binaries to ship** (Elixir release + Zig executable) | Burrito packages everything into a single distributable binary. |
+| **Multiple binaries to ship** (Elixir release + platform frontend) | macOS: `.app` bundle. Linux: Flatpak/AppImage. TUI: Burrito single binary. |
 | **BEAM startup time** (the Erlang VM isn't instant) | ~200ms cold start. Acceptable for an editor you keep open. |
 | **Memory overhead** (the BEAM VM has a baseline footprint) | ~30MB for the VM + processes. Comparable to Neovim with plugins. |
 | **Latency floor** (message passing adds microseconds vs direct function calls) | Measured end-to-end keystroke latency is <1ms. Below human perception. |

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -334,11 +334,22 @@ Note: GUI chrome commands are sent after `batch_end`. They are separate from the
 
 ## Implementation References
 
+### BEAM (canonical source of truth)
+
 | Component | File | Language |
 |-----------|------|----------|
 | Encoder | `lib/minga/port/protocol/gui.ex` | Elixir |
 | Theme slot mapping | `lib/minga/theme/slots.ex` | Elixir |
+| Integration tests | `test/minga/integration/gui_protocol_test.exs` | Elixir |
+
+### macOS GUI
+
+| Component | File | Language |
+|-----------|------|----------|
 | Decoder | `macos/Sources/Protocol/ProtocolDecoder.swift` | Swift |
 | Constants | `macos/Sources/Protocol/ProtocolConstants.swift` | Swift |
 | Test harness | `macos/TestHarness/main.swift` | Swift |
-| Integration tests | `test/minga/integration/gui_protocol_test.exs` | Elixir |
+
+### Linux GUI (planned)
+
+The GTK4 frontend will need its own protocol decoder implementing the same opcodes. When building it, use the BEAM encoder and integration tests as the reference, not the Swift decoder (which may have platform-specific assumptions).

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,6 +1,6 @@
 # Minga Port Protocol Specification
 
-The BEAM editor core and the rendering frontend communicate over a binary protocol on stdin/stdout of the frontend process. This document is the authoritative reference for implementing a Minga frontend. You should be able to build a working frontend by reading only this file.
+The BEAM editor core and rendering frontends communicate over a binary protocol on stdin/stdout of each frontend process. All frontends (Swift/Metal on macOS, GTK4 on Linux, Zig/libvaxis TUI) speak the same base protocol. GUI frontends additionally receive structured chrome opcodes documented in [GUI_PROTOCOL.md](GUI_PROTOCOL.md). This document is the authoritative reference for implementing a Minga frontend. You should be able to build a working frontend by reading only this file (plus GUI_PROTOCOL.md for native GUIs).
 
 ## Transport
 
@@ -627,17 +627,9 @@ Total size: 4 + msg_len bytes.
 
 ### Current design
 
-The Zig process currently handles both rendering and tree-sitter parsing. The TUI runtime intercepts highlight opcodes before the renderer. The GUI runtime does not, so highlight opcodes are silently no-op'd.
+Tree-sitter parsing runs in a dedicated `minga-parser` Zig process, separate from the rendering frontend. The renderer process handles only render commands (`0x10`-`0x1B` plus GUI chrome `0x70`-`0x78`). The parser process handles highlight commands (`0x20`-`0x26`) and sends highlight responses (`0x30`-`0x39`). Both use the same `{:packet, 4}` framing on their respective stdin/stdout pipes. The BEAM manages both Port processes, routing commands to the appropriate one.
 
-### Planned evolution
-
-Tree-sitter parsing will be extracted into a separate `minga-parser` process (see #150). When this happens:
-- The **renderer** process handles only render commands (`0x10`-`0x16`)
-- The **parser** process handles only highlight commands (`0x20`-`0x25`) and sends highlight responses (`0x30`-`0x34`)
-- Both use the same `{:packet, 4}` framing on their respective stdin/stdout pipes
-- The BEAM manages two Port processes, routing commands to the appropriate one
-
-This separation means new rendering frontends (Swift, GTK4) only need to implement render commands. Tree-sitter parsing is handled by the shared parser process.
+This separation means rendering frontends (Swift/Metal, GTK4, Zig/libvaxis) only need to implement render commands. Tree-sitter parsing is handled by the shared parser process regardless of which frontend is active.
 
 ---
 

--- a/docs/RENDERING_GAPS.md
+++ b/docs/RENDERING_GAPS.md
@@ -6,7 +6,7 @@ This document was originally written to identify missing architectural primitive
 
 ## Architecture Overview
 
-Minga's two-process architecture (BEAM for logic, Zig for terminal output) remains the foundation. The BEAM side owns all rendering decisions: layout, content composition, dirty tracking, caching. The Zig side is a thin terminal adapter that receives draw commands and puts cells on screen via libvaxis.
+Minga's multi-process architecture (BEAM for logic, platform-native frontends for display) is the foundation. The BEAM side owns all rendering decisions: layout, content composition, dirty tracking, caching. Frontends are thin adapters that receive draw commands and put pixels on screen. The macOS GUI (Swift/Metal) renders editor content on a Metal surface and chrome via SwiftUI. The TUI (Zig/libvaxis) renders to terminal cells. A Linux GUI (GTK4) is planned.
 
 The rendering pipeline lives in `Minga.Editor.RenderPipeline` and runs seven named stages per frame:
 
@@ -133,15 +133,20 @@ With all gaps closed, the rendering pipeline has these properties:
 - **Context changes** (entering/leaving visual mode, search highlight updates, new syntax highlights) trigger full redraws via the context fingerprint mechanism.
 - **Per-stage timing** is available at debug log level for profiling.
 
-## Relationship to the Zig Renderer
+## Relationship to the Frontends
 
-The Zig side (`zig/src/renderer.zig`) is intentionally thin: ~430 lines that translate protocol commands into libvaxis cell writes. It handles:
+Each frontend is intentionally thin. The BEAM side's dirty-line tracking reduces how much data crosses the Port boundary; the frontend's own optimizations reduce how much data hits the display.
 
-- `draw_text`: grapheme iteration, display width calculation, cell writes with region clipping
-- `set_cursor` / `set_cursor_shape`: cursor positioning
-- `define_region` / `set_active_region` / `clear_region`: region management
-- `batch_end`: triggers libvaxis frame diff and terminal flush
+### macOS GUI (Swift/Metal)
 
-libvaxis provides cell-level diffing (only changed cells are written to the terminal), grapheme cluster handling, and terminal capability detection. The BEAM side's dirty-line tracking reduces how much data crosses the Port boundary; libvaxis's cell diffing reduces how much data hits the terminal. Both layers contribute to rendering efficiency.
+The macOS frontend (`macos/Sources/`) handles two categories of rendering:
+- **Editor surface:** Metal renders the cell grid (text content, gutter, minibuffer). `CommandDispatcher` routes decoded commands to `CellGrid`, and `MetalRenderer` paints the grid with instanced glyph draws.
+- **Native chrome:** SwiftUI views render tab bar, file tree, status bar, which-key popup, completion menu, breadcrumb, and agent chat. These consume structured data from GUI chrome opcodes (0x70-0x78), not cell-grid commands.
 
-The `Surface` interface (`zig/src/surface.zig`) abstracts the terminal backend, enabling future backends (e.g., a Metal-based GUI surface) to implement the same 7-method interface without changing the renderer or protocol.
+### TUI (Zig/libvaxis)
+
+The Zig renderer (`zig/src/renderer.zig`) is ~430 lines that translate protocol commands into libvaxis cell writes. It handles `draw_text`, `set_cursor`, region management, and `batch_end` (which triggers libvaxis's cell-level diffing and terminal flush). libvaxis provides grapheme cluster handling and terminal capability detection.
+
+### Linux GUI (GTK4, planned)
+
+Will follow the same architecture as macOS: platform-native widgets for chrome, GPU-accelerated or Cairo-based rendering for the editor text surface. Implements the same protocol spec documented in [PROTOCOL.md](PROTOCOL.md) and [GUI_PROTOCOL.md](GUI_PROTOCOL.md).


### PR DESCRIPTION
## What

Updates 5 documentation files to reflect the GUI-first strategic direction: native frontends (Swift/Metal on macOS, GTK4 on Linux) lead the design, with the TUI as a capable fallback. Think Emacs: the GUI is the primary experience, the terminal mode benefits from the same core improvements.

## Why

The docs and AGENTS.md were written when the Zig TUI was the only frontend. Now that the macOS GUI exists and a GTK4 Linux frontend is planned, every document that says "Zig renderer" or "two processes" needs to reflect the multi-frontend reality. Agents reading AGENTS.md were getting stale context about the project direction.

## Changes

### AGENTS.md (root)
- New "Strategic Direction: GUI-First" section
- Tech stack: Swift/Metal (primary), GTK4 (planned), Zig (TUI)
- Project structure: includes `macos/` directory
- Commit scopes: added `macos`, `gtk`
- Port protocol: references PROTOCOL.md and GUI_PROTOCOL.md instead of stale PLAN.md
- Rendering architecture: mentions GUI chrome protocol
- Mouse support: lists all frontends
- New render command guide: covers macOS, TUI, and future GTK4

### docs/ARCHITECTURE.md
- Big Idea diagram: shows Swift, GTK4, and Zig frontends instead of just Zig
- Supervision tree: generalized "Frontend Process" instead of "Zig Process"
- New "Why Native Frontends?" section replacing "Why Zig for Rendering?"
- Life of a Keystroke: generalized frontend participant
- Protocol diagram: shows GUI chrome opcodes and gui_action input
- Design principles: "GUI-first, TUI-capable" and "platform-native rendering"
- Trade-offs: updated binary shipping row

### docs/RENDERING_GAPS.md
- Frontend-agnostic architecture overview
- Per-frontend sections (macOS GUI, TUI, Linux GUI planned)

### docs/PROTOCOL.md
- Multi-frontend opening paragraph
- Updated architecture notes reflecting parser extraction

### docs/GUI_PROTOCOL.md
- Per-platform implementation reference tables
- GTK4 guidance for future implementors

## GitHub Issues Updated

- **#571** (Linux GUI): rewritten from Zig+Vulkan to GTK4
- **#554** (macOS GUI epic): elevated priority comment
- **#737** (render pipeline split): elevated priority comment
- **#569** (Linux distribution): GTK4/Flatpak guidance
- **#613** (smooth scroll): GUI path prioritized
- **#195** (TUI bypass libvaxis): deprioritized with comment
