### PR TITLE
refactor(editor): centralize VimState and Workspace.State mutations (#1226)

### DIFF
--- a/credo/checks/no_direct_state_machine_write_check.exs
+++ b/credo/checks/no_direct_state_machine_write_check.exs
@@ -43,7 +43,13 @@ defmodule Minga.Credo.NoDirectStateMachineWriteCheck do
     category: :design,
     param_defaults: [
       gated_fields: [:mode],
-      allowed_files: ["vim_state.ex", "state.ex"]
+      guarded_struct_fields: [
+        # VimState fields: must use VimState.set_*/transition instead of direct writes
+        {:editing, [:mode_state, :marks, :last_jump_pos, :last_find_char, :macro_recorder, :change_recorder, :reg]},
+        # Workspace.State fields: must use WorkspaceState.set_* instead of direct writes
+        {:workspace, [:keymap_scope, :completion, :completion_trigger, :highlight, :mouse, :document_highlights, :search, :pending_conflict, :lsp_pending, :viewport, :windows, :buffers, :agent_ui, :injection_ranges, :editing]}
+      ],
+      allowed_files: ["vim_state.ex", "state.ex", "workspace/state.ex"]
     ],
     explanations: [
       check: """
@@ -54,9 +60,13 @@ defmodule Minga.Credo.NoDirectStateMachineWriteCheck do
 
       Use `EditorState.transition_mode(state, mode)` or
       `VimState.transition(vim, mode)` instead of setting `mode:` directly.
+
+      Use `WorkspaceState.set_completion(ws, completion)` instead of
+      `%{ws | completion: completion}`.
       """,
       params: [
         gated_fields: "List of field atoms to flag when set in map updates.",
+        guarded_struct_fields: "List of {parent_field, [child_fields]} tuples for nested struct checks.",
         allowed_files: "Filename suffixes where direct writes are permitted (gate function homes)."
       ]
     ]

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -63,6 +63,8 @@ defmodule Minga.Editor do
   alias Minga.Agent.Session, as: AgentSession
 
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.VimState
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.Editor.State.LSP, as: LSPState
   alias Minga.Editor.State.Session, as: SessionState
 
@@ -359,9 +361,11 @@ defmodule Minga.Editor do
     caps = Startup.fetch_capabilities(state.port_manager)
 
     new_state = %{
-      state
-      | workspace: %{state.workspace | viewport: Viewport.new(height, width)},
-        capabilities: caps,
+      EditorState.update_workspace(
+        state,
+        &WorkspaceState.set_viewport(&1, Viewport.new(height, width))
+      )
+      | capabilities: caps,
         layout: nil
     }
 
@@ -394,7 +398,12 @@ defmodule Minga.Editor do
   end
 
   def handle_info({:minga_input, {:resize, width, height}}, state) do
-    new_state = %{state | workspace: %{state.workspace | viewport: Viewport.new(height, width)}}
+    new_state =
+      EditorState.update_workspace(
+        state,
+        &WorkspaceState.set_viewport(&1, Viewport.new(height, width))
+      )
+
     # Invalidate the cached layout so resize_all_windows computes fresh
     # rectangles from the new viewport dimensions.
     new_state = Layout.invalidate(new_state)
@@ -828,7 +837,8 @@ defmodule Minga.Editor do
     new_bridge =
       CompletionTrigger.flush_debounce(state.workspace.completion_trigger, clients, buffer_pid)
 
-    {:noreply, %{state | workspace: %{state.workspace | completion_trigger: new_bridge}}}
+    {:noreply,
+     EditorState.update_workspace(state, &WorkspaceState.set_completion_trigger(&1, new_bridge))}
   end
 
   # LSP async response — route to the appropriate handler based on lsp.pending
@@ -1853,7 +1863,7 @@ defmodule Minga.Editor do
         updated = %{comp | selected: index}
 
         do_accept_completion(
-          %{state | workspace: %{state.workspace | completion: updated}},
+          EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, updated)),
           updated
         )
 
@@ -1997,14 +2007,7 @@ defmodule Minga.Editor do
 
           %{label: label} ->
             new_ms = %{ms | input: label, candidate_index: 0}
-
-            %{
-              state
-              | workspace: %{
-                  state.workspace
-                  | editing: %{state.workspace.editing | mode_state: new_ms}
-                }
-            }
+            set_vim_mode_state(state, new_ms)
         end
 
       _ ->
@@ -2317,4 +2320,11 @@ defmodule Minga.Editor do
   defdelegate do_dismiss_completion(state), to: CompletionHandling, as: :dismiss
 
   # Sets the manual workspace label to the project directory name.
+
+  @spec set_vim_mode_state(state(), term()) :: state()
+  defp set_vim_mode_state(state, new_ms) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_mode_state(&1, new_ms))
+    end)
+  end
 end

--- a/lib/minga/editor/commands/editing.ex
+++ b/lib/minga/editor/commands/editing.ex
@@ -14,6 +14,8 @@ defmodule Minga.Editor.Commands.Editing do
   alias Minga.Editor.Indent
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Registers
+  alias Minga.Editor.VimState
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.Mode
   alias Minga.Mode.ReplaceState
   alias Minga.Mode.VisualState
@@ -230,10 +232,9 @@ defmodule Minga.Editor.Commands.Editing do
     Buffer.insert_char(buf, char)
     new_ms = %{ms | original_chars: [original | ms.original_chars]}
 
-    %{
-      state
-      | workspace: %{state.workspace | editing: %{state.workspace.editing | mode_state: new_ms}}
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_mode_state(&1, new_ms))
+    end)
   end
 
   def execute(state, {:replace_overwrite, _char}), do: state
@@ -252,10 +253,9 @@ defmodule Minga.Editor.Commands.Editing do
     Buffer.move(buf, :left)
     new_ms = %{ms | original_chars: rest}
 
-    %{
-      state
-      | workspace: %{state.workspace | editing: %{state.workspace.editing | mode_state: new_ms}}
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_mode_state(&1, new_ms))
+    end)
   end
 
   def execute(

--- a/lib/minga/editor/commands/file_tree.ex
+++ b/lib/minga/editor/commands/file_tree.ex
@@ -11,6 +11,7 @@ defmodule Minga.Editor.Commands.FileTree do
   alias Minga.Editor.Layout
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.FileTree, as: FileTreeState
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.BufferSync
 
@@ -23,27 +24,25 @@ defmodule Minga.Editor.Commands.FileTree do
   def toggle(%{workspace: %{file_tree: %{buffer: buf}}} = state) when is_pid(buf) do
     GenServer.stop(buf, :normal)
 
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | file_tree: FileTreeState.close(state.workspace.file_tree),
-            keymap_scope: restore_scope(state)
-        }
-    }
+    scope = restore_scope(state)
+
+    EditorState.update_workspace(state, fn ws ->
+      ws
+      |> Map.put(:file_tree, FileTreeState.close(ws.file_tree))
+      |> WorkspaceState.set_keymap_scope(scope)
+    end)
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end
 
   def toggle(state) do
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | file_tree: FileTreeState.close(state.workspace.file_tree),
-            keymap_scope: restore_scope(state)
-        }
-    }
+    scope = restore_scope(state)
+
+    EditorState.update_workspace(state, fn ws ->
+      ws
+      |> Map.put(:file_tree, FileTreeState.close(ws.file_tree))
+      |> WorkspaceState.set_keymap_scope(scope)
+    end)
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end
@@ -64,7 +63,7 @@ defmodule Minga.Editor.Commands.FileTree do
         state = put_in(state.workspace.file_tree.focused, false)
         # Opening a file buffer always uses :editor scope (not restore_scope)
         # because the new buffer becomes the active window content.
