### PR TITLE
fix(editor): 2dd/3dd now yank all deleted lines into register

### DIFF
--- a/lib/minga/editor/change_tracking.ex
+++ b/lib/minga/editor/change_tracking.ex
@@ -151,7 +151,9 @@ defmodule Minga.Editor.ChangeTracking do
   defp editing_command?({:delete_chars_at, _}), do: true
   defp editing_command?({:delete_chars_before, _}), do: true
   defp editing_command?(:delete_line), do: true
+  defp editing_command?({:delete_lines_counted, _}), do: true
   defp editing_command?(:change_line), do: true
+  defp editing_command?({:change_lines_counted, _}), do: true
   defp editing_command?(:join_lines), do: true
   defp editing_command?(:toggle_case), do: true
   defp editing_command?(:indent_line), do: true

--- a/lib/minga/editor/commands.ex
+++ b/lib/minga/editor/commands.ex
@@ -287,6 +287,18 @@ defmodule Minga.Editor.Commands do
     guard_buffer(state, fn -> Operators.execute(state, cmd) end)
   end
 
+  def execute(state, {:delete_lines_counted, _} = cmd) do
+    guard_buffer(state, fn -> Operators.execute(state, cmd) end)
+  end
+
+  def execute(state, {:change_lines_counted, _} = cmd) do
+    guard_buffer(state, fn -> Operators.execute(state, cmd) end)
+  end
+
+  def execute(state, {:yank_lines_counted, _} = cmd) do
+    guard_buffer(state, fn -> Operators.execute(state, cmd) end)
+  end
+
   # ── Parameterized visual ──────────────────────────────────────────────────
 
   def execute(state, {:wrap_visual_selection, _, _} = cmd) do

--- a/lib/minga/editor/commands/operators.ex
+++ b/lib/minga/editor/commands/operators.ex
@@ -41,30 +41,57 @@ defmodule Minga.Editor.Commands.Operators do
 
   # ── Line-wise operators (dd / yy / cc / S) ────────────────────────────────
 
-  def execute(%{buffers: %{active: buf}} = state, :delete_line) do
+  def execute(%{buffers: %{active: _buf}} = state, :delete_line) do
+    execute(state, {:delete_lines_counted, 1})
+  end
+
+  def execute(%{buffers: %{active: buf}} = state, {:delete_lines_counted, count})
+      when is_integer(count) and count >= 1 do
     if read_only?(buf) do
       read_only_msg(state)
     else
       {line, _col} = BufferServer.cursor(buf)
-      yanked = BufferServer.get_lines_content(buf, line, line)
-      BufferServer.delete_lines(buf, line, line)
+      total = BufferServer.line_count(buf)
+      end_line = min(line + count - 1, total - 1)
+      yanked = BufferServer.get_lines_content(buf, line, end_line)
+      BufferServer.delete_lines(buf, line, end_line)
       Helpers.put_register(state, yanked <> "\n", :delete, :linewise)
     end
   end
 
-  def execute(%{buffers: %{active: buf}} = state, :change_line) do
+  def execute(%{buffers: %{active: _buf}} = state, :change_line) do
+    execute(state, {:change_lines_counted, 1})
+  end
+
+  def execute(%{buffers: %{active: buf}} = state, {:change_lines_counted, count})
+      when is_integer(count) and count >= 1 do
     if read_only?(buf) do
       read_only_msg(state)
     else
       {line, _col} = BufferServer.cursor(buf)
-      {:ok, yanked} = BufferServer.clear_line(buf, line)
+      total = BufferServer.line_count(buf)
+      end_line = min(line + count - 1, total - 1)
+
+      # Yank all lines first, then clear/delete
+      yanked = BufferServer.get_lines_content(buf, line, end_line)
+
+      # Delete extra lines (all but the first), then clear the remaining one
+      delete_trailing_lines(buf, line, end_line)
+      {:ok, _} = BufferServer.clear_line(buf, line)
       Helpers.put_register(state, yanked <> "\n", :delete, :linewise)
     end
   end
 
-  def execute(%{buffers: %{active: buf}} = state, :yank_line) do
+  def execute(%{buffers: %{active: _buf}} = state, :yank_line) do
+    execute(state, {:yank_lines_counted, 1})
+  end
+
+  def execute(%{buffers: %{active: buf}} = state, {:yank_lines_counted, count})
+      when is_integer(count) and count >= 1 do
     {line, _col} = BufferServer.cursor(buf)
