### PR TITLE
Phase I: CUA keymap scopes for all UI surfaces

### DIFF
--- a/lib/minga/input/file_tree_handler.ex
+++ b/lib/minga/input/file_tree_handler.ex
@@ -92,7 +92,10 @@ defmodule Minga.Input.FileTreeHandler do
     else
       key = {cp, mods}
 
-      case Scope.resolve_key(:file_tree, :normal, key) do
+      vim_state =
+        if Minga.Editor.Editing.active_model() == Minga.EditingModel.CUA, do: :cua, else: :normal
+
+      case Scope.resolve_key(:file_tree, vim_state, key) do
         {:command, command} ->
           {:handled, Commands.execute(state, command)}
 

--- a/lib/minga/input/scoped.ex
+++ b/lib/minga/input/scoped.ex
@@ -107,7 +107,18 @@ defmodule Minga.Input.Scoped do
     # separate Input.Handler modules in the surface handler list. They run
     # before Scoped in the focus stack walk. See Input.surface_handlers/0.
 
-    # Normal dispatch: determine vim state and resolve through scope
+    # CUA mode: resolve all keys through the :cua trie. No vim modes.
+    if cua_active?() do
+      resolve_agent_key(state, :cua, cp, mods)
+    else
+      dispatch_agent_key_vim(state, panel, cp, mods)
+    end
+  end
+
+  # Vim-mode agent key dispatch. Split out so CUA path stays clean.
+  @spec dispatch_agent_key_vim(EditorState.t(), Panel.t(), non_neg_integer(), non_neg_integer()) ::
+          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  defp dispatch_agent_key_vim(state, panel, cp, mods) do
     # Tab on a paste placeholder line: toggle expand/collapse
     if cp == @tab and mods == 0 and panel.input_focused do
       {cursor_line, _} = UIState.input_cursor(panel)
@@ -137,6 +148,11 @@ defmodule Minga.Input.Scoped do
       # targeting the prompt buffer.
       {:handled, AgentPanel.dispatch_prompt_via_mode_fsm(state, cp, mods)}
     end
+  end
+
+  @spec cua_active?() :: boolean()
+  defp cua_active? do
+    Minga.Editor.Editing.active_model() == Minga.EditingModel.CUA
   end
 
   # ── Agent scope trie resolution ────────────────────────────────────────────

