### PR TITLE
refactor(commands): GUI/TUI dispatch pattern + SPC b m opens bottom panel

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -649,6 +649,23 @@ LSP communication, file indexing, git operations: these can run as separate BEAM
 
 ---
 
+## GUI/TUI Command Branching
+
+Commands that open GUI-native chrome (bottom panel, native pickers, native tooltips) need a TUI fallback that does something reasonable with the TUI's tools (gap buffers, popup windows, cell-grid overlays). The branching uses `Capabilities.gui?` at runtime since the frontend type isn't known at compile time.
+
+**Established pattern:** follow the Chrome module's approach. `Chrome` dispatches to `Chrome.TUI` / `Chrome.GUI` submodules. Command modules with GUI/TUI branches use `Commands.Foo.GUI` and `Commands.Foo.TUI` submodules with a `Frontend` behaviour and a single dispatch in the parent. Already implemented in `Commands.UI` and `Commands.BufferManagement`. For simpler cases with 1-2 branches that don't warrant submodules, inline `if Capabilities.gui?` checks are acceptable.
+
+```
+lib/minga/editor/commands/
+  buffer_management.ex          # shared commands + dispatch
+  buffer_management/gui.ex      # GUI-specific (bottom panel, native UI)
+  buffer_management/tui.ex      # TUI-specific (gap buffers, popups)
+```
+
+The dispatch helper lives in the parent module (not a shared utility), since each command group may dispatch on different capabilities.
+
+---
+
 ## Design Principles
 
 These guide what we build and how:

--- a/lib/minga/editor/commands/buffer_management.ex
+++ b/lib/minga/editor/commands/buffer_management.ex
@@ -145,20 +145,8 @@ defmodule Minga.Editor.Commands.BufferManagement do
     end
   end
 
-  def execute(%{buffers: %{messages: nil}} = state, :view_messages) do
-    %{state | status_msg: "No messages buffer"}
-  end
-
-  def execute(%{buffers: %{messages: msg_buf}} = state, :view_messages) do
-    open_special_buffer(state, "*Messages*", msg_buf)
-  end
-
-  def execute(state, :view_warnings) do
-    alias Minga.Editor.BottomPanel
-    # Open bottom panel with warnings filter preset (#825)
-    new_panel = BottomPanel.show(state.bottom_panel, :messages, :warnings)
-    %{state | bottom_panel: new_panel}
-  end
+  def execute(state, :view_messages), do: frontend(state).view_messages(state)
+  def execute(state, :view_warnings), do: frontend(state).view_warnings(state)
 
   def execute(state, {:open_special_buffer, buffer_name, buffer_pid})
       when is_binary(buffer_name) and is_pid(buffer_pid) do
@@ -1010,8 +998,12 @@ defmodule Minga.Editor.Commands.BufferManagement do
   # Opens a special buffer (like *Messages* or *Warnings*) as a popup if a
   # matching popup rule exists, otherwise falls back to normal buffer switching.
   # If the buffer is already open in a popup, toggles it closed.
+  @doc """
+  Opens a special buffer in a popup window (TUI) or switches to it.
+  Public so `BufferManagement.TUI` can call it for TUI fallback paths.
+  """
   @spec open_special_buffer(state(), String.t(), pid()) :: state()
-  defp open_special_buffer(state, buffer_name, buffer_pid) do
+  def open_special_buffer(state, buffer_name, buffer_pid) do
     case find_popup_for_buffer(state, buffer_pid) do
       {:ok, popup_window_id} ->
         # Toggle: close the existing popup
@@ -1178,8 +1170,8 @@ defmodule Minga.Editor.Commands.BufferManagement do
       },
       %Minga.Command{
         name: :view_messages,
-        description: "View *Messages* buffer",
-        requires_buffer: true,
+        description: "Show messages in bottom panel",
+        requires_buffer: false,
         execute: fn state -> execute(state, :view_messages) end
       },
       %Minga.Command{
@@ -1264,5 +1256,13 @@ defmodule Minga.Editor.Commands.BufferManagement do
     ]
 
     standard ++ tabs ++ scoped
+  end
+
+  # ── Frontend dispatch ─────────────────────────────────────────────────────
+
+  @spec frontend(state()) :: module()
+  defp frontend(%{capabilities: caps}) do
+    alias Minga.Port.Capabilities
+    if Capabilities.gui?(caps), do: __MODULE__.GUI, else: __MODULE__.TUI
   end
 end

