### PR TITLE
feat(keymap): add Scope.Builder macro for declarative scope definitions

### DIFF
--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -16,14 +16,18 @@ defmodule Minga.Keymap.Scope.Agent do
   functions, not separate dispatch paths.
   """
 
-  @behaviour Minga.Keymap.Scope
+  use Minga.Keymap.Scope.Builder,
+    name: :agent,
+    display_name: "Agent"
 
   alias Minga.Keymap.Bindings
+  alias Minga.Keymap.CUADefaults
 
   # Modifier bitmasks
   @ctrl 0x02
   @shift 0x01
   @alt 0x04
+  @cmd 0x08
 
   # Special codepoints
   @tab 9
@@ -31,15 +35,12 @@ defmodule Minga.Keymap.Scope.Agent do
   @escape 27
   @backspace 127
 
+  # Group specs for each vim state.
+  @insert_groups [:ctrl_agent_common, :newline_variants]
+  @input_normal_groups [:ctrl_agent_common]
+  @cua_groups [{:cua_navigation, exclude: [:half_page_up, :half_page_down]}]
+
   # ── Behaviour callbacks ────────────────────────────────────────────────────
-
-  @impl true
-  @spec name() :: :agent
-  def name, do: :agent
-
-  @impl true
-  @spec display_name() :: String.t()
-  def display_name, do: "Agent"
 
   @impl true
   @spec keymap(Minga.Keymap.Scope.vim_state(), Minga.Keymap.Scope.context()) ::
@@ -52,7 +53,7 @@ defmodule Minga.Keymap.Scope.Agent do
 
   @impl true
   @spec shared_keymap() :: Bindings.node_t()
-  def shared_keymap, do: shared_trie()
+  def shared_keymap, do: Bindings.new()
 
   @impl true
   @spec help_groups(atom()) :: [Minga.Keymap.Scope.help_group()]
@@ -68,14 +69,6 @@ defmodule Minga.Keymap.Scope.Agent do
       {:cua_navigation, exclude: [:half_page_up, :half_page_down]}
     ]
   end
-
-  @impl true
-  @spec on_enter(term()) :: term()
-  def on_enter(state), do: state
-
-  @impl true
-  @spec on_exit(term()) :: term()
-  def on_exit(state), do: state
 
   # ── Normal mode bindings ───────────────────────────────────────────────────
 
@@ -148,32 +141,33 @@ defmodule Minga.Keymap.Scope.Agent do
 
   @spec insert_trie() :: Bindings.node_t()
   defp insert_trie do
-    Bindings.new()
-    # Shared Ctrl shortcuts (Ctrl+C, D, U, L, S, Q) from group
-    |> Bindings.merge_group(:ctrl_agent_common)
-    # Newline variants (Shift+Enter across all terminal encodings) from group
-    |> Bindings.merge_group(:newline_variants)
-    # ESC switches to input normal mode (vim-style)
-    |> Bindings.bind([{@escape, 0}], :agent_input_to_normal, "Normal mode")
-    # Enter submits
-    |> Bindings.bind([{@enter, 0}], :agent_submit_or_newline, "Submit prompt")
-    # Backspace
-    |> Bindings.bind([{@backspace, 0}], :agent_input_backspace, "Delete character")
-    # Left/right arrows handled by Vim.handle_key (shared primitive).
-    # Up/down arrows handled here: moves cursor OR recalls prompt history.
-    |> Bindings.bind([{0xF700, 0}], :agent_input_up, "Move up / history prev")
-    |> Bindings.bind([{0xF701, 0}], :agent_input_down, "Move down / history next")
-    |> Bindings.bind([{57_352, 0}], :agent_input_up, "Move up / history prev")
-    |> Bindings.bind([{57_353, 0}], :agent_input_down, "Move down / history next")
-    # Ctrl+Enter queues as follow-up during streaming; submits normally when idle.
-    |> Bindings.bind([{@enter, @ctrl}], :agent_queue_follow_up, "Queue as follow-up")
-    # Alt+Up dequeues pending messages back into the prompt buffer.
-    |> Bindings.bind([{0xF700, @alt}], :agent_dequeue, "Dequeue to editor")
-    |> Bindings.bind([{57_352, @alt}], :agent_dequeue, "Dequeue to editor")
-    # Scope-specific overrides on top of group bindings:
-    # Ctrl+D/U get more specific descriptions in insert context
-    |> Bindings.bind([{?d, @ctrl}], :agent_scroll_half_down, "Scroll down (while typing)")
-    |> Bindings.bind([{?u, @ctrl}], :agent_scroll_half_up, "Scroll up (while typing)")
+    build_trie(
+      groups: @insert_groups,
+      then: fn trie ->
+        trie
+        # ESC switches to input normal mode (vim-style)
+        |> Bindings.bind([{@escape, 0}], :agent_input_to_normal, "Normal mode")
+        # Enter submits
+        |> Bindings.bind([{@enter, 0}], :agent_submit_or_newline, "Submit prompt")
+        # Backspace
+        |> Bindings.bind([{@backspace, 0}], :agent_input_backspace, "Delete character")
+        # Left/right arrows handled by Vim.handle_key (shared primitive).
+        # Up/down arrows handled here: moves cursor OR recalls prompt history.
+        |> Bindings.bind([{0xF700, 0}], :agent_input_up, "Move up / history prev")
+        |> Bindings.bind([{0xF701, 0}], :agent_input_down, "Move down / history next")
+        |> Bindings.bind([{57_352, 0}], :agent_input_up, "Move up / history prev")
+        |> Bindings.bind([{57_353, 0}], :agent_input_down, "Move down / history next")
+        # Ctrl+Enter queues as follow-up during streaming; submits normally when idle.
+        |> Bindings.bind([{@enter, @ctrl}], :agent_queue_follow_up, "Queue as follow-up")
+        # Alt+Up dequeues pending messages back into the prompt buffer.
+        |> Bindings.bind([{0xF700, @alt}], :agent_dequeue, "Dequeue to editor")
+        |> Bindings.bind([{57_352, @alt}], :agent_dequeue, "Dequeue to editor")
+        # Scope-specific overrides on top of group bindings:
+        # Ctrl+D/U get more specific descriptions in insert context
+        |> Bindings.bind([{?d, @ctrl}], :agent_scroll_half_down, "Scroll down (while typing)")
+        |> Bindings.bind([{?u, @ctrl}], :agent_scroll_half_up, "Scroll up (while typing)")
+      end
+    )
   end
 
   # ── Input normal mode meta keys ──────────────────────────────────────────
@@ -184,20 +178,15 @@ defmodule Minga.Keymap.Scope.Agent do
 
   @spec input_normal_trie() :: Bindings.node_t()
   defp input_normal_trie do
-    Bindings.new()
-    # Shared Ctrl shortcuts from group (Ctrl+C, D, U, L, S, Q)
-    |> Bindings.merge_group(:ctrl_agent_common)
-    # No Escape binding: in normal mode, Escape is a no-op (vim semantics).
-    # Use `q` or Ctrl+Q to leave the input field.
-    |> Bindings.bind([{?q, 0}], :agent_unfocus_input, "Back to chat nav")
-  end
-
-  # ── Shared bindings (both normal and insert) ───────────────────────────────
-
-  @spec shared_trie() :: Bindings.node_t()
-  defp shared_trie do
-    # Ctrl+C works the same in both modes
-    Bindings.new()
+    build_trie(
+      groups: @input_normal_groups,
+      then: fn trie ->
+        trie
+        # No Escape binding: in normal mode, Escape is a no-op (vim semantics).
+        # Use `q` or Ctrl+Q to leave the input field.
+        |> Bindings.bind([{?q, 0}], :agent_unfocus_input, "Back to chat nav")
+      end
+    )
   end
 
   # ── Help content ───────────────────────────────────────────────────────────
@@ -297,32 +286,47 @@ defmodule Minga.Keymap.Scope.Agent do
   # determines whether input is focused and routes accordingly; the trie
   # contains bindings for both states.
 
-  alias Minga.Keymap.CUADefaults
-
-  @cmd 0x08
-
   @spec cua_trie() :: Bindings.node_t()
   defp cua_trie do
-    CUADefaults.navigation_trie()
-    # Enter: focus input if not focused, submit if focused
-    |> Bindings.bind([{@enter, 0}], :agent_focus_or_submit, "Focus input / submit")
-    |> Bindings.bind([{@escape, 0}], :agent_dismiss_or_noop, "Dismiss/cancel")
-    |> Bindings.bind([{@tab, 0}], :agent_switch_focus, "Switch panel focus")
-    # Cmd chords (GUI) + Ctrl fallbacks (TUI)
-    |> Bindings.bind([{?c, @cmd}], :agent_copy_code_block, "Copy code block")
-    |> Bindings.bind([{?a, @cmd}], :select_all, "Select all")
-    |> Bindings.bind([{?c, @ctrl}], :agent_copy_code_block, "Copy code block")
-    |> Bindings.bind([{?a, @ctrl}], :select_all, "Select all")
-    # Input field bindings (used when input focused)
-    |> Bindings.bind([{@backspace, 0}], :agent_input_backspace, "Delete character")
-    |> Bindings.bind([{@enter, @shift}], :agent_insert_newline, "Insert newline")
-    |> Bindings.bind([{?j, @ctrl}], :agent_insert_newline, "Insert newline")
-    |> Bindings.bind([{0x0A, 0}], :agent_insert_newline, "Insert newline")
-    |> Bindings.bind([{@enter, @alt}], :agent_insert_newline, "Insert newline")
-    # Arrow up/down in input: history navigation
-    |> Bindings.bind([{57_352, 0}], :agent_input_up, "Move up / history prev")
-    |> Bindings.bind([{57_353, 0}], :agent_input_down, "Move down / history next")
-    |> Bindings.bind([{0xF700, 0}], :agent_input_up, "Move up / history prev")
-    |> Bindings.bind([{0xF701, 0}], :agent_input_down, "Move down / history next")
+    build_trie(
+      groups: @cua_groups,
+      then: fn trie ->
+        CUADefaults.navigation_trie()
+        |> merge_trie(trie)
+        # Enter: focus input if not focused, submit if focused
+        |> Bindings.bind([{@enter, 0}], :agent_focus_or_submit, "Focus input / submit")
+        |> Bindings.bind([{@escape, 0}], :agent_dismiss_or_noop, "Dismiss/cancel")
+        |> Bindings.bind([{@tab, 0}], :agent_switch_focus, "Switch panel focus")
+        # Cmd chords (GUI) + Ctrl fallbacks (TUI)
+        |> Bindings.bind([{?c, @cmd}], :agent_copy_code_block, "Copy code block")
+        |> Bindings.bind([{?a, @cmd}], :select_all, "Select all")
+        |> Bindings.bind([{?c, @ctrl}], :agent_copy_code_block, "Copy code block")
+        |> Bindings.bind([{?a, @ctrl}], :select_all, "Select all")
+        # Input field bindings (used when input focused)
+        |> Bindings.bind([{@backspace, 0}], :agent_input_backspace, "Delete character")
+        |> Bindings.bind([{@enter, @shift}], :agent_insert_newline, "Insert newline")
+        |> Bindings.bind([{?j, @ctrl}], :agent_insert_newline, "Insert newline")
+        |> Bindings.bind([{0x0A, 0}], :agent_insert_newline, "Insert newline")
+        |> Bindings.bind([{@enter, @alt}], :agent_insert_newline, "Insert newline")
+        # Arrow up/down in input: history navigation
+        |> Bindings.bind([{57_352, 0}], :agent_input_up, "Move up / history prev")
+        |> Bindings.bind([{57_353, 0}], :agent_input_down, "Move down / history next")
+        |> Bindings.bind([{0xF700, 0}], :agent_input_up, "Move up / history prev")
+        |> Bindings.bind([{0xF701, 0}], :agent_input_down, "Move down / history next")
+      end
+    )
+  end
+
+  # Merge two tries together (source wins on conflict).
+  @spec merge_trie(Bindings.node_t(), Bindings.node_t()) :: Bindings.node_t()
+  defp merge_trie(target, %Bindings.Node{children: children}) do
+    Enum.reduce(children, target, fn {key, %Bindings.Node{command: cmd, description: desc}},
+                                     acc ->
+      if cmd do
+        Bindings.bind(acc, [key], cmd, desc || "")
+      else
+        acc
+      end
+    end)
   end
 end

--- a/lib/minga/keymap/scope/builder.ex
+++ b/lib/minga/keymap/scope/builder.ex
@@ -1,0 +1,193 @@
+defmodule Minga.Keymap.Scope.Builder do
+  @moduledoc """
+  Declarative builder for keymap scope modules.
+
+  Reduces boilerplate in scope modules and ensures shared binding groups
+  are correctly merged into per-vim-state tries at compile time. Each scope
+  module `use`s this builder and gets:
+
+  - Automatic `@behaviour Minga.Keymap.Scope` implementation
+  - Default `name/0`, `display_name/0`, `on_enter/1`, `on_exit/1` callbacks
+  - `build_trie/1` helper for declarative group merging + scope-specific bindings
+  - `groups_to_trie/1` for building a trie from groups alone (no scope bindings)
+
+  ## Usage
+
+      defmodule Minga.Keymap.Scope.MyScope do
+        use Minga.Keymap.Scope.Builder,
+          name: :my_scope,
+          display_name: "My Scope"
+
+        @impl true
+        def keymap(:normal, _context) do
+          build_trie(
+            groups: [:cua_navigation, {:cua_cmd_chords, exclude: [:select_all]}],
+            exclude: [:quit_editor],
+            then: fn trie ->
+              trie
+              |> Bindings.bind([{?q, 0}], :my_close, "Close")
+            end
+          )
+        end
+        def keymap(_state, _context), do: Bindings.new()
+      end
+
+  ## Group merging order
+
+  Groups are merged first (in declaration order), then the `then` function
+  runs on top. This means scope-specific bindings in `then` override group
+  bindings on conflict. Per-group exclusions (via `{name, exclude: [...]}`)
+  are applied when merging that specific group. Global exclusions (via the
+  top-level `exclude:` option) apply to all groups.
+
+  ## Compile-time evaluation
+
+  The trie is built when the `defp` function is first called (BEAM memoizes
+  the pattern match). There's no per-keystroke overhead. To force compile-time
+  evaluation, assign the result to a module attribute:
+
+      @my_trie build_trie(groups: [:cua_navigation])
+  """
+
+  alias Minga.Keymap.Bindings
+  alias Minga.Keymap.SharedGroups
+
+  @doc false
+  defmacro __using__(opts) do
+    quote bind_quoted: [opts: opts] do
+      @behaviour Minga.Keymap.Scope
+      import Minga.Keymap.Scope.Builder, only: [build_trie: 1, groups_to_trie: 1]
+
+      @_scope_name Keyword.fetch!(opts, :name)
+      @_scope_display_name Keyword.fetch!(opts, :display_name)
+
+      @impl true
+      @spec name() :: atom()
+      def name, do: @_scope_name
+
+      @impl true
+      @spec display_name() :: String.t()
+      def display_name, do: @_scope_display_name
+
+      @impl true
+      @spec on_enter(term()) :: term()
+      def on_enter(state), do: state
+
+      @impl true
+      @spec on_exit(term()) :: term()
+      def on_exit(state), do: state
+
+      defoverridable on_enter: 1, on_exit: 1
+    end
+  end
+
+  @doc """
+  Builds a trie by merging shared groups, then applying scope-specific bindings.
+
+  ## Options
+
+  - `:groups` - list of group names or `{name, opts}` tuples to merge. Groups
+    are merged in order; later groups override earlier ones on key conflict.
+  - `:exclude` - list of command atoms to exclude from ALL groups. Applied
+    globally before per-group exclusions.
+  - `:then` - function `(trie -> trie)` that applies scope-specific bindings
+    on top of the merged groups. Runs last, so scope bindings win on conflict.
+
+  ## Examples
+
+      # Groups only
+      build_trie(groups: [:cua_navigation, :cua_cmd_chords])
+
+      # Groups with global exclusion
+      build_trie(groups: [:cua_navigation], exclude: [:move_up])
+
+      # Groups with per-group exclusion
+      build_trie(groups: [{:cua_navigation, exclude: [:half_page_up]}])
+
+      # Groups + scope-specific bindings
+      build_trie(
+        groups: [:ctrl_agent_common],
+        then: fn trie ->
+          trie
+          |> Bindings.bind([{27, 0}], :my_escape, "Escape")
+        end
+      )
+  """
+  @spec build_trie(keyword()) :: Bindings.node_t()
+  def build_trie(opts) when is_list(opts) do
+    groups = Keyword.get(opts, :groups, [])
+    global_excludes = Keyword.get(opts, :exclude, [])
+    then_fn = Keyword.get(opts, :then, fn trie -> trie end)
+
+    Bindings.new()
+    |> merge_groups(groups, global_excludes)
+    |> then_fn.()
+  end
+
+  @doc """
+  Builds a trie from shared groups only, with no scope-specific bindings.
+
+  Shorthand for `build_trie(groups: groups)`.
+  """
+  @spec groups_to_trie([atom() | {atom(), keyword()}]) :: Bindings.node_t()
+  def groups_to_trie(groups) when is_list(groups) do
+    build_trie(groups: groups)
+  end
+
+  @doc """
+  Returns the list of group names from a group spec list.
+
+  Normalizes `{name, opts}` tuples to just the name atom. Useful for
+  implementing `included_groups/0`.
+  """
+  @spec group_names_from([atom() | {atom(), keyword()}]) :: [atom()]
+  def group_names_from(groups) when is_list(groups) do
+    Enum.map(groups, fn
+      {name, _opts} when is_atom(name) -> name
+      name when is_atom(name) -> name
+    end)
+  end
+
+  @doc """
+  Validates that all group names in a spec list exist in SharedGroups.
+
+  Returns `:ok` or raises `ArgumentError` with the unknown group names.
+  Useful as a compile-time check in scope modules.
+  """
+  @spec validate_groups!([atom() | {atom(), keyword()}]) :: :ok
+  def validate_groups!(groups) when is_list(groups) do
+    known = MapSet.new(SharedGroups.group_names())
+
+    unknown =
+      groups
+      |> group_names_from()
+      |> Enum.reject(&MapSet.member?(known, &1))
+
+    case unknown do
+      [] -> :ok
+      names -> raise ArgumentError, "unknown shared groups: #{inspect(names)}"
+    end
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────────────
+
+  @spec merge_groups(Bindings.node_t(), [atom() | {atom(), keyword()}], [atom()]) ::
+          Bindings.node_t()
+  defp merge_groups(trie, groups, global_excludes) do
+    Enum.reduce(groups, trie, fn group_spec, acc ->
+      {name, per_group_opts} = normalize_group_spec(group_spec)
+      per_group_excludes = Keyword.get(per_group_opts, :exclude, [])
+      all_excludes = Enum.uniq(global_excludes ++ per_group_excludes)
+
+      if all_excludes == [] do
+        Bindings.merge_group(acc, name)
+      else
+        Bindings.merge_group(acc, name, exclude: all_excludes)
+      end
+    end)
+  end
+
+  @spec normalize_group_spec(atom() | {atom(), keyword()}) :: {atom(), keyword()}
+  defp normalize_group_spec({name, opts}) when is_atom(name) and is_list(opts), do: {name, opts}
+  defp normalize_group_spec(name) when is_atom(name), do: {name, []}
+end

--- a/lib/minga/keymap/scope/editor.ex
+++ b/lib/minga/keymap/scope/editor.ex
@@ -15,18 +15,22 @@ defmodule Minga.Keymap.Scope.Editor do
   `CUA.Dispatch` (CUA) when this scope returns `:not_found`.
   """
 
