### PR TITLE
refactor(shell): establish Traditional shell rendering modules (#1222)

### DIFF
--- a/lib/minga/shell/traditional.ex
+++ b/lib/minga/shell/traditional.ex
@@ -17,6 +17,13 @@ defmodule Minga.Shell.Traditional do
   Phase F for the full plan.
 
   Batch 1 (current): `nav_flash`, `hover_popup`, `dashboard`, `status_msg`
+
+  ## Rendering architecture
+
+  Layout, chrome, and rendering are owned by modules under
+  `Shell.Traditional.*`: `Layout`, `Chrome`, and `Renderer`. These
+  currently delegate to `Editor.*` modules; the implementations will
+  move here as the shell independence refactor progresses.
   """
 
   @behaviour Minga.Shell
@@ -45,26 +52,17 @@ defmodule Minga.Shell.Traditional do
 
   @impl true
   @spec compute_layout(term()) :: Minga.Editor.Layout.t()
-  def compute_layout(editor_state) do
-    Minga.Editor.Layout.compute(editor_state)
-  end
+  defdelegate compute_layout(editor_state), to: Minga.Shell.Traditional.Layout, as: :compute
 
   @impl true
   @spec build_chrome(term(), Minga.Editor.Layout.t(), map(), term()) ::
           Minga.Editor.RenderPipeline.Chrome.t()
-  def build_chrome(editor_state, layout, scrolls, cursor_info) do
-    Minga.Editor.RenderPipeline.Chrome.build_chrome(editor_state, layout, scrolls, cursor_info)
-  end
+  defdelegate build_chrome(editor_state, layout, scrolls, cursor_info),
+    to: Minga.Shell.Traditional.Chrome
 
   @impl true
   @spec render(term()) :: term()
-  def render(%{workspace: %{buffers: %{active: nil}}} = editor_state) do
-    Minga.Editor.Renderer.render_dashboard(editor_state)
-  end
-
-  def render(editor_state) do
-    Minga.Editor.Renderer.render_buffer(editor_state)
-  end
+  defdelegate render(editor_state), to: Minga.Shell.Traditional.Renderer
 
   @impl true
   @spec input_handlers(term()) :: %{overlay: [module()], surface: [module()]}

--- a/lib/minga/shell/traditional/chrome.ex
+++ b/lib/minga/shell/traditional/chrome.ex
@@ -1,0 +1,16 @@
+defmodule Minga.Shell.Traditional.Chrome do
+  @moduledoc """
+  Chrome building for the Traditional shell.
+
+  The Traditional shell's chrome includes: tab bar, modeline/status bar,
+  file tree sidebar, agent panel, which-key popup, completion menu,
+  signature help, and hover popups.
+
+  Delegates to `Minga.Editor.RenderPipeline.Chrome` which contains the
+  actual chrome building logic. As the shell independence refactor
+  progresses, the implementation will move here.
+  """
+
+  defdelegate build_chrome(state, layout, scrolls, cursor_info),
+    to: Minga.Editor.RenderPipeline.Chrome
+end

--- a/lib/minga/shell/traditional/layout.ex
+++ b/lib/minga/shell/traditional/layout.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Shell.Traditional.Layout do
+  @moduledoc """
+  Layout computation for the Traditional shell.
+
+  Delegates to `Minga.Editor.Layout` which contains the actual layout
+  computation logic. As the shell independence refactor progresses,
+  the implementation will move here from `editor/layout.ex`.
+
+  This module exists to establish the correct dependency direction:
+  the Traditional shell owns its own layout decisions, the Editor
+  GenServer just calls them through the Shell behaviour.
+  """
+
+  defdelegate compute(state), to: Minga.Editor.Layout
+  defdelegate get(state), to: Minga.Editor.Layout
+  defdelegate put(state), to: Minga.Editor.Layout
+  defdelegate invalidate(state), to: Minga.Editor.Layout
+end

--- a/lib/minga/shell/traditional/renderer.ex
+++ b/lib/minga/shell/traditional/renderer.ex
@@ -1,0 +1,22 @@
+defmodule Minga.Shell.Traditional.Renderer do
+  @moduledoc """
+  Render pipeline for the Traditional shell.
+
+  Orchestrates the full render cycle: invalidation, layout, scroll,
+  content, chrome, compose, and emit. This is the Traditional shell's
+  implementation of the Shell.render callback.
+
+  Delegates to `Minga.Editor.Renderer` which contains the actual render
+  logic. As the shell independence refactor progresses, the implementation
+  will move here.
+  """
+
+  @spec render(term()) :: term()
+  def render(%{workspace: %{buffers: %{active: nil}}} = state) do
+    Minga.Editor.Renderer.render_dashboard(state)
+  end
+
+  def render(state) do
+    Minga.Editor.Renderer.render_buffer(state)
+  end
+end


### PR DESCRIPTION
## What

Phase A of the big move: creates `Shell.Traditional.Layout`, `Shell.Traditional.Chrome`, and `Shell.Traditional.Renderer` modules that own the Traditional shell's rendering pipeline.

## Why

The endgame of shell independence is that presentation code lives in `shell/*/`, not `editor/`. This PR establishes the correct module structure: Shell.Traditional routes through its own modules instead of referencing Editor modules directly.

## Changes

- New `Shell.Traditional.Layout` delegating to `Editor.Layout`
- New `Shell.Traditional.Chrome` delegating to `Editor.RenderPipeline.Chrome`
- New `Shell.Traditional.Renderer` delegating to `Editor.Renderer` (handles dashboard vs buffer rendering)
- Updated `Shell.Traditional` to use these modules via `defdelegate`
- Board shell does not import any Traditional shell module

## What's next

The implementations will gradually move from `editor/` into `shell/traditional/` in future PRs (Phases B and C from the ticket). The delegation pattern makes this incremental: each move is a single file relocation that updates the delegate target.

## Stacked on

PR #1324 (feat/1225-decouple-picker)

Partially addresses #1222
Part of epic #1304