### PR TITLE
refactor(editor): move workspace operations to Workspace module (Phase E)

### DIFF
--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -53,6 +53,7 @@ defmodule Minga.Editor.State do
   alias Minga.Panel.MessageStore
   alias Minga.Port.Capabilities
   alias Minga.Tool.Manager, as: ToolManager
+  alias Minga.Workspace
   alias Minga.Workspace.State, as: WorkspaceState
 
   @typedoc "Line number display style."
@@ -266,44 +267,17 @@ defmodule Minga.Editor.State do
   monitor ref.
   """
   @spec remove_dead_buffer(t(), pid()) :: t()
-  def remove_dead_buffer(
-        %__MODULE__{workspace: %{buffers: %Buffers{} = bs} = ws, buffer_monitors: monitors} =
-          state,
-        pid
-      ) do
-    # Clean up monitor ref
+  def remove_dead_buffer(%__MODULE__{buffer_monitors: monitors} = state, pid) do
+    # Clean up monitor ref (EditorState concern)
     monitors = Map.delete(monitors, pid)
 
-    # Remove from buffer list
-    new_list = Enum.reject(bs.list, &(&1 == pid))
+    # Delegate workspace buffer cleanup to Workspace (pure calculation)
+    updated_ws = Workspace.remove_dead_buffer(state.workspace, pid)
 
-    # Clear special buffer slots if they match
-    messages = if bs.messages == pid, do: nil, else: bs.messages
-    help = if bs.help == pid, do: nil, else: bs.help
-
-    # Determine new active buffer
-    {new_active, new_index} =
-      case new_list do
-        [] ->
-          {nil, 0}
-
-        _ ->
-          new_index = min(bs.active_index, length(new_list) - 1)
-          {Enum.at(new_list, new_index), new_index}
-      end
-
-    new_bs = %Buffers{
-      bs
-      | list: new_list,
-        active: new_active,
-        active_index: new_index,
-        messages: messages,
-        help: help
-    }
-
-    state = %{state | workspace: %{ws | buffers: new_bs}, buffer_monitors: monitors}
+    state = %{state | workspace: updated_ws, buffer_monitors: monitors}
 
     # Clear agent buffer or prompt buffer if the dead pid matches
+    # (EditorState concern: agent state is global, not per-workspace)
     state =
       if state.agent != nil and state.agent.buffer == pid do
         AgentAccess.update_agent(state, fn a -> %{a | buffer: nil} end)
@@ -311,14 +285,11 @@ defmodule Minga.Editor.State do
         state
       end
 
-    state =
-      if state.workspace.agent_ui != nil and state.workspace.agent_ui.panel.prompt_buffer == pid do
-        AgentAccess.update_panel(state, fn p -> %{p | prompt_buffer: nil} end)
-      else
-        state
-      end
-
-    sync_active_window_buffer(state)
+    if state.workspace.agent_ui != nil and state.workspace.agent_ui.panel.prompt_buffer == pid do
+      AgentAccess.update_panel(state, fn p -> %{p | prompt_buffer: nil} end)
+    else
+      state
+    end
   end
 
   # ── Active content context ───────────────────────────────────────────────────
@@ -402,21 +373,21 @@ defmodule Minga.Editor.State do
   end
 
   # ── Window delegates ────────────────────────────────────────────────────────
-  # Pure window-only logic lives in `Windows`. These delegators keep the
-  # call-site API stable so callers pass the full editor state.
+  # Pure window logic lives in `Minga.Workspace`. These delegates unwrap
+  # the workspace, call the calculation, and rewrap the result.
 
   @doc "Returns the active window struct, or nil if windows aren't initialized."
   @spec active_window_struct(t()) :: Window.t() | nil
-  def active_window_struct(%__MODULE__{workspace: %{windows: ws}}), do: Windows.active_struct(ws)
+  def active_window_struct(%__MODULE__{workspace: ws}), do: Workspace.active_window_struct(ws)
 
   @doc "Returns true if the editor has more than one window."
   @spec split?(t()) :: boolean()
-  def split?(%__MODULE__{workspace: %{windows: ws}}), do: Windows.split?(ws)
+  def split?(%__MODULE__{workspace: ws}), do: Workspace.split?(ws)
 
   @doc "Updates the window struct for the given window id via a mapper function."
   @spec update_window(t(), Window.id(), (Window.t() -> Window.t())) :: t()
-  def update_window(%__MODULE__{workspace: %{windows: ws} = wks} = state, id, fun) do
-    %{state | workspace: %{wks | windows: Windows.update(ws, id, fun)}}
+  def update_window(%__MODULE__{workspace: ws} = state, id, fun) do
+    %{state | workspace: Workspace.update_window(ws, id, fun)}
   end
 
   @doc """
@@ -427,11 +398,8 @@ defmodule Minga.Editor.State do
   wrong when column offsets shift.
   """
   @spec invalidate_all_windows(t()) :: t()
-  def invalidate_all_windows(%__MODULE__{workspace: %{windows: ws} = wks} = state) do
-    new_map =
-      Map.new(ws.map, fn {id, window} -> {id, Window.invalidate(window)} end)
-
-    %{state | workspace: %{wks | windows: %{ws | map: new_map}}}
+  def invalidate_all_windows(%__MODULE__{workspace: ws} = state) do
+    %{state | workspace: Workspace.invalidate_all_windows(ws)}
   end
 
   @doc """
@@ -441,11 +409,8 @@ defmodule Minga.Editor.State do
   viewport).
   """
   @spec active_window_viewport(t()) :: Viewport.t()
-  def active_window_viewport(%__MODULE__{} = state) do
-    case active_window_struct(state) do
-      nil -> state.workspace.viewport
-      %Window{viewport: vp} -> vp
-    end
+  def active_window_viewport(%__MODULE__{workspace: ws}) do
+    Workspace.active_window_viewport(ws)
   end
 
   @doc """
@@ -453,14 +418,8 @@ defmodule Minga.Editor.State do
   `state.workspace.viewport` when no window is active.
   """
   @spec put_active_window_viewport(t(), Viewport.t()) :: t()
-  def put_active_window_viewport(%__MODULE__{} = state, new_vp) do
-    case active_window_struct(state) do
-      nil ->
-        update_workspace(state, fn ws -> %{ws | viewport: new_vp} end)
-
-      %Window{id: win_id} ->
-        update_window(state, win_id, fn w -> %{w | viewport: new_vp} end)
-    end
+  def put_active_window_viewport(%__MODULE__{workspace: ws} = state, new_vp) do
+    %{state | workspace: Workspace.put_active_window_viewport(ws, new_vp)}
   end
 
   @doc """
