### PR TITLE
chore(keymap): add unbind API and wire extension keybind deregistration

### DIFF
--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -188,6 +188,7 @@ defmodule Minga.Extension.Supervisor do
         ) :: :ok
   def stop_extension(supervisor, registry, name, entry, opts \\ []) do
     cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
+    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
 
     if is_pid(entry.pid) do
       try do
@@ -197,15 +198,12 @@ defmodule Minga.Extension.Supervisor do
       end
     end
 
-    # Deregister DSL-declared commands before purging the module.
-    # The module must still be loaded for __command_schema__/0 to work.
-    #
-    # NOTE: keybindings registered via keybind/4 are NOT deregistered here.
-    # Minga.Keymap.Active has no unbind API. The reload path is safe because
-    # Config.Loader.reload/1 calls Keymap.Active.reset() after stop_all/0.
-    # A future "disable extension" feature will need unbind/3 added to Active.
+    # Deregister DSL-declared commands and keybindings before purging the module.
+    # The module must still be loaded for __command_schema__/0 and
+    # __keybind_schema__/0 to work.
     if entry.module do
       deregister_extension_commands(entry.module, cmd_registry)
+      deregister_extension_keybinds(entry.module, keymap)
       :code.purge(entry.module)
       :code.delete(entry.module)
     end
@@ -479,6 +477,25 @@ defmodule Minga.Extension.Supervisor do
       Minga.Log.warning(
         :config,
         "Extension #{inspect(module)} command deregistration failed: #{Exception.message(e)}"
+      )
+
+      :ok
+  end
+
+  @spec deregister_extension_keybinds(module(), GenServer.server()) :: :ok
+  defp deregister_extension_keybinds(module, keymap) do
+    if function_exported?(module, :__keybind_schema__, 0) do
+      for {mode, key_str, _command, _description, opts} <- module.__keybind_schema__() do
+        Minga.Keymap.Active.unbind(keymap, mode, key_str, opts)
+      end
+    end
+
+    :ok
+  rescue
+    e ->
+      Minga.Log.warning(
+        :config,
+        "Extension #{inspect(module)} keybind deregistration failed: #{Exception.message(e)}"
       )
 
       :ok

