### PR TITLE
feat(editor): migrate diagnostics and LSP notifications to Events bus

### DIFF
--- a/lib/minga/diagnostics.ex
+++ b/lib/minga/diagnostics.ex
@@ -8,9 +8,9 @@ defmodule Minga.Diagnostics do
   and doesn't know or care where diagnostics came from.
 
   Backed by ETS with `read_concurrency: true` for lock-free reads on the
-  render path. The GenServer owns the ETS table lifecycle and manages
-  subscriber notifications. Reads go directly to ETS; writes go through
-  the GenServer to serialize subscriber notifications.
+  render path. The GenServer owns the ETS table lifecycle and broadcasts
+  change notifications via `Minga.Events`. Reads go directly to ETS;
+  writes go through the GenServer to serialize event broadcasts.
 
   Modeled on Neovim's `vim.diagnostic` and Emacs's `flymake`.
 
@@ -31,10 +31,12 @@ defmodule Minga.Diagnostics do
       Diagnostics.next("file:///...", current_line)     # next diagnostic
       Diagnostics.count("file:///...")                  # {error: N, ...}
 
-  ## Subscriptions
+  ## Notifications
 
-  The Editor subscribes to receive `{:diagnostics_changed, uri}` messages
-  when diagnostics are published or cleared, triggering re-renders.
+  After each publish or clear, the GenServer broadcasts a
+  `{:minga_event, :diagnostics_updated, %DiagnosticsUpdatedEvent{}}` event
+  via `Minga.Events`. Subscribers (e.g., the Editor) react to re-render
+  gutter signs and minibuffer hints.
   """
 
   use GenServer
@@ -47,12 +49,11 @@ defmodule Minga.Diagnostics do
   @typedoc "A file URI string (e.g., `\"file:///path/to/file.ex\"`)."
   @type uri :: String.t()
 
-  @typedoc "Internal state: ETS table references, merge cache, subscriber list, and generation counter."
+  @typedoc "Internal state: ETS table references, merge cache, and generation counter."
   @type state :: %{
           table: :ets.table(),
           uri_index: :ets.table(),
           merge_cache: :ets.table(),
-          subscribers: [pid()],
           generation: non_neg_integer()
         }
 
@@ -65,24 +66,13 @@ defmodule Minga.Diagnostics do
     GenServer.start_link(__MODULE__, name, name: name)
   end
 
-  @doc """
-  Subscribes the calling process to diagnostic change notifications.
-
-  The subscriber receives `{:diagnostics_changed, uri}` messages whenever
-  diagnostics are published or cleared for a URI.
-  """
-  @spec subscribe(GenServer.server()) :: :ok
-  def subscribe(server \\ __MODULE__) do
-    GenServer.call(server, {:subscribe, self()})
-  end
-
-  # ── Client API: Producers (writes go through GenServer for subscriber notifications) ──
+  # ── Client API: Producers (writes go through GenServer for event broadcasts) ──
 
   @doc """
   Publishes diagnostics for a `{source, uri}` pair.
 
   Replaces all existing diagnostics for this source+URI combination.
-  Notifies subscribers with `{:diagnostics_changed, uri}`.
+  Broadcasts `:diagnostics_updated` via `Minga.Events`.
   """
   @spec publish(GenServer.server(), source(), uri(), [Diagnostic.t()]) :: :ok
   def publish(server \\ __MODULE__, source, uri, diagnostics)
@@ -93,7 +83,7 @@ defmodule Minga.Diagnostics do
   @doc """
   Clears all diagnostics for a specific `{source, uri}` pair.
 
-  Notifies subscribers with `{:diagnostics_changed, uri}`.
+  Broadcasts `:diagnostics_updated` via `Minga.Events`.
   """
   @spec clear(GenServer.server(), source(), uri()) :: :ok
   def clear(server \\ __MODULE__, source, uri)
@@ -104,7 +94,7 @@ defmodule Minga.Diagnostics do
   @doc """
   Clears all diagnostics from a specific source across all URIs.
 