--- a/lib/minga/keymap/cua_defaults.ex
+++ b/lib/minga/keymap/cua_defaults.ex
@@ -1,0 +1,111 @@
+defmodule Minga.Keymap.CUADefaults do
+  @moduledoc """
+  Shared CUA keybinding fragments for scope modules.
+
+  Provides composable trie builders for standard CUA vocabulary:
+  arrow-key navigation, Cmd-chord clipboard/undo, and common editing
+  primitives (Enter, Backspace, Tab, Escape). Scope modules merge
+  these fragments with their surface-specific bindings to build the
+  `:cua` keymap clause.
+
+  All functions return `Bindings.node_t()` suitable for piping into
+  additional `Bindings.bind/4` calls.
+  """
+
+  alias Minga.Keymap.Bindings
+
+  import Bitwise
+
+  # Modifier bitmasks (matching port protocol)
+  @shift 0x01
+  @ctrl 0x02
+  @cmd 0x08
+
+  # Arrow keys (Kitty keyboard protocol codepoints)
+  @arrow_up 57_352
+  @arrow_down 57_353
+  @arrow_left 57_350
+  @arrow_right 57_351
+
+  # macOS NSEvent arrow key codepoints (GUI frontend)
+  @ns_up 0xF700
+  @ns_down 0xF701
+  @ns_left 0xF702
+  @ns_right 0xF703
+
+  # Common keys
+  @escape 27
+  @backspace 127
+  @tab 9
+
+  @doc """
+  Arrow key navigation bindings.
+
+  Up/Down map to vertical movement commands. Accepts both Kitty protocol
+  and macOS NSEvent codepoints so bindings work on both TUI and GUI.
+  """
+  @spec navigation_trie() :: Bindings.node_t()
+  def navigation_trie do
+    Bindings.new()
+    |> Bindings.bind([{@arrow_up, 0}], :move_up, "Move up")
+    |> Bindings.bind([{@arrow_down, 0}], :move_down, "Move down")
+    |> Bindings.bind([{@ns_up, 0}], :move_up, "Move up")
+    |> Bindings.bind([{@ns_down, 0}], :move_down, "Move down")
+  end
+
+  @doc """
+  Cmd-chord bindings for clipboard, undo, and common actions.
+
+  Cmd+C = copy, Cmd+X = cut, Cmd+V = paste, Cmd+Z = undo,
+  Cmd+Shift+Z = redo, Cmd+A = select all, Cmd+S = save.
+  """
+  @spec cmd_chords_trie() :: Bindings.node_t()
+  def cmd_chords_trie do
+    Bindings.new()
+    |> Bindings.bind([{?c, @cmd}], :yank_visual_selection, "Copy")
+    |> Bindings.bind([{?x, @cmd}], :delete_visual_selection, "Cut")
+    |> Bindings.bind([{?v, @cmd}], :paste_after, "Paste")
+    |> Bindings.bind([{?z, @cmd}], :undo, "Undo")
+    |> Bindings.bind([{?z, @cmd ||| @shift}], :redo, "Redo")
+    |> Bindings.bind([{?a, @cmd}], :select_all, "Select all")
+    |> Bindings.bind([{?s, @cmd}], :save, "Save")
+  end
+
+  @doc """
+  Common editing primitives: Escape, Enter, Backspace.
+
+  These are surface-neutral defaults. Scopes override specific keys
+  when needed (e.g., Enter opens a file in file tree, submits in agent).
+  """
+  @spec editing_trie() :: Bindings.node_t()
+  def editing_trie do
+    Bindings.new()
+    |> Bindings.bind([{@escape, 0}], :escape, "Cancel / dismiss")
+    |> Bindings.bind([{@backspace, 0}], :delete_before, "Delete before cursor")
+    |> Bindings.bind([{@tab, 0}], :indent, "Indent / next field")
+  end
+
+  @doc """
+  Left/Right arrow keys for horizontal navigation.
+
+  Used by file tree (expand/collapse) and other surfaces that need
+  directional input.
+  """
+  @spec horizontal_nav_trie() :: Bindings.node_t()
+  def horizontal_nav_trie do
+    Bindings.new()
+    |> Bindings.bind([{@arrow_left, 0}], :move_left, "Move left")
+    |> Bindings.bind([{@arrow_right, 0}], :move_right, "Move right")
+    |> Bindings.bind([{@ns_left, 0}], :move_left, "Move left")
+    |> Bindings.bind([{@ns_right, 0}], :move_right, "Move right")
+  end
+
+  @doc """
+  Ctrl+C interrupt binding. Shared across all CUA surfaces.
+  """
+  @spec interrupt_trie() :: Bindings.node_t()
+  def interrupt_trie do
+    Bindings.new()
+    |> Bindings.bind([{?c, @ctrl}], :interrupt, "Interrupt / cancel")
+  end
+end

--- a/lib/minga/keymap/scope.ex
+++ b/lib/minga/keymap/scope.ex
@@ -39,7 +39,7 @@ defmodule Minga.Keymap.Scope do
   @type scope_name :: :editor | :agent | :file_tree | :git_status
 
   @typedoc "Vim state relevant to scope resolution."
-  @type vim_state :: :normal | :insert | :input_normal
+  @type vim_state :: :normal | :insert | :input_normal | :cua
 
   @typedoc "A single help binding: `{key_string, description}`."
   @type help_binding :: {String.t(), String.t()}