--- a/lib/minga/keymap/active.ex
+++ b/lib/minga/keymap/active.ex
@@ -301,6 +301,57 @@ defmodule Minga.Keymap.Active do
   end
 
   @doc """
+  Removes a key binding from the given mode.
+
+  Mirrors the dispatch logic of `bind/4`: for normal mode, leader
+  sequences are removed from the leader trie and single-key bindings
+  are removed from normal overrides. For other modes, the binding is
+  removed from the per-mode trie.
+
+  Returns `:ok` on success or `{:error, reason}` on failure.
+
+  ## Examples
+
+      unbind(:normal, "SPC g s")
+      unbind(:insert, "C-j")
+  """
+  @spec unbind(atom(), String.t()) :: :ok | {:error, String.t()}
+  @spec unbind(GenServer.server(), atom(), String.t()) :: :ok | {:error, String.t()}
+  def unbind(mode, key_str), do: unbind(__MODULE__, mode, key_str)
+
+  def unbind(server, mode, key_str) when is_atom(mode) and is_binary(key_str) do
+    case KeyParser.parse(key_str) do
+      {:ok, keys} ->
+        do_unbind(server, mode, keys)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Removes a filetype-scoped key binding.
+
+  ## Examples
+
+      unbind(:normal, "SPC m t", filetype: :org)
+  """
+  @spec unbind(atom(), String.t(), keyword()) :: :ok | {:error, String.t()}
+  @spec unbind(GenServer.server(), atom(), String.t(), keyword()) :: :ok | {:error, String.t()}
+  def unbind(mode, key_str, opts), do: unbind(__MODULE__, mode, key_str, opts)
+
+  def unbind(server, mode, key_str, opts)
+      when is_atom(mode) and is_binary(key_str) and is_list(opts) do
+    filetype = Keyword.get(opts, :filetype)
+
+    if filetype do
+      unbind_filetype(server, mode, filetype, key_str)
+    else
+      unbind(server, mode, key_str)
+    end
+  end
+
+  @doc """
   Resets all bindings to defaults (removes user overrides).
   """
   @spec reset() :: :ok
@@ -485,4 +536,80 @@ defmodule Minga.Keymap.Active do
   @spec strip_spc_m_prefix([Bindings.key()]) :: [Bindings.key()]
   defp strip_spc_m_prefix([{32, 0}, {?m, 0} | rest]) when rest != [], do: rest
   defp strip_spc_m_prefix(keys), do: keys
+
+  # ── Private: unbind dispatch ────────────────────────────────────────────────
+
+  @spec do_unbind(GenServer.server(), atom(), [Bindings.key()]) :: :ok | {:error, String.t()}
+
+  # Normal mode: leader sequences (SPC + more keys)
+  defp do_unbind(server, :normal, [{32, 0} | rest]) when rest != [] do
+    ets_update(server, @leader_trie_key, Defaults.leader_trie(), fn trie ->
+      Bindings.unbind(trie, rest)
+    end)
+  end
+
+  # Normal mode: single-key binding
+  defp do_unbind(server, :normal, [single_key]) do
+    ets_update(server, @normal_overrides_key, %{}, fn overrides ->
+      Map.delete(overrides, single_key)
+    end)
+  end
+
+  # Normal mode: unsupported multi-key
+  defp do_unbind(_server, :normal, _keys) do
+    {:error, "unsupported key sequence for normal mode unbind"}
+  end
+
+  # Insert, visual, operator_pending, command modes
+  defp do_unbind(server, mode, keys)
+       when mode in [:insert, :visual, :operator_pending, :command] do
+    ets_update(server, @mode_tries_key, %{}, fn tries ->
+      trie = Map.get(tries, mode, Bindings.new())
+      updated = Bindings.unbind(trie, keys)
+      Map.put(tries, mode, updated)
+    end)
+  end
+
+  defp do_unbind(_server, mode, _keys) do
+    {:error, "unbind not supported for mode #{inspect(mode)}"}
+  end
+
+  # ── Private: filetype unbind ────────────────────────────────────────────────
+
+  @spec unbind_filetype(GenServer.server(), atom(), atom(), String.t()) ::
+          :ok | {:error, String.t()}
+  defp unbind_filetype(server, :normal, filetype, key_str) do
+    case KeyParser.parse(key_str) do
+      {:ok, keys} ->
+        sub_keys = strip_spc_m_prefix(keys)
+
+        ets_update(server, @filetype_tries_key, %{}, fn tries ->
+          trie = Map.get(tries, filetype, Bindings.new())
+          updated = Bindings.unbind(trie, sub_keys)
+          Map.put(tries, filetype, updated)
+        end)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp unbind_filetype(server, mode, filetype, key_str)
+       when mode in [:insert, :visual] do
+    case KeyParser.parse(key_str) do
+      {:ok, keys} ->
+        ets_update(server, @filetype_mode_tries_key, %{}, fn tries ->
+          trie = Map.get(tries, {filetype, mode}, Bindings.new())
+          updated = Bindings.unbind(trie, keys)
+          Map.put(tries, {filetype, mode}, updated)
+        end)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp unbind_filetype(_server, mode, _filetype, _key_str) do
+    {:error, "filetype-scoped unbind not supported for #{mode} mode"}
+  end
 end

--- a/lib/minga/keymap/bindings.ex
+++ b/lib/minga/keymap/bindings.ex
@@ -142,6 +142,53 @@ defmodule Minga.Keymap.Bindings do
   end
 
   @doc """
