### PR TITLE
refactor(config): thread Config.Options server through editor state

### DIFF
--- a/lib/minga/config.ex
+++ b/lib/minga/config.ex
@@ -51,10 +51,19 @@ defmodule Minga.Config do
 
   @spec options_server() :: Options.server()
   defp options_server do
-    Process.get(:minga_config_options, Options.default_server())
+    case Process.get(:minga_config_options) do
+      nil -> Options.default_server()
+      server -> Options.validate_server!(server)
+    end
   end
 
   # ── Read options ───────────────────────────────────────────────────
+  #
+  # Reads consult `options_server()` so callers running inside a
+  # `Loader.load_all/2` window see the per-test/per-editor server and not
+  # the global singleton. This matches the write path; without it, an .exs
+  # snippet like `if Config.get(:foo) == :x, do: set(:foo, :y)` would read
+  # from one server and write to another.
 
   @doc """
   Reads a config option value.
@@ -65,7 +74,7 @@ defmodule Minga.Config do
       Config.get(:theme)        #=> :doom_one
   """
   @spec get(Options.option_name()) :: term()
-  defdelegate get(name), to: Options
+  def get(name), do: Options.get(options_server(), name)
 
   @doc """
   Reads a config option, merging per-filetype overrides when present.
@@ -74,7 +83,8 @@ defmodule Minga.Config do
   otherwise falls back to the global value.
   """
   @spec get_for_filetype(Options.option_name(), atom() | nil) :: term()
-  defdelegate get_for_filetype(name, filetype), to: Options
+  def get_for_filetype(name, filetype),
+    do: Options.get_for_filetype(options_server(), name, filetype)
 
   @doc """
   Reads an extension option value.
@@ -84,13 +94,15 @@ defmodule Minga.Config do
       Config.get_extension_option(:minga_org, :conceal)  #=> true
   """
   @spec get_extension_option(atom(), atom()) :: term()
-  defdelegate get_extension_option(ext_name, opt_name), to: Options
+  def get_extension_option(ext_name, opt_name),
+    do: Options.get_extension_option(options_server(), ext_name, opt_name)
 
   @doc """
   Reads an extension option, merging per-filetype overrides when present.
   """
   @spec get_extension_option_for_filetype(atom(), atom(), atom() | nil) :: term()
-  defdelegate get_extension_option_for_filetype(ext_name, opt_name, filetype), to: Options
+  def get_extension_option_for_filetype(ext_name, opt_name, filetype),
+    do: Options.get_extension_option_for_filetype(options_server(), ext_name, opt_name, filetype)
 
   # ── Write options (non-raising) ────────────────────────────────────
 
@@ -101,22 +113,29 @@ defmodule Minga.Config do
   returns the result tuple for callers that handle errors themselves.
   """
   @spec set_option(Options.option_name(), term()) :: {:ok, term()} | {:error, String.t()}
-  defdelegate set_option(name, value), to: Options, as: :set
+  def set_option(name, value), do: Options.set(options_server(), name, value)
 
   @doc """
   Sets an extension option, returning `{:ok, value}` or `{:error, message}`.
   """
   @spec set_extension_option!(atom(), atom(), term()) :: {:ok, term()} | {:error, String.t()}
-  defdelegate set_extension_option!(ext_name, opt_name, value),
-    to: Options,
-    as: :set_extension_option
+  def set_extension_option!(ext_name, opt_name, value),
+    do: Options.set_extension_option(options_server(), ext_name, opt_name, value)
 
   @doc """
   Sets an extension option override for a specific filetype.
   """
   @spec set_extension_option_for_filetype(atom(), atom(), atom(), term()) ::
           {:ok, term()} | {:error, String.t()}
-  defdelegate set_extension_option_for_filetype(ext_name, filetype, opt_name, value), to: Options
+  def set_extension_option_for_filetype(ext_name, filetype, opt_name, value),
+    do:
+      Options.set_extension_option_for_filetype(
+        options_server(),
+        ext_name,
+        filetype,
+        opt_name,
+        value
+      )
 
   # ── Extension schema ───────────────────────────────────────────────
 
@@ -126,14 +145,16 @@ defmodule Minga.Config do
   Called by the extension supervisor when loading an extension.
   """
   @spec register_extension_schema(atom(), [Minga.Extension.option_spec()], keyword()) ::
-          :ok | {:error, [String.t()]}
-  defdelegate register_extension_schema(ext_name, schema, user_config), to: Options
+          :ok | {:error, String.t()}
+  def register_extension_schema(ext_name, schema, user_config),
+    do: Options.register_extension_schema(options_server(), ext_name, schema, user_config)
 
   @doc """
   Returns the registered option schema for an extension, or nil.
   """
   @spec extension_schema(atom()) :: [Minga.Extension.option_spec()] | nil
-  defdelegate extension_schema(ext_name), to: Options
+  def extension_schema(ext_name),
+    do: Options.extension_schema(options_server(), ext_name)
 
   # ── Command advice ─────────────────────────────────────────────────
 

--- a/lib/minga/config.ex
+++ b/lib/minga/config.ex
@@ -49,6 +49,11 @@ defmodule Minga.Config do
     Process.get(:minga_config_keymap, Keymap.default_server())
   end
 
+  @spec options_server() :: Options.server()
+  defp options_server do
+    Process.get(:minga_config_options, Options.default_server())
+  end
+
   # ── Read options ───────────────────────────────────────────────────
 
   @doc """
@@ -213,7 +218,7 @@ defmodule Minga.Config do
   """
   @spec set(Options.option_name(), term()) :: :ok
   def set(name, value) when is_atom(name) do
-    case Options.set(name, value) do
+    case Options.set(options_server(), name, value) do
       {:ok, _} -> :ok
       {:error, msg} -> raise ArgumentError, msg
     end
@@ -235,7 +240,7 @@ defmodule Minga.Config do
   @spec set_extension_option(atom(), atom(), term()) :: :ok
   def set_extension_option(extension, name, value)
       when is_atom(extension) and is_atom(name) do
-    case Options.set_extension_option(extension, name, value) do
+    case Options.set_extension_option(options_server(), extension, name, value) do
       {:ok, _} -> :ok
       {:error, msg} -> raise ArgumentError, msg
     end
@@ -448,7 +453,7 @@ defmodule Minga.Config do
   @spec for_filetype(atom(), keyword()) :: :ok
   def for_filetype(filetype, opts) when is_atom(filetype) and is_list(opts) do
     for {name, value} <- opts do
-      case Options.set_for_filetype(filetype, name, value) do
+      case Options.set_for_filetype(options_server(), filetype, name, value) do
         {:ok, _} -> :ok
         {:error, msg} -> raise ArgumentError, "for_filetype #{filetype}: #{msg}"
       end

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -35,6 +35,7 @@ defmodule Minga.Config.Loader do
   alias Minga.Popup.Registry, as: PopupRegistry
 
   @type keymap_server :: Keymap.server()
+  @type options_server :: Options.server()
 
   @typedoc "Loader state: stores paths, loaded modules, and any errors from each stage."
   @type state :: %{
@@ -45,7 +46,8 @@ defmodule Minga.Config.Loader do
           project_config_path: String.t() | nil,
           project_config_error: String.t() | nil,
           after_error: String.t() | nil,
-          keymap_server: keymap_server()
+          keymap_server: keymap_server(),
+          options_server: options_server()
         }
 
   # ── Client API ──────────────────────────────────────────────────────────────
@@ -71,7 +73,14 @@ defmodule Minga.Config.Loader do
         Process.get(:minga_config_keymap, Keymap.default_server())
       )
 
