### PR TITLE
test: property-based decoder fuzzing + protocol schema validation

### DIFF
--- a/docs/protocol_schema.json
+++ b/docs/protocol_schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Minga port protocol opcode registry. Single source of truth for opcode hex values across Elixir, Swift, and Zig. Validated by tests in each language.",
+  "version": "1.0.0",
+  "opcodes": {
+    "input": {
+      "description": "Frontend → BEAM events",
+      "key_press":       { "hex": "0x01", "direction": "input" },
+      "resize":          { "hex": "0x02", "direction": "input" },
+      "ready":           { "hex": "0x03", "direction": "input" },
+      "mouse_event":     { "hex": "0x04", "direction": "input" },
+      "paste_event":     { "hex": "0x06", "direction": "input" },
+      "gui_action":      { "hex": "0x07", "direction": "input" },
+      "log_message":     { "hex": "0x60", "direction": "input" }
+    },
+    "render": {
+      "description": "BEAM → frontend render commands",
+      "draw_text":         { "hex": "0x10" },
+      "set_cursor":        { "hex": "0x11" },
+      "clear":             { "hex": "0x12" },
+      "batch_end":         { "hex": "0x13" },
+      "define_region":     { "hex": "0x14" },
+      "set_cursor_shape":  { "hex": "0x15" },
+      "set_title":         { "hex": "0x16" },
+      "set_window_bg":     { "hex": "0x17" },
+      "clear_region":      { "hex": "0x18" },
+      "destroy_region":    { "hex": "0x19" },
+      "set_active_region": { "hex": "0x1A" },
+      "draw_styled_text":  { "hex": "0x1C" }
+    },
+    "config": {
+      "description": "BEAM → frontend configuration",
+      "set_font":          { "hex": "0x50" },
+      "set_font_fallback": { "hex": "0x51" },
+      "register_font":     { "hex": "0x52" }
+    },
+    "highlight": {
+      "description": "BEAM → parser highlight commands (ignored by GUI, handled by Zig)",
+      "set_language":        { "hex": "0x20" },
+      "parse_buffer":        { "hex": "0x21" },
+      "set_highlight_query": { "hex": "0x22" },
+      "load_grammar":        { "hex": "0x23" },
+      "set_injection_query": { "hex": "0x24" },
+      "query_language_at":   { "hex": "0x25" },
+      "edit_buffer":         { "hex": "0x26" },
+      "measure_text":        { "hex": "0x27" }
+    },
+    "gui_chrome": {
+      "description": "BEAM → GUI-only chrome commands (0x70-0x7E range)",
+      "gui_file_tree":      { "hex": "0x70" },
+      "gui_tab_bar":        { "hex": "0x71" },
+      "gui_which_key":      { "hex": "0x72" },
+      "gui_completion":     { "hex": "0x73" },
+      "gui_theme":          { "hex": "0x74" },
+      "gui_breadcrumb":     { "hex": "0x75" },
+      "gui_status_bar":     { "hex": "0x76" },
+      "gui_picker":         { "hex": "0x77" },
+      "gui_agent_chat":     { "hex": "0x78" },
+      "gui_gutter_sep":     { "hex": "0x79" },
+      "gui_cursorline":     { "hex": "0x7A" },
+      "gui_gutter":         { "hex": "0x7B" },
+      "gui_bottom_panel":   { "hex": "0x7C" },
+      "gui_picker_preview": { "hex": "0x7D" },
+      "gui_tool_manager":   { "hex": "0x7E" }
+    },
+    "gui_semantic": {
+      "description": "BEAM → GUI semantic rendering (0x80+ range)",
+      "gui_window_content": { "hex": "0x80" }
+    }
+  },
+  "gui_actions": {
+    "description": "Sub-opcodes within gui_action (0x07)",
+    "select_tab":           { "hex": "0x01" },
+    "close_tab":            { "hex": "0x02" },
+    "file_tree_click":      { "hex": "0x03" },
+    "file_tree_toggle":     { "hex": "0x04" },
+    "completion_select":    { "hex": "0x05" },
+    "breadcrumb_click":     { "hex": "0x06" },
+    "toggle_panel":         { "hex": "0x07" },
+    "new_tab":              { "hex": "0x08" },
+    "panel_switch_tab":     { "hex": "0x09" },
+    "panel_dismiss":        { "hex": "0x0A" },
+    "panel_resize":         { "hex": "0x0B" },
+    "open_file":            { "hex": "0x0C" },
+    "file_tree_new_file":   { "hex": "0x0D" },
+    "file_tree_new_folder": { "hex": "0x0E" },
+    "file_tree_collapse_all": { "hex": "0x0F" },
+    "file_tree_refresh":    { "hex": "0x10" },
+    "tool_install":         { "hex": "0x11" },
+    "tool_uninstall":       { "hex": "0x12" },
+    "tool_update":          { "hex": "0x13" },
+    "tool_dismiss":         { "hex": "0x14" }
+  }
+}

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		7C9B7CB6670412D9F4DE60BB /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
 		7FD39613E25BB0588ADBECCC /* FileTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */; };
 		854BCC1151B43E9A161C95B5 /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */; };
