### PR TITLE
feat(macos): embed BEAM release and Zig parser inside Minga.app bundle

### DIFF
--- a/lib/minga/port/manager.ex
+++ b/lib/minga/port/manager.ex
@@ -129,15 +129,6 @@ defmodule Minga.Port.Manager do
   @impl true
   @spec handle_info(term(), state()) :: {:noreply, state()}
   def handle_info({port, {:data, data}}, %{port: port} = state) do
-    # Debug: log all port data opcodes
-    opcode = if byte_size(data) > 0, do: :binary.at(data, 0), else: nil
-
-    File.write(
-      "/tmp/minga_port.log",
-      "opcode=0x#{if opcode, do: Integer.to_string(opcode, 16), else: "nil"} size=#{byte_size(data)}\n",
-      [:append]
-    )
-
     case Protocol.decode_event(data) do
       {:ok, {:ready, width, height, caps}} ->
         new_state = %{state | ready: true, terminal_size: {width, height}, capabilities: caps}
@@ -155,12 +146,6 @@ defmodule Minga.Port.Manager do
         {:noreply, new_state}
 
       {:ok, {:resize, width, height}} ->
-        File.write(
-          "/tmp/minga_resize.log",
-          "RESIZE w=#{width} h=#{height} subs=#{length(state.subscribers)}\n",
-          [:append]
-        )
-
         new_state = %{state | terminal_size: {width, height}}
         broadcast(new_state.subscribers, {:minga_input, {:resize, width, height}})
         {:noreply, new_state}
@@ -281,23 +266,77 @@ defmodule Minga.Port.Manager do
   defp default_renderer_path(backend) do
     binary_name = renderer_binary_name(backend)
 
-    # In a release (or Burrito binary), the renderer lives in priv/
-    priv_path = Application.app_dir(:minga, "priv/#{binary_name}")
+    # Priority 1: app bundle context (BEAM release embedded inside Minga.app).
+    # Priority 2: priv/ directory (Burrito binary or standard release).
+    # Priority 3: dev/test fallback in the source tree.
+    case find_app_bundle_binary(binary_name, backend) do
+      {:ok, path} ->
+        path
 
-    if File.exists?(priv_path) do
-      priv_path
+      :not_in_bundle ->
+        priv_path = Application.app_dir(:minga, "priv/#{binary_name}")
+        if File.exists?(priv_path), do: priv_path, else: dev_fallback_path(backend)
+    end
+  end
+
+  @spec dev_fallback_path(backend()) :: String.t()
+  defp dev_fallback_path(:gui), do: find_xcode_build_product("Minga")
+
+  defp dev_fallback_path(:tui) do
+    Path.join([File.cwd!(), "zig", "zig-out", "bin", "minga-renderer"])
+  end
+
+  # When running from a BEAM release embedded inside a .app bundle,
+  # resolve the frontend binary relative to the bundle root.
+  #
+  # The release root is at: Minga.app/Contents/Resources/release/
+  # The GUI binary is at:   Minga.app/Contents/MacOS/Minga
+  # The TUI binary is at:   Minga.app/Contents/Resources/release/lib/minga-*/priv/minga-renderer
+  #                         (which Application.app_dir already resolves, so TUI returns :not_in_bundle)
+  @spec find_app_bundle_binary(String.t(), backend()) :: {:ok, String.t()} | :not_in_bundle
+  defp find_app_bundle_binary(binary_name, :gui) do
+    case app_bundle_root() do
+      {:ok, bundle_root} ->
+        gui_path = Path.join([bundle_root, "Contents", "MacOS", binary_name])
+
+        if File.exists?(gui_path) do
+          {:ok, gui_path}
+        else
+          :not_in_bundle
+        end
+
+      :not_in_bundle ->
+        :not_in_bundle
+    end
+  end
+
+  defp find_app_bundle_binary(_binary_name, _tui), do: :not_in_bundle
+
+  # Detect whether the BEAM is running inside a .app bundle by checking
+  # the release root path. Returns the bundle root (e.g., "/path/to/Minga.app")
+  # or :not_in_bundle.
+  #
+  # The release root is the directory containing bin/, lib/, releases/, erts-*.
+  # In a bundle, this is at: Minga.app/Contents/Resources/release/
+  # So the bundle root is 3 levels up from the release root.
+  @spec app_bundle_root() :: {:ok, String.t()} | :not_in_bundle
+  defp app_bundle_root do
+    # :code.root_dir() returns the release root in an OTP release,
+    # e.g., "/path/to/Minga.app/Contents/Resources/release"
+    release_root = :code.root_dir() |> to_string()
+
+    if String.contains?(release_root, ".app/Contents/Resources/release") do
+      # Walk up: release/ -> Resources/ -> Contents/ -> Minga.app/
+      bundle_root =
+        release_root
+        |> Path.join("..")
+        |> Path.join("..")
+        |> Path.join("..")
+        |> Path.expand()
+
+      {:ok, bundle_root}
     else
