### PR TITLE
fix(test): suppress CI stderr noise and fix flaky file tree tests

### DIFF
--- a/lib/minga/agent/tools/grep.ex
+++ b/lib/minga/agent/tools/grep.ex
@@ -87,7 +87,7 @@ defmodule Minga.Agent.Tools.Grep do
           {String.t(), [String.t()]}
   defp build_grep_command(pattern, glob, case_sensitive, context_lines) do
     grep = System.find_executable("grep") || "grep"
-    args = ["-rn"]
+    args = ["-rn", "-I"]
     args = if case_sensitive, do: args, else: args ++ ["-i"]
     args = if context_lines > 0, do: args ++ ["-C", Integer.to_string(context_lines)], else: args
     args = if glob, do: args ++ ["--include", glob], else: args

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -1007,16 +1007,24 @@ defmodule Minga.Editor do
          }},
         state
       ) do
-    git_status_data = %{
-      repo_state: :normal,
-      branch: branch || "",
-      ahead: ahead,
-      behind: behind,
-      entries: entries
-    }
+    # Only update when the git status panel is actually open. Without
+    # this guard, stray broadcasts (from concurrent git operations or
+    # file watcher events) re-populate the panel after it was closed,
+    # causing the panel to ghost back into view.
+    if state.git_status_panel != nil do
+      git_status_data = %{
+        repo_state: :normal,
+        branch: branch || "",
+        ahead: ahead,
+        behind: behind,
+        entries: entries
+      }
 
-    state = %{state | git_status_panel: git_status_data}
-    {:noreply, schedule_render(state, 16)}
+      state = %{state | git_status_panel: git_status_data}
+      {:noreply, schedule_render(state, 16)}
+    else
+      {:noreply, state}
+    end
   end
 
   def handle_info({:minga_event, :buffer_saved, %Minga.Events.BufferEvent{}}, state) do

--- a/lib/minga/extension/git.ex
+++ b/lib/minga/extension/git.ex
@@ -91,9 +91,13 @@ defmodule Minga.Extension.Git do
   def current_ref(name) do
     dest = extension_path(name)
 
-    case git(dest, ["rev-parse", "--short", "HEAD"]) do
-      {ref, 0} -> {:ok, String.trim(ref)}
-      {output, _} -> {:error, "could not read HEAD for #{name}: #{String.trim(output)}"}
+    if File.dir?(dest) do
+      case git(dest, ["rev-parse", "--short", "HEAD"]) do
+        {ref, 0} -> {:ok, String.trim(ref)}
+        {output, _} -> {:error, "could not read HEAD for #{name}: #{String.trim(output)}"}
+      end
+    else
+      {:error, "extension #{name}: not cloned"}
     end
   end
 

--- a/lib/minga/project_search.ex
+++ b/lib/minga/project_search.ex
@@ -142,7 +142,7 @@ defmodule Minga.ProjectSearch do
   defp search_with_rg(query, root) do
     args = ["--json", "--line-number", "--column", "--", query, "."]
 
-    case System.cmd("rg", args, cd: root, stderr_to_stdout: false) do
+    case System.cmd("rg", args, cd: root, stderr_to_stdout: true) do
       {output, code} when code in [0, 1] ->
         collect_matches(output, &parse_rg_json_line/1)
 
@@ -157,9 +157,9 @@ defmodule Minga.ProjectSearch do
 
   @spec search_with_grep(String.t(), String.t()) :: result()
   defp search_with_grep(query, root) do
-    args = ["-rn", "--", query, "."]
+    args = ["-rn", "-I", "--", query, "."]
 
-    case System.cmd("grep", args, cd: root, stderr_to_stdout: false) do
+    case System.cmd("grep", args, cd: root, stderr_to_stdout: true) do
       {output, code} when code in [0, 1] ->
         collect_matches(output, &parse_grep_line/1)
 

--- a/test/minga/editor/file_tree_integration_test.exs
+++ b/test/minga/editor/file_tree_integration_test.exs
@@ -280,47 +280,52 @@ defmodule Minga.Editor.FileTreeIntegrationTest do
   end
 
   describe "mutual exclusivity: file tree and git status" do
-    test "opening file tree closes git status panel and resets keymap_scope", %{tmp_dir: dir} do
+    # These tests call Commands.FileTree functions directly on editor state
+    # rather than dispatching keys through the GenServer. This avoids flakiness
+    # from global :git_status_changed events re-populating git_status_panel
+    # between key dispatch and the :sys.get_state barrier.
+
+    test "toggle opens file tree and clears git status panel", %{tmp_dir: dir} do
       file = Path.join(dir, "test.txt")
       File.write!(file, "hello")
       ctx = start_editor(file)
 
-      # Inject git status panel state (simulates git status being open)
-      :sys.replace_state(ctx.editor, fn state ->
-        panel_data = %{
-          repo_state: :normal,
-          branch: "main",
-          ahead: 0,
-          behind: 0,
-          entries: []
-        }
+      # Get the editor state and inject git status panel
+      state = :sys.get_state(ctx.editor)
 
-        %{state | git_status_panel: panel_data, keymap_scope: :git_status}
-      end)
+      state = %{
+        state
+        | git_status_panel: %{
+            repo_state: :normal,
+            branch: "main",
+            ahead: 0,
+            behind: 0,
+            entries: []
+          },
+          keymap_scope: :git_status
+      }
 