--- a/lib/minga/editor/commands/buffer_management/frontend.ex
+++ b/lib/minga/editor/commands/buffer_management/frontend.ex
@@ -1,0 +1,13 @@
+defmodule Minga.Editor.Commands.BufferManagement.Frontend do
+  @moduledoc """
+  Behaviour for GUI/TUI variant dispatch of buffer management commands.
+
+  Commands that show messages or warnings use the bottom panel on GUI
+  and gap buffers in popup windows on TUI.
+  """
+
+  alias Minga.Editor.State, as: EditorState
+
+  @callback view_messages(EditorState.t()) :: EditorState.t()
+  @callback view_warnings(EditorState.t()) :: EditorState.t()
+end

--- a/lib/minga/editor/commands/buffer_management/gui.ex
+++ b/lib/minga/editor/commands/buffer_management/gui.ex
@@ -1,0 +1,22 @@
+defmodule Minga.Editor.Commands.BufferManagement.GUI do
+  @moduledoc "GUI variant of buffer management commands. Uses the bottom panel."
+
+  @behaviour Minga.Editor.Commands.BufferManagement.Frontend
+
+  alias Minga.Editor.BottomPanel
+  alias Minga.Editor.State, as: EditorState
+
+  @impl true
+  @spec view_messages(EditorState.t()) :: EditorState.t()
+  def view_messages(state) do
+    new_panel = BottomPanel.show(state.bottom_panel, :messages)
+    %{state | bottom_panel: new_panel}
+  end
+
+  @impl true
+  @spec view_warnings(EditorState.t()) :: EditorState.t()
+  def view_warnings(state) do
+    new_panel = BottomPanel.show(state.bottom_panel, :messages, :warnings)
+    %{state | bottom_panel: new_panel}
+  end
+end

--- a/lib/minga/editor/commands/buffer_management/tui.ex
+++ b/lib/minga/editor/commands/buffer_management/tui.ex
@@ -1,0 +1,29 @@
+defmodule Minga.Editor.Commands.BufferManagement.TUI do
+  @moduledoc "TUI variant of buffer management commands. Opens gap buffers in windows."
+
+  @behaviour Minga.Editor.Commands.BufferManagement.Frontend
+
+  alias Minga.Editor.Commands.BufferManagement
+  alias Minga.Editor.State, as: EditorState
+
+  @impl true
+  @spec view_messages(EditorState.t()) :: EditorState.t()
+  def view_messages(%{buffers: %{messages: nil}} = state) do
+    %{state | status_msg: "No messages buffer"}
+  end
+
+  def view_messages(%{buffers: %{messages: msg_buf}} = state) do
+    BufferManagement.open_special_buffer(state, "*Messages*", msg_buf)
+  end
+
+  @impl true
+  @spec view_warnings(EditorState.t()) :: EditorState.t()
+  def view_warnings(%{buffers: %{messages: nil}} = state) do
+    %{state | status_msg: "No messages buffer"}
+  end
+
+  def view_warnings(%{buffers: %{messages: msg_buf}} = state) do
+    # Warnings appear in *Messages* with [WARN] prefix (no separate buffer)
+    BufferManagement.open_special_buffer(state, "*Messages*", msg_buf)
+  end
+end

--- a/lib/minga/editor/commands/ui.ex
+++ b/lib/minga/editor/commands/ui.ex
@@ -7,10 +7,10 @@ defmodule Minga.Editor.Commands.UI do
 
   @behaviour Minga.Command.Provider
 
-  alias Minga.Editor.BottomPanel
   alias Minga.Editor.PickerUI
   alias Minga.Editor.State, as: EditorState
   alias Minga.Parser.Manager, as: ParserManager
+  alias Minga.Port.Capabilities
 
   @impl Minga.Command.Provider
   def __commands__ do
@@ -79,18 +79,17 @@ defmodule Minga.Editor.Commands.UI do
   end
 
   @spec toggle_bottom_panel(EditorState.t()) :: EditorState.t()
