### PR TITLE
fix(parser): prevent crash after system sleep/wake

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -83,6 +83,7 @@ The frontend runs as a child process of the BEAM. Communication uses stdin (BEAM
 | `0x37` | indent_result | 13 | Indent level result for a line |
 | `0x38` | textobject_result | variable | Text object range result (or nil) |
 | `0x39` | textobject_positions | 9 + count × 9 | Proactive text object position cache |
+| `0x3B` | request_reparse | 5 | Parser requests full reparse after stale edit deltas |
 
 ### Frontend → BEAM (Diagnostics)
 
@@ -581,6 +582,19 @@ Total size: 9 + count × 9 bytes.
 
 **Behavior:** The Zig parser runs the `textobjects.scm` query against the parse tree and collects the start positions of all `.around` captures (e.g., `@function.around`, `@class.around`). Entries are sorted by (row, col) before sending. The BEAM decodes them into a `%{atom => [{row, col}]}` map and stores them on the active window struct. Navigation commands (`]f`, `[f`, etc.) scan this cached data with no further IPC to Zig.
 
+### `0x3B` request_reparse
+
+Sent by the parser when it receives an `edit_buffer` command with stale edit deltas (byte offsets that don't match the parser's stored source for that buffer). This typically happens after system sleep/wake, when the BEAM's view of the buffer has drifted from the parser's. The parser discards the buffer's tree and source and asks the BEAM to resend the full content via `parse_buffer`.
+
+```
+opcode:     u8  = 0x3B
+buffer_id:  u32          the buffer that needs a full reparse
+```
+
+Total size: 5 bytes.
+
+**Behavior:** The BEAM receives this event, looks up the buffer PID for the given `buffer_id`, and sends a full `set_language` + `parse_buffer` sequence for that buffer. This is the same path used when setting up a buffer for the first time, so custom user queries are replayed correctly.
+
 ---
 
 ## Log Messages (Frontend → BEAM)
@@ -627,7 +641,7 @@ Total size: 4 + msg_len bytes.
 
 ### Current design
 
-Tree-sitter parsing runs in a dedicated `minga-parser` Zig process, separate from the rendering frontend. The renderer process handles only render commands (`0x10`-`0x1B` plus GUI chrome `0x70`-`0x78`). The parser process handles highlight commands (`0x20`-`0x26`) and sends highlight responses (`0x30`-`0x39`). Both use the same `{:packet, 4}` framing on their respective stdin/stdout pipes. The BEAM manages both Port processes, routing commands to the appropriate one.
+Tree-sitter parsing runs in a dedicated `minga-parser` Zig process, separate from the rendering frontend. The renderer process handles only render commands (`0x10`-`0x1B` plus GUI chrome `0x70`-`0x78`). The parser process handles highlight commands (`0x20`-`0x26`) and sends highlight responses (`0x30`-`0x3B`). Both use the same `{:packet, 4}` framing on their respective stdin/stdout pipes. The BEAM manages both Port processes, routing commands to the appropriate one.
 
 This separation means rendering frontends (Swift/Metal, GTK4, Zig/libvaxis) only need to implement render commands. Tree-sitter parsing is handled by the shared parser process regardless of which frontend is active.
 

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -739,6 +739,29 @@ defmodule Minga.Editor do
   end
 
   # Parser process crashed; Manager is scheduling a restart.
+  # Parser detected stale edit deltas (byte offsets don't match its stored
+  # source). This typically happens after system sleep/wake. The parser has
+  # already discarded the buffer's tree and source. We resend the full content
+  # so highlighting recovers without user intervention.
+  def handle_info({:minga_highlight, {:request_reparse, buffer_id}}, state) do
+    case HighlightSync.resolve_buffer_pid(state, buffer_id) do
+      nil ->
+        {:noreply, state}
+
+      buf_pid ->
+        Minga.Log.info(:editor, "Parser requested full reparse for buffer #{buffer_id}")
+
+        new_state =
+          if buf_pid == state.workspace.buffers.active do
+            HighlightSync.setup_for_buffer(state)
+          else
+            HighlightSync.request_reparse_buffer(state, buf_pid)
+          end
+
+        {:noreply, new_state}
+    end
+  end
+
   def handle_info({:minga_highlight, :parser_crashed}, state) do
     {:noreply, %{state | parser_status: :restarting}}
   end

--- a/lib/minga/editor/highlight_sync.ex
+++ b/lib/minga/editor/highlight_sync.ex
@@ -86,7 +86,11 @@ defmodule Minga.Editor.HighlightSync do
         parse_cmd = Protocol.encode_parse_buffer(buffer_id, version, content)
         ParserManager.send_commands([parse_cmd])
 
-        state = %{state | workspace: %{state.workspace | highlight: %{hl | version: version}}}
+        state = %{
+          state
+          | workspace: %{state.workspace | highlight: %{hl | version: version}}
+        }
+
         touch_buffer(state, buf_pid)
 
       :error ->
@@ -177,7 +181,11 @@ defmodule Minga.Editor.HighlightSync do
       state
       | workspace: %{
           state.workspace
-          | highlight: %{hl2 | version: version, syntax_overrides: syntax_overrides}
+          | highlight: %{
+              hl2
+              | version: version,
+                syntax_overrides: syntax_overrides
+            }
         }
     }
 
