### PR TITLE
refactor(agent): decouple agent view renderers from Editor.State (#1224)

### DIFF
--- a/lib/minga/agent/view/dashboard_renderer.ex
+++ b/lib/minga/agent/view/dashboard_renderer.ex
@@ -10,9 +10,9 @@ defmodule Minga.Agent.View.DashboardRenderer do
   alias Minga.Agent.Config, as: AgentConfig
   alias Minga.Agent.ModelLimits
   alias Minga.Agent.View.RenderInput
+  alias Minga.Agent.ViewContext
   alias Minga.Core.Face
   alias Minga.Editor.DisplayList
-  alias Minga.Editor.State, as: EditorState
   alias Minga.UI.Theme
 
   @typedoc "Screen rectangle {row_offset, col_offset, width, height}."
@@ -21,9 +21,9 @@ defmodule Minga.Agent.View.DashboardRenderer do
   # ── Public API ──────────────────────────────────────────────────────────────
 
   @doc "Renders the agent dashboard sidebar (Context, Model, LSP, Directory)."
-  @spec render(EditorState.t(), rect()) :: [DisplayList.draw()]
-  def render(%EditorState{} = state, rect) do
-    input = RenderInput.extract(state)
+  @spec render(ViewContext.t(), rect()) :: [DisplayList.draw()]
+  def render(%ViewContext{} = ctx, rect) do
+    input = RenderInput.extract(ctx)
     render_dashboard(input, rect)
   end
 

--- a/lib/minga/agent/view/prompt_renderer.ex
+++ b/lib/minga/agent/view/prompt_renderer.ex
@@ -14,10 +14,9 @@ defmodule Minga.Agent.View.PromptRenderer do
   alias Minga.Agent.Config, as: AgentConfig
   alias Minga.Agent.UIState
   alias Minga.Agent.View.RenderInput
+  alias Minga.Agent.ViewContext
   alias Minga.Core.Face
   alias Minga.Editor.DisplayList
-  alias Minga.Editor.State, as: EditorState
-  alias Minga.Editor.State.AgentAccess
 
   alias Minga.Input.Wrap, as: InputWrap
   alias Minga.UI.Theme
@@ -37,9 +36,9 @@ defmodule Minga.Agent.View.PromptRenderer do
   Used by the Content stage to determine how much space to reserve for
   the prompt at the bottom of the agent chat window.
   """
-  @spec prompt_height(EditorState.t(), pos_integer()) :: pos_integer()
-  def prompt_height(%EditorState{} = state, chat_width) do
-    input = RenderInput.extract(state)
+  @spec prompt_height(ViewContext.t(), pos_integer()) :: pos_integer()
+  def prompt_height(%ViewContext{} = ctx, chat_width) do
+    input = RenderInput.extract(ctx)
     box_width = max(chat_width - 2 * @input_h_margin, 10)
     compute_input_height(input.panel.input_lines, input_inner_width(box_width))
   end
@@ -50,9 +49,9 @@ defmodule Minga.Agent.View.PromptRenderer do
   Used by the Content stage when the chat content is rendered through
   the standard buffer pipeline with decorations.
   """
-  @spec render(EditorState.t(), rect()) :: [DisplayList.draw()]
-  def render(%EditorState{} = state, {row, col, width, _height}) do
-    input = RenderInput.extract(state)
+  @spec render(ViewContext.t(), rect()) :: [DisplayList.draw()]
+  def render(%ViewContext{} = ctx, {row, col, width, _height}) do
+    input = RenderInput.extract(ctx)
     box_width = max(width - 2 * @input_h_margin, 10)
     box_col = col + @input_h_margin
     render_input_from_input(input, row, box_col, box_width)
@@ -67,13 +66,13 @@ defmodule Minga.Agent.View.PromptRenderer do
 
   Returns nil when input is not focused (cursor hidden).
   """
-  @spec cursor_position_in_rect(EditorState.t(), rect()) ::
+  @spec cursor_position_in_rect(ViewContext.t(), rect()) ::
           {non_neg_integer(), non_neg_integer()} | nil
-  def cursor_position_in_rect(state, {row_off, col_off, width, height}) do
-    panel = AgentAccess.panel(state)
+  def cursor_position_in_rect(ctx, {row_off, col_off, width, height}) do
+    panel = ctx.ui_state.panel
 
     if panel.input_focused do
-      view = AgentAccess.view(state)
+      view = ctx.ui_state.view
       chat_width_pct = view.chat_width_pct
       chat_width = max(div(width * chat_width_pct, 100), 20)
       box_width = max(chat_width - 2 * @input_h_margin, 10)

--- a/lib/minga/agent/view/prompt_semantic_window.ex
+++ b/lib/minga/agent/view/prompt_semantic_window.ex
@@ -16,17 +16,16 @@ defmodule Minga.Agent.View.PromptSemanticWindow do
 
   alias Minga.Agent.UIState
   alias Minga.Agent.UIState.Panel
+  alias Minga.Agent.ViewContext
   alias Minga.Editor.SemanticWindow
   alias Minga.Editor.SemanticWindow.Selection
   alias Minga.Editor.SemanticWindow.Span
   alias Minga.Editor.SemanticWindow.VisualRow
-  alias Minga.Editor.State, as: EditorState
-  alias Minga.Editor.State.AgentAccess
   alias Minga.Input.Wrap, as: InputWrap
   alias Minga.UI.Theme
 
-  @typedoc "Internal editor state."
-  @type state :: EditorState.t()
+  @typedoc "Agent view context."
+  @type ctx :: ViewContext.t()
 
   @doc "Reserved window_id for the agent prompt SemanticWindow."
   @spec prompt_window_id() :: pos_integer()
@@ -44,12 +43,12 @@ defmodule Minga.Agent.View.PromptSemanticWindow do
   inside the prompt box (excluding borders and padding). The caller
   computes this from the chat panel width.
   """
-  @spec build(state(), pos_integer()) :: SemanticWindow.t() | nil
-  def build(%EditorState{} = state, inner_width) when inner_width > 0 do
-    panel = AgentAccess.panel(state)
+  @spec build(ctx(), pos_integer()) :: SemanticWindow.t() | nil
+  def build(%ViewContext{} = ctx, inner_width) when inner_width > 0 do
+    panel = ctx.ui_state.panel
 
     if is_pid(panel.prompt_buffer) do
-      build_from_panel(state, panel, inner_width)
+      build_from_panel(ctx, panel, inner_width)
     end
   end
 
@@ -71,13 +70,13 @@ defmodule Minga.Agent.View.PromptSemanticWindow do
 
   # ── Private ─────────────────────────────────────────────────────────────
 
-  @spec build_from_panel(state(), Panel.t(), pos_integer()) :: SemanticWindow.t()
-  defp build_from_panel(state, panel, inner_width) do
+  @spec build_from_panel(ctx(), Panel.t(), pos_integer()) :: SemanticWindow.t()
+  defp build_from_panel(ctx, panel, inner_width) do
     lines = Panel.input_lines(panel)
     cursor = Panel.input_cursor(panel)
-    mode = Minga.Editing.mode(state)
-    mode_state = Minga.Editor.Editing.mode_state(state)
-    theme = state.theme
+    mode = ctx.editing.mode
+    mode_state = ctx.editing.mode_state
+    theme = ctx.theme
     at = Theme.agent_theme(theme)
 
     total_visual = InputWrap.visual_line_count(lines, inner_width)

--- a/lib/minga/agent/view/render_input.ex
+++ b/lib/minga/agent/view/render_input.ex
@@ -11,9 +11,8 @@ defmodule Minga.Agent.View.RenderInput do
 
   alias Minga.Agent.Session
   alias Minga.Agent.UIState
+  alias Minga.Agent.ViewContext
   alias Minga.Editing.Scroll
-  alias Minga.Editor.State, as: EditorState
-  alias Minga.Editor.State.AgentAccess
   alias Minga.UI.Theme
 
   @enforce_keys [:theme, :agent_status, :panel, :agent_ui]
@@ -69,18 +68,17 @@ defmodule Minga.Agent.View.RenderInput do
         }
 
   @doc """
-  Extracts a focused `RenderInput` from full editor state.
+  Extracts a focused `RenderInput` from agent view context.
 
   Reads the agent session (messages, usage) and agent UI state, producing
   a self-contained struct that both `PromptRenderer` and `DashboardRenderer`
-  can render from without touching `EditorState` again.
+  can render from without touching `ViewContext` again.
   """
