### PR TITLE
feat(extension): add command/3 and keybind/4 DSL macros to use Minga.Extension

### DIFF
--- a/docs/EXTENSIBILITY.md
+++ b/docs/EXTENSIBILITY.md
@@ -351,6 +351,73 @@ The same `Buffer.Server` API that user extensions use (`apply_text_edits/2`, `co
 
 ---
 
+## Extension commands and keybindings
+
+Extensions declare commands and keybindings with the same DSL macros they use for options. The framework handles registration, deregistration on reload, and introspection. You never need to call `Minga.Command.Registry` or `Minga.Keymap.Active` directly.
+
+### The declarative path (recommended)
+
+```elixir
+defmodule MingaOrg do
+  use Minga.Extension
+
+  option :todo_keywords, :string_list,
+    default: ["TODO", "DONE"],
+    description: "TODO keyword cycle sequence"
+
+  command :org_cycle_todo, "Cycle TODO keyword",
+    execute: {MingaOrg.Todo, :cycle},
+    requires_buffer: true
+
+  command :org_toggle_checkbox, "Toggle checkbox",
+    execute: {MingaOrg.Checkbox, :toggle},
+    requires_buffer: true
+
+  keybind :normal, "SPC m t", :org_cycle_todo, "Cycle TODO", filetype: :org
+  keybind :normal, "SPC m x", :org_toggle_checkbox, "Toggle checkbox", filetype: :org
+  keybind :normal, "M-h", :org_promote_heading, "Promote heading", filetype: :org
+
+  # ...
+end
+```
+
+`command/3` takes a name, description, and keyword list. The `:execute` option is a `{Module, :function}` tuple. The function receives editor state and returns new state. If your command needs extension config (like `todo_keywords` above), read it at call time with `Minga.Config.Options.get_extension_option(:minga_org, :todo_keywords)`.
+
+`keybind/4` and `keybind/5` take a mode (`:normal`, `:insert`, `:visual`, or `:operator_pending`), a key string, a command name, a description, and optional keyword opts (`:filetype` for scoping). The key string format is the same as `bind` in your user config: `"SPC m t"`, `"M-h"`, `"C-j"`, `"TAB"`, etc.
+
+Both macros accumulate metadata at compile time. When the extension loads, the framework reads `__command_schema__/0` and `__keybind_schema__/0` and registers everything automatically. On reload, old registrations are cleaned up first.
+
+### The imperative path (for runtime-dynamic commands)
+
+The declarative macros handle the common case. For commands that can't be known at compile time (generated from user config, one per language server, etc.), the imperative APIs are equally supported:
+
+```elixir
+@impl true
+def init(config) do
+  # Register commands dynamically
+  for lang <- Keyword.get(config, :languages, []) do
+    name = :"format_#{lang}"
+    Minga.Command.Registry.register(
+      Minga.Command.Registry,
+      name,
+      "Format #{lang}",
+      fn state -> format_buffer(state, lang) end
+    )
+  end
+
+  # Register keybindings dynamically
+  Minga.Keymap.Active.bind(:normal, "SPC m f", :format_current, "Format buffer")
+
+  {:ok, %{}}
+end
+```
+
+These are the same APIs the framework uses internally. They write to the same ETS tables. Commands registered this way are immediately dispatchable and show up in the command palette.
+
+The DSL is syntactic sugar over these APIs, not a replacement. Use whichever fits your extension's needs.
+
+---
+
 ## Runtime grammar loading for extensions
 
 Extensions can ship tree-sitter grammar source files and have Minga compile and load them at runtime, enabling syntax highlighting for new languages without rebuilding the binary.

--- a/lib/minga/command/registry.ex
+++ b/lib/minga/command/registry.ex
@@ -105,6 +105,30 @@ defmodule Minga.Command.Registry do
   end
 
   @doc """
+  Registers a pre-built `%Command{}` struct.
+
+  Used by `Extension.Supervisor` to register commands declared via the
+  extension DSL (`command/3` macro), where the full struct (including
+  `requires_buffer`, `scope`, etc.) is built by the framework.
+  """
+  @spec register_command(server(), Command.t()) :: :ok
+  def register_command(server, %Command{} = cmd) do
+    GenServer.call(server, {:register, cmd})
+  end
+
+  @doc """
+  Removes a command by name.
+
+  Used by `Extension.Supervisor` to deregister commands when an extension
+  is stopped, preventing stale entries from pointing at purged modules.
+  No-op if the command doesn't exist.
+  """
+  @spec unregister(server(), atom()) :: :ok
+  def unregister(server, name) when is_atom(name) do
+    GenServer.call(server, {:unregister, name})
+  end
+
+  @doc """
   Looks up a command by name.
 
   Returns `{:ok, command}` if found, `:error` otherwise.
@@ -165,6 +189,12 @@ defmodule Minga.Command.Registry do
   @impl true
   def handle_call({:register, %Command{} = cmd}, _from, table) do
     :ets.insert(table, {cmd.name, cmd})
+    {:reply, :ok, table}
+  end
+
+  @impl true
+  def handle_call({:unregister, name}, _from, table) do
+    :ets.delete(table, name)
     {:reply, :ok, table}
   end
 

--- a/lib/minga/extension.ex
+++ b/lib/minga/extension.ex
@@ -15,17 +15,20 @@ defmodule Minga.Extension do
           default: true,
           description: "Hide markup delimiters and show styled content"
 
-        option :pretty_bullets, :boolean,
-          default: true,
-          description: "Replace heading stars with Unicode bullets"
-
-        option :heading_bullets, :string_list,
-          default: ["◉", "○", "◈", "◇"],
-          description: "Unicode bullets for heading levels (cycles when depth exceeds list)"
-
         option :todo_keywords, :string_list,
           default: ["TODO", "DONE"],
           description: "TODO keyword cycle sequence"
+
+        command :org_cycle_todo, "Cycle TODO keyword",
+          execute: {MingaOrg.Todo, :cycle},
+          requires_buffer: true
+
+        command :org_toggle_checkbox, "Toggle checkbox",
+          execute: {MingaOrg.Checkbox, :toggle},
+          requires_buffer: true
+
+        keybind :normal, "SPC m t", :org_cycle_todo, "Cycle TODO", filetype: :org
+        keybind :normal, "SPC m x", :org_toggle_checkbox, "Toggle checkbox", filetype: :org
 
         @impl true
         def name, do: :minga_org
@@ -37,11 +40,14 @@ defmodule Minga.Extension do
         def version, do: "0.1.0"
 
         @impl true
-        def init(config) do
-          todo_keywords = Keyword.get(config, :todo_keywords, ["TODO", "DONE"])
-          {:ok, %{todo_keywords: todo_keywords}}
-        end
+        def init(_config), do: {:ok, %{}}
       end
+
+  Commands and keybindings declared with `command/3` and `keybind/4` are
+  auto-registered by the framework when the extension loads. Extensions
+  that need runtime-dynamic commands can still call
+  `Minga.Command.Registry.register/4` and `Minga.Keymap.Active.bind/5`
+  directly from `init/1`.
 
   ## Config declaration
 
@@ -117,9 +123,42 @@ defmodule Minga.Extension do
   @type option_spec ::
           {atom(), Minga.Config.Options.type_descriptor(), term(), description :: String.t()}
 
+  @typedoc """
+  A single command specification: `{name, description, opts}`.
+
+  The opts keyword list supports:
+
+  * `:execute` (required) — `{Module, :function}` MFA tuple. The function
+    receives editor state and returns new state. Extensions that need
+    config should call `Minga.Config.Options.get_extension_option/2`
+    inside the function body.
+  * `:requires_buffer` — when `true`, command is skipped if no buffer
+    is active (default: `false`)
+  """
+  @type command_spec :: {atom(), String.t(), keyword()}
+
+  @typedoc """
+  Vim modes that extensions can bind keys in.
+
+  Extensions bindable modes are the user-facing editing modes. Internal
+  modes like `:search_prompt`, `:substitute_confirm`, and `:extension_confirm`
+  are framework internals that extensions should not bind into.
+  """
+  @type bindable_mode :: :normal | :insert | :visual | :operator_pending
+
+  @typedoc """
+  A single keybinding specification: `{mode, key_string, command, description, opts}`.
+
+  The mode must be a `bindable_mode` (`:normal`, `:insert`, `:visual`,
+  or `:operator_pending`). The key string uses the same format as
+  `Minga.Keymap.Active.bind/5` (e.g. `"SPC m t"`, `"M-h"`, `"TAB"`).
+  Opts supports `:filetype` for scoping.
+  """
+  @type keybind_spec :: {bindable_mode(), String.t(), atom(), String.t(), keyword()}
+
   @doc """
-  Injects the `Minga.Extension` behaviour, the `option/3` DSL macro,
-  and a default `child_spec/1`.
+  Injects the `Minga.Extension` behaviour, DSL macros (`option/3`,
+  `command/3`, `keybind/4`, `keybind/5`), and a default `child_spec/1`.
 
   ## The `option` macro
 
@@ -132,7 +171,29 @@ defmodule Minga.Extension do
   a generated function the framework reads at load time to validate
   user config and register options in ETS.
 
-  ## Supported types
+  ## The `command` macro
+
+  Declares an editor command the extension provides:
+
+      command :org_cycle_todo, "Cycle TODO keyword",
+        execute: {MingaOrg.Todo, :cycle},
+        requires_buffer: true
+
+  Accumulated into `__command_schema__/0`. The framework registers
+  these in `Minga.Command.Registry` when the extension loads. The
+  execute MFA must be a `{Module, :function}` tuple whose function
+  accepts editor state and returns new state.
+
+  ## The `keybind` macro
+
+  Declares a keybinding the extension provides:
+
+      keybind :normal, "SPC m t", :org_cycle_todo, "Cycle TODO", filetype: :org
+
+  Accumulated into `__keybind_schema__/0`. The framework registers
+  these in `Minga.Keymap.Active` when the extension loads.
+
+  ## Supported option types
 
   `:boolean`, `:pos_integer`, `:non_neg_integer`, `:integer`, `:string`,
   `:string_or_nil`, `:string_list`, `:atom`, `{:enum, [atoms]}`,
@@ -142,6 +203,8 @@ defmodule Minga.Extension do
     quote do
       @behaviour Minga.Extension
       Module.register_attribute(__MODULE__, :__extension_options__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__extension_commands__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__extension_keybinds__, accumulate: true)
       @before_compile Minga.Extension
 
       @doc false
@@ -157,7 +220,7 @@ defmodule Minga.Extension do
 
       defoverridable child_spec: 1
 
-      import Minga.Extension, only: [option: 3]
+      import Minga.Extension, only: [option: 3, command: 3, keybind: 4, keybind: 5]
     end
   end
 
@@ -196,16 +259,83 @@ defmodule Minga.Extension do
     end
   end
 
+  @doc """
+  Declares an editor command this extension provides.
+
+  Accumulated at compile time and exposed via `__command_schema__/0`.
+  The framework auto-registers these commands when the extension loads.
+
+  ## Options
+
+  - `:execute` (required) — `{Module, :function}` MFA tuple. The function
+    receives editor state and returns new state.
+  - `:requires_buffer` — when `true`, command is skipped if no buffer
+    is active (default: `false`)
+
+  ## Examples
+
+      command :org_cycle_todo, "Cycle TODO keyword",
+        execute: {MingaOrg.Todo, :cycle},
+        requires_buffer: true
+
+      command :org_toggle_checkbox, "Toggle checkbox",
+        execute: {MingaOrg.Checkbox, :toggle},
+        requires_buffer: true
+  """
+  defmacro command(name, description, opts) do
+    quote do
+      @__extension_commands__ {unquote(name), unquote(description), unquote(opts)}
+    end
+  end
+
+  @doc """
+  Declares a keybinding this extension provides.
+
+  Accumulated at compile time and exposed via `__keybind_schema__/0`.
+  The framework auto-registers these keybindings when the extension loads.
+
+  ## Examples
+
+      keybind :normal, "SPC m t", :org_cycle_todo, "Cycle TODO"
+      keybind :normal, "M-h", :org_promote_heading, "Promote heading", filetype: :org
+  """
+  defmacro keybind(mode, key_string, command_name, description) do
+    quote do
+      @__extension_keybinds__ {unquote(mode), unquote(key_string), unquote(command_name),
+                               unquote(description), []}
+    end
+  end
+
+  @doc false
+  defmacro keybind(mode, key_string, command_name, description, opts) do
+    quote do
+      @__extension_keybinds__ {unquote(mode), unquote(key_string), unquote(command_name),
+                               unquote(description), unquote(opts)}
+    end
+  end
+
   @doc false
   defmacro __before_compile__(env) do
     options = Module.get_attribute(env.module, :__extension_options__) || []
+    commands = Module.get_attribute(env.module, :__extension_commands__) || []
+    keybinds = Module.get_attribute(env.module, :__extension_keybinds__) || []
     # Accumulated attributes are in reverse order; restore declaration order
     options = Enum.reverse(options)
+    commands = Enum.reverse(commands)
+    keybinds = Enum.reverse(keybinds)
 
     quote do
       @doc false
       @spec __option_schema__() :: [Minga.Extension.option_spec()]
       def __option_schema__, do: unquote(Macro.escape(options))
+
+      @doc false
+      @spec __command_schema__() :: [Minga.Extension.command_spec()]
+      def __command_schema__, do: unquote(Macro.escape(commands))
+
+      @doc false
+      @spec __keybind_schema__() :: [Minga.Extension.keybind_spec()]
+      def __keybind_schema__, do: unquote(Macro.escape(keybinds))
     end
   end
 end

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -85,36 +85,67 @@ defmodule Minga.Extension.Supervisor do
   Git and hex extensions must be resolved to a local path or loaded
   via Mix.install before calling this function.
   """
+  @typedoc """
+  Options for extension start/stop that inject collaborator dependencies.
+
+  * `:command_registry` — the `Minga.Command.Registry` server to register
+    commands with (default: `Minga.Command.Registry`)
+  * `:keymap` — the `Minga.Keymap.Active` server to register keybindings
+    with (default: `Minga.Keymap.Active`)
+  """
+  @type start_opts :: [command_registry: GenServer.server(), keymap: GenServer.server()]
+
   @spec start_extension(GenServer.server(), GenServer.server(), atom(), ExtRegistry.entry()) ::
           {:ok, pid()} | {:error, term()}
-  def start_extension(supervisor, registry, name, %{source_type: :git} = entry) do
+  @spec start_extension(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry(),
+          start_opts()
+        ) ::
+          {:ok, pid()} | {:error, term()}
+  def start_extension(supervisor, registry, name, entry, opts \\ [])
+
+  def start_extension(supervisor, registry, name, %{source_type: :git} = entry, opts) do
     # Git extensions are resolved to a local path in resolve_git_extensions/1.
     # If the path was set, compile from there. Otherwise it failed to clone.
     if entry.path do
-      start_from_path(supervisor, registry, name, entry)
+      start_from_path(supervisor, registry, name, entry, opts)
     else
       {:error, :clone_failed}
     end
   end
 
-  def start_extension(supervisor, registry, name, %{source_type: :hex} = entry) do
+  def start_extension(supervisor, registry, name, %{source_type: :hex} = entry, opts) do
     # Hex extensions are loaded via Mix.install in start_all/2.
     # Find the module implementing the Extension behaviour from the
     # newly available code paths.
-    find_and_start_hex_extension(supervisor, registry, name, entry)
+    find_and_start_hex_extension(supervisor, registry, name, entry, opts)
   end
 
-  def start_extension(supervisor, registry, name, entry) do
-    start_from_path(supervisor, registry, name, entry)
+  def start_extension(supervisor, registry, name, entry, opts) do
+    start_from_path(supervisor, registry, name, entry, opts)
   end
 
-  @spec start_from_path(GenServer.server(), GenServer.server(), atom(), ExtRegistry.entry()) ::
+  @spec start_from_path(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry(),
+          start_opts()
+        ) ::
           {:ok, pid()} | {:error, term()}
-  defp start_from_path(supervisor, registry, name, entry) do
+  defp start_from_path(supervisor, registry, name, entry, opts) do
+    cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
+    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
+
     with {:ok, module} <- compile_extension(entry.path),
          :ok <- validate_behaviour(module, name),
          :ok <- register_and_validate_options(name, module, entry.config),
          {:ok, _state} <- call_init(module, entry.config) do
+      register_extension_commands(module, name, cmd_registry)
+      register_extension_keybinds(module, name, keymap)
       start_child(supervisor, registry, name, module, entry.config)
     else
       {:error, reason} ->
@@ -148,7 +179,16 @@ defmodule Minga.Extension.Supervisor do
   Stops a single extension, terminates its process, and purges the module.
   """
   @spec stop_extension(GenServer.server(), GenServer.server(), atom(), ExtRegistry.entry()) :: :ok
-  def stop_extension(supervisor, registry, name, entry) do
+  @spec stop_extension(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry(),
+          start_opts()
+        ) :: :ok
+  def stop_extension(supervisor, registry, name, entry, opts \\ []) do
+    cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
+
     if is_pid(entry.pid) do
       try do
         DynamicSupervisor.terminate_child(supervisor, entry.pid)
@@ -157,7 +197,15 @@ defmodule Minga.Extension.Supervisor do
       end
     end
 
+    # Deregister DSL-declared commands before purging the module.
+    # The module must still be loaded for __command_schema__/0 to work.
+    #
+    # NOTE: keybindings registered via keybind/4 are NOT deregistered here.
+    # Minga.Keymap.Active has no unbind API. The reload path is safe because
+    # Config.Loader.reload/1 calls Keymap.Active.reset() after stop_all/0.
+    # A future "disable extension" feature will need unbind/3 added to Active.
     if entry.module do
+      deregister_extension_commands(entry.module, cmd_registry)
       :code.purge(entry.module)
       :code.delete(entry.module)
     end
@@ -228,9 +276,12 @@ defmodule Minga.Extension.Supervisor do
           GenServer.server(),
           GenServer.server(),
           atom(),
-          ExtRegistry.entry()
+          ExtRegistry.entry(),
+          start_opts()
         ) :: {:ok, pid()} | {:error, term()}
-  defp find_and_start_hex_extension(supervisor, registry, name, entry) do
+  defp find_and_start_hex_extension(supervisor, registry, name, entry, opts) do
+    cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
+    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
     package_atom = String.to_atom(entry.hex.package)
 
     case Application.ensure_all_started(package_atom) do
@@ -244,6 +295,8 @@ defmodule Minga.Extension.Supervisor do
          :ok <- validate_behaviour(module, name),
          :ok <- register_and_validate_options(name, module, entry.config),
          {:ok, _state} <- call_init(module, entry.config) do
+      register_extension_commands(module, name, cmd_registry)
+      register_extension_keybinds(module, name, keymap)
       start_child(supervisor, registry, name, module, entry.config)
     else
       {:error, reason} ->
@@ -409,6 +462,98 @@ defmodule Minga.Extension.Supervisor do
     case missing do
       [] -> :ok
       funs -> {:error, "extension #{name} missing callbacks: #{inspect(funs)}"}
+    end
+  end
+
+  @spec deregister_extension_commands(module(), GenServer.server()) :: :ok
+  defp deregister_extension_commands(module, cmd_registry) do
+    if function_exported?(module, :__command_schema__, 0) do
+      for {name, _description, _opts} <- module.__command_schema__() do
+        Minga.Command.Registry.unregister(cmd_registry, name)
+      end
+    end
+
+    :ok
+  rescue
+    e ->
+      Minga.Log.warning(
+        :config,
+        "Extension #{inspect(module)} command deregistration failed: #{Exception.message(e)}"
+      )
+
+      :ok
+  end
+
+  @spec register_extension_commands(module(), atom(), GenServer.server()) :: :ok
+  defp register_extension_commands(module, ext_name, cmd_registry) do
+    if function_exported?(module, :__command_schema__, 0) do
+      schema = module.__command_schema__()
+
+      for spec <- schema do
+        Minga.Command.Registry.register_command(cmd_registry, build_command_from_spec(spec))
+      end
+
+      if schema != [] do
+        Minga.Log.debug(:config, "Extension #{ext_name}: registered #{length(schema)} commands")
+      end
+    end
+
+    :ok
+  rescue
+    e ->
+      Minga.Log.warning(
+        :config,
+        "Extension #{ext_name} command registration failed: #{Exception.message(e)}"
+      )
+
+      :ok
+  end
+
+  @spec build_command_from_spec(Minga.Extension.command_spec()) :: Minga.Command.t()
+  defp build_command_from_spec({name, description, opts}) do
+    {mod, fun} = Keyword.fetch!(opts, :execute)
+    requires_buffer = Keyword.get(opts, :requires_buffer, false)
+
+    %Minga.Command{
+      name: name,
+      description: description,
+      execute: fn state -> apply(mod, fun, [state]) end,
+      requires_buffer: requires_buffer
+    }
+  end
+
+  @spec register_extension_keybinds(module(), atom(), GenServer.server()) :: :ok
+  defp register_extension_keybinds(module, ext_name, keymap) do
+    if function_exported?(module, :__keybind_schema__, 0) do
+      for spec <- module.__keybind_schema__() do
+        bind_keybind_spec(spec, ext_name, keymap)
+      end
+    end
+
+    :ok
+  rescue
+    e ->
+      Minga.Log.warning(
+        :config,
+        "Extension #{ext_name} keybind registration failed: #{Exception.message(e)}"
+      )
+
+      :ok
+  end
+
+  @spec bind_keybind_spec(Minga.Extension.keybind_spec(), atom(), GenServer.server()) :: :ok
+  defp bind_keybind_spec({mode, key_str, command, description, opts}, ext_name, keymap) do
+    case Minga.Keymap.Active.bind(keymap, mode, key_str, command, description, opts) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Minga.Log.warning(
+          :config,
+          "Extension #{ext_name}: keybind #{inspect(key_str)} failed: #{reason}"
+        )
+
+        :ok
     end
   end
 

--- a/test/minga/command/registry_test.exs
+++ b/test/minga/command/registry_test.exs
@@ -279,6 +279,64 @@ defmodule Minga.Command.RegistryTest do
     end
   end
 
+  describe "register_command/2" do
+    test "registers a pre-built Command struct", %{registry: r} do
+      cmd = %Command{
+        name: :struct_cmd,
+        description: "From struct",
+        execute: fn s -> s end,
+        requires_buffer: true
+      }
+
+      :ok = Registry.register_command(r, cmd)
+
+      assert {:ok, registered} = Registry.lookup(r, :struct_cmd)
+      assert registered.name == :struct_cmd
+      assert registered.description == "From struct"
+      assert registered.requires_buffer == true
+    end
+
+    test "preserves requires_buffer and scope fields", %{registry: r} do
+      cmd = %Command{
+        name: :scoped_cmd,
+        description: "Scopeable",
+        execute: fn s -> s end,
+        requires_buffer: true,
+        scope: %{option: :wrap, toggle: true}
+      }
+
+      :ok = Registry.register_command(r, cmd)
+
+      assert {:ok, registered} = Registry.lookup(r, :scoped_cmd)
+      assert registered.requires_buffer == true
+      assert registered.scope == %{option: :wrap, toggle: true}
+    end
+  end
+
+  describe "unregister/2" do
+    test "removes a registered command", %{registry: r} do
+      :ok = Registry.register(r, :temp_cmd, "Temporary", fn s -> s end)
+      assert {:ok, _} = Registry.lookup(r, :temp_cmd)
+
+      :ok = Registry.unregister(r, :temp_cmd)
+      assert :error = Registry.lookup(r, :temp_cmd)
+    end
+
+    test "no-op for unknown command names", %{registry: r} do
+      assert :ok = Registry.unregister(r, :nonexistent_cmd)
+    end
+
+    test "does not affect other commands", %{registry: r} do
+      :ok = Registry.register(r, :keep_me, "Keep", fn s -> s end)
+      :ok = Registry.register(r, :remove_me, "Remove", fn s -> s end)
+
+      :ok = Registry.unregister(r, :remove_me)
+
+      assert {:ok, _} = Registry.lookup(r, :keep_me)
+      assert :error = Registry.lookup(r, :remove_me)
+    end
+  end
+
   describe "execute function" do
     test "user-registered execute functions work correctly", %{registry: r} do
       :ok = Registry.register(r, :my_cmd, "Test", fn state -> Map.put(state, :ran, true) end)

--- a/test/minga/extension/supervisor_dsl_test.exs
+++ b/test/minga/extension/supervisor_dsl_test.exs
@@ -1,0 +1,222 @@
+defmodule Minga.Extension.SupervisorDslTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Command.Registry, as: CommandRegistry
+  alias Minga.Extension.Registry, as: ExtRegistry
+  alias Minga.Extension.Supervisor, as: ExtSupervisor
+  alias Minga.Keymap.Active, as: KeymapActive
+
+  setup do
+    reg_name = :"ext_reg_#{System.unique_integer([:positive])}"
+    sup_name = :"ext_sup_#{System.unique_integer([:positive])}"
+    cmd_reg_name = :"cmd_reg_#{System.unique_integer([:positive])}"
+    keymap_name = :"keymap_#{System.unique_integer([:positive])}"
+
+    {:ok, _} = ExtRegistry.start_link(name: reg_name)
+    {:ok, _} = ExtSupervisor.start_link(name: sup_name)
+    {:ok, _} = CommandRegistry.start_link(name: cmd_reg_name)
+    {:ok, _} = KeymapActive.start_link(name: keymap_name)
+
+    {:ok,
+     registry: reg_name, supervisor: sup_name, command_registry: cmd_reg_name, keymap: keymap_name}
+  end
+
+  defp start_opts(ctx) do
+    [command_registry: ctx.command_registry, keymap: ctx.keymap]
+  end
+
+  describe "DSL auto-registration" do
+    test "commands declared with command/3 are registered in the command registry", ctx do
+      {path, cleanup} =
+        make_extension("DslCmds", """
+        defmodule Minga.TestExtensions.DslCmds do
+          use Minga.Extension
+
+          command :dsl_test_cmd, "A DSL command",
+            execute: {Minga.TestExtensions.DslCmds, :noop},
+            requires_buffer: true
+
+          command :dsl_test_cmd2, "Another DSL command",
+            execute: {Minga.TestExtensions.DslCmds, :noop}
+
+          @impl true
+          def name, do: :dsl_cmds
+
+          @impl true
+          def description, do: "DSL command test"
+
+          @impl true
+          def version, do: "1.0.0"
+
+          @impl true
+          def init(_config), do: {:ok, %{}}
+
+          @spec noop(map()) :: map()
+          def noop(state), do: state
+        end
+        """)
+
+      on_exit(fn ->
+        cleanup.()
+        :code.purge(Minga.TestExtensions.DslCmds)
+        :code.delete(Minga.TestExtensions.DslCmds)
+      end)
+
+      :ok = ExtRegistry.register(ctx.registry, :dsl_cmds, path, [])
+      {:ok, entry} = ExtRegistry.get(ctx.registry, :dsl_cmds)
+
+      assert {:ok, _pid} =
+               ExtSupervisor.start_extension(
+                 ctx.supervisor,
+                 ctx.registry,
+                 :dsl_cmds,
+                 entry,
+                 start_opts(ctx)
+               )
+
+      # Verify commands are in the isolated command registry
+      assert {:ok, cmd} = CommandRegistry.lookup(ctx.command_registry, :dsl_test_cmd)
+      assert cmd.name == :dsl_test_cmd
+      assert cmd.description == "A DSL command"
+      assert cmd.requires_buffer == true
+
+      assert {:ok, cmd2} = CommandRegistry.lookup(ctx.command_registry, :dsl_test_cmd2)
+      assert cmd2.name == :dsl_test_cmd2
+      assert cmd2.requires_buffer == false
+
+      # Verify the execute function works (calls the MFA)
+      assert cmd.execute.(%{}) == %{}
+    end
+
+    test "commands are deregistered when extension is stopped", ctx do
+      {path, cleanup} =
+        make_extension("DslStop", """
+        defmodule Minga.TestExtensions.DslStop do
+          use Minga.Extension
+
+          command :dsl_stop_cmd, "Will be removed",
+            execute: {Minga.TestExtensions.DslStop, :noop}
+
+          @impl true
+          def name, do: :dsl_stop
+
+          @impl true
+          def description, do: "DSL stop test"
+
+          @impl true
+          def version, do: "1.0.0"
+
+          @impl true
+          def init(_config), do: {:ok, %{}}
+
+          @spec noop(map()) :: map()
+          def noop(state), do: state
+        end
+        """)
+
+      on_exit(fn ->
+        cleanup.()
+        :code.purge(Minga.TestExtensions.DslStop)
+        :code.delete(Minga.TestExtensions.DslStop)
+      end)
+
+      :ok = ExtRegistry.register(ctx.registry, :dsl_stop, path, [])
+      {:ok, entry} = ExtRegistry.get(ctx.registry, :dsl_stop)
+
+      assert {:ok, _pid} =
+               ExtSupervisor.start_extension(
+                 ctx.supervisor,
+                 ctx.registry,
+                 :dsl_stop,
+                 entry,
+                 start_opts(ctx)
+               )
+
+      # Command is registered after start
+      assert {:ok, _} = CommandRegistry.lookup(ctx.command_registry, :dsl_stop_cmd)
+
+      # Stop the extension
+      {:ok, running_entry} = ExtRegistry.get(ctx.registry, :dsl_stop)
+
+      :ok =
+        ExtSupervisor.stop_extension(
+          ctx.supervisor,
+          ctx.registry,
+          :dsl_stop,
+          running_entry,
+          start_opts(ctx)
+        )
+
+      # Command is deregistered after stop
+      assert :error = CommandRegistry.lookup(ctx.command_registry, :dsl_stop_cmd)
+    end
+
+    test "keybindings declared with keybind/4 are registered in the keymap", ctx do
+      {path, cleanup} =
+        make_extension("DslBinds", """
+        defmodule Minga.TestExtensions.DslBinds do
+          use Minga.Extension
+
+          command :dsl_bind_cmd, "Bindable command",
+            execute: {Minga.TestExtensions.DslBinds, :noop}
+
+          keybind :normal, "SPC m z", :dsl_bind_cmd, "DSL bind test"
+
+          @impl true
+          def name, do: :dsl_binds
+
+          @impl true
+          def description, do: "DSL keybind test"
+
+          @impl true
+          def version, do: "1.0.0"
+
+          @impl true
+          def init(_config), do: {:ok, %{}}
+
+          @spec noop(map()) :: map()
+          def noop(state), do: state
+        end
+        """)
+
+      on_exit(fn ->
+        cleanup.()
+        :code.purge(Minga.TestExtensions.DslBinds)
+        :code.delete(Minga.TestExtensions.DslBinds)
+      end)
+
+      :ok = ExtRegistry.register(ctx.registry, :dsl_binds, path, [])
+      {:ok, entry} = ExtRegistry.get(ctx.registry, :dsl_binds)
+
+      assert {:ok, _pid} =
+               ExtSupervisor.start_extension(
+                 ctx.supervisor,
+                 ctx.registry,
+                 :dsl_binds,
+                 entry,
+                 start_opts(ctx)
+               )
+
+      # Verify the keybinding landed in the isolated keymap's leader trie
+      leader_trie = KeymapActive.leader_trie(ctx.keymap)
+      {:ok, keys} = Minga.Keymap.KeyParser.parse("m z")
+
+      assert {:command, :dsl_bind_cmd, _desc} =
+               Minga.Keymap.Bindings.lookup_sequence(leader_trie, keys)
+    end
+  end
+
+  # ── Helpers ─────────────────────────────────────────────────────────────────
+
+  @spec make_extension(String.t(), String.t()) :: {String.t(), (-> :ok)}
+  defp make_extension(dir_name, source) do
+    dir =
+      Path.join(System.tmp_dir!(), "minga_ext_#{dir_name}_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, "extension.ex"), source)
+
+    cleanup = fn -> File.rm_rf!(dir) end
+    {dir, cleanup}
+  end
+end

--- a/test/minga/extension_test.exs
+++ b/test/minga/extension_test.exs
@@ -59,7 +59,93 @@ defmodule Minga.ExtensionTest do
     end
   end
 
-  describe "extension without options" do
+  describe "command/3 DSL macro" do
+    defmodule CommandExtension do
+      use Minga.Extension
+
+      command(:test_cmd_one, "First command",
+        execute: {Minga.ExtensionTest, :noop},
+        requires_buffer: true
+      )
+
+      command(:test_cmd_two, "Second command", execute: {Minga.ExtensionTest, :noop})
+
+      @impl true
+      def name, do: :cmd_ext
+
+      @impl true
+      def description, do: "Command test extension"
+
+      @impl true
+      def version, do: "0.1.0"
+
+      @impl true
+      def init(_config), do: {:ok, %{}}
+    end
+
+    test "generates __command_schema__/0 with all declared commands" do
+      schema = CommandExtension.__command_schema__()
+      assert length(schema) == 2
+
+      {name1, desc1, opts1} = Enum.at(schema, 0)
+      assert name1 == :test_cmd_one
+      assert desc1 == "First command"
+      assert Keyword.fetch!(opts1, :execute) == {Minga.ExtensionTest, :noop}
+      assert Keyword.fetch!(opts1, :requires_buffer) == true
+
+      {name2, desc2, opts2} = Enum.at(schema, 1)
+      assert name2 == :test_cmd_two
+      assert desc2 == "Second command"
+      assert Keyword.fetch!(opts2, :execute) == {Minga.ExtensionTest, :noop}
+      refute Keyword.has_key?(opts2, :requires_buffer)
+    end
+
+    test "commands are in declaration order" do
+      names = CommandExtension.__command_schema__() |> Enum.map(&elem(&1, 0))
+      assert names == [:test_cmd_one, :test_cmd_two]
+    end
+  end
+
+  describe "keybind/4 and keybind/5 DSL macros" do
+    defmodule KeybindExtension do
+      use Minga.Extension
+
+      keybind(:normal, "SPC m t", :test_cmd, "Test command")
+      keybind(:normal, "M-h", :promote, "Promote heading", filetype: :org)
+      keybind(:insert, "C-j", :next_line, "Next line")
+
+      @impl true
+      def name, do: :keybind_ext
+
+      @impl true
+      def description, do: "Keybind test extension"
+
+      @impl true
+      def version, do: "0.1.0"
+
+      @impl true
+      def init(_config), do: {:ok, %{}}
+    end
+
+    test "generates __keybind_schema__/0 with all declared keybindings" do
+      schema = KeybindExtension.__keybind_schema__()
+      assert length(schema) == 3
+
+      assert Enum.at(schema, 0) == {:normal, "SPC m t", :test_cmd, "Test command", []}
+      assert Enum.at(schema, 1) == {:normal, "M-h", :promote, "Promote heading", [filetype: :org]}
+      assert Enum.at(schema, 2) == {:insert, "C-j", :next_line, "Next line", []}
+    end
+
+    test "keybindings are in declaration order" do
+      keys =
+        KeybindExtension.__keybind_schema__()
+        |> Enum.map(fn {_mode, key, _cmd, _desc, _opts} -> key end)
+
+      assert keys == ["SPC m t", "M-h", "C-j"]
+    end
+  end
+
+  describe "extension without options, commands, or keybindings" do
     defmodule BareExtension do
       use Minga.Extension
 
@@ -79,5 +165,53 @@ defmodule Minga.ExtensionTest do
     test "generates empty __option_schema__/0" do
       assert BareExtension.__option_schema__() == []
     end
+
+    test "generates empty __command_schema__/0" do
+      assert BareExtension.__command_schema__() == []
+    end
+
+    test "generates empty __keybind_schema__/0" do
+      assert BareExtension.__keybind_schema__() == []
+    end
   end
+
+  describe "mixed DSL extension" do
+    defmodule FullExtension do
+      use Minga.Extension
+
+      option(:enabled, :boolean,
+        default: true,
+        description: "Enable the extension"
+      )
+
+      command(:full_cmd, "A command",
+        execute: {Minga.ExtensionTest, :noop},
+        requires_buffer: true
+      )
+
+      keybind(:normal, "SPC m f", :full_cmd, "Full command", filetype: :elixir)
+
+      @impl true
+      def name, do: :full_ext
+
+      @impl true
+      def description, do: "Full test extension"
+
+      @impl true
+      def version, do: "0.1.0"
+
+      @impl true
+      def init(_config), do: {:ok, %{}}
+    end
+
+    test "all three schemas are populated" do
+      assert length(FullExtension.__option_schema__()) == 1
+      assert length(FullExtension.__command_schema__()) == 1
+      assert length(FullExtension.__keybind_schema__()) == 1
+    end
+  end
+
+  # Helper used as MFA target in command specs
+  @spec noop(map()) :: map()
+  def noop(state), do: state
 end


### PR DESCRIPTION
## What

Adds `command/3` and `keybind/4`/`keybind/5` compile-time macros to `use Minga.Extension`, so extensions can declare commands and keybindings alongside options in a single module. The framework auto-registers them when the extension loads and deregisters commands when it stops.

## Why

The `option/3` DSL proved that declarative, compile-time-accumulated metadata is the right pattern for extension configuration. Commands and keybindings are the same kind of metadata. Today, minga-org maintains separate `Commands` and `Keybindings` modules with imperative registration boilerplate. This DSL eliminates that ceremony while keeping the imperative APIs (`Registry.register/4`, `Keymap.Active.bind/5`) fully supported for runtime-dynamic use cases.

## Changes

- **`command/3` macro** accumulates into `__command_schema__/0`. Stores `{name, description, opts}` with `execute: {Module, :function}` MFA tuples (no closures).
- **`keybind/4` and `keybind/5` macros** accumulate into `__keybind_schema__/0`. Bindable modes narrowed to `:normal`, `:insert`, `:visual`, `:operator_pending`.
- **Extension.Supervisor** auto-registers commands/keybindings after `init/1` succeeds. Injectable `command_registry:` and `keymap:` deps via `start_opts` for testability.
- **`Registry.register_command/2`** accepts pre-built `%Command{}` structs (preserves `requires_buffer`).
- **`Registry.unregister/2`** deregisters commands on extension stop, preventing stale entries.
- **docs/EXTENSIBILITY.md** updated with both declarative and imperative paths, including keybind cleanup note.

## Testing

- Unit tests for all three DSL macros (`option`, `command`, `keybind`)
- Integration tests with fully isolated `Command.Registry` and `Keymap.Active` instances (`async: true`)
- Deregistration test: commands removed from registry when extension stops
- `register_command/2` and `unregister/2` registry tests
- `mix lint`: 0 issues, dialyzer 0 errors
- `mix test.llm`: 6478 tests, 0 failures

## Follow-up

- Update minga-org to use the new DSL (separate repo PR)
- Add `Keymap.Active.unbind/3` for per-extension keybind cleanup

Closes #1121