### PR TITLE
fix(editor,macos): picker crash and Messages panel bottom-anchoring

### DIFF
--- a/lib/minga/editor/render_pipeline/emit/gui.ex
+++ b/lib/minga/editor/render_pipeline/emit/gui.ex
@@ -305,7 +305,7 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
     # Preview content is NOT in the fingerprint: a file changing on disk while
     # the picker is open won't refresh the preview. Acceptable trade-off for
     # scroll perf since the picker isn't open during normal editing.
-    fp = :erlang.phash2({picker.query, picker.selected, picker.total, action_menu})
+    fp = :erlang.phash2({picker.query, picker.selected, Picker.total(picker), action_menu})
 
     if fp != Process.get(:last_gui_picker_fp) do
       Process.put(:last_gui_picker_fp, fp)
@@ -323,11 +323,11 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
   # Returns a list of lines, where each line is a list of {text, fg_color, bold} segments.
   @spec build_picker_preview(state()) :: [[ProtocolGUI.preview_segment()]] | nil
   defp build_picker_preview(%{picker_ui: %{picker: picker}} = state) do
-    case Minga.Picker.selected_item(picker) do
+    case Picker.selected_item(picker) do
       nil ->
         nil
 
-      %Minga.Picker.Item{id: id} ->
+      %Picker.Item{id: id} ->
         build_preview_for_item(state, id)
     end
   end

--- a/macos/Sources/Views/MessagesContentView.swift
+++ b/macos/Sources/Views/MessagesContentView.swift
@@ -55,6 +55,7 @@ struct MessagesContentView: View {
                             }
                         }
                     }
+                    .defaultScrollAnchor(.bottom)
                 }
 
                 // "Jump to latest" button

--- a/test/minga/editor/render_pipeline/emit/gui_chrome_cache_test.exs
+++ b/test/minga/editor/render_pipeline/emit/gui_chrome_cache_test.exs
@@ -190,6 +190,23 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI.ChromeCacheTest do
       assert Map.has_key?(new_state, :message_store)
     end
 
+    test "picker cache fingerprints an open picker without crashing" do
+      item = %Minga.Picker.Item{id: "a", label: "a.txt"}
+      picker = Minga.Picker.new([item], title: "Test")
+      state = gui_chrome_state()
+
+      # Inject an open picker into picker_ui state.
+      picker_ui = %{state.picker_ui | picker: picker, source: nil, action_menu: nil}
+      state = %{state | picker_ui: picker_ui}
+      sb_data = StatusBarData.from_state(state)
+
+      # Before the fix, this raised KeyError: key :total not found in %Minga.Picker{}.
+      EmitGUI.sync_swiftui_chrome(state, sb_data)
+      flush_port_casts()
+
+      refute Process.get(:last_gui_picker_fp) in [:closed, nil]
+    end
+
     test "agent chat survives dead prompt buffer process" do
       state = gui_chrome_state()
 


### PR DESCRIPTION
## What

Two bug fixes from a user-reported screenshot:

1. **Picker crash fix**: The render pipeline crashed with `key :total not found in %Minga.Picker{}` when opening the picker on GUI frontends. The fingerprint hash in `build_gui_picker_cmd/1` accessed `picker.total` (a nonexistent struct field) instead of calling `Picker.total(picker)`.

2. **Messages panel bottom-anchoring**: The Messages pane showed a large empty dark area below log entries. Added `.defaultScrollAnchor(.bottom)` to the ScrollView so entries anchor to the bottom, matching terminal/console behavior where content grows upward.

## Changes

- `lib/minga/editor/render_pipeline/emit/gui.ex`: Fix `picker.total` → `Picker.total(picker)`, normalize alias usage
- `macos/Sources/Views/MessagesContentView.swift`: Add `.defaultScrollAnchor(.bottom)`
- `test/.../gui_chrome_cache_test.exs`: Regression test for open-picker fingerprinting

## Testing

- `mix lint`: clean (format, credo, compile, dialyzer)
- `mix test.llm`: 6051 tests, 0 failures
- `xcodebuild build`: BUILD SUCCEEDED
- Regression test exercises the exact crash path