### PR TITLE
fix(port): blank screen on macOS GUI launch

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -16,3 +16,25 @@ port_mode =
   end
 
 config :minga, port_mode: port_mode
+
+# Connected mode means the GUI app spawned us. Start the editor with
+# the GUI backend so the supervision tree boots Port.Manager, Editor,
+# and the parser. Without this, the BEAM process sits idle and the
+# Swift frontend sees only its default (empty) SwiftUI state.
+#
+# The default Erlang logger handler writes to :standard_io (stdout).
+# In connected mode, stdout is the binary protocol pipe to the Swift
+# frontend. Unframed log text would corrupt the {:packet, 4} protocol
+# stream, causing unknownOpcode decode errors on the Swift side.
+#
+# Redirect the default handler to the Minga log file. This matches
+# what LoggerHandler.install() does later during Editor.init, but
+# covers the startup window before the Editor is running.
+if port_mode == :connected do
+  config :minga, start_editor: true, backend: :gui
+
+  log_dir = Path.expand("~/.local/share/minga")
+  File.mkdir_p!(log_dir)
+  log_path = Path.join(log_dir, "minga.log")
+  config :logger, :default_handler, config: [type: {:file, String.to_charlist(log_path)}]
+end

--- a/lib/minga/port/manager.ex
+++ b/lib/minga/port/manager.ex
@@ -113,7 +113,23 @@ defmodule Minga.Port.Manager do
   def handle_call({:subscribe, pid}, _from, state) do
     Process.monitor(pid)
     subscribers = [pid | state.subscribers] |> Enum.uniq()
-    {:reply, :ok, %{state | subscribers: subscribers}}
+    new_state = %{state | subscribers: subscribers}
+
+    # Replay the ready event to late subscribers. In connected mode
+    # (GUI frontend), the frontend may send the ready event before any
+    # subscriber registers. The event gets broadcast to an empty list
+    # and is lost. Replaying it here ensures the Editor always receives
+    # the initial dimensions and capabilities regardless of startup
+    # ordering.
+    case new_state do
+      %{ready: true, terminal_size: {width, height}} ->
+        send(pid, {:minga_input, {:ready, width, height}})
+
+      _ ->
+        :ok
+    end
+
+    {:reply, :ok, new_state}
   end
 
   def handle_call(:terminal_size, _from, state) do

--- a/test/minga/port/manager_test.exs
+++ b/test/minga/port/manager_test.exs
@@ -148,6 +148,78 @@ defmodule Minga.Port.ManagerTest do
     end
   end
 
+  describe "ready event replay on late subscribe" do
+    test "late subscriber receives replayed ready event" do
+      name = unique_name()
+      pid = start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
+
+      # Ready event arrives with no subscribers
+      ready_payload = <<0x03, 80::16, 24::16>>
+      send(pid, {nil, {:data, ready_payload}})
+      _ = :sys.get_state(pid)
+
+      # Subscribe after ready was already processed
+      :ok = Manager.subscribe(name)
+
+      assert_receive {:minga_input, {:ready, 80, 24}}
+    end
+
+    test "replayed ready uses current terminal size, not stale" do
+      name = unique_name()
+      pid = start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
+
+      # Ready at 80x24, then resize to 120x40
+      send(pid, {nil, {:data, <<0x03, 80::16, 24::16>>}})
+      _ = :sys.get_state(pid)
+      send(pid, {nil, {:data, <<0x02, 120::16, 40::16>>}})
+      _ = :sys.get_state(pid)
+
+      :ok = Manager.subscribe(name)
+
+      # Should receive the current size (120x40), not the original (80x24)
+      assert_receive {:minga_input, {:ready, 120, 40}}
+      refute_receive {:minga_input, {:ready, 80, 24}}, 50
+    end
+
+    test "no spurious ready when port is not yet ready" do
+      name = unique_name()
+      start_supervised!({Manager, name: name, renderer_path: "/nonexistent"}, id: name)
+
+      :ok = Manager.subscribe(name)
+
+      refute_receive {:minga_input, {:ready, _, _}}, 50
+    end
+
+    test "late subscriber in connected mode receives replayed ready" do
+      name = unique_name()
+      {pid, fake_port} = start_connected(name)
+
+      # Ready arrives before any subscribers
+      ready_payload = <<0x03, 80::16, 24::16>>
+      send(pid, {fake_port, {:data, ready_payload}})
+      _ = :sys.get_state(pid)
+
+      :ok = Manager.subscribe(name)
+
+      assert_receive {:minga_input, {:ready, 80, 24}}
+    end
+
+    test "no replay after port EOF clears ready state" do
+      name = unique_name()
+      {pid, fake_port} = start_connected(name)
+
+      # Ready, then EOF (GUI parent exited)
+      send(pid, {fake_port, {:data, <<0x03, 80::16, 24::16>>}})
+      _ = :sys.get_state(pid)
+      send(pid, {fake_port, :eof})
+      _ = :sys.get_state(pid)
+
+      :ok = Manager.subscribe(name)
+
+      refute_receive {:minga_input, {:ready, _, _}}, 50
+    end
+  end
+
   describe "subscriber cleanup" do
     test "removes subscriber when it exits" do
       name = unique_name()


### PR DESCRIPTION
## Problem

Opening Minga.app (built with `MIX_ENV=prod mix app.assemble`) showed a completely blank screen with only default SwiftUI status bar values (Ln 1, Col 1, NORMAL).

## Root Causes

Three independent issues prevented the macOS GUI app from rendering:

### 1. Editor never started
`config/runtime.exs` detected `MINGA_PORT_MODE=connected` (set by the Swift app when spawning the BEAM) but never set `start_editor: true` or `backend: :gui`. The BEAM booted its supervision tree but skipped the editor runtime entirely, sitting idle while the Swift frontend showed default SwiftUI state.

### 2. Logger corrupted protocol pipe
The default Erlang logger handler writes to `:standard_io` (stdout). In connected mode, stdout is the binary protocol pipe to the Swift frontend. Unframed log text injected into the `{:packet, 4}` stream caused `unknownOpcode(0)` decode errors on the Swift side, preventing any protocol communication.

### 3. Ready event race condition
The Swift frontend could send the `ready` event before the Editor GenServer subscribed to Port.Manager. With `rest_for_one` supervision (Parser -> Port -> Editor), Port.Manager processes the ready event and broadcasts to an empty subscriber list. The Editor never receives it and never renders.

## Fixes

- **`config/runtime.exs`**: When `port_mode == :connected`, set `start_editor: true`, `backend: :gui`, and redirect the default logger to `~/.local/share/minga/minga.log`
- **`lib/minga/port/manager.ex`**: Replay the ready event to late subscribers when `state.ready` is already true
- **5 new tests** covering ready-replay behavior (late subscribe, stale size, spurious replay, connected mode, EOF)