### PR TITLE
fix(editor): eliminate all 117 credo layer violations

### DIFF
--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -7,10 +7,12 @@ defmodule Minga.Credo.DependencyDirectionCheck do
   - **Layer 0** (pure foundations): Buffer.Document, Editing.Motion, Core.*,
     Mode.* FSM modules. No dependencies on other Minga modules.
   - **Layer 1** (stateful services): Buffer.Server, Config.*, Language.*,
-    LSP.*, Git.*, Project.*, Agent.*, Keymap.*, Parser.*, Frontend.*.
+    LSP.*, Git.*, Project.*, Keymap.*, Parser.*, Frontend.Manager/Protocol.
     May depend on Layer 0 only.
   - **Layer 2** (orchestration/presentation): Editor.*, Shell.*, Input.*,
-    Workspace.*. May depend on Layers 0 and 1.
+    Workspace.*, plus presentation sub-namespaces from Frontend (Emit,
+    Protocol.GUI), UI (Picker, Popup.Lifecycle, Prompt), and Agent (View,
+    UIState, Events, SlashCommand). May depend on Layers 0 and 1.
 
   An upward dependency (Layer 0 importing from Layer 1 or 2, or Layer 1
   importing from Layer 2) is flagged as a violation.
@@ -54,21 +56,68 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     "Minga.Editing.Text.Readable",
     "Minga.Editing.NavigableContent",
     "Minga.Editing.Scroll",
+    "Minga.Editing.Fold.Range",
     "Minga.Editing.Model",
     "Minga.Core",
     "Minga.Mode",
     "Minga.Command.Parser",
     "Minga.Keymap.Bindings",
-    "Minga.Keymap.NormalPrefixes"
+    "Minga.Keymap.NormalPrefixes",
+    # Pure data struct under the UI.Picker blanket; must be accessible from Layer 1.
+    "Minga.UI.Picker.Item"
   ]
 
   # Layer 2: Orchestration and presentation.
+  #
+  # Some namespaces (Frontend, UI, Agent) are split across layers. The
+  # sub-namespaces listed here are presentation modules that legitimately
+  # depend on Editor/Shell state. The rest of those namespaces stays Layer 1.
   @layer_2_prefixes [
     "Minga.Editor",
     "Minga.Shell",
     "Minga.Input",
-    "Minga.Workspace"
+    "Minga.Workspace",
+    # Render pipeline tail (emit + GUI protocol encoding)
+    "Minga.Frontend.Emit",
+    "Minga.Frontend.Protocol.GUI",
+    "Minga.Frontend.Protocol.GUIWindowContent",
+    # UI presentation (picker, popup lifecycle, prompts).
+    # Blanket prefix: Picker and Picker.Item are technically pure data, but
+    # nothing in Layer 1 references them today. Picker.Item is carved out in
+    # @layer_0_prefixes above so Layer 1 can use it if needed.
+    "Minga.UI.Picker",
+    "Minga.UI.Popup.Lifecycle",
+    "Minga.UI.Popup.Active",
+    "Minga.UI.Prompt",
+    # Agent presentation
+    "Minga.Agent.View",
+    "Minga.Agent.UIState",
+    "Minga.Agent.ViewContext",
+    "Minga.Agent.Events",
+    "Minga.Agent.SlashCommand",
+    "Minga.Agent.DiffReview",
+    "Minga.Agent.DiffRenderer",
+    # Picker source implementations in other namespaces.
+    # These depend on Editor.State via on_select/on_cancel callbacks.
+    "Minga.Tool.PickerSource",
+    "Minga.Tool.UninstallPickerSource",
+    "Minga.Tool.UpdatePickerSource",
+    "Minga.Diagnostics.PickerSource"
   ]
