### PR TITLE
refactor(keymap): thread keymap server through editor state

### DIFF
--- a/lib/minga/config.ex
+++ b/lib/minga/config.ex
@@ -44,11 +44,9 @@ defmodule Minga.Config do
   alias Minga.Popup.Registry, as: PopupRegistry
   alias Minga.Popup.Rule, as: PopupRule
 
-  @type keymap_server :: GenServer.server()
-
-  @spec keymap_server() :: keymap_server()
+  @spec keymap_server() :: Keymap.server()
   defp keymap_server do
-    Process.get(:minga_config_keymap, Minga.Keymap.Active)
+    Process.get(:minga_config_keymap, Keymap.default_server())
   end
 
   # ── Read options ───────────────────────────────────────────────────
@@ -273,7 +271,7 @@ defmodule Minga.Config do
       if filetype do
         Keymap.bind(keymap_server(), mode, key_str, command_name, description, filetype: filetype)
       else
-        Keymap.bind(keymap_server(), mode, key_str, command_name, description)
+        Keymap.bind(keymap_server(), mode, key_str, command_name, description, [])
       end
 
     case result do

--- a/lib/minga/config.ex
+++ b/lib/minga/config.ex
@@ -44,6 +44,13 @@ defmodule Minga.Config do
   alias Minga.Popup.Registry, as: PopupRegistry
   alias Minga.Popup.Rule, as: PopupRule
 
+  @type keymap_server :: GenServer.server()
+
+  @spec keymap_server() :: keymap_server()
+  defp keymap_server do
+    Process.get(:minga_config_keymap, Minga.Keymap.Active)
+  end
+
   # ── Read options ───────────────────────────────────────────────────
 
   @doc """
@@ -264,9 +271,9 @@ defmodule Minga.Config do
 
     result =
       if filetype do
-        Keymap.bind(mode, key_str, command_name, description, filetype: filetype)
+        Keymap.bind(keymap_server(), mode, key_str, command_name, description, filetype: filetype)
       else
-        Keymap.bind(mode, key_str, command_name, description)
+        Keymap.bind(keymap_server(), mode, key_str, command_name, description)
       end
 
     case result do
@@ -292,7 +299,7 @@ defmodule Minga.Config do
   def bind(mode, key_str, command_name, description, opts)
       when is_atom(mode) and is_binary(key_str) and is_atom(command_name) and
              is_binary(description) and is_list(opts) do
-    case Keymap.bind(mode, key_str, command_name, description, opts) do
+    case Keymap.bind(keymap_server(), mode, key_str, command_name, description, opts) do
       :ok -> :ok
       {:error, reason} -> Minga.Log.warning(:config, "bind failed: #{reason}")
     end

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -34,6 +34,8 @@ defmodule Minga.Config.Loader do
   alias Minga.Keymap
   alias Minga.Popup.Registry, as: PopupRegistry
 
+  @type keymap_server :: GenServer.server()
+
   @typedoc "Loader state: stores paths, loaded modules, and any errors from each stage."
   @type state :: %{
           config_path: String.t(),
@@ -42,7 +44,8 @@ defmodule Minga.Config.Loader do
           modules_errors: [String.t()],
           project_config_path: String.t() | nil,
           project_config_error: String.t() | nil,
-          after_error: String.t() | nil
+          after_error: String.t() | nil,
+          keymap_server: keymap_server()
         }
 
   # ── Client API ──────────────────────────────────────────────────────────────
@@ -50,8 +53,12 @@ defmodule Minga.Config.Loader do
   @doc "Starts the loader, compiles user modules, and evaluates all config files."
   @spec start_link(keyword()) :: Agent.on_start()
   def start_link(opts \\ []) do
-    {name, _opts} = Keyword.pop(opts, :name, __MODULE__)
-    Agent.start_link(fn -> load_all() end, name: name)
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+
+    keymap_server =
+      Keyword.get(opts, :keymap_server, Process.get(:minga_config_keymap, Minga.Keymap.Active))
+
+    Agent.start_link(fn -> load_all(keymap_server) end, name: name)
   end
 
   @doc """
@@ -123,16 +130,22 @@ defmodule Minga.Config.Loader do
     end
 
     # Reset all registries to defaults
+    keymap_server =
+      Agent.get(server, fn
+        %{keymap_server: keymap_server} -> keymap_server
+        _ -> Process.get(:minga_config_keymap, Minga.Keymap.Active)
+      end)
+
     Options.reset()
     Hooks.reset()
     Advice.reset()
-    Keymap.reset()
+    Keymap.reset(keymap_server)
     Command.reset_registry()
     ExtRegistry.reset()
     PopupRegistry.clear()
 
     # Re-run the full load sequence (includes starting extensions)
-    new_state = load_all()
+    new_state = load_all(keymap_server)
     Agent.update(server, fn _ -> new_state end)
 
     # Return error if any stage had problems
@@ -150,67 +163,78 @@ defmodule Minga.Config.Loader do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
-  @spec load_all() :: state()
-  defp load_all do
-    config_path = resolve_config_path()
-    config_dir = Path.dirname(config_path)
+  @spec load_all(keymap_server()) :: state()
+  defp load_all(keymap_server) do
+    previous_server = Process.put(:minga_config_keymap, keymap_server)
 
-    # 0. Register default popup rules (before user config so overrides work)
-    register_default_popup_rules()
+    try do
+      config_path = resolve_config_path()
+      config_dir = Path.dirname(config_path)
 
-    # 1. Compile user modules
-    {loaded_modules, modules_errors} = compile_user_modules(config_dir)
+      # 0. Register default popup rules (before user config so overrides work)
+      register_default_popup_rules()
 
-    # 2. Load user themes (before config eval so `set :theme, :my_custom` works)
-    load_user_themes()
+      # 1. Compile user modules
+      {loaded_modules, modules_errors} = compile_user_modules(config_dir)
 
-    # 3. Eval global config
-    custom_config? = cli_config_file() != nil
+      # 2. Load user themes (before config eval so `set :theme, :my_custom` works)
+      load_user_themes()
 
-    load_error =
-      case {custom_config?, File.exists?(config_path)} do
-        {true, false} ->
-          "Custom config not found: #{config_path} (using defaults)"
+      # 3. Eval global config
+      custom_config? = cli_config_file() != nil
 
-        _ ->
-          eval_if_exists(config_path)
+      load_error =
+        case {custom_config?, File.exists?(config_path)} do
+          {true, false} ->
+            "Custom config not found: #{config_path} (using defaults)"
+
+          _ ->
+            eval_if_exists(config_path)
+        end
+
+      load_error =
+        if custom_config? and load_error == nil and not String.ends_with?(config_path, ".exs") do
+          "Custom config path does not end in .exs: #{config_path} (file was loaded, but may not be valid Elixir)"
+        else
+          load_error
+        end
+
+      # 4. Eval project-local config
+      project_path = resolve_project_config_path()
+      project_config_error = eval_if_exists(project_path)
+
+      # 5. Eval after.exs
+      after_path = Path.join(config_dir, "after.exs")
+      after_error = eval_if_exists(after_path)
+
+      # 6. Apply log level from config
+      apply_log_level()
+
+      # 7. Start declared extensions (if the supervisor is running).
+      # Skip in test mode so user-installed extensions don't affect test
+      # determinism (e.g., extra keybindings altering which-key snapshots).
+      if Process.whereis(Minga.Extension.Supervisor) != nil &&
+           Application.get_env(:minga, :load_extensions, true) do
+        ExtSupervisor.start_all()
       end
 
-    load_error =
-      if custom_config? and load_error == nil and not String.ends_with?(config_path, ".exs") do
-        "Custom config path does not end in .exs: #{config_path} (file was loaded, but may not be valid Elixir)"
+      %{
+        config_path: config_path,
+        load_error: load_error,
+        loaded_modules: loaded_modules,
+        modules_errors: modules_errors,
+        project_config_path: project_path,
+        project_config_error: project_config_error,
+        after_error: after_error,
+        keymap_server: keymap_server
+      }
+    after
+      if is_nil(previous_server) do
+        Process.delete(:minga_config_keymap)
       else
-        load_error
+        Process.put(:minga_config_keymap, previous_server)
       end
-
-    # 4. Eval project-local config
-    project_path = resolve_project_config_path()
-    project_config_error = eval_if_exists(project_path)
-
-    # 5. Eval after.exs
-    after_path = Path.join(config_dir, "after.exs")
-    after_error = eval_if_exists(after_path)
-
-    # 6. Apply log level from config
-    apply_log_level()
-
-    # 7. Start declared extensions (if the supervisor is running).
-    # Skip in test mode so user-installed extensions don't affect test
-    # determinism (e.g., extra keybindings altering which-key snapshots).
-    if Process.whereis(Minga.Extension.Supervisor) != nil &&
-         Application.get_env(:minga, :load_extensions, true) do
-      ExtSupervisor.start_all()
     end
-
-    %{
-      config_path: config_path,
-      load_error: load_error,
-      loaded_modules: loaded_modules,
-      modules_errors: modules_errors,
-      project_config_path: project_path,
-      project_config_error: project_config_error,
-      after_error: after_error
-    }
   end
 
   @spec load_user_themes() :: :ok

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -34,7 +34,7 @@ defmodule Minga.Config.Loader do
   alias Minga.Keymap
   alias Minga.Popup.Registry, as: PopupRegistry
 
