### PR TITLE
feat(agent): edit boundaries restrict agent edits to buffer regions (#78)

### DIFF
--- a/lib/minga/agent/edit_boundary.ex
+++ b/lib/minga/agent/edit_boundary.ex
@@ -1,0 +1,97 @@
+defmodule Minga.Agent.EditBoundary do
+  @moduledoc """
+  Defines a line range that an agent session is allowed to edit within a buffer.
+
+  Boundaries are per-buffer, per-session. When set, agent edits outside the
+  boundary are rejected with a descriptive error. Boundaries adjust automatically
+  when edits change the line count within the bounded region or when user edits
+  above the boundary shift line numbers.
+  """
+
+  @enforce_keys [:start_line, :end_line]
+  defstruct [:start_line, :end_line]
+
+  @typedoc "A line range boundary (both inclusive, 0-indexed)."
+  @type t :: %__MODULE__{
+          start_line: non_neg_integer(),
+          end_line: non_neg_integer()
+        }
+
+  @doc """
+  Creates a new boundary for the given line range (both inclusive, 0-indexed).
+
+  Returns `{:error, reason}` if the range is invalid.
+  """
+  @spec new(non_neg_integer(), non_neg_integer()) :: {:ok, t()} | {:error, String.t()}
+  def new(start_line, end_line)
+      when is_integer(start_line) and is_integer(end_line) and start_line >= 0 and
+             end_line >= start_line do
+    {:ok, %__MODULE__{start_line: start_line, end_line: end_line}}
+  end
+
+  def new(start_line, end_line)
+      when is_integer(start_line) and is_integer(end_line) do
+    {:error, "invalid boundary: start_line (#{start_line}) must be <= end_line (#{end_line})"}
+  end
+
+  @doc """
+  Checks whether a line falls within the boundary (inclusive on both ends).
+  """
+  @spec contains_line?(t(), non_neg_integer()) :: boolean()
+  def contains_line?(%__MODULE__{start_line: s, end_line: e}, line)
+      when is_integer(line) do
+    line >= s and line <= e
+  end
+
+  @doc """
+  Checks whether a line range (start..end, both inclusive) falls entirely within the boundary.
+  """
+  @spec contains_range?(t(), non_neg_integer(), non_neg_integer()) :: boolean()
+  def contains_range?(%__MODULE__{start_line: s, end_line: e}, range_start, range_end)
+      when is_integer(range_start) and is_integer(range_end) do
+    range_start >= s and range_end <= e
+  end
+
+  @doc """
+  Adjusts the boundary after an edit changed the line count.
+
+  `edit_line` is the 0-indexed line where the edit started. `line_delta` is the
+  number of lines added (positive) or removed (negative) by the edit.
+
+  - Edits within the boundary: the end shifts by `line_delta`.
+  - Edits above the boundary: both start and end shift by `line_delta`.
+  - Edits below the boundary: no change.
+
+  Returns `nil` if the boundary collapses to zero or negative size (e.g., the
+  user deleted all lines within the boundary).
+  """
+  @spec adjust(t(), non_neg_integer(), integer()) :: t() | nil
+  def adjust(%__MODULE__{start_line: s, end_line: e}, edit_line, line_delta) do
+    cond do
+      # Edit is below the boundary: no adjustment needed
+      edit_line > e ->
+        %__MODULE__{start_line: s, end_line: e}
+
+      # Edit is above the boundary: shift both start and end
+      edit_line < s ->
+        new_start = max(s + line_delta, 0)
+        new_end = max(e + line_delta, 0)
+
+        if new_end >= new_start do
+          %__MODULE__{start_line: new_start, end_line: new_end}
+        else
+          nil
+        end
+
+      # Edit is within the boundary: only shift the end
+      true ->
+        new_end = max(e + line_delta, s)
+
+        if new_end >= s do
+          %__MODULE__{start_line: s, end_line: new_end}
+        else
+          nil
+        end
+    end
+  end
+end

--- a/lib/minga/agent/session.ex
+++ b/lib/minga/agent/session.ex
@@ -30,6 +30,7 @@ defmodule Minga.Agent.Session do
   alias Minga.Agent.ProviderResolver
   alias Minga.Agent.SessionMetadata
   alias Minga.Agent.SessionStore
+  alias Minga.Agent.EditBoundary
   alias Minga.Agent.ToolCall
   alias Minga.Agent.TurnUsage
 
@@ -67,7 +68,8 @@ defmodule Minga.Agent.Session do
           branches: [Branch.t()],
           steering_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
           follow_up_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
-          touched_files: %{String.t() => file_touch()}
+          touched_files: %{String.t() => file_touch()},
+          boundaries: %{String.t() => EditBoundary.t()}
         }
 
   # ── Public API ──────────────────────────────────────────────────────────────
