### PR TITLE
feat(macos): Board change summary sidebar with diff stats

### DIFF
--- a/lib/minga/frontend/emit/gui.ex
+++ b/lib/minga/frontend/emit/gui.ex
@@ -144,6 +144,7 @@ defmodule Minga.Frontend.Emit.GUI do
         build_gui_float_popup_cmd(state),
         build_gui_board_cmd(state),
         build_gui_agent_context_cmd(state)
+        build_gui_change_summary_cmd(state)
       ]
       |> Enum.reject(&is_nil/1)
 
@@ -1409,5 +1410,34 @@ defmodule Minga.Frontend.Emit.GUI do
   @spec encode_hidden_agent_context() :: binary()
   defp encode_hidden_agent_context do
     ProtocolGUI.encode_gui_agent_context(false, "", DateTime.utc_now(), :idle, false)
+  end
+  # ── Change Summary ──
+
+  @spec build_gui_change_summary_cmd(state()) :: binary() | nil
+
+  # Change summary visible when zoomed into an agent card (not You card)
+  defp build_gui_change_summary_cmd(
+         %{shell: Minga.Shell.Board, shell_state: %{zoomed_into: card_id}} = _state
+       )
+       when card_id != nil do
+    # TODO: Compute diff stats from the card's touched files
+    # For now, send empty list to test the UI
+    entries = []
+    selected_index = 0
+
+    fp = :erlang.phash2({card_id, entries})
+
+    if fp != Process.get(:last_gui_change_summary_fp) do
+      Process.put(:last_gui_change_summary_fp, fp)
+      ProtocolGUI.encode_gui_change_summary(entries, selected_index)
+    end
+  end
+
+  # Board grid or other shells: hide change summary
+  defp build_gui_change_summary_cmd(_state) do
+    if Process.get(:last_gui_change_summary_fp) != :hidden do
+      Process.put(:last_gui_change_summary_fp, :hidden)
+      ProtocolGUI.encode_gui_change_summary([], 0)
+    end
   end
 end

--- a/lib/minga/frontend/protocol/gui.ex
+++ b/lib/minga/frontend/protocol/gui.ex
@@ -115,6 +115,7 @@ defmodule Minga.Frontend.Protocol.GUI do
   @op_gui_agent_groups 0x86
   @op_gui_board 0x87
   @op_gui_agent_context 0x88
+  @op_gui_change_summary 0x88
 
   # ── Sectioned format section IDs ──
   # Used by opcodes that encode their fields in self-describing sections.
@@ -205,6 +206,7 @@ defmodule Minga.Frontend.Protocol.GUI do
   @gui_action_agent_approve 0x29
   @gui_action_agent_request_changes 0x2A
   @gui_action_agent_dismiss 0x2B
+  @gui_action_change_summary_click 0x2C
 
   # ── Types ──
 
@@ -254,6 +256,7 @@ defmodule Minga.Frontend.Protocol.GUI do
           | :agent_approve
           | :agent_request_changes
           | :agent_dismiss
+          | {:change_summary_click, index :: non_neg_integer()}
 
   # ═══════════════════════════════════════════════════════════════════════════
   # Encoding (BEAM → Frontend)
@@ -801,6 +804,48 @@ defmodule Minga.Frontend.Protocol.GUI do
         status_byte::8, can_approve_byte::8>>
     ])
   end
