### PR TITLE
feat(editor): TUI rendering for file tree editing entries (#1301)

### DIFF
--- a/lib/minga/editor/tree_renderer.ex
+++ b/lib/minga/editor/tree_renderer.ex
@@ -12,6 +12,7 @@ defmodule Minga.Editor.TreeRenderer do
   alias Minga.Core.Face
   alias Minga.Editor.DisplayList
   alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.FileTree, as: FileTreeState
   alias Minga.Editor.WindowTree
   alias Minga.Language
   alias Minga.Project.FileTree
@@ -40,6 +41,7 @@ defmodule Minga.Editor.TreeRenderer do
       :focused,
       :theme,
       :active_path,
+      editing: nil,
       git_status: %{},
       dirty_paths: MapSet.new()
     ]
@@ -50,6 +52,7 @@ defmodule Minga.Editor.TreeRenderer do
             focused: boolean(),
             theme: Theme.t(),
             active_path: String.t() | nil,
+            editing: FileTreeState.editing() | nil,
             git_status: Minga.Project.FileTree.GitStatus.status_map(),
             dirty_paths: MapSet.t(String.t())
           }
@@ -72,6 +75,7 @@ defmodule Minga.Editor.TreeRenderer do
       input.focused,
       input.theme,
       input.active_path,
+      input.editing,
       input.git_status,
       input.dirty_paths
     )
@@ -92,6 +96,7 @@ defmodule Minga.Editor.TreeRenderer do
           focused: focused,
           theme: state.theme,
           active_path: active_buffer_path(state),
+          editing: state.workspace.file_tree.editing,
           git_status: tree.git_status,
           dirty_paths: compute_dirty_paths(state)
         }
@@ -106,6 +111,7 @@ defmodule Minga.Editor.TreeRenderer do
           boolean(),
           Theme.t(),
           String.t() | nil,
+          FileTreeState.editing() | nil,
           FileTree.GitStatus.status_map(),
           MapSet.t(String.t())
         ) :: [DisplayList.draw()]
@@ -115,6 +121,7 @@ defmodule Minga.Editor.TreeRenderer do
          focused,
          theme,
          active_path,
+         editing,
          git_status,
          dirty_paths
        ) do
@@ -146,6 +153,7 @@ defmodule Minga.Editor.TreeRenderer do
       width: width,
       theme: theme,
       expanded: tree.expanded,
+      editing: editing,
       git_status: git_status,
       dirty_paths: dirty_paths
     }
@@ -157,7 +165,13 @@ defmodule Minga.Editor.TreeRenderer do
       |> Enum.take(content_rows)
       |> Enum.with_index()
       |> Enum.flat_map(fn {{entry, global_idx}, screen_row} ->
-        render_entry(entry, global_idx, row_off + 1 + screen_row, render_opts)
+        row = row_off + 1 + screen_row
+
+        if editing != nil and global_idx == editing.index do
+          render_editing_entry(entry, row, render_opts)
+        else
+          render_entry(entry, global_idx, row, render_opts)
+        end
       end)
 
     # Fill remaining rows with blanks
@@ -279,6 +293,70 @@ defmodule Minga.Editor.TreeRenderer do
         draws
       end
     end
