### PR TITLE
refactor(mode): fix Layer 0 violations in VisualLine and Mode FSMs

### DIFF
--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -57,6 +57,7 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     "Minga.Editing.Model",
     "Minga.Core",
     "Minga.Mode",
+    "Minga.Command.Parser",
     "Minga.Keymap.Bindings",
     "Minga.Keymap.NormalPrefixes"
   ]

--- a/lib/minga/core/wrap_map.ex
+++ b/lib/minga/core/wrap_map.ex
@@ -1,4 +1,4 @@
-defmodule Minga.Editor.WrapMap do
+defmodule Minga.Core.WrapMap do
   @moduledoc """
   Computes visual line breaks for soft word-wrapping.
 

--- a/lib/minga/editing/motion/visual_line.ex
+++ b/lib/minga/editing/motion/visual_line.ex
@@ -13,7 +13,7 @@ defmodule Minga.Editing.Motion.VisualLine do
 
   alias Minga.Buffer.Document
   alias Minga.Core.Unicode
-  alias Minga.Editor.WrapMap
+  alias Minga.Core.WrapMap
 
   @type position :: Document.position()
 

--- a/lib/minga/editor/key_dispatch.ex
+++ b/lib/minga/editor/key_dispatch.ex
@@ -21,6 +21,7 @@ defmodule Minga.Editor.KeyDispatch do
   alias Minga.Editor.ModeTransitions
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.AgentAccess
+  alias Minga.Keymap
   alias Minga.Mode
 
   @doc """
@@ -40,7 +41,8 @@ defmodule Minga.Editor.KeyDispatch do
     # This proves the EditingModel abstraction under real load. When CUA
     # (#306) arrives, this call site dispatches through the active editing
     # model instead of hardcoding Vim.
-    vim_state = VimModel.from_editor(old_mode, Editing.mode_state(state))
+    mode_state = populate_mode_tries(Editing.mode_state(state), old_mode, state)
+    vim_state = VimModel.from_editor(old_mode, mode_state)
     {new_mode, commands, new_vim_state} = VimModel.process_key(vim_state, key)
     {_, new_mode_state} = VimModel.to_editor(new_vim_state)
 
@@ -218,5 +220,67 @@ defmodule Minga.Editor.KeyDispatch do
     Buffer.filetype(buf)
   catch
     :exit, _ -> :text
+  end
+
+  # ── Mode trie population ──────────────────────────────────────────────────
+  # Populates leader_trie, normal_bindings, and mode_trie on the mode state
+  # so Mode FSM modules (Layer 0) never need to call the Keymap GenServer
+  # (Layer 1) directly.
+
+  @spec populate_mode_tries(Mode.state(), Mode.mode(), EditorState.t()) :: Mode.state()
+  defp populate_mode_tries(%Minga.Mode.State{} = mode_state, mode, state) do
+    %{
+      mode_state
+      | leader_trie: fetch_leader_trie(),
+        normal_bindings: fetch_normal_bindings(),
+        mode_trie: fetch_mode_trie(mode, active_filetype(state))
+    }
+  end
+
+  defp populate_mode_tries(%{mode_trie: _} = mode_state, mode, state) do
+    %{mode_state | mode_trie: fetch_mode_trie(mode, active_filetype(state))}
+  end
+
+  defp populate_mode_tries(mode_state, _mode, _state), do: mode_state
+
+  @spec fetch_leader_trie() :: Minga.Keymap.Bindings.node_t()
+  defp fetch_leader_trie do
+    Keymap.leader_trie()
+  catch
+    :exit, _ -> Keymap.default_leader_trie()
+  end
+
+  @spec fetch_normal_bindings() :: %{Minga.Keymap.Bindings.key() => {atom(), String.t()}}
+  defp fetch_normal_bindings do
+    Keymap.normal_bindings()
+  catch
+    :exit, _ -> Keymap.default_normal_bindings()
+  end
+
+  @spec fetch_mode_trie(Mode.mode(), atom()) :: Minga.Keymap.Bindings.node_t() | nil
+  defp fetch_mode_trie(mode, filetype) when mode in [:insert, :visual] do
+    global = Keymap.mode_trie(mode)
+    ft = Keymap.Active.filetype_mode_trie(filetype, mode)
+    merge_tries(global, ft)
+  catch
+    :exit, _ -> nil
+  end
+
+  defp fetch_mode_trie(_mode, _filetype), do: nil
+
+  # Merges filetype-specific bindings on top of global mode bindings.
+  # Filetype bindings override global ones on conflict (same key).
+  @spec merge_tries(Minga.Keymap.Bindings.node_t(), Minga.Keymap.Bindings.node_t()) ::
+          Minga.Keymap.Bindings.node_t()
+  defp merge_tries(base, %{children: ft_children}) when map_size(ft_children) == 0, do: base
+
+  defp merge_tries(base, %{children: ft_children}) do
+    Enum.reduce(ft_children, base, fn {key, %{command: cmd, description: desc}}, acc ->
+      if cmd do
+        Minga.Keymap.Bindings.bind(acc, [key], cmd, desc || "")
+      else
+        acc
+      end
+    end)
   end
 end