-  Notifies subscribers for each affected URI.
+  Broadcasts `:diagnostics_updated` for each affected URI.
   """
   @spec clear_source(GenServer.server(), source()) :: :ok
   def clear_source(server \\ __MODULE__, source) when is_atom(source) do
@@ -248,23 +238,17 @@ defmodule Minga.Diagnostics do
        table: table,
        uri_index: uri_index,
        merge_cache: merge_cache,
-       subscribers: [],
        generation: 0
      }}
   end
 
   @impl GenServer
-  def handle_call({:subscribe, pid}, _from, state) when is_pid(pid) do
-    Process.monitor(pid)
-    {:reply, :ok, %{state | subscribers: [pid | state.subscribers]}}
-  end
-
   def handle_call({:publish, source, uri, diagnostics}, _from, state) do
     :ets.insert(state.table, {{source, uri}, diagnostics})
     update_uri_index(state.uri_index, uri, source, :add)
     invalidate_cache(state.merge_cache, uri)
     gen = state.generation + 1
-    notify_subscribers(state.subscribers, uri)
+    broadcast_diagnostics_updated(uri, source)
     {:reply, :ok, %{state | generation: gen}}
   end
 
@@ -273,7 +257,7 @@ defmodule Minga.Diagnostics do
     update_uri_index(state.uri_index, uri, source, :remove)
     invalidate_cache(state.merge_cache, uri)
     gen = state.generation + 1
-    notify_subscribers(state.subscribers, uri)
+    broadcast_diagnostics_updated(uri, source)
     {:reply, :ok, %{state | generation: gen}}
   end
 
@@ -305,13 +289,8 @@ defmodule Minga.Diagnostics do
     end)
 
     gen = state.generation + 1
-    Enum.each(affected_uris, &notify_subscribers(state.subscribers, &1))
+    Enum.each(affected_uris, &broadcast_diagnostics_updated(&1, source))
     {:reply, :ok, %{state | generation: gen}}
-  end
-
-  @impl GenServer
-  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    {:noreply, %{state | subscribers: List.delete(state.subscribers, pid)}}
   end
 
   # ── Private ────────────────────────────────────────────────────────────────
@@ -413,9 +392,12 @@ defmodule Minga.Diagnostics do
     :ets.delete(cache, uri)
   end
 
-  @spec notify_subscribers([pid()], uri()) :: :ok
-  defp notify_subscribers(subscribers, uri) do
-    Enum.each(subscribers, &send(&1, {:diagnostics_changed, uri}))
+  @spec broadcast_diagnostics_updated(uri(), source()) :: :ok
+  defp broadcast_diagnostics_updated(uri, source) do
+    Minga.Events.broadcast(
+      :diagnostics_updated,
+      %Minga.Events.DiagnosticsUpdatedEvent{uri: uri, source: source}
+    )
   end
 
   @spec table_name(GenServer.server()) :: atom()

--- a/lib/minga/diagnostics/decorations.ex
+++ b/lib/minga/diagnostics/decorations.ex
@@ -15,8 +15,8 @@ defmodule Minga.Diagnostics.Decorations do
 
   ## Integration
 
-  Called by the Editor when it receives a `{:diagnostics_changed, uri}`
-  message. The Editor finds the buffer for the URI, fetches the current
+  Called by the Editor when it receives a `:diagnostics_updated` event
+  via `Minga.Events`. The Editor finds the buffer for the URI, fetches the current
   diagnostics, and calls `apply/3` to update the decorations.
   """
 

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -27,7 +27,7 @@ defmodule Minga.Editor do
 
   alias Minga.Editor.AgentLifecycle
   alias Minga.Editor.BottomPanel
-  alias Minga.Editor.BufferLifecycle
+
   alias Minga.Editor.Commands
   alias Minga.Editor.CompletionHandling
   alias Minga.Editor.CompletionTrigger
@@ -187,7 +187,8 @@ defmodule Minga.Editor do
       end
 
     state = Startup.apply_config_options(state)
-    Minga.Diagnostics.subscribe()
+    Minga.Events.subscribe(:diagnostics_updated)
+    Minga.Events.subscribe(:lsp_status_changed)
 
     # Refresh file tree git status when any buffer is saved.
     Minga.Events.subscribe(:buffer_saved)
@@ -871,23 +872,32 @@ defmodule Minga.Editor do
     {:noreply, state}
   end
 
-  def handle_info(:refresh_lsp_status, state) do
+  # LSP status changed — update per-server status map and derive aggregate for modeline.
+  def handle_info(
+        {:minga_event, :lsp_status_changed,
+         %Minga.Events.LspStatusEvent{name: name, status: status}},
+        state
+      ) do
     old_status = state.lsp_status
-    state = BufferLifecycle.refresh_lsp_status(state)
 
-    # If still initializing/starting, check again in 1 second
-    if state.lsp_status in [:starting, :initializing] do
-      Process.send_after(self(), :refresh_lsp_status, 1_000)
-    end
+    server_statuses =
+      case status do
+        :stopped -> Map.delete(state.lsp_server_statuses, name)
+        s -> Map.put(state.lsp_server_statuses, name, s)
+      end
 
-    # Re-render if status changed (modeline needs update)
-    state = if state.lsp_status != old_status, do: schedule_render(state, 16), else: state
+    lsp_status = aggregate_lsp_server_statuses(server_statuses)
+    state = %{state | lsp_server_statuses: server_statuses, lsp_status: lsp_status}
+    state = if lsp_status != old_status, do: schedule_render(state, 16), else: state
     {:noreply, state}
   end
 
   # Diagnostics changed — re-render to update gutter signs and minibuffer hint.
   # Debounced because multiple diagnostics may arrive in rapid succession.
-  def handle_info({:diagnostics_changed, uri}, state) do
+  def handle_info(
+        {:minga_event, :diagnostics_updated, %Minga.Events.DiagnosticsUpdatedEvent{uri: uri}},
+        state
+      ) do
     # Apply diagnostic underline decorations to the affected buffer
     apply_diagnostic_decorations(state, uri)
     {:noreply, schedule_render(state, 16)}
@@ -1394,10 +1404,34 @@ defmodule Minga.Editor do
     %{state | render_timer: ref}
   end
 
