### PR TITLE
feat(agent): stable BEAM-assigned message IDs for agent chat

### DIFF
--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -51,6 +51,8 @@ defmodule Minga.Agent.Session do
           provider_opts: keyword(),
           status: status(),
           messages: [Message.t()],
+          message_ids: [pos_integer()],
+          next_message_id: pos_integer(),
           subscribers: MapSet.t(pid()),
           total_usage: Event.token_usage(),
           error_message: String.t() | nil,
@@ -106,6 +108,12 @@ defmodule Minga.Agent.Session do
   @spec messages(GenServer.server()) :: [Message.t()]
   def messages(session) do
     GenServer.call(session, :messages)
+  end
+
+  @doc "Returns the conversation messages paired with their stable BEAM-assigned IDs."
+  @spec messages_with_ids(GenServer.server()) :: [{pos_integer(), Message.t()}]
+  def messages_with_ids(session) do
+    GenServer.call(session, :messages_with_ids)
   end
 
   @doc "Returns accumulated token usage."
@@ -410,6 +418,8 @@ defmodule Minga.Agent.Session do
       provider_opts: provider_opts,
       status: :idle,
       messages: [Message.system("Session started · #{timestamp}")],
+      message_ids: [1],
+      next_message_id: 2,
       subscribers: MapSet.new(),
       total_usage: %{input: 0, output: 0, cache_read: 0, cache_write: 0, cost: 0.0},
       error_message: nil,
@@ -449,7 +459,7 @@ defmodule Minga.Agent.Session do
     # Content may be a plain string or a list of ContentPart structs
     # (when images are attached via @image.png mentions).
     {user_msg, send_content} = build_user_message(content)
-    state = %{state | messages: state.messages ++ [user_msg]}
+    state = append_msg(state, user_msg)
     state = notify_messages_changed(state)
 
     case state.provider_module.send_prompt(state.provider, send_content) do
@@ -476,7 +486,7 @@ defmodule Minga.Agent.Session do
   def handle_call({:send_follow_up, content}, _from, state) do
     # Agent is idle: treat follow-up as a regular prompt.
     {user_msg, send_content} = build_user_message(content)
-    state = %{state | messages: state.messages ++ [user_msg]}
+    state = append_msg(state, user_msg)
     state = notify_messages_changed(state)
 
     case state.provider_module.send_prompt(state.provider, send_content) do
@@ -492,13 +502,14 @@ defmodule Minga.Agent.Session do
       {:reply, [], state}
     else
       # Add each steering message to conversation history so it appears in chat.
-      messages =
-        Enum.reduce(steering, state.messages, fn content, msgs ->
+      new_msgs =
+        Enum.map(steering, fn content ->
           {user_msg, _} = build_user_message(content)
-          msgs ++ [user_msg]
+          user_msg
         end)
 
-      state = %{state | steering_queue: [], messages: messages}
+      state = %{state | steering_queue: []}
+      state = append_msgs(state, new_msgs)
       state = notify_messages_changed(state)
       {:reply, steering, state}
     end
@@ -558,7 +569,6 @@ defmodule Minga.Agent.Session do
     state = %{
       state
       | session_id: generate_session_id(),
-        messages: [Message.system("Session cleared · #{timestamp}")],
         status: :idle,
         total_usage: %{input: 0, output: 0, cache_read: 0, cache_write: 0, cost: 0.0},
         error_message: nil,
@@ -566,6 +576,8 @@ defmodule Minga.Agent.Session do
         steering_queue: [],
         follow_up_queue: []
     }
+
+    state = reset_messages(state, [Message.system("Session cleared · #{timestamp}")])
 
     broadcast(state, {:status_changed, :idle})
     state = notify_messages_changed(state)
@@ -584,7 +596,6 @@ defmodule Minga.Agent.Session do
         state = %{
           state
           | session_id: data.id,
-            messages: data.messages,
             total_usage: data.usage,
             model_name: data.model_name,
             status: :idle,
@@ -593,6 +604,8 @@ defmodule Minga.Agent.Session do
             steering_queue: [],
             follow_up_queue: []
         }
+
+        state = reset_messages(state, data.messages)
 
         broadcast(state, {:status_changed, :idle})
         state = notify_messages_changed(state)
@@ -609,6 +622,11 @@ defmodule Minga.Agent.Session do
 
   def handle_call(:messages, _from, state) do
     {:reply, state.messages, state}
+  end
+
+  def handle_call(:messages_with_ids, _from, state) do
+    paired = Enum.zip(state.message_ids, state.messages)
+    {:reply, paired, state}
   end
 
   def handle_call(:usage, _from, state) do
@@ -828,7 +846,8 @@ defmodule Minga.Agent.Session do
 
     case Branch.branch_at(state.messages, turn_index, branch_name, state.branches) do
       {:ok, truncated, branches} ->
-        state = %{state | messages: truncated, branches: branches}
+        truncated_ids = Enum.take(state.message_ids, length(truncated))
+        state = %{state | messages: truncated, message_ids: truncated_ids, branches: branches}
         state = notify_messages_changed(state)
 
         {:reply, {:ok, "Branched at turn #{turn_index}. Branch saved as '#{branch_name}'."},
@@ -851,7 +870,7 @@ defmodule Minga.Agent.Session do
         {:reply, {:error, "Branch #{branch_index} not found. Use /branches to list."}, state}
 
       branch ->
-        state = %{state | messages: branch.messages}
+        state = reset_messages(state, branch.messages)
         state = notify_messages_changed(state)
         {:reply, :ok, state}
     end
@@ -937,10 +956,10 @@ defmodule Minga.Agent.Session do
               cache_read: state.total_usage.cache_read + usage.cache_read,
               cache_write: state.total_usage.cache_write + usage.cache_write,
               cost: state.total_usage.cost + usage.cost
-            },
-            messages: state.messages ++ [Message.usage(usage)]
+            }
         }
 
+        state = append_msg(state, Message.usage(usage))
         notify_messages_changed(state)
       else
         state
@@ -962,8 +981,8 @@ defmodule Minga.Agent.Session do
         combined = combine_queue_entries_to_text(pending)
         {user_msg, send_content} = build_user_message(combined)
 
-        messages = state.messages ++ [user_msg]
-        state = %{state | messages: messages, steering_queue: [], follow_up_queue: []}
+        state = %{state | steering_queue: [], follow_up_queue: []}
+        state = append_msg(state, user_msg)
         state = notify_messages_changed(state)
 
         case state.provider_module.send_prompt(state.provider, send_content) do
@@ -980,22 +999,37 @@ defmodule Minga.Agent.Session do
   defp handle_provider_event(%Event.TextDelta{delta: delta}, state) do
     # Auto-collapse any expanded thinking blocks (thinking is done)
     messages = collapse_thinking_blocks(state.messages)
-    messages = append_to_last_assistant(messages, delta)
-    state = %{state | messages: messages}
+
+    state =
+      case append_to_last_assistant(messages, delta) do
+        {:updated, updated_messages} ->
+          %{state | messages: updated_messages}
+
+        {:appended, new_msg} ->
+          %{state | messages: messages} |> append_msg(new_msg)
+      end
+
     broadcast(state, {:text_delta, delta})
     state
   end
 
   defp handle_provider_event(%Event.ThinkingDelta{delta: delta}, state) do
