### PR TITLE
feat(buffer): Line annotations decoration type (#1115)

### DIFF
--- a/docs/EXTENSION_API.md
+++ b/docs/EXTENSION_API.md
@@ -389,6 +389,49 @@ end)
 
 **Style properties:** `:fg`, `:bg` (24-bit RGB integers like `0x61AFEF`), `:bold`, `:italic`, `:underline`, `:strikethrough`, `:reverse`.
 
+### Line Annotations
+
+Line annotations attach visual metadata to buffer lines: colored pill badges, inline dimmed text, and gutter icons. Each frontend renders them natively (GUI renders pill badges with rounded rect backgrounds; TUI renders styled text at end of line).
+
+Three annotation kinds are supported:
+
+| Kind | Description | Example use |
+|------|-------------|-------------|
+| `:inline_pill` | Colored pill badge after line content | Org tags (`:work:`, `:urgent:`), diagnostic counts |
+| `:inline_text` | Styled text after line content (no background) | Git blame, inline hints |
+| `:gutter_icon` | Symbol in the gutter sign column | Bookmarks, breakpoints |
+
+```elixir
+# Add annotations inside a batch_decorations call
+Minga.Buffer.Server.batch_decorations(buf, fn decs ->
+  # Clear previous annotations from this group
+  decs = Minga.Buffer.Decorations.remove_group(decs, :org_tags)
+
+  # Pill badge: colored background + contrasting text
+  {_id, decs} = Minga.Buffer.Decorations.add_annotation(decs, line, "work",
+    kind: :inline_pill, fg: 0xFFFFFF, bg: 0x6366F1, group: :org_tags)
+
+  {_id, decs} = Minga.Buffer.Decorations.add_annotation(decs, line, "urgent",
+    kind: :inline_pill, fg: 0xFFFFFF, bg: 0xDC2626, group: :org_tags)
+
+  # Inline text: dimmed annotation (git blame style)
+  {_id, decs} = Minga.Buffer.Decorations.add_annotation(decs, line, "J. Smith, 2d ago",
+    kind: :inline_text, fg: 0x888888, group: :git_blame)
+
+  decs
+end)
+```
+
+**Options:**
+
+- `:kind` (default `:inline_pill`) -- `:inline_pill`, `:inline_text`, or `:gutter_icon`
+- `:fg` (default `0xFFFFFF`) -- foreground color, 24-bit RGB
+- `:bg` (default `0x6366F1`) -- background color, 24-bit RGB (only used by `:inline_pill`)
+- `:group` -- atom for bulk removal via `remove_group/2`
+- `:priority` (default `0`) -- ordering when multiple annotations share a line (lower first)
+
+Annotations are line-anchored: they automatically shift when lines are inserted or deleted above them. Deleting the line an annotation is on removes the annotation.
+
 ---
 
 ## Tree-Sitter Grammars

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -532,6 +532,19 @@ Diagnostic ranges section:
   diag_count(2)
   Per range: start_row(2) + start_col(2) + end_row(2) + end_col(2) + severity(1)
   Severity: 0=error, 1=warning, 2=info, 3=hint
