### PR TITLE
refactor(editor): Phase E — move workspace operations to Workspace.State

### DIFF
--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -399,16 +399,17 @@ defmodule Minga.Editor.State do
 
   @doc "Returns the active window struct, or nil if windows aren't initialized."
   @spec active_window_struct(t()) :: Window.t() | nil
-  def active_window_struct(%__MODULE__{workspace: %{windows: ws}}), do: Windows.active_struct(ws)
+  def active_window_struct(%__MODULE__{workspace: ws}),
+    do: WorkspaceState.active_window_struct(ws)
 
   @doc "Returns true if the editor has more than one window."
   @spec split?(t()) :: boolean()
-  def split?(%__MODULE__{workspace: %{windows: ws}}), do: Windows.split?(ws)
+  def split?(%__MODULE__{workspace: ws}), do: WorkspaceState.split?(ws)
 
   @doc "Updates the window struct for the given window id via a mapper function."
   @spec update_window(t(), Window.id(), (Window.t() -> Window.t())) :: t()
-  def update_window(%__MODULE__{workspace: %{windows: ws} = wspace} = state, id, fun) do
-    %{state | workspace: %{wspace | windows: Windows.update(ws, id, fun)}}
+  def update_window(%__MODULE__{} = state, id, fun) do
+    update_workspace(state, &WorkspaceState.update_window(&1, id, fun))
   end
 
   @doc """
@@ -419,11 +420,8 @@ defmodule Minga.Editor.State do
   wrong when column offsets shift.
   """
   @spec invalidate_all_windows(t()) :: t()
-  def invalidate_all_windows(%__MODULE__{workspace: %{windows: ws} = wspace} = state) do
-    new_map =
-      Map.new(ws.map, fn {id, window} -> {id, Window.invalidate(window)} end)
-
-    %{state | workspace: %{wspace | windows: %{ws | map: new_map}}}
+  def invalidate_all_windows(%__MODULE__{} = state) do
+    update_workspace(state, &WorkspaceState.invalidate_all_windows/1)
   end
 
   @doc """
@@ -526,37 +524,8 @@ defmodule Minga.Editor.State do
   window tree consistent. No-op when windows aren't initialized.
   """
   @spec sync_active_window_buffer(t()) :: t()
-  def sync_active_window_buffer(%__MODULE__{workspace: %{buffers: %{active: nil}}} = state),
-    do: state
-
-  def sync_active_window_buffer(
-        %__MODULE__{
-          workspace: %{windows: %{map: windows, active: id} = ws, buffers: buffers} = wspace
-        } = state
-      ) do
-    case Map.fetch(windows, id) do
-      {:ok, %Window{buffer: existing} = window} when existing != buffers.active ->
-        # Buffer changed: invalidate all caches. The new buffer has
-        # different content, and cached draws from the old buffer are
-        # completely wrong. Also reset tracking fields so
-        # detect_invalidation forces a full redraw on the next frame.
-        #
-        # Both `buffer` and `content` must be updated. The render
-        # pipeline checks `Content.agent_chat?(window.content)` to
-        # decide rendering paths, so a stale content tag causes the
-        # window to be routed to the wrong renderer (e.g., blank
-        # screen when opening a file from the agent tab).
-        window = %{
-          Window.invalidate(window)
-          | buffer: buffers.active,
-            content: Content.buffer(buffers.active)
-        }
-
-        %{state | workspace: %{wspace | windows: %{ws | map: Map.put(windows, id, window)}}}
-
-      _ ->
-        state
-    end
+  def sync_active_window_buffer(%__MODULE__{} = state) do
+    update_workspace(state, &WorkspaceState.sync_active_window_buffer/1)
   end
 
   @doc """
@@ -693,9 +662,8 @@ defmodule Minga.Editor.State do
   remember to call `sync_active_window_buffer/1`.
   """
   @spec switch_buffer(t(), non_neg_integer()) :: t()
-  def switch_buffer(%__MODULE__{workspace: %{buffers: bs} = wspace} = state, idx) do
-    state = %{state | workspace: %{wspace | buffers: Buffers.switch_to(bs, idx)}}
-    state = sync_active_window_buffer(state)
+  def switch_buffer(%__MODULE__{} = state, idx) do
+    state = update_workspace(state, &WorkspaceState.switch_buffer(&1, idx))
     sync_active_tab_label(state)
   end
 
