### PR TITLE
feat(buffer): expose undo/redo edit source via public Server API

### DIFF
--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -605,6 +605,18 @@ defmodule Minga.Buffer.Server do
     GenServer.call(server, :redo)
   end
 
+  @doc "Returns the edit source of the most recent undo entry, or `nil` if the undo stack is empty."
+  @spec last_undo_source(GenServer.server()) :: Minga.Buffer.State.edit_source() | nil
+  def last_undo_source(server) do
+    GenServer.call(server, :last_undo_source)
+  end
+
+  @doc "Returns the edit source of the most recent redo entry, or `nil` if the redo stack is empty."
+  @spec last_redo_source(GenServer.server()) :: Minga.Buffer.State.edit_source() | nil
+  def last_redo_source(server) do
+    GenServer.call(server, :last_redo_source)
+  end
+
   @doc """
   Resets the undo coalescing timer so the next mutation starts a fresh
   undo entry. Call this at undo boundaries like mode transitions (e.g.,
@@ -1616,6 +1628,26 @@ defmodule Minga.Buffer.Server do
 
   def handle_call(:break_undo_coalescing, _from, state) do
     {:reply, :ok, BufState.break_undo_coalescing(state)}
+  end
+
+  def handle_call(:last_undo_source, _from, state) do
+    source =
+      case state.undo_stack do
+        [] -> nil
+        [{_version, _doc, source} | _] -> source
+      end
+
+    {:reply, source, state}
+  end
+
+  def handle_call(:last_redo_source, _from, state) do
+    source =
+      case state.redo_stack do
+        [] -> nil
+        [{_version, _doc, source} | _] -> source
+      end
+
+    {:reply, source, state}
   end
 
   # ── Decoration callbacks ──

--- a/lib/minga/buffer/state.ex
+++ b/lib/minga/buffer/state.ex
@@ -138,7 +138,8 @@ defmodule Minga.Buffer.State do
   separated by a pause.
   """
   @spec push_undo(t(), Document.t(), edit_source()) :: t()
-  def push_undo(%__MODULE__{} = state, new_buf, source) when source in [:user, :agent, :lsp, :recovery] do
+  def push_undo(%__MODULE__{} = state, new_buf, source)
+      when source in [:user, :agent, :lsp, :recovery] do
     now = System.monotonic_time(:millisecond)
     elapsed = now - state.last_undo_at
 

--- a/lib/minga/buffer/state.ex
+++ b/lib/minga/buffer/state.ex
@@ -138,7 +138,7 @@ defmodule Minga.Buffer.State do
   separated by a pause.
   """
   @spec push_undo(t(), Document.t(), edit_source()) :: t()
-  def push_undo(%__MODULE__{} = state, new_buf, source) when source in [:user, :agent, :lsp] do
+  def push_undo(%__MODULE__{} = state, new_buf, source) when source in [:user, :agent, :lsp, :recovery] do
     now = System.monotonic_time(:millisecond)
     elapsed = now - state.last_undo_at
 
@@ -174,7 +174,7 @@ defmodule Minga.Buffer.State do
   """
   @spec push_undo_force(t(), Document.t(), edit_source()) :: t()
   def push_undo_force(%__MODULE__{} = state, new_buf, source)
-      when source in [:user, :agent, :lsp] do
+      when source in [:user, :agent, :lsp, :recovery] do
     now = System.monotonic_time(:millisecond)
     entry = {state.version, state.document, source}
 

--- a/test/minga/buffer/server_test.exs
+++ b/test/minga/buffer/server_test.exs
@@ -771,6 +771,48 @@ defmodule Minga.Buffer.ServerTest do
     end
   end
 
+  describe "last_undo_source/1 and last_redo_source/1" do
+    test "returns nil when stacks are empty" do
+      pid = start_supervised!({Server, content: "hello"})
+      assert Server.last_undo_source(pid) == nil
+      assert Server.last_redo_source(pid) == nil
+    end
+
+    test "returns source of most recent undo entry" do
+      pid = start_supervised!({Server, content: "hello world"})
+      Server.insert_char(pid, "X")
+      assert Server.last_undo_source(pid) == :user
+    end
+
+    test "returns :agent for agent edits" do
+      pid = start_supervised!({Server, content: "hello world"})
+      Server.find_and_replace(pid, "hello", "goodbye")
+      assert Server.last_undo_source(pid) == :agent
+    end
+
+    test "returns :lsp for LSP edits" do
+      pid = start_supervised!({Server, content: "hello"})
+      Server.apply_text_edits(pid, [{{0, 0}, {0, 5}, "goodbye"}])
+      assert Server.last_undo_source(pid) == :lsp
+    end
+
+    test "last_redo_source/1 returns source after undo" do
+      pid = start_supervised!({Server, content: "hello world"})
+      Server.find_and_replace(pid, "hello", "goodbye")
+      Server.undo(pid)
+      assert Server.last_redo_source(pid) == :agent
+    end
+
+    test "redo clears redo and updates undo source" do
+      pid = start_supervised!({Server, content: "hello world"})
+      Server.find_and_replace(pid, "hello", "goodbye")
+      Server.undo(pid)
+      Server.redo(pid)
+      assert Server.last_undo_source(pid) == :agent
+      assert Server.last_redo_source(pid) == nil
+    end
+  end
+
   describe "edit delta tracking" do
     test "insert_char records an insertion delta" do
       {:ok, pid} = Server.start_link(content: "hello")


### PR DESCRIPTION
## Summary

- Adds `Buffer.Server.last_undo_source/1` — returns the source atom (`:user | :agent | :lsp | :recovery | nil`) at the head of the undo stack.
- Adds `Buffer.Server.last_redo_source/1` — same for the redo stack.
- Both have `@spec`, handle the empty-stack case (return `nil`), and are covered by new unit tests in `server_test.exs`.

No production callers added; these exist to unblock Ticket #1447 (rewriting the 7 `:sys.get_state` tests in the `"undo source metadata"` describe block to use the public API).

## Test plan

- [x] `mix test.llm test/minga/buffer/server_test.exs` — 163 tests, 0 failures
- [x] `make lint` — exit 0

Closes #1446

🤖 Generated with [Claude Code](https://claude.com/claude-code)