-      # Dev/test fallback: look in the source tree.
-      case backend do
-        :gui ->
-          # Swift GUI binary built by Xcode.
-          # In dev, find it in DerivedData via the build settings output.
-          find_xcode_build_product("Minga")
-
-        _tui ->
-          # Zig TUI binary in zig-out/bin/
-          Path.join([File.cwd!(), "zig", "zig-out", "bin", "minga-renderer"])
-      end
+      :not_in_bundle
     end
   end
 

--- a/lib/mix/tasks/app.assemble.ex
+++ b/lib/mix/tasks/app.assemble.ex
@@ -1,0 +1,306 @@
+defmodule Mix.Tasks.App.Assemble do
+  @moduledoc """
+  Assembles a complete `Minga.app` macOS application bundle.
+
+  Takes the Xcode-built `.app` bundle (with the Swift/Metal GUI, Metal shaders,
+  fonts, and Info.plist) and embeds the BEAM release (from `mix release minga_macos`)
+  inside it at `Contents/Resources/release/`.
+
+  The result is a self-contained application: double-clicking `Minga.app` will
+  eventually launch the editor with no external Erlang/Elixir dependency (#952).
+
+  ## Usage
+
+      # Build everything from scratch:
+      MIX_ENV=prod mix app.assemble
+
+      # Skip the Xcode/release builds if you already ran them:
+      MIX_ENV=prod mix app.assemble --no-build
+
+  ## CPU Architecture
+
+  Apple Silicon (arm64) only. Minga does not target Intel Macs.
+  All three components (Swift GUI, BEAM release, Zig parser) are
+  compiled for arm64. The CI release pipeline runs on `macos-14`
+  (Apple Silicon) runners.
+
+  ## Prerequisites
+
+  - Xcode command line tools installed (`xcode-select --install`)
+  - XcodeGen installed (`brew install xcodegen`)
+  - Zig toolchain available (for the tree-sitter parser)
+
+  ## What it produces
+
+      Minga.app/
+        Contents/
+          MacOS/
+            Minga                    # Swift/Metal GUI executable
+          Resources/
+            release/                 # Self-contained BEAM release
+              bin/minga_macos        # Release entry script
+              lib/                   # BEAM modules (includes minga-parser in priv/)
+              releases/              # Release metadata
+              erts-*/                # Embedded Erlang runtime
+            default.metallib         # Metal shaders (from Xcode)
+            Fonts/                   # Bundled fonts (from Xcode)
+            Assets.car               # App icon (from Xcode)
+          Info.plist
+  """
+
+  use Mix.Task
+
+  @app_name "Minga"
+
+  @doc false
+  @spec run([String.t()]) :: :ok
+  def run(args) do
+    no_build = "--no-build" in args
+
+    # Step 1: Build the BEAM release (unless --no-build)
+    release_path = build_beam_release(no_build)
+
+    # Step 2: Build the Xcode project (unless --no-build)
+    app_bundle_path = build_xcode_project(no_build)
+
+    # Step 3: Embed the BEAM release into the app bundle
+    embed_release(app_bundle_path, release_path)
+
+    # Step 4: Strip TUI-only binaries from the embedded release
+    strip_tui_binaries(app_bundle_path)
+
+    # Step 5: Ad-hoc codesign the complete bundle
+    codesign_bundle(app_bundle_path)
+
+    # Step 6: Report bundle size
+    report_size(app_bundle_path)
+
+    Mix.shell().info("""
+
+    ✅ #{@app_name}.app assembled successfully at:
+       #{app_bundle_path}
+    """)
+  end
+
+  @spec build_beam_release(boolean()) :: String.t()
+  defp build_beam_release(true) do
+    release_path = Path.join([Mix.Project.build_path(), "rel", "minga_macos"])
+
+    unless File.dir?(release_path) do
+      Mix.raise("""
+      BEAM release not found at #{release_path}.
+      Run `MIX_ENV=prod mix release minga_macos` first, or drop --no-build.
+      """)
+    end
+
+    Mix.shell().info("Using existing BEAM release at #{release_path}")
+    release_path
+  end
+
+  defp build_beam_release(false) do
+    Mix.shell().info("Building BEAM release (minga_macos)...")
+    Mix.Task.run("release", ["minga_macos", "--overwrite"])
+    Path.join([Mix.Project.build_path(), "rel", "minga_macos"])
+  end
+
+  @spec build_xcode_project(boolean()) :: String.t()
+  defp build_xcode_project(true) do
+    app_path = find_xcode_app_bundle()
+
+    unless app_path do
+      Mix.raise("""
+      Xcode build product not found. Run `xcodebuild` first, or drop --no-build.
+      """)
+    end
+
+    Mix.shell().info("Using existing Xcode build at #{app_path}")
+    app_path
+  end
+
+  defp build_xcode_project(false) do
+    macos_dir = Path.join(File.cwd!(), "macos")
+    project_path = Path.join(macos_dir, "#{@app_name}.xcodeproj")
+
+    # Generate the Xcode project from project.yml if needed
+    unless File.dir?(project_path) do
+      Mix.shell().info("Generating Xcode project with XcodeGen...")
+
+      case System.cmd("xcodegen", ["generate"], cd: macos_dir, stderr_to_stdout: true) do
+        {_output, 0} -> :ok
+        {output, _} -> Mix.raise("XcodeGen failed:\n#{output}")
+      end
+    end
+
+    Mix.shell().info("Building Xcode project (Release configuration)...")
+
+    case System.cmd(
+           "xcodebuild",
+           [
+             "-project",
+             project_path,
+             "-scheme",
+             @app_name,
+             "-configuration",
+             "Release",
+             "build"
+           ],
+           stderr_to_stdout: true
+         ) do
+      {_output, 0} ->
+        :ok
+
+      {output, _} ->
+        Mix.raise("Xcode build failed:\n#{output}")
+    end
+
+    app_path = find_xcode_app_bundle()
+
+    unless app_path do
+      Mix.raise("Xcode build succeeded but #{@app_name}.app not found in DerivedData")
+    end
+
+    app_path
+  end
+
+  @spec embed_release(String.t(), String.t()) :: :ok
+  defp embed_release(app_bundle_path, release_path) do
+    resources_dir = Path.join([app_bundle_path, "Contents", "Resources"])
+    target_dir = Path.join(resources_dir, "release")
+
+    # Remove any previous embedded release
+    if File.dir?(target_dir) do
+      File.rm_rf!(target_dir)
+    end
+
+    Mix.shell().info("Embedding BEAM release into #{@app_name}.app...")
+    File.mkdir_p!(target_dir)
+
+    # Copy the entire release directory tree
+    case System.cmd("cp", ["-a", release_path <> "/.", target_dir], stderr_to_stdout: true) do
+      {_output, 0} -> :ok
+      {output, _} -> Mix.raise("Failed to copy release: #{output}")
+    end
+
+    :ok
+  end
+
+  @spec strip_tui_binaries(String.t()) :: :ok
+  defp strip_tui_binaries(app_bundle_path) do
+    # Find and remove TUI-only binaries from the embedded release's priv/
+    priv_glob =
+      Path.join([
+        app_bundle_path,
+        "Contents",
+        "Resources",
+        "release",
+        "lib",
+        "minga-*",
+        "priv"
+      ])
+
+    priv_dirs = Path.wildcard(priv_glob)
+
+    tui_binaries = ["minga-renderer", "minga-renderer-gui"]
+
+    for priv_dir <- priv_dirs, binary_name <- tui_binaries do
+      path = Path.join(priv_dir, binary_name)
+
+      if File.exists?(path) do
+        File.rm!(path)
+        Mix.shell().info("Stripped TUI binary: #{binary_name}")
+      end
+    end
+
+    :ok
+  end
+
+  @spec codesign_bundle(String.t()) :: :ok
+  defp codesign_bundle(app_bundle_path) do
+    Mix.shell().info("Ad-hoc code signing #{@app_name}.app...")
+
+    case System.cmd(
+           "codesign",
+           ["--force", "--deep", "--sign", "-", app_bundle_path],
+           stderr_to_stdout: true
+         ) do
+      {_output, 0} -> :ok
+      {output, _} -> Mix.shell().error("codesign warning: #{output}")
+    end
+
+    :ok
+  end
+
+  @spec report_size(String.t()) :: :ok
+  defp report_size(app_bundle_path) do
+    {output, 0} = System.cmd("du", ["-sh", app_bundle_path])
+    total_size = output |> String.split("\t") |> hd() |> String.trim()
+
+    release_dir = Path.join([app_bundle_path, "Contents", "Resources", "release"])
+    {rel_output, 0} = System.cmd("du", ["-sh", release_dir])
+    release_size = rel_output |> String.split("\t") |> hd() |> String.trim()
+
+    gui_binary = Path.join([app_bundle_path, "Contents", "MacOS", @app_name])
+    {gui_stat, 0} = System.cmd("du", ["-sh", gui_binary])
+    gui_size = gui_stat |> String.split("\t") |> hd() |> String.trim()
+
+    Mix.shell().info("""
+
+    Bundle size breakdown:
+      Total:        #{total_size}
+      BEAM release: #{release_size}
+      GUI binary:   #{gui_size}
+    """)
+  end
+
+  @spec find_xcode_app_bundle() :: String.t() | nil
+  defp find_xcode_app_bundle do
+    project_path = Path.join([File.cwd!(), "macos", "#{@app_name}.xcodeproj"])
+
+    with {output, 0} <- xcodebuild_show_settings(project_path),
+         {:ok, path} <- resolve_app_path(output) do
+      path
+    else
+      _ -> nil
+    end
+  end
+
+  @spec xcodebuild_show_settings(String.t()) :: {String.t(), non_neg_integer()}
+  defp xcodebuild_show_settings(project_path) do
+    System.cmd(
+      "xcodebuild",
+      [
+        "-project",
+        project_path,
+        "-scheme",
+        @app_name,
+        "-configuration",
+        "Release",
+        "-showBuildSettings"
+      ],
+      stderr_to_stdout: true
+    )
+  end
+
+  @spec resolve_app_path(String.t()) :: {:ok, String.t()} | :error
+  defp resolve_app_path(build_settings_output) do
+    built_dir = parse_build_setting(build_settings_output, "BUILT_PRODUCTS_DIR")
+    full_product = parse_build_setting(build_settings_output, "FULL_PRODUCT_NAME")
+
+    case {built_dir, full_product} do
+      {dir, product} when is_binary(dir) and is_binary(product) ->
+        path = Path.join(dir, product)
+        if File.dir?(path), do: {:ok, path}, else: :error
+
+      _ ->
+        :error
+    end
+  end
+
+  @spec parse_build_setting(String.t(), String.t()) :: String.t() | nil
+  defp parse_build_setting(output, key) do
+    case Regex.run(~r/\s+#{Regex.escape(key)} = (.+)/, output) do
+      [_, value] -> String.trim(value)
+      _ -> nil
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -226,6 +226,7 @@ defmodule Minga.MixProject do
 
   defp releases do
     [
+      # TUI release: Burrito-wrapped standalone binary (macOS + Linux)
       minga: [
         steps: [:assemble, &Burrito.wrap/1],
         burrito: [
@@ -233,6 +234,16 @@ defmodule Minga.MixProject do
           debug: Mix.env() != :prod,
           no_clean: true
         ]
+      ],
+      # macOS GUI release: plain OTP release embedded inside Minga.app bundle.
+      # Produces a self-contained BEAM release with ERTS included.
+      # Use `mix release minga_macos` then `mix app.assemble` to build the bundle.
+      minga_macos: [
+        include_erts: true,
+        cookie: "minga_app_cookie",
+        steps: [:assemble],
+        rel_templates_path: "rel",
+        strip_beams: Mix.env() == :prod
       ]
     ]
   end


### PR DESCRIPTION
## What

Adds a self-contained BEAM release inside the `Minga.app` bundle so users don't need Erlang/Elixir installed.

## Changes

**`mix.exs`** — New `minga_macos` release target (`include_erts: true`, plain OTP release) alongside the existing Burrito-wrapped `minga` release for TUI distribution.

**`lib/mix/tasks/app.assemble.ex`** (new) — `mix app.assemble` task that:
1. Builds the BEAM release (`mix release minga_macos`)
2. Builds the Xcode project (`xcodebuild Release`)
3. Embeds the release at `Contents/Resources/release/`
4. Strips TUI-only binaries (`minga-renderer`, `minga-renderer-gui`)
5. Ad-hoc code signs the bundle
6. Reports bundle size breakdown

**`lib/minga/port/manager.ex`** — App bundle detection: when the BEAM runs inside a `.app` bundle, `Port.Manager` resolves the GUI binary at `Contents/MacOS/Minga` by detecting the bundle root from `:code.root_dir()`. Also removes two debug `File.write` calls that were writing to `/tmp/` on every port message.

## Bundle size

| Component | Size |
|-----------|------|
| Total | 103MB |
| BEAM release | 88MB |
| GUI binary | 124K |
| Parser (tree-sitter) | 49MB |

Apple Silicon (arm64) only.

## Testing

- `mix precommit` passes (lint + tests)
- `MIX_ENV=prod mix app.assemble` produces a complete bundle
- Bundle structure verified: GUI binary, BEAM release, parser, Metal shaders, fonts, icon all present
- TUI binaries correctly stripped from embedded release

Closes #951. Part of #554.