### PR TITLE
DDD-5a: Credo check enforces domain boundaries for all facade'd domains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,10 +221,8 @@ end
 
 ### What crosses boundaries
 
-- **Function calls** go through the facade. Always.
-- **Struct types** in `@spec` annotations may reference internal modules directly (e.g., `Minga.UI.Face.t()` in a spec is fine). Types are data, not behavior.
-- **Behaviours** that other domains implement (like `Minga.Command.Provider`) are part of the public API.
-- **Protocols** (like `Minga.Editing.Text.Readable`) are part of the public API since implementors need to reference them.
+- **Function calls** go through the facade. Always. No exceptions.
+- **Struct types, protocols, and behaviours** follow the same rule. If a struct or protocol is needed across multiple domains, it should be promoted to a **core entity** at the top level (alongside `Minga.Events`, `Minga.Log`, etc.), not given a special exemption. Reaching past a facade to grab an internal type is still a boundary violation.
 
 ### Domains
 
@@ -253,9 +251,11 @@ end
 
 ### Enforcement
 
-`Minga.Credo.DomainBoundaryCheck` (in `credo/checks/domain_boundary_check.exs`) enforces domain boundaries at lint time. Today it only covers the Agent <-> Buffer boundary. As domains are migrated to the facade pattern, the check will be generalized to enforce all domain boundaries: each domain will declare its facade and a `public` list of struct types allowed across boundaries. The `public` list should shrink over time as facade APIs stabilize.
+`Minga.Credo.DomainBoundaryCheck` (in `credo/checks/domain_boundary_check.exs`) enforces domain boundaries at lint time for all 14 facade'd domains. Any `alias`, `import`, `require`, or `use` of an internal module from outside the domain is flagged as a violation. The only reference that passes cleanly is the facade module itself.
 
-Run `mix credo` to check. The check runs at `:high` priority.
+There is no allowlist. Existing violations show up in `mix credo` output as visible debt. New violations are immediately obvious as new entries.
+
+Run `mix credo` to check. The check runs at `:high` priority with `exit_status: 0` (warns without blocking CI).
 
 ### Adding a new domain
 

--- a/credo/checks/domain_boundary_check.exs
+++ b/credo/checks/domain_boundary_check.exs
@@ -1,30 +1,16 @@
 defmodule Minga.Credo.DomainBoundaryCheck do
   @moduledoc """
-  Enforces domain boundaries between Minga.Agent and Minga.Buffer.
+  Enforces domain boundaries for all facade'd domains in Minga.
 
-  These are separate bounded contexts that share infrastructure through
-  Minga.Editor, Minga.EditingModel, and Minga.NavigableContent, but must
-  never import from each other directly.
+  Each domain has a facade module (e.g., `Minga.Buffer`) that is the
+  only valid entry point from outside the domain. Any reference to an
+  internal module (alias, import, require, use) from outside the domain
+  is a violation. No exceptions for struct types, protocols, or
+  behaviours: if something is genuinely needed across multiple domains,
+  it should be promoted to a core entity at the top level.
 
-  ## Why this exists
-
-  The original Minga architecture had agent code scattered inside the
-  editor namespace (editor/commands/agent.ex, input/scoped.ex with agent
-  branches). Every feature required changes in multiple domains. This
-  check prevents that coupling from creeping back in after the domain
-  reorganization.
-
-  See docs/REFACTOR.md § "Why Not Surfaces?" for the full history.
-
-  ## Rules
-
-  - `Minga.Agent.*` modules must not alias, import, require, or use
-    any `Minga.Buffer.*` module.
-  - `Minga.Buffer.*` modules must not alias, import, require, or use
-    any `Minga.Agent.*` module.
-  - Both may freely reference `Minga.Editor.*`, `Minga.EditingModel.*`,
-    `Minga.NavigableContent`, `Minga.Input.*`, and other shared
-    infrastructure.
+  See AGENTS.md § "Domain Architecture" and BIG_REFACTOR_PLAN.md
+  § "Domain Architecture Integration" for the full rationale.
   """
 
   use Credo.Check,
@@ -33,56 +19,51 @@ defmodule Minga.Credo.DomainBoundaryCheck do
     category: :design,
     explanations: [
       check: """
-      Minga.Agent and Minga.Buffer are separate domains that must not
-      import from each other. Both may use shared infrastructure
-      (Minga.Editor, Minga.EditingModel, Minga.NavigableContent) but
-      never cross-reference each other's modules.
+      Minga uses bounded contexts (domains) with facade modules as the
+      only valid entry point. Code outside a domain must go through the
+      facade, not reference internal modules directly.
 
-      If you need shared functionality, move it to shared infrastructure
-      or use the NavigableContent protocol.
+      Example: use `Minga.Buffer.content(buf)` instead of
+      `Minga.Buffer.Server.content(buf)`.
+
+      If a struct, protocol, or behaviour is needed across domains,
+      promote it to a core entity rather than reaching past the facade.
       """
     ]
 
   @reference_forms [:alias, :import, :require, :use]
 
