### PR TITLE
fix(port): add window_id to gui_gutter opcode for multi-window support

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -296,7 +296,7 @@ The GUI frontend draws the cursorline as a full-width colored rectangle behind t
 Structured gutter data for native line number and sign rendering. One message is sent per editor window (split pane), each including the window's screen position. Agent chat windows are skipped.
 
 ```
-opcode(1) + content_row(2) + content_col(2) + content_height(2) + is_active(1)
+opcode(1) + window_id(2) + content_row(2) + content_col(2) + content_height(2) + is_active(1)
 + cursor_line(4) + line_number_style(1) + line_number_width(1)
 + sign_col_width(1) + line_count(2) + entries...
 
@@ -304,7 +304,7 @@ Per entry:
   buf_line(4) + display_type(1) + sign_type(1)
 ```
 
-`content_row` and `content_col` are the screen position of the window's content area (0-indexed). `content_height` is the height in rows. `is_active` is 1 for the focused window, 0 otherwise. `cursor_line` is the 0-indexed buffer line where the cursor sits. `line_number_width` is the character column count allocated for line numbers. `sign_col_width` is 0 (no sign column) or 2 (sign column present). `line_count` is the number of visible line entries.
+`window_id` matches the `window_id` field in `gui_window_content` (0x80), enabling the frontend to correlate gutter data with semantic buffer content for the same window. `content_row` and `content_col` are the screen position of the window's content area (0-indexed). `content_height` is the height in rows. `is_active` is 1 for the focused window, 0 otherwise. `cursor_line` is the 0-indexed buffer line where the cursor sits. `line_number_width` is the character column count allocated for line numbers. `sign_col_width` is 0 (no sign column) or 2 (sign column present). `line_count` is the number of visible line entries.
 
 Line number style values:
 | Value | Style |

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -65,6 +65,8 @@ defmodule Minga.Editor do
   alias Minga.Editor.State.Tab
   alias Minga.Editor.State.TabBar
 
+  alias Minga.Editor.PickerUI
+
   @typedoc "Internal state."
   @type state :: EditorState.t()
 
@@ -1432,7 +1434,7 @@ defmodule Minga.Editor do
   # sees live updates (spinner → checkmark, etc.).
   @spec maybe_refresh_tool_picker(state()) :: state()
   defp maybe_refresh_tool_picker(%{picker_ui: %{source: Minga.Tool.PickerSource}} = state) do
-    Minga.Editor.PickerUI.refresh_items(state)
+    PickerUI.refresh_items(state)
   end
 
   defp maybe_refresh_tool_picker(state), do: state

--- a/lib/minga/editor/picker_ui.ex
+++ b/lib/minga/editor/picker_ui.ex
@@ -194,23 +194,8 @@ defmodule Minga.Editor.PickerUI do
 
   def handle_key(%{picker_ui: %{picker: picker, source: source}} = state, @enter, _mods) do
     case Picker.selected_item(picker) do
-      nil ->
-        close(state)
-
-      item ->
-        if Picker.Source.keep_open_on_select?(source) do
-          # Stay open: run the action, then refresh items in place
-          new_state = source.on_select(item, state)
-          refresh_items(new_state)
-        else
-          new_state = close(state)
-          new_state = source.on_select(item, new_state)
-
-          case Map.get(new_state, :pending_command) do
-            nil -> new_state
-            cmd -> {Map.delete(new_state, :pending_command), {:execute_command, cmd}}
-          end
-        end
+      nil -> close(state)
+      item -> select_item(state, item, source)
     end
   end
 
@@ -321,6 +306,23 @@ defmodule Minga.Editor.PickerUI do
 
   # Ignore all other keys
   def handle_key(state, _cp, _mods), do: state