-        state = %{state | workspace: %{state.workspace | keymap_scope: :editor}}
+        state = EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor))
         open_file_from_tree(state, path, tree)
 
       nil ->
@@ -164,7 +163,7 @@ defmodule Minga.Editor.Commands.FileTree do
         state = sync_and_update(state, tree)
         state = put_in(state.workspace.file_tree.focused, true)
 
-        %{state | workspace: %{state.workspace | keymap_scope: :file_tree}}
+        EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :file_tree))
         |> Layout.invalidate()
         |> EditorState.invalidate_all_windows()
     end
@@ -182,25 +181,24 @@ defmodule Minga.Editor.Commands.FileTree do
   def close(%{workspace: %{file_tree: %{buffer: buf}}} = state) when is_pid(buf) do
     GenServer.stop(buf, :normal)
 
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | file_tree: FileTreeState.close(state.workspace.file_tree),
-            keymap_scope: restore_scope(state)
-        }
-    }
+    scope = restore_scope(state)
+
+    EditorState.update_workspace(state, fn ws ->
+      ws
+      |> Map.put(:file_tree, FileTreeState.close(ws.file_tree))
+      |> WorkspaceState.set_keymap_scope(scope)
+    end)
   end
 
-  def close(state),
-    do: %{
-      state
-      | workspace: %{
-          state.workspace
-          | file_tree: FileTreeState.close(state.workspace.file_tree),
-            keymap_scope: restore_scope(state)
-        }
-    }
+  def close(state) do
+    scope = restore_scope(state)
+
+    EditorState.update_workspace(state, fn ws ->
+      ws
+      |> Map.put(:file_tree, FileTreeState.close(ws.file_tree))
+      |> WorkspaceState.set_keymap_scope(scope)
+    end)
+  end
 
   # ── Private helpers ───────────────────────────────────────────────────────
 
@@ -212,10 +210,9 @@ defmodule Minga.Editor.Commands.FileTree do
 
   defp close_git_status_if_open(state),
     do:
-      EditorState.close_git_status_panel(%{
-        state
-        | workspace: %{state.workspace | keymap_scope: :editor}
-      })
+      state
+      |> EditorState.update_workspace(&WorkspaceState.set_keymap_scope(&1, :editor))
+      |> EditorState.close_git_status_panel()
 
   # Opens a file from the tree, reusing an existing buffer when one exists
   # for the same path. Without the dedup check, the file tree creates
@@ -264,14 +261,11 @@ defmodule Minga.Editor.Commands.FileTree do
     tree = reveal_active(tree, state.workspace.buffers.active)
     buf = BufferSync.start_buffer(tree)
 
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | file_tree: FileTreeState.open(state.workspace.file_tree, tree, buf),
-            keymap_scope: :file_tree
-        }
-    }
+    EditorState.update_workspace(state, fn ws ->
+      ws
+      |> Map.put(:file_tree, FileTreeState.open(ws.file_tree, tree, buf))
+      |> WorkspaceState.set_keymap_scope(:file_tree)
+    end)
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end

--- a/lib/minga/editor/commands/git.ex
+++ b/lib/minga/editor/commands/git.ex
@@ -13,6 +13,7 @@ defmodule Minga.Editor.Commands.Git do
   alias Minga.Editor.PickerUI
   alias Minga.Editor.State, as: EditorState
   alias Minga.Git
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.Language
   alias Minga.UI.Picker.GitChangedSource
 
@@ -40,7 +41,7 @@ defmodule Minga.Editor.Commands.Git do
 
   def execute(state, :git_status_toggle) do
     if state.workspace.keymap_scope == :git_status do
-      state = %{state | workspace: %{state.workspace | keymap_scope: :editor}}
+      state = EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor))
       EditorState.close_git_status_panel(state)
     else
       open_git_status_panel(state)
@@ -330,7 +331,9 @@ defmodule Minga.Editor.Commands.Git do
         # Mutual exclusivity: close file tree when opening git status
         state = close_file_tree_if_open(state)
 
-        state = %{state | workspace: %{state.workspace | keymap_scope: :git_status}}
+        state =
+          EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :git_status))
+
         EditorState.set_git_status_panel(state, panel_data)
     end
   end

--- a/lib/minga/editor/commands/marks.ex
+++ b/lib/minga/editor/commands/marks.ex
@@ -10,7 +10,9 @@ defmodule Minga.Editor.Commands.Marks do
   alias Minga.Buffer.Document
   alias Minga.Editor.Commands.Helpers
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.VimState
   alias Minga.Mode
+  alias Minga.Workspace.State, as: WorkspaceState
 
   @type state :: EditorState.t()
 
@@ -30,10 +32,9 @@ defmodule Minga.Editor.Commands.Marks do
     buf_marks = Map.get(marks, buf, %{})
     new_marks = Map.put(marks, buf, Map.put(buf_marks, char, pos))
 
-    %{
-      state
-      | workspace: %{state.workspace | editing: %{state.workspace.editing | marks: new_marks}}
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_marks(&1, new_marks))
+    end)
   end
 
   def execute(
@@ -87,13 +88,9 @@ defmodule Minga.Editor.Commands.Marks do
     target = Minga.Editing.first_non_blank(tmp_buf, {last_line, 0})
     Buffer.move_to(buf, target)
 
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | editing: %{state.workspace.editing | last_jump_pos: current_pos}
-        }
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_last_jump_pos(&1, current_pos))
+    end)
   end
 
   def execute(state, :jump_to_last_pos_line), do: state
@@ -106,13 +103,9 @@ defmodule Minga.Editor.Commands.Marks do
     current_pos = Buffer.cursor(buf)
     Buffer.move_to(buf, last_pos)
 
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | editing: %{state.workspace.editing | last_jump_pos: current_pos}
-        }
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_last_jump_pos(&1, current_pos))
+    end)
   end
 
   def execute(state, :jump_to_last_pos_exact), do: state

--- a/lib/minga/editor/commands/movement.ex
+++ b/lib/minga/editor/commands/movement.ex
@@ -14,7 +14,9 @@ defmodule Minga.Editor.Commands.Movement do
   alias Minga.Editor.FoldMap
   alias Minga.Editor.Layout
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.VimState
   alias Minga.Editor.Viewport
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.Editor.Window
   alias Minga.Editor.WindowTree
   alias Minga.Mode
@@ -243,13 +245,9 @@ defmodule Minga.Editor.Commands.Movement do
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, {:find_char, dir, char}) do
     Helpers.apply_find_char(buf, dir, char)
 
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | editing: %{state.workspace.editing | last_find_char: {dir, char}}
-        }
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_last_find_char(&1, {dir, char}))
+    end)
   end
 
   def execute(
@@ -478,7 +476,7 @@ defmodule Minga.Editor.Commands.Movement do
   defp navigate_window(%{workspace: %{file_tree: %{focused: true}}} = state, :right) do
     state = put_in(state.workspace.file_tree.focused, false)
     scope = EditorState.scope_for_active_window(state)
-    %{state | workspace: %{state.workspace | keymap_scope: scope}}
+    EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, scope))
   end
 
   defp navigate_window(state, direction) do
@@ -505,7 +503,7 @@ defmodule Minga.Editor.Commands.Movement do
          :left
        ) do
     state = put_in(state.workspace.file_tree.focused, true)
-    %{state | workspace: %{state.workspace | keymap_scope: :file_tree}}
+    EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :file_tree))
   end
 
   defp maybe_focus_file_tree(state, _direction), do: state

--- a/lib/minga/editor/commands/search.ex
+++ b/lib/minga/editor/commands/search.ex
@@ -13,6 +13,7 @@ defmodule Minga.Editor.Commands.Search do
   alias Minga.Editor.PickerUI
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.Window
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.Mode
   alias Minga.Mode.SearchState
   alias Minga.Project.ProjectSearch