-  # Agent modules that are allowed to reference Buffer.Server.
-  # The agent's prompt buffer is a Buffer.Server instance, so these
-  # cross-domain references are deliberate and unavoidable.
-  @allowed_agent_buffer_modules [
-    "Minga.Agent.View.PromptRenderer",
-    "Minga.Agent.View.DashboardRenderer",
-    "Minga.Agent.View.RenderInput",
-    # Macro.camelize turns "ui_state" → "UiState", not "UIState"
-    "Minga.Agent.UiState",
-    "Minga.Agent.UiState.Panel",
-    "Minga.Agent.BufferSync",
-    "Minga.Agent.ChatDecorations",
-    # Agent tools route through Buffer.Server when a buffer is open (#905).
-    # This is the core of buffer-routed agent edits.
-    "Minga.Agent.Tools.EditFile",
-    "Minga.Agent.Tools.MultiEditFile",
-    "Minga.Agent.Tools.WriteFile"
-  ]
+  # Domain facade modules. The facade is the only valid entry point.
+  @domains %{
+    agent: "Minga.Agent",
+    buffer: "Minga.Buffer",
+    editing: "Minga.Editing",
+    frontend: "Minga.Frontend",
+    ui: "Minga.UI",
+    project: "Minga.Project",
+    language: "Minga.Language",
+    session: "Minga.Session",
+    config: "Minga.Config",
+    keymap: "Minga.Keymap",
+    command: "Minga.Command",
+    git: "Minga.Git",
+    input: "Minga.Input",
+    mode: "Minga.Mode"
+  }
 
   @impl Credo.Check
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
-
-    # Determine what domain this file's module is in from the filename.
-    # This avoids tracking module names through AST traversal state.
     filename = source_file.filename
-
     source_domain = domain_for_file(filename)
-    source_module = module_for_file(filename)
 
-    # Skip files outside agent/buffer domains, and skip test files
-    # (tests naturally need to reference the modules they test).
-    if source_domain && source_module do
-      source_file
-      |> Credo.Code.prewalk(&find_violations(&1, &2, source_domain, source_module, issue_meta))
-      |> Enum.filter(&is_map/1)
-    else
+    # Skip test files (tests naturally reference the modules they test)
+    if test_file?(filename) do
       []
+    else
+      source_file
+      |> Credo.Code.prewalk(&find_violations(&1, &2, source_domain, issue_meta))
+      |> Enum.filter(&is_map/1)
     end
   end
 
@@ -90,73 +71,60 @@ defmodule Minga.Credo.DomainBoundaryCheck do
          {form, meta, [{:__aliases__, _, ref_parts} | _]} = ast,
          issues,
          source_domain,
-         source_module,
          issue_meta
        )
        when form in @reference_forms do
-    ref_name = Enum.join(ref_parts, ".")
-    target_domain = domain_for_module(ref_name)
+    if Enum.all?(ref_parts, &is_atom/1) do
+      ref_name = Enum.map_join(ref_parts, ".", &Atom.to_string/1)
+      target_domain = domain_for_module(ref_name)
 
-    if target_domain && violates_boundary?(source_domain, target_domain) &&
-         not allowed?(source_module, source_domain, target_domain) do
-      issue =
-        format_issue(issue_meta,
-          message:
-            "#{source_domain} must not reference #{target_domain} (domain boundary violation: #{form} #{ref_name})",
-          trigger: ref_name,
-          line_no: meta[:line]
-        )
+      if target_domain &&
+           target_domain != source_domain &&
+           ref_name != Map.fetch!(@domains, target_domain) do
+        facade = Map.fetch!(@domains, target_domain)
 
-      {ast, [issue | issues]}
+        issue =
+          format_issue(issue_meta,
+            message:
+              "Domain boundary violation: #{form} #{ref_name}. " <>
+                "Use the `#{facade}` facade instead.",
+            trigger: ref_name,
+            line_no: meta[:line]
+          )
+
+        {ast, [issue | issues]}
+      else
+        {ast, issues}
+      end
     else
       {ast, issues}
     end
   end
 
-  defp find_violations(ast, issues, _source_domain, _source_module, _issue_meta),
+  defp find_violations(ast, issues, _source_domain, _issue_meta),
     do: {ast, issues}
 
-  # Check if this specific module is allowed to cross the boundary.
-  defp allowed?(nil, _source_domain, _target_domain), do: false
-
-  defp allowed?(source_module, :agent, :buffer) do
-    source_module in @allowed_agent_buffer_modules
+  defp test_file?(filename) do
+    String.contains?(Path.expand(filename), "/test/")
   end
 
-  defp allowed?(_source_module, _source_domain, _target_domain), do: false
-
-  # Extract a likely module name from the file path.
-  # Returns nil for test files (tests are always allowed to cross boundaries).
-  defp module_for_file(filename) do
-    expanded = Path.expand(filename)
-
-    if String.contains?(expanded, "/test/") do
-      nil
-    else
-      expanded
-      |> String.split("/lib/")
-      |> List.last()
-      |> String.trim_trailing(".ex")
-      |> String.split("/")
-      |> Enum.map_join(".", &Macro.camelize/1)
-    end
-  end
-
+  # Determine which domain a file belongs to from its path.
+  @spec domain_for_file(String.t()) :: atom() | nil
   defp domain_for_file(filename) do
     expanded = Path.expand(filename)
 