@@ -258,7 +266,18 @@ defmodule Minga.Editor.HighlightSync do
 
     state = put_active_highlight(state, Highlight.from_theme(state.theme))
     hl2 = state.workspace.highlight
-    state = %{state | workspace: %{state.workspace | highlight: %{hl2 | version: version}}}
+
+    state = %{
+      state
+      | workspace: %{
+          state.workspace
+          | highlight: %{
+              hl2
+              | version: version
+            }
+        }
+    }
+
     touch_active(state)
   end
 

--- a/lib/minga/frontend/protocol.ex
+++ b/lib/minga/frontend/protocol.ex
@@ -117,6 +117,7 @@ defmodule Minga.Frontend.Protocol do
   @op_textobject_result 0x38
   @op_textobject_positions 0x39
   @op_conceal_spans 0x3A
+  @op_request_reparse 0x3B
 
   # Config commands (BEAM → frontend)
   @op_set_font 0x50
@@ -205,6 +206,7 @@ defmodule Minga.Frontend.Protocol do
                | nil}
           | {:textobject_positions, buffer_id :: non_neg_integer(), version :: non_neg_integer(),
              %{atom() => [{non_neg_integer(), non_neg_integer()}]}}
+          | {:request_reparse, buffer_id :: non_neg_integer()}
           | {:log_message, level :: String.t(), text :: String.t()}
           | {:gui_action, ProtocolGUI.gui_action()}
 
@@ -769,6 +771,10 @@ defmodule Minga.Frontend.Protocol do
       {:ok, spans} -> {:ok, {:conceal_spans, buffer_id, version, spans}}
       :error -> {:error, :malformed}
     end
+  end
+
+  def decode_event(<<@op_request_reparse, buffer_id::32>>) do
+    {:ok, {:request_reparse, buffer_id}}
   end
 
   def decode_event(<<@op_log_message, level_byte::8, msg_len::16, msg::binary-size(msg_len)>>) do

--- a/test/minga/editor/highlight_sync_test.exs
+++ b/test/minga/editor/highlight_sync_test.exs
@@ -189,4 +189,21 @@ defmodule Minga.Editor.HighlightSyncTest do
       assert HighlightSync.request_reparse(state) == state
     end
   end
+
+  describe "resolve_buffer_pid/2" do
+    test "returns the buffer PID for a known buffer_id" do
+      state = base_state()
+      {:ok, md_buf} = BufferServer.start_link(content: "# Hello", filetype: :markdown)
+
+      new_state = HighlightSync.setup_for_buffer_pid(state, md_buf)
+      buffer_id = Map.get(new_state.workspace.highlight.buffer_ids, md_buf)
+
+      assert HighlightSync.resolve_buffer_pid(new_state, buffer_id) == md_buf
+    end
+
+    test "returns nil for an unknown buffer_id" do
+      state = base_state()
+      assert HighlightSync.resolve_buffer_pid(state, 999) == nil
+    end
+  end
 end

--- a/test/minga/frontend/protocol_test.exs
+++ b/test/minga/frontend/protocol_test.exs
@@ -728,6 +728,23 @@ defmodule Minga.Frontend.ProtocolTest do
     end
   end
 
