### PR TITLE
perf(macos): line texture atlas for batched instanced draw calls (#859)

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		00F882ED2F8F2943E71E34BC /* CoreTextShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 48E21C30D142028698027567 /* CoreTextShaders.metal */; };
 		03FDC63893F3CAA82BCE2A49 /* TabBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7AA0437B5C38BA8A8A80D5 /* TabBarState.swift */; };
 		07C32C28178AE5675ACF4539 /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
+		07C6F28E3CD1A55ABD5344AA /* SlotAllocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */; };
 		0A5FA884302FD99B07B78852 /* AgentChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD14027C8C7BD17057DE820B /* AgentChatView.swift */; };
 		0A71887712DA184422548C26 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
 		0CB4D8D8FE0F7CBB3C69E609 /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
@@ -20,6 +21,7 @@
 		16E32CF32A4AE261F717B823 /* MingaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A647814918768E62822D4A1 /* MingaApp.swift */; };
 		1F9F7B302A2A8598C1391FA0 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
 		2534C98EBC14F9F08600AE7A /* SymbolsNerdFontMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FD66FBCBFC20D50D22A969C8 /* SymbolsNerdFontMono-Regular.ttf */; };
+		26DAAF2C2CCC2713AD30C539 /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
 		27236A210603A4548A56F072 /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */; };
 		2A14A36D7CB3580A73355970 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7C3564C27A7E14D894539 /* TabBarView.swift */; };
 		2BA99A1851D0FF01436D5FF8 /* ToolManagerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64B96EAA100E627F4E8E0A1 /* ToolManagerState.swift */; };
@@ -39,6 +41,7 @@
 		527C7DB557EFD09B3161BC20 /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		531166B714D49278BA811033 /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E892F827AFBE959F9DF25C05 /* StatusBarView.swift */; };
 		538E6D52EBF51B7D360A5A0A /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */; };
+		54D70F98C342DBD31BDB667D /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
 		558E321D35C5B67801EE9CF2 /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		59546703C9DBB4BA6E15DE28 /* BottomPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */; };
 		5BEEC2FD4D95EBA70FE036E7 /* BottomPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */; };
@@ -51,6 +54,7 @@
 		6442AF895C03F5AEF2D4500F /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
 		6474095F95F4DA480AFE91B7 /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
 		64A5A16E02B3E2694060F1A1 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
+		6700C63C4B7070D3388A7BD4 /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		686DD6EB8AFDCAFC79EA100A /* ProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F220A60775A252A728477659 /* ProtocolTests.swift */; };
 		687B43B79B14FA56F9B76115 /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD30A2572AE2608F099407 /* ScrollAccumulator.swift */; };
 		6C386E10E81099D724B28984 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
@@ -93,6 +97,7 @@
 		D1EEFBDAE315F717373F82BD /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83165B89231936674C54B513 /* EditorNSView.swift */; };
 		D3D3326E46122D2FEA329E47 /* WhichKeyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5765529645C5D860576B7 /* WhichKeyState.swift */; };
 		D42695D627BD38405475ECFF /* ScrollAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */; };
+		E18A2D9D7987A763DBD8214D /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		E2F11A5F81A89C0BF03D9EE2 /* CoreTextLineRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5387C9048870A71E7565ED06 /* CoreTextLineRenderer.swift */; };
 		EDF83D0ACFCCB4ED91C1813C /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
 		F16FDEC1BFC1776B1109622E /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7C3564C27A7E14D894539 /* TabBarView.swift */; };
@@ -111,9 +116,11 @@
 		0C26E064D810299C0302F439 /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
 		211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollAccumulatorTests.swift; sourceTree = "<group>"; };
 		2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMEComposition.swift; sourceTree = "<group>"; };
+		371C61E78D4BB39467516BA7 /* SlotAllocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotAllocator.swift; sourceTree = "<group>"; };
 		3E23DC6E0ACB156F21293E87 /* PortLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortLogger.swift; sourceTree = "<group>"; };
 		42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapRasterizer.swift; sourceTree = "<group>"; };
 		443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPanelView.swift; sourceTree = "<group>"; };
+		4742DDE225F256A140177301 /* LineTextureAtlas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineTextureAtlas.swift; sourceTree = "<group>"; };
 		48E21C30D142028698027567 /* CoreTextShaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = CoreTextShaders.metal; sourceTree = "<group>"; };
 		4A647814918768E62822D4A1 /* MingaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MingaApp.swift; sourceTree = "<group>"; };
 		4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolReader.swift; sourceTree = "<group>"; };
@@ -138,6 +145,7 @@
 		83165B89231936674C54B513 /* EditorNSView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorNSView.swift; sourceTree = "<group>"; };
 		89DAA6AEFA6A62A1172EABF2 /* minga-mac */ = {isa = PBXFileReference; includeInIndex = 0; path = "minga-mac"; sourceTree = BUILT_PRODUCTS_DIR; };
 		92C0836F0D4150126F181C05 /* PickerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerState.swift; sourceTree = "<group>"; };
+		9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotAllocatorTests.swift; sourceTree = "<group>"; };
 		A64B96EAA100E627F4E8E0A1 /* ToolManagerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolManagerState.swift; sourceTree = "<group>"; };
 		AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentView.swift; sourceTree = "<group>"; };
 		BD2DE335B00721CBB29329F9 /* FontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontTests.swift; sourceTree = "<group>"; };
@@ -172,6 +180,8 @@
 				5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */,
 				48E21C30D142028698027567 /* CoreTextShaders.metal */,
 				F87D78FA2B8AA133DDD3141B /* LineBuffer.swift */,
+				4742DDE225F256A140177301 /* LineTextureAtlas.swift */,
+				371C61E78D4BB39467516BA7 /* SlotAllocator.swift */,
 				790F7E20F30FEEFC552B3685 /* WindowContent.swift */,
 				CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */,
 			);
@@ -297,6 +307,7 @@
 				5F5F10DF600E92632AD966A5 /* LineBufferTests.swift */,
 				F220A60775A252A728477659 /* ProtocolTests.swift */,
 				211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */,
+				9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */,
 				56B00002D020FED57D265C74 /* SystemColorTests.swift */,
 				620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */,
 				FD7FC26DB745A436D50E3AA6 /* WindowContentTests.swift */,
