### PR TITLE
fix(editor): remove synthetic tab bar from Board mode and fix close_tab crashes

### DIFF
--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -1826,6 +1826,9 @@ defmodule Minga.Editor do
     EditorState.switch_tab(state, id)
   end
 
+  # Board mode has no tab bar; ignore close_tab events from phantom GUI state.
+  defp handle_gui_action(%{shell_state: %{tab_bar: nil}} = state, {:close_tab, _id}), do: state
+
   defp handle_gui_action(state, {:close_tab, id}) do
     # Switch to the target tab first (if not already active), then close
     # it. This ensures the right tab is closed when the user clicks X

--- a/lib/minga/editor/commands/buffer_management.ex
+++ b/lib/minga/editor/commands/buffer_management.ex
@@ -986,9 +986,14 @@ defmodule Minga.Editor.Commands.BufferManagement do
     # and resets the agent UI). For file tabs it replaces in place.
     state = EditorState.add_buffer(state, buf)
 
-    # Now we have 2 tabs; remove the old one.
-    {:ok, tb} = TabBar.remove(state.shell_state.tab_bar, only.id)
-    EditorState.set_tab_bar(state, tb)
+    # Now we have 2 tabs; remove the old one. add_buffer may have reused
+    # the existing tab (replaced in-place), leaving only one tab, so
+    # TabBar.remove returns :last_tab. That's fine: the buffer was
+    # already swapped.
+    case TabBar.remove(state.shell_state.tab_bar, only.id) do
+      {:ok, tb} -> EditorState.set_tab_bar(state, tb)
+      :last_tab -> state
+    end
   end
 
   defp close_tab_or_quit(state), do: shutdown_editor(state)

--- a/lib/minga/frontend/emit/gui.ex
+++ b/lib/minga/frontend/emit/gui.ex
@@ -24,7 +24,7 @@ defmodule Minga.Frontend.Emit.GUI do
   alias Minga.Agent.View.PromptSemanticWindow
   alias Minga.Buffer
   alias Minga.Config
-  alias Minga.Editor.Commands.Helpers, as: CommandHelpers
+
   alias Minga.Editor.DisplayList.Frame
   alias Minga.Editor.Layout
   alias Minga.Editor.MinibufferData
@@ -175,23 +175,7 @@ defmodule Minga.Frontend.Emit.GUI do
 
   @spec build_gui_tab_bar_cmd(ctx()) :: binary() | nil
 
-  # Board zoomed: show scoped tab bar for agent's touched files or full buffer list for "You"
-  defp build_gui_tab_bar_cmd(
-         %{shell: Minga.Shell.Board, shell_state: %{zoomed_into: card_id}} = ctx
-       )
-       when card_id != nil do
-    card = Minga.Shell.Board.State.zoomed(ctx.shell_state)
-
-    if card && Minga.Shell.Board.Card.you_card?(card) do
-      # "You" card: show full buffer list from workspace
-      build_you_card_tab_bar(ctx)
-    else
-      # Agent card: show only files touched by this agent
-      build_agent_scoped_tab_bar(ctx, card)
-    end
-  end
-
-  # Board grid: no tab bar needed (Board is the view)
+  # Board: no tab bar (Board manages its own navigation)
   defp build_gui_tab_bar_cmd(%{shell: Minga.Shell.Board}), do: nil
 
   defp build_gui_tab_bar_cmd(%{shell_state: %{tab_bar: %TabBar{} = tb}} = ctx) do
@@ -205,137 +189,6 @@ defmodule Minga.Frontend.Emit.GUI do
   end
 
   defp build_gui_tab_bar_cmd(%{shell_state: %{tab_bar: nil}}), do: nil