-    yanked = BufferServer.get_lines_content(buf, line, line)
+    total = BufferServer.line_count(buf)
+    end_line = min(line + count - 1, total - 1)
+    yanked = BufferServer.get_lines_content(buf, line, end_line)
     Helpers.put_register(state, yanked <> "\n", :yank, :linewise)
   end
 
@@ -90,6 +117,14 @@ defmodule Minga.Editor.Commands.Operators do
   end
 
   # ── Helpers ────────────────────────────────────────────────────────────────
+
+  @spec delete_trailing_lines(pid(), non_neg_integer(), non_neg_integer()) :: :ok
+  defp delete_trailing_lines(_buf, same, same), do: :ok
+
+  defp delete_trailing_lines(buf, start_line, end_line) do
+    BufferServer.delete_lines(buf, start_line + 1, end_line)
+    :ok
+  end
 
   @spec read_only?(pid()) :: boolean()
   defp read_only?(buf), do: BufferServer.read_only?(buf)

--- a/lib/minga/mode/operator_pending.ex
+++ b/lib/minga/mode/operator_pending.ex
@@ -28,11 +28,11 @@ defmodule Minga.Mode.OperatorPending do
   | `d$`         | `{:delete_motion, :line_end}`            |
   | `dgg`        | `{:delete_motion, :document_start}`      |
   | `dG`         | `{:delete_motion, :document_end}`        |
-  | `dd`         | `:delete_line`                           |
+  | `dd`         | `{:delete_lines_counted, n}`             |
   | `cw`         | `{:change_motion, :word_forward}`        |
-  | `cc`         | `:change_line`                           |
+  | `cc`         | `{:change_lines_counted, n}`             |
   | `yw`         | `{:yank_motion, :word_forward}`          |
-  | `yy`         | `:yank_line`                             |
+  | `yy`         | `{:yank_lines_counted, n}`               |
 
   The `c*` variants transition to `:insert` mode; all others return to `:normal`.
 
@@ -252,18 +252,18 @@ defmodule Minga.Mode.OperatorPending do
   # ── Double-operator: line-wise variants (dd / cc / yy / >> / <<) ─────────
 
   def handle_key({?d, 0}, %OPState{operator: :delete} = state) do
-    cmds = List.duplicate(:delete_line, OPState.total_count(state))
-    {:execute_then_transition, cmds, :normal, OPState.to_base_state(state)}
+    {:execute_then_transition, [{:delete_lines_counted, OPState.total_count(state)}], :normal,
+     OPState.to_base_state(state)}
   end
 
   def handle_key({?c, 0}, %OPState{operator: :change} = state) do
-    cmds = List.duplicate(:change_line, OPState.total_count(state))
-    {:execute_then_transition, cmds, :insert, OPState.to_base_state(state)}
+    {:execute_then_transition, [{:change_lines_counted, OPState.total_count(state)}], :insert,
+     OPState.to_base_state(state)}
   end
 
   def handle_key({?y, 0}, %OPState{operator: :yank} = state) do
-    cmds = List.duplicate(:yank_line, OPState.total_count(state))
-    {:execute_then_transition, cmds, :normal, OPState.to_base_state(state)}
+    {:execute_then_transition, [{:yank_lines_counted, OPState.total_count(state)}], :normal,
+     OPState.to_base_state(state)}
   end
 
   # gcc — comment current line(s)

--- a/test/minga/editor/commands/operators_test.exs
+++ b/test/minga/editor/commands/operators_test.exs
@@ -51,5 +51,134 @@ defmodule Minga.Editor.Commands.OperatorsTest do
       send_key(editor, ?p)
       assert String.contains?(BufferServer.content(buffer), "hello")
     end
