### PR TITLE
feat(port): gui_window_content encoder + Swift decoder (#828 Phase 2)

### DIFF
--- a/lib/minga/editor/render_pipeline/emit.ex
+++ b/lib/minga/editor/render_pipeline/emit.ex
@@ -25,6 +25,7 @@ defmodule Minga.Editor.RenderPipeline.Emit do
   alias Minga.Editor.Title
   alias Minga.Port.Capabilities
   alias Minga.Port.Manager, as: PortManager
+  alias Minga.Port.Protocol.GUIWindowContent
   alias Minga.Telemetry
 
   @typedoc "Internal editor state."
@@ -69,6 +70,7 @@ defmodule Minga.Editor.RenderPipeline.Emit do
       send_window_bg(state)
 
       if gui? do
+        send_gui_window_content(frame, state)
         status_bar_data = chrome && chrome.status_bar_data
         EmitGUI.sync_chrome(state, status_bar_data)
       else
@@ -125,6 +127,31 @@ defmodule Minga.Editor.RenderPipeline.Emit do
     Process.put(:emit_prev_content_rects, rects)
     Process.put(:emit_prev_gutter_ws, gutter_ws)
     Process.put(:emit_prev_buf_versions, buf_versions)
+    :ok
+  end
+
+  # ── GUI window content (0x80) ────────────────────────────────────────────
+
+  # Sends the gui_window_content opcode for each buffer window that has
+  # a semantic struct attached. This runs alongside (not instead of)
+  # draw_text commands during Phase 2. Phase 3 will stop sending draw_text
+  # for buffer windows.
+  @spec send_gui_window_content(Frame.t(), state()) :: :ok
+  defp send_gui_window_content(frame, state) do
+    cmds =
+      frame.windows
+      |> Enum.flat_map(fn %DisplayList.WindowFrame{semantic: semantic} ->
+        if semantic != nil do
+          [GUIWindowContent.encode(semantic)]
+        else
+          []
+        end
+      end)
+
+    if cmds != [] do
+      PortManager.send_commands(state.port_manager, cmds)
+    end
+
     :ok
   end
 

--- a/lib/minga/port/protocol/gui_window_content.ex
+++ b/lib/minga/port/protocol/gui_window_content.ex
@@ -1,0 +1,193 @@
+defmodule Minga.Port.Protocol.GUIWindowContent do
+  @moduledoc """
+  Binary protocol encoder for the `gui_window_content` opcode (0x80).
+
+  Encodes a `SemanticWindow` struct into the wire format for GUI frontends.
+  This replaces draw_text commands for buffer windows, sending pre-resolved
+  semantic data that Swift renders directly via CoreText.
+
+  ## Wire Format
+
+  ```
+  opcode:               u8 = 0x80
+  window_id:            u16
+  flags:                u8       (bit 0 = full_refresh)
+  cursor_row:           u16      (display row, fold/wrap adjusted)
+  cursor_col:           u16      (display col, virtual text adjusted)
+  cursor_shape:         u8
+  visible_row_count:    u16
+
+  per visible row:
+    row_type:           u8       (0=normal, 1=fold_start, 2=virtual_line,
+                                  3=block, 4=wrap_continuation)
+    buf_line:           u32
+    content_hash:       u32      (for CTLine cache invalidation)
+    text_len:           u32
+    text:               [text_len]  UTF-8
+    span_count:         u16
+    per span:
+      start_col:        u16
+      end_col:          u16
+      fg:               u24
+      bg:               u24
+      attrs:            u8
+      font_weight:      u8
+      font_id:          u8
+
+  selection_type:       u8       0=none, 1=char, 2=line, 3=block
+  if != 0: start_row(u16), start_col(u16), end_row(u16), end_col(u16)
+
+  match_count:          u16
+  per match: row(u16), start_col(u16), end_col(u16), is_current(u8)
+
+  diag_range_count:     u16
+  per range: start_row(u16), start_col(u16), end_row(u16), end_col(u16),
+             severity(u8)
+  ```
+  """
+
+  import Bitwise
+
+  alias Minga.Editor.SemanticWindow
+  alias Minga.Editor.SemanticWindow.DiagnosticRange
+  alias Minga.Editor.SemanticWindow.SearchMatch
+  alias Minga.Editor.SemanticWindow.Selection
+  alias Minga.Editor.SemanticWindow.Span
+  alias Minga.Editor.SemanticWindow.VisualRow
+
+  @op_gui_window_content 0x80
+
+  @doc """
+  Encodes a `SemanticWindow` into the 0x80 wire format.
+
+  Returns a single binary suitable for sending via `PortManager.send_commands/2`.
+  """
+  @spec encode(SemanticWindow.t()) :: binary()
+  def encode(%SemanticWindow{} = sw) do
+    flags = if sw.full_refresh, do: 1, else: 0
+    cursor_shape = encode_cursor_shape(sw.cursor_shape)
+    row_count = length(sw.rows)
+
+    header =
+      <<@op_gui_window_content, sw.window_id::16, flags::8, sw.cursor_row::16, sw.cursor_col::16,
+        cursor_shape::8, row_count::16>>
+
+    rows_binary = encode_rows(sw.rows)
+    selection_binary = encode_selection(sw.selection)
+    matches_binary = encode_search_matches(sw.search_matches)
+    diag_binary = encode_diagnostic_ranges(sw.diagnostic_ranges)
+
+    IO.iodata_to_binary([header, rows_binary, selection_binary, matches_binary, diag_binary])
+  end
+
+  @doc """
+  Returns the opcode constant for gui_window_content.
+  """
+  @spec opcode() :: non_neg_integer()
+  def opcode, do: @op_gui_window_content
+
+  # ── Rows ─────────────────────────────────────────────────────────────────
+
+  @spec encode_rows([VisualRow.t()]) :: iodata()
+  defp encode_rows(rows) do
+    Enum.map(rows, &encode_row/1)
+  end
+
+  @spec encode_row(VisualRow.t()) :: binary()
+  defp encode_row(%VisualRow{} = row) do
+    row_type = encode_row_type(row.row_type)
+    text_bytes = row.text
+    text_len = byte_size(text_bytes)
+    span_count = length(row.spans)
+
+    spans_binary = Enum.map(row.spans, &encode_span/1)
+
+    IO.iodata_to_binary([
+      <<row_type::8, row.buf_line::32, row.content_hash::32, text_len::32, text_bytes::binary,
+        span_count::16>>
+      | spans_binary
+    ])
+  end
+
+  @spec encode_row_type(VisualRow.row_type()) :: non_neg_integer()
+  defp encode_row_type(:normal), do: 0
+  defp encode_row_type(:fold_start), do: 1
+  defp encode_row_type(:virtual_line), do: 2
+  defp encode_row_type(:block), do: 3
+  defp encode_row_type(:wrap_continuation), do: 4
+
+  # ── Spans ────────────────────────────────────────────────────────────────
+
+  @spec encode_span(Span.t()) :: binary()
+  defp encode_span(%Span{} = span) do
+    fg_r = span.fg >>> 16 &&& 0xFF
+    fg_g = span.fg >>> 8 &&& 0xFF
+    fg_b = span.fg &&& 0xFF
+    bg_r = span.bg >>> 16 &&& 0xFF
+    bg_g = span.bg >>> 8 &&& 0xFF
+    bg_b = span.bg &&& 0xFF
+
+    <<span.start_col::16, span.end_col::16, fg_r::8, fg_g::8, fg_b::8, bg_r::8, bg_g::8, bg_b::8,
+      span.attrs::8, span.font_weight::8, span.font_id::8>>
+  end
+
+  # ── Selection ────────────────────────────────────────────────────────────
+
+  @spec encode_selection(Selection.t() | nil) :: binary()
+  defp encode_selection(nil), do: <<0::8>>
+
+  defp encode_selection(%Selection{} = sel) do
+    type_byte = encode_selection_type(sel.type)
+
+    <<type_byte::8, sel.start_row::16, sel.start_col::16, sel.end_row::16, sel.end_col::16>>
+  end
+
+  @spec encode_selection_type(Selection.selection_type()) :: non_neg_integer()
+  defp encode_selection_type(:char), do: 1
+  defp encode_selection_type(:line), do: 2
+  defp encode_selection_type(:block), do: 3
+
+  # ── Search matches ──────────────────────────────────────────────────────
+
+  @spec encode_search_matches([SearchMatch.t()]) :: binary()
+  defp encode_search_matches(matches) do
+    count = length(matches)
+    entries = Enum.map(matches, &encode_search_match/1)
+    IO.iodata_to_binary([<<count::16>> | entries])
+  end
+
+  @spec encode_search_match(SearchMatch.t()) :: binary()
+  defp encode_search_match(%SearchMatch{} = m) do
+    is_current = if m.is_current, do: 1, else: 0
+    <<m.row::16, m.start_col::16, m.end_col::16, is_current::8>>
+  end
+
+  # ── Diagnostic ranges ──────────────────────────────────────────────────
+
+  @spec encode_diagnostic_ranges([DiagnosticRange.t()]) :: binary()
+  defp encode_diagnostic_ranges(ranges) do
+    count = length(ranges)
+    entries = Enum.map(ranges, &encode_diagnostic_range/1)
+    IO.iodata_to_binary([<<count::16>> | entries])
+  end
+
+  @spec encode_diagnostic_range(DiagnosticRange.t()) :: binary()
+  defp encode_diagnostic_range(%DiagnosticRange{} = d) do
+    severity = encode_severity(d.severity)
+
+    <<d.start_row::16, d.start_col::16, d.end_row::16, d.end_col::16, severity::8>>
+  end
+
+  @spec encode_severity(atom()) :: non_neg_integer()
+  defp encode_severity(:error), do: 0
+  defp encode_severity(:warning), do: 1
+  defp encode_severity(:info), do: 2
+  defp encode_severity(:hint), do: 3
+
+  # ── Cursor shape ────────────────────────────────────────────────────────
+
+  @spec encode_cursor_shape(SemanticWindow.cursor_shape()) :: non_neg_integer()
+  defp encode_cursor_shape(:block), do: 0
+  defp encode_cursor_shape(:beam), do: 1
+  defp encode_cursor_shape(:underline), do: 2
+end

--- a/lib/mix/tasks/swift_harness.ex
+++ b/lib/mix/tasks/swift_harness.ex
@@ -21,6 +21,7 @@ defmodule Mix.Tasks.Swift.Harness do
     sources = [
       "macos/Sources/Protocol/ProtocolConstants.swift",
       "macos/Sources/Protocol/ProtocolDecoder.swift",
+      "macos/Sources/Renderer/WindowContent.swift",
       "macos/TestHarness/main.swift"
     ]
 

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		32171233224FC90E1E956631 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C0836F0D4150126F181C05 /* PickerState.swift */; };
 		36E0C059965477465E15CC02 /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */; };
 		3DF3937E460A624254F647BC /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
