### PR TITLE
refactor(editor): split Emit into TUI/GUI modules

### DIFF
--- a/lib/minga/editor/render_pipeline/emit.ex
+++ b/lib/minga/editor/render_pipeline/emit.ex
@@ -2,58 +2,44 @@ defmodule Minga.Editor.RenderPipeline.Emit do
   @moduledoc """
   Stage 7: Emit.
 
-  Converts the composed `Frame` into protocol command binaries and
-  sends them to the Zig renderer port. Also sends title and window
-  background color when they change (side-channel writes).
+  Dispatches to `Emit.TUI` or `Emit.GUI` based on frontend capabilities,
+  then handles shared concerns (viewport tracking, title, window background).
 
-  ## Scroll region optimization
+  TUI: converts the composed `Frame` into protocol command binaries using
+  scroll region optimization when possible (see `Emit.TUI`).
 
-  When the viewport shifts by 1-3 lines between frames and no structural
-  changes occurred (layout, gutter width, window set), the emit stage
-  sends a `scroll_region` command instead of a full `clear + redraw`.
-  The terminal emulator shifts its internal buffer, then only the newly
-  revealed lines are drawn. This eliminates the majority of cell writes
-  for the most common scroll case (Ctrl-e/y, mouse wheel, cursor near edges).
+  GUI: filters SwiftUI-owned chrome from the frame, converts to Metal
+  cell-grid commands, then syncs structured chrome data via dedicated
+  protocol opcodes (see `Emit.GUI`).
   """
 
   alias Minga.Config.Options
   alias Minga.Editor.DisplayList
-  alias Minga.Editor.DisplayList.{Frame, Overlay, WindowFrame}
+  alias Minga.Editor.DisplayList.Frame
   alias Minga.Editor.Layout
   alias Minga.Editor.RenderPipeline.Chrome
   alias Minga.Editor.RenderPipeline.Emit.GUI, as: EmitGUI
+  alias Minga.Editor.RenderPipeline.Emit.TUI, as: EmitTUI
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.TabBar
   alias Minga.Editor.Title
   alias Minga.Port.Capabilities
   alias Minga.Port.Manager, as: PortManager
-  alias Minga.Port.Protocol
   alias Minga.Telemetry
 
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
 
-  @typedoc "Scroll delta info for one window."
-  @type scroll_delta :: %{
-          win_id: pos_integer(),
-          delta: integer(),
-          content_rect: Layout.rect()
-        }
-
-  # Maximum viewport delta for scroll region optimization.
-  @max_scroll_delta 3
-
   @doc """
   Converts the frame to protocol command binaries and sends them to
-  the Zig port. Uses scroll region optimization when possible.
+  the frontend port. Dispatches to `Emit.TUI` or `Emit.GUI` based on
+  frontend capabilities.
 
   Also sends title and window background color when they change
   (side-channel writes).
   """
   @spec emit(Frame.t(), state(), Chrome.t() | nil) :: state()
   def emit(frame, state, chrome \\ nil) do
-    scroll_deltas = detect_scroll_regions(state)
-
     # Make the font registry available for font_family → font_id resolution
     # during draws_to_commands. Initialize only on first frame; subsequent
     # frames reuse the accumulated registry so IDs are stable and register_font
@@ -62,13 +48,15 @@ defmodule Minga.Editor.RenderPipeline.Emit do
       Process.put(:emit_font_registry, state.font_registry)
     end
 
+    gui? = Capabilities.gui?(state.capabilities)
+
     commands =
-      if Capabilities.gui?(state.capabilities) do
+      if gui? do
         frame
-        |> filter_frame_for_gui()
+        |> EmitGUI.filter_frame_for_gui()
         |> DisplayList.to_commands()
       else
-        build_commands(frame, scroll_deltas)
+        EmitTUI.build_commands(frame, state)
       end
 
     update_tracking(state)
@@ -80,7 +68,7 @@ defmodule Minga.Editor.RenderPipeline.Emit do
       send_title(state)
       send_window_bg(state)
 
-      if Capabilities.gui?(state.capabilities) do
+      if gui? do
         status_bar_data = chrome && chrome.status_bar_data
         EmitGUI.sync_chrome(state, status_bar_data)
       else
@@ -89,275 +77,7 @@ defmodule Minga.Editor.RenderPipeline.Emit do
     end)
   end
 
