### PR TITLE
feat(lsp): document highlight - highlight symbol occurrences (#867)

### DIFF
--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -681,119 +681,25 @@ defmodule Minga.Editor do
   # LSP async response — route to the appropriate handler based on lsp.pending
   def handle_info({:lsp_response, ref, result}, state) do
     case Map.pop(state.lsp_pending, ref) do
-      {:definition, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_definition_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:hover, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_hover_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
       {:completion_resolve, pending} ->
         new_state = put_in(state.lsp_pending, pending)
         new_state = CompletionHandling.handle_resolve_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
+        {:noreply, Renderer.render(new_state)}
 
       {:signature_help, pending} ->
         new_state = put_in(state.lsp_pending, pending)
         new_state = CompletionHandling.handle_signature_help_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
+        {:noreply, Renderer.render(new_state)}
 
       {{:semantic_tokens, buf_pid}, pending} ->
         new_state = put_in(state.lsp_pending, pending)
         new_state = SemanticTokenSync.handle_response(new_state, buf_pid, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
+        {:noreply, Renderer.render(new_state)}
 
-      {:references, pending} ->
+      {kind, pending} when is_atom(kind) ->
         new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_references_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:document_highlight, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_document_highlight_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:code_action, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_code_action_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:prepare_rename, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_prepare_rename_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:rename, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_rename_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:type_definition, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_type_definition_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:implementation, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_implementation_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:document_symbol, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_document_symbol_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:workspace_symbol, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_workspace_symbol_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:selection_range, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_selection_range_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:prepare_call_hierarchy, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_prepare_call_hierarchy_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:incoming_calls, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_incoming_calls_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:code_lens, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_code_lens_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
-
-      {:inlay_hint, pending} ->
-        new_state = put_in(state.lsp_pending, pending)
-        new_state = LspActions.handle_inlay_hint_response(new_state, result)
-        new_state = Renderer.render(new_state)
-        {:noreply, new_state}
+        new_state = dispatch_lsp_response(kind, new_state, result)
+        {:noreply, Renderer.render(new_state)}
 
       {nil, _} ->
         # Not a tracked request — try completion handler
@@ -1006,6 +912,63 @@ defmodule Minga.Editor do
 
   def handle_info(_msg, state) do
     {:noreply, state}
+  end
+
+  # ── LSP response dispatch ──────────────────────────────────────────────────
+
+  # Dispatches an LSP response to the appropriate handler based on the kind atom.
+  @spec dispatch_lsp_response(atom(), EditorState.t(), term()) :: EditorState.t()
+  defp dispatch_lsp_response(:definition, state, result),
+    do: LspActions.handle_definition_response(state, result)
+
+  defp dispatch_lsp_response(:hover, state, result),
+    do: LspActions.handle_hover_response(state, result)
+
+  defp dispatch_lsp_response(:references, state, result),
+    do: LspActions.handle_references_response(state, result)
+
+  defp dispatch_lsp_response(:document_highlight, state, result),
+    do: LspActions.handle_document_highlight_response(state, result)
+
+  defp dispatch_lsp_response(:code_action, state, result),
+    do: LspActions.handle_code_action_response(state, result)
+
+  defp dispatch_lsp_response(:prepare_rename, state, result),
+    do: LspActions.handle_prepare_rename_response(state, result)
+
+  defp dispatch_lsp_response(:rename, state, result),
+    do: LspActions.handle_rename_response(state, result)
+
+  defp dispatch_lsp_response(:type_definition, state, result),
+    do: LspActions.handle_type_definition_response(state, result)
+
+  defp dispatch_lsp_response(:implementation, state, result),
+    do: LspActions.handle_implementation_response(state, result)
+
+  defp dispatch_lsp_response(:document_symbol, state, result),
+    do: LspActions.handle_document_symbol_response(state, result)
+
+  defp dispatch_lsp_response(:workspace_symbol, state, result),
+    do: LspActions.handle_workspace_symbol_response(state, result)
+
+  defp dispatch_lsp_response(:selection_range, state, result),
+    do: LspActions.handle_selection_range_response(state, result)
+
+  defp dispatch_lsp_response(:prepare_call_hierarchy, state, result),
+    do: LspActions.handle_prepare_call_hierarchy_response(state, result)
+
+  defp dispatch_lsp_response(:incoming_calls, state, result),
+    do: LspActions.handle_incoming_calls_response(state, result)
+
+  defp dispatch_lsp_response(:code_lens, state, result),
+    do: LspActions.handle_code_lens_response(state, result)
+
+  defp dispatch_lsp_response(:inlay_hint, state, result),
+    do: LspActions.handle_inlay_hint_response(state, result)
+
+  defp dispatch_lsp_response(kind, state, _result) do
+    Minga.Log.debug(:lsp, "Unhandled LSP response kind: #{inspect(kind)}")
+    state
   end
 
   # ── Agent event dispatch ──────────────────────────────────────────────────

--- a/lib/minga/editor/commands.ex
+++ b/lib/minga/editor/commands.ex
@@ -34,12 +34,12 @@ defmodule Minga.Editor.Commands do
   alias Minga.Editor.Commands.Extensions, as: ExtCommands
   alias Minga.Editor.Commands.Help
   alias Minga.Editor.Commands.Lsp, as: LspCommands
-  alias Minga.Editor.LspActions
   alias Minga.Editor.Commands.Marks
   alias Minga.Editor.Commands.Movement
   alias Minga.Editor.Commands.Operators
   alias Minga.Editor.Commands.Tool
   alias Minga.Editor.Commands.Visual
+  alias Minga.Editor.LspActions
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.Window
   alias Minga.Keymap.Active, as: KeymapActive

--- a/lib/minga/editor/lsp_actions.ex
+++ b/lib/minga/editor/lsp_actions.ex
@@ -29,9 +29,14 @@ defmodule Minga.Editor.LspActions do
   alias Minga.Editor.HoverPopup
   alias Minga.Editor.PickerUI
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.VimState
+  alias Minga.Log
   alias Minga.LSP.Client
+  alias Minga.LSP.DocumentHighlight
   alias Minga.LSP.SyncServer
   alias Minga.LSP.WorkspaceEdit
+  alias Minga.Mode.CommandState
+  alias Minga.Mode.VisualState
   alias Minga.Picker.LocationSource
 
   @type state :: EditorState.t()
@@ -121,8 +126,17 @@ defmodule Minga.Editor.LspActions do
 
   def document_highlight(%{buffers: %{active: buf}} = state) do
     case lsp_client_for(state, buf) do
-      nil -> state
-      client -> send_lsp_request(state, client, buf, "textDocument/documentHighlight", :document_highlight)
+      nil ->
+        state
+
+      client ->
+        send_lsp_request(
+          state,
+          client,
+          buf,
+          "textDocument/documentHighlight",
+          :document_highlight
+        )
     end
   end
 
@@ -271,8 +285,11 @@ defmodule Minga.Editor.LspActions do
 
   def goto_type_definition(%{buffers: %{active: buf}} = state) do
     case lsp_client_for(state, buf) do
-      nil -> %{state | status_msg: "No language server"}
-      client -> send_lsp_request(state, client, buf, "textDocument/typeDefinition", :type_definition)
+      nil ->
+        %{state | status_msg: "No language server"}
+
+      client ->
+        send_lsp_request(state, client, buf, "textDocument/typeDefinition", :type_definition)
     end
   end
 
@@ -284,8 +301,11 @@ defmodule Minga.Editor.LspActions do
 
   def goto_implementation(%{buffers: %{active: buf}} = state) do
     case lsp_client_for(state, buf) do
-      nil -> %{state | status_msg: "No language server"}
-      client -> send_lsp_request(state, client, buf, "textDocument/implementation", :implementation)
+      nil ->
+        %{state | status_msg: "No language server"}
+
+      client ->
+        send_lsp_request(state, client, buf, "textDocument/implementation", :implementation)
     end
   end
 
@@ -391,7 +411,13 @@ defmodule Minga.Editor.LspActions do
         %{state | status_msg: "No language server"}
 
       client ->
-        send_lsp_request(state, client, buf, "textDocument/prepareCallHierarchy", :prepare_call_hierarchy)
+        send_lsp_request(
+          state,
+          client,
+          buf,
+          "textDocument/prepareCallHierarchy",
+          :prepare_call_hierarchy
+        )
     end
   end
 
@@ -472,7 +498,7 @@ defmodule Minga.Editor.LspActions do
   """
   @spec handle_definition_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_definition_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "Definition request failed: #{inspect(error)}")
+    Log.debug(:lsp, "Definition request failed: #{inspect(error)}")
     %{state | status_msg: "Definition request failed"}
   end
 
@@ -503,7 +529,7 @@ defmodule Minga.Editor.LspActions do
   """
   @spec handle_hover_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_hover_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "Hover request failed: #{inspect(error)}")
+    Log.debug(:lsp, "Hover request failed: #{inspect(error)}")
     %{state | status_msg: "Hover request failed"}
   end
 
@@ -539,7 +565,7 @@ defmodule Minga.Editor.LspActions do
   """
   @spec handle_references_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_references_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "References request failed: #{inspect(error)}")
+    Log.debug(:lsp, "References request failed: #{inspect(error)}")
     %{state | status_msg: "References request failed"}
   end
 
@@ -595,28 +621,7 @@ defmodule Minga.Editor.LspActions do
   end
 
   def handle_document_highlight_response(state, {:ok, highlights}) when is_list(highlights) do
-    parsed =
-      Enum.map(highlights, fn hl ->
-        range = hl["range"]
-        start_pos = range["start"]
-        end_pos = range["end"]
-
-        kind =
-          case hl["kind"] do
-            2 -> :read
-            3 -> :write
-            _ -> :text
-          end
-
-        %{
-          start_line: start_pos["line"],
-          start_col: start_pos["character"],
-          end_line: end_pos["line"],
-          end_col: end_pos["character"],
-          kind: kind
-        }
-      end)
-
+    parsed = Enum.map(highlights, &DocumentHighlight.from_lsp/1)
     %{state | document_highlights: parsed}
   end
 
@@ -630,7 +635,7 @@ defmodule Minga.Editor.LspActions do
   """
   @spec handle_code_action_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_code_action_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "Code action request failed: #{inspect(error)}")
+    Log.debug(:lsp, "Code action request failed: #{inspect(error)}")
     %{state | status_msg: "Code action request failed"}
   end
 
@@ -656,7 +661,7 @@ defmodule Minga.Editor.LspActions do
   """
   @spec handle_prepare_rename_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_prepare_rename_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "Prepare rename failed: #{inspect(error)}")
+    Log.debug(:lsp, "Prepare rename failed: #{inspect(error)}")
     %{state | status_msg: "Cannot rename at this position"}
   end
 
@@ -669,8 +674,8 @@ defmodule Minga.Editor.LspActions do
 
     # Enter command mode with "rename <placeholder>" pre-filled
     # The ex-command parser handles "rename <new_name>" → {:rename, new_name}
-    command_state = %Minga.Mode.CommandState{input: "rename #{placeholder}"}
-    vim = Minga.Editor.VimState.transition(state.vim, :command, command_state)
+    command_state = %CommandState{input: "rename #{placeholder}"}
+    vim = VimState.transition(state.vim, :command, command_state)
     %{state | vim: vim}
   end
 
@@ -681,7 +686,7 @@ defmodule Minga.Editor.LspActions do
   """
   @spec handle_rename_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_rename_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "Rename failed: #{inspect(error)}")
