### PR TITLE
feat(macos): Board agent context bar with review actions

### DIFF
--- a/lib/minga/frontend/emit/gui.ex
+++ b/lib/minga/frontend/emit/gui.ex
@@ -142,7 +142,8 @@ defmodule Minga.Frontend.Emit.GUI do
         build_gui_hover_popup_cmd(state),
         build_gui_signature_help_cmd(state),
         build_gui_float_popup_cmd(state),
-        build_gui_board_cmd(state)
+        build_gui_board_cmd(state),
+        build_gui_agent_context_cmd(state)
       ]
       |> Enum.reject(&is_nil/1)
 
@@ -1341,5 +1342,72 @@ defmodule Minga.Frontend.Emit.GUI do
       dismissed = %Minga.Shell.Board.State{zoomed_into: 1}
       ProtocolGUI.encode_gui_board(dismissed)
     end
+  end
+
+  # ── Agent context bar ──
+
+  @spec build_gui_agent_context_cmd(state()) :: binary() | nil
+  defp build_gui_agent_context_cmd(%{
+         shell: Minga.Shell.Board,
+         shell_state: %{zoomed_into: nil}
+       }) do
+    send_hide_if_needed(:hidden)
+  end
+
+  defp build_gui_agent_context_cmd(%{shell: Minga.Shell.Board, shell_state: board}) do
+    card = Minga.Shell.Board.State.zoomed(board)
+    send_agent_context_if_applicable(board.zoomed_into, card)
+  end
+
+  # Not Board shell: hide context bar
+  defp build_gui_agent_context_cmd(_state) do
+    send_hide_if_needed(:not_board)
+  end
+
+  @spec send_hide_if_needed(atom()) :: binary() | nil
+  defp send_hide_if_needed(fp_key) do
+    if Process.get(:last_gui_agent_context_fp) != fp_key do
+      Process.put(:last_gui_agent_context_fp, fp_key)
+      encode_hidden_agent_context()
+    end
+  end
+
+  @spec send_agent_context_if_applicable(pos_integer(), Minga.Shell.Board.Card.t() | nil) ::
+          binary() | nil
+  defp send_agent_context_if_applicable(card_id, card)
+       when is_map(card) and not is_nil(card) do
+    if Minga.Shell.Board.Card.you_card?(card) do
+      send_hide_if_needed(:you_card)
+    else
+      send_agent_context_for_card(card_id, card)
+    end
+  end
+
+  defp send_agent_context_if_applicable(_card_id, _card) do
+    send_hide_if_needed(:you_card)
+  end
+
+  @spec send_agent_context_for_card(pos_integer(), Minga.Shell.Board.Card.t()) ::
+          binary() | nil
+  defp send_agent_context_for_card(card_id, card) do
+    can_approve = card.status in [:needs_you, :done]
+    fp = :erlang.phash2({card_id, card.task, card.created_at, card.status, can_approve})
+
+    if fp != Process.get(:last_gui_agent_context_fp) do
+      Process.put(:last_gui_agent_context_fp, fp)
+
+      ProtocolGUI.encode_gui_agent_context(
+        true,
+        card.task,
+        card.created_at,
+        card.status,
+        can_approve
+      )
+    end
+  end
+
+  @spec encode_hidden_agent_context() :: binary()
+  defp encode_hidden_agent_context do
+    ProtocolGUI.encode_gui_agent_context(false, "", DateTime.utc_now(), :idle, false)
   end
 end

--- a/lib/minga/frontend/protocol/gui.ex
+++ b/lib/minga/frontend/protocol/gui.ex
@@ -114,6 +114,7 @@ defmodule Minga.Frontend.Protocol.GUI do
   @op_gui_git_status 0x85
   @op_gui_agent_groups 0x86
   @op_gui_board 0x87
+  @op_gui_agent_context 0x88
 
   # ── Sectioned format section IDs ──
   # Used by opcodes that encode their fields in self-describing sections.
