### PR TITLE
refactor(ui): decouple picker sources from Editor.State (#1225)

### DIFF
--- a/lib/minga/editor/picker_ui.ex
+++ b/lib/minga/editor/picker_ui.ex
@@ -22,6 +22,7 @@ defmodule Minga.Editor.PickerUI do
   alias Minga.Editor.State.Picker, as: PickerState
   alias Minga.Editor.State.WhichKey, as: WhichKeyState
   alias Minga.UI.Picker
+  alias Minga.UI.Picker.Context
 
   import Bitwise
 
@@ -89,7 +90,9 @@ defmodule Minga.Editor.PickerUI do
         state
       end
 
-    items = source_module.candidates(state_with_ctx)
+    # Build Context for source
+    ctx = Context.from_editor_state(state_with_ctx)
+    items = source_module.candidates(ctx)
 
     case items do
       [] ->
@@ -509,7 +512,8 @@ defmodule Minga.Editor.PickerUI do
   def refresh_items(%{shell_state: %{picker_ui: %{picker: nil}}} = state), do: state
 
   def refresh_items(%{shell_state: %{picker_ui: %{picker: picker, source: source} = pui}} = state) do
-    items = source.candidates(state)
+    ctx = Context.from_editor_state(state)
+    items = source.candidates(ctx)
     refreshed = %{picker | items: items}
     refreshed = Picker.filter(refreshed, picker.query)
 
@@ -731,7 +735,8 @@ defmodule Minga.Editor.PickerUI do
          new_source,
          prefix
        ) do
-    items = new_source.candidates(state)
+    ctx = Context.from_editor_state(state)
+    items = new_source.candidates(ctx)
     max_vis = state.workspace.viewport.rows - 3
     max_vis = max(5, min(max_vis, state.workspace.viewport.rows - 3))
     picker = Picker.new(items, title: new_source.title(), max_visible: max_vis)
@@ -754,7 +759,8 @@ defmodule Minga.Editor.PickerUI do
   defp switch_back_to_original(
          %{shell_state: %{picker_ui: %{original_source: orig} = pui}} = state
        ) do
-    items = orig.candidates(state)
+    ctx = Context.from_editor_state(state)
+    items = orig.candidates(ctx)
     max_vis = state.workspace.viewport.rows - 3
     max_vis = max(5, min(max_vis, state.workspace.viewport.rows - 3))
     picker = Picker.new(items, title: orig.title(), max_visible: max_vis)

--- a/lib/minga/ui/picker/agent_group_icon_source.ex
+++ b/lib/minga/ui/picker/agent_group_icon_source.ex
@@ -10,6 +10,7 @@ defmodule Minga.UI.Picker.AgentGroupIconSource do
 
   alias Minga.Editor.State.AgentGroup
   alias Minga.Editor.State.TabBar
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   @icons [
@@ -69,8 +70,8 @@ defmodule Minga.UI.Picker.AgentGroupIconSource do
   def title, do: "Set Workspace Icon"
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(%{shell_state: %{tab_bar: %TabBar{} = tb}}) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{tab_bar: %TabBar{} = tb}) do
     current_icon =
       case TabBar.active_group(tb) do
         %AgentGroup{icon: icon} -> icon

--- a/lib/minga/ui/picker/agent_group_source.ex
+++ b/lib/minga/ui/picker/agent_group_source.ex
@@ -8,6 +8,7 @@ defmodule Minga.UI.Picker.AgentGroupSource do
 
   @behaviour Minga.UI.Picker.Source
 
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Editor.State, as: EditorState
@@ -19,8 +20,8 @@ defmodule Minga.UI.Picker.AgentGroupSource do
   def title, do: "Switch Workspace"
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(%{shell_state: %{tab_bar: %TabBar{} = tb}}) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{tab_bar: %TabBar{} = tb}) do
     # Filter out workspaces with no tabs (empty manual workspace)
     tb.agent_groups
     |> Enum.filter(fn ws ->

--- a/lib/minga/ui/picker/agent_model_source.ex
+++ b/lib/minga/ui/picker/agent_model_source.ex
@@ -13,10 +13,10 @@ defmodule Minga.UI.Picker.AgentModelSource do
 
   @behaviour Minga.UI.Picker.Source
 
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Agent.Session
-  alias Minga.Editor.State.AgentAccess
 
   @impl true
   @spec title() :: String.t()
@@ -31,10 +31,8 @@ defmodule Minga.UI.Picker.AgentModelSource do
   def layout, do: :centered
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(state) do
-    session = AgentAccess.session(state)
-
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{agent_session: session}) do
     with true <- is_pid(session),
          {:ok, models} when is_list(models) <- fetch_models(session) do
       Enum.map(models, &format_model/1)

--- a/lib/minga/ui/picker/agent_session_source.ex
+++ b/lib/minga/ui/picker/agent_session_source.ex
@@ -9,6 +9,7 @@ defmodule Minga.UI.Picker.AgentSessionSource do
 
   @behaviour Minga.UI.Picker.Source
 
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Agent.Session
@@ -27,8 +28,8 @@ defmodule Minga.UI.Picker.AgentSessionSource do
   def preview?, do: false
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(%{shell_state: %{tab_bar: %TabBar{} = tb}} = _state) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{tab_bar: %TabBar{} = tb}) do
     live = tab_candidates(tb)
     disk = disk_candidates()
     live_ids = MapSet.new(live, fn %Item{id: {id, _}} -> id end)

