### PR TITLE
fix(tool): fix GitHub release asset matching for all LSP servers

### DIFF
--- a/lib/minga/tool/installer/github_release.ex
+++ b/lib/minga/tool/installer/github_release.ex
@@ -4,15 +4,21 @@ defmodule Minga.Tool.Installer.GitHubRelease do
 
   Downloads pre-built binaries from a GitHub repository's latest release.
   Detects the current platform (OS + architecture) and selects the
-  matching asset. Handles .tar.gz, .gz, and .zip archives.
+  matching asset. Handles .tar.gz, .tar.xz, .gz, and .zip archives.
 
   ## Platform detection
 
   Maps `{:os.type(), :erlang.system_info(:system_architecture)}` to
-  standard platform suffixes used in release naming:
+  canonical platform names, then matches against common synonyms used
+  in release asset naming:
 
-  - `darwin_arm64` / `darwin_amd64` for macOS
-  - `linux_arm64` / `linux_amd64` for Linux
+  - OS: `"darwin"` also matches `"macos"` in asset names
+  - Arch: `"arm64"` also matches `"aarch64"`;
+          `"amd64"` also matches `"x86_64"` and `"x64"`
+
+  Only recognized archive formats (.tar.gz, .tar.xz, .gz, .zip) are
+  considered, filtering out signature files (.minisig, .sha256) and
+  editor extensions (.vsix).
 
   Recipes with non-standard naming can provide an `:asset_pattern`
   function for custom matching.
@@ -152,17 +158,37 @@ defmodule Minga.Tool.Installer.GitHubRelease do
     fn asset -> pattern.(asset["name"], suffix) end
   end
 
-  defp build_asset_matcher(_pattern, suffix) do
-    os = detect_os()
-    arch = detect_arch()
+  defp build_asset_matcher(_pattern, _suffix) do
+    os_names = os_synonyms(detect_os())
+    arch_names = arch_synonyms(detect_arch())
 
     fn asset ->
       name = String.downcase(asset["name"] || "")
 
-      (String.contains?(name, os) and String.contains?(name, arch)) or
-        String.contains?(name, suffix) or
-        String.contains?(name, String.replace(suffix, "_", "-"))
+      recognized_archive?(name) and
+        Enum.any?(os_names, &String.contains?(name, &1)) and
+        Enum.any?(arch_names, &String.contains?(name, &1))
     end
+  end
+
+  @spec os_synonyms(String.t()) :: [String.t()]
+  defp os_synonyms("darwin"), do: ["darwin", "macos"]
+  defp os_synonyms("linux"), do: ["linux"]
+  defp os_synonyms("windows"), do: ["windows", "win32", "win"]
+  defp os_synonyms(other), do: [other]
+
+  @spec arch_synonyms(String.t()) :: [String.t()]
+  defp arch_synonyms("arm64"), do: ["arm64", "aarch64"]
+  defp arch_synonyms("amd64"), do: ["amd64", "x86_64", "x64"]
+  defp arch_synonyms(other), do: [other]
+
+  @spec recognized_archive?(String.t()) :: boolean()
+  defp recognized_archive?(name) do
+    String.ends_with?(name, ".tar.gz") or
+      String.ends_with?(name, ".tgz") or
+      String.ends_with?(name, ".tar.xz") or
+      String.ends_with?(name, ".gz") or
+      String.ends_with?(name, ".zip")
   end
 
   @spec extract_version(map()) :: {:ok, String.t()} | {:error, term()}
@@ -204,15 +230,26 @@ defmodule Minga.Tool.Installer.GitHubRelease do
     end
   end
 
-  @type archive_type :: :tar_gz | :gz | :zip | :raw
+  @type archive_type :: :tar_gz | :tar_xz | :gz | :zip | :raw
 
   @spec detect_archive_type(String.t()) :: archive_type()
   defp detect_archive_type(name) do
