### PR TITLE
feat(macos): app launches BEAM from Finder, Spotlight, and Dock

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,18 @@
+import Config
+
+# Port mode: how the BEAM connects to the GUI frontend.
+#
+# - "connected" — the GUI process spawned us as a child. Our stdin/stdout
+#   are already piped to the GUI. Port.Manager opens {fd, 0, 1} instead
+#   of spawning a new child process. Set by the Swift app via the
+#   MINGA_PORT_MODE env var when launching the embedded BEAM release.
+#
+# - "spawn" (default) — we're the parent. Port.Manager spawns the GUI
+#   binary as a child process via Port.open({:spawn_executable, ...}).
+port_mode =
+  case System.get_env("MINGA_PORT_MODE") do
+    "connected" -> :connected
+    _ -> :spawn
+  end
+
+config :minga, port_mode: port_mode

--- a/lib/minga/port/manager.ex
+++ b/lib/minga/port/manager.ex
@@ -1,10 +1,20 @@
 defmodule Minga.Port.Manager do
   @moduledoc """
-  GenServer that manages the Zig renderer Port process.
+  GenServer that manages the frontend renderer Port.
 
-  Spawns the Zig binary as an Erlang Port with `{:packet, 4}` framing.
-  Incoming input events from Zig are decoded and forwarded to subscribers.
-  Outgoing render commands are encoded and sent to the Port.
+  Operates in two modes depending on the `MINGA_PORT_MODE` env var:
+
+  - **Spawn mode** (default): BEAM is the parent process. Port.Manager
+    spawns the GUI/TUI binary as a child via `Port.open({:spawn_executable, ...})`.
+    Used in development, TUI mode, and Burrito releases.
+
+  - **Connected mode** (`MINGA_PORT_MODE=connected`): BEAM is a child of
+    the GUI process. The GUI set up stdin/stdout pipes before launching us.
+    Port.Manager opens `{:fd, 0, 1}` as a Port instead of spawning a child.
+    Used when launching from `Minga.app` (Finder, Spotlight, Dock).
+
+  Both modes use identical `{:packet, 4}` framing. The protocol layer
+  (event decoding, render commands, subscriber broadcasting) is the same.
 
   Subscribers register via `subscribe/1` and receive messages as:
 
@@ -27,6 +37,8 @@ defmodule Minga.Port.Manager do
           {:name, GenServer.name()}
           | {:renderer_path, String.t()}
           | {:backend, backend()}
+          | {:port_mode, Minga.Port.Manager.State.port_mode()}
+          | {:port_opener, (term(), [term()] -> port())}
 
   alias Minga.Port.Manager.State, as: PortState
 
@@ -88,10 +100,12 @@ defmodule Minga.Port.Manager do
     Process.flag(:fullsweep_after, 20)
 
     backend = Keyword.get(opts, :backend, :tui)
+    port_mode = Keyword.get(opts, :port_mode, Application.get_env(:minga, :port_mode, :spawn))
     renderer_path = Keyword.get(opts, :renderer_path, default_renderer_path(backend))
 
-    state = %PortState{renderer_path: renderer_path}
-    {:ok, start_port(state)}
+    port_opener = Keyword.get(opts, :port_opener, &Port.open/2)
+    state = %PortState{renderer_path: renderer_path, port_mode: port_mode}
+    {:ok, start_port(state, port_opener)}
   end
 
   @impl true
@@ -176,6 +190,14 @@ defmodule Minga.Port.Manager do
     {:noreply, %{state | port: nil, ready: false}}
   end
 
+  # In connected mode ({:fd, 0, 1}), stdin EOF means the GUI parent exited.
+  # Shut down cleanly, same as a normal exit in spawn mode.
+  def handle_info({port, :eof}, %{port: port} = state) do
+    Minga.Log.info(:port, "GUI parent disconnected (stdin EOF)")
+    maybe_stop_system(0)
+    {:noreply, %{state | port: nil, ready: false}}
+  end
+
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
     subscribers = Enum.reject(state.subscribers, &(&1 == pid))
     {:noreply, %{state | subscribers: subscribers}}
@@ -187,13 +209,24 @@ defmodule Minga.Port.Manager do
 
   # ── Private ──
 
-  @spec start_port(state()) :: state()
-  defp start_port(state) do
+  @spec start_port(state(), fun()) :: state()
+  defp start_port(%{port_mode: :connected} = state, port_opener) do
+    # Connected mode: the GUI parent already set up stdin/stdout pipes.
+    # Open fd 0 (stdin) and fd 1 (stdout) as an Erlang Port with the
+    # same {:packet, 4} framing used in spawn mode. The entire protocol
+    # layer (event decoding, render commands, subscriber broadcasting)
+    # works identically over both transports.
+    port = port_opener.({:fd, 0, 1}, [:binary, {:packet, 4}, :eof])
+    %{state | port: port}
+  end
+
+  defp start_port(state, port_opener) do
+    # Spawn mode: we're the parent. Launch the GUI binary as a child process.
     if File.exists?(state.renderer_path) do
       env = tty_env()
 
       port =
-        Port.open(
+        port_opener.(
           {:spawn_executable, state.renderer_path},
           [:binary, :exit_status, {:packet, 4}, :use_stdio, {:env, env}]
         )

--- a/lib/minga/port/manager/state.ex
+++ b/lib/minga/port/manager/state.ex
@@ -7,10 +7,19 @@ defmodule Minga.Port.Manager.State do
 
   alias Minga.Port.Capabilities
 
+  @typedoc """
+  Port connection mode.
+
+  - `:spawn` — BEAM is the parent; Port.Manager spawns the GUI as a child process (dev mode, TUI, Burrito).
+  - `:connected` — BEAM is the child; the GUI parent already set up stdin/stdout pipes. Port.Manager connects to fd 0/1 instead of spawning.
+  """
+  @type port_mode :: :spawn | :connected
+
   @enforce_keys [:renderer_path]
   defstruct port: nil,
             subscribers: [],
             renderer_path: "",
+            port_mode: :spawn,
             ready: false,
             terminal_size: nil,
             capabilities: %Capabilities{}
@@ -19,6 +28,7 @@ defmodule Minga.Port.Manager.State do
           port: port() | nil,
           subscribers: [pid()],
           renderer_path: String.t(),
+          port_mode: port_mode(),
           ready: boolean(),
           terminal_size: {width :: pos_integer(), height :: pos_integer()} | nil,
           capabilities: Capabilities.t()

--- a/macos/AGENTS.md
+++ b/macos/AGENTS.md
@@ -78,7 +78,7 @@ macos/
 ## Tech Requirements
 
 - **Swift 6.0+** with strict concurrency
-- **Metal 3.1+** (MSL 3.1), macOS 14.0+ deployment target
+- **Metal 3.2+** (MSL 3.2), macOS 15.0+ deployment target
 - **Xcode 16+** for building
 - Build via `xcodebuild -project Minga.xcodeproj -scheme Minga build`
 

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		1631D7B76B33CD897C48F263 /* IMECompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */; };
 		18F0DDA03D08C0B4302DCCF4 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
 		1965FE752C77D2EB386EC4D8 /* BottomPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */; };
+		19E561E5F7841B2CF1ABB085 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
 		1F9F7B302A2A8598C1391FA0 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
 		23DA463A92D1EC2F7BFA5B5A /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		26DAAF2C2CCC2713AD30C539 /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
@@ -72,6 +73,7 @@
 		785A55B784A3EE17DC3E0AC6 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C0836F0D4150126F181C05 /* PickerState.swift */; };
 		78F06B9BFB553B50D9BDD50F /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		793247C2AB95598A1AC4C6EC /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD30A2572AE2608F099407 /* ScrollAccumulator.swift */; };
+		79E8353F67F7638721A02A54 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
 		7A21099CFC922D178A3079DF /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C26E064D810299C0302F439 /* EditorView.swift */; };
 		7C9B7CB6670412D9F4DE60BB /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
 		810251CDDA9CB63F881D426C /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D6B3C68CFF37BC4303933A /* ThemeColors.swift */; };
@@ -217,6 +219,7 @@
 		E892F827AFBE959F9DF25C05 /* StatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarView.swift; sourceTree = "<group>"; };
 		ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolManagerView.swift; sourceTree = "<group>"; };
 		F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorsTests.swift; sourceTree = "<group>"; };
+		F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BEAMProcessManager.swift; sourceTree = "<group>"; };
 		F220A60775A252A728477659 /* ProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolTests.swift; sourceTree = "<group>"; };
 		F5647A59C841B3C408994CC7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMECompositionTests.swift; sourceTree = "<group>"; };
@@ -336,6 +339,7 @@
 		C6B8D946BE6392AA3F4AE5E9 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */,
 				4A647814918768E62822D4A1 /* MingaApp.swift */,
 				4AACF7C989E8FDB12B3EC840 /* Font */,
 				BE05074760AA9D5983E99402 /* Protocol */,
@@ -520,6 +524,7 @@
 			files = (
 				DE6C77896ED3E1E885216DC3 /* AgentChatState.swift in Sources */,
 				4DF0BD94C77CA840CC92ACB7 /* AgentChatView.swift in Sources */,
+				19E561E5F7841B2CF1ABB085 /* BEAMProcessManager.swift in Sources */,
 				18F0DDA03D08C0B4302DCCF4 /* BitmapRasterizer.swift in Sources */,
 				941C53DDBC488FE908656CD3 /* BottomPanelState.swift in Sources */,
 				1965FE752C77D2EB386EC4D8 /* BottomPanelView.swift in Sources */,
@@ -580,6 +585,7 @@
 			files = (
 				1F9F7B302A2A8598C1391FA0 /* AgentChatState.swift in Sources */,
 				0D5DFD181E86D51707D3A59E /* AgentChatView.swift in Sources */,
+				79E8353F67F7638721A02A54 /* BEAMProcessManager.swift in Sources */,
 				64A5A16E02B3E2694060F1A1 /* BitmapRasterizer.swift in Sources */,
 				5BEEC2FD4D95EBA70FE036E7 /* BottomPanelState.swift in Sources */,
 				59546703C9DBB4BA6E15DE28 /* BottomPanelView.swift in Sources */,
@@ -705,7 +711,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -788,7 +794,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;

--- a/macos/Sources/BEAMProcessManager.swift
+++ b/macos/Sources/BEAMProcessManager.swift
@@ -1,0 +1,221 @@
+/// Manages the BEAM child process when running in bundle mode.
+///
+/// When the user launches Minga.app from Finder, Spotlight, or the Dock,
+/// this class discovers the embedded BEAM release inside the app bundle,
+/// spawns it as a child process with piped stdin/stdout, and monitors
+/// its lifecycle.
+///
+/// The BEAM receives `MINGA_PORT_MODE=connected` in its environment,
+/// which tells Port.Manager to open `{:fd, 0, 1}` instead of spawning
+/// a GUI process. The pipes connect the BEAM's stdin/stdout to our
+/// ProtocolReader/ProtocolEncoder.
+///
+/// Crash recovery: if the BEAM exits unexpectedly, the manager attempts
+/// automatic restart with exponential backoff (max 3 restarts in 5 seconds).
+/// After the limit is exceeded, the onCrash callback fires so the app
+/// can show an error UI.
+
+import Foundation
+
+@MainActor
+final class BEAMProcessManager {
+    /// File handle for reading protocol messages from the BEAM (BEAM's stdout).
+    private(set) var readHandle: FileHandle?
+
+    /// File handle for writing protocol messages to the BEAM (BEAM's stdin).
+    private(set) var writeHandle: FileHandle?
+
+    /// The running BEAM child process.
+    private var process: Process?
+
+    /// Called when the BEAM exits unexpectedly and restart limits are exceeded.
+    var onCrash: (@MainActor () -> Void)?
+
+    /// Called when the BEAM exits normally (exit code 0).
+    var onNormalExit: (@MainActor () -> Void)?
+
+    /// Called each time the BEAM process starts (initial or restart).
+    /// Provides the new read/write handles for protocol communication.
+    var onBEAMReady: (@MainActor (_ readHandle: FileHandle, _ writeHandle: FileHandle) -> Void)?
+
+    // Restart backoff tracking (OTP-style: max restarts in a time window).
+    private var restartTimestamps: [Date] = []
+    private let maxRestarts = 3
+    private let windowSeconds: TimeInterval = 5.0
+
+    /// Set during graceful shutdown to prevent the termination handler
+    /// from attempting a restart.
+    private(set) var isShuttingDown = false
+
+    /// Whether start() has been called at least once. Used to gate
+    /// onBEAMReady so it only fires on restarts, not the initial start.
+    private var hasStartedOnce = false
+
+    /// URLs for files passed via Finder "Open With" before the BEAM is ready.
+    /// Flushed to the BEAM once the protocol signals ready.
+    private(set) var pendingFileURLs: [URL] = []
+
+    /// Resolves the BEAM release executable inside the app bundle.
+    /// Returns nil if not running as a bundled app.
+    static func beamExecutableURL() -> URL? {
+        guard let resourceURL = Bundle.main.resourceURL else { return nil }
+        let releaseURL = resourceURL
+            .appendingPathComponent("release")
+            .appendingPathComponent("bin")
+            .appendingPathComponent("minga_macos")
+
+        guard FileManager.default.fileExists(atPath: releaseURL.path) else { return nil }
+        return releaseURL
+    }
+
+    /// Whether the app is running as a bundle with an embedded BEAM release.
+    static var isBundleMode: Bool {
+        beamExecutableURL() != nil
+    }
+
+    /// Spawns the BEAM release as a child process with piped stdin/stdout.
+    func start() {
+        guard let execURL = Self.beamExecutableURL() else {
+            NSLog("BEAMProcessManager: no embedded BEAM release found")
+            return
+        }
+
+        let proc = Process()
+        proc.executableURL = execURL
+        proc.arguments = ["start"]
+
+        // Set up pipes for the port protocol.
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        proc.standardInput = stdinPipe
+        proc.standardOutput = stdoutPipe
+
+        // Pass stderr through to the app's stderr for logging.
+        // The BEAM writes log messages to stderr; they'll appear in
+        // Console.app and Xcode's debug output.
+        proc.standardError = FileHandle.standardError
+
+        // Tell the BEAM to use connected mode (don't spawn a GUI).
+        var env = ProcessInfo.processInfo.environment
+        env["MINGA_PORT_MODE"] = "connected"
+
+        // Set RELEASE_NODE to prevent the BEAM from trying to connect
+        // to other BEAM nodes (which would fail in a sandboxed app).
+        env["RELEASE_DISTRIBUTION"] = "none"
+
+        proc.environment = env
+
+        proc.terminationHandler = { [weak self] process in
+            Task { @MainActor in
+                self?.handleTermination(
+                    status: process.terminationStatus,
+                    reason: process.terminationReason
+                )
+            }
+        }
+
+        do {
+            try proc.run()
+        } catch {
+            NSLog("BEAMProcessManager: failed to start BEAM: \(error)")
+            onCrash?()
+            return
+        }
+
+        self.process = proc
+        self.readHandle = stdoutPipe.fileHandleForReading
+        self.writeHandle = stdinPipe.fileHandleForWriting
+
+        NSLog("BEAMProcessManager: BEAM started (pid \(proc.processIdentifier))")
+
+        // Only fire onBEAMReady on restarts, not the initial start.
+        // The initial start is handled by AppDelegate.applicationDidFinishLaunching
+        // which reads readHandle/writeHandle directly.
+        if hasStartedOnce {
+            onBEAMReady?(stdoutPipe.fileHandleForReading, stdinPipe.fileHandleForWriting)
+        }
+        hasStartedOnce = true
+    }
+
+    /// Buffers a file URL for opening once the BEAM is ready.
+    func bufferFileURL(_ url: URL) {
+        pendingFileURLs.append(url)
+    }
+
+    /// Returns and clears the pending file URLs.
+    func flushPendingFileURLs() -> [URL] {
+        let urls = pendingFileURLs
+        pendingFileURLs = []
+        return urls
+    }
+
+    /// Sends SIGTERM to the BEAM and waits briefly for clean shutdown.
+    /// Used during Cmd+Q / applicationShouldTerminate.
+    func shutdownGracefully(timeout: TimeInterval = 3.0) {
+        guard let proc = process, proc.isRunning else { return }
+
+        isShuttingDown = true
+
+        // SIGTERM triggers orderly OTP shutdown in the BEAM.
+        proc.terminate()
+
+        // Wait on a background thread to avoid blocking the main thread.
+        DispatchQueue.global().async {
+            proc.waitUntilExit()
+        }
+
+        // Safety timeout: if the BEAM hasn't exited after `timeout` seconds,
+        // force kill it. Uses global queue so it fires even if main thread is blocked.
+        let pid = proc.processIdentifier
+        DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+            // Check if the process is still alive via kill(pid, 0).
+            if kill(pid, 0) == 0 {
+                NSLog("BEAMProcessManager: BEAM did not exit in \(timeout)s, sending SIGKILL")
+                kill(pid, SIGKILL)
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func handleTermination(status: Int32, reason: Process.TerminationReason) {
+        NSLog("BEAMProcessManager: BEAM exited (status \(status), reason \(reason.rawValue))")
+
+        self.process = nil
+        self.readHandle = nil
+        self.writeHandle = nil
+
+        // Graceful shutdown in progress (Cmd+Q): don't restart.
+        guard !isShuttingDown else {
+            onNormalExit?()
+            return
+        }
+
+        // Normal exit (user quit): don't restart.
+        guard status != 0 else {
+            onNormalExit?()
+            return
+        }
+
+        // Prune old timestamps outside the restart window.
+        let now = Date()
+        let cutoff = now.addingTimeInterval(-windowSeconds)
+        restartTimestamps.removeAll { $0 < cutoff }
+
+        if restartTimestamps.count >= maxRestarts {
+            NSLog("BEAMProcessManager: too many crashes (\(maxRestarts) in \(windowSeconds)s), giving up")
+            onCrash?()
+            return
+        }
+
+        restartTimestamps.append(now)
+
+        // Exponential backoff: 100ms, 200ms, 400ms
+        let delay = 0.1 * pow(2.0, Double(restartTimestamps.count - 1))
+        NSLog("BEAMProcessManager: restarting in \(delay)s")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.start()
+        }
+    }
+}

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -275,10 +275,16 @@ final class AppState: ObservableObject {
 }
 
 /// App delegate that sets up the protocol reader, renderer, and wiring.
+///
+/// Operates in two modes:
+/// - **Bundle mode**: Minga.app launched from Finder/Spotlight/Dock. The app
+///   spawns the BEAM release as a child process via BEAMProcessManager.
+/// - **Dev mode**: BEAM spawned us. We read/write our own stdin/stdout.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let appState = AppState()
 
+    private var beamManager: BEAMProcessManager?
     private var protocolReader: ProtocolReader?
     private var encoder: ProtocolEncoder?
     private var dispatcher: CommandDispatcher?
@@ -317,14 +323,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         ctRenderer.setupLineRenderer(fontManager: fm)
 
-        // Protocol encoder (writes to stdout).
-        let enc = ProtocolEncoder()
+        // Protocol encoder and reader: in bundle mode, we spawn the BEAM
+        // and use pipe file handles. In dev mode, we use stdin/stdout.
+        let protocolInput: FileHandle
+        let protocolOutput: FileHandle
+
+        if BEAMProcessManager.isBundleMode {
+            let manager = BEAMProcessManager()
+            self.beamManager = manager
+
+            manager.onCrash = {
+                // TODO: show error UI instead of terminating
+                NSLog("BEAM crashed too many times, terminating")
+                NSApp.terminate(nil)
+            }
+            manager.onNormalExit = {
+                NSApp.terminate(nil)
+            }
+            manager.onBEAMReady = { [weak self] newReadHandle, newWriteHandle in
+                self?.reconnectProtocol(readHandle: newReadHandle, writeHandle: newWriteHandle)
+            }
+
+            manager.start()
+
+            guard let readH = manager.readHandle, let writeH = manager.writeHandle else {
+                NSLog("Failed to start BEAM process")
+                NSApp.terminate(nil)
+                return
+            }
+            protocolInput = readH
+            protocolOutput = writeH
+        } else {
+            // Dev mode: BEAM is our parent, use stdin/stdout
+            protocolInput = .standardInput
+            protocolOutput = .standardOutput
+        }
+
+        let enc = ProtocolEncoder(output: protocolOutput)
         self.encoder = enc
         appState.encoder = enc
 
         // Enable port-based logging so messages appear in *Messages*.
         PortLogger.setup(encoder: enc)
-        PortLogger.info("macOS GUI frontend starting")
+        PortLogger.info("macOS GUI frontend starting (\(beamManager != nil ? "bundle" : "dev") mode)")
         PortLogger.info("Font: \(defaultFontName) \(Int(defaultFontSize))pt, cell: \(face.cellWidth)x\(face.cellHeight), scale: \(scale)x")
         PortLogger.info("Initial grid: \(cols)x\(rows) cells")
 
@@ -379,30 +420,129 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // once SwiftUI assigns the real frame dimensions. This avoids
         // the BEAM rendering at hardcoded 800x600 defaults.
 
-        // Start reading protocol commands from stdin.
+        // Start reading protocol commands.
         let reader = ProtocolReader(
+            input: protocolInput,
             handler: { [weak self] data in
                 DispatchQueue.main.async {
                     self?.handleProtocolData(data)
                 }
             },
-            onDisconnect: {
-                // BEAM has exited; shut down gracefully.
+            onDisconnect: { [weak self] in
                 DispatchQueue.main.async {
-                    NSApp.terminate(nil)
+                    // In bundle mode, BEAMProcessManager handles restart/error.
+                    // In dev mode, our parent (BEAM) exited; shut down.
+                    if self?.beamManager == nil {
+                        NSApp.terminate(nil)
+                    }
                 }
             }
         )
         reader.start()
         self.protocolReader = reader
+
+        // In bundle mode, file URLs buffered before the BEAM was ready are
+        // flushed when the dispatcher receives the first ready acknowledgement
+        // from the BEAM (via onFirstRender below).
+        if beamManager != nil {
+            disp.onFirstRender = { [weak self] in
+                guard let self, let manager = self.beamManager, let enc = self.encoder else { return }
+                let urls = manager.flushPendingFileURLs()
+                for url in urls {
+                    enc.sendOpenFile(path: url.path)
+                }
+            }
+        }
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         true
     }
 
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        // In dev mode (no beamManager), terminate immediately.
+        guard let manager = beamManager, !manager.isShuttingDown else {
+            return .terminateNow
+        }
+
+        // In bundle mode, wait for the BEAM to exit cleanly before
+        // allowing the app to terminate. This prevents orphaned BEAM
+        // processes running in the background after the Dock icon disappears.
+        manager.onNormalExit = {
+            NSApp.reply(toApplicationShouldTerminate: true)
+        }
+        manager.onCrash = {
+            NSApp.reply(toApplicationShouldTerminate: true)
+        }
+        manager.shutdownGracefully(timeout: 3.0)
+        return .terminateLater
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         protocolReader?.stop()
+    }
+
+    /// Handle files opened via Finder "Open With", file associations, or
+    /// `open -a Minga file.ex` from the terminal.
+    func application(_ application: NSApplication, open urls: [URL]) {
+        if let enc = encoder {
+            // BEAM is running, send open_file commands directly.
+            for url in urls where url.isFileURL {
+                enc.sendOpenFile(path: url.path)
+            }
+        } else if let manager = beamManager {
+            // BEAM not ready yet, buffer the URLs.
+            for url in urls where url.isFileURL {
+                manager.bufferFileURL(url)
+            }
+        }
+    }
+
+    // MARK: - Protocol reconnection (after BEAM restart)
+
+    /// Replaces the protocol reader and encoder with fresh ones backed by new pipe handles.
+    /// Called by BEAMProcessManager.onBEAMReady after a crash restart.
+    private func reconnectProtocol(readHandle: FileHandle, writeHandle: FileHandle) {
+        // Stop the old reader (its input pipe is already closed).
+        protocolReader?.stop()
+
+        // Create new encoder for the new pipe.
+        let enc = ProtocolEncoder(output: writeHandle)
+        self.encoder = enc
+        appState.encoder = enc
+        PortLogger.setup(encoder: enc)
+
+        // Create new reader for the new pipe.
+        let reader = ProtocolReader(
+            input: readHandle,
+            handler: { [weak self] data in
+                DispatchQueue.main.async {
+                    self?.handleProtocolData(data)
+                }
+            },
+            onDisconnect: { [weak self] in
+                DispatchQueue.main.async {
+                    if self?.beamManager == nil {
+                        NSApp.terminate(nil)
+                    }
+                }
+            }
+        )
+        reader.start()
+        self.protocolReader = reader
+
+        // Update the editor view's encoder reference so keystrokes
+        // go to the new BEAM process, not the dead pipe.
+        editorNSView?.encoder = enc
+
+        // Re-send ready event so the new BEAM knows our dimensions.
+        if let nsView = editorNSView {
+            let cols = UInt16(nsView.bounds.width / CGFloat(nsView.cellWidth))
+            let rows = UInt16(nsView.bounds.height / CGFloat(nsView.cellHeight))
+            enc.sendReady(cols: cols, rows: rows)
+        }
+
+        PortLogger.info("Protocol reconnected after BEAM restart")
     }
 
     // MARK: - Font change

--- a/macos/Sources/Protocol/ProtocolReader.swift
+++ b/macos/Sources/Protocol/ProtocolReader.swift
@@ -5,25 +5,43 @@
 /// (the BEAM batches an entire render frame into one message).
 
 import Foundation
+import Synchronization
 
-/// Reads framed protocol messages from stdin and dispatches them.
+/// Reads framed protocol messages from an input file handle and dispatches them.
+///
+/// Defaults to stdin (BEAM is parent, spawned us). In bundle mode, the
+/// BEAMProcessManager passes the child process's stdout pipe instead.
 final class ProtocolReader: @unchecked Sendable {
     private var thread: Thread?
+    private let input: FileHandle
     private let handler: @Sendable (Data) -> Void
     private let onDisconnect: @Sendable () -> Void
-    private var running = false
+    private let running = Mutex(false)
 
     /// Create a reader that calls `handler` with each payload on a background thread.
-    /// `onDisconnect` is called when stdin closes (BEAM exited).
-    init(handler: @escaping @Sendable (Data) -> Void, onDisconnect: @escaping @Sendable () -> Void) {
+    /// `onDisconnect` is called when the input closes (peer exited).
+    ///
+    /// - Parameters:
+    ///   - input: File handle to read from. Defaults to `.standardInput`.
+    ///   - handler: Called with each decoded payload.
+    ///   - onDisconnect: Called when the input stream closes.
+    init(input: FileHandle = .standardInput,
+         handler: @escaping @Sendable (Data) -> Void,
+         onDisconnect: @escaping @Sendable () -> Void) {
+        self.input = input
         self.handler = handler
         self.onDisconnect = onDisconnect
     }
 
-    /// Start reading stdin on a background thread.
+    /// Start reading on a background thread.
     func start() {
-        guard !running else { return }
-        running = true
+        let alreadyRunning = running.withLock { val -> Bool in
+            if val { return true }
+            val = true
+            return false
+        }
+        guard !alreadyRunning else { return }
+
         let t = Thread { [weak self] in
             self?.readLoop()
         }
@@ -36,17 +54,15 @@ final class ProtocolReader: @unchecked Sendable {
     /// Stop the reader. Note: the thread blocks on read(), so this
     /// only takes effect after the current read completes or stdin closes.
     func stop() {
-        running = false
+        running.withLock { $0 = false }
     }
 
     // MARK: - Private
 
     private func readLoop() {
-        let stdin = FileHandle.standardInput
-
-        while running {
+        while running.withLock({ $0 }) {
             // Read 4-byte length header.
-            let lenData = stdin.readData(ofLength: 4)
+            let lenData = input.readData(ofLength: 4)
             guard lenData.count == 4 else {
                 // stdin closed or short read: BEAM has exited.
                 onDisconnect()
@@ -65,7 +81,7 @@ final class ProtocolReader: @unchecked Sendable {
             var payload = Data()
             var remaining = length
             while remaining > 0 {
-                let chunk = stdin.readData(ofLength: remaining)
+                let chunk = input.readData(ofLength: remaining)
                 guard !chunk.isEmpty else {
                     onDisconnect()
                     return

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -48,6 +48,10 @@ final class CommandDispatcher {
     /// Parameter: mode name string (e.g., "NORMAL", "INSERT", "VISUAL").
     var onModeChanged: ((String) -> Void)?
 
+    /// Called once after the first `batch_end` is received from the BEAM.
+    /// Used in bundle mode to flush pending file URLs after the BEAM is ready.
+    var onFirstRender: (() -> Void)?
+
     /// Tracks the last mode to detect changes.
     private var lastMode: UInt8 = 0
 
@@ -94,6 +98,10 @@ final class CommandDispatcher {
             }
 
         case .batchEnd:
+            if let firstRender = onFirstRender {
+                firstRender()
+                onFirstRender = nil
+            }
             onFrameReady?()
 
         case .setTitle(let title):

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -13,7 +13,7 @@ import MetalKit
 /// The main editor view. Uses MTKView's built-in display link for
 /// vsync-driven rendering with automatic frame coalescing.
 final class EditorNSView: MTKView {
-    let encoder: InputEncoder
+    var encoder: InputEncoder
     private(set) var fontFace: FontFace
 
     /// Line-based styled run buffer for CoreText rendering.

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -2,7 +2,7 @@ name: Minga
 options:
   bundleIdPrefix: com.minga
   deploymentTarget:
-    macOS: "14.0"
+    macOS: "15.0"
   xcodeVersion: "16.0"
   generateEmptyDirectories: true
   createIntermediateGroups: true

--- a/test/minga/port/manager_test.exs
+++ b/test/minga/port/manager_test.exs
@@ -9,68 +9,58 @@ defmodule Minga.Port.ManagerTest do
   describe "start_link/1" do
     test "starts with a custom name" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
-      assert Process.alive?(pid)
-      GenServer.stop(pid)
+      pid = start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
+      _ = :sys.get_state(pid)
     end
 
     test "starts without crashing when renderer binary is missing" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
-      assert Process.alive?(pid)
+      start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
       refute Manager.ready?(name)
       assert Manager.terminal_size(name) == nil
-      GenServer.stop(pid)
     end
   end
 
   describe "subscribe/1" do
     test "subscribing process receives events" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      pid = start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
       :ok = Manager.subscribe(name)
 
-      # Simulate sending a ready event as if from the port
       ready_payload = <<0x03, 80::16, 24::16>>
       send(pid, {nil, {:data, ready_payload}})
+      _ = :sys.get_state(pid)
 
-      GenServer.stop(pid)
+      assert_receive {:minga_input, {:ready, 80, 24}}
     end
 
     test "multiple subscriptions from same process are deduplicated" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
       :ok = Manager.subscribe(name)
       :ok = Manager.subscribe(name)
 
-      # Should still work — no duplicate messages
-      assert Process.alive?(pid)
-      GenServer.stop(pid)
+      state = :sys.get_state(name)
+      assert length(state.subscribers) == 1
     end
   end
 
   describe "send_commands/2" do
     test "does not crash when port is not open" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
-
+      start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
       :ok = Manager.send_commands(name, [Protocol.encode_clear()])
-      assert Process.alive?(pid)
-      GenServer.stop(pid)
     end
 
     test "handles empty command list" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
-
+      start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
       :ok = Manager.send_commands(name, [])
-      assert Process.alive?(pid)
-      GenServer.stop(pid)
     end
 
     test "handles multiple commands" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
 
       commands = [
         Protocol.encode_clear(),
@@ -80,33 +70,29 @@ defmodule Minga.Port.ManagerTest do
       ]
 
       :ok = Manager.send_commands(name, commands)
-      assert Process.alive?(pid)
-      GenServer.stop(pid)
     end
   end
 
   describe "terminal_size/1" do
     test "returns nil before ready" do
       name = unique_name()
-      {:ok, _pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
       assert Manager.terminal_size(name) == nil
-      GenServer.stop(name)
     end
   end
 
   describe "ready?/1" do
     test "returns false before ready event" do
       name = unique_name()
-      {:ok, _pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
       refute Manager.ready?(name)
-      GenServer.stop(name)
     end
   end
 
   describe "event handling" do
     test "ready event sets ready state and terminal size" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      pid = start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
       :ok = Manager.subscribe(name)
 
       ready_payload = <<0x03, 120::16, 40::16>>
@@ -115,14 +101,12 @@ defmodule Minga.Port.ManagerTest do
 
       assert Manager.ready?(name)
       assert Manager.terminal_size(name) == {120, 40}
-
       assert_receive {:minga_input, {:ready, 120, 40}}
-      GenServer.stop(pid)
     end
 
     test "resize event updates terminal size" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      pid = start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
       :ok = Manager.subscribe(name)
 
       resize_payload = <<0x02, 100::16, 50::16>>
@@ -130,14 +114,12 @@ defmodule Minga.Port.ManagerTest do
       _ = :sys.get_state(pid)
 
       assert Manager.terminal_size(name) == {100, 50}
-
       assert_receive {:minga_input, {:resize, 100, 50}}
-      GenServer.stop(pid)
     end
 
     test "key_press event is broadcast to subscribers" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      pid = start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
       :ok = Manager.subscribe(name)
 
       key_payload = <<0x01, ?h::32, 0::8>>
@@ -145,37 +127,31 @@ defmodule Minga.Port.ManagerTest do
       _ = :sys.get_state(pid)
 
       assert_receive {:minga_input, {:key_press, ?h, 0}}
-      GenServer.stop(pid)
     end
 
     test "malformed event data logs warning but doesn't crash" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      pid = start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
 
       send(pid, {nil, {:data, <<0xFF, 0x01>>}})
       _ = :sys.get_state(pid)
-
-      assert Process.alive?(pid)
-      GenServer.stop(pid)
     end
 
     test "port exit status is handled" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      pid = start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
 
       send(pid, {nil, {:exit_status, 1}})
       _ = :sys.get_state(pid)
 
-      assert Process.alive?(pid)
       refute Manager.ready?(name)
-      GenServer.stop(pid)
     end
   end
 
   describe "subscriber cleanup" do
     test "removes subscriber when it exits" do
       name = unique_name()
-      {:ok, mgr} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      mgr = start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
 
       task =
         Task.async(fn ->
@@ -185,22 +161,176 @@ defmodule Minga.Port.ManagerTest do
 
       Task.await(task)
       _ = :sys.get_state(mgr)
-
-      assert Process.alive?(mgr)
-      GenServer.stop(mgr)
     end
   end
 
   describe "unknown messages" do
     test "unknown messages are ignored" do
       name = unique_name()
-      {:ok, pid} = Manager.start_link(name: name, renderer_path: "/nonexistent")
+      pid = start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
 
       send(pid, :totally_unknown)
       _ = :sys.get_state(pid)
+    end
+  end
 
-      assert Process.alive?(pid)
-      GenServer.stop(pid)
+  # Helper that creates a fake port for connected mode tests.
+  # Uses `cat` as a harmless process so Port.command doesn't crash.
+  defp fake_port_opener do
+    test_pid = self()
+
+    fn _spec, _opts ->
+      port = Port.open({:spawn, "cat"}, [:binary, {:packet, 4}])
+      send(test_pid, {:fake_port, port})
+      port
+    end
+  end
+
+  defp start_connected(name) do
+    opener = fake_port_opener()
+
+    pid =
+      start_supervised!(
+        {Manager,
+         name: name, renderer_path: "/nonexistent", port_mode: :connected, port_opener: opener},
+        id: name
+      )
+
+    assert_receive {:fake_port, fake_port}
+    {pid, fake_port}
+  end
+
+  describe "connected mode" do
+    test "starts successfully in connected mode" do
+      name = unique_name()
+      {_pid, _fake_port} = start_connected(name)
+
+      refute Manager.ready?(name)
+    end
+
+    test "connected mode opens port with {:fd, 0, 1} and :eof option" do
+      name = unique_name()
+      test_pid = self()
+
+      capturing_opener = fn spec, opts ->
+        send(test_pid, {:port_open_args, spec, opts})
+        Port.open({:spawn, "cat"}, [:binary, {:packet, 4}])
+      end
+
+      start_supervised!(
+        {Manager,
+         name: name,
+         renderer_path: "/nonexistent",
+         port_mode: :connected,
+         port_opener: capturing_opener},
+        id: name
+      )
+
+      assert_receive {:port_open_args, {:fd, 0, 1}, opts}
+      assert :binary in opts
+      assert {:packet, 4} in opts
+      assert :eof in opts
+    end
+
+    test "port_mode option is stored in state" do
+      name = unique_name()
+
+      # Explicitly passing :spawn should set port_mode regardless of any config
+      pid =
+        start_supervised!(
+          {Manager, name: name, renderer_path: "/nonexistent", port_mode: :spawn},
+          id: name
+        )
+
+      state = :sys.get_state(pid)
+      assert state.port_mode == :spawn
+    end
+
+    test "protocol events work identically in connected mode" do
+      name = unique_name()
+      {pid, fake_port} = start_connected(name)
+      :ok = Manager.subscribe(name)
+
+      # Ready event
+      ready_payload = <<0x03, 80::16, 24::16>>
+      send(pid, {fake_port, {:data, ready_payload}})
+      _ = :sys.get_state(pid)
+
+      assert Manager.ready?(name)
+      assert Manager.terminal_size(name) == {80, 24}
+      assert_receive {:minga_input, {:ready, 80, 24}}
+
+      # Key press event
+      key_payload = <<0x01, ?j::32, 0::8>>
+      send(pid, {fake_port, {:data, key_payload}})
+      _ = :sys.get_state(pid)
+
+      assert_receive {:minga_input, {:key_press, ?j, 0}}
+    end
+
+    test "EOF on connected port clears ready state" do
+      name = unique_name()
+      {pid, fake_port} = start_connected(name)
+      :ok = Manager.subscribe(name)
+
+      # Set ready state first
+      ready_payload = <<0x03, 80::16, 24::16>>
+      send(pid, {fake_port, {:data, ready_payload}})
+      _ = :sys.get_state(pid)
+      assert Manager.ready?(name)
+
+      # Simulate stdin EOF (GUI parent exited)
+      send(pid, {fake_port, :eof})
+      _ = :sys.get_state(pid)
+
+      refute Manager.ready?(name)
+    end
+
+    test "double EOF does not crash" do
+      name = unique_name()
+      {pid, fake_port} = start_connected(name)
+
+      send(pid, {fake_port, :eof})
+      _ = :sys.get_state(pid)
+
+      # Second EOF: port is nil, message won't match the port guard
+      send(pid, {fake_port, :eof})
+      # Process should still be alive (sync barrier confirms)
+      _ = :sys.get_state(pid)
+    end
+
+    test "send_commands works in connected mode" do
+      name = unique_name()
+      {_pid, _fake_port} = start_connected(name)
+
+      # Should not crash (port is open via fake_port_opener)
+      :ok = Manager.send_commands(name, [Protocol.encode_clear()])
+    end
+
+    test "send_commands after EOF silently drops commands" do
+      name = unique_name()
+      {pid, fake_port} = start_connected(name)
+
+      send(pid, {fake_port, :eof})
+      _ = :sys.get_state(pid)
+
+      # Port is nil now, commands should be silently dropped
+      :ok = Manager.send_commands(name, [Protocol.encode_clear()])
+    end
+
+    test "port_mode defaults to :spawn when no option is passed" do
+      name = unique_name()
+
+      # Without passing port_mode, and with no app config set (test env default),
+      # it should default to :spawn
+      pid =
+        start_supervised!(
+          {Manager, name: name, renderer_path: "/nonexistent"},
+          id: name
+        )
+
+      state = :sys.get_state(pid)
+      assert state.port_mode == :spawn
     end
   end
 end


### PR DESCRIPTION
## What

Reverses the parent/child relationship in bundle mode. When a user launches `Minga.app` from Finder, Spotlight, or the Dock, the Swift GUI spawns the embedded BEAM release as a child process. In dev mode, the existing BEAM-spawns-GUI flow is unchanged.

## Changes

### BEAM side
- **Port.Manager** supports `:connected` mode (`MINGA_PORT_MODE=connected` env var) which opens `Port({:fd, 0, 1})` instead of spawning a GUI child. Added `:eof` handler for stdin EOF detection. Injectable `port_opener` for testing.
- **config/runtime.exs** (new) reads the env var and sets `:minga, :port_mode`

### Swift side
- **BEAMProcessManager** (new): spawns BEAM child with piped stdin/stdout, crash recovery with exponential backoff (max 3 in 5s), graceful shutdown via SIGTERM with force-kill timeout, file URL buffering for launch-time "Open With" arguments
- **ProtocolReader**: injectable `FileHandle` input, thread-safe `Mutex<Bool>` for running flag
- **AppDelegate**: branches bundle vs dev mode, `reconnectProtocol` for crash restart (swaps encoder + reader + re-sends ready), `application(_:open:)` for Finder file handling, `.terminateLater` shutdown prevents orphaned BEAM processes
- **CommandDispatcher**: `onFirstRender` callback defers file URL flush until BEAM is ready
- **EditorNSView**: `encoder` changed `let` to `var` for reconnect

### Also
- Bumps deployment target to macOS 15.0 (Sequoia) for `Synchronization.Mutex`
- All existing Port.Manager tests migrated to `start_supervised!` and removed `Process.alive?` assertions

## Testing

25 Port.Manager tests (9 new connected-mode tests). Swift build + test pass. Reviewed by archie, swift-expert, and test-advisor.

Closes #952. Part of #554.
