### PR TITLE
fix(test): drain deferred messages after start_editor to prevent send_key race

### DIFF
--- a/test/minga/buffer_management_test.exs
+++ b/test/minga/buffer_management_test.exs
@@ -35,7 +35,7 @@ defmodule Minga.BufferManagementTest do
       assert_row_contains(ctx, 1, "first file")
 
       # Open second file via :e
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       assert_row_contains(ctx, 1, "second file")
       assert_modeline_contains(ctx, "file2.txt")
@@ -52,11 +52,11 @@ defmodule Minga.BufferManagementTest do
       ctx = start_editor("first", file_path: path1)
 
       # Open second file
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
       assert_modeline_contains(ctx, "[2/2]")
 
       # Open first file again — should switch back, not create a third buffer
-      send_keys(ctx, ":e #{path1}<CR>")
+      send_keys_sync(ctx, ":e #{path1}<CR>")
       assert_row_contains(ctx, 1, "first")
       assert_modeline_contains(ctx, "[1/2]")
     end
@@ -74,25 +74,25 @@ defmodule Minga.BufferManagementTest do
 
       ctx = start_editor("alpha", file_path: path1)
 
-      send_keys(ctx, ":e #{path2}<CR>")
-      send_keys(ctx, ":e #{path3}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path3}<CR>")
 
       # Now on buffer 3/3 (gamma)
       assert_row_contains(ctx, 1, "gamma")
       assert_modeline_contains(ctx, "[3/3]")
 
       # SPC b n → wraps to buffer 1 (alpha)
-      send_keys(ctx, "<SPC>bn")
+      send_keys_sync(ctx, "<SPC>bn")
       assert_row_contains(ctx, 1, "alpha")
       assert_modeline_contains(ctx, "[1/3]")
 
       # SPC b n → buffer 2 (beta)
-      send_keys(ctx, "<SPC>bn")
+      send_keys_sync(ctx, "<SPC>bn")
       assert_row_contains(ctx, 1, "beta")
       assert_modeline_contains(ctx, "[2/3]")
 
       # SPC b p → back to buffer 1 (alpha)
-      send_keys(ctx, "<SPC>bp")
+      send_keys_sync(ctx, "<SPC>bp")
       assert_row_contains(ctx, 1, "alpha")
       assert_modeline_contains(ctx, "[1/3]")
     end
@@ -100,10 +100,10 @@ defmodule Minga.BufferManagementTest do
     test "next/prev with single buffer is a no-op" do
       ctx = start_editor("only one")
 
-      send_keys(ctx, "<SPC>bn")
+      send_keys_sync(ctx, "<SPC>bn")
       assert_row_contains(ctx, 1, "only one")
 
-      send_keys(ctx, "<SPC>bp")
+      send_keys_sync(ctx, "<SPC>bp")
       assert_row_contains(ctx, 1, "only one")
     end
   end
@@ -117,12 +117,12 @@ defmodule Minga.BufferManagementTest do
       File.write!(path2, "why")
 
       ctx = start_editor("ex", file_path: path1)
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
       assert_row_contains(ctx, 1, "why")
 
       # SPC b b → opens picker, first item is x.txt, Enter selects it
-      send_keys(ctx, "<SPC>bb")
-      send_key(ctx, 13)
+      send_keys_sync(ctx, "<SPC>bb")
+      send_key_sync(ctx, 13)
       assert_row_contains(ctx, 1, "ex")
     end
   end
@@ -136,10 +136,10 @@ defmodule Minga.BufferManagementTest do
       File.write!(path2, "second")
 
       ctx = start_editor("first", file_path: path1)
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       # On buffer 2/2, kill it
-      send_keys(ctx, "<SPC>bd")
+      send_keys_sync(ctx, "<SPC>bd")
 
       # Should switch to the remaining buffer
       assert_row_contains(ctx, 1, "first")
@@ -154,7 +154,7 @@ defmodule Minga.BufferManagementTest do
       File.write!(path, "alone")
 
       ctx = start_editor("alone", file_path: path)
-      send_keys(ctx, "<SPC>bd")
+      send_keys_sync(ctx, "<SPC>bd")
 
       # Should show an empty buffer (dashboard disabled pending rewrite)
       screen = screen_text(ctx)
@@ -170,13 +170,13 @@ defmodule Minga.BufferManagementTest do
       File.write!(path2, "quebec")
 
       ctx = start_editor("papa", file_path: path1)
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       # Switch back to first buffer and kill it
-      send_keys(ctx, "<SPC>bp")
+      send_keys_sync(ctx, "<SPC>bp")
       assert_row_contains(ctx, 1, "papa")
 
-      send_keys(ctx, "<SPC>bd")
+      send_keys_sync(ctx, "<SPC>bd")
       assert_row_contains(ctx, 1, "quebec")
       ml = modeline(ctx)
       refute String.contains?(ml, "[")
@@ -195,10 +195,10 @@ defmodule Minga.BufferManagementTest do
       ml = modeline(ctx)
       refute String.contains?(ml, "[1/")
 
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
       assert_modeline_contains(ctx, "[2/2]")
 
-      send_keys(ctx, "<SPC>bp")
+      send_keys_sync(ctx, "<SPC>bp")
       assert_modeline_contains(ctx, "[1/2]")
     end
   end
@@ -206,7 +206,7 @@ defmodule Minga.BufferManagementTest do
   describe ":new — new empty buffer" do
     test "creates a new unnamed buffer" do
       ctx = start_editor("hello")
-      send_keys(ctx, ":new<CR>")
+      send_keys_sync(ctx, ":new<CR>")
 
       # Should show empty buffer with [new 1] name
       assert_modeline_contains(ctx, "[new 1]")
@@ -214,17 +214,17 @@ defmodule Minga.BufferManagementTest do
 
     test "successive :new increments the number" do
       ctx = start_editor("hello")
-      send_keys(ctx, ":new<CR>")
+      send_keys_sync(ctx, ":new<CR>")
       assert_modeline_contains(ctx, "[new 1]")
 
-      send_keys(ctx, ":new<CR>")
+      send_keys_sync(ctx, ":new<CR>")
       assert_modeline_contains(ctx, "[new 2]")
     end
 
     test "new buffer is editable" do
       ctx = start_editor("hello")
-      send_keys(ctx, ":new<CR>")
-      send_keys(ctx, "isome text<Esc>")
+      send_keys_sync(ctx, ":new<CR>")
+      send_keys_sync(ctx, "isome text<Esc>")
       assert_row_contains(ctx, 1, "some text")
     end
   end
@@ -232,7 +232,7 @@ defmodule Minga.BufferManagementTest do
   describe "SPC b N — new buffer via leader" do
     test "creates a new buffer" do
       ctx = start_editor("hello")
-      send_keys(ctx, "<SPC>bN")
+      send_keys_sync(ctx, "<SPC>bN")
       assert_modeline_contains(ctx, "[new 1]")
     end
   end

--- a/test/minga/buffer_picker_test.exs
+++ b/test/minga/buffer_picker_test.exs
@@ -14,10 +14,10 @@ defmodule Minga.BufferPickerTest do
       File.write!(path2, "beta content")
 
       ctx = start_editor("alpha content", file_path: path1)
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       # Open buffer picker
-      send_keys(ctx, "<SPC>bb")
+      send_keys_sync(ctx, "<SPC>bb")
 
       # Should see the prompt line
       mb = minibuffer(ctx)
@@ -32,7 +32,7 @@ defmodule Minga.BufferPickerTest do
 
     test "SPC b b with single buffer still opens picker" do
       ctx = start_editor("hello")
-      send_keys(ctx, "<SPC>bb")
+      send_keys_sync(ctx, "<SPC>bb")
 
       mb = minibuffer(ctx)
       assert String.contains?(mb, ">")
@@ -53,13 +53,13 @@ defmodule Minga.BufferPickerTest do
       File.write!(path3, "zen")
 
       ctx = start_editor("xylo", file_path: path1)
-      send_keys(ctx, ":e #{path2}<CR>")
-      send_keys(ctx, ":e #{path3}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path3}<CR>")
 
       # Open picker and type "ze" to match only zen.txt
-      send_keys(ctx, "<SPC>bb")
-      send_key(ctx, ?z)
-      send_key(ctx, ?e)
+      send_keys_sync(ctx, "<SPC>bb")
+      send_key_sync(ctx, ?z)
+      send_key_sync(ctx, ?e)
 
       # Should see zen but not xylo (skip row 0 which is the tab bar)
       screen = screen_text(ctx)
@@ -78,13 +78,13 @@ defmodule Minga.BufferPickerTest do
       File.write!(path2, "second file content")
 
       ctx = start_editor("first file content", file_path: path1)
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       # Open picker — should start showing current buffer
-      send_keys(ctx, "<SPC>bb")
+      send_keys_sync(ctx, "<SPC>bb")
 
       # Move down with C-j
-      send_key(ctx, ?j, 0x02)
+      send_key_sync(ctx, ?j, 0x02)
 
       # Check that preview shows one of the buffer's content (file or scratch)
       row0 = screen_row(ctx, 1)
@@ -103,13 +103,13 @@ defmodule Minga.BufferPickerTest do
       File.write!(path2, "two content")
 
       ctx = start_editor("one content", file_path: path1)
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       # We're on buffer 2, open picker — selection starts at index 0 (one.txt)
-      send_keys(ctx, "<SPC>bb")
+      send_keys_sync(ctx, "<SPC>bb")
 
       # Press Enter to select the first item (one.txt)
-      send_key(ctx, 13)
+      send_key_sync(ctx, 13)
 
       # Picker should be closed (minibuffer is empty, not showing ">")
       mb = minibuffer(ctx)
@@ -127,16 +127,16 @@ defmodule Minga.BufferPickerTest do
       File.write!(path2, "bbb content")
 
       ctx = start_editor("aaa content", file_path: path1)
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       # On buffer 3 (bbb). Open picker — items: aaa, [no file], bbb
       # Navigate and select bbb
-      send_keys(ctx, "<SPC>bb")
+      send_keys_sync(ctx, "<SPC>bb")
       # Filter to just "bbb" to avoid scratch confusion
-      send_key(ctx, ?b)
-      send_key(ctx, ?b)
-      send_key(ctx, ?b)
-      send_key(ctx, 13)
+      send_key_sync(ctx, ?b)
+      send_key_sync(ctx, ?b)
+      send_key_sync(ctx, ?b)
+      send_key_sync(ctx, 13)
 
       # Should show bbb content
       assert_row_contains(ctx, 1, "bbb content")
@@ -152,15 +152,15 @@ defmodule Minga.BufferPickerTest do
       File.write!(path2, "bbb content")
 
       ctx = start_editor("aaa content", file_path: path1)
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
       # Currently on buffer 2 (bbb)
       assert_row_contains(ctx, 1, "bbb content")
 
       # Open picker, navigate to buffer 1 (preview changes), then cancel
-      send_keys(ctx, "<SPC>bb")
-      send_key(ctx, ?j, 0x02)
+      send_keys_sync(ctx, "<SPC>bb")
+      send_key_sync(ctx, ?j, 0x02)
       # Escape
-      send_key(ctx, 27)
+      send_key_sync(ctx, 27)
 
       # Should restore original buffer (bbb)
       assert_row_contains(ctx, 1, "bbb content")
@@ -198,7 +198,7 @@ defmodule Minga.BufferPickerTest do
   describe "cursor shape" do
     test "picker uses beam cursor" do
       ctx = start_editor("hello")
-      send_keys(ctx, "<SPC>bb")
+      send_keys_sync(ctx, "<SPC>bb")
       assert cursor_shape(ctx) == :beam
     end
   end

--- a/test/minga/editor/commands/search_test.exs
+++ b/test/minga/editor/commands/search_test.exs
@@ -4,13 +4,13 @@ defmodule Minga.Editor.Commands.SearchTest do
   describe "forward search with /" do
     test "/ enters search mode and shows prompt" do
       ctx = start_editor("hello world\nfoo bar")
-      send_keys(ctx, "/")
+      send_keys_sync(ctx, "/")
       assert_minibuffer_contains(ctx, "/")
     end
 
     test "typing pattern incrementally moves cursor to match" do
       ctx = start_editor("hello world\nfoo bar")
-      send_keys(ctx, "/")
+      send_keys_sync(ctx, "/")
       type_text(ctx, "foo")
       # Cursor should be on "foo" at line 1
       assert {1, 0} = buffer_cursor(ctx)
@@ -18,9 +18,9 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test "Enter confirms search and returns to normal mode" do
       ctx = start_editor("hello world\nfoo bar")
-      send_keys(ctx, "/")
+      send_keys_sync(ctx, "/")
       type_text(ctx, "foo")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
       assert {1, 0} = buffer_cursor(ctx)
       assert_modeline_contains(ctx, "NORMAL")
     end
@@ -28,50 +28,50 @@ defmodule Minga.Editor.Commands.SearchTest do
     test "Escape cancels search and restores cursor" do
       ctx = start_editor("hello world\nfoo bar")
       # Move cursor to {0, 5} first
-      send_keys(ctx, "lllll")
+      send_keys_sync(ctx, "lllll")
       assert {0, 5} = buffer_cursor(ctx)
 
-      send_keys(ctx, "/")
+      send_keys_sync(ctx, "/")
       type_text(ctx, "foo")
       assert {1, 0} = buffer_cursor(ctx)
 
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
       # Cursor restored to original position
       assert {0, 5} = buffer_cursor(ctx)
     end
 
     test "n jumps to next match" do
       ctx = start_editor("foo hello foo world foo")
-      send_keys(ctx, "/")
+      send_keys_sync(ctx, "/")
       type_text(ctx, "foo")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
       # First match found after {0,0} should be {0,10}
       assert {0, 10} = buffer_cursor(ctx)
 
-      send_keys(ctx, "n")
+      send_keys_sync(ctx, "n")
       assert {0, 20} = buffer_cursor(ctx)
     end
 
     test "N jumps to previous match" do
       ctx = start_editor("foo hello foo world foo")
-      send_keys(ctx, "/")
+      send_keys_sync(ctx, "/")
       type_text(ctx, "foo")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
       # At {0, 10}
       assert {0, 10} = buffer_cursor(ctx)
 
-      send_keys(ctx, "N")
+      send_keys_sync(ctx, "N")
       assert {0, 0} = buffer_cursor(ctx)
     end
 
     test "search wraps around end of buffer" do
       ctx = start_editor("foo\nbar\nbaz")
       # Move to last line
-      send_keys(ctx, "G")
+      send_keys_sync(ctx, "G")
 
-      send_keys(ctx, "/")
+      send_keys_sync(ctx, "/")
       type_text(ctx, "foo")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
       # Should wrap to {0, 0}
       assert {0, 0} = buffer_cursor(ctx)
     end
@@ -80,20 +80,20 @@ defmodule Minga.Editor.Commands.SearchTest do
   describe "backward search with ?" do
     test "? enters backward search mode" do
       ctx = start_editor("hello world\nfoo bar")
-      send_keys(ctx, "?")
+      send_keys_sync(ctx, "?")
       assert_minibuffer_contains(ctx, "?")
     end
 
     test "backward search finds match before cursor" do
       ctx = start_editor("foo\nbar\nfoo")
       # G goes to last line. Move to end of "foo" on line 2
