### PR TITLE
feat(state): introduce ModalOverlay foundation with dual-write gate

### DIFF
--- a/lib/minga_editor/shell/board/state.ex
+++ b/lib/minga_editor/shell/board/state.ex
@@ -20,6 +20,7 @@ defmodule MingaEditor.Shell.Board.State do
   """
 
   alias MingaEditor.Shell.Board.Card
+  alias MingaEditor.State.ModalOverlay
 
   @type t :: %__MODULE__{
           cards: %{Card.id() => Card.t()},
@@ -43,6 +44,7 @@ defmodule MingaEditor.Shell.Board.State do
           hover_popup: nil,
           tab_bar: nil,
           agent: MingaEditor.State.Agent.t(),
+          modal: ModalOverlay.t(),
           bottom_panel: MingaEditor.BottomPanel.t(),
           git_status_panel: nil,
           modeline_click_regions: [],
@@ -71,6 +73,7 @@ defmodule MingaEditor.Shell.Board.State do
             hover_popup: nil,
             tab_bar: nil,
             agent: %MingaEditor.State.Agent{},
+            modal: :none,
             bottom_panel: %MingaEditor.BottomPanel{},
             git_status_panel: nil,
             modeline_click_regions: [],
@@ -84,6 +87,22 @@ defmodule MingaEditor.Shell.Board.State do
   @doc "Creates a fresh Board state with an empty card grid."
   @spec new() :: t()
   def new, do: %__MODULE__{}
+
+  @doc "Returns the active modal overlay value (`:none` when no modal is open)."
+  @spec modal(t()) :: ModalOverlay.t()
+  def modal(%__MODULE__{modal: m}), do: m
+
+  @doc """
+  Replaces the modal overlay value.
+
+  This is a low-level setter for `MingaEditor.State.ModalOverlay`. Normal
+  callers should use `ModalOverlay.open/3`, `transition/3`, `close/1`, or
+  `dismiss/1` rather than calling this directly.
+  """
+  @spec set_modal(t(), ModalOverlay.t()) :: t()
+  def set_modal(%__MODULE__{} = ss, modal) do
+    %{ss | modal: modal}
+  end
 
   @doc """
   Creates a new card and adds it to the board.

--- a/lib/minga_editor/shell/traditional/state.ex
+++ b/lib/minga_editor/shell/traditional/state.ex
@@ -17,6 +17,7 @@ defmodule MingaEditor.Shell.Traditional.State do
   alias MingaEditor.HoverPopup
   alias MingaEditor.NavFlash
   alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.Picker
   alias MingaEditor.State.Prompt
   alias MingaEditor.State.TabBar
@@ -35,6 +36,7 @@ defmodule MingaEditor.Shell.Traditional.State do
           git_status_panel: MingaEditor.Frontend.Protocol.GUI.git_status_data() | nil,
           tab_bar: TabBar.t() | nil,
           agent: AgentState.t(),
+          modal: ModalOverlay.t(),
           modeline_click_regions: [MingaEditor.Shell.Traditional.Modeline.click_region()],
           tab_bar_click_regions: [MingaEditor.Shell.Traditional.TabBarRenderer.click_region()],
           warning_popup_timer: reference() | nil,
@@ -55,6 +57,7 @@ defmodule MingaEditor.Shell.Traditional.State do
             git_status_panel: nil,
             tab_bar: nil,
             agent: %AgentState{},
+            modal: :none,
             modeline_click_regions: [],
             tab_bar_click_regions: [],
             warning_popup_timer: nil,
@@ -229,6 +232,24 @@ defmodule MingaEditor.Shell.Traditional.State do
   @spec set_agent(t(), AgentState.t()) :: t()
   def set_agent(%{} = ss, agent) do
     %{ss | agent: agent}
+  end
+
+  # ── Modal overlay ──────────────────────────────────────────────────────────
+
+  @doc "Returns the active modal overlay value (`:none` when no modal is open)."
+  @spec modal(t()) :: ModalOverlay.t()
+  def modal(%{modal: m}), do: m
+
+  @doc """
+  Replaces the modal overlay value.
+
+  This is a low-level setter for `MingaEditor.State.ModalOverlay`. Normal
+  callers should use `ModalOverlay.open/3`, `transition/3`, `close/1`, or
+  `dismiss/1` rather than calling this directly.
+  """
+  @spec set_modal(t(), ModalOverlay.t()) :: t()
+  def set_modal(%{} = ss, modal) do
+    %{ss | modal: modal}
   end
 
   # ── Tool prompt helpers ────────────────────────────────────────────────────

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -253,6 +253,11 @@ defmodule MingaEditor.State do
   @spec set_agent(t(), AgentState.t()) :: t()
   def set_agent(s, agent), do: update_shell_state(s, &ShellState.set_agent(&1, agent))
 
+  @spec modal(t()) :: MingaEditor.State.ModalOverlay.t()
+  def modal(%{shell_state: ss}), do: ShellState.modal(ss)
+  @spec set_modal(t(), MingaEditor.State.ModalOverlay.t()) :: t()
+  def set_modal(s, modal), do: update_shell_state(s, &ShellState.set_modal(&1, modal))
+
   # ── Convenience accessors ─────────────────────────────────────────────────
 
   @doc "Returns the active buffer pid."