--- a/lib/minga/ui/picker/buffer_all_source.ex
+++ b/lib/minga/ui/picker/buffer_all_source.ex
@@ -9,6 +9,7 @@ defmodule Minga.UI.Picker.BufferAllSource do
 
   @behaviour Minga.UI.Picker.Source
 
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.UI.Picker.BufferSource
@@ -22,8 +23,8 @@ defmodule Minga.UI.Picker.BufferAllSource do
   def preview?, do: true
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(state), do: BufferSource.build_candidates(state, include_special: true)
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(ctx), do: BufferSource.build_candidates(ctx, include_special: true)
 
   @impl true
   @spec on_select(Item.t(), term()) :: term()

--- a/lib/minga/ui/picker/buffer_source.ex
+++ b/lib/minga/ui/picker/buffer_source.ex
@@ -9,6 +9,7 @@ defmodule Minga.UI.Picker.BufferSource do
 
   @behaviour Minga.UI.Picker.Source
 
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
   alias Minga.UI.Picker.Source
 
@@ -27,8 +28,8 @@ defmodule Minga.UI.Picker.BufferSource do
   def preview?, do: true
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(state), do: build_candidates(state, include_special: false)
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(ctx), do: build_candidates(ctx, include_special: false)
 
   @doc """
   Builds picker candidates from the buffer list.
@@ -38,8 +39,8 @@ defmodule Minga.UI.Picker.BufferSource do
   * `:include_special` — when `true`, includes special buffers (`*Messages*`,
     `*Warnings*`, etc.) in the results. Defaults to `false`.
   """
-  @spec build_candidates(term(), keyword()) :: [Item.t()]
-  def build_candidates(%{workspace: %{buffers: buffers_state}}, opts \\ []) do
+  @spec build_candidates(Context.t(), keyword()) :: [Item.t()]
+  def build_candidates(%Context{buffers: buffers_state}, opts \\ []) do
     %{list: buffers} = buffers_state
     include_special = Keyword.get(opts, :include_special, false)
 

--- a/lib/minga/ui/picker/code_action_source.ex
+++ b/lib/minga/ui/picker/code_action_source.ex
@@ -15,6 +15,7 @@ defmodule Minga.UI.Picker.CodeActionSource do
   alias Minga.Log
   alias Minga.LSP.Client
   alias Minga.LSP.SyncServer
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   @impl true
@@ -26,8 +27,8 @@ defmodule Minga.UI.Picker.CodeActionSource do
   def layout, do: :centered
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(%{shell_state: %{picker_ui: %{context: %{actions: actions}}}})
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{picker_ui: %{context: %{actions: actions}}})
       when is_list(actions) do
     actions
     |> Enum.with_index()

--- a/lib/minga/ui/picker/command_source.ex
+++ b/lib/minga/ui/picker/command_source.ex
@@ -11,6 +11,7 @@ defmodule Minga.UI.Picker.CommandSource do
   @behaviour Minga.UI.Picker.Source
 
   alias Minga.Keymap
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Buffer
@@ -23,8 +24,8 @@ defmodule Minga.UI.Picker.CommandSource do
   def title, do: "Commands"
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(_context) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(_ctx) do
     keybind_map = build_keybind_map()
 
     try do

--- a/lib/minga/ui/picker/context.ex
+++ b/lib/minga/ui/picker/context.ex
@@ -1,0 +1,90 @@
+defmodule Minga.UI.Picker.Context do
+  @moduledoc """
+  Picker context struct — what picker sources need from Editor.State.
+
+  This struct decouples picker sources from the full `Editor.State`, allowing
+  sources to depend only on the subset of state they actually use. This makes
+  sources easier to test, easier to reason about, and prevents the cyclic
+  dependency between `UI.Picker` and `Editor.State`.
+
+  ## Fields
+
+  - `buffers` — buffer list and active buffer (`Editor.State.Buffers.t()`)
+  - `editing` — vim state (marks, registers, jump positions, mode)
+  - `file_tree` — file tree state (if available)
+  - `search` — search state (buffer search, project search results)
+  - `viewport` — viewport dimensions
+  - `tab_bar` — tab bar state (tabs, active tab, agent groups)
+  - `agent_session` — agent session PID (if available)
+  - `picker_ui` — picker UI state (context map for sources)
+  - `capabilities` — frontend capabilities (GUI detection, etc.)
+  - `theme` — active theme
+  """
+
+  alias Minga.Editor.State
+  alias Minga.Editor.State.Buffers
+  alias Minga.Editor.State.Search
+  alias Minga.Editor.State.TabBar
+  alias Minga.Editor.Viewport
+  alias Minga.Editor.VimState
+  alias Minga.UI.Theme
+  alias Minga.Editor.State.FileTree
+
+  @enforce_keys [
+    :buffers,
+    :editing,
+    :search,
+    :viewport,
+    :tab_bar,
+    :picker_ui,
+    :capabilities,
+    :theme
+  ]
+
+  defstruct [
+    :buffers,
+    :editing,
+    :file_tree,
+    :search,
+    :viewport,
+    :tab_bar,
+    :agent_session,
+    :picker_ui,
+    :capabilities,
+    :theme
+  ]
+
+  @type t :: %__MODULE__{
+          buffers: Buffers.t(),
+          editing: VimState.t(),
+          file_tree: FileTree.t() | nil,
+          search: Search.t(),
+          viewport: Viewport.t(),
+          tab_bar: TabBar.t(),
+          agent_session: pid() | nil,
+          picker_ui: map(),
+          capabilities: map(),
+          theme: Theme.t()
+        }
+
+  @doc """
+  Builds a picker context from the full editor state.
+  """
+  @spec from_editor_state(State.t()) :: t()
+  def from_editor_state(%State{} = state) do
+    agent_session = state.shell_state.agent.session
+
+    %__MODULE__{
+      buffers: state.workspace.buffers,
+      editing: state.workspace.editing,
+      file_tree: Map.get(state.workspace, :file_tree),
+      search: state.workspace.search,
+      viewport: state.workspace.viewport,
+      tab_bar: state.shell_state.tab_bar,
+      agent_session: agent_session,
+      picker_ui: state.shell_state.picker_ui,
+      capabilities: state.capabilities,
+      theme: state.theme
+    }
+  end
+end

