### PR TITLE
refactor(events): convert SyncServer and GitTracker to buffer_changed subscribers

### DIFF
--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -79,9 +79,6 @@ defmodule Minga.Events do
     @type t :: %__MODULE__{old: atom(), new: atom()}
   end
 
-  alias Minga.Git.Tracker, as: GitTracker
-  alias Minga.LSP.SyncServer
-
   # ── Types ───────────────────────────────────────────────────────────────────
 
   @typedoc "Known event topics."
@@ -179,17 +176,15 @@ defmodule Minga.Events do
   end
 
   @doc """
-  Broadcasts `:buffer_changed` and notifies LSP sync and Git tracker.
+  Broadcasts `:buffer_changed` to all subscribers.
 
-  This is the single call site for the buffer-changed notification sequence.
+  Convenience wrapper that constructs the typed payload struct.
   Callers that modify buffer content should call this instead of manually
-  broadcasting + notifying each subscriber.
+  building a `BufferChangedEvent` and calling `broadcast/2`.
   """
   @spec notify_buffer_changed(pid()) :: :ok
   def notify_buffer_changed(buf) when is_pid(buf) do
     broadcast(:buffer_changed, %BufferChangedEvent{buffer: buf})
-    SyncServer.notify_change(buf)
-    GitTracker.notify_change(buf)
   end
 
   # ── Query ───────────────────────────────────────────────────────────────────

--- a/lib/minga/git/tracker.ex
+++ b/lib/minga/git/tracker.ex
@@ -60,37 +60,6 @@ defmodule Minga.Git.Tracker do
     ArgumentError -> false
   end
 
-  @doc """
-  Notifies the git buffer that tracked content has changed.
-
-  Reads the current buffer content and sends it to the `Git.Buffer` for
-  diff recomputation. No-op if the buffer has no git tracking. Safe to
-  call from any process.
-  """
-  @spec notify_change(term()) :: :ok
-  def notify_change(buffer_pid) when not is_pid(buffer_pid) do
-    Minga.Log.warning(
-      :editor,
-      "[Git.Tracker] notify_change called with non-pid: #{inspect(buffer_pid)}"
-    )
-
-    :ok
-  end
-
-  def notify_change(buffer_pid) when is_pid(buffer_pid) do
-    case lookup(buffer_pid) do
-      nil ->
-        :ok
-
-      git_pid ->
-        {content, _cursor} = BufferServer.content_and_cursor(buffer_pid)
-        GitBuffer.update(git_pid, content)
-        :ok
-    end
-  catch
-    :exit, _ -> :ok
-  end
-
   # ── GenServer callbacks ────────────────────────────────────────────────
 
   @impl true
@@ -105,11 +74,21 @@ defmodule Minga.Git.Tracker do
 
     Minga.Events.subscribe(:buffer_opened)
     Minga.Events.subscribe(:buffer_saved)
+    Minga.Events.subscribe(:buffer_changed)
 
     {:ok, %{monitors: %{}}}
   end
 
   @impl true