@@ -201,6 +202,9 @@ defmodule Minga.Frontend.Protocol.GUI do
   @gui_action_board_close_card 0x26
   @gui_action_board_reorder 0x27
   @gui_action_board_dispatch_agent 0x28
+  @gui_action_agent_approve 0x29
+  @gui_action_agent_request_changes 0x2A
+  @gui_action_agent_dismiss 0x2B
 
   # ── Types ──
 
@@ -247,6 +251,9 @@ defmodule Minga.Frontend.Protocol.GUI do
           | {:board_close_card, card_id :: pos_integer()}
           | {:board_reorder, card_id :: pos_integer(), new_index :: non_neg_integer()}
           | {:board_dispatch_agent, task :: String.t(), model :: String.t()}
+          | :agent_approve
+          | :agent_request_changes
+          | :agent_dismiss
 
   # ═══════════════════════════════════════════════════════════════════════════
   # Encoding (BEAM → Frontend)
@@ -765,6 +772,35 @@ defmodule Minga.Frontend.Protocol.GUI do
   defp board_status_byte(:done), do: 4
   defp board_status_byte(:errored), do: 5
   defp board_status_byte(_), do: 0
+
+  # ── Agent context bar (0x88) ──
+
+  @doc """
+  Encodes the agent context bar state when zoomed into an agent card.
+
+  Layout:
+    - visible(1): 1 if zoomed into a non-You agent card, 0 otherwise
+    - task_len(2): length of task string
+    - task(N): task description
+    - dispatch_timestamp(8): Unix timestamp when the task was dispatched
+    - status(1): current card status (0-5)
+    - can_approve(1): 1 if the user can approve the agent's work, 0 otherwise
+  """
+  @spec encode_gui_agent_context(boolean(), String.t(), DateTime.t(), atom(), boolean()) ::
+          binary()
+  def encode_gui_agent_context(visible, task, dispatch_timestamp, status, can_approve) do
+    visible_byte = if visible, do: 1, else: 0
+    task_bytes = :erlang.iolist_to_binary([task])
+    timestamp_seconds = DateTime.to_unix(dispatch_timestamp)
+    status_byte = board_status_byte(status)
+    can_approve_byte = if can_approve, do: 1, else: 0
+
+    IO.iodata_to_binary([
+      @op_gui_agent_context,
+      <<visible_byte::8, byte_size(task_bytes)::16, task_bytes::binary, timestamp_seconds::64,
+        status_byte::8, can_approve_byte::8>>
+    ])
+  end
 
   # ── Clipboard write (forward-compatible, 0x90+) ──
 
@@ -1774,6 +1810,15 @@ defmodule Minga.Frontend.Protocol.GUI do
         <<model_len::16, model::binary-size(model_len), task_len::16, task::binary-size(task_len)>>
       ),
       do: {:ok, {:board_dispatch_agent, task, model}}
+
+  def decode_gui_action(@gui_action_agent_approve, <<>>),
+    do: {:ok, :agent_approve}
+
+  def decode_gui_action(@gui_action_agent_request_changes, <<>>),
+    do: {:ok, :agent_request_changes}
+
+  def decode_gui_action(@gui_action_agent_dismiss, <<>>),
+    do: {:ok, :agent_dismiss}
 
   def decode_gui_action(_, _), do: :error
 

--- a/lib/minga/shell/board.ex
+++ b/lib/minga/shell/board.ex
@@ -24,6 +24,7 @@ defmodule Minga.Shell.Board do
 
   alias Minga.Editor.DisplayList
   alias Minga.Editor.DisplayList.{Cursor, Frame}
+  alias Minga.Shell.Board.Card
   alias Minga.Shell.Board.State, as: BoardState
 
   @impl true
@@ -139,6 +140,85 @@ defmodule Minga.Shell.Board do
 
         Minga.Shell.Board.Persistence.save(shell_state)
         {shell_state, workspace}