-  @spec extract(EditorState.t()) :: t()
-  def extract(%EditorState{} = state) do
-    agent = AgentAccess.agent(state)
-    panel = AgentAccess.panel(state)
-    session = AgentAccess.session(state)
-    view = AgentAccess.view(state)
+  @spec extract(ViewContext.t()) :: t()
+  def extract(%ViewContext{} = ctx) do
+    panel = ctx.ui_state.panel
+    view = ctx.ui_state.view
+    session = ctx.session
 
     messages =
       if session do
@@ -105,14 +103,14 @@ defmodule Minga.Agent.View.RenderInput do
       end
 
     %__MODULE__{
-      theme: state.theme,
-      agent_status: agent.status,
+      theme: ctx.theme,
+      agent_status: ctx.agent_status,
       panel: %{
         input_focused: panel.input_focused,
         input_lines: UIState.input_lines(panel),
         input_cursor: UIState.input_cursor(panel),
-        mode: Minga.Editing.mode(state),
-        mode_state: Minga.Editor.Editing.mode_state(state),
+        mode: ctx.editing.mode,
+        mode_state: ctx.editing.mode_state,
         scroll: panel.scroll,
         spinner_frame: panel.spinner_frame,
         model_name: panel.model_name,
@@ -132,7 +130,7 @@ defmodule Minga.Agent.View.RenderInput do
       },
       messages: messages,
       usage: usage,
-      pending_approval: agent.pending_approval,
+      pending_approval: ctx.pending_approval,
       session_title: session_title(messages),
       lsp_servers: safe_lsp_servers()
     }

