### PR TITLE
fix(cli): silence noisy output from bin/minga-mac launch

### DIFF
--- a/bin/minga-mac
+++ b/bin/minga-mac
@@ -14,8 +14,11 @@ PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 XCODEPROJ="$PROJECT_DIR/macos/Minga.xcodeproj"
 
 # Build the macOS renderer if needed.
+ARCH=$(uname -m)
 echo "Building minga-mac..."
-xcodebuild -project "$XCODEPROJ" -scheme minga-mac -configuration Debug build -quiet 2>&1 | grep -v "^$" || true
+xcodebuild -project "$XCODEPROJ" -scheme minga-mac -configuration Debug \
+  -destination "platform=macOS,arch=$ARCH" build -quiet 2>&1 \
+  | grep -vE "^$|^note:|^Run script build phase" || true
 echo "Build complete."
 
 exec elixir -S mix run --no-halt --no-start \

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,5 @@
 import Config
+
+# Suppress routine info-level startup logs on the console.
+# Subsystem-specific debug logging still goes to *Messages* when enabled.
+config :logger, level: :warning

--- a/lib/minga/log.ex
+++ b/lib/minga/log.ex
@@ -42,11 +42,18 @@ defmodule Minga.Log do
 
   @type level :: :debug | :info | :warning | :error
 
+  # Covers both Minga's own levels and OTP Logger primary levels
+  # (all, notice, critical, alert, emergency) used in maybe_route_to_messages/2.
   @level_priority %{
+    all: 0,
     debug: 0,
     info: 1,
+    notice: 1,
     warning: 2,
     error: 3,
+    critical: 3,
+    alert: 3,
+    emergency: 3,
     none: 4
   }
 
@@ -114,11 +121,33 @@ defmodule Minga.Log do
           msg when is_binary(msg) -> msg
         end
 
+      # Route to *Messages* directly when the OTP primary level filter
+      # would suppress this message (e.g., :info suppressed by level: :warning).
+      # For levels that pass the OTP filter, Minga.LoggerHandler already
+      # routes to *Messages* so we stay out of the way to avoid duplicates.
+      maybe_route_to_messages(level, subsystem, message)
+
       case level do
         :debug -> Logger.debug(message)
         :info -> Logger.info(message)
         :warning -> Logger.warning(message)
         :error -> Logger.error(message)
+      end
+    end
+
+    :ok
+  end
+
+  @spec maybe_route_to_messages(level(), subsystem(), String.t()) :: :ok
+  defp maybe_route_to_messages(level, subsystem, message) do
+    otp_level = Logger.level()
+    otp_priority = Map.fetch!(@level_priority, otp_level)
+    msg_priority = Map.fetch!(@level_priority, level)
+
+    if otp_priority > msg_priority do
+      case Process.whereis(Minga.Editor) do
+        nil -> :ok
+        _pid -> Minga.Editor.log_to_messages("[#{subsystem}/#{level}] " <> message)
       end
     end
 

--- a/lib/minga/telemetry/dev_handler.ex
+++ b/lib/minga/telemetry/dev_handler.ex
@@ -44,7 +44,7 @@ defmodule Minga.Telemetry.DevHandler do
         [:minga, :command, :execute, :stop],
         [:minga, :port, :emit, :stop]
       ],