@@ -416,10 +417,9 @@ defmodule Minga.Editor.Commands.Search do
   end
 
   defp put_in_search(state, :last_direction, value) do
-    %{
-      state
-      | workspace: %{state.workspace | search: %{state.workspace.search | last_direction: value}}
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_search(ws, fn s -> %{s | last_direction: value} end)
+    end)
   end
 
   # Replace a match at a specific line/col/length in content string.

--- a/lib/minga/editor/commands/visual.ex
+++ b/lib/minga/editor/commands/visual.ex
@@ -11,7 +11,9 @@ defmodule Minga.Editor.Commands.Visual do
   alias Minga.Editor.Commands.Helpers
   alias Minga.Editor.HighlightSync
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.VimState
   alias Minga.Mode
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.Mode.VisualState
 
   @type state :: EditorState.t()
@@ -125,7 +127,11 @@ defmodule Minga.Editor.Commands.Visual do
         # Update visual anchor to start of text object, move cursor to end
         new_ms = %{ms | visual_anchor: start_pos}
         Buffer.move_to(buf, end_pos)
-        %{state | workspace: %{state.workspace | editing: %{vim | mode_state: new_ms}}}
+
+        EditorState.update_workspace(
+          state,
+          &WorkspaceState.set_editing(&1, VimState.set_mode_state(vim, new_ms))
+        )
     end
   end
 

--- a/lib/minga/editor/completion_handling.ex
+++ b/lib/minga/editor/completion_handling.ex
@@ -15,6 +15,7 @@ defmodule Minga.Editor.CompletionHandling do
   alias Minga.Editor.SignatureHelp
   alias Minga.Editor.State, as: EditorState
   alias Minga.LSP.Client
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.LSP.SyncServer
 
   @resolve_debounce_ms 150
@@ -47,7 +48,7 @@ defmodule Minga.Editor.CompletionHandling do
         Process.send_after(self(), {:completion_resolve, selected_idx}, @resolve_debounce_ms)
 
       completion = %{completion | resolve_timer: timer}
-      %{state | workspace: %{state.workspace | completion: completion}}
+      EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, completion))
     end
   end
 
@@ -99,7 +100,7 @@ defmodule Minga.Editor.CompletionHandling do
     doc_text = extract_resolve_documentation(resolved)
     completion = Completion.update_selected_documentation(completion, doc_text)
     completion = %{completion | last_resolved_index: completion.selected}
-    %{state | workspace: %{state.workspace | completion: completion}}
+    EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, completion))
   end
 
   @doc """
@@ -152,7 +153,7 @@ defmodule Minga.Editor.CompletionHandling do
     end
 
     new_bridge = CompletionTrigger.dismiss(state.workspace.completion_trigger)
-    %{state | workspace: %{state.workspace | completion: nil, completion_trigger: new_bridge}}
+    EditorState.update_workspace(state, &WorkspaceState.clear_completion(&1, new_bridge))
   end
 
   # ── Private helpers ────────────────────────────────────────────────────────
@@ -230,7 +231,7 @@ defmodule Minga.Editor.CompletionHandling do
     filtered = Completion.filter(completion, prefix)
 
     if Completion.active?(filtered) do
-      %{state | workspace: %{state.workspace | completion: filtered}}
+      EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, filtered))
     else
       dismiss(state)
     end
@@ -246,7 +247,10 @@ defmodule Minga.Editor.CompletionHandling do
         {new_bridge, _comp} =
           CompletionTrigger.maybe_trigger(state.workspace.completion_trigger, char, buf)
 
-        %{state | workspace: %{state.workspace | completion_trigger: new_bridge}}
+        EditorState.update_workspace(
+          state,
+          &WorkspaceState.set_completion_trigger(&1, new_bridge)
+        )
     end
   end
 
@@ -380,7 +384,7 @@ defmodule Minga.Editor.CompletionHandling do
     completion = Completion.filter(completion, prefix)
 
     if Completion.active?(completion) do
-      %{state | workspace: %{state.workspace | completion: completion}}
+      EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, completion))
     else
       state
     end
@@ -481,7 +485,8 @@ defmodule Minga.Editor.CompletionHandling do
         buffer_pid
       )
 
-    new_state = %{state | workspace: %{state.workspace | completion_trigger: new_bridge}}
+    new_state =
+      EditorState.update_workspace(state, &WorkspaceState.set_completion_trigger(&1, new_bridge))
 
     case completion do
       nil ->
@@ -513,7 +518,7 @@ defmodule Minga.Editor.CompletionHandling do
           CompletionTrigger.get_typed_since_trigger(state.workspace.buffers.active, trigger_pos)
 
         completion = Completion.filter(completion, prefix)
-        %{state | workspace: %{state.workspace | completion: completion}}
+        EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, completion))
 
       %Completion{} = existing ->
         # Merge into existing completion
@@ -527,7 +532,7 @@ defmodule Minga.Editor.CompletionHandling do
           )
 
         completion = Completion.filter(completion, prefix)
-        %{state | workspace: %{state.workspace | completion: completion}}
+        EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, completion))
     end
   end
 

--- a/lib/minga/editor/editing.ex
+++ b/lib/minga/editor/editing.ex
@@ -15,7 +15,9 @@ defmodule Minga.Editor.Editing do
   alias Minga.Editor.MacroRecorder
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Registers
+  alias Minga.Editor.VimState
   alias Minga.Mode
+  alias Minga.Workspace.State, as: WorkspaceState
 
   # ── Vim-specific reads ─────────────────────────────────────────────────────
 
@@ -116,6 +118,8 @@ defmodule Minga.Editor.Editing do
   @spec save_jump_pos(EditorState.t(), {non_neg_integer(), non_neg_integer()}) ::
           EditorState.t()
   def save_jump_pos(%EditorState{} = state, pos) do
-    put_in(state.workspace.editing.last_jump_pos, pos)
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_last_jump_pos(&1, pos))
+    end)
   end
 end

--- a/lib/minga/editor/file_watcher_helpers.ex
+++ b/lib/minga/editor/file_watcher_helpers.ex
@@ -10,6 +10,7 @@ defmodule Minga.Editor.FileWatcherHelpers do
   alias Minga.Buffer
   alias Minga.Editor.State, as: EditorState
   alias Minga.FileWatcher
+  alias Minga.Workspace.State, as: WorkspaceState
 
   @type state :: EditorState.t()
 
@@ -73,7 +74,9 @@ defmodule Minga.Editor.FileWatcherHelpers do
   defp handle_change(state, buf, path, _buf_state, _mtime, _size) do
     name = Path.basename(path)
 
-    state = %{state | workspace: %{state.workspace | pending_conflict: {buf, path}}}
+    state =
+      EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, {buf, path}))
+
     EditorState.set_status(state, "#{name} changed on disk. [r]eload / [k]eep")
   end
 

--- a/lib/minga/editor/highlight_sync.ex
+++ b/lib/minga/editor/highlight_sync.ex
@@ -9,6 +9,7 @@ defmodule Minga.Editor.HighlightSync do
   alias Minga.Buffer
   alias Minga.Editor.State, as: EditorState
   alias Minga.Frontend.Protocol
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.Parser.Manager, as: ParserManager
   alias Minga.UI.Highlight
   alias Minga.UI.Highlight.Grammar
@@ -86,10 +87,11 @@ defmodule Minga.Editor.HighlightSync do
         parse_cmd = Protocol.encode_parse_buffer(buffer_id, version, content)
         ParserManager.send_commands([parse_cmd])
 
-        state = %{
-          state
-          | workspace: %{state.workspace | highlight: %{hl | version: version}}
-        }
+        state =
+          EditorState.update_workspace(
+            state,
+            &WorkspaceState.update_highlight(&1, fn h -> %{h | version: version} end)
+          )
 
         touch_buffer(state, buf_pid)
 
@@ -212,7 +214,11 @@ defmodule Minga.Editor.HighlightSync do
     hl = state.workspace.highlight
     now = System.monotonic_time(:millisecond)
     timestamps = Map.put(hl.last_active_at, buf_pid, now)
-    %{state | workspace: %{state.workspace | highlight: %{hl | last_active_at: timestamps}}}
+
+    EditorState.update_workspace(
+      state,
+      &WorkspaceState.update_highlight(&1, fn h -> %{h | last_active_at: timestamps} end)
+    )
   end
 
   @spec send_parse_only(EditorState.t(), String.t()) :: EditorState.t()
@@ -313,7 +319,7 @@ defmodule Minga.Editor.HighlightSync do
         next_buffer_id: id + 1
     }
 
-    {id, %{state | workspace: %{state.workspace | highlight: new_hl}}}
+    {id, EditorState.update_workspace(state, &WorkspaceState.set_highlight(&1, new_hl))}
   end
 
   @doc """