@@ -469,29 +428,29 @@ defmodule Minga.Editor.State do
   Returns `{win_id, window}` or `nil` if no agent chat window exists.
   """
   @spec find_agent_chat_window(t()) :: {Window.id(), Window.t()} | nil
-  def find_agent_chat_window(%__MODULE__{workspace: %{windows: ws}}) do
-    Enum.find_value(ws.map, fn
-      {win_id, %Window{content: {:agent_chat, _}} = window} -> {win_id, window}
-      _ -> nil
-    end)
+  def find_agent_chat_window(%__MODULE__{workspace: ws}) do
+    Workspace.find_agent_chat_window(ws)
   end
 
   @doc """
   Scrolls the agent chat window's viewport by `delta` lines and updates
-  pinned state. Delegates to `Window.scroll_viewport/3`.
+  pinned state.
 
-  Returns the state unchanged if no agent chat window exists.
+  Note: This is an action delegate (calls BufferServer.line_count).
   """
   @spec scroll_agent_chat_window(t(), integer()) :: t()
   def scroll_agent_chat_window(%__MODULE__{} = state, delta) do
-    case find_agent_chat_window(state) do
+    case Workspace.find_agent_chat_window(state.workspace) do
       nil ->
         state
 
-      {win_id, window} ->
+      {_win_id, window} ->
         total_lines = BufferServer.line_count(window.buffer)
-        updated = Window.scroll_viewport(window, delta, total_lines)
-        update_window(state, win_id, fn _ -> updated end)
+
+        %{
+          state
+          | workspace: Workspace.scroll_agent_chat_window(state.workspace, delta, total_lines)
+        }
     end
   end
 
@@ -532,42 +491,11 @@ defmodule Minga.Editor.State do
   @doc """
   Syncs the active window's buffer reference with `state.workspace.buffers.active`.
 
-  Call this after any operation that changes `state.workspace.buffers.active` to keep the
-  window tree consistent. No-op when windows aren't initialized.
+  Delegates to `Workspace.sync_active_window_buffer/1`.
   """
   @spec sync_active_window_buffer(t()) :: t()
-  def sync_active_window_buffer(%__MODULE__{workspace: %{buffers: %{active: nil}}} = state),
-    do: state
-
-  def sync_active_window_buffer(
-        %__MODULE__{
-          workspace:
-            %{windows: %{map: windows, active: id} = wins, buffers: buffers} = wks
-        } = state
-      ) do
-    case Map.fetch(windows, id) do
-      {:ok, %Window{buffer: existing} = window} when existing != buffers.active ->
-        # Buffer changed: invalidate all caches. The new buffer has
-        # different content, and cached draws from the old buffer are
-        # completely wrong. Also reset tracking fields so
-        # detect_invalidation forces a full redraw on the next frame.
-        #
-        # Both `buffer` and `content` must be updated. The render
-        # pipeline checks `Content.agent_chat?(window.content)` to
-        # decide rendering paths, so a stale content tag causes the
-        # window to be routed to the wrong renderer (e.g., blank
-        # screen when opening a file from the agent tab).
-        window = %{
-          Window.invalidate(window)
-          | buffer: buffers.active,
-            content: Content.buffer(buffers.active)
-        }
-
-        %{state | workspace: %{wks | windows: %{wins | map: Map.put(windows, id, window)}}}
-
-      _ ->
-        state
-    end
+  def sync_active_window_buffer(%__MODULE__{workspace: ws} = state) do
+    %{state | workspace: Workspace.sync_active_window_buffer(ws)}
   end
 
   @doc """
@@ -581,7 +509,7 @@ defmodule Minga.Editor.State do
   dedicated file tab.
   """
   @spec add_buffer(t(), pid()) :: t()
-  def add_buffer(%__MODULE__{workspace: %{buffers: bs} = wks, tab_bar: %TabBar{} = tb} = state, pid) do
+  def add_buffer(%__MODULE__{tab_bar: %TabBar{} = tb} = state, pid) do
     label = buffer_label(pid)
     active_tab = TabBar.active(tb)
 
@@ -589,8 +517,9 @@ defmodule Minga.Editor.State do
       "[tab] add_buffer label=#{label} tab=#{tb.active_id} kind=#{active_tab.kind}"
     end)
 
-    # Add the buffer to the pool (Buffers.add auto-activates it)
-    state = %{state | workspace: %{wks | buffers: Buffers.add(bs, pid)}}
+    # Add the buffer to the workspace (Workspace.add_buffer handles
+    # Buffers.add + window sync as a pure calculation)
+    state = %{state | workspace: Workspace.add_buffer(state.workspace, pid)}
     state = monitor_buffer(state, pid)
 
     # Check if a tab for this buffer already exists (by label match).
@@ -610,10 +539,9 @@ defmodule Minga.Editor.State do
     end
   end
 
-  def add_buffer(%__MODULE__{workspace: %{buffers: bs} = wks} = state, pid) do
-    %{state | workspace: %{wks | buffers: Buffers.add(bs, pid)}}
+  def add_buffer(%__MODULE__{} = state, pid) do
+    %{state | workspace: Workspace.add_buffer(state.workspace, pid)}
     |> monitor_buffer(pid)
-    |> sync_active_window_buffer()
   end
 
   # Creates a new file tab from a file tab context. Snapshots the current
@@ -707,9 +635,8 @@ defmodule Minga.Editor.State do
   remember to call `sync_active_window_buffer/1`.
   """
   @spec switch_buffer(t(), non_neg_integer()) :: t()
-  def switch_buffer(%__MODULE__{workspace: %{buffers: bs} = wks} = state, idx) do
-    state = %{state | workspace: %{wks | buffers: Buffers.switch_to(bs, idx)}}
-    state = sync_active_window_buffer(state)
+  def switch_buffer(%__MODULE__{workspace: ws} = state, idx) do
+    state = %{state | workspace: Workspace.switch_buffer(ws, idx)}
     sync_active_tab_label(state)
   end
 
@@ -718,29 +645,17 @@ defmodule Minga.Editor.State do
 
   Call this before rendering split views so inactive windows have a fresh
   cursor position for the active window when it becomes inactive later.
+
+  This is an action delegate: fetches the cursor from BufferServer, then
+  delegates to `Workspace.sync_active_window_cursor/2`.
   """
   @spec sync_active_window_cursor(t()) :: t()
   def sync_active_window_cursor(%__MODULE__{workspace: %{buffers: %{active: nil}}} = state),
     do: state
 
-  def sync_active_window_cursor(
-        %__MODULE__{
-          workspace:
-            %{windows: %{map: windows, active: id} = wins, buffers: %{active: buf}} = wks
-        } = state
-      ) do
-    case Map.fetch(windows, id) do
-      {:ok, window} ->
-        cursor = BufferServer.cursor(buf)
-
-        %{
-          state
-          | workspace: %{wks | windows: %{wins | map: Map.put(windows, id, %{window | cursor: cursor})}}
-        }
-
-      :error ->
-        state
-    end
+  def sync_active_window_cursor(%__MODULE__{workspace: %{buffers: %{active: buf}} = ws} = state) do
+    cursor = BufferServer.cursor(buf)
+    %{state | workspace: Workspace.sync_active_window_cursor(ws, cursor)}
   catch
     :exit, _ -> state
   end
@@ -749,81 +664,52 @@ defmodule Minga.Editor.State do
   Switches focus to the given window, saving the current cursor to the
   outgoing window and restoring the target window's stored cursor.
 
+  This is an action delegate: fetches the current cursor from BufferServer,
+  calls `Workspace.focus_window/3` (pure calculation), then executes
+  `BufferServer.move_to/2` as a side effect.
+
   No-op if `target_id` is already the active window or windows aren't set up.
   """
   @spec focus_window(t(), Window.id()) :: t()
