### PR TITLE
refactor(buffer): add EditSource constructor functions with guard validation

### DIFF
--- a/lib/minga/buffer/edit_source.ex
+++ b/lib/minga/buffer/edit_source.ex
@@ -6,6 +6,20 @@ defmodule Minga.Buffer.EditSource do
   timeline. The undo stack uses a simpler atom-based source (see
   `Minga.Buffer.State.edit_source`); use `to_undo_source/1` to bridge.
 
+  ## Creating sources
+
+  Always use the constructor functions instead of building raw tuples:
+
+      EditSource.user()
+      EditSource.agent(session_pid, tool_call_id)
+      EditSource.lsp(:elixir_ls)
+      EditSource.formatter()
+      EditSource.unknown()
+
+  Constructors validate arguments with guards (e.g. `session_id` must be a
+  pid, `server_name` must be an atom). Pattern matching on the raw shapes
+  is fine and encouraged; only construction should go through constructors.
+
   ## Source variants
 
   - `:user` — interactive keystroke from the human
@@ -22,6 +36,35 @@ defmodule Minga.Buffer.EditSource do
           | {:lsp, server_name :: atom()}
           | :formatter
           | :unknown
+
+  # ── Constructors ──────────────────────────────────────────────────────
+
+  @doc "Interactive edit from the human user."
+  @spec user() :: t()
+  def user, do: :user
+
+  @doc "Edit from an agent tool call."
+  @spec agent(pid(), String.t()) :: t()
+  def agent(session_id, tool_call_id)
+      when is_pid(session_id) and is_binary(tool_call_id) do
+    {:agent, session_id, tool_call_id}
+  end
+
+  @doc "Edit from an LSP server (code action, rename, etc.)."
+  @spec lsp(atom()) :: t()
+  def lsp(server_name) when is_atom(server_name) do
+    {:lsp, server_name}
+  end
+
+  @doc "Edit from format-on-save or explicit format command."
+  @spec formatter() :: t()
+  def formatter, do: :formatter
+
+  @doc "Source not determined (legacy code paths during migration)."
+  @spec unknown() :: t()
+  def unknown, do: :unknown
+
+  # ── Undo stack bridge ─────────────────────────────────────────────────
 
   @doc """
   Maps a rich edit source to the simple atom used by the undo stack.
@@ -47,8 +90,8 @@ defmodule Minga.Buffer.EditSource do
   reference. Treat it as a sentinel indicating "some agent edit, origin unknown."
   """
   @spec from_undo_source(Minga.Buffer.State.edit_source()) :: t()
-  def from_undo_source(:user), do: :user
-  def from_undo_source(:agent), do: {:agent, self(), "unknown"}
-  def from_undo_source(:lsp), do: {:lsp, :unknown}
-  def from_undo_source(:recovery), do: :unknown
+  def from_undo_source(:user), do: user()
+  def from_undo_source(:agent), do: agent(self(), "unknown")
+  def from_undo_source(:lsp), do: lsp(:unknown)
+  def from_undo_source(:recovery), do: unknown()
 end

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -21,6 +21,7 @@ defmodule Minga.Buffer.Server do
   alias Minga.Buffer.Decorations
   alias Minga.Buffer.Document
   alias Minga.Buffer.EditDelta
+  alias Minga.Buffer.EditSource
   alias Minga.Buffer.Unicode
   alias Minga.Config.Options
   alias Minga.Events
@@ -81,8 +82,8 @@ defmodule Minga.Buffer.Server do
   end
 
   @doc "Inserts a character at the current cursor position."
-  @spec insert_char(GenServer.server(), String.t(), Minga.Buffer.EditSource.t()) :: :ok
-  def insert_char(server, char, source \\ :user) when is_binary(char) do
+  @spec insert_char(GenServer.server(), String.t(), EditSource.t()) :: :ok
+  def insert_char(server, char, source \\ EditSource.user()) when is_binary(char) do
     GenServer.call(server, {:insert_char, char, source})
   end
 