-    cond do
-      String.contains?(expanded, "/minga/agent/") -> :agent
-      String.contains?(expanded, "/minga/buffer/") -> :buffer
-      true -> nil
-    end
+    Enum.find_value(@domains, fn {domain, _facade} ->
+      if String.contains?(expanded, "/minga/#{domain}/"), do: domain
+    end)
   end
 
-  defp domain_for_module("Minga.Agent." <> _), do: :agent
-  defp domain_for_module("Minga.Buffer." <> _), do: :buffer
-  defp domain_for_module(_), do: nil
-
-  defp violates_boundary?(:agent, :buffer), do: true
-  defp violates_boundary?(:buffer, :agent), do: true
-  defp violates_boundary?(_, _), do: false
+  # Determine which domain a module belongs to from its name.
+  @spec domain_for_module(String.t()) :: atom() | nil
+  defp domain_for_module(ref_name) do
+    Enum.find_value(@domains, fn {domain, facade} ->
+      if ref_name == facade || String.starts_with?(ref_name, facade <> ".") do
+        domain
+      end
+    end)
+  end
 end

--- a/lib/minga/agent/events.ex
+++ b/lib/minga/agent/events.ex
@@ -295,7 +295,9 @@ defmodule Minga.Agent.Events do
   defp track_board_card_file(state, _path), do: state
 
   # Finds a Board card by agent session PID and applies an update function.
-  @spec update_board_card_by_session(EditorState.t(), pid(), (Minga.Shell.Board.Card.t() -> Minga.Shell.Board.Card.t())) :: EditorState.t()
+  @spec update_board_card_by_session(EditorState.t(), pid(), (Minga.Shell.Board.Card.t() ->
+                                                                Minga.Shell.Board.Card.t())) ::
+          EditorState.t()
   defp update_board_card_by_session(state, session, update_fn) do
     board = state.shell_state
 

--- a/lib/minga/editor/commands/ui.ex
+++ b/lib/minga/editor/commands/ui.ex
@@ -111,15 +111,17 @@ defmodule Minga.Editor.Commands.UI do
   defp toggle_board(%{shell: Minga.Shell.Board} = state) do
     # Stash Board state so we can restore it when toggling back
     board_state = state.shell_state
+
     traditional_state = %Minga.Shell.Traditional.State{
       suppress_tool_prompts: board_state.suppress_tool_prompts
     }
 