+    detect_tar(name) || detect_single_compressed(name) || detect_zip_or_raw(name)
+  end
+
+  @spec detect_tar(String.t()) :: :tar_gz | :tar_xz | nil
+  defp detect_tar(name) do
     if String.ends_with?(name, ".tar.gz") or String.ends_with?(name, ".tgz") do
       :tar_gz
     else
-      if String.ends_with?(name, ".gz"), do: :gz, else: detect_zip_or_raw(name)
+      if String.ends_with?(name, ".tar.xz") or String.ends_with?(name, ".txz"),
+        do: :tar_xz
     end
+  end
+
+  @spec detect_single_compressed(String.t()) :: :gz | nil
+  defp detect_single_compressed(name) do
+    if String.ends_with?(name, ".gz"), do: :gz, else: nil
   end
 
   @spec detect_zip_or_raw(String.t()) :: :zip | :raw
@@ -224,6 +261,10 @@ defmodule Minga.Tool.Installer.GitHubRelease do
           {String.t(), integer()}
   defp run_extraction(:tar_gz, tmp_path, _asset_name, dest_dir) do
     System.cmd("tar", ["xzf", tmp_path, "-C", dest_dir], stderr_to_stdout: true)
+  end
+
+  defp run_extraction(:tar_xz, tmp_path, _asset_name, dest_dir) do
+    System.cmd("tar", ["xJf", tmp_path, "-C", dest_dir], stderr_to_stdout: true)
   end
 
   defp run_extraction(:gz, tmp_path, asset_name, dest_dir) do

--- a/lib/minga/tool/recipe/registry.ex
+++ b/lib/minga/tool/recipe/registry.ex
@@ -48,7 +48,8 @@ defmodule Minga.Tool.Recipe.Registry do
       package: "elixir-lsp/elixir-ls",
       homepage: "https://github.com/elixir-lsp/elixir-ls",
       category: :lsp_server,
-      languages: [:elixir]
+      languages: [:elixir],
+      asset_pattern: &Minga.Tool.Recipe.Registry.elixir_ls_asset?/2
     },
     %Recipe{
       name: :lexical,
@@ -59,7 +60,8 @@ defmodule Minga.Tool.Recipe.Registry do
       package: "lexical-lsp/lexical",
       homepage: "https://github.com/lexical-lsp/lexical",
       category: :lsp_server,
-      languages: [:elixir]
+      languages: [:elixir],
+      asset_pattern: &Minga.Tool.Recipe.Registry.lexical_asset?/2
     },
     %Recipe{
       name: :pyright,
@@ -92,8 +94,7 @@ defmodule Minga.Tool.Recipe.Registry do
       package: "rust-lang/rust-analyzer",
       homepage: "https://rust-analyzer.github.io",
       category: :lsp_server,
-      languages: [:rust],
-      asset_pattern: &Minga.Tool.Recipe.Registry.rust_analyzer_asset?/2
+      languages: [:rust]
     },
     %Recipe{
       name: :gopls,
@@ -170,7 +171,8 @@ defmodule Minga.Tool.Recipe.Registry do
       package: "clangd/clangd",
       homepage: "https://clangd.llvm.org",
       category: :lsp_server,
-      languages: [:c, :cpp]
+      languages: [:c, :cpp],
+      asset_pattern: &Minga.Tool.Recipe.Registry.clangd_asset?/2
     }
   ]
 
@@ -239,11 +241,58 @@ defmodule Minga.Tool.Recipe.Registry do
 
   # ── Asset pattern helpers ───────────────────────────────────────────────────
 