+    Log.debug(:lsp, "Rename failed: #{inspect(error)}")
     %{state | status_msg: "Rename failed"}
   end
 
@@ -698,7 +703,7 @@ defmodule Minga.Editor.LspActions do
   @doc "Handles a textDocument/typeDefinition response (same format as definition)."
   @spec handle_type_definition_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_type_definition_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "Type definition request failed: #{inspect(error)}")
+    Log.debug(:lsp, "Type definition request failed: #{inspect(error)}")
     %{state | status_msg: "Type definition request failed"}
   end
 
@@ -720,7 +725,7 @@ defmodule Minga.Editor.LspActions do
   @doc "Handles a textDocument/implementation response (same format as definition)."
   @spec handle_implementation_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_implementation_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "Implementation request failed: #{inspect(error)}")
+    Log.debug(:lsp, "Implementation request failed: #{inspect(error)}")
     %{state | status_msg: "Implementation request failed"}
   end
 
@@ -758,7 +763,7 @@ defmodule Minga.Editor.LspActions do
   @doc "Handles a textDocument/documentSymbol response."
   @spec handle_document_symbol_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_document_symbol_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "Document symbol request failed: #{inspect(error)}")
+    Log.debug(:lsp, "Document symbol request failed: #{inspect(error)}")
     %{state | status_msg: "Document symbol request failed"}
   end
 
