### PR TITLE
feat(config): namespaced extension config with option/3 DSL macro

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -898,6 +898,15 @@ An extension is a directory containing `.ex` files, with one module that impleme
 defmodule MingaTodo do
   use Minga.Extension
 
+  # Declare typed config options (validated at load time)
+  option :keyword, :string,
+    default: "TODO",
+    description: "The keyword to scan for"
+
+  option :highlight, :boolean,
+    default: true,
+    description: "Highlight TODO lines in the gutter"
+
   @impl true
   def name, do: :minga_todo
 
@@ -915,7 +924,9 @@ defmodule MingaTodo do
 end
 ```
 
-The `use Minga.Extension` macro gives you a default `child_spec/1` that starts a simple Agent holding your config. Override `child_spec/1` if your extension needs a GenServer or a full supervision tree:
+Options declared with `option/3` are validated against their type when the extension loads. Users configure them directly in the extension declaration (see [Loading extensions](#loading-extensions) below). At runtime, read them with `Minga.Config.Options.get_extension_option(:minga_todo, :keyword)`.
+
+The `use Minga.Extension` macro also gives you a default `child_spec/1` that starts a simple Agent holding your config. Override `child_spec/1` if your extension needs a GenServer or a full supervision tree:
 
 ```elixir
 defmodule MingaTodo do
@@ -970,7 +981,15 @@ extension :minga_snippets, git: "https://github.com/user/minga-snippets"
 extension :minga_tools, hex: "minga_tools", version: "~> 0.3"
 ```
 
-Exactly one of `path:`, `git:`, or `hex:` is required. Extra keyword options (everything except the source option) are passed to the extension's `init/1` callback.
+Exactly one of `path:`, `git:`, or `hex:` is required. Extra keyword options (everything except the source and its sub-options like `branch:` or `version:`) are passed to the extension as config. If the extension declares typed options with `option/3`, these values are validated at load time:
+
+```elixir
+# Config options are grouped right in the extension declaration
+extension :minga_org, git: "https://github.com/jsmestad/minga-org",
+  conceal: false,
+  pretty_bullets: true,
+  heading_bullets: ["•", "◦"]
+```
 
 ### Local path extensions
 

--- a/docs/EXTENSION_API.md
+++ b/docs/EXTENSION_API.md
@@ -18,17 +18,30 @@ When a user writes `extension :my_ext, git: "..."` in their config, they're choo
 
 ## The Extension Behaviour
 
-Every extension implements four callbacks. `use Minga.Extension` gives you a default `child_spec/1` (an Agent holding your config). Override it if you need a custom GenServer or supervision tree.
+Every extension implements four callbacks. `use Minga.Extension` gives you a default `child_spec/1` (an Agent holding your config), the `option/3` macro for declaring typed config options, and a generated `__option_schema__/0` function the framework reads at load time. Override `child_spec/1` if you need a custom GenServer or supervision tree.
 
 ```elixir
-defmodule MyExtension do
+defmodule MingaOrg do
   use Minga.Extension
 
-  @impl true
-  def name, do: :my_extension
+  # Declare typed config options (validated at load time)
+  option :conceal, :boolean,
+    default: true,
+    description: "Hide markup delimiters and show styled content"
+
+  option :pretty_bullets, :boolean,
+    default: true,
+    description: "Replace heading stars with Unicode bullets"
+
+  option :heading_bullets, :string_list,
+    default: ["◉", "○", "◈", "◇"],
+    description: "Unicode bullets for heading levels"
 
   @impl true
-  def description, do: "Adds org-mode support"
+  def name, do: :minga_org
+
+  @impl true
+  def description, do: "Org-mode support"
 
   @impl true
   def version, do: "0.1.0"
@@ -36,15 +49,17 @@ defmodule MyExtension do
   @impl true
   def init(config) do
     # config is the keyword list from the user's extension declaration.
-    # This is where you register everything.
-    MyExtension.Commands.register()
-    MyExtension.Keybindings.register()
+    # Options declared above are already validated and stored in ETS.
+    MingaOrg.Commands.register()
+    MingaOrg.Keybindings.register()
     {:ok, %{}}
   end
 end
 ```
 
-**Lifecycle:** The user declares the extension in `config.exs`. Minga compiles it, calls `init/1`, then starts the `child_spec/1` under `Extension.Supervisor`. On config reload (`SPC h r`), all extensions stop and re-load from scratch.
+The `option` macro follows the same pattern as Ecto's `field`: you declare it at the module level, and `use Minga.Extension` generates a `__option_schema__/0` function from the accumulated declarations. You never write the introspection function yourself.
+
+**Lifecycle:** The user declares the extension in `config.exs`. Minga compiles it, validates config options against the schema, calls `init/1`, then starts `child_spec/1` under `Extension.Supervisor`. On config reload (`SPC h r`), all extensions stop and re-load from scratch.
 
 Each extension runs under a `DynamicSupervisor` with `:one_for_one` strategy. If your extension crashes, only your extension restarts. The editor and other extensions keep running.
 
@@ -130,39 +145,66 @@ All advice is wrapped in try/rescue. If your advice function crashes, it logs a 
 
 ## Config Options
 
-Extensions can register typed options that users set in `config.exs`, right alongside built-in options like `:tab_width` and `:theme`. No separate config DSL, no special syntax. Just `set :org_conceal, false`.
+Extension options are declared with the `option/3` macro in your module (see [The Extension Behaviour](#the-extension-behaviour) above) and configured by users in the extension declaration. No flat `set` calls, no namespace collisions, no separate DSL.
+
+**Declaring options** (in your extension module):
 
 ```elixir
-# In your init/1:
-Minga.Config.Options.register_extension_option(:org_conceal, :boolean, true)
-Minga.Config.Options.register_extension_option(
-  :org_heading_bullets, :string_list, ["◉", "○", "◈", "◇"]
-)
+option :conceal, :boolean,
+  default: true,
+  description: "Hide markup delimiters and show styled content"
+
+option :pretty_bullets, :boolean,
+  default: true,
+  description: "Replace heading stars with Unicode bullets"
+
+option :heading_bullets, :string_list,
+  default: ["◉", "○", "◈", "◇"],
+  description: "Unicode bullets for heading levels"
 ```
 
-Users configure these the same way they configure everything else:
+**User configuration** (in `config.exs`, grouped under the extension):
 
 ```elixir