@@ -479,7 +485,12 @@ defmodule Minga.Editor.HighlightSync do
 
     ParserManager.send_commands(commands)
 
-    state = %{state | workspace: %{state.workspace | highlight: %{hl | version: version}}}
+    state =
+      EditorState.update_workspace(
+        state,
+        &WorkspaceState.update_highlight(&1, fn h -> %{h | version: version} end)
+      )
+
     touch_active(state)
   end
 
@@ -506,7 +517,11 @@ defmodule Minga.Editor.HighlightSync do
     hl = state.workspace.highlight
     now = System.monotonic_time(:millisecond)
     timestamps = Map.put(hl.last_active_at, state.workspace.buffers.active, now)
-    %{state | workspace: %{state.workspace | highlight: %{hl | last_active_at: timestamps}}}
+
+    EditorState.update_workspace(
+      state,
+      &WorkspaceState.update_highlight(&1, fn h -> %{h | last_active_at: timestamps} end)
+    )
   end
 
   @doc """
@@ -588,7 +603,7 @@ defmodule Minga.Editor.HighlightSync do
     new_hl =
       compute_post_eviction_state(state.workspace.highlight, evicted_ids, remaining_timestamps)
 
-    %{state | workspace: %{state.workspace | highlight: new_hl}}
+    EditorState.update_workspace(state, &WorkspaceState.set_highlight(&1, new_hl))
   end
 
   # Pure calculation: produces the new Highlighting struct with evicted entries removed.

--- a/lib/minga/editor/layout_preset.ex
+++ b/lib/minga/editor/layout_preset.ex
@@ -28,6 +28,7 @@ defmodule Minga.Editor.LayoutPreset do
 
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.Window
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.Editor.Window.Content
   alias Minga.Editor.WindowTree
 
@@ -72,12 +73,12 @@ defmodule Minga.Editor.LayoutPreset do
       {:ok, new_tree} ->
         map = Map.delete(state.workspace.windows.map, agent_win_id)
         windows = %{state.workspace.windows | tree: new_tree, map: map}
-        state = %{state | workspace: %{state.workspace | windows: windows}}
+        state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, windows))
 
         # If we were in agent scope, return to editor scope since the
         # agent pane is gone.
         if state.workspace.keymap_scope == :agent do
-          %{state | workspace: %{state.workspace | keymap_scope: :editor}}
+          EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor))
         else
           state
         end
@@ -147,7 +148,7 @@ defmodule Minga.Editor.LayoutPreset do
               next_id: next_id + 1
           }
 
-          %{state | workspace: %{state.workspace | windows: windows}}
+          EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, windows))
 
         :error ->
           state

--- a/lib/minga/editor/lsp_actions.ex
+++ b/lib/minga/editor/lsp_actions.ex
@@ -33,6 +33,7 @@ defmodule Minga.Editor.LspActions do
   alias Minga.Editor.State.LSP, as: LSPState
   alias Minga.Editor.VimState
   alias Minga.Log
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.LSP.Client
   alias Minga.LSP.DocumentHighlight
   alias Minga.LSP.SyncServer
@@ -461,9 +462,8 @@ defmodule Minga.Editor.LspActions do
     vim = VimState.transition(state.workspace.editing, :normal)
 
     %{
-      state
-      | workspace: %{state.workspace | editing: vim},
-        lsp: LSPState.clear_selection_ranges(state.lsp)
+      EditorState.update_workspace(state, &WorkspaceState.set_editing(&1, vim))
+      | lsp: LSPState.clear_selection_ranges(state.lsp)
     }
   end
 
@@ -786,20 +786,20 @@ defmodule Minga.Editor.LspActions do
   """
   @spec handle_document_highlight_response(state(), {:ok, term()} | {:error, term()}) :: state()
   def handle_document_highlight_response(state, {:error, _error}) do
-    %{state | workspace: %{state.workspace | document_highlights: nil}}
+    EditorState.update_workspace(state, &WorkspaceState.set_document_highlights(&1, nil))
   end
 
   def handle_document_highlight_response(state, {:ok, nil}) do
-    %{state | workspace: %{state.workspace | document_highlights: nil}}
+    EditorState.update_workspace(state, &WorkspaceState.set_document_highlights(&1, nil))
   end
 
   def handle_document_highlight_response(state, {:ok, []}) do
-    %{state | workspace: %{state.workspace | document_highlights: nil}}
+    EditorState.update_workspace(state, &WorkspaceState.set_document_highlights(&1, nil))
   end
 
   def handle_document_highlight_response(state, {:ok, highlights}) when is_list(highlights) do
     parsed = Enum.map(highlights, &DocumentHighlight.from_lsp/1)
-    %{state | workspace: %{state.workspace | document_highlights: parsed}}
+    EditorState.update_workspace(state, &WorkspaceState.set_document_highlights(&1, parsed))
   end
 
   # ── Code action response ──────────────────────────────────────────────────
@@ -853,7 +853,7 @@ defmodule Minga.Editor.LspActions do
     # The ex-command parser handles "rename <new_name>" → {:rename, new_name}
     command_state = %CommandState{input: "rename #{placeholder}"}
     vim = VimState.transition(state.workspace.editing, :command, command_state)