+  end
+
+  # ── Editing entry rendering ─────────────────────────────────────────────
+
+  # Renders the inline editing entry with highlighted styling and a cursor indicator.
+  # The editing row shows the entry's indent guides, a type indicator icon, the
+  # current editing text, and a block cursor at the insertion point.
+  @spec render_editing_entry(FileTree.entry(), non_neg_integer(), map()) :: [DisplayList.draw()]
+  defp render_editing_entry(entry, row, opts) do
+    %{col_off: col, width: width, theme: theme, editing: editing} = opts
+
+    # Build indent guides (same depth as the entry being edited/created)
+    guide_prefix = build_guides(entry.guides, entry.last_child?)
+    guide_len = String.length(guide_prefix)
+
+    # Type indicator: file icon for new file, folder icon for new folder,
+    # the entry's own icon for rename
+    {icon, _icon_color} =
+      case editing.type do
+        :new_file -> {"", 0x519ABA}
+        :new_folder -> {@folder_open, 0x519ABA}
+        :rename -> entry_icon(entry, false)
+      end
+
+    prefix = guide_prefix <> icon <> " "
+    prefix_len = String.length(prefix)
+
+    # Editing text with cursor
+    text = editing.text
+    cursor_char = "▏"
+    display_text = text <> cursor_char
+
+    # Truncate to fit
+    max_text_len = max(width - prefix_len, 0)
+    display_text = String.slice(display_text, 0, max_text_len)
+
+    # Pad to fill the row
+    total_drawn = prefix_len + String.length(display_text)
+    pad = if total_drawn < width, do: String.duplicate(" ", width - total_drawn), else: ""
+
+    # Editing row uses inverse video (selection highlight)
+    editing_bg = theme.tree.dir_fg
+    editing_fg = theme.tree.bg
+
+    guide_style = Face.new(fg: editing_fg, bg: editing_bg)
+    icon_style = Face.new(fg: editing_fg, bg: editing_bg)
+    text_style = Face.new(fg: editing_fg, bg: editing_bg, bold: true)
+
+    draws = []
+
+    draws =
+      if guide_len > 0 do
+        draws ++ [DisplayList.draw(row, col, guide_prefix, guide_style)]
+      else
+        draws
+      end
+
+    icon_col = col + guide_len
+    draws = draws ++ [DisplayList.draw(row, icon_col, icon <> " ", icon_style)]
+
+    text_col = col + prefix_len
+    draws = draws ++ [DisplayList.draw(row, text_col, display_text <> pad, text_style)]
+
+    draws
   end
 
   # ── Indent guides ──────────────────────────────────────────────────────

--- a/test/minga/editor/tree_renderer_test.exs
+++ b/test/minga/editor/tree_renderer_test.exs
@@ -251,4 +251,157 @@ defmodule Minga.Editor.TreeRendererTest do
       assert [_ | _] = draws
     end
   end
