### PR TITLE
fix(agent): use graceful task shutdown on abort to suppress log noise

### DIFF
--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -335,7 +335,11 @@ defmodule Minga.Agent.Providers.Native do
   end
 
   def handle_call(:abort, _from, state) do
-    Task.shutdown(state.task, :brutal_kill)
+    # Use a short timeout instead of :brutal_kill so the StreamServer
+    # (which traps exits) can terminate cleanly via its terminate/2
+    # callback. :brutal_kill sends an untrappable :kill signal that
+    # causes OTP to log the StreamServer's state as an [error].
+    Task.shutdown(state.task, 150)
     state = %{state | task: nil, streaming: false}
     Minga.Log.info(:agent, "[Agent.Native] aborted current operation")
     {:reply, :ok, state}
@@ -418,9 +422,9 @@ defmodule Minga.Agent.Providers.Native do
   end
 
   def handle_call(:new_session, _from, state) do
-    # Kill any running task
+    # Gracefully stop any running task (see :abort handler comment)
     if state.task do
-      Task.shutdown(state.task, :brutal_kill)
+      Task.shutdown(state.task, 150)
     end
 
     system_prompt = build_system_prompt(state.project_root)


### PR DESCRIPTION
## Problem

When pressing Ctrl+C to abort the agent while streaming, OTP logs a noisy `[error]` containing the full `ReqLLM.StreamServer` GenServer state (including the entire model struct with pricing, capabilities, etc.). The abort works correctly, but the log output is alarming and unhelpful.

## Root Cause

`Task.shutdown(:brutal_kill)` sends an untrappable `:kill` signal. This cascades to the `StreamServer` (which traps exits and has a clean `terminate/2` callback), but `:kill` bypasses trap_exit. OTP sees reason `:killed` as abnormal and logs the full state at error level.

## Fix

Replace `:brutal_kill` with `Task.shutdown(150)`, which:
1. First sends `:shutdown` (trappable by the StreamServer)
2. Waits 150ms for clean termination via `terminate/2`
3. Falls back to `:kill` only if the process doesn't respond

Applied to both abort code paths: `handle_call(:abort)` and `handle_call(:new_session)`.

## Verification

- `mix lint`: clean (format + credo + compile + dialyzer)
- `mix test.llm`: 6486 tests, 0 failures
- Native provider abort test passes