@@ -790,7 +795,7 @@ defmodule Minga.Editor.LspActions do
   @doc "Handles a workspace/symbol response."
   @spec handle_workspace_symbol_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_workspace_symbol_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "Workspace symbol request failed: #{inspect(error)}")
+    Log.debug(:lsp, "Workspace symbol request failed: #{inspect(error)}")
     %{state | status_msg: "Workspace symbol request failed"}
   end
 
@@ -827,7 +832,7 @@ defmodule Minga.Editor.LspActions do
   """
   @spec handle_selection_range_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_selection_range_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "Selection range request failed: #{inspect(error)}")
+    Log.debug(:lsp, "Selection range request failed: #{inspect(error)}")
     %{state | status_msg: "Selection range request failed"}
   end
 
@@ -860,7 +865,7 @@ defmodule Minga.Editor.LspActions do
   @spec handle_prepare_call_hierarchy_response(state(), {:ok, term()} | {:error, term()}) ::
           state()
   def handle_prepare_call_hierarchy_response(state, {:error, error}) do
-    Minga.Log.debug(:lsp, "Call hierarchy request failed: #{inspect(error)}")
+    Log.debug(:lsp, "Call hierarchy request failed: #{inspect(error)}")
     %{state | status_msg: "Call hierarchy request failed"}
   end
 
@@ -913,7 +918,7 @@ defmodule Minga.Editor.LspActions do
   @doc "Handles a textDocument/codeLens response (stores for rendering)."
   @spec handle_code_lens_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_code_lens_response(state, {:error, _}) do
-    Minga.Log.debug(:lsp, "Code lens request failed")
+    Log.debug(:lsp, "Code lens request failed")
     state
   end
 
@@ -941,7 +946,7 @@ defmodule Minga.Editor.LspActions do
   @doc "Handles a textDocument/inlayHint response (stores for rendering)."
   @spec handle_inlay_hint_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_inlay_hint_response(state, {:error, _}) do
-    Minga.Log.debug(:lsp, "Inlay hint request failed")
+    Log.debug(:lsp, "Inlay hint request failed")
     state
   end
 
@@ -991,22 +996,28 @@ defmodule Minga.Editor.LspActions do
 
       _ ->
         {state, file_count, edit_count} =
-          Enum.reduce(file_edits, {state, 0, 0}, fn {path, edits}, {st, fc, ec} ->
-            st = ensure_buffer_open(st, path)
-            buf = find_buffer_by_path(st, path)
-
-            case buf do
-              nil ->
-                Minga.Log.warning(:lsp, "#{label}: could not open buffer for #{path}")
-                {st, fc, ec}
-
-              pid ->
-                BufferServer.apply_text_edits(pid, edits)
-                {st, fc + 1, ec + length(edits)}
-            end
-          end)
+          Enum.reduce(file_edits, {state, 0, 0}, &apply_single_file_edit(&1, &2, label))
 
         %{state | status_msg: "#{label}: applied #{edit_count} edits across #{file_count} files"}
+    end
+  end
+
+  @spec apply_single_file_edit(
+          {String.t(), [WorkspaceEdit.text_edit()]},
+          {state(), non_neg_integer(), non_neg_integer()},
+          String.t()
+        ) :: {state(), non_neg_integer(), non_neg_integer()}
+  defp apply_single_file_edit({path, edits}, {st, fc, ec}, label) do
+    st = ensure_buffer_open(st, path)
+
+    case find_buffer_by_path(st, path) do
+      nil ->
+        Log.warning(:lsp, "#{label}: could not open buffer for #{path}")
+        {st, fc, ec}
+
+      pid ->
+        BufferServer.apply_text_edits(pid, edits)
+        {st, fc + 1, ec + length(edits)}
     end
   end
 
@@ -1333,7 +1344,9 @@ defmodule Minga.Editor.LspActions do
 
   @spec extract_rename_placeholder(map()) :: String.t()
   defp extract_rename_placeholder(%{"placeholder" => name}) when is_binary(name), do: name
-  defp extract_rename_placeholder(%{"range" => _, "placeholder" => name}) when is_binary(name), do: name
+
+  defp extract_rename_placeholder(%{"range" => _, "placeholder" => name}) when is_binary(name),
+    do: name
 
   defp extract_rename_placeholder(%{"start" => _, "end" => _} = _range) do
     # Server returned a Range, meaning the cursor is on a renameable symbol
@@ -1441,12 +1454,12 @@ defmodule Minga.Editor.LspActions do
       BufferServer.move_to(buf, {range.end_line, range.end_col})
 
       # Enter visual mode with the anchor at the start of the range
-      visual_state = %Minga.Mode.VisualState{
+      visual_state = %VisualState{
         visual_anchor: {range.start_line, range.start_col},
         visual_type: :char
       }
 
-      vim = Minga.Editor.VimState.transition(state.vim, :visual, visual_state)
+      vim = VimState.transition(state.vim, :visual, visual_state)
       %{state | vim: vim}
     else
       state
@@ -1472,13 +1485,11 @@ defmodule Minga.Editor.LspActions do
   defp extract_inlay_label(label) when is_binary(label), do: label
 
   defp extract_inlay_label(parts) when is_list(parts) do
-    parts
-    |> Enum.map(fn
+    Enum.map_join(parts, fn
       %{"value" => v} when is_binary(v) -> v
       s when is_binary(s) -> s
       _ -> ""
     end)
-    |> Enum.join()
   end
 
   defp extract_inlay_label(_), do: ""

--- a/lib/minga/editor/render_pipeline/content_helpers.ex
+++ b/lib/minga/editor/render_pipeline/content_helpers.ex
@@ -101,6 +101,13 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
         state.theme.search
       )
 
+    decorations =
+      if is_active do
+        merge_document_highlight_decorations(decorations, state.document_highlights, state.theme)
+      else
+        decorations
+      end
+
     cursorline_bg =
       if is_active and Options.get(:cursorline) do
         state.theme.editor.cursorline_bg
@@ -738,6 +745,67 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
 
     decs
   end
+
+  # ── Document highlight decorations ──────────────────────────────────────────
+
+  # Merges LSP document highlights into decorations with caching.
+  # Uses a process-dictionary cache keyed on the highlight list and base
+  # decorations version, matching the search highlight caching pattern.
+  @spec merge_document_highlight_decorations(
+          Decorations.t(),
+          [Minga.LSP.DocumentHighlight.t()] | nil,
+          Minga.Theme.t()
+        ) :: Decorations.t()
+  defp merge_document_highlight_decorations(decs, nil, _theme), do: decs
+  defp merge_document_highlight_decorations(decs, [], _theme), do: decs
+
+  defp merge_document_highlight_decorations(decs, highlights, theme) do
+    cached = Process.get(:doc_highlight_cache)
+    fingerprint = {highlights, decs.version}
+
+    case cached do
+      {^fingerprint, cached_decs} ->
+        cached_decs
+
+      _ ->
+        result = rebuild_document_highlight_decorations(decs, highlights, theme)
+        Process.put(:doc_highlight_cache, {fingerprint, result})
+        result
+    end
+  end
+
+  @spec rebuild_document_highlight_decorations(
+          Decorations.t(),
+          [Minga.LSP.DocumentHighlight.t()],
+          Minga.Theme.t()
+        ) :: Decorations.t()
+  defp rebuild_document_highlight_decorations(decs, highlights, theme) do
+    Decorations.batch(decs, fn d ->
+      d = Decorations.remove_group(d, :document_highlight)
+
+      Enum.reduce(highlights, d, fn hl, acc ->
+        bg = document_highlight_bg(hl.kind, theme)
+        style = Face.new(bg: bg)
+
+        {_id, acc} =
+          Decorations.add_highlight(acc, {hl.start_line, hl.start_col}, {hl.end_line, hl.end_col},
+            style: style,
+            priority: -15,
+            group: :document_highlight
+          )
+
+        acc
+      end)
+    end)
+  end
+
+  # Resolve background color for document highlights from the theme.
+  # Uses subtle, muted colors that are visible but don't compete with
+  # search highlights (priority -10) or selection.
+  @spec document_highlight_bg(Minga.LSP.DocumentHighlight.kind(), Minga.Theme.t()) ::
+          Minga.Theme.color()
+  defp document_highlight_bg(:write, _theme), do: 0x4A3F2B
+  defp document_highlight_bg(_kind, _theme), do: 0x3A3F4B
 
   @doc "Returns the decorations for a window's buffer."
   @spec window_decorations(Window.t()) :: Decorations.t()

--- a/lib/minga/editor/semantic_window.ex
+++ b/lib/minga/editor/semantic_window.ex
@@ -32,7 +32,7 @@ defmodule Minga.Editor.SemanticWindow do
      change).
   """
 