--- a/lib/minga/ui/picker/extension_source.ex
+++ b/lib/minga/ui/picker/extension_source.ex
@@ -9,6 +9,7 @@ defmodule Minga.UI.Picker.ExtensionSource do
 
   @behaviour Minga.UI.Picker.Source
 
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Extension.Registry, as: ExtRegistry
@@ -19,8 +20,8 @@ defmodule Minga.UI.Picker.ExtensionSource do
   def title, do: "Extension"
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(_context) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(_ctx) do
     extensions = ExtSupervisor.list_extensions()
     all_entries = ExtRegistry.all()
 

--- a/lib/minga/ui/picker/file_source.ex
+++ b/lib/minga/ui/picker/file_source.ex
@@ -13,6 +13,7 @@ defmodule Minga.UI.Picker.FileSource do
   alias Minga.Language
   alias Minga.Log
   alias Minga.UI.Devicon
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
   alias Minga.UI.Picker.Source
 
@@ -25,8 +26,8 @@ defmodule Minga.UI.Picker.FileSource do
   def preview?, do: true
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(_context) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(_ctx) do
     root = project_root()
 
     case Minga.Project.list_files(root) do

--- a/lib/minga/ui/picker/git_branch_source.ex
+++ b/lib/minga/ui/picker/git_branch_source.ex
@@ -11,6 +11,7 @@ defmodule Minga.UI.Picker.GitBranchSource do
 
   alias Minga.Git
   alias Minga.Log
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   @impl true
@@ -18,8 +19,8 @@ defmodule Minga.UI.Picker.GitBranchSource do
   def title, do: "Switch Branch"
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(_context) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(_ctx) do
     root = Minga.Project.resolve_root()
 
     case Git.root_for(root) do

--- a/lib/minga/ui/picker/git_changed_source.ex
+++ b/lib/minga/ui/picker/git_changed_source.ex
@@ -13,6 +13,7 @@ defmodule Minga.UI.Picker.GitChangedSource do
   alias Minga.Language
   alias Minga.Log
   alias Minga.UI.Devicon
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
   alias Minga.UI.Picker.Source
 
@@ -25,8 +26,8 @@ defmodule Minga.UI.Picker.GitChangedSource do
   def preview?, do: true
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(_context) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(_ctx) do
     root = Minga.Project.resolve_root()
 
     case Minga.Git.root_for(root) do

--- a/lib/minga/ui/picker/language_source.ex
+++ b/lib/minga/ui/picker/language_source.ex
@@ -14,6 +14,7 @@ defmodule Minga.UI.Picker.LanguageSource do
   alias Minga.Editor.Commands.BufferManagement
   alias Minga.Language
   alias Minga.UI.Devicon
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   @impl true
@@ -21,9 +22,9 @@ defmodule Minga.UI.Picker.LanguageSource do
   def title, do: "Set language"
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(state) do
-    current_ft = current_filetype(state)
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(ctx) do
+    current_ft = current_filetype(ctx)
 
     Language.all()
     |> Enum.map(fn %Language{} = lang -> format_candidate(lang, current_ft) end)
@@ -65,12 +66,12 @@ defmodule Minga.UI.Picker.LanguageSource do
     |> Enum.map_join(", ", &".#{&1}")
   end
 
-  @spec current_filetype(term()) :: atom()
-  defp current_filetype(%{workspace: %{buffers: %{active: buf}}}) when is_pid(buf) do
+  @spec current_filetype(Context.t()) :: atom()
+  defp current_filetype(%Context{buffers: %{active: buf}}) when is_pid(buf) do
     Buffer.filetype(buf)
   catch
     :exit, _ -> :text
   end
 
