### PR TITLE
feat(gui): WindowContentRenderer + semantic rendering cutover (#828 Phase 3)

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -35,7 +35,7 @@ The BEAM checks `Capabilities.gui?` (true when `frontend_type == :native_gui`) t
 
 ## GUI Render Opcodes (BEAM → Frontend)
 
-All GUI chrome opcodes live in the contiguous range 0x70-0x7F. Frontends can classify an opcode as GUI chrome by checking `opcode >= 0x70 && opcode <= 0x7F`.
+GUI chrome opcodes live in the range 0x70-0x7F. GUI content opcodes (semantic buffer rendering) start at 0x80. Frontends can classify an opcode as GUI by checking `opcode >= 0x70`.
 
 ### 0x70 — gui_file_tree
 
@@ -334,6 +334,55 @@ When hidden:
 `height_percent` is the BEAM's default/initial height (10-60). The frontend may override with a user-dragged height stored locally.
 
 `filter_preset` is a hint for the Messages tab. When the panel auto-opens for warnings, the BEAM sets `filter_preset=1`. The frontend should apply a warnings+errors level filter on the visibility transition (hidden to visible). If the user has already changed filters manually, don't override.
+
+### 0x80 — gui_window_content
+
+Semantic rendering data for a buffer window. Replaces draw_text commands for buffer content. The BEAM pre-resolves all layout (word wrap, folding, virtual text splicing, conceal ranges) and all styling (syntax highlighting colors). The frontend renders directly from this data via CoreText, with selection/search/diagnostics as overlay quads (not baked into text colors).
+
+One 0x80 message is sent per buffer window per frame. Agent chat windows do not use this opcode.
+
+```
+opcode(1) + window_id(2) + flags(1) + cursor_row(2) + cursor_col(2) + cursor_shape(1) + visible_row_count(2) + rows... + selection + search_matches + diagnostic_ranges
+
+Flags:
+  bit 0: full_refresh (1 = all rows changed, 0 = incremental)
+
+Cursor shape: 0 = block, 1 = beam, 2 = underline
+
+Per visual row:
+  row_type(1) + buf_line(4) + content_hash(4) + text_len(4) + text(text_len) + span_count(2) + spans...
+
+Row types:
+  0 = normal, 1 = fold_start, 2 = virtual_line, 3 = block_decoration, 4 = wrap_continuation
+
+Per highlight span:
+  start_col(2) + end_col(2) + fg(3) + bg(3) + attrs(1) + font_weight(1) + font_id(1)
+
+Attrs bits: 0=bold, 1=italic, 2=underline, 3=strikethrough, 4=curl_underline
+
+Span columns are in display column coordinates (CJK/fullwidth = 2 columns).
+Colors are pre-resolved 24-bit RGB from the BEAM's theme/highlight resolver.
+
+Selection section:
+  selection_type(1): 0=none, 1=char, 2=line, 3=block
+  If type != 0: start_row(2) + start_col(2) + end_row(2) + end_col(2)
+  All coordinates are display-relative (within the window's content area).
+
+Search matches section:
+  match_count(2)
+  Per match: row(2) + start_col(2) + end_col(2) + is_current(1)
+
+Diagnostic ranges section:
+  diag_count(2)
+  Per range: start_row(2) + start_col(2) + end_row(2) + end_col(2) + severity(1)
+  Severity: 0=error, 1=warning, 2=info, 3=hint
+```
+
+The frontend renders selection and search matches as Metal quads behind text (not baked into line textures). This enables zero re-rasterization when the selection changes. Diagnostic underlines are rendered as quads after text.
+
+`content_hash` is a per-row hash computed by the BEAM. The frontend uses it for CTLine texture cache invalidation: if the hash matches, the cached texture is reused without re-rasterization.
+
+When `gui_window_content` is present for a window, the BEAM does not send draw_text commands for that window's buffer content. Overlays (hover popups, signature help) continue as draw_text. Gutter data (0x7B), cursorline (0x7A), and cursor position continue through their existing opcodes.
 
 ## GUI Action Input Opcode (Frontend → BEAM)
 

--- a/lib/minga/editor/render_pipeline/emit/gui.ex
+++ b/lib/minga/editor/render_pipeline/emit/gui.ex
@@ -61,7 +61,18 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
         agentic_view: [],
         status_bar: [],
         splash: nil,
-        windows: Enum.map(frame.windows, fn wf -> %{wf | gutter: %{}} end)
+        windows:
+          Enum.map(frame.windows, fn wf ->
+            # Buffer windows with semantic content get their text from the
+            # 0x80 opcode, not draw_text. Strip lines + tilde_lines so
+            # the cell-grid only carries overlays (hover, signature help).
+            # Agent chat windows don't have semantic content and keep their draws.
+            if wf.semantic != nil do
+              %{wf | gutter: %{}, lines: %{}, tilde_lines: %{}}
+            else
+              %{wf | gutter: %{}}
+            end
+          end)
     }
   end
 

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -63,11 +63,14 @@
 		931A6127210D4ED441AC04B2 /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */; };
 		939991DD65293C6C796EAA66 /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
 		93E7D214A27256CF06571EFE /* ProtocolDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */; };
+		97FB334A605B5B1FAEEFADF7 /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
 		9BAECBE2506FC3893151FD6C /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		A15090D92542403F12179DFD /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */; };
 		A6F3965C6177C36406CC4FF8 /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */; };
 		A78FBA1CD5BB02EEBA8ACB45 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
+		AB804A6366BEFE62E30C929B /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
 		AE619C9C5E8A6C337F6283F1 /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C26E064D810299C0302F439 /* EditorView.swift */; };
+		B12FA22E8F25CE3E5F55366F /* WindowContentRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */; };
 		B2EFBC6B76ABF724B8C9B04F /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E892F827AFBE959F9DF25C05 /* StatusBarView.swift */; };
 		B3CE9FF4E42438A1A72BD156 /* CompletionOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */; };
 		B6295F0247ADE2D1D0133DCB /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D6B3C68CFF37BC4303933A /* ThemeColors.swift */; };