-  alias __MODULE__.{DiagnosticRange, SearchMatch, Selection, VisualRow}
+  alias __MODULE__.{DiagnosticRange, DocumentHighlightRange, SearchMatch, Selection, VisualRow}
 
   @enforce_keys [:window_id, :rows, :cursor_row, :cursor_col, :cursor_shape]
   defstruct window_id: 0,
@@ -43,6 +43,7 @@ defmodule Minga.Editor.SemanticWindow do
             selection: nil,
             search_matches: [],
             diagnostic_ranges: [],
+            document_highlights: [],
             full_refresh: true
 
   @type cursor_shape :: :block | :beam | :underline
@@ -56,6 +57,7 @@ defmodule Minga.Editor.SemanticWindow do
           selection: Selection.t() | nil,
           search_matches: [SearchMatch.t()],
           diagnostic_ranges: [DiagnosticRange.t()],
+          document_highlights: [DocumentHighlightRange.t()],
           full_refresh: boolean()
         }
 end

--- a/lib/minga/editor/semantic_window/builder.ex
+++ b/lib/minga/editor/semantic_window/builder.ex
@@ -29,6 +29,7 @@ defmodule Minga.Editor.SemanticWindow.Builder do
   alias Minga.Editor.RenderPipeline.Scroll.WindowScroll
   alias Minga.Editor.SemanticWindow
   alias Minga.Editor.SemanticWindow.DiagnosticRange
+  alias Minga.Editor.SemanticWindow.DocumentHighlightRange
   alias Minga.Editor.SemanticWindow.SearchMatch
   alias Minga.Editor.SemanticWindow.Selection
   alias Minga.Editor.SemanticWindow.Span
@@ -109,6 +110,10 @@ defmodule Minga.Editor.SemanticWindow.Builder do
     # Diagnostic inline ranges in display coordinates
     diagnostic_ranges = build_diagnostic_ranges(window, viewport, visible_rows)
 
+    # Document highlights in display coordinates
+    doc_highlights =
+      build_document_highlights(state.document_highlights, viewport.top, viewport_bottom)
+
     %SemanticWindow{
       window_id: win_id,
       rows: visual_rows,
@@ -118,6 +123,7 @@ defmodule Minga.Editor.SemanticWindow.Builder do
       selection: selection,
       search_matches: search_matches,
       diagnostic_ranges: diagnostic_ranges,
+      document_highlights: doc_highlights,
       full_refresh: true
     }
   end
@@ -351,6 +357,32 @@ defmodule Minga.Editor.SemanticWindow.Builder do
     end
   catch
     :exit, _ -> []