-    %{state |
-      shell: Minga.Shell.Traditional,
-      shell_state: traditional_state,
-      layout: nil,
-      stashed_board_state: board_state
+    %{
+      state
+      | shell: Minga.Shell.Traditional,
+        shell_state: traditional_state,
+        layout: nil,
+        stashed_board_state: board_state
     }
   end
 
@@ -127,11 +129,12 @@ defmodule Minga.Editor.Commands.UI do
     # Restore stashed Board state, or create fresh if none
     board_state = Map.get(state, :stashed_board_state) || Minga.Shell.Board.init()
 
-    %{state |
-      shell: Minga.Shell.Board,
-      shell_state: board_state,
-      layout: nil,
-      stashed_board_state: nil
+    %{
+      state
+      | shell: Minga.Shell.Board,
+        shell_state: board_state,
+        layout: nil,
+        stashed_board_state: nil
     }
   end
 

--- a/lib/minga/frontend/emit.ex
+++ b/lib/minga/frontend/emit.ex
@@ -231,5 +231,4 @@ defmodule Minga.Frontend.Emit do
       end
     end
   end
-
 end

--- a/lib/minga/frontend/emit/gui.ex
+++ b/lib/minga/frontend/emit/gui.ex
@@ -170,7 +170,9 @@ defmodule Minga.Frontend.Emit.GUI do
   @spec build_gui_tab_bar_cmd(state()) :: binary() | nil
 
   # Board zoomed: show a single tab with the card name and a back indicator
-  defp build_gui_tab_bar_cmd(%{shell: Minga.Shell.Board, shell_state: %{zoomed_into: card_id}} = state)
+  defp build_gui_tab_bar_cmd(
+         %{shell: Minga.Shell.Board, shell_state: %{zoomed_into: card_id}} = state
+       )
        when card_id != nil do
     card = Minga.Shell.Board.State.zoomed(state.shell_state)
     label = if card, do: "◇ #{card.task}", else: "◇ Board"

--- a/lib/minga/frontend/protocol/gui.ex
+++ b/lib/minga/frontend/protocol/gui.ex
@@ -652,8 +652,8 @@ defmodule Minga.Frontend.Protocol.GUI do
 
     IO.iodata_to_binary([
       @op_gui_board,
-      <<visible::8, focused_id::32, length(cards)::16,
-        filter_mode::8, byte_size(filter_bytes)::16, filter_bytes::binary>>
+      <<visible::8, focused_id::32, length(cards)::16, filter_mode::8,
+        byte_size(filter_bytes)::16, filter_bytes::binary>>
       | card_entries
     ])
   end
@@ -685,11 +685,8 @@ defmodule Minga.Frontend.Protocol.GUI do
       end)
 
     IO.iodata_to_binary([
-      <<card.id::32, status_byte::8, flags::8,
-        byte_size(task_bytes)::16, task_bytes::binary,
-        byte_size(model_bytes)::8, model_bytes::binary,
-        elapsed::32,
-        length(recent_files)::8>>
+      <<card.id::32, status_byte::8, flags::8, byte_size(task_bytes)::16, task_bytes::binary,
+        byte_size(model_bytes)::8, model_bytes::binary, elapsed::32, length(recent_files)::8>>
       | file_entries
     ])
   end

--- a/lib/minga/shell/board.ex
+++ b/lib/minga/shell/board.ex
@@ -38,7 +38,9 @@ defmodule Minga.Shell.Board do
         if Enum.any?(restored.cards, fn {_id, c} -> c.kind == :you end) do
           restored
         else
-          {restored, _you} = BoardState.create_card(restored, task: "You", status: :idle, kind: :you)
+          {restored, _you} =
+            BoardState.create_card(restored, task: "You", status: :idle, kind: :you)
+
           restored
         end
 
@@ -121,7 +123,8 @@ defmodule Minga.Shell.Board do
   @spec build_chrome(term(), Minga.Editor.Layout.t(), map(), term()) ::
           Minga.Editor.RenderPipeline.Chrome.t()
   def build_chrome(editor_state, layout, scrolls, cursor_info) do
-    chrome = Minga.Editor.RenderPipeline.Chrome.build_chrome(editor_state, layout, scrolls, cursor_info)
+    chrome =
+      Minga.Editor.RenderPipeline.Chrome.build_chrome(editor_state, layout, scrolls, cursor_info)
 
     if BoardState.grid_view?(editor_state.shell_state) do
       chrome
@@ -178,7 +181,10 @@ defmodule Minga.Shell.Board do
 
   @spec zoom_status_face(Minga.Shell.Board.Card.status(), Minga.UI.Theme.t()) :: Minga.UI.Face.t()
   defp zoom_status_face(:working, theme), do: Minga.UI.Face.new(fg: 0x98C379, bg: theme.editor.bg)
-  defp zoom_status_face(:needs_you, theme), do: Minga.UI.Face.new(fg: 0xE5C07B, bg: theme.editor.bg)
+
+  defp zoom_status_face(:needs_you, theme),
+    do: Minga.UI.Face.new(fg: 0xE5C07B, bg: theme.editor.bg)
+
   defp zoom_status_face(:done, theme), do: Minga.UI.Face.new(fg: 0x61AFEF, bg: theme.editor.bg)
   defp zoom_status_face(:errored, theme), do: Minga.UI.Face.new(fg: 0xE06C75, bg: theme.editor.bg)
   defp zoom_status_face(_, theme), do: Minga.UI.Face.new(fg: 0x5C6370, bg: theme.editor.bg)

--- a/lib/minga/shell/board/input.ex
+++ b/lib/minga/shell/board/input.ex
@@ -162,11 +162,12 @@ defmodule Minga.Shell.Board.Input do
       suppress_tool_prompts: board_state.suppress_tool_prompts
     }
 