--- a/lib/minga_editor/state/modal_overlay.ex
+++ b/lib/minga_editor/state/modal_overlay.ex
@@ -1,0 +1,346 @@
+defmodule MingaEditor.State.ModalOverlay do
+  @moduledoc """
+  Tagged-union representation of input-capturing modal overlays.
+
+  Today the picker, prompt, completion menu, conflict prompt, and
+  dashboard live as independent nullable fields on shell state and
+  workspace state. The type system permits 32 combinations even though
+  only six are meaningful, and `MingaEditor.Input.Interrupt` resets eight
+  independent axes by hand. See `docs/UI-STATE-ANALYSIS.md` for the full
+  analysis.
+
+  This module replaces those fields with a single sum type:
+
+      :none
+      | {:picker, ModalOverlay.Picker.t()}
+      | {:prompt, ModalOverlay.Prompt.t()}
+      | {:completion, ModalOverlay.Completion.t()}
+      | {:conflict, ModalOverlay.Conflict.t()}
+      | {:dashboard, ModalOverlay.Dashboard.t()}
+
+  ## Migration phase: dual-write
+
+  This is step 1 of 5 (Epic #1421). The new `:modal` field has been
+  added to `Shell.Traditional.State` and `Shell.Board.State` but no
+  callers read it yet. To keep the migration safe, every gate function
+  here writes both:
+
+  * `state.shell_state.modal` — the new sum-type field
+  * The variant's legacy field — `picker_ui`, `prompt_ui`, `dashboard`,
+    `workspace.completion`, or `workspace.pending_conflict`
+
+  Variant-by-variant migrations (#1424-#1426) point reads at the new
+  field one variant at a time. When all variants have migrated, #1427
+  removes the dual-write and adds a Credo rule that forbids direct
+  writes to the legacy fields.
+
+  Until then, **do not mutate `:modal` directly**: always call this
+  module's `open/3`, `transition/3`, `close/1`, or `dismiss/1`. Direct
+  mutation of the legacy fields is still permitted (existing call
+  sites have not been migrated), but a runtime assertion in `:dev` and
+  `:test` builds crashes when the gate detects that its tracked variant
+  has diverged from the legacy mirror. That surfaces stray writes in CI
+  rather than letting them drift silently.
+
+  ## Replacement policy
+
+  `open/3` while a modal is already active replaces the previous one and
+  clears its legacy slot. There is no queue. The exception is
+  `:conflict`: while a conflict prompt is active, other `open/3` calls
+  are logged and return state unchanged. This matches today's behavior
+  where `ConflictPrompt` sits before every other handler in the input
+  stack.
+
+  `transition/3` performs the same replacement but without the sticky
+  rule; it is intended for FSM-style steps where the caller has already
+  decided that a transition must happen (e.g., picker → prompt).
+  """
+
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
+  alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
+  alias MingaEditor.State.ModalOverlay.Dashboard, as: DashboardPayload
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+  alias MingaEditor.State.ModalOverlay.Prompt, as: PromptPayload
+  alias MingaEditor.State.Picker, as: PickerLegacy
+  alias MingaEditor.State.Prompt, as: PromptLegacy
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  @type variant :: :picker | :prompt | :completion | :conflict | :dashboard
+
+  @type payload ::
+          PickerPayload.t()
+          | PromptPayload.t()
+          | CompletionPayload.t()
+          | ConflictPayload.t()
+          | DashboardPayload.t()
+
+  @type t ::
+          :none
+          | {:picker, PickerPayload.t()}
+          | {:prompt, PromptPayload.t()}
+          | {:completion, CompletionPayload.t()}
+          | {:conflict, ConflictPayload.t()}
+          | {:dashboard, DashboardPayload.t()}
+
+  @assert_consistency Mix.env() in [:dev, :test]
+
+  # ── Pure queries on the modal value ────────────────────────────────────────
+
+  @doc "Returns the closed modal (`:none`)."
+  @spec none() :: t()
+  def none, do: :none
+
+  @doc """
+  Returns the variant tag of `modal`, or `:none` when no modal is active.
+  """
+  @spec tag(t()) :: :none | variant()
+  def tag(:none), do: :none
+
+  def tag({tag, _payload}) when tag in [:picker, :prompt, :completion, :conflict, :dashboard],
+    do: tag
+
+  @doc "Returns true when a modal is currently active (`modal != :none`)."
+  @spec active?(t()) :: boolean()
+  def active?(:none), do: false
+
+  def active?({tag, _payload}) when tag in [:picker, :prompt, :completion, :conflict, :dashboard],
+    do: true
+
+  @doc """
+  Returns true when `modal` matches the given variant tag.
+
+  `match(:none, :none)` is true; `match({:picker, _}, :picker)` is true.
+  Any other combination is false.
+  """
+  @spec match(t(), :none | variant()) :: boolean()
+  def match(:none, :none), do: true
+
+  def match({tag, _payload}, tag)
+      when tag in [:picker, :prompt, :completion, :conflict, :dashboard],
+      do: true
+
+  def match(_modal, _tag), do: false
+
+  # ── Mutating gate functions on EditorState ─────────────────────────────────
+
+  @doc """
+  Opens a modal overlay, replacing any active one.
+
+  Conflict prompts are sticky: if the active modal is a conflict, calls
+  to `open/3` for any other variant are logged and return state
+  unchanged. To force a transition out of a conflict modal, call
+  `close/1` or `dismiss/1` first, or use `transition/3`.
+
+  Dual-write phase: in addition to setting `state.shell_state.modal`,
+  this function mirrors the payload's underlying state into the variant's
+  legacy field so existing readers continue to work.
+  """
+  @spec open(EditorState.t(), variant(), payload()) :: EditorState.t()
+  def open(%EditorState{} = state, variant, payload) do
+    state
+    |> assert_consistency!()
+    |> do_open(variant, payload)
+    |> assert_consistency!()
+  end
+
+  @doc """
+  Transitions the active modal to a new variant unconditionally.
+
+  Equivalent to `open/3` except the conflict-sticky rule is bypassed.
+  Use this when the caller has already decided the transition must
+  happen (e.g., dismissing a picker into a prompt).
+  """
+  @spec transition(EditorState.t(), variant(), payload()) :: EditorState.t()
+  def transition(%EditorState{} = state, variant, payload) do
+    state
+    |> assert_consistency!()
+    |> do_set_modal(variant, payload)
+    |> assert_consistency!()
+  end
+
+  @doc """
+  Closes the active modal cleanly.
+
+  Used when the modal has completed its task (e.g., picker accepted,
+  prompt submitted). No-op when no modal is active.
+  """
+  @spec close(EditorState.t()) :: EditorState.t()
+  def close(%EditorState{} = state), do: do_close(state, :close)
+
+  @doc """
+  Dismisses the active modal as a cancellation.
+
+  Used when the user backs out (Esc, Ctrl-G). Behavior is identical to
+  `close/1` in the dual-write phase; the distinction exists so callers
+  can express intent and so future per-variant cleanup hooks can branch
+  on it.
+  """
+  @spec dismiss(EditorState.t()) :: EditorState.t()
+  def dismiss(%EditorState{} = state), do: do_close(state, :dismiss)
+
+  # ── Internals ──────────────────────────────────────────────────────────────
+
+  @spec do_open(EditorState.t(), variant(), payload()) :: EditorState.t()
+  defp do_open(state, variant, payload) do
+    case state.shell_state.modal do
+      {:conflict, _} when variant != :conflict ->
+        Minga.Log.info(
+          :editor,
+          "ModalOverlay.open(#{inspect(variant)}) suppressed: conflict prompt is active"
+        )
+
+        state
+
+      _ ->
+        do_set_modal(state, variant, payload)
+    end
+  end
+
+  @spec do_set_modal(EditorState.t(), variant(), payload()) :: EditorState.t()
+  defp do_set_modal(state, variant, payload) do
+    state
+    |> clear_displaced_legacy()
+    |> put_modal({variant, payload})
+    |> mirror_to_legacy({variant, payload})
+  end
+
+  @spec do_close(EditorState.t(), :close | :dismiss) :: EditorState.t()
+  defp do_close(state, _kind) do
+    state = assert_consistency!(state)
+
+    case state.shell_state.modal do
+      :none ->
+        state
+
+      _ ->
+        state
+        |> clear_displaced_legacy()
+        |> put_modal(:none)
+        |> assert_consistency!()
+    end
+  end
+
+  # Clears the legacy slot of whichever variant is currently tracked in
+  # `state.shell_state.modal`. No-op when the modal is `:none`.
+  @spec clear_displaced_legacy(EditorState.t()) :: EditorState.t()
+  defp clear_displaced_legacy(state) do
+    case state.shell_state.modal do
+      :none ->
+        state
+
+      {:picker, _} ->
+        EditorState.set_picker_ui(state, %PickerLegacy{})
+
+      {:prompt, _} ->
+        EditorState.set_prompt_ui(state, %PromptLegacy{})
+
+      {:dashboard, _} ->
+        EditorState.close_dashboard(state)
+
+      {:completion, _} ->
+        EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, nil))
+
+      {:conflict, _} ->
+        EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, nil))
+    end
+  end
+
+  # Writes the payload's underlying state to the variant's legacy slot.
+  @spec mirror_to_legacy(EditorState.t(), {variant(), payload()}) :: EditorState.t()
+  defp mirror_to_legacy(state, {:picker, %PickerPayload{picker_ui: pui}}) do
+    EditorState.set_picker_ui(state, pui)
+  end
+
+  defp mirror_to_legacy(state, {:prompt, %PromptPayload{prompt_ui: pui}}) do
+    EditorState.set_prompt_ui(state, pui)
+  end
+
+  defp mirror_to_legacy(state, {:dashboard, %DashboardPayload{state: dash}}) do
+    EditorState.set_dashboard(state, dash)
+  end
+
+  defp mirror_to_legacy(state, {:completion, %CompletionPayload{completion: comp}}) do
+    EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, comp))
+  end
+
+  defp mirror_to_legacy(state, {:conflict, %ConflictPayload{} = conflict}) do
+    legacy = ConflictPayload.to_legacy(conflict)
+    EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, legacy))
+  end
+
+  @spec put_modal(EditorState.t(), t()) :: EditorState.t()
+  defp put_modal(state, modal) do
+    EditorState.set_modal(state, modal)
+  end
+
+  # ── Divergence assertion ───────────────────────────────────────────────────
+  #
+  # The assertion runs before and after every gate function in `:dev` and
+  # `:test`. When the gate is tracking a variant, the legacy slot for that
+  # variant must equal the payload's underlying state. Any mismatch means
+  # legacy state was mutated outside this gate; we crash so the offending
+  # caller surfaces in CI.
+  #
+  # When `:modal` is `:none`, the gate makes no claims about legacy slots —
+  # they remain managed by their pre-migration callers.
+
+  if @assert_consistency do
+    @spec assert_consistency!(EditorState.t()) :: EditorState.t()
+    defp assert_consistency!(%EditorState{} = state) do
+      check_consistency!(state)
+      state
+    end
+
+    @spec check_consistency!(EditorState.t()) :: :ok
+    defp check_consistency!(%EditorState{} = state) do
+      ss = state.shell_state
+      ws = state.workspace
+
+      case ss.modal do
+        :none ->
+          :ok
+
+        {:picker, %PickerPayload{picker_ui: pui}} ->
+          if ss.picker_ui != pui, do: raise_divergence!(:picker, pui, ss.picker_ui)
+          :ok
+
+        {:prompt, %PromptPayload{prompt_ui: pu}} ->
+          if ss.prompt_ui != pu, do: raise_divergence!(:prompt, pu, ss.prompt_ui)
+          :ok
+
+        {:dashboard, %DashboardPayload{state: dash}} ->
+          if ss.dashboard != dash, do: raise_divergence!(:dashboard, dash, ss.dashboard)
+          :ok
+
+        {:completion, %CompletionPayload{completion: comp}} ->
+          if ws.completion != comp, do: raise_divergence!(:completion, comp, ws.completion)
+          :ok
+
+        {:conflict, %ConflictPayload{} = conflict} ->
+          expected = ConflictPayload.to_legacy(conflict)
+
+          if ws.pending_conflict != expected,
+            do: raise_divergence!(:conflict, expected, ws.pending_conflict)
+
+          :ok
+      end
+    end
+
+    @spec raise_divergence!(variant(), term(), term()) :: no_return()
+    defp raise_divergence!(variant, expected, found) do
+      raise """
+      MingaEditor.State.ModalOverlay divergence: tracked variant #{inspect(variant)} \
+      diverges from its legacy mirror. The gate expected the legacy slot to equal \
+      the payload's underlying state, but found a different value. This means the \
+      legacy field was mutated without going through ModalOverlay.
+
+        expected: #{inspect(expected, pretty: true, limit: :infinity)}
+        found:    #{inspect(found, pretty: true, limit: :infinity)}
+      """
+    end
+  else
+    @spec assert_consistency!(EditorState.t()) :: EditorState.t()
+    defp assert_consistency!(state), do: state
+  end
+end

