### PR TITLE
fix(macos): respect reduced motion in picker, which-key, and tool manager

### DIFF
--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -15,6 +15,11 @@ struct PickerOverlay: View {
     private let itemHeight: CGFloat = 24
     private let maxListHeight: CGFloat = 440
 
+    /// Transition animation duration. Respects reduced motion.
+    private var animDuration: Double {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.1
+    }
+
     var body: some View {
         if state.visible {
             ZStack {
@@ -55,7 +60,7 @@ struct PickerOverlay: View {
                 }
                 .offset(y: -60)
             }
-            .transition(.opacity.animation(.easeInOut(duration: 0.1)))
+            .transition(.opacity.animation(.easeInOut(duration: animDuration)))
         }
     }
 

--- a/macos/Sources/Views/ToolManagerView.swift
+++ b/macos/Sources/Views/ToolManagerView.swift
@@ -18,6 +18,11 @@ struct ToolManagerView: View {
     private let itemHeight: CGFloat = 64
     private let failedItemHeight: CGFloat = 96
 
+    /// Transition animation duration. Respects reduced motion.
+    private var animDuration: Double {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.15
+    }
+
     var body: some View {
         if state.visible {
             ZStack {
@@ -57,7 +62,7 @@ struct ToolManagerView: View {
                 .offset(y: -30)
             }
             .allowsHitTesting(false)  // BEAM handles all input
-            .transition(.opacity.combined(with: .scale(scale: 0.97)).animation(.easeOut(duration: 0.15)))
+            .transition(.opacity.combined(with: .scale(scale: 0.97)).animation(.easeOut(duration: animDuration)))
         }
     }
 

--- a/macos/Sources/Views/WhichKeyOverlay.swift
+++ b/macos/Sources/Views/WhichKeyOverlay.swift
@@ -14,6 +14,11 @@ struct WhichKeyOverlay: View {
     private let rowHeight: CGFloat = 22
     private let maxColumns = 4
 
+    /// Transition animation duration. Respects reduced motion.
+    private var animDuration: Double {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.15
+    }
+
     var body: some View {
         if state.visible && !state.bindings.isEmpty {
             VStack(spacing: 0) {
@@ -56,7 +61,7 @@ struct WhichKeyOverlay: View {
             .padding(.horizontal, 16)
             .padding(.bottom, 8)
             .allowsHitTesting(false)
-            .transition(.opacity.animation(.easeInOut(duration: 0.15)))
+            .transition(.opacity.animation(.easeInOut(duration: animDuration)))
         }
     }
 


### PR DESCRIPTION
## What

Three overlay views had hardcoded transition animation durations that ignored the macOS "Reduce motion" accessibility setting. Four other overlays (FileTree, HoverPopup, SignatureHelp, FloatPopup) already respected it.

## Fix

Add the same `animDuration` computed property pattern to `PickerOverlay`, `WhichKeyOverlay`, and `ToolManagerView`. When `accessibilityDisplayShouldReduceMotion` is true, animations use zero duration (instant).

All 7 overlay views now behave consistently.

## Testing

426 Swift tests pass.

Closes #999