-      send_keys(ctx, "G$")
+      send_keys_sync(ctx, "G$")
       {line, _} = buffer_cursor(ctx)
       assert line == 2
 
-      send_keys(ctx, "?")
+      send_keys_sync(ctx, "?")
       type_text(ctx, "bar")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
       assert {1, 0} = buffer_cursor(ctx)
     end
   end
@@ -101,17 +101,17 @@ defmodule Minga.Editor.Commands.SearchTest do
   describe "* and # word search" do
     test "* searches for word under cursor forward" do
       ctx = start_editor("hello world\nhello again")
-      send_keys(ctx, "*")
+      send_keys_sync(ctx, "*")
       assert {1, 0} = buffer_cursor(ctx)
     end
 
     test "# searches for word under cursor backward" do
       ctx = start_editor("hello world\nhello again")
       # Go to second line, cursor on "hello"
-      send_keys(ctx, "j")
+      send_keys_sync(ctx, "j")
       assert {1, 0} = buffer_cursor(ctx)
 
-      send_keys(ctx, "#")
+      send_keys_sync(ctx, "#")
       assert {0, 0} = buffer_cursor(ctx)
     end
   end
@@ -119,7 +119,7 @@ defmodule Minga.Editor.Commands.SearchTest do
   describe "n/N without prior search" do
     test "n shows message when no previous pattern" do
       ctx = start_editor("hello world")
-      send_keys(ctx, "n")
+      send_keys_sync(ctx, "n")
       assert_minibuffer_contains(ctx, "No previous search pattern")
     end
   end
@@ -127,9 +127,9 @@ defmodule Minga.Editor.Commands.SearchTest do
   describe ":%s substitution" do
     test ":%s/old/new/g replaces all occurrences" do
       ctx = start_editor("foo bar foo\nfoo baz")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/foo/hello/g")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       assert buffer_content(ctx) == "hello bar hello\nhello baz"
       assert_minibuffer_contains(ctx, "3 substitutions")
@@ -137,9 +137,9 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test ":%s/old/new/ replaces first per line" do
       ctx = start_editor("foo bar foo\nfoo baz foo")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/foo/x/")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       assert buffer_content(ctx) == "x bar foo\nx baz foo"
       assert_minibuffer_contains(ctx, "2 substitutions")
@@ -147,9 +147,9 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test ":%s with no match shows error" do
       ctx = start_editor("hello world")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/xyz/abc/g")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       assert buffer_content(ctx) == "hello world"
       assert_minibuffer_contains(ctx, "Pattern not found: xyz")
@@ -157,18 +157,18 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test ":%s/old//g deletes all occurrences" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/foo//g")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       assert buffer_content(ctx) == " bar "
     end
 
     test ":%s/old/new/gc enters substitute confirm mode" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/foo/baz/gc")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       # Content unchanged until confirmations are applied
       assert buffer_content(ctx) == "foo bar foo"
@@ -177,13 +177,13 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test ":%s/old/new/gc with y on all matches replaces all" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/foo/baz/gc")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       # Two matches: accept both
-      send_keys(ctx, "y")
-      send_keys(ctx, "y")
+      send_keys_sync(ctx, "y")
+      send_keys_sync(ctx, "y")
 
       assert buffer_content(ctx) == "baz bar baz"
       assert editor_mode(ctx) == :normal
@@ -191,13 +191,13 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test ":%s/old/new/gc with n skips matches" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/foo/baz/gc")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       # Skip first, accept second
-      send_keys(ctx, "n")
-      send_keys(ctx, "y")
+      send_keys_sync(ctx, "n")
+      send_keys_sync(ctx, "y")
 
       assert buffer_content(ctx) == "foo bar baz"
       assert editor_mode(ctx) == :normal
@@ -205,13 +205,13 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test ":%s/old/new/gc with q stops early" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/foo/baz/gc")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       # Accept first, then quit
-      send_keys(ctx, "y")
-      send_keys(ctx, "q")
+      send_keys_sync(ctx, "y")
+      send_keys_sync(ctx, "q")
 
       assert buffer_content(ctx) == "baz bar foo"
       assert editor_mode(ctx) == :normal
@@ -219,12 +219,12 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test ":%s/old/new/gc with a accepts all remaining" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/foo/baz/gc")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       # Accept all from the start
-      send_keys(ctx, "a")
+      send_keys_sync(ctx, "a")
 
       assert buffer_content(ctx) == "baz bar baz"
       assert editor_mode(ctx) == :normal
@@ -232,13 +232,13 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test "substitution is undoable" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/foo/baz/g")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       assert buffer_content(ctx) == "baz bar baz"
 
-      send_keys(ctx, "u")
+      send_keys_sync(ctx, "u")
       assert buffer_content(ctx) == "foo bar foo"
     end
   end
@@ -246,12 +246,12 @@ defmodule Minga.Editor.Commands.SearchTest do
   describe "search highlighting" do
     test "search pattern persists after confirmed search" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, "/")
+      send_keys_sync(ctx, "/")
       type_text(ctx, "foo")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       # Pattern persists — n should work
-      send_keys(ctx, "n")
+      send_keys_sync(ctx, "n")
       # Should have moved to next occurrence
       {_line, col} = buffer_cursor(ctx)
       assert col >= 0
@@ -259,9 +259,9 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test "matches are highlighted with search background color" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, "/")
+      send_keys_sync(ctx, "/")
       type_text(ctx, "foo")
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       # The gutter takes some columns; find where "foo" appears on screen.
       # Both occurrences of "foo" should have the search highlight bg.
@@ -277,7 +277,7 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test "matches highlight live during incremental / search" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, "/")
+      send_keys_sync(ctx, "/")
       type_text(ctx, "foo")
 
       # Still in search mode — highlights should be visible
@@ -291,7 +291,7 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test "matches highlight live while typing :%s/pattern" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/foo")
 
       # Still in command mode typing the substitute — highlights should show
@@ -305,7 +305,7 @@ defmodule Minga.Editor.Commands.SearchTest do
 
     test "live substitution preview shows replacement text highlighted" do
       ctx = start_editor("foo bar foo")
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       type_text(ctx, "%s/foo/hello/g")
 
       # Buffer is NOT modified yet (still in command mode)

--- a/test/minga/editor/file_change_test.exs
+++ b/test/minga/editor/file_change_test.exs
@@ -38,7 +38,7 @@ defmodule Minga.Editor.FileChangeTest do
     ctx = start_editor("original", file_path: path)
 
     # Make local edit to dirty the buffer
-    send_keys(ctx, "ix<Esc>")
+    send_keys_sync(ctx, "ix<Esc>")
 
     # Simulate external modification
     File.write!(path, "external change that is longer")
@@ -61,7 +61,7 @@ defmodule Minga.Editor.FileChangeTest do
     ctx = start_editor("original", file_path: path)
 
     # Dirty the buffer
-    send_keys(ctx, "ix<Esc>")
+    send_keys_sync(ctx, "ix<Esc>")
 
     # External change
     File.write!(path, "reloaded content")
@@ -71,7 +71,7 @@ defmodule Minga.Editor.FileChangeTest do
     _ = :sys.get_state(ctx.editor)
 
     # Press r to reload
-    send_key(ctx, ?r)
+    send_key_sync(ctx, ?r)
 
     content = BufferServer.content(ctx.buffer)
     assert content == "reloaded content"
@@ -89,7 +89,7 @@ defmodule Minga.Editor.FileChangeTest do
     ctx = start_editor("original", file_path: path)
 
     # Dirty the buffer
-    send_keys(ctx, "ilocal<Esc>")
+    send_keys_sync(ctx, "ilocal<Esc>")
 
     # External change
     File.write!(path, "external modification")
@@ -99,7 +99,7 @@ defmodule Minga.Editor.FileChangeTest do
     _ = :sys.get_state(ctx.editor)
 
     # Press k to keep
-    send_key(ctx, ?k)
+    send_key_sync(ctx, ?k)
 
     content = BufferServer.content(ctx.buffer)
     assert String.contains?(content, "local")
@@ -114,7 +114,7 @@ defmodule Minga.Editor.FileChangeTest do
     File.write!(path, "original")
 
     ctx = start_editor("original", file_path: path)
-    send_keys(ctx, "ix<Esc>")
+    send_keys_sync(ctx, "ix<Esc>")
 
     File.write!(path, "external modification")
 

--- a/test/minga/editor/highlight_integration_test.exs
+++ b/test/minga/editor/highlight_integration_test.exs
@@ -50,7 +50,7 @@ defmodule Minga.Editor.HighlightIntegrationTest do
              "Pre-condition: file1 should have spans"
 
       # Open second file via :e — triggers buffer switch
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       state = :sys.get_state(ctx.editor)
 
@@ -68,7 +68,7 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       ctx = start_editor("defmodule A do\nend\n", file_path: path1)
 
       # Open second file
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       # Inject spans for file2
       spans = [%{start_byte: 0, end_byte: 9, capture_id: 0}]
@@ -80,7 +80,7 @@ defmodule Minga.Editor.HighlightIntegrationTest do
              "Pre-condition: file2 should have spans"
 
       # Switch to previous buffer via SPC b n
-      send_keys(ctx, "<Space>bn")
+      send_keys_sync(ctx, "<Space>bn")
 
       state = :sys.get_state(ctx.editor)
 
@@ -107,7 +107,7 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       assert HighlightSync.get_active_highlight(state).spans == List.to_tuple(spans_a)
 
       # Open file2 via :e command (deterministic, no CWD dependency)
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       state = :sys.get_state(ctx.editor)
 
@@ -131,7 +131,7 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       buf1_pid = :sys.get_state(ctx.editor).buffers.active
 
       # Switch to file2 via :e command (deterministic, no CWD dependency)
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       state = :sys.get_state(ctx.editor)
 
@@ -222,13 +222,13 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       inject_highlights(ctx, ["keyword"], 1, spans_a)
 
       # Switch to file2
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       state2 = :sys.get_state(ctx.editor)
       assert HighlightSync.get_active_highlight(state2).spans == {}
 
       # Switch back to file1 via :e (should already be in buffer list)
-      send_keys(ctx, ":e #{path1}<CR>")
+      send_keys_sync(ctx, ":e #{path1}<CR>")
 
       state = :sys.get_state(ctx.editor)
 
@@ -256,7 +256,7 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       assert HighlightSync.get_active_highlight(state).spans == List.to_tuple(spans_a)
 
       # Open file2 and switch to it
-      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys_sync(ctx, ":e #{path2}<CR>")
 
       state = :sys.get_state(ctx.editor)
 
@@ -264,7 +264,7 @@ defmodule Minga.Editor.HighlightIntegrationTest do
              "File2 should start with empty spans"
 
       # Switch back to file1 — should restore cached highlights instantly
-      send_keys(ctx, "<Space>bn")
+      send_keys_sync(ctx, "<Space>bn")
 
       state = :sys.get_state(ctx.editor)
 
@@ -335,7 +335,7 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       version_before = :sys.get_state(ctx.editor).highlight.version
 
       # dd deletes the current line
-      send_keys(ctx, "dd")
+      send_keys_sync(ctx, "dd")
 
       version_after = :sys.get_state(ctx.editor).highlight.version
 
@@ -350,7 +350,7 @@ defmodule Minga.Editor.HighlightIntegrationTest do
 
       version_before = :sys.get_state(ctx.editor).highlight.version
 
-      send_key(ctx, ?x)
+      send_key_sync(ctx, ?x)
 
       version_after = :sys.get_state(ctx.editor).highlight.version
 
@@ -364,11 +364,11 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       inject_highlights(ctx, ["keyword"], 1, [%{start_byte: 0, end_byte: 5, capture_id: 0}])
 
       # Yank a word first (yw), then paste
-      send_keys(ctx, "yw")
+      send_keys_sync(ctx, "yw")
 
       version_before = :sys.get_state(ctx.editor).highlight.version
 
-      send_key(ctx, ?p)
+      send_key_sync(ctx, ?p)
 
       version_after = :sys.get_state(ctx.editor).highlight.version
 
@@ -382,12 +382,12 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       inject_highlights(ctx, ["keyword"], 1, [%{start_byte: 0, end_byte: 5, capture_id: 0}])
 
       # Make a change first
-      send_key(ctx, ?x)
+      send_key_sync(ctx, ?x)
 
       version_before = :sys.get_state(ctx.editor).highlight.version
 
       # Undo
-      send_key(ctx, ?u)
+      send_key_sync(ctx, ?u)
 
       version_after = :sys.get_state(ctx.editor).highlight.version
 
@@ -403,7 +403,7 @@ defmodule Minga.Editor.HighlightIntegrationTest do
       version_before = :sys.get_state(ctx.editor).highlight.version
 
       # Pure motions: h, j, k, l, w
-      send_keys(ctx, "llljkw")
+      send_keys_sync(ctx, "llljkw")
 
       version_after = :sys.get_state(ctx.editor).highlight.version
 
@@ -481,8 +481,8 @@ defmodule Minga.Editor.HighlightIntegrationTest do
 
       version_before = :sys.get_state(ctx.editor).highlight.version
 
-      send_key(ctx, ?i)
-      send_key(ctx, ?a)
+      send_key_sync(ctx, ?i)
+      send_key_sync(ctx, ?a)
 
       version_after = :sys.get_state(ctx.editor).highlight.version
 

--- a/test/minga/editor/macro_integration_test.exs
+++ b/test/minga/editor/macro_integration_test.exs
@@ -10,7 +10,7 @@ defmodule Minga.Editor.MacroIntegrationTest do
       ctx = start_editor("aaa\nbbb\nccc")
 
       # Record macro: qa (start), x (delete char), j (move down), q (stop)
-      send_keys(ctx, "qaxjq")
+      send_keys_sync(ctx, "qaxjq")
 
       # First line should have "aa" (deleted first char)
       assert_row_contains(ctx, 1, "aa")
@@ -18,7 +18,7 @@ defmodule Minga.Editor.MacroIntegrationTest do
       assert buffer_cursor(ctx) == {1, 0}
 
       # Replay: @a
-      send_keys(ctx, "@a")
+      send_keys_sync(ctx, "@a")
 
       # Second line should have "bb" (deleted first char)
       assert_row_contains(ctx, 2, "bb")
@@ -30,10 +30,10 @@ defmodule Minga.Editor.MacroIntegrationTest do
       ctx = start_editor("1xxx\n2xxx\n3xxx\n4xxx\n5xxx")
 
       # Record macro: delete first char, move down
-      send_keys(ctx, "qaxjq")
+      send_keys_sync(ctx, "qaxjq")
 
       # Replay twice with count
-      send_keys(ctx, "2@a")
+      send_keys_sync(ctx, "2@a")
 
       # Lines 0, 1, 2 should have first char deleted
       content = buffer_content(ctx)
@@ -50,10 +50,10 @@ defmodule Minga.Editor.MacroIntegrationTest do
       ctx = start_editor("aaa\nbbb\nccc")
 
       # Record macro into register a
-      send_keys(ctx, "qaxjq")
+      send_keys_sync(ctx, "qaxjq")
 
       # Replay with @@
-      send_keys(ctx, "@@")
+      send_keys_sync(ctx, "@@")
 
       content = buffer_content(ctx)
       lines = String.split(content, "\n")
@@ -65,13 +65,13 @@ defmodule Minga.Editor.MacroIntegrationTest do
       ctx = start_editor("hello")
 
       # Start recording into register a