-  @type keymap_server :: GenServer.server()
+  @type keymap_server :: Keymap.server()
 
   @typedoc "Loader state: stores paths, loaded modules, and any errors from each stage."
   @type state :: %{
@@ -50,13 +50,26 @@ defmodule Minga.Config.Loader do
 
   # ── Client API ──────────────────────────────────────────────────────────────
 
-  @doc "Starts the loader, compiles user modules, and evaluates all config files."
+  @doc """
+  Starts the loader, compiles user modules, and evaluates all config files.
+
+  When the loader is started under the application supervisor, the caller
+  process is the supervisor, so the `:minga_config_keymap` process-dict
+  fallback below reads the supervisor's pdict (effectively unset) and
+  resolves to `Keymap.default_server/0`. To target a non-default server at
+  boot, pass `:keymap_server` explicitly. The chosen server is persisted in
+  the loader's Agent state and re-read on `reload/1`.
+  """
   @spec start_link(keyword()) :: Agent.on_start()
   def start_link(opts \\ []) do
     {name, opts} = Keyword.pop(opts, :name, __MODULE__)
 
     keymap_server =
-      Keyword.get(opts, :keymap_server, Process.get(:minga_config_keymap, Minga.Keymap.Active))
+      Keyword.get(
+        opts,
+        :keymap_server,
+        Process.get(:minga_config_keymap, Keymap.default_server())
+      )
 
     Agent.start_link(fn -> load_all(keymap_server) end, name: name)
   end
@@ -132,8 +145,15 @@ defmodule Minga.Config.Loader do
     # Reset all registries to defaults
     keymap_server =
       Agent.get(server, fn
-        %{keymap_server: keymap_server} -> keymap_server
-        _ -> Process.get(:minga_config_keymap, Minga.Keymap.Active)
+        %{keymap_server: keymap_server} ->
+          keymap_server
+
+        # Defensive fallback: state shape predates the keymap_server field.
+        # Unreachable in single-version processes; logged so a real schema
+        # mismatch doesn't degrade silently.
+        _ ->
+          Minga.Log.warning(:config, "loader state missing :keymap_server; using default")
+          Process.get(:minga_config_keymap, Keymap.default_server())
       end)
 
     Options.reset()
@@ -165,9 +185,9 @@ defmodule Minga.Config.Loader do
 
   # The process dictionary bridges `keymap_server` into `Minga.Config.bind/3,4,5`,
   # which is invoked synchronously while `.exs` configs evaluate. Code that
-  # `Minga.Config.bind` from a separate process (e.g., a GenServer started
-  # by an extension callback) won't see this dict and will fall back to the
-  # global `Minga.Keymap.Active`. Extensions are skipped in test mode, so
+  # calls `Minga.Config.bind` from a separate process (e.g., a GenServer
+  # started by an extension callback) won't see this dict and will fall back
+  # to `Keymap.default_server/0`. Extensions are skipped in test mode, so
   # this only affects long-lived runtime callers.
   @spec load_all(keymap_server()) :: state()
   defp load_all(keymap_server) do

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -163,9 +163,15 @@ defmodule Minga.Config.Loader do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
+  # The process dictionary bridges `keymap_server` into `Minga.Config.bind/3,4,5`,
+  # which is invoked synchronously while `.exs` configs evaluate. Code that
+  # `Minga.Config.bind` from a separate process (e.g., a GenServer started
+  # by an extension callback) won't see this dict and will fall back to the
+  # global `Minga.Keymap.Active`. Extensions are skipped in test mode, so
+  # this only affects long-lived runtime callers.
   @spec load_all(keymap_server()) :: state()
   defp load_all(keymap_server) do
-    previous_server = Process.put(:minga_config_keymap, keymap_server)
+    previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
     try do
       config_path = resolve_config_path()
@@ -229,10 +235,10 @@ defmodule Minga.Config.Loader do
         keymap_server: keymap_server
       }
     after
-      if is_nil(previous_server) do
+      if is_nil(previous_keymap_server) do
         Process.delete(:minga_config_keymap)
       else
-        Process.put(:minga_config_keymap, previous_server)
+        Process.put(:minga_config_keymap, previous_keymap_server)
       end
     end
   end

--- a/lib/minga/keymap.ex
+++ b/lib/minga/keymap.ex
@@ -25,33 +25,49 @@ defmodule Minga.Keymap do
 
   @doc "Returns the merged leader trie (defaults + user overrides)."
   @spec leader_trie() :: Bindings.node_t()
+  @spec leader_trie(GenServer.server()) :: Bindings.node_t()
   defdelegate leader_trie, to: Active
+  defdelegate leader_trie(server), to: Active
 
   @doc "Returns the merged normal-mode single-key bindings."
   @spec normal_bindings() :: %{Bindings.key() => {atom(), String.t()}}
+  @spec normal_bindings(GenServer.server()) :: %{Bindings.key() => {atom(), String.t()}}
   defdelegate normal_bindings, to: Active
+  defdelegate normal_bindings(server), to: Active
 
   @doc "Returns the mode-specific trie for the given mode."
   @spec mode_trie(atom()) :: Bindings.node_t()
+  @spec mode_trie(GenServer.server(), atom()) :: Bindings.node_t()
   defdelegate mode_trie(mode), to: Active
+  defdelegate mode_trie(server, mode), to: Active
 
   @doc "Returns the filetype-scoped trie (SPC m bindings)."
   @spec filetype_trie(atom()) :: Bindings.node_t()
+  @spec filetype_trie(GenServer.server(), atom()) :: Bindings.node_t()
   defdelegate filetype_trie(filetype), to: Active
+  defdelegate filetype_trie(server, filetype), to: Active
 
   @doc "Returns the scope-specific trie for a given scope and vim state."
   @spec scope_trie(Scope.scope_name(), Scope.vim_state()) :: Bindings.node_t()
+  @spec scope_trie(GenServer.server(), Scope.scope_name(), Scope.vim_state()) :: Bindings.node_t()
   defdelegate scope_trie(scope, vim_state), to: Active
+  defdelegate scope_trie(server, scope, vim_state), to: Active
 
   @doc """
-  Resolves a single key press against a mode's merged bindings.
+  Resolves a key press against a mode's merged bindings.
 
-  Checks mode-specific trie first, then normal overrides. Returns
-  `{:command, name, desc}`, `{:prefix, node}`, or `:unbound`.
+  Checks mode-specific trie first, then normal overrides.
+  Returns `{:command, name}` when a command is found, or `:not_found`.
   """
   @spec resolve_binding(atom(), atom() | nil, Bindings.key()) ::
           {:command, atom()} | :not_found
+  @spec resolve_binding(GenServer.server(), atom(), atom() | nil, Bindings.key()) ::
+          {:command, atom()} | :not_found
   defdelegate resolve_binding(mode, filetype, key), to: Active, as: :resolve_mode_binding
+
+  defdelegate resolve_binding(server, mode, filetype, key),
+    to: Active,
+    as: :resolve_mode_binding
 
   # ── Key resolution (scoped dispatch) ───────────────────────────────
 
@@ -78,7 +94,17 @@ defmodule Minga.Keymap do
   @doc "Binds a key sequence with options (e.g., `filetype:`)."
   @spec bind(atom() | {atom(), atom()}, String.t(), atom(), String.t(), keyword()) ::
           :ok | {:error, String.t()}
+  @spec bind(
+          GenServer.server(),
+          atom() | {atom(), atom()},
+          String.t(),
+          atom(),
+          String.t(),
+          keyword()
+        ) ::
+          :ok | {:error, String.t()}
   defdelegate bind(mode, key_str, command, description, opts), to: Active
+  defdelegate bind(server, mode, key_str, command, description, opts), to: Active
 
   @doc "Removes a key binding from a mode."
   @spec unbind(atom(), String.t()) :: :ok | {:error, String.t()}
@@ -86,7 +112,9 @@ defmodule Minga.Keymap do
 
   @doc "Resets all bindings to defaults (discards user overrides)."
   @spec reset() :: :ok
+  @spec reset(GenServer.server()) :: :ok
   defdelegate reset, to: Active
+  defdelegate reset(server), to: Active
 
   # ── Default bindings ───────────────────────────────────────────────
 

--- a/lib/minga/keymap.ex
+++ b/lib/minga/keymap.ex
@@ -11,6 +11,14 @@ defmodule Minga.Keymap do
   External callers use this facade for binding lookups, key resolution,
   and runtime rebinding. The `Keymap.Bindings` trie type appears in
   specs across mode dispatch and input handling code.
+
+  ## Server-aware API
+
+  Every binding-lookup and runtime-rebinding function takes an optional
+  `server` argument. When omitted, calls go to the singleton process
+  registered under the `default_server/0` name. Pass an explicit server
+  (pid or registered name) to target an isolated instance, e.g. per-test
+  fixtures or future per-tab keymaps.
   """
 
   alias Minga.Keymap.Active
@@ -21,53 +29,52 @@ defmodule Minga.Keymap do
   @typedoc "Supported editor modes."
   @type mode :: :normal | :insert | :visual | :command
 
+  @typedoc "Reference to a Keymap.Active GenServer (registered name or pid)."
+  @type server :: GenServer.server()
+
+  # Single source of truth for the default registered Keymap.Active. Other
+  # modules should call `default_server/0` rather than referencing `Active`
+  # directly so future renames or alternate defaults stay localized here.
+  @default_server Active
+
+  @doc "Returns the registered name of the default keymap server."
+  @spec default_server() :: server()
+  def default_server, do: @default_server
+
   # ── Binding lookup ─────────────────────────────────────────────────
 
   @doc "Returns the merged leader trie (defaults + user overrides)."
-  @spec leader_trie() :: Bindings.node_t()
-  @spec leader_trie(GenServer.server()) :: Bindings.node_t()
-  defdelegate leader_trie, to: Active
-  defdelegate leader_trie(server), to: Active
+  @spec leader_trie(server()) :: Bindings.node_t()
+  defdelegate leader_trie(server \\ @default_server), to: Active
 
   @doc "Returns the merged normal-mode single-key bindings."
-  @spec normal_bindings() :: %{Bindings.key() => {atom(), String.t()}}
-  @spec normal_bindings(GenServer.server()) :: %{Bindings.key() => {atom(), String.t()}}
-  defdelegate normal_bindings, to: Active
-  defdelegate normal_bindings(server), to: Active
+  @spec normal_bindings(server()) :: %{Bindings.key() => {atom(), String.t()}}
+  defdelegate normal_bindings(server \\ @default_server), to: Active
 
   @doc "Returns the mode-specific trie for the given mode."
-  @spec mode_trie(atom()) :: Bindings.node_t()
-  @spec mode_trie(GenServer.server(), atom()) :: Bindings.node_t()
-  defdelegate mode_trie(mode), to: Active
-  defdelegate mode_trie(server, mode), to: Active
+  @spec mode_trie(server(), atom()) :: Bindings.node_t()
+  def mode_trie(server \\ @default_server, mode), do: Active.mode_trie(server, mode)
 
   @doc "Returns the filetype-scoped trie (SPC m bindings)."
-  @spec filetype_trie(atom()) :: Bindings.node_t()
-  @spec filetype_trie(GenServer.server(), atom()) :: Bindings.node_t()
-  defdelegate filetype_trie(filetype), to: Active
-  defdelegate filetype_trie(server, filetype), to: Active
+  @spec filetype_trie(server(), atom()) :: Bindings.node_t()
+  def filetype_trie(server \\ @default_server, filetype),
+    do: Active.filetype_trie(server, filetype)
 
   @doc "Returns the scope-specific trie for a given scope and vim state."
-  @spec scope_trie(Scope.scope_name(), Scope.vim_state()) :: Bindings.node_t()
-  @spec scope_trie(GenServer.server(), Scope.scope_name(), Scope.vim_state()) :: Bindings.node_t()
-  defdelegate scope_trie(scope, vim_state), to: Active
-  defdelegate scope_trie(server, scope, vim_state), to: Active
+  @spec scope_trie(server(), Scope.scope_name(), Scope.vim_state()) :: Bindings.node_t()
+  def scope_trie(server \\ @default_server, scope, vim_state),
+    do: Active.scope_trie(server, scope, vim_state)
 
   @doc """
   Resolves a key press against a mode's merged bindings.
 
   Checks mode-specific trie first, then normal overrides.