+  end
+
+  # ── Document highlights ─────────────────────────────────────────────────
+
+  @spec build_document_highlights(
+          [Minga.LSP.DocumentHighlight.t()] | nil,
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [DocumentHighlightRange.t()]
+  defp build_document_highlights(nil, _top, _bottom), do: []
+  defp build_document_highlights([], _top, _bottom), do: []
+
+  defp build_document_highlights(highlights, viewport_top, viewport_bottom) do
+    highlights
+    |> Enum.filter(fn hl ->
+      hl.start_line < viewport_bottom and hl.end_line >= viewport_top
+    end)
+    |> Enum.map(fn hl ->
+      %DocumentHighlightRange{
+        start_row: hl.start_line - viewport_top,
+        start_col: hl.start_col,
+        end_row: hl.end_line - viewport_top,
+        end_col: hl.end_col,
+        kind: hl.kind
+      }
+    end)
   end
 
   # ── Helpers ────────────────────────────────────────────────────────────

--- a/lib/minga/editor/semantic_window/document_highlight_range.ex
+++ b/lib/minga/editor/semantic_window/document_highlight_range.ex
@@ -1,0 +1,22 @@
+defmodule Minga.Editor.SemanticWindow.DocumentHighlightRange do
+  @moduledoc """
+  A document highlight range in display coordinates for the GUI protocol.
+
+  Sent as part of the `gui_window_content` (0x80) opcode. The kind field
+  distinguishes text, read, and write references for distinct styling.
+  """
+
+  @enforce_keys [:start_row, :start_col, :end_row, :end_col, :kind]
+  defstruct [:start_row, :start_col, :end_row, :end_col, :kind]
+
+  @typedoc "Highlight kind matching the LSP spec."
+  @type kind :: :text | :read | :write
+
+  @type t :: %__MODULE__{
+          start_row: non_neg_integer(),
+          start_col: non_neg_integer(),
+          end_row: non_neg_integer(),
+          end_col: non_neg_integer(),
+          kind: kind()
+        }
+end

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -65,17 +65,8 @@ defmodule Minga.Editor.State do
   @typedoc "Line number display style."
   @type line_number_style :: :hybrid | :absolute | :relative | :none
 
-  @typedoc "LSP document highlight kind."
-  @type highlight_kind :: :text | :read | :write
-
   @typedoc "A document highlight range from the LSP server."
-  @type document_highlight :: %{
-          start_line: non_neg_integer(),
-          start_col: non_neg_integer(),
-          end_line: non_neg_integer(),
-          end_col: non_neg_integer(),
-          kind: highlight_kind()
-        }
+  @type document_highlight :: Minga.LSP.DocumentHighlight.t()
 
   # Fields saved/restored per-tab. Adding a per-tab field? Add it here,
   # and snapshot_tab_fields/1 + restore_tab_context/1 will pick it up

--- a/lib/minga/input/router.ex
+++ b/lib/minga/input/router.ex
@@ -15,6 +15,7 @@ defmodule Minga.Input.Router do
 
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor
+  alias Minga.Editor.LspActions
   alias Minga.Editor.State, as: EditorState
   alias Minga.Port.Manager, as: PortManager
   alias Minga.Port.Protocol
@@ -65,12 +66,20 @@ defmodule Minga.Input.Router do
     old_buffer = state.buffers.active
     old_mode = state.vim.mode
     buf_version_before = buffer_version(state)
+    old_cursor = safe_cursor(old_buffer)
 
     state = %{state | status_msg: nil}
 
     state = dispatch_split(state, codepoint, modifiers)
 
-    post_key_housekeeping(state, old_buffer, buf_version_before, old_mode, {codepoint, modifiers})
+    post_key_housekeeping(
+      state,
+      old_buffer,
+      buf_version_before,
+      old_mode,
+      {codepoint, modifiers},
+      old_cursor
+    )
   end
 
   # Walks overlay handlers first (ConflictPrompt, Picker, Completion).
@@ -113,20 +122,68 @@ defmodule Minga.Input.Router do
           pid() | nil,
           non_neg_integer(),
           atom(),
-          {non_neg_integer(), non_neg_integer()}
+          {non_neg_integer(), non_neg_integer()},
+          {non_neg_integer(), non_neg_integer()} | nil
         ) :: EditorState.t()
   def post_key_housekeeping(
         state,
         old_buffer,
         buf_version_before,
         old_mode,
-        {codepoint, modifiers}
+        {codepoint, modifiers},
+        old_cursor \\ nil
       ) do
     state
     |> Editor.do_maybe_reset_highlight(old_buffer)
     |> Editor.do_maybe_reparse(buf_version_before)
     |> Editor.do_maybe_handle_completion(old_mode, codepoint, modifiers)
+    |> maybe_schedule_document_highlight(old_buffer, old_cursor)
     |> maybe_render(buf_version_before)
+  end
+
+  # Schedules a debounced document highlight request when the cursor moves
+  # in normal mode. Clears highlights on buffer switch or mode change.
+  # Only schedules when the cursor actually moved (avoids timer churn on
+  # keystrokes that don't change position, like failed motions or `zz`).
+  @spec maybe_schedule_document_highlight(
+          EditorState.t(),
+          pid() | nil,
+          {non_neg_integer(), non_neg_integer()} | nil
+        ) :: EditorState.t()
+  defp maybe_schedule_document_highlight(state, old_buffer, old_cursor) do
+    current_buffer = state.buffers.active
+
+    cond do
+      # Buffer changed: clear highlights
+      current_buffer != old_buffer ->
+        LspActions.clear_document_highlights(state)
+
+      # Not normal mode: clear highlights
+      state.vim.mode != :normal ->
+        LspActions.clear_document_highlights(state)
+
+      # Normal mode with a live buffer: schedule only if cursor moved
+      current_buffer != nil ->
+        new_cursor = safe_cursor(current_buffer)
+
+        if new_cursor != old_cursor do
+          LspActions.schedule_document_highlight(state)
+        else
+          state
+        end
+
+      true ->
+        state
+    end
+  end
+
+  @spec safe_cursor(pid() | nil) :: {non_neg_integer(), non_neg_integer()} | nil
+  defp safe_cursor(nil), do: nil
+
+  defp safe_cursor(buf) do
+    BufferServer.cursor(buf)
+  catch
+    :exit, _ -> nil
   end
 
   # Skips the full render when entering operator-pending mode with no buffer

--- a/lib/minga/lsp/document_highlight.ex
+++ b/lib/minga/lsp/document_highlight.ex
@@ -1,0 +1,45 @@
+defmodule Minga.LSP.DocumentHighlight do
+  @moduledoc """
+  A document highlight range from the LSP server.
+
+  Represents a single occurrence of a symbol in the current buffer,
+  returned by `textDocument/documentHighlight`. The `kind` field
+  distinguishes read references from write references.
+  """
+
+  @enforce_keys [:start_line, :start_col, :end_line, :end_col, :kind]
+  defstruct [:start_line, :start_col, :end_line, :end_col, :kind]
+
+  @typedoc "LSP document highlight kind."
+  @type kind :: :text | :read | :write
+
+  @type t :: %__MODULE__{
+          start_line: non_neg_integer(),
+          start_col: non_neg_integer(),
+          end_line: non_neg_integer(),
+          end_col: non_neg_integer(),
+          kind: kind()
+        }
+
+  @doc "Parses an LSP DocumentHighlight JSON object into a struct."
+  @spec from_lsp(map()) :: t()
+  def from_lsp(%{"range" => range} = hl) do
+    start_pos = range["start"]
+    end_pos = range["end"]
+
+    kind =
+      case hl["kind"] do
+        2 -> :read
+        3 -> :write
+        _ -> :text
+      end
+
+    %__MODULE__{
+      start_line: start_pos["line"],
+      start_col: start_pos["character"],
+      end_line: end_pos["line"],
+      end_col: end_pos["character"],
+      kind: kind
+    }
+  end
+end

