### PR TITLE
feat(tool): show install error reason inline in tool manager

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -403,6 +403,7 @@ Per tool:
   + version_len(1) + version(version_len)
   + homepage_len(2) + homepage(homepage_len)
   + provides_count(1) + provides...
+  + error_reason_len(2) + error_reason(error_reason_len)
 
 Per language:
   lang_len(1) + lang(lang_len)
@@ -438,6 +439,7 @@ Status values:
 | 1 | installed |
 | 2 | installing |
 | 3 | update_available |
+| 4 | failed |
 
 Method values:
 | Value | Method |

--- a/lib/minga/port/protocol/gui.ex
+++ b/lib/minga/port/protocol/gui.ex
@@ -1168,6 +1168,7 @@ defmodule Minga.Port.Protocol.GUI do
         + version_len(1) + version(version_len)
         + homepage_len(2) + homepage(homepage_len)
         + provides_count(1) + provides...
+        + error_reason_len(2) + error_reason(error_reason_len)
 
       Per language:
         lang_len(1) + lang(lang_len)
@@ -1186,6 +1187,7 @@ defmodule Minga.Port.Protocol.GUI do
   | 1     | installed       |
   | 2     | installing      |
   | 3     | update_available|
+  | 4     | failed          |
 
   ## Category values
 
@@ -1243,6 +1245,8 @@ defmodule Minga.Port.Protocol.GUI do
         version_len = byte_size(version)
         homepage = tool.homepage || ""
         homepage_len = byte_size(homepage)
+        error_reason = tool.error_reason || ""
+        error_reason_len = byte_size(error_reason)
 
         lang_data =
           Enum.map(tool.languages, fn lang ->
@@ -1260,7 +1264,8 @@ defmodule Minga.Port.Protocol.GUI do
           IO.iodata_to_binary(lang_data) <>
           <<version_len::8, version::binary, homepage_len::16, homepage::binary,
             length(tool.provides)::8>> <>
-          IO.iodata_to_binary(provides_data)
+          IO.iodata_to_binary(provides_data) <>
+          <<error_reason_len::16, error_reason::binary>>
       end)
 
     <<@op_gui_tool_manager, 1::8, filter_byte::8, selected::16, tool_count::16>> <>

--- a/lib/minga/tool/manager.ex
+++ b/lib/minga/tool/manager.ex
@@ -45,14 +45,14 @@ defmodule Minga.Tool.Manager do
     defstruct [
       :table,
       installing: MapSet.new(),
-      failed: MapSet.new(),
+      failed: %{},
       task_refs: %{}
     ]
 
     @type t :: %__MODULE__{
             table: :ets.tid(),
             installing: MapSet.t(atom()),
-            failed: MapSet.t(atom()),
+            failed: %{atom() => String.t()},
             task_refs: %{reference() => atom()}
           }
   end
@@ -123,12 +123,19 @@ defmodule Minga.Tool.Manager do
 
   @doc """
   Returns the status of every known tool (installed, installing, not_installed,
-  update_available) along with version info.
+  update_available, failed) along with version and error info.
 
   Returns a list of maps suitable for UI rendering:
-  `%{recipe: Recipe.t(), status: tool_status(), installed_version: String.t() | nil}`
+  `%{recipe: Recipe.t(), status: tool_status(), installed_version: String.t() | nil, error_reason: String.t() | nil}`
   """
-  @spec tool_status_list() :: [map()]
+  @spec tool_status_list() :: [
+          %{
+            recipe: Recipe.t(),
+            status: tool_status(),
+            installed_version: String.t() | nil,
+            error_reason: String.t() | nil
+          }
+        ]
   def tool_status_list do
     GenServer.call(__MODULE__, :tool_status_list)
   end
@@ -216,12 +223,13 @@ defmodule Minga.Tool.Manager do
 
     statuses =
       Enum.map(recipes, fn recipe ->
-        {status, version} = tool_status(recipe.name, state)
+        {status, version, error_reason} = tool_status(recipe.name, state)
 
         %{
           recipe: recipe,
           status: status,
-          installed_version: version
+          installed_version: version,
+          error_reason: error_reason
         }
       end)
       |> Enum.sort_by(fn %{recipe: r} -> {status_sort_order(r.name, state), r.label} end)
@@ -255,12 +263,13 @@ defmodule Minga.Tool.Manager do
               record_installation(recipe, version)
               broadcast(:tool_install_complete, %{name: name, version: version})
               log_message("Tool installed: #{recipe.label} v#{version}")