-  def focus_window(%__MODULE__{workspace: %{windows: %{active: active}}} = state, target_id)
-      when target_id == active,
-      do: state
+  def focus_window(%__MODULE__{workspace: ws} = state, target_id) do
+    # Fetch current cursor (side effect) before the pure calculation
+    current_cursor =
+      case ws.buffers.active do
+        nil -> {0, 0}
+        buf -> BufferServer.cursor(buf)
+      end
 
-  def focus_window(%__MODULE__{workspace: %{buffers: %{active: nil}}} = state, _target_id),
-    do: state
-
-  def focus_window(
-        %__MODULE__{
-          workspace:
-            %{
-              windows: %{map: windows, active: old_id} = wins,
-              buffers: buffers,
-              keymap_scope: current_scope
-            } = wks
-        } = state,
-        target_id
-      ) do
-    case {Map.fetch(windows, old_id), Map.fetch(windows, target_id)} do
-      {{:ok, old_win}, {:ok, target_win}} ->
-        # Save current cursor to outgoing window
-        current_cursor = BufferServer.cursor(buffers.active)
-        windows = Map.put(windows, old_id, %{old_win | cursor: current_cursor})
-
-        # Restore target window's cursor into its buffer
-        BufferServer.move_to(target_win.buffer, target_win.cursor)
-
-        # Derive keymap_scope from the target window's content type.
-        # Agent chat windows use :agent scope; buffer windows use the
-        # current scope (preserving :file_tree if the tree is focused).
-        scope = scope_for_content(target_win.content, current_scope)
-
-        %{
-          state
-          | workspace: %{
-              wks
-              | windows: %{wins | map: windows, active: target_id},
-                buffers: %{buffers | active: target_win.buffer},
-                keymap_scope: scope
-            }
-        }
-
-      _ ->
+    case Workspace.focus_window(ws, target_id, current_cursor) do
+      {^ws, nil} ->
         state
+
+      {updated_ws, target_cursor} ->
+        # Restore target window's cursor into its buffer (side effect)
+        if target_cursor do
+          BufferServer.move_to(updated_ws.buffers.active, target_cursor)
+        end
+
+        %{state | workspace: updated_ws}
     end
   end
 
   @doc """
   Derives the keymap scope from a window's content type.
 
-  Agent chat windows always use `:agent` scope. Buffer windows use
-  `:editor` when coming from `:agent` scope, and preserve the current
-  scope otherwise (e.g., `:file_tree` stays as `:file_tree`).
+  Delegates to `Workspace.scope_for_content/2`.
   """
   @spec scope_for_content(Content.t(), Minga.Keymap.Scope.scope_name()) ::
           Minga.Keymap.Scope.scope_name()
-  def scope_for_content({:agent_chat, _pid}, _current_scope), do: :agent
-  def scope_for_content({:buffer, _pid}, current_scope) when current_scope == :agent, do: :editor
-  def scope_for_content({:buffer, _pid}, current_scope), do: current_scope
+  defdelegate scope_for_content(content, current_scope), to: Workspace
 
   @doc """
   Returns the appropriate keymap scope for the active window's content type.
 
-  Used when leaving the file tree (toggle, close, navigate right) to restore
-  the correct scope. Returns :agent for agent chat windows, :editor otherwise.
+  Delegates to `Workspace.scope_for_active_window/1`.
   """
   @spec scope_for_active_window(t()) :: atom()
-  def scope_for_active_window(%__MODULE__{workspace: %{windows: %{map: map, active: active_id}}}) do
-    case Map.get(map, active_id) do
-      %{content: content} -> scope_for_content(content, :editor)
-      nil -> :editor
-    end
+  def scope_for_active_window(%__MODULE__{workspace: ws}) do
+    Workspace.scope_for_active_window(ws)
   end
 
   @spec buffer_label(pid()) :: String.t()
