### PR TITLE
docs: rewrite documentation site in project voice and reorganize sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,32 +10,70 @@
 
 <!-- TODO: add a screenshot or terminal recording here -->
 
-Minga is a modal text editor powered by **Elixir on the BEAM VM**. Every buffer, every agent session, every background task runs in its own isolated process. Nothing shares memory. Nothing blocks your keystrokes. If a component crashes, the rest keep running.
+Minga is a modal text editor powered by Elixir on the BEAM VM. It runs natively in the terminal (TUI) and as a macOS desktop app (GUI). Same editor core, same config, same extensions.
 
-You get the editing model you already know (Vim motions, operators, text objects), the runtime depth you wish you had (redefine any command at runtime, hook into any lifecycle event, extend with real code), and an architecture that was designed from day one for the world where AI agents are editing files alongside you.
-
-Runs natively in the terminal (TUI) and as a macOS desktop app (GUI). Same editor core, same config, same extensions. Pick whichever fits your workflow.
-
-## Why another editor?
-
-AI coding agents need to read files, write files, run commands, and do it all concurrently with your own edits. Every mainstream editor handles this the same way: one event loop, shared state, hope for the best.
-
-The BEAM VM was built 30 years ago to solve exactly this class of problem. Millions of lightweight processes, preemptive scheduling, no shared memory, crash isolation. It powers telecom switches and messaging systems where "one component failing takes down everything" is not acceptable.
-
-Minga points that runtime at a text editor. The editor core runs on the BEAM. Rendering is delegated to native frontends (a terminal UI and a macOS app) that communicate over a clean binary protocol. Two processes, no shared memory, each doing what it's best at.
-
-## What you get
-
-- **Vim-style modal editing**: Normal, Insert, Visual, Operator-Pending, Replace, and Search modes. The motions and operators you think in (`d`, `c`, `y`, `w`, `b`, `e`, `iw`, `i"`, `a{`, and many more).
-- **Space-leader commands**: `SPC f f` to find files, `SPC b b` to switch buffers, `SPC s p` to search your project. A Which-Key popup shows what's available as you type.
-- **Tree-sitter highlighting**: 24 languages compiled in. Instant on file open.
-- **Built-in AI agent**: native LLM integration with streaming, tool use, inline diff review, and conversation management. Supports Anthropic, OpenAI, and Google models.
-- **Extensible in Elixir**: define commands, add keybindings, hook into save/open/mode-change events, advise any command with before/after/around wrappers. All from your config file, no restart needed.
-- **Process isolation**: every buffer is its own process. Agents, renderers, parsers, file watchers all run independently. Your typing is always responsive.
+You get the editing model you already know (Vim motions, operators, text objects), the runtime depth you wish you had (redefine any command at runtime, hook into any lifecycle event, extend with real code), and an architecture that was designed from day one for a world where AI agents edit files alongside you.
 
 ### Current status
 
