### PR TITLE
refactor(lsp): monitor LSP client PIDs in SyncServer for ETS cleanup

### DIFF
--- a/lib/minga/lsp/sync_server.ex
+++ b/lib/minga/lsp/sync_server.ex
@@ -12,6 +12,10 @@ defmodule Minga.LSP.SyncServer do
   clients via `clients_for_buffer/1` (direct ETS read, no GenServer
   call needed).
 
+  Monitors all registered LSP client PIDs. If a client crashes outside
+  the event bus path, the `:DOWN` handler removes stale ETS entries so
+  they don't accumulate.
+
   ## Event subscriptions
 
   | Event              | Action                                           |
@@ -36,7 +40,8 @@ defmodule Minga.LSP.SyncServer do
 
   @typedoc "Internal state."
   @type state :: %{
-          debounce_timers: %{pid() => reference()}
+          debounce_timers: %{pid() => reference()},
+          client_monitors: %{reference() => {buffer_pid :: pid(), client_pid :: pid()}}
         }
 
   # ── Client API ─────────────────────────────────────────────────────────
@@ -81,10 +86,11 @@ defmodule Minga.LSP.SyncServer do
     Events.subscribe(:buffer_closed)
     Events.subscribe(:buffer_changed)
 
-    {:ok, %{debounce_timers: %{}}}
+    {:ok, %{debounce_timers: %{}, client_monitors: %{}}}
   end
 
   @impl true
+  @spec handle_info(term(), state()) :: {:noreply, state()}
   def handle_info(
         {:minga_event, :buffer_changed, %Events.BufferChangedEvent{buffer: buf}},
         state
@@ -96,7 +102,7 @@ defmodule Minga.LSP.SyncServer do
         {:minga_event, :buffer_opened, %Events.BufferEvent{buffer: buf, path: _path}},
         state
       ) do
-    do_buffer_open(buf)
+    state = do_buffer_open(state, buf)
     {:noreply, state}
   end
 
@@ -115,18 +121,23 @@ defmodule Minga.LSP.SyncServer do
     {:noreply, state}
   end
 
+  def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
+    state = handle_client_down(state, ref, pid)
+    {:noreply, state}
+  end
+
   def handle_info(_msg, state), do: {:noreply, state}
 
   # ── Private: buffer lifecycle ──────────────────────────────────────────
 
-  @spec do_buffer_open(pid()) :: :ok
-  defp do_buffer_open(buffer_pid) do
+  @spec do_buffer_open(state(), pid()) :: state()
+  defp do_buffer_open(state, buffer_pid) do
     filetype = BufferServer.filetype(buffer_pid)
     file_path = BufferServer.file_path(buffer_pid)
 
     case file_path do
       nil ->
-        :ok
+        state
 
       path ->
         configs = ServerRegistry.servers_for(filetype)
@@ -151,14 +162,15 @@ defmodule Minga.LSP.SyncServer do
 
         if clients != [] do
           :ets.insert(@registry_table, {buffer_pid, clients})
+          monitor_clients(state, buffer_pid, clients)
+        else
+          state
         end
-
-        :ok
     end
   rescue
-    _ -> :ok
+    _ -> state
   catch
-    :exit, _ -> :ok
+    :exit, _ -> state
   end
 
   @spec do_buffer_save(pid()) :: :ok
@@ -175,9 +187,72 @@ defmodule Minga.LSP.SyncServer do
     notify_clients(clients, buffer_pid, &Client.did_close/2)
 
     :ets.delete(@registry_table, buffer_pid)
+    state = demonitor_clients_for_buffer(state, buffer_pid)
     cancel_debounce(state, buffer_pid)
   catch
     :exit, _ -> state
