### PR TITLE
feat(ui): migrate picker reads and writes through ModalOverlay gate

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -2080,7 +2080,11 @@ defmodule MingaEditor do
   # sees live updates (spinner → checkmark, etc.).
   @spec maybe_refresh_tool_picker(state()) :: state()
   defp maybe_refresh_tool_picker(
-         %{shell_state: %{picker_ui: %{source: MingaEditor.UI.Picker.Sources.Tool}}} = state
+         %{
+           shell_state: %{
+             modal: {:picker, %{picker_ui: %{source: MingaEditor.UI.Picker.Sources.Tool}}}
+           }
+         } = state
        ) do
     PickerUI.refresh_items(state)
   end

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -414,21 +414,28 @@ defmodule MingaEditor.Frontend.Emit.GUI do
   # ── Picker ──
 
   @spec build_gui_picker_cmd(ctx(), Caches.t()) :: {binary() | nil, Caches.t()}
-  defp build_gui_picker_cmd(%{shell_state: %{picker_ui: %{picker: nil}}}, caches) do
-    if caches.last_gui_picker_fp != :closed do
-      picker_cmd = ProtocolGUI.encode_gui_picker(nil)
-      preview_cmd = ProtocolGUI.encode_gui_picker_preview(nil)
-      {IO.iodata_to_binary([picker_cmd, preview_cmd]), %{caches | last_gui_picker_fp: :closed}}
-    else
-      {nil, caches}
+  defp build_gui_picker_cmd(ctx, caches) do
+    case ctx.shell_state.modal do
+      {:picker, %{picker_ui: %{picker: picker, source: source, action_menu: action_menu}}}
+      when picker != nil ->
+        do_build_gui_picker_cmd(ctx, picker, source, action_menu, caches)
+
+      _ ->
+        if caches.last_gui_picker_fp != :closed do
+          picker_cmd = ProtocolGUI.encode_gui_picker(nil)
+          preview_cmd = ProtocolGUI.encode_gui_picker_preview(nil)
+
+          {IO.iodata_to_binary([picker_cmd, preview_cmd]),
+           %{caches | last_gui_picker_fp: :closed}}
+        else
+          {nil, caches}
+        end
     end
   end
 
-  defp build_gui_picker_cmd(
-         %{shell_state: %{picker_ui: %{picker: picker, source: source, action_menu: action_menu}}} =
-           ctx,
-         caches
-       ) do
+  @spec do_build_gui_picker_cmd(ctx(), term(), module() | nil, term(), Caches.t()) ::
+          {binary() | nil, Caches.t()}
+  defp do_build_gui_picker_cmd(ctx, picker, source, action_menu, caches) do
     # Preview content is NOT in the fingerprint: a file changing on disk while
     # the picker is open won't refresh the preview. Acceptable trade-off for
     # scroll perf since the picker isn't open during normal editing.
@@ -450,7 +457,9 @@ defmodule MingaEditor.Frontend.Emit.GUI do
   # Build preview content for the currently selected picker item.
   # Returns a list of lines, where each line is a list of {text, fg_color, bold} segments.
   @spec build_picker_preview(ctx()) :: [[ProtocolGUI.preview_segment()]] | nil
-  defp build_picker_preview(%{shell_state: %{picker_ui: %{picker: picker}}} = ctx) do
+  defp build_picker_preview(
+         %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = ctx
+       ) do
     case Picker.selected_item(picker) do
       nil ->
         nil

--- a/lib/minga_editor/input/interrupt.ex
+++ b/lib/minga_editor/input/interrupt.ex
@@ -34,7 +34,7 @@ defmodule MingaEditor.Input.Interrupt do
   alias Minga.Editing.Completion
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
-  alias MingaEditor.State.Picker
+  alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.WhichKey
   alias MingaEditor.VimState
   alias Minga.Mode
