### PR TITLE
fix(test): update tests for agent_flush_before_shell and CodeActionSource context

### DIFF
--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -72,6 +72,7 @@ defmodule Minga.Config.OptionsTest do
                agent_notify_on: [:approval, :complete, :error],
                agent_max_turns: 100,
                agent_max_cost: nil,
+               agent_flush_before_shell: true,
                agent_compaction_threshold: 0.80,
                agent_compaction_keep_recent: 6,
                agent_approval_timeout: 300_000,

--- a/test/minga/editor/lsp_actions_test.exs
+++ b/test/minga/editor/lsp_actions_test.exs
@@ -12,6 +12,7 @@ defmodule Minga.Editor.LspActionsTest do
   alias Minga.Editor.VimState
   alias Minga.Editor.Viewport
   alias Minga.UI.Picker.CodeActionSource
+  alias Minga.UI.Picker.Context, as: PickerContext
   alias Minga.Workspace.State, as: WorkspaceState
 
   # ── parse_location/1 ──────────────────────────────────────────────────────
@@ -574,8 +575,20 @@ defmodule Minga.Editor.LspActionsTest do
         %{"title" => "Extract variable", "kind" => "refactor.extract", "isPreferred" => true}
       ]
 
-      state = %{shell_state: %{picker_ui: %{context: %{actions: actions}}}}
-      items = CodeActionSource.candidates(state)
+      tab = Minga.Editor.State.Tab.new_file(1, "test")
+
+      ctx = %PickerContext{
+        buffers: %Buffers{},
+        editing: VimState.new(),
+        search: %Minga.Editor.State.Search{},
+        viewport: Viewport.new(24, 80),
+        tab_bar: Minga.Editor.State.TabBar.new(tab),
+        picker_ui: %{context: %{actions: actions}},
+        capabilities: %{},
+        theme: Minga.UI.Theme.get!(:doom_one)
+      }
+
+      items = CodeActionSource.candidates(ctx)
 
       assert length(items) == 2
       assert Enum.any?(items, fn item -> String.contains?(item.label, "Fix import") end)


### PR DESCRIPTION
## What

Fixes two deterministic CI test failures on main.

## Why

Two recent PRs introduced test breakage that wasn't caught before merge:

1. **`OptionsTest`** (#1310 added `agent_flush_before_shell` option but didn't update the `all/1 returns all defaults` test)
2. **`LspActionsTest`** (`CodeActionSource.candidates/1` was refactored to pattern-match on `%Context{}` struct, but the test still passed a bare map, so the match silently fell through to the `candidates(_state)` fallback returning `[]`)

## Changes

- `test/minga/config/options_test.exs`: Add missing `agent_flush_before_shell: true` to expected defaults map
- `test/minga/editor/lsp_actions_test.exs`: Construct a proper `Picker.Context` struct instead of a bare map

## Third failure (flaky)

CI also showed a failure in `BuftypeIntegrationTest` (`dirty?` returning false). This passes consistently locally and the logic is sound (synchronous GenServer.call chain). Likely a CI-only timing flake, not addressed here.