-  @behaviour Minga.Keymap.Scope
+  use Minga.Keymap.Scope.Builder,
+    name: :editor,
+    display_name: "Editor"
 
   alias Minga.Keymap.Bindings
-  alias Minga.Keymap.CUADefaults
+
+  @ctrl 0x02
+
+  # Groups included by this scope.
+  @cua_groups [:cua_cmd_chords]
 
   @impl true
-  @spec name() :: :editor
-  def name, do: :editor
+  @spec included_groups() :: [atom() | {atom(), keyword()}]
+  def included_groups, do: @cua_groups
 
-  @impl true
-  @spec display_name() :: String.t()
-  def display_name, do: "Editor"
+  # ── Keymap ─────────────────────────────────────────────────────────────────
 
   @impl true
   @spec keymap(Minga.Keymap.Scope.vim_state(), Minga.Keymap.Scope.context()) ::
@@ -42,25 +46,16 @@ defmodule Minga.Keymap.Scope.Editor do
   @spec help_groups(atom()) :: [Minga.Keymap.Scope.help_group()]
   def help_groups(_focus), do: []
 
-  @impl true
-  @spec included_groups() :: [atom() | {atom(), keyword()}]
-  def included_groups, do: [:cua_cmd_chords]
-
-  @impl true
-  @spec on_enter(term()) :: term()
-  def on_enter(state), do: state
-
-  @impl true
-  @spec on_exit(term()) :: term()
-  def on_exit(state), do: state
-
   # ── CUA bindings ───────────────────────────────────────────────────────