-      send_keys(ctx, "qa")
+      send_keys_sync(ctx, "qa")
 
       ml = modeline(ctx)
       assert String.contains?(ml, "recording @a")
 
       # Stop recording
-      send_keys(ctx, "q")
+      send_keys_sync(ctx, "q")
 
       ml = modeline(ctx)
       refute String.contains?(ml, "recording")
@@ -81,15 +81,15 @@ defmodule Minga.Editor.MacroIntegrationTest do
       ctx = start_editor("aaa\nbbb\nccc")
 
       # Record into a: delete char
-      send_keys(ctx, "qaxq")
+      send_keys_sync(ctx, "qaxq")
       # Record into b: move down
-      send_keys(ctx, "qbjq")
+      send_keys_sync(ctx, "qbjq")
 
       # Go to start
-      send_keys(ctx, "gg0")
+      send_keys_sync(ctx, "gg0")
 
       # Replay b (move down), then a (delete char)
-      send_keys(ctx, "@b@a")
+      send_keys_sync(ctx, "@b@a")
 
       content = buffer_content(ctx)
       lines = String.split(content, "\n")
@@ -101,14 +101,14 @@ defmodule Minga.Editor.MacroIntegrationTest do
 
     test "replaying unrecorded register shows error" do
       ctx = start_editor("hello")
-      send_keys(ctx, "@z")
+      send_keys_sync(ctx, "@z")
       mb = minibuffer(ctx)
       assert String.contains?(mb, "No macro in register @z")
     end
 
     test "@@ with no previous macro shows error" do
       ctx = start_editor("hello")
-      send_keys(ctx, "@@")
+      send_keys_sync(ctx, "@@")
       mb = minibuffer(ctx)
       assert String.contains?(mb, "No previous macro")
     end
@@ -119,14 +119,14 @@ defmodule Minga.Editor.MacroIntegrationTest do
       ctx = start_editor("aaa\nbbb\nccc")
 
       # Record a macro (doesn't matter what)
-      send_keys(ctx, "qajq")
+      send_keys_sync(ctx, "qajq")
 
       # Now do a normal edit: delete first char
-      send_keys(ctx, "gg0x")
+      send_keys_sync(ctx, "gg0x")
       assert buffer_content(ctx) |> String.split("\n") |> List.first() == "aa"
 
       # Dot repeat should repeat the x (delete char)
-      send_keys(ctx, ".")
+      send_keys_sync(ctx, ".")
       assert buffer_content(ctx) |> String.split("\n") |> List.first() == "a"
     end
   end

--- a/test/minga/editor/messages_buffer_test.exs
+++ b/test/minga/editor/messages_buffer_test.exs
@@ -8,7 +8,7 @@ defmodule Minga.Editor.MessagesBufferTest do
   describe "*Messages* buffer" do
     test "SPC b m opens messages buffer in a popup split" do
       ctx = start_editor("hello")
-      send_keys(ctx, "<SPC>bm")
+      send_keys_sync(ctx, "<SPC>bm")
 
       # The messages buffer opens as a popup split. Its modeline should be
       # visible on screen (not necessarily the last modeline row, since
@@ -20,7 +20,7 @@ defmodule Minga.Editor.MessagesBufferTest do
 
     test "messages buffer contains editor startup log" do
       ctx = start_editor("hello")
-      send_keys(ctx, "<SPC>bm")
+      send_keys_sync(ctx, "<SPC>bm")
 
       # The messages buffer content appears in the popup split area.
       screen = screen_text(ctx)
@@ -30,7 +30,7 @@ defmodule Minga.Editor.MessagesBufferTest do
 
     test "messages buffer shows [RO] indicator" do
       ctx = start_editor("hello")
-      send_keys(ctx, "<SPC>bm")
+      send_keys_sync(ctx, "<SPC>bm")
 
       screen = screen_text(ctx)
       all_text = Enum.join(screen, "\n")
@@ -39,8 +39,8 @@ defmodule Minga.Editor.MessagesBufferTest do
 
     test "entering insert mode on messages buffer is blocked" do
       ctx = start_editor("hello")
-      send_keys(ctx, "<SPC>bm")
-      send_keys(ctx, "i")
+      send_keys_sync(ctx, "<SPC>bm")
+      send_keys_sync(ctx, "i")
 
       assert editor_mode(ctx) == :normal
       screen = screen_text(ctx)
@@ -52,13 +52,13 @@ defmodule Minga.Editor.MessagesBufferTest do
       ctx = start_editor("hello")
 
       # Open the messages popup
-      send_keys(ctx, "<SPC>bm")
+      send_keys_sync(ctx, "<SPC>bm")
       screen = screen_text(ctx)
       all_text = Enum.join(screen, "\n")
       assert String.contains?(all_text, "*Messages*")
 
       # Toggle it closed
-      send_keys(ctx, "<SPC>bm")
+      send_keys_sync(ctx, "<SPC>bm")
       screen = screen_text(ctx)
       all_text = Enum.join(screen, "\n")
       refute String.contains?(all_text, "*Messages*")
@@ -66,14 +66,14 @@ defmodule Minga.Editor.MessagesBufferTest do
 
     test "q dismisses the messages popup" do
       ctx = start_editor("hello")
-      send_keys(ctx, "<SPC>bm")
+      send_keys_sync(ctx, "<SPC>bm")
 
       screen = screen_text(ctx)
       all_text = Enum.join(screen, "\n")
       assert String.contains?(all_text, "*Messages*")
 
       # Press q to dismiss
-      send_keys(ctx, "q")
+      send_keys_sync(ctx, "q")
       screen = screen_text(ctx)
       all_text = Enum.join(screen, "\n")
       refute String.contains?(all_text, "*Messages*")
@@ -82,7 +82,7 @@ defmodule Minga.Editor.MessagesBufferTest do
     test "messages buffer is hidden from buffer picker" do
       ctx = start_editor("hello")
 
-      send_keys(ctx, "<SPC>bb")
+      send_keys_sync(ctx, "<SPC>bb")
       screen = screen_text(ctx)
       all_text = Enum.join(screen, "\n")
 

--- a/test/minga/editor/renderer/byte_grapheme_boundary_test.exs
+++ b/test/minga/editor/renderer/byte_grapheme_boundary_test.exs
@@ -15,7 +15,7 @@ defmodule Minga.Editor.Renderer.ByteGraphemeBoundaryTest do
       ctx = start_editor("café")
 
       # Move to end of line ($ in normal mode)
-      send_key(ctx, ?$)
+      send_key_sync(ctx, ?$)
 
       {_row, col} = screen_cursor(ctx)
       gutter_w = 3
@@ -28,7 +28,7 @@ defmodule Minga.Editor.Renderer.ByteGraphemeBoundaryTest do
       # "a🎉b" — 🎉 is 4 bytes and 2 display columns wide
       ctx = start_editor("a🎉b")
 
-      send_key(ctx, ?$)
+      send_key_sync(ctx, ?$)
 
       {_row, col} = screen_cursor(ctx)
       gutter_w = 3
@@ -42,9 +42,9 @@ defmodule Minga.Editor.Renderer.ByteGraphemeBoundaryTest do
       ctx = start_editor("ñoño")
 
       # Move right 3 times to reach 'o' at end
-      send_key(ctx, ?l)
-      send_key(ctx, ?l)
-      send_key(ctx, ?l)
+      send_key_sync(ctx, ?l)
+      send_key_sync(ctx, ?l)
+      send_key_sync(ctx, ?l)
 
       {_row, col} = screen_cursor(ctx)
       gutter_w = 3
@@ -59,7 +59,7 @@ defmodule Minga.Editor.Renderer.ByteGraphemeBoundaryTest do
       ctx = start_editor("café")
 
       # Move to end: $ puts cursor on last char
-      send_key(ctx, ?$)
+      send_key_sync(ctx, ?$)
 
       ml = modeline(ctx)
       # cursor_line=0, grapheme_col=3 → displayed as "1:4" (1-indexed)
@@ -84,9 +84,9 @@ defmodule Minga.Editor.Renderer.ByteGraphemeBoundaryTest do
       gutter_w = 3
 
       # Move to 'a', enter visual, select through 'f'
-      send_key(ctx, ?l)
-      send_key(ctx, ?v)
-      send_key(ctx, ?l)
+      send_key_sync(ctx, ?l)
+      send_key_sync(ctx, ?v)
+      send_key_sync(ctx, ?l)
 
       # Cells at grapheme positions 1 and 2 (gutter_w + 1, gutter_w + 2) should be reversed
       cell_a = screen_cell(ctx, 1, gutter_w + 1)
@@ -108,8 +108,8 @@ defmodule Minga.Editor.Renderer.ByteGraphemeBoundaryTest do
       gutter_w = 3
 
       # Select all with v$
-      send_key(ctx, ?v)
-      send_key(ctx, ?$)
+      send_key_sync(ctx, ?v)
+      send_key_sync(ctx, ?$)
 
       cell_a = screen_cell(ctx, 1, gutter_w)
       assert :reverse in cell_a.attrs, "Expected 'a' to be selected"
@@ -120,10 +120,10 @@ defmodule Minga.Editor.Renderer.ByteGraphemeBoundaryTest do
     test "cursor after inserting multi-byte character" do
       ctx = start_editor("")
 
-      send_key(ctx, ?i)
+      send_key_sync(ctx, ?i)
       # Type 'é' — this is tricky since send_key sends a codepoint
-      send_key(ctx, ?a)
-      send_key(ctx, ?b)
+      send_key_sync(ctx, ?a)
+      send_key_sync(ctx, ?b)
 
       {_row, col} = screen_cursor(ctx)
       gutter_w = 3
@@ -137,7 +137,7 @@ defmodule Minga.Editor.Renderer.ByteGraphemeBoundaryTest do
     test "cursor placement unchanged for ASCII" do
       ctx = start_editor("hello world")
 
-      send_key(ctx, ?$)
+      send_key_sync(ctx, ?$)
 
       {_row, col} = screen_cursor(ctx)
       gutter_w = 3
@@ -149,7 +149,7 @@ defmodule Minga.Editor.Renderer.ByteGraphemeBoundaryTest do
     test "modeline column correct for ASCII" do
       ctx = start_editor("hello")
 
-      send_key(ctx, ?$)
+      send_key_sync(ctx, ?$)
 
       ml = modeline(ctx)
 

--- a/test/minga/editor/renderer/conceal_render_test.exs
+++ b/test/minga/editor/renderer/conceal_render_test.exs
@@ -27,7 +27,7 @@ defmodule Minga.Editor.Renderer.ConcealRenderTest do
       end)
 
       # Move cursor to line 1 so line 0 conceals are active
-      send_key(ctx, ?j)
+      send_key_sync(ctx, ?j)
 
       row_text = screen_row(ctx, @content_row)
 
@@ -52,7 +52,7 @@ defmodule Minga.Editor.Renderer.ConcealRenderTest do
       end)
 
       # Move cursor to line 1
-      send_key(ctx, ?j)
+      send_key_sync(ctx, ?j)
 
       row_text = screen_row(ctx, @content_row)
 
@@ -84,14 +84,14 @@ defmodule Minga.Editor.Renderer.ConcealRenderTest do
       end)
 
       # Move cursor off line 0, then remove conceals
-      send_key(ctx, ?j)
+      send_key_sync(ctx, ?j)
 
       BufferServer.batch_decorations(ctx.buffer, fn decs ->
         Decorations.remove_conceal_group(decs, :test)
       end)
 
       # Move back to line 0 to re-render
-      send_key(ctx, ?k)
+      send_key_sync(ctx, ?k)
 
       row_text = screen_row(ctx, @content_row)
 
@@ -108,7 +108,7 @@ defmodule Minga.Editor.Renderer.ConcealRenderTest do
       end)
 
       # Move cursor to line 1 so line 0 conceals are active
-      send_key(ctx, ?j)
+      send_key_sync(ctx, ?j)
 
       row_text = screen_row(ctx, @content_row)
 
@@ -125,7 +125,7 @@ defmodule Minga.Editor.Renderer.ConcealRenderTest do
         decs
       end)
 
-      send_key(ctx, 0)
+      send_key_sync(ctx, 0)
 
       # Cursor is on line 0, so conceals should be revealed
       row_text = screen_row(ctx, @content_row)
@@ -145,7 +145,7 @@ defmodule Minga.Editor.Renderer.ConcealRenderTest do
         decs
       end)
 
-      send_key(ctx, 0)
+      send_key_sync(ctx, 0)
 
       # Cursor is on line 0: line 0 reveals, line 1 conceals
       row_text_line1 = screen_row(ctx, @content_row + 1)
@@ -167,7 +167,7 @@ defmodule Minga.Editor.Renderer.ConcealRenderTest do
       end)
 
       # Yank the line
-      send_keys(ctx, "Vy")
+      send_keys_sync(ctx, "Vy")
 
       content = BufferServer.content(ctx.buffer)
       assert content == "**bold**"

--- a/test/minga/editor/renderer/line_test.exs
+++ b/test/minga/editor/renderer/line_test.exs
@@ -39,9 +39,9 @@ defmodule Minga.Editor.Renderer.LineTest do
     test "typed characters appear on screen" do
       ctx = start_editor("hello")
 
-      send_key(ctx, ?i)
-      send_key(ctx, ?X)
-      send_key(ctx, ?Y)
+      send_key_sync(ctx, ?i)
+      send_key_sync(ctx, ?X)
+      send_key_sync(ctx, ?Y)
 
       assert_row_contains(ctx, @content_row, "XYhello")
     end
@@ -49,8 +49,8 @@ defmodule Minga.Editor.Renderer.LineTest do
     test "newline in insert mode creates a new line on screen" do
       ctx = start_editor("hello")
 
-      send_key(ctx, ?i)
-      send_key(ctx, 13)
+      send_key_sync(ctx, ?i)
+      send_key_sync(ctx, 13)
 
       assert_row_contains(ctx, @content_row + 1, "hello")
     end
@@ -67,7 +67,7 @@ defmodule Minga.Editor.Renderer.LineTest do
       ctx = start_editor("你好")
 
       # Move right once - cursor steps to second CJK char (display col 2)
-      send_key(ctx, ?l)
+      send_key_sync(ctx, ?l)
 
       screen = HeadlessPort.get_screen(ctx.port)
       {cursor_row, cursor_col} = screen.cursor
@@ -81,9 +81,9 @@ defmodule Minga.Editor.Renderer.LineTest do
       ctx = start_editor("你好世界")
 
       # v selects '你', l extends to '好', l extends to '世'
-      send_key(ctx, ?v)
-      send_key(ctx, ?l)
-      send_key(ctx, ?l)
+      send_key_sync(ctx, ?v)
+      send_key_sync(ctx, ?l)
+      send_key_sync(ctx, ?l)
 
       screen = HeadlessPort.get_screen(ctx.port)
       row = Enum.at(screen.grid, @content_row)
@@ -114,7 +114,7 @@ defmodule Minga.Editor.Renderer.LineTest do
       assert_row_contains(ctx, @content_row, "é hello")
 
       # Moving right from 'é' should step 1 display col (to the space)
-      send_key(ctx, ?l)
+      send_key_sync(ctx, ?l)
 
       screen = HeadlessPort.get_screen(ctx.port)
       {_crow, cursor_col} = screen.cursor