-      &handle_event/4,
+      &__MODULE__.handle_event/4,
       nil
     )
 

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -519,7 +519,7 @@ final class CoreTextMetalRenderer {
            let instBuf = instanceBuffer {
             // Copy instance data into the shared Metal buffer.
             let byteCount = lineInstances.count * MemoryLayout<LineGPU>.stride
-            lineInstances.withUnsafeBytes { ptr in
+            _ = lineInstances.withUnsafeBytes { ptr in
                 memcpy(instBuf.contents(), ptr.baseAddress!, byteCount)
             }
 

--- a/macos/Sources/Views/ToolManagerView.swift
+++ b/macos/Sources/Views/ToolManagerView.swift
@@ -393,7 +393,7 @@ struct ToolManagerView: View {
             keyHint(key: "↵", action: "Retry")
         case .installing:
             keyHint(key: "↵", action: "Installing…")
-        case nil, .none:
+        case nil:
             keyHint(key: "↵", action: "Select")
         }
     }

--- a/test/minga/log_messages_routing_test.exs
+++ b/test/minga/log_messages_routing_test.exs
@@ -1,0 +1,56 @@
+defmodule Minga.LogMessagesRoutingTest do
+  # async: false because Logger.configure/1 mutates global state
+  use ExUnit.Case, async: false
+
+  alias Minga.Config.Options
+
+  setup do
+    {:ok, _opts} = Options.start_link(name: :"opts_#{System.unique_integer()}")
+
+    on_exit(fn -> Options.reset() end)
+
+    :ok
+  end
+
+  describe "Messages routing" do
+    test "routes to *Messages* when OTP Logger level suppresses the message" do
+      Options.set(:log_level, :info)
+      Options.set(:log_level_editor, :default)
+
+      # Register a fake Editor process so Process.whereis(Minga.Editor) finds it.
+      test_pid = self()
+
+      fake_editor =
+        spawn(fn ->
+          Process.register(self(), Minga.Editor)
+          send(test_pid, :registered)
+
+          # Receive the cast from log_to_messages
+          receive do
+            {:"$gen_cast", {:log_to_messages, text}} ->
+              send(test_pid, {:got_message, text})
+          after
+            1000 -> :timeout
+          end
+        end)
+
+      assert_receive :registered
+
+      # Set OTP Logger to :warning so :info is suppressed at Logger level
+      # but Minga.Log's subsystem level still permits it.
+      previous_level = Logger.level()
+      Logger.configure(level: :warning)
+
+      on_exit(fn ->
+        Logger.configure(level: previous_level)
+        Process.exit(fake_editor, :kill)
+      end)
+
+      Minga.Log.info(:editor, "Grammar org registered successfully")
+
+      assert_receive {:got_message, text}
+      assert text =~ "Grammar org registered successfully"
+      assert text =~ "[editor/info]"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Running `bin/minga-mac` printed a wall of noise to the console: xcodebuild destination warnings, Swift compiler warnings, a codesign build phase note, a telemetry local function capture warning, and Elixir Logger info-level startup messages (grammar registered, extension started, watchdog started).

## Changes

**Shell script (`bin/minga-mac`)**
- Add `-destination "platform=macOS,arch=$ARCH"` (dynamic via `uname -m`) to eliminate multi-destination warnings
- Expand grep filter to suppress `note:` and `Run script build phase` lines

**Swift warnings**
- `CoreTextMetalRenderer.swift`: Add `_ =` to discard unused `withUnsafeBytes` return value
- `ToolManagerView.swift`: Remove redundant `.none` case (`nil` already covers it for Optionals)

**Telemetry handler**
- Use `&__MODULE__.handle_event/4` instead of `&handle_event/4` to avoid the local function capture warning from OTP telemetry

**Logging**
- Set `config :logger, level: :warning` in `config/dev.exs` to suppress info-level console noise
- Add `maybe_route_to_messages/3` in `Minga.Log` that detects when the OTP primary level filter would suppress a message and routes it directly to `*Messages*` via `Editor.log_to_messages/1`, avoiding duplicates with `Minga.LoggerHandler`
- Extend `@level_priority` to cover all OTP Logger levels (`:all`, `:notice`, `:critical`, `:alert`, `:emergency`)

## Testing

- 6,015 Elixir tests pass (including new `log_messages_routing_test.exs`)
- 445 Swift tests pass
- `mix lint` clean (format + credo + compile --warnings-as-errors + dialyzer)
- xcodebuild produces zero output with `-quiet`