@@ -111,11 +111,12 @@ defmodule MingaEditor.Input.Interrupt do
   end
 
   @spec maybe_close_picker(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
-  defp maybe_close_picker(%{shell_state: %{picker_ui: %Picker{picker: nil}}} = state, resets),
-    do: {state, resets}
-
   defp maybe_close_picker(state, resets) do
-    {EditorState.set_picker_ui(state, %Picker{}), ["picker closed" | resets]}
+    if ModalOverlay.match(state.shell_state.modal, :picker) do
+      {ModalOverlay.dismiss(state), ["picker closed" | resets]}
+    else
+      {state, resets}
+    end
   end
 
   @spec maybe_close_whichkey(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}

--- a/lib/minga_editor/input/picker.ex
+++ b/lib/minga_editor/input/picker.ex
@@ -14,24 +14,26 @@ defmodule MingaEditor.Input.Picker do
 
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
   alias MingaEditor.UI.Picker, as: PickerData
 
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
-  def handle_key(%{shell_state: %{picker_ui: %{picker: picker}}} = state, codepoint, modifiers)
-      when is_struct(picker, PickerData) do
-    new_state =
-      case PickerUI.handle_key(state, codepoint, modifiers) do
-        {s, {:execute_command, cmd}} -> MingaEditor.dispatch_command(s, cmd)
-        s -> s
-      end
+  def handle_key(state, codepoint, modifiers) do
+    case ModalOverlay.match(state.shell_state.modal, :picker) do
+      true ->
+        new_state =
+          case PickerUI.handle_key(state, codepoint, modifiers) do
+            {s, {:execute_command, cmd}} -> MingaEditor.dispatch_command(s, cmd)
+            s -> s
+          end
 
-    {:handled, new_state}
-  end
+        {:handled, new_state}
 
-  def handle_key(state, _cp, _mods) do
-    {:passthrough, state}
+      false ->
+        {:passthrough, state}
+    end
   end
 
   @impl true
@@ -47,7 +49,11 @@ defmodule MingaEditor.Input.Picker do
 
   # Picker active: intercept scroll and clicks
   def handle_mouse(
-        %{shell_state: %{picker_ui: %{picker: %PickerData{} = picker, source: source}}} = state,
+        %{
+          shell_state: %{
+            modal: {:picker, %{picker_ui: %{picker: %PickerData{} = picker, source: source}}}
+          }
+        } = state,
         row,
         col,
         button,
@@ -58,15 +64,16 @@ defmodule MingaEditor.Input.Picker do
     case button do
       :wheel_down ->
         new_picker = PickerData.move_down(picker)
-        {:handled, EditorState.update_picker_ui(state, &%{&1 | picker: new_picker})}
+        {:handled, PickerUI.update_picker(state, &%{&1 | picker: new_picker})}
 
       :wheel_up ->
         new_picker = PickerData.move_up(picker)
-        {:handled, EditorState.update_picker_ui(state, &%{&1 | picker: new_picker})}
+        {:handled, PickerUI.update_picker(state, &%{&1 | picker: new_picker})}
 
       :left ->
-        if state.shell_state.picker_ui.layout == :centered and
-             not inside_centered_box?(state, row, col) do
+        {:picker, %{picker_ui: %{layout: layout}}} = state.shell_state.modal
+
+        if layout == :centered and not inside_centered_box?(state, row, col) do
           {:handled, PickerUI.close(state)}
         else
           {:handled, handle_picker_click(state, picker, source, row)}
@@ -87,7 +94,7 @@ defmodule MingaEditor.Input.Picker do
   @spec handle_picker_click(EditorState.t(), PickerData.t(), module(), integer()) ::
           EditorState.t()
   defp handle_picker_click(state, picker, source, row) do
-    layout = state.shell_state.picker_ui.layout
+    {:picker, %{picker_ui: %{layout: layout}}} = state.shell_state.modal
 
     clicked_idx =
       case layout do

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -19,6 +19,8 @@ defmodule MingaEditor.PickerUI do
   alias MingaEditor.DisplayList
   alias MingaEditor.FloatingWindow
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.Picker, as: PickerState
   alias MingaEditor.State.WhichKey, as: WhichKeyState
   alias MingaEditor.UI.Picker
@@ -82,16 +84,8 @@ defmodule MingaEditor.PickerUI do
   """
   @spec open(state(), module(), map() | nil) :: state()
   def open(state, source_module, context \\ nil) do
-    # Set context before calling candidates so sources can read it.
-    state_with_ctx =
-      if context do
-        EditorState.update_picker_ui(state, &%{&1 | context: context})
-      else
-        state
-      end
-
-    # Build Context for source
-    ctx = Context.from_editor_state(state_with_ctx)
+    # Pass context directly so sources can read it from ctx.picker_ui.context.
+    ctx = Context.from_editor_state(state, context)
     items = source_module.candidates(ctx)
 
     case items do
@@ -114,14 +108,16 @@ defmodule MingaEditor.PickerUI do
 
         layout = MingaEditor.UI.Picker.Source.layout(source_module)
 
-        EditorState.set_picker_ui(new_state, %PickerState{
+        picker_state = %PickerState{
           picker: picker,
           source: source_module,
           restore: state.workspace.buffers.active_index,
           restore_theme: state.theme,
           context: context,
           layout: layout
-        })
+        }
+
+        ModalOverlay.open(new_state, :picker, PickerPayload.new(picker_state))
     end
   end
 
@@ -138,23 +134,31 @@ defmodule MingaEditor.PickerUI do
 
   # Esc or C-g in action menu → close menu, return to picker
   def handle_key(
-        %{shell_state: %{picker_ui: %{action_menu: {_actions, _sel}}}} = state,
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{action_menu: {_actions, _sel}}}}}} =
+          state,
         @escape,
         _mods
       ) do
-    EditorState.update_picker_ui(state, &%{&1 | action_menu: nil})
+    update_picker(state, &%{&1 | action_menu: nil})
   end
 
-  def handle_key(%{shell_state: %{picker_ui: %{action_menu: {_actions, _sel}}}} = state, ?g, mods)
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{action_menu: {_actions, _sel}}}}}} =
+          state,
+        ?g,
+        mods
+      )
       when band(mods, @ctrl) != 0 do
-    EditorState.update_picker_ui(state, &%{&1 | action_menu: nil})
+    update_picker(state, &%{&1 | action_menu: nil})
   end
 
   # Enter in action menu → execute selected action
   def handle_key(
         %{
           shell_state: %{
-            picker_ui: %{action_menu: {actions, sel}, picker: picker, source: source}
+            modal:
+              {:picker,
+               %{picker_ui: %{action_menu: {actions, sel}, picker: picker, source: source}}}
           }
         } = state,
         @enter,
@@ -162,38 +166,47 @@ defmodule MingaEditor.PickerUI do
       ) do
     case {Enum.at(actions, sel), Picker.selected_item(picker)} do
       {nil, _} ->
-        EditorState.update_picker_ui(state, &%{&1 | action_menu: nil})
+        update_picker(state, &%{&1 | action_menu: nil})
 
       {_, nil} ->
-        EditorState.update_picker_ui(state, &%{&1 | action_menu: nil})
+        update_picker(state, &%{&1 | action_menu: nil})
 
       {{_name, action_id}, item} ->
-        new_state = close(EditorState.update_picker_ui(state, &%{&1 | action_menu: nil}))
+        new_state = close(update_picker(state, &%{&1 | action_menu: nil}))
         source.on_action(action_id, item, new_state)
     end
   end
 
   # Arrow down / C-j / C-n in action menu → move selection down
-  def handle_key(%{shell_state: %{picker_ui: %{action_menu: {actions, sel}}}} = state, cp, mods)
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{action_menu: {actions, sel}}}}}} = state,
+        cp,
+        mods
+      )
       when (cp == ?j and band(mods, @ctrl) != 0) or
              (cp == ?n and band(mods, @ctrl) != 0) or
              cp == @arrow_down do
     new_sel = rem(sel + 1, length(actions))
-    EditorState.update_picker_ui(state, &%{&1 | action_menu: {actions, new_sel}})
+    update_picker(state, &%{&1 | action_menu: {actions, new_sel}})
   end
 
   # Arrow up / C-k / C-p in action menu → move selection up
-  def handle_key(%{shell_state: %{picker_ui: %{action_menu: {actions, sel}}}} = state, cp, mods)
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{action_menu: {actions, sel}}}}}} = state,
+        cp,
+        mods
+      )
       when (cp == ?k and band(mods, @ctrl) != 0) or
              (cp == ?p and band(mods, @ctrl) != 0) or
              cp == @arrow_up do
     new_sel = if sel == 0, do: length(actions) - 1, else: sel - 1
-    EditorState.update_picker_ui(state, &%{&1 | action_menu: {actions, new_sel}})
+    update_picker(state, &%{&1 | action_menu: {actions, new_sel}})
   end
 
   # Ignore all other keys while action menu is open
   def handle_key(
-        %{shell_state: %{picker_ui: %{action_menu: {_actions, _sel}}}} = state,
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{action_menu: {_actions, _sel}}}}}} =
+          state,
         _cp,
         _mods
       ),
@@ -201,20 +214,29 @@ defmodule MingaEditor.PickerUI do
 
   # ── Normal picker handlers ─────────────────────────────────────────────────
 
-  def handle_key(%{shell_state: %{picker_ui: %{source: source}}} = state, @escape, _mods) do
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{source: source}}}}} = state,
+        @escape,
+        _mods
+      ) do
     new_state = source.on_cancel(state)
     close(new_state)
   end
 
   # C-g → cancel (Emacs-style)
-  def handle_key(%{shell_state: %{picker_ui: %{source: source}}} = state, ?g, mods)
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{source: source}}}}} = state,
+        ?g,
+        mods
+      )
       when band(mods, @ctrl) != 0 do
     new_state = source.on_cancel(state)
     close(new_state)
   end
 
   def handle_key(
-        %{shell_state: %{picker_ui: %{picker: picker, source: source}}} = state,
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
+          state,
         @enter,
         _mods
       ) do
@@ -225,50 +247,71 @@ defmodule MingaEditor.PickerUI do
   end
 
   # C-j, C-n, or arrow down → move selection down
-  def handle_key(%{shell_state: %{picker_ui: %{picker: picker} = pui}} = state, cp, mods)
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        cp,
+        mods
+      )
       when (cp == ?j and band(mods, @ctrl) != 0) or
              (cp == ?n and band(mods, @ctrl) != 0) or
              cp == @arrow_down do
     new_picker = Picker.move_down(picker)
-    state = EditorState.set_picker_ui(state, %{pui | picker: new_picker})
+    state = update_picker(state, &%{&1 | picker: new_picker})
     maybe_preview_selection(state)
   end
 
   # C-k, C-p, or arrow up → move selection up
-  def handle_key(%{shell_state: %{picker_ui: %{picker: picker} = pui}} = state, cp, mods)
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        cp,
+        mods
+      )
       when (cp == ?k and band(mods, @ctrl) != 0) or
              (cp == ?p and band(mods, @ctrl) != 0) or
              cp == @arrow_up do
     new_picker = Picker.move_up(picker)
-    state = EditorState.set_picker_ui(state, %{pui | picker: new_picker})
+    state = update_picker(state, &%{&1 | picker: new_picker})
     maybe_preview_selection(state)
   end
 
   # C-v → page down
-  def handle_key(%{shell_state: %{picker_ui: %{picker: picker} = pui}} = state, ?v, mods)
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        ?v,
+        mods
+      )
       when band(mods, @ctrl) != 0 do
     new_picker = Picker.page_down(picker)
-    state = EditorState.set_picker_ui(state, %{pui | picker: new_picker})
+    state = update_picker(state, &%{&1 | picker: new_picker})
     maybe_preview_selection(state)
   end
 
   # M-v (Alt+v) → page up
-  def handle_key(%{shell_state: %{picker_ui: %{picker: picker} = pui}} = state, ?v, mods)
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        ?v,
+        mods
+      )
       when band(mods, @alt) != 0 do
     new_picker = Picker.page_up(picker)
-    state = EditorState.set_picker_ui(state, %{pui | picker: new_picker})
+    state = update_picker(state, &%{&1 | picker: new_picker})
     maybe_preview_selection(state)
   end
 
   # Tab → toggle multi-select mark on current item, then move down
-  def handle_key(%{shell_state: %{picker_ui: %{picker: picker} = pui}} = state, 9, _mods) do
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        9,
+        _mods
+      ) do
     new_picker = picker |> Picker.toggle_mark() |> Picker.move_down()
-    EditorState.set_picker_ui(state, %{pui | picker: new_picker})
+    update_picker(state, &%{&1 | picker: new_picker})
   end
 
   # C-o → open action menu for the selected item
   def handle_key(
-        %{shell_state: %{picker_ui: %{picker: picker, source: source}}} = state,
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
+          state,
         ?o,
         mods
       )
@@ -282,7 +325,7 @@ defmodule MingaEditor.PickerUI do
 
         case actions do
           [] -> state
-          actions -> EditorState.update_picker_ui(state, &%{&1 | action_menu: {actions, 0}})
+          actions -> update_picker(state, &%{&1 | action_menu: {actions, 0}})
         end
     end
   end
@@ -291,7 +334,9 @@ defmodule MingaEditor.PickerUI do
   def handle_key(
         %{
           shell_state: %{
-            picker_ui: %{picker: picker, mode_prefix: prefix, original_source: orig} = pui
+            modal:
+              {:picker,
+               %{picker_ui: %{picker: picker, mode_prefix: prefix, original_source: orig}}}
           }
         } = state,
         cp,
@@ -304,13 +349,17 @@ defmodule MingaEditor.PickerUI do
     if new_picker.query == "" and prefix != "" and orig != nil do
       switch_back_to_original(state)
     else
-      state = EditorState.set_picker_ui(state, %{pui | picker: new_picker})
+      state = update_picker(state, &%{&1 | picker: new_picker})
       maybe_preview_selection(state)
     end
   end
 
   # Printable characters → filter (with mode-switch detection)
-  def handle_key(%{shell_state: %{picker_ui: %{picker: picker} = pui}} = state, codepoint, 0)
+  def handle_key(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        codepoint,
+        0
+      )
       when codepoint >= 32 and codepoint <= 0x10FFFF do
     char =
       try do
@@ -331,7 +380,7 @@ defmodule MingaEditor.PickerUI do
 
           :no_switch ->
             new_picker = Picker.type_char(picker, c)
-            state = EditorState.set_picker_ui(state, %{pui | picker: new_picker})
+            state = update_picker(state, &%{&1 | picker: new_picker})
             maybe_preview_selection(state)
         end
     end
@@ -515,8 +564,14 @@ defmodule MingaEditor.PickerUI do
   @spec render(state(), term()) ::
           {[DisplayList.draw()], {non_neg_integer(), non_neg_integer()} | nil}
   def render(state, viewport) do
+    picker_state =
+      case state.shell_state.modal do
+        {:picker, %{picker_ui: pui}} -> pui
+        _ -> %PickerState{}
+      end
+
     input = %RenderInput{
-      picker_state: state.shell_state.picker_ui,
+      picker_state: picker_state,
       theme_picker: state.theme.picker,
       viewport: viewport
     }
@@ -527,7 +582,7 @@ defmodule MingaEditor.PickerUI do
   @doc "Closes the picker and resets picker-related state."
   @spec close(state()) :: state()
   def close(state) do
-    EditorState.set_picker_ui(state, %PickerState{})
+    ModalOverlay.dismiss(state)
   end
 
   @doc """
@@ -536,9 +591,13 @@ defmodule MingaEditor.PickerUI do
   to update item status after an action.
   """
   @spec refresh_items(state()) :: state()
-  def refresh_items(%{shell_state: %{picker_ui: %{picker: nil}}} = state), do: state
+  def refresh_items(%{shell_state: %{modal: {:picker, %{picker_ui: %{picker: nil}}}}} = state),
+    do: state
 
-  def refresh_items(%{shell_state: %{picker_ui: %{picker: picker, source: source} = pui}} = state) do
+  def refresh_items(
+        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
+          state
+      ) do
     ctx = Context.from_editor_state(state)
     items = source.candidates(ctx)
     refreshed = %{picker | items: items}
@@ -548,7 +607,22 @@ defmodule MingaEditor.PickerUI do
     max_sel = max(length(refreshed.filtered) - 1, 0)
     refreshed = %{refreshed | selected: min(picker.selected, max_sel)}
 
-    EditorState.set_picker_ui(state, %{pui | picker: refreshed})
+    update_picker(state, &%{&1 | picker: refreshed})
+  end
+
+  @doc """
+  Applies `fun` to the current PickerState inside the modal and writes back
+  via ModalOverlay.transition, keeping the modal sum type and consistency
+  check in sync.
+
+  Public so that `Input.Picker` (mouse handler) can update scroll position
+  without going through the full key-handling path.
+  """
+  @spec update_picker(state(), (PickerState.t() -> PickerState.t())) :: state()
+  def update_picker(state, fun) do
+    {:picker, payload} = state.shell_state.modal
+    new_pui = fun.(payload.picker_ui)
+    ModalOverlay.transition(state, :picker, %{payload | picker_ui: new_pui})
   end
 
   # ── Centered (floating) layout ───────────────────────────────────────────────
@@ -746,7 +820,11 @@ defmodule MingaEditor.PickerUI do
   # Only triggers on the first character in an empty query, for switchable sources.
   @spec maybe_switch_mode(state(), String.t(), String.t()) ::
           {:switched, state()} | :no_switch
-  defp maybe_switch_mode(%{shell_state: %{picker_ui: %{source: source}}} = state, char, query) do
+  defp maybe_switch_mode(
+         %{shell_state: %{modal: {:picker, %{picker_ui: %{source: source}}}}} = state,
+         char,
+         query
+       ) do
     if query == "" and source in @switchable_sources and Map.has_key?(@mode_prefixes, char) do
       target_source = Map.fetch!(@mode_prefixes, char)
       {:switched, switch_to_source(state, target_source, char)}
@@ -758,7 +836,11 @@ defmodule MingaEditor.PickerUI do
   # Switch the picker to a new source module, preserving the original source for switch-back.
   @spec switch_to_source(state(), module(), String.t()) :: state()
   defp switch_to_source(
-         %{shell_state: %{picker_ui: %{source: current_source} = pui}} = state,
+         %{
+           shell_state: %{
+             modal: {:picker, %{picker_ui: %{source: current_source, original_source: orig_src}}}
+           }
+         } = state,
          new_source,
          prefix
        ) do
@@ -768,23 +850,25 @@ defmodule MingaEditor.PickerUI do
     max_vis = max(5, min(max_vis, state.workspace.viewport.rows - 3))
     picker = Picker.new(items, title: new_source.title(), max_visible: max_vis)
     layout = MingaEditor.UI.Picker.Source.layout(new_source)
+    original = orig_src || current_source
 
-    original = pui.original_source || current_source
-
-    EditorState.set_picker_ui(state, %{
-      pui
-      | picker: picker,
-        source: new_source,
-        layout: layout,
-        original_source: original,
-        mode_prefix: prefix
-    })
+    update_picker(
+      state,
+      &%{
+        &1
+        | picker: picker,
+          source: new_source,
+          layout: layout,
+          original_source: original,
+          mode_prefix: prefix
+      }
+    )
   end
 
   # Switch back to the original source after the prefix is deleted.
   @spec switch_back_to_original(state()) :: state()
   defp switch_back_to_original(
-         %{shell_state: %{picker_ui: %{original_source: orig} = pui}} = state
+         %{shell_state: %{modal: {:picker, %{picker_ui: %{original_source: orig}}}}} = state
        ) do
     ctx = Context.from_editor_state(state)
     items = orig.candidates(ctx)
@@ -793,14 +877,17 @@ defmodule MingaEditor.PickerUI do
     picker = Picker.new(items, title: orig.title(), max_visible: max_vis)
     layout = MingaEditor.UI.Picker.Source.layout(orig)
 
-    EditorState.set_picker_ui(state, %{
-      pui
-      | picker: picker,
-        source: orig,
-        layout: layout,
-        original_source: nil,
-        mode_prefix: ""
-    })
+    update_picker(
+      state,
+      &%{
+        &1
+        | picker: picker,
+          source: orig,
+          layout: layout,
+          original_source: nil,
+          mode_prefix: ""
+      }
+    )
   end
 
   # ── Private helpers ──────────────────────────────────────────────────────────
@@ -810,7 +897,10 @@ defmodule MingaEditor.PickerUI do
   # Returns true when preview navigation changed the active buffer from
   # what it was when the picker opened (stored in picker_ui.restore).
   @spec previewed?(state()) :: boolean()
-  defp previewed?(%{shell_state: %{picker_ui: %{restore: restore}}, workspace: %{buffers: bs}})
+  defp previewed?(%{
+         shell_state: %{modal: {:picker, %{picker_ui: %{restore: restore}}}},
+         workspace: %{buffers: bs}
+       })
        when is_integer(restore) do
     bs.active_index != restore
   end
@@ -820,7 +910,8 @@ defmodule MingaEditor.PickerUI do
   # on_select update the current tab in-place instead of creating a new tab.
   @spec maybe_preview_selection(state()) :: state()
   defp maybe_preview_selection(
-         %{shell_state: %{picker_ui: %{picker: picker, source: source}}} = state
+         %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
+           state
        ) do
     if Picker.Source.preview?(source) do
       case Picker.selected_item(picker) do

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -77,14 +77,16 @@ defmodule MingaEditor.PickerUI do
   @doc """
   Opens the picker for the given source module.
 
-  An optional context map can be passed and will be stored in
-  `state.picker_ui.context` for the source's `on_select` callback
-  to read. Used by `OptionScopeSource` to pass the option name and
-  new value through the picker flow.
+  An optional context map can be passed; it is threaded into the
+  `Context` struct passed to `candidates/1` so sources can use it to
+  build items. Sources that need the context inside `on_select/2` must
+  embed it in each `Item.id` at candidate-build time, because the picker
+  is closed (modal reset to `:none`) before `on_select/2` runs. See
+  `OptionScopeSource` for the canonical pattern.
   """
   @spec open(state(), module(), map() | nil) :: state()
   def open(state, source_module, context \\ nil) do
-    # Pass context directly so sources can read it from ctx.picker_ui.context.
+    # Context flows into Context.from_editor_state so candidates/1 can read it.
     ctx = Context.from_editor_state(state, context)
     items = source_module.candidates(ctx)
 
@@ -622,7 +624,7 @@ defmodule MingaEditor.PickerUI do
   def update_picker(state, fun) do
     {:picker, payload} = state.shell_state.modal
     new_pui = fun.(payload.picker_ui)
-    ModalOverlay.transition(state, :picker, %{payload | picker_ui: new_pui})
+    ModalOverlay.transition(state, :picker, PickerPayload.put_picker_ui(payload, new_pui))
   end
 
   # ── Centered (floating) layout ───────────────────────────────────────────────
@@ -895,7 +897,7 @@ defmodule MingaEditor.PickerUI do
   # Preview: temporarily apply the source's on_select for the highlighted item.
   # Sets buffer_add_context to :preview so any add_buffer calls inside
   # Returns true when preview navigation changed the active buffer from
-  # what it was when the picker opened (stored in picker_ui.restore).
+  # what it was when the picker opened (stored in the picker payload's `restore` field).
   @spec previewed?(state()) :: boolean()
   defp previewed?(%{
          shell_state: %{modal: {:picker, %{picker_ui: %{restore: restore}}}},

--- a/lib/minga_editor/prompt_ui.ex
+++ b/lib/minga_editor/prompt_ui.ex
@@ -20,7 +20,7 @@ defmodule MingaEditor.PromptUI do
   """
 
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.State.Picker, as: PickerState
+  alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.Prompt, as: PromptState
 
   @escape 27
@@ -173,10 +173,13 @@ defmodule MingaEditor.PromptUI do
   # ── Private ────────────────────────────────────────────────────────────────
 
   @spec maybe_close_picker(state()) :: state()
-  defp maybe_close_picker(%{shell_state: %{picker_ui: %PickerState{picker: nil}}} = state),
-    do: state
-
-  defp maybe_close_picker(state), do: EditorState.set_picker_ui(state, %PickerState{})
+  defp maybe_close_picker(state) do
+    if ModalOverlay.match(state.shell_state.modal, :picker) do
+      ModalOverlay.dismiss(state)
+    else
+      state
+    end
+  end
 
   @spec do_backspace(state(), PromptState.t()) :: state()
   defp do_backspace(state, %{cursor: 0} = _prompt), do: state

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -201,8 +201,8 @@ defmodule MingaEditor.RenderPipeline.Input do
       input.shell_state |> Map.get(:signature_help),
       # Which-key popup
       input.shell_state |> Map.get(:whichkey),
-      # Picker UI
-      input.shell_state |> Map.get(:picker_ui),
+      # Picker overlay (read from the modal sum type)
+      input.shell_state |> Map.get(:modal),
       # Prompt UI
       input.shell_state |> Map.get(:prompt_ui),
       # Agent state (status, pending approval)

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -201,9 +201,11 @@ defmodule MingaEditor.RenderPipeline.Input do
       input.shell_state |> Map.get(:signature_help),
       # Which-key popup
       input.shell_state |> Map.get(:whichkey),
-      # Picker overlay (read from the modal sum type)
+      # Modal overlay (sum type covering picker, completion, conflict,
+      # dashboard; prompt is still mirrored to :prompt_ui below until its
+      # migration lands)
       input.shell_state |> Map.get(:modal),
-      # Prompt UI
+      # Prompt UI (legacy mirror; still read for invalidation parity)
       input.shell_state |> Map.get(:prompt_ui),
       # Agent state (status, pending approval)
       input.shell_state |> Map.get(:agent),

--- a/lib/minga_editor/shell/board/state.ex
+++ b/lib/minga_editor/shell/board/state.ex
@@ -36,7 +36,6 @@ defmodule MingaEditor.Shell.Board.State do
           # transitioning between shells or when the render pipeline runs
           # before the Board-specific renderer takes over.
           whichkey: MingaEditor.State.WhichKey.t(),
-          picker_ui: MingaEditor.State.Picker.t(),
           prompt_ui: MingaEditor.State.Prompt.t(),
           status_msg: String.t() | nil,
           dashboard: nil,
@@ -65,7 +64,6 @@ defmodule MingaEditor.Shell.Board.State do
             next_id: 1,
             # Compatibility fields (see type doc above)
             whichkey: %MingaEditor.State.WhichKey{},
-            picker_ui: %MingaEditor.State.Picker{},
             prompt_ui: %MingaEditor.State.Prompt{},
             status_msg: nil,
             dashboard: nil,

--- a/lib/minga_editor/shell/traditional/state.ex
+++ b/lib/minga_editor/shell/traditional/state.ex
@@ -18,7 +18,6 @@ defmodule MingaEditor.Shell.Traditional.State do
   alias MingaEditor.NavFlash
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.ModalOverlay
-  alias MingaEditor.State.Picker
   alias MingaEditor.State.Prompt
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.WhichKey
@@ -29,7 +28,6 @@ defmodule MingaEditor.Shell.Traditional.State do
           hover_popup: HoverPopup.t() | nil,
           dashboard: Dashboard.state() | nil,
           status_msg: String.t() | nil,
-          picker_ui: Picker.t(),
           prompt_ui: Prompt.t(),
           whichkey: WhichKey.t(),
           bottom_panel: BottomPanel.t(),
@@ -50,7 +48,6 @@ defmodule MingaEditor.Shell.Traditional.State do
             hover_popup: nil,
             dashboard: nil,
             status_msg: nil,
-            picker_ui: %Picker{},
             prompt_ui: %Prompt{},
             whichkey: %WhichKey{},
             bottom_panel: %BottomPanel{},
@@ -136,24 +133,6 @@ defmodule MingaEditor.Shell.Traditional.State do
   @spec close_dashboard(t()) :: t()
   def close_dashboard(%{} = ss) do
     %{ss | dashboard: nil}
-  end
-
-  # ── Picker UI ──────────────────────────────────────────────────────────────
-
-  @doc "Returns the picker UI state."
-  @spec picker_ui(t()) :: Picker.t()
-  def picker_ui(%{picker_ui: pui}), do: pui
-
-  @doc "Replaces the picker UI state."
-  @spec set_picker_ui(t(), Picker.t()) :: t()
-  def set_picker_ui(%{} = ss, pui) do
-    %{ss | picker_ui: pui}
-  end
-
-  @doc "Applies a function to the picker UI state."
-  @spec update_picker_ui(t(), (Picker.t() -> Picker.t())) :: t()
-  def update_picker_ui(%{picker_ui: pui} = ss, fun) when is_function(fun, 1) do
-    %{ss | picker_ui: fun.(pui)}
   end
 
   # ── Prompt UI ──────────────────────────────────────────────────────────────

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -18,13 +18,12 @@ defmodule MingaEditor.State do
   **Global fields** are shared across all tabs and never snapshotted:
   `port_manager`, `theme`, `render_timer`, `focus_stack`,
   `tab_bar`, `capabilities`, `layout`, `modeline_click_regions`,
-  `tab_bar_click_regions`, `agent`, `picker_ui`, `whichkey`.
+  `tab_bar_click_regions`, `agent`, `whichkey`.
 
   ## Composed sub-structs
 
   * `MingaEditor.Workspace.State`           — per-tab editing context (buffers, windows, vim, etc.)
   * `MingaEditor.Shell.Traditional.State`   — presentation state (nav_flash, hover, dashboard, etc.)
-  * `MingaEditor.State.Picker`       — picker instance, source, restore index
   * `MingaEditor.State.WhichKey`     — which-key popup node, timer, visibility
   * `MingaEditor.State.Registers`    — named registers and active register selection
   """
@@ -44,7 +43,6 @@ defmodule MingaEditor.State do
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Highlighting
   alias MingaEditor.State.Mouse
-  alias MingaEditor.State.Picker
   alias MingaEditor.State.Prompt
   alias MingaEditor.State.Registers
   alias MingaEditor.State.Search
@@ -210,13 +208,6 @@ defmodule MingaEditor.State do
   def set_dashboard(s, dash), do: update_shell_state(s, &ShellState.set_dashboard(&1, dash))
   @spec close_dashboard(t()) :: t()
   def close_dashboard(s), do: update_shell_state(s, &ShellState.close_dashboard/1)
-
-  @spec picker_ui(t()) :: Picker.t()
-  def picker_ui(%{shell_state: ss}), do: ShellState.picker_ui(ss)
-  @spec set_picker_ui(t(), Picker.t()) :: t()
-  def set_picker_ui(s, pui), do: update_shell_state(s, &ShellState.set_picker_ui(&1, pui))
-  @spec update_picker_ui(t(), (Picker.t() -> Picker.t())) :: t()
-  def update_picker_ui(s, fun), do: update_shell_state(s, &ShellState.update_picker_ui(&1, fun))
 
   @spec prompt_ui(t()) :: Prompt.t()
   def prompt_ui(%{shell_state: ss}), do: ShellState.prompt_ui(ss)

--- a/lib/minga_editor/state/modal_overlay.ex
+++ b/lib/minga_editor/state/modal_overlay.ex
@@ -20,27 +20,28 @@ defmodule MingaEditor.State.ModalOverlay do
 
   ## Migration phase: dual-write
 
-  This is step 1 of 5 (Epic #1421). The new `:modal` field has been
-  added to `Shell.Traditional.State` and `Shell.Board.State` but no
-  callers read it yet. To keep the migration safe, every gate function
-  here writes both:
+  This is step 2 of 5 (Epic #1421). The picker variant (#1424) has been
+  fully migrated — all reads and writes go through this gate, and
+  `picker_ui` has been removed from `Shell.Traditional.State`.
 
-  * `state.shell_state.modal` — the new sum-type field
-  * The variant's legacy field — `picker_ui`, `prompt_ui`, `dashboard`,
-    `workspace.completion`, or `workspace.pending_conflict`
+  The remaining variants still use dual-write: every gate function writes
+  both `state.shell_state.modal` and the variant's legacy field so that
+  existing readers continue to work during the migration:
 
-  Variant-by-variant migrations (#1424-#1426) point reads at the new
-  field one variant at a time. When all variants have migrated, #1427
-  removes the dual-write and adds a Credo rule that forbids direct
-  writes to the legacy fields.
+  * `prompt_ui` — legacy mirror for the `:prompt` variant
+  * `dashboard` — legacy mirror for the `:dashboard` variant
+  * `workspace.completion` — legacy mirror for `:completion`
+  * `workspace.pending_conflict` — legacy mirror for `:conflict`
 
-  Until then, **do not mutate `:modal` directly**: always call this
-  module's `open/3`, `transition/3`, `close/1`, or `dismiss/1`. Direct
-  mutation of the legacy fields is still permitted (existing call
-  sites have not been migrated), but a runtime assertion in `:dev` and
-  `:test` builds crashes when the gate detects that its tracked variant
-  has diverged from the legacy mirror. That surfaces stray writes in CI
-  rather than letting them drift silently.
+  Migrations #1425-#1426 point reads at the new field one variant at a
+  time. When all variants have migrated, #1427 removes the remaining
+  dual-writes and adds a Credo rule that forbids direct writes to the
+  legacy fields.
+
+  **Do not mutate `:modal` directly**: always call this module's
+  `open/3`, `transition/3`, `close/1`, or `dismiss/1`. A runtime
+  assertion in `:dev` and `:test` builds crashes when the gate detects
+  that its tracked variant has diverged from the legacy mirror.
 
   ## Replacement policy
 
@@ -62,7 +63,6 @@ defmodule MingaEditor.State.ModalOverlay do
   alias MingaEditor.State.ModalOverlay.Dashboard, as: DashboardPayload
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.ModalOverlay.Prompt, as: PromptPayload
-  alias MingaEditor.State.Picker, as: PickerLegacy
   alias MingaEditor.State.Prompt, as: PromptLegacy
   alias MingaEditor.Workspace.State, as: WorkspaceState
 
@@ -234,7 +234,8 @@ defmodule MingaEditor.State.ModalOverlay do
         state
 
       {:picker, _} ->
-        EditorState.set_picker_ui(state, %PickerLegacy{})
+        # Picker has no legacy field — it was removed in #1424.
+        state
 
       {:prompt, _} ->
         EditorState.set_prompt_ui(state, %PromptLegacy{})
@@ -251,10 +252,9 @@ defmodule MingaEditor.State.ModalOverlay do
   end
 
   # Writes the payload's underlying state to the variant's legacy slot.
+  # The picker variant has no legacy field (#1424 removed it).
   @spec mirror_to_legacy(EditorState.t(), {variant(), payload()}) :: EditorState.t()
-  defp mirror_to_legacy(state, {:picker, %PickerPayload{picker_ui: pui}}) do
-    EditorState.set_picker_ui(state, pui)
-  end
+  defp mirror_to_legacy(state, {:picker, %PickerPayload{}}), do: state
 
   defp mirror_to_legacy(state, {:prompt, %PromptPayload{prompt_ui: pui}}) do
     EditorState.set_prompt_ui(state, pui)
@@ -305,8 +305,8 @@ defmodule MingaEditor.State.ModalOverlay do
         :none ->
           :ok
 
-        {:picker, %PickerPayload{picker_ui: pui}} ->
-          if ss.picker_ui != pui, do: raise_divergence!(:picker, pui, ss.picker_ui)
+        # Picker has no legacy field (#1424 removed it): no consistency check needed.
+        {:picker, %PickerPayload{}} ->
           :ok
 
         {:prompt, %PromptPayload{prompt_ui: pu}} ->

--- a/lib/minga_editor/state/modal_overlay/picker.ex
+++ b/lib/minga_editor/state/modal_overlay/picker.ex
@@ -39,4 +39,14 @@ defmodule MingaEditor.State.ModalOverlay.Picker do
       opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
     }
   end
+
+  @doc """
+  Replaces the inner `picker_ui` state on the payload, preserving `owner`
+  and `opened_at`. This is the only sanctioned way to update the inner
+  state from outside this module (Rule 2: state ownership).
+  """
+  @spec put_picker_ui(t(), PickerState.t()) :: t()
+  def put_picker_ui(%__MODULE__{} = payload, %PickerState{} = picker_ui) do
+    %{payload | picker_ui: picker_ui}
+  end
 end

--- a/lib/minga_editor/ui/picker/context.ex
+++ b/lib/minga_editor/ui/picker/context.ex
@@ -23,6 +23,7 @@ defmodule MingaEditor.UI.Picker.Context do
 
   alias MingaEditor.State
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Picker, as: PickerState
   alias MingaEditor.State.Search
   alias MingaEditor.State.TabBar
   alias MingaEditor.Viewport
@@ -69,10 +70,15 @@ defmodule MingaEditor.UI.Picker.Context do
 
   @doc """
   Builds a picker context from the full editor state.
+
+  The optional `extra_context` is stored in `picker_ui.context` so that
+  sources invoked from `PickerUI.open/3` can read it before the picker
+  modal has been opened (i.e. when `shell_state.modal` is still `:none`).
   """
-  @spec from_editor_state(State.t()) :: t()
-  def from_editor_state(%State{} = state) do
+  @spec from_editor_state(State.t(), map() | nil) :: t()
+  def from_editor_state(%State{} = state, extra_context \\ nil) do
     agent_session = MingaEditor.State.AgentAccess.session(state)
+    picker_ui = picker_ui_from_modal(state, extra_context)
 
     %__MODULE__{
       buffers: state.workspace.buffers,
@@ -82,9 +88,20 @@ defmodule MingaEditor.UI.Picker.Context do
       viewport: state.workspace.viewport,
       tab_bar: state.shell_state.tab_bar,
       agent_session: agent_session,
-      picker_ui: state.shell_state.picker_ui,
+      picker_ui: picker_ui,
       capabilities: state.capabilities,
       theme: state.theme
     }
+  end
+
+  @spec picker_ui_from_modal(State.t(), map() | nil) :: PickerState.t()
+  defp picker_ui_from_modal(state, extra_context) do
+    base =
+      case state.shell_state.modal do
+        {:picker, %{picker_ui: pui}} -> pui
+        _ -> %PickerState{}
+      end
+
+    if extra_context, do: %{base | context: extra_context}, else: base
   end
 end

--- a/lib/minga_editor/ui/picker/option_scope_source.ex
+++ b/lib/minga_editor/ui/picker/option_scope_source.ex
@@ -7,7 +7,7 @@ defmodule MingaEditor.UI.Picker.OptionScopeSource do
   buffer's local options) and "All Buffers (Default)" (writes to the
   global Options agent, affecting all buffers without a local override).
 
-  The picker context (stored in `state.shell_state.picker_ui.context`) must include:
+  The picker context (stored in the picker payload's `context` field) must include:
 
   * `:option_name` — the option atom
   * `:new_value` — the computed new value
@@ -28,21 +28,26 @@ defmodule MingaEditor.UI.Picker.OptionScopeSource do
 
   @impl true
   @spec candidates(Context.t()) :: [Item.t()]
-  def candidates(_ctx) do
+  def candidates(%Context{picker_ui: %{context: ctx}}) when is_map(ctx) do
     [
-      %Item{id: :buffer, label: "This Buffer", description: "Set for the current buffer only"},
       %Item{
-        id: :global,
+        id: {:buffer, ctx},
+        label: "This Buffer",
+        description: "Set for the current buffer only"
+      },
+      %Item{
+        id: {:global, ctx},
         label: "All Buffers (Default)",
         description: "Set the default for all buffers without a local override"
       }
     ]
   end
 
+  def candidates(_ctx), do: []
+
   @impl true
   @spec on_select(Item.t(), term()) :: term()
-  def on_select(%Item{id: scope}, state) when scope in [:buffer, :global] do
-    ctx = state.shell_state.picker_ui.context
+  def on_select(%Item{id: {scope, ctx}}, state) when scope in [:buffer, :global] do
     apply_scoped(scope, ctx.option_name, ctx.new_value, state)
   end
 

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -43,7 +43,14 @@ defmodule MingaEditor.UI.Picker.Source do
   @doc "Returns the list of candidates to display in the picker."
   @callback candidates(Context.t()) :: [Picker.item()]
 
-  @doc "Called when the user selects an item. Returns the new editor state."
+  @doc """
+  Called when the user selects an item. Returns the new editor state.
+
+  Important: this callback runs *after* the picker has been closed
+  (`state.shell_state.modal` has been reset to `:none`). Any context the
+  callback needs must travel with the `Picker.item()` (typically embedded
+  in `Item.id`). Reading `state.shell_state.modal` here will see `:none`.
+  """
   @callback on_select(Picker.item(), state :: term()) :: term()
 
   @doc "Called when the user cancels the picker. Returns the new editor state."
@@ -64,6 +71,10 @@ defmodule MingaEditor.UI.Picker.Source do
   @doc """
   Executes an alternative action on a picker item.
   Called when the user selects an action from the C-o menu.
+
+  Like `on_select/2`, this runs *after* the picker has been closed. Any
+  context required must travel with the `Picker.item()`; do not read
+  `state.shell_state.modal` here.
   """
   @callback on_action(atom(), Picker.item(), state :: term()) :: term()
 

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -89,16 +89,19 @@ defmodule MingaEditor.UI.Picker.Source do
 
   @doc """
   Default `on_cancel` implementation: restores the buffer that was active
-  when the picker opened (stored in `picker_ui.restore`), or returns state
-  unchanged if no restore index was saved.
+  when the picker opened (stored in the picker payload's `restore` field),
+  or returns state unchanged if no restore index was saved.
   """
   @spec restore_or_keep(term()) :: term()
-  def restore_or_keep(%{shell_state: %{picker_ui: %{restore: idx}}} = state)
-      when is_integer(idx) do
-    EditorState.switch_buffer(state, idx)
-  end
+  def restore_or_keep(state) do
+    case state.shell_state.modal do
+      {:picker, %{picker_ui: %{restore: idx}}} when is_integer(idx) ->
+        EditorState.switch_buffer(state, idx)
 
-  def restore_or_keep(state), do: state
+      _ ->
+        state
+    end
+  end
 
   @doc """
   Returns whether a source module supports preview.

--- a/lib/minga_editor/ui/picker/theme_source.ex
+++ b/lib/minga_editor/ui/picker/theme_source.ex
@@ -40,11 +40,12 @@ defmodule MingaEditor.UI.Picker.ThemeSource do
 
   @impl true
   @spec on_cancel(term()) :: term()
-  def on_cancel(%{shell_state: %{picker_ui: %{restore_theme: %Theme{} = theme}}} = state) do
-    %{state | theme: theme}
+  def on_cancel(state) do
+    case state.shell_state.modal do
+      {:picker, %{picker_ui: %{restore_theme: %Theme{} = theme}}} -> %{state | theme: theme}
+      _ -> state
+    end
   end
-
-  def on_cancel(state), do: state
 
   # ── Private ─────────────────────────────────────────────────────────────────
 

--- a/test/minga_editor/dashboard_test.exs
+++ b/test/minga_editor/dashboard_test.exs
@@ -5,6 +5,8 @@ defmodule MingaEditor.DashboardTest do
   alias MingaEditor.Renderer
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.Picker, as: PickerState
   alias MingaEditor.Viewport
   alias MingaEditor.UI.Picker
@@ -184,7 +186,12 @@ defmodule MingaEditor.DashboardTest do
         focus_stack: MingaEditor.Input.default_stack(),
         shell_state: %MingaEditor.Shell.Traditional.State{
           dashboard: Dashboard.new_state(),
-          picker_ui: %PickerState{picker: picker, source: MingaEditor.UI.Picker.FileSource}
+          modal:
+            {:picker,
+             PickerPayload.new(%PickerState{
+               picker: picker,
+               source: MingaEditor.UI.Picker.FileSource
+             })}
         },
         theme: MingaEditor.UI.Theme.get!(:doom_one)
       }
@@ -202,7 +209,7 @@ defmodule MingaEditor.DashboardTest do
       assert commands != []
 
       # Re-render without the picker to compare command counts
-      bare_state = MingaEditor.State.set_picker_ui(state, %PickerState{})
+      bare_state = ModalOverlay.dismiss(state)
       _new_bare = Renderer.render(bare_state)
       assert_receive {:"$gen_cast", {:send_commands, bare_commands}}
 

--- a/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
+++ b/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
@@ -10,6 +10,8 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.Renderer.Caches
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.StatusBar.Data, as: StatusBarData
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.Frontend.Emit.GUI, as: EmitGUI
@@ -165,8 +167,8 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
       picker = MingaEditor.UI.Picker.new([item], title: "Test")
       state = gui_state()
 
-      picker_ui = %{state.shell_state.picker_ui | picker: picker, source: nil, action_menu: nil}
-      state = MingaEditor.State.set_picker_ui(state, picker_ui)
+      picker_state = %MingaEditor.State.Picker{picker: picker, source: nil, action_menu: nil}
+      state = ModalOverlay.open(state, :picker, PickerPayload.new(picker_state))
       sb_data = StatusBarData.from_state(state)
 
       {_ctx, caches} =

--- a/test/minga_editor/input/interrupt_test.exs
+++ b/test/minga_editor/input/interrupt_test.exs
@@ -5,6 +5,8 @@ defmodule MingaEditor.Input.InterruptTest do
   alias Minga.Editing.Completion
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.Picker
   alias MingaEditor.State.WhichKey
   alias MingaEditor.Viewport
@@ -55,7 +57,7 @@ defmodule MingaEditor.Input.InterruptTest do
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
       assert new_state.workspace.keymap_scope == :editor
       assert new_state.workspace.editing.mode == :normal
-      assert new_state.shell_state.picker_ui.picker == nil
+      assert new_state.shell_state.modal == :none
       assert new_state.shell_state.whichkey.node == nil
     end
   end
@@ -150,10 +152,12 @@ defmodule MingaEditor.Input.InterruptTest do
     test "closes open picker" do
       state = base_state()
       picker = MingaEditor.UI.Picker.new(["a", "b", "c"])
-      state = MingaEditor.State.set_picker_ui(state, %Picker{picker: picker, source: nil})
+
+      state =
+        ModalOverlay.open(state, :picker, PickerPayload.new(%Picker{picker: picker, source: nil}))
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
-      assert new_state.shell_state.picker_ui.picker == nil
+      assert new_state.shell_state.modal == :none
     end
 
     test "dismisses which-key popup" do
@@ -211,14 +215,14 @@ defmodule MingaEditor.Input.InterruptTest do
           }
       }
 