-# In ~/.config/minga/config.exs:
-set :org_conceal, false
-set :org_heading_bullets, ["•", "◦", "▸"]
+extension :minga_org, git: "https://github.com/jsmestad/minga-org",
+  conceal: false,
+  pretty_bullets: true,
+  heading_bullets: ["•", "◦"]
 ```
 
-Values are validated against the registered type. Setting `:org_conceal` to `"yes"` gives a clear error telling the user it must be a boolean. Registering a name that collides with a built-in option returns `{:error, reason}`.
+Values are validated against your declared types at load time. Setting `:conceal` to `"yes"` gives a clear error telling the user it must be a boolean. Unknown keys produce a warning log.
+
+Two extensions can both declare a `:conceal` option without conflict. Options are namespaced under the extension name in ETS.
 
 **Supported types:** `:boolean`, `:pos_integer`, `:non_neg_integer`, `:integer`, `:string`, `:string_or_nil`, `:string_list`, `:atom`, `{:enum, [atoms]}`, `:map_or_nil`, `:any`.
 
-**Reading values:**
+**Reading values at runtime:**
 
 ```elixir
-Minga.Config.Options.get(:org_conceal)
-# => true (or whatever the user set)
+Minga.Config.Options.get_extension_option(:minga_org, :conceal)
+# => false
 
 # With filetype override support:
-Minga.Config.Options.get_for_filetype(:org_conceal, :org)
+Minga.Config.Options.get_extension_option_for_filetype(:minga_org, :conceal, :org)
 ```
 
-**Prefix your option names** to avoid collisions: `:org_conceal`, not `:conceal`.
+**Setting values at runtime** (e.g., from a toggle command):
+
+```elixir
+Minga.Config.Options.set_extension_option(:minga_org, :conceal, false)
+```
+
+**Overriding per filetype** (e.g., disable conceal only for org files):
+
+```elixir
+Minga.Config.Options.set_extension_option_for_filetype(:minga_org, :org, :conceal, false)
+```
+
+**Overriding at runtime** (e.g., from a toggle command):
+
+```elixir
+Minga.Config.Options.set_extension_option(:minga_org, :conceal, false)
+```
 
 ---
 

--- a/lib/minga/config.ex
+++ b/lib/minga/config.ex
@@ -75,6 +75,28 @@ defmodule Minga.Config do
   end
 
   @doc """
+  Sets an extension option at runtime.
+
+  Use this from commands, keybindings, or extension code to change an
+  extension option after load. Not usable in `config.exs` (the schema
+  isn't registered yet at config eval time; use the extension declaration
+  syntax instead).
+
+  ## Examples
+
+      set_extension_option :minga_org, :conceal, false
+      set_extension_option :minga_org, :heading_bullets, ["•", "◦"]
+  """
+  @spec set_extension_option(atom(), atom(), term()) :: :ok
+  def set_extension_option(extension, name, value)
+      when is_atom(extension) and is_atom(name) do
+    case Options.set_extension_option(extension, name, value) do
+      {:ok, _} -> :ok
+      {:error, msg} -> raise ArgumentError, msg
+    end
+  end
+
+  @doc """
   Binds a key sequence to a command in the given mode.
 
   Supports all vim modes: `:normal`, `:insert`, `:visual`,

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -152,20 +152,20 @@ defmodule Minga.Config.Options do
   @typedoc "Option spec: `{name, type_descriptor, default_value}`."
   @type option_spec :: {option_name(), type_descriptor(), term()}
 
-  @typep type_descriptor ::
-           :pos_integer
-           | :non_neg_integer
-           | :integer
-           | :boolean
-           | :atom
-           | {:enum, [atom()]}
-           | :theme_atom
-           | :string
-           | :string_or_nil
-           | :string_list
-           | :map_or_nil
-           | :float_or_nil
-           | :any
+  @type type_descriptor ::
+          :pos_integer
+          | :non_neg_integer
+          | :integer
+          | :boolean
+          | :atom
+          | {:enum, [atom()]}
+          | :theme_atom
+          | :string
+          | :string_or_nil
+          | :string_list
+          | :map_or_nil
+          | :float_or_nil
+          | :any
 
   @typedoc "ETS table reference used for reads and writes."
   @type table :: :ets.table()
@@ -268,77 +268,245 @@ defmodule Minga.Config.Options do
   @doc """
   Registers a typed option for use by an extension.
 
-  Extensions call this during `init/1` to declare options that users can
-  set in their `config.exs` alongside built-in options. The option is
-  immediately available via `get/1` and `set/2`.
+  Registers a full option schema for an extension and validates user
+  config against it. Called by `Extension.Supervisor` at load time,
+  not by extensions directly.
 
-  Returns `:ok` on success or `{:error, reason}` if the name collides
-  with a built-in option.
+  Each spec in the schema is stored under `{:extension, ext_name, opt_name}`
+  in ETS, with type metadata under `{:extension_schema, ext_name}`.
 
-  ## Type descriptors
-
-  Supported type descriptors (same as built-in options):
-
-  - `:boolean` — true/false
-  - `:pos_integer` — positive integer (> 0)
-  - `:non_neg_integer` — non-negative integer (>= 0)
-  - `:string` — binary string
-  - `:string_or_nil` — string or nil
-  - `:string_list` — list of strings
-  - `:atom` — any atom
-  - `{:enum, [atom()]}` — one of the listed atoms
-  - `:map_or_nil` — map or nil
-  - `:any` — no validation
-
-  ## Examples
-
-      # In your extension's init/1:
-      Minga.Config.Options.register_extension_option(:org_conceal, :boolean, true)
-      Minga.Config.Options.register_extension_option(:org_heading_bullets, :string_list, ["◉", "○", "◈", "◇"])
-
-      # Users can then set in config.exs:
-      set :org_conceal, false
+  User config values that match a schema entry are validated and stored.
+  Unknown keys produce a warning log. Type mismatches return an error.
   """
-  @spec register_extension_option(atom(), type_descriptor(), term()) ::
+  @spec register_extension_schema(atom(), [Minga.Extension.option_spec()], keyword()) ::
           :ok | {:error, String.t()}
-  @spec register_extension_option(GenServer.server(), atom(), type_descriptor(), term()) ::
+  @spec register_extension_schema(
+          GenServer.server(),
+          atom(),
+          [Minga.Extension.option_spec()],
+          keyword()
+        ) ::
           :ok | {:error, String.t()}
-  def register_extension_option(name, type, default) when is_atom(name),
-    do: register_extension_option(__MODULE__, name, type, default)
+  def register_extension_schema(ext_name, schema, user_config) when is_atom(ext_name),
+    do: register_extension_schema(__MODULE__, ext_name, schema, user_config)
 
-  def register_extension_option(_server, name, _type, _default)
-      when is_atom(name) and name in @valid_names do
-    {:error,
-     "option #{inspect(name)} conflicts with a built-in option; choose a prefixed name (e.g., :myext_#{name})"}
-  end
-
-  def register_extension_option(server, name, type, default) when is_atom(name) do
+  def register_extension_schema(server, ext_name, schema, user_config)
+      when is_atom(ext_name) and is_list(schema) and is_list(user_config) do
     table = table_name(server)
-    :ets.insert(table, {{:ext_type, name}, type})
-    :ets.insert(table, {{:ext_default, name}, default})
 
-    # Seed the default value only if no user value is set yet
-    case :ets.lookup(table, name) do
-      [{^name, _}] -> :ok
-      [] -> :ets.insert(table, {name, default})
+    # Store the full schema for introspection
+    :ets.insert(table, {{:extension_schema, ext_name}, schema})
+
+    # Register each option with its type, default, and doc
+    for {opt_name, type, default, description} <- schema do
+      :ets.insert(table, {{:extension_type, ext_name, opt_name}, type})
+      :ets.insert(table, {{:extension_default, ext_name, opt_name}, default})
+      :ets.insert(table, {{:extension_description, ext_name, opt_name}, description})
+
+      # Seed the default value
+      key = {:extension, ext_name, opt_name}
+
+      case :ets.lookup(table, key) do
+        [{^key, _}] -> :ok
+        [] -> :ets.insert(table, {key, default})
+      end
     end
 
-    :ok
+    # Validate and apply user config values
+    schema_names = MapSet.new(schema, &elem(&1, 0))
+    validate_and_apply_user_config(table, ext_name, user_config, schema_names)
+  end
+
+  @spec validate_and_apply_user_config(:ets.table(), atom(), keyword(), MapSet.t()) ::
+          :ok | {:error, String.t()}
+  defp validate_and_apply_user_config(table, ext_name, user_config, schema_names) do
+    errors =
+      Enum.reduce(user_config, [], fn {key, value}, errs ->
+        validate_user_config_entry(table, ext_name, key, value, schema_names, errs)
+      end)
+
+    case Enum.reverse(errors) do
+      [] -> :ok
+      [first | _] -> {:error, first}
+    end
+  end
+
+  @spec validate_user_config_entry(:ets.table(), atom(), atom(), term(), MapSet.t(), [String.t()]) ::
+          [String.t()]
+  defp validate_user_config_entry(table, ext_name, key, value, schema_names, errors) do
+    case MapSet.member?(schema_names, key) do
+      true ->
+        apply_validated_config_entry(table, ext_name, key, value, errors)
+
+      false ->
+        Minga.Log.warning(
+          :config,
+          "Extension #{ext_name}: unknown option #{inspect(key)} (ignored)"
+        )
+
+        errors
+    end
+  end
+
+  @spec apply_validated_config_entry(:ets.table(), atom(), atom(), term(), [String.t()]) ::
+          [String.t()]
+  defp apply_validated_config_entry(table, ext_name, key, value, errors) do
+    case validate_extension_value(table, ext_name, key, value) do
+      :ok ->
+        :ets.insert(table, {{:extension, ext_name, key}, value})
+        errors
+
+      {:error, msg} ->
+        [msg | errors]
+    end
   end
 
   @doc """
-  Returns true if the given option name is registered as an extension option.
-  """
-  @spec extension_option?(atom()) :: boolean()
-  @spec extension_option?(GenServer.server(), atom()) :: boolean()
-  def extension_option?(name) when is_atom(name), do: extension_option?(__MODULE__, name)
+  Gets an extension option value, falling back to its registered default.
 
-  def extension_option?(server, name) when is_atom(name) do
+  ## Examples
+
+      Config.Options.get_extension_option(:minga_org, :conceal)
+      # => true
+  """
+  @spec get_extension_option(atom(), atom()) :: term()
+  @spec get_extension_option(GenServer.server(), atom(), atom()) :: term()
+  def get_extension_option(ext_name, opt_name) when is_atom(ext_name) and is_atom(opt_name),
+    do: get_extension_option(__MODULE__, ext_name, opt_name)
+
+  def get_extension_option(server, ext_name, opt_name)
+      when is_atom(ext_name) and is_atom(opt_name) do
+    table = table_name(server)
+    key = {:extension, ext_name, opt_name}
+
+    case :ets.lookup(table, key) do
+      [{^key, value}] -> value
+      [] -> extension_default(table, ext_name, opt_name)
+    end
+  end
+
+  @doc """
+  Sets an extension option value after type validation.
+
+  ## Examples
+
+      Config.Options.set_extension_option(:minga_org, :conceal, false)
+      # => {:ok, false}
+  """
+  @spec set_extension_option(atom(), atom(), term()) :: {:ok, term()} | {:error, String.t()}
+  @spec set_extension_option(GenServer.server(), atom(), atom(), term()) ::
+          {:ok, term()} | {:error, String.t()}
+  def set_extension_option(ext_name, opt_name, value)
+      when is_atom(ext_name) and is_atom(opt_name),
+      do: set_extension_option(__MODULE__, ext_name, opt_name, value)
+
+  def set_extension_option(server, ext_name, opt_name, value)
+      when is_atom(ext_name) and is_atom(opt_name) do
     table = table_name(server)
 
-    case :ets.lookup(table, {:ext_type, name}) do
-      [{_, _}] -> true
-      [] -> false
+    case validate_extension_value(table, ext_name, opt_name, value) do
+      :ok ->
+        :ets.insert(table, {{:extension, ext_name, opt_name}, value})
+        {:ok, value}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  @doc """
+  Sets an extension option override for a specific filetype.
+
+  The value is validated against the extension's registered schema.
+
+  ## Examples
+
+      Config.Options.set_extension_option_for_filetype(:minga_org, :org, :conceal, false)
+  """
+  @spec set_extension_option_for_filetype(atom(), atom(), atom(), term()) ::
+          {:ok, term()} | {:error, String.t()}
+  @spec set_extension_option_for_filetype(GenServer.server(), atom(), atom(), atom(), term()) ::
+          {:ok, term()} | {:error, String.t()}
+  def set_extension_option_for_filetype(ext_name, filetype, opt_name, value)
+      when is_atom(ext_name) and is_atom(filetype) and is_atom(opt_name),
+      do: set_extension_option_for_filetype(__MODULE__, ext_name, filetype, opt_name, value)
+
+  def set_extension_option_for_filetype(server, ext_name, filetype, opt_name, value)
+      when is_atom(ext_name) and is_atom(filetype) and is_atom(opt_name) do
+    table = table_name(server)
+
+    case validate_extension_value(table, ext_name, opt_name, value) do
+      :ok ->
+        :ets.insert(table, {{:filetype, filetype, {:extension, ext_name, opt_name}}, value})
+        {:ok, value}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  @doc """
+  Gets an extension option with filetype override applied.
+
+  Checks filetype-specific override first, then falls back to the
+  global extension option value.
+  """
+  @spec get_extension_option_for_filetype(atom(), atom(), atom() | nil) :: term()
+  @spec get_extension_option_for_filetype(GenServer.server(), atom(), atom(), atom() | nil) ::
+          term()
+  def get_extension_option_for_filetype(ext_name, opt_name, filetype),
+    do: get_extension_option_for_filetype(__MODULE__, ext_name, opt_name, filetype)
+
+  def get_extension_option_for_filetype(server, ext_name, opt_name, nil),
+    do: get_extension_option(server, ext_name, opt_name)
+
+  def get_extension_option_for_filetype(server, ext_name, opt_name, filetype)
+      when is_atom(ext_name) and is_atom(opt_name) and is_atom(filetype) do
+    table = table_name(server)
+    ft_key = {:filetype, filetype, {:extension, ext_name, opt_name}}
+
+    case :ets.lookup(table, ft_key) do
+      [{^ft_key, value}] -> value
+      [] -> get_extension_option(server, ext_name, opt_name)
+    end
+  end
+
+  @doc """
+  Returns the registered option schema for an extension, or `nil` if
+  the extension has no schema.
+  """
+  @spec extension_schema(atom()) :: [Minga.Extension.option_spec()] | nil
+  @spec extension_schema(GenServer.server(), atom()) :: [Minga.Extension.option_spec()] | nil
+  def extension_schema(ext_name) when is_atom(ext_name),
+    do: extension_schema(__MODULE__, ext_name)
+
+  def extension_schema(server, ext_name) when is_atom(ext_name) do
+    table = table_name(server)
+
+    case :ets.lookup(table, {:extension_schema, ext_name}) do
+      [{_, schema}] -> schema
+      [] -> nil
+    end
+  end
+
+  @doc """
+  Returns the description string for an extension option, or `nil` if
+  not found.
+
+  Used by `SPC h v` (describe option) and other introspection features.
+  """
+  @spec extension_option_description(atom(), atom()) :: String.t() | nil
+  @spec extension_option_description(GenServer.server(), atom(), atom()) :: String.t() | nil
+  def extension_option_description(ext_name, opt_name),
+    do: extension_option_description(__MODULE__, ext_name, opt_name)
+
+  def extension_option_description(server, ext_name, opt_name)
+      when is_atom(ext_name) and is_atom(opt_name) do
+    table = table_name(server)
+
+    case :ets.lookup(table, {:extension_description, ext_name, opt_name}) do
+      [{_, description}] -> description
+      [] -> nil
     end
   end
 
@@ -377,7 +545,7 @@ defmodule Minga.Config.Options do
 
     case :ets.lookup(table, name) do
       [{^name, value}] -> value
-      [] -> builtin_or_extension_default(table, name)
+      [] -> Map.get(@defaults, name)
     end
   end
 
@@ -486,24 +654,13 @@ defmodule Minga.Config.Options do
   def validate_option(name, value), do: validate(__MODULE__, name, value)
 
   @spec validate(GenServer.server(), atom(), term()) :: :ok | {:error, String.t()}
-  defp validate(server, name, value) do
+  defp validate(_server, name, value) do
     case Map.fetch(@types, name) do
       {:ok, type} ->
         validate_type(type, name, value)
 
       :error ->
-        validate_extension_option(server, name, value)
-    end
-  end
-
-  @spec validate_extension_option(GenServer.server(), atom(), term()) ::
-          :ok | {:error, String.t()}
-  defp validate_extension_option(server, name, value) do
-    table = table_name(server)
-
-    case :ets.lookup(table, {:ext_type, name}) do
-      [{_, type}] -> validate_type(type, name, value)
-      [] -> {:error, "unknown option: #{inspect(name)}"}
+        {:error, "unknown option: #{inspect(name)}"}
     end
   end
 
@@ -610,17 +767,20 @@ defmodule Minga.Config.Options do
 
   # ── Private helpers ─────────────────────────────────────────────────────────
 
-  @spec builtin_or_extension_default(:ets.table(), atom()) :: term() | nil
-  defp builtin_or_extension_default(table, name) do
-    case Map.fetch(@defaults, name) do
-      {:ok, default} ->
-        default
+  @spec extension_default(:ets.table(), atom(), atom()) :: term() | nil
+  defp extension_default(table, ext_name, opt_name) do
+    case :ets.lookup(table, {:extension_default, ext_name, opt_name}) do
+      [{_, default}] -> default
+      [] -> nil
+    end
+  end
 
-      :error ->
-        case :ets.lookup(table, {:ext_default, name}) do
-          [{_, default}] -> default
-          [] -> nil
-        end
+  @spec validate_extension_value(:ets.table(), atom(), atom(), term()) ::
+          :ok | {:error, String.t()}
+  defp validate_extension_value(table, ext_name, opt_name, value) do
+    case :ets.lookup(table, {:extension_type, ext_name, opt_name}) do
+      [{_, type}] -> validate_type(type, opt_name, value)
+      [] -> {:error, "extension #{ext_name}: unknown option #{inspect(opt_name)}"}
     end
   end
 

--- a/lib/minga/extension.ex
+++ b/lib/minga/extension.ex
@@ -1,6 +1,6 @@
 defmodule Minga.Extension do
   @moduledoc """
-  Behaviour for Minga editor extensions.
+  Behaviour and DSL for Minga editor extensions.
 
   Extensions are self-contained Elixir modules that add functionality to
   the editor. Each extension runs under its own supervisor, so a crash in
@@ -8,22 +8,38 @@ defmodule Minga.Extension do
 
   ## Implementing an extension
 
-      defmodule MyExtension do
+      defmodule MingaOrg do
         use Minga.Extension
 
-        @impl true
-        def name, do: :my_extension
+        option :conceal, :boolean,
+          default: true,
+          description: "Hide markup delimiters and show styled content"
+
+        option :pretty_bullets, :boolean,
+          default: true,
+          description: "Replace heading stars with Unicode bullets"
+
+        option :heading_bullets, :string_list,
+          default: ["◉", "○", "◈", "◇"],
+          description: "Unicode bullets for heading levels (cycles when depth exceeds list)"
+
+        option :todo_keywords, :string_list,
+          default: ["TODO", "DONE"],
+          description: "TODO keyword cycle sequence"
 
         @impl true
-        def description, do: "Does something useful"
+        def name, do: :minga_org
+
+        @impl true
+        def description, do: "Org-mode support"
 
         @impl true
         def version, do: "0.1.0"
 
         @impl true
         def init(config) do
-          # config is the keyword list from the extension declaration
-          {:ok, %{greeting: Keyword.get(config, :greeting, "hello")}}
+          todo_keywords = Keyword.get(config, :todo_keywords, ["TODO", "DONE"])
+          {:ok, %{todo_keywords: todo_keywords}}
         end
       end
 
@@ -31,15 +47,26 @@ defmodule Minga.Extension do
 
       use Minga.Config
 
-      extension :my_extension, path: "~/code/my_extension"
-      extension :greeter, path: "~/code/greeter", greeting: "howdy"
+      extension :minga_org, git: "https://github.com/jsmestad/minga-org",
+        conceal: false,
+        pretty_bullets: true
+
+  Options declared with `option/3` are validated against their type at
+  load time. Users get clear errors for type mismatches. Unknown keys
+  produce a warning log.
+
+  ## Reading options at runtime
+
+      Minga.Config.Options.get_extension_option(:minga_org, :conceal)
+      # => false
 
   ## Lifecycle
 
   1. The extension module is compiled from the declared path
-  2. `init/1` is called with the config keyword list (minus `:path`)
-  3. The extension's `child_spec/1` is started under `Minga.Extension.Supervisor`
-  4. On config reload (`SPC h r`), all extensions are stopped and re-loaded
+  2. Options from the extension declaration are validated against the schema
+  3. `init/1` is called with the config keyword list (minus `:path`)
+  4. The extension's `child_spec/1` is started under `Minga.Extension.Supervisor`
+  5. On config reload (`SPC h r`), all extensions are stopped and re-loaded
   """
 
   @typedoc "Extension runtime status."
@@ -59,7 +86,7 @@ defmodule Minga.Extension do
 
   @doc """
   Called when the extension is loaded. Receives the config keyword list
-  from the extension declaration (with `:path` removed).
+  from the extension declaration (with source keys like `:path` removed).
 
   Return `{:ok, state}` to start successfully, or `{:error, reason}` to
   report a load failure without crashing the editor.
@@ -78,15 +105,44 @@ defmodule Minga.Extension do
 
   @optional_callbacks [child_spec: 1]
 
-  @doc """
-  Injects the `Minga.Extension` behaviour and a default `child_spec/1`.
+  @typedoc """
+  A single option specification: `{name, type, default, description}`.
 
-  The default child_spec starts an Agent holding the extension's init state.
-  Override `child_spec/1` for custom process trees.
+  The type descriptor uses the same types as `Minga.Config.Options`:
+  `:boolean`, `:pos_integer`, `:string`, `:string_list`, `{:enum, [atoms]}`, etc.
+
+  The doc string is used by `SPC h v` (describe option) and other
+  introspection features.
+  """
+  @type option_spec ::
+          {atom(), Minga.Config.Options.type_descriptor(), term(), description :: String.t()}
+
+  @doc """
+  Injects the `Minga.Extension` behaviour, the `option/3` DSL macro,
+  and a default `child_spec/1`.
+
+  ## The `option` macro
+
+  Declares a typed config option the extension accepts:
+
+      option :conceal, :boolean, default: true
+      option :heading_bullets, :string_list, default: ["◉", "○", "◈", "◇"]
+
+  At compile time, these are accumulated into `__option_schema__/0`,
+  a generated function the framework reads at load time to validate
+  user config and register options in ETS.
+
+  ## Supported types
+
+  `:boolean`, `:pos_integer`, `:non_neg_integer`, `:integer`, `:string`,
+  `:string_or_nil`, `:string_list`, `:atom`, `{:enum, [atoms]}`,
+  `:map_or_nil`, `:any`.
   """
   defmacro __using__(_opts) do
     quote do
       @behaviour Minga.Extension
+      Module.register_attribute(__MODULE__, :__extension_options__, accumulate: true)
+      @before_compile Minga.Extension
 
       @doc false
       @spec child_spec(keyword()) :: Supervisor.child_spec()
@@ -100,6 +156,56 @@ defmodule Minga.Extension do
       end
 
       defoverridable child_spec: 1
+
+      import Minga.Extension, only: [option: 3]
+    end
+  end
+
+  @doc """
+  Declares a typed config option for this extension.
+
+  Accumulated at compile time and exposed via `__option_schema__/0`.
+
+  ## Options
+
+  - `:default` (required) — the default value when the user doesn't set it
+  - `:description` (required) — a short human-readable description shown by `SPC h v`
+
+  ## Examples
+
+      option :conceal, :boolean,
+        default: true,
+        description: "Hide markup delimiters and show styled content"
+
+      option :format, {:enum, [:html, :pdf, :md]},
+        default: :html,
+        description: "Default export format"
+
+      option :heading_bullets, :string_list,
+        default: ["◉", "○"],
+        description: "Unicode bullets for heading levels (cycles when depth exceeds list length)"
+  """
+  defmacro option(name, type, opts) do
+    quote do
+      @__extension_options__ {
+        unquote(name),
+        unquote(type),
+        Keyword.fetch!(unquote(opts), :default),
+        Keyword.fetch!(unquote(opts), :description)
+      }
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    options = Module.get_attribute(env.module, :__extension_options__) || []
+    # Accumulated attributes are in reverse order; restore declaration order
+    options = Enum.reverse(options)
+
+    quote do
+      @doc false
+      @spec __option_schema__() :: [Minga.Extension.option_spec()]
+      def __option_schema__, do: unquote(Macro.escape(options))
     end
   end
 end

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -113,6 +113,7 @@ defmodule Minga.Extension.Supervisor do
   defp start_from_path(supervisor, registry, name, entry) do
     with {:ok, module} <- compile_extension(entry.path),
          :ok <- validate_behaviour(module, name),
+         :ok <- register_and_validate_options(name, module, entry.config),
          {:ok, _state} <- call_init(module, entry.config) do
       start_child(supervisor, registry, name, module, entry.config)
     else
@@ -241,6 +242,7 @@ defmodule Minga.Extension.Supervisor do
     # The convention is the package name maps to a module like MingaSnippets.
     with {:ok, module} <- find_extension_module(package_atom),
          :ok <- validate_behaviour(module, name),
+         :ok <- register_and_validate_options(name, module, entry.config),
          {:ok, _state} <- call_init(module, entry.config) do
       start_child(supervisor, registry, name, module, entry.config)
     else
@@ -408,6 +410,20 @@ defmodule Minga.Extension.Supervisor do
       [] -> :ok
       funs -> {:error, "extension #{name} missing callbacks: #{inspect(funs)}"}
     end
+  end
+
+  @spec register_and_validate_options(atom(), module(), keyword()) ::
+          :ok | {:error, String.t()}
+  defp register_and_validate_options(name, module, config) do
+    if function_exported?(module, :__option_schema__, 0) do
+      schema = module.__option_schema__()
+      Minga.Config.Options.register_extension_schema(name, schema, config)
+    else
+      :ok
+    end
+  rescue
+    e ->
+      {:error, "__option_schema__/0 crashed: #{Exception.message(e)}"}
   end
 
   @spec call_init(module(), keyword()) :: {:ok, term()} | {:error, term()}

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -361,108 +361,167 @@ defmodule Minga.Config.OptionsTest do
     end
   end
 
-  describe "register_extension_option/4" do
-    test "registers a boolean option with default", %{server: s} do
-      assert :ok = Options.register_extension_option(s, :org_conceal, :boolean, true)
-      assert Options.get(s, :org_conceal) == true
+  describe "extension option schema" do
+    @schema [
+      {:conceal, :boolean, true, "Hide markup delimiters"},
+      {:pretty_bullets, :boolean, true, "Replace heading stars with Unicode bullets"},
+      {:heading_bullets, :string_list, ["◉", "○", "◈", "◇"], "Unicode bullets for heading levels"}
+    ]
+
+    test "registers schema and seeds defaults", %{server: s} do
+      assert :ok = Options.register_extension_schema(s, :minga_org, @schema, [])
+      assert Options.get_extension_option(s, :minga_org, :conceal) == true
+      assert Options.get_extension_option(s, :minga_org, :pretty_bullets) == true
+      assert Options.get_extension_option(s, :minga_org, :heading_bullets) == ["◉", "○", "◈", "◇"]
     end
 
-    test "registered option is settable by users", %{server: s} do
-      Options.register_extension_option(s, :org_conceal, :boolean, true)
-      assert {:ok, false} = Options.set(s, :org_conceal, false)
-      assert Options.get(s, :org_conceal) == false
+    test "user config overrides defaults", %{server: s} do
+      user_config = [conceal: false, heading_bullets: ["•", "◦"]]
+      assert :ok = Options.register_extension_schema(s, :minga_org, @schema, user_config)
+
+      assert Options.get_extension_option(s, :minga_org, :conceal) == false
+      assert Options.get_extension_option(s, :minga_org, :heading_bullets) == ["•", "◦"]
+      # Unset options keep their default
+      assert Options.get_extension_option(s, :minga_org, :pretty_bullets) == true
     end
 
-    test "validates extension option types", %{server: s} do
-      Options.register_extension_option(s, :org_conceal, :boolean, true)
-      assert {:error, msg} = Options.set(s, :org_conceal, "yes")
+    test "validates user config types at registration", %{server: s} do
+      assert {:error, msg} =
+               Options.register_extension_schema(s, :minga_org, @schema, conceal: "yes")
+
       assert msg =~ "boolean"
     end
 
-    test "rejects collision with built-in option name", %{server: s} do
-      assert {:error, msg} = Options.register_extension_option(s, :tab_width, :pos_integer, 4)
-      assert msg =~ "conflicts with a built-in option"
+    test "unknown user config keys produce warning but succeed", %{server: s} do
+      # Unknown keys are logged as warnings, not errors
+      assert :ok = Options.register_extension_schema(s, :minga_org, @schema, unknown_key: true)
     end
 
-    test "supports enum type descriptor", %{server: s} do
-      Options.register_extension_option(s, :org_export_format, {:enum, [:html, :pdf, :md]}, :html)
-      assert Options.get(s, :org_export_format) == :html
-      assert {:ok, :pdf} = Options.set(s, :org_export_format, :pdf)
-      assert {:error, _} = Options.set(s, :org_export_format, :docx)
+    test "set_extension_option validates against schema", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, [])
+
+      assert {:ok, false} = Options.set_extension_option(s, :minga_org, :conceal, false)
+      assert Options.get_extension_option(s, :minga_org, :conceal) == false
+
+      assert {:error, msg} = Options.set_extension_option(s, :minga_org, :conceal, "nope")
+      assert msg =~ "boolean"
     end
 
-    test "supports string_list type descriptor", %{server: s} do
-      bullets = ["◉", "○", "◈"]
-      Options.register_extension_option(s, :org_heading_bullets, :string_list, bullets)
-      assert Options.get(s, :org_heading_bullets) == bullets
-      assert {:ok, ["•"]} = Options.set(s, :org_heading_bullets, ["•"])
-      assert {:error, _} = Options.set(s, :org_heading_bullets, :not_a_list)
-    end
+    test "set_extension_option rejects unregistered option names", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, [])
 
-    test "re-registration does not overwrite existing user value", %{server: s} do
-      # Simulates config reload: register, user sets value, then re-register on reload.
-      Options.register_extension_option(s, :org_conceal, :boolean, true)
-      Options.set(s, :org_conceal, false)
-
-      Options.register_extension_option(s, :org_conceal, :boolean, true)
-      assert Options.get(s, :org_conceal) == false
-    end
-
-    test "extension_option? returns true for registered options", %{server: s} do
-      Options.register_extension_option(s, :org_conceal, :boolean, true)
-      assert Options.extension_option?(s, :org_conceal) == true
-    end
-
-    test "extension_option? returns false for built-in options", %{server: s} do
-      assert Options.extension_option?(s, :tab_width) == false
-    end
-
-    test "extension_option? returns false for unknown options", %{server: s} do
-      assert Options.extension_option?(s, :nonexistent) == false
-    end
-
-    test "filetype overrides work for extension options", %{server: s} do
-      Options.register_extension_option(s, :org_conceal, :boolean, true)
-      Options.set_for_filetype(s, :org, :org_conceal, false)
-
-      assert Options.get_for_filetype(s, :org_conceal, :org) == false
-      assert Options.get(s, :org_conceal) == true
-    end
-
-    test "re-registration after reset preserves the pattern", %{server: s} do
-      Options.register_extension_option(s, :org_conceal, :boolean, true)
-      Options.set(s, :org_conceal, false)
-
-      # Reset clears everything (simulates config reload)
-      Options.reset(s)
-
-      # Extension re-registers during init
-      Options.register_extension_option(s, :org_conceal, :boolean, true)
-      # Default is restored since user value was cleared by reset
-      assert Options.get(s, :org_conceal) == true
-    end
-
-    test "all/1 includes extension option values", %{server: s} do
-      Options.register_extension_option(s, :org_conceal, :boolean, true)
-      all = Options.all(s)
-      assert Map.get(all, :org_conceal) == true
-    end
-
-    test "reset clears extension type metadata", %{server: s} do
-      Options.register_extension_option(s, :org_conceal, :boolean, true)
-      Options.reset(s)
-
-      assert Options.extension_option?(s, :org_conceal) == false
-      assert {:error, msg} = Options.set(s, :org_conceal, false)
+      assert {:error, msg} = Options.set_extension_option(s, :minga_org, :nonexistent, true)
       assert msg =~ "unknown option"
     end
 
-    test "multiple extensions can register different options", %{server: s} do
-      Options.register_extension_option(s, :org_conceal, :boolean, true)
-      Options.register_extension_option(s, :zen_mode, :boolean, false)
+    test "supports enum type descriptor", %{server: s} do
+      schema = [{:format, {:enum, [:html, :pdf, :md]}, :html, "Default export format"}]
+      Options.register_extension_schema(s, :exporter, schema, [])
 
-      assert Options.get(s, :org_conceal) == true
-      assert Options.get(s, :zen_mode) == false
+      assert Options.get_extension_option(s, :exporter, :format) == :html
+      assert {:ok, :pdf} = Options.set_extension_option(s, :exporter, :format, :pdf)
+      assert {:error, _} = Options.set_extension_option(s, :exporter, :format, :docx)
+    end
+
+    test "two extensions can have options with the same name", %{server: s} do
+      schema_a = [{:conceal, :boolean, true, "Ext A conceal"}]
+      schema_b = [{:conceal, :boolean, false, "Ext B conceal"}]
+
+      Options.register_extension_schema(s, :ext_a, schema_a, [])
+      Options.register_extension_schema(s, :ext_b, schema_b, [])
+
+      assert Options.get_extension_option(s, :ext_a, :conceal) == true
+      assert Options.get_extension_option(s, :ext_b, :conceal) == false
+
+      Options.set_extension_option(s, :ext_a, :conceal, false)
+      # ext_b is unaffected
+      assert Options.get_extension_option(s, :ext_b, :conceal) == false
+    end
+
+    test "per-filetype overrides work for extension options", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, [])
+
+      # Global default is true
+      assert Options.get_extension_option_for_filetype(s, :minga_org, :conceal, :org) == true
+
+      # Set a filetype-specific override
+      assert {:ok, false} =
+               Options.set_extension_option_for_filetype(s, :minga_org, :org, :conceal, false)
+
+      # Filetype lookup returns the override
+      assert Options.get_extension_option_for_filetype(s, :minga_org, :conceal, :org) == false
+
+      # Global value is unchanged
+      assert Options.get_extension_option(s, :minga_org, :conceal) == true
+
+      # Different filetype falls back to global
+      assert Options.get_extension_option_for_filetype(s, :minga_org, :conceal, :markdown) == true
+    end
+
+    test "set_extension_option_for_filetype validates against schema", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, [])
+
+      assert {:error, msg} =
+               Options.set_extension_option_for_filetype(s, :minga_org, :org, :conceal, "nope")
+
+      assert msg =~ "boolean"
+    end
+
+    test "get_extension_option_for_filetype falls back to global when no override", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, conceal: false)
+
+      assert Options.get_extension_option_for_filetype(s, :minga_org, :conceal, :org) == false
+    end
+
+    test "get_extension_option_for_filetype with nil filetype returns global", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, [])
+
+      assert Options.get_extension_option_for_filetype(s, :minga_org, :conceal, nil) == true
+    end
+
+    test "extension_schema returns the registered schema", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, [])
+      assert Options.extension_schema(s, :minga_org) == @schema
+    end
+
+    test "extension_schema returns nil for unknown extension", %{server: s} do
+      assert Options.extension_schema(s, :unknown) == nil
+    end
+
+    test "extension_option_description returns the description string", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, [])
+
+      assert Options.extension_option_description(s, :minga_org, :conceal) ==
+               "Hide markup delimiters"
+
+      assert Options.extension_option_description(s, :minga_org, :pretty_bullets) ==
+               "Replace heading stars with Unicode bullets"
+    end
+
+    test "extension_option_description returns nil for unknown option", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, [])
+      assert Options.extension_option_description(s, :minga_org, :nonexistent) == nil
+    end
+
+    test "extension_option_description returns nil for unknown extension", %{server: s} do
+      assert Options.extension_option_description(s, :unknown, :conceal) == nil
+    end
+
+    test "re-registration does not overwrite user-set values", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, [])
+      Options.set_extension_option(s, :minga_org, :conceal, false)
+
+      # Re-register (simulates config reload)
+      Options.register_extension_schema(s, :minga_org, @schema, [])
+      assert Options.get_extension_option(s, :minga_org, :conceal) == false
+    end
+
+    test "reset clears extension schemas and values", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, [])
+      Options.reset(s)
+
+      assert Options.extension_schema(s, :minga_org) == nil
+      assert Options.get_extension_option(s, :minga_org, :conceal) == nil
     end
   end
 end

--- a/test/minga/extension_test.exs
+++ b/test/minga/extension_test.exs
@@ -1,0 +1,83 @@
+defmodule Minga.ExtensionTest do
+  use ExUnit.Case, async: true
+
+  describe "option/3 DSL macro" do
+    defmodule TestExtension do
+      use Minga.Extension
+
+      option(:conceal, :boolean,
+        default: true,
+        description: "Hide markup delimiters"
+      )
+
+      option(:bullets, :string_list,
+        default: ["◉", "○"],
+        description: "Unicode bullets for headings"
+      )
+
+      option(:format, {:enum, [:html, :pdf]},
+        default: :html,
+        description: "Default export format"
+      )
+
+      @impl true
+      def name, do: :test_ext
+
+      @impl true
+      def description, do: "Test extension"
+
+      @impl true
+      def version, do: "0.1.0"
+
+      @impl true
+      def init(_config), do: {:ok, %{}}
+    end
+
+    test "generates __option_schema__/0 with all declared options" do
+      schema = TestExtension.__option_schema__()
+
+      assert schema == [
+               {:conceal, :boolean, true, "Hide markup delimiters"},
+               {:bullets, :string_list, ["◉", "○"], "Unicode bullets for headings"},
+               {:format, {:enum, [:html, :pdf]}, :html, "Default export format"}
+             ]
+    end
+
+    test "options are in declaration order" do
+      names = TestExtension.__option_schema__() |> Enum.map(&elem(&1, 0))
+      assert names == [:conceal, :bullets, :format]
+    end
+
+    test "descriptions are preserved" do
+      descs = TestExtension.__option_schema__() |> Enum.map(&elem(&1, 3))
+
+      assert descs == [
+               "Hide markup delimiters",
+               "Unicode bullets for headings",
+               "Default export format"
+             ]
+    end
+  end
+
+  describe "extension without options" do
+    defmodule BareExtension do
+      use Minga.Extension
+
+      @impl true
+      def name, do: :bare
+
+      @impl true
+      def description, do: "No options"
+
+      @impl true
+      def version, do: "0.1.0"
+
+      @impl true
+      def init(_config), do: {:ok, %{}}
+    end
+
+    test "generates empty __option_schema__/0" do
+      assert BareExtension.__option_schema__() == []
+    end
+  end
+end


### PR DESCRIPTION
## What

Replaces the flat `register_extension_option/3` API with a schema-based, namespaced system. Extensions declare typed config options with an `option/3` DSL macro (like Ecto's `field`), users configure them grouped under the extension declaration, and values are validated at load time.

## Why

The flat approach (`set :org_conceal, false` scattered in config) pollutes the global namespace. With multiple extensions, config becomes unreadable. Two extensions can't both have a `:conceal` option. There's no way to enumerate all options for one extension. No self-documentation.

The existing `extension :name, key: value` syntax already groups config naturally. This change adds the schema, validation, and runtime access layer underneath.

## How it works

**Extension declares options with the DSL:**

```elixir
defmodule MingaOrg do
  use Minga.Extension

  option :conceal, :boolean,
    default: true,
    description: "Hide markup delimiters and show styled content"

  option :heading_bullets, :string_list,
    default: ["◉", "○", "◈", "◇"],
    description: "Unicode bullets for heading levels"