+  end
+
+  # ── Private: client monitoring ─────────────────────────────────────────
+
+  @spec monitor_clients(state(), pid(), [pid()]) :: state()
+  defp monitor_clients(state, buffer_pid, clients) do
+    new_monitors =
+      Enum.reduce(clients, state.client_monitors, fn client_pid, acc ->
+        ref = Process.monitor(client_pid)
+        Map.put(acc, ref, {buffer_pid, client_pid})
+      end)
+
+    %{state | client_monitors: new_monitors}
+  end
+
+  @spec demonitor_clients_for_buffer(state(), pid()) :: state()
+  defp demonitor_clients_for_buffer(state, buffer_pid) do
+    {to_remove, to_keep} =
+      Map.split_with(state.client_monitors, fn {_ref, {buf_pid, _client_pid}} ->
+        buf_pid == buffer_pid
+      end)
+
+    Enum.each(to_remove, fn {ref, _} ->
+      Process.demonitor(ref, [:flush])
+    end)
+
+    %{state | client_monitors: to_keep}
+  end
+
+  @spec handle_client_down(state(), reference(), pid()) :: state()
+  defp handle_client_down(state, ref, client_pid) do
+    case Map.pop(state.client_monitors, ref) do
+      {nil, _monitors} ->
+        state
+
+      {{buffer_pid, ^client_pid}, remaining_monitors} ->
+        state = %{state | client_monitors: remaining_monitors}
+        remove_client_from_buffer(buffer_pid, client_pid)
+        state
+
+      {_other, _monitors} ->
+        # ref found but pid mismatch; shouldn't happen, but don't crash
+        state
+    end
+  end
+
+  @spec remove_client_from_buffer(pid(), pid()) :: :ok
+  defp remove_client_from_buffer(buffer_pid, client_pid) do
+    case :ets.lookup(@registry_table, buffer_pid) do
+      [{^buffer_pid, clients}] ->
+        remaining = List.delete(clients, client_pid)
+
+        case remaining do
+          [] -> :ets.delete(@registry_table, buffer_pid)
+          _ -> :ets.insert(@registry_table, {buffer_pid, remaining})
+        end
+
+        :ok
+
+      [] ->
+        :ok
+    end
   end
 
   # ── Private: didChange debouncing ──────────────────────────────────────

--- a/test/minga/lsp/sync_server_test.exs
+++ b/test/minga/lsp/sync_server_test.exs
@@ -7,14 +7,14 @@ defmodule Minga.LSP.SyncServerTest do
 
   describe "clients_for_buffer/1" do
     test "returns empty list for untracked buffer" do
-      {:ok, buf} = BufferServer.start_link(content: "hello")
+      buf = start_supervised!({BufferServer, content: "hello"})
       assert SyncServer.clients_for_buffer(buf) == []
     end
   end
 
   describe "event bus integration" do
     test "buffer_opened for non-file buffer is a no-op" do
-      {:ok, buf} = BufferServer.start_link(content: "scratch")
+      buf = start_supervised!({BufferServer, content: "scratch"})
 
       Events.broadcast(:buffer_opened, %Events.BufferEvent{buffer: buf, path: "/tmp/no_lsp.txt"})
 
@@ -25,7 +25,8 @@ defmodule Minga.LSP.SyncServerTest do
     end
 
     test "buffer_closed cleans up ETS entries" do
-      {:ok, buf} = BufferServer.start_link(content: "hello", file_path: "/tmp/cleanup.ex")
+      buf =
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/cleanup.ex"})
 
       # Manually insert a fake entry to simulate an open buffer with clients.
       :ets.insert(SyncServer.Registry, {buf, [self()]})
@@ -45,13 +46,14 @@ defmodule Minga.LSP.SyncServerTest do
 
   describe "buffer_changed event" do
     test "no-op for buffer with no clients" do
-      {:ok, buf} = BufferServer.start_link(content: "hello")
+      buf = start_supervised!({BufferServer, content: "hello"})
       Events.notify_buffer_changed(buf)
       :sys.get_state(SyncServer)
     end
 
     test "schedules debounced didChange" do
-      {:ok, buf} = BufferServer.start_link(content: "hello", file_path: "/tmp/debounce.ex")
+      buf =
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/debounce.ex"})
 
       # Insert a fake client entry.
       :ets.insert(SyncServer.Registry, {buf, [self()]})
@@ -63,6 +65,83 @@ defmodule Minga.LSP.SyncServerTest do
 
       state = :sys.get_state(SyncServer)
       assert Map.has_key?(state.debounce_timers, buf)