-
-  # Builds the tab bar for Board's "You" card, showing workspace buffers.
-  @spec build_you_card_tab_bar(ctx()) :: binary() | nil
-  defp build_you_card_tab_bar(%{buffers: buffers} = ctx) do
-    # Board "You" card: build tab bar from workspace buffers
-    tabs =
-      buffers.list
-      |> Enum.with_index(1)
-      |> Enum.map(fn {buf_pid, idx} ->
-        label =
-          try do
-            CommandHelpers.buffer_display_name(buf_pid)
-          catch
-            :exit, _ -> "[buffer]"
-          end
-
-        %Minga.Editor.State.Tab{
-          id: idx,
-          label: label,
-          kind: :file,
-          context: %{buffer: buf_pid},
-          agent_status: nil,
-          attention: false
-        }
-      end)
-
-    if tabs == [] do
-      # No buffers: show a single "You" tab
-      tab = %Minga.Editor.State.Tab{
-        id: 1,
-        label: "You",
-        kind: :file,
-        context: %{},
-        agent_status: nil,
-        attention: false
-      }
-
-      tb = %TabBar{tabs: [tab], active_id: 1, next_id: 2}
-      fp = :erlang.phash2({:board_you_empty})
-
-      if fp != Process.get(:last_gui_tab_bar_fp) do
-        Process.put(:last_gui_tab_bar_fp, fp)
-        ProtocolGUI.encode_gui_tab_bar(tb)
-      end
-    else
-      active_idx = buffers.active_index
-      active_id = if active_idx < length(tabs), do: active_idx + 1, else: 1
-      tb = %TabBar{tabs: tabs, active_id: active_id, next_id: length(tabs) + 1}
-      active_buf = active_window_buffer(ctx)
-      fp = :erlang.phash2({:board_you_tb, buffers.list, active_idx, active_buf})
-
-      if fp != Process.get(:last_gui_tab_bar_fp) do
-        Process.put(:last_gui_tab_bar_fp, fp)
-        ProtocolGUI.encode_gui_tab_bar(tb, active_buf)
-      end
-    end
-  end
-
-  defp build_you_card_tab_bar(_ctx), do: nil
-
-  # Builds a scoped tab bar showing only files touched by the agent session.
-  @spec build_agent_scoped_tab_bar(ctx(), Minga.Shell.Board.Card.t() | nil) :: binary() | nil
-  defp build_agent_scoped_tab_bar(_ctx, nil), do: nil
-
-  defp build_agent_scoped_tab_bar(_ctx, %{session: nil}), do: nil
-
-  defp build_agent_scoped_tab_bar(ctx, %{session: session_pid, task: task})
-       when is_pid(session_pid) do
-    touched =
-      try do
-        AgentSession.touched_files(session_pid)
-      catch
-        :exit, _ -> []
-      end
-
-    # Build tabs for touched files, most recent first
-    tabs =
-      touched
-      |> Enum.with_index(1)
-      |> Enum.map(fn {file, idx} ->
-        # Extract filename for the label
-        label = Path.basename(file.path)
-
-        # Find the buffer pid for this path to check dirty state
-        buf_pid =
-          case Buffer.pid_for_path(file.path) do
-            {:ok, pid} -> pid
-            :not_found -> nil
-          end
-
-        %Minga.Editor.State.Tab{
-          id: idx,
-          label: label,
-          kind: :file,
-          context: %{path: file.path, buffer: buf_pid},
-          agent_status: nil,
-          attention: false
-        }
-      end)
-
-    # If no files touched yet, show a single "Agent Chat" tab
-    tabs =
-      if tabs == [] do
-        label = if is_binary(task), do: task, else: "Agent"
-
-        [
-          %Minga.Editor.State.Tab{
-            id: 1,
-            label: label,
-            kind: :agent,
-            context: %{},
-            agent_status: nil,
-            attention: false
-          }
-        ]
-      else
-        tabs
-      end
-
-    # Most recent file is the active tab (tabs is guaranteed non-empty after the if above)
-    active_id = hd(tabs).id
-    tb = %TabBar{tabs: tabs, active_id: active_id, next_id: length(tabs) + 1}
-    active_buf = active_window_buffer(ctx)
-
-    fp = :erlang.phash2({:agent_scoped, session_pid, touched, active_buf})
-
-    if fp != Process.get(:last_gui_tab_bar_fp) do
-      Process.put(:last_gui_tab_bar_fp, fp)
-      ProtocolGUI.encode_gui_tab_bar(tb, active_buf)
-    end
-  end
 
   @spec build_gui_agent_groups_cmd(ctx()) :: binary() | nil
   defp build_gui_agent_groups_cmd(%{shell_state: %{tab_bar: %TabBar{} = tb}}) do


### PR DESCRIPTION
# TL;DR
Removes phantom tab bar construction from Board zoomed mode and fixes two crash sites where `close_tab` events hit nil tab bar state, stopping the Editor GenServer crash cascade.

Closes #1340

## Context
Board zoomed mode fabricated synthetic `TabBar` structs in the GUI emit layer so SwiftUI could reuse `TabBarView` for file switching. Those synthetic tabs had close buttons that sent `{:close_tab, id}` events back to the BEAM, but Board's `shell_state.tab_bar` is nil. Every close-tab click crashed the Editor GenServer with BadMapError (accessing `.active_id` on nil) or MatchError (`:last_tab` from `TabBar.remove`). The GenServer restarted, queued events crashed it again, cascade repeated.

Part of #1222 (render pipeline split epic). This is subtask 1 of 3.

## Changes
- **Deleted ~140 lines of synthetic tab bar code** from `lib/minga/frontend/emit/gui.ex`: the Board-zoomed clause of `build_gui_tab_bar_cmd`, `build_you_card_tab_bar/1`, and `build_agent_scoped_tab_bar/2`. The remaining Board clause (`%{shell: Minga.Shell.Board}`) returns nil for both grid and zoomed modes.
- **Added nil guard on close_tab handler** in `lib/minga/editor.ex`: when `tab_bar` is nil (Board mode), `handle_gui_action({:close_tab, id})` returns state unchanged instead of crashing.
- **Handled `:last_tab` in `close_tab_or_quit`** in `lib/minga/editor/commands/buffer_management.ex`: `TabBar.remove` can return `:last_tab` when `add_buffer` reused the existing tab in-place. The old code did `{:ok, tb} = TabBar.remove(...)` which crashed on `:last_tab`. Now uses a `case` that handles both branches.
- **Removed dead `CommandHelpers` alias** from gui.ex (only used by the deleted code).

## Verification
```bash
mix test.llm    # 7176 tests pass, 0 failures
make lint       # all checks pass (format, credo, compile, dialyzer)
```

To verify the synthetic tab bar is fully removed:
```bash
rg "build_you_card_tab_bar|build_agent_scoped_tab_bar" lib/
# Should return nothing
```

## Acceptance Criteria Addressed
- `build_gui_tab_bar_cmd` has no Board-zoomed clause constructing synthetic TabBar structs ✅
- `build_you_card_tab_bar` and `build_agent_scoped_tab_bar` are deleted ✅
- `handle_gui_action(state, {:close_tab, id})` handles `tab_bar: nil` gracefully ✅
- `close_tab_or_quit` handles `:last_tab` from `TabBar.remove` ✅
- `mix lint` and `mix test.llm` pass with no new failures ✅