+
+    test "2dd deletes two lines and p pastes both back" do
+      {editor, buffer} = start_editor("aaa\nbbb\nccc\nddd")
+
+      # 2dd: delete two lines starting from cursor (line 0)
+      send_key(editor, ?2)
+      send_key(editor, ?d)
+      send_key(editor, ?d)
+
+      content = BufferServer.content(buffer)
+      refute String.contains?(content, "aaa")
+      refute String.contains?(content, "bbb")
+      assert String.contains?(content, "ccc")
+      assert String.contains?(content, "ddd")
+
+      # p: paste after cursor — should restore both deleted lines
+      send_key(editor, ?p)
+
+      pasted = BufferServer.content(buffer)
+      assert String.contains?(pasted, "aaa")
+      assert String.contains?(pasted, "bbb")
+    end
+
+    test "3dd deletes three lines and p pastes all three back" do
+      {editor, buffer} = start_editor("line1\nline2\nline3\nline4\nline5")
+
+      send_key(editor, ?3)
+      send_key(editor, ?d)
+      send_key(editor, ?d)
+
+      content = BufferServer.content(buffer)
+      refute String.contains?(content, "line1")
+      refute String.contains?(content, "line2")
+      refute String.contains?(content, "line3")
+      assert String.contains?(content, "line4")
+
+      send_key(editor, ?p)
+
+      pasted = BufferServer.content(buffer)
+      assert String.contains?(pasted, "line1")
+      assert String.contains?(pasted, "line2")
+      assert String.contains?(pasted, "line3")
+    end
+
+    test "2yy yanks two lines and p pastes both" do
+      {editor, buffer} = start_editor("aaa\nbbb\nccc")
+
+      send_key(editor, ?2)
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+
+      # Buffer should be unchanged after yank
+      assert BufferServer.content(buffer) == "aaa\nbbb\nccc"
+
+      # Move to last line and paste
+      send_key(editor, ?G)
+      send_key(editor, ?p)
+
+      pasted = BufferServer.content(buffer)
+      assert String.contains?(pasted, "aaa")
+      assert String.contains?(pasted, "bbb")
+
+      # Both yanked lines should appear in the pasted content
+      lines = String.split(pasted, "\n")
+      assert length(lines) == 5
+    end
+
+    test "cc clears current line and enters insert mode" do
+      {editor, buffer} = start_editor("hello\nworld\nfoo")
+      send_key(editor, ?c)
+      send_key(editor, ?c)
+
+      # Line should be cleared but still exist
+      content = BufferServer.content(buffer)
+      refute String.contains?(content, "hello")
+      assert String.contains?(content, "world")
+      assert String.contains?(content, "foo")
+
+      # The editor should now be in insert mode
+      %{vim: %{mode: mode}} = :sys.get_state(editor)
+      assert mode == :insert
+    end
+
+    test "2cc deletes both lines and register contains both" do
+      {editor, buffer} = start_editor("aaa\nbbb\nccc\nddd")
+
+      send_key(editor, ?2)
+      send_key(editor, ?c)
+      send_key(editor, ?c)
+
+      content = BufferServer.content(buffer)
+      refute String.contains?(content, "aaa")
+      refute String.contains?(content, "bbb")
+      assert String.contains?(content, "ccc")
+      assert String.contains?(content, "ddd")
+
+      # Should be in insert mode
+      %{vim: %{mode: mode}} = :sys.get_state(editor)
+      assert mode == :insert
+
+      # Escape to normal, then paste to verify register has both lines
+      send_key(editor, 27)
+      send_key(editor, ?p)
+
+      pasted = BufferServer.content(buffer)
+      assert String.contains?(pasted, "aaa")
+      assert String.contains?(pasted, "bbb")
+    end
+
+    test "dd on single line clears content" do
+      {editor, buffer} = start_editor("only line")
+      send_key(editor, ?d)
+      send_key(editor, ?d)
+
+      content = BufferServer.content(buffer)
+      assert content == ""
+    end
+
+    test "2dd with count exceeding buffer lines deletes to end" do
+      {editor, buffer} = start_editor("aaa\nbbb")
+
+      # 5dd but only 2 lines exist — should delete both without crashing
+      send_key(editor, ?5)
+      send_key(editor, ?d)
+      send_key(editor, ?d)
+
+      content = BufferServer.content(buffer)
+      assert content == ""
+    end
   end
 end

--- a/test/minga/mode/operator_pending_test.exs
+++ b/test/minga/mode/operator_pending_test.exs
@@ -110,35 +110,35 @@ defmodule Minga.Mode.OperatorPendingTest do
   # ── Double-operator (line-wise) ────────────────────────────────────────────
 
   describe "dd (delete line)" do
-    test "d+d emits :delete_line and transitions to :normal" do
+    test "d+d emits {:delete_lines_counted, 1} and transitions to :normal" do
       state = op_state(:delete)
 
