### PR TITLE
feat(buffer): buffer forking with three-way merge (#394)

### DIFF
--- a/lib/minga/buffer/fork.ex
+++ b/lib/minga/buffer/fork.ex
@@ -1,0 +1,258 @@
+defmodule Minga.Buffer.Fork do
+  @moduledoc """
+  A forked copy of a buffer for concurrent agent editing.
+
+  When an agent session starts editing a file, a fork is created from the
+  parent `Buffer.Server`. The fork holds a snapshot of the parent's Document
+  at fork time (the common ancestor) and its own Document that the agent edits.
+  The user continues editing the parent buffer independently.
+
+  When the agent finishes, `merge/1` computes a three-way merge: common ancestor,
+  fork changes, and current parent changes. Non-overlapping changes merge
+  automatically. Overlapping changes are returned as conflicts for resolution.
+
+  The fork exposes the same GenServer call messages as Buffer.Server for the
+  editing subset (content, find_and_replace, replace_content, etc.), so agent
+  tools can call it without knowing whether they're talking to a fork or a
+  real buffer.
+
+  ## Lifecycle
+
+      parent_pid ──→ Fork.create(parent_pid) ──→ fork_pid
+                                                    │
+                                  agent edits ◀─────┘
+                                                    │
+                                Fork.merge(fork_pid) ──→ {:ok, merged} | {:conflict, hunks}
+  """
+
+  use GenServer
+
+  alias Minga.Buffer.Document
+  alias Minga.Buffer.Server, as: BufServer
+  alias Minga.Core.Diff
+
+  @typedoc "Fork creation options."
+  @type create_opt :: {:parent, pid()} | {:content, String.t()}
+
+  @typedoc "Internal fork state."
+  @type state :: %{
+          ancestor: Document.t(),
+          document: Document.t(),
+          parent: pid(),
+          parent_monitor: reference(),
+          parent_alive: boolean(),
+          version: non_neg_integer(),
+          dirty: boolean()
+        }
+
+  # ── Public API ──────────────────────────────────────────────────────────────
+
+  @doc """
+  Creates a fork from an existing buffer.
+
+  Snapshots the parent's current Document as the common ancestor and creates
+  an independent copy for editing. The fork monitors the parent buffer.
+  """
+  @spec create(pid()) :: {:ok, pid()} | {:error, term()}
+  def create(parent_pid) when is_pid(parent_pid) do
+    content = BufServer.content(parent_pid)
+    start_link(parent: parent_pid, content: content)
+  end
+
+  @doc """
+  Returns the full text content of the fork.
+  """
+  @spec content(GenServer.server()) :: String.t()
+  def content(server) do
+    GenServer.call(server, :content)
+  end
+
+  @doc """
+  Computes a three-way merge between the ancestor, fork, and current parent.
+
+  Returns `{:ok, merged_text}` when all changes merge cleanly, or
+  `{:conflict, merge_hunks}` when overlapping changes exist.
+  Returns `{:error, reason}` if the parent buffer is dead.
+  """
+  @spec merge(GenServer.server()) ::
+          {:ok, String.t()} | {:conflict, [Diff.merge_hunk()]} | {:error, term()}
+  def merge(server) do
+    GenServer.call(server, :merge)
+  end
+
+  @doc """
+  Returns the ancestor (snapshot at fork time) content.
+  """
+  @spec ancestor_content(GenServer.server()) :: String.t()
+  def ancestor_content(server) do
+    GenServer.call(server, :ancestor_content)
+  end
+
+  @doc "Whether the fork has been edited since creation."
+  @spec dirty?(GenServer.server()) :: boolean()
+  def dirty?(server) do
+    GenServer.call(server, :dirty?)
+  end
+
+  @doc "Monotonic version counter."
+  @spec version(GenServer.server()) :: non_neg_integer()
+  def version(server) do
+    GenServer.call(server, :version)
+  end
+
+  # ── GenServer lifecycle ─────────────────────────────────────────────────────
+
+  @spec start_link([create_opt()]) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(opts) do
+    parent = Keyword.fetch!(opts, :parent)
+    content = Keyword.fetch!(opts, :content)
+
+    ref = Process.monitor(parent)
+    doc = Document.new(content)
+
+    state = %{
+      ancestor: doc,
+      document: doc,
+      parent: parent,
+      parent_monitor: ref,
+      parent_alive: true,
+      version: 0,
+      dirty: false
+    }
+
+    {:ok, state}
+  end
+
+  # ── handle_call: editing subset ─────────────────────────────────────────────
+
+  @impl true
+  def handle_call(:content, _from, state) do
+    {:reply, Document.content(state.document), state}
+  end
+
+  def handle_call(:ancestor_content, _from, state) do
+    {:reply, Document.content(state.ancestor), state}
+  end
+
+  def handle_call(:dirty?, _from, state) do
+    {:reply, state.dirty, state}
+  end
+
+  def handle_call(:version, _from, state) do
+    {:reply, state.version, state}
+  end
+
+  def handle_call({:find_and_replace, old_text, new_text, _boundary}, _from, state) do
+    content = Document.content(state.document)
+
+    case do_find_and_replace(content, old_text, new_text) do
+      {:ok, new_doc, msg} ->
+        {:reply, {:ok, msg},
+         %{state | document: new_doc, dirty: true, version: state.version + 1}}
+
+      {:error, _} = err ->
+        {:reply, err, state}
+    end
+  end
+
+  def handle_call({:replace_content, new_content, _source}, _from, state) do
+    new_doc = Document.new(new_content)
+    {:reply, :ok, %{state | document: new_doc, dirty: true, version: state.version + 1}}
+  end
+
+  def handle_call({:find_and_replace_batch, edits, _boundary}, _from, state) do
+    {final_doc, results_reversed} =
+      Enum.reduce(edits, {state.document, []}, fn
+        {"", _new_text}, {doc, acc} ->
+          {doc, [{:error, "old_text is empty"} | acc]}
+
+        {old_text, new_text}, {doc, acc} ->
+          content = Document.content(doc)
+
+          case do_find_and_replace(content, old_text, new_text) do
+            {:ok, new_doc, msg} -> {new_doc, [{:ok, msg} | acc]}
+            {:error, _} = err -> {doc, [err | acc]}
+          end
+      end)
+
+    results = Enum.reverse(results_reversed)
+    any_applied = Enum.any?(results, &match?({:ok, _}, &1))
+
+    new_state =
+      if any_applied do
+        %{state | document: final_doc, dirty: true, version: state.version + 1}
+      else
+        state
+      end
+
+    {:reply, {:ok, results}, new_state}
+  end
+
+  def handle_call(:merge, _from, %{parent_alive: false} = state) do
+    {:reply, {:error, :parent_dead}, state}
+  end
+
+  def handle_call(:merge, _from, state) do
+    ancestor_lines = Document.content(state.ancestor) |> String.split("\n")
+    fork_lines = Document.content(state.document) |> String.split("\n")
+
+    parent_content = BufServer.content(state.parent)
+    parent_lines = String.split(parent_content, "\n")
+
+    result = Diff.merge3(ancestor_lines, fork_lines, parent_lines)
+    {:reply, format_merge_result(result), state}
+  catch
+    :exit, _ ->
+      {:reply, {:error, :parent_dead}, %{state | parent_alive: false}}
+  end
+
+  # ── handle_info ─────────────────────────────────────────────────────────────
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{parent_monitor: ref} = state) do
+    {:noreply, %{state | parent_alive: false}}
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec do_find_and_replace(String.t(), String.t(), String.t()) ::
+          {:ok, Document.t(), String.t()} | {:error, String.t()}
+  defp do_find_and_replace(_content, "", _new_text) do
+    {:error, "old_text is empty"}
+  end
+
+  defp do_find_and_replace(content, old_text, new_text) do
+    case :binary.matches(content, old_text) do
+      [] ->
+        {:error, "old_text not found"}
+
+      [{offset, len}] ->
+        before_match = binary_part(content, 0, offset)
+        after_match = binary_part(content, offset + len, byte_size(content) - offset - len)
+        new_content = before_match <> new_text <> after_match
+        {:ok, Document.new(new_content), "applied"}
+
+      matches ->
+        {:error, "old_text found #{length(matches)} times (ambiguous)"}
+    end
+  end
+
+  @spec format_merge_result(Diff.merge3_result()) ::
+          {:ok, String.t()} | {:conflict, [Diff.merge_hunk()]}
+  defp format_merge_result({:ok, lines}) do
+    {:ok, Enum.join(lines, "\n")}
+  end
+
+  defp format_merge_result({:conflict, hunks}) do
+    {:conflict, hunks}
+  end
+end

