### PR TITLE
feat(editor): file tree inline editing - BEAM core (#1299)

### DIFF
--- a/lib/minga/editor/commands/file_tree.ex
+++ b/lib/minga/editor/commands/file_tree.ex
@@ -113,33 +113,137 @@ defmodule Minga.Editor.Commands.FileTree do
   end
 
   @doc """
-  Stub for creating a new file at the selected directory.
-  Requires a name prompt UI (not yet implemented). Logs intent to *Messages*.
+  Enters inline editing mode to create a new file.
+
+  If the selected entry is a directory, the new file appears inside it
+  (expanding the directory if collapsed). If the selected entry is a
+  file, the new file appears as a sibling in the same directory.
   """
   @spec new_file(state()) :: state()
   def new_file(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
 
-  def new_file(state) do
-    Minga.Editor.log_to_messages(
-      "[file-tree] New file: requires name prompt (not yet implemented)"
-    )
-
-    state
+  def new_file(%{workspace: %{file_tree: %{tree: tree}}} = state) do
+    {index, tree} = editing_insertion_index(tree)
+    ft = FileTreeState.start_editing(state.workspace.file_tree, index, :new_file)
+    state = put_in(state.workspace.file_tree, %{ft | tree: tree})
+    sync_buffer(state)
   end
 
   @doc """
-  Stub for creating a new folder at the selected directory.
-  Requires a name prompt UI (not yet implemented). Logs intent to *Messages*.
+  Enters inline editing mode to create a new folder.
+
+  Same positioning logic as `new_file/1`.
   """
   @spec new_folder(state()) :: state()
   def new_folder(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
 
-  def new_folder(state) do
-    Minga.Editor.log_to_messages(
-      "[file-tree] New folder: requires name prompt (not yet implemented)"
-    )
+  def new_folder(%{workspace: %{file_tree: %{tree: tree}}} = state) do
+    {index, tree} = editing_insertion_index(tree)
+    ft = FileTreeState.start_editing(state.workspace.file_tree, index, :new_folder)
+    state = put_in(state.workspace.file_tree, %{ft | tree: tree})
+    sync_buffer(state)
+  end
 
-    state
+  @doc """
+  Enters inline editing mode to rename the selected entry.
+
+  Pre-fills the input with the current entry name.
+  """
+  @spec rename(state()) :: state()
+  def rename(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+
+  def rename(%{workspace: %{file_tree: %{tree: tree}}} = state) do
+    case FileTree.selected_entry(tree) do
+      nil ->
+        state
+
+      entry ->
+        ft =
+          FileTreeState.start_editing(
+            state.workspace.file_tree,
+            tree.cursor,
+            :rename,
+            entry.name
+          )
+
+        put_in(state.workspace.file_tree, ft)
+    end
+  end
+
+  @doc """
+  Confirms the current inline edit.
+
+  Dispatches on the editing type:
+  - `:new_file` creates the file on disk, opens it as a buffer.
+  - `:new_folder` creates the directory on disk.
+  - `:rename` renames the file/directory and updates any open buffer.
+  """
+  @spec confirm_editing(state()) :: state()
+  def confirm_editing(%{workspace: %{file_tree: %{editing: nil}}} = state), do: state
+
+  def confirm_editing(%{workspace: %{file_tree: %{editing: %{text: text}}}} = state)
+      when text == "" do
+    cancel_editing(state)
+  end
+
+  def confirm_editing(
+        %{workspace: %{file_tree: %{editing: %{type: :new_file} = editing}}} = state
+      ) do
+    parent_dir = editing_parent_dir(state)
+    full_path = Path.join(parent_dir, editing.text)
+
+    File.mkdir_p!(Path.dirname(full_path))
+    File.touch!(full_path)
+
+    state = clear_editing_and_refresh(state)
+
+    case Commands.start_buffer(full_path) do
+      {:ok, pid} ->
+        Minga.Editor.do_file_tree_open(state, pid, full_path, state.workspace.file_tree.tree)
+
+      {:error, reason} ->
+        Minga.Editor.log_to_messages(
+          "[file-tree] Failed to open #{full_path}: #{inspect(reason)}"
+        )
+
+        state
+    end
+  end
+
+  def confirm_editing(
+        %{workspace: %{file_tree: %{editing: %{type: :new_folder} = editing}}} = state
+      ) do
+    parent_dir = editing_parent_dir(state)
+    full_path = Path.join(parent_dir, editing.text)
+
+    case File.mkdir_p(full_path) do
+      :ok ->
+        Minga.Editor.log_to_messages("[file-tree] Created folder: #{editing.text}")
+        clear_editing_and_refresh(state)
+
+      {:error, reason} ->
+        Minga.Editor.log_to_messages("[file-tree] Failed to create folder: #{inspect(reason)}")
+
+        cancel_editing(state)
+    end
+  end
+
+  def confirm_editing(
+        %{workspace: %{file_tree: %{editing: %{type: :rename} = _editing, tree: tree}}} = state
+      ) do
+    case FileTree.selected_entry(tree) do
+      nil -> cancel_editing(state)
+      entry -> do_rename(state, entry, state.workspace.file_tree.editing.text)
+    end
+  end
+
+  @doc "Cancels the current inline edit without making changes."
+  @spec cancel_editing(state()) :: state()
+  def cancel_editing(%{workspace: %{file_tree: %{editing: nil}}} = state), do: state
+
+  def cancel_editing(state) do
+    ft = FileTreeState.cancel_editing(state.workspace.file_tree)
+    put_in(state.workspace.file_tree, ft)
   end
 
   @doc """
@@ -297,6 +401,114 @@ defmodule Minga.Editor.Commands.FileTree do
     put_in(state.workspace.file_tree.tree, new_tree)
   end
 
+  # Computes the insertion index for a new file/folder.
+  # If the selected entry is a directory, inserts inside it (expanding if needed).
+  # If the selected entry is a file, inserts as a sibling after the cursor.
+  @spec editing_insertion_index(FileTree.t()) :: {non_neg_integer(), FileTree.t()}
+  defp editing_insertion_index(tree) do
+    case FileTree.selected_entry(tree) do
+      nil ->
+        {0, tree}
+
+      %{dir?: true, path: dir_path} ->
+        tree = ensure_expanded(tree, dir_path)
+        {tree.cursor + 1, tree}
+
+      %{dir?: false} ->
+        {tree.cursor + 1, tree}
+    end
+  end
+
+  @spec ensure_expanded(FileTree.t(), String.t()) :: FileTree.t()
+  defp ensure_expanded(tree, dir_path) do
+    if MapSet.member?(tree.expanded, dir_path), do: tree, else: FileTree.toggle_expand(tree)
+  end
+
+  # Determines the parent directory path for the current editing operation.
+  @spec editing_parent_dir(state()) :: String.t()
+  defp editing_parent_dir(%{workspace: %{file_tree: %{editing: editing, tree: tree}}}) do
+    entries = FileTree.visible_entries(tree)
+
+    case editing.type do
+      type when type in [:new_file, :new_folder] ->
+        prev_entry = if editing.index > 0, do: Enum.at(entries, editing.index - 1)
+
+        case prev_entry do
+          %{dir?: true, path: path} -> path
+          %{path: path} -> Path.dirname(path)
+          nil -> tree.root
+        end
+
+      :rename ->
+        case Enum.at(entries, editing.index) do
+          %{path: path} -> Path.dirname(path)
+          nil -> tree.root
+        end
+    end
+  end
+
+  # Clears editing state and refreshes the tree from disk.
+  @spec clear_editing_and_refresh(state()) :: state()
+  defp clear_editing_and_refresh(state) do
+    ft = FileTreeState.cancel_editing(state.workspace.file_tree)
+    state = put_in(state.workspace.file_tree, ft)
+    refresh(state)
+  end
+
+  # Syncs the buffer after editing state changes.
+  @spec sync_buffer(state()) :: state()
+  defp sync_buffer(%{workspace: %{file_tree: %{buffer: buf, tree: tree}}} = state)
+       when is_pid(buf) do
+    BufferSync.sync(buf, tree)
+    state
+  end
+
+  defp sync_buffer(state), do: state
+
+  @spec do_rename(state(), FileTree.entry(), String.t()) :: state()
+  defp do_rename(state, entry, new_name) do
+    old_path = entry.path
+    new_path = Path.join(Path.dirname(old_path), new_name)
+
+    if old_path == new_path do
+      cancel_editing(state)
+    else
+      execute_rename(state, old_path, new_path, new_name)
+    end
+  end
+
+  @spec execute_rename(state(), String.t(), String.t(), String.t()) :: state()
+  defp execute_rename(state, old_path, new_path, new_name) do
+    case File.rename(old_path, new_path) do
+      :ok ->
+        state = update_buffer_path(state, old_path, new_path)
+
+        Minga.Editor.log_to_messages(
+          "[file-tree] Renamed: #{Path.basename(old_path)} \u2192 #{new_name}"
+        )
+
+        clear_editing_and_refresh(state)
+
+      {:error, reason} ->
+        Minga.Editor.log_to_messages("[file-tree] Rename failed: #{inspect(reason)}")
+        cancel_editing(state)
+    end
+  end
+
+  # Updates any open buffer that references the old path to the new path.
+  @spec update_buffer_path(state(), String.t(), String.t()) :: state()
+  defp update_buffer_path(state, old_path, new_path) do
+    case EditorState.find_buffer_by_path(state, old_path) do
+      nil ->
+        state
+
+      idx ->
+        pid = Enum.at(state.workspace.buffers.list, idx)
+        Buffer.save_as(pid, new_path)
+        state
+    end
+  end
+
   @impl Minga.Command.Provider
   def __commands__ do
     [
@@ -365,6 +577,24 @@ defmodule Minga.Editor.Commands.FileTree do
         description: "Create new folder in tree",
         requires_buffer: false,
         execute: &new_folder/1
+      },
+      %Minga.Command{
+        name: :tree_rename,
+        description: "Rename file or folder in tree",
+        requires_buffer: false,
+        execute: &rename/1
+      },
+      %Minga.Command{
+        name: :tree_confirm_editing,
+        description: "Confirm file tree inline edit",
+        requires_buffer: false,
+        execute: &confirm_editing/1
+      },
+      %Minga.Command{
+        name: :tree_cancel_editing,
+        description: "Cancel file tree inline edit",
+        requires_buffer: false,
+        execute: &cancel_editing/1
       },
       %Minga.Command{
         name: :tree_reveal_active,

--- a/lib/minga/editor/state/file_tree.ex
+++ b/lib/minga/editor/state/file_tree.ex
@@ -2,22 +2,42 @@ defmodule Minga.Editor.State.FileTree do
   @moduledoc """
   File tree sub-state: tree data, focus, and backing buffer.
 
-  Wraps the three file-tree-related fields from EditorState into a
-  single struct with query and mutation helpers.
+  Wraps the file-tree-related fields from EditorState into a single
+  struct with query and mutation helpers. Includes inline editing state
+  for new file, new folder, and rename operations.
   """
 
   alias Minga.Project.FileTree
+
+  @typedoc """
+  Inline editing state for creating files/folders or renaming entries.
+
+  When non-nil, the user is actively typing a filename in the tree.
+  The `index` is the visual position in the visible entry list where
+  the editing row appears. For new file/folder, this is the insertion
+  point. For rename, this is the entry being renamed.
+  """
+  @type editing_type :: :new_file | :new_folder | :rename
+
+  @type editing :: %{
+          index: non_neg_integer(),
+          text: String.t(),
+          type: editing_type(),
+          original_name: String.t() | nil
+        }
 
   @typedoc "File tree sub-state."
   @type t :: %__MODULE__{
           tree: FileTree.t() | nil,
           focused: boolean(),
-          buffer: pid() | nil
+          buffer: pid() | nil,
+          editing: editing() | nil
         }
 
   defstruct tree: nil,
             focused: false,
-            buffer: nil
+            buffer: nil,
+            editing: nil
 
   @doc "Returns true when the file tree is open."
   @spec open?(t()) :: boolean()
@@ -28,6 +48,11 @@ defmodule Minga.Editor.State.FileTree do
   @spec focused?(t()) :: boolean()
   def focused?(%__MODULE__{tree: %FileTree{}, focused: true}), do: true
   def focused?(%__MODULE__{}), do: false
+
+  @doc "Returns true when inline editing is active."
+  @spec editing?(t()) :: boolean()
+  def editing?(%__MODULE__{editing: %{}}), do: true
+  def editing?(%__MODULE__{}), do: false
 
   @doc "Returns the tree width, or 0 if the tree is not open."
   @spec width(t()) :: non_neg_integer()
@@ -43,6 +68,35 @@ defmodule Minga.Editor.State.FileTree do
   @doc "Closes the tree and clears the buffer."
   @spec close(t()) :: t()
   def close(%__MODULE__{} = ft) do
-    %{ft | tree: nil, focused: false, buffer: nil}
+    %{ft | tree: nil, focused: false, buffer: nil, editing: nil}
+  end
+
+  @doc """
+  Enters inline editing mode at the given index.
+
+  For new file/folder, `initial_text` is empty. For rename,
+  `initial_text` is the current entry name.
+  """
+  @spec start_editing(t(), non_neg_integer(), editing_type(), String.t()) :: t()
+  def start_editing(%__MODULE__{} = ft, index, type, initial_text \\ "")
+      when type in [:new_file, :new_folder, :rename] and is_integer(index) and index >= 0 do
+    original = if type == :rename, do: initial_text, else: nil
+
+    %{ft | editing: %{index: index, text: initial_text, type: type, original_name: original}}
+  end
+
+  @doc "Updates the text being typed in the inline editor."
+  @spec update_editing_text(t(), String.t()) :: t()
+  def update_editing_text(%__MODULE__{editing: %{} = editing} = ft, new_text)
+      when is_binary(new_text) do
+    %{ft | editing: %{editing | text: new_text}}
+  end
+
+  def update_editing_text(%__MODULE__{editing: nil} = ft, _new_text), do: ft
+
+  @doc "Cancels inline editing, clearing the editing state back to nil."
+  @spec cancel_editing(t()) :: t()
+  def cancel_editing(%__MODULE__{} = ft) do
+    %{ft | editing: nil}
   end
 end

--- a/lib/minga/input/file_tree_handler.ex
+++ b/lib/minga/input/file_tree_handler.ex
@@ -14,12 +14,22 @@ defmodule Minga.Input.FileTreeHandler do
   alias Minga.Editor.Commands
   alias Minga.Editor.Layout
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.FileTree, as: FileTreeState
   alias Minga.Input
   alias Minga.Keymap
   alias Minga.Project.FileTree
   @impl true
   @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+
+  # Inline editing active: capture all keys before they reach the mode FSM or scope trie
+  def handle_key(
+        %{workspace: %{keymap_scope: :file_tree, file_tree: %{editing: %{} = _editing}}} = state,
+        cp,
+        mods
+      ) do
+    {:handled, handle_inline_edit_key(state, cp, mods)}
+  end
 
   # File tree scope with tree focused
   def handle_key(
@@ -210,6 +220,48 @@ defmodule Minga.Input.FileTreeHandler do
   defp tree_scroll_offset(cursor, visible_rows) when visible_rows <= 0, do: cursor
   defp tree_scroll_offset(cursor, visible_rows) when cursor < visible_rows, do: 0
   defp tree_scroll_offset(cursor, visible_rows), do: cursor - visible_rows + 1
+
+  # ── Inline editing key handler ──────────────────────────────────────────
+
+  @enter 13
+  @escape 27
+  @backspace 127
+
+  @spec handle_inline_edit_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          EditorState.t()
+  defp handle_inline_edit_key(state, @enter, 0) do
+    Commands.FileTree.confirm_editing(state)
+  end
+
+  defp handle_inline_edit_key(state, @escape, 0) do
+    Commands.FileTree.cancel_editing(state)
+  end
+
+  defp handle_inline_edit_key(state, @backspace, 0) do
+    editing = state.workspace.file_tree.editing
+
+    if editing.text == "" do
+      Commands.FileTree.cancel_editing(state)
+    else
+      # Delete the last grapheme from the editing text.
+      # Use String.slice/3 (start, length) to avoid negative index issues.
+      new_text = String.slice(editing.text, 0, max(String.length(editing.text) - 1, 0))
+      ft = FileTreeState.update_editing_text(state.workspace.file_tree, new_text)
+      put_in(state.workspace.file_tree, ft)
+    end
+  end
+
+  # Printable characters: append to editing text
+  defp handle_inline_edit_key(state, cp, 0) when cp >= 32 do
+    char = <<cp::utf8>>
+    editing = state.workspace.file_tree.editing
+    new_text = editing.text <> char
+    ft = FileTreeState.update_editing_text(state.workspace.file_tree, new_text)
+    put_in(state.workspace.file_tree, ft)
+  end
+
+  # All other keys (with modifiers, control chars): swallow them
+  defp handle_inline_edit_key(state, _cp, _mods), do: state
 
   # ── Shared helpers ──────────────────────────────────────────────────────
 end

--- a/lib/minga/keymap/scope/file_tree.ex
+++ b/lib/minga/keymap/scope/file_tree.ex
@@ -60,6 +60,12 @@ defmodule Minga.Keymap.Scope.FileTree do
          {"H", "Toggle hidden files"},
          {"r", "Refresh tree"}
        ]},
+      {"File Operations",
+       [
+         {"a", "New file"},
+         {"A", "New folder"},
+         {"R", "Rename"}
+       ]},
       {"View",
        [
          {"q / Esc", "Close file tree"}
@@ -80,6 +86,9 @@ defmodule Minga.Keymap.Scope.FileTree do
     |> Bindings.bind([{?r, 0}], :tree_refresh, "Refresh file tree")
     |> Bindings.bind([{?q, 0}], :tree_close, "Close file tree")
     |> Bindings.bind([{@escape, 0}], :tree_close, "Close file tree")
+    |> Bindings.bind([{?a, 0}], :tree_new_file, "New file")
+    |> Bindings.bind([{?A, 0}], :tree_new_folder, "New folder")
+    |> Bindings.bind([{?R, 0}], :tree_rename, "Rename")
   end
 
   # ── CUA mode bindings ─────────────────────────────────────────────────────

--- a/test/minga/editor/commands/file_tree_editing_test.exs
+++ b/test/minga/editor/commands/file_tree_editing_test.exs
@@ -1,0 +1,173 @@
+defmodule Minga.Editor.Commands.FileTreeEditingTest do
+  @moduledoc """
+  Tests for file tree inline editing commands: new file, new folder,
+  rename, confirm, and cancel.
+
+  Uses EditorCase with tmp_dir for real filesystem operations.
+  """
+  use Minga.Test.EditorCase, async: true
+
+  @moduletag :tmp_dir
+
+  describe "new file (a)" do
+    test "enters new-file editing mode", %{tmp_dir: dir} do
+      file = Path.join(dir, "test.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      state = send_keys_sync(ctx, "a")
+
+      assert state.workspace.file_tree.editing != nil
+      assert state.workspace.file_tree.editing.type == :new_file
+      assert state.workspace.file_tree.editing.text == ""
+    end
+
+    test "creates file on disk after typing name and pressing Enter", %{tmp_dir: dir} do
+      file = Path.join(dir, "test.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      _state = send_keys_sync(ctx, "a")
+      state = send_keys_sync(ctx, "newfile.txt<Enter>")
+
+      assert state.workspace.file_tree.editing == nil
+
+      expected = Path.join(dir, "newfile.txt")
+      assert File.exists?(expected), "Expected newfile.txt to exist at #{expected}"
+    end
+  end
+
+  describe "new folder (A)" do
+    test "enters new-folder editing mode", %{tmp_dir: dir} do
+      file = Path.join(dir, "test.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      state = send_keys_sync(ctx, "A")
+
+      assert state.workspace.file_tree.editing != nil
+      assert state.workspace.file_tree.editing.type == :new_folder
+    end
+
+    test "creates directory on disk after typing name and pressing Enter", %{tmp_dir: dir} do
+      file = Path.join(dir, "test.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      _state = send_keys_sync(ctx, "A")
+      state = send_keys_sync(ctx, "newfolder<Enter>")
+
+      assert state.workspace.file_tree.editing == nil
+
+      expected = Path.join(dir, "newfolder")
+      assert File.dir?(expected), "Expected newfolder to exist at #{expected}"
+    end
+  end
+
+  describe "rename (R)" do
+    test "enters rename editing mode with current name pre-filled", %{tmp_dir: dir} do
+      file = Path.join(dir, "target.txt")
+      File.write!(file, "content")
+
+      ctx = start_editor("content", file_path: file)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      state = send_keys_sync(ctx, "R")
+
+      assert state.workspace.file_tree.editing != nil
+      assert state.workspace.file_tree.editing.type == :rename
+      assert state.workspace.file_tree.editing.original_name != nil
+    end
+
+    test "renames file on disk after changing name", %{tmp_dir: dir} do
+      file = Path.join(dir, "target.txt")
+      File.write!(file, "content")
+
+      ctx = start_editor("content", file_path: file)
+
+      # Open tree (reveals active file automatically), press R
+      _state = send_keys_sync(ctx, "<SPC>op")
+      state = send_keys_sync(ctx, "R")
+      name = state.workspace.file_tree.editing.text
+
+      # Clear pre-filled text with backspaces, then type new name
+      backspaces = String.duplicate("<BS>", String.length(name))
+      state = send_keys_sync(ctx, "#{backspaces}renamed.txt<Enter>")
+
+      assert state.workspace.file_tree.editing == nil
+
+      new_path = Path.join(dir, "renamed.txt")
+      assert File.exists?(new_path), "Expected renamed.txt to exist"
+      refute File.exists?(file), "Expected target.txt to no longer exist"
+    end
+  end
+
+  describe "cancel editing" do
+    test "Escape cancels without filesystem changes", %{tmp_dir: dir} do
+      file = Path.join(dir, "test.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      _state = send_keys_sync(ctx, "a")
+      _state = send_keys_sync(ctx, "partial")
+      state = send_keys_sync(ctx, "<Esc>")
+
+      assert state.workspace.file_tree.editing == nil
+
+      refute File.exists?(Path.join(dir, "partial")),
+             "No file should be created when editing is cancelled"
+    end
+
+    test "confirm with empty text cancels", %{tmp_dir: dir} do
+      file = Path.join(dir, "test.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      _state = send_keys_sync(ctx, "a")
+      state = send_keys_sync(ctx, "<Enter>")
+
+      assert state.workspace.file_tree.editing == nil
+    end
+
+    test "Backspace on empty text cancels editing", %{tmp_dir: dir} do
+      file = Path.join(dir, "test.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      _state = send_keys_sync(ctx, "a")
+      state = send_keys_sync(ctx, "<BS>")
+
+      assert state.workspace.file_tree.editing == nil
+    end
+  end
+
+  describe "rename to same name cancels" do
+    test "no filesystem operation when name unchanged", %{tmp_dir: dir} do
+      file = Path.join(dir, "same.txt")
+      File.write!(file, "content")
+
+      ctx = start_editor("content", file_path: file)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      _state = send_keys_sync(ctx, "R")
+      state = send_keys_sync(ctx, "<Enter>")
+
+      assert state.workspace.file_tree.editing == nil
+      assert File.exists?(file), "File should still exist unchanged"
+    end
+  end
+end

--- a/test/minga/editor/state/file_tree_editing_test.exs
+++ b/test/minga/editor/state/file_tree_editing_test.exs
@@ -1,0 +1,126 @@
+defmodule Minga.Editor.State.FileTreeEditingTest do
+  @moduledoc """
+  Pure unit tests for the inline editing state on FileTree sub-state.
+
+  Tests start_editing/4, update_editing_text/2, cancel_editing/1, and
+  editing?/1. No GenServer, no processes, just struct manipulation.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Editor.State.FileTree, as: FileTreeState
+
+  describe "editing?/1" do
+    test "returns false when editing is nil" do
+      assert FileTreeState.editing?(%FileTreeState{}) == false
+    end
+
+    test "returns true when editing state exists" do
+      ft = FileTreeState.start_editing(%FileTreeState{}, 0, :new_file)
+      assert FileTreeState.editing?(ft) == true
+    end
+  end
+
+  describe "start_editing/4" do
+    test "sets index, type, and empty text for new file" do
+      ft = FileTreeState.start_editing(%FileTreeState{}, 3, :new_file)
+
+      assert ft.editing.index == 3
+      assert ft.editing.type == :new_file
+      assert ft.editing.text == ""
+      assert ft.editing.original_name == nil
+    end
+
+    test "sets type correctly for new folder" do
+      ft = FileTreeState.start_editing(%FileTreeState{}, 1, :new_folder)
+
+      assert ft.editing.type == :new_folder
+      assert ft.editing.text == ""
+      assert ft.editing.original_name == nil
+    end
+
+    test "pre-fills text and original_name for rename" do
+      ft = FileTreeState.start_editing(%FileTreeState{}, 2, :rename, "old.txt")
+
+      assert ft.editing.text == "old.txt"
+      assert ft.editing.original_name == "old.txt"
+      assert ft.editing.type == :rename
+      assert ft.editing.index == 2
+    end
+
+    test "works at index 0" do
+      ft = FileTreeState.start_editing(%FileTreeState{}, 0, :new_file)
+      assert ft.editing.index == 0
+    end
+
+    test "handles unicode filename for rename" do
+      ft = FileTreeState.start_editing(%FileTreeState{}, 0, :rename, "日本語.txt")
+
+      assert ft.editing.text == "日本語.txt"
+      assert ft.editing.original_name == "日本語.txt"
+    end
+  end
+
+  describe "update_editing_text/2" do
+    test "replaces text when editing is active" do
+      ft =
+        %FileTreeState{}
+        |> FileTreeState.start_editing(0, :new_file)
+        |> FileTreeState.update_editing_text("new_name.ex")
+
+      assert ft.editing.text == "new_name.ex"
+      assert ft.editing.type == :new_file
+      assert ft.editing.index == 0
+    end
+
+    test "is a no-op when editing is nil" do
+      ft = FileTreeState.update_editing_text(%FileTreeState{}, "ignored")
+      assert ft.editing == nil
+    end
+
+    test "handles empty string (clearing text)" do
+      ft =
+        %FileTreeState{}
+        |> FileTreeState.start_editing(0, :new_file, "something")
+        |> FileTreeState.update_editing_text("")
+
+      assert ft.editing.text == ""
+    end
+
+    test "handles unicode text" do
+      ft =
+        %FileTreeState{}
+        |> FileTreeState.start_editing(0, :new_file)
+        |> FileTreeState.update_editing_text("café.txt")
+
+      assert ft.editing.text == "café.txt"
+    end
+  end
+
+  describe "cancel_editing/1" do
+    test "clears editing back to nil" do
+      ft =
+        %FileTreeState{}
+        |> FileTreeState.start_editing(0, :new_file, "partial")
+        |> FileTreeState.cancel_editing()
+
+      assert ft.editing == nil
+    end
+
+    test "is idempotent on nil editing" do
+      ft = FileTreeState.cancel_editing(%FileTreeState{})
+      assert ft.editing == nil
+    end
+  end
+
+  describe "close/1 clears editing" do
+    test "close resets editing to nil" do
+      ft =
+        %FileTreeState{}
+        |> FileTreeState.start_editing(0, :new_file)
+        |> FileTreeState.close()
+
+      assert ft.editing == nil
+      assert ft.tree == nil
+    end
+  end
+end

--- a/test/minga/input/file_tree_editing_input_test.exs
+++ b/test/minga/input/file_tree_editing_input_test.exs
@@ -1,0 +1,154 @@
+defmodule Minga.Input.FileTreeEditingInputTest do
+  @moduledoc """
+  Tests for inline editing key capture in the file tree handler.
+
+  Verifies that when editing is active, all keys are captured (never
+  :passthrough), printable chars append to text, Backspace deletes,
+  Enter confirms, Escape cancels, and no keys leak to the mode FSM.
+
+  Uses direct handler calls on constructed state (Layer 2), following
+  the pattern from file_tree_nav_test.exs.
+  """
+  use ExUnit.Case, async: true
+
+  @moduletag :tmp_dir
+
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.FileTree, as: FileTreeState
+  alias Minga.Editor.Viewport
+  alias Minga.Input.FileTreeHandler
+  alias Minga.Project.FileTree
+  alias Minga.Project.FileTree.BufferSync
+
+  @enter 13
+  @escape 27
+  @backspace 127
+
+  defp make_state(tmp_dir) do
+    File.write!(Path.join(tmp_dir, "existing.txt"), "content")
+    File.mkdir_p!(Path.join(tmp_dir, "subdir"))
+
+    tree = FileTree.new(tmp_dir)
+    buf = BufferSync.start_buffer(tree)
+
+    %EditorState{
+      port_manager: self(),
+      workspace: %Minga.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        file_tree: %FileTreeState{tree: tree, focused: true, buffer: buf},
+        keymap_scope: :file_tree
+      },
+      focus_stack: [Minga.Input.Scoped, Minga.Input.ModeFSM]
+    }
+  end
+
+  defp make_editing_state(tmp_dir, opts \\ []) do
+    state = make_state(tmp_dir)
+    type = Keyword.get(opts, :type, :new_file)
+    text = Keyword.get(opts, :text, "")
+    index = state.workspace.file_tree.tree.cursor
+
+    ft = FileTreeState.start_editing(state.workspace.file_tree, index, type, text)
+    put_in(state.workspace.file_tree, ft)
+  end
+
+  describe "printable character input" do
+    test "appends character to editing text", %{tmp_dir: dir} do
+      state = make_editing_state(dir)
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?h, 0)
+      assert state.workspace.file_tree.editing.text == "h"
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?e, 0)
+      assert state.workspace.file_tree.editing.text == "he"
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?l, 0)
+      assert state.workspace.file_tree.editing.text == "hel"
+    end
+
+    test "handles unicode codepoints", %{tmp_dir: dir} do
+      state = make_editing_state(dir)
+
+      {:handled, state} = FileTreeHandler.handle_key(state, 0x00E9, 0)
+      assert state.workspace.file_tree.editing.text == "é"
+    end
+  end
+
+  describe "Enter confirms editing" do
+    test "clears editing state on Enter", %{tmp_dir: dir} do
+      state = make_editing_state(dir, text: "test.txt")
+
+      {:handled, state} = FileTreeHandler.handle_key(state, @enter, 0)
+      assert state.workspace.file_tree.editing == nil
+    end
+  end
+
+  describe "Escape cancels editing" do
+    test "clears editing state on Escape", %{tmp_dir: dir} do
+      state = make_editing_state(dir, text: "partial")
+
+      {:handled, state} = FileTreeHandler.handle_key(state, @escape, 0)
+      assert state.workspace.file_tree.editing == nil
+    end
+  end
+
+  describe "Backspace" do
+    test "deletes last grapheme", %{tmp_dir: dir} do
+      state = make_editing_state(dir, text: "abc")
+
+      {:handled, state} = FileTreeHandler.handle_key(state, @backspace, 0)
+      assert state.workspace.file_tree.editing.text == "ab"
+    end
+
+    test "cancels editing when text is empty", %{tmp_dir: dir} do
+      state = make_editing_state(dir, text: "")
+
+      {:handled, state} = FileTreeHandler.handle_key(state, @backspace, 0)
+      assert state.workspace.file_tree.editing == nil
+    end
+
+    test "handles multi-byte unicode correctly", %{tmp_dir: dir} do
+      state = make_editing_state(dir, text: "café")
+
+      {:handled, state} = FileTreeHandler.handle_key(state, @backspace, 0)
+      assert state.workspace.file_tree.editing.text == "caf"
+    end
+  end
+
+  describe "key swallowing (no leaking to mode FSM)" do
+    test "modifier keys are swallowed during editing", %{tmp_dir: dir} do
+      state = make_editing_state(dir, text: "test")
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?a, 0x02)
+      assert state.workspace.file_tree.editing.text == "test"
+    end
+
+    test "Tab is swallowed during editing", %{tmp_dir: dir} do
+      state = make_editing_state(dir, text: "test")
+
+      {:handled, state} = FileTreeHandler.handle_key(state, 9, 0)
+      assert state.workspace.file_tree.editing.text == "test"
+    end
+
+    test "vim navigation keys append as text instead of moving cursor", %{tmp_dir: dir} do
+      state = make_editing_state(dir)
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?j, 0)
+      assert state.workspace.file_tree.editing.text == "j"
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?k, 0)
+      assert state.workspace.file_tree.editing.text == "jk"
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?d, 0)
+      assert state.workspace.file_tree.editing.text == "jkd"
+    end
+
+    test "q appends to text instead of closing tree", %{tmp_dir: dir} do
+      state = make_editing_state(dir)
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?q, 0)
+      assert state.workspace.file_tree.editing.text == "q"
+      assert state.workspace.file_tree.tree != nil
+    end
+  end
+end