-  @doc false
-  @spec rust_analyzer_asset?(String.t(), String.t()) :: boolean()
-  def rust_analyzer_asset?(asset_name, platform_suffix) do
-    String.contains?(asset_name, platform_suffix) and
-      String.ends_with?(asset_name, ".gz") and
-      not String.contains?(asset_name, "sha256")
+  @doc """
+  Matches clangd release assets.
+
+  clangd uses "mac" instead of "darwin"/"macos" and ships one binary per
+  OS (no architecture in the filename, likely universal on macOS). We also
+  need to exclude `clangd_indexing_tools-*` assets.
+  """
+  @spec clangd_asset?(String.t(), String.t()) :: boolean()
+  def clangd_asset?(asset_name, platform_suffix) do
+    name = String.downcase(asset_name)
+    os_token = clangd_os_token(platform_suffix)
+
+    String.starts_with?(name, "clangd-") and
+      String.contains?(name, os_token) and
+      String.ends_with?(name, ".zip")
+  end
+
+  @spec clangd_os_token(String.t()) :: String.t()
+  defp clangd_os_token("darwin_" <> _), do: "mac"
+  defp clangd_os_token("linux_" <> _), do: "linux"
+  defp clangd_os_token("windows_" <> _), do: "windows"
+  defp clangd_os_token(_), do: "unknown"
+
+  @doc """
+  Matches ElixirLS release assets.
+
+  ElixirLS is a BEAM application that ships a single platform-independent
+  zip (e.g., `elixir-ls-v0.30.0.zip`). The default asset matcher fails
+  because it looks for OS/arch strings like `darwin_arm64` in the filename.
+  """
+  @spec elixir_ls_asset?(String.t(), String.t()) :: boolean()
+  def elixir_ls_asset?(asset_name, _platform_suffix) do
+    name = String.downcase(asset_name)
+
+    String.starts_with?(name, "elixir-ls") and
+      String.ends_with?(name, ".zip")
+  end
+
+  @doc """
+  Matches Lexical release assets.
+
+  Lexical is a BEAM application that ships platform-independent zips.
+  Releases include both a versioned zip (`lexical-v0.7.3.zip`) and a
+  plain `lexical.zip`. We prefer the versioned one to avoid cache
+  confusion across upgrades.
+  """
+  @spec lexical_asset?(String.t(), String.t()) :: boolean()
+  def lexical_asset?(asset_name, _platform_suffix) do
+    name = String.downcase(asset_name)
+
+    String.starts_with?(name, "lexical") and
+      String.ends_with?(name, ".zip") and
+      String.contains?(name, "-v")
   end
 end

--- a/test/minga/tool/installer/github_release_test.exs
+++ b/test/minga/tool/installer/github_release_test.exs
@@ -1,0 +1,20 @@
+defmodule Minga.Tool.Installer.GitHubReleaseTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Tool.Installer.GitHubRelease
+
+  describe "platform_suffix/0" do
+    test "returns a string with os_arch format" do
+      suffix = GitHubRelease.platform_suffix()
+      assert is_binary(suffix)
+      assert String.contains?(suffix, "_")
+    end
+
+    test "returns valid os and arch components" do
+      suffix = GitHubRelease.platform_suffix()
+      [os, arch] = String.split(suffix, "_", parts: 2)
+      assert os in ["darwin", "linux", "windows", "unknown"]
+      assert arch in ["arm64", "amd64"]
+    end
+  end
+end

--- a/test/minga/tool/recipe_registry_test.exs
+++ b/test/minga/tool/recipe_registry_test.exs
@@ -95,6 +95,76 @@ defmodule Minga.Tool.Recipe.RegistryTest do
     end
   end
 