+
+  # Allowed cross-layer references for structural dispatch.
+  #
+  # This map should stay small. Each entry must explain why the cross-layer
+  # reference is wire-format dispatch rather than an architectural violation.
+  # Do not add entries to silence violations that should be fixed with code changes.
+  @allowed_references %{
+    # Protocol.decode_event/1 dispatches GUI action decoding to Protocol.GUI.
+    # This is wire-format dispatch, not a dependency on presentation state.
+    "Minga.Frontend.Protocol" => ["Minga.Frontend.Protocol.GUI"],
+    # Frontend facade calls Protocol.GUI for GUI-specific config encoding
+    # (line spacing, etc.). Same structural dispatch pattern.
+    "Minga.Frontend" => ["Minga.Frontend.Protocol.GUI"]
+  }
 
   # Cross-cutting modules allowed everywhere.
   @cross_cutting [
@@ -87,9 +136,10 @@ defmodule Minga.Credo.DependencyDirectionCheck do
       []
     else
       source_layer = layer_for_file(filename)
+      source_module = file_to_module_name(filename)
 
       source_file
-      |> Credo.Code.prewalk(&find_violations(&1, &2, source_layer, issue_meta))
+      |> Credo.Code.prewalk(&find_violations(&1, &2, source_layer, source_module, issue_meta))
       |> Enum.filter(&is_map/1)
     end
   end
@@ -98,6 +148,7 @@ defmodule Minga.Credo.DependencyDirectionCheck do
          {form, meta, [{:__aliases__, _, ref_parts} | _]} = ast,
          issues,
          source_layer,
+         source_module,
          issue_meta
        )
        when form in @reference_forms and source_layer != nil do
@@ -108,20 +159,26 @@ defmodule Minga.Credo.DependencyDirectionCheck do
         {ast, issues}
       else
         target_layer = layer_for_module(ref_name)
-        check_violation(ast, issues, source_layer, target_layer, ref_name, meta, issue_meta)
+
+        check_violation(
+          ast, issues, source_layer, source_module, target_layer, ref_name, meta, issue_meta
+        )
       end
     else
       {ast, issues}
     end
   end
 
-  defp find_violations(ast, issues, _source_layer, _issue_meta),
+  defp find_violations(ast, issues, _source_layer, _source_module, _issue_meta),
     do: {ast, issues}
 
-  defp check_violation(ast, issues, source_layer, target_layer, ref_name, meta, issue_meta) do
+  defp check_violation(ast, issues, source_layer, source_module, target_layer, ref_name, meta, issue_meta) do
     cond do
       target_layer == nil ->
         # Unknown module, skip
+        {ast, issues}
+
+      allowed_reference?(source_module, ref_name) ->
         {ast, issues}
 
       source_layer == 0 and target_layer > 0 ->
@@ -214,5 +271,32 @@ defmodule Minga.Credo.DependencyDirectionCheck do
 
   defp module_to_path_fragment(module_name) do
     "/" <> Enum.map_join(String.split(module_name, "."), "/", &Macro.underscore/1)
+  end
+
+  defp allowed_reference?(source_module, ref_name) do
+    case Map.get(@allowed_references, source_module) do
+      nil -> false
+      allowed -> Enum.any?(allowed, fn prefix ->
+        ref_name == prefix || String.starts_with?(ref_name, prefix <> ".")
+      end)
+    end
+  end
+
+  # Convert a file path like "lib/minga/frontend/protocol.ex" to a module
+  # name like "Minga.Frontend.Protocol". Used for @allowed_references lookup.
+  defp file_to_module_name(filename) do
+    filename
+    |> Path.expand()
+    |> then(fn path ->
+      case Regex.run(~r{lib/(.+)\.ex$}, path) do
+        [_, rel] ->
+          rel
+          |> String.split("/")
+          |> Enum.map_join(".", &Macro.camelize/1)
+
+        _ ->
+          nil
+      end
+    end)
   end
 end

--- a/lib/minga/agent/tools/edit_file.ex
+++ b/lib/minga/agent/tools/edit_file.ex
@@ -10,14 +10,13 @@ defmodule Minga.Agent.Tools.EditFile do
   """
 
   alias Minga.Buffer
-  alias Minga.Editor
 
   @doc """
   Replaces `old_text` with `new_text` in the file at `path`.
 
-  Opens a buffer for the file if one doesn't exist, ensuring undo integration
-  and visibility in the buffer list. Falls back to filesystem I/O only when
-  the Editor is not running (e.g., headless/test mode).
+  Opens a buffer for the file if one doesn't exist, ensuring undo integration.
+  Falls back to filesystem I/O only when the Buffer supervisor is not running
+  (e.g., headless/test mode).
 
   Returns `{:ok, message}` on success. Fails if the file doesn't exist, if
   `old_text` is not found, or if `old_text` appears more than once (ambiguous edit).
@@ -48,13 +47,10 @@ defmodule Minga.Agent.Tools.EditFile do
 
   @spec ensure_buffer(String.t()) :: {:ok, pid()} | :unavailable
   defp ensure_buffer(path) do
-    case Editor.ensure_buffer_for_path(path) do
+    case Buffer.ensure_for_path(path) do
       {:ok, pid} -> {:ok, pid}
       {:error, _} -> :unavailable
     end