@@ -346,6 +348,39 @@ defmodule Minga.Agent.Session do
   end
 
   @doc """
+  Sets an edit boundary for the agent on the given file path.
+
+  The agent will be restricted to editing within the specified line range
+  (0-indexed, both inclusive). Edits outside the boundary are rejected with
+  a descriptive error message.
+  """
+  @spec set_boundary(GenServer.server(), String.t(), non_neg_integer(), non_neg_integer()) ::
+          :ok | {:error, String.t()}
+  def set_boundary(session, path, start_line, end_line)
+      when is_binary(path) and is_integer(start_line) and is_integer(end_line) do
+    GenServer.call(session, {:set_boundary, path, start_line, end_line})
+  end
+
+  @doc "Clears the edit boundary for the given file path, restoring full-buffer access."
+  @spec clear_boundary(GenServer.server(), String.t()) :: :ok
+  def clear_boundary(session, path) when is_binary(path) do
+    GenServer.call(session, {:clear_boundary, path})
+  end
+
+  @doc "Clears all edit boundaries for this session."
+  @spec clear_all_boundaries(GenServer.server()) :: :ok
+  def clear_all_boundaries(session) do
+    GenServer.call(session, :clear_all_boundaries)
+  end
+
+  @doc "Returns the edit boundary for the given file path, or nil if unbounded."
+  @spec boundary_for(GenServer.server(), String.t()) ::
+          {non_neg_integer(), non_neg_integer()} | nil
+  def boundary_for(session, path) when is_binary(path) do
+    GenServer.call(session, {:boundary_for, path})
+  end
+
+  @doc """
   Returns both queues and clears them. Used by abort (Ctrl-C) and dequeue (Alt+Up)
   so pending messages can be restored to the prompt input.
   """
@@ -443,7 +478,8 @@ defmodule Minga.Agent.Session do
       branches: [],
       steering_queue: [],
       follow_up_queue: [],
-      touched_files: %{}
+      touched_files: %{},
+      boundaries: %{}
     }
 
     # Start provider asynchronously so init doesn't block
@@ -553,6 +589,39 @@ defmodule Minga.Agent.Session do
     {:reply, files, state}
   end
 
+  def handle_call({:set_boundary, path, start_line, end_line}, _from, state) do
+    abs_path = Path.expand(path)
+
+    case EditBoundary.new(start_line, end_line) do
+      {:ok, boundary} ->
+        {:reply, :ok, %{state | boundaries: Map.put(state.boundaries, abs_path, boundary)}}
+
+      {:error, _} = err ->
+        {:reply, err, state}
+    end
+  end
+
+  def handle_call({:clear_boundary, path}, _from, state) do
+    abs_path = Path.expand(path)
+    {:reply, :ok, %{state | boundaries: Map.delete(state.boundaries, abs_path)}}
+  end
+
+  def handle_call(:clear_all_boundaries, _from, state) do
+    {:reply, :ok, %{state | boundaries: %{}}}
+  end
+
+  def handle_call({:boundary_for, path}, _from, state) do
+    abs_path = Path.expand(path)
+
+    result =
+      case Map.get(state.boundaries, abs_path) do
+        nil -> nil
+        %EditBoundary{start_line: s, end_line: e} -> {s, e}
+      end
+
+    {:reply, result, state}
+  end
+
   def handle_call(:abort, _from, %{provider: nil} = state) do
     {:reply, :ok, state}
   end
@@ -593,7 +662,8 @@ defmodule Minga.Agent.Session do
         pending_approval: nil,
         steering_queue: [],
         follow_up_queue: [],
-        touched_files: %{}
+        touched_files: %{},
+        boundaries: %{}
     }
 
     state = reset_messages(state, [Message.system("Session cleared · #{timestamp}")])
@@ -622,7 +692,8 @@ defmodule Minga.Agent.Session do
             pending_approval: nil,
             steering_queue: [],
             follow_up_queue: [],