+
+  # ── Change Summary ──
+
+  @doc """
+  Encodes a gui_change_summary command (0x88).
+
+  Sends the list of changed files with diff stats when zoomed into an agent card.
+  The Swift frontend renders this as a resizable sidebar on the left.
+
+  Wire format:
+    opcode(1) + visible(1) + selected_index(2) + entry_count(2) + entries...
+
+  Each entry:
+    path_len(2) + path + action(1) + lines_added(4) + lines_removed(4)
+
+  Action: 0=modified, 1=added, 2=deleted, 3=renamed
+  """
+  @spec encode_gui_change_summary([map()], non_neg_integer()) :: binary()
+  def encode_gui_change_summary(entries, selected_index \\ 0) when is_list(entries) do
+    visible = if entries == [], do: 0, else: 1
+
+    entry_binaries =
+      Enum.map(entries, fn entry ->
+        path_bytes = :erlang.iolist_to_binary([entry.path])
+        action_byte = file_action_byte(entry.action)
+
+        <<byte_size(path_bytes)::16, path_bytes::binary, action_byte::8, entry.lines_added::32,
+          entry.lines_removed::32>>
+      end)
+
+    IO.iodata_to_binary([
+      <<@op_gui_change_summary, visible::8, selected_index::16, length(entries)::16>>
+      | entry_binaries
+    ])
+  end
+
+  @spec file_action_byte(:modified | :added | :deleted | :renamed) :: non_neg_integer()
+  defp file_action_byte(:modified), do: 0
+  defp file_action_byte(:added), do: 1
+  defp file_action_byte(:deleted), do: 2
+  defp file_action_byte(:renamed), do: 3
+  defp file_action_byte(_), do: 0
 
   # ── Clipboard write (forward-compatible, 0x90+) ──
 
@@ -1819,6 +1864,8 @@ defmodule Minga.Frontend.Protocol.GUI do
 
   def decode_gui_action(@gui_action_agent_dismiss, <<>>),
     do: {:ok, :agent_dismiss}
+  def decode_gui_action(@gui_action_change_summary_click, <<index::32>>),
+    do: {:ok, {:change_summary_click, index}}
 
   def decode_gui_action(_, _), do: :error
 

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		07C32C28178AE5675ACF4539 /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
 		07C6F28E3CD1A55ABD5344AA /* SlotAllocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */; };
 		084A4F7680D533CDACEC729A /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E892F827AFBE959F9DF25C05 /* StatusBarView.swift */; };
+		0B68D79FFC2E1BC94D2B8F9F /* ChangeSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2812AE57C17D25D125076FA3 /* ChangeSummaryView.swift */; };
 		0BCDFB56E8397D739F52ED34 /* StateLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5634B25BE5BB945A83E30FAD /* StateLifecycleTests.swift */; };
 		0D5DFD181E86D51707D3A59E /* AgentChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD14027C8C7BD17057DE820B /* AgentChatView.swift */; };
 		0D8C5FFA3F7BE723E50A58B6 /* BoardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F80894B4E875FD2C66F14CC /* BoardState.swift */; };
@@ -89,12 +90,14 @@
 		74D29226F82E6ADE18E2E108 /* MinibufferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D2D3B0C9A042E9A5C485E1 /* MinibufferState.swift */; };
 		7680EFD077E0B916411123FA /* SymbolsNerdFontMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FD66FBCBFC20D50D22A969C8 /* SymbolsNerdFontMono-Regular.ttf */; };
 		778C6A917140005C0C0643CB /* ProtocolEncoderBinaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BD56B7D6D195D236F9BF40 /* ProtocolEncoderBinaryTests.swift */; };
+		783AEDBA1B0D4557E0D1DD81 /* ChangeSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2812AE57C17D25D125076FA3 /* ChangeSummaryView.swift */; };
 		785A55B784A3EE17DC3E0AC6 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C0836F0D4150126F181C05 /* PickerState.swift */; };
 		78F06B9BFB553B50D9BDD50F /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		793247C2AB95598A1AC4C6EC /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD30A2572AE2608F099407 /* ScrollAccumulator.swift */; };
 		79E8353F67F7638721A02A54 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
 		7A21099CFC922D178A3079DF /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C26E064D810299C0302F439 /* EditorView.swift */; };
 		7C9B7CB6670412D9F4DE60BB /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
+		7DB249F526EB508249BE3964 /* ChangeSummaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E3D96CF06FCC7F116AF4DC /* ChangeSummaryState.swift */; };
 		7E2428F971A8835D3B42598B /* GitStatusState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B5F67DE84B139C6F8F3C9F /* GitStatusState.swift */; };
 		810251CDDA9CB63F881D426C /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D6B3C68CFF37BC4303933A /* ThemeColors.swift */; };
 		82E444261F28262834866B20 /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83165B89231936674C54B513 /* EditorNSView.swift */; };