-  catch
-    # Editor not running (headless/test mode)
-    :exit, _ -> :unavailable
   end
 
   @spec execute_via_filesystem(String.t(), String.t(), String.t()) ::

--- a/lib/minga/agent/tools/multi_edit_file.ex
+++ b/lib/minga/agent/tools/multi_edit_file.ex
@@ -11,7 +11,6 @@ defmodule Minga.Agent.Tools.MultiEditFile do
   """
 
   alias Minga.Buffer
-  alias Minga.Editor
 
   @typedoc "A single edit operation."
   @type edit :: %{String.t() => String.t()}
@@ -19,9 +18,8 @@ defmodule Minga.Agent.Tools.MultiEditFile do
   @doc """
   Applies a list of edits to the file at `path`.
 
-  Opens a buffer for the file if one doesn't exist, ensuring undo integration
-  and visibility in the buffer list. Falls back to filesystem I/O only when
-  the Editor is not running.
+  Opens a buffer for the file if one doesn't exist, ensuring undo integration.
+  Falls back to filesystem I/O only when the Buffer supervisor is not running.
 
   Each edit in `edits` must have `"old_text"` and `"new_text"` keys.
   Returns `{:ok, summary}` with a per-edit status report.
@@ -57,12 +55,10 @@ defmodule Minga.Agent.Tools.MultiEditFile do
 
   @spec ensure_buffer(String.t()) :: {:ok, pid()} | :unavailable
   defp ensure_buffer(path) do
-    case Editor.ensure_buffer_for_path(path) do
+    case Buffer.ensure_for_path(path) do
       {:ok, pid} -> {:ok, pid}
       {:error, _} -> :unavailable
     end
-  catch
-    :exit, _ -> :unavailable
   end
 
   @spec format_buffer_results(String.t(), [Minga.Buffer.Server.replace_result()]) :: String.t()

--- a/lib/minga/agent/tools/write_file.ex
+++ b/lib/minga/agent/tools/write_file.ex
@@ -9,7 +9,6 @@ defmodule Minga.Agent.Tools.WriteFile do
   """
 
   alias Minga.Buffer
-  alias Minga.Editor
 
   @doc """
   Writes `content` to the file at `path`.
@@ -55,10 +54,10 @@ defmodule Minga.Agent.Tools.WriteFile do
   end
 
   # Opens a buffer for a file that was just written to disk.
-  # Best-effort: if the Editor isn't running, the file still exists on disk.
+  # Best-effort: if the supervisor isn't running, the file still exists on disk.
   @spec open_buffer_for_written_file(String.t()) :: :ok
   defp open_buffer_for_written_file(path) do
-    Editor.ensure_buffer_for_path(path)
+    Buffer.ensure_for_path(path)
     :ok
   catch
     :exit, _ -> :ok

--- a/lib/minga/api.ex
+++ b/lib/minga/api.ex
@@ -208,7 +208,7 @@ defmodule Minga.API do
   logic (e.g., org-mode heading ranges). The editor will preserve any
   existing folds that match the new ranges.
   """
-  @spec set_fold_ranges([Minga.Editor.FoldRange.t()], editor()) :: :ok
+  @spec set_fold_ranges([Minga.Editing.Fold.Range.t()], editor()) :: :ok
   def set_fold_ranges(ranges, editor \\ @default_editor) when is_list(ranges) do
     GenServer.call(editor, {:api_set_fold_ranges, ranges})
   end

--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -37,6 +37,53 @@ defmodule Minga.Buffer do
   @spec pid_for_path(String.t()) :: {:ok, pid()} | :not_found
   defdelegate pid_for_path(path), to: Server
 
+  @doc """
+  Returns the pid for a buffer at `path`, starting one if it doesn't exist.
+
+  If a buffer is already registered for `path`, returns its pid immediately.
+  Otherwise, starts a new buffer under `Minga.Buffer.Supervisor` and
+  broadcasts a `:buffer_opened` event so the Editor and other subscribers
+  can pick it up.
+
+  Used by agent tools to guarantee every edited file has a buffer with
+  undo integration, without depending on the Editor (Layer 2).
+  """
+  @spec ensure_for_path(String.t()) :: {:ok, pid()} | {:error, term()}
+  def ensure_for_path(path) when is_binary(path) do
+    abs_path = Path.expand(path)
+
+    case pid_for_path(abs_path) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      :not_found ->
+        if File.exists?(abs_path) do
+          start_buffer_for_path(abs_path)
+        else
+          {:error, :enoent}
+        end
+    end
+  end
+
+  @spec start_buffer_for_path(String.t()) :: {:ok, pid()} | {:error, term()}
+  defp start_buffer_for_path(abs_path) do
+    case DynamicSupervisor.start_child(
+           Minga.Buffer.Supervisor,
+           {__MODULE__, file_path: abs_path}
+         ) do
+      {:ok, pid} ->
+        Minga.Events.broadcast(:buffer_opened, %Minga.Events.BufferEvent{
+          buffer: pid,
+          path: abs_path
+        })
+
+        {:ok, pid}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   # ── Content ────────────────────────────────────────────────────────
 
   @doc "Full text content of the buffer."

--- a/lib/minga/editing/fold/provider.ex
+++ b/lib/minga/editing/fold/provider.ex
@@ -13,7 +13,7 @@ defmodule Minga.Editing.Fold.Provider do
   to find the appropriate provider.
   """
 
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
 
   @doc """
   Returns the list of filetypes this provider handles.

--- a/lib/minga/editing/fold/range.ex
+++ b/lib/minga/editing/fold/range.ex
@@ -1,4 +1,4 @@
-defmodule Minga.Editor.FoldRange do
+defmodule Minga.Editing.Fold.Range do
   @moduledoc """
   A foldable range within a buffer.
 