--- a/lib/minga/editor/render_pipeline/content_helpers.ex
+++ b/lib/minga/editor/render_pipeline/content_helpers.ex
@@ -25,7 +25,7 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   alias Minga.Editor.Renderer.SearchHighlight
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.Window
-  alias Minga.Editor.WrapMap
+  alias Minga.Core.WrapMap
   alias Minga.Git
   alias Minga.LSP.SyncServer
   alias Minga.Mode.VisualState

--- a/lib/minga/editor/renderer/buffer_line.ex
+++ b/lib/minga/editor/renderer/buffer_line.ex
@@ -26,7 +26,7 @@ defmodule Minga.Editor.Renderer.BufferLine do
   alias Minga.Editor.Renderer.Context
   alias Minga.Editor.Renderer.Gutter
   alias Minga.Editor.Renderer.Line, as: LineRenderer
-  alias Minga.Editor.WrapMap
+  alias Minga.Core.WrapMap
   alias Minga.UI.Highlight
 
   @typedoc """

--- a/lib/minga/input/wrap.ex
+++ b/lib/minga/input/wrap.ex
@@ -17,7 +17,7 @@ defmodule Minga.Input.Wrap do
   All functions are pure; there is no state. Call them at render time
   with the current text and width.
 
-  ## Comparison with `Minga.Editor.WrapMap`
+  ## Comparison with `Minga.Core.WrapMap`
 
   `WrapMap` serves the main editor buffer and tracks byte offsets for
   syntax highlighting alignment. It also supports breakindent (preserving

--- a/lib/minga/keymap/bindings.ex
+++ b/lib/minga/keymap/bindings.ex
@@ -343,6 +343,50 @@ defmodule Minga.Keymap.Bindings do
     merge_bindings(trie, Minga.Keymap.SharedGroups.get(group_name), opts)
   end
 
+  # ── Key formatting ───────────────────────────────────────────────────────────
+
+  import Bitwise, only: [band: 2]
+
+  @doc """
+  Formats a single `t:key/0` tuple into a human-readable string.
+
+  ## Examples
+
+      iex> Minga.Keymap.Bindings.format_key({32, 0})
+      "SPC"
+
+      iex> Minga.Keymap.Bindings.format_key({?s, 0x02})
+      "C-s"
+
+      iex> Minga.Keymap.Bindings.format_key({?j, 0x00})
+      "j"
+  """
+  @spec format_key(key()) :: String.t()
+  def format_key({32, 0}), do: "SPC"
+  def format_key({9, _}), do: "TAB"
+  def format_key({13, _}), do: "RET"
+  def format_key({27, _}), do: "ESC"
+
+  def format_key({codepoint, modifiers}) do
+    char = <<codepoint::utf8>>
+    modifier_prefix(modifiers) <> char
+  end
+
+  @spec modifier_prefix(non_neg_integer()) :: String.t()
+  defp modifier_prefix(modifiers) do
+    ctrl = band(modifiers, 0x02) != 0
+    alt = band(modifiers, 0x04) != 0
+    modifier_string(ctrl, alt)
+  end
+
+  @spec modifier_string(boolean(), boolean()) :: String.t()
+  defp modifier_string(true, true), do: "C-M-"
+  defp modifier_string(true, false), do: "C-"
+  defp modifier_string(false, true), do: "M-"
+  defp modifier_string(false, false), do: ""
+
+  # ── Children / which-key display ───────────────────────────────────────────
+
   @doc """
   Returns the direct children of a trie node for which-key display.
 

