### PR TITLE
fix(agent): bootstrap card workspace on first zoom and clean cache on zoom-out

### DIFF
--- a/lib/minga_editor/shell/board/agent_deactivation.ex
+++ b/lib/minga_editor/shell/board/agent_deactivation.ex
@@ -1,0 +1,32 @@
+defmodule MingaEditor.Shell.Board.AgentDeactivation do
+  @moduledoc """
+  Clears the shell-level agent rendering cache when leaving a Board card.
+
+  Symmetric counterpart to the activation step that runs on zoom-in: when
+  the user zooms out of a card, the cached `runtime`, `pending_approval`,
+  and `error` fields on `state.shell_state.agent` belong to the card the
+  user just left. The grid view must not show those.
+
+  This is narrower than `MingaEditor.AgentActivation.deactivate/1`, which
+  also resets workspace-level fields (keymap scope, prompt focus). On
+  zoom-out the workspace is replaced by the grid snapshot via
+  `restore_tab_context/2`, so workspace-level cleanup is unnecessary.
+  Resetting only the shell-level cache keeps the responsibility on this
+  module clear.
+  """
+
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.AgentAccess
+
+  @doc """
+  Resets the agent rendering cache (`runtime`, `pending_approval`, `error`).
+
+  Call from `ZoomOut.zoom_out/1` before restoring the grid workspace so the
+  grid renders against an idle cache.
+  """
+  @spec deactivate_agent_for_card(EditorState.t()) :: EditorState.t()
+  def deactivate_agent_for_card(%EditorState{} = state) do
+    AgentAccess.update_agent(state, &AgentState.reset_cache/1)
+  end
+end

--- a/lib/minga_editor/shell/board/input.ex
+++ b/lib/minga_editor/shell/board/input.ex
@@ -18,9 +18,8 @@ defmodule MingaEditor.Shell.Board.Input do
   @behaviour MingaEditor.Input.Handler
 
   alias MingaAgent.Config, as: AgentConfig
-  alias MingaEditor.Agent.UIState
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.VimState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.Shell.Board
   alias MingaEditor.Shell.Board.Card
   alias MingaEditor.Shell.Board.State, as: BoardState
@@ -259,23 +258,18 @@ defmodule MingaEditor.Shell.Board.Input do
       state = %{state | shell_state: new_board}
 
       # Restore the card's workspace if it has one from a previous zoom.
-      # First zoom: reset workspace to clean state so activate_for_card
-      # operates on a fresh window, not the grid's window.
+      # First zoom: build a fresh agent-shaped workspace (own window with
+      # agent_chat content, agent scope, default agent_ui) so activate_for_card
+      # operates on a card-shaped window, not the grid's buffer window.
       state =
         case card.workspace do
           ws when is_map(ws) and map_size(ws) > 0 ->
             EditorState.restore_tab_context(state, ws)
 
           _ ->
-            fresh_ws = %{
-              state.workspace
-              | keymap_scope: :editor,
-                editing: VimState.new(),
-                completion: nil,
-                agent_ui: UIState.new()
-            }
-
-            %{state | workspace: fresh_ws}
+            agent_buf = AgentAccess.agent(state).buffer
+            fresh_context = EditorState.build_agent_card_workspace(state, agent_buf)
+            EditorState.restore_tab_context(state, fresh_context)
         end
 
       # For agent cards, activate the agentic view so the user sees

--- a/lib/minga_editor/shell/board/zoom_out.ex
+++ b/lib/minga_editor/shell/board/zoom_out.ex
@@ -11,9 +11,9 @@ defmodule MingaEditor.Shell.Board.ZoomOut do
 
   @behaviour MingaEditor.Input.Handler
 
-  alias MingaEditor.AgentActivation
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Shell.Board
+  alias MingaEditor.Shell.Board.AgentDeactivation
   alias MingaEditor.Shell.Board.Card
   alias MingaEditor.Shell.Board.State, as: BoardState
 
@@ -76,15 +76,18 @@ defmodule MingaEditor.Shell.Board.ZoomOut do
     board = %{board | zoomed_into: nil}
     state = %{state | shell_state: board}
 
-    # Restore the grid workspace if we have one
-    state =
-      if grid_workspace && is_map(grid_workspace) && map_size(grid_workspace) > 0 do
-        EditorState.restore_tab_context(state, grid_workspace)
-      else
-        state
-      end
+    # Reset the shell-level agent rendering cache before restoring the grid
+    # workspace so the grid does not render against the previous card's
+    # status, error, or pending approval.
+    state = AgentDeactivation.deactivate_agent_for_card(state)
 
