### PR TITLE
feat(macos): extract shared BlinkingCursor with typing reset (#935)

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0089154318A4683A07D2918C /* BlinkingCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3927622EC3475A69EE524899 /* BlinkingCursor.swift */; };
 		00BFD5EFCCE2F178469BBA9E /* ToolManagerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64B96EAA100E627F4E8E0A1 /* ToolManagerState.swift */; };
 		03FDC63893F3CAA82BCE2A49 /* TabBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7AA0437B5C38BA8A8A80D5 /* TabBarState.swift */; };
 		058481A528AFB6C7225A067D /* MouseInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */; };
@@ -77,6 +78,7 @@
 		810251CDDA9CB63F881D426C /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D6B3C68CFF37BC4303933A /* ThemeColors.swift */; };
 		82E444261F28262834866B20 /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83165B89231936674C54B513 /* EditorNSView.swift */; };
 		854BCC1151B43E9A161C95B5 /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */; };
+		87C92A93D274184D1608DAC5 /* BlinkingCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3927622EC3475A69EE524899 /* BlinkingCursor.swift */; };
 		888A35D1348A7A3CAE935561 /* DecoderFuzzTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053D515EC453DEBFF51FB6CB /* DecoderFuzzTests.swift */; };
 		8B944E100C80DFF282D25D4C /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */; };
 		8CB3E1EEDEA109F6C0183597 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EED42A8B64B9CDFEF37ED9D /* SignatureHelpState.swift */; };
@@ -159,6 +161,7 @@
 		2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMEComposition.swift; sourceTree = "<group>"; };
 		321E4E28F5F49F089CCE2E1D /* PipelineCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineCacheTests.swift; sourceTree = "<group>"; };
 		371C61E78D4BB39467516BA7 /* SlotAllocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotAllocator.swift; sourceTree = "<group>"; };
+		3927622EC3475A69EE524899 /* BlinkingCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlinkingCursor.swift; sourceTree = "<group>"; };
 		3DC281B7F9F7E4C0BA793B1E /* ProtocolSchemaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolSchemaTests.swift; sourceTree = "<group>"; };
 		3E23DC6E0ACB156F21293E87 /* PortLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortLogger.swift; sourceTree = "<group>"; };
 		3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineCache.swift; sourceTree = "<group>"; };
@@ -296,6 +299,7 @@
 			children = (
 				E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */,
 				DD14027C8C7BD17057DE820B /* AgentChatView.swift */,
+				3927622EC3475A69EE524899 /* BlinkingCursor.swift */,
 				638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */,
 				443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */,
 				CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */,
@@ -556,6 +560,7 @@
 				4DF0BD94C77CA840CC92ACB7 /* AgentChatView.swift in Sources */,
 				19E561E5F7841B2CF1ABB085 /* BEAMProcessManager.swift in Sources */,
 				18F0DDA03D08C0B4302DCCF4 /* BitmapRasterizer.swift in Sources */,
+				0089154318A4683A07D2918C /* BlinkingCursor.swift in Sources */,
 				941C53DDBC488FE908656CD3 /* BottomPanelState.swift in Sources */,
 				1965FE752C77D2EB386EC4D8 /* BottomPanelView.swift in Sources */,
 				6860E9D6217B72EAA8AD71A5 /* BreadcrumbBar.swift in Sources */,
@@ -618,6 +623,7 @@
 				0D5DFD181E86D51707D3A59E /* AgentChatView.swift in Sources */,
 				79E8353F67F7638721A02A54 /* BEAMProcessManager.swift in Sources */,
 				64A5A16E02B3E2694060F1A1 /* BitmapRasterizer.swift in Sources */,
+				87C92A93D274184D1608DAC5 /* BlinkingCursor.swift in Sources */,
 				5BEEC2FD4D95EBA70FE036E7 /* BottomPanelState.swift in Sources */,
 				59546703C9DBB4BA6E15DE28 /* BottomPanelView.swift in Sources */,
 				8F6865441CD813045F071273 /* BreadcrumbBar.swift in Sources */,