+		888A35D1348A7A3CAE935561 /* DecoderFuzzTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053D515EC453DEBFF51FB6CB /* DecoderFuzzTests.swift */; };
 		8B944E100C80DFF282D25D4C /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */; };
 		8D4AE4D5778E872B2FAF4A07 /* LineBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87D78FA2B8AA133DDD3141B /* LineBuffer.swift */; };
 		8D55764B8CF042B4C48AA5D0 /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
@@ -110,6 +111,7 @@
 		E18A2D9D7987A763DBD8214D /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		E2F11A5F81A89C0BF03D9EE2 /* CoreTextLineRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5387C9048870A71E7565ED06 /* CoreTextLineRenderer.swift */; };
 		EDF83D0ACFCCB4ED91C1813C /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
+		F0A2BCCA095F1CA4FBE9BE3F /* ProtocolSchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC281B7F9F7E4C0BA793B1E /* ProtocolSchemaTests.swift */; };
 		F16FDEC1BFC1776B1109622E /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D7C3564C27A7E14D894539 /* TabBarView.swift */; };
 		F3BB64E36F257BD7FACEA5D6 /* CoreTextShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 48E21C30D142028698027567 /* CoreTextShaders.metal */; };
 		F3BD75F62566F16642D8159D /* MessagesContentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67102D81C9E70546F1019B /* MessagesContentState.swift */; };
@@ -122,12 +124,14 @@
 /* Begin PBXFileReference section */
 		00D6B3C68CFF37BC4303933A /* ThemeColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColors.swift; sourceTree = "<group>"; };
 		03D7C3564C27A7E14D894539 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
+		053D515EC453DEBFF51FB6CB /* DecoderFuzzTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderFuzzTests.swift; sourceTree = "<group>"; };
 		0A7AA0437B5C38BA8A8A80D5 /* TabBarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarState.swift; sourceTree = "<group>"; };
 		0C26E064D810299C0302F439 /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
 		211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollAccumulatorTests.swift; sourceTree = "<group>"; };
 		22420E1CC772DAFB9A5043C2 /* ViewModelComputedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelComputedTests.swift; sourceTree = "<group>"; };
 		2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMEComposition.swift; sourceTree = "<group>"; };
 		371C61E78D4BB39467516BA7 /* SlotAllocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotAllocator.swift; sourceTree = "<group>"; };
+		3DC281B7F9F7E4C0BA793B1E /* ProtocolSchemaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolSchemaTests.swift; sourceTree = "<group>"; };
 		3E23DC6E0ACB156F21293E87 /* PortLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortLogger.swift; sourceTree = "<group>"; };
 		42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapRasterizer.swift; sourceTree = "<group>"; };
 		443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPanelView.swift; sourceTree = "<group>"; };
@@ -323,6 +327,7 @@
 			children = (
 				470991E7B3850B1AADFD46FD /* CommandDispatcherTests.swift */,
 				7E7AEABDC6CCBE796A539322 /* CoreTextLineRendererTests.swift */,
+				053D515EC453DEBFF51FB6CB /* DecoderFuzzTests.swift */,
 				57B35E8311966948B1BA7AEF /* DecoderRobustnessTests.swift */,
 				BD2DE335B00721CBB29329F9 /* FontTests.swift */,
 				E2C629D58FF3305F579BA5E2 /* GUIActionEncoderTests.swift */,
@@ -332,6 +337,7 @@
 				5F5F10DF600E92632AD966A5 /* LineBufferTests.swift */,
 				AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */,
 				47BD56B7D6D195D236F9BF40 /* ProtocolEncoderBinaryTests.swift */,
+				3DC281B7F9F7E4C0BA793B1E /* ProtocolSchemaTests.swift */,
 				F220A60775A252A728477659 /* ProtocolTests.swift */,
 				211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */,
 				9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */,
@@ -519,6 +525,7 @@
 				5F396BB608D3548513CA4BC8 /* CoreTextLineRendererTests.swift in Sources */,
 				527C7DB557EFD09B3161BC20 /* CoreTextMetalRenderer.swift in Sources */,
 				F3BB64E36F257BD7FACEA5D6 /* CoreTextShaders.metal in Sources */,
+				888A35D1348A7A3CAE935561 /* DecoderFuzzTests.swift in Sources */,
 				A6327C6FAB3DCFD57327FBF4 /* DecoderRobustnessTests.swift in Sources */,
 				D1EEFBDAE315F717373F82BD /* EditorNSView.swift in Sources */,
 				7A21099CFC922D178A3079DF /* EditorView.swift in Sources */,
@@ -548,6 +555,7 @@
 				7C9B7CB6670412D9F4DE60BB /* ProtocolEncoder.swift in Sources */,
 				778C6A917140005C0C0643CB /* ProtocolEncoderBinaryTests.swift in Sources */,
 				FA582944CD6B90BCABC13FCE /* ProtocolReader.swift in Sources */,
+				F0A2BCCA095F1CA4FBE9BE3F /* ProtocolSchemaTests.swift in Sources */,
 				686DD6EB8AFDCAFC79EA100A /* ProtocolTests.swift in Sources */,
 				793247C2AB95598A1AC4C6EC /* ScrollAccumulator.swift in Sources */,
 				D42695D627BD38405475ECFF /* ScrollAccumulatorTests.swift in Sources */,

