### PR TITLE
fix(lsp): close remaining gaps from post-merge audit of #892

### DIFF
--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -260,6 +260,7 @@ defmodule Minga.Buffer.Server do
   Deprecated: use `flush_edits/2` with a consumer_id for per-consumer cursors.
   This legacy version destructively drains the shared pending_edits list.
   """
+  @deprecated "Use flush_edits/2 with a consumer_id instead"
   @spec flush_edits(GenServer.server()) :: [EditDelta.t()]
   def flush_edits(server) do
     GenServer.call(server, :flush_edits)
@@ -1122,10 +1123,9 @@ defmodule Minga.Buffer.Server do
     new_cursor = state.edit_seq
     new_cursors = Map.put(state.consumer_cursors, consumer_id, new_cursor)
 
-    # Trim log entries that all *registered* consumers have read,
-    # but only if we have at least 2 consumers registered (both known
-    # consumers are active). With fewer than 2, keep the full log so
-    # a consumer that hasn't registered yet can still read historical entries.
+    # Trim log entries that all *registered* consumers have read.
+    # When only one consumer is registered, cap the log at @max_single_consumer_log
+    # to prevent unbounded growth if the second consumer never arrives.
     trimmed_log =
       if map_size(new_cursors) >= 2 do
         min_cursor =
@@ -1135,7 +1135,7 @@ defmodule Minga.Buffer.Server do
 
         Enum.filter(state.edit_log, fn {seq, _} -> seq > min_cursor end)
       else
-        state.edit_log
+        cap_log(state.edit_log)
       end
 
     new_state = %{state | consumer_cursors: new_cursors, edit_log: trimmed_log}
@@ -1683,6 +1683,19 @@ defmodule Minga.Buffer.Server do
   defp clear_edits(state) do
     %{state | pending_edits: [], edit_log: [], consumer_cursors: %{}}
   end
+
+  # Maximum edit_log entries retained when only one consumer is registered.
+  # Prevents unbounded growth if the second consumer never calls flush_edits.
+  # At this limit, older entries are dropped (the lagging consumer will get a
+  # partial log and must fall back to full sync).
+  @max_single_consumer_log 1000
+
+  # Keeps only the most recent @max_single_consumer_log entries.
+  # The edit_log is stored newest-first (prepended in record_edit),
+  # so Enum.take gets the most recent entries. Enum.take is a no-op
+  # when the list is already shorter than the limit.
+  @spec cap_log([{non_neg_integer(), EditDelta.t()}]) :: [{non_neg_integer(), EditDelta.t()}]
+  defp cap_log(log), do: Enum.take(log, @max_single_consumer_log)
 
   # Compute byte offset for a {line, col} position in content.
   @spec byte_offset_at(String.t(), {non_neg_integer(), non_neg_integer()}) :: non_neg_integer()

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -376,6 +376,9 @@ defmodule Minga.Editor do
     new_state =
       Input.Router.dispatch_mouse(state, row, col, button, mods, event_type, click_count)
 
+    # Scroll wheel events change the viewport; schedule inlay hint refresh.
+    # The function no-ops if the viewport top hasn't actually changed.
+    new_state = LspActions.schedule_inlay_hints_on_scroll(new_state)
     new_state = Renderer.render(new_state)
     {:noreply, new_state}
   end
@@ -386,6 +389,7 @@ defmodule Minga.Editor do
         state
       ) do
     new_state = Input.Router.dispatch_mouse(state, row, col, button, mods, event_type, 1)
+    new_state = LspActions.schedule_inlay_hints_on_scroll(new_state)
     new_state = Renderer.render(new_state)
     {:noreply, new_state}
   end

--- a/lib/minga/editor/lsp_actions.ex
+++ b/lib/minga/editor/lsp_actions.ex
@@ -570,7 +570,7 @@ defmodule Minga.Editor.LspActions do
   def schedule_inlay_hints_on_scroll(%{buffers: %{active: nil}} = state), do: state
 
   def schedule_inlay_hints_on_scroll(state) do
-    vp_top = state.viewport.top
+    vp_top = effective_viewport_top(state)
 
     if vp_top == state.last_inlay_viewport_top do
       state
@@ -592,6 +592,16 @@ defmodule Minga.Editor.LspActions do
     Process.cancel_timer(timer)
     %{state | inlay_hint_debounce_timer: nil}
   end
+
+  # Returns the viewport top for the active window, falling back to
+  # state.viewport.top. Uses EditorState.active_window_viewport when
+  # the state is a proper struct, otherwise reads state.viewport directly.
+  @spec effective_viewport_top(state()) :: non_neg_integer()
+  defp effective_viewport_top(%EditorState{} = state) do
+    EditorState.active_window_viewport(state).top
+  end
+
+  defp effective_viewport_top(state), do: state.viewport.top
 
   # ── Response handlers ──────────────────────────────────────────────────────
 

--- a/test/minga/buffer/server_test.exs
+++ b/test/minga/buffer/server_test.exs
@@ -609,7 +609,7 @@ defmodule Minga.Buffer.ServerTest do
       {:ok, pid} = Server.start_link(content: "hello")
       Server.move_to(pid, {0, 5})
       Server.insert_char(pid, "!")
-      edits = Server.flush_edits(pid)
+      edits = Server.flush_edits(pid, :test)
       assert [delta] = edits
       assert delta.start_byte == 5
       assert delta.old_end_byte == 5
@@ -621,7 +621,7 @@ defmodule Minga.Buffer.ServerTest do
       {:ok, pid} = Server.start_link(content: "hello")
       Server.move_to(pid, {0, 5})
       Server.delete_before(pid)
-      edits = Server.flush_edits(pid)
+      edits = Server.flush_edits(pid, :test)
       assert [delta] = edits
       assert delta.start_byte == 4
       assert delta.old_end_byte == 5
@@ -629,12 +629,12 @@ defmodule Minga.Buffer.ServerTest do
       assert delta.inserted_text == ""
     end
 
-    test "flush_edits clears pending deltas" do
+    test "flush_edits clears pending deltas for that consumer" do
       {:ok, pid} = Server.start_link(content: "hello")
       Server.move_to(pid, {0, 5})
       Server.insert_char(pid, "!")
-      assert [_] = Server.flush_edits(pid)
-      assert [] = Server.flush_edits(pid)
+      assert [_] = Server.flush_edits(pid, :test)
+      assert [] = Server.flush_edits(pid, :test)
     end
 
     test "multiple edits accumulate in order" do
@@ -642,7 +642,7 @@ defmodule Minga.Buffer.ServerTest do
       Server.move_to(pid, {0, 2})
       Server.insert_char(pid, "c")
       Server.insert_char(pid, "d")
-      edits = Server.flush_edits(pid)
+      edits = Server.flush_edits(pid, :test)
       assert length(edits) == 2
       assert [first, second] = edits
       assert first.inserted_text == "c"
@@ -652,7 +652,7 @@ defmodule Minga.Buffer.ServerTest do
     test "delete_range records a deletion delta" do
       {:ok, pid} = Server.start_link(content: "hello world")
       Server.delete_range(pid, {0, 5}, {0, 11})
-      edits = Server.flush_edits(pid)
+      edits = Server.flush_edits(pid, :test)
       assert [delta] = edits
       assert delta.start_byte == 5
       assert delta.old_end_byte == 11
@@ -664,12 +664,12 @@ defmodule Minga.Buffer.ServerTest do
       {:ok, pid} = Server.start_link(content: "hello")
       Server.move_to(pid, {0, 5})
       Server.insert_char(pid, "!")
-      assert [_] = Server.flush_edits(pid)
+      assert [_] = Server.flush_edits(pid, :test)
       # Make another edit then undo
       Server.insert_char(pid, "?")
       Server.undo(pid)
       # Undo clears edits to force full sync
-      assert [] = Server.flush_edits(pid)
+      assert [] = Server.flush_edits(pid, :test)
     end
 
     test "replace_content clears pending edits" do
@@ -677,7 +677,7 @@ defmodule Minga.Buffer.ServerTest do
       Server.move_to(pid, {0, 5})
       Server.insert_char(pid, "!")
       Server.replace_content(pid, "goodbye")
-      assert [] = Server.flush_edits(pid)
+      assert [] = Server.flush_edits(pid, :test)
     end
   end
 
@@ -824,6 +824,20 @@ defmodule Minga.Buffer.ServerTest do
       Server.insert_char(pid, "!")
       assert [_] = Server.flush_edits(pid, :lsp)
       assert [] = Server.flush_edits(pid, :lsp)
+    end
+
+    test "edit_log is capped at 1000 entries when only one consumer is registered" do
+      {:ok, pid} = Server.start_link(content: "")
+
+      # Insert more than 1000 chars with only :lsp reading periodically
+      for _ <- 1..1100, do: Server.insert_char(pid, "x")
+
+      # Only one consumer has ever called flush_edits
+      _deltas = Server.flush_edits(pid, :lsp)
+
+      # Internal log should be capped, not grow to 1100
+      internal = :sys.get_state(pid)
+      assert length(internal.edit_log) <= 1000
     end
   end
 


### PR DESCRIPTION
## What

Follow-up fixes for gaps found during an independent audit of PR #892 ("fix(lsp): close all gaps from feature parity sprint").

## Changes

### 1. Mouse scroll triggers inlay hint refresh
`schedule_inlay_hints_on_scroll` was only called from the keyboard input path (`Router.post_key_housekeeping`). Mouse wheel events that change the viewport now also schedule a debounced inlay hint refresh. The function already no-ops when the viewport top hasn't changed, so calling it after every mouse event is safe.

### 2. Viewport top read from active window, not terminal viewport
`schedule_inlay_hints_on_scroll` was reading `state.viewport.top` (the terminal-level viewport), which doesn't reflect per-window scroll position. Now reads via `EditorState.active_window_viewport` to get the actual scroll position of the focused window.

### 3. `flush_edits/1` formally deprecated
Added `@deprecated` attribute so callers get compile-time warnings. Migrated legacy edit delta tracking tests to `flush_edits/2`.

### 4. edit_log bounded for single-consumer edge case
When only one consumer is registered, the edit_log is now capped at 1000 entries via `Enum.take`. Prevents unbounded growth if the second consumer (tree-sitter or LSP) never calls `flush_edits`.

### 5. Clause grouping warning fixed
Moved `cap_log/1` and `@max_single_consumer_log` out from between `handle_call` clauses to eliminate the clause grouping warning under `--warnings-as-errors`.

## Testing

149 tests in the affected files, 0 failures. Full suite: 5996 tests, 0 failures.