-    messages = append_to_last_thinking(state.messages, delta)
-    state = %{state | messages: messages}
+    state =
+      case append_to_last_thinking(state.messages, delta) do
+        {:updated, updated_messages} ->
+          %{state | messages: updated_messages}
+
+        {:appended, new_msg} ->
+          append_msg(state, new_msg)
+      end
+
     broadcast(state, {:thinking_delta, delta})
     state
   end
 
   defp handle_provider_event(%Event.ToolStart{} = event, state) do
     msg = Message.tool_call(event.tool_call_id, event.name, event.args)
-    state = %{state | messages: Enum.reverse([msg | Enum.reverse(state.messages)])}
+    state = append_msg(state, msg)
     state = set_status(state, :tool_executing)
     broadcast(state, {:tool_started, event.name, event.args})
     notify_messages_changed(state)
@@ -1080,20 +1114,65 @@ defmodule Minga.Agent.Session do
 
   # ── Message list helpers ────────────────────────────────────────────────────
 
+  # Appends a message and assigns it a new stable ID.
+  @spec append_msg(state(), Message.t()) :: state()
+  defp append_msg(state, msg) do
+    id = state.next_message_id
+
+    %{
+      state
+      | messages: state.messages ++ [msg],
+        message_ids: state.message_ids ++ [id],
+        next_message_id: id + 1
+    }
+  end
+
+  # Appends multiple messages, assigning each a new stable ID.
+  @spec append_msgs(state(), [Message.t()]) :: state()
+  defp append_msgs(state, []), do: state
+
+  defp append_msgs(state, msgs) do
+    count = length(msgs)
+    base_id = state.next_message_id
+    new_ids = Enum.to_list(base_id..(base_id + count - 1))
+
+    %{
+      state
+      | messages: state.messages ++ msgs,
+        message_ids: state.message_ids ++ new_ids,
+        next_message_id: base_id + count
+    }
+  end
+
+  # Replaces all messages and resets IDs (used by new_session, load_session, switch_branch).
+  @spec reset_messages(state(), [Message.t()]) :: state()
+  defp reset_messages(state, msgs) do
+    count = length(msgs)
+    ids = Enum.to_list(1..max(count, 1))
+
+    %{
+      state
+      | messages: msgs,
+        message_ids: Enum.take(ids, count),
+        next_message_id: count + 1
+    }
+  end
+
   @spec append_system_message(state(), String.t(), Message.system_level()) :: state()
   defp append_system_message(state, text, level) do
     msg = Message.system(text, level)
-    %{state | messages: state.messages ++ [msg]}
+    append_msg(state, msg)
   end
 
-  @spec append_to_last_assistant([Message.t()], String.t()) :: [Message.t()]
+  @spec append_to_last_assistant([Message.t()], String.t()) ::
+          {:updated, [Message.t()]} | {:appended, Message.t()}
   defp append_to_last_assistant(messages, delta) do
     case List.last(messages) do
       {:assistant, text} ->
-        List.replace_at(messages, length(messages) - 1, {:assistant, text <> delta})
+        {:updated, List.replace_at(messages, length(messages) - 1, {:assistant, text <> delta})}
 
       _ ->
-        messages ++ [Message.assistant(delta)]
+        {:appended, Message.assistant(delta)}
     end
   end
 
@@ -1105,14 +1184,16 @@ defmodule Minga.Agent.Session do
     end)
   end
 
-  @spec append_to_last_thinking([Message.t()], String.t()) :: [Message.t()]
+  @spec append_to_last_thinking([Message.t()], String.t()) ::
+          {:updated, [Message.t()]} | {:appended, Message.t()}
   defp append_to_last_thinking(messages, delta) do
     case List.last(messages) do
       {:thinking, text, _collapsed} ->
-        List.replace_at(messages, length(messages) - 1, {:thinking, text <> delta, false})
+        {:updated,
+         List.replace_at(messages, length(messages) - 1, {:thinking, text <> delta, false})}
 
       _ ->
-        messages ++ [Message.thinking(delta)]
+        {:appended, Message.thinking(delta)}
     end
   end
 
@@ -1210,9 +1291,9 @@ defmodule Minga.Agent.Session do
           "Get your Anthropic key at: https://console.anthropic.com/settings/keys\n\n" <>
           "Run `/auth` with no arguments to see status for all providers."
 
-      messages = state.messages ++ [Message.system(msg)]
+      state = append_msg(state, Message.system(msg))
       broadcast(state, {:system_message, msg, :info})
-      %{state | messages: messages}
+      state
     else
       state
     end

--- a/lib/minga/editor/render_pipeline/emit/gui.ex
+++ b/lib/minga/editor/render_pipeline/emit/gui.ex
@@ -582,9 +582,9 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
     session = state.agent.session
 
     if is_agent_chat && session do
-      messages =
+      messages_with_ids =
         try do
-          AgentSession.messages(session)
+          AgentSession.messages_with_ids(session)
         catch
           :exit, _ -> []
         end
@@ -592,7 +592,7 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
       # Use cached styled runs for assistant messages when available.
       # This avoids recomputing tree-sitter/markdown styling per frame.
       styled_cache = state.agent_ui.panel.cached_styled_messages
-      gui_messages = build_gui_messages(messages, styled_cache)
+      gui_messages = build_gui_messages(messages_with_ids, styled_cache)
 
       %{
         visible: true,
@@ -607,33 +607,34 @@ defmodule Minga.Editor.RenderPipeline.Emit.GUI do
     end
   end
 
-  # Builds the message list for GUI encoding. Replaces assistant messages
-  # with {:styled_assistant, styled_lines} when cached styled runs are
-  # available. Other message types pass through unchanged.
+  # Builds the message list for GUI encoding. Each entry is `{id, gui_message}`
+  # where `id` is the stable BEAM-assigned message ID. Replaces assistant messages
+  # with {:styled_assistant, styled_lines} when cached styled runs are available.
   #
+  # Input: list of `{id, Message.t()}` pairs from `messages_with_ids/1`.
   # Uses Enum.zip (O(n)) instead of Enum.at in a loop (O(n²)) since this
   # runs every render frame at 60fps.
-  @spec build_gui_messages([term()], [term()] | nil) :: [term()]
-  defp build_gui_messages(messages, nil), do: messages
+  @spec build_gui_messages([{pos_integer(), term()}], [term()] | nil) :: [{pos_integer(), term()}]
+  defp build_gui_messages(messages_with_ids, nil), do: messages_with_ids
 
-  defp build_gui_messages(messages, styled_cache) when is_list(styled_cache) do
+  defp build_gui_messages(messages_with_ids, styled_cache) when is_list(styled_cache) do
     # Pad the cache to match message length if needed (messages may have grown)
-    padded = pad_cache(styled_cache, length(messages))
+    padded = pad_cache(styled_cache, length(messages_with_ids))
 
-    Enum.zip(messages, padded)
+    Enum.zip(messages_with_ids, padded)
     |> Enum.map(&maybe_style_message/1)
   end
 
-  @spec maybe_style_message({term(), term()}) :: term()
-  defp maybe_style_message({{:assistant, _text} = msg, nil}), do: msg
+  @spec maybe_style_message({{pos_integer(), term()}, term()}) :: {pos_integer(), term()}
+  defp maybe_style_message({{id, {:assistant, _text} = msg}, nil}), do: {id, msg}
 
-  defp maybe_style_message({{:assistant, _text}, styled_lines}),
-    do: {:styled_assistant, styled_lines}
+  defp maybe_style_message({{id, {:assistant, _text}}, styled_lines}),
+    do: {id, {:styled_assistant, styled_lines}}
 
-  defp maybe_style_message({{:tool_call, tc}, styled_lines}) when is_list(styled_lines),
-    do: {:styled_tool_call, tc, styled_lines}
+  defp maybe_style_message({{id, {:tool_call, tc}}, styled_lines}) when is_list(styled_lines),
+    do: {id, {:styled_tool_call, tc, styled_lines}}
 
-  defp maybe_style_message({msg, _cache_entry}), do: msg
+  defp maybe_style_message({{id, msg}, _cache_entry}), do: {id, msg}
 
   @spec pad_cache([term()], non_neg_integer()) :: [term()]
   defp pad_cache(cache, target_len) when length(cache) >= target_len, do: cache

--- a/lib/minga/port/protocol/gui.ex
+++ b/lib/minga/port/protocol/gui.ex
@@ -61,12 +61,7 @@ defmodule Minga.Port.Protocol.GUI do
   | 0x14       | tool_dismiss         |
   | 0x15       | agent_tool_toggle    |
   | 0x16       | execute_command      |
-  <<<<<<< HEAD
   | 0x17       | minibuffer_select    |
-
-
-  =======
-  >>>>>>> 8fcc39d8 (fix(editor): suppress tool prompts in headless editors + add protocol tests)
   | 0x18       | git_stage_file       |
   | 0x19       | git_unstage_file     |
   | 0x1A       | git_discard_file     |
@@ -1045,7 +1040,13 @@ defmodule Minga.Port.Protocol.GUI do
 
   # ── Agent chat ──
 
-  @doc "Encodes a gui_agent_chat command with conversation messages."
+  @doc """
+  Encodes a gui_agent_chat command with conversation messages.
+
+  Messages are `{id, message}` tuples where `id` is a stable BEAM-assigned
+  uint32. Each encoded message is prefixed with its ID so the GUI frontend
+  can use it as a persistent SwiftUI identity across updates.
+  """
   @spec encode_gui_agent_chat(map()) :: binary()
   def encode_gui_agent_chat(%{visible: false}) do
     <<@op_gui_agent_chat, 0::8>>
@@ -1132,25 +1133,36 @@ defmodule Minga.Port.Protocol.GUI do
                result: String.t() | nil
              }, [[styled_run()]]}
 