@@ -433,6 +444,7 @@
 				538E6D52EBF51B7D360A5A0A /* GUIState.swift in Sources */,
 				A6F3965C6177C36406CC4FF8 /* IMEComposition.swift in Sources */,
 				8D4AE4D5778E872B2FAF4A07 /* LineBuffer.swift in Sources */,
+				54D70F98C342DBD31BDB667D /* LineTextureAtlas.swift in Sources */,
 				F3BD75F62566F16642D8159D /* MessagesContentState.swift in Sources */,
 				A15090D92542403F12179DFD /* MessagesContentView.swift in Sources */,
 				16E32CF32A4AE261F717B823 /* MingaApp.swift in Sources */,
@@ -445,6 +457,7 @@
 				0CB4D8D8FE0F7CBB3C69E609 /* ProtocolEncoder.swift in Sources */,
 				C17647BBA01612BBFC7DCC04 /* ProtocolReader.swift in Sources */,
 				687B43B79B14FA56F9B76115 /* ScrollAccumulator.swift in Sources */,
+				E18A2D9D7987A763DBD8214D /* SlotAllocator.swift in Sources */,
 				B2EFBC6B76ABF724B8C9B04F /* StatusBarView.swift in Sources */,
 				2E40B27FA890123D325C4346 /* TabBarState.swift in Sources */,
 				2A14A36D7CB3580A73355970 /* TabBarView.swift in Sources */,
@@ -487,6 +500,7 @@
 				1631D7B76B33CD897C48F263 /* IMECompositionTests.swift in Sources */,
 				63A874F653524DCE4E046BDD /* LineBuffer.swift in Sources */,
 				C7F0701B0E9FCF7E0293E84D /* LineBufferTests.swift in Sources */,
+				26DAAF2C2CCC2713AD30C539 /* LineTextureAtlas.swift in Sources */,
 				8D55764B8CF042B4C48AA5D0 /* MessagesContentState.swift in Sources */,
 				931A6127210D4ED441AC04B2 /* MessagesContentView.swift in Sources */,
 				8B944E100C80DFF282D25D4C /* MingaWindow.swift in Sources */,
@@ -500,6 +514,8 @@
 				686DD6EB8AFDCAFC79EA100A /* ProtocolTests.swift in Sources */,
 				793247C2AB95598A1AC4C6EC /* ScrollAccumulator.swift in Sources */,
 				D42695D627BD38405475ECFF /* ScrollAccumulatorTests.swift in Sources */,
+				6700C63C4B7070D3388A7BD4 /* SlotAllocator.swift in Sources */,
+				07C6F28E3CD1A55ABD5344AA /* SlotAllocatorTests.swift in Sources */,
 				531166B714D49278BA811033 /* StatusBarView.swift in Sources */,
 				FEFCEFCDC21C5AA5456036D0 /* SystemColorTests.swift in Sources */,
 				03FDC63893F3CAA82BCE2A49 /* TabBarState.swift in Sources */,

--- a/macos/Sources/Renderer/CoreTextLineRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextLineRenderer.swift
@@ -195,6 +195,41 @@ final class CoreTextLineRenderer {
         return cached
     }
 