--- a/test/minga/keymap/scope/file_tree_scope_test.exs
+++ b/test/minga/keymap/scope/file_tree_scope_test.exs
@@ -1,0 +1,92 @@
+defmodule Minga.Keymap.Scope.FileTreeScopeTest do
+  @moduledoc """
+  Trie-level unit tests for file tree keymap scope.
+
+  Verifies the new a/A/R bindings for inline editing, and regression
+  checks that existing bindings (Enter, q, h, l, etc.) still work.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Keymap.Scope
+
+  @enter 13
+  @escape 27
+  @tab 9
+
+  describe "normal mode: file operation bindings" do
+    test "a resolves to tree_new_file" do
+      assert {:command, :tree_new_file} = Scope.resolve_key(:file_tree, :normal, {?a, 0})
+    end
+
+    test "A resolves to tree_new_folder" do
+      assert {:command, :tree_new_folder} = Scope.resolve_key(:file_tree, :normal, {?A, 0})
+    end
+
+    test "R resolves to tree_rename" do
+      assert {:command, :tree_rename} = Scope.resolve_key(:file_tree, :normal, {?R, 0})
+    end
+  end
+
+  describe "CUA mode: file operation bindings not present" do
+    test "a is not bound in CUA mode" do
+      assert :not_found = Scope.resolve_key(:file_tree, :cua, {?a, 0})
+    end
+
+    test "A is not bound in CUA mode" do
+      assert :not_found = Scope.resolve_key(:file_tree, :cua, {?A, 0})
+    end
+
+    test "R is not bound in CUA mode" do
+      assert :not_found = Scope.resolve_key(:file_tree, :cua, {?R, 0})
+    end
+  end
+
+  describe "normal mode: existing bindings still work (regression)" do
+    test "Enter opens file or toggles directory" do
+      assert {:command, :tree_open_or_toggle} =
+               Scope.resolve_key(:file_tree, :normal, {@enter, 0})
+    end
+
+    test "q closes file tree" do
+      assert {:command, :tree_close} = Scope.resolve_key(:file_tree, :normal, {?q, 0})
+    end
+
+    test "Escape closes file tree" do
+      assert {:command, :tree_close} = Scope.resolve_key(:file_tree, :normal, {@escape, 0})
+    end
+
+    test "Tab toggles directory" do
+      assert {:command, :tree_toggle_directory} =
+               Scope.resolve_key(:file_tree, :normal, {@tab, 0})
+    end
+
+    test "l expands directory" do
+      assert {:command, :tree_expand} = Scope.resolve_key(:file_tree, :normal, {?l, 0})
+    end
+
+    test "h collapses directory" do
+      assert {:command, :tree_collapse} = Scope.resolve_key(:file_tree, :normal, {?h, 0})
+    end
+
+    test "H toggles hidden files" do
+      assert {:command, :tree_toggle_hidden} = Scope.resolve_key(:file_tree, :normal, {?H, 0})
+    end
+
+    test "r refreshes tree" do
+      assert {:command, :tree_refresh} = Scope.resolve_key(:file_tree, :normal, {?r, 0})
+    end
+  end
+
+  describe "help_groups includes File Operations" do
+    test "File Operations group contains a, A, R bindings" do
+      groups = Minga.Keymap.Scope.FileTree.help_groups(:default)
+
+      {_name, bindings} =
+        Enum.find(groups, fn {name, _} -> name == "File Operations" end)
+
+      assert Enum.any?(bindings, fn {key, _desc} -> key == "a" end)
+      assert Enum.any?(bindings, fn {key, _desc} -> key == "A" end)
+      assert Enum.any?(bindings, fn {key, _desc} -> key == "R" end)
+    end
+  end
+end


### PR DESCRIPTION
## What

Implements the BEAM-side editing state machine, commands, input handling, and keymap bindings for file tree inline editing. After this lands, `a`/`A`/`R` work in the TUI file tree to create files, create folders, and rename entries.

Part of #851. This is ticket 1 of 3 in the dependency chain.

## Changes

### Editor.State.FileTree
- Added `editing` field (map with `index`, `text`, `type`, `original_name`)
- Helpers: `start_editing/4`, `update_editing_text/2`, `cancel_editing/1`, `editing?/1`

### Commands.FileTree
- Replaced `new_file/1` and `new_folder/1` stubs with real implementations
- Added `rename/1`, `confirm_editing/1`, `cancel_editing/1`
- Confirm dispatches on type: `:new_file` creates file + opens buffer, `:new_folder` creates directory, `:rename` does `File.rename` + updates open buffer paths
- Insertion position logic: inside directory if dir selected (auto-expands), sibling if file selected

### Input.FileTreeHandler
- Inline editing key interception as first clause in `handle_key/3`
- Enter confirms, Escape cancels, Backspace deletes (or cancels if empty), printable chars append
- All other keys swallowed (no leak to mode FSM)

### Keymap.Scope.FileTree
- `a` -> `:tree_new_file`, `A` -> `:tree_new_folder`, `R` -> `:tree_rename`
- "File Operations" help group added

## Testing

50 tests across 4 files:
- `file_tree_editing_test.exs` (state): 14 pure unit tests
- `file_tree_editing_input_test.exs` (input): 11 handler tests including unicode and key swallowing
- `file_tree_scope_test.exs` (keymap): 15 trie resolution tests
- `file_tree_editing_test.exs` (commands): 10 EditorCase tests with real filesystem ops

Closes #1299