+		44D48DF33203C53ACC3BA1AA /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
+		46198F3E1A959C3E17E02031 /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
 		471CF61DF64C16924558DE47 /* BottomPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */; };
 		48842D6AE71AA7EB08B9ED03 /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83165B89231936674C54B513 /* EditorNSView.swift */; };
 		49CE8F263AD2A900F0894F32 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
@@ -89,6 +91,7 @@
 		F3BD75F62566F16642D8159D /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
 		F560D385A1FB0A46824F7B1F /* PickerOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F606681DE9AA9D502A42AA /* PickerOverlay.swift */; };
 		FA582944CD6B90BCABC13FCE /* ProtocolReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */; };
+		FEA7FDF0B8C5551790872FCA /* WindowContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7FC26DB745A436D50E3AA6 /* WindowContentTests.swift */; };
 		FEFCEFCDC21C5AA5456036D0 /* SystemColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B00002D020FED57D265C74 /* SystemColorTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -116,6 +119,7 @@
 		638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPanelState.swift; sourceTree = "<group>"; };
 		64CEFB02A774E5E8EF19029F /* MingaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MingaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		70D5765529645C5D860576B7 /* WhichKeyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhichKeyState.swift; sourceTree = "<group>"; };
+		790F7E20F30FEEFC552B3685 /* WindowContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContent.swift; sourceTree = "<group>"; };
 		79F5D551302873BE8F7240ED /* FontManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontManager.swift; sourceTree = "<group>"; };
 		7A67102D81C9E70546F1019B /* MessagesContentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentState.swift; sourceTree = "<group>"; };
 		7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolEncoder.swift; sourceTree = "<group>"; };
@@ -141,6 +145,7 @@
 		F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMECompositionTests.swift; sourceTree = "<group>"; };
 		F87D78FA2B8AA133DDD3141B /* LineBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineBuffer.swift; sourceTree = "<group>"; };
 		FD66FBCBFC20D50D22A969C8 /* SymbolsNerdFontMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SymbolsNerdFontMono-Regular.ttf"; sourceTree = "<group>"; };
+		FD7FC26DB745A436D50E3AA6 /* WindowContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -152,6 +157,7 @@
 				5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */,
 				48E21C30D142028698027567 /* CoreTextShaders.metal */,
 				F87D78FA2B8AA133DDD3141B /* LineBuffer.swift */,
+				790F7E20F30FEEFC552B3685 /* WindowContent.swift */,
 			);
 			path = Renderer;
 			sourceTree = "<group>";
@@ -274,6 +280,7 @@
 				F220A60775A252A728477659 /* ProtocolTests.swift */,
 				211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */,
 				56B00002D020FED57D265C74 /* SystemColorTests.swift */,
+				FD7FC26DB745A436D50E3AA6 /* WindowContentTests.swift */,
 			);
 			path = MingaTests;
 			sourceTree = "<group>";
@@ -424,6 +431,7 @@
 				1512D09504679F58B63B14DD /* ThemeColors.swift in Sources */,
 				3DF3937E460A624254F647BC /* WhichKeyOverlay.swift in Sources */,
 				D3D3326E46122D2FEA329E47 /* WhichKeyState.swift in Sources */,
+				46198F3E1A959C3E17E02031 /* WindowContent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -475,6 +483,8 @@
 				B6295F0247ADE2D1D0133DCB /* ThemeColors.swift in Sources */,
 				6474095F95F4DA480AFE91B7 /* WhichKeyOverlay.swift in Sources */,
 				CF09E23141DB0E6D9B65826A /* WhichKeyState.swift in Sources */,