--- a/lib/minga_editor/state/modal_overlay.ex
+++ b/lib/minga_editor/state/modal_overlay.ex
@@ -85,6 +85,11 @@ defmodule MingaEditor.State.ModalOverlay do
 
   @assert_consistency Mix.env() in [:dev, :test]
 
+  # Single source of truth for the variant tag list. Adding a sixth modal
+  # later means adding to this attribute plus the `t()` and `payload()`
+  # types — the guards below stay correct automatically.
+  @variants [:picker, :prompt, :completion, :conflict, :dashboard]
+
   # ── Pure queries on the modal value ────────────────────────────────────────
 
   @doc "Returns the closed modal (`:none`)."
@@ -96,16 +101,12 @@ defmodule MingaEditor.State.ModalOverlay do
   """
   @spec tag(t()) :: :none | variant()
   def tag(:none), do: :none
-
-  def tag({tag, _payload}) when tag in [:picker, :prompt, :completion, :conflict, :dashboard],
-    do: tag
+  def tag({tag, _payload}) when tag in @variants, do: tag
 
   @doc "Returns true when a modal is currently active (`modal != :none`)."
   @spec active?(t()) :: boolean()
   def active?(:none), do: false
-
-  def active?({tag, _payload}) when tag in [:picker, :prompt, :completion, :conflict, :dashboard],
-    do: true
+  def active?({tag, _payload}) when tag in @variants, do: true
 
   @doc """
   Returns true when `modal` matches the given variant tag.