-            touched_files: %{}
+            touched_files: %{},
+            boundaries: %{}
         }
 
         state = reset_messages(state, data.messages)

--- a/lib/minga/agent/tools/edit_file.ex
+++ b/lib/minga/agent/tools/edit_file.ex
@@ -22,19 +22,23 @@ defmodule Minga.Agent.Tools.EditFile do
   Returns `{:ok, message}` on success. Fails if the file doesn't exist, if
   `old_text` is not found, or if `old_text` appears more than once (ambiguous edit).
   """
-  @spec execute(String.t(), String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def execute(path, old_text, new_text)
+  @typedoc "An edit boundary as `{start_line, end_line}` (both inclusive, 0-indexed), or nil for unbounded."
+  @type boundary :: {non_neg_integer(), non_neg_integer()} | nil
+
+  @spec execute(String.t(), String.t(), String.t(), boundary()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def execute(path, old_text, new_text, boundary \\ nil)
       when is_binary(path) and is_binary(old_text) and is_binary(new_text) do
     case ensure_buffer(path) do
-      {:ok, pid} -> execute_via_buffer(pid, path, old_text, new_text)
+      {:ok, pid} -> execute_via_buffer(pid, path, old_text, new_text, boundary)
       :unavailable -> execute_via_filesystem(path, old_text, new_text)
     end
   end
 
-  @spec execute_via_buffer(pid(), String.t(), String.t(), String.t()) ::
+  @spec execute_via_buffer(pid(), String.t(), String.t(), String.t(), boundary()) ::
           {:ok, String.t()} | {:error, String.t()}
-  defp execute_via_buffer(pid, path, old_text, new_text) do
-    case Buffer.find_and_replace(pid, old_text, new_text) do
+  defp execute_via_buffer(pid, path, old_text, new_text, boundary) do
+    case Buffer.find_and_replace(pid, old_text, new_text, boundary) do
       {:ok, _} -> {:ok, "edited #{path}"}
       {:error, reason} -> {:error, "#{reason} in #{path}. Read the file first to get exact text."}
     end

--- a/lib/minga/agent/tools/multi_edit_file.ex
+++ b/lib/minga/agent/tools/multi_edit_file.ex
@@ -26,25 +26,28 @@ defmodule Minga.Agent.Tools.MultiEditFile do
   Each edit in `edits` must have `"old_text"` and `"new_text"` keys.
   Returns `{:ok, summary}` with a per-edit status report.
   """
-  @spec execute(String.t(), [edit()]) :: {:ok, String.t()} | {:error, String.t()}
-  def execute(path, edits) when is_binary(path) and is_list(edits) do
+  @typedoc "An edit boundary as `{start_line, end_line}` (both inclusive, 0-indexed), or nil for unbounded."
+  @type boundary :: {non_neg_integer(), non_neg_integer()} | nil
+
+  @spec execute(String.t(), [edit()], boundary()) :: {:ok, String.t()} | {:error, String.t()}
+  def execute(path, edits, boundary \\ nil) when is_binary(path) and is_list(edits) do
     case ensure_buffer(path) do
-      {:ok, pid} -> execute_via_buffer(pid, path, edits)
+      {:ok, pid} -> execute_via_buffer(pid, path, edits, boundary)
       :unavailable -> execute_via_filesystem(path, edits)
     end
   end
 
   # ── Buffer path ──
 
-  @spec execute_via_buffer(pid(), String.t(), [edit()]) ::
+  @spec execute_via_buffer(pid(), String.t(), [edit()], boundary()) ::
           {:ok, String.t()} | {:error, String.t()}
-  defp execute_via_buffer(pid, path, edits) do
+  defp execute_via_buffer(pid, path, edits, boundary) do
     edit_pairs =
       Enum.map(edits, fn edit ->
         {edit["old_text"] || "", edit["new_text"] || ""}
       end)
 
-    case Buffer.find_and_replace_batch(pid, edit_pairs) do
+    case Buffer.find_and_replace_batch(pid, edit_pairs, boundary) do
       {:ok, results} -> {:ok, format_buffer_results(path, results)}
       {:error, msg} -> {:error, "#{path}: #{msg}"}
     end

--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -158,14 +158,14 @@ defmodule Minga.Buffer do
   defdelegate replace_content_force(server, new_content), to: Server
 
   @doc "Find and replace the first occurrence of `old_text` with `new_text`."
