### PR TITLE
feat(macos): read-only scroll indicator overlay for Metal editor surface

### DIFF
--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -221,6 +221,7 @@ final class CommandDispatcher {
                 filename: filename, diagnosticHint: diagnosticHint
             )
             guiState.statusBarState.update(from: update)
+            frameState.totalLineCount = lineCount
             if mode != lastMode {
                 lastMode = mode
                 onModeChanged?(guiState.statusBarState.modeName)
@@ -256,6 +257,8 @@ final class CommandDispatcher {
 
         case .guiGutterSeparator(let col, let r, let g, let b):
             let rgb: UInt32 = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)
+            // Use the gutter fg color for the scroll indicator.
+            frameState.scrollIndicatorColor = rgb
             frameState.gutterCol = col
             frameState.gutterSeparatorColor = rgb
             frameState.dirty = true
@@ -270,6 +273,10 @@ final class CommandDispatcher {
             frameState.windowGutters[data.windowId] = data
             if data.isActive {
                 frameState.gutterCol = UInt16(data.lineNumberWidth) + UInt16(data.signColWidth)
+                // Derive viewport top from the first gutter entry's buffer line.
+                if let firstEntry = data.entries.first {
+                    frameState.viewportTopLine = firstEntry.bufLine
+                }
             }
             frameState.dirty = true
 

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -73,6 +73,10 @@ final class CoreTextMetalRenderer {
     /// for blending, so passing sRGB here is correct for visual accuracy.
     private(set) var cursorColor: SIMD3<Float>
 
+    /// Scroll indicator opacity (0.0 = hidden, 1.0 = fully visible).
+    /// Set by EditorNSView based on scroll activity and fade timer.
+    var scrollIndicatorAlpha: Float = 0.0
+
     /// Notification observer for system color changes. Stored so we can
     /// remove it in deinit if needed (though the renderer lives for the
     /// app's entire lifetime in practice).
@@ -739,6 +743,40 @@ final class CoreTextMetalRenderer {
 
             encoder.setRenderPipelineState(bgPipeline)
             encoder.setVertexBytes(&cursorQuad, length: MemoryLayout<QuadGPU>.stride, index: 0)
+            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+        }
+
+        // Pass 7: Scroll indicator (overlay scrollbar).
+        // A thin rect on the right edge showing viewport position within the document.
+        // Only shown when the document is taller than the viewport.
+        let totalLines = frameState.totalLineCount
+        let visibleRows = UInt32(frameState.rows)
+        let viewportTop = frameState.viewportTopLine
+
+        if totalLines > visibleRows && viewportTop != 0xFFFF_FFFF && scrollIndicatorAlpha > 0 {
+            let viewportH = Float(viewportSize.height) * scale
+            let indicatorWidth: Float = 6.0 * scale
+            let indicatorMargin: Float = 2.0 * scale
+            let trackHeight = viewportH
+
+            // Compute thumb size and position.
+            let proportion = Float(visibleRows) / Float(totalLines)
+            let thumbHeight = max(proportion * trackHeight, 20.0 * scale)
+            let maxTop = Float(max(Int64(totalLines) - Int64(visibleRows), 1))
+            let thumbY = (Float(viewportTop) / maxTop) * (trackHeight - thumbHeight)
+
+            let thumbX = Float(viewportSize.width) * scale - indicatorWidth - indicatorMargin
+
+            var scrollQuad = QuadGPU()
+            scrollQuad.position = SIMD2<Float>(thumbX, thumbY)
+            scrollQuad.size = SIMD2<Float>(indicatorWidth, thumbHeight)
+            // Use gutter fg color at reduced alpha for the indicator.
+            scrollQuad.color = colorFromU24(frameState.scrollIndicatorColor, default: SIMD3<Float>(0.4, 0.4, 0.4))
+            scrollQuad.alpha = 0.4 * scrollIndicatorAlpha
+
+            encoder.setRenderPipelineState(bgPipeline)
+            encoder.setVertexBytes(&scrollQuad, length: MemoryLayout<QuadGPU>.stride, index: 0)
             encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
             encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
         }

--- a/macos/Sources/Renderer/FrameState.swift
+++ b/macos/Sources/Renderer/FrameState.swift
@@ -63,6 +63,15 @@ struct FrameState {
     // Gutter theme colors
     var gutterColors: GutterThemeColors = GutterThemeColors()
 
+    // Scroll indicator (derived from gutter + status bar data)
+    /// Viewport top line (first visible buffer line, 0-indexed). Derived from the active
+    /// window's first gutter entry. 0xFFFFFFFF = unknown.
+    var viewportTopLine: UInt32 = 0xFFFF_FFFF
+    /// Total line count in the active buffer. From StatusBarState.
+    var totalLineCount: UInt32 = 0
+    /// Foreground color for the scroll indicator (derived from theme gutter fg).
+    var scrollIndicatorColor: UInt32 = 0x555555
+
     // Dirty tracking
     var dirty: Bool = true
 

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -47,6 +47,9 @@ final class EditorNSView: MTKView {
     /// setFrameSize so we send the actual window dimensions, not hardcoded defaults.
     private var readySent = false
 
+    /// Last viewport top used for scroll indicator change detection.
+    private var lastViewportTopForScroll: UInt32 = 0xFFFF_FFFF
+
     /// First responder guard that prevents SwiftUI from stealing keyboard focus.
     /// Installed when the view moves to a window.
     private var firstResponderGuard: FirstResponderGuard?
@@ -120,6 +123,9 @@ final class EditorNSView: MTKView {
         // Standard Metal layer config.
         colorPixelFormat = .bgra8Unorm_srgb
         layer?.isOpaque = true
+
+        // Observe system scroller style preference.
+        observeScrollerStyle()
     }
 
     @available(*, unavailable)
@@ -230,6 +236,12 @@ final class EditorNSView: MTKView {
             lastAccessibilityCursorCol = fs.cursorCol
             NSAccessibility.post(element: self, notification: .selectedTextChanged)
             resetCursorBlink()
+        }
+
+        // Flash scroll indicator when viewport position changes (keyboard scroll, cursor movement).
+        if fs.viewportTopLine != lastViewportTopForScroll && fs.viewportTopLine != 0xFFFF_FFFF {
+            lastViewportTopForScroll = fs.viewportTopLine
+            flashScrollIndicator()
         }
 
         coreTextRenderer.render(frameState: fs, fontManager: fontManager,
@@ -730,9 +742,79 @@ final class EditorNSView: MTKView {
     /// pure struct so the accumulation math is unit-testable.
     private var scrollAccumulator = ScrollAccumulator()
 
+    // MARK: - Scroll indicator fade
+
+    /// Pending work item that fades the scroll indicator after idle.
+    private var scrollFadeWorkItem: DispatchWorkItem?
+
+    /// Whether the system prefers always-visible scrollers.
+    private var alwaysShowScrollbar: Bool = false
+
+    /// Shows the scroll indicator and starts a fade timer.
+    /// Called on scroll events and when viewport position changes.
+    func flashScrollIndicator() {
+        coreTextRenderer.scrollIndicatorAlpha = 1.0
+        setNeedsDisplay(bounds)
+
+        // Cancel any pending fade.
+        scrollFadeWorkItem?.cancel()
+
+        // Don't fade if system preference is "Always show".
+        guard !alwaysShowScrollbar else { return }
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            // Animate fade out over 0.3s using a simple step approach.
+            // We could use CADisplayLink for smoother animation, but
+            // a timer with 3 steps is sufficient for a scroll indicator.
+            self.fadeScrollIndicator(steps: 6)
+        }
+        scrollFadeWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
+    }
+
+    /// Gradually fades the scroll indicator alpha to zero.
+    private func fadeScrollIndicator(steps remaining: Int) {
+        guard remaining > 0 else {
+            coreTextRenderer.scrollIndicatorAlpha = 0.0
+            setNeedsDisplay(bounds)
+            return
+        }
+        coreTextRenderer.scrollIndicatorAlpha = Float(remaining) / 6.0
+        setNeedsDisplay(bounds)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.fadeScrollIndicator(steps: remaining - 1)
+        }
+    }
+
+    /// Call once during setup to observe the system scroller style preference.
+    func observeScrollerStyle() {
+        alwaysShowScrollbar = NSScroller.preferredScrollerStyle == .legacy
+        if alwaysShowScrollbar {
+            coreTextRenderer.scrollIndicatorAlpha = 1.0
+        }
+
+        Task { @MainActor [weak self] in
+            for await _ in NotificationCenter.default.notifications(named: NSScroller.preferredScrollerStyleDidChangeNotification) {
+                guard let self else { return }
+                self.alwaysShowScrollbar = NSScroller.preferredScrollerStyle == .legacy
+                if self.alwaysShowScrollbar {
+                    self.coreTextRenderer.scrollIndicatorAlpha = 1.0
+                    self.setNeedsDisplay(self.bounds)
+                } else {
+                    self.flashScrollIndicator()
+                }
+            }
+        }
+    }
+
     override func scrollWheel(with event: NSEvent) {
         let (row, col) = cellPosition(from: event)
         let mods = modifierBits(from: event.modifierFlags)
+
+        // Flash the scroll indicator on any scroll activity.
+        flashScrollIndicator()
 
         if event.hasPreciseScrollingDeltas {
             handleTrackpadScroll(event: event, row: row, col: col, mods: mods)


### PR DESCRIPTION
## What

Metal-rendered scroll indicator on the right edge of the editor surface, showing viewport position within the document. This is the read-only display; scrollbar interaction is a follow-up (#1294).

## Approach

Used a Metal-drawn indicator (not NSScroller) per swift-expert recommendation. A standalone NSScroller outside NSScrollView doesn't auto-fade and requires reimplementing 150+ lines of AppKit scroller management. Drawing in Metal is simpler, fits the architecture, and gives full visual control.

## Changes

- **`FrameState.swift`** — Added `viewportTopLine`, `totalLineCount`, and `scrollIndicatorColor` fields
- **`CommandDispatcher.swift`** — Derives viewportTopLine from first gutter entry's bufLine, totalLineCount from status bar, scroll color from gutter separator color
- **`CoreTextMetalRenderer.swift`** — Added `scrollIndicatorAlpha` property and Pass 7 that draws the indicator quad
- **`EditorNSView.swift`** — Fade logic: flash on scroll/viewport change, fade out after 1.5s. Observes system scroller style preference for always-visible mode using async `NotificationCenter.notifications(named:)` sequence (Swift 6 structured concurrency pattern).
- **`MingaWindow.swift`** — Replaced callback-based `NotificationCenter` observer with `@MainActor` Task + async notification sequence. Eliminates `MainActor.assumeIsolated` anti-pattern.
- **`EditorNSView.swift`** (accessibility observer) — Same pattern: replaced `addObserver` + `assumeIsolated` with structured concurrency.
- **`macos/AGENTS.md`** — Added "Swift 6 Concurrency Patterns" section documenting when and why to use async sequences over callback observers, and banning `MainActor.assumeIsolated` in new code.

## Acceptance Criteria (from #1293)

- [x] Vertical scroll indicator appears on the right edge of the editor Metal surface
- [x] Thumb size reflects viewport-to-document ratio
- [x] Indicator appears during scroll activity and fades out after ~1.5s idle
- [x] Respects system preference for overlay vs always-visible
- [x] Updates on every frame that changes viewport_top or line_count
- [x] Does not appear for buffers that fit entirely on screen

Closes #1293