+    end
+  end
+
+  describe "client monitoring" do
+    test "crashed client is removed from ETS registry" do
+      buf =
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/monitor.ex"})
+
+      client = spawn(fn -> receive do: (_ -> :ok) end)
+      :ets.insert(SyncServer.Registry, {buf, [client]})
+
+      # Create the monitor inside SyncServer's process so the :DOWN
+      # message is delivered to SyncServer, not the test process.
+      :sys.replace_state(SyncServer, fn state ->
+        ref = Process.monitor(client)
+        %{state | client_monitors: Map.put(state.client_monitors, ref, {buf, client})}
+      end)
+
+      # Monitor from test process to confirm the process is dead before
+      # using :sys.get_state as a flush barrier on SyncServer.
+      test_ref = Process.monitor(client)
+      Process.exit(client, :kill)
+      assert_receive {:DOWN, ^test_ref, :process, ^client, :killed}
+
+      # Now the :DOWN to SyncServer is guaranteed to be in its mailbox.
+      :sys.get_state(SyncServer)
+
+      assert SyncServer.clients_for_buffer(buf) == []
+    end
+
+    test "crashed client is removed but other clients for same buffer remain" do
+      buf =
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/multi.ex"})
+
+      doomed = spawn(fn -> receive do: (_ -> :ok) end)
+      survivor = spawn(fn -> receive do: (_ -> :ok) end)
+
+      on_exit(fn -> Process.exit(survivor, :kill) end)
+
+      :ets.insert(SyncServer.Registry, {buf, [doomed, survivor]})
+
+      :sys.replace_state(SyncServer, fn state ->
+        ref = Process.monitor(doomed)
+        %{state | client_monitors: Map.put(state.client_monitors, ref, {buf, doomed})}
+      end)
+
+      test_ref = Process.monitor(doomed)
+      Process.exit(doomed, :kill)
+      assert_receive {:DOWN, ^test_ref, :process, ^doomed, :killed}
+
+      :sys.get_state(SyncServer)
+
+      assert SyncServer.clients_for_buffer(buf) == [survivor]
+    end
+
+    test "no stale monitors remain after buffer_closed" do
+      buf =
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/close_mon.ex"})
+
+      client = spawn(fn -> receive do: (_ -> :ok) end)
+
+      on_exit(fn -> Process.exit(client, :kill) end)
+
+      :ets.insert(SyncServer.Registry, {buf, [client]})
+
+      :sys.replace_state(SyncServer, fn state ->
+        ref = Process.monitor(client)
+        %{state | client_monitors: Map.put(state.client_monitors, ref, {buf, client})}
+      end)
+
+      Events.broadcast(
+        :buffer_closed,
+        %Events.BufferClosedEvent{buffer: buf, path: "/tmp/close_mon.ex"}
+      )
+
+      final_state = :sys.get_state(SyncServer)
+      assert final_state.client_monitors == %{}
     end
   end
 end


### PR DESCRIPTION
## What

Add `Process.monitor/1` when `SyncServer` registers LSP client PIDs in its ETS table. The `:DOWN` handler removes stale entries for crashed clients, preventing accumulation when clients die outside the event bus path.

This follows the same monitor pattern already established in `CommandOutput` and `Editor` for buffer/session monitoring.

## Changes

- Add `client_monitors` map to SyncServer state (`ref -> {buffer_pid, client_pid}`)
- Monitor each client PID during `do_buffer_open` registration
- Handle `:DOWN` to remove crashed client from ETS (or delete entry if last)
- Demonitor all clients for a buffer on `buffer_closed`
- `do_buffer_open` now returns state (was `:ok`) to thread monitor updates
- Defensive catch-all in `handle_client_down` for ref/pid mismatch

## Test improvements

- Three new tests: crash cleanup, partial cleanup, monitor cleanup on close
- Converted all pre-existing tests to use `start_supervised!/1`
- Proper process synchronization via test-side monitor + `assert_receive`

## Verification

- `mix lint`: 0 errors
- `mix test.llm`: 6145 tests, 0 failures

Closes #932