-      assert {:execute_then_transition, [:delete_line], :normal, _} =
+      assert {:execute_then_transition, [{:delete_lines_counted, 1}], :normal, _} =
                OperatorPending.handle_key({?d, 0}, state)
     end
 
-    test "dd with op_count=3 emits 3 :delete_line commands" do
+    test "dd with op_count=3 emits {:delete_lines_counted, 3}" do
       state = op_state(:delete, 3)
 
-      assert {:execute_then_transition, [:delete_line, :delete_line, :delete_line], :normal, _} =
+      assert {:execute_then_transition, [{:delete_lines_counted, 3}], :normal, _} =
                OperatorPending.handle_key({?d, 0}, state)
     end
   end
 
   describe "cc (change line)" do
-    test "c+c emits :change_line and transitions to :insert" do
+    test "c+c emits {:change_lines_counted, 1} and transitions to :insert" do
       state = op_state(:change)
 
-      assert {:execute_then_transition, [:change_line], :insert, _} =
+      assert {:execute_then_transition, [{:change_lines_counted, 1}], :insert, _} =
                OperatorPending.handle_key({?c, 0}, state)
     end
   end
 
   describe "yy (yank line)" do
-    test "y+y emits :yank_line and transitions to :normal" do
+    test "y+y emits {:yank_lines_counted, 1} and transitions to :normal" do
       state = op_state(:yank)
 
-      assert {:execute_then_transition, [:yank_line], :normal, _} =
+      assert {:execute_then_transition, [{:yank_lines_counted, 1}], :normal, _} =
                OperatorPending.handle_key({?y, 0}, state)
     end
   end
@@ -262,12 +262,12 @@ defmodule Minga.Mode.OperatorPendingTest do
       assert [{:delete_motion, :word_forward}] = cmds
     end
 
-    test "d then d produces :delete_line command and normal mode" do
+    test "d then d produces {:delete_lines_counted, 1} command and normal mode" do
       state = Mode.initial_state()
       {_, _, op_state} = Mode.process(:normal, {?d, 0}, state)
       {new_mode, cmds, _} = Mode.process(:operator_pending, {?d, 0}, op_state)
       assert new_mode == :normal
-      assert cmds == [:delete_line]
+      assert cmds == [{:delete_lines_counted, 1}]
     end
 
     test "Escape from operator_pending returns to normal" do


### PR DESCRIPTION
# TL;DR

`2dd` then `p` now correctly pastes both deleted lines. Previously only the last line was pasted because each line deletion independently overwrote the register.

## Context

User-reported bug: pressing `2dd` (delete two lines) followed by `p` (paste) only restored one of the two deleted lines. The same issue affected all counted line-wise operators (`3dd`, `2yy`, `2cc`, etc.).

## Changes

- **Root cause:** Operator-pending mode emitted `List.duplicate(:delete_line, n)`, producing N separate commands. Each `:delete_line` independently yanked its single line into the register, overwriting whatever was stored by the previous one. Only the last deleted line survived.
- **Fix:** Replaced the duplicated atom commands with single counted commands (`{:delete_lines_counted, n}`, `{:change_lines_counted, n}`, `{:yank_lines_counted, n}`). These yank all N lines as a single string into the register before performing the delete/clear.
- **Backward compatibility:** The old `:delete_line`, `:change_line`, `:yank_line` atoms now delegate to the counted variants with count=1.
- **Supporting changes:** Added command dispatch entries in `commands.ex`, registered the new commands as editing commands in `change_tracking.ex`, updated the operator-pending moduledoc to reflect the new command shapes.
- Extracted `delete_trailing_lines/3` multi-clause helper in `operators.ex` to replace an `if` conditional (pattern matching per project style).

## Verification

```bash
mix test.debug test/minga/editor/commands/operators_test.exs
# 10 tests, 0 failures

mix test.debug test/minga/mode/operator_pending_test.exs
# 53 tests, 0 failures

mix precommit  # lint + dialyzer pass
mix test       # full suite: 6212 tests, 0 failures from this change
```

Manual verification: open a file with 4+ lines, press `2dd`, then `p`. Both deleted lines are restored.

## Acceptance Criteria Addressed

- `2dd` deletes two lines and stores both in the register ✅
- `p` after `2dd` pastes both deleted lines ✅
- Same fix applies to `cc` and `yy` counted variants ✅
- No regressions in existing single-line `dd`/`cc`/`yy` behavior ✅