-  @spec find_and_replace(server(), String.t(), String.t()) ::
+  @spec find_and_replace(server(), String.t(), String.t(), Server.boundary()) ::
           {:ok, String.t()} | {:error, String.t()}
-  defdelegate find_and_replace(server, old_text, new_text), to: Server
+  defdelegate find_and_replace(server, old_text, new_text, boundary \\ nil), to: Server
 
   @doc "Find and replace multiple patterns atomically."
-  @spec find_and_replace_batch(server(), [Server.replace_edit()]) ::
+  @spec find_and_replace_batch(server(), [Server.replace_edit()], Server.boundary()) ::
           {:ok, [Server.replace_result()]} | {:error, String.t()}
-  defdelegate find_and_replace_batch(server, edits), to: Server
+  defdelegate find_and_replace_batch(server, edits, boundary \\ nil), to: Server
 
   @doc "Append text to the end of the buffer."
   @spec append(server(), String.t()) :: :ok

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -160,11 +160,14 @@ defmodule Minga.Buffer.Server do
   if the text is not found, is ambiguous (multiple matches), or the buffer
   is read-only.
   """
-  @spec find_and_replace(GenServer.server(), String.t(), String.t()) ::
+  @typedoc "An edit boundary as `{start_line, end_line}` (both inclusive, 0-indexed), or nil for unbounded."
+  @type boundary :: {non_neg_integer(), non_neg_integer()} | nil
+
+  @spec find_and_replace(GenServer.server(), String.t(), String.t(), boundary()) ::
           {:ok, String.t()} | {:error, String.t()}
-  def find_and_replace(server, old_text, new_text)
+  def find_and_replace(server, old_text, new_text, boundary \\ nil)
       when is_binary(old_text) and is_binary(new_text) do
-    GenServer.call(server, {:find_and_replace, old_text, new_text})
+    GenServer.call(server, {:find_and_replace, old_text, new_text, boundary})
   end
 
   @typedoc "A find-and-replace edit pair for batch operations."
@@ -181,12 +184,15 @@ defmodule Minga.Buffer.Server do
   don't block subsequent edits. A single undo entry is pushed for the entire
   batch.
 
+  When `boundary` is provided, each edit is checked against the boundary and
+  rejected if the match falls outside the allowed line range.
+
   Returns `{:ok, results}` where results is a list of per-edit outcomes.
   """
-  @spec find_and_replace_batch(GenServer.server(), [replace_edit()]) ::
+  @spec find_and_replace_batch(GenServer.server(), [replace_edit()], boundary()) ::
           {:ok, [replace_result()]} | {:error, String.t()}
-  def find_and_replace_batch(server, edits) when is_list(edits) do
-    GenServer.call(server, {:find_and_replace_batch, edits})
+  def find_and_replace_batch(server, edits, boundary \\ nil) when is_list(edits) do
+    GenServer.call(server, {:find_and_replace_batch, edits, boundary})
   end
 
   @doc "Deletes the character before the cursor (backspace)."
@@ -970,40 +976,48 @@ defmodule Minga.Buffer.Server do
 
   # ── Find and Replace ──
 
-  def handle_call({:find_and_replace, _old, _new}, _from, %{read_only: true} = state) do
+  def handle_call({:find_and_replace, _old, _new, _boundary}, _from, %{read_only: true} = state) do
     {:reply, {:error, "buffer is read-only"}, state}
   end
 
-  def handle_call({:find_and_replace, "", _new}, _from, state) do
+  def handle_call({:find_and_replace, "", _new, _boundary}, _from, state) do
     {:reply, {:error, "old_text is empty"}, state}
   end
 
-  def handle_call({:find_and_replace, old_text, new_text}, _from, state) do
+  def handle_call({:find_and_replace, old_text, new_text, boundary}, _from, state) do
     content = Document.content(state.document)
 
     case do_find_and_replace(content, old_text, new_text) do
       {:ok, new_doc, msg} ->
-        {:reply, {:ok, msg},
-         push_undo_force(state, new_doc, :agent)
-         |> mark_dirty()
-         |> clear_edits(EditSource.agent(self(), "unknown"))}
+        case check_boundary(content, old_text, boundary) do
+          :ok ->
+            {:reply, {:ok, msg},
+             push_undo_force(state, new_doc, :agent)
+             |> mark_dirty()
+             |> clear_edits(EditSource.agent(self(), "unknown"))}
+
+          {:error, _} = err ->
+            {:reply, err, state}
+        end
 
       {:error, _} = err ->
         {:reply, err, state}
     end
   end
 