+  describe "request_reparse protocol" do
+    test "decode_event request_reparse extracts buffer_id" do
+      payload = <<0x3B, 42::32>>
+      assert {:ok, {:request_reparse, 42}} = Protocol.decode_event(payload)
+    end
+
+    test "decode_event request_reparse with buffer_id zero" do
+      payload = <<0x3B, 0::32>>
+      assert {:ok, {:request_reparse, 0}} = Protocol.decode_event(payload)
+    end
+
+    test "decode_event request_reparse with large buffer_id" do
+      payload = <<0x3B, 0xFFFFFFFF::32>>
+      assert {:ok, {:request_reparse, 0xFFFFFFFF}} = Protocol.decode_event(payload)
+    end
+  end
+
   describe "incremental content sync" do
     test "encode_edit_buffer with a single edit" do
       edits = [

--- a/zig/src/parser_main.zig
+++ b/zig/src/parser_main.zig
@@ -160,13 +160,20 @@ const BufferState = struct {
     }
 
     /// Apply edit deltas to the stored source, in order.
+    /// Returns error.StaleEdit if any delta's byte range is inconsistent with
+    /// the current source length, which indicates the BEAM and parser are out
+    /// of sync (e.g., after system sleep/wake). Callers should fall back to a
+    /// full reparse when this happens.
     fn applyEdits(self: *BufferState, alloc: std.mem.Allocator, edits: []const protocol.EditDelta) !void {
         for (edits) |edit| {
             const start: usize = @intCast(edit.start_byte);
             const old_end: usize = @intCast(edit.old_end_byte);
 
-            if (start > self.source.items.len) continue;
+            // Stale delta: old_end before start, or start past source length.
+            // This means the BEAM's view of the buffer doesn't match ours.
+            if (old_end < edit.start_byte or start > self.source.items.len) return error.StaleEdit;
             const clamped_old_end = @min(old_end, self.source.items.len);
+            if (clamped_old_end < start) return error.StaleEdit;
 
             // Replace [start..old_end) with inserted_text.
             try self.source.replaceRange(alloc, start, clamped_old_end - start, edit.inserted_text);
@@ -396,8 +403,29 @@ fn handleEditBuffer(
 
     const bs = try getOrCreateBuffer(buffers, alloc, decoded.buffer_id);
 
-    // Apply edits to stored source.
-    bs.applyEdits(alloc, decoded.edits) catch return;
+    // Apply edits to stored source. If the deltas are stale (byte offsets
+    // don't match our source), discard the tree and ask the BEAM to send
+    // a full parse_buffer. Attempting to parse with mismatched source and
+    // tree causes memory corruption in tree-sitter.
+    bs.applyEdits(alloc, decoded.edits) catch |err| {
+        if (err == error.StaleEdit) {
+            // Source and tree are out of sync. Delete the tree so the next
+            // parse_buffer from the BEAM starts fresh.
+            if (bs.tree) |t| {
+                c.ts_tree_delete(t);
+                bs.tree = null;
+            }
+            bs.source.clearRetainingCapacity();
+            std.log.warn("edit_buffer: stale deltas for buffer {d}, requesting full reparse", .{decoded.buffer_id});
+
+            // Tell the BEAM to resend the full buffer content.
+            var reparse_buf: [5]u8 = undefined;
+            const len = protocol.encodeRequestReparse(&reparse_buf, decoded.buffer_id) catch return;
+            protocol.writeMessage(stdout, reparse_buf[0..len]) catch return;
+            stdout.flush() catch {};
+        }
+        return;
+    };
 
     // Activate this buffer (sets language, installs its tree for incremental parsing).
     if (!activateBuffer(hl, bs)) return;
@@ -519,6 +547,142 @@ fn readExact(fd: std.posix.fd_t, buf: []u8) !bool {
         total += n;
     }
     return true;
+}
+
+// ── BufferState.applyEdits tests ──────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "applyEdits: valid edit replaces text" {
+    var bs: BufferState = .{};
+    defer bs.deinit(testing.allocator);
+    try bs.setSource(testing.allocator, "hello world");
+
+    const edits = [_]protocol.EditDelta{.{
+        .start_byte = 5,
+        .old_end_byte = 11,
+        .new_end_byte = 13,
+        .start_row = 0,
+        .start_col = 5,
+        .old_end_row = 0,
+        .old_end_col = 11,
+        .new_end_row = 0,
+        .new_end_col = 13,
+        .inserted_text = " universe",
+    }};
+
+    try bs.applyEdits(testing.allocator, &edits);
+    try testing.expectEqualStrings("hello universe", bs.source.items);
+}
+
+test "applyEdits: returns StaleEdit when old_end_byte < start_byte" {
+    var bs: BufferState = .{};
+    defer bs.deinit(testing.allocator);
+    try bs.setSource(testing.allocator, "hello world");
+
+    const edits = [_]protocol.EditDelta{.{
+        .start_byte = 8,
+        .old_end_byte = 3, // before start: stale/corrupted delta
+        .new_end_byte = 8,
+        .start_row = 0,
+        .start_col = 8,
+        .old_end_row = 0,
+        .old_end_col = 3,
+        .new_end_row = 0,
+        .new_end_col = 8,
+        .inserted_text = "",
+    }};
+
+    try testing.expectError(error.StaleEdit, bs.applyEdits(testing.allocator, &edits));
+    // Source should be unchanged after the error.
+    try testing.expectEqualStrings("hello world", bs.source.items);
+}
+
+test "applyEdits: returns StaleEdit when start_byte exceeds source length" {
+    var bs: BufferState = .{};
+    defer bs.deinit(testing.allocator);
+    try bs.setSource(testing.allocator, "hi");
+
+    const edits = [_]protocol.EditDelta{.{
+        .start_byte = 100,
+        .old_end_byte = 105,
+        .new_end_byte = 103,
+        .start_row = 5,
+        .start_col = 0,
+        .old_end_row = 5,
+        .old_end_col = 5,
+        .new_end_row = 5,
+        .new_end_col = 3,
+        .inserted_text = "abc",
+    }};
+
+    try testing.expectError(error.StaleEdit, bs.applyEdits(testing.allocator, &edits));
+    try testing.expectEqualStrings("hi", bs.source.items);
+}
+
+test "applyEdits: returns StaleEdit on empty source with non-zero offsets" {
+    var bs: BufferState = .{};
+    defer bs.deinit(testing.allocator);
+    // Source is empty (simulates a cleared buffer after previous StaleEdit).
+
+    const edits = [_]protocol.EditDelta{.{
+        .start_byte = 10,
+        .old_end_byte = 15,
+        .new_end_byte = 12,
+        .start_row = 0,
+        .start_col = 10,
+        .old_end_row = 0,
+        .old_end_col = 15,
+        .new_end_row = 0,
+        .new_end_col = 12,
+        .inserted_text = "ab",
+    }};
+
+    try testing.expectError(error.StaleEdit, bs.applyEdits(testing.allocator, &edits));
+}
+
+test "applyEdits: valid insert at beginning of source" {
+    var bs: BufferState = .{};
+    defer bs.deinit(testing.allocator);
+    try bs.setSource(testing.allocator, "world");
+
+    const edits = [_]protocol.EditDelta{.{
+        .start_byte = 0,
+        .old_end_byte = 0,
+        .new_end_byte = 6,
+        .start_row = 0,
+        .start_col = 0,
+        .old_end_row = 0,
+        .old_end_col = 0,
+        .new_end_row = 0,
+        .new_end_col = 6,
+        .inserted_text = "hello ",
+    }};
+
+    try bs.applyEdits(testing.allocator, &edits);
+    try testing.expectEqualStrings("hello world", bs.source.items);
+}
+
+test "applyEdits: clamped_old_end < start returns StaleEdit" {
+    // old_end is valid (within source) but less than start after clamping.
+    var bs: BufferState = .{};
+    defer bs.deinit(testing.allocator);
+    try bs.setSource(testing.allocator, "hello world");
+
+    const edits = [_]protocol.EditDelta{.{
+        .start_byte = 8,
+        .old_end_byte = 5, // clamped to 5, which is < start(8)
+        .new_end_byte = 8,
+        .start_row = 0,
+        .start_col = 8,
+        .old_end_row = 0,
+        .old_end_col = 5,
+        .new_end_row = 0,
+        .new_end_col = 8,
+        .inserted_text = "",
+    }};
+
+    try testing.expectError(error.StaleEdit, bs.applyEdits(testing.allocator, &edits));
 }
 
 // Pull in tests from imported modules for the parser test step.

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -88,6 +88,11 @@ pub const OP_TEXTOBJECT_RESULT: u8 = 0x38;
 pub const OP_TEXTOBJECT_POSITIONS: u8 = 0x39;
 pub const OP_CONCEAL_SPANS: u8 = 0x3A;
 
+/// Requests that the BEAM send a full parse_buffer for this buffer_id.
+/// Sent when the parser detects stale edit deltas (byte offsets don't match
+/// the stored source), typically after system sleep/wake.
+pub const OP_REQUEST_REPARSE: u8 = 0x3B;
+
 // Log messages (Zig → BEAM)
 pub const OP_LOG_MESSAGE: u8 = 0x60;
 
@@ -599,6 +604,18 @@ pub fn encodeGrammarLoaded(buf: []u8, success: bool, name: []const u8) !usize {
     buf[1] = if (success) 1 else 0;
     std.mem.writeInt(u16, buf[2..4], @intCast(name.len), .big);
     @memcpy(buf[4 .. 4 + name.len], name);
+    return total;
+}
+
+/// Encodes request_reparse: opcode(1) + buffer_id:u32
+/// Wire format: `<0x3B, buffer_id:32>`
+/// Sent when the parser detects stale edit deltas and needs the BEAM
+/// to resend the full buffer content via parse_buffer.
+pub fn encodeRequestReparse(buf: []u8, buffer_id: u32) !usize {
+    const total = 5;
+    if (buf.len < total) return error.Malformed;
+    buf[0] = OP_REQUEST_REPARSE;
+    std.mem.writeInt(u32, buf[1..5], buffer_id, .big);
     return total;
 }
 
@@ -2143,6 +2160,36 @@ test "encodeLogMessage empty message" {
 test "encodeLogMessage buffer too small returns error" {
     var buf: [3]u8 = undefined; // needs at least 4
     const result = encodeLogMessage(&buf, LOG_LEVEL_ERR, "");
+    try std.testing.expectError(error.Malformed, result);
+}
+
+// ── Request reparse protocol tests ────────────────────────────────────────────
+
+test "encodeRequestReparse byte layout" {
+    var buf: [5]u8 = undefined;
+    const len = try encodeRequestReparse(&buf, 42);
+    try std.testing.expectEqual(@as(usize, 5), len);
+    try std.testing.expectEqual(OP_REQUEST_REPARSE, buf[0]);
+    try std.testing.expectEqual(@as(u32, 42), std.mem.readInt(u32, buf[1..5], .big));
+}
+
+test "encodeRequestReparse with zero buffer_id" {
+    var buf: [5]u8 = undefined;
+    const len = try encodeRequestReparse(&buf, 0);
+    try std.testing.expectEqual(@as(usize, 5), len);
+    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, buf[1..5], .big));
+}
+
+test "encodeRequestReparse with max buffer_id" {
+    var buf: [5]u8 = undefined;
+    const len = try encodeRequestReparse(&buf, std.math.maxInt(u32));
+    try std.testing.expectEqual(@as(usize, 5), len);
+    try std.testing.expectEqual(std.math.maxInt(u32), std.mem.readInt(u32, buf[1..5], .big));
+}
+
+test "encodeRequestReparse buffer too small returns error" {
+    var buf: [4]u8 = undefined;
+    const result = encodeRequestReparse(&buf, 1);
     try std.testing.expectError(error.Malformed, result);
 }
 


### PR DESCRIPTION
## Summary

Fixes #1165. The tree-sitter parser crashed with an integer overflow in `BufferState.applyEdits` followed by a segfault when the editor resumed after system sleep/wake.

## Root Cause

Stale edit deltas (with `old_end_byte < start_byte`) caused an unsigned subtraction underflow in the Zig parser's `applyEdits`, corrupting the buffer's source and tree. Subsequent `PredicateTable.evaluate` calls read from corrupted memory and segfaulted.

## Fix

The fix lives in the Zig/parser layer with a protocol-based recovery mechanism:

**Zig (prevention):** `applyEdits` validates delta byte ranges against the stored source. Inconsistent deltas return `error.StaleEdit` instead of performing the underflow. `handleEditBuffer` catches this, clears the buffer's tree and source, and sends a new `OP_REQUEST_REPARSE` (0x3B) event to the BEAM.

**BEAM (recovery):** Decodes `OP_REQUEST_REPARSE`, resolves the buffer PID, and triggers a full `setup_for_buffer` / `request_reparse_buffer`. Highlighting recovers automatically with at most a brief flicker.

## Tests

- 6 Zig unit tests for `applyEdits` (valid edits, stale deltas, empty source, edge cases)
- 4 Zig unit tests for `encodeRequestReparse` encoding
- 3 Elixir protocol decode tests for `OP_REQUEST_REPARSE`
- 2 Elixir `resolve_buffer_pid` tests

## Checklist

- [x] `make lint` passes
- [x] `mix test.llm` passes (6948 tests, 0 failures)
- [x] `mix zig.lint` passes (all Zig tests)
- [x] Protocol doc updated (`docs/PROTOCOL.md`)