### PR TITLE
fix(editor): eliminate mode gates from command executors, fix CUA gaps

### DIFF
--- a/lib/minga/editing_model/vim.ex
+++ b/lib/minga/editing_model/vim.ex
@@ -74,8 +74,16 @@ defmodule Minga.EditingModel.Vim do
 
   @impl Minga.EditingModel
   @spec cursor_shape(t()) :: :beam | :block | :underline
+  def cursor_shape(%__MODULE__{mode: :normal, mode_state: %{pending_replace: true}}),
+    do: :underline
+
   def cursor_shape(%__MODULE__{mode: :insert}), do: :beam
   def cursor_shape(%__MODULE__{mode: :replace}), do: :underline
+
+  def cursor_shape(%__MODULE__{mode: mode})
+      when mode in [:search, :command, :eval, :search_prompt],
+      do: :beam
+
   def cursor_shape(%__MODULE__{}), do: :block
 
   @impl Minga.EditingModel

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -1578,7 +1578,7 @@ defmodule Minga.Editor do
   end
 
   @spec handle_paste_event_editor(state(), String.t()) :: state()
-  defp handle_paste_event_editor(%{vim: %{mode: :insert}, buffers: %{active: buf}} = state, text)
+  defp handle_paste_event_editor(%{buffers: %{active: buf}} = state, text)
        when is_pid(buf) do
     {line, col} = BufferServer.cursor(buf)
     BufferServer.apply_text_edit(buf, line, col, line, col, text)
@@ -1586,7 +1586,7 @@ defmodule Minga.Editor do
   end
 
   defp handle_paste_event_editor(state, _text) do
-    log_message(state, "Paste ignored (not in insert mode or agent input)")
+    log_message(state, "Paste ignored (no active buffer)")
   end
 
   # ── File tree helpers ───────────────────────────────────────────────────
@@ -2182,9 +2182,9 @@ defmodule Minga.Editor do
   defdelegate do_accept_completion(state, completion), to: CompletionHandling, as: :accept
 
   @doc false
-  @spec do_maybe_handle_completion(state(), atom(), non_neg_integer(), non_neg_integer()) ::
+  @spec do_maybe_handle_completion(state(), boolean(), non_neg_integer(), non_neg_integer()) ::
           state()
-  defdelegate do_maybe_handle_completion(state, old_mode, codepoint, modifiers),
+  defdelegate do_maybe_handle_completion(state, was_inserting, codepoint, modifiers),
     to: CompletionHandling,
     as: :maybe_handle
 

--- a/lib/minga/editor/commands/editing.ex
+++ b/lib/minga/editor/commands/editing.ex
@@ -47,21 +47,13 @@ defmodule Minga.Editor.Commands.Editing do
 
   # ── Deletion ──────────────────────────────────────────────────────────────
 
-  def execute(
-        %{vim: %{mode: :insert}, buffers: %{active: buf}} = state,
-        :delete_before
-      ) do
+  def execute(%{buffers: %{active: buf}} = state, :delete_before) do
     if BufferServer.get_option(buf, :autopair) do
       execute_autopair_delete(state, buf)
     else
       BufferServer.delete_before(buf)
       state
     end
-  end
-
-  def execute(%{buffers: %{active: buf}} = state, :delete_before) do
-    BufferServer.delete_before(buf)
-    state
   end
 
   def execute(%{buffers: %{active: buf}} = state, :delete_at) do
@@ -102,22 +94,13 @@ defmodule Minga.Editor.Commands.Editing do
     state
   end
 
-  def execute(
-        %{vim: %{mode: :insert}, buffers: %{active: buf}} = state,
-        {:insert_char, char}
-      )
-      when is_binary(char) do
+  def execute(%{buffers: %{active: buf}} = state, {:insert_char, char}) when is_binary(char) do
     if BufferServer.get_option(buf, :autopair) do
       execute_autopair_insert(buf, char)
     else
       BufferServer.insert_char(buf, char)
     end
 
-    state
-  end
-
-  def execute(%{buffers: %{active: buf}} = state, {:insert_char, char}) when is_binary(char) do
-    BufferServer.insert_char(buf, char)
     state
   end
 