-    Agent.start_link(fn -> load_all(keymap_server) end, name: name)
+    options_server =
+      Keyword.get(
+        opts,
+        :options_server,
+        Process.get(:minga_config_options, Options.default_server())
+      )
+
+    Agent.start_link(fn -> load_all(keymap_server, options_server) end, name: name)
   end
 
   @doc """
@@ -143,20 +152,27 @@ defmodule Minga.Config.Loader do
     end
 
     # Reset all registries to defaults
-    keymap_server =
+    {keymap_server, options_server} =
       Agent.get(server, fn
-        %{keymap_server: keymap_server} ->
-          keymap_server
+        %{keymap_server: keymap_server, options_server: options_server} ->
+          {keymap_server, options_server}
 
-        # Defensive fallback: state shape predates the keymap_server field.
+        # Defensive fallback: state shape predates the *_server fields.
         # Unreachable in single-version processes; logged so a real schema
         # mismatch doesn't degrade silently.
         _ ->
-          Minga.Log.warning(:config, "loader state missing :keymap_server; using default")
-          Process.get(:minga_config_keymap, Keymap.default_server())
+          Minga.Log.warning(
+            :config,
+            "loader state missing :keymap_server/:options_server; using defaults"
+          )
+
+          {
+            Process.get(:minga_config_keymap, Keymap.default_server()),
+            Process.get(:minga_config_options, Options.default_server())
+          }
       end)
 
-    Options.reset()
+    Options.reset(options_server)
     Hooks.reset()
     Advice.reset()
     Keymap.reset(keymap_server)
@@ -165,7 +181,7 @@ defmodule Minga.Config.Loader do
     PopupRegistry.clear()
 
     # Re-run the full load sequence (includes starting extensions)
-    new_state = load_all(keymap_server)
+    new_state = load_all(keymap_server, options_server)
     Agent.update(server, fn _ -> new_state end)
 
     # Return error if any stage had problems
@@ -183,15 +199,16 @@ defmodule Minga.Config.Loader do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
-  # The process dictionary bridges `keymap_server` into `Minga.Config.bind/3,4,5`,
-  # which is invoked synchronously while `.exs` configs evaluate. Code that
-  # calls `Minga.Config.bind` from a separate process (e.g., a GenServer
-  # started by an extension callback) won't see this dict and will fall back
-  # to `Keymap.default_server/0`. Extensions are skipped in test mode, so
-  # this only affects long-lived runtime callers.
-  @spec load_all(keymap_server()) :: state()
-  defp load_all(keymap_server) do
+  # The process dictionary bridges `keymap_server` and `options_server` into
+  # `Minga.Config.bind/3,4,5` and `Minga.Config.set/2`, which run synchronously
+  # while `.exs` configs evaluate. Code that calls those helpers from a separate
+  # process (e.g., a GenServer started by an extension callback) won't see this
+  # dict and will fall back to the registered defaults. Extensions are skipped
+  # in test mode, so this only affects long-lived runtime callers.
+  @spec load_all(keymap_server(), options_server()) :: state()
+  defp load_all(keymap_server, options_server) do
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
+    previous_options_server = Process.put(:minga_config_options, options_server)
 
     try do
       config_path = resolve_config_path()
@@ -234,7 +251,7 @@ defmodule Minga.Config.Loader do
       after_error = eval_if_exists(after_path)
 
       # 6. Apply log level from config
-      apply_log_level()
+      apply_log_level(options_server)
 
       # 7. Start declared extensions (if the supervisor is running).
       # Skip in test mode so user-installed extensions don't affect test
@@ -252,16 +269,18 @@ defmodule Minga.Config.Loader do
         project_config_path: project_path,
         project_config_error: project_config_error,
         after_error: after_error,
-        keymap_server: keymap_server
+        keymap_server: keymap_server,
+        options_server: options_server
       }
     after
-      if is_nil(previous_keymap_server) do
-        Process.delete(:minga_config_keymap)
-      else
-        Process.put(:minga_config_keymap, previous_keymap_server)
-      end
+      restore_pdict(:minga_config_keymap, previous_keymap_server)
+      restore_pdict(:minga_config_options, previous_options_server)
     end
   end
+
+  @spec restore_pdict(atom(), term() | nil) :: term() | nil
+  defp restore_pdict(key, nil), do: Process.delete(key)
+  defp restore_pdict(key, value), do: Process.put(key, value)
 
   @spec load_user_themes() :: :ok
   defp load_user_themes do
@@ -269,9 +288,9 @@ defmodule Minga.Config.Loader do
     :ok
   end
 
-  @spec apply_log_level() :: :ok
-  defp apply_log_level do
-    level = Options.get(:log_level)
+  @spec apply_log_level(options_server()) :: :ok
+  defp apply_log_level(options_server) do
+    level = Options.get(options_server, :log_level)
 
     # Only apply the Minga log level if it is more restrictive than what
     # Mix config already set. This prevents the default :info from

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -74,11 +74,12 @@ defmodule Minga.Config.Loader do
       )
 
     options_server =
-      Keyword.get(
-        opts,
+      opts
+      |> Keyword.get(
         :options_server,
         Process.get(:minga_config_options, Options.default_server())
       )
+      |> Options.validate_server!()
 
     Agent.start_link(fn -> load_all(keymap_server, options_server) end, name: name)
   end
@@ -172,7 +173,7 @@ defmodule Minga.Config.Loader do
           }
       end)
 
-    Options.reset(options_server)
+    maybe_reset_options(options_server)
     Hooks.reset()
     Advice.reset()
     Keymap.reset(keymap_server)
@@ -282,6 +283,27 @@ defmodule Minga.Config.Loader do
   defp restore_pdict(key, nil), do: Process.delete(key)
   defp restore_pdict(key, value), do: Process.put(key, value)
 
+  # Skips the reset if the persisted options_server is no longer alive (anonymous
+  # pid that crashed and was never restarted) or never registered. Otherwise
+  # `Options.reset/1` exits with :noproc, taking the loader Agent down with it.
+  @spec maybe_reset_options(options_server()) :: :ok
+  defp maybe_reset_options(server) do
+    if options_server_alive?(server) do
+      Options.reset(server)
+    else
+      Minga.Log.warning(
+        :config,
+        "Loader.reload: options_server #{inspect(server)} not alive, skipping reset"
+      )
+    end
+
+    :ok
+  end
+
+  @spec options_server_alive?(options_server()) :: boolean()
+  defp options_server_alive?(pid) when is_pid(pid), do: Process.alive?(pid)
+  defp options_server_alive?(name) when is_atom(name), do: Process.whereis(name) != nil
+
   @spec load_user_themes() :: :ok
   defp load_user_themes do
     Minga.Events.broadcast(:load_user_themes, %Minga.Events.LoadUserThemesEvent{})
@@ -303,8 +325,10 @@ defmodule Minga.Config.Loader do
 
     :ok
   rescue
-    # Options agent may not be running yet (e.g., during tests)
-    _ -> :ok
+    # The Options ETS table is not registered yet (typically the suite-wide
+    # singleton hasn't booted under test). Other failure modes — wrong
+    # log_level value, Logger crashes — are real bugs and should propagate.
+    ArgumentError -> :ok
   end
 
   @spec compile_user_modules(String.t()) :: {[module()], [String.t()]}

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -191,6 +191,23 @@ defmodule Minga.Config.Options do
   @spec default_server() :: server()
   def default_server, do: @default_server
 
+  @doc """
+  Asserts that `server` is a valid `server/0` reference (pid or non-nil atom).
+
+  Raises `ArgumentError` otherwise. Use at boundaries that accept a caller-
+  supplied `:options_server` opt — bad values would otherwise silently
+  short-circuit later (e.g. `Process.get(:minga_config_options, default)`
+  returns `nil` if the key is set to `nil`, defeating the fallback).
+  """
+  @spec validate_server!(term()) :: server()
+  def validate_server!(server) when is_pid(server), do: server
+  def validate_server!(server) when is_atom(server) and not is_nil(server), do: server
+
+  def validate_server!(invalid) do
+    raise ArgumentError,
+          "expected Minga.Config.Options server (pid or non-nil atom), got: #{inspect(invalid)}"
+  end
+
   @option_specs [
     {:editing_model, {:enum, [:vim, :cua]}, :vim},
     {:space_leader, {:enum, [:chord, :off]}, :chord},
@@ -296,6 +313,10 @@ defmodule Minga.Config.Options do
 
   @impl GenServer
   def init(:anonymous) do
+    # The first arg to :ets.new/2 is a tag, not a table identity, when
+    # :named_table is omitted. Do NOT add :named_table here — multiple
+    # anonymous Options servers may run concurrently (per-test isolation),
+    # and a named ETS table can only exist once per BEAM node.
     table = :ets.new(:config_options, [:set, :public, read_concurrency: true])
     seed_defaults(table)
     {:ok, %{table: table}}

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -179,6 +179,18 @@ defmodule Minga.Config.Options do
   @typedoc "ETS table reference used for reads and writes."
   @type table :: :ets.table()
 
+  @typedoc "Reference to a Config.Options GenServer (registered name or pid)."
+  @type server :: GenServer.server()
+
+  # Single source of truth for the default registered Options server. Other
+  # modules call `default_server/0` rather than referencing `__MODULE__`
+  # directly so future renames or alternate defaults stay localized here.
+  @default_server __MODULE__
+
+  @doc "Returns the registered name of the default options server."
+  @spec default_server() :: server()
+  def default_server, do: @default_server
+
   @option_specs [
     {:editing_model, {:enum, [:vim, :cua]}, :vim},
     {:space_leader, {:enum, [:chord, :off]}, :chord},
@@ -266,14 +278,29 @@ defmodule Minga.Config.Options do
 
   # ── GenServer (table lifecycle only) ────────────────────────────────────────
 
-  @doc "Starts the options registry and creates the backing ETS table."
+  @doc """
+  Starts the options registry and creates the backing ETS table.
+
+  Pass `name: nil` to start anonymously (no registered name, unnamed ETS
+  table). Useful for isolated test fixtures: pass the returned pid to
+  server-aware functions instead of generating per-test atoms.
+  """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    {name, _opts} = Keyword.pop(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, name, name: name)
+    case Keyword.fetch(opts, :name) do
+      {:ok, nil} -> GenServer.start_link(__MODULE__, :anonymous, [])
+      {:ok, name} -> GenServer.start_link(__MODULE__, name, name: name)
+      :error -> GenServer.start_link(__MODULE__, __MODULE__, name: __MODULE__)
+    end
   end
 
   @impl GenServer
+  def init(:anonymous) do
+    table = :ets.new(:config_options, [:set, :public, read_concurrency: true])
+    seed_defaults(table)
+    {:ok, %{table: table}}
+  end
+
   def init(name) do
     table = :ets.new(table_name(name), [:set, :public, :named_table, read_concurrency: true])
     seed_defaults(table)
@@ -295,19 +322,14 @@ defmodule Minga.Config.Options do
   User config values that match a schema entry are validated and stored.
   Unknown keys produce a warning log. Type mismatches return an error.
   """