+  # ── LSP status aggregation ────────────────────────────────────────────────────
+
+  # Derives an aggregate LSP status from the per-server status map.
+  # Priority: :ready > :error > :initializing > :starting > :none
+  @spec aggregate_lsp_server_statuses(%{atom() => :starting | :initializing | :ready | :crashed}) ::
+          Minga.Editor.Modeline.lsp_status()
+  defp aggregate_lsp_server_statuses(server_statuses) when server_statuses == %{}, do: :none
+
+  defp aggregate_lsp_server_statuses(server_statuses) do
+    server_statuses
+    |> Map.values()
+    |> Enum.reduce(:none, fn
+      :ready, _acc -> :ready
+      _status, :ready -> :ready
+      :crashed, _acc -> :error
+      _status, :error -> :error
+      :initializing, _acc -> :initializing
+      _status, :initializing -> :initializing
+      :starting, _acc -> :starting
+      _status, :starting -> :starting
+      _status, acc -> acc
+    end)
+  end
+
   # ── Diagnostic decorations ──────────────────────────────────────────────────
 
   # Applies diagnostic underline decorations to the buffer matching the URI.
-  # Called when {:diagnostics_changed, uri} arrives from the Diagnostics server.
+  # Called when {:minga_event, :diagnostics_updated, ...} arrives via the event bus.
   @spec apply_diagnostic_decorations(state(), String.t()) :: :ok
   defp apply_diagnostic_decorations(state, uri) do
     path = LspSyncServer.uri_to_path(uri)
@@ -1664,7 +1698,6 @@ defmodule Minga.Editor do
   defp register_buffer(state, buffer_pid, file_path) do
     state = Commands.add_buffer(state, buffer_pid)
     state = log_message(state, "Opened: #{file_path}")
