### PR TITLE
feat(macos): rounded corners on block cursor

### DIFF
--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -41,6 +41,11 @@ struct CTUniformsGPU {
     var scrollOffset: SIMD2<Float> = .zero
 }
 
+/// Per-draw-call parameters for bg/cursor passes (must match BgParams in CoreTextShaders.metal).
+struct BgParamsGPU {
+    var cornerRadius: Float = 0.0
+}
+
 /// Default background clear color (dark gray matching the default bg).
 /// Linear equivalents of sRGB (0.12, 0.12, 0.14).
 private let ctBgClearColorDefault = MTLClearColor(red: 0.01298, green: 0.01298, blue: 0.01681, alpha: 1.0)
@@ -502,6 +507,11 @@ final class CoreTextMetalRenderer {
             scrollOffset: SIMD2<Float>(scrollOffset.x * scale, scrollOffset.y * scale)
         )
 
+        // Default fragment params: no corner radius (sharp rectangles).
+        // The cursor draw call overrides this with a nonzero radius.
+        var defaultBgParams = BgParamsGPU(cornerRadius: 0.0)
+        encoder.setFragmentBytes(&defaultBgParams, length: MemoryLayout<BgParamsGPU>.size, index: 0)
+
         // Pass 1: Background fills.
         if !bgQuads.isEmpty {
             encoder.setRenderPipelineState(bgPipeline)
@@ -541,10 +551,16 @@ final class CoreTextMetalRenderer {
             cursorQuad.color = cursorColor
             cursorQuad.alpha = 1.0
 
+            // Rounded corners on the block cursor (~3pt radius, snapped to backing pixels).
+            var cursorBgParams = BgParamsGPU(cornerRadius: round(3.0 * scale))
             encoder.setRenderPipelineState(bgPipeline)
             encoder.setVertexBytes(&cursorQuad, length: MemoryLayout<QuadGPU>.stride, index: 0)
             encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+            encoder.setFragmentBytes(&cursorBgParams, length: MemoryLayout<BgParamsGPU>.size, index: 0)
             encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+
+            // Restore default (no rounding) for subsequent draws.
+            encoder.setFragmentBytes(&defaultBgParams, length: MemoryLayout<BgParamsGPU>.size, index: 0)
         }
 
         // Pass 3: Line textures — one instanced draw call with the atlas texture.

--- a/macos/Sources/Renderer/CoreTextShaders.metal
+++ b/macos/Sources/Renderer/CoreTextShaders.metal
@@ -67,10 +67,18 @@ inline float3 srgbToLinear(float3 c) {
 
 // ── Background fill pass ──────────────────────────────────────────────────────
 
+/// Per-draw-call parameters for the background/cursor pass.
+/// Bound at fragment buffer(0). Non-cursor draws set cornerRadius = 0.
+struct BgParams {
+    float cornerRadius;
+};
+
 struct BgVertexOut {
     float4 position [[position]];
     float3 color;
     float alpha;
+    float2 localPos;    // [0,1] UV within the quad (for SDF)
+    float2 quadSize;    // quad size in pixels (for SDF)
 };
 
 vertex BgVertexOut ct_bg_vertex(
@@ -87,11 +95,34 @@ vertex BgVertexOut ct_bg_vertex(
     out.position = float4(pixelToNDC(pixel_pos, uniforms.viewport_size), 0.0, 1.0);
     out.color = quad.color;
     out.alpha = quad.alpha;
+    out.localPos = pos;         // unit quad UV, interpolates to [0,1]
+    out.quadSize = quad.size;   // pixel size, constant across quad vertices
     return out;
 }
 
-fragment float4 ct_bg_fragment(BgVertexOut in [[stage_in]]) {
-    return float4(srgbToLinear(in.color) * in.alpha, in.alpha);
+fragment float4 ct_bg_fragment(
+    BgVertexOut in [[stage_in]],
+    constant BgParams& params [[buffer(0)]]
+) {
+    float3 linearColor = srgbToLinear(in.color);
+    float alpha = in.alpha;
+
+    if (params.cornerRadius > 0.0) {
+        // SDF rounded rectangle in pixel space.
+        float2 pixelPos = in.localPos * in.quadSize;
+        float2 halfSize = in.quadSize * 0.5;
+        float r = params.cornerRadius;
+
+        // Signed distance from rounded rect boundary (negative = inside).
+        float2 d = abs(pixelPos - halfSize) - (halfSize - float2(r));
+        float dist = length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - r;
+
+        // 1px anti-aliased edge (subpixel on Retina).
+        alpha *= 1.0 - smoothstep(-0.5, 0.5, dist);
+    }
+
+    // Premultiplied alpha output.
+    return float4(linearColor * alpha, alpha);
 }
 
 // ── Line texture blit pass ────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Add SDF-based rounded corner rendering to the Metal block cursor, matching native macOS editor conventions (Zed, Nova, Xcode).

## Changes

- **`CoreTextShaders.metal`** — Added `BgParams` struct with `cornerRadius` field. Updated `BgVertexOut` with `localPos` and `quadSize` interpolants. Added SDF rounded-rect computation with smoothstep anti-aliasing in `ct_bg_fragment`.
- **`CoreTextMetalRenderer.swift`** — Added `BgParamsGPU` Swift mirror struct. Set default zero-radius params at encoder creation. Override to 3pt radius for the block cursor draw call only.

## Design Decisions

- **Per-draw-call uniform** instead of per-instance struct field. The cursor is already an isolated draw call, so `cornerRadius` is a constant, not a varying. This avoids bloating `QuadGPU` from 32 to 48 bytes for every bg fill quad.
- **No `discard_fragment()`** per project AGENTS.md. Uses premultiplied alpha with smoothstep for anti-aliased edges.
- **Beam and underline cursors stay sharp** (cornerRadius = 0). A 2px beam with rounding would look like a capsule.

## Acceptance Criteria (from #732)

- [x] Block cursor has ~2-3px rounded corners
- [x] Beam cursor (insert mode) and underline cursor remain unchanged
- [x] Cursor color continues to use system accent color (no regression)
- [x] Text under block cursor remains readable
- [x] Cursor rounding looks correct at all display scales (uses `round(3.0 * scale)`)

Closes #732