### PR TITLE
chore(test): remove redundant field assignments from state helpers

### DIFF
--- a/test/minga/editor/commands/agent_split_test.exs
+++ b/test/minga/editor/commands/agent_split_test.exs
@@ -2,17 +2,14 @@ defmodule Minga.Editor.Commands.AgentSplitTest do
   use ExUnit.Case, async: true
 
   alias Minga.Agent.BufferSync, as: AgentBufferSync
-  alias Minga.Agent.UIState
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.Commands.Agent, as: AgentCommands
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.Buffers
-  alias Minga.Editor.State.FileTree, as: FileTreeState
   alias Minga.Editor.State.Tab
   alias Minga.Editor.State.TabBar
   alias Minga.Editor.Viewport
-  alias Minga.Editor.VimState
   alias Minga.Editor.Window
   alias Minga.Editor.Window.Content
   alias Minga.Test.StubServer
@@ -28,9 +25,7 @@ defmodule Minga.Editor.Commands.AgentSplitTest do
     agent = %AgentState{
       buffer: agent_buf,
       session: fake_session,
-      status: :idle,
-      error: nil,
-      spinner_timer: nil
+      status: :idle
     }
 
     # File tab with context
@@ -73,7 +68,7 @@ defmodule Minga.Editor.Commands.AgentSplitTest do
 
     %EditorState{
       port_manager: self(),
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(24, 80),
       buffers: %Buffers{active: buf, list: [buf]},
       windows: %{
         tree: {:leaf, 1},
@@ -81,12 +76,8 @@ defmodule Minga.Editor.Commands.AgentSplitTest do
         active: 1,
         next_id: 2
       },
-      vim: VimState.new(),
-      keymap_scope: :editor,
       agent: agent,
-      agent_ui: UIState.new(),
-      tab_bar: tb,
-      file_tree: %FileTreeState{}
+      tab_bar: tb
     }
   end
 

--- a/test/minga/editor/commands/clipboard_sync_test.exs
+++ b/test/minga/editor/commands/clipboard_sync_test.exs
@@ -18,9 +18,7 @@ defmodule Minga.Editor.Commands.ClipboardSyncTest do
   alias Minga.Config.Options
   alias Minga.Editor.Commands.Helpers
   alias Minga.Editor.State
-  alias Minga.Editor.State.Registers
   alias Minga.Editor.Viewport
-  alias Minga.Editor.VimState
 
   setup :verify_on_exit!
 
@@ -50,12 +48,7 @@ defmodule Minga.Editor.Commands.ClipboardSyncTest do
   defp make_state do
     %State{
       port_manager: nil,
-      viewport: %Viewport{top: 0, left: 0, rows: 24, cols: 80},
-      vim: %VimState{
-        mode: :normal,
-        mode_state: nil,
-        reg: %Registers{}
-      }
+      viewport: Viewport.new(24, 80)
     }
   end
 

--- a/test/minga/editor/commands/eval_test.exs
+++ b/test/minga/editor/commands/eval_test.exs
@@ -11,7 +11,6 @@ defmodule Minga.Editor.Commands.EvalTest do
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Buffers
   alias Minga.Editor.Viewport
-  alias Minga.Editor.VimState
 
   # ── Test helpers ──────────────────────────────────────────────────────────────
 
@@ -29,8 +28,7 @@ defmodule Minga.Editor.Commands.EvalTest do
   defp build_state(messages_buf \\ nil) do
     %EditorState{
       port_manager: nil,
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
-      vim: VimState.new(),
+      viewport: Viewport.new(24, 80),
       buffers: %Buffers{messages: messages_buf}
     }
   end

--- a/test/minga/editor/commands/help_test.exs
+++ b/test/minga/editor/commands/help_test.exs
@@ -7,7 +7,6 @@ defmodule Minga.Editor.Commands.HelpTest do
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Buffers
   alias Minga.Editor.Viewport
-  alias Minga.Editor.VimState
 
   # ── Test helpers ──────────────────────────────────────────────────────────────
 
@@ -21,8 +20,7 @@ defmodule Minga.Editor.Commands.HelpTest do
 
     %EditorState{
       port_manager: nil,
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
-      vim: VimState.new(),
+      viewport: Viewport.new(24, 80),
       buffers: %Buffers{active: buf, list: [buf]}
     }
   end