@@ -116,6 +119,7 @@
 		56B00002D020FED57D265C74 /* SystemColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemColorTests.swift; sourceTree = "<group>"; };
 		5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreTextMetalRenderer.swift; sourceTree = "<group>"; };
 		5F5F10DF600E92632AD966A5 /* LineBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineBufferTests.swift; sourceTree = "<group>"; };
+		620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentRendererTests.swift; sourceTree = "<group>"; };
 		638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPanelState.swift; sourceTree = "<group>"; };
 		64CEFB02A774E5E8EF19029F /* MingaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MingaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		70D5765529645C5D860576B7 /* WhichKeyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhichKeyState.swift; sourceTree = "<group>"; };
@@ -135,6 +139,7 @@
 		C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIState.swift; sourceTree = "<group>"; };
 		C441427A427E23B912F70092 /* ProtocolConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolConstants.swift; sourceTree = "<group>"; };
 		CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeState.swift; sourceTree = "<group>"; };
+		CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentRenderer.swift; sourceTree = "<group>"; };
 		CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhichKeyOverlay.swift; sourceTree = "<group>"; };
 		CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbBar.swift; sourceTree = "<group>"; };
 		DD14027C8C7BD17057DE820B /* AgentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatView.swift; sourceTree = "<group>"; };
@@ -158,6 +163,7 @@
 				48E21C30D142028698027567 /* CoreTextShaders.metal */,
 				F87D78FA2B8AA133DDD3141B /* LineBuffer.swift */,
 				790F7E20F30FEEFC552B3685 /* WindowContent.swift */,
+				CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */,
 			);
 			path = Renderer;
 			sourceTree = "<group>";
@@ -280,6 +286,7 @@
 				F220A60775A252A728477659 /* ProtocolTests.swift */,
 				211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */,
 				56B00002D020FED57D265C74 /* SystemColorTests.swift */,
+				620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */,
 				FD7FC26DB745A436D50E3AA6 /* WindowContentTests.swift */,
 			);
 			path = MingaTests;
@@ -432,6 +439,7 @@
 				3DF3937E460A624254F647BC /* WhichKeyOverlay.swift in Sources */,
 				D3D3326E46122D2FEA329E47 /* WhichKeyState.swift in Sources */,
 				46198F3E1A959C3E17E02031 /* WindowContent.swift in Sources */,
+				97FB334A605B5B1FAEEFADF7 /* WindowContentRenderer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -484,6 +492,8 @@
 				6474095F95F4DA480AFE91B7 /* WhichKeyOverlay.swift in Sources */,
 				CF09E23141DB0E6D9B65826A /* WhichKeyState.swift in Sources */,
 				44D48DF33203C53ACC3BA1AA /* WindowContent.swift in Sources */,