@@ -115,11 +116,7 @@ defmodule MingaEditor.State.ModalOverlay do
   """
   @spec match(t(), :none | variant()) :: boolean()
   def match(:none, :none), do: true
-
-  def match({tag, _payload}, tag)
-      when tag in [:picker, :prompt, :completion, :conflict, :dashboard],
-      do: true
-
+  def match({tag, _payload}, tag) when tag in @variants, do: true
   def match(_modal, _tag), do: false
 
   # ── Mutating gate functions on EditorState ─────────────────────────────────
@@ -190,6 +187,9 @@ defmodule MingaEditor.State.ModalOverlay do
           "ModalOverlay.open(#{inspect(variant)}) suppressed: conflict prompt is active"
         )
 
+        # Sticky-conflict early return: state is unchanged, so the entry
+        # assertion already proved consistency and there is nothing new to
+        # check on the way out.
         state
 
       _ ->
@@ -205,6 +205,10 @@ defmodule MingaEditor.State.ModalOverlay do
     |> mirror_to_legacy({variant, payload})
   end
 
+  # `_kind` is intentionally unused in the dual-write phase. It is plumbed
+  # through so future per-variant cleanup hooks (introduced once the legacy
+  # mirror is removed in #1427) can branch on `:close` vs `:dismiss` without
+  # changing the public API.
   @spec do_close(EditorState.t(), :close | :dismiss) :: EditorState.t()
   defp do_close(state, _kind) do
     state = assert_consistency!(state)
@@ -313,6 +317,16 @@ defmodule MingaEditor.State.ModalOverlay do
           if ss.dashboard != dash, do: raise_divergence!(:dashboard, dash, ss.dashboard)
           :ok
 
+        # NOTE for #1424+: the completion and conflict payloads live on
+        # shell_state.modal, but their legacy mirrors live on `workspace`,
+        # which is snapshotted per tab while shell_state is not. Once a
+        # caller actually opens one of these variants, switching tabs will
+        # swap workspace.completion / workspace.pending_conflict out from
+        # under the gate and trip this assertion on the next call. Resolve
+        # by either (a) clearing :modal on tab-switch via a hook, or
+        # (b) moving these variants' authoritative state onto workspace.
+        # This step intentionally does not pick — flagged in the next
+        # ticket's developer notes.
         {:completion, %CompletionPayload{completion: comp}} ->
           if ws.completion != comp, do: raise_divergence!(:completion, comp, ws.completion)
           :ok

--- a/lib/minga_editor/state/modal_overlay/completion.ex
+++ b/lib/minga_editor/state/modal_overlay/completion.ex
@@ -1,0 +1,39 @@
+defmodule MingaEditor.State.ModalOverlay.Completion do
+  @moduledoc """
+  Modal-overlay payload for the completion menu.
+
+  The completion menu is logically per-tab: it tracks the cursor position of
+  the buffer that triggered it. The `owner` field carries the tab identifier
+  so a future tab-switch hook can auto-dismiss completion that no longer
+  belongs to the active tab.
+  """
+
+  alias Minga.Editing.Completion
+
+  @typedoc """
+  Identifier of the tab that triggered completion.
+
+  Tab IDs are the keys of `MingaEditor.State.TabBar`'s tab map. We accept
+  any term so callers do not need to depend on TabBar's id type directly.
+  """
+  @type owner :: term()
+
+  @type t :: %__MODULE__{
+          completion: Completion.t(),
+          owner: owner(),
+          opened_at: integer()
+        }
+
+  @enforce_keys [:completion, :owner]
+  defstruct [:completion, :owner, opened_at: 0]
+
+  @doc "Builds a completion payload bound to `owner` (typically a tab id)."
+  @spec new(Completion.t(), owner(), keyword()) :: t()
+  def new(%Completion{} = completion, owner, opts \\ []) do
+    %__MODULE__{
+      completion: completion,
+      owner: owner,
+      opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
+    }
+  end
+end

--- a/lib/minga_editor/state/modal_overlay/conflict.ex
+++ b/lib/minga_editor/state/modal_overlay/conflict.ex
@@ -1,0 +1,45 @@
+defmodule MingaEditor.State.ModalOverlay.Conflict do
+  @moduledoc """
+  Modal-overlay payload for the conflict prompt.
+
+  The conflict prompt asks the user to resolve a buffer/disk conflict. It is
+  bound to a specific buffer process; `owner` carries that buffer pid so the
+  modal can be auto-dismissed when its buffer dies or the user switches
+  away.
+
+  The legacy representation is `state.workspace.pending_conflict =
+  {buffer_pid, prompt_text}`. This struct mirrors that pair while making the
+  metadata explicit.
+  """
+
+  @type owner :: pid()
+
+  @type t :: %__MODULE__{
+          buffer: pid(),
+          message: String.t(),
+          owner: owner(),
+          opened_at: integer()
+        }
+
+  @enforce_keys [:buffer, :message, :owner]
+  defstruct [:buffer, :message, :owner, opened_at: 0]
+
+  @doc """
+  Builds a conflict payload from the legacy `{buffer_pid, message}` tuple.
+
+  The owner is set to the buffer pid; callers can override via opts.
+  """
+  @spec new(pid(), String.t(), keyword()) :: t()
+  def new(buffer, message, opts \\ []) when is_pid(buffer) and is_binary(message) do
+    %__MODULE__{
+      buffer: buffer,
+      message: message,
+      owner: Keyword.get(opts, :owner, buffer),
+      opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
+    }
+  end
+
+  @doc "Returns the legacy `{buffer, message}` tuple shape."
+  @spec to_legacy(t()) :: {pid(), String.t()}
+  def to_legacy(%__MODULE__{buffer: buf, message: msg}), do: {buf, msg}
+end

--- a/lib/minga_editor/state/modal_overlay/dashboard.ex
+++ b/lib/minga_editor/state/modal_overlay/dashboard.ex
@@ -1,0 +1,32 @@
+defmodule MingaEditor.State.ModalOverlay.Dashboard do
+  @moduledoc """
+  Modal-overlay payload for the dashboard home screen.
+
+  Wraps the existing `MingaEditor.Dashboard.state()` map (cursor + items)
+  with the metadata every ModalOverlay variant carries. The dashboard is
+  global UX, so `owner` defaults to `:global`.
+  """
+
+  alias MingaEditor.Dashboard
+
+  @type owner :: term()
+
+  @type t :: %__MODULE__{
+          state: Dashboard.state(),
+          owner: owner(),
+          opened_at: integer()
+        }
+
+  @enforce_keys [:state]
+  defstruct [:state, owner: :global, opened_at: 0]
+
+  @doc "Builds a dashboard payload wrapping the given dashboard state map."
+  @spec new(Dashboard.state(), keyword()) :: t()
+  def new(state, opts \\ []) when is_map(state) do
+    %__MODULE__{
+      state: state,
+      owner: Keyword.get(opts, :owner, :global),
+      opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
+    }
+  end
+end

--- a/lib/minga_editor/state/modal_overlay/dashboard.ex
+++ b/lib/minga_editor/state/modal_overlay/dashboard.ex
@@ -5,6 +5,12 @@ defmodule MingaEditor.State.ModalOverlay.Dashboard do
   Wraps the existing `MingaEditor.Dashboard.state()` map (cursor + items)
   with the metadata every ModalOverlay variant carries. The dashboard is
   global UX, so `owner` defaults to `:global`.
+
+  Scoped to the Traditional shell. `Shell.Board.State` declares
+  `dashboard: nil` in its typespec because Board does not surface the
+  dashboard; opening this variant while the active shell is Board would
+  violate that type. Callers that want a dashboard-style affordance on
+  Board should add a Board-specific variant rather than reusing this one.
   """
 
   alias MingaEditor.Dashboard