--- a/test/minga/editor/editing_test.exs
+++ b/test/minga/editor/editing_test.exs
@@ -27,7 +27,7 @@ defmodule Minga.Editor.EditingTest do
 
     %EditorState{
       port_manager: @port_manager,
-      viewport: %Viewport{top: 0, left: 0, rows: 24, cols: 80},
+      viewport: Viewport.new(24, 80),
       vim: vim
     }
   end

--- a/test/minga/editor/layout_preset_test.exs
+++ b/test/minga/editor/layout_preset_test.exs
@@ -6,7 +6,6 @@ defmodule Minga.Editor.LayoutPresetTest do
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Buffers
   alias Minga.Editor.Viewport
-  alias Minga.Editor.VimState
   alias Minga.Editor.Window
   alias Minga.Editor.Window.Content
 
@@ -16,16 +15,14 @@ defmodule Minga.Editor.LayoutPresetTest do
 
     %EditorState{
       port_manager: self(),
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(24, 80),
       buffers: %Buffers{active: buf, list: [buf]},
       windows: %{
         tree: {:leaf, 1},
         map: %{1 => window},
         active: 1,
         next_id: 2
-      },
-      vim: VimState.new(),
-      keymap_scope: :editor
+      }
     }
   end
 

--- a/test/minga/editor/lsp_actions/rename_test.exs
+++ b/test/minga/editor/lsp_actions/rename_test.exs
@@ -17,7 +17,7 @@ defmodule Minga.Editor.LspActions.RenameTest do
       whichkey: %WhichKey{},
       vim: VimState.new(),
       theme: Minga.Theme.get!(:doom_one),
-      viewport: %Viewport{rows: 40, cols: 120, top: 0, left: 0}
+      viewport: Viewport.new(40, 120)
     }
   end
 

--- a/test/minga/editor/state/event_routing_test.exs
+++ b/test/minga/editor/state/event_routing_test.exs
@@ -7,9 +7,7 @@ defmodule Minga.Editor.State.EventRoutingTest do
   alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.AgentAccess
   alias Minga.Editor.State.{Tab, TabBar}
-  alias Minga.Editor.State.Windows
   alias Minga.Editor.Viewport
-  alias Minga.Editor.VimState
 
   defp make_state(opts \\ []) do
     session = opts[:session] || spawn(fn -> :timer.sleep(:infinity) end)
@@ -20,13 +18,7 @@ defmodule Minga.Editor.State.EventRoutingTest do
       port_manager: self(),
       viewport: Viewport.new(24, 80),
       tab_bar: tb,
-      buffers: %EditorState.Buffers{list: [], active: nil, active_index: 0},
-      windows: %Windows{},
-      vim: VimState.new(),
-      keymap_scope: :editor,
-      agent: %AgentState{session: session, status: :idle},
-      agent_ui: UIState.new(),
-      file_tree: nil
+      agent: %AgentState{session: session, status: :idle}
     }
 
     %{state: state, session: session}

--- a/test/minga/editor/state/snapshot_test.exs
+++ b/test/minga/editor/state/snapshot_test.exs
@@ -6,7 +6,6 @@ defmodule Minga.Editor.State.SnapshotTest do
   alias Minga.Editor.State.Buffers
   alias Minga.Editor.State.Tab
   alias Minga.Editor.State.TabBar
-  alias Minga.Editor.State.Windows
   alias Minga.Editor.Viewport
   alias Minga.Editor.VimState
   alias Minga.Mode
@@ -21,10 +20,8 @@ defmodule Minga.Editor.State.SnapshotTest do
       vim: %VimState{mode: mode, mode_state: Mode.initial_state()},
       buffers: %Buffers{
         active: buf,
-        list: if(buf, do: [buf], else: []),
-        active_index: 0
+        list: if(buf, do: [buf], else: [])
       },
-      windows: %Windows{},
       keymap_scope: Keyword.get(opts, :keymap_scope, :editor),
       tab_bar: Keyword.get(opts, :tab_bar)
     }