@@ -127,9 +127,9 @@ defmodule Minga.Editor.Renderer.LineTest do
 
       assert_row_contains(ctx, @content_row, "hello world")
 
-      send_key(ctx, ?v)
-      send_key(ctx, ?l)
-      send_key(ctx, ?l)
+      send_key_sync(ctx, ?v)
+      send_key_sync(ctx, ?l)
+      send_key_sync(ctx, ?l)
 
       screen = HeadlessPort.get_screen(ctx.port)
       row = Enum.at(screen.grid, @content_row)
@@ -148,9 +148,9 @@ defmodule Minga.Editor.Renderer.LineTest do
     test "selected text has reverse attribute" do
       ctx = start_editor("hello world")
 
-      send_key(ctx, ?v)
-      send_key(ctx, ?l)
-      send_key(ctx, ?l)
+      send_key_sync(ctx, ?v)
+      send_key_sync(ctx, ?l)
+      send_key_sync(ctx, ?l)
 
       screen = HeadlessPort.get_screen(ctx.port)
       row = Enum.at(screen.grid, @content_row)
@@ -171,7 +171,7 @@ defmodule Minga.Editor.Renderer.LineTest do
       # assert exact scroll positions without affecting other async tests.
       BufferServer.set_option(ctx.buffer, :scroll_margin, 0)
 
-      for _ <- 1..10, do: send_key(ctx, ?j)
+      for _ <- 1..10, do: send_key_sync(ctx, ?j)
 
       row_text = screen_row(ctx, @content_row)
 

--- a/test/minga/editor/renderer/minibuffer_test.exs
+++ b/test/minga/editor/renderer/minibuffer_test.exs
@@ -10,25 +10,25 @@ defmodule Minga.Editor.Renderer.MinibufferTest do
     test "shows colon and typed command in minibuffer" do
       ctx = start_editor("hello")
 
-      send_key(ctx, ?:)
-      send_key(ctx, ?w)
-      send_key(ctx, ?q)
+      send_key_sync(ctx, ?:)
+      send_key_sync(ctx, ?w)
+      send_key_sync(ctx, ?q)
 
       assert_minibuffer_contains(ctx, ":wq")
     end
 
     test "shows COMMAND mode in modeline" do
       ctx = start_editor("hello")
-      send_key(ctx, ?:)
+      send_key_sync(ctx, ?:)
       assert_mode(ctx, :command)
     end
 
     test "minibuffer clears after Esc" do
       ctx = start_editor("hello")
 
-      send_key(ctx, ?:)
-      send_key(ctx, ?w)
-      send_key(ctx, 27)
+      send_key_sync(ctx, ?:)
+      send_key_sync(ctx, ?w)
+      send_key_sync(ctx, 27)
 
       assert_mode(ctx, :normal)
       mb = minibuffer(ctx)
@@ -38,8 +38,8 @@ defmodule Minga.Editor.Renderer.MinibufferTest do
     test "cursor moves to minibuffer in command mode" do
       ctx = start_editor("hello")
 
-      send_key(ctx, ?:)
-      send_key(ctx, ?q)
+      send_key_sync(ctx, ?:)
+      send_key_sync(ctx, ?q)
 
       {cursor_row, cursor_col} = screen_cursor(ctx)
       assert cursor_row == ctx.height - 1

--- a/test/minga/editor/status_msg_test.exs
+++ b/test/minga/editor/status_msg_test.exs
@@ -11,7 +11,7 @@ defmodule Minga.Editor.StatusMsgTest do
     File.write!(path, "hello")
 
     ctx = start_editor("hello", file_path: path)
-    send_keys(ctx, ":w<CR>")
+    send_keys_sync(ctx, ":w<CR>")
 
     mb = minibuffer(ctx)
     assert String.contains?(mb, "Wrote")
@@ -28,7 +28,7 @@ defmodule Minga.Editor.StatusMsgTest do
     # Simulate external modification (mtime must advance)
     File.write!(path, "externally modified")
 
-    send_keys(ctx, ":w<CR>")
+    send_keys_sync(ctx, ":w<CR>")
 
     mb = minibuffer(ctx)
     assert String.contains?(mb, "WARNING")
@@ -45,7 +45,7 @@ defmodule Minga.Editor.StatusMsgTest do
     # Simulate external modification
     File.write!(path, "externally modified")
 
-    send_keys(ctx, ":w!<CR>")
+    send_keys_sync(ctx, ":w!<CR>")
 
     mb = minibuffer(ctx)
     assert String.contains?(mb, "Wrote")
@@ -60,7 +60,7 @@ defmodule Minga.Editor.StatusMsgTest do
     ctx = start_editor("original", file_path: path)
     File.write!(path, "reloaded")
 
-    send_keys(ctx, ":e!<CR>")
+    send_keys_sync(ctx, ":e!<CR>")
 
     mb = minibuffer(ctx)
     assert String.contains?(mb, "Reloaded")
@@ -72,13 +72,13 @@ defmodule Minga.Editor.StatusMsgTest do
     File.write!(path, "hello")
 
     ctx = start_editor("hello", file_path: path)
-    send_keys(ctx, ":w<CR>")
+    send_keys_sync(ctx, ":w<CR>")
 
     mb = minibuffer(ctx)
     assert String.contains?(mb, "Wrote")
 
     # Press any key — message should clear
-    send_key(ctx, ?j)
+    send_key_sync(ctx, ?j)
 
     mb = minibuffer(ctx)
     refute String.contains?(mb, "Wrote")
@@ -86,7 +86,7 @@ defmodule Minga.Editor.StatusMsgTest do
 
   test "save on scratch buffer shows error in minibuffer" do
     ctx = start_editor("scratch content")
-    send_keys(ctx, ":w<CR>")
+    send_keys_sync(ctx, ":w<CR>")
 
     mb = minibuffer(ctx)
     assert String.contains?(mb, "No file name")

--- a/test/minga/editor/user_query_override_test.exs
+++ b/test/minga/editor/user_query_override_test.exs
@@ -44,7 +44,7 @@ defmodule Minga.Editor.UserQueryOverrideTest do
       version_before = state.highlight.version
 
       # Run :reload-highlights
-      send_keys(ctx, ":reload-highlights<CR>")
+      send_keys_sync(ctx, ":reload-highlights<CR>")
 
       state = :sys.get_state(ctx.editor)
 
@@ -69,7 +69,7 @@ defmodule Minga.Editor.UserQueryOverrideTest do
 
       version_before = :sys.get_state(ctx.editor).highlight.version
 
-      send_keys(ctx, ":rh<CR>")
+      send_keys_sync(ctx, ":rh<CR>")
 
       state = :sys.get_state(ctx.editor)
       assert HighlightSync.get_active_highlight(state).spans == {}

--- a/test/minga/editor/warnings_buffer_test.exs
+++ b/test/minga/editor/warnings_buffer_test.exs
@@ -16,7 +16,7 @@ defmodule Minga.Editor.WarningsBufferTest do
     test "SPC b W opens bottom panel with warnings filter" do
       ctx = start_editor("hello")
       set_gui_capabilities(ctx)
-      send_keys(ctx, "<SPC>bW")
+      send_keys_sync(ctx, "<SPC>bW")
 
       state = :sys.get_state(ctx.editor)
       assert state.bottom_panel.visible == true
@@ -33,7 +33,7 @@ defmodule Minga.Editor.WarningsBufferTest do
         %{s | bottom_panel: BottomPanel.dismiss(s.bottom_panel)}
       end)
 
-      send_keys(ctx, "<SPC>bW")
+      send_keys_sync(ctx, "<SPC>bW")
       state = :sys.get_state(ctx.editor)
       assert state.bottom_panel.visible == true
       assert state.bottom_panel.dismissed == false
@@ -42,7 +42,7 @@ defmodule Minga.Editor.WarningsBufferTest do
     test ":warnings ex-command opens bottom panel with warnings filter" do
       ctx = start_editor("hello")
       set_gui_capabilities(ctx)
-      send_keys(ctx, ":warnings<CR>")
+      send_keys_sync(ctx, ":warnings<CR>")
 
       state = :sys.get_state(ctx.editor)
       assert state.bottom_panel.visible == true
@@ -83,7 +83,7 @@ defmodule Minga.Editor.WarningsBufferTest do
       set_gui_capabilities(ctx)
 
       # Open panel manually (no filter)
-      send_keys(ctx, "<SPC>tp")
+      send_keys_sync(ctx, "<SPC>tp")
       state = :sys.get_state(ctx.editor)
       assert state.bottom_panel.visible == true
       assert state.bottom_panel.filter == nil
@@ -100,7 +100,7 @@ defmodule Minga.Editor.WarningsBufferTest do
   describe "warnings (TUI: *Messages* buffer fallback)" do
     test "SPC b W opens *Messages* buffer on TUI" do
       ctx = start_editor("hello")
-      send_keys(ctx, "<SPC>bW")
+      send_keys_sync(ctx, "<SPC>bW")
 
       screen = screen_text(ctx)
       all_text = Enum.join(screen, "\n")
@@ -109,7 +109,7 @@ defmodule Minga.Editor.WarningsBufferTest do
 
     test "SPC b m opens *Messages* buffer on TUI" do
       ctx = start_editor("hello")
-      send_keys(ctx, "<SPC>bm")
+      send_keys_sync(ctx, "<SPC>bm")
 
       screen = screen_text(ctx)
       all_text = Enum.join(screen, "\n")

--- a/test/minga/integration/agent_cursor_test.exs
+++ b/test/minga/integration/agent_cursor_test.exs
@@ -115,7 +115,7 @@ defmodule Minga.Integration.AgentCursorTest do
       ctx = start_agent_editor()
 
       # Press i to focus the prompt input (enters insert mode)
-      send_keys(ctx, "i")
+      send_keys_sync(ctx, "i")
 
       rows = screen_text(ctx)
       {cursor_row, _cursor_col} = screen_cursor(ctx)
@@ -136,7 +136,7 @@ defmodule Minga.Integration.AgentCursorTest do
     test "cursor stays on content row after typing" do
       ctx = start_agent_editor()
 
-      send_keys(ctx, "i")
+      send_keys_sync(ctx, "i")
       type_text(ctx, "hello")
 
       rows = screen_text(ctx)
@@ -155,7 +155,7 @@ defmodule Minga.Integration.AgentCursorTest do
       for {width, height} <- [{80, 24}, {120, 40}, {60, 20}] do
         ctx = start_agent_editor(width: width, height: height)
 
-        send_keys(ctx, "i")
+        send_keys_sync(ctx, "i")
 
         rows = screen_text(ctx)
         {cursor_row, _cursor_col} = screen_cursor(ctx)
@@ -192,7 +192,7 @@ defmodule Minga.Integration.AgentCursorTest do
     test "modeline shows INSERT mode after focusing input" do
       ctx = start_agent_editor()
 
-      send_keys(ctx, "i")
+      send_keys_sync(ctx, "i")
 
       rows = screen_text(ctx)
 

--- a/test/minga/integration/agent_panel_test.exs
+++ b/test/minga/integration/agent_panel_test.exs
@@ -41,7 +41,7 @@ defmodule Minga.Integration.AgentPanelTest do
   # Opens the agent split and asserts a separator rendered.
   # Returns `{ctx, sep_col}` where `sep_col` is the column index of the separator.
   defp open_agent_split(ctx) do
-    send_keys(ctx, "<Space>aa")
+    send_keys_sync(ctx, "<Space>aa")
     row1 = screen_row(ctx, 1)
     sep_col = row1 |> String.graphemes() |> Enum.find_index(&(&1 == "│"))
 
@@ -76,7 +76,7 @@ defmodule Minga.Integration.AgentPanelTest do
 
       assert Enum.any?(screen_text(ctx), &String.contains?(&1, "│"))
 
-      send_keys(ctx, "<Space>aa")
+      send_keys_sync(ctx, "<Space>aa")
 
       row1 = screen_row(ctx, 1)
       refute String.contains?(row1, "│"), "separator should be gone after closing agent panel"
@@ -85,10 +85,10 @@ defmodule Minga.Integration.AgentPanelTest do
     test "double toggle is idempotent (open -> close -> clean)" do
       ctx = start_editor_with_fake_session("hello world")
 
-      send_keys(ctx, "<Space>aa")
+      send_keys_sync(ctx, "<Space>aa")
       assert Enum.any?(screen_text(ctx), &String.contains?(&1, "│"))
 
-      send_keys(ctx, "<Space>aa")
+      send_keys_sync(ctx, "<Space>aa")
 
       content_row = screen_row(ctx, 1)
 
@@ -99,8 +99,8 @@ defmodule Minga.Integration.AgentPanelTest do
     test "buffer content is preserved through open/close cycle" do
       ctx = start_editor_with_fake_session("hello world")
 
-      send_keys(ctx, "<Space>aa")
-      send_keys(ctx, "<Space>aa")
+      send_keys_sync(ctx, "<Space>aa")
+      send_keys_sync(ctx, "<Space>aa")
 
       content = buffer_content(ctx)
       assert content == "hello world"
@@ -153,7 +153,7 @@ defmodule Minga.Integration.AgentPanelTest do
       ctx = start_editor_with_fake_session("one line")
       {ctx, _sep_col} = open_agent_split(ctx)
 
-      send_keys(ctx, "<Space>aa")
+      send_keys_sync(ctx, "<Space>aa")
 
       # Tilde rows (empty buffer lines) should span the full terminal width
       tilde_row = screen_row(ctx, 3)
@@ -194,7 +194,7 @@ defmodule Minga.Integration.AgentPanelTest do
       {_ctx, _sep_col} = open_agent_split(ctx)
 
       # x should delete a character because we're in editor scope
-      send_keys(ctx, "x")
+      send_keys_sync(ctx, "x")
       content = buffer_content(ctx)
       refute content == "hello world", "buffer should still be editable"
     end
@@ -222,7 +222,7 @@ defmodule Minga.Integration.AgentPanelTest do
 
       # Try to delete with x; buffer should be unchanged because keystrokes
       # route to the agent chat nav handler, not the buffer
-      send_keys(ctx, "x")
+      send_keys_sync(ctx, "x")
       content = buffer_content(ctx)
 
       assert content == "hello world",
@@ -247,7 +247,7 @@ defmodule Minga.Integration.AgentPanelTest do
              "clicking editor should return scope to :editor, got #{state.keymap_scope}"
 
       # Verify buffer editing works again
-      send_keys(ctx, "x")
+      send_keys_sync(ctx, "x")
       content = buffer_content(ctx)
       refute content == "hello world", "buffer should be editable after returning focus"
     end
@@ -262,7 +262,7 @@ defmodule Minga.Integration.AgentPanelTest do
 
       # SPC a v should toggle focus to agent (re-opens split if needed,
       # or toggles the active window)
-      send_keys(ctx, "<Space>av")
+      send_keys_sync(ctx, "<Space>av")
 
       state = :sys.get_state(ctx.editor)
 