--- a/lib/minga_editor/state/modal_overlay/picker.ex
+++ b/lib/minga_editor/state/modal_overlay/picker.ex
@@ -1,0 +1,42 @@
+defmodule MingaEditor.State.ModalOverlay.Picker do
+  @moduledoc """
+  Modal-overlay payload for the picker variant.
+
+  Wraps the existing `MingaEditor.State.Picker` struct with the metadata the
+  ModalOverlay sum type carries for every variant: `opened_at` (monotonic
+  millisecond timestamp) and `owner` (a tag identifying the lifecycle scope
+  the modal belongs to).
+
+  The picker is global UX, so `owner` defaults to `:global`. It is included
+  here for API uniformity with the per-tab variants (`Completion`,
+  `Conflict`).
+  """
+
+  alias MingaEditor.State.Picker, as: PickerState
+
+  @type owner :: term()
+
+  @type t :: %__MODULE__{
+          picker_ui: PickerState.t(),
+          owner: owner(),
+          opened_at: integer()
+        }
+
+  @enforce_keys [:picker_ui]
+  defstruct picker_ui: %PickerState{}, owner: :global, opened_at: 0
+
+  @doc """
+  Builds a picker payload wrapping the given `picker_ui` state.
+
+  The optional `:owner` keyword defaults to `:global`. The optional
+  `:opened_at` keyword defaults to `System.monotonic_time(:millisecond)`.
+  """
+  @spec new(PickerState.t(), keyword()) :: t()
+  def new(%PickerState{} = picker_ui, opts \\ []) do
+    %__MODULE__{
+      picker_ui: picker_ui,
+      owner: Keyword.get(opts, :owner, :global),
+      opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
+    }
+  end
+end