@@ -1309,8 +1195,8 @@ defmodule Minga.Editor.State do
       EditorState.transition_mode(state, :visual, %VisualState{...})
   """
   @spec transition_mode(t(), Mode.mode(), Mode.state() | nil) :: t()
-  def transition_mode(%__MODULE__{workspace: wks} = state, mode, mode_state \\ nil) do
-    %{state | workspace: %{wks | vim: VimState.transition(wks.vim, mode, mode_state)}}
+  def transition_mode(%__MODULE__{workspace: ws} = state, mode, mode_state \\ nil) do
+    %{state | workspace: Workspace.transition_mode(ws, mode, mode_state)}
   end
 
   # ── Tool prompt helpers ──────────────────────────────────────────────────────

--- a/lib/minga/editor/state/agent_access.ex
+++ b/lib/minga/editor/state/agent_access.ex
@@ -32,20 +32,17 @@ defmodule Minga.Editor.State.AgentAccess do
   @doc "Returns the full agent UI state (wrapping Panel and View)."
   @spec agent_ui(EditorState.t() | map()) :: UIState.t()
   def agent_ui(%EditorState{workspace: %{agent_ui: a}}), do: a
-  def agent_ui(%EditorState{workspace: %{agent_ui: a}}), do: a
   def agent_ui(%{agent_ui: a}), do: a
   def agent_ui(_), do: UIState.new()
 
   @doc "Returns the agent panel state (prompt editing and chat display)."
   @spec panel(EditorState.t() | map()) :: Panel.t()
   def panel(%EditorState{workspace: %{agent_ui: %UIState{panel: p}}}), do: p
-  def panel(%EditorState{workspace: %{agent_ui: %UIState{panel: p}}}), do: p
   def panel(%{agent_ui: %UIState{panel: p}}), do: p
   def panel(_), do: Panel.new()
 
   @doc "Returns the agent view state (layout, search, preview, toasts)."
   @spec view(EditorState.t() | map()) :: View.t()
-  def view(%EditorState{workspace: %{agent_ui: %UIState{view: v}}}), do: v
   def view(%EditorState{workspace: %{agent_ui: %UIState{view: v}}}), do: v
   def view(%{agent_ui: %UIState{view: v}}), do: v
   def view(_), do: View.new()
@@ -83,10 +80,6 @@ defmodule Minga.Editor.State.AgentAccess do
     %{state | workspace: %{ws | agent_ui: fun.(a)}}
   end
 
-  def update_agent_ui(%EditorState{workspace: %{agent_ui: a} = ws} = state, fun) do
-    %{state | workspace: %{ws | agent_ui: fun.(a)}}
-  end
-
   def update_agent_ui(%{agent_ui: a} = state, fun) do
     %{state | agent_ui: fun.(a)}
   end
@@ -94,11 +87,10 @@ defmodule Minga.Editor.State.AgentAccess do
   @doc "Updates just the panel sub-struct via a transform function."
   @spec update_panel(EditorState.t() | map(), (Panel.t() -> Panel.t())) ::
           EditorState.t() | map()
-  def update_panel(%EditorState{workspace: %{agent_ui: %UIState{panel: p} = ui} = ws} = state, fun) do
-    %{state | workspace: %{ws | agent_ui: %{ui | panel: fun.(p)}}}
-  end
-
-  def update_panel(%EditorState{workspace: %{agent_ui: %UIState{panel: p} = ui} = ws} = state, fun) do
+  def update_panel(
+        %EditorState{workspace: %{agent_ui: %UIState{panel: p} = ui} = ws} = state,
+        fun
+      ) do
     %{state | workspace: %{ws | agent_ui: %{ui | panel: fun.(p)}}}
   end
 
@@ -109,10 +101,6 @@ defmodule Minga.Editor.State.AgentAccess do
   @doc "Updates just the view sub-struct via a transform function."
   @spec update_view(EditorState.t() | map(), (View.t() -> View.t())) ::
           EditorState.t() | map()
-  def update_view(%EditorState{workspace: %{agent_ui: %UIState{view: v} = ui} = ws} = state, fun) do
-    %{state | workspace: %{ws | agent_ui: %{ui | view: fun.(v)}}}
-  end
-
   def update_view(%EditorState{workspace: %{agent_ui: %UIState{view: v} = ui} = ws} = state, fun) do
     %{state | workspace: %{ws | agent_ui: %{ui | view: fun.(v)}}}
   end

--- a/lib/minga/picker/buffer_source.ex
+++ b/lib/minga/picker/buffer_source.ex
@@ -127,9 +127,9 @@ defmodule Minga.Picker.BufferSource do
       _ ->
         new_active = min(bs.active_index, length(new_buffers) - 1)
         new_bs = %Buffers{bs | list: new_buffers}
+        updated_ws = %{state.workspace | buffers: Buffers.switch_to(new_bs, new_active)}
 
-        %{state | workspace: %{state.workspace | buffers: Buffers.switch_to(new_bs, new_active)}}
-        |> EditorState.sync_active_window_buffer()
+        %{state | workspace: Minga.Workspace.sync_active_window_buffer(updated_ws)}
     end
   end
 

--- a/lib/minga/workspace.ex
+++ b/lib/minga/workspace.ex
@@ -1,0 +1,345 @@
+defmodule Minga.Workspace do
+  @moduledoc """
+  Pure calculation functions on `Workspace.State`.
+
+  Every function in this module is a calculation: it takes a
+  `WorkspaceState.t()` (and possibly extra arguments), returns an
+  updated `WorkspaceState.t()` (or a derived value), and never calls
+  a GenServer, monitors a process, or produces side effects.
+
+  The `Minga.Editor.State` module is the action layer that fetches
+  external data (e.g., `BufferServer.cursor/1`), calls these
+  calculations, and then executes side effects (e.g.,
+  `BufferServer.move_to/2`, `Process.monitor/1`).
+
+  ## Moved from EditorState
+
+  These functions previously lived in `Minga.Editor.State` and
+  operated on the full `EditorState.t()`. They now operate on
+  `WorkspaceState.t()` only. EditorState retains thin delegates
+  that unwrap/rewrap the workspace.
+  """
+
+  alias Minga.Editor.State.Buffers
+  alias Minga.Editor.State.Windows
+  alias Minga.Editor.VimState
+  alias Minga.Editor.Viewport
+  alias Minga.Editor.Window
+  alias Minga.Editor.Window.Content
+  alias Minga.Mode
+  alias Minga.Workspace.State, as: WorkspaceState
+
+  # ── Window operations (pure) ─────────────────────────────────────────────
+
+  @doc "Returns the active window struct, or nil if windows aren't initialized."
+  @spec active_window_struct(WorkspaceState.t()) :: Window.t() | nil
+  def active_window_struct(%WorkspaceState{windows: ws}), do: Windows.active_struct(ws)
+
+  @doc "Returns true if the editor has more than one window."
+  @spec split?(WorkspaceState.t()) :: boolean()
+  def split?(%WorkspaceState{windows: ws}), do: Windows.split?(ws)
+
+  @doc "Updates the window struct for the given window id via a mapper function."
+  @spec update_window(WorkspaceState.t(), Window.id(), (Window.t() -> Window.t())) ::
+          WorkspaceState.t()
+  def update_window(%WorkspaceState{windows: ws} = wks, id, fun) do
+    %{wks | windows: Windows.update(ws, id, fun)}
+  end
+
+  @doc """
+  Invalidates render caches for all windows.
+
+  Call when the screen layout changes (file tree toggle, agent panel toggle)
+  because cached draws contain baked-in absolute coordinates that become
+  wrong when column offsets shift.
+  """
+  @spec invalidate_all_windows(WorkspaceState.t()) :: WorkspaceState.t()
+  def invalidate_all_windows(%WorkspaceState{windows: ws} = wks) do
+    new_map =
+      Map.new(ws.map, fn {id, window} -> {id, Window.invalidate(window)} end)
+
+    %{wks | windows: %{ws | map: new_map}}
+  end
+
+  @doc """
+  Returns the active window's viewport, falling back to the workspace
+  viewport when no window is active.
+  """
+  @spec active_window_viewport(WorkspaceState.t()) :: Viewport.t()
+  def active_window_viewport(%WorkspaceState{} = wks) do
+    case active_window_struct(wks) do
+      nil -> wks.viewport
+      %Window{viewport: vp} -> vp
+    end
+  end
+
+  @doc """
+  Updates the active window's viewport. Falls back to updating
+  the workspace viewport when no window is active.
+  """
+  @spec put_active_window_viewport(WorkspaceState.t(), Viewport.t()) :: WorkspaceState.t()
+  def put_active_window_viewport(%WorkspaceState{} = wks, new_vp) do
+    case active_window_struct(wks) do
+      nil ->
+        %{wks | viewport: new_vp}
+
+      %Window{id: win_id} ->
+        update_window(wks, win_id, fn w -> %{w | viewport: new_vp} end)
+    end
+  end
+
+  @doc """
+  Finds the agent chat window in the windows map.
+
+  Returns `{win_id, window}` or `nil` if no agent chat window exists.
+  """
+  @spec find_agent_chat_window(WorkspaceState.t()) :: {Window.id(), Window.t()} | nil
+  def find_agent_chat_window(%WorkspaceState{windows: ws}) do
+    Enum.find_value(ws.map, fn
+      {win_id, %Window{content: {:agent_chat, _}} = window} -> {win_id, window}
+      _ -> nil
+    end)
+  end
+
+  @doc """
+  Scrolls the agent chat window's viewport by `delta` lines and updates
+  pinned state. Delegates to `Window.scroll_viewport/3`.
+
+  Note: Requires `total_lines` as an argument to stay pure. The caller
+  must fetch the line count from `BufferServer.line_count/1`.
+
+  Returns the workspace unchanged if no agent chat window exists.
+  """
+  @spec scroll_agent_chat_window(WorkspaceState.t(), integer(), non_neg_integer()) ::
+          WorkspaceState.t()
+  def scroll_agent_chat_window(%WorkspaceState{} = wks, delta, total_lines) do
+    case find_agent_chat_window(wks) do
+      nil ->
+        wks
+
+      {win_id, window} ->
+        updated = Window.scroll_viewport(window, delta, total_lines)
+        update_window(wks, win_id, fn _ -> updated end)
+    end
+  end
+
+  @doc """
+  Derives the keymap scope from a window's content type.
+
+  Agent chat windows always use `:agent` scope. Buffer windows use
+  `:editor` when coming from `:agent` scope, and preserve the current
+  scope otherwise (e.g., `:file_tree` stays as `:file_tree`).
+  """
+  @spec scope_for_content(Content.t(), Minga.Keymap.Scope.scope_name()) ::
+          Minga.Keymap.Scope.scope_name()
+  def scope_for_content({:agent_chat, _pid}, _current_scope), do: :agent
+  def scope_for_content({:buffer, _pid}, current_scope) when current_scope == :agent, do: :editor
+  def scope_for_content({:buffer, _pid}, current_scope), do: current_scope
+
+  @doc """
+  Returns the appropriate keymap scope for the active window's content type.
+
+  Used when leaving the file tree (toggle, close, navigate right) to restore
+  the correct scope. Returns :agent for agent chat windows, :editor otherwise.
+  """
+  @spec scope_for_active_window(WorkspaceState.t()) :: atom()
+  def scope_for_active_window(%WorkspaceState{windows: %{map: map, active: active_id}}) do
+    case Map.get(map, active_id) do
+      %{content: content} -> scope_for_content(content, :editor)
+      nil -> :editor
+    end
+  end
+
+  # ── Buffer operations (pure workspace part) ──────────────────────────────
+
+  @doc """
+  Switches to the buffer at `idx` and syncs the active window.
+
+  Pure calculation: updates `buffers` via `Buffers.switch_to/2` and
+  syncs the window's buffer reference. The EditorState delegate
+  handles tab label sync (which needs `tab_bar`).
+  """
+  @spec switch_buffer(WorkspaceState.t(), non_neg_integer()) :: WorkspaceState.t()
+  def switch_buffer(%WorkspaceState{buffers: bs} = wks, idx) do
+    %{wks | buffers: Buffers.switch_to(bs, idx)}
+    |> sync_active_window_buffer()
+  end
+
+  @doc """
+  Adds a buffer pid to the workspace and syncs the active window.
+
+  Pure calculation: updates `buffers` via `Buffers.add/2` and syncs
+  the window's buffer reference. The EditorState delegate handles
+  process monitoring and tab_bar logic.
+  """
+  @spec add_buffer(WorkspaceState.t(), pid()) :: WorkspaceState.t()
+  def add_buffer(%WorkspaceState{buffers: bs} = wks, pid) do
+    %{wks | buffers: Buffers.add(bs, pid)}
+    |> sync_active_window_buffer()
+  end
+
+  @doc """
+  Removes a dead buffer from the workspace.
+
+  Pure calculation: removes the pid from the buffer list, clears
+  special buffer slots, picks a new active buffer, and syncs the
+  window. The EditorState delegate handles `buffer_monitors` cleanup
+  and agent buffer ref clearing.
+  """
+  @spec remove_dead_buffer(WorkspaceState.t(), pid()) :: WorkspaceState.t()
+  def remove_dead_buffer(%WorkspaceState{buffers: %Buffers{} = bs} = wks, pid) do
+    # Remove from buffer list
+    new_list = Enum.reject(bs.list, &(&1 == pid))
+
+    # Clear special buffer slots if they match
+    messages = if bs.messages == pid, do: nil, else: bs.messages
+    help = if bs.help == pid, do: nil, else: bs.help
+
+    # Determine new active buffer
+    {new_active, new_index} =
+      case new_list do
+        [] ->
+          {nil, 0}
+
+        _ ->
+          new_index = min(bs.active_index, length(new_list) - 1)
+          {Enum.at(new_list, new_index), new_index}
+      end
+
+    new_bs = %Buffers{
+      bs
+      | list: new_list,
+        active: new_active,
+        active_index: new_index,
+        messages: messages,
+        help: help
+    }
+
+    %{wks | buffers: new_bs}
+    |> sync_active_window_buffer()
+  end
+
+  @doc """
+  Syncs the active window's buffer reference with `buffers.active`.
+
+  Call after any operation that changes `buffers.active` to keep the
+  window tree consistent. No-op when windows aren't initialized or
+  the buffer hasn't changed.
+  """
+  @spec sync_active_window_buffer(WorkspaceState.t()) :: WorkspaceState.t()
+  def sync_active_window_buffer(%WorkspaceState{buffers: %{active: nil}} = wks), do: wks
+
+  def sync_active_window_buffer(
+        %WorkspaceState{
+          windows: %{map: windows, active: id} = wins,
+          buffers: buffers
+        } = wks
+      ) do
+    case Map.fetch(windows, id) do
+      {:ok, %Window{buffer: existing} = window} when existing != buffers.active ->
+        window = %{
+          Window.invalidate(window)
+          | buffer: buffers.active,
+            content: Content.buffer(buffers.active)
+        }
+
+        %{wks | windows: %{wins | map: Map.put(windows, id, window)}}
+
+      _ ->
+        wks
+    end
+  end
+
+  @doc """
+  Pure part of focus_window: saves the current cursor to the outgoing
+  window, updates the active pointer, switches the active buffer, and
+  derives the new keymap scope.
+
+  Returns `{updated_workspace, target_cursor}` where `target_cursor`
+  is the cursor position stored in the target window. The caller must
+  call `BufferServer.move_to/2` with the target cursor as a side effect.
+
+  Returns `{workspace, nil}` unchanged if the target is already active,
+  no buffer is active, or the window ids are invalid.
+  """
+  @spec focus_window(WorkspaceState.t(), Window.id(), Minga.Buffer.Document.position()) ::
+          {WorkspaceState.t(), Minga.Buffer.Document.position() | nil}
+  def focus_window(%WorkspaceState{windows: %{active: active}} = wks, target_id, _current_cursor)
+      when target_id == active,
+      do: {wks, nil}
+
+  def focus_window(%WorkspaceState{buffers: %{active: nil}} = wks, _target_id, _current_cursor),
+    do: {wks, nil}
+
+  def focus_window(
+        %WorkspaceState{
+          windows: %{map: windows, active: old_id} = wins,
+          buffers: buffers,
+          keymap_scope: current_scope
+        } = wks,
+        target_id,
+        current_cursor
+      ) do
+    case {Map.fetch(windows, old_id), Map.fetch(windows, target_id)} do
+      {{:ok, old_win}, {:ok, target_win}} ->
+        # Save current cursor to outgoing window
+        windows = Map.put(windows, old_id, %{old_win | cursor: current_cursor})
+
+        # Derive keymap_scope from the target window's content type
+        scope = scope_for_content(target_win.content, current_scope)
+
+        updated_wks = %{
+          wks
+          | windows: %{wins | map: windows, active: target_id},
+            buffers: %{buffers | active: target_win.buffer},
+            keymap_scope: scope
+        }
+
+        {updated_wks, target_win.cursor}
+
+      _ ->
+        {wks, nil}
+    end
+  end
+
+  # ── Mode transitions ────────────────────────────────────────────────────────
+
+  @doc """
+  Transitions the workspace to a new vim mode.
+
+  Pure calculation wrapper around `VimState.transition/3`.
+
+  ## Examples
+
+      Workspace.transition_mode(ws, :normal)
+      Workspace.transition_mode(ws, :visual, %VisualState{...})
+  """
+  @spec transition_mode(WorkspaceState.t(), Mode.mode(), Mode.state() | nil) ::
+          WorkspaceState.t()
+  def transition_mode(%WorkspaceState{vim: vim} = wks, mode, mode_state \\ nil) do
+    %{wks | vim: VimState.transition(vim, mode, mode_state)}
+  end
+
+  @doc """
+  Syncs the active window's cursor from an externally fetched position.
+
+  Pure calculation: stores the cursor in the active window struct.
+  The caller must fetch the cursor from `BufferServer.cursor/1`.
+  """
+  @spec sync_active_window_cursor(WorkspaceState.t(), Minga.Buffer.Document.position()) ::
+          WorkspaceState.t()
+  def sync_active_window_cursor(%WorkspaceState{buffers: %{active: nil}} = wks, _cursor), do: wks
+
+  def sync_active_window_cursor(
+        %WorkspaceState{windows: %{map: windows, active: id} = wins} = wks,
+        cursor
+      ) do
+    case Map.fetch(windows, id) do
+      {:ok, window} ->
+        %{wks | windows: %{wins | map: Map.put(windows, id, %{window | cursor: cursor})}}
+
+      :error ->
+        wks
+    end
+  end
+end

--- a/test/minga/workspace_test.exs
+++ b/test/minga/workspace_test.exs
@@ -1,0 +1,475 @@
+defmodule Minga.WorkspaceTest do
+  @moduledoc """
+  Unit tests for `Minga.Workspace` pure calculation functions.
+
+  These tests verify that workspace operations produce correct results
+  without GenServer calls. Buffer pids are started via `BufferServer.start_link`
+  for realistic struct shapes, but the Workspace functions themselves
+  never call BufferServer.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Editor.State.Buffers
+  alias Minga.Editor.State.Windows
+  alias Minga.Editor.Viewport
+  alias Minga.Editor.VimState
+  alias Minga.Editor.Window
+  alias Minga.Editor.Window.Content
+  alias Minga.Editor.WindowTree
+  alias Minga.Workspace
+  alias Minga.Workspace.State, as: WorkspaceState
+
+  # ── Helpers ──────────────────────────────────────────────────────────────────
+
+  defp new_workspace do
+    %WorkspaceState{viewport: Viewport.new(24, 80)}
+  end
+
+  defp start_buffer(content \\ "hello") do
+    {:ok, pid} = BufferServer.start_link(content: content)
+    pid
+  end
+
+  defp workspace_with_buffer(content \\ "hello") do
+    buf = start_buffer(content)
+
+    ws =
+      %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{list: [buf], active_index: 0, active: buf}
+      }
+      |> setup_windows()
+
+    {ws, buf}
+  end
+
+  defp setup_windows(%WorkspaceState{buffers: %{active: buf}} = ws) do
+    tree = WindowTree.new(1)
+    window = Window.new(1, buf, 24, 80)
+
+    %{
+      ws
+      | windows: %Windows{tree: tree, map: %{1 => window}, active: 1, next_id: 2}
+    }
+  end
+
+  # ── Window operations ────────────────────────────────────────────────────────
+
+  describe "active_window_struct/1" do
+    test "returns the active window" do
+      {ws, buf} = workspace_with_buffer()
+      win = Workspace.active_window_struct(ws)
+      assert %Window{id: 1, buffer: ^buf} = win
+    end
+
+    test "returns nil when windows not initialized" do
+      ws = new_workspace()
+      assert Workspace.active_window_struct(ws) == nil
+    end
+  end
+
+  describe "split?/1" do
+    test "returns false for a single window" do
+      {ws, _buf} = workspace_with_buffer()
+      refute Workspace.split?(ws)
+    end
+
+    test "returns false when tree is nil" do
+      ws = new_workspace()
+      refute Workspace.split?(ws)
+    end
+  end
+
+  describe "update_window/3" do
+    test "updates the window via a mapper function" do
+      {ws, _buf} = workspace_with_buffer()
+
+      updated = Workspace.update_window(ws, 1, fn w -> %{w | cursor: {5, 10}} end)
+
+      assert %Window{cursor: {5, 10}} = Workspace.active_window_struct(updated)
+    end
+
+    test "returns unchanged when window id not found" do
+      {ws, _buf} = workspace_with_buffer()
+
+      updated = Workspace.update_window(ws, 999, fn w -> %{w | cursor: {5, 10}} end)
+      assert updated == ws
+    end
+  end
+
+  describe "invalidate_all_windows/1" do
+    test "clears cached content for all windows" do
+      {ws, _buf} = workspace_with_buffer()
+
+      # Set cached content so we can verify it gets cleared
+      ws =
+        Workspace.update_window(ws, 1, fn w ->
+          %{w | cached_content: %{0 => :some_data}}
+        end)
+
+      invalidated = Workspace.invalidate_all_windows(ws)
+      win = Workspace.active_window_struct(invalidated)
+      assert win.cached_content == %{}
+    end
+  end
+
+  describe "active_window_viewport/1" do
+    test "returns the active window's viewport" do
+      {ws, _buf} = workspace_with_buffer()
+      vp = Workspace.active_window_viewport(ws)
+      assert %Viewport{rows: 24, cols: 80} = vp
+    end
+
+    test "falls back to workspace viewport when no window" do
+      ws = new_workspace()
+      vp = Workspace.active_window_viewport(ws)
+      assert %Viewport{rows: 24, cols: 80} = vp
+    end
+  end
+
+  describe "put_active_window_viewport/2" do
+    test "updates the active window's viewport" do
+      {ws, _buf} = workspace_with_buffer()
+      new_vp = Viewport.new(40, 120)
+      updated = Workspace.put_active_window_viewport(ws, new_vp)
+      win = Workspace.active_window_struct(updated)
+      assert win.viewport.rows == 40
+      assert win.viewport.cols == 120
+    end
+
+    test "falls back to workspace viewport when no window" do
+      ws = new_workspace()
+      new_vp = Viewport.new(40, 120)
+      updated = Workspace.put_active_window_viewport(ws, new_vp)
+      assert updated.viewport.rows == 40
+      assert updated.viewport.cols == 120
+    end
+  end
+
+  describe "find_agent_chat_window/1" do
+    test "returns nil when no agent chat window exists" do
+      {ws, _buf} = workspace_with_buffer()
+      assert Workspace.find_agent_chat_window(ws) == nil
+    end
+
+    test "returns agent chat window when present" do
+      buf = start_buffer()
+
+      window = %Window{
+        id: 2,
+        buffer: buf,
+        content: {:agent_chat, buf},
+        viewport: Viewport.new(24, 80),
+        cursor: {0, 0}
+      }
+
+      ws = %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{list: [buf], active_index: 0, active: buf},
+        windows: %Windows{
+          tree: WindowTree.new(2),
+          map: %{2 => window},
+          active: 2,
+          next_id: 3
+        }
+      }
+
+      assert {2, %Window{content: {:agent_chat, ^buf}}} =
+               Workspace.find_agent_chat_window(ws)
+    end
+  end
+
+  describe "scope_for_content/2" do
+    test "agent chat always returns :agent" do
+      buf = start_buffer()
+      assert Workspace.scope_for_content({:agent_chat, buf}, :editor) == :agent
+      assert Workspace.scope_for_content({:agent_chat, buf}, :file_tree) == :agent
+    end
+
+    test "buffer from agent scope returns :editor" do
+      buf = start_buffer()
+      assert Workspace.scope_for_content({:buffer, buf}, :agent) == :editor
+    end
+
+    test "buffer preserves current scope" do
+      buf = start_buffer()
+      assert Workspace.scope_for_content({:buffer, buf}, :file_tree) == :file_tree
+      assert Workspace.scope_for_content({:buffer, buf}, :editor) == :editor
+    end
+  end
+
+  describe "scope_for_active_window/1" do
+    test "returns :editor for buffer windows" do
+      {ws, _buf} = workspace_with_buffer()
+      assert Workspace.scope_for_active_window(ws) == :editor
+    end
+
+    test "returns :editor when no window" do
+      ws = new_workspace()
+      assert Workspace.scope_for_active_window(ws) == :editor
+    end
+  end
+
+  describe "scroll_agent_chat_window/3" do
+    test "scrolls agent chat window viewport" do
+      buf = start_buffer(String.duplicate("line\n", 100))
+
+      window = %Window{
+        id: 2,
+        buffer: buf,
+        content: {:agent_chat, buf},
+        viewport: Viewport.new(24, 80),
+        cursor: {0, 0}
+      }
+
+      ws = %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{list: [buf], active_index: 0, active: buf},
+        windows: %Windows{
+          tree: WindowTree.new(2),
+          map: %{2 => window},
+          active: 2,
+          next_id: 3
+        }
+      }
+
+      updated = Workspace.scroll_agent_chat_window(ws, 5, 100)
+      {_id, scrolled_win} = Workspace.find_agent_chat_window(updated)
+      assert scrolled_win.viewport.top > 0
+    end
+
+    test "returns unchanged when no agent chat window" do
+      {ws, _buf} = workspace_with_buffer()
+      assert Workspace.scroll_agent_chat_window(ws, 5, 100) == ws
+    end
+  end
+
+  # ── Buffer operations ────────────────────────────────────────────────────────
+
+  describe "switch_buffer/2" do
+    test "switches the active buffer and syncs window" do
+      buf1 = start_buffer("first")
+      buf2 = start_buffer("second")
+
+      ws =
+        %WorkspaceState{
+          viewport: Viewport.new(24, 80),
+          buffers: %Buffers{list: [buf1, buf2], active_index: 0, active: buf1}
+        }
+        |> setup_windows()
+
+      updated = Workspace.switch_buffer(ws, 1)
+      assert updated.buffers.active == buf2
+      assert updated.buffers.active_index == 1
+
+      # Window should have synced
+      win = Workspace.active_window_struct(updated)
+      assert win.buffer == buf2
+    end
+  end
+
+  describe "add_buffer/2" do
+    test "adds a buffer and syncs window" do
+      {ws, _buf1} = workspace_with_buffer("first")
+      buf2 = start_buffer("second")
+
+      updated = Workspace.add_buffer(ws, buf2)
+      assert buf2 in updated.buffers.list
+      assert updated.buffers.active == buf2
+
+      # Window should have synced to the new buffer
+      win = Workspace.active_window_struct(updated)
+      assert win.buffer == buf2
+    end
+  end
+
+  describe "remove_dead_buffer/2" do
+    test "removes the buffer and picks a new active" do
+      buf1 = start_buffer("first")
+      buf2 = start_buffer("second")
+
+      ws =
+        %WorkspaceState{
+          viewport: Viewport.new(24, 80),
+          buffers: %Buffers{list: [buf1, buf2], active_index: 0, active: buf1}
+        }
+        |> setup_windows()
+
+      updated = Workspace.remove_dead_buffer(ws, buf1)
+      refute buf1 in updated.buffers.list
+      assert updated.buffers.active == buf2
+    end
+
+    test "handles removing the only buffer" do
+      {ws, buf} = workspace_with_buffer()
+
+      updated = Workspace.remove_dead_buffer(ws, buf)
+      assert updated.buffers.list == []
+      assert updated.buffers.active == nil
+    end
+
+    test "clears special buffer slots when they match" do
+      buf1 = start_buffer("first")
+      buf2 = start_buffer("messages")
+
+      ws = %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{
+          list: [buf1, buf2],
+          active_index: 0,
+          active: buf1,
+          messages: buf2
+        }
+      }
+
+      updated = Workspace.remove_dead_buffer(ws, buf2)
+      assert updated.buffers.messages == nil
+    end
+  end
+
+  describe "sync_active_window_buffer/1" do
+    test "syncs window buffer to match active buffer" do
+      buf1 = start_buffer("first")
+      buf2 = start_buffer("second")
+
+      ws =
+        %WorkspaceState{
+          viewport: Viewport.new(24, 80),
+          buffers: %Buffers{list: [buf1, buf2], active_index: 0, active: buf1}
+        }
+        |> setup_windows()
+
+      # Manually change active buffer without syncing
+      ws = %{ws | buffers: %{ws.buffers | active: buf2}}
+
+      synced = Workspace.sync_active_window_buffer(ws)
+      win = Workspace.active_window_struct(synced)
+      assert win.buffer == buf2
+      assert win.content == Content.buffer(buf2)
+    end
+
+    test "no-op when buffer is nil" do
+      ws = new_workspace()
+      assert Workspace.sync_active_window_buffer(ws) == ws
+    end
+
+    test "no-op when window buffer already matches" do
+      {ws, _buf} = workspace_with_buffer()
+      assert Workspace.sync_active_window_buffer(ws) == ws
+    end
+  end
+
+  # ── Focus window ─────────────────────────────────────────────────────────────
+
+  describe "focus_window/3" do
+    test "returns unchanged when target is already active" do
+      {ws, _buf} = workspace_with_buffer()
+
+      assert {^ws, nil} = Workspace.focus_window(ws, 1, {0, 0})
+    end
+
+    test "returns unchanged when no active buffer" do
+      ws = new_workspace()
+      assert {^ws, nil} = Workspace.focus_window(ws, 2, {0, 0})
+    end
+
+    test "switches active window and returns target cursor" do
+      buf1 = start_buffer("first")
+      buf2 = start_buffer("second")
+
+      win1 = Window.new(1, buf1, 24, 80)
+      win2 = %{Window.new(2, buf2, 24, 80) | cursor: {5, 3}}
+
+      ws = %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{list: [buf1, buf2], active_index: 0, active: buf1},
+        windows: %Windows{
+          tree: {:split, :horizontal, 0.5, {:leaf, 1}, {:leaf, 2}},
+          map: %{1 => win1, 2 => win2},
+          active: 1,
+          next_id: 3
+        }
+      }
+
+      {updated, target_cursor} = Workspace.focus_window(ws, 2, {3, 7})
+
+      # Active window switched
+      assert updated.windows.active == 2
+      assert updated.buffers.active == buf2
+
+      # Old window got cursor saved
+      assert Map.get(updated.windows.map, 1).cursor == {3, 7}
+
+      # Target cursor returned for side effect
+      assert target_cursor == {5, 3}
+    end
+
+    test "returns unchanged for invalid target window id" do
+      {ws, _buf} = workspace_with_buffer()
+
+      # Window id 999 doesn't exist in the map
+      assert {^ws, nil} = Workspace.focus_window(ws, 999, {0, 0})
+    end
+
+    test "derives keymap scope from target window content" do
+      buf1 = start_buffer("file")
+      buf2 = start_buffer("agent")
+
+      win1 = Window.new(1, buf1, 24, 80)
+      win2 = %{Window.new(2, buf2, 24, 80) | content: {:agent_chat, buf2}}
+
+      ws = %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{list: [buf1, buf2], active_index: 0, active: buf1},
+        keymap_scope: :editor,
+        windows: %Windows{
+          tree: {:split, :horizontal, 0.5, {:leaf, 1}, {:leaf, 2}},
+          map: %{1 => win1, 2 => win2},
+          active: 1,
+          next_id: 3
+        }
+      }
+
+      {updated, _cursor} = Workspace.focus_window(ws, 2, {0, 0})
+      assert updated.keymap_scope == :agent
+    end
+  end
+
+  # ── Mode transitions ────────────────────────────────────────────────────────
+
+  describe "transition_mode/2,3" do
+    test "transitions to normal mode" do
+      ws = %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        vim: %VimState{VimState.new() | mode: :insert}
+      }
+
+      updated = Workspace.transition_mode(ws, :normal)
+      assert updated.vim.mode == :normal
+    end
+
+    test "transitions to insert mode" do
+      {ws, _buf} = workspace_with_buffer()
+      updated = Workspace.transition_mode(ws, :insert)
+      assert updated.vim.mode == :insert
+    end
+  end
+
+  # ── Cursor sync ──────────────────────────────────────────────────────────────
+
+  describe "sync_active_window_cursor/2" do
+    test "stores cursor in the active window" do
+      {ws, _buf} = workspace_with_buffer()
+
+      updated = Workspace.sync_active_window_cursor(ws, {10, 5})
+      win = Workspace.active_window_struct(updated)
+      assert win.cursor == {10, 5}
+    end
+
+    test "no-op when no active buffer" do
+      ws = new_workspace()
+      assert Workspace.sync_active_window_cursor(ws, {0, 0}) == ws
+    end
+  end
+end


