### PR TITLE
fix(macos): tool call toggle not updating GUI due to stale fingerprint

### DIFF
--- a/lib/minga/agent/events.ex
+++ b/lib/minga/agent/events.ex
@@ -11,6 +11,7 @@ defmodule Minga.Agent.Events do
 
   alias Minga.Agent.DiffReview
   alias Minga.Agent.UIState
+  alias Minga.Agent.UIState.Panel
   alias Minga.Agent.View.Preview
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Agent, as: AgentState
@@ -73,6 +74,7 @@ defmodule Minga.Agent.Events do
 
   def handle(state, :messages_changed) do
     state = AgentAccess.update_agent_ui(state, &UIState.maybe_auto_scroll/1)
+    state = AgentAccess.update_panel(state, &Panel.bump_message_version/1)
     {state, [{:render, 16}, :sync_agent_buffer, {:update_tab_label, ""}]}
   end
 

--- a/lib/minga/agent/ui_state/panel.ex
+++ b/lib/minga/agent/ui_state/panel.ex
@@ -35,7 +35,8 @@ defmodule Minga.Agent.UIState.Panel do
           mention_completion: Minga.Agent.FileMention.completion() | nil,
           pasted_blocks: [paste_block()],
           cached_line_index: [{non_neg_integer(), Minga.Agent.BufferSync.line_type()}],
-          cached_styled_messages: [Minga.Agent.MarkdownHighlight.styled_lines()] | nil
+          cached_styled_messages: [Minga.Agent.MarkdownHighlight.styled_lines()] | nil,
+          message_version: non_neg_integer()
         }
 
   @enforce_keys []
@@ -53,7 +54,8 @@ defmodule Minga.Agent.UIState.Panel do
             mention_completion: nil,
             pasted_blocks: [],
             cached_line_index: [],
-            cached_styled_messages: nil
+            cached_styled_messages: nil,
+            message_version: 0
 
   @doc "Creates a new panel state with defaults."
   @spec new() :: t()
@@ -100,4 +102,10 @@ defmodule Minga.Agent.UIState.Panel do
   end
 
   def input_text(%__MODULE__{}), do: ""
+
+  @doc "Increments the message version counter. Used to invalidate the GUI fingerprint cache when message content changes (collapse toggles, new messages, etc.)."
+  @spec bump_message_version(t()) :: t()
+  def bump_message_version(%__MODULE__{message_version: v} = panel) do
+    %{panel | message_version: v + 1}
+  end
 end

--- a/lib/minga/editor/render_pipeline/emit/gui.ex
+++ b/lib/minga/editor/render_pipeline/emit/gui.ex
@@ -509,14 +509,17 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
     # alone is stable (wouldn't detect typing). The styled cache length
     # is a reliable proxy for message count changes because styling
     # happens in the same render cycle as message arrival.
+    # message_version is bumped on every :messages_changed event,
+    # including collapse toggles, ensuring the fingerprint changes.
     {fp, prompt_text} =
       if is_agent_chat && session do
-        styled_len = length(state.agent_ui.panel.cached_styled_messages || [])
-        text = safe_prompt_content(state.agent_ui.panel.prompt_buffer)
+        panel = state.agent_ui.panel
+        styled_len = length(panel.cached_styled_messages || [])
+        text = safe_prompt_content(panel.prompt_buffer)
 
         {:erlang.phash2(
            {:visible, state.agent.status, state.agent.pending_approval, styled_len,
-            state.agent_ui.panel.model_name, text}
+            panel.model_name, text, panel.message_version}
          ), text}
       else
         {:not_visible, ""}

--- a/test/minga/agent/ui_state_test.exs
+++ b/test/minga/agent/ui_state_test.exs
@@ -3,6 +3,7 @@ defmodule Minga.Agent.UIStateTest do
 
   alias Minga.Agent.Config, as: AgentConfig
   alias Minga.Agent.UIState
+  alias Minga.Agent.UIState.Panel
   alias Minga.Buffer.Server, as: BufferServer
 
   # Creates a UIState with a running prompt buffer containing the given text.
@@ -511,6 +512,19 @@ defmodule Minga.Agent.UIStateTest do
       ui = UIState.ensure_prompt_buffer(ui)
       assert is_pid(ui.panel.prompt_buffer)
       assert ui.panel.prompt_buffer != old_pid
+    end
+  end
+
+  describe "Panel.bump_message_version/1" do
+    test "increments the counter each call" do
+      panel = Panel.new()
+      assert panel.message_version == 0
+
+      panel = Panel.bump_message_version(panel)
+      assert panel.message_version == 1
+
+      panel = Panel.bump_message_version(panel)
+      assert panel.message_version == 2
     end
   end
 end

--- a/test/minga/editor/state/event_routing_test.exs
+++ b/test/minga/editor/state/event_routing_test.exs
@@ -88,10 +88,12 @@ defmodule Minga.Editor.State.EventRoutingTest do
     test "messages_changed triggers buffer sync and tab label update" do
       %{state: state} = make_state()
 
-      {_new_state, effects} = AgentEvents.handle(state, :messages_changed)
+      {new_state, effects} = AgentEvents.handle(state, :messages_changed)
 
       assert :sync_agent_buffer in effects
       assert {:update_tab_label, ""} in effects
+      # message_version is bumped so the GUI fingerprint cache is invalidated
+      assert AgentAccess.panel(new_state).message_version == 1
     end
   end
 


### PR DESCRIPTION
## Problem

After merging #919, tool call detail toggling had two bugs:

1. **Cannot expand while streaming** - clicking a tool call header during active output had no visible effect
2. **Cannot toggle twice** - after one open/close cycle, subsequent clicks appeared to do nothing

## Root Cause

The GUI agent chat fingerprint cache in `build_gui_agent_chat_cmd` used `{status, pending_approval, styled_len, model_name, prompt_text}` to decide whether to re-encode and send the agent chat state. When `Session.toggle_tool_collapse` flips a tool call's `collapsed` flag, none of these fingerprint inputs change. The BEAM computes a matching fingerprint, skips re-encoding, and the GUI never receives the updated collapsed state.

For bug #2 specifically: the first click changes session state (`collapsed: true → false`) but the GUI still shows collapsed. The second click flips it back (`false → true`), matching what the GUI already shows, so nothing appears to happen.

## Fix

Add a `message_version` counter to `Panel` that gets bumped on every `:messages_changed` event (which fires on every collapse toggle via `notify_messages_changed`). Include `panel.message_version` in the fingerprint so any message content change invalidates the cache.

### Changes
- `lib/minga/agent/ui_state/panel.ex` - new `message_version` field + `bump_message_version/1`
- `lib/minga/agent/events.ex` - bump version in `:messages_changed` handler
- `lib/minga/editor/render_pipeline/emit/gui.ex` - include `message_version` in fingerprint

### Tests
- Updated `event_routing_test.exs` to assert `message_version == 1` after `:messages_changed`
- Added `Panel.bump_message_version/1` unit test in `ui_state_test.exs`

Closes the toggle issues from #919.