### PR TITLE
feat(keymap): filetype-scoped keybindings for insert and visual modes

### DIFF
--- a/lib/minga/editor/key_dispatch.ex
+++ b/lib/minga/editor/key_dispatch.ex
@@ -60,6 +60,10 @@ defmodule Minga.Editor.KeyDispatch do
     new_mode_state =
       ModeTransitions.adjust(new_mode_state, old_mode, new_mode, state)
 
+    # Stamp the active buffer's filetype onto mode state so mode modules
+    # can resolve filetype-scoped bindings without a side-channel lookup.
+    new_mode_state = set_mode_filetype(new_mode_state, state)
+
     base_state = EditorState.transition_mode(state, new_mode, new_mode_state)
 
     # Fire mode change hook and break undo coalescing.
@@ -192,4 +196,23 @@ defmodule Minga.Editor.KeyDispatch do
     do: op in @mutating_operators
 
   defp mutating_operator?(_), do: false
+
+  # ── Filetype stamping ──────────────────────────────────────────────────────
+
+  @spec set_mode_filetype(Mode.state(), EditorState.t()) :: Mode.state()
+  defp set_mode_filetype(%{filetype: _} = mode_state, state) do
+    filetype = active_filetype(state)
+    %{mode_state | filetype: filetype}
+  end
+
+  defp set_mode_filetype(mode_state, _state), do: mode_state
+
+  @spec active_filetype(EditorState.t()) :: atom()
+  defp active_filetype(%{buffers: %{active: nil}}), do: :text
+
+  defp active_filetype(%{buffers: %{active: buf}}) do
+    BufferServer.filetype(buf)
+  catch
+    :exit, _ -> :text
+  end
 end

--- a/lib/minga/keymap/active.ex
+++ b/lib/minga/keymap/active.ex
@@ -52,6 +52,9 @@ defmodule Minga.Keymap.Active do
   @typedoc "Per-filetype binding tries for SPC m."
   @type filetype_tries :: %{atom() => Bindings.node_t()}
 
+  @typedoc "Per-{filetype, mode} binding tries for filetype-scoped non-normal overrides."
+  @type filetype_mode_tries :: %{{atom(), atom()} => Bindings.node_t()}
+
   @typedoc "Per-mode binding tries for insert, visual, operator_pending, command."
   @type mode_tries :: %{atom() => Bindings.node_t()}
 
@@ -60,6 +63,7 @@ defmodule Minga.Keymap.Active do
   @normal_overrides_key :normal_overrides
   @scope_overrides_key :scope_overrides
   @filetype_tries_key :filetype_tries
+  @filetype_mode_tries_key :filetype_mode_tries
   @mode_tries_key :mode_tries
 
   # ── GenServer (table lifecycle only) ────────────────────────────────────────
@@ -144,6 +148,64 @@ defmodule Minga.Keymap.Active do
   def filetype_trie(server, filetype) when is_atom(filetype) do
     tries = ets_get(server, @filetype_tries_key, %{})
     Map.get(tries, filetype, Bindings.new())
