### PR TITLE
feat(macos): Board card view enhancements

### DIFF
--- a/lib/minga/frontend/protocol/gui.ex
+++ b/lib/minga/frontend/protocol/gui.ex
@@ -669,7 +669,8 @@ defmodule Minga.Frontend.Protocol.GUI do
     task_bytes = :erlang.iolist_to_binary([card.task])
     model_bytes = :erlang.iolist_to_binary([card.model || ""])
 
-    elapsed = DateTime.diff(DateTime.utc_now(), card.created_at, :second)
+    # Send Unix timestamp so Swift can compute elapsed time locally
+    dispatch_timestamp = DateTime.to_unix(card.created_at)
 
     recent_files = card.recent_files
 
@@ -681,7 +682,8 @@ defmodule Minga.Frontend.Protocol.GUI do
 
     IO.iodata_to_binary([
       <<card.id::32, status_byte::8, flags::8, byte_size(task_bytes)::16, task_bytes::binary,
-        byte_size(model_bytes)::8, model_bytes::binary, elapsed::32, length(recent_files)::8>>
+        byte_size(model_bytes)::8, model_bytes::binary, dispatch_timestamp::32,
+        length(recent_files)::8>>
       | file_entries
     ])
   end

--- a/macos/Sources/Protocol/BoardTypes.swift
+++ b/macos/Sources/Protocol/BoardTypes.swift
@@ -5,6 +5,8 @@
 /// consumes them for rendering). Kept in Protocol/ so the headless
 /// test harness can compile them without SwiftUI/Observation dependencies.
 
+import Foundation
+
 /// A single card on The Board, decoded from the gui_board opcode.
 struct BoardCard: Identifiable, Equatable, Sendable {
     let id: UInt32
@@ -13,15 +15,16 @@ struct BoardCard: Identifiable, Equatable, Sendable {
     let isFocused: Bool
     let task: String
     let model: String
-    let elapsedSeconds: UInt32
+    let dispatchTimestamp: UInt32  // Unix seconds when card was created
     let recentFiles: [String]
 
-    /// Formatted elapsed time string.
+    /// Formatted elapsed time string computed from dispatch timestamp.
     var elapsedDisplay: String {
-        let s = Int(elapsedSeconds)
-        if s < 60 { return "\(s)s" }
-        if s < 3600 { return "\(s / 60)m" }
-        return "\(s / 3600)h \((s % 3600) / 60)m"
+        let now = UInt32(Date().timeIntervalSince1970)
+        let elapsed = Int(now - dispatchTimestamp)
+        if elapsed < 60 { return "\(elapsed)s" }
+        if elapsed < 3600 { return "\(elapsed / 60)m" }
+        return "\(elapsed / 3600)h \((elapsed % 3600) / 60)m"
     }
 }
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1999,7 +1999,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 isFocused: isFocused,
                 task: task,
                 model: model,
-                elapsedSeconds: elapsed,
+                dispatchTimestamp: elapsed,  // Now treated as Unix timestamp, not elapsed seconds
                 recentFiles: recentFiles
             ))
             bPos = cPos

--- a/macos/Sources/Views/Board/BoardView.swift
+++ b/macos/Sources/Views/Board/BoardView.swift
@@ -149,44 +149,47 @@ struct BoardCardView: View {
     @State private var isHovered = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            // Header: status badge + elapsed time
-            HStack {
-                statusBadge
-                Spacer()
-                Text(card.elapsedDisplay)
-                    .font(.system(size: 11))
-                    .foregroundStyle(.tertiary)
-            }
-
-            // Task description
-            Text(card.task)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(theme.editorFg.opacity(0.9))
-                .lineLimit(2)
-
-            Spacer(minLength: 4)
-
-            // Footer: model name + file count
-            HStack {
-                if !card.model.isEmpty {
-                    Text(card.model)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                if !card.recentFiles.isEmpty {
-                    Text(card.recentFiles.prefix(3).joined(separator: ", "))
-                        .font(.system(size: 11))
+        // TimelineView updates elapsed time every minute
+        TimelineView(.periodic(from: .now, by: 60)) { _ in
+            VStack(alignment: .leading, spacing: 8) {
+                // Header: status badge + elapsed time
+                HStack {
+                    statusBadge
+                    Spacer()
+                    Text(card.elapsedDisplay)
+                        .font(.system(size: 11).monospacedDigit())
                         .foregroundStyle(.tertiary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+                }
+
+                // Task description (or "Manual editing" for You card)
+                Text(card.isYouCard ? "Manual editing" : card.task)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(theme.editorFg.opacity(0.9))
+                    .lineLimit(2)
+
+                Spacer(minLength: 4)
+
+                // Footer: model name + touched files
+                HStack {
+                    if !card.model.isEmpty {
+                        Text(card.model)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if !card.recentFiles.isEmpty {
+                        Text(formattedFiles)
+                            .font(.system(size: 10))
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
                 }
             }
+            // Internal padding: vertical = horizontal × φ (golden ratio emphasis)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 12 * phi)
         }
-        // Internal padding: vertical = horizontal × φ (golden ratio emphasis)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 12 * phi)
         .background(
             RoundedRectangle(cornerRadius: 10)
                 .fill(cardBackground)
@@ -208,9 +211,24 @@ struct BoardCardView: View {
         }
         // VoiceOver: announce card as a single element with combined label
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(card.task), \(card.isYouCard ? "You" : card.status.label), \(card.elapsedDisplay)")
+        .accessibilityLabel("\(card.isYouCard ? "Manual editing" : card.task), \(card.isYouCard ? "You" : card.status.label), \(card.elapsedDisplay)")
         .accessibilityHint("Double tap to open")
         .accessibilityAddTraits(.isButton)
+    }
+
+    // MARK: - Formatted Files
+
+    /// Formats touched files as comma-separated basenames, max 3 with "+N more" suffix.
+    private var formattedFiles: String {
+        let basenames = card.recentFiles.map { URL(fileURLWithPath: $0).lastPathComponent }
+        let total = basenames.count
+        if total <= 3 {
+            return basenames.joined(separator: ", ")
+        } else {
+            let first3 = basenames.prefix(3).joined(separator: ", ")
+            let remaining = total - 3
+            return "\(first3) +\(remaining) more"
+        }
     }
 
     // MARK: - Status Badge


### PR DESCRIPTION
Enhances the existing BoardCardView with live elapsed time, improved file list formatting, and distinct You card treatment.

## Changes
- **BoardCard**: Added dispatchTimestamp for local elapsed time computation
- **BoardCardView**: "+N more" suffix for touched files, distinct You card styling
- **Protocol decoder**: Parses dispatchTimestamp from guiBoard card data

Closes #1240