--- a/lib/minga/agent/view_context.ex
+++ b/lib/minga/agent/view_context.ex
@@ -1,0 +1,73 @@
+defmodule Minga.Agent.ViewContext do
+  @moduledoc """
+  Agent view rendering context.
+
+  Contains the subset of `Editor.State` that agent renderers need to
+  draw the prompt input, dashboard sidebar, and agent chat chrome.
+  Decouples `lib/minga/agent/view/` modules from `Minga.Editor.State`
+  dependencies (per ticket #1224).
+
+  Both `PromptRenderer` and `DashboardRenderer` consume this struct.
+  Constructed via `from_editor_state/1` at the call sites in the
+  render pipeline.
+  """
+
+  alias Minga.Agent.UIState
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Editor.State.AgentAccess
+  alias Minga.Editor.VimState
+  alias Minga.Frontend.Capabilities
+  alias Minga.UI.Theme
+
+  @enforce_keys [:ui_state, :capabilities, :theme, :editing]
+  defstruct [
+    :session,
+    :ui_state,
+    :capabilities,
+    :theme,
+    :layout_rect,
+    :editing,
+    :buffers,
+    :agent_status,
+    :pending_approval
+  ]
+
+  @typedoc "Agent view rendering context."
+  @type t :: %__MODULE__{
+          session: pid() | nil,
+          ui_state: UIState.t(),
+          capabilities: Capabilities.t(),
+          theme: Theme.t(),
+          layout_rect: {non_neg_integer(), non_neg_integer(), pos_integer(), pos_integer()} | nil,
+          editing: VimState.t(),
+          buffers: Minga.Editor.State.Buffers.t(),
+          agent_status: atom() | nil,
+          pending_approval: map() | nil
+        }
+
+  @typedoc "Screen rectangle {row, col, width, height}."
+  @type rect :: {non_neg_integer(), non_neg_integer(), pos_integer(), pos_integer()}
+
+  @doc """
+  Builds a `ViewContext` from full editor state.
+
+  Extracts only the fields agent renderers need, eliminating the
+  `Editor.State` dependency from agent view modules.
+  """
+  @spec from_editor_state(EditorState.t()) :: t()
+  def from_editor_state(%EditorState{} = state) do
+    agent = AgentAccess.agent(state)
+
+    %__MODULE__{
+      session: AgentAccess.session(state),
+      ui_state: state.workspace.agent_ui,
+      capabilities: state.capabilities,
+      theme: state.theme,
+      layout_rect: nil,
+      editing: state.workspace.editing,
+      buffers: state.workspace.buffers,
+      agent_status: agent.status,
+      pending_approval: agent.pending_approval
+    }
+  end
+end

