### PR TITLE
feat(macos): Board cards activity sparkline

### DIFF
--- a/lib/minga/frontend/protocol/gui.ex
+++ b/lib/minga/frontend/protocol/gui.ex
@@ -726,12 +726,31 @@ defmodule Minga.Frontend.Protocol.GUI do
         <<byte_size(path_bytes)::16, path_bytes::binary>>
       end)
 
+    # Encode sparkline data as half-precision floats (Float16)
+    sparkline = card.sparkline
+    sparkline_count = length(sparkline)
+
+    sparkline_bytes =
+      sparkline
+      |> Enum.map(&encode_float16/1)
+      |> IO.iodata_to_binary()
+
     IO.iodata_to_binary([
       <<card.id::32, status_byte::8, flags::8, byte_size(task_bytes)::16, task_bytes::binary,
         byte_size(model_bytes)::8, model_bytes::binary, dispatch_timestamp::32,
-        length(recent_files)::8>>
-      | file_entries
+        length(recent_files)::8>>,
+      file_entries,
+      <<sparkline_count::8, sparkline_bytes::binary>>
     ])
+  end
+
+  # Encode a float as Float16 (half-precision, 16 bits)
+  # Simple approximation: clamp to [0.0, 1.0], scale to [0, 65535]
+  @spec encode_float16(float()) :: binary()
+  defp encode_float16(value) do
+    clamped = max(0.0, min(1.0, value))
+    scaled = round(clamped * 65_535.0)
+    <<scaled::16>>
   end
 
   @spec board_status_byte(Minga.Shell.Board.Card.status()) :: non_neg_integer()

--- a/lib/minga/shell/board/card.ex
+++ b/lib/minga/shell/board/card.ex
@@ -33,7 +33,8 @@ defmodule Minga.Shell.Board.Card do
           model: String.t() | nil,
           kind: :you | :agent,
           created_at: DateTime.t(),
-          recent_files: [String.t()]
+          recent_files: [String.t()],
+          sparkline: [float()]
         }
 
   @enforce_keys [:id, :task]
@@ -45,7 +46,8 @@ defmodule Minga.Shell.Board.Card do
             model: nil,
             kind: :agent,
             created_at: nil,
-            recent_files: []
+            recent_files: [],
+            sparkline: []
 
   @doc "Creates a new card with the given attributes."
   @spec new(id(), keyword()) :: t()
@@ -59,7 +61,8 @@ defmodule Minga.Shell.Board.Card do
       status: Keyword.get(attrs, :status, :idle),
       kind: Keyword.get(attrs, :kind, :agent),
       created_at: DateTime.utc_now(),
-      recent_files: Keyword.get(attrs, :recent_files, [])
+      recent_files: Keyword.get(attrs, :recent_files, []),
+      sparkline: Keyword.get(attrs, :sparkline, [])
     }
   end
 

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -39,9 +39,11 @@
 		2BA99A1851D0FF01436D5FF8 /* ToolManagerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64B96EAA100E627F4E8E0A1 /* ToolManagerState.swift */; };
 		2CB47C7E5221C260DE6EE77F /* ToolManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */; };
 		30E31170A79F30413D15D858 /* GUIChromeDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */; };
+		31B993BFA99DD58462B8924B /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9958CDCF40B9580E12AD1A81 /* SparklineView.swift */; };
 		31E0D1C2347322703DA6CC71 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5458552EC58E44C7CD15A98A /* FileTreeView.swift */; };
 		32171233224FC90E1E956631 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C0836F0D4150126F181C05 /* PickerState.swift */; };
 		364C48575BB95C9CA535A9C8 /* ProtocolReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */; };
+		364F7DD64DD5E3AF11361F9B /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9958CDCF40B9580E12AD1A81 /* SparklineView.swift */; };
 		36E0C059965477465E15CC02 /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */; };
 		3767C83415B32C31B33EFFFB /* MinibufferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D2D3B0C9A042E9A5C485E1 /* MinibufferState.swift */; };
 		393F9EE9CE5F6691781C8CF7 /* MinibufferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DDF3EED1B486C4639A06FF /* MinibufferView.swift */; };
@@ -235,6 +237,7 @@
 		84C47F406747CA6DD924A1AB /* FloatPopupOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatPopupOverlay.swift; sourceTree = "<group>"; };
 		86478D5660213F165B7E1E35 /* SwiftUIViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewTests.swift; sourceTree = "<group>"; };
 		92C0836F0D4150126F181C05 /* PickerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerState.swift; sourceTree = "<group>"; };
+		9958CDCF40B9580E12AD1A81 /* SparklineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparklineView.swift; sourceTree = "<group>"; };
 		9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotAllocatorTests.swift; sourceTree = "<group>"; };
 		A64B96EAA100E627F4E8E0A1 /* ToolManagerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolManagerState.swift; sourceTree = "<group>"; };
 		AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseInputTests.swift; sourceTree = "<group>"; };
@@ -340,6 +343,7 @@
 			children = (
 				2F80894B4E875FD2C66F14CC /* BoardState.swift */,
 				CC4D2EC281455699168DA872 /* BoardView.swift */,