-  defp toggle_bottom_panel(state) do
-    %{state | bottom_panel: BottomPanel.toggle(state.bottom_panel)}
-  end
+  defp toggle_bottom_panel(state), do: frontend(state).toggle_bottom_panel(state)
 
   @spec bottom_panel_next_tab(EditorState.t()) :: EditorState.t()
-  defp bottom_panel_next_tab(state) do
-    %{state | bottom_panel: BottomPanel.next_tab(state.bottom_panel)}
-  end
+  defp bottom_panel_next_tab(state), do: frontend(state).bottom_panel_next_tab(state)
 
   @spec bottom_panel_prev_tab(EditorState.t()) :: EditorState.t()
-  defp bottom_panel_prev_tab(state) do
-    %{state | bottom_panel: BottomPanel.prev_tab(state.bottom_panel)}
+  defp bottom_panel_prev_tab(state), do: frontend(state).bottom_panel_prev_tab(state)
+
+  @spec frontend(EditorState.t()) :: module()
+  defp frontend(%{capabilities: caps}) do
+    if Capabilities.gui?(caps), do: __MODULE__.GUI, else: __MODULE__.TUI
   end
 
   @spec execute_parser_restart(EditorState.t()) :: EditorState.t()

--- a/lib/minga/editor/commands/ui/frontend.ex
+++ b/lib/minga/editor/commands/ui/frontend.ex
@@ -1,0 +1,15 @@
+defmodule Minga.Editor.Commands.UI.Frontend do
+  @moduledoc """
+  Behaviour for GUI/TUI variant dispatch of UI commands.
+
+  Commands that interact with GUI chrome (bottom panel, native pickers)
+  implement this behaviour in both `UI.GUI` and `UI.TUI` submodules.
+  The parent `UI` module dispatches based on `Capabilities.gui?`.
+  """
+
+  alias Minga.Editor.State, as: EditorState
+
+  @callback toggle_bottom_panel(EditorState.t()) :: EditorState.t()
+  @callback bottom_panel_next_tab(EditorState.t()) :: EditorState.t()
+  @callback bottom_panel_prev_tab(EditorState.t()) :: EditorState.t()
+end

--- a/lib/minga/editor/commands/ui/gui.ex
+++ b/lib/minga/editor/commands/ui/gui.ex
@@ -1,0 +1,26 @@
+defmodule Minga.Editor.Commands.UI.GUI do
+  @moduledoc "GUI variant of UI commands. Uses the bottom panel."
+
+  @behaviour Minga.Editor.Commands.UI.Frontend
+
+  alias Minga.Editor.BottomPanel
+  alias Minga.Editor.State, as: EditorState
+
+  @impl true
+  @spec toggle_bottom_panel(EditorState.t()) :: EditorState.t()
+  def toggle_bottom_panel(state) do
+    %{state | bottom_panel: BottomPanel.toggle(state.bottom_panel)}
+  end
+
+  @impl true
+  @spec bottom_panel_next_tab(EditorState.t()) :: EditorState.t()
+  def bottom_panel_next_tab(state) do
+    %{state | bottom_panel: BottomPanel.next_tab(state.bottom_panel)}
+  end
+
+  @impl true
+  @spec bottom_panel_prev_tab(EditorState.t()) :: EditorState.t()
+  def bottom_panel_prev_tab(state) do
+    %{state | bottom_panel: BottomPanel.prev_tab(state.bottom_panel)}
+  end
+end

--- a/lib/minga/editor/commands/ui/tui.ex
+++ b/lib/minga/editor/commands/ui/tui.ex
@@ -1,0 +1,19 @@
+defmodule Minga.Editor.Commands.UI.TUI do
+  @moduledoc "TUI variant of UI commands. Panel commands are no-ops."
+
+  @behaviour Minga.Editor.Commands.UI.Frontend
+
+  alias Minga.Editor.State, as: EditorState
+
+  @impl true
+  @spec toggle_bottom_panel(EditorState.t()) :: EditorState.t()
+  def toggle_bottom_panel(state), do: state
+
+  @impl true
+  @spec bottom_panel_next_tab(EditorState.t()) :: EditorState.t()
+  def bottom_panel_next_tab(state), do: state
+
+  @impl true
+  @spec bottom_panel_prev_tab(EditorState.t()) :: EditorState.t()
+  def bottom_panel_prev_tab(state), do: state
+end