--- a/lib/minga/picker/code_action_source.ex
+++ b/lib/minga/picker/code_action_source.ex
@@ -12,6 +12,7 @@ defmodule Minga.Picker.CodeActionSource do
   @behaviour Minga.Picker.Source
 
   alias Minga.Editor.LspActions
+  alias Minga.Log
   alias Minga.Picker.Item
 
   @impl true
@@ -73,7 +74,7 @@ defmodule Minga.Picker.CodeActionSource do
         state
 
       %{"command" => cmd, "title" => title} ->
-        Minga.Log.info(:lsp, "Code action command: #{title} (#{cmd})")
+        Log.info(:lsp, "Code action command: #{title} (#{cmd})")
         # TODO: Execute the command via Client.request("workspace/executeCommand", ...)
         state
 

--- a/lib/minga/picker/location_source.ex
+++ b/lib/minga/picker/location_source.ex
@@ -24,6 +24,7 @@ defmodule Minga.Picker.LocationSource do
   alias Minga.Editor.Commands
   alias Minga.Editor.State, as: EditorState
   alias Minga.Picker.Item
+  alias Minga.Picker.Source
 
   @impl true
   @spec title() :: String.t()
@@ -50,7 +51,7 @@ defmodule Minga.Picker.LocationSource do
   @impl true
   @spec on_cancel(term()) :: term()
   def on_cancel(state) do
-    Minga.Picker.Source.restore_or_keep(state)
+    Source.restore_or_keep(state)
   end
 
   # ── Private ────────────────────────────────────────────────────────────────

--- a/lib/minga/port/protocol/gui_window_content.ex
+++ b/lib/minga/port/protocol/gui_window_content.ex
@@ -43,6 +43,11 @@ defmodule Minga.Port.Protocol.GUIWindowContent do
   diag_range_count:     u16
   per range: start_row(u16), start_col(u16), end_row(u16), end_col(u16),
              severity(u8)