-  # ── Scroll region detection ──────────────────────────────────────────────
-
-  @spec detect_scroll_regions(state()) :: [scroll_delta()] | nil
-  defp detect_scroll_regions(state) do
-    # Scroll region optimization disabled: the interaction between ANSI
-    # scroll regions, libvaxis internal buffer sync, and partial content
-    # redraws causes content corruption on shifted rows. Full redraw on
-    # every frame until this is properly debugged.
-    if scroll_optimization_enabled?() do
-      detect_scroll_regions_impl(state)
-    else
-      nil
-    end
-  end
-
-  # Kill switch for the scroll region optimization. Set to true to re-enable
-  # once the libvaxis buffer sync issue is resolved.
-  @spec scroll_optimization_enabled?() :: boolean()
-  defp scroll_optimization_enabled?, do: false
-
-  @spec detect_scroll_regions_impl(state()) :: [scroll_delta()] | nil
-  defp detect_scroll_regions_impl(state) do
-    prev_tops = Process.get(:emit_prev_viewport_tops)
-    prev_rects = Process.get(:emit_prev_content_rects)
-    prev_gutter_ws = Process.get(:emit_prev_gutter_ws)
-
-    # First frame or no previous data: full redraw
-    if is_nil(prev_tops) or is_nil(prev_rects) or is_nil(prev_gutter_ws) do
-      nil
-    else
-      layout = Layout.get(state)
-      collect_scroll_deltas(state, layout, prev_tops, prev_rects, prev_gutter_ws)
-    end
-  end
-
-  @spec collect_scroll_deltas(
-          state(),
-          Layout.t(),
-          %{pos_integer() => non_neg_integer()},
-          %{pos_integer() => Layout.rect()},
-          %{pos_integer() => non_neg_integer()}
-        ) :: [scroll_delta()] | nil
-  defp collect_scroll_deltas(state, layout, prev_tops, prev_rects, prev_gutter_ws) do
-    current_win_ids = MapSet.new(Map.keys(layout.window_layouts))
-    prev_win_ids = MapSet.new(Map.keys(prev_tops))
-
-    # Window set changed (split/close): full redraw
-    if current_win_ids != prev_win_ids do
-      nil
-    else
-      prev_versions = Process.get(:emit_prev_buf_versions, %{})
-
-      prev = %{
-        tops: prev_tops,
-        rects: prev_rects,
-        gutter_ws: prev_gutter_ws,
-        buf_versions: prev_versions
-      }
-
-      deltas =
-        Enum.reduce_while(layout.window_layouts, [], fn {win_id, win_layout}, acc ->
-          window = Map.get(state.windows.map, win_id)
-          check_window_scroll(window, win_id, win_layout, prev, acc)
-        end)
-
-      case deltas do
-        list when is_list(list) and list != [] -> Enum.reverse(list)
-        _ -> nil
-      end
-    end
-  end
-
-  @spec check_window_scroll(
-          Minga.Editor.Window.t() | nil,
-          pos_integer(),
-          Layout.window_layout(),
-          map(),
-          list()
-        ) :: {:cont, list()} | {:halt, atom()}
-  defp check_window_scroll(nil, _win_id, _win_layout, _prev, acc), do: {:cont, acc}
-
-  defp check_window_scroll(window, win_id, win_layout, prev, acc) do
-    if match?({:agent_chat, _}, window.content) do
-      {:cont, acc}
-    else
-      compare_window_scroll(window, win_id, win_layout, prev, acc)
-    end
-  end
-
-  @spec compare_window_scroll(
-          Minga.Editor.Window.t(),
-          pos_integer(),
-          Layout.window_layout(),
-          map(),
-          list()
-        ) :: {:cont, list()} | {:halt, atom()}
-  defp compare_window_scroll(window, win_id, win_layout, prev, acc) do
-    prev_rect = Map.get(prev.rects, win_id)
-    current_rect = win_layout.content
-
-    prev_gutter_w = Map.get(prev.gutter_ws, win_id)
-    current_gutter_w = window.last_gutter_w
-
-    prev_top = Map.get(prev.tops, win_id)
-    current_top = window.last_viewport_top
-
-    prev_version = Map.get(prev.buf_versions, win_id)
-    current_version = window.last_buf_version
-
-    classify_scroll_delta(
-      %{
-        prev_rect: prev_rect,
-        cur_rect: current_rect,
-        prev_gw: prev_gutter_w,
-        cur_gw: current_gutter_w,
-        prev_top: prev_top,
-        cur_top: current_top,
-        prev_ver: prev_version,
-        cur_ver: current_version
-      },
-      win_id,
-      acc
-    )
-  end
-
-  # Multi-clause function replacing the cond block (project coding standards).
-  @spec classify_scroll_delta(map(), pos_integer(), list()) ::
-          {:cont, list()} | {:halt, atom()}
-  defp classify_scroll_delta(%{prev_rect: pr, cur_rect: cr}, _, _) when pr != cr,
-    do: {:halt, :layout_changed}
-
-  defp classify_scroll_delta(%{prev_gw: pg, cur_gw: cg}, _, _) when pg != cg,
-    do: {:halt, :gutter_changed}
-
-  defp classify_scroll_delta(%{prev_top: pt, cur_top: ct}, _, acc) when pt == ct,
-    do: {:cont, acc}
-
-  defp classify_scroll_delta(%{prev_top: pt, cur_top: ct}, _, _)
-       when abs(ct - pt) > @max_scroll_delta,
-       do: {:halt, :delta_too_large}
-
-  # Buffer content changed (edits, highlight updates, decorations) during scroll.
-  # Fall back to full redraw so shifted rows show correct content.
-  defp classify_scroll_delta(%{prev_ver: pv, cur_ver: cv}, _, _) when pv != cv,
-    do: {:halt, :content_changed}
-
-  defp classify_scroll_delta(%{cur_rect: rect, prev_top: pt, cur_top: ct}, win_id, acc) do
-    {:cont, [%{win_id: win_id, delta: ct - pt, content_rect: rect} | acc]}
-  end
-
-  # ── Command building ─────────────────────────────────────────────────────
-
-  # GUI mode: allowlist of Frame fields sent to Metal.
-  #
-  # Overlays pass through intentionally: the Chrome stage already filters
-  # them in Chrome.GUI.build (picker, which-key, completion are empty).
-  # The remaining overlays (hover popup, signature help, float popups)
-  # are Metal-rendered and belong in the cell-grid output.
-  @spec filter_frame_for_gui(Frame.t()) :: Frame.t()
-  defp filter_frame_for_gui(frame) do
-    %{
-      frame
-      | tab_bar: [],
-        file_tree: [],
-        agent_panel: [],
-        agentic_view: [],
-        status_bar: [],
-        splash: nil,
-        windows: Enum.map(frame.windows, fn wf -> %{wf | gutter: %{}} end)
-    }
-  end
-
-  @spec build_commands(Frame.t(), [scroll_delta()] | nil) :: [binary()]
-  defp build_commands(frame, nil) do
-    # Full redraw path (existing behavior)
-    DisplayList.to_commands(frame)
-  end
-
-  defp build_commands(frame, scroll_deltas) do
-    # Scroll region path: skip clear, send scroll_region + partial content + all chrome
-    scroll_cmds = build_scroll_commands(scroll_deltas)
-    new_content_draws = collect_new_content_draws(frame, scroll_deltas)
-    chrome_draws = collect_chrome_draws(frame)
-    overlay_draws = collect_overlay_draws(frame)
-
-    scroll_cmds ++
-      frame.regions ++
-      DisplayList.draws_to_commands(chrome_draws) ++
-      DisplayList.draws_to_commands(new_content_draws) ++
-      DisplayList.draws_to_commands(overlay_draws) ++
-      [
-        Protocol.encode_cursor_shape(frame.cursor.shape),
-        Protocol.encode_cursor(frame.cursor.row, frame.cursor.col),
-        Protocol.encode_batch_end()
-      ]
-  end
-
-  @spec build_scroll_commands([scroll_delta()]) :: [binary()]
-  defp build_scroll_commands(scroll_deltas) do
-    Enum.map(scroll_deltas, fn %{delta: delta, content_rect: {row, _col, _w, height}} ->
-      top_row = row
-      bottom_row = row + height - 1
-      Protocol.encode_scroll_region(top_row, bottom_row, delta)
-    end)
-  end
-
-  @spec collect_new_content_draws(Frame.t(), [scroll_delta()]) :: [DisplayList.draw()]
-  defp collect_new_content_draws(frame, scroll_deltas) do
-    # Build new_rows ranges from scroll deltas. Since WindowFrame.rect is
-    # always {0, 0, w, h} (draws use absolute screen coords), we can't key
-    # by rect. Instead, build a list of new_rows ranges from the content_rects
-    # and match layer row keys against them.
-    all_new_rows = Enum.map(scroll_deltas, &compute_new_rows/1)
-
-    Enum.flat_map(frame.windows, fn wf ->
-      filter_window_draws_for_new_rows(wf, all_new_rows)
-    end)
-  end
-
-  @spec compute_new_rows(scroll_delta()) :: Range.t()
-  defp compute_new_rows(%{delta: delta, content_rect: {row, _col, _w, height}}) do
-    if delta > 0 do
-      # Scrolled down: new content at the bottom
-      bottom = row + height - 1
-      (bottom - delta + 1)..bottom
-    else
-      # Scrolled up: new content at the top
-      row..(row + abs(delta) - 1)
-    end
-  end
-
-  @spec filter_window_draws_for_new_rows(WindowFrame.t(), [Range.t()]) :: [DisplayList.draw()]
-  defp filter_window_draws_for_new_rows(wf, all_new_rows) do
-    # Draws in layers already use absolute screen coordinates (wf.rect is {0,0,...}).
-    # Filter layer entries whose row falls into any of the new_rows ranges.
-    gutter = filter_layer_by_ranges(wf.gutter, all_new_rows)
-    lines = filter_layer_by_ranges(wf.lines, all_new_rows)
-    tildes = filter_layer_by_ranges(wf.tilde_lines, all_new_rows)
-
-    gutter ++ lines ++ tildes
-  end
-
-  @spec filter_layer_by_ranges(DisplayList.render_layer(), [Range.t()]) :: [DisplayList.draw()]
-  defp filter_layer_by_ranges(layer, ranges) do
-    layer
-    |> Enum.filter(fn {row, _runs} -> Enum.any?(ranges, fn r -> row in r end) end)
-    |> Enum.flat_map(fn {row, runs} ->
-      Enum.map(runs, fn {col, text, style} -> {row, col, text, style} end)
-    end)
-  end
-
-  @spec collect_chrome_draws(Frame.t()) :: [DisplayList.draw()]
-  defp collect_chrome_draws(frame) do
-    frame.tab_bar ++
-      frame.file_tree ++
-      frame.agentic_view ++
-      frame.separators ++
-      frame.status_bar ++
-      frame.agent_panel ++
-      frame.minibuffer ++
-      (frame.splash || [])
-  end
-
-  @spec collect_overlay_draws(Frame.t()) :: [DisplayList.draw()]
-  defp collect_overlay_draws(frame) do
-    Enum.flat_map(frame.overlays, fn %Overlay{draws: draws} -> draws end)
-  end
-
-  # ── Tracking state ───────────────────────────────────────────────────────
+  # ── Tracking state (shared) ──────────────────────────────────────────────
 
   @spec update_tracking(state()) :: :ok
   defp update_tracking(state) do
@@ -408,7 +128,7 @@ defmodule Minga.Editor.RenderPipeline.Emit do
     :ok
   end
 
-  # ── Side-channel writes ──────────────────────────────────────────────────
+  # ── Side-channel writes (shared) ─────────────────────────────────────────
 
   @spec send_title(state()) :: :ok
   defp send_title(state) do
@@ -429,7 +149,7 @@ defmodule Minga.Editor.RenderPipeline.Emit do
 
     if title != Process.get(:last_title) do
       Process.put(:last_title, title)
-      PortManager.send_commands([Protocol.encode_set_title(title)])
+      PortManager.send_commands([Minga.Port.Protocol.encode_set_title(title)])
     end
 
     :ok
@@ -441,7 +161,7 @@ defmodule Minga.Editor.RenderPipeline.Emit do
 
     if bg != Process.get(:last_window_bg) do
       Process.put(:last_window_bg, bg)
-      PortManager.send_commands([Protocol.encode_set_window_bg(bg)])
+      PortManager.send_commands([Minga.Port.Protocol.encode_set_window_bg(bg)])
     end
 
     :ok

--- a/lib/minga/editor/render_pipeline/emit/gui.ex
+++ b/lib/minga/editor/render_pipeline/emit/gui.ex
@@ -1,20 +1,28 @@
 defmodule Minga.Editor.RenderPipeline.Emit.GUI do
   @moduledoc """
-  GUI chrome synchronization for the Emit stage.
+  GUI-specific emit logic for the Emit stage.
 
-  Sends structured chrome data (tab bar, file tree, which-key, completion,
-  breadcrumb, status bar, picker, agent chat, theme) to the native GUI
-  frontend. These are separate from the TUI cell-grid rendering commands
-  and from the frame-to-commands conversion in `Emit`.
+  Handles two responsibilities:
 
-  Called from `Emit.emit/2` only when the frontend has GUI capabilities.
-  Each function independently gathers state, encodes to protocol binary,
-  and sends to the port manager.
+  1. **Frame filtering**: strips SwiftUI-owned chrome fields from the
+     display list frame before it's converted to Metal cell-grid commands.
+     Tab bar, file tree, agent panel, agentic view, status bar, and splash
+     are handled natively by SwiftUI and should not appear in the cell grid.
+     Gutter is also stripped from window frames since the GUI renders it
+     natively.
+
+  2. **Chrome synchronization**: sends structured chrome data (tab bar,
+     file tree, which-key, completion, breadcrumb, status bar, picker,
+     agent chat, theme) to the native GUI frontend via dedicated protocol
+     opcodes. These are separate from the cell-grid rendering commands.
+
+  Called from `Emit.emit/3` only when the frontend has GUI capabilities.
   """
 
   alias Minga.Agent.Session, as: AgentSession
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Config.Options
+  alias Minga.Editor.DisplayList.Frame
   alias Minga.Editor.Layout
   alias Minga.Editor.RenderPipeline.ContentHelpers
   alias Minga.Editor.State, as: EditorState