--- a/test/minga/editor/commands/buffer_management_frontend_test.exs
+++ b/test/minga/editor/commands/buffer_management_frontend_test.exs
@@ -1,0 +1,53 @@
+defmodule Minga.Editor.Commands.BufferManagement.FrontendTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.BottomPanel
+  alias Minga.Editor.Commands.BufferManagement.GUI, as: BufGUI
+  alias Minga.Editor.Commands.BufferManagement.TUI, as: BufTUI
+
+  defp base_state(opts \\ []) do
+    %{
+      bottom_panel: %BottomPanel{},
+      buffers: %{messages: Keyword.get(opts, :messages)},
+      status_msg: nil
+    }
+  end
+
+  describe "GUI.view_messages/1" do
+    test "opens bottom panel on messages tab" do
+      state = BufGUI.view_messages(base_state())
+      assert state.bottom_panel.visible == true
+      assert state.bottom_panel.active_tab == :messages
+      assert state.bottom_panel.filter == nil
+    end
+
+    test "clears dismissed state" do
+      state = %{base_state() | bottom_panel: %BottomPanel{dismissed: true}}
+      state = BufGUI.view_messages(state)
+      assert state.bottom_panel.dismissed == false
+    end
+  end
+
+  describe "GUI.view_warnings/1" do
+    test "opens bottom panel with warnings filter" do
+      state = BufGUI.view_warnings(base_state())
+      assert state.bottom_panel.visible == true
+      assert state.bottom_panel.active_tab == :messages
+      assert state.bottom_panel.filter == :warnings
+    end
+  end
+
+  describe "TUI.view_messages/1" do
+    test "returns status message when no messages buffer" do
+      state = BufTUI.view_messages(base_state(messages: nil))
+      assert state.status_msg == "No messages buffer"
+    end
+  end
+
+  describe "TUI.view_warnings/1" do
+    test "returns status message when no messages buffer" do
+      state = BufTUI.view_warnings(base_state(messages: nil))
+      assert state.status_msg == "No messages buffer"
+    end
+  end
+end

--- a/test/minga/editor/commands/ui_frontend_test.exs
+++ b/test/minga/editor/commands/ui_frontend_test.exs
@@ -1,0 +1,65 @@
+defmodule Minga.Editor.Commands.UI.FrontendTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.BottomPanel
+  alias Minga.Editor.Commands.UI.GUI, as: UIGUI
+  alias Minga.Editor.Commands.UI.TUI, as: UITUI
+
+  defp base_state do
+    %{bottom_panel: %BottomPanel{}}
+  end
+
+  describe "GUI.toggle_bottom_panel/1" do
+    test "opens panel when hidden" do
+      state = UIGUI.toggle_bottom_panel(base_state())
+      assert state.bottom_panel.visible == true
+    end
+
+    test "closes panel when visible" do
+      state = %{base_state() | bottom_panel: %BottomPanel{visible: true}}
+      state = UIGUI.toggle_bottom_panel(state)
+      assert state.bottom_panel.visible == false
+    end
+  end
+
+  describe "GUI.bottom_panel_next_tab/1" do
+    test "cycles to next tab" do
+      state = %{
+        base_state()
+        | bottom_panel: %BottomPanel{tabs: [:messages, :diagnostics], active_tab: :messages}
+      }
+
+      state = UIGUI.bottom_panel_next_tab(state)
+      assert state.bottom_panel.active_tab == :diagnostics
+    end
+  end
+
+  describe "GUI.bottom_panel_prev_tab/1" do
+    test "cycles to previous tab" do
+      state = %{
+        base_state()
+        | bottom_panel: %BottomPanel{tabs: [:messages, :diagnostics], active_tab: :diagnostics}
+      }
+
+      state = UIGUI.bottom_panel_prev_tab(state)
+      assert state.bottom_panel.active_tab == :messages
+    end
+  end
+
+  describe "TUI variants are no-ops" do
+    test "toggle_bottom_panel returns state unchanged" do
+      state = base_state()
+      assert UITUI.toggle_bottom_panel(state) == state
+    end
+
+    test "bottom_panel_next_tab returns state unchanged" do
+      state = base_state()
+      assert UITUI.bottom_panel_next_tab(state) == state
+    end
+
+    test "bottom_panel_prev_tab returns state unchanged" do
+      state = base_state()
+      assert UITUI.bottom_panel_prev_tab(state) == state
+    end
+  end
+end

