### PR TITLE
refactor(input): narrow Input handler type signature to handler_state contract (#1215)

### DIFF
--- a/lib/minga/input/agent_mouse.ex
+++ b/lib/minga/input/agent_mouse.ex
@@ -22,6 +22,8 @@ defmodule Minga.Input.AgentMouse do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Agent.UIState
   alias Minga.Agent.View.PromptRenderer
   alias Minga.Config
@@ -42,20 +44,19 @@ defmodule Minga.Input.AgentMouse do
   # ── Handler callbacks ──────────────────────────────────────────────────────
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(state, _cp, _mods), do: {:passthrough, state}
 
   @impl true
   @spec handle_mouse(
-          EditorState.t(),
+          state(),
           integer(),
           integer(),
           atom(),
           non_neg_integer(),
           atom(),
           pos_integer()
-        ) :: {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+        ) :: Minga.Input.Handler.result()
 
   def handle_mouse(state, row, col, button, mods, event_type, click_count) do
     layout = Layout.get(state)

--- a/lib/minga/input/agent_nav.ex
+++ b/lib/minga/input/agent_nav.ex
@@ -27,6 +27,8 @@ defmodule Minga.Input.AgentNav do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   import Bitwise
 
   alias Minga.Agent.UIState
@@ -35,8 +37,7 @@ defmodule Minga.Input.AgentNav do
   alias Minga.Editor.State.AgentAccess
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          Minga.Input.Handler.result()
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(%{workspace: %{keymap_scope: :agent}} = state, cp, mods) do
     panel = AgentAccess.panel(state)
 

--- a/lib/minga/input/agent_panel.ex
+++ b/lib/minga/input/agent_panel.ex
@@ -17,6 +17,8 @@ defmodule Minga.Input.AgentPanel do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Agent.UIState
   alias Minga.Editor.Commands
   alias Minga.Editor.Commands.Agent, as: AgentCommands
@@ -28,8 +30,7 @@ defmodule Minga.Input.AgentPanel do
   alias Minga.Keymap
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
 
   # Editor scope with agent side panel visible + input focused
   def handle_key(%{workspace: %{keymap_scope: :editor}} = state, cp, mods) do

--- a/lib/minga/input/completion.ex
+++ b/lib/minga/input/completion.ex
@@ -11,6 +11,8 @@ defmodule Minga.Input.Completion do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   import Bitwise
 
   alias Minga.Buffer
@@ -30,8 +32,7 @@ defmodule Minga.Input.Completion do
   @max_rows 10
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          Minga.Input.Handler.result()
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(
         %{workspace: %{editing: %{mode: :insert}, completion: %Completion{} = completion}} = state,
         cp,
@@ -49,7 +50,7 @@ defmodule Minga.Input.Completion do
 
   @impl true
   @spec handle_mouse(
-          EditorState.t(),
+          state(),
           integer(),
           integer(),
           atom(),

--- a/lib/minga/input/conflict_prompt.ex
+++ b/lib/minga/input/conflict_prompt.ex
@@ -9,13 +9,14 @@ defmodule Minga.Input.ConflictPrompt do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Buffer
   alias Minga.Editor.State, as: EditorState
   alias Minga.Workspace.State, as: WorkspaceState
 
   @impl true
-  @spec handle_key(Minga.Editor.State.t(), non_neg_integer(), non_neg_integer()) ::
-          Minga.Input.Handler.result()
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(%{workspace: %{pending_conflict: {buf, _path}}} = state, ?r, _mods)
       when is_pid(buf) do
     Buffer.reload(buf)

--- a/lib/minga/input/dashboard.ex
+++ b/lib/minga/input/dashboard.ex
@@ -10,6 +10,8 @@ defmodule Minga.Input.Dashboard do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Editor.Commands
   alias Minga.Editor.Commands.BufferManagement
   alias Minga.Editor.Dashboard
@@ -26,8 +28,7 @@ defmodule Minga.Input.Dashboard do
   @arrow_down 57_353
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          Minga.Input.Handler.result()
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(
         %{workspace: %{buffers: %{active: nil}}, shell_state: %{dashboard: %{} = dash}} = state,
         codepoint,

--- a/lib/minga/input/diff_review.ex
+++ b/lib/minga/input/diff_review.ex
@@ -10,6 +10,8 @@ defmodule Minga.Input.DiffReview do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Agent.View.Preview
   alias Minga.Editor.Commands
   alias Minga.Editor.State, as: EditorState
@@ -17,8 +19,7 @@ defmodule Minga.Input.DiffReview do
   alias Minga.Keymap
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(state, cp, _mods) do
     view = AgentAccess.view(state)
     panel = AgentAccess.panel(state)
@@ -32,8 +33,7 @@ defmodule Minga.Input.DiffReview do
     end
   end
 
-  @spec dispatch_diff_key(EditorState.t(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  @spec dispatch_diff_key(EditorState.t(), non_neg_integer()) :: Minga.Input.Handler.result()
   defp dispatch_diff_key(state, ?y), do: {:handled, Commands.execute(state, :agent_accept_hunk)}
   defp dispatch_diff_key(state, ?x), do: {:handled, Commands.execute(state, :agent_reject_hunk)}
 

--- a/lib/minga/input/file_tree_handler.ex
+++ b/lib/minga/input/file_tree_handler.ex
@@ -10,6 +10,8 @@ defmodule Minga.Input.FileTreeHandler do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Buffer
   alias Minga.Editor.Commands
   alias Minga.Editor.Layout
@@ -18,8 +20,7 @@ defmodule Minga.Input.FileTreeHandler do
   alias Minga.Keymap
   alias Minga.Project.FileTree
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
 
   # File tree scope with tree focused
   def handle_key(
@@ -41,14 +42,14 @@ defmodule Minga.Input.FileTreeHandler do
 
   @impl true
   @spec handle_mouse(
-          EditorState.t(),
+          state(),
           integer(),
           integer(),
           atom(),
           non_neg_integer(),
           atom(),
           pos_integer()
-        ) :: {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+        ) :: Minga.Input.Handler.result()
 
   # File tree: left click opens file/toggles dir, scroll wheel scrolls tree
   def handle_mouse(
@@ -85,7 +86,7 @@ defmodule Minga.Input.FileTreeHandler do
   # ── File tree key dispatch ─────────────────────────────────────────────
 
   @spec handle_file_tree_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+          Minga.Input.Handler.result()
   defp handle_file_tree_key(state, cp, mods) do
     if Input.key_sequence_pending?(state) do
       {:handled, delegate_to_mode_fsm_with_tree_buffer(state, cp, mods)}

--- a/lib/minga/input/git_status.ex
+++ b/lib/minga/input/git_status.ex
@@ -9,6 +9,8 @@ defmodule Minga.Input.GitStatus do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Buffer
   alias Minga.Editor.Commands
   alias Minga.Editor.State, as: EditorState
@@ -19,8 +21,7 @@ defmodule Minga.Input.GitStatus do
   alias Minga.Workspace.State, as: WorkspaceState
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(%{workspace: %{keymap_scope: :git_status}} = state, cp, mods) do
     if Input.key_sequence_pending?(state) do
       # Multi-key sequence in progress; delegate to mode FSM

--- a/lib/minga/input/global_bindings.ex
+++ b/lib/minga/input/global_bindings.ex
@@ -9,6 +9,8 @@ defmodule Minga.Input.GlobalBindings do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   import Bitwise
 
   alias Minga.Buffer
@@ -16,8 +18,7 @@ defmodule Minga.Input.GlobalBindings do
   @ctrl Minga.Input.mod_ctrl()
 
   @impl true
-  @spec handle_key(Minga.Editor.State.t(), non_neg_integer(), non_neg_integer()) ::
-          Minga.Input.Handler.result()
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
 
   # Ctrl+S: save current buffer
   def handle_key(state, ?s, mods) when band(mods, @ctrl) != 0 do

--- a/lib/minga/input/handler.ex
+++ b/lib/minga/input/handler.ex
@@ -7,6 +7,15 @@ defmodule Minga.Input.Handler do
   return `{:passthrough, state}` when their feature is inactive (e.g.,
   the picker handler passes through when no picker is open).
 
+  ## State contract
+
+  Input handlers receive a `handler_state()` which is currently
+  `Editor.State.t()`. This type alias is the narrowing point: as the
+  shell independence refactor progresses, it will be replaced by a
+  focused contract struct containing only what handlers need (workspace,
+  capabilities, layout, shell_state). Handlers should avoid accessing
+  fields outside these four to prepare for that narrowing.
+
   ## Implementing a handler
 
       defmodule MyHandler do
@@ -25,8 +34,17 @@ defmodule Minga.Input.Handler do
 
   alias Minga.Editor.State, as: EditorState
 
+  @typedoc """
+  The state type passed to input handlers.
+
+  Currently `Editor.State.t()`. This alias is the single point to narrow
+  when the input contract is fully decoupled from `Editor.State`. Handlers
+  should access only: `workspace`, `capabilities`, `layout`, `shell_state`.
+  """
+  @type handler_state :: EditorState.t()
+
   @typedoc "Result of handling a key press."
-  @type result :: {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  @type result :: {:handled, handler_state()} | {:passthrough, handler_state()}
 
   @doc """
   Processes a key press event.
@@ -37,7 +55,7 @@ defmodule Minga.Input.Handler do
   through (e.g., clearing a transient flag).
   """
   @callback handle_key(
-              EditorState.t(),
+              handler_state(),
               codepoint :: non_neg_integer(),
               modifiers :: non_neg_integer()
             ) :: result()
@@ -52,7 +70,7 @@ defmodule Minga.Input.Handler do
   this callback to intercept mouse events for your UI region.
   """
   @callback handle_mouse(
-              EditorState.t(),
+              handler_state(),
               row :: integer(),
               col :: integer(),
               button :: atom(),

--- a/lib/minga/input/hover.ex
+++ b/lib/minga/input/hover.ex
@@ -15,6 +15,8 @@ defmodule Minga.Input.Hover do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Editor.HoverPopup
   alias Minga.Editor.State, as: EditorState
 
@@ -22,8 +24,7 @@ defmodule Minga.Input.Hover do
   @key_escape 27
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          Minga.Input.Handler.result()
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(%{shell_state: %{hover_popup: nil}} = state, _codepoint, _modifiers) do
     {:passthrough, state}
   end
@@ -75,7 +76,7 @@ defmodule Minga.Input.Hover do
 
   @impl true
   @spec handle_mouse(
-          EditorState.t(),
+          state(),
           integer(),
           integer(),
           atom(),

--- a/lib/minga/input/interrupt.ex
+++ b/lib/minga/input/interrupt.ex
@@ -28,6 +28,8 @@ defmodule Minga.Input.Interrupt do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Agent.UIState
   alias Minga.Editing.Completion
   alias Minga.Editor.State, as: EditorState
@@ -42,8 +44,7 @@ defmodule Minga.Input.Interrupt do
   @ctrl_g 7
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          Minga.Input.Handler.result()
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(state, @ctrl_g, 0) do
     {new_state, resets} = reset_to_known_good(state)
     new_state = log_resets(new_state, resets)

--- a/lib/minga/input/mention_completion.ex
+++ b/lib/minga/input/mention_completion.ex
@@ -10,13 +10,13 @@ defmodule Minga.Input.MentionCompletion do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Editor.Commands.Agent, as: AgentCommands
-  alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.AgentAccess
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
 
   # Agent scope: mention completion active in insert mode
   def handle_key(%{workspace: %{keymap_scope: :agent}} = state, cp, mods) do

--- a/lib/minga/input/mode_fsm.ex
+++ b/lib/minga/input/mode_fsm.ex
@@ -13,12 +13,12 @@ defmodule Minga.Input.ModeFSM do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Editor.Mouse
-  alias Minga.Editor.State, as: EditorState
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          Minga.Input.Handler.result()
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(state, codepoint, modifiers) do
     new_state = Minga.Editor.do_handle_key(state, codepoint, modifiers)
     {:handled, new_state}
@@ -26,7 +26,7 @@ defmodule Minga.Input.ModeFSM do
 
   @impl true
   @spec handle_mouse(
-          EditorState.t(),
+          state(),
           integer(),
           integer(),
           atom(),

--- a/lib/minga/input/picker.ex
+++ b/lib/minga/input/picker.ex
@@ -10,13 +10,14 @@ defmodule Minga.Input.Picker do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Editor.PickerUI
   alias Minga.Editor.State, as: EditorState
   alias Minga.UI.Picker, as: PickerData
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          Minga.Input.Handler.result()
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(%{shell_state: %{picker_ui: %{picker: picker}}} = state, codepoint, modifiers)
       when is_struct(picker, PickerData) do
     new_state =
@@ -34,7 +35,7 @@ defmodule Minga.Input.Picker do
 
   @impl true
   @spec handle_mouse(
-          EditorState.t(),
+          state(),
           integer(),
           integer(),
           atom(),

--- a/lib/minga/input/popup.ex
+++ b/lib/minga/input/popup.ex
@@ -14,13 +14,14 @@ defmodule Minga.Input.Popup do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.Window
   alias Minga.UI.Popup.Lifecycle
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(state, codepoint, _modifiers) do
     case active_popup_meta(state) do
       nil ->
@@ -39,14 +40,14 @@ defmodule Minga.Input.Popup do
 
   @impl true
   @spec handle_mouse(
-          EditorState.t(),
+          state(),
           integer(),
           integer(),
           atom(),
           non_neg_integer(),
           atom(),
           pos_integer()
-        ) :: {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+        ) :: Minga.Input.Handler.result()
   def handle_mouse(state, row, col, :left, _mods, :press, _cc) do
     # Check if any float popups are visible. Clicks outside their box
     # dismiss them; clicks inside are passed through to the buffer.

--- a/lib/minga/input/prompt.ex
+++ b/lib/minga/input/prompt.ex
@@ -9,13 +9,13 @@ defmodule Minga.Input.Prompt do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Editor.PromptUI
-  alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Prompt, as: PromptState
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          Minga.Input.Handler.result()
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(
         %{shell_state: %{prompt_ui: %PromptState{handler: handler}}} = state,
         codepoint,
@@ -32,7 +32,7 @@ defmodule Minga.Input.Prompt do
 
   @impl true
   @spec handle_mouse(
-          EditorState.t(),
+          state(),
           integer(),
           integer(),
           atom(),

--- a/lib/minga/input/scoped.ex
+++ b/lib/minga/input/scoped.ex
@@ -22,6 +22,8 @@ defmodule Minga.Input.Scoped do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   import Bitwise
 
   alias Minga.Agent.UIState
@@ -43,8 +45,7 @@ defmodule Minga.Input.Scoped do
   # ── Handler callback ───────────────────────────────────────────────────────
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
 
   # ── Editor scope ─────────────────────────────────────────────────────────
 
@@ -90,7 +91,7 @@ defmodule Minga.Input.Scoped do
   # ══════════════════════════════════════════════════════════════════════════
 
   @spec handle_agent_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+          Minga.Input.Handler.result()
 
   # Dismiss toast on any key (then re-process)
   defp handle_agent_key(state, cp, mods) do
@@ -135,7 +136,7 @@ defmodule Minga.Input.Scoped do
 
   # Vim-mode agent key dispatch. Split out so CUA path stays clean.
   @spec dispatch_agent_key_vim(EditorState.t(), Panel.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+          Minga.Input.Handler.result()
   defp dispatch_agent_key_vim(state, panel, cp, mods) do
     # Tab on a paste placeholder line: toggle expand/collapse
     if cp == @tab and mods == 0 and panel.input_focused do
@@ -181,7 +182,7 @@ defmodule Minga.Input.Scoped do
           non_neg_integer(),
           non_neg_integer()
         ) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+          Minga.Input.Handler.result()
   defp resolve_agent_key(state, vim_state, cp, mods) do
     key = {cp, mods}
 
@@ -223,7 +224,7 @@ defmodule Minga.Input.Scoped do
           non_neg_integer(),
           non_neg_integer()
         ) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+          Minga.Input.Handler.result()
   defp resolve_scope_key(state, scope_name, vim_state, key, cp, mods) do
     case Keymap.resolve_scoped_key(scope_name, vim_state, key) do
       {:command, command} ->

--- a/lib/minga/input/signature_help.ex
+++ b/lib/minga/input/signature_help.ex
@@ -9,6 +9,8 @@ defmodule Minga.Input.SignatureHelp do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Editor.SignatureHelp, as: SigHelp
   alias Minga.Editor.State, as: EditorState
 
@@ -18,8 +20,7 @@ defmodule Minga.Input.SignatureHelp do
   @key_escape 27
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          Minga.Input.Handler.result()
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(%{shell_state: %{signature_help: nil}} = state, _cp, _mods) do
     {:passthrough, state}
   end

--- a/lib/minga/input/tool_approval.ex
+++ b/lib/minga/input/tool_approval.ex
@@ -9,13 +9,14 @@ defmodule Minga.Input.ToolApproval do
 
   @behaviour Minga.Input.Handler
 
+  @type state :: Minga.Input.Handler.handler_state()
+
   alias Minga.Editor.Commands
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.AgentAccess
 
   @impl true
-  @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
-          {:handled, EditorState.t()} | {:passthrough, EditorState.t()}
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: Minga.Input.Handler.result()
   def handle_key(state, cp, _mods) do
     agent = AgentAccess.agent(state)
 


### PR DESCRIPTION
## What

Introduces a `handler_state()` type alias on the `Input.Handler` behaviour as the single narrowing point for the input handler contract. All 20 input handler modules now use this type.

## Why

Every input handler took `Editor.State.t()` directly, coupling 30+ modules to the full god struct. This is the intermediate step toward shell independence: the type alias resolves to `Editor.State.t()` today, but narrowing it to a focused contract struct later requires changing only the `Handler` behaviour module.

## Changes

- `Input.Handler` behaviour: added `@type handler_state :: EditorState.t()` and `@type result` using it
- All 20 handler modules: added `@type state :: Minga.Input.Handler.handler_state()`, updated callback specs to use `state()` and `Minga.Input.Handler.result()`

## Stacked on

PR #1312 (feat/1226-centralize-mutations)

Closes #1215
Part of epic #1304