-  @spec encode_chat_message(gui_chat_message()) :: binary()
-  defp encode_chat_message({:user, text}) do
+  # Unwrap {id, message} tuple: prefix with the stable uint32 ID, then encode the message.
+  @spec encode_chat_message({pos_integer(), gui_chat_message()} | gui_chat_message()) :: binary()
+  defp encode_chat_message({id, msg}) when is_integer(id) do
+    <<id::32, encode_chat_message_body(msg)::binary>>
+  end
+
+  # Bare messages (no ID wrapper) for backward compat in tests. ID defaults to 0.
+  defp encode_chat_message(msg) when is_tuple(msg) do
+    <<0::32, encode_chat_message_body(msg)::binary>>
+  end
+
+  @spec encode_chat_message_body(gui_chat_message()) :: binary()
+  defp encode_chat_message_body({:user, text}) do
     text_bytes = :erlang.iolist_to_binary([text])
     <<0x01::8, byte_size(text_bytes)::32, text_bytes::binary>>
   end
 
-  defp encode_chat_message({:user, text, _attachments}) do
+  defp encode_chat_message_body({:user, text, _attachments}) do
     text_bytes = :erlang.iolist_to_binary([text])
     <<0x01::8, byte_size(text_bytes)::32, text_bytes::binary>>
   end
 
-  defp encode_chat_message({:assistant, text}) do
+  defp encode_chat_message_body({:assistant, text}) do
     text_bytes = :erlang.iolist_to_binary([text])
     <<0x02::8, byte_size(text_bytes)::32, text_bytes::binary>>
   end
 
   # Styled assistant message: opcode 0x07, line_count::16, then per line:
   # run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8
-  defp encode_chat_message({:styled_assistant, styled_lines}) do
+  defp encode_chat_message_body({:styled_assistant, styled_lines}) do
     line_binaries =
       Enum.map(styled_lines, fn runs ->
         run_binaries =
@@ -1166,13 +1178,13 @@ defmodule Minga.Port.Protocol.GUI do
     IO.iodata_to_binary([<<0x07::8, length(styled_lines)::16>> | line_binaries])
   end
 
-  defp encode_chat_message({:thinking, text, collapsed}) do
+  defp encode_chat_message_body({:thinking, text, collapsed}) do
     collapsed_byte = if collapsed, do: 1, else: 0
     text_bytes = :erlang.iolist_to_binary([text])
     <<0x03::8, collapsed_byte::8, byte_size(text_bytes)::32, text_bytes::binary>>
   end
 
-  defp encode_chat_message({:tool_call, tc}) do
+  defp encode_chat_message_body({:tool_call, tc}) do
     name_bytes = :erlang.iolist_to_binary([tc.name])
     result_bytes = :erlang.iolist_to_binary([tc.result || ""])
 
@@ -1197,7 +1209,7 @@ defmodule Minga.Port.Protocol.GUI do
   #   0x08, status::8, error::8, collapsed::8, duration::32,
   #   name_len::16, name, line_count::16, then per line:
   #   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8
-  defp encode_chat_message({:styled_tool_call, tc, styled_lines}) do
+  defp encode_chat_message_body({:styled_tool_call, tc, styled_lines}) do
     name_bytes = :erlang.iolist_to_binary([tc.name])
 
     status_byte =
@@ -1229,13 +1241,13 @@ defmodule Minga.Port.Protocol.GUI do
     ])
   end
 
-  defp encode_chat_message({:system, text, level}) do
+  defp encode_chat_message_body({:system, text, level}) do
     level_byte = if level == :error, do: 1, else: 0
     text_bytes = :erlang.iolist_to_binary([text])
     <<0x05::8, level_byte::8, byte_size(text_bytes)::32, text_bytes::binary>>
   end
 
-  defp encode_chat_message({:usage, u}) do
+  defp encode_chat_message_body({:usage, u}) do
     cost_int = round((u.cost || 0.0) * 1_000_000)
     <<0x06::8, u.input::32, u.output::32, u.cache_read::32, u.cache_write::32, cost_int::32>>
   end

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -263,8 +263,15 @@ struct StyledTextRun: Sendable {
     let underline: Bool
 }
 
