### PR TITLE
fix(editor): prevent chaos fuzzer crash and harden render pipeline

### DIFF
--- a/lib/minga/editor/commands/buffer_management.ex
+++ b/lib/minga/editor/commands/buffer_management.ex
@@ -868,9 +868,13 @@ defmodule Minga.Editor.Commands.BufferManagement do
 
   # Exits the editor. Single exit point so shutdown cleanup (flush buffers,
   # save session, etc.) can be added in one place.
+  #
+  # The shutdown function is injectable via application config so the chaos
+  # fuzzer can prevent `System.stop/1` from killing the VM mid-test.
   @spec shutdown_editor(state()) :: state()
   defp shutdown_editor(state) do
-    System.stop(0)
+    shutdown_fn = Application.get_env(:minga, :shutdown_fn, &System.stop/1)
+    shutdown_fn.(0)
     state
   end
 

--- a/lib/minga/editor/render_pipeline/content.ex
+++ b/lib/minga/editor/render_pipeline/content.ex
@@ -243,6 +243,12 @@ defmodule Minga.Editor.RenderPipeline.Content do
     {frame, ci, st} = render_agent_chat_window(st, window, win_id, win_layout)
     new_cursor = if ci != nil, do: ci, else: cursor
     {[frame | frames], new_cursor, st}
+  catch
+    # Buffer process died between the :DOWN message and this render.
+    # Skip this window; the :DOWN handler will clean up state next cycle.
+    :exit, _ ->
+      Minga.Log.debug(:render, "[content] skipped agent window #{win_id}: buffer process dead")
+      {frames, cursor, st}
   end
 
   defp maybe_render_agent_window(_window, _win_id, _win_layout, frames, cursor, st) do

--- a/lib/minga/editor/render_pipeline/scroll.ex
+++ b/lib/minga/editor/render_pipeline/scroll.ex
@@ -125,10 +125,33 @@ defmodule Minga.Editor.RenderPipeline.Scroll do
         # Skip nil windows and agent chat windows (rendered by build_agent_chat_content)
         {acc, st}
       else
-        is_active = win_id == state.windows.active
-        scroll = scroll_window(st, win_id, window, win_layout, is_active)
+        scroll_and_invalidate(state, st, acc, win_id, window, win_layout)
+      end
+    end)
+  end
 
-        # Detect per-window invalidation by comparing against last frame
+  # ── Private ──────────────────────────────────────────────────────────────
+
+  # Scrolls a single window and detects invalidation. Guards against buffer
+  # death in the race window between the process dying and the :DOWN message
+  # being processed. Only scroll_window makes GenServer calls to the buffer;
+  # the invalidation detection is pure computation.
+  @spec scroll_and_invalidate(
+          state(),
+          state(),
+          %{Window.id() => WindowScroll.t()},
+          Window.id(),
+          Window.t(),
+          Layout.window_layout()
+        ) :: {%{Window.id() => WindowScroll.t()}, state()}
+  defp scroll_and_invalidate(state, st, acc, win_id, window, win_layout) do
+    is_active = win_id == state.windows.active
+
+    case safe_scroll_window(st, win_id, window, win_layout, is_active) do
+      :skip ->
+        {acc, st}
+
+      {:ok, scroll} ->
         updated_window =
           Window.detect_invalidation(
             window,
@@ -138,7 +161,6 @@ defmodule Minga.Editor.RenderPipeline.Scroll do
             scroll.buf_version
           )
 
-        # Also invalidate gutter when cursor line changed with relative numbering
         updated_window =
           detect_gutter_invalidation(
             updated_window,
@@ -146,18 +168,24 @@ defmodule Minga.Editor.RenderPipeline.Scroll do
             scroll.line_number_style
           )
 
-        # Store the invalidated window and update the scroll to reference it
         scroll = %{scroll | window: updated_window}
-
         new_map = Map.put(st.windows.map, win_id, updated_window)
         st = %{st | windows: %{st.windows | map: new_map}}
-
         {Map.put(acc, win_id, scroll), st}
-      end
-    end)
+    end
   end
 