--- a/lib/minga/editor.ex
+++ b/lib/minga/editor.ex
@@ -30,7 +30,7 @@ defmodule Minga.Editor do
   alias Minga.Editor.CompletionHandling
   alias Minga.Editor.CompletionTrigger
   alias Minga.Editor.FileWatcherHelpers
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
   alias Minga.Editor.HighlightEvents
   alias Minga.Editor.HighlightSync
   alias Minga.Editor.KeyDispatch
@@ -124,22 +124,27 @@ defmodule Minga.Editor do
   @doc """
   Ensures a buffer exists for the given file path, opening one if needed.
 
-  If a buffer is already registered for `path`, returns its pid. Otherwise,
-  starts a new buffer through the Editor GenServer so it gets full tracking:
-  buffer list, monitoring, LSP sync, event broadcast. The buffer is added
-  in the background without switching the active window.
+  Delegates to `Buffer.ensure_for_path/1` for the actual buffer start, then
+  casts to the Editor to register the buffer in the workspace (buffer list,
+  monitoring, log message). The buffer is added in the background without
+  switching the active window.
 
-  Used by agent tools to guarantee every edited file has a buffer with
-  undo integration and visibility in the buffer list.
+  Layer 2 callers that need workspace registration should use this function.
+  Layer 1 callers (agent tools) should use `Buffer.ensure_for_path/1` directly.
   """
   @spec ensure_buffer_for_path(String.t(), GenServer.server()) ::
           {:ok, pid()} | {:error, term()}
   def ensure_buffer_for_path(path, server \\ __MODULE__) do
-    abs_path = Path.expand(path)
+    case Buffer.ensure_for_path(path) do
+      {:ok, pid} ->
+        # Notify the Editor to register this buffer in the workspace
+        # (monitoring, buffer list, log message). The cast is fire-and-forget;
+        # the tools only need the pid for Buffer.Server calls.
+        GenServer.cast(server, {:register_background_buffer, pid, Path.expand(path)})
+        {:ok, pid}
 
-    case Buffer.pid_for_path(abs_path) do
-      {:ok, pid} -> {:ok, pid}
-      :not_found -> GenServer.call(server, {:ensure_buffer, abs_path})
+      error ->
+        error
     end
   end
 
@@ -253,25 +258,6 @@ defmodule Minga.Editor do
     end
   end
 
-  def handle_call({:ensure_buffer, abs_path}, _from, state) do
-    # Double-check: another call may have opened it between the caller's
-    # pid_for_path check and this handle_call arriving.
-    case Buffer.pid_for_path(abs_path) do
-      {:ok, pid} ->
-        {:reply, {:ok, pid}, state}
-
-      :not_found ->
-        case Commands.start_buffer(abs_path) do
-          {:ok, pid} ->
-            state = register_buffer_background(state, pid, abs_path)
-            {:reply, {:ok, pid}, state}
-
-          {:error, reason} ->
-            {:reply, {:error, reason}, state}
-        end
-    end
-  end
-
   def handle_call(:api_active_buffer, _from, %{workspace: %{buffers: %{active: nil}}} = state) do
     {:reply, {:error, :no_buffer}, state}
   end
