### PR TITLE
feat(lsp): incremental sync + diagnostics ETS optimization (#639, #531)

### DIFF
--- a/lib/minga/diagnostics.ex
+++ b/lib/minga/diagnostics.ex
@@ -223,8 +223,28 @@ defmodule Minga.Diagnostics do
   @impl GenServer
   @spec init(atom()) :: {:ok, state()}
   def init(name) do
-    table = :ets.new(table_name(name), [:set, :public, :named_table, read_concurrency: true])
-    {:ok, %{table: table, subscribers: []}}
+    tname = table_name(name)
+    table = :ets.new(tname, [:set, :public, :named_table, read_concurrency: true])
+
+    # Secondary index: maps URI → list of sources that have diagnostics for it.
+    # Enables O(1) URI lookups instead of scanning the entire table.
+    uri_index = :ets.new(:"#{tname}_uri_idx", [:set, :public, read_concurrency: true])
+
+    # Merge cache: stores merged diagnostics per URI.
+    # Invalidated on publish/clear for that URI only.
+    merge_cache = :ets.new(:"#{tname}_cache", [:set, :public, read_concurrency: true])
+
+    # Store refs so readers can find the secondary tables from the main table name.
+    :persistent_term.put({__MODULE__, tname}, {uri_index, merge_cache})
+
+    {:ok,
+     %{
+       table: table,
+       uri_index: uri_index,
+       merge_cache: merge_cache,
+       subscribers: [],
+       generation: 0
+     }}
   end
 
   @impl GenServer
@@ -235,18 +255,28 @@ defmodule Minga.Diagnostics do
 
   def handle_call({:publish, source, uri, diagnostics}, _from, state) do
     :ets.insert(state.table, {{source, uri}, diagnostics})
+    update_uri_index(state.uri_index, uri, source, :add)
+    invalidate_cache(state.merge_cache, uri)
+    gen = state.generation + 1
     notify_subscribers(state.subscribers, uri)
-    {:reply, :ok, state}
+    {:reply, :ok, %{state | generation: gen}}
   end
 
   def handle_call({:clear, source, uri}, _from, state) do
     :ets.delete(state.table, {source, uri})
+    update_uri_index(state.uri_index, uri, source, :remove)
+    invalidate_cache(state.merge_cache, uri)
+    gen = state.generation + 1
     notify_subscribers(state.subscribers, uri)
-    {:reply, :ok, state}
+    {:reply, :ok, %{state | generation: gen}}
   end
 
   def handle_call(:table_name, _from, state) do
     {:reply, state.table, state}
+  end
+
+  def handle_call(:table_refs, _from, state) do
+    {:reply, {state.table, state.uri_index, state.merge_cache}, state}
   end
 
   def handle_call({:clear_source, source}, _from, state) do
@@ -262,8 +292,15 @@ defmodule Minga.Diagnostics do
       )
 
     :ets.match_delete(state.table, {{source, :_}, :_})
+
+    Enum.each(affected_uris, fn uri ->
+      update_uri_index(state.uri_index, uri, source, :remove)
+      invalidate_cache(state.merge_cache, uri)
+    end)
+
+    gen = state.generation + 1
     Enum.each(affected_uris, &notify_subscribers(state.subscribers, &1))
-    {:reply, :ok, state}
+    {:reply, :ok, %{state | generation: gen}}
   end
 
   @impl GenServer
@@ -273,16 +310,40 @@ defmodule Minga.Diagnostics do
 
   # ── Private ────────────────────────────────────────────────────────────────
 
+  # Merged diagnostics for a URI, using the URI index for O(1) source
+  # lookup and a generation-based cache to avoid re-merging on every call.
   @spec merged_for_uri(:ets.table(), uri()) :: [Diagnostic.t()]
   defp merged_for_uri(table, uri) do