-    # Deactivate the agent view (clear session, reset scope, unfocus prompt)
-    AgentActivation.deactivate(state)
+    # Restore the grid workspace if we have one. The restore replaces the
+    # workspace fields wholesale, so workspace-level activation state
+    # (keymap scope, agent_ui focus) is reset by the restore itself.
+    if grid_workspace && is_map(grid_workspace) && map_size(grid_workspace) > 0 do
+      EditorState.restore_tab_context(state, grid_workspace)
+    else
+      state
+    end
   end
 end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -985,6 +985,42 @@ defmodule MingaEditor.State do
     }
   end
 
+  @doc """
+  Builds a fresh agent-shaped workspace context for a Board card on first zoom.
+
+  Returns a `Tab.context()` carrying a single agent-chat window sized to the
+  current viewport, with the agent keymap scope and a fresh `agent_ui`. The
+  caller restores it via `restore_tab_context/2` and then runs
+  `AgentActivation.activate_for_card/2` to attach the card's session pid to
+  the window content.
+
+  Falls back to an empty `Windows` map when no agent buffer is available;
+  the caller's activation step then becomes a no-op.
+  """
+  @spec build_agent_card_workspace(t(), pid() | nil) :: Tab.context()
+  def build_agent_card_workspace(%__MODULE__{} = state, agent_buf) do
+    rows = max(state.workspace.viewport.rows, 1)
+    cols = max(state.workspace.viewport.cols, 1)
+
+    windows = build_agent_card_windows(agent_buf, rows, cols)
+    build_agent_tab_defaults(state, windows, agent_buf)
+  end
+
+  @spec build_agent_card_windows(pid() | nil, pos_integer(), pos_integer()) :: Windows.t()
+  defp build_agent_card_windows(agent_buf, rows, cols) when is_pid(agent_buf) do
+    win_id = 1
+    agent_window = Window.new_agent_chat(win_id, agent_buf, rows, cols)
+
+    %Windows{
+      tree: WindowTree.new(win_id),
+      map: %{win_id => agent_window},
+      active: win_id,
+      next_id: win_id + 1
+    }
+  end
+
+  defp build_agent_card_windows(_agent_buf, _rows, _cols), do: %Windows{}
+
   # Migrates legacy contexts (old nested format or oldest
   # bare-field format) to the new flat format. If the context already
   # has the :buffers key (new format), returns it unchanged.