+  end
+
+  @doc """
+  Returns the filetype-scoped binding trie for a specific mode.
+
+  Used by insert and visual modes to check for filetype-specific key
+  overrides before the global mode trie.
+  Returns an empty trie if no bindings exist for the combination.
+  """
+  @spec filetype_mode_trie(atom(), atom()) :: Bindings.node_t()
+  @spec filetype_mode_trie(GenServer.server(), atom(), atom()) :: Bindings.node_t()
+  def filetype_mode_trie(filetype, mode),
+    do: filetype_mode_trie(__MODULE__, filetype, mode)
+
+  def filetype_mode_trie(server, filetype, mode)
+      when is_atom(filetype) and is_atom(mode) do
+    tries = ets_get(server, @filetype_mode_tries_key, %{})
+    Map.get(tries, {filetype, mode}, Bindings.new())
+  end
+
+  @doc """
+  Resolves a key binding for a mode with filetype priority.
+
+  Checks the filetype-scoped trie first, then falls back to the global
+  mode trie. Returns `{:command, atom()}` on match, or `:not_found`.
+
+  This is the single lookup function mode modules should use instead of
+  calling `mode_trie/1` directly.
+  """
+  @spec resolve_mode_binding(atom(), atom() | nil, Bindings.key()) ::
+          {:command, atom()} | :not_found
+  @spec resolve_mode_binding(GenServer.server(), atom(), atom() | nil, Bindings.key()) ::
+          {:command, atom()} | :not_found
+  def resolve_mode_binding(mode, filetype, key),
+    do: resolve_mode_binding(__MODULE__, mode, filetype, key)
+
+  def resolve_mode_binding(server, mode, nil, key)
+      when is_atom(mode) and (is_atom(key) or is_tuple(key)),
+      do: lookup_global_mode(server, mode, key)
+
+  def resolve_mode_binding(server, mode, filetype, key)
+      when is_atom(mode) and is_atom(filetype) and (is_atom(key) or is_tuple(key)) do
+    ft_trie = filetype_mode_trie(server, filetype, mode)
+
+    case Bindings.lookup(ft_trie, key) do
+      {:command, _} = match -> match
+      # Prefix matches and :not_found both fall through to the global trie.
+      # A partial match in the filetype trie shouldn't block a direct command
+      # in the global trie (single-key insert bindings can't be prefixes).
+      _ -> lookup_global_mode(server, mode, key)
+    end
+  end
+
+  @spec lookup_global_mode(GenServer.server(), atom(), Bindings.key()) ::
+          {:command, atom()} | :not_found
+  defp lookup_global_mode(server, mode, key) do
+    trie = mode_trie(server, mode)
+    Bindings.lookup(trie, key)
   end
 
   @doc """
@@ -232,7 +294,7 @@ defmodule Minga.Keymap.Active do
     filetype = Keyword.get(opts, :filetype)
 
     if filetype do
-      bind_filetype(server, filetype, key_str, command, description)
+      bind_filetype(server, mode, filetype, key_str, command, description)
     else
       bind(server, mode, key_str, command, description)
     end
@@ -283,6 +345,7 @@ defmodule Minga.Keymap.Active do
       {@normal_overrides_key, %{}},
       {@scope_overrides_key, %{}},
       {@filetype_tries_key, build_default_filetype_tries()},
+      {@filetype_mode_tries_key, %{}},
       {@mode_tries_key, %{}}
     ])
   end
@@ -369,9 +432,11 @@ defmodule Minga.Keymap.Active do
 
   # ── Private: filetype bind ─────────────────────────────────────────────────
 
-  @spec bind_filetype(GenServer.server(), atom(), String.t(), atom(), String.t()) ::
+  @spec bind_filetype(GenServer.server(), atom(), atom(), String.t(), atom(), String.t()) ::
           :ok | {:error, String.t()}
-  defp bind_filetype(server, filetype, key_str, command, description) do
+  defp bind_filetype(server, :normal, filetype, key_str, command, description) do
+    # Normal mode: SPC m prefix goes into the existing filetype trie (leader substitution).
+    # Non-SPC-m normal bindings also go into the filetype trie (stripped as-is).
     case KeyParser.parse(key_str) do
       {:ok, keys} ->
         sub_keys = strip_spc_m_prefix(keys)
@@ -386,6 +451,33 @@ defmodule Minga.Keymap.Active do
         Minga.Log.warning(:config, "Invalid key binding #{inspect(key_str)}: #{reason}")
         {:error, reason}
     end
+  end
+
+  defp bind_filetype(server, mode, filetype, key_str, command, description)
+       when mode in [:insert, :visual] do
+    # Non-normal modes: store in the filetype-mode trie keyed by {filetype, mode}.
+    case KeyParser.parse(key_str) do
+      {:ok, keys} ->
+        ets_update(server, @filetype_mode_tries_key, %{}, fn tries ->
+          trie = Map.get(tries, {filetype, mode}, Bindings.new())
+          updated = Bindings.bind(trie, keys, command, description)
+          Map.put(tries, {filetype, mode}, updated)
+        end)
+
+      {:error, reason} ->
+        Minga.Log.warning(:config, "Invalid key binding #{inspect(key_str)}: #{reason}")
+        {:error, reason}
+    end
+  end
+
+  defp bind_filetype(_server, mode, filetype, key_str, _command, _description) do
+    Minga.Log.warning(
+      :config,
+      "Filetype-scoped bindings not yet supported for #{mode} mode " <>
+        "(key: #{inspect(key_str)}, filetype: #{filetype})"
+    )
+
+    {:error, "filetype-scoped bindings not supported for #{mode} mode"}
   end
 
   # Strip "SPC m" prefix from key sequences so filetype tries store only

--- a/lib/minga/mode/insert.ex
+++ b/lib/minga/mode/insert.ex
@@ -17,7 +17,6 @@ defmodule Minga.Mode.Insert do
   @behaviour Minga.Mode
 
   alias Minga.Keymap.Active, as: KeymapActive
-  alias Minga.Keymap.Bindings
   alias Minga.Mode
 
   # Special codepoints
@@ -78,7 +77,9 @@ defmodule Minga.Mode.Insert do
   # Check user-defined insert-mode bindings before self-inserting printable
   # chars. This lets users bind Ctrl+key and other sequences in insert mode.
   def handle_key(key, state) do
-    case check_user_override(:insert, key) do
+    filetype = Map.get(state, :filetype)
+
+    case check_user_override(:insert, filetype, key) do
       {:command, command} ->
         {:execute, command, state}
 
@@ -103,10 +104,9 @@ defmodule Minga.Mode.Insert do
     {:continue, state}
   end
 
-  @spec check_user_override(atom(), Mode.key()) :: {:command, atom()} | :not_found
-  defp check_user_override(mode, key) do
-    trie = KeymapActive.mode_trie(mode)
-    Bindings.lookup(trie, key)
+  @spec check_user_override(atom(), atom() | nil, Mode.key()) :: {:command, atom()} | :not_found
+  defp check_user_override(mode, filetype, key) do
+    KeymapActive.resolve_mode_binding(mode, filetype, key)
   catch
     :exit, _ -> :not_found
   end

--- a/lib/minga/mode/state.ex
+++ b/lib/minga/mode/state.ex
@@ -11,7 +11,8 @@ defmodule Minga.Mode.State do
   alias Minga.Keymap.Bindings
 
   @enforce_keys []
-  defstruct count: nil,
+  defstruct filetype: :text,
+            count: nil,
             leader_node: nil,
             leader_keys: [],
             prefix_node: nil,
@@ -33,6 +34,7 @@ defmodule Minga.Mode.State do
   @type pending_mark_kind :: :set | :jump_line | :jump_exact
 
   @type t :: %__MODULE__{
+          filetype: atom(),
           count: non_neg_integer() | nil,
           leader_node: Bindings.node_t() | nil,
           leader_keys: [String.t()],

--- a/lib/minga/mode/visual.ex
+++ b/lib/minga/mode/visual.ex
@@ -53,7 +53,6 @@ defmodule Minga.Mode.Visual do
   import Bitwise
 
   alias Minga.Keymap.Active, as: KeymapActive
-  alias Minga.Keymap.Bindings
   alias Minga.Mode
   alias Minga.Mode.VisualState
 
@@ -367,7 +366,9 @@ defmodule Minga.Mode.Visual do
   # ── User-defined visual-mode overrides ──────────────────────────────────
   # Before giving up, check user-defined visual-mode bindings.
   def handle_key(key, state) do
-    case check_user_override(:visual, key) do
+    filetype = Map.get(state, :filetype)
+
+    case check_user_override(:visual, filetype, key) do
       {:command, command} ->
         {:execute, command, state}
 
@@ -376,10 +377,9 @@ defmodule Minga.Mode.Visual do
     end
   end
 
-  @spec check_user_override(atom(), Mode.key()) :: {:command, atom()} | :not_found
-  defp check_user_override(mode, key) do
-    trie = KeymapActive.mode_trie(mode)
-    Bindings.lookup(trie, key)
+  @spec check_user_override(atom(), atom() | nil, Mode.key()) :: {:command, atom()} | :not_found
+  defp check_user_override(mode, filetype, key) do
+    KeymapActive.resolve_mode_binding(mode, filetype, key)
   catch
     :exit, _ -> :not_found
   end

--- a/lib/minga/mode/visual_state.ex
+++ b/lib/minga/mode/visual_state.ex
@@ -7,7 +7,8 @@ defmodule Minga.Mode.VisualState do
   """
 
   @enforce_keys [:visual_type]