-  @spec register_extension_schema(atom(), [Minga.Extension.option_spec()], keyword()) ::
-          :ok | {:error, String.t()}
   @spec register_extension_schema(
-          GenServer.server(),
+          server(),
           atom(),
           [Minga.Extension.option_spec()],
           keyword()
         ) ::
           :ok | {:error, String.t()}
-  def register_extension_schema(ext_name, schema, user_config) when is_atom(ext_name),
-    do: register_extension_schema(__MODULE__, ext_name, schema, user_config)
-
-  def register_extension_schema(server, ext_name, schema, user_config)
+  def register_extension_schema(server \\ @default_server, ext_name, schema, user_config)
       when is_atom(ext_name) and is_list(schema) and is_list(user_config) do
     table = table_name(server)
 
@@ -386,12 +408,8 @@ defmodule Minga.Config.Options do
       Config.Options.get_extension_option(:minga_org, :conceal)
       # => true
   """
-  @spec get_extension_option(atom(), atom()) :: term()
-  @spec get_extension_option(GenServer.server(), atom(), atom()) :: term()
-  def get_extension_option(ext_name, opt_name) when is_atom(ext_name) and is_atom(opt_name),
-    do: get_extension_option(__MODULE__, ext_name, opt_name)
-
-  def get_extension_option(server, ext_name, opt_name)
+  @spec get_extension_option(server(), atom(), atom()) :: term()
+  def get_extension_option(server \\ @default_server, ext_name, opt_name)
       when is_atom(ext_name) and is_atom(opt_name) do
     table = table_name(server)
     key = {:extension, ext_name, opt_name}
@@ -410,14 +428,9 @@ defmodule Minga.Config.Options do
       Config.Options.set_extension_option(:minga_org, :conceal, false)
       # => {:ok, false}
   """
-  @spec set_extension_option(atom(), atom(), term()) :: {:ok, term()} | {:error, String.t()}
-  @spec set_extension_option(GenServer.server(), atom(), atom(), term()) ::
+  @spec set_extension_option(server(), atom(), atom(), term()) ::
           {:ok, term()} | {:error, String.t()}
-  def set_extension_option(ext_name, opt_name, value)
-      when is_atom(ext_name) and is_atom(opt_name),
-      do: set_extension_option(__MODULE__, ext_name, opt_name, value)
-
-  def set_extension_option(server, ext_name, opt_name, value)
+  def set_extension_option(server \\ @default_server, ext_name, opt_name, value)
       when is_atom(ext_name) and is_atom(opt_name) do
     table = table_name(server)
 
@@ -440,15 +453,15 @@ defmodule Minga.Config.Options do
 
       Config.Options.set_extension_option_for_filetype(:minga_org, :org, :conceal, false)
   """
-  @spec set_extension_option_for_filetype(atom(), atom(), atom(), term()) ::
+  @spec set_extension_option_for_filetype(server(), atom(), atom(), atom(), term()) ::
           {:ok, term()} | {:error, String.t()}
-  @spec set_extension_option_for_filetype(GenServer.server(), atom(), atom(), atom(), term()) ::
-          {:ok, term()} | {:error, String.t()}
-  def set_extension_option_for_filetype(ext_name, filetype, opt_name, value)
-      when is_atom(ext_name) and is_atom(filetype) and is_atom(opt_name),
-      do: set_extension_option_for_filetype(__MODULE__, ext_name, filetype, opt_name, value)
-
-  def set_extension_option_for_filetype(server, ext_name, filetype, opt_name, value)
+  def set_extension_option_for_filetype(
+        server \\ @default_server,
+        ext_name,
+        filetype,
+        opt_name,
+        value
+      )
       when is_atom(ext_name) and is_atom(filetype) and is_atom(opt_name) do
     table = table_name(server)
 
@@ -468,11 +481,8 @@ defmodule Minga.Config.Options do
   Checks filetype-specific override first, then falls back to the
   global extension option value.
   """
-  @spec get_extension_option_for_filetype(atom(), atom(), atom() | nil) :: term()
-  @spec get_extension_option_for_filetype(GenServer.server(), atom(), atom(), atom() | nil) ::
-          term()
-  def get_extension_option_for_filetype(ext_name, opt_name, filetype),
-    do: get_extension_option_for_filetype(__MODULE__, ext_name, opt_name, filetype)
+  @spec get_extension_option_for_filetype(server(), atom(), atom(), atom() | nil) :: term()
+  def get_extension_option_for_filetype(server \\ @default_server, ext_name, opt_name, filetype)
 
   def get_extension_option_for_filetype(server, ext_name, opt_name, nil),
     do: get_extension_option(server, ext_name, opt_name)
@@ -492,12 +502,8 @@ defmodule Minga.Config.Options do
   Returns the registered option schema for an extension, or `nil` if
   the extension has no schema.
   """
-  @spec extension_schema(atom()) :: [Minga.Extension.option_spec()] | nil
-  @spec extension_schema(GenServer.server(), atom()) :: [Minga.Extension.option_spec()] | nil
-  def extension_schema(ext_name) when is_atom(ext_name),
-    do: extension_schema(__MODULE__, ext_name)
-
-  def extension_schema(server, ext_name) when is_atom(ext_name) do
+  @spec extension_schema(server(), atom()) :: [Minga.Extension.option_spec()] | nil
+  def extension_schema(server \\ @default_server, ext_name) when is_atom(ext_name) do
     table = table_name(server)
 
     case :ets.lookup(table, {:extension_schema, ext_name}) do
@@ -512,12 +518,8 @@ defmodule Minga.Config.Options do
 
   Used by `SPC h v` (describe option) and other introspection features.
   """