-  def handle_call({:find_and_replace_batch, _edits}, _from, %{read_only: true} = state) do
+  def handle_call({:find_and_replace_batch, _edits, _boundary}, _from, %{read_only: true} = state) do
     {:reply, {:error, "buffer is read-only"}, state}
   end
 
-  def handle_call({:find_and_replace_batch, []}, _from, state) do
+  def handle_call({:find_and_replace_batch, [], _boundary}, _from, state) do
     {:reply, {:ok, []}, state}
   end
 
-  def handle_call({:find_and_replace_batch, edits}, _from, state) do
+  def handle_call({:find_and_replace_batch, edits, boundary}, _from, state) do
     {final_doc, results_reversed} =
-      Enum.reduce(edits, {state.document, []}, &apply_batch_edit/2)
+      Enum.reduce(edits, {state.document, []}, fn edit, acc ->
+        apply_batch_edit(edit, acc, boundary)
+      end)
 
     results = Enum.reverse(results_reversed)
     any_applied = Enum.any?(results, &match?({:ok, _}, &1))
@@ -1725,19 +1739,63 @@ defmodule Minga.Buffer.Server do
 
   # ── Find and Replace helpers ──
 
-  @spec apply_batch_edit({String.t(), String.t()}, {Document.t(), [replace_result()]}) ::
+  @spec apply_batch_edit({String.t(), String.t()}, {Document.t(), [replace_result()]}, boundary()) ::
           {Document.t(), [replace_result()]}
-  defp apply_batch_edit({"", _new_text}, {doc, acc}) do
+  defp apply_batch_edit({"", _new_text}, {doc, acc}, _boundary) do
     {doc, [{:error, "old_text is empty"} | acc]}
   end
 
-  defp apply_batch_edit({old_text, new_text}, {doc, acc}) do
+  defp apply_batch_edit({old_text, new_text}, {doc, acc}, boundary) do
     content = Document.content(doc)
 
     case do_find_and_replace(content, old_text, new_text) do
-      {:ok, new_doc, msg} -> {new_doc, [{:ok, msg} | acc]}
-      {:error, _} = err -> {doc, [err | acc]}
+      {:ok, new_doc, msg} ->
+        case check_boundary(content, old_text, boundary) do
+          :ok -> {new_doc, [{:ok, msg} | acc]}
+          {:error, _} = err -> {doc, [err | acc]}
+        end
+
+      {:error, _} = err ->
+        {doc, [err | acc]}
     end
+  end
+
+  # Checks whether a text match falls within the allowed boundary.
+  # Returns :ok if no boundary is set or the match is within bounds.
+  # Returns {:error, reason} if the match is outside the boundary.
+  @spec check_boundary(String.t(), String.t(), boundary()) :: :ok | {:error, String.t()}
+  defp check_boundary(_content, _old_text, nil), do: :ok
+
+  defp check_boundary(content, old_text, {boundary_start, boundary_end}) do
+    case :binary.matches(content, old_text) do
+      [{offset, len}] ->
+        # Count newlines before the match to determine the start line
+        before_match = binary_part(content, 0, offset)
+        match_start_line = count_newlines(before_match)
+
+        # Count newlines within the match to determine the end line
+        match_text = binary_part(content, offset, len)
+        match_end_line = match_start_line + count_newlines(match_text)
+
+        if match_start_line >= boundary_start and match_end_line <= boundary_end do
+          :ok
+        else
+          {:error,
+           "edit outside boundary: match spans lines #{match_start_line}-#{match_end_line}, " <>
+             "allowed range is #{boundary_start}-#{boundary_end}"}
+        end
+
+      # Not found or ambiguous: let do_find_and_replace handle the error
+      _ ->
+        :ok
+    end
+  end
+
+  @spec count_newlines(binary()) :: non_neg_integer()
+  defp count_newlines(binary) do
+    binary
+    |> :binary.matches("\n")
+    |> length()
   end
 
   # Performs the actual string search and replace on raw content.

