### PR TITLE
test(editor): split editor_test.exs into Mode FSM + EditorState handler tests

### DIFF
--- a/lib/minga/mode/extension_confirm_state.ex
+++ b/lib/minga/mode/extension_confirm_state.ex
@@ -7,6 +7,9 @@ defmodule Minga.Mode.ExtensionConfirmState do
   """
 
   @enforce_keys [:updates]
+  # `count` is unused by this mode, but `Minga.Mode.apply_result/2` runs
+  # `reset_count/1` (i.e. `%{state | count: nil}`) on every transition and
+  # execute, so the field must exist or the dispatcher raises KeyError.
   defstruct updates: [],
             current: 0,
             accepted: [],

--- a/lib/minga/mode/extension_confirm_state.ex
+++ b/lib/minga/mode/extension_confirm_state.ex
@@ -10,7 +10,8 @@ defmodule Minga.Mode.ExtensionConfirmState do
   defstruct updates: [],
             current: 0,
             accepted: [],
-            show_details: false
+            show_details: false,
+            count: nil
 
   @typedoc "An update summary for display in the confirmation dialog."
   @type update_entry :: %{
@@ -27,6 +28,7 @@ defmodule Minga.Mode.ExtensionConfirmState do
           updates: [update_entry()],
           current: non_neg_integer(),
           accepted: [non_neg_integer()],
-          show_details: boolean()
+          show_details: boolean(),
+          count: non_neg_integer() | nil
         }
 end

--- a/test/minga/mode/extension_confirm_test.exs
+++ b/test/minga/mode/extension_confirm_test.exs
@@ -1,6 +1,7 @@
 defmodule Minga.Mode.ExtensionConfirmTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Mode
   alias Minga.Mode.ExtensionConfirm
   alias Minga.Mode.ExtensionConfirmState
 
@@ -112,6 +113,32 @@ defmodule Minga.Mode.ExtensionConfirmTest do
       s = %{state([@git_update, @pinned_update]) | current: 1}
       display = Minga.Mode.display(:extension_confirm, s)
       assert display =~ "(2 of 2)"
+    end
+  end
+
+  describe "Mode.process/3 reset_count" do
+    # Regression: Mode.apply_result/2 calls reset_count(state) on :transition,
+    # :execute, and :execute_then_transition results. reset_count does
+    # `%{state | count: nil}`, which raises KeyError if the struct lacks a
+    # :count field. ExtensionConfirmState was previously missing this field,
+    # so any non-:continue dispatch on this mode crashed in production.
+    test "Y on the last update routes through reset_count without raising" do
+      s = state([@git_update])
+
+      assert {new_mode, [:apply_extension_updates], new_state} =
+               Mode.process(:extension_confirm, {?Y, 0}, s)
+
+      assert new_mode == :normal
+      assert new_state.count == nil
+    end
+
+    test "Esc routes through reset_count without raising" do
+      s = state([@git_update])
+
+      assert {:normal, [:apply_extension_updates], new_state} =
+               Mode.process(:extension_confirm, {27, 0}, s)
+
+      assert new_state.count == nil
     end
   end
 end

--- a/test/minga/mode/properties_test.exs
+++ b/test/minga/mode/properties_test.exs
@@ -1,0 +1,162 @@
+defmodule Minga.Mode.PropertiesTest do
+  @moduledoc """
+  Property tests for the Mode FSM dispatcher.
+
+  Two invariants:
+    1. `Mode.process/3` always returns `{new_mode, [command()], state()}`
+       where `new_mode` is a member of the closed `Mode.mode()` enum.
+    2. Pressing Escape from any mode transitions to `:normal` (the rest mode).
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Minga.Keymap.Defaults
+  alias Minga.Mode
+
+  alias Minga.Mode.{
+    CommandState,
+    DeleteConfirmState,
+    EvalState,
+    OperatorPendingState,
+    ReplaceState,
+    SearchPromptState,
+    SearchState,
+    State,
+    SubstituteConfirmState,
+    ToolConfirmState,
+    VisualState
+  }
+
+  @escape 27
+
+  # The full Mode.mode() enum. Kept here as a literal so the test fails if
+  # `Mode.mode()` ever expands without the property generators tracking it.
+  @all_modes [
+    :normal,
+    :insert,
+    :visual,
+    :visual_line,
+    :visual_block,
+    :operator_pending,
+    :command,
+    :eval,
+    :replace,
+    :search,
+    :search_prompt,
+    :substitute_confirm,
+    :extension_confirm,
+    :tool_confirm,
+    :delete_confirm
+  ]
+
+  # Modes Mode.process/3 actually dispatches. :visual_line and :visual_block
+  # are valid mode atoms in the FSM enum, but they're held by VisualState's
+  # :visual_type field — the dispatcher routes both through Minga.Mode.Visual
+  # via the :visual key.
+  #
+  # NOTE: :extension_confirm is intentionally omitted: its state struct
+  # has no `count` field, so `Mode.reset_count/1` raises a KeyError when
+  # the dispatcher applies a transition result. Re-add this mode once
+  # `ExtensionConfirmState` includes `count: nil`.
+  @dispatchable_modes [
+    :normal,
+    :insert,
+    :visual,
+    :operator_pending,
+    :command,
+    :eval,
+    :replace,
+    :search,
+    :search_prompt,
+    :substitute_confirm,
+    :tool_confirm,
+    :delete_confirm
+  ]
+
+  # ── Generators ────────────────────────────────────────────────────────────
+
+  # Builds a fresh `Mode.State` populated with the production keymap so
+  # leader/normal-binding lookups behave the same as in the editor.
+  defp base_state do
+    %{
+      Mode.initial_state()
+      | leader_trie: Defaults.leader_trie(),
+        normal_bindings: Defaults.normal_bindings()
+    }
+  end
+
+  defp default_mode_state(:normal), do: base_state()
+  defp default_mode_state(:insert), do: base_state()
+  defp default_mode_state(:replace), do: %ReplaceState{}
+  defp default_mode_state(:visual), do: %VisualState{visual_type: :char}
+  defp default_mode_state(:operator_pending), do: %OperatorPendingState{operator: :delete}
+  defp default_mode_state(:command), do: %CommandState{}
+  defp default_mode_state(:eval), do: %EvalState{}
+  defp default_mode_state(:search), do: %SearchState{direction: :forward}
+  defp default_mode_state(:search_prompt), do: %SearchPromptState{}
+
+  defp default_mode_state(:substitute_confirm) do
+    %SubstituteConfirmState{
+      matches: [{0, 0, 1}],
+      pattern: "x",
+      replacement: "y",
+      original_content: "x"
+    }
+  end
+
+  defp default_mode_state(:tool_confirm) do
+    %ToolConfirmState{pending: [:formatter]}
+  end
+
+  defp default_mode_state(:delete_confirm) do
+    %DeleteConfirmState{path: "/tmp/x", name: "x", dir?: false}
+  end
+
+  # Codepoints across the printable ASCII range plus control codes that the
+  # FSM recognises (Esc, Backspace, Enter, etc.). Keep modifiers small —
+  # the FSM only branches on Ctrl/Alt, not arbitrary masks.
+  defp key_gen do
+    gen all(
+          codepoint <- StreamData.integer(0..127),
+          modifiers <- StreamData.integer(0..7)
+        ) do
+      {codepoint, modifiers}
+    end
+  end
+
+  # ── Property 1: result shape and mode-enum closure ─────────────────────────
+
+  property "Mode.process/3 always returns {mode, [command], state} with mode in the enum" do
+    check all(
+            mode <- StreamData.member_of(@dispatchable_modes),
+            key <- key_gen()
+          ) do
+      state = default_mode_state(mode)
+      result = Mode.process(mode, key, state)
+
+      assert {new_mode, commands, new_state} = result
+      assert new_mode in @all_modes, "#{inspect(new_mode)} is not a valid mode atom"
+      assert is_list(commands)
+      assert is_struct(new_state)
+    end
+  end
+
+  # ── Property 2: Esc is a universal exit to :normal ─────────────────────────
+
+  property "Escape from any mode lands in :normal" do
+    check all(mode <- StreamData.member_of(@dispatchable_modes)) do
+      state = default_mode_state(mode)
+      {new_mode, _commands, _new_state} = Mode.process(mode, {@escape, 0}, state)
+      assert new_mode == :normal
+    end
+  end
+
+  # ── Sanity guard: enum coverage ────────────────────────────────────────────
+
+  test "default_mode_state/1 covers every dispatchable mode" do
+    for mode <- @dispatchable_modes do
+      assert match?(%_{}, default_mode_state(mode)) or
+               match?(%State{}, default_mode_state(mode))
+    end
+  end
+end