@@ -27,6 +35,37 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
 
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
+
+  # ── Frame filtering ──────────────────────────────────────────────────────
+
+  @doc """
+  Filters a frame for GUI rendering by zeroing SwiftUI-owned chrome fields.
+
+  The GUI frontend renders tab bar, file tree, agent panel, agentic view,
+  status bar, and splash natively via SwiftUI. These fields are cleared so
+  they don't appear in the Metal cell-grid output. Window frame gutters are
+  also cleared since the GUI renders gutter natively.
+
+  Overlays pass through intentionally: the Chrome stage already filters
+  picker, which-key, and completion (empty in GUI mode). The remaining
+  overlays (hover popup, signature help, float popups) are Metal-rendered
+  and belong in the cell-grid output.
+  """
+  @spec filter_frame_for_gui(Frame.t()) :: Frame.t()
+  def filter_frame_for_gui(frame) do
+    %{
+      frame
+      | tab_bar: [],
+        file_tree: [],
+        agent_panel: [],
+        agentic_view: [],
+        status_bar: [],
+        splash: nil,
+        windows: Enum.map(frame.windows, fn wf -> %{wf | gutter: %{}} end)
+    }
+  end
+
+  # ── Chrome synchronization ──────────────────────────────────────────────
 
   @doc """
   Sends all GUI chrome data to the native frontend.

--- a/lib/minga/editor/render_pipeline/emit/tui.ex
+++ b/lib/minga/editor/render_pipeline/emit/tui.ex
@@ -1,0 +1,306 @@
+defmodule Minga.Editor.RenderPipeline.Emit.TUI do
+  @moduledoc """
+  TUI-specific command building for the Emit stage.
+
+  Converts a composed `Frame` into protocol command binaries for the
+  Zig/libvaxis TUI renderer. Handles scroll region optimization when
+  the viewport shifts by a small delta between frames.
+
+  ## Scroll region optimization
+
+  When the viewport shifts by 1-3 lines between frames and no structural
+  changes occurred (layout, gutter width, window set), we send a
+  `scroll_region` command instead of a full `clear + redraw`. The terminal
+  emulator shifts its internal buffer, then only the newly revealed lines
+  are drawn. This eliminates the majority of cell writes for the most
+  common scroll case (Ctrl-e/y, mouse wheel, cursor near edges).
+
+  Currently disabled pending a libvaxis buffer sync fix.
+  """
+
+  alias Minga.Editor.DisplayList
+  alias Minga.Editor.DisplayList.{Frame, Overlay, WindowFrame}
+  alias Minga.Editor.Layout
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Port.Protocol
+
+  @typedoc "Internal editor state."
+  @type state :: EditorState.t()
+
+  @typedoc "Scroll delta info for one window."
+  @type scroll_delta :: %{
+          win_id: pos_integer(),
+          delta: integer(),
+          content_rect: Layout.rect()
+        }
+
+  # Maximum viewport delta for scroll region optimization.
+  @max_scroll_delta 3
+
+  @doc """
+  Builds protocol command binaries from a frame for the TUI renderer.
+
+  Detects scroll regions from tracking state and uses scroll region
+  optimization when possible, otherwise does a full redraw.
+  """
+  @spec build_commands(Frame.t(), state()) :: [binary()]
+  def build_commands(frame, state) do
+    scroll_deltas = detect_scroll_regions(state)
+    build_commands_from_deltas(frame, scroll_deltas)
+  end
+
+  @doc """
+  Builds protocol commands from a frame and pre-computed scroll deltas.
+
+  When `scroll_deltas` is nil, performs a full redraw via `DisplayList.to_commands/1`.
+  When scroll deltas are present, sends scroll_region commands + partial content + chrome.
+  """
+  @spec build_commands_from_deltas(Frame.t(), [scroll_delta()] | nil) :: [binary()]
+  def build_commands_from_deltas(frame, nil) do
+    DisplayList.to_commands(frame)
+  end
+
+  def build_commands_from_deltas(frame, scroll_deltas) do
+    scroll_cmds = build_scroll_commands(scroll_deltas)
+    new_content_draws = collect_new_content_draws(frame, scroll_deltas)
+    chrome_draws = collect_chrome_draws(frame)
+    overlay_draws = collect_overlay_draws(frame)
+
+    scroll_cmds ++
+      frame.regions ++
+      DisplayList.draws_to_commands(chrome_draws) ++
+      DisplayList.draws_to_commands(new_content_draws) ++
+      DisplayList.draws_to_commands(overlay_draws) ++
+      [
+        Protocol.encode_cursor_shape(frame.cursor.shape),
+        Protocol.encode_cursor(frame.cursor.row, frame.cursor.col),
+        Protocol.encode_batch_end()
+      ]
+  end
+
+  # ── Scroll region detection ──────────────────────────────────────────────
+
+  @spec detect_scroll_regions(state()) :: [scroll_delta()] | nil
+  defp detect_scroll_regions(state) do
+    if scroll_optimization_enabled?() do
+      detect_scroll_regions_impl(state)
+    else
+      nil
+    end
+  end
+
+  # Kill switch for the scroll region optimization. Set to true to re-enable
+  # once the libvaxis buffer sync issue is resolved.
+  @spec scroll_optimization_enabled?() :: boolean()
+  defp scroll_optimization_enabled?, do: false
+
+  @spec detect_scroll_regions_impl(state()) :: [scroll_delta()] | nil
+  defp detect_scroll_regions_impl(state) do
+    prev_tops = Process.get(:emit_prev_viewport_tops)
+    prev_rects = Process.get(:emit_prev_content_rects)
+    prev_gutter_ws = Process.get(:emit_prev_gutter_ws)
+
+    if is_nil(prev_tops) or is_nil(prev_rects) or is_nil(prev_gutter_ws) do
+      nil
+    else
+      layout = Layout.get(state)
+      collect_scroll_deltas(state, layout, prev_tops, prev_rects, prev_gutter_ws)
+    end
+  end
+
+  @spec collect_scroll_deltas(
+          state(),
+          Layout.t(),
+          %{pos_integer() => non_neg_integer()},
+          %{pos_integer() => Layout.rect()},
+          %{pos_integer() => non_neg_integer()}
+        ) :: [scroll_delta()] | nil
+  defp collect_scroll_deltas(state, layout, prev_tops, prev_rects, prev_gutter_ws) do
+    current_win_ids = MapSet.new(Map.keys(layout.window_layouts))
+    prev_win_ids = MapSet.new(Map.keys(prev_tops))
+
+    if current_win_ids != prev_win_ids do
+      nil
+    else
+      prev_versions = Process.get(:emit_prev_buf_versions, %{})
+
+      prev = %{
+        tops: prev_tops,
+        rects: prev_rects,
+        gutter_ws: prev_gutter_ws,
+        buf_versions: prev_versions
+      }
+
+      deltas =
+        Enum.reduce_while(layout.window_layouts, [], fn {win_id, win_layout}, acc ->
+          window = Map.get(state.windows.map, win_id)
+          check_window_scroll(window, win_id, win_layout, prev, acc)
+        end)
+
+      case deltas do
+        list when is_list(list) and list != [] -> Enum.reverse(list)
+        _ -> nil
+      end
+    end
+  end
+
+  @spec check_window_scroll(
+          Minga.Editor.Window.t() | nil,
+          pos_integer(),
+          Layout.window_layout(),
+          map(),
+          list()
+        ) :: {:cont, list()} | {:halt, atom()}
+  defp check_window_scroll(nil, _win_id, _win_layout, _prev, acc), do: {:cont, acc}
+
+  defp check_window_scroll(window, win_id, win_layout, prev, acc) do
+    if match?({:agent_chat, _}, window.content) do
+      {:cont, acc}
+    else
+      compare_window_scroll(window, win_id, win_layout, prev, acc)
+    end
+  end
+
+  @spec compare_window_scroll(
+          Minga.Editor.Window.t(),
+          pos_integer(),
+          Layout.window_layout(),
+          map(),
+          list()
+        ) :: {:cont, list()} | {:halt, atom()}
+  defp compare_window_scroll(window, win_id, win_layout, prev, acc) do
+    prev_rect = Map.get(prev.rects, win_id)
+    current_rect = win_layout.content
+
+    prev_gutter_w = Map.get(prev.gutter_ws, win_id)
+    current_gutter_w = window.last_gutter_w
+
+    prev_top = Map.get(prev.tops, win_id)
+    current_top = window.last_viewport_top
+
+    prev_version = Map.get(prev.buf_versions, win_id)
+    current_version = window.last_buf_version
+
+    classify_scroll_delta(
+      %{
+        prev_rect: prev_rect,
+        cur_rect: current_rect,
+        prev_gw: prev_gutter_w,
+        cur_gw: current_gutter_w,
+        prev_top: prev_top,
+        cur_top: current_top,
+        prev_ver: prev_version,
+        cur_ver: current_version
+      },
+      win_id,
+      acc
+    )
+  end
+
+  @spec classify_scroll_delta(map(), pos_integer(), list()) ::
+          {:cont, list()} | {:halt, atom()}
+  defp classify_scroll_delta(%{prev_rect: pr, cur_rect: cr}, _, _) when pr != cr,
+    do: {:halt, :layout_changed}
+
+  defp classify_scroll_delta(%{prev_gw: pg, cur_gw: cg}, _, _) when pg != cg,
+    do: {:halt, :gutter_changed}
+
+  defp classify_scroll_delta(%{prev_top: pt, cur_top: ct}, _, acc) when pt == ct,
+    do: {:cont, acc}
+
+  defp classify_scroll_delta(%{prev_top: pt, cur_top: ct}, _, _)
+       when abs(ct - pt) > @max_scroll_delta,
+       do: {:halt, :delta_too_large}
+
+  defp classify_scroll_delta(%{prev_ver: pv, cur_ver: cv}, _, _) when pv != cv,
+    do: {:halt, :content_changed}
+
+  defp classify_scroll_delta(%{cur_rect: rect, prev_top: pt, cur_top: ct}, win_id, acc) do
+    {:cont, [%{win_id: win_id, delta: ct - pt, content_rect: rect} | acc]}
+  end
+
+  # ── Command building helpers ─────────────────────────────────────────────
+
+  @spec build_scroll_commands([scroll_delta()]) :: [binary()]
+  defp build_scroll_commands(scroll_deltas) do
+    Enum.map(scroll_deltas, fn %{delta: delta, content_rect: {row, _col, _w, height}} ->
+      top_row = row
+      bottom_row = row + height - 1
+      Protocol.encode_scroll_region(top_row, bottom_row, delta)
+    end)
+  end
+
+  @doc """
+  Collects all chrome draws from a frame for TUI rendering.
+
+  Concatenates tab_bar, file_tree, agentic_view, separators, status_bar,
+  agent_panel, minibuffer, and splash draws.
+  """
+  @spec collect_chrome_draws(Frame.t()) :: [DisplayList.draw()]
+  def collect_chrome_draws(frame) do
+    frame.tab_bar ++
+      frame.file_tree ++
+      frame.agentic_view ++
+      frame.separators ++
+      frame.status_bar ++
+      frame.agent_panel ++
+      frame.minibuffer ++
+      (frame.splash || [])
+  end
+
+  @doc """
+  Collects all overlay draws from a frame, flattening overlay draw lists.
+  """
+  @spec collect_overlay_draws(Frame.t()) :: [DisplayList.draw()]
+  def collect_overlay_draws(frame) do
+    Enum.flat_map(frame.overlays, fn %Overlay{draws: draws} -> draws end)
+  end
+
+  @spec collect_new_content_draws(Frame.t(), [scroll_delta()]) :: [DisplayList.draw()]
+  defp collect_new_content_draws(frame, scroll_deltas) do
+    all_new_rows = Enum.map(scroll_deltas, &compute_new_rows/1)
+
+    Enum.flat_map(frame.windows, fn wf ->
+      filter_window_draws_for_new_rows(wf, all_new_rows)
+    end)
+  end
+
+  @doc """
+  Computes which rows are newly revealed after a scroll delta.
+
+  For a positive delta (scrolled down), the new rows are at the bottom.
+  For a negative delta (scrolled up), the new rows are at the top.
+  """
+  @spec compute_new_rows(scroll_delta()) :: Range.t()
+  def compute_new_rows(%{delta: delta, content_rect: {row, _col, _w, height}}) do
+    if delta > 0 do
+      bottom = row + height - 1
+      (bottom - delta + 1)..bottom
+    else
+      row..(row + abs(delta) - 1)
+    end
+  end
+
+  @spec filter_window_draws_for_new_rows(WindowFrame.t(), [Range.t()]) :: [DisplayList.draw()]
+  defp filter_window_draws_for_new_rows(wf, all_new_rows) do
+    gutter = filter_layer_by_ranges(wf.gutter, all_new_rows)
+    lines = filter_layer_by_ranges(wf.lines, all_new_rows)
+    tildes = filter_layer_by_ranges(wf.tilde_lines, all_new_rows)
+
+    gutter ++ lines ++ tildes
+  end
+
+  @doc """
+  Filters a render layer to only include rows that fall within the given ranges.
+
+  Used by scroll region optimization to extract only newly revealed content.
+  """
+  @spec filter_layer_by_ranges(DisplayList.render_layer(), [Range.t()]) :: [DisplayList.draw()]
+  def filter_layer_by_ranges(layer, ranges) do
+    layer
+    |> Enum.filter(fn {row, _runs} -> Enum.any?(ranges, fn r -> row in r end) end)
+    |> Enum.flat_map(fn {row, runs} ->
+      Enum.map(runs, fn {col, text, style} -> {row, col, text, style} end)
+    end)
+  end
+end

--- a/test/minga/editor/layout/gui_test.exs
+++ b/test/minga/editor/layout/gui_test.exs
@@ -3,14 +3,7 @@ defmodule Minga.Editor.Layout.GUITest do
 
   alias Minga.Editor.Layout
   alias Minga.Editor.Layout.GUI, as: LayoutGUI
-  alias Minga.Port.Capabilities
-
   import Minga.Editor.RenderPipeline.TestHelpers
-
-  defp gui_state do
-    state = base_state()
-    %{state | capabilities: %Capabilities{frontend_type: :native_gui}}
-  end
 
   describe "Layout.GUI.compute/1" do
     test "returns a Layout struct" do

--- a/test/minga/editor/render_pipeline/chrome/gui_test.exs
+++ b/test/minga/editor/render_pipeline/chrome/gui_test.exs
@@ -8,7 +8,6 @@ defmodule Minga.Editor.RenderPipeline.Chrome.GUITest do
   alias Minga.Editor.RenderPipeline.Content
   alias Minga.Editor.RenderPipeline.Scroll
   alias Minga.Editor.State, as: EditorState
-  alias Minga.Port.Capabilities
 
   import Minga.Editor.RenderPipeline.TestHelpers
 
@@ -19,11 +18,6 @@ defmodule Minga.Editor.RenderPipeline.Chrome.GUITest do
     {scrolls, state} = Scroll.scroll_windows(state, layout)
     {_frames, cursor_info, state} = Content.build_content(state, scrolls)
     {scrolls, cursor_info, state, layout}
-  end
-
-  defp gui_state do
-    state = base_state()
-    %{state | capabilities: %Capabilities{frontend_type: :native_gui}}
   end
 
   describe "Chrome.GUI.build/4" do

--- a/test/minga/editor/render_pipeline/chrome_test.exs
+++ b/test/minga/editor/render_pipeline/chrome_test.exs
@@ -24,8 +24,6 @@ defmodule Minga.Editor.RenderPipeline.ChromeTest do
     {scrolls, cursor_info, state, layout}
   end
 
-  alias Minga.Port.Capabilities
-
   describe "build_chrome/4 TUI path" do
     test "returns a Chrome struct" do
       state = base_state()
@@ -67,11 +65,6 @@ defmodule Minga.Editor.RenderPipeline.ChromeTest do
   end
 
   describe "build_chrome/4 GUI path" do
-    defp gui_state(opts \\ []) do
-      state = base_state(opts)
-      %{state | capabilities: %Capabilities{frontend_type: :native_gui}}
-    end
-
     test "returns a Chrome struct with GUI capabilities" do
       state = gui_state()
       {scrolls, cursor_info, state, layout} = run_through_content(state)

--- a/test/minga/editor/render_pipeline/emit/gui_test.exs
+++ b/test/minga/editor/render_pipeline/emit/gui_test.exs
@@ -1,0 +1,194 @@
+defmodule Minga.Editor.RenderPipeline.Emit.GUITest do
+  @moduledoc """
+  Tests for the GUI-specific Emit stage logic: frame filtering and
+  integration with the emit dispatcher.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.DisplayList
+  alias Minga.Editor.DisplayList.{Cursor, Frame, Overlay, WindowFrame}
+  alias Minga.Editor.RenderPipeline.Emit
+  alias Minga.Editor.RenderPipeline.Emit.GUI, as: EmitGUI
+
+  import Minga.Editor.RenderPipeline.TestHelpers
+
+  describe "filter_frame_for_gui/1" do
+    test "zeroes SwiftUI-owned fields" do
+      face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
+
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        tab_bar: [DisplayList.draw(0, 0, "tab", face)],
+        file_tree: [DisplayList.draw(1, 0, "tree", face)],
+        agent_panel: [DisplayList.draw(2, 0, "panel", face)],
+        agentic_view: [DisplayList.draw(3, 0, "view", face)],
+        status_bar: [DisplayList.draw(4, 0, "status", face)],
+        splash: [DisplayList.draw(5, 0, "splash", face)]
+      }
+
+      filtered = EmitGUI.filter_frame_for_gui(frame)
+
+      assert filtered.tab_bar == []
+      assert filtered.file_tree == []
+      assert filtered.agent_panel == []
+      assert filtered.agentic_view == []
+      assert filtered.status_bar == []
+      assert filtered.splash == nil
+    end
+
+    test "preserves minibuffer and overlays" do
+      face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
+      hover_face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x3E4451)
+
+      minibuffer_draws = [DisplayList.draw(24, 0, ":write", face)]
+      overlay_draws = [DisplayList.draw(5, 10, "hover info", hover_face)]
+
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        minibuffer: minibuffer_draws,
+        overlays: [%Overlay{draws: overlay_draws}]
+      }
+
+      filtered = EmitGUI.filter_frame_for_gui(frame)
+
+      assert filtered.minibuffer == minibuffer_draws
+      assert length(filtered.overlays) == 1
+      assert hd(filtered.overlays).draws == overlay_draws
+    end
+
+    test "strips gutter from all window frames" do
+      face = Minga.Face.new(fg: 0x5B6268, bg: 0x282C34)
+
+      wf1 = %WindowFrame{
+        rect: {0, 0, 40, 20},
+        gutter: DisplayList.draws_to_layer([DisplayList.draw(0, 0, "  1 ", face)]),
+        lines: %{},
+        tilde_lines: %{},
+        modeline: %{},
+        cursor: nil
+      }
+
+      wf2 = %WindowFrame{
+        rect: {0, 40, 40, 20},
+        gutter: DisplayList.draws_to_layer([DisplayList.draw(0, 0, "  1 ", face)]),
+        lines: %{},
+        tilde_lines: %{},
+        modeline: %{},
+        cursor: nil
+      }
+
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        windows: [wf1, wf2]
+      }
+
+      filtered = EmitGUI.filter_frame_for_gui(frame)
+
+      assert length(filtered.windows) == 2
+      assert Enum.all?(filtered.windows, fn wf -> wf.gutter == %{} end)
+    end
+
+    test "preserves window content lines and tilde_lines" do
+      face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
+      tilde_face = Minga.Face.new(fg: 0x5B6268, bg: 0x282C34)
+
+      content_layer = DisplayList.draws_to_layer([DisplayList.draw(0, 4, "hello world", face)])
+      tilde_layer = DisplayList.draws_to_layer([DisplayList.draw(5, 0, "~", tilde_face)])
+
+      wf = %WindowFrame{
+        rect: {0, 0, 80, 20},
+        gutter: DisplayList.draws_to_layer([DisplayList.draw(0, 0, "  1 ", face)]),
+        lines: content_layer,
+        tilde_lines: tilde_layer,
+        modeline: %{},
+        cursor: nil
+      }
+
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        windows: [wf]
+      }
+
+      filtered = EmitGUI.filter_frame_for_gui(frame)
+      filtered_wf = hd(filtered.windows)
+
+      assert filtered_wf.lines == content_layer
+      assert filtered_wf.tilde_lines == tilde_layer
+    end
+
+    test "handles empty frame (no windows, no chrome)" do
+      frame = %Frame{cursor: Cursor.new(0, 0, :block)}
+
+      filtered = EmitGUI.filter_frame_for_gui(frame)
+      assert filtered.windows == []
+      assert filtered.tab_bar == []
+      assert filtered.splash == nil
+    end
+  end
+
+  describe "emit/2 GUI integration" do
+    test "GUI path strips SwiftUI-owned chrome from draw commands" do
+      state = gui_state(rows: 24, cols: 80, content: long_content(20))
+
+      frame = build_frame_with_window(state, viewport_top: 0)
+
+      face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x21242B)
+
+      frame_with_chrome = %{
+        frame
+        | file_tree: [DisplayList.draw(0, 0, "src/", face)],
+          tab_bar: [DisplayList.draw(0, 0, " main.ex ", face)],
+          agent_panel: [DisplayList.draw(0, 0, "agent", face)],
+          minibuffer: [
+            DisplayList.draw(24, 0, ":quit", Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34))
+          ]
+      }
+
+      Emit.emit(frame_with_chrome, state)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+
+      draw_commands = Enum.filter(commands, &match?(<<0x10, _::binary>>, &1))
+
+      # SwiftUI-owned chrome should NOT appear
+      for chrome_text <- ["src/", " main.ex ", "agent"] do
+        refute Enum.any?(draw_commands, fn <<0x10, _row::16, _col::16, _fg::24, _bg::24,
+                                             _attrs::8, len::16, text::binary-size(len)>> ->
+                 text == chrome_text
+               end),
+               "SwiftUI chrome '#{chrome_text}' should not appear in GUI draw commands"
+      end
+
+      # Minibuffer passes through
+      assert Enum.any?(draw_commands, fn <<0x10, _row::16, _col::16, _fg::24, _bg::24, _attrs::8,
+                                           len::16, text::binary-size(len)>> ->
+               text == ":quit"
+             end)
+    end
+
+    test "GUI path preserves Metal-rendered overlays" do
+      state = gui_state()
+
+      frame = build_frame_with_window(state, viewport_top: 0)
+
+      hover_draw =
+        DisplayList.draw(5, 10, "hover info", Minga.Face.new(fg: 0xBBC2CF, bg: 0x3E4451))
+
+      frame_with_overlay = %{
+        frame
+        | overlays: [%Overlay{draws: [hover_draw]}]
+      }
+
+      Emit.emit(frame_with_overlay, state)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      draw_commands = Enum.filter(commands, &match?(<<0x10, _::binary>>, &1))
+
+      assert Enum.any?(draw_commands, fn <<0x10, _row::16, _col::16, _fg::24, _bg::24, _attrs::8,
+                                           len::16, text::binary-size(len)>> ->
+               text == "hover info"
+             end)
+    end
+  end
+end