-  @spec extension_option_description(atom(), atom()) :: String.t() | nil
-  @spec extension_option_description(GenServer.server(), atom(), atom()) :: String.t() | nil
-  def extension_option_description(ext_name, opt_name),
-    do: extension_option_description(__MODULE__, ext_name, opt_name)
-
-  def extension_option_description(server, ext_name, opt_name)
+  @spec extension_option_description(server(), atom(), atom()) :: String.t() | nil
+  def extension_option_description(server \\ @default_server, ext_name, opt_name)
       when is_atom(ext_name) and is_atom(opt_name) do
     table = table_name(server)
 
@@ -535,12 +537,9 @@ defmodule Minga.Config.Options do
   Returns `{:ok, value}` on success or `{:error, reason}` if the option
   name is unknown or the value has the wrong type.
   """
-  @spec set(option_name(), term()) :: {:ok, term()} | {:error, String.t()}
-  @spec set(GenServer.server(), option_name(), term()) :: {:ok, term()} | {:error, String.t()}
-  def set(name, value) when is_atom(name), do: set(__MODULE__, name, value)
-
-  def set(server, name, value) when is_atom(name) do
-    case validate(server, name, value) do
+  @spec set(server(), option_name(), term()) :: {:ok, term()} | {:error, String.t()}
+  def set(server \\ @default_server, name, value) when is_atom(name) do
+    case validate(name, value) do
       :ok ->
         :ets.insert(table_name(server), {name, value})
         {:ok, value}
@@ -553,11 +552,8 @@ defmodule Minga.Config.Options do
   @doc """
   Gets the current global value of an option, falling back to its default.
   """
-  @spec get(option_name()) :: term()
-  @spec get(GenServer.server(), option_name()) :: term()
-  def get(name) when is_atom(name), do: get(__MODULE__, name)
-
-  def get(server, name) when is_atom(name) do
+  @spec get(server(), option_name()) :: term()
+  def get(server \\ @default_server, name) when is_atom(name) do
     table = table_name(server)
 
     case :ets.lookup(table, name) do
@@ -572,10 +568,8 @@ defmodule Minga.Config.Options do
   Checks filetype-specific settings first, then falls back to the global
   value. If `filetype` is `nil`, returns the global value.
   """
-  @spec get_for_filetype(option_name(), atom() | nil) :: term()
-  @spec get_for_filetype(GenServer.server(), option_name(), atom() | nil) :: term()
-  def get_for_filetype(name, filetype) when is_atom(name),
-    do: get_for_filetype(__MODULE__, name, filetype)
+  @spec get_for_filetype(server(), option_name(), atom() | nil) :: term()
+  def get_for_filetype(server \\ @default_server, name, filetype)
 
   def get_for_filetype(server, name, nil), do: get(server, name)
 
@@ -593,16 +587,11 @@ defmodule Minga.Config.Options do
 
   The value is validated the same way as global options.
   """
-  @spec set_for_filetype(atom(), option_name(), term()) :: {:ok, term()} | {:error, String.t()}
-  @spec set_for_filetype(GenServer.server(), atom(), option_name(), term()) ::
+  @spec set_for_filetype(server(), atom(), option_name(), term()) ::
           {:ok, term()} | {:error, String.t()}
-  def set_for_filetype(filetype, name, value)
-      when is_atom(filetype) and is_atom(name),
-      do: set_for_filetype(__MODULE__, filetype, name, value)
-
-  def set_for_filetype(server, filetype, name, value)
+  def set_for_filetype(server \\ @default_server, filetype, name, value)
       when is_atom(filetype) and is_atom(name) do
-    case validate(server, name, value) do
+    case validate(name, value) do
       :ok ->
         :ets.insert(table_name(server), {{:filetype, filetype, name}, value})
         {:ok, value}
@@ -615,11 +604,8 @@ defmodule Minga.Config.Options do
   @doc """
   Returns all current global option values as a map.
   """
-  @spec all() :: %{option_name() => term()}
-  @spec all(GenServer.server()) :: %{option_name() => term()}
-  def all, do: all(__MODULE__)
-
-  def all(server) do
+  @spec all(server()) :: %{option_name() => term()}
+  def all(server \\ @default_server) do
     table = table_name(server)
 
     :ets.foldl(
@@ -635,11 +621,8 @@ defmodule Minga.Config.Options do
   @doc """
   Resets all options (global and per-filetype) to defaults.
   """
-  @spec reset() :: :ok
-  @spec reset(GenServer.server()) :: :ok
-  def reset, do: reset(__MODULE__)
-
-  def reset(server) do
+  @spec reset(server()) :: :ok
+  def reset(server \\ @default_server) do
     table = table_name(server)
     :ets.delete_all_objects(table)
     seed_defaults(table)
@@ -686,10 +669,10 @@ defmodule Minga.Config.Options do
   to validate buffer-local option overrides.
   """
   @spec validate_option(atom(), term()) :: :ok | {:error, String.t()}
-  def validate_option(name, value), do: validate(__MODULE__, name, value)
+  def validate_option(name, value), do: validate(name, value)
 
-  @spec validate(GenServer.server(), atom(), term()) :: :ok | {:error, String.t()}
-  defp validate(_server, name, value) do
+  @spec validate(atom(), term()) :: :ok | {:error, String.t()}
+  defp validate(name, value) do
     case Map.fetch(@types, name) do
       {:ok, type} ->
         validate_type(type, name, value)

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -60,6 +60,7 @@ defmodule MingaEditor do
           {:name, GenServer.name()}
           | {:port_manager, GenServer.server()}
           | {:keymap_server, GenServer.server()}
+          | {:options_server, GenServer.server()}
           | {:buffer, pid()}
           | {:width, pos_integer()}
           | {:height, pos_integer()}
@@ -371,7 +372,7 @@ defmodule MingaEditor do
   def handle_info({:minga_input, {:ready, width, height}}, state) do
     # Query capabilities from the frontend (may have been sent in extended ready).
     caps = Startup.fetch_capabilities(state.port_manager)
-    Startup.apply_gui_defaults(caps)
+    Startup.apply_gui_defaults(caps, EditorState.options_server(state))
 
     line_spacing = Config.get(:line_spacing) || 1.0
     effective_height = Viewport.effective_rows(height, line_spacing)

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -45,7 +45,12 @@ defmodule MingaEditor.Startup do
     backend = Keyword.get(opts, :backend, :headless)
     port_manager = Keyword.get(opts, :port_manager, MingaEditor.Frontend.Manager)
     keymap_server = Keyword.get(opts, :keymap_server, Minga.Keymap.default_server())
-    options_server = Keyword.get(opts, :options_server, Minga.Config.Options.default_server())
+
+    options_server =
+      opts
+      |> Keyword.get(:options_server, Minga.Config.Options.default_server())
+      |> Minga.Config.Options.validate_server!()
+
     width = Keyword.get(opts, :width, 80)
     height = Keyword.get(opts, :height, 24)
     buffer = Keyword.get(opts, :buffer)
@@ -331,7 +336,7 @@ defmodule MingaEditor.Startup do
   """
   @spec apply_gui_defaults(MingaEditor.Frontend.Capabilities.t(), Minga.Config.Options.server()) ::
           :ok
-  def apply_gui_defaults(caps, options_server \\ Minga.Config.Options.default_server()) do
+  def apply_gui_defaults(caps, options_server) do
     alias MingaEditor.Frontend.Capabilities
 
     if Capabilities.gui?(caps) do

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -45,6 +45,7 @@ defmodule MingaEditor.Startup do
     backend = Keyword.get(opts, :backend, :headless)
     port_manager = Keyword.get(opts, :port_manager, MingaEditor.Frontend.Manager)
     keymap_server = Keyword.get(opts, :keymap_server, Minga.Keymap.default_server())
+    options_server = Keyword.get(opts, :options_server, Minga.Config.Options.default_server())
     width = Keyword.get(opts, :width, 80)
     height = Keyword.get(opts, :height, 24)
     buffer = Keyword.get(opts, :buffer)
@@ -118,6 +119,7 @@ defmodule MingaEditor.Startup do
       workspace: workspace,
       port_manager: port_manager,
       keymap_server: keymap_server,
+      options_server: options_server,
       editing_model: editing_model,
       focus_stack: MingaEditor.Input.default_stack(),
       shell: resolve_shell(opts),
@@ -327,20 +329,21 @@ defmodule MingaEditor.Startup do
   - `:line_spacing` — `1.0` → `1.2` (GUI text benefits from breathing room;
     TUI stays at 1.0 because terminal cells have fixed height)
   """
