### PR TITLE
feat(editor): Board shell builds its own chrome and layout

### DIFF
--- a/lib/minga/shell/board.ex
+++ b/lib/minga/shell/board.ex
@@ -24,6 +24,8 @@ defmodule Minga.Shell.Board do
 
   alias Minga.Editor.DisplayList
   alias Minga.Editor.DisplayList.{Cursor, Frame}
+  alias Minga.Editor.RenderPipeline.Chrome
+  alias Minga.Editor.Renderer.Regions
   alias Minga.Frontend.Emit.Context, as: EmitContext
   alias Minga.Shell.Board.Card
   alias Minga.Shell.Board.State, as: BoardState
@@ -202,33 +204,73 @@ defmodule Minga.Shell.Board do
   @impl true
   @spec compute_layout(term()) :: Minga.Editor.Layout.t()
   def compute_layout(editor_state) do
-    # Board currently reuses Traditional's layout computation for both
-    # grid and zoomed modes. #1342 will give Board its own layout.
     if Minga.Frontend.gui?(editor_state.capabilities) do
+      # GUI: Metal viewport is the full editor area, no shell chrome rects
       Minga.Editor.Layout.GUI.compute(editor_state)
     else
-      Minga.Shell.Traditional.Layout.TUI.compute(editor_state)
+      compute_board_tui_layout(editor_state)
+    end
+  end
+
+  # Board TUI layout: no tab bar, no file tree, no modeline.
+  # Grid view uses the full viewport. Zoomed view reserves row 0
+  # for the context bar and the last row for the minibuffer.
+  @spec compute_board_tui_layout(term()) :: Minga.Editor.Layout.t()
+  defp compute_board_tui_layout(editor_state) do
+    alias Minga.Editor.Layout
+    vp = editor_state.workspace.viewport
+    {rows, cols} = {vp.rows, vp.cols}
+
+    if BoardState.grid_view?(editor_state.shell_state) do
+      # Grid: full viewport as editor_area, 1-row minibuffer at bottom
+      editor_rows = max(rows - 1, 1)
+
+      %Layout{
+        terminal: {0, 0, cols, rows},
+        editor_area: {0, 0, cols, editor_rows},
+        minibuffer: {editor_rows, 0, cols, 1}
+      }
+    else
+      # Zoomed: row 0 = context bar, last row = minibuffer, rest = editor
+      context_bar_height = 1
+      minibuffer_height = 1
+      editor_rows = max(rows - context_bar_height - minibuffer_height, 1)
+      editor_top = context_bar_height
+
+      {window_layouts, h_seps} =
+        Layout.compute_window_layouts_with_separators(
+          editor_state.workspace.windows.tree,
+          {editor_top, 0, cols, editor_rows},
+          editor_state.workspace.windows.map
+        )
+
+      %Layout{
+        terminal: {0, 0, cols, rows},
+        editor_area: {editor_top, 0, cols, editor_rows},
+        window_layouts: window_layouts,
+        horizontal_separators: h_seps,
+        minibuffer: {editor_top + editor_rows, 0, cols, minibuffer_height}
+      }
     end
   end
 
   @impl true
   @spec build_chrome(term(), Minga.Editor.Layout.t(), map(), term()) ::
-          Minga.Editor.RenderPipeline.Chrome.t()
-  def build_chrome(editor_state, layout, scrolls, cursor_info) do
-    chrome =
-      Minga.Shell.Traditional.Chrome.build_chrome(editor_state, layout, scrolls, cursor_info)
-
+          Chrome.t()
+  def build_chrome(editor_state, layout, _scrolls, _cursor_info) do
     if BoardState.grid_view?(editor_state.shell_state) do
-      chrome
+      # Grid view: BoardView overlay handles everything, empty chrome
+      %Chrome{}
     else
-      # Zoomed: inject context bar into the tab_bar chrome slot
-      inject_zoom_context_bar(chrome, editor_state)
+      # Zoomed: context bar in tab_bar slot, everything else empty
+      context_draws = build_zoom_context_bar(editor_state)
+      regions = Regions.define_regions(layout)
+      %Chrome{tab_bar: context_draws, regions: regions}
     end
   end
 
-  @spec inject_zoom_context_bar(Minga.Editor.RenderPipeline.Chrome.t(), term()) ::
-          Minga.Editor.RenderPipeline.Chrome.t()
-  defp inject_zoom_context_bar(chrome, editor_state) do
+  @spec build_zoom_context_bar(term()) :: [DisplayList.draw()]
+  defp build_zoom_context_bar(editor_state) do
     board = editor_state.shell_state
     card = BoardState.zoomed(board)
     cols = editor_state.workspace.viewport.cols
@@ -249,16 +291,13 @@ defmodule Minga.Shell.Board do
       right = " #{hint} "
       gap = max(cols - String.length(left) - String.length(right), 0)
 
