### PR TITLE
feat(macos): add animated status badges to Board cards

### DIFF
--- a/lib/minga/ui/theme/slots.ex
+++ b/lib/minga/ui/theme/slots.ex
@@ -16,7 +16,8 @@ defmodule Minga.UI.Theme.Slots do
   | 0x20-0x29 | Popups + Breadcrumb |
   | 0x30-0x3A | Modeline + Status bar |
   | 0x40      | Accent        |
-  | 0x50-0x58 | Gutter + Git  |
+  | 0x50-0x5B | Gutter + Git + Highlights |
+  | 0x5C-0x61 | Agent status  |
   """
 
   # ── Editor + Tree ──
@@ -86,6 +87,14 @@ defmodule Minga.UI.Theme.Slots do
   @highlight_read_bg 0x59
   @highlight_write_bg 0x5A
   @selection_bg 0x5B
+
+  # ── Agent status (shared across Board cards, tab badges, chat header) ──
+  @agent_status_idle 0x5C
+  @agent_status_working 0x5D
+  @agent_status_iterating 0x5E
+  @agent_status_needs_you 0x5F
+  @agent_status_done 0x60
+  @agent_status_errored 0x61
 
   # ── Accent ──
   @accent 0x40
@@ -168,6 +177,18 @@ defmodule Minga.UI.Theme.Slots do
       {@highlight_read_bg, e.highlight_read_bg || 0x3A3F4B},
       {@highlight_write_bg, e.highlight_write_bg || 0x4A3F2B},
       {@selection_bg, e.selection_bg || 0x264F78}
+    ] ++ agent_status_pairs(theme, tb)
+  end
+
+  @spec agent_status_pairs(Minga.UI.Theme.t(), Minga.UI.Theme.TabBar.t() | nil) :: [color_pair()]
+  defp agent_status_pairs(theme, tb) do
+    [
+      {@agent_status_idle, theme.gutter.fg},
+      {@agent_status_working, theme.git.added_fg},
+      {@agent_status_iterating, theme.git.added_fg},
+      {@agent_status_needs_you, tb && tb.modified_fg},
+      {@agent_status_done, theme.tree.active_fg},
+      {@agent_status_errored, theme.gutter.error_fg}
     ]
   end
 

--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -140,6 +140,14 @@ let GUI_COLOR_HIGHLIGHT_READ_BG: UInt8 = 0x59
 let GUI_COLOR_HIGHLIGHT_WRITE_BG: UInt8 = 0x5A
 let GUI_COLOR_SELECTION_BG: UInt8 = 0x5B
 
+// Agent status color slots (shared across Board cards, tab bar badges, chat header, etc.)
+let GUI_COLOR_AGENT_STATUS_IDLE: UInt8 = 0x5C
+let GUI_COLOR_AGENT_STATUS_WORKING: UInt8 = 0x5D
+let GUI_COLOR_AGENT_STATUS_ITERATING: UInt8 = 0x5E
+let GUI_COLOR_AGENT_STATUS_NEEDS_YOU: UInt8 = 0x5F
+let GUI_COLOR_AGENT_STATUS_DONE: UInt8 = 0x60
+let GUI_COLOR_AGENT_STATUS_ERRORED: UInt8 = 0x61
+
 // MARK: - Config opcodes (BEAM → frontend)
 
 let OP_SET_FONT: UInt8 = 0x50

--- a/macos/Sources/Views/Board/BoardView.swift
+++ b/macos/Sources/Views/Board/BoardView.swift
@@ -307,7 +307,16 @@ struct BoardCardView: View {
 
     // MARK: - Status Badge
 
+    /// Drives the working-state pulse animation (opacity 0.6 ↔ 1.0).
     @State private var isPulsing = false
+
+    /// Drives the one-shot glow for the "needs you" state.
+    @State private var showGlow = false
+
+    /// Whether to skip animations for accessibility.
+    private var reduceMotion: Bool {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    }
 
     private var statusBadge: some View {
         HStack(spacing: 4) {
@@ -317,16 +326,35 @@ struct BoardCardView: View {
                     .foregroundStyle(.secondary)
             } else {
                 Circle()
-                    .fill(statusColor)
+                    .fill(badgeColor)
                     .frame(width: 8, height: 8)
-                    .opacity(isPulsing && card.status == .working ? 0.4 : 1.0)
-                    .animation(
-                        card.status == .working
-                            ? .easeInOut(duration: 0.8).repeatForever(autoreverses: true)
-                            : .default,
-                        value: isPulsing
+                    .opacity(badgeOpacity)
+                    .shadow(
+                        color: card.status == .needsYou && showGlow
+                            ? badgeColor.opacity(0.6) : .clear,
+                        radius: card.status == .needsYou && showGlow ? 6 : 0
                     )
-                    .onAppear { isPulsing = true }
+                    .animation(pulseAnimation, value: isPulsing)
+                    .onAppear {
+                        guard !reduceMotion else { return }
+                        isPulsing = true
+                        if card.status == .needsYou {
+                            withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
+                                showGlow = true
+                            }
+                        }
+                    }
+                    .onChange(of: card.status) { _, newStatus in
+                        guard !reduceMotion else { return }
+                        if newStatus == .needsYou {
+                            showGlow = false
+                            withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
+                                showGlow = true
+                            }
+                        } else {
+                            showGlow = false
+                        }
+                    }
             }
 
             Text(card.isYouCard ? "You" : card.status.label)
@@ -335,10 +363,36 @@ struct BoardCardView: View {
         }
     }
 
-    private var statusColor: Color {
-        let c = card.status.color
-        return Color(red: c.r, green: c.g, blue: c.b)
+    /// Badge color from theme, mapped by card status.
+    private var badgeColor: Color {
+        switch card.status {
+        case .idle: theme.agentStatusIdle
+        case .working: theme.agentStatusWorking
+        case .iterating: theme.agentStatusIterating
+        case .needsYou: theme.agentStatusNeedsYou
+        case .done: theme.agentStatusDone
+        case .errored: theme.agentStatusErrored
+        }
     }
+
+    /// Badge opacity: pulsing for "working", solid for everything else.
+    /// When reduced motion is on, always returns 1.0 (static badge).
+    private var badgeOpacity: Double {
+        if !reduceMotion && card.status == .working && isPulsing {
+            return 0.6
+        }
+        return 1.0
+    }
+
+    /// Animation for the pulse effect: only active for "working" status.
+    /// Returns nil when reduced motion is on (static badge).
+    private var pulseAnimation: Animation? {
+        guard !reduceMotion, card.status == .working else { return .default }
+        return .easeInOut(duration: 1.0).repeatForever(autoreverses: true)
+    }
+
+    /// Status color used by non-badge elements (sparkline).
+    private var statusColor: Color { badgeColor }
 
     // MARK: - Background
 

--- a/macos/Sources/Views/ThemeColors.swift
+++ b/macos/Sources/Views/ThemeColors.swift
@@ -112,6 +112,14 @@ final class ThemeColors {
     var gitModifiedFgRGB: UInt32 = 0x51AFEF
     var gitDeletedFgRGB: UInt32 = 0xFF6C6B
 
+    // ── Agent status (shared across Board cards, tab badges, chat header) ──
+    var agentStatusIdle: Color = color(0x555555)
+    var agentStatusWorking: Color = color(0x98BE65)
+    var agentStatusIterating: Color = color(0x98BE65)
+    var agentStatusNeedsYou: Color = color(0xECBE7B)
+    var agentStatusDone: Color = color(0x51AFEF)
+    var agentStatusErrored: Color = color(0xFF6C6B)
+
     // ── Accent ──
     var accent: Color = color(0x51AFEF)
 
@@ -201,6 +209,12 @@ final class ThemeColors {
         case GUI_COLOR_SELECTION_BG:
             selectionBg = c
             selectionBgSIMD = rgbToSIMD3(rgb)
+        case GUI_COLOR_AGENT_STATUS_IDLE: agentStatusIdle = c
+        case GUI_COLOR_AGENT_STATUS_WORKING: agentStatusWorking = c
+        case GUI_COLOR_AGENT_STATUS_ITERATING: agentStatusIterating = c
+        case GUI_COLOR_AGENT_STATUS_NEEDS_YOU: agentStatusNeedsYou = c
+        case GUI_COLOR_AGENT_STATUS_DONE: agentStatusDone = c
+        case GUI_COLOR_AGENT_STATUS_ERRORED: agentStatusErrored = c
         default: break
         }
     }

--- a/macos/Tests/MingaTests/ThemeColorsTests.swift
+++ b/macos/Tests/MingaTests/ThemeColorsTests.swift
@@ -244,6 +244,26 @@ struct ThemeColorsSlotMappingTests {
     @Test("Slot 0x40 maps to accent")
     @MainActor func accent() { #expect(applySlot(GUI_COLOR_ACCENT).accent == expectedColor()) }
 
+    // MARK: - Agent status slots
+
+    @Test("Slot 0x5C maps to agentStatusIdle")
+    @MainActor func agentStatusIdle() { #expect(applySlot(GUI_COLOR_AGENT_STATUS_IDLE).agentStatusIdle == expectedColor()) }
+
+    @Test("Slot 0x5D maps to agentStatusWorking")
+    @MainActor func agentStatusWorking() { #expect(applySlot(GUI_COLOR_AGENT_STATUS_WORKING).agentStatusWorking == expectedColor()) }
+
+    @Test("Slot 0x5E maps to agentStatusIterating")
+    @MainActor func agentStatusIterating() { #expect(applySlot(GUI_COLOR_AGENT_STATUS_ITERATING).agentStatusIterating == expectedColor()) }
+
+    @Test("Slot 0x5F maps to agentStatusNeedsYou")
+    @MainActor func agentStatusNeedsYou() { #expect(applySlot(GUI_COLOR_AGENT_STATUS_NEEDS_YOU).agentStatusNeedsYou == expectedColor()) }
+
+    @Test("Slot 0x60 maps to agentStatusDone")
+    @MainActor func agentStatusDone() { #expect(applySlot(GUI_COLOR_AGENT_STATUS_DONE).agentStatusDone == expectedColor()) }
+
+    @Test("Slot 0x61 maps to agentStatusErrored")
+    @MainActor func agentStatusErrored() { #expect(applySlot(GUI_COLOR_AGENT_STATUS_ERRORED).agentStatusErrored == expectedColor()) }
+
     // MARK: - Batch application
 
     @Test("Multiple slots applied in one call all take effect")

--- a/test/minga/frontend/protocol_test.exs
+++ b/test/minga/frontend/protocol_test.exs
@@ -953,7 +953,7 @@ defmodule Minga.Frontend.ProtocolTest do
 
       # Should have a reasonable number of color slots
       assert count > 20
-      assert count < 60
+      assert count < 70
 
       # Each entry is 4 bytes (slot_id, r, g, b)
       assert byte_size(rest) == count * 4

--- a/test/minga/ui/theme/slots_test.exs
+++ b/test/minga/ui/theme/slots_test.exs
@@ -120,6 +120,28 @@ defmodule Minga.UI.Theme.SlotsTest do
       end
     end
 
+    test "agent status slots map to expected theme colors" do
+      theme = Minga.UI.Theme.get!(:doom_one)
+      pair_map = Map.new(Slots.to_color_pairs(theme))
+
+      assert pair_map[0x5C] == theme.gutter.fg
+      assert pair_map[0x5D] == theme.git.added_fg
+      assert pair_map[0x5E] == theme.git.added_fg
+      assert pair_map[0x5F] == theme.tab_bar.modified_fg
+      assert pair_map[0x60] == theme.tree.active_fg
+      assert pair_map[0x61] == theme.gutter.error_fg
+    end
+
+    test "agent status needs_you is nil when tab_bar is nil" do
+      theme = %{Minga.UI.Theme.get!(:doom_one) | tab_bar: nil}
+      pair_map = Map.new(Slots.to_color_pairs(theme))
+
+      assert is_nil(pair_map[0x5F])
+      # Other agent status slots should still have values
+      assert pair_map[0x5C] != nil
+      assert pair_map[0x5D] != nil
+    end
+
     test "all slot IDs are unique" do
       theme = Minga.UI.Theme.get!(:doom_one)
       pairs = Slots.to_color_pairs(theme)


### PR DESCRIPTION
# TL;DR
Board cards now display animated status badges that communicate agent state at a glance: pulsing green for working, solid green for iterating, amber glow for needs-you, red for errored, blue for done, dim gray for idle.

Closes #1232

## Context
The Board is a supervision dashboard. The status badge is the single most information-dense element on each card, and it needed proper visual hierarchy so your eye goes to amber cards first (need attention), then pulsing green (active work), and ignores blue/gray (done/idle). This PR replaces the placeholder badge implementation with the full animated version specified in the ticket.

## Changes
- **Pulse animation** for "working" state: `easeInOut(duration: 1.0).repeatForever(autoreverses: true)` on opacity 0.6-1.0. Slow breathing cycle draws attention to active cards without being distracting.
- **One-shot glow** for "needs you" state: spring animation that fades in a shadow glow once and holds. Not blinking (blinking badges are hostile). Replays when a card transitions into needs-you.
- **Solid vs pulsing** distinction: "iterating" gets the same green as "working" but at full opacity with no animation. This tells you the agent is productively busy (self-correcting against feedback), not stuck.
- **Reduced motion**: all animations check `NSWorkspace.shared.accessibilityDisplayShouldReduceMotion`. When enabled, every badge is a static filled circle at full opacity.
- **Theme-driven colors**: badge colors read from `ThemeColors.agentStatus*` properties instead of hardcoded RGB in `CardStatus.color`. These adapt to any theme automatically.
- **Semantic color slots** (0x5C-0x61): named `agent_status_*` rather than `board_badge_*` so the tab bar, chat header, and future surfaces can share the same status colors. BEAM side derives them from existing theme fields (git added green, tab modified amber, gutter error red, etc.).

## Verification
1. Open The Board (SPC b B or equivalent)
2. Dispatch an agent. Its card should show a pulsing green badge during generation
3. When the agent enters iterating (lint/test feedback loop), the badge should be solid green, no pulse
4. If an agent needs input, badge should be steady amber with a subtle glow on transition
5. Errored cards show solid red; done cards show muted blue; idle cards show dim gray
6. System Preferences > Accessibility > Display > Reduce motion: all badges become static circles
7. Switch themes: badge colors should follow the theme

## Acceptance Criteria Addressed
- BoardCardView displays a status badge with color and animation matching the state ✅
- Pulse animation for "working" uses easeInOut(duration: 1.0).repeatForever(autoreverses: true) on opacity (0.6 to 1.0) ✅
- "Needs you" amber badge has a one-shot fade-in glow (spring animation, not repeating) ✅
- "Iterating" green badge is visually distinct from "working" (solid vs pulsing) ✅
- All animations respect NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ✅
- Badge state is driven by BoardState from BEAM via guiBoard opcode (0x87) ✅
- Badge colors use theme colors from ThemeColors (not hardcoded hex values) ✅