-  @spec apply_gui_defaults(MingaEditor.Frontend.Capabilities.t()) :: :ok
-  def apply_gui_defaults(caps) do
+  @spec apply_gui_defaults(MingaEditor.Frontend.Capabilities.t(), Minga.Config.Options.server()) ::
+          :ok
+  def apply_gui_defaults(caps, options_server \\ Minga.Config.Options.default_server()) do
     alias MingaEditor.Frontend.Capabilities
 
     if Capabilities.gui?(caps) do
       # Only override if the user hasn't explicitly set a preference.
       # :hybrid is the TUI default; if it's still :hybrid, the user
       # hasn't touched it, so we can safely switch to :absolute.
-      if Config.get(:line_numbers) == :hybrid do
-        Minga.Config.Options.set(:line_numbers, :absolute)
+      if Minga.Config.Options.get(options_server, :line_numbers) == :hybrid do
+        Minga.Config.Options.set(options_server, :line_numbers, :absolute)
       end
 
-      if Config.get(:line_spacing) == 1.0 do
-        Minga.Config.Options.set(:line_spacing, 1.2)
+      if Minga.Config.Options.get(options_server, :line_spacing) == 1.0 do
+        Minga.Config.Options.set(options_server, :line_spacing, 1.2)
       end
     end
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -73,7 +73,11 @@ defmodule MingaEditor.State do
   @typedoc "Re-export of `Minga.Keymap.server/0` for editor-state callers."
   @type keymap_server :: Minga.Keymap.server()
 
+  @typedoc "Re-export of `Minga.Config.Options.server/0` for editor-state callers."
+  @type options_server :: Minga.Config.Options.server()
+
   @default_keymap_server Minga.Keymap.default_server()
+  @default_options_server Minga.Config.Options.default_server()
 
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.Shell.Board.State, as: BoardState
@@ -82,6 +86,7 @@ defmodule MingaEditor.State do
   defstruct backend: :headless,
             port_manager: nil,
             keymap_server: @default_keymap_server,
+            options_server: @default_options_server,
             workspace: nil,
             editing_model: :vim,
             shell: MingaEditor.Shell.Traditional,
@@ -114,6 +119,7 @@ defmodule MingaEditor.State do
           backend: backend(),
           port_manager: GenServer.server() | nil,
           keymap_server: keymap_server(),
+          options_server: options_server(),
           workspace: WorkspaceState.t(),
           editing_model: :vim | :cua,
           shell: module(),
@@ -152,6 +158,10 @@ defmodule MingaEditor.State do
   @spec keymap_context(t()) :: [{:keymap_server, keymap_server()}]
   def keymap_context(%__MODULE__{} = state),
     do: [keymap_server: keymap_server(state)]
+
+  @doc "Returns the options server used for typed option lookups."
+  @spec options_server(t()) :: options_server()
+  def options_server(%__MODULE__{options_server: options_server}), do: options_server
 
   # ── Workspace helpers ──────────────────────────────────────────────────────
 

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -48,7 +48,7 @@ defmodule Minga.Config.LoaderTest do
 
   @spec test_options_server() :: GenServer.server()
   defp test_options_server do
-    Process.get(:minga_config_options, Options)
+    Process.get(:minga_config_options, Options.default_server())
   end
 
   describe "config_path/1" do
@@ -416,6 +416,108 @@ defmodule Minga.Config.LoaderTest do
 
       assert {:error, msg} = Loader.reload(pid)
       assert is_binary(msg)
+    end
+  end
+
+  describe "pdict bridge isolation" do
+    test "Loader.start_link does not leak :minga_config_options into the caller pdict" do
+      # The bridge mutations happen inside the Agent process running load_all,
+      # not in the calling process. Verify nothing leaks back: the test's own
+      # pdict value (set by setup) must be unchanged after Loader runs.
+      {_dir, cleanup} = make_config_dir("")
+      on_exit(cleanup)
+
+      caller_before = Process.get(:minga_config_options)
+
+      name = :"loader_pdict_isolation_#{System.unique_integer([:positive])}"
+      {:ok, _pid} = Loader.start_link(name: name)
+
+      assert Process.get(:minga_config_options) == caller_before
+    end
+
+    test "user config raise during eval still completes the load with an error" do
+      # The Loader's try/after restores the pdict bridge regardless of whether
+      # eval_config_file's rescue caught the user-config raise. This test drives
+      # the raise path and confirms (a) the loader still starts cleanly and
+      # (b) the error is captured rather than crashing the Agent. If the bridge
+      # had leaked, subsequent Loader.load_error/1 calls would fail.
+      {_dir, cleanup} =
+        make_config_dir("""
+        use Minga.Config
+        raise "intentional config-eval failure"
+        """)
+
+      on_exit(cleanup)
+
+      caller_before = Process.get(:minga_config_options)
+
+      name = :"loader_raise_pdict_#{System.unique_integer([:positive])}"
+      {:ok, pid} = Loader.start_link(name: name)
+
+      assert is_binary(Loader.load_error(pid))
+      assert Process.get(:minga_config_options) == caller_before
+    end
+  end
+
+  describe "apply_log_level (via Loader)" do
+    test "raises Logger level when config sets a more restrictive level" do
+      # apply_log_level/1 only applies the config value when it's *more*
+      # restrictive than the current Logger level. Mix test config sets
+      # :warning, so :error is :gt :warning and should be applied.
+      original_level = Logger.level()
+      Logger.configure(level: :info)
+
+      {_dir, cleanup} =
+        make_config_dir("""
+        use Minga.Config
+        set :log_level, :error
+        """)
+
+      on_exit(fn ->
+        Logger.configure(level: original_level)
+        cleanup.()
+      end)
+
+      name = :"loader_log_level_raise_#{System.unique_integer([:positive])}"
+      {:ok, _pid} = Loader.start_link(name: name)
+
+      assert Logger.level() == :error
+    end
+
+    test "leaves Logger level alone when config is less restrictive than current" do
+      original_level = Logger.level()
+      Logger.configure(level: :error)
+
+      {_dir, cleanup} =
+        make_config_dir("""
+        use Minga.Config
+        set :log_level, :debug
+        """)
+
+      on_exit(fn ->
+        Logger.configure(level: original_level)
+        cleanup.()
+      end)
+
+      name = :"loader_log_level_keep_#{System.unique_integer([:positive])}"
+      {:ok, _pid} = Loader.start_link(name: name)
+
+      # :debug is not :gt :error, so Logger.configure must not have been
+      # called: the existing :error level wins.
+      assert Logger.level() == :error
+    end
+
+    test "rescues ArgumentError when Options ETS table does not exist" do
+      # Pointing the loader at a registered name with no backing ETS table
+      # would otherwise crash apply_log_level/1 on :ets.lookup. The narrow
+      # rescue keeps loader startup unaffected; everything else still runs.
+      {_dir, cleanup} = make_config_dir("")
+      on_exit(cleanup)
+
+      name = :"loader_log_level_rescue_#{System.unique_integer([:positive])}"
+
+      assert {:ok, _pid} =
+               Loader.start_link(name: name, options_server: :nonexistent_options_server)
     end
   end
 

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -1,6 +1,11 @@
 defmodule Minga.Config.LoaderTest do
   # credo:disable-for-this-file Credo.Check.Refactor.Apply
