### PR TITLE
fix(editor): stop code_lens from showing "No language server" in minibuffer

### DIFF
--- a/lib/minga/editor/lsp_actions.ex
+++ b/lib/minga/editor/lsp_actions.ex
@@ -501,7 +501,7 @@ defmodule Minga.Editor.LspActions do
   def code_lens(%{buffers: %{active: buf}} = state) do
     case lsp_client_for(state, buf) do
       nil ->
-        %{state | status_msg: "No language server"}
+        state
 
       client ->
         file_path = BufferServer.file_path(buf)

--- a/test/minga/editor/lsp_actions_test.exs
+++ b/test/minga/editor/lsp_actions_test.exs
@@ -188,6 +188,23 @@ defmodule Minga.Editor.LspActionsTest do
     end
   end
 
+  # ── code_lens/1 ───────────────────────────────────────────────────────────
+
+  describe "code_lens/1" do
+    test "sets status_msg when no active buffer" do
+      state = fake_state()
+      result = LspActions.code_lens(state)
+      assert result.status_msg == "No active buffer"
+    end
+
+    test "silently no-ops when no LSP client is registered" do
+      buf = start_supervised!({BufferServer, content: "hello"})
+      state = fake_state_with_buffer(buf)
+      result = LspActions.code_lens(state)
+      assert result.status_msg == nil
+    end
+  end
+
   # ── handle_code_lens_response/2 ──────────────────────────────────────────
 
   describe "handle_code_lens_response/2" do


### PR DESCRIPTION
## Problem

Opening a file in the GUI shows "No language server" in the minibuffer even though the user never triggered an LSP action. The same message flashes on every buffer save.

## Root Cause

`code_lens/1` is called automatically on buffer open (800ms delayed timer) and on every buffer save. When no LSP client is registered for the buffer's filetype, it was setting `status_msg: "No language server"`. The minibuffer is Metal-rendered in GUI mode, so this painted the message in the editor window.

This was inconsistent with `inlay_hints/1` and `document_highlight/1`, which both silently return `state` when no LSP client is available.

## Fix

Changed `code_lens/1` to silently return `state` (no-op) when `lsp_client_for` returns `nil`, matching the pattern used by `inlay_hints` and `document_highlight`.

User-initiated LSP actions (goto_definition, hover, find_references, etc.) still show "No language server" as expected.

## Testing

- 2 new tests in `lsp_actions_test.exs` for `code_lens/1` covering both the no-buffer and no-client branches
- Full suite: 6031 tests, 0 failures
- `mix lint` clean (format, credo, compile --warnings-as-errors, dialyzer)