--- a/test/minga/input/agent_mouse_test.exs
+++ b/test/minga/input/agent_mouse_test.exs
@@ -41,7 +41,7 @@ defmodule Minga.Input.AgentMouseTest do
 
     %EditorState{
       port_manager: self(),
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(24, 80),
       vim: %VimState{mode: :normal, mode_state: Mode.initial_state()},
       buffers: %Buffers{active: buf, list: [buf]},
       focus_stack: [],

--- a/test/minga/input/agent_nav_test.exs
+++ b/test/minga/input/agent_nav_test.exs
@@ -8,10 +8,8 @@ defmodule Minga.Input.AgentNavTest do
   alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.AgentAccess
   alias Minga.Editor.State.Buffers
-  alias Minga.Editor.State.FileTree, as: FileTreeState
   alias Minga.Editor.State.Windows
   alias Minga.Editor.Viewport
-  alias Minga.Editor.VimState
   alias Minga.Editor.Window
   alias Minga.Input.AgentNav
   @ctrl Minga.Port.Protocol.mod_ctrl()
@@ -31,13 +29,7 @@ defmodule Minga.Input.AgentNavTest do
     {:ok, prompt_buf} = BufferServer.start_link(content: "")
     {:ok, file_buf} = BufferServer.start_link(content: "file content")
 
-    agent = %AgentState{
-      buffer: buf,
-      session: nil,
-      status: :idle,
-      error: nil,
-      spinner_timer: nil
-    }
+    agent = %AgentState{buffer: buf, status: :idle}
 
     agentic = %UIState{
       panel: %UIState.Panel{
@@ -58,16 +50,11 @@ defmodule Minga.Input.AgentNavTest do
 
     %EditorState{
       port_manager: self(),
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(24, 80),
       agent: agent,
       agent_ui: agentic,
       buffers: %Buffers{active: file_buf, list: [file_buf]},
-      vim: VimState.new(),
-      status_msg: nil,
-      file_tree: %FileTreeState{},
-      completion: nil,
-      keymap_scope: :agent,
-      focus_stack: []
+      keymap_scope: :agent
     }
   end
 
@@ -133,7 +120,7 @@ defmodule Minga.Input.AgentNavTest do
         buffer: buf,
         content: {:agent_chat, buf},
         cursor: {0, 0},
-        viewport: %Viewport{rows: 20, cols: 80, top: 0, left: 0},
+        viewport: Viewport.new(20, 80),
         pinned: true
       }
 

--- a/test/minga/input/agent_panel_nav_test.exs
+++ b/test/minga/input/agent_panel_nav_test.exs
@@ -20,9 +20,7 @@ defmodule Minga.Input.AgentPanelNavTest do
     end)
   end
 
-  alias Minga.Editor.State.FileTree, as: FileTreeState
   alias Minga.Editor.Viewport
-  alias Minga.Editor.VimState
   alias Minga.Input.Scoped
 
   defp make_state do
@@ -36,13 +34,7 @@ defmodule Minga.Input.AgentPanelNavTest do
 
     {:ok, prompt_buf} = BufferServer.start_link(content: "")
 
-    agent = %AgentState{
-      buffer: buf,
-      session: nil,
-      status: :idle,
-      error: nil,
-      spinner_timer: nil
-    }
+    agent = %AgentState{buffer: buf, status: :idle}
 
     base = UIState.new()
 
@@ -53,15 +45,9 @@ defmodule Minga.Input.AgentPanelNavTest do
 
     %EditorState{
       port_manager: self(),
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(24, 80),
       agent: agent,
       agent_ui: agentic,
-      buffers: %{active: nil, list: [], recent: []},
-      vim: VimState.new(),
-      status_msg: nil,
-      file_tree: %FileTreeState{},
-      completion: nil,
-      keymap_scope: :editor,
       focus_stack: [Scoped, Minga.Input.ModeFSM]
     }
   end

--- a/test/minga/input/completion_mouse_test.exs
+++ b/test/minga/input/completion_mouse_test.exs
@@ -16,7 +16,7 @@ defmodule Minga.Input.CompletionMouseTest do
     %EditorState{
       port_manager: nil,
       vim: %VimState{mode: :insert, mode_state: Mode.initial_state()},
-      viewport: %Viewport{rows: 30, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(30, 80),
       completion: completion
     }
   end
@@ -52,7 +52,7 @@ defmodule Minga.Input.CompletionMouseTest do
       state = %EditorState{
         port_manager: nil,
         vim: %VimState{mode: :normal, mode_state: Mode.initial_state()},
-        viewport: %Viewport{rows: 30, cols: 80, top: 0, left: 0},
+        viewport: Viewport.new(30, 80),
         completion: nil
       }
 

--- a/test/minga/input/file_tree_nav_test.exs
+++ b/test/minga/input/file_tree_nav_test.exs
@@ -3,13 +3,10 @@ defmodule Minga.Input.FileTreeNavTest do
 
   @moduletag :tmp_dir
 
-  alias Minga.Agent.UIState
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.State, as: EditorState
-  alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.FileTree, as: FileTreeState
   alias Minga.Editor.Viewport
-  alias Minga.Editor.VimState
   alias Minga.FileTree
   alias Minga.FileTree.BufferSync
   alias Minga.Input.FileTreeHandler
@@ -33,19 +30,10 @@ defmodule Minga.Input.FileTreeNavTest do
     tree = FileTree.new(tmp_dir)
     buf = BufferSync.start_buffer(tree)
 
-    agent = %AgentState{}
-    agentic = %UIState{}
-
     %EditorState{
       port_manager: self(),
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(24, 80),
       file_tree: %FileTreeState{tree: tree, focused: true, buffer: buf},
-      buffers: %{active: nil, list: [], recent: []},
-      vim: VimState.new(),
-      status_msg: nil,
-      agent: agent,
-      agent_ui: agentic,
-      completion: nil,
       keymap_scope: :file_tree,
       focus_stack: [Scoped, Minga.Input.ModeFSM]
     }

--- a/test/minga/input/picker_mouse_test.exs
+++ b/test/minga/input/picker_mouse_test.exs
@@ -29,7 +29,7 @@ defmodule Minga.Input.PickerMouseTest do
     %EditorState{
       port_manager: nil,
       vim: VimState.new(),
-      viewport: %Viewport{rows: 30, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(30, 80),
       picker_ui: %Minga.Editor.State.Picker{picker: picker, source: TestSource}
     }
   end
@@ -84,7 +84,7 @@ defmodule Minga.Input.PickerMouseTest do
       %EditorState{
         port_manager: nil,
         vim: VimState.new(),
-        viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+        viewport: Viewport.new(24, 80),
         picker_ui: %Minga.Editor.State.Picker{
           picker: picker,
           source: TestSource,
@@ -134,7 +134,7 @@ defmodule Minga.Input.PickerMouseTest do
       state = %EditorState{
         port_manager: nil,
         vim: VimState.new(),
-        viewport: %Viewport{rows: 30, cols: 80, top: 0, left: 0}
+        viewport: Viewport.new(30, 80)
       }
 
       {:passthrough, ^state} = PickerInput.handle_mouse(state, 10, 10, :left, 0, :press, 1)

--- a/test/minga/input/popup_test.exs
+++ b/test/minga/input/popup_test.exs
@@ -34,7 +34,7 @@ defmodule Minga.Input.PopupTest do
 
     %EditorState{
       port_manager: nil,
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(24, 80),
       vim: vim,
       buffers: %Buffers{active: main_buf, list: [main_buf]},
       windows: %Windows{
@@ -52,8 +52,7 @@ defmodule Minga.Input.PopupTest do
 
     %EditorState{
       port_manager: nil,
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
-      vim: VimState.new(),
+      viewport: Viewport.new(24, 80),
       buffers: %Buffers{active: main_buf, list: [main_buf]},
       windows: %Windows{
         tree: WindowTree.new(1),
@@ -138,8 +137,7 @@ defmodule Minga.Input.PopupTest do
 
       %EditorState{
         port_manager: nil,
-        viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
-        vim: VimState.new(),
+        viewport: Viewport.new(24, 80),
         buffers: %Buffers{active: main_buf, list: [main_buf]},
         windows: %Windows{
           tree: WindowTree.new(1),

--- a/test/minga/input/scoped_test.exs
+++ b/test/minga/input/scoped_test.exs
@@ -30,10 +30,7 @@ defmodule Minga.Input.ScopedTest do
     {:ok, prompt_buf} = BufferServer.start_link(content: "")
 
     agent = %AgentState{
-      session: nil,
       status: :idle,
-      error: nil,
-      spinner_timer: nil,
       buffer: Keyword.get(opts, :agent_buffer, nil)
     }
 
@@ -63,10 +60,9 @@ defmodule Minga.Input.ScopedTest do
 
     %EditorState{
       port_manager: self(),
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(24, 80),
       vim: %VimState{mode: mode, mode_state: Mode.initial_state()},
       buffers: %Buffers{active: buf, list: [buf]},
-      focus_stack: [],
       keymap_scope: Keyword.get(opts, :keymap_scope, :editor),
       agent: agent,
       agent_ui: agentic,

--- a/test/minga/input/sub_state_handlers_test.exs
+++ b/test/minga/input/sub_state_handlers_test.exs
@@ -65,7 +65,7 @@ defmodule Minga.Input.SubStateHandlersTest do
 
     %EditorState{
       port_manager: self(),
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(24, 80),
       vim: VimState.new(),
       buffers: %Buffers{active: buf, list: [buf]},
       focus_stack: [],

--- a/test/minga/input/vim_nav_integration_test.exs
+++ b/test/minga/input/vim_nav_integration_test.exs
@@ -12,13 +12,10 @@ defmodule Minga.Input.VimNavIntegrationTest do
 
   @moduletag :tmp_dir
 
-  alias Minga.Agent.UIState
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.State, as: EditorState
-  alias Minga.Editor.State.Agent, as: AgentState
   alias Minga.Editor.State.FileTree, as: FileTreeState
   alias Minga.Editor.Viewport
-  alias Minga.Editor.VimState
   alias Minga.FileTree
   alias Minga.FileTree.BufferSync
 
@@ -45,19 +42,10 @@ defmodule Minga.Input.VimNavIntegrationTest do
     tree = FileTree.new(tmp_dir)
     buf = BufferSync.start_buffer(tree)
 
-    agent = %AgentState{}
-    agentic = %UIState{}
-
     %EditorState{
       port_manager: self(),
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(24, 80),
       file_tree: %FileTreeState{tree: tree, focused: true, buffer: buf},
-      buffers: %{active: nil, list: [], recent: []},
-      vim: VimState.new(),
-      status_msg: nil,
-      agent: agent,
-      agent_ui: agentic,
-      completion: nil,
       keymap_scope: :file_tree,
       focus_stack: [Scoped, Minga.Input.ModeFSM]
     }

--- a/test/minga/picker/command_source_test.exs
+++ b/test/minga/picker/command_source_test.exs
@@ -32,7 +32,7 @@ defmodule Minga.Picker.CommandSourceTest do
 
       state = %EditorState{
         port_manager: nil,
-        viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+        viewport: Viewport.new(24, 80),
         buffers: %Buffers{active: buf, list: [buf], active_index: 0},
         picker_ui: %PickerState{},
         vim: VimState.new()

--- a/test/minga/popup/lifecycle_test.exs
+++ b/test/minga/popup/lifecycle_test.exs
@@ -43,7 +43,7 @@ defmodule Minga.Popup.LifecycleTest do
 
     state = %EditorState{
       port_manager: nil,
-      viewport: %Viewport{rows: 24, cols: 80, top: 0, left: 0},
+      viewport: Viewport.new(24, 80),
       vim: VimState.new(),
       buffers: %Buffers{active: main_buf, list: [main_buf]},
       windows: %Windows{


### PR DESCRIPTION
## Summary

Remove fields that match `defstruct` defaults from test `make_state`/`build_state`/`new_state` helpers across 21 test files. This reduces visual noise without changing behavior.

## Changes

- **Remove redundant EditorState fields:** `status_msg: nil`, `completion: nil`, `file_tree: %FileTreeState{}`, `vim: VimState.new()`, `keymap_scope: :editor`, `focus_stack: []`, `windows: %Windows{}`, `agent_ui: UIState.new()`
- **Remove redundant AgentState fields:** `session: nil`, `error: nil`, `spinner_timer: nil`
- **Replace verbose Viewport literals** with `Viewport.new(R, C)` (17 instances)
- **Remove unused aliases** that were only needed for the removed fields

## Why not a factory?

Consulted the test-advisor agent. The recommendation was to keep per-file private helpers because:
1. The duplication is shallow (3-line common core)
2. The interesting parts diverge intentionally across test categories
3. EditorState changes frequently, so a centralized factory would be a maintenance burden
4. Several helpers start real processes, which couples badly with factory patterns

This cleanup addresses the real issue (redundant noise) without the indirection cost of a factory.

## Verification

- `mix lint` passes (format + credo + compile + dialyzer)
- `mix test.llm` passes: 6708 tests, 0 failures
- Net: **-91 lines** across 21 files