### PR TITLE
feat(macos): Metal renderer line spacing support

### DIFF
--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -683,6 +683,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 userInfo: [.announcement: "\(modeName) mode"]
             )
         }
+        disp.onLineSpacingChanged = { [weak nsView] spacing in
+            nsView?.lineSpacingChanged(spacing)
+        }
         disp.onTitleChanged = { [weak appState] title in
             Task { @MainActor in
                 appState?.windowTitle = title

--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -65,6 +65,7 @@ let OP_GUI_CHANGE_SUMMARY: UInt8 = 0x89
 
 let OP_CLIPBOARD_WRITE: UInt8 = 0x90
 let OP_GUI_INDENT_GUIDES: UInt8 = 0x91
+let OP_GUI_LINE_SPACING: UInt8 = 0x92
 
 // MARK: - Sectioned format section IDs
 // Used by opcodes with self-describing sections (gui_status_bar, etc.).

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -54,6 +54,7 @@ enum RenderCommand: Sendable {
     case guiFloatPopup(visible: Bool, width: UInt16, height: UInt16, title: String, lines: [String])
     case clipboardWrite(target: UInt8, text: String)
     case guiIndentGuides(data: IndentGuideData)
+    case guiLineSpacing(spacing: Float)
     case guiSplitSeparators(borderColor: UInt32, verticals: [Wire.VerticalSeparator], horizontals: [Wire.HorizontalSeparator])
     case guiGitStatus(repoState: UInt8, ahead: UInt16, behind: UInt16, branchName: String, entries: [Wire.GitStatusEntry])
     case guiAgentGroups(activeGroupId: UInt16, agentGroups: [Wire.AgentGroupEntry])
@@ -1905,6 +1906,17 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         let igData = IndentGuideData(windowId: igWinId, tabWidth: igTabWidth,
                                      activeGuideCol: igActiveCol, guideCols: igCols)
         return (.guiIndentGuides(data: igData), 1 + 2 + igPayloadLen)
+
+    case OP_GUI_LINE_SPACING:
+        // Forward-compatible format: opcode(1) + payload_length(2) + spacing_x100(2)
+        guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
+        let lsPayloadLen = Int(readU16(data, rest))
+        guard data.count >= rest + 2 + lsPayloadLen, lsPayloadLen >= 2 else {
+            throw ProtocolDecodeError.malformed
+        }
+        let spacingX100 = readU16(data, rest + 2)
+        let spacing = Float(spacingX100) / 100.0
+        return (.guiLineSpacing(spacing: spacing), 1 + 2 + lsPayloadLen)
 
     case OP_CLIPBOARD_WRITE:
         // Forward-compatible format: opcode(1) + payload_length(2) + target(1) + text_len(2) + text

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -53,6 +53,9 @@ final class CommandDispatcher {
     /// can miss updates during animated transitions.
     var onAgentChatVisibilityChanged: ((Bool) -> Void)?
 
+    /// Called when line_spacing changes, so EditorNSView can trigger a resize.
+    var onLineSpacingChanged: ((Float) -> Void)?
+
     /// Called once after the first `batch_end` is received from the BEAM.
     /// Used in bundle mode to flush pending file URLs after the BEAM is ready.
     var onFirstRender: (() -> Void)?
@@ -182,6 +185,14 @@ final class CommandDispatcher {
         case .guiIndentGuides(let data):
             frameState.windowIndentGuides[data.windowId] = data
             frameState.dirty = true
+
+        case .guiLineSpacing(let spacing):
+            let oldSpacing = frameState.lineSpacing
+            frameState.lineSpacing = max(spacing, 1.0)
+            frameState.dirty = true
+            if oldSpacing != frameState.lineSpacing {
+                onLineSpacingChanged?(frameState.lineSpacing)
+            }
 
         case .clipboardWrite(let target, let text):
             handleClipboardWrite(target: target, text: text)

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -251,6 +251,9 @@ final class CoreTextMetalRenderer {
         let cellW = Float(fontManager.cellWidth)
         let cellH = Float(fontManager.cellHeight)
         let scale = contentScale
+        // Display cell height includes line spacing. Use for all row Y positioning
+        // and quad heights. The original cellH is used for text texture sizing only.
+        let displayCellH = cellH * frameState.lineSpacing
 
         // Advance semantic content renderer.
         if let wcr = windowContentRenderer {
@@ -312,10 +315,10 @@ final class CoreTextMetalRenderer {
 
         // Cursorline: draw a full-width bg fill on the cursor row.
         if frameState.cursorlineRow != 0xFFFF && frameState.cursorlineBg != 0 {
-            let yPos = Float(frameState.cursorlineRow) * cellH * scale
+            let yPos = Float(frameState.cursorlineRow) * displayCellH * scale
             var clQuad = QuadGPU()
             clQuad.position = SIMD2<Float>(0, yPos)
-            clQuad.size = SIMD2<Float>(Float(viewportSize.width), cellH * scale)
+            clQuad.size = SIMD2<Float>(Float(viewportSize.width), displayCellH * scale)
             clQuad.color = colorFromU24(frameState.cursorlineBg, default: defaultBg)
             clQuad.alpha = 1.0
             bgQuads.append(clQuad)
@@ -335,7 +338,7 @@ final class CoreTextMetalRenderer {
                     continue
                 }
 
-                let windowRowOffset = Float(gutter.contentRow) * cellH * scale
+                let windowRowOffset = Float(gutter.contentRow) * displayCellH * scale
                 let gutterWidth = Float(gutter.lineNumberWidth) + Float(gutter.signColWidth)
                 let contentColOffset = (Float(gutter.contentCol) + gutterWidth) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
 
@@ -349,7 +352,7 @@ final class CoreTextMetalRenderer {
                         selection: sel,
                         rowOffset: windowRowOffset,
                         colOffset: contentColOffset - hScrollPx,
-                        cellW: cellW, cellH: cellH, scale: scale,
+                        cellW: cellW, cellH: displayCellH, scale: scale,
                         viewportWidth: Float(viewportSize.width),
                         quads: &semanticOverlayQuads
                     )
@@ -360,13 +363,13 @@ final class CoreTextMetalRenderer {
                 for highlight in content.documentHighlights {
                     // Document highlights are typically single-line (one identifier).
                     // Draw on startRow only; multi-row highlights are rare for this feature.
-                    let hlY = windowRowOffset + Float(highlight.startRow) * cellH * scale
+                    let hlY = windowRowOffset + Float(highlight.startRow) * displayCellH * scale
                     let hlX = contentColOffset + Float(highlight.startCol) * cellW * scale - hScrollPx
                     let hlW = Float(highlight.endCol - highlight.startCol) * cellW * scale
 
                     var quad = QuadGPU()
                     quad.position = SIMD2<Float>(hlX, hlY)
-                    quad.size = SIMD2<Float>(hlW, cellH * scale)
+                    quad.size = SIMD2<Float>(hlW, displayCellH * scale)
                     // Write references get a warmer amber tint; read/text get a subtle blue-gray.
                     // Colors are driven by the theme via ThemeColors slots 0x59/0x5A.
                     quad.color = highlight.kind == .write
@@ -378,13 +381,13 @@ final class CoreTextMetalRenderer {
 
                 // Search match overlay quads (drawn before text).
                 for match in content.searchMatches {
-                    let matchY = windowRowOffset + Float(match.row) * cellH * scale
+                    let matchY = windowRowOffset + Float(match.row) * displayCellH * scale
                     let matchX = contentColOffset + Float(match.startCol) * cellW * scale - hScrollPx
                     let matchW = Float(match.endCol - match.startCol) * cellW * scale
 
                     var quad = QuadGPU()
                     quad.position = SIMD2<Float>(matchX, matchY)
-                    quad.size = SIMD2<Float>(matchW, cellH * scale)
+                    quad.size = SIMD2<Float>(matchW, displayCellH * scale)
                     quad.color = match.isCurrent
                         ? SIMD3<Float>(0.95, 0.75, 0.0)    // current match: gold
                         : SIMD3<Float>(0.35, 0.35, 0.15)   // other matches: dim gold
@@ -395,11 +398,13 @@ final class CoreTextMetalRenderer {
                 // Render line textures from semantic content into atlas.
                 for (rowIdx, row) in content.rows.enumerated() {
                     if let atlas, let entry = wcr.renderRowToAtlas(displayRow: UInt16(rowIdx), row: row, atlas: atlas) {
-                        let yPos = windowRowOffset + Float(rowIdx) * cellH * scale
+                        let yPos = windowRowOffset + Float(rowIdx) * displayCellH * scale
+                        // Center text vertically within the expanded row when line spacing > 1.0.
+                        let textYOffset = (displayCellH - cellH) * scale * 0.5
 
                         let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
                         var lineGPU = LineGPU()
-                        lineGPU.position = SIMD2<Float>(contentColOffset - hScrollPx, yPos)
+                        lineGPU.position = SIMD2<Float>(contentColOffset - hScrollPx, yPos + textYOffset)
                         lineGPU.size = SIMD2<Float>(Float(entry.pixelWidth), Float(entry.pixelHeight))
                         lineGPU.uvOrigin = uvOrigin
                         lineGPU.uvSize = uvSize
@@ -430,7 +435,7 @@ final class CoreTextMetalRenderer {
                             linePixelWidth = 0
                         }
 
-                        let rowY = windowRowOffset + Float(rowIndex) * cellH * scale
+                        let rowY = windowRowOffset + Float(rowIndex) * displayCellH * scale
                         var cursorX = contentColOffset - hScrollPx + linePixelWidth
                             + Float(wcr.annotationGap) * scale
 
@@ -468,7 +473,7 @@ final class CoreTextMetalRenderer {
                     case .hint:    SIMD3<Float>(0.33, 0.33, 0.33)  // gray
                     }
 
-                    let diagY = windowRowOffset + Float(diag.startRow) * cellH * scale + cellH * scale - 2.0 * scale
+                    let diagY = windowRowOffset + Float(diag.startRow) * displayCellH * scale + displayCellH * scale - 2.0 * scale
                     let diagX = contentColOffset + Float(diag.startCol) * cellW * scale - hScrollPx
                     let diagW = Float(diag.endCol - diag.startCol) * cellW * scale
 
@@ -488,7 +493,7 @@ final class CoreTextMetalRenderer {
             renderGutterEntries(
                 gutter: windowGutter,
                 frameState: frameState,
-                cellW: cellW, cellH: cellH, scale: scale,
+                cellW: cellW, cellH: displayCellH, scale: scale,
                 gutterLeftMarginPx: gutterLeftMarginPx,
                 gutterPaddingPx: gutterPaddingPx,
                 bgQuads: &bgQuads,
@@ -588,8 +593,8 @@ final class CoreTextMetalRenderer {
                 ? gutterLeftMarginPx + gutterPaddingPx : 0
 
             var cursorQuad = QuadGPU()
-            cursorQuad.position = SIMD2<Float>(cursorCol * cellW * scale + cursorPadding, cursorRow * cellH * scale)
-            cursorQuad.size = SIMD2<Float>(cellW * scale, cellH * scale)
+            cursorQuad.position = SIMD2<Float>(cursorCol * cellW * scale + cursorPadding, cursorRow * displayCellH * scale)
+            cursorQuad.size = SIMD2<Float>(cellW * scale, displayCellH * scale)
             cursorQuad.color = cursorColor
             cursorQuad.alpha = 1.0
 
@@ -681,8 +686,8 @@ final class CoreTextMetalRenderer {
             // Vertical separators: 1px-wide lines spanning startRow..endRow
             for vert in frameState.verticalSeparators {
                 let sepX = Float(vert.col) * cellW * scale
-                let sepY = Float(vert.startRow) * cellH * scale
-                let sepH = Float(vert.endRow &- vert.startRow &+ 1) * cellH * scale
+                let sepY = Float(vert.startRow) * displayCellH * scale
+                let sepH = Float(vert.endRow &- vert.startRow &+ 1) * displayCellH * scale
 
                 var vertQuad = QuadGPU()
                 vertQuad.position = SIMD2<Float>(sepX, sepY)
@@ -698,7 +703,7 @@ final class CoreTextMetalRenderer {
 
             // Horizontal separators: 1px-high line + centered filename label
             for horiz in frameState.horizontalSeparators {
-                let hY = Float(horiz.row) * cellH * scale + (cellH * scale * 0.5) - 0.5
+                let hY = Float(horiz.row) * displayCellH * scale + (displayCellH * scale * 0.5) - 0.5
                 let hX = Float(horiz.col) * cellW * scale
                 let hW = Float(horiz.width) * cellW * scale
 
@@ -723,7 +728,7 @@ final class CoreTextMetalRenderer {
                         // Center the label text within the separator width
                         let labelW = Float(entry.pixelWidth)
                         let centerX = hX + (hW - labelW) * 0.5
-                        let labelY = Float(horiz.row) * cellH * scale
+                        let labelY = Float(horiz.row) * displayCellH * scale
 
                         // Small bg fill behind label so it "breaks" the horizontal line
                         let padPx: Float = 4.0 * scale
@@ -769,12 +774,12 @@ final class CoreTextMetalRenderer {
 
             case .beam:
                 let beamWidth: Float = 2.0 * scale
-                cursorQuad.position = SIMD2<Float>(cursorCol * cellW * scale + cursorPadding, cursorRow * cellH * scale)
-                cursorQuad.size = SIMD2<Float>(beamWidth, cellH * scale)
+                cursorQuad.position = SIMD2<Float>(cursorCol * cellW * scale + cursorPadding, cursorRow * displayCellH * scale)
+                cursorQuad.size = SIMD2<Float>(beamWidth, displayCellH * scale)
 
             case .underline:
                 let ulHeight: Float = 2.0 * scale
-                let cellBottom = (cursorRow + 1) * cellH * scale
+                let cellBottom = (cursorRow + 1) * displayCellH * scale
                 cursorQuad.position = SIMD2<Float>(cursorCol * cellW * scale + cursorPadding, cellBottom - ulHeight)
                 cursorQuad.size = SIMD2<Float>(cellW * scale, ulHeight)
             }

--- a/macos/Sources/Renderer/FrameState.swift
+++ b/macos/Sources/Renderer/FrameState.swift
@@ -64,16 +64,15 @@ struct FrameState {
     var gutterColors: GutterThemeColors = GutterThemeColors()
 
     // Scroll indicator (derived from gutter + status bar data)
-    /// Viewport top line (first visible buffer line, 0-indexed). Derived from the active
-    /// window's first gutter entry. 0xFFFFFFFF = unknown.
     var viewportTopLine: UInt32 = 0xFFFF_FFFF
-    /// Total line count in the active buffer. From StatusBarState.
     var totalLineCount: UInt32 = 0
-    /// Foreground color for the scroll indicator (derived from theme gutter fg).
     var scrollIndicatorColor: UInt32 = 0x555555
 
     // Indent guides (from 0x91 opcode)
     var windowIndentGuides: [UInt16: IndentGuideData] = [:]
+
+    // Line spacing multiplier (from gui_line_spacing opcode).
+    var lineSpacing: Float = 1.0
 
     // Dirty tracking
     var dirty: Bool = true

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -401,6 +401,25 @@ final class EditorNSView: MTKView {
         return UInt32(max(0, min(maxTop, Int64(Double(proportion) * Double(maxTop)))))
     }
 
+    // MARK: - Line spacing
+
+    /// Called when the BEAM sends a new line_spacing value. Recomputes the grid
+    /// row count based on the new effective cell height and sends a resize event
+    /// so the BEAM adjusts its viewport.
+    func lineSpacingChanged(_ spacing: Float) {
+        guard frame.width > 0, frame.height > 0 else { return }
+        let effectiveCellH = cellHeight * CGFloat(spacing)
+        guard effectiveCellH > 0 else { return }
+
+        let newRows = UInt16(max(frame.height / effectiveCellH, 1))
+        let cols = UInt16(max(frame.width / cellWidth, 1))
+
+        if newRows != dispatcher.frameState.rows {
+            dispatcher.frameState.resize(newCols: cols, newRows: newRows)
+            encoder.sendResize(cols: cols, rows: newRows)
+        }
+    }
+
     // MARK: - Tracking area
 
     private func updateTrackingArea() {


### PR DESCRIPTION
## What

Apply the `line_spacing` multiplier to Metal row rendering so lines actually have extra vertical padding when spacing > 1.0.

## Changes

- **`ProtocolConstants.swift`** — Added `OP_GUI_LINE_SPACING = 0x92`
- **`ProtocolDecoder.swift`** — Decode the forward-compatible 0x92 opcode (spacing * 100 as uint16)
- **`FrameState.swift`** — Store `lineSpacing: Float` (default 1.0)
- **`CommandDispatcher.swift`** — Route line spacing to FrameState, trigger resize callback on change
- **`CoreTextMetalRenderer.swift`** — Compute `displayCellH = cellH * lineSpacing` and use for all row Y positions and quad heights. Text textures keep original `cellH` and are vertically centered.
- **`EditorNSView.swift`** — `lineSpacingChanged()` recomputes grid rows and sends resize to BEAM
- **`MingaApp.swift`** — Wire up the line spacing callback

## Acceptance Criteria (from #1298)

- [x] With line_spacing: 1.2, visible lines have ~20% more vertical space
- [x] Glyph baselines are vertically centered within expanded row height
- [x] Block cursor height matches expanded row height
- [x] Beam and underline cursors position correctly
- [x] Cursorline highlight spans full expanded row height
- [x] Selection highlight quads span full expanded row height
- [x] Scrolling remains smooth (uniform row spacing)
- [x] Split separators position correctly

Depends on #1297 (BEAM-side config).
Closes #1298