--- a/test/minga/agent/edit_boundary_test.exs
+++ b/test/minga/agent/edit_boundary_test.exs
@@ -1,0 +1,162 @@
+defmodule Minga.Agent.EditBoundaryTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Minga.Agent.EditBoundary
+
+  describe "new/2" do
+    test "creates a boundary when start <= end" do
+      assert {:ok, %EditBoundary{start_line: 5, end_line: 10}} = EditBoundary.new(5, 10)
+    end
+
+    test "creates a single-line boundary" do
+      assert {:ok, %EditBoundary{start_line: 0, end_line: 0}} = EditBoundary.new(0, 0)
+    end
+
+    test "returns error when start > end" do
+      assert {:error, msg} = EditBoundary.new(10, 5)
+      assert msg =~ "start_line"
+      assert msg =~ "end_line"
+    end
+  end
+
+  describe "contains_line?/2" do
+    setup do
+      {:ok, boundary} = EditBoundary.new(5, 10)
+      %{boundary: boundary}
+    end
+
+    test "returns true for lines within the range", %{boundary: b} do
+      assert EditBoundary.contains_line?(b, 5)
+      assert EditBoundary.contains_line?(b, 7)
+      assert EditBoundary.contains_line?(b, 10)
+    end
+
+    test "returns false for lines outside the range", %{boundary: b} do
+      refute EditBoundary.contains_line?(b, 4)
+      refute EditBoundary.contains_line?(b, 11)
+      refute EditBoundary.contains_line?(b, 0)
+    end
+  end
+
+  describe "contains_range?/3" do
+    setup do
+      {:ok, boundary} = EditBoundary.new(5, 10)
+      %{boundary: boundary}
+    end
+
+    test "returns true when the range is fully inside the boundary", %{boundary: b} do
+      assert EditBoundary.contains_range?(b, 5, 10)
+      assert EditBoundary.contains_range?(b, 6, 9)
+    end
+
+    test "returns false when the range extends outside the boundary", %{boundary: b} do
+      refute EditBoundary.contains_range?(b, 4, 10)
+      refute EditBoundary.contains_range?(b, 5, 11)
+      refute EditBoundary.contains_range?(b, 0, 20)
+    end
+  end
+
+  describe "adjust/3" do
+    test "shifts both start and end when edit is above the boundary" do
+      {:ok, b} = EditBoundary.new(10, 20)
+
+      assert %EditBoundary{start_line: 13, end_line: 23} = EditBoundary.adjust(b, 5, 3)
+      assert %EditBoundary{start_line: 7, end_line: 17} = EditBoundary.adjust(b, 5, -3)
+    end
+
+    test "shifts only end when edit is within the boundary" do
+      {:ok, b} = EditBoundary.new(10, 20)
+
+      assert %EditBoundary{start_line: 10, end_line: 22} = EditBoundary.adjust(b, 15, 2)
+      assert %EditBoundary{start_line: 10, end_line: 18} = EditBoundary.adjust(b, 10, -2)
+    end
+
+    test "is a no-op when edit is below the boundary" do
+      {:ok, b} = EditBoundary.new(10, 20)
+
+      assert %EditBoundary{start_line: 10, end_line: 20} = EditBoundary.adjust(b, 21, 5)
+    end
+
+    test "returns nil when the boundary collapses from large negative delta above" do
+      {:ok, b} = EditBoundary.new(10, 12)
+
+      # Shift by -20 above the boundary
+      result = EditBoundary.adjust(b, 5, -20)
+
+      # Both lines clamp to 0, so 0 >= 0, returns {0, 0} not nil
+      # Actually: max(10 + -20, 0) = 0, max(12 + -20, 0) = 0, 0 >= 0 → %{0, 0}
+      assert %EditBoundary{start_line: 0, end_line: 0} = result
+    end
+
+    test "single-line boundary within-edit preserves itself" do
+      {:ok, b} = EditBoundary.new(5, 5)
+
+      # Edit at line 5 with delta -1: max(5 + -1, 5) = 5
+      assert %EditBoundary{start_line: 5, end_line: 5} = EditBoundary.adjust(b, 5, -1)
+    end
+
+    test "zero-line boundary at line 0 survives within-edit" do
+      {:ok, b} = EditBoundary.new(0, 0)
+
+      assert %EditBoundary{start_line: 0, end_line: 0} = EditBoundary.adjust(b, 0, -1)
+    end
+  end
+
+  describe "properties" do
+    property "contains_line? is true for all lines in start..end" do
+      check all(
+              start <- integer(0..100),
+              span <- integer(0..50)
+            ) do
+        {:ok, b} = EditBoundary.new(start, start + span)
+
+        for line <- start..(start + span) do
+          assert EditBoundary.contains_line?(b, line)
+        end
+      end
+    end
+
+    property "adjust with delta 0 is identity" do
+      check all(
+              start <- integer(0..100),
+              span <- integer(0..50),
+              edit_line <- integer(0..200)
+            ) do
+        {:ok, b} = EditBoundary.new(start, start + span)
+        result = EditBoundary.adjust(b, edit_line, 0)
+        assert result == b
+      end
+    end
+
+    property "adjust with edits below is identity" do
+      check all(
+              start <- integer(0..100),
+              span <- integer(0..50),
+              offset <- integer(1..50)
+            ) do
+        end_line = start + span
+        {:ok, b} = EditBoundary.new(start, end_line)
+        result = EditBoundary.adjust(b, end_line + offset, 5)
+        assert result == b
+      end
+    end
+
+    property "adjust preserves span when edit is above and no clamping" do
+      check all(
+              start <- integer(1..100),
+              span <- integer(0..50),
+              delta <- integer(0..10),
+              edit_line <- integer(0..(start - 1))
+            ) do
+        end_line = start + span
+        {:ok, b} = EditBoundary.new(start, end_line)
+        result = EditBoundary.adjust(b, edit_line, delta)
+
+        # Positive deltas (or zero) above the boundary never clamp,
+        # so the span is always preserved
+        assert result.end_line - result.start_line == span
+      end
+    end
+  end
+end

