### PR TITLE
fix(macos): bottom-anchor agent chat messages to eliminate empty void

### DIFF
--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -7,35 +7,56 @@
 
 import SwiftUI
 
+/// Measures the ScrollView's visible viewport height so the content
+/// can be bottom-anchored when there are fewer messages than screen space.
+private struct ScrollViewHeightKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
 struct AgentChatView: View {
     let state: AgentChatState
     let theme: ThemeColors
     let isInsertMode: Bool
+
+    @State private var scrollViewHeight: CGFloat = 0
 
     var body: some View {
         VStack(spacing: 0) {
             // Header bar
             chatHeader
 
-            // Messages
+            // Messages: bottom-anchored so few messages cluster near the
+            // prompt input rather than leaving a void below them.
             ScrollViewReader { proxy in
                 ScrollView(.vertical) {
                     LazyVStack(spacing: 12) {
                         ForEach(state.messages) { msg in
                             messageView(msg)
                         }
-
-                        // Bottom padding so the last message has breathing room
-                        // above the prompt separator / approval banner.
-                        Spacer(minLength: 16)
-                            .id("bottom-padding")
                     }
                     .padding(.horizontal, 16)
                     .padding(.top, 12)
+                    .padding(.bottom, 16)
+                    .frame(minHeight: scrollViewHeight, alignment: .bottom)
+                }
+                .defaultScrollAnchor(.bottom)
+                .background(
+                    GeometryReader { geo in
+                        Color.clear.preference(
+                            key: ScrollViewHeightKey.self,
+                            value: geo.size.height
+                        )
+                    }
+                )
+                .onPreferenceChange(ScrollViewHeightKey.self) { height in
+                    scrollViewHeight = height
                 }
                 .onChange(of: state.messages.count) { _, _ in
                     withAnimation(nil) {
-                        proxy.scrollTo("bottom-padding", anchor: .bottom)
+                        proxy.scrollTo(state.messages.last?.id, anchor: .bottom)
                     }
                 }
             }

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -272,6 +272,78 @@ struct TabBarViewViewTests {
     }
 }
 
+// MARK: - AgentChatView
+
+@Suite("AgentChatView View Structure")
+struct AgentChatViewTests {
+
+    @Test("Empty messages shows header and prompt area")
+    @MainActor func emptyMessages() throws {
+        let state = AgentChatState()
+        state.visible = true
+        state.model = "claude-sonnet-4"
+        state.status = 0
+
+        let sut = AgentChatView(state: state, theme: ThemeColors(), isInsertMode: false)
+        let body = try sut.inspect()
+        let texts = body.findAll(ViewInspectorQuery.text)
+        let strings = texts.compactMap { try? $0.string() }
+
+        // Header shows model name and status
+        #expect(strings.contains("claude-sonnet-4"))
+        #expect(strings.contains("idle"))
+        // Prompt shows normal-mode placeholder
+        #expect(strings.contains("Press i to type"))
+        #expect(strings.contains("NORMAL"))
+    }
+
+    @Test("User message renders as bubble")
+    @MainActor func userMessage() throws {
+        let state = AgentChatState()
+        state.visible = true
+        state.model = "test-model"
+        state.messages = [.user(id: 0, text: "Hello world")]
+
+        let sut = AgentChatView(state: state, theme: ThemeColors(), isInsertMode: false)
+        let body = try sut.inspect()
+        let texts = body.findAll(ViewInspectorQuery.text)
+        let strings = texts.compactMap { try? $0.string() }
+
+        #expect(strings.contains("Hello world"))
+    }
+
+    @Test("System message renders centered")
+    @MainActor func systemMessage() throws {
+        let state = AgentChatState()
+        state.visible = true
+        state.model = "test-model"
+        state.messages = [.system(id: 0, text: "Session started", isError: false)]
+
+        let sut = AgentChatView(state: state, theme: ThemeColors(), isInsertMode: false)
+        let body = try sut.inspect()
+        let texts = body.findAll(ViewInspectorQuery.text)
+        let strings = texts.compactMap { try? $0.string() }
+
+        #expect(strings.contains("Session started"))
+    }
+
+    @Test("Insert mode shows typing placeholder")
+    @MainActor func insertMode() throws {
+        let state = AgentChatState()
+        state.visible = true
+        state.model = "test-model"
+
+        let sut = AgentChatView(state: state, theme: ThemeColors(), isInsertMode: true)
+        let body = try sut.inspect()
+        let texts = body.findAll(ViewInspectorQuery.text)
+        let strings = texts.compactMap { try? $0.string() }
+
+        #expect(strings.contains("Type a message, Enter to send"))
+        // Should NOT show NORMAL badge in insert mode
+        #expect(!strings.contains("NORMAL"))
+    }
+}
+
 // MARK: - ViewInspector query helper
 
 /// Namespace for ViewInspector query types.


### PR DESCRIPTION
## Problem

When the agent panel had few messages (e.g., just "Session started"), the ScrollView filled all available vertical space with the message at the top, leaving a huge empty void (roughly 2/3 of the panel) between the content and the prompt input area at the bottom.

## Root Cause

The `AgentChatView` overlays the editor surface in a ZStack. Its `ScrollView` with `LazyVStack` uses default top alignment. With sparse content, the single message sits at the top and the rest is empty space. Standard ScrollView behavior, but wrong for a chat UI.

## Fix

Bottom-anchor messages using the canonical SwiftUI pattern for macOS 14+:

1. **PreferenceKey + GeometryReader** measures the ScrollView's visible viewport height
2. **`.frame(minHeight: scrollViewHeight, alignment: .bottom)`** on the LazyVStack pushes content to the bottom when shorter than viewport
3. **`.defaultScrollAnchor(.bottom)`** sets initial scroll position at the bottom
4. **`scrollTo(state.messages.last?.id)`** replaces the synthetic spacer anchor for auto-scroll on new messages

When content exceeds the viewport, the `minHeight` constraint is already satisfied, so scrolling works normally. No layout loops (measurement and modification are in different layout domains).

## Tests

Added `AgentChatViewTests` suite (4 tests) covering empty state, user message, system message, and insert mode. Total Swift tests: 445 → 449.

## Verification

- Swift expert confirmed diagnosis and fix approach (consulted twice)
- `xcodebuild build` → BUILD SUCCEEDED
- `xcodebuild test` → 449 tests / 83 suites passed
- Intent-reviewer: PASS