### PR TITLE
feat(macos): Metal-side indent guide rendering

### DIFF
--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -64,6 +64,7 @@ let OP_GUI_CHANGE_SUMMARY: UInt8 = 0x89
 // Old frontends skip unknown 0x90+ opcodes by reading the length.
 
 let OP_CLIPBOARD_WRITE: UInt8 = 0x90
+let OP_GUI_INDENT_GUIDES: UInt8 = 0x91
 
 // MARK: - Sectioned format section IDs
 // Used by opcodes with self-describing sections (gui_status_bar, etc.).

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -53,6 +53,7 @@ enum RenderCommand: Sendable {
     case guiSignatureHelp(visible: Bool, anchorRow: UInt16, anchorCol: UInt16, activeSignature: UInt8, activeParameter: UInt8, signatures: [Wire.Signature])
     case guiFloatPopup(visible: Bool, width: UInt16, height: UInt16, title: String, lines: [String])
     case clipboardWrite(target: UInt8, text: String)
+    case guiIndentGuides(data: IndentGuideData)
     case guiSplitSeparators(borderColor: UInt32, verticals: [Wire.VerticalSeparator], horizontals: [Wire.HorizontalSeparator])
     case guiGitStatus(repoState: UInt8, ahead: UInt16, behind: UInt16, branchName: String, entries: [Wire.GitStatusEntry])
     case guiAgentGroups(activeGroupId: UInt16, agentGroups: [Wire.AgentGroupEntry])
@@ -1879,6 +1880,31 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         }
         return (.guiChangeSummary(visible: csVisible, entries: csEntries, selectedIndex: csSelectedIndex),
                 csPos - offset)
+
+    case OP_GUI_INDENT_GUIDES:
+        // Forward-compatible format: opcode(1) + payload_length(2) + payload
+        // Payload: window_id(2) + tab_width(1) + active_guide_col(2) + guide_count(1) + guide_cols(2 each)
+        guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
+        let igPayloadLen = Int(readU16(data, rest))
+        guard data.count >= rest + 2 + igPayloadLen, igPayloadLen >= 6 else {
+            throw ProtocolDecodeError.malformed
+        }
+        let igStart = rest + 2
+        let igWinId = readU16(data, igStart)
+        let igTabWidth = data[igStart + 2]
+        let igActiveCol = readU16(data, igStart + 3)
+        let igGuideCount = Int(data[igStart + 5])
+        var igCols: [UInt16] = []
+        igCols.reserveCapacity(igGuideCount)
+        var igPos = igStart + 6
+        for _ in 0..<igGuideCount {
+            guard igPos + 2 <= rest + 2 + igPayloadLen else { break }
+            igCols.append(readU16(data, igPos))
+            igPos += 2
+        }
+        let igData = IndentGuideData(windowId: igWinId, tabWidth: igTabWidth,
+                                     activeGuideCol: igActiveCol, guideCols: igCols)
+        return (.guiIndentGuides(data: igData), 1 + 2 + igPayloadLen)
 
     case OP_CLIPBOARD_WRITE:
         // Forward-compatible format: opcode(1) + payload_length(2) + target(1) + text_len(2) + text

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -373,3 +373,13 @@ enum CursorShape: UInt8, Sendable {
     case beam = 0x01
     case underline = 0x02
 }
+
+/// Indent guide data from the BEAM (opcode 0x91).
+struct IndentGuideData: Sendable {
+    let windowId: UInt16
+    let tabWidth: UInt8
+    /// Character column of the active guide. 0xFFFF = no active guide.
+    let activeGuideCol: UInt16
+    /// Character columns where guides appear (content-relative, not screen-relative).
+    let guideCols: [UInt16]
+}

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -179,6 +179,10 @@ final class CommandDispatcher {
         case .guiChangeSummary(let visible, let entries, let selectedIndex):
             guiState.changeSummaryState.update(visible: visible, entries: entries, selectedIndex: selectedIndex)
 
+        case .guiIndentGuides(let data):
+            frameState.windowIndentGuides[data.windowId] = data
+            frameState.dirty = true
+
         case .clipboardWrite(let target, let text):
             handleClipboardWrite(target: target, text: text)
 

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -524,6 +524,44 @@ final class CoreTextMetalRenderer {
             encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: bgQuads.count)
         }
 