+
+Document highlights section:
+  highlight_count(2)
+  Per highlight: start_row(2) + start_col(2) + end_row(2) + end_col(2) + kind(1)
+  Kind: 1=text, 2=read, 3=write
+
+Line annotations section:
+  annotation_count(2)
+  Per annotation: row(2) + kind(1) + fg(3) + bg(3) + text_len(2) + text(text_len)
+  Kind: 0=inline_pill, 1=inline_text, 2=gutter_icon
+  fg/bg are 24-bit RGB. text is UTF-8, text_len is byte length.
+  The frontend renders inline_pill as rounded-rect pills, inline_text as styled
+  text after line content, and gutter_icon in the sign column.
 ```
 
 The frontend renders selection and search matches as Metal quads behind text (not baked into line textures). This enables zero re-rasterization when the selection changes. Diagnostic underlines are rendered as quads after text.

--- a/lib/minga/buffer/decorations.ex
+++ b/lib/minga/buffer/decorations.ex
@@ -41,6 +41,7 @@ defmodule Minga.Buffer.Decorations do
   alias Minga.Buffer.Decorations.ConcealRange
   alias Minga.Buffer.Decorations.FoldRegion
   alias Minga.Buffer.Decorations.HighlightRange
+  alias Minga.Buffer.Decorations.LineAnnotation
   alias Minga.Buffer.Decorations.VirtualText
   alias Minga.Buffer.IntervalTree
   alias Minga.Face
@@ -87,6 +88,7 @@ defmodule Minga.Buffer.Decorations do
 
   - `highlights`: interval tree of highlight ranges
   - `virtual_texts`: list of virtual text decorations (queried by line, not range)
+  - `annotations`: list of line annotations (pill badges, inline text, gutter icons)
   - `fold_regions`: list of buffer-level fold regions (per-buffer, not per-window)
   - `block_decorations`: list of block decorations (custom-rendered lines between buffer lines)
   - `conceal_ranges`: list of conceal ranges (hidden buffer text with optional replacement)
@@ -96,24 +98,28 @@ defmodule Minga.Buffer.Decorations do
   @type t :: %__MODULE__{
           highlights: IntervalTree.t(),
           virtual_texts: [VirtualText.t()],
+          annotations: [LineAnnotation.t()],
           fold_regions: [FoldRegion.t()],
           block_decorations: [BlockDecoration.t()],
           conceal_ranges: [ConcealRange.t()],
           pending:
             [{:add, highlight_range()} | {:remove, reference()} | {:remove_group, term()}] | nil,
           version: non_neg_integer(),
-          vt_line_cache: %{non_neg_integer() => [VirtualText.t()]} | nil
+          vt_line_cache: %{non_neg_integer() => [VirtualText.t()]} | nil,
+          ann_line_cache: %{non_neg_integer() => [LineAnnotation.t()]} | nil
         }
 
   @enforce_keys []
   defstruct highlights: nil,
             virtual_texts: [],
+            annotations: [],
             fold_regions: [],
             block_decorations: [],
             conceal_ranges: [],
             pending: nil,
             version: 0,
-            vt_line_cache: nil
+            vt_line_cache: nil,
+            ann_line_cache: nil
 
   # ── Construction ─────────────────────────────────────────────────────────
 
@@ -201,10 +207,12 @@ defmodule Minga.Buffer.Decorations do
       decs
       | pending: [{:remove_group, group} | pending],
         virtual_texts: Enum.reject(decs.virtual_texts, &(&1.group == group)),
+        annotations: Enum.reject(decs.annotations, &(&1.group == group)),
         block_decorations: Enum.reject(decs.block_decorations, &(&1.group == group)),
         fold_regions: Enum.reject(decs.fold_regions, &(&1.group == group)),
         conceal_ranges: Enum.reject(decs.conceal_ranges, &(&1.group == group)),
-        vt_line_cache: nil
+        vt_line_cache: nil,
+        ann_line_cache: nil
     }
   end
 
@@ -213,6 +221,7 @@ defmodule Minga.Buffer.Decorations do
       IntervalTree.map_filter(decs.highlights, &filter_group(&1, group))
 
     new_virtual_texts = Enum.reject(decs.virtual_texts, &(&1.group == group))
+    new_annotations = Enum.reject(decs.annotations, &(&1.group == group))
     new_blocks = Enum.reject(decs.block_decorations, &(&1.group == group))
     new_folds = Enum.reject(decs.fold_regions, &(&1.group == group))
     new_conceals = Enum.reject(decs.conceal_ranges, &(&1.group == group))
@@ -221,11 +230,13 @@ defmodule Minga.Buffer.Decorations do
       decs
       | highlights: new_highlights,
         virtual_texts: new_virtual_texts,
+        annotations: new_annotations,
         block_decorations: new_blocks,
         fold_regions: new_folds,
         conceal_ranges: new_conceals,
         version: decs.version + 1,
-        vt_line_cache: nil
+        vt_line_cache: nil,
+        ann_line_cache: nil
     }
   end
 
@@ -702,6 +713,105 @@ defmodule Minga.Buffer.Decorations do
     if el > line, do: @max_col, else: ec
   end
 
+  # ── Line annotation API ────────────────────────────────────────────────────
+
+  @doc """
+  Adds a line annotation to the buffer. Returns `{id, updated_decorations}`.
+
+  ## Options
+
+  - `:kind` (optional, default `:inline_pill`) - `:inline_pill`, `:inline_text`, or `:gutter_icon`
+  - `:fg` (optional, default `0xFFFFFF`) - foreground color (24-bit RGB)
+  - `:bg` (optional, default `0x6366F1`) - background color (24-bit RGB)
+  - `:group` (optional) - atom for bulk removal (e.g., `:org_tags`, `:agent`)
+  - `:priority` (optional, default 0) - ordering when multiple annotations share a line
+
+  ## Examples
+
+      {id, decs} = Decorations.add_annotation(decs, 5, "work",
+        kind: :inline_pill, fg: 0xFFFFFF, bg: 0x6366F1, group: :org_tags)
+
+      {id, decs} = Decorations.add_annotation(decs, 10, "J. Smith, 2d ago",
+        kind: :inline_text, fg: 0x888888, group: :git_blame)
+  """
+  @spec add_annotation(t(), non_neg_integer(), String.t(), keyword()) :: {reference(), t()}
+  def add_annotation(%__MODULE__{} = decs, line, text, opts \\ [])
+      when is_integer(line) and line >= 0 and is_binary(text) do
+    id = make_ref()
+
+    ann = %LineAnnotation{
+      id: id,
+      line: line,
+      text: text,
+      kind: Keyword.get(opts, :kind, :inline_pill),
+      fg: Keyword.get(opts, :fg, 0xFFFFFF),
+      bg: Keyword.get(opts, :bg, 0x6366F1),
+      group: Keyword.get(opts, :group),
+      priority: Keyword.get(opts, :priority, 0)
+    }
+
+    new_anns = [ann | decs.annotations]
+    {id, %{decs | annotations: new_anns, version: decs.version + 1, ann_line_cache: nil}}
+  end
+
+  @doc "Removes a line annotation by ID."
+  @spec remove_annotation(t(), reference()) :: t()
+  def remove_annotation(%__MODULE__{} = decs, id) do
+    case Enum.split_with(decs.annotations, fn ann -> ann.id == id end) do
+      {[], _} ->
+        decs
+
+      {_, remaining} ->
+        %{decs | annotations: remaining, version: decs.version + 1, ann_line_cache: nil}
+    end
+  end
+
+  # ── Line annotation queries ──────────────────────────────────────────────
+
+  @doc """
+  Returns all annotations for a specific line, sorted by priority.
+  """
+  @spec annotations_for_line(t(), non_neg_integer()) :: [LineAnnotation.t()]
+  def annotations_for_line(%__MODULE__{ann_line_cache: cache}, line) when cache != nil do
+    Map.get(cache, line, [])
+  end
+
+  def annotations_for_line(%__MODULE__{annotations: anns}, line) do
+    anns
+    |> Enum.filter(fn %LineAnnotation{line: l} -> l == line end)
+    |> Enum.sort_by(fn %LineAnnotation{priority: p} -> p end)
+  end
+
+  @doc """
+  Builds the annotation line cache for O(1) per-line lookups.
+
+  Call once before a render pass. The cache is invalidated on any
+  annotation mutation.
+  """
+  @spec build_ann_line_cache(t()) :: t()
+  def build_ann_line_cache(%__MODULE__{ann_line_cache: cache} = decs) when cache != nil, do: decs
+
+  def build_ann_line_cache(%__MODULE__{annotations: []} = decs) do
+    %{decs | ann_line_cache: %{}}
+  end
+
+  def build_ann_line_cache(%__MODULE__{annotations: anns} = decs) do
+    cache =
+      anns
+      |> Enum.group_by(fn %LineAnnotation{line: l} -> l end)
+      |> Map.new(fn {line, line_anns} ->
+        sorted = Enum.sort_by(line_anns, fn %LineAnnotation{priority: p} -> p end)
+        {line, sorted}
+      end)
+
+    %{decs | ann_line_cache: cache}
+  end
+
+  @doc "Returns true if there are any annotations."
+  @spec has_annotations?(t()) :: boolean()
+  def has_annotations?(%__MODULE__{annotations: []}), do: false
+  def has_annotations?(%__MODULE__{}), do: true
+
   # ── Column mapping (inline virtual text + conceals) ──────────────────────
 
   @doc """
@@ -982,6 +1092,7 @@ defmodule Minga.Buffer.Decorations do
   def empty?(%__MODULE__{
         highlights: nil,
         virtual_texts: [],
+        annotations: [],
         fold_regions: [],
         block_decorations: [],
         conceal_ranges: []
@@ -991,12 +1102,13 @@ defmodule Minga.Buffer.Decorations do
   def empty?(%__MODULE__{
         highlights: hl,
         virtual_texts: vts,
+        annotations: anns,
         fold_regions: folds,
         block_decorations: blocks,
         conceal_ranges: conceals
       }) do
-    (hl == nil or IntervalTree.empty?(hl)) and vts == [] and folds == [] and blocks == [] and
-      conceals == []
+    (hl == nil or IntervalTree.empty?(hl)) and vts == [] and anns == [] and folds == [] and
+      blocks == [] and conceals == []
   end
 
   # ── Anchor adjustment ───────────────────────────────────────────────────
@@ -1024,8 +1136,9 @@ defmodule Minga.Buffer.Decorations do
           IntervalTree.position()
         ) :: t()
   def adjust_for_edit(%__MODULE__{} = decs, _edit_start, _edit_end, _new_end)
-      when decs.highlights == nil and decs.virtual_texts == [] and decs.fold_regions == [] and
-             decs.block_decorations == [] and decs.conceal_ranges == [],
+      when decs.highlights == nil and decs.virtual_texts == [] and decs.annotations == [] and
+             decs.fold_regions == [] and decs.block_decorations == [] and
+             decs.conceal_ranges == [],
       do: decs
 
   def adjust_for_edit(%__MODULE__{} = decs, edit_start, edit_end, new_end) do
@@ -1046,6 +1159,7 @@ defmodule Minga.Buffer.Decorations do
       end
 
     new_vts = adjust_virtual_texts(decs.virtual_texts, ctx)
+    new_anns = adjust_annotations(decs.annotations, ctx)
     new_folds = adjust_fold_regions(decs.fold_regions, ctx)
 
     new_blocks = adjust_block_decorations(decs.block_decorations, ctx)
@@ -1055,11 +1169,13 @@ defmodule Minga.Buffer.Decorations do
       decs
       | highlights: new_highlights,
         virtual_texts: new_vts,
+        annotations: new_anns,
         fold_regions: new_folds,
         block_decorations: new_blocks,
         conceal_ranges: new_conceals,
         version: decs.version + 1,
-        vt_line_cache: nil
+        vt_line_cache: nil,
+        ann_line_cache: nil
     }
   end
 
@@ -1076,6 +1192,44 @@ defmodule Minga.Buffer.Decorations do
     new_anchor = adjust_anchor_position(anchor, ctx)
     %{vt | anchor: new_anchor}
   end
+
+  # ── Annotation edit adjustment ──────────────────────────────────────────
+
+  # Annotations are line-anchored (no column). On deletion, annotations
+  # whose line falls within the deleted range are removed (a deleted line's
+  # annotation is semantically void). Survivors after the edit are shifted
+  # by line_delta.
+  @spec adjust_annotations([LineAnnotation.t()], edit_ctx()) :: [LineAnnotation.t()]
+  defp adjust_annotations([], _ctx), do: []
+
+  defp adjust_annotations(anns, ctx) do
+    {edit_start_line, _} = ctx.edit_start
+    {edit_end_line, _} = ctx.edit_end
+
+    anns
+    |> Enum.reject(fn ann ->
+      # Remove annotations on lines entirely within a deleted range
+      ctx.is_delete and ann.line >= edit_start_line and ann.line < edit_end_line
+    end)
+    |> Enum.map(&shift_ann_line(&1, edit_start_line, edit_end_line, ctx.line_delta))
+  end
+
+  # After the edit: shift by line delta
+  @spec shift_ann_line(LineAnnotation.t(), non_neg_integer(), non_neg_integer(), integer()) ::
+          LineAnnotation.t()
+  defp shift_ann_line(%LineAnnotation{line: l} = ann, _start_line, end_line, delta)
+       when l > end_line do
+    %{ann | line: l + delta}
+  end
+
+  # Within the edit region but not deleted: clamp to edit start
+  defp shift_ann_line(%LineAnnotation{line: l} = ann, start_line, _end_line, _delta)
+       when l >= start_line do
+    %{ann | line: start_line}
+  end
+
+  # Before the edit: no change
+  defp shift_ann_line(ann, _start_line, _end_line, _delta), do: ann
 
   @spec adjust_anchor_position(IntervalTree.position(), edit_ctx()) :: IntervalTree.position()
   defp adjust_anchor_position(anchor, ctx) when anchor < ctx.edit_start, do: anchor

--- a/lib/minga/buffer/decorations/line_annotation.ex
+++ b/lib/minga/buffer/decorations/line_annotation.ex
@@ -1,0 +1,59 @@
+defmodule Minga.Buffer.Decorations.LineAnnotation do
+  @moduledoc """
+  A line annotation decoration: structured metadata attached to a buffer line.
+
+  Annotations display visual metadata alongside buffer content without
+  modifying the text. They come in three kinds:
+
+  - `:inline_pill` - colored pill badge (rounded rect background + text)
+    rendered after line content. Used for tags, labels, status indicators.
+  - `:inline_text` - styled text (no background pill) rendered after line
+    content. Used for git blame, inline hints, dimmed annotations.
+  - `:gutter_icon` - icon or symbol rendered in the gutter sign column.
+    Used for bookmarks, breakpoints, markers.
+
+  Each frontend renders annotations according to its capabilities:
+  - **GUI (Swift/Metal):** pills as CoreText bitmaps with rounded rect
+    backgrounds; inline text as styled runs; gutter icons natively.
+  - **TUI (Zig/libvaxis):** pills as space-padded text with terminal
+    background color; inline text as dimmed text; gutter icons as
+    characters in the sign column.
+
+  ## Examples
+
+      %LineAnnotation{
+        id: make_ref(),
+        line: 5,
+        text: "work",
+        kind: :inline_pill,
+        fg: 0xFFFFFF,
+        bg: 0x6366F1,
+        group: :org_tags,
+        priority: 0
+      }
+  """
+
+  @enforce_keys [:id, :line, :text, :kind]
+  defstruct id: nil,
+            line: 0,
+            text: "",
+            kind: :inline_pill,
+            fg: 0xFFFFFF,
+            bg: 0x6366F1,
+            group: nil,
+            priority: 0
+
+  @typedoc "The visual kind of annotation."
+  @type kind :: :inline_pill | :inline_text | :gutter_icon
+
+  @type t :: %__MODULE__{
+          id: reference(),
+          line: non_neg_integer(),
+          text: String.t(),
+          kind: kind(),
+          fg: non_neg_integer(),
+          bg: non_neg_integer(),
+          group: term() | nil,
+          priority: integer()
+        }
+end

--- a/lib/minga/editor/renderer/line.ex
+++ b/lib/minga/editor/renderer/line.ex
@@ -130,6 +130,7 @@ defmodule Minga.Editor.Renderer.Line do
         )
     end
     |> append_eol_virtual_text(screen_row, buf_line, line_display_len, ctx)
+    |> append_annotations(screen_row, buf_line, line_display_len, ctx)
   end
 
   # Appends EOL virtual text draw commands after the line content.
@@ -178,6 +179,83 @@ defmodule Minga.Editor.Renderer.Line do
       draw = DisplayList.draw(screen_row, col, text, style)
       {[draw | draws], col + width}
     end)
+  end
+
+  # Appends line annotation draw commands after EOL virtual text.
+  # Pill annotations render with background color; inline text without.
+  # Gutter icons are handled separately in the gutter renderer.
+  @spec append_annotations(
+          [DisplayList.draw()],
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          Context.t()
+        ) :: [DisplayList.draw()]
+  defp append_annotations(draws, _screen_row, _buf_line, _line_len, %{
+         decorations: %{annotations: []}
+       }),
+       do: draws
+
+  defp append_annotations(draws, screen_row, buf_line, line_display_len, ctx) do
+    anns = Decorations.annotations_for_line(ctx.decorations, buf_line)
+
+    if anns == [] do
+      draws
+    else
+      # Annotations start after the last drawn content on this line.
+      # We compute the current end column from existing draws.
+      ann_start = max_draw_end_col(draws, line_display_len, ctx)
+
+      {ann_draws, _col} =
+        Enum.reduce(anns, {[], ann_start}, fn ann, {acc, col} ->
+          render_annotation(ann, screen_row, col, acc)
+        end)
+
+      draws ++ Enum.reverse(ann_draws)
+    end
+  end
+
+  # Computes the column after the last draw command, so annotations
+  # don't overlap with EOL virtual text.
+  @spec max_draw_end_col([DisplayList.draw()], non_neg_integer(), Context.t()) ::
+          non_neg_integer()
+  defp max_draw_end_col(draws, line_display_len, ctx) do
+    base = max(line_display_len + 1 - ctx.viewport.left, 0) + ctx.gutter_w
+
+    Enum.reduce(draws, base, fn draw, acc ->
+      {_row, col, text, _style} = draw
+      draw_end = col + Unicode.display_width(text)
+      max(acc, draw_end + 1)
+    end)
+  end
+
+  @spec render_annotation(
+          Decorations.LineAnnotation.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          [DisplayList.draw()]
+        ) :: {[DisplayList.draw()], non_neg_integer()}
+  defp render_annotation(%{kind: :inline_pill} = ann, screen_row, col, acc) do
+    # Pill: space-padded text with background color
+    text = " #{ann.text} "
+    style = Face.new(fg: ann.fg, bg: ann.bg, bold: true)
+    width = Unicode.display_width(text)
+    draw = DisplayList.draw(screen_row, col, text, style)
+    {[draw | acc], col + width + 1}
+  end
+
+  defp render_annotation(%{kind: :inline_text} = ann, screen_row, col, acc) do
+    # Inline text: styled text, no background
+    style = Face.new(fg: ann.fg)
+    width = Unicode.display_width(ann.text)
+    draw = DisplayList.draw(screen_row, col, ann.text, style)
+    {[draw | acc], col + width + 1}
+  end
+
+  defp render_annotation(%{kind: :gutter_icon}, _screen_row, col, acc) do
+    # Gutter icons are rendered in the gutter renderer, not at EOL.
+    # Skip here.
+    {acc, col}
   end
 
   # ── Display-width helpers ─────────────────────────────────────────────────

--- a/lib/minga/editor/semantic_window.ex
+++ b/lib/minga/editor/semantic_window.ex
@@ -32,7 +32,14 @@ defmodule Minga.Editor.SemanticWindow do
      change).
   """
 
-  alias __MODULE__.{DiagnosticRange, DocumentHighlightRange, SearchMatch, Selection, VisualRow}
+  alias __MODULE__.{
+    DiagnosticRange,
+    DocumentHighlightRange,
+    ResolvedAnnotation,
+    SearchMatch,
+    Selection,
+    VisualRow
+  }
 
   @enforce_keys [:window_id, :rows, :cursor_row, :cursor_col, :cursor_shape]
   defstruct window_id: 0,
@@ -46,6 +53,7 @@ defmodule Minga.Editor.SemanticWindow do
             search_matches: [],
             diagnostic_ranges: [],
             document_highlights: [],
+            annotations: [],
             full_refresh: true
 
   @type cursor_shape :: :block | :beam | :underline
@@ -62,6 +70,7 @@ defmodule Minga.Editor.SemanticWindow do
           search_matches: [SearchMatch.t()],
           diagnostic_ranges: [DiagnosticRange.t()],
           document_highlights: [DocumentHighlightRange.t()],
+          annotations: [ResolvedAnnotation.t()],
           full_refresh: boolean()
         }
 end

--- a/lib/minga/editor/semantic_window/builder.ex
+++ b/lib/minga/editor/semantic_window/builder.ex
@@ -30,6 +30,7 @@ defmodule Minga.Editor.SemanticWindow.Builder do
   alias Minga.Editor.SemanticWindow
   alias Minga.Editor.SemanticWindow.DiagnosticRange
   alias Minga.Editor.SemanticWindow.DocumentHighlightRange
+  alias Minga.Editor.SemanticWindow.ResolvedAnnotation
   alias Minga.Editor.SemanticWindow.SearchMatch
   alias Minga.Editor.SemanticWindow.Selection
   alias Minga.Editor.SemanticWindow.Span
@@ -124,6 +125,10 @@ defmodule Minga.Editor.SemanticWindow.Builder do
     doc_highlights =
       build_document_highlights(state.document_highlights, viewport.top, viewport_bottom)
 
+    # Line annotations in display coordinates
+    annotations =
+      build_annotations(ctx.decorations, viewport.top, viewport_bottom)
+
     %SemanticWindow{
       window_id: win_id,
       rows: visual_rows,
@@ -136,6 +141,7 @@ defmodule Minga.Editor.SemanticWindow.Builder do
       search_matches: search_matches,
       diagnostic_ranges: diagnostic_ranges,
       document_highlights: doc_highlights,
+      annotations: annotations,
       full_refresh: true
     }
   end
@@ -393,6 +399,29 @@ defmodule Minga.Editor.SemanticWindow.Builder do
         end_row: hl.end_line - viewport_top,
         end_col: hl.end_col,
         kind: hl.kind
+      }
+    end)
+  end
+
+  # ── Line annotations ──────────────────────────────────────────────────
+
+  @spec build_annotations(Decorations.t(), non_neg_integer(), non_neg_integer()) ::
+          [ResolvedAnnotation.t()]
+  defp build_annotations(%Decorations{annotations: []}, _top, _bottom), do: []
+
+  defp build_annotations(%Decorations{} = decorations, viewport_top, viewport_bottom) do
+    decorations.annotations
+    |> Enum.filter(fn ann ->
+      ann.line >= viewport_top and ann.line < viewport_bottom
+    end)
+    |> Enum.sort_by(fn ann -> {ann.line, ann.priority} end)
+    |> Enum.map(fn ann ->
+      %ResolvedAnnotation{
+        row: ann.line - viewport_top,
+        kind: ann.kind,
+        fg: ann.fg,
+        bg: ann.bg,
+        text: ann.text
       }
     end)
   end

--- a/lib/minga/editor/semantic_window/resolved_annotation.ex
+++ b/lib/minga/editor/semantic_window/resolved_annotation.ex
@@ -1,0 +1,22 @@
+defmodule Minga.Editor.SemanticWindow.ResolvedAnnotation do
+  @moduledoc """
+  A line annotation resolved to display coordinates for GUI rendering.
+
+  Built by the SemanticWindow.Builder from buffer decorations, this struct
+  contains the display row and the annotation's visual properties. Consumed
+  by the GUI protocol encoder (0x80 wire format) and the TUI render pipeline.
+  """
+
+  alias Minga.Buffer.Decorations.LineAnnotation
+
+  @enforce_keys [:row, :kind, :fg, :bg, :text]
+  defstruct [:row, :kind, :fg, :bg, :text]
+
+  @type t :: %__MODULE__{
+          row: non_neg_integer(),
+          kind: LineAnnotation.kind(),
+          fg: non_neg_integer(),
+          bg: non_neg_integer(),
+          text: String.t()
+        }
+end

--- a/lib/minga/port/protocol/gui_window_content.ex
+++ b/lib/minga/port/protocol/gui_window_content.ex
@@ -49,6 +49,15 @@ defmodule Minga.Port.Protocol.GUIWindowContent do
   per highlight: start_row(u16), start_col(u16), end_row(u16), end_col(u16),
                  kind(u8)
   Kind: 1=text, 2=read, 3=write
+
+  annotation_count:     u16
+  per annotation:
+    row:                u16      (display row)
+    kind:               u8       (0=inline_pill, 1=inline_text, 2=gutter_icon)
+    fg:                 u24
+    bg:                 u24
+    text_len:           u16
+    text:               [text_len] UTF-8
   ```
   """
 
@@ -57,6 +66,7 @@ defmodule Minga.Port.Protocol.GUIWindowContent do
   alias Minga.Editor.SemanticWindow
   alias Minga.Editor.SemanticWindow.DiagnosticRange
   alias Minga.Editor.SemanticWindow.DocumentHighlightRange
+  alias Minga.Editor.SemanticWindow.ResolvedAnnotation
   alias Minga.Editor.SemanticWindow.SearchMatch
   alias Minga.Editor.SemanticWindow.Selection
   alias Minga.Editor.SemanticWindow.Span
@@ -88,6 +98,7 @@ defmodule Minga.Port.Protocol.GUIWindowContent do
     matches_binary = encode_search_matches(sw.search_matches)
     diag_binary = encode_diagnostic_ranges(sw.diagnostic_ranges)
     highlight_binary = encode_document_highlights(sw.document_highlights)
+    annotation_binary = encode_annotations(sw.annotations)
 
     IO.iodata_to_binary([
       header,
@@ -95,7 +106,8 @@ defmodule Minga.Port.Protocol.GUIWindowContent do
       selection_binary,
       matches_binary,
       diag_binary,
-      highlight_binary
+      highlight_binary,
+      annotation_binary
     ])
   end
 
@@ -223,6 +235,37 @@ defmodule Minga.Port.Protocol.GUIWindowContent do
   defp encode_highlight_kind(:text), do: 1
   defp encode_highlight_kind(:read), do: 2
   defp encode_highlight_kind(:write), do: 3
+
+  # ── Line annotations ─────────────────────────────────────────────────────
+
+  @spec encode_annotations([ResolvedAnnotation.t()]) :: binary()
+  defp encode_annotations(annotations) do
+    count = length(annotations)
+    entries = Enum.map(annotations, &encode_annotation/1)
+    IO.iodata_to_binary([<<count::16>> | entries])
+  end
+
+  @spec encode_annotation(ResolvedAnnotation.t()) :: binary()
+  defp encode_annotation(%ResolvedAnnotation{} = ann) do
+    kind = encode_annotation_kind(ann.kind)
+    fg_r = ann.fg >>> 16 &&& 0xFF
+    fg_g = ann.fg >>> 8 &&& 0xFF
+    fg_b = ann.fg &&& 0xFF
+    bg_r = ann.bg >>> 16 &&& 0xFF
+    bg_g = ann.bg >>> 8 &&& 0xFF
+    bg_b = ann.bg &&& 0xFF
+    text_bytes = ann.text
+    text_len = byte_size(text_bytes)
+
+    <<ann.row::16, kind::8, fg_r::8, fg_g::8, fg_b::8, bg_r::8, bg_g::8, bg_b::8, text_len::16,
+      text_bytes::binary>>
+  end
+
+  @spec encode_annotation_kind(Minga.Buffer.Decorations.LineAnnotation.kind()) ::
+          non_neg_integer()
+  defp encode_annotation_kind(:inline_pill), do: 0
+  defp encode_annotation_kind(:inline_text), do: 1
+  defp encode_annotation_kind(:gutter_icon), do: 2
 
   # ── Cursor shape ────────────────────────────────────────────────────────
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1349,6 +1349,33 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             }
         }
 
+        // Line annotations: count:2, then per annotation: row:2 + kind:1 + fg:3 + bg:3 + text_len:2 + text
+        var lineAnnotations: [GUILineAnnotation] = []
+        if data.count >= pos + 2 {
+            let annotationCount = Int(readU16(data, pos))
+            pos += 2
+            lineAnnotations.reserveCapacity(annotationCount)
+            for _ in 0..<annotationCount {
+                guard data.count >= pos + 11 else { throw ProtocolDecodeError.malformed }
+                let annRow = readU16(data, pos)
+                let annKind = GUILineAnnotationKind(rawValue: data[pos + 2]) ?? .inlinePill
+                let annFg = readU24(data, pos + 3)
+                let annBg = readU24(data, pos + 6)
+                let annTextLen = Int(readU16(data, pos + 9))
+                pos += 11
+                guard data.count >= pos + annTextLen else { throw ProtocolDecodeError.malformed }
+                let annText = String(data: Data(data[pos..<(pos + annTextLen)]), encoding: .utf8) ?? ""
+                pos += annTextLen
+                lineAnnotations.append(GUILineAnnotation(
+                    row: annRow,
+                    kind: annKind,
+                    fg: annFg,
+                    bg: annBg,
+                    text: annText
+                ))
+            }
+        }
+
         let content = GUIWindowContent(
             windowId: windowId,
             fullRefresh: (flags & 0x01) != 0,
@@ -1361,7 +1388,8 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             selection: selection,
             searchMatches: matches,
             diagnosticUnderlines: diags,
-            documentHighlights: docHighlights
+            documentHighlights: docHighlights,
+            lineAnnotations: lineAnnotations
         )
         return (.guiWindowContent(data: content), pos - offset)
 

--- a/macos/Sources/Renderer/WindowContent.swift
+++ b/macos/Sources/Renderer/WindowContent.swift
@@ -122,6 +122,28 @@ struct GUIDocumentHighlight: Sendable, Equatable {
     let kind: GUIDocumentHighlightKind
 }
 
+// MARK: - Line annotation
+
+/// The visual kind of a line annotation.
+enum GUILineAnnotationKind: UInt8, Sendable {
+    case inlinePill = 0
+    case inlineText = 1
+    case gutterIcon = 2
+}
+
+/// A line annotation in display coordinates.
+///
+/// Pill badges render as rounded-rect pills after line content.
+/// Inline text renders as styled text after line content (no background).
+/// Gutter icons render in the sign column.
+struct GUILineAnnotation: Sendable, Equatable {
+    let row: UInt16
+    let kind: GUILineAnnotationKind
+    let fg: UInt32      // 24-bit RGB
+    let bg: UInt32      // 24-bit RGB
+    let text: String
+}
+
 // MARK: - Window content
 
 /// Complete semantic content for one editor window.
@@ -147,6 +169,7 @@ final class GUIWindowContent: Sendable {
     let searchMatches: [GUISearchMatch]
     let diagnosticUnderlines: [GUIDiagnosticUnderline]
     let documentHighlights: [GUIDocumentHighlight]
+    let lineAnnotations: [GUILineAnnotation]
 
     init(windowId: UInt16, fullRefresh: Bool, cursorVisible: Bool = true,
          cursorRow: UInt16, cursorCol: UInt16, cursorShape: CursorShape,
@@ -154,7 +177,8 @@ final class GUIWindowContent: Sendable {
          rows: [GUIVisualRow], selection: GUISelectionOverlay?,
          searchMatches: [GUISearchMatch],
          diagnosticUnderlines: [GUIDiagnosticUnderline],
-         documentHighlights: [GUIDocumentHighlight]) {
+         documentHighlights: [GUIDocumentHighlight],
+         lineAnnotations: [GUILineAnnotation] = []) {
         self.windowId = windowId
         self.fullRefresh = fullRefresh
         self.cursorVisible = cursorVisible
@@ -167,5 +191,6 @@ final class GUIWindowContent: Sendable {
         self.searchMatches = searchMatches
         self.diagnosticUnderlines = diagnosticUnderlines
         self.documentHighlights = documentHighlights
+        self.lineAnnotations = lineAnnotations
     }
 }

--- a/test/minga/buffer/decorations_test.exs
+++ b/test/minga/buffer/decorations_test.exs
@@ -630,4 +630,246 @@ defmodule Minga.Buffer.DecorationsTest do
       assert result.version == decs.version + 1
     end
   end
+
+  # ── Line annotation tests ──────────────────────────────────────────────
+
+  describe "add_annotation/4" do
+    test "adds an annotation and returns its ID" do
+      decs = Decorations.new()
+      {id, decs} = Decorations.add_annotation(decs, 5, "3 errors")
+
+      assert is_reference(id)
+      assert Decorations.has_annotations?(decs)
+    end
+
+    test "bumps version on add" do
+      decs = Decorations.new()
+      v0 = decs.version
+      {_id, decs} = Decorations.add_annotation(decs, 5, "test")
+
+      assert decs.version == v0 + 1
+    end
+
+    test "invalidates ann_line_cache on add" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 5, "first")
+      decs = Decorations.build_ann_line_cache(decs)
+      assert decs.ann_line_cache != nil
+
+      {_id, decs} = Decorations.add_annotation(decs, 10, "second")
+      assert decs.ann_line_cache == nil
+    end
+
+    test "respects kind, fg, bg, group, priority options" do
+      decs = Decorations.new()
+
+      {_id, decs} =
+        Decorations.add_annotation(decs, 3, "urgent",
+          kind: :inline_text,
+          fg: 0xFF0000,
+          bg: 0x00FF00,
+          group: :tags,
+          priority: 10
+        )
+
+      [ann] = Decorations.annotations_for_line(decs, 3)
+      assert ann.kind == :inline_text
+      assert ann.fg == 0xFF0000
+      assert ann.bg == 0x00FF00
+      assert ann.group == :tags
+      assert ann.priority == 10
+    end
+  end
+
+  describe "remove_annotation/2" do
+    test "removes a specific annotation by ID" do
+      decs = Decorations.new()
+      {id1, decs} = Decorations.add_annotation(decs, 5, "first")
+      {_id2, decs} = Decorations.add_annotation(decs, 10, "second")
+
+      decs = Decorations.remove_annotation(decs, id1)
+
+      assert Decorations.annotations_for_line(decs, 5) == []
+      assert length(Decorations.annotations_for_line(decs, 10)) == 1
+    end
+
+    test "no-op for non-existent ID" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 5, "test")
+      v = decs.version
+
+      decs = Decorations.remove_annotation(decs, make_ref())
+
+      assert Decorations.has_annotations?(decs)
+      assert decs.version == v
+    end
+  end
+
+  describe "annotations_for_line/2" do
+    test "returns annotations sorted by priority" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 5, "high", priority: 20)
+      {_id, decs} = Decorations.add_annotation(decs, 5, "low", priority: 5)
+      {_id, decs} = Decorations.add_annotation(decs, 5, "mid", priority: 10)
+
+      anns = Decorations.annotations_for_line(decs, 5)
+      texts = Enum.map(anns, & &1.text)
+      assert texts == ["low", "mid", "high"]
+    end
+
+    test "returns empty list for line with no annotations" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 5, "test")
+
+      assert Decorations.annotations_for_line(decs, 10) == []
+    end
+
+    test "returns all annotations on a line" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 0, "a")
+      {_id, decs} = Decorations.add_annotation(decs, 0, "b")
+      {_id, decs} = Decorations.add_annotation(decs, 0, "c")
+
+      assert length(Decorations.annotations_for_line(decs, 0)) == 3
+    end
+  end
+
+  describe "build_ann_line_cache/1" do
+    test "builds cache and subsequent queries use it" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 0, "a")
+      {_id, decs} = Decorations.add_annotation(decs, 5, "b")
+      {_id, decs} = Decorations.add_annotation(decs, 10, "c")
+
+      decs = Decorations.build_ann_line_cache(decs)
+      assert decs.ann_line_cache != nil
+
+      # Queries should still work correctly with cache
+      assert length(Decorations.annotations_for_line(decs, 5)) == 1
+      assert Decorations.annotations_for_line(decs, 3) == []
+    end
+
+    test "returns unchanged when cache already built" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 5, "test")
+      decs = Decorations.build_ann_line_cache(decs)
+
+      assert decs == Decorations.build_ann_line_cache(decs)
+    end
+
+    test "handles empty annotations" do
+      decs = Decorations.new()
+      decs = Decorations.build_ann_line_cache(decs)
+
+      assert decs.ann_line_cache == %{}
+    end
+  end
+
+  describe "remove_group/2 with annotations" do
+    test "removes all annotations in a group" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 5, "lsp1", group: :lsp)
+      {_id, decs} = Decorations.add_annotation(decs, 10, "lsp2", group: :lsp)
+      {_id, decs} = Decorations.add_annotation(decs, 15, "agent", group: :agent)
+
+      decs = Decorations.remove_group(decs, :lsp)
+
+      assert Decorations.annotations_for_line(decs, 5) == []
+      assert Decorations.annotations_for_line(decs, 10) == []
+      assert length(Decorations.annotations_for_line(decs, 15)) == 1
+    end
+
+    test "no-op on non-existent group" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 5, "test", group: :lsp)
+
+      decs = Decorations.remove_group(decs, :nonexistent)
+
+      assert length(Decorations.annotations_for_line(decs, 5)) == 1
+    end
+  end
+
+  describe "adjust_for_edit/4 with annotations" do
+    test "insertion before annotation line shifts it forward" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 10, "test")
+
+      # Insert 3 lines at line 2
+      decs = Decorations.adjust_for_edit(decs, {2, 0}, {2, 0}, {5, 0})
+
+      [ann] = decs.annotations
+      assert ann.line == 13
+    end
+
+    test "insertion after annotation line leaves it unchanged" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 5, "test")
+
+      decs = Decorations.adjust_for_edit(decs, {20, 0}, {20, 0}, {23, 0})
+
+      [ann] = decs.annotations
+      assert ann.line == 5
+    end
+
+    test "deletion before annotation line shifts it back" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 10, "test")
+
+      # Delete lines 2-5 (3 lines)
+      decs = Decorations.adjust_for_edit(decs, {2, 0}, {5, 0}, {2, 0})
+
+      [ann] = decs.annotations
+      assert ann.line == 7
+    end
+
+    test "deletion spanning annotation line removes it" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 5, "test")
+
+      # Delete lines 3-8
+      decs = Decorations.adjust_for_edit(decs, {3, 0}, {8, 0}, {3, 0})
+
+      assert not Decorations.has_annotations?(decs)
+    end
+
+    test "annotation on line 0 survives insertion at line 0" do
+      decs = Decorations.new()
+      {_id, decs} = Decorations.add_annotation(decs, 0, "test")
+
+      # Insert at line 0 (pushes content down)
+      decs = Decorations.adjust_for_edit(decs, {0, 0}, {0, 0}, {2, 0})
+
+      [ann] = decs.annotations
+      # Annotation at line 0 is within the edit region; clamped to edit start
+      assert ann.line == 0
+    end
+
+    test "no-op on empty annotations" do
+      decs = Decorations.new()
+      decs = Decorations.adjust_for_edit(decs, {0, 0}, {0, 0}, {1, 0})
+
+      assert not Decorations.has_annotations?(decs)
+    end
+  end
+
+  describe "has_annotations?/1" do
+    test "false for new decorations" do
+      assert not Decorations.has_annotations?(Decorations.new())
+    end
+
+    test "true after adding an annotation" do
+      {_id, decs} = Decorations.add_annotation(Decorations.new(), 0, "test")
+      assert Decorations.has_annotations?(decs)
+    end
+  end
+
+  describe "empty?/1 with annotations" do
+    test "annotations count as non-empty" do
+      decs = Decorations.new()
+      assert Decorations.empty?(decs)
+
+      {_id, decs} = Decorations.add_annotation(decs, 0, "test")
+      assert not Decorations.empty?(decs)
+    end
+  end
 end

--- a/test/minga/port/protocol/gui_window_content_test.exs
+++ b/test/minga/port/protocol/gui_window_content_test.exs
@@ -12,6 +12,7 @@ defmodule Minga.Port.Protocol.GUIWindowContentTest do
 
   alias Minga.Editor.SemanticWindow
   alias Minga.Editor.SemanticWindow.DiagnosticRange
+  alias Minga.Editor.SemanticWindow.ResolvedAnnotation
   alias Minga.Editor.SemanticWindow.SearchMatch
   alias Minga.Editor.SemanticWindow.Selection
   alias Minga.Editor.SemanticWindow.Span
@@ -33,6 +34,7 @@ defmodule Minga.Port.Protocol.GUIWindowContentTest do
       selection: Keyword.get(opts, :selection, nil),
       search_matches: Keyword.get(opts, :search_matches, []),
       diagnostic_ranges: Keyword.get(opts, :diagnostic_ranges, []),
+      annotations: Keyword.get(opts, :annotations, []),
       full_refresh: Keyword.get(opts, :full_refresh, true)
     }
   end
@@ -364,6 +366,96 @@ defmodule Minga.Port.Protocol.GUIWindowContentTest do
       assert decoded.selection == nil
       assert decoded.search_matches == []
       assert decoded.diagnostic_ranges == []
+      assert decoded.annotations == []
+    end
+  end
+
+  # ── Round-trip: line annotations ────────────────────────────────────────
+
+  describe "round-trip: line annotations" do
+    test "empty annotations round-trip" do
+      decoded = round_trip(minimal_window(annotations: []))
+      assert decoded.annotations == []
+    end
+
+    test "inline_pill annotation round-trips" do
+      ann = %ResolvedAnnotation{
+        row: 5,
+        kind: :inline_pill,
+        fg: 0xFF6C6B,
+        bg: 0x3E4452,
+        text: "3 errors"
+      }
+
+      decoded = round_trip(minimal_window(annotations: [ann]))
+
+      assert length(decoded.annotations) == 1
+      [d] = decoded.annotations
+      assert d.row == 5
+      assert d.kind == :inline_pill
+      assert d.fg == 0xFF6C6B
+      assert d.bg == 0x3E4452
+      assert d.text == "3 errors"
+    end
+
+    test "all three annotation kinds round-trip" do
+      anns = [
+        %ResolvedAnnotation{row: 0, kind: :inline_pill, fg: 0xFFFFFF, bg: 0x6366F1, text: "pill"},
+        %ResolvedAnnotation{row: 1, kind: :inline_text, fg: 0x888888, bg: 0x000000, text: "text"},
+        %ResolvedAnnotation{row: 2, kind: :gutter_icon, fg: 0xFF0000, bg: 0x00FF00, text: "!"}
+      ]
+
+      decoded = round_trip(minimal_window(annotations: anns))
+
+      assert length(decoded.annotations) == 3
+      kinds = Enum.map(decoded.annotations, & &1.kind)
+      assert kinds == [:inline_pill, :inline_text, :gutter_icon]
+    end
+
+    test "unicode annotation text round-trips" do
+      ann = %ResolvedAnnotation{
+        row: 0,
+        kind: :inline_pill,
+        fg: 0xFFFFFF,
+        bg: 0x000000,
+        text: "⚠ 日本語"
+      }
+
+      decoded = round_trip(minimal_window(annotations: [ann]))
+
+      assert hd(decoded.annotations).text == "⚠ 日本語"
+    end
+
+    test "multiple annotations on same row round-trip" do
+      anns = [
+        %ResolvedAnnotation{row: 7, kind: :inline_pill, fg: 0xFFFFFF, bg: 0x6366F1, text: "work"},
+        %ResolvedAnnotation{
+          row: 7,
+          kind: :inline_pill,
+          fg: 0xFFFFFF,
+          bg: 0xDC2626,
+          text: "urgent"
+        },
+        %ResolvedAnnotation{
+          row: 7,
+          kind: :inline_text,
+          fg: 0x888888,
+          bg: 0x000000,
+          text: "3 tags"
+        }
+      ]
+
+      decoded = round_trip(minimal_window(annotations: anns))
+
+      assert length(decoded.annotations) == 3
+      assert Enum.all?(decoded.annotations, &(&1.row == 7))
+    end
+
+    test "empty text annotation round-trips" do
+      ann = %ResolvedAnnotation{row: 0, kind: :inline_pill, fg: 0xFFFFFF, bg: 0x000000, text: ""}
+      decoded = round_trip(minimal_window(annotations: [ann]))
+
+      assert hd(decoded.annotations).text == ""
     end
   end
 
@@ -462,6 +554,8 @@ defmodule Minga.Port.Protocol.GUIWindowContentTest do
           matches <- list_of(search_match_gen(), length: match_count),
           diag_count <- integer(0..5),
           diags <- list_of(diagnostic_range_gen(), length: diag_count),
+          ann_count <- integer(0..5),
+          anns <- list_of(annotation_gen(), length: ann_count),
           full_refresh <- boolean(),
           cursor_visible <- boolean()
         ) do
@@ -476,6 +570,7 @@ defmodule Minga.Port.Protocol.GUIWindowContentTest do
         selection: selection,
         search_matches: matches,
         diagnostic_ranges: diags,
+        annotations: anns,
         full_refresh: full_refresh
       }
     end
@@ -570,6 +665,18 @@ defmodule Minga.Port.Protocol.GUIWindowContentTest do
         end_col: end_col,
         severity: severity
       }
+    end
+  end
+
+  defp annotation_gen do
+    gen all(
+          row <- integer(0..100),
+          kind <- member_of([:inline_pill, :inline_text, :gutter_icon]),
+          fg <- integer(0..0xFFFFFF),
+          bg <- integer(0..0xFFFFFF),
+          text <- string(:printable, max_length: 50)
+        ) do
+      %ResolvedAnnotation{row: row, kind: kind, fg: fg, bg: bg, text: text}
     end
   end
 end

--- a/test/support/gui_window_content_decoder.ex
+++ b/test/support/gui_window_content_decoder.ex
@@ -20,7 +20,8 @@ defmodule Minga.Test.GUIWindowContentDecoder do
     {selection, rest} = decode_selection(rest)
     {search_matches, rest} = decode_search_matches(rest)
     {diagnostic_ranges, rest} = decode_diagnostic_ranges(rest)
-    {document_highlights, <<>>} = decode_document_highlights(rest)
+    {document_highlights, rest} = decode_document_highlights(rest)
+    {annotations, <<>>} = decode_annotations(rest)
 
     %{
       window_id: window_id,
@@ -34,7 +35,8 @@ defmodule Minga.Test.GUIWindowContentDecoder do
       selection: selection,
       search_matches: search_matches,
       diagnostic_ranges: diagnostic_ranges,
-      document_highlights: document_highlights
+      document_highlights: document_highlights,
+      annotations: annotations
     }
   end
 
@@ -191,6 +193,35 @@ defmodule Minga.Test.GUIWindowContentDecoder do
   defp decode_highlight_kind(1), do: :text
   defp decode_highlight_kind(2), do: :read
   defp decode_highlight_kind(3), do: :write
+
+  # ── Line annotations ─────────────────────────────────────────────────────
+
+  defp decode_annotations(<<count::16, rest::binary>>) do
+    decode_annotation_entries(rest, count, [])
+  end
+
+  defp decode_annotation_entries(rest, 0, acc), do: {Enum.reverse(acc), rest}
+
+  defp decode_annotation_entries(
+         <<row::16, kind::8, fg_r::8, fg_g::8, fg_b::8, bg_r::8, bg_g::8, bg_b::8, text_len::16,
+           text::binary-size(text_len), rest::binary>>,
+         remaining,
+         acc
+       ) do
+    annotation = %{
+      row: row,
+      kind: decode_annotation_kind(kind),
+      fg: fg_r <<< 16 ||| fg_g <<< 8 ||| fg_b,
+      bg: bg_r <<< 16 ||| bg_g <<< 8 ||| bg_b,
+      text: text
+    }
+
+    decode_annotation_entries(rest, remaining - 1, [annotation | acc])
+  end
+
+  defp decode_annotation_kind(0), do: :inline_pill
+  defp decode_annotation_kind(1), do: :inline_text
+  defp decode_annotation_kind(2), do: :gutter_icon
 
   # ── Cursor shape ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Implements #1115: the BEAM-side foundation for the line annotation system (epic #1114).

Extensions can attach structured annotations to buffer lines: colored pill badges, inline dimmed text, and gutter icons. This is the data model, storage, render pipeline integration, and protocol encoding that the GUI pill renderer (#1116) and TUI text renderer (#1117) build on.

## Changes

**New struct: `LineAnnotation`** with three kinds: `:inline_pill`, `:inline_text`, `:gutter_icon`. Colors, group, and priority are configurable per annotation.

**Decorations API:**
- `add_annotation/4` / `remove_annotation/2` - CRUD
- `annotations_for_line/2` - per-line query with O(1) cache
- `build_ann_line_cache/1` - pre-render cache build
- Participates in `remove_group/2` (batch clear) and `adjust_for_edit/3` (line-level anchor shifting, removal on delete)

**Render pipeline:**
- `SemanticWindow` carries resolved annotations via `ResolvedAnnotation` struct
- Builder populates from viewport-visible buffer lines
- 0x80 wire format extended with annotation section (row, kind, fg, bg, text)
- Swift `ProtocolDecoder` updated to consume annotation bytes
- TUI `Renderer.Line` appends styled annotation runs after EOL virtual text

**Documentation:** `EXTENSION_API.md` documents the API with examples. `GUI_PROTOCOL.md` documents the wire format.

## Testing

- 22 new Decorations unit tests (add, remove, query, group, adjust_for_edit, cache, empty?)
- 6 protocol round-trip tests (all kinds, unicode, empty, multiple per row)
- Property test generator extended with annotations
- Swift build + test pass
- Swift harness integration tests pass (35 tests)
- Full suite: 6483 tests, 0 failures

## Unlocks

With this merged, #1116 (GUI pill rendering) and #1117 (TUI annotation rendering) can proceed in parallel.

Closes #1115