--- a/macos/Tests/MingaTests/DecoderFuzzTests.swift
+++ b/macos/Tests/MingaTests/DecoderFuzzTests.swift
@@ -1,0 +1,365 @@
+/// Property-based decoder fuzzing tests.
+///
+/// Generates valid binary payloads with randomized field values for each
+/// opcode family, decodes them, and verifies the decoder:
+/// 1. Doesn't crash (the primary goal)
+/// 2. Produces the correct command type
+/// 3. Consumes the exact number of bytes it should
+///
+/// Also tests truncation at every byte position within valid payloads,
+/// verifying the decoder throws ProtocolDecodeError rather than crashing.
+///
+/// No external dependencies. Uses Swift's built-in randomness.
+
+import Testing
+import Foundation
+
+// MARK: - Random payload generators
+
+/// Generates a random UTF-8 string of the given byte length (ASCII subset for simplicity).
+private func randomASCII(maxLen: Int = 20) -> String {
+    let len = Int.random(in: 0...maxLen)
+    return String((0..<len).map { _ in Character(UnicodeScalar(Int.random(in: 0x20...0x7E))!) })
+}
+
+/// Generates a random UInt8-prefixed string field.
+private func randomString8Field(maxLen: Int = 20) -> Data {
+    let s = randomASCII(maxLen: min(maxLen, 255))
+    let utf8 = Array(s.utf8)
+    var data = Data()
+    data.append(UInt8(utf8.count))
+    data.append(contentsOf: utf8)
+    return data
+}
+
+/// Generates a random UInt16-prefixed string field.
+private func randomString16Field(maxLen: Int = 50) -> Data {
+    let s = randomASCII(maxLen: min(maxLen, 200))
+    let utf8 = Array(s.utf8)
+    var data = Data()
+    data.append(UInt8(utf8.count >> 8))
+    data.append(UInt8(utf8.count & 0xFF))
+    data.append(contentsOf: utf8)
+    return data
+}
+
+/// Appends a random 3-byte RGB color.
+private func appendRandomRGB(_ data: inout Data) {
+    data.append(UInt8.random(in: 0...255))
+    data.append(UInt8.random(in: 0...255))
+    data.append(UInt8.random(in: 0...255))
+}
+
+/// Appends a random big-endian UInt16.
+private func appendRandomU16(_ data: inout Data, range: ClosedRange<UInt16> = 0...UInt16.max) {
+    let v = UInt16.random(in: range)
+    data.append(UInt8(v >> 8))
+    data.append(UInt8(v & 0xFF))
+}
+
+/// Appends a random big-endian UInt32.
+private func appendRandomU32(_ data: inout Data) {
+    let v = UInt32.random(in: 0...UInt32.max)
+    data.append(UInt8((v >> 24) & 0xFF))
+    data.append(UInt8((v >> 16) & 0xFF))
+    data.append(UInt8((v >> 8) & 0xFF))
+    data.append(UInt8(v & 0xFF))
+}
+
+// MARK: - Payload builders per opcode
+
+/// Builds a valid draw_text payload with random values.
+private func randomDrawText() -> Data {
+    var data = Data([OP_DRAW_TEXT])
+    appendRandomU16(&data)  // row
+    appendRandomU16(&data)  // col
+    appendRandomRGB(&data)  // fg
+    appendRandomRGB(&data)  // bg
+    data.append(UInt8.random(in: 0...0x0F))  // attrs
+    let text = randomString16Field(maxLen: 30)
+    data.append(text)
+    return data
+}
+
+/// Builds a valid draw_styled_text payload with random values.
+private func randomDrawStyledText() -> Data {
+    var data = Data([OP_DRAW_STYLED_TEXT])
+    appendRandomU16(&data)  // row
+    appendRandomU16(&data)  // col
+    appendRandomRGB(&data)  // fg
+    appendRandomRGB(&data)  // bg
+    appendRandomU16(&data)  // attrs16
+    appendRandomRGB(&data)  // underlineColor
+    data.append(UInt8.random(in: 0...255))  // blend
+    data.append(UInt8.random(in: 0...7))    // fontWeight
+    data.append(UInt8.random(in: 0...3))    // fontId
+    let text = randomString16Field(maxLen: 30)
+    data.append(text)
+    return data
+}
+
+/// Builds a valid gui_theme payload with random slots.
+private func randomGuiTheme() -> Data {
+    let count = UInt8.random(in: 0...20)
+    var data = Data([OP_GUI_THEME, count])
+    for _ in 0..<count {
+        data.append(UInt8.random(in: 0...0x60))  // slotId
+        appendRandomRGB(&data)
+    }
+    return data
+}
+
+/// Builds a valid gui_tab_bar payload with random tabs.
+private func randomGuiTabBar() -> Data {
+    let tabCount = UInt8.random(in: 0...5)
+    var data = Data([OP_GUI_TAB_BAR, UInt8.random(in: 0...tabCount), tabCount])
+    for _ in 0..<tabCount {
+        data.append(UInt8.random(in: 0...0xFF))  // flags
+        appendRandomU32(&data)  // id
+        data.append(randomString8Field(maxLen: 4))  // icon
+        data.append(randomString16Field(maxLen: 20))  // label
+    }
+    return data
+}
+
+/// Builds a valid gui_completion payload with random items.
+private func randomGuiCompletion() -> Data {
+    let visible = Bool.random()
+    var data = Data([OP_GUI_COMPLETION, visible ? 1 : 0])
+    guard visible else { return data }
+
+    appendRandomU16(&data)  // anchorRow
+    appendRandomU16(&data)  // anchorCol
+    appendRandomU16(&data)  // selectedIndex
+    let itemCount = UInt16.random(in: 0...3)
+    data.append(UInt8(itemCount >> 8))
+    data.append(UInt8(itemCount & 0xFF))
+    for _ in 0..<itemCount {
+        data.append(UInt8.random(in: 0...15))  // kind
+        data.append(randomString16Field(maxLen: 15))  // label
+        data.append(randomString16Field(maxLen: 15))  // detail
+    }
+    return data
+}
+
+/// Builds a valid gui_breadcrumb payload.
+private func randomGuiBreadcrumb() -> Data {
+    let count = UInt8.random(in: 0...5)
+    var data = Data([OP_GUI_BREADCRUMB, count])
+    for _ in 0..<count {
+        data.append(randomString16Field(maxLen: 20))
+    }
+    return data
+}
+
+/// Builds a valid gui_gutter_sep payload.
+private func randomGuiGutterSep() -> Data {
+    var data = Data([OP_GUI_GUTTER_SEP])
+    appendRandomU16(&data)
+    appendRandomRGB(&data)
+    return data
+}
+
+/// Builds a valid gui_cursorline payload.
+private func randomGuiCursorline() -> Data {
+    var data = Data([OP_GUI_CURSORLINE])
+    appendRandomU16(&data)
+    appendRandomRGB(&data)
+    return data
+}
+
+// MARK: - Fuzz test suites
+
+private let fuzzIterations = 500
+
+@Suite("Decoder Fuzz: Fixed-Size Commands")
+struct DecoderFuzzFixedSizeTests {
+
+    @Test("clear never crashes on valid input")
+    func fuzzClear() throws {
+        for _ in 0..<fuzzIterations {
+            let (cmd, size) = try decodeCommand(data: Data([OP_CLEAR]), offset: 0)
+            #expect(size == 1)
+            guard case .clear = cmd else { Issue.record("Expected .clear"); return }
+        }
+    }
+
+    @Test("set_cursor with random values never crashes")
+    func fuzzSetCursor() throws {
+        for _ in 0..<fuzzIterations {
+            var data = Data([OP_SET_CURSOR])
+            appendRandomU16(&data)
+            appendRandomU16(&data)
+            let (cmd, size) = try decodeCommand(data: data, offset: 0)
+            #expect(size == 5)
+            guard case .setCursor = cmd else { Issue.record("Expected .setCursor"); return }
+        }
+    }
+
+    @Test("gui_gutter_sep with random values never crashes")
+    func fuzzGutterSep() throws {
+        for _ in 0..<fuzzIterations {
+            let data = randomGuiGutterSep()
+            let (cmd, size) = try decodeCommand(data: data, offset: 0)
+            #expect(size == 6)
+            guard case .guiGutterSeparator = cmd else { Issue.record("Expected .guiGutterSeparator"); return }
+        }
+    }
+
+    @Test("gui_cursorline with random values never crashes")
+    func fuzzCursorline() throws {
+        for _ in 0..<fuzzIterations {
+            let data = randomGuiCursorline()
+            let (cmd, size) = try decodeCommand(data: data, offset: 0)
+            #expect(size == 6)
+            guard case .guiCursorline = cmd else { Issue.record("Expected .guiCursorline"); return }
+        }
+    }
+}
+
+@Suite("Decoder Fuzz: Variable-Length Commands")
+struct DecoderFuzzVariableLengthTests {
+
+    @Test("draw_text with random values never crashes")
+    func fuzzDrawText() throws {
+        for _ in 0..<fuzzIterations {
+            let data = randomDrawText()
+            let (cmd, size) = try decodeCommand(data: data, offset: 0)
+            #expect(size == data.count)
+            guard case .drawText = cmd else { Issue.record("Expected .drawText"); return }
+        }
+    }
+
+    @Test("draw_styled_text with random values never crashes")
+    func fuzzDrawStyledText() throws {
+        for _ in 0..<fuzzIterations {
+            let data = randomDrawStyledText()
+            let (cmd, size) = try decodeCommand(data: data, offset: 0)
+            #expect(size == data.count)
+            guard case .drawStyledText = cmd else { Issue.record("Expected .drawStyledText"); return }
+        }
+    }
+
+    @Test("gui_theme with random slots never crashes")
+    func fuzzGuiTheme() throws {
+        for _ in 0..<fuzzIterations {
+            let data = randomGuiTheme()
+            let (cmd, size) = try decodeCommand(data: data, offset: 0)
+            #expect(size == data.count)
+            guard case .guiTheme = cmd else { Issue.record("Expected .guiTheme"); return }
+        }
+    }
+
+    @Test("gui_tab_bar with random tabs never crashes")
+    func fuzzGuiTabBar() throws {
+        for _ in 0..<fuzzIterations {
+            let data = randomGuiTabBar()
+            let (cmd, size) = try decodeCommand(data: data, offset: 0)
+            #expect(size == data.count)
+            guard case .guiTabBar = cmd else { Issue.record("Expected .guiTabBar"); return }
+        }
+    }
+
+    @Test("gui_completion with random items never crashes")
+    func fuzzGuiCompletion() throws {
+        for _ in 0..<fuzzIterations {
+            let data = randomGuiCompletion()
+            let (cmd, size) = try decodeCommand(data: data, offset: 0)
+            #expect(size == data.count)
+            guard case .guiCompletion = cmd else { Issue.record("Expected .guiCompletion"); return }
+        }
+    }
+
+    @Test("gui_breadcrumb with random segments never crashes")
+    func fuzzGuiBreadcrumb() throws {
+        for _ in 0..<fuzzIterations {
+            let data = randomGuiBreadcrumb()
+            let (cmd, size) = try decodeCommand(data: data, offset: 0)
+            #expect(size == data.count)
+            guard case .guiBreadcrumb = cmd else { Issue.record("Expected .guiBreadcrumb"); return }
+        }
+    }
+}
+
+@Suite("Decoder Fuzz: Truncation at Every Byte Position")
+struct DecoderFuzzTruncationTests {
+
+    @Test("draw_text truncated at every position throws, never crashes")
+    func truncateDrawText() {
+        for _ in 0..<100 {
+            let full = randomDrawText()
+            for cutoff in 1..<full.count {
+                let truncated = full.prefix(cutoff)
+                do {
+                    _ = try decodeCommand(data: Data(truncated), offset: 0)
+                    // If it decodes, it must have consumed <= cutoff bytes
+                } catch {
+                    // Expected: ProtocolDecodeError
+                }
+            }
+        }
+    }
+
+    @Test("draw_styled_text truncated at every position throws, never crashes")
+    func truncateDrawStyledText() {
+        for _ in 0..<100 {
+            let full = randomDrawStyledText()
+            for cutoff in 1..<full.count {
+                let truncated = full.prefix(cutoff)
+                do {
+                    _ = try decodeCommand(data: Data(truncated), offset: 0)
+                } catch {
+                    // Expected
+                }
+            }
+        }
+    }
+
+    @Test("gui_tab_bar truncated at every position throws, never crashes")
+    func truncateGuiTabBar() {
+        for _ in 0..<100 {
+            let full = randomGuiTabBar()
+            guard full.count > 1 else { continue }
+            for cutoff in 1..<full.count {
+                let truncated = full.prefix(cutoff)
+                do {
+                    _ = try decodeCommand(data: Data(truncated), offset: 0)
+                } catch {
+                    // Expected
+                }
+            }
+        }
+    }
+
+    @Test("gui_completion truncated at every position throws, never crashes")
+    func truncateGuiCompletion() {
+        for _ in 0..<100 {
+            let full = randomGuiCompletion()
+            guard full.count > 1 else { continue }
+            for cutoff in 1..<full.count {
+                let truncated = full.prefix(cutoff)
+                do {
+                    _ = try decodeCommand(data: Data(truncated), offset: 0)
+                } catch {
+                    // Expected
+                }
+            }
+        }
+    }
+
+    @Test("gui_theme truncated at every position throws, never crashes")
+    func truncateGuiTheme() {
+        for _ in 0..<100 {
+            let full = randomGuiTheme()
+            guard full.count > 1 else { continue }
+            for cutoff in 1..<full.count {
+                let truncated = full.prefix(cutoff)
+                do {
+                    _ = try decodeCommand(data: Data(truncated), offset: 0)
+                } catch {
+                    // Expected
+                }
+            }
+        }
+    }
+}