--- a/test/minga/buffer/server_test.exs
+++ b/test/minga/buffer/server_test.exs
@@ -1403,4 +1403,102 @@ defmodule Minga.Buffer.ServerTest do
       assert {:ok, ^pid_b} = Server.pid_for_path(path_b)
     end
   end
+
+  describe "find_and_replace/4 with boundary" do
+    test "edit within boundary succeeds" do
+      {:ok, pid} = Server.start_link(content: "line0\nline1\nline2\nline3\nline4")
+
+      assert {:ok, _} = Server.find_and_replace(pid, "line2", "REPLACED", {1, 3})
+      assert Server.content(pid) =~ "REPLACED"
+    end
+
+    test "edit outside boundary is rejected with descriptive error" do
+      {:ok, pid} = Server.start_link(content: "line0\nline1\nline2\nline3\nline4")
+
+      assert {:error, msg} = Server.find_and_replace(pid, "line0", "NOPE", {1, 3})
+      assert msg =~ "outside boundary"
+      assert msg =~ "lines 0-0"
+      assert msg =~ "1-3"
+      assert Server.content(pid) == "line0\nline1\nline2\nline3\nline4"
+    end
+
+    test "edit at boundary start line succeeds (inclusive)" do
+      {:ok, pid} = Server.start_link(content: "line0\nline1\nline2\nline3\nline4")
+
+      assert {:ok, _} = Server.find_and_replace(pid, "line2", "OK", {2, 4})
+    end
+
+    test "edit at boundary end line succeeds (inclusive)" do
+      {:ok, pid} = Server.start_link(content: "line0\nline1\nline2\nline3\nline4")
+
+      assert {:ok, _} = Server.find_and_replace(pid, "line4", "OK", {2, 4})
+    end
+
+    test "nil boundary allows any edit (backward compatible)" do
+      {:ok, pid} = Server.start_link(content: "line0\nline1\nline2")
+
+      assert {:ok, _} = Server.find_and_replace(pid, "line0", "OK", nil)
+      assert {:ok, _} = Server.find_and_replace(pid, "OK", "DONE")
+    end
+
+    test "multi-line match spanning boundary is rejected" do
+      {:ok, pid} = Server.start_link(content: "aaa\nbbb\nccc\nddd")
+
+      assert {:error, msg} = Server.find_and_replace(pid, "bbb\nccc\nddd", "NOPE", {1, 2})
+      assert msg =~ "outside boundary"
+    end
+
+    test "multi-line match fully within boundary succeeds" do
+      {:ok, pid} = Server.start_link(content: "aaa\nbbb\nccc\nddd\neee")
+
+      assert {:ok, _} = Server.find_and_replace(pid, "bbb\nccc\nddd", "OK", {1, 3})
+    end
+
+    test "edit on single-line boundary at line 0 succeeds" do
+      {:ok, pid} = Server.start_link(content: "only_line")
+
+      assert {:ok, _} = Server.find_and_replace(pid, "only_line", "replaced", {0, 0})
+    end
+
+    test "unicode content does not confuse boundary check" do
+      {:ok, pid} = Server.start_link(content: "café\n日本語\ntarget\nmore")
+
+      assert {:ok, _} = Server.find_and_replace(pid, "target", "hit", {2, 2})
+      assert Server.content(pid) =~ "hit"
+    end
+
+    test "ambiguous match returns ambiguous error, not boundary error" do
+      {:ok, pid} = Server.start_link(content: "foo\nfoo")
+
+      assert {:error, msg} = Server.find_and_replace(pid, "foo", "bar", {0, 0})
+      assert msg =~ "2 times"
+    end
+  end
+
+  describe "find_and_replace_batch/3 with boundary" do
+    test "rejects individual edits outside boundary while applying valid ones" do
+      {:ok, pid} = Server.start_link(content: "line0\nline1\nline2\nline3")
+
+      edits = [{"line1", "OK1"}, {"line0", "NOPE"}, {"line2", "OK2"}]
+      assert {:ok, results} = Server.find_and_replace_batch(pid, edits, {1, 2})
+
+      assert [{:ok, _}, {:error, _}, {:ok, _}] = results
+
+      content = Server.content(pid)
+      assert content =~ "OK1"
+      assert content =~ "OK2"
+      assert content =~ "line0"
+    end
+
+    test "all edits outside boundary leaves buffer unchanged" do
+      {:ok, pid} = Server.start_link(content: "line0\nline1\nline2")
+
+      edits = [{"line0", "X"}, {"line2", "Y"}]
+      assert {:ok, results} = Server.find_and_replace_batch(pid, edits, {1, 1})
+
+      assert [{:error, _}, {:error, _}] = results
+      refute Server.dirty?(pid)
+      assert Server.content(pid) == "line0\nline1\nline2"
+    end
+  end
 end