-
-  @ctrl 0x02
 
   @spec cua_trie() :: Bindings.node_t()
   defp cua_trie do
-    CUADefaults.cmd_chords_trie()
-    |> Bindings.bind([{?p, @ctrl}], :command_palette, "Command palette")
+    build_trie(
+      groups: @cua_groups,
+      then: fn trie ->
+        trie
+        |> Bindings.bind([{?p, @ctrl}], :command_palette, "Command palette")
+      end
+    )
   end
 end

--- a/lib/minga/keymap/scope/file_tree.ex
+++ b/lib/minga/keymap/scope/file_tree.ex
@@ -11,7 +11,9 @@ defmodule Minga.Keymap.Scope.FileTree do
   or visual are blocked.
   """
 
-  @behaviour Minga.Keymap.Scope
+  use Minga.Keymap.Scope.Builder,
+    name: :file_tree,
+    display_name: "File Tree"
 
   alias Minga.Keymap.Bindings
 
@@ -19,15 +21,15 @@ defmodule Minga.Keymap.Scope.FileTree do
   @enter 13
   @escape 27
 
-  # ── Behaviour callbacks ────────────────────────────────────────────────────
+  # Groups included by this scope, per vim state.
+  # CUA mode gets arrow-key navigation from the shared group.
+  @cua_groups [:cua_navigation]
 
   @impl true
-  @spec name() :: :file_tree
-  def name, do: :file_tree
+  @spec included_groups() :: [atom() | {atom(), keyword()}]
+  def included_groups, do: @cua_groups
 
-  @impl true
-  @spec display_name() :: String.t()
-  def display_name, do: "File Tree"
+  # ── Keymap ─────────────────────────────────────────────────────────────────
 
   @impl true
   @spec keymap(Minga.Keymap.Scope.vim_state(), Minga.Keymap.Scope.context()) ::
@@ -65,18 +67,6 @@ defmodule Minga.Keymap.Scope.FileTree do
     ]
   end
 
-  @impl true
-  @spec included_groups() :: [atom() | {atom(), keyword()}]
-  def included_groups, do: [:cua_navigation]
-
-  @impl true
-  @spec on_enter(term()) :: term()
-  def on_enter(state), do: state
-
-  @impl true
-  @spec on_exit(term()) :: term()
-  def on_exit(state), do: state
-
   # ── Normal mode bindings ───────────────────────────────────────────────────
 
   @spec normal_trie() :: Bindings.node_t()
@@ -96,17 +86,20 @@ defmodule Minga.Keymap.Scope.FileTree do
   # Arrow keys for navigation, Enter to open, Escape to close.
   # Left/Right expand/collapse directories (matching macOS Finder).
 
-  alias Minga.Keymap.CUADefaults
-
   @spec cua_trie() :: Bindings.node_t()
   defp cua_trie do
-    CUADefaults.navigation_trie()
-    |> Bindings.bind([{@enter, 0}], :tree_open_or_toggle, "Open file / toggle directory")
-    |> Bindings.bind([{@escape, 0}], :tree_close, "Close file tree")
-    # Arrow left/right: collapse/expand (Finder-style)
-    |> Bindings.bind([{57_351, 0}], :tree_expand, "Expand directory")
-    |> Bindings.bind([{57_350, 0}], :tree_collapse, "Collapse directory")
-    |> Bindings.bind([{0xF703, 0}], :tree_expand, "Expand directory")
-    |> Bindings.bind([{0xF702, 0}], :tree_collapse, "Collapse directory")
+    build_trie(
+      groups: @cua_groups,
+      then: fn trie ->
+        trie
+        |> Bindings.bind([{@enter, 0}], :tree_open_or_toggle, "Open file / toggle directory")
+        |> Bindings.bind([{@escape, 0}], :tree_close, "Close file tree")
+        # Arrow left/right: collapse/expand (Finder-style)
+        |> Bindings.bind([{57_351, 0}], :tree_expand, "Expand directory")
+        |> Bindings.bind([{57_350, 0}], :tree_collapse, "Collapse directory")
+        |> Bindings.bind([{0xF703, 0}], :tree_expand, "Expand directory")
+        |> Bindings.bind([{0xF702, 0}], :tree_collapse, "Collapse directory")
+      end
+    )
   end
 end

--- a/lib/minga/keymap/scope/git_status.ex
+++ b/lib/minga/keymap/scope/git_status.ex
@@ -10,23 +10,26 @@ defmodule Minga.Keymap.Scope.GitStatus do
   to insert or visual are blocked.
   """
 