-  # Not async because we manipulate XDG_CONFIG_HOME and shared environment
+  # Not async: the project-local config tests call `File.cd!/1` to point the
+  # loader at a temp project directory, but the BEAM cwd is process-global.
+  # Running these in parallel with other compilation work breaks
+  # `Code.compile_file/1` calls in unrelated suites. Per-test Options/Keymap
+  # servers handle the singleton-isolation goal of #1448; the env-and-cwd
+  # races are out of scope.
   use ExUnit.Case, async: false
 
   alias Minga.Command.Registry, as: CommandRegistry
@@ -10,11 +15,14 @@ defmodule Minga.Config.LoaderTest do
   alias Minga.Keymap.Active, as: KeymapActive
 
   setup do
+    options_server = start_supervised!({Options, name: nil})
     keymap_server = start_supervised!({KeymapActive, name: nil})
+    previous_options_server = Process.put(:minga_config_options, options_server)
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
-    # Ensure other global servers are running (config eval needs them)
-    for {mod, _} <- [{Options, nil}, {Hooks, nil}, {CommandRegistry, nil}] do
+    # Hooks/CommandRegistry remain global singletons (Tickets 8 and beyond);
+    # ensure they're running but not isolated per test.
+    for {mod, _} <- [{Hooks, nil}, {CommandRegistry, nil}] do
       case mod.start_link() do
         {:ok, _} -> :ok
         {:error, {:already_started, _}} -> mod.reset()
@@ -27,9 +35,20 @@ defmodule Minga.Config.LoaderTest do
       else
         Process.put(:minga_config_keymap, previous_keymap_server)
       end
+
+      if is_nil(previous_options_server) do
+        Process.delete(:minga_config_options)
+      else
+        Process.put(:minga_config_options, previous_options_server)
+      end
     end)
 
-    :ok
+    %{options_server: options_server, keymap_server: keymap_server}
+  end
+
+  @spec test_options_server() :: GenServer.server()
+  defp test_options_server do
+    Process.get(:minga_config_options, Options)
   end
 
   describe "config_path/1" do
@@ -72,8 +91,8 @@ defmodule Minga.Config.LoaderTest do
       {:ok, pid} = Loader.start_link(name: name)
 
       assert Loader.load_error(pid) == nil
-      assert Options.get(:tab_width) == 4
-      assert Options.get(:line_numbers) == :relative
+      assert Options.get(test_options_server(), :tab_width) == 4
+      assert Options.get(test_options_server(), :line_numbers) == :relative
     end
   end
 
@@ -239,7 +258,7 @@ defmodule Minga.Config.LoaderTest do
       {:ok, pid} = Loader.start_link(name: name)
 
       assert Loader.project_config_error(pid) == nil
-      assert Options.get(:tab_width) == 8
+      assert Options.get(test_options_server(), :tab_width) == 8
     end
 
     test "no error when .minga.exs does not exist" do
@@ -293,7 +312,7 @@ defmodule Minga.Config.LoaderTest do
       {:ok, pid} = Loader.start_link(name: name)
 
       assert Loader.after_error(pid) == nil
-      assert Options.get(:tab_width) == 6
+      assert Options.get(test_options_server(), :tab_width) == 6
     end
   end
 
@@ -309,7 +328,7 @@ defmodule Minga.Config.LoaderTest do
 
       name = :"loader_reload_#{System.unique_integer([:positive])}"
       {:ok, pid} = Loader.start_link(name: name)
-      assert Options.get(:tab_width) == 3
+      assert Options.get(test_options_server(), :tab_width) == 3
 
       # Change the config file
       File.write!(Path.join(minga_dir, "config.exs"), """
@@ -318,7 +337,7 @@ defmodule Minga.Config.LoaderTest do
       """)
 
       assert :ok = Loader.reload(pid)
-      assert Options.get(:tab_width) == 7
+      assert Options.get(test_options_server(), :tab_width) == 7
     end
 
     test "reload purges old user modules" do
@@ -439,7 +458,7 @@ defmodule Minga.Config.LoaderTest do
       {:ok, pid} = Loader.start_link(name: name)
 
       # The custom config should have been loaded (tab_width = 42)
-      assert Options.get(:tab_width) == 42
+      assert Options.get(test_options_server(), :tab_width) == 42
       # config_path should return the custom path
       assert Loader.config_path(pid) == custom_path
       # No load errors
@@ -508,7 +527,7 @@ defmodule Minga.Config.LoaderTest do
       {:ok, pid} = Loader.start_link(name: name)
 
       # The file was loaded (tab_width changed), but a warning is shown
-      assert Options.get(:tab_width) == 7
+      assert Options.get(test_options_server(), :tab_width) == 7
       assert Loader.load_error(pid) =~ "does not end in .exs"
       assert Loader.load_error(pid) =~ custom_path
     end
@@ -560,7 +579,7 @@ defmodule Minga.Config.LoaderTest do
       {:ok, pid} = Loader.start_link(name: name)
 
       # Project-local config overrides the custom global config (last writer wins)
-      assert Options.get(:tab_width) == 99
+      assert Options.get(test_options_server(), :tab_width) == 99
       assert Loader.project_config_error(pid) == nil
     end
 
@@ -581,7 +600,7 @@ defmodule Minga.Config.LoaderTest do
       name = :"loader_no_flag_#{System.unique_integer([:positive])}"
       {:ok, pid} = Loader.start_link(name: name)
 
-      assert Options.get(:tab_width) == 5
+      assert Options.get(test_options_server(), :tab_width) == 5
       # config_path should be the standard XDG path
       assert Loader.config_path(pid) =~ "minga/config.exs"
     end
@@ -614,7 +633,7 @@ defmodule Minga.Config.LoaderTest do
 
       name = :"loader_reload_custom_#{System.unique_integer([:positive])}"
       {:ok, pid} = Loader.start_link(name: name)
-      assert Options.get(:tab_width) == 11
+      assert Options.get(test_options_server(), :tab_width) == 11
 
       # Change the custom config
       File.write!(custom_path, """
@@ -623,7 +642,7 @@ defmodule Minga.Config.LoaderTest do
       """)
 
       assert :ok = Loader.reload(pid)
-      assert Options.get(:tab_width) == 22
+      assert Options.get(test_options_server(), :tab_width) == 22
       # Path should still be the custom one
       assert Loader.config_path(pid) == custom_path
     end
@@ -641,16 +660,11 @@ defmodule Minga.Config.LoaderTest do
     File.write!(Path.join(minga_dir, "config.exs"), config_content)
     System.put_env("XDG_CONFIG_HOME", base)
 
+    # The per-test Options server started in setup is auto-cleaned by
+    # start_supervised!, so no explicit reset is needed here.
     cleanup = fn ->
       System.delete_env("XDG_CONFIG_HOME")
       File.rm_rf!(base)
-
-      try do
-        Options.reset()
-        Options.set(:clipboard, :none)
-      catch
-        :exit, _ -> :ok
-      end
     end
 
     {minga_dir, cleanup}

--- a/test/minga/config_test.exs
+++ b/test/minga/config_test.exs
@@ -1,5 +1,5 @@
 defmodule Minga.ConfigTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Minga.Command.Registry, as: CommandRegistry
   alias Minga.Config.Hooks
@@ -11,17 +11,14 @@ defmodule Minga.ConfigTest do
   alias Minga.Popup.Registry, as: PopupRegistry
 
   setup do
-    # Ensure required servers are running
-    case Options.start_link() do
-      {:ok, _} ->
-        :ok
-
-      {:error, {:already_started, _}} ->
-        Options.reset()
-        Options.set(:clipboard, :none)
-    end
-
+    # Per-test isolated singletons keep this suite async-safe. Tests that
+    # mutate global state (Options, Keymap.Active, Hooks, ExtRegistry,
+    # PopupRegistry, CommandRegistry) all read the test's process-dictionary
+    # bridge — Process.get(:minga_config_options) and :minga_config_keymap —
+    # via Minga.Config.{set,bind,for_filetype,…}.
+    options_server = start_supervised!({Options, name: nil})
     keymap_server = start_supervised!({KeymapActive, name: nil})