+  Removes a key sequence binding from the trie.
+
+  Clears the command and description on the terminal node. Prunes empty
+  intermediate nodes (nodes with no command and no children) on the way
+  back up so the trie doesn't accumulate dead branches.
+
+  Returns the updated trie. No-op if the sequence doesn't exist.
+
+  ## Examples
+
+      iex> trie = Minga.Keymap.Bindings.new()
+      iex> trie = Minga.Keymap.Bindings.bind(trie, [{?j, 0}], :move_down, "Move cursor down")
+      iex> trie = Minga.Keymap.Bindings.unbind(trie, [{?j, 0}])
+      iex> Minga.Keymap.Bindings.lookup(trie, {?j, 0})
+      :not_found
+  """
+  @spec unbind(node_t(), [key()]) :: node_t()
+  def unbind(root, []), do: root
+
+  def unbind(%Node{children: children} = root, [key | rest]) do
+    case Map.fetch(children, key) do
+      :error ->
+        root
+
+      {:ok, child} ->
+        updated_child =
+          case rest do
+            [] ->
+              %{child | command: nil, description: nil}
+
+            _ ->
+              unbind(child, rest)
+          end
+
+        if empty_node?(updated_child) do
+          %{root | children: Map.delete(children, key)}
+        else
+          %{root | children: Map.put(children, key, updated_child)}
+        end
+    end
+  end
+
+  @spec empty_node?(node_t()) :: boolean()
+  defp empty_node?(%Node{command: nil, children: children}), do: map_size(children) == 0
+  defp empty_node?(_), do: false
+
+  @doc """
   Sets a human-readable description on an intermediate (prefix) node without
   binding a command. Useful for labelling leader-key groups like `f → "+file"`.
 

--- a/test/minga/extension/supervisor_dsl_test.exs
+++ b/test/minga/extension/supervisor_dsl_test.exs
@@ -204,6 +204,77 @@ defmodule Minga.Extension.SupervisorDslTest do
       assert {:command, :dsl_bind_cmd, _desc} =
                Minga.Keymap.Bindings.lookup_sequence(leader_trie, keys)
     end
+
+    test "keybindings are deregistered when extension is stopped", ctx do
+      {path, cleanup} =
+        make_extension("DslUnbind", """
+        defmodule Minga.TestExtensions.DslUnbind do
+          use Minga.Extension
+
+          command :dsl_unbind_cmd, "Will be unbound",
+            execute: {Minga.TestExtensions.DslUnbind, :noop}
+
+          keybind :normal, "SPC m y", :dsl_unbind_cmd, "DSL unbind test"
+
+          @impl true
+          def name, do: :dsl_unbind
+
+          @impl true
+          def description, do: "DSL unbind test"
+
+          @impl true
+          def version, do: "1.0.0"
+
+          @impl true
+          def init(_config), do: {:ok, %{}}
+
+          @spec noop(map()) :: map()
+          def noop(state), do: state
+        end
+        """)
+
+      on_exit(fn ->
+        cleanup.()
+        :code.purge(Minga.TestExtensions.DslUnbind)
+        :code.delete(Minga.TestExtensions.DslUnbind)
+      end)
+
+      :ok = ExtRegistry.register(ctx.registry, :dsl_unbind, path, [])
+      {:ok, entry} = ExtRegistry.get(ctx.registry, :dsl_unbind)
+
+      assert {:ok, _pid} =
+               ExtSupervisor.start_extension(
+                 ctx.supervisor,
+                 ctx.registry,
+                 :dsl_unbind,
+                 entry,
+                 start_opts(ctx)
+               )
+
+      # Keybinding exists after start
+      leader_trie = KeymapActive.leader_trie(ctx.keymap)
+      {:ok, keys} = Minga.Keymap.KeyParser.parse("m y")
+
+      assert {:command, :dsl_unbind_cmd, _desc} =
+               Minga.Keymap.Bindings.lookup_sequence(leader_trie, keys)
+
+      # Stop the extension
+      {:ok, running_entry} = ExtRegistry.get(ctx.registry, :dsl_unbind)
+
+      :ok =
+        ExtSupervisor.stop_extension(
+          ctx.supervisor,
+          ctx.registry,
+          :dsl_unbind,
+          running_entry,
+          start_opts(ctx)
+        )
+
+      # Keybinding is gone after stop
+      leader_trie = KeymapActive.leader_trie(ctx.keymap)
+
+      assert :not_found = Minga.Keymap.Bindings.lookup_sequence(leader_trie, keys)
+    end
   end
 
   # ── Helpers ─────────────────────────────────────────────────────────────────