--- a/lib/minga/editor/render_pipeline/content.ex
+++ b/lib/minga/editor/render_pipeline/content.ex
@@ -9,6 +9,7 @@ defmodule Minga.Editor.RenderPipeline.Content do
 
   alias Minga.Agent.View.DashboardRenderer
   alias Minga.Agent.View.PromptRenderer
+  alias Minga.Agent.ViewContext
   alias Minga.Buffer
   alias Minga.Core.Decorations
   alias Minga.Core.Unicode
@@ -265,6 +266,9 @@ defmodule Minga.Editor.RenderPipeline.Content do
   @spec render_agent_chat_window(state(), Window.t(), Window.id(), Layout.window_layout()) ::
           {WindowFrame.t(), Cursor.t() | nil, state()}
   defp render_agent_chat_window(state, window, _win_id, win_layout) do
+    # Build ViewContext once for all agent renderers
+    ctx = ViewContext.from_editor_state(state)
+
     # Split the content rect to carve out a sidebar when wide enough.
     win_layout = Layout.add_sidebar(win_layout)
     {row_off, col_off, chat_width, height} = win_layout.content
@@ -285,7 +289,7 @@ defmodule Minga.Editor.RenderPipeline.Content do
               )
             end
 
-          separator ++ DashboardRenderer.render(state, {sr, sc, sw, sh})
+          separator ++ DashboardRenderer.render(ctx, {sr, sc, sw, sh})
 
         nil ->
           []
@@ -293,14 +297,14 @@ defmodule Minga.Editor.RenderPipeline.Content do
 
     # Compute prompt height and subdivide the content rect.
     # Subdivide the content rect for chat content vs prompt input.
-    prompt_height = PromptRenderer.prompt_height(state, chat_width)
+    prompt_height = PromptRenderer.prompt_height(ctx, chat_width)
     input_v_gap = 1
     chat_height = max(height - prompt_height - input_v_gap, 1)
     prompt_row = row_off + chat_height + input_v_gap
 
     # Render the prompt (agent chrome, not buffer content)
     prompt_rect = {prompt_row, col_off, chat_width, prompt_height}
-    prompt_draws = PromptRenderer.render(state, prompt_rect)
+    prompt_draws = PromptRenderer.render(ctx, prompt_rect)
 
     # When help overlay is visible, render help content instead of buffer
     help_visible = state.workspace.agent_ui.view.help_visible
@@ -322,7 +326,7 @@ defmodule Minga.Editor.RenderPipeline.Content do
 
       {frame, nil, state}
     else