-  @behaviour Minga.Keymap.Scope
+  use Minga.Keymap.Scope.Builder,
+    name: :git_status,
+    display_name: "Git Status"
 
   alias Minga.Keymap.Bindings
 
   @enter 13
   @escape 27
   @tab 9
+  @ctrl 0x02
+  @cmd 0x08
 
-  # ── Behaviour callbacks ────────────────────────────────────────────────
+  # Groups included by this scope.
+  @cua_groups [:cua_navigation, :cua_cmd_chords]
 
   @impl true
-  @spec name() :: :git_status
-  def name, do: :git_status
+  @spec included_groups() :: [atom() | {atom(), keyword()}]
+  def included_groups, do: @cua_groups
 
-  @impl true
-  @spec display_name() :: String.t()
-  def display_name, do: "Git Status"
+  # ── Keymap ─────────────────────────────────────────────────────────────────
 
   @impl true
   @spec keymap(Minga.Keymap.Scope.vim_state(), Minga.Keymap.Scope.context()) ::
@@ -67,18 +70,6 @@ defmodule Minga.Keymap.Scope.GitStatus do
     ]
   end
 
-  @impl true
-  @spec included_groups() :: [atom() | {atom(), keyword()}]
-  def included_groups, do: [:cua_navigation, :cua_cmd_chords]
-
-  @impl true
-  @spec on_enter(term()) :: term()
-  def on_enter(state), do: state
-
-  @impl true
-  @spec on_exit(term()) :: term()
-  def on_exit(state), do: state
-
   # ── Normal mode bindings ───────────────────────────────────────────────
 
   @spec normal_trie() :: Bindings.node_t()