--- a/test/minga/editor/render_pipeline/emit/tui_test.exs
+++ b/test/minga/editor/render_pipeline/emit/tui_test.exs
@@ -1,0 +1,326 @@
+defmodule Minga.Editor.RenderPipeline.Emit.TUITest do
+  @moduledoc """
+  Tests for the TUI-specific Emit stage logic: scroll region detection,
+  command building, and helper functions.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.DisplayList
+  alias Minga.Editor.DisplayList.{Cursor, Frame, Overlay}
+  alias Minga.Editor.RenderPipeline.Emit
+  alias Minga.Editor.RenderPipeline.Emit.TUI, as: EmitTUI
+
+  import Minga.Editor.RenderPipeline.TestHelpers
+
+  describe "build_commands via emit/2 (TUI path)" do
+    setup do
+      Process.delete(:emit_prev_viewport_tops)
+      Process.delete(:emit_prev_content_rects)
+      Process.delete(:emit_prev_gutter_ws)
+      :ok
+    end
+
+    test "first frame always does full redraw (clear command present)" do
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        splash: [DisplayList.draw(0, 0, "hello")]
+      }
+
+      state = base_state()
+      Emit.emit(frame, state)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert [<<0x12>> | _] = commands
+    end
+
+    test "converts frame to commands and sends to port_manager" do
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        splash: [DisplayList.draw(0, 0, "hello")]
+      }
+
+      state = base_state()
+      Emit.emit(frame, state)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert is_list(commands)
+      assert Enum.all?(commands, &is_binary/1)
+    end
+  end
+
+  describe "scroll region optimization" do
+    setup do
+      Process.delete(:emit_prev_viewport_tops)
+      Process.delete(:emit_prev_content_rects)
+      Process.delete(:emit_prev_gutter_ws)
+      :ok
+    end
+
+    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
+    test "uses scroll_region when viewport shifts by 1 line" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _first_commands}}
+
+      state2 = simulate_scroll(state, 1)
+      frame2 = build_frame_with_window(state2, viewport_top: 1)
+      Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
+      refute match?([<<0x12>> | _], scroll_commands)
+
+      assert Enum.any?(scroll_commands, fn cmd ->
+               match?(<<0x1B, _::binary>>, cmd)
+             end)
+    end
+
+    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
+    test "uses scroll_region when viewport shifts by 3 lines" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 3)
+      frame2 = build_frame_with_window(state2, viewport_top: 3)
+      Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
+      refute match?([<<0x12>> | _], scroll_commands)
+
+      scroll_cmd =
+        Enum.find(scroll_commands, fn cmd -> match?(<<0x1B, _::binary>>, cmd) end)
+
+      assert <<0x1B, _top::16, _bottom::16, 3::16-signed>> = scroll_cmd
+    end
+
+    test "falls back to full redraw when delta exceeds 3 lines" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 4)
+      frame2 = build_frame_with_window(state2, viewport_top: 4)
+      Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert [<<0x12>> | _] = commands
+    end
+
+    test "falls back to full redraw when no scroll happened" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 5)
+      frame1 = build_frame_with_window(state1, viewport_top: 5)
+      Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      frame2 = build_frame_with_window(state1, viewport_top: 5)
+      Emit.emit(frame2, state1)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert [<<0x12>> | _] = commands
+    end
+
+    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
+    test "scroll_region uses negative delta for scrolling up" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 10)
+      frame1 = build_frame_with_window(state1, viewport_top: 10)
+      Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 8)
+      frame2 = build_frame_with_window(state2, viewport_top: 8)
+      Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
+      refute match?([<<0x12>> | _], scroll_commands)
+
+      scroll_cmd =
+        Enum.find(scroll_commands, fn cmd -> match?(<<0x1B, _::binary>>, cmd) end)
+
+      assert <<0x1B, _top::16, _bottom::16, delta::16-signed>> = scroll_cmd
+      assert delta == -2
+    end
+
+    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
+    test "always includes batch_end in scroll region commands" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 1)
+      frame2 = build_frame_with_window(state2, viewport_top: 1)
+      Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert <<0x13>> = List.last(commands)
+    end
+
+    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
+    test "always includes cursor commands in scroll region output" do
+      state = base_state(rows: 24, cols: 80, content: long_content(100))
+
+      state1 = seed_state(state, 0)
+      frame1 = build_frame_with_window(state1, viewport_top: 0)
+      Emit.emit(frame1, state1)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      state2 = simulate_scroll(state, 1)
+      frame2 = build_frame_with_window(state2, viewport_top: 1)
+      Emit.emit(frame2, state2)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert Enum.any?(commands, fn cmd -> match?(<<0x11, _::binary>>, cmd) end)
+      assert Enum.any?(commands, fn cmd -> match?(<<0x15, _::binary>>, cmd) end)
+    end
+  end
+
+  describe "collect_chrome_draws/1" do
+    test "concatenates all chrome frame fields" do
+      face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
+
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        tab_bar: [DisplayList.draw(0, 0, "tab", face)],
+        file_tree: [DisplayList.draw(1, 0, "tree", face)],
+        agentic_view: [DisplayList.draw(2, 0, "agent_view", face)],
+        separators: [DisplayList.draw(3, 0, "|", face)],
+        status_bar: [DisplayList.draw(4, 0, "status", face)],
+        agent_panel: [DisplayList.draw(5, 0, "panel", face)],
+        minibuffer: [DisplayList.draw(6, 0, ":cmd", face)],
+        splash: [DisplayList.draw(7, 0, "splash", face)]
+      }
+
+      draws = EmitTUI.collect_chrome_draws(frame)
+
+      texts = Enum.map(draws, fn {_r, _c, text, _style} -> text end)
+      assert "tab" in texts
+      assert "tree" in texts
+      assert "agent_view" in texts
+      assert "|" in texts
+      assert "status" in texts
+      assert "panel" in texts
+      assert ":cmd" in texts
+      assert "splash" in texts
+    end
+
+    test "handles nil splash gracefully" do
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        splash: nil
+      }
+
+      draws = EmitTUI.collect_chrome_draws(frame)
+      assert is_list(draws)
+    end
+  end
+
+  describe "collect_overlay_draws/1" do
+    test "flattens overlay draw lists" do
+      face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x3E4451)
+
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        overlays: [
+          %Overlay{draws: [DisplayList.draw(5, 10, "hover", face)]},
+          %Overlay{
+            draws: [DisplayList.draw(6, 10, "sig", face), DisplayList.draw(7, 10, "help", face)]
+          }
+        ]
+      }
+
+      draws = EmitTUI.collect_overlay_draws(frame)
+      texts = Enum.map(draws, fn {_r, _c, text, _style} -> text end)
+      assert length(draws) == 3
+      assert "hover" in texts
+      assert "sig" in texts
+      assert "help" in texts
+    end
+
+    test "returns empty list for frame with no overlays" do
+      frame = %Frame{cursor: Cursor.new(0, 0, :block)}
+      assert EmitTUI.collect_overlay_draws(frame) == []
+    end
+  end
+
+  describe "compute_new_rows/1" do
+    test "returns bottom rows for positive delta (scrolled down)" do
+      delta = %{delta: 2, content_rect: {0, 0, 80, 24}}
+      # bottom = 0 + 24 - 1 = 23, new rows = (23 - 2 + 1)..23 = 22..23
+      assert EmitTUI.compute_new_rows(delta) == 22..23
+    end
+
+    test "returns top rows for negative delta (scrolled up)" do
+      delta = %{delta: -2, content_rect: {0, 0, 80, 24}}
+      assert EmitTUI.compute_new_rows(delta) == 0..1
+    end
+
+    test "handles content_rect with non-zero row offset" do
+      delta = %{delta: 1, content_rect: {5, 0, 80, 20}}
+      # Bottom row is 5 + 20 - 1 = 24, new row is 24..24
+      assert EmitTUI.compute_new_rows(delta) == 24..24
+    end
+  end
+
+  describe "filter_layer_by_ranges/2" do
+    test "returns only draws in the specified row ranges" do
+      face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
+
+      layer = %{
+        0 => [{0, "line0", face}],
+        1 => [{0, "line1", face}],
+        5 => [{0, "line5", face}],
+        8 => [{0, "line8", face}],
+        9 => [{0, "line9", face}]
+      }
+
+      result = EmitTUI.filter_layer_by_ranges(layer, [7..9])
+      texts = Enum.map(result, fn {_r, _c, text, _style} -> text end)
+      assert length(result) == 2
+      assert "line8" in texts
+      assert "line9" in texts
+    end
+
+    test "returns empty list when no rows match" do
+      face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
+      layer = %{0 => [{0, "line0", face}]}
+
+      assert EmitTUI.filter_layer_by_ranges(layer, [5..10]) == []
+    end
+
+    test "handles multiple ranges" do
+      face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
+
+      layer = %{
+        0 => [{0, "line0", face}],
+        3 => [{0, "line3", face}],
+        7 => [{0, "line7", face}]
+      }
+
+      result = EmitTUI.filter_layer_by_ranges(layer, [0..0, 7..7])
+      texts = Enum.map(result, fn {_r, _c, text, _style} -> text end)
+      assert length(result) == 2
+      assert "line0" in texts
+      assert "line7" in texts
+    end
+
+    test "handles empty layer" do
+      assert EmitTUI.filter_layer_by_ranges(%{}, [0..5]) == []
+    end
+  end
+end

--- a/test/minga/editor/render_pipeline/emit_test.exs
+++ b/test/minga/editor/render_pipeline/emit_test.exs
@@ -1,39 +1,77 @@
 defmodule Minga.Editor.RenderPipeline.EmitTest do
   @moduledoc """