+  def handle_info(
+        {:minga_event, :buffer_changed, %Minga.Events.BufferChangedEvent{buffer: buf}},
+        state
+      )
+      when is_pid(buf) do
+    do_notify_change(buf)
+    {:noreply, state}
+  end
+
   def handle_info(
         {:minga_event, :buffer_opened, %Minga.Events.BufferEvent{buffer: buf, path: path}},
         state
@@ -142,6 +121,21 @@ defmodule Minga.Git.Tracker do
   def handle_info(_msg, state), do: {:noreply, state}
 
   # ── Private ────────────────────────────────────────────────────────────
+
+  @spec do_notify_change(pid()) :: :ok
+  defp do_notify_change(buffer_pid) do
+    case lookup(buffer_pid) do
+      nil ->
+        :ok
+
+      git_pid ->
+        {content, _cursor} = BufferServer.content_and_cursor(buffer_pid)
+        GitBuffer.update(git_pid, content)
+        :ok
+    end
+  catch
+    :exit, _ -> :ok
+  end
 
   @spec maybe_start_git_buffer(map(), pid(), String.t()) :: map()
   defp maybe_start_git_buffer(state, buffer_pid, path) do

--- a/lib/minga/lsp/sync_server.ex
+++ b/lib/minga/lsp/sync_server.ex
@@ -14,14 +14,12 @@ defmodule Minga.LSP.SyncServer do
 
   ## Event subscriptions
 
-  | Event            | Action                                         |
-  |------------------|-------------------------------------------------|
-  | `:buffer_opened` | Detect filetype, start LSP clients, send didOpen |
-  | `:buffer_saved`  | Send didSave to attached clients                 |
-  | `:buffer_closed` | Send didClose, remove tracking                   |
-
-  Content changes (`:buffer_changed`) are handled via `notify_change/1`,
-  which debounces didChange notifications per-buffer.
+  | Event              | Action                                           |
+  |--------------------|--------------------------------------------------|
+  | `:buffer_opened`   | Detect filetype, start LSP clients, send didOpen  |
+  | `:buffer_saved`    | Send didSave to attached clients                   |
+  | `:buffer_closed`   | Send didClose, remove tracking                     |
+  | `:buffer_changed`  | Debounce and send didChange to attached clients    |
   """
 
   use GenServer
@@ -66,18 +64,6 @@ defmodule Minga.LSP.SyncServer do
     ArgumentError -> []
   end
 
-  @doc """
-  Notifies the sync server that a buffer's content changed.
-
-  Debounces didChange notifications: rapid edits coalesce into a single
-  notification after #{@debounce_ms}ms of quiet. Call this after any
-  editing operation (insert, delete, paste, undo, completion accept).
-  """
-  @spec notify_change(pid()) :: :ok
-  def notify_change(buffer_pid) when is_pid(buffer_pid) do
-    GenServer.cast(__MODULE__, {:buffer_changed, buffer_pid})
-  end
-
   # ── GenServer callbacks ────────────────────────────────────────────────
 
   @impl true
@@ -93,16 +79,19 @@ defmodule Minga.LSP.SyncServer do
     Events.subscribe(:buffer_opened)
     Events.subscribe(:buffer_saved)
     Events.subscribe(:buffer_closed)
+    Events.subscribe(:buffer_changed)
 
     {:ok, %{debounce_timers: %{}}}
   end
 
   @impl true
-  def handle_cast({:buffer_changed, buffer_pid}, state) do
-    {:noreply, schedule_did_change(state, buffer_pid)}
+  def handle_info(
+        {:minga_event, :buffer_changed, %Events.BufferChangedEvent{buffer: buf}},
+        state
+      ) do
+    {:noreply, schedule_did_change(state, buf)}
   end
 
-  @impl true
   def handle_info(
         {:minga_event, :buffer_opened, %Events.BufferEvent{buffer: buf, path: _path}},
         state

--- a/test/minga/git/tracker_test.exs
+++ b/test/minga/git/tracker_test.exs
@@ -70,7 +70,7 @@ defmodule Minga.Git.TrackerTest do
     end
   end
 
-  describe "notify_change/1" do
+  describe "buffer_changed event" do
     test "updates git buffer diff when content changes", %{root: dir} do
       path = Path.join(dir, "tracker_change_#{:rand.uniform(100_000)}.ex")
       File.write!(path, "line1\nline2\n")
@@ -81,7 +81,10 @@ defmodule Minga.Git.TrackerTest do
       assert_until(fn -> Tracker.tracked?(buf) end)
 
       BufferServer.insert_text(buf, "new line\n")
-      Tracker.notify_change(buf)
+      Events.notify_buffer_changed(buf)
+
+      # Sync to flush the event through Tracker's mailbox.
+      :sys.get_state(Tracker)
 
       git_pid = Tracker.lookup(buf)
       assert is_pid(git_pid)
@@ -89,13 +92,8 @@ defmodule Minga.Git.TrackerTest do
 
     test "no-op for untracked buffer" do
       {:ok, buf} = BufferServer.start_link(content: "hello")
-      assert :ok = Tracker.notify_change(buf)
-    end
-
-    test "logs warning for non-pid argument" do
-      import ExUnit.CaptureLog
-      log = capture_log(fn -> assert :ok = Tracker.notify_change(:not_a_pid) end)
-      assert log =~ "[Git.Tracker] notify_change called with non-pid"
+      Events.notify_buffer_changed(buf)
+      :sys.get_state(Tracker)
     end
   end
 

--- a/test/minga/lsp/sync_server_test.exs
+++ b/test/minga/lsp/sync_server_test.exs
@@ -43,10 +43,11 @@ defmodule Minga.LSP.SyncServerTest do
     end
   end
 
-  describe "notify_change/1" do
+  describe "buffer_changed event" do
     test "no-op for buffer with no clients" do
       {:ok, buf} = BufferServer.start_link(content: "hello")
-      assert :ok = SyncServer.notify_change(buf)
+      Events.notify_buffer_changed(buf)
+      :sys.get_state(SyncServer)
     end
 
     test "schedules debounced didChange" do
@@ -55,9 +56,11 @@ defmodule Minga.LSP.SyncServerTest do
       # Insert a fake client entry.
       :ets.insert(SyncServer.Registry, {buf, [self()]})
 
-      SyncServer.notify_change(buf)
+      Events.notify_buffer_changed(buf)
 
-      # The debounce timer should be set in SyncServer state.
+      # Sync call to flush the event message through SyncServer's mailbox.
+      :sys.get_state(SyncServer)
+
       state = :sys.get_state(SyncServer)
       assert Map.has_key?(state.debounce_timers, buf)
     end


### PR DESCRIPTION
## What

Converts `SyncServer` and `GitTracker` from direct calls in `Events.notify_buffer_changed/1` to proper event bus subscribers. Both processes now subscribe to `:buffer_changed` in their `init/1` and handle the event in `handle_info`, matching the pattern they already use for other events.

## Why

`Events.notify_buffer_changed/1` coupled the event bus to specific consumers by calling them directly. This inverts the event bus pattern (publishers broadcast, subscribers listen) and means adding a new consumer requires modifying the Events module.

## Changes

- **`Events.notify_buffer_changed/1`** now only calls `broadcast/2`. Aliases to SyncServer and GitTracker removed.
- **`SyncServer`** subscribes to `:buffer_changed` in `init/1`, handles it in `handle_info`, debounce logic unchanged. `notify_change/1` removed.
- **`GitTracker`** subscribes to `:buffer_changed` in `init/1`, handles it in `handle_info`. `notify_change/1` removed, logic moved to private `do_notify_change/1`.
- **Tests** updated to use `Events.notify_buffer_changed/1` + `:sys.get_state` sync barriers.

Side benefit: GitTracker's content read + diff update now runs in its own process instead of blocking the Editor.

Closes #790