### PR TITLE
feat(macos): unified status bar layout across buffer and agent modes

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -156,17 +156,17 @@ Segments are the path components relative to the project root. For example, `lib
 
 ### 0x76 — gui_status_bar
 
-Status bar data for the focused window. The first byte after the opcode is `content_kind`:
-- `0` — buffer window: show file info, cursor position, git, diagnostics.
-- `1` — agent chat window: show model name, message count, session status.
+Status bar data for the focused window. Both variants use the same unified wire format so the status bar layout stays stable across mode switches. The first byte after the opcode is `content_kind`:
+- `0` — buffer window
+- `1` — agent chat window (background buffer fields populate the standard slots; agent-specific fields are appended at the end)
 
-**Buffer variant (content_kind == 0):**
+**Unified layout (both variants):**
 ```
-opcode(1) + content_kind=0(1) + mode(1) + cursor_line(4) + cursor_col(4) + line_count(4)
+opcode(1) + content_kind(1) + mode(1) + cursor_line(4) + cursor_col(4) + line_count(4)
 + flags(1) + lsp_status(1) + git_branch_len(1) + git_branch(git_branch_len)
 + message_len(2) + message(message_len) + filetype_len(1) + filetype(filetype_len)
 + error_count(2) + warning_count(2)
--- Extended fields (TUI modeline parity) --
+-- Extended fields --
 + info_count(2) + hint_count(2)
 + macro_recording(1) + parser_status(1) + agent_status(1)
 + git_added(2) + git_modified(2) + git_deleted(2)
@@ -175,14 +175,13 @@ opcode(1) + content_kind=0(1) + mode(1) + cursor_line(4) + cursor_col(4) + line_
 + diagnostic_hint_len(2) + diagnostic_hint(diagnostic_hint_len)
 ```
 
-**Agent variant (content_kind == 1):**
+**Agent trailing fields (content_kind == 1 only, appended after diagnostic_hint):**
 ```