@@ -792,9 +760,7 @@ defmodule Minga.Editor.State do
   """
   @spec scope_for_content(Content.t(), Minga.Keymap.Scope.scope_name()) ::
           Minga.Keymap.Scope.scope_name()
-  def scope_for_content({:agent_chat, _pid}, _current_scope), do: :agent
-  def scope_for_content({:buffer, _pid}, current_scope) when current_scope == :agent, do: :editor
-  def scope_for_content({:buffer, _pid}, current_scope), do: current_scope
+  defdelegate scope_for_content(content, current_scope), to: WorkspaceState
 
   @doc """
   Returns the appropriate keymap scope for the active window's content type.
@@ -803,11 +769,8 @@ defmodule Minga.Editor.State do
   the correct scope. Returns :agent for agent chat windows, :editor otherwise.
   """
   @spec scope_for_active_window(t()) :: atom()
-  def scope_for_active_window(%{workspace: %{windows: %{map: map, active: active_id}}}) do
-    case Map.get(map, active_id) do
-      %{content: content} -> scope_for_content(content, :editor)
-      nil -> :editor
-    end
+  def scope_for_active_window(%{workspace: ws}) do
+    WorkspaceState.scope_for_active_window(ws)
   end
 
   @spec buffer_label(pid()) :: String.t()
@@ -1278,7 +1241,7 @@ defmodule Minga.Editor.State do
   """
   @spec transition_mode(t(), Mode.mode(), Mode.state() | nil) :: t()
   def transition_mode(%__MODULE__{} = state, mode, mode_state \\ nil) do
-    put_in(state.workspace.vim, VimState.transition(state.workspace.vim, mode, mode_state))
+    update_workspace(state, &WorkspaceState.transition_mode(&1, mode, mode_state))
   end
 
   # ── Tool prompt helpers ──────────────────────────────────────────────────────

--- a/lib/minga/workspace/state.ex
+++ b/lib/minga/workspace/state.ex
@@ -72,4 +72,109 @@ defmodule Minga.Workspace.State do
     |> Map.keys()
     |> Enum.reject(&(&1 == :__struct__))
   end