--- a/lib/minga/editor/completion_handling.ex
+++ b/lib/minga/editor/completion_handling.ex
@@ -119,10 +119,10 @@ defmodule Minga.Editor.CompletionHandling do
   insert, dismisses completion. Otherwise updates the filter prefix
   and possibly triggers new completion.
   """
-  @spec maybe_handle(EditorState.t(), atom(), non_neg_integer(), non_neg_integer()) ::
+  @spec maybe_handle(EditorState.t(), boolean(), non_neg_integer(), non_neg_integer()) ::
           EditorState.t()
-  def maybe_handle(state, old_mode, codepoint, modifiers) do
-    if Minga.Editor.Editing.inserting?(state) and old_mode == :insert do
+  def maybe_handle(state, was_inserting, codepoint, modifiers) do
+    if Minga.Editor.Editing.inserting?(state) and was_inserting do
       maybe_update(state, codepoint, modifiers)
     else
       state = dismiss(state)

--- a/lib/minga/editor/render_pipeline/compose.ex
+++ b/lib/minga/editor/render_pipeline/compose.ex
@@ -9,7 +9,7 @@ defmodule Minga.Editor.RenderPipeline.Compose do
 
   alias Minga.Editor.DisplayList.{Cursor, Frame, WindowFrame}
   alias Minga.Editor.Layout
-  alias Minga.Editor.Modeline
+
   alias Minga.Editor.RenderPipeline.Chrome
   alias Minga.Editor.RenderPipeline.ComposeHelpers
   alias Minga.Editor.State, as: EditorState
@@ -55,7 +55,7 @@ defmodule Minga.Editor.RenderPipeline.Compose do
         ComposeHelpers.agent_cursor_from_layout(state, layout),
         active_wf_cursor,
         minibuffer_result,
-        Modeline.cursor_shape(state.vim)
+        Minga.Editor.Editing.cursor_shape(state)
       )
 
     %Frame{

--- a/lib/minga/editor/render_pipeline/compose_helpers.ex
+++ b/lib/minga/editor/render_pipeline/compose_helpers.ex
@@ -12,7 +12,7 @@ defmodule Minga.Editor.RenderPipeline.ComposeHelpers do
   alias Minga.Buffer.Unicode
   alias Minga.Editor.DisplayList.{Cursor, Overlay}
   alias Minga.Editor.Layout
-  alias Minga.Editor.RenderPipeline.ChromeHelpers
+
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.AgentAccess
 
@@ -99,7 +99,7 @@ defmodule Minga.Editor.RenderPipeline.ComposeHelpers do
       Cursor.new(
         input_row,
         input_col,
-        ChromeHelpers.input_cursor_shape(Minga.Editor.Editing.mode(state))
+        Minga.Editor.Editing.cursor_shape(state)
       )
     else
       nil

--- a/lib/minga/editor/render_pipeline/content.ex
+++ b/lib/minga/editor/render_pipeline/content.ex
@@ -17,7 +17,7 @@ defmodule Minga.Editor.RenderPipeline.Content do
   alias Minga.Editor.DisplayMap
   alias Minga.Editor.FoldMap
   alias Minga.Editor.Layout
-  alias Minga.Editor.Modeline
+
   alias Minga.Editor.RenderPipeline.ContentHelpers
   alias Minga.Editor.RenderPipeline.Scroll.WindowScroll
   alias Minga.Editor.SemanticWindow
@@ -185,7 +185,7 @@ defmodule Minga.Editor.RenderPipeline.Content do
           Decorations.buf_col_to_display_col(render_ctx.decorations, cursor_line, cursor_col)
 
         cc = gutter_w + adjusted_cursor_col - viewport.left + col_off
-        Cursor.new(cr, cc, Modeline.cursor_shape(state.vim))
+        Cursor.new(cr, cc, Minga.Editor.Editing.cursor_shape(state))
       else
         nil
       end
@@ -469,7 +469,7 @@ defmodule Minga.Editor.RenderPipeline.Content do
 
         cr = cursor_line - viewport.top + row_off
         cc = gutter_w + adjusted_cc - viewport.left + col_off
-        Cursor.new(cr, cc, Modeline.cursor_shape(state.vim))
+        Cursor.new(cr, cc, Minga.Editor.Editing.cursor_shape(state))
       else
         nil
       end

--- a/lib/minga/editor/semantic_window/builder.ex
+++ b/lib/minga/editor/semantic_window/builder.ex
@@ -23,7 +23,7 @@ defmodule Minga.Editor.SemanticWindow.Builder do
   alias Minga.Diagnostics
   alias Minga.Editor.DisplayMap
   alias Minga.Editor.FoldMap
-  alias Minga.Editor.Modeline
+
   alias Minga.Editor.Renderer.Composition
   alias Minga.Editor.Renderer.Context
   alias Minga.Editor.RenderPipeline.Scroll.WindowScroll
@@ -89,7 +89,7 @@ defmodule Minga.Editor.SemanticWindow.Builder do
 
     cursor_shape =
       if is_active do
-        Modeline.cursor_shape(state.vim)
+        Minga.Editor.Editing.cursor_shape(state)
       else
         :block
       end

--- a/lib/minga/input/router.ex
+++ b/lib/minga/input/router.ex
@@ -79,6 +79,7 @@ defmodule Minga.Input.Router do
           state.buffers.active,
           buffer_version(state),
           Editing.mode(state),
+          Editing.inserting?(state),
           {cancel, 0}
         )
 
@@ -91,6 +92,7 @@ defmodule Minga.Input.Router do
   defp dispatch_normal(state, codepoint, modifiers) do
     old_buffer = state.buffers.active
     old_mode = Editing.mode(state)
+    was_inserting = Editing.inserting?(state)
     buf_version_before = buffer_version(state)
     old_cursor = safe_cursor(old_buffer)
 
@@ -103,6 +105,7 @@ defmodule Minga.Input.Router do
       old_buffer,
       buf_version_before,
       old_mode,
+      was_inserting,
       {codepoint, modifiers},
       old_cursor
     )
@@ -168,6 +171,7 @@ defmodule Minga.Input.Router do
           pid() | nil,
           non_neg_integer(),
           atom(),
+          boolean(),
           {non_neg_integer(), non_neg_integer()},
           {non_neg_integer(), non_neg_integer()} | nil
         ) :: EditorState.t()
@@ -176,6 +180,7 @@ defmodule Minga.Input.Router do
         old_buffer,
         buf_version_before,
         old_mode,
+        was_inserting,
         {codepoint, modifiers},
         old_cursor \\ nil
       ) do
@@ -187,7 +192,7 @@ defmodule Minga.Input.Router do
     }
 
     state
-    |> Editor.do_maybe_handle_completion(old_mode, codepoint, modifiers)
+    |> Editor.do_maybe_handle_completion(was_inserting, codepoint, modifiers)
     |> post_action_housekeeping(snapshot)
   end
 

--- a/test/minga/editing_model/vim_test.exs
+++ b/test/minga/editing_model/vim_test.exs
@@ -155,6 +155,30 @@ defmodule Minga.EditingModel.VimTest do
       {_, _, state} = Vim.process_key(Vim.initial_state(), key_i())
       assert Vim.cursor_shape(state) == :beam
     end
+
+    test "underline when pending_replace is true" do
+      state = %Vim{mode: :normal, mode_state: %Mode.State{pending_replace: true}}
+      assert Vim.cursor_shape(state) == :underline
+    end
+
+    test "underline in replace mode" do
+      state = %Vim{mode: :replace, mode_state: Mode.initial_state()}
+      assert Vim.cursor_shape(state) == :underline
+    end
+
+    test "beam for minibuffer modes" do
+      for mode <- [:search, :command, :eval, :search_prompt] do
+        state = %Vim{mode: mode, mode_state: Mode.initial_state()}
+        assert Vim.cursor_shape(state) == :beam, "expected :beam for #{mode}"
+      end
+    end
+
+    test "block for visual modes" do
+      for mode <- [:visual, :visual_line, :visual_block] do
+        state = %Vim{mode: mode, mode_state: Mode.initial_state()}
+        assert Vim.cursor_shape(state) == :block, "expected :block for #{mode}"
+      end
+    end
   end
 
   describe "key_sequence_pending?/1" do
@@ -164,6 +188,15 @@ defmodule Minga.EditingModel.VimTest do
 
     test "true in operator-pending mode" do
       {_, _, state} = Vim.process_key(Vim.initial_state(), key_d())
+      assert Vim.key_sequence_pending?(state)
+    end
+
+    test "true when prefix_node is set" do
+      state = %Vim{
+        mode: :normal,
+        mode_state: %Mode.State{prefix_node: %Minga.Keymap.Bindings.Node{}}
+      }
+
       assert Vim.key_sequence_pending?(state)
     end
   end

--- a/test/minga/editor/commands/editing_test.exs
+++ b/test/minga/editor/commands/editing_test.exs
@@ -644,4 +644,80 @@ defmodule Minga.Editor.Commands.EditingTest do
       refute String.contains?(content, "\n")
     end
   end
+
+  # ── Paste event (mode-independent) ──────────────────────────────────────
+
+  describe "paste event" do
+    test "paste inserts text in vim normal mode" do
+      {editor, buffer} = start_editor("hello")
+      # Don't enter insert mode, stay in normal
+      send(editor, {:minga_input, {:paste_event, "world"}})
+      _ = :sys.get_state(editor)
+
+      assert String.contains?(BufferServer.content(buffer), "world")
+    end
+
+    test "paste inserts text in vim insert mode" do
+      {editor, buffer} = start_editor("hello")
+      send_key(editor, ?i)
+      send(editor, {:minga_input, {:paste_event, "xyz"}})
+      _ = :sys.get_state(editor)
+
+      assert String.contains?(BufferServer.content(buffer), "xyz")
+    end
+
+    test "paste inserts multiline text" do
+      {editor, buffer} = start_editor("start")
+      send_key(editor, ?i)
+      send(editor, {:minga_input, {:paste_event, "line1\nline2"}})
+      _ = :sys.get_state(editor)
+
+      content = BufferServer.content(buffer)
+      assert String.contains?(content, "line1\nline2")
+    end
+  end
+
+  # ── Autopair without mode gate ──────────────────────────────────────────
+
+  describe "autopair fires regardless of vim mode" do
+    test "insert_char autopairs opening bracket in normal mode context" do
+      # Autopair should fire for any :insert_char command, because the
+      # editing model already decided to produce the command. The executor
+      # doesn't second-guess mode.
+      {:ok, buffer} = BufferServer.start_link(content: "")
+      BufferServer.set_option(buffer, :autopair, true)
+
+      state = %Minga.Editor.State{
+        port_manager: nil,
+        viewport: %Minga.Editor.Viewport{top: 0, left: 0, rows: 10, cols: 40},
+        buffers: %Minga.Editor.State.Buffers{active: buffer, list: [buffer]},
+        vim: Minga.Editor.VimState.new()
+      }
+
+      # Execute insert_char directly (bypasses mode FSM, tests the executor)
+      Minga.Editor.Commands.Editing.execute(state, {:insert_char, "("})
+
+      content = BufferServer.content(buffer)
+      assert content == "()", "autopair should insert closing paren, got: #{inspect(content)}"
+    end
+
+    test "delete_before removes autopair in normal mode context" do
+      {:ok, buffer} = BufferServer.start_link(content: "()")
+      BufferServer.set_option(buffer, :autopair, true)
+      # Place cursor between the parens (line 0, col 1)
+      BufferServer.move_to(buffer, {0, 1})
+
+      state = %Minga.Editor.State{
+        port_manager: nil,
+        viewport: %Minga.Editor.Viewport{top: 0, left: 0, rows: 10, cols: 40},
+        buffers: %Minga.Editor.State.Buffers{active: buffer, list: [buffer]},
+        vim: Minga.Editor.VimState.new()
+      }
+
+      Minga.Editor.Commands.Editing.execute(state, :delete_before)
+
+      content = BufferServer.content(buffer)
+      assert content == "", "autopair should delete both parens, got: #{inspect(content)}"
+    end
+  end
 end

--- a/test/minga/editor/editing_test.exs
+++ b/test/minga/editor/editing_test.exs
@@ -108,6 +108,18 @@ defmodule Minga.Editor.EditingTest do
     test "returns :underline for replace mode" do
       assert Editing.cursor_shape(build_state(mode: :replace)) == :underline
     end
+
+    test "returns :underline when pending_replace is true in normal mode" do
+      ms = %{Mode.initial_state() | pending_replace: true}
+      assert Editing.cursor_shape(build_state(mode: :normal, mode_state: ms)) == :underline
+    end
+
+    test "returns :beam for minibuffer modes" do
+      for mode <- [:command, :search, :eval, :search_prompt] do
+        assert Editing.cursor_shape(build_state(mode: mode)) == :beam,
+               "expected :beam for #{mode}"
+      end
+    end
   end
 
   describe "key_sequence_pending?/1" do
@@ -117,6 +129,11 @@ defmodule Minga.Editor.EditingTest do
 
     test "true when leader_node is set" do
       ms = %{Mode.initial_state() | leader_node: %{children: %{}}}
+      assert Editing.key_sequence_pending?(build_state(mode_state: ms))
+    end
+
+    test "true when prefix_node is set" do
+      ms = %{Mode.initial_state() | prefix_node: %Minga.Keymap.Bindings.Node{}}
       assert Editing.key_sequence_pending?(build_state(mode_state: ms))
     end
   end


### PR DESCRIPTION
## What

Fixes all CUA-mode gaps identified by archie's audit of the Phase A/B/D PR. Establishes a clean architectural rule: **command executors don't check mode; the editing model's command choice IS the decision.**

Related: #306

## The Rule

Two principles govern where mode checks belong:

1. **Command executors honor the model's command choice.** If the model produced `:delete_before`, run autopair. If the model produced `{:insert_char, char}`, run autopair. The command atom is the semantic gate. No `inserting?` check needed.

2. **Dispatch and feature activation query the model's state.** Completions (`was_inserting AND still_inserting`), input routing, cursor shape decisions legitimately need `inserting?/1` or `cursor_shape/1`. These stay.

## Changes

### Autopair (commands/editing.ex)
- Removed mode gate from `:delete_before` and `{:insert_char, char}` executors
- Autopair fires whenever the buffer has `autopair: true`, regardless of editing mode
- Under CUA (always inserting), autopair now works. Under vim, the mode FSM never produces these commands outside insert mode, so behavior is identical.

### Paste (editor.ex)
- Port paste events always accepted when a buffer is active
- Previously blocked in vim normal mode. System paste (Cmd+V) is a user-level gesture that bypasses the editing model; blocking it was wrong.

### Cursor Shape (5 render sites)
- Routed through `Editing.cursor_shape(state)` instead of `Modeline.cursor_shape(state.vim)`
- `EditingModel.Vim.cursor_shape/1` updated to handle `pending_replace: true` (underline) and minibuffer modes (beam for search/command/eval/search_prompt)
- CUA always returns `:beam`

### Completions (completion_handling.ex, router.ex)
- Changed from `old_mode :: atom()` to `was_inserting :: boolean()`
- Router captures `Editing.inserting?(state)` before dispatch
- Under CUA, completions now trigger correctly (was broken because `old_mode` was always `:normal`)

## Tests (13 new)

- `vim_test.exs`: pending_replace cursor, minibuffer mode cursors, visual mode cursors, prefix_node key_sequence_pending
- `editing_test.exs`: facade delegation for pending_replace, minibuffer modes, prefix_node
- `editing_test.exs` (integration): paste in normal mode, paste in insert mode, multiline paste, autopair insert without mode gate, autopair delete without mode gate

## CI Status

- 6664 tests passing (13 new)
- 0 dialyzer errors
- 0 credo issues
- Format clean