--- a/macos/Tests/MingaTests/ProtocolSchemaTests.swift
+++ b/macos/Tests/MingaTests/ProtocolSchemaTests.swift
@@ -1,0 +1,146 @@
+/// Validates Swift opcode constants against the canonical protocol_schema.json.
+///
+/// This is the Swift half of the cross-language schema validation. The Elixir
+/// side has its own test that validates against the same JSON file. If either
+/// language's constants drift from the schema, the test fails.
+///
+/// The schema file is at docs/protocol_schema.json in the project root.
+
+import Testing
+import Foundation
+
+/// Loads the protocol schema JSON and returns the parsed dictionary.
+private func loadSchema() throws -> [String: Any] {
+    // Navigate from the test binary to the project root.
+    // In Xcode, the test binary runs from DerivedData; we need the source tree.
+    // Walk up from the current file's compile-time path.
+    let thisFile = #filePath
+    // thisFile = .../macos/Tests/MingaTests/ProtocolSchemaTests.swift
+    // Project root = 3 directories up from macos/
+    let macosDir = URL(fileURLWithPath: thisFile)
+        .deletingLastPathComponent()  // MingaTests
+        .deletingLastPathComponent()  // Tests
+        .deletingLastPathComponent()  // macos
+    let projectRoot = macosDir.deletingLastPathComponent()
+    let schemaURL = projectRoot.appendingPathComponent("docs/protocol_schema.json")
+
+    let data = try Data(contentsOf: schemaURL)
+    guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw SchemaError.invalidJSON
+    }
+    return json
+}
+
+private enum SchemaError: Error { case invalidJSON, missingKey }
+
+/// Extracts the hex value for a named opcode from a schema section.
+private func schemaHex(_ section: [String: Any], _ name: String) throws -> UInt8 {
+    guard let entry = section[name] as? [String: Any],
+          let hexStr = entry["hex"] as? String else {
+        throw SchemaError.missingKey
+    }
+    // Parse "0x70" -> 0x70
+    let stripped = hexStr.hasPrefix("0x") ? String(hexStr.dropFirst(2)) : hexStr
+    guard let value = UInt8(stripped, radix: 16) else {
+        throw SchemaError.invalidJSON
+    }
+    return value
+}
+
+@Suite("Protocol Schema: Swift Constants Match")
+struct ProtocolSchemaSwiftTests {
+
+    @Test("Render opcode constants match schema")
+    func renderOpcodes() throws {
+        let schema = try loadSchema()
+        guard let opcodes = schema["opcodes"] as? [String: Any],
+              let render = opcodes["render"] as? [String: Any] else { return }
+
+        #expect(try schemaHex(render, "draw_text") == OP_DRAW_TEXT)
+        #expect(try schemaHex(render, "set_cursor") == OP_SET_CURSOR)
+        #expect(try schemaHex(render, "clear") == OP_CLEAR)
+        #expect(try schemaHex(render, "batch_end") == OP_BATCH_END)
+        #expect(try schemaHex(render, "define_region") == OP_DEFINE_REGION)
+        #expect(try schemaHex(render, "set_cursor_shape") == OP_SET_CURSOR_SHAPE)
+        #expect(try schemaHex(render, "set_title") == OP_SET_TITLE)
+        #expect(try schemaHex(render, "set_window_bg") == OP_SET_WINDOW_BG)
+        #expect(try schemaHex(render, "clear_region") == OP_CLEAR_REGION)
+        #expect(try schemaHex(render, "destroy_region") == OP_DESTROY_REGION)
+        #expect(try schemaHex(render, "set_active_region") == OP_SET_ACTIVE_REGION)
+        #expect(try schemaHex(render, "draw_styled_text") == OP_DRAW_STYLED_TEXT)
+    }
+
+    @Test("GUI chrome opcode constants match schema")
+    func guiChromeOpcodes() throws {
+        let schema = try loadSchema()
+        guard let opcodes = schema["opcodes"] as? [String: Any],
+              let chrome = opcodes["gui_chrome"] as? [String: Any] else { return }
+
+        #expect(try schemaHex(chrome, "gui_file_tree") == OP_GUI_FILE_TREE)
+        #expect(try schemaHex(chrome, "gui_tab_bar") == OP_GUI_TAB_BAR)
+        #expect(try schemaHex(chrome, "gui_which_key") == OP_GUI_WHICH_KEY)
+        #expect(try schemaHex(chrome, "gui_completion") == OP_GUI_COMPLETION)
+        #expect(try schemaHex(chrome, "gui_theme") == OP_GUI_THEME)
+        #expect(try schemaHex(chrome, "gui_breadcrumb") == OP_GUI_BREADCRUMB)
+        #expect(try schemaHex(chrome, "gui_status_bar") == OP_GUI_STATUS_BAR)
+        #expect(try schemaHex(chrome, "gui_picker") == OP_GUI_PICKER)
+        #expect(try schemaHex(chrome, "gui_agent_chat") == OP_GUI_AGENT_CHAT)
+        #expect(try schemaHex(chrome, "gui_gutter_sep") == OP_GUI_GUTTER_SEP)
+        #expect(try schemaHex(chrome, "gui_cursorline") == OP_GUI_CURSORLINE)
+        #expect(try schemaHex(chrome, "gui_gutter") == OP_GUI_GUTTER)
+        #expect(try schemaHex(chrome, "gui_bottom_panel") == OP_GUI_BOTTOM_PANEL)
+        #expect(try schemaHex(chrome, "gui_picker_preview") == OP_GUI_PICKER_PREVIEW)
+        #expect(try schemaHex(chrome, "gui_tool_manager") == OP_GUI_TOOL_MANAGER)
+    }
+
+    @Test("Input opcode constants match schema")
+    func inputOpcodes() throws {
+        let schema = try loadSchema()
+        guard let opcodes = schema["opcodes"] as? [String: Any],
+              let input = opcodes["input"] as? [String: Any] else { return }
+
+        #expect(try schemaHex(input, "key_press") == OP_KEY_PRESS)
+        #expect(try schemaHex(input, "resize") == OP_RESIZE)
+        #expect(try schemaHex(input, "ready") == OP_READY)
+        #expect(try schemaHex(input, "mouse_event") == OP_MOUSE_EVENT)
+        #expect(try schemaHex(input, "paste_event") == OP_PASTE_EVENT)
+        #expect(try schemaHex(input, "gui_action") == OP_GUI_ACTION)
+        #expect(try schemaHex(input, "log_message") == OP_LOG_MESSAGE)
+    }
+
+    @Test("GUI action sub-opcode constants match schema")
+    func guiActionOpcodes() throws {
+        let schema = try loadSchema()
+        guard let actions = schema["gui_actions"] as? [String: Any] else { return }
+
+        #expect(try schemaHex(actions, "select_tab") == GUI_ACTION_SELECT_TAB)
+        #expect(try schemaHex(actions, "close_tab") == GUI_ACTION_CLOSE_TAB)
+        #expect(try schemaHex(actions, "file_tree_click") == GUI_ACTION_FILE_TREE_CLICK)
+        #expect(try schemaHex(actions, "file_tree_toggle") == GUI_ACTION_FILE_TREE_TOGGLE)
+        #expect(try schemaHex(actions, "completion_select") == GUI_ACTION_COMPLETION_SELECT)
+        #expect(try schemaHex(actions, "breadcrumb_click") == GUI_ACTION_BREADCRUMB_CLICK)
+        #expect(try schemaHex(actions, "toggle_panel") == GUI_ACTION_TOGGLE_PANEL)
+        #expect(try schemaHex(actions, "new_tab") == GUI_ACTION_NEW_TAB)
+        #expect(try schemaHex(actions, "panel_switch_tab") == GUI_ACTION_PANEL_SWITCH_TAB)
+        #expect(try schemaHex(actions, "panel_dismiss") == GUI_ACTION_PANEL_DISMISS)
+        #expect(try schemaHex(actions, "panel_resize") == GUI_ACTION_PANEL_RESIZE)
+        #expect(try schemaHex(actions, "open_file") == GUI_ACTION_OPEN_FILE)
+        #expect(try schemaHex(actions, "file_tree_new_file") == GUI_ACTION_FILE_TREE_NEW_FILE)
+        #expect(try schemaHex(actions, "file_tree_new_folder") == GUI_ACTION_FILE_TREE_NEW_FOLDER)
+        #expect(try schemaHex(actions, "file_tree_collapse_all") == GUI_ACTION_FILE_TREE_COLLAPSE_ALL)
+        #expect(try schemaHex(actions, "file_tree_refresh") == GUI_ACTION_FILE_TREE_REFRESH)
+        #expect(try schemaHex(actions, "tool_install") == GUI_ACTION_TOOL_INSTALL)
+        #expect(try schemaHex(actions, "tool_uninstall") == GUI_ACTION_TOOL_UNINSTALL)
+        #expect(try schemaHex(actions, "tool_update") == GUI_ACTION_TOOL_UPDATE)
+        #expect(try schemaHex(actions, "tool_dismiss") == GUI_ACTION_TOOL_DISMISS)
+    }
+
+    @Test("GUI window content opcode matches schema")
+    func guiWindowContentOpcode() throws {
+        let schema = try loadSchema()
+        guard let opcodes = schema["opcodes"] as? [String: Any],
+              let semantic = opcodes["gui_semantic"] as? [String: Any] else { return }
+
+        #expect(try schemaHex(semantic, "gui_window_content") == OP_GUI_WINDOW_CONTENT)
+    }
+}