+				9958CDCF40B9580E12AD1A81 /* SparklineView.swift */,
 			);
 			path = Board;
 			sourceTree = "<group>";
@@ -676,6 +680,7 @@
 				A613934E53A1D3B8BAEB69FB /* SignatureHelpOverlay.swift in Sources */,
 				8CB3E1EEDEA109F6C0183597 /* SignatureHelpState.swift in Sources */,
 				CE2F1915565DB90F4A7FC04C /* SlotAllocator.swift in Sources */,
+				31B993BFA99DD58462B8924B /* SparklineView.swift in Sources */,
 				084A4F7680D533CDACEC729A /* StatusBarView.swift in Sources */,
 				C134E5115725A3A85492FF51 /* TabBarState.swift in Sources */,
 				A574FC420DE17918612DFA48 /* TabBarView.swift in Sources */,
@@ -767,6 +772,7 @@
 				2A5DCAC8284B11CD4F8625A5 /* SignatureHelpState.swift in Sources */,
 				6700C63C4B7070D3388A7BD4 /* SlotAllocator.swift in Sources */,
 				07C6F28E3CD1A55ABD5344AA /* SlotAllocatorTests.swift in Sources */,
+				364F7DD64DD5E3AF11361F9B /* SparklineView.swift in Sources */,
 				0BCDFB56E8397D739F52ED34 /* StateLifecycleTests.swift in Sources */,
 				531166B714D49278BA811033 /* StatusBarView.swift in Sources */,
 				9758BF46BB0EC7FEEB14FBA3 /* SwiftUIViewTests.swift in Sources */,

--- a/macos/Sources/Protocol/BoardTypes.swift
+++ b/macos/Sources/Protocol/BoardTypes.swift
@@ -17,6 +17,7 @@ struct BoardCard: Identifiable, Equatable, Sendable {
     let model: String
     let dispatchTimestamp: UInt32  // Unix seconds when card was created
     let recentFiles: [String]
+    let sparkline: [Float]
 
     /// Formatted elapsed time string computed from dispatch timestamp.
     var elapsedDisplay: String {

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1778,6 +1778,18 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 recentFiles.append(String(data: pathData, encoding: .utf8) ?? "")
                 cPos += pathLen
             }
+            // sparkline_count(1) + sparkline_data(count * 2 bytes as Float16)
+            guard data.count >= cPos + 1 else { throw ProtocolDecodeError.malformed }
+            let sparklineCount = Int(data[cPos])
+            cPos += 1
+            guard data.count >= cPos + sparklineCount * 2 else { throw ProtocolDecodeError.malformed }
+            var sparkline: [Float] = []
+            sparkline.reserveCapacity(sparklineCount)
+            for _ in 0..<sparklineCount {
+                let raw = readU16(data, cPos)
+                sparkline.append(Float(raw) / 65535.0)
+                cPos += 2
+            }
             let isYou = (flags & 0x01) != 0
             let isFocused = (flags & 0x02) != 0
             boardCards.append(BoardCard(
@@ -1787,8 +1799,9 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 isFocused: isFocused,
                 task: task,
                 model: model,
-                dispatchTimestamp: elapsed,  // Now treated as Unix timestamp, not elapsed seconds
-                recentFiles: recentFiles
+                dispatchTimestamp: elapsed,
+                recentFiles: recentFiles,
+                sparkline: sparkline
             ))
             bPos = cPos
         }