-  Returns `{:command, name}` when a command is found, or `:not_found`.
+  Returns `{:command, atom()}` when a command is found, or `:not_found`.
   """
-  @spec resolve_binding(atom(), atom() | nil, Bindings.key()) ::
+  @spec resolve_binding(server(), atom(), atom() | nil, Bindings.key()) ::
           {:command, atom()} | :not_found
-  @spec resolve_binding(GenServer.server(), atom(), atom() | nil, Bindings.key()) ::
-          {:command, atom()} | :not_found
-  defdelegate resolve_binding(mode, filetype, key), to: Active, as: :resolve_mode_binding
-
-  defdelegate resolve_binding(server, mode, filetype, key),
-    to: Active,
-    as: :resolve_mode_binding
+  def resolve_binding(server \\ @default_server, mode, filetype, key),
+    do: Active.resolve_mode_binding(server, mode, filetype, key)
 
   # ── Key resolution (scoped dispatch) ───────────────────────────────
 
@@ -75,8 +82,8 @@ defmodule Minga.Keymap do
   Resolves a key press within a scope (e.g., `:editor`, `:agent`, `:file_tree`).
 
   Checks scope-specific bindings first, then falls through to the
-  scope's fallback chain. Returns `{:command, name, desc}`,
-  `{:prefix, node}`, or `:unbound`.
+  scope's fallback chain. Returns `Scope.resolve_result()`:
+  `{:command, atom()}`, `{:prefix, Bindings.node_t()}`, or `:not_found`.
   """
   @spec resolve_scoped_key(Scope.scope_name(), Scope.vim_state(), Bindings.key(), keyword()) ::
           Scope.resolve_result()
@@ -89,34 +96,28 @@ defmodule Minga.Keymap do
   @doc "Binds a key sequence to a command in the given mode."
   @spec bind(atom() | {atom(), atom()}, String.t(), atom(), String.t()) ::
           :ok | {:error, String.t()}
-  defdelegate bind(mode, key_str, command, description), to: Active
+  def bind(mode, key_str, command, description),
+    do: Active.bind(@default_server, mode, key_str, command, description, [])
 
   @doc "Binds a key sequence with options (e.g., `filetype:`)."
   @spec bind(atom() | {atom(), atom()}, String.t(), atom(), String.t(), keyword()) ::
           :ok | {:error, String.t()}
-  @spec bind(
-          GenServer.server(),
-          atom() | {atom(), atom()},
-          String.t(),
-          atom(),
-          String.t(),
-          keyword()
-        ) ::
+  def bind(mode, key_str, command, description, opts) when is_list(opts),
+    do: Active.bind(@default_server, mode, key_str, command, description, opts)
+
+  @doc "Binds a key sequence on an explicit keymap server."
+  @spec bind(server(), atom() | {atom(), atom()}, String.t(), atom(), String.t(), keyword()) ::
           :ok | {:error, String.t()}
-  defdelegate bind(mode, key_str, command, description, opts), to: Active
   defdelegate bind(server, mode, key_str, command, description, opts), to: Active
 
   @doc "Removes a key binding from a mode."
-  @spec unbind(atom(), String.t()) :: :ok | {:error, String.t()}
-  @spec unbind(GenServer.server(), atom(), String.t()) :: :ok | {:error, String.t()}
-  defdelegate unbind(mode, key_str), to: Active
-  defdelegate unbind(server, mode, key_str), to: Active
+  @spec unbind(server(), atom(), String.t()) :: :ok | {:error, String.t()}
+  def unbind(server \\ @default_server, mode, key_str),
+    do: Active.unbind(server, mode, key_str)
 
   @doc "Resets all bindings to defaults (discards user overrides)."
-  @spec reset() :: :ok
-  @spec reset(GenServer.server()) :: :ok
-  defdelegate reset, to: Active
-  defdelegate reset(server), to: Active
+  @spec reset(server()) :: :ok
+  defdelegate reset(server \\ @default_server), to: Active
 
   # ── Default bindings ───────────────────────────────────────────────
 

--- a/lib/minga/keymap.ex
+++ b/lib/minga/keymap.ex
@@ -108,7 +108,9 @@ defmodule Minga.Keymap do
 
   @doc "Removes a key binding from a mode."
   @spec unbind(atom(), String.t()) :: :ok | {:error, String.t()}
+  @spec unbind(GenServer.server(), atom(), String.t()) :: :ok | {:error, String.t()}
   defdelegate unbind(mode, key_str), to: Active
+  defdelegate unbind(server, mode, key_str), to: Active
 
   @doc "Resets all bindings to defaults (discards user overrides)."
   @spec reset() :: :ok

--- a/lib/minga/keymap/active.ex
+++ b/lib/minga/keymap/active.ex
@@ -296,19 +296,28 @@ defmodule Minga.Keymap.Active do
       bind(:normal, "SPC m t", :mix_test, "Run tests", filetype: :elixir)
       bind(:normal, "SPC m p", :markdown_preview, "Preview", filetype: :markdown)
   """
-  @spec bind(atom(), String.t(), atom(), String.t(), keyword()) ::
+  @spec bind(atom() | {atom(), atom()}, String.t(), atom(), String.t(), keyword()) ::
           :ok | {:error, String.t()}
-  @spec bind(GenServer.server(), atom(), String.t(), atom(), String.t(), keyword()) ::
-          :ok | {:error, String.t()}
+  @spec bind(
+          GenServer.server(),
+          atom() | {atom(), atom()},
+          String.t(),
+          atom(),
+          String.t(),
+          keyword()
+        ) :: :ok | {:error, String.t()}
   def bind(mode, key_str, command, description, opts),
     do: bind(__MODULE__, mode, key_str, command, description, opts)
 
   def bind(server, mode, key_str, command, description, opts)
-      when is_atom(mode) and is_binary(key_str) and is_atom(command) and is_binary(description) and
-             is_list(opts) do
+      when (is_atom(mode) or is_tuple(mode)) and is_binary(key_str) and is_atom(command) and
+             is_binary(description) and is_list(opts) do
+    # `:filetype` only applies to atom modes (`:normal` SPC m bindings, etc.).
+    # Scope bindings (tuple modes like `{:agent, :normal}`) ignore opts and
+    # fall through to the no-options path.
     filetype = Keyword.get(opts, :filetype)
 
-    if filetype do
+    if filetype && is_atom(mode) do
       bind_filetype(server, mode, filetype, key_str, command, description)
     else
       bind(server, mode, key_str, command, description)

--- a/lib/minga/keymap/active.ex
+++ b/lib/minga/keymap/active.ex
@@ -68,14 +68,29 @@ defmodule Minga.Keymap.Active do
 
   # ── GenServer (table lifecycle only) ────────────────────────────────────────
 
-  @doc "Starts the keymap store and creates the backing ETS table."
+  @doc """
+  Starts the keymap store and creates the backing ETS table.
+
+  Pass `name: nil` to start anonymously (no registered name, unnamed ETS
+  table). Useful for isolated test fixtures: pass the returned pid to
+  server-aware functions instead of generating per-test atoms.
+  """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    {name, _opts} = Keyword.pop(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, name, name: name)
+    case Keyword.fetch(opts, :name) do
+      {:ok, nil} -> GenServer.start_link(__MODULE__, :anonymous, [])
+      {:ok, name} -> GenServer.start_link(__MODULE__, name, name: name)
+      :error -> GenServer.start_link(__MODULE__, __MODULE__, name: __MODULE__)
+    end
   end
 
   @impl GenServer
+  def init(:anonymous) do
+    table = :ets.new(:keymap_active, [:set, :public, read_concurrency: true])
+    seed_defaults(table)
+    {:ok, %{table: table}}
+  end
+
   def init(name) do
     table = :ets.new(table_name(name), [:set, :public, :named_table, read_concurrency: true])
     seed_defaults(table)

--- a/lib/minga/keymap/scope.ex
+++ b/lib/minga/keymap/scope.ex
@@ -195,9 +195,11 @@ defmodule Minga.Keymap.Scope do
   @spec resolve_through_layers(module(), scope_name(), vim_state(), Bindings.key(), context()) ::
           resolve_result()
   defp resolve_through_layers(mod, scope_name, vim_state, key, context) do
+    keymap_server = context_server(context)
+
     tries = [
       # Layer 0: user overrides for this scope + vim state
-      user_scope_trie(scope_name, vim_state),
+      user_scope_trie(scope_name, vim_state, keymap_server),
       # Layer 1: vim-state-specific bindings from the scope module
       mod.keymap(vim_state, context),
       # Layer 2: shared bindings (cross vim-state)
@@ -212,9 +214,14 @@ defmodule Minga.Keymap.Scope do
     end)
   end
 
-  @spec user_scope_trie(scope_name(), vim_state()) :: Bindings.node_t()
-  defp user_scope_trie(scope_name, vim_state) do
-    KeymapActive.scope_trie(scope_name, vim_state)
+  @spec context_server(context()) :: GenServer.server()
+  defp context_server(context) do
+    Keyword.get(context, :keymap_server, Minga.Keymap.Active)
+  end
+
+  @spec user_scope_trie(scope_name(), vim_state(), GenServer.server()) :: Bindings.node_t()
+  defp user_scope_trie(scope_name, vim_state, keymap_server) do
+    KeymapActive.scope_trie(keymap_server, scope_name, vim_state)
   catch
     :exit, _ -> Bindings.new()
   end

--- a/lib/minga/keymap/scope.ex
+++ b/lib/minga/keymap/scope.ex
@@ -51,6 +51,7 @@ defmodule Minga.Keymap.Scope do
   ignore context.
   """
 
+  alias Minga.Keymap
   alias Minga.Keymap.Active, as: KeymapActive
   alias Minga.Keymap.Bindings
 
@@ -214,16 +215,41 @@ defmodule Minga.Keymap.Scope do
     end)
   end
 
-  @spec context_server(context()) :: GenServer.server()
+  # Reads the keymap server from the resolution context. Production callers
+  # are expected to pass `EditorState.keymap_context(state)`. Setting
+  # `config :minga, :strict_keymap_context, true` (e.g., in dev/test) turns
+  # a missing key into a hard failure to catch forgotten threading at its
+  # source. Default behavior falls back to the singleton silently so a
+  # forgotten context can't crash the editor in production.
+  @spec context_server(context()) :: Keymap.server()
   defp context_server(context) do
-    Keyword.get(context, :keymap_server, Minga.Keymap.Active)
+    case Keyword.fetch(context, :keymap_server) do
+      {:ok, server} ->
+        server
+
+      :error ->
+        if Application.get_env(:minga, :strict_keymap_context, false) do
+          raise ArgumentError,
+                "Scope.resolve_key/4 called without :keymap_server in context. " <>
+                  "Pass EditorState.keymap_context(state)."
+        else
+          Keymap.default_server()
+        end
+    end
   end
 
