### PR TITLE
feat(macos): editor cursor blinks at system rate (#933)

### DIFF
--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -217,6 +217,7 @@ final class CoreTextMetalRenderer {
     /// default bg) comes from FrameState. Content comes from WindowContentRenderer
     /// via the gui_window_content (0x80) semantic rendering pipeline.
     func render(frameState: FrameState, fontManager: FontManager,
+                cursorBlinkVisible: Bool = true,
                 windowContents: [UInt16: GUIWindowContent] = [:],
                 themeColors: ThemeColors? = nil,
                 drawable: CAMetalDrawable, viewportSize: CGSize,
@@ -459,7 +460,7 @@ final class CoreTextMetalRenderer {
         // Horizontal scroll is already baked in. If the TUI rendering path is ever
         // removed for GUI frontends, cursor positioning will need to use the semantic
         // window's cursor_col and scroll_left instead.
-        if frameState.cursorVisible && frameState.cursorShape == .block {
+        if frameState.cursorVisible && cursorBlinkVisible && frameState.cursorShape == .block {
             let cursorRow = Float(frameState.cursorRow)
             let cursorCol = Float(frameState.cursorCol)
             let cursorPadding: Float = (frameState.gutterCol > 0 && frameState.cursorCol >= frameState.gutterCol)
@@ -611,7 +612,7 @@ final class CoreTextMetalRenderer {
         // Pass 6: Cursor overlay for beam and underline shapes.
         // Block cursor is drawn in pass 2 (before text) so text shows on top.
         // Beam and underline are drawn AFTER text so they overlay it.
-        if frameState.cursorVisible && frameState.cursorShape != .block {
+        if frameState.cursorVisible && cursorBlinkVisible && frameState.cursorShape != .block {
             let cursorRow = Float(frameState.cursorRow)
             let cursorCol = Float(frameState.cursorCol)
             let cursorPadding: Float = (frameState.gutterCol > 0 && frameState.cursorCol >= frameState.gutterCol)

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -62,6 +62,20 @@ final class EditorNSView: MTKView {
     /// normal mode, not swallowed while the user is typing in insert mode.
     var statusBarState: StatusBarState?
 
+    // MARK: - Cursor blink
+
+    /// Whether the cursor is currently visible in the blink cycle.
+    /// The Metal renderer ANDs this with `frameState.cursorVisible` to
+    /// determine whether to draw the cursor.
+    private(set) var cursorBlinkVisible: Bool = true
+
+    /// The async task driving the blink timer. Cancelled on focus loss,
+    /// cursor hide, or dealloc.
+    private var blinkTask: Task<Void, Never>?
+
+    /// Observation token for accessibility display options changes.
+    private var accessibilityObserver: NSObjectProtocol?
+
     init(encoder: InputEncoder, fontFace: FontFace, dispatcher: CommandDispatcher,
          coreTextRenderer: CoreTextMetalRenderer, fontManager: FontManager) {
         self.encoder = encoder
@@ -84,8 +98,75 @@ final class EditorNSView: MTKView {
     @available(*, unavailable)
     required init(coder: NSCoder) { fatalError("Not implemented") }
 
+    /// Cleans up blink timer and accessibility observer.
+    /// Called from viewDidMoveToWindow when window is nil (view removed).
+    private func cleanupBlinkResources() {
+        blinkTask?.cancel()
+        blinkTask = nil
+        if let observer = accessibilityObserver {
+            NotificationCenter.default.removeObserver(observer)
+            accessibilityObserver = nil
+        }
+    }
+
     override var acceptsFirstResponder: Bool { true }
     override var isFlipped: Bool { true }
+
+    // MARK: - Cursor blink control
+
+    /// Resets the cursor to visible and restarts the blink cycle.
+    /// Called on keystrokes, cursor movement, and focus gain.
+    func resetCursorBlink() {
+        blinkTask?.cancel()
+        cursorBlinkVisible = true
+
+        // Don't blink when Accessibility > Reduce Motion is on.
+        guard !SystemBlinkTiming.blinkingDisabled else { return }
+
+        let timing = SystemBlinkTiming.system
+
+        // If on-period is 0, the user has disabled cursor blink system-wide.
+        guard timing.onDuration > 0 else { return }
+
+        blinkTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: timing.onDuration)
+                guard !Task.isCancelled else { break }
+                self?.cursorBlinkVisible = false
+                self?.needsDisplay = true
+                try? await Task.sleep(nanoseconds: timing.offDuration)
+                guard !Task.isCancelled else { break }
+                self?.cursorBlinkVisible = true
+                self?.needsDisplay = true
+            }
+        }
+    }
+
+    /// Stops the blink timer and shows the cursor as solid.
+    /// Called on focus loss and when the cursor is hidden (minibuffer active).
+    func stopCursorBlink() {
+        blinkTask?.cancel()
+        cursorBlinkVisible = true
+        needsDisplay = true
+    }
+
+    /// Starts observing Accessibility display option changes so the blink
+    /// timer responds to live Reduce Motion toggles. Idempotent: only
+    /// registers once (guards against repeated viewDidMoveToWindow calls).
+    private func observeAccessibilityChanges() {
+        guard accessibilityObserver == nil else { return }
+        accessibilityObserver = NotificationCenter.default.addObserver(
+            forName: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            if SystemBlinkTiming.blinkingDisabled {
+                self?.stopCursorBlink()
+            } else {
+                self?.resetCursorBlink()
+            }
+        }
+    }
 
     // MARK: - Rendering
 
@@ -116,9 +197,11 @@ final class EditorNSView: MTKView {
             lastAccessibilityCursorRow = fs.cursorRow
             lastAccessibilityCursorCol = fs.cursorCol
             NSAccessibility.post(element: self, notification: .selectedTextChanged)
+            resetCursorBlink()
         }
 
         coreTextRenderer.render(frameState: fs, fontManager: fontManager,
+                                cursorBlinkVisible: cursorBlinkVisible,
                                 windowContents: guiState?.windowContents ?? [:],
                                 themeColors: guiState?.themeColors,
                                 drawable: drawable, viewportSize: drawableSize,
@@ -155,32 +238,45 @@ final class EditorNSView: MTKView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        if let window = window {
-            // Match the Metal layer's scale to the window's backing scale.
-            (layer as? CAMetalLayer)?.contentsScale = window.backingScaleFactor
-
-            // Restore window position and size from previous session.
-            // This fires before the window is made key/visible, so the
-            // saved frame is applied without a visible position jump.
-            window.setFrameAutosaveName("MingaEditorWindow")
-
-            // Observe window becoming key to reclaim first responder.
-            // SwiftUI can reassign it during layout passes.
-            NotificationCenter.default.addObserver(
-                self,
-                selector: #selector(windowDidBecomeKey),
-                name: NSWindow.didBecomeKeyNotification,
-                object: window
-            )
-
-            // Install the first responder guard. This uses KVO to monitor
-            // first responder changes and immediately redirect them back
-            // to this editor view. Combined with .focusable(false) on all
-            // SwiftUI chrome, this ensures vim keybindings always work.
-            firstResponderGuard = FirstResponderGuard(window: window, editorView: self)
+        guard let window = window else {
+            cleanupBlinkResources()
+            return
         }
+
+        // Match the Metal layer's scale to the window's backing scale.
+        (layer as? CAMetalLayer)?.contentsScale = window.backingScaleFactor
+
+        // Restore window position and size from previous session.
+        // This fires before the window is made key/visible, so the
+        // saved frame is applied without a visible position jump.
+        window.setFrameAutosaveName("MingaEditorWindow")
+
+        // Observe window becoming/losing key to manage first responder
+        // and cursor blink. SwiftUI can reassign first responder during
+        // layout passes.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidBecomeKey),
+            name: NSWindow.didBecomeKeyNotification,
+            object: window
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidResignKey),
+            name: NSWindow.didResignKeyNotification,
+            object: window
+        )
+
+        // Install the first responder guard. This uses KVO to monitor
+        // first responder changes and immediately redirect them back
+        // to this editor view. Combined with .focusable(false) on all
+        // SwiftUI chrome, this ensures vim keybindings always work.
+        firstResponderGuard = FirstResponderGuard(window: window, editorView: self)
+
         updateTrackingArea()
         claimFirstResponder()
+        observeAccessibilityChanges()
+        resetCursorBlink()
     }
 
     /// Claim first responder after a short delay so SwiftUI's layout pass
@@ -197,6 +293,23 @@ final class EditorNSView: MTKView {
 
     @objc private func windowDidBecomeKey(_ notification: Notification) {
         claimFirstResponder()
+        resetCursorBlink()
+    }
+
+    @objc private func windowDidResignKey(_ notification: Notification) {
+        stopCursorBlink()
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let result = super.becomeFirstResponder()
+        if result { resetCursorBlink() }
+        return result
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let result = super.resignFirstResponder()
+        if result { stopCursorBlink() }
+        return result
     }
 
     override func setFrameSize(_ newSize: NSSize) {
@@ -318,6 +431,7 @@ final class EditorNSView: MTKView {
     }
 
     override func keyDown(with event: NSEvent) {
+        resetCursorBlink()
         let mods = modifierBits(from: event.modifierFlags)
 
         // Cmd+V: intercept paste and send as a single paste_event instead
@@ -387,6 +501,7 @@ final class EditorNSView: MTKView {
     // MARK: - Mouse
 
     override func mouseDown(with event: NSEvent) {
+        resetCursorBlink()
         let (row, col) = cellPosition(from: event)
         let cc = UInt8(clamping: event.clickCount)
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_LEFT,


### PR DESCRIPTION
## What

The Metal-rendered editor cursor now blinks at the macOS system insertion point rate, matching every native macOS text editor (Xcode, TextEdit, Nova, VS Code).

## Why

A blinking cursor communicates "this is where your input will go." A solid cursor in a GUI feels wrong, even if the user can't articulate why. This is especially noticeable in insert mode, where a solid beam cursor looks like a rendering artifact.

## Changes

- **EditorNSView**: Task-based blink timer reads system blink period from UserDefaults, toggles `cursorBlinkVisible` and schedules Metal redraws (~2x/sec)
- **CoreTextMetalRenderer**: `cursorBlinkVisible` parameter gates both block cursor (pass 2) and beam/underline cursor (pass 6) draw
- **Focus management**: cursor stops blinking on window resign key (solid when unfocused), restarts on become key
- **Input reset**: cursor snaps to visible on every keystroke, mouse click, and BEAM frame cursor position change
- **Accessibility**: respects Reduce Motion (solid cursor), observes live setting changes, handles blink period of 0

## Architecture

The blink timer lives on EditorNSView (owns NSView lifecycle), not the renderer or LineBuffer. `cursorBlinkVisible` is separate from `frameState.cursorVisible` (BEAM semantic intent vs local cosmetic state). The renderer ANDs both flags.

## Testing

- Swift build: BUILD SUCCEEDED
- Swift tests: 426 tests in 85 suites passed
- Manual verification needed: cursor blinks in normal/insert mode, resets on typing, stops on unfocus

Depends on #994 (BlinkingCursor extraction)
Closes #933
Part of #921

**PR 2 of 7** for the native minibuffer polish epic.