-      state = MingaEditor.State.set_picker_ui(state, %Picker{picker: picker})
+      state = ModalOverlay.open(state, :picker, PickerPayload.new(%Picker{picker: picker}))
       state = MingaEditor.State.set_whichkey(state, %WhichKey{node: %{}, show: true})
       state = MingaEditor.State.set_status(state, "hello")
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
       assert new_state.workspace.keymap_scope == :editor
       assert new_state.workspace.editing.mode == :normal
-      assert new_state.shell_state.picker_ui.picker == nil
+      assert new_state.shell_state.modal == :none
       assert new_state.shell_state.whichkey.node == nil
       assert new_state.shell_state.whichkey.show == false
       assert new_state.workspace.pending_conflict == nil

--- a/test/minga_editor/input/picker_mouse_test.exs
+++ b/test/minga_editor/input/picker_mouse_test.exs
@@ -3,6 +3,8 @@ defmodule MingaEditor.Input.PickerMouseTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
   alias MingaEditor.Input.Picker, as: PickerInput
@@ -33,7 +35,9 @@ defmodule MingaEditor.Input.PickerMouseTest do
         viewport: Viewport.new(30, 80)
       },
       shell_state: %MingaEditor.Shell.Traditional.State{
-        picker_ui: %MingaEditor.State.Picker{picker: picker, source: TestSource}
+        modal:
+          {:picker,
+           PickerPayload.new(%MingaEditor.State.Picker{picker: picker, source: TestSource})}
       }
     }
   end