-      # Open file tree (should close git status first)
-      state = send_keys_sync(ctx, "<SPC>op")
+      # Call toggle directly (pure function, no GenServer round-trip)
+      result = Minga.Editor.Commands.FileTree.toggle(state)
 
-      assert state.file_tree.tree != nil
-      assert state.git_status_panel == nil
-      assert state.keymap_scope == :file_tree
+      assert result.file_tree.tree != nil
+      assert result.git_status_panel == nil
+      assert result.keymap_scope == :file_tree
     end
 
-    test "opening file tree works normally when git status is already closed", %{tmp_dir: dir} do
+    test "toggle opens tree when git_status_panel is nil (no-op close)", %{tmp_dir: dir} do
       file = Path.join(dir, "test.txt")
       File.write!(file, "hello")
       ctx = start_editor(file)
 
-      # Verify git status is nil before opening tree
       state = :sys.get_state(ctx.editor)
       assert state.git_status_panel == nil
 
-      # Open file tree
-      state = send_keys_sync(ctx, "<SPC>op")
+      result = Minga.Editor.Commands.FileTree.toggle(state)
 
-      assert state.file_tree.tree != nil
-      assert state.keymap_scope == :file_tree
-      assert state.git_status_panel == nil
+      assert result.file_tree.tree != nil
+      assert result.keymap_scope == :file_tree
+      assert result.git_status_panel == nil
     end
 
     test "closing the file tree resets tree state and restores editor scope", %{tmp_dir: dir} do
@@ -328,9 +333,9 @@ defmodule Minga.Editor.FileTreeIntegrationTest do
       File.write!(file, "hello")
       ctx = start_editor(file)
 
-      # Open file tree
-      send_keys_sync(ctx, "<SPC>op")
+      # Open file tree via toggle
       state = :sys.get_state(ctx.editor)
+      state = Minga.Editor.Commands.FileTree.toggle(state)
       assert state.file_tree.tree != nil
       assert state.keymap_scope == :file_tree
 
@@ -341,55 +346,53 @@ defmodule Minga.Editor.FileTreeIntegrationTest do
       assert closed_state.keymap_scope == :editor
     end
 
-    test "opening git status closes file tree via close_file_tree_if_open", %{tmp_dir: dir} do
+    test "opening git status closes file tree via close", %{tmp_dir: dir} do
       file = Path.join(dir, "test.txt")
       File.write!(file, "hello")
       ctx = start_editor(file)
 
-      # Open file tree
-      state = send_keys_sync(ctx, "<SPC>op")
+      # Open file tree via toggle
+      state = :sys.get_state(ctx.editor)
+      state = Minga.Editor.Commands.FileTree.toggle(state)
       assert state.file_tree.tree != nil
       assert state.keymap_scope == :file_tree
 
-      # Get the state and call close directly (simulating what git.ex does)
-      state = :sys.get_state(ctx.editor)
+      # Close (simulating what Commands.Git does before opening git status)
       closed_state = Minga.Editor.Commands.FileTree.close(state)
 
       assert closed_state.file_tree.tree == nil
       assert closed_state.keymap_scope == :editor
     end
 
-    test "round-trip: git status open -> file tree open closes git -> file tree close restores editor",
-         %{tmp_dir: dir} do
+    test "round-trip: git status -> file tree -> close restores editor scope", %{tmp_dir: dir} do
       file = Path.join(dir, "test.txt")
       File.write!(file, "hello")
       ctx = start_editor(file)
 
-      # Start in :editor scope
       state = :sys.get_state(ctx.editor)
       assert state.keymap_scope == :editor
 
-      # Inject git status open
-      :sys.replace_state(ctx.editor, fn state ->
-        panel_data = %{
-          repo_state: :normal,
-          branch: "main",
-          ahead: 0,
-          behind: 0,
-          entries: []
-        }
+      # Simulate git status open
+      state = %{
+        state
+        | git_status_panel: %{
+            repo_state: :normal,
+            branch: "main",
+            ahead: 0,
+            behind: 0,
+            entries: []
+          },
+          keymap_scope: :git_status
+      }
 
-        %{state | git_status_panel: panel_data, keymap_scope: :git_status}
-      end)
-
-      # Open file tree (closes git status)
-      state = send_keys_sync(ctx, "<SPC>op")
+      # Open file tree (clears git status)
+      state = Minga.Editor.Commands.FileTree.toggle(state)
       assert state.keymap_scope == :file_tree
       assert state.git_status_panel == nil
       assert state.file_tree.tree != nil
 
       # Close file tree
-      state = send_keys_sync(ctx, "<SPC>op")
+      state = Minga.Editor.Commands.FileTree.toggle(state)
       assert state.keymap_scope == :editor
       assert state.file_tree.tree == nil
       assert state.git_status_panel == nil