+  describe "elixir_ls_asset?/2" do
+    test "matches the standard versioned zip" do
+      assert Registry.elixir_ls_asset?("elixir-ls-v0.30.0.zip", "darwin_arm64")
+    end
+
+    test "matches regardless of platform suffix" do
+      assert Registry.elixir_ls_asset?("elixir-ls-v0.30.0.zip", "linux_amd64")
+    end
+
+    test "rejects non-zip files" do
+      refute Registry.elixir_ls_asset?("elixir-ls-v0.30.0.tar.gz", "darwin_arm64")
+    end
+
+    test "rejects unrelated assets" do
+      refute Registry.elixir_ls_asset?("some-other-tool.zip", "darwin_arm64")
+    end
+  end
+
+  describe "lexical_asset?/2" do
+    test "matches the versioned zip" do
+      assert Registry.lexical_asset?("lexical-v0.7.3.zip", "darwin_arm64")
+    end
+
+    test "matches regardless of platform suffix" do
+      assert Registry.lexical_asset?("lexical-v0.7.3.zip", "linux_amd64")
+    end
+
+    test "rejects the unversioned zip to prefer the versioned one" do
+      refute Registry.lexical_asset?("lexical.zip", "darwin_arm64")
+    end
+
+    test "rejects non-zip files" do
+      refute Registry.lexical_asset?("lexical-v0.7.3.tar.gz", "darwin_arm64")
+    end
+
+    test "rejects unrelated assets" do
+      refute Registry.lexical_asset?("some-other-tool.zip", "darwin_arm64")
+    end
+  end
+
+  describe "clangd_asset?/2" do
+    test "matches the macOS asset with darwin suffix" do
+      assert Registry.clangd_asset?("clangd-mac-21.1.8.zip", "darwin_arm64")
+    end
+
+    test "matches the macOS asset with darwin amd64 suffix" do
+      assert Registry.clangd_asset?("clangd-mac-21.1.8.zip", "darwin_amd64")
+    end
+
+    test "matches the Linux asset with linux suffix" do
+      assert Registry.clangd_asset?("clangd-linux-21.1.8.zip", "linux_amd64")
+    end
+
+    test "rejects macOS asset when platform is linux" do
+      refute Registry.clangd_asset?("clangd-mac-21.1.8.zip", "linux_amd64")
+    end
+
+    test "rejects indexing tools asset" do
+      refute Registry.clangd_asset?("clangd_indexing_tools-mac-21.1.8.zip", "darwin_arm64")
+    end
+
+    test "matches the Windows asset with windows suffix" do
+      assert Registry.clangd_asset?("clangd-windows-21.1.8.zip", "windows_amd64")
+    end
+
+    test "rejects debug symbols asset" do
+      refute Registry.clangd_asset?("clangd-debug-symbols-windows-21.1.8.7z", "darwin_arm64")
+    end
+  end
+
   describe "for_language/1" do
     test "finds tools for Python" do
       tools = Registry.for_language(:python)


### PR DESCRIPTION
## Problem

Every `github_release` tool installation was broken on at least some platforms. The default asset matcher hardcoded one string per concept (`"darwin"` for macOS, `"arm64"`/`"amd64"` for arch) but real GitHub releases use many different naming conventions.

**Tools that were broken:**
| Tool | Asset name | Why it failed |
|------|-----------|---------------|
| ElixirLS | `elixir-ls-v0.30.0.zip` | Platform-independent BEAM app, no OS/arch in name |
| Lexical | `lexical-v0.7.3.zip` | Same, platform-independent BEAM app |
| ZLS | `zls-aarch64-macos.tar.xz` | Uses "macos" not "darwin", "aarch64" not "arm64", .tar.xz unsupported |
| StyLua | `stylua-macos-aarch64.zip` | Uses "macos" not "darwin", "aarch64" not "arm64" |
| clangd | `clangd-mac-21.1.8.zip` | Uses "mac" not "darwin", no arch in name |
| rust-analyzer | `...-aarch64-apple-darwin.gz` | Custom pattern checked for "darwin_arm64" substring not in name |
| lua-language-server | `...-darwin-x64.tar.gz` | Uses "x64" not "amd64" (broken on Intel) |

## Fix

**Improved default matcher** with synonym lists (verified against Mason registry for correctness):
- OS: `"darwin"` also matches `"macos"`
- Arch: `"arm64"` matches `"aarch64"`; `"amd64"` matches `"x86_64"`, `"x64"`
- Archive format filter so `.minisig`, `.vsix`, `.sha256` files are never matched
- `.tar.xz` extraction support (ZLS needs it)

**Custom patterns** only where naming is truly non-standard:
- ElixirLS/Lexical: platform-independent BEAM apps
- clangd: uses "mac" for OS, no arch in filename

**Removed** the broken `rust_analyzer_asset?/2` (improved default matcher handles it).

## Testing

48 tool tests pass, 5960 total tests pass. New tests cover all custom asset patterns with positive matches, cross-platform variants, and rejection cases.