### PR DESCRIPTION
## TL;DR

Extracts pure calculation functions from `EditorState` into a new `Minga.Workspace` module. EditorState becomes a thin delegate layer that unwraps/rewraps workspace state and handles side effects. Part of the Core/Shell architecture plan (`BIG_REFACTOR_PLAN.md`, Phase E).

## Context

Phase C (`#1176`) created `Workspace.State` as a typed struct embedded in `EditorState`. But the functions that operate on workspace fields still lived in `EditorState`, mixing pure calculations with side effects (GenServer calls, process monitoring). This makes it impossible to test workspace logic in isolation and blocks the Shell extraction in Phase F.

Phase E separates calculations from actions following the Grokking Simplicity taxonomy:
- **Workspace** = pure calculations on `WorkspaceState.t()` (no GenServer calls, no side effects)
- **EditorState** = action layer (fetches external data, calls Workspace, executes side effects)

## Changes

**New module: `Minga.Workspace`** (`lib/minga/workspace.ex`)

Pure workspace operations moved:
- `active_window_struct/1`, `split?/1`, `update_window/3`, `invalidate_all_windows/1`
- `active_window_viewport/1`, `put_active_window_viewport/2`
- `find_agent_chat_window/1`, `scroll_agent_chat_window/3`
- `scope_for_content/2`, `scope_for_active_window/1`
- `transition_mode/2,3`, `sync_active_window_cursor/2`

