### PR TITLE
refactor(motion): use line_at iteration for word motions instead of full content materialization

### DIFF
--- a/lib/minga/motion/word.ex
+++ b/lib/minga/motion/word.ex
@@ -5,9 +5,11 @@ defmodule Minga.Motion.Word do
   Implements Vim's `w`/`b`/`e` (word-boundary) and `W`/`B`/`E`
   (whitespace-only boundary) motions.
 
-  Internally, motions scan grapheme tuples for character classification,
-  then convert the resulting grapheme index to a byte offset via a
-  parallel byte-offset lookup table.
+  Motions scan line-by-line using `Readable.line_at/2` to avoid
+  materializing the full document content. Typically only 1-3 lines
+  are fetched per motion, making these O(k) where k is the number of
+  lines between the cursor and the next word boundary, instead of the
+  previous O(n) full-content materialization on every keystroke.
   """
 
   alias Minga.Motion.Helpers
@@ -16,7 +18,320 @@ defmodule Minga.Motion.Word do
   @typedoc "A zero-indexed {line, byte_col} cursor position."
   @type position :: {non_neg_integer(), non_neg_integer()}
 
-  # ── word motions (w / b / e) ──────────────────────────────────────────────
+  # ── Line-level grapheme helpers ──────────────────────────────────────────
+
+  @spec line_graphemes(String.t()) :: {tuple(), tuple()}
+  defp line_graphemes(line_text), do: Helpers.graphemes_with_byte_offsets(line_text)
+
+  @spec byte_col_to_gidx(tuple(), non_neg_integer()) :: non_neg_integer()
+  defp byte_col_to_gidx(bos, byte_col), do: Helpers.byte_offset_to_grapheme_index(bos, byte_col)
+
+  @spec gidx_to_byte_col(tuple(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp gidx_to_byte_col(bos, gidx, lbs), do: Helpers.grapheme_index_to_byte_offset(bos, gidx, lbs)
+
+  # Position at a grapheme index within a known line.
+  @spec pos_at(non_neg_integer(), tuple(), non_neg_integer(), non_neg_integer()) :: position()
+  defp pos_at(line_num, bos, gidx, lbs), do: {line_num, gidx_to_byte_col(bos, gidx, lbs)}
+
+  # Clamp byte_col to valid grapheme index for a line with `total` graphemes.
+  @spec clamped_gidx(tuple(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp clamped_gidx(bos, col, total), do: min(byte_col_to_gidx(bos, col), total - 1)
+
+  # ── Scanning primitives (line-local, returns index up to `total`) ────────
+
+  @spec skip_class(
+          tuple(),
+          non_neg_integer(),
+          non_neg_integer(),
+          :word | :whitespace | :punctuation
+        ) :: non_neg_integer()
+  defp skip_class(_gs, idx, total, _class) when idx >= total, do: total
+
+  defp skip_class(gs, idx, total, :word) do
+    if Helpers.word_char?(elem(gs, idx)),
+      do: skip_class(gs, idx + 1, total, :word),
+      else: idx
+  end
+
+  defp skip_class(gs, idx, total, :whitespace) do
+    if Helpers.whitespace?(elem(gs, idx)),
+      do: skip_class(gs, idx + 1, total, :whitespace),
+      else: idx
+  end
+
+  defp skip_class(gs, idx, total, :punctuation) do
+    g = elem(gs, idx)
+
+    if not Helpers.word_char?(g) and not Helpers.whitespace?(g),
+      do: skip_class(gs, idx + 1, total, :punctuation),
+      else: idx
+  end
+
+  @spec skip_ws(tuple(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp skip_ws(_gs, idx, total) when idx >= total, do: total
+
+  defp skip_ws(gs, idx, total) do
+    if Helpers.whitespace?(elem(gs, idx)),
+      do: skip_ws(gs, idx + 1, total),
+      else: idx
+  end
+
+  @spec skip_non_ws(tuple(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp skip_non_ws(_gs, idx, total) when idx >= total, do: total
+
+  defp skip_non_ws(gs, idx, total) do
+    if Helpers.whitespace?(elem(gs, idx)),
+      do: idx,
+      else: skip_non_ws(gs, idx + 1, total)
+  end
+
+  @spec run_end(tuple(), non_neg_integer(), non_neg_integer(), :word | :punctuation) ::
+          non_neg_integer()
+  defp run_end(gs, idx, max, :word) do
+    next = idx + 1
+
+    if next <= max and Helpers.word_char?(elem(gs, next)),
+      do: run_end(gs, next, max, :word),
+      else: idx
+  end
+
+  defp run_end(gs, idx, max, :punctuation) do
+    next = idx + 1
+
+    if next <= max do
+      g = elem(gs, next)
+
+      if not Helpers.word_char?(g) and not Helpers.whitespace?(g),
+        do: run_end(gs, next, max, :punctuation),
+        else: idx
+    else
+      idx
+    end
+  end
+
+  @spec backward_non_ws(tuple(), integer()) :: integer()
+  defp backward_non_ws(_gs, idx) when idx < 0, do: -1
+
+  defp backward_non_ws(gs, idx) do
+    if Helpers.whitespace?(elem(gs, idx)),
+      do: backward_non_ws(gs, idx - 1),
+      else: idx
+  end
+
+  @spec run_start_at(tuple(), non_neg_integer()) :: non_neg_integer()
+  defp run_start_at(gs, idx) do
+    run_start(gs, idx, Helpers.classify_char(elem(gs, idx)))
+  end
+
+  @spec run_start(tuple(), non_neg_integer(), :word | :punctuation | :whitespace) ::
+          non_neg_integer()
+  defp run_start(gs, idx, :word) do
+    if idx > 0 and Helpers.word_char?(elem(gs, idx - 1)),
+      do: run_start(gs, idx - 1, :word),
+      else: idx
+  end
+
+  defp run_start(gs, idx, :punctuation) do
+    prev = idx - 1
+
+    if prev >= 0 do
+      g = elem(gs, prev)
+
+      if not Helpers.word_char?(g) and not Helpers.whitespace?(g),
+        do: run_start(gs, prev, :punctuation),
+        else: idx
+    else
+      idx
+    end
+  end
+
+  defp run_start(_gs, idx, :whitespace), do: idx
+
+  @spec big_run_start(tuple(), non_neg_integer()) :: non_neg_integer()
+  defp big_run_start(gs, idx) do
+    if idx > 0 and not Helpers.whitespace?(elem(gs, idx - 1)),
+      do: big_run_start(gs, idx - 1),
+      else: idx
+  end
+
+  @spec big_run_end(tuple(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp big_run_end(gs, idx, max) do
+    next = idx + 1
+
+    if next <= max and not Helpers.whitespace?(elem(gs, next)),
+      do: big_run_end(gs, next, max),
+      else: idx
+  end
+
+  # Skip current class then whitespace (for forward motions).
+  @spec forward_skip_class_and_ws(tuple(), non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  defp forward_skip_class_and_ws(gs, g_idx, total) do
+    current_class = Helpers.classify_char(elem(gs, g_idx))
+    after_class = skip_class(gs, g_idx + 1, total, current_class)
+
+    case current_class do
+      :whitespace -> after_class
+      _ -> skip_ws(gs, after_class, total)
+    end
+  end
+
+  # Skip non-ws (or ws) then trailing ws (for W motion).
+  @spec forward_skip_big_and_ws(tuple(), non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  defp forward_skip_big_and_ws(gs, g_idx, total) do
+    if Helpers.whitespace?(elem(gs, g_idx)) do
+      skip_ws(gs, g_idx + 1, total)
+    else
+      after_non_ws = skip_non_ws(gs, g_idx + 1, total)
+      skip_ws(gs, after_non_ws, total)
+    end
+  end
+
+  # ── Cross-line helpers ───────────────────────────────────────────────────
+
+  @spec find_next_word_start(Readable.t(), non_neg_integer()) :: position() | nil
+  defp find_next_word_start(buf, line_num) do
+    case Readable.line_at(buf, line_num) do
+      nil -> nil
+      line_text -> first_non_ws_on_line(buf, line_num, line_text)
+    end
+  end
+
+  @spec first_non_ws_on_line(Readable.t(), non_neg_integer(), String.t()) :: position() | nil
+  defp first_non_ws_on_line(buf, line_num, line_text) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
+    first = skip_ws(gs, 0, total)
+
+    if first < total,
+      do: pos_at(line_num, bos, first, byte_size(line_text)),
+      else: find_next_word_start(buf, line_num + 1)
+  end
+
+  @spec last_char_position(Readable.t()) :: position()
+  defp last_char_position(buf) do
+    find_last_char_from(buf, Readable.line_count(buf) - 1)
+  end
+
+  @spec find_last_char_from(Readable.t(), integer()) :: position()
+  defp find_last_char_from(_buf, line_num) when line_num < 0, do: {0, 0}
+
+  defp find_last_char_from(buf, line_num) do
+    case Readable.line_at(buf, line_num) do
+      nil -> {0, 0}
+      line_text -> last_char_on_line(buf, line_num, line_text)
+    end
+  end
+
+  @spec last_char_on_line(Readable.t(), non_neg_integer(), String.t()) :: position()
+  defp last_char_on_line(buf, line_num, line_text) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
+
+    if total == 0,
+      do: find_last_char_from(buf, line_num - 1),
+      else: pos_at(line_num, bos, total - 1, byte_size(line_text))
+  end
+
+  @spec find_prev_word_start(Readable.t(), integer()) :: position()
+  defp find_prev_word_start(_buf, line_num) when line_num < 0, do: {0, 0}
+
+  defp find_prev_word_start(buf, line_num) do
+    case Readable.line_at(buf, line_num) do
+      nil -> {0, 0}
+      line_text -> last_word_start_on_line(buf, line_num, line_text, &find_prev_word_start/2)
+    end
+  end
+
+  @spec last_word_start_on_line(
+          Readable.t(),
+          integer(),
+          String.t(),
+          (Readable.t(), integer() -> position())
+        ) :: position()
+  defp last_word_start_on_line(buf, line_num, line_text, fallback_fn) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
+    non_ws = if total > 0, do: backward_non_ws(gs, total - 1), else: -1
+
+    if non_ws < 0 do
+      fallback_fn.(buf, line_num - 1)
+    else
+      pos_at(line_num, bos, run_start_at(gs, non_ws), byte_size(line_text))
+    end
+  end
+
+  @spec find_prev_big_word_start(Readable.t(), integer()) :: position()
+  defp find_prev_big_word_start(_buf, line_num) when line_num < 0, do: {0, 0}
+
+  defp find_prev_big_word_start(buf, line_num) do
+    case Readable.line_at(buf, line_num) do
+      nil -> {0, 0}
+      line_text -> last_big_word_start_on_line(buf, line_num, line_text)
+    end
+  end
+
+  @spec last_big_word_start_on_line(Readable.t(), integer(), String.t()) :: position()
+  defp last_big_word_start_on_line(buf, line_num, line_text) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
+    non_ws = if total > 0, do: backward_non_ws(gs, total - 1), else: -1
+
+    if non_ws < 0 do
+      find_prev_big_word_start(buf, line_num - 1)
+    else
+      pos_at(line_num, bos, big_run_start(gs, non_ws), byte_size(line_text))
+    end
+  end
+
+  @spec find_word_end_from(Readable.t(), non_neg_integer(), position()) :: position()
+  defp find_word_end_from(buf, line_num, fallback) do
+    case Readable.line_at(buf, line_num) do
+      nil -> fallback
+      line_text -> word_end_on_line(buf, line_num, line_text, fallback)
+    end
+  end
+
+  @spec word_end_on_line(Readable.t(), non_neg_integer(), String.t(), position()) :: position()
+  defp word_end_on_line(buf, line_num, line_text, fallback) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
+    first = skip_ws(gs, 0, total)
+
+    if first >= total do
+      find_word_end_from(buf, line_num + 1, fallback)
+    else
+      class = Helpers.classify_char(elem(gs, first))
+      pos_at(line_num, bos, run_end(gs, first, total - 1, class), byte_size(line_text))
+    end
+  end
+
+  @spec find_big_word_end_from(Readable.t(), non_neg_integer(), position()) :: position()
+  defp find_big_word_end_from(buf, line_num, fallback) do
+    case Readable.line_at(buf, line_num) do
+      nil -> fallback
+      line_text -> big_word_end_on_line(buf, line_num, line_text, fallback)
+    end
+  end
+
+  @spec big_word_end_on_line(Readable.t(), non_neg_integer(), String.t(), position()) ::
+          position()
+  defp big_word_end_on_line(buf, line_num, line_text, fallback) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
+    first = skip_ws(gs, 0, total)
+
+    if first >= total do
+      find_big_word_end_from(buf, line_num + 1, fallback)
+    else
+      pos_at(line_num, bos, big_run_end(gs, first, total - 1), byte_size(line_text))
+    end
+  end
+
+  # ── Public API ───────────────────────────────────────────────────────────
+
+  # ── word_forward (w) ──────────────────────────────────────────────────────
 
   @doc """
   Move forward to the start of the next word (Vim's `w`).
@@ -29,24 +344,49 @@ defmodule Minga.Motion.Word do
   """
   @spec word_forward(Readable.t(), position()) :: position()
   def word_forward(buf, {line, col} = pos) do
-    text = Readable.content(buf)
-    {graphemes, byte_offsets} = Helpers.graphemes_with_byte_offsets(text)
-    total = tuple_size(graphemes)
-
-    if total == 0 do
-      pos
-    else
-      all_lines = :binary.split(text, "\n", [:global])
-      byte_off = Helpers.offset_for(all_lines, line, col)
-      g_idx = Helpers.byte_offset_to_grapheme_index(byte_offsets, byte_off)
-      new_g_idx = do_word_forward(graphemes, g_idx, total - 1)
-
-      new_byte_off =
-        Helpers.grapheme_index_to_byte_offset(byte_offsets, new_g_idx, byte_size(text))
-
-      Readable.offset_to_position(buf, new_byte_off)
+    case Readable.line_at(buf, line) do
+      nil -> pos
+      line_text -> do_word_forward(buf, line, col, pos, line_text)
     end
   end
+
+  @spec do_word_forward(
+          Readable.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          position(),
+          String.t()
+        ) :: position()
+  defp do_word_forward(buf, line, col, pos, line_text) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
+
+    if total == 0 do
+      find_next_word_start(buf, line + 1) || pos
+    else
+      after_ws = forward_skip_class_and_ws(gs, clamped_gidx(bos, col, total), total)
+      resolve_forward(buf, line, bos, after_ws, total, byte_size(line_text))
+    end
+  end
+
+  # Resolve a forward scan: either return position on line or cross to next line.
+  @spec resolve_forward(
+          Readable.t(),
+          non_neg_integer(),
+          tuple(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: position()
+  defp resolve_forward(_buf, line, bos, after_ws, total, lbs) when after_ws < total do
+    pos_at(line, bos, after_ws, lbs)
+  end
+
+  defp resolve_forward(buf, line, _bos, _after_ws, _total, _lbs) do
+    find_next_word_start(buf, line + 1) || last_char_position(buf)
+  end
+
+  # ── word_backward (b) ─────────────────────────────────────────────────────
 
   @doc """
   Move backward to the start of the previous word (Vim's `b`).
@@ -58,29 +398,46 @@ defmodule Minga.Motion.Word do
       {0, 0}
   """
   @spec word_backward(Readable.t(), position()) :: position()
+  def word_backward(_buf, {0, 0}), do: {0, 0}
+
   def word_backward(buf, {line, col} = pos) do
-    text = Readable.content(buf)
-    {graphemes, byte_offsets} = Helpers.graphemes_with_byte_offsets(text)
-
-    if tuple_size(graphemes) == 0 do
-      pos
-    else
-      all_lines = :binary.split(text, "\n", [:global])
-      byte_off = Helpers.offset_for(all_lines, line, col)
-      g_idx = Helpers.byte_offset_to_grapheme_index(byte_offsets, byte_off)
-
-      if g_idx == 0 do
-        {0, 0}
-      else
-        new_g_idx = do_word_backward(graphemes, g_idx - 1)
-
-        new_byte_off =
-          Helpers.grapheme_index_to_byte_offset(byte_offsets, new_g_idx, byte_size(text))
-
-        Readable.offset_to_position(buf, new_byte_off)
-      end
+    case Readable.line_at(buf, line) do
+      nil -> pos
+      line_text -> do_word_backward(buf, line, col, line_text)
     end
   end
+
+  @spec do_word_backward(Readable.t(), non_neg_integer(), non_neg_integer(), String.t()) ::
+          position()
+  defp do_word_backward(buf, line, col, line_text) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
+    g_idx = if total > 0, do: clamped_gidx(bos, col, total), else: 0
+
+    if total == 0 or g_idx == 0 do
+      find_prev_word_start(buf, line - 1)
+    else
+      backward_word_on_line(buf, line, gs, bos, g_idx, byte_size(line_text))
+    end
+  end
+
+  @spec backward_word_on_line(
+          Readable.t(),
+          non_neg_integer(),
+          tuple(),
+          tuple(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: position()
+  defp backward_word_on_line(buf, line, gs, bos, g_idx, lbs) do
+    non_ws = backward_non_ws(gs, g_idx - 1)
+
+    if non_ws < 0,
+      do: find_prev_word_start(buf, line - 1),
+      else: pos_at(line, bos, run_start_at(gs, non_ws), lbs)
+  end
+
+  # ── word_end (e) ──────────────────────────────────────────────────────────
 
   @doc """
   Move to the end of the current or next word (Vim's `e`).
@@ -93,26 +450,57 @@ defmodule Minga.Motion.Word do
   """
   @spec word_end(Readable.t(), position()) :: position()
   def word_end(buf, {line, col} = pos) do
-    text = Readable.content(buf)
-    {graphemes, byte_offsets} = Helpers.graphemes_with_byte_offsets(text)
-    total = tuple_size(graphemes)
-
-    if total == 0 do
-      pos
-    else
-      all_lines = :binary.split(text, "\n", [:global])
-      byte_off = Helpers.offset_for(all_lines, line, col)
-      g_idx = Helpers.byte_offset_to_grapheme_index(byte_offsets, byte_off)
-      new_g_idx = do_word_end(graphemes, g_idx, total - 1)
-
-      new_byte_off =
-        Helpers.grapheme_index_to_byte_offset(byte_offsets, new_g_idx, byte_size(text))
-
-      Readable.offset_to_position(buf, new_byte_off)
+    case Readable.line_at(buf, line) do
+      nil -> pos
+      line_text -> do_word_end(buf, line, col, pos, line_text)
     end
   end
 
-  # ── WORD motions (W / B / E) ──────────────────────────────────────────────
+  @spec do_word_end(
+          Readable.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          position(),
+          String.t()
+        ) :: position()
+  defp do_word_end(buf, line, col, pos, line_text) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
+
+    if total == 0 do
+      find_word_end_from(buf, line + 1, pos)
+    else
+      start = clamped_gidx(bos, col, total) + 1
+      find_end_after(buf, line, gs, bos, start, total, pos, byte_size(line_text))
+    end
+  end
+
+  @spec find_end_after(
+          Readable.t(),
+          non_neg_integer(),
+          tuple(),
+          tuple(),
+          non_neg_integer(),
+          non_neg_integer(),
+          position(),
+          non_neg_integer()
+        ) :: position()
+  defp find_end_after(buf, line, _gs, _bos, start, total, pos, _lbs) when start >= total do
+    find_word_end_from(buf, line + 1, pos)
+  end
+
+  defp find_end_after(buf, line, gs, bos, start, total, pos, lbs) do
+    after_ws = skip_ws(gs, start, total)
+
+    if after_ws >= total do
+      find_word_end_from(buf, line + 1, pos)
+    else
+      class = Helpers.classify_char(elem(gs, after_ws))
+      pos_at(line, bos, run_end(gs, after_ws, total - 1, class), lbs)
+    end
+  end
+
+  # ── word_forward_big (W) ──────────────────────────────────────────────────
 
   @doc """
   Move forward to the start of the next WORD (Vim's `W`).
@@ -125,24 +513,32 @@ defmodule Minga.Motion.Word do
   """
   @spec word_forward_big(Readable.t(), position()) :: position()
   def word_forward_big(buf, {line, col} = pos) do
-    text = Readable.content(buf)
-    {graphemes, byte_offsets} = Helpers.graphemes_with_byte_offsets(text)
-    total = tuple_size(graphemes)
-
-    if total == 0 do
-      pos
-    else
-      all_lines = :binary.split(text, "\n", [:global])
-      byte_off = Helpers.offset_for(all_lines, line, col)
-      g_idx = Helpers.byte_offset_to_grapheme_index(byte_offsets, byte_off)
-      new_g_idx = do_word_forward_big(graphemes, g_idx, total - 1)
-
-      new_byte_off =
-        Helpers.grapheme_index_to_byte_offset(byte_offsets, new_g_idx, byte_size(text))
-
-      Readable.offset_to_position(buf, new_byte_off)
+    case Readable.line_at(buf, line) do
+      nil -> pos
+      line_text -> do_word_forward_big(buf, line, col, pos, line_text)
     end
   end
+
+  @spec do_word_forward_big(
+          Readable.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          position(),
+          String.t()
+        ) :: position()
+  defp do_word_forward_big(buf, line, col, pos, line_text) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
+
+    if total == 0 do
+      find_next_word_start(buf, line + 1) || pos
+    else
+      after_ws = forward_skip_big_and_ws(gs, clamped_gidx(bos, col, total), total)
+      resolve_forward(buf, line, bos, after_ws, total, byte_size(line_text))
+    end
+  end
+
+  # ── word_backward_big (B) ─────────────────────────────────────────────────
 
   @doc """
   Move backward to the start of the previous WORD (Vim's `B`).
@@ -154,29 +550,46 @@ defmodule Minga.Motion.Word do
       {0, 0}
   """
   @spec word_backward_big(Readable.t(), position()) :: position()
+  def word_backward_big(_buf, {0, 0}), do: {0, 0}
+
   def word_backward_big(buf, {line, col} = pos) do
-    text = Readable.content(buf)
-    {graphemes, byte_offsets} = Helpers.graphemes_with_byte_offsets(text)
-
-    if tuple_size(graphemes) == 0 do
-      pos
-    else
-      all_lines = :binary.split(text, "\n", [:global])
-      byte_off = Helpers.offset_for(all_lines, line, col)
-      g_idx = Helpers.byte_offset_to_grapheme_index(byte_offsets, byte_off)
-
-      if g_idx == 0 do
-        {0, 0}
-      else
-        new_g_idx = do_word_backward_big(graphemes, g_idx - 1)
-
-        new_byte_off =
-          Helpers.grapheme_index_to_byte_offset(byte_offsets, new_g_idx, byte_size(text))
-
-        Readable.offset_to_position(buf, new_byte_off)
-      end
+    case Readable.line_at(buf, line) do
+      nil -> pos
+      line_text -> do_word_backward_big(buf, line, col, line_text)
     end
   end
+
+  @spec do_word_backward_big(Readable.t(), non_neg_integer(), non_neg_integer(), String.t()) ::
+          position()
+  defp do_word_backward_big(buf, line, col, line_text) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
+    g_idx = if total > 0, do: clamped_gidx(bos, col, total), else: 0
+
+    if total == 0 or g_idx == 0 do
+      find_prev_big_word_start(buf, line - 1)
+    else
+      backward_big_word_on_line(buf, line, gs, bos, g_idx, byte_size(line_text))
+    end
+  end
+
+  @spec backward_big_word_on_line(
+          Readable.t(),
+          non_neg_integer(),
+          tuple(),
+          tuple(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: position()
+  defp backward_big_word_on_line(buf, line, gs, bos, g_idx, lbs) do
+    non_ws = backward_non_ws(gs, g_idx - 1)
+
+    if non_ws < 0,
+      do: find_prev_big_word_start(buf, line - 1),
+      else: pos_at(line, bos, big_run_start(gs, non_ws), lbs)
+  end
+
+  # ── word_end_big (E) ──────────────────────────────────────────────────────
 
   @doc """
   Move to the end of the current or next WORD (Vim's `E`).
@@ -189,155 +602,52 @@ defmodule Minga.Motion.Word do
   """
   @spec word_end_big(Readable.t(), position()) :: position()
   def word_end_big(buf, {line, col} = pos) do
-    text = Readable.content(buf)
-    {graphemes, byte_offsets} = Helpers.graphemes_with_byte_offsets(text)
-    total = tuple_size(graphemes)
+    case Readable.line_at(buf, line) do
+      nil -> pos
+      line_text -> do_word_end_big(buf, line, col, pos, line_text)
+    end
+  end
+
+  @spec do_word_end_big(
+          Readable.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          position(),
+          String.t()
+        ) :: position()
+  defp do_word_end_big(buf, line, col, pos, line_text) do
+    {gs, bos} = line_graphemes(line_text)
+    total = tuple_size(gs)
 
     if total == 0 do
-      pos
+      find_big_word_end_from(buf, line + 1, pos)
     else
-      all_lines = :binary.split(text, "\n", [:global])
-      byte_off = Helpers.offset_for(all_lines, line, col)
-      g_idx = Helpers.byte_offset_to_grapheme_index(byte_offsets, byte_off)
-      new_g_idx = do_word_end_big(graphemes, g_idx, total - 1)
-
-      new_byte_off =
-        Helpers.grapheme_index_to_byte_offset(byte_offsets, new_g_idx, byte_size(text))
-
-      Readable.offset_to_position(buf, new_byte_off)
+      start = clamped_gidx(bos, col, total) + 1
+      find_big_end_after(buf, line, gs, bos, start, total, pos, byte_size(line_text))
     end
   end
 
-  # ── Private: `b` motion ───────────────────────────────────────────────────
-
-  @spec do_word_backward(tuple(), non_neg_integer()) :: non_neg_integer()
-  defp do_word_backward(graphemes, offset) do
-    non_ws = Helpers.backward_find(graphemes, offset, fn g -> not Helpers.whitespace?(g) end)
-
-    if non_ws < 0 do
-      0
-    else
-      Helpers.find_run_start_at(graphemes, non_ws)
-    end
-  end
-
-  # ── Private: `w` motion ───────────────────────────────────────────────────
-
-  @spec do_word_forward(tuple(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
-  defp do_word_forward(_graphemes, offset, max) when offset >= max, do: max
-
-  defp do_word_forward(graphemes, offset, max) do
-    current = elem(graphemes, offset)
-    advance_word_forward(graphemes, offset, max, Helpers.classify_char(current))
-  end
-
-  @spec advance_word_forward(
+  @spec find_big_end_after(
+          Readable.t(),
+          non_neg_integer(),
+          tuple(),
           tuple(),
           non_neg_integer(),
           non_neg_integer(),
-          :word | :whitespace | :punctuation
-        ) :: non_neg_integer()
-  defp advance_word_forward(graphemes, offset, max, :whitespace) do
-    Helpers.skip_while(graphemes, offset + 1, max, &Helpers.whitespace?/1)
-  end
-
-  defp advance_word_forward(graphemes, offset, max, :word) do
-    after_word = Helpers.skip_while(graphemes, offset + 1, max, &Helpers.word_char?/1)
-    Helpers.skip_while(graphemes, after_word, max, &Helpers.whitespace?/1)
-  end
-
-  defp advance_word_forward(graphemes, offset, max, :punctuation) do
-    after_punct =
-      Helpers.skip_while(graphemes, offset + 1, max, fn g ->
-        not Helpers.word_char?(g) and not Helpers.whitespace?(g)
-      end)
-
-    Helpers.skip_while(graphemes, after_punct, max, &Helpers.whitespace?/1)
-  end
-
-  # ── Private: `e` motion ───────────────────────────────────────────────────
-
-  @spec do_word_end(tuple(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
-  defp do_word_end(_graphemes, offset, max) when offset >= max, do: max
-
-  defp do_word_end(graphemes, offset, max) do
-    start = min(offset + 1, max)
-    current = elem(graphemes, start)
-
-    run_start =
-      if Helpers.whitespace?(current),
-        do: Helpers.skip_while(graphemes, start, max, &Helpers.whitespace?/1),
-        else: start
-
-    run_char = elem(graphemes, run_start)
-    advance_word_end(graphemes, run_start, max, Helpers.classify_char(run_char))
-  end
-
-  @spec advance_word_end(
-          tuple(),
-          non_neg_integer(),
-          non_neg_integer(),
-          :word | :whitespace | :punctuation
-        ) :: non_neg_integer()
-  defp advance_word_end(graphemes, run_start, max, :word) do
-    Helpers.last_in_run(graphemes, run_start, max, &Helpers.word_char?/1)
-  end
-
-  defp advance_word_end(graphemes, run_start, max, :punctuation) do
-    Helpers.last_in_run(graphemes, run_start, max, fn g ->
-      not Helpers.word_char?(g) and not Helpers.whitespace?(g)
-    end)
-  end
-
-  defp advance_word_end(_graphemes, run_start, _max, :whitespace), do: run_start
-
-  # ── Private: `B` motion ───────────────────────────────────────────────────
-
-  @spec do_word_backward_big(tuple(), non_neg_integer()) :: non_neg_integer()
-  defp do_word_backward_big(graphemes, offset) do
-    non_ws = Helpers.backward_find(graphemes, offset, fn g -> not Helpers.whitespace?(g) end)
-
-    if non_ws < 0 do
-      0
-    else
-      Helpers.find_run_start(graphemes, non_ws, fn g -> not Helpers.whitespace?(g) end)
-    end
-  end
-
-  # ── Private: `W` motion ───────────────────────────────────────────────────
-
-  @spec do_word_forward_big(tuple(), non_neg_integer(), non_neg_integer()) ::
+          position(),
           non_neg_integer()
-  defp do_word_forward_big(_graphemes, offset, max) when offset >= max, do: max
-
-  defp do_word_forward_big(graphemes, offset, max) do
-    current = elem(graphemes, offset)
-
-    if Helpers.whitespace?(current) do
-      Helpers.skip_while(graphemes, offset + 1, max, &Helpers.whitespace?/1)
-    else
-      after_word =
-        Helpers.skip_while(graphemes, offset + 1, max, fn g -> not Helpers.whitespace?(g) end)
-
-      Helpers.skip_while(graphemes, after_word, max, &Helpers.whitespace?/1)
-    end
+        ) :: position()
+  defp find_big_end_after(buf, line, _gs, _bos, start, total, pos, _lbs) when start >= total do
+    find_big_word_end_from(buf, line + 1, pos)
   end
 
-  # ── Private: `E` motion ───────────────────────────────────────────────────
+  defp find_big_end_after(buf, line, gs, bos, start, total, pos, lbs) do
+    after_ws = skip_ws(gs, start, total)
 
-  @spec do_word_end_big(tuple(), non_neg_integer(), non_neg_integer()) ::
-          non_neg_integer()
-  defp do_word_end_big(_graphemes, offset, max) when offset >= max, do: max
-
-  defp do_word_end_big(graphemes, offset, max) do
-    start = min(offset + 1, max)
-    current = elem(graphemes, start)
-
-    run_start =
-      if Helpers.whitespace?(current),
-        do: Helpers.skip_while(graphemes, start, max, &Helpers.whitespace?/1),
-        else: start
-
-    Helpers.last_in_run(graphemes, run_start, max, fn g -> not Helpers.whitespace?(g) end)
+    if after_ws >= total do
+      find_big_word_end_from(buf, line + 1, pos)
+    else
+      pos_at(line, bos, big_run_end(gs, after_ws, total - 1), lbs)
+    end
   end
 end

--- a/test/minga/motion/word_test.exs
+++ b/test/minga/motion/word_test.exs
@@ -134,4 +134,105 @@ defmodule Minga.Motion.WordTest do
       assert Motion.word_end(b, {0, 0}) == {0, 0}
     end
   end
+
+  describe "word_forward_big/2" do
+    test "moves past punctuation without stopping" do
+      b = buf("foo.bar baz")
+      assert Motion.word_forward_big(b, {0, 0}) == {0, 8}
+    end
+
+    test "moves across lines" do
+      b = buf("foo.bar\nbaz")
+      assert Motion.word_forward_big(b, {0, 0}) == {1, 0}
+    end
+
+    test "skips multiple spaces" do
+      b = buf("abc   def")
+      assert Motion.word_forward_big(b, {0, 0}) == {0, 6}
+    end
+
+    test "stays at end of buffer when no next WORD" do
+      b = buf("hello")
+      assert Motion.word_forward_big(b, {0, 4}) == {0, 4}
+    end
+
+    test "works on empty buffer" do
+      b = buf("")
+      assert Motion.word_forward_big(b, {0, 0}) == {0, 0}
+    end
+
+    test "moves from whitespace to start of next WORD" do
+      b = buf("foo bar")
+      assert Motion.word_forward_big(b, {0, 3}) == {0, 4}
+    end
+
+    test "moves across blank lines" do
+      b = buf("abc\n\ndef")
+      assert Motion.word_forward_big(b, {0, 0}) == {2, 0}
+    end
+  end
+
+  describe "word_backward_big/2" do
+    test "moves past punctuation to start of WORD" do
+      b = buf("foo.bar baz")
+      assert Motion.word_backward_big(b, {0, 8}) == {0, 0}
+    end
+
+    test "moves across lines" do
+      b = buf("hello\nworld")
+      assert Motion.word_backward_big(b, {1, 0}) == {0, 0}
+    end
+
+    test "stays at {0,0} when already at start" do
+      b = buf("hello")
+      assert Motion.word_backward_big(b, {0, 0}) == {0, 0}
+    end
+
+    test "works on empty buffer" do
+      b = buf("")
+      assert Motion.word_backward_big(b, {0, 0}) == {0, 0}
+    end
+
+    test "skips whitespace backward to find WORD start" do
+      b = buf("foo   bar")
+      assert Motion.word_backward_big(b, {0, 8}) == {0, 6}
+    end
+
+    test "treats punctuation as part of WORD" do
+      b = buf("foo.bar baz.qux")
+      assert Motion.word_backward_big(b, {0, 10}) == {0, 8}
+    end
+  end
+
+  describe "word_end_big/2" do
+    test "moves to end of WORD including punctuation" do
+      b = buf("foo.bar baz")
+      assert Motion.word_end_big(b, {0, 0}) == {0, 6}
+    end
+
+    test "moves across lines" do
+      b = buf("hi\nfoo.bar")
+      assert Motion.word_end_big(b, {0, 1}) == {1, 6}
+    end
+
+    test "stays at end of buffer" do
+      b = buf("hello")
+      assert Motion.word_end_big(b, {0, 4}) == {0, 4}
+    end
+
+    test "works on empty buffer" do
+      b = buf("")
+      assert Motion.word_end_big(b, {0, 0}) == {0, 0}
+    end
+
+    test "skips whitespace to reach next WORD end" do
+      b = buf("abc   def.ghi")
+      assert Motion.word_end_big(b, {0, 2}) == {0, 12}
+    end
+
+    test "single character" do
+      b = buf("x")
+      assert Motion.word_end_big(b, {0, 0}) == {0, 0}
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Word motions (`w`, `b`, `e`, `W`, `B`, `E`) previously called `Readable.content/1` which concatenated the entire gap buffer into a new binary on every keystroke. For a 50K-line file, that's an O(n) allocation per motion.

Now each motion uses `Readable.line_at/2` iteratively, fetching only the lines it needs (typically 1-3). This makes word motions O(k) where k is the number of lines between the cursor and the next word boundary.

## Changes

- **`lib/minga/motion/word.ex`**: Complete rewrite of internal scanning logic. All 6 public functions (`word_forward`, `word_backward`, `word_end`, `word_forward_big`, `word_backward_big`, `word_end_big`) now use line-by-line scanning instead of global grapheme tables. Cross-line helpers fetch next/previous lines only when needed.
- **`test/minga/motion/word_test.exs`**: Added 19 new tests for `W`, `B`, `E` (big-word) motions which were previously untested.

## Verification

- All 24 existing word motion tests pass unchanged (behavior identical)
- All 12 property-based motion tests pass
- All 53 operator-pending tests pass (`dw`, `cw`, `yw` etc.)
- Full suite: 6161 tests, 0 failures
- `mix lint` passes clean (format, credo, compile --warnings-as-errors, dialyzer)

Closes #907