@@ -42,7 +46,8 @@ defmodule MingaEditor.Input.PickerMouseTest do
     test "wheel_down moves picker selection down" do
       state = picker_state([%{id: 1, label: "one"}, %{id: 2, label: "two"}])
       {:handled, new_state} = PickerInput.handle_mouse(state, 10, 10, :wheel_down, 0, :press, 1)
-      assert new_state.shell_state.picker_ui.picker.selected == 1
+      {:picker, %{picker_ui: %{picker: pui}}} = new_state.shell_state.modal
+      assert pui.selected == 1
     end
 
     test "wheel_up moves picker selection up" do
@@ -50,7 +55,8 @@ defmodule MingaEditor.Input.PickerMouseTest do
       # Move down first, then up
       {:handled, state} = PickerInput.handle_mouse(state, 10, 10, :wheel_down, 0, :press, 1)
       {:handled, new_state} = PickerInput.handle_mouse(state, 10, 10, :wheel_up, 0, :press, 1)
-      assert new_state.shell_state.picker_ui.picker.selected == 0
+      {:picker, %{picker_ui: %{picker: pui}}} = new_state.shell_state.modal
+      assert pui.selected == 0
     end
   end
 
@@ -64,7 +70,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       {:handled, new_state} = PickerInput.handle_mouse(state, 26, 10, :left, 0, :press, 1)
 
       # Picker should be closed
