### PR TITLE
feat(buffer): add move_if_possible/2 to eliminate h/l motion snapshots

### DIFF
--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -274,6 +274,23 @@ defmodule Minga.Buffer.Server do
     GenServer.call(server, {:move_cursor, direction})
   end
 
+  @doc """
+  Moves the cursor left or right if the move is valid, performing the boundary
+  check inside the buffer process. Returns `{:ok, new_position}` if the cursor
+  moved, or `:at_boundary` if the cursor was already at the boundary.
+
+  For `:left`, the boundary is column 0.
+  For `:right`, the boundary is the last grapheme position on the current line.
+
+  This avoids copying the entire `Document.t()` across the process boundary
+  just to check whether the cursor is at a line boundary.
+  """
+  @spec move_if_possible(GenServer.server(), :left | :right) ::
+          {:ok, Document.position()} | :at_boundary
+  def move_if_possible(server, direction) when direction in [:left, :right] do
+    GenServer.call(server, {:move_if_possible, direction})
+  end
+
   @doc "Returns the total line count."
   @spec line_count(GenServer.server()) :: pos_integer()
   def line_count(server) do
@@ -1205,6 +1222,26 @@ defmodule Minga.Buffer.Server do
     {:reply, :ok, %{state | document: doc}}
   end
 
+  def handle_call(
+        {:move_if_possible, :left},
+        _from,
+        %{document: %Document{cursor_col: col} = doc} = state
+      )
+      when col > 0 do
+    new_doc = Document.move(doc, :left)
+    {:reply, {:ok, Document.cursor(new_doc)}, %{state | document: new_doc}}
+  end
+
+  def handle_call({:move_if_possible, :left}, _from, state) do
+    {:reply, :at_boundary, state}
+  end
+
+  def handle_call({:move_if_possible, :right}, _from, state) do
+    %Document{cursor_line: line, cursor_col: col} = doc = state.document
+    max_col = right_boundary(doc, line)
+    do_move_right(col, max_col, doc, state)
+  end
+
   def handle_call(:line_count, _from, state) do
     {:reply, Document.line_count(state.document), state}
   end
@@ -1905,5 +1942,26 @@ defmodule Minga.Buffer.Server do
         last_part = List.last(parts)
         {line + new_lines, String.length(last_part)}
     end
+  end
+
+  # ── move_if_possible helpers ──
+
+  @spec right_boundary(Document.t(), non_neg_integer()) :: non_neg_integer()
+  defp right_boundary(doc, line) do
+    case Document.lines(doc, line, 1) do
+      [text] when byte_size(text) > 0 -> Unicode.last_grapheme_byte_offset(text)
+      _ -> 0
+    end
+  end
+
+  @spec do_move_right(non_neg_integer(), non_neg_integer(), Document.t(), BufState.t()) ::
+          {:reply, {:ok, Document.position()} | :at_boundary, BufState.t()}
+  defp do_move_right(col, max_col, doc, state) when col < max_col do
+    new_doc = Document.move(doc, :right)
+    {:reply, {:ok, Document.cursor(new_doc)}, %{state | document: new_doc}}
+  end
+
+  defp do_move_right(_col, _max_col, _doc, state) do
+    {:reply, :at_boundary, state}
   end
 end

--- a/lib/minga/editor/commands/movement.ex
+++ b/lib/minga/editor/commands/movement.ex
@@ -76,9 +76,7 @@ defmodule Minga.Editor.Commands.Movement do
     if mode in [:insert, :replace] do
       BufferServer.move(buf, :left)
     else
-      gb = BufferServer.snapshot(buf)
-      {_line, col} = Document.cursor(gb)
-      if col > 0, do: BufferServer.move(buf, :left)
+      BufferServer.move_if_possible(buf, :left)
     end
 
     state
@@ -88,16 +86,7 @@ defmodule Minga.Editor.Commands.Movement do
     if mode in [:insert, :replace] do
       BufferServer.move(buf, :right)
     else
-      gb = BufferServer.snapshot(buf)
-      {line, col} = Document.cursor(gb)
-
-      max_col =
-        case Document.lines(gb, line, 1) do
-          [text] when byte_size(text) > 0 -> Unicode.last_grapheme_byte_offset(text)
-          _ -> 0
-        end
-
-      if col < max_col, do: BufferServer.move(buf, :right)
+      BufferServer.move_if_possible(buf, :right)
     end
 
     state

--- a/test/minga/buffer/server_test.exs
+++ b/test/minga/buffer/server_test.exs
@@ -147,6 +147,96 @@ defmodule Minga.Buffer.ServerTest do
     end
   end
 