+    /// Render a line's styled runs into an atlas slot.
+    ///
+    /// Checks the atlas cache first. On hit, returns the cached entry.
+    /// On miss, rasterizes via BitmapRasterizer and uploads into the atlas.
+    func renderLineToAtlas(row: UInt16, runs: [StyledRun], contentHash: Int,
+                           atlas: LineTextureAtlas) -> AtlasEntry? {
+        guard !runs.isEmpty else { return nil }
+
+        // Atlas cache hit.
+        if let entry = atlas.cachedEntry(forKey: row, contentHash: contentHash) {
+            return entry
+        }
+
+        // Build attributed string and CTLine.
+        let attributedString = buildAttributedString(runs: runs)
+        let ctLine = CTLineCreateWithAttributedString(attributedString)
+
+        var lineAscent: CGFloat = 0
+        var lineDescent: CGFloat = 0
+        var lineLeading: CGFloat = 0
+        let lineWidth = CTLineGetTypographicBounds(ctLine, &lineAscent, &lineDescent, &lineLeading)
+
+        let pixelWidth = min(Int(ceil(lineWidth * scale)), maxLinePixelWidth)
+        guard pixelWidth > 0, linePixelHeight > 0 else { return nil }
+
+        // Rasterize into pooled bitmap.
+        let result = rasterizer.rasterize(ctLine, width: pixelWidth, height: linePixelHeight,
+                                          scale: scale, descent: descent)
+
+        // Upload into atlas slot.
+        return atlas.upload(key: row, contentHash: contentHash,
+                           pointer: result.pointer, pixelWidth: pixelWidth,
+                           bytesPerRow: result.bytesPerRow)
+    }
+
     /// Advance the frame counter and evict stale textures.
     func beginFrame() {
         frameCounter += 1

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -156,12 +156,22 @@ final class CoreTextMetalRenderer {
     /// Shared pooled bitmap rasterizer for both line renderers.
     private var bitmapRasterizer: BitmapRasterizer?
 
+    /// Line texture atlas for batched instanced drawing.
+    private(set) var atlas: LineTextureAtlas?
+
+    /// Metal buffer for line GPU instances (one instanced draw call).
+    private var instanceBuffer: MTLBuffer?
+    private var maxInstanceSlots: Int = 0
+
     /// Set up the line renderer. Called once the FontManager is available.
     func setupLineRenderer(fontManager: FontManager) {
         let rasterizer = BitmapRasterizer()
         self.bitmapRasterizer = rasterizer
         self.lineRenderer = CoreTextLineRenderer(device: device, fontManager: fontManager, rasterizer: rasterizer)
         self.windowContentRenderer = WindowContentRenderer(device: device, fontManager: fontManager, rasterizer: rasterizer)
+
+        let linePixelHeight = Int(ceil(CGFloat(fontManager.cellHeight) * fontManager.scale))
+        self.atlas = LineTextureAtlas(device: device, slotHeight: linePixelHeight)
     }
 
     /// Render the editor from LineBuffer data + semantic window content.
@@ -193,6 +203,22 @@ final class CoreTextMetalRenderer {
             }
         }
 
+        // Ensure atlas can hold all lines (content + gutter + semantic).
+        if let atlas {
+            let neededSlots = Int(lineBuffer.rows) * 4
+            let atlasPixelWidth = Int(ceil(CGFloat(lineBuffer.cols) * CGFloat(cellW) * CGFloat(scale)))
+            atlas.ensureCapacity(maxSlots: neededSlots, width: atlasPixelWidth)
+            atlas.beginFrame()
+
+            if neededSlots > maxInstanceSlots {
+                maxInstanceSlots = neededSlots
+                instanceBuffer = device.makeBuffer(
+                    length: neededSlots * MemoryLayout<LineGPU>.stride,
+                    options: .storageModeShared
+                )
+            }
+        }
+
         // Default background color.
         let defaultBg = lineBuffer.defaultBg != 0
             ? colorFromU24(lineBuffer.defaultBg, default: SIMD3<Float>(0.12, 0.12, 0.14))
@@ -221,7 +247,7 @@ final class CoreTextMetalRenderer {
 
         // Build background quads and line texture instances.
         var bgQuads: [QuadGPU] = []
-        var lineInstances: [(LineGPU, MTLTexture)] = []
+        var lineInstances: [LineGPU] = []
 
         for row: UInt16 in 0..<lineBuffer.rows {
             let rowF = Float(row)
@@ -290,20 +316,19 @@ final class CoreTextMetalRenderer {
             // Line texture.
             if !runs.isEmpty {
                 let contentHash = lineBuffer.computeLineHash(row: row)
-                if let cached = lineRenderer.renderLine(row: row, runs: runs, contentHash: contentHash) {
-                    // The texture starts at the first run's column. Gap-filling
-                    // spaces in the attributed string handle intra-line positioning.
+                if let atlas, let entry = lineRenderer.renderLineToAtlas(row: row, runs: runs, contentHash: contentHash, atlas: atlas) {
                     let firstCol = runs.first.map { Float($0.col) } ?? 0
                     let colPx = firstCol * cellW * scale
                     let xPos = firstCol >= Float(lineBuffer.gutterCol)
                         ? colPx + gutterPaddingPx : colPx
 
+                    let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
                     var lineGPU = LineGPU()
                     lineGPU.position = SIMD2<Float>(xPos, yPos)
-                    lineGPU.size = SIMD2<Float>(Float(cached.pixelWidth), Float(cached.pixelHeight))
-                    lineGPU.uvOrigin = .zero
-                    lineGPU.uvSize = SIMD2<Float>(1, 1)
-                    lineInstances.append((lineGPU, cached.texture))
+                    lineGPU.size = SIMD2<Float>(Float(entry.pixelWidth), Float(entry.pixelHeight))
+                    lineGPU.uvOrigin = uvOrigin
+                    lineGPU.uvSize = uvSize
+                    lineInstances.append(lineGPU)
                 }
             }
         }
@@ -354,17 +379,18 @@ final class CoreTextMetalRenderer {
                     semanticOverlayQuads.append(quad)
                 }
 
-                // Render line textures from semantic content.
+                // Render line textures from semantic content into atlas.
                 for (rowIdx, row) in content.rows.enumerated() {
-                    if let cached = wcr.renderRow(displayRow: UInt16(rowIdx), row: row) {
+                    if let atlas, let entry = wcr.renderRowToAtlas(displayRow: UInt16(rowIdx), row: row, atlas: atlas) {
                         let yPos = windowRowOffset + Float(rowIdx) * cellH * scale
 
+                        let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
                         var lineGPU = LineGPU()
                         lineGPU.position = SIMD2<Float>(contentColOffset, yPos)
-                        lineGPU.size = SIMD2<Float>(Float(cached.pixelWidth), Float(cached.pixelHeight))
-                        lineGPU.uvOrigin = .zero
-                        lineGPU.uvSize = SIMD2<Float>(1, 1)
-                        lineInstances.append((lineGPU, cached.texture))
+                        lineGPU.size = SIMD2<Float>(Float(entry.pixelWidth), Float(entry.pixelHeight))
+                        lineGPU.uvOrigin = uvOrigin
+                        lineGPU.uvSize = uvSize
+                        lineInstances.append(lineGPU)
                     }
                 }
 
@@ -459,15 +485,21 @@ final class CoreTextMetalRenderer {
             encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
         }
 
-        // Pass 3: Line textures (one draw call per line since each has its own texture).
-        if !lineInstances.isEmpty {
-            encoder.setRenderPipelineState(linePipeline)
-            for (var lineGPU, texture) in lineInstances {
-                encoder.setVertexBytes(&lineGPU, length: MemoryLayout<LineGPU>.stride, index: 0)
-                encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
-                encoder.setFragmentTexture(texture, index: 0)
-                encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+        // Pass 3: Line textures — one instanced draw call with the atlas texture.
+        if !lineInstances.isEmpty, let atlas, let atlasTexture = atlas.texture,
+           let instBuf = instanceBuffer {
+            // Copy instance data into the shared Metal buffer.
+            let byteCount = lineInstances.count * MemoryLayout<LineGPU>.stride
+            lineInstances.withUnsafeBytes { ptr in
+                memcpy(instBuf.contents(), ptr.baseAddress!, byteCount)
             }
+
+            encoder.setRenderPipelineState(linePipeline)
+            encoder.setVertexBuffer(instBuf, offset: 0, index: 0)
+            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+            encoder.setFragmentTexture(atlasTexture, index: 0)
+            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6,
+                                   instanceCount: lineInstances.count)
         }
 
         // Pass 3.5: Diagnostic underline quads (drawn after text, before gutter).
@@ -560,7 +592,7 @@ final class CoreTextMetalRenderer {
         cellW: Float, cellH: Float, scale: Float,
         gutterPaddingPx: Float,
         bgQuads: inout [QuadGPU],
-        lineInstances: inout [(LineGPU, MTLTexture)]
+        lineInstances: inout [LineGPU]
     ) {
         guard let lineRenderer else { return }
         let signColWidth = Int(gutter.signColWidth)
@@ -608,7 +640,7 @@ final class CoreTextMetalRenderer {
         cellW: Float, cellH: Float, scale: Float,
         lineBuffer: LineBuffer,
         bgQuads: inout [QuadGPU],
-        lineInstances: inout [(LineGPU, MTLTexture)],
+        lineInstances: inout [LineGPU],
         lineRenderer: CoreTextLineRenderer
     ) {
         switch entry.signType {
@@ -642,16 +674,16 @@ final class CoreTextMetalRenderer {
         case .diagError, .diagWarning, .diagInfo, .diagHint:
             let (text, fg) = diagnosticSignTextAndColor(entry.signType, lineBuffer: lineBuffer)
             let runs = [StyledRun(col: 0, text: text, fg: fg, bg: 0, attrs: 0)]
-            // Use screen row directly for cache key (unique per screen position)
             let cacheRow = 0x8000 + screenRow
             let contentHash = gutterContentHash(text: text, fg: fg)
-            if let cached = lineRenderer.renderLine(row: cacheRow, runs: runs, contentHash: contentHash) {
+            if let atlas, let entry = lineRenderer.renderLineToAtlas(row: cacheRow, runs: runs, contentHash: contentHash, atlas: atlas) {
+                let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
                 var lineGPU = LineGPU()
                 lineGPU.position = SIMD2<Float>(xOffset, yPos)
-                lineGPU.size = SIMD2<Float>(Float(cached.pixelWidth), Float(cached.pixelHeight))
-                lineGPU.uvOrigin = .zero
-                lineGPU.uvSize = SIMD2<Float>(1, 1)
-                lineInstances.append((lineGPU, cached.texture))
+                lineGPU.size = SIMD2<Float>(Float(entry.pixelWidth), Float(entry.pixelHeight))
+                lineGPU.uvOrigin = uvOrigin
+                lineGPU.uvSize = uvSize
+                lineInstances.append(lineGPU)
             }
 
         case .none:
@@ -666,7 +698,7 @@ final class CoreTextMetalRenderer {
         signColWidth: Int,
         cellW: Float, cellH: Float, scale: Float,
         lineBuffer: LineBuffer,
-        lineInstances: inout [(LineGPU, MTLTexture)],
+        lineInstances: inout [LineGPU],
         lineRenderer: CoreTextLineRenderer
     ) {
         let (numberStr, isCurrent) = gutterNumberString(
@@ -686,17 +718,17 @@ final class CoreTextMetalRenderer {
         let startCol = UInt16(signColWidth + padCols)
 
         let runs = [StyledRun(col: startCol, text: numberStr, fg: fg, bg: 0, attrs: 0)]
-        // Use screen row for cache key (unique per screen position)
         let cacheRow = 0x9000 + screenRow
         let contentHash = gutterContentHash(text: numberStr, fg: fg)
-        if let cached = lineRenderer.renderLine(row: cacheRow, runs: runs, contentHash: contentHash) {
+        if let atlas, let entry = lineRenderer.renderLineToAtlas(row: cacheRow, runs: runs, contentHash: contentHash, atlas: atlas) {
+            let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
             let xPos = xOffset + Float(startCol) * cellW * scale
             var lineGPU = LineGPU()
             lineGPU.position = SIMD2<Float>(xPos, yPos)
-            lineGPU.size = SIMD2<Float>(Float(cached.pixelWidth), Float(cached.pixelHeight))
-            lineGPU.uvOrigin = .zero
-            lineGPU.uvSize = SIMD2<Float>(1, 1)
-            lineInstances.append((lineGPU, cached.texture))
+            lineGPU.size = SIMD2<Float>(Float(entry.pixelWidth), Float(entry.pixelHeight))
+            lineGPU.uvOrigin = uvOrigin
+            lineGPU.uvSize = uvSize
+            lineInstances.append(lineGPU)
         }
     }
 

--- a/macos/Sources/Renderer/LineTextureAtlas.swift
+++ b/macos/Sources/Renderer/LineTextureAtlas.swift
@@ -1,0 +1,138 @@
+/// Single-texture atlas backed by `SlotAllocator` for slot management.
+///
+/// Thin Metal wrapper: delegates slot allocation, caching, and UV math
+/// to `SlotAllocator` (pure, testable). Owns the `MTLTexture` and
+/// handles `texture.replace` for bitmap uploads.
+
+import Metal
+import Foundation
+
+/// Result of rendering a line into the atlas.
+struct AtlasEntry {
+    let slotIndex: Int
+    let pixelWidth: Int
+    let pixelHeight: Int
+}
+
+@MainActor
+final class LineTextureAtlas {
+    /// The atlas texture.
+    private(set) var texture: MTLTexture?
+
+    private let device: MTLDevice
+
+    /// Pure slot management (testable without Metal).
+    private(set) var allocator = SlotAllocator()
+
+    /// Height of each slot in pixels.
+    let slotHeight: Int
+
+    /// Width of the atlas in pixels.
+    private(set) var atlasWidth: Int = 0
+
+    /// Total atlas height in pixels.
+    private(set) var atlasHeight: Int = 0
+
+    /// Number of allocated slots.
+    var slotCount: Int { allocator.capacity }
+
+    init(device: MTLDevice, slotHeight: Int) {
+        self.device = device
+        self.slotHeight = slotHeight
+    }
+
+    /// Grow the atlas if needed. Reallocates the texture on size change.
+    func ensureCapacity(maxSlots: Int, width: Int) {
+        guard maxSlots > 0, width > 0 else { return }
+
+        let needsRealloc = maxSlots > allocator.capacity || width > atlasWidth
+        guard needsRealloc else { return }
+
+        let newSlotCount = max(maxSlots, allocator.capacity)
+        let newWidth = max(width, atlasWidth)
+        let newHeight = newSlotCount * slotHeight
+
+        let desc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb,
+            width: newWidth,
+            height: newHeight,
+            mipmapped: false
+        )
+        desc.usage = [.shaderRead]
+        desc.storageMode = .managed
+
+        texture = device.makeTexture(descriptor: desc)
+        atlasWidth = newWidth
+        atlasHeight = newHeight
+
+        // Reset allocator on reallocation (texture contents are gone).
+        allocator = SlotAllocator()
+        allocator.ensureCapacity(maxSlots: newSlotCount)
+    }
+
+    func beginFrame() {
+        allocator.beginFrame()
+    }
+
+    /// Check atlas cache. Returns entry if hit, nil if miss.
+    func cachedEntry(forKey key: UInt16, contentHash: Int) -> AtlasEntry? {
+        let result = allocator.allocate(key: key, contentHash: contentHash)
+        switch result {
+        case .hit(let slotIndex):
+            return AtlasEntry(
+                slotIndex: slotIndex,
+                pixelWidth: allocator.pixelWidth(forSlot: slotIndex),
+                pixelHeight: slotHeight
+            )
+        default:
+            return nil
+        }
+    }
+
+    /// Upload bitmap into the atlas. Allocates a slot if needed.
+    func upload(key: UInt16, contentHash: Int,
+                pointer: UnsafeRawPointer, pixelWidth: Int,
+                bytesPerRow: Int) -> AtlasEntry? {
+        guard let tex = texture else { return nil }
+
+        let result = allocator.allocate(key: key, contentHash: contentHash)
+        let slotIndex: Int
+
+        switch result {
+        case .hit(let idx):
+            // Already cached and uploaded.
+            return AtlasEntry(slotIndex: idx, pixelWidth: allocator.pixelWidth(forSlot: idx), pixelHeight: slotHeight)
+        case .miss(let idx):
+            slotIndex = idx
+        case .evicted(let idx, _):
+            slotIndex = idx
+        case .full:
+            return nil
+        }
+
+        // Upload bitmap into the slot region.
+        let yOffset = slotIndex * slotHeight
+        let uploadWidth = min(pixelWidth, atlasWidth)
+        let region = MTLRegion(
+            origin: MTLOrigin(x: 0, y: yOffset, z: 0),
+            size: MTLSize(width: uploadWidth, height: slotHeight, depth: 1)
+        )
+        tex.replace(region: region, mipmapLevel: 0,
+                    withBytes: pointer, bytesPerRow: bytesPerRow)
+
+        allocator.markUploaded(slotIndex: slotIndex, contentHash: contentHash, pixelWidth: pixelWidth)
+
+        return AtlasEntry(slotIndex: slotIndex, pixelWidth: pixelWidth, pixelHeight: slotHeight)
+    }
+
+    /// Compute UV for a slot.
+    func uvForSlot(_ slotIndex: Int, pixelWidth: Int) -> (SIMD2<Float>, SIMD2<Float>) {
+        SlotAllocator.uvForSlot(slotIndex, pixelWidth: pixelWidth,
+                                slotHeight: slotHeight, atlasWidth: atlasWidth,
+                                atlasHeight: atlasHeight)
+    }
+
+    func invalidateAll() {
+        allocator.invalidateAll()
+    }
+}

--- a/macos/Sources/Renderer/SlotAllocator.swift
+++ b/macos/Sources/Renderer/SlotAllocator.swift
@@ -1,0 +1,169 @@
+/// Pure slot allocation and cache management for the line texture atlas.
+///
+/// Manages key-to-slot mapping, content hash caching, LRU eviction, and
+/// UV coordinate computation. No Metal dependency; fully unit-testable.
+///
+/// `LineTextureAtlas` wraps this with an `MTLTexture` for actual GPU uploads.
+
+import simd
+
+/// Metadata for one slot in the atlas.
+struct AtlasSlot {
+    var contentHash: Int = 0
+    var pixelWidth: Int = 0
+    var lastWrittenFrame: UInt64 = 0
+}
+
+/// Result of a slot allocation request.
+enum SlotResult: Equatable {
+    /// Cache hit: the slot already contains the right content.
+    case hit(slotIndex: Int)
+    /// Cache miss: the slot needs new content uploaded.
+    /// For a reused key with changed hash, the slot index is the same.
+    case miss(slotIndex: Int)
+    /// All slots were full. An old slot was evicted to make room.
+    case evicted(slotIndex: Int, evictedKey: UInt16)
+    /// No slots available (capacity 0).
+    case full
+}
+
+struct SlotAllocator {
+    /// Per-slot metadata.
+    private var slots: [AtlasSlot] = []
+
+    /// Maps cache keys to slot indices.
+    private var keyToSlot: [UInt16: Int] = [:]
+
+    /// Free slot indices.
+    private var freeSlots: [Int] = []
+
+    /// Current frame counter for LRU tracking.
+    private var frameCounter: UInt64 = 0
+
+    /// Current capacity.
+    private(set) var capacity: Int = 0
+
+    /// Number of occupied slots.
+    var occupiedCount: Int { capacity - freeSlots.count }
+
+    /// Initialize with zero capacity. Call `ensureCapacity` before use.
+    init() {}
+
+    /// Grow capacity if needed. Never shrinks. Preserves existing slots.
+    mutating func ensureCapacity(maxSlots: Int) {
+        guard maxSlots > capacity else { return }
+
+        let oldCount = capacity
+        capacity = maxSlots
+        slots.append(contentsOf: Array(repeating: AtlasSlot(), count: maxSlots - oldCount))
+        // New slots are free, added in reverse order for LIFO allocation.
+        freeSlots.append(contentsOf: ((oldCount)..<maxSlots).reversed())
+    }
+
+    /// Advance frame counter.
+    mutating func beginFrame() {
+        frameCounter += 1
+    }
+
+    /// Request a slot for the given key and content hash.
+    ///
+    /// - `.hit`: slot is cached with matching hash. No upload needed.
+    /// - `.miss`: slot is assigned but content changed. Upload needed.
+    /// - `.evicted`: an old slot was freed to make room. Upload needed.
+    /// - `.full`: no capacity.
+    mutating func allocate(key: UInt16, contentHash: Int) -> SlotResult {
+        // Existing key: check if hash matches.
+        if let slotIndex = keyToSlot[key] {
+            slots[slotIndex].lastWrittenFrame = frameCounter
+            if slots[slotIndex].contentHash == contentHash {
+                return .hit(slotIndex: slotIndex)
+            }
+            // Same key, different hash: reuse slot, caller re-uploads.
+            return .miss(slotIndex: slotIndex)
+        }
+
+        // New key: allocate a free slot.
+        if let free = freeSlots.popLast() {
+            keyToSlot[key] = free
+            slots[free].lastWrittenFrame = frameCounter
+            return .miss(slotIndex: free)
+        }
+
+        // No free slots: evict LRU.
+        guard let (evictIndex, evictedKey) = evictOldest() else {
+            return .full
+        }
+        keyToSlot[key] = evictIndex
+        slots[evictIndex].lastWrittenFrame = frameCounter
+        return .evicted(slotIndex: evictIndex, evictedKey: evictedKey)
+    }
+
+    /// Mark a slot as successfully uploaded with the given hash and width.
+    mutating func markUploaded(slotIndex: Int, contentHash: Int, pixelWidth: Int) {
+        guard slotIndex < slots.count else { return }
+        slots[slotIndex].contentHash = contentHash
+        slots[slotIndex].pixelWidth = pixelWidth
+        slots[slotIndex].lastWrittenFrame = frameCounter
+    }
+
+    /// Get the pixel width of a cached slot (for UV computation).
+    func pixelWidth(forSlot slotIndex: Int) -> Int {
+        guard slotIndex < slots.count else { return 0 }
+        return slots[slotIndex].pixelWidth
+    }
+
+    /// Compute UV origin and size for a slot.
+    ///
+    /// - Parameters:
+    ///   - slotIndex: Slot index in the atlas.
+    ///   - pixelWidth: Actual content width.
+    ///   - slotHeight: Height of each slot in pixels.
+    ///   - atlasWidth: Total atlas width in pixels.
+    ///   - atlasHeight: Total atlas height in pixels.
+    static func uvForSlot(_ slotIndex: Int, pixelWidth: Int,
+                          slotHeight: Int, atlasWidth: Int,
+                          atlasHeight: Int) -> (SIMD2<Float>, SIMD2<Float>) {
+        let aw = Float(atlasWidth)
+        let ah = Float(atlasHeight)
+        guard aw > 0, ah > 0 else { return (.zero, SIMD2<Float>(1, 1)) }
+
+        let origin = SIMD2<Float>(0, Float(slotIndex * slotHeight) / ah)
+        let size = SIMD2<Float>(
+            pixelWidth > 0 ? Float(pixelWidth) / aw : 0,
+            Float(slotHeight) / ah
+        )
+        return (origin, size)
+    }
+
+    /// Clear all slots. Capacity is preserved.
+    mutating func invalidateAll() {
+        for i in 0..<slots.count {
+            slots[i].contentHash = 0
+            slots[i].pixelWidth = 0
+        }
+        keyToSlot.removeAll(keepingCapacity: true)
+        freeSlots = Array((0..<capacity).reversed())
+    }
+
+    // MARK: - Private
+
+    private mutating func evictOldest() -> (index: Int, key: UInt16)? {
+        guard !slots.isEmpty else { return nil }
+
+        var oldestFrame: UInt64 = .max
+        var oldestIndex = 0
+
+        for (i, slot) in slots.enumerated() {
+            if keyToSlot.values.contains(i), slot.lastWrittenFrame < oldestFrame {
+                oldestFrame = slot.lastWrittenFrame
+                oldestIndex = i
+            }
+        }
+
+        guard let oldKey = keyToSlot.first(where: { $0.value == oldestIndex })?.key else {
+            return nil
+        }
+        keyToSlot.removeValue(forKey: oldKey)
+        return (oldestIndex, oldKey)
+    }
+}

--- a/macos/Sources/Renderer/WindowContentRenderer.swift
+++ b/macos/Sources/Renderer/WindowContentRenderer.swift
@@ -166,6 +166,44 @@ final class WindowContentRenderer {
         return cached
     }
 
+    /// Render a visual row into an atlas slot.
+    ///
+    /// Checks the atlas cache first (using a key offset of 0xA000 to avoid
+    /// collision with content/gutter keys). On miss, rasterizes and uploads.
+    func renderRowToAtlas(displayRow: UInt16, row: GUIVisualRow,
+                          atlas: LineTextureAtlas) -> AtlasEntry? {
+        let hash = Int(row.contentHash)
+        let key = 0xA000 + displayRow  // Namespace to avoid collisions
+
+        guard !row.text.isEmpty else { return nil }
+
+        // Atlas cache hit.
+        if let entry = atlas.cachedEntry(forKey: key, contentHash: hash) {
+            return entry
+        }
+
+        // Build attributed string and CTLine.
+        let attributedString = buildAttributedString(text: row.text, spans: row.spans)
+        let ctLine = CTLineCreateWithAttributedString(attributedString)
+
+        var lineAscent: CGFloat = 0
+        var lineDescent: CGFloat = 0
+        var lineLeading: CGFloat = 0
+        let lineWidth = CTLineGetTypographicBounds(ctLine, &lineAscent, &lineDescent, &lineLeading)
+
+        let pixelWidth = min(Int(ceil(lineWidth * scale)), maxLinePixelWidth)
+        guard pixelWidth > 0, linePixelHeight > 0 else { return nil }
+
+        // Rasterize into pooled bitmap.
+        let result = rasterizer.rasterize(ctLine, width: pixelWidth, height: linePixelHeight,
+                                          scale: scale, descent: descent)
+
+        // Upload into atlas slot.
+        return atlas.upload(key: key, contentHash: hash,
+                           pointer: result.pointer, pixelWidth: pixelWidth,
+                           bytesPerRow: result.bytesPerRow)
+    }
+
     // MARK: - Attributed String Building
 
     /// Builds an NSAttributedString from composed text and pre-resolved spans.

--- a/macos/Tests/MingaTests/SlotAllocatorTests.swift
+++ b/macos/Tests/MingaTests/SlotAllocatorTests.swift
@@ -1,0 +1,293 @@
+/// Tests for SlotAllocator: pure slot management logic for the line texture atlas.
+/// No Metal dependency. Runs on all platforms.
+
+import Testing
+import simd
+
+@Suite("SlotAllocator — Allocation")
+struct SlotAllocatorAllocationTests {
+
+    @Test("New key returns miss with a valid slot index")
+    func newKeyReturnsMiss() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 10)
+
+        let result = alloc.allocate(key: 0, contentHash: 42)
+
+        guard case .miss(let slot) = result else {
+            Issue.record("Expected .miss, got \(result)")
+            return
+        }
+        #expect(slot >= 0 && slot < 10)
+        #expect(alloc.occupiedCount == 1)
+    }
+
+    @Test("Same key and hash returns cache hit")
+    func sameKeyAndHashReturnsHit() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 10)
+
+        let first = alloc.allocate(key: 5, contentHash: 42)
+        guard case .miss(let slot1) = first else {
+            Issue.record("Expected first .miss"); return
+        }
+        alloc.markUploaded(slotIndex: slot1, contentHash: 42, pixelWidth: 100)
+
+        let second = alloc.allocate(key: 5, contentHash: 42)
+        guard case .hit(let slot2) = second else {
+            Issue.record("Expected .hit, got \(second)"); return
+        }
+        #expect(slot1 == slot2)
+    }
+
+    @Test("Same key with different hash returns miss, reuses slot")
+    func sameKeyDifferentHashReturnsMiss() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 10)
+
+        let first = alloc.allocate(key: 5, contentHash: 42)
+        guard case .miss(let slot1) = first else {
+            Issue.record("Expected first .miss"); return
+        }
+        alloc.markUploaded(slotIndex: slot1, contentHash: 42, pixelWidth: 100)
+
+        let second = alloc.allocate(key: 5, contentHash: 99)
+        guard case .miss(let slot2) = second else {
+            Issue.record("Expected .miss, got \(second)"); return
+        }
+        #expect(slot1 == slot2)
+        #expect(alloc.occupiedCount == 1)
+    }
+
+    @Test("Multiple keys get distinct slots")
+    func multipleKeysGetDistinctSlots() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 10)
+
+        var slots: Set<Int> = []
+        for key: UInt16 in 0..<5 {
+            let result = alloc.allocate(key: key, contentHash: Int(key))
+            guard case .miss(let slot) = result else {
+                Issue.record("Expected .miss for key \(key)"); return
+            }
+            slots.insert(slot)
+        }
+        #expect(slots.count == 5)
+        #expect(alloc.occupiedCount == 5)
+    }
+
+    @Test("Zero capacity returns .full")
+    func zeroCapacityReturnsFull() {
+        var alloc = SlotAllocator()
+        // Don't call ensureCapacity
+        let result = alloc.allocate(key: 0, contentHash: 1)
+        #expect(result == .full)
+    }
+}
+
+@Suite("SlotAllocator — Eviction")
+struct SlotAllocatorEvictionTests {
+
+    @Test("Evicts oldest slot when full")
+    func evictsOldestWhenFull() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 3)
+
+        // Fill all 3 slots.
+        for key: UInt16 in 0..<3 {
+            let r = alloc.allocate(key: key, contentHash: Int(key))
+            guard case .miss(let s) = r else { Issue.record("Expected .miss"); return }
+            alloc.markUploaded(slotIndex: s, contentHash: Int(key), pixelWidth: 100)
+            alloc.beginFrame()
+        }
+
+        // Touch keys 1 and 2 (not key 0).
+        _ = alloc.allocate(key: 1, contentHash: 1)
+        _ = alloc.allocate(key: 2, contentHash: 2)
+        alloc.beginFrame()
+
+        // Allocate key 3 — should evict key 0.
+        let result = alloc.allocate(key: 3, contentHash: 3)
+        guard case .evicted(_, let evictedKey) = result else {
+            Issue.record("Expected .evicted, got \(result)"); return
+        }
+        #expect(evictedKey == 0)
+    }
+
+    @Test("Evicted slot is reused for new key")
+    func evictedSlotIsReused() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 2)
+
+        // Fill slots.
+        let r0 = alloc.allocate(key: 0, contentHash: 0)
+        guard case .miss(let slot0) = r0 else { Issue.record("Expected .miss"); return }
+        alloc.markUploaded(slotIndex: slot0, contentHash: 0, pixelWidth: 100)
+        alloc.beginFrame()
+
+        let r1 = alloc.allocate(key: 1, contentHash: 1)
+        guard case .miss(let slot1) = r1 else { Issue.record("Expected .miss"); return }
+        alloc.markUploaded(slotIndex: slot1, contentHash: 1, pixelWidth: 100)
+        alloc.beginFrame()
+
+        // Touch key 1 only.
+        _ = alloc.allocate(key: 1, contentHash: 1)
+        alloc.beginFrame()
+
+        // Evict: should get key 0's slot.
+        let r2 = alloc.allocate(key: 2, contentHash: 2)
+        guard case .evicted(let evictedSlot, _) = r2 else {
+            Issue.record("Expected .evicted, got \(r2)"); return
+        }
+        #expect(evictedSlot == slot0)
+    }
+}
+
+@Suite("SlotAllocator — Capacity")
+struct SlotAllocatorCapacityTests {
+
+    @Test("ensureCapacity grows but never shrinks")
+    func growNeverShrink() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 10)
+        #expect(alloc.capacity == 10)
+
+        alloc.ensureCapacity(maxSlots: 5) // should not shrink
+        #expect(alloc.capacity == 10)
+
+        alloc.ensureCapacity(maxSlots: 20) // should grow
+        #expect(alloc.capacity == 20)
+    }
+
+    @Test("Growing preserves existing slots")
+    func growPreservesExisting() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 5)
+
+        let r = alloc.allocate(key: 0, contentHash: 42)
+        guard case .miss(let slot) = r else { Issue.record("Expected .miss"); return }
+        alloc.markUploaded(slotIndex: slot, contentHash: 42, pixelWidth: 100)
+
+        alloc.ensureCapacity(maxSlots: 20)
+
+        // Original key should still be cached.
+        let r2 = alloc.allocate(key: 0, contentHash: 42)
+        #expect(r2 == .hit(slotIndex: slot))
+    }
+
+    @Test("invalidateAll clears all slots, preserves capacity")
+    func invalidateAll() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 5)
+
+        for key: UInt16 in 0..<5 {
+            let r = alloc.allocate(key: key, contentHash: Int(key))
+            guard case .miss(let s) = r else { Issue.record("Expected .miss"); return }
+            alloc.markUploaded(slotIndex: s, contentHash: Int(key), pixelWidth: 100)
+        }
+        #expect(alloc.occupiedCount == 5)
+
+        alloc.invalidateAll()
+        #expect(alloc.occupiedCount == 0)
+        #expect(alloc.capacity == 5)
+
+        // Allocating the same key should be a miss (not stale hit).
+        let r = alloc.allocate(key: 0, contentHash: 0)
+        guard case .miss = r else {
+            Issue.record("Expected .miss after invalidate, got \(r)"); return
+        }
+    }
+}
+
+@Suite("SlotAllocator — UV Computation")
+struct SlotAllocatorUVTests {
+
+    @Test("First slot has UV origin at (0, 0)")
+    func firstSlotOrigin() {
+        let (origin, size) = SlotAllocator.uvForSlot(0, pixelWidth: 500,
+                                                      slotHeight: 40, atlasWidth: 1024, atlasHeight: 400)
+        #expect(origin.x == 0.0)
+        #expect(origin.y == 0.0)
+        #expect(abs(size.x - 500.0 / 1024.0) < 0.001)
+        #expect(abs(size.y - 40.0 / 400.0) < 0.001)
+    }
+
+    @Test("Nth slot has correct vertical offset")
+    func nthSlotOffset() {
+        let (origin, _) = SlotAllocator.uvForSlot(3, pixelWidth: 200,
+                                                    slotHeight: 40, atlasWidth: 1024, atlasHeight: 400)
+        #expect(abs(origin.y - (3.0 * 40.0 / 400.0)) < 0.001)
+    }
+
+    @Test("Width fraction matches pixel width ratio")
+    func widthFraction() {
+        let (_, size) = SlotAllocator.uvForSlot(0, pixelWidth: 200,
+                                                  slotHeight: 40, atlasWidth: 1024, atlasHeight: 400)
+        #expect(abs(size.x - 200.0 / 1024.0) < 0.001)
+    }
+
+    @Test("Zero pixel width returns zero UV width")
+    func zeroPixelWidth() {
+        let (_, size) = SlotAllocator.uvForSlot(0, pixelWidth: 0,
+                                                  slotHeight: 40, atlasWidth: 1024, atlasHeight: 400)
+        #expect(size.x == 0.0)
+    }
+
+    @Test("Zero atlas dimensions return default UV")
+    func zeroAtlasDimensions() {
+        let (origin, size) = SlotAllocator.uvForSlot(0, pixelWidth: 100,
+                                                      slotHeight: 40, atlasWidth: 0, atlasHeight: 0)
+        #expect(origin == .zero)
+        #expect(size == SIMD2<Float>(1, 1))
+    }
+}
+
+@Suite("SlotAllocator — Edge Cases")
+struct SlotAllocatorEdgeCaseTests {
+
+    @Test("Single slot capacity: every new key evicts the previous")
+    func singleSlotCapacity() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 1)
+
+        let r0 = alloc.allocate(key: 0, contentHash: 0)
+        guard case .miss(let s0) = r0 else { Issue.record("Expected .miss"); return }
+        alloc.markUploaded(slotIndex: s0, contentHash: 0, pixelWidth: 100)
+        alloc.beginFrame()
+
+        let r1 = alloc.allocate(key: 1, contentHash: 1)
+        guard case .evicted(let s1, let evicted) = r1 else {
+            Issue.record("Expected .evicted, got \(r1)"); return
+        }
+        #expect(s1 == 0) // only slot available
+        #expect(evicted == 0) // key 0 was evicted
+    }
+
+    @Test("Key 0 and UInt16.max work correctly")
+    func boundaryKeys() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 10)
+
+        let r0 = alloc.allocate(key: 0, contentHash: 1)
+        let rMax = alloc.allocate(key: UInt16.max, contentHash: 2)
+
+        guard case .miss = r0, case .miss = rMax else {
+            Issue.record("Both should be .miss"); return
+        }
+        #expect(alloc.occupiedCount == 2)
+    }
+
+    @Test("Same content hash, different keys get separate slots")
+    func sameHashDifferentKeys() {
+        var alloc = SlotAllocator()
+        alloc.ensureCapacity(maxSlots: 10)
+
+        let r0 = alloc.allocate(key: 0, contentHash: 42)
+        let r1 = alloc.allocate(key: 1, contentHash: 42) // same hash!
+
+        guard case .miss(let s0) = r0, case .miss(let s1) = r1 else {
+            Issue.record("Both should be .miss"); return
+        }
+        #expect(s0 != s1) // different slots despite same hash
+    }
+}