+				AB804A6366BEFE62E30C929B /* WindowContentRenderer.swift in Sources */,
+				B12FA22E8F25CE3E5F55366F /* WindowContentRendererTests.swift in Sources */,
 				FEA7FDF0B8C5551790872FCA /* WindowContentTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -252,6 +252,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Create the editor view.
         let nsView = EditorNSView(encoder: enc, fontFace: face, lineBuffer: disp.lineBuffer,
                                    coreTextRenderer: ctRenderer, fontManager: fm)
+        nsView.guiState = appState.gui
         nsView.statusBarState = appState.gui.statusBarState
         self.editorNSView = nsView
         appState.editorNSView = nsView

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -65,6 +65,7 @@ final class CommandDispatcher {
         switch command {
         case .clear:
             lineBuffer.clear()
+            guiState.beginFrame()
 
         case .drawText(let row, let col, let fg, let bg, let attrs, let text):
             drawText(row: row, col: col, fg: fg, bg: bg, attrs: attrs, text: text)
@@ -225,10 +226,7 @@ final class CommandDispatcher {
             }
 
         case .guiWindowContent(let data):
-            // Phase 2: store the semantic window content for future rendering.
-            // During Phase 2, draw_text commands still drive rendering.
-            // Phase 3 will switch to rendering from this data.
-            guiState.windowContent = data
+            guiState.windowContents[data.windowId] = data
 
         case .guiBottomPanel(let visible, let activeTabIndex, let heightPercent, let filterPreset, let tabs, let entries):
             if visible {

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -149,13 +149,23 @@ final class CoreTextMetalRenderer {
                             Float(rgb.blueComponent))
     }
 
+    /// Semantic window content renderer (from 0x80 opcode).
+    private(set) var windowContentRenderer: WindowContentRenderer?
+
     /// Set up the line renderer. Called once the FontManager is available.
     func setupLineRenderer(fontManager: FontManager) {
         self.lineRenderer = CoreTextLineRenderer(device: device, fontManager: fontManager)
+        self.windowContentRenderer = WindowContentRenderer(device: device, fontManager: fontManager)
     }
 
-    /// Render the editor from LineBuffer data.
+    /// Render the editor from LineBuffer data + semantic window content.
+    ///
+    /// Buffer windows with semantic content (from 0x80 opcode) are rendered
+    /// via `WindowContentRenderer`. Everything else (overlays, agent chat,
+    /// cursor, gutter, separator) continues through the LineBuffer path.
     func render(lineBuffer: LineBuffer, fontManager: FontManager,
+                windowContents: [UInt16: GUIWindowContent] = [:],
+                themeColors: ThemeColors? = nil,
                 drawable: CAMetalDrawable, viewportSize: CGSize,
                 contentScale: Float, scrollOffset: SIMD2<Float> = .zero) {
         guard let lineRenderer else { return }
@@ -167,6 +177,15 @@ final class CoreTextMetalRenderer {
         // Advance frame counter for cache eviction.
         lineRenderer.beginFrame()
         lineRenderer.updateViewportWidth(cols: lineBuffer.cols)
+
+        // Advance semantic content renderer.
+        if let wcr = windowContentRenderer {
+            wcr.beginFrame()
+            wcr.updateViewportWidth(cols: lineBuffer.cols)
+            if let tc = themeColors {
+                wcr.defaultFgRGB = tc.editorFgRGB
+            }
+        }
 
         // Default background color.
         let defaultBg = lineBuffer.defaultBg != 0
@@ -283,6 +302,96 @@ final class CoreTextMetalRenderer {
             }
         }
 
+        // Semantic window content rendering (from 0x80 opcode).
+        // Buffer windows with semantic content bypass LineBuffer for text;
+        // their line textures come from WindowContentRenderer instead.
+        // Selection, search, and diagnostic overlays are drawn as Metal quads.
+        var semanticOverlayQuads: [QuadGPU] = []
+        var diagnosticQuads: [QuadGPU] = []
+
+        if let wcr = windowContentRenderer {
+            for (_, content) in windowContents {
+                // Find the matching gutter entry to get window screen position.
+                // The gutter's contentRow/contentCol define where this window's
+                // content area starts on screen.
+                //
+                // TODO: GUIWindowGutter doesn't have a windowId field yet.
+                // For now, match the active gutter for single-window layouts.
+                // Multi-window support requires adding windowId to the 0x7B
+                // gutter opcode or matching by contentRow ranges.
+                guard let gutter = lineBuffer.windowGutters.first(where: { $0.isActive }) else {
+                    continue
+                }
+
+                let windowRowOffset = Float(gutter.contentRow) * cellH * scale
+                let gutterWidth = Float(gutter.lineNumberWidth) + Float(gutter.signColWidth)
+                let contentColOffset = (Float(gutter.contentCol) + gutterWidth) * cellW * scale + gutterPaddingPx
+
+                // Selection overlay quads (drawn before text).
+                if let sel = content.selection {
+                    appendSelectionQuads(
+                        selection: sel,
+                        rowOffset: windowRowOffset,
+                        colOffset: contentColOffset,
+                        cellW: cellW, cellH: cellH, scale: scale,
+                        viewportWidth: Float(viewportSize.width),
+                        quads: &semanticOverlayQuads
+                    )
+                }
+
+                // Search match overlay quads (drawn before text).
+                for match in content.searchMatches {
+                    let matchY = windowRowOffset + Float(match.row) * cellH * scale
+                    let matchX = contentColOffset + Float(match.startCol) * cellW * scale
+                    let matchW = Float(match.endCol - match.startCol) * cellW * scale
+
+                    var quad = QuadGPU()
+                    quad.position = SIMD2<Float>(matchX, matchY)
+                    quad.size = SIMD2<Float>(matchW, cellH * scale)
+                    quad.color = match.isCurrent
+                        ? SIMD3<Float>(0.95, 0.75, 0.0)    // current match: gold
+                        : SIMD3<Float>(0.35, 0.35, 0.15)   // other matches: dim gold
+                    quad.alpha = 1.0
+                    semanticOverlayQuads.append(quad)
+                }
+
+                // Render line textures from semantic content.
+                for (rowIdx, row) in content.rows.enumerated() {
+                    if let cached = wcr.renderRow(displayRow: UInt16(rowIdx), row: row) {
+                        let yPos = windowRowOffset + Float(rowIdx) * cellH * scale
+
+                        var lineGPU = LineGPU()
+                        lineGPU.position = SIMD2<Float>(contentColOffset, yPos)
+                        lineGPU.size = SIMD2<Float>(Float(cached.pixelWidth), Float(cached.pixelHeight))
+                        lineGPU.uvOrigin = .zero
+                        lineGPU.uvSize = SIMD2<Float>(1, 1)
+                        lineInstances.append((lineGPU, cached.texture))
+                    }
+                }
+
+                // Diagnostic underline quads (drawn after text).
+                for diag in content.diagnosticUnderlines {
+                    let diagColor: SIMD3<Float> = switch diag.severity {
+                    case .error:   SIMD3<Float>(1.0, 0.42, 0.42)   // red
+                    case .warning: SIMD3<Float>(0.93, 0.75, 0.48)  // yellow
+                    case .info:    SIMD3<Float>(0.32, 0.69, 0.94)  // blue
+                    case .hint:    SIMD3<Float>(0.33, 0.33, 0.33)  // gray
+                    }
+
+                    let diagY = windowRowOffset + Float(diag.startRow) * cellH * scale + cellH * scale - 2.0 * scale
+                    let diagX = contentColOffset + Float(diag.startCol) * cellW * scale
+                    let diagW = Float(diag.endCol - diag.startCol) * cellW * scale
+
+                    var quad = QuadGPU()
+                    quad.position = SIMD2<Float>(diagX, diagY)
+                    quad.size = SIMD2<Float>(diagW, 2.0 * scale)
+                    quad.color = diagColor
+                    quad.alpha = 1.0
+                    diagnosticQuads.append(quad)
+                }
+            }
+        }
+
         // Native gutter rendering from structured data.
         // One GUIWindowGutter per editor window (split pane).
         for windowGutter in lineBuffer.windowGutters {
@@ -319,6 +428,17 @@ final class CoreTextMetalRenderer {
             encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: bgQuads.count)
         }
 
+        // Pass 1.5: Semantic overlay quads (search matches, selection).
+        // Drawn after bg fills but before cursor and text so they appear
+        // behind text content. Selection and search highlights render as
+        // Metal quads instead of being baked into line textures.
+        if !semanticOverlayQuads.isEmpty {
+            encoder.setRenderPipelineState(bgPipeline)
+            encoder.setVertexBytes(&semanticOverlayQuads, length: semanticOverlayQuads.count * MemoryLayout<QuadGPU>.stride, index: 0)
+            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: semanticOverlayQuads.count)
+        }
+
         // Pass 2: Cursor background (drawn BEFORE text so text is visible on top).
         // For block cursors, draw the cursor bg here so the text pass composites over it.
         // Beam and underline cursors are drawn AFTER text (pass 5).
@@ -349,6 +469,14 @@ final class CoreTextMetalRenderer {
                 encoder.setFragmentTexture(texture, index: 0)
                 encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
             }
+        }
+
+        // Pass 3.5: Diagnostic underline quads (drawn after text, before gutter).
+        if !diagnosticQuads.isEmpty {
+            encoder.setRenderPipelineState(bgPipeline)
+            encoder.setVertexBytes(&diagnosticQuads, length: diagnosticQuads.count * MemoryLayout<QuadGPU>.stride, index: 0)
+            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: diagnosticQuads.count)
         }
 
         // Pass 4: Gutter gap fill.
@@ -639,6 +767,74 @@ final class CoreTextMetalRenderer {
             Float((color >> 8) & 0xFF) / 255.0,
             Float(color & 0xFF) / 255.0
         )
+    }
+
+    /// Build selection overlay quads from semantic selection data.
+    ///
+    /// Char selection: one quad per row (partial for first/last rows).
+    /// Line selection: full-width quads for each row in the range.
+    private func appendSelectionQuads(
+        selection sel: GUISelectionOverlay,
+        rowOffset: Float, colOffset: Float,
+        cellW: Float, cellH: Float, scale: Float,
+        viewportWidth: Float,
+        quads: inout [QuadGPU]
+    ) {
+        let selColor = SIMD3<Float>(0.15, 0.30, 0.55)  // blue selection bg
+
+        switch sel.type {
+        case .line:
+            for row in sel.startRow...sel.endRow {
+                var quad = QuadGPU()
+                quad.position = SIMD2<Float>(colOffset, rowOffset + Float(row) * cellH * scale)
+                quad.size = SIMD2<Float>(viewportWidth - colOffset, cellH * scale)
+                quad.color = selColor
+                quad.alpha = 1.0
+                quads.append(quad)
+            }
+
+        case .char:
+            for row in sel.startRow...sel.endRow {
+                let y = rowOffset + Float(row) * cellH * scale
+                let startCol: Float
+                let endCol: Float
+
+                if row == sel.startRow && row == sel.endRow {
+                    startCol = Float(sel.startCol)
+                    endCol = Float(sel.endCol)
+                } else if row == sel.startRow {
+                    startCol = Float(sel.startCol)
+                    endCol = (viewportWidth - colOffset) / (cellW * scale)
+                } else if row == sel.endRow {
+                    startCol = 0
+                    endCol = Float(sel.endCol)
+                } else {
+                    startCol = 0
+                    endCol = (viewportWidth - colOffset) / (cellW * scale)
+                }
+
+                var quad = QuadGPU()
+                quad.position = SIMD2<Float>(colOffset + startCol * cellW * scale, y)
+                quad.size = SIMD2<Float>((endCol - startCol) * cellW * scale, cellH * scale)
+                quad.color = selColor
+                quad.alpha = 1.0
+                quads.append(quad)
+            }
+
+        case .block:
+            for row in sel.startRow...sel.endRow {
+                let y = rowOffset + Float(row) * cellH * scale
+                let x = colOffset + Float(sel.startCol) * cellW * scale
+                let w = Float(sel.endCol - sel.startCol) * cellW * scale
+
+                var quad = QuadGPU()
+                quad.position = SIMD2<Float>(x, y)
+                quad.size = SIMD2<Float>(w, cellH * scale)
+                quad.color = selColor
+                quad.alpha = 1.0
+                quads.append(quad)
+            }
+        }
     }
 
     /// Calculate the display width (in cell columns) of a string,

--- a/macos/Sources/Renderer/WindowContentRenderer.swift
+++ b/macos/Sources/Renderer/WindowContentRenderer.swift
@@ -1,0 +1,375 @@
+/// Renders semantic window content (from 0x80 opcode) into Metal textures.
+///
+/// Converts `GUIVisualRow` data into `NSAttributedString` via CoreText,
+/// then rasterizes to Metal textures using the same pipeline as
+/// `CoreTextLineRenderer`. The key difference: styled runs come from
+/// pre-resolved `GUIHighlightSpan` structs (BEAM-computed colors) instead
+/// of `StyledRun` decoded from draw_text commands.
+///
+/// Selection, search matches, and diagnostics are NOT baked into the
+/// attributed string. They are returned as overlay quad data for the
+/// Metal renderer to draw as separate geometry (zero re-rasterization
+/// when selection changes).
+
+import Foundation
+import CoreText
+import CoreGraphics
+import Metal
+import AppKit
+
+/// Renders `GUIWindowContent` rows into cached Metal line textures.
+///
+/// Each row's text + spans produce an `NSAttributedString` → `CTLine` →
+/// bitmap → `MTLTexture`, cached by content hash. The texture cache is
+/// separate from `CoreTextLineRenderer`'s cache to avoid row key collisions
+/// during the transition period.
+@MainActor
+final class WindowContentRenderer {
+    /// Metal device for texture creation.
+    private let device: MTLDevice
+
+    /// Font manager for resolving font faces.
+    private let fontManager: FontManager
+
+    /// Per-row texture cache keyed by display row index.
+    /// Separate from CoreTextLineRenderer's cache to avoid key collisions.
+    private var lineCache: [UInt16: CachedLineTexture] = [:]
+
+    /// Frame counter for LRU eviction.
+    private var frameCounter: UInt64 = 0
+
+    /// Eviction threshold (frames).
+    private let evictionThreshold: UInt64 = 120
+
+    /// Backing scale factor.
+    let scale: CGFloat
+
+    /// Cell width in points.
+    let cellWidth: CGFloat
+
+    /// Cell height in points.
+    let cellHeight: CGFloat
+
+    /// Line height in pixels at backing scale.
+    let linePixelHeight: Int
+
+    /// Font ascent in points.
+    let ascent: CGFloat
+
+    /// Font descent in points.
+    let descent: CGFloat
+
+    /// Maximum line width in pixels.
+    private var maxLinePixelWidth: Int
+
+    /// Default foreground color (24-bit RGB) for text between spans.
+    /// Updated from theme's editor_fg color slot each frame.
+    var defaultFgRGB: UInt32 = 0xBBC2CF
+
+    init(device: MTLDevice, fontManager: FontManager) {
+        self.device = device
+        self.fontManager = fontManager
+        self.scale = fontManager.scale
+        self.cellWidth = CGFloat(fontManager.cellWidth)
+        self.cellHeight = CGFloat(fontManager.cellHeight)
+        self.ascent = fontManager.ascent
+        self.descent = fontManager.primary.descent
+        self.linePixelHeight = Int(ceil(cellHeight * scale))
+        self.maxLinePixelWidth = Int(ceil(200.0 * cellWidth * scale))
+    }
+
+    /// Update max line width on viewport resize.
+    func updateViewportWidth(cols: UInt16) {
+        let newWidth = Int(ceil(CGFloat(cols) * cellWidth * scale))
+        if newWidth != maxLinePixelWidth {
+            maxLinePixelWidth = newWidth
+            lineCache.removeAll(keepingCapacity: true)
+        }
+    }
+
+    /// Advance frame counter and evict stale textures.
+    func beginFrame() {
+        frameCounter += 1
+        let threshold = frameCounter > evictionThreshold ? frameCounter - evictionThreshold : 0
+        lineCache = lineCache.filter { $0.value.lastUsedFrame >= threshold }
+    }
+
+    /// Clear all cached textures.
+    func invalidateAll() {
+        lineCache.removeAll(keepingCapacity: true)
+    }
+
+    /// Render a single visual row into a cached Metal texture.
+    ///
+    /// Returns the cached texture if the content hash matches, or
+    /// rasterizes a new texture from the row's text + spans.
+    func renderRow(displayRow: UInt16, row: GUIVisualRow) -> CachedLineTexture? {
+        let hash = Int(row.contentHash)
+
+        // Cache hit check.
+        if var cached = lineCache[displayRow], cached.contentHash == hash {
+            cached.lastUsedFrame = frameCounter
+            lineCache[displayRow] = cached
+            return cached
+        }
+
+        guard !row.text.isEmpty else { return nil }
+
+        // Build NSAttributedString from spans.
+        let attributedString = buildAttributedString(text: row.text, spans: row.spans)
+
+        // Create CTLine and measure.
+        let ctLine = CTLineCreateWithAttributedString(attributedString)
+        var lineAscent: CGFloat = 0
+        var lineDescent: CGFloat = 0
+        var lineLeading: CGFloat = 0
+        let lineWidth = CTLineGetTypographicBounds(ctLine, &lineAscent, &lineDescent, &lineLeading)
+
+        let pixelWidth = min(Int(ceil(lineWidth * scale)), maxLinePixelWidth)
+        let pixelHeight = linePixelHeight
+        guard pixelWidth > 0, pixelHeight > 0 else { return nil }
+
+        // Rasterize to BGRA bitmap.
+        let bgraData = rasterize(ctLine, width: pixelWidth, height: pixelHeight)
+
+        // Create texture.
+        let texDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb,
+            width: pixelWidth,
+            height: pixelHeight,
+            mipmapped: false
+        )
+        texDesc.usage = [.shaderRead]
+        texDesc.storageMode = .managed
+
+        guard let texture = device.makeTexture(descriptor: texDesc) else { return nil }
+
+        let region = MTLRegion(origin: MTLOrigin(x: 0, y: 0, z: 0),
+                               size: MTLSize(width: pixelWidth, height: pixelHeight, depth: 1))
+        bgraData.withUnsafeBytes { ptr in
+            texture.replace(region: region, mipmapLevel: 0,
+                           withBytes: ptr.baseAddress!, bytesPerRow: pixelWidth * 4)
+        }
+
+        let cached = CachedLineTexture(
+            texture: texture,
+            contentHash: hash,
+            lastUsedFrame: frameCounter,
+            pixelWidth: pixelWidth,
+            pixelHeight: pixelHeight
+        )
+        lineCache[displayRow] = cached
+        return cached
+    }
+
+    // MARK: - Attributed String Building
+
+    /// Builds an NSAttributedString from composed text and pre-resolved spans.
+    ///
+    /// Spans are in display column coordinates (CJK = 2 columns, ASCII = 1).
+    /// We build a display-column-to-String.Index mapping once per line (O(n)),
+    /// then look up each span boundary in O(1).
+    ///
+    /// Unlike the LineBuffer path, no gap-filling transparent spaces are needed
+    /// because the BEAM sends composed text with virtual text already spliced.
+    func buildAttributedString(text: String, spans: [GUIHighlightSpan]) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+
+        guard !text.isEmpty else { return result }
+
+        let defaultFgColor = nsColor(from: defaultFgRGB)
+        let ligatures = fontManager.primary.ligaturesEnabled ? 2 : 0
+
+        if spans.isEmpty {
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: fontManager.primary.ctFont,
+                .foregroundColor: defaultFgColor,
+                .ligature: ligatures
+            ]
+            result.append(NSAttributedString(string: text, attributes: attrs))
+            return result
+        }
+
+        // Build display-column-to-String.Index mapping.
+        // Each grapheme cluster maps to 1 or 2 display columns (CJK/fullwidth = 2).
+        // columnIndex[displayCol] gives the String.Index at that display column.
+        let columnMap = buildDisplayColumnMap(for: text)
+        let totalDisplayCols = columnMap.count > 0 ? columnMap.count - 1 : 0
+
+        var lastCol = 0
+
+        for span in spans {
+            let spanStart = min(Int(span.startCol), totalDisplayCols)
+            let spanEnd = min(Int(span.endCol), totalDisplayCols)
+
+            // Fill gap before this span with default-styled text.
+            if spanStart > lastCol {
+                let gapStartIdx = columnMap[min(lastCol, columnMap.count - 1)]
+                let gapEndIdx = columnMap[min(spanStart, columnMap.count - 1)]
+                if gapStartIdx < gapEndIdx {
+                    let gapText = String(text[gapStartIdx..<gapEndIdx])
+                    let gapAttrs: [NSAttributedString.Key: Any] = [
+                        .font: fontManager.primary.ctFont,
+                        .foregroundColor: defaultFgColor,
+                        .ligature: ligatures
+                    ]
+                    result.append(NSAttributedString(string: gapText, attributes: gapAttrs))
+                }
+            }
+
+            guard spanStart < spanEnd else { continue }
+
+            let segStartIdx = columnMap[spanStart]
+            let segEndIdx = columnMap[min(spanEnd, columnMap.count - 1)]
+            guard segStartIdx < segEndIdx else { continue }
+            let segText = String(text[segStartIdx..<segEndIdx])
+
+            let font = resolveFont(for: span)
+            let fgColor = span.fg != 0 ? nsColor(from: span.fg) : defaultFgColor
+
+            var attrs: [NSAttributedString.Key: Any] = [
+                .font: font,
+                .foregroundColor: fgColor,
+                .ligature: ligatures
+            ]
+
+            if span.isUnderline {
+                if span.isCurl {
+                    attrs[.underlineStyle] = NSUnderlineStyle.thick.rawValue
+                } else {
+                    attrs[.underlineStyle] = NSUnderlineStyle.single.rawValue
+                }
+            }
+
+            if span.isStrikethrough {
+                attrs[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+                attrs[.strikethroughColor] = fgColor
+            }
+
+            result.append(NSAttributedString(string: segText, attributes: attrs))
+            lastCol = spanEnd
+        }
+
+        // Append trailing text after the last span.
+        if lastCol < totalDisplayCols {
+            let tailStartIdx = columnMap[lastCol]
+            let tailText = String(text[tailStartIdx...])
+            if !tailText.isEmpty {
+                let tailAttrs: [NSAttributedString.Key: Any] = [
+                    .font: fontManager.primary.ctFont,
+                    .foregroundColor: defaultFgColor,
+                    .ligature: ligatures
+                ]
+                result.append(NSAttributedString(string: tailText, attributes: tailAttrs))
+            }
+        }
+
+        return result
+    }
+
+    // MARK: - Display Column Mapping
+
+    /// Builds a mapping from display column offset to String.Index.
+    ///
+    /// Display columns use the terminal convention: ASCII/Latin = 1 column,
+    /// CJK/fullwidth = 2 columns. The resulting array has `totalDisplayCols + 1`
+    /// entries, where `map[col]` is the String.Index at that display column.
+    /// Built once per line in O(n), enabling O(1) span boundary lookups.
+    func buildDisplayColumnMap(for text: String) -> [String.Index] {
+        var map: [String.Index] = []
+        // Reserve a reasonable estimate (most chars are 1 column)
+        map.reserveCapacity(text.count + text.count / 4)
+
+        for index in text.indices {
+            let char = text[index]
+            let width = displayColumnWidth(char)
+            // First column of this character maps to this index
+            map.append(index)
+            // Wide characters occupy 2 display columns; the second column
+            // also maps to this same index (the span boundary will slice
+            // at the character boundary, not mid-character)
+            if width == 2 {
+                map.append(index)
+            }
+        }
+        // Sentinel: one past the end
+        map.append(text.endIndex)
+        return map
+    }
+
+    /// Returns the display column width of a character (1 or 2).
+    /// Matches the BEAM's `Unicode.display_width/1` for monospace terminals.
+    private func displayColumnWidth(_ char: Character) -> Int {
+        guard let scalar = char.unicodeScalars.first else { return 1 }
+        let v = scalar.value
+        if (v >= 0x1100 && v <= 0x115F)
+            || (v >= 0x2E80 && v <= 0x303E)
+            || (v >= 0x3040 && v <= 0x33BF)
+            || (v >= 0x3400 && v <= 0x4DBF)
+            || (v >= 0x4E00 && v <= 0xA4CF)
+            || (v >= 0xAC00 && v <= 0xD7AF)
+            || (v >= 0xF900 && v <= 0xFAFF)
+            || (v >= 0xFE30 && v <= 0xFE6F)
+            || (v >= 0xFF01 && v <= 0xFF60)
+            || (v >= 0xFFE0 && v <= 0xFFE6)
+            || (v >= 0x20000 && v <= 0x2FA1F)
+        {
+            return 2
+        }
+        return 1
+    }
+
+    // MARK: - Font Resolution
+
+    /// Resolve CTFont for a highlight span.
+    /// When bold attr is set but weight is default (0), use weight 5 (bold).
+    private func resolveFont(for span: GUIHighlightSpan) -> CTFont {
+        let face = fontManager.fontFace(for: span.fontId)
+        let weight: UInt8 = (span.isBold && span.fontWeight == 0) ? 5 : span.fontWeight
+        return face.fontForWeight(weight, isItalic: span.isItalic)
+    }
+
+    // MARK: - Color Conversion
+
+    /// Convert 24-bit RGB to NSColor.
+    private func nsColor(from rgb: UInt32) -> NSColor {
+        let r = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let g = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let b = CGFloat(rgb & 0xFF) / 255.0
+        return NSColor(red: r, green: g, blue: b, alpha: 1.0)
+    }
+
+    // MARK: - Rasterization
+
+    /// Rasterize a CTLine into a premultiplied BGRA bitmap.
+    private func rasterize(_ ctLine: CTLine, width: Int, height: Int) -> [UInt8] {
+        let bytesPerRow = width * 4
+        var buffer = [UInt8](repeating: 0, count: bytesPerRow * height)
+
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        guard let ctx = CGContext(
+            data: &buffer,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        ) else {
+            return buffer
+        }
+
+        ctx.scaleBy(x: scale, y: scale)
+        ctx.setAllowsFontSmoothing(true)
+        ctx.setShouldSmoothFonts(true)
+        ctx.setAllowsFontSubpixelPositioning(true)
+        ctx.setShouldSubpixelPositionFonts(true)
+        ctx.setAllowsAntialiasing(true)
+        ctx.setShouldAntialias(true)
+
+        ctx.textPosition = CGPoint(x: 0, y: descent)
+        CTLineDraw(ctLine, ctx)
+
+        return buffer
+    }
+}

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -25,6 +25,9 @@ final class EditorNSView: MTKView {
     /// Font manager for per-span font family support.
     let fontManager: FontManager
 
+    /// GUI state for semantic window content (0x80) and theme colors.
+    var guiState: GUIState?
+
     private var trackingArea: NSTrackingArea?
 
     /// IME composition state (marked text tracking).
@@ -114,6 +117,8 @@ final class EditorNSView: MTKView {
         }
 
         coreTextRenderer.render(lineBuffer: lineBuffer, fontManager: fontManager,
+                                windowContents: guiState?.windowContents ?? [:],
+                                themeColors: guiState?.themeColors,
                                 drawable: drawable, viewportSize: drawableSize,
                                 contentScale: scale)
         lineBuffer.dirty = false

--- a/macos/Sources/Views/GUIState.swift
+++ b/macos/Sources/Views/GUIState.swift
@@ -40,7 +40,12 @@ final class GUIState {
     let bottomPanelState = BottomPanelState()
 
     /// Semantic window content from gui_window_content (0x80).
-    /// Phase 2: stored but not yet used for rendering. Phase 3 will
-    /// switch buffer window rendering from draw_text to this data.
-    var windowContent: GUIWindowContent?
+    /// Keyed by windowId. Cleared each frame before dispatch.
+    var windowContents: [UInt16: GUIWindowContent] = [:]
+
+    /// Clears per-frame state that must be rebuilt from incoming commands.
+    /// Called at the start of each frame before dispatching commands.
+    func beginFrame() {
+        windowContents.removeAll(keepingCapacity: true)
+    }
 }

--- a/macos/Sources/Views/ThemeColors.swift
+++ b/macos/Sources/Views/ThemeColors.swift
@@ -77,8 +77,9 @@ final class ThemeColors {
     var gitModifiedFg: Color = color(0x51AFEF)
     var gitDeletedFg: Color = color(0xFF6C6B)
 
-    // Raw 24-bit RGB values for Metal renderer (gutter rendering).
+    // Raw 24-bit RGB values for Metal renderer.
     // Updated alongside the Color properties when gui_theme slots arrive.
+    var editorFgRGB: UInt32 = 0xBBC2CF
     var gutterFgRGB: UInt32 = 0x555555
     var gutterCurrentFgRGB: UInt32 = 0xBBC2CF
     var gutterErrorFgRGB: UInt32 = 0xFF6C6B
@@ -108,7 +109,7 @@ final class ThemeColors {
     private func applySlot(_ slot: UInt8, color c: Color, rgb: UInt32) {
         switch slot {
         case GUI_COLOR_EDITOR_BG: editorBg = c
-        case GUI_COLOR_EDITOR_FG: editorFg = c
+        case GUI_COLOR_EDITOR_FG: editorFg = c; editorFgRGB = rgb
         case GUI_COLOR_TREE_BG: treeBg = c
         case GUI_COLOR_TREE_FG: treeFg = c
         case GUI_COLOR_TREE_SELECTION_BG: treeSelectionBg = c

--- a/macos/Tests/MingaTests/WindowContentRendererTests.swift
+++ b/macos/Tests/MingaTests/WindowContentRendererTests.swift
@@ -1,0 +1,155 @@
+/// Tests for WindowContentRenderer's display column mapping and attributed string building.
+///
+/// These tests verify the critical coordinate mapping logic that converts
+/// BEAM display columns (CJK = 2 cols) to Swift String.Index positions.
+
+import Testing
+import Foundation
+import Metal
+
+@Suite("Window Content Renderer - Display Column Mapping")
+struct DisplayColumnMappingTests {
+
+    /// Helper to create a WindowContentRenderer for testing.
+    /// Uses a real Metal device but the tests only exercise pure functions.
+    @MainActor
+    private func makeRenderer() -> WindowContentRenderer? {
+        guard let device = MTLCreateSystemDefaultDevice() else { return nil }
+        let fm = FontManager(name: "Menlo", size: 13.0, scale: 2.0)
+        return WindowContentRenderer(device: device, fontManager: fm)
+    }
+
+    @Test("ASCII text: each char maps to one display column")
+    @MainActor func asciiMapping() throws {
+        guard let renderer = makeRenderer() else { return }
+        let map = renderer.buildDisplayColumnMap(for: "hello")
+
+        // "hello" = 5 display columns + 1 sentinel
+        #expect(map.count == 6)
+    }
+
+    @Test("CJK text: each char maps to two display columns")
+    @MainActor func cjkMapping() throws {
+        guard let renderer = makeRenderer() else { return }
+        let text = "日本語"
+        let map = renderer.buildDisplayColumnMap(for: text)
+
+        // 3 CJK chars × 2 display columns = 6 display columns + 1 sentinel
+        #expect(map.count == 7)
+
+        // Column 0 and 1 both map to the first character
+        #expect(map[0] == text.startIndex)
+        #expect(map[1] == text.startIndex)
+
+        // Column 2 and 3 map to the second character
+        let secondIdx = text.index(text.startIndex, offsetBy: 1)
+        #expect(map[2] == secondIdx)
+        #expect(map[3] == secondIdx)
+    }
+
+    @Test("Mixed ASCII and CJK: correct column mapping")
+    @MainActor func mixedMapping() throws {
+        guard let renderer = makeRenderer() else { return }
+        let text = "ab日c"
+        // a=1col, b=1col, 日=2col, c=1col = 5 display columns
+        let map = renderer.buildDisplayColumnMap(for: text)
+
+        #expect(map.count == 6) // 5 cols + sentinel
+
+        // col 0 = 'a', col 1 = 'b', col 2,3 = '日', col 4 = 'c'
+        let indices = Array(text.indices) + [text.endIndex]
+        #expect(map[0] == indices[0]) // 'a'
+        #expect(map[1] == indices[1]) // 'b'
+        #expect(map[2] == indices[2]) // '日'
+        #expect(map[3] == indices[2]) // '日' (second column)
+        #expect(map[4] == indices[3]) // 'c'
+        #expect(map[5] == indices[4]) // endIndex (sentinel)
+    }
+
+    @Test("Empty text: single sentinel entry")
+    @MainActor func emptyMapping() throws {
+        guard let renderer = makeRenderer() else { return }
+        let map = renderer.buildDisplayColumnMap(for: "")
+
+        #expect(map.count == 1) // just the sentinel
+    }
+
+    @Test("buildAttributedString with no spans uses default fg color")
+    @MainActor func noSpansUsesDefaultFg() throws {
+        guard let renderer = makeRenderer() else { return }
+        renderer.defaultFgRGB = 0xBBC2CF
+
+        let attrStr = renderer.buildAttributedString(text: "hello", spans: [])
+
+        #expect(attrStr.string == "hello")
+        #expect(attrStr.length == 5)
+    }
+
+    @Test("buildAttributedString with spans produces correct text")
+    @MainActor func spansProduceCorrectText() throws {
+        guard let renderer = makeRenderer() else { return }
+        renderer.defaultFgRGB = 0xBBC2CF
+
+        let spans = [
+            GUIHighlightSpan(startCol: 0, endCol: 3, fg: 0xFF0000, bg: 0, attrs: 0, fontWeight: 0, fontId: 0),
+            GUIHighlightSpan(startCol: 3, endCol: 5, fg: 0x00FF00, bg: 0, attrs: 0, fontWeight: 0, fontId: 0),
+        ]
+
+        let attrStr = renderer.buildAttributedString(text: "hello", spans: spans)
+
+        #expect(attrStr.string == "hello")
+    }
+
+    @Test("buildAttributedString with CJK spans maps columns correctly")
+    @MainActor func cjkSpanMapping() throws {
+        guard let renderer = makeRenderer() else { return }
+        renderer.defaultFgRGB = 0xBBC2CF
+
+        // "ab日c" -> display cols: a=0, b=1, 日=2-3, c=4
+        // Span covering "日" needs display cols 2-4
+        let spans = [
+            GUIHighlightSpan(startCol: 2, endCol: 4, fg: 0xFF0000, bg: 0, attrs: 0, fontWeight: 0, fontId: 0),
+        ]
+
+        let attrStr = renderer.buildAttributedString(text: "ab日c", spans: spans)
+
+        // The full text should be preserved
+        #expect(attrStr.string == "ab日c")
+    }
+
+    @Test("buildAttributedString with gap between spans fills with default style")
+    @MainActor func gapBetweenSpans() throws {
+        guard let renderer = makeRenderer() else { return }
+        renderer.defaultFgRGB = 0xBBC2CF
+
+        // "hello world" with spans on "hello" (0-5) and "world" (6-11)
+        // Gap at col 5 (the space) should be filled with default style
+        let spans = [
+            GUIHighlightSpan(startCol: 0, endCol: 5, fg: 0xFF0000, bg: 0, attrs: 0, fontWeight: 0, fontId: 0),
+            GUIHighlightSpan(startCol: 6, endCol: 11, fg: 0x00FF00, bg: 0, attrs: 0, fontWeight: 0, fontId: 0),
+        ]
+
+        let attrStr = renderer.buildAttributedString(text: "hello world", spans: spans)
+
+        #expect(attrStr.string == "hello world")
+    }
+}
+
+@Suite("GUIState Frame Lifecycle")
+struct GUIStateFrameTests {
+    @Test("beginFrame clears windowContents")
+    @MainActor func beginFrameClearsContents() {
+        let state = GUIState()
+        let content = GUIWindowContent(
+            windowId: 1, fullRefresh: true,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: []
+        )
+        state.windowContents[1] = content
+        #expect(state.windowContents.count == 1)
+
+        state.beginFrame()
+        #expect(state.windowContents.isEmpty)
+    }
+}

--- a/test/minga/editor/render_pipeline/emit/gui_test.exs
+++ b/test/minga/editor/render_pipeline/emit/gui_test.exs
@@ -89,7 +89,7 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUITest do
       assert Enum.all?(filtered.windows, fn wf -> wf.gutter == %{} end)
     end
 
-    test "preserves window content lines and tilde_lines" do
+    test "preserves lines and tilde_lines when no semantic content" do
       face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
       tilde_face = Minga.Face.new(fg: 0x5B6268, bg: 0x282C34)
 
@@ -115,6 +115,88 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUITest do
 
       assert filtered_wf.lines == content_layer
       assert filtered_wf.tilde_lines == tilde_layer
+    end
+
+    test "strips lines and tilde_lines from windows with semantic content" do
+      face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
+
+      content_layer = DisplayList.draws_to_layer([DisplayList.draw(0, 4, "hello world", face)])
+      tilde_layer = DisplayList.draws_to_layer([DisplayList.draw(5, 0, "~", face)])
+
+      semantic = %Minga.Editor.SemanticWindow{
+        window_id: 1,
+        rows: [],
+        cursor_row: 0,
+        cursor_col: 0,
+        cursor_shape: :block
+      }
+
+      wf = %WindowFrame{
+        rect: {0, 0, 80, 20},
+        gutter: DisplayList.draws_to_layer([DisplayList.draw(0, 0, "  1 ", face)]),
+        lines: content_layer,
+        tilde_lines: tilde_layer,
+        modeline: %{},
+        cursor: nil,
+        semantic: semantic
+      }
+
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        windows: [wf]
+      }
+
+      filtered = EmitGUI.filter_frame_for_gui(frame)
+      filtered_wf = hd(filtered.windows)
+
+      assert filtered_wf.lines == %{}
+      assert filtered_wf.tilde_lines == %{}
+      assert filtered_wf.gutter == %{}
+    end
+
+    test "mixed windows: semantic gets stripped, non-semantic preserved" do
+      face = Minga.Face.new(fg: 0xBBC2CF, bg: 0x282C34)
+      content = DisplayList.draws_to_layer([DisplayList.draw(0, 4, "text", face)])
+
+      semantic = %Minga.Editor.SemanticWindow{
+        window_id: 1,
+        rows: [],
+        cursor_row: 0,
+        cursor_col: 0,
+        cursor_shape: :block
+      }
+
+      buffer_wf = %WindowFrame{
+        rect: {0, 0, 40, 20},
+        lines: content,
+        tilde_lines: %{},
+        modeline: %{},
+        cursor: nil,
+        semantic: semantic
+      }
+
+      chat_wf = %WindowFrame{
+        rect: {0, 40, 40, 20},
+        lines: content,
+        tilde_lines: %{},
+        modeline: %{},
+        cursor: nil,
+        semantic: nil
+      }
+
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        windows: [buffer_wf, chat_wf]
+      }
+
+      filtered = EmitGUI.filter_frame_for_gui(frame)
+      [filtered_buf, filtered_chat] = filtered.windows
+
+      # Buffer window: lines stripped (semantic provides content via 0x80)
+      assert filtered_buf.lines == %{}
+
+      # Chat window: lines preserved (no semantic content)
+      assert filtered_chat.lines == content
     end
 
     test "handles empty frame (no windows, no chrome)" do


### PR DESCRIPTION
## What

Phase 3 of #828: switches GUI buffer window rendering from draw_text cell-grid commands to the semantic 0x80 opcode. The BEAM sends pre-resolved visual rows with highlight spans, and Swift renders them directly via CoreText. Selection, search matches, and diagnostics are rendered as Metal overlay quads instead of being baked into line textures.

## Why

This completes the gui_window_content work. Buffer windows no longer receive draw_text commands that carry TUI artifacts. Instead, the BEAM sends semantic data (composed text + pre-resolved highlight spans) and Swift builds NSAttributedString directly from it. Selection changes no longer force line re-rasterization because they render as Metal quads behind text.

## What Changed

### BEAM side
- `filter_frame_for_gui()` strips `lines` and `tilde_lines` from buffer windows that have semantic content (`wf.semantic != nil`). Agent chat windows and overlays (hover, signature help) continue as draw_text.
- 3 new tests verifying semantic/non-semantic window filtering.

### Swift side

**WindowContentRenderer** (`WindowContentRenderer.swift`, 375 lines):
- Builds `NSAttributedString` from `GUIVisualRow` + `GUIHighlightSpan` via CoreText
- Display-column-to-grapheme-index mapping (`buildDisplayColumnMap`): handles CJK/fullwidth characters (2 display columns) correctly. O(n) per line, O(1) per span lookup.
- Theme `editor_fg` color for default text between spans (not hardcoded white)
- Ligature attribute matching CoreTextLineRenderer behavior
- Separate texture cache from CoreTextLineRenderer (avoids row key collisions)

**GUIState** changes:
- `windowContents` is now `[UInt16: GUIWindowContent]` dictionary (was single optional)
- `beginFrame()` clears per-frame state; called by CommandDispatcher on `.clear`

**CoreTextMetalRenderer** changes:
- `render()` accepts `windowContents` and `themeColors`
- Renders semantic content via WindowContentRenderer for windows that have it
- Selection overlay quads (blue bg, drawn before text)
- Search match overlay quads (gold bg, drawn before text)
- Diagnostic underline quads (colored by severity, drawn after text)

**ThemeColors**: new `editorFgRGB: UInt32` property synced from gui_theme color slot

### Docs
- `GUI_PROTOCOL.md` updated with full 0x80 wire format specification

### Draw order
1. Background fills (existing)
2. Cursorline bg quad (existing, 0x7A)
3. **Selection + search overlay quads** (NEW)
4. Block cursor bg (existing)
5. Line textures (semantic via WindowContentRenderer + legacy via LineBuffer for overlays)
6. **Diagnostic underline quads** (NEW)
7. Gutter gap fill + separator (existing)
8. Beam/underline cursor (existing)

## Testing

**Elixir (3 new tests):**
- filter_frame_for_gui strips lines from windows with semantic content
- Mixed windows: semantic gets stripped, non-semantic preserved
- Full test suite (5806 tests) passes

**Swift (8 new tests):**
- Display column mapping: ASCII, CJK, mixed ASCII+CJK, empty text
- Attributed string building: no spans, with spans, CJK spans, gap filling
- GUIState.beginFrame clears windowContents
- All 128 Swift tests pass

## Known Limitations

- **Multi-window gutter matching**: Uses `isActive` filter to find the window's screen position from gutter data. Works for single-window layouts (the common case). Multi-window support requires adding `windowId` to the 0x7B gutter opcode. TODO documented in code.
- **Compose line text stub**: The `compose_line_text` function in the BEAM builder is a pass-through (returns raw text without splicing virtual text or applying conceals). This will be addressed when virtual text and conceals interact with the semantic path.

Depends on Phase 2 (#848). Closes #828.