-/// A chat message from gui_agent_chat.
-enum GUIChatMessage: Sendable {
+/// A chat message from gui_agent_chat, with a stable BEAM-assigned ID.
+struct GUIChatMessage: Sendable {
+    /// Stable uint32 ID assigned by the BEAM. Persists across streaming updates.
+    let beamId: UInt32
+    let content: GUIChatMessageContent
+}
+
+/// The payload of a chat message (type-specific data).
+enum GUIChatMessageContent: Sendable {
     case user(text: String)
     case assistant(text: String)
     /// Assistant message with pre-styled text runs from tree-sitter.
@@ -971,7 +978,10 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         messages.reserveCapacity(msgCount)
         var pos = pendingPos + 2
         for _ in 0..<msgCount {
-            guard data.count >= pos + 1 else { throw ProtocolDecodeError.malformed }
+            // Each message is prefixed with a stable uint32 ID from the BEAM
+            guard data.count >= pos + 5 else { throw ProtocolDecodeError.malformed }
+            let beamId = readU32(data, pos)
+            pos += 4
             let msgType = data[pos]
             switch msgType {
             case 0x01: // user
@@ -979,14 +989,14 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 let tLen = Int(readU32(data, pos + 1))
                 guard data.count >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
                 let t = String(data: data[(pos + 5)..<(pos + 5 + tLen)], encoding: .utf8) ?? ""
-                messages.append(.user(text: t))
+                messages.append(GUIChatMessage(beamId: beamId, content: .user(text: t)))
                 pos += 5 + tLen
             case 0x02: // assistant
                 guard data.count >= pos + 5 else { throw ProtocolDecodeError.malformed }
                 let tLen = Int(readU32(data, pos + 1))
                 guard data.count >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
                 let t = String(data: data[(pos + 5)..<(pos + 5 + tLen)], encoding: .utf8) ?? ""
-                messages.append(.assistant(text: t))
+                messages.append(GUIChatMessage(beamId: beamId, content: .assistant(text: t)))
                 pos += 5 + tLen
             case 0x03: // thinking
                 guard data.count >= pos + 6 else { throw ProtocolDecodeError.malformed }
@@ -994,7 +1004,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 let tLen = Int(readU32(data, pos + 2))
                 guard data.count >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
                 let t = String(data: data[(pos + 6)..<(pos + 6 + tLen)], encoding: .utf8) ?? ""
-                messages.append(.thinking(text: t, collapsed: collapsed))
+                messages.append(GUIChatMessage(beamId: beamId, content: .thinking(text: t, collapsed: collapsed)))
                 pos += 6 + tLen
             case 0x04: // tool_call
                 guard data.count >= pos + 10 else { throw ProtocolDecodeError.malformed }
@@ -1008,7 +1018,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 let resultLen = Int(readU32(data, pos + 10 + nameLen))
                 guard data.count >= pos + 14 + nameLen + resultLen else { throw ProtocolDecodeError.malformed }
                 let result = String(data: data[(pos + 14 + nameLen)..<(pos + 14 + nameLen + resultLen)], encoding: .utf8) ?? ""
-                messages.append(.toolCall(name: name, status: tcStatus, isError: isError, collapsed: tcCollapsed, durationMs: duration, result: result))
+                messages.append(GUIChatMessage(beamId: beamId, content: .toolCall(name: name, status: tcStatus, isError: isError, collapsed: tcCollapsed, durationMs: duration, result: result)))
                 pos += 14 + nameLen + resultLen
             case 0x05: // system
                 guard data.count >= pos + 6 else { throw ProtocolDecodeError.malformed }
@@ -1016,7 +1026,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 let tLen = Int(readU32(data, pos + 2))
                 guard data.count >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
                 let t = String(data: data[(pos + 6)..<(pos + 6 + tLen)], encoding: .utf8) ?? ""
-                messages.append(.system(text: t, isError: isError))
+                messages.append(GUIChatMessage(beamId: beamId, content: .system(text: t, isError: isError)))
                 pos += 6 + tLen
             case 0x06: // usage
                 guard data.count >= pos + 21 else { throw ProtocolDecodeError.malformed }
@@ -1025,7 +1035,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 let cacheR = readU32(data, pos + 9)
                 let cacheW = readU32(data, pos + 13)
                 let costM = readU32(data, pos + 17)
-                messages.append(.usage(input: inp, output: outp, cacheRead: cacheR, cacheWrite: cacheW, costMicros: costM))
+                messages.append(GUIChatMessage(beamId: beamId, content: .usage(input: inp, output: outp, cacheRead: cacheR, cacheWrite: cacheW, costMicros: costM)))
                 pos += 21
             case 0x07: // styled_assistant
                 // Format: 0x07, line_count::16, then per line:
@@ -1066,7 +1076,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                     }
                     lines.append(runs)
                 }
-                messages.append(.styledAssistant(lines: lines))
+                messages.append(GUIChatMessage(beamId: beamId, content: .styledAssistant(lines: lines)))
                 pos = rPos
             case 0x08: // styled_tool_call
                 // Same header as tool_call (0x04) but result is styled runs instead of plain text.
@@ -1109,7 +1119,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                     }
                     stcLines.append(runs)
                 }
-                messages.append(.styledToolCall(name: stcName, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, durationMs: stcDuration, resultLines: stcLines))
+                messages.append(GUIChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, durationMs: stcDuration, resultLines: stcLines)))
                 pos = stcPos
             default:
                 break

