### PR TITLE
docs(standards): prefer fully qualified module names, disable AliasUsage lint

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -20,7 +20,7 @@
           {Credo.Check.Consistency.TabsOrSpaces, []},
 
           # ── Design ─────────────────────────────────────────────────────────
-          {Credo.Check.Design.AliasUsage, [priority: :low, if_nested_deeper_than: 2]},
+          {Credo.Check.Design.AliasUsage, false},
           {Credo.Check.Design.TagFIXME, []},
           {Credo.Check.Design.TagTODO, [exit_status: 0]},
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,18 @@ Elixir 1.19's set-theoretic type system catches real bugs at compile time. Help 
   5. **Never build a "safe client" wrapper module** that mirrors another module's API with nil-handling and exit-catching added. That's just indirection. The monitor is the real fix; the wrapper hides the problem behind a layer that every caller must remember to use.
 - `mix compile --warnings-as-errors` must pass clean
 
+### Module Aliases (convention, not linted)
+
+Prefer fully qualified module names by default. Aliases add indirection that hurts LLM comprehension: when reading a snippet or diff, the alias block at the top of the file may not be visible, and `Document.insert_text(...)` is ambiguous where `Minga.Buffer.Document.insert_text(...)` is not. Fully qualified names also make grep/search reliable across the codebase.
+
+**Alias when the module path is 4+ segments deep** (e.g., `Minga.Agent.Tools.FileOperations`). At that depth, the fully qualified name eats enough line width to obscure the actual logic. Aliasing to `FileOperations` is a reasonable tradeoff.
+
+**For 2-3 segments** (`Minga.Motion`, `Minga.Buffer.Document`), use the fully qualified name. It's short enough to carry everywhere without readability cost.
+
+**Exception:** if a 3-segment module appears 8+ times in one file and the repetition genuinely hurts human readability, aliasing is fine. But that frequency is also a signal the function may be doing too much or the modules are too tightly coupled.
+
+The `Credo.Check.Design.AliasUsage` lint is disabled. This is a judgment call, not an automated rule.
+
 ### Common Elixir Footguns
 
 LLM agents hit these repeatedly. Read before writing any Elixir:


### PR DESCRIPTION
## What

Disables `Credo.Check.Design.AliasUsage` and documents the convention for when to use aliases vs fully qualified module names.

## Why

Fully qualified module names are better for LLM comprehension. Aliases add indirection that may not be visible in snippets or diffs. `Minga.Buffer.Document.insert_text(...)` is unambiguous at every call site; `Document.insert_text(...)` requires resolving the alias block.

## Convention

- **Default:** fully qualified names
- **Alias at 4+ segments deep** (e.g., `Minga.Agent.Tools.FileOperations`) where the name eats too much line width
- **Exception:** a 3-segment module appearing 8+ times in one file
- Not linted, judgment call

Also updated `minga-org/.credo.exs` and `minga-org/AGENTS.md` to match (in a separate local change).