-              %{state | failed: MapSet.delete(state.failed, name)}
+              %{state | failed: Map.delete(state.failed, name)}
 
             {:error, reason} ->
+              reason_str = format_error_reason(reason)
               broadcast(:tool_install_failed, %{name: name, reason: reason})
-              log_message("Tool install failed: #{name} - #{inspect(reason)}")
-              %{state | failed: MapSet.put(state.failed, name)}
+              log_message("Tool install failed: #{name} - #{reason_str}")
+              %{state | failed: Map.put(state.failed, name, reason_str)}
           end
 
         {:noreply, state}
@@ -273,10 +282,11 @@ defmodule Minga.Tool.Manager do
         {:noreply, state}
 
       {name, task_refs} ->
+        reason_str = format_error_reason(reason)
         state = %{state | task_refs: task_refs, installing: MapSet.delete(state.installing, name)}
-        state = %{state | failed: MapSet.put(state.failed, name)}
+        state = %{state | failed: Map.put(state.failed, name, reason_str)}
         broadcast(:tool_install_failed, %{name: name, reason: reason})
-        log_message("Tool install crashed: #{name} - #{inspect(reason)}")
+        log_message("Tool install crashed: #{name} - #{reason_str}")
         {:noreply, state}
     end
   end
@@ -296,28 +306,29 @@ defmodule Minga.Tool.Manager do
     end
   end
 
-  @spec tool_status(atom(), map()) :: {tool_status(), String.t() | nil}
+  @spec tool_status(atom(), map()) :: {tool_status(), String.t() | nil, String.t() | nil}
   defp tool_status(name, state) do
     tool_status_for(name, state.installing, state.failed)
   end
 
-  @spec tool_status_for(atom(), MapSet.t(), MapSet.t()) :: {tool_status(), String.t() | nil}
+  @spec tool_status_for(atom(), MapSet.t(), %{atom() => String.t()}) ::
+          {tool_status(), String.t() | nil, String.t() | nil}
   defp tool_status_for(name, installing, failed) do
-    cond_tool_status(
-      MapSet.member?(installing, name),
-      MapSet.member?(failed, name),
-      name
-    )
+    if MapSet.member?(installing, name) do
+      {:installing, nil, nil}
+    else
+      case Map.get(failed, name) do
+        nil -> installed_status(name)
+        reason -> {:failed, nil, reason}
+      end
+    end
   end
 
-  @spec cond_tool_status(boolean(), boolean(), atom()) :: {tool_status(), String.t() | nil}
-  defp cond_tool_status(true, _, _name), do: {:installing, nil}
-  defp cond_tool_status(_, true, _name), do: {:failed, nil}
-
-  defp cond_tool_status(false, false, name) do
+  @spec installed_status(atom()) :: {tool_status(), String.t() | nil, String.t() | nil}
+  defp installed_status(name) do
     case get_installation(name) do
-      %Installation{version: version} -> {:installed, version}
-      nil -> {:not_installed, nil}
+      %Installation{version: version} -> {:installed, version, nil}
+      nil -> {:not_installed, nil, nil}
     end
   end
 
@@ -371,7 +382,7 @@ defmodule Minga.Tool.Manager do
     %{
       state
       | installing: MapSet.put(state.installing, name),
-        failed: MapSet.delete(state.failed, name),
+        failed: Map.delete(state.failed, name),
         task_refs: Map.put(state.task_refs, task.ref, name)
     }
   end
@@ -505,7 +516,7 @@ defmodule Minga.Tool.Manager do
 
   @spec status_sort_order(atom(), map()) :: non_neg_integer()
   defp status_sort_order(name, state) do
-    {status, _} = tool_status(name, state)
+    {status, _, _} = tool_status(name, state)
     status_order(status)
   end
 
@@ -516,6 +527,10 @@ defmodule Minga.Tool.Manager do
   defp status_order(:failed), do: 0
   defp status_order(:installed), do: 1
   defp status_order(:not_installed), do: 2
+
+  @spec format_error_reason(term()) :: String.t()
+  defp format_error_reason(reason) when is_binary(reason), do: reason
+  defp format_error_reason(reason), do: inspect(reason, limit: 200)
 
   @spec broadcast(atom(), map()) :: :ok
   defp broadcast(topic, payload) do

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -57,6 +57,7 @@ struct GUIToolEntry {
     let version: String
     let homepage: String
     let provides: [String]
+    let errorReason: String
 }
 
 /// Line number display style from the BEAM.
@@ -1277,11 +1278,20 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 pos += cLen
                 provides.append(cmd)
             }