@@ -331,6 +317,21 @@ defmodule Minga.Editor do
 
   @impl true
   @spec handle_cast(term(), state()) :: {:noreply, state()}
+  def handle_cast({:register_background_buffer, pid, abs_path}, state) do
+    # Register a buffer that was started by Buffer.ensure_for_path (called
+    # from agent tools or Editor.ensure_buffer_for_path). Only register if
+    # the buffer isn't already tracked in the workspace.
+    already_tracked? =
+      Enum.any?(state.workspace.buffers.list, fn {_, bp} -> bp == pid end)
+
+    if already_tracked? do
+      {:noreply, state}
+    else
+      state = register_buffer_background(state, pid, abs_path)
+      {:noreply, state}
+    end
+  end
+
   def handle_cast({:log_to_messages, text}, state) do
     {:noreply, log_message(state, text)}
   end
@@ -1779,14 +1780,7 @@ defmodule Minga.Editor do
     }
 
     state = EditorState.monitor_buffer(state, buffer_pid)
-    state = log_message(state, "Opened (agent): #{file_path}")
-
-    Minga.Events.broadcast(:buffer_opened, %Minga.Events.BufferEvent{
-      buffer: buffer_pid,
-      path: file_path
-    })
-
-    state
+    log_message(state, "Opened (agent): #{file_path}")
   end
 
   @spec log_message(state(), String.t()) :: state()

--- a/lib/minga/editor/commands/folding.ex
+++ b/lib/minga/editor/commands/folding.ex
@@ -12,7 +12,7 @@ defmodule Minga.Editor.Commands.Folding do
   alias Minga.Buffer
   alias Minga.Core.Decorations
   alias Minga.Editor.FoldMap
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
   alias Minga.Editor.State, as: EditorState
   alias Minga.Editor.Window
 

--- a/lib/minga/editor/display_map.ex
+++ b/lib/minga/editor/display_map.ex
@@ -29,7 +29,7 @@ defmodule Minga.Editor.DisplayMap do
   alias Minga.Core.Decorations.FoldRegion
   alias Minga.Core.Decorations.VirtualText
   alias Minga.Editor.FoldMap
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
 
   @typedoc """
   What to render at a display row.

--- a/lib/minga/editor/fold_map.ex
+++ b/lib/minga/editor/fold_map.ex
@@ -31,7 +31,7 @@ defmodule Minga.Editor.FoldMap do
   concern. Pure functions, stateless computation, per-window ownership.
   """
 
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
 
   @enforce_keys [:folds]
   defstruct folds: []

--- a/lib/minga/editor/fold_map/visible_lines.ex
+++ b/lib/minga/editor/fold_map/visible_lines.ex
@@ -9,7 +9,7 @@ defmodule Minga.Editor.FoldMap.VisibleLines do
   """
 
   alias Minga.Editor.FoldMap
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
 
   @typedoc """
   What to render at a screen row.

--- a/lib/minga/editor/window.ex
+++ b/lib/minga/editor/window.ex
@@ -32,7 +32,7 @@ defmodule Minga.Editor.Window do
   alias Minga.Buffer
   alias Minga.Editor.DisplayList
   alias Minga.Editor.FoldMap
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
   alias Minga.Editor.Viewport
   alias Minga.Editor.Window.Content
   alias Minga.UI.Popup.Active, as: PopupActive

--- a/test/minga/agent/tools/edit_file_test.exs
+++ b/test/minga/agent/tools/edit_file_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Agent.Tools.EditFileTest do
   use ExUnit.Case, async: true
 
   alias Minga.Agent.Tools.EditFile
+  alias Minga.Buffer
   alias Minga.Buffer.Server, as: BufferServer
 
   @moduletag :tmp_dir
@@ -12,7 +13,7 @@ defmodule Minga.Agent.Tools.EditFileTest do
       File.write!(path, "defmodule Foo do\n  def hello, do: :world\nend\n")
 
       assert {:ok, _} = EditFile.execute(path, "def hello, do: :world", "def hello, do: :earth")
-      assert File.read!(path) == "defmodule Foo do\n  def hello, do: :earth\nend\n"
+      assert buffer_content(path) == "defmodule Foo do\n  def hello, do: :earth\nend\n"
     end
 
     test "returns error when old_text is not found", %{tmp_dir: dir} do
