### PR TITLE
feat(editor): reveal active file in tree (SPC o r)

### DIFF
--- a/lib/minga/editor/commands/file_tree.ex
+++ b/lib/minga/editor/commands/file_tree.ex
@@ -128,6 +128,42 @@ defmodule Minga.Editor.Commands.FileTree do
     state
   end
 
+  @doc """
+  Reveals the active buffer's file in the tree: opens the tree if closed,
+  expands parent directories, moves the cursor to the file, and focuses
+  the tree panel.
+  """
+  @spec reveal_active_file(state()) :: state()
+  def reveal_active_file(state) do
+    # When the file tree is focused, state.buffers.active points at the
+    # tree's backing buffer (no file path). Use the active window's buffer
+    # instead, which always holds the real editing buffer.
+    buf = active_editing_buffer(state)
+
+    case buf && BufferServer.file_path(buf) do
+      nil ->
+        state
+
+      path ->
+        state = ensure_tree_open(state)
+        tree = FileTree.reveal(state.file_tree.tree, path)
+        state = sync_and_update(state, tree)
+        state = put_in(state.file_tree.focused, true)
+
+        %{state | keymap_scope: :file_tree}
+        |> Layout.invalidate()
+        |> EditorState.invalidate_all_windows()
+    end
+  end
+
+  @spec active_editing_buffer(state()) :: pid() | nil
+  defp active_editing_buffer(state) do
+    case EditorState.active_window_struct(state) do
+      %{buffer: buf} when is_pid(buf) -> buf
+      _ -> state.buffers.active
+    end
+  end
+
   @spec close(state()) :: state()
   def close(%{file_tree: %{buffer: buf}} = state) when is_pid(buf) do
     GenServer.stop(buf, :normal)
@@ -162,6 +198,12 @@ defmodule Minga.Editor.Commands.FileTree do
         put_in(state.file_tree.tree, FileTree.reveal(tree, path))
     end
   end
+
+  # Opens the tree if not already open. Used by reveal_active_file to
+  # ensure the tree exists before calling FileTree.reveal.
+  @spec ensure_tree_open(state()) :: state()
+  defp ensure_tree_open(%{file_tree: %{tree: %FileTree{}}} = state), do: state
+  defp ensure_tree_open(state), do: open(state)
 
   @spec open(state()) :: state()
   defp open(state) do
@@ -264,6 +306,12 @@ defmodule Minga.Editor.Commands.FileTree do
         description: "Create new folder in tree",
         requires_buffer: false,
         execute: &new_folder/1
+      },
+      %Minga.Command{
+        name: :tree_reveal_active,
+        description: "Reveal active file in tree",
+        requires_buffer: false,
+        execute: &reveal_active_file/1
       }
     ]
   end

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -13,9 +13,16 @@ defmodule Minga.Keymap.Defaults do
   | `SPC f`   | +file       |
   | `SPC b`   | +buffer     |
   | `SPC w`   | +window     |
+  | `SPC s`   | +search     |
+  | `SPC c`   | +code       |
+  | `SPC g`   | +git        |
+  | `SPC o`   | +open       |
+  | `SPC a`   | +ai         |
+  | `SPC t`   | +toggle     |
   | `SPC p`   | +project    |
   | `SPC q`   | +quit       |
   | `SPC h`   | +help       |