--- a/test/minga/editor/warnings_buffer_test.exs
+++ b/test/minga/editor/warnings_buffer_test.exs
@@ -3,32 +3,36 @@ defmodule Minga.Editor.WarningsBufferTest do
 
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.BottomPanel
+  alias Minga.Port.Capabilities
 
-  describe "warnings via bottom panel" do
+  # Helper to switch the editor to GUI capabilities so bottom panel commands work.
+  defp set_gui_capabilities(ctx) do
+    :sys.replace_state(ctx.editor, fn %{capabilities: %Capabilities{} = caps} = s ->
+      %{s | capabilities: %Capabilities{caps | frontend_type: :native_gui}}
+    end)
+  end
+
+  describe "warnings (GUI: bottom panel)" do
     test "SPC b W opens bottom panel with warnings filter" do
       ctx = start_editor("hello")
+      set_gui_capabilities(ctx)
       send_keys(ctx, "<SPC>bW")
 
       state = :sys.get_state(ctx.editor)
       assert state.bottom_panel.visible == true
       assert state.bottom_panel.active_tab == :messages
       assert state.bottom_panel.filter == :warnings
-      assert state.bottom_panel.dismissed == false
     end
 
     test "SPC b W resets dismissed state" do
       ctx = start_editor("hello")
+      set_gui_capabilities(ctx)
 
       # Dismiss the panel first
-      state = :sys.get_state(ctx.editor)
-      dismissed_panel = BottomPanel.dismiss(state.bottom_panel)
-      :sys.replace_state(ctx.editor, fn s -> %{s | bottom_panel: dismissed_panel} end)
+      :sys.replace_state(ctx.editor, fn s ->
+        %{s | bottom_panel: BottomPanel.dismiss(s.bottom_panel)}
+      end)
 
-      # Verify it's dismissed
-      state = :sys.get_state(ctx.editor)
-      assert state.bottom_panel.dismissed == true
-
-      # SPC b W should reset dismissed and open
       send_keys(ctx, "<SPC>bW")
       state = :sys.get_state(ctx.editor)
       assert state.bottom_panel.visible == true
@@ -37,7 +41,21 @@ defmodule Minga.Editor.WarningsBufferTest do
 
     test ":warnings ex-command opens bottom panel with warnings filter" do
       ctx = start_editor("hello")
+      set_gui_capabilities(ctx)
       send_keys(ctx, ":warnings<CR>")
+
+      state = :sys.get_state(ctx.editor)
+      assert state.bottom_panel.visible == true
+      assert state.bottom_panel.filter == :warnings
+    end
+
+    test "warning auto-opens bottom panel when not dismissed" do
+      ctx = start_editor("hello")
+      set_gui_capabilities(ctx)
+
+      Minga.Editor.log_to_warnings("test warning", ctx.editor)
+      Process.sleep(300)
+      :sys.get_state(ctx.editor)
 
       state = :sys.get_state(ctx.editor)
       assert state.bottom_panel.visible == true
@@ -46,67 +64,59 @@ defmodule Minga.Editor.WarningsBufferTest do
 
     test "warnings logged after dismissal do not auto-open panel" do
       ctx = start_editor("hello")
+      set_gui_capabilities(ctx)
 
-      # Dismiss the bottom panel
-      state = :sys.get_state(ctx.editor)
-      dismissed_panel = BottomPanel.dismiss(state.bottom_panel)
-      :sys.replace_state(ctx.editor, fn s -> %{s | bottom_panel: dismissed_panel} end)
+      :sys.replace_state(ctx.editor, fn s ->
+        %{s | bottom_panel: BottomPanel.dismiss(s.bottom_panel)}
+      end)
 
-      # Log a warning
       Minga.Editor.log_to_warnings("test warning after dismiss", ctx.editor)
-
-      # Wait for debounce timer (200ms) plus margin
       Process.sleep(300)
       :sys.get_state(ctx.editor)
 
       state = :sys.get_state(ctx.editor)
       assert state.bottom_panel.visible == false