### PR DESCRIPTION
## What

Replaces per-line MTLTexture creation with a single atlas texture that packs all line bitmaps into fixed-height vertical slots. One instanced draw call per frame instead of ~50 individual draw calls with per-texture binds.

## Why

Each visible line currently creates a separate MTLTexture (~50 per frame). This causes GPU memory fragmentation, 50 texture bind changes per frame, and per-line texture allocation overhead during scrolling. The atlas eliminates all of these.

Expected improvement: 100-200µs per frame during scrolling (no per-line texture allocation), 30-50µs for static frames.

## Architecture

**SlotAllocator** (pure struct, no Metal, fully testable): key-to-slot mapping, content hash caching, LRU eviction, UV coordinate computation. This is where the slot management logic lives, extracted per test-advisor recommendation so all critical logic is testable without a GPU.

**LineTextureAtlas** (thin Metal wrapper): delegates slot decisions to SlotAllocator, owns the MTLTexture, handles `texture.replace` for bitmap uploads.

**MTLBuffer** for instance data (`.storageModeShared`): replaces per-line `setVertexBytes` calls. Supports >128 instances (the `setVertexBytes` 4KB limit caps at 128 LineGPU structs).

## What Changed

All four line types route through the atlas:
- Content lines (`renderLineToAtlas`)
- Semantic lines (`renderRowToAtlas`)
- Gutter signs (diagnostic/git indicators)
- Gutter line numbers

Pass 3 in the render loop is now one instanced draw call: one pipeline bind, one texture bind, one buffer bind, one draw. The atlas grows to fit the viewport but never shrinks. Content hash cache preserved: only dirty lines are re-rasterized.

Old per-texture `renderLine`/`renderRow` methods kept for backward compatibility.

## Testing

18 new `SlotAllocator` tests (no Metal dependency, runs everywhere):
- Allocation: new key miss, cache hit, hash change miss, multiple distinct keys
- Eviction: LRU eviction when full, evicted slot reuse
- Capacity: grow never shrink, grow preserves existing, invalidateAll
- UV computation: first slot origin, Nth slot offset, width fraction, zero cases
- Edge cases: single slot capacity, boundary keys (0, UInt16.max), same hash different keys

146 total Swift tests pass. **Visual testing recommended** after merge to verify no rendering artifacts.

Closes #859.