--- a/lib/minga/core/diff.ex
+++ b/lib/minga/core/diff.ex
@@ -231,6 +231,195 @@ defmodule Minga.Core.Diff do
     build_hunks(rest, cur + length(ins_lines), base, [hunk | acc])
   end
 
+  # ── Three-way merge ─────────────────────────────────────────────────────────
+
+  @typedoc """
+  A hunk in a three-way merge result.
+
+  * `{:resolved, lines}` — auto-merged content (from either side or unchanged)
+  * `{:conflict, fork_lines, parent_lines}` — both sides changed the same region
+  """
+  @type merge_hunk :: {:resolved, [String.t()]} | {:conflict, [String.t()], [String.t()]}
+
+  @typedoc "Result of a three-way merge."
+  @type merge3_result :: {:ok, [String.t()]} | {:conflict, [merge_hunk()]}
+
+  @doc """
+  Three-way merge: given a common ancestor and two divergent versions (fork and parent),
+  produces a merged result or identifies conflicts.
+
+  Non-overlapping changes from both sides are merged automatically.
+  Overlapping changes (both sides modified the same region of the ancestor)
+  become conflicts.
+
+  Returns `{:ok, merged_lines}` when all changes merge cleanly, or
+  `{:conflict, merge_hunks}` when at least one conflict exists.
+  The hunks list contains both resolved and conflicting regions.
+  """
+  @spec merge3([String.t()], [String.t()], [String.t()]) ::
+          {:ok, [String.t()]} | {:conflict, [merge_hunk()]}
+  def merge3(ancestor, fork, parent) do
+    # Compute diffs from ancestor to each side
+    fork_ops = List.myers_difference(ancestor, fork)
+    parent_ops = List.myers_difference(ancestor, parent)
+
+    # Convert myers ops to indexed edit regions
+    fork_edits = ops_to_edits(fork_ops)
+    parent_edits = ops_to_edits(parent_ops)
+
+    # Walk both edit lists and merge
+    hunks = merge_edits(ancestor, fork_edits, parent_edits)
+
+    if Enum.any?(hunks, &match?({:conflict, _, _}, &1)) do
+      {:conflict, hunks}
+    else
+      merged = Enum.flat_map(hunks, fn {:resolved, lines} -> lines end)
+      {:ok, merged}
+    end
+  end
+
+  # Converts myers_difference ops into a list of {start, count, replacement_lines}
+  # edit records, where start/count refer to the ancestor line range.
+  @spec ops_to_edits([{atom(), [String.t()]}]) :: [
+          {non_neg_integer(), non_neg_integer(), [String.t()]}
+        ]
+  defp ops_to_edits(ops) do
+    {edits, _pos} =
+      Enum.reduce(ops, {[], 0}, fn
+        {:eq, lines}, {acc, pos} ->
+          {acc, pos + length(lines)}
+
+        {:del, del_lines}, {acc, pos} ->
+          {[{pos, length(del_lines), :pending_del} | acc], pos + length(del_lines)}
+
+        {:ins, ins_lines}, {[{start, count, :pending_del} | rest], pos} ->
+          # del followed by ins = replacement
+          {[{start, count, ins_lines} | rest], pos}
+
+        {:ins, ins_lines}, {acc, pos} ->
+          # pure insertion at current position
+          {[{pos, 0, ins_lines} | acc], pos}
+      end)
+
+    # Resolve any trailing pending_del (pure deletion)
+    edits
+    |> Enum.map(fn
+      {start, count, :pending_del} -> {start, count, []}
+      edit -> edit
+    end)
+    |> Enum.reverse()
+  end
+
+  # Walks both edit lists against the ancestor, producing merge hunks.
+  @spec merge_edits([String.t()], [{non_neg_integer(), non_neg_integer(), [String.t()]}], [
+          {non_neg_integer(), non_neg_integer(), [String.t()]}
+        ]) :: [merge_hunk()]
+  defp merge_edits(ancestor, fork_edits, parent_edits) do
+    do_merge(ancestor, 0, fork_edits, parent_edits, [])
+    |> Enum.reverse()
+  end
+
+  # Both edit lists exhausted: emit remaining ancestor lines
+  defp do_merge(ancestor, pos, [], [], acc) do
+    remaining = Enum.drop(ancestor, pos)
+
+    if remaining == [] do
+      acc
+    else
+      [{:resolved, remaining} | acc]
+    end
+  end
+
+  # Only fork edits remain
+  defp do_merge(ancestor, pos, [fe | fork_rest], [], acc) do
+    {start, count, replacement} = fe
+    # Emit unchanged lines before this edit
+    unchanged = Enum.slice(ancestor, pos, max(start - pos, 0))
+    acc = if unchanged != [], do: [{:resolved, unchanged} | acc], else: acc
+    acc = [{:resolved, replacement} | acc]
+    do_merge(ancestor, start + count, fork_rest, [], acc)
+  end
+
+  # Only parent edits remain
+  defp do_merge(ancestor, pos, [], [pe | parent_rest], acc) do
+    {start, count, replacement} = pe
+    unchanged = Enum.slice(ancestor, pos, max(start - pos, 0))
+    acc = if unchanged != [], do: [{:resolved, unchanged} | acc], else: acc
+    acc = [{:resolved, replacement} | acc]
+    do_merge(ancestor, start + count, [], parent_rest, acc)
+  end
+
+  # Both sides have edits: pick the earlier one, detect overlaps
+  defp do_merge(
+         ancestor,
+         pos,
+         [fe | fork_rest] = fork_edits,
+         [pe | parent_rest] = parent_edits,
+         acc
+       ) do
+    {f_start, f_count, f_replacement} = fe
+    {p_start, p_count, p_replacement} = pe
+
+    f_end = f_start + f_count
+    p_end = p_start + p_count
+
+    cond do
+      # Both sides made the same change (identical replacement for the same region).
+      # Must be checked before the "before" conditions because identical insertions
+      # at the same position (f_end == p_start) would otherwise be duplicated.
+      f_start == p_start and f_count == p_count and f_replacement == p_replacement ->
+        unchanged = Enum.slice(ancestor, pos, max(f_start - pos, 0))
+        acc = if unchanged != [], do: [{:resolved, unchanged} | acc], else: acc
+        acc = [{:resolved, f_replacement} | acc]
+        do_merge(ancestor, f_end, fork_rest, parent_rest, acc)
+
+      # Fork edit is entirely before parent edit (no overlap)
+      f_end <= p_start ->
+        unchanged = Enum.slice(ancestor, pos, max(f_start - pos, 0))
+        acc = if unchanged != [], do: [{:resolved, unchanged} | acc], else: acc
+        acc = [{:resolved, f_replacement} | acc]
+        do_merge(ancestor, f_end, fork_rest, parent_edits, acc)
+
+      # Parent edit is entirely before fork edit (no overlap)
+      p_end <= f_start ->
+        unchanged = Enum.slice(ancestor, pos, max(p_start - pos, 0))
+        acc = if unchanged != [], do: [{:resolved, unchanged} | acc], else: acc
+        acc = [{:resolved, p_replacement} | acc]
+        do_merge(ancestor, p_end, fork_edits, parent_rest, acc)
+
+      # Overlap: conflict
+      true ->
+        # Emit unchanged lines before the conflict region
+        conflict_start = min(f_start, p_start)
+        conflict_end = max(f_end, p_end)
+        unchanged = Enum.slice(ancestor, pos, max(conflict_start - pos, 0))
+        acc = if unchanged != [], do: [{:resolved, unchanged} | acc], else: acc
+        acc = [{:conflict, f_replacement, p_replacement} | acc]
+
+        # Skip past all edits consumed by this conflict region
+        {fork_rest2, parent_rest2} = skip_consumed_edits(fork_rest, parent_rest, conflict_end)
+        do_merge(ancestor, conflict_end, fork_rest2, parent_rest2, acc)
+    end
+  end
+
+  # Skip edits that fall within the conflict region
+  @spec skip_consumed_edits(
+          [{non_neg_integer(), non_neg_integer(), [String.t()]}],
+          [{non_neg_integer(), non_neg_integer(), [String.t()]}],
+          non_neg_integer()
+        ) ::
+          {[{non_neg_integer(), non_neg_integer(), [String.t()]}],
+           [{non_neg_integer(), non_neg_integer(), [String.t()]}]}
+  defp skip_consumed_edits(fork_edits, parent_edits, conflict_end) do
+    fork_rest =
+      Enum.drop_while(fork_edits, fn {start, count, _} -> start + count <= conflict_end end)
+
+    parent_rest =
+      Enum.drop_while(parent_edits, fn {start, count, _} -> start + count <= conflict_end end)
+
+    {fork_rest, parent_rest}
+  end
+
   # ── Private: patch generation ──────────────────────────────────────────────
 
   @spec base_range(hunk(), non_neg_integer(), non_neg_integer()) ::