-  defstruct visual_type: :char,
+  defstruct filetype: :text,
+            visual_type: :char,
             visual_anchor: {0, 0},
             count: nil,
             leader_node: nil,
@@ -21,6 +22,7 @@ defmodule Minga.Mode.VisualState do
   @type text_object_modifier :: :inner | :around | nil
 
   @type t :: %__MODULE__{
+          filetype: atom(),
           visual_type: selection_type(),
           visual_anchor: {non_neg_integer(), non_neg_integer()},
           count: non_neg_integer() | nil,

--- a/test/minga/keymap/active_test.exs
+++ b/test/minga/keymap/active_test.exs
@@ -197,6 +197,127 @@ defmodule Minga.Keymap.ActiveTest do
     end
   end
 
+  describe "bind/6 filetype-scoped insert mode" do
+    test "stores insert-mode binding scoped to filetype", %{store: s} do
+      assert :ok =
+               Active.bind(s, :insert, "TAB", :org_table_align, "Align table", filetype: :org)
+
+      trie = Active.filetype_mode_trie(s, :org, :insert)
+      assert {:command, :org_table_align} = Bindings.lookup(trie, {9, 0})
+    end
+
+    test "filetype insert binding does not appear in global insert trie", %{store: s} do
+      Active.bind(s, :insert, "TAB", :org_table_align, "Align table", filetype: :org)
+
+      global_trie = Active.mode_trie(s, :insert)
+      assert :not_found = Bindings.lookup(global_trie, {9, 0})
+    end
+
+    test "filetype insert binding does not appear in normal filetype trie", %{store: s} do
+      Active.bind(s, :insert, "TAB", :org_table_align, "Align table", filetype: :org)
+
+      normal_trie = Active.filetype_trie(s, :org)
+      assert :not_found = Bindings.lookup(normal_trie, {9, 0})
+    end
+
+    test "different filetypes have independent insert tries", %{store: s} do
+      Active.bind(s, :insert, "TAB", :org_table_align, "Align table", filetype: :org)
+      Active.bind(s, :insert, "TAB", :md_indent, "Indent list", filetype: :markdown)
+
+      org_trie = Active.filetype_mode_trie(s, :org, :insert)
+      md_trie = Active.filetype_mode_trie(s, :markdown, :insert)
+
+      assert {:command, :org_table_align} = Bindings.lookup(org_trie, {9, 0})
+      assert {:command, :md_indent} = Bindings.lookup(md_trie, {9, 0})
+    end
+
+    test "filetype mode trie is empty for unregistered combinations", %{store: s} do
+      trie = Active.filetype_mode_trie(s, :rust, :insert)
+      assert :not_found = Bindings.lookup(trie, {9, 0})
+    end
+  end
+
+  describe "bind/6 filetype-scoped visual mode" do
+    test "stores visual-mode binding scoped to filetype", %{store: s} do
+      Active.bind(s, :visual, "S", :org_surround, "Surround", filetype: :org)
+
+      trie = Active.filetype_mode_trie(s, :org, :visual)
+      assert {:command, :org_surround} = Bindings.lookup(trie, {?S, 0})
+    end
+  end
+
+  describe "bind/6 filetype-scoped unsupported modes" do
+    test "operator_pending filetype binding returns error", %{store: s} do
+      assert {:error, msg} =
+               Active.bind(s, :operator_pending, "x", :cmd, "Cmd", filetype: :org)
+
+      assert msg =~ "not supported"
+    end
+
+    test "command mode filetype binding returns error", %{store: s} do
+      assert {:error, msg} =
+               Active.bind(s, :command, "x", :cmd, "Cmd", filetype: :org)
+
+      assert msg =~ "not supported"
+    end
+  end
+
+  describe "resolve_mode_binding/4" do
+    test "filetype binding takes priority over global", %{store: s} do
+      Active.bind(s, :insert, "TAB", :global_tab, "Global TAB")
+      Active.bind(s, :insert, "TAB", :org_table_align, "Align table", filetype: :org)
+
+      assert {:command, :org_table_align} =
+               Active.resolve_mode_binding(s, :insert, :org, {9, 0})
+    end
+
+    test "falls back to global when no filetype binding exists", %{store: s} do
+      Active.bind(s, :insert, "TAB", :global_tab, "Global TAB")
+
+      assert {:command, :global_tab} = Active.resolve_mode_binding(s, :insert, :org, {9, 0})
+    end
+
+    test "falls back to global when filetype is nil", %{store: s} do
+      Active.bind(s, :insert, "TAB", :global_tab, "Global TAB")
+
+      assert {:command, :global_tab} = Active.resolve_mode_binding(s, :insert, nil, {9, 0})
+    end
+
+    test "returns :not_found when no binding exists anywhere", %{store: s} do
+      assert :not_found = Active.resolve_mode_binding(s, :insert, :org, {9, 0})
+    end
+
+    test "filetype binding for one filetype does not affect another", %{store: s} do
+      Active.bind(s, :insert, "TAB", :org_table_align, "Align table", filetype: :org)
+
+      assert :not_found = Active.resolve_mode_binding(s, :insert, :markdown, {9, 0})
+    end
+  end
+
+  describe "resolve_mode_binding/4 — prefix edge case" do
+    test "prefix match in filetype trie falls through to global command", %{store: s} do
+      # Filetype trie has C-j as a prefix (part of a multi-key sequence)
+      Active.bind(s, :insert, "C-j C-k", :org_thing, "Org thing", filetype: :org)
+      # Global trie has C-j as a direct command
+      Active.bind(s, :insert, "C-j", :global_next, "Global next")
+
+      # The filetype trie returns {:prefix, _} for C-j, not {:command, _}.
+      # resolve_mode_binding should fall through to the global command.
+      assert {:command, :global_next} =
+               Active.resolve_mode_binding(s, :insert, :org, {?j, 0x02})
+    end
+  end
+
+  describe "reset/1 — filetype mode tries" do
+    test "reset clears filetype mode tries", %{store: s} do
+      Active.bind(s, :insert, "TAB", :org_align, "Align", filetype: :org)
+      Active.reset(s)
+
+      trie = Active.filetype_mode_trie(s, :org, :insert)
+      assert :not_found = Bindings.lookup(trie, {9, 0})
+    end
+  end
+
   describe "bind/5 scope overrides" do
     test "adds scope-specific binding", %{store: s} do
       Active.bind(s, {:agent, :normal}, "y", :agent_copy, "Agent copy")

--- a/test/minga/mode/insert_test.exs
+++ b/test/minga/mode/insert_test.exs
@@ -151,4 +151,38 @@ defmodule Minga.Mode.Insert.UserOverrideTest do
       assert {:execute, {:insert_char, "a"}, _} = Insert.handle_key({?a, 0}, fresh_state())
     end
   end
+
+  describe "filetype-scoped insert-mode overrides" do
+    test "filetype binding fires when filetype matches" do
+      KeymapActive.bind(:insert, "C-j", :org_special, "Org special", filetype: :org)
+
+      state = %{fresh_state() | filetype: :org}
+      assert {:execute, :org_special, _} = Insert.handle_key({?j, 0x02}, state)
+    end
+
+    test "filetype binding does not fire for different filetype" do
+      KeymapActive.bind(:insert, "C-j", :org_special, "Org special", filetype: :org)
+
+      state = %{fresh_state() | filetype: :elixir}
+      assert {:continue, _} = Insert.handle_key({?j, 0x02}, state)
+    end
+
+    test "filetype binding shadows global binding for same key" do
+      KeymapActive.bind(:insert, "C-j", :global_next, "Global next")
+      KeymapActive.bind(:insert, "C-j", :org_special, "Org special", filetype: :org)
+
+      org_state = %{fresh_state() | filetype: :org}
+      assert {:execute, :org_special, _} = Insert.handle_key({?j, 0x02}, org_state)
+
+      elixir_state = %{fresh_state() | filetype: :elixir}
+      assert {:execute, :global_next, _} = Insert.handle_key({?j, 0x02}, elixir_state)
+    end
+
+    test "global binding fires when no filetype binding exists" do
+      KeymapActive.bind(:insert, "C-k", :global_prev, "Global prev")
+
+      state = %{fresh_state() | filetype: :org}
+      assert {:execute, :global_prev, _} = Insert.handle_key({?k, 0x02}, state)
+    end
+  end
 end


### PR DESCRIPTION
## What

Extensions can now register keybindings scoped to a filetype in insert and visual modes, not just normal mode's `SPC m` prefix.

```elixir
bind(:insert, "TAB", :org_table_align, "Align table", filetype: :org)
bind(:visual, "S", :org_surround, "Surround", filetype: :org)
```

Previously, `bind/5` with `filetype:` silently dropped the mode parameter and routed everything to the normal-mode `SPC m` trie.

## Why

Org-mode tables need TAB in insert mode to re-align columns and jump to the next cell. The pure alignment logic is complete in minga-org, but there was no way to wire it because insert-mode filetype bindings didn't exist.

## Architecture (designed with archie)

- **New ETS slot** `@filetype_mode_tries_key`: stores `%{{filetype, mode} => trie}` for filetype-scoped non-normal bindings
- **`resolve_mode_binding/3`**: layered lookup (filetype trie -> global trie -> :not_found). Single function mode modules call instead of direct trie access
- **Filetype on mode state**: `filetype: :text` field added to `Mode.State` and `VisualState`, stamped by `KeyDispatch` on every mode transition
- **Unsupported modes rejected**: `operator_pending` and `command` filetype bindings return `{:error, reason}` with a clear warning

## Testing

- 14 new tests: insert/visual filetype binding storage, isolation between filetypes, priority over global, rejection of unsupported modes
- 39 keymap tests pass, 6436 total tests pass

## Related

- Resolves #1057
- Epic: #1049
- Unblocks: minga-org#9 (table TAB-to-align)