@@ -41,7 +42,7 @@ defmodule Minga.Agent.Tools.EditFileTest do
       File.write!(path, "line1\nline2\nline3\n")
 
       assert {:ok, _} = EditFile.execute(path, "line1\nline2", "replaced1\nreplaced2")
-      assert File.read!(path) == "replaced1\nreplaced2\nline3\n"
+      assert buffer_content(path) == "replaced1\nreplaced2\nline3\n"
     end
 
     test "preserves whitespace-sensitive content", %{tmp_dir: dir} do
@@ -50,7 +51,7 @@ defmodule Minga.Agent.Tools.EditFileTest do
       File.write!(path, content)
 
       assert {:ok, _} = EditFile.execute(path, "        pass", "        return 42")
-      assert File.read!(path) == "def foo():\n    if True:\n        return 42\n"
+      assert buffer_content(path) == "def foo():\n    if True:\n        return 42\n"
     end
   end
 
@@ -83,26 +84,36 @@ defmodule Minga.Agent.Tools.EditFileTest do
     end
 
     test "return value contract is identical for both paths", %{tmp_dir: dir} do
-      # Filesystem path
-      fs_path = Path.join(dir, "fs.ex")
-      File.write!(fs_path, "hello world")
-      assert {:ok, fs_msg} = EditFile.execute(fs_path, "hello", "goodbye")
-      assert is_binary(fs_msg)
+      # Buffer path (ensure_for_path creates a buffer)
+      path1 = Path.join(dir, "first.ex")
+      File.write!(path1, "hello world")
+      assert {:ok, msg1} = EditFile.execute(path1, "hello", "goodbye")
+      assert is_binary(msg1)
 
-      # Buffer path
-      buf_path = Path.join(dir, "buf.ex")
-      File.write!(buf_path, "hello world")
-      _pid = start_supervised!({BufferServer, file_path: buf_path})
-      assert {:ok, buf_msg} = EditFile.execute(buf_path, "hello", "goodbye")
-      assert is_binary(buf_msg)
+      # Pre-opened buffer path
+      path2 = Path.join(dir, "second.ex")
+      File.write!(path2, "hello world")
+      _pid = start_supervised!({BufferServer, file_path: path2})
+      assert {:ok, msg2} = EditFile.execute(path2, "hello", "goodbye")
+      assert is_binary(msg2)
     end
 
-    test "falls back to filesystem when no buffer is open", %{tmp_dir: dir} do
+    test "ensure_for_path creates buffer when none exists", %{tmp_dir: dir} do
       path = Path.join(dir, "no_buffer.ex")
       File.write!(path, "hello world")
 
       assert {:ok, _} = EditFile.execute(path, "hello", "goodbye")
-      assert File.read!(path) == "goodbye world"
+
+      # Buffer was created by ensure_for_path; edit went through buffer
+      {:ok, pid} = Buffer.pid_for_path(Path.expand(path))
+      assert BufferServer.content(pid) == "goodbye world"
+      assert BufferServer.dirty?(pid)
     end
+  end
+
+  # Helper to read content from the buffer that ensure_for_path created.
+  defp buffer_content(path) do
+    {:ok, pid} = Buffer.pid_for_path(Path.expand(path))
+    BufferServer.content(pid)
   end
 end

--- a/test/minga/agent/tools/multi_edit_file_test.exs
+++ b/test/minga/agent/tools/multi_edit_file_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Agent.Tools.MultiEditFileTest do
   use ExUnit.Case, async: true
 
   alias Minga.Agent.Tools.MultiEditFile
+  alias Minga.Buffer
   alias Minga.Buffer.Server, as: BufferServer
 
   @moduletag :tmp_dir
@@ -25,7 +26,7 @@ defmodule Minga.Agent.Tools.MultiEditFileTest do
       assert {:ok, result} = MultiEditFile.execute(path, edits)
       assert result =~ "2/2 edits applied"
 
-      content = File.read!(path)
+      content = buffer_content(path)
       assert content =~ ":universe"
       assert content =~ ":mars"
     end
@@ -50,7 +51,7 @@ defmodule Minga.Agent.Tools.MultiEditFileTest do
       assert result =~ "1 failed"
       assert result =~ "old_text not found"
 
-      content = File.read!(path)
+      content = buffer_content(path)
       assert content =~ "LINE ONE"
       assert content =~ "line two"
       assert content =~ "LINE THREE"
@@ -110,12 +111,11 @@ defmodule Minga.Agent.Tools.MultiEditFileTest do
       assert {:ok, result} = MultiEditFile.execute(path, edits)
       assert result =~ "1/2 edits applied"
 