end
```

**User configures grouped under the declaration:**

```elixir
extension :minga_org, git: "https://github.com/jsmestad/minga-org",
  conceal: false,
  heading_bullets: ["•", "◦"]
```

**Runtime access is namespaced:**

```elixir
Config.Options.get_extension_option(:minga_org, :conceal)
Config.Options.set_extension_option(:minga_org, :conceal, true)
Config.Options.get_extension_option_for_filetype(:minga_org, :conceal, :org)
Config.Options.extension_option_description(:minga_org, :conceal)
```

## Key design decisions

- **`option/3` DSL macro** follows Ecto's `field` pattern: module-level declarations, `Module.register_attribute` with accumulate, `@before_compile` generates `__option_schema__/0`
- **Deferred validation**: config.exs stores raw values, schema validates when extension compiles
- **`:description` on every option** enables `SPC h v` (describe option) for extension options
- **Namespaced ETS keys** (`{:extension, ext_name, opt_name}`) prevent collisions between extensions
- **Per-filetype overrides** fully wired with `set/get_extension_option_for_filetype`
- **Backward compatible**: extensions without `option/3` declarations work unchanged

## Testing

- 76 tests covering: schema registration, type validation, user config override, unknown key warnings, namespaced get/set, filetype overrides, collision isolation, description retrieval, DSL macro generation, empty schema, re-registration idempotency
- All 6424 tests pass, 0 failures

## Related

- Resolves #1060
- Epic: #1049
- Supersedes the flat `register_extension_option/3` from #1050