-    :ets.foldl(
-      fn
-        {{_src, ^uri}, diags}, acc -> diags ++ acc
-        _other, acc -> acc
-      end,
-      [],
-      table
-    )
+    {uri_index, cache_table} = :persistent_term.get({__MODULE__, table})
+
+    # Check cache first
+    case :ets.lookup(cache_table, uri) do
+      [{^uri, cached_diags}] ->
+        cached_diags
+
+      [] ->
+        # Cache miss: look up sources for this URI, then fetch each
+        result = merge_from_index(table, uri_index, uri)
+        :ets.insert(cache_table, {uri, result})
+        result
+    end
+  end
+
+  @spec merge_from_index(:ets.table(), :ets.table(), uri()) :: [Diagnostic.t()]
+  defp merge_from_index(table, uri_index, uri) do
+    sources =
+      case :ets.lookup(uri_index, uri) do
+        [{^uri, src_list}] -> src_list
+        [] -> []
+      end
+
+    sources
+    |> Enum.flat_map(fn source ->
+      case :ets.lookup(table, {source, uri}) do
+        [{{^source, ^uri}, diags}] -> diags
+        [] -> []
+      end
+    end)
     |> Diagnostic.sort()
   end
 
@@ -306,6 +367,44 @@ defmodule Minga.Diagnostics do
       nil -> List.last(sorted_diags)
       diag -> diag
     end
+  end
+
+  @spec update_uri_index(:ets.table(), uri(), source(), :add | :remove) :: :ok
+  defp update_uri_index(uri_index, uri, source, :add) do
+    case :ets.lookup(uri_index, uri) do
+      [{^uri, sources}] ->
+        unless source in sources do
+          :ets.insert(uri_index, {uri, [source | sources]})
+        end
+
+      [] ->
+        :ets.insert(uri_index, {uri, [source]})
+    end
+
+    :ok
+  end
+
+  defp update_uri_index(uri_index, uri, source, :remove) do
+    case :ets.lookup(uri_index, uri) do
+      [{^uri, sources}] ->
+        new_sources = List.delete(sources, source)
+
+        if new_sources == [] do
+          :ets.delete(uri_index, uri)
+        else
+          :ets.insert(uri_index, {uri, new_sources})
+        end
+
+      [] ->
+        :ok
+    end
+
+    :ok
+  end
+
+  @spec invalidate_cache(:ets.table(), uri()) :: true
+  defp invalidate_cache(cache, uri) do
+    :ets.delete(cache, uri)
   end
 
   @spec notify_subscribers([pid()], uri()) :: :ok

