### PR TITLE
fix(frontend): replace dangling PortManager atom breaking GUI

### DIFF
--- a/lib/minga/editor/startup.ex
+++ b/lib/minga/editor/startup.ex
@@ -39,7 +39,7 @@ defmodule Minga.Editor.Startup do
   @spec build_initial_state(keyword()) :: EditorState.t()
   def build_initial_state(opts) do
     backend = Keyword.get(opts, :backend, :headless)
-    port_manager = Keyword.get(opts, :port_manager, PortManager)
+    port_manager = Keyword.get(opts, :port_manager, Minga.Frontend.Manager)
     width = Keyword.get(opts, :width, 80)
     height = Keyword.get(opts, :height, 24)
     buffer = Keyword.get(opts, :buffer)

--- a/lib/minga/frontend/protocol/gui_window_content.ex
+++ b/lib/minga/frontend/protocol/gui_window_content.ex
@@ -77,7 +77,7 @@ defmodule Minga.Frontend.Protocol.GUIWindowContent do
   @doc """
   Encodes a `SemanticWindow` into the 0x80 wire format.
 
-  Returns a single binary suitable for sending via `PortManager.send_commands/2`.
+  Returns a single binary suitable for sending via `Minga.Frontend.send_commands/2`.
   """
   @spec encode(SemanticWindow.t()) :: binary()
   def encode(%SemanticWindow{} = sw) do


### PR DESCRIPTION
DDD-3 renamed `Minga.Port.Manager` to `Minga.Frontend.Manager` but left a bare `PortManager` atom as the default in `startup.ex`. The alias that resolved it was removed during the rename, so `subscribe_port` called a nonexistent process. This broke GUI frontend communication: no render commands sent, spinner forever.

**Root cause:** `Keyword.get(opts, :port_manager, PortManager)` where `PortManager` was previously aliased to `Minga.Port.Manager`. After DDD-3, the alias was gone but the default wasn't updated.

**Fix:** Replace `PortManager` with `Minga.Frontend.Manager`.