+
+  @spec select_item(EditorState.t(), Picker.item(), module()) ::
+          EditorState.t() | {EditorState.t(), {:execute_command, atom()}}
+  defp select_item(state, item, source) do
+    if Picker.Source.keep_open_on_select?(source) do
+      new_state = source.on_select(item, state)
+      refresh_items(new_state)
+    else
+      new_state = close(state)
+      new_state = source.on_select(item, new_state)
+
+      case Map.get(new_state, :pending_command) do
+        nil -> new_state
+        cmd -> {Map.delete(new_state, :pending_command), {:execute_command, cmd}}
+      end
+    end
+  end
 
   @doc """
   Renders the picker overlay. Returns `{draws, cursor_pos | nil}`.

--- a/lib/minga/editor/render_pipeline/emit/gui.ex
+++ b/lib/minga/editor/render_pipeline/emit/gui.ex
@@ -568,7 +568,7 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
         # Skip agent chat windows (they don't have gutter)
         if window && is_pid(window.buffer) && !Content.agent_chat?(window.content) do
           is_active = win_id == state.windows.active
-          gutter_data = build_window_gutter(state, window, win_layout, is_active)
+          gutter_data = build_window_gutter(state, window, win_id, win_layout, is_active)
           [ProtocolGUI.encode_gui_gutter(gutter_data)]
         else
           []
@@ -585,10 +585,11 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
   @spec build_window_gutter(
           state(),
           Minga.Editor.Window.t(),
+          pos_integer(),
           Layout.window_layout(),
           boolean()
         ) :: ProtocolGUI.gutter_data()
-  defp build_window_gutter(state, window, win_layout, is_active) do
+  defp build_window_gutter(state, window, win_id, win_layout, is_active) do
     buf = window.buffer
     cursor_line = max(window.last_cursor_line, 0)
     viewport_top = max(window.last_viewport_top, 0)
@@ -597,6 +598,7 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
     {content_row, content_col, _content_w, content_height} = win_layout.content
 
     win_pos = %{
+      window_id: win_id,
       content_row: content_row,
       content_col: content_col,
       content_height: content_height,

--- a/lib/minga/port/protocol/gui.ex
+++ b/lib/minga/port/protocol/gui.ex
@@ -175,6 +175,7 @@ defmodule Minga.Port.Protocol.GUI do
 
   @typedoc "Gutter data for a single window."
   @type gutter_data :: %{
+          window_id: non_neg_integer(),
           content_row: non_neg_integer(),
           content_col: non_neg_integer(),
           content_height: non_neg_integer(),
@@ -193,7 +194,7 @@ defmodule Minga.Port.Protocol.GUI do
   the window's screen position so the GUI knows where to render.
 
   Wire format:
-    opcode(1) + content_row(2) + content_col(2) + content_height(2)
+    opcode(1) + window_id(2) + content_row(2) + content_col(2) + content_height(2)
     + is_active(1) + cursor_line(4) + line_number_style(1)
     + line_number_width(1) + sign_col_width(1) + line_count(2) + entries...
 
@@ -202,6 +203,7 @@ defmodule Minga.Port.Protocol.GUI do
   """
   @spec encode_gui_gutter(gutter_data()) :: binary()
   def encode_gui_gutter(%{
+        window_id: window_id,
         content_row: row,
         content_col: col,
         content_height: height,
@@ -222,8 +224,8 @@ defmodule Minga.Port.Protocol.GUI do
       end)
 
     IO.iodata_to_binary([
-      <<@op_gui_gutter, row::16, col::16, height::16, active_byte::8, cursor_line::32,
-        style_byte::8, ln_width::8, sign_width::8, count::16>>
+      <<@op_gui_gutter, window_id::16, row::16, col::16, height::16, active_byte::8,
+        cursor_line::32, style_byte::8, ln_width::8, sign_width::8, count::16>>
       | entry_binaries
     ])
   end

--- a/lib/minga/tool/manager.ex
+++ b/lib/minga/tool/manager.ex
@@ -299,17 +299,26 @@ defmodule Minga.Tool.Manager do
 
   @spec tool_status(atom(), map()) :: {tool_status(), String.t() | nil}
   defp tool_status(name, state) do
-    if MapSet.member?(state.installing, name) do
-      {:installing, nil}
-    else
-      if MapSet.member?(state.failed, name) do
-        {:failed, nil}
-      else
-        case get_installation(name) do
-          %Installation{version: version} -> {:installed, version}
-          nil -> {:not_installed, nil}
-        end
-      end
+    tool_status_for(name, state.installing, state.failed)
+  end
+
+  @spec tool_status_for(atom(), MapSet.t(), MapSet.t()) :: {tool_status(), String.t() | nil}
+  defp tool_status_for(name, installing, failed) do
+    cond_tool_status(
+      MapSet.member?(installing, name),
+      MapSet.member?(failed, name),
+      name
+    )
+  end
+
+  @spec cond_tool_status(boolean(), boolean(), atom()) :: {tool_status(), String.t() | nil}
+  defp cond_tool_status(true, _, _name), do: {:installing, nil}
+  defp cond_tool_status(_, true, _name), do: {:failed, nil}
+
+  defp cond_tool_status(false, false, name) do
+    case get_installation(name) do
+      %Installation{version: version} -> {:installed, version}
+      nil -> {:not_installed, nil}
     end
   end
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -97,6 +97,8 @@ struct GUIGutterEntry: Sendable {
 /// Gutter data for one window, including its screen position.
 /// One message per window arrives each frame.
 struct GUIWindowGutter: Sendable {
+    /// Window ID matching the gui_window_content (0x80) windowId.
+    let windowId: UInt16
     /// Screen row where this window's content area begins.
     let contentRow: UInt16
     /// Screen column where this window's content area begins.
@@ -913,37 +915,39 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         return (.guiCursorline(row: row, r: data[rest + 2], g: data[rest + 3], b: data[rest + 4]), 6)
 
     case OP_GUI_GUTTER:
-        // Per-window format: content_row:2 + content_col:2 + content_height:2 + is_active:1
-        // + cursor_line:4 + style:1 + ln_width:1 + sign_width:1 + line_count:2 = 16 bytes header
-        guard data.count >= rest + 16 else { throw ProtocolDecodeError.malformed }
-        let contentRow = readU16(data, rest)
-        let contentCol = readU16(data, rest + 2)
-        let contentHeight = readU16(data, rest + 4)
-        let isActive = data[rest + 6] != 0
-        let cursorLine = readU32(data, rest + 7)
-        let styleRaw = data[rest + 11]
-        let lnWidth = data[rest + 12]
-        let signWidth = data[rest + 13]
-        let lineCount = Int(readU16(data, rest + 14))
+        // Per-window format: window_id:2 + content_row:2 + content_col:2 + content_height:2
+        // + is_active:1 + cursor_line:4 + style:1 + ln_width:1 + sign_width:1 + line_count:2 = 18 bytes header
+        guard data.count >= rest + 18 else { throw ProtocolDecodeError.malformed }
+        let windowId = readU16(data, rest)
+        let contentRow = readU16(data, rest + 2)
+        let contentCol = readU16(data, rest + 4)
+        let contentHeight = readU16(data, rest + 6)
+        let isActive = data[rest + 8] != 0
+        let cursorLine = readU32(data, rest + 9)
+        let styleRaw = data[rest + 13]
+        let lnWidth = data[rest + 14]
+        let signWidth = data[rest + 15]
+        let lineCount = Int(readU16(data, rest + 16))
         let style = GUILineNumberStyle(rawValue: styleRaw) ?? .hybrid
 
         // Each entry is 6 bytes: buf_line:4 + display_type:1 + sign_type:1
-        guard data.count >= rest + 16 + lineCount * 6 else { throw ProtocolDecodeError.malformed }
+        guard data.count >= rest + 18 + lineCount * 6 else { throw ProtocolDecodeError.malformed }
         var entries: [GUIGutterEntry] = []
         entries.reserveCapacity(lineCount)
         for i in 0..<lineCount {
-            let base = rest + 16 + i * 6
+            let base = rest + 18 + i * 6
             let bufLine = readU32(data, base)
             let dt = GUIGutterDisplayType(rawValue: data[base + 4]) ?? .normal
             let st = GUIGutterSignType(rawValue: data[base + 5]) ?? .none
             entries.append(GUIGutterEntry(bufLine: bufLine, displayType: dt, signType: st))
         }
         let windowGutter = GUIWindowGutter(
+            windowId: windowId,
             contentRow: contentRow, contentCol: contentCol, contentHeight: contentHeight,
             isActive: isActive, cursorLine: cursorLine, lineNumberStyle: style,
             lineNumberWidth: lnWidth, signColWidth: signWidth, entries: entries
         )
-        return (.guiGutter(data: windowGutter), 1 + 16 + lineCount * 6)
+        return (.guiGutter(data: windowGutter), 1 + 18 + lineCount * 6)
 
     case OP_GUI_BOTTOM_PANEL:
         // visible(1)

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -225,7 +225,7 @@ final class CommandDispatcher {
             lineBuffer.cursorlineBg = rgb
 
         case .guiGutter(let data):
-            lineBuffer.windowGutters.append(data)
+            lineBuffer.windowGutters[data.windowId] = data
             // Sync gutterCol from the active window's gutter data so the
             // separator and gap fill logic stays consistent.
             if data.isActive {

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -311,15 +311,8 @@ final class CoreTextMetalRenderer {
 
         if let wcr = windowContentRenderer {
             for (_, content) in windowContents {
-                // Find the matching gutter entry to get window screen position.
-                // The gutter's contentRow/contentCol define where this window's
-                // content area starts on screen.
-                //
-                // TODO: GUIWindowGutter doesn't have a windowId field yet.
-                // For now, match the active gutter for single-window layouts.
-                // Multi-window support requires adding windowId to the 0x7B
-                // gutter opcode or matching by contentRow ranges.
-                guard let gutter = lineBuffer.windowGutters.first(where: { $0.isActive }) else {
+                // Match gutter data to semantic window content by windowId.
+                guard let gutter = lineBuffer.windowGutters[content.windowId] else {
                     continue
                 }
 
@@ -394,7 +387,7 @@ final class CoreTextMetalRenderer {
 
         // Native gutter rendering from structured data.
         // One GUIWindowGutter per editor window (split pane).
-        for windowGutter in lineBuffer.windowGutters {
+        for (_, windowGutter) in lineBuffer.windowGutters {
             renderGutterEntries(
                 gutter: windowGutter,
                 lineBuffer: lineBuffer,

--- a/macos/Sources/Renderer/LineBuffer.swift
+++ b/macos/Sources/Renderer/LineBuffer.swift
@@ -96,7 +96,7 @@ final class LineBuffer {
     /// One entry per editor window (split pane). Cleared each frame.
     /// The renderer iterates these to draw gutter content at the correct
     /// screen positions for each window.
-    var windowGutters: [GUIWindowGutter] = []
+    var windowGutters: [UInt16: GUIWindowGutter] = [:]
 
     /// Gutter theme colors as 24-bit RGB values.
     /// Updated by CommandDispatcher from ThemeColors when gui_theme arrives.
@@ -228,7 +228,7 @@ final class LineBuffer {
 
     /// Returns the window gutter whose content area contains the given screen row.
     func windowGutter(forRow row: UInt16) -> GUIWindowGutter? {
-        windowGutters.first { row >= $0.contentRow && row < $0.contentRow &+ $0.contentHeight }
+        windowGutters.values.first { row >= $0.contentRow && row < $0.contentRow &+ $0.contentHeight }
     }
 
     /// Returns the total number of lines that have content.

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -321,6 +321,10 @@ final class SpyEncoder: InputEncoder, Sendable {
     func sendPanelDismiss() {}
     func sendPanelResize(heightPercent: UInt8) {}
     func sendOpenFile(path: String) {}
+    func sendToolInstall(name: String) {}
+    func sendToolUninstall(name: String) {}
+    func sendToolUpdate(name: String) {}
+    func sendToolDismiss() {}
 }
 
 @Suite("EditorNSView Resize")

--- a/test/minga/port/protocol_test.exs
+++ b/test/minga/port/protocol_test.exs
@@ -1193,6 +1193,7 @@ defmodule Minga.Port.ProtocolTest do
   describe "encode_gui_gutter/1" do
     test "encodes per-window gutter with position header and entries" do
       data = %{
+        window_id: 1,
         content_row: 2,
         content_col: 10,
         content_height: 30,
@@ -1210,8 +1211,10 @@ defmodule Minga.Port.ProtocolTest do
 
       encoded = ProtocolGUI.encode_gui_gutter(data)
 
-      assert <<0x7B, c_row::16, c_col::16, c_h::16, active::8, cursor::32, style::8, ln_w::8,
-               sign_w::8, count::16, rest::binary>> = encoded
+      assert <<0x7B, wid::16, c_row::16, c_col::16, c_h::16, active::8, cursor::32, style::8,
+               ln_w::8, sign_w::8, count::16, rest::binary>> = encoded
+
+      assert wid == 1
 
       assert c_row == 2
       assert c_col == 10
@@ -1232,6 +1235,7 @@ defmodule Minga.Port.ProtocolTest do
 
     test "encodes inactive window" do
       data = %{
+        window_id: 1,
         content_row: 25,
         content_col: 0,
         content_height: 20,
@@ -1245,12 +1249,13 @@ defmodule Minga.Port.ProtocolTest do
 
       encoded = ProtocolGUI.encode_gui_gutter(data)
 
-      assert <<0x7B, 25::16, 0::16, 20::16, 0::8, 10::32, 1::8, 3::8, 0::8, 1::16, _rest::binary>> =
-               encoded
+      assert <<0x7B, 1::16, 25::16, 0::16, 20::16, 0::8, 10::32, 1::8, 3::8, 0::8, 1::16,
+               _rest::binary>> = encoded
     end
 
     test "encodes empty gutter (no entries)" do
       data = %{
+        window_id: 1,
         content_row: 0,
         content_col: 0,
         content_height: 0,
@@ -1265,12 +1270,13 @@ defmodule Minga.Port.ProtocolTest do
       encoded = ProtocolGUI.encode_gui_gutter(data)
 
       # none = 3
-      assert <<0x7B, 0::16, 0::16, 0::16, 0::8, 0::32, 3::8, 0::8, 0::8, 0::16>> = encoded
+      assert <<0x7B, 1::16, 0::16, 0::16, 0::16, 0::8, 0::32, 3::8, 0::8, 0::8, 0::16>> = encoded
     end
 
     test "encodes all line number styles" do
       for {style, expected_byte} <- [hybrid: 0, absolute: 1, relative: 2, none: 3] do
         data = %{
+          window_id: 1,
           content_row: 0,
           content_col: 0,
           content_height: 10,
@@ -1283,7 +1289,8 @@ defmodule Minga.Port.ProtocolTest do
         }
 
         encoded = ProtocolGUI.encode_gui_gutter(data)
-        assert <<0x7B, _pos::binary-size(7), 0::32, ^expected_byte::8, _rest::binary>> = encoded
+        # header: opcode(1) + window_id(2) + pos(6) + is_active(1) = 10 bytes before cursor_line
+        assert <<0x7B, _pre::binary-size(9), 0::32, ^expected_byte::8, _rest::binary>> = encoded
       end
     end
 
@@ -1305,6 +1312,7 @@ defmodule Minga.Port.ProtocolTest do
         end)
 
       data = %{
+        window_id: 1,
         content_row: 0,
         content_col: 0,
         content_height: 40,
@@ -1318,8 +1326,8 @@ defmodule Minga.Port.ProtocolTest do
 
       encoded = ProtocolGUI.encode_gui_gutter(data)
 
-      # Header: opcode(1) + pos(7) + cursor(4) + style(1) + ln_w(1) + sign_w(1) + count(2) = 17
-      <<0x7B, _header::binary-size(16), rest::binary>> = encoded
+      # Header: opcode(1) + wid(2) + pos(7) + cursor(4) + style(1) + ln_w(1) + sign_w(1) + count(2) = 19
+      <<0x7B, _header::binary-size(18), rest::binary>> = encoded
 
       # Extract sign_type bytes from each 6-byte entry
       actual_sign_bytes =


### PR DESCRIPTION
## What

Adds `window_id(u16)` to the 0x7B gui_gutter wire format so the Swift renderer can match gutter data to semantic window content (0x80) by window ID. This fixes a latent bug from #828 Phase 3 where multi-window (split pane) layouts would render all semantic content at the first window's position.

## Why

The `CoreTextMetalRenderer` needs to know which gutter entry corresponds to which `GUIWindowContent` to position buffer content correctly. Without `windowId`, it used `$0.isActive` which only matched the focused window and silently broke for splits.

## What Changed

**BEAM**: `gutter_data` type and `encode_gui_gutter` include `window_id`. `build_window_gutter` receives `win_id` from layout iteration.

**Swift**: `GUIWindowGutter.windowId` decoded from wire format. `LineBuffer.windowGutters` changed from array to `[UInt16: GUIWindowGutter]` dictionary. `CoreTextMetalRenderer` matches by `lineBuffer.windowGutters[content.windowId]`.

**Credo fixes** (pre-existing, unrelated): aliased `PickerUI` in editor.ex, extracted `select_item` in picker_ui.ex, extracted `cond_tool_status` in tool/manager.ex.

**Docs**: GUI_PROTOCOL.md 0x7B section updated.

## Testing

- 5 existing gutter protocol tests updated for new wire format (all pass)
- 128 Swift tests pass
- Full Elixir suite passes (5867 tests)