### PR TITLE
feat(agent): flush dirty buffers to disk before shell commands (#395)

### DIFF
--- a/lib/minga/agent/providers/native.ex
+++ b/lib/minga/agent/providers/native.ex
@@ -1123,6 +1123,7 @@ defmodule Minga.Agent.Providers.Native do
   # Runs the shell tool with incremental output streaming via ToolUpdate events.
   @spec run_shell_with_streaming(map(), pid()) :: {String.t(), boolean()}
   defp run_shell_with_streaming(tool_call, provider_pid) do
+    flush_before_shell()
     args = tool_call.arguments
     root = detect_project_root()
     timeout_secs = min(args["timeout"] || 30, 300)
@@ -1704,5 +1705,30 @@ defmodule Minga.Agent.Providers.Native do
   defp notify(subscriber, event) do
     send(subscriber, {:agent_provider_event, event})
     event
+  end
+
+  # Saves all dirty file-backed buffers to disk before running shell commands.
+  # Build tools read from the filesystem, not from buffer memory, so in-memory
+  # edits must be flushed for the build to see them.
+  @spec flush_before_shell() :: :ok
+  defp flush_before_shell do
+    if Config.get(:agent_flush_before_shell) do
+      {saved, warnings} = Minga.Buffer.save_all_dirty()
+
+      if saved > 0 do
+        Minga.Log.debug(:agent, "Flushed #{saved} dirty buffer(s) to disk before shell command")
+      end
+
+      for warning <- warnings do
+        Minga.Log.warning(:agent, "Pre-shell flush: #{warning}")
+      end
+
+      :ok
+    else
+      :ok
+    end
+  rescue
+    # Config not available (headless/test mode)
+    _ -> :ok
   end
 end

--- a/lib/minga/agent/tools.ex
+++ b/lib/minga/agent/tools.ex
@@ -440,6 +440,7 @@ defmodule Minga.Agent.Tools do
         "required" => ["command"]
       },
       callback: fn args ->
+        flush_before_shell()
         timeout_secs = min(args["timeout"] || 30, 300)
         Shell.execute(args["command"], root, timeout_secs)
       end
@@ -895,6 +896,34 @@ defmodule Minga.Agent.Tools do
         LspCodeActions.execute(path, args["line"], opts)
       end
     )
+  end
+
+  # ── Pre-shell buffer flush ─────────────────────────────────────────────────
+
+  # Saves all dirty file-backed buffers to disk before running shell commands.
+  # Build tools read from the filesystem, not from buffer memory, so in-memory
+  # edits must be flushed for the build to see them. Gated by the
+  # :agent_flush_before_shell config option (default: true).
+  @spec flush_before_shell() :: :ok
+  defp flush_before_shell do
+    if Config.get(:agent_flush_before_shell) do
+      {saved, warnings} = Minga.Buffer.save_all_dirty()
+
+      if saved > 0 do
+        Minga.Log.debug(:agent, "Flushed #{saved} dirty buffer(s) to disk before shell command")
+      end
+
+      for warning <- warnings do
+        Minga.Log.warning(:agent, "Pre-shell flush: #{warning}")
+      end
+
+      :ok
+    else
+      :ok
+    end
+  rescue
+    # Config not available (headless/test mode)
+    _ -> :ok
   end
 
   # ── Diagnostic feedback ──────────────────────────────────────────────────────

--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -191,6 +191,45 @@ defmodule Minga.Buffer do
   @spec save(server()) :: :ok | {:error, term()}
   defdelegate save(server), to: Server
 
+  @doc """
+  Saves all dirty file-backed buffers to disk.
+
+  Enumerates the Buffer.Registry, filters for dirty buffers, and saves each one.
+  Read-only buffers and save failures are logged as warnings but do not block
+  other saves. Returns the count of successfully saved buffers and a list of
+  any warnings (path + error reason).
+  """
+  @spec save_all_dirty() :: {non_neg_integer(), [String.t()]}
+  def save_all_dirty do
+    pids = Registry.select(Minga.Buffer.Registry, [{{:_, :"$1", :_}, [], [:"$1"]}])
+
+    {saved, warnings} =
+      Enum.reduce(pids, {0, []}, fn pid, {count, warns} ->
+        save_if_dirty(pid, count, warns)
+      end)
+
+    {saved, Enum.reverse(warnings)}
+  end
+
+  @spec save_if_dirty(pid(), non_neg_integer(), [String.t()]) ::
+          {non_neg_integer(), [String.t()]}
+  defp save_if_dirty(pid, count, warns) do
+    if Process.alive?(pid) and Server.dirty?(pid) do
+      case Server.save(pid) do
+        :ok ->
+          {count + 1, warns}
+
+        {:error, reason} ->
+          path = Server.file_path(pid) || "unknown"
+          {count, ["failed to save #{path}: #{inspect(reason)}" | warns]}
+      end
+    else
+      {count, warns}
+    end
+  catch
+    :exit, _ -> {count, warns}
+  end
+
   @doc "Save even if the buffer appears clean."
   @spec force_save(server()) :: :ok | {:error, term()}
   defdelegate force_save(server), to: Server

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -130,6 +130,7 @@ defmodule Minga.Config.Options do
           | :agent_mention_max_file_size
           | :agent_notify_debounce
           | :agent_diagnostic_feedback
+          | :agent_flush_before_shell
           | :confirm_quit
           | :font_family
           | :font_size