-      render_agent_chat_buffer(state, window, win_layout, sidebar_draws, prompt_draws,
+      render_agent_chat_buffer(state, ctx, window, win_layout, sidebar_draws, prompt_draws,
         row_off: row_off,
         col_off: col_off,
         chat_width: chat_width,
@@ -334,13 +338,22 @@ defmodule Minga.Editor.RenderPipeline.Content do
 
   @spec render_agent_chat_buffer(
           state(),
+          ViewContext.t(),
           Window.t(),
           Layout.window_layout(),
           [DisplayList.draw()],
           [DisplayList.draw()],
           keyword()
         ) :: {WindowFrame.t(), Cursor.t() | nil, state()}
-  defp render_agent_chat_buffer(state, window, _win_layout, sidebar_draws, prompt_draws, opts) do
+  defp render_agent_chat_buffer(
+         state,
+         ctx,
+         window,
+         _win_layout,
+         sidebar_draws,
+         prompt_draws,
+         opts
+       ) do
     row_off = Keyword.fetch!(opts, :row_off)
     col_off = Keyword.fetch!(opts, :col_off)
     chat_width = Keyword.fetch!(opts, :chat_width)
@@ -485,7 +498,7 @@ defmodule Minga.Editor.RenderPipeline.Content do
     full_rect = {row_off, col_off, chat_width, height}
 
     prompt_cursor =
-      case PromptRenderer.cursor_position_in_rect(state, full_rect) do
+      case PromptRenderer.cursor_position_in_rect(ctx, full_rect) do
         {row, col} -> Cursor.new(row, col, :beam)
         nil -> nil
       end

--- a/lib/minga/input/agent_mouse.ex
+++ b/lib/minga/input/agent_mouse.ex
@@ -26,6 +26,7 @@ defmodule Minga.Input.AgentMouse do
 
   alias Minga.Agent.UIState
   alias Minga.Agent.View.PromptRenderer
+  alias Minga.Agent.ViewContext
   alias Minga.Config
   alias Minga.Editor.Layout
   alias Minga.Editor.State, as: EditorState
@@ -223,7 +224,8 @@ defmodule Minga.Input.AgentMouse do
 
   @spec click_in_prompt?(Layout.rect(), non_neg_integer(), EditorState.t()) :: boolean()
   defp click_in_prompt?({row_off, _col, width, height}, click_row, state) do
-    prompt_h = PromptRenderer.prompt_height(state, width)
+    ctx = ViewContext.from_editor_state(state)
+    prompt_h = PromptRenderer.prompt_height(ctx, width)
     chat_h = max(height - prompt_h - 1, 1)
     click_row >= row_off + chat_h
   end

--- a/test/minga/agent/view/dashboard_renderer_test.exs
+++ b/test/minga/agent/view/dashboard_renderer_test.exs
@@ -3,6 +3,7 @@ defmodule Minga.Agent.View.DashboardRendererTest do
 
   alias Minga.Agent.UIState
   alias Minga.Agent.View.DashboardRenderer
+  alias Minga.Agent.ViewContext
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Agent, as: AgentState
@@ -64,7 +65,8 @@ defmodule Minga.Agent.View.DashboardRendererTest do
   describe "render/2" do
     test "shows context, model, LSP, and directory sections" do
       state = base_state()
-      commands = DashboardRenderer.render(state, {0, 80, 40, 30})
+      ctx = ViewContext.from_editor_state(state)
+      commands = DashboardRenderer.render(ctx, {0, 80, 40, 30})
       texts = Enum.map(commands, fn d -> elem(d, 2) end)
 
       assert Enum.any?(texts, &String.contains?(&1, "Context"))
@@ -75,7 +77,8 @@ defmodule Minga.Agent.View.DashboardRendererTest do
 
     test "shows LSP section with no servers when list is empty" do
       state = base_state()
-      commands = DashboardRenderer.render(state, {0, 80, 40, 30})
+      ctx = ViewContext.from_editor_state(state)
+      commands = DashboardRenderer.render(ctx, {0, 80, 40, 30})
       texts = Enum.map(commands, fn d -> elem(d, 2) end)
 
       assert Enum.any?(texts, &String.contains?(&1, "LSP"))
@@ -84,7 +87,8 @@ defmodule Minga.Agent.View.DashboardRendererTest do
 
     test "dashboard model section strips provider prefix" do
       state = base_state()
-      commands = DashboardRenderer.render(state, {0, 80, 40, 30})
+      ctx = ViewContext.from_editor_state(state)
+      commands = DashboardRenderer.render(ctx, {0, 80, 40, 30})
       texts = Enum.map(commands, fn d -> elem(d, 2) end)
 
       # The model section should show bare model name, not the prefixed spec

--- a/test/minga/agent/view/prompt_renderer_test.exs
+++ b/test/minga/agent/view/prompt_renderer_test.exs
@@ -3,6 +3,7 @@ defmodule Minga.Agent.View.PromptRendererTest do
 
   alias Minga.Agent.UIState
   alias Minga.Agent.View.PromptRenderer
+  alias Minga.Agent.ViewContext
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.State.Agent, as: AgentState
@@ -64,12 +65,14 @@ defmodule Minga.Agent.View.PromptRendererTest do
   describe "cursor_position_in_rect/2" do
     test "returns nil when input is not focused" do
       state = base_state(rows: 40, input_focused: false)
-      assert PromptRenderer.cursor_position_in_rect(state, {0, 0, 80, 40}) == nil
+      ctx = ViewContext.from_editor_state(state)
+      assert PromptRenderer.cursor_position_in_rect(ctx, {0, 0, 80, 40}) == nil
     end
 
     test "returns {row, col} when input is focused" do
       state = base_state(rows: 40, input_focused: true)
-      result = PromptRenderer.cursor_position_in_rect(state, {0, 0, 80, 40})
+      ctx = ViewContext.from_editor_state(state)
+      result = PromptRenderer.cursor_position_in_rect(ctx, {0, 0, 80, 40})
 
       assert {row, col} = result
       assert is_integer(row)
@@ -80,29 +83,34 @@ defmodule Minga.Agent.View.PromptRendererTest do
 
     test "cursor column advances with input text length" do
       state_empty = base_state(input_focused: true, input_text: "")
+      ctx_empty = ViewContext.from_editor_state(state_empty)
       state_hello = base_state(input_focused: true, input_text: "hello")
+      ctx_hello = ViewContext.from_editor_state(state_hello)
 
-      {_r, col_empty} = PromptRenderer.cursor_position_in_rect(state_empty, {0, 0, 80, 40})
-      {_r, col_hello} = PromptRenderer.cursor_position_in_rect(state_hello, {0, 0, 80, 40})
+      {_r, col_empty} = PromptRenderer.cursor_position_in_rect(ctx_empty, {0, 0, 80, 40})
+      {_r, col_hello} = PromptRenderer.cursor_position_in_rect(ctx_hello, {0, 0, 80, 40})
 
       assert col_hello == col_empty + String.length("hello")
     end
 
     test "cursor row is the same regardless of short input text" do
       state_short = base_state(input_focused: true, input_text: "hi")
+      ctx_short = ViewContext.from_editor_state(state_short)
       state_long = base_state(input_focused: true, input_text: "a long message here")
+      ctx_long = ViewContext.from_editor_state(state_long)
 
-      {row_short, _} = PromptRenderer.cursor_position_in_rect(state_short, {0, 0, 80, 40})
-      {row_long, _} = PromptRenderer.cursor_position_in_rect(state_long, {0, 0, 80, 40})
+      {row_short, _} = PromptRenderer.cursor_position_in_rect(ctx_short, {0, 0, 80, 40})
+      {row_long, _} = PromptRenderer.cursor_position_in_rect(ctx_long, {0, 0, 80, 40})
 
       assert row_short == row_long
     end
 
     test "cursor position is offset by the rect origin" do
       state = base_state(rows: 40, input_focused: true, input_text: "test")
+      ctx = ViewContext.from_editor_state(state)
 
-      {row_origin, _col_origin} = PromptRenderer.cursor_position_in_rect(state, {0, 0, 80, 40})
-      {row_offset, _col_offset} = PromptRenderer.cursor_position_in_rect(state, {5, 0, 80, 40})
+      {row_origin, _col_origin} = PromptRenderer.cursor_position_in_rect(ctx, {0, 0, 80, 40})
+      {row_offset, _col_offset} = PromptRenderer.cursor_position_in_rect(ctx, {5, 0, 80, 40})
 
       assert row_offset == row_origin + 5
     end
@@ -111,17 +119,20 @@ defmodule Minga.Agent.View.PromptRendererTest do
   describe "prompt_height/2" do
     test "returns a positive integer" do
       state = base_state()
-      height = PromptRenderer.prompt_height(state, 80)
+      ctx = ViewContext.from_editor_state(state)
+      height = PromptRenderer.prompt_height(ctx, 80)
       assert is_integer(height)
       assert height >= 3
     end
 
     test "grows with multiline input" do
       state_single = base_state(input_lines: ["hello"])
+      ctx_single = ViewContext.from_editor_state(state_single)
       state_multi = base_state(input_lines: ["line 1", "line 2", "line 3"])
+      ctx_multi = ViewContext.from_editor_state(state_multi)
 
-      h_single = PromptRenderer.prompt_height(state_single, 80)
-      h_multi = PromptRenderer.prompt_height(state_multi, 80)
+      h_single = PromptRenderer.prompt_height(ctx_single, 80)
+      h_multi = PromptRenderer.prompt_height(ctx_multi, 80)
 
       assert h_multi > h_single
     end
@@ -130,7 +141,8 @@ defmodule Minga.Agent.View.PromptRendererTest do
   describe "render/2" do
     test "returns draw tuples with prompt border" do
       state = base_state()
-      commands = PromptRenderer.render(state, {30, 0, 80, 5})
+      ctx = ViewContext.from_editor_state(state)
+      commands = PromptRenderer.render(ctx, {30, 0, 80, 5})
 
       assert [_ | _] = commands
       texts = Enum.map(commands, fn d -> elem(d, 2) end)
@@ -140,7 +152,8 @@ defmodule Minga.Agent.View.PromptRendererTest do
 
     test "model info is embedded in bottom border" do
       state = base_state()
-      commands = PromptRenderer.render(state, {30, 0, 80, 5})
+      ctx = ViewContext.from_editor_state(state)
+      commands = PromptRenderer.render(ctx, {30, 0, 80, 5})
       texts = Enum.map(commands, fn d -> elem(d, 2) end)
 
       assert Enum.any?(texts, fn text ->
@@ -174,7 +187,8 @@ defmodule Minga.Agent.View.PromptRendererTest do
   describe "model name display with provider prefix" do
     test "prompt bar strips provider prefix from model name" do
       state = base_state()
-      commands = PromptRenderer.render(state, {30, 0, 80, 5})
+      ctx = ViewContext.from_editor_state(state)
+      commands = PromptRenderer.render(ctx, {30, 0, 80, 5})
       texts = Enum.map(commands, fn d -> elem(d, 2) end)
 
       # model_name defaults to "anthropic:claude-sonnet-4" but the display


### PR DESCRIPTION
## What

Introduces `Agent.ViewContext` struct containing only what agent renderers need, decoupling agent view modules from `Editor.State`.

## Changes

- New `Agent.ViewContext` struct with `from_editor_state/1`
- Updated prompt_renderer, dashboard_renderer, render_input, prompt_semantic_window to use ViewContext
- Updated call sites in render pipeline and input handlers

## Stacked on

PR #1322 (feat/1223-decouple-emit)

Closes #1224
Part of epic #1304