@@ -126,6 +129,7 @@
 		AFE31388980EE451C8F734A3 /* CachedLineTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */; };
 		B0A5712B943D48F8F72C1DDA /* KeyboardInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */; };
 		B12FA22E8F25CE3E5F55366F /* WindowContentRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */; };
+		B17D4B05015400A97E490FEF /* ChangeSummaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E3D96CF06FCC7F116AF4DC /* ChangeSummaryState.swift */; };
 		B2063C405BABC6C1D394C3AF /* CompletionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA9C2BB0C840BE88B0FEA52 /* CompletionState.swift */; };
 		B52CC06DF924153EAA3BADBE /* SidebarHeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */; };
 		B6295F0247ADE2D1D0133DCB /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D6B3C68CFF37BC4303933A /* ThemeColors.swift */; };
@@ -187,6 +191,7 @@
 		00D6B3C68CFF37BC4303933A /* ThemeColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColors.swift; sourceTree = "<group>"; };
 		02D2D3B0C9A042E9A5C485E1 /* MinibufferState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinibufferState.swift; sourceTree = "<group>"; };
 		03D7C3564C27A7E14D894539 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
+		03E3D96CF06FCC7F116AF4DC /* ChangeSummaryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryState.swift; sourceTree = "<group>"; };
 		053D515EC453DEBFF51FB6CB /* DecoderFuzzTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderFuzzTests.swift; sourceTree = "<group>"; };
 		05DDF3EED1B486C4639A06FF /* MinibufferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinibufferView.swift; sourceTree = "<group>"; };
 		08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolTypes.swift; sourceTree = "<group>"; };
@@ -200,6 +205,7 @@
 		211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollAccumulatorTests.swift; sourceTree = "<group>"; };
 		22420E1CC772DAFB9A5043C2 /* ViewModelComputedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelComputedTests.swift; sourceTree = "<group>"; };
 		23EF5FFAD8310BD41CF784AC /* FloatPopupState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatPopupState.swift; sourceTree = "<group>"; };
+		2812AE57C17D25D125076FA3 /* ChangeSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryView.swift; sourceTree = "<group>"; };
 		2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMEComposition.swift; sourceTree = "<group>"; };
 		2F80894B4E875FD2C66F14CC /* BoardState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardState.swift; sourceTree = "<group>"; };
 		321E4E28F5F49F089CCE2E1D /* PipelineCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineCacheTests.swift; sourceTree = "<group>"; };
@@ -360,6 +366,8 @@
 				9958CDCF40B9580E12AD1A81 /* SparklineView.swift */,
 				A4322CD8BEEFC8C2FB832438 /* DispatchSheetState.swift */,
 				BF5A488C20326CCE3A7FC46E /* DispatchSheetView.swift */,
+				03E3D96CF06FCC7F116AF4DC /* ChangeSummaryState.swift */,
+				2812AE57C17D25D125076FA3 /* ChangeSummaryView.swift */,
 			);
 			path = Board;
 			sourceTree = "<group>";
@@ -653,6 +661,8 @@
 				1965FE752C77D2EB386EC4D8 /* BottomPanelView.swift in Sources */,
 				6860E9D6217B72EAA8AD71A5 /* BreadcrumbBar.swift in Sources */,
 				AFE31388980EE451C8F734A3 /* CachedLineTexture.swift in Sources */,
+				B17D4B05015400A97E490FEF /* ChangeSummaryState.swift in Sources */,
+				0B68D79FFC2E1BC94D2B8F9F /* ChangeSummaryView.swift in Sources */,
 				C44D9CF03C49E7BCA39A76A9 /* CommandDispatcher.swift in Sources */,
 				6F7F50CEC5067770E4865C2A /* CompletionOverlay.swift in Sources */,
 				B2063C405BABC6C1D394C3AF /* CompletionState.swift in Sources */,
@@ -734,6 +744,8 @@
 				59546703C9DBB4BA6E15DE28 /* BottomPanelView.swift in Sources */,
 				8F6865441CD813045F071273 /* BreadcrumbBar.swift in Sources */,
 				E2BC69E1121328310B830E45 /* CachedLineTexture.swift in Sources */,