-    %{state | workspace: %{state.workspace | editing: vim}}
+    EditorState.update_workspace(state, &WorkspaceState.set_editing(&1, vim))
   end
 
   @doc """
@@ -1414,10 +1414,9 @@ defmodule Minga.Editor.LspActions do
   defp set_jump_mark(%{workspace: %{buffers: %{active: buf}}} = state) when is_pid(buf) do
     pos = Buffer.cursor(buf)
 
-    %{
-      state
-      | workspace: %{state.workspace | editing: %{state.workspace.editing | last_jump_pos: pos}}
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_last_jump_pos(&1, pos))
+    end)
   end
 
   defp set_jump_mark(state), do: state
@@ -1806,7 +1805,7 @@ defmodule Minga.Editor.LspActions do
       }
 
       vim = VimState.transition(state.workspace.editing, :visual, visual_state)
-      %{state | workspace: %{state.workspace | editing: vim}}
+      EditorState.update_workspace(state, &WorkspaceState.set_editing(&1, vim))
     else
       state
     end

--- a/lib/minga/editor/mouse.ex
+++ b/lib/minga/editor/mouse.ex
@@ -37,6 +37,7 @@ defmodule Minga.Editor.Mouse do
   alias Minga.Editor.Renderer.Gutter
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Mouse, as: MouseState
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.Editor.State.WhichKey, as: WhichKeyState
   alias Minga.Editor.Viewport
   alias Minga.Editor.Window
@@ -215,10 +216,10 @@ defmodule Minga.Editor.Mouse do
         :release,
         _cc
       ) do
-    %{
-      state
-      | workspace: %{state.workspace | mouse: MouseState.stop_resize(state.workspace.mouse)}
-    }
+    EditorState.update_workspace(
+      state,
+      &WorkspaceState.set_mouse(&1, MouseState.stop_resize(&1.mouse))
+    )
   end
 
   def handle(
@@ -230,10 +231,11 @@ defmodule Minga.Editor.Mouse do
         :release,
         _cc
       ) do
-    state = %{
-      state
-      | workspace: %{state.workspace | mouse: MouseState.stop_drag(state.workspace.mouse)}
-    }
+    state =
+      EditorState.update_workspace(
+        state,
+        &WorkspaceState.set_mouse(&1, MouseState.stop_drag(&1.mouse))
+      )
 
     # Auto-copy selection to system clipboard on mouse release.
     # Standard terminal behavior: selecting text copies it.
@@ -249,7 +251,10 @@ defmodule Minga.Editor.Mouse do
         :release,
         _cc
       ) do
-    %{state | workspace: %{state.workspace | mouse: MouseState.stop_drag(state.workspace.mouse)}}
+    EditorState.update_workspace(
+      state,
+      &WorkspaceState.set_mouse(&1, MouseState.stop_drag(&1.mouse))
+    )
   end
 
   # ── Mouse motion (hover tracking) ──
@@ -283,7 +288,7 @@ defmodule Minga.Editor.Mouse do
   defp handle_left_press(state, row, col, mods, native_click_count) do
     # Record press for multi-click detection
     mouse = MouseState.record_press(state.workspace.mouse, row, col, native_click_count)
-    state = %{state | workspace: %{state.workspace | mouse: mouse}}
+    state = EditorState.update_workspace(state, &WorkspaceState.set_mouse(&1, mouse))
     click_count = mouse.click_count
 
     # Check modifier clicks first

--- a/lib/minga/editor/render_pipeline/content.ex
+++ b/lib/minga/editor/render_pipeline/content.ex
@@ -23,6 +23,7 @@ defmodule Minga.Editor.RenderPipeline.Content do
   alias Minga.Editor.RenderPipeline.Scroll.WindowScroll
   alias Minga.Editor.SemanticWindow
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.Editor.Viewport
   alias Minga.Editor.Window
 
@@ -227,10 +228,10 @@ defmodule Minga.Editor.RenderPipeline.Content do
 
     new_map = Map.put(state.workspace.windows.map, scroll.win_id, updated_window)
 
-    state = %{
-      state
-      | workspace: %{state.workspace | windows: %{state.workspace.windows | map: new_map}}
-    }
+    state =
+      EditorState.update_workspace(state, fn ws ->
+        WorkspaceState.set_windows(ws, %{ws.windows | map: new_map})
+      end)
 
     {win_frame, cursor_info, state}
   end

--- a/lib/minga/editor/semantic_token_sync.ex
+++ b/lib/minga/editor/semantic_token_sync.ex
@@ -27,6 +27,7 @@ defmodule Minga.Editor.SemanticTokenSync do
   alias Minga.Buffer
   alias Minga.Editor.State, as: EditorState
   alias Minga.LSP.Client
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.LSP.SemanticTokens
   alias Minga.UI.Highlight
 
@@ -50,7 +51,7 @@ defmodule Minga.Editor.SemanticTokenSync do
       uri = "file://#{file_path}"
       ref = Client.request_semantic_tokens(client, uri)
       pending = Map.put(state.workspace.lsp_pending, ref, {:semantic_tokens, buf_pid})
-      %{state | workspace: %{state.workspace | lsp_pending: pending}}
+      EditorState.update_workspace(state, &WorkspaceState.set_lsp_pending(&1, pending))
     else
       _ -> state
     end

--- a/lib/minga/editor/state.ex
+++ b/lib/minga/editor/state.ex
@@ -336,13 +336,14 @@ defmodule Minga.Editor.State do
         help: help
     }
 
-    state = %{state | workspace: %{state.workspace | buffers: new_bs}, buffer_monitors: monitors}
+    state = %{
+      update_workspace(state, &WorkspaceState.set_buffers(&1, new_bs))
+      | buffer_monitors: monitors
+    }
 
     # Clear agent buffer or prompt buffer if the dead pid matches
-    agent = state.shell_state.agent
-
     state =
-      if agent != nil and agent.buffer == pid do
+      if state.shell_state.agent.buffer == pid do
         AgentAccess.update_agent(state, fn a -> %{a | buffer: nil} end)
       else
         state

--- a/lib/minga/editor/vim_state.ex
+++ b/lib/minga/editor/vim_state.ex
@@ -97,4 +97,54 @@ defmodule Minga.Editor.VimState do
           "Mode #{inspect(mode)} requires an explicit mode_state argument. " <>
             "Call VimState.transition(vim, #{inspect(mode)}, mode_state) instead."
   end
+
+  # ── Field mutation functions (Rule 2 enforcement) ──────────────────────
+
+  @doc "Updates mode_state without changing the mode."
+  @spec set_mode_state(t(), Mode.state()) :: t()
+  def set_mode_state(%__MODULE__{} = vim, mode_state) do
+    %{vim | mode_state: mode_state}
+  end
+
+  @doc "Sets the marks map for a specific buffer."
+  @spec set_buffer_marks(t(), pid(), %{String.t() => Buffer.position()}) :: t()
+  def set_buffer_marks(%__MODULE__{marks: marks} = vim, buf_pid, buf_marks) do
+    %{vim | marks: Map.put(marks, buf_pid, buf_marks)}
+  end
+
+  @doc "Replaces the entire marks map."
+  @spec set_marks(t(), marks()) :: t()
+  def set_marks(%__MODULE__{} = vim, marks) do
+    %{vim | marks: marks}
+  end
+
+  @doc "Records the cursor position before a jump."
+  @spec set_last_jump_pos(t(), Buffer.position() | nil) :: t()
+  def set_last_jump_pos(%__MODULE__{} = vim, pos) do
+    %{vim | last_jump_pos: pos}
+  end
+
+  @doc "Records the last f/F/t/T char for ; and , repeat."
+  @spec set_last_find_char(t(), last_find_char()) :: t()
+  def set_last_find_char(%__MODULE__{} = vim, find_char) do
+    %{vim | last_find_char: find_char}
+  end
+
+  @doc "Updates the macro recorder state."
+  @spec set_macro_recorder(t(), MacroRecorder.t()) :: t()
+  def set_macro_recorder(%__MODULE__{} = vim, recorder) do
+    %{vim | macro_recorder: recorder}
+  end
+
+  @doc "Updates the change recorder state."
+  @spec set_change_recorder(t(), ChangeRecorder.t()) :: t()
+  def set_change_recorder(%__MODULE__{} = vim, recorder) do
+    %{vim | change_recorder: recorder}
+  end
+
+  @doc "Updates the register state."
+  @spec set_registers(t(), Registers.t()) :: t()
+  def set_registers(%__MODULE__{} = vim, reg) do
+    %{vim | reg: reg}
+  end
 end

--- a/lib/minga/input/completion.ex
+++ b/lib/minga/input/completion.ex
@@ -18,6 +18,7 @@ defmodule Minga.Input.Completion do
   alias Minga.Editor.CompletionHandling
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.Viewport
+  alias Minga.Workspace.State, as: WorkspaceState
 
   @ctrl Minga.Input.mod_ctrl()
   @escape 27
@@ -70,11 +71,17 @@ defmodule Minga.Input.Completion do
     case button do
       :wheel_down ->
         {:handled,
-         %{state | workspace: %{state.workspace | completion: Completion.move_down(completion)}}}
+         EditorState.update_workspace(
+           state,
+           &WorkspaceState.set_completion(&1, Completion.move_down(completion))
+         )}
 
       :wheel_up ->
         {:handled,
-         %{state | workspace: %{state.workspace | completion: Completion.move_up(completion)}}}
+         EditorState.update_workspace(
+           state,
+           &WorkspaceState.set_completion(&1, Completion.move_up(completion))
+         )}
 
       :left ->
         handle_completion_click(state, completion, row, col)
@@ -184,10 +191,11 @@ defmodule Minga.Input.Completion do
   # C-n or arrow down: move selection down
   defp do_handle(state, completion, cp, mods)
        when (cp == ?n and band(mods, @ctrl) != 0) or cp == @arrow_down do
-    state = %{
-      state
-      | workspace: %{state.workspace | completion: Completion.move_down(completion)}
-    }
+    state =
+      EditorState.update_workspace(
+        state,
+        &WorkspaceState.set_completion(&1, Completion.move_down(completion))
+      )
 
     {:handled, CompletionHandling.maybe_resolve_selected(state)}
   end
@@ -195,7 +203,12 @@ defmodule Minga.Input.Completion do
   # C-p or arrow up: move selection up
   defp do_handle(state, completion, cp, mods)
        when (cp == ?p and band(mods, @ctrl) != 0) or cp == @arrow_up do
-    state = %{state | workspace: %{state.workspace | completion: Completion.move_up(completion)}}
+    state =
+      EditorState.update_workspace(
+        state,
+        &WorkspaceState.set_completion(&1, Completion.move_up(completion))
+      )
+
     {:handled, CompletionHandling.maybe_resolve_selected(state)}
   end
 

--- a/lib/minga/input/conflict_prompt.ex
+++ b/lib/minga/input/conflict_prompt.ex
@@ -11,6 +11,7 @@ defmodule Minga.Input.ConflictPrompt do
 
   alias Minga.Buffer
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Workspace.State, as: WorkspaceState
 
   @impl true
   @spec handle_key(Minga.Editor.State.t(), non_neg_integer(), non_neg_integer()) ::
@@ -21,7 +22,7 @@ defmodule Minga.Input.ConflictPrompt do
     name = Path.basename(Buffer.file_path(buf) || "buffer")
 
     {:handled,
-     %{state | workspace: %{state.workspace | pending_conflict: nil}}
+     EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, nil))
      |> EditorState.set_status("#{name} reloaded (changed on disk)")}
   end
 
@@ -37,7 +38,7 @@ defmodule Minga.Input.ConflictPrompt do
         :ok
     end
 
-    state = %{state | workspace: %{state.workspace | pending_conflict: nil}}
+    state = EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, nil))
     {:handled, EditorState.clear_status(state)}
   end
 

--- a/lib/minga/input/git_status.ex
+++ b/lib/minga/input/git_status.ex
@@ -16,6 +16,7 @@ defmodule Minga.Input.GitStatus do
   alias Minga.Input
   alias Minga.Input.GitStatus.TuiState
   alias Minga.Keymap
+  alias Minga.Workspace.State, as: WorkspaceState
 
   @impl true
   @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
@@ -141,7 +142,7 @@ defmodule Minga.Input.GitStatus do
       abs_path = Path.join(git_root, entry.path)
 
       closed_state =
-        %{state | workspace: %{state.workspace | keymap_scope: :editor}}
+        EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor))
         |> EditorState.close_git_status_panel()
 
       open_file_in_editor(closed_state, abs_path)
@@ -156,7 +157,7 @@ defmodule Minga.Input.GitStatus do
   end
 
   defp execute_command(state, :git_status_close) do
-    state = %{state | workspace: %{state.workspace | keymap_scope: :editor}}
+    state = EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor))
     EditorState.close_git_status_panel(state)
   end
 

--- a/lib/minga/input/interrupt.ex
+++ b/lib/minga/input/interrupt.ex
@@ -34,7 +34,9 @@ defmodule Minga.Input.Interrupt do
   alias Minga.Editor.State.AgentAccess
   alias Minga.Editor.State.Picker
   alias Minga.Editor.State.WhichKey
+  alias Minga.Editor.VimState
   alias Minga.Mode
+  alias Minga.Workspace.State, as: WorkspaceState
 
   # Ctrl-G sends codepoint 7 (BEL / ASCII control code for ^G).
   @ctrl_g 7
@@ -73,7 +75,7 @@ defmodule Minga.Input.Interrupt do
     do: {state, resets}
 
   defp maybe_reset_scope(%{workspace: %{keymap_scope: scope}} = state, resets) do
-    {%{state | workspace: %{state.workspace | keymap_scope: :editor}},
+    {EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor)),
      ["scope #{scope} → :editor" | resets]}
   end
 
@@ -87,9 +89,9 @@ defmodule Minga.Input.Interrupt do
     fresh_state = Mode.initial_state()
 
     if mode_state_dirty?(vim.mode_state, fresh_state) do
-      new_vim = %{vim | mode_state: fresh_state}
+      new_vim = VimState.set_mode_state(vim, fresh_state)
 
-      {%{state | workspace: %{state.workspace | editing: new_vim}},
+      {EditorState.update_workspace(state, &WorkspaceState.set_editing(&1, new_vim)),
        ["mode state reset (pending sequence cleared)" | resets]}
     else
       {state, resets}
@@ -133,7 +135,7 @@ defmodule Minga.Input.Interrupt do
     do: {state, resets}
 
   defp maybe_close_conflict(state, resets) do
-    {%{state | workspace: %{state.workspace | pending_conflict: nil}},
+    {EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, nil)),
      ["conflict prompt dismissed" | resets]}
   end
 
@@ -142,7 +144,8 @@ defmodule Minga.Input.Interrupt do
     do: {state, resets}
 
   defp maybe_close_completion(%{workspace: %{completion: %Completion{}}} = state, resets) do
-    {%{state | workspace: %{state.workspace | completion: nil}}, ["completion closed" | resets]}
+    {EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, nil)),
+     ["completion closed" | resets]}
   end
 
   @spec maybe_clear_agent_prefix(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}

--- a/lib/minga/ui/picker/buffer_source.ex
+++ b/lib/minga/ui/picker/buffer_source.ex
@@ -16,6 +16,7 @@ defmodule Minga.UI.Picker.BufferSource do
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Buffers
   alias Minga.UI.Devicon
+  alias Minga.Workspace.State, as: WorkspaceState
 
   @impl true
   @spec title() :: String.t()
@@ -128,7 +129,10 @@ defmodule Minga.UI.Picker.BufferSource do
         new_active = min(bs.active_index, length(new_buffers) - 1)
         new_bs = %Buffers{bs | list: new_buffers}
 
-        %{state | workspace: %{state.workspace | buffers: Buffers.switch_to(new_bs, new_active)}}
+        EditorState.update_workspace(
+          state,
+          &WorkspaceState.set_buffers(&1, Buffers.switch_to(new_bs, new_active))
+        )
         |> EditorState.sync_active_window_buffer()
     end
   end

--- a/lib/minga/ui/picker/location_source.ex
+++ b/lib/minga/ui/picker/location_source.ex
@@ -23,7 +23,9 @@ defmodule Minga.UI.Picker.LocationSource do
   alias Minga.Buffer
   alias Minga.Editor.Commands
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.VimState
   alias Minga.UI.Picker.Item
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.UI.Picker.Source
 
   @impl true
@@ -126,10 +128,9 @@ defmodule Minga.UI.Picker.LocationSource do
   defp set_jump_mark(%{workspace: %{buffers: %{active: buf}}} = state) when is_pid(buf) do
     pos = Buffer.cursor(buf)
 
-    %{
-      state
-      | workspace: %{state.workspace | editing: %{state.workspace.editing | last_jump_pos: pos}}
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_last_jump_pos(&1, pos))
+    end)
   end
 
   defp set_jump_mark(state), do: state

--- a/lib/minga/ui/picker/workspace_symbol_source.ex
+++ b/lib/minga/ui/picker/workspace_symbol_source.ex
@@ -15,7 +15,9 @@ defmodule Minga.UI.Picker.WorkspaceSymbolSource do
   alias Minga.Buffer
   alias Minga.Editor.Commands
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.VimState
   alias Minga.LSP.Client
+  alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.LSP.SyncServer
   alias Minga.UI.Picker.Item
   alias Minga.UI.Picker.Source
@@ -117,10 +119,9 @@ defmodule Minga.UI.Picker.WorkspaceSymbolSource do
   defp set_jump_mark(%{workspace: %{buffers: %{active: buf}}} = state) when is_pid(buf) do
     pos = Buffer.cursor(buf)
 
-    %{
-      state
-      | workspace: %{state.workspace | editing: %{state.workspace.editing | last_jump_pos: pos}}
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_last_jump_pos(&1, pos))
+    end)
   end
 
   defp set_jump_mark(state), do: state

--- a/lib/minga/ui/popup/lifecycle.ex
+++ b/lib/minga/ui/popup/lifecycle.ex
@@ -42,6 +42,7 @@ defmodule Minga.UI.Popup.Lifecycle do
   alias Minga.UI.Popup.Active, as: PopupActive
   alias Minga.UI.Popup.Registry, as: PopupRegistry
   alias Minga.UI.Popup.Rule
+  alias Minga.Workspace.State, as: WorkspaceState
 
   @type state :: EditorState.t()
 
@@ -297,21 +298,8 @@ defmodule Minga.UI.Popup.Lifecycle do
         new_map = Map.put(ws.map, next_id, popup_window)
         new_windows = %{ws | tree: new_tree, map: new_map, next_id: next_id + 1}
 
-        state = %{state | workspace: %{state.workspace | windows: new_windows}}
-
-        # Optionally switch focus to the popup
-        state =
-          if rule.focus do
-            %{
-              state
-              | workspace: %{
-                  state.workspace
-                  | windows: %{state.workspace.windows | active: next_id}
-                }
-            }
-          else
-            state
-          end
+        windows = if rule.focus, do: %{new_windows | active: next_id}, else: new_windows
+        state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, windows))
 
         Layout.invalidate(state)
 
@@ -335,15 +323,14 @@ defmodule Minga.UI.Popup.Lifecycle do
     # Add window to map but NOT to the tree (floats overlay the layout)
     new_map = Map.put(ws.map, next_id, popup_window)
     new_windows = %{ws | map: new_map, next_id: next_id + 1}
-    state = %{state | workspace: %{state.workspace | windows: new_windows}}
+    state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, new_windows))
 
     # Optionally switch focus to the popup
     state =
       if rule.focus do
-        %{
-          state
-          | workspace: %{state.workspace | windows: %{state.workspace.windows | active: next_id}}
-        }
+        EditorState.update_workspace(state, fn wspace ->
+          WorkspaceState.set_windows(wspace, %{wspace.windows | active: next_id})
+        end)
       else
         state
       end
@@ -366,7 +353,9 @@ defmodule Minga.UI.Popup.Lifecycle do
             find_non_popup_window(ws.map, window_id)
           end
 
-        %{state | workspace: %{state.workspace | windows: %{ws | active: restore_id}}}
+        EditorState.update_workspace(state, fn wspace ->
+          WorkspaceState.set_windows(wspace, %{wspace.windows | active: restore_id})
+        end)
       else
         state
       end
@@ -385,7 +374,7 @@ defmodule Minga.UI.Popup.Lifecycle do
     # Remove the popup window from the map
     new_map = Map.delete(ws.map, window_id)
     new_windows = %{ws | tree: new_tree, map: new_map}
-    state = %{state | workspace: %{state.workspace | windows: new_windows}}
+    state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, new_windows))
 
     Layout.invalidate(state)
   end

--- a/lib/minga/workspace/state.ex
+++ b/lib/minga/workspace/state.ex
@@ -177,4 +177,120 @@ defmodule Minga.Workspace.State do
       nil -> :editor
     end
   end
+
+  # ── Field mutation functions (Rule 2 enforcement) ──────────────────────
+
+  @doc "Updates the editing (VimState) sub-struct."
+  @spec update_editing(t(), (VimState.t() -> VimState.t())) :: t()
+  def update_editing(%__MODULE__{editing: vim} = wspace, fun) when is_function(fun, 1) do
+    %{wspace | editing: fun.(vim)}
+  end
+
+  @doc "Replaces the editing (VimState) sub-struct."
+  @spec set_editing(t(), VimState.t()) :: t()
+  def set_editing(%__MODULE__{} = wspace, vim) do
+    %{wspace | editing: vim}
+  end
+
+  @doc "Sets the keymap scope."
+  @spec set_keymap_scope(t(), Scope.scope_name()) :: t()
+  def set_keymap_scope(%__MODULE__{} = wspace, scope) do
+    %{wspace | keymap_scope: scope}
+  end
+
+  @doc "Updates the completion state."
+  @spec set_completion(t(), Completion.t() | nil) :: t()
+  def set_completion(%__MODULE__{} = wspace, completion) do
+    %{wspace | completion: completion}
+  end
+
+  @doc "Updates the completion trigger bridge."
+  @spec set_completion_trigger(t(), CompletionTrigger.t()) :: t()
+  def set_completion_trigger(%__MODULE__{} = wspace, trigger) do
+    %{wspace | completion_trigger: trigger}
+  end
+
+  @doc "Clears completion and resets the trigger bridge."
+  @spec clear_completion(t(), CompletionTrigger.t()) :: t()
+  def clear_completion(%__MODULE__{} = wspace, new_bridge) do
+    %{wspace | completion: nil, completion_trigger: new_bridge}
+  end
+
+  @doc "Updates the highlighting sub-struct."
+  @spec set_highlight(t(), Highlighting.t()) :: t()
+  def set_highlight(%__MODULE__{} = wspace, highlight) do
+    %{wspace | highlight: highlight}
+  end
+
+  @doc "Updates the highlighting sub-struct via a mapper function."
+  @spec update_highlight(t(), (Highlighting.t() -> Highlighting.t())) :: t()
+  def update_highlight(%__MODULE__{highlight: hl} = wspace, fun) when is_function(fun, 1) do
+    %{wspace | highlight: fun.(hl)}
+  end
+
+  @doc "Updates the mouse sub-struct."
+  @spec set_mouse(t(), Mouse.t()) :: t()
+  def set_mouse(%__MODULE__{} = wspace, mouse) do
+    %{wspace | mouse: mouse}
+  end
+
+  @doc "Updates the document highlights from LSP."
+  @spec set_document_highlights(t(), [document_highlight()] | nil) :: t()
+  def set_document_highlights(%__MODULE__{} = wspace, highlights) do
+    %{wspace | document_highlights: highlights}
+  end
+
+  @doc "Updates the search sub-struct."
+  @spec set_search(t(), Search.t()) :: t()
+  def set_search(%__MODULE__{} = wspace, search) do
+    %{wspace | search: search}
+  end
+
+  @doc "Updates the search sub-struct via a mapper function."
+  @spec update_search(t(), (Search.t() -> Search.t())) :: t()
+  def update_search(%__MODULE__{search: s} = wspace, fun) when is_function(fun, 1) do
+    %{wspace | search: fun.(s)}
+  end
+
+  @doc "Sets the pending conflict state."
+  @spec set_pending_conflict(t(), {pid(), String.t()} | nil) :: t()
+  def set_pending_conflict(%__MODULE__{} = wspace, conflict) do
+    %{wspace | pending_conflict: conflict}
+  end
+
+  @doc "Updates the LSP pending requests map."
+  @spec set_lsp_pending(t(), %{reference() => atom() | tuple()}) :: t()
+  def set_lsp_pending(%__MODULE__{} = wspace, pending) do
+    %{wspace | lsp_pending: pending}
+  end
+
+  @doc "Sets the viewport dimensions."
+  @spec set_viewport(t(), Viewport.t()) :: t()
+  def set_viewport(%__MODULE__{} = wspace, viewport) do
+    %{wspace | viewport: viewport}
+  end
+
+  @doc "Replaces the windows sub-struct."
+  @spec set_windows(t(), Windows.t()) :: t()
+  def set_windows(%__MODULE__{} = wspace, windows) do
+    %{wspace | windows: windows}
+  end
+
+  @doc "Replaces the buffers sub-struct."
+  @spec set_buffers(t(), Buffers.t()) :: t()
+  def set_buffers(%__MODULE__{} = wspace, buffers) do
+    %{wspace | buffers: buffers}
+  end
+
+  @doc "Updates the agent UI state."
+  @spec set_agent_ui(t(), UIState.t()) :: t()
+  def set_agent_ui(%__MODULE__{} = wspace, agent_ui) do
+    %{wspace | agent_ui: agent_ui}
+  end
+
+  @doc "Updates the injection ranges map."
+  @spec set_injection_ranges(t(), %{pid() => [Minga.UI.Highlight.InjectionRange.t()]}) :: t()
+  def set_injection_ranges(%__MODULE__{} = wspace, ranges) do
+    %{wspace | injection_ranges: ranges}
+  end
 end

--- a/test/minga/editor/completion_doc_preview_test.exs
+++ b/test/minga/editor/completion_doc_preview_test.exs
@@ -9,9 +9,24 @@ defmodule Minga.Editor.CompletionDocPreviewTest do
   alias Minga.Editing.Completion
   alias Minga.Editor.CompletionHandling
   alias Minga.Editor.CompletionUI
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.Viewport
   alias Minga.UI.Theme
+  alias Minga.Workspace.State, as: WorkspaceState
 
   @theme Theme.get!(:doom_one)
+
+  defp make_state(completion) do
+    ws = %WorkspaceState{
+      viewport: %Viewport{top: 0, left: 0, rows: 24, cols: 80},
+      completion: completion
+    }
+
+    %EditorState{
+      port_manager: self(),
+      workspace: ws
+    }
+  end
 
   # ── Completion item parsing ──────────────────────────────────────────────
 
@@ -72,14 +87,14 @@ defmodule Minga.Editor.CompletionDocPreviewTest do
 
   describe "maybe_resolve_selected/1" do
     test "returns state unchanged when completion is nil" do
-      state = %{workspace: %{completion: nil}}
+      state = make_state(nil)
       assert CompletionHandling.maybe_resolve_selected(state) == state
     end
 
     test "skips resolve when documentation already present" do
       items = [Completion.parse_item(%{"label" => "a", "documentation" => "Already here"})]
       completion = Completion.new(items, {0, 0})
-      state = %{workspace: %{completion: completion}}
+      state = make_state(completion)
       result = CompletionHandling.maybe_resolve_selected(state)
       # No timer set because documentation is already present
       assert result.workspace.completion.resolve_timer == nil
@@ -88,7 +103,7 @@ defmodule Minga.Editor.CompletionDocPreviewTest do
     test "sets a resolve timer when documentation is empty" do
       items = [Completion.parse_item(%{"label" => "a"})]
       completion = Completion.new(items, {0, 0})
-      state = %{workspace: %{completion: completion}}
+      state = make_state(completion)
       result = CompletionHandling.maybe_resolve_selected(state)
       assert result.workspace.completion.resolve_timer != nil
     end
@@ -96,7 +111,7 @@ defmodule Minga.Editor.CompletionDocPreviewTest do
     test "skips when already resolved for this index" do
       items = [Completion.parse_item(%{"label" => "a"})]
       completion = %{Completion.new(items, {0, 0}) | last_resolved_index: 0}
-      state = %{workspace: %{completion: completion}}
+      state = make_state(completion)
       result = CompletionHandling.maybe_resolve_selected(state)
       assert result.workspace.completion.resolve_timer == nil
     end
@@ -108,7 +123,7 @@ defmodule Minga.Editor.CompletionDocPreviewTest do
     test "updates selected item documentation on success" do
       items = [Completion.parse_item(%{"label" => "a"})]
       completion = Completion.new(items, {0, 0})
-      state = %{workspace: %{completion: completion}}
+      state = make_state(completion)
 
       resolved = %{"documentation" => %{"kind" => "markdown", "value" => "Full docs"}}
       result = CompletionHandling.handle_resolve_response(state, {:ok, resolved})
@@ -121,7 +136,7 @@ defmodule Minga.Editor.CompletionDocPreviewTest do
     test "handles plain string documentation in resolve response" do
       items = [Completion.parse_item(%{"label" => "a"})]
       completion = Completion.new(items, {0, 0})
-      state = %{workspace: %{completion: completion}}
+      state = make_state(completion)
 
       resolved = %{"documentation" => "Plain text docs"}
       result = CompletionHandling.handle_resolve_response(state, {:ok, resolved})
@@ -133,14 +148,14 @@ defmodule Minga.Editor.CompletionDocPreviewTest do
     test "returns state unchanged on error" do
       items = [Completion.parse_item(%{"label" => "a"})]
       completion = Completion.new(items, {0, 0})
-      state = %{workspace: %{completion: completion}}
+      state = make_state(completion)
 
       result = CompletionHandling.handle_resolve_response(state, {:error, "timeout"})
       assert result == state
     end
 
     test "returns state unchanged when completion is nil" do
-      state = %{workspace: %{completion: nil}}
+      state = make_state(nil)
       result = CompletionHandling.handle_resolve_response(state, {:ok, %{}})
       assert result == state
     end


### PR DESCRIPTION
## What

Centralizes all VimState and Workspace.State mutations behind owning-module functions, enforcing AGENTS.md Rule 2 (one writer per struct).

## Why

8+ files were doing `%{state.workspace.editing | mode: :insert, mode_state: ms}` instead of calling `VimState.transition/3`. Similar patterns existed across 28 files for Workspace.State fields. This makes it impossible to add invariants to state transitions without hunting down every mutation site.

## Changes

**VimState** gains: `set_mode_state/2`, `set_marks/2`, `set_buffer_marks/3`, `set_last_jump_pos/2`, `set_last_find_char/2`, `set_macro_recorder/2`, `set_change_recorder/2`, `set_registers/2`

**Workspace.State** gains: `set_keymap_scope/2`, `set_completion/2`, `set_completion_trigger/2`, `clear_completion/2`, `set_highlight/2`, `update_highlight/2`, `set_mouse/2`, `set_document_highlights/2`, `set_search/2`, `update_search/2`, `set_pending_conflict/2`, `set_lsp_pending/2`, `set_viewport/2`, `set_windows/2`, `set_buffers/2`, `set_agent_ui/2`, `set_injection_ranges/2`, `update_editing/2`, `set_editing/2`

All 28 files with external mutations now use these functions. Extended the credo check configuration to cover both structs. Fixed a pre-existing dialyzer false positive.

Closes #1226
Part of epic #1304