+    previous_options_server = Process.put(:minga_config_options, options_server)
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
 
     case CommandRegistry.start_link() do
@@ -65,20 +62,24 @@ defmodule Minga.ConfigTest do
         Process.put(:minga_config_keymap, previous_keymap_server)
       end
 
-      try do
-        Options.reset()
-        Options.set(:clipboard, :none)
-      catch
-        :exit, _ -> :ok
+      if is_nil(previous_options_server) do
+        Process.delete(:minga_config_options)
+      else
+        Process.put(:minga_config_options, previous_options_server)
       end
     end)
 
-    %{keymap_server: keymap_server}
+    %{keymap_server: keymap_server, options_server: options_server}
   end
 
   @spec test_keymap_server() :: GenServer.server()
   defp test_keymap_server do
     Process.get(:minga_config_keymap, KeymapActive)
+  end
+
+  @spec test_options_server() :: GenServer.server()
+  defp test_options_server do
+    Process.get(:minga_config_options, Options)
   end
 
   describe "use Minga.Config" do
@@ -244,15 +245,15 @@ defmodule Minga.ConfigTest do
     test "sets per-filetype option overrides" do
       Minga.Config.for_filetype(:go, tab_width: 8)
 
-      assert Options.get_for_filetype(:tab_width, :go) == 8
-      assert Options.get(:tab_width) == 2
+      assert Options.get_for_filetype(test_options_server(), :tab_width, :go) == 8
+      assert Options.get(test_options_server(), :tab_width) == 2
     end
 
     test "sets multiple options at once" do
       Minga.Config.for_filetype(:python, tab_width: 4, autopair: false)
 
-      assert Options.get_for_filetype(:tab_width, :python) == 4
-      assert Options.get_for_filetype(:autopair, :python) == false
+      assert Options.get_for_filetype(test_options_server(), :tab_width, :python) == 4
+      assert Options.get_for_filetype(test_options_server(), :autopair, :python) == false
     end
 
     test "raises for invalid option value" do

--- a/test/minga/config_test.exs
+++ b/test/minga/config_test.exs
@@ -74,12 +74,12 @@ defmodule Minga.ConfigTest do
 
   @spec test_keymap_server() :: GenServer.server()
   defp test_keymap_server do
-    Process.get(:minga_config_keymap, KeymapActive)
+    Process.get(:minga_config_keymap, Minga.Keymap.default_server())
   end
 
   @spec test_options_server() :: GenServer.server()
   defp test_options_server do
-    Process.get(:minga_config_options, Options)
+    Process.get(:minga_config_options, Options.default_server())
   end
 
   describe "use Minga.Config" do

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.StartupTest do
   use ExUnit.Case, async: false
 
   alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Config.Options
   alias MingaEditor.LayoutPreset
   alias MingaEditor.Startup
   alias MingaEditor.State, as: EditorState
@@ -42,88 +43,95 @@ defmodule MingaEditor.StartupTest do
     end
   end
 
-  describe "apply_gui_defaults/1" do
-    test "sets line_spacing to 1.2 for GUI frontend" do
-      gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
-      Minga.Config.Options.set(:line_spacing, 1.0)
-
-      Startup.apply_gui_defaults(gui_caps)
-
-      assert Minga.Config.Options.get(:line_spacing) == 1.2
-    after
-      Minga.Config.Options.set(:line_spacing, 1.0)
-      Minga.Config.Options.set(:line_numbers, :hybrid)
+  describe "apply_gui_defaults/2" do
+    setup do
+      # Per-test isolated Options server keeps these cases from racing on the
+      # global singleton and lets us assert exactly which server received the
+      # writes (proving the threading argument is honored).
+      server = start_supervised!({Options, name: nil})
+      %{server: server}
     end
 
-    test "does not change line_spacing for TUI frontend" do
+    test "sets line_spacing to 1.2 for GUI frontend", %{server: server} do
+      gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
+
+      Startup.apply_gui_defaults(gui_caps, server)
+
+      assert Options.get(server, :line_spacing) == 1.2
+    end
+
+    test "does not change line_spacing for TUI frontend", %{server: server} do
       tui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :tui}
-      Minga.Config.Options.set(:line_spacing, 1.0)
 
-      Startup.apply_gui_defaults(tui_caps)
+      Startup.apply_gui_defaults(tui_caps, server)
 
-      assert Minga.Config.Options.get(:line_spacing) == 1.0
+      assert Options.get(server, :line_spacing) == 1.0
     end
 
-    test "respects explicit user override to custom line_spacing in GUI mode" do
+    test "respects explicit user override to custom line_spacing in GUI mode",
+         %{server: server} do
       gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
-      Minga.Config.Options.set(:line_spacing, 1.5)
+      {:ok, _} = Options.set(server, :line_spacing, 1.5)
 
-      Startup.apply_gui_defaults(gui_caps)
+      Startup.apply_gui_defaults(gui_caps, server)
 
-      assert Minga.Config.Options.get(:line_spacing) == 1.5
-    after
-      Minga.Config.Options.set(:line_spacing, 1.0)
-      Minga.Config.Options.set(:line_numbers, :hybrid)
+      assert Options.get(server, :line_spacing) == 1.5
     end
 
-    test "sets line_numbers to :absolute for GUI frontend" do
+    test "sets line_numbers to :absolute for GUI frontend", %{server: server} do
       gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
 
       # Ensure the default is :hybrid before applying
-      assert Minga.Config.Options.get(:line_numbers) == :hybrid
+      assert Options.get(server, :line_numbers) == :hybrid
 
-      Startup.apply_gui_defaults(gui_caps)
+      Startup.apply_gui_defaults(gui_caps, server)
 
-      assert Minga.Config.Options.get(:line_numbers) == :absolute
-    after
-      Minga.Config.Options.set(:line_numbers, :hybrid)
-      Minga.Config.Options.set(:line_spacing, 1.0)
+      assert Options.get(server, :line_numbers) == :absolute
     end
 
-    test "does not change line_numbers for TUI frontend" do
+    test "does not change line_numbers for TUI frontend", %{server: server} do
       tui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :tui}
 
-      Startup.apply_gui_defaults(tui_caps)
+      Startup.apply_gui_defaults(tui_caps, server)
 
-      assert Minga.Config.Options.get(:line_numbers) == :hybrid
+      assert Options.get(server, :line_numbers) == :hybrid
     end
 
-    test "respects explicit user override to :relative in GUI mode" do
+    test "respects explicit user override to :relative in GUI mode", %{server: server} do
       gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
+      {:ok, _} = Options.set(server, :line_numbers, :relative)
 
-      # Simulate user setting :relative before the ready handshake
-      Minga.Config.Options.set(:line_numbers, :relative)
+      Startup.apply_gui_defaults(gui_caps, server)
 
-      Startup.apply_gui_defaults(gui_caps)
-
-      assert Minga.Config.Options.get(:line_numbers) == :relative
-    after
-      Minga.Config.Options.set(:line_numbers, :hybrid)
+      assert Options.get(server, :line_numbers) == :relative
     end
 
-    test "respects explicit user override to :hybrid in GUI mode" do
+    test "respects explicit user override to :hybrid in GUI mode", %{server: server} do
       # Edge case: user explicitly wants :hybrid in GUI mode.
       # Our heuristic treats this as "not explicitly set" and overrides it.
       # This is an acknowledged tradeoff (ticket #728 notes this).
       gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
 
-      Startup.apply_gui_defaults(gui_caps)
+      Startup.apply_gui_defaults(gui_caps, server)
 
       # :hybrid becomes :absolute because we can't distinguish "user set :hybrid"
       # from "default :hybrid". This is acceptable per ticket scope.