--- a/macos/Sources/Views/AgentChatState.swift
+++ b/macos/Sources/Views/AgentChatState.swift
@@ -65,24 +65,25 @@ final class AgentChatState {
         self.prompt = prompt
         self.promptVersion += 1
         self.pendingApproval = pendingToolName.map { PendingApproval(toolName: $0, summary: pendingToolSummary) }
-        self.messages = rawMessages.enumerated().map { i, msg in
-            switch msg {
+        self.messages = rawMessages.map { msg in
+            let id = Int(msg.beamId)
+            switch msg.content {
             case .user(let text):
-                return .user(id: i, text: text)
+                return .user(id: id, text: text)
             case .assistant(let text):
-                return .assistant(id: i, text: text)
+                return .assistant(id: id, text: text)
             case .styledAssistant(let lines):
-                return .styledAssistant(id: i, lines: lines)
+                return .styledAssistant(id: id, lines: lines)
             case .thinking(let text, let collapsed):
-                return .thinking(id: i, text: text, collapsed: collapsed)
+                return .thinking(id: id, text: text, collapsed: collapsed)
             case .toolCall(let name, let st, let isError, let collapsed, let duration, let result):
-                return .toolCall(id: i, name: name, status: st, isError: isError, collapsed: collapsed, durationMs: duration, result: result)
+                return .toolCall(id: id, name: name, status: st, isError: isError, collapsed: collapsed, durationMs: duration, result: result)
             case .styledToolCall(let name, let st, let isError, let collapsed, let duration, let resultLines):
-                return .styledToolCall(id: i, name: name, status: st, isError: isError, collapsed: collapsed, durationMs: duration, resultLines: resultLines)
+                return .styledToolCall(id: id, name: name, status: st, isError: isError, collapsed: collapsed, durationMs: duration, resultLines: resultLines)
             case .system(let text, let isError):
-                return .system(id: i, text: text, isError: isError)
+                return .system(id: id, text: text, isError: isError)
             case .usage(let inp, let outp, let cacheR, let cacheW, let costM):
-                return .usage(id: i, input: inp, output: outp, cacheRead: cacheR, cacheWrite: cacheW, costMicros: costM)
+                return .usage(id: id, input: inp, output: outp, cacheRead: cacheR, cacheWrite: cacheW, costMicros: costM)
             }
         }
     }

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -269,11 +269,12 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
 }
 
 func chatMessageToJSON(_ msg: GUIChatMessage) -> [String: Any] {
-    switch msg {
+    var result: [String: Any] = ["beam_id": Int(msg.beamId)]
+    switch msg.content {
     case .user(let text):
-        return ["kind": "user", "text": text]
+        result["kind"] = "user"; result["text"] = text
     case .assistant(let text):
-        return ["kind": "assistant", "text": text]
+        result["kind"] = "assistant"; result["text"] = text
     case .styledAssistant(let lines):
         let linesJSON: [[Any]] = lines.map { runs in
             runs.map { run -> [String: Any] in
@@ -287,11 +288,13 @@ func chatMessageToJSON(_ msg: GUIChatMessage) -> [String: Any] {
                 ]
             }
         }
-        return ["kind": "styled_assistant", "lines": linesJSON]
+        result["kind"] = "styled_assistant"; result["lines"] = linesJSON
     case .thinking(let text, let collapsed):
-        return ["kind": "thinking", "text": text, "collapsed": collapsed]
-    case .toolCall(let name, let status, let isError, let collapsed, let durationMs, let result):
-        return ["kind": "tool_call", "name": name, "status": Int(status), "is_error": isError, "collapsed": collapsed, "duration_ms": Int(durationMs), "result": result]
+        result["kind"] = "thinking"; result["text"] = text; result["collapsed"] = collapsed
+    case .toolCall(let name, let status, let isError, let collapsed, let durationMs, let resultStr):
+        result["kind"] = "tool_call"; result["name"] = name; result["status"] = Int(status)
+        result["is_error"] = isError; result["collapsed"] = collapsed
+        result["duration_ms"] = Int(durationMs); result["result"] = resultStr
     case .styledToolCall(let name, let status, let isError, let collapsed, let durationMs, let resultLines):
         let linesJSON: [[Any]] = resultLines.map { runs in
             runs.map { run -> [String: Any] in
@@ -305,12 +308,17 @@ func chatMessageToJSON(_ msg: GUIChatMessage) -> [String: Any] {
                 ]
             }
         }
-        return ["kind": "styled_tool_call", "name": name, "status": Int(status), "is_error": isError, "collapsed": collapsed, "duration_ms": Int(durationMs), "result_lines": linesJSON]
+        result["kind"] = "styled_tool_call"; result["name"] = name; result["status"] = Int(status)
+        result["is_error"] = isError; result["collapsed"] = collapsed
+        result["duration_ms"] = Int(durationMs); result["result_lines"] = linesJSON
     case .system(let text, let isError):
-        return ["kind": "system", "text": text, "is_error": isError]
+        result["kind"] = "system"; result["text"] = text; result["is_error"] = isError
     case .usage(let input, let output, let cacheRead, let cacheWrite, let costMicros):
-        return ["kind": "usage", "input": Int(input), "output": Int(output), "cache_read": Int(cacheRead), "cache_write": Int(cacheWrite), "cost_micros": Int(costMicros)]
+        result["kind"] = "usage"; result["input"] = Int(input); result["output"] = Int(output)
+        result["cache_read"] = Int(cacheRead); result["cache_write"] = Int(cacheWrite)
+        result["cost_micros"] = Int(costMicros)
     }
+    return result
 }
 
 // MARK: - Main loop

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -302,7 +302,7 @@ struct CommandDispatcherRoutingTests {
     @Test("guiAgentChat visible updates agentChatState")
     @MainActor func guiAgentChatVisible() {
         let (dispatcher, gui) = makeDispatcher()
-        let messages: [GUIChatMessage] = [.user(text: "hello")]
+        let messages: [GUIChatMessage] = [GUIChatMessage(beamId: 1, content: .user(text: "hello"))]
         dispatcher.dispatch(.guiAgentChat(visible: true, status: 1, model: "claude",
                                            prompt: "Fix this", pendingToolName: nil,
                                            pendingToolSummary: "", messages: messages))

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -888,12 +888,14 @@ struct GUIAgentChatDecoderTests {
         data.append(0) // no pending approval
         appendU16(&data, 2) // messageCount
 
-        // Message 1: user
+        // Message 1: user (beam_id=1)
+        appendU32(&data, 1)
         data.append(0x01) // type=user
         appendU32(&data, UInt32("hello".utf8.count))
         data.append(contentsOf: "hello".utf8)
 
-        // Message 2: assistant
+        // Message 2: assistant (beam_id=2)
+        appendU32(&data, 2)
         data.append(0x02) // type=assistant
         appendU32(&data, UInt32("hi there".utf8.count))
         data.append(contentsOf: "hi there".utf8)
@@ -912,12 +914,14 @@ struct GUIAgentChatDecoderTests {
         #expect(pendingToolName == nil)
         #expect(messages.count == 2)
 
-        guard case .user(let userText) = messages[0] else {
+        #expect(messages[0].beamId == 1)
+        guard case .user(let userText) = messages[0].content else {
             Issue.record("Expected .user message"); return
         }
         #expect(userText == "hello")
 
-        guard case .assistant(let assistantText) = messages[1] else {
+        #expect(messages[1].beamId == 2)
+        guard case .assistant(let assistantText) = messages[1].content else {
             Issue.record("Expected .assistant message"); return
         }
         #expect(assistantText == "hi there")
@@ -934,7 +938,8 @@ struct GUIAgentChatDecoderTests {
         data.append(0) // no pending approval
         appendU16(&data, 1) // messageCount
 
-        // Thinking message
+        // Thinking message (beam_id=10)
+        appendU32(&data, 10)
         data.append(0x03) // type=thinking
         data.append(1) // collapsed
         let thinkText = "Let me analyze..."
@@ -946,7 +951,8 @@ struct GUIAgentChatDecoderTests {
             Issue.record("Expected .guiAgentChat"); return
         }
 
-        guard case .thinking(let text, let collapsed) = messages[0] else {
+        #expect(messages[0].beamId == 10)
+        guard case .thinking(let text, let collapsed) = messages[0].content else {
             Issue.record("Expected .thinking message"); return
         }
         #expect(text == "Let me analyze...")
@@ -962,7 +968,8 @@ struct GUIAgentChatDecoderTests {
         data.append(0) // no pending
         appendU16(&data, 1)
 
-        // Tool call message
+        // Tool call message (beam_id=5)
+        appendU32(&data, 5)
         data.append(0x04) // type=tool_call
         data.append(1) // status
         data.append(0) // isError
@@ -978,7 +985,7 @@ struct GUIAgentChatDecoderTests {
             Issue.record("Expected .guiAgentChat"); return
         }
 
-        guard case .toolCall(let name, let tcStatus, let isError, let collapsed, let duration, let tcResult) = messages[0] else {
+        guard case .toolCall(let name, let tcStatus, let isError, let collapsed, let duration, let tcResult) = messages[0].content else {
             Issue.record("Expected .toolCall message"); return
         }
         #expect(name == "read_file")
@@ -998,6 +1005,7 @@ struct GUIAgentChatDecoderTests {
         data.append(0)
         appendU16(&data, 1)
 
+        appendU32(&data, 1) // beam_id
         data.append(0x05) // type=system
         data.append(1) // isError
         let sysText = "Session terminated"
@@ -1009,7 +1017,7 @@ struct GUIAgentChatDecoderTests {
             Issue.record("Expected .guiAgentChat"); return
         }
 
-        guard case .system(let text, let isError) = messages[0] else {
+        guard case .system(let text, let isError) = messages[0].content else {
             Issue.record("Expected .system message"); return
         }
         #expect(text == "Session terminated")
@@ -1025,6 +1033,7 @@ struct GUIAgentChatDecoderTests {
         data.append(0)
         appendU16(&data, 1)
 
+        appendU32(&data, 1) // beam_id
         data.append(0x06) // type=usage
         appendU32(&data, 1000) // input
         appendU32(&data, 500) // output
@@ -1037,7 +1046,7 @@ struct GUIAgentChatDecoderTests {
             Issue.record("Expected .guiAgentChat"); return
         }
 
-        guard case .usage(let input, let output, let cacheRead, let cacheWrite, let costMicros) = messages[0] else {
+        guard case .usage(let input, let output, let cacheRead, let cacheWrite, let costMicros) = messages[0].content else {
             Issue.record("Expected .usage message"); return
         }
         #expect(input == 1000)
@@ -1075,8 +1084,9 @@ struct GUIAgentChatDecoderTests {
         data.append(0) // no pending
         appendU16(&data, 1) // 1 message
 
-        // styled_assistant: 0x07, line_count::16, then per line:
+        // styled_assistant: beam_id::32, 0x07, line_count::16, then per line:
         //   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8
+        appendU32(&data, 42) // beam_id
         data.append(0x07) // type=styled_assistant
         appendU16(&data, 2) // 2 lines
 
@@ -1108,7 +1118,8 @@ struct GUIAgentChatDecoderTests {
             Issue.record("Expected .guiAgentChat"); return
         }
 
-        guard case .styledAssistant(let lines) = messages[0] else {
+        #expect(messages[0].beamId == 42)
+        guard case .styledAssistant(let lines) = messages[0].content else {
             Issue.record("Expected .styledAssistant message"); return
         }
         #expect(lines.count == 2)

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -280,13 +280,13 @@ struct AgentChatStateLifecycleTests {
     @MainActor func updateConvertsMessages() {
         let state = AgentChatState()
         let raw: [GUIChatMessage] = [
-            .user(text: "hello"),
-            .assistant(text: "hi"),
-            .thinking(text: "analyzing...", collapsed: false),
-            .toolCall(name: "read_file", status: 1, isError: false,
-                     collapsed: true, durationMs: 500, result: "contents"),
-            .system(text: "session started", isError: false),
-            .usage(input: 100, output: 50, cacheRead: 80, cacheWrite: 20, costMicros: 5000)
+            GUIChatMessage(beamId: 1, content: .user(text: "hello")),
+            GUIChatMessage(beamId: 2, content: .assistant(text: "hi")),
+            GUIChatMessage(beamId: 3, content: .thinking(text: "analyzing...", collapsed: false)),
+            GUIChatMessage(beamId: 4, content: .toolCall(name: "read_file", status: 1, isError: false,
+                     collapsed: true, durationMs: 500, result: "contents")),
+            GUIChatMessage(beamId: 5, content: .system(text: "session started", isError: false)),
+            GUIChatMessage(beamId: 6, content: .usage(input: 100, output: 50, cacheRead: 80, cacheWrite: 20, costMicros: 5000))
         ]
         state.update(visible: true, status: 1, model: "claude", prompt: "fix bug",
                      pendingToolName: "write_file",
@@ -309,7 +309,7 @@ struct AgentChatStateLifecycleTests {
         let state = AgentChatState()
         state.update(visible: true, status: 1, model: "claude", prompt: "test",
                      pendingToolName: nil, pendingToolSummary: "",
-                     rawMessages: [.user(text: "hi")])
+                     rawMessages: [GUIChatMessage(beamId: 1, content: .user(text: "hi"))])
         state.hide()
 
         #expect(state.visible == false)

--- a/test/minga/agent/session_test.exs
+++ b/test/minga/agent/session_test.exs
@@ -994,4 +994,294 @@ defmodule Minga.Agent.SessionTest do
       assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
     end
   end
+
+  # ── Stable message IDs ───────────────────────────────────────────────────
+
+  describe "message IDs" do
+    test "initial session has one message with ID 1", %{session: session} do
+      pairs = Session.messages_with_ids(session)
+      assert [{1, {:system, _, :info}}] = pairs
+    end
+
+    test "send_prompt assigns incrementing IDs", %{session: session} do
+      :ok = Session.send_prompt(session, "Hello!")
+      await_turn_complete()
+
+      pairs = Session.messages_with_ids(session)
+      ids = Enum.map(pairs, &elem(&1, 0))
+
+      # system(1), user(2), assistant(3), usage(4)
+      assert ids == [1, 2, 3, 4]
+      assert length(pairs) == length(Session.messages(session))
+    end
+
+    test "IDs are monotonically increasing after multiple turns", %{session: session} do
+      :ok = Session.send_prompt(session, "first")
+      await_turn_complete()
+
+      :ok = Session.send_prompt(session, "second")
+      await_turn_complete()
+
+      pairs = Session.messages_with_ids(session)
+      ids = Enum.map(pairs, &elem(&1, 0))
+
+      assert ids == Enum.sort(ids)
+      assert ids == Enum.uniq(ids)
+      assert length(pairs) == length(Session.messages(session))
+    end
+
+    test "streaming text deltas don't create new IDs" do
+      {:ok, slow_session} =
+        Session.start_link(provider: SlowMockProvider, provider_opts: [])
+
+      Session.subscribe(slow_session)
+      :sys.get_state(slow_session)
+
+      :ok = Session.send_prompt(slow_session, "hello")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      # Mid-stream: system(1), user(2), assistant(3)
+      # The SlowMockProvider sends one TextDelta with the prompt text,
+      # which creates an assistant message.
+      pairs_during = Session.messages_with_ids(slow_session)
+      ids_during = Enum.map(pairs_during, &elem(&1, 0))
+      assert ids_during == [1, 2, 3]
+
+      # Send another text delta manually (simulates streaming tokens)
+      send(slow_session, {:agent_provider_event, %Event.TextDelta{delta: " world"}})
+
+      # The assistant message at ID 3 should still be there, not a new ID
+      pairs_after_delta = Session.messages_with_ids(slow_session)
+      ids_after_delta = Enum.map(pairs_after_delta, &elem(&1, 0))
+      assert ids_after_delta == [1, 2, 3]
+
+      # Content grew but ID is stable
+      {3, {:assistant, text}} = List.last(pairs_after_delta)
+      assert String.contains?(text, "world")
+
+      SlowMockProvider.proceed(Session.get_provider(slow_session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+
+      # After turn completes, usage message gets the next ID
+      pairs_final = Session.messages_with_ids(slow_session)
+      ids_final = Enum.map(pairs_final, &elem(&1, 0))
+      assert ids_final == [1, 2, 3, 4]
+      assert length(pairs_final) == length(Session.messages(slow_session))
+    end
+
+    test "thinking deltas get one stable ID, then assistant gets the next", %{session: session} do
+      # Inject events directly: thinking then text
+      send(session, {:agent_provider_event, %Event.AgentStart{}})
+      send(session, {:agent_provider_event, %Event.ThinkingDelta{delta: "hmm"}})
+      send(session, {:agent_provider_event, %Event.ThinkingDelta{delta: " ok"}})
+
+      # Sync: call forces processing of all prior handle_info messages
+      pairs_thinking = Session.messages_with_ids(session)
+      ids = Enum.map(pairs_thinking, &elem(&1, 0))
+
+      # system(1), thinking(2). Two ThinkingDeltas, but one message.
+      assert ids == [1, 2]
+      assert {2, {:thinking, "hmm ok", _collapsed}} = List.last(pairs_thinking)
+
+      # Now assistant text arrives (collapses thinking, creates new assistant msg)
+      send(session, {:agent_provider_event, %Event.TextDelta{delta: "answer"}})
+      pairs_with_assistant = Session.messages_with_ids(session)
+      ids2 = Enum.map(pairs_with_assistant, &elem(&1, 0))
+
+      # system(1), thinking(2), assistant(3)
+      assert ids2 == [1, 2, 3]
+      assert {3, {:assistant, "answer"}} = List.last(pairs_with_assistant)
+      assert length(pairs_with_assistant) == length(Session.messages(session))
+    end
+
+    test "new_session resets IDs to 1", %{session: session} do
+      :ok = Session.send_prompt(session, "Hello!")
+      await_turn_complete()
+
+      # IDs are now [1, 2, 3, 4]
+      pairs_before = Session.messages_with_ids(session)
+      assert length(pairs_before) == 4
+
+      :ok = Session.new_session(session)
+      # Drain the broadcasts from new_session
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 200
+
+      pairs_after = Session.messages_with_ids(session)
+      assert [{1, {:system, _, :info}}] = pairs_after
+      assert length(pairs_after) == length(Session.messages(session))
+    end
+
+    test "load_session resets IDs starting from 1", %{session: session} do
+      SessionStore.save(%{
+        id: "id-test-session",
+        timestamp: DateTime.to_iso8601(DateTime.utc_now()),
+        model_name: "test-model",
+        messages: [{:user, "loaded"}, {:assistant, "reply"}],
+        usage: %{input: 10, output: 5, cache_read: 0, cache_write: 0, cost: 0.001}
+      })
+
+      :ok = Session.load_session(session, "id-test-session")
+      # Drain the broadcasts
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 200
+
+      pairs = Session.messages_with_ids(session)
+      ids = Enum.map(pairs, &elem(&1, 0))
+      assert ids == [1, 2]
+      assert {1, {:user, "loaded"}} = hd(pairs)
+      assert length(pairs) == length(Session.messages(session))
+    end
+
+    test "tool start/update/end keeps a stable ID for the tool message", %{session: session} do
+      send(
+        session,
+        {:agent_provider_event, %Event.ToolStart{tool_call_id: "tc1", name: "bash", args: %{}}}
+      )
+
+      pairs_start = Session.messages_with_ids(session)
+      {tool_id, {:tool_call, tc_start}} = List.last(pairs_start)
+      assert tc_start.status == :running
+
+      # ToolUpdate: in-place mutation, same ID
+      send(
+        session,
+        {:agent_provider_event,
+         %Event.ToolUpdate{tool_call_id: "tc1", name: "bash", partial_result: "output"}}
+      )
+
+      pairs_update = Session.messages_with_ids(session)
+      {^tool_id, {:tool_call, tc_update}} = List.last(pairs_update)
+      assert tc_update.result == "output"
+
+      # ToolEnd: in-place mutation, same ID
+      send(
+        session,
+        {:agent_provider_event, %Event.ToolEnd{tool_call_id: "tc1", name: "bash", result: "done"}}
+      )
+
+      pairs_end = Session.messages_with_ids(session)
+      {^tool_id, {:tool_call, tc_end}} = List.last(pairs_end)
+      assert tc_end.status == :complete
+
+      # IDs list length always matches messages
+      assert length(pairs_end) == length(Session.messages(session))
+    end
+
+    test "toggle_tool_collapse does not change IDs", %{session: session} do
+      send(
+        session,
+        {:agent_provider_event, %Event.ToolStart{tool_call_id: "tc1", name: "bash", args: %{}}}
+      )
+
+      send(
+        session,
+        {:agent_provider_event,
+         %Event.ToolEnd{tool_call_id: "tc1", name: "bash", result: "output"}}
+      )
+
+      pairs_before = Session.messages_with_ids(session)
+      ids_before = Enum.map(pairs_before, &elem(&1, 0))
+
+      tool_index =
+        Enum.find_index(pairs_before, fn {_id, msg} -> match?({:tool_call, _}, msg) end)
+
+      :ok = Session.toggle_tool_collapse(session, tool_index)
+
+      pairs_after = Session.messages_with_ids(session)
+      ids_after = Enum.map(pairs_after, &elem(&1, 0))
+
+      assert ids_before == ids_after
+      assert length(pairs_after) == length(Session.messages(session))
+    end
+
+    test "toggle_all_tool_collapses does not change IDs", %{session: session} do
+      # Add a thinking block and a tool call
+      send(session, {:agent_provider_event, %Event.ThinkingDelta{delta: "thinking..."}})
+
+      send(
+        session,
+        {:agent_provider_event, %Event.ToolStart{tool_call_id: "tc1", name: "bash", args: %{}}}
+      )
+
+      send(
+        session,
+        {:agent_provider_event, %Event.ToolEnd{tool_call_id: "tc1", name: "bash", result: "ok"}}
+      )
+
+      pairs_before = Session.messages_with_ids(session)
+      ids_before = Enum.map(pairs_before, &elem(&1, 0))
+
+      :ok = Session.toggle_all_tool_collapses(session)
+
+      pairs_after = Session.messages_with_ids(session)
+      ids_after = Enum.map(pairs_after, &elem(&1, 0))
+
+      assert ids_before == ids_after
+    end
+
+    test "abort maps messages in place without changing IDs", %{session: session} do
+      send(
+        session,
+        {:agent_provider_event, %Event.ToolStart{tool_call_id: "tc1", name: "bash", args: %{}}}
+      )
+
+      pairs_before = Session.messages_with_ids(session)
+      ids_before = Enum.map(pairs_before, &elem(&1, 0))
+
+      :ok = Session.abort(session)
+
+      pairs_after = Session.messages_with_ids(session)
+      ids_after = Enum.map(pairs_after, &elem(&1, 0))
+
+      # Abort adds one "Aborted" system message at the end
+      assert Enum.take(ids_after, length(ids_before)) == ids_before
+      assert length(ids_after) == length(ids_before) + 1
+      assert length(pairs_after) == length(Session.messages(session))
+    end
+
+    test "dequeue_steering adds messages with incrementing IDs" do
+      {:ok, slow_session} =
+        Session.start_link(provider: SlowMockProvider, provider_opts: [])
+
+      Session.subscribe(slow_session)
+      :sys.get_state(slow_session)
+
+      :ok = Session.send_prompt(slow_session, "first")
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+
+      # Queue two steering messages
+      assert {:queued, :steering} = Session.send_prompt(slow_session, "steer 1")
+      assert {:queued, :steering} = Session.send_prompt(slow_session, "steer 2")
+
+      # Dequeue: adds user messages to history
+      _steering = Session.dequeue_steering(slow_session)
+
+      pairs = Session.messages_with_ids(slow_session)
+      ids = Enum.map(pairs, &elem(&1, 0))
+
+      # system(1), user(2), assistant(3), steer1-user(4), steer2-user(5)
+      assert ids == Enum.sort(ids)
+      assert ids == Enum.uniq(ids)
+      assert length(pairs) == length(Session.messages(slow_session))
+
+      # Clean up
+      Session.clear_queues(slow_session)
+      SlowMockProvider.proceed(Session.get_provider(slow_session))
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+    end
+
+    test "add_system_message (cast) assigns a new ID", %{session: session} do
+      pairs_before = Session.messages_with_ids(session)
+      max_id_before = pairs_before |> Enum.map(&elem(&1, 0)) |> Enum.max()
+
+      Session.add_system_message(session, "hello from test")
+
+      # The cast is async. Use messages_with_ids as a sync barrier.
+      pairs_after = Session.messages_with_ids(session)
+      ids_after = Enum.map(pairs_after, &elem(&1, 0))
+
+      assert length(ids_after) == length(pairs_before) + 1
+      assert List.last(ids_after) > max_id_before
+      assert length(pairs_after) == length(Session.messages(session))
+    end
+  end
 end

--- a/test/minga/port/gui_agent_chat_protocol_test.exs
+++ b/test/minga/port/gui_agent_chat_protocol_test.exs
@@ -107,4 +107,97 @@ defmodule Minga.Port.GUIAgentChatProtocolTest do
       assert :binary.match(binary, <<0x04>>) != :nomatch
     end
   end
+
+  describe "stable message ID encoding" do
+    test "encodes {id, message} tuples with uint32 ID prefix" do
+      data = %{
+        visible: true,
+        messages: [{42, {:user, "hello"}}, {99, {:assistant, "hi"}}],
+        status: :idle,
+        model: "",
+        prompt: "",
+        pending_approval: nil
+      }
+
+      binary = ProtocolGUI.encode_gui_agent_chat(data)
+
+      # Parse the envelope to get to the message payload
+      <<0x78, 1::8, _status::8, model_len::16, _model::binary-size(model_len), prompt_len::16,
+        _prompt::binary-size(prompt_len), 0::8, msg_count::16, msg_data::binary>> = binary
+
+      assert msg_count == 2
+
+      # First message: ID=42, type=0x01 (user), text="hello"
+      <<42::32, 0x01::8, text_len::32, text::binary-size(text_len), rest::binary>> = msg_data
+      assert text == "hello"
+
+      # Second message: ID=99, type=0x02 (assistant), text="hi"
+      <<99::32, 0x02::8, text2_len::32, text2::binary-size(text2_len)>> = rest
+      assert text2 == "hi"
+    end
+
+    test "bare tuple messages (no ID wrapper) encode with ID 0" do
+      data = %{
+        visible: true,
+        messages: [{:user, "bare"}],
+        status: :idle,
+        model: "",
+        prompt: "",
+        pending_approval: nil
+      }
+
+      binary = ProtocolGUI.encode_gui_agent_chat(data)
+
+      <<0x78, 1::8, _status::8, model_len::16, _model::binary-size(model_len), prompt_len::16,
+        _prompt::binary-size(prompt_len), 0::8, 1::16, msg_data::binary>> = binary
+
+      # ID prefix should be 0 for bare tuples
+      <<0::32, 0x01::8, _rest::binary>> = msg_data
+    end
+
+    test "all message types carry the ID prefix" do
+      tc = %{
+        name: "bash",
+        status: :complete,
+        is_error: false,
+        collapsed: true,
+        duration_ms: 100,
+        result: "ok"
+      }
+
+      messages = [
+        {1, {:user, "hello"}},
+        {2, {:assistant, "hi"}},
+        {3, {:thinking, "hmm", true}},
+        {4, {:tool_call, tc}},
+        {5, {:system, "started", :info}},
+        {6, {:usage, %{input: 10, output: 5, cache_read: 0, cache_write: 0, cost: 0.001}}}
+      ]
+
+      data = %{
+        visible: true,
+        messages: messages,
+        status: :idle,
+        model: "",
+        prompt: "",
+        pending_approval: nil
+      }
+
+      binary = ProtocolGUI.encode_gui_agent_chat(data)
+
+      <<0x78, 1::8, _status::8, model_len::16, _model::binary-size(model_len), prompt_len::16,
+        _prompt::binary-size(prompt_len), 0::8, msg_count::16, _msg_data::binary>> = binary
+
+      assert msg_count == 6
+
+      # Verify each message starts with its expected ID by scanning the binary.
+      # The messages are sequential, so we check the first 4 bytes of each.
+      # Rather than parsing all message bodies, just verify the binary contains
+      # the expected ID values in order.
+      for {id, _msg} <- messages do
+        assert :binary.match(binary, <<id::32>>) != :nomatch,
+               "Expected message ID #{id} in encoded binary"
+      end
+    end
+  end
 end

--- a/test/minga/port/protocol_test.exs
+++ b/test/minga/port/protocol_test.exs
@@ -1117,8 +1117,8 @@ defmodule Minga.Port.ProtocolTest do
 
       assert msg_count == 1
 
-      # First byte should be 0x07 (styled_assistant opcode)
-      assert <<0x07, line_count::16, rest::binary>> = msg_data
+      # 4-byte message ID prefix (0 for bare messages), then 0x07 (styled_assistant opcode)
+      assert <<0::32, 0x07, line_count::16, rest::binary>> = msg_data
       assert line_count == 2
 
       # First line: 2 runs


### PR DESCRIPTION
# TL;DR

Each agent chat message now receives a stable monotonic uint32 ID from the BEAM. SwiftUI uses these IDs instead of array indices, so streaming updates no longer cause scroll jitter or unnecessary view recreation.

Closes #1064

## Context

During active LLM streaming, the BEAM sends frequent message list updates to the macOS GUI. Previously, `AgentChatState.update()` assigned IDs as array indices via `enumerated().map`. When messages were inserted or content changed, every subsequent ID shifted. SwiftUI treated the entire list as "changed" on every tick, destroying and recreating every `LazyVStack` child below the insertion point. This caused visible scroll jumps and defeated view recycling.

## Changes

**BEAM side (`session.ex`):**
- Added `message_ids` (parallel list of `pos_integer()`) and `next_message_id` counter to Session state
- Created three helpers that keep both lists in sync: `append_msg/2`, `append_msgs/2`, `reset_messages/2`
- Refactored `append_to_last_assistant/2` and `append_to_last_thinking/2` to return `{:updated, msgs}` or `{:appended, msg}`, so callers only assign a new ID when a message is actually created (not when content grows during streaming)
- Routed all 7 message mutation paths through the helpers (send_prompt, dequeue_steering, follow-up auto-send, ToolStart, AgentEnd usage, auth onboarding, add_system_message)
- In-place mutations (abort map, collapse toggles, tool updates) don't touch `message_ids` since they don't change message count
- New `messages_with_ids/1` public API returns `[{id, Message.t()}]` via `Enum.zip`

**Protocol (`gui.ex`):**
- Each encoded message is prefixed with `id::32` before the message type byte
- Bare tuples (no ID wrapper) default to ID 0 for backward compat in tests

**Swift side:**
- `GUIChatMessage` changed from an enum to a struct with `beamId: UInt32` and `content: GUIChatMessageContent` enum
- `AgentChatState.update()` uses `msg.beamId` instead of the array index from `enumerated()`
- Updated ProtocolDecoder to read the 4-byte ID prefix before each message

**Design decision: parallel list vs embedded IDs.** Consulted archie on three approaches. Embedding IDs as `{id, message}` tuples in `state.messages` would change `Message.t()` everywhere (20+ pattern match sites across Session, protocol, render pipeline, SessionStore, Branch). Computing IDs at the render boundary would break on `branch_at` truncation (count could match previous frame, causing ID reuse). The parallel list keeps `Message.t()` unchanged and limits the blast radius to Session internals.

## Verification

1. `mix test.llm` passes all 6502 tests (16 new)
2. `mix compile --warnings-as-errors` is clean
3. Swift build succeeds (`xcodebuild build`)
4. All 435 Swift tests pass (`xcodebuild test`)
5. To verify the streaming behavior: open the agent chat, send a prompt, and observe that scroll position stays stable as the assistant response streams in (no jumps when tool calls start/end)

## Acceptance Criteria Addressed

- Each chat message has a stable uint32 ID assigned by the BEAM that persists across updates ✅
- IDs are monotonically increasing (new messages get higher IDs) ✅
- When a message's content changes during streaming, its ID remains the same ✅
- SwiftUI's ForEach uses this stable ID, not an array index ✅
- Scroll position does not jump when new messages arrive or existing messages update during streaming ✅ (structural fix; visual confirmation needed with a running instance)