--- a/lib/minga_editor/state/modal_overlay/prompt.ex
+++ b/lib/minga_editor/state/modal_overlay/prompt.ex
@@ -1,0 +1,35 @@
+defmodule MingaEditor.State.ModalOverlay.Prompt do
+  @moduledoc """
+  Modal-overlay payload for the prompt variant.
+
+  Wraps the existing `MingaEditor.State.Prompt` struct with the metadata the
+  ModalOverlay sum type carries for every variant: `opened_at` (monotonic
+  millisecond timestamp) and `owner`. Prompts are global UX, so `owner`
+  defaults to `:global`.
+  """
+
+  alias MingaEditor.State.Prompt, as: PromptState
+
+  @type owner :: term()
+
+  @type t :: %__MODULE__{
+          prompt_ui: PromptState.t(),
+          owner: owner(),
+          opened_at: integer()
+        }
+
+  @enforce_keys [:prompt_ui]
+  defstruct prompt_ui: %PromptState{}, owner: :global, opened_at: 0
+
+  @doc """
+  Builds a prompt payload wrapping the given `prompt_ui` state.
+  """
+  @spec new(PromptState.t(), keyword()) :: t()
+  def new(%PromptState{} = prompt_ui, opts \\ []) do
+    %__MODULE__{
+      prompt_ui: prompt_ui,
+      owner: Keyword.get(opts, :owner, :global),
+      opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
+    }
+  end
+end

