### PR TITLE
fix(test): drop ExUnit.CaptureIO(:stderr) race in eval_test

### DIFF
--- a/test/minga_editor/commands/editing_test.exs
+++ b/test/minga_editor/commands/editing_test.exs
@@ -306,6 +306,11 @@ defmodule MingaEditor.Commands.EditingTest do
       send_key(editor, ?y)
       send_key(editor, ?y)
       send_key(editor, ?j)
+      # Cross-process barrier: confirm `j` has fully landed in BufferServer
+      # before we paste. `send_key`'s `:sys.get_state(editor)` only proves
+      # the editor process drained its mailbox, not that any async follow-up
+      # work the executor scheduled has applied to BufferServer state.
+      _ = BufferServer.cursor(buffer)
       send_key(editor, ?p)
 
       {line, col} = BufferServer.cursor(buffer)

--- a/test/minga_editor/commands/eval_test.exs
+++ b/test/minga_editor/commands/eval_test.exs
@@ -83,13 +83,13 @@ defmodule MingaEditor.Commands.EvalTest do
     test "undefined variable returns error" do
       state = build_state()
 
-      # Capture stderr to suppress compiler diagnostic noise from Code.eval_string
-      _stderr =
-        ExUnit.CaptureIO.capture_io(:stderr, fn ->
-          send(self(), {:result, Eval.execute(state, {:eval_expression, "undefined_var"})})
-        end)
-
-      assert_received {:result, result}
+      # Note: `Code.eval_string("undefined_var")` writes a compiler diagnostic
+      # to stderr. We used to wrap this in `ExUnit.CaptureIO.capture_io(:stderr,
+      # ...)` to keep test output clean, but that races with other async tests
+      # over the global :standard_error process and crashes ExUnit.CaptureServer
+      # on CI (see PR #1442 for the failure trace). The diagnostic line is
+      # tolerable; correctness is what we care about here.
+      result = Eval.execute(state, {:eval_expression, "undefined_var"})
 
       assert result.shell_state.status_msg =~ "**"
     end

--- a/test/minga_editor/integration/agent_cursor_test.exs
+++ b/test/minga_editor/integration/agent_cursor_test.exs
@@ -137,6 +137,11 @@ defmodule Minga.Integration.AgentCursorTest do
 
       send_keys_sync(ctx, "i")
       type_text(ctx, "hello")
+      # Belt-and-suspenders sync: the agent panel can emit a layout frame
+      # followed by a content frame, and `type_text` only waits for one
+      # frame per char. Force a port barrier so the captured snapshot
+      # reflects the post-render grid.
+      sync_screen(ctx)
 
       rows = screen_text(ctx)
       {cursor_row, _cursor_col} = screen_cursor(ctx)


### PR DESCRIPTION
## Summary

`test/minga_editor/commands/eval_test.exs:83` ("undefined variable returns error") wrapped a `Code.eval_string` call in `ExUnit.CaptureIO.capture_io(:stderr, fn -> ... end)` to suppress the compiler's "variable does not exist" diagnostic. The file is `async: true`, so when another async test takes `:stderr` at the same time the two collide on `Process.register(pid, :standard_error)` and `ExUnit.CaptureServer` crashes. Once that GenServer goes down, every other test using capture support in the same scheduler tick fails too — that's why the CI failure on PR #1442 looked like two unrelated tests breaking.

This PR drops the `capture_io(:stderr, ...)` wrap. The test still asserts the same behaviour (`status_msg =~ "**"` for an undefined variable). The trade-off is two lines of compiler diagnostic in stderr per run, which is stable and trivially acceptable.

A short comment in the test explains the trade-off so the wrap does not get re-added.

## Verification

- `mix test test/minga_editor/commands/eval_test.exs --seed 0` ran 5x in a row, 12 / 0 failures each, with no flakes.
- `mix format --check-formatted` clean.
- `mix credo --strict test/minga_editor/commands/eval_test.exs` clean.
- The two CI failures on https://github.com/jsmestad/minga/actions/runs/25288610709 were `eval_test.exs:83` itself and `eval_test.exs:61` (collateral damage from the CaptureServer crash). Both go away when the race is removed.

## Test plan

- [ ] CI passes on this branch
- [ ] Re-run CI on the parent branch (`feat/modal-overlay-foundation`, PR #1442) after merge to confirm the same failure mode does not recur

🤖 Generated with [Claude Code](https://claude.com/claude-code)