-  Tests for the Emit stage of the render pipeline.
+  Tests for the Emit stage dispatcher and shared helpers.
+
+  TUI-specific tests are in `emit/tui_test.exs`.
+  GUI-specific tests are in `emit/gui_test.exs`.
   """
 
   use ExUnit.Case, async: true
 
   alias Minga.Editor.DisplayList
-  alias Minga.Editor.DisplayList.{Cursor, Frame, WindowFrame}
+  alias Minga.Editor.DisplayList.{Cursor, Frame}
   alias Minga.Editor.Layout
   alias Minga.Editor.RenderPipeline.Emit
 
   import Minga.Editor.RenderPipeline.TestHelpers
 
-  alias Minga.Port.Capabilities
+  describe "emit/2 dispatching" do
+    test "TUI path produces commands starting with clear" do
+      Process.delete(:emit_prev_viewport_tops)
+      Process.delete(:emit_prev_content_rects)
+      Process.delete(:emit_prev_gutter_ws)
 
-  describe "emit/2" do
-    test "converts frame to commands and sends to port_manager" do
       frame = %Frame{
         cursor: Cursor.new(0, 0, :block),
         splash: [DisplayList.draw(0, 0, "hello")]
       }
 
       state = base_state()
+      Emit.emit(frame, state)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      assert [<<0x12>> | _] = commands
+    end
+
+    test "GUI path produces commands (no clear expected for GUI with to_commands)" do
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        splash: [DisplayList.draw(0, 0, "hello")]
+      }
+
+      state = gui_state()
       Emit.emit(frame, state)
 
       assert_receive {:"$gen_cast", {:send_commands, commands}}
       assert is_list(commands)
       assert Enum.all?(commands, &is_binary/1)
     end
+  end
 
-    test "first frame always does full redraw (clear command present)" do
-      # Clear any previous tracking state
+  describe "update_tracking (shared)" do
+    test "writes viewport tracking state to process dictionary" do
       Process.delete(:emit_prev_viewport_tops)
       Process.delete(:emit_prev_content_rects)
       Process.delete(:emit_prev_gutter_ws)
+      Process.delete(:emit_prev_buf_versions)
+
+      frame = build_frame_with_window(base_state(), viewport_top: 0)
+      state = base_state()
+      _layout = Layout.put(state)
+
+      Emit.emit(frame, state)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+
+      assert is_map(Process.get(:emit_prev_viewport_tops))
+      assert is_map(Process.get(:emit_prev_content_rects))
+      assert is_map(Process.get(:emit_prev_gutter_ws))
+      assert is_map(Process.get(:emit_prev_buf_versions))
+    end
+  end
+
+  describe "send_title (shared)" do
+    test "sends title command only when title changes" do
+      Process.delete(:last_title)
 
       frame = %Frame{
         cursor: Cursor.new(0, 0, :block),
@@ -43,372 +81,42 @@ defmodule Minga.Editor.RenderPipeline.EmitTest do
       state = base_state()
       Emit.emit(frame, state)
 
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
-      # First command should be clear (0x12)
-      assert [<<0x12>> | _] = commands
+      # Flush first commands + title
+      assert_receive {:"$gen_cast", {:send_commands, _commands}}
+
+      # There may be a title command sent separately
+      title_sent_first = Process.get(:last_title)
+      assert is_binary(title_sent_first)
+
+      # Emit again with same state, title should not be re-sent
+      Emit.emit(frame, state)
+      assert_receive {:"$gen_cast", {:send_commands, _commands2}}
+
+      # Title in process dictionary unchanged
+      assert Process.get(:last_title) == title_sent_first
     end
   end
 
-  describe "scroll region optimization" do
-    setup do
-      # Clear tracking state between tests
-      Process.delete(:emit_prev_viewport_tops)
-      Process.delete(:emit_prev_content_rects)
-      Process.delete(:emit_prev_gutter_ws)
-      :ok
-    end
+  describe "send_window_bg (shared)" do
+    test "sends background command only when theme changes" do
+      Process.delete(:last_window_bg)
 
-    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
-    test "uses scroll_region when viewport shifts by 1 line" do
-      state = base_state(rows: 24, cols: 80, content: long_content(100))
-
-      # First emit: establishes tracking state (full redraw)
-      state1 = seed_state(state, 0)
-      frame1 = build_frame_with_window(state1, viewport_top: 0)
-      Emit.emit(frame1, state1)
-      assert_receive {:"$gen_cast", {:send_commands, _first_commands}}
-
-      # Simulate scrolling down by 1 line
-      state2 = simulate_scroll(state, 1)
-      frame2 = build_frame_with_window(state2, viewport_top: 1)
-      Emit.emit(frame2, state2)
-
-      assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
-      # Should NOT start with clear (0x12)
-      refute match?([<<0x12>> | _], scroll_commands)
-      # Should contain a scroll_region command (0x1B)
-      assert Enum.any?(scroll_commands, fn cmd ->
-               match?(<<0x1B, _::binary>>, cmd)
-             end)
-    end
-
-    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
-    test "uses scroll_region when viewport shifts by 3 lines" do
-      state = base_state(rows: 24, cols: 80, content: long_content(100))
-
-      state1 = seed_state(state, 0)
-      frame1 = build_frame_with_window(state1, viewport_top: 0)
-      Emit.emit(frame1, state1)
-      assert_receive {:"$gen_cast", {:send_commands, _}}
-
-      state2 = simulate_scroll(state, 3)
-      frame2 = build_frame_with_window(state2, viewport_top: 3)
-      Emit.emit(frame2, state2)
-
-      assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
-      refute match?([<<0x12>> | _], scroll_commands)
-
-      # Verify the scroll_region delta is 3
-      scroll_cmd =
-        Enum.find(scroll_commands, fn cmd -> match?(<<0x1B, _::binary>>, cmd) end)
-
-      assert <<0x1B, _top::16, _bottom::16, 3::16-signed>> = scroll_cmd
-    end
-
-    test "falls back to full redraw when delta exceeds 3 lines" do
-      state = base_state(rows: 24, cols: 80, content: long_content(100))
-
-      state1 = seed_state(state, 0)
-      frame1 = build_frame_with_window(state1, viewport_top: 0)
-      Emit.emit(frame1, state1)
-      assert_receive {:"$gen_cast", {:send_commands, _}}
-
-      state2 = simulate_scroll(state, 4)
-      frame2 = build_frame_with_window(state2, viewport_top: 4)
-      Emit.emit(frame2, state2)
-
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
-      # Should start with clear (full redraw)
-      assert [<<0x12>> | _] = commands
-    end
-
-    test "falls back to full redraw when no scroll happened" do
-      state = base_state(rows: 24, cols: 80, content: long_content(100))
-
-      state1 = seed_state(state, 5)
-      frame1 = build_frame_with_window(state1, viewport_top: 5)
-      Emit.emit(frame1, state1)
-      assert_receive {:"$gen_cast", {:send_commands, _}}
-
-      # Same viewport top: no scroll, full redraw (no deltas collected)
-      frame2 = build_frame_with_window(state1, viewport_top: 5)
-      Emit.emit(frame2, state1)
-
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
-      assert [<<0x12>> | _] = commands
-    end
-
-    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
-    test "scroll_region uses negative delta for scrolling up" do
-      state = base_state(rows: 24, cols: 80, content: long_content(100))
-
-      # Start at line 10
-      state1 = seed_state(state, 10)
-      frame1 = build_frame_with_window(state1, viewport_top: 10)
-      Emit.emit(frame1, state1)
-      assert_receive {:"$gen_cast", {:send_commands, _}}
-
-      # Scroll up by 2
-      state2 = simulate_scroll(state, 8)
-      frame2 = build_frame_with_window(state2, viewport_top: 8)
-      Emit.emit(frame2, state2)
-
-      assert_receive {:"$gen_cast", {:send_commands, scroll_commands}}
-      refute match?([<<0x12>> | _], scroll_commands)
-
-      scroll_cmd =
-        Enum.find(scroll_commands, fn cmd -> match?(<<0x1B, _::binary>>, cmd) end)
-
-      assert <<0x1B, _top::16, _bottom::16, delta::16-signed>> = scroll_cmd
-      assert delta == -2
-    end
-
-    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
-    test "always includes batch_end in scroll region commands" do
-      state = base_state(rows: 24, cols: 80, content: long_content(100))
-
-      state1 = seed_state(state, 0)
-      frame1 = build_frame_with_window(state1, viewport_top: 0)
-      Emit.emit(frame1, state1)
-      assert_receive {:"$gen_cast", {:send_commands, _}}
-
-      state2 = simulate_scroll(state, 1)
-      frame2 = build_frame_with_window(state2, viewport_top: 1)
-      Emit.emit(frame2, state2)
-
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
-      # Last command should be batch_end (0x13)
-      assert <<0x13>> = List.last(commands)
-    end
-
-    @tag skip: "scroll optimization disabled pending libvaxis buffer sync fix"
-    test "always includes cursor commands in scroll region output" do
-      state = base_state(rows: 24, cols: 80, content: long_content(100))
-
-      state1 = seed_state(state, 0)
-      frame1 = build_frame_with_window(state1, viewport_top: 0)
-      Emit.emit(frame1, state1)
-      assert_receive {:"$gen_cast", {:send_commands, _}}
-
-      state2 = simulate_scroll(state, 1)
-      frame2 = build_frame_with_window(state2, viewport_top: 1)
-      Emit.emit(frame2, state2)
-
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
-      # Should contain set_cursor (0x11) and set_cursor_shape (0x15)
-      assert Enum.any?(commands, fn cmd -> match?(<<0x11, _::binary>>, cmd) end)
-      assert Enum.any?(commands, fn cmd -> match?(<<0x15, _::binary>>, cmd) end)
-    end
-  end
-
-  describe "GUI frame filtering" do
-    test "GUI path excludes SwiftUI-owned chrome, keeps window content and minibuffer" do
-      state = base_state(rows: 24, cols: 80, content: long_content(20))
-      gui_state = %{state | capabilities: %Capabilities{frontend_type: :native_gui}}
-
-      # SwiftUI-owned fields (file_tree, tab_bar, agent_panel) are stripped
-      # by filter_frame_for_gui. Minibuffer passes through because
-      # Chrome.GUI handles its content upstream.
-      frame = build_frame_with_window(gui_state, viewport_top: 0)
-
-      frame_with_chrome = %{
-        frame
-        | file_tree: [DisplayList.draw(0, 0, "src/", Minga.Face.new(fg: 0xBBC2CF, bg: 0x21242B))],
-          tab_bar: [
-            DisplayList.draw(0, 0, " main.ex ", Minga.Face.new(fg: 0xBBC2CF, bg: 0x21242B))
-          ],
-          agent_panel: [
-            DisplayList.draw(0, 0, "agent", Minga.Face.new(fg: 0xBBC2CF, bg: 0x21242B))
-          ],
-          minibuffer: [
-            DisplayList.draw(24, 0, ":quit", Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34))
-          ]
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        splash: [DisplayList.draw(0, 0, "hello")]
       }
 
-      Emit.emit(frame_with_chrome, gui_state)
-
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
-
-      draw_commands = Enum.filter(commands, &match?(<<0x10, _::binary>>, &1))
-
-      # SwiftUI-owned chrome should NOT appear
-      for chrome_text <- ["src/", " main.ex ", "agent"] do
-        refute Enum.any?(draw_commands, fn <<0x10, _row::16, _col::16, _fg::24, _bg::24,
-                                             _attrs::8, len::16, text::binary-size(len)>> ->
-                 text == chrome_text
-               end),
-               "SwiftUI chrome '#{chrome_text}' should not appear in GUI draw commands"
-      end
-
-      # Window content should still be present
-      assert draw_commands != []
-
-      # Minibuffer passes through (Chrome.GUI handles its content)
-      assert Enum.any?(draw_commands, fn <<0x10, _row::16, _col::16, _fg::24, _bg::24, _attrs::8,
-                                           len::16, text::binary-size(len)>> ->
-               text == ":quit"
-             end)
-    end
-
-    test "GUI emit path uses filtered frame via to_commands" do
       state = base_state()
-      gui_state = %{state | capabilities: %Capabilities{frontend_type: :native_gui}}
+      Emit.emit(frame, state)
 
-      frame = build_frame_with_window(gui_state, viewport_top: 0)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+      bg = Process.get(:last_window_bg)
+      assert bg == state.theme.editor.bg
 
-      frame_with_chrome = %{
-        frame
-        | file_tree: [DisplayList.draw(0, 0, "src/", Minga.Face.new(fg: 0xBBC2CF, bg: 0x21242B))],
-          tab_bar: [DisplayList.draw(0, 0, " tab ", Minga.Face.new(fg: 0xBBC2CF, bg: 0x21242B))]
-      }
-
-      Emit.emit(frame_with_chrome, gui_state)
-
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
-      assert is_list(commands)
-
-      # Should have clear at the start
-      assert [<<0x12>> | _] = commands
-
-      # Should NOT contain file tree or tab bar draw commands.
-      # The file tree draw is at row=0, col=0 with "src/" text.
-      # The tab bar draw is at row=0, col=0 with " tab " text.
-      draw_commands = Enum.filter(commands, &match?(<<0x10, _::binary>>, &1))
-
-      refute Enum.any?(draw_commands, fn <<0x10, _row::16, _col::16, _fg::24, _bg::24, _attrs::8,
-                                           len::16, text::binary-size(len)>> ->
-               text == "src/" or text == " tab "
-             end)
+      # Emit again, should not re-send
+      Emit.emit(frame, state)
+      assert_receive {:"$gen_cast", {:send_commands, _}}
+      assert Process.get(:last_window_bg) == bg
     end
-
-    test "GUI path passes through modeline and minibuffer (Chrome.GUI handles content)" do
-      state = base_state()
-      gui_state = %{state | capabilities: %Capabilities{frontend_type: :native_gui}}
-
-      frame = build_frame_with_window(gui_state, viewport_top: 0)
-
-      frame_with_chrome = %{
-        frame
-        | minibuffer: [
-            DisplayList.draw(24, 0, ":write", Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34))
-          ]
-      }
-
-      Emit.emit(frame_with_chrome, gui_state)
-
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
-
-      draw_commands = Enum.filter(commands, &match?(<<0x10, _::binary>>, &1))
-
-      assert Enum.any?(draw_commands, fn <<0x10, _row::16, _col::16, _fg::24, _bg::24, _attrs::8,
-                                           len::16, text::binary-size(len)>> ->
-               text == ":write"
-             end),
-             "Minibuffer should pass through to Metal renderer"
-    end
-
-    test "GUI path preserves Metal-rendered overlays (hover, signature help)" do
-      state = base_state()
-      gui_state = %{state | capabilities: %Capabilities{frontend_type: :native_gui}}
-
-      frame = build_frame_with_window(gui_state, viewport_top: 0)
-
-      hover_draw =
-        DisplayList.draw(5, 10, "hover info", Minga.Face.new(fg: 0xBBC2CF, bg: 0x3E4451))
-
-      frame_with_overlay = %{
-        frame
-        | overlays: [%DisplayList.Overlay{draws: [hover_draw]}]
-      }
-
-      Emit.emit(frame_with_overlay, gui_state)
-
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
-      draw_commands = Enum.filter(commands, &match?(<<0x10, _::binary>>, &1))
-
-      # The hover overlay draw should be present in the output
-      assert Enum.any?(draw_commands, fn <<0x10, _row::16, _col::16, _fg::24, _bg::24, _attrs::8,
-                                           len::16, text::binary-size(len)>> ->
-               text == "hover info"
-             end)
-    end
-  end
-
-  # ── Test helpers ──────────────────────────────────────────────────────────
-
-  defp long_content(n) do
-    Enum.map_join(1..n, "\n", fn i -> "line #{i}: content here for testing" end)
-  end
-
-  # Sets up the window tracking fields as if a render pass completed at the given
-  # viewport top. Ensures gutter_w and buf_version are consistent across frames.
-  defp simulate_scroll(state, new_top) do
-    win_id = state.windows.active
-    window = Map.get(state.windows.map, win_id)
-
-    updated_window = %{
-      window
-      | last_viewport_top: new_top,
-        last_gutter_w: 4,
-        last_buf_version: 1,
-        last_line_count: 100,
-        last_cursor_line: new_top
-    }
-
-    new_map = Map.put(state.windows.map, win_id, updated_window)
-    %{state | windows: %{state.windows | map: new_map}}
-  end
-
-  # Seeds the initial tracking state so the first frame has consistent values.
-  # Without this, the sentinel values (-1) cause spurious gutter-width mismatches.
-  defp seed_state(state, viewport_top) do
-    simulate_scroll(state, viewport_top)
-  end
-
-  defp build_frame_with_window(state, opts) do
-    viewport_top = Keyword.get(opts, :viewport_top, 0)
-    layout = Layout.put(state) |> Layout.get()
-
-    win_id = state.windows.active
-    win_layout = Map.get(layout.window_layouts, win_id)
-    {_row, _col, width, height} = win_layout.content
-
-    # Build some content draws for the visible area
-    content_draws =
-      for row <- 0..(height - 1) do
-        DisplayList.draw(
-          row,
-          4,
-          "line #{viewport_top + row}: content",
-          Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
-        )
-      end
-
-    gutter_draws =
-      for row <- 0..(height - 1) do
-        DisplayList.draw(
-          row,
-          0,
-          String.pad_leading("#{viewport_top + row + 1}", 3) <> " ",
-          Minga.Face.new(fg: 0x5B6268, bg: 0x282C34)
-        )
-      end
-
-    win_frame = %WindowFrame{
-      rect: {0, 0, width, height},
-      gutter: DisplayList.draws_to_layer(gutter_draws),
-      lines: DisplayList.draws_to_layer(content_draws),
-      tilde_lines: %{},
-      modeline: %{},
-      cursor: nil
-    }
-
-    %Frame{
-      cursor: Cursor.new(0, 4, :block),
-      windows: [win_frame],
-      minibuffer: [
-        DisplayList.draw(height + 1, 0, " ", Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34))
-      ]
-    }
   end
 end

--- a/test/minga/editor/semantic_window_test.exs
+++ b/test/minga/editor/semantic_window_test.exs
@@ -22,16 +22,10 @@ defmodule Minga.Editor.SemanticWindowTest do
   alias Minga.Editor.SemanticWindow.VisualRow
   alias Minga.Editor.State, as: EditorState
   alias Minga.Face
-  alias Minga.Port.Capabilities
+
   alias Minga.Search.Match, as: SearchMatchStruct
 
   import Minga.Editor.RenderPipeline.TestHelpers
-
-  # Creates a GUI-capable base state
-  defp gui_state(opts) do
-    state = base_state(opts)
-    %{state | capabilities: %Capabilities{frontend_type: :native_gui}}
-  end
 
   # Runs through scroll + content stages, returns {frames, cursor, state}
   defp build_content(state) do

--- a/test/support/render_pipeline_test_helpers.ex
+++ b/test/support/render_pipeline_test_helpers.ex
@@ -7,6 +7,9 @@ defmodule Minga.Editor.RenderPipeline.TestHelpers do
   """
 
   alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Editor.DisplayList