@@ -290,7 +290,7 @@ defmodule Minga.Integration.AgentPanelTest do
     test "file tree open: tree on left, editor on right" do
       ctx = start_editor_with_fake_session("hello world")
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
 
       wait_until(
         ctx,
@@ -350,7 +350,7 @@ defmodule Minga.Integration.AgentPanelTest do
       ctx = start_editor_with_fake_session("hello world")
 
       # Open file tree first
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
 
       wait_until(
         ctx,
@@ -406,7 +406,7 @@ defmodule Minga.Integration.AgentPanelTest do
       ml_before = modeline(ctx)
 
       {ctx, _sep_col} = open_agent_split(ctx)
-      send_keys(ctx, "<Space>aa")
+      send_keys_sync(ctx, "<Space>aa")
 
       ml_after = modeline(ctx)
 
@@ -423,7 +423,7 @@ defmodule Minga.Integration.AgentPanelTest do
       ctx = start_editor_with_fake_session("hello world\nsecond line\nthird line")
       {ctx, _sep_col} = open_agent_split(ctx)
 
-      send_keys(ctx, "<Space>aa")
+      send_keys_sync(ctx, "<Space>aa")
 
       for row_idx <- 1..3 do
         row = screen_row(ctx, row_idx)

--- a/test/minga/integration/command_mode_test.exs
+++ b/test/minga/integration/command_mode_test.exs
@@ -13,7 +13,7 @@ defmodule Minga.Integration.CommandModeTest do
     test "colon shows in minibuffer with cursor positioned after it" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
 
       assert editor_mode(ctx) == :command
       assert_minibuffer_contains(ctx, ":")
@@ -30,7 +30,7 @@ defmodule Minga.Integration.CommandModeTest do
     test "typed text appears in minibuffer after colon" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, ":set nu")
+      send_keys_sync(ctx, ":set nu")
 
       assert editor_mode(ctx) == :command
       assert_minibuffer_contains(ctx, ":set nu")
@@ -40,7 +40,7 @@ defmodule Minga.Integration.CommandModeTest do
     test "partial command shows incrementally" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, ":se")
+      send_keys_sync(ctx, ":se")
 
       assert_minibuffer_contains(ctx, ":se")
       {cursor_row, cursor_col} = screen_cursor(ctx)
@@ -56,10 +56,10 @@ defmodule Minga.Integration.CommandModeTest do
     test "removes last character from minibuffer" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, ":set")
+      send_keys_sync(ctx, ":set")
       assert_minibuffer_contains(ctx, ":set")
 
-      send_keys(ctx, "<BS>")
+      send_keys_sync(ctx, "<BS>")
 
       assert editor_mode(ctx) == :command
       assert_minibuffer_contains(ctx, ":se")
@@ -69,7 +69,7 @@ defmodule Minga.Integration.CommandModeTest do
     test "backspacing to empty exits command mode" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, ":a<BS>")
+      send_keys_sync(ctx, ":a<BS>")
 
       assert editor_mode(ctx) == :normal
       assert_modeline_contains(ctx, "NORMAL")
@@ -86,7 +86,7 @@ defmodule Minga.Integration.CommandModeTest do
       # Record buffer cursor before command mode
       cursor_before = buffer_cursor(ctx)
 
-      send_keys(ctx, ":set nu<Esc>")
+      send_keys_sync(ctx, ":set nu<Esc>")
 
       assert editor_mode(ctx) == :normal
       assert_modeline_contains(ctx, "NORMAL")
@@ -98,12 +98,12 @@ defmodule Minga.Integration.CommandModeTest do
       ctx = start_editor("hello world")
 
       # Move cursor to col 5 before entering command mode
-      send_keys(ctx, "lllll")
+      send_keys_sync(ctx, "lllll")
       cursor_before = buffer_cursor(ctx)
       {_line, col} = cursor_before
       assert col == 5
 
-      send_keys(ctx, ":w<Esc>")
+      send_keys_sync(ctx, ":w<Esc>")
 
       assert buffer_cursor(ctx) == cursor_before
     end
@@ -115,7 +115,7 @@ defmodule Minga.Integration.CommandModeTest do
     test "toggles line numbers and returns to normal mode" do
       ctx = start_editor("hello\nworld\nfoo")
 
-      send_keys(ctx, ":set nu<CR>")
+      send_keys_sync(ctx, ":set nu<CR>")
 
       assert editor_mode(ctx) == :normal
       assert_modeline_contains(ctx, "NORMAL")
@@ -129,7 +129,7 @@ defmodule Minga.Integration.CommandModeTest do
     test "toggles relative line numbers and returns to normal mode" do
       ctx = start_editor("line one\nline two\nline three\nline four\nline five")
 
-      send_keys(ctx, ":set rnu<CR>")
+      send_keys_sync(ctx, ":set rnu<CR>")
 
       assert editor_mode(ctx) == :normal
       assert_screen_snapshot(ctx, "command_exec_set_rnu")
@@ -143,7 +143,7 @@ defmodule Minga.Integration.CommandModeTest do
       ctx =
         start_editor("line one\nline two\nline three\nline four\nline five")
 
-      send_keys(ctx, ":3<CR>")
+      send_keys_sync(ctx, ":3<CR>")
 
       assert editor_mode(ctx) == :normal
       {line, col} = buffer_cursor(ctx)
@@ -157,8 +157,8 @@ defmodule Minga.Integration.CommandModeTest do
         start_editor("line one\nline two\nline three\nline four\nline five")
 
       # Move to line 3 first, then :1 to go back to top
-      send_keys(ctx, ":3<CR>")
-      send_keys(ctx, ":1<CR>")
+      send_keys_sync(ctx, ":3<CR>")
+      send_keys_sync(ctx, ":1<CR>")
 
       {line, _col} = buffer_cursor(ctx)
       assert line == 0
@@ -172,7 +172,7 @@ defmodule Minga.Integration.CommandModeTest do
     test "shows no file name error in status" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, ":w<CR>")
+      send_keys_sync(ctx, ":w<CR>")
 
       assert editor_mode(ctx) == :normal
       assert_screen_snapshot(ctx, "command_save_unnamed")
@@ -185,7 +185,7 @@ defmodule Minga.Integration.CommandModeTest do
     test "returns to normal mode silently" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, ":nonexistent<CR>")
+      send_keys_sync(ctx, ":nonexistent<CR>")
 
       assert editor_mode(ctx) == :normal
       assert_modeline_contains(ctx, "NORMAL")
@@ -205,7 +205,7 @@ defmodule Minga.Integration.CommandModeTest do
       assert start_line == 0
 
       # Enter command mode and jump to line 4
-      send_keys(ctx, ":4<CR>")
+      send_keys_sync(ctx, ":4<CR>")
 
       assert editor_mode(ctx) == :normal
       {line, _} = buffer_cursor(ctx)
@@ -218,17 +218,17 @@ defmodule Minga.Integration.CommandModeTest do
         start_editor("first\nsecond\nthird\nfourth\nfifth")
 
       # Toggle line numbers
-      send_keys(ctx, ":set nu<CR>")
+      send_keys_sync(ctx, ":set nu<CR>")
       assert editor_mode(ctx) == :normal
 
       # Jump to line 3
-      send_keys(ctx, ":3<CR>")
+      send_keys_sync(ctx, ":3<CR>")
       assert editor_mode(ctx) == :normal
       {line, _} = buffer_cursor(ctx)
       assert line == 2
 
       # Enter and escape without executing
-      send_keys(ctx, ":w<Esc>")
+      send_keys_sync(ctx, ":w<Esc>")
       assert editor_mode(ctx) == :normal
       # Cursor stays where it was after :3
       {line2, _} = buffer_cursor(ctx)

--- a/test/minga/integration/file_open_from_agent_tab_test.exs
+++ b/test/minga/integration/file_open_from_agent_tab_test.exs
@@ -236,14 +236,14 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
       {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
 
       # Navigate down and verify cursor moves
-      send_key(ctx, ?j)
+      send_key_sync(ctx, ?j)
 
       active_buf = :sys.get_state(ctx.editor).buffers.active
       {line, _col} = BufferServer.cursor(active_buf)
       assert line == 1, "Expected cursor on line 1 after j, got #{line}"
 
       # Insert mode should work
-      send_keys(ctx, "iHELLO<Esc>")
+      send_keys_sync(ctx, "iHELLO<Esc>")
       content = BufferServer.content(active_buf)
 
       assert String.contains?(content, "HELLO"),

--- a/test/minga/integration/file_tree_test.exs
+++ b/test/minga/integration/file_tree_test.exs
@@ -14,7 +14,7 @@ defmodule Minga.Integration.FileTreeTest do
     test "opening shows file tree panel with separator" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
 
       # File tree should show directory structure with separator
       rows = screen_text(ctx)
@@ -26,10 +26,10 @@ defmodule Minga.Integration.FileTreeTest do
       ctx = start_editor("hello world")
 
       # Open then close
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
       assert Enum.any?(screen_text(ctx), &String.contains?(&1, "│"))
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
 
       # Separator should be gone
       row1 = screen_row(ctx, 1)
@@ -43,10 +43,10 @@ defmodule Minga.Integration.FileTreeTest do
     test "j/k moves tree cursor" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
       # Move down in tree
-      send_keys(ctx, "j")
-      send_keys(ctx, "j")
+      send_keys_sync(ctx, "j")
+      send_keys_sync(ctx, "j")
     end
   end
 
@@ -56,11 +56,11 @@ defmodule Minga.Integration.FileTreeTest do
     test "pressing Escape returns focus to editor" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
       # Tree should be focused initially
-      send_keys(ctx, "j")
+      send_keys_sync(ctx, "j")
 
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
 
       # After escape, focus should return to editor
       # Subsequent keys should operate on the buffer, not the tree
@@ -74,16 +74,16 @@ defmodule Minga.Integration.FileTreeTest do
     test "Enter on a file opens it in the editor and returns focus" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
       # Navigate down to find a file (skip root dir entry)
-      send_keys(ctx, "jjjjj")
+      send_keys_sync(ctx, "jjjjj")
       # Open the selected file
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       # Focus should be in the editor (not stuck in tree)
       # Verify by checking that 'j' moves the buffer cursor, not the tree cursor
       cursor_before = buffer_cursor(ctx)
-      send_keys(ctx, "j")
+      send_keys_sync(ctx, "j")
       cursor_after = buffer_cursor(ctx)
 
       # If focus returned to buffer, j moves cursor down one line
@@ -101,12 +101,12 @@ defmodule Minga.Integration.FileTreeTest do
     test "Escape from tree returns focus to editor while keeping tree open" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
       state = :sys.get_state(ctx.editor)
       assert state.keymap_scope == :file_tree
 
       # Escape closes the tree and returns focus to the editor
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
       state = :sys.get_state(ctx.editor)
       assert state.keymap_scope == :editor
     end
@@ -114,13 +114,13 @@ defmodule Minga.Integration.FileTreeTest do
     test "opening a file from tree returns focus to editor" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
       state = :sys.get_state(ctx.editor)
       assert state.keymap_scope == :file_tree
 
       # Navigate past all directories to reach a file (directories come first).
       # Go to the bottom of the tree to find a file entry.
-      send_keys(ctx, "G<CR>")
+      send_keys_sync(ctx, "G<CR>")
 
       state = :sys.get_state(ctx.editor)
 
@@ -135,13 +135,13 @@ defmodule Minga.Integration.FileTreeTest do
     test "l expands a directory and shows children" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
       # The root dir entry should be at the top
       # Navigate to it and expand with l
-      send_keys(ctx, "j")
+      send_keys_sync(ctx, "j")
 
       rows_before = screen_text(ctx)
-      send_keys(ctx, "l")
+      send_keys_sync(ctx, "l")
       rows_after = screen_text(ctx)
 
       # After expansion, there should be more content rows (children visible)
@@ -155,12 +155,12 @@ defmodule Minga.Integration.FileTreeTest do
     test "h collapses an expanded directory" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>op")
-      send_keys(ctx, "j")
-      send_keys(ctx, "l")
+      send_keys_sync(ctx, "<Space>op")
+      send_keys_sync(ctx, "j")
+      send_keys_sync(ctx, "l")
       rows_expanded = screen_text(ctx)
 
-      send_keys(ctx, "h")
+      send_keys_sync(ctx, "h")
       rows_collapsed = screen_text(ctx)
 
       # After collapse, some child rows should disappear
@@ -178,18 +178,18 @@ defmodule Minga.Integration.FileTreeTest do
     test "open -> close -> open shows tree with separator both times" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
       first_has_separator = Enum.any?(screen_text(ctx), &String.contains?(&1, "│"))
       assert first_has_separator
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
 
       refute Enum.any?(1..20, fn row ->
                screen_row(ctx, row) |> String.contains?("│")
              end),
              "separator should be gone after close"
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
       second_has_separator = Enum.any?(screen_text(ctx), &String.contains?(&1, "│"))
       assert second_has_separator, "re-opening tree should show separator again"
     end

--- a/test/minga/integration/lsp_wiring_test.exs
+++ b/test/minga/integration/lsp_wiring_test.exs
@@ -161,10 +161,10 @@ defmodule Minga.Integration.LspWiringTest do
       end)
 
       # Enter visual mode then exit
-      send_keys(ctx, "v")
+      send_keys_sync(ctx, "v")
       assert editor_mode(ctx) == :visual
 
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
       assert editor_mode(ctx) == :normal
 
       # Selection range state should be cleared

--- a/test/minga/integration/mode_transitions_test.exs
+++ b/test/minga/integration/mode_transitions_test.exs
@@ -16,7 +16,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "modeline shows INSERT, cursor shape is beam" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "i")
+      send_keys_sync(ctx, "i")
 
       assert_modeline_contains(ctx, "INSERT")
       assert cursor_shape(ctx) == :beam
@@ -29,7 +29,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "cursor moves right one column, enters insert mode" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "a")
+      send_keys_sync(ctx, "a")
 
       assert cursor_shape(ctx) == :beam
       assert_modeline_contains(ctx, "INSERT")
@@ -41,7 +41,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "cursor moves to end of line, enters insert mode" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "A")
+      send_keys_sync(ctx, "A")
 
       assert cursor_shape(ctx) == :beam
       assert_modeline_contains(ctx, "INSERT")
@@ -53,7 +53,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "opens new line below, cursor on new line" do
       ctx = start_editor("hello\nworld")
 
-      send_keys(ctx, "o")
+      send_keys_sync(ctx, "o")
 
       assert cursor_shape(ctx) == :beam
       assert_modeline_contains(ctx, "INSERT")
@@ -67,7 +67,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "opens new line above, cursor on new line" do
       ctx = start_editor("hello\nworld")
 
-      send_keys(ctx, "O")
+      send_keys_sync(ctx, "O")
 
       assert cursor_shape(ctx) == :beam
       assert_modeline_contains(ctx, "INSERT")
@@ -83,10 +83,10 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "cursor shape returns to block, modeline shows NORMAL" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "i")
+      send_keys_sync(ctx, "i")
       assert cursor_shape(ctx) == :beam
 
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
 
       assert cursor_shape(ctx) == :block
       assert_modeline_contains(ctx, "NORMAL")
@@ -98,11 +98,11 @@ defmodule Minga.Integration.ModeTransitionsTest do
       ctx = start_editor("hello world")
 
       # Move right three times then enter insert mode
-      send_keys(ctx, "llli")
+      send_keys_sync(ctx, "llli")
       assert editor_mode(ctx) == :insert
       {_, col_in_insert} = buffer_cursor(ctx)
 
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
 
       {_, col_after_escape} = buffer_cursor(ctx)
       # Minga currently keeps cursor at same column on insert→normal
@@ -112,7 +112,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "cursor stays at col 0 when escaping at start of line" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "i<Esc>")
+      send_keys_sync(ctx, "i<Esc>")
 
       {_line, col} = buffer_cursor(ctx)
       assert col == 0
