### PR TITLE
fix(macos): resolve Swift 6 concurrency errors in cursor blink observer

### DIFF
--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -160,10 +160,12 @@ final class EditorNSView: MTKView {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            if SystemBlinkTiming.blinkingDisabled {
-                self?.stopCursorBlink()
-            } else {
-                self?.resetCursorBlink()
+            MainActor.assumeIsolated {
+                if SystemBlinkTiming.blinkingDisabled {
+                    self?.stopCursorBlink()
+                } else {
+                    self?.resetCursorBlink()
+                }
             }
         }
     }


### PR DESCRIPTION
## What

PR #1006 (cursor blink) introduced 3 Swift 6 strict concurrency compile errors that break the "Swift (macOS GUI)" CI step on every open PR and on main itself.

## Errors

All three in `EditorNSView.observeAccessibilityChanges()`:
1. `main actor-isolated static property 'blinkingDisabled' can not be referenced from a Sendable closure`
2. `call to main actor-isolated instance method 'stopCursorBlink()' in a synchronous nonisolated context`
3. `call to main actor-isolated instance method 'resetCursorBlink()' in a synchronous nonisolated context`

## Fix

Wrap the NotificationCenter observer closure body in `MainActor.assumeIsolated { }`. This is the idiomatic Swift 6 pattern for closures guaranteed to run on the main thread (registered with `queue: .main`) but whose `@Sendable` requirement prevents the compiler from proving it statically. Same pattern already used in `MingaWindow.swift:49`.

## Impact

Unblocks all 9 open PRs (#1012-#1021) whose Swift CI step was failing with these compile errors.

## Testing

426 Swift tests pass.