### PR TITLE
docs(agents): add dual-surface rule for modeline/status bar features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,6 +448,9 @@ When implementing features, completing planned work, or changing architecture:
 
 ## Adding New Features
 
+### Dual-surface rule for status/chrome features
+Any new modeline data (diagnostic counts, indent info, selection size, etc.) must appear in **both** the cell-painted TUI modeline (`Chrome.TUI`) and the GUI status bar (`ProtocolGUI.encode_gui_status_bar/1`). The GUI status bar opcode (0x76) uses structured data with explicit fields, so adding new data means extending the wire format in `docs/PROTOCOL.md` and updating `gui_protocol_test.exs`. Design the GUI status bar fields first, then map them into TUI modeline cells. Forgetting to update one surface is a common mistake.
+
 ### New command
 1. Add the command to the appropriate `Commands.*` sub-module's `__commands__/0` (implements `Minga.Command.Provider` behaviour). Include name, description, `requires_buffer` flag, and execute function. If no existing sub-module fits, create a new one and add it to the `@command_modules` list in `Minga.Command.Registry`.
 2. Add keybinding in `Minga.Keymap.Defaults`


### PR DESCRIPTION
## What

Adds a guideline to the "Adding New Features" section of AGENTS.md: any new modeline data must be added to both the cell-painted TUI modeline (`Chrome.TUI`) and the GUI status bar (`ProtocolGUI.encode_gui_status_bar/1`). Design the GUI fields first, then map to TUI cells.

## Why

Archie flagged this as a real risk during the GUI-first issue audit. Forgetting to update one surface when adding a feature is a common mistake. This makes the dual-surface requirement explicit so agents and contributors don't miss it.

## Also done (GitHub issue body updates, no code changes)

Updated the bodies of 11 open issues with GUI-first architectural guidance:
- #585, #584 (modeline): dual-surface requirement
- #132 (soft-wrap): WidthOracle behaviour for proportional fonts
- #74 (ghost text): display list decoration, not frontend-native
- #122, #19 (terminal): BEAM owns PTY, native terminal widgets per frontend
- #305 (browser): WebKitGTK for GTK4
- #234 (context menu): GtkPopoverMenu for GTK4
- #539 (copy from chat): native text selection in GUI
- #39 (emoji): GUI gets correct rendering from platform text stack