### PR TITLE
feat(macos): vibrancy material backgrounds for popups and overlays

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		42E4FAA9F204D88F8D19EFF6 /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE9DFE38318A361BEF0B773 /* MessagesContentView.swift */; };
 		44D48DF33203C53ACC3BA1AA /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
 		4515011E135C9FAE8D843610 /* ProtocolTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */; };
+		464594D4B82950CD0F0F250A /* VibrancyBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074581CB7F823DBB4563E3A3 /* VibrancyBackground.swift */; };
 		4699A67786955024F156446F /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
 		4ADE54090FEEF5AA2A6C86A0 /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
 		4D631534301A80CEC8BC147A /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2EC7DA888E31E55CE0D715 /* AgentContextBar.swift */; };
@@ -80,6 +81,7 @@
 		6474095F95F4DA480AFE91B7 /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */; };
 		64A5A16E02B3E2694060F1A1 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
 		654E7E631260BE13502E1C32 /* FloatPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C47F406747CA6DD924A1AB /* FloatPopupOverlay.swift */; };
+		6560FE3E237307974110AC6C /* VibrancyBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074581CB7F823DBB4563E3A3 /* VibrancyBackground.swift */; };
 		6700C63C4B7070D3388A7BD4 /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		67BB06B6822104CDE37EDF83 /* BoardTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C874A0099721763D5109D99 /* BoardTypes.swift */; };
 		6860E9D6217B72EAA8AD71A5 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
@@ -194,6 +196,7 @@
 		03E3D96CF06FCC7F116AF4DC /* ChangeSummaryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryState.swift; sourceTree = "<group>"; };
 		053D515EC453DEBFF51FB6CB /* DecoderFuzzTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderFuzzTests.swift; sourceTree = "<group>"; };
 		05DDF3EED1B486C4639A06FF /* MinibufferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinibufferView.swift; sourceTree = "<group>"; };
+		074581CB7F823DBB4563E3A3 /* VibrancyBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrancyBackground.swift; sourceTree = "<group>"; };
 		08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolTypes.swift; sourceTree = "<group>"; };
 		0A7AA0437B5C38BA8A8A80D5 /* TabBarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarState.swift; sourceTree = "<group>"; };
 		0C26E064D810299C0302F439 /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
@@ -416,6 +419,7 @@
 				00D6B3C68CFF37BC4303933A /* ThemeColors.swift */,
 				A64B96EAA100E627F4E8E0A1 /* ToolManagerState.swift */,
 				ED47BC6334A067AE04FEE032 /* ToolManagerView.swift */,
+				074581CB7F823DBB4563E3A3 /* VibrancyBackground.swift */,
 				CF8ACE680725ECE21E6E03B4 /* WhichKeyOverlay.swift */,
 				70D5765529645C5D860576B7 /* WhichKeyState.swift */,
 				73F9A4109AB33ABF7FB441EE /* WorkspaceIconPicker.swift */,
@@ -718,6 +722,7 @@
 				810251CDDA9CB63F881D426C /* ThemeColors.swift in Sources */,
 				00BFD5EFCCE2F178469BBA9E /* ToolManagerState.swift in Sources */,
 				2CB47C7E5221C260DE6EE77F /* ToolManagerView.swift in Sources */,
+				6560FE3E237307974110AC6C /* VibrancyBackground.swift in Sources */,
 				4699A67786955024F156446F /* WhichKeyOverlay.swift in Sources */,
 				5FDD7CBBCB910BDC63276AA7 /* WhichKeyState.swift in Sources */,
 				58D1135E113BF3A33EF7815F /* WindowContent.swift in Sources */,
@@ -820,6 +825,7 @@
 				61CF67858355FFF4962D9D99 /* ThemeColorsTests.swift in Sources */,
 				2BA99A1851D0FF01436D5FF8 /* ToolManagerState.swift in Sources */,
 				4D83576C27CB59935BE53667 /* ToolManagerView.swift in Sources */,
+				464594D4B82950CD0F0F250A /* VibrancyBackground.swift in Sources */,
 				DD0B958D8ACEFFEF3C1A50AE /* ViewModelComputedTests.swift in Sources */,
 				6474095F95F4DA480AFE91B7 /* WhichKeyOverlay.swift in Sources */,
 				CF09E23141DB0E6D9B65826A /* WhichKeyState.swift in Sources */,