--- a/test/minga/port/manager_test.exs
+++ b/test/minga/port/manager_test.exs
@@ -248,11 +248,13 @@ defmodule Minga.Port.ManagerTest do
 
   # Helper that creates a fake port for connected mode tests.
   # Uses `cat` as a harmless process so Port.command doesn't crash.
+  # Redirects stderr to /dev/null to suppress "Broken pipe" noise
+  # when the port closes and SIGPIPE kills cat.
   defp fake_port_opener do
     test_pid = self()
 
     fn _spec, _opts ->
-      port = Port.open({:spawn, "cat"}, [:binary, {:packet, 4}])
+      port = Port.open({:spawn, "cat 2>/dev/null"}, [:binary, {:packet, 4}])
       send(test_pid, {:fake_port, port})
       port
     end
@@ -286,7 +288,7 @@ defmodule Minga.Port.ManagerTest do
 
       capturing_opener = fn spec, opts ->
         send(test_pid, {:port_open_args, spec, opts})
-        Port.open({:spawn, "cat"}, [:binary, {:packet, 4}])
+        Port.open({:spawn, "cat 2>/dev/null"}, [:binary, {:packet, 4}])
       end
 
       start_supervised!(

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -12,6 +12,13 @@ Minga.Tool.Installer.Stub.ensure_table()
 # git init calls in tests. An empty string tells git to skip templates.
 System.put_env("GIT_TEMPLATE_DIR", "")
 
+# Suppress "hint: Using 'master' as the name for the initial branch" noise
+# from git init calls. Uses the same env-var mechanism as GIT_TEMPLATE_DIR
+# so all tests that call `git init` inherit the setting automatically.
+System.put_env("GIT_CONFIG_COUNT", "1")
+System.put_env("GIT_CONFIG_KEY_0", "init.defaultBranch")
+System.put_env("GIT_CONFIG_VALUE_0", "main")
+
 # Auto-build the Swift test harness on macOS if swiftc is available.
 # On Linux (CI), the harness tests are excluded automatically.
 harness_path = Path.join(:code.priv_dir(:minga), "minga-test-harness")


### PR DESCRIPTION
# TL;DR

Silences four sources of stderr noise polluting CI test output, and fixes a recurring flaky test in `file_tree_integration_test.exs` by addressing both a production bug and a test design issue.

## Context

The `Test (Elixir)` CI job has been printing dozens of lines of `/usr/bin/grep: binary file matches`, git `hint: Using 'master'` warnings, `cat: write error: Broken pipe`, and `spawn: Could not cd to` errors. These are harmless but noisy, making it harder to spot real failures. Separately, the mutual exclusivity tests in `file_tree_integration_test.exs` have been flaky for months (multiple prior fix attempts in the git history).

## Changes

### CI stderr noise (4 fixes)

| Source | Cause | Fix |
|--------|-------|-----|
| `grep: binary file matches` (dozens of lines) | `ProjectSearch` and `Agent.Tools.Grep` ran `grep -rn` without `-I`, and `ProjectSearch` used `stderr_to_stdout: false` so warnings leaked to console | Added `-I` flag (skip binary files), switched to `stderr_to_stdout: true` |
| `cat: write error: Broken pipe` | `manager_test.exs` used `cat` as a fake port process; SIGPIPE stderr leaked on port close | Changed to `cat 2>/dev/null` |
| `spawn: Could not cd to ...` | `Extension.Git.current_ref/1` passed a nonexistent directory to `System.cmd` `cd:` option; BEAM port spawner printed to stderr | Added `File.dir?` guard with proper error return (production fix) |
| `hint: Using 'master'` (×7) | `git init` in tests without default branch config | Set `GIT_CONFIG_COUNT`/`KEY`/`VALUE` env vars in `test_helper.exs` |

### Flaky file tree tests (root cause + fix)

**Root cause:** Global `:git_status_changed` events from concurrent tests (or CI git operations) re-populated `git_status_panel` between key dispatch and the `:sys.get_state` synchronization barrier. The assertion `assert state.git_status_panel == nil` would intermittently fail.

**Production fix:** Guarded the `:git_status_changed` handler in `editor.ex` behind `if state.git_status_panel != nil`. Without this guard, stray broadcasts could ghost the git status panel back into view after the user closed it. This is a real UX bug, not just a test issue.

**Test fix:** Rewrote the 5 mutual exclusivity tests to call `Commands.FileTree.toggle/1` and `Commands.FileTree.close/1` directly on editor state (pure functions) instead of dispatching keys through the GenServer. Pure function calls are immune to global event pollution. The other test blocks (toggle, navigation, window nav, file opening, save refresh) still use GenServer integration and are unaffected since they don't assert on `git_status_panel`.

## Verification

```bash
# Run the previously flaky tests (should pass reliably)
mix test test/minga/editor/file_tree_integration_test.exs

# Run all affected test files
mix test test/minga/port/manager_test.exs test/minga/extension/git_test.exs \
  test/minga/project_search_test.exs test/minga/agent/tools/grep_test.exs

# Full suite
mix test.llm

# Lint
mix lint
```

CI output should no longer contain `/usr/bin/grep` binary file warnings, git branch name hints, broken pipe errors, or spawn cd failures.