+				7DB249F526EB508249BE3964 /* ChangeSummaryState.swift in Sources */,
+				783AEDBA1B0D4557E0D1DD81 /* ChangeSummaryView.swift in Sources */,
 				07C32C28178AE5675ACF4539 /* CommandDispatcher.swift in Sources */,
 				28F3D7BFADCE4A2509D66C2B /* CommandDispatcherTests.swift in Sources */,
 				C00E62ED31BA198B0EC92EAF /* CompletionOverlay.swift in Sources */,

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -134,9 +134,14 @@ struct ContentView: View {
     @ObservedObject var appState: AppState
     @State private var rightPaneHeight: CGFloat = 600
     @State private var sidebarWidth: CGFloat = 240
+    @State private var changeSummaryWidth: CGFloat = 280
 
     private var showSidebar: Bool {
         appState.gui.fileTreeState.visible || appState.gui.gitStatusState.visible
+    }
+
+    private var showChangeSummary: Bool {
+        appState.gui.changeSummaryState.visible
     }
 
     private var theme: ThemeColors { appState.gui.themeColors }
@@ -232,6 +237,55 @@ struct ContentView: View {
         }
     }
 
+    // MARK: - Change Summary Sidebar
+
+    @State private var changeSummaryMinWidth: CGFloat = 200
+    @State private var changeSummaryMaxWidth: CGFloat = 400
+    @State private var isDraggingChangeSummaryResize: Bool = false
+
+    @ViewBuilder
+    private var changeSummarySidebar: some View {
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                ChangeSummaryView(
+                    state: appState.gui.changeSummaryState,
+                    theme: theme,
+                    encoder: appState.encoder
+                )
+            }
+            .frame(width: changeSummaryWidth)
+            .background(theme.treeBg)
+
+            // Resize handle (8px hit target with 1px visible separator)
+            Color.clear
+                .frame(width: 8)
+                .overlay(alignment: .leading) {
+                    Rectangle()
+                        .fill(isDraggingChangeSummaryResize ? theme.treeActiveFg.opacity(0.3) : theme.treeSeparatorFg.opacity(0.4))
+                        .frame(width: 1)
+                }
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 1)
+                        .onChanged { value in
+                            isDraggingChangeSummaryResize = true
+                            let newWidth = changeSummaryWidth + value.translation.width
+                            changeSummaryWidth = min(max(newWidth, changeSummaryMinWidth), changeSummaryMaxWidth)
+                        }
+                        .onEnded { _ in
+                            isDraggingChangeSummaryResize = false
+                        }
+                )
+                .onHover { hovering in
+                    if hovering {
+                        NSCursor.resizeLeftRight.push()
+                    } else {
+                        NSCursor.pop()
+                    }
+                }
+        }
+    }
+
     // MARK: - Editor Body
 
     @Namespace private var zoomNamespace
@@ -276,6 +330,30 @@ struct ContentView: View {
                         namespace: zoomNamespace
                     )
                     .transition(.opacity)
+            // HStack: change summary sidebar (when zoomed into agent card) + editor
+            HStack(spacing: 0) {
+                if showChangeSummary {
+                    changeSummarySidebar
+                }
+
+                // ZStack: editor surface (always present for keyboard input)
+                // with Board overlay on top when active.
+                ZStack {
+                    editorSurface
+                        .opacity(appState.gui.boardState.visible ? 0 : 1)
+
+                    if appState.gui.boardState.visible {
+                        BoardView(
+                            state: appState.gui.boardState,
+                            theme: appState.gui.themeColors,
+                            encoder: appState.encoder
+                        )
+                        .transition(
+                            NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+                                ? .opacity
+                                : .scale(scale: 0.97).combined(with: .opacity)
+                        )
+                    }
                 }
             }
             .animation(

--- a/macos/Sources/Protocol/BoardTypes.swift
+++ b/macos/Sources/Protocol/BoardTypes.swift
@@ -62,3 +62,40 @@ enum CardStatus: UInt8, Equatable, Sendable {
         }
     }
 }