@@ -107,24 +98,24 @@ defmodule Minga.Keymap.Scope.GitStatus do
 
   # ── CUA mode bindings ─────────────────────────────────────────────────
 
-  alias Minga.Keymap.CUADefaults
-
-  @ctrl 0x02
-  @cmd 0x08
-
   @spec cua_trie() :: Bindings.node_t()
   defp cua_trie do
-    CUADefaults.navigation_trie()
-    # Git operations (same keys as normal, these are domain-specific not vim-specific)
-    |> Bindings.bind([{?s, 0}], :git_status_stage, "Stage file")
-    |> Bindings.bind([{?u, 0}], :git_status_unstage, "Unstage file")
-    |> Bindings.bind([{?d, 0}], :git_status_discard, "Discard changes")
-    |> Bindings.bind([{@tab, 0}], :git_status_toggle_section, "Toggle section collapse")
-    # Open/commit
-    |> Bindings.bind([{@enter, 0}], :git_status_open_file, "Open file")
-    |> Bindings.bind([{?c, @cmd}], :git_status_start_commit, "Start commit")
-    |> Bindings.bind([{?c, @ctrl}], :git_status_start_commit, "Start commit")
-    # Close
-    |> Bindings.bind([{@escape, 0}], :git_status_close, "Close git status")
+    build_trie(
+      groups: @cua_groups,
+      then: fn trie ->
+        trie
+        # Git operations (same keys as normal, domain-specific not vim-specific)
+        |> Bindings.bind([{?s, 0}], :git_status_stage, "Stage file")
+        |> Bindings.bind([{?u, 0}], :git_status_unstage, "Unstage file")
+        |> Bindings.bind([{?d, 0}], :git_status_discard, "Discard changes")
+        |> Bindings.bind([{@tab, 0}], :git_status_toggle_section, "Toggle section collapse")
+        # Open/commit
+        |> Bindings.bind([{@enter, 0}], :git_status_open_file, "Open file")
+        |> Bindings.bind([{?c, @cmd}], :git_status_start_commit, "Start commit")
+        |> Bindings.bind([{?c, @ctrl}], :git_status_start_commit, "Start commit")
+        # Close
+        |> Bindings.bind([{@escape, 0}], :git_status_close, "Close git status")
+      end
+    )
   end
 end