-      assert new_state.shell_state.picker_ui.picker == nil
+      assert new_state.shell_state.modal == :none
       # Source's on_select should have been called
       assert Map.has_key?(new_state, :selected_item)
     end
@@ -76,7 +82,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       # Click on row 0 (well above the picker)
       {:handled, new_state} = PickerInput.handle_mouse(state, 0, 10, :left, 0, :press, 1)
       # Picker should still be open
-      assert new_state.shell_state.picker_ui.picker != nil
+      assert ModalOverlay.match(new_state.shell_state.modal, :picker)
     end
   end
 
@@ -92,11 +98,13 @@ defmodule MingaEditor.Input.PickerMouseTest do
           viewport: Viewport.new(24, 80)
         },
         shell_state: %MingaEditor.Shell.Traditional.State{
-          picker_ui: %MingaEditor.State.Picker{
-            picker: picker,
-            source: TestSource,
-            layout: :centered
-          }
+          modal:
+            {:picker,
+             PickerPayload.new(%MingaEditor.State.Picker{
+               picker: picker,
+               source: TestSource,
+               layout: :centered
+             })}
         }
       }
     end
@@ -110,7 +118,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       # First item is at interior row 0 = screen row 5
       {:handled, new_state} = PickerInput.handle_mouse(state, 5, 20, :left, 0, :press, 1)
 
