### PR TITLE
feat(git): wire git pull command + async push/pull/fetch operations

### DIFF
--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -955,8 +955,8 @@ defmodule Minga.Editor do
 
   # Process died. Check agent session first, then buffer monitors.
   def handle_info({:DOWN, ref, :process, pid, reason}, state) do
-    cond do
-      AgentAccess.session(state) == pid and AgentAccess.agent(state).session_monitor == ref ->
+    case classify_down(state, ref, pid) do
+      :agent_session ->
         Minga.Log.error(
           :agent,
           "[Agent] Session #{inspect(pid)} terminated: #{inspect(reason, pretty: true, limit: 500)}"
@@ -966,12 +966,15 @@ defmodule Minga.Editor do
         state = %{state | status_msg: "Agent session terminated, SPC a n to restart"}
         {:noreply, state}
 
-      Map.has_key?(state.buffer_monitors, pid) ->
+      :buffer ->
         Minga.Log.info(:editor, "Buffer process #{inspect(pid)} died, removing from state")
         state = EditorState.remove_dead_buffer(state, pid)
         {:noreply, Renderer.render(state)}
 
-      true ->
+      {:git_remote_task, updated_state} ->
+        {:noreply, Renderer.render(updated_state)}
+
+      :unknown ->
         {:noreply, state}
     end
   end
@@ -1024,6 +1027,13 @@ defmodule Minga.Editor do
     # Save session state on every file save
     send(self(), :save_session)
     {:noreply, state}
+  end
+
+  # ── Async git remote operations ─────────────────────────────────────────────
+
+  def handle_info({:git_remote_result, ref, result}, state) when is_reference(ref) do
+    state = Commands.Git.handle_remote_result(state, ref, result)
+    {:noreply, Renderer.render(state)}
   end
 
   # ── Tool manager events ────────────────────────────────────────────────────
@@ -1104,6 +1114,29 @@ defmodule Minga.Editor do
 
   def handle_info(_msg, state) do
     {:noreply, state}
+  end
+
+  # ── :DOWN classifier ────────────────────────────────────────────────────────
+
+  @spec classify_down(EditorState.t(), reference(), pid()) ::
+          :agent_session | :buffer | {:git_remote_task, EditorState.t()} | :unknown
+  defp classify_down(state, ref, pid) do
+    agent_pid = AgentAccess.session(state)
+    agent_monitor = AgentAccess.agent(state).session_monitor
+
+    case {agent_pid == pid and agent_monitor == ref, Map.has_key?(state.buffer_monitors, pid)} do
+      {true, _} ->
+        :agent_session
+
+      {_, true} ->
+        :buffer
+
+      _ ->
+        case Commands.Git.handle_remote_task_down(state, ref) do
+          :not_matched -> :unknown
+          updated_state -> {:git_remote_task, updated_state}
+        end
+    end
   end
 
   # ── LSP response dispatch ──────────────────────────────────────────────────

--- a/lib/minga/editor/commands/git.ex
+++ b/lib/minga/editor/commands/git.ex
@@ -1,6 +1,7 @@
 defmodule Minga.Editor.Commands.Git do
   @moduledoc """
-  Git hunk operations: navigation, stage, revert, preview, and blame.
+  Git commands: status panel, remote operations (push/pull/fetch), diff view,
+  branch picker, hunk navigation, stage, revert, preview, and blame.
   """
 
   @behaviour Minga.Command.Provider
@@ -24,6 +25,7 @@ defmodule Minga.Editor.Commands.Git do
     {:git_changed_files, "Changed files", false},
     {:git_branch_picker, "Switch branch", false},
     {:git_push, "Push", false},
+    {:git_pull, "Pull", false},
     {:git_fetch, "Fetch", false},
     {:git_diff_file, "View diff", true},
     {:next_git_hunk, "Next git hunk", true},
@@ -57,11 +59,15 @@ defmodule Minga.Editor.Commands.Git do
   end
 
   def execute(state, :git_push) do
-    git_remote_action(state, &Git.push/1, "Pushing...", "Pushed", "Push failed")
+    git_remote_action(state, &Git.push/1, "Pushing…", "Pushed", "Push failed")
+  end
+
+  def execute(state, :git_pull) do
+    git_remote_action(state, &Git.pull/1, "Pulling…", "Pulled", "Pull failed")
   end
 
   def execute(state, :git_fetch) do
-    git_remote_action(state, &Git.fetch_remotes/1, "Fetching...", "Fetched", "Fetch failed")
+    git_remote_action(state, &Git.fetch_remotes/1, "Fetching…", "Fetched", "Fetch failed")
   end
 
   # ── Diff view ──────────────────────────────────────────────────────────────
@@ -196,6 +202,54 @@ defmodule Minga.Editor.Commands.Git do
     end
   end
 
+  @doc """
+  Handles the result of an async git remote operation.
+
+  Called by `Minga.Editor.handle_info/2` when a `{:git_remote_result, ref, result}`
+  message arrives. Matches the ref against the in-flight operation to ignore stale
+  results, then updates the status bar and refreshes the git repo.
+  """
+  @spec handle_remote_result(state(), reference(), :ok | {:error, String.t()}) :: state()
+  def handle_remote_result(state, ref, result) do
+    case state.git_remote_op do
+      {^ref, task_monitor, {git_root, success_msg, error_prefix}} ->
+        Process.demonitor(task_monitor, [:flush])
+
+        status_msg =
+          case result do
+            :ok ->
+              refresh_repo(git_root)
+              success_msg
+
+            {:error, reason} ->
+              "#{error_prefix}: #{reason}"
+          end
+
+        %{state | git_remote_op: nil, status_msg: status_msg}
+
+      _ ->
+        # Stale result from a superseded operation; ignore
+        state
+    end
+  end
+
+  @doc """
+  Handles the `:DOWN` message when an async git remote task crashes.
+
+  Clears the in-flight operation so future remote operations aren't
+  permanently blocked. Called by the Editor's `:DOWN` handler.
+  """
+  @spec handle_remote_task_down(state(), reference()) :: state() | :not_matched
+  def handle_remote_task_down(state, monitor_ref) do
+    case state.git_remote_op do
+      {_msg_ref, ^monitor_ref, _context} ->
+        %{state | git_remote_op: nil, status_msg: "Git operation failed unexpectedly"}
+
+      _ ->
+        :not_matched
+    end
+  end
+
   @spec git_remote_action(
           state(),
           (String.t() -> :ok | {:error, String.t()}),
@@ -204,18 +258,30 @@ defmodule Minga.Editor.Commands.Git do
           String.t()
         ) ::
           state()
-  defp git_remote_action(state, operation, _progress_msg, success_msg, error_prefix) do
+  defp git_remote_action(state, _operation, _progress_msg, _success_msg, _error_prefix)
+       when state.git_remote_op != nil do
+    %{state | status_msg: "Git operation already in progress"}
+  end
+
+  defp git_remote_action(state, operation, progress_msg, success_msg, error_prefix) do
     case Git.root_for(Minga.Project.resolve_root()) do
       {:ok, git_root} ->
-        # Run synchronously for now; async with progress feedback is a future enhancement
-        case operation.(git_root) do
-          :ok ->
-            refresh_repo(git_root)
-            %{state | status_msg: success_msg}
+        ref = make_ref()
+        editor_pid = self()
 
-          {:error, reason} ->
-            %{state | status_msg: "#{error_prefix}: #{reason}"}
-        end
+        {:ok, task_pid} =
+          Task.start(fn ->
+            result = operation.(git_root)
+            send(editor_pid, {:git_remote_result, ref, result})
+          end)
+
+        task_monitor = Process.monitor(task_pid)
+
+        %{
+          state
+          | git_remote_op: {ref, task_monitor, {git_root, success_msg, error_prefix}},
+            status_msg: progress_msg
+        }
 
       :not_git ->
         %{state | status_msg: "Not in a git repository"}

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -113,6 +113,7 @@ defmodule Minga.Editor.State do
             windows: %Windows{},
             file_tree: %FileTreeState{},
             git_status_panel: nil,
+            git_remote_op: nil,
             lsp_status: :none,
             parser_status: :available,
             hover_popup: nil,
@@ -173,6 +174,10 @@ defmodule Minga.Editor.State do
           windows: Windows.t(),
           file_tree: FileTreeState.t(),
           git_status_panel: Minga.Port.Protocol.GUI.git_status_data() | nil,
+          git_remote_op:
+            {msg_ref :: reference(), task_monitor :: reference(),
+             {git_root :: String.t(), success_msg :: String.t(), error_prefix :: String.t()}}
+            | nil,
           lsp_status: Minga.Editor.Modeline.lsp_status(),
           parser_status: Minga.Editor.Modeline.parser_status(),
           hover_popup: Minga.Editor.HoverPopup.t() | nil,

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -105,11 +105,12 @@ defmodule Minga.Keymap.Defaults do
     {[{?g, @none}, {?f, @none}], :git_changed_files, "Changed files"},
     {[{?g, @none}, {?B, @none}], :git_branch_picker, "Switch branch"},
     {[{?g, @none}, {?P, @none}], :git_push, "Push"},
+    {[{?g, @none}, {?p, @none}], :git_pull, "Pull"},
     {[{?g, @none}, {?F, @none}], :git_fetch, "Fetch"},
     {[{?g, @none}, {?d, @none}], :git_diff_file, "View diff"},
     {[{?g, @none}, {?s, @none}], :git_stage_hunk, "Stage hunk"},
     {[{?g, @none}, {?r, @none}], :git_revert_hunk, "Revert hunk"},
-    {[{?g, @none}, {?p, @none}], :git_preview_hunk, "Preview hunk"},
+    {[{?g, @none}, {?v, @none}], :git_preview_hunk, "Preview hunk"},
     {[{?g, @none}, {?b, @none}], :git_blame_line, "Blame line"},
 
     # ── Project ────────────────────────────────────────────────────────────────

--- a/test/minga/editor/commands/git_remote_test.exs
+++ b/test/minga/editor/commands/git_remote_test.exs
@@ -1,0 +1,252 @@
+defmodule Minga.Editor.Commands.GitRemoteTest do
+  @moduledoc """
+  Tests for async git remote operations (push/pull/fetch) and the
+  `:git_pull` command wiring.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Editor
+  alias Minga.Editor.Commands.Git, as: GitCommands
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.Viewport
+
+  # ── Helpers ──────────────────────────────────────────────────────────────
+
+  defp build_state(overrides) do
+    Map.merge(
+      %EditorState{port_manager: nil, viewport: Viewport.new(80, 24)},
+      overrides
+    )
+  end
+
+  defp start_editor(content \\ "") do
+    {:ok, buffer} = BufferServer.start_link(content: content)
+
+    {:ok, editor} =
+      Editor.start_link(
+        name: :"editor_#{:erlang.unique_integer([:positive])}",
+        port_manager: nil,
+        buffer: buffer,
+        width: 40,
+        height: 10
+      )
+
+    {editor, buffer}
+  end
+
+  defp get_state(editor), do: :sys.get_state(editor)
+
+  # Build a git_remote_op tuple with a fake monitor ref for unit tests.
+  # Integration tests that go through the Editor GenServer use real monitors.
+  defp make_remote_op(msg_ref, context) do
+    fake_monitor = make_ref()
+    {msg_ref, fake_monitor, context}
+  end
+
+  # ── Command registration ────────────────────────────────────────────────
+
+  describe "command registration" do
+    test "git_pull is registered as a command" do
+      commands = GitCommands.__commands__()
+      names = Enum.map(commands, & &1.name)
+
+      assert :git_pull in names
+    end
+
+    test "git_push is registered as a command" do
+      commands = GitCommands.__commands__()
+      names = Enum.map(commands, & &1.name)
+
+      assert :git_push in names
+    end
+
+    test "git_fetch is registered as a command" do
+      commands = GitCommands.__commands__()
+      names = Enum.map(commands, & &1.name)
+
+      assert :git_fetch in names
+    end
+  end
+
+  # ── handle_remote_result/3 ─────────────────────────────────────────────
+
+  describe "handle_remote_result/3" do
+    test "sets success message and clears git_remote_op on matching ref" do
+      ref = make_ref()
+      op = make_remote_op(ref, {"/tmp/repo", "Pushed", "Push failed"})
+      state = build_state(%{git_remote_op: op})
+
+      result = GitCommands.handle_remote_result(state, ref, :ok)
+
+      assert result.status_msg == "Pushed"
+      assert result.git_remote_op == nil
+    end
+
+    test "sets error message on matching ref with error result" do
+      ref = make_ref()
+      op = make_remote_op(ref, {"/tmp/repo", "Pushed", "Push failed"})
+      state = build_state(%{git_remote_op: op})
+
+      result = GitCommands.handle_remote_result(state, ref, {:error, "rejected"})
+
+      assert result.status_msg == "Push failed: rejected"
+      assert result.git_remote_op == nil
+    end
+
+    test "ignores stale results with non-matching ref" do
+      current_ref = make_ref()
+      stale_ref = make_ref()
+      op = make_remote_op(current_ref, {"/tmp/repo", "Pushed", "Push failed"})
+
+      state = build_state(%{git_remote_op: op, status_msg: "Pushing…"})
+
+      result = GitCommands.handle_remote_result(state, stale_ref, :ok)
+
+      assert result.status_msg == "Pushing…"
+      assert result.git_remote_op == op
+    end
+
+    test "ignores result when no operation is in flight" do
+      ref = make_ref()
+      state = build_state(%{git_remote_op: nil, status_msg: nil})
+
+      result = GitCommands.handle_remote_result(state, ref, :ok)
+
+      assert result.git_remote_op == nil
+      assert result.status_msg == nil
+    end
+  end
+
+  # ── handle_remote_task_down/2 ──────────────────────────────────────────
+
+  describe "handle_remote_task_down/2" do
+    test "clears git_remote_op when task monitor matches" do
+      msg_ref = make_ref()
+      task_monitor = make_ref()
+      op = {msg_ref, task_monitor, {"/tmp/repo", "Pushed", "Push failed"}}
+      state = build_state(%{git_remote_op: op, status_msg: "Pushing…"})
+
+      result = GitCommands.handle_remote_task_down(state, task_monitor)
+
+      assert result.git_remote_op == nil
+      assert result.status_msg == "Git operation failed unexpectedly"
+    end
+
+    test "returns :not_matched when monitor ref doesn't match" do
+      msg_ref = make_ref()
+      task_monitor = make_ref()
+      unrelated_monitor = make_ref()
+      op = {msg_ref, task_monitor, {"/tmp/repo", "Pushed", "Push failed"}}
+      state = build_state(%{git_remote_op: op})
+
+      assert GitCommands.handle_remote_task_down(state, unrelated_monitor) == :not_matched
+    end
+
+    test "returns :not_matched when no operation is in flight" do
+      state = build_state(%{git_remote_op: nil})
+
+      assert GitCommands.handle_remote_task_down(state, make_ref()) == :not_matched
+    end
+  end
+
+  # ── Async integration via Editor GenServer ─────────────────────────────
+
+  describe "async git remote result via Editor" do
+    test "Editor handles {:git_remote_result, ref, :ok} message" do
+      {editor, _buffer} = start_editor()
+      ref = make_ref()
+      task_monitor = make_ref()
+
+      :sys.replace_state(editor, fn state ->
+        %{state | git_remote_op: {ref, task_monitor, {"/tmp/repo", "Fetched", "Fetch failed"}}}
+      end)
+
+      send(editor, {:git_remote_result, ref, :ok})
+      state = get_state(editor)
+
+      assert state.status_msg == "Fetched"
+      assert state.git_remote_op == nil
+    end
+
+    test "Editor handles {:git_remote_result, ref, {:error, reason}} message" do
+      {editor, _buffer} = start_editor()
+      ref = make_ref()
+      task_monitor = make_ref()
+
+      :sys.replace_state(editor, fn state ->
+        %{state | git_remote_op: {ref, task_monitor, {"/tmp/repo", "Pulled", "Pull failed"}}}
+      end)
+
+      send(editor, {:git_remote_result, ref, {:error, "merge conflict"}})
+      state = get_state(editor)
+
+      assert state.status_msg == "Pull failed: merge conflict"
+      assert state.git_remote_op == nil
+    end
+
+    test "Editor clears git_remote_op when task crashes via :DOWN" do
+      {editor, _buffer} = start_editor()
+      ref = make_ref()
+      task_monitor = make_ref()
+      # Spawn a short-lived process just to get a real pid for the :DOWN message
+      fake_pid = spawn(fn -> :ok end)
+
+      :sys.replace_state(editor, fn state ->
+        %{state | git_remote_op: {ref, task_monitor, {"/tmp/repo", "Pushed", "Push failed"}}}
+      end)
+
+      # Simulate the :DOWN the BEAM would send when the monitored task crashes
+      send(editor, {:DOWN, task_monitor, :process, fake_pid, :killed})
+      _ = :sys.get_state(editor)
+
+      state = get_state(editor)
+      assert state.git_remote_op == nil
+      assert state.status_msg == "Git operation failed unexpectedly"
+    end
+
+    test "stale :DOWN after successful result is a no-op" do
+      {editor, _buffer} = start_editor()
+      ref = make_ref()
+      task_monitor = make_ref()
+      fake_pid = spawn(fn -> :ok end)
+
+      :sys.replace_state(editor, fn state ->
+        %{state | git_remote_op: {ref, task_monitor, {"/tmp/repo", "Fetched", "Fetch failed"}}}
+      end)
+
+      # Result arrives first and clears the op (with demonitor+flush in production)
+      send(editor, {:git_remote_result, ref, :ok})
+      _ = :sys.get_state(editor)
+
+      assert get_state(editor).git_remote_op == nil
+      assert get_state(editor).status_msg == "Fetched"
+
+      # A stale :DOWN arrives after (in production, demonitor(:flush) prevents this,
+      # but if it slips through, it should be harmless)
+      send(editor, {:DOWN, task_monitor, :process, fake_pid, :normal})
+      _ = :sys.get_state(editor)
+
+      state = get_state(editor)
+      # Op stays nil, status_msg unchanged (not overwritten with crash message)
+      assert state.git_remote_op == nil
+      assert state.status_msg == "Fetched"
+    end
+  end
+
+  # ── Concurrent operation guard ─────────────────────────────────────────
+
+  describe "concurrent operation guard" do
+    test "rejects remote action when operation already in flight" do
+      ref = make_ref()
+      op = make_remote_op(ref, {"/tmp/repo", "Pushed", "Push failed"})
+
+      state = build_state(%{git_remote_op: op, status_msg: "Pushing…"})
+
+      result = GitCommands.execute(state, :git_pull)
+
+      assert result.status_msg == "Git operation already in progress"
+      assert result.git_remote_op == op
+    end
+  end
+end


### PR DESCRIPTION
## What

Wires the existing `Git.pull/2` backend as a user-facing command and converts all remote operations (push/pull/fetch) from synchronous to async. This was the biggest gap found during the #1022 audit: pull had a full backend implementation but was never surfaced to users, and all three remote ops blocked the Editor GenServer during network I/O.

Closes #1028

## Changes

### Wire git pull command
- Add `:git_pull` to `@command_specs` in `Commands.Git`
- Add `SPC g p` keybinding (moved `:git_preview_hunk` to `SPC g v` to resolve conflict)
- `execute(state, :git_pull)` calls `git_remote_action/5` with `&Git.pull/1`

### Async remote operations
- `git_remote_action/5` spawns a `Task.start` that runs the git operation and sends `{:git_remote_result, ref, result}` back to the Editor
- Progress message shown immediately ('Pushing…', 'Pulling…', 'Fetching…')
- Task pid is monitored via `Process.monitor` so crashes clear the in-flight state (prevents permanently blocking future operations)
- Guard clause rejects concurrent operations ('Git operation already in progress')
- `handle_remote_result/3` matches the ref, demonitors the task, sets success/error message
- `handle_remote_task_down/2` handles the crash case via the Editor's `:DOWN` dispatch

### Code quality
- Refactored pre-existing `cond` in `:DOWN` handler to `case` + `classify_down/3` helper (per project coding standards)
- Added `git_remote_op` field to `EditorState` with full type annotation

## Keybinding change

| Before | After |
|--------|-------|
| `SPC g p` → `:git_preview_hunk` | `SPC g p` → `:git_pull` |
| (none) | `SPC g v` → `:git_preview_hunk` |

## Tests

15 new tests in `test/minga/editor/commands/git_remote_test.exs`:
- Command registration (3): pull, push, fetch registered
- `handle_remote_result/3` (4): success, error, stale ref ignored, nil op ignored
- `handle_remote_task_down/2` (3): matching monitor, non-matching, nil op
- Editor GenServer integration (4): success message, error message, task crash via :DOWN, stale :DOWN after success
- Concurrent operation guard (1): rejects when op in flight

## Review trail

- **archie**: recommended Task.start + explicit message pattern; caught the silent-crash-permanently-blocks bug that led to the Process.monitor addition
- **test-advisor**: fixed the :DOWN test approach (send synthetic :DOWN instead of trying to make the Editor call Process.monitor from the test process)
- **reviewer**: caught the `SPC g p` keybinding conflict with `:git_preview_hunk`; PASS on second review
- **intent-reviewer**: PASS, all criteria met
- **swift-expert**: recommended GUI UX improvements (spinner, toasts, error recovery actions) captured in autoresearch.ideas.md for follow-up