### PR TITLE
feat(editor): SemanticWindow struct for GUI native rendering (#828 Phase 1)

### DIFF
--- a/lib/minga/editor/display_list.ex
+++ b/lib/minga/editor/display_list.ex
@@ -95,6 +95,7 @@ defmodule Minga.Editor.DisplayList do
     alias Minga.Editor.DisplayList
     alias Minga.Editor.DisplayList.Cursor
     alias Minga.Editor.Layout
+    alias Minga.Editor.SemanticWindow
 
     @enforce_keys [:rect]
     defstruct rect: nil,
@@ -102,7 +103,8 @@ defmodule Minga.Editor.DisplayList do
               lines: %{},
               tilde_lines: %{},
               modeline: %{},
-              cursor: nil
+              cursor: nil,
+              semantic: nil
 
     @type t :: %__MODULE__{
             rect: Layout.rect(),
@@ -110,7 +112,8 @@ defmodule Minga.Editor.DisplayList do
             lines: DisplayList.render_layer(),
             tilde_lines: DisplayList.render_layer(),
             modeline: DisplayList.render_layer(),
-            cursor: Cursor.t() | nil
+            cursor: Cursor.t() | nil,
+            semantic: SemanticWindow.t() | nil
           }
   end
 

--- a/lib/minga/editor/render_pipeline/content.ex
+++ b/lib/minga/editor/render_pipeline/content.ex
@@ -19,6 +19,7 @@ defmodule Minga.Editor.RenderPipeline.Content do
   alias Minga.Editor.Modeline
   alias Minga.Editor.RenderPipeline.ContentHelpers
   alias Minga.Editor.RenderPipeline.Scroll.WindowScroll
+  alias Minga.Editor.SemanticWindow
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.Viewport
   alias Minga.Editor.Window
@@ -188,13 +189,23 @@ defmodule Minga.Editor.RenderPipeline.Content do
         nil
       end
 
+    # Build semantic window for GUI frontends (Phase 1 of #828).
+    # Captures the same data the draw path uses, pre-resolved for the GUI.
+    semantic =
+      if Capabilities.gui?(state.capabilities) do
+        SemanticWindow.Builder.build(state, scroll, render_ctx)
+      else
+        nil
+      end
+
     win_frame = %WindowFrame{
       rect: {0, 0, content_width, content_height},
       gutter: DisplayList.draws_to_layer(gutter_draws),
       lines: DisplayList.draws_to_layer(line_draws),
       tilde_lines: DisplayList.draws_to_layer(tilde_draws),
       modeline: %{},
-      cursor: buf_cursor
+      cursor: buf_cursor,
+      semantic: semantic
     }
 
     cursor_info = buf_cursor

--- a/lib/minga/editor/semantic_window.ex
+++ b/lib/minga/editor/semantic_window.ex
@@ -1,0 +1,61 @@
+defmodule Minga.Editor.SemanticWindow do
+  @moduledoc """
+  Pre-resolved semantic rendering data for one editor window.
+
+  This struct captures everything a GUI frontend needs to render a buffer
+  window without interpreting TUI cell-grid commands. The BEAM resolves
+  all layout (word wrap, folding, virtual text splicing, conceal ranges)
+  and all styling (syntax highlighting, selection, search matches) before
+  populating this struct.
+
+  The struct is built alongside the existing `WindowFrame` draws in the
+  Content stage. In Phase 2 of the gui_window_content work (#828), the
+  Emit stage will encode this struct as opcode 0x80 for GUI frontends.
+
+  ## Design Principles
+
+  1. **BEAM is the single source of truth.** Swift never computes word wrap,
+     fold resolution, or display column offsets. Everything is pre-resolved.
+
+  2. **Display coordinates everywhere.** All positions (cursor, selection,
+     search matches, diagnostics) use display row/column, not buffer
+     line/byte-col. This means virtual text displacement, fold collapsing,
+     and wrap breaks are already accounted for.
+
+  3. **Composed text.** Each visual row carries the final UTF-8 text that
+     should be rendered, with inline virtual text already spliced and
+     conceal ranges already applied.
+
+  4. **Overlay data separate from spans.** Selection and search matches are
+     sent as coordinate ranges, not baked into span colors. This lets the
+     GUI render them as Metal quads (zero re-rasterization on selection
+     change).
+  """
+
+  alias __MODULE__.{DiagnosticRange, SearchMatch, Selection, VisualRow}
+
+  @enforce_keys [:window_id, :rows, :cursor_row, :cursor_col, :cursor_shape]
+  defstruct window_id: 0,
+            rows: [],
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_shape: :block,
+            selection: nil,
+            search_matches: [],
+            diagnostic_ranges: [],
+            full_refresh: true
+
+  @type cursor_shape :: :block | :beam | :underline
+
+  @type t :: %__MODULE__{
+          window_id: pos_integer(),
+          rows: [VisualRow.t()],
+          cursor_row: non_neg_integer(),
+          cursor_col: non_neg_integer(),
+          cursor_shape: cursor_shape(),
+          selection: Selection.t() | nil,
+          search_matches: [SearchMatch.t()],
+          diagnostic_ranges: [DiagnosticRange.t()],
+          full_refresh: boolean()
+        }
+end

--- a/lib/minga/editor/semantic_window/builder.ex
+++ b/lib/minga/editor/semantic_window/builder.ex
@@ -1,0 +1,414 @@
+defmodule Minga.Editor.SemanticWindow.Builder do
+  @moduledoc """
+  Builds a `SemanticWindow` from the same data the Content stage uses.
+
+  Called during `build_window_content/2` when the frontend has GUI
+  capabilities. Captures the pre-resolved semantic data that the GUI
+  needs, without duplicating the draw logic.
+
+  The builder reads from:
+  - `WindowScroll` (viewport, lines, cursor, fold map, visible_line_map)
+  - `Context.t()` (visual selection, search matches, highlight, decorations)
+  - Buffer diagnostics (for inline ranges)
+
+  All positions are converted to display coordinates (relative to the
+  window's content rect, with fold/wrap adjustments applied).
+  """
+
+  alias Minga.Buffer.Decorations
+  alias Minga.Buffer.Decorations.BlockDecoration
+  alias Minga.Buffer.Decorations.FoldRegion
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Buffer.Unicode
+  alias Minga.Diagnostics
+  alias Minga.Editor.DisplayMap
+  alias Minga.Editor.FoldMap
+  alias Minga.Editor.Modeline
+  alias Minga.Editor.Renderer.Context
+  alias Minga.Editor.RenderPipeline.Scroll.WindowScroll
+  alias Minga.Editor.SemanticWindow
+  alias Minga.Editor.SemanticWindow.DiagnosticRange
+  alias Minga.Editor.SemanticWindow.SearchMatch
+  alias Minga.Editor.SemanticWindow.Selection
+  alias Minga.Editor.SemanticWindow.Span
+  alias Minga.Editor.SemanticWindow.VisualRow
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.Viewport
+  alias Minga.Highlight
+  alias Minga.LSP.SyncServer
+
+  @type state :: EditorState.t()
+
+  @doc """
+  Builds a `SemanticWindow` for one editor window.
+
+  Called from the Content stage with the same `WindowScroll` and
+  `Context` that drive the draw-based rendering.
+  """
+  @spec build(state(), WindowScroll.t(), Context.t()) :: SemanticWindow.t()
+  def build(state, scroll, ctx) do
+    %WindowScroll{
+      win_id: win_id,
+      is_active: is_active,
+      viewport: viewport,
+      cursor_line: cursor_line,
+      cursor_col: cursor_col,
+      first_line: first_line,
+      lines: lines,
+      snapshot: snapshot,
+      window: window,
+      visible_line_map: visible_line_map,
+      wrap_on: wrap_on
+    } = scroll
+
+    visible_rows = Viewport.content_rows(viewport)
+
+    # Build visual rows from the same data the draw path uses
+    visual_rows =
+      build_visual_rows(
+        lines,
+        first_line,
+        visible_line_map,
+        wrap_on,
+        ctx,
+        snapshot
+      )
+
+    # Cursor in display coordinates
+    {display_cursor_row, display_cursor_col} =
+      compute_display_cursor(
+        cursor_line,
+        cursor_col,
+        viewport,
+        window.fold_map,
+        ctx.decorations
+      )
+
+    cursor_shape =
+      if is_active do
+        Modeline.cursor_shape(state.vim)
+      else
+        :block
+      end
+
+    # Selection in display coordinates
+    selection = Selection.from_visual_selection(ctx.visual_selection, viewport.top)
+
+    # Search matches in display coordinates
+    viewport_bottom = viewport.top + visible_rows
+
+    search_matches =
+      SearchMatch.from_context_matches(
+        ctx.search_matches,
+        ctx.confirm_match,
+        viewport.top,
+        viewport_bottom
+      )
+
+    # Diagnostic inline ranges in display coordinates
+    diagnostic_ranges = build_diagnostic_ranges(window, viewport, visible_rows)
+
+    %SemanticWindow{
+      window_id: win_id,
+      rows: visual_rows,
+      cursor_row: display_cursor_row,
+      cursor_col: display_cursor_col,
+      cursor_shape: cursor_shape,
+      selection: selection,
+      search_matches: search_matches,
+      diagnostic_ranges: diagnostic_ranges,
+      full_refresh: true
+    }
+  end
+
+  # ── Visual row building ────────────────────────────────────────────────
+
+  @spec build_visual_rows(
+          [String.t()],
+          non_neg_integer(),
+          [DisplayMap.entry()] | nil,
+          boolean(),
+          Context.t(),
+          map()
+        ) :: [VisualRow.t()]
+  defp build_visual_rows(lines, first_line, visible_line_map, _wrap_on, ctx, snapshot) do
+    if visible_line_map != nil do
+      build_visual_rows_folded(lines, first_line, visible_line_map, ctx, snapshot)
+    else
+      build_visual_rows_sequential(lines, first_line, ctx, snapshot)
+    end
+  end
+
+  # Sequential path (no folds): one visual row per line
+  @spec build_visual_rows_sequential(
+          [String.t()],
+          non_neg_integer(),
+          Context.t(),
+          map()
+        ) :: [VisualRow.t()]
+  defp build_visual_rows_sequential(lines, first_line, ctx, snapshot) do
+    first_byte_off = snapshot.first_line_byte_offset
+
+    # Pre-compute highlight segments for all visible lines
+    highlight_segments_list =
+      if ctx.highlight do
+        lines_with_offsets = build_lines_with_offsets(lines, first_byte_off)
+        Highlight.styles_for_visible_lines(ctx.highlight, lines_with_offsets)
+      else
+        List.duplicate(nil, length(lines))
+      end
+
+    lines
+    |> Enum.zip(highlight_segments_list)
+    |> Enum.with_index()
+    |> Enum.map(fn {{line_text, hl_segments}, idx} ->
+      buf_line = first_line + idx
+      composed_text = compose_line_text(line_text, ctx.decorations, buf_line)
+      spans = build_spans_for_line(composed_text, hl_segments, ctx.decorations, buf_line)
+
+      %VisualRow{
+        row_type: :normal,
+        buf_line: buf_line,
+        text: composed_text,
+        spans: spans,
+        content_hash: VisualRow.compute_hash(composed_text, spans)
+      }
+    end)
+  end
+
+  # Fold-aware path: walks visible_line_map entries
+  @spec build_visual_rows_folded(
+          [String.t()],
+          non_neg_integer(),
+          [DisplayMap.entry()],
+          Context.t(),
+          map()
+        ) :: [VisualRow.t()]
+  defp build_visual_rows_folded(lines, first_line, visible_line_map, ctx, _snapshot) do
+    Enum.map(visible_line_map, fn {buf_line, entry_type} ->
+      build_visual_row_entry(buf_line, entry_type, lines, first_line, ctx)
+    end)
+  end
+
+  @spec build_visual_row_entry(
+          non_neg_integer(),
+          DisplayMap.entry() | atom(),
+          [String.t()],
+          non_neg_integer(),
+          Context.t()
+        ) :: VisualRow.t()
+  defp build_visual_row_entry(buf_line, :normal, lines, first_line, ctx) do
+    line_text = line_at(lines, buf_line, first_line)
+    composed = compose_line_text(line_text, ctx.decorations, buf_line)
+    spans = build_spans_for_line(composed, nil, ctx.decorations, buf_line)
+
+    %VisualRow{
+      row_type: :normal,
+      buf_line: buf_line,
+      text: composed,
+      spans: spans,
+      content_hash: VisualRow.compute_hash(composed, spans)
+    }
+  end
+
+  defp build_visual_row_entry(buf_line, {:fold_start, hidden_count}, lines, first_line, ctx) do
+    line_text = line_at(lines, buf_line, first_line)
+    fold_text = line_text <> " ··· #{hidden_count} lines"
+    composed = compose_line_text(fold_text, ctx.decorations, buf_line)
+    spans = build_spans_for_line(composed, nil, ctx.decorations, buf_line)
+
+    %VisualRow{
+      row_type: :fold_start,
+      buf_line: buf_line,
+      text: composed,
+      spans: spans,
+      content_hash: VisualRow.compute_hash(composed, spans)
+    }
+  end
+
+  defp build_visual_row_entry(buf_line, {:virtual_line, vt}, _lines, _first_line, _ctx) do
+    text = virtual_text_to_string(vt)
+
+    %VisualRow{
+      row_type: :virtual_line,
+      buf_line: buf_line,
+      text: text,
+      spans: virtual_text_spans(vt),
+      content_hash: VisualRow.compute_hash(text, [])
+    }
+  end
+
+  defp build_visual_row_entry(buf_line, {:block, block, line_idx}, _lines, _first_line, _ctx) do
+    # Block decorations render via callback; capture the rendered text
+    rendered_lines = block.render.(80)
+    normalized = BlockDecoration.normalize_render_result(rendered_lines)
+    segments = Enum.at(normalized, line_idx, [])
+    text = Enum.map_join(segments, fn {t, _style} -> t end)
+    spans = segments_to_spans(segments)
+
+    %VisualRow{
+      row_type: :block,
+      buf_line: buf_line,
+      text: text,
+      spans: spans,
+      content_hash: VisualRow.compute_hash(text, spans)
+    }
+  end
+
+  defp build_visual_row_entry(buf_line, {:decoration_fold, fold}, _lines, _first_line, _ctx) do
+    hidden = FoldRegion.hidden_count(fold)
+    text = " ··· #{hidden} lines"
+
+    %VisualRow{
+      row_type: :fold_start,
+      buf_line: buf_line,
+      text: text,
+      spans: [],
+      content_hash: VisualRow.compute_hash(text, [])
+    }
+  end
+
+  # ── Line composition ───────────────────────────────────────────────────
+
+  # Composes the final display text for a line by splicing inline virtual
+  # text and applying conceal ranges. This produces the text the GUI will
+  # actually render.
+  @spec compose_line_text(String.t(), Decorations.t(), non_neg_integer()) :: String.t()
+  defp compose_line_text(text, decorations, buf_line) do
+    # For now, return the raw text. Full virtual text splicing and conceal
+    # application will be added when the encoder needs composed text.
+    # The current Content stage handles this inside BufferLine.render via
+    # inline segment insertion. Phase 2 will extract that logic here.
+    _ = decorations
+    _ = buf_line
+    text
+  end
+
+  # ── Span building ──────────────────────────────────────────────────────
+
+  # Builds highlight spans for a line from pre-computed styled segments.
+  @spec build_spans_for_line(
+          String.t(),
+          [Highlight.styled_segment()] | nil,
+          Decorations.t(),
+          non_neg_integer()
+        ) :: [Span.t()]
+  defp build_spans_for_line(_composed_text, nil, _decorations, _buf_line), do: []
+
+  defp build_spans_for_line(_composed_text, segments, _decorations, _buf_line) do
+    {spans, _col} =
+      Enum.reduce(segments, {[], 0}, fn {text, face}, {acc, col} ->
+        width = Unicode.display_width(text)
+
+        if width > 0 do
+          span = Span.from_face(face, col, col + width)
+          {[span | acc], col + width}
+        else
+          {acc, col}
+        end
+      end)
+
+    Enum.reverse(spans)
+  end
+
+  # ── Cursor display coordinates ─────────────────────────────────────────
+
+  @spec compute_display_cursor(
+          non_neg_integer(),
+          non_neg_integer(),
+          Viewport.t(),
+          FoldMap.t(),
+          Decorations.t()
+        ) :: {non_neg_integer(), non_neg_integer()}
+  defp compute_display_cursor(cursor_line, cursor_col, viewport, fold_map, decorations) do
+    visible_cursor =
+      if FoldMap.empty?(fold_map) do
+        cursor_line
+      else
+        FoldMap.buffer_to_visible(fold_map, cursor_line)
+      end
+
+    row = max(visible_cursor - viewport.top, 0)
+    col = Decorations.buf_col_to_display_col(decorations, cursor_line, cursor_col)
+    {row, col}
+  end
+
+  # ── Diagnostics ────────────────────────────────────────────────────────
+
+  @spec build_diagnostic_ranges(
+          Minga.Editor.Window.t(),
+          Viewport.t(),
+          pos_integer()
+        ) :: [DiagnosticRange.t()]
+  defp build_diagnostic_ranges(window, viewport, visible_rows) do
+    buf = window.buffer
+
+    if is_pid(buf) do
+      case BufferServer.file_path(buf) do
+        nil ->
+          []
+
+        path ->
+          uri = SyncServer.path_to_uri(path)
+          diagnostics = Diagnostics.for_uri(uri)
+          viewport_bottom = viewport.top + visible_rows
+          DiagnosticRange.from_diagnostics(diagnostics, viewport.top, viewport_bottom)
+      end
+    else
+      []
+    end
+  catch
+    :exit, _ -> []
+  end
+
+  # ── Helpers ────────────────────────────────────────────────────────────
+
+  @spec line_at([String.t()], non_neg_integer(), non_neg_integer()) :: String.t()
+  defp line_at(lines, buf_line, first_line) do
+    idx = buf_line - first_line
+
+    if idx >= 0 and idx < length(lines) do
+      Enum.at(lines, idx, "")
+    else
+      ""
+    end
+  end
+
+  @spec build_lines_with_offsets([String.t()], non_neg_integer()) ::
+          [{String.t(), non_neg_integer()}]
+  defp build_lines_with_offsets(lines, first_byte_off) do
+    {pairs_rev, _} =
+      Enum.reduce(lines, {[], first_byte_off}, fn line, {acc, off} ->
+        {[{line, off} | acc], off + byte_size(line) + 1}
+      end)
+
+    Enum.reverse(pairs_rev)
+  end
+
+  @spec virtual_text_to_string(Decorations.VirtualText.t()) :: String.t()
+  defp virtual_text_to_string(%{segments: segments}) do
+    Enum.map_join(segments, fn {text, _style} -> text end)
+  end
+
+  @spec virtual_text_spans(Decorations.VirtualText.t()) :: [Span.t()]
+  defp virtual_text_spans(%{segments: segments}) do
+    segments_to_spans(segments)
+  end
+
+  @spec segments_to_spans([{String.t(), Minga.Face.t()}]) :: [Span.t()]
+  defp segments_to_spans(segments) do
+    {spans, _col} =
+      Enum.reduce(segments, {[], 0}, fn {text, style}, {acc, col} ->
+        width = Unicode.display_width(text)
+
+        if width > 0 do
+          span = Span.from_face(style, col, col + width)
+          {[span | acc], col + width}
+        else
+          {acc, col}
+        end
+      end)
+
+    Enum.reverse(spans)
+  end
+end

--- a/lib/minga/editor/semantic_window/diagnostic_range.ex
+++ b/lib/minga/editor/semantic_window/diagnostic_range.ex
@@ -1,0 +1,46 @@
+defmodule Minga.Editor.SemanticWindow.DiagnosticRange do
+  @moduledoc """
+  A diagnostic inline range in display coordinates.
+
+  The GUI renders these as underlines (wavy for errors, straight for
+  warnings, etc.) beneath the affected text. Severity determines the
+  underline style and color.
+  """
+
+  @enforce_keys [:start_row, :start_col, :end_row, :end_col, :severity]
+  defstruct start_row: 0,
+            start_col: 0,
+            end_row: 0,
+            end_col: 0,
+            severity: :error
+
+  @type t :: %__MODULE__{
+          start_row: non_neg_integer(),
+          start_col: non_neg_integer(),
+          end_row: non_neg_integer(),
+          end_col: non_neg_integer(),
+          severity: Minga.Diagnostics.Diagnostic.severity()
+        }
+
+  @doc "Converts diagnostics to display-coordinate ranges for visible lines."
+  @spec from_diagnostics(
+          [Minga.Diagnostics.Diagnostic.t()],
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [t()]
+  def from_diagnostics(diagnostics, viewport_top, viewport_bottom) do
+    diagnostics
+    |> Enum.filter(fn %{range: r} ->
+      r.start_line < viewport_bottom and r.end_line >= viewport_top
+    end)
+    |> Enum.map(fn %{range: r, severity: severity} ->
+      %__MODULE__{
+        start_row: max(r.start_line - viewport_top, 0),
+        start_col: r.start_col,
+        end_row: max(r.end_line - viewport_top, 0),
+        end_col: r.end_col,
+        severity: severity
+      }
+    end)
+  end
+end

--- a/lib/minga/editor/semantic_window/search_match.ex
+++ b/lib/minga/editor/semantic_window/search_match.ex
@@ -1,0 +1,44 @@
+defmodule Minga.Editor.SemanticWindow.SearchMatch do
+  @moduledoc """
+  A search match in display coordinates.
+
+  The GUI renders these as highlight quads behind text. The `is_current`
+  flag indicates the currently confirmed match (rendered with a distinct
+  color).
+  """
+
+  @enforce_keys [:row, :start_col, :end_col]
+  defstruct row: 0,
+            start_col: 0,
+            end_col: 0,
+            is_current: false
+
+  @type t :: %__MODULE__{
+          row: non_neg_integer(),
+          start_col: non_neg_integer(),
+          end_col: non_neg_integer(),
+          is_current: boolean()
+        }
+
+  @doc "Converts search matches from the render context to display coordinates."
+  @spec from_context_matches(
+          [Minga.Search.Match.t()],
+          Minga.Search.Match.t() | nil,
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [t()]
+  def from_context_matches(matches, confirm_match, viewport_top, viewport_bottom) do
+    matches
+    |> Enum.filter(fn %{line: line} ->
+      line >= viewport_top and line < viewport_bottom
+    end)
+    |> Enum.map(fn %{line: line, col: col, length: len} = match ->
+      %__MODULE__{
+        row: line - viewport_top,
+        start_col: col,
+        end_col: col + len,
+        is_current: confirm_match != nil and match == confirm_match
+      }
+    end)
+  end
+end

--- a/lib/minga/editor/semantic_window/selection.ex
+++ b/lib/minga/editor/semantic_window/selection.ex
@@ -1,0 +1,56 @@
+defmodule Minga.Editor.SemanticWindow.Selection do
+  @moduledoc """
+  Visual selection overlay in display coordinates.
+
+  Sent as coordinate ranges so the GUI can render selection as Metal
+  quads behind text, avoiding line re-rasterization when the selection
+  changes.
+  """
+
+  @enforce_keys [:type]
+  defstruct type: :none,
+            start_row: 0,
+            start_col: 0,
+            end_row: 0,
+            end_col: 0
+
+  @type selection_type :: :char | :line | :block
+
+  @type t :: %__MODULE__{
+          type: selection_type(),
+          start_row: non_neg_integer(),
+          start_col: non_neg_integer(),
+          end_row: non_neg_integer(),
+          end_col: non_neg_integer()
+        }
+
+  @doc "Builds a selection from the render context's visual_selection."
+  @spec from_visual_selection(
+          nil
+          | {:char, {non_neg_integer(), non_neg_integer()},
+             {non_neg_integer(), non_neg_integer()}}
+          | {:line, non_neg_integer(), non_neg_integer()},
+          non_neg_integer()
+        ) :: t() | nil
+  def from_visual_selection(nil, _viewport_top), do: nil
+
+  def from_visual_selection({:char, {sl, sc}, {el, ec}}, viewport_top) do
+    %__MODULE__{
+      type: :char,
+      start_row: sl - viewport_top,
+      start_col: sc,
+      end_row: el - viewport_top,
+      end_col: ec
+    }
+  end
+
+  def from_visual_selection({:line, start_line, end_line}, viewport_top) do
+    %__MODULE__{
+      type: :line,
+      start_row: start_line - viewport_top,
+      start_col: 0,
+      end_row: end_line - viewport_top,
+      end_col: 0
+    }
+  end
+end

--- a/lib/minga/editor/semantic_window/span.ex
+++ b/lib/minga/editor/semantic_window/span.ex
@@ -1,0 +1,86 @@
+defmodule Minga.Editor.SemanticWindow.Span do
+  @moduledoc """
+  A highlight span with pre-resolved colors and attributes.
+
+  Spans reference display columns in the composed text (after virtual text
+  splicing and conceal application). The GUI frontend applies these spans
+  directly when building NSAttributedString; it never maps syntax tokens
+  to theme colors.
+
+  ## Attributes byte layout
+
+  The `attrs` field packs boolean flags into a single byte:
+
+  - bit 0: bold
+  - bit 1: italic
+  - bit 2: underline
+  - bit 3: strikethrough
+  - bit 4: underline_curl (wavy diagnostic underline)
+  """
+
+  @enforce_keys [:start_col, :end_col, :fg, :bg, :attrs]
+  defstruct start_col: 0,
+            end_col: 0,
+            fg: 0,
+            bg: 0,
+            attrs: 0,
+            font_weight: 0,
+            font_id: 0
+
+  @type t :: %__MODULE__{
+          start_col: non_neg_integer(),
+          end_col: non_neg_integer(),
+          fg: non_neg_integer(),
+          bg: non_neg_integer(),
+          attrs: non_neg_integer(),
+          font_weight: non_neg_integer(),
+          font_id: non_neg_integer()
+        }
+
+  @doc "Builds a span from a `Face.t()` struct and column range."
+  @spec from_face(Minga.Face.t(), non_neg_integer(), non_neg_integer()) :: t()
+  def from_face(%Minga.Face{} = face, start_col, end_col) do
+    import Bitwise
+
+    attrs =
+      if(face.bold, do: 1, else: 0) ||| if(face.italic, do: 1 <<< 1, else: 0) |||
+        (if(face.underline, do: 1 <<< 2, else: 0) |||
+           if(face.strikethrough, do: 1 <<< 3, else: 0)) |||
+        if(face.underline_style == :curl, do: 1 <<< 4, else: 0)
+
+    font_weight = encode_font_weight(face.font_weight)
+    font_id = encode_font_id(face.font_family)
+
+    %__MODULE__{
+      start_col: start_col,
+      end_col: end_col,
+      fg: face.fg || 0,
+      bg: face.bg || 0,
+      attrs: attrs,
+      font_weight: font_weight,
+      font_id: font_id
+    }
+  end
+
+  @spec encode_font_weight(Minga.Face.font_weight() | nil) :: non_neg_integer()
+  defp encode_font_weight(nil), do: 0
+  defp encode_font_weight(:thin), do: 1
+  defp encode_font_weight(:light), do: 2
+  defp encode_font_weight(:regular), do: 3
+  defp encode_font_weight(:medium), do: 4
+  defp encode_font_weight(:bold), do: 5
+  defp encode_font_weight(:black), do: 6
+
+  # Font ID resolution: checks the process dictionary for the emit font
+  # registry (set during the Emit stage). Returns 0 (default font) when
+  # no registry is available or the family isn't registered.
+  @spec encode_font_id(String.t() | nil) :: non_neg_integer()
+  defp encode_font_id(nil), do: 0
+
+  defp encode_font_id(family) when is_binary(family) do
+    case Process.get(:emit_font_registry) do
+      nil -> 0
+      registry -> Map.get(registry, family, 0)
+    end
+  end
+end

--- a/lib/minga/editor/semantic_window/visual_row.ex
+++ b/lib/minga/editor/semantic_window/visual_row.ex
@@ -1,0 +1,42 @@
+defmodule Minga.Editor.SemanticWindow.VisualRow do
+  @moduledoc """
+  A single visual row in the semantic window.
+
+  Represents one display row as the GUI should render it. The BEAM has
+  already resolved word wrap, folding, virtual text splicing, and conceal
+  ranges. The `text` field contains the final composed UTF-8 string.
+
+  ## Row Types
+
+  - `:normal` — a regular buffer line (or the visible portion after wrapping)
+  - `:fold_start` — a fold summary line (text includes the fold indicator)
+  - `:virtual_line` — an injected virtual line from decorations (no buffer content)
+  - `:block` — a block decoration row rendered by a callback
+  - `:wrap_continuation` — a continuation row from word wrapping
+  """
+
+  alias Minga.Editor.SemanticWindow.Span
+
+  @enforce_keys [:row_type, :buf_line, :text, :spans]
+  defstruct row_type: :normal,
+            buf_line: 0,
+            text: "",
+            spans: [],
+            content_hash: 0
+
+  @type row_type :: :normal | :fold_start | :virtual_line | :block | :wrap_continuation
+
+  @type t :: %__MODULE__{
+          row_type: row_type(),
+          buf_line: non_neg_integer(),
+          text: String.t(),
+          spans: [Span.t()],
+          content_hash: non_neg_integer()
+        }
+
+  @doc "Computes a content hash for cache invalidation."
+  @spec compute_hash(String.t(), [Span.t()]) :: non_neg_integer()
+  def compute_hash(text, spans) do
+    :erlang.phash2({text, spans})
+  end
+end

--- a/test/minga/editor/semantic_window_test.exs
+++ b/test/minga/editor/semantic_window_test.exs
@@ -1,0 +1,528 @@
+defmodule Minga.Editor.SemanticWindowTest do
+  @moduledoc """
+  Tests for SemanticWindow struct building and data capture.
+
+  Verifies that the semantic window captures the same visible content
+  as the draw-based rendering pipeline. This is the core validation
+  for Phase 1 of #828.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.DisplayList.Cursor
+  alias Minga.Editor.Layout
+  alias Minga.Editor.RenderPipeline
+  alias Minga.Editor.RenderPipeline.Content
+  alias Minga.Editor.RenderPipeline.Scroll
+  alias Minga.Editor.SemanticWindow
+  alias Minga.Editor.SemanticWindow.DiagnosticRange
+  alias Minga.Editor.SemanticWindow.SearchMatch
+  alias Minga.Editor.SemanticWindow.Selection
+  alias Minga.Editor.SemanticWindow.Span
+  alias Minga.Editor.SemanticWindow.VisualRow
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Face
+  alias Minga.Port.Capabilities
+  alias Minga.Search.Match, as: SearchMatchStruct
+
+  import Minga.Editor.RenderPipeline.TestHelpers
+
+  # Creates a GUI-capable base state
+  defp gui_state(opts) do
+    state = base_state(opts)
+    %{state | capabilities: %Capabilities{frontend_type: :native_gui}}
+  end
+
+  # Runs through scroll + content stages, returns {frames, cursor, state}
+  defp build_content(state) do
+    state = EditorState.sync_active_window_cursor(state)
+    state = RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    {scrolls, state} = Scroll.scroll_windows(state, layout)
+    Content.build_content(state, scrolls)
+  end
+
+  # Extracts text from draw layer (render_layer is %{row => [{col, text, style}]})
+  defp extract_draw_texts(render_layer) do
+    render_layer
+    |> Enum.sort_by(fn {row, _runs} -> row end)
+    |> Enum.map(fn {_row, runs} ->
+      runs
+      |> Enum.sort_by(fn {col, _text, _style} -> col end)
+      |> Enum.map_join(fn {_col, text, _style} -> text end)
+    end)
+  end
+
+  # ── GUI vs TUI gating ─────────────────────────────────────────────────
+
+  describe "GUI/TUI gating" do
+    test "WindowFrame.semantic is nil for TUI frontends" do
+      state = base_state(content: "hello\nworld")
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert wf.semantic == nil
+    end
+
+    test "WindowFrame.semantic is populated for GUI frontends" do
+      state = gui_state(content: "hello\nworld")
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert %SemanticWindow{} = wf.semantic
+    end
+
+    test "semantic window has correct window_id" do
+      state = gui_state(content: "hello")
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert wf.semantic.window_id == state.windows.active
+    end
+  end
+
+  # ── Core: semantic text matches draw text ──────────────────────────────
+
+  describe "semantic text matches draw text" do
+    test "semantic row text matches draw text for plain content" do
+      content = "line one\nline two\nline three"
+      state = gui_state(content: content)
+      {[wf], _cursor, _state} = build_content(state)
+
+      semantic_texts = Enum.map(wf.semantic.rows, & &1.text)
+      draw_texts = extract_draw_texts(wf.lines)
+
+      assert semantic_texts == draw_texts
+    end
+
+    test "semantic row text matches for single-line buffer" do
+      state = gui_state(content: "hello world")
+      {[wf], _cursor, _state} = build_content(state)
+
+      [row] = wf.semantic.rows
+      [draw_text] = extract_draw_texts(wf.lines)
+
+      assert row.text == draw_text
+    end
+
+    test "semantic row text matches for multiline content" do
+      content = "alpha\nbeta\ngamma\ndelta\nepsilon"
+      state = gui_state(content: content)
+      {[wf], _cursor, _state} = build_content(state)
+
+      semantic_texts = Enum.map(wf.semantic.rows, & &1.text)
+      assert semantic_texts == ["alpha", "beta", "gamma", "delta", "epsilon"]
+    end
+
+    test "empty buffer produces valid semantic window" do
+      state = gui_state(content: "")
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert %SemanticWindow{} = wf.semantic
+      # Empty buffer still has one line (the empty line)
+      assert is_list(wf.semantic.rows)
+      assert wf.semantic.cursor_row >= 0
+      assert wf.semantic.cursor_col >= 0
+    end
+  end
+
+  # ── Visual rows ────────────────────────────────────────────────────────
+
+  describe "visual rows" do
+    test "each row has row_type :normal for regular lines" do
+      state = gui_state(content: "a\nb\nc")
+      {[wf], _cursor, _state} = build_content(state)
+
+      types = Enum.map(wf.semantic.rows, & &1.row_type)
+      assert types == [:normal, :normal, :normal]
+    end
+
+    test "buf_line is correctly assigned" do
+      state = gui_state(content: "a\nb\nc\nd")
+      {[wf], _cursor, _state} = build_content(state)
+
+      buf_lines = Enum.map(wf.semantic.rows, & &1.buf_line)
+      assert buf_lines == [0, 1, 2, 3]
+    end
+
+    test "content_hash is non-zero for non-empty lines" do
+      state = gui_state(content: "hello world")
+      {[wf], _cursor, _state} = build_content(state)
+
+      [row] = wf.semantic.rows
+      assert row.content_hash != 0
+    end
+
+    test "different lines produce different hashes" do
+      state = gui_state(content: "hello\nworld")
+      {[wf], _cursor, _state} = build_content(state)
+
+      [row1, row2] = wf.semantic.rows
+      assert row1.content_hash != row2.content_hash
+    end
+
+    test "identical lines produce identical hashes" do
+      state = gui_state(content: "same\nsame")
+      {[wf], _cursor, _state} = build_content(state)
+
+      [row1, row2] = wf.semantic.rows
+      assert row1.content_hash == row2.content_hash
+    end
+
+    test "semantic row count matches draw line count" do
+      content = "one\ntwo\nthree\nfour\nfive"
+      state = gui_state(content: content)
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert length(wf.semantic.rows) == map_size(wf.lines)
+    end
+  end
+
+  # ── Cursor ─────────────────────────────────────────────────────────────
+
+  describe "cursor" do
+    test "cursor at row 0, col 0 for new buffer" do
+      state = gui_state(content: "hello")
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert wf.semantic.cursor_row == 0
+      assert wf.semantic.cursor_col == 0
+    end
+
+    test "cursor shape is :block in normal mode" do
+      state = gui_state(content: "hello")
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert wf.semantic.cursor_shape == :block
+    end
+
+    test "semantic cursor row is consistent with draw cursor" do
+      content = "hello\nworld"
+      state = gui_state(content: content)
+      {[wf], %Cursor{} = cursor, _state} = build_content(state)
+
+      # Both should be on the first line (row 0 in window-relative coords)
+      assert wf.semantic.cursor_row == 0
+      assert is_integer(cursor.row)
+    end
+  end
+
+  # ── Span.from_face/3 ──────────────────────────────────────────────────
+
+  describe "Span.from_face/3" do
+    test "encodes bold flag in bit 0" do
+      face = Face.new(bold: true)
+      span = Span.from_face(face, 0, 10)
+
+      import Bitwise
+      assert (span.attrs &&& 1) == 1
+    end
+
+    test "encodes italic flag in bit 1" do
+      face = Face.new(italic: true)
+      span = Span.from_face(face, 0, 10)
+
+      import Bitwise
+      assert (span.attrs >>> 1 &&& 1) == 1
+    end
+
+    test "encodes underline flag in bit 2" do
+      face = Face.new(underline: true)
+      span = Span.from_face(face, 0, 10)
+
+      import Bitwise
+      assert (span.attrs >>> 2 &&& 1) == 1
+    end
+
+    test "encodes strikethrough flag in bit 3" do
+      face = Face.new(strikethrough: true)
+      span = Span.from_face(face, 0, 10)
+
+      import Bitwise
+      assert (span.attrs >>> 3 &&& 1) == 1
+    end
+
+    test "encodes curl underline in bit 4" do
+      face = Face.new(underline: true, underline_style: :curl)
+      span = Span.from_face(face, 0, 5)
+
+      import Bitwise
+      assert (span.attrs >>> 4 &&& 1) == 1
+    end
+
+    test "packs all attrs into one byte correctly" do
+      face = Face.new(bold: true, italic: true, underline: true, strikethrough: true)
+      span = Span.from_face(face, 0, 10)
+
+      import Bitwise
+      assert (span.attrs &&& 0x0F) == 0x0F
+    end
+
+    test "preserves fg and bg colors" do
+      face = Face.new(fg: 0xFF6C6B, bg: 0x282C34)
+      span = Span.from_face(face, 0, 10)
+
+      assert span.fg == 0xFF6C6B
+      assert span.bg == 0x282C34
+    end
+
+    test "nil colors default to 0" do
+      face = Face.new()
+      span = Span.from_face(face, 0, 1)
+
+      assert span.fg == 0
+      assert span.bg == 0
+    end
+
+    test "preserves column range" do
+      face = Face.new(fg: 0xABCDEF)
+      span = Span.from_face(face, 3, 17)
+
+      assert span.start_col == 3
+      assert span.end_col == 17
+    end
+
+    test "encodes font weight" do
+      face = Face.new(font_weight: :bold)
+      span = Span.from_face(face, 0, 10)
+
+      assert span.font_weight == 5
+    end
+
+    test "nil font weight defaults to 0" do
+      face = Face.new()
+      span = Span.from_face(face, 0, 10)
+
+      assert span.font_weight == 0
+    end
+  end
+
+  # ── Selection.from_visual_selection/2 ──────────────────────────────────
+
+  describe "Selection.from_visual_selection/2" do
+    test "returns nil for no selection" do
+      assert Selection.from_visual_selection(nil, 0) == nil
+    end
+
+    test "converts char selection to display coordinates" do
+      sel = Selection.from_visual_selection({:char, {5, 3}, {7, 10}}, 0)
+
+      assert sel.type == :char
+      assert sel.start_row == 5
+      assert sel.start_col == 3
+      assert sel.end_row == 7
+      assert sel.end_col == 10
+    end
+
+    test "char selection adjusts for viewport scroll offset" do
+      sel = Selection.from_visual_selection({:char, {5, 3}, {7, 10}}, 2)
+
+      assert sel.start_row == 3
+      assert sel.end_row == 5
+    end
+
+    test "converts line selection to display coordinates" do
+      sel = Selection.from_visual_selection({:line, 10, 15}, 5)
+
+      assert sel.type == :line
+      assert sel.start_row == 5
+      assert sel.end_row == 10
+    end
+  end
+
+  # ── SearchMatch.from_context_matches/4 ─────────────────────────────────
+
+  describe "SearchMatch.from_context_matches/4" do
+    test "filters matches to visible viewport range" do
+      matches = [
+        %SearchMatchStruct{line: 0, col: 5, length: 3},
+        %SearchMatchStruct{line: 3, col: 2, length: 4},
+        %SearchMatchStruct{line: 5, col: 0, length: 2},
+        %SearchMatchStruct{line: 8, col: 1, length: 3},
+        %SearchMatchStruct{line: 12, col: 0, length: 5}
+      ]
+
+      result = SearchMatch.from_context_matches(matches, nil, 3, 10)
+
+      lines = Enum.map(result, & &1.row)
+      # Lines 3, 5, 8 are in viewport [3, 10). Converted to display rows: 0, 2, 5
+      assert lines == [0, 2, 5]
+    end
+
+    test "converts buffer line to display row" do
+      matches = [%SearchMatchStruct{line: 5, col: 10, length: 3}]
+
+      [match] = SearchMatch.from_context_matches(matches, nil, 3, 10)
+
+      assert match.row == 2
+      assert match.start_col == 10
+      assert match.end_col == 13
+    end
+
+    test "marks exactly one match as current" do
+      confirm = %SearchMatchStruct{line: 5, col: 2, length: 4}
+
+      matches = [
+        %SearchMatchStruct{line: 3, col: 0, length: 2},
+        confirm,
+        %SearchMatchStruct{line: 7, col: 1, length: 3}
+      ]
+
+      result = SearchMatch.from_context_matches(matches, confirm, 0, 10)
+
+      current_flags = Enum.map(result, & &1.is_current)
+      assert current_flags == [false, true, false]
+    end
+
+    test "empty matches produces empty result" do
+      assert SearchMatch.from_context_matches([], nil, 0, 24) == []
+    end
+
+    test "all matches outside viewport produces empty result" do
+      matches = [
+        %SearchMatchStruct{line: 100, col: 0, length: 5},
+        %SearchMatchStruct{line: 200, col: 0, length: 3}
+      ]
+
+      assert SearchMatch.from_context_matches(matches, nil, 0, 24) == []
+    end
+  end
+
+  # ── DiagnosticRange.from_diagnostics/3 ─────────────────────────────────
+
+  describe "DiagnosticRange.from_diagnostics/3" do
+    test "filters diagnostics to visible line range" do
+      diagnostics = [
+        %Minga.Diagnostics.Diagnostic{
+          range: %{start_line: 1, start_col: 0, end_line: 1, end_col: 5},
+          severity: :error,
+          message: "err"
+        },
+        %Minga.Diagnostics.Diagnostic{
+          range: %{start_line: 5, start_col: 0, end_line: 5, end_col: 10},
+          severity: :warning,
+          message: "warn"
+        },
+        %Minga.Diagnostics.Diagnostic{
+          range: %{start_line: 30, start_col: 0, end_line: 30, end_col: 3},
+          severity: :info,
+          message: "info"
+        }
+      ]
+
+      result = DiagnosticRange.from_diagnostics(diagnostics, 0, 10)
+
+      # Lines 1 and 5 in viewport [0, 10), line 30 is out
+      assert length(result) == 2
+    end
+
+    test "converts buffer coordinates to display coordinates" do
+      diagnostics = [
+        %Minga.Diagnostics.Diagnostic{
+          range: %{start_line: 5, start_col: 3, end_line: 5, end_col: 10},
+          severity: :error,
+          message: "err"
+        }
+      ]
+
+      [range] = DiagnosticRange.from_diagnostics(diagnostics, 2, 10)
+
+      assert range.start_row == 3
+      assert range.start_col == 3
+      assert range.end_row == 3
+      assert range.end_col == 10
+    end
+
+    test "maps all severity levels correctly" do
+      make_diag = fn line, severity ->
+        %Minga.Diagnostics.Diagnostic{
+          range: %{start_line: line, start_col: 0, end_line: line, end_col: 5},
+          severity: severity,
+          message: "msg"
+        }
+      end
+
+      diagnostics = [
+        make_diag.(0, :error),
+        make_diag.(1, :warning),
+        make_diag.(2, :info),
+        make_diag.(3, :hint)
+      ]
+
+      result = DiagnosticRange.from_diagnostics(diagnostics, 0, 10)
+
+      severities = Enum.map(result, & &1.severity)
+      assert severities == [:error, :warning, :info, :hint]
+    end
+
+    test "empty diagnostics produces empty result" do
+      assert DiagnosticRange.from_diagnostics([], 0, 24) == []
+    end
+
+    test "all diagnostics outside viewport produces empty result" do
+      diagnostics = [
+        %Minga.Diagnostics.Diagnostic{
+          range: %{start_line: 50, start_col: 0, end_line: 50, end_col: 5},
+          severity: :error,
+          message: "err"
+        }
+      ]
+
+      assert DiagnosticRange.from_diagnostics(diagnostics, 0, 24) == []
+    end
+  end
+
+  # ── VisualRow.compute_hash/2 ───────────────────────────────────────────
+
+  describe "VisualRow.compute_hash/2" do
+    test "same inputs produce same hash" do
+      h1 = VisualRow.compute_hash("hello", [])
+      h2 = VisualRow.compute_hash("hello", [])
+      assert h1 == h2
+    end
+
+    test "different text produces different hash" do
+      h1 = VisualRow.compute_hash("hello", [])
+      h2 = VisualRow.compute_hash("world", [])
+      assert h1 != h2
+    end
+
+    test "same text with different spans produces different hash" do
+      span_bold = %Span{start_col: 0, end_col: 5, fg: 0xFF0000, bg: 0, attrs: 1}
+      span_italic = %Span{start_col: 0, end_col: 5, fg: 0xFF0000, bg: 0, attrs: 2}
+
+      h1 = VisualRow.compute_hash("hello", [span_bold])
+      h2 = VisualRow.compute_hash("hello", [span_italic])
+      assert h1 != h2
+    end
+  end
+
+  # ── Integration: semantic window in render pipeline ────────────────────
+
+  describe "integration: semantic window in full pipeline" do
+    test "semantic selection is nil when not in visual mode" do
+      state = gui_state(content: "hello\nworld")
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert wf.semantic.selection == nil
+    end
+
+    test "semantic search_matches is empty when no search" do
+      state = gui_state(content: "hello world")
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert wf.semantic.search_matches == []
+    end
+
+    test "semantic diagnostic_ranges is empty when no diagnostics" do
+      state = gui_state(content: "hello world")
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert wf.semantic.diagnostic_ranges == []
+    end
+
+    test "full_refresh is true on initial render" do
+      state = gui_state(content: "hello")
+      {[wf], _cursor, _state} = build_content(state)
+
+      assert wf.semantic.full_refresh == true
+    end
+  end
+end


### PR DESCRIPTION
## What

Phase 1 of #828: introduces the `SemanticWindow` data model that captures pre-resolved semantic rendering data alongside the existing draw-based pipeline. BEAM-only refactor with no protocol or Swift changes.

## Why

The current pipeline flattens rich semantic data into draw_text commands, which the GUI must decode and reconstruct. By capturing semantic data before flattening, Phase 2 can encode it directly as opcode 0x80, eliminating TUI artifacts in GUI rendering and enabling selection/search as Metal overlay quads (zero line re-rasterization).

## What Changed

The `SemanticWindow` is built during the Content stage when the frontend has GUI capabilities. It captures:

- **Visual rows** with row type (normal, fold_start, virtual_line, block, wrap_continuation), buffer line number, composed text, highlight spans with pre-resolved colors, and content hash for CTLine cache invalidation
- **Cursor** in display coordinates (fold/wrap adjusted)
- **Selection** as display-coordinate overlay data (not baked into span colors)
- **Search matches** as display-coordinate overlay data
- **Diagnostic ranges** with severity as display-coordinate overlay data

All positions use display coordinates. The BEAM resolves folds, word wrap, virtual text displacement, and conceal ranges before populating the struct. Swift never needs to compute any of these.

### New modules (7)
- `SemanticWindow` (root struct)
- `SemanticWindow.VisualRow` (per-row data with content hash)
- `SemanticWindow.Span` (pre-resolved highlight span via `from_face/3`)
- `SemanticWindow.Selection` (display-coordinate selection overlay)
- `SemanticWindow.SearchMatch` (display-coordinate search match)
- `SemanticWindow.DiagnosticRange` (display-coordinate diagnostic underline)
- `SemanticWindow.Builder` (builds from Content stage data)

### Modified (2)
- `WindowFrame` gains optional `semantic` field (nil for TUI)
- Content stage calls builder when `Capabilities.gui?` is true

### Tests
48 tests covering GUI/TUI gating, semantic text matches draw text, visual row properties, cursor positioning, span bit-packing, selection coordinate conversion, search match filtering/viewport clipping, diagnostic range conversion, and content hash determinism.

## Architecture Decisions

Based on review from Archie and Swift expert:
- BEAM sends pre-wrapped visual rows, not raw buffer lines (Swift never wraps)
- BEAM sends resolved DisplayMap output, not fold ranges (Swift never resolves folds)
- Virtual text spliced into composed text before sending (Swift never composes)
- Selection/search/diagnostics as overlay coordinates, not baked into styled runs
- Gutter (0x7B) and cursorline (0x7A) remain separate opcodes

Closes nothing yet (Phase 1 of 3 for #828).