--- a/test/minga_editor/state/modal_overlay_test.exs
+++ b/test/minga_editor/state/modal_overlay_test.exs
@@ -1,0 +1,309 @@
+defmodule MingaEditor.State.ModalOverlayTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Editing.Completion
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
+  alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
+  alias MingaEditor.State.ModalOverlay.Dashboard, as: DashboardPayload
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+  alias MingaEditor.State.ModalOverlay.Prompt, as: PromptPayload
+  alias MingaEditor.State.Picker, as: PickerLegacy
+  alias MingaEditor.State.Prompt, as: PromptLegacy
+  alias MingaEditor.UI.Picker, as: UIPicker
+  alias MingaEditor.Viewport
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  defp base_state do
+    %EditorState{
+      port_manager: nil,
+      workspace: %WorkspaceState{
+        viewport: %Viewport{top: 0, left: 0, rows: 10, cols: 40}
+      },
+      shell_state: %ShellState{}
+    }
+  end
+
+  defp picker_payload(label \\ "test") do
+    PickerPayload.new(
+      %PickerLegacy{
+        picker: UIPicker.new([], title: label),
+        source: nil,
+        restore: 7
+      },
+      opened_at: 1_000
+    )
+  end
+
+  defp prompt_payload(text \\ "search") do
+    PromptPayload.new(
+      %PromptLegacy{handler: SomeHandler, text: text, cursor: byte_size(text), label: ":"},
+      opened_at: 1_001
+    )
+  end
+
+  defp dashboard_payload do
+    DashboardPayload.new(%{cursor: 0, items: []}, opened_at: 1_002)
+  end
+
+  defp completion_payload(tab_id \\ 1) do
+    completion =
+      Completion.new(
+        [],
+        {0, 0}
+      )
+
+    CompletionPayload.new(completion, tab_id, opened_at: 1_003)
+  end
+
+  defp conflict_payload(buffer \\ self()) do
+    ConflictPayload.new(buffer, "buffer changed on disk", opened_at: 1_004)
+  end
+
+  describe "queries on the modal value" do
+    test "none/0 returns :none" do
+      assert ModalOverlay.none() == :none
+    end
+
+    test "tag/1 returns :none for :none and the variant tag for a tuple" do
+      assert ModalOverlay.tag(:none) == :none
+      assert ModalOverlay.tag({:picker, picker_payload()}) == :picker
+      assert ModalOverlay.tag({:prompt, prompt_payload()}) == :prompt
+      assert ModalOverlay.tag({:completion, completion_payload()}) == :completion
+      assert ModalOverlay.tag({:conflict, conflict_payload()}) == :conflict
+      assert ModalOverlay.tag({:dashboard, dashboard_payload()}) == :dashboard
+    end
+
+    test "active?/1 distinguishes :none from any variant" do
+      refute ModalOverlay.active?(:none)
+      assert ModalOverlay.active?({:picker, picker_payload()})
+      assert ModalOverlay.active?({:conflict, conflict_payload()})
+    end
+
+    test "match/2 is true only for the same tag" do
+      assert ModalOverlay.match(:none, :none)
+      assert ModalOverlay.match({:picker, picker_payload()}, :picker)
+      refute ModalOverlay.match({:picker, picker_payload()}, :prompt)
+      refute ModalOverlay.match({:picker, picker_payload()}, :none)
+      refute ModalOverlay.match(:none, :picker)
+    end
+  end
+
+  describe "open/3 from :none" do
+    test "writes the modal field and mirrors picker payload to the legacy slot" do
+      state = base_state()
+      payload = picker_payload()
+
+      result = ModalOverlay.open(state, :picker, payload)
+
+      assert result.shell_state.modal == {:picker, payload}
+      assert result.shell_state.picker_ui == payload.picker_ui
+    end
+
+    test "writes the prompt legacy field" do
+      state = base_state()
+      payload = prompt_payload()
+
+      result = ModalOverlay.open(state, :prompt, payload)
+
+      assert result.shell_state.modal == {:prompt, payload}
+      assert result.shell_state.prompt_ui == payload.prompt_ui
+    end
+
+    test "writes the dashboard legacy field" do
+      state = base_state()
+      payload = dashboard_payload()
+
+      result = ModalOverlay.open(state, :dashboard, payload)
+
+      assert result.shell_state.modal == {:dashboard, payload}
+      assert result.shell_state.dashboard == payload.state
+    end
+
+    test "writes the completion legacy field on workspace" do
+      state = base_state()
+      payload = completion_payload(7)
+
+      result = ModalOverlay.open(state, :completion, payload)
+
+      assert result.shell_state.modal == {:completion, payload}
+      assert result.workspace.completion == payload.completion
+    end
+
+    test "writes the conflict legacy field as a {pid, message} tuple" do
+      state = base_state()
+      buffer = self()
+      payload = conflict_payload(buffer)
+
+      result = ModalOverlay.open(state, :conflict, payload)
+
+      assert result.shell_state.modal == {:conflict, payload}
+      assert result.workspace.pending_conflict == {buffer, payload.message}
+    end
+  end
+
+  describe "open/3 displacement" do
+    test "replacing a picker with a prompt clears the picker legacy slot" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:picker, picker_payload())
+
+      prompt = prompt_payload("hello")
+      result = ModalOverlay.open(state, :prompt, prompt)
+
+      assert result.shell_state.modal == {:prompt, prompt}
+      assert result.shell_state.prompt_ui == prompt.prompt_ui
+      assert result.shell_state.picker_ui == %PickerLegacy{}
+    end
+
+    test "replacing completion with picker clears workspace.completion" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:completion, completion_payload(1))
+
+      picker = picker_payload()
+      result = ModalOverlay.open(state, :picker, picker)
+
+      assert result.shell_state.modal == {:picker, picker}
+      assert result.workspace.completion == nil
+      assert result.shell_state.picker_ui == picker.picker_ui
+    end
+
+    test "replacing dashboard clears the dashboard legacy field" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:dashboard, dashboard_payload())
+
+      picker = picker_payload()
+      result = ModalOverlay.open(state, :picker, picker)
+
+      assert result.shell_state.modal == {:picker, picker}
+      assert result.shell_state.dashboard == nil
+    end
+  end
+
+  describe "open/3 conflict-sticky rule" do
+    test "open(:picker) while conflict is active is suppressed and returns state unchanged" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:conflict, conflict_payload())
+
+      result = ModalOverlay.open(state, :picker, picker_payload())
+
+      assert result == state
+    end
+
+    test "open(:conflict) over an existing conflict replaces (same-variant transition)" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:conflict, conflict_payload(self()))
+
+      other = self()
+      next = ConflictPayload.new(other, "different message", opened_at: 2_000)
+      result = ModalOverlay.open(state, :conflict, next)
+
+      assert result.shell_state.modal == {:conflict, next}
+      assert result.workspace.pending_conflict == {other, "different message"}
+    end
+  end
+
+  describe "transition/3" do
+    test "bypasses the conflict-sticky rule" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:conflict, conflict_payload())
+
+      picker = picker_payload()
+      result = ModalOverlay.transition(state, :picker, picker)
+
+      assert result.shell_state.modal == {:picker, picker}
+      assert result.shell_state.picker_ui == picker.picker_ui
+      assert result.workspace.pending_conflict == nil
+    end
+  end
+
+  describe "close/1 and dismiss/1" do
+    test "close clears the active picker and resets the legacy slot" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:picker, picker_payload())
+
+      result = ModalOverlay.close(state)
+
+      assert result.shell_state.modal == :none
+      assert result.shell_state.picker_ui == %PickerLegacy{}
+    end
+
+    test "dismiss clears the active prompt and resets the legacy slot" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:prompt, prompt_payload())
+
+      result = ModalOverlay.dismiss(state)
+
+      assert result.shell_state.modal == :none
+      assert result.shell_state.prompt_ui == %PromptLegacy{}
+    end
+
+    test "close clears workspace.completion when a completion is active" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:completion, completion_payload(3))
+
+      result = ModalOverlay.close(state)
+
+      assert result.shell_state.modal == :none
+      assert result.workspace.completion == nil
+    end
+
+    test "close on an idle state is a no-op" do
+      state = base_state()
+      result = ModalOverlay.close(state)
+      assert result == state
+    end
+  end
+
+  describe "divergence assertion (dev/test only)" do
+    test "raises when picker_ui is mutated outside the gate" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:picker, picker_payload())
+
+      tampered =
+        update_in(state.shell_state.picker_ui, fn pui ->
+          %{pui | restore: 999}
+        end)
+
+      assert_raise RuntimeError, ~r/ModalOverlay divergence/, fn ->
+        ModalOverlay.close(tampered)
+      end
+    end
+
+    test "raises when workspace.completion is cleared outside the gate" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:completion, completion_payload(2))
+
+      tampered = put_in(state.workspace.completion, nil)
+
+      assert_raise RuntimeError, ~r/ModalOverlay divergence/, fn ->
+        ModalOverlay.close(tampered)
+      end
+    end
+
+    test "tolerates legacy mutation while modal is :none" do
+      state = base_state()
+      tampered = EditorState.set_picker_ui(state, %PickerLegacy{restore: 42})
+
+      payload = prompt_payload()
+      result = ModalOverlay.open(tampered, :prompt, payload)
+
+      assert result.shell_state.modal == {:prompt, payload}
+      # The mutated picker_ui is preserved: the gate makes no claims about
+      # legacy fields whose variant is not currently tracked.
+      assert result.shell_state.picker_ui.restore == 42
+    end
+  end
+end