--- a/macos/Sources/Views/CompletionOverlay.swift
+++ b/macos/Sources/Views/CompletionOverlay.swift
@@ -40,8 +40,12 @@ struct CompletionOverlay: View {
             .frame(width: popupWidth)
             .frame(maxHeight: CGFloat(min(state.items.count, maxVisibleItems)) * itemHeight + 8)
             .background(
+                VibrancyBackground(material: .popover)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            )
+            .background(
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(theme.popupBg)
+                    .fill(theme.popupBg.opacity(0.5))
                     .shadow(color: .black.opacity(0.4), radius: 12, y: 4)
             )
             .overlay(

--- a/macos/Sources/Views/FloatPopupOverlay.swift
+++ b/macos/Sources/Views/FloatPopupOverlay.swift
@@ -61,8 +61,12 @@ struct FloatPopupOverlay: View {
             }
             .frame(width: panelWidth, height: panelHeight)
             .background(
+                VibrancyBackground(material: .popover)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            )
+            .background(
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(theme.popupBg)
+                    .fill(theme.popupBg.opacity(0.5))
                     .shadow(color: .black.opacity(0.5), radius: 16, y: 4)
             )
             .overlay(

--- a/macos/Sources/Views/HoverPopupOverlay.swift
+++ b/macos/Sources/Views/HoverPopupOverlay.swift
@@ -85,8 +85,12 @@ struct HoverPopupOverlay: View {
                 .onPreferenceChange(HoverHeightKey.self) { popupHeight = $0 }
                 .onPreferenceChange(HoverWidthKey.self) { popupWidth = $0 }
                 .background(
+                    VibrancyBackground(material: .popover)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                )
+                .background(
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(theme.popupBg)
+                        .fill(theme.popupBg.opacity(0.5))
                         .shadow(color: .black.opacity(0.4), radius: 12,
                                 y: showAbove ? -4 : 4)
                 )

--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -49,8 +49,12 @@ struct PickerOverlay: View {
                 }
                 .frame(width: panelWidth)
                 .background(
+                    VibrancyBackground(material: .popover)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                )
+                .background(
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(theme.popupBg)
+                        .fill(theme.popupBg.opacity(0.5))
                         .shadow(color: .black.opacity(0.5), radius: 20, y: 8)
                 )
                 .overlay(
@@ -282,8 +286,12 @@ struct PickerOverlay: View {
         }
         .frame(width: 200)
         .background(
+            VibrancyBackground(material: .popover)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        )
+        .background(
             RoundedRectangle(cornerRadius: 8)
-                .fill(theme.popupBg)
+                .fill(theme.popupBg.opacity(0.5))
                 .shadow(color: .black.opacity(0.4), radius: 12, y: 4)
         )
         .overlay(

--- a/macos/Sources/Views/SignatureHelpOverlay.swift
+++ b/macos/Sources/Views/SignatureHelpOverlay.swift
@@ -101,8 +101,12 @@ struct SignatureHelpOverlay: View {
             .onPreferenceChange(SigHelpHeightKey.self) { popupHeight = $0 }
             .onPreferenceChange(SigHelpWidthKey.self) { popupWidth = $0 }
             .background(
+                VibrancyBackground(material: .popover)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            )
+            .background(
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(theme.popupBg)
+                    .fill(theme.popupBg.opacity(0.5))
                     .shadow(color: .black.opacity(0.4), radius: 12,
                             y: showAbove ? -4 : 4)
             )

--- a/macos/Sources/Views/VibrancyBackground.swift
+++ b/macos/Sources/Views/VibrancyBackground.swift
@@ -1,0 +1,33 @@
+/// Reusable vibrancy/frosted-glass background using NSVisualEffectView.
+///
+/// Falls back gracefully when the user enables "Reduce transparency" in
+/// System Settings > Accessibility > Display (NSVisualEffectView handles
+/// this automatically by rendering a solid material-appropriate color).
+
+import SwiftUI
+import AppKit
+
+struct VibrancyBackground: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
+
+    init(material: NSVisualEffectView.Material = .popover,
+         blendingMode: NSVisualEffectView.BlendingMode = .behindWindow) {
+        self.material = material
+        self.blendingMode = blendingMode
+    }
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .active
+        view.isEmphasized = true
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        nsView.material = material
+        nsView.blendingMode = blendingMode
+    }
+}

--- a/macos/Sources/Views/WhichKeyOverlay.swift
+++ b/macos/Sources/Views/WhichKeyOverlay.swift
@@ -49,8 +49,12 @@ struct WhichKeyOverlay: View {
                     .padding(.vertical, 6)
             }
             .background(
+                VibrancyBackground(material: .popover)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            )
+            .background(
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(theme.popupBg)
+                    .fill(theme.popupBg.opacity(0.5))
                     .shadow(color: .black.opacity(0.4), radius: 12, y: -4)
             )
             .overlay(


### PR DESCRIPTION
## What

Adds native macOS vibrancy (frosted glass) backgrounds to all popup/overlay views, replacing the flat opaque `theme.popupBg` fills.

Closes #1003

## How

A new reusable `VibrancyBackground` component wraps `NSVisualEffectView` as an `NSViewRepresentable`. Each overlay layers it behind a semi-transparent theme tint (`popupBg` at 0.5 opacity), so the frosted glass bleeds through while text stays legible. The existing border overlays are unchanged.

### Files changed

| File | Change |
|------|--------|
| `VibrancyBackground.swift` | New. Reusable `NSViewRepresentable` with `.popover` material, `.behindWindow` blending. |
| `PickerOverlay.swift` | Vibrancy on main panel and action menu (2 locations). |
| `CompletionOverlay.swift` | Vibrancy on completion popup. |
| `WhichKeyOverlay.swift` | Vibrancy on which-key popup. |
| `HoverPopupOverlay.swift` | Vibrancy on hover tooltip. |
| `SignatureHelpOverlay.swift` | Vibrancy on signature help popup. |
| `FloatPopupOverlay.swift` | Vibrancy on float popup. |

## Accessibility

`NSVisualEffectView` automatically falls back to a solid material-appropriate background when the user enables **Reduce Transparency** in System Settings > Accessibility > Display. No extra code needed.

## Testing

- `make lint` passes (format + credo + compile + dialyzer)
- All 7,112 Elixir tests pass
- Xcode build succeeds
- Visual verification needed: open each popup type and confirm the frosted glass effect is visible with legible text in both light and dark themes