--- a/test/minga/keymap/scope/builder_test.exs
+++ b/test/minga/keymap/scope/builder_test.exs
@@ -1,0 +1,217 @@
+defmodule Minga.Keymap.Scope.BuilderTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Keymap.Bindings
+  alias Minga.Keymap.Scope.Builder
+
+  describe "build_trie/1" do
+    test "empty options returns empty trie" do
+      trie = Builder.build_trie([])
+      assert :not_found = Bindings.lookup(trie, {?j, 0})
+    end
+
+    test "merges a single group" do
+      trie = Builder.build_trie(groups: [:cua_navigation])
+
+      # Kitty protocol up arrow
+      assert {:command, :move_up} = Bindings.lookup(trie, {57_352, 0})
+      # macOS up arrow
+      assert {:command, :move_up} = Bindings.lookup(trie, {0xF700, 0})
+    end
+
+    test "merges multiple groups" do
+      trie = Builder.build_trie(groups: [:cua_navigation, :ctrl_agent_common])
+
+      # From cua_navigation
+      assert {:command, :move_up} = Bindings.lookup(trie, {57_352, 0})
+      # From ctrl_agent_common
+      assert {:command, :agent_ctrl_c} = Bindings.lookup(trie, {?c, 0x02})
+    end
+
+    test "global exclude removes commands from all groups" do
+      trie = Builder.build_trie(groups: [:cua_navigation], exclude: [:move_up])
+
+      # move_up excluded (both encodings)
+      assert :not_found = Bindings.lookup(trie, {57_352, 0})
+      assert :not_found = Bindings.lookup(trie, {0xF700, 0})
+      # move_down still present
+      assert {:command, :move_down} = Bindings.lookup(trie, {57_353, 0})
+    end
+
+    test "per-group exclude removes commands from that group only" do
+      trie =
+        Builder.build_trie(
+          groups: [
+            {:cua_navigation, exclude: [:half_page_up, :half_page_down]},
+            :ctrl_agent_common
+          ]
+        )
+
+      # half_page_up excluded from cua_navigation
+      assert :not_found = Bindings.lookup(trie, {57_352, 0x01})
+      # move_up still present
+      assert {:command, :move_up} = Bindings.lookup(trie, {57_352, 0})
+      # ctrl_agent_common unaffected
+      assert {:command, :agent_ctrl_c} = Bindings.lookup(trie, {?c, 0x02})
+    end
+
+    test "then function applies scope-specific bindings on top" do
+      trie =
+        Builder.build_trie(
+          groups: [:ctrl_agent_common],
+          then: fn t ->
+            t
+            |> Bindings.bind([{?q, 0}], :my_close, "Close")
+          end
+        )
+
+      # Group binding present
+      assert {:command, :agent_ctrl_c} = Bindings.lookup(trie, {?c, 0x02})
+      # Scope binding present
+      assert {:command, :my_close} = Bindings.lookup(trie, {?q, 0})
+    end
+
+    test "then function overrides group bindings on conflict" do
+      trie =
+        Builder.build_trie(
+          groups: [:ctrl_agent_common],
+          then: fn t ->
+            # Override Ctrl+C from group with a different command
+            Bindings.bind(t, [{?c, 0x02}], :my_abort, "My abort")
+          end
+        )
+
+      assert {:command, :my_abort} = Bindings.lookup(trie, {?c, 0x02})
+    end
+  end
+
+  describe "groups_to_trie/1" do
+    test "shorthand for build_trie with groups only" do
+      trie = Builder.groups_to_trie([:cua_navigation])
+      assert {:command, :move_up} = Bindings.lookup(trie, {57_352, 0})
+    end
+  end
+
+  describe "group_names_from/1" do
+    test "extracts names from mixed spec list" do
+      specs = [:cua_navigation, {:cua_cmd_chords, exclude: [:undo]}, :ctrl_agent_common]
+
+      assert [:cua_navigation, :cua_cmd_chords, :ctrl_agent_common] =
+               Builder.group_names_from(specs)
+    end
+
+    test "handles empty list" do
+      assert [] = Builder.group_names_from([])
+    end
+  end
+
+  describe "validate_groups!/1" do
+    test "returns :ok for known groups" do
+      assert :ok = Builder.validate_groups!([:cua_navigation, :ctrl_agent_common])
+    end
+
+    test "raises for unknown groups" do
+      assert_raise ArgumentError, ~r/unknown shared groups/, fn ->
+        Builder.validate_groups!([:cua_navigation, :nonexistent_group])
+      end
+    end
+  end
+
+  describe "Builder macro generates behaviour callbacks" do
+    # Define a test scope module using the Builder
+    defmodule TestScope do
+      use Minga.Keymap.Scope.Builder,
+        name: :test_scope,
+        display_name: "Test Scope"
+
+      alias Minga.Keymap.Bindings
+
+      @impl true
+      def keymap(:normal, _context) do
+        build_trie(
+          groups: [:cua_navigation],
+          then: fn trie ->
+            Bindings.bind(trie, [{?x, 0}], :test_action, "Test action")
+          end
+        )
+      end
+
+      def keymap(_state, _context), do: Bindings.new()
+
+      @impl true
+      def shared_keymap, do: Bindings.new()
+
+      @impl true
+      def help_groups(_focus), do: []
+
+      @impl true
+      def included_groups, do: [:cua_navigation]
+    end
+
+    test "name/0 returns configured name" do
+      assert :test_scope = TestScope.name()
+    end
+
+    test "display_name/0 returns configured display name" do
+      assert "Test Scope" = TestScope.display_name()
+    end
+
+    test "on_enter/1 passes state through" do
+      assert :my_state = TestScope.on_enter(:my_state)
+    end
+
+    test "on_exit/1 passes state through" do
+      assert :my_state = TestScope.on_exit(:my_state)
+    end
+
+    test "keymap/2 returns trie with group + scope bindings" do
+      trie = TestScope.keymap(:normal, [])
+
+      # From group
+      assert {:command, :move_up} = Bindings.lookup(trie, {57_352, 0})
+      # Scope-specific
+      assert {:command, :test_action} = Bindings.lookup(trie, {?x, 0})
+    end
+
+    test "keymap/2 returns empty trie for unconfigured vim states" do
+      trie = TestScope.keymap(:insert, [])
+      assert :not_found = Bindings.lookup(trie, {?x, 0})
+    end
+  end
+
+  describe "Builder with overridable on_enter/on_exit" do
+    defmodule CustomLifecycleScope do
+      use Minga.Keymap.Scope.Builder,
+        name: :custom,
+        display_name: "Custom"
+
+      alias Minga.Keymap.Bindings
+
+      @impl true
+      def on_enter(state), do: Map.put(state, :entered, true)
+
+      @impl true
+      def on_exit(state), do: Map.put(state, :exited, true)
+
+      @impl true
+      def keymap(_state, _context), do: Bindings.new()
+
+      @impl true
+      def shared_keymap, do: Bindings.new()
+
+      @impl true
+      def help_groups(_focus), do: []
+
+      @impl true
+      def included_groups, do: []
+    end
+
+    test "custom on_enter/1 is used" do
+      assert %{entered: true} = CustomLifecycleScope.on_enter(%{})
+    end
+
+    test "custom on_exit/1 is used" do
+      assert %{exited: true} = CustomLifecycleScope.on_exit(%{})
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `Minga.Keymap.Scope.Builder`, a macro that reduces boilerplate in keymap scope modules and makes shared group inclusion declarative.

## Why

Scope modules had ~30 lines of repeated callback boilerplate (name/0, display_name/0, on_enter/1, on_exit/1) and manually chained `merge_group` calls. The Builder consolidates this into a `use` macro + `build_trie/1` helper that merges groups first, then applies scope-specific bindings on top.

## Changes

- **New:** `lib/minga/keymap/scope/builder.ex` with `__using__/1` macro, `build_trie/1`, `groups_to_trie/1`, `validate_groups!/1`
- **Refactored:** All 4 scope modules (Editor, Agent, FileTree, GitStatus) to use the Builder
- **Tests:** 20 new tests covering group merging, exclusions, macro-generated callbacks, and overridable lifecycle hooks

## Behavioral changes

None. All 6959 existing tests pass unchanged.

Closes #1278