-  # ── Private ──────────────────────────────────────────────────────────────
+  # Wraps scroll_window with a catch for dead buffer processes. Returns
+  # {:ok, scroll} on success, :skip if the buffer died mid-call.
+  @spec safe_scroll_window(state(), Window.id(), Window.t(), Layout.window_layout(), boolean()) ::
+          {:ok, WindowScroll.t()} | :skip
+  defp safe_scroll_window(state, win_id, window, win_layout, is_active) do
+    {:ok, scroll_window(state, win_id, window, win_layout, is_active)}
+  catch
+    :exit, _ ->
+      Minga.Log.debug(:render, "[scroll] skipped window #{win_id}: buffer process dead")
+      :skip
+  end
 
   @spec scroll_window(
           state(),

--- a/test/minga/chaos/editor_fuzzer_test.exs
+++ b/test/minga/chaos/editor_fuzzer_test.exs
@@ -14,7 +14,8 @@ defmodule Minga.Chaos.EditorFuzzerTest do
       mix test test/minga/chaos/ --include chaos --seed 12345  # reproduce
   """
 
-  use ExUnit.Case
+  # Mutates Application env (:minga, :shutdown_fn); must not run concurrently with other tests.
+  use ExUnit.Case, async: false
   use PropCheck
   use PropCheck.StateM.ModelDSL
 
@@ -24,7 +25,24 @@ defmodule Minga.Chaos.EditorFuzzerTest do
   alias Minga.Test.HeadlessPort
 
   @moduletag :chaos
-  @moduletag timeout: 120_000
+  @moduletag timeout: 180_000
+
+  # Prevent :q/:qa/:wq from calling System.stop(0) and killing the VM.
+  # The editor still runs the quit path; it just becomes a no-op at the
+  # System.stop call site.
+  setup do
+    prev = Application.get_env(:minga, :shutdown_fn)
+    Application.put_env(:minga, :shutdown_fn, fn _status -> :ok end)
+
+    on_exit(fn ->
+      case prev do
+        nil -> Application.delete_env(:minga, :shutdown_fn)
+        fun -> Application.put_env(:minga, :shutdown_fn, fun)
+      end
+    end)
+
+    :ok
+  end
 
   # ── Model state ──────────────────────────────────────────────────────────
 
@@ -308,7 +326,10 @@ defmodule Minga.Chaos.EditorFuzzerTest do
 
   # ── Property ──────────────────────────────────────────────────────────
 
-  property "editor survives random action sequences", numtests: 50, max_size: 100 do
+  property "editor survives random action sequences",
+    numtests: 50,
+    max_size: 100,
+    max_shrinks: 200 do
     forall {content, cmds} <- content_and_commands() do
       ctx = start_chaos_editor(content)
       store_ctx(ctx)


### PR DESCRIPTION
## Summary

Fixes the chaos fuzzer test that was consistently failing on CI (including on main). The root cause was two problems compounding:

**Test design bug:** The command-mode generator types random chars + Enter. When it spells `:q`, `:qa`, or `:wq`, it calls `System.stop(0)`, killing the VM mid-test. PropCheck then spends its shrink budget waiting for 5-second GenServer.call timeouts on dead processes, blowing past the 120s test timeout.

**Production bug:** The render pipeline calls `BufferServer.line_count(window.buffer)` without guarding against a dead buffer PID. When a buffer dies for any reason, the render pipeline crashes the Editor GenServer. There's a race window between the buffer process dying and the `:DOWN` message being processed where a render frame can be triggered.

## Changes

1. **Injectable shutdown function** (`buffer_management.ex`): `shutdown_editor/1` reads `:shutdown_fn` from Application env with `&System.stop/1` as default. The chaos fuzzer stubs it as a no-op.

2. **Render pipeline resilience** (`scroll.ex`, `content.ex`): Added `catch :exit, _` at the per-window boundary in the scroll stage (`safe_scroll_window/5`) and the agent chat content stage. When a buffer dies mid-render, skip that window. The `:DOWN` handler cleans up state on the next message cycle. Matches the existing `catch :exit` pattern used in `fetch_decorations` and `wrap_enabled?` in the same files.

3. **Shrinking limits** (`editor_fuzzer_test.exs`): Added `max_shrinks: 200` and bumped timeout from 120s to 180s so shrinking can't hang CI indefinitely.

4. **Proper teardown**: Uses `Application.delete_env` when restoring nil to avoid poisoning app env.

## Testing

- Chaos fuzzer: 5 consecutive green runs locally
- Full `mix lint`: 0 errors
- Full `mix test.llm`: 6507 tests, only 2 pre-existing flakes in unrelated files