### PR TITLE
refactor: document remaining catch :exit blocks with AGENTS.md rule 4 citations

### DIFF
--- a/lib/minga/agent/provider_resolver.ex
+++ b/lib/minga/agent/provider_resolver.ex
@@ -102,10 +102,6 @@ defmodule Minga.Agent.ProviderResolver do
   @spec has_native_credentials?() :: boolean()
   defp has_native_credentials? do
     Credentials.any_configured?()
-  rescue
-    ArgumentError -> false
-  catch
-    :exit, _ -> false
   end
 
   @spec pi_available?() :: boolean()

--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -742,6 +742,8 @@ defmodule Minga.Agent.Providers.Native do
       emit_error_and_end(lctx.provider_pid, Exception.message(e))
       {:error, Exception.message(e)}
   catch
+    # HTTP client or session process may die mid-stream. Targeted catch
+    # per AGENTS.md rule 4.
     :exit, reason ->
       emit_error_and_end(lctx.provider_pid, inspect(reason))
       {:error, reason}
@@ -892,6 +894,8 @@ defmodule Minga.Agent.Providers.Native do
       try do
         GenServer.call(lctx.session_pid, :dequeue_steering, 200)
       catch
+        # Session may die between loop iterations. Targeted catch per
+        # AGENTS.md rule 4.
         :exit, _ -> []
       end
 

--- a/lib/minga/agent/ui_state.ex
+++ b/lib/minga/agent/ui_state.ex
@@ -86,6 +86,8 @@ defmodule Minga.Agent.UIState do
     BufferServer.buffer_name(pid)
     state
   catch
+    # Liveness probe: prompt buffer may die between pid check and this call.
+    # Targeted catch per AGENTS.md rule 4.
     :exit, _ ->
       %{state | panel: start_prompt_buffer(panel, "")}
   end

--- a/lib/minga/command_output.ex
+++ b/lib/minga/command_output.ex
@@ -189,6 +189,9 @@ defmodule Minga.CommandOutput do
     BufferServer.buffer_name(buf)
     state
   catch
+    # Liveness probe: the monitor handles the common case, but there's a narrow
+    # race where the buffer dies between monitor delivery and this call.
+    # Targeted catch per AGENTS.md rule 4.
     :exit, _ -> create_buffer(state)
   end
 

--- a/lib/minga/input/agent_panel.ex
+++ b/lib/minga/input/agent_panel.ex
@@ -179,6 +179,8 @@ defmodule Minga.Input.AgentPanel do
           state
         end
       catch
+        # Hot path race: prompt buffer may die between existence check and
+        # key dispatch. Targeted catch per AGENTS.md rule 4.
         :exit, _ -> state
       end
     else


### PR DESCRIPTION
Closes #775

## What

Finishes the remaining acceptance criteria from #775. The heavy lifting (adding  + `:DOWN` handlers to CommandOutput, agent buffers, and eliminating defensive `Options.get` wrappers) was completed in prior work.

This PR:
- Adds AGENTS.md rule 4 comments to all 5 kept `catch :exit` blocks from the ticket's groups (command_output `ensure_buffer`, agent_panel prompt dispatch, ui_state `ensure_prompt_buffer`, native.ex streaming + steering)
- Removes unnecessary `rescue ArgumentError` + `catch :exit` from `provider_resolver.ex` (`Credentials.any_configured?/0` is pure code with no GenServer calls)

## Audit

An architectural review (archie) audited all ~150 remaining `catch :exit` blocks across the codebase and confirmed they are all legitimate patterns:
- Monitor already in place, catch covers race window (rule 4)
- Caller is a plain module, can't receive `:DOWN`
- One-shot enumeration of process lists
- OTP teardown idiom
- Boot-order tolerance
- User code sandboxing

## Testing

- `mix lint`: 0 errors (format + credo + compile --warnings-as-errors + dialyzer)
- `mix test.llm`: 5938 tests, 0 failures