-opcode(1) + content_kind=1(1) + mode(1)
-+ zeros(4) + zeros(4) + zeros(4)          <- shared header slots, all zero for agent
-+ zeros(1) + zeros(1) + zeros(1) + zeros(2) + zeros(1) + zeros(2) + zeros(2)
 + model_name_len(1) + model_name(model_name_len)
 + message_count(4) + session_status(1)
 ```
+
+When `content_kind == 1`, the standard slots (cursor_line, git_branch, diagnostics, etc.) are populated from the background buffer so the status bar can show them alongside agent-specific info.
 
 `cursor_line` and `cursor_col` are 1-indexed on the wire.
 

--- a/lib/minga/editor/status_bar/data.ex
+++ b/lib/minga/editor/status_bar/data.ex
@@ -60,7 +60,7 @@ defmodule Minga.Editor.StatusBar.Data do
           status_msg: String.t() | nil
         }
 
-  @typedoc "Data for a focused agent chat window."
+  @typedoc "Data for a focused agent chat window. Includes background buffer context so the status bar layout stays stable across mode switches."
   @type agent_data :: %{
           mode: Minga.Mode.mode(),
           mode_state: Minga.Mode.state() | nil,
@@ -69,7 +69,24 @@ defmodule Minga.Editor.StatusBar.Data do
           message_count: non_neg_integer(),
           macro_recording: {true, String.t()} | false,
           agent_status: AgentState.status(),
-          agent_theme_colors: Theme.Agent.t() | nil
+          agent_theme_colors: Theme.Agent.t() | nil,
+          # Background buffer context (same fields as buffer_data)
+          cursor_line: non_neg_integer(),
+          cursor_col: non_neg_integer(),
+          line_count: non_neg_integer(),
+          file_name: String.t(),
+          filetype: atom(),
+          dirty: boolean(),
+          git_branch: String.t() | nil,
+          git_diff_summary: git_diff_summary(),
+          diagnostic_counts:
+            {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil,
+          diagnostic_hint: String.t() | nil,
+          lsp_status: lsp_status(),
+          parser_status: parser_status(),
+          buf_index: pos_integer(),
+          buf_count: non_neg_integer(),
+          status_msg: String.t() | nil
         }
 
   @typedoc "Tagged union: buffer or agent variant."
@@ -172,6 +189,18 @@ defmodule Minga.Editor.StatusBar.Data do
 
     model_name = if panel.model_name != "", do: panel.model_name, else: "Agent"
 
+    # Pull background buffer context so the status bar stays stable
+    buf = state.buffers.active
+    {line, col} = if buf, do: BufferServer.cursor(buf), else: {0, 0}
+    line_count = if buf, do: BufferServer.line_count(buf), else: 1
+    file_name = if buf, do: buf_display_name(buf), else: "[no file]"
+    dirty = buf != nil and BufferServer.dirty?(buf)
+    filetype = if buf, do: buffer_filetype(buf), else: :text
+
+    {git_branch, git_diff_summary} = git_modeline_data(buf)
+    diagnostic_counts = diagnostic_modeline_data(buf)
+    diagnostic_hint = cursor_line_diagnostic_hint(buf, line)
+
     %{
       mode: state.vim.mode,
       mode_state: state.vim.mode_state,
@@ -180,7 +209,23 @@ defmodule Minga.Editor.StatusBar.Data do
       message_count: message_count,
       macro_recording: MacroRecorder.recording?(state.vim.macro_recorder),
       agent_status: agent.status,
-      agent_theme_colors: Theme.agent_theme(state.theme)
+      agent_theme_colors: Theme.agent_theme(state.theme),
+      # Background buffer context
+      cursor_line: line,
+      cursor_col: col,
+      line_count: line_count,
+      file_name: file_name,
+      filetype: filetype,
+      dirty: dirty,
+      git_branch: git_branch,
+      git_diff_summary: git_diff_summary,
+      diagnostic_counts: diagnostic_counts,
+      diagnostic_hint: diagnostic_hint,
+      lsp_status: state.lsp_status,
+      parser_status: state.parser_status,
+      buf_index: state.buffers.active_index + 1,
+      buf_count: length(state.buffers.list),
+      status_msg: state.status_msg
     }
   end
 
@@ -278,11 +323,10 @@ defmodule Minga.Editor.StatusBar.Data do
   @doc """
   Converts a `StatusBar.Data.t()` to the map shape expected by `Modeline.render/5`.
 
-  Both variants produce data shaped identically for the modeline renderer;
-  the agent variant maps its fields onto the buffer modeline slots.
+  Both variants carry the same buffer fields and produce identical modeline data.
   """
   @spec to_modeline_data(t()) :: Minga.Editor.Modeline.modeline_data()
-  def to_modeline_data({:buffer, d}) do
+  def to_modeline_data({_variant, d}) do
     %{
       mode: d.mode,
       mode_state: d.mode_state,
@@ -302,25 +346,6 @@ defmodule Minga.Editor.StatusBar.Data do
       git_branch: d.git_branch,
       git_diff_summary: d.git_diff_summary,
       diagnostic_counts: d.diagnostic_counts
-    }
-  end
-
-  def to_modeline_data({:agent, d}) do
-    %{
-      mode: d.mode,
-      mode_state: d.mode_state,
-      file_name: "󰚩 #{d.model_name}",
-      filetype: :text,
-      dirty_marker: "",
-      cursor_line: d.message_count,
-      cursor_col: 0,
-      line_count: max(d.message_count, 1),
-      buf_index: 1,
-      buf_count: 1,
-      macro_recording: d.macro_recording,
-      agent_status: d.agent_status,
-      agent_theme_colors: d.agent_theme_colors,
-      mode_override: nil
     }
   end
 end

--- a/lib/minga/port/protocol/gui.ex
+++ b/lib/minga/port/protocol/gui.ex
@@ -754,7 +754,7 @@ defmodule Minga.Port.Protocol.GUI do
   def encode_gui_status_bar({:buffer, d}) do
     mode_byte = encode_vim_mode(d.mode)
     lsp_byte = encode_lsp_status(d.lsp_status)
-    flags = build_buffer_status_flags(d)
+    flags = build_status_flags(d)
 
     git_branch = :erlang.iolist_to_binary([d.git_branch || ""])
     filetype = :erlang.iolist_to_binary([Atom.to_string(d.filetype || :text)])
@@ -791,15 +791,45 @@ defmodule Minga.Port.Protocol.GUI do
   end
 
   def encode_gui_status_bar({:agent, d}) do
+    # Same wire format as the buffer variant (background buffer context fills
+    # all the standard slots), plus agent-specific fields appended at the end.
     mode_byte = encode_vim_mode(d.mode)
+    lsp_byte = encode_lsp_status(d.lsp_status)
+    flags = build_status_flags(d)
+
+    git_branch = :erlang.iolist_to_binary([d.git_branch || ""])
+    filetype = :erlang.iolist_to_binary([Atom.to_string(d.filetype || :text)])
+
+    {error_count, warning_count, info_count, hint_count} =
+      full_diagnostic_counts(d)
+
+    macro_byte = encode_macro_recording(d.macro_recording)
+    parser_byte = encode_parser_status(d.parser_status)
+    agent_byte = encode_agent_session_status(d.agent_status)
+    {git_added, git_modified, git_deleted} = git_diff_counts(d)
+    {icon, icon_color} = Minga.Devicon.icon_and_color(d.filetype)
+    icon_bytes = :erlang.iolist_to_binary([icon])
+    icon_r = icon_color >>> 16 &&& 0xFF
+    icon_g = icon_color >>> 8 &&& 0xFF
+    icon_b = icon_color &&& 0xFF
+    filename = :erlang.iolist_to_binary([d.file_name || ""])
+
+    diag_hint = :erlang.iolist_to_binary([d.diagnostic_hint || ""])
+    message = :erlang.iolist_to_binary([d.status_msg || ""])
+
+    # Agent-specific trailing fields
     model_name = :erlang.iolist_to_binary([d.model_name || "Agent"])
     session_status_byte = encode_agent_session_status(d.session_status)
 
-    # Shared header fields are all zeros (not meaningful for agent windows).
-    # message_count and session_status are explicit fields — no slot reuse.
-    <<@op_gui_status_bar, 1::8, mode_byte::8, 0::32, 0::32, 0::32, 0::8, 0::8, 0::8, 0::16, 0::8,
-      0::16, 0::16, byte_size(model_name)::8, model_name::binary, d.message_count::32,
-      session_status_byte::8>>
+    # content_kind=1 signals agent mode; cursor_line/col are 0-indexed, +1 for GUI
+    <<@op_gui_status_bar, 1::8, mode_byte::8, d.cursor_line + 1::32, d.cursor_col + 1::32,
+      d.line_count::32, flags::8, lsp_byte::8, byte_size(git_branch)::8, git_branch::binary,
+      byte_size(message)::16, message::binary, byte_size(filetype)::8, filetype::binary,
+      error_count::16, warning_count::16, info_count::16, hint_count::16, macro_byte::8,
+      parser_byte::8, agent_byte::8, git_added::16, git_modified::16, git_deleted::16,
+      byte_size(icon_bytes)::8, icon_bytes::binary, icon_r::8, icon_g::8, icon_b::8,
+      byte_size(filename)::16, filename::binary, byte_size(diag_hint)::16, diag_hint::binary,
+      byte_size(model_name)::8, model_name::binary, d.message_count::32, session_status_byte::8>>
   end
 
   @spec encode_vim_mode(atom()) :: non_neg_integer()
@@ -849,8 +879,8 @@ defmodule Minga.Port.Protocol.GUI do
 
   defp git_diff_counts(_), do: {0, 0, 0}
 
-  @spec build_buffer_status_flags(map()) :: non_neg_integer()
-  defp build_buffer_status_flags(d) do
+  @spec build_status_flags(map()) :: non_neg_integer()
+  defp build_status_flags(d) do
     has_lsp = if d.lsp_status && d.lsp_status != :none, do: 1, else: 0
     has_git = if d.git_branch && d.git_branch != "", do: 1, else: 0
     is_dirty = if d.dirty, do: 1, else: 0

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -734,12 +734,20 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         return (.guiBreadcrumb(segments: segments), pos - offset)
 
     case OP_GUI_STATUS_BAR:
-        // Shared header (both variants):
+        // Unified wire format for both buffer (contentKind=0) and agent (contentKind=1).
+        // Both variants encode the full buffer field set. The agent variant appends
+        // model_name, message_count, and session_status at the end.
+        //
+        // Layout:
         //   content_kind:1 mode:1 cursor_line:4 cursor_col:4 line_count:4
-        //   flags:1 lsp:1 git_len:1 git(:git_len) msg_len:2 msg(:msg_len) ft_len:1 ft(:ft_len)
-        //   error_count:2 warning_count:2
-        // Agent-only fields (content_kind == 1), appended after the shared header:
-        //   model_name_len:1 model_name(:model_name_len) message_count:4 session_status:1
+        //   flags:1 lsp:1 git_len:1 git(:git_len) msg_len:2 msg(:msg_len)
+        //   ft_len:1 ft(:ft_len) error_count:2 warning_count:2
+        //   info_count:2 hint_count:2 macro_recording:1 parser_status:1 agent_status:1
+        //   git_added:2 git_modified:2 git_deleted:2
+        //   icon_len:1 icon(:icon_len) icon_r:1 icon_g:1 icon_b:1
+        //   filename_len:2 filename(:filename_len)
+        //   diag_hint_len:2 diag_hint(:diag_hint_len)
+        //   [agent only] model_name_len:1 model_name(:model_name_len) message_count:4 session_status:1
         guard data.count >= rest + 17 else { throw ProtocolDecodeError.malformed }
         let contentKind = data[rest]
         let mode = data[rest + 1]
@@ -762,82 +770,65 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         let warningCount: UInt16 = readU16(data, diagBase + 2)
         var totalConsumed = diagBase + 4
 
-        // Agent-only fields: explicit message_count and session_status after model_name.
+        // Extended fields (shared by both variants)
+        guard data.count >= totalConsumed + 13 else { throw ProtocolDecodeError.malformed }
+        let infoCount: UInt16 = readU16(data, totalConsumed)
+        let hintCount: UInt16 = readU16(data, totalConsumed + 2)
+        let macroRecording: UInt8 = data[totalConsumed + 4]
+        let parserStatus: UInt8 = data[totalConsumed + 5]
+        let agentStatus: UInt8 = data[totalConsumed + 6]
+        let gitAdded: UInt16 = readU16(data, totalConsumed + 7)
+        let gitModified: UInt16 = readU16(data, totalConsumed + 9)
+        let gitDeleted: UInt16 = readU16(data, totalConsumed + 11)
+        totalConsumed += 13
+
+        // icon: len:1 + data + color:3
+        guard data.count >= totalConsumed + 1 else { throw ProtocolDecodeError.malformed }
+        let iconLen = Int(data[totalConsumed])
+        totalConsumed += 1
+        guard data.count >= totalConsumed + iconLen + 3 else { throw ProtocolDecodeError.malformed }
+        let icon = String(data: data[totalConsumed..<(totalConsumed + iconLen)], encoding: .utf8) ?? ""
+        totalConsumed += iconLen
+        let iconColorR = data[totalConsumed]
+        let iconColorG = data[totalConsumed + 1]
+        let iconColorB = data[totalConsumed + 2]
+        totalConsumed += 3
+
+        // filename: len:2 + data
+        guard data.count >= totalConsumed + 2 else { throw ProtocolDecodeError.malformed }
+        let filenameLen = Int(readU16(data, totalConsumed))
+        totalConsumed += 2
+        guard data.count >= totalConsumed + filenameLen else { throw ProtocolDecodeError.malformed }
+        let filename = String(data: data[totalConsumed..<(totalConsumed + filenameLen)], encoding: .utf8) ?? ""
+        totalConsumed += filenameLen
+
+        // diagnostic_hint: len:2 + data
+        var diagnosticHint = ""
+        if data.count >= totalConsumed + 2 {
+            let diagHintLen = Int(readU16(data, totalConsumed))
+            totalConsumed += 2
+            if data.count >= totalConsumed + diagHintLen, diagHintLen > 0 {
+                diagnosticHint = String(data: data[totalConsumed..<(totalConsumed + diagHintLen)], encoding: .utf8) ?? ""
+                totalConsumed += diagHintLen
+            }
+        }
+
+        // Agent-only trailing fields (only present when contentKind == 1)
         var modelName = ""
         var messageCount: UInt32 = 0
         var sessionStatus: UInt8 = 0
 
-        // Extended buffer fields (TUI modeline parity)
-        var infoCount: UInt16 = 0
-        var hintCount: UInt16 = 0
-        var macroRecording: UInt8 = 0
-        var parserStatus: UInt8 = 0
-        var agentStatus: UInt8 = 0
-        var gitAdded: UInt16 = 0
-        var gitModified: UInt16 = 0
-        var gitDeleted: UInt16 = 0
-        var icon = ""
-        var iconColorR: UInt8 = 0
-        var iconColorG: UInt8 = 0
-        var iconColorB: UInt8 = 0
-        var filename = ""
-        var diagnosticHint = ""
-
-        if contentKind == 1 && data.count >= totalConsumed + 1 {
+        if contentKind == 1, data.count >= totalConsumed + 1 {
             let modelNameLen = Int(data[totalConsumed])
             totalConsumed += 1
-            // 4 bytes message_count + 1 byte session_status follow the model name
             guard data.count >= totalConsumed + modelNameLen + 5 else { throw ProtocolDecodeError.malformed }
             modelName = String(data: data[totalConsumed..<(totalConsumed + modelNameLen)], encoding: .utf8) ?? ""
             totalConsumed += modelNameLen
             messageCount = readU32(data, totalConsumed)
             sessionStatus = data[totalConsumed + 4]
             totalConsumed += 5
-        } else if contentKind == 0 {
-            // Extended buffer fields after warning_count:
-            // info_count:2 hint_count:2 macro_recording:1 parser_status:1 agent_status:1
-            // git_added:2 git_modified:2 git_deleted:2
-            // icon_len:1 icon:N icon_color_r:1 icon_color_g:1 icon_color_b:1
-            // filename_len:2 filename:N
-            // 2+2+1+1+1+2+2+2 = 13 bytes of fixed fields before icon
-            guard data.count >= totalConsumed + 13 else { throw ProtocolDecodeError.malformed }
-            infoCount = readU16(data, totalConsumed)
-            hintCount = readU16(data, totalConsumed + 2)
-            macroRecording = data[totalConsumed + 4]
-            parserStatus = data[totalConsumed + 5]
-            agentStatus = data[totalConsumed + 6]
-            gitAdded = readU16(data, totalConsumed + 7)
-            gitModified = readU16(data, totalConsumed + 9)
-            gitDeleted = readU16(data, totalConsumed + 11)
-            totalConsumed += 13
-            // icon: len:1 + data + color:3
-            guard data.count >= totalConsumed + 1 else { throw ProtocolDecodeError.malformed }
-            let iconLen = Int(data[totalConsumed])
-            totalConsumed += 1
-            guard data.count >= totalConsumed + iconLen + 3 else { throw ProtocolDecodeError.malformed }
-            icon = String(data: data[totalConsumed..<(totalConsumed + iconLen)], encoding: .utf8) ?? ""
-            totalConsumed += iconLen
-            iconColorR = data[totalConsumed]
-            iconColorG = data[totalConsumed + 1]
-            iconColorB = data[totalConsumed + 2]
-            totalConsumed += 3
-            // filename: len:2 + data
-            guard data.count >= totalConsumed + 2 else { throw ProtocolDecodeError.malformed }
-            let filenameLen = Int(readU16(data, totalConsumed))
-            totalConsumed += 2
-            guard data.count >= totalConsumed + filenameLen else { throw ProtocolDecodeError.malformed }
-            filename = String(data: data[totalConsumed..<(totalConsumed + filenameLen)], encoding: .utf8) ?? ""
-            totalConsumed += filenameLen
-            // diagnostic_hint_len:2 + diagnostic_hint:N (backward-compatible: may be absent)
-            if data.count >= totalConsumed + 2 {
-                let diagHintLen = Int(readU16(data, totalConsumed))
-                totalConsumed += 2
-                if data.count >= totalConsumed + diagHintLen, diagHintLen > 0 {
-                    diagnosticHint = String(data: data[totalConsumed..<(totalConsumed + diagHintLen)], encoding: .utf8) ?? ""
-                    totalConsumed += diagHintLen
-                }
-            }
         }
+
         return (.guiStatusBar(contentKind: contentKind, mode: mode, cursorLine: cursorLine, cursorCol: cursorCol, lineCount: lineCount, flags: flags, lspStatus: lspStatus, gitBranch: gitBranch, message: message, filetype: filetype, errorCount: errorCount, warningCount: warningCount, modelName: modelName, messageCount: messageCount, sessionStatus: sessionStatus, infoCount: infoCount, hintCount: hintCount, macroRecording: macroRecording, parserStatus: parserStatus, agentStatus: agentStatus, gitAdded: gitAdded, gitModified: gitModified, gitDeleted: gitDeleted, icon: icon, iconColorR: iconColorR, iconColorG: iconColorG, iconColorB: iconColorB, filename: filename, diagnosticHint: diagnosticHint), totalConsumed - offset)
 
     case OP_GUI_PICKER:

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -451,19 +451,6 @@ struct AgentChatView: View {
             }
 
             Spacer()
-
-            if !isInsertMode {
-                Text("NORMAL")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(theme.modeNormalFg)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(RoundedRectangle(cornerRadius: 3).fill(theme.modeNormalBg))
-            }
-
-            Text(state.model)
-                .font(.system(size: 10))
-                .foregroundStyle(theme.popupFg.opacity(0.3))
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)

--- a/macos/Sources/Views/StatusBarView.swift
+++ b/macos/Sources/Views/StatusBarView.swift
@@ -178,24 +178,16 @@ struct StatusBarView: View {
             // Center (lowest priority, truncates first)
             centerSegment
 
-            // Left-aligned
+            // Left-aligned (unified: same layout for buffer and agent)
             HStack(spacing: 0) {
-                if state.isAgentWindow {
-                    agentLeftSegment
-                } else {
-                    leftSegment
-                }
+                leftSegment
                 Spacer(minLength: 0)
             }
 
-            // Right-aligned
+            // Right-aligned (unified: same layout for buffer and agent)
             HStack(spacing: 0) {
                 Spacer(minLength: 0)
-                if state.isAgentWindow {
-                    agentRightSegment
-                } else {
-                    rightSegment
-                }
+                rightSegment
             }
         }
         .frame(height: barHeight)
@@ -208,9 +200,7 @@ struct StatusBarView: View {
 
     @ViewBuilder
     private var centerSegment: some View {
-        if state.isAgentWindow {
-            AgentStatusIndicator(sessionStatus: state.sessionStatus, theme: theme)
-        } else if state.isRecordingMacro, let reg = state.macroRegister {
+        if state.isRecordingMacro, let reg = state.macroRegister {
             HStack(spacing: 4) {
                 Circle()
                     .fill(Color.red)
@@ -232,33 +222,6 @@ struct StatusBarView: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
         }
-    }
-
-    // MARK: - Agent segments
-
-    @ViewBuilder
-    private var agentLeftSegment: some View {
-        HStack(spacing: 4) {
-            Image(systemName: "bubble.left.and.bubble.right")
-                .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(theme.modelineBarFg.opacity(0.6))
-            Text(state.modelName.isEmpty ? "Agent" : state.modelName)
-                .font(.system(size: 11))
-                .foregroundStyle(theme.modelineBarFg.opacity(0.8))
-                .lineLimit(1)
-        }
-        .padding(.leading, 6)
-    }
-
-    @ViewBuilder
-    private var agentRightSegment: some View {
-        HStack(spacing: 8) {
-            Text("\(state.messageCount) msgs")
-                .font(.system(size: 11))
-                .foregroundStyle(theme.modelineBarFg.opacity(0.6))
-            modeBadge
-        }
-        .padding(.trailing, 8)
     }
 
     // MARK: - Left segment
@@ -517,11 +480,17 @@ struct StatusBarView: View {
                 .help(state.filetype)
             }
 
-            // Cursor position
-            Text("Ln \(state.cursorLine), Col \(state.cursorCol)")
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundStyle(theme.modelineBarFg.opacity(0.7))
-                .help("Line \(state.cursorLine), Column \(state.cursorCol)")
+            // Cursor position / message count
+            if state.isAgentWindow {
+                Text("\(state.messageCount) msgs")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(theme.modelineBarFg.opacity(0.7))
+            } else {
+                Text("Ln \(state.cursorLine), Col \(state.cursorCol)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(theme.modelineBarFg.opacity(0.7))
+                    .help("Line \(state.cursorLine), Column \(state.cursorCol)")
+            }
 
             // Vim mode badge
             modeBadge
@@ -633,46 +602,4 @@ private struct StatusBarIconButton: View {
     }
 }
 
-// MARK: - Animated agent session status indicator
 
-/// Shows nothing for idle, a native spinner for active states, and a red
-/// icon for error. Static text for an active state reads as "maybe broken" —
-/// the spinner communicates liveness.
-private struct AgentStatusIndicator: View {
-    let sessionStatus: UInt8
-    let theme: ThemeColors
-
-    var body: some View {
-        switch sessionStatus {
-        case 1: // thinking
-            HStack(spacing: 5) {
-                ProgressView()
-                    .scaleEffect(0.55)
-                    .frame(width: 12, height: 12)
-                Text("thinking…")
-                    .font(.system(size: 11))
-                    .foregroundStyle(theme.modelineBarFg.opacity(0.65))
-            }
-        case 2: // tool executing
-            HStack(spacing: 5) {
-                ProgressView()
-                    .scaleEffect(0.55)
-                    .frame(width: 12, height: 12)
-                Text("executing…")
-                    .font(.system(size: 11))
-                    .foregroundStyle(theme.modelineBarFg.opacity(0.65))
-            }
-        case 3: // error
-            HStack(spacing: 4) {
-                Image(systemName: "exclamationmark.circle.fill")
-                    .font(.system(size: 10))
-                    .foregroundStyle(theme.gutterErrorFg)
-                Text("error")
-                    .font(.system(size: 11))
-                    .foregroundStyle(theme.gutterErrorFg)
-            }
-        default: // idle — show nothing; no need to announce inactivity
-            EmptyView()
-        }
-    }
-}

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -238,6 +238,33 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.statusBarState.errorCount == 3)
     }
 
+    @Test("guiStatusBar agent variant populates background buffer fields")
+    @MainActor func guiStatusBarAgentRouting() {
+        let (dispatcher, gui) = makeDispatcher()
+        dispatcher.dispatch(.guiStatusBar(contentKind: 1, mode: 0, cursorLine: 11,
+                                           cursorCol: 6, lineCount: 100, flags: 0x03,
+                                           lspStatus: 1, gitBranch: "feat/agent",
+                                           message: "", filetype: "elixir",
+                                           errorCount: 1, warningCount: 2,
+                                           modelName: "claude-3-5-sonnet", messageCount: 7, sessionStatus: 1,
+                                           infoCount: 0, hintCount: 1,
+                                           macroRecording: 0, parserStatus: 0, agentStatus: 1,
+                                           gitAdded: 3, gitModified: 2, gitDeleted: 0,
+                                           icon: "", iconColorR: 0, iconColorG: 0, iconColorB: 0,
+                                           filename: "editor.ex", diagnosticHint: ""))
+
+        #expect(gui.statusBarState.contentKind == 1)
+        #expect(gui.statusBarState.isAgentWindow == true)
+        #expect(gui.statusBarState.modelName == "claude-3-5-sonnet")
+        #expect(gui.statusBarState.messageCount == 7)
+        // Background buffer fields populated
+        #expect(gui.statusBarState.cursorLine == 11)
+        #expect(gui.statusBarState.gitBranch == "feat/agent")
+        #expect(gui.statusBarState.filetype == "elixir")
+        #expect(gui.statusBarState.errorCount == 1)
+        #expect(gui.statusBarState.gitAdded == 3)
+    }
+
     @Test("guiBreadcrumb updates breadcrumbState")
     @MainActor func guiBreadcrumbRouting() {
         let (dispatcher, gui) = makeDispatcher()

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -386,23 +386,36 @@ struct GUIStatusBarDecoderTests {
         #expect(filename == "editor.ex")
     }
 
-    @Test("Decode gui_status_bar agent variant with model and session status")
+    @Test("Decode gui_status_bar agent variant with background buffer context")
     func decodeAgentVariant() throws {
         var data = Data()
         data.append(OP_GUI_STATUS_BAR)
         data.append(1) // contentKind = agent
         data.append(0) // mode = normal
-        appendU32(&data, 0) // cursorLine
-        appendU32(&data, 0) // cursorCol
-        appendU32(&data, 0) // lineCount
-        data.append(0) // flags
-        data.append(0) // lspStatus
-        appendString8(&data, "") // gitBranch (empty)
-        appendString16(&data, "") // message (empty)
-        appendString8(&data, "") // filetype (empty)
-        appendU16(&data, 0) // errorCount
-        appendU16(&data, 0) // warningCount
-        // Agent-only fields
+        appendU32(&data, 11) // cursorLine (1-indexed)
+        appendU32(&data, 6)  // cursorCol (1-indexed)
+        appendU32(&data, 100) // lineCount
+        data.append(0x03) // flags (hasLsp=1, hasGit=1)
+        data.append(1) // lspStatus = ready
+        appendString8(&data, "feat/agent") // gitBranch
+        appendString16(&data, "") // message
+        appendString8(&data, "elixir") // filetype
+        appendU16(&data, 1) // errorCount
+        appendU16(&data, 2) // warningCount
+        // Extended fields (same as buffer variant)
+        appendU16(&data, 0) // infoCount
+        appendU16(&data, 1) // hintCount
+        data.append(0) // macroRecording
+        data.append(0) // parserStatus
+        data.append(1) // agentStatus = thinking
+        appendU16(&data, 3) // gitAdded
+        appendU16(&data, 2) // gitModified
+        appendU16(&data, 0) // gitDeleted
+        appendString8(&data, "") // icon
+        data.append(0); data.append(0); data.append(0) // icon color
+        appendString16(&data, "editor.ex") // filename
+        appendString16(&data, "") // diagnosticHint
+        // Agent-only trailing fields
         appendString8(&data, "claude-3-5-sonnet") // modelName
         appendU32(&data, 12) // messageCount
         data.append(1) // sessionStatus = thinking
@@ -410,7 +423,7 @@ struct GUIStatusBarDecoderTests {
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiStatusBar(let contentKind, _, _, _, _, _, _, _, _, _, _, _, let modelName, let messageCount, let sessionStatus, _, _, _, _, _, _, _, _, _, _, _, _, _, _) = cmd else {
+        guard case .guiStatusBar(let contentKind, _, let cursorLine, _, let lineCount, _, _, let gitBranch, _, let filetype, let errorCount, _, let modelName, let messageCount, let sessionStatus, _, let hintCount, _, _, let agentStatus, let gitAdded, let gitModified, _, _, _, _, _, let filename, _) = cmd else {
             Issue.record("Expected .guiStatusBar"); return
         }
 
@@ -418,6 +431,17 @@ struct GUIStatusBarDecoderTests {
         #expect(modelName == "claude-3-5-sonnet")
         #expect(messageCount == 12)
         #expect(sessionStatus == 1) // thinking
+        // Background buffer fields populated
+        #expect(cursorLine == 11)
+        #expect(lineCount == 100)
+        #expect(gitBranch == "feat/agent")
+        #expect(filetype == "elixir")
+        #expect(errorCount == 1)
+        #expect(hintCount == 1)
+        #expect(agentStatus == 1)
+        #expect(gitAdded == 3)
+        #expect(gitModified == 2)
+        #expect(filename == "editor.ex")
     }
 }
 

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -181,7 +181,7 @@ struct StatusBarViewViewTests {
         #expect(strings.contains("elixir"))
     }
 
-    @Test("Agent mode shows model name and mode badge")
+    @Test("Agent mode shows message count and mode badge (model name is in agent chat header, not status bar)")
     @MainActor func agentMode() throws {
         let state = StatusBarState()
         state.update(from: StatusBarUpdate(
@@ -199,8 +199,10 @@ struct StatusBarViewViewTests {
         let texts = body.findAll(ViewInspectorQuery.text)
         let strings = texts.compactMap { try? $0.string() }
 
-        #expect(strings.contains("claude-3-5-sonnet"))
+        // Model name no longer appears in the status bar (lives in agent chat header only)
+        #expect(!strings.contains("claude-3-5-sonnet"))
         #expect(strings.contains("7 msgs"))
+        #expect(strings.contains("NORMAL"))
     }
 
     @Test("Git branch shown when flag is set")
@@ -292,9 +294,10 @@ struct AgentChatViewTests {
         // Header shows model name and status
         #expect(strings.contains("claude-sonnet-4"))
         #expect(strings.contains("idle"))
-        // Prompt shows normal-mode placeholder
+        // Prompt is a pure input affordance: placeholder text only, no mode badge or model name
         #expect(strings.contains("Press i to type"))
-        #expect(strings.contains("NORMAL"))
+        // NORMAL badge moved to unified status bar, no longer in prompt area
+        #expect(!strings.contains("NORMAL"))
     }
 
     @Test("User message renders as bubble")

--- a/test/minga/integration/agent_cursor_test.exs
+++ b/test/minga/integration/agent_cursor_test.exs
@@ -171,15 +171,15 @@ defmodule Minga.Integration.AgentCursorTest do
   end
 
   describe "agent modeline" do
-    test "modeline shows vim mode and model name in agent view" do
+    test "modeline shows vim mode and background buffer name in agent view" do
       ctx = start_agent_editor()
 
       rows = screen_text(ctx)
 
-      # The modeline is the last row containing the model name (the sidebar
-      # also shows it, so we need the bottom-most occurrence).
-      modeline_idx = find_last_row_containing(rows, "claude-sonnet-4")
-      assert modeline_idx != nil, "Should find model name in the modeline"
+      # The modeline shows the background buffer name (not the model name,
+      # which now lives only in the agent chat header).
+      modeline_idx = find_last_row_containing(rows, "NORMAL")
+      assert modeline_idx != nil, "Should find modeline with NORMAL mode"
 
       modeline_text = Enum.at(rows, modeline_idx)
 
@@ -194,8 +194,8 @@ defmodule Minga.Integration.AgentCursorTest do
 
       rows = screen_text(ctx)
 
-      modeline_idx = find_last_row_containing(rows, "claude-sonnet-4")
-      assert modeline_idx != nil, "Should find modeline with model name"
+      modeline_idx = find_last_row_containing(rows, "INSERT")
+      assert modeline_idx != nil, "Should find modeline with INSERT mode"
 
       modeline_text = Enum.at(rows, modeline_idx)
 
@@ -209,7 +209,8 @@ defmodule Minga.Integration.AgentCursorTest do
       rows = screen_text(ctx)
 
       prompt_row = find_row_containing(rows, "Prompt")
-      modeline_row = find_last_row_containing(rows, "claude-sonnet-4")
+      # Find modeline by looking for the vim mode badge (always present)
+      modeline_row = find_last_row_containing(rows, "NORMAL")
 
       assert prompt_row != nil, "Should find the prompt border"
       assert modeline_row != nil, "Should find the modeline"

--- a/test/minga/integration/gui_protocol_test.exs
+++ b/test/minga/integration/gui_protocol_test.exs
@@ -7,6 +7,7 @@ defmodule Minga.Integration.GUIProtocolTest do
   checking its JSON output.
   """
 
+  # async: false: spawns the headless Swift test harness as a real OS process via Port.open/2
   use ExUnit.Case, async: false
 
   alias Minga.Port.Protocol.GUI, as: ProtocolGUI
@@ -168,7 +169,23 @@ defmodule Minga.Integration.GUIProtocolTest do
            message_count: 7,
            macro_recording: false,
            agent_status: :thinking,
-           agent_theme_colors: nil
+           agent_theme_colors: nil,
+           # Background buffer context
+           cursor_line: 10,
+           cursor_col: 5,
+           line_count: 100,
+           file_name: "editor.ex",
+           filetype: :elixir,
+           dirty: true,
+           git_branch: "feat/agent",
+           git_diff_summary: {3, 2, 0},
+           diagnostic_counts: {1, 2, 0, 1},
+           diagnostic_hint: "⚠ unused variable [ElixirLS]",
+           lsp_status: :ready,
+           parser_status: :available,
+           buf_index: 2,
+           buf_count: 4,
+           status_msg: nil
          }}
 
       cmd = ProtocolGUI.encode_gui_status_bar(data)
@@ -182,6 +199,20 @@ defmodule Minga.Integration.GUIProtocolTest do
       assert decoded["mode"] == 0
       assert decoded["model_name"] == "claude-3-5-sonnet"
       assert decoded["message_count"] == 7
+      # Background buffer fields are now populated
+      assert decoded["cursor_line"] == 11
+      assert decoded["cursor_col"] == 6
+      assert decoded["line_count"] == 100
+      assert decoded["git_branch"] == "feat/agent"
+      assert decoded["filetype"] == "elixir"
+      assert decoded["error_count"] == 1
+      assert decoded["warning_count"] == 2
+      assert decoded["hint_count"] == 1
+      assert decoded["git_added"] == 3
+      assert decoded["git_modified"] == 2
+      assert decoded["git_deleted"] == 0
+      assert decoded["filename"] == "editor.ex"
+      assert decoded["diagnostic_hint"] == "⚠ unused variable [ElixirLS]"
     end
 
     test "gui_agent_chat hidden encodes and decodes correctly", %{port: port} do


### PR DESCRIPTION
## What

Closes #1061.

The status bar now uses a single layout for both buffer editing and agent chat. Previously, switching to agent mode replaced the entire status bar with a minimal layout (model name + message count), losing toggle icons, git branch, diagnostics, and LSP status.

## Changes

### BEAM (Elixir)

- **`build_agent_data`** enriched with background buffer context: git branch, diff stats, diagnostics, LSP status, parser status, filetype, cursor position, and filename are all pulled from the active buffer
- **`encode_gui_status_bar`** agent variant now encodes the same wire format as the buffer variant, with agent-specific fields (model_name, message_count, session_status) appended at the end
- **`to_modeline_data`** consolidated: both variants produce identical modeline maps since agent data now carries all buffer fields
- **`build_status_flags`** deduplicated from two identical functions into one

### Swift (macOS)

- **StatusBarView**: deleted `agentLeftSegment`, `agentRightSegment`, and `AgentStatusIndicator`. Both modes use the unified `leftSegment`/`rightSegment` layout.
- **AgentChatView**: removed NORMAL mode badge and model name from the prompt bar. The prompt is now a pure input affordance (chevron + text/placeholder).
- **ProtocolDecoder**: restructured to parse extended fields (git stats, icon, filename, diagnostic hint) unconditionally for both variants, then read agent trailing fields when `contentKind == 1`.
- Cursor position slot shows "N msgs" when agent window is focused.

### Protocol

- Updated `docs/GUI_PROTOCOL.md` wire format spec: the agent variant now uses the unified layout with trailing agent fields instead of a completely separate format.

## Testing

- **Elixir**: 6,449 tests, 0 failures (`mix test.llm`)
- **Swift**: 435 tests, 0 failures (`xcodebuild test`)
- **Lint**: `mix lint` passes clean
- Updated protocol round-trip test: agent variant now asserts background buffer fields (git_branch, diagnostics, filetype, etc.)
- Updated Swift decoder test, command dispatcher test, view structure tests
- Updated TUI integration tests (agent modeline assertions)