### PR TITLE
fix(macos): allow typing 'y' in agent chat insert mode

### DIFF
--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -243,6 +243,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Create the editor view.
         let nsView = EditorNSView(encoder: enc, fontFace: face, lineBuffer: disp.lineBuffer,
                                    coreTextRenderer: ctRenderer, fontManager: fm)
+        nsView.statusBarState = appState.gui.statusBarState
         self.editorNSView = nsView
         appState.editorNSView = nsView
 

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -54,6 +54,11 @@ final class EditorNSView: MTKView {
     private(set) var agentChatVisible: Bool = false
     private var agentKeyMonitor: Any?
 
+    /// Status bar state from the BEAM. Used by the agent key monitor to
+    /// check the current vim mode so `y` is only intercepted as copy in
+    /// normal mode, not swallowed while the user is typing in insert mode.
+    var statusBarState: StatusBarState?
+
     init(encoder: InputEncoder, fontFace: FontFace, lineBuffer: LineBuffer,
          coreTextRenderer: CoreTextMetalRenderer, fontManager: FontManager) {
         self.encoder = encoder
@@ -257,11 +262,14 @@ final class EditorNSView: MTKView {
                 return nil
             }
 
-            // `y` with no modifiers: trigger copy, swallow the event.
-            // Without swallowing, the BEAM enters operator-pending yank
-            // mode and the next keypress is misinterpreted as a motion.
+            // `y` with no modifiers in normal mode: trigger copy, swallow
+            // the event. Without swallowing, the BEAM enters operator-pending
+            // yank mode and the next keypress is misinterpreted as a motion.
+            // Only intercept in normal mode (mode == 0) so the user can still
+            // type `y` in the agent chat input field during insert mode.
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            if event.characters == "y" && flags.isEmpty {
+            let isNormalMode = self.statusBarState?.mode == 0
+            if event.characters == "y" && flags.isEmpty && isNormalMode {
                 NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: nil)
                 return nil
             }


### PR DESCRIPTION
## Problem

Typing `y` in the agent chat input field while in insert mode was impossible. The letter was silently swallowed, so typing "hey" produced "he".

## Root Cause

The `installAgentKeyMonitor()` in `EditorNSView.swift` unconditionally intercepted all bare `y` keypresses and routed them to `NSText.copy()`. This was meant to handle vim-style yank in agent normal mode (where the BEAM can't access SwiftUI text selections), but it fired in every mode, including insert.

## Fix

Gate the `y` intercept on normal mode only (`statusBarState.mode == 0`). The `StatusBarState` is already updated by the BEAM every frame via the GUI status bar protocol opcode, so the mode check is always current.

Changes:
- Add `statusBarState` property to `EditorNSView`
- Wire it from `AppDelegate` at init time
- Check `isNormalMode` before intercepting `y`

## Testing

- Build compiles clean (`xcodebuild build -scheme minga-mac`)
- `mix lint` passes
- Manual verification needed: type `hey` in agent chat input