-  @spec user_scope_trie(scope_name(), vim_state(), GenServer.server()) :: Bindings.node_t()
+  @spec user_scope_trie(scope_name(), vim_state(), Keymap.server()) :: Bindings.node_t()
   defp user_scope_trie(scope_name, vim_state, keymap_server) do
     KeymapActive.scope_trie(keymap_server, scope_name, vim_state)
   catch
-    :exit, _ -> Bindings.new()
+    :exit, _ ->
+      Minga.Log.warning(
+        :config,
+        "scope_trie unavailable for #{inspect(scope_name)}/#{inspect(vim_state)}; " <>
+          "using empty overrides"
+      )
+
+      Bindings.new()
   end
 
   @doc """

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -59,6 +59,7 @@ defmodule MingaEditor do
   @type start_opt ::
           {:name, GenServer.name()}
           | {:port_manager, GenServer.server()}
+          | {:keymap_server, GenServer.server()}
           | {:buffer, pid()}
           | {:width, pos_integer()}
           | {:height, pos_integer()}

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -627,7 +627,7 @@ defmodule MingaEditor.Commands do
     case Editing.mode_state(state) do
       %{leader_keys: ["m", "SPC"]} ->
         filetype = current_filetype(state)
-        ft_trie = filetype_trie_for(filetype)
+        ft_trie = filetype_trie_for(state, filetype)
 
         if ft_trie.children == %{} do
           {node, state}
@@ -650,9 +650,9 @@ defmodule MingaEditor.Commands do
     :exit, _ -> :text
   end
 
-  @spec filetype_trie_for(atom()) :: Bindings.node_t()
-  defp filetype_trie_for(filetype) do
-    Keymap.filetype_trie(filetype)
+  @spec filetype_trie_for(EditorState.t(), atom()) :: Bindings.node_t()
+  defp filetype_trie_for(state, filetype) do
+    Keymap.filetype_trie(EditorState.keymap_server(state), filetype)
   catch
     :exit, _ -> Bindings.new()
   end

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -654,6 +654,12 @@ defmodule MingaEditor.Commands do
   defp filetype_trie_for(state, filetype) do
     Keymap.filetype_trie(EditorState.keymap_server(state), filetype)
   catch
-    :exit, _ -> Bindings.new()
+    :exit, _ ->
+      Minga.Log.warning(
+        :config,
+        "filetype_trie unavailable for #{inspect(filetype)}; using empty trie"
+      )
+
+      Bindings.new()
   end
 end

--- a/lib/minga_editor/input/agent_panel.ex
+++ b/lib/minga_editor/input/agent_panel.ex
@@ -90,7 +90,12 @@ defmodule MingaEditor.Input.AgentPanel do
       # need self-insert fallback for printable chars.
       key = {cp, mods}
 
-      case Keymap.resolve_scoped_key(:agent, binding_state, key, keymap_context(state)) do
+      case Keymap.resolve_scoped_key(
+             :agent,
+             binding_state,
+             key,
+             EditorState.keymap_context(state)
+           ) do
         {:command, command} ->
           Commands.execute(state, command)
 
@@ -231,7 +236,12 @@ defmodule MingaEditor.Input.AgentPanel do
       # No prompt buffer, try scope bindings
       key = {cp, mods}
 
-      case Keymap.resolve_scoped_key(:agent, :input_normal, key, keymap_context(state)) do
+      case Keymap.resolve_scoped_key(
+             :agent,
+             :input_normal,
+             key,
+             EditorState.keymap_context(state)
+           ) do
         {:command, command} -> Commands.execute(state, command)
         {:prefix, _node} -> state
         :not_found -> state
@@ -253,7 +263,4 @@ defmodule MingaEditor.Input.AgentPanel do
       state
     end
   end
-
-  @spec keymap_context(EditorState.t()) :: [{:keymap_server, GenServer.server()}]
-  defp keymap_context(state), do: [keymap_server: EditorState.keymap_server(state)]
 end

--- a/lib/minga_editor/input/agent_panel.ex
+++ b/lib/minga_editor/input/agent_panel.ex
@@ -90,7 +90,7 @@ defmodule MingaEditor.Input.AgentPanel do
       # need self-insert fallback for printable chars.
       key = {cp, mods}
 
-      case Keymap.resolve_scoped_key(:agent, binding_state, key) do
+      case Keymap.resolve_scoped_key(:agent, binding_state, key, keymap_context(state)) do
         {:command, command} ->
           Commands.execute(state, command)
 
@@ -231,7 +231,7 @@ defmodule MingaEditor.Input.AgentPanel do
       # No prompt buffer, try scope bindings
       key = {cp, mods}
 
-      case Keymap.resolve_scoped_key(:agent, :input_normal, key) do
+      case Keymap.resolve_scoped_key(:agent, :input_normal, key, keymap_context(state)) do
         {:command, command} -> Commands.execute(state, command)
         {:prefix, _node} -> state
         :not_found -> state
@@ -253,4 +253,7 @@ defmodule MingaEditor.Input.AgentPanel do
       state
     end
   end
+
+  @spec keymap_context(EditorState.t()) :: [{:keymap_server, GenServer.server()}]
+  defp keymap_context(state), do: [keymap_server: EditorState.keymap_server(state)]
 end

--- a/lib/minga_editor/input/cua/space_leader.ex
+++ b/lib/minga_editor/input/cua/space_leader.ex
@@ -34,7 +34,7 @@ defmodule MingaEditor.Input.CUA.SpaceLeader do
   @spec handle_chord(EditorState.t(), non_neg_integer(), non_neg_integer()) :: EditorState.t()
   def handle_chord(state, codepoint, modifiers) do
     if active?(state) do
-      trie = leader_trie()
+      trie = leader_trie(state)
 
       case lookup_leader(trie, codepoint, modifiers) do
         {:match, node} ->
@@ -65,7 +65,7 @@ defmodule MingaEditor.Input.CUA.SpaceLeader do
   @spec handle_retract(EditorState.t(), non_neg_integer(), non_neg_integer()) :: EditorState.t()
   def handle_retract(state, codepoint, modifiers) do
     if active?(state) do
-      trie = leader_trie()
+      trie = leader_trie(state)
 
       case lookup_leader(trie, codepoint, modifiers) do
         {:match, node} ->
@@ -145,9 +145,9 @@ defmodule MingaEditor.Input.CUA.SpaceLeader do
     end
   end
 
-  @spec leader_trie() :: Minga.Keymap.Bindings.node_t()
-  defp leader_trie do
-    Keymap.leader_trie()
+  @spec leader_trie(EditorState.t()) :: Minga.Keymap.Bindings.node_t()
+  defp leader_trie(state) do
+    Keymap.leader_trie(EditorState.keymap_server(state))
   catch
     :exit, _ -> Minga.Keymap.Bindings.new()
   end

--- a/lib/minga_editor/input/cua/space_leader.ex
+++ b/lib/minga_editor/input/cua/space_leader.ex
@@ -149,7 +149,9 @@ defmodule MingaEditor.Input.CUA.SpaceLeader do
   defp leader_trie(state) do
     Keymap.leader_trie(EditorState.keymap_server(state))
   catch
-    :exit, _ -> Minga.Keymap.Bindings.new()
+    :exit, _ ->
+      Minga.Log.warning(:config, "leader_trie unavailable; SPC bindings disabled this frame")
+      Minga.Keymap.Bindings.new()
   end
 
   @spec lookup_leader(Minga.Keymap.Bindings.node_t(), non_neg_integer(), non_neg_integer()) ::

--- a/lib/minga_editor/input/cua/tui_space_leader.ex
+++ b/lib/minga_editor/input/cua/tui_space_leader.ex
@@ -75,7 +75,7 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
       state = cancel_timer(state)
       state = put_space_leader_pending(state, false)
 
-      trie = leader_trie()
+      trie = leader_trie(state)
       key = {cp, mods}
 
       case Map.get(trie.children, key) do
@@ -180,9 +180,9 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
     end
   end
 
-  @spec leader_trie() :: Bindings.node_t()
-  defp leader_trie do
-    Keymap.leader_trie()
+  @spec leader_trie(EditorState.t()) :: Bindings.node_t()
+  defp leader_trie(state) do
+    Keymap.leader_trie(EditorState.keymap_server(state))
   catch
     :exit, _ -> Bindings.new()
   end

--- a/lib/minga_editor/input/cua/tui_space_leader.ex
+++ b/lib/minga_editor/input/cua/tui_space_leader.ex
@@ -184,6 +184,8 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
   defp leader_trie(state) do
     Keymap.leader_trie(EditorState.keymap_server(state))
   catch
-    :exit, _ -> Bindings.new()
+    :exit, _ ->
+      Minga.Log.warning(:config, "leader_trie unavailable; SPC bindings disabled this frame")
+      Bindings.new()
   end
 end

--- a/lib/minga_editor/input/diff_review.ex
+++ b/lib/minga_editor/input/diff_review.ex
@@ -49,13 +49,10 @@ defmodule MingaEditor.Input.DiffReview do
   defp dispatch_diff_key(state, cp) do
     key = {cp, 0}
 
-    case Keymap.resolve_scoped_key(:agent, :normal, key, keymap_context(state)) do
+    case Keymap.resolve_scoped_key(:agent, :normal, key, EditorState.keymap_context(state)) do
       {:command, command} -> {:handled, Commands.execute(state, command)}
       {:prefix, _node} -> {:handled, state}
       :not_found -> {:handled, state}
     end
   end
-
-  @spec keymap_context(EditorState.t()) :: [{:keymap_server, GenServer.server()}]
-  defp keymap_context(state), do: [keymap_server: EditorState.keymap_server(state)]
 end

--- a/lib/minga_editor/input/diff_review.ex
+++ b/lib/minga_editor/input/diff_review.ex
@@ -49,10 +49,13 @@ defmodule MingaEditor.Input.DiffReview do
   defp dispatch_diff_key(state, cp) do
     key = {cp, 0}
 
-    case Keymap.resolve_scoped_key(:agent, :normal, key) do
+    case Keymap.resolve_scoped_key(:agent, :normal, key, keymap_context(state)) do
       {:command, command} -> {:handled, Commands.execute(state, command)}
       {:prefix, _node} -> {:handled, state}
       :not_found -> {:handled, state}
     end
   end
+
+  @spec keymap_context(EditorState.t()) :: [{:keymap_server, GenServer.server()}]
+  defp keymap_context(state), do: [keymap_server: EditorState.keymap_server(state)]
 end

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -107,7 +107,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
       vim_state =
         if Minga.Editing.active_model(state) == Minga.Editing.Model.CUA, do: :cua, else: :normal
 
-      case Keymap.resolve_scoped_key(:file_tree, vim_state, key) do
+      case Keymap.resolve_scoped_key(:file_tree, vim_state, key, keymap_context(state)) do
         {:command, command} ->
           {:handled, Commands.execute(state, command)}
 
@@ -162,6 +162,9 @@ defmodule MingaEditor.Input.FileTreeHandler do
     clamped = min(cursor_line, max_cursor)
     put_in(state.workspace.file_tree.tree, %{tree | cursor: clamped})
   end
+
+  @spec keymap_context(EditorState.t()) :: [{:keymap_server, GenServer.server()}]
+  defp keymap_context(state), do: [keymap_server: EditorState.keymap_server(state)]
 
   # ── File tree mouse helpers ────────────────────────────────────────────
 

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -107,7 +107,12 @@ defmodule MingaEditor.Input.FileTreeHandler do
       vim_state =
         if Minga.Editing.active_model(state) == Minga.Editing.Model.CUA, do: :cua, else: :normal
 
-      case Keymap.resolve_scoped_key(:file_tree, vim_state, key, keymap_context(state)) do
+      case Keymap.resolve_scoped_key(
+             :file_tree,
+             vim_state,
+             key,
+             EditorState.keymap_context(state)
+           ) do
         {:command, command} ->
           {:handled, Commands.execute(state, command)}
 
@@ -162,9 +167,6 @@ defmodule MingaEditor.Input.FileTreeHandler do
     clamped = min(cursor_line, max_cursor)
     put_in(state.workspace.file_tree.tree, %{tree | cursor: clamped})
   end
-
-  @spec keymap_context(EditorState.t()) :: [{:keymap_server, GenServer.server()}]
-  defp keymap_context(state), do: [keymap_server: EditorState.keymap_server(state)]
 
   # ── File tree mouse helpers ────────────────────────────────────────────
 

--- a/lib/minga_editor/input/git_status.ex
+++ b/lib/minga_editor/input/git_status.ex
@@ -32,7 +32,7 @@ defmodule MingaEditor.Input.GitStatus do
 
       binding_state = Minga.Editing.binding_state(state)
 
-      case Keymap.resolve_scoped_key(:git_status, binding_state, key) do
+      case Keymap.resolve_scoped_key(:git_status, binding_state, key, keymap_context(state)) do
         {:command, cmd} ->
           {:handled, execute_command(state, cmd)}
 
@@ -164,6 +164,9 @@ defmodule MingaEditor.Input.GitStatus do
   end
 
   defp execute_command(state, _cmd), do: state
+
+  @spec keymap_context(EditorState.t()) :: [{:keymap_server, GenServer.server()}]
+  defp keymap_context(state), do: [keymap_server: EditorState.keymap_server(state)]
 
   # ── TUI state helpers ──────────────────────────────────────────────────
 

--- a/lib/minga_editor/input/git_status.ex
+++ b/lib/minga_editor/input/git_status.ex
@@ -32,7 +32,12 @@ defmodule MingaEditor.Input.GitStatus do
 
       binding_state = Minga.Editing.binding_state(state)
 
-      case Keymap.resolve_scoped_key(:git_status, binding_state, key, keymap_context(state)) do
+      case Keymap.resolve_scoped_key(
+             :git_status,
+             binding_state,
+             key,
+             EditorState.keymap_context(state)
+           ) do
         {:command, cmd} ->
           {:handled, execute_command(state, cmd)}
 
@@ -164,9 +169,6 @@ defmodule MingaEditor.Input.GitStatus do
   end
 
   defp execute_command(state, _cmd), do: state
-
-  @spec keymap_context(EditorState.t()) :: [{:keymap_server, GenServer.server()}]
-  defp keymap_context(state), do: [keymap_server: EditorState.keymap_server(state)]
 
   # ── TUI state helpers ──────────────────────────────────────────────────
 

--- a/lib/minga_editor/input/scoped.ex
+++ b/lib/minga_editor/input/scoped.ex
@@ -58,7 +58,7 @@ defmodule MingaEditor.Input.Scoped do
     if Minga.Editing.active_model(state) == Minga.Editing.Model.CUA do
       key = {cp, mods}
 
-      case Keymap.resolve_scoped_key(:editor, :cua, key) do
+      case Keymap.resolve_scoped_key(:editor, :cua, key, keymap_context(state)) do
         {:command, command} ->
           {:handled, Commands.execute(state, command)}
 
@@ -227,7 +227,7 @@ defmodule MingaEditor.Input.Scoped do
         ) ::
           MingaEditor.Input.Handler.result()
   defp resolve_scope_key(state, scope_name, vim_state, key, cp, mods) do
-    case Keymap.resolve_scoped_key(scope_name, vim_state, key) do
+    case Keymap.resolve_scoped_key(scope_name, vim_state, key, keymap_context(state)) do
       {:command, command} ->
         {:handled, Commands.execute(state, command)}
 
@@ -305,4 +305,7 @@ defmodule MingaEditor.Input.Scoped do
           cursor_line >= start and cursor_line < start + text_len
       end)
   end
+
+  @spec keymap_context(EditorState.t()) :: [{:keymap_server, GenServer.server()}]
+  defp keymap_context(state), do: [keymap_server: EditorState.keymap_server(state)]
 end

--- a/lib/minga_editor/input/scoped.ex
+++ b/lib/minga_editor/input/scoped.ex
@@ -58,7 +58,7 @@ defmodule MingaEditor.Input.Scoped do
     if Minga.Editing.active_model(state) == Minga.Editing.Model.CUA do
       key = {cp, mods}
 
-      case Keymap.resolve_scoped_key(:editor, :cua, key, keymap_context(state)) do
+      case Keymap.resolve_scoped_key(:editor, :cua, key, EditorState.keymap_context(state)) do
         {:command, command} ->
           {:handled, Commands.execute(state, command)}
 
@@ -227,7 +227,7 @@ defmodule MingaEditor.Input.Scoped do
         ) ::
           MingaEditor.Input.Handler.result()
   defp resolve_scope_key(state, scope_name, vim_state, key, cp, mods) do
-    case Keymap.resolve_scoped_key(scope_name, vim_state, key, keymap_context(state)) do
+    case Keymap.resolve_scoped_key(scope_name, vim_state, key, EditorState.keymap_context(state)) do
       {:command, command} ->
         {:handled, Commands.execute(state, command)}
 
@@ -305,7 +305,4 @@ defmodule MingaEditor.Input.Scoped do
           cursor_line >= start and cursor_line < start + text_len
       end)
   end
-
-  @spec keymap_context(EditorState.t()) :: [{:keymap_server, GenServer.server()}]
-  defp keymap_context(state), do: [keymap_server: EditorState.keymap_server(state)]
 end

--- a/lib/minga_editor/key_dispatch.ex
+++ b/lib/minga_editor/key_dispatch.ex
@@ -231,42 +231,46 @@ defmodule MingaEditor.KeyDispatch do
   defp populate_mode_tries(%Minga.Mode.State{} = mode_state, mode, state) do
     %{
       mode_state
-      | leader_trie: fetch_leader_trie(),
-        normal_bindings: fetch_normal_bindings(),
-        mode_trie: fetch_mode_trie(mode, active_filetype(state))
+      | leader_trie: fetch_leader_trie(state),
+        normal_bindings: fetch_normal_bindings(state),
+        mode_trie: fetch_mode_trie(state, mode, active_filetype(state))
     }
   end
 
   defp populate_mode_tries(%{mode_trie: _} = mode_state, mode, state) do
-    %{mode_state | mode_trie: fetch_mode_trie(mode, active_filetype(state))}
+    %{mode_state | mode_trie: fetch_mode_trie(state, mode, active_filetype(state))}
   end
 
   defp populate_mode_tries(mode_state, _mode, _state), do: mode_state
 
-  @spec fetch_leader_trie() :: Minga.Keymap.Bindings.node_t()
-  defp fetch_leader_trie do
-    Keymap.leader_trie()
+  @spec fetch_leader_trie(EditorState.t()) :: Minga.Keymap.Bindings.node_t()
+  defp fetch_leader_trie(state) do
+    Keymap.leader_trie(EditorState.keymap_server(state))
   catch
     :exit, _ -> Keymap.default_leader_trie()
   end
 
-  @spec fetch_normal_bindings() :: %{Minga.Keymap.Bindings.key() => {atom(), String.t()}}
-  defp fetch_normal_bindings do
-    Keymap.normal_bindings()
+  @spec fetch_normal_bindings(EditorState.t()) :: %{
+          Minga.Keymap.Bindings.key() => {atom(), String.t()}
+        }
+  defp fetch_normal_bindings(state) do
+    Keymap.normal_bindings(EditorState.keymap_server(state))
   catch
     :exit, _ -> Keymap.default_normal_bindings()
   end
 
-  @spec fetch_mode_trie(Mode.mode(), atom()) :: Minga.Keymap.Bindings.node_t() | nil
-  defp fetch_mode_trie(mode, filetype) when mode in [:insert, :visual] do
-    global = Keymap.mode_trie(mode)
-    ft = Keymap.Active.filetype_mode_trie(filetype, mode)
+  @spec fetch_mode_trie(EditorState.t(), Mode.mode(), atom()) ::
+          Minga.Keymap.Bindings.node_t() | nil
+  defp fetch_mode_trie(state, mode, filetype) when mode in [:insert, :visual] do
+    keymap_server = EditorState.keymap_server(state)
+    global = Keymap.mode_trie(keymap_server, mode)
+    ft = Minga.Keymap.Active.filetype_mode_trie(keymap_server, filetype, mode)
     merge_tries(global, ft)
   catch
     :exit, _ -> nil
   end
 
-  defp fetch_mode_trie(_mode, _filetype), do: nil
+  defp fetch_mode_trie(_state, _mode, _filetype), do: nil
 
   # Merges filetype-specific bindings on top of global mode bindings.
   # Filetype bindings override global ones on conflict (same key).

--- a/lib/minga_editor/key_dispatch.ex
+++ b/lib/minga_editor/key_dispatch.ex
@@ -247,7 +247,9 @@ defmodule MingaEditor.KeyDispatch do
   defp fetch_leader_trie(state) do
     Keymap.leader_trie(EditorState.keymap_server(state))
   catch
-    :exit, _ -> Keymap.default_leader_trie()
+    :exit, _ ->
+      Minga.Log.warning(:config, "leader_trie unavailable; falling back to defaults")
+      Keymap.default_leader_trie()
   end
 
   @spec fetch_normal_bindings(EditorState.t()) :: %{
@@ -256,7 +258,9 @@ defmodule MingaEditor.KeyDispatch do
   defp fetch_normal_bindings(state) do
     Keymap.normal_bindings(EditorState.keymap_server(state))
   catch
-    :exit, _ -> Keymap.default_normal_bindings()
+    :exit, _ ->
+      Minga.Log.warning(:config, "normal_bindings unavailable; falling back to defaults")
+      Keymap.default_normal_bindings()
   end
 
   @spec fetch_mode_trie(EditorState.t(), Mode.mode(), atom()) ::
@@ -267,7 +271,9 @@ defmodule MingaEditor.KeyDispatch do
     ft = Minga.Keymap.Active.filetype_mode_trie(keymap_server, filetype, mode)
     merge_tries(global, ft)
   catch
-    :exit, _ -> nil
+    :exit, _ ->
+      Minga.Log.warning(:config, "mode_trie unavailable for #{inspect(mode)}; using nil")
+      nil
   end
 
   defp fetch_mode_trie(_state, _mode, _filetype), do: nil

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -44,6 +44,7 @@ defmodule MingaEditor.Startup do
   def build_initial_state(opts) do
     backend = Keyword.get(opts, :backend, :headless)
     port_manager = Keyword.get(opts, :port_manager, MingaEditor.Frontend.Manager)
+    keymap_server = Keyword.get(opts, :keymap_server, Minga.Keymap.Active)
     width = Keyword.get(opts, :width, 80)
     height = Keyword.get(opts, :height, 24)
     buffer = Keyword.get(opts, :buffer)
@@ -116,6 +117,7 @@ defmodule MingaEditor.Startup do
       backend: backend,
       workspace: workspace,
       port_manager: port_manager,
+      keymap_server: keymap_server,
       editing_model: editing_model,
       focus_stack: MingaEditor.Input.default_stack(),
       shell: resolve_shell(opts),

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -44,7 +44,7 @@ defmodule MingaEditor.Startup do
   def build_initial_state(opts) do
     backend = Keyword.get(opts, :backend, :headless)
     port_manager = Keyword.get(opts, :port_manager, MingaEditor.Frontend.Manager)
-    keymap_server = Keyword.get(opts, :keymap_server, Minga.Keymap.Active)
+    keymap_server = Keyword.get(opts, :keymap_server, Minga.Keymap.default_server())
     width = Keyword.get(opts, :width, 80)
     height = Keyword.get(opts, :height, 24)
     buffer = Keyword.get(opts, :buffer)

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -72,7 +72,10 @@ defmodule MingaEditor.State do
   @typedoc "A document highlight range from the LSP server."
   @type document_highlight :: Minga.LSP.DocumentHighlight.t()
 
-  @type keymap_server :: GenServer.server()
+  @typedoc "Re-export of `Minga.Keymap.server/0` for editor-state callers."
+  @type keymap_server :: Minga.Keymap.server()
+
+  @default_keymap_server Minga.Keymap.default_server()
 
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.Shell.Board.State, as: BoardState
@@ -80,7 +83,7 @@ defmodule MingaEditor.State do
   @enforce_keys [:port_manager, :workspace]
   defstruct backend: :headless,
             port_manager: nil,
-            keymap_server: Minga.Keymap.Active,
+            keymap_server: @default_keymap_server,
             workspace: nil,
             editing_model: :vim,
             shell: MingaEditor.Shell.Traditional,

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -72,12 +72,15 @@ defmodule MingaEditor.State do
   @typedoc "A document highlight range from the LSP server."
   @type document_highlight :: Minga.LSP.DocumentHighlight.t()
 
+  @type keymap_server :: GenServer.server()
+
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.Shell.Board.State, as: BoardState
 
   @enforce_keys [:port_manager, :workspace]
   defstruct backend: :headless,
             port_manager: nil,
+            keymap_server: Minga.Keymap.Active,
             workspace: nil,
             editing_model: :vim,
             shell: MingaEditor.Shell.Traditional,
@@ -109,6 +112,7 @@ defmodule MingaEditor.State do
   @type t :: %__MODULE__{
           backend: backend(),
           port_manager: GenServer.server() | nil,
+          keymap_server: keymap_server(),
           workspace: WorkspaceState.t(),
           editing_model: :vim | :cua,
           shell: module(),
@@ -138,6 +142,11 @@ defmodule MingaEditor.State do
           space_leader_timer: reference() | nil,
           stashed_board_state: MingaEditor.Shell.Board.State.t() | nil
         }
+
+  @doc "Returns the keymap server used for scope and binding lookups."
+  @spec keymap_server(t()) :: keymap_server()
+  def keymap_server(%__MODULE__{keymap_server: nil}), do: Minga.Keymap.Active
+  def keymap_server(%__MODULE__{keymap_server: keymap_server}), do: keymap_server
 
   # ── Workspace helpers ──────────────────────────────────────────────────────
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -145,8 +145,12 @@ defmodule MingaEditor.State do
 
   @doc "Returns the keymap server used for scope and binding lookups."
   @spec keymap_server(t()) :: keymap_server()
-  def keymap_server(%__MODULE__{keymap_server: nil}), do: Minga.Keymap.Active
   def keymap_server(%__MODULE__{keymap_server: keymap_server}), do: keymap_server
+
+  @doc "Returns the keymap context keyword list passed to scoped key resolution."
+  @spec keymap_context(t()) :: [{:keymap_server, keymap_server()}]
+  def keymap_context(%__MODULE__{} = state),
+    do: [keymap_server: keymap_server(state)]
 
   # ── Workspace helpers ──────────────────────────────────────────────────────
 

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -10,10 +10,7 @@ defmodule Minga.Config.LoaderTest do
   alias Minga.Keymap.Active, as: KeymapActive
 
   setup do
-    keymap_server =
-      String.to_atom("loader_keymap_#{System.unique_integer([:positive])}_config")
-
-    start_supervised!({KeymapActive, name: keymap_server})
+    keymap_server = start_supervised!({KeymapActive, name: nil})
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
     # Ensure other global servers are running (config eval needs them)

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -1,6 +1,6 @@
 defmodule Minga.Config.LoaderTest do
   # credo:disable-for-this-file Credo.Check.Refactor.Apply
-  # Not async because we manipulate XDG_CONFIG_HOME and the global Options/Hooks/Keymap servers
+  # Not async because we manipulate XDG_CONFIG_HOME and shared environment
   use ExUnit.Case, async: false
 
   alias Minga.Command.Registry, as: CommandRegistry
@@ -10,13 +10,27 @@ defmodule Minga.Config.LoaderTest do
   alias Minga.Keymap.Active, as: KeymapActive
 
   setup do
-    # Ensure all global servers are running (config eval needs them)
-    for {mod, _} <- [{Options, nil}, {Hooks, nil}, {KeymapActive, nil}, {CommandRegistry, nil}] do
+    keymap_server =
+      String.to_atom("loader_keymap_#{System.unique_integer([:positive])}_config")
+
+    start_supervised!({KeymapActive, name: keymap_server})
+    previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
+
+    # Ensure other global servers are running (config eval needs them)
+    for {mod, _} <- [{Options, nil}, {Hooks, nil}, {CommandRegistry, nil}] do
       case mod.start_link() do
         {:ok, _} -> :ok
         {:error, {:already_started, _}} -> mod.reset()
       end
     end
+
+    on_exit(fn ->
+      if is_nil(previous_keymap_server) do
+        Process.delete(:minga_config_keymap)
+      else
+        Process.put(:minga_config_keymap, previous_keymap_server)
+      end
+    end)
 
     :ok
   end

--- a/test/minga/config_test.exs
+++ b/test/minga/config_test.exs
@@ -21,10 +21,11 @@ defmodule Minga.ConfigTest do
         Options.set(:clipboard, :none)
     end
 
-    case KeymapActive.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> KeymapActive.reset()
-    end
+    keymap_server =
+      String.to_atom("minga_test_keymap_#{System.unique_integer([:positive])}_config_test")
+
+    start_supervised!({KeymapActive, name: keymap_server})
+    previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
     case CommandRegistry.start_link() do
       {:ok, _} -> :ok
@@ -47,7 +48,7 @@ defmodule Minga.ConfigTest do
     on_exit(fn ->
       PopupRegistry.clear()
 
-      for mod <- [KeymapActive, Hooks] do
+      for mod <- [Hooks] do
         try do
           mod.reset()
         catch
@@ -61,6 +62,12 @@ defmodule Minga.ConfigTest do
         :exit, _ -> :ok
       end
 
+      if is_nil(previous_keymap_server) do
+        Process.delete(:minga_config_keymap)
+      else
+        Process.put(:minga_config_keymap, previous_keymap_server)
+      end
+
       try do
         Options.reset()
         Options.set(:clipboard, :none)
@@ -69,7 +76,12 @@ defmodule Minga.ConfigTest do
       end
     end)
 
-    :ok
+    %{keymap_server: keymap_server}
+  end
+
+  @spec test_keymap_server() :: GenServer.server()
+  defp test_keymap_server do
+    Process.get(:minga_config_keymap, KeymapActive)
   end
 
   describe "use Minga.Config" do
@@ -106,7 +118,7 @@ defmodule Minga.ConfigTest do
     test "adds a leader key binding" do
       Minga.Config.bind(:normal, "SPC g s", :git_status, "Git status")
 
-      trie = KeymapActive.leader_trie()
+      trie = KeymapActive.leader_trie(test_keymap_server())
       {:prefix, g_node} = Bindings.lookup(trie, {?g, 0})
       assert {:command, :git_status} = Bindings.lookup(g_node, {?s, 0})
     end
@@ -114,21 +126,21 @@ defmodule Minga.ConfigTest do
     test "binds insert-mode key" do
       Minga.Config.bind(:insert, "C-j", :next_line, "Next line")
 
-      trie = KeymapActive.mode_trie(:insert)
+      trie = KeymapActive.mode_trie(test_keymap_server(), :insert)
       assert {:command, :next_line} = Bindings.lookup(trie, {?j, 0x02})
     end
 
     test "binds visual-mode key" do
       Minga.Config.bind(:visual, "C-x", :custom_cut, "Custom cut")
 
-      trie = KeymapActive.mode_trie(:visual)
+      trie = KeymapActive.mode_trie(test_keymap_server(), :visual)
       assert {:command, :custom_cut} = Bindings.lookup(trie, {?x, 0x02})
     end
 
     test "binds scope-specific key" do
       Minga.Config.bind({:agent, :normal}, "y", :agent_copy, "Agent copy")
 
-      trie = KeymapActive.scope_trie(:agent, :normal)
+      trie = KeymapActive.scope_trie(test_keymap_server(), :agent, :normal)
       assert {:command, :agent_copy} = Bindings.lookup(trie, {?y, 0})
     end
 
@@ -142,7 +154,7 @@ defmodule Minga.ConfigTest do
     test "registers filetype-scoped binding" do
       Minga.Config.bind(:normal, "SPC m t", :mix_test, "Run tests", filetype: :elixir)
 
-      trie = KeymapActive.filetype_trie(:elixir)
+      trie = KeymapActive.filetype_trie(test_keymap_server(), :elixir)
       assert {:command, :mix_test} = Bindings.lookup(trie, {?t, 0})
     end
   end
@@ -158,7 +170,7 @@ defmodule Minga.ConfigTest do
       end
       """)
 
