### PR TITLE
feat(agent): wire ReadFile to check open buffers before disk (#393)

### DIFF
--- a/lib/minga/agent/tools/read_file.ex
+++ b/lib/minga/agent/tools/read_file.ex
@@ -2,6 +2,10 @@ defmodule Minga.Agent.Tools.ReadFile do
   @moduledoc """
   Reads the contents of a file and returns it as a string.
 
+  Routes through `Buffer.Server.content/1` when a buffer is open for the
+  file, returning the live in-memory content instead of stale disk content.
+  Falls back to `File.read/1` when no buffer exists.
+
   Handles missing files, permission errors, and binary files gracefully.
   Large files are truncated with a notice to prevent context window bloat.
 
@@ -10,6 +14,8 @@ defmodule Minga.Agent.Tools.ReadFile do
   is returned with a position header so the model knows where it is in the file.
   """
 
+  alias Minga.Buffer
+
   @max_bytes 256_000
 
   @typedoc "Options for partial file reads."
@@ -17,6 +23,11 @@ defmodule Minga.Agent.Tools.ReadFile do
 
   @doc """
   Reads the file at `path` and returns its content.
+
+  When a buffer is open for the file, returns the live in-memory content
+  (which may differ from disk if the buffer has unsaved changes). When no
+  buffer exists, reads from disk. Buffer content is always valid UTF-8, so
+  the binary file check is skipped for buffer reads.
 
   Files larger than #{div(@max_bytes, 1000)}KB are truncated. Binary (non-UTF-8)
   files are rejected with an error message.
@@ -31,11 +42,16 @@ defmodule Minga.Agent.Tools.ReadFile do
   """
   @spec execute(String.t(), read_opts()) :: {:ok, String.t()} | {:error, String.t()}
   def execute(path, opts \\ []) when is_binary(path) do
+    abs_path = Path.expand(path)
     offset = Keyword.get(opts, :offset)
     limit = Keyword.get(opts, :limit)
 
-    case File.read(path) do
-      {:ok, content} ->
+    case read_content(abs_path) do
+      {:ok, content, :buffer} ->
+        # Buffer content is always valid UTF-8, skip binary check
+        format_content(path, content, offset, limit)
+
+      {:ok, content, :disk} ->
         validate_and_read(path, content, offset, limit)
 
       {:error, :enoent} ->
@@ -47,6 +63,49 @@ defmodule Minga.Agent.Tools.ReadFile do
       {:error, reason} ->
         {:error, "failed to read #{path}: #{reason}"}
     end
+  end
+
+  # Tries the open buffer first, then falls back to disk.
+  # Does NOT open a buffer on demand (ReadFile should not pollute the buffer list).
+  @spec read_content(String.t()) ::
+          {:ok, String.t(), :buffer | :disk} | {:error, File.posix() | :eisdir}
+  defp read_content(abs_path) do
+    case Buffer.pid_for_path(abs_path) do
+      {:ok, pid} ->
+        content = Buffer.content(pid)
+        {:ok, content, :buffer}
+
+      :not_found ->
+        case File.read(abs_path) do
+          {:ok, content} -> {:ok, content, :disk}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  catch
+    # Buffer process died between pid_for_path and content call
+    :exit, _ ->
+      case File.read(abs_path) do
+        {:ok, content} -> {:ok, content, :disk}
+        {:error, reason} -> {:error, reason}
+      end
+  end
+
+  # Formats buffer-sourced content (always valid UTF-8, no binary check needed).
+  @spec format_content(String.t(), String.t(), pos_integer() | nil, pos_integer() | nil) ::
+          {:ok, String.t()}
+  defp format_content(_path, content, nil, nil) do
+    if byte_size(content) > @max_bytes do
+      truncated = binary_part(content, 0, @max_bytes)
+      {:ok, truncated <> "\n\n[truncated at #{div(@max_bytes, 1000)}KB]"}
+    else
+      {:ok, content}
+    end
+  end
+
+  defp format_content(_path, content, offset, limit) do
+    all_lines = String.split(content, "\n")
+    total_lines = length(all_lines)
+    read_partial(all_lines, total_lines, offset, limit)
   end
 
   @spec validate_and_read(String.t(), String.t(), pos_integer() | nil, pos_integer() | nil) ::

--- a/test/minga/agent/tools/read_file_test.exs
+++ b/test/minga/agent/tools/read_file_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Agent.Tools.ReadFileTest do
   use ExUnit.Case, async: true
 
   alias Minga.Agent.Tools.ReadFile
+  alias Minga.Buffer
 
   @moduletag :tmp_dir
 
@@ -109,6 +110,102 @@ defmodule Minga.Agent.Tools.ReadFileTest do
       assert result =~ "[lines 1-2 of 100]"
       assert result =~ "line 1"
       assert result =~ "line 2"
+    end
+  end
+
+  describe "buffer-first routing" do
+    test "returns in-memory buffer content instead of disk content", %{tmp_dir: dir} do
+      path = Path.join(dir, "buffered.txt")
+      File.write!(path, "disk content")
+
+      # Start a buffer for the file, which registers in the Buffer.Registry
+      {:ok, pid} = start_supervised({Buffer.Server, file_path: path})
+
+      # Modify the buffer in-memory without saving to disk
+      :ok = Buffer.Server.insert_text(pid, " MODIFIED")
+
+      # ReadFile should return the in-memory content, not the disk content
+      assert {:ok, result} = ReadFile.execute(path)
+      assert result =~ "MODIFIED"
+      refute result == "disk content"
+
+      # Disk should still have the original content
+      assert File.read!(path) == "disk content"
+    end
+
+    test "buffer routing works with offset and limit", %{tmp_dir: dir} do
+      path = Path.join(dir, "buffered_lines.txt")
+      disk_lines = Enum.map_join(1..10, "\n", &"disk line #{&1}")
+      File.write!(path, disk_lines)
+
+      {:ok, pid} = start_supervised({Buffer.Server, file_path: path})
+
+      # Replace content in buffer with different lines
+      :ok = Buffer.Server.replace_content(pid, Enum.map_join(1..10, "\n", &"buffer line #{&1}"))
+
+      assert {:ok, result} = ReadFile.execute(path, offset: 3, limit: 2)
+      assert result =~ "[lines 3-4 of 10]"
+      assert result =~ "buffer line 3"
+      assert result =~ "buffer line 4"
+      refute result =~ "disk line"
+    end
+
+    test "falls back to disk when no buffer is open", %{tmp_dir: dir} do
+      path = Path.join(dir, "no_buffer.txt")
+      File.write!(path, "disk only content")
+
+      # No buffer started, should read from disk
+      assert {:ok, "disk only content"} = ReadFile.execute(path)
+    end
+
+    test "truncates large buffer content", %{tmp_dir: dir} do
+      path = Path.join(dir, "large_buffer.txt")
+      File.write!(path, "small")
+
+      {:ok, pid} = start_supervised({Buffer.Server, file_path: path})
+
+      # Replace with large content in buffer
+      large_content = String.duplicate("x", 300_000)
+      :ok = Buffer.Server.replace_content(pid, large_content)
+
+      assert {:ok, result} = ReadFile.execute(path)
+      assert result =~ "[truncated at 256KB]"
+    end
+
+    test "works with expanded paths", %{tmp_dir: dir} do
+      path = Path.join(dir, "expanded.txt")
+      File.write!(path, "disk content")
+
+      {:ok, pid} = start_supervised({Buffer.Server, file_path: path})
+      :ok = Buffer.Server.replace_content(pid, "buffer content")
+
+      # ReadFile expands the path, so relative/absolute should both work
+      assert {:ok, "buffer content"} = ReadFile.execute(path)
+    end
+  end
+
+  describe "EditDelta tree-sitter sync" do
+    test "find_and_replace broadcasts buffer_changed event", %{tmp_dir: dir} do
+      path = Path.join(dir, "delta.txt")
+      File.write!(path, "hello world")
+
+      {:ok, pid} = start_supervised({Buffer.Server, file_path: path})
+
+      # Subscribe to buffer change events
+      Minga.Events.subscribe(:buffer_changed)
+
+      # Apply an agent edit via find_and_replace (same path as agent tools)
+      {:ok, _msg} = Buffer.Server.find_and_replace(pid, "hello", "goodbye")
+
+      # The buffer should broadcast a :buffer_changed event that the parser
+      # would use for tree-sitter incremental updates
+      assert_receive {:minga_event, :buffer_changed, %{buffer: ^pid, version: version}},
+                     1_000
+
+      assert is_integer(version)
+
+      # Verify the content was actually changed
+      assert Buffer.Server.content(pid) =~ "goodbye world"
     end
   end
 end


### PR DESCRIPTION
## What

Completes the final acceptance criteria for #393: `ReadFile.execute/1` now routes through `Buffer.Server.content/1` when a buffer is open for the target file, returning live in-memory content instead of stale disk content.

## Why

With `EditFile`, `WriteFile`, and `MultiEditFile` already routing through `Buffer.Server`, `ReadFile` was the last holdout. An agent editing a buffer in-memory (unsaved) and then reading the same file would get stale disk content instead of its own changes.

## Changes

**`lib/minga/agent/tools/read_file.ex`**
- Added `read_content/1` that checks `Buffer.pid_for_path/1` first, falls back to `File.read/1`
- Buffer-sourced content skips the binary file check (buffer content is always valid UTF-8)
- Does NOT open buffers on demand (ReadFile should not pollute the buffer list)
- Handles the race where a buffer process dies between lookup and content call

**`test/minga/agent/tools/read_file_test.exs`**
- Buffer-first routing: modified in-memory buffer returns buffer content, not disk content
- Buffer routing with offset/limit slicing
- Fallback to disk when no buffer is open
- Truncation of large buffer content
- Path expansion works correctly
- EditDelta tree-sitter sync: `find_and_replace` broadcasts `:buffer_changed` events

## Acceptance Criteria

All 9 acceptance criteria from #393 are now satisfied:
1. ✅ EditFile routes through Buffer.Server (pre-existing)
2. ✅ WriteFile routes through Buffer.Server (pre-existing)
3. ✅ MultiEditFile routes through Buffer.Server (pre-existing)
4. ✅ Agent edits appear immediately (pre-existing)
5. ✅ Agent edits go on undo stack (pre-existing)
6. ✅ Dirty flag set after agent edits (pre-existing)
7. ✅ Filesystem fallback for unvisited files (pre-existing)
8. ✅ **ReadFile returns buffer content when available** (this PR)
9. ✅ **Agent edits trigger tree-sitter updates via buffer_changed events** (confirming test added)

Closes #393