+            // error_reason_len(2) + error_reason
+            guard data.count >= pos + 2 else { throw ProtocolDecodeError.malformed }
+            let errLen = Int(readU16(data, pos)); pos += 2
+            guard data.count >= pos + errLen else { throw ProtocolDecodeError.malformed }
+            let errorReason = errLen > 0
+                ? (String(data: data[pos..<(pos + errLen)], encoding: .utf8) ?? "")
+                : ""
+            pos += errLen
             tools.append(GUIToolEntry(
                 name: name, label: toolLabel, description: desc,
                 category: cat, status: stat, method: meth,
                 languages: langs, version: version,
-                homepage: homepage, provides: provides
+                homepage: homepage, provides: provides,
+                errorReason: errorReason
             ))
         }
         return (.guiToolManager(visible: true, filter: tmFilter,

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -282,7 +282,8 @@ final class CommandDispatcher {
                         languages: t.languages,
                         version: t.version,
                         homepage: t.homepage,
-                        provides: t.provides
+                        provides: t.provides,
+                        errorReason: t.errorReason
                     )
                 }
                 guiState.toolManagerState.update(

--- a/macos/Sources/Views/ToolManagerState.swift
+++ b/macos/Sources/Views/ToolManagerState.swift
@@ -109,6 +109,7 @@ struct ToolEntry: Identifiable {
     let version: String
     let homepage: String
     let provides: [String]
+    let errorReason: String
 }
 
 // MARK: - Observable state

--- a/macos/Sources/Views/ToolManagerView.swift
+++ b/macos/Sources/Views/ToolManagerView.swift
@@ -16,6 +16,7 @@ struct ToolManagerView: View {
     private let panelWidth: CGFloat = 680
     private let panelMaxHeight: CGFloat = 520
     private let itemHeight: CGFloat = 64
+    private let failedItemHeight: CGFloat = 96
 
     var body: some View {
         if state.visible {
@@ -188,6 +189,9 @@ struct ToolManagerView: View {
 
     @ViewBuilder
     private func toolRow(_ tool: ToolEntry, isSelected: Bool) -> some View {
+        let hasError = tool.status == .failed && !tool.errorReason.isEmpty
+        let rowHeight = hasError ? failedItemHeight : itemHeight
+
         HStack(spacing: 12) {
             // Category icon
             categoryIcon(tool.category)
@@ -213,33 +217,43 @@ struct ToolManagerView: View {
                     .foregroundStyle(theme.popupFg.opacity(0.45))
                     .lineLimit(1)
 
-                // Languages and commands
-                HStack(spacing: 8) {
-                    if !tool.languages.isEmpty {
-                        HStack(spacing: 3) {
-                            Image(systemName: "globe")
-                                .font(.system(size: 9))
-                            Text(tool.languages.joined(separator: ", "))
-                                .font(.system(size: 10))
+                if hasError {
+                    // Inline error detail for failed tools
+                    Text(tool.errorReason)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(Color(red: 1.0, green: 0.47, blue: 0.47).opacity(0.8))
+                        .lineLimit(2)
+                        .truncationMode(.tail)
+                        .padding(.top, 2)
+                } else {
+                    // Languages and commands (hidden when showing error)
+                    HStack(spacing: 8) {
+                        if !tool.languages.isEmpty {
+                            HStack(spacing: 3) {
+                                Image(systemName: "globe")
+                                    .font(.system(size: 9))
+                                Text(tool.languages.joined(separator: ", "))
+                                    .font(.system(size: 10))
+                            }
+                            .foregroundStyle(theme.popupFg.opacity(0.3))
                         }
-                        .foregroundStyle(theme.popupFg.opacity(0.3))
-                    }
 
-                    if !tool.provides.isEmpty {
-                        HStack(spacing: 3) {
-                            Image(systemName: "terminal")
-                                .font(.system(size: 9))
-                            Text(tool.provides.joined(separator: ", "))
-                                .font(.system(size: 10, design: .monospaced))
+                        if !tool.provides.isEmpty {
+                            HStack(spacing: 3) {
+                                Image(systemName: "terminal")
+                                    .font(.system(size: 9))
+                                Text(tool.provides.joined(separator: ", "))
+                                    .font(.system(size: 10, design: .monospaced))
+                            }
+                            .foregroundStyle(theme.popupFg.opacity(0.3))
                         }
-                        .foregroundStyle(theme.popupFg.opacity(0.3))
                     }
                 }
             }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 8)
-        .frame(height: itemHeight)
+        .frame(minHeight: rowHeight)
         .background(
             isSelected
                 ? RoundedRectangle(cornerRadius: 6)

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -180,10 +180,15 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
 
     case .guiToolManager(let visible, let filter, let selectedIndex, let tools):
         let toolArray = tools.map { t -> [String: Any] in
-            ["name": t.name, "label": t.label, "description": t.description,
-             "category": Int(t.category), "status": Int(t.status), "method": Int(t.method),
-             "languages": t.languages, "version": t.version, "homepage": t.homepage,
-             "provides": t.provides]
+            var entry: [String: Any] = [
+                "name": t.name, "label": t.label, "description": t.description,
+                "category": Int(t.category), "status": Int(t.status), "method": Int(t.method),
+                "languages": t.languages, "version": t.version, "homepage": t.homepage,
+                "provides": t.provides]
+            if !t.errorReason.isEmpty {
+                entry["error_reason"] = t.errorReason
+            }
+            return entry
         }
         return ["type": "gui_tool_manager", "visible": visible, "filter": Int(filter),
                 "selected_index": Int(selectedIndex), "tools": toolArray]

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -284,7 +284,8 @@ struct CommandDispatcherRoutingTests {
         let tools = [GUIToolEntry(name: "elixir_ls", label: "ElixirLS",
                                   description: "LSP", category: 0, status: 1,
                                   method: 0, languages: ["elixir"], version: "0.22",
-                                  homepage: "", provides: ["elixir-ls"])]
+                                  homepage: "", provides: ["elixir-ls"],
+                                  errorReason: "")]
         dispatcher.dispatch(.guiToolManager(visible: true, filter: 0,
                                              selectedIndex: 0, tools: tools))
 

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -1130,6 +1130,7 @@ struct GUIToolManagerDecoderTests {
         appendString16(&data, "https://github.com/elixir-lsp/elixir-ls") // homepage
         data.append(1) // providesCount
         appendString8(&data, "elixir-ls") // provides
+        appendString16(&data, "") // errorReason (empty for installed)
 
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
@@ -1150,6 +1151,7 @@ struct GUIToolManagerDecoderTests {
         #expect(tools[0].languages == ["elixir"])
         #expect(tools[0].version == "0.22.1")
         #expect(tools[0].provides == ["elixir-ls"])
+        #expect(tools[0].errorReason == "")
     }
 
     @Test("Decode gui_tool_manager hidden")

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -336,13 +336,13 @@ struct ToolManagerStateLifecycleTests {
         let state = ToolManagerState()
         state.tools = [
             ToolEntry(id: "a", name: "a", label: "A", description: "", category: .lspServer,
-                     status: .installed, method: .npm, languages: [], version: "", homepage: "", provides: []),
+                     status: .installed, method: .npm, languages: [], version: "", homepage: "", provides: [], errorReason: ""),
             ToolEntry(id: "b", name: "b", label: "B", description: "", category: .formatter,
-                     status: .notInstalled, method: .pip, languages: [], version: "", homepage: "", provides: []),
+                     status: .notInstalled, method: .pip, languages: [], version: "", homepage: "", provides: [], errorReason: ""),
             ToolEntry(id: "c", name: "c", label: "C", description: "", category: .linter,
-                     status: .installing, method: .cargo, languages: [], version: "", homepage: "", provides: []),
+                     status: .installing, method: .cargo, languages: [], version: "", homepage: "", provides: [], errorReason: ""),
             ToolEntry(id: "d", name: "d", label: "D", description: "", category: .debugger,
-                     status: .updateAvailable, method: .goInstall, languages: [], version: "", homepage: "", provides: [])
+                     status: .updateAvailable, method: .goInstall, languages: [], version: "", homepage: "", provides: [], errorReason: "")
         ]
 
         #expect(state.installedCount == 2) // installed + updateAvailable
@@ -355,7 +355,7 @@ struct ToolManagerStateLifecycleTests {
         let state = ToolManagerState()
         state.tools = [
             ToolEntry(id: "a", name: "a", label: "A", description: "", category: .lspServer,
-                     status: .installed, method: .npm, languages: [], version: "", homepage: "", provides: [])
+                     status: .installed, method: .npm, languages: [], version: "", homepage: "", provides: [], errorReason: "")
         ]
         state.hide()
 

--- a/test/minga/integration/gui_protocol_test.exs
+++ b/test/minga/integration/gui_protocol_test.exs
@@ -584,7 +584,8 @@ defmodule Minga.Integration.GUIProtocolTest do
       # Tool: name_len(1)+name, label_len(1)+label, desc_len(2)+desc,
       #       category(1)+status(1)+method(1)+lang_count(1),
       #       lang_len(1)+lang, version_len(1)+version,
-      #       homepage_len(2)+homepage, provides_count(1)+provides_len(1)+provides
+      #       homepage_len(2)+homepage, provides_count(1)+provides_len(1)+provides,
+      #       error_reason_len(2)+error_reason
       name = "elixir_ls"
       label = "ElixirLS"
       desc = "Elixir LSP"
@@ -597,7 +598,7 @@ defmodule Minga.Integration.GUIProtocolTest do
         <<byte_size(name)::8, name::binary, byte_size(label)::8, label::binary,
           byte_size(desc)::16, desc::binary, 0::8, 1::8, 0::8, 1::8, byte_size(lang)::8,
           lang::binary, byte_size(version)::8, version::binary, byte_size(homepage)::16,
-          homepage::binary, 1::8, byte_size(provides)::8, provides::binary>>
+          homepage::binary, 1::8, byte_size(provides)::8, provides::binary, 0::16>>
 
       cmd = <<0x7E, 1::8, 0::8, 0::16, 1::16, tool::binary>>
 
@@ -621,6 +622,58 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert t["version"] == "0.22"
       assert t["homepage"] == "https://github.com/elixir-lsp/elixir-ls"
       assert t["provides"] == ["elixir-ls"]
+    end
+
+    test "round-trips failed tool with error reason", %{port: port} do
+      error = "No matching asset for darwin_arm64"
+
+      tool =
+        <<5::8, "pyrit"::binary, 6::8, "Pyrite"::binary, 4::16, "Test"::binary, 0::8, 4::8, 0::8,
+          0::8, 0::8, ""::binary, 0::16, ""::binary, 0::8, byte_size(error)::16, error::binary>>
+
+      cmd = <<0x7E, 1::8, 0::8, 0::16, 1::16, tool::binary>>
+
+      Port.command(port, cmd)
+
+      assert_receive {^port, {:data, json}}, 5_000
+      decoded = Jason.decode!(json)
+
+      t = hd(decoded["tools"])
+      assert t["status"] == 4
+      assert t["error_reason"] == "No matching asset for darwin_arm64"
+    end
+
+    test "encodes failed tool error_reason through Elixir encoder", %{port: port} do
+      tool = %{
+        name: :pyrite,
+        label: "Pyrite",
+        description: "Test",
+        category: :lsp_server,
+        status: :failed,
+        method: :npm,
+        languages: [],
+        version: nil,
+        homepage: nil,
+        provides: [],
+        error_reason: "No matching asset for darwin_arm64"
+      }
+
+      cmd =
+        ProtocolGUI.encode_gui_tool_manager(%{
+          visible: true,
+          filter: :all,
+          selected_index: 0,
+          tools: [tool]
+        })
+
+      Port.command(port, cmd)
+
+      assert_receive {^port, {:data, json}}, 5_000
+      decoded = Jason.decode!(json)
+
+      t = hd(decoded["tools"])
+      assert t["status"] == 4
+      assert t["error_reason"] == "No matching asset for darwin_arm64"
     end
   end
 


### PR DESCRIPTION
## Problem

When a tool installation fails, the error reason was only shown as a truncated single line in the message bar at the bottom of the screen. The GUI's Tool Manager panel showed "✕ Failed" but couldn't tell the user *why* it failed, because the error reason wasn't sent through the protocol.

## Fix

Preserve the error reason in Manager state and send it through the wire protocol to the GUI frontend, where it's displayed inline in the tool row.

### BEAM side
- `Manager.State.failed` changed from `MapSet` to `Map` (name → reason string) so the error reason survives past the install task completion
- `tool_status_list/0` now returns `error_reason` field
- Protocol wire format extended: `error_reason_len(2) + error_reason` appended after `provides` in per-tool encoding
- `docs/GUI_PROTOCOL.md` updated with new field and status value 4 (failed)

### Swift side
- `GUIToolEntry` and `ToolEntry` gain `errorReason: String`
- `ProtocolDecoder` reads the new field with `guard...throw` pattern
- `ToolManagerView` shows error inline below the description in monospaced red text (2-line limit). Failed tools get a taller row (96pt vs 64pt)

### Testing
- GUI protocol round-trip test for raw binary with error reason
- Elixir encoder round-trip test through TestHarness
- Swift decoder test updated
- All 5962 tests pass, lint clean