--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -47,6 +47,7 @@ defmodule Minga.Keymap.Scope.Agent do
   def keymap(:normal, _context), do: normal_trie()
   def keymap(:insert, _context), do: insert_trie()
   def keymap(:input_normal, _context), do: input_normal_trie()
+  def keymap(:cua, _context), do: cua_trie()
   def keymap(_state, _context), do: Bindings.new()
 
   @impl true
@@ -306,5 +307,37 @@ defmodule Minga.Keymap.Scope.Agent do
          {"?", "This help overlay"}
        ]}
     ]
+  end
+
+  # ── CUA mode bindings ─────────────────────────────────────────────────────
+  # Combined trie for CUA users in the agent panel. The Scoped handler
+  # determines whether input is focused and routes accordingly; the trie
+  # contains bindings for both states.
+
+  alias Minga.Keymap.CUADefaults
+
+  @cmd 0x08
+
+  @spec cua_trie() :: Bindings.node_t()
+  defp cua_trie do
+    CUADefaults.navigation_trie()
+    # Chat navigation (not input focused)
+    |> Bindings.bind([{@enter, 0}], :agent_focus_input, "Focus input")
+    |> Bindings.bind([{@escape, 0}], :agent_dismiss_or_noop, "Dismiss/cancel")
+    |> Bindings.bind([{@tab, 0}], :agent_switch_focus, "Switch panel focus")
+    # Cmd chords work everywhere
+    |> Bindings.bind([{?c, @cmd}], :agent_copy_code_block, "Copy code block")
+    |> Bindings.bind([{?a, @cmd}], :select_all, "Select all")
+    # Input field bindings (used when input focused)
+    |> Bindings.bind([{@backspace, 0}], :agent_input_backspace, "Delete character")
+    |> Bindings.bind([{@enter, @shift}], :agent_insert_newline, "Insert newline")
+    |> Bindings.bind([{?j, @ctrl}], :agent_insert_newline, "Insert newline")
+    |> Bindings.bind([{0x0A, 0}], :agent_insert_newline, "Insert newline")
+    |> Bindings.bind([{@enter, @alt}], :agent_insert_newline, "Insert newline")
+    # Arrow up/down in input: history navigation
+    |> Bindings.bind([{57_352, 0}], :agent_input_up, "Move up / history prev")
+    |> Bindings.bind([{57_353, 0}], :agent_input_down, "Move down / history next")
+    |> Bindings.bind([{0xF700, 0}], :agent_input_up, "Move up / history prev")
+    |> Bindings.bind([{0xF701, 0}], :agent_input_down, "Move down / history next")
   end
 end

--- a/lib/minga/keymap/scope/file_tree.ex
+++ b/lib/minga/keymap/scope/file_tree.ex
@@ -33,6 +33,7 @@ defmodule Minga.Keymap.Scope.FileTree do
   @spec keymap(Minga.Keymap.Scope.vim_state(), Minga.Keymap.Scope.context()) ::
           Bindings.node_t()
   def keymap(:normal, _context), do: normal_trie()
+  def keymap(:cua, _context), do: cua_trie()
   def keymap(_state, _context), do: Bindings.new()
 
   @impl true
@@ -85,5 +86,23 @@ defmodule Minga.Keymap.Scope.FileTree do
     |> Bindings.bind([{?r, 0}], :tree_refresh, "Refresh file tree")
     |> Bindings.bind([{?q, 0}], :tree_close, "Close file tree")
     |> Bindings.bind([{@escape, 0}], :tree_close, "Close file tree")
