### PR TITLE
fix(macos): use POSIX write() to survive broken pipe on BEAM exit

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		DB83E9F1763A0D2E7BD7F7D3 /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = BD2531C0969FD21CC18D2FDB /* ViewInspector */; };
 		DD0B958D8ACEFFEF3C1A50AE /* ViewModelComputedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22420E1CC772DAFB9A5043C2 /* ViewModelComputedTests.swift */; };
 		DE6C77896ED3E1E885216DC3 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
+		DF3B2A645C089F616B9DBD1B /* ProtocolEncoderDisconnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D226D16EF96375868F716D /* ProtocolEncoderDisconnectTests.swift */; };
 		E04EB44BCBE0CEB501618F1A /* FileTreeHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */; };
 		E073657EE87B3F145830B7C7 /* FileTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */; };
 		E2BC69E1121328310B830E45 /* CachedLineTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */; };
@@ -205,6 +206,7 @@
 		0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedLineTexture.swift; sourceTree = "<group>"; };
 		0E2EC7DA888E31E55CE0D715 /* AgentContextBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentContextBar.swift; sourceTree = "<group>"; };
 		16B5F67DE84B139C6F8F3C9F /* GitStatusState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusState.swift; sourceTree = "<group>"; };
+		19D226D16EF96375868F716D /* ProtocolEncoderDisconnectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolEncoderDisconnectTests.swift; sourceTree = "<group>"; };
 		1AC5F0D37085813890268537 /* InlineEditField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineEditField.swift; sourceTree = "<group>"; };
 		1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewTests.swift; sourceTree = "<group>"; };
 		1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderButton.swift; sourceTree = "<group>"; };
@@ -503,6 +505,7 @@
 				AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */,
 				321E4E28F5F49F089CCE2E1D /* PipelineCacheTests.swift */,
 				47BD56B7D6D195D236F9BF40 /* ProtocolEncoderBinaryTests.swift */,
+				19D226D16EF96375868F716D /* ProtocolEncoderDisconnectTests.swift */,
 				3DC281B7F9F7E4C0BA793B1E /* ProtocolSchemaTests.swift */,
 				F220A60775A252A728477659 /* ProtocolTests.swift */,
 				211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */,
@@ -806,6 +809,7 @@
 				93E7D214A27256CF06571EFE /* ProtocolDecoder.swift in Sources */,
 				7C9B7CB6670412D9F4DE60BB /* ProtocolEncoder.swift in Sources */,
 				778C6A917140005C0C0643CB /* ProtocolEncoderBinaryTests.swift in Sources */,
+				DF3B2A645C089F616B9DBD1B /* ProtocolEncoderDisconnectTests.swift in Sources */,
 				FA582944CD6B90BCABC13FCE /* ProtocolReader.swift in Sources */,
 				F0A2BCCA095F1CA4FBE9BE3F /* ProtocolSchemaTests.swift in Sources */,
 				686DD6EB8AFDCAFC79EA100A /* ProtocolTests.swift in Sources */,

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -574,6 +574,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var editorNSView: EditorNSView?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Ignore SIGPIPE so broken pipe writes return EPIPE instead of
+        // killing the process. Without this, any write to the BEAM pipe
+        // after Ctrl+C delivers SIGPIPE (default action: terminate).
+        signal(SIGPIPE, SIG_IGN)
+
         os_signpost(.begin, log: startupLog, name: "AppStartup")
 
         // Register the bundled Nerd Font for devicon rendering.
@@ -707,6 +712,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // once SwiftUI assigns the real frame dimensions. This avoids
         // the BEAM rendering at hardcoded 800x600 defaults.
 