--- a/test/minga_editor/shell/board/input_test.exs
+++ b/test/minga_editor/shell/board/input_test.exs
@@ -7,11 +7,11 @@ defmodule MingaEditor.Shell.Board.InputTest do
   """
   use ExUnit.Case, async: true
 
+  alias MingaAgent.RuntimeState
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
-  alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
-  alias MingaEditor.Window
   alias MingaEditor.Window.Content
   alias MingaEditor.Shell.Board
   alias MingaEditor.Shell.Board.Input, as: BoardInput
@@ -135,9 +135,11 @@ defmodule MingaEditor.Shell.Board.InputTest do
     end
 
     test "first-time zoom into agent card builds fresh workspace and activates agent view" do
-      # Set up a board with one agent card that has a session but no workspace
+      # Set up a board with one agent card that has a session but no workspace.
+      # The shell carries the agent buffer pid that the bootstrap helper uses
+      # to construct the agent-chat window.
       fake_session = spawn(fn -> Process.sleep(:infinity) end)
-      {:ok, buf_pid} = Minga.Buffer.start_link(content: "")
+      {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
 
       board =
         BoardState.new()
@@ -145,34 +147,77 @@ defmodule MingaEditor.Shell.Board.InputTest do
           {b, _card} = BoardState.create_card(b, task: "Agent 1", session: fake_session)
           b
         end)
+        |> Map.put(:agent, %AgentState{buffer: agent_buf})
 
       # Ensure the focused card has workspace: nil (first-time zoom)
       focused_id = board.focused_card
       assert board.cards[focused_id].workspace == nil
 
-      # Build state with a window in the map so activate_for_card can set content
-      win = Window.new(1, buf_pid, 24, 80)
-      windows = %Windows{map: %{1 => win}, active: 1, next_id: 2}
-
+      # Start state has the grid's empty windows; the bootstrap helper
+      # replaces them with a fresh agent-chat window.
       state = %EditorState{
         port_manager: self(),
         shell: Board,
         shell_state: board,
-        workspace: %MingaEditor.Workspace.State{
-          viewport: Viewport.new(24, 80),
-          windows: windows
-        },
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
         focus_stack: [BoardInput, MingaEditor.Input.GlobalBindings]
       }
 
       {:handled, new_state} = BoardInput.handle_key(state, @enter, 0)
 
-      # Agent activation should have set keymap scope to :agent
+      # Bootstrap should have set the agent keymap scope...
       assert new_state.workspace.keymap_scope == :agent
 
-      # Window content should be agent_chat
+      # ...and the active window must now be an agent-chat window backed by
+      # the card's session pid (set by AgentActivation, not the bootstrap).
       active_win = new_state.workspace.windows.map[new_state.workspace.windows.active]
       assert Content.agent_chat?(active_win.content)
+      assert active_win.content == Content.agent_chat(fake_session)
+      assert active_win.pinned == true
+    end
+
+    test "first-time zoom matches re-zoom shape (modulo prompt content)" do
+      # The acceptance criterion: first-zoom and re-zoom land in the same
+      # workspace shape — agent scope, agent-chat window, fresh agent_ui.
+      fake_session = spawn(fn -> Process.sleep(:infinity) end)
+      {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
+
+      board =
+        BoardState.new()
+        |> then(fn b ->
+          {b, _card} = BoardState.create_card(b, task: "Agent 1", session: fake_session)
+          b
+        end)
+        |> Map.put(:agent, %AgentState{buffer: agent_buf})
+
+      state = %EditorState{
+        port_manager: self(),
+        shell: Board,
+        shell_state: board,
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+        focus_stack: [BoardInput, MingaEditor.Input.GlobalBindings]
+      }
+
+      # First zoom: bootstrap path
+      {:handled, after_first_zoom} = BoardInput.handle_key(state, @enter, 0)
+
+      # Zoom out then back in: snapshot/restore path
+      {:handled, after_zoom_out} = ZoomOut.handle_key(after_first_zoom, @escape, 0)
+      {:handled, after_second_zoom} = BoardInput.handle_key(after_zoom_out, @enter, 0)
+
+      # Both zoom-ins should produce the same shape.
+      assert after_first_zoom.workspace.keymap_scope ==
+               after_second_zoom.workspace.keymap_scope
+
+      first_win =
+        after_first_zoom.workspace.windows.map[after_first_zoom.workspace.windows.active]
+
+      second_win =
+        after_second_zoom.workspace.windows.map[after_second_zoom.workspace.windows.active]
+
+      assert Content.agent_chat?(first_win.content)
+      assert Content.agent_chat?(second_win.content)
+      assert first_win.content == second_win.content
     end
   end
 
@@ -210,6 +255,88 @@ defmodule MingaEditor.Shell.Board.InputTest do
       assert AgentAccess.session(new_state) == nil
       # The card still holds the pid so a subsequent zoom-in restores it.
       assert new_state.shell_state.cards[1].session == fake_pid
+    end
+
+    test "zoom-out clears the agent rendering cache so the grid view starts idle" do
+      # Card A is zoomed in with a busy/errored agent state cached on the
+      # shell. Zooming out must reset the cache so the grid isn't showing
+      # card A's status, error, or pending approval.
+      board =
+        BoardState.new()
+        |> then(fn b ->
+          {b, _card} = BoardState.create_card(b, task: "Agent A")
+          b
+        end)
+        |> Map.put(:agent, %AgentState{
+          runtime: %RuntimeState{status: :thinking},
+          error: "boom",
+          pending_approval: %{kind: :tool, name: "fake"}
+        })
+
+      board = BoardState.zoom_into(board, board.focused_card, %{fake: :grid_workspace})
+
+      state = %EditorState{
+        port_manager: self(),
+        shell: Board,
+        shell_state: board,
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+        focus_stack: [ZoomOut, MingaEditor.Input.GlobalBindings]
+      }
+
+      {:handled, new_state} = ZoomOut.handle_key(state, @escape, 0)
+
+      agent = AgentAccess.agent(new_state)
+      assert agent.runtime.status == :idle
+      assert agent.error == nil
+      assert agent.pending_approval == nil
+    end
+
+    test "zoom A → out → zoom B does not leak A's session into B's rendering cache" do
+      # Two cards with distinct sessions. After zooming through A and into
+      # B, the active session must report as B's pid (no leak from A).
+      session_a = spawn(fn -> Process.sleep(:infinity) end)
+      session_b = spawn(fn -> Process.sleep(:infinity) end)
+      {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
+
+      board =
+        BoardState.new()
+        |> then(fn b ->
+          {b, _card_a} = BoardState.create_card(b, task: "A", session: session_a)
+          b
+        end)
+        |> then(fn b ->
+          {b, _card_b} = BoardState.create_card(b, task: "B", session: session_b)
+          b
+        end)
+        |> Map.put(:agent, %AgentState{buffer: agent_buf})
+
+      state = %EditorState{
+        port_manager: self(),
+        shell: Board,
+        shell_state: board,
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+        focus_stack: [BoardInput, ZoomOut, MingaEditor.Input.GlobalBindings]
+      }
+
+      # Focus A, zoom in.
+      board = BoardState.focus_card(state.shell_state, 1)
+      state = %{state | shell_state: board}
+      {:handled, state} = BoardInput.handle_key(state, @enter, 0)
+      assert AgentAccess.session(state) == session_a
+
+      # Zoom out: cache reset, grid view has no active session.
+      {:handled, state} = ZoomOut.handle_key(state, @escape, 0)
+      assert AgentAccess.session(state) == nil
+
+      # Focus B, zoom in. The active session must be B, not A.
+      board = BoardState.focus_card(state.shell_state, 2)
+      state = %{state | shell_state: board}
+      {:handled, state} = BoardInput.handle_key(state, @enter, 0)
+      assert AgentAccess.session(state) == session_b
+
+      # The cards still hold their original sessions.
+      assert state.shell_state.cards[1].session == session_a
+      assert state.shell_state.cards[2].session == session_b
     end
 
     test "passes through when not zoomed" do


### PR DESCRIPTION
Closes #1429.

## Summary

Two surgical fixes to the Board zoom lifecycle so the cycle is symmetric — zoom-in always lands in a valid card-shaped workspace, zoom-out always tears the activation down cleanly without leaking the previous card's rendering state.

- **First-zoom bootstrap.** `Board.Input.zoom_into_focused/1` previously fell back to "keep the grid workspace, let `activate_for_card/2` retag the active window's content." That meant a buffer window pretended to be an agent chat window, and the next snapshot/restore cycle carried the corruption forward. Replaced with `EditorState.build_agent_card_workspace/2`, which builds a single `Window.new_agent_chat`-shaped window, agent keymap scope, and a fresh `agent_ui`. The activation step then attaches the card's session pid to the already-correctly-shaped window.
- **Zoom-out cleanup.** `ZoomOut.zoom_out/1` now calls the new `MingaEditor.Shell.Board.AgentDeactivation.deactivate_agent_for_card/1` helper before the grid restore, resetting `runtime`, `pending_approval`, and `error` on `state.shell_state.agent`. The grid workspace restore replaces workspace-level fields (keymap scope, `agent_ui`) wholesale, so the previous trailing `AgentActivation.deactivate/1` (which only re-cleared workspace fields the restore had just rewritten) is now redundant and removed.
- **New module.** `lib/minga_editor/shell/board/agent_deactivation.ex`, a Board-shell-specific helper narrowly scoped to the shell-level cache reset. Distinct from `MingaEditor.AgentActivation.deactivate/1`, which also touches workspace fields the restore handles.

## Verification | AC | How proved |
| --- | --- |
| 1. First zoom of a workspace-less card produces a fresh card workspace with the agent chat window content, agent keymap scope, and prompt buffer wired up | `test/minga_editor/shell/board/input_test.exs` — "first-time zoom into agent card builds fresh workspace and activates agent view" asserts `keymap_scope == :agent`, the active window content is `Content.agent_chat(session)`, and the window is pinned. |
| 2. First-zoom path produces the same end state as a re-zoom (modulo prompt content) | `test/minga_editor/shell/board/input_test.exs` — "first-time zoom matches re-zoom shape (modulo prompt content)" zooms in, out, and back in, asserting both states have agent scope and the same agent-chat window content. |
| 3. `ZoomOut.zoom_out/1` clears `runtime`, `pending_approval`, `error` before grid restore | `lib/minga_editor/shell/board/zoom_out.ex:79-83` calls `AgentDeactivation.deactivate_agent_for_card/1` before `restore_tab_context`. `test/minga_editor/shell/board/input_test.exs` — "zoom-out clears the agent rendering cache so the grid view starts idle" seeds the cache with `:thinking`, `error: "boom"`, and a pending approval, then asserts all three reset after zoom-out. |
| 4. After zoom-out, no card session is reachable through `AgentAccess.session/1` from the grid view | Existing test "active agent session goes out of scope on zoom-out" already covers this; new test "zoom A → out → zoom B does not leak A's session into B's rendering cache" extends it to the multi-card path. |
| 5. Zoom A → out → zoom B shows B's state with no leak from A | `test/minga_editor/shell/board/input_test.exs` — "zoom A → out → zoom B does not leak A's session into B's rendering cache" zooms two cards with distinct sessions, asserts `AgentAccess.session/1` returns the correct pid at each step, and verifies cards retain their original sessions. |
| 6. Existing Board tests pass; new tests cover the new paths | `mix test.llm test/minga_editor/shell/board/` — 66 tests, 0 failures. Full `mix test.llm` shows no regressions related to this change (one unrelated pre-existing flake on `messages_buffer_test.exs:53` confirmed to be test-order-dependent — passes in isolation on both `main` and this branch). |

### Local verification commands

- `mix compile --warnings-as-errors` — clean
- `mix test.llm test/minga_editor/shell/board/` — 66/66 pass
- `make lint` — passes (format + credo + warnings + dialyzer); 13 unrelated pre-existing struct-field-count warnings remain on other modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)