### PR TITLE
feat(buffer): add source metadata to undo stack entries

### DIFF
--- a/lib/minga/agent/tools/write_file.ex
+++ b/lib/minga/agent/tools/write_file.ex
@@ -45,7 +45,7 @@ defmodule Minga.Agent.Tools.WriteFile do
   @spec execute_via_buffer(pid(), String.t(), String.t()) ::
           {:ok, String.t()} | {:error, String.t()}
   defp execute_via_buffer(pid, path, content) do
-    case BufferServer.replace_content(pid, content) do
+    case BufferServer.replace_content(pid, content, :agent) do
       :ok -> {:ok, "wrote #{byte_size(content)} bytes to #{path} (via buffer)"}
       {:error, :read_only} -> {:error, "buffer is read-only: #{path}"}
     end

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -226,9 +226,11 @@ defmodule Minga.Buffer.Server do
   end
 
   @doc "Replaces the entire buffer content, pushing the old content onto the undo stack."
-  @spec replace_content(GenServer.server(), String.t()) :: :ok | {:error, :read_only}
-  def replace_content(server, new_content) when is_binary(new_content) do
-    GenServer.call(server, {:replace_content, new_content})
+  @spec replace_content(GenServer.server(), String.t(), BufState.edit_source()) ::
+          :ok | {:error, :read_only}
+  def replace_content(server, new_content, source \\ :user)
+      when is_binary(new_content) and source in [:user, :agent, :lsp] do
+    GenServer.call(server, {:replace_content, new_content, source})
   end
 
   @doc "Replaces buffer content bypassing read-only. For programmatic panel updates."
@@ -862,7 +864,7 @@ defmodule Minga.Buffer.Server do
         Document.cursor(new_buf)
       )
 
-    state = push_undo(state, new_buf) |> mark_dirty() |> record_edit(delta)
+    state = push_undo(state, new_buf, :user) |> mark_dirty() |> record_edit(delta)
     {:reply, :ok, state}
   end
 
@@ -882,7 +884,7 @@ defmodule Minga.Buffer.Server do
         Document.cursor(new_doc)
       )
 
-    state = push_undo(state, new_doc) |> mark_dirty() |> record_edit(delta)
+    state = push_undo(state, new_doc, :user) |> mark_dirty() |> record_edit(delta)
     {:reply, :ok, state}
   end
 
@@ -908,7 +910,7 @@ defmodule Minga.Buffer.Server do
     delta =
       EditDelta.replacement(start_byte, old_end_byte, from_pos, to_pos, new_text, new_end_pos)
 
-    {:reply, :ok, push_undo(state, doc) |> mark_dirty() |> record_edit(delta)}
+    {:reply, :ok, push_undo(state, doc, :user) |> mark_dirty() |> record_edit(delta)}
   end
 
   def handle_call({:apply_text_edits, _edits}, _from, %{read_only: true} = state) do
@@ -937,7 +939,7 @@ defmodule Minga.Buffer.Server do
 
     # Multi-edit batches are complex to delta-track (offsets shift between
     # edits). Clear pending edits to force a full content sync.
-    {:reply, :ok, push_undo(state, doc) |> mark_dirty() |> clear_edits()}
+    {:reply, :ok, push_undo(state, doc, :lsp) |> mark_dirty() |> clear_edits()}
   end
 
   # ── Find and Replace ──
@@ -955,7 +957,8 @@ defmodule Minga.Buffer.Server do
 
     case do_find_and_replace(content, old_text, new_text) do
       {:ok, new_doc, msg} ->
-        {:reply, {:ok, msg}, push_undo_force(state, new_doc) |> mark_dirty() |> clear_edits()}
+        {:reply, {:ok, msg},
+         push_undo_force(state, new_doc, :agent) |> mark_dirty() |> clear_edits()}
 
       {:error, _} = err ->
         {:reply, err, state}
@@ -979,7 +982,7 @@ defmodule Minga.Buffer.Server do
 
     new_state =
       if any_applied do
-        push_undo_force(state, final_doc) |> mark_dirty() |> clear_edits()
+        push_undo_force(state, final_doc, :agent) |> mark_dirty() |> clear_edits()
       else
         state
       end
@@ -1008,7 +1011,7 @@ defmodule Minga.Buffer.Server do
           Document.cursor(old_doc)
         )
 
-      {:reply, :ok, push_undo(state, new_buf) |> mark_dirty() |> record_edit(delta)}
+      {:reply, :ok, push_undo(state, new_buf, :user) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -1046,7 +1049,7 @@ defmodule Minga.Buffer.Server do
           old_end_pos
         )
 