@@ -228,6 +229,7 @@ defmodule Minga.Config.Options do
     {:agent_mention_max_file_size, :pos_integer, 262_144},
     {:agent_notify_debounce, :pos_integer, 5_000},
     {:agent_diagnostic_feedback, :boolean, true},
+    {:agent_flush_before_shell, :boolean, true},
     {:confirm_quit, :boolean, true},
     {:cursorline, :boolean, true},
     {:nav_flash, :boolean, true},

--- a/test/minga/buffer/save_all_dirty_test.exs
+++ b/test/minga/buffer/save_all_dirty_test.exs
@@ -1,0 +1,88 @@
+defmodule Minga.Buffer.SaveAllDirtyTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer
+  alias Minga.Buffer.Server
+
+  @moduletag :tmp_dir
+
+  defp start_file_buffer(path) do
+    start_supervised!({Server, file_path: path}, id: make_ref())
+  end
+
+  describe "save_all_dirty/0" do
+    test "saves dirty file-backed buffers to disk", %{tmp_dir: dir} do
+      a_path = Path.join(dir, "a.txt")
+      b_path = Path.join(dir, "b.txt")
+      File.write!(a_path, "original_a")
+      File.write!(b_path, "original_b")
+
+      buf_a = start_file_buffer(a_path)
+      buf_b = start_file_buffer(b_path)
+
+      :ok = Server.insert_text(buf_a, " MODIFIED_A")
+      :ok = Server.insert_text(buf_b, " MODIFIED_B")
+
+      assert Server.dirty?(buf_a)
+      assert Server.dirty?(buf_b)
+
+      {saved, _warnings} = Buffer.save_all_dirty()
+
+      # At least our two buffers were saved (others may exist from concurrent tests)
+      assert saved >= 2
+      assert File.read!(a_path) =~ "MODIFIED_A"
+      assert File.read!(b_path) =~ "MODIFIED_B"
+    end
+
+    test "does not write clean buffers to disk", %{tmp_dir: dir} do
+      path = Path.join(dir, "clean.txt")
+      File.write!(path, "original")
+
+      buf = start_file_buffer(path)
+      refute Server.dirty?(buf)
+
+      Buffer.save_all_dirty()
+
+      assert File.read!(path) == "original"
+    end
+
+    test "one buffer failing does not block other saves", %{tmp_dir: dir} do
+      writable_path = Path.join(dir, "writable.txt")
+      readonly_path = Path.join(dir, "readonly.txt")
+      File.write!(writable_path, "original")
+      File.write!(readonly_path, "original")
+
+      writable_buf = start_file_buffer(writable_path)
+      readonly_buf = start_file_buffer(readonly_path)
+
+      :ok = Server.insert_text(writable_buf, " MODIFIED")
+      :ok = Server.insert_text(readonly_buf, " MODIFIED")
+
+      # Make the file unwritable so save fails
+      File.chmod!(readonly_path, 0o000)
+      on_exit(fn -> File.chmod!(readonly_path, 0o644) end)
+
+      {saved, warnings} = Buffer.save_all_dirty()
+
+      # The writable buffer was saved successfully
+      assert saved >= 1
+      assert File.read!(writable_path) =~ "MODIFIED"
+
+      # The readonly buffer produced a warning
+      assert Enum.any?(warnings, &String.contains?(&1, "readonly.txt"))
+    end
+
+    test "saved buffers are no longer dirty", %{tmp_dir: dir} do
+      path = Path.join(dir, "dirty.txt")
+      File.write!(path, "original")
+
+      buf = start_file_buffer(path)
+      :ok = Server.insert_text(buf, " MODIFIED")
+      assert Server.dirty?(buf)
+
+      Buffer.save_all_dirty()
+
+      refute Server.dirty?(buf)
+    end
+  end
+end


### PR DESCRIPTION
## What

Saves all dirty file-backed buffers to disk before the agent's shell tool executes a command. Build tools (compilers, test runners, linters) read from the filesystem, not buffer memory, so in-memory agent edits must be flushed for them to see the changes.

## Why

Once agent tools route through `Buffer.Server` (#393), agent edits live in memory and the filesystem is stale. Without this flush, running `mix test` after an agent edits code would test the old version on disk.

## Changes

**`lib/minga/buffer.ex`**
- Added `save_all_dirty/0`: enumerates `Buffer.Registry`, filters dirty file-backed buffers, saves each one. Returns `{saved_count, warnings}`. Save failures produce warnings but don't block other saves.
- Added `save_if_dirty/3` helper with `catch :exit` for dead buffer processes.

**`lib/minga/agent/tools.ex`** and **`lib/minga/agent/providers/native.ex`**
- Added `flush_before_shell/0` to both shell execution paths (tool callback and streaming path). Checks the config option, calls `save_all_dirty/0`, logs results.

**`lib/minga/config/options.ex`**
- Added `:agent_flush_before_shell` config option (boolean, default `true`).

**Architecture decision:** Saves ALL dirty file-backed buffers, not just agent-modified ones. The tool callback closure (`fn args -> result end`) has no access to session state, so tracking which buffers the agent touched would require restructuring the tool API. Saving all dirty buffers is actually better: the agent should see the same files as the user, and users generally want their edits saved before `mix test` anyway.

## Tests

`test/minga/buffer/save_all_dirty_test.exs`:
- Saves dirty file-backed buffers to disk
- Skips clean buffers
- One buffer failing doesn't block others (warns instead)
- Saved buffers are no longer dirty

Depends on #393. Stacked on `feat/393-readfile-buffer-routing`.

Closes #395