+  alias Minga.Editor.DisplayList.{Cursor, Frame, WindowFrame}
+  alias Minga.Editor.Layout
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.{Buffers, Highlighting, Windows}
   alias Minga.Editor.Viewport
@@ -14,6 +17,7 @@ defmodule Minga.Editor.RenderPipeline.TestHelpers do
   alias Minga.Editor.Window
   alias Minga.Editor.WindowTree
   alias Minga.Input
+  alias Minga.Port.Capabilities
   alias Minga.Theme
 
   @doc """
@@ -49,6 +53,106 @@ defmodule Minga.Editor.RenderPipeline.TestHelpers do
       focus_stack: Input.default_stack(),
       theme: Theme.get!(:doom_one),
       highlight: %Highlighting{}
+    }
+  end
+
+  @doc """
+  Constructs a GUI-capable EditorState for pipeline stage tests.
+
+  Same as `base_state/1` but with `frontend_type: :native_gui` capabilities.
+  """
+  @spec gui_state(keyword()) :: EditorState.t()
+  def gui_state(opts \\ []) do
+    state = base_state(opts)
+    %{state | capabilities: %Capabilities{frontend_type: :native_gui}}
+  end
+
+  @doc """
+  Generates content with `n` lines for testing scrolling and large buffers.
+  """
+  @spec long_content(pos_integer()) :: String.t()
+  def long_content(n) do
+    Enum.map_join(1..n, "\n", fn i -> "line #{i}: content here for testing" end)
+  end
+
+  @doc """
+  Updates window tracking fields as if a render pass completed at the given
+  viewport top. Ensures gutter_w and buf_version are consistent across frames.
+  """
+  @spec simulate_scroll(EditorState.t(), non_neg_integer()) :: EditorState.t()
+  def simulate_scroll(state, new_top) do
+    win_id = state.windows.active
+    window = Map.get(state.windows.map, win_id)
+
+    updated_window = %{
+      window
+      | last_viewport_top: new_top,
+        last_gutter_w: 4,
+        last_buf_version: 1,
+        last_line_count: 100,
+        last_cursor_line: new_top
+    }
+
+    new_map = Map.put(state.windows.map, win_id, updated_window)
+    %{state | windows: %{state.windows | map: new_map}}
+  end
+
+  @doc """
+  Seeds the initial tracking state so the first frame has consistent values.
+  Without this, the sentinel values (-1) cause spurious gutter-width mismatches.
+  """
+  @spec seed_state(EditorState.t(), non_neg_integer()) :: EditorState.t()
+  def seed_state(state, viewport_top) do
+    simulate_scroll(state, viewport_top)
+  end
+
+  @doc """
+  Builds a Frame with a single window for testing emit and content stages.
+  """
+  @spec build_frame_with_window(EditorState.t(), keyword()) :: Frame.t()
+  def build_frame_with_window(state, opts) do
+    viewport_top = Keyword.get(opts, :viewport_top, 0)
+    layout = Layout.put(state) |> Layout.get()
+
+    win_id = state.windows.active
+    win_layout = Map.get(layout.window_layouts, win_id)
+    {_row, _col, width, height} = win_layout.content
+
+    content_draws =
+      for row <- 0..(height - 1) do
+        DisplayList.draw(
+          row,
+          4,
+          "line #{viewport_top + row}: content",
+          Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
+        )
+      end
+
+    gutter_draws =
+      for row <- 0..(height - 1) do
+        DisplayList.draw(
+          row,
+          0,
+          String.pad_leading("#{viewport_top + row + 1}", 3) <> " ",
+          Minga.Face.new(fg: 0x5B6268, bg: 0x282C34)
+        )
+      end
+
+    win_frame = %WindowFrame{
+      rect: {0, 0, width, height},
+      gutter: DisplayList.draws_to_layer(gutter_draws),
+      lines: DisplayList.draws_to_layer(content_draws),
+      tilde_lines: %{},
+      modeline: %{},
+      cursor: nil
+    }
+
+    %Frame{
+      cursor: Cursor.new(0, 4, :block),
+      windows: [win_frame],
+      minibuffer: [
+        DisplayList.draw(height + 1, 0, " ", Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34))
+      ]
     }
   end
 end


### PR DESCRIPTION
## What

Completes #737 by splitting the Emit stage into `Emit.TUI` and `Emit.GUI` modules, matching the pattern already established by Chrome and Layout splits.

## Why

The Emit module branched internally on `Capabilities.gui?` for two distinct code paths: TUI scroll region optimization + command building vs GUI frame filtering + chrome sync. These shared almost no logic, making the single module harder to navigate and test.

## Changes

**`Emit.TUI`** (new) — TUI-specific command building:
- Scroll region detection and optimization (currently disabled pending libvaxis fix)
- `build_commands/2` for full redraw vs scroll region paths
- `collect_chrome_draws/1`, `collect_overlay_draws/1` (now public, testable)
- `compute_new_rows/1`, `filter_layer_by_ranges/2` (now public, testable)

**`Emit.GUI`** (updated) — GUI-specific emit logic:
- `filter_frame_for_gui/1` moved here from `Emit` (was private, now public)
- `sync_chrome/2` unchanged

**`Emit`** (slimmed) — dispatcher + shared helpers:
- Resolves `gui?` once, dispatches to the right module
- Shared: `update_tracking`, `send_title`, `send_window_bg`

**Tests restructured** into three files matching the module split:
- `emit_test.exs` — dispatcher + shared helper tests
- `emit/tui_test.exs` — scroll regions, command building, chrome/overlay collection, layer filtering
- `emit/gui_test.exs` — frame filtering (direct unit tests) + integration

Shared test helpers (`gui_state`, `long_content`, `simulate_scroll`, `build_frame_with_window`) moved to `TestHelpers`, removing duplicate definitions from chrome and layout test files.

## Verification

- 32 emit tests pass (5 skipped for disabled scroll optimization)
- Full suite passes (5847 tests)
- `mix lint` clean
- No functional changes to rendering behavior

Closes #737