@@ -91,8 +92,8 @@ defmodule Minga.Buffer.Server do
 
   Each character is inserted sequentially, advancing the cursor.
   """
-  @spec insert_text(GenServer.server(), String.t(), Minga.Buffer.EditSource.t()) :: :ok
-  def insert_text(server, text, source \\ :user) when is_binary(text) do
+  @spec insert_text(GenServer.server(), String.t(), EditSource.t()) :: :ok
+  def insert_text(server, text, source \\ EditSource.user()) when is_binary(text) do
     GenServer.call(server, {:insert_text, text, source})
   end
 
@@ -109,7 +110,7 @@ defmodule Minga.Buffer.Server do
           non_neg_integer(),
           non_neg_integer(),
           String.t(),
-          Minga.Buffer.EditSource.t()
+          EditSource.t()
         ) :: :ok
   def apply_text_edit(
         server,
@@ -118,7 +119,7 @@ defmodule Minga.Buffer.Server do
         end_line,
         end_col,
         new_text,
-        source \\ :user
+        source \\ EditSource.user()
       ) do
     GenServer.call(
       server,
@@ -145,8 +146,8 @@ defmodule Minga.Buffer.Server do
   Source defaults to `{:lsp, :unknown}` (not `:user`) because batch edits
   are typically LSP code actions or agent tool calls, not interactive typing.
   """
-  @spec apply_text_edits(GenServer.server(), [text_edit()], Minga.Buffer.EditSource.t()) :: :ok
-  def apply_text_edits(server, edits, source \\ {:lsp, :unknown}) when is_list(edits) do
+  @spec apply_text_edits(GenServer.server(), [text_edit()], EditSource.t()) :: :ok
+  def apply_text_edits(server, edits, source \\ EditSource.lsp(:unknown)) when is_list(edits) do
     GenServer.call(server, {:apply_text_edits, edits, source})
   end
 
@@ -882,7 +883,7 @@ defmodule Minga.Buffer.Server do
         Document.cursor(new_buf)
       )
 
-    undo_source = Minga.Buffer.EditSource.to_undo_source(source)
+    undo_source = EditSource.to_undo_source(source)
     state = push_undo(state, new_buf, undo_source) |> mark_dirty() |> record_edit(delta, source)
     {:reply, :ok, state}
   end
@@ -903,7 +904,7 @@ defmodule Minga.Buffer.Server do
         Document.cursor(new_doc)
       )
 
-    undo_source = Minga.Buffer.EditSource.to_undo_source(source)
+    undo_source = EditSource.to_undo_source(source)
     state = push_undo(state, new_doc, undo_source) |> mark_dirty() |> record_edit(delta, source)
     {:reply, :ok, state}
   end
@@ -930,7 +931,7 @@ defmodule Minga.Buffer.Server do
     delta =
       EditDelta.replacement(start_byte, old_end_byte, from_pos, to_pos, new_text, new_end_pos)
 
-    undo_source = Minga.Buffer.EditSource.to_undo_source(source)
+    undo_source = EditSource.to_undo_source(source)
 
     {:reply, :ok,
      push_undo(state, doc, undo_source) |> mark_dirty() |> record_edit(delta, source)}
@@ -960,7 +961,7 @@ defmodule Minga.Buffer.Server do
         |> Document.insert_text(new_text)
       end)
 
-    undo_source = Minga.Buffer.EditSource.to_undo_source(source)
+    undo_source = EditSource.to_undo_source(source)
 
     # Multi-edit batches are complex to delta-track (offsets shift between
     # edits). Clear pending edits to force a full content sync.
@@ -985,7 +986,7 @@ defmodule Minga.Buffer.Server do
         {:reply, {:ok, msg},
          push_undo_force(state, new_doc, :agent)
          |> mark_dirty()
-         |> clear_edits({:agent, self(), "unknown"})}
+         |> clear_edits(EditSource.agent(self(), "unknown"))}
 
       {:error, _} = err ->
         {:reply, err, state}
@@ -1011,7 +1012,7 @@ defmodule Minga.Buffer.Server do
       if any_applied do
         push_undo_force(state, final_doc, :agent)
         |> mark_dirty()
-        |> clear_edits({:agent, self(), "unknown"})
+        |> clear_edits(EditSource.agent(self(), "unknown"))
       else
         state
       end
@@ -1207,7 +1208,7 @@ defmodule Minga.Buffer.Server do
   def handle_call({:replace_content, new_content, source}, _from, state) do
     new_state = push_undo_force(state, state.document, source)
     new_buf = Document.new(new_content)
-    event_source = Minga.Buffer.EditSource.from_undo_source(source)
+    event_source = EditSource.from_undo_source(source)
     {:reply, :ok, mark_dirty(%{new_state | document: new_buf}) |> clear_edits(event_source)}
   end
 