@@ -125,7 +125,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "modeline shows VISUAL, cursor stays block" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "v")
+      send_keys_sync(ctx, "v")
 
       assert_modeline_contains(ctx, "VISUAL")
       assert cursor_shape(ctx) == :block
@@ -138,7 +138,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "modeline shows V-LINE" do
       ctx = start_editor("hello world\nsecond line")
 
-      send_keys(ctx, "V")
+      send_keys_sync(ctx, "V")
 
       assert_modeline_contains(ctx, "V-LINE")
       assert cursor_shape(ctx) == :block
@@ -152,10 +152,10 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "returns to normal mode, selection cleared" do
       ctx = start_editor("hello world\nsecond line")
 
-      send_keys(ctx, "vlll")
+      send_keys_sync(ctx, "vlll")
       assert_modeline_contains(ctx, "VISUAL")
 
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
 
       assert_modeline_contains(ctx, "NORMAL")
       assert cursor_shape(ctx) == :block
@@ -170,7 +170,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "minibuffer shows colon, cursor moves to minibuffer row" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
 
       assert_minibuffer_contains(ctx, ":")
       assert_modeline_contains(ctx, "COMMAND")
@@ -194,10 +194,10 @@ defmodule Minga.Integration.ModeTransitionsTest do
       # Record cursor position before command mode
       cursor_before = screen_cursor(ctx)
 
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       assert_modeline_contains(ctx, "COMMAND")
 
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
 
       assert_modeline_contains(ctx, "NORMAL")
       assert cursor_shape(ctx) == :block
@@ -220,7 +220,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
       ctx = start_editor("hello world")
 
       # :set nu is a valid command that toggles line numbers
-      send_keys(ctx, ":set nu<CR>")
+      send_keys_sync(ctx, ":set nu<CR>")
 
       assert_modeline_contains(ctx, "NORMAL")
       assert cursor_shape(ctx) == :block
@@ -235,7 +235,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
 
       cursor_before = screen_cursor(ctx)
 
-      send_keys(ctx, ":x<BS><BS>")
+      send_keys_sync(ctx, ":x<BS><BS>")
 
       assert_modeline_contains(ctx, "NORMAL")
       assert cursor_shape(ctx) == :block
@@ -252,7 +252,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "modeline stays NORMAL while in operator-pending mode" do
       ctx = start_editor("hello world\nsecond line")
 
-      send_keys(ctx, "d")
+      send_keys_sync(ctx, "d")
 
       # Operator-pending is an invisible sub-state of Normal (like Vim/Doom).
       # The modeline should NOT flash "OPERATOR".
@@ -268,7 +268,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
 
       content_before = buffer_content(ctx)
 
-      send_keys(ctx, "d<Esc>")
+      send_keys_sync(ctx, "d<Esc>")
 
       assert_modeline_contains(ctx, "NORMAL")
       assert editor_mode(ctx) == :normal
@@ -281,7 +281,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "executes linewise delete, returns to normal" do
       ctx = start_editor("first\nsecond\nthird")
 
-      send_keys(ctx, "dd")
+      send_keys_sync(ctx, "dd")
 
       assert_modeline_contains(ctx, "NORMAL")
       assert editor_mode(ctx) == :normal
@@ -297,7 +297,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
       ctx = start_editor("hello world")
 
       # r sets pending_replace in normal mode state, not a mode transition
-      send_keys(ctx, "r")
+      send_keys_sync(ctx, "r")
 
       assert_modeline_contains(ctx, "NORMAL")
       assert editor_mode(ctx) == :normal
@@ -310,7 +310,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "replaces character and stays in normal mode" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "rX")
+      send_keys_sync(ctx, "rX")
 
       assert_modeline_contains(ctx, "NORMAL")
       assert cursor_shape(ctx) == :block
@@ -323,10 +323,10 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "Escape after r returns to block cursor without replacing" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "r")
+      send_keys_sync(ctx, "r")
       assert cursor_shape(ctx) == :underline
 
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
       assert cursor_shape(ctx) == :block
       assert String.starts_with?(buffer_content(ctx), "hello")
     end
@@ -336,7 +336,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "R overwrites then backspace restores" do
       ctx = start_editor("abcdef")
 
-      send_keys(ctx, "R")
+      send_keys_sync(ctx, "R")
       assert editor_mode(ctx) == :replace
       assert cursor_shape(ctx) == :underline
 
@@ -345,20 +345,20 @@ defmodule Minga.Integration.ModeTransitionsTest do
       assert String.starts_with?(buffer_content(ctx), "XYcdef")
 
       # Backspace restores 'b'
-      send_keys(ctx, "<BS>")
+      send_keys_sync(ctx, "<BS>")
       assert String.starts_with?(buffer_content(ctx), "Xbcdef")
 
       # Backspace restores 'a'
-      send_keys(ctx, "<BS>")
+      send_keys_sync(ctx, "<BS>")
       assert String.starts_with?(buffer_content(ctx), "abcdef")
     end
 
     test "backspace at entry column is a no-op" do
       ctx = start_editor("abcdef")
 
-      send_keys(ctx, "R")
+      send_keys_sync(ctx, "R")
       # No overwrites yet, backspace should do nothing
-      send_keys(ctx, "<BS>")
+      send_keys_sync(ctx, "<BS>")
       assert String.starts_with?(buffer_content(ctx), "abcdef")
     end
   end
@@ -370,20 +370,20 @@ defmodule Minga.Integration.ModeTransitionsTest do
       ctx = start_editor("hello world\nsecond line\nthird line")
 
       # Step 1: Enter insert mode, type text
-      send_keys(ctx, "iABC<Esc>")
+      send_keys_sync(ctx, "iABC<Esc>")
       assert_modeline_contains(ctx, "NORMAL")
       assert cursor_shape(ctx) == :block
       assert String.contains?(buffer_content(ctx), "ABC")
 
       # Step 2: Enter command mode
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
       assert_modeline_contains(ctx, "COMMAND")
       assert cursor_shape(ctx) == :beam
       {cursor_row, _} = screen_cursor(ctx)
       assert cursor_row == ctx.height - 1
 
       # Step 3: Escape back to normal
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
       assert_modeline_contains(ctx, "NORMAL")
       assert cursor_shape(ctx) == :block
 
@@ -399,7 +399,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
       ctx = start_editor("hello world")
 
       # Select "hel" in visual mode, then change
-      send_keys(ctx, "vllc")
+      send_keys_sync(ctx, "vllc")
       assert_modeline_contains(ctx, "INSERT")
       assert cursor_shape(ctx) == :beam
 
@@ -407,7 +407,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
       type_text(ctx, "XYZ")
 
       # Escape back to normal
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
       assert_modeline_contains(ctx, "NORMAL")
       assert cursor_shape(ctx) == :block
       assert String.starts_with?(buffer_content(ctx), "XYZ")
@@ -422,7 +422,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
     test "minibuffer shows search prompt, cursor on minibuffer row" do
       ctx = start_editor("hello world\nfoo bar")
 
-      send_keys(ctx, "/")
+      send_keys_sync(ctx, "/")
 
       assert_modeline_contains(ctx, "SEARCH")
       assert cursor_shape(ctx) == :beam
@@ -438,7 +438,7 @@ defmodule Minga.Integration.ModeTransitionsTest do
 
       cursor_before = screen_cursor(ctx)
 
-      send_keys(ctx, "/hello<Esc>")
+      send_keys_sync(ctx, "/hello<Esc>")
 
       assert_modeline_contains(ctx, "NORMAL")
       assert cursor_shape(ctx) == :block

--- a/test/minga/integration/mouse_test.exs
+++ b/test/minga/integration/mouse_test.exs
@@ -28,7 +28,7 @@ defmodule Minga.Integration.MouseTest do
   # Fails the test if the separator can't be found (layout didn't render).
   defp open_agent_split(ctx) do
     ctx = inject_fake_session(ctx)
-    send_keys(ctx, "<Space>aa")
+    send_keys_sync(ctx, "<Space>aa")
     row1 = screen_row(ctx, 1)
     sep_col = row1 |> String.graphemes() |> Enum.find_index(&(&1 == "│"))
 
@@ -134,7 +134,7 @@ defmodule Minga.Integration.MouseTest do
     test "clicking in tree area doesn't move buffer cursor" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
       cursor_before = buffer_cursor(ctx)
 
       # Click in the tree area (col 2, well within tree panel)
@@ -408,7 +408,7 @@ defmodule Minga.Integration.MouseTest do
 
       # Open file tree and wait for it to render.
       # Bump polling budget for CI runners where layout settling takes longer.
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
 
       wait_until(
         ctx,
@@ -423,7 +423,7 @@ defmodule Minga.Integration.MouseTest do
 
       # Open agent panel (inject fake session to skip ~700ms provider startup)
       inject_fake_session(ctx)
-      send_keys(ctx, "<Space>aa")
+      send_keys_sync(ctx, "<Space>aa")
 
       # Wait for both separators to appear (file tree | editor | agent).
       # Use wait_until_screen to sync the HeadlessPort before reading the

--- a/test/minga/integration/picker_lifecycle_test.exs
+++ b/test/minga/integration/picker_lifecycle_test.exs
@@ -13,7 +13,7 @@ defmodule Minga.Integration.PickerLifecycleTest do
     test "shows picker overlay with title and prompt" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>bb")
+      send_keys_sync(ctx, "<Space>bb")
 
       # Picker renders at the bottom: title row, item rows, prompt row
       assert_minibuffer_contains(ctx, ">")
@@ -25,7 +25,7 @@ defmodule Minga.Integration.PickerLifecycleTest do
     test "shows current buffer in item list" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>bb")
+      send_keys_sync(ctx, "<Space>bb")
 
       assert screen_contains?(ctx, "[no file]")
     end
@@ -40,10 +40,10 @@ defmodule Minga.Integration.PickerLifecycleTest do
       # Record state before picker
       cursor_before = buffer_cursor(ctx)
 
-      send_keys(ctx, "<Space>bb")
+      send_keys_sync(ctx, "<Space>bb")
       assert screen_contains?(ctx, "Switch buffer")
 
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
 
       assert editor_mode(ctx) == :normal
       assert_modeline_contains(ctx, "NORMAL")
@@ -56,12 +56,12 @@ defmodule Minga.Integration.PickerLifecycleTest do
       ctx = start_editor("hello world")
 
       # Move cursor to col 5
-      send_keys(ctx, "lllll")
+      send_keys_sync(ctx, "lllll")
       cursor_before = buffer_cursor(ctx)
       {_line, col} = cursor_before
       assert col == 5
 
-      send_keys(ctx, "<Space>bb<Esc>")
+      send_keys_sync(ctx, "<Space>bb<Esc>")
 
       assert buffer_cursor(ctx) == cursor_before
     end
@@ -73,11 +73,11 @@ defmodule Minga.Integration.PickerLifecycleTest do
     test "typing in prompt filters visible items" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>bb")
+      send_keys_sync(ctx, "<Space>bb")
       assert screen_contains?(ctx, "[no file]")
 
       # Type something that won't match "[no file]"
-      send_keys(ctx, "zzz")
+      send_keys_sync(ctx, "zzz")
 
       # The item should be filtered out (no match)
       assert_screen_snapshot(ctx, "buffer_picker_filter_no_match")
@@ -86,11 +86,11 @@ defmodule Minga.Integration.PickerLifecycleTest do
     test "backspace in filter restores previous results" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>bb")
-      send_keys(ctx, "zzz")
+      send_keys_sync(ctx, "<Space>bb")
+      send_keys_sync(ctx, "zzz")
       # Filter should show no matches
 
-      send_keys(ctx, "<BS><BS><BS>")
+      send_keys_sync(ctx, "<BS><BS><BS>")
       # Cleared filter, should show items again
       assert screen_contains?(ctx, "[no file]")
     end
@@ -102,7 +102,7 @@ defmodule Minga.Integration.PickerLifecycleTest do
     test "selecting the only buffer closes picker" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>bb<CR>")
+      send_keys_sync(ctx, "<Space>bb<CR>")
 
       assert editor_mode(ctx) == :normal
       refute screen_contains?(ctx, "Switch buffer")
@@ -116,7 +116,7 @@ defmodule Minga.Integration.PickerLifecycleTest do
     test "shows picker overlay with Commands title" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>:")
+      send_keys_sync(ctx, "<Space>:")
 
       assert screen_contains?(ctx, "Commands")
       # No snapshot: command count in the title bar changes when commands
@@ -130,11 +130,11 @@ defmodule Minga.Integration.PickerLifecycleTest do
     test "typing filters the command list" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>:")
+      send_keys_sync(ctx, "<Space>:")
       assert screen_contains?(ctx, "Commands")
 
       # Type "save" to filter to save-related commands
-      send_keys(ctx, "save")
+      send_keys_sync(ctx, "save")
 
       assert screen_contains?(ctx, "save")
     end
@@ -148,10 +148,10 @@ defmodule Minga.Integration.PickerLifecycleTest do
 
       cursor_before = buffer_cursor(ctx)
 
-      send_keys(ctx, "<Space>:")
+      send_keys_sync(ctx, "<Space>:")
       assert screen_contains?(ctx, "Commands")
 
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
 
       assert editor_mode(ctx) == :normal
       refute screen_contains?(ctx, "Commands")
@@ -166,11 +166,11 @@ defmodule Minga.Integration.PickerLifecycleTest do
       ctx = start_editor("hello world")
 
       # Open command palette and filter to "new_buffer"
-      send_keys(ctx, "<Space>:")
-      send_keys(ctx, "new_buffer")
+      send_keys_sync(ctx, "<Space>:")
+      send_keys_sync(ctx, "new_buffer")
 
       # Select the first match
-      send_keys(ctx, "<CR>")
+      send_keys_sync(ctx, "<CR>")
 
       assert editor_mode(ctx) == :normal
       refute screen_contains?(ctx, "Commands")
@@ -184,11 +184,11 @@ defmodule Minga.Integration.PickerLifecycleTest do
       ctx = start_editor("hello world")
 
       # Enter visual mode and start selection
-      send_keys(ctx, "llv")
+      send_keys_sync(ctx, "llv")
       assert editor_mode(ctx) == :visual
 
-      send_keys(ctx, "<Space>bb")
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Space>bb")
+      send_keys_sync(ctx, "<Esc>")
 
       # After picker cancel, should return to visual mode
       # (The picker restores the mode it was opened from)

--- a/test/minga/integration/resize_test.exs
+++ b/test/minga/integration/resize_test.exs
@@ -58,7 +58,7 @@ defmodule Minga.Integration.ResizeTest do
       ctx = start_editor(content)
 
       # Move cursor to line 20
-      send_keys(ctx, "20j")
+      send_keys_sync(ctx, "20j")
       {line, _} = buffer_cursor(ctx)
       assert line == 20
 
@@ -79,7 +79,7 @@ defmodule Minga.Integration.ResizeTest do
     test "file tree and editor adjust to new width" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>op")
+      send_keys_sync(ctx, "<Space>op")
       assert Enum.any?(screen_text(ctx), &String.contains?(&1, "│"))
 
       ctx = send_resize(ctx, 120, 24)
@@ -95,7 +95,7 @@ defmodule Minga.Integration.ResizeTest do
     test "split panes adjust proportionally" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>wv")
+      send_keys_sync(ctx, "<Space>wv")
       row_before = screen_row(ctx, 1)
       assert String.contains?(row_before, "│")
 

--- a/test/minga/integration/scroll_viewport_test.exs
+++ b/test/minga/integration/scroll_viewport_test.exs
@@ -18,8 +18,8 @@ defmodule Minga.Integration.ScrollViewportTest do
       ctx = start_editor(@test_content)
 
       # Move down first, then gg back to top
-      send_keys(ctx, "20j")
-      send_keys(ctx, "gg")
+      send_keys_sync(ctx, "20j")
+      send_keys_sync(ctx, "gg")
 
       {line, col} = buffer_cursor(ctx)
       assert line == 0
@@ -35,7 +35,7 @@ defmodule Minga.Integration.ScrollViewportTest do
     test "shows last lines of file, cursor at last line" do
       ctx = start_editor(@test_content)
 
-      send_keys(ctx, "G")
+      send_keys_sync(ctx, "G")
 
       {line, _col} = buffer_cursor(ctx)
       assert line == @line_count - 1
@@ -52,7 +52,7 @@ defmodule Minga.Integration.ScrollViewportTest do
       ctx = start_editor(@test_content)
 
       # Move down enough to scroll (24-row terminal, ~22 content rows)
-      send_keys(ctx, "30j")
+      send_keys_sync(ctx, "30j")
 
       {line, _col} = buffer_cursor(ctx)
       assert line == 30
@@ -69,8 +69,8 @@ defmodule Minga.Integration.ScrollViewportTest do
       ctx = start_editor(@test_content)
 
       # Go to bottom, then come back up
-      send_keys(ctx, "G")
-      send_keys(ctx, "30k")
+      send_keys_sync(ctx, "G")
+      send_keys_sync(ctx, "30k")
 
       {line, _col} = buffer_cursor(ctx)
       assert line == @line_count - 1 - 30
@@ -86,7 +86,7 @@ defmodule Minga.Integration.ScrollViewportTest do
       ctx = start_editor(@test_content)
 
       {line_before, _} = buffer_cursor(ctx)
-      send_keys(ctx, "<C-d>")
+      send_keys_sync(ctx, "<C-d>")
       {line_after, _} = buffer_cursor(ctx)
 
       # Should move roughly half the screen height (10-12 lines for 24-row terminal)
@@ -103,10 +103,10 @@ defmodule Minga.Integration.ScrollViewportTest do
       ctx = start_editor(@test_content)
 
       # Go down first
-      send_keys(ctx, "50j")
+      send_keys_sync(ctx, "50j")
       {line_before, _} = buffer_cursor(ctx)
 
-      send_keys(ctx, "<C-u>")
+      send_keys_sync(ctx, "<C-u>")
       {line_after, _} = buffer_cursor(ctx)
 
       jump = line_before - line_after
@@ -121,7 +121,7 @@ defmodule Minga.Integration.ScrollViewportTest do
     test "line numbers are correct after scrolling" do
       ctx = start_editor(@test_content)
 
-      send_keys(ctx, "25j")
+      send_keys_sync(ctx, "25j")
 
       # The gutter should show numbers around line 26
       # (0-indexed line 25 = display line 26)
@@ -140,7 +140,7 @@ defmodule Minga.Integration.ScrollViewportTest do
       ctx = start_editor(@test_content)
 
       # Move down enough to trigger scrolling
-      send_keys(ctx, "30j")
+      send_keys_sync(ctx, "30j")
 
       {cursor_line, _} = buffer_cursor(ctx)
       # The cursor should be visible on screen, not at the very last content row.
@@ -163,8 +163,8 @@ defmodule Minga.Integration.ScrollViewportTest do
     test "cursor stays away from viewport edge when scrolling up" do
       ctx = start_editor(@test_content)
 
-      send_keys(ctx, "G")
-      send_keys(ctx, "30k")
+      send_keys_sync(ctx, "G")
+      send_keys_sync(ctx, "30k")
 
       {cursor_line, _} = buffer_cursor(ctx)
       cursor_display_line = cursor_line + 1
@@ -189,9 +189,9 @@ defmodule Minga.Integration.ScrollViewportTest do
       ctx = start_editor(@wide_content)
 
       # Move to the long line (line 2, 0-indexed line 1)
-      send_keys(ctx, "j")
+      send_keys_sync(ctx, "j")
       # Move cursor far right past the terminal width
-      send_keys(ctx, "$")
+      send_keys_sync(ctx, "$")
 
       {_, col} = buffer_cursor(ctx)
       assert col >= 100, "cursor should be far right on the long line, at col #{col}"
@@ -213,10 +213,10 @@ defmodule Minga.Integration.ScrollViewportTest do
       # Capture initial screen
       initial_cursor = buffer_cursor(ctx)
 
-      send_keys(ctx, "G")
+      send_keys_sync(ctx, "G")
       assert buffer_cursor(ctx) != initial_cursor
 
-      send_keys(ctx, "gg")
+      send_keys_sync(ctx, "gg")
       assert buffer_cursor(ctx) == initial_cursor
       assert_screen_snapshot(ctx, "scroll_roundtrip_gg")
     end

--- a/test/minga/integration/snapshot_test.exs
+++ b/test/minga/integration/snapshot_test.exs
@@ -52,7 +52,7 @@ defmodule Minga.Integration.SnapshotTest do
     test "cursor after $ (end of line)" do
       ctx = start_editor("hello world\nsecond line")
 
-      send_keys(ctx, "$")
+      send_keys_sync(ctx, "$")
 
       assert_screen_snapshot(ctx, "nav_end_of_line")
     end
@@ -60,7 +60,7 @@ defmodule Minga.Integration.SnapshotTest do
     test "cursor after 0 (start of line)" do
       ctx = start_editor("hello world\nsecond line")
 
-      send_keys(ctx, "ll0")
+      send_keys_sync(ctx, "ll0")
 
       assert_screen_snapshot(ctx, "nav_start_of_line")
     end
@@ -87,7 +87,7 @@ defmodule Minga.Integration.SnapshotTest do
     test "screen after escape back to normal mode" do
       ctx = start_editor("hello")
 
-      send_keys(ctx, "iabc<Esc>")
+      send_keys_sync(ctx, "iabc<Esc>")
 
       assert_screen_snapshot(ctx, "insert_then_escape")
     end
@@ -97,7 +97,7 @@ defmodule Minga.Integration.SnapshotTest do
     test "screen after dd (delete line)" do
       ctx = start_editor("first\nsecond\nthird")
 
-      send_keys(ctx, "dd")
+      send_keys_sync(ctx, "dd")
 
       assert_screen_snapshot(ctx, "dd_first_line")
     end
@@ -105,7 +105,7 @@ defmodule Minga.Integration.SnapshotTest do
     test "screen after x (delete char)" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "x")