-      assert state.bottom_panel.dismissed == true
-    end
-
-    test "warning auto-opens bottom panel when not dismissed" do
-      ctx = start_editor("hello")
-
-      # Ensure panel is not dismissed and not visible
-      state = :sys.get_state(ctx.editor)
-      assert state.bottom_panel.visible == false
-      assert state.bottom_panel.dismissed == false
-
-      # Log a warning
-      Minga.Editor.log_to_warnings("test warning", ctx.editor)
-
-      # Wait for debounce timer (200ms) plus margin
-      Process.sleep(300)
-      :sys.get_state(ctx.editor)
-
-      state = :sys.get_state(ctx.editor)
-      assert state.bottom_panel.visible == true
-      assert state.bottom_panel.filter == :warnings
     end
 
     test "warning does not change filter when panel already open on Messages tab" do
       ctx = start_editor("hello")
+      set_gui_capabilities(ctx)
 
-      # Open the panel manually (no filter preset)
+      # Open panel manually (no filter)
       send_keys(ctx, "<SPC>tp")
       state = :sys.get_state(ctx.editor)
       assert state.bottom_panel.visible == true
       assert state.bottom_panel.filter == nil
 
-      # Log a warning
       Minga.Editor.log_to_warnings("test warning", ctx.editor)
-
-      # Wait for debounce
       Process.sleep(300)
       :sys.get_state(ctx.editor)
 
-      # Filter should not have changed
       state = :sys.get_state(ctx.editor)
-      assert state.bottom_panel.visible == true
       assert state.bottom_panel.filter == nil
     end
+  end
 
-    test "warnings appear in *Messages* gap buffer for TUI" do
+  describe "warnings (TUI: *Messages* buffer fallback)" do
+    test "SPC b W opens *Messages* buffer on TUI" do
+      ctx = start_editor("hello")
+      send_keys(ctx, "<SPC>bW")
+
+      screen = screen_text(ctx)
+      all_text = Enum.join(screen, "\n")
+      assert String.contains?(all_text, "*Messages*")
+    end
+
+    test "SPC b m opens *Messages* buffer on TUI" do
+      ctx = start_editor("hello")
+      send_keys(ctx, "<SPC>bm")
+
+      screen = screen_text(ctx)
+      all_text = Enum.join(screen, "\n")
+      assert String.contains?(all_text, "*Messages*")
+    end
+
+    test "warnings appear in *Messages* gap buffer with [WARN] prefix" do
       ctx = start_editor("hello")
 
       Minga.Editor.log_to_warnings("something broke", ctx.editor)
@@ -124,9 +134,7 @@ defmodule Minga.Editor.WarningsBufferTest do
       :sys.get_state(ctx.editor)
 
       state = :sys.get_state(ctx.editor)
-      entries = state.message_store.entries
-
-      warning_entries = Enum.filter(entries, fn e -> e.level == :warning end)
+      warning_entries = Enum.filter(state.message_store.entries, fn e -> e.level == :warning end)
       assert warning_entries != []
       assert Enum.any?(warning_entries, fn e -> String.contains?(e.text, "something broke") end)
     end


### PR DESCRIPTION
## What

Extracts the GUI/TUI command branching into a clean dispatch pattern with compile-time enforcement via behaviours. Also wires `SPC b m` and `SPC b W` to open the bottom panel on GUI while preserving TUI fallback behavior.

## Pattern

Commands that interact with GUI chrome dispatch to `.GUI` and `.TUI` submodules via a `Frontend` behaviour:

```
Commands.BufferManagement.Frontend  # @callback view_messages/1, view_warnings/1
Commands.BufferManagement.GUI       # opens bottom panel
Commands.BufferManagement.TUI       # opens *Messages* gap buffer in window

Commands.UI.Frontend                # @callback toggle_bottom_panel/1, next/prev_tab
Commands.UI.GUI                     # bottom panel operations
Commands.UI.TUI                     # no-ops
```

Parent modules dispatch via `frontend(state).function_name(state)`, where `frontend/1` checks `Capabilities.gui?`.

## Behavior changes

- `SPC b m`: opens bottom panel (Messages tab) on GUI, `*Messages*` buffer on TUI
- `SPC b W`: opens bottom panel with warnings filter on GUI, `*Messages*` on TUI
- `SPC t p`: toggle bottom panel on GUI, no-op on TUI

Pattern documented in `docs/ARCHITECTURE.md` for future features.