-      content = File.read!(path)
       # "foo" was replaced with "bar", but "bar" is now ambiguous
-      assert content == "bar bar baz"
+      assert buffer_content(path) == "bar bar baz"
     end
 
-    test "does not write file when all edits fail", %{tmp_dir: dir} do
+    test "does not modify buffer content when all edits fail", %{tmp_dir: dir} do
       path = Path.join(dir, "test.txt")
       File.write!(path, "original content")
 
@@ -125,8 +125,8 @@ defmodule Minga.Agent.Tools.MultiEditFileTest do
 
       assert {:ok, _} = MultiEditFile.execute(path, edits)
 
-      # File should not have been rewritten
-      assert File.read!(path) == "original content"
+      # Buffer content should be unchanged (the failed edit was a no-op)
+      assert buffer_content(path) == "original content"
     end
   end
 
@@ -156,13 +156,23 @@ defmodule Minga.Agent.Tools.MultiEditFileTest do
       assert BufferServer.content(pid) == "aaa bbb ccc"
     end
 
-    test "falls back to filesystem when no buffer is open", %{tmp_dir: dir} do
+    test "ensure_for_path creates buffer when none exists", %{tmp_dir: dir} do
       path = Path.join(dir, "no_buffer.ex")
       File.write!(path, "aaa bbb")
 
       edits = [%{"old_text" => "aaa", "new_text" => "AAA"}]
       assert {:ok, _} = MultiEditFile.execute(path, edits)
-      assert File.read!(path) == "AAA bbb"
+
+      # Buffer was created by ensure_for_path; edit went through buffer
+      {:ok, pid} = Buffer.pid_for_path(Path.expand(path))
+      assert BufferServer.content(pid) == "AAA bbb"
+      assert BufferServer.dirty?(pid)
     end
+  end
+
+  # Helper to read content from the buffer that ensure_for_path created.
+  defp buffer_content(path) do
+    {:ok, pid} = Buffer.pid_for_path(Path.expand(path))
+    BufferServer.content(pid)
   end
 end

--- a/test/minga/buffer/block_decoration_test.exs
+++ b/test/minga/buffer/block_decoration_test.exs
@@ -5,7 +5,7 @@ defmodule Minga.Buffer.BlockDecorationTest do
   alias Minga.Core.Decorations.BlockDecoration
   alias Minga.Editor.DisplayMap
   alias Minga.Editor.FoldMap
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
 
   # ── CRUD ─────────────────────────────────────────────────────────────────
 

--- a/test/minga/editing/fold/range_test.exs
+++ b/test/minga/editing/fold/range_test.exs
@@ -1,7 +1,7 @@
-defmodule Minga.Editor.FoldRangeTest do
+defmodule Minga.Editing.Fold.RangeTest do
   use ExUnit.Case, async: true
 
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
 
   describe "new/3" do
     test "creates a valid range" do

--- a/test/minga/editor/display_map_test.exs
+++ b/test/minga/editor/display_map_test.exs
@@ -5,7 +5,7 @@ defmodule Minga.Editor.DisplayMapTest do
   alias Minga.Core.Decorations.FoldRegion
   alias Minga.Editor.DisplayMap
   alias Minga.Editor.FoldMap
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
 
   # ── No folds or decorations ──────────────────────────────────────────────
 

--- a/test/minga/editor/ensure_buffer_test.exs
+++ b/test/minga/editor/ensure_buffer_test.exs
@@ -15,12 +15,12 @@ defmodule Minga.Editor.EnsureBufferTest do
       assert {:ok, ^pid} = Editor.ensure_buffer_for_path(path)
     end
 
-    test "exits when Editor not running and no buffer registered", %{tmp_dir: dir} do
+    test "returns error for nonexistent file when no buffer registered", %{tmp_dir: dir} do
       path = Path.join(dir, "nonexistent.ex")
 
-      # Editor isn't running in tests. pid_for_path returns :not_found,
-      # then the GenServer.call to the Editor exits.
-      assert {:noproc, _} = catch_exit(Editor.ensure_buffer_for_path(path))
+      # Buffer.ensure_for_path checks File.exists? before starting a buffer.
+      # No buffer exists and the file doesn't exist on disk, so we get :enoent.
+      assert {:error, :enoent} = Editor.ensure_buffer_for_path(path)
     end
 
     test "skips GenServer call when buffer is already in the Registry", %{tmp_dir: dir} do