+  | `SPC m`   | +filetype   |
   """
 
   alias Minga.Keymap.Bindings
@@ -109,6 +116,7 @@ defmodule Minga.Keymap.Defaults do
 
     # ── Open ──────────────────────────────────────────────────────────────────
     {[{?o, @none}, {?p, @none}], :toggle_file_tree, "Toggle file tree"},
+    {[{?o, @none}, {?r, @none}], :tree_reveal_active, "Reveal file in tree"},
 
     # ── AI agent ─────────────────────────────────────────────────────────────
     {[{?a, @none}, {?a, @none}], :toggle_agentic_view, "Toggle agent split"},

--- a/test/minga/editor/commands/file_tree_reveal_test.exs
+++ b/test/minga/editor/commands/file_tree_reveal_test.exs
@@ -1,0 +1,108 @@
+defmodule Minga.Editor.Commands.FileTreeRevealTest do
+  @moduledoc """
+  Tests for the reveal_active_file command (SPC o r).
+
+  Verifies that revealing the active buffer's file in the tree opens the
+  tree if needed, expands parents, moves the cursor, and focuses the tree.
+
+  These tests use files inside the actual project root (via tmp_dir under
+  the repo) because the file tree opens at Project.root(), so test files
+  must exist within that tree to be revealed.
+  """
+  use Minga.Test.EditorCase, async: true
+
+  alias Minga.FileTree
+
+  @moduletag :tmp_dir
+
+  describe "reveal active file (SPC o r)" do
+    test "opens tree and reveals file when tree is closed", %{tmp_dir: dir} do
+      file = Path.join(dir, "reveal_test.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file)
+
+      # Tree starts closed
+      state = :sys.get_state(ctx.editor)
+      assert state.file_tree.tree == nil
+
+      # Reveal active file
+      state = send_keys_sync(ctx, "<SPC>or")
+
+      # Tree should be open and focused
+      assert state.file_tree.tree != nil
+      assert state.file_tree.focused == true
+      assert state.keymap_scope == :file_tree
+
+      # Cursor should be on the file
+      selected = FileTree.selected_entry(state.file_tree.tree)
+      assert selected != nil
+      assert selected.name == "reveal_test.txt"
+    end
+
+    test "moves cursor to file when tree is already open", %{tmp_dir: dir} do
+      file = Path.join(dir, "reveal_open_tree.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file)
+
+      # Open the tree first
+      _state = send_keys_sync(ctx, "<SPC>op")
+
+      # Move cursor to top (away from the file)
+      state = send_keys_sync(ctx, "gg")
+      top_entry = FileTree.selected_entry(state.file_tree.tree)
+      assert top_entry.name != "reveal_open_tree.txt"
+
+      # Reveal without closing: this exercises the ensure_tree_open pass-through
+      state = send_keys_sync(ctx, "<SPC>or")
+
+      selected = FileTree.selected_entry(state.file_tree.tree)
+      assert selected.name == "reveal_open_tree.txt"
+      assert state.file_tree.focused == true
+    end
+
+    test "reopens closed tree and re-reveals file", %{tmp_dir: dir} do
+      file = Path.join(dir, "reveal_test2.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file)
+
+      # Open the tree and reveal the file
+      state = send_keys_sync(ctx, "<SPC>or")
+      assert state.file_tree.tree != nil
+
+      # Close tree, then reveal again to reopen and re-reveal
+      _state = send_keys_sync(ctx, "<SPC>op")
+      state = send_keys_sync(ctx, "<SPC>or")
+
+      # Tree should be open and focused after re-reveal
+      assert state.file_tree.tree != nil
+      assert state.file_tree.focused == true
+      assert state.keymap_scope == :file_tree
+
+      # The file should be visible in the tree and the cursor should
+      # be on it. The tree root is Project.root() which may differ
+      # between local and CI, so verify via visible_entries lookup.
+      entries = FileTree.visible_entries(state.file_tree.tree)
+      expanded_path = Path.expand(file)
+      file_entry = Enum.find(entries, fn e -> e.path == expanded_path end)
+      assert file_entry != nil, "reveal_test2.txt should be visible in the tree"
+
+      assert state.file_tree.tree.cursor ==
+               Enum.find_index(entries, fn e -> e.path == expanded_path end)
+    end
+
+    test "no-op when active buffer has no file path", %{tmp_dir: _dir} do
+      # Buffer with content but no file_path
+      ctx = start_editor("scratch content")
+
+      # Reveal should be a no-op (tree stays closed)
+      _state = send_keys_sync(ctx, "<SPC>or")
+      state = :sys.get_state(ctx.editor)
+
+      # Tree should not have opened
+      assert state.file_tree.tree == nil
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `SPC o r` to reveal the active buffer's file in the file tree sidebar. Opens the tree if closed, expands parent directories, moves the cursor to the file, and focuses the tree panel.

## Why

When you open a file via fuzzy finder or follow a definition jump, you often want to see where it lives in the project structure. Without reveal, the tree is disconnected from your editing context. Every editor with a file tree has this.

## Changes

- New `reveal_active_file/1` command in `Commands.FileTree`
- `ensure_tree_open/1` helper that reuses existing `open/1` logic
- `active_editing_buffer/1` helper that resolves the real editing buffer even when the file tree is focused (where `buffers.active` temporarily points at the tree's backing buffer)
- Registered as `:tree_reveal_active` in the command registry
- Bound to `SPC o r` under the `+open` group
- Backfilled `@moduledoc` key groups table with all registered groups

## Edge Cases Handled

- **Tree closed**: opens the tree, then reveals
- **Tree open, cursor elsewhere**: moves cursor to file without collapsing anything
- **Tree focused**: correctly resolves the editing buffer from the active window (not the tree buffer)
- **Scratch buffer / no file path**: no-op

## Testing

4 new tests in `file_tree_reveal_test.exs`:
- Opens tree and reveals file when tree is closed
- Moves cursor to file when tree is already open
- Reopens closed tree and re-reveals file
- No-op when active buffer has no file path

All 324 targeted tests pass. `mix lint` clean.

Closes #992