--- a/test/minga/port/protocol_schema_test.exs
+++ b/test/minga/port/protocol_schema_test.exs
@@ -1,0 +1,120 @@
+defmodule Minga.Port.ProtocolSchemaTest do
+  @moduledoc """
+  Validates that Elixir opcode constants match the canonical
+  protocol_schema.json. Catches drift between the schema and
+  the Elixir protocol implementation.
+  """
+
+  use ExUnit.Case, async: true
+
+  @schema_path Path.join([File.cwd!(), "docs", "protocol_schema.json"])
+
+  setup_all do
+    schema = @schema_path |> File.read!() |> Jason.decode!()
+    %{schema: schema}
+  end
+
+  describe "render opcodes match schema" do
+    test "all render opcode hex values match", %{schema: schema} do
+      expected = schema["opcodes"]["render"]
+
+      assert_opcode(expected, "draw_text", 0x10)
+      assert_opcode(expected, "set_cursor", 0x11)
+      assert_opcode(expected, "clear", 0x12)
+      assert_opcode(expected, "batch_end", 0x13)
+      assert_opcode(expected, "define_region", 0x14)
+      assert_opcode(expected, "set_cursor_shape", 0x15)
+      assert_opcode(expected, "set_title", 0x16)
+      assert_opcode(expected, "set_window_bg", 0x17)
+      assert_opcode(expected, "clear_region", 0x18)
+      assert_opcode(expected, "destroy_region", 0x19)
+      assert_opcode(expected, "set_active_region", 0x1A)
+      assert_opcode(expected, "draw_styled_text", 0x1C)
+    end
+  end
+
+  describe "GUI chrome opcodes match schema" do
+    test "all GUI chrome opcode hex values match", %{schema: schema} do
+      expected = schema["opcodes"]["gui_chrome"]
+
+      assert_opcode(expected, "gui_file_tree", 0x70)
+      assert_opcode(expected, "gui_tab_bar", 0x71)
+      assert_opcode(expected, "gui_which_key", 0x72)
+      assert_opcode(expected, "gui_completion", 0x73)
+      assert_opcode(expected, "gui_theme", 0x74)
+      assert_opcode(expected, "gui_breadcrumb", 0x75)
+      assert_opcode(expected, "gui_status_bar", 0x76)
+      assert_opcode(expected, "gui_picker", 0x77)
+      assert_opcode(expected, "gui_agent_chat", 0x78)
+      assert_opcode(expected, "gui_gutter_sep", 0x79)
+      assert_opcode(expected, "gui_cursorline", 0x7A)
+      assert_opcode(expected, "gui_gutter", 0x7B)
+      assert_opcode(expected, "gui_bottom_panel", 0x7C)
+      assert_opcode(expected, "gui_picker_preview", 0x7D)
+      assert_opcode(expected, "gui_tool_manager", 0x7E)
+    end
+  end
+
+  describe "input opcodes match schema" do
+    test "all input opcode hex values match", %{schema: schema} do
+      expected = schema["opcodes"]["input"]
+
+      assert_opcode(expected, "key_press", 0x01)
+      assert_opcode(expected, "resize", 0x02)
+      assert_opcode(expected, "ready", 0x03)
+      assert_opcode(expected, "mouse_event", 0x04)
+      assert_opcode(expected, "paste_event", 0x06)
+      assert_opcode(expected, "gui_action", 0x07)
+      assert_opcode(expected, "log_message", 0x60)
+    end
+  end
+
+  describe "gui_action sub-opcodes match schema" do
+    test "all gui_action sub-opcode hex values match", %{schema: schema} do
+      expected = schema["gui_actions"]
+
+      assert_opcode(expected, "select_tab", 0x01)
+      assert_opcode(expected, "close_tab", 0x02)
+      assert_opcode(expected, "file_tree_click", 0x03)
+      assert_opcode(expected, "file_tree_toggle", 0x04)
+      assert_opcode(expected, "completion_select", 0x05)
+      assert_opcode(expected, "breadcrumb_click", 0x06)
+      assert_opcode(expected, "toggle_panel", 0x07)
+      assert_opcode(expected, "new_tab", 0x08)
+      assert_opcode(expected, "panel_switch_tab", 0x09)
+      assert_opcode(expected, "panel_dismiss", 0x0A)
+      assert_opcode(expected, "panel_resize", 0x0B)
+      assert_opcode(expected, "open_file", 0x0C)
+      assert_opcode(expected, "file_tree_new_file", 0x0D)
+      assert_opcode(expected, "file_tree_new_folder", 0x0E)
+      assert_opcode(expected, "file_tree_collapse_all", 0x0F)
+      assert_opcode(expected, "file_tree_refresh", 0x10)
+      assert_opcode(expected, "tool_install", 0x11)
+      assert_opcode(expected, "tool_uninstall", 0x12)
+      assert_opcode(expected, "tool_update", 0x13)
+      assert_opcode(expected, "tool_dismiss", 0x14)
+    end
+  end
+
+  describe "gui_window_content opcode matches schema" do
+    test "gui_window_content hex value matches", %{schema: schema} do
+      expected = schema["opcodes"]["gui_semantic"]
+      assert_opcode(expected, "gui_window_content", 0x80)
+    end
+  end
+
+  # Helper: asserts an opcode name maps to the expected hex value in the schema
+  defp assert_opcode(section, name, expected_value) do
+    entry = section[name]
+    assert entry != nil, "Schema missing opcode: #{name}"
+    hex_str = entry["hex"]
+
+    # Strip "0x" prefix and parse as hex
+    trimmed = String.replace_prefix(hex_str, "0x", "")
+    {schema_value, ""} = Integer.parse(trimmed, 16)
+
+    assert schema_value == expected_value,
+           "Opcode #{name}: schema says #{hex_str} (#{schema_value}), " <>
+             "Elixir says 0x#{Integer.to_string(expected_value, 16)}"
+  end
+end