-      {:reply, :ok, push_undo(state, new_buf) |> mark_dirty() |> record_edit(delta)}
+      {:reply, :ok, push_undo(state, new_buf, :user) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -1168,12 +1171,12 @@ defmodule Minga.Buffer.Server do
     end
   end
 
-  def handle_call({:replace_content, _new_content}, _from, %{read_only: true} = state) do
+  def handle_call({:replace_content, _new_content, _source}, _from, %{read_only: true} = state) do
     {:reply, {:error, :read_only}, state}
   end
 
-  def handle_call({:replace_content, new_content}, _from, state) do
-    new_state = push_undo_force(state, state.document)
+  def handle_call({:replace_content, new_content, source}, _from, state) do
+    new_state = push_undo_force(state, state.document, source)
     new_buf = Document.new(new_content)
     {:reply, :ok, mark_dirty(%{new_state | document: new_buf}) |> clear_edits()}
   end
@@ -1447,7 +1450,7 @@ defmodule Minga.Buffer.Server do
       start_byte = byte_offset_at(old_content, from_pos)
       old_end_byte = byte_offset_at(old_content, to_pos)
       delta = EditDelta.deletion(start_byte, old_end_byte, from_pos, to_pos)
-      {:reply, :ok, push_undo(state, new_buf) |> mark_dirty() |> record_edit(delta)}
+      {:reply, :ok, push_undo(state, new_buf, :user) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -1479,7 +1482,7 @@ defmodule Minga.Buffer.Server do
       start_byte = byte_offset_at(old_content, from_pos)
       old_end_byte = byte_offset_at(old_content, to_pos)
       delta = EditDelta.deletion(start_byte, old_end_byte, from_pos, to_pos)
-      {:reply, :ok, push_undo(state, new_buf) |> mark_dirty() |> record_edit(delta)}
+      {:reply, :ok, push_undo(state, new_buf, :user) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -1496,7 +1499,7 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call({:apply_snapshot, new_buf}, _from, state) do
-    {:reply, :ok, push_undo(state, new_buf) |> mark_dirty() |> clear_edits()}
+    {:reply, :ok, push_undo(state, new_buf, :user) |> mark_dirty() |> clear_edits()}
   end
 
   def handle_call({:clear_line, _line}, _from, %{read_only: true} = state) do
@@ -1509,7 +1512,7 @@ defmodule Minga.Buffer.Server do
     if new_buf == state.document do
       {:reply, {:ok, yanked}, state}
     else
-      {:reply, {:ok, yanked}, push_undo(state, new_buf) |> mark_dirty()}
+      {:reply, {:ok, yanked}, push_undo(state, new_buf, :user) |> mark_dirty()}
     end
   end
 
@@ -1518,8 +1521,8 @@ defmodule Minga.Buffer.Server do
       [] ->
         {:reply, :ok, state}
 
-      [{prev_version, prev_buf} | rest_undo] ->
-        redo_entry = {state.version, state.document}
+      [{prev_version, prev_buf, source} | rest_undo] ->
+        redo_entry = {state.version, state.document, source}
 
         new_state =
           %{
@@ -1532,6 +1535,7 @@ defmodule Minga.Buffer.Server do
           |> sync_dirty()
           |> clear_edits()
 
+        log_undo_source(:undo, source)
         {:reply, :ok, new_state}
     end
   end
@@ -1541,8 +1545,8 @@ defmodule Minga.Buffer.Server do
       [] ->
         {:reply, :ok, state}
 
-      [{next_version, next_buf} | rest_redo] ->
-        undo_entry = {state.version, state.document}
+      [{next_version, next_buf, source} | rest_redo] ->
+        undo_entry = {state.version, state.document, source}
 
         new_state =
           %{
@@ -1555,6 +1559,7 @@ defmodule Minga.Buffer.Server do
           |> sync_dirty()
           |> clear_edits()
 
+        log_undo_source(:redo, source)
         {:reply, :ok, new_state}
     end
   end
@@ -1828,13 +1833,26 @@ defmodule Minga.Buffer.Server do
   end
 
   # Delegates to BufState for time-based undo coalescing.
-  @spec push_undo(state(), Document.t()) :: state()
-  defp push_undo(state, new_buf), do: BufState.push_undo(state, new_buf)
+  @spec push_undo(state(), Document.t(), BufState.edit_source()) :: state()
+  defp push_undo(state, new_buf, source), do: BufState.push_undo(state, new_buf, source)
 
-  # Force-pushes an undo entry, bypassing coalescing. Used for explicit
-  # user actions like :replace_content.
-  @spec push_undo_force(state(), Document.t()) :: state()
-  defp push_undo_force(state, new_buf), do: BufState.push_undo_force(state, new_buf)
+  # Force-pushes an undo entry, bypassing coalescing. Used for agent
+  # batch edits and explicit actions like :replace_content.
+  @spec push_undo_force(state(), Document.t(), BufState.edit_source()) :: state()
+  defp push_undo_force(state, new_buf, source),
+    do: BufState.push_undo_force(state, new_buf, source)
+
+  # Logs undo/redo source for non-user edits (diagnostic, gated by :log_level_editor).
+  @spec log_undo_source(:undo | :redo, BufState.edit_source()) :: :ok
+  defp log_undo_source(_action, :user), do: :ok
+
+  defp log_undo_source(:undo, source) do
+    Minga.Log.debug(:editor, "Undo: #{source} edit")
+  end
+
+  defp log_undo_source(:redo, source) do
+    Minga.Log.debug(:editor, "Redo: #{source} edit")
+  end
 
   @spec mark_dirty(state()) :: state()
   defp mark_dirty(state), do: BufState.mark_dirty(state)

--- a/lib/minga/buffer/state.ex
+++ b/lib/minga/buffer/state.ex
@@ -28,8 +28,12 @@ defmodule Minga.Buffer.State do
   """
   @type buffer_type :: :file | :nofile | :nowrite | :prompt | :terminal
 
-  @typedoc "An undo/redo stack entry: the document snapshot and its version at capture time."
-  @type stack_entry :: {non_neg_integer(), Document.t()}
+  @typedoc "The source of an edit for undo/redo attribution."
+  @type edit_source :: :user | :agent | :lsp
+
+  @typedoc "An undo/redo stack entry: the document snapshot, version, and edit source."
+  @type stack_entry ::
+          {version :: non_neg_integer(), document :: Document.t(), source :: edit_source()}
 
   @enforce_keys [:document]
   defstruct document: nil,
@@ -129,19 +133,19 @@ defmodule Minga.Buffer.State do
   single undo step while preserving distinct undo entries for edits
   separated by a pause.
   """
-  @spec push_undo(t(), Document.t()) :: t()
-  def push_undo(%__MODULE__{} = state, new_buf) do
+  @spec push_undo(t(), Document.t(), edit_source()) :: t()
+  def push_undo(%__MODULE__{} = state, new_buf, source) when source in [:user, :agent, :lsp] do
     now = System.monotonic_time(:millisecond)
     elapsed = now - state.last_undo_at
 
-    push_undo(state, new_buf, now, elapsed)
+    do_push_undo(state, new_buf, source, now, elapsed)
   end
 
   # First undo ever, or enough time has passed: push a new entry.
-  @spec push_undo(t(), Document.t(), integer(), integer()) :: t()
-  defp push_undo(%__MODULE__{} = state, new_buf, now, elapsed)
+  @spec do_push_undo(t(), Document.t(), edit_source(), integer(), integer()) :: t()
+  defp do_push_undo(%__MODULE__{} = state, new_buf, source, now, elapsed)
        when state.last_undo_at == 0 or elapsed >= @undo_coalesce_ms do
-    entry = {state.version, state.document}
+    entry = {state.version, state.document, source}
 
     new_undo =
       [entry | state.undo_stack]
@@ -151,21 +155,24 @@ defmodule Minga.Buffer.State do
   end
 
   # Within the coalescing window: replace document, keep stack as-is.
-  defp push_undo(%__MODULE__{} = state, new_buf, now, _elapsed) do
+  # Source is ignored here; the stack entry was already recorded with the
+  # source from the first edit in this coalescing window.
+  defp do_push_undo(%__MODULE__{} = state, new_buf, _source, now, _elapsed) do
     %{state | document: new_buf, redo_stack: [], last_undo_at: now}
   end
 
   @doc """
   Pushes an undo entry unconditionally, bypassing time-based coalescing.
 
-  Use this for explicit user actions (like `:replace_content`) where
-  each invocation should always be a separate undo step regardless of
+  Use this for explicit actions (like `:replace_content`, agent batch edits)
+  where each invocation should always be a separate undo step regardless of
   timing.
   """
-  @spec push_undo_force(t(), Document.t()) :: t()
-  def push_undo_force(%__MODULE__{} = state, new_buf) do
+  @spec push_undo_force(t(), Document.t(), edit_source()) :: t()
+  def push_undo_force(%__MODULE__{} = state, new_buf, source)
+      when source in [:user, :agent, :lsp] do
     now = System.monotonic_time(:millisecond)
-    entry = {state.version, state.document}
+    entry = {state.version, state.document, source}
 
     new_undo =
       [entry | state.undo_stack]

--- a/test/minga/buffer/server_test.exs
+++ b/test/minga/buffer/server_test.exs
@@ -694,6 +694,83 @@ defmodule Minga.Buffer.ServerTest do
     end
   end
 
+  describe "undo source metadata" do
+    test "user edits are tagged :user in undo stack" do
+      pid = start_supervised!({Server, content: "hello"})
+      Server.insert_char(pid, "X")
+
+      %{undo_stack: [{_version, _doc, source} | _]} = :sys.get_state(pid)
+      assert source == :user
+    end
+
+    test "agent edits (find_and_replace) are tagged :agent" do
+      pid = start_supervised!({Server, content: "hello world"})
+      Server.find_and_replace(pid, "hello", "goodbye")
+
+      %{undo_stack: [{_version, _doc, source} | _]} = :sys.get_state(pid)
+      assert source == :agent
+    end
+
+    test "agent batch edits (find_and_replace_batch) are tagged :agent" do
+      pid = start_supervised!({Server, content: "hello world"})
+      Server.find_and_replace_batch(pid, [{"hello", "goodbye"}])
+
+      %{undo_stack: [{_version, _doc, source} | _]} = :sys.get_state(pid)
+      assert source == :agent
+    end
+
+    test "LSP batch edits (apply_text_edits) are tagged :lsp" do
+      pid = start_supervised!({Server, content: "hello"})
+      Server.apply_text_edits(pid, [{{0, 0}, {0, 5}, "goodbye"}])
+
+      %{undo_stack: [{_version, _doc, source} | _]} = :sys.get_state(pid)
+      assert source == :lsp
+    end
+
+    test "source metadata survives undo/redo round-trip" do
+      pid = start_supervised!({Server, content: "hello world"})
+      Server.find_and_replace(pid, "hello", "goodbye")
+
+      # Undo pops the agent entry and creates a redo entry carrying the source
+      Server.undo(pid)
+      %{redo_stack: [{_version, _doc, source} | _]} = :sys.get_state(pid)
+      assert source == :agent
+
+      # Redo pushes it back to undo_stack
+      Server.redo(pid)
+      %{undo_stack: [{_version, _doc, source} | _]} = :sys.get_state(pid)
+      assert source == :agent
+    end
+
+    test "replace_content with :agent source is tagged :agent" do
+      pid = start_supervised!({Server, content: "hello"})
+      Server.replace_content(pid, "goodbye", :agent)
+
+      %{undo_stack: [{_version, _doc, source} | _]} = :sys.get_state(pid)
+      assert source == :agent
+    end
+
+    test "replace_content defaults to :user source" do
+      pid = start_supervised!({Server, content: "hello"})
+      Server.replace_content(pid, "goodbye")
+
+      %{undo_stack: [{_version, _doc, source} | _]} = :sys.get_state(pid)
+      assert source == :user
+    end
+
+    test "interleaved user and agent edits preserve correct sources" do
+      pid = start_supervised!({Server, content: "hello world"})
+
+      Server.insert_char(pid, "X")
+      Server.break_undo_coalescing(pid)
+      Server.find_and_replace(pid, "Xhello", "goodbye")
+
+      %{undo_stack: [{_, _, agent_source}, {_, _, user_source} | _]} = :sys.get_state(pid)
+      assert agent_source == :agent
+      assert user_source == :user
+    end
+  end
+
   describe "edit delta tracking" do
     test "insert_char records an insertion delta" do
       {:ok, pid} = Server.start_link(content: "hello")


### PR DESCRIPTION
Closes #943

## What

Undo stack entries now carry a `:source` field (`:user`, `:agent`, or `:lsp`) so the editor can distinguish who made each change. This is a prerequisite for future UX improvements like grouped agent undo, visual indicators for agent-modified regions, and undo history browsing.

## Changes

- **`state.ex`**: New `edit_source` type, `stack_entry` widened from 2-tuple to labeled 3-tuple `{version, document, source}`. `push_undo/3` and `push_undo_force/3` accept and thread source.
- **`server.ex`**: All 13 `push_undo` call sites pass the correct source. Undo/redo handlers destructure 3-tuples and carry source across. New `log_undo_source/2` logs non-user undo/redo to `Minga.Log.debug(:editor)`.
- **`write_file.ex`**: Passes `:agent` to `replace_content/3`.
- **`replace_content/3`**: New optional `source` parameter (defaults to `:user`) with runtime guard validation.

## Source assignments

| Source | Operations |
|--------|-----------|
| `:user` | insert_char, insert_text, delete_*, apply_snapshot, clear_line, replace_content (default), apply_text_edit |
| `:agent` | find_and_replace, find_and_replace_batch, replace_content (from agent tools) |
| `:lsp` | apply_text_edits (batch) |

## Testing

8 new tests covering: source tagging for each source type, undo/redo round-trip preservation, interleaved user/agent ordering, replace_content default and explicit source. All 6185 existing tests pass unchanged.