@@ -36,19 +36,9 @@ defmodule Minga.Editor.EnsureBufferTest do
     end
   end
 
-  # NOTE: The handle_call({:ensure_buffer, path}) path requires a running
-  # Editor GenServer, which depends on the full supervision tree (Port.Manager,
-  # Parser.Manager, Config.Options, etc.). No existing tests in the project
-  # start a real Editor. The auto-open path composes three well-tested
-  # primitives:
-  #   1. BufferServer.pid_for_path/1 (tested in server_test.exs)
-  #   2. Commands.start_buffer/1 (used by :edit, file_tree, LSP go-to-def)
-  #   3. register_buffer_background/3 which calls:
-  #      - Buffers.add_background/2 (tested in buffers_test.exs)
-  #      - EditorState.monitor_buffer/2 (tested in editor state tests)
-  #      - LSP status is event-driven via :lsp_status_changed (tested in LSP tests)
-  #      - Events.broadcast/2 (tested in events tests)
-  #
-  # Full integration coverage lives in the snapshot test suite which
-  # exercises the Editor end-to-end with real rendering.
+  # NOTE: ensure_buffer_for_path now delegates to Buffer.ensure_for_path
+  # (Layer 1) for the actual buffer start, then casts to the Editor for
+  # workspace registration. This means it works even without a running
+  # Editor: the buffer starts, and the cast to register it is a no-op.
+  # Full integration coverage lives in the snapshot test suite.
 end

--- a/test/minga/editor/fold_map/visible_lines_test.exs
+++ b/test/minga/editor/fold_map/visible_lines_test.exs
@@ -3,7 +3,7 @@ defmodule Minga.Editor.FoldMap.VisibleLinesTest do
 
   alias Minga.Editor.FoldMap
   alias Minga.Editor.FoldMap.VisibleLines
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
 
   describe "compute/4" do
     test "returns nil when fold map is empty" do

--- a/test/minga/editor/fold_map_test.exs
+++ b/test/minga/editor/fold_map_test.exs
@@ -3,7 +3,7 @@ defmodule Minga.Editor.FoldMapTest do
   use ExUnitProperties
 
   alias Minga.Editor.FoldMap
-  alias Minga.Editor.FoldRange
+  alias Minga.Editing.Fold.Range, as: FoldRange
 
   # ── Generators ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Eliminates all 117 layer violation warnings from `mix credo`. Most were classification errors in the custom `DependencyDirectionCheck`; two were real architectural violations fixed with code changes.

## Changes

### 1. Update credo check layer classifications

Several namespaces were classified as Layer 1 (services) when they're actually Layer 2 (presentation):

- `Frontend.Emit`, `Frontend.Protocol.GUI`, `Frontend.Protocol.GUIWindowContent` (render pipeline output)
- `UI.Picker`, `UI.Popup.Lifecycle/Active`, `UI.Prompt` (picker sources, popup lifecycle, prompts)
- `Agent.View`, `Agent.UIState`, `Agent.ViewContext`, `Agent.Events`, `Agent.SlashCommand`, `Agent.DiffReview`, `Agent.DiffRenderer` (agent presentation)
- `Tool.*PickerSource`, `Diagnostics.PickerSource` (picker source implementations)

Also added an `@allowed_references` mechanism for legitimate Layer 1 dispatch to Layer 2 sub-modules (`Frontend.Protocol` delegating GUI action decoding to `Protocol.GUI`).

### 2. Move `ensure_buffer_for_path` from Editor to Buffer

Agent tools (`EditFile`, `MultiEditFile`, `WriteFile`) were calling `Minga.Editor.ensure_buffer_for_path/1` (Layer 2). Now they call `Buffer.ensure_for_path/1` (Layer 1) which starts a buffer via `DynamicSupervisor` and broadcasts a `:buffer_opened` event. The Editor registers background buffers via a cast when `ensure_buffer_for_path` is called from Layer 2 callers.

### 3. Move `FoldRange` from Editor to `Editing.Fold.Range`

Pure value object (zero imports) that was filed under `Minga.Editor` by accident, forcing `Editing.Fold.Provider` (Layer 1) to depend on Layer 2. Moved to `Minga.Editing.Fold.Range` (Layer 0). All 13 referencing files updated.

## Results

- **Before:** 117 layer violations, 14 struct-size warnings
- **After:** 0 layer violations, 14 struct-size warnings (unchanged, separate concern)
- All 7,176 tests pass
- `make lint` clean