-      context_draws = [
+      [
         DisplayList.draw(0, 0, left, bar_face),
         DisplayList.draw(0, String.length(left), String.duplicate(" ", gap), status_face),
         DisplayList.draw(0, String.length(left) + gap, right, hint_face)
       ]
-
-      # Replace the tab_bar draws with our context bar
-      %{chrome | tab_bar: context_draws}
     else
-      chrome
+      []
     end
   end
 

--- a/test/minga/shell/board_chrome_test.exs
+++ b/test/minga/shell/board_chrome_test.exs
@@ -1,0 +1,182 @@
+defmodule Minga.Shell.Board.ChromeTest do
+  @moduledoc "Tests Board's build_chrome callback."
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Core.Face
+  alias Minga.Editor.DisplayList.Frame
+  alias Minga.Editor.Layout
+  alias Minga.Editor.RenderPipeline
+  alias Minga.Editor.RenderPipeline.Chrome
+  alias Minga.Editor.RenderPipeline.Compose
+  alias Minga.Editor.RenderPipeline.Content
+  alias Minga.Editor.RenderPipeline.Scroll
+  alias Minga.Editor.State, as: EditorState
+  alias Minga.Shell.Board
+  alias Minga.Shell.Board.State, as: BoardState
+
+  import Minga.Editor.RenderPipeline.TestHelpers
+
+  # ── Helpers ──────────────────────────────────────────────────────────────
+
+  defp grid_board_state do
+    state = base_state()
+    %{state | shell: Board, shell_state: BoardState.new()}
+  end
+
+  defp zoomed_board_state(card_attrs \\ []) do
+    board = BoardState.new()
+    attrs = Keyword.merge([task: "Test task", status: :working, model: "sonnet-4"], card_attrs)
+    {board, card} = BoardState.create_card(board, attrs)
+    board = BoardState.zoom_into(board, card.id, %{})
+
+    state = base_state()
+    %{state | shell: Board, shell_state: board}
+  end
+
+  defp run_through_content(state) do
+    state = EditorState.sync_active_window_cursor(state)
+    state = RenderPipeline.compute_layout(state)
+    layout = Layout.get(state)
+    {scrolls, state} = Scroll.scroll_windows(state, layout)
+    {frames, cursor_info, state} = Content.build_content(state, scrolls)
+    {scrolls, frames, cursor_info, state, layout}
+  end
+
+  defp context_bar_text(chrome) do
+    Enum.map_join(chrome.tab_bar, fn {_row, _col, text, _face} -> text end)
+  end
+
+  # ── Grid view ────────────────────────────────────────────────────────────
+
+  describe "build_chrome/4 grid view" do
+    test "returns an empty Chrome struct" do
+      state = grid_board_state()
+      {scrolls, _frames, cursor_info, state, layout} = run_through_content(state)
+
+      chrome = Board.build_chrome(state, layout, scrolls, cursor_info)
+
+      assert %Chrome{} = chrome
+      assert chrome.tab_bar == []
+      assert chrome.status_bar_draws == []
+      assert chrome.minibuffer == []
+      assert chrome.file_tree == []
+      assert chrome.agent_panel == []
+      assert chrome.overlays == []
+      assert chrome.separators == []
+      assert chrome.regions == []
+    end
+  end
+
+  # ── Zoomed view ──────────────────────────────────────────────────────────
+
+  describe "build_chrome/4 zoomed view" do
+    test "returns context bar draws in tab_bar" do
+      state = zoomed_board_state()
+      {scrolls, _frames, cursor_info, state, layout} = run_through_content(state)
+
+      chrome = Board.build_chrome(state, layout, scrolls, cursor_info)
+
+      assert [_ | _] = chrome.tab_bar
+      assert Enum.all?(chrome.tab_bar, &match?({_, _, _, %Face{}}, &1))
+    end
+
+    test "context bar contains card task text" do
+      state = zoomed_board_state(task: "Fix the login bug")
+      {scrolls, _frames, cursor_info, state, layout} = run_through_content(state)
+
+      chrome = Board.build_chrome(state, layout, scrolls, cursor_info)
+
+      assert context_bar_text(chrome) =~ "Fix the login bug"
+    end
+
+    test "context bar contains model name when present" do
+      state = zoomed_board_state(model: "sonnet-4")
+      {scrolls, _frames, cursor_info, state, layout} = run_through_content(state)
+
+      chrome = Board.build_chrome(state, layout, scrolls, cursor_info)
+
+      assert context_bar_text(chrome) =~ "sonnet-4"
+    end
+
+    test "context bar contains ESC hint" do
+      state = zoomed_board_state()
+      {scrolls, _frames, cursor_info, state, layout} = run_through_content(state)
+
+      chrome = Board.build_chrome(state, layout, scrolls, cursor_info)
+
+      assert context_bar_text(chrome) =~ "ESC back to Board"
+    end
+
+    test "context bar shows Untitled for empty task" do
+      state = zoomed_board_state(task: "")
+      {scrolls, _frames, cursor_info, state, layout} = run_through_content(state)
+
+      chrome = Board.build_chrome(state, layout, scrolls, cursor_info)
+
+      assert context_bar_text(chrome) =~ "Untitled"
+    end
+
+    test "context bar omits model segment when model is nil" do
+      state = zoomed_board_state(model: nil)
+      {scrolls, _frames, cursor_info, state, layout} = run_through_content(state)
+
+      chrome = Board.build_chrome(state, layout, scrolls, cursor_info)
+
+      refute context_bar_text(chrome) =~ " · "
+    end
+
+    test "produces regions list" do
+      state = zoomed_board_state()
+      {scrolls, _frames, cursor_info, state, layout} = run_through_content(state)
+
+      chrome = Board.build_chrome(state, layout, scrolls, cursor_info)
+
+      assert is_list(chrome.regions)
+      assert Enum.all?(chrome.regions, &is_binary/1)
+    end
+
+    test "leaves other chrome fields empty" do
+      state = zoomed_board_state()
+      {scrolls, _frames, cursor_info, state, layout} = run_through_content(state)
+
+      chrome = Board.build_chrome(state, layout, scrolls, cursor_info)
+
+      assert chrome.status_bar_draws == []
+      assert chrome.minibuffer == []
+      assert chrome.file_tree == []
+      assert chrome.agent_panel == []
+      assert chrome.overlays == []
+    end
+
+    test "each card status has a distinct icon" do
+      statuses = [:idle, :working, :iterating, :needs_you, :done, :errored]
+
+      icons =
+        Enum.map(statuses, fn status ->
+          state = zoomed_board_state(status: status)
+          {scrolls, _frames, cursor_info, state, layout} = run_through_content(state)
+          chrome = Board.build_chrome(state, layout, scrolls, cursor_info)
+          context_bar_text(chrome)
+        end)
+
+      # All texts should be unique (different status icons)
+      assert length(Enum.uniq(icons)) == length(statuses)
+    end
+  end
+
+  # ── Composition ──────────────────────────────────────────────────────────
+
+  describe "build_chrome/4 zoomed composition" do
+    test "zoomed chrome composes into a valid Frame without crashing" do
+      state = zoomed_board_state()
+      {scrolls, frames, cursor_info, state, layout} = run_through_content(state)
+      chrome = Board.build_chrome(state, layout, scrolls, cursor_info)
+
+      frame = Compose.compose_windows(frames, chrome, cursor_info, state)
+
+      assert %Frame{} = frame
+      assert frame.cursor.shape in [:block, :beam, :underline]
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR
Board now produces its own `%Chrome{}` and computes its own layout rects, removing its dependency on Traditional shell chrome and layout modules.

Closes #1342

## Context
Final subtask of #1222 (render pipeline split epic). With #1340 removing the synthetic tab bar and #1341 moving Traditional modules to `shell/traditional/`, Board was the last piece still calling Traditional code for chrome and layout. This PR completes the separation.

## Changes
- **`build_chrome`** rewritten: grid view returns empty `%Chrome{}` (BoardView overlay handles everything); zoomed view builds a context bar with status icon, task, model, and "ESC back to Board" hint. No Traditional chrome builder is called.
- **`compute_layout`** rewritten: grid TUI uses full viewport as editor_area with 1-row minibuffer; zoomed TUI reserves row 0 for context bar, bottom row for minibuffer, editor in between. GUI delegates to shared `Layout.GUI.compute`.
- **`inject_zoom_context_bar`** removed: replaced by `build_zoom_context_bar` which returns draw tuples directly instead of patching a Traditional-produced chrome struct.
- **11 new tests** in `test/minga/shell/board_chrome_test.exs`: grid chrome is empty, zoomed chrome contains context bar with correct content (task, model, hint, status icons), empty task shows "Untitled", nil model omits separator, regions are produced, other chrome fields stay empty, all 6 statuses produce distinct icons, zoomed chrome composes into a valid Frame.

## Verification
```bash
mix test.llm    # 7187 tests pass, 0 failures
make lint       # all checks pass
rg "Shell\.Traditional" lib/minga/shell/board.ex  # returns nothing
```

## Acceptance Criteria Addressed
- Board build_chrome produces its own %Chrome{} without Traditional ✅
- Board compute_layout computes its own rects ✅
- Board does not import shell/traditional/ modules ✅
- Board zoomed chrome composes into valid Frame ✅
- mix lint and mix test.llm pass ✅