### PR TITLE
test(editor): fix flaky integration tests with race-free screen assertions

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -31,3 +31,9 @@ config :minga,
     go_install: Minga.Tool.Installer.Stub,
     github_release: Minga.Tool.Installer.Stub
   }
+
+# Disable the which-key popup timer in tests. The timer fires after 300ms
+# and triggers an extra render, which can steal frame waiters from the
+# headless test harness. Setting :infinity prevents the timer from firing
+# while still allowing the which-key popup to render via explicit tests.
+config :minga, whichkey_timeout_ms: :infinity

--- a/lib/minga/which_key.ex
+++ b/lib/minga/which_key.ex
@@ -62,12 +62,33 @@ defmodule Minga.WhichKey do
   After `timeout_ms` milliseconds (default #{@default_timeout_ms} ms), sends
   `{:whichkey_timeout, ref}` to the calling process. Returns the `ref` that
   will be included in the message so the caller can identify it.
+
+  When the application config `:whichkey_timeout_ms` is set to `:infinity`
+  (e.g., in test mode), no timer is started. The returned `ref` is still
+  safe to pass to `cancel_timeout/1`, which will be a no-op.
   """
-  @spec start_timeout(non_neg_integer()) :: timer_ref()
-  def start_timeout(timeout_ms \\ @default_timeout_ms)
-      when is_integer(timeout_ms) and timeout_ms >= 0 do
+  @spec start_timeout(non_neg_integer() | nil) :: timer_ref()
+  def start_timeout(timeout_ms \\ nil) do
     ref = make_ref()
-    Process.send_after(self(), {:whichkey_timeout, ref}, timeout_ms)
+
+    effective =
+      case timeout_ms do
+        nil -> Application.get_env(:minga, :whichkey_timeout_ms, @default_timeout_ms)
+        ms when is_integer(ms) and ms >= 0 -> ms
+      end
+
+    case effective do
+      :infinity ->
+        :ok
+
+      ms when is_integer(ms) and ms >= 0 ->
+        Process.send_after(self(), {:whichkey_timeout, ref}, ms)
+
+      bad ->
+        raise ArgumentError,
+              "whichkey_timeout_ms must be a non-negative integer or :infinity, got: #{inspect(bad)}"
+    end
+
     ref
   end
 
@@ -157,14 +178,14 @@ defmodule Minga.WhichKey do
   defp modifier_prefix(modifiers) do
     ctrl = band(modifiers, 0x02) != 0
     alt = band(modifiers, 0x04) != 0
-
-    cond do
-      ctrl and alt -> "C-M-"
-      ctrl -> "C-"
-      alt -> "M-"
-      true -> ""
-    end
+    modifier_string(ctrl, alt)
   end
+
+  @spec modifier_string(boolean(), boolean()) :: String.t()
+  defp modifier_string(true, true), do: "C-M-"
+  defp modifier_string(true, false), do: "C-"
+  defp modifier_string(false, true), do: "M-"
+  defp modifier_string(false, false), do: ""
 
   @spec format_label(String.t() | atom()) :: String.t()
   defp format_label(label) when is_binary(label), do: label

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -71,7 +71,8 @@ defmodule Minga.Test.EditorCase do
     # Send ready event to trigger initial render
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:ready, width, height}})
-    {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+    {:ok, snapshot} = HeadlessPort.collect_frame(ref)
+    Process.put({:last_frame_snapshot, port}, snapshot)
 
     Map.merge(ctx, %{
       editor: editor,
@@ -106,7 +107,8 @@ defmodule Minga.Test.EditorCase do
 
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:ready, width, height}})
-    {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+    {:ok, snapshot} = HeadlessPort.collect_frame(ref)
+    Process.put({:last_frame_snapshot, port}, snapshot)
 
     %{
       editor: editor,
@@ -195,6 +197,10 @@ defmodule Minga.Test.EditorCase do
   """
   @spec send_key(editor_ctx(), non_neg_integer(), non_neg_integer()) :: :ok
   def send_key(%{editor: editor, port: port}, codepoint, mods \\ 0) do
+    # Drain any pending async messages (timers, highlight events, etc.)
+    # before registering the frame waiter. This prevents a pending render
+    # from satisfying our waiter instead of the intended key's render.
+    _ = :sys.get_state(editor)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
     {:ok, snapshot} = HeadlessPort.collect_frame(ref)
@@ -261,40 +267,70 @@ defmodule Minga.Test.EditorCase do
   end
 
   # ── Screen query helpers ─────────────────────────────────────────────────────
+
+  # All screen helpers read from the last captured frame snapshot stored
+  # by send_key/send_mouse/start_editor. This is race-free: the snapshot
+  # is immutable data in the test process, unaffected by subsequent async
+  # renders. Falls back to the live HeadlessPort grid only when no
+  # snapshot exists (should not happen in well-structured tests).
+
   @doc "Returns the rendered text for a specific row."
   @spec screen_row(editor_ctx(), non_neg_integer()) :: String.t()
   def screen_row(%{port: port}, row) do
-    HeadlessPort.get_row_text(port, row)
+    case Process.get({:last_frame_snapshot, port}) do
+      %{grid: grid} ->
+        grid
+        |> Enum.at(row, [])
+        |> Enum.map_join(& &1.char)
+        |> String.trim_trailing()
+
+      nil ->
+        HeadlessPort.get_row_text(port, row)
+    end
   end
 
   @doc "Returns all screen rows as a list of strings."
   @spec screen_text(editor_ctx()) :: [String.t()]
   def screen_text(%{port: port}) do
-    HeadlessPort.get_screen_text(port)
+    case Process.get({:last_frame_snapshot, port}) do
+      %{grid: grid} ->
+        Enum.map(grid, fn row ->
+          row |> Enum.map_join(& &1.char) |> String.trim_trailing()
+        end)
+
+      nil ->
+        HeadlessPort.get_screen_text(port)
+    end
   end
 
   @doc "Returns the modeline row text (second to last row)."
   @spec modeline(editor_ctx()) :: String.t()
-  def modeline(%{port: port, height: height}) do
-    HeadlessPort.get_row_text(port, height - 2)
+  def modeline(%{height: height} = ctx) do
+    screen_row(ctx, height - 2)
   end
 
   @doc "Returns the minibuffer row text (last row)."
   @spec minibuffer(editor_ctx()) :: String.t()
-  def minibuffer(%{port: port, height: height}) do
-    HeadlessPort.get_row_text(port, height - 1)
+  def minibuffer(%{height: height} = ctx) do
+    screen_row(ctx, height - 1)
   end
 
   @doc "Returns the cursor position on screen."
   @spec screen_cursor(editor_ctx()) :: {non_neg_integer(), non_neg_integer()}
   def screen_cursor(%{port: port}) do
-    HeadlessPort.get_cursor(port)
+    case Process.get({:last_frame_snapshot, port}) do
+      %{cursor: cursor} -> cursor
+      nil -> HeadlessPort.get_cursor(port)
+    end
   end
 
   @doc "Returns the current cursor shape."
   @spec cursor_shape(editor_ctx()) :: Minga.Port.Protocol.cursor_shape()
   def cursor_shape(%{port: port}) do
-    HeadlessPort.get_cursor_shape(port)
+    case Process.get({:last_frame_snapshot, port}) do
+      %{cursor_shape: shape} -> shape
+      nil -> HeadlessPort.get_cursor_shape(port)
+    end
   end
 
   @doc "Returns the buffer content."
@@ -540,6 +576,7 @@ defmodule Minga.Test.EditorCase do
         event_type \\ :press,
         click_count \\ 1
       ) do
