### PR TITLE
Fix Dialyzer warnings: missing field, type mismatch, dead code

### DIFF
--- a/lib/minga/editor/completion_handling.ex
+++ b/lib/minga/editor/completion_handling.ex
@@ -36,7 +36,7 @@ defmodule Minga.Editor.CompletionHandling do
 
     # Skip if already resolved for this index, or if doc is already present
     if item == nil or selected_idx == completion.last_resolved_index or
-         (item.documentation != "" and item.documentation != nil) do
+         item.documentation != "" do
       state
     else
       # Cancel previous resolve timer

--- a/lib/minga/editor/render_pipeline/content.ex
+++ b/lib/minga/editor/render_pipeline/content.ex
@@ -538,10 +538,10 @@ defmodule Minga.Editor.RenderPipeline.Content do
 
     # Header
     header_face = Face.new(fg: at.text_fg, bg: at.panel_bg, bold: true)
-    hint_face = Face.new(fg: at.text_dim, bg: at.panel_bg)
+    hint_face = Face.new(fg: at.hint_fg, bg: at.panel_bg)
     label_face = Face.new(fg: at.dashboard_label, bg: at.panel_bg, bold: true)
     key_face = Face.new(fg: at.text_fg, bg: at.panel_bg)
-    desc_face = Face.new(fg: at.text_dim, bg: at.panel_bg)
+    desc_face = Face.new(fg: at.hint_fg, bg: at.panel_bg)
 
     header_row = 1
 

--- a/lib/minga/editor/render_pipeline/content_helpers.ex
+++ b/lib/minga/editor/render_pipeline/content_helpers.ex
@@ -134,8 +134,8 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
       is_gui: is_gui,
       has_sign_column: has_sign_column,
       decorations: decorations,
-      diagnostic_signs: diagnostic_signs_for_window(state, window),
-      git_signs: git_signs_for_window(state, window),
+      diagnostic_signs: diagnostic_signs_for_window(window),
+      git_signs: git_signs_for_window(window),
       gutter_colors: state.theme.gutter,
       git_colors: state.theme.git
     }
@@ -850,8 +850,8 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   end
 
   @doc "Returns git signs for a window's buffer."
-  @spec git_signs_for_window(state(), Window.t()) :: %{non_neg_integer() => atom()}
-  def git_signs_for_window(_state, %{buffer: buf}) when is_pid(buf) do
+  @spec git_signs_for_window(Window.t()) :: %{non_neg_integer() => atom()}
+  def git_signs_for_window(%{buffer: buf}) when is_pid(buf) do
     case Git.tracking_pid(buf) do
       nil ->
         %{}
@@ -866,8 +866,8 @@ defmodule Minga.Editor.RenderPipeline.ContentHelpers do
   end
 
   @doc "Returns diagnostic signs for a window's buffer."
-  @spec diagnostic_signs_for_window(state(), Window.t()) :: %{non_neg_integer() => atom()}
-  def diagnostic_signs_for_window(_state, %{buffer: buf}) when is_pid(buf) do
+  @spec diagnostic_signs_for_window(Window.t()) :: %{non_neg_integer() => atom()}
+  def diagnostic_signs_for_window(%{buffer: buf}) when is_pid(buf) do
     case Buffer.file_path(buf) do
       nil -> %{}
       path -> Diagnostics.severity_by_line(SyncServer.path_to_uri(path))

--- a/lib/minga/frontend/emit/gui.ex
+++ b/lib/minga/frontend/emit/gui.ex
@@ -942,7 +942,7 @@ defmodule Minga.Frontend.Emit.GUI do
         # Skip agent chat windows (they don't have gutter)
         if window && is_pid(window.buffer) && !Content.agent_chat?(window.content) do
           is_active = win_id == ctx.windows.active
-          gutter_data = build_window_gutter(ctx, window, win_id, win_layout, is_active)
+          gutter_data = build_window_gutter(window, win_id, win_layout, is_active)
           [ProtocolGUI.encode_gui_gutter(gutter_data)]
         else
           []
@@ -955,13 +955,12 @@ defmodule Minga.Frontend.Emit.GUI do
   # Builds a minimal gutter entry for the agent prompt SemanticWindow.
   # Positions it at the bottom of the grid with no line numbers or sign column.
   @spec build_window_gutter(
-          ctx(),
           Minga.Editor.Window.t(),
           pos_integer(),
           Layout.window_layout(),
           boolean()
         ) :: ProtocolGUI.gutter_data()