+  end
+
+  # ── CUA mode bindings ─────────────────────────────────────────────────────
+  # Arrow keys for navigation, Enter to open, Escape to close.
+  # Left/Right expand/collapse directories (matching macOS Finder).
+
+  alias Minga.Keymap.CUADefaults
+
+  @spec cua_trie() :: Bindings.node_t()
+  defp cua_trie do
+    CUADefaults.navigation_trie()
+    |> Bindings.bind([{@enter, 0}], :tree_open_or_toggle, "Open file / toggle directory")
+    |> Bindings.bind([{@escape, 0}], :tree_close, "Close file tree")
+    # Arrow left/right: collapse/expand (Finder-style)
+    |> Bindings.bind([{57_351, 0}], :tree_expand, "Expand directory")
+    |> Bindings.bind([{57_350, 0}], :tree_collapse, "Collapse directory")
+    |> Bindings.bind([{0xF703, 0}], :tree_expand, "Expand directory")
+    |> Bindings.bind([{0xF702, 0}], :tree_collapse, "Collapse directory")
   end
 end

--- a/lib/minga/keymap/scope/git_status.ex
+++ b/lib/minga/keymap/scope/git_status.ex
@@ -32,6 +32,7 @@ defmodule Minga.Keymap.Scope.GitStatus do
   @spec keymap(Minga.Keymap.Scope.vim_state(), Minga.Keymap.Scope.context()) ::
           Bindings.node_t()
   def keymap(:normal, _context), do: normal_trie()
+  def keymap(:cua, _context), do: cua_trie()
   def keymap(_state, _context), do: Bindings.new()
 
   @impl true
@@ -97,6 +98,27 @@ defmodule Minga.Keymap.Scope.GitStatus do
     |> Bindings.bind([{?c, 0}, {?c, 0}], :git_status_start_commit, "Start commit")
     # Close
     |> Bindings.bind([{?q, 0}], :git_status_close, "Close git status")
+    |> Bindings.bind([{@escape, 0}], :git_status_close, "Close git status")
+  end
+
+  # ── CUA mode bindings ─────────────────────────────────────────────────
+
+  alias Minga.Keymap.CUADefaults
+
+  @cmd 0x08
+
+  @spec cua_trie() :: Bindings.node_t()
+  defp cua_trie do
+    CUADefaults.navigation_trie()
+    # Git operations (same keys as normal, these are domain-specific not vim-specific)
+    |> Bindings.bind([{?s, 0}], :git_status_stage, "Stage file")
+    |> Bindings.bind([{?u, 0}], :git_status_unstage, "Unstage file")
+    |> Bindings.bind([{?d, 0}], :git_status_discard, "Discard changes")
+    |> Bindings.bind([{@tab, 0}], :git_status_toggle_section, "Toggle section collapse")
+    # Open/commit
+    |> Bindings.bind([{@enter, 0}], :git_status_open_file, "Open file")
+    |> Bindings.bind([{?c, @cmd}], :git_status_start_commit, "Start commit")
+    # Close
     |> Bindings.bind([{@escape, 0}], :git_status_close, "Close git status")
   end
 end