### PR DESCRIPTION
## What

Users can define line ranges that an agent session is allowed to edit within a buffer. Edits outside the boundary are rejected with a descriptive error message telling the agent which lines it tried to edit and which lines are allowed.

## Why

As agents become more autonomous, users need guardrails. An agent refactoring a module should not accidentally modify the public API contract at the top of the file, or rewrite test fixtures it was not asked to touch. Edit boundaries enforce constraints structurally through the buffer's edit pipeline, not through prompt engineering that the agent might ignore.

## Changes

**`lib/minga/agent/edit_boundary.ex`** (new)
Pure struct with line range validation, membership checks, and line-shift adjustment. Boundaries track `{start_line, end_line}` (0-indexed, both inclusive) and adjust when edits above or within the boundary change line counts.

**`lib/minga/buffer/server.ex`**
- `find_and_replace/4` accepts optional `boundary` parameter
- `find_and_replace_batch/3` accepts optional `boundary` parameter
- Boundary enforcement is atomic: search, boundary check, and replace happen in a single `handle_call`. No TOCTOU race.
- Uses byte offset to line number conversion via newline counting.

**`lib/minga/agent/session.ex`**
- Added `boundaries` field to session state (`%{String.t() => EditBoundary.t()}`)
- Public API: `set_boundary/4`, `clear_boundary/2`, `clear_all_boundaries/1`, `boundary_for/2`
- Boundaries are cleared on session reset/load

**`lib/minga/agent/tools/edit_file.ex`** and **`multi_edit_file.ex`**
- Accept and pass optional boundary parameter through to Buffer.Server

**`lib/minga/buffer.ex`**
- Facade updated with optional boundary parameter on `find_and_replace` and `find_and_replace_batch`

## Architecture Decision

Boundaries live in agent session state (per-session policy). Enforcement happens in Buffer.Server via parameter (atomic, no TOCTOU). Adjustment happens in the session after each edit. This was validated with archie: storing boundaries in Buffer.Server would mix agent-session concerns into the buffer layer.

## Tests

- 15 unit tests + 4 property tests for `EditBoundary` (pure functions)
- 11 Buffer.Server tests: within boundary, outside boundary, start/end inclusive, nil boundary (backward compatible), multi-line match spanning boundary, multi-line match within, single-line boundary, unicode content, ambiguous match priority, batch with mixed results, all-outside batch

735 existing tests pass with 0 failures.

Depends on #393. Stacked on `feat/393-readfile-buffer-routing`.

Closes #78