### PR TITLE
feat(macos): add hover highlighting to completion popup and bottom panel tabs

### DIFF
--- a/macos/Sources/Views/BottomPanelView.swift
+++ b/macos/Sources/Views/BottomPanelView.swift
@@ -22,6 +22,7 @@ struct BottomPanelView: View {
 
     /// Height at drag start, used to avoid compounding error from cumulative translation.
     @State private var dragStartHeight: CGFloat = 0
+    @State private var hoveredTabId: Int? = nil
 
     var body: some View {
         let maxH = availableHeight * maxHeightFraction
@@ -119,7 +120,7 @@ struct BottomPanelView: View {
         .background(
             isActive
                 ? theme.tabActiveBg.opacity(0.5)
-                : Color.clear
+                : (hoveredTabId == tab.id ? theme.tabInactiveFg.opacity(0.06) : Color.clear)
         )
         .overlay(alignment: .bottom) {
             if isActive {
@@ -127,6 +128,9 @@ struct BottomPanelView: View {
                     .fill(theme.accent)
                     .frame(height: 2)
             }
+        }
+        .onHover { isHovered in
+            hoveredTabId = isHovered ? tab.id : nil
         }
     }
 

--- a/macos/Sources/Views/CompletionOverlay.swift
+++ b/macos/Sources/Views/CompletionOverlay.swift
@@ -17,6 +17,8 @@ struct CompletionOverlay: View {
     private let itemHeight: CGFloat = 24
     private let popupWidth: CGFloat = 340
 
+    @State private var hoveredItemId: Int? = nil
+
     var body: some View {
         if state.visible && !state.items.isEmpty {
             VStack(spacing: 0) {
@@ -77,11 +79,18 @@ struct CompletionOverlay: View {
         }
         .padding(.horizontal, 8)
         .frame(height: itemHeight)
-        .background(isSelected ? theme.popupSelBg.opacity(0.7) : Color.clear)
+        .background(
+            isSelected
+                ? theme.popupSelBg.opacity(0.7)
+                : (hoveredItemId == item.id ? theme.popupFg.opacity(0.06) : Color.clear)
+        )
         .clipShape(RoundedRectangle(cornerRadius: 4))
         .padding(.horizontal, 4)
         .id(item.id)
         .contentShape(Rectangle())
+        .onHover { isHovered in
+            hoveredItemId = isHovered ? item.id : nil
+        }
         .onTapGesture {
             encoder?.sendCompletionSelect(index: UInt16(item.id))
         }


### PR DESCRIPTION
## What

Two interactive list views were missing hover state feedback: completion popup items and bottom panel tab buttons. The file tree already had hover highlighting; these two views now match.

## Changes

- **Completion popup items**: subtle background highlight (`popupFg` at 6% opacity) on hover, tracked via `@State hoveredItemId`
- **Bottom panel tabs**: subtle background highlight (`tabInactiveFg` at 6% opacity) on inactive tabs, tracked via `@State hoveredTabId`

Both follow the same pattern as `FileTreeView.swift` where `hoveredEntryId` drives the hover state.

## Testing

426 Swift tests pass.

Closes #1004