+      send_keys_sync(ctx, "x")
 
       assert_screen_snapshot(ctx, "x_delete_char")
     end
@@ -115,7 +115,7 @@ defmodule Minga.Integration.SnapshotTest do
     test "screen after dd then undo" do
       ctx = start_editor("first\nsecond\nthird")
 
-      send_keys(ctx, "dd")
+      send_keys_sync(ctx, "dd")
       send_key(ctx, ?u)
 
       assert_screen_snapshot(ctx, "dd_then_undo")
@@ -134,7 +134,7 @@ defmodule Minga.Integration.SnapshotTest do
     test "screen after visual selection with lll" do
       ctx = start_editor("hello world\nsecond line")
 
-      send_keys(ctx, "vlll")
+      send_keys_sync(ctx, "vlll")
 
       assert_screen_snapshot(ctx, "visual_select_lll")
     end
@@ -144,7 +144,7 @@ defmodule Minga.Integration.SnapshotTest do
     test "screen after pressing colon" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, ":")
+      send_keys_sync(ctx, ":")
 
       assert_screen_snapshot(ctx, "command_mode_entered")
     end
@@ -152,7 +152,7 @@ defmodule Minga.Integration.SnapshotTest do
     test "screen after typing a command" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, ":set")
+      send_keys_sync(ctx, ":set")
 
       assert_screen_snapshot(ctx, "command_mode_typed_set")
     end
@@ -160,7 +160,7 @@ defmodule Minga.Integration.SnapshotTest do
     test "screen after escaping command mode" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, ":set<Esc>")
+      send_keys_sync(ctx, ":set<Esc>")
 
       assert_screen_snapshot(ctx, "command_mode_escaped")
     end
@@ -171,17 +171,17 @@ defmodule Minga.Integration.SnapshotTest do
       ctx = start_editor("line one\nline two\nline three")
 
       # Navigate to line 2, col 3
-      send_key(ctx, ?j)
-      send_key(ctx, ?l)
-      send_key(ctx, ?l)
+      send_key_sync(ctx, ?j)
+      send_key_sync(ctx, ?l)
+      send_key_sync(ctx, ?l)
 
       # Insert text
-      send_keys(ctx, "iXY<Esc>")
+      send_keys_sync(ctx, "iXY<Esc>")
 
       assert_screen_snapshot(ctx, "workflow_after_insert")
 
       # Delete the line
-      send_keys(ctx, "dd")
+      send_keys_sync(ctx, "dd")
 
       assert_screen_snapshot(ctx, "workflow_after_dd")
 

--- a/test/minga/integration/toggle_line_numbers_test.exs
+++ b/test/minga/integration/toggle_line_numbers_test.exs
@@ -18,16 +18,16 @@ defmodule Minga.Integration.ToggleLineNumbersTest do
 
       assert BufferServer.get_option(ctx.buffer, :line_numbers) == :hybrid
 
-      send_keys(ctx, "<SPC>tl")
+      send_keys_sync(ctx, "<SPC>tl")
       assert BufferServer.get_option(ctx.buffer, :line_numbers) == :absolute
 
-      send_keys(ctx, "<SPC>tl")
+      send_keys_sync(ctx, "<SPC>tl")
       assert BufferServer.get_option(ctx.buffer, :line_numbers) == :relative
 
-      send_keys(ctx, "<SPC>tl")
+      send_keys_sync(ctx, "<SPC>tl")
       assert BufferServer.get_option(ctx.buffer, :line_numbers) == :none
 
-      send_keys(ctx, "<SPC>tl")
+      send_keys_sync(ctx, "<SPC>tl")
       assert BufferServer.get_option(ctx.buffer, :line_numbers) == :hybrid
     end
 
@@ -41,9 +41,9 @@ defmodule Minga.Integration.ToggleLineNumbersTest do
       assert row2 =~ ~r/\d.*line two/, "hybrid: line 2 shows a number"
 
       # Cycle to none (hybrid → absolute → relative → none = 3 presses).
-      send_keys(ctx, "<SPC>tl")
-      send_keys(ctx, "<SPC>tl")
-      send_keys(ctx, "<SPC>tl")
+      send_keys_sync(ctx, "<SPC>tl")
+      send_keys_sync(ctx, "<SPC>tl")
+      send_keys_sync(ctx, "<SPC>tl")
       assert BufferServer.get_option(ctx.buffer, :line_numbers) == :none
 
       row1 = screen_row(ctx, 1)
@@ -51,7 +51,7 @@ defmodule Minga.Integration.ToggleLineNumbersTest do
       refute row1 =~ ~r/^\s+\d/, "none: no line number padding"
 
       # One more press back to hybrid.
-      send_keys(ctx, "<SPC>tl")
+      send_keys_sync(ctx, "<SPC>tl")
       assert BufferServer.get_option(ctx.buffer, :line_numbers) == :hybrid
 
       row1 = screen_row(ctx, 1)

--- a/test/minga/integration/which_key_test.exs
+++ b/test/minga/integration/which_key_test.exs
@@ -15,7 +15,7 @@ defmodule Minga.Integration.WhichKeyTest do
       ctx = start_editor("hello world")
 
       # Press SPC to enter leader mode
-      send_keys(ctx, "<Space>")
+      send_keys_sync(ctx, "<Space>")
 
       # The which-key popup is timer-based (300ms default).
       # Trigger it by sending the timeout message directly.
@@ -35,7 +35,7 @@ defmodule Minga.Integration.WhichKeyTest do
     test "SPC w shows window-specific bindings" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>w")
+      send_keys_sync(ctx, "<Space>w")
       trigger_whichkey_timeout(ctx)
 
       # Window group should show split/navigation bindings
@@ -48,7 +48,7 @@ defmodule Minga.Integration.WhichKeyTest do
     test "SPC b shows buffer-specific bindings" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>b")
+      send_keys_sync(ctx, "<Space>b")
       trigger_whichkey_timeout(ctx)
 
       assert screen_contains?(ctx, "buffer") or screen_contains?(ctx, "Switch") or
@@ -64,12 +64,12 @@ defmodule Minga.Integration.WhichKeyTest do
     test "completing a binding dismisses the popup" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>")
+      send_keys_sync(ctx, "<Space>")
       trigger_whichkey_timeout(ctx)
       assert screen_contains?(ctx, "+file")
 
       # Complete the binding: SPC f f (find file) opens picker, closes which-key
-      send_keys(ctx, "ff")
+      send_keys_sync(ctx, "ff")
 
       # Which-key labels should be gone, picker should be visible instead
       refute screen_contains?(ctx, "+buffer")
@@ -79,10 +79,10 @@ defmodule Minga.Integration.WhichKeyTest do
     test "escape dismisses the popup and returns to normal" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>")
+      send_keys_sync(ctx, "<Space>")
       trigger_whichkey_timeout(ctx)
 
-      send_keys(ctx, "<Esc>")
+      send_keys_sync(ctx, "<Esc>")
 
       assert editor_mode(ctx) == :normal
       assert_screen_snapshot(ctx, "whichkey_dismissed_by_escape")
@@ -96,7 +96,7 @@ defmodule Minga.Integration.WhichKeyTest do
       ctx = start_editor("hello world")
 
       # Send the full SPC b b sequence without triggering timeout
-      send_keys(ctx, "<Space>bb")
+      send_keys_sync(ctx, "<Space>bb")
 
       # The picker should be open, but no which-key popup artifacts
       assert screen_contains?(ctx, "Switch buffer")

--- a/test/minga/integration/window_splits_test.exs
+++ b/test/minga/integration/window_splits_test.exs
@@ -12,7 +12,7 @@ defmodule Minga.Integration.WindowSplitsTest do
     test "creates two side-by-side panes with separator" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>wv")
+      send_keys_sync(ctx, "<Space>wv")
 
       # Both panes should show the same buffer content
       rows = screen_text(ctx)
@@ -25,7 +25,7 @@ defmodule Minga.Integration.WindowSplitsTest do
     test "global status bar appears at row height-2" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>wv")
+      send_keys_sync(ctx, "<Space>wv")
 
       # Single global status bar (not per-pane); shows focused window info.
       status_bar_row = screen_row(ctx, ctx.height - 2)
@@ -42,7 +42,7 @@ defmodule Minga.Integration.WindowSplitsTest do
     test "creates two stacked panes with global status bar" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>ws")
+      send_keys_sync(ctx, "<Space>ws")
 
       # Single global status bar at row height-2 (not one per pane).
       rows = screen_text(ctx)
@@ -65,11 +65,11 @@ defmodule Minga.Integration.WindowSplitsTest do
     test "C-w l moves focus to right pane" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>wv")