--- a/lib/minga/mode/command.ex
+++ b/lib/minga/mode/command.ex
@@ -28,7 +28,7 @@ defmodule Minga.Mode.Command do
 
   @behaviour Minga.Mode
 
-  alias Minga.Command
+  alias Minga.Command.Parser, as: CommandParser
   alias Minga.Mode
   alias Minga.Mode.CommandState
 
@@ -53,7 +53,7 @@ defmodule Minga.Mode.Command do
 
   # Enter → parse the accumulated input and emit an :execute_ex_command
   def handle_key({@enter, _mods}, %CommandState{input: input} = state) do
-    parsed = Command.parse(input)
+    parsed = CommandParser.parse(input)
     {:execute_then_transition, [{:execute_ex_command, parsed}], :normal, %{state | input: ""}}
   end
 

--- a/lib/minga/mode/insert.ex
+++ b/lib/minga/mode/insert.ex
@@ -16,7 +16,7 @@ defmodule Minga.Mode.Insert do
 
   @behaviour Minga.Mode
 
-  alias Minga.Keymap
+  alias Minga.Keymap.Bindings
   alias Minga.Mode
 
   # Special codepoints
@@ -77,9 +77,7 @@ defmodule Minga.Mode.Insert do
   # Check user-defined insert-mode bindings before self-inserting printable
   # chars. This lets users bind Ctrl+key and other sequences in insert mode.
   def handle_key(key, state) do
-    filetype = Map.get(state, :filetype)
-
-    case check_user_override(:insert, filetype, key) do
+    case resolve_mode_binding(state, key) do
       {:command, command} ->
         {:execute, command, state}
 
@@ -104,10 +102,13 @@ defmodule Minga.Mode.Insert do
     {:continue, state}
   end
 
-  @spec check_user_override(atom(), atom() | nil, Mode.key()) :: {:command, atom()} | :not_found
-  defp check_user_override(mode, filetype, key) do
-    Keymap.resolve_binding(mode, filetype, key)
-  catch
-    :exit, _ -> :not_found
+  @spec resolve_mode_binding(map(), Mode.key()) :: {:command, atom()} | :not_found
+  defp resolve_mode_binding(%{mode_trie: trie}, key) when trie != nil do
+    case Bindings.lookup(trie, key) do
+      {:command, _} = result -> result
+      _ -> :not_found
+    end
   end
+
+  defp resolve_mode_binding(_state, _key), do: :not_found
 end

--- a/lib/minga/mode/normal.ex
+++ b/lib/minga/mode/normal.ex
@@ -63,11 +63,9 @@ defmodule Minga.Mode.Normal do
 
   import Bitwise
 
-  alias Minga.Keymap
   alias Minga.Keymap.Bindings
   alias Minga.Mode
   alias Minga.Mode.State, as: ModeState
-  alias Minga.UI.WhichKey
 
   # Special codepoints
   @escape 27
@@ -76,6 +74,9 @@ defmodule Minga.Mode.Normal do
   # Modifier flags (mirrors Minga.Frontend.Protocol)
   @ctrl 0x02
   @alt 0x04
+
+  # Normal-mode prefix trie (g, z, [, ]) — must be defined before handle_key
+  @prefix_trie Minga.Keymap.NormalPrefixes.trie()
 
   # Arrow key codepoints sent by libvaxis
   @arrow_up 57_352
@@ -107,9 +108,8 @@ defmodule Minga.Mode.Normal do
         {@space, 0},
         %ModeState{pending_describe_key: true, describe_key_leader_node: nil} = state
       ) do