+    end
+  end
+
+  def handle_gui_action(shell_state, workspace, :agent_approve) do
+    # Approve the agent's work: transition card to :done status
+    case shell_state.zoomed_into do
+      nil ->
+        {shell_state, workspace}
+
+      card_id ->
+        card = Map.get(shell_state.cards, card_id)
+
+        if card && !Card.you_card?(card) do
+          updated_card = Card.set_status(card, :done)
+          shell_state = %{shell_state | cards: Map.put(shell_state.cards, card_id, updated_card)}
+          Minga.Shell.Board.Persistence.save(shell_state)
+          {shell_state, workspace}
+        else
+          {shell_state, workspace}
+        end
+    end
+  end
+
+  def handle_gui_action(shell_state, workspace, :agent_request_changes) do
+    # Request changes from the agent: transition card to :needs_you status
+    case shell_state.zoomed_into do
+      nil ->
+        {shell_state, workspace}
+
+      card_id ->
+        card = Map.get(shell_state.cards, card_id)
+
+        if card && !Card.you_card?(card) do
+          updated_card = Card.set_status(card, :needs_you)
+          shell_state = %{shell_state | cards: Map.put(shell_state.cards, card_id, updated_card)}
+          Minga.Shell.Board.Persistence.save(shell_state)
+          {shell_state, workspace}
+        else
+          {shell_state, workspace}
+        end
+    end
+  end
+
+  def handle_gui_action(shell_state, workspace, :agent_dismiss) do
+    # Dismiss the agent: zoom out to the Board grid
+    case shell_state.zoomed_into do
+      nil ->
+        {shell_state, workspace}
+
+      card_id ->
+        card = Map.get(shell_state.cards, card_id)
+
+        if card do
+          # Get the grid workspace that was stored on the card when we zoomed in
+          grid_workspace = card.workspace
+
+          # Store the current workspace back onto the card
+          live_workspace = Map.from_struct(workspace)
+          updated_card = Card.store_workspace(card, live_workspace)
+          shell_state = %{shell_state | cards: Map.put(shell_state.cards, card_id, updated_card)}
+
+          # Zoom out to grid
+          shell_state = %{shell_state | zoomed_into: nil}
+
+          # Restore the grid workspace if available, otherwise use the current workspace
+          workspace =
+            case grid_workspace do
+              ws when is_map(ws) and map_size(ws) > 0 ->
+                struct!(Minga.Workspace.State, ws)
+
+              _ ->
+                workspace
+            end
+
+          Minga.Shell.Board.Persistence.save(shell_state)
+          {shell_state, workspace}
+        else
+          {shell_state, workspace}
+        end
     end
   end
 

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -38,10 +38,12 @@
 		2A5DCAC8284B11CD4F8625A5 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EED42A8B64B9CDFEF37ED9D /* SignatureHelpState.swift */; };
 		2BA99A1851D0FF01436D5FF8 /* ToolManagerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64B96EAA100E627F4E8E0A1 /* ToolManagerState.swift */; };
 		2CB47C7E5221C260DE6EE77F /* ToolManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */; };
+		2F5F89DAEB979F0B5ACB9E7F /* AgentContextBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D15FC229A7AAA6AD493D1F /* AgentContextBarState.swift */; };
 		30E31170A79F30413D15D858 /* GUIChromeDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */; };
 		31B993BFA99DD58462B8924B /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9958CDCF40B9580E12AD1A81 /* SparklineView.swift */; };
 		31E0D1C2347322703DA6CC71 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5458552EC58E44C7CD15A98A /* FileTreeView.swift */; };
 		32171233224FC90E1E956631 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C0836F0D4150126F181C05 /* PickerState.swift */; };
+		3576D476C304CBAEA792D86A /* AgentContextBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D15FC229A7AAA6AD493D1F /* AgentContextBarState.swift */; };
 		364C48575BB95C9CA535A9C8 /* ProtocolReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */; };
 		364F7DD64DD5E3AF11361F9B /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9958CDCF40B9580E12AD1A81 /* SparklineView.swift */; };
 		36E0C059965477465E15CC02 /* GUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */; };