### PR DESCRIPTION
Closes #1423
Refs #1421 (Modal Overlay sum type, step 1 of 5)

## Summary

- Adds `MingaEditor.State.ModalOverlay`, a tagged-union gate over the picker/prompt/completion/conflict/dashboard modals, plus per-variant payload structs that carry `opened_at` and `owner` metadata.
- Adds a `:modal` field (defaulted to `:none`) on both `Shell.Traditional.State` and `Shell.Board.State`, with low-level `set_modal/2` setters and an `EditorState.set_modal/2` wrapper.
- The gate dual-writes: every `open`/`transition`/`close`/`dismiss` updates the new `:modal` field **and** mirrors the variant's underlying state into the legacy slot (`picker_ui`, `prompt_ui`, `dashboard`, `workspace.completion`, or `workspace.pending_conflict`) so existing readers continue to work unchanged.
- A divergence assertion compiled into `:dev` and `:test` builds crashes when the gate's tracked variant diverges from its legacy mirror, surfacing stray legacy writes in CI before later migrations remove the dual-write entirely (#1427).
- Conflict-sticky rule: `open/3` for any other variant while a conflict modal is active is logged and returns state unchanged. `transition/3` bypasses that rule for FSM-style steps.
- No existing tests modified; the full suite still passes because no production callers read or write `:modal` yet.

## Verification

- **AC 1 — module + functions exist.** `lib/minga_editor/state/modal_overlay.ex` defines `t() :: :none | {:picker, ...} | ...` and exposes `none/0`, `open/3`, `transition/3`, `close/1`, `dismiss/1`, `tag/1`, `active?/1`, `match/2`. Covered by `test/minga_editor/state/modal_overlay_test.exs` `describe "queries on the modal value"` and `describe "open/3 from :none"`.
- **AC 2 — `:modal` field on both shell states defaulted to `:none`.** `lib/minga_editor/shell/traditional/state.ex` (typespec + defstruct) and `lib/minga_editor/shell/board/state.ex` (typespec + defstruct). Construct a fresh `%ShellState{}` or `%BoardState{}` and observe `.modal == :none`.
- **AC 3 — gate writes both new field and legacy field.** `mirror_to_legacy/2` in `modal_overlay.ex` dispatches per variant. Tests `"writes the picker legacy slot"`, `"writes the prompt legacy field"`, `"writes the dashboard legacy field"`, `"writes the completion legacy field on workspace"`, `"writes the conflict legacy field as a {pid, message} tuple"`.
- **AC 4 — variant payloads carry state, `opened_at`, `owner`.** Five files under `lib/minga_editor/state/modal_overlay/`. `Conflict.owner` is the buffer pid; `Completion.owner` is a tab id; the global variants default to `:global`. The test helpers exercise the constructors with explicit `opened_at:` for determinism.
- **AC 5 — divergence assertion.** `assert_consistency!/1` and `check_consistency!/1` in `modal_overlay.ex`, gated by `@assert_consistency Mix.env() in [:dev, :test]`. Tests `"raises when picker_ui is mutated outside the gate"`, `"raises when workspace.completion is cleared outside the gate"`, `"tolerates legacy mutation while modal is :none"`.
- **AC 6 — no existing tests modified; all pass.** `mix test.llm` reports 7498 tests / 0 failures, and the only test diff in this PR is the new `modal_overlay_test.exs` (22 tests).

Local checks before opening:

- `mix compile --warnings-as-errors` — clean
- `mix test.llm` — 7498 / 0 failures
- `make lint` — format clean, credo `--strict` produces only the pre-existing "struct has more than 15 fields" warnings (Epic #1421 exit criterion AC 6 will resolve those), `mix dialyzer` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)