-Minga is pre-release. Check the [issue tracker](https://github.com/jsmestad/minga/issues) for planned work. If you want to help shape what a BEAM-powered editor can be, now is a great time.
+Minga is pre-release. If you want to help shape what a BEAM-powered editor can be, now is a great time. Check the [issue tracker](https://github.com/jsmestad/minga/issues) for planned work.
+
+## What it feels like to use
+
+Press `Space` in normal mode. A popup appears showing every command, organized by mnemonic prefix. You don't memorize anything. You read the menu, press the next key, and the popup narrows down. `SPC f f` finds files. `SPC b b` switches buffers. `SPC s p` searches your project.
+
+After a few sessions, these become muscle memory. The popup is always there when you forget.
+
+The AI agent is built in. Toggle the side panel with `SPC a a`, or open a full-screen agent view with `SPC a t`. The agent reads, edits, and creates files in your project. You review every change as an inline diff before it hits disk. Navigate hunks with `]c`/`[c`, accept with `y`, reject with `x`.
+
+Your config is real Elixir, the same language the editor is written in:
+
+```elixir
+use Minga.Config
+
+set :theme, :catppuccin_mocha
+set :line_numbers, :relative
+set :tab_width, 2
+
+# Hooks run in their own processes. This never blocks your typing.
+on :after_save, fn _buf, path ->
+  if String.ends_with?(path, ".ex") do
+    System.cmd("mix", ["format", path])
+  end
+end
+```
+
+That's not a limited DSL. It's the full language. Define commands, add keybindings, hook into save/open/mode-change events, wrap any command with before/after/around advice. No restart needed; press `SPC h r` to hot-reload your config.
+
+## Why the BEAM matters
+
+Every editor you use today was built on the same assumption: one human, typing sequentially, in one buffer at a time. The entire architecture (single event loop, shared memory, global state) follows from that.
+
+Then AI agents showed up. Now you have external processes making API calls, reading your files, writing to your buffers, spawning shell commands, and running for minutes at a time.
+
+You've already seen what happens. An agent streaming a large response causes UI jank because it's competing with your keystrokes for the same thread. You can't tell if the agent is thinking, stuck, or writing to the wrong file. A slow API call hangs the extension, and everything else waits.
+
+Those aren't bugs in the AI tools. They're architectural limits of editors that were designed before AI coding existed.
+
+The BEAM VM was built 30 years ago to solve exactly this class of problem. It powers telecom switches and messaging systems where "one component failing takes down everything" is not acceptable. Minga points that same runtime at a text editor.
+
+**Your typing never freezes.** The BEAM runs a preemptive scheduler that guarantees every process gets fair CPU time. An agent streaming a 2,000-line response? An LSP server parsing a huge codebase? Your keystrokes don't queue up. This isn't async with callbacks. The VM enforces fairness at the scheduler level.
+
+**Components can't corrupt each other.** Every buffer is its own process with its own memory. An agent editing line 200 while you type on line 50 isn't a race condition. Both edits arrive as messages to the buffer's process and are handled sequentially, atomically. No locks, no mutexes.
+
+**Crashes don't take down the editor.** BEAM processes are organized into supervision trees. If a plugin fails, its supervisor restarts it. Your buffers, undo history, and unsaved changes are in completely separate processes. They can't be affected because they don't share memory.
+
+For the full technical story (supervision tree, port protocol, display list IR, rendering pipeline), read the [Architecture doc](https://jsmestad.github.io/minga/architecture.html).
+
+## What ships today
+
+- **Vim-style modal editing.** Normal, Insert, Visual, Operator-Pending, Replace, and Search modes. Motions, operators, text objects (`iw`, `i"`, `a{`), registers, macros, marks, dot repeat.
+- **Space-leader commands.** Doom-style `SPC` menus with Which-Key popup. Discoverable from day one.
+- **Tree-sitter highlighting.** 39 languages compiled in. Instant on file open.
+- **Built-in AI agent.** Native LLM integration with streaming, tool use, inline diff review, and conversation management. Supports Anthropic, OpenAI, and Google models.
+- **Extensible in Elixir.** Commands, keybindings, hooks, advice system, extensions, hot reload. The config is the same language as the editor.
+- **Native frontends.** Terminal (Zig + libvaxis) and macOS (Swift + Metal). Same core, same config.
+- **Project management.** Auto-detected root, file finder, project search, recent files per project.
 
 ## Quick start
 
@@ -48,31 +86,29 @@ bin/minga
 
 Press `Space` to see what's possible. Read the [Getting Started guide](https://jsmestad.github.io/minga/getting-started.html) for the full walkthrough.
 
-## Documentation
+## Where to go from here
 
-The [doc site](https://jsmestad.github.io/minga/) is organized by what you're looking for:
+The rest of the docs are organized by what you're trying to do.
 
-| You want to... | Read |
-|----------------|------|
-| Install and start using Minga | [Getting Started](https://jsmestad.github.io/minga/getting-started.html) |
-| Configure themes, keys, options | [Configuration](https://jsmestad.github.io/minga/configuration.html) |
-| Understand the architecture | [Architecture](https://jsmestad.github.io/minga/architecture.html) |
-| Write extensions | [Extensibility](https://jsmestad.github.io/minga/extensibility.html) |
-| Migrate from Neovim | [For Neovim Users](https://jsmestad.github.io/minga/for-neovim-users.html) |
-| Migrate from Emacs | [For Emacs Users](https://jsmestad.github.io/minga/for-emacs-users.html) |
-| Use AI agents effectively | [For AI-Assisted Developers](https://jsmestad.github.io/minga/for-ai-coders.html) |
-| Contribute code | [Contributing](https://jsmestad.github.io/minga/contributing.html) |
+**Just want to use Minga?** Start with the [Getting Started guide](https://jsmestad.github.io/minga/getting-started.html). Five minutes from install to editing. Then read [Configuration](https://jsmestad.github.io/minga/configuration.html) for themes, keybindings, formatters, and per-filetype settings.
 
-## Coming from another editor?
+**Coming from another editor?** Pick your guide:
 
-- **[For Neovim users](https://jsmestad.github.io/minga/for-neovim-users.html):** Same modal editing, better runtime.
+- **[For Neovim users](https://jsmestad.github.io/minga/for-neovim-users.html):** Same modal editing, better runtime. Your muscle memory transfers directly.
 - **[For Emacs users](https://jsmestad.github.io/minga/for-emacs-users.html):** Same depth of customization, none of the single-threaded pain.
 - **[For pi users](https://jsmestad.github.io/minga/for-pi-users.html):** Minga embeds pi as a supervised Port. Everything you like about pi, plus an editor built for it.
-- **[For AI-assisted developers](https://jsmestad.github.io/minga/for-ai-coders.html):** Your editor wasn't designed for concurrent autonomous agents. Minga was.
+
+**Using AI coding tools?** Read [For AI-Assisted Developers](https://jsmestad.github.io/minga/for-ai-coders.html). It covers the architectural limitations of current editors when agents are involved and how the BEAM solves them. An honest technical comparison, not a sales pitch.
+
+**Want to extend the editor?** [Configuration](https://jsmestad.github.io/minga/configuration.html) covers commands, hooks, advice, and extensions. For the deeper "why Elixir is a real extension language" argument, read [Elixir is Minga's Elisp](https://jsmestad.github.io/minga/extensibility.html).
+
+**Want to understand the internals?** [Architecture](https://jsmestad.github.io/minga/architecture.html) covers the two-process design, supervision tree, and rendering pipeline. [Keymap Scopes](https://jsmestad.github.io/minga/keymap-scopes.html) explains how different views get different keybindings.
+
+**Want to contribute?** [Contributing](https://jsmestad.github.io/minga/contributing.html) has the build-from-source setup, testing, and how to add new commands, motions, and render features.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the build-from-source setup, testing, and how to add new commands, motions, and render features.
+Bug reports, feature ideas, and code are all welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the details.
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,12 +1,12 @@
 # Minga Architecture
 
-How a text editor built on process isolation and preemptive concurrency actually works, and why it's a surprisingly good idea.
+How a text editor built on process isolation and preemptive concurrency actually works.
 
 ---
 
 ## The Big Idea
 
-Most text editors are single-threaded programs with shared state. Buffers, rendering, input handling, plugin execution, AI agents: all living in one address space, contending for one event loop. When a background task does heavy work, your keystrokes queue up. When two things modify the same buffer, you get race conditions. When you want to know what a plugin is doing, you add `print` statements and restart.
+Most editors are single-threaded with shared state. Everything (buffers, rendering, input, plugins, AI agents) lives in one address space, contending for one event loop. When a background task does heavy work, your keystrokes queue up. When two things modify the same buffer, you get race conditions.
 
 Minga splits the editor into **separate OS processes** with completely isolated memory: a BEAM process for all editor logic, and one or more frontend processes for rendering and input.
 
@@ -442,19 +442,19 @@ Editor.handle_info decodes via Port.Protocol
     ▼
 Input.Router.dispatch_mouse walks overlay handlers, then surface handlers
     │
-    ├─ Overlays (Picker, Completion) — intercept when their UI is visible
+    ├─ Overlays (Picker, Completion) - intercept when their UI is visible
     │
-    ├─ Input.FileTreeHandler — hit-tests against Layout.file_tree rect
+    ├─ Input.FileTreeHandler - hit-tests against Layout.file_tree rect
     │     ├─ Inside file tree → handle tree click/scroll
     │     └─ Outside → :passthrough
     │
-    ├─ Input.AgentMouse — hit-tests against agent regions (position-based)
+    ├─ Input.AgentMouse - hit-tests against agent regions (position-based)
     │     ├─ Agent chat window (WindowTree + Content.agent_chat?) → scroll chat, click-to-focus
     │     ├─ Agent side panel (Layout.agent_panel rect) → scroll chat, click-to-focus
     │     ├─ File viewer sidebar (right of chat_width_pct) → scroll preview
     │     └─ Outside agent regions → :passthrough
     │
-    └─ Input.ModeFSM (fallback) — buffer-content mouse handling
+    └─ Input.ModeFSM (fallback) - buffer-content mouse handling
           └─ Editor.Mouse.handle/7
                 ├─ click_count=1 → position cursor, start drag
                 ├─ click_count=2 → select word (visual char), word-snapped drag
@@ -670,14 +670,14 @@ The dispatch helper lives in the parent module (not a shared utility), since eac
 
 These guide what we build and how:
 
-- **GUI-first, TUI-capable** — Design for native GUI frontends (Swift/Metal, GTK4) first. The TUI is a capable fallback, like Emacs's terminal mode, not the primary target.
-- **Fault tolerance over speed** — The BEAM's supervision model means crashes are recoverable events, not catastrophes.
-- **Process isolation** — Editor state and rendering never share memory; either can fail independently. Multiple frontends can exist because the protocol enforces this boundary.
-- **Vim grammar, modern UX** — Modal editing with discoverable leader-key menus.
-- **Elixir for logic, platform-native rendering** — The BEAM handles everything a text editor needs to think about. Swift, GTK4, and Zig handle everything a display needs to draw.
-- **Test everything** — Property-based tests for data structures, snapshot tests for UI, integration tests for the full pipeline.
-- **Convention over configuration** — Minga ships working defaults for everything: theme, keybindings, tab width, formatters, LSP servers. A fresh install with no config file should feel like Doom Emacs on day one. Your `config.exs` is a diff, not a manifest; it contains only what you've changed. Defaults are inspectable (`:set` shows current values, `SPC h k` shows bindings and whether they're defaults or overrides) and never hidden so deep that users can't find them.
-- **Core vs. extension** — If a Doom Emacs user installs Minga with zero configuration, would they expect this feature to work? If yes, it ships built-in. If it's a power-user addition, a niche workflow, or a matter of taste, it's an extension. Built-in features that touch only public APIs should be architected as if they were extensions (clean boundary, no internal coupling) so extraction is possible later. See `docs/AUTHORING_EXTENSIONS.md` for the full philosophy.
+- **GUI-first, TUI-capable.** Design for native GUI frontends (Swift/Metal, GTK4) first. The TUI is a capable fallback, like Emacs's terminal mode, not the primary target.
+- **Fault tolerance over speed.** The BEAM's supervision model means crashes are recoverable events, not catastrophes.
+- **Process isolation.** Editor state and rendering never share memory; either can fail independently. Multiple frontends can exist because the protocol enforces this boundary.
+- **Vim grammar, modern UX.** Modal editing with discoverable leader-key menus.
+- **Elixir for logic, platform-native rendering.** The BEAM handles everything a text editor needs to think about. Swift, GTK4, and Zig handle everything a display needs to draw.
+- **Test everything.** Property-based tests for data structures, snapshot tests for UI, integration tests for the full pipeline.
+- **Convention over configuration.** Minga ships working defaults for everything: theme, keybindings, tab width, formatters, LSP servers. A fresh install with no config file should feel like Doom Emacs on day one. Your `config.exs` is a diff, not a manifest; it contains only what you've changed. Defaults are inspectable (`:set` shows current values, `SPC h k` shows bindings and whether they're defaults or overrides) and never hidden so deep that users can't find them.
+- **Core vs. extension.** If a Doom Emacs user installs Minga with zero configuration, would they expect this feature to work? If yes, it ships built-in. If it's a power-user addition, a niche workflow, or a matter of taste, it's an extension. Built-in features that touch only public APIs should be architected as if they were extensions (clean boundary, no internal coupling) so extraction is possible later. See `docs/AUTHORING_EXTENSIONS.md` for the full philosophy.
 
 ---
 

--- a/docs/EXTENSIBILITY.md
+++ b/docs/EXTENSIBILITY.md
@@ -1,8 +1,6 @@
 # Elixir is Minga's Elisp
 
-> **Looking for the full Emacs-to-Minga pitch?** See [For Emacs Users](FOR-EMACS-USERS.md). This document is the technical deep-dive proving Elixir matches Elisp's extensibility, and where it's stronger.
-
-A detailed comparison of Elisp and Elixir as editor extension languages: proof that Elixir on the BEAM matches every property that makes Emacs programmable, and where it's stronger.
+> **Coming from Emacs?** See [For Emacs Users](FOR-EMACS-USERS.md) for the pitch. This page is the technical deep-dive proving Elixir matches every property that makes Elisp powerful, and where it's stronger.
 
 ---
 

--- a/docs/FOR-AI-CODERS.md
+++ b/docs/FOR-AI-CODERS.md
@@ -1,28 +1,26 @@
 # Minga for AI-Assisted Developers
 
-You use Claude Code, Cursor, Copilot, pi, Aider, or similar tools. Maybe you write every line yourself with AI suggestions. Maybe you describe what you want and review what the agent produces. Either way, AI is part of your workflow, and your editor wasn't designed for it.
+You use Claude Code, Cursor, Copilot, pi, Aider, or similar tools. AI is part of your workflow, and your editor wasn't designed for it.
 
-**Minga was.**
+Minga was.
 
 ---
 
-## The problem nobody's talking about
+## The problem with current editors
 
-Every editor you use today was built on the same assumption: **one human, typing sequentially, in one buffer at a time.** The entire architecture (single event loop, shared memory, global state) assumes a single operator.
+Every editor you use today was built on the same assumption: one human, typing sequentially, in one buffer at a time. The entire architecture (single event loop, shared memory, global state) assumes a single operator.
 
-Then AI agents showed up.
+Then AI agents showed up. Now you have external processes making API calls, reading your files, writing to your buffers, spawning shell commands, and running for minutes at a time. Your editor handles this by running everything on one event loop and hoping nothing contends too badly.
 
-Now you have external processes making API calls, reading your files, writing to your buffers, spawning shell commands, and running for minutes at a time. Your editor handles this by running everything on one event loop and hoping nothing contends too badly.
+You've already seen what happens:
 
-You've already seen what happens when it does:
+- An agent streaming a large response causes UI jank because it's competing with your keystrokes for the same thread
+- An agent writes to a file you're editing and your undo history gets confused
+- You have no visibility into what an agent is doing. Is it thinking? Stuck? Writing to the wrong file?
+- A long-running agent operation blocks your ability to switch buffers or save files
+- An API timeout hangs the extension and you have to force-quit
 
-- An agent streaming a large response **causes UI jank** because it's competing with your keystrokes for the same thread
-- An agent writes to a file you're editing and **your undo history gets confused** because there's no serialization between concurrent modifications
-- You have **no visibility** into what an agent is doing. Is it thinking? Stuck? Writing to the wrong file? You can't tell without checking the terminal
-- A long-running agent operation **blocks your ability to switch buffers** or save files because the event loop is busy
-- An API timeout **hangs the extension** and you have to force-quit or wait it out
-
-These aren't bugs in the AI tools. They're architectural limitations of editors that were designed decades before AI coding existed.
+These aren't bugs in the AI tools. They're architectural limitations of editors designed decades before AI coding existed.
 
 ---
 
@@ -36,22 +34,22 @@ Every component in Minga runs in its own isolated process. The BEAM's preemptive
 
 An agent streaming a 2,000-line response? You're still editing. An LSP server parsing a huge codebase? Your keystrokes don't queue up. Three agents working on three different files? The scheduler handles it.
 
-This isn't async-with-callbacks like JavaScript or Neovim's event loop. It's true preemptive concurrency. The VM enforces fairness at the scheduler level. No single process can starve another. Your typing is responsive not because of careful engineering, but because the runtime makes it structurally impossible for anything to block your input handling.
+This isn't async-with-callbacks like JavaScript or Neovim's event loop. The VM enforces fairness at the scheduler level. No single process can starve another.
 
 ### No buffer corruption from concurrent edits
 
-You're editing line 50. An agent writes to line 200 of the same file. In most editors, this is a race condition waiting to happen. Undo history gets confused, cursor positions shift unexpectedly, or worse.
+You're editing line 50. An agent writes to line 200 of the same file. In most editors, this is a race condition. Undo history gets confused, cursor positions shift, or worse.
 
-In Minga, every buffer is a GenServer, a process that handles one message at a time. Your keystroke and the agent's edit both arrive as messages. The buffer processes them sequentially, atomically, in order. There is no race condition. The buffer's mailbox serializes all access naturally:
+In Minga, every buffer is a GenServer (a process that handles one message at a time). Your keystroke and the agent's edit both arrive as messages. The buffer processes them sequentially, atomically, in order:
 
 ```
 Your keystroke:     {:insert, "x", {50, 10}}     → processed first
 Agent edit:         {:insert, code, {200, 0}}     → processed second
 ```
 
-No locks. No mutexes. No "file changed on disk" dialogs. Just ordered message passing.
+No locks. No mutexes. No "file changed on disk" dialogs.
 
-> **Where we are today:** Agent tools currently write to the filesystem (`File.read/write`), bypassing the buffer. The architecture above is what the BEAM enables, and we're actively wiring agent tools to route through `Buffer.Server` so edits go through the same mailbox as your keystrokes, with full undo integration. See [Buffer-Aware Agents](BUFFER-AWARE-AGENTS.md) for the design and phased plan.
+> **Where we are today:** Agent tools currently write to the filesystem (`File.read/write`), bypassing the buffer. We're actively wiring agent tools to route through `Buffer.Server` so edits go through the same mailbox as your keystrokes, with full undo integration. See [Buffer-Aware Agents](BUFFER-AWARE-AGENTS.md) for the design.
 
 ### You can see what agents are doing
 
@@ -65,39 +63,24 @@ Agent.Session.list()
 # Watch messages flowing to a buffer in real-time
 :dbg.tracer()
 :dbg.p(buffer_pid, [:receive])
-# {:insert, "defmodule MyApp do\n", {1, 0}}
-# {:insert, "  use Phoenix.Router\n", {2, 0}}
 
 # Full system dashboard: every process, memory, CPU
 :observer.start()
 ```
 
-When an agent is doing something unexpected, you don't have to guess. You inspect the running system. This is how Erlang engineers debug telecom switches that can't be stopped. The same tools work for debugging agent behavior in your editor.
+When an agent is doing something unexpected, you don't guess. You inspect the running system. This is how Erlang engineers debug telecom switches that can't be stopped.
 
 ### Agents are isolated from everything
 
-Each agent session runs in its own supervised process tree. An agent can't corrupt buffer state because it doesn't have direct access to buffer memory. It communicates through the same message-passing interface the editor itself uses.
+Each agent session runs in its own supervised process tree. An agent can't corrupt buffer state because it communicates through message passing, the same interface the editor itself uses.
 
-```
-Minga.Supervisor
-├── Buffer "main.ex"           ← isolated process, private state
-├── Buffer "router.ex"         ← isolated process, private state
-├── Agent.Session (Claude)     ← isolated process tree
-│   ├── API client             ← API timeout? just this process is affected
-│   ├── File watcher
-│   └── Tool executor          ← shell command hangs? just this process
-└── Editor                     ← keeps running, always
-```
-
-If an agent hits an error, its supervisor handles recovery. Your buffers, undo history, cursor positions, and unsaved changes are in completely separate processes with completely separate memory. They aren't affected because they *can't* be affected. The VM enforces the boundary.
+If an agent hits an error, its supervisor handles recovery. Your buffers, undo history, and unsaved changes are in completely separate processes with completely separate memory.
 
 ### Multiple agents, no conflicts
 
-Want a code review agent examining one buffer while a refactoring agent works on another? Want a test-writing agent running alongside your manual editing?
+Want a code review agent on one buffer while a refactoring agent works on another? Those are just processes. The BEAM was built to run millions of them. Each agent has its own memory and communicates with buffers through message passing.
 
-These are just processes. The BEAM was built to run millions of them. Each agent has its own memory, its own state, and communicates with buffers through message passing. There's no thread pool to configure, no async runtime to tune, no concern about one agent blocking another.
-
-> **Where we are today:** Multiple agent sessions work, and process isolation prevents them from interfering with each other at the BEAM level. But because agent tools write directly to the filesystem, two agents editing the same file can clobber each other on disk. The planned fix is [buffer forking](BUFFER-AWARE-AGENTS.md#phase-2-buffer-forking-with-three-way-merge): each agent gets its own in-memory copy of the document, and changes merge back via three-way merge when the agent finishes.
+> **Where we are today:** Multiple agent sessions work, and process isolation prevents them from interfering at the BEAM level. But because agent tools write directly to the filesystem, two agents editing the same file can clobber each other on disk. The planned fix is [buffer forking](BUFFER-AWARE-AGENTS.md#phase-2-buffer-forking-with-three-way-merge): each agent gets its own in-memory copy of the document, and changes merge back via three-way merge.
 
 ---
 
@@ -105,58 +88,45 @@ These are just processes. The BEAM was built to run millions of them. Each agent
 
 ### vs. Cursor / Windsurf
 
-Cursor is VS Code with AI bolted on. The agent runs as an extension in Electron's single-threaded JavaScript runtime. When the agent is working hard, you feel it: UI lag, slow tab switching, occasional stutters.
+Cursor is VS Code with AI bolted on. The agent runs as an extension in Electron's single-threaded JavaScript runtime. When the agent is working hard, you feel it.
 
-Cursor's "background agent" runs in a separate process, which helps, but the results still flow back into the single-threaded VS Code extension host. Buffer modifications, diagnostics, and UI updates all contend on one thread.
+Cursor's "background agent" runs in a separate process, which helps, but the results still flow back into the single-threaded extension host. Buffer modifications, diagnostics, and UI updates all contend on one thread.
 
-**Minga:** Agents, buffers, and the editor run as separate BEAM processes with preemptive scheduling. There's no single thread to contend on. The scheduler guarantees fair CPU time for every process.
+**Minga:** Agents, buffers, and the editor run as separate BEAM processes with preemptive scheduling. There's no single thread to contend on.
 
 ### vs. Claude Code / pi / Aider (terminal agents)
 
-These tools run outside your editor entirely. They read and write files on disk, and your editor picks up the changes via file watching. This works, but:
+These tools run outside your editor entirely. They read and write files on disk, and your editor picks up the changes via file watching. This works, but you see changes after the fact, there's no undo integration, and you can't edit the same file while the agent writes to it.
 
-- You see the changes after the fact, not as they happen
-- No integration with your undo history; agent changes are just disk writes
-- You can't edit the same file while the agent is writing to it
-- No way to see the agent's progress from inside your editor
+Here's the thing nobody says out loud: you still open an editor. You run Claude Code in one terminal, then flip to Neovim or VS Code to audit what it did. The agent is your writer; the editor is your reviewer. You're always running two tools because neither one is complete on its own.
 
-And here's the thing nobody says out loud: **you still open an editor.** You run Claude Code in one terminal, then flip to Neovim or VS Code to audit what it did. You follow along, spot-check diffs, review file by file. The agent is your writer; the editor is your reviewer. You're always running two tools because neither one is complete on its own.
+**Minga today:** The built-in agent collapses this into one tool. You chat, watch the agent work, and review inline diffs without switching windows.
 
-The terminal agent can't show you the codebase the way an editor can. The editor can't see or control the agent. So you play air traffic controller between them, context-switching constantly, losing flow state every time you alt-tab.
-
-**Minga today:** Minga's built-in agent already collapses the two-tool workflow. You chat with the agent, watch it work, and review inline diffs without switching windows. Agent edits appear in the diff review UI as they happen.
-
-**Minga next:** Agent tools are being [rewired to route through `Buffer.Server`](BUFFER-AWARE-AGENTS.md) instead of the filesystem. When that lands, agent edits will flow through the same undo system as your typing, appear instantly in the editor (no file watcher delay), and trigger incremental tree-sitter updates. You'll be able to edit one part of a file while an agent edits another, with the GenServer mailbox serializing both safely.
+**Minga next:** Agent tools are being [rewired to route through `Buffer.Server`](BUFFER-AWARE-AGENTS.md) instead of the filesystem. Agent edits will flow through the same undo system as your typing, appear instantly, and trigger incremental tree-sitter updates.
 
 ### vs. Copilot / inline completions
 
-Inline completion (ghost text) is the simplest AI integration, and most editors handle it fine. Minga will support this too. It's not the interesting problem.
+Inline completion (ghost text) is the simplest AI integration, and most editors handle it fine. Minga will support this too.
 
-The interesting problem is **agentic editing**: AI that doesn't just suggest one line, but reads your codebase, plans changes across multiple files, executes shell commands, and modifies buffers autonomously. That's where single-threaded editors hit their limits, and where Minga's architecture matters.
-
----
-
-## The IDE isn't dead. It's just wrong.
-
-There's a popular narrative that AI agents will replace the IDE. You'll just talk to a terminal, describe what you want, and the agent will write everything. The editor becomes a vestige.
-
-That hasn't happened. It won't happen, either.
-
-Even the best AI coding agents hit a wall when they touch too many files too quickly. They make mistakes. They misunderstand context. They hallucinate function signatures. And when they do, you need to *see* the code, navigate it, understand what changed, and fix what's wrong. That's what an editor is for.
-
-The proof is in your own workflow. Nobody runs Claude Code or Cursor's agent and then blindly commits the result. You review. You audit. You open files, check diffs, trace through logic, run tests. The editor is still essential; it's just been demoted to a review tool that has no idea an agent exists.
-
-Some people push back here: "I just review the PR diff" or "I fix things by telling the agent what to change." Sure, and sometimes that works. But a PR diff shows you what changed, not *why it's wrong*. You can't jump to a definition from a diff view. You can't trace a call chain across three files. You can't set a breakpoint or run a single test from GitHub's review UI. And telling an agent "fix line 47" only works when you already understand the problem well enough to describe it. For the cases where you don't (where you need to read surrounding code, check types, follow imports, understand state flow) you open an editor. Every time.
-
-The chat prompt has the same limitation. It's great for describing intent, terrible for spatial reasoning about code. "Move the validation before the database call" is easy to say, hard to verify without seeing both locations in context. You end up pasting code into the chat so the agent can see what you're already looking at in your editor. That's two tools doing one job, badly.
-
-The concept of an IDE (a place where you read, write, navigate, build, and debug code) hasn't been made obsolete by AI. It just needs to be reinvented for a world where you're not the only one editing. The old IDE assumed one operator. The new one needs to assume many: you, plus one or more agents, all working concurrently, all visible, all controllable from one place.
-
-That's what Minga is. Not a throwback to the IDE era, but the version of it that AI-assisted coding actually demands: an environment where human editing, agent editing, review, and orchestration all happen in the same process, with the same undo history, in the same viewport.
+The interesting problem is agentic editing: AI that reads your codebase, plans changes across multiple files, executes shell commands, and modifies buffers autonomously. That's where single-threaded editors hit their limits.
 
 ---
 
-## What this enables (that no other editor can do)
+## The IDE isn't dead. It needs a new architecture.
+
+There's a popular narrative that AI agents will replace the IDE. You'll just talk to a terminal, describe what you want, and the agent will write everything. The editor becomes a relic.
+
+That hasn't happened. Nobody runs Claude Code and blindly commits the result. You review. You audit. You open files, check diffs, trace through logic, run tests. The editor is still essential; it's just been demoted to a review tool that has no idea an agent exists.
+
+A PR diff shows you what changed, not why it's wrong. You can't jump to a definition from a diff view. You can't trace a call chain across three files. Telling an agent "fix line 47" only works when you already understand the problem. For the cases where you don't, you open an editor. Every time.
+
+The concept of an IDE (a place where you read, write, navigate, build, and debug code) hasn't been made obsolete by AI. It needs to be reinvented for a world where you're not the only one editing. The old IDE assumed one operator. The new one needs to assume many: you, plus one or more agents, all working concurrently, all visible, all controllable from one place.
+
+That's what Minga is building.
+
+---
+
+## What this enables
 
 ### Agent status in the modeline ✅
 
@@ -166,46 +136,30 @@ The editor monitors agent processes and reflects their status:
  NORMAL  main.ex [+]  ◐ Claude: refactoring extract_function  42:10
 ```
 
-Running, thinking, writing, errored: the editor knows because it supervises the agent process. This works today.
+Running, thinking, writing, errored: the editor knows because it supervises the agent process.
 
 ### Inline diff review ✅
 
-When the agent edits a file, the diff appears in the preview pane immediately. You review hunks with `y` (accept) / `x` (reject), navigate with `]c` / `[c`. No context switching to a terminal or a separate diff tool. This works today.
+When the agent edits a file, the diff appears in the preview pane immediately. Navigate hunks with `]c`/`[c`, accept with `y`, reject with `x`, bulk-accept with `Y`, bulk-reject with `X`. No context switching.
 
 ### Agent-aware undo (planned)
 
-Once agent tools are [routed through `Buffer.Server`](BUFFER-AWARE-AGENTS.md#phase-1-route-agent-tools-through-buffers), agent edits will participate in the undo system. You'll undo an agent's changes the same way you undo your own typing (`u` in normal mode). No "accept/reject" modal dialog. Just undo.
-
-Today, agent edits go to the filesystem and aren't part of the undo stack. The buffer architecture supports this (every edit through `apply_text_edits/2` pushes an undo entry); the agent tools just need to be wired to use it.
+Once agent tools [route through `Buffer.Server`](BUFFER-AWARE-AGENTS.md#phase-1-route-agent-tools-through-buffers), agent edits will participate in the undo system. Press `u` to undo an agent's changes the same way you undo your own typing. The buffer architecture supports this; the agent tools just need to be wired to use it.
 
 ### Buffer forking for concurrent agents (planned)
 
-Multiple agents will be able to edit the same file concurrently, each working on their own [in-memory fork](BUFFER-AWARE-AGENTS.md#phase-2-buffer-forking-with-three-way-merge) of the buffer. When they finish, changes merge back via three-way merge. Conflicts go through the diff review UI. This replaces git worktrees for most multi-agent workflows.
+Multiple agents will edit the same file concurrently, each on their own [in-memory fork](BUFFER-AWARE-AGENTS.md#phase-2-buffer-forking-with-three-way-merge). Changes merge back via three-way merge. Conflicts go through the diff review UI.
 
 ### Pausable agents
 
 Because agents are BEAM processes, you can suspend them:
 
 ```elixir
-# Pause an agent (it stops processing, but doesn't lose state)
-:sys.suspend(agent_pid)
-
-# Resume when ready
-:sys.resume(agent_pid)
+:sys.suspend(agent_pid)   # pause (keeps state)
+:sys.resume(agent_pid)    # resume
 ```
 
-This is a built-in BEAM capability. No special agent-side support needed.
-
-### Edit boundaries (planned)
-
-Define regions of a file that an agent can or can't touch:
-
-```elixir
-# Agent can only edit lines 50-100 of this buffer
-Agent.Session.set_boundary(session, buffer_pid, {50, 0}, {100, :end})
-```
-
-Once agent edits route through the GenServer, enforcing boundaries is just a guard clause on the message handler.
+Built-in BEAM capability. No special agent-side support needed.
 
 ---
 
@@ -213,33 +167,23 @@ Once agent edits route through the GenServer, enforcing boundaries is just a gua
 
 | Current tool has | Minga status |
 |-----------------|-------------|
-| VS Code's extension ecosystem | Early. Core editor only. |
-| Cursor's inline diff view | ✅ Shipped. Agent edits shown as reviewable diffs in preview pane. |
+| VS Code's extension ecosystem | ✅ Extension system ships (Hex, git, local). Ecosystem is young. |
+| Cursor's inline diff view | ✅ Shipped. |
 | Copilot ghost text | Planned. |
 | Agent undo integration | Planned. Requires [buffer-routed agent tools](BUFFER-AWARE-AGENTS.md). |
 | Multi-agent concurrent editing | Planned. [Buffer forking](BUFFER-AWARE-AGENTS.md#phase-2-buffer-forking-with-three-way-merge) with three-way merge. |
-| Claude Code's autonomous mode | Future. Minga could host the agent runtime directly. |
-| GUI (mouse-driven, graphical) | Terminal-based. Minga uses Zig + libvaxis for TUI. |
+| Claude Code's autonomous mode | Future. |
 
-Minga isn't a drop-in replacement for Cursor today. It's building the editor architecture that AI-assisted coding actually needs, not the one that made sense when editors were designed for solo human typing.
+Minga isn't a drop-in replacement for Cursor today. It's building the editor architecture that AI-assisted coding actually needs.
 
 ---
 
 ## The bet
 
-Your current editor was designed for you, sitting at a keyboard, typing one character at a time. AI coding agents are the biggest change in how code gets written since IDEs replaced `ed`. And they need an editor architecture that treats concurrent, independent, observable processes as first-class citizens, not an afterthought.
+Your current editor was designed for you, sitting at a keyboard, typing one character at a time. AI coding agents are the biggest change in how code gets written since IDEs replaced `ed`.
 
 Every other editor is retrofitting. Minga is building for this future from the ground up.
 
-And unlike the flavor-of-the-week AI editors that keep appearing (and disappearing), Minga isn't built on hype. It's built on a lineage. Emacs proved that an editor is really a Lisp runtime that happens to edit text. That insight, that the editor should be a programmable environment, not a static tool, is almost 50 years old and still correct. Minga carries that same philosophy forward: the editor is a BEAM runtime that happens to edit text. Buffers are processes. Modes are processes. Agents are processes. Everything is extensible, inspectable, and composable because the runtime makes it so.
+And unlike the flavor-of-the-week AI editors, Minga isn't built on hype. Emacs proved that an editor is really a Lisp runtime that happens to edit text. That insight (the editor should be a programmable environment, not a static tool) is almost 50 years old and still correct. Minga carries it forward: the editor is a BEAM runtime that happens to edit text. Buffers are processes. Modes are processes. Agents are processes.
 
-Emacs survived every editor war because its architecture was deeper than its UI. Minga makes the same bet: get the runtime right and the editor can adapt to whatever comes next, whether that's today's LLM-based agents or whatever replaces them in five years. Editors built as thin wrappers around a specific AI product have a shelf life. Editors built as programmable runtimes don't.
-
-If you've ever:
-- Had your editor stutter while an agent was streaming a response
-- Wished you could keep editing while an agent runs in the background without any jank
-- Wanted to see exactly what an agent is doing from inside your editor
-- Wanted to undo agent changes the same way you undo your own
-- Wondered why your editor can't handle two agents at once without slowing down
-
-Then Minga is the editor you've been waiting for. The age of AI-assisted coding needs an editor that was designed for it. This is that editor.
+Emacs survived every editor war because its architecture was deeper than its UI. Minga makes the same bet: get the runtime right and the editor can adapt to whatever comes next. Editors built as thin wrappers around a specific AI product have a shelf life. Editors built as programmable runtimes don't.

--- a/docs/FOR-EMACS-USERS.md
+++ b/docs/FOR-EMACS-USERS.md
@@ -1,10 +1,12 @@
 # Minga for Emacs Users
 
-You love Emacs because you can modify *anything*. The advice system, hooks, buffer-local variables, live eval. No other editor comes close to that level of programmability. So why would you even look at something else?
+You love Emacs because you can modify *anything*. The advice system, hooks, buffer-local variables, live eval. No other editor comes close to that level of programmability.
 
-**Because everything in Emacs shares one thread and one address space.** Every extension, every hook, every piece of advice competes for the same event loop. A slow hook freezes your editor. A global GC pause stutters your typing. Two packages can stomp on each other's state. You've accepted these trade-offs because nothing else offered the same extensibility.
+So why would you look at something else?
 
-Minga does. Without the trade-offs.
+Because everything in Emacs shares one thread and one address space. Every extension, every hook, every piece of advice competes for the same event loop. A slow hook freezes your editor. A global GC pause stutters your typing. Two packages can stomp on each other's state.
+
+Minga keeps the programmability and fixes all of that.
 
 ---
 
@@ -21,85 +23,68 @@ The extensibility model you love transfers directly. Minga's runtime is the BEAM
 | `M-:` / `eval-expression` | `Code.eval_string` / eval prompt | ✅ |
 | `describe-function` / `describe-key` | `h/1`, `:sys.get_state`, runtime docs | ✅ |
 | `init.el` is real Elisp | `config.exs` is real Elixir | ✅ |
-| Major modes (filetype keymaps) | [Keymap scopes](KEYMAP-SCOPES.md) + `SPC m` prefix scoped to filetype | ✅ ([#223](https://github.com/jsmestad/minga/issues/223), [#215](https://github.com/jsmestad/minga/issues/215)) |
+| Major modes (filetype keymaps) | [Keymap scopes](KEYMAP-SCOPES.md) + `SPC m` filetype bindings | ✅ |
 | Minor modes (toggleable keymaps) | Keymap layers with activation predicates | Future ([#216](https://github.com/jsmestad/minga/issues/216)) |
-| MELPA packages | Hex packages + supervised extensions | Future |
+| MELPA packages | Hex packages, git repos, or local paths + supervised extensions | ✅ |
 
-Every property that makes Emacs Emacs, Minga is building on the BEAM. The [Elixir as Elisp](EXTENSIBILITY.md) doc proves it point by point.
+For the point-by-point proof that Elixir matches every property that makes Elisp powerful, read [Elixir is Minga's Elisp](EXTENSIBILITY.md).
 
 ---
 
 ## What's actually limiting about Emacs
 
-You know these problems. You've just decided they're worth it. But they don't have to be.
-
-### 1. One slow hook freezes everything
+### One slow hook freezes everything
 
 ```elisp
 (add-hook 'after-save-hook #'my-format-and-lint)
 ```
 
-If `my-format-and-lint` takes 3 seconds, your editor freezes for 3 seconds. Every save. You can't type, you can't scroll, you can't switch buffers. Emacs is single-threaded. Your hooks, your commands, your rendering: all on one thread.
+If `my-format-and-lint` takes 3 seconds, your editor freezes for 3 seconds. Every save. You've tried `async.el` and `start-process`. They help, but they're brittle. Most packages don't bother.
 
-You've tried workarounds. `async.el`. `emacs-async`. Shelling out with `start-process`. They help, but they're brittle. Coordinating async results back into the single-threaded Elisp environment is error-prone, and most packages don't bother.
-
-**Minga:** Hooks run in their own BEAM processes. The editor's main loop never blocks:
+**Minga:** Hooks run in their own BEAM processes. A 3-second hook never blocks your typing:
 
 ```elixir
 on :after_save, fn _buf, path ->
-  # This takes 3 seconds. Your editor doesn't care.
-  # It's running in a separate process.
   System.cmd("mix", ["format", path])
   System.cmd("mix", ["credo", "--strict", path])
 end
+# You're already typing while this runs.
 ```
 
-This isn't async bolted on. The BEAM's preemptive scheduler runs all processes concurrently with fairness guarantees. Your typing always gets CPU time, even if a hook is doing heavy work.
+### GC pauses are real
 
-### 2. GC pauses are real
+Emacs uses a stop-the-world garbage collector. When it runs, everything pauses. `gc-cons-threshold` tuning is a rite of passage. You shouldn't need to tune your garbage collector to get a smooth editing experience.
 
-Emacs uses a stop-the-world garbage collector. When it runs, everything pauses: rendering, input handling, all of it. With large buffers or many packages loaded, you've felt the stutters. `gc-cons-threshold` tuning is a rite of passage for Emacs users. You shouldn't need to tune your garbage collector to get a smooth editing experience.
+**Minga:** Each BEAM process has its own heap and garbage collector. A 10MB log file being GC'd has zero impact on the small config file you're actively editing.
 
-**Minga:** Each BEAM process has its own heap and its own garbage collector. When a large buffer's process collects garbage, it doesn't pause the editor, the renderer, or any other buffer. A 10MB log file being GC'd has zero impact on the small config file you're actively editing.
+### Everything shares one environment
 
-### 3. Everything shares one environment
+`magit` can accidentally shadow a variable that `org-mode` depends on. A `use-package` `:config` block can throw an error that prevents the rest of your init from loading. You update a package, restart Emacs, and half your config is broken.
 
-Emacs has no isolation. Every package, every hook, every piece of advice shares one Elisp environment. `magit` can accidentally shadow a variable that `org-mode` depends on. A `use-package` `:config` block can throw an error that prevents the rest of your init from loading.
+**Minga:** Every component is an isolated BEAM process. If a package fails, its supervisor handles recovery. You see an error message. Other packages don't even know it happened.
 
-You update a package, restart Emacs, and your `init.el` fails halfway through. You're dropped into a half-configured editor with broken keybindings and missing modes. Or a package runs fine for weeks, then hits an edge case that corrupts a buffer's undo history or leaves `after-save-hook` in a broken state.
+### The C core is a wall
 
-**Minga:** Every component is an isolated BEAM process. Packages run in their own supervised process trees. A git integration package can't affect your buffer state because they're in different processes with different memory. If a package fails, its supervisor handles recovery. You see an error message in the status bar. Your editing session continues. Other packages don't even know anything happened.
+Emacs is "written in Elisp," except for the display engine, regex engine, buffer internals, and redisplay loop. Those are C. When you need to change how rendering works or modify buffer data structures, you hit a wall.
 
-### 4. The C core is a wall
+**Minga:** Editor logic is Elixir all the way down. Buffers, modes, motions, operators, the keymap trie, the render pipeline. The only non-Elixir code is the Zig renderer, and that's on the other side of a process boundary by design.
 
-Emacs is "written in Elisp," except for the parts that aren't. The display engine, the regex engine, buffer internals, the redisplay loop: these are C. When you need to change how rendering works, or fix a display bug, or modify buffer data structures, you hit a wall. The C core isn't practically modifiable by users.
+### AI agents need concurrency you don't have
 
-This creates two classes of functionality: things you can customize (Elisp layer) and things you can't (C core). You've worked around C-level limitations by writing increasingly clever Elisp, but the wall is always there.
+You're using `gptel` or `ellama`. They make HTTP requests and stream responses in your single-threaded Elisp environment. A slow API response blocks your typing. Now imagine agentic tools that modify files, run shell commands, and operate autonomously for minutes.
 
-**Minga:** The editor logic is Elixir all the way down. Buffers, modes, motions, operators, commands, the keymap trie, the renderer pipeline: it's all Elixir modules you can read, understand, and replace at runtime. The only non-Elixir boundary is the Zig renderer, and that's on the other side of a process boundary by design. It handles pixels, not editor logic.
-
-### 5. AI agents need concurrency you don't have
-
-You're using `gptel` or `ellama` or `org-ai`. They make HTTP requests to LLM APIs, stream responses into buffers, and sometimes execute code. All of this happens in your single-threaded Elisp environment. A slow API response blocks your typing. Concurrent modifications to the same buffer have no serialization guarantees.
-
-Now imagine agentic tools that don't just chat but modify files, run shell commands, create buffers, and operate autonomously for minutes. In Emacs, all of that contends with your typing for the same thread.
-
-**Minga:** Each AI agent session is its own supervised process tree. It communicates with buffers via message passing, the same mechanism the editor itself uses. An agent can't interfere with buffer state because it doesn't have direct access to buffer memory. The BEAM's preemptive scheduler guarantees your typing is always responsive regardless of what agents are doing. You can run multiple agents on multiple buffers simultaneously, and you can inspect any agent's live state with `:sys.get_state(agent_pid)`.
-
-And Minga is going further: agent tools are being [wired to edit buffers in-memory](BUFFER-AWARE-AGENTS.md) instead of writing to the filesystem. Agent edits will go through the same `Buffer.Server` GenServer as your keystrokes, with full undo integration, incremental tree-sitter sync, and no "file changed on disk" prompts. Multiple agents will be able to work on the same file concurrently via buffer forking with three-way merge, replacing the need for git worktrees. This is something no editor does today, and the BEAM's process model makes it architecturally natural.
+**Minga:** Each AI agent session is its own supervised process tree. Agent tools are being [wired to edit buffers in-memory](BUFFER-AWARE-AGENTS.md) with full undo integration, incremental tree-sitter sync, and buffer forking for concurrent agents. The BEAM's process model makes this architecturally natural.
 
 ---
 
 ## What you gain
 
-Beyond addressing Emacs's limitations:
-
 ### Modal editing (yes, really)
 
-You might already use `evil-mode`, an admission that Emacs's default keybindings cause RSI and Vim's modal model is more efficient. Minga gives you Vim-native modal editing without the impedance mismatch of running a Vim emulation layer on top of a non-modal editor:
+You might already use `evil-mode`, an admission that Emacs's default keybindings cause RSI and Vim's modal model is more efficient. Minga gives you Vim-native modal editing without the impedance mismatch:
 
 - Full normal/insert/visual/operator-pending modes
-- `d`, `c`, `y` + motions and text objects (`iw`, `i"`, `a{`, etc.)
+- Motions and text objects (`iw`, `i"`, `a{`)
 - Space-leader keys with Which-Key popup (like Doom's `SPC` menus)
 - Macros, registers, marks, dot repeat
 
@@ -107,249 +92,22 @@ If you use Doom Emacs, the leader key layout will feel familiar.
 
 ### Hot code reloading that actually works
 
-Emacs has `eval-buffer` and `load-file`. They work, but reloading a package often requires restarting because of stale state, cached closures, and order-dependent initialization.
+Emacs has `eval-buffer` and `load-file`. They work, but reloading a package often requires restarting because of stale state and cached closures.
 
-The BEAM was designed for hot code upgrades in production systems. It manages two versions of a module simultaneously. Old calls finish on the old version, new calls use the new code. Reload your config with `SPC h r` and the editor applies changes cleanly. No restart. No stale state.
+The BEAM was designed for hot code upgrades in production systems. It manages two versions of a module simultaneously. Reload your config with `SPC h r` and it applies cleanly. No restart. No stale state.
 
 ### Observability that Emacs can't match
 
-Emacs has `describe-function` and `edebug`. Useful, but limited.
-
-The BEAM has a production-grade observability toolkit:
+Emacs has `describe-function` and `edebug`. The BEAM has a production-grade observability toolkit:
 
 ```elixir
-# Full GUI showing every process, memory, CPU, message queues
-:observer.start()
+:observer.start()                     # full GUI dashboard
+:sys.get_state(Minga.Editor)          # inspect any process live
+:sys.get_state(buffer_pid)            # buffer state without stopping it
 
-# Inspect any process's state without stopping it
-:sys.get_state(Minga.Editor)
-:sys.get_state(buffer_pid)
-
-# Trace every message a process receives, live
 :dbg.tracer()
-:dbg.p(Process.whereis(Minga.Editor), [:receive])
-
-# See all buffer processes and their memory usage
-DynamicSupervisor.which_children(Minga.Buffer.Supervisor)
+:dbg.p(Process.whereis(Minga.Editor), [:receive])  # trace messages live
 ```
-
-This exists because the BEAM was built for systems that run 24/7 and must be debuggable without stopping. You get telecom-grade introspection for free.
-
----
-
-## Elixir is Minga's Elisp
-
-This is the part that matters most to Emacs users. You need proof that Elixir can replace Elisp, not just for config, but for the deep programmability that makes Emacs what it is.
-
-Here's the point-by-point comparison across every property that makes Elisp powerful:
-
-### 1. Redefine any function at runtime ✅
-
-**Elisp:**
-```elisp
-(defun my-custom-word-forward ()
-  "Jump to next camelCase boundary."
-  (interactive)
-  (re-search-forward "[A-Z]" nil t))
-
-(fset 'forward-word #'my-custom-word-forward)
-```
-
-**Elixir:**
-```elixir
-defmodule MyMotion do
-  def word_forward(buffer, pos) do
-    find_next_uppercase(buffer, pos)
-  end
-end
-
-Minga.Config.override(Minga.Motion.Word, :word_forward, &MyMotion.word_forward/2)
-```
-
-The BEAM's code server manages two versions of a module simultaneously. Old calls finish on the old code, new calls use the new version. This is safer than Elisp's immediate replacement, where redefining a function mid-execution can cause subtle bugs.
-
-### 2. Advice system ✅
-
-Emacs has eight advice combinators. Minga implements four that cover all the same use cases. The conditional combinators (`:before-while`, `:before-until`, `:after-while`, `:after-until`) rely on Elisp's nil/non-nil truthiness, which doesn't map to Elixir. Use `:around` instead; it gives you full control over whether the command runs.
-
-| Emacs | Minga | Notes |
-|-------|-------|-------|
-| `:before` | `:before` | Transforms state before the command |
-| `:after` | `:after` | Transforms state after the command |
-| `:around` | `:around` | Receives original function; full control |
-| `:override` | `:override` | Replaces the command entirely |
-| `:before-while` | Use `:around` | `if condition, do: execute.(state), else: state` |
-| `:before-until` | Use `:around` | Same pattern, inverted condition |
-| `:after-while` | Use `:around` | Check result after calling `execute.(state)` |
-| `:after-until` | Use `:around` | Same pattern, inverted condition |
-
-**Elisp:**
-```elisp
-(define-advice save-buffer (:before (&rest _args))
-  "Strip trailing whitespace before every save."
-  (delete-trailing-whitespace))
-
-;; :before-while - only save if buffer has a file
-(advice-add 'save-buffer :before-while
-  (lambda (&rest _) (buffer-file-name)))
-
-;; :around - full control
-(define-advice format-buffer (:around (orig-fn &rest args))
-  "Skip formatting if buffer has errors."
-  (if (zerop (length (flymake-diagnostics)))
-      (apply orig-fn args)
-    (message "Format skipped: buffer has errors")))
-```
-
-**Elixir:**
-```elixir
-# :before - transform state on the way in
-advise :before, :save, fn state ->
-  strip_trailing_whitespace(state)
-end
-
-# :around - conditionally skip formatting (replaces :before-while pattern)
-advise :around, :format_buffer, fn execute, state ->
-  errors =
-    state.buffers.active
-    |> Minga.Diagnostics.for_buffer()
-    |> Enum.count(fn d -> d.severity == :error end)
-
-  if errors == 0 do
-    execute.(state)
-  else
-    %{state | status_msg: "Format skipped: #{errors} error(s)"}
-  end
-end
-
-# :override - replace save with a version that also stages in git
-advise :override, :save, fn state ->
-  state = Minga.API.save()
-  case Minga.Buffer.Server.file_path(state.buffers.active) do
-    nil -> state
-    path ->
-      System.cmd("git", ["add", path], stderr_to_stdout: true)
-      %{state | status_msg: "Saved and staged: #{Path.basename(path)}"}
-  end
-end
-```
-
-**Where Elixir is stronger:** Advice runs inside a supervised process. If your advice function raises an error, it's caught, logged, and skipped. The command still runs, the editor stays up. In Emacs, badly written advice can leave the editor in a half-modified state. Minga also stores advice in an ETS table with `read_concurrency`, so looking up advice adds zero contention to the command dispatch path, even under heavy programmatic editing (AI agents, macros).
-
-### 3. Hooks ✅
-
-**Elisp:**
-```elisp
-(add-hook 'after-save-hook #'my-post-save-function)
-```
-
-**Elixir:**
-```elixir
-on :after_save, fn buffer_pid, path ->
-  if String.ends_with?(path, ".ex"), do: System.cmd("mix", ["format", path])
-end
-```
-
-**Where Elixir is stronger:** Hooks run concurrently in their own processes. A slow hook never blocks your typing.
-
-### 4. Buffer-local variables ✅
-
-**Elisp:**
-```elisp
-;; Is this global or local? Depends on make-local-variable. Have fun.
-(setq tab-width 4)         ;; global, unless someone called make-local-variable
-(setq-local tab-width 2)   ;; local to current buffer
-(setq-default tab-width 4) ;; sets the default for new buffers
-```
-
-In Emacs, whether `setq` writes a global or local depends on whether someone previously called `make-local-variable` on that symbol in the current buffer. This is invisible state that makes it hard to reason about what `setq` actually does.
-
-**Minga:**
-```elixir
-# In command mode:
-#   :set wrap          -> writes to THIS buffer
-#   :setglobal wrap    -> writes to the global default (all buffers without a local override)
-
-# In Elixir:
-Buffer.Server.set_option(buffer_pid, :tab_width, 2)  # always buffer-local
-Minga.Config.Options.set(:tab_width, 4)               # always global default
-```
-
-The scope is always explicit in the command you choose. `:set` is buffer-local, `:setglobal` is the global default. There is no `make-local-variable` equivalent because every buffer is a BEAM process with its own state. Buffer-local is the structural default, not a mode you opt into.
-
-**Resolution chain:** When reading an option, Minga checks buffer-local first, then filetype defaults, then the global default. This maps to Emacs as:
-
-| Emacs | Minga |
-|-------|-------|
-| `setq-local` | `:set` or `Buffer.Server.set_option/3` |
-| `setq-default` | `:setglobal` or `Options.set/2` |
-| `make-local-variable` | Not needed. Process isolation makes every option structurally local. |
-| `kill-local-variable` | Not yet implemented. The buffer always has a value (from seeding). |
-
-**Where Elixir is stronger:** No `make-local-variable` dance. Process boundaries enforce the separation. You cannot accidentally mutate another buffer's state. The VM prevents it. Options are eagerly seeded from filetype/global defaults when a buffer opens, so reading an option never crosses a process boundary.
-
-### 5. Live evaluation ✅
-
-**Elisp:**
-```elisp
-;; M-: evaluate any expression
-(buffer-file-name)
-```
-
-**Elixir:**
-```elixir
-Buffer.Server.file_path(current_buffer())
-Enum.map(buffers(), &Buffer.Server.file_path/1)
-```
-
-**Where Elixir is stronger:** You can inspect any process's live state, trace messages, and use `:observer.start()` for a full system dashboard. Emacs has nothing equivalent.
-
-### 6. Introspection ✅
-
-**Elisp:**
-```elisp
-(describe-function 'forward-word)
-(describe-key (kbd "C-f"))
-```
-
-**Elixir:**
-```elixir
-h Minga.Motion.Word.word_forward      # docstring from @doc
-Minga.Keymap.describe("SPC f f")      # binding lookup
-Minga.Motion.Word.__info__(:functions) # list all functions
-```
-
-Documentation lives in `@moduledoc` / `@doc` attributes, always in sync with the running code because it *is* the running code.
-
-### 7. The config IS the language ✅
-
-**Elisp:** `init.el` is real Lisp. You program the editor.
-
-**Elixir:** `config.exs` is real Elixir. You program the editor.
-
-```elixir
-use Minga.Config
-
-set :theme, :doom_one
-set :tab_size, 2
-
-bind :normal, "SPC g s", :git_status, "Git status"
-
-command :count_todos, "Count TODOs in buffer" do
-  content = Buffer.Server.content(current_buffer())
-  count = content |> String.split("\n") |> Enum.count(&String.contains?(&1, "TODO"))
-  notify("#{count} TODOs found")
-end
-
-for_filetype :elixir do
-  set :formatter, {"mix", ["format", "--stdin-filename", "{file}", "-"]}
-  on :after_save, fn _buf, path -> System.cmd("mix", ["format", path]) end
-end
-
-require_config "modules/*.ex"
-```
-
-When you outgrow your config, you're already writing the same code as the editor itself. No graduation from "config language" to "real language." It's Elixir all the way down.
 
 ---
 
@@ -359,16 +117,29 @@ When you outgrow your config, you're already writing the same code as the editor
 |--------|-------|--------|
 | **Execution model** | Single-threaded interpreter | Multi-process preemptive VM |
 | **Function redefinition** | Immediate, per-function | Per-module reload (~50ms) |
-| **Eval speed** | Interpreted (fast for small exprs) | Interpreted via `Code.eval_string` (comparable) |
-| **Failure behavior** | Can leave editor in inconsistent state | Contained to one process; supervisor recovers |
-| **Extension concurrency** | None (slow extension freezes editor) | Extensions are processes; can't block UI |
-| **GC model** | Stop-the-world (tunable but painful) | Per-process (no global pauses) |
-| **State model** | Global mutable state (footgun-prone) | Per-process state (isolated by default) |
-| **Community packages** | MELPA (thousands of packages) | Hex (large ecosystem, not editor-specific yet) |
-| **Learning curve** | Lisp syntax is polarizing | Ruby/Python-like; approachable |
+| **Failure behavior** | Can leave editor in inconsistent state | Contained to one process |
+| **Extension concurrency** | None (slow extension freezes editor) | Extensions are processes |
+| **GC model** | Stop-the-world | Per-process (no global pauses) |
+| **State model** | Global mutable state | Per-process state (isolated by default) |
+| **Community packages** | MELPA (thousands) | Hex (large ecosystem, not editor-specific yet) |
 | **Editor internals** | Elisp + C wall | Elixir all the way down |
 
-The single real trade-off: you reload a whole module, not a single function. In practice, modules are small and reload is fast. You won't notice.
+The single real tradeoff: you reload a whole module, not a single function. In practice, modules are small and reload is fast.
+
+---
+
+## "But what about minor modes?"
+
+If you're a Doom user, you rely on minor modes constantly. Minga doesn't have this yet. Here's why it's less of a gap than you'd expect.
+
+Most of what minor modes do in Emacs, Minga handles differently:
+
+- **LSP keybindings** live under `SPC c` globally. They no-op gracefully if no server is connected.
+- **Git keybindings** live under `SPC g` globally. Commands check for a git repo.
+- **Surround operations** are operators in operator-pending mode (`ds"`, `cs"'`).
+- **Error navigation** (`]d`, `[d`) is always available. Does nothing if there are no diagnostics.
+
+The Doom pattern of "always bind the key, let the command handle the empty case" works better than toggling keybindings on and off. When extensions mature enough to need toggleable keymap layers, the architecture is ready. See [#216](https://github.com/jsmestad/minga/issues/216).
 
 ---
 
@@ -376,46 +147,16 @@ The single real trade-off: you reload a whole module, not a single function. In 
 
 | Emacs has | Minga status |
 |-----------|-------------|
-| `org-mode` | Not planned. Org is a universe unto itself. |
-| `magit` | Git integration planned (#23), as supervised processes |
-| LSP (`eglot` / `lsp-mode`) | Planned (#22). Each LSP client as its own process |
-| Thousands of MELPA packages | Early. The extension system is being built (#14) |
-| Splits / windows | Planned. Keybindings exist, implementation pending |
-| `projectile` | ✅ Project detection, known projects, `SPC p` group. See [Projects](PROJECTS.md) |
-| `dired` | File tree planned (#40) |
-| Decades of community wisdom | Brand new. You'd be early. |
-| Emacs Lisp (if you love Lisp) | Elixir. Optional LFE support planned (#3) for Lisp fans. |
-| Major modes (filetype keymaps) | ✅ [Keymap scopes](KEYMAP-SCOPES.md) + `SPC m` filetype bindings. `keymap :elixir do ... end` in config. |
-| Minor modes (toggleable keymaps) | Future ([#216](https://github.com/jsmestad/minga/issues/216)). See below for why this is less of a gap than it sounds. |
+| `org-mode` | In progress. See [minga-org](https://github.com/jsmestad/minga-org) for TODO cycling, checkbox toggling, heading promotion, and tree-sitter highlighting. |
+| `magit` | Git integration planned, as supervised processes. |
+| LSP (`eglot` / `lsp-mode`) | Planned. Each LSP client as its own process. |
+| MELPA packages | ✅ Extensions install from Hex packages, git repos, or local paths. Supervised, crash-isolated, with update and rollback. |
+| `projectile` | ✅ Project detection, `SPC p` group. See [Projects](PROJECTS.md). |
+| Emacs Lisp (if you love Lisp) | Elixir. |
 
-Minga is not trying to replace Emacs today. `org-mode` alone is a reason to keep Emacs around.
+`org-mode` is the feature that keeps most Emacs users from leaving. That's exactly why [minga-org](https://github.com/jsmestad/minga-org) exists. It's an extension (installed via `extension :minga_org, git: "..."` in your config) that ships tree-sitter highlighting for org files, TODO keyword cycling, checkbox toggling, and heading manipulation. It's early, but it proves the extension system works for real use cases and that org support doesn't have to live inside the editor core.
 
-But for code editing, the thing you actually spend most of your time doing, Minga offers the same deep programmability with an architecture that eliminates the concurrency, isolation, and observability gaps you've been working around for years.
-
----
-
-## "But what about minor modes?"
-
-If you're a Doom Emacs user, you rely on minor modes constantly. `lsp-mode` adds code action keybindings. `flycheck-mode` adds error navigation. `evil-surround` adds surround operators. Each minor mode contributes its own keybindings that activate when the mode is enabled and disappear when it's not. Minga doesn't have this yet. Here's why it's less of a gap than you'd expect.
-
-**Most of what minor modes do in Emacs, Minga handles differently.**
-
-In Emacs, minor modes exist because packages need a way to contribute keybindings without stomping on each other in a single global keymap. The minor mode system is the coordination mechanism. But Minga's architecture already solves the underlying problems:
-
-- **LSP keybindings** live under `SPC c` globally. They no-op gracefully if no language server is connected. No mode toggle needed; the command itself checks for an active server.
-- **Git keybindings** live under `SPC g` globally. Same pattern: the commands check for a git repo.
-- **Surround operations** are operators in operator-pending mode (`ds"`, `cs"'`, etc.), not a separate mode layer.
-- **Error navigation** (`]d`, `[d`) is always available. It just does nothing if there are no diagnostics.
-
-The Doom Emacs pattern of "always bind the key, let the command handle the empty case" works better in practice than toggling keybindings on and off. Users build muscle memory for `SPC c a` (code action) regardless of whether an LSP is active. The key always exists, the popup always shows it, and the command tells you if it can't do anything right now.
-
-**Where minor modes actually matter: extensions that ship keybindings.**
-
-The real gap shows up when third-party extensions want to contribute keybindings that should only exist while their feature is active. A debugger extension shouldn't pollute the global keymap with `SPC d` bindings when no debug session is running. An AI extension might want to add bindings only when an agent is active.
-
-This is a genuine need, but it's a future need. Minga's extension ecosystem is early. The keymap architecture (trie-based, centralized lookup, per-mode storage) is designed so that keymap layers can be added on top without restructuring anything. Mode handlers already go through `Keymap.Active` for all lookups; adding a layer stack is an internal change to that module, not a rewrite. See [#216](https://github.com/jsmestad/minga/issues/216) for the planned design.
-
-**The short version:** Minga doesn't need minor modes today because the use cases they solve in Emacs are handled by different patterns here (global bindings with graceful no-ops, filetype-scoped `SPC m` bindings, advice system). When extensions mature enough to need toggleable keymap layers, the architecture is ready for them.
+For code editing, the thing you actually spend most of your time doing, Minga offers the same deep programmability with an architecture that eliminates the concurrency, isolation, and observability gaps you've been working around for years.
 
 ---
 
@@ -423,13 +164,6 @@ This is a genuine need, but it's a future need. Minga's extension ecosystem is e
 
 Emacs is the most programmable editor ever built. That's why you use it, despite the single-threaded freezes, the GC pauses, the package conflicts, and the C core you can't touch.
 
-Minga keeps the programmability and fixes everything else:
+Minga keeps the programmability and fixes everything else. Same depth of customization. Structural isolation between components. True concurrency. Per-process garbage collection. No C wall. Modal editing.
 
-- **Same depth of customization:** hooks, advice, live eval, buffer-local state, config-as-code
-- **Structural isolation:** components can't interfere with each other. Process boundaries enforce it.
-- **True concurrency:** hooks, agents, LSP, background work all run in parallel without blocking your typing
-- **No GC pauses:** per-process garbage collection
-- **No C wall:** editor logic is Elixir all the way down
-- **Modal editing:** because your wrists deserve it
-
-If you've ever wished Emacs had real concurrency, isolated components, or production-grade observability: Minga is building exactly that. Same philosophy. Better runtime.
+Same philosophy. Better runtime.

--- a/docs/FOR-NEOVIM-USERS.md
+++ b/docs/FOR-NEOVIM-USERS.md
@@ -2,13 +2,13 @@
 
 You already have modal editing, tree-sitter, and LSP. So why would you consider Minga?
 
-**Short answer:** True preemptive concurrency instead of a single-threaded event loop, an extension language that's also the implementation language, and components that are structurally isolated from each other.
+True preemptive concurrency instead of a single-threaded event loop, an extension language that's also the implementation language, and components that are structurally isolated from each other.
 
 ---
 
 ## What you keep
 
-Let's start with what doesn't change. If you use Neovim, your muscle memory transfers directly:
+Your muscle memory transfers directly:
 
 | Neovim | Minga | Status |
 |--------|-------|--------|
@@ -21,32 +21,32 @@ Let's start with what doesn't change. If you use Neovim, your muscle memory tran
 | `gg` `G` `{` `}` `%` | Same | ✅ |
 | Normal / Insert / Visual / Operator-Pending | Same | ✅ |
 | `:w` `:q` `:wq` `:e` `:%s` | Same | ✅ |
-| Registers (`"a`–`"z`, `"+`, `"_`) | Same | ✅ |
+| Registers (`"a`-`"z`, `"+`, `"_`) | Same | ✅ |
 | Macros (`q{a-z}`, `@{a-z}`, `@@`) | Same | ✅ |
 | Marks (`m{a-z}`, `'{a-z}`, `` `{a-z} ``) | Same | ✅ |
 | Dot repeat (`.`) | Same | ✅ |
 | Count prefix (`3dd`, `5j`) | Same | ✅ |
 | Tree-sitter highlighting | Same engine, 39 grammars | ✅ |
 
-The editing model is Vim. You're not learning a new editor. You're getting a better runtime under the same interface.
+You're not learning a new editor. You're getting a better runtime under the same interface.
 
 ---
 
 ## What's actually different about Neovim's architecture
 
-You probably already know these pain points, even if you've accepted them:
+You probably already know these pain points, even if you've accepted them.
 
-### 1. "Async" isn't really async
+### "Async" isn't really async
 
-Neovim is single-threaded. When people say it supports "async," they mean it has an event loop with callbacks, like JavaScript. One thing runs at a time. If your LSP server sends a huge response, or tree-sitter is reparsing a large file, or a plugin is doing something expensive in a `vim.schedule` callback, the event loop blocks. Your keystrokes queue up. You feel the lag.
+Neovim is single-threaded. When people say it supports "async," they mean it has an event loop with callbacks, like JavaScript. One thing runs at a time. If your LSP server sends a huge response, or tree-sitter is reparsing a large file, or a plugin is doing something expensive, the event loop blocks. Your keystrokes queue up.
 
-Neovim works around this with `:jobstart` (separate process) and Lua coroutines, but the coordination is manual and error-prone. You've debugged why a plugin "hangs" Neovim. It's almost always a synchronous call hiding in what looks like async code.
+Neovim works around this with `:jobstart` and Lua coroutines, but the coordination is manual and error-prone. You've debugged why a plugin "hangs" Neovim. It's almost always a synchronous call hiding in what looks like async code.
 
-**Minga:** The BEAM runs a preemptive scheduler with true parallelism. Every process gets a fair share of CPU time, enforced by the VM. An LSP client parsing a huge JSON response literally cannot block your keystroke handling because they run on different scheduler threads. This isn't async with callbacks. It's real concurrency with fairness guarantees.
+**Minga:** The BEAM runs a preemptive scheduler with true parallelism. Every process gets a fair share of CPU time, enforced by the VM. An LSP client parsing a huge JSON response literally cannot block your keystroke handling because they run on different scheduler threads.
 
-### 2. Lua is... fine
+### Lua is... fine
 
-Be honest. You don't love Lua. You tolerate it because it's better than Vimscript. Your `init.lua` is 500 lines of boilerplate. Half your config is copy-pasted from GitHub READMEs. Plugin configurations look like this:
+Be honest. You don't love Lua. You tolerate it because it's better than Vimscript. Your `init.lua` is 500 lines of boilerplate. Plugin configurations look like this:
 
 ```lua
 require("telescope").setup({
@@ -62,7 +62,7 @@ require("telescope").setup({
 })
 ```
 
-That's a data structure pretending to be configuration. You can't put real logic in there without it getting ugly fast. Lua has no pattern matching, no pipe operator, a 1-indexed standard library, and nil-propagation bugs that only surface at runtime.
+That's a data structure pretending to be configuration. Lua has no pattern matching, no pipe operator, a 1-indexed standard library, and nil-propagation bugs that only surface at runtime.
 
 **Minga:** Config is Elixir, a modern language with pattern matching, pipe operators, excellent error messages, and a type system that catches bugs at compile time:
 
@@ -70,7 +70,7 @@ That's a data structure pretending to be configuration. You can't put real logic
 use Minga.Config
 
 set :theme, :doom_one
-set :tab_size, 2
+set :tab_width, 2
 
 bind :normal, "SPC f f", :find_file, "Find file"
 
@@ -79,79 +79,39 @@ on :after_save, fn _buf, path ->
     System.cmd("mix", ["format", path])
   end
 end
-
-command :toggle_zen, "Toggle zen mode" do
-  state
-  |> set_option(:line_numbers, :none)
-  |> set_option(:gutter, false)
-  |> set_option(:padding, 20)
-end
 ```
 
-And because Elixir is the same language the editor is written in, you can read the source to understand what you're configuring. No Lua↔C boundary to navigate. No `:h api` that describes C functions you call from Lua.
+And because Elixir is the same language the editor is written in, you can read the source to understand what you're configuring. No Lua-to-C boundary to navigate.
 
-### 3. Everything shares one address space
+### Everything shares one address space
 
-Neovim plugins run in-process. There's no isolation between components. A bug in `telescope.nvim` can corrupt state used by `nvim-cmp`. A C extension with a memory error takes down the entire process. And every plugin, hook, and autocmd competes for the same event loop.
+Neovim plugins run in-process. There's no isolation between components. A bug in `telescope.nvim` can corrupt state used by `nvim-cmp`. A C extension with a memory error takes down the entire process.
 
-This also means plugin dependency management is fragile. Your `lazy.nvim` config has 40 plugins. Half of them have breaking changes every few months. If one fails to load, it can cascade into errors in unrelated plugins because they share global state.
+Your `lazy.nvim` config has 40 plugins. Half of them have breaking changes every few months. If one fails to load, it can cascade into errors in unrelated plugins because they share global state.
 
-**Minga:** Every component is an isolated BEAM process. Buffers, plugins, agents: they each have their own memory and their own state. A buggy plugin can't corrupt your buffer state because it literally doesn't have access to buffer memory. The VM enforces the isolation. If a plugin fails, its supervisor handles it while everything else keeps running. Other plugins don't even know it happened.
+**Minga:** Every component is an isolated BEAM process. A buggy plugin can't corrupt your buffer state because it doesn't have access to buffer memory. The VM enforces the isolation. If a plugin fails, its supervisor handles it while everything else keeps running.
 
-### 4. AI agents are fighting your event loop
+### AI agents are fighting your event loop
 
-You're using `copilot.vim` or `codecompanion.nvim` or `avante.nvim`. These plugins make HTTP requests to LLM APIs, stream responses, and modify buffers. They do this on the same event loop as your typing. You've noticed the occasional stutter when a completion comes in.
+You're using `copilot.vim` or `codecompanion.nvim`. These plugins make HTTP requests, stream responses, and modify buffers on the same event loop as your typing. Now imagine agentic tools that spawn shell commands, read files, write to multiple buffers, and run for minutes. All on Neovim's single-threaded event loop.
 
-Now imagine agentic coding tools that don't just suggest, but execute. They spawn shell commands, read files, write to multiple buffers, and run for minutes. All of this on Neovim's single-threaded event loop, contending with your keystrokes.
-
-**Minga:** Each AI agent session is its own supervised process tree. It communicates with buffers via message passing. The BEAM's preemptive scheduler guarantees your typing always gets CPU time, even if an agent is burning cycles on a long operation. You can inspect agent state live with `:sys.get_state(agent_pid)`. You can run multiple agents concurrently without any of them affecting your input responsiveness.
-
-Minga is also taking this further than any editor: agent tools are being [wired to edit buffers in-memory](BUFFER-AWARE-AGENTS.md) instead of going through the filesystem. Agent edits will participate in the undo stack, trigger incremental tree-sitter reparses, and appear in the editor instantly. Multiple agents will get their own buffer forks with three-way merge, eliminating the need for git worktrees. Neovim's single-threaded core makes this kind of concurrent buffer access fundamentally difficult; the BEAM's process model makes it natural.
+**Minga:** Each AI agent session is its own supervised process tree. The BEAM's preemptive scheduler guarantees your typing always gets CPU time. Agent tools are being [wired to edit buffers in-memory](BUFFER-AWARE-AGENTS.md) instead of going through the filesystem. Multiple agents will get their own buffer forks with three-way merge.
 
 ---
 
 ## What you gain
 
-Beyond addressing Neovim's architectural limitations:
-
 ### Hot code reloading
 
-Change your config, press `SPC h r`, and the editor reloads without restarting. No `:source %`, no restarting Neovim, no re-opening your files. The BEAM hot-loads the new code and your session continues.
+Change your config, press `SPC h r`, and the editor reloads without restarting. No `:source %`, no restarting Neovim, no re-opening your files.
 
 ### Buffer-local everything
 
-In Neovim, `vim.bo` vs `vim.o` vs `vim.g` is a source of constant confusion. Which options are buffer-local? Which are window-local? The answer is "it depends on the option" and there's a `:h` page you've never fully read.
+In Neovim, `vim.bo` vs `vim.o` vs `vim.g` is a constant source of confusion. Which options are buffer-local? Which are window-local?
 
-In Minga, each buffer is a BEAM process with its own state. Editing options (tab_width, wrap, indent_with, line_numbers, autopair, etc.) are inherently buffer-local. The scope is always explicit in the command:
+In Minga, each buffer is a BEAM process with its own state. `:set` is always buffer-local. `:setglobal` is always the global default. Process isolation makes this structural, not conventional.
 
-```vim
-:set wrap         " buffer-local: only this buffer
-:setglobal wrap   " global default: all buffers without a local override
-```
-
-Compare to Neovim's three confusing scopes:
-
-| Neovim | Minga | Scope |
-|--------|-------|-------|
-| `vim.bo[0].tabstop = 4` | `:set tab_width=4` | Current buffer |
-| `vim.o.tabstop = 4` | `:setglobal tab_width=4` | Global default |
-| `vim.wo[0].wrap = true` | `:set wrap` | Minga uses buffer-local (no window-local yet) |
-| `vim.g.some_plugin_var` | `Options.set(:name, val)` | Global |
-
-No `vim.bo` vs `vim.o` vs `vim.wo` to remember. `:set` is always buffer-local. `:setglobal` is always the global default. Process isolation makes this structural, not conventional.
-
-**Resolution chain:** When reading an option, Minga checks buffer-local first, then filetype defaults (like Neovim's `ftplugin`), then the global default. Options are eagerly seeded from filetype/global defaults when a buffer opens, so option reads are fast (no cross-process calls).
-
-```elixir
-# In config.exs (equivalent to ftplugin/go.vim):
-for_filetype :go do
-  set :tab_width, 8
-  set :indent_with, :tabs
-end
-
-# At runtime, override one buffer:
-Buffer.Server.set_option(buf, :tab_width, 4)
-```
+Resolution: buffer-local first, then filetype defaults, then global. No ambiguity.
 
 ### Live introspection
 
@@ -160,7 +120,7 @@ Neovim's debugging story is `:messages`, `:checkhealth`, and `print()`.
 The BEAM gives you:
 
 ```elixir
-# See every process in the editor, their memory, message queues
+# Full GUI: every process, memory, CPU, message queues
 :observer.start()
 
 # Inspect any process's state live
@@ -171,13 +131,13 @@ The BEAM gives you:
 :dbg.p(Process.whereis(Minga.Editor), [:receive])
 ```
 
-This is a production-grade observability toolkit. When something goes wrong, you don't add `print` statements and restart. You inspect the running system. This is how Erlang engineers debug systems that run for years without downtime. The same tools work for understanding what your editor is doing.
+This is a production-grade observability toolkit. When something goes wrong, you inspect the running system instead of adding `print` statements and restarting.
 
 ### The extension language is the implementation language
 
-In Neovim, you write config in Lua, but the editor is written in C. When you need to understand what `vim.api.nvim_buf_set_lines()` does, you're reading C source. The Lua API is a binding layer, not the real thing.
+In Neovim, you write config in Lua, but the editor is written in C. When you need to understand what `vim.api.nvim_buf_set_lines()` does, you're reading C source.
 
-In Minga, when you call `Buffer.Server.content(buf)` in your config, you're calling the same Elixir function the editor calls. The source you read to learn the API is the source that runs the editor. No translation layer.
+In Minga, when you call `Buffer.Server.content(buf)` in your config, you're calling the same Elixir function the editor calls. The source you read to learn the API is the source that runs the editor.
 
 ---
 
@@ -185,15 +145,13 @@ In Minga, when you call `Buffer.Server.content(buf)` in your config, you're call
 
 | Neovim has | Minga status |
 |-----------|-------------|
-| Massive plugin ecosystem | Early, core plugins only. The extension system (#14) is being built. |
-| LSP built-in | Planned (#22). Will run as supervised BEAM processes. |
-| Splits / tabs | Planned. Keybindings exist, implementation pending. |
+| Massive plugin ecosystem | ✅ Extension system ships (Hex, git, local path sources, supervised, with update/rollback). Ecosystem is young. |
+| LSP built-in | Planned. Will run as supervised BEAM processes. |
+| Splits / tabs | Planned. |
 | Visual block mode | Planned. |
-| Telescope / fzf-lua | Built-in fuzzy picker with project-scoped file finding and search. See [Projects](PROJECTS.md) |
+| Telescope / fzf-lua | Built-in fuzzy picker with project-scoped search. See [Projects](PROJECTS.md). |
 | DAP (debugger) | Not planned yet. |
-| Established community | Brand new. You'd be early. |
-
-Minga isn't trying to match Neovim feature-for-feature today. It's building on a fundamentally different architecture that solves problems Neovim can't fix without a rewrite.
+| Established community | Brand new. |
 
 ---
 
@@ -201,13 +159,8 @@ Minga isn't trying to match Neovim feature-for-feature today. It's building on a
 
 Neovim is a great editor today. Minga is a better architecture for tomorrow.
 
-If you're happy with Neovim and you don't mind the occasional UI jank from background operations and you don't use AI coding agents heavily, stay with Neovim. It's a good editor.
+If you're happy with Neovim and AI agents aren't a big part of your workflow, stay with Neovim.
 
-But if you've ever:
-- Noticed your editor stutter while an LSP server or AI plugin was doing heavy work
-- Wished your background tasks were truly concurrent instead of cooperative
-- Wanted an extension language that's also the implementation language
-- Wanted to inspect the live state of your editor's internals without restarting
-- Wondered how AI agents will integrate with a single-threaded event loop as they get more capable
+But if you've ever noticed your editor stutter during background operations, wished your background tasks were truly concurrent, wanted an extension language that's also the implementation language, or wondered how AI agents will integrate with a single-threaded event loop as they get more capable, Minga is building the editor you want.
 
-Then Minga is building the editor you want. The modal editing you know, on a runtime that was designed from the ground up for exactly the problems modern editors face.
+The modal editing you know, on a runtime designed for the problems modern editors actually face.

--- a/docs/FOR-PI-USERS.md
+++ b/docs/FOR-PI-USERS.md
@@ -1,8 +1,8 @@
 # Minga for Pi Users
 
-You read Mario's blog post. You like the philosophy: minimal system prompt, minimal toolset, full observability, YOLO by default, file-based plans over ephemeral modes. You use pi because it gives you control over what goes into the model's context and doesn't hide things behind sub-agent black boxes.
+You read Mario's blog post. You like the philosophy: minimal system prompt, minimal toolset, full observability, YOLO by default, file-based plans over ephemeral modes. You use pi because it gives you control over what goes into the model's context.
 
-**Minga already embeds pi.** Its agent backend spawns `pi --mode rpc` as a supervised BEAM Port. You keep everything pi gives you and gain an editor architecture that was designed from the ground up for AI-assisted coding.
+Minga already embeds pi. Its agent backend spawns `pi --mode rpc` as a supervised BEAM Port. You keep everything pi gives you and gain an editor that was designed from the ground up for AI-assisted coding.
 
 ---
 
@@ -12,30 +12,29 @@ Here's the workflow you're running today:
 
 1. Open a terminal. Run pi.
 2. The agent reads files, writes code, runs commands.
-3. You open a second terminal (or a split, or a different app) with Neovim/VS Code/Emacs to *review* what the agent did.
-4. You navigate the codebase, check diffs, trace call chains, verify types.
-5. You switch back to pi. Give it more instructions.
+3. Open a second terminal with Neovim or VS Code to review what the agent did.
+4. Navigate the codebase, check diffs, trace call chains.
+5. Switch back to pi. Give it more instructions.
 6. Repeat.
 
-You're running two tools because neither one is complete. Pi can't show you the codebase the way an editor can. Your editor can't see or control the agent. So you play air traffic controller between them, context-switching constantly, losing flow state every time you alt-tab.
+Two tools because neither one is complete. Pi can't show you the codebase the way an editor can. Your editor can't see or control the agent. You context-switch constantly.
 
-**Minga collapses this into one tool.** The agent works in the left pane. The editor shows the affected files in the right pane. Diffs appear inline as the agent edits. You review and keep editing in the same viewport. No window switching. No "let me check what it did."
+Minga collapses this into one tool. The agent works in the left pane. The editor shows affected files in the right pane. Diffs appear inline as the agent edits. No window switching.
 
 ---
 
 ## What you keep from pi
 
-Minga's agent backend *is* pi. The `PiRpc` provider spawns `pi --mode rpc` as a supervised OS process, communicates via JSON lines on stdin/stdout, and translates pi's event protocol into Minga's internal event system. Every pi capability flows through:
+Minga's agent backend *is* pi. The `PiRpc` provider spawns `pi --mode rpc` as a supervised OS process, communicates via JSON lines on stdin/stdout, and translates pi's event protocol into Minga's internal events.
 
 | Pi feature | How it works in Minga |
 |-----------|----------------------|
-| Minimal system prompt | Same. Pi's prompt is under 1,000 tokens. |
+| Minimal system prompt | Same. Under 1,000 tokens. |
 | 4 core tools (read, write, edit, bash) | Mapped to Minga's agent tools with identical semantics |
-| Multi-provider support | Pi handles provider switching; Minga surfaces it |
-| Session management | Minga adds its own persistence layer on top (`SPC a h` to browse sessions) |
+| Multi-provider support | Pi handles switching; Minga surfaces it |
+| Session management | Minga adds persistence on top (`SPC a h` to browse) |
 | AGENTS.md context files | Pi loads them. Minga's project detection feeds the right paths. |
-| Model switching | Available through pi's model selection |
-| Cost and token tracking | Surfaced in Minga's modeline and agent status |
+| Cost and token tracking | Surfaced in modeline and agent status |
 | Abort support | `SPC a s` sends abort through pi's RPC protocol |
 | YOLO mode | Minga adds optional tool approval on top for destructive operations |
 
@@ -45,70 +44,41 @@ You don't lose pi. You gain an editor around it.
 
 ## What you gain
 
-### 1. Agent edits participate in undo
+### Agent edits participate in undo
 
-When pi writes to a file via its `write` or `edit` tool, the change flows through Minga's buffer GenServer. It enters the same undo stack as your manual edits. Press `u` to undo an agent change. No external diffing. No "what did it change?" No `git diff` to figure out what happened.
+When pi writes to a file, the change flows through Minga's buffer GenServer and enters the same undo stack as your manual edits. Press `u` to undo an agent change. No `git diff` to figure out what happened.
 
-In pi alone, agent edits are disk writes. Your editor (if you have one open) picks them up via file watching, possibly with a "file changed on disk" dialog. Undo history is disconnected from the agent's changes.
+### Inline diff review
 
-### 2. Inline diff review
+When the agent edits a file, Minga shows a unified diff in the preview pane. Navigate hunks with `]c`/`[c`. Accept with `y`, reject with `x`. Bulk-accept with `Y`, bulk-reject with `X`. You review agent changes as diffs in context, not by reading chat output.
 
-When the agent edits a file, Minga shows a unified diff in the preview pane. Navigate hunks with `]c`/`[c`. Accept with `y`, reject with `x`. Bulk-accept with `Y`, bulk-reject with `X`. You review agent changes the way you review code, not by reading chat output, but by reading diffs in context.
+### Tool approval flow
 
-### 3. Structured split tool results (you already have this)
+Pi runs YOLO by default. Minga adds a configurable layer: destructive tools (write_file, edit_file, shell) can require approval before executing. This isn't security theater. It's a review checkpoint so you can make sure the agent understood your intent.
 
-The blog talks about pi-ai's innovation of separating LLM-facing tool output from UI-facing tool output. Minga's tool-reactive preview pane does the same thing. The agent chat shows tool summaries ("Edited main.ex lines 42-50"). The preview pane shows the full output: streaming shell results, unified diffs, directory listings with file/folder icons. Same concept, different implementation.
+### Your typing never freezes
 
-### 4. Tool approval flow
+Minga hosts both the agent and the editor. The BEAM's preemptive scheduler gives every process fair CPU time. The agent session, each buffer, the render pipeline: all separate processes. Your typing is responsive because the VM makes it structurally impossible for the agent to block your input.
 
-Pi runs YOLO by default, and the blog argues this is correct because security measures in coding agents are mostly theater. Minga agrees philosophically but adds a configurable layer: destructive tools (write_file, edit_file, shell) can require user approval before executing. You see exactly what the agent wants to do, approve or reject, and move on. Configurable via `agent_tool_approval` and `agent_destructive_tools` in your config.
+### Crash isolation
 
-This isn't security theater. It's a review checkpoint. You're not trying to prevent the agent from being malicious; you're making sure it understood your intent before it writes to disk.
+Pi is a single Node.js process. If it crashes, everything is gone.
 
-### 5. Your typing never freezes
+Minga's supervision tree isolates every component. If the pi RPC process crashes, the BEAM detects it, logs the error, and the agent session reports a failure. Your buffers, undo history, and unsaved changes are untouched. Completely separate processes, completely separate memory.
 
-Pi runs in a Node.js process. It's single-threaded. When pi is streaming a large response or executing a slow tool, pi's event loop is busy. This is fine because pi doesn't handle your typing; your terminal does.
+### Multiple agents
 
-But Minga hosts both the agent *and* the editor. If they shared a thread, a busy agent could lag your keystrokes. They don't share a thread. The BEAM runs a preemptive scheduler that gives every process fair CPU time. The agent session, each buffer, the renderer pipeline: all separate processes. The VM guarantees your typing gets CPU time regardless of what the agent is doing. This isn't async. It's true preemptive concurrency with fairness enforcement at the scheduler level.
+Pi runs one session per terminal. Minga can run multiple agent sessions as independent BEAM processes, each with its own provider and conversation.
 
-### 6. Crash isolation
+### Observability
 
-Pi is a single Node.js process. If it crashes, everything is gone: the session, the streaming response, the in-progress tool execution.
+The blog emphasizes full observability. Minga surfaces it differently than pi's scrollback TUI:
 
-Minga's supervision tree isolates every component:
-
-```
-Minga.Supervisor (rest_for_one)
-├── Buffer.Supervisor           ← buffers survive everything below
-│    ├── Buffer "main.ex"       ← isolated process, private state
-│    └── Buffer "router.ex"     ← isolated process, private state
-├── Agent.Supervisor            ← agent crashes don't affect buffers
-│    └── Agent.Session          ← supervised, restartable
-│         └── PiRpc provider    ← pi process supervised by BEAM
-├── Port.Manager                ← renderer crash doesn't lose state
-└── Editor                      ← orchestration
-```
-
-If the pi RPC process crashes, the BEAM detects it, logs the error, and the agent session reports a failure state. Your buffers, undo history, cursor positions, and unsaved changes are untouched. They're in completely separate processes with completely separate memory.
-
-### 7. Multiple agents
-
-Pi runs one agent session per terminal. Want to run a code review agent while a refactoring agent works on another file? Open two terminals. Coordinate manually.
-
-Minga can run multiple agent sessions as independent BEAM processes. Each has its own provider, its own conversation, its own supervised process tree. They communicate with buffers through message passing, the same mechanism the editor uses internally. No thread pool to configure, no concern about one agent blocking another.
-
-### 8. Observability you can't get from a CLI
-
-The blog emphasizes full observability: seeing every tool call, every model interaction, every edit. Pi surfaces this in its scrollback-buffer TUI. Minga surfaces it differently:
-
-- **Agent chat panel**: every message, tool call, and tool result visible with markdown rendering
-- **Tool-reactive preview pane**: shell output streams in real time, diffs appear as edits happen, directory listings show with icons
-- **Modeline status**: `◯` idle, `⟳` thinking, `⚡` tool executing, `✗` error
-- **Notification toasts**: actions confirmed in the top-right corner
-- **`*Messages*` buffer**: runtime log viewable via `SPC b m`
-- **BEAM introspection**: `:sys.get_state(agent_pid)` to inspect any process live
-
-You see everything the agent does without leaving the editor.
+- **Agent chat panel:** every message, tool call, and result with markdown rendering
+- **Tool-reactive preview pane:** streaming shell output, diffs as they happen, directory listings
+- **Modeline status:** `◯` idle, `⟳` thinking, `⚡` tool executing, `✗` error
+- **`*Messages*` buffer:** runtime log via `SPC b m`
+- **BEAM introspection:** `:sys.get_state(agent_pid)` to inspect any process live
 
 ---
 
@@ -116,81 +86,32 @@ You see everything the agent does without leaving the editor.
 
 The blog's strongest opinions map directly to how Minga works:
 
-### "No built-in to-dos. Write to a file."
+**"No built-in to-dos. Write to a file."** Minga agrees. The agent reads and updates `PLAN.md` or `TODO.md` like any other file.
 
-Minga agrees. There's no to-do widget. The agent reads and updates `PLAN.md` or `TODO.md` like any other file. File-based artifacts are versionable, shareable, and persistent across sessions. The agent can `@-mention` files to include them as context.
+**"No plan mode. Talk to the agent and write plans to files."** Minga agrees. The split view lets you see the plan file alongside the chat.
 
-### "No plan mode. Talk to the agent and write plans to files."
+**"No MCP. Use CLI tools with READMEs."** Minga's default agent follows the same philosophy. For users with existing MCP infrastructure, Minga offers MCP as an optional extension ([#286](https://github.com/jsmestad/minga/issues/286)) with lazy tool discovery to avoid context bloat. If you don't enable it, it doesn't exist.
 
-Minga agrees. There's no dedicated "plan UI." The agent chat is the planning interface. Plans go into files. The split view lets you see the plan file alongside the chat. `@-mentions` let you attach files as context when you need the agent to reference them.
-
-### "No MCP. Use CLI tools with READMEs."
-
-Minga's default agent follows the same philosophy: bash is the universal adapter, CLI tools with READMEs are cheaper on tokens (progressive disclosure: read the README only when needed), and easier to debug than MCP servers.
-
-For users with existing MCP infrastructure, Minga offers MCP as an **optional extension** ([#286](https://github.com/jsmestad/minga/issues/286)). Enable it in your config, declare your servers, and the extension manages their lifecycles under its own supervisor. The key design decision: MCP tool descriptions are not dumped into the system prompt. Instead, a lightweight meta-tool lets the agent discover available MCP tools on demand. This keeps the context overhead near zero (~100 tokens instead of 13K+) until the agent actually needs an MCP tool. Users who don't enable the extension see zero impact.
-
-### "Context engineering is paramount."
-
-This is the blog's deepest insight. Controlling what goes into the model's context yields better outputs. Minga supports this through:
-
-- **`@-mentions`**: type `@path` to attach specific files as context, with tab-completion
-- **`agent_auto_context`**: configurable automatic context injection
-- **Session persistence**: save and resume conversations, review what context was used
-- **Session artifacts**: the agent can write summaries to files that feed future sessions
-
-### "Observability over abstraction."
-
-The blog criticizes Claude Code for hiding sub-agent activity behind black boxes. Minga's agent shows every tool call, every result, every diff. The BEAM's introspection tools let you go even deeper when you need to.
+**"Context engineering is paramount."** Minga supports this through `@-mentions` for file context, configurable auto-context injection, session persistence, and session artifacts.
 
 ---
 
 ## What's different (and why)
 
-Not everything from pi's design translates to an editor. A few places where Minga intentionally diverges:
+**Full-screen TUI, not scrollback.** Pi uses scrollback for a linear chat. Minga is a full-screen editor with split windows, tab bars, gutter columns, and which-key popups. The tradeoff (losing native scrollback) is worth it for spatial layout.
 
-### Full-screen TUI, not scrollback
+**Agent processes, not bash self-spawn.** Minga has first-class agent processes with structured event streaming, inline diff review, and tool approval.
 
-Pi uses the scrollback-buffer TUI approach: append content to the terminal like a CLI program, get free scrolling and search from the terminal emulator. The blog explains why this makes sense for a linear chat interface.
-
-Minga is a full-screen editor. It takes ownership of the terminal viewport and draws a cell grid. This is the right choice for an editor that needs split windows, a tab bar, gutter columns, diagnostic overlays, which-key popups, and pixel-level control over every region. The trade-off (losing native scrollback) is worth it because editors need spatial layout that scrollback can't provide.
-
-### Agent processes, not bash self-spawn
-
-The blog argues against built-in sub-agents, preferring to spawn pi via bash for observability. This makes sense for a CLI tool where tmux is a natural companion.
-
-Minga has first-class agent processes. Each agent session is a supervised BEAM process tree with structured event streaming, inline diff review, and tool approval. The editor's split-panel design gives you observability that a raw bash sub-spawn can't: you see the chat, the diffs, and the affected files simultaneously in one viewport.
-
-### MCP as an extension, not core
-
-Pi has no MCP support and never will. The blog argues MCP servers are overkill and waste context. Minga agrees for the default experience, but ships MCP as an optional extension for users with existing MCP infrastructure. The extension uses lazy tool description injection (a meta-tool instead of dumping all descriptions upfront) to avoid the context bloat the blog criticizes. If you don't enable it, it doesn't exist.
-
-### Optional tool approval
-
-Pi runs YOLO-only. The blog argues that security measures are theater. Minga defaults to YOLO but lets you opt into approval for destructive tools. This isn't about security; it's about review cadence. Sometimes you want the agent to explain what it's about to do before it does it, especially when you're learning a new codebase or the agent is working on something critical.
+**Optional tool approval.** Pi is YOLO-only. Minga defaults to YOLO but lets you opt into approval for destructive tools. Not about security; about review cadence.
 
 ---
 
 ## Migration
 
-If you're a pi user, the migration is trivial:
-
 1. **Install Minga.** Your pi binary stays where it is.
-2. **Your AGENTS.md files work unchanged.** Minga's pi RPC provider loads them through pi.
-3. **Your pi config works unchanged.** Model settings, provider API keys, everything pi reads is separate from Minga's config.
-4. **Learn the keybindings.** `SPC a a` toggles the agent view. `SPC a s` stops the agent. `SPC a n` starts a new session. `SPC a h` browses saved sessions. Normal vim keybindings work everywhere.
-5. **Keep pi installed for standalone use.** Minga spawns pi as a subprocess. You can still run pi directly in a terminal when that's what you want.
+2. **Your AGENTS.md files work unchanged.** Pi loads them through its RPC protocol.
+3. **Your pi config works unchanged.** Model settings, API keys, everything pi reads is separate from Minga's config.
+4. **Learn the keybindings.** `SPC a a` toggles the agent. `SPC a s` stops it. `SPC a n` new session. `SPC a h` session history.
+5. **Keep pi for standalone use.** Minga spawns pi as a subprocess. You can still run pi directly when that's what you want.
 
 You're not replacing pi. You're giving it an editor to live in.
-
----
-
-## The bet
-
-Pi proved that a minimal, opinionated coding agent can match or beat feature-heavy alternatives. The blog's benchmark results show pi with Claude Opus 4.5 competitive with Cursor, Codex, and Windsurf on Terminal-Bench 2.0.
-
-But pi is still a CLI tool. When you're done talking to the agent, you open an editor. When you want to review what the agent wrote, you switch windows. When you want to trace a call chain across three files, you leave pi entirely.
-
-Minga is the editor that pi users open after pi finishes. Except now you don't have to leave. The agent lives inside the editor, edits flow through the undo system, diffs appear inline, and the BEAM's preemptive scheduler guarantees your typing is always responsive regardless of what the agent is doing.
-
-Same philosophy. Same agent. Better integration. One tool instead of two.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -127,4 +127,6 @@ You're up and running. Here's what to read based on what you care about:
 
 **"I'm coming from Neovim/Emacs."** The [Neovim](for-neovim-users.html) and [Emacs](for-emacs-users.html) migration guides explain what's the same, what's different, and what's better.
 
+**"I use AI coding tools."** Read [For AI-Assisted Developers](for-ai-coders.html). It covers why Minga's architecture matters for agentic workflows and how it compares to what you're using today.
+
 **"I want to contribute."** The [Contributing guide](contributing.html) has the build-from-source setup, testing, and how to add new commands and motions.

--- a/mix.exs
+++ b/mix.exs
@@ -31,22 +31,21 @@ defmodule Minga.MixProject do
           "docs/GETTING-STARTED.md",
           # Using Minga
           "docs/CONFIGURATION.md",
-          "docs/KEYMAP-SCOPES.md",
-          "docs/AGENTIC-KEYMAP.md",
           "docs/PROJECTS.md",
-          # Architecture
-          "docs/ARCHITECTURE.md",
-          "docs/PROTOCOL.md",
-          "docs/PERFORMANCE.md",
-          # Agent System
-          "docs/FOR-AI-CODERS.md",
-          "docs/BUFFER-AWARE-AGENTS.md",
-          # Extending Minga
-          "docs/EXTENSIBILITY.md",
           # Coming From...
           "docs/FOR-NEOVIM-USERS.md",
           "docs/FOR-EMACS-USERS.md",
           "docs/FOR-PI-USERS.md",
+          "docs/FOR-AI-CODERS.md",
+          # Extending Minga
+          "docs/EXTENSIBILITY.md",
+          "docs/KEYMAP-SCOPES.md",
+          "docs/AGENTIC-KEYMAP.md",
+          # Architecture
+          "docs/ARCHITECTURE.md",
+          "docs/PROTOCOL.md",
+          "docs/BUFFER-AWARE-AGENTS.md",
+          "docs/PERFORMANCE.md",
           # Development
           "CONTRIBUTING.md",
           "docs/RELEASING.md"
@@ -57,26 +56,24 @@ defmodule Minga.MixProject do
           ],
           "Using Minga": [
             "docs/CONFIGURATION.md",
-            "docs/KEYMAP-SCOPES.md",
-            "docs/AGENTIC-KEYMAP.md",
             "docs/PROJECTS.md"
-          ],
-          Architecture: [
-            "docs/ARCHITECTURE.md",
-            "docs/PROTOCOL.md",
-            "docs/PERFORMANCE.md"
-          ],
-          "Agent System": [
-            "docs/FOR-AI-CODERS.md",
-            "docs/BUFFER-AWARE-AGENTS.md"
-          ],
-          "Extending Minga": [
-            "docs/EXTENSIBILITY.md"
           ],
           "Coming From...": [
             "docs/FOR-NEOVIM-USERS.md",
             "docs/FOR-EMACS-USERS.md",
-            "docs/FOR-PI-USERS.md"
+            "docs/FOR-PI-USERS.md",
+            "docs/FOR-AI-CODERS.md"
+          ],
+          "Extending Minga": [
+            "docs/EXTENSIBILITY.md",
+            "docs/KEYMAP-SCOPES.md",
+            "docs/AGENTIC-KEYMAP.md"
+          ],
+          Architecture: [
+            "docs/ARCHITECTURE.md",
+            "docs/PROTOCOL.md",
+            "docs/BUFFER-AWARE-AGENTS.md",
+            "docs/PERFORMANCE.md"
           ],
           Development: [
             "CONTRIBUTING.md",


### PR DESCRIPTION
# TL;DR

Rewrites the README landing page and all "Coming From" docs in the project's writing voice. Cuts ~700 lines of redundant content while preserving all technical substance. Reorganizes the ExDoc sidebar for better reader flow.

## Context

The documentation site at jsmestad.github.io/minga/readme.html greets visitors with a wall of side navigation and text. The README opens defensively ("Why another editor?") before showing what Minga actually is. The "Coming From" docs repeat architecture explanations that exist in ARCHITECTURE.md. The sidebar groups docs in ways that don't match how readers navigate.

## Changes

**README.md** (complete rewrite):
- Replace "Why another editor?" with "What it feels like to use" showing the Space-leader popup, agent panel, and config-as-Elixir experience
- Add "Why the BEAM matters" that builds from the problem (agents fighting your event loop) to three concrete payoffs
- Replace flat documentation table with persona-driven "Where to go from here"
- Move current status notice up front

**FOR-AI-CODERS.md** (~35% shorter):
- Cut repetitive explanations that appeared multiple times
- Tighten editor comparison section
- Update extension ecosystem status to ✅ shipped

**FOR-EMACS-USERS.md** (~50% shorter):
- Remove duplicate Elisp/Elixir code examples (point to EXTENSIBILITY.md for the deep dive)
- Add minga-org teaser with link to the repo for org-mode users
- Update MELPA/extension status to ✅ shipped

**FOR-NEOVIM-USERS.md** (~30% shorter):
- Trim verbose explanations, keep all comparison tables
- Fix `set :tab_size` to `:tab_width` (correctness bug)
- Update plugin ecosystem status to ✅ shipped

**FOR-PI-USERS.md** (~40% shorter):
- Cut architecture explanations redundant with ARCHITECTURE.md

**ARCHITECTURE.md** (targeted edits):
- Tighten opening paragraph
- Replace em-dashes per style rules

**mix.exs** (sidebar reorganization):
- Move "Coming From..." higher (conversion path, not afterthought)
- Move FOR-AI-CODERS into "Coming From..." (pitch doc, not system doc)
- Move KEYMAP-SCOPES and AGENTIC-KEYMAP into "Extending Minga" (reference docs)
- Move BUFFER-AWARE-AGENTS into "Architecture" (internal design doc)
- Remove "Agent System" group
- Simplify "Using Minga" to Configuration + Projects

## Verification

1. Run `mix docs` and open `doc/index.html` in a browser
2. Verify the sidebar groups match: Getting Started, Using Minga, Coming From..., Extending Minga, Architecture, Development
3. Read the README page and check that persona-driven navigation links resolve correctly
4. Spot-check the "Coming From" docs for broken internal links
5. Verify `mix lint` passes (no Elixir code changes, but mix.exs was modified)

All CI checks pass: `mix lint` clean, 6228 tests / 0 failures.