+
+/// A single file entry in the change summary with its diff stats.
+struct ChangeSummaryEntry: Identifiable, Equatable, Sendable {
+    let id: Int
+    let path: String
+    let action: FileAction
+    let linesAdded: UInt32
+    let linesRemoved: UInt32
+
+    /// File action type (modified, added, deleted, renamed).
+    enum FileAction: UInt8, Equatable, Sendable {
+        case modified = 0
+        case added = 1
+        case deleted = 2
+        case renamed = 3
+
+        /// Single-letter status indicator.
+        var indicator: String {
+            switch self {
+            case .modified: "M"
+            case .added: "A"
+            case .deleted: "D"
+            case .renamed: "R"
+            }
+        }
+
+        /// Color for the status indicator.
+        var color: (r: Double, g: Double, b: Double) {
+            switch self {
+            case .modified: (0.38, 0.69, 0.93)  // Blue
+            case .added: (0.2, 0.8, 0.4)        // Green
+            case .deleted: (1.0, 0.3, 0.3)      // Red
+            case .renamed: (1.0, 0.75, 0.2)     // Amber
+            }
+        }
+    }
+}

--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -57,6 +57,7 @@ let OP_GUI_GIT_STATUS: UInt8 = 0x85
 let OP_GUI_AGENT_GROUPS: UInt8 = 0x86
 let OP_GUI_BOARD: UInt8 = 0x87
 let OP_GUI_AGENT_CONTEXT: UInt8 = 0x88
+let OP_GUI_CHANGE_SUMMARY: UInt8 = 0x88
 
 // MARK: - Forward-compatible opcodes (0x90+, include 2-byte length prefix)
 // All opcodes >= 0x90 use the format: opcode(1) + payload_length(2) + payload.
@@ -255,6 +256,7 @@ let GUI_ACTION_BOARD_DISPATCH_AGENT: UInt8 = 0x28
 let GUI_ACTION_AGENT_APPROVE: UInt8 = 0x29
 let GUI_ACTION_AGENT_REQUEST_CHANGES: UInt8 = 0x2A
 let GUI_ACTION_AGENT_DISMISS: UInt8 = 0x2B
+let GUI_ACTION_CHANGE_SUMMARY_CLICK: UInt8 = 0x2C
 
 // MARK: - Log message opcode (frontend → BEAM)
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -58,6 +58,7 @@ enum RenderCommand: Sendable {
     case guiAgentGroups(activeGroupId: UInt16, agentGroups: [Wire.AgentGroupEntry])
     case guiBoard(visible: Bool, focusedCardId: UInt32, cards: [BoardCard], filterMode: Bool, filterText: String)
     case guiAgentContext(visible: Bool, task: String, dispatchTimestamp: Date, status: CardStatus, canApprove: Bool)
+    case guiChangeSummary(visible: Bool, entries: [ChangeSummaryEntry], selectedIndex: Int)
 }
 
 // MARK: - Decoder
@@ -1826,6 +1827,36 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         return (.guiAgentContext(visible: contextVisible, task: task, dispatchTimestamp: dispatchTimestamp,
                                  status: CardStatus(rawValue: statusRaw) ?? .idle, canApprove: canApprove),
                 timestampPos + 10 - offset)
+    case OP_GUI_CHANGE_SUMMARY:
+        // visible(1) + selected_index(2) + entry_count(2)
+        guard data.count >= rest + 5 else { throw ProtocolDecodeError.malformed }
+        let csVisible = data[rest] != 0
+        let csSelectedIndex = Int(readU16(data, rest + 1))
+        let entryCount = Int(readU16(data, rest + 3))
+        var csEntries: [ChangeSummaryEntry] = []
+        csEntries.reserveCapacity(entryCount)
+        var csPos = rest + 5
+        for idx in 0..<entryCount {
+            // path_len(2) + path + action(1) + lines_added(4) + lines_removed(4)
+            guard data.count >= csPos + 2 else { throw ProtocolDecodeError.malformed }
+            let pathLen = Int(readU16(data, csPos))
+            guard data.count >= csPos + 2 + pathLen + 1 + 4 + 4 else { throw ProtocolDecodeError.malformed }
+            let pathData = data[(csPos + 2)..<(csPos + 2 + pathLen)]
+            let path = String(data: pathData, encoding: .utf8) ?? ""
+            let actionByte = data[csPos + 2 + pathLen]
+            let linesAdded = readU32(data, csPos + 2 + pathLen + 1)
+            let linesRemoved = readU32(data, csPos + 2 + pathLen + 5)
+            csEntries.append(ChangeSummaryEntry(
+                id: idx,
+                path: path,
+                action: ChangeSummaryEntry.FileAction(rawValue: actionByte) ?? .modified,
+                linesAdded: linesAdded,
+                linesRemoved: linesRemoved
+            ))
+            csPos += 2 + pathLen + 1 + 4 + 4
+        }
+        return (.guiChangeSummary(visible: csVisible, entries: csEntries, selectedIndex: csSelectedIndex),
+                csPos - offset)
 
     case OP_CLIPBOARD_WRITE:
         // Forward-compatible format: opcode(1) + payload_length(2) + target(1) + text_len(2) + text