--- a/test/minga/keymap/cua_defaults_test.exs
+++ b/test/minga/keymap/cua_defaults_test.exs
@@ -1,0 +1,72 @@
+defmodule Minga.Keymap.CUADefaultsTest do
+  use ExUnit.Case, async: true
+
+  import Bitwise
+
+  alias Minga.Keymap.Bindings
+  alias Minga.Keymap.CUADefaults
+
+  # Arrow key codepoints (Kitty protocol)
+  @arrow_up 57_352
+  @arrow_down 57_353
+
+  # macOS NSEvent arrow keys
+  @ns_up 0xF700
+  @ns_down 0xF701
+
+  @cmd 0x08
+  @shift 0x01
+
+  describe "navigation_trie/0" do
+    test "arrow up resolves to :move_up" do
+      trie = CUADefaults.navigation_trie()
+      assert {:command, :move_up} = Bindings.lookup(trie, {@arrow_up, 0})
+    end
+
+    test "arrow down resolves to :move_down" do
+      trie = CUADefaults.navigation_trie()
+      assert {:command, :move_down} = Bindings.lookup(trie, {@arrow_down, 0})
+    end
+
+    test "macOS NSEvent arrows also work" do
+      trie = CUADefaults.navigation_trie()
+      assert {:command, :move_up} = Bindings.lookup(trie, {@ns_up, 0})
+      assert {:command, :move_down} = Bindings.lookup(trie, {@ns_down, 0})
+    end
+
+    test "unbound key returns :not_found" do
+      trie = CUADefaults.navigation_trie()
+      assert :not_found = Bindings.lookup(trie, {?j, 0})
+    end
+  end
+
+  describe "cmd_chords_trie/0" do
+    test "Cmd+C resolves to :yank_visual_selection" do
+      trie = CUADefaults.cmd_chords_trie()
+      assert {:command, :yank_visual_selection} = Bindings.lookup(trie, {?c, @cmd})
+    end
+
+    test "Cmd+Z resolves to :undo" do
+      trie = CUADefaults.cmd_chords_trie()
+      assert {:command, :undo} = Bindings.lookup(trie, {?z, @cmd})
+    end
+
+    test "Cmd+Shift+Z resolves to :redo" do
+      trie = CUADefaults.cmd_chords_trie()
+      assert {:command, :redo} = Bindings.lookup(trie, {?z, @cmd ||| @shift})
+    end
+
+    test "Cmd+S resolves to :save" do
+      trie = CUADefaults.cmd_chords_trie()
+      assert {:command, :save} = Bindings.lookup(trie, {?s, @cmd})
+    end
+  end
+
+  describe "horizontal_nav_trie/0" do
+    test "provides left and right arrow bindings" do
+      trie = CUADefaults.horizontal_nav_trie()
+      assert {:command, :move_left} = Bindings.lookup(trie, {57_350, 0})
+      assert {:command, :move_right} = Bindings.lookup(trie, {57_351, 0})
+    end
+  end
+end

--- a/test/minga/keymap/scope/cua_scope_test.exs
+++ b/test/minga/keymap/scope/cua_scope_test.exs
@@ -1,0 +1,87 @@
+defmodule Minga.Keymap.Scope.CUAScopeTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Keymap.Scope
+
+  # Arrow keys (Kitty protocol)
+  @arrow_up 57_352
+  @arrow_down 57_353
+  @arrow_left 57_350
+  @arrow_right 57_351
+
+  @enter 13
+  @escape 27
+  @cmd 0x08
+
+  describe "file_tree scope with :cua" do
+    test "arrow up/down resolve to movement commands" do
+      assert {:command, :move_up} = Scope.resolve_key(:file_tree, :cua, {@arrow_up, 0})
+      assert {:command, :move_down} = Scope.resolve_key(:file_tree, :cua, {@arrow_down, 0})
+    end
+
+    test "arrow right expands directory" do
+      assert {:command, :tree_expand} = Scope.resolve_key(:file_tree, :cua, {@arrow_right, 0})
+    end
+
+    test "arrow left collapses directory" do
+      assert {:command, :tree_collapse} = Scope.resolve_key(:file_tree, :cua, {@arrow_left, 0})
+    end
+
+    test "Enter opens file" do
+      assert {:command, :tree_open_or_toggle} = Scope.resolve_key(:file_tree, :cua, {@enter, 0})
+    end
+
+    test "Escape closes tree" do
+      assert {:command, :tree_close} = Scope.resolve_key(:file_tree, :cua, {@escape, 0})
+    end
+
+    test "vim j/k are not bound in CUA mode" do
+      assert :not_found = Scope.resolve_key(:file_tree, :cua, {?j, 0})
+      assert :not_found = Scope.resolve_key(:file_tree, :cua, {?k, 0})
+    end
+  end
+
+  describe "agent scope with :cua" do
+    test "arrow up/down resolve to agent-specific navigation" do
+      assert {:command, :agent_input_up} = Scope.resolve_key(:agent, :cua, {@arrow_up, 0})
+      assert {:command, :agent_input_down} = Scope.resolve_key(:agent, :cua, {@arrow_down, 0})
+    end
+
+    test "Enter focuses input" do
+      assert {:command, :agent_focus_input} = Scope.resolve_key(:agent, :cua, {@enter, 0})
+    end
+
+    test "Cmd+C copies code block" do
+      assert {:command, :agent_copy_code_block} = Scope.resolve_key(:agent, :cua, {?c, @cmd})
+    end
+
+    test "Escape dismisses" do
+      assert {:command, :agent_dismiss_or_noop} = Scope.resolve_key(:agent, :cua, {@escape, 0})
+    end
+  end
+
+  describe "git_status scope with :cua" do
+    test "arrow up/down navigate entries" do
+      assert {:command, :move_up} = Scope.resolve_key(:git_status, :cua, {@arrow_up, 0})
+      assert {:command, :move_down} = Scope.resolve_key(:git_status, :cua, {@arrow_down, 0})
+    end
+
+    test "Enter opens file" do
+      assert {:command, :git_status_open_file} = Scope.resolve_key(:git_status, :cua, {@enter, 0})
+    end
+
+    test "Escape closes panel" do
+      assert {:command, :git_status_close} = Scope.resolve_key(:git_status, :cua, {@escape, 0})
+    end
+
+    test "s stages file (domain key shared with vim)" do
+      assert {:command, :git_status_stage} = Scope.resolve_key(:git_status, :cua, {?s, 0})
+    end
+  end
+
+  describe "editor scope with :cua" do
+    test "returns :not_found (CUA.Dispatch handles buffer editing)" do
+      assert :not_found = Scope.resolve_key(:editor, :cua, {?a, 0})
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