--- a/test/minga/keymap/active_test.exs
+++ b/test/minga/keymap/active_test.exs
@@ -390,4 +390,56 @@ defmodule Minga.Keymap.ActiveTest do
       end
     end
   end
+
+  describe "unbind/3" do
+    test "removes a leader binding", %{store: s} do
+      Active.bind(s, :normal, "SPC z z", :custom_cmd, "Custom")
+      trie = Active.leader_trie(s)
+      assert {:command, :custom_cmd, _} = Bindings.lookup_sequence(trie, [{?z, 0}, {?z, 0}])
+
+      assert :ok = Active.unbind(s, :normal, "SPC z z")
+      trie = Active.leader_trie(s)
+      assert :not_found = Bindings.lookup_sequence(trie, [{?z, 0}, {?z, 0}])
+    end
+
+    test "removes a single-key normal override", %{store: s} do
+      Active.bind(s, :normal, "Q", :replay_macro, "Replay")
+      assert %{{?Q, 0} => {:replay_macro, "Replay"}} = Active.normal_overrides(s)
+
+      assert :ok = Active.unbind(s, :normal, "Q")
+      assert %{} = Active.normal_overrides(s)
+    end
+
+    test "removes an insert mode binding", %{store: s} do
+      Active.bind(s, :insert, "C-j", :next_line, "Next line")
+      trie = Active.mode_trie(s, :insert)
+      assert {:command, :next_line} = Bindings.lookup(trie, {?j, 0x02})
+
+      assert :ok = Active.unbind(s, :insert, "C-j")
+      trie = Active.mode_trie(s, :insert)
+      assert :not_found = Bindings.lookup(trie, {?j, 0x02})
+    end
+  end
+
+  describe "unbind/4 (filetype-scoped)" do
+    test "removes a filetype-scoped normal binding", %{store: s} do
+      Active.bind(s, :normal, "SPC m t", :org_test, "Test", filetype: :org)
+      ft_trie = Active.filetype_trie(s, :org)
+      assert {:command, :org_test} = Bindings.lookup(ft_trie, {?t, 0})
+
+      assert :ok = Active.unbind(s, :normal, "SPC m t", filetype: :org)
+      ft_trie = Active.filetype_trie(s, :org)
+      assert :not_found = Bindings.lookup(ft_trie, {?t, 0})
+    end
+
+    test "removes a filetype-scoped insert binding", %{store: s} do
+      Active.bind(s, :insert, "TAB", :org_table_align, "Align table", filetype: :org)
+      ft_trie = Active.filetype_mode_trie(s, :org, :insert)
+      assert {:command, :org_table_align} = Bindings.lookup(ft_trie, {9, 0})
+
+      assert :ok = Active.unbind(s, :insert, "TAB", filetype: :org)
+      ft_trie = Active.filetype_mode_trie(s, :org, :insert)
+      assert :not_found = Bindings.lookup(ft_trie, {9, 0})
+    end
+  end
 end

--- a/test/minga/keymap/bindings_test.exs
+++ b/test/minga/keymap/bindings_test.exs
@@ -290,4 +290,75 @@ defmodule Minga.Keymap.BindingsTest do
       assert :not_found = Bindings.lookup_sequence(trie, [])
     end
   end