-      assert Minga.Config.Options.get(:line_numbers) == :absolute
-    after
-      Minga.Config.Options.set(:line_numbers, :hybrid)
+      assert Options.get(server, :line_numbers) == :absolute
+    end
+
+    test "writes land on the supplied server, not the default singleton" do
+      # End-to-end proof of the threading: two isolated servers, only the
+      # one passed to apply_gui_defaults/2 is mutated.
+      server_a = start_supervised!({Options, name: nil}, id: :gui_defaults_a)
+      server_b = start_supervised!({Options, name: nil}, id: :gui_defaults_b)
+      gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
+
+      Startup.apply_gui_defaults(gui_caps, server_a)
+
+      assert Options.get(server_a, :line_numbers) == :absolute
+      assert Options.get(server_a, :line_spacing) == 1.2
+      assert Options.get(server_b, :line_numbers) == :hybrid
+      assert Options.get(server_b, :line_spacing) == 1.0
     end
   end
 

--- a/test/minga_editor/state/options_server_threading_test.exs
+++ b/test/minga_editor/state/options_server_threading_test.exs
@@ -1,0 +1,69 @@
+defmodule MingaEditor.State.OptionsServerThreadingTest do
+  @moduledoc """
+  Integration test that proves `EditorState.options_server` is honored end-to-end.
+
+  Without this test, every other test in the options suite would still pass even
+  if `EditorState.options_server/1` were stubbed to ignore the field and always
+  return the default singleton — because all other tests both write to and read
+  from the same server, picked from the process dictionary.
+
+  Here we start two anonymous `Config.Options` servers, point an `EditorState`
+  at one of them, and assert that reads through `EditorState.options_server/1`
+  honor that choice rather than falling back to the singleton.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Config.Options
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias Minga.Mode
+
+  defp build_state(options_server) do
+    %EditorState{
+      port_manager: self(),
+      options_server: options_server,
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: %VimState{mode: :normal, mode_state: Mode.initial_state()},
+        buffers: %Buffers{active: nil, list: []},
+        keymap_scope: :editor
+      }
+    }
+  end
+
+  test "EditorState.options_server isolates writes between distinct servers" do
+    server_a = start_supervised!({Options, name: nil}, id: :options_a)
+    server_b = start_supervised!({Options, name: nil}, id: :options_b)
+
+    # Same option key, different values per server.
+    {:ok, _} = Options.set(server_a, :tab_width, 4)
+    {:ok, _} = Options.set(server_b, :tab_width, 8)
+
+    state_a = build_state(server_a)
+    state_b = build_state(server_b)
+
+    # The accessor returns the right server.
+    assert EditorState.options_server(state_a) == server_a
+    assert EditorState.options_server(state_b) == server_b
+
+    # End-to-end: option reads through the editor state's server honor which
+    # server the state points at, even when both have written to the same key.
+    assert Options.get(EditorState.options_server(state_a), :tab_width) == 4
+    assert Options.get(EditorState.options_server(state_b), :tab_width) == 8
+  end
+
+  test "EditorState defaults options_server to Minga.Config.Options.default_server/0" do
+    state = %EditorState{
+      port_manager: self(),
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: %VimState{mode: :normal, mode_state: Mode.initial_state()},
+        buffers: %Buffers{active: nil, list: []}
+      }
+    }
+
+    assert EditorState.options_server(state) == Options.default_server()
+  end
+end

--- a/test/minga_editor/state/options_server_threading_test.exs
+++ b/test/minga_editor/state/options_server_threading_test.exs
@@ -8,12 +8,15 @@ defmodule MingaEditor.State.OptionsServerThreadingTest do
   from the same server, picked from the process dictionary.
 
   Here we start two anonymous `Config.Options` servers, point an `EditorState`
-  at one of them, and assert that reads through `EditorState.options_server/1`
-  honor that choice rather than falling back to the singleton.
+  at one of them, and assert that the only `lib/` consumer of the field today
+  (`Startup.apply_gui_defaults/2`) actually mutates the server pointed to by
+  `EditorState.options_server/1` rather than falling back to the singleton.
   """
   use ExUnit.Case, async: true
 
   alias Minga.Config.Options
+  alias MingaEditor.Frontend.Capabilities
+  alias MingaEditor.Startup
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.Viewport
@@ -52,6 +55,24 @@ defmodule MingaEditor.State.OptionsServerThreadingTest do
     # server the state points at, even when both have written to the same key.
     assert Options.get(EditorState.options_server(state_a), :tab_width) == 4
     assert Options.get(EditorState.options_server(state_b), :tab_width) == 8
+  end
+
+  test "Startup.apply_gui_defaults writes through EditorState.options_server" do
+    # Drives the actual lib/ consumer: a stub that read EditorState.options_server
+    # but ignored its value would let writes leak to the default singleton, and
+    # this assertion would fail.
+    server_a = start_supervised!({Options, name: nil}, id: :gui_a)
+    server_b = start_supervised!({Options, name: nil}, id: :gui_b)
+    state_a = build_state(server_a)
+    gui_caps = %Capabilities{frontend_type: :native_gui}
+
+    Startup.apply_gui_defaults(gui_caps, EditorState.options_server(state_a))
+
+    assert Options.get(server_a, :line_numbers) == :absolute
+    assert Options.get(server_a, :line_spacing) == 1.2
+    # The unrelated server is untouched, proving isolation.
+    assert Options.get(server_b, :line_numbers) == :hybrid
+    assert Options.get(server_b, :line_spacing) == 1.0
   end
 
   test "EditorState defaults options_server to Minga.Config.Options.default_server/0" do


### PR DESCRIPTION
Closes #1448.

## Summary

Mirrors the keymap-server migration (#1458) for `Minga.Config.Options` so per-test isolation is achievable without an async-killing global GenServer.

- `Minga.Config.Options` gains `default_server/0`, `@type server`, anonymous start (`name: nil`), and a single-arity API with `\\ default_server()` defaults (collapsed from the previous dual-arity defdelegates).
- `EditorState` gains an `options_server` field + accessor, plumbed in via a new `:options_server` opt on `MingaEditor.start_link/1` and consumed by `Startup.apply_gui_defaults/2`.
- `Minga.Config.{set,set_extension_option,for_filetype}` read the target server from `Process.get(:minga_config_options, …)` — the same pdict bridge pattern `bind` uses for keymap. The bridge is installed by `Loader.load_all/2` while user `.exs` configs evaluate.
- `Minga.Config.Loader` accepts `:options_server`, persists it in Agent state, threads it through `reload/1` and `apply_log_level/1`.

## Test changes

- `test/minga/config_test.exs` → `async: true`, with `start_supervised!({Options, name: nil})` per test.
- `test/minga/config/loader_test.exs` adopts the per-test Options server but **stays `async: false`** — the project-local config cases call `File.cd!/1`, and the BEAM cwd is process-global. Without that race, the singleton-isolation goal of the ticket is met; cwd/env races are out of scope.
- New `MingaEditor.State.OptionsServerThreadingTest` proves the `EditorState.options_server` field is honored end-to-end (writes to server A do not leak to server B), mirroring the keymap threading test added in #1458.

## Deviations from the issue notes

1. The issue cited "11 lib call sites across 4 files." Real stateful `Options.{get,set,reset,…}` runtime callsites in `lib/` are 7 (loader 2, config 3, startup 2). The other matches are type aliases, docstrings, and pure module-attribute accessors (`Options.option_specs/0`, `Options.default/1`, `Options.type_for/1`) which need no server. All 7 stateful callsites are now threaded.
2. The issue mentioned "the same Credo guard introduced in Ticket 1." No such guard exists in `.credo.exs` or `credo/checks/` — Ticket 1 didn't add one. Skipped.
3. The issue called for `EditorCase` to start a per-test `Config.Options`. `EditorCase` is unchanged, matching what Ticket 1 did for `Keymap.Active`. The new `:options_server` start opt is available for any test fixture that wants it.
4. `loader_test` stays `async: false` (rationale above).

## Test plan

- [x] `mix test test/minga/config_test.exs test/minga/config/loader_test.exs test/minga_editor/state/options_server_threading_test.exs` (62/62 pass)
- [x] `mix test.llm` full suite — 7511 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — clean (only pre-existing struct-size warnings)
- [x] `mix dialyzer` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)