+    _ = :sys.get_state(editor)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:mouse_event, row, col, button, mods, event_type, click_count}})
     {:ok, snapshot} = HeadlessPort.collect_frame(ref)
@@ -553,6 +590,7 @@ defmodule Minga.Test.EditorCase do
   """
   @spec send_resize(editor_ctx(), pos_integer(), pos_integer()) :: editor_ctx()
   def send_resize(%{editor: editor, port: port} = ctx, new_width, new_height) do
+    _ = :sys.get_state(editor)
     HeadlessPort.resize(port, new_width, new_height)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:resize, new_width, new_height}})


### PR DESCRIPTION
# TL;DR

Eliminates two intermittently-failing integration tests by fixing race conditions in the headless test harness. Screen assertions now read from immutable frame snapshots instead of a live mutable grid.

## Context

`WindowSplitsTest` ("closing one pane restores full width") and `BufferManagementTest` ("next/prev cycle through open buffers") failed intermittently in CI but passed locally. The root cause was timing dependencies in the test harness, not in the editor code.

## Changes

Three structural fixes, no band-aids:

1. **Disable which-key timer in test mode** (`config/test.exs`): The 300ms which-key popup timer could fire between a `prepare_await` and the intended key's render, causing the test to capture the wrong frame. Setting `whichkey_timeout_ms: :infinity` prevents the timer from firing. Tests that explicitly call `start_timeout(10)` with a value still work because the config only affects the nil-default path.

2. **Screen helpers read from captured snapshots** (`test/support/editor_case.ex`): `screen_row`, `screen_text`, `modeline`, `minibuffer`, `screen_cursor`, and `cursor_shape` now read from the last frame snapshot stored by `send_key` (via `Process.put`). This snapshot is immutable data in the test process, unaffected by subsequent async renders. Previously these helpers called `HeadlessPort.get_row_text` which reads the live mutable grid. Also stored the initial frame snapshot from `start_editor`/`start_editor_with_buffer`.

3. **`:sys.get_state` drain before frame registration** (`test/support/editor_case.ex`): `send_key`, `send_mouse`, and `send_resize` now call `:sys.get_state(editor)` before `prepare_await` to flush any pending async messages (timers, highlight events) that might trigger renders. This prevents stale renders from satisfying the frame waiter.

Also refactored `modifier_prefix/1` in `which_key.ex` to use multi-clause `defp` instead of `cond` (per project coding standard, since the file was touched).

## Verification

```bash
# Stress test: 60/60 consecutive passes for both previously-flaky tests
for i in $(seq 1 60); do
  mix test test/minga/integration/window_splits_test.exs:115 \
           test/minga/buffer_management_test.exs:67 \
           --seed $RANDOM || break
done
# Result: 60/60 passes

mix lint    # passes clean (format, credo, compile, dialyzer)
mix test    # 6205 tests, 0 failures
```

## Acceptance Criteria Addressed

- WindowSplitsTest no longer flaky ✅
- BufferManagementTest no longer flaky ✅
- Fix eliminates timing dependencies structurally (no Process.sleep) ✅
- No regressions in full test suite ✅