Split functions (pure part extracted, side effects remain in EditorState):
- `switch_buffer`: Workspace handles `Buffers.switch_to` + window sync; EditorState handles tab label sync
- `add_buffer`: Workspace handles `Buffers.add` + window sync; EditorState handles `Process.monitor` + tab_bar logic
- `remove_dead_buffer`: Workspace handles buffer list cleanup; EditorState handles `buffer_monitors` + agent refs
- `focus_window`: Workspace takes cursor as arg, returns `{ws, target_cursor}`; EditorState fetches/applies cursor via BufferServer
- `sync_active_window_cursor`: Workspace takes cursor as arg; EditorState fetches from BufferServer

**EditorState delegates** retain the same public API, so all callers are unchanged.

**AgentAccess fix**: removed duplicate clause warnings from Phase C.

## Verification

```
mix compile --warnings-as-errors  # Clean
mix test.llm                       # 6744 tests, 0 failures
mix lint                           # Clean
```

## Acceptance Criteria (Phase E)

Per `BIG_REFACTOR_PLAN.md`:

- Functions that operate on workspace fields live in Workspace ✅
- EditorState is a thin delegate ✅
- Behavioral change: None (pure refactor) ✅
- All tests pass ✅
- Unblocks Phase F (shell extraction can rely on workspace API) ✅

Beyond the plan:
- 34 new unit tests for Workspace calculations ✅
- Split function pattern: Workspace takes external data as args, returns pure result ✅