+				44D48DF33203C53ACC3BA1AA /* WindowContent.swift in Sources */,
+				FEA7FDF0B8C5551790872FCA /* WindowContentTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -42,6 +42,9 @@ let OP_GUI_CURSORLINE: UInt8 = 0x7A
 let OP_GUI_GUTTER: UInt8 = 0x7B
 let OP_GUI_BOTTOM_PANEL: UInt8 = 0x7C
 
+// GUI window content opcode (semantic rendering data for buffer windows)
+let OP_GUI_WINDOW_CONTENT: UInt8 = 0x80
+
 // GUI theme color slot IDs
 let GUI_COLOR_EDITOR_BG: UInt8 = 0x01
 let GUI_COLOR_EDITOR_FG: UInt8 = 0x02

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -39,6 +39,7 @@ enum RenderCommand: Sendable {
     case guiBottomPanel(visible: Bool, activeTabIndex: UInt8, heightPercent: UInt8,
                          filterPreset: UInt8, tabs: [GUIBottomPanelTab],
                          entries: [GUIMessageEntry])
+    case guiWindowContent(data: GUIWindowContent)
 }
 
 /// Line number display style from the BEAM.
@@ -880,6 +881,128 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         return (.guiBottomPanel(visible: true, activeTabIndex: activeTabIndex,
                                  heightPercent: heightPercent, filterPreset: filterPreset,
                                  tabs: tabs, entries: entries), pos - offset)
+
+    case OP_GUI_WINDOW_CONTENT:
+        // Header: window_id:2 + flags:1 + cursor_row:2 + cursor_col:2 + cursor_shape:1 + row_count:2 = 10
+        guard data.count >= rest + 10 else { throw ProtocolDecodeError.malformed }
+        let windowId = readU16(data, rest)
+        let flags = data[rest + 2]
+        let cursorRow = readU16(data, rest + 3)
+        let cursorCol = readU16(data, rest + 5)
+        let cursorShape = CursorShape(rawValue: data[rest + 7]) ?? .block
+        let rowCount = Int(readU16(data, rest + 8))
+        var pos = rest + 10
+
+        // Decode rows
+        var rows: [GUIVisualRow] = []
+        rows.reserveCapacity(rowCount)
+        for _ in 0..<rowCount {
+            // row_type:1 + buf_line:4 + content_hash:4 + text_len:4 = 13
+            guard data.count >= pos + 13 else { throw ProtocolDecodeError.malformed }
+            let rowType = GUIVisualRowType(rawValue: data[pos]) ?? .normal
+            let bufLine = readU32(data, pos + 1)
+            let contentHash = readU32(data, pos + 5)
+            let textLen = Int(readU32(data, pos + 9))
+            pos += 13
+            guard data.count >= pos + textLen else { throw ProtocolDecodeError.malformed }
+            let text = String(data: data[pos..<(pos + textLen)], encoding: .utf8) ?? ""
+            pos += textLen
+
+            // span_count:2
+            guard data.count >= pos + 2 else { throw ProtocolDecodeError.malformed }
+            let spanCount = Int(readU16(data, pos))
+            pos += 2
+
+            // Each span: start_col:2 + end_col:2 + fg:3 + bg:3 + attrs:1 + font_weight:1 + font_id:1 = 13
+            var spans: [GUIHighlightSpan] = []
+            spans.reserveCapacity(spanCount)
+            for _ in 0..<spanCount {
+                guard data.count >= pos + 13 else { throw ProtocolDecodeError.malformed }
+                let startCol = readU16(data, pos)
+                let endCol = readU16(data, pos + 2)
+                let fg = readU24(data, pos + 4)
+                let bg = readU24(data, pos + 7)
+                let attrs = data[pos + 10]
+                let fontWeight = data[pos + 11]
+                let fontId = data[pos + 12]
+                spans.append(GUIHighlightSpan(
+                    startCol: startCol, endCol: endCol,
+                    fg: fg, bg: bg, attrs: attrs,
+                    fontWeight: fontWeight, fontId: fontId
+                ))
+                pos += 13
+            }
+
+            rows.append(GUIVisualRow(
+                rowType: rowType, bufLine: bufLine,
+                contentHash: contentHash, text: text, spans: spans
+            ))
+        }
+
+        // Selection: type:1, then if type != 0: start_row:2 + start_col:2 + end_row:2 + end_col:2
+        guard data.count >= pos + 1 else { throw ProtocolDecodeError.malformed }
+        let selType = data[pos]
+        pos += 1
+        var selection: GUISelectionOverlay? = nil
+        if selType != 0 {
+            guard data.count >= pos + 8 else { throw ProtocolDecodeError.malformed }
+            selection = GUISelectionOverlay(
+                type: GUISelectionType(rawValue: selType) ?? .char,
+                startRow: readU16(data, pos),
+                startCol: readU16(data, pos + 2),
+                endRow: readU16(data, pos + 4),
+                endCol: readU16(data, pos + 6)
+            )
+            pos += 8
+        }
+
+        // Search matches: count:2, then per match: row:2 + start_col:2 + end_col:2 + is_current:1 = 7
+        guard data.count >= pos + 2 else { throw ProtocolDecodeError.malformed }
+        let matchCount = Int(readU16(data, pos))
+        pos += 2
+        var matches: [GUISearchMatch] = []
+        matches.reserveCapacity(matchCount)
+        for _ in 0..<matchCount {
+            guard data.count >= pos + 7 else { throw ProtocolDecodeError.malformed }
+            matches.append(GUISearchMatch(
+                row: readU16(data, pos),
+                startCol: readU16(data, pos + 2),
+                endCol: readU16(data, pos + 4),
+                isCurrent: data[pos + 6] != 0
+            ))
+            pos += 7
+        }
+
+        // Diagnostic ranges: count:2, then per range: start_row:2 + start_col:2 + end_row:2 + end_col:2 + severity:1 = 9
+        guard data.count >= pos + 2 else { throw ProtocolDecodeError.malformed }
+        let diagCount = Int(readU16(data, pos))
+        pos += 2
+        var diags: [GUIDiagnosticUnderline] = []
+        diags.reserveCapacity(diagCount)
+        for _ in 0..<diagCount {
+            guard data.count >= pos + 9 else { throw ProtocolDecodeError.malformed }
+            diags.append(GUIDiagnosticUnderline(
+                startRow: readU16(data, pos),
+                startCol: readU16(data, pos + 2),
+                endRow: readU16(data, pos + 4),
+                endCol: readU16(data, pos + 6),
+                severity: GUIDiagnosticSeverity(rawValue: data[pos + 8]) ?? .error
+            ))
+            pos += 9
+        }
+
+        let content = GUIWindowContent(
+            windowId: windowId,
+            fullRefresh: (flags & 0x01) != 0,
+            cursorRow: cursorRow,
+            cursorCol: cursorCol,
+            cursorShape: cursorShape,
+            rows: rows,
+            selection: selection,
+            searchMatches: matches,
+            diagnosticUnderlines: diags
+        )
+        return (.guiWindowContent(data: content), pos - offset)
 
     default:
         throw ProtocolDecodeError.unknownOpcode(opcode)

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -224,6 +224,12 @@ final class CommandDispatcher {
                 lineBuffer.gutterCol = UInt16(data.lineNumberWidth) + UInt16(data.signColWidth)
             }
 
+        case .guiWindowContent(let data):
+            // Phase 2: store the semantic window content for future rendering.
+            // During Phase 2, draw_text commands still drive rendering.
+            // Phase 3 will switch to rendering from this data.
+            guiState.windowContent = data
+
         case .guiBottomPanel(let visible, let activeTabIndex, let heightPercent, let filterPreset, let tabs, let entries):
             if visible {
                 let panelTabs = tabs.enumerated().map { (i, t) in

--- a/macos/Sources/Renderer/WindowContent.swift
+++ b/macos/Sources/Renderer/WindowContent.swift
@@ -1,0 +1,139 @@
+/// Semantic window content decoded from the gui_window_content (0x80) opcode.
+///
+/// Replaces LineBuffer-based rendering for buffer windows. The BEAM sends
+/// pre-resolved visual rows with composed text, highlight spans, selection,
+/// search matches, and diagnostic ranges. Swift renders this directly via
+/// CoreText without interpreting cell-grid draw_text commands.
+///
+/// Phase 2: stored alongside LineBuffer, not yet used for rendering.
+/// Phase 3: replaces LineBuffer for buffer window content.
+
+import Foundation
+
+// MARK: - Row type
+
+/// What kind of content a visual row represents.
+enum GUIVisualRowType: UInt8, Sendable {
+    case normal = 0
+    case foldStart = 1
+    case virtualLine = 2
+    case block = 3
+    case wrapContinuation = 4
+}
+
+// MARK: - Highlight span
+
+/// A pre-resolved highlight span from the BEAM's syntax highlighter.
+///
+/// Colors are already resolved to 24-bit RGB. Swift applies them directly
+/// when building NSAttributedString; no syntax-token-to-theme mapping.
+struct GUIHighlightSpan: Sendable, Equatable {
+    let startCol: UInt16
+    let endCol: UInt16
+    let fg: UInt32      // 24-bit RGB
+    let bg: UInt32      // 24-bit RGB (0 = transparent)
+    let attrs: UInt8    // bit 0: bold, 1: italic, 2: underline, 3: strikethrough, 4: curl
+    let fontWeight: UInt8
+    let fontId: UInt8
+
+    var isBold: Bool { attrs & 0x01 != 0 }
+    var isItalic: Bool { attrs & 0x02 != 0 }
+    var isUnderline: Bool { attrs & 0x04 != 0 }
+    var isStrikethrough: Bool { attrs & 0x08 != 0 }
+    var isCurl: Bool { attrs & 0x10 != 0 }
+}
+
+// MARK: - Visual row
+
+/// A single visual row as the GUI should render it.
+///
+/// The BEAM has already resolved word wrap, folding, virtual text splicing,
+/// and conceal ranges. The `text` field is the final composed UTF-8 string.
+struct GUIVisualRow: Sendable, Equatable {
+    let rowType: GUIVisualRowType
+    let bufLine: UInt32
+    let contentHash: UInt32
+    let text: String
+    let spans: [GUIHighlightSpan]
+}
+
+// MARK: - Selection overlay
+
+/// Visual selection in display coordinates, rendered as Metal quads.
+enum GUISelectionType: UInt8, Sendable {
+    case char = 1
+    case line = 2
+    case block = 3
+}
+
+struct GUISelectionOverlay: Sendable, Equatable {
+    let type: GUISelectionType
+    let startRow: UInt16
+    let startCol: UInt16
+    let endRow: UInt16
+    let endCol: UInt16
+}
+
+// MARK: - Search match
+
+/// A search match in display coordinates, rendered as a highlight quad.
+struct GUISearchMatch: Sendable, Equatable {
+    let row: UInt16
+    let startCol: UInt16
+    let endCol: UInt16
+    let isCurrent: Bool
+}
+
+// MARK: - Diagnostic underline
+
+/// Diagnostic severity for underline rendering.
+enum GUIDiagnosticSeverity: UInt8, Sendable {
+    case error = 0
+    case warning = 1
+    case info = 2
+    case hint = 3
+}
+
+/// A diagnostic range in display coordinates, rendered as an underline.
+struct GUIDiagnosticUnderline: Sendable, Equatable {
+    let startRow: UInt16
+    let startCol: UInt16
+    let endRow: UInt16
+    let endCol: UInt16
+    let severity: GUIDiagnosticSeverity
+}
+
+// MARK: - Window content
+
+/// Complete semantic content for one editor window.
+///
+/// Decoded from the gui_window_content (0x80) opcode. During Phase 2,
+/// this is stored but not yet used for rendering (draw_text still active).
+/// Phase 3 will switch rendering to use this data directly.
+final class GUIWindowContent: Sendable {
+    let windowId: UInt16
+    let fullRefresh: Bool
+    let cursorRow: UInt16
+    let cursorCol: UInt16
+    let cursorShape: CursorShape
+    let rows: [GUIVisualRow]
+    let selection: GUISelectionOverlay?
+    let searchMatches: [GUISearchMatch]
+    let diagnosticUnderlines: [GUIDiagnosticUnderline]
+
+    init(windowId: UInt16, fullRefresh: Bool,
+         cursorRow: UInt16, cursorCol: UInt16, cursorShape: CursorShape,
+         rows: [GUIVisualRow], selection: GUISelectionOverlay?,
+         searchMatches: [GUISearchMatch],
+         diagnosticUnderlines: [GUIDiagnosticUnderline]) {
+        self.windowId = windowId
+        self.fullRefresh = fullRefresh
+        self.cursorRow = cursorRow
+        self.cursorCol = cursorCol
+        self.cursorShape = cursorShape
+        self.rows = rows
+        self.selection = selection
+        self.searchMatches = searchMatches
+        self.diagnosticUnderlines = diagnosticUnderlines
+    }
+}

--- a/macos/Sources/Views/GUIState.swift
+++ b/macos/Sources/Views/GUIState.swift
@@ -38,4 +38,9 @@ final class GUIState {
 
     /// Bottom panel container state.
     let bottomPanelState = BottomPanelState()
+
+    /// Semantic window content from gui_window_content (0x80).
+    /// Phase 2: stored but not yet used for rendering. Phase 3 will
+    /// switch buffer window rendering from draw_text to this data.
+    var windowContent: GUIWindowContent?
 }

--- a/macos/Tests/MingaTests/WindowContentTests.swift
+++ b/macos/Tests/MingaTests/WindowContentTests.swift
@@ -1,0 +1,389 @@
+/// Tests for the gui_window_content (0x80) protocol decoder.
+///
+/// Verifies that the Swift decoder correctly parses binaries produced
+/// by the BEAM's GUIWindowContent encoder. Tests build binary payloads
+/// matching the wire format spec, decode them, and assert field values.
+
+import Testing
+import Foundation
+
+// MARK: - Binary builder helpers
+
+/// Builds a gui_window_content binary payload for testing.
+struct WindowContentBuilder {
+    var windowId: UInt16 = 1
+    var flags: UInt8 = 1  // full_refresh
+    var cursorRow: UInt16 = 0
+    var cursorCol: UInt16 = 0
+    var cursorShape: UInt8 = 0  // block
+    var rows: [RowBuilder] = []
+    var selectionType: UInt8 = 0
+    var selectionCoords: (UInt16, UInt16, UInt16, UInt16)?
+    var searchMatches: [(row: UInt16, startCol: UInt16, endCol: UInt16, isCurrent: UInt8)] = []
+    var diagnosticRanges: [(startRow: UInt16, startCol: UInt16, endRow: UInt16, endCol: UInt16, severity: UInt8)] = []
+
+    struct RowBuilder {
+        var rowType: UInt8 = 0  // normal
+        var bufLine: UInt32 = 0
+        var contentHash: UInt32 = 12345
+        var text: String = ""
+        var spans: [SpanBuilder] = []
+    }
+
+    struct SpanBuilder {
+        var startCol: UInt16 = 0
+        var endCol: UInt16 = 0
+        var fgR: UInt8 = 0; var fgG: UInt8 = 0; var fgB: UInt8 = 0
+        var bgR: UInt8 = 0; var bgG: UInt8 = 0; var bgB: UInt8 = 0
+        var attrs: UInt8 = 0
+        var fontWeight: UInt8 = 0
+        var fontId: UInt8 = 0
+    }
+
+    func build() -> Data {
+        var data = Data()
+        data.append(OP_GUI_WINDOW_CONTENT)
+        appendU16(&data, windowId)
+        data.append(flags)
+        appendU16(&data, cursorRow)
+        appendU16(&data, cursorCol)
+        data.append(cursorShape)
+        appendU16(&data, UInt16(rows.count))
+
+        for row in rows {
+            data.append(row.rowType)
+            appendU32(&data, row.bufLine)
+            appendU32(&data, row.contentHash)
+            let textBytes = Array(row.text.utf8)
+            appendU32(&data, UInt32(textBytes.count))
+            data.append(contentsOf: textBytes)
+            appendU16(&data, UInt16(row.spans.count))
+            for span in row.spans {
+                appendU16(&data, span.startCol)
+                appendU16(&data, span.endCol)
+                data.append(contentsOf: [span.fgR, span.fgG, span.fgB])
+                data.append(contentsOf: [span.bgR, span.bgG, span.bgB])
+                data.append(span.attrs)
+                data.append(span.fontWeight)
+                data.append(span.fontId)
+            }
+        }
+
+        data.append(selectionType)
+        if selectionType != 0, let coords = selectionCoords {
+            appendU16(&data, coords.0)
+            appendU16(&data, coords.1)
+            appendU16(&data, coords.2)
+            appendU16(&data, coords.3)
+        }
+
+        appendU16(&data, UInt16(searchMatches.count))
+        for m in searchMatches {
+            appendU16(&data, m.row)
+            appendU16(&data, m.startCol)
+            appendU16(&data, m.endCol)
+            data.append(m.isCurrent)
+        }
+
+        appendU16(&data, UInt16(diagnosticRanges.count))
+        for d in diagnosticRanges {
+            appendU16(&data, d.startRow)
+            appendU16(&data, d.startCol)
+            appendU16(&data, d.endRow)
+            appendU16(&data, d.endCol)
+            data.append(d.severity)
+        }
+
+        return data
+    }
+
+    private func appendU16(_ data: inout Data, _ value: UInt16) {
+        data.append(UInt8(value >> 8))
+        data.append(UInt8(value & 0xFF))
+    }
+
+    private func appendU32(_ data: inout Data, _ value: UInt32) {
+        data.append(UInt8((value >> 24) & 0xFF))
+        data.append(UInt8((value >> 16) & 0xFF))
+        data.append(UInt8((value >> 8) & 0xFF))
+        data.append(UInt8(value & 0xFF))
+    }
+}
+
+// MARK: - Tests
+
+@Suite("GUI Window Content Decoder")
+struct WindowContentDecoderTests {
+
+    @Test("Decode empty window (0 rows, no selection, no matches, no diagnostics)")
+    func decodeEmptyWindow() throws {
+        let builder = WindowContentBuilder(windowId: 42, cursorRow: 0, cursorCol: 0)
+        let data = builder.build()
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+
+        #expect(size == data.count)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent, got \(String(describing: cmd))")
+            return
+        }
+
+        #expect(content.windowId == 42)
+        #expect(content.fullRefresh == true)
+        #expect(content.cursorRow == 0)
+        #expect(content.cursorCol == 0)
+        #expect(content.cursorShape == .block)
+        #expect(content.rows.isEmpty)
+        #expect(content.selection == nil)
+        #expect(content.searchMatches.isEmpty)
+        #expect(content.diagnosticUnderlines.isEmpty)
+    }
+
+    @Test("Decode header fields: window_id, cursor, shape, full_refresh")
+    func decodeHeaderFields() throws {
+        var builder = WindowContentBuilder()
+        builder.windowId = 7
+        builder.flags = 0  // full_refresh = false
+        builder.cursorRow = 15
+        builder.cursorCol = 42
+        builder.cursorShape = 1  // beam
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.windowId == 7)
+        #expect(content.fullRefresh == false)
+        #expect(content.cursorRow == 15)
+        #expect(content.cursorCol == 42)
+        #expect(content.cursorShape == .beam)
+    }
+
+    @Test("Decode rows with text and buf_line")
+    func decodeRows() throws {
+        var builder = WindowContentBuilder()
+        builder.rows = [
+            .init(rowType: 0, bufLine: 0, text: "hello"),
+            .init(rowType: 0, bufLine: 1, text: "world"),
+        ]
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.rows.count == 2)
+        #expect(content.rows[0].text == "hello")
+        #expect(content.rows[0].bufLine == 0)
+        #expect(content.rows[1].text == "world")
+        #expect(content.rows[1].bufLine == 1)
+    }
+
+    @Test("Decode all row types")
+    func decodeRowTypes() throws {
+        var builder = WindowContentBuilder()
+        builder.rows = [
+            .init(rowType: 0, text: "normal"),
+            .init(rowType: 1, text: "fold"),
+            .init(rowType: 2, text: "virtual"),
+            .init(rowType: 3, text: "block"),
+            .init(rowType: 4, text: "wrap"),
+        ]
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.rows[0].rowType == .normal)
+        #expect(content.rows[1].rowType == .foldStart)
+        #expect(content.rows[2].rowType == .virtualLine)
+        #expect(content.rows[3].rowType == .block)
+        #expect(content.rows[4].rowType == .wrapContinuation)
+    }
+
+    @Test("Decode multi-byte UTF-8 text")
+    func decodeUTF8() throws {
+        var builder = WindowContentBuilder()
+        builder.rows = [.init(text: "🥨日本語héllo")]
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.rows[0].text == "🥨日本語héllo")
+    }
+
+    @Test("Decode content_hash")
+    func decodeContentHash() throws {
+        var builder = WindowContentBuilder()
+        builder.rows = [.init(contentHash: 0xDEADBEEF, text: "x")]
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.rows[0].contentHash == 0xDEADBEEF)
+    }
+
+    @Test("Decode spans with colors and attributes")
+    func decodeSpans() throws {
+        var builder = WindowContentBuilder()
+        let span = WindowContentBuilder.SpanBuilder(
+            startCol: 3, endCol: 17,
+            fgR: 0xFF, fgG: 0x6C, fgB: 0x6B,
+            bgR: 0x28, bgG: 0x2C, bgB: 0x34,
+            attrs: 0x03,  // bold + italic
+            fontWeight: 5, fontId: 2
+        )
+        builder.rows = [.init(text: "hello world", spans: [span])]
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        let s = content.rows[0].spans[0]
+        #expect(s.startCol == 3)
+        #expect(s.endCol == 17)
+        #expect(s.fg == 0xFF6C6B)
+        #expect(s.bg == 0x282C34)
+        #expect(s.isBold == true)
+        #expect(s.isItalic == true)
+        #expect(s.isUnderline == false)
+        #expect(s.fontWeight == 5)
+        #expect(s.fontId == 2)
+    }
+
+    @Test("Decode char selection")
+    func decodeCharSelection() throws {
+        var builder = WindowContentBuilder()
+        builder.selectionType = 1  // char
+        builder.selectionCoords = (2, 5, 7, 15)
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.selection != nil)
+        #expect(content.selection?.type == .char)
+        #expect(content.selection?.startRow == 2)
+        #expect(content.selection?.startCol == 5)
+        #expect(content.selection?.endRow == 7)
+        #expect(content.selection?.endCol == 15)
+    }
+
+    @Test("Decode nil selection")
+    func decodeNilSelection() throws {
+        let builder = WindowContentBuilder()  // selectionType defaults to 0
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.selection == nil)
+    }
+
+    @Test("Decode search matches with is_current flag")
+    func decodeSearchMatches() throws {
+        var builder = WindowContentBuilder()
+        builder.searchMatches = [
+            (row: 5, startCol: 10, endCol: 15, isCurrent: 0),
+            (row: 8, startCol: 0, endCol: 3, isCurrent: 1),
+        ]
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.searchMatches.count == 2)
+        #expect(content.searchMatches[0].row == 5)
+        #expect(content.searchMatches[0].startCol == 10)
+        #expect(content.searchMatches[0].isCurrent == false)
+        #expect(content.searchMatches[1].row == 8)
+        #expect(content.searchMatches[1].isCurrent == true)
+    }
+
+    @Test("Decode diagnostic ranges with all severity levels")
+    func decodeDiagnosticRanges() throws {
+        var builder = WindowContentBuilder()
+        builder.diagnosticRanges = [
+            (startRow: 1, startCol: 0, endRow: 1, endCol: 10, severity: 0),  // error
+            (startRow: 3, startCol: 5, endRow: 3, endCol: 20, severity: 1),  // warning
+            (startRow: 5, startCol: 0, endRow: 5, endCol: 5, severity: 2),   // info
+            (startRow: 7, startCol: 0, endRow: 7, endCol: 3, severity: 3),   // hint
+        ]
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.diagnosticUnderlines.count == 4)
+        #expect(content.diagnosticUnderlines[0].severity == .error)
+        #expect(content.diagnosticUnderlines[1].severity == .warning)
+        #expect(content.diagnosticUnderlines[2].severity == .info)
+        #expect(content.diagnosticUnderlines[3].severity == .hint)
+        #expect(content.diagnosticUnderlines[0].startRow == 1)
+        #expect(content.diagnosticUnderlines[1].startCol == 5)
+    }
+
+    @Test("Decode consumes entire binary (no leftover bytes)")
+    func decodeConsumesAllBytes() throws {
+        var builder = WindowContentBuilder()
+        builder.rows = [.init(text: "hello", spans: [
+            .init(startCol: 0, endCol: 5, fgR: 0xFF, fgG: 0, fgB: 0)
+        ])]
+        builder.selectionType = 1
+        builder.selectionCoords = (0, 0, 0, 5)
+        builder.searchMatches = [(row: 0, startCol: 0, endCol: 5, isCurrent: 1)]
+        builder.diagnosticRanges = [(startRow: 0, startCol: 0, endRow: 0, endCol: 5, severity: 0)]
+
+        let data = builder.build()
+        let (_, size) = try decodeCommand(data: data, offset: 0)
+
+        #expect(size == data.count, "Decoder should consume all \(data.count) bytes, consumed \(size)")
+    }
+
+    @Test("Complete window with all sections decodes correctly")
+    func decodeCompleteWindow() throws {
+        var builder = WindowContentBuilder(windowId: 7, cursorRow: 1, cursorCol: 3, cursorShape: 1)
+        builder.rows = [
+            .init(rowType: 0, bufLine: 0, text: "def foo do", spans: [
+                .init(startCol: 0, endCol: 3, fgR: 0x51, fgG: 0xAF, fgB: 0xEF, attrs: 0x01),
+                .init(startCol: 4, endCol: 7, fgR: 0xEC, fgG: 0xBE, fgB: 0x7B),
+            ]),
+            .init(rowType: 1, bufLine: 1, text: "  :ok ··· 3 lines"),
+        ]
+        builder.selectionType = 1
+        builder.selectionCoords = (0, 0, 0, 10)
+        builder.searchMatches = [(row: 0, startCol: 4, endCol: 7, isCurrent: 0)]
+        builder.diagnosticRanges = [(startRow: 0, startCol: 0, endRow: 0, endCol: 3, severity: 1)]
+
+        let data = builder.build()
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.windowId == 7)
+        #expect(content.cursorShape == .beam)
+        #expect(content.rows.count == 2)
+        #expect(content.rows[0].text == "def foo do")
+        #expect(content.rows[0].spans.count == 2)
+        #expect(content.rows[0].spans[0].fg == 0x51AFEF)
+        #expect(content.rows[0].spans[0].isBold == true)
+        #expect(content.rows[1].rowType == .foldStart)
+        #expect(content.selection?.type == .char)
+        #expect(content.searchMatches.count == 1)
+        #expect(content.diagnosticUnderlines.count == 1)
+        #expect(content.diagnosticUnderlines[0].severity == .warning)
+    }
+}

--- a/test/minga/port/protocol/gui_window_content_test.exs
+++ b/test/minga/port/protocol/gui_window_content_test.exs
@@ -1,0 +1,545 @@
+defmodule Minga.Port.Protocol.GUIWindowContentTest do
+  @moduledoc """
+  Tests for the gui_window_content (0x80) encoder.
+
+  Uses a test-only decoder for round-trip assertions, plus a few
+  intentionally brittle wire format pinning tests that define the
+  contract with the Swift decoder.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Minga.Editor.SemanticWindow
+  alias Minga.Editor.SemanticWindow.DiagnosticRange
+  alias Minga.Editor.SemanticWindow.SearchMatch
+  alias Minga.Editor.SemanticWindow.Selection
+  alias Minga.Editor.SemanticWindow.Span
+  alias Minga.Editor.SemanticWindow.VisualRow
+  alias Minga.Port.Protocol.GUIWindowContent
+  alias Minga.Test.GUIWindowContentDecoder
+
+  # ── Helpers ──────────────────────────────────────────────────────────────
+
+  defp minimal_window(opts) do
+    %SemanticWindow{
+      window_id: Keyword.get(opts, :window_id, 1),
+      rows: Keyword.get(opts, :rows, []),
+      cursor_row: Keyword.get(opts, :cursor_row, 0),
+      cursor_col: Keyword.get(opts, :cursor_col, 0),
+      cursor_shape: Keyword.get(opts, :cursor_shape, :block),
+      selection: Keyword.get(opts, :selection, nil),
+      search_matches: Keyword.get(opts, :search_matches, []),
+      diagnostic_ranges: Keyword.get(opts, :diagnostic_ranges, []),
+      full_refresh: Keyword.get(opts, :full_refresh, true)
+    }
+  end
+
+  defp make_row(text, opts \\ []) do
+    %VisualRow{
+      row_type: Keyword.get(opts, :row_type, :normal),
+      buf_line: Keyword.get(opts, :buf_line, 0),
+      text: text,
+      spans: Keyword.get(opts, :spans, []),
+      content_hash: Keyword.get(opts, :content_hash, 12_345)
+    }
+  end
+
+  defp make_span(start_col, end_col, opts) do
+    %Span{
+      start_col: start_col,
+      end_col: end_col,
+      fg: Keyword.get(opts, :fg, 0xFF6C6B),
+      bg: Keyword.get(opts, :bg, 0x282C34),
+      attrs: Keyword.get(opts, :attrs, 0),
+      font_weight: Keyword.get(opts, :font_weight, 0),
+      font_id: Keyword.get(opts, :font_id, 0)
+    }
+  end
+
+  defp round_trip(sw) do
+    sw |> GUIWindowContent.encode() |> GUIWindowContentDecoder.decode()
+  end
+
+  # ── Round-trip: header fields ──────────────────────────────────────────
+
+  describe "round-trip: header fields" do
+    test "all header fields survive round-trip" do
+      sw =
+        minimal_window(
+          window_id: 42,
+          cursor_row: 15,
+          cursor_col: 33,
+          cursor_shape: :beam,
+          full_refresh: true
+        )
+
+      decoded = round_trip(sw)
+
+      assert decoded.window_id == 42
+      assert decoded.cursor_row == 15
+      assert decoded.cursor_col == 33
+      assert decoded.cursor_shape == :beam
+      assert decoded.full_refresh == true
+    end
+
+    test "full_refresh false round-trips" do
+      decoded = round_trip(minimal_window(full_refresh: false))
+      assert decoded.full_refresh == false
+    end
+
+    test "all cursor shapes round-trip" do
+      for shape <- [:block, :beam, :underline] do
+        decoded = round_trip(minimal_window(cursor_shape: shape))
+        assert decoded.cursor_shape == shape
+      end
+    end
+  end
+
+  # ── Round-trip: rows ───────────────────────────────────────────────────
+
+  describe "round-trip: rows" do
+    test "row text and buf_line survive round-trip" do
+      rows = [make_row("hello", buf_line: 7), make_row("world", buf_line: 8)]
+      decoded = round_trip(minimal_window(rows: rows))
+
+      assert length(decoded.rows) == 2
+      assert Enum.at(decoded.rows, 0).text == "hello"
+      assert Enum.at(decoded.rows, 0).buf_line == 7
+      assert Enum.at(decoded.rows, 1).text == "world"
+      assert Enum.at(decoded.rows, 1).buf_line == 8
+    end
+
+    test "all row types round-trip to distinct values" do
+      types = [:normal, :fold_start, :virtual_line, :block, :wrap_continuation]
+
+      rows =
+        Enum.with_index(types, fn type, i ->
+          make_row("line #{i}", row_type: type, buf_line: i)
+        end)
+
+      decoded = round_trip(minimal_window(rows: rows))
+      decoded_types = Enum.map(decoded.rows, & &1.row_type)
+
+      assert decoded_types == types
+    end
+
+    test "content_hash round-trips" do
+      decoded = round_trip(minimal_window(rows: [make_row("x", content_hash: 0xDEADBEEF)]))
+      assert hd(decoded.rows).content_hash == 0xDEADBEEF
+    end
+
+    test "multi-byte UTF-8 text round-trips" do
+      decoded = round_trip(minimal_window(rows: [make_row("🥨日本語héllo")]))
+      assert hd(decoded.rows).text == "🥨日本語héllo"
+    end
+
+    test "empty text round-trips" do
+      decoded = round_trip(minimal_window(rows: [make_row("")]))
+      assert hd(decoded.rows).text == ""
+    end
+
+    test "row with zero spans round-trips" do
+      decoded = round_trip(minimal_window(rows: [make_row("hello", spans: [])]))
+      assert hd(decoded.rows).spans == []
+    end
+  end
+
+  # ── Round-trip: spans ──────────────────────────────────────────────────
+
+  describe "round-trip: spans" do
+    test "span columns and colors round-trip" do
+      span = make_span(3, 17, fg: 0xFF6C6B, bg: 0x282C34)
+      decoded = round_trip(minimal_window(rows: [make_row("x", spans: [span])]))
+
+      [dec_span] = hd(decoded.rows).spans
+      assert dec_span.start_col == 3
+      assert dec_span.end_col == 17
+      assert dec_span.fg == 0xFF6C6B
+      assert dec_span.bg == 0x282C34
+    end
+
+    test "span attrs and font fields round-trip" do
+      span = make_span(0, 5, attrs: 0x0F, font_weight: 5, font_id: 2)
+      decoded = round_trip(minimal_window(rows: [make_row("x", spans: [span])]))
+
+      [dec_span] = hd(decoded.rows).spans
+      assert dec_span.attrs == 0x0F
+      assert dec_span.font_weight == 5
+      assert dec_span.font_id == 2
+    end
+
+    test "multiple spans per row round-trip" do
+      spans = [
+        make_span(0, 5, fg: 0xFF0000),
+        make_span(5, 10, fg: 0x00FF00),
+        make_span(10, 20, fg: 0x0000FF)
+      ]
+
+      decoded = round_trip(minimal_window(rows: [make_row("x", spans: spans)]))
+      dec_spans = hd(decoded.rows).spans
+
+      assert length(dec_spans) == 3
+      assert Enum.at(dec_spans, 0).fg == 0xFF0000
+      assert Enum.at(dec_spans, 1).fg == 0x00FF00
+      assert Enum.at(dec_spans, 2).fg == 0x0000FF
+    end
+  end
+
+  # ── Round-trip: selection ──────────────────────────────────────────────
+
+  describe "round-trip: selection" do
+    test "nil selection round-trips" do
+      decoded = round_trip(minimal_window(selection: nil))
+      assert decoded.selection == nil
+    end
+
+    test "char selection round-trips" do
+      sel = %Selection{type: :char, start_row: 2, start_col: 5, end_row: 7, end_col: 15}
+      decoded = round_trip(minimal_window(selection: sel))
+
+      assert decoded.selection.type == :char
+      assert decoded.selection.start_row == 2
+      assert decoded.selection.start_col == 5
+      assert decoded.selection.end_row == 7
+      assert decoded.selection.end_col == 15
+    end
+
+    test "line selection round-trips" do
+      sel = %Selection{type: :line, start_row: 3, start_col: 0, end_row: 10, end_col: 0}
+      decoded = round_trip(minimal_window(selection: sel))
+
+      assert decoded.selection.type == :line
+      assert decoded.selection.start_row == 3
+      assert decoded.selection.end_row == 10
+    end
+
+    test "block selection round-trips" do
+      sel = %Selection{type: :block, start_row: 1, start_col: 5, end_row: 4, end_col: 20}
+      decoded = round_trip(minimal_window(selection: sel))
+
+      assert decoded.selection.type == :block
+    end
+  end
+
+  # ── Round-trip: search matches ─────────────────────────────────────────
+
+  describe "round-trip: search matches" do
+    test "empty matches round-trip" do
+      decoded = round_trip(minimal_window(search_matches: []))
+      assert decoded.search_matches == []
+    end
+
+    test "matches with is_current flag round-trip" do
+      matches = [
+        %SearchMatch{row: 5, start_col: 10, end_col: 15, is_current: false},
+        %SearchMatch{row: 8, start_col: 0, end_col: 3, is_current: true}
+      ]
+
+      decoded = round_trip(minimal_window(search_matches: matches))
+
+      assert length(decoded.search_matches) == 2
+      [m1, m2] = decoded.search_matches
+      assert {m1.row, m1.start_col, m1.end_col, m1.is_current} == {5, 10, 15, false}
+      assert {m2.row, m2.start_col, m2.end_col, m2.is_current} == {8, 0, 3, true}
+    end
+  end
+
+  # ── Round-trip: diagnostic ranges ──────────────────────────────────────
+
+  describe "round-trip: diagnostic ranges" do
+    test "empty diagnostics round-trip" do
+      decoded = round_trip(minimal_window(diagnostic_ranges: []))
+      assert decoded.diagnostic_ranges == []
+    end
+
+    test "all severity levels round-trip" do
+      make_diag = fn sev ->
+        %DiagnosticRange{start_row: 0, start_col: 0, end_row: 0, end_col: 5, severity: sev}
+      end
+
+      ranges = Enum.map([:error, :warning, :info, :hint], make_diag)
+      decoded = round_trip(minimal_window(diagnostic_ranges: ranges))
+
+      severities = Enum.map(decoded.diagnostic_ranges, & &1.severity)
+      assert severities == [:error, :warning, :info, :hint]
+    end
+
+    test "diagnostic coordinates round-trip" do
+      diag = %DiagnosticRange{
+        start_row: 3,
+        start_col: 5,
+        end_row: 4,
+        end_col: 20,
+        severity: :warning
+      }
+
+      decoded = round_trip(minimal_window(diagnostic_ranges: [diag]))
+      [d] = decoded.diagnostic_ranges
+
+      assert {d.start_row, d.start_col, d.end_row, d.end_col} == {3, 5, 4, 20}
+    end
+  end
+
+  # ── Full round-trip ────────────────────────────────────────────────────
+
+  describe "full round-trip" do
+    test "complete window with all sections round-trips" do
+      spans = [make_span(0, 5, fg: 0xFF0000), make_span(5, 10, fg: 0x00FF00)]
+
+      rows = [
+        make_row("hello", buf_line: 0, spans: spans, row_type: :normal),
+        make_row("world", buf_line: 1, row_type: :fold_start)
+      ]
+
+      sel = %Selection{type: :char, start_row: 0, start_col: 0, end_row: 0, end_col: 5}
+
+      matches = [
+        %SearchMatch{row: 1, start_col: 0, end_col: 5, is_current: true}
+      ]
+
+      diags = [
+        %DiagnosticRange{
+          start_row: 0,
+          start_col: 0,
+          end_row: 0,
+          end_col: 5,
+          severity: :error
+        }
+      ]
+
+      sw =
+        minimal_window(
+          window_id: 7,
+          rows: rows,
+          cursor_row: 0,
+          cursor_col: 3,
+          cursor_shape: :beam,
+          selection: sel,
+          search_matches: matches,
+          diagnostic_ranges: diags,
+          full_refresh: true
+        )
+
+      decoded = round_trip(sw)
+
+      assert decoded.window_id == 7
+      assert decoded.cursor_shape == :beam
+      assert length(decoded.rows) == 2
+      assert hd(decoded.rows).text == "hello"
+      assert length(hd(decoded.rows).spans) == 2
+      assert decoded.selection.type == :char
+      assert length(decoded.search_matches) == 1
+      assert hd(decoded.search_matches).is_current == true
+      assert length(decoded.diagnostic_ranges) == 1
+      assert hd(decoded.diagnostic_ranges).severity == :error
+    end
+
+    test "empty window (0 rows, nil selection, 0 matches, 0 diagnostics) round-trips" do
+      decoded = round_trip(minimal_window([]))
+
+      assert decoded.rows == []
+      assert decoded.selection == nil
+      assert decoded.search_matches == []
+      assert decoded.diagnostic_ranges == []
+    end
+  end
+
+  # ── Wire format pinning (Swift compatibility contract) ─────────────────
+
+  describe "wire format pinning" do
+    test "header layout: opcode(1) + wid(2) + flags(1) + crow(2) + ccol(2) + shape(1) + count(2)" do
+      sw = minimal_window(window_id: 1, cursor_row: 2, cursor_col: 3, cursor_shape: :block)
+      binary = GUIWindowContent.encode(sw)
+
+      <<0x80, 0x00, 0x01, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x00, 0x00, _rest::binary>> =
+        binary
+    end
+
+    test "span layout: start_col(2) + end_col(2) + fg(3) + bg(3) + attrs(1) + fw(1) + fid(1)" do
+      span =
+        make_span(1, 10, fg: 0xAA_BB_CC, bg: 0x11_22_33, attrs: 0x07, font_weight: 3, font_id: 1)
+
+      row = make_row("x", spans: [span], content_hash: 0)
+      binary = GUIWindowContent.encode(minimal_window(rows: [row]))
+
+      # header(11) + row_type(1) + buf_line(4) + hash(4) + text_len(4) + "x"(1) + span_count(2) = 27
+      <<_header::binary-size(27), 0x00, 0x01, 0x00, 0x0A, 0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33,
+        0x07, 0x03, 0x01, _rest::binary>> = binary
+    end
+
+    test "opcode is 0x80" do
+      <<opcode::8, _::binary>> = GUIWindowContent.encode(minimal_window([]))
+      assert opcode == 0x80
+    end
+  end
+
+  # ── Property tests ─────────────────────────────────────────────────────
+
+  describe "property: encode/decode round-trip" do
+    property "any SemanticWindow encodes to a binary the test decoder can fully consume" do
+      check all(sw <- semantic_window_gen()) do
+        binary = GUIWindowContent.encode(sw)
+        assert is_binary(binary)
+
+        decoded = GUIWindowContentDecoder.decode(binary)
+        assert decoded.window_id == sw.window_id
+        assert decoded.cursor_row == sw.cursor_row
+        assert decoded.cursor_col == sw.cursor_col
+        assert decoded.cursor_shape == sw.cursor_shape
+        assert decoded.full_refresh == sw.full_refresh
+        assert length(decoded.rows) == length(sw.rows)
+      end
+    end
+
+    property "row text and buf_line survive round-trip for any input" do
+      check all(sw <- semantic_window_gen()) do
+        decoded = GUIWindowContentDecoder.decode(GUIWindowContent.encode(sw))
+
+        for {orig, dec} <- Enum.zip(sw.rows, decoded.rows) do
+          assert dec.text == orig.text
+          assert dec.buf_line == orig.buf_line
+          assert dec.row_type == orig.row_type
+          assert length(dec.spans) == length(orig.spans)
+        end
+      end
+    end
+
+    property "span colors survive round-trip for any input" do
+      check all(sw <- semantic_window_gen()) do
+        decoded = GUIWindowContentDecoder.decode(GUIWindowContent.encode(sw))
+
+        for {orig_row, dec_row} <- Enum.zip(sw.rows, decoded.rows) do
+          for {orig_span, dec_span} <- Enum.zip(orig_row.spans, dec_row.spans) do
+            assert dec_span.fg == orig_span.fg
+            assert dec_span.bg == orig_span.bg
+            assert dec_span.attrs == orig_span.attrs
+          end
+        end
+      end
+    end
+  end
+
+  # ── Generators ─────────────────────────────────────────────────────────
+
+  defp semantic_window_gen do
+    gen all(
+          window_id <- integer(1..0xFFFF),
+          row_count <- integer(0..10),
+          rows <- list_of(visual_row_gen(), length: row_count),
+          cursor_row <- integer(0..100),
+          cursor_col <- integer(0..200),
+          cursor_shape <- member_of([:block, :beam, :underline]),
+          selection <- one_of([constant(nil), selection_gen()]),
+          match_count <- integer(0..5),
+          matches <- list_of(search_match_gen(), length: match_count),
+          diag_count <- integer(0..5),
+          diags <- list_of(diagnostic_range_gen(), length: diag_count),
+          full_refresh <- boolean()
+        ) do
+      %SemanticWindow{
+        window_id: window_id,
+        rows: rows,
+        cursor_row: cursor_row,
+        cursor_col: cursor_col,
+        cursor_shape: cursor_shape,
+        selection: selection,
+        search_matches: matches,
+        diagnostic_ranges: diags,
+        full_refresh: full_refresh
+      }
+    end
+  end
+
+  defp visual_row_gen do
+    gen all(
+          row_type <- member_of([:normal, :fold_start, :virtual_line, :block, :wrap_continuation]),
+          buf_line <- integer(0..10_000),
+          text <- string(:printable, max_length: 100),
+          span_count <- integer(0..5),
+          spans <- list_of(span_gen(), length: span_count)
+        ) do
+      %VisualRow{
+        row_type: row_type,
+        buf_line: buf_line,
+        text: text,
+        spans: spans,
+        content_hash: :erlang.phash2({text, spans})
+      }
+    end
+  end
+
+  defp span_gen do
+    gen all(
+          start_col <- integer(0..200),
+          width <- integer(1..50),
+          fg <- integer(0..0xFFFFFF),
+          bg <- integer(0..0xFFFFFF),
+          attrs <- integer(0..0x1F),
+          font_weight <- integer(0..6),
+          font_id <- integer(0..10)
+        ) do
+      %Span{
+        start_col: start_col,
+        end_col: start_col + width,
+        fg: fg,
+        bg: bg,
+        attrs: attrs,
+        font_weight: font_weight,
+        font_id: font_id
+      }
+    end
+  end
+
+  defp selection_gen do
+    gen all(
+          type <- member_of([:char, :line, :block]),
+          start_row <- integer(0..100),
+          start_col <- integer(0..200),
+          end_row <- integer(0..100),
+          end_col <- integer(0..200)
+        ) do
+      %Selection{
+        type: type,
+        start_row: start_row,
+        start_col: start_col,
+        end_row: end_row,
+        end_col: end_col
+      }
+    end
+  end
+
+  defp search_match_gen do
+    gen all(
+          row <- integer(0..100),
+          start_col <- integer(0..200),
+          width <- integer(1..50),
+          is_current <- boolean()
+        ) do
+      %SearchMatch{
+        row: row,
+        start_col: start_col,
+        end_col: start_col + width,
+        is_current: is_current
+      }
+    end
+  end
+
+  defp diagnostic_range_gen do
+    gen all(
+          start_row <- integer(0..100),
+          start_col <- integer(0..200),
+          end_row <- integer(0..100),
+          end_col <- integer(0..200),
+          severity <- member_of([:error, :warning, :info, :hint])
+        ) do
+      %DiagnosticRange{
+        start_row: start_row,
+        start_col: start_col,
+        end_row: end_row,
+        end_col: end_col,
+        severity: severity
+      }
+    end
+  end
+end

--- a/test/support/gui_window_content_decoder.ex
+++ b/test/support/gui_window_content_decoder.ex
@@ -1,0 +1,168 @@
+defmodule Minga.Test.GUIWindowContentDecoder do
+  @moduledoc """
+  Test-only decoder for the gui_window_content (0x80) wire format.
+
+  Parses an encoded binary back into a map so tests can do round-trip
+  assertions without fragile byte-offset pattern matching. The decoder
+  must consume the entire binary (ending with `<<>>`) to catch encoder
+  bugs that emit extra or missing bytes.
+  """
+
+  import Bitwise
+
+  @doc "Decodes an 0x80 binary back into a map for test assertions."
+  @spec decode(binary()) :: map()
+  def decode(
+        <<0x80, window_id::16, flags::8, cursor_row::16, cursor_col::16, cursor_shape::8,
+          row_count::16, rest::binary>>
+      ) do
+    {rows, rest} = decode_rows(rest, row_count, [])
+    {selection, rest} = decode_selection(rest)
+    {search_matches, rest} = decode_search_matches(rest)
+    {diagnostic_ranges, <<>>} = decode_diagnostic_ranges(rest)
+
+    %{
+      window_id: window_id,
+      full_refresh: (flags &&& 1) == 1,
+      cursor_row: cursor_row,
+      cursor_col: cursor_col,
+      cursor_shape: decode_cursor_shape(cursor_shape),
+      rows: rows,
+      selection: selection,
+      search_matches: search_matches,
+      diagnostic_ranges: diagnostic_ranges
+    }
+  end
+
+  # ── Rows ─────────────────────────────────────────────────────────────────
+
+  defp decode_rows(rest, 0, acc), do: {Enum.reverse(acc), rest}
+
+  defp decode_rows(
+         <<row_type::8, buf_line::32, content_hash::32, text_len::32, text::binary-size(text_len),
+           span_count::16, rest::binary>>,
+         remaining,
+         acc
+       ) do
+    {spans, rest} = decode_spans(rest, span_count, [])
+
+    row = %{
+      row_type: decode_row_type(row_type),
+      buf_line: buf_line,
+      content_hash: content_hash,
+      text: text,
+      spans: spans
+    }
+
+    decode_rows(rest, remaining - 1, [row | acc])
+  end
+
+  defp decode_row_type(0), do: :normal
+  defp decode_row_type(1), do: :fold_start
+  defp decode_row_type(2), do: :virtual_line
+  defp decode_row_type(3), do: :block
+  defp decode_row_type(4), do: :wrap_continuation
+
+  # ── Spans ────────────────────────────────────────────────────────────────
+
+  defp decode_spans(rest, 0, acc), do: {Enum.reverse(acc), rest}
+
+  defp decode_spans(
+         <<start_col::16, end_col::16, fg_r::8, fg_g::8, fg_b::8, bg_r::8, bg_g::8, bg_b::8,
+           attrs::8, font_weight::8, font_id::8, rest::binary>>,
+         remaining,
+         acc
+       ) do
+    span = %{
+      start_col: start_col,
+      end_col: end_col,
+      fg: fg_r <<< 16 ||| fg_g <<< 8 ||| fg_b,
+      bg: bg_r <<< 16 ||| bg_g <<< 8 ||| bg_b,
+      attrs: attrs,
+      font_weight: font_weight,
+      font_id: font_id
+    }
+
+    decode_spans(rest, remaining - 1, [span | acc])
+  end
+
+  # ── Selection ────────────────────────────────────────────────────────────
+
+  defp decode_selection(<<0::8, rest::binary>>), do: {nil, rest}
+
+  defp decode_selection(
+         <<type::8, start_row::16, start_col::16, end_row::16, end_col::16, rest::binary>>
+       ) do
+    sel = %{
+      type: decode_selection_type(type),
+      start_row: start_row,
+      start_col: start_col,
+      end_row: end_row,
+      end_col: end_col
+    }
+
+    {sel, rest}
+  end
+
+  defp decode_selection_type(1), do: :char
+  defp decode_selection_type(2), do: :line
+  defp decode_selection_type(3), do: :block
+
+  # ── Search matches ──────────────────────────────────────────────────────
+
+  defp decode_search_matches(<<count::16, rest::binary>>) do
+    decode_search_match_entries(rest, count, [])
+  end
+
+  defp decode_search_match_entries(rest, 0, acc), do: {Enum.reverse(acc), rest}
+
+  defp decode_search_match_entries(
+         <<row::16, start_col::16, end_col::16, is_current::8, rest::binary>>,
+         remaining,
+         acc
+       ) do
+    match = %{
+      row: row,
+      start_col: start_col,
+      end_col: end_col,
+      is_current: is_current == 1
+    }
+
+    decode_search_match_entries(rest, remaining - 1, [match | acc])
+  end
+
+  # ── Diagnostic ranges ──────────────────────────────────────────────────
+
+  defp decode_diagnostic_ranges(<<count::16, rest::binary>>) do
+    decode_diag_entries(rest, count, [])
+  end
+
+  defp decode_diag_entries(rest, 0, acc), do: {Enum.reverse(acc), rest}
+
+  defp decode_diag_entries(
+         <<start_row::16, start_col::16, end_row::16, end_col::16, severity::8, rest::binary>>,
+         remaining,
+         acc
+       ) do
+    diag = %{
+      start_row: start_row,
+      start_col: start_col,
+      end_row: end_row,
+      end_col: end_col,
+      severity: decode_severity(severity)
+    }
+
+    decode_diag_entries(rest, remaining - 1, [diag | acc])
+  end
+
+  defp decode_severity(0), do: :error
+  defp decode_severity(1), do: :warning
+  defp decode_severity(2), do: :info
+  defp decode_severity(3), do: :hint
+
+  # ── Cursor shape ────────────────────────────────────────────────────────
+
+  defp decode_cursor_shape(0), do: :block
+  defp decode_cursor_shape(1), do: :beam
+  defp decode_cursor_shape(2), do: :underline
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -12,11 +12,9 @@ System.put_env("GIT_TEMPLATE_DIR", "")
 # On Linux (CI), the harness tests are excluded automatically.
 harness_path = Path.join(:code.priv_dir(:minga), "minga-test-harness")
 
-unless File.exists?(harness_path) do
-  case System.find_executable("swiftc") do
-    nil -> :noop
-    _swiftc -> Mix.Task.run("swift.harness")
-  end
+case System.find_executable("swiftc") do
+  nil -> :noop
+  _swiftc -> Mix.Task.run("swift.harness")
 end
 
 swift_exclude = if File.exists?(harness_path), do: [], else: [:swift_harness]


### PR DESCRIPTION
## What

Phase 2 of #828: adds the binary protocol encoder (BEAM), decoder (Swift), and dual-path sending for the `gui_window_content` opcode (0x80). The BEAM now sends pre-resolved semantic window data alongside draw_text for GUI frontends. Swift decodes and stores the data but does not yet render from it.

## Why

This establishes the protocol layer that Phase 3 will use to replace draw_text for buffer windows. By sending both draw_text and 0x80 in parallel, we can verify the semantic data is correct without any visual changes. Phase 3 switches rendering to the semantic path and removes draw_text for buffer windows.

## What Changed

### BEAM side
- **`GUIWindowContent` encoder** (`lib/minga/port/protocol/gui_window_content.ex`): encodes a `SemanticWindow` struct into the 0x80 wire format (header + visual rows with spans + selection overlay + search matches + diagnostic ranges)
- **Emit stage** sends `gui_window_content` for each buffer window alongside existing draw_text commands
- **Test-only decoder** (`test/support/gui_window_content_decoder.ex`) for clean encode/decode round-trip assertions instead of fragile byte-offset pattern matching
- **29 Elixir tests**: 26 unit (round-trip assertions + 3 wire format pinning tests for Swift compatibility) + 3 property-based tests with full generators fuzzing thousands of SemanticWindow inputs

### Swift side
- **`OP_GUI_WINDOW_CONTENT = 0x80`** constant
- **Data structures** (`WindowContent.swift`): `GUIWindowContent`, `GUIVisualRow`, `GUIHighlightSpan`, `GUISelectionOverlay`, `GUISearchMatch`, `GUIDiagnosticUnderline`
- **Decoder** in `ProtocolDecoder.swift`: full parser with bounds checking for all sections
- **CommandDispatcher** stores decoded content on `GUIState.windowContent`
- **13 Swift tests**: binary builder + decoder assertions including a "consumes entire binary" test that catches encoder/decoder length mismatches

### Wire format

```
opcode(0x80) + window_id(u16) + flags(u8) + cursor_row(u16) + cursor_col(u16)
+ cursor_shape(u8) + row_count(u16) + rows... + selection + search_matches + diagnostic_ranges
```

Per row: `row_type(u8) + buf_line(u32) + content_hash(u32) + text_len(u32) + text + span_count(u16) + spans...`
Per span: `start_col(u16) + end_col(u16) + fg(u24) + bg(u24) + attrs(u8) + font_weight(u8) + font_id(u8)`

Wire format verified consistent across all three implementations (Elixir encoder, Elixir test decoder, Swift decoder).

## Testing approach

The Elixir encoder tests use a test-only decoder for round-trip assertions (recommended by test-advisor). This avoids the brittle `<<_skip::binary-size(27), field::16, ...>>` pattern and instead verifies that `decode(encode(input)) == input` for all fields. Property-based tests fuzz the round-trip with generated SemanticWindow structs.

The Swift decoder tests use a `WindowContentBuilder` that constructs binary payloads matching the wire format spec, then decodes them and asserts field values.

## Phase 3 note

Intent reviewer noted that `GUIState.windowContent` stores a single `GUIWindowContent?`, but the emit stage sends one 0x80 per window. Phase 3 will need a dictionary keyed by `windowId` for multi-window support.

Builds on Phase 1 (#846). Does not close #828 (Phase 3 remaining).