+
+  describe "unbind/2" do
+    test "removes a single-key binding" do
+      trie = Bindings.new()
+      trie = Bindings.bind(trie, [key(?j)], :move_down, "Move down")
+      assert {:command, :move_down} = Bindings.lookup(trie, key(?j))
+
+      trie = Bindings.unbind(trie, [key(?j)])
+      assert :not_found = Bindings.lookup(trie, key(?j))
+    end
+
+    test "removes a multi-key binding" do
+      trie = Bindings.new()
+      trie = Bindings.bind(trie, [key(?g), key(?g)], :document_start, "Go to first line")
+
+      trie = Bindings.unbind(trie, [key(?g), key(?g)])
+      assert :not_found = Bindings.lookup_sequence(trie, [key(?g), key(?g)])
+    end
+
+    test "prunes empty intermediate nodes" do
+      trie = Bindings.new()
+      trie = Bindings.bind(trie, [key(?g), key(?g)], :document_start, "Go to first line")
+
+      trie = Bindings.unbind(trie, [key(?g), key(?g)])
+      # The intermediate 'g' node should be pruned since it has no command and no children
+      assert :not_found = Bindings.lookup(trie, key(?g))
+    end
+
+    test "preserves sibling bindings when unbinding" do
+      trie = Bindings.new()
+      trie = Bindings.bind(trie, [key(?g), key(?g)], :document_start, "Go to first line")
+      trie = Bindings.bind(trie, [key(?g), key(?e)], :document_end, "Go to last line")
+
+      trie = Bindings.unbind(trie, [key(?g), key(?g)])
+      # g -> e still works
+      assert {:command, :document_end, _} =
+               Bindings.lookup_sequence(trie, [key(?g), key(?e)])
+
+      # g -> g is gone
+      assert :not_found = Bindings.lookup_sequence(trie, [key(?g), key(?g)])
+    end
+
+    test "no-op for nonexistent sequence" do
+      trie = Bindings.new()
+      trie = Bindings.bind(trie, [key(?j)], :move_down, "Move down")
+
+      trie2 = Bindings.unbind(trie, [key(?z)])
+      assert trie2 == trie
+    end
+
+    test "no-op for empty key list" do
+      trie = Bindings.new()
+      trie = Bindings.bind(trie, [key(?j)], :move_down, "Move down")
+
+      trie2 = Bindings.unbind(trie, [])
+      assert trie2 == trie
+    end
+
+    test "preserves prefix node that also has a command" do
+      trie = Bindings.new()
+      # 'g' is both a command and a prefix for 'gg'
+      trie = Bindings.bind(trie, [key(?g)], :go_prefix, "Go prefix")
+      trie = Bindings.bind(trie, [key(?g), key(?g)], :document_start, "Go to first line")
+
+      # Remove only the 'gg' binding
+      trie = Bindings.unbind(trie, [key(?g), key(?g)])
+
+      # 'g' command still works
+      assert {:command, :go_prefix} = Bindings.lookup(trie, key(?g))
+    end
+  end
 end


### PR DESCRIPTION
## What

Adds `Bindings.unbind/2` and `Keymap.Active.unbind/3-4` to remove key bindings from the trie and active keymap. Wires keybind deregistration into `Extension.Supervisor.stop_extension` so extension keybindings are cleaned up alongside commands when an extension stops.

## Why

PR #1126 added the `keybind/4` DSL macro but left a known gap: keybindings weren't deregistered on extension stop because `Keymap.Active` had no unbind API. This closes that gap.

## Changes

- **`Bindings.unbind/2`** removes a key sequence from the trie, pruning empty intermediate nodes on the way back up
- **`Active.unbind/3` and `unbind/4`** mirror the bind dispatch: leader sequences, single-key normal overrides, per-mode tries, and filetype-scoped bindings all support removal
- **`Extension.Supervisor.stop_extension`** now calls `deregister_extension_keybinds` alongside `deregister_extension_commands` before purging the module
- Refactored `children/1` `cond` block to multi-clause `label_for_node/1` per project coding standards

## Testing

- 7 trie unit tests for `Bindings.unbind/2` (single-key, multi-key, pruning, siblings, no-op, prefix-with-command)
- 6 active tests for `Active.unbind/3-4` (leader, normal override, insert mode, filetype normal, filetype insert, error path)
- 1 integration test: keybinding exists after extension start, gone after stop
- `mix lint`: 0 issues. `mix test.llm`: all keymap/extension tests pass