-    trie = get_leader_trie()
-
-    {:continue, %{state | describe_key_leader_node: trie, describe_key_keys: ["SPC"]}}
+    {:continue,
+     %{state | describe_key_leader_node: state.leader_trie, describe_key_keys: ["SPC"]}}
   end
 
   # Key while walking leader trie in describe-key mode
@@ -118,7 +118,7 @@ defmodule Minga.Mode.Normal do
         %ModeState{pending_describe_key: true, describe_key_leader_node: node} = state
       )
       when is_map(node) do
-    formatted = WhichKey.format_key(key)
+    formatted = Bindings.format_key(key)
     keys_so_far = [formatted | state.describe_key_keys]
 
     case Bindings.lookup(node, key) do
@@ -153,9 +153,9 @@ defmodule Minga.Mode.Normal do
 
   # Any other key while in describe-key (not leader) → look up in normal bindings
   def handle_key(key, %ModeState{pending_describe_key: true} = state) do
-    formatted = WhichKey.format_key(key)
+    formatted = Bindings.format_key(key)
 
-    case Map.fetch(get_normal_bindings(), key) do
+    case Map.fetch(state.normal_bindings, key) do
       {:ok, {command, description}} ->
         {:execute, {:describe_key_result, formatted, command, description},
          %{
@@ -180,16 +180,14 @@ defmodule Minga.Mode.Normal do
 
   # SPC pressed while not in leader mode → start leader sequence.
   def handle_key({@space, 0}, %ModeState{leader_node: nil} = state) do
-    trie = get_leader_trie()
-    new_state = %{state | leader_node: trie, leader_keys: ["SPC"]}
-    {:execute, {:leader_start, trie}, new_state}
+    new_state = %{state | leader_node: state.leader_trie, leader_keys: ["SPC"]}
+    {:execute, {:leader_start, state.leader_trie}, new_state}
   end
 
   # SPC pressed while already in leader mode → cancel and restart.
   def handle_key({@space, 0}, %ModeState{leader_node: _node} = state) do
-    trie = get_leader_trie()
-    new_state = %{state | leader_node: trie, leader_keys: ["SPC"]}
-    {:execute, [:leader_cancel, {:leader_start, trie}], new_state}
+    new_state = %{state | leader_node: state.leader_trie, leader_keys: ["SPC"]}
+    {:execute, [:leader_cancel, {:leader_start, state.leader_trie}], new_state}
   end
 
   # Ctrl+D / Ctrl+U while in leader mode → paginate which-key popup.
@@ -210,7 +208,7 @@ defmodule Minga.Mode.Normal do
         {:execute, :leader_cancel, new_state}
 
       {:prefix, sub_node} ->
-        formatted = WhichKey.format_key(key)
+        formatted = Bindings.format_key(key)
         new_keys = [formatted | state.leader_keys]
         new_state = %{state | leader_node: sub_node, leader_keys: new_keys}
         {:execute, {:leader_progress, sub_node}, new_state}
@@ -318,11 +316,9 @@ defmodule Minga.Mode.Normal do
   # Trigger keys: start walking the prefix trie.
   def handle_key({key, 0}, %ModeState{prefix_node: nil} = state)
       when key in [?g, ?z, ?], ?[] do
-    trie = get_prefix_trie()
-
-    case Bindings.lookup(trie, {key, 0}) do
+    case Bindings.lookup(@prefix_trie, {key, 0}) do
       {:prefix, sub_node} ->
-        formatted = WhichKey.format_key({key, 0})
+        formatted = Bindings.format_key({key, 0})
         {:continue, %{state | prefix_node: sub_node, prefix_keys: [formatted]}}
 
       {:command, command} ->
@@ -337,7 +333,7 @@ defmodule Minga.Mode.Normal do
   def handle_key(key, %ModeState{prefix_node: node} = state) when is_map(node) do
     case Bindings.lookup(node, key) do
       {:prefix, sub_node} ->
-        formatted = WhichKey.format_key(key)
+        formatted = Bindings.format_key(key)
         new_keys = [formatted | state.prefix_keys]
         {:continue, %{state | prefix_node: sub_node, prefix_keys: new_keys}}
 
@@ -828,25 +824,6 @@ defmodule Minga.Mode.Normal do
   end
 
   # ── Private helpers ──────────────────────────────────────────────────────
-
-  @spec get_leader_trie() :: Bindings.node_t()
-  defp get_leader_trie do
-    Keymap.leader_trie()
-  catch
-    :exit, _ -> Keymap.default_leader_trie()
-  end
-
-  @spec get_normal_bindings() :: %{Bindings.key() => {atom(), String.t()}}
-  defp get_normal_bindings do
-    Keymap.normal_bindings()
-  catch
-    :exit, _ -> Keymap.default_normal_bindings()
-  end
-
-  @prefix_trie Minga.Keymap.NormalPrefixes.trie()
-
-  @spec get_prefix_trie() :: Bindings.node_t()
-  defp get_prefix_trie, do: @prefix_trie
 
   # Dispatches a command from the prefix trie. Most commands are simple
   # :execute results. A few need special handling (mode transitions).

--- a/lib/minga/mode/state.ex
+++ b/lib/minga/mode/state.ex
@@ -12,6 +12,9 @@ defmodule Minga.Mode.State do
 
   defstruct filetype: :text,
             count: nil,
+            leader_trie: nil,
+            normal_bindings: %{},
+            mode_trie: nil,
             leader_node: nil,
             leader_keys: [],
             prefix_node: nil,
@@ -32,9 +35,15 @@ defmodule Minga.Mode.State do
   @typedoc "Pending mark operation kind."
   @type pending_mark_kind :: :set | :jump_line | :jump_exact
 
+  @typedoc "Single-key normal bindings map: key => {command, description}."
+  @type normal_bindings_map :: %{Bindings.key() => {atom(), String.t()}}
+
   @type t :: %__MODULE__{
           filetype: atom(),
           count: non_neg_integer() | nil,
+          leader_trie: Bindings.node_t() | nil,
+          normal_bindings: normal_bindings_map(),
+          mode_trie: Bindings.node_t() | nil,
           leader_node: Bindings.node_t() | nil,
           leader_keys: [String.t()],
           prefix_node: Bindings.node_t() | nil,

--- a/lib/minga/mode/visual.ex
+++ b/lib/minga/mode/visual.ex
@@ -52,7 +52,7 @@ defmodule Minga.Mode.Visual do
 
   import Bitwise
 
-  alias Minga.Keymap
+  alias Minga.Keymap.Bindings
   alias Minga.Mode
   alias Minga.Mode.VisualState
 
@@ -366,9 +366,7 @@ defmodule Minga.Mode.Visual do
   # ── User-defined visual-mode overrides ──────────────────────────────────
   # Before giving up, check user-defined visual-mode bindings.
   def handle_key(key, state) do
-    filetype = Map.get(state, :filetype)
-
-    case check_user_override(:visual, filetype, key) do
+    case resolve_mode_binding(state, key) do
       {:command, command} ->
         {:execute, command, state}
 
@@ -377,10 +375,13 @@ defmodule Minga.Mode.Visual do
     end
   end
 
-  @spec check_user_override(atom(), atom() | nil, Mode.key()) :: {:command, atom()} | :not_found
-  defp check_user_override(mode, filetype, key) do
-    Keymap.resolve_binding(mode, filetype, key)
-  catch
-    :exit, _ -> :not_found
+  @spec resolve_mode_binding(map(), Mode.key()) :: {:command, atom()} | :not_found
+  defp resolve_mode_binding(%{mode_trie: trie}, key) when trie != nil do
+    case Bindings.lookup(trie, key) do
+      {:command, _} = result -> result
+      _ -> :not_found
+    end
   end
+
+  defp resolve_mode_binding(_state, _key), do: :not_found
 end

--- a/lib/minga/mode/visual_state.ex
+++ b/lib/minga/mode/visual_state.ex
@@ -11,6 +11,7 @@ defmodule Minga.Mode.VisualState do
             visual_type: :char,
             visual_anchor: {0, 0},
             count: nil,
+            mode_trie: nil,
             leader_node: nil,
             leader_keys: [],
             text_object_modifier: nil
@@ -26,6 +27,7 @@ defmodule Minga.Mode.VisualState do
           visual_type: selection_type(),
           visual_anchor: {non_neg_integer(), non_neg_integer()},
           count: non_neg_integer() | nil,
+          mode_trie: Minga.Keymap.Bindings.node_t() | nil,
           leader_node: Minga.Keymap.Bindings.node_t() | nil,
           leader_keys: [String.t()],
           text_object_modifier: text_object_modifier()

--- a/lib/minga/ui/which_key.ex
+++ b/lib/minga/ui/which_key.ex
@@ -25,8 +25,6 @@ defmodule Minga.UI.WhichKey do
   | `{?j, 0x00}`            | `"j"`   |
   """
 
-  import Bitwise
-
   alias Minga.Keymap.Bindings
   alias Minga.UI.WhichKey.Icons
 
@@ -123,15 +121,7 @@ defmodule Minga.UI.WhichKey do
       "j"
   """
   @spec format_key(Bindings.key()) :: String.t()
-  def format_key({32, 0}), do: "SPC"
-  def format_key({9, _}), do: "TAB"
-  def format_key({13, _}), do: "RET"
-  def format_key({27, _}), do: "ESC"
-
-  def format_key({codepoint, modifiers}) do
-    char = <<codepoint::utf8>>
-    modifier_prefix(modifiers) <> char
-  end
+  defdelegate format_key(key), to: Bindings
 
   # ── Binding display ───────────────────────────────────────────────────────────
 
@@ -173,19 +163,6 @@ defmodule Minga.UI.WhichKey do
   end
 
   # ── Private ───────────────────────────────────────────────────────────────────
-
-  @spec modifier_prefix(non_neg_integer()) :: String.t()
-  defp modifier_prefix(modifiers) do
-    ctrl = band(modifiers, 0x02) != 0
-    alt = band(modifiers, 0x04) != 0
-    modifier_string(ctrl, alt)
-  end
-
-  @spec modifier_string(boolean(), boolean()) :: String.t()
-  defp modifier_string(true, true), do: "C-M-"
-  defp modifier_string(true, false), do: "C-"
-  defp modifier_string(false, true), do: "M-"
-  defp modifier_string(false, false), do: ""
 
   @spec format_label(String.t() | atom()) :: String.t()
   defp format_label(label) when is_binary(label), do: label

--- a/test/minga/core/wrap_map_test.exs
+++ b/test/minga/core/wrap_map_test.exs
@@ -1,7 +1,7 @@
-defmodule Minga.Editor.WrapMapTest do
+defmodule Minga.Core.WrapMapTest do
   use ExUnit.Case, async: true
 
-  alias Minga.Editor.WrapMap
+  alias Minga.Core.WrapMap
 
   describe "compute/3 with no wrapping needed" do
     test "short line produces a single visual row" do

--- a/test/minga/mode/insert_test.exs
+++ b/test/minga/mode/insert_test.exs
@@ -98,10 +98,25 @@ defmodule Minga.Mode.Insert.UserOverrideTest do
   use ExUnit.Case, async: false
 
   alias Minga.Keymap.Active, as: KeymapActive
+  alias Minga.Keymap.Bindings
   alias Minga.Mode
   alias Minga.Mode.Insert
 
   defp fresh_state, do: Mode.initial_state()
+
+  # Builds a mode_trie by merging filetype bindings on top of global insert bindings.
+  defp state_with_trie(filetype \\ :text) do
+    global = KeymapActive.mode_trie(:insert)
+
+    ft_trie = KeymapActive.filetype_mode_trie(filetype, :insert)
+
+    mode_trie =
+      Enum.reduce(ft_trie.children, global, fn {key, %{command: cmd, description: desc}}, acc ->
+        if cmd, do: Bindings.bind(acc, [key], cmd, desc || ""), else: acc
+      end)
+
+    %{fresh_state() | filetype: filetype, mode_trie: mode_trie}
+  end
 
   setup do
     case KeymapActive.start_link() do
@@ -124,31 +139,32 @@ defmodule Minga.Mode.Insert.UserOverrideTest do
     test "Ctrl+J bound to :next_line overrides default (continue)" do
       KeymapActive.bind(:insert, "C-j", :next_line, "Next line")
 
-      assert {:execute, :next_line, _} = Insert.handle_key({?j, 0x02}, fresh_state())
+      assert {:execute, :next_line, _} = Insert.handle_key({?j, 0x02}, state_with_trie())
     end
 
     test "Ctrl+K bound to :prev_line overrides default (continue)" do
       KeymapActive.bind(:insert, "C-k", :prev_line, "Prev line")
 
-      assert {:execute, :prev_line, _} = Insert.handle_key({?k, 0x02}, fresh_state())
+      assert {:execute, :prev_line, _} = Insert.handle_key({?k, 0x02}, state_with_trie())
     end
 
     test "unbound key falls through to default handling" do
       # Ctrl+C is not bound, should be :continue
-      assert {:continue, _} = Insert.handle_key({?c, 0x02}, fresh_state())
+      assert {:continue, _} = Insert.handle_key({?c, 0x02}, state_with_trie())
     end
 
     test "built-in keys still work when user overrides exist" do
       KeymapActive.bind(:insert, "C-j", :next_line, "Next line")
+      state = state_with_trie()
 
       # Escape should still transition to normal
-      assert {:transition, :normal, _} = Insert.handle_key({27, 0}, fresh_state())
+      assert {:transition, :normal, _} = Insert.handle_key({27, 0}, state)
 
       # Backspace should still delete
-      assert {:execute, :delete_before, _} = Insert.handle_key({127, 0}, fresh_state())
+      assert {:execute, :delete_before, _} = Insert.handle_key({127, 0}, state)
 
       # Printable chars should still insert
-      assert {:execute, {:insert_char, "a"}, _} = Insert.handle_key({?a, 0}, fresh_state())
+      assert {:execute, {:insert_char, "a"}, _} = Insert.handle_key({?a, 0}, state)
     end
   end
 
@@ -156,33 +172,27 @@ defmodule Minga.Mode.Insert.UserOverrideTest do
     test "filetype binding fires when filetype matches" do
       KeymapActive.bind(:insert, "C-j", :org_special, "Org special", filetype: :org)
 
-      state = %{fresh_state() | filetype: :org}
-      assert {:execute, :org_special, _} = Insert.handle_key({?j, 0x02}, state)
+      assert {:execute, :org_special, _} = Insert.handle_key({?j, 0x02}, state_with_trie(:org))
     end
 
     test "filetype binding does not fire for different filetype" do
       KeymapActive.bind(:insert, "C-j", :org_special, "Org special", filetype: :org)
 
-      state = %{fresh_state() | filetype: :elixir}
-      assert {:continue, _} = Insert.handle_key({?j, 0x02}, state)
+      assert {:continue, _} = Insert.handle_key({?j, 0x02}, state_with_trie(:elixir))
     end
 
     test "filetype binding shadows global binding for same key" do
       KeymapActive.bind(:insert, "C-j", :global_next, "Global next")
       KeymapActive.bind(:insert, "C-j", :org_special, "Org special", filetype: :org)
 
-      org_state = %{fresh_state() | filetype: :org}
-      assert {:execute, :org_special, _} = Insert.handle_key({?j, 0x02}, org_state)
-
-      elixir_state = %{fresh_state() | filetype: :elixir}
-      assert {:execute, :global_next, _} = Insert.handle_key({?j, 0x02}, elixir_state)
+      assert {:execute, :org_special, _} = Insert.handle_key({?j, 0x02}, state_with_trie(:org))
+      assert {:execute, :global_next, _} = Insert.handle_key({?j, 0x02}, state_with_trie(:elixir))
     end
 
     test "global binding fires when no filetype binding exists" do
       KeymapActive.bind(:insert, "C-k", :global_prev, "Global prev")
 
-      state = %{fresh_state() | filetype: :org}
-      assert {:execute, :global_prev, _} = Insert.handle_key({?k, 0x02}, state)
+      assert {:execute, :global_prev, _} = Insert.handle_key({?k, 0x02}, state_with_trie(:org))
     end
   end
 end

--- a/test/minga/mode/normal_test.exs
+++ b/test/minga/mode/normal_test.exs
@@ -6,7 +6,15 @@ defmodule Minga.Mode.NormalTest do
   alias Minga.Mode.Normal
 
   # Shorthand: call Normal.handle_key directly with a fresh state.
-  defp fresh_state, do: Mode.initial_state()
+  # Populates leader_trie and normal_bindings so the FSM can resolve
+  # leader sequences and normal bindings without calling the Keymap GenServer.
+  defp fresh_state do
+    %{
+      Mode.initial_state()
+      | leader_trie: Defaults.leader_trie(),
+        normal_bindings: Defaults.normal_bindings()
+    }
+  end
 
   describe "mode transitions" do
     test "i produces {:transition, :insert, state}" do

--- a/test/minga/mode/visual_user_override_test.exs
+++ b/test/minga/mode/visual_user_override_test.exs
@@ -10,6 +10,12 @@ defmodule Minga.Mode.Visual.UserOverrideTest do
     %VisualState{visual_anchor: anchor, visual_type: type}
   end
 
+  defp visual_state_with_trie(anchor \\ {0, 0}, type \\ :char) do
+    global = KeymapActive.mode_trie(:visual)
+
+    %VisualState{visual_anchor: anchor, visual_type: type, mode_trie: global}
+  end
+
   setup do
     # KeymapActive is a global singleton; start_supervised! won't work until
     # it accepts a name: param. See autoresearch.md for the planned refactor.
@@ -33,7 +39,7 @@ defmodule Minga.Mode.Visual.UserOverrideTest do
     test "Ctrl+X bound to :custom_cut executes the command" do
       KeymapActive.bind(:visual, "C-x", :custom_cut, "Custom cut")
 
-      state = visual_state()
+      state = visual_state_with_trie()
       assert {:execute, :custom_cut, _} = Visual.handle_key({?x, 0x02}, state)
     end
 


### PR DESCRIPTION
## What

Fixes two Layer 0 dependency violations that the credo `DependencyDirectionCheck` flagged.

### #1218: VisualLine → WrapMap

`Editing.Motion.VisualLine` (Layer 0) was importing `Editor.WrapMap` (Layer 2). Since `WrapMap` is entirely pure (only depends on `Core.Unicode`), the fix is to relocate it to `Core.WrapMap` where it belongs. All 6 call sites updated, no re-alias shim needed.

### #1219: Mode FSMs → Keymap, WhichKey, Command

Four distinct violations across the Mode modules:

1. **`WhichKey.format_key/1`** moved to `Keymap.Bindings` (already Layer 0). `WhichKey` now delegates to it.

2. **`Keymap.leader_trie()` and `Keymap.normal_bindings()`** in Normal mode replaced with state fields. New fields `leader_trie`, `normal_bindings`, and `mode_trie` on `Mode.State` are populated by `KeyDispatch` (Layer 2) before calling `Mode.process/3`. The exit-catch fallbacks live at the Layer 2 call site, not inside the FSM.

3. **`Keymap.resolve_binding/3`** in Insert and Visual modes replaced with `Bindings.lookup(state.mode_trie, key)`. `KeyDispatch` builds a merged trie (filetype bindings on top of global mode bindings) so the mode module does a single pure trie lookup.

4. **`Command.parse/1`** in Command mode now calls `Command.Parser.parse/1` directly (pure module, added to credo Layer 0 prefixes).

## Testing

All existing tests pass. Mode tests updated to populate trie fields on state, matching how the Editor does it in production. No new test files needed since existing coverage already exercises the affected code paths.

## Verification

- `make lint` passes (format + credo + compile + dialyzer)
- `mix test.llm` passes (0 failures across 6941 tests)
- Credo `DependencyDirectionCheck` reports zero violations for all touched files

Closes #1218
Closes #1219