-    new_state = %{state |
-      shell: Minga.Shell.Traditional,
-      shell_state: traditional_state,
-      layout: nil,
-      stashed_board_state: board_state
+    new_state = %{
+      state
+      | shell: Minga.Shell.Traditional,
+        shell_state: traditional_state,
+        layout: nil,
+        stashed_board_state: board_state
     }
 
     {:handled, new_state}
@@ -204,8 +205,11 @@ defmodule Minga.Shell.Board.Input do
 
     board =
       case matches do
-        [first | _] -> BoardState.focus_card(%{board | filter_mode: false, filter_text: ""}, first.id)
-        [] -> %{board | filter_mode: false, filter_text: ""}
+        [first | _] ->
+          BoardState.focus_card(%{board | filter_mode: false, filter_text: ""}, first.id)
+
+        [] ->
+          %{board | filter_mode: false, filter_text: ""}
       end
 
     {:handled, %{state | shell_state: board}}
@@ -291,9 +295,10 @@ defmodule Minga.Shell.Board.Input do
     ws = %{state.workspace | keymap_scope: :agent}
 
     # Make the agent panel visible
-    state = Minga.Editor.State.AgentAccess.update_agent_ui(state, fn ui ->
-      Minga.Agent.UIState.set_input_focused(ui, true)
-    end)
+    state =
+      Minga.Editor.State.AgentAccess.update_agent_ui(state, fn ui ->
+        Minga.Agent.UIState.set_input_focused(ui, true)
+      end)
 
     %{state | workspace: ws}
   end

--- a/lib/minga/shell/board/persistence.ex
+++ b/lib/minga/shell/board/persistence.ex
@@ -126,7 +126,10 @@ defmodule Minga.Shell.Board.Persistence do
 
         _ ->
           Path.join(
-            System.get_env("XDG_DATA_HOME", Path.join(System.get_env("HOME", "~"), ".local/share")),
+            System.get_env(
+              "XDG_DATA_HOME",
+              Path.join(System.get_env("HOME", "~"), ".local/share")
+            ),
             "minga"
           )
       end

--- a/lib/minga/shell/board/renderer.ex
+++ b/lib/minga/shell/board/renderer.ex
@@ -97,7 +97,12 @@ defmodule Minga.Shell.Board.Renderer do
 
     [
       DisplayList.draw(0, 0, title, face),
-      DisplayList.draw(0, String.length(title), pad_right(count_text, max(cols - String.length(title), 0)), dim_face)
+      DisplayList.draw(
+        0,
+        String.length(title),
+        pad_right(count_text, max(cols - String.length(title), 0)),
+        dim_face
+      )
     ]
   end
 
@@ -145,7 +150,11 @@ defmodule Minga.Shell.Board.Renderer do
         elapsed = format_elapsed(card.created_at)
 
         line = build_two_column_line(icon <> " " <> label, elapsed, inner_width)
-        [DisplayList.draw(content_start, col, @v <> " " <> line <> " " <> @v, status_face) | draws]
+
+        [
+          DisplayList.draw(content_start, col, @v <> " " <> line <> " " <> @v, status_face)
+          | draws
+        ]
       else
         draws
       end
@@ -154,7 +163,11 @@ defmodule Minga.Shell.Board.Renderer do
     draws =
       if content_start + 1 <= content_end do
         task = pad_right(card.task, inner_width)
-        [DisplayList.draw(content_start + 1, col, @v <> " " <> task <> " " <> @v, content_face) | draws]
+
+        [
+          DisplayList.draw(content_start + 1, col, @v <> " " <> task <> " " <> @v, content_face)
+          | draws
+        ]
       else
         draws
       end
@@ -163,7 +176,8 @@ defmodule Minga.Shell.Board.Renderer do
     fill_face = Face.new(fg: 0x5C6370, bg: card_bg)
 
     draws =
-      Enum.reduce((content_start + 2)..max(content_end - 1, content_start + 1)//1, draws, fn r, acc ->
+      Enum.reduce((content_start + 2)..max(content_end - 1, content_start + 1)//1, draws, fn r,
+                                                                                             acc ->
         blank_line = String.duplicate(" ", inner_width)
         [DisplayList.draw(r, col, @v <> " " <> blank_line <> " " <> @v, fill_face) | acc]
       end)
@@ -277,7 +291,12 @@ defmodule Minga.Shell.Board.Renderer do
     [
       DisplayList.draw(bar_row, 0, prompt, bar_face),
       DisplayList.draw(bar_row, String.length(prompt), filter_text <> cursor, text_face),
-      DisplayList.draw(bar_row, String.length(line), String.duplicate(" ", max(cols - String.length(line), 0)), bar_face)
+      DisplayList.draw(
+        bar_row,
+        String.length(line),
+        String.duplicate(" ", max(cols - String.length(line), 0)),
+        bar_face
+      )
     ]
   end
 

--- a/lib/minga/shell/board/zoom_out.ex
+++ b/lib/minga/shell/board/zoom_out.ex
@@ -53,9 +53,10 @@ defmodule Minga.Shell.Board.ZoomOut do
     # Store the live (zoomed) workspace onto the card for next zoom-in
     live_workspace = Map.from_struct(state.workspace)
 
-    board = BoardState.update_card(board, card_id, fn c ->
-      Card.store_workspace(c, live_workspace)
-    end)
+    board =
+      BoardState.update_card(board, card_id, fn c ->
+        Card.store_workspace(c, live_workspace)
+      end)
 
     # Clear zoom state
     board = %{board | zoomed_into: nil}

--- a/test/minga/credo/domain_boundary_check_test.exs
+++ b/test/minga/credo/domain_boundary_check_test.exs
@@ -1,0 +1,228 @@
+Code.require_file("credo/checks/domain_boundary_check.exs")
+
+defmodule Minga.Credo.DomainBoundaryCheckTest do
+  use Credo.Test.Case, async: false
+
+  alias Minga.Credo.DomainBoundaryCheck
+
+  @moduletag :credo
+
+  # Credo's test helpers need the SourceFileAST service running.
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  # Helper: run the check against inline source code with a given filename.
+  defp check(source_code, filename) do
+    source_code
+    |> to_source_file(filename)
+    |> run_check(DomainBoundaryCheck, [])
+  end
+
+  describe "catches violations" do
+    test "flags alias of internal module from outside the domain" do
+      """
+      defmodule Minga.Editor.Commands.Foo do
+        alias Minga.Buffer.Server
+      end
+      """
+      |> check("lib/minga/editor/commands/foo.ex")
+      |> assert_issue(%{trigger: "Minga.Buffer.Server"})
+    end
+
+    test "flags import of internal module" do
+      """
+      defmodule Minga.Editor.Foo do
+        import Minga.Config.Options
+      end
+      """
+      |> check("lib/minga/editor/foo.ex")
+      |> assert_issue(%{trigger: "Minga.Config.Options"})
+    end
+
+    test "flags require of internal module" do
+      """
+      defmodule Minga.Agent.Foo do
+        require Minga.Buffer.Document
+      end
+      """
+      |> check("lib/minga/agent/foo.ex")
+      |> assert_issue(%{trigger: "Minga.Buffer.Document"})
+    end
+
+    test "flags use of internal module" do
+      """
+      defmodule Minga.Project.Foo do
+        use Minga.Git.Backend
+      end
+      """
+      |> check("lib/minga/project/foo.ex")
+      |> assert_issue(%{trigger: "Minga.Git.Backend"})
+    end
+
+    test "flags deeply nested internal module" do
+      """
+      defmodule Minga.Editor.Foo do
+        alias Minga.Buffer.Decorations.FoldRegion
+      end
+      """
+      |> check("lib/minga/editor/foo.ex")
+      |> assert_issue(%{trigger: "Minga.Buffer.Decorations.FoldRegion"})
+    end
+
+    test "flags multiple violations in one file" do
+      """
+      defmodule Minga.Agent.Foo do
+        alias Minga.Buffer.Server
+        alias Minga.Config.Options
+        alias Minga.UI.Face
+      end
+      """
+      |> check("lib/minga/agent/foo.ex")
+      |> assert_issues(3)
+    end
+
+    test "flags crossing from top-level module into domain" do
+      """
+      defmodule Minga.SomeTopLevel do
+        alias Minga.Buffer.Server
+      end
+      """
+      |> check("lib/minga/some_top_level.ex")
+      |> assert_issue()
+    end
+
+    test "flags protocols and behaviours (no exceptions)" do
+      """
+      defmodule Minga.Agent.Foo do
+        alias Minga.Command.Provider
+        alias Minga.Input.Handler
+      end
+      """
+      |> check("lib/minga/agent/foo.ex")
+      |> assert_issues(2)
+    end
+  end
+
+  describe "allows valid references" do
+    test "allows alias of facade module" do
+      """
+      defmodule Minga.Editor.Foo do
+        alias Minga.Buffer
+      end
+      """
+      |> check("lib/minga/editor/foo.ex")
+      |> refute_issues()
+    end
+
+    test "allows intra-domain references" do
+      """
+      defmodule Minga.Buffer.Server do
+        alias Minga.Buffer.Document
+      end
+      """
+      |> check("lib/minga/buffer/server.ex")
+      |> refute_issues()
+    end
+
+    test "allows references to non-domain modules" do
+      """
+      defmodule Minga.Editor.Foo do
+        alias Minga.Events
+        alias Minga.Log
+        alias Minga.Clipboard
+      end
+      """
+      |> check("lib/minga/editor/foo.ex")
+      |> refute_issues()
+    end
+
+    test "skips test files entirely" do
+      """
+      defmodule Minga.Buffer.ServerTest do
+        alias Minga.Buffer.Server
+        alias Minga.Config.Options
+      end
+      """
+      |> check("test/minga/buffer/server_test.exs")
+      |> refute_issues()
+    end
+
+    test "allows multiple facade references" do
+      """
+      defmodule Minga.Editor.Foo do
+        alias Minga.Buffer
+        alias Minga.Config
+        alias Minga.UI
+      end
+      """
+      |> check("lib/minga/editor/foo.ex")
+      |> refute_issues()
+    end
+  end
+
+  describe "covers all 14 domains" do
+    # Map domain atoms to their facade module name segments.
+    # Most are Macro.camelize, but "ui" -> "UI" is a special case.
+    domain_facades = %{
+      "agent" => "Agent",
+      "buffer" => "Buffer",
+      "editing" => "Editing",
+      "frontend" => "Frontend",
+      "ui" => "UI",
+      "project" => "Project",
+      "language" => "Language",
+      "session" => "Session",
+      "config" => "Config",
+      "keymap" => "Keymap",
+      "command" => "Command",
+      "git" => "Git",
+      "input" => "Input",
+      "mode" => "Mode"
+    }
+
+    for {domain, segment} <- domain_facades do
+      test "catches violations targeting #{domain} domain" do
+        facade = "Minga.#{unquote(segment)}"
+        internal = "#{facade}.SomeInternal"
+
+        """
+        defmodule Minga.Editor.TestModule do
+          alias #{internal}
+        end
+        """
+        |> check("lib/minga/editor/test_module.ex")
+        |> assert_issue(fn issue ->
+          assert issue.message =~ facade
+        end)
+      end
+    end
+  end
+
+  describe "message format" do
+    test "suggests the correct facade module" do
+      """
+      defmodule Minga.Editor.Foo do
+        alias Minga.Git.Tracker
+      end
+      """
+      |> check("lib/minga/editor/foo.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Use the `Minga.Git` facade instead."
+      end)
+    end
+
+    test "names the violating form and module" do
+      """
+      defmodule Minga.Agent.Foo do
+        alias Minga.Buffer.Server
+      end
+      """
+      |> check("lib/minga/agent/foo.ex")
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "alias Minga.Buffer.Server"
+      end)
+    end
+  end
+end

--- a/test/minga/frontend/protocol_gui_board_test.exs
+++ b/test/minga/frontend/protocol_gui_board_test.exs
@@ -14,9 +14,8 @@ defmodule Minga.Frontend.Protocol.GUIBoardTest do
 
   # Helper: parse the gui_board header and return the card data portion
   defp parse_board_header(binary) do
-    <<0x87, visible::8, focused_id::32, card_count::16,
-      filter_mode::8, filter_len::16, _filter::binary-size(filter_len),
-      card_data::binary>> = binary
+    <<0x87, visible::8, focused_id::32, card_count::16, filter_mode::8, filter_len::16,
+      _filter::binary-size(filter_len), card_data::binary>> = binary
 
     %{
       visible: visible,
@@ -33,8 +32,9 @@ defmodule Minga.Frontend.Protocol.GUIBoardTest do
       binary = GUI.encode_gui_board(state)
 
       # opcode(0x87) + visible(1) + focused_card_id(4) + card_count(2) + filter_mode(1) + filter_len(2)
-      assert <<0x87, visible::8, _focused::32, card_count::16, filter_mode::8,
-               filter_len::16, _rest::binary>> = binary
+      assert <<0x87, visible::8, _focused::32, card_count::16, filter_mode::8, filter_len::16,
+               _rest::binary>> = binary
+
       assert visible == 1
       assert card_count == 0
       assert filter_mode == 0
@@ -45,16 +45,15 @@ defmodule Minga.Frontend.Protocol.GUIBoardTest do
       {state, _card} = State.create_card(State.new(), task: "refactor auth", model: "claude-4")
       binary = GUI.encode_gui_board(state)
 
-      <<0x87, _visible::8, focused_id::32, card_count::16,
-        _filter_mode::8, filter_len::16, _filter::binary-size(filter_len),
-        rest::binary>> = binary
+      <<0x87, _visible::8, focused_id::32, card_count::16, _filter_mode::8, filter_len::16,
+        _filter::binary-size(filter_len), rest::binary>> = binary
+
       assert card_count == 1
       assert focused_id == 1
 
       # Parse the card: id(4) + status(1) + flags(1) + task_len(2) + task
-      <<card_id::32, status::8, flags::8, task_len::16, task::binary-size(task_len),
-        model_len::8, model::binary-size(model_len), _elapsed::32, file_count::8,
-        _rest::binary>> = rest
+      <<card_id::32, status::8, flags::8, task_len::16, task::binary-size(task_len), model_len::8,
+        model::binary-size(model_len), _elapsed::32, file_count::8, _rest::binary>> = rest
 
       assert card_id == 1
       assert status == 0
@@ -119,8 +118,9 @@ defmodule Minga.Frontend.Protocol.GUIBoardTest do
       {state, _} = State.create_card(State.new(), task: "修复认证 🔐", model: "gemini-2")
 
       %{card_data: data} = GUI.encode_gui_board(state) |> parse_board_header()
-      <<_id::32, _s::8, _f::8, task_len::16, task::binary-size(task_len),
-        model_len::8, model::binary-size(model_len), _::binary>> = data
+
+      <<_id::32, _s::8, _f::8, task_len::16, task::binary-size(task_len), model_len::8,
+        model::binary-size(model_len), _::binary>> = data
 
       assert task == "修复认证 🔐"
       assert model == "gemini-2"
@@ -128,14 +128,17 @@ defmodule Minga.Frontend.Protocol.GUIBoardTest do
 
     test "encodes recent files" do
       {state, card} =
-        State.create_card(State.new(), task: "t", recent_files: ["lib/auth.ex", "test/auth_test.exs"])
+        State.create_card(State.new(),
+          task: "t",
+          recent_files: ["lib/auth.ex", "test/auth_test.exs"]
+        )
 
       state = State.update_card(state, card.id, & &1)
 
       %{card_data: data} = GUI.encode_gui_board(state) |> parse_board_header()
-      <<_id::32, _s::8, _f::8, task_len::16, _task::binary-size(task_len),
-        model_len::8, _model::binary-size(model_len), _elapsed::32,
-        file_count::8, rest::binary>> = data
+
+      <<_id::32, _s::8, _f::8, task_len::16, _task::binary-size(task_len), model_len::8,
+        _model::binary-size(model_len), _elapsed::32, file_count::8, rest::binary>> = data
 
       assert file_count == 2
       <<p1_len::16, p1::binary-size(p1_len), p2_len::16, p2::binary-size(p2_len)>> = rest

--- a/test/minga/shell/board/layout_test.exs
+++ b/test/minga/shell/board/layout_test.exs
@@ -160,9 +160,11 @@ defmodule Minga.Shell.Board.LayoutTest do
   # ── Property: non-overlap invariant ────────────────────────────────────
 
   property "card rects never overlap for any viewport size and card count" do
-    check all width <- integer(20..200),
-              height <- integer(8..60),
-              card_count <- integer(1..20) do
+    check all(
+            width <- integer(20..200),
+            height <- integer(8..60),
+            card_count <- integer(1..20)
+          ) do
       state = build_board(card_count)
       layout = Layout.compute(state, width, height)
 
@@ -180,9 +182,11 @@ defmodule Minga.Shell.Board.LayoutTest do
   # ── Property: bounds invariant ─────────────────────────────────────────
 
   property "all card rects fit within viewport bounds" do
-    check all width <- integer(20..200),
-              height <- integer(8..60),
-              card_count <- integer(1..20) do
+    check all(
+            width <- integer(20..200),
+            height <- integer(8..60),
+            card_count <- integer(1..20)
+          ) do
       state = build_board(card_count)
       layout = Layout.compute(state, width, height)
 
@@ -191,7 +195,9 @@ defmodule Minga.Shell.Board.LayoutTest do
         assert col >= 0, "col #{col} is negative"
         assert w > 0, "width #{w} is not positive"
         assert h > 0, "height #{h} is not positive"
-        assert col + w <= width, "card exceeds viewport width: col=#{col} w=#{w} viewport=#{width}"
+
+        assert col + w <= width,
+               "card exceeds viewport width: col=#{col} w=#{w} viewport=#{width}"
       end
     end
   end
@@ -199,9 +205,11 @@ defmodule Minga.Shell.Board.LayoutTest do
   # ── Property: all cards get a rect ─────────────────────────────────────
 
   property "every card gets a rect in the layout" do
-    check all width <- integer(30..200),
-              height <- integer(10..60),
-              card_count <- integer(1..15) do
+    check all(
+            width <- integer(30..200),
+            height <- integer(10..60),
+            card_count <- integer(1..15)
+          ) do
       state = build_board(card_count)
       layout = Layout.compute(state, width, height)
 

--- a/test/minga/shell/board/state_test.exs
+++ b/test/minga/shell/board/state_test.exs
@@ -48,7 +48,7 @@ defmodule Minga.Shell.Board.StateTest do
   # ── Card ID uniqueness (property) ──────────────────────────────────────
 
   property "card IDs are always unique across any number of creates" do
-    check all n <- integer(1..50) do
+    check all(n <- integer(1..50)) do
       state =
         Enum.reduce(1..n, State.new(), fn _, acc ->
           {acc, _card} = State.create_card(acc, task: "t")
@@ -206,7 +206,7 @@ defmodule Minga.Shell.Board.StateTest do
   # ── Zoom round-trip (property) ─────────────────────────────────────────
 
   property "zoom_into then zoom_out restores the original workspace snapshot" do
-    check all task <- string(:printable, min_length: 1, max_length: 100) do
+    check all(task <- string(:printable, min_length: 1, max_length: 100)) do
       {state, card} = State.create_card(State.new(), task: task)
       workspace = %{content: task, cursor: {0, 0}}
 

--- a/test/minga/shell/board_integration_test.exs
+++ b/test/minga/shell/board_integration_test.exs
@@ -42,10 +42,11 @@ defmodule Minga.Shell.BoardIntegrationTest do
       # Toggle back via :sys.replace_state (Board grid consumes
       # unmodified keys, so SPC leader doesn't work from grid view).
       :sys.replace_state(ctx.editor, fn state ->
-        %{state |
-          shell: Minga.Shell.Traditional,
-          shell_state: %Minga.Shell.Traditional.State{},
-          layout: nil
+        %{
+          state
+          | shell: Minga.Shell.Traditional,
+            shell_state: %Minga.Shell.Traditional.State{},
+            layout: nil
         }
       end)
 

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -77,7 +77,8 @@ defmodule Minga.Test.EditorCase do
       suppress_tool_prompts: true
     ]
 
-    editor_opts = if shell, do: [{:shell, shell}, {:skip_persistence, true} | editor_opts], else: editor_opts
+    editor_opts =
+      if shell, do: [{:shell, shell}, {:skip_persistence, true} | editor_opts], else: editor_opts
 
     {:ok, editor} = Editor.start_link(editor_opts)
 


### PR DESCRIPTION
## What

Expands `DomainBoundaryCheck` from Agent <-> Buffer only to all 14 facade'd domains. Any `alias`, `import`, `require`, or `use` of an internal module from outside the domain is a violation. The facade is the only valid entry point.

## Design decisions (refined during implementation)

Three simplifications over the original ticket spec, each driven by DDD principles:

1. **No public type exceptions.** The ticket proposed a "public list" of struct types allowed across boundaries. We ruled this out: if a struct is genuinely needed in multiple domains, it should be promoted to a core entity at the top level, not exempted from enforcement.

2. **No protocol/behaviour exceptions.** Same reasoning. Protocols and behaviours inside a domain that are implemented across domains should be core entities, not special-cased.

3. **No allowlist.** The ticket proposed per-module allowlists for existing violations. We dropped this: the allowlist hides debt instead of surfacing it, creates maintenance burden, and tempts developers to add entries instead of fixing crossings. Existing violations show up in `mix credo` output as visible debt (487 currently). The `exit_status: 0` config means it warns without blocking CI.

## Result

The check is 130 lines. One rule: facade or violation.

- 14 domains: agent, buffer, editing, frontend, ui, project, language, session, config, keymap, command, git, input, mode
- 487 existing boundary violations surfaced
- 29 tests covering all domains, valid references, test file skipping, message format
- AGENTS.md updated to reflect the stricter boundary model

## Files changed

- `credo/checks/domain_boundary_check.exs` -- rewritten
- `test/minga/credo/domain_boundary_check_test.exs` -- new
- `AGENTS.md` -- updated "What crosses boundaries" and "Enforcement" sections

Closes #1205