--- a/macos/Sources/Protocol/ProtocolEncoder.swift
+++ b/macos/Sources/Protocol/ProtocolEncoder.swift
@@ -82,6 +82,7 @@ protocol InputEncoder: AnyObject, Sendable {
     func sendAgentApprove()
     func sendAgentRequestChanges()
     func sendAgentDismiss()
+    func sendChangeSummaryClick(index: UInt32)
 }
 
 extension InputEncoder {
@@ -613,6 +614,12 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
         var buf = Data(count: 2)
         buf[0] = OP_GUI_ACTION
         buf[1] = GUI_ACTION_AGENT_DISMISS
+    /// Send a gui_action: change_summary_click. Layout: opcode(1) + action_type(1) + index(4).
+    func sendChangeSummaryClick(index: UInt32) {
+        var buf = Data(count: 6)
+        buf[0] = OP_GUI_ACTION
+        buf[1] = GUI_ACTION_CHANGE_SUMMARY_CLICK
+        writeU32(&buf, 2, index)
         writeFrame(buf)
     }
 

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -171,6 +171,8 @@ final class CommandDispatcher {
         case .guiAgentContext(let visible, let task, let dispatchTimestamp, let status, let canApprove):
             guiState.agentContextBarState.update(visible: visible, task: task, dispatchTimestamp: dispatchTimestamp,
                                                   status: status, canApprove: canApprove)
+        case .guiChangeSummary(let visible, let entries, let selectedIndex):
+            guiState.changeSummaryState.update(visible: visible, entries: entries, selectedIndex: selectedIndex)
 
         case .clipboardWrite(let target, let text):
             handleClipboardWrite(target: target, text: text)

--- a/macos/Sources/Views/Board/ChangeSummaryState.swift
+++ b/macos/Sources/Views/Board/ChangeSummaryState.swift
@@ -1,0 +1,33 @@
+import Observation
+
+/// State for the change summary sidebar shown when zoomed into an agent card.
+///
+/// Updated by the BEAM via the `gui_board` opcode (0x87) with per-file diff
+/// stats. Drives `ChangeSummaryView` which renders a list of changed files
+/// with their status and line counts.
+@MainActor
+@Observable
+final class ChangeSummaryState {
+    /// Whether the change summary sidebar is visible.
+    var visible: Bool = false
+
+    /// The list of changed files with their diff stats.
+    var entries: [ChangeSummaryEntry] = []
+
+    /// Index of the currently selected file (0-based).
+    var selectedIndex: Int = 0
+
+    /// Updates the change summary state from decoded protocol data.
+    func update(visible: Bool, entries: [ChangeSummaryEntry], selectedIndex: Int) {
+        self.visible = visible
+        self.entries = entries
+        self.selectedIndex = selectedIndex
+    }
+
+    /// Hides the change summary sidebar.
+    func hide() {
+        self.visible = false
+        self.entries = []
+        self.selectedIndex = 0
+    }
+}

--- a/macos/Sources/Views/Board/ChangeSummaryView.swift
+++ b/macos/Sources/Views/Board/ChangeSummaryView.swift
@@ -1,0 +1,252 @@
+import SwiftUI
+
+/// Change summary sidebar showing files touched by an agent with diff stats.
+///
+/// Displays a list of changed files grouped by status (modified, added, deleted).
+/// Each entry shows a file icon (based on extension), relative path, diff stats
+/// (+N in green, -M in red), and a status indicator (M/A/D/R).
+///
+/// The selected file is highlighted. Clicking a file sends a `change_summary_click`
+/// gui_action to the BEAM, which opens the file and activates diff view.
+struct ChangeSummaryView: View {
+    let state: ChangeSummaryState
+    let theme: ThemeColors
+    let encoder: InputEncoder?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack(spacing: 8) {
+                Image(systemName: "doc.text.magnifyingglass")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                Text("Changes")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(theme.treeFg)
+                Spacer()
+                Text("\(state.entries.count)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(theme.treeBg)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(theme.treeSeparatorFg.opacity(0.3))
+                    .frame(height: 1)
+            }
+
+            // File list
+            ScrollView {
+                VStack(spacing: 0) {
+                    if state.entries.isEmpty {
+                        emptyState
+                    } else {
+                        // Group by status: modified first, then added, then deleted
+                        let grouped = Dictionary(grouping: state.entries) { $0.action }
+                        let statusOrder: [ChangeSummaryEntry.FileAction] = [.modified, .added, .deleted, .renamed]
+
+                        ForEach(statusOrder, id: \.self) { action in
+                            if let entries = grouped[action], !entries.isEmpty {
+                                statusSection(action: action, entries: entries)
+                            }
+                        }
+                    }
+                }
+            }
+            .background(theme.treeBg)
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "doc.text")
+                .font(.system(size: 24))
+                .foregroundStyle(.tertiary)
+            Text("No changes yet")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical, 40)
+    }
+
+    // MARK: - Status Section
+
+    @ViewBuilder
+    private func statusSection(action: ChangeSummaryEntry.FileAction, entries: [ChangeSummaryEntry]) -> some View {
+        // Section header
+        HStack(spacing: 4) {
+            Text(sectionTitle(for: action))
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .textCase(.uppercase)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 12)
+        .padding(.bottom, 4)
+
+        // File entries
+        ForEach(entries) { entry in
+            fileEntryView(entry: entry)
+        }
+    }
+
+    private func sectionTitle(for action: ChangeSummaryEntry.FileAction) -> String {
+        switch action {
+        case .modified: "Modified"
+        case .added: "Added"
+        case .deleted: "Deleted"
+        case .renamed: "Renamed"
+        }
+    }
+
+    // MARK: - File Entry
+
+    @State private var hoveredEntryId: Int? = nil
+
+    @ViewBuilder
+    private func fileEntryView(entry: ChangeSummaryEntry) -> some View {
+        let isSelected = entry.id == state.selectedIndex
+        let isHovered = hoveredEntryId == entry.id
+
+        HStack(spacing: 8) {
+            // Status indicator
+            Text(entry.action.indicator)
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(statusColor(entry.action))
+                .frame(width: 14)
+
+            // File icon (SF Symbol based on extension)
+            Image(systemName: fileIcon(for: entry.path))
+                .font(.system(size: 12))
+                .foregroundStyle(fileIconColor(for: entry.path))
+                .frame(width: 16)
+
+            // File path
+            VStack(alignment: .leading, spacing: 2) {
+                Text(fileName(from: entry.path))
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.treeFg)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                if let dir = directoryPath(from: entry.path) {
+                    Text(dir)
+                        .font(.system(size: 9))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.head)
+                }
+            }
+
+            Spacer(minLength: 4)
+
+            // Diff stats
+            HStack(spacing: 4) {
+                if entry.linesAdded > 0 {
+                    Text("+\(entry.linesAdded)")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(Color(red: 0.2, green: 0.8, blue: 0.4))
+                }
+                if entry.linesRemoved > 0 {
+                    Text("-\(entry.linesRemoved)")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(Color(red: 1.0, green: 0.3, blue: 0.3))
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(
+            isSelected
+                ? theme.treeSelectionBg
+                : isHovered
+                    ? Color.blend(theme.treeBg, with: .white, amount: 0.08)
+                    : Color.clear
+        )
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            hoveredEntryId = hovering ? entry.id : nil
+        }
+        .onTapGesture {
+            encoder?.sendChangeSummaryClick(index: UInt32(entry.id))
+        }
+    }
+
+    private func statusColor(_ action: ChangeSummaryEntry.FileAction) -> Color {
+        let c = action.color
+        return Color(red: c.r, green: c.g, blue: c.b)
+    }
+
+    // MARK: - File Path Helpers
+
+    /// Extracts the file name from a path.
+    private func fileName(from path: String) -> String {
+        (path as NSString).lastPathComponent
+    }
+
+    /// Extracts the directory path from a path, or nil if it's a top-level file.
+    private func directoryPath(from path: String) -> String? {
+        let dir = (path as NSString).deletingLastPathComponent
+        return dir.isEmpty ? nil : dir
+    }
+
+    /// Returns an SF Symbol name for the given file extension.
+    private func fileIcon(for path: String) -> String {
+        let ext = (path as NSString).pathExtension.lowercased()
+        switch ext {
+        case "ex", "exs": return "chevron.left.forwardslash.chevron.right"
+        case "swift": return "swift"
+        case "zig": return "z.square"
+        case "rs": return "r.square"
+        case "py": return "p.square"
+        case "js", "ts", "jsx", "tsx": return "j.square"
+        case "go": return "g.square"
+        case "rb": return "r.square.fill"
+        case "md": return "doc.text"
+        case "json": return "curlybraces"
+        case "yml", "yaml": return "list.bullet.indent"
+        case "toml": return "text.alignleft"
+        default: return "doc"
+        }
+    }
+
+    /// Returns a color for the file icon based on extension.
+    private func fileIconColor(for path: String) -> Color {
+        let ext = (path as NSString).pathExtension.lowercased()
+        switch ext {
+        case "ex", "exs": return Color(red: 0.6, green: 0.4, blue: 0.8)
+        case "swift": return Color(red: 1.0, green: 0.45, blue: 0.2)
+        case "zig": return Color(red: 0.95, green: 0.75, blue: 0.3)
+        case "py": return Color(red: 0.3, green: 0.6, blue: 0.85)
+        case "js", "ts", "jsx", "tsx": return Color(red: 0.95, green: 0.8, blue: 0.2)
+        default: return .secondary
+        }
+    }
+}
+
+// MARK: - Color Blending Extension
+
+private extension Color {
+    /// Blends two colors by the given amount (0 = all base, 1 = all target).
+    /// Uses NSColor component interpolation for true color mixing.
+    static func blend(_ base: Color, with target: Color, amount: Double) -> Color {
+        let nsBase = NSColor(base).usingColorSpace(.sRGB) ?? NSColor(base)
+        let nsTarget = NSColor(target).usingColorSpace(.sRGB) ?? NSColor(target)
+        let t = max(0, min(1, amount))
+
+        let r = nsBase.redComponent * (1 - t) + nsTarget.redComponent * t
+        let g = nsBase.greenComponent * (1 - t) + nsTarget.greenComponent * t
+        let b = nsBase.blueComponent * (1 - t) + nsTarget.blueComponent * t
+        let a = nsBase.alphaComponent * (1 - t) + nsTarget.alphaComponent * t
+
+        return Color(nsColor: NSColor(srgbRed: r, green: g, blue: b, alpha: a))
+    }
+}

--- a/macos/Sources/Views/GUIState.swift
+++ b/macos/Sources/Views/GUIState.swift
@@ -63,6 +63,8 @@ final class GUIState {
 
     /// Agent context bar state (0x88).
     let agentContextBarState = AgentContextBarState()
+    /// Change summary sidebar for agent card zoomed-in view.
+    let changeSummaryState = ChangeSummaryState()
 
     /// Semantic window content from gui_window_content (0x80).
     /// Keyed by windowId. NOT cleared between frames; the guiWindowContent


### PR DESCRIPTION
Adds a change summary sidebar showing files modified by an agent with diff stats, replacing the file tree when zoomed into an agent's Board card.

## Changes
- **ChangeSummaryView.swift**: Left sidebar with file list, diff stats (+N/-M), status indicators (M/A/D/R)
- **ChangeSummaryState.swift**: Observable state for the sidebar
- **Protocol**: Decoder and encoder for change summary data
- **BEAM side**: Protocol encoding for change summary entries

Closes #1237