@@ -55,6 +57,7 @@
 		4515011E135C9FAE8D843610 /* ProtocolTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */; };
 		4699A67786955024F156446F /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
 		4ADE54090FEEF5AA2A6C86A0 /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
+		4D631534301A80CEC8BC147A /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2EC7DA888E31E55CE0D715 /* AgentContextBar.swift */; };
 		4D83576C27CB59935BE53667 /* ToolManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */; };
 		4DF0BD94C77CA840CC92ACB7 /* AgentChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD14027C8C7BD17057DE820B /* AgentChatView.swift */; };
 		4E1EEFA65935DCE58528E02B /* PipelineCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E4E28F5F49F089CCE2E1D /* PipelineCacheTests.swift */; };
@@ -70,6 +73,7 @@
 		5E6F3B6E3BDA7B6CC3965F96 /* DispatchSheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4322CD8BEEFC8C2FB832438 /* DispatchSheetState.swift */; };
 		5FC076D7FA45C7F1829213AA /* GitStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5F52D925D26A6D8919A0CB /* GitStatusView.swift */; };
 		5FDD7CBBCB910BDC63276AA7 /* WhichKeyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5765529645C5D860576B7 /* WhichKeyState.swift */; };
+		6131983A64CD5FE094D2430E /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2EC7DA888E31E55CE0D715 /* AgentContextBar.swift */; };
 		61CF67858355FFF4962D9D99 /* ThemeColorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */; };
 		63F3CF3A4746901FDF1C3356 /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
 		6474095F95F4DA480AFE91B7 /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