--- a/test/minga/buffer/fork_test.exs
+++ b/test/minga/buffer/fork_test.exs
@@ -1,0 +1,200 @@
+defmodule Minga.Buffer.ForkTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Fork
+  alias Minga.Buffer.Server
+
+  defp start_parent!(content) do
+    start_supervised!({Server, content: content}, id: make_ref())
+  end
+
+  describe "create/1 and content/1" do
+    test "fork content matches parent at creation" do
+      parent = start_parent!("hello\nworld")
+
+      {:ok, fork} = Fork.create(parent)
+
+      assert Fork.content(fork) == "hello\nworld"
+      assert Fork.content(fork) == Server.content(parent)
+    end
+
+    test "fork starts clean and at version 0" do
+      parent = start_parent!("test")
+
+      {:ok, fork} = Fork.create(parent)
+
+      refute Fork.dirty?(fork)
+      assert Fork.version(fork) == 0
+    end
+  end
+
+  describe "editing" do
+    test "editing fork does not affect parent" do
+      parent = start_parent!("hello\nworld")
+
+      {:ok, fork} = Fork.create(parent)
+      GenServer.call(fork, {:replace_content, "new content", :agent})
+
+      assert Fork.content(fork) == "new content"
+      assert Server.content(parent) == "hello\nworld"
+    end
+
+    test "editing fork marks it dirty and increments version" do
+      parent = start_parent!("test")
+
+      {:ok, fork} = Fork.create(parent)
+      GenServer.call(fork, {:replace_content, "changed", :agent})
+
+      assert Fork.dirty?(fork)
+      assert Fork.version(fork) == 1
+    end
+
+    test "find_and_replace updates fork content" do
+      parent = start_parent!("hello world")
+
+      {:ok, fork} = Fork.create(parent)
+      assert {:ok, "applied"} = GenServer.call(fork, {:find_and_replace, "hello", "goodbye", nil})
+
+      assert Fork.content(fork) == "goodbye world"
+      assert Fork.dirty?(fork)
+      assert Fork.version(fork) == 1
+    end
+
+    test "find_and_replace_batch applies multiple edits" do
+      parent = start_parent!("aaa bbb ccc")
+
+      {:ok, fork} = Fork.create(parent)
+      edits = [{"aaa", "AAA"}, {"ccc", "CCC"}]
+      {:ok, results} = GenServer.call(fork, {:find_and_replace_batch, edits, nil})
+
+      assert [{:ok, _}, {:ok, _}] = results
+      assert Fork.content(fork) == "AAA bbb CCC"
+      assert Fork.dirty?(fork)
+      assert Fork.version(fork) == 1
+    end
+
+    test "find_and_replace with ambiguous match returns error" do
+      parent = start_parent!("foo\nbar\nfoo")
+
+      {:ok, fork} = Fork.create(parent)
+      assert {:error, msg} = GenServer.call(fork, {:find_and_replace, "foo", "X", nil})
+      assert msg =~ "2 times"
+      refute Fork.dirty?(fork)
+      assert Fork.version(fork) == 0
+    end
+
+    test "find_and_replace_batch with all failures does not mark dirty" do
+      parent = start_parent!("hello")
+
+      {:ok, fork} = Fork.create(parent)
+      edits = [{"missing1", "X"}, {"missing2", "Y"}]
+      {:ok, results} = GenServer.call(fork, {:find_and_replace_batch, edits, nil})
+
+      assert [{:error, _}, {:error, _}] = results
+      refute Fork.dirty?(fork)
+      assert Fork.version(fork) == 0
+    end
+
+    test "version increments on each edit operation" do
+      parent = start_parent!("aaa bbb ccc")
+
+      {:ok, fork} = Fork.create(parent)
+      GenServer.call(fork, {:replace_content, "first", :agent})
+      GenServer.call(fork, {:replace_content, "second", :agent})
+      GenServer.call(fork, {:find_and_replace, "second", "third", nil})
+
+      assert Fork.version(fork) == 3
+    end
+  end
+
+  describe "ancestor_content/1" do
+    test "returns the snapshot at fork time" do
+      parent = start_parent!("original content")
+
+      {:ok, fork} = Fork.create(parent)
+
+      # Edit both fork and parent
+      GenServer.call(fork, {:replace_content, "fork changed", :agent})
+      Server.replace_content(parent, "parent changed")
+
+      assert Fork.ancestor_content(fork) == "original content"
+    end
+  end
+
+  describe "merge/1" do
+    test "merge when only fork changed returns fork content" do
+      parent = start_parent!("line1\nline2\nline3")
+
+      {:ok, fork} = Fork.create(parent)
+      GenServer.call(fork, {:find_and_replace, "line2", "changed", nil})
+
+      assert {:ok, "line1\nchanged\nline3"} = Fork.merge(fork)
+    end
+
+    test "merge when only parent changed returns parent content" do
+      parent = start_parent!("line1\nline2\nline3")
+
+      {:ok, fork} = Fork.create(parent)
+      Server.replace_content(parent, "line1\nparent_changed\nline3")
+
+      assert {:ok, "line1\nparent_changed\nline3"} = Fork.merge(fork)
+    end
+
+    test "merge with non-overlapping changes from both sides" do
+      parent = start_parent!("a\nb\nc\nd\ne")
+
+      {:ok, fork} = Fork.create(parent)
+      GenServer.call(fork, {:find_and_replace, "b", "fork_b", nil})
+      Server.replace_content(parent, "a\nb\nc\nparent_d\ne")
+
+      assert {:ok, merged} = Fork.merge(fork)
+      assert merged =~ "fork_b"
+      assert merged =~ "parent_d"
+    end
+
+    test "merge with conflicting changes returns conflict hunks" do
+      parent = start_parent!("a\nb\nc")
+
+      {:ok, fork} = Fork.create(parent)
+      GenServer.call(fork, {:find_and_replace, "b", "fork_b", nil})
+      Server.replace_content(parent, "a\nparent_b\nc")
+
+      assert {:conflict, hunks} = Fork.merge(fork)
+      assert Enum.any?(hunks, &match?({:conflict, _, _}, &1))
+    end
+
+    test "merge with no edits on either side returns original" do
+      parent = start_parent!("unchanged")
+
+      {:ok, fork} = Fork.create(parent)
+
+      assert {:ok, "unchanged"} = Fork.merge(fork)
+    end
+
+    test "merge returns {:error, :parent_dead} when parent died" do
+      parent = start_parent!("test")
+
+      {:ok, fork} = Fork.create(parent)
+
+      # Stop the parent
+      GenServer.stop(parent)
+
+      # Synchronize: ensure fork has processed the :DOWN message
+      :sys.get_state(fork)
+
+      assert {:error, :parent_dead} = Fork.merge(fork)
+    end
+  end
+
+  describe "edge cases" do
+    test "fork from empty parent" do
+      parent = start_parent!("")
+
+      {:ok, fork} = Fork.create(parent)
+      assert Fork.content(fork) == ""
+      refute Fork.dirty?(fork)
+
+      assert {:ok, ""} = Fork.merge(fork)
+    end
+  end
+end