-  defp build_window_gutter(ctx, window, win_id, win_layout, is_active) do
+  defp build_window_gutter(window, win_id, win_layout, is_active) do
     buf = window.buffer
     cursor_line = max(window.last_cursor_line, 0)
     viewport_top = max(window.last_viewport_top, 0)
@@ -987,7 +986,7 @@ defmodule Minga.Frontend.Emit.GUI do
         entries: []
       })
     else
-      build_gutter_entries(ctx, window, buf, win_pos, %{
+      build_gutter_entries(window, buf, win_pos, %{
         cursor_line: cursor_line,
         viewport_top: viewport_top,
         line_count: line_count
@@ -995,9 +994,9 @@ defmodule Minga.Frontend.Emit.GUI do
     end
   end
 
-  @spec build_gutter_entries(ctx(), Minga.Editor.Window.t(), pid(), map(), map()) ::
+  @spec build_gutter_entries(Minga.Editor.Window.t(), pid(), map(), map()) ::
           ProtocolGUI.gutter_data()
-  defp build_gutter_entries(ctx, window, buf, win_pos, params) do
+  defp build_gutter_entries(window, buf, win_pos, params) do
     %{cursor_line: cursor_line, viewport_top: viewport_top, line_count: line_count} = params
     line_number_style = Buffer.get_option(buf, :line_numbers)
 
@@ -1009,8 +1008,8 @@ defmodule Minga.Frontend.Emit.GUI do
 
     # Get signs and decorations for the buffer
     decorations = Buffer.decorations(buf)
-    diag_signs = ContentHelpers.diagnostic_signs_for_window(ctx, window)
-    git_signs = ContentHelpers.git_signs_for_window(ctx, window)
+    diag_signs = ContentHelpers.diagnostic_signs_for_window(window)
+    git_signs = ContentHelpers.git_signs_for_window(window)
 
     # Build entries for each visible line
     entries =

--- a/lib/minga/shell/board.ex
+++ b/lib/minga/shell/board.ex
@@ -236,7 +236,7 @@ defmodule Minga.Shell.Board do
 
     if card do
       icon = zoom_status_icon(card.status)
-      task = card.task || "Untitled"
+      task = if card.task == "", do: "Untitled", else: card.task
       model = if card.model, do: " · #{card.model}", else: ""
       hint = "ESC back to Board"
 
@@ -269,7 +269,6 @@ defmodule Minga.Shell.Board do
   defp zoom_status_icon(:needs_you), do: "◆"
   defp zoom_status_icon(:done), do: "✓"
   defp zoom_status_icon(:errored), do: "✗"
-  defp zoom_status_icon(_), do: "○"
 
   @spec zoom_status_face(Minga.Shell.Board.Card.status(), Minga.UI.Theme.t()) ::
           Minga.Core.Face.t()


### PR DESCRIPTION
## What

Fixes 5 Dialyzer warnings surfaced by running `mix dialyzer` under OTP 28. These are real codebase issues (not OTP/Elixir beta noise).

Closes #1335, #1336, #1337

## Changes

**#1335 — `content.ex` crash on missing Agent theme field:**
`render_help_overlay/3` referenced `at.text_dim`, which does not exist on `Minga.UI.Theme.Agent`. Replaced with `at.hint_fg`. Without this fix, triggering the help overlay in the agent panel would crash with `KeyError`.

**#1336 — GUI gutter emit type mismatch:**
`diagnostic_signs_for_window/2` and `git_signs_for_window/2` had specs requiring `EditorState.t()` as the first argument, but the GUI emit pipeline passed `Context.t()`. Both functions ignore that argument entirely. Removed the unused `state` param from both functions and cascaded the removal through `build_gutter_entries` and `build_window_gutter` in `gui.ex`. This restores Dialyzer coverage for the entire GUI gutter code path (~100 lines that were previously marked as dead code).

**#1337 — Dead code cleanup (3 items):**
- `board.ex`: `card.task || "Untitled"` guarded against nil, but `Card.task` is `String.t()` (never nil, defaults to `""`). Changed to check for empty string.
- `board.ex`: Removed unreachable catch-all `zoom_status_icon(_)` since the 6 explicit clauses fully cover `Card.status()`.
- `completion_handling.ex`: Removed redundant `!= nil` check on `item.documentation`, which is always `String.t()`.

## Verification

- `make lint` passes (format + credo + compile + dialyzer)
- `mix test.llm`: 7094 tests, 0 failures
- All 5 Dialyzer warnings confirmed resolved