--- a/macos/Sources/Views/Board/BoardView.swift
+++ b/macos/Sources/Views/Board/BoardView.swift
@@ -169,6 +169,12 @@ struct BoardCardView: View {
 
                 Spacer(minLength: 4)
 
+                // Sparkline (activity indicator, hidden for You card)
+                if !card.isYouCard && !card.sparkline.isEmpty {
+                    SparklineView(data: card.sparkline, color: statusColor)
+                        .frame(height: 24)
+                }
+
                 // Footer: model name + touched files
                 HStack {
                     if !card.model.isEmpty {

--- a/macos/Sources/Views/Board/SparklineView.swift
+++ b/macos/Sources/Views/Board/SparklineView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// A filled area sparkline chart showing recent activity.
+///
+/// Takes an array of Float values in [0.0, 1.0] (typically 60 data points
+/// for the last minute of activity) and renders a filled area path with
+/// smooth line interpolation. Used to show agent output activity on Board cards.
+struct SparklineView: View {
+    let data: [Float]
+    let color: Color
+    
+    /// Whether to reduce motion (instant transitions vs animated).
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    
+    var body: some View {
+        GeometryReader { geometry in
+            if data.isEmpty || data.allSatisfy({ $0 == 0.0 }) {
+                // Empty or all-zero data: flat line at bottom
+                Path { path in
+                    path.move(to: CGPoint(x: 0, y: geometry.size.height))
+                    path.addLine(to: CGPoint(x: geometry.size.width, y: geometry.size.height))
+                }
+                .stroke(color.opacity(0.3), lineWidth: 1)
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: data)
+            } else {
+                // Draw filled area path
+                Path { path in
+                    let width = geometry.size.width
+                    let height = geometry.size.height
+                    let count = data.count
+                    guard count > 0 else { return }
+                    
+                    let step = width / CGFloat(max(count - 1, 1))
+                    
+                    // Start at bottom-left
+                    path.move(to: CGPoint(x: 0, y: height))
+                    
+                    // Line through data points
+                    for (index, value) in data.enumerated() {
+                        let x = CGFloat(index) * step
+                        let y = height * (1.0 - CGFloat(value))
+                        path.addLine(to: CGPoint(x: x, y: y))
+                    }
+                    
+                    // Close path at bottom-right
+                    path.addLine(to: CGPoint(x: width, y: height))
+                    path.closeSubpath()
+                }
+                .fill(color.opacity(0.3))
+                
+                Path { path in
+                    let width = geometry.size.width
+                    let height = geometry.size.height
+                    let count = data.count
+                    guard count > 0 else { return }
+                    
+                    let step = width / CGFloat(max(count - 1, 1))
+                    
+                    // Draw just the top line
+                    if let firstValue = data.first {
+                        let y = height * (1.0 - CGFloat(firstValue))
+                        path.move(to: CGPoint(x: 0, y: y))
+                    }
+                    
+                    for (index, value) in data.dropFirst().enumerated() {
+                        let x = CGFloat(index + 1) * step
+                        let y = height * (1.0 - CGFloat(value))
+                        path.addLine(to: CGPoint(x: x, y: y))
+                    }
+                }
+                .stroke(color, lineWidth: 1)
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: data)
+            }
+        }
+    }
+}

--- a/test/minga/frontend/protocol_gui_board_test.exs
+++ b/test/minga/frontend/protocol_gui_board_test.exs
@@ -141,9 +141,13 @@ defmodule Minga.Frontend.Protocol.GUIBoardTest do
         _model::binary-size(model_len), _elapsed::32, file_count::8, rest::binary>> = data
 
       assert file_count == 2
-      <<p1_len::16, p1::binary-size(p1_len), p2_len::16, p2::binary-size(p2_len)>> = rest
+
+      <<p1_len::16, p1::binary-size(p1_len), p2_len::16, p2::binary-size(p2_len),
+        sparkline_count::8, _sparkline_data::binary>> = rest
+
       assert p1 == "lib/auth.ex"
       assert p2 == "test/auth_test.exs"
+      assert sparkline_count == 0
     end
 
     test "visible flag is 0 when zoomed into a card" do
@@ -159,6 +163,28 @@ defmodule Minga.Frontend.Protocol.GUIBoardTest do
 
       %{filter_mode: fm} = GUI.encode_gui_board(state) |> parse_board_header()
       assert fm == 1
+    end
+
+    test "encodes sparkline data as Float16" do
+      {state, card} =
+        State.create_card(State.new(),
+          task: "t",
+          sparkline: [0.0, 0.5, 1.0]
+        )
+
+      state = State.update_card(state, card.id, & &1)
+
+      %{card_data: data} = GUI.encode_gui_board(state) |> parse_board_header()
+
+      <<_id::32, _s::8, _f::8, task_len::16, _task::binary-size(task_len), model_len::8,
+        _model::binary-size(model_len), _elapsed::32, _file_count::8, sparkline_count::8, s1::16,
+        s2::16, s3::16>> = data
+
+      assert sparkline_count == 3
+      # 0.0 -> 0, 0.5 -> 32768, 1.0 -> 65535
+      assert s1 == 0
+      assert s2 == 32_768
+      assert s3 == 65_535
     end
   end
 end


### PR DESCRIPTION
Adds a SparklineView component and wires sparkline data into Board cards.

## Changes
- **SparklineView.swift**: New SwiftUI view rendering a filled area path from 60 float data points
- **BoardCard/Card**: Added sparkline data field  
- **Protocol decoder**: Parses sparkline data from guiBoard opcode
- **BEAM renderer**: Encodes sparkline data in guiBoard protocol

Closes #1233