-      assert new_state.shell_state.picker_ui.picker == nil
+      assert new_state.shell_state.modal == :none
       assert Map.has_key?(new_state, :selected_item)
     end
 
@@ -122,7 +130,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       {:handled, new_state} = PickerInput.handle_mouse(state, 0, 0, :left, 0, :press, 1)
 
       # Picker should be closed (dismissed), no item selected
-      assert new_state.shell_state.picker_ui.picker == nil
+      assert new_state.shell_state.modal == :none
       refute Map.has_key?(new_state, :selected_item)
     end
 
@@ -133,7 +141,8 @@ defmodule MingaEditor.Input.PickerMouseTest do
       {:handled, new_state} =
         PickerInput.handle_mouse(state, 10, 20, :wheel_down, 0, :press, 1)
 
-      assert new_state.shell_state.picker_ui.picker.selected == 1
+      {:picker, %{picker_ui: %{picker: pui}}} = new_state.shell_state.modal
+      assert pui.selected == 1
     end
   end
 

--- a/test/minga_editor/input/prompt_test.exs
+++ b/test/minga_editor/input/prompt_test.exs
@@ -22,8 +22,7 @@ defmodule MingaEditor.Input.PromptTest do
 
     %{
       shell_state: %MingaEditor.Shell.Traditional.State{
-        prompt_ui: prompt,
-        picker_ui: %MingaEditor.State.Picker{}
+        prompt_ui: prompt
       },
       submitted: nil,
       cancelled: nil

--- a/test/minga_editor/lsp_actions/code_action_test.exs
+++ b/test/minga_editor/lsp_actions/code_action_test.exs
@@ -40,11 +40,9 @@ defmodule MingaEditor.LspActions.CodeActionTest do
 
       result = LspActions.handle_code_action_response(stub_state(), {:ok, actions})
 
-      # When PickerUI.open succeeds, it sets the picker source.
-      # When items are empty (which they won't be since we have actions),
-      # it returns state unchanged. The picker_ui.source being set confirms
-      # the picker was opened.
-      assert result.shell_state.picker_ui.source == MingaEditor.UI.Picker.CodeActionSource
+      # When PickerUI.open succeeds, the picker is active in the modal.
+      {:picker, %{picker_ui: picker_ui}} = result.shell_state.modal
+      assert picker_ui.source == MingaEditor.UI.Picker.CodeActionSource
     end
   end
 end

--- a/test/minga_editor/prompt_ui_test.exs
+++ b/test/minga_editor/prompt_ui_test.exs
@@ -43,12 +43,11 @@ defmodule MingaEditor.PromptUITest do
   @delete 57_348
 
   defp make_state(overrides \\ %{}) do
-    shell_overrides = Map.take(overrides, [:prompt_ui, :picker_ui])
-    other_overrides = Map.drop(overrides, [:prompt_ui, :picker_ui])
+    shell_overrides = Map.take(overrides, [:prompt_ui])
+    other_overrides = Map.drop(overrides, [:prompt_ui])
 
     shell = %MingaEditor.Shell.Traditional.State{
-      prompt_ui: Map.get(shell_overrides, :prompt_ui, %PromptState{}),
-      picker_ui: Map.get(shell_overrides, :picker_ui, %MingaEditor.State.Picker{})
+      prompt_ui: Map.get(shell_overrides, :prompt_ui, %PromptState{})
     }
 
     base = %{
@@ -88,7 +87,12 @@ defmodule MingaEditor.PromptUITest do
     end
 
     test "closes active picker when opening prompt" do
-      picker_state = %MingaEditor.State.Picker{
+      alias MingaEditor.State, as: EditorState
+      alias MingaEditor.State.ModalOverlay
+      alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+      alias MingaEditor.Viewport
+
+      picker_struct = %MingaEditor.State.Picker{
         picker: %MingaEditor.UI.Picker{
           items: [],
           filtered: [],
@@ -99,11 +103,16 @@ defmodule MingaEditor.PromptUITest do
         source: SomeSource
       }
 
-      state = make_state(%{picker_ui: picker_state})
+      state = %EditorState{
+        port_manager: nil,
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)}
+      }
+
+      state = ModalOverlay.open(state, :picker, PickerPayload.new(picker_struct))
       state = PromptUI.open(state, TestHandler)
 
       assert state.shell_state.prompt_ui.handler == TestHandler
-      assert state.shell_state.picker_ui.picker == nil
+      refute ModalOverlay.match(state.shell_state.modal, :picker)
     end
   end
 

--- a/test/minga_editor/state/modal_overlay_test.exs
+++ b/test/minga_editor/state/modal_overlay_test.exs
@@ -99,7 +99,6 @@ defmodule MingaEditor.State.ModalOverlayTest do
       result = ModalOverlay.open(state, :picker, payload)
 
       assert result.shell_state.modal == {:picker, payload}
-      assert result.shell_state.picker_ui == payload.picker_ui
     end
 
     test "writes the prompt legacy field" do
@@ -155,7 +154,6 @@ defmodule MingaEditor.State.ModalOverlayTest do
 
       assert result.shell_state.modal == {:prompt, prompt}
       assert result.shell_state.prompt_ui == prompt.prompt_ui
-      assert result.shell_state.picker_ui == %PickerLegacy{}
     end
 
     test "replacing completion with picker clears workspace.completion" do
@@ -168,7 +166,6 @@ defmodule MingaEditor.State.ModalOverlayTest do
 
       assert result.shell_state.modal == {:picker, picker}
       assert result.workspace.completion == nil
-      assert result.shell_state.picker_ui == picker.picker_ui
     end
 
     test "replacing dashboard clears the dashboard legacy field" do
@@ -219,7 +216,6 @@ defmodule MingaEditor.State.ModalOverlayTest do
       result = ModalOverlay.transition(state, :picker, picker)
 
       assert result.shell_state.modal == {:picker, picker}
-      assert result.shell_state.picker_ui == picker.picker_ui
       assert result.workspace.pending_conflict == nil
     end
   end
@@ -233,7 +229,6 @@ defmodule MingaEditor.State.ModalOverlayTest do
       result = ModalOverlay.close(state)
 
       assert result.shell_state.modal == :none
-      assert result.shell_state.picker_ui == %PickerLegacy{}
     end
 
     test "dismiss clears the active prompt and resets the legacy slot" do
@@ -266,14 +261,14 @@ defmodule MingaEditor.State.ModalOverlayTest do
   end
 
   describe "divergence assertion (dev/test only)" do
-    test "raises when picker_ui is mutated outside the gate" do
+    test "raises when prompt_ui is mutated outside the gate" do
       state =
         base_state()
-        |> ModalOverlay.open(:picker, picker_payload())
+        |> ModalOverlay.open(:prompt, prompt_payload())
 
       tampered =
-        update_in(state.shell_state.picker_ui, fn pui ->
-          %{pui | restore: 999}
+        update_in(state.shell_state.prompt_ui, fn pui ->
+          %{pui | cursor: 999}
         end)
 
       assert_raise RuntimeError, ~r/ModalOverlay divergence/, fn ->
@@ -295,15 +290,22 @@ defmodule MingaEditor.State.ModalOverlayTest do
 
     test "tolerates legacy mutation while modal is :none" do
       state = base_state()
-      tampered = EditorState.set_picker_ui(state, %PickerLegacy{restore: 42})
 
-      payload = prompt_payload()
-      result = ModalOverlay.open(tampered, :prompt, payload)
+      tampered =
+        put_in(state.shell_state.prompt_ui, %PromptLegacy{
+          handler: SomeHandler,
+          text: "x",
+          cursor: 1,
+          label: ":"
+        })
 
-      assert result.shell_state.modal == {:prompt, payload}
-      # The mutated picker_ui is preserved: the gate makes no claims about
+      payload = picker_payload()
+      result = ModalOverlay.open(tampered, :picker, payload)
+
+      assert result.shell_state.modal == {:picker, payload}
+      # The mutated prompt_ui is preserved: the gate makes no claims about
       # legacy fields whose variant is not currently tracked.
-      assert result.shell_state.picker_ui.restore == 42
+      assert result.shell_state.prompt_ui.text == "x"
     end
   end
 end

--- a/test/minga_editor/ui/picker/command_source_test.exs
+++ b/test/minga_editor/ui/picker/command_source_test.exs
@@ -7,7 +7,6 @@ defmodule MingaEditor.UI.Picker.CommandSourceTest do
   alias Minga.Command
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
-  alias MingaEditor.State.Picker, as: PickerState
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
   alias MingaEditor.UI.Picker.CommandSource
@@ -37,7 +36,7 @@ defmodule MingaEditor.UI.Picker.CommandSourceTest do
           buffers: %Buffers{active: buf, list: [buf], active_index: 0},
           editing: VimState.new()
         },
-        shell_state: %MingaEditor.Shell.Traditional.State{picker_ui: %PickerState{}}
+        shell_state: %MingaEditor.Shell.Traditional.State{}
       }
 
       result =
@@ -49,11 +48,12 @@ defmodule MingaEditor.UI.Picker.CommandSourceTest do
       # Should have opened the scope picker, not set pending_command
       assert is_nil(Map.get(result, :pending_command))
       # The scope picker should be open
-      assert result.shell_state.picker_ui.picker != nil
-      assert result.shell_state.picker_ui.source == MingaEditor.UI.Picker.OptionScopeSource
+      {:picker, %{picker_ui: picker_ui}} = result.shell_state.modal
+      assert picker_ui.picker != nil
+      assert picker_ui.source == MingaEditor.UI.Picker.OptionScopeSource
       # Context should carry the option info
-      assert result.shell_state.picker_ui.context.option_name == :wrap
-      assert is_boolean(result.shell_state.picker_ui.context.new_value)
+      assert picker_ui.context.option_name == :wrap
+      assert is_boolean(picker_ui.context.new_value)
     end
   end
 

--- a/test/minga_editor/ui/picker/option_scope_source_test.exs
+++ b/test/minga_editor/ui/picker/option_scope_source_test.exs
@@ -91,4 +91,61 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
       assert is_binary(OptionScopeSource.title())
     end
   end
+
+  describe "on_select after picker close (regression for context-in-id fix)" do
+    # `PickerUI.run_select_and_close/3` resets the modal to `:none` before
+    # invoking `on_select`. Previously this source read the picker context
+    # from `state.shell_state.picker_ui.context`, which had been cleared by
+    # the close, so the option was never applied. The fix carries the
+    # context inside `Item.id`. This test pins that contract by passing a
+    # state with `modal: :none` (matching what `on_select` actually sees in
+    # production).
+
+    test "applies buffer-scoped option when modal is already :none" do
+      {:ok, buf} = BufferServer.start_link(content: "hello")
+      assert BufferServer.get_option(buf, :wrap) == false
+
+      state = %{
+        workspace: %{buffers: %{active: buf}},
+        shell_state: %MingaEditor.Shell.Traditional.State{
+          status_msg: nil,
+          modal: :none
+        }
+      }
+
+      result =
+        OptionScopeSource.on_select(
+          %Item{id: {:buffer, @ctx}, label: "This Buffer", description: ""},
+          state
+        )
+
+      assert BufferServer.get_option(buf, :wrap) == true
+      assert result.shell_state.status_msg =~ "this buffer"
+    end
+
+    test "applies global-scoped option when modal is already :none" do
+      {:ok, buf} = BufferServer.start_link(content: "hello")
+      original = Options.get(:wrap)
+      ctx = %{option_name: :wrap, new_value: !original}
+
+      state = %{
+        workspace: %{buffers: %{active: buf}},
+        shell_state: %MingaEditor.Shell.Traditional.State{
+          status_msg: nil,
+          modal: :none
+        }
+      }
+
+      result =
+        OptionScopeSource.on_select(
+          %Item{id: {:global, ctx}, label: "All Buffers", description: ""},
+          state
+        )
+
+      assert Options.get(:wrap) == !original
+      assert result.shell_state.status_msg =~ "all buffers"
+
+      Options.set(:wrap, original)
+    end
+  end
 end

--- a/test/minga_editor/ui/picker/option_scope_source_test.exs
+++ b/test/minga_editor/ui/picker/option_scope_source_test.exs
@@ -1,39 +1,59 @@
 defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
   use ExUnit.Case, async: true
 
+  alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.OptionScopeSource
 
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Config.Options
-  alias MingaEditor.State.Picker, as: PickerState
-  alias MingaEditor.UI.Picker.OptionScopeSource
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Search
+  alias MingaEditor.VimState
+  alias MingaEditor.Viewport
+  alias MingaEditor.UI.Theme
+
+  @ctx %{option_name: :wrap, new_value: true}
+
+  defp picker_context(ctx) do
+    %Context{
+      buffers: %Buffers{},
+      editing: VimState.new(),
+      search: %Search{},
+      viewport: Viewport.new(24, 80),
+      tab_bar: %{},
+      picker_ui: %{context: ctx},
+      capabilities: %{},
+      theme: Theme.get!(:doom_one)
+    }
+  end
 
   describe "candidates/1" do
-    test "returns two scope choices" do
-      items = OptionScopeSource.candidates(nil)
+    test "returns two scope choices when context is present" do
+      items = OptionScopeSource.candidates(picker_context(@ctx))
       assert length(items) == 2
-      assert %Item{id: :buffer} = Enum.find(items, fn %Item{id: id} -> id == :buffer end)
-      assert %Item{id: :global} = Enum.find(items, fn %Item{id: id} -> id == :global end)
+      assert Enum.any?(items, fn %Item{id: {scope, _}} -> scope == :buffer end)
+      assert Enum.any?(items, fn %Item{id: {scope, _}} -> scope == :global end)
+    end
+
+    test "returns empty list when context is missing" do
+      assert OptionScopeSource.candidates(nil) == []
     end
   end
 
   describe "on_select/2 — buffer scope" do
     test "sets option on the active buffer" do
       {:ok, buf} = BufferServer.start_link(content: "hello")
-      # Confirm the buffer starts with wrap: false (seeded default)
       assert BufferServer.get_option(buf, :wrap) == false
 
       state = %{
         workspace: %{buffers: %{active: buf}},
-        shell_state: %MingaEditor.Shell.Traditional.State{
-          status_msg: nil,
-          picker_ui: %PickerState{context: %{option_name: :wrap, new_value: true}}
-        }
+        shell_state: %MingaEditor.Shell.Traditional.State{status_msg: nil}
       }
 
       result =
         OptionScopeSource.on_select(
-          %Item{id: :buffer, label: "This Buffer", description: ""},
+          %Item{id: {:buffer, @ctx}, label: "This Buffer", description: ""},
           state
         )
 
@@ -46,25 +66,22 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
     test "sets option on the global Options agent" do
       {:ok, buf} = BufferServer.start_link(content: "hello")
       original = Options.get(:wrap)
+      ctx = %{option_name: :wrap, new_value: !original}
 
       state = %{
         workspace: %{buffers: %{active: buf}},
-        shell_state: %MingaEditor.Shell.Traditional.State{
-          status_msg: nil,
-          picker_ui: %PickerState{context: %{option_name: :wrap, new_value: !original}}
-        }
+        shell_state: %MingaEditor.Shell.Traditional.State{status_msg: nil}
       }
 
       result =
         OptionScopeSource.on_select(
-          %Item{id: :global, label: "All Buffers", description: ""},
+          %Item{id: {:global, ctx}, label: "All Buffers", description: ""},
           state
         )
 
       assert Options.get(:wrap) == !original
       assert result.shell_state.status_msg =~ "all buffers"
 
-      # Restore
       Options.set(:wrap, original)
     end
   end

--- a/test/minga_editor/ui/picker/theme_source_test.exs
+++ b/test/minga_editor/ui/picker/theme_source_test.exs
@@ -62,7 +62,7 @@ defmodule MingaEditor.UI.Picker.ThemeSourceTest do
 
       state = %{
         theme: Theme.get!(:one_dark),
-        shell_state: %MingaEditor.Shell.Traditional.State{picker_ui: %{restore_theme: original}}
+        shell_state: %{modal: {:picker, %{picker_ui: %{restore_theme: original}}}}
       }
 
       restored = ThemeSource.on_cancel(state)
@@ -72,7 +72,7 @@ defmodule MingaEditor.UI.Picker.ThemeSourceTest do
     test "returns state unchanged when no restore_theme" do
       state = %{
         theme: Theme.get!(:one_dark),
-        shell_state: %MingaEditor.Shell.Traditional.State{picker_ui: %{restore_theme: nil}}
+        shell_state: %{modal: :none}
       }
 
       assert ThemeSource.on_cancel(state) == state

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -468,13 +468,25 @@ defmodule Minga.Test.EditorCase do
   @doc "Returns true if a picker is currently open."
   @spec picker_open?(editor_ctx()) :: boolean()
   def picker_open?(%{editor: editor}) do
-    MingaEditor.State.Picker.open?(:sys.get_state(editor).shell_state.picker_ui)
+    MingaEditor.State.ModalOverlay.match(:sys.get_state(editor).shell_state.modal, :picker)
   end
 
   @doc "Returns the active picker state, or nil."
   @spec picker_state(editor_ctx()) :: MingaEditor.UI.Picker.t() | nil
   def picker_state(%{editor: editor}) do
-    :sys.get_state(editor).shell_state.picker_ui.picker
+    case :sys.get_state(editor).shell_state.modal do
+      {:picker, %{picker_ui: %{picker: picker}}} -> picker
+      _ -> nil
+    end
+  end
+
+  @doc "Returns the picker payload (ModalOverlay.Picker) when a picker is open, or nil."
+  @spec modal_picker(editor_ctx()) :: MingaEditor.State.ModalOverlay.Picker.t() | nil
+  def modal_picker(%{editor: editor}) do
+    case :sys.get_state(editor).shell_state.modal do
+      {:picker, payload} -> payload
+      _ -> nil
+    end
   end
 
   @doc "Returns the cell at a given screen row and col."

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -489,6 +489,23 @@ defmodule Minga.Test.EditorCase do
     end
   end
 
+  @doc """
+  Like `modal_picker/1` but raises with a clear message when no picker is
+  open. Use this in tests where the next step assumes the payload exists,
+  so the failure surfaces as "picker not open" instead of `nil.picker_ui`.
+  """
+  @spec modal_picker!(editor_ctx()) :: MingaEditor.State.ModalOverlay.Picker.t()
+  def modal_picker!(ctx) do
+    case modal_picker(ctx) do
+      nil ->
+        modal = :sys.get_state(ctx.editor).shell_state.modal
+        raise "expected picker payload, but modal was: #{inspect(modal)}"
+
+      payload ->
+        payload
+    end
+  end
+
   @doc "Returns the cell at a given screen row and col."
   @spec screen_cell(editor_ctx(), non_neg_integer(), non_neg_integer()) :: map()
   def screen_cell(%{port: port}, row, col) do


### PR DESCRIPTION
## Summary

- Completes the picker overlay migration from the legacy `picker_ui` nullable field to the `{:picker, %ModalOverlay.Picker{}}` sum-type slot introduced in #1442
- Removes `picker_ui` from `Shell.Traditional.State` and `Shell.Board.State` entirely — no more dual-write for this variant
- Adds `EditorCase.modal_picker/1` helper and updates `picker_open?/1` and `picker_state/1` to read from `shell_state.modal`
- Fixes a pre-existing bug in `OptionScopeSource` where `on_select` read `picker_ui.context` after the picker was closed; context now travels with each item's ID tuple

## Test plan

- [x] `mix test.llm` — 7,499 tests, 0 failures
- [x] `make lint` — format passes, credo passes (13 pre-existing struct-size warnings only), dialyzer passes
- [x] Picker key handling, mouse handling, and rendering all read from `shell_state.modal`
- [x] All `picker_ui` references in test support and integration tests updated to use modal

Closes #1424

🤖 Generated with [Claude Code](https://claude.com/claude-code)