+  describe "move_if_possible/2" do
+    test "moves left when not at column 0" do
+      pid = start_supervised!({Server, content: "hello"})
+      Server.move_to(pid, {0, 3})
+      assert {:ok, {0, 2}} = Server.move_if_possible(pid, :left)
+      assert Server.cursor(pid) == {0, 2}
+    end
+
+    test "left from column 1 succeeds and reaches column 0" do
+      pid = start_supervised!({Server, content: "hello"})
+      Server.move_to(pid, {0, 1})
+      assert {:ok, {0, 0}} = Server.move_if_possible(pid, :left)
+      assert Server.cursor(pid) == {0, 0}
+    end
+
+    test "returns :at_boundary when at column 0 (left)" do
+      pid = start_supervised!({Server, content: "hello"})
+      assert :at_boundary = Server.move_if_possible(pid, :left)
+      assert Server.cursor(pid) == {0, 0}
+    end
+
+    test "moves right when not at end of line" do
+      pid = start_supervised!({Server, content: "hello"})
+      assert {:ok, {0, 1}} = Server.move_if_possible(pid, :right)
+      assert Server.cursor(pid) == {0, 1}
+    end
+
+    test "returns :at_boundary when at last grapheme position (right)" do
+      pid = start_supervised!({Server, content: "hello"})
+      # "hello" has last grapheme at byte offset 4
+      Server.move_to(pid, {0, 4})
+      assert :at_boundary = Server.move_if_possible(pid, :right)
+      assert Server.cursor(pid) == {0, 4}
+    end
+
+    test "single character line is at boundary for right" do
+      # single char: last_grapheme_byte_offset("x") is 0, cursor already at max_col
+      pid = start_supervised!({Server, content: "x"})
+      assert :at_boundary = Server.move_if_possible(pid, :right)
+      assert Server.cursor(pid) == {0, 0}
+    end
+
+    test "returns :at_boundary on empty line (right)" do
+      pid = start_supervised!({Server, content: "\n"})
+      assert :at_boundary = Server.move_if_possible(pid, :right)
+      assert Server.cursor(pid) == {0, 0}
+    end
+
+    test "returns :at_boundary at start of buffer (left)" do
+      pid = start_supervised!({Server, content: "abc\ndef"})
+      assert :at_boundary = Server.move_if_possible(pid, :left)
+    end
+
+    test "returns :at_boundary at end of last line (right)" do
+      pid = start_supervised!({Server, content: "abc\ndef"})
+      Server.move_to(pid, {1, 2})
+      assert :at_boundary = Server.move_if_possible(pid, :right)
+    end
+
+    test "consecutive right moves walk to end of line then stop" do
+      pid = start_supervised!({Server, content: "abc"})
+      assert {:ok, {0, 1}} = Server.move_if_possible(pid, :right)
+      assert {:ok, {0, 2}} = Server.move_if_possible(pid, :right)
+      assert :at_boundary = Server.move_if_possible(pid, :right)
+      # cursor stays put after boundary
+      assert :at_boundary = Server.move_if_possible(pid, :right)
+      assert Server.cursor(pid) == {0, 2}
+    end
+
+    test "respects byte-offset positions for multi-byte graphemes (right)" do
+      # "héllo": h(0) é(1, 2 bytes) l(3) l(4) o(5) — last grapheme at byte offset 5
+      pid = start_supervised!({Server, content: "héllo"})
+      Server.move_to(pid, {0, 5})
+      assert :at_boundary = Server.move_if_possible(pid, :right)
+    end
+
+    test "left through multi-byte grapheme returns correct byte offset" do
+      # "héllo": moving left from l(3) should land on é(1)
+      pid = start_supervised!({Server, content: "héllo"})
+      Server.move_to(pid, {0, 3})
+      assert {:ok, {0, 1}} = Server.move_if_possible(pid, :left)
+    end
+
+    test "does not mark buffer dirty" do
+      pid = start_supervised!({Server, content: "hello"})
+      Server.move_if_possible(pid, :right)
+      refute Server.dirty?(pid)
+    end
+  end
+
   describe "move_to/2" do
     test "moves to exact position" do
       {:ok, pid} = Server.start_link(content: "abc\ndef\nghi")


### PR DESCRIPTION
## Summary

Adds `Buffer.Server.move_if_possible/2` that performs boundary checks inside the buffer process, returning `{:ok, new_position} | :at_boundary`. This eliminates copying the entire `Document.t()` across the process boundary for every `h`/`l` keystroke in normal mode.

## Changes

- **`lib/minga/buffer/server.ex`**: New `move_if_possible/2` public API with guard-based `handle_call` for `:left` and extracted private helpers (`right_boundary/2`, `do_move_right/4`) for `:right`
- **`lib/minga/editor/commands/movement.ex`**: `:move_left` and `:move_right` in normal mode now delegate to `move_if_possible` instead of `snapshot` + boundary check + `move`
- **`test/minga/buffer/server_test.exs`**: 13 new tests covering boundary cases, unicode, consecutive moves, and dirty flag

## Performance impact

For a 50K-line file (~3MB), every `h` or `l` keystroke previously copied the entire document across the process boundary just to check a boundary condition. Now it's a single GenServer call with zero document copies.

Insert/replace modes are unchanged (they allow crossing line boundaries via `BufferServer.move/2`).

Closes #906