+      send_keys_sync(ctx, "<Space>wv")
       # Focus starts in the left pane (or right, depending on impl)
       cursor_before = screen_cursor(ctx)
 
-      send_keys(ctx, "<C-w>l")
+      send_keys_sync(ctx, "<C-w>l")
       cursor_after = screen_cursor(ctx)
 
       # Cursor should move to the other pane (different column region)
@@ -80,11 +80,11 @@ defmodule Minga.Integration.WindowSplitsTest do
     test "C-w h moves focus to left pane" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>wv")
-      send_keys(ctx, "<C-w>l")
+      send_keys_sync(ctx, "<Space>wv")
+      send_keys_sync(ctx, "<C-w>l")
       cursor_right = screen_cursor(ctx)
 
-      send_keys(ctx, "<C-w>h")
+      send_keys_sync(ctx, "<C-w>h")
       cursor_left = screen_cursor(ctx)
 
       assert cursor_left != cursor_right
@@ -98,9 +98,9 @@ defmodule Minga.Integration.WindowSplitsTest do
     test "typing in one pane doesn't affect the other" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>wv")
+      send_keys_sync(ctx, "<Space>wv")
       # Type in the active pane
-      send_keys(ctx, "iNEW TEXT<Esc>")
+      send_keys_sync(ctx, "iNEW TEXT<Esc>")
 
       # Both panes share the same buffer, so content changes appear in both.
       # But cursor position should only be in the active pane.
@@ -115,13 +115,13 @@ defmodule Minga.Integration.WindowSplitsTest do
     test "closing one pane restores full width" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>wv")
+      send_keys_sync(ctx, "<Space>wv")
       # Verify split exists
       row1_split = screen_row(ctx, 1)
       assert String.contains?(row1_split, "│")
 
       # Close the current window
-      send_keys(ctx, "<Space>wd")
+      send_keys_sync(ctx, "<Space>wd")
 
       # Should be back to single pane, no separator
       row1_single = screen_row(ctx, 1)
@@ -136,14 +136,14 @@ defmodule Minga.Integration.WindowSplitsTest do
     test "switching away and back preserves cursor position" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>wv")
+      send_keys_sync(ctx, "<Space>wv")
       # Move cursor in left pane
-      send_keys(ctx, "lllll")
+      send_keys_sync(ctx, "lllll")
       cursor_left = buffer_cursor(ctx)
 
       # Switch to right pane and back
-      send_keys(ctx, "<C-w>l")
-      send_keys(ctx, "<C-w>h")
+      send_keys_sync(ctx, "<C-w>l")
+      send_keys_sync(ctx, "<C-w>h")
 
       assert buffer_cursor(ctx) == cursor_left
     end
@@ -155,8 +155,8 @@ defmodule Minga.Integration.WindowSplitsTest do
     test "splitting twice creates three panes" do
       ctx = start_editor("hello world")
 
-      send_keys(ctx, "<Space>wv")
-      send_keys(ctx, "<Space>wv")
+      send_keys_sync(ctx, "<Space>wv")
+      send_keys_sync(ctx, "<Space>wv")
 
       # Should have two separators (three panes)
       rows = screen_text(ctx)

--- a/test/minga/integration_test.exs
+++ b/test/minga/integration_test.exs
@@ -81,7 +81,7 @@ defmodule Minga.IntegrationTest do
     test "i enters insert mode and characters are inserted" do
       ctx = start_editor("hello")
 
-      send_key(ctx, ?i)
+      send_key_sync(ctx, ?i)
       assert_mode(ctx, :insert)
 
       type_text(ctx, "abc")
@@ -93,19 +93,19 @@ defmodule Minga.IntegrationTest do
     test "Escape returns to normal mode — subsequent keys move, not insert" do
       ctx = start_editor("hello")
 
-      send_keys(ctx, "ix<Esc>")
+      send_keys_sync(ctx, "ix<Esc>")
 
       content_after_insert = buffer_content(ctx)
       assert_mode(ctx, :normal)
 
-      send_key(ctx, ?l)
+      send_key_sync(ctx, ?l)
       assert buffer_content(ctx) == content_after_insert
     end
 
     test "backspace deletes the previous character in insert mode" do
       ctx = start_editor("hello")
 
-      send_keys(ctx, "ia<BS>")
+      send_keys_sync(ctx, "ia<BS>")
 
       assert buffer_content(ctx) == "hello"
     end
@@ -113,7 +113,7 @@ defmodule Minga.IntegrationTest do
     test "Enter inserts a newline in insert mode" do
       ctx = start_editor("hello")
 
-      send_keys(ctx, "i<CR>")
+      send_keys_sync(ctx, "i<CR>")
 
       assert String.contains?(buffer_content(ctx), "\n")
     end
@@ -121,7 +121,7 @@ defmodule Minga.IntegrationTest do
     test "a moves right before entering insert mode" do
       ctx = start_editor("hi")
 
-      send_key(ctx, ?a)
+      send_key_sync(ctx, ?a)
       type_text(ctx, "!")
 
       assert String.contains?(buffer_content(ctx), "!")
@@ -134,8 +134,8 @@ defmodule Minga.IntegrationTest do
     test "dd deletes the current line and moves cursor" do
       ctx = start_editor("hello\nworld\nfoo")
 
-      send_key(ctx, ?d)
-      send_key(ctx, ?d)
+      send_key_sync(ctx, ?d)
+      send_key_sync(ctx, ?d)
 
       content = buffer_content(ctx)
       refute String.contains?(content, "hello")
@@ -145,8 +145,8 @@ defmodule Minga.IntegrationTest do
     test "dd on a single-line buffer leaves it empty or minimal" do
       ctx = start_editor("only line")
 
-      send_key(ctx, ?d)
-      send_key(ctx, ?d)
+      send_key_sync(ctx, ?d)
+      send_key_sync(ctx, ?d)
 
       refute String.contains?(buffer_content(ctx), "only")
     end
@@ -158,21 +158,21 @@ defmodule Minga.IntegrationTest do
     test "u after inserting reverts the buffer" do
       ctx = start_editor("hello")
 
-      send_keys(ctx, "ix<Esc>")
+      send_keys_sync(ctx, "ix<Esc>")
       assert buffer_content(ctx) == "xhello"
 
-      send_key(ctx, ?u)
+      send_key_sync(ctx, ?u)
       assert buffer_content(ctx) == "hello"
     end
 
     test "u after dd reverts the deletion" do
       ctx = start_editor("hello\nworld\nfoo")
 
-      send_key(ctx, ?d)
-      send_key(ctx, ?d)
+      send_key_sync(ctx, ?d)
+      send_key_sync(ctx, ?d)
       refute String.contains?(buffer_content(ctx), "hello")
 
-      send_key(ctx, ?u)
+      send_key_sync(ctx, ?u)
       assert String.contains?(buffer_content(ctx), "hello")
     end
 
@@ -180,7 +180,7 @@ defmodule Minga.IntegrationTest do
       ctx = start_editor("hello")
       original = buffer_content(ctx)
 
-      send_key(ctx, ?u)
+      send_key_sync(ctx, ?u)
       assert buffer_content(ctx) == original
     end
 
@@ -190,18 +190,18 @@ defmodule Minga.IntegrationTest do
       ctx = start_editor("aaa\nbbb\nccc")
 
       # Delete first line (dd), then delete next line (dd)
-      send_keys(ctx, "dd")
+      send_keys_sync(ctx, "dd")
       assert buffer_content(ctx) == "bbb\nccc"
 
-      send_keys(ctx, "dd")
+      send_keys_sync(ctx, "dd")
       assert buffer_content(ctx) == "ccc"
 
       # First undo restores "bbb"
-      send_key(ctx, ?u)
+      send_key_sync(ctx, ?u)
       assert buffer_content(ctx) == "bbb\nccc"
 
       # Second undo restores "aaa"
-      send_key(ctx, ?u)
+      send_key_sync(ctx, ?u)
       assert buffer_content(ctx) == "aaa\nbbb\nccc"
     end
   end
@@ -212,10 +212,10 @@ defmodule Minga.IntegrationTest do
     test "p pastes register text after cursor after yy" do
       ctx = start_editor("hello\nworld")
 
-      send_key(ctx, ?y)
-      send_key(ctx, ?y)
-      send_key(ctx, ?j)
-      send_key(ctx, ?p)
+      send_key_sync(ctx, ?y)
+      send_key_sync(ctx, ?y)
+      send_key_sync(ctx, ?j)
+      send_key_sync(ctx, ?p)
 
       lines = buffer_content(ctx) |> String.split("\n")
       assert length(lines) >= 3
@@ -224,10 +224,10 @@ defmodule Minga.IntegrationTest do
     test "P pastes register text before cursor" do
       ctx = start_editor("hello\nworld")
 
-      send_key(ctx, ?y)
-      send_key(ctx, ?y)
-      send_key(ctx, ?j)
-      send_key(ctx, ?P)
+      send_key_sync(ctx, ?y)
+      send_key_sync(ctx, ?y)
+      send_key_sync(ctx, ?j)
+      send_key_sync(ctx, ?P)
 
       assert String.contains?(buffer_content(ctx), "hello")
     end
@@ -236,7 +236,7 @@ defmodule Minga.IntegrationTest do
       ctx = start_editor("hello")
       original = buffer_content(ctx)
 
-      send_key(ctx, ?p)
+      send_key_sync(ctx, ?p)
       assert buffer_content(ctx) == original
     end
   end
@@ -249,7 +249,7 @@ defmodule Minga.IntegrationTest do
       ctx = start_editor("save me", file_path: path)
 
       # Type some content, then save via :w
-      send_keys(ctx, "iextra <Esc>:w<CR>")
+      send_keys_sync(ctx, "iextra <Esc>:w<CR>")
 
       assert File.exists?(path)
       assert String.contains?(File.read!(path), "extra")
@@ -263,23 +263,23 @@ defmodule Minga.IntegrationTest do
       ctx = start_editor("line one\nline two\nline three")
 
       # Navigate
-      send_key(ctx, ?j)
-      send_key(ctx, ?l)
-      send_key(ctx, ?l)
+      send_key_sync(ctx, ?j)
+      send_key_sync(ctx, ?l)
+      send_key_sync(ctx, ?l)
       assert_modeline_contains(ctx, "2:3")
 
       # Enter insert mode and type
-      send_keys(ctx, "iINSERTED<Esc>")
+      send_keys_sync(ctx, "iINSERTED<Esc>")
       assert String.contains?(buffer_content(ctx), "INSERTED")
       assert_row_contains(ctx, 2, "INSERTED")
 
       # Delete the line
-      send_key(ctx, ?d)
-      send_key(ctx, ?d)
+      send_key_sync(ctx, ?d)
+      send_key_sync(ctx, ?d)
       refute String.contains?(buffer_content(ctx), "INSERTED")
 
       # Undo the delete
-      send_key(ctx, ?u)
+      send_key_sync(ctx, ?u)
       assert String.contains?(buffer_content(ctx), "INSERTED")
       assert_row_contains(ctx, 2, "INSERTED")
 

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -234,8 +234,11 @@ defmodule Minga.Test.EditorCase do
   `assert_screen_snapshot`. Returns the editor state after processing.
   """
   @spec send_key_sync(editor_ctx(), non_neg_integer(), non_neg_integer()) :: map()
-  def send_key_sync(%{editor: editor}, codepoint, mods \\ 0) do
+  def send_key_sync(%{editor: editor, port: port}, codepoint, mods \\ 0) do
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
+    # Clear any stale frame snapshot so assert_screen_snapshot falls back
+    # to reading the live (post-render) grid from HeadlessPort.
+    Process.delete({:last_frame_snapshot, port})
     :sys.get_state(editor)
   end
 
@@ -246,13 +249,16 @@ defmodule Minga.Test.EditorCase do
   or which-key timeouts) are fully processed before the next key.
   """
   @spec send_keys_sync(editor_ctx(), String.t()) :: map()
-  def send_keys_sync(%{editor: editor} = _ctx, sequence) do
+  def send_keys_sync(%{editor: editor, port: port} = _ctx, sequence) do
     parse_key_sequence(sequence)
     |> Enum.each(fn {cp, mods} ->
       send(editor, {:minga_input, {:key_press, cp, mods}})
       :sys.get_state(editor)
     end)
 
+    # Clear any stale frame snapshot so assert_screen_snapshot falls back
+    # to reading the live (post-render) grid from HeadlessPort.
+    Process.delete({:last_frame_snapshot, port})
     :sys.get_state(editor)
   end
 
@@ -431,19 +437,19 @@ defmodule Minga.Test.EditorCase do
   Run with `UPDATE_SNAPSHOTS=1 mix test` to overwrite all baselines.
   ## Example
       ctx = start_editor("hello world")
-      send_keys(ctx, "llx")
+      send_keys_sync(ctx, "llx")
       assert_screen_snapshot(ctx, "after_delete_char")
   """
   defmacro assert_screen_snapshot(ctx, snapshot_name) do
     quote do
       ctx = unquote(ctx)
       name = unquote(snapshot_name)
-      # Use the frame snapshot captured atomically at batch_end time
-      # (stored by send_key/send_keys, keyed by port pid). This is
-      # race-free: no late render can overwrite it because it lives in
-      # the test process's memory. Falls back to reading the live grid
-      # if no snapshot was captured (e.g., asserting immediately after
-      # start_editor without any keys).
+      # If a preceding `send_key` captured a frame snapshot, use it.
+      # Otherwise (after `send_key_sync`/`send_keys_sync`, which clear
+      # the stale snapshot), fall back to reading the live grid from
+      # HeadlessPort. The fallback is safe because BEAM message ordering
+      # guarantees the render cast reached the port before the sync
+      # barrier returned.
       {rows, snap_cursor, snap_shape} =
         case Process.get({:last_frame_snapshot, ctx.port}) do
           %{grid: grid, cursor: c, cursor_shape: s} ->


### PR DESCRIPTION
## Problem

The `send_key` test helper has a structural race condition. It registers a frame waiter via `prepare_await`, sends a key to the editor, then waits for the next `batch_end` frame. It assumes that frame was caused by its key press.

But background renders from deferred messages queued by the `:ready` handler (e.g. `:setup_highlight`, `:debounced_render`, diagnostics events) can produce spurious `batch_end` frames that satisfy the waiter before the key press is actually processed. On slow CI runners (GitHub Actions Ubuntu, `max_cases: 8`), this race window widens enough to trigger.

**CI failure:** `buffer_cursor(ctx) == {0, 0}` instead of `{0, 2}` after two `l` presses. Both key presses missed because a background render satisfied both waiters early.

## Fix

Two complementary changes:

1. **Drain barriers in `start_editor`**: Add `:sys.get_state(editor)` + `:sys.get_state(port)` after consuming the initial `:ready` frame. This ensures all deferred messages (and their render side effects) are fully processed before the test body runs. Protects ALL tests, not just the failing one.

2. **Migrate hjkl tests to `send_key_sync`**: These tests check buffer/screen state, not frame snapshots. `send_key_sync` uses `:sys.get_state` as a race-free synchronization barrier. Also updated the `send_key_sync` `@doc` to clarify it's safe for screen state reads (BEAM message ordering guarantees the render cast reaches the port before any subsequent query).

## Files changed

- `test/support/editor_case.ex` — drain barriers + doc update
- `test/minga/integration_test.exs` — `send_key` → `send_key_sync` in navigation tests