### PR TITLE
fix(macos): prevent FirstResponderGuard from stealing focus from text fields

### DIFF
--- a/macos/Sources/Views/MingaWindow.swift
+++ b/macos/Sources/Views/MingaWindow.swift
@@ -13,6 +13,11 @@
 /// provides two layers of defense:
 /// 1. SwiftUI views don't participate in the focus system at all
 /// 2. If anything does steal focus, this guard reclaims it immediately
+///
+/// Exception: when AppKit installs a field editor (`NSTextView`, a subclass
+/// of `NSText`) as first responder for an active TextField, the guard yields
+/// intentionally. This covers all current and future SwiftUI text fields
+/// without per-field suspend/resume wiring. See `checkFirstResponder()`.
 
 import AppKit
 
@@ -55,6 +60,12 @@ final class FirstResponderGuard {
     private func checkFirstResponder() {
         guard !suspended else { return }
         guard let window, let editor = editorView else { return }
+        // Don't steal focus from active text fields. When a SwiftUI TextField
+        // (or any NSTextField) is focused, AppKit makes the window's field
+        // editor (an NSTextView, subclass of NSText) the first responder.
+        // Checking for NSText covers all current and future text fields without
+        // requiring per-field suspend/resume wiring.
+        if window.firstResponder is NSText { return }
         if window.firstResponder !== editor {
             window.makeFirstResponder(editor)
         }


### PR DESCRIPTION
## What

The Messages panel filter text field was unusable because the `FirstResponderGuard` immediately reclaimed keyboard focus for the `EditorNSView` on every `NSWindow.didUpdateNotification` cycle.

## Fix

One-line check in `checkFirstResponder()`: when AppKit's field editor (an `NSTextView`, subclass of `NSText`) is first responder, the guard yields. This happens automatically whenever any `TextField` is focused.

```swift
if window.firstResponder is NSText { return }
```

This covers all current and future SwiftUI text fields without requiring per-field suspend/resume wiring. The agent chat's existing `suspended` flag still works for its broader overlay interactions.

## Why not per-field wiring?

The `suspended` pattern used by the agent chat requires each new text field to find a way to toggle the flag. The `is NSText` check eliminates this for the common case. `MTKView` (the editor surface) is not in the `NSText` hierarchy, so there's zero risk of the guard mistakenly yielding to the editor itself.

## Testing

- 426 Swift tests pass
- Manual verification: filter field accepts typing, clicking the editor area reclaims focus, Escape returns to editor, vim keybindings resume immediately

Closes #996