+
+  highlight_count:      u16
+  per highlight: start_row(u16), start_col(u16), end_row(u16), end_col(u16),
+                 kind(u8)
+  Kind: 1=text, 2=read, 3=write
   ```
   """
 
@@ -50,6 +55,7 @@ defmodule Minga.Port.Protocol.GUIWindowContent do
 
   alias Minga.Editor.SemanticWindow
   alias Minga.Editor.SemanticWindow.DiagnosticRange
+  alias Minga.Editor.SemanticWindow.DocumentHighlightRange
   alias Minga.Editor.SemanticWindow.SearchMatch
   alias Minga.Editor.SemanticWindow.Selection
   alias Minga.Editor.SemanticWindow.Span
@@ -76,8 +82,16 @@ defmodule Minga.Port.Protocol.GUIWindowContent do
     selection_binary = encode_selection(sw.selection)
     matches_binary = encode_search_matches(sw.search_matches)
     diag_binary = encode_diagnostic_ranges(sw.diagnostic_ranges)
+    highlight_binary = encode_document_highlights(sw.document_highlights)
 
-    IO.iodata_to_binary([header, rows_binary, selection_binary, matches_binary, diag_binary])
+    IO.iodata_to_binary([
+      header,
+      rows_binary,
+      selection_binary,
+      matches_binary,
+      diag_binary,
+      highlight_binary
+    ])
   end
 
   @doc """
@@ -183,6 +197,27 @@ defmodule Minga.Port.Protocol.GUIWindowContent do
   defp encode_severity(:warning), do: 1
   defp encode_severity(:info), do: 2
   defp encode_severity(:hint), do: 3
+
+  # ── Document highlights ─────────────────────────────────────────────────
+
+  @spec encode_document_highlights([DocumentHighlightRange.t()]) :: binary()
+  defp encode_document_highlights(highlights) do
+    count = length(highlights)
+    entries = Enum.map(highlights, &encode_document_highlight/1)
+    IO.iodata_to_binary([<<count::16>> | entries])
+  end
+
+  @spec encode_document_highlight(DocumentHighlightRange.t()) :: binary()
+  defp encode_document_highlight(%DocumentHighlightRange{} = h) do
+    kind = encode_highlight_kind(h.kind)
+
+    <<h.start_row::16, h.start_col::16, h.end_row::16, h.end_col::16, kind::8>>
+  end
+
+  @spec encode_highlight_kind(DocumentHighlightRange.kind()) :: non_neg_integer()
+  defp encode_highlight_kind(:text), do: 1
+  defp encode_highlight_kind(:read), do: 2
+  defp encode_highlight_kind(:write), do: 3
 
   # ── Cursor shape ────────────────────────────────────────────────────────
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1119,6 +1119,25 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             pos += 9
         }
 
+        // Document highlights: count:2, then per highlight: start_row:2 + start_col:2 + end_row:2 + end_col:2 + kind:1 = 9
+        var docHighlights: [GUIDocumentHighlight] = []
+        if data.count >= pos + 2 {
+            let highlightCount = Int(readU16(data, pos))
+            pos += 2
+            docHighlights.reserveCapacity(highlightCount)
+            for _ in 0..<highlightCount {
+                guard data.count >= pos + 9 else { throw ProtocolDecodeError.malformed }
+                docHighlights.append(GUIDocumentHighlight(
+                    startRow: readU16(data, pos),
+                    startCol: readU16(data, pos + 2),
+                    endRow: readU16(data, pos + 4),
+                    endCol: readU16(data, pos + 6),
+                    kind: GUIDocumentHighlightKind(rawValue: data[pos + 8]) ?? .text
+                ))
+                pos += 9
+            }
+        }
+
         let content = GUIWindowContent(
             windowId: windowId,
             fullRefresh: (flags & 0x01) != 0,
@@ -1128,7 +1147,8 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             rows: rows,
             selection: selection,
             searchMatches: matches,
-            diagnosticUnderlines: diags
+            diagnosticUnderlines: diags,
+            documentHighlights: docHighlights
         )
         return (.guiWindowContent(data: content), pos - offset)
 

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -363,6 +363,26 @@ final class CoreTextMetalRenderer {
                     )
                 }
 
+                // Document highlight overlay quads (drawn before search matches,
+                // so search matches paint over them when they overlap).
+                for highlight in content.documentHighlights {
+                    // Document highlights are typically single-line (one identifier).
+                    // Draw on startRow only; multi-row highlights are rare for this feature.
+                    let hlY = windowRowOffset + Float(highlight.startRow) * cellH * scale
+                    let hlX = contentColOffset + Float(highlight.startCol) * cellW * scale
+                    let hlW = Float(highlight.endCol - highlight.startCol) * cellW * scale
+
+                    var quad = QuadGPU()
+                    quad.position = SIMD2<Float>(hlX, hlY)
+                    quad.size = SIMD2<Float>(hlW, cellH * scale)
+                    // Write references get a warmer amber tint; read/text get a subtle blue-gray.
+                    quad.color = highlight.kind == .write
+                        ? SIMD3<Float>(0.29, 0.25, 0.17)   // amber: 0x4A3F2B
+                        : SIMD3<Float>(0.23, 0.25, 0.29)   // blue-gray: 0x3A3F4B
+                    quad.alpha = 1.0
+                    semanticOverlayQuads.append(quad)
+                }
+
                 // Search match overlay quads (drawn before text).
                 for match in content.searchMatches {
                     let matchY = windowRowOffset + Float(match.row) * cellH * scale

--- a/macos/Sources/Renderer/WindowContent.swift
+++ b/macos/Sources/Renderer/WindowContent.swift
@@ -103,6 +103,25 @@ struct GUIDiagnosticUnderline: Sendable, Equatable {
     let severity: GUIDiagnosticSeverity
 }
 
+// MARK: - Document highlight
+
+/// LSP document highlight kind (matches LSP spec values).
+enum GUIDocumentHighlightKind: UInt8, Sendable {
+    case text = 1
+    case read = 2
+    case write = 3
+}
+
+/// A document highlight range in display coordinates.
+/// Rendered as a subtle background quad behind text, similar to search matches.
+struct GUIDocumentHighlight: Sendable, Equatable {
+    let startRow: UInt16
+    let startCol: UInt16
+    let endRow: UInt16
+    let endCol: UInt16
+    let kind: GUIDocumentHighlightKind
+}
+
 // MARK: - Window content
 
 /// Complete semantic content for one editor window.
@@ -120,12 +139,14 @@ final class GUIWindowContent: Sendable {
     let selection: GUISelectionOverlay?
     let searchMatches: [GUISearchMatch]
     let diagnosticUnderlines: [GUIDiagnosticUnderline]
+    let documentHighlights: [GUIDocumentHighlight]
 
     init(windowId: UInt16, fullRefresh: Bool,
          cursorRow: UInt16, cursorCol: UInt16, cursorShape: CursorShape,
          rows: [GUIVisualRow], selection: GUISelectionOverlay?,
          searchMatches: [GUISearchMatch],
-         diagnosticUnderlines: [GUIDiagnosticUnderline]) {
+         diagnosticUnderlines: [GUIDiagnosticUnderline],
+         documentHighlights: [GUIDocumentHighlight]) {
         self.windowId = windowId
         self.fullRefresh = fullRefresh
         self.cursorRow = cursorRow
@@ -135,5 +156,6 @@ final class GUIWindowContent: Sendable {
         self.selection = selection
         self.searchMatches = searchMatches
         self.diagnosticUnderlines = diagnosticUnderlines
+        self.documentHighlights = documentHighlights
     }
 }

--- a/macos/Tests/MingaTests/WindowContentRendererTests.swift
+++ b/macos/Tests/MingaTests/WindowContentRendererTests.swift
@@ -145,7 +145,8 @@ struct GUIStateFrameTests {
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,
-            searchMatches: [], diagnosticUnderlines: []
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
         )
         state.windowContents[1] = content
         #expect(state.windowContents.count == 1)

--- a/macos/Tests/MingaTests/WindowContentTests.swift
+++ b/macos/Tests/MingaTests/WindowContentTests.swift
@@ -21,6 +21,7 @@ struct WindowContentBuilder {
     var selectionCoords: (UInt16, UInt16, UInt16, UInt16)?
     var searchMatches: [(row: UInt16, startCol: UInt16, endCol: UInt16, isCurrent: UInt8)] = []
     var diagnosticRanges: [(startRow: UInt16, startCol: UInt16, endRow: UInt16, endCol: UInt16, severity: UInt8)] = []
+    var documentHighlights: [(startRow: UInt16, startCol: UInt16, endRow: UInt16, endCol: UInt16, kind: UInt8)] = []
 
     struct RowBuilder {
         var rowType: UInt8 = 0  // normal
@@ -94,6 +95,15 @@ struct WindowContentBuilder {
             data.append(d.severity)
         }
 
+        appendU16(&data, UInt16(documentHighlights.count))
+        for h in documentHighlights {
+            appendU16(&data, h.startRow)
+            appendU16(&data, h.startCol)
+            appendU16(&data, h.endRow)
+            appendU16(&data, h.endCol)
+            data.append(h.kind)
+        }
+
         return data
     }
 
@@ -136,6 +146,7 @@ struct WindowContentDecoderTests {
         #expect(content.selection == nil)
         #expect(content.searchMatches.isEmpty)
         #expect(content.diagnosticUnderlines.isEmpty)
+        #expect(content.documentHighlights.isEmpty)
     }
 
     @Test("Decode header fields: window_id, cursor, shape, full_refresh")
@@ -333,6 +344,32 @@ struct WindowContentDecoderTests {
         #expect(content.diagnosticUnderlines[1].startCol == 5)
     }
 
+    @Test("Decode document highlights with all kind values")
+    func decodeDocumentHighlights() throws {
+        var builder = WindowContentBuilder()
+        builder.documentHighlights = [
+            (startRow: 2, startCol: 4, endRow: 2, endCol: 12, kind: 1),  // text
+            (startRow: 5, startCol: 0, endRow: 5, endCol: 8, kind: 2),   // read
+            (startRow: 8, startCol: 10, endRow: 8, endCol: 18, kind: 3), // write
+        ]
+
+        let (cmd, _) = try decodeCommand(data: builder.build(), offset: 0)
+        guard case .guiWindowContent(let content) = cmd else {
+            Issue.record("Expected .guiWindowContent"); return
+        }
+
+        #expect(content.documentHighlights.count == 3)
+        #expect(content.documentHighlights[0].kind == .text)
+        #expect(content.documentHighlights[0].startRow == 2)
+        #expect(content.documentHighlights[0].startCol == 4)
+        #expect(content.documentHighlights[0].endCol == 12)
+        #expect(content.documentHighlights[1].kind == .read)
+        #expect(content.documentHighlights[1].startRow == 5)
+        #expect(content.documentHighlights[2].kind == .write)
+        #expect(content.documentHighlights[2].startCol == 10)
+        #expect(content.documentHighlights[2].endCol == 18)
+    }
+
     @Test("Decode consumes entire binary (no leftover bytes)")
     func decodeConsumesAllBytes() throws {
         var builder = WindowContentBuilder()
@@ -364,6 +401,7 @@ struct WindowContentDecoderTests {
         builder.selectionCoords = (0, 0, 0, 10)
         builder.searchMatches = [(row: 0, startCol: 4, endCol: 7, isCurrent: 0)]
         builder.diagnosticRanges = [(startRow: 0, startCol: 0, endRow: 0, endCol: 3, severity: 1)]
+        builder.documentHighlights = [(startRow: 0, startCol: 4, endRow: 0, endCol: 7, kind: 2)]
 
         let data = builder.build()
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
@@ -385,5 +423,7 @@ struct WindowContentDecoderTests {
         #expect(content.searchMatches.count == 1)
         #expect(content.diagnosticUnderlines.count == 1)
         #expect(content.diagnosticUnderlines[0].severity == .warning)
+        #expect(content.documentHighlights.count == 1)
+        #expect(content.documentHighlights[0].kind == .read)
     }
 }

--- a/test/minga/lsp/document_highlight_test.exs
+++ b/test/minga/lsp/document_highlight_test.exs
@@ -1,0 +1,72 @@
+defmodule Minga.LSP.DocumentHighlightTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.LSP.DocumentHighlight
+
+  describe "from_lsp/1" do
+    test "parses a text highlight (kind 1)" do
+      lsp = %{
+        "range" => %{
+          "start" => %{"line" => 5, "character" => 10},
+          "end" => %{"line" => 5, "character" => 15}
+        },
+        "kind" => 1
+      }
+
+      result = DocumentHighlight.from_lsp(lsp)
+      assert %DocumentHighlight{} = result
+      assert result.start_line == 5
+      assert result.start_col == 10
+      assert result.end_line == 5
+      assert result.end_col == 15
+      assert result.kind == :text
+    end
+
+    test "parses a read highlight (kind 2)" do
+      lsp = %{
+        "range" => %{
+          "start" => %{"line" => 10, "character" => 0},
+          "end" => %{"line" => 10, "character" => 8}
+        },
+        "kind" => 2
+      }
+
+      assert %DocumentHighlight{kind: :read} = DocumentHighlight.from_lsp(lsp)
+    end
+
+    test "parses a write highlight (kind 3)" do
+      lsp = %{
+        "range" => %{
+          "start" => %{"line" => 3, "character" => 4},
+          "end" => %{"line" => 3, "character" => 12}
+        },
+        "kind" => 3
+      }
+
+      assert %DocumentHighlight{kind: :write} = DocumentHighlight.from_lsp(lsp)
+    end
+
+    test "defaults to :text when kind is nil" do
+      lsp = %{
+        "range" => %{
+          "start" => %{"line" => 0, "character" => 0},
+          "end" => %{"line" => 0, "character" => 5}
+        }
+      }
+
+      assert %DocumentHighlight{kind: :text} = DocumentHighlight.from_lsp(lsp)
+    end
+
+    test "defaults to :text for unknown kind values" do
+      lsp = %{
+        "range" => %{
+          "start" => %{"line" => 0, "character" => 0},
+          "end" => %{"line" => 0, "character" => 5}
+        },
+        "kind" => 99
+      }
+
+      assert %DocumentHighlight{kind: :text} = DocumentHighlight.from_lsp(lsp)
+    end
+  end
+end

--- a/test/support/gui_window_content_decoder.ex
+++ b/test/support/gui_window_content_decoder.ex
@@ -19,7 +19,8 @@ defmodule Minga.Test.GUIWindowContentDecoder do
     {rows, rest} = decode_rows(rest, row_count, [])
     {selection, rest} = decode_selection(rest)
     {search_matches, rest} = decode_search_matches(rest)
-    {diagnostic_ranges, <<>>} = decode_diagnostic_ranges(rest)
+    {diagnostic_ranges, rest} = decode_diagnostic_ranges(rest)
+    {document_highlights, <<>>} = decode_document_highlights(rest)
 
     %{
       window_id: window_id,
@@ -30,7 +31,8 @@ defmodule Minga.Test.GUIWindowContentDecoder do
       rows: rows,
       selection: selection,
       search_matches: search_matches,
-      diagnostic_ranges: diagnostic_ranges
+      diagnostic_ranges: diagnostic_ranges,
+      document_highlights: document_highlights
     }
   end
 
@@ -159,6 +161,34 @@ defmodule Minga.Test.GUIWindowContentDecoder do
   defp decode_severity(1), do: :warning
   defp decode_severity(2), do: :info
   defp decode_severity(3), do: :hint
+
+  # ── Document highlights ─────────────────────────────────────────────────
+
+  defp decode_document_highlights(<<count::16, rest::binary>>) do
+    decode_highlight_entries(rest, count, [])
+  end
+
+  defp decode_highlight_entries(rest, 0, acc), do: {Enum.reverse(acc), rest}
+
+  defp decode_highlight_entries(
+         <<start_row::16, start_col::16, end_row::16, end_col::16, kind::8, rest::binary>>,
+         remaining,
+         acc
+       ) do
+    highlight = %{
+      start_row: start_row,
+      start_col: start_col,
+      end_row: end_row,
+      end_col: end_col,
+      kind: decode_highlight_kind(kind)
+    }
+
+    decode_highlight_entries(rest, remaining - 1, [highlight | acc])
+  end
+
+  defp decode_highlight_kind(1), do: :text
+  defp decode_highlight_kind(2), do: :read
+  defp decode_highlight_kind(3), do: :write
 
   # ── Cursor shape ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Implements LSP `textDocument/documentHighlight`. When the cursor rests on a symbol in normal mode, all other occurrences in the visible buffer are highlighted with subtle background colors. Read and write references get distinct colors.

Depends on #876 (LSP infrastructure). Review that PR first.

## How it works

1. Cursor moves in normal mode
2. Router compares cursor position before/after dispatch
3. 150ms debounce timer starts (cancels pending)
4. Timer fires, sends `textDocument/documentHighlight` request
5. Response parsed into `DocumentHighlight` structs
6. Render pipeline merges into Decorations as bg overlay (with cache)
7. TUI draws via Face bg; GUI sends via 0x80, Metal draws overlay quads

## Changes

### BEAM: debounce, parse, merge into Decorations, GUI protocol section
### macOS GUI: decode, Metal overlay quads (write=amber, read=blue-gray)
### Tests: 5 Elixir + 1 Swift decode test + existing round-trips updated

Closes #867