-      trie = KeymapActive.filetype_trie(:elixir)
+      trie = KeymapActive.filetype_trie(test_keymap_server(), :elixir)
       assert {:command, :mix_test} = Bindings.lookup(trie, {?t, 0})
       assert {:command, :mix_format} = Bindings.lookup(trie, {?f, 0})
     end
@@ -175,12 +187,12 @@ defmodule Minga.ConfigTest do
       """)
 
       # The "SPC z z" binding should be global (in leader trie), not scoped to :go
-      trie = KeymapActive.leader_trie()
+      trie = KeymapActive.leader_trie(test_keymap_server())
       {:prefix, z_node} = Bindings.lookup(trie, {?z, 0})
       assert {:command, :global_cmd} = Bindings.lookup(z_node, {?z, 0})
 
       # And not in the go filetype trie
-      go_trie = KeymapActive.filetype_trie(:go)
+      go_trie = KeymapActive.filetype_trie(test_keymap_server(), :go)
       assert :not_found = Bindings.lookup(go_trie, {?z, 0})
     end
   end

--- a/test/minga/config_test.exs
+++ b/test/minga/config_test.exs
@@ -21,10 +21,7 @@ defmodule Minga.ConfigTest do
         Options.set(:clipboard, :none)
     end
 
-    keymap_server =
-      String.to_atom("minga_test_keymap_#{System.unique_integer([:positive])}_config_test")
-
-    start_supervised!({KeymapActive, name: keymap_server})
+    keymap_server = start_supervised!({KeymapActive, name: nil})
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
     case CommandRegistry.start_link() do

--- a/test/minga/keymap/scope_user_override_test.exs
+++ b/test/minga/keymap/scope_user_override_test.exs
@@ -6,10 +6,7 @@ defmodule Minga.Keymap.Scope.UserOverrideTest do
   alias Minga.Keymap.Scope
 
   setup do
-    keymap_server =
-      String.to_atom("scope_override_#{System.unique_integer([:positive])}_keymap")
-
-    start_supervised!({KeymapActive, name: keymap_server})
+    keymap_server = start_supervised!({KeymapActive, name: nil})
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
     on_exit(fn ->

--- a/test/minga/keymap/scope_user_override_test.exs
+++ b/test/minga/keymap/scope_user_override_test.exs
@@ -89,4 +89,38 @@ defmodule Minga.Keymap.Scope.UserOverrideTest do
                Scope.resolve_key(:agent, :normal, {?~, 0}, keymap_server: test_keymap_server())
     end
   end
+
+  describe ":keymap_server context routes to the requested server" do
+    # Discriminating tests: bind on server A, resolve against server B, prove
+    # the override is consulted. Without this, a regression that ignored the
+    # context would still pass the producer-and-asserter-share-a-server tests.
+    test "binding on server_a is not visible when resolving against server_b" do
+      server_a = start_supervised!({KeymapActive, name: nil}, id: :server_a)
+      server_b = start_supervised!({KeymapActive, name: nil}, id: :server_b)
+
+      KeymapActive.bind(server_a, {:agent, :normal}, "~", :only_on_a, "Only A")
+
+      assert {:command, :only_on_a} =
+               Scope.resolve_key(:agent, :normal, {?~, 0}, keymap_server: server_a)
+
+      # Server B has no override for `~`, so the agent default applies (which
+      # is :not_found for tilde, per the scope defaults).
+      assert :not_found =
+               Scope.resolve_key(:agent, :normal, {?~, 0}, keymap_server: server_b)
+    end
+
+    test "different bindings on server_a and server_b are honored independently" do
+      server_a = start_supervised!({KeymapActive, name: nil}, id: :server_a)
+      server_b = start_supervised!({KeymapActive, name: nil}, id: :server_b)
+
+      KeymapActive.bind(server_a, {:agent, :normal}, "y", :yank_a, "Yank A")
+      KeymapActive.bind(server_b, {:agent, :normal}, "y", :yank_b, "Yank B")
+
+      assert {:command, :yank_a} =
+               Scope.resolve_key(:agent, :normal, {?y, 0}, keymap_server: server_a)
+
+      assert {:command, :yank_b} =
+               Scope.resolve_key(:agent, :normal, {?y, 0}, keymap_server: server_b)
+    end
+  end
 end

--- a/test/minga/keymap/scope_user_override_test.exs
+++ b/test/minga/keymap/scope_user_override_test.exs
@@ -1,60 +1,95 @@
 defmodule Minga.Keymap.Scope.UserOverrideTest do
   @moduledoc "Tests for user-defined scope overrides via Keymap.Active."
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Minga.Keymap.Active, as: KeymapActive
   alias Minga.Keymap.Scope
 
   setup do
-    case KeymapActive.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> KeymapActive.reset()
-    end
+    keymap_server =
+      String.to_atom("scope_override_#{System.unique_integer([:positive])}_keymap")
+
+    start_supervised!({KeymapActive, name: keymap_server})
+    previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
     on_exit(fn ->
-      try do
-        KeymapActive.reset()
-      catch
-        :exit, _ -> :ok
+      if is_nil(previous_keymap_server) do
+        Process.delete(:minga_config_keymap)
+      else
+        Process.put(:minga_config_keymap, previous_keymap_server)
       end
     end)
 
     :ok
   end
 
+  @spec test_keymap_server() :: GenServer.server()
+  defp test_keymap_server, do: Process.get(:minga_config_keymap, KeymapActive)
+
   describe "scope overrides take priority over scope defaults" do
     test "user override for agent scope normal mode wins" do
       # y is :agent_copy_code_block by default
-      assert {:command, :agent_copy_code_block} = Scope.resolve_key(:agent, :normal, {?y, 0})
+      assert {:command, :agent_copy_code_block} =
+               Scope.resolve_key(:agent, :normal, {?y, 0}, keymap_server: test_keymap_server())
 
       # Override it
-      KeymapActive.bind({:agent, :normal}, "y", :my_custom_yank, "Custom yank")
+      KeymapActive.bind(
+        test_keymap_server(),
+        {:agent, :normal},
+        "y",
+        :my_custom_yank,
+        "Custom yank"
+      )
 
       # Now the override takes priority
-      assert {:command, :my_custom_yank} = Scope.resolve_key(:agent, :normal, {?y, 0})
+      assert {:command, :my_custom_yank} =
+               Scope.resolve_key(:agent, :normal, {?y, 0}, keymap_server: test_keymap_server())
     end
 
     test "user override for file_tree scope works" do
       # q is :tree_close by default
-      assert {:command, :tree_close} = Scope.resolve_key(:file_tree, :normal, {?q, 0})
+      assert {:command, :tree_close} =
+               Scope.resolve_key(:file_tree, :normal, {?q, 0},
+                 keymap_server: test_keymap_server()
+               )
 
-      KeymapActive.bind({:file_tree, :normal}, "q", :custom_close, "Custom close")
-      assert {:command, :custom_close} = Scope.resolve_key(:file_tree, :normal, {?q, 0})
+      KeymapActive.bind(
+        test_keymap_server(),
+        {:file_tree, :normal},
+        "q",
+        :custom_close,
+        "Custom close"
+      )
+
+      assert {:command, :custom_close} =
+               Scope.resolve_key(:file_tree, :normal, {?q, 0},
+                 keymap_server: test_keymap_server()
+               )
     end
 
     test "non-overridden keys still work from scope defaults" do
-      KeymapActive.bind({:agent, :normal}, "y", :my_yank, "My yank")
+      KeymapActive.bind(test_keymap_server(), {:agent, :normal}, "y", :my_yank, "My yank")
 
       # q should still be agent_close from the default scope keymap
-      assert {:command, :agent_close} = Scope.resolve_key(:agent, :normal, {?q, 0})
+      assert {:command, :agent_close} =
+               Scope.resolve_key(:agent, :normal, {?q, 0}, keymap_server: test_keymap_server())
     end
 
     test "user can add new keys to a scope" do
       # tilde is not bound in agent scope by default
-      assert :not_found = Scope.resolve_key(:agent, :normal, {?~, 0})
+      assert :not_found =
+               Scope.resolve_key(:agent, :normal, {?~, 0}, keymap_server: test_keymap_server())
 
-      KeymapActive.bind({:agent, :normal}, "~", :toggle_debug, "Toggle debug")
-      assert {:command, :toggle_debug} = Scope.resolve_key(:agent, :normal, {?~, 0})
+      KeymapActive.bind(
+        test_keymap_server(),
+        {:agent, :normal},
+        "~",
+        :toggle_debug,
+        "Toggle debug"
+      )
+
+      assert {:command, :toggle_debug} =
+               Scope.resolve_key(:agent, :normal, {?~, 0}, keymap_server: test_keymap_server())
     end
   end
 end

--- a/test/minga/mode/insert_test.exs
+++ b/test/minga/mode/insert_test.exs
@@ -123,10 +123,7 @@ defmodule Minga.Mode.Insert.UserOverrideTest do
   end
 
   setup do
-    keymap_server =
-      String.to_atom("insert_override_#{System.unique_integer([:positive])}_keymap")
-
-    start_supervised!({KeymapActive, name: keymap_server})
+    keymap_server = start_supervised!({KeymapActive, name: nil})
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
     on_exit(fn ->

--- a/test/minga/mode/insert_test.exs
+++ b/test/minga/mode/insert_test.exs
@@ -95,7 +95,7 @@ end
 
 defmodule Minga.Mode.Insert.UserOverrideTest do
   @moduledoc "Tests for user-defined insert mode bindings via Keymap.Active."
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Minga.Keymap.Active, as: KeymapActive
   alias Minga.Keymap.Bindings
@@ -105,10 +105,14 @@ defmodule Minga.Mode.Insert.UserOverrideTest do
   defp fresh_state, do: Mode.initial_state()
 
   # Builds a mode_trie by merging filetype bindings on top of global insert bindings.
-  defp state_with_trie(filetype \\ :text) do
-    global = KeymapActive.mode_trie(:insert)
+  defp test_keymap_server do
+    Process.get(:minga_config_keymap, KeymapActive)
+  end
 
-    ft_trie = KeymapActive.filetype_mode_trie(filetype, :insert)
+  defp state_with_trie(filetype \\ :text) do
+    global = KeymapActive.mode_trie(test_keymap_server(), :insert)
+
+    ft_trie = KeymapActive.filetype_mode_trie(test_keymap_server(), filetype, :insert)
 
     mode_trie =
       Enum.reduce(ft_trie.children, global, fn {key, %{command: cmd, description: desc}}, acc ->
@@ -119,16 +123,17 @@ defmodule Minga.Mode.Insert.UserOverrideTest do
   end
 
   setup do
-    case KeymapActive.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> KeymapActive.reset()
-    end
+    keymap_server =
+      String.to_atom("insert_override_#{System.unique_integer([:positive])}_keymap")
+
+    start_supervised!({KeymapActive, name: keymap_server})
+    previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
     on_exit(fn ->
-      try do
-        KeymapActive.reset()
-      catch
-        :exit, _ -> :ok
+      if is_nil(previous_keymap_server) do
+        Process.delete(:minga_config_keymap)
+      else
+        Process.put(:minga_config_keymap, previous_keymap_server)
       end
     end)
 
@@ -137,13 +142,13 @@ defmodule Minga.Mode.Insert.UserOverrideTest do
 
   describe "user-defined insert-mode overrides" do
     test "Ctrl+J bound to :next_line overrides default (continue)" do
-      KeymapActive.bind(:insert, "C-j", :next_line, "Next line")
+      KeymapActive.bind(test_keymap_server(), :insert, "C-j", :next_line, "Next line")
 
       assert {:execute, :next_line, _} = Insert.handle_key({?j, 0x02}, state_with_trie())
     end
 
     test "Ctrl+K bound to :prev_line overrides default (continue)" do
-      KeymapActive.bind(:insert, "C-k", :prev_line, "Prev line")
+      KeymapActive.bind(test_keymap_server(), :insert, "C-k", :prev_line, "Prev line")
 
       assert {:execute, :prev_line, _} = Insert.handle_key({?k, 0x02}, state_with_trie())
     end
@@ -154,7 +159,7 @@ defmodule Minga.Mode.Insert.UserOverrideTest do
     end
 
     test "built-in keys still work when user overrides exist" do
-      KeymapActive.bind(:insert, "C-j", :next_line, "Next line")
+      KeymapActive.bind(test_keymap_server(), :insert, "C-j", :next_line, "Next line")
       state = state_with_trie()
 
       # Escape should still transition to normal
@@ -170,27 +175,34 @@ defmodule Minga.Mode.Insert.UserOverrideTest do
 
   describe "filetype-scoped insert-mode overrides" do
     test "filetype binding fires when filetype matches" do
-      KeymapActive.bind(:insert, "C-j", :org_special, "Org special", filetype: :org)
+      KeymapActive.bind(test_keymap_server(), :insert, "C-j", :org_special, "Org special",
+        filetype: :org
+      )
 
       assert {:execute, :org_special, _} = Insert.handle_key({?j, 0x02}, state_with_trie(:org))
     end
 
     test "filetype binding does not fire for different filetype" do
-      KeymapActive.bind(:insert, "C-j", :org_special, "Org special", filetype: :org)
+      KeymapActive.bind(test_keymap_server(), :insert, "C-j", :org_special, "Org special",
+        filetype: :org
+      )
 
       assert {:continue, _} = Insert.handle_key({?j, 0x02}, state_with_trie(:elixir))
     end
 
     test "filetype binding shadows global binding for same key" do
-      KeymapActive.bind(:insert, "C-j", :global_next, "Global next")
-      KeymapActive.bind(:insert, "C-j", :org_special, "Org special", filetype: :org)
+      KeymapActive.bind(test_keymap_server(), :insert, "C-j", :global_next, "Global next")
+
+      KeymapActive.bind(test_keymap_server(), :insert, "C-j", :org_special, "Org special",
+        filetype: :org
+      )
 
       assert {:execute, :org_special, _} = Insert.handle_key({?j, 0x02}, state_with_trie(:org))
       assert {:execute, :global_next, _} = Insert.handle_key({?j, 0x02}, state_with_trie(:elixir))
     end
 
     test "global binding fires when no filetype binding exists" do
-      KeymapActive.bind(:insert, "C-k", :global_prev, "Global prev")
+      KeymapActive.bind(test_keymap_server(), :insert, "C-k", :global_prev, "Global prev")
 
       assert {:execute, :global_prev, _} = Insert.handle_key({?k, 0x02}, state_with_trie(:org))
     end

--- a/test/minga/mode/visual_user_override_test.exs
+++ b/test/minga/mode/visual_user_override_test.exs
@@ -1,6 +1,6 @@
 defmodule Minga.Mode.Visual.UserOverrideTest do
   @moduledoc "Tests for user-defined visual mode bindings via Keymap.Active."
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Minga.Keymap.Active, as: KeymapActive
   alias Minga.Mode.Visual
@@ -10,25 +10,28 @@ defmodule Minga.Mode.Visual.UserOverrideTest do
     %VisualState{visual_anchor: anchor, visual_type: type}
   end
 
+  defp test_keymap_server do
+    Process.get(:minga_config_keymap, KeymapActive)
+  end
+
   defp visual_state_with_trie(anchor \\ {0, 0}, type \\ :char) do
-    global = KeymapActive.mode_trie(:visual)
+    global = KeymapActive.mode_trie(test_keymap_server(), :visual)
 
     %VisualState{visual_anchor: anchor, visual_type: type, mode_trie: global}
   end
 
   setup do
-    # KeymapActive is a global singleton; start_supervised! won't work until
-    # it accepts a name: param. See autoresearch.md for the planned refactor.
-    case KeymapActive.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> KeymapActive.reset()
-    end
+    keymap_server =
+      String.to_atom("visual_override_#{System.unique_integer([:positive])}_keymap")
+
+    start_supervised!({KeymapActive, name: keymap_server})
+    previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
     on_exit(fn ->
-      try do
-        KeymapActive.reset()
-      catch
-        :exit, _ -> :ok
+      if is_nil(previous_keymap_server) do
+        Process.delete(:minga_config_keymap)
+      else
+        Process.put(:minga_config_keymap, previous_keymap_server)
       end
     end)
 
@@ -37,7 +40,7 @@ defmodule Minga.Mode.Visual.UserOverrideTest do
 
   describe "user-defined visual-mode overrides" do
     test "Ctrl+X bound to :custom_cut executes the command" do
-      KeymapActive.bind(:visual, "C-x", :custom_cut, "Custom cut")
+      KeymapActive.bind(test_keymap_server(), :visual, "C-x", :custom_cut, "Custom cut")
 
       state = visual_state_with_trie()
       assert {:execute, :custom_cut, _} = Visual.handle_key({?x, 0x02}, state)
@@ -50,7 +53,7 @@ defmodule Minga.Mode.Visual.UserOverrideTest do
     end
 
     test "built-in visual keys still work when user overrides exist" do
-      KeymapActive.bind(:visual, "C-x", :custom_cut, "Custom cut")
+      KeymapActive.bind(test_keymap_server(), :visual, "C-x", :custom_cut, "Custom cut")
 
       state = visual_state()
       # Escape should still transition to normal

--- a/test/minga/mode/visual_user_override_test.exs
+++ b/test/minga/mode/visual_user_override_test.exs
@@ -21,10 +21,7 @@ defmodule Minga.Mode.Visual.UserOverrideTest do
   end
 
   setup do
-    keymap_server =
-      String.to_atom("visual_override_#{System.unique_integer([:positive])}_keymap")
-
-    start_supervised!({KeymapActive, name: keymap_server})
+    keymap_server = start_supervised!({KeymapActive, name: nil})
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
     on_exit(fn ->

--- a/test/minga_editor/state/keymap_server_threading_test.exs
+++ b/test/minga_editor/state/keymap_server_threading_test.exs
@@ -1,0 +1,79 @@
+defmodule MingaEditor.State.KeymapServerThreadingTest do
+  @moduledoc """
+  Integration test that proves `EditorState.keymap_server` is honored end-to-end.
+
+  Without this test, every other test in the keymap suite would still pass even
+  if `EditorState.keymap_server/1` were stubbed to ignore the field and always
+  return the default singleton — because all the other tests both bind on and
+  resolve against the same server, picked from the process dictionary.
+
+  Here we start two anonymous `KeymapActive` servers, point an `EditorState` at
+  one of them, and assert that scope resolution through
+  `EditorState.keymap_context/1` honors that choice rather than falling back to
+  the singleton.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Keymap.Active, as: KeymapActive
+  alias Minga.Keymap.Scope
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias Minga.Mode
+
+  defp build_state(keymap_server) do
+    %EditorState{
+      port_manager: self(),
+      keymap_server: keymap_server,
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: %VimState{mode: :normal, mode_state: Mode.initial_state()},
+        buffers: %Buffers{active: nil, list: []},
+        keymap_scope: :agent
+      }
+    }
+  end
+
+  test "EditorState.keymap_server flows through keymap_context to scope resolution" do
+    server_a = start_supervised!({KeymapActive, name: nil}, id: :server_a)
+    server_b = start_supervised!({KeymapActive, name: nil}, id: :server_b)
+
+    # Same key, different commands per server.
+    KeymapActive.bind(server_a, {:agent, :normal}, "~", :cmd_from_a, "From A")
+    KeymapActive.bind(server_b, {:agent, :normal}, "~", :cmd_from_b, "From B")
+
+    state_a = build_state(server_a)
+    state_b = build_state(server_b)
+
+    # The accessor returns the right server.
+    assert EditorState.keymap_server(state_a) == server_a
+    assert EditorState.keymap_server(state_b) == server_b
+
+    # The keymap_context kw list carries the server.
+    assert EditorState.keymap_context(state_a) == [keymap_server: server_a]
+    assert EditorState.keymap_context(state_b) == [keymap_server: server_b]
+
+    # End-to-end: scope resolution through the editor state's context honors
+    # which server the state points at, even when both servers have a binding
+    # for the same key.
+    assert {:command, :cmd_from_a} =
+             Scope.resolve_key(:agent, :normal, {?~, 0}, EditorState.keymap_context(state_a))
+
+    assert {:command, :cmd_from_b} =
+             Scope.resolve_key(:agent, :normal, {?~, 0}, EditorState.keymap_context(state_b))
+  end
+
+  test "EditorState defaults keymap_server to Minga.Keymap.default_server/0" do
+    state = %EditorState{
+      port_manager: self(),
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: %VimState{mode: :normal, mode_state: Mode.initial_state()},
+        buffers: %Buffers{active: nil, list: []}
+      }
+    }
+
+    assert EditorState.keymap_server(state) == Minga.Keymap.default_server()
+  end
+end


### PR DESCRIPTION
## Summary
This change moves keymap resolution in ticket #1445 toward instance-aware behavior while preserving default singleton compatibility.

## What changed
- Added server-aware keymap API entrypoints in `Minga.Keymap` while keeping zero-arity defaults.
- Threaded the active keymap server through editor state and startup.
- Updated key dispatch and scoped handlers to resolve leader/normal/mode/filetype/scope tries from editor state server.
- Migrated config loading to run with a process-local keymap server selector (`:minga_config_keymap`) and persisted that server in loader state.
- Updated config loader and tests to support isolated, per-test keymap servers.

## Validation
- `touch priv/minga-renderer priv/minga-parser && mix test --no-compile`
  - 54 doctests, 95 properties, 7590 tests, 0 failures, 6 skipped (1 excluded)

## Notes
- Default behavior still uses `Minga.Keymap.Active` when no explicit server is provided.
- This preserves legacy precedence semantics and improves async-safety around keymap state.