@@ -189,6 +193,7 @@
 		0A7AA0437B5C38BA8A8A80D5 /* TabBarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarState.swift; sourceTree = "<group>"; };
 		0C26E064D810299C0302F439 /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
 		0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedLineTexture.swift; sourceTree = "<group>"; };
+		0E2EC7DA888E31E55CE0D715 /* AgentContextBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentContextBar.swift; sourceTree = "<group>"; };
 		16B5F67DE84B139C6F8F3C9F /* GitStatusState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusState.swift; sourceTree = "<group>"; };
 		1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewTests.swift; sourceTree = "<group>"; };
 		1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderButton.swift; sourceTree = "<group>"; };
@@ -229,6 +234,7 @@
 		620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentRendererTests.swift; sourceTree = "<group>"; };
 		638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPanelState.swift; sourceTree = "<group>"; };
 		64CEFB02A774E5E8EF19029F /* MingaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MingaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		65D15FC229A7AAA6AD493D1F /* AgentContextBarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentContextBarState.swift; sourceTree = "<group>"; };
 		70D5765529645C5D860576B7 /* WhichKeyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhichKeyState.swift; sourceTree = "<group>"; };
 		73F9A4109AB33ABF7FB441EE /* WorkspaceIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceIconPicker.swift; sourceTree = "<group>"; };
 		754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIChromeDecoderTests.swift; sourceTree = "<group>"; };
@@ -347,6 +353,8 @@
 		8BF88DE53DE8F2D7ACD9276B /* Board */ = {
 			isa = PBXGroup;
 			children = (
+				0E2EC7DA888E31E55CE0D715 /* AgentContextBar.swift */,
+				65D15FC229A7AAA6AD493D1F /* AgentContextBarState.swift */,
 				2F80894B4E875FD2C66F14CC /* BoardState.swift */,
 				CC4D2EC281455699168DA872 /* BoardView.swift */,
 				9958CDCF40B9580E12AD1A81 /* SparklineView.swift */,
@@ -633,6 +641,8 @@
 			files = (
 				DE6C77896ED3E1E885216DC3 /* AgentChatState.swift in Sources */,
 				4DF0BD94C77CA840CC92ACB7 /* AgentChatView.swift in Sources */,
+				6131983A64CD5FE094D2430E /* AgentContextBar.swift in Sources */,
+				3576D476C304CBAEA792D86A /* AgentContextBarState.swift in Sources */,
 				19E561E5F7841B2CF1ABB085 /* BEAMProcessManager.swift in Sources */,
 				18F0DDA03D08C0B4302DCCF4 /* BitmapRasterizer.swift in Sources */,
 				0089154318A4683A07D2918C /* BlinkingCursor.swift in Sources */,
@@ -712,6 +722,8 @@
 			files = (
 				1F9F7B302A2A8598C1391FA0 /* AgentChatState.swift in Sources */,
 				0D5DFD181E86D51707D3A59E /* AgentChatView.swift in Sources */,
+				4D631534301A80CEC8BC147A /* AgentContextBar.swift in Sources */,
+				2F5F89DAEB979F0B5ACB9E7F /* AgentContextBarState.swift in Sources */,
 				79E8353F67F7638721A02A54 /* BEAMProcessManager.swift in Sources */,
 				64A5A16E02B3E2694060F1A1 /* BitmapRasterizer.swift in Sources */,
 				87C92A93D274184D1608DAC5 /* BlinkingCursor.swift in Sources */,

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -239,12 +239,21 @@ struct ContentView: View {
     private var editorBody: some View {
         VStack(spacing: 0) {
 
-            // Breadcrumb path bar
-            BreadcrumbBar(
-                state: appState.gui.breadcrumbState,
-                theme: appState.gui.themeColors,
-                encoder: appState.encoder
-            )
+            // Conditionally show agent context bar (when zoomed into an agent card)
+            // or breadcrumb bar (when in traditional editor or zoomed into You card)
+            if appState.gui.agentContextBarState.visible {
+                AgentContextBar(
+                    state: appState.gui.agentContextBarState,
+                    theme: appState.gui.themeColors,
+                    encoder: appState.encoder
+                )
+            } else {
+                BreadcrumbBar(
+                    state: appState.gui.breadcrumbState,
+                    theme: appState.gui.themeColors,
+                    encoder: appState.encoder
+                )
+            }
 
             // ZStack: editor surface (always present for keyboard input)
             // with Board overlay on top when active.

--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -56,6 +56,7 @@ let OP_GUI_SPLIT_SEPARATORS: UInt8 = 0x84
 let OP_GUI_GIT_STATUS: UInt8 = 0x85
 let OP_GUI_AGENT_GROUPS: UInt8 = 0x86
 let OP_GUI_BOARD: UInt8 = 0x87
+let OP_GUI_AGENT_CONTEXT: UInt8 = 0x88
 
 // MARK: - Forward-compatible opcodes (0x90+, include 2-byte length prefix)
 // All opcodes >= 0x90 use the format: opcode(1) + payload_length(2) + payload.
@@ -251,6 +252,9 @@ let GUI_ACTION_BOARD_SELECT_CARD: UInt8 = 0x25
 let GUI_ACTION_BOARD_CLOSE_CARD: UInt8 = 0x26
 let GUI_ACTION_BOARD_REORDER: UInt8 = 0x27
 let GUI_ACTION_BOARD_DISPATCH_AGENT: UInt8 = 0x28
+let GUI_ACTION_AGENT_APPROVE: UInt8 = 0x29
+let GUI_ACTION_AGENT_REQUEST_CHANGES: UInt8 = 0x2A
+let GUI_ACTION_AGENT_DISMISS: UInt8 = 0x2B
 
 // MARK: - Log message opcode (frontend → BEAM)
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -57,6 +57,7 @@ enum RenderCommand: Sendable {
     case guiGitStatus(repoState: UInt8, ahead: UInt16, behind: UInt16, branchName: String, entries: [Wire.GitStatusEntry])
     case guiAgentGroups(activeGroupId: UInt16, agentGroups: [Wire.AgentGroupEntry])
     case guiBoard(visible: Bool, focusedCardId: UInt32, cards: [BoardCard], filterMode: Bool, filterText: String)
+    case guiAgentContext(visible: Bool, task: String, dispatchTimestamp: Date, status: CardStatus, canApprove: Bool)
 }
 
 // MARK: - Decoder
@@ -1809,6 +1810,23 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                          filterMode: boardFilterMode, filterText: boardFilterText),
                 bPos - offset)
 
+    case OP_GUI_AGENT_CONTEXT:
+        // visible(1) + task_len(2) + task + dispatch_timestamp(8) + status(1) + can_approve(1)
+        guard data.count >= rest + 3 else { throw ProtocolDecodeError.malformed }
+        let contextVisible = data[rest] != 0
+        let taskLen = Int(readU16(data, rest + 1))
+        guard data.count >= rest + 3 + taskLen + 10 else { throw ProtocolDecodeError.malformed }
+        let taskData = data[(rest + 3)..<(rest + 3 + taskLen)]
+        let task = String(data: taskData, encoding: .utf8) ?? ""
+        let timestampPos = rest + 3 + taskLen
+        let timestampSeconds = readU64(data, timestampPos)
+        let dispatchTimestamp = Date(timeIntervalSince1970: TimeInterval(timestampSeconds))
+        let statusRaw = data[timestampPos + 8]
+        let canApprove = data[timestampPos + 9] != 0
+        return (.guiAgentContext(visible: contextVisible, task: task, dispatchTimestamp: dispatchTimestamp,
+                                 status: CardStatus(rawValue: statusRaw) ?? .idle, canApprove: canApprove),
+                timestampPos + 10 - offset)
+
     case OP_CLIPBOARD_WRITE:
         // Forward-compatible format: opcode(1) + payload_length(2) + target(1) + text_len(2) + text
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
@@ -1853,4 +1871,11 @@ private func readU24(_ data: Data, _ offset: Int) -> UInt32 {
 private func readU32(_ data: Data, _ offset: Int) -> UInt32 {
     return UInt32(data[offset]) << 24 | UInt32(data[offset + 1]) << 16 |
            UInt32(data[offset + 2]) << 8 | UInt32(data[offset + 3])
+}
+
+private func readU64(_ data: Data, _ offset: Int) -> UInt64 {
+    return UInt64(data[offset]) << 56 | UInt64(data[offset + 1]) << 48 |
+           UInt64(data[offset + 2]) << 40 | UInt64(data[offset + 3]) << 32 |
+           UInt64(data[offset + 4]) << 24 | UInt64(data[offset + 5]) << 16 |
+           UInt64(data[offset + 6]) << 8 | UInt64(data[offset + 7])
 }

--- a/macos/Sources/Protocol/ProtocolEncoder.swift
+++ b/macos/Sources/Protocol/ProtocolEncoder.swift
@@ -77,6 +77,11 @@ protocol InputEncoder: AnyObject, Sendable {
     func sendBoardCloseCard(id: UInt32)
     func sendBoardReorder(cardId: UInt32, newIndex: UInt16)
     func sendDispatchAgent(task: String, model: String)
+
+    // Agent review actions
+    func sendAgentApprove()
+    func sendAgentRequestChanges()
+    func sendAgentDismiss()
 }
 
 extension InputEncoder {
@@ -584,6 +589,30 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
             buf.replaceSubrange((taskOffset + 2)..<(taskOffset + 2 + taskLen), with: taskUtf8[0..<taskLen])
         }
 
+        writeFrame(buf)
+    }
+
+    /// Send a gui_action: agent_approve. Layout: opcode(1) + action_type(1).
+    func sendAgentApprove() {
+        var buf = Data(count: 2)
+        buf[0] = OP_GUI_ACTION
+        buf[1] = GUI_ACTION_AGENT_APPROVE
+        writeFrame(buf)
+    }
+
+    /// Send a gui_action: agent_request_changes. Layout: opcode(1) + action_type(1).
+    func sendAgentRequestChanges() {
+        var buf = Data(count: 2)
+        buf[0] = OP_GUI_ACTION
+        buf[1] = GUI_ACTION_AGENT_REQUEST_CHANGES
+        writeFrame(buf)
+    }
+
+    /// Send a gui_action: agent_dismiss. Layout: opcode(1) + action_type(1).
+    func sendAgentDismiss() {
+        var buf = Data(count: 2)
+        buf[0] = OP_GUI_ACTION
+        buf[1] = GUI_ACTION_AGENT_DISMISS
         writeFrame(buf)
     }
 

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -168,6 +168,10 @@ final class CommandDispatcher {
             guiState.boardState.update(visible: visible, focusedCardId: focusedCardId, cards: cards,
                                         filterMode: filterMode, filterText: filterText)
 
+        case .guiAgentContext(let visible, let task, let dispatchTimestamp, let status, let canApprove):
+            guiState.agentContextBarState.update(visible: visible, task: task, dispatchTimestamp: dispatchTimestamp,
+                                                  status: status, canApprove: canApprove)
+
         case .clipboardWrite(let target, let text):
             handleClipboardWrite(target: target, text: text)
 

--- a/macos/Sources/Views/Board/AgentContextBar.swift
+++ b/macos/Sources/Views/Board/AgentContextBar.swift
@@ -1,0 +1,158 @@
+/// Agent context bar for Board shell when zoomed into an agent card.
+///
+/// Shows the agent's task, status badge, elapsed time, and review actions.
+/// Replaces the breadcrumb bar when zoomed into a non-You agent card.
+
+import SwiftUI
+
+struct AgentContextBar: View {
+    let state: AgentContextBarState
+    let theme: ThemeColors
+    let encoder: InputEncoder?
+
+    private let barHeight: CGFloat = 28
+
+    /// Timer to refresh elapsed time every second.
+    @State private var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    @State private var elapsedDisplay: String = "0s"
+
+    var body: some View {
+        if state.visible {
+            HStack(spacing: 12) {
+                // Task description (left-aligned)
+                Text(state.task)
+                    .font(.system(size: 12))
+                    .foregroundStyle(theme.breadcrumbFg)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                // Status badge (inline)
+                statusBadge
+
+                Spacer()
+
+                // Elapsed time (right-aligned, monospaced)
+                Text(elapsedDisplay)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(theme.breadcrumbFg.opacity(0.6))
+                    .onReceive(timer) { _ in
+                        updateElapsedDisplay()
+                    }
+                    .onAppear {
+                        updateElapsedDisplay()
+                    }
+
+                // Action buttons (right-aligned)
+                if state.canApprove {
+                    actionButtons
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(height: barHeight)
+            .background(theme.breadcrumbBg)
+            .focusable(false)
+            .focusEffectDisabled()
+
+            // Bottom border
+            Rectangle()
+                .fill(theme.breadcrumbSeparatorFg.opacity(0.3))
+                .frame(height: 1)
+        }
+    }
+
+    // MARK: - Status Badge
+
+    private var statusBadge: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 7, height: 7)
+
+            Text(state.status.label)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(statusColor.opacity(0.15))
+        .cornerRadius(4)
+    }
+
+    private var statusColor: Color {
+        let c = state.status.color
+        return Color(red: c.r, green: c.g, blue: c.b)
+    }
+
+    // MARK: - Action Buttons
+
+    private var actionButtons: some View {
+        HStack(spacing: 6) {
+            reviewButton(
+                label: "Approve",
+                systemIcon: "checkmark.circle.fill",
+                color: Color(red: 0.2, green: 0.8, blue: 0.4),
+                action: {
+                    encoder?.sendAgentApprove()
+                }
+            )
+
+            reviewButton(
+                label: "Request Changes",
+                systemIcon: "exclamationmark.triangle.fill",
+                color: Color(red: 1.0, green: 0.75, blue: 0.2),
+                action: {
+                    encoder?.sendAgentRequestChanges()
+                }
+            )
+
+            reviewButton(
+                label: "Dismiss",
+                systemIcon: "xmark.circle.fill",
+                color: Color(red: 0.6, green: 0.3, blue: 0.3),
+                action: {
+                    encoder?.sendAgentDismiss()
+                }
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func reviewButton(
+        label: String,
+        systemIcon: String,
+        color: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: systemIcon)
+                    .font(.system(size: 10, weight: .medium))
+                Text(label)
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .foregroundStyle(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(color.opacity(0.15))
+            .cornerRadius(4)
+        }
+        .buttonStyle(.plain)
+        .help(label)
+        .onHover { isHovered in
+            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func updateElapsedDisplay() {
+        let seconds = state.elapsedSeconds
+        if seconds < 60 {
+            elapsedDisplay = "\(seconds)s"
+        } else if seconds < 3600 {
+            elapsedDisplay = "\(seconds / 60)m"
+        } else {
+            elapsedDisplay = "\(seconds / 3600)h \((seconds % 3600) / 60)m"
+        }
+    }
+}

--- a/macos/Sources/Views/Board/AgentContextBarState.swift
+++ b/macos/Sources/Views/Board/AgentContextBarState.swift
@@ -1,0 +1,51 @@
+import Observation
+import Foundation
+
+/// State for the agent context bar shown when zoomed into an agent card.
+///
+/// Displays the agent's task, status, elapsed time, and review actions
+/// (Approve, Request Changes, Dismiss). Replaces the breadcrumb bar
+/// when the Board shell is zoomed into a non-You agent card.
+///
+/// Updated by the BEAM via the `gui_agent_context` opcode (0x88).
+@MainActor
+@Observable
+final class AgentContextBarState {
+    /// Whether the context bar is visible (zoomed into an agent card, not You card).
+    var visible: Bool = false
+
+    /// The agent's task description.
+    var task: String = ""
+
+    /// Unix timestamp when the task was dispatched.
+    var dispatchTimestamp: Date = Date()
+
+    /// The agent's current status.
+    var status: CardStatus = .idle
+
+    /// Whether the user can approve the agent's work (work is complete and awaiting approval).
+    var canApprove: Bool = false
+
+    /// Elapsed time since dispatch, computed from dispatchTimestamp.
+    var elapsedSeconds: Int {
+        Int(Date().timeIntervalSince(dispatchTimestamp))
+    }
+
+    /// Updates the context bar state from a decoded protocol command.
+    func update(visible: Bool, task: String, dispatchTimestamp: Date, status: CardStatus, canApprove: Bool) {
+        self.visible = visible
+        self.task = task
+        self.dispatchTimestamp = dispatchTimestamp
+        self.status = status
+        self.canApprove = canApprove
+    }
+
+    /// Hides the context bar. Called when zooming out or switching to the You card.
+    func hide() {
+        visible = false
+        task = ""
+        dispatchTimestamp = Date()
+        status = .idle
+        canApprove = false
+    }
+}

--- a/macos/Sources/Views/GUIState.swift
+++ b/macos/Sources/Views/GUIState.swift
@@ -61,6 +61,9 @@ final class GUIState {
     /// Agent dispatch sheet state.
     let dispatchSheetState = DispatchSheetState()
 
+    /// Agent context bar state (0x88).
+    let agentContextBarState = AgentContextBarState()
+
     /// Semantic window content from gui_window_content (0x80).
     /// Keyed by windowId. NOT cleared between frames; the guiWindowContent
     /// dispatch overwrites per-window data each frame. Stale entries serve


### PR DESCRIPTION
Adds a context bar above the editor when zoomed into an agent's Board card, showing task description, elapsed time, status, and review action buttons.

## Changes
- **AgentContextBar.swift**: SwiftUI view with task, elapsed time, status badge, action buttons
- **AgentContextBarState.swift**: Observable state for context bar
- **Protocol**: New opcode for context bar data, encoder methods for review actions
- **BEAM side**: gui_action handlers for approve/request_changes/dismiss

Closes #1236