+        // Capture the encoder for the disconnect callback. The closure
+        // runs on the reader's background thread; ProtocolEncoder is
+        // @unchecked Sendable and disconnect() is lock-protected.
+        let disconnectEncoder = enc
+
         // Start reading protocol commands.
         let reader = ProtocolReader(
             input: protocolInput,
@@ -716,6 +726,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             },
             onDisconnect: { [weak self] in
+                // Immediately mark the encoder as disconnected so any
+                // in-flight writes (keystrokes, mouse events) on the
+                // main thread are silently dropped instead of hitting
+                // a broken pipe. This runs on the reader's background
+                // thread, but ProtocolEncoder.disconnect() is lock-
+                // protected and safe to call from any thread.
+                disconnectEncoder.disconnect()
+
                 DispatchQueue.main.async {
                     // In bundle mode, BEAMProcessManager handles restart/error.
                     // In dev mode, our parent (BEAM) exited; shut down.
@@ -807,6 +825,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.encoder = enc
         PortLogger.setup(encoder: enc)
 
+        // Capture for the background-thread disconnect callback.
+        let disconnectEncoder = enc
+
         // Create new reader for the new pipe.
         let reader = ProtocolReader(
             input: readHandle,
@@ -816,6 +837,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             },
             onDisconnect: { [weak self] in
+                disconnectEncoder.disconnect()
+
                 DispatchQueue.main.async {
                     if self?.beamManager == nil {
                         NSApp.terminate(nil)

--- a/macos/Sources/Protocol/ProtocolEncoder.swift
+++ b/macos/Sources/Protocol/ProtocolEncoder.swift
@@ -95,14 +95,32 @@ extension InputEncoder {
 }
 
 /// Thread-safe encoder that writes `{:packet, 4}` framed events to stdout.
+///
+/// Uses POSIX `write()` instead of `FileHandle.write()` to avoid
+/// `NSFileHandleOperationException` (ObjC exception) on broken pipes.
+/// ObjC exceptions cannot be caught from Swift, so `FileHandle.write()`
+/// to a dead pipe zombifies the app (beachball). POSIX `write()` returns
+/// -1 with `errno = EPIPE`, which we handle by marking the encoder as
+/// disconnected and silently dropping subsequent writes.
 final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
     private let lock = NSLock()
-    private let output: FileHandle
+    private let fd: Int32
+    /// Once a write fails with EPIPE, all subsequent writes are dropped.
+    private var connected: Bool = true
 
     /// Creates an encoder. Defaults to stdout for production use.
     /// Pass a pipe's write handle for testing binary layout.
     init(output: FileHandle = .standardOutput) {
-        self.output = output
+        self.fd = output.fileDescriptor
+    }
+
+    /// Mark the encoder as disconnected. Called by the reader's
+    /// `onDisconnect` callback so writes stop immediately without
+    /// waiting for the next EPIPE.
+    func disconnect() {
+        lock.lock()
+        defer { lock.unlock() }
+        connected = false
     }
 
     /// Send the ready event with initial dimensions and capabilities.
@@ -654,8 +672,18 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
 
     // MARK: - Private
 
-    /// Write a length-prefixed frame to stdout.
+    /// Write a length-prefixed frame using POSIX `write()`.
+    ///
+    /// `FileHandle.write()` raises an ObjC `NSFileHandleOperationException`
+    /// on EPIPE that Swift cannot catch, zombifying the app. POSIX `write()`
+    /// returns -1 and sets `errno = EPIPE`, which we handle by flipping
+    /// `connected` to false.
     private func writeFrame(_ payload: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard connected else { return }
+
         var frame = Data(count: 4 + payload.count)
         let len = UInt32(payload.count)
         frame[0] = UInt8((len >> 24) & 0xFF)
@@ -664,9 +692,22 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
         frame[3] = UInt8(len & 0xFF)
         frame.replaceSubrange(4..<(4 + payload.count), with: payload)
 
-        lock.lock()
-        defer { lock.unlock() }
-        output.write(frame)
+        frame.withUnsafeBytes { buffer in
+            guard let ptr = buffer.baseAddress else { return }
+            var remaining = frame.count
+            var offset = 0
+            while remaining > 0 {
+                let written = Darwin.write(fd, ptr + offset, remaining)
+                if written < 0 {
+                    if errno == EINTR { continue }
+                    // EPIPE or other fatal error: pipe is broken.
+                    connected = false
+                    return
+                }
+                offset += written
+                remaining -= written
+            }
+        }
     }
 
     private func writeU16(_ buf: inout Data, _ offset: Int, _ value: UInt16) {

--- a/macos/Tests/MingaTests/ProtocolEncoderDisconnectTests.swift
+++ b/macos/Tests/MingaTests/ProtocolEncoderDisconnectTests.swift
@@ -1,0 +1,136 @@
+/// Tests for ProtocolEncoder broken pipe / disconnect handling.
+///
+/// Verifies that the encoder survives a broken pipe without crashing,
+/// throwing, or blocking the calling thread. This guards against the
+/// regression where `FileHandle.write()` to a dead pipe raised an
+/// uncatchable ObjC `NSFileHandleOperationException`, zombifying the app.
+
+import Testing
+import Foundation
+
+@Suite("Encoder: Disconnect Safety")
+struct EncoderDisconnectTests {
+
+    // MARK: - disconnect() drops writes
+
+    @Test("disconnect() causes subsequent writes to be silently dropped")
+    func disconnectDropsWrites() {
+        let pipe = Pipe()
+        let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting)
+
+        // Send one frame before disconnect (should succeed).
+        encoder.sendReady(cols: 80, rows: 24)
+
+        // Disconnect the encoder.
+        encoder.disconnect()
+
+        // These should be silently dropped, not crash.
+        encoder.sendKeyPress(codepoint: 0x61, modifiers: 0)
+        encoder.sendResize(cols: 120, rows: 40)
+        encoder.sendMouseEvent(row: 5, col: 10, button: 0, modifiers: 0,
+                               eventType: 0, clickCount: 1)
+        encoder.sendPasteEvent(text: "hello")
+        encoder.sendLog(level: 1, message: "test")
+        encoder.sendSelectTab(id: 1)
+        encoder.sendExecuteCommand(name: "quit")
+
+        // Close write end and read everything that was written.
+        pipe.fileHandleForWriting.closeFile()
+        let raw = pipe.fileHandleForReading.readDataToEndOfFile()
+
+        // Only the ready frame should have been written (13 bytes payload + 4 length).
+        #expect(raw.count == 17)
+    }
+
+    @Test("disconnect() is idempotent")
+    func disconnectIdempotent() {
+        let pipe = Pipe()
+        let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting)
+
+        encoder.disconnect()
+        encoder.disconnect()
+        encoder.disconnect()
+
+        // Should not crash. Writes should still be dropped.
+        encoder.sendKeyPress(codepoint: 0x61, modifiers: 0)
+
+        pipe.fileHandleForWriting.closeFile()
+        let raw = pipe.fileHandleForReading.readDataToEndOfFile()
+        #expect(raw.isEmpty)
+    }
+
+    // MARK: - Broken pipe detection
+
+    @Test("writing to a closed pipe marks encoder as disconnected")
+    func brokenPipeAutoDisconnects() {
+        let pipe = Pipe()
+        let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting)
+
+        // Close the read end to simulate the BEAM dying.
+        // This makes the pipe broken: writes will get EPIPE.
+        pipe.fileHandleForReading.closeFile()
+
+        // Ignore SIGPIPE for this test (mirrors production setup).
+        signal(SIGPIPE, SIG_IGN)
+
+        // This write should hit EPIPE and auto-disconnect.
+        // It must NOT crash, throw, or block.
+        encoder.sendKeyPress(codepoint: 0x61, modifiers: 0)
+
+        // Subsequent writes should be silently dropped (encoder is
+        // now disconnected). If these crash, the auto-disconnect
+        // didn't work.
+        encoder.sendKeyPress(codepoint: 0x62, modifiers: 0)
+        encoder.sendResize(cols: 100, rows: 50)
+        encoder.sendPasteEvent(text: "should be dropped")
+    }
+
+    @Test("encoder survives rapid writes to a broken pipe")
+    func brokenPipeRapidWrites() {
+        let pipe = Pipe()
+        let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting)
+
+        // Close read end to break the pipe.
+        pipe.fileHandleForReading.closeFile()
+
+        signal(SIGPIPE, SIG_IGN)
+
+        // Simulate a burst of user input arriving after the BEAM dies.
+        // None of these should crash or block.
+        for i: UInt32 in 0..<100 {
+            encoder.sendKeyPress(codepoint: 0x61 + (i % 26), modifiers: 0)
+        }
+    }
+
+    // MARK: - Thread safety
+
+    @Test("disconnect() is safe to call from a background thread while main thread writes")
+    func disconnectFromBackgroundThread() async {
+        let pipe = Pipe()
+        let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting)
+
+        // Simulate the race: reader thread calls disconnect() while
+        // the main thread is still sending keystrokes.
+        let iterations = 1000
+
+        await withTaskGroup(of: Void.self) { group in
+            // Writer task: rapid-fire key presses.
+            group.addTask {
+                for i: UInt32 in 0..<UInt32(iterations) {
+                    encoder.sendKeyPress(codepoint: 0x61 + (i % 26), modifiers: 0)
+                }
+            }
+
+            // Disconnector task: disconnect partway through.
+            group.addTask {
+                // Small yield to let some writes happen first.
+                try? await Task.sleep(nanoseconds: 100_000) // 0.1ms
+                encoder.disconnect()
+            }
+        }
+
+        // If we get here without crashing or deadlocking, the test passes.
+        // Close the pipe so it doesn't leak.
+        pipe.fileHandleForWriting.closeFile()
+    }
+}


### PR DESCRIPTION
## Problem

`FileHandle.write()` raises an uncatchable ObjC `NSFileHandleOperationException` when the pipe breaks (BEAM exits via Ctrl+C). Since Swift cannot catch ObjC exceptions, the app zombifies with a beachball.

## Solution

Replace `FileHandle.write()` with POSIX `Darwin.write()` in `ProtocolEncoder`, which returns `-1`/`EPIPE` instead of throwing. On EPIPE, the encoder marks itself as disconnected and silently drops all subsequent writes.

### Changes

- **`ProtocolEncoder.swift`**: Switch from `FileHandle.write()` to POSIX `write()` with proper partial-write handling and EPIPE detection. Add `disconnect()` method (lock-protected) to immediately stop writes.
- **`MingaApp.swift`**: Ignore SIGPIPE at app startup so broken pipe writes return EPIPE instead of killing the process. Call `encoder.disconnect()` in both `ProtocolReader.onDisconnect` callbacks so writes stop immediately.
- **`ProtocolEncoderDisconnectTests.swift`**: 5 tests covering disconnect drops writes, idempotent disconnect, auto-disconnect on broken pipe, rapid writes to broken pipe, and thread safety (concurrent write + disconnect).

## Testing

All 475 Swift tests pass, including the 5 new disconnect tests.