--- a/test/minga/mode/properties_test.exs
+++ b/test/minga/mode/properties_test.exs
@@ -17,6 +17,7 @@ defmodule Minga.Mode.PropertiesTest do
     CommandState,
     DeleteConfirmState,
     EvalState,
+    ExtensionConfirmState,
     OperatorPendingState,
     ReplaceState,
     SearchPromptState,
@@ -53,11 +54,6 @@ defmodule Minga.Mode.PropertiesTest do
   # are valid mode atoms in the FSM enum, but they're held by VisualState's
   # :visual_type field — the dispatcher routes both through Minga.Mode.Visual
   # via the :visual key.
-  #
-  # NOTE: :extension_confirm is intentionally omitted: its state struct
-  # has no `count` field, so `Mode.reset_count/1` raises a KeyError when
-  # the dispatcher applies a transition result. Re-add this mode once
-  # `ExtensionConfirmState` includes `count: nil`.
   @dispatchable_modes [
     :normal,
     :insert,
@@ -69,6 +65,7 @@ defmodule Minga.Mode.PropertiesTest do
     :search,
     :search_prompt,
     :substitute_confirm,
+    :extension_confirm,
     :tool_confirm,
     :delete_confirm
   ]
@@ -102,6 +99,10 @@ defmodule Minga.Mode.PropertiesTest do
       replacement: "y",
       original_content: "x"
     }