@@ -1529,7 +1530,8 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call({:apply_snapshot, new_buf}, _from, state) do
-    {:reply, :ok, push_undo(state, new_buf, :user) |> mark_dirty() |> clear_edits(:user)}
+    {:reply, :ok,
+     push_undo(state, new_buf, :user) |> mark_dirty() |> clear_edits(EditSource.user())}
   end
 
   def handle_call({:clear_line, _line}, _from, %{read_only: true} = state) do
@@ -1554,7 +1556,7 @@ defmodule Minga.Buffer.Server do
       [{prev_version, prev_buf, source} | rest_undo] ->
         redo_entry = {state.version, state.document, source}
 
-        event_source = Minga.Buffer.EditSource.from_undo_source(source)
+        event_source = EditSource.from_undo_source(source)
 
         new_state =
           %{
@@ -1580,7 +1582,7 @@ defmodule Minga.Buffer.Server do
       [{next_version, next_buf, source} | rest_redo] ->
         undo_entry = {state.version, state.document, source}
 
-        event_source = Minga.Buffer.EditSource.from_undo_source(source)
+        event_source = EditSource.from_undo_source(source)
 
         new_state =
           %{
@@ -1817,7 +1819,7 @@ defmodule Minga.Buffer.Server do
 
   # Defers a :buffer_changed broadcast with delta and source to a
   # subsequent handle_info turn. Same pattern as defer_content_replaced.
-  @spec defer_buffer_changed(state(), EditDelta.t() | nil, Minga.Buffer.EditSource.t()) :: :ok
+  @spec defer_buffer_changed(state(), EditDelta.t() | nil, EditSource.t()) :: :ok
   defp defer_buffer_changed(state, delta, source) do
     send(
       self(),
@@ -2004,10 +2006,10 @@ defmodule Minga.Buffer.Server do
 
   @spec record_edit(state(), EditDelta.t()) :: state()
   defp record_edit(state, delta) do
-    record_edit(state, delta, :user)
+    record_edit(state, delta, EditSource.user())
   end
 
-  @spec record_edit(state(), EditDelta.t(), Minga.Buffer.EditSource.t()) :: state()
+  @spec record_edit(state(), EditDelta.t(), EditSource.t()) :: state()
   defp record_edit(state, delta, source) do
     new_seq = state.edit_seq + 1
 
@@ -2041,7 +2043,7 @@ defmodule Minga.Buffer.Server do
   # Clear pending edits to force HighlightSync into full content sync.
   # Used for operations where computing accurate deltas is impractical
   # (undo, redo, multi-edit batches, full content replacement).
-  @spec clear_edits(state(), Minga.Buffer.EditSource.t()) :: state()
+  @spec clear_edits(state(), EditSource.t()) :: state()
   defp clear_edits(state, source) do
     defer_buffer_changed(state, nil, source)
     %{state | pending_edits: [], edit_log: [], consumer_cursors: %{}}

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -270,7 +270,10 @@ defmodule Minga.Events do
   @deprecated "Buffer.Server now broadcasts :buffer_changed automatically on every edit. No manual broadcast needed."
   @spec notify_buffer_changed(pid()) :: :ok
   def notify_buffer_changed(buf) when is_pid(buf) do
-    broadcast(:buffer_changed, %BufferChangedEvent{buffer: buf, source: :unknown})
+    broadcast(:buffer_changed, %BufferChangedEvent{
+      buffer: buf,
+      source: Minga.Buffer.EditSource.unknown()
+    })
   end
 
   # ── Query ───────────────────────────────────────────────────────────────────

--- a/test/minga/buffer/buffer_changed_event_test.exs
+++ b/test/minga/buffer/buffer_changed_event_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Buffer.BufferChangedEventTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.EditDelta
+  alias Minga.Buffer.EditSource
   alias Minga.Buffer.Server
   alias Minga.Events
   alias Minga.Events.BufferChangedEvent
@@ -55,7 +56,7 @@ defmodule Minga.Buffer.BufferChangedEventTest do
 
     test "custom source is propagated" do
       buf = start_supervised!({Server, content: "hello world"})
-      Server.apply_text_edit(buf, 0, 0, 0, 5, "goodbye", {:lsp, :elixir_ls})
+      Server.apply_text_edit(buf, 0, 0, 0, 5, "goodbye", EditSource.lsp(:elixir_ls))
 
       assert_receive {:minga_event, :buffer_changed,
                       %BufferChangedEvent{
@@ -70,7 +71,7 @@ defmodule Minga.Buffer.BufferChangedEventTest do
     test "batch edits send nil delta with source" do
       buf = start_supervised!({Server, content: "aaa\nbbb\nccc"})
       edits = [{{0, 0}, {0, 3}, "AAA"}, {{1, 0}, {1, 3}, "BBB"}]
-      Server.apply_text_edits(buf, edits, {:lsp, :elixir_ls})
+      Server.apply_text_edits(buf, edits, EditSource.lsp(:elixir_ls))
 
       assert_receive {:minga_event, :buffer_changed,
                       %BufferChangedEvent{

--- a/test/minga/buffer/edit_source_test.exs
+++ b/test/minga/buffer/edit_source_test.exs
@@ -3,31 +3,67 @@ defmodule Minga.Buffer.EditSourceTest do
 
   alias Minga.Buffer.EditSource
 
+  describe "constructors" do
+    test "user/0 returns :user" do
+      assert EditSource.user() == :user
+    end
+
+    test "agent/2 returns tagged tuple with validated args" do
+      result = EditSource.agent(self(), "call_123")
+      assert {:agent, pid, "call_123"} = result
+      assert pid == self()
+    end
+
+    test "lsp/1 returns tagged tuple with server name" do
+      assert EditSource.lsp(:elixir_ls) == {:lsp, :elixir_ls}
+    end
+
+    test "formatter/0 returns :formatter" do
+      assert EditSource.formatter() == :formatter
+    end
+
+    test "unknown/0 returns :unknown" do
+      assert EditSource.unknown() == :unknown
+    end
+
+    test "agent/2 rejects non-pid session_id" do
+      assert_raise FunctionClauseError, fn -> EditSource.agent("not-a-pid", "call") end
+    end
+
+    test "agent/2 rejects non-binary tool_call_id" do
+      assert_raise FunctionClauseError, fn -> EditSource.agent(self(), :not_binary) end
+    end
+
+    test "lsp/1 rejects non-atom server_name" do
+      assert_raise FunctionClauseError, fn -> EditSource.lsp("elixir_ls") end
+    end
+  end
+
   describe "to_undo_source/1" do
     test "maps :user to :user" do
-      assert EditSource.to_undo_source(:user) == :user
+      assert EditSource.to_undo_source(EditSource.user()) == :user
     end
 
     test "maps {:agent, pid, tool_call_id} to :agent" do
-      assert EditSource.to_undo_source({:agent, self(), "call_123"}) == :agent
+      assert EditSource.to_undo_source(EditSource.agent(self(), "call_123")) == :agent
     end
 
     test "maps {:lsp, server_name} to :lsp" do
-      assert EditSource.to_undo_source({:lsp, :elixir_ls}) == :lsp
+      assert EditSource.to_undo_source(EditSource.lsp(:elixir_ls)) == :lsp
     end
 
     test "maps :formatter to :lsp" do
-      assert EditSource.to_undo_source(:formatter) == :lsp
+      assert EditSource.to_undo_source(EditSource.formatter()) == :lsp
     end
 
     test "maps :unknown to :user" do
-      assert EditSource.to_undo_source(:unknown) == :user
+      assert EditSource.to_undo_source(EditSource.unknown()) == :user
     end
   end
 
   describe "from_undo_source/1" do
     test "maps :user to :user" do
-      assert EditSource.from_undo_source(:user) == :user
+      assert EditSource.from_undo_source(:user) == EditSource.user()
     end
 
     test "maps :agent to {:agent, self(), \"unknown\"}" do
@@ -37,11 +73,11 @@ defmodule Minga.Buffer.EditSourceTest do
     end
 
     test "maps :lsp to {:lsp, :unknown}" do
-      assert EditSource.from_undo_source(:lsp) == {:lsp, :unknown}
+      assert EditSource.from_undo_source(:lsp) == EditSource.lsp(:unknown)
     end
 
     test "maps :recovery to :unknown" do
-      assert EditSource.from_undo_source(:recovery) == :unknown
+      assert EditSource.from_undo_source(:recovery) == EditSource.unknown()
     end
   end
 end

--- a/test/minga/events_test.exs
+++ b/test/minga/events_test.exs
@@ -136,7 +136,7 @@ defmodule Minga.EventsTest do
 
       Events.broadcast(
         :buffer_changed,
-        %Events.BufferChangedEvent{buffer: buf, source: :user}
+        %Events.BufferChangedEvent{buffer: buf, source: Minga.Buffer.EditSource.user()}
       )
 
       assert_receive {:minga_event, :buffer_changed,

--- a/test/minga/git/tracker_test.exs
+++ b/test/minga/git/tracker_test.exs
@@ -123,7 +123,7 @@ defmodule Minga.Git.TrackerTest do
 
       Events.broadcast(
         :buffer_changed,
-        %Events.BufferChangedEvent{buffer: buf, source: :user}
+        %Events.BufferChangedEvent{buffer: buf, source: Minga.Buffer.EditSource.user()}
       )
 
       flush_tracker()
@@ -137,7 +137,7 @@ defmodule Minga.Git.TrackerTest do
 
       Events.broadcast(
         :buffer_changed,
-        %Events.BufferChangedEvent{buffer: buf, source: :user}
+        %Events.BufferChangedEvent{buffer: buf, source: Minga.Buffer.EditSource.user()}
       )
 
       flush_tracker()

--- a/test/minga/lsp/sync_server_test.exs
+++ b/test/minga/lsp/sync_server_test.exs
@@ -51,7 +51,7 @@ defmodule Minga.LSP.SyncServerTest do
 
       Events.broadcast(
         :buffer_changed,
-        %Events.BufferChangedEvent{buffer: buf, source: :user}
+        %Events.BufferChangedEvent{buffer: buf, source: Minga.Buffer.EditSource.user()}
       )
 
       :sys.get_state(SyncServer)
@@ -66,7 +66,7 @@ defmodule Minga.LSP.SyncServerTest do
 
       Events.broadcast(
         :buffer_changed,
-        %Events.BufferChangedEvent{buffer: buf, source: :user}
+        %Events.BufferChangedEvent{buffer: buf, source: Minga.Buffer.EditSource.user()}
       )
 
       # Sync call to flush the event message through SyncServer's mailbox.
@@ -86,7 +86,11 @@ defmodule Minga.LSP.SyncServerTest do
 
       Events.broadcast(
         :buffer_changed,
-        %Events.BufferChangedEvent{buffer: buf, source: :user, delta: delta}
+        %Events.BufferChangedEvent{
+          buffer: buf,
+          source: Minga.Buffer.EditSource.user(),
+          delta: delta
+        }
       )
 
       :sys.get_state(SyncServer)
@@ -106,7 +110,11 @@ defmodule Minga.LSP.SyncServerTest do
       # First: accumulate a real delta
       Events.broadcast(
         :buffer_changed,
-        %Events.BufferChangedEvent{buffer: buf, source: :user, delta: delta}
+        %Events.BufferChangedEvent{
+          buffer: buf,
+          source: Minga.Buffer.EditSource.user(),
+          delta: delta
+        }
       )
 
       :sys.get_state(SyncServer)
@@ -114,7 +122,11 @@ defmodule Minga.LSP.SyncServerTest do
       # Second: nil delta (bulk op) should mark as full_sync
       Events.broadcast(
         :buffer_changed,
-        %Events.BufferChangedEvent{buffer: buf, source: :unknown, delta: nil}
+        %Events.BufferChangedEvent{
+          buffer: buf,
+          source: Minga.Buffer.EditSource.unknown(),
+          delta: nil
+        }
       )
 
       :sys.get_state(SyncServer)


### PR DESCRIPTION
Follow-up to #1130. Adds constructor functions to `EditSource` so the internal representation is centralized and validated.

## What

- **5 constructors**: `user/0`, `agent/2`, `lsp/1`, `formatter/0`, `unknown/0`
- **Guard validation**: `agent/2` requires `is_pid(session_id)` and `is_binary(tool_call_id)`; `lsp/1` requires `is_atom(server_name)`
- **All construction sites migrated**: Buffer.Server defaults, clear_edits calls, event broadcasts, test helpers
- **Pattern matching unchanged**: consumers still match on `{:agent, sid, _}`, `:user`, etc.

## Why not a Credo check?

We investigated a custom Credo check but dropped it. The Elixir AST represents 2-element tuples (`{:lsp, :elixir_ls}`) identically in construction and pattern match positions, so the check could only reliably catch 3-element tuples (`{:agent, ...}`). A half-working check is worse than convention.

## Testing

- 3 new guard validation tests (reject bad input with FunctionClauseError)
- 5 new constructor return-value tests
- Existing tests migrated to use constructors
- Full suite: 6543 tests, 0 failures