### PR TITLE
fix: resolve 5 dialyzer errors so mix lint passes cleanly

### DIFF
--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -876,12 +876,12 @@ defmodule Minga.Editor do
   def handle_info({:minga_event, :tool_install_started, %{name: name}}, state) do
     state = %{state | status_msg: "Installing #{name}..."}
     state = maybe_refresh_tool_picker(state)
-    {:noreply, render(state)}
+    {:noreply, Renderer.render(state)}
   end
 
   def handle_info({:minga_event, :tool_install_progress, %{name: name, message: msg}}, state) do
     state = %{state | status_msg: "#{name}: #{msg}"}
-    {:noreply, render(state)}
+    {:noreply, Renderer.render(state)}
   end
 
   def handle_info({:minga_event, :tool_install_complete, %{name: name, version: version}}, state) do
@@ -890,7 +890,7 @@ defmodule Minga.Editor do
     state = maybe_refresh_tool_picker(state)
     # Clear the success message after 5 seconds
     Process.send_after(self(), :clear_tool_status, 5_000)
-    {:noreply, render(state)}
+    {:noreply, Renderer.render(state)}
   end
 
   def handle_info({:minga_event, :tool_install_failed, %{name: name, reason: reason}}, state) do
@@ -898,7 +898,7 @@ defmodule Minga.Editor do
     state = log_message(state, "Tool install failed: #{name} — #{reason_str}")
     state = %{state | status_msg: "✕ #{name} install failed: #{reason_str}"}
     state = maybe_refresh_tool_picker(state)
-    {:noreply, render(state)}
+    {:noreply, Renderer.render(state)}
   end
 
   def handle_info(:clear_tool_status, state) do
@@ -910,7 +910,7 @@ defmodule Minga.Editor do
         state
       end
 
-    {:noreply, render(state)}
+    {:noreply, Renderer.render(state)}
   end
 
   def handle_info(_msg, state) do

--- a/lib/minga/tool/manager.ex
+++ b/lib/minga/tool/manager.ex
@@ -148,7 +148,6 @@ defmodule Minga.Tool.Manager do
   end
 
   @impl true
-  @spec init(keyword()) :: {:ok, State.t()}
   def init(_opts) do
     table = :ets.new(@table, [:named_table, :set, :public, read_concurrency: true])
     dir = tools_dir()


### PR DESCRIPTION
## What

Fixes 5 dialyzer errors that caused `mix lint` to fail on every branch.

## Fixes

**editor.ex** (4 errors): 5 `handle_info` clauses for tool install events called `render(state)` which resolved to the public `render/1` API (takes `GenServer.server()`, returns `:ok`). Dialyzer correctly flagged this as "will not succeed" since `state` is `%EditorState{}`, not a server reference. Fixed to `Renderer.render(state)` matching all other `handle_info` clauses.

**tool/manager.ex** (1 error): Removed redundant `@spec init(keyword()) :: {:ok, State.t()}` that exposed opaque `MapSet` internals inside `State.t()`. The `@impl true` already delegates to GenServer's callback spec.

`mix dialyzer` now reports 0 errors. `mix lint` passes cleanly.