+  end
+
+  defp default_mode_state(:extension_confirm) do
+    %ExtensionConfirmState{updates: []}
   end
 
   defp default_mode_state(:tool_confirm) do

--- a/test/minga/mode/properties_test.exs
+++ b/test/minga/mode/properties_test.exs
@@ -70,10 +70,6 @@ defmodule Minga.Mode.PropertiesTest do
     :delete_confirm
   ]
 
-  # ── Generators ────────────────────────────────────────────────────────────
-
-  # Builds a fresh `Mode.State` populated with the production keymap so
-  # leader/normal-binding lookups behave the same as in the editor.
   defp base_state do
     %{
       Mode.initial_state()
@@ -113,9 +109,9 @@ defmodule Minga.Mode.PropertiesTest do
     %DeleteConfirmState{path: "/tmp/x", name: "x", dir?: false}
   end
 
-  # Codepoints across the printable ASCII range plus control codes that the
-  # FSM recognises (Esc, Backspace, Enter, etc.). Keep modifiers small —
-  # the FSM only branches on Ctrl/Alt, not arbitrary masks.
+  # Codepoints span ASCII (0..127) so the generator hits printable characters
+  # plus control codes the FSM recognises (Esc, Backspace, Enter, etc.).
+  # Modifiers are kept to 0..7 because the FSM only branches on Ctrl/Alt.
   defp key_gen do
     gen all(
           codepoint <- StreamData.integer(0..127),
@@ -124,8 +120,6 @@ defmodule Minga.Mode.PropertiesTest do
       {codepoint, modifiers}
     end
   end
-
-  # ── Property 1: result shape and mode-enum closure ─────────────────────────
 
   property "Mode.process/3 always returns {mode, [command], state} with mode in the enum" do
     check all(
@@ -142,8 +136,6 @@ defmodule Minga.Mode.PropertiesTest do
     end
   end
 
-  # ── Property 2: Esc is a universal exit to :normal ─────────────────────────
-
   property "Escape from any mode lands in :normal" do
     check all(mode <- StreamData.member_of(@dispatchable_modes)) do
       state = default_mode_state(mode)
@@ -151,8 +143,6 @@ defmodule Minga.Mode.PropertiesTest do
       assert new_mode == :normal
     end
   end
-
-  # ── Sanity guard: enum coverage ────────────────────────────────────────────
 
   test "default_mode_state/1 covers every dispatchable mode" do
     for mode <- @dispatchable_modes do

--- a/test/minga_editor/commands/insert_entry_test.exs
+++ b/test/minga_editor/commands/insert_entry_test.exs
@@ -1,0 +1,67 @@
+defmodule MingaEditor.Commands.InsertEntryTest do
+  @moduledoc """
+  Layer-1 tests for the read-only buffer guard on mode-entry keys.
+
+  Builds an EditorState backed by a real `Buffer.Server` flagged
+  `read_only: true`, then exercises `KeyDispatch.handle_key/3` for the
+  `i` (insert) and `R` (replace) keys. The guard in
+  `KeyDispatch.guard_read_only/4` should keep the editor in :normal
+  mode and emit the "Buffer is read-only" status message.
+  """
+  use Minga.Test.EditingModelCase, async: true
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias MingaEditor.KeyDispatch
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  defp start_read_only_buffer do
+    start_supervised!({BufferServer, content: "read only", read_only: true})
+  end
+
+  defp build_state(buffer) do
+    %EditorState{
+      port_manager: nil,
+      workspace: %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{active: buffer, list: [buffer]},
+        editing: VimState.new()
+      }
+    }
+  end
+
+  describe "read-only buffer guard" do
+    test "i (insert) keeps mode :normal and sets status" do
+      buffer = start_read_only_buffer()
+      state = build_state(buffer)
+
+      result = KeyDispatch.handle_key(state, ?i, 0)
+
+      assert result.workspace.editing.mode == :normal
+      assert EditorState.status_msg(result) == "Buffer is read-only"
+    end
+
+    test "R (replace) keeps mode :normal and sets status" do
+      buffer = start_read_only_buffer()
+      state = build_state(buffer)
+
+      result = KeyDispatch.handle_key(state, ?R, 0)
+
+      assert result.workspace.editing.mode == :normal
+      assert EditorState.status_msg(result) == "Buffer is read-only"
+    end
+
+    test "writable buffer transitions into :insert on i" do
+      {:ok, buffer} = start_supervised({BufferServer, content: "writable"})
+      state = build_state(buffer)
+
+      result = KeyDispatch.handle_key(state, ?i, 0)
+
+      assert result.workspace.editing.mode == :insert
+      assert EditorState.status_msg(result) == nil
+    end
+  end
+end

--- a/test/minga_editor/commands/no_buffer_test.exs
+++ b/test/minga_editor/commands/no_buffer_test.exs
@@ -1,0 +1,60 @@
+defmodule MingaEditor.Commands.NoBufferTest do
+  @moduledoc """
+  Layer-1 contract: when no buffer is active, every command that requires a
+  buffer returns state unchanged. This replaces the old Editor GenServer
+  smoke test that asserted `Process.alive?(editor)` after pressing keys
+  without a buffer (which was tautological — the GenServer ignores
+  unknown messages by design).
+  """
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Commands
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  defp no_buffer_state do
+    %EditorState{
+      port_manager: nil,
+      workspace: %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{active: nil, list: []},
+        editing: VimState.new()
+      }
+    }
+  end
+
+  describe "Commands.execute/2 with no active buffer" do
+    setup do
+      {:ok, state: no_buffer_state()}
+    end
+
+    # Atom commands looked up through the Command Registry; the buffer-required
+    # commands return state unchanged when buffers.active is nil.
+    test "atom motion commands are no-ops", %{state: state} do
+      for cmd <- [:move_left, :move_right, :move_up, :move_down] do
+        assert Commands.execute(state, cmd) == state
+      end
+    end
+
+    test "atom edit commands are no-ops", %{state: state} do
+      for cmd <- [:undo, :redo, :paste, :paste_before, :join_lines] do
+        assert Commands.execute(state, cmd) == state
+      end
+    end
+
+    # Tuple commands routed through guard_buffer/2.
+    test "tuple commands are no-ops", %{state: state} do
+      for cmd <- [
+            {:insert_char, "x"},
+            {:delete_chars_at, 1},
+            {:delete_motion, :line_end},
+            {:set_mark, "a"}
+          ] do
+        assert Commands.execute(state, cmd) == state
+      end
+    end
+  end
+end

--- a/test/minga_editor/commands/no_buffer_test.exs
+++ b/test/minga_editor/commands/no_buffer_test.exs
@@ -1,10 +1,7 @@
 defmodule MingaEditor.Commands.NoBufferTest do
   @moduledoc """
   Layer-1 contract: when no buffer is active, every command that requires a
-  buffer returns state unchanged. This replaces the old Editor GenServer
-  smoke test that asserted `Process.alive?(editor)` after pressing keys
-  without a buffer (which was tautological — the GenServer ignores
-  unknown messages by design).
+  buffer returns state unchanged.
   """
   use ExUnit.Case, async: true
 
@@ -31,8 +28,6 @@ defmodule MingaEditor.Commands.NoBufferTest do
       {:ok, state: no_buffer_state()}
     end
 
-    # Atom commands looked up through the Command Registry; the buffer-required
-    # commands return state unchanged when buffers.active is nil.
     test "atom motion commands are no-ops", %{state: state} do
       for cmd <- [:move_left, :move_right, :move_up, :move_down] do
         assert Commands.execute(state, cmd) == state
@@ -45,7 +40,6 @@ defmodule MingaEditor.Commands.NoBufferTest do
       end
     end
 
-    # Tuple commands routed through guard_buffer/2.
     test "tuple commands are no-ops", %{state: state} do
       for cmd <- [
             {:insert_char, "x"},

--- a/test/minga_editor/editor_test.exs
+++ b/test/minga_editor/editor_test.exs
@@ -1,10 +1,31 @@
 defmodule MingaEditor.EditorTest do
+  @moduledoc """
+  Integration smoke tests for the Editor GenServer.
+
+  Pure-function and Layer-1 contracts that used to live here have been
+  moved closer to the modules they exercise:
+
+    * Mode FSM dispatch shape & Esc-to-rest invariants
+      → `test/minga/mode/properties_test.exs`
+    * Read-only buffer guard for `i` / `R`
+      → `test/minga_editor/commands/insert_entry_test.exs`
+    * Commands no-op when no active buffer
+      → `test/minga_editor/commands/no_buffer_test.exs`
+    * Per-key Mode.process/3 dispatch shape
+      → `test/minga/mode/normal_test.exs` (already covered)
+
+  This file keeps only tests that exercise contracts the GenServer
+  itself owns: port roundtrip, file open, viewport propagation through
+  the editor process, and stale-timer message handling.
+  """
   use Minga.Test.EditingModelCase, async: true
 
   alias Minga.Buffer.Server, as: BufferServer
   alias MingaEditor
+  alias MingaEditor.Startup
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
 
-  # Helper: start a fresh editor with its own buffer.
   defp start_editor(content \\ "hello\nworld\nfoo") do
     {:ok, buffer} = BufferServer.start_link(content: content)
 
@@ -21,84 +42,46 @@ defmodule MingaEditor.EditorTest do
     {editor, buffer}
   end
 
-  # Helper: start editor with no buffer (splash screen)
-  defp start_editor_no_buffer do
-    {:ok, editor} =
-      MingaEditor.start_link(
-        name: :"editor_#{:erlang.unique_integer([:positive])}",
-        port_manager: nil,
-        buffer: nil,
-        width: 40,
-        height: 10,
-        editing_model: :vim
-      )
+  describe "build_initial_state/1" do
+    test "returns an EditorState in :normal mode" do
+      {:ok, buffer} = BufferServer.start_link(content: "hi")
 
-    editor
-  end
+      state =
+        Startup.build_initial_state(
+          port_manager: nil,
+          buffer: buffer,
+          width: 40,
+          height: 10,
+          editing_model: :vim
+        )
 
-  defp send_key(editor, codepoint, mods \\ 0) do
-    send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor)
-  end
-
-  describe "init" do
-    test "editor starts alive with Normal mode" do
-      {editor, _buffer} = start_editor()
-      assert Process.alive?(editor)
-    end
-
-    test "editor starts with no buffer" do
-      editor = start_editor_no_buffer()
-      assert Process.alive?(editor)
+      assert state.workspace.editing.mode == :normal
+      assert Minga.Editing.mode(state) == :normal
+      assert state.workspace.buffers.active == buffer
     end
   end
 
-  describe "handle_info — resize" do
-    test "resize event updates viewport" do
+  describe "render/1" do
+    test "render cast doesn't crash with a buffer" do
       {editor, _buffer} = start_editor()
-      send(editor, {:minga_input, {:resize, 120, 40}})
-      _ = :sys.get_state(editor)
-      assert Process.alive?(editor)
-    end
-  end
-
-  describe "handle_info — ready" do
-    test "ready event updates viewport" do
-      {editor, _buffer} = start_editor()
-      send(editor, {:minga_input, {:ready, 100, 30}})
-      _ = :sys.get_state(editor)
-      assert Process.alive?(editor)
-    end
-  end
-
-  describe "handle_info — unknown messages" do
-    test "unknown messages are ignored" do
-      {editor, _buffer} = start_editor()
-      send(editor, :some_random_message)
+      MingaEditor.render(editor)
       _ = :sys.get_state(editor)
       assert Process.alive?(editor)
     end
 
-    test "stale whichkey timeout is ignored" do
-      {editor, _buffer} = start_editor()
-      send(editor, {:whichkey_timeout, make_ref()})
+    test "render cast doesn't crash without a buffer" do
+      {:ok, editor} =
+        MingaEditor.start_link(
+          name: :"editor_#{:erlang.unique_integer([:positive])}",
+          port_manager: nil,
+          buffer: nil,
+          width: 40,
+          height: 10,
+          editing_model: :vim
+        )
+
+      MingaEditor.render(editor)
       _ = :sys.get_state(editor)
-      assert Process.alive?(editor)
-    end
-  end
-
-  describe "commands with no buffer" do
-    test "key presses with no buffer don't crash" do
-      editor = start_editor_no_buffer()
-
-      send_key(editor, ?h)
-      send_key(editor, ?j)
-      send_key(editor, ?i)
-      send_key(editor, ?d)
-      send_key(editor, ?d)
-      send_key(editor, ?u)
-      send_key(editor, ?p)
-
       assert Process.alive?(editor)
     end
   end
@@ -123,61 +106,58 @@ defmodule MingaEditor.EditorTest do
     end
   end
 
-  describe "render/1" do
-    test "render cast doesn't crash with a buffer" do
+  describe "resize" do
+    test "port-driven resize updates the workspace viewport" do
       {editor, _buffer} = start_editor()
-      MingaEditor.render(editor)
-      _ = :sys.get_state(editor)
-      assert Process.alive?(editor)
-    end
+      send(editor, {:minga_input, {:resize, 120, 40}})
+      state = :sys.get_state(editor)
 
-    test "render cast doesn't crash without a buffer" do
-      editor = start_editor_no_buffer()
-      MingaEditor.render(editor)
-      _ = :sys.get_state(editor)
-      assert Process.alive?(editor)
+      assert %Viewport{rows: 40, cols: 120} = state.workspace.viewport
     end
   end
 
-  describe "read-only buffer guard" do
-    test "entering insert mode on read-only buffer stays in normal mode" do
-      {:ok, buffer} = BufferServer.start_link(content: "read only", read_only: true)
+  describe "whichkey timeout" do
+    test "real-timer fires end-to-end and is ignored when ref is stale" do
+      {editor, _buffer} = start_editor()
+      before_whichkey = :sys.get_state(editor).shell_state.whichkey
 
-      {:ok, editor} =
-        MingaEditor.start_link(
-          name: :"editor_ro_#{:erlang.unique_integer([:positive])}",
-          port_manager: nil,
-          buffer: buffer,
-          width: 40,
-          height: 10,
-          editing_model: :vim
-        )
+      # Real timer using Process.send_after with a ref that does NOT match
+      # the editor's stored timer (nil by default). The handler's stale-ref
+      # branch must return state unchanged — popup stays hidden.
+      timer_ref = Process.send_after(editor, {:whichkey_timeout, make_ref()}, 0)
 
-      # Try pressing 'i' to enter insert mode
-      send(editor, {:minga_input, {:key_press, ?i, 0}})
-      state = :sys.get_state(editor)
-      assert state.workspace.editing.mode == :normal
-      assert state.shell_state.status_msg == "Buffer is read-only"
+      # Wait until the timer has actually fired (read_timer returns false
+      # once it's been delivered), then sync via :sys.get_state.
+      _ = await_timer_fired(timer_ref)
+      after_whichkey = :sys.get_state(editor).shell_state.whichkey
+
+      assert after_whichkey.show == before_whichkey.show
+      assert after_whichkey.timer == before_whichkey.timer
     end
 
-    test "entering replace mode on read-only buffer stays in normal mode" do
-      {:ok, buffer} = BufferServer.start_link(content: "read only", read_only: true)
-
-      {:ok, editor} =
-        MingaEditor.start_link(
-          name: :"editor_ro2_#{:erlang.unique_integer([:positive])}",
-          port_manager: nil,
-          buffer: buffer,
-          width: 40,
-          height: 10,
-          editing_model: :vim
-        )
-
-      # Try pressing 'R' to enter replace mode
-      send(editor, {:minga_input, {:key_press, ?R, 0}})
+    test "stale ref handler is a pure no-op (called directly with a fabricated ref)" do
+      {editor, _buffer} = start_editor()
       state = :sys.get_state(editor)
-      assert state.workspace.editing.mode == :normal
-      assert state.shell_state.status_msg == "Buffer is read-only"
+
+      # `whichkey.timer` defaults to nil; any fresh ref differs from nil
+      # so the handler hits the stale-ref branch.
+      assert {:noreply, ^state} =
+               MingaEditor.handle_info({:whichkey_timeout, make_ref()}, state)
+
+      assert EditorState.whichkey(state).timer == nil
+    end
+  end
+
+  # Polls Process.read_timer/1 until the timer has been delivered. Bounded
+  # by 50 iterations × 1ms to keep the test from hanging if something goes
+  # wrong with the timer wheel.
+  defp await_timer_fired(ref, attempts \\ 50)
+  defp await_timer_fired(_ref, 0), do: :timeout
+
+  defp await_timer_fired(ref, attempts) do
+    case Process.read_timer(ref) do
+      false -> :ok
+      _ms_left -> await_timer_fired(ref, attempts - 1)
     end
   end
 end

--- a/test/minga_editor/editor_test.exs
+++ b/test/minga_editor/editor_test.exs
@@ -1,22 +1,8 @@
 defmodule MingaEditor.EditorTest do
   @moduledoc """
-  Integration smoke tests for the Editor GenServer.
-
-  Pure-function and Layer-1 contracts that used to live here have been
-  moved closer to the modules they exercise:
-
-    * Mode FSM dispatch shape & Esc-to-rest invariants
-      → `test/minga/mode/properties_test.exs`
-    * Read-only buffer guard for `i` / `R`
-      → `test/minga_editor/commands/insert_entry_test.exs`
-    * Commands no-op when no active buffer
-      → `test/minga_editor/commands/no_buffer_test.exs`
-    * Per-key Mode.process/3 dispatch shape
-      → `test/minga/mode/normal_test.exs` (already covered)
-
-  This file keeps only tests that exercise contracts the GenServer
-  itself owns: port roundtrip, file open, viewport propagation through
-  the editor process, and stale-timer message handling.
+  Integration smoke tests for the Editor GenServer: contracts the
+  GenServer itself owns (port roundtrip, file open, viewport
+  propagation, stale-timer dispatch, status_msg surfacing).
   """
   use Minga.Test.EditingModelCase, async: true
 
@@ -42,8 +28,22 @@ defmodule MingaEditor.EditorTest do
     {editor, buffer}
   end
 
+  defp start_editor_no_buffer do
+    {:ok, editor} =
+      MingaEditor.start_link(
+        name: :"editor_#{:erlang.unique_integer([:positive])}",
+        port_manager: nil,
+        buffer: nil,
+        width: 40,
+        height: 10,
+        editing_model: :vim
+      )
+
+    editor
+  end
+
   describe "build_initial_state/1" do
-    test "returns an EditorState in :normal mode" do
+    test "returns an EditorState in :normal mode with the buffer wired up" do
       {:ok, buffer} = BufferServer.start_link(content: "hi")
 
       state =
@@ -59,6 +59,23 @@ defmodule MingaEditor.EditorTest do
       assert Minga.Editing.mode(state) == :normal
       assert state.workspace.buffers.active == buffer
     end
+
+    test "creates a default [new 1] buffer when none is provided" do
+      state =
+        Startup.build_initial_state(
+          port_manager: nil,
+          buffer: nil,
+          width: 40,
+          height: 10,
+          editing_model: :vim
+        )
+
+      assert state.workspace.editing.mode == :normal
+      # Render pipeline / command dispatch / input routing all assume
+      # buffers.active is a pid, so Startup synthesises one when caller
+      # passes nil.
+      assert is_pid(state.workspace.buffers.active)
+    end
   end
 
   describe "render/1" do
@@ -70,16 +87,7 @@ defmodule MingaEditor.EditorTest do
     end
 
     test "render cast doesn't crash without a buffer" do
-      {:ok, editor} =
-        MingaEditor.start_link(
-          name: :"editor_#{:erlang.unique_integer([:positive])}",
-          port_manager: nil,
-          buffer: nil,
-          width: 40,
-          height: 10,
-          editing_model: :vim
-        )
-
+      editor = start_editor_no_buffer()
       MingaEditor.render(editor)
       _ = :sys.get_state(editor)
       assert Process.alive?(editor)
@@ -116,19 +124,64 @@ defmodule MingaEditor.EditorTest do
     end
   end
 
+  describe "ready" do
+    test "ready event seeds the workspace viewport columns" do
+      {editor, _buffer} = start_editor()
+      send(editor, {:minga_input, {:ready, 100, 30}})
+      state = :sys.get_state(editor)
+
+      assert state.workspace.viewport.cols == 100
+    end
+  end
+
+  describe "unknown handle_info messages" do
+    test "stray messages are dropped without crashing" do
+      {editor, _buffer} = start_editor()
+      ref = Process.monitor(editor)
+      send(editor, :some_random_message)
+      send(editor, {:unexpected, :tuple})
+      _ = :sys.get_state(editor)
+
+      refute_received {:DOWN, ^ref, :process, _, _}
+    end
+  end
+
+  describe "read-only buffer through the GenServer" do
+    # Layer-1 KeyDispatch behaviour is covered in
+    # test/minga_editor/commands/insert_entry_test.exs. This smoke test
+    # exists to catch regressions where Editor.handle_info swallows or
+    # rewrites the status_msg surfaced by KeyDispatch.
+    test "pressing i on a read-only buffer surfaces status_msg in shell_state" do
+      {:ok, buffer} = BufferServer.start_link(content: "read only", read_only: true)
+
+      {:ok, editor} =
+        MingaEditor.start_link(
+          name: :"editor_ro_#{:erlang.unique_integer([:positive])}",
+          port_manager: nil,
+          buffer: buffer,
+          width: 40,
+          height: 10,
+          editing_model: :vim
+        )
+
+      send(editor, {:minga_input, {:key_press, ?i, 0}})
+      state = :sys.get_state(editor)
+
+      assert state.workspace.editing.mode == :normal
+      assert state.shell_state.status_msg == "Buffer is read-only"
+    end
+  end
+
   describe "whichkey timeout" do
     test "real-timer fires end-to-end and is ignored when ref is stale" do
       {editor, _buffer} = start_editor()
       before_whichkey = :sys.get_state(editor).shell_state.whichkey
 
-      # Real timer using Process.send_after with a ref that does NOT match
-      # the editor's stored timer (nil by default). The handler's stale-ref
-      # branch must return state unchanged — popup stays hidden.
+      # Ref does not match the editor's stored timer (nil by default), so the
+      # handler must hit its stale-ref branch and leave the popup hidden.
       timer_ref = Process.send_after(editor, {:whichkey_timeout, make_ref()}, 0)
 
-      # Wait until the timer has actually fired (read_timer returns false
-      # once it's been delivered), then sync via :sys.get_state.
-      _ = await_timer_fired(timer_ref)
+      assert :ok = await_timer_fired(timer_ref)
       after_whichkey = :sys.get_state(editor).shell_state.whichkey
 
       assert after_whichkey.show == before_whichkey.show
@@ -138,26 +191,29 @@ defmodule MingaEditor.EditorTest do
     test "stale ref handler is a pure no-op (called directly with a fabricated ref)" do
       {editor, _buffer} = start_editor()
       state = :sys.get_state(editor)
+      assert EditorState.whichkey(state).timer == nil
 
-      # `whichkey.timer` defaults to nil; any fresh ref differs from nil
-      # so the handler hits the stale-ref branch.
+      # Any fresh ref differs from the nil-default timer, so the handler hits
+      # the stale-ref branch and returns state unchanged (pinned match below).
       assert {:noreply, ^state} =
                MingaEditor.handle_info({:whichkey_timeout, make_ref()}, state)
-
-      assert EditorState.whichkey(state).timer == nil
     end
   end
 
-  # Polls Process.read_timer/1 until the timer has been delivered. Bounded
-  # by 50 iterations × 1ms to keep the test from hanging if something goes
-  # wrong with the timer wheel.
+  # Polls Process.read_timer/1 until the timer has been delivered. Bounded by
+  # 50 iterations of 1ms sleeps so the test fails loudly via :timeout instead
+  # of hanging if the timer wheel ever stalls.
   defp await_timer_fired(ref, attempts \\ 50)
   defp await_timer_fired(_ref, 0), do: :timeout
 
   defp await_timer_fired(ref, attempts) do
     case Process.read_timer(ref) do
-      false -> :ok
-      _ms_left -> await_timer_fired(ref, attempts - 1)
+      false ->
+        :ok
+
+      _ms_left ->
+        Process.sleep(1)
+        await_timer_fired(ref, attempts - 1)
     end
   end
 end


### PR DESCRIPTION
Closes #1449.

## Summary

- **Layer 0** `test/minga/mode/properties_test.exs` — two StreamData property tests covering `Mode.process/3`'s result-shape closure and the Esc-to-`:normal` invariant; built on `Defaults.leader_trie/0` + `Defaults.normal_bindings/0` so generators match production keymap loading.
- **Layer 1** `test/minga_editor/commands/insert_entry_test.exs` — read-only buffer guard tests for `i` (insert) and `R` (replace) via `KeyDispatch.handle_key/3`, with a writable-buffer control case.
- **Layer 1** `test/minga_editor/commands/no_buffer_test.exs` — atom and tuple commands no-op when `buffers.active` is nil.
- **`test/minga_editor/editor_test.exs`** rewritten (-111/+91): drops `Process.alive?` smokes, adds a `Startup.build_initial_state/1` constructor test, makes the resize test assert the actual viewport, replaces the stale-whichkey send with a real `Process.send_after` roundtrip plus a pure `handle_info` call.

## Notable finding

The Esc property test surfaced a real production bug: `Minga.Mode.ExtensionConfirmState` is missing `count: nil`, so `Mode.reset_count/1` raises `KeyError` on `Esc` / `q`. The fix is incoming as a follow-up commit on this branch — `:extension_confirm` is currently excluded from the property generators with a NOTE pointing at the missing field.

## Test plan

- [x] `mix test.llm` — 54 doctests, 97 properties, 7511 tests, 0 failures
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean (13 pre-existing struct-size warnings, none in new files)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix dialyzer` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)