-    state = BufferLifecycle.lsp_buffer_opened(state, buffer_pid)
 
     Minga.Events.broadcast(:buffer_opened, %Minga.Events.BufferEvent{
       buffer: buffer_pid,
@@ -1689,7 +1722,6 @@ defmodule Minga.Editor do
     state = %{state | buffers: Buffers.add_background(state.buffers, buffer_pid)}
     state = EditorState.monitor_buffer(state, buffer_pid)
     state = log_message(state, "Opened (agent): #{file_path}")
-    state = BufferLifecycle.lsp_buffer_opened(state, buffer_pid)
 
     Minga.Events.broadcast(:buffer_opened, %Minga.Events.BufferEvent{
       buffer: buffer_pid,

--- a/lib/minga/editor/buffer_lifecycle.ex
+++ b/lib/minga/editor/buffer_lifecycle.ex
@@ -1,73 +1,19 @@
 defmodule Minga.Editor.BufferLifecycle do
   @moduledoc """
-  LSP status tracking and post-command lifecycle helpers for the Editor.
+  Post-command lifecycle helpers for the Editor.
 
   LSP document synchronization (didOpen, didChange, didSave, didClose) is
-  handled by `Minga.LSP.SyncServer` via the event bus. This module retains
-  only the LSP status queries (for the modeline indicator) and the
-  post-command hook that broadcasts `:buffer_saved`.
+  handled by `Minga.LSP.SyncServer` via the event bus. LSP status tracking
+  is event-driven via `:lsp_status_changed` events from `LSP.Client`.
+
+  This module retains the post-command hook that broadcasts `:buffer_saved`.
   """
 
   alias Minga.Buffer.Server, as: BufferServer
-  alias Minga.Editor.Modeline
   alias Minga.Editor.State, as: EditorState
-  alias Minga.LSP.Client
-  alias Minga.LSP.SyncServer
   alias Minga.Mode
 
   @type state :: EditorState.t()
-
-  # ── LSP status ─────────────────────────────────────────────────────────
-
-  @doc """
-  Refreshes the cached LSP status for the active buffer and schedules
-  a deferred poll for async LSP initialization.
-
-  Called when a buffer is opened so the modeline shows the LSP indicator.
-  """
-  @spec lsp_buffer_opened(state(), pid()) :: state()
-  def lsp_buffer_opened(state, _buffer_pid) do
-    state = refresh_lsp_status(state)
-
-    if state.lsp_status in [:starting, :initializing, :none] do
-      Process.send_after(self(), :refresh_lsp_status, 500)
-    end
-
-    state
-  end
-
-  @doc """
-  Refreshes the cached LSP status for the active buffer.
-
-  Call this when LSP lifecycle events arrive (client connected,
-  initialized, crashed) to keep the modeline indicator current
-  without querying on every render frame.
-  """
-  @spec refresh_lsp_status(state()) :: state()
-  def refresh_lsp_status(%{buffers: %{active: nil}} = state), do: %{state | lsp_status: :none}
-
-  def refresh_lsp_status(%{buffers: %{active: buf}} = state) do
-    %{state | lsp_status: lsp_status_for_buffer(buf)}
-  end
-
-  @doc """
-  Queries the LSP status for a buffer by calling each attached client.
-
-  Returns the aggregate status: `:ready` if any client is ready,
-  `:error` if any crashed, `:initializing`/`:starting` if connecting,
-  or `:none` if no LSP clients are attached.
-  """
-  @spec lsp_status_for_buffer(pid() | nil) :: Modeline.lsp_status()
-  def lsp_status_for_buffer(nil), do: :none
-
-  def lsp_status_for_buffer(buffer_pid) do
-    clients = SyncServer.clients_for_buffer(buffer_pid)
-
-    case clients do
-      [] -> :none
-      pids -> pids |> Enum.map(&query_client_status/1) |> aggregate_lsp_status()
-    end
-  end
 
   # ── Post-command lifecycle ─────────────────────────────────────────────
 
@@ -111,28 +57,4 @@ defmodule Minga.Editor.BufferLifecycle do
   end
 
   def lsp_after_save(state, _cmd), do: state
-
-  # ── Private ────────────────────────────────────────────────────────────
-
-  @spec query_client_status(pid()) :: Client.State.status() | :error
-  defp query_client_status(pid) do
-    Client.status(pid)
-  catch
-    :exit, _ -> :error
-  end
-
-  @spec aggregate_lsp_status([Client.State.status() | :error]) :: Modeline.lsp_status()
-  defp aggregate_lsp_status(statuses) do
-    Enum.reduce(statuses, :none, &merge_lsp_status/2)
-  end
-
-  defp merge_lsp_status(:ready, _acc), do: :ready
-  defp merge_lsp_status(_status, :ready), do: :ready
-  defp merge_lsp_status(:error, _acc), do: :error
-  defp merge_lsp_status(_status, :error), do: :error
-  defp merge_lsp_status(:initializing, _acc), do: :initializing
-  defp merge_lsp_status(_status, :initializing), do: :initializing
-  defp merge_lsp_status(:starting, _acc), do: :starting
-  defp merge_lsp_status(_status, :starting), do: :starting
-  defp merge_lsp_status(_status, acc), do: acc
 end

--- a/lib/minga/editor/commands/lsp.ex
+++ b/lib/minga/editor/commands/lsp.ex
@@ -9,7 +9,6 @@ defmodule Minga.Editor.Commands.Lsp do
   @behaviour Minga.Command.Provider
 
   alias Minga.Buffer.Server, as: BufferServer
-  alias Minga.Editor.BufferLifecycle
   alias Minga.Editor.HoverPopup
   alias Minga.Editor.LspActions
   alias Minga.Editor.PickerUI
@@ -62,8 +61,8 @@ defmodule Minga.Editor.Commands.Lsp do
       client_keys ->
         results = Enum.map(client_keys, &restart_one/1)
         msg = format_results(results, "Restarted", "Failed to restart")
-        state = %{state | status_msg: msg}
-        BufferLifecycle.refresh_lsp_status(state)
+        # Status will update via :lsp_status_changed events from the new clients
+        %{state | status_msg: msg}
     end
   end
 
@@ -79,8 +78,8 @@ defmodule Minga.Editor.Commands.Lsp do
       client_keys ->
         results = Enum.map(client_keys, &stop_one/1)
         msg = format_results(results, "Stopped", "Failed to stop")
-        state = %{state | status_msg: msg}
-        BufferLifecycle.refresh_lsp_status(state)
+        # Status will update via :lsp_status_changed events from the stopped clients
+        %{state | status_msg: msg}
     end
   end
 
@@ -101,11 +100,8 @@ defmodule Minga.Editor.Commands.Lsp do
         root = Minga.Project.root() || "."
         {results, state} = start_servers(configs, root, state, buf)
         msg = format_results(results, "Started", "Failed to start")
-        state = %{state | status_msg: msg}
-
-        # Schedule deferred refresh for async initialization
-        Process.send_after(self(), :refresh_lsp_status, 500)
-        BufferLifecycle.refresh_lsp_status(state)
+        # Status will update via :lsp_status_changed events from the new clients
+        %{state | status_msg: msg}
     end
   end
 

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -117,6 +117,7 @@ defmodule Minga.Editor.State do
             git_status_panel: nil,
             git_remote_op: nil,
             lsp_status: :none,
+            lsp_server_statuses: %{},
             parser_status: :available,
             hover_popup: nil,
             signature_help: nil,
@@ -182,6 +183,9 @@ defmodule Minga.Editor.State do
              {git_root :: String.t(), success_msg :: String.t(), error_prefix :: String.t()}}
             | nil,
           lsp_status: Minga.Editor.Modeline.lsp_status(),
+          lsp_server_statuses: %{
+            atom() => :starting | :initializing | :ready | :crashed
+          },
           parser_status: Minga.Editor.Modeline.parser_status(),
           hover_popup: Minga.Editor.HoverPopup.t() | nil,
           signature_help: Minga.Editor.SignatureHelp.t() | nil,

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -34,6 +34,8 @@ defmodule Minga.Events do
   | `:buffer_changed` | `BufferChangedEvent` | `buffer: pid(), source: EditSource.t()`  |
   | `:mode_changed`   | `ModeEvent`          | `old: atom(), new: atom()`        |
   | `:git_status_changed` | `GitStatusEvent` | `git_root, entries, branch, ahead, behind` |
+  | `:diagnostics_updated` | `DiagnosticsUpdatedEvent` | `uri: String.t(), source: atom()` |
+  | `:lsp_status_changed` | `LspStatusEvent` | `name: atom(), status: atom(), uri: String.t() \| nil` |
   | `:project_rebuilt` | `ProjectRebuiltEvent` | `root: String.t()` |
   | `:command_done`    | `CommandDoneEvent`    | `name: String.t(), exit_code: non_neg_integer()` |
 
@@ -135,6 +137,26 @@ defmodule Minga.Events do
           }
   end
 
+  defmodule DiagnosticsUpdatedEvent do
+    @moduledoc "Payload for `:diagnostics_updated` events. Published by `Diagnostics` when diagnostics are published or cleared for a URI."
+    @enforce_keys [:uri, :source]
+    defstruct [:uri, :source]
+
+    @type t :: %__MODULE__{uri: String.t(), source: atom()}
+  end
+
+  defmodule LspStatusEvent do
+    @moduledoc "Payload for `:lsp_status_changed` events. Published by `LSP.Client` on status transitions."
+    @enforce_keys [:name, :status]
+    defstruct [:name, :status, :uri]
+
+    @type t :: %__MODULE__{
+            name: atom(),
+            status: :starting | :initializing | :ready | :stopped | :crashed,
+            uri: String.t() | nil
+          }
+  end
+
   # ── Types ───────────────────────────────────────────────────────────────────
 
   @typedoc "Known event topics."
@@ -146,6 +168,8 @@ defmodule Minga.Events do
           | :content_replaced
           | :mode_changed
           | :git_status_changed
+          | :diagnostics_updated
+          | :lsp_status_changed
           | :tool_install_started
           | :tool_install_progress
           | :tool_install_complete
@@ -165,6 +189,8 @@ defmodule Minga.Events do
           | ProjectRebuiltEvent.t()
           | CommandDoneEvent.t()
           | GitStatusEvent.t()
+          | DiagnosticsUpdatedEvent.t()
+          | LspStatusEvent.t()
 
   # ── Child spec ──────────────────────────────────────────────────────────────
 
@@ -252,6 +278,8 @@ defmodule Minga.Events do
   @spec broadcast(:project_rebuilt, ProjectRebuiltEvent.t()) :: :ok
   @spec broadcast(:command_done, CommandDoneEvent.t()) :: :ok
   @spec broadcast(:git_status_changed, GitStatusEvent.t()) :: :ok
+  @spec broadcast(:diagnostics_updated, DiagnosticsUpdatedEvent.t()) :: :ok
+  @spec broadcast(:lsp_status_changed, LspStatusEvent.t()) :: :ok
   def broadcast(topic, %_{} = payload) when is_atom(topic) do
     Registry.dispatch(@registry, topic, fn entries ->
       for {pid, _value} <- entries do

--- a/lib/minga/lsp/client.ex
+++ b/lib/minga/lsp/client.ex
@@ -122,12 +122,6 @@ defmodule Minga.LSP.Client do
     GenServer.cast(server, {:did_close, uri})
   end
 
-  @doc "Subscribes the calling process to LSP events."
-  @spec subscribe(GenServer.server()) :: :ok
-  def subscribe(server) do
-    GenServer.call(server, {:subscribe, self()})
-  end
-
   @doc """
   Sends an async LSP request and returns a reference.
 
@@ -262,6 +256,7 @@ defmodule Minga.LSP.Client do
 
         Process.put(:diagnostics_server, diagnostics)
 
+        broadcast_status_changed(server_config.name, :starting, root_path)
         send(self(), :send_initialize)
         {:ok, state}
 
@@ -310,14 +305,10 @@ defmodule Minga.LSP.Client do
     {:reply, state.started_at, state}
   end
 
-  def handle_call({:subscribe, pid}, _from, state) do
-    Process.monitor(pid)
-    {:reply, :ok, %{state | subscribers: [pid | state.subscribers]}}
-  end
-
   def handle_call(:shutdown, from, %{status: :ready} = state) do
     {id, state} = send_request(state, "shutdown", %{})
     state = put_pending(state, id, "shutdown", from)
+    broadcast_status_changed(state.server_config.name, :stopped, state.root_path)
     {:noreply, %{state | status: :shutdown}}
   end
 
@@ -440,6 +431,7 @@ defmodule Minga.LSP.Client do
 
     {id, state} = send_request(state, "initialize", params)
     state = put_pending(state, id, "initialize", nil)
+    broadcast_status_changed(state.server_config.name, :initializing, state.root_path)
     {:noreply, %{state | status: :initializing}}
   end
 
@@ -452,17 +444,31 @@ defmodule Minga.LSP.Client do
     {:noreply, state}
   end
 
+  # Normal exit after deliberate shutdown: :stopped was already broadcast.
+  def handle_info({port, {:exit_status, _code}}, %{port: port, status: :shutdown} = state) do
+    {:stop, :normal, %{state | port: nil}}
+  end
+
+  # Unexpected exit: server died on its own.
   def handle_info({port, {:exit_status, code}}, %{port: port} = state) do
     msg = "LSP server #{state.server_config.name} exited with code #{code}"
     Minga.Log.warning(:lsp, msg)
     Minga.Editor.log_to_warnings(msg)
+    broadcast_status_changed(state.server_config.name, :crashed, state.root_path)
     {:stop, {:server_exited, code}, %{state | port: nil, status: :shutdown}}
   end
 
+  # Normal port close after deliberate shutdown: :stopped was already broadcast.
+  def handle_info({:EXIT, port, _reason}, %{port: port, status: :shutdown} = state) do
+    {:stop, :normal, %{state | port: nil}}
+  end
+
+  # Unexpected port crash.
   def handle_info({:EXIT, port, reason}, %{port: port} = state) do
     msg = "LSP server #{state.server_config.name} crashed: #{inspect(reason)}"
     Minga.Log.warning(:lsp, msg)
     Minga.Editor.log_to_warnings(msg)
+    broadcast_status_changed(state.server_config.name, :crashed, state.root_path)
     {:stop, {:port_crashed, reason}, %{state | port: nil, status: :shutdown}}
   end
 
@@ -476,10 +482,6 @@ defmodule Minga.LSP.Client do
         reply_to_caller(from, {:error, :timeout})
         {:noreply, %{state | pending: pending}}
     end
-  end
-
-  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    {:noreply, %{state | subscribers: List.delete(state.subscribers, pid)}}
   end
 
   def handle_info(_msg, state) do
@@ -584,7 +586,7 @@ defmodule Minga.LSP.Client do
           nil
       end
 
-    notify_subscribers(state.subscribers, {:lsp_ready, state.server_config.name})
+    broadcast_status_changed(state.server_config.name, :ready, state.root_path)
 
     %{
       state
@@ -951,8 +953,19 @@ defmodule Minga.LSP.Client do
     :ok
   end
 
-  @spec notify_subscribers([pid()], term()) :: :ok
-  defp notify_subscribers(subscribers, message) do
-    Enum.each(subscribers, &send(&1, message))
+  @spec broadcast_status_changed(
+          atom(),
+          :starting | :initializing | :ready | :stopped | :crashed,
+          String.t()
+        ) :: :ok
+  defp broadcast_status_changed(name, status, root_path) do
+    Minga.Events.broadcast(
+      :lsp_status_changed,
+      %Minga.Events.LspStatusEvent{
+        name: name,
+        status: status,
+        uri: "file://#{root_path}"
+      }
+    )
   end
 end

--- a/lib/minga/lsp/client/state.ex
+++ b/lib/minga/lsp/client/state.ex
@@ -18,8 +18,7 @@ defmodule Minga.LSP.Client.State do
     open_documents: %{},
     capabilities: %{},
     semantic_token_legend: nil,
-    status: :starting,
-    subscribers: []
+    status: :starting
   ]
 
   @typedoc "Client lifecycle status."
@@ -53,7 +52,6 @@ defmodule Minga.LSP.Client.State do
           open_documents: %{String.t() => open_doc()},
           capabilities: map(),
           semantic_token_legend: {[String.t()], [String.t()]} | nil,
-          status: status(),
-          subscribers: [pid()]
+          status: status()
         }
 end

--- a/lib/minga/lsp/sync_server.ex
+++ b/lib/minga/lsp/sync_server.ex
@@ -8,7 +8,7 @@ defmodule Minga.LSP.SyncServer do
 
   Maintains an ETS table (`Minga.LSP.SyncServer.Registry`) mapping
   buffer pids to their attached LSP client pids. Consumers like
-  `CompletionTrigger`, `LspActions`, and `BufferLifecycle` look up
+  `CompletionTrigger` and `LspActions` look up
   clients via `clients_for_buffer/1` (direct ETS read, no GenServer
   call needed).
 

--- a/test/minga/diagnostics_test.exs
+++ b/test/minga/diagnostics_test.exs
@@ -292,49 +292,63 @@ defmodule Minga.DiagnosticsTest do
     end
   end
 
-  describe "subscriptions" do
-    test "subscriber receives notification on publish", %{server: s} do
-      Diagnostics.subscribe(s)
-      Diagnostics.publish(s, :server_a, @uri, [make_diag()])
+  describe "event bus notifications" do
+    # Use per-test unique URIs to avoid cross-contamination via the global
+    # event bus when running async: true.
+    defp unique_uri, do: "file:///tmp/diag_event_#{:erlang.unique_integer([:positive])}.ex"
 
-      assert_receive {:diagnostics_changed, @uri}
+    test "publish broadcasts :diagnostics_updated event", %{server: s} do
+      uri = unique_uri()
+      Minga.Events.subscribe(:diagnostics_updated)
+      Diagnostics.publish(s, :server_a, uri, [make_diag()])
+
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri, source: :server_a}}
     end
 
-    test "subscriber receives notification on clear", %{server: s} do
-      Diagnostics.subscribe(s)
-      Diagnostics.publish(s, :server_a, @uri, [make_diag()])
-      assert_receive {:diagnostics_changed, @uri}
+    test "clear broadcasts :diagnostics_updated event", %{server: s} do
+      uri = unique_uri()
+      Minga.Events.subscribe(:diagnostics_updated)
+      Diagnostics.publish(s, :server_a, uri, [make_diag()])
 
-      Diagnostics.clear(s, :server_a, @uri)
-      assert_receive {:diagnostics_changed, @uri}
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri}}
+
+      Diagnostics.clear(s, :server_a, uri)
+
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri, source: :server_a}}
     end
 
-    test "subscriber receives notification per affected URI on clear_source", %{server: s} do
-      Diagnostics.subscribe(s)
-      Diagnostics.publish(s, :server_a, @uri, [make_diag()])
-      Diagnostics.publish(s, :server_a, @uri2, [make_diag()])
-      assert_receive {:diagnostics_changed, @uri}
-      assert_receive {:diagnostics_changed, @uri2}
+    test "clear_source broadcasts :diagnostics_updated per affected URI", %{server: s} do
+      uri_a = unique_uri()
+      uri_b = unique_uri()
+      Minga.Events.subscribe(:diagnostics_updated)
+      Diagnostics.publish(s, :server_a, uri_a, [make_diag()])
+      Diagnostics.publish(s, :server_a, uri_b, [make_diag()])
+
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri_a}}
+
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri_b}}
 
       Diagnostics.clear_source(s, :server_a)
-      assert_receive {:diagnostics_changed, @uri}
-      assert_receive {:diagnostics_changed, @uri2}
+
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri_a, source: :server_a}}
+
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri_b, source: :server_a}}
     end
 
-    test "dead subscriber is automatically cleaned up", %{server: s} do
-      task =
-        Task.async(fn ->
-          Diagnostics.subscribe(s)
-          :ok
-        end)
+    test "event payload includes source field", %{server: s} do
+      uri = unique_uri()
+      Minga.Events.subscribe(:diagnostics_updated)
+      Diagnostics.publish(s, :custom_linter, uri, [make_diag()])
 
-      Task.await(task)
-
-      # Flush the mailbox so the DOWN message is processed
-      :sys.get_state(s)
-
-      # Publishing should not crash even though subscriber is dead
-      assert :ok = Diagnostics.publish(s, :server_a, @uri, [make_diag()])
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri, source: :custom_linter}}
     end
   end
 

--- a/test/minga/editor/ensure_buffer_test.exs
+++ b/test/minga/editor/ensure_buffer_test.exs
@@ -46,7 +46,7 @@ defmodule Minga.Editor.EnsureBufferTest do
   #   3. register_buffer_background/3 which calls:
   #      - Buffers.add_background/2 (tested in buffers_test.exs)
   #      - EditorState.monitor_buffer/2 (tested in editor state tests)
-  #      - BufferLifecycle.lsp_buffer_opened/2 (tested in LSP tests)
+  #      - LSP status is event-driven via :lsp_status_changed (tested in LSP tests)
   #      - Events.broadcast/2 (tested in events tests)
   #
   # Full integration coverage lives in the snapshot test suite which

--- a/test/minga/lsp/client_test.exs
+++ b/test/minga/lsp/client_test.exs
@@ -22,13 +22,17 @@ defmodule Minga.LSP.ClientTest do
          diagnostics: diag_server}
       )
 
-    # Subscribe before the init handshake completes, then wait for the
-    # :lsp_ready message. If init already finished, status check catches it.
-    Client.subscribe(client)
+    # Subscribe to LSP status events and wait for the client to be ready.
+    Minga.Events.subscribe(:lsp_status_changed)
 
     case Client.status(client) do
-      :ready -> :ok
-      _ -> assert_receive {:lsp_ready, :mock_lsp}, 5_000
+      :ready ->
+        :ok
+
+      _ ->
+        assert_receive {:minga_event, :lsp_status_changed,
+                        %Minga.Events.LspStatusEvent{name: :mock_lsp, status: :ready}},
+                       5_000
     end
 
     %{client: client, diag_server: diag_server}
@@ -62,10 +66,12 @@ defmodule Minga.LSP.ClientTest do
       client: client,
       diag_server: diag_server
     } do
-      Diagnostics.subscribe(diag_server)
+      Minga.Events.subscribe(:diagnostics_updated)
       Client.did_open(client, @uri, "elixir", "defmodule Test do\nend\n")
 
-      assert_receive {:diagnostics_changed, @uri}, 5_000
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: @uri}},
+                     5_000
 
       diags = Diagnostics.for_uri(diag_server, @uri)
       assert length(diags) == 1
@@ -101,14 +107,22 @@ defmodule Minga.LSP.ClientTest do
     end
 
     test "didClose clears diagnostics", %{client: client, diag_server: diag_server} do
-      Diagnostics.subscribe(diag_server)
+      Minga.Events.subscribe(:diagnostics_updated)
 
       Client.did_open(client, @uri, "elixir", "content")
-      assert_receive {:diagnostics_changed, @uri}, 5_000
+
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: @uri}},
+                     5_000
+
       assert Diagnostics.for_uri(diag_server, @uri) != []
 
       Client.did_close(client, @uri)
-      assert_receive {:diagnostics_changed, @uri}, 5_000
+
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: @uri}},
+                     5_000
+
       assert Diagnostics.for_uri(diag_server, @uri) == []
     end
 
@@ -119,9 +133,20 @@ defmodule Minga.LSP.ClientTest do
     end
   end
 
-  describe "subscriptions" do
-    test "subscriber can subscribe to client", %{client: client} do
-      assert :ok = Client.subscribe(client)
+  describe "status events" do
+    test "client broadcasts :lsp_status_changed with :stopped on shutdown", %{client: client} do
+      # Setup already proved :ready fires (via assert_receive). Test :stopped.
+      Minga.Events.subscribe(:lsp_status_changed)
+      Client.shutdown(client)
+
+      assert_receive {:minga_event, :lsp_status_changed,
+                      %Minga.Events.LspStatusEvent{name: :mock_lsp, status: :stopped}},
+                     5_000
+
+      # Clean shutdown must not produce a spurious :crashed event.
+      refute_receive {:minga_event, :lsp_status_changed,
+                      %Minga.Events.LspStatusEvent{status: :crashed}},
+                     200
     end
   end
 

--- a/test/minga/lsp/supervisor_test.exs
+++ b/test/minga/lsp/supervisor_test.exs
@@ -22,15 +22,20 @@ defmodule Minga.LSP.SupervisorTest do
     %{supervisor: sup_name, diag_server: diag_name}
   end
 
-  # Subscribes to the client's events and waits for the LSP handshake to
-  # complete. If the handshake already finished before we subscribed,
-  # the status check catches it immediately.
+  # Subscribes to LSP status events and waits for the handshake to complete.
+  # If the handshake already finished before we subscribed, the status check
+  # catches it immediately.
   defp await_ready(client) do
-    Client.subscribe(client)
+    Minga.Events.subscribe(:lsp_status_changed)
 
     case Client.status(client) do
-      :ready -> :ok
-      _ -> assert_receive {:lsp_ready, :mock_lsp}, 5_000
+      :ready ->
+        :ok
+
+      _ ->
+        assert_receive {:minga_event, :lsp_status_changed,
+                        %Minga.Events.LspStatusEvent{name: :mock_lsp, status: :ready}},
+                       5_000
     end
   end
 


### PR DESCRIPTION
# TL;DR

Diagnostics and LSP status notifications now flow through `Minga.Events` instead of hand-rolled subscriber lists. The Editor reacts instantly to LSP status changes instead of polling every second.

Closes #1094, closes #1095

## Context

Minga has a well-designed event bus (`Minga.Events`) with typed payload structs and Registry-based pub/sub. Two subsystems predated this bus and used bespoke subscriber patterns: `Diagnostics` maintained a manual subscriber list with process monitoring, and `LSP.Client` did the same. The Editor polled LSP status on a 1-second timer. This PR unifies both notification paths through the event bus, matching how every other cross-component notification in the codebase works.

## Changes

**Diagnostics (#1094):**
- Added `DiagnosticsUpdatedEvent` struct with `uri` and `source` fields
- Replaced `notify_subscribers/2` with `Events.broadcast(:diagnostics_updated, ...)`
- Removed `subscribe/1`, the manual subscriber list, and the `:DOWN` cleanup handler
- Editor subscribes via `Events.subscribe(:diagnostics_updated)` and pattern-matches the event tuple

**LSP status (#1095):**
- Added `LspStatusEvent` struct with `name`, `status`, and `uri` fields
- `LSP.Client` broadcasts at every status transition: `:starting` (port spawn), `:initializing` (handshake), `:ready` (initialized), `:stopped` (clean shutdown), `:crashed` (unexpected exit)
- Editor maintains a `%{server_name => status}` map (`lsp_server_statuses`) and derives the aggregate modeline status from it, no polling needed
- Removed `BufferLifecycle.refresh_lsp_status/1`, `lsp_status_for_buffer/1`, `lsp_buffer_opened/2`, and all supporting private functions
- Removed the 1-second `Process.send_after` polling timer
- Split port exit handlers into deliberate shutdown vs unexpected crash to prevent a double-broadcast (`:stopped` then `:crashed`) on clean shutdown

**Key design decision:** On clean LSP shutdown, the port exit handler matches `%{status: :shutdown}` and stops normally without broadcasting. This prevents the modeline from briefly flashing `:error` after every `lsp stop` or `lsp restart` command.

## Verification

```bash
mix lint                    # format + credo + compile --warnings-as-errors + dialyzer
mix test.llm                # 6449 tests, 0 failures
mix test.heavy              # LSP client/supervisor tests (OS processes)
```

The LSP heavy tests verify:
- Client reaches `:ready` via event (not polling)
- Clean shutdown broadcasts `:stopped` and does NOT produce a spurious `:crashed`
- Diagnostics flow through the event bus end-to-end

## Acceptance Criteria Addressed

**#1094:**
- `:diagnostics_updated` topic with typed `DiagnosticsUpdatedEvent` payload ✅
- `publish/3` and `clear/2` broadcast through `Minga.Events` ✅
- Editor subscribes and handles `{:minga_event, :diagnostics_updated, ...}` ✅
- `Diagnostics.subscribe/1` removed (no other callers) ✅
- Manual subscribers list and `notify_subscribers/2` removed ✅
- Diagnostic reads remain on ETS fast path ✅

**#1095:**
- `:lsp_status_changed` topic with typed `LspStatusEvent` payload ✅
- `LSP.Client` broadcasts on all status transitions ✅
- Editor subscribes and updates from events instead of polling ✅
- `:refresh_lsp_status` timer and `BufferLifecycle.refresh_lsp_status/1` removed ✅
- Status bar updates within one render frame ✅
- LSP crash and restart still work correctly ✅