--- a/macos/Sources/Views/AgentChatState.swift
+++ b/macos/Sources/Views/AgentChatState.swift
@@ -37,6 +37,10 @@ final class AgentChatState {
     var messages: [ChatMessageEntry] = []
     var pendingApproval: PendingApproval?
 
+    /// Monotonically increasing counter for BlinkingCursor reset token.
+    /// Increments on every update() so the cursor resets on each BEAM frame.
+    var promptVersion: Int = 0
+
     struct PendingApproval {
         let toolName: String
         let summary: String
@@ -59,6 +63,7 @@ final class AgentChatState {
         self.status = status
         self.model = model
         self.prompt = prompt
+        self.promptVersion += 1
         self.pendingApproval = pendingToolName.map { PendingApproval(toolName: $0, summary: pendingToolSummary) }
         self.messages = rawMessages.enumerated().map { i, msg in
             switch msg {

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -445,10 +445,7 @@ struct AgentChatView: View {
                         .font(.system(size: 13))
                         .foregroundStyle(theme.popupFg)
                     if isInsertMode {
-                        // Cursor indicator
-                        Rectangle()
-                            .fill(theme.accent)
-                            .frame(width: 1.5, height: 16)
+                        BlinkingCursor(color: theme.accent, resetToken: state.promptVersion)
                     }
                 }
             }

--- a/macos/Sources/Views/BlinkingCursor.swift
+++ b/macos/Sources/Views/BlinkingCursor.swift
@@ -1,0 +1,95 @@
+/// Shared blinking cursor view and system blink timing utilities.
+///
+/// Used by MinibufferView, AgentChatView, and any future SwiftUI input
+/// surfaces that need a macOS-native blinking text cursor. The Metal
+/// editor cursor (#933) reads SystemBlinkTiming directly but manages
+/// its own blink loop on the MTKView.
+
+import SwiftUI
+
+// MARK: - System blink timing
+
+/// Reads the macOS system cursor blink rate from UserDefaults.
+///
+/// All cursor-blinking surfaces (SwiftUI BlinkingCursor, Metal editor
+/// cursor) share this single source of truth for blink timing. The
+/// system settings are NSTextInsertionPointBlinkPeriodOn/Off (milliseconds).
+struct SystemBlinkTiming {
+    /// Nanoseconds the cursor stays visible per blink cycle.
+    let onDuration: UInt64
+
+    /// Nanoseconds the cursor stays hidden per blink cycle.
+    let offDuration: UInt64
+
+    /// Reads the current system blink timing. Falls back to 530ms (macOS default)
+    /// if the UserDefaults keys are missing or zero.
+    static var system: SystemBlinkTiming {
+        let onMs = UserDefaults.standard.double(forKey: "NSTextInsertionPointBlinkPeriodOn")
+        let offMs = UserDefaults.standard.double(forKey: "NSTextInsertionPointBlinkPeriodOff")
+        return SystemBlinkTiming(
+            onDuration: onMs > 0 ? UInt64(onMs * 1_000_000) : 530_000_000,
+            offDuration: offMs > 0 ? UInt64(offMs * 1_000_000) : 530_000_000
+        )
+    }
+
+    /// Whether the system has disabled cursor blinking via Accessibility settings.
+    /// When true, cursors should remain solid (always visible, no blink).
+    @MainActor
+    static var blinkingDisabled: Bool {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    }
+}
+
+// MARK: - Blinking cursor view
+
+/// A beam cursor (thin vertical bar) that blinks at the macOS system
+/// insertion point rate. Resets to visible whenever `resetToken` changes,
+/// so typing keeps the cursor solid during active input.
+///
+/// Uses a Task-based timer loop for precise on/off timing that matches
+/// native macOS text cursor behavior (no fade, just toggle).
+struct BlinkingCursor: View {
+    let color: Color
+    var width: CGFloat = 2
+    var height: CGFloat = 16
+    var resetToken: Int = 0
+
+    @State private var isVisible = true
+    @State private var blinkTask: Task<Void, Never>?
+
+    var body: some View {
+        Rectangle()
+            .fill(color)
+            .frame(width: width, height: height)
+            .opacity(isVisible ? 1 : 0)
+            .onAppear { restartBlink() }
+            .onDisappear { blinkTask?.cancel() }
+            .onChange(of: resetToken) { _, _ in
+                restartBlink()
+            }
+    }
+
+    /// Cancels any active blink timer, snaps cursor to visible, and starts
+    /// a new blink cycle. Called on appear and whenever resetToken changes.
+    @MainActor
+    private func restartBlink() {
+        blinkTask?.cancel()
+        isVisible = true
+
+        // Don't blink when Accessibility > Reduce Motion is enabled.
+        guard !SystemBlinkTiming.blinkingDisabled else { return }
+
+        let timing = SystemBlinkTiming.system
+
+        blinkTask = Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: timing.onDuration)
+                guard !Task.isCancelled else { break }
+                isVisible = false
+                try? await Task.sleep(nanoseconds: timing.offDuration)
+                guard !Task.isCancelled else { break }
+                isVisible = true
+            }
+        }
+    }
+}

--- a/macos/Sources/Views/MinibufferState.swift
+++ b/macos/Sources/Views/MinibufferState.swift
@@ -38,6 +38,12 @@ final class MinibufferState {
     var selectedIndex: UInt16 = 0
     var candidates: [MinibufferCandidate] = []
 
+    /// Monotonically increasing counter that increments on every update().
+    /// Used as a reset token for BlinkingCursor so the cursor snaps to
+    /// visible on every BEAM frame, regardless of whether the input string
+    /// changed length (e.g., delete one char then type one char).
+    var inputVersion: Int = 0
+
     /// Whether the current mode accepts text input (shows a cursor).
     var isInputMode: Bool {
         mode <= MinibufferMode.eval.rawValue
@@ -72,6 +78,7 @@ final class MinibufferState {
             MinibufferCandidate(id: i, matchScore: c.matchScore,
                                 label: c.label, description: c.description)
         }
+        self.inputVersion += 1
     }
 
     func hide() {

--- a/macos/Sources/Views/MinibufferView.swift
+++ b/macos/Sources/Views/MinibufferView.swift
@@ -85,9 +85,9 @@ struct MinibufferView: View {
                     .foregroundStyle(theme.popupFg)
             }
 
-            // Blinking cursor
+            // Blinking cursor (resets on every input change via inputVersion)
             if state.showCursor {
-                BlinkingCursor(color: theme.accent)
+                BlinkingCursor(color: theme.accent, resetToken: state.inputVersion)
             }
 
             // Text after cursor
@@ -194,44 +194,6 @@ struct MinibufferView: View {
                 .padding(.horizontal, 4)
         } else {
             Color.clear
-        }
-    }
-}
-
-// MARK: - Blinking cursor
-
-/// A 2px-wide beam cursor that blinks at the system insertion point rate.
-/// Uses a Task-based timer loop for precise on/off timing that matches
-/// native macOS text cursor behavior (no fade, just toggle).
-private struct BlinkingCursor: View {
-    let color: Color
-    @State private var isVisible = true
-    @State private var blinkTask: Task<Void, Never>?
-
-    var body: some View {
-        Rectangle()
-            .fill(color)
-            .frame(width: 2, height: 16)
-            .opacity(isVisible ? 1 : 0)
-            .onAppear { startBlinking() }
-            .onDisappear { blinkTask?.cancel() }
-    }
-
-    private func startBlinking() {
-        // Read system blink rate (milliseconds), fall back to 530ms
-        let onMs = UserDefaults.standard.double(forKey: "NSTextInsertionPointBlinkPeriodOn")
-        let offMs = UserDefaults.standard.double(forKey: "NSTextInsertionPointBlinkPeriodOff")
-        let onNanos = onMs > 0 ? UInt64(onMs * 1_000_000) : 530_000_000
-        let offNanos = offMs > 0 ? UInt64(offMs * 1_000_000) : 530_000_000
-
-        blinkTask = Task { @MainActor in
-            while !Task.isCancelled {
-                isVisible = true
-                try? await Task.sleep(nanoseconds: onNanos)
-                guard !Task.isCancelled else { break }
-                isVisible = false
-                try? await Task.sleep(nanoseconds: offNanos)
-            }
         }
     }
 }


### PR DESCRIPTION
## What

Extracts `BlinkingCursor` from a private struct in MinibufferView to a shared file accessible to all SwiftUI input surfaces. Adds typing reset so the cursor snaps to visible on every keystroke, and replaces the static cursor in AgentChatView with the shared blinking cursor.

## Why

Three cursor surfaces (minibuffer, agent chat, and the Metal editor cursor in #933) all need the same blinking behavior. Extracting to a shared component eliminates duplication and ensures consistent behavior. The typing reset is the most impactful fix: without it, there's a ~530ms window on each keystroke where the cursor might be invisible.

## Changes

- **New file: `BlinkingCursor.swift`** with `BlinkingCursor` view and `SystemBlinkTiming` utility
- `BlinkingCursor` accepts `resetToken: Int` parameter; `.onChange` restarts the blink cycle
- `SystemBlinkTiming` reads macOS system blink rate, shared between SwiftUI and Metal cursor surfaces
- `MinibufferState.inputVersion`: monotonically increasing counter (avoids same-length-string bug)
- `AgentChatState.promptVersion`: same pattern for agent chat
- AgentChatView: replaces static `Rectangle` cursor with `BlinkingCursor`
- Respects Accessibility > Reduce Motion (disable blink, keep solid)
- `@MainActor` annotations for Swift 6 strict concurrency compliance

## Testing

- Swift build: `BUILD SUCCEEDED`
- Swift tests: 426 tests in 85 suites passed
- No BEAM/Elixir changes required

Closes #935
Part of #921

**PR 1 of 7** for the native minibuffer polish epic.