+
+  describe "editing entry rendering" do
+    test "editing entry renders with inverse video styling", %{tmp_dir: tmp_dir} do
+      theme = Theme.get!(:doom_one)
+
+      input = %RenderInput{
+        tree: sample_tree(tmp_dir),
+        rect: {0, 0, 30, 10},
+        focused: true,
+        theme: theme,
+        active_path: nil,
+        editing: %{index: 0, text: "new_file.ex", type: :new_file, original_name: nil}
+      }
+
+      draws = TreeRenderer.render(input)
+
+      # Row 1 is the first entry (header is row 0). Find the text segment.
+      row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
+      assert row1_draws != []
+
+      # The text segment should have inverse video: fg = tree.bg, bg = tree.dir_fg
+      text_draw =
+        Enum.find(row1_draws, fn {_r, _c, text, _s} -> String.contains?(text, "new_file.ex") end)
+
+      assert text_draw != nil
+      {_r, _c, _text, style} = text_draw
+      assert style.fg == theme.tree.bg
+      assert style.bg == theme.tree.dir_fg
+    end
+
+    test "editing entry shows cursor indicator at end of text", %{tmp_dir: tmp_dir} do
+      input = %RenderInput{
+        tree: sample_tree(tmp_dir),
+        rect: {0, 0, 30, 10},
+        focused: true,
+        theme: Theme.get!(:doom_one),
+        active_path: nil,
+        editing: %{index: 0, text: "hello", type: :new_file, original_name: nil}
+      }
+
+      draws = TreeRenderer.render(input)
+      row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
+      texts = Enum.map(row1_draws, fn {_r, _c, text, _s} -> text end)
+      all_text = Enum.join(texts)
+
+      # Should contain the text followed by the cursor indicator
+      assert String.contains?(all_text, "hello▏")
+    end
+
+    test "editing entry with empty text shows only cursor indicator", %{tmp_dir: tmp_dir} do
+      input = %RenderInput{
+        tree: sample_tree(tmp_dir),
+        rect: {0, 0, 30, 10},
+        focused: true,
+        theme: Theme.get!(:doom_one),
+        active_path: nil,
+        editing: %{index: 0, text: "", type: :new_file, original_name: nil}
+      }
+
+      draws = TreeRenderer.render(input)
+      row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
+      texts = Enum.map(row1_draws, fn {_r, _c, text, _s} -> text end)
+      all_text = Enum.join(texts)
+
+      assert String.contains?(all_text, "▏")
+    end
+
+    test "editing entry shows correct indent guides at depth", %{tmp_dir: tmp_dir} do
+      # main.ex is inside expanded lib/, so it has depth > 0 and should have guides.
+      # Index 1 in sample_tree is lib/main.ex (inside expanded lib/).
+      input = %RenderInput{
+        tree: sample_tree(tmp_dir),
+        rect: {0, 0, 30, 10},
+        focused: true,
+        theme: Theme.get!(:doom_one),
+        active_path: nil,
+        editing: %{index: 1, text: "renamed.ex", type: :rename, original_name: "main.ex"}
+      }
+
+      draws = TreeRenderer.render(input)
+      row2_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 2 end)
+      texts = Enum.map(row2_draws, fn {_r, _c, text, _s} -> text end)
+      all_text = Enum.join(texts)
+
+      # The entry at depth 1 should have a guide connector (└─ since it's last child)
+      assert String.contains?(all_text, "└─") or String.contains?(all_text, "├─")
+    end
+
+    test "non-editing entries render normally when editing is active", %{tmp_dir: tmp_dir} do
+      theme = Theme.get!(:doom_one)
+
+      input = %RenderInput{
+        tree: sample_tree(tmp_dir),
+        rect: {0, 0, 30, 10},
+        focused: false,
+        theme: theme,
+        active_path: nil,
+        editing: %{index: 0, text: "new.txt", type: :new_file, original_name: nil}
+      }
+
+      draws = TreeRenderer.render(input)
+
+      # Row 2 is the second entry (not being edited). It should have normal styling.
+      row2_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 2 end)
+      assert row2_draws != []
+
+      # Non-editing, non-cursor entries should have the normal tree bg
+      name_draw =
+        Enum.find(row2_draws, fn {_r, _c, _text, style} -> style.bg == theme.tree.bg end)
+
+      assert name_draw != nil
+    end
+
+    test "editing type :new_folder shows folder icon", %{tmp_dir: tmp_dir} do
+      input = %RenderInput{
+        tree: sample_tree(tmp_dir),
+        rect: {0, 0, 30, 10},
+        focused: true,
+        theme: Theme.get!(:doom_one),
+        active_path: nil,
+        editing: %{index: 0, text: "new_dir", type: :new_folder, original_name: nil}
+      }
+
+      draws = TreeRenderer.render(input)
+      row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
+      texts = Enum.map(row1_draws, fn {_r, _c, text, _s} -> text end)
+      all_text = Enum.join(texts)
+
+      # Should contain the folder-open icon (U+F0256)
+      assert String.contains?(all_text, "\u{F0256}")
+    end
+
+    test "editing text style is bold", %{tmp_dir: tmp_dir} do
+      input = %RenderInput{
+        tree: sample_tree(tmp_dir),
+        rect: {0, 0, 30, 10},
+        focused: true,
+        theme: Theme.get!(:doom_one),
+        active_path: nil,
+        editing: %{index: 0, text: "test.txt", type: :new_file, original_name: nil}
+      }
+
+      draws = TreeRenderer.render(input)
+      row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
+
+      text_draw =
+        Enum.find(row1_draws, fn {_r, _c, text, _s} -> String.contains?(text, "test.txt") end)
+
+      assert text_draw != nil
+      {_r, _c, _text, style} = text_draw
+      assert style.bold == true
+    end
+  end
 end


### PR DESCRIPTION
## What

Updates the TUI tree renderer to visually distinguish the editing entry when inline editing is active. The editing row renders with inverse video, shows the current text with a cursor indicator, and maintains correct indent depth.

Part of #851. Depends on #1309 (BEAM core, ticket #1299). Independent of the Protocol + macOS GUI ticket.

## Changes

### TreeRenderer
- `RenderInput` gained an `editing` field, populated from `EditorState.workspace.file_tree.editing`
- Entry rendering loop checks if the current entry matches `editing.index` and dispatches to `render_editing_entry`
- `render_editing_entry` renders with:
  - Inverse video (fg=tree.bg, bg=tree.dir_fg) for the full row
  - Editing text in bold
  - Cursor indicator (`▏`) at the text insertion point
  - Type-appropriate icon: generic file for new_file, folder for new_folder, entry's own icon for rename
  - Correct indent guides matching the entry's depth

## Testing

7 new tests added to `tree_renderer_test.exs`:
- Inverse video styling assertion
- Cursor indicator at end of text
- Empty text shows only cursor
- Correct indent guides at depth
- Non-editing entries render normally
- Folder icon for new_folder type
- Bold text style

Closes #1301