-  defp current_filetype(_state), do: :text
+  defp current_filetype(_ctx), do: :text
 end

--- a/lib/minga/ui/picker/location_source.ex
+++ b/lib/minga/ui/picker/location_source.ex
@@ -24,6 +24,7 @@ defmodule Minga.UI.Picker.LocationSource do
   alias Minga.Editor.Commands
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.VimState
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
   alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.UI.Picker.Source
@@ -37,8 +38,8 @@ defmodule Minga.UI.Picker.LocationSource do
   def preview?, do: true
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(%{shell_state: %{picker_ui: %{context: %{locations: locations}}}})
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{picker_ui: %{context: %{locations: locations}}})
       when is_list(locations) do
     Enum.map(locations, &format_location/1)
   end

--- a/lib/minga/ui/picker/option_scope_source.ex
+++ b/lib/minga/ui/picker/option_scope_source.ex
@@ -17,6 +17,7 @@ defmodule Minga.UI.Picker.OptionScopeSource do
   @behaviour Minga.UI.Picker.Source
 
   alias Minga.Config
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Buffer
@@ -26,8 +27,8 @@ defmodule Minga.UI.Picker.OptionScopeSource do
   def title, do: "Apply to..."
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(_context) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(_ctx) do
     [
       %Item{id: :buffer, label: "This Buffer", description: "Set for the current buffer only"},
       %Item{

--- a/lib/minga/ui/picker/project_search_source.ex
+++ b/lib/minga/ui/picker/project_search_source.ex
@@ -9,6 +9,7 @@ defmodule Minga.UI.Picker.ProjectSearchSource do
   @behaviour Minga.UI.Picker.Source
 
   alias Minga.Language
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Buffer
@@ -25,8 +26,8 @@ defmodule Minga.UI.Picker.ProjectSearchSource do
   def preview?, do: true
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(%{workspace: %{search: %{project_results: results}}}) when is_list(results) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{search: %{project_results: results}}) when is_list(results) do
     results
     |> Enum.with_index()
     |> Enum.map(fn {match, idx} ->

--- a/lib/minga/ui/picker/project_source.ex
+++ b/lib/minga/ui/picker/project_source.ex
@@ -8,6 +8,7 @@ defmodule Minga.UI.Picker.ProjectSource do
 
   @behaviour Minga.UI.Picker.Source
 
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Project
@@ -17,8 +18,8 @@ defmodule Minga.UI.Picker.ProjectSource do
   def title, do: "Switch project"
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(_context) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(_ctx) do
     Project.known_projects()
     |> Enum.with_index()
     |> Enum.map(fn {root, _idx} ->

--- a/lib/minga/ui/picker/recent_file_source.ex
+++ b/lib/minga/ui/picker/recent_file_source.ex
@@ -9,6 +9,7 @@ defmodule Minga.UI.Picker.RecentFileSource do
   @behaviour Minga.UI.Picker.Source
 
   alias Minga.Language
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Editor.State, as: EditorState
@@ -25,8 +26,8 @@ defmodule Minga.UI.Picker.RecentFileSource do
   def preview?, do: true
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(_context) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(_ctx) do
     files = Project.recent_files()
 
     Enum.map(files, fn rel_path ->

--- a/lib/minga/ui/picker/session_history_source.ex
+++ b/lib/minga/ui/picker/session_history_source.ex
@@ -9,6 +9,7 @@ defmodule Minga.UI.Picker.SessionHistorySource do
 
   @behaviour Minga.UI.Picker.Source
 
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Agent.Session
@@ -24,8 +25,8 @@ defmodule Minga.UI.Picker.SessionHistorySource do
   def preview?, do: false
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(_state) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(_ctx) do
     SessionStore.list()
     |> Enum.map(fn meta ->
       label = format_label(meta)

--- a/lib/minga/ui/picker/source.ex
+++ b/lib/minga/ui/picker/source.ex
@@ -35,15 +35,13 @@ defmodule Minga.UI.Picker.Source do
 
   alias Minga.Editor.State, as: EditorState
   alias Minga.UI.Picker
-
-  @typedoc "Context passed to `candidates/1` — typically editor state or options."
-  @type context :: term()
+  alias Minga.UI.Picker.Context
 
   @doc "Returns the display title for this picker source."
   @callback title() :: String.t()
 
   @doc "Returns the list of candidates to display in the picker."
-  @callback candidates(context()) :: [Picker.item()]
+  @callback candidates(Context.t()) :: [Picker.item()]
 
   @doc "Called when the user selects an item. Returns the new editor state."
   @callback on_select(Picker.item(), state :: term()) :: term()

--- a/lib/minga/ui/picker/tab_source.ex
+++ b/lib/minga/ui/picker/tab_source.ex
@@ -10,6 +10,7 @@ defmodule Minga.UI.Picker.TabSource do
   @behaviour Minga.UI.Picker.Source
 
   alias Minga.Language
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Editor.State, as: EditorState
@@ -21,8 +22,8 @@ defmodule Minga.UI.Picker.TabSource do
   def title, do: "Switch Tab"
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(%{shell_state: %{tab_bar: %TabBar{} = tb}}) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{tab_bar: %TabBar{} = tb}) do
     Enum.map(tb.tabs, fn tab ->
       icon = tab_icon(tab)
       label = tab_display_label(tab)

--- a/lib/minga/ui/picker/theme_source.ex
+++ b/lib/minga/ui/picker/theme_source.ex
@@ -9,6 +9,7 @@ defmodule Minga.UI.Picker.ThemeSource do
 
   @behaviour Minga.UI.Picker.Source
 
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.UI.Theme
@@ -22,8 +23,8 @@ defmodule Minga.UI.Picker.ThemeSource do
   def preview?, do: true
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(_context) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(_ctx) do
     Theme.available()
     |> Enum.sort()
     |> Enum.map(fn name ->

--- a/lib/minga/ui/picker/workspace_symbol_source.ex
+++ b/lib/minga/ui/picker/workspace_symbol_source.ex
@@ -19,6 +19,7 @@ defmodule Minga.UI.Picker.WorkspaceSymbolSource do
   alias Minga.LSP.Client
   alias Minga.Workspace.State, as: WorkspaceState
   alias Minga.LSP.SyncServer
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
   alias Minga.UI.Picker.Source
 
@@ -31,8 +32,8 @@ defmodule Minga.UI.Picker.WorkspaceSymbolSource do
   def preview?, do: true
 
   @impl true
-  @spec candidates(term()) :: [Item.t()]
-  def candidates(%{workspace: %{buffers: %{active: buf}}} = _state) when is_pid(buf) do
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{buffers: %{active: buf}}) when is_pid(buf) do
     # Send a synchronous workspace/symbol request with empty query.
     # Most servers return commonly-used symbols for "".
     case lsp_client_for(buf) do

--- a/test/minga/ui/picker/agent_group_icon_source_test.exs
+++ b/test/minga/ui/picker/agent_group_icon_source_test.exs
@@ -1,10 +1,31 @@
 defmodule Minga.UI.Picker.AgentGroupIconSourceTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Editor.State.Buffers
+  alias Minga.Editor.State.Search
   alias Minga.Editor.State.Tab
   alias Minga.Editor.State.TabBar
+  alias Minga.Editor.VimState
+  alias Minga.Editor.Viewport
   alias Minga.UI.Picker.AgentGroupIconSource
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
+  alias Minga.UI.Theme
+
+  defp fake_context(tab_bar) do
+    %Context{
+      buffers: %Buffers{list: [], active: nil, active_index: 0},
+      editing: VimState.new(),
+      file_tree: nil,
+      search: %Search{},
+      viewport: Viewport.new(80, 24),
+      tab_bar: tab_bar,
+      agent_session: nil,
+      picker_ui: %{},
+      capabilities: %{},
+      theme: Theme.get!(:doom_one)
+    }
+  end
 
   describe "title/0" do
     test "returns a descriptive title" do
@@ -15,7 +36,7 @@ defmodule Minga.UI.Picker.AgentGroupIconSourceTest do
   describe "candidates/1" do
     test "returns items for all curated icons" do
       tb = TabBar.new(Tab.new_file(1, "a.ex"))
-      items = AgentGroupIconSource.candidates(%{shell_state: %{tab_bar: tb}})
+      items = AgentGroupIconSource.candidates(fake_context(tb))
       assert length(items) > 40
       assert Enum.all?(items, &match?(%Item{}, &1))
     end
@@ -27,7 +48,7 @@ defmodule Minga.UI.Picker.AgentGroupIconSourceTest do
       tb = TabBar.move_tab_to_group(tb, 2, group.id)
       tb = TabBar.switch_to_group(tb, group.id)
 
-      items = AgentGroupIconSource.candidates(%{shell_state: %{tab_bar: tb}})
+      items = AgentGroupIconSource.candidates(fake_context(tb))
       cpu_item = Enum.find(items, &(&1.id == "cpu"))
       assert cpu_item.label =~ "\u{2022}"
       other = Enum.find(items, &(&1.id == "brain"))
@@ -35,17 +56,28 @@ defmodule Minga.UI.Picker.AgentGroupIconSourceTest do
     end
 
     test "items include category as description" do
-      items =
-        AgentGroupIconSource.candidates(%{
-          shell_state: %{tab_bar: TabBar.new(Tab.new_file(1, "a.ex"))}
-        })
+      tb = TabBar.new(Tab.new_file(1, "a.ex"))
+      items = AgentGroupIconSource.candidates(fake_context(tb))
 
       folder_item = Enum.find(items, &(&1.id == "folder"))
       assert folder_item.description == "General"
     end
 
-    test "returns empty for state without tab_bar" do
-      assert AgentGroupIconSource.candidates(%{}) == []
+    test "returns empty for context without TabBar struct" do
+      ctx = %Context{
+        buffers: %Buffers{list: [], active: nil, active_index: 0},
+        editing: VimState.new(),
+        file_tree: nil,
+        search: %Search{},
+        viewport: Viewport.new(80, 24),
+        tab_bar: %{},
+        agent_session: nil,
+        picker_ui: %{},
+        capabilities: %{},
+        theme: Theme.get!(:doom_one)
+      }
+
+      assert AgentGroupIconSource.candidates(ctx) == []
     end
   end
 

--- a/test/minga/ui/picker/agent_group_source_test.exs
+++ b/test/minga/ui/picker/agent_group_source_test.exs
@@ -1,9 +1,30 @@
 defmodule Minga.UI.Picker.AgentGroupSourceTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Editor.State.Buffers
+  alias Minga.Editor.State.Search
   alias Minga.Editor.State.Tab
   alias Minga.Editor.State.TabBar
+  alias Minga.Editor.VimState
+  alias Minga.Editor.Viewport
   alias Minga.UI.Picker.AgentGroupSource
+  alias Minga.UI.Picker.Context
+  alias Minga.UI.Theme
+
+  defp fake_context(tab_bar) do
+    %Context{
+      buffers: %Buffers{list: [], active: nil, active_index: 0},
+      editing: VimState.new(),
+      file_tree: nil,
+      search: %Search{},
+      viewport: Viewport.new(80, 24),
+      tab_bar: tab_bar,
+      agent_session: nil,
+      picker_ui: %{},
+      capabilities: %{},
+      theme: Theme.get!(:doom_one)
+    }
+  end
 
   describe "candidates/1" do
     test "returns one item per agent group with tabs" do
@@ -11,9 +32,8 @@ defmodule Minga.UI.Picker.AgentGroupSourceTest do
       {tb, _} = TabBar.add(tb, :agent, "Agent")
       {tb, group} = TabBar.add_agent_group(tb, "Research")
       tb = TabBar.move_tab_to_group(tb, 2, group.id)
-      state = %{shell_state: %{tab_bar: tb}}
 
-      items = AgentGroupSource.candidates(state)
+      items = AgentGroupSource.candidates(fake_context(tb))
       assert length(items) == 1
       assert hd(items).id == group.id
     end
@@ -21,9 +41,8 @@ defmodule Minga.UI.Picker.AgentGroupSourceTest do
     test "filters out groups with no tabs" do
       tb = TabBar.new(Tab.new_file(1, "a.ex"))
       {tb, _} = TabBar.add_agent_group(tb, "Empty")
-      state = %{shell_state: %{tab_bar: tb}}
 
-      items = AgentGroupSource.candidates(state)
+      items = AgentGroupSource.candidates(fake_context(tb))
       assert items == []
     end
 
@@ -33,15 +52,27 @@ defmodule Minga.UI.Picker.AgentGroupSourceTest do
       {tb, group} = TabBar.add_agent_group(tb, "Work")
       tb = TabBar.move_tab_to_group(tb, 1, group.id)
       tb = TabBar.move_tab_to_group(tb, 2, group.id)
-      state = %{shell_state: %{tab_bar: tb}}
 
-      [item] = AgentGroupSource.candidates(state)
+      [item] = AgentGroupSource.candidates(fake_context(tb))
       assert item.description =~ "editor.ex"
       assert item.description =~ "main.ex"
     end
 
-    test "returns empty for state without tab_bar" do
-      assert AgentGroupSource.candidates(%{}) == []
+    test "returns empty for context without TabBar struct" do
+      ctx = %Context{
+        buffers: %Buffers{list: [], active: nil, active_index: 0},
+        editing: VimState.new(),
+        file_tree: nil,
+        search: %Search{},
+        viewport: Viewport.new(80, 24),
+        tab_bar: %{},
+        agent_session: nil,
+        picker_ui: %{},
+        capabilities: %{},
+        theme: Theme.get!(:doom_one)
+      }
+
+      assert AgentGroupSource.candidates(ctx) == []
     end
   end
 

--- a/test/minga/ui/picker/agent_session_source_test.exs
+++ b/test/minga/ui/picker/agent_session_source_test.exs
@@ -1,6 +1,7 @@
 defmodule Minga.UI.Picker.AgentSessionSourceTest do
   use ExUnit.Case, async: true
 
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
   alias Minga.Agent.Session
@@ -30,8 +31,20 @@ defmodule Minga.UI.Picker.AgentSessionSourceTest do
   describe "candidates/1" do
     test "returns only disk candidates when no agent tabs" do
       tb = TabBar.new(Tab.new_file(1, "main.ex"))
-      state = %{tab_bar: tb, agent: %AgentState{session: nil}}
-      candidates = AgentSessionSource.candidates(state)
+
+      state = %EditorState{
+        port_manager: self(),
+        workspace: %Minga.Workspace.State{
+          viewport: Viewport.new(24, 80),
+          buffers: %Buffers{},
+          windows: %Windows{},
+          editing: VimState.new()
+        },
+        shell_state: %Minga.Shell.Traditional.State{tab_bar: tb, agent: %AgentState{session: nil}}
+      }
+
+      ctx = Context.from_editor_state(state)
+      candidates = AgentSessionSource.candidates(ctx)
 
       Enum.each(candidates, fn %Item{id: {_, tag}} ->
         assert tag == :disk
@@ -43,7 +56,8 @@ defmodule Minga.UI.Picker.AgentSessionSourceTest do
       Session.subscribe(pid)
 
       state = state_with_agent_tab(pid)
-      candidates = AgentSessionSource.candidates(state)
+      ctx = Context.from_editor_state(state)
+      candidates = AgentSessionSource.candidates(ctx)
       tab_entries = Enum.filter(candidates, fn %Item{id: {_, tag}} -> match?({:tab, _}, tag) end)
       assert tab_entries != []
 
@@ -60,7 +74,8 @@ defmodule Minga.UI.Picker.AgentSessionSourceTest do
       Session.subscribe(pid)
 
       state = state_with_agent_tab(pid)
-      candidates = AgentSessionSource.candidates(state)
+      ctx = Context.from_editor_state(state)
+      candidates = AgentSessionSource.candidates(ctx)
 
       active =
         Enum.find(candidates, fn
@@ -81,7 +96,8 @@ defmodule Minga.UI.Picker.AgentSessionSourceTest do
       Session.subscribe(pid2)
 
       state = state_with_two_agent_tabs(pid1, pid2)
-      candidates = AgentSessionSource.candidates(state)
+      ctx = Context.from_editor_state(state)
+      candidates = AgentSessionSource.candidates(ctx)
 
       # Active tab is the first one (pid1). Background tab (pid2) should not have bullet.
       bg_tabs =

--- a/test/minga/ui/picker/buffer_source_test.exs
+++ b/test/minga/ui/picker/buffer_source_test.exs
@@ -5,9 +5,14 @@ defmodule Minga.UI.Picker.BufferSourceTest do
 
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editor.State.Buffers
+  alias Minga.Editor.State.Search
+  alias Minga.Editor.VimState
+  alias Minga.Editor.Viewport
   alias Minga.UI.Picker.BufferAllSource
   alias Minga.UI.Picker.BufferSource
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
+  alias Minga.UI.Theme
 
   defp start_buffer(opts) do
     {:ok, pid} = BufferServer.start_link(opts)
@@ -24,13 +29,22 @@ defmodule Minga.UI.Picker.BufferSourceTest do
   end
 
   defp fake_state(buffers, opts \\ []) do
-    %{
-      workspace: %{
-        buffers: %Buffers{
-          list: buffers,
-          messages: Keyword.get(opts, :messages)
-        }
-      }
+    %Context{
+      buffers: %Buffers{
+        list: buffers,
+        active: nil,
+        active_index: 0,
+        messages: Keyword.get(opts, :messages)
+      },
+      editing: VimState.new(),
+      file_tree: nil,
+      search: %Search{},
+      viewport: Viewport.new(80, 24),
+      tab_bar: %{},
+      agent_session: nil,
+      picker_ui: %{},
+      capabilities: %{},
+      theme: Theme.get!(:doom_one)
     }
   end
 

--- a/test/minga/ui/picker/language_source_test.exs
+++ b/test/minga/ui/picker/language_source_test.exs
@@ -3,8 +3,14 @@ defmodule Minga.UI.Picker.LanguageSourceTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Editor.State.Buffers
+  alias Minga.Editor.State.Search
+  alias Minga.Editor.VimState
+  alias Minga.Editor.Viewport
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
   alias Minga.UI.Picker.LanguageSource
+  alias Minga.UI.Theme
 
   describe "title/0" do
     test "returns Set language" do
@@ -14,16 +20,16 @@ defmodule Minga.UI.Picker.LanguageSourceTest do
 
   describe "candidates/1" do
     test "returns all registered languages" do
-      state = state_with_buffer("hello", :elixir)
-      candidates = LanguageSource.candidates(state)
+      ctx = context_with_buffer("hello", :elixir)
+      candidates = LanguageSource.candidates(ctx)
 
       assert candidates != []
       assert Enum.all?(candidates, &match?(%Item{}, &1))
     end
 
     test "each candidate has an icon and label" do
-      state = state_with_buffer("hello", :elixir)
-      candidates = LanguageSource.candidates(state)
+      ctx = context_with_buffer("hello", :elixir)
+      candidates = LanguageSource.candidates(ctx)
 
       elixir = Enum.find(candidates, fn %Item{id: id} -> id == :elixir end)
       assert elixir != nil
@@ -31,8 +37,8 @@ defmodule Minga.UI.Picker.LanguageSourceTest do
     end
 
     test "current filetype is marked with a bullet" do
-      state = state_with_buffer("hello", :elixir)
-      candidates = LanguageSource.candidates(state)
+      ctx = context_with_buffer("hello", :elixir)
+      candidates = LanguageSource.candidates(ctx)
 
       elixir = Enum.find(candidates, fn %Item{id: id} -> id == :elixir end)
       assert elixir.label =~ "•"
@@ -42,16 +48,16 @@ defmodule Minga.UI.Picker.LanguageSourceTest do
     end
 
     test "shows file extensions in description" do
-      state = state_with_buffer("hello", :text)
-      candidates = LanguageSource.candidates(state)
+      ctx = context_with_buffer("hello", :text)
+      candidates = LanguageSource.candidates(ctx)
 
       elixir = Enum.find(candidates, fn %Item{id: id} -> id == :elixir end)
       assert elixir.description =~ ".ex"
     end
 
     test "candidates are sorted by label" do
-      state = state_with_buffer("hello", :text)
-      candidates = LanguageSource.candidates(state)
+      ctx = context_with_buffer("hello", :text)
+      candidates = LanguageSource.candidates(ctx)
       labels = Enum.map(candidates, & &1.label)
       assert labels == Enum.sort(labels)
     end
@@ -95,6 +101,23 @@ defmodule Minga.UI.Picker.LanguageSourceTest do
   end
 
   # ── Helpers ─────────────────────────────────────────────────────────────────
+
+  defp context_with_buffer(content, filetype) do
+    {:ok, buf} = BufferServer.start_link(content: content, filetype: filetype)
+
+    %Context{
+      buffers: %Buffers{list: [buf], active: buf, active_index: 0},
+      editing: VimState.new(),
+      file_tree: nil,
+      search: %Search{},
+      viewport: Viewport.new(80, 24),
+      tab_bar: %{},
+      agent_session: nil,
+      picker_ui: %{},
+      capabilities: %{},
+      theme: Theme.get!(:doom_one)
+    }
+  end
 
   defp state_with_buffer(content, filetype) do
     {:ok, buf} = BufferServer.start_link(content: content, filetype: filetype)

--- a/test/minga/ui/picker/tab_source_test.exs
+++ b/test/minga/ui/picker/tab_source_test.exs
@@ -1,11 +1,32 @@
 defmodule Minga.UI.Picker.TabSourceTest do
   use ExUnit.Case, async: true
 
+  alias Minga.UI.Picker.Context
   alias Minga.UI.Picker.Item
 
+  alias Minga.Editor.State.Buffers
+  alias Minga.Editor.State.Search
   alias Minga.Editor.State.Tab
   alias Minga.Editor.State.TabBar
+  alias Minga.Editor.VimState
+  alias Minga.Editor.Viewport
   alias Minga.UI.Picker.TabSource
+  alias Minga.UI.Theme
+
+  defp fake_context(tab_bar) do
+    %Context{
+      buffers: %Buffers{list: [], active: nil, active_index: 0},
+      editing: VimState.new(),
+      file_tree: nil,
+      search: %Search{},
+      viewport: Viewport.new(80, 24),
+      tab_bar: tab_bar,
+      agent_session: nil,
+      picker_ui: %{},
+      capabilities: %{},
+      theme: Theme.get!(:doom_one)
+    }
+  end
 
   describe "title/0" do
     test "returns Switch Tab" do
@@ -20,7 +41,7 @@ defmodule Minga.UI.Picker.TabSourceTest do
       {tb, _} = TabBar.add(tb, :file, "lib.ex")
       {tb, _} = TabBar.add(tb, :agent, "Agent")
 
-      candidates = TabSource.candidates(%{shell_state: %{tab_bar: tb}})
+      candidates = TabSource.candidates(fake_context(tb))
       assert length(candidates) == 3
 
       %Item{id: id1, label: label1} = Enum.find(candidates, fn %Item{id: id} -> id == 1 end)
@@ -34,7 +55,7 @@ defmodule Minga.UI.Picker.TabSourceTest do
       {tb, _} = TabBar.add(tb, :file, "two.ex")
       tb = TabBar.switch_to(tb, 1)
 
-      candidates = TabSource.candidates(%{shell_state: %{tab_bar: tb}})
+      candidates = TabSource.candidates(fake_context(tb))
 
       %Item{label: active_label} = Enum.find(candidates, fn %Item{id: id} -> id == 1 end)
       assert String.contains?(active_label, "\u{2022}")
@@ -48,14 +69,28 @@ defmodule Minga.UI.Picker.TabSourceTest do
       tb = TabBar.new(tab)
 
       [%Item{label: label, description: desc}] =
-        TabSource.candidates(%{shell_state: %{tab_bar: tb}})
+        TabSource.candidates(fake_context(tb))
 
       assert String.contains?(label, "My Session")
       assert desc == "agent"
     end
 
-    test "returns empty list for non-tab-bar context" do
-      assert TabSource.candidates(%{}) == []
+    test "returns empty list when tab_bar is not a TabBar struct" do
+      # When tab_bar is not a TabBar struct, candidates/1 returns []
+      ctx = %Context{
+        buffers: %Buffers{list: [], active: nil, active_index: 0},
+        editing: VimState.new(),
+        file_tree: nil,
+        search: %Search{},
+        viewport: Viewport.new(80, 24),
+        tab_bar: %{},
+        agent_session: nil,
+        picker_ui: %{},
+        capabilities: %{},
+        theme: Theme.get!(:doom_one)
+      }
+
+      assert TabSource.candidates(ctx) == []
     end
   end
 


### PR DESCRIPTION
## What

Introduces `Picker.Context` struct, decoupling all 22 picker source modules from `Editor.State`.

## Changes

- New `Picker.Context` struct with `from_editor_state/1`
- Updated Source behaviour callback to use `Context.t()`
- All picker sources updated to accept Context
- `on_select/on_cancel` callbacks still use EditorState (they need full state)
- All 101 picker tests pass

## Stacked on

PR #1323 (feat/1224-decouple-agent)

Closes #1225
Part of epic #1304