### PR TITLE
feat(macos): dismiss picker overlay on backdrop click

### DIFF
--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -228,7 +228,8 @@ struct ContentView: View {
         // Picker overlay (floats over entire window)
         PickerOverlay(
             state: appState.gui.pickerState,
-            theme: appState.gui.themeColors
+            theme: appState.gui.themeColors,
+            encoder: appState.encoder
         )
 
         // Tool manager overlay (floats over entire window)

--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct PickerOverlay: View {
     let state: PickerState
     let theme: ThemeColors
+    let encoder: InputEncoder?
 
     private let panelWidth: CGFloat = 600
     private let itemHeight: CGFloat = 24
@@ -18,11 +19,14 @@ struct PickerOverlay: View {
     var body: some View {
         if state.visible {
             ZStack {
-                // Dimmed background: non-interactive
+                // Dimmed background: click to dismiss (like Spotlight, Alfred, Xcode Open Quickly)
                 Color.black.opacity(0.3)
                     .ignoresSafeArea()
-                    .allowsHitTesting(false)
                     .accessibilityHidden(true)
+                    .onTapGesture {
+                        // Send Escape to the BEAM to dismiss the picker via the normal mode transition
+                        encoder?.sendKeyPress(codepoint: 27, modifiers: 0)
+                    }
 
                 VStack(spacing: 0) {
                     searchField


### PR DESCRIPTION
## What

Clicking outside the picker overlay (command palette, file finder) did not dismiss it. The dimmed backdrop had `.allowsHitTesting(false)`. In every macOS app with a modal overlay (Spotlight, Alfred, Raycast, Xcode Open Quickly), clicking outside dismisses.

## Fix

Remove `.allowsHitTesting(false)` from the backdrop. Add `onTapGesture` that sends Escape (keypress codepoint 27) to the BEAM, triggering the normal picker dismiss flow. Added `encoder: InputEncoder?` parameter to `PickerOverlay`.

## Testing

426 Swift tests pass.

Closes #1001