CUA editing bindings now work in all UI surfaces (agent panel, file tree, git status), not just buffer editing. Arrow keys, Enter, Escape, and Cmd-chords work everywhere when `editing_model: :cua` is active.

Closes #1196

## Context

CUA mode worked for buffer editing (Phase D) but fell back to vim keybindings (j/k, y, za) in other surfaces. A CUA user opening the agent panel or file tree would get vim vocabulary they do not know. This completes CUA support across the entire editor.

## Changes

- **New `:cua` vim_state** in `Keymap.Scope` type, alongside `:normal`/`:insert`/`:input_normal`
- **`Keymap.CUADefaults`** module with composable trie fragments: `navigation_trie()` (arrow keys), `cmd_chords_trie()` (Cmd+C/V/Z/S), `horizontal_nav_trie()` (left/right arrows), `editing_trie()` (Escape, Backspace, Tab)
- **`:cua` clause on each scope module:**
  - FileTree: arrows navigate, left/right collapse/expand (Finder-style), Enter opens, Escape closes
  - Agent: arrows scroll, Enter focuses input, Cmd+C copies code block, Escape dismisses
  - GitStatus: arrows navigate, Enter opens, s/u/d stage/unstage/discard, Escape closes
  - Editor: empty (CUA.Dispatch handles buffer editing at the bottom of the stack)
- **Scoped handler** detects CUA model and passes `:cua` as vim_state
- **FileTreeHandler** detects CUA model and passes `:cua` instead of `:normal`

Vim mode completely unchanged. 24 new tests.

## Verification

```bash
mix test test/minga/keymap/cua_defaults_test.exs test/minga/keymap/scope/cua_scope_test.exs
# 24 tests, 0 failures

mix test.llm  # 6,769 tests, 0 failures (excluding pre-existing local snapshot diff)
```

To manually verify: set `editing_model: :cua` in config, open file tree with SPC f t, navigate with arrow keys. Open agent panel with SPC a a, scroll with arrows, press Enter to focus input.

## Acceptance Criteria Addressed

- Arrow keys navigate file tree in CUA mode ✅
- Arrow keys scroll agent chat panel, Enter focuses input, Escape unfocuses ✅
- Cmd+C copies code block in agent panel ✅
- Arrow keys navigate git status entries, Enter opens file ✅
- Picker already works (arrow keys, Enter, Escape) ✅
- Vim mode unchanged ✅
- SPC leader preserved ✅