+        // Pass 1.25: Indent guides (vertical lines at indentation levels).
+        // Drawn after bg fills but before text, cursor, and selection overlays.
+        for (_, guideData) in frameState.windowIndentGuides {
+            guard !guideData.guideCols.isEmpty else { continue }
+
+            // Find the window gutter to get the content offset for this window.
+            guard let gutter = frameState.windowGutters[guideData.windowId] else { continue }
+            let gutterWidth = Float(gutter.lineNumberWidth) + Float(gutter.signColWidth)
+            let windowContentColOffset = (Float(gutter.contentCol) + gutterWidth) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
+            let contentTopY = Float(gutter.contentRow) * cellH * scale
+            let contentHeightPx = Float(gutter.contentHeight) * cellH * scale
+
+            var guideQuads: [QuadGPU] = []
+            guideQuads.reserveCapacity(guideData.guideCols.count)
+
+            // Default foreground color from theme, at low alpha.
+            let inactiveFg = colorFromU24(frameState.gutterColors.fg, default: SIMD3<Float>(0.33, 0.33, 0.33))
+
+            for col in guideData.guideCols {
+                let guideX = windowContentColOffset + Float(col) * cellW * scale
+                let isActive = col == guideData.activeGuideCol
+
+                var quad = QuadGPU()
+                quad.position = SIMD2<Float>(guideX, contentTopY)
+                quad.size = SIMD2<Float>(1.0 * scale, contentHeightPx)
+                quad.color = inactiveFg
+                quad.alpha = isActive ? 0.4 : 0.15
+                guideQuads.append(quad)
+            }
+
+            if !guideQuads.isEmpty {
+                encoder.setRenderPipelineState(bgPipeline)
+                encoder.setVertexBytes(&guideQuads, length: guideQuads.count * MemoryLayout<QuadGPU>.stride, index: 0)
+                encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+                encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: guideQuads.count)
+            }
+        }
+
         // Pass 1.5: Semantic overlay quads (search matches, selection).
         // Drawn after bg fills but before cursor and text so they appear
         // behind text content. Selection and search highlights render as

--- a/macos/Sources/Renderer/FrameState.swift
+++ b/macos/Sources/Renderer/FrameState.swift
@@ -72,6 +72,9 @@ struct FrameState {
     /// Foreground color for the scroll indicator (derived from theme gutter fg).
     var scrollIndicatorColor: UInt32 = 0x555555
 
+    // Indent guides (from 0x91 opcode)
+    var windowIndentGuides: [UInt16: IndentGuideData] = [:]
+
     // Dirty tracking
     var dirty: Bool = true
 


### PR DESCRIPTION
## What

Render indent guide lines in the Metal editor surface using data from the BEAM's indent guide opcode (0x91, from #1295).

## Changes

- **`ProtocolConstants.swift`** — Added `OP_GUI_INDENT_GUIDES = 0x91`
- **`ProtocolDecoder.swift`** — Decode the forward-compatible 0x91 opcode into `IndentGuideData`
- **`ProtocolTypes.swift`** — New `IndentGuideData` struct (windowId, tabWidth, activeGuideCol, guideCols)
- **`FrameState.swift`** — Store per-window indent guide data
- **`CommandDispatcher.swift`** — Route decoded guide data to FrameState
- **`CoreTextMetalRenderer.swift`** — New Pass 1.25 renders 1px vertical guide lines at each column. Active guide at 40% alpha, inactive at 15%.

## Acceptance Criteria (from #1296)

- [x] Thin vertical lines (1px at screen scale) at each indent guide column
- [x] Lines span the full content area height
- [x] Active indent guide renders in brighter/more visible color (40% vs 15% alpha)
- [x] Guide colors derived from theme gutter foreground
- [x] Guides render behind text (Pass 1.25, between bg fills and overlays)
- [x] Guides do not render in the gutter area (positioned from content start)

Depends on #1295 (BEAM-side computation).
Closes #1296