--- a/test/minga/core/diff_merge3_test.exs
+++ b/test/minga/core/diff_merge3_test.exs
@@ -1,0 +1,180 @@
+defmodule Minga.Core.DiffMerge3Test do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  import Minga.Test.Generators
+
+  alias Minga.Core.Diff
+
+  describe "merge3/3 basic cases" do
+    test "both sides unchanged returns ancestor" do
+      ancestor = ["a", "b", "c"]
+      assert {:ok, ^ancestor} = Diff.merge3(ancestor, ancestor, ancestor)
+    end
+
+    test "only fork changes returns fork version" do
+      ancestor = ["a", "b", "c"]
+      fork = ["a", "X", "c"]
+      assert {:ok, ^fork} = Diff.merge3(ancestor, fork, ancestor)
+    end
+
+    test "only parent changes returns parent version" do
+      ancestor = ["a", "b", "c"]
+      parent = ["a", "Y", "c"]
+      assert {:ok, ^parent} = Diff.merge3(ancestor, ancestor, parent)
+    end
+
+    test "non-overlapping changes from both sides merge cleanly" do
+      ancestor = ["a", "b", "c", "d", "e"]
+      fork = ["a", "X", "c", "d", "e"]
+      parent = ["a", "b", "c", "Y", "e"]
+
+      assert {:ok, ["a", "X", "c", "Y", "e"]} = Diff.merge3(ancestor, fork, parent)
+    end
+
+    test "both sides make identical change auto-resolves" do
+      ancestor = ["a", "b", "c"]
+      changed = ["a", "X", "c"]
+
+      assert {:ok, ^changed} = Diff.merge3(ancestor, changed, changed)
+    end
+
+    test "both sides delete the same lines auto-resolves" do
+      ancestor = ["a", "b", "c"]
+      both = ["a", "c"]
+
+      assert {:ok, ^both} = Diff.merge3(ancestor, both, both)
+    end
+  end
+
+  describe "merge3/3 conflicts" do
+    test "overlapping changes produce a conflict" do
+      ancestor = ["a", "b", "c"]
+      fork = ["a", "X", "c"]
+      parent = ["a", "Y", "c"]
+
+      assert {:conflict, hunks} = Diff.merge3(ancestor, fork, parent)
+
+      # Should have resolved and conflict regions
+      assert Enum.any?(hunks, &match?({:conflict, _, _}, &1))
+      assert Enum.any?(hunks, &match?({:resolved, _}, &1))
+    end
+
+    test "conflict hunks include resolved regions" do
+      ancestor = ["header", "a", "b", "footer"]
+      fork = ["header", "X", "b", "footer"]
+      parent = ["header", "Y", "b", "footer"]
+
+      assert {:conflict, hunks} = Diff.merge3(ancestor, fork, parent)
+
+      resolved_texts = for {:resolved, lines} <- hunks, do: lines
+      assert ["header"] in resolved_texts
+    end
+
+    test "fork deletes lines parent modifies produces conflict" do
+      ancestor = ["a", "b", "c", "d"]
+      fork = ["a", "d"]
+      parent = ["a", "X", "c", "d"]
+
+      assert {:conflict, _hunks} = Diff.merge3(ancestor, fork, parent)
+    end
+  end
+
+  describe "merge3/3 adjacent edits" do
+    test "adjacent but non-overlapping edits merge cleanly" do
+      ancestor = ["a", "b", "c", "d"]
+      fork = ["a", "X", "c", "d"]
+      parent = ["a", "b", "Y", "d"]
+
+      assert {:ok, ["a", "X", "Y", "d"]} = Diff.merge3(ancestor, fork, parent)
+    end
+
+    test "fork adds lines, parent modifies different region" do
+      ancestor = ["a", "b", "c"]
+      fork = ["a", "b", "new1", "new2", "c"]
+      parent = ["a", "X", "c"]
+
+      assert {:ok, merged} = Diff.merge3(ancestor, fork, parent)
+      assert "X" in merged
+      assert "new1" in merged
+      assert "new2" in merged
+    end
+  end
+
+  describe "merge3/3 edge cases" do
+    test "empty ancestor, fork, and parent" do
+      assert {:ok, []} = Diff.merge3([], [], [])
+    end
+
+    test "single-line files with conflicting edits" do
+      assert {:conflict, _} = Diff.merge3(["a"], ["X"], ["Y"])
+    end
+
+    test "large shared context with small changes" do
+      ancestor = Enum.map(0..19, &"line#{&1}")
+      fork = List.replace_at(ancestor, 2, "fork_change")
+      parent = List.replace_at(ancestor, 18, "parent_change")
+
+      assert {:ok, merged} = Diff.merge3(ancestor, fork, parent)
+      assert Enum.at(merged, 2) == "fork_change"
+      assert Enum.at(merged, 18) == "parent_change"
+      assert length(merged) == 20
+    end
+
+    test "multiple non-overlapping edits from both sides" do
+      ancestor = ["a", "b", "c", "d", "e", "f"]
+      fork = ["X", "b", "c", "d", "Y", "f"]
+      parent = ["a", "b", "Z", "d", "e", "f"]
+
+      assert {:ok, merged} = Diff.merge3(ancestor, fork, parent)
+      assert "X" in merged
+      assert "Y" in merged
+      assert "Z" in merged
+    end
+  end
+
+  describe "merge3/3 properties" do
+    property "merge3 with unchanged parent returns fork verbatim" do
+      check all(
+              ancestor <- line_list(),
+              fork <- line_list(),
+              max_runs: 300
+            ) do
+        assert {:ok, ^fork} = Diff.merge3(ancestor, fork, ancestor)
+      end
+    end
+
+    property "merge3 with unchanged fork returns parent verbatim" do
+      check all(
+              ancestor <- line_list(),
+              parent <- line_list(),
+              max_runs: 300
+            ) do
+        assert {:ok, ^parent} = Diff.merge3(ancestor, ancestor, parent)
+      end
+    end
+
+    property "merge3 with identical fork and parent returns that version" do
+      check all(
+              ancestor <- line_list(),
+              changed <- line_list(),
+              max_runs: 300
+            ) do
+        assert {:ok, ^changed} = Diff.merge3(ancestor, changed, changed)
+      end
+    end
+
+    property "merge3 never crashes on arbitrary inputs" do
+      check all(
+              a <- line_list(),
+              f <- line_list(),
+              p <- line_list(),
+              max_runs: 500
+            ) do
+        result = Diff.merge3(a, f, p)
+
+        assert match?({:ok, _}, result) or match?({:conflict, _}, result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds core infrastructure for buffer forking: agents can fork a buffer, edit it independently while the user continues editing the parent, and merge changes back with automatic conflict detection.

This is the foundational PR for #394. It delivers the three-way merge algorithm and the Fork GenServer. Follow-up PRs will wire forks into the agent workflow.

## Why

Two agents editing the same file today serialize through the same Buffer.Server GenServer mailbox. Buffer forking replaces git worktrees for the common case: forks are instant (copy a struct into a new process, microseconds) vs worktrees (clone a directory, seconds to minutes). No existing editor does this.

## Changes

**`lib/minga/core/diff.ex`**
- Added `merge3/3`: pure three-way merge using line-level Myers diff. Computes ancestor→fork and ancestor→parent edit lists, walks them simultaneously to auto-merge non-overlapping changes and detect conflicts.
- Added `merge_hunk` and `merge3_result` types for clean data contracts.
- Property tests caught a bug where identical insertions at the same position were duplicated. Fixed by checking for identical changes before the "before" ordering check.

**`lib/minga/buffer/fork.ex`** (new)
- GenServer holding ancestor Document (snapshot at fork time), editable Document, and parent pid.
- Handles same GenServer call messages as Buffer.Server for the editing subset (`find_and_replace`, `replace_content`, `find_and_replace_batch`).
- `merge/1` computes three-way merge and returns `{:ok, merged_text}` or `{:conflict, hunks}`.
- Monitors parent buffer; returns `{:error, :parent_dead}` on merge if parent died.

## Architecture Decisions

- **No behaviour.** Fork handles the same call messages for the editing subset. Extract a behaviour later if a second consumer appears.
- **Line-based diff.** Matches the design doc model and agent editing patterns (block-level edits, not character-by-character).
- **No registry.** Fork is accessed by pid, held by the creator. No file path to register.
- **:temporary restart.** Monitor-based lifecycle cleanup.

## Tests

**Merge3 (15 unit + 4 property):**
- Both sides unchanged, one-sided changes, non-overlapping merge
- Conflicting changes, adjacent edits, identical changes auto-resolve
- Edge cases: empty inputs, single-line conflicts, large shared context
- Properties: one-sided always succeeds, identical always succeeds, never crashes

**Fork (17 tests):**
- Create and verify content matches parent
- Edit independently, parent unchanged
- Merge clean (one side, both sides non-overlapping)
- Merge conflict with hunk data
- Parent death → `{:error, :parent_dead}`
- Version tracking, dirty flag, ancestor preservation

## Follow-up PRs (not in scope)

- Fork routing in agent tools (session context threading)
- DiffReview integration for conflict resolution UI
- Automatic fork creation on agent edit
- Modeline indicator for active forks
- Multiple concurrent forks on the same buffer

Depends on #393. Stacked on `feat/393-readfile-buffer-routing`.

Partial implementation of #394.