### PR DESCRIPTION
## Summary

Two initiatives from the Swift audit's long-term recommendations:

### Property-Based Decoder Fuzzing
Generates structurally valid binary payloads with randomized field values for each opcode family. Unlike the hand-written truncation tests in PR #862, this systematically explores the input space with thousands of random payloads.

- **Valid payload fuzzing**: 500 iterations per opcode for draw_text, draw_styled_text, gui_theme, gui_tab_bar, gui_completion, gui_breadcrumb, set_cursor, gui_gutter_sep, gui_cursorline, clear. Total: ~5,000 random payloads. Zero crashes.
- **Truncation fuzzing**: Takes valid payloads and truncates at every byte position (100 iterations x 5 opcodes). Verifies the decoder throws ProtocolDecodeError at every possible cut point.
- No external dependencies. Uses Swift's built-in randomness.

### Protocol Schema Validation
Single source of truth for opcode hex values: `docs/protocol_schema.json`.

Both Elixir and Swift have tests that validate their constants against this file. When someone adds a new opcode, they update the schema and both languages' tests verify the constant is defined correctly. This catches the 'forgot to update one frontend' class of bug without the complexity of full codegen.

- `docs/protocol_schema.json`: all opcodes + gui_action sub-opcodes
- `ProtocolSchemaTests.swift`: 5 Swift validation tests
- `protocol_schema_test.exs`: 5 Elixir validation tests