+
+  # ── Pure workspace operations ─────────────────────────────────────────────
+  #
+  # These are pure functions (no side effects) on WorkspaceState. The
+  # Editor GenServer calls these through EditorState wrappers that handle
+  # cross-cutting concerns (tab bar sync, process monitoring, etc.).
+
+  alias Minga.Editor.Window
+  alias Minga.Editor.Window.Content
+
+  @doc "Returns the active window struct, or nil."
+  @spec active_window_struct(t()) :: Window.t() | nil
+  def active_window_struct(%__MODULE__{windows: ws}), do: Windows.active_struct(ws)
+
+  @doc "Returns true if the workspace has more than one window."
+  @spec split?(t()) :: boolean()
+  def split?(%__MODULE__{windows: ws}), do: Windows.split?(ws)
+
+  @doc "Updates the window struct for the given window id via a mapper function."
+  @spec update_window(t(), Window.id(), (Window.t() -> Window.t())) :: t()
+  def update_window(%__MODULE__{windows: ws} = wspace, id, fun) do
+    %{wspace | windows: Windows.update(ws, id, fun)}
+  end
+
+  @doc """
+  Invalidates render caches for all windows.
+
+  Call when the screen layout changes (file tree toggle, agent panel toggle)
+  because cached draws contain baked-in absolute coordinates that become
+  wrong when column offsets shift.
+  """
+  @spec invalidate_all_windows(t()) :: t()
+  def invalidate_all_windows(%__MODULE__{windows: ws} = wspace) do
+    new_map =
+      Map.new(ws.map, fn {id, window} -> {id, Window.invalidate(window)} end)
+
+    %{wspace | windows: %{ws | map: new_map}}
+  end
+
+  @doc """
+  Switches to the buffer at `idx`, making it active for the current window.
+
+  Pure workspace operation: updates Buffers and syncs the active window.
+  """
+  @spec switch_buffer(t(), non_neg_integer()) :: t()
+  def switch_buffer(%__MODULE__{buffers: bs} = wspace, idx) do
+    %{wspace | buffers: Buffers.switch_to(bs, idx)}
+    |> sync_active_window_buffer()
+  end
+
+  @doc """
+  Syncs the active window's buffer reference with `buffers.active`.
+
+  Call after any operation that changes `buffers.active` to keep the
+  window tree consistent. No-op when windows aren't initialized.
+  """
+  @spec sync_active_window_buffer(t()) :: t()
+  def sync_active_window_buffer(%__MODULE__{buffers: %{active: nil}} = wspace), do: wspace
+
+  def sync_active_window_buffer(
+        %__MODULE__{windows: %{map: windows, active: id} = ws, buffers: buffers} = wspace
+      ) do
+    case Map.fetch(windows, id) do
+      {:ok, %Window{buffer: existing} = window} when existing != buffers.active ->
+        window = %{
+          Window.invalidate(window)
+          | buffer: buffers.active,
+            content: Content.buffer(buffers.active)
+        }
+
+        %{wspace | windows: %{ws | map: Map.put(windows, id, window)}}
+
+      _ ->
+        wspace
+    end
+  end
+
+  @doc "Transitions the editing model to a new mode."
+  @spec transition_mode(t(), atom(), term()) :: t()
+  def transition_mode(%__MODULE__{vim: vim} = wspace, mode, mode_state \\ nil) do
+    %{wspace | vim: VimState.transition(vim, mode, mode_state)}
+  end
+
+  @doc """
+  Derives the keymap scope from a window's content type.
+
+  Agent chat windows always use `:agent` scope. Buffer windows use
+  `:editor` when coming from `:agent` scope, and preserve the current
+  scope otherwise.
+  """
+  @spec scope_for_content(Content.t(), Scope.scope_name()) :: Scope.scope_name()
+  def scope_for_content({:agent_chat, _pid}, _current_scope), do: :agent
+  def scope_for_content({:buffer, _pid}, :agent), do: :editor
+  def scope_for_content({:buffer, _pid}, current_scope), do: current_scope
+
+  @doc """
+  Returns the appropriate keymap scope for the active window's content type.
+  """
+  @spec scope_for_active_window(t()) :: atom()
+  def scope_for_active_window(%__MODULE__{windows: %{map: map, active: active_id}}) do
+    case Map.get(map, active_id) do
+      %{content: content} -> scope_for_content(content, :editor)
+      nil -> :editor
+    end
+  end
 end


### PR DESCRIPTION
## What

Phase E of the Core/Shell refactor. Extracts 9 pure workspace operations from EditorState to Workspace.State.

## Why

EditorState mixed orchestration logic with pure data operations. Phase E separates them: pure calculations on workspace data live in `Workspace.State`, EditorState keeps thin wrappers for cross-cutting concerns (tab bar sync, process monitoring).

## Design Decision

Per archie's analysis, Workspace is **not** a bounded context facade (zero external callers outside the Editor domain). It's an internal data boundary. No `Minga.Workspace` facade module needed.

## Moved Functions

| Function | Type | Notes |
|----------|------|-------|
| `active_window_struct/1` | Query | Read-only |
| `split?/1` | Query | Read-only |
| `update_window/3` | Calculation | Pure struct update |
| `invalidate_all_windows/1` | Calculation | Pure struct update |
| `switch_buffer/2` | Calculation | EditorState adds tab label sync |
| `sync_active_window_buffer/1` | Calculation | Pure window/buffer sync |
| `transition_mode/3` | Calculation | Pure vim state transition |
| `scope_for_content/2` | Calculation | Pure scope derivation |
| `scope_for_active_window/1` | Calculation | Pure scope derivation |

## Quality

| Check | Status |
|-------|--------|
| `mix lint` | ✅ clean |
| `mix test.llm` | ✅ 6743 tests, 0 failures |

## Sequence

```
C ✅ → DDD-1 ✅ → E ✅ → DDD-2 → DDD-3 → F(⛔) → ...
```