### PR TITLE
fix(macos): remove dead space below bottom panel content

### DIFF
--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -42,10 +42,22 @@ struct MingaApp: App {
     }
 }
 
+/// Preference key for measuring the right pane's total height.
+/// Used by BottomPanelView to cap its height at a fraction of
+/// available space without needing a greedy GeometryReader.
+private struct PaneHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 600
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        // Single measurement source (one GeometryReader); last write wins.
+        value = nextValue()
+    }
+}
+
 /// ContentView observes AppState and switches from a placeholder to the
 /// editor surface once the AppDelegate finishes initialization.
 struct ContentView: View {
     @ObservedObject var appState: AppState
+    @State private var rightPaneHeight: CGFloat = 600
 
     var body: some View {
         ZStack {
@@ -132,7 +144,8 @@ struct ContentView: View {
                     BottomPanelView(
                         state: appState.gui.bottomPanelState,
                         theme: appState.gui.themeColors,
-                        encoder: appState.encoder
+                        encoder: appState.encoder,
+                        availableHeight: rightPaneHeight
                     )
                 }
 
@@ -155,6 +168,17 @@ struct ContentView: View {
                     theme: appState.gui.themeColors,
                     encoder: appState.encoder
                 )
+            }
+            .background(
+                GeometryReader { geo in
+                    Color.clear.preference(
+                        key: PaneHeightKey.self,
+                        value: geo.size.height
+                    )
+                }
+            )
+            .onPreferenceChange(PaneHeightKey.self) { height in
+                rightPaneHeight = height
             }
 
         }

--- a/macos/Sources/Views/BottomPanelView.swift
+++ b/macos/Sources/Views/BottomPanelView.swift
@@ -10,6 +10,10 @@ struct BottomPanelView: View {
     @Bindable var state: BottomPanelState
     let theme: ThemeColors
     let encoder: InputEncoder?
+    /// Total height of the right pane (tab bar + editor + panel + status bar).
+    /// Used to cap the panel at 60% of available space. Measured by the parent
+    /// via a preference key so the panel itself doesn't need a GeometryReader.
+    let availableHeight: CGFloat
 
     /// Minimum panel height in points.
     private let minHeight: CGFloat = 100
@@ -20,24 +24,23 @@ struct BottomPanelView: View {
     @State private var dragStartHeight: CGFloat = 0
 
     var body: some View {
-        GeometryReader { geo in
-            let maxH = geo.size.height * maxHeightFraction
-            let panelH = min(max(state.userHeight, minHeight), maxH)
+        let maxH = availableHeight * maxHeightFraction
+        let panelH = min(max(state.userHeight, minHeight), maxH)
 
-            VStack(spacing: 0) {
-                // Drag handle at the top edge
-                dragHandle(maxHeight: maxH, windowHeight: geo.size.height)
+        VStack(spacing: 0) {
+            // Drag handle at the top edge
+            dragHandle(maxHeight: maxH, windowHeight: availableHeight)
 
-                // Tab bar
-                tabBar
+            // Tab bar
+            tabBar
 
-                // Content area (placeholder for now; Messages content is a follow-up)
-                contentArea
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-            .frame(height: panelH)
-            .background(theme.editorBg)
+            // Content area (placeholder for now; Messages content is a follow-up)
+            contentArea
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .frame(height: panelH)
+        .clipped()
+        .background(theme.editorBg)
     }
 
     // MARK: - Drag handle

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -344,6 +344,52 @@ struct AgentChatViewTests {
     }
 }
 
+// MARK: - BottomPanelView
+
+@Suite("BottomPanelView View Structure")
+struct BottomPanelViewTests {
+
+    @Test("Panel renders tab bar with tab name")
+    @MainActor func rendersTabBar() throws {
+        let state = BottomPanelState()
+        state.visible = true
+        state.userHeight = 200
+        state.tabs = [BottomPanelTab(id: 0, tabType: 0x01, name: "Messages")]
+        state.activeTabIndex = 0
+
+        let sut = BottomPanelView(
+            state: state, theme: ThemeColors(),
+            encoder: nil, availableHeight: 600
+        )
+        let body = try sut.inspect()
+        let texts = body.findAll(ViewInspectorQuery.text)
+        let strings = texts.compactMap { try? $0.string() }
+        #expect(strings.contains("Messages"))
+    }
+
+    @Test("Panel renders multiple tabs")
+    @MainActor func multipleTabsRender() throws {
+        let state = BottomPanelState()
+        state.visible = true
+        state.userHeight = 200
+        state.tabs = [
+            BottomPanelTab(id: 0, tabType: 0x01, name: "Messages"),
+            BottomPanelTab(id: 1, tabType: 0x02, name: "Diagnostics"),
+        ]
+        state.activeTabIndex = 0
+
+        let sut = BottomPanelView(
+            state: state, theme: ThemeColors(),
+            encoder: nil, availableHeight: 600
+        )
+        let body = try sut.inspect()
+        let texts = body.findAll(ViewInspectorQuery.text)
+        let strings = texts.compactMap { try? $0.string() }
+        #expect(strings.contains("Messages"))
+        #expect(strings.contains("Diagnostics"))
+    }
+}
+
 // MARK: - ViewInspector query helper
 
 /// Namespace for ViewInspector query types.


### PR DESCRIPTION
## Problem

The bottom panel (Messages tab) had a large empty dark area between the last log message and the status bar. The panel content didn't fill its allocated vertical space.

## Root Cause

`BottomPanelView` used a `GeometryReader` internally to measure available height for max-height capping. `GeometryReader` is greedy: it consumed all remaining space in the parent VStack, but the inner content was constrained to `panelH`. The gap between those two values was the dead space.

## Fix

- Remove `GeometryReader` from `BottomPanelView`
- Measure the right pane's height in `ContentView` via a `PreferenceKey`
- Pass `availableHeight` to `BottomPanelView` as a parameter
- Panel now uses fixed `.frame(height: panelH)` so SwiftUI treats it as a fixed-height child
- Added `.clipped()` to prevent overflow during resize animations
- Added 2 ViewInspector tests for `BottomPanelView`

## Testing

Swift build succeeds, 451 tests pass (2 new).