--- a/lib/minga/lsp/client.ex
+++ b/lib/minga/lsp/client.ex
@@ -144,6 +144,37 @@ defmodule Minga.LSP.Client do
   end
 
   @doc """
+  Returns the sync kind negotiated with the server.
+
+  - `:full` (1) — server expects full content on every change
+  - `:incremental` (2) — server accepts incremental content changes
+  - `:none` (0) — server doesn't want change notifications
+  """
+  @spec sync_kind(GenServer.server()) :: :none | :full | :incremental
+  def sync_kind(server) do
+    GenServer.call(server, :sync_kind)
+  end
+
+  @doc """
+  Sends `textDocument/didChange` with incremental content changes.
+
+  Each change is a `{start_line, start_col, end_line, end_col, new_text}`
+  tuple matching the LSP TextDocumentContentChangeEvent format.
+  """
+  @spec did_change_incremental(
+          GenServer.server(),
+          String.t(),
+          [
+            {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer(),
+             String.t()}
+          ]
+        ) :: :ok
+  def did_change_incremental(server, uri, changes)
+      when is_binary(uri) and is_list(changes) do
+    GenServer.cast(server, {:did_change_incremental, uri, changes})
+  end
+
+  @doc """
   Sends a synchronous LSP request and waits for the response.
 
   Blocks the caller for up to `timeout` milliseconds. Returns
@@ -247,6 +278,10 @@ defmodule Minga.LSP.Client do
     {:reply, state.capabilities, state}
   end
 
+  def handle_call(:sync_kind, _from, state) do
+    {:reply, extract_sync_kind(state.capabilities), state}
+  end
+
   def handle_call(:semantic_token_legend, _from, state) do
     {:reply, state.semantic_token_legend, state}
   end
@@ -320,6 +355,36 @@ defmodule Minga.LSP.Client do
         send_notification(state, "textDocument/didChange", %{
           "textDocument" => %{"uri" => uri, "version" => new_version},
           "contentChanges" => [%{"text" => text}]
+        })
+
+        {:noreply, state}
+    end
+  end
+
+  def handle_cast({:did_change_incremental, uri, changes}, %{status: :ready} = state) do
+    case Map.get(state.open_documents, uri) do
+      nil ->
+        {:noreply, state}
+
+      %{version: version} ->
+        new_version = version + 1
+        doc = %{uri: uri, version: new_version}
+        state = %{state | open_documents: Map.put(state.open_documents, uri, doc)}
+
+        content_changes =
+          Enum.map(changes, fn {sl, sc, el, ec, text} ->
+            %{
+              "range" => %{
+                "start" => %{"line" => sl, "character" => sc},
+                "end" => %{"line" => el, "character" => ec}
+              },
+              "text" => text
+            }
+          end)
+
+        send_notification(state, "textDocument/didChange", %{
+          "textDocument" => %{"uri" => uri, "version" => new_version},
+          "contentChanges" => content_changes
         })
 
         {:noreply, state}
@@ -853,6 +918,24 @@ defmodule Minga.LSP.Client do
         }
       }
     }
+  end
+
+  @spec extract_sync_kind(map()) :: :none | :full | :incremental
+  defp extract_sync_kind(capabilities) do
+    sync = get_in(capabilities, ["textDocumentSync"])
+
+    case sync do
+      # TextDocumentSyncOptions object
+      %{"change" => 2} -> :incremental
+      %{"change" => 1} -> :full
+      %{"change" => 0} -> :none
+      # Shorthand integer
+      2 -> :incremental
+      1 -> :full
+      0 -> :none
+      # Default to full
+      _ -> :full
+    end
   end
 
   @spec reply_to_caller(State.pending_from(), term()) :: :ok

--- a/lib/minga/lsp/sync_server.ex
+++ b/lib/minga/lsp/sync_server.ex
@@ -242,13 +242,47 @@ defmodule Minga.LSP.SyncServer do
 
   defp notify_clients_change(clients, buffer_pid) do
     with uri when is_binary(uri) <- buffer_uri(buffer_pid) do
-      {content, _cursor} = BufferServer.content_and_cursor(buffer_pid)
-      send_to_alive_clients(clients, fn c -> Client.did_change(c, uri, content) end)
+      # Collect edit deltas for incremental sync
+      deltas = BufferServer.flush_edits(buffer_pid)
+
+      send_to_alive_clients(clients, fn client ->
+        send_change(client, uri, buffer_pid, deltas)
+      end)
     end
 
     :ok
   catch
     :exit, _ -> :ok
+  end
+
+  # Sends a change notification using incremental sync if the server supports
+  # it and deltas are available, otherwise falls back to full sync.
+  @spec send_change(pid(), String.t(), pid(), [Minga.Buffer.EditDelta.t()]) :: :ok
+  defp send_change(client, uri, buffer_pid, deltas) do
+    sync_kind =
+      try do
+        Client.sync_kind(client)
+      catch
+        :exit, _ -> :full
+      end
+
+    case {sync_kind, deltas} do
+      {:incremental, [_ | _]} ->
+        changes = Enum.map(deltas, &delta_to_lsp_change/1)
+        Client.did_change_incremental(client, uri, changes)
+
+      _ ->
+        {content, _cursor} = BufferServer.content_and_cursor(buffer_pid)
+        Client.did_change(client, uri, content)
+    end
+  end
+
+  @spec delta_to_lsp_change(Minga.Buffer.EditDelta.t()) ::
+          {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer(), String.t()}
+  defp delta_to_lsp_change(delta) do
+    {sl, sc} = delta.start_position
+    {el, ec} = delta.old_end_position
+    {sl, sc, el, ec, delta.inserted_text}
   end
 
   @spec buffer_uri(pid()) :: String.t() | nil


### PR DESCRIPTION
## Incremental Document Sync (#639)
When the LSP server supports incremental sync (TextDocumentSyncKind 2), sends only changed ranges instead of full content on every keystroke. Falls back to full sync for servers that don't support it.

## Diagnostics ETS Optimization (#531)
Replaces full-table `ets.foldl` scan with:
- URI-indexed secondary ETS table for O(1) source lookup per URI
- Merge cache with per-URI invalidation
- `persistent_term` for reader access to secondary tables

All 33 diagnostics tests pass unchanged.

Closes #639, closes #531