### PR TITLE
feat(ui): migrate prompt, dashboard, and conflict prompt to ModalOverlay

### DIFF
--- a/credo/checks/no_direct_state_machine_write_check.exs
+++ b/credo/checks/no_direct_state_machine_write_check.exs
@@ -47,7 +47,7 @@ defmodule Minga.Credo.NoDirectStateMachineWriteCheck do
         # VimState fields: must use VimState.set_*/transition instead of direct writes
         {:editing, [:mode_state, :marks, :last_jump_pos, :last_find_char, :macro_recorder, :change_recorder, :reg]},
         # Workspace.State fields: must use WorkspaceState.set_* instead of direct writes
-        {:workspace, [:keymap_scope, :completion, :completion_trigger, :highlight, :mouse, :document_highlights, :search, :pending_conflict, :lsp_pending, :viewport, :windows, :buffers, :agent_ui, :injection_ranges, :editing]}
+        {:workspace, [:keymap_scope, :completion, :completion_trigger, :highlight, :mouse, :document_highlights, :search, :lsp_pending, :viewport, :windows, :buffers, :agent_ui, :injection_ranges, :editing]}
       ],
       allowed_files: ["vim_state.ex", "state.ex", "workspace/state.ex"]
     ],

--- a/lib/minga_editor/file_watcher_helpers.ex
+++ b/lib/minga_editor/file_watcher_helpers.ex
@@ -9,8 +9,9 @@ defmodule MingaEditor.FileWatcherHelpers do
 
   alias Minga.Buffer
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
   alias Minga.FileWatcher
-  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   @type state :: EditorState.t()
 
@@ -74,8 +75,7 @@ defmodule MingaEditor.FileWatcherHelpers do
   defp handle_change(state, buf, path, _buf_state, _mtime, _size) do
     name = Path.basename(path)
 
-    state =
-      EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, {buf, path}))
+    state = ModalOverlay.open(state, :conflict, ConflictPayload.new(buf, path))
 
     EditorState.set_status(state, "#{name} changed on disk. [r]eload / [k]eep")
   end

--- a/lib/minga_editor/input/conflict_prompt.ex
+++ b/lib/minga_editor/input/conflict_prompt.ex
@@ -5,6 +5,10 @@ defmodule MingaEditor.Input.ConflictPrompt do
   When a buffer's file has been modified externally and the user hasn't
   responded yet, this handler intercepts all keys. `r` reloads the buffer
   from disk, `k` keeps the local version, and all other keys are swallowed.
+
+  The conflict prompt lives on `state.shell_state.modal` as
+  `{:conflict, %ModalOverlay.Conflict{}}`. While active, the gate's
+  conflict-sticky rule prevents other modals from opening on top.
   """
 
   @behaviour MingaEditor.Input.Handler
@@ -13,22 +17,31 @@ defmodule MingaEditor.Input.ConflictPrompt do
 
   alias Minga.Buffer
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.Workspace.State, as: WorkspaceState
+  alias MingaEditor.State.ModalOverlay
 
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
-  def handle_key(%{workspace: %{pending_conflict: {buf, _path}}} = state, ?r, _mods)
+  def handle_key(
+        %{shell_state: %{modal: {:conflict, %{buffer: buf}}}} = state,
+        ?r,
+        _mods
+      )
       when is_pid(buf) do
     Buffer.reload(buf)
     name = Path.basename(Buffer.file_path(buf) || "buffer")
 
     {:handled,
-     EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, nil))
+     state
+     |> ModalOverlay.dismiss()
      |> EditorState.set_status("#{name} reloaded (changed on disk)")}
   end
 
-  def handle_key(%{workspace: %{pending_conflict: {buf, _path}}} = state, ?k, _mods)
+  def handle_key(
+        %{shell_state: %{modal: {:conflict, %{buffer: buf}}}} = state,
+        ?k,
+        _mods
+      )
       when is_pid(buf) do
     buf_state = :sys.get_state(buf)
 
@@ -40,11 +53,10 @@ defmodule MingaEditor.Input.ConflictPrompt do
         :ok
     end
 
-    state = EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, nil))
-    {:handled, EditorState.clear_status(state)}
+    {:handled, state |> ModalOverlay.dismiss() |> EditorState.clear_status()}
   end
 
-  def handle_key(%{workspace: %{pending_conflict: {_, _}}} = state, _cp, _mods) do
+  def handle_key(%{shell_state: %{modal: {:conflict, _}}} = state, _cp, _mods) do
     # Swallow all other keys while conflict prompt is active
     {:handled, state}
   end

--- a/lib/minga_editor/input/dashboard.ex
+++ b/lib/minga_editor/input/dashboard.ex
@@ -2,10 +2,10 @@ defmodule MingaEditor.Input.Dashboard do
   @moduledoc """
   Input handler for the dashboard home screen.
 
-  Active only when no file buffer is open (`buffers.active == nil`).
-  Captures j/k and arrow keys for cursor navigation, Enter or SPC for
-  item selection, and passes everything else through so global bindings
-  (Ctrl+Q) still work.
+  Active when the dashboard modal is open (`state.shell_state.modal ==
+  {:dashboard, _}`). Captures j/k and arrow keys for cursor navigation,
+  Enter or SPC for item selection, and passes everything else through so
+  global bindings (Ctrl+Q) still work.
   """
 
   @behaviour MingaEditor.Input.Handler
@@ -15,7 +15,8 @@ defmodule MingaEditor.Input.Dashboard do
   alias MingaEditor.Commands
   alias MingaEditor.Commands.BufferManagement
   alias MingaEditor.Dashboard
-  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Dashboard, as: DashboardPayload
 
   # Key codepoints
   @key_j ?j
@@ -31,16 +32,16 @@ defmodule MingaEditor.Input.Dashboard do
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
   def handle_key(
-        %{workspace: %{buffers: %{active: nil}}, shell_state: %{dashboard: %{} = dash}} = state,
+        %{shell_state: %{modal: {:dashboard, %{state: %{} = dash}}}} = state,
         codepoint,
         _modifiers
       ) do
     case codepoint do
       cp when cp == @key_j or cp == @arrow_down ->
-        {:handled, EditorState.set_dashboard(state, Dashboard.cursor_down(dash))}
+        {:handled, transition_dashboard(state, Dashboard.cursor_down(dash))}
 
       cp when cp == @key_k or cp == @arrow_up ->
-        {:handled, EditorState.set_dashboard(state, Dashboard.cursor_up(dash))}
+        {:handled, transition_dashboard(state, Dashboard.cursor_up(dash))}
 
       cp when cp == @key_enter or cp == @key_space ->
         handle_select(state, dash)
@@ -52,7 +53,7 @@ defmodule MingaEditor.Input.Dashboard do
 
   def handle_key(state, _codepoint, _modifiers), do: {:passthrough, state}
 
-  @spec handle_select(EditorState.t(), Dashboard.state()) :: MingaEditor.Input.Handler.result()
+  @spec handle_select(state(), Dashboard.state()) :: MingaEditor.Input.Handler.result()
   defp handle_select(state, dash) do
     case Dashboard.selected_command(dash) do
       nil ->
@@ -62,14 +63,18 @@ defmodule MingaEditor.Input.Dashboard do
         root = safe_project_root()
         full_path = Path.join(root, path)
         state = BufferManagement.execute(state, {:execute_ex_command, {:edit, full_path}})
-        state = EditorState.close_dashboard(state)
-        {:handled, state}
+        {:handled, ModalOverlay.dismiss(state)}
 
       command when is_atom(command) ->
         state = Commands.execute(state, command)
-        state = EditorState.close_dashboard(state)
-        {:handled, state}
+        {:handled, ModalOverlay.dismiss(state)}
     end
+  end
+
+  @spec transition_dashboard(state(), Dashboard.state()) :: state()
+  defp transition_dashboard(state, new_dash) do
+    {:dashboard, payload} = state.shell_state.modal
+    ModalOverlay.transition(state, :dashboard, DashboardPayload.put_state(payload, new_dash))
   end
 
   defdelegate safe_project_root, to: Minga.Project, as: :resolve_root

--- a/lib/minga_editor/input/interrupt.ex
+++ b/lib/minga_editor/input/interrupt.ex
@@ -132,12 +132,12 @@ defmodule MingaEditor.Input.Interrupt do
   end
 
   @spec maybe_close_conflict(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
-  defp maybe_close_conflict(%{workspace: %{pending_conflict: nil}} = state, resets),
-    do: {state, resets}
-
   defp maybe_close_conflict(state, resets) do
-    {EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, nil)),
-     ["conflict prompt dismissed" | resets]}
+    if ModalOverlay.match(state.shell_state.modal, :conflict) do
+      {ModalOverlay.dismiss(state), ["conflict prompt dismissed" | resets]}
+    else
+      {state, resets}
+    end
   end
 
   @spec maybe_close_completion(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}

--- a/lib/minga_editor/input/prompt.ex
+++ b/lib/minga_editor/input/prompt.ex
@@ -18,7 +18,11 @@ defmodule MingaEditor.Input.Prompt do
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
   def handle_key(
-        %{shell_state: %{prompt_ui: %PromptState{handler: handler}}} = state,
+        %{
+          shell_state: %{
+            modal: {:prompt, %{prompt_ui: %PromptState{handler: handler}}}
+          }
+        } = state,
         codepoint,
         modifiers
       )

--- a/lib/minga_editor/prompt_ui.ex
+++ b/lib/minga_editor/prompt_ui.ex
@@ -7,7 +7,8 @@ defmodule MingaEditor.PromptUI do
   search queries). All functions are pure `state -> state` transformations.
 
   Prompts and pickers are mutually exclusive: opening a prompt closes any
-  active picker, and vice versa.
+  active picker. The replacement is handled automatically by
+  `MingaEditor.State.ModalOverlay.open/3`.
 
   ## Usage
 
@@ -21,6 +22,7 @@ defmodule MingaEditor.PromptUI do
 
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Prompt, as: PromptPayload
   alias MingaEditor.State.Prompt, as: PromptState
 
   @escape 27
@@ -41,9 +43,10 @@ defmodule MingaEditor.PromptUI do
   @doc """
   Opens a text input prompt with the given handler module.
 
-  Closes any active picker first. An optional `:default` value pre-fills
-  the input field. An optional `:context` map is stored for the handler
-  to read.
+  Replaces any active modal (the gate's replacement policy handles the
+  picker → prompt transition). An optional `:default` value pre-fills the
+  input field. An optional `:context` map is stored for the handler to
+  read.
 
   ## Options
 
@@ -56,15 +59,15 @@ defmodule MingaEditor.PromptUI do
     context = Keyword.get(opts, :context)
     label = handler_module.label()
 
-    state = maybe_close_picker(state)
-
-    EditorState.set_prompt_ui(state, %PromptState{
+    prompt_state = %PromptState{
       handler: handler_module,
       text: default_text,
       cursor: String.length(default_text),
       label: label,
       context: context
-    })
+    }
+
+    ModalOverlay.open(state, :prompt, PromptPayload.new(prompt_state))
   end
 
   @doc """
@@ -72,14 +75,14 @@ defmodule MingaEditor.PromptUI do
   """
   @spec close(state()) :: state()
   def close(state) do
-    EditorState.set_prompt_ui(state, %PromptState{})
+    ModalOverlay.dismiss(state)
   end
 
   @doc """
   Returns true if a prompt is currently open.
   """
   @spec open?(state()) :: boolean()
-  def open?(state), do: PromptState.open?(state.shell_state.prompt_ui)
+  def open?(state), do: ModalOverlay.match(state.shell_state.modal, :prompt)
 
   @doc """
   Handles a key event while the prompt is active.
@@ -89,7 +92,7 @@ defmodule MingaEditor.PromptUI do
   """
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: {state(), action()}
   def handle_key(state, key, _mods) do
-    prompt = state.shell_state.prompt_ui
+    {:prompt, %{prompt_ui: prompt}} = state.shell_state.modal
 
     case key do
       @escape ->
@@ -108,12 +111,12 @@ defmodule MingaEditor.PromptUI do
 
       @arrow_left ->
         new_cursor = max(0, prompt.cursor - 1)
-        {EditorState.set_prompt_ui(state, %{prompt | cursor: new_cursor}), nil}
+        {update_prompt(state, &%{&1 | cursor: new_cursor}), nil}
 
       @arrow_right ->
         max_pos = String.length(prompt.text)
         new_cursor = min(max_pos, prompt.cursor + 1)
-        {EditorState.set_prompt_ui(state, %{prompt | cursor: new_cursor}), nil}
+        {update_prompt(state, &%{&1 | cursor: new_cursor}), nil}
 
       _ ->
         {do_insert(state, prompt, key), nil}
@@ -128,7 +131,7 @@ defmodule MingaEditor.PromptUI do
   """
   @spec render_data(state()) :: {String.t(), String.t(), non_neg_integer()}
   def render_data(state) do
-    prompt = state.shell_state.prompt_ui
+    prompt = current_prompt(state)
     {prompt.label, prompt.text, prompt.cursor}
   end
 
@@ -141,9 +144,44 @@ defmodule MingaEditor.PromptUI do
   """
   @spec render(state(), MingaEditor.Viewport.t()) ::
           {[MingaEditor.DisplayList.draw()], {non_neg_integer(), non_neg_integer()} | nil}
-  def render(%{shell_state: %{prompt_ui: %PromptState{handler: nil}}}, _viewport), do: {[], nil}
+  def render(state, viewport) do
+    case state.shell_state.modal do
+      {:prompt, %{prompt_ui: %PromptState{handler: nil}}} ->
+        {[], nil}
 
-  def render(%{shell_state: %{prompt_ui: prompt}, theme: theme} = _state, viewport) do
+      {:prompt, %{prompt_ui: prompt}} ->
+        do_render(prompt, state.theme, viewport)
+
+      _ ->
+        {[], nil}
+    end
+  end
+
+  @doc """
+  Applies `fun` to the current PromptState inside the modal and writes
+  back via `ModalOverlay.transition`, keeping the modal sum type and
+  consistency check in sync.
+  """
+  @spec update_prompt(state(), (PromptState.t() -> PromptState.t())) :: state()
+  def update_prompt(state, fun) do
+    {:prompt, payload} = state.shell_state.modal
+    new_pui = fun.(payload.prompt_ui)
+    ModalOverlay.transition(state, :prompt, PromptPayload.put_prompt_ui(payload, new_pui))
+  end
+
+  # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec current_prompt(state()) :: PromptState.t()
+  defp current_prompt(state) do
+    case state.shell_state.modal do
+      {:prompt, %{prompt_ui: prompt}} -> prompt
+      _ -> %PromptState{}
+    end
+  end
+
+  @spec do_render(PromptState.t(), MingaEditor.UI.Theme.t(), MingaEditor.Viewport.t()) ::
+          {[MingaEditor.DisplayList.draw()], {non_neg_integer(), non_neg_integer()}}
+  defp do_render(prompt, theme, viewport) do
     alias MingaEditor.DisplayList
     alias Minga.Core.Face
 
@@ -156,7 +194,6 @@ defmodule MingaEditor.PromptUI do
     label_face = Face.new(fg: pc.prompt_fg, bg: pc.prompt_bg)
     input_face = Face.new(fg: pc.fg, bg: pc.bg)
 
-    # Pad to fill the row
     total_len = label_len + String.length(text)
     padding = String.duplicate(" ", max(0, viewport.cols - total_len))
 
@@ -170,17 +207,6 @@ defmodule MingaEditor.PromptUI do
     {draws, cursor_pos}
   end
 
-  # ── Private ────────────────────────────────────────────────────────────────
-
-  @spec maybe_close_picker(state()) :: state()
-  defp maybe_close_picker(state) do
-    if ModalOverlay.match(state.shell_state.modal, :picker) do
-      ModalOverlay.dismiss(state)
-    else
-      state
-    end
-  end
-
   @spec do_backspace(state(), PromptState.t()) :: state()
   defp do_backspace(state, %{cursor: 0} = _prompt), do: state
 
@@ -189,7 +215,7 @@ defmodule MingaEditor.PromptUI do
     {before, after_} = Enum.split(graphemes, prompt.cursor)
     new_text = Enum.join(Enum.drop(before, -1)) <> Enum.join(after_)
     new_cursor = prompt.cursor - 1
-    EditorState.set_prompt_ui(state, %{prompt | text: new_text, cursor: new_cursor})
+    update_prompt(state, &%{&1 | text: new_text, cursor: new_cursor})
   end
 
   @spec do_delete(state(), PromptState.t()) :: state()
@@ -206,7 +232,7 @@ defmodule MingaEditor.PromptUI do
   defp do_delete_grapheme(state, prompt, graphemes) do
     {before, [_deleted | after_]} = Enum.split(graphemes, prompt.cursor)
     new_text = Enum.join(before) <> Enum.join(after_)
-    EditorState.set_prompt_ui(state, %{prompt | text: new_text})
+    update_prompt(state, &%{&1 | text: new_text})
   end
 
   @spec do_insert(state(), PromptState.t(), non_neg_integer()) :: state()
@@ -217,7 +243,7 @@ defmodule MingaEditor.PromptUI do
     {before, after_} = Enum.split(graphemes, prompt.cursor)
     new_text = Enum.join(before) <> char <> Enum.join(after_)
     new_cursor = prompt.cursor + 1
-    EditorState.set_prompt_ui(state, %{prompt | text: new_text, cursor: new_cursor})
+    update_prompt(state, &%{&1 | text: new_text, cursor: new_cursor})
   end
 
   defp do_insert(state, _prompt, _key), do: state

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -201,12 +201,9 @@ defmodule MingaEditor.RenderPipeline.Input do
       input.shell_state |> Map.get(:signature_help),
       # Which-key popup
       input.shell_state |> Map.get(:whichkey),
-      # Modal overlay (sum type covering picker, completion, conflict,
-      # dashboard; prompt is still mirrored to :prompt_ui below until its
-      # migration lands)
+      # Modal overlay (sum type covering picker, prompt, dashboard,
+      # conflict, completion)
       input.shell_state |> Map.get(:modal),
-      # Prompt UI (legacy mirror; still read for invalidation parity)
-      input.shell_state |> Map.get(:prompt_ui),
       # Agent state (status, pending approval)
       input.shell_state |> Map.get(:agent),
       # Viewport dimensions (overlay positioning)

--- a/lib/minga_editor/renderer.ex
+++ b/lib/minga_editor/renderer.ex
@@ -63,9 +63,14 @@ defmodule MingaEditor.Renderer do
     cols = state.workspace.viewport.cols
     viewport = state.workspace.viewport
 
-    # Dashboard state is initialized by the editor when buffers empty,
-    # but fall back to an empty state if somehow nil.
-    dash_state = state.shell_state.dashboard || Dashboard.new_state()
+    # Dashboard state lives on the modal overlay when the dashboard is
+    # open. Fall back to a fresh state when no dashboard modal is active
+    # (the renderer still draws the splash whenever no buffer is open).
+    dash_state =
+      case state.shell_state.modal do
+        {:dashboard, %{state: dash}} -> dash
+        _ -> Dashboard.new_state()
+      end
 
     splash_draws = Dashboard.render(cols, rows, state.theme, dash_state)
 

--- a/lib/minga_editor/shell/board/state.ex
+++ b/lib/minga_editor/shell/board/state.ex
@@ -36,9 +36,7 @@ defmodule MingaEditor.Shell.Board.State do
           # transitioning between shells or when the render pipeline runs
           # before the Board-specific renderer takes over.
           whichkey: MingaEditor.State.WhichKey.t(),
-          prompt_ui: MingaEditor.State.Prompt.t(),
           status_msg: String.t() | nil,
-          dashboard: nil,
           nav_flash: nil,
           hover_popup: nil,
           tab_bar: nil,
@@ -64,9 +62,7 @@ defmodule MingaEditor.Shell.Board.State do
             next_id: 1,
             # Compatibility fields (see type doc above)
             whichkey: %MingaEditor.State.WhichKey{},
-            prompt_ui: %MingaEditor.State.Prompt{},
             status_msg: nil,
-            dashboard: nil,
             nav_flash: nil,
             hover_popup: nil,
             tab_bar: nil,

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -135,19 +135,38 @@ defmodule MingaEditor.Shell.Traditional do
   @impl true
   @spec on_buffer_added(ShellState.t(), WorkspaceState.t(), pid(), atom()) ::
           {ShellState.t(), WorkspaceState.t()}
-  def on_buffer_added(shell_state, workspace, buffer_pid, context \\ :open)
+  def on_buffer_added(shell_state, workspace, buffer_pid, context \\ :open) do
+    do_on_buffer_added(maybe_dismiss_dashboard(shell_state), workspace, buffer_pid, context)
+  end
 
-  def on_buffer_added(%ShellState{tab_bar: nil} = shell_state, workspace, _buffer_pid, _context) do
+  # Dismisses the dashboard modal when a buffer becomes active. The
+  # dashboard is the "no buffer" splash; once a buffer opens, the
+  # splash should disappear so it does not stick visually behind the
+  # buffer view. Other modal variants are left alone.
+  @spec maybe_dismiss_dashboard(ShellState.t()) :: ShellState.t()
+  defp maybe_dismiss_dashboard(%ShellState{modal: {:dashboard, _}} = shell_state),
+    do: ShellState.set_modal(shell_state, :none)
+
+  defp maybe_dismiss_dashboard(shell_state), do: shell_state
+
+  @spec do_on_buffer_added(ShellState.t(), WorkspaceState.t(), pid(), atom()) ::
+          {ShellState.t(), WorkspaceState.t()}
+  defp do_on_buffer_added(
+         %ShellState{tab_bar: nil} = shell_state,
+         workspace,
+         _buffer_pid,
+         _context
+       ) do
     workspace = WorkspaceState.sync_active_window_buffer(workspace)
     {shell_state, workspace}
   end
 
-  def on_buffer_added(
-        %ShellState{tab_bar: %TabBar{} = tb} = shell_state,
-        workspace,
-        buffer_pid,
-        context
-      ) do
+  defp do_on_buffer_added(
+         %ShellState{tab_bar: %TabBar{} = tb} = shell_state,
+         workspace,
+         buffer_pid,
+         context
+       ) do
     label = buffer_label(buffer_pid)
 
     Log.debug(:editor, fn ->

--- a/lib/minga_editor/shell/traditional/state.ex
+++ b/lib/minga_editor/shell/traditional/state.ex
@@ -13,12 +13,10 @@ defmodule MingaEditor.Shell.Traditional.State do
   """
 
   alias MingaEditor.BottomPanel
-  alias MingaEditor.Dashboard
   alias MingaEditor.HoverPopup
   alias MingaEditor.NavFlash
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.ModalOverlay
-  alias MingaEditor.State.Prompt
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.WhichKey
   alias Minga.Tool.Manager, as: ToolManager
@@ -26,9 +24,7 @@ defmodule MingaEditor.Shell.Traditional.State do
   @type t :: %__MODULE__{
           nav_flash: NavFlash.t() | nil,
           hover_popup: HoverPopup.t() | nil,
-          dashboard: Dashboard.state() | nil,
           status_msg: String.t() | nil,
-          prompt_ui: Prompt.t(),
           whichkey: WhichKey.t(),
           bottom_panel: BottomPanel.t(),
           git_status_panel: MingaEditor.Frontend.Protocol.GUI.git_status_data() | nil,
@@ -46,9 +42,7 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   defstruct nav_flash: nil,
             hover_popup: nil,
-            dashboard: nil,
             status_msg: nil,
-            prompt_ui: %Prompt{},
             whichkey: %WhichKey{},
             bottom_panel: %BottomPanel{},
             git_status_panel: nil,
@@ -115,36 +109,6 @@ defmodule MingaEditor.Shell.Traditional.State do
   @spec dismiss_hover_popup(t()) :: t()
   def dismiss_hover_popup(%{} = ss) do
     %{ss | hover_popup: nil}
-  end
-
-  # ── Dashboard ──────────────────────────────────────────────────────────────
-
-  @doc "Returns the dashboard home screen state, or nil."
-  @spec dashboard(t()) :: Dashboard.state() | nil
-  def dashboard(%{dashboard: dash}), do: dash
-
-  @doc "Sets the dashboard home screen state."
-  @spec set_dashboard(t(), Dashboard.state()) :: t()
-  def set_dashboard(%{} = ss, dash) when is_map(dash) do
-    %{ss | dashboard: dash}
-  end
-
-  @doc "Closes the dashboard home screen."
-  @spec close_dashboard(t()) :: t()
-  def close_dashboard(%{} = ss) do
-    %{ss | dashboard: nil}
-  end
-
-  # ── Prompt UI ──────────────────────────────────────────────────────────────
-
-  @doc "Returns the prompt UI state."
-  @spec prompt_ui(t()) :: Prompt.t()
-  def prompt_ui(%{prompt_ui: p}), do: p
-
-  @doc "Replaces the prompt UI state."
-  @spec set_prompt_ui(t(), Prompt.t()) :: t()
-  def set_prompt_ui(%{} = ss, prompt) do
-    %{ss | prompt_ui: prompt}
   end
 
   # ── Which-key ──────────────────────────────────────────────────────────────

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -409,9 +409,8 @@ defmodule MingaEditor.Startup do
     MingaEditor.Shell.Board.init(opts)
   end
 
-  defp init_shell_state(MingaEditor.Shell.Traditional, dashboard, opts) do
+  defp init_shell_state(MingaEditor.Shell.Traditional, _dashboard, opts) do
     %MingaEditor.Shell.Traditional.State{
-      dashboard: dashboard,
       suppress_tool_prompts: Keyword.get(opts, :suppress_tool_prompts, false)
     }
   end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -34,7 +34,6 @@ defmodule MingaEditor.State do
 
   alias MingaEditor.BottomPanel
   alias MingaEditor.CompletionTrigger
-  alias MingaEditor.Dashboard
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.LSP, as: LSPState
@@ -43,7 +42,6 @@ defmodule MingaEditor.State do
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Highlighting
   alias MingaEditor.State.Mouse
-  alias MingaEditor.State.Prompt
   alias MingaEditor.State.Registers
   alias MingaEditor.State.Search
   alias MingaEditor.State.Tab
@@ -227,18 +225,6 @@ defmodule MingaEditor.State do
   def set_hover_popup(s, popup), do: update_shell_state(s, &ShellState.set_hover_popup(&1, popup))
   @spec dismiss_hover_popup(t()) :: t()
   def dismiss_hover_popup(s), do: update_shell_state(s, &ShellState.dismiss_hover_popup/1)
-
-  @spec dashboard(t()) :: Dashboard.state() | nil
-  def dashboard(%{shell_state: ss}), do: ShellState.dashboard(ss)
-  @spec set_dashboard(t(), Dashboard.state()) :: t()
-  def set_dashboard(s, dash), do: update_shell_state(s, &ShellState.set_dashboard(&1, dash))
-  @spec close_dashboard(t()) :: t()
-  def close_dashboard(s), do: update_shell_state(s, &ShellState.close_dashboard/1)
-
-  @spec prompt_ui(t()) :: Prompt.t()
-  def prompt_ui(%{shell_state: ss}), do: ShellState.prompt_ui(ss)
-  @spec set_prompt_ui(t(), Prompt.t()) :: t()
-  def set_prompt_ui(s, prompt), do: update_shell_state(s, &ShellState.set_prompt_ui(&1, prompt))
 
   @spec whichkey(t()) :: WhichKey.t()
   def whichkey(%{shell_state: ss}), do: ShellState.whichkey(ss)
@@ -945,7 +931,6 @@ defmodule MingaEditor.State do
       completion_trigger: CompletionTrigger.new(),
       injection_ranges: %{},
       search: %Search{},
-      pending_conflict: nil,
       editing: VimState.new(),
       document_highlights: nil,
       agent_ui: UIState.new()
@@ -978,7 +963,6 @@ defmodule MingaEditor.State do
       completion_trigger: CompletionTrigger.new(),
       injection_ranges: %{},
       search: %Search{},
-      pending_conflict: nil,
       editing: VimState.new(),
       document_highlights: nil,
       agent_ui: UIState.new()
@@ -1053,7 +1037,6 @@ defmodule MingaEditor.State do
       completion_trigger: Map.get(ss, :completion_trigger, CompletionTrigger.new()),
       injection_ranges: Map.get(ss, :injection_ranges, %{}),
       search: Map.get(ss, :search, %Search{}),
-      pending_conflict: Map.get(ss, :pending_conflict),
       editing: vim
     }
   end

--- a/lib/minga_editor/state/modal_overlay.ex
+++ b/lib/minga_editor/state/modal_overlay.ex
@@ -2,12 +2,12 @@ defmodule MingaEditor.State.ModalOverlay do
   @moduledoc """
   Tagged-union representation of input-capturing modal overlays.
 
-  Today the picker, prompt, completion menu, conflict prompt, and
-  dashboard live as independent nullable fields on shell state and
-  workspace state. The type system permits 32 combinations even though
-  only six are meaningful, and `MingaEditor.Input.Interrupt` resets eight
-  independent axes by hand. See `docs/UI-STATE-ANALYSIS.md` for the full
-  analysis.
+  Before this work, the picker, prompt, completion menu, conflict prompt,
+  and dashboard each lived as an independent nullable field on shell
+  state or workspace state. The type system permitted 32 combinations
+  even though only six were meaningful, and `MingaEditor.Input.Interrupt`
+  reset eight independent axes by hand. See `docs/UI-STATE-ANALYSIS.md`
+  for the full analysis.
 
   This module replaces those fields with a single sum type:
 
@@ -20,23 +20,18 @@ defmodule MingaEditor.State.ModalOverlay do
 
   ## Migration phase: dual-write
 
-  This is step 2 of 5 (Epic #1421). The picker variant (#1424) has been
-  fully migrated — all reads and writes go through this gate, and
-  `picker_ui` has been removed from `Shell.Traditional.State`.
+  This is step 3 of 5 (Epic #1421). The picker, prompt, dashboard, and
+  conflict variants have been fully migrated — all reads and writes go
+  through this gate, and their legacy fields have been removed from
+  `Shell.Traditional.State` and `Workspace.State`.
 
-  The remaining variants still use dual-write: every gate function writes
-  both `state.shell_state.modal` and the variant's legacy field so that
-  existing readers continue to work during the migration:
+  The completion variant still uses dual-write: every gate function writes
+  both `state.shell_state.modal` and `workspace.completion` so existing
+  readers continue to work during the migration.
 
-  * `prompt_ui` — legacy mirror for the `:prompt` variant
-  * `dashboard` — legacy mirror for the `:dashboard` variant
-  * `workspace.completion` — legacy mirror for `:completion`
-  * `workspace.pending_conflict` — legacy mirror for `:conflict`
-
-  Migrations #1425-#1426 point reads at the new field one variant at a
-  time. When all variants have migrated, #1427 removes the remaining
-  dual-writes and adds a Credo rule that forbids direct writes to the
-  legacy fields.
+  Migration #1426 points completion reads at the new field. When all
+  variants have migrated, #1427 removes the remaining dual-write and
+  adds a Credo rule that forbids direct writes to the legacy field.
 
   **Do not mutate `:modal` directly**: always call this module's
   `open/3`, `transition/3`, `close/1`, or `dismiss/1`. A runtime
@@ -63,7 +58,6 @@ defmodule MingaEditor.State.ModalOverlay do
   alias MingaEditor.State.ModalOverlay.Dashboard, as: DashboardPayload
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.ModalOverlay.Prompt, as: PromptPayload
-  alias MingaEditor.State.Prompt, as: PromptLegacy
   alias MingaEditor.Workspace.State, as: WorkspaceState
 
   @type variant :: :picker | :prompt | :completion | :conflict | :dashboard
@@ -226,52 +220,28 @@ defmodule MingaEditor.State.ModalOverlay do
   end
 
   # Clears the legacy slot of whichever variant is currently tracked in
-  # `state.shell_state.modal`. No-op when the modal is `:none`.
+  # `state.shell_state.modal`. No-op when the modal is `:none` or when the
+  # tracked variant has no legacy mirror left.
   @spec clear_displaced_legacy(EditorState.t()) :: EditorState.t()
   defp clear_displaced_legacy(state) do
     case state.shell_state.modal do
-      :none ->
-        state
-
-      {:picker, _} ->
-        # Picker has no legacy field — it was removed in #1424.
-        state
-
-      {:prompt, _} ->
-        EditorState.set_prompt_ui(state, %PromptLegacy{})
-
-      {:dashboard, _} ->
-        EditorState.close_dashboard(state)
-
       {:completion, _} ->
         EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, nil))
 
-      {:conflict, _} ->
-        EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, nil))
+      _ ->
+        state
     end
   end
 
   # Writes the payload's underlying state to the variant's legacy slot.
-  # The picker variant has no legacy field (#1424 removed it).
+  # Only completion still has a legacy mirror; the other variants are
+  # tracked exclusively on `shell_state.modal`.
   @spec mirror_to_legacy(EditorState.t(), {variant(), payload()}) :: EditorState.t()
-  defp mirror_to_legacy(state, {:picker, %PickerPayload{}}), do: state
-
-  defp mirror_to_legacy(state, {:prompt, %PromptPayload{prompt_ui: pui}}) do
-    EditorState.set_prompt_ui(state, pui)
-  end
-
-  defp mirror_to_legacy(state, {:dashboard, %DashboardPayload{state: dash}}) do
-    EditorState.set_dashboard(state, dash)
-  end
-
   defp mirror_to_legacy(state, {:completion, %CompletionPayload{completion: comp}}) do
     EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, comp))
   end
 
-  defp mirror_to_legacy(state, {:conflict, %ConflictPayload{} = conflict}) do
-    legacy = ConflictPayload.to_legacy(conflict)
-    EditorState.update_workspace(state, &WorkspaceState.set_pending_conflict(&1, legacy))
-  end
+  defp mirror_to_legacy(state, _other), do: state
 
   @spec put_modal(EditorState.t(), t()) :: EditorState.t()
   defp put_modal(state, modal) do
@@ -298,45 +268,26 @@ defmodule MingaEditor.State.ModalOverlay do
 
     @spec check_consistency!(EditorState.t()) :: :ok
     defp check_consistency!(%EditorState{} = state) do
-      ss = state.shell_state
       ws = state.workspace
 
-      case ss.modal do
+      case state.shell_state.modal do
         :none ->
           :ok
 
-        # Picker has no legacy field (#1424 removed it): no consistency check needed.
-        {:picker, %PickerPayload{}} ->
+        # Picker (#1424), prompt/dashboard/conflict (#1425): tracked
+        # exclusively on shell_state.modal — no legacy mirror to compare.
+        {tag, _} when tag in [:picker, :prompt, :dashboard, :conflict] ->
           :ok
 
-        {:prompt, %PromptPayload{prompt_ui: pu}} ->
-          if ss.prompt_ui != pu, do: raise_divergence!(:prompt, pu, ss.prompt_ui)
-          :ok
-
-        {:dashboard, %DashboardPayload{state: dash}} ->
-          if ss.dashboard != dash, do: raise_divergence!(:dashboard, dash, ss.dashboard)
-          :ok
-
-        # NOTE for #1424+: the completion and conflict payloads live on
-        # shell_state.modal, but their legacy mirrors live on `workspace`,
+        # NOTE for #1426: completion's legacy mirror lives on `workspace`,
         # which is snapshotted per tab while shell_state is not. Once a
-        # caller actually opens one of these variants, switching tabs will
-        # swap workspace.completion / workspace.pending_conflict out from
-        # under the gate and trip this assertion on the next call. Resolve
-        # by either (a) clearing :modal on tab-switch via a hook, or
-        # (b) moving these variants' authoritative state onto workspace.
-        # This step intentionally does not pick — flagged in the next
-        # ticket's developer notes.
+        # caller actually opens this variant, switching tabs swaps
+        # workspace.completion out from under the gate and trips this
+        # assertion on the next call. Resolve by either (a) clearing
+        # :modal on tab-switch via a hook, or (b) moving completion's
+        # authoritative state onto workspace.
         {:completion, %CompletionPayload{completion: comp}} ->
           if ws.completion != comp, do: raise_divergence!(:completion, comp, ws.completion)
-          :ok
-
-        {:conflict, %ConflictPayload{} = conflict} ->
-          expected = ConflictPayload.to_legacy(conflict)
-
-          if ws.pending_conflict != expected,
-            do: raise_divergence!(:conflict, expected, ws.pending_conflict)
-
           :ok
       end
     end

--- a/lib/minga_editor/state/modal_overlay/conflict.ex
+++ b/lib/minga_editor/state/modal_overlay/conflict.ex
@@ -7,9 +7,9 @@ defmodule MingaEditor.State.ModalOverlay.Conflict do
   modal can be auto-dismissed when its buffer dies or the user switches
   away.
 
-  The legacy representation is `state.workspace.pending_conflict =
-  {buffer_pid, prompt_text}`. This struct mirrors that pair while making the
-  metadata explicit.
+  Before #1425 the conflict prompt lived as `state.workspace.pending_conflict
+  = {buffer_pid, prompt_text}`. This payload preserves that pair while
+  making the metadata explicit.
   """
 
   @type owner :: pid()

--- a/lib/minga_editor/state/modal_overlay/dashboard.ex
+++ b/lib/minga_editor/state/modal_overlay/dashboard.ex
@@ -35,4 +35,14 @@ defmodule MingaEditor.State.ModalOverlay.Dashboard do
       opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
     }
   end
+
+  @doc """
+  Replaces the inner dashboard state on the payload, preserving `owner` and
+  `opened_at`. The only sanctioned way to update the inner state from
+  outside this module (Rule 2: state ownership).
+  """
+  @spec put_state(t(), Dashboard.state()) :: t()
+  def put_state(%__MODULE__{} = payload, state) when is_map(state) do
+    %{payload | state: state}
+  end
 end

--- a/lib/minga_editor/state/modal_overlay/prompt.ex
+++ b/lib/minga_editor/state/modal_overlay/prompt.ex
@@ -32,4 +32,14 @@ defmodule MingaEditor.State.ModalOverlay.Prompt do
       opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
     }
   end
+
+  @doc """
+  Replaces the inner `prompt_ui` state on the payload, preserving `owner`
+  and `opened_at`. The only sanctioned way to update the inner state from
+  outside this module (Rule 2: state ownership).
+  """
+  @spec put_prompt_ui(t(), PromptState.t()) :: t()
+  def put_prompt_ui(%__MODULE__{} = payload, %PromptState{} = prompt_ui) do
+    %{payload | prompt_ui: prompt_ui}
+  end
 end

--- a/lib/minga_editor/state/tab.ex
+++ b/lib/minga_editor/state/tab.ex
@@ -44,7 +44,6 @@ defmodule MingaEditor.State.Tab do
           optional(:completion_trigger) => term(),
           optional(:injection_ranges) => term(),
           optional(:search) => term(),
-          optional(:pending_conflict) => term(),
           optional(:editing) => MingaEditor.VimState.t(),
           # Legacy: old contexts may have :vim instead of :editing
           optional(:vim) => MingaEditor.VimState.t(),

--- a/lib/minga_editor/workspace/state.ex
+++ b/lib/minga_editor/workspace/state.ex
@@ -41,7 +41,6 @@ defmodule MingaEditor.Workspace.State do
           completion_trigger: CompletionTrigger.t(),
           injection_ranges: %{pid() => [Minga.Language.Highlight.InjectionRange.t()]},
           search: Search.t(),
-          pending_conflict: {pid(), String.t()} | nil,
           editing: VimState.t(),
           document_highlights: [document_highlight()] | nil,
           agent_ui: UIState.t()
@@ -60,7 +59,6 @@ defmodule MingaEditor.Workspace.State do
             completion_trigger: CompletionTrigger.new(),
             injection_ranges: %{},
             search: %Search{},
-            pending_conflict: nil,
             editing: VimState.new(),
             document_highlights: nil,
             agent_ui: UIState.new()
@@ -251,12 +249,6 @@ defmodule MingaEditor.Workspace.State do
   @spec update_search(t(), (Search.t() -> Search.t())) :: t()
   def update_search(%__MODULE__{search: s} = wspace, fun) when is_function(fun, 1) do
     %{wspace | search: fun.(s)}
-  end
-
-  @doc "Sets the pending conflict state."
-  @spec set_pending_conflict(t(), {pid(), String.t()} | nil) :: t()
-  def set_pending_conflict(%__MODULE__{} = wspace, conflict) do
-    %{wspace | pending_conflict: conflict}
   end
 
   @doc "Updates the LSP pending requests map."

--- a/test/minga_editor/dashboard_test.exs
+++ b/test/minga_editor/dashboard_test.exs
@@ -185,7 +185,6 @@ defmodule MingaEditor.DashboardTest do
         },
         focus_stack: MingaEditor.Input.default_stack(),
         shell_state: %MingaEditor.Shell.Traditional.State{
-          dashboard: Dashboard.new_state(),
           modal:
             {:picker,
              PickerPayload.new(%PickerState{

--- a/test/minga_editor/file_change_test.exs
+++ b/test/minga_editor/file_change_test.exs
@@ -48,7 +48,7 @@ defmodule MingaEditor.FileChangeTest do
     _ = :sys.get_state(ctx.editor)
 
     state = :sys.get_state(ctx.editor)
-    assert state.workspace.pending_conflict != nil
+    assert MingaEditor.State.ModalOverlay.match(state.shell_state.modal, :conflict)
     assert state.shell_state.status_msg =~ "[r]eload"
     assert state.shell_state.status_msg =~ "[k]eep"
   end
@@ -78,7 +78,7 @@ defmodule MingaEditor.FileChangeTest do
 
     state = :sys.get_state(ctx.editor)
     assert state.shell_state.status_msg =~ "reloaded"
-    assert state.workspace.pending_conflict == nil
+    refute MingaEditor.State.ModalOverlay.match(state.shell_state.modal, :conflict)
   end
 
   @tag :tmp_dir
@@ -105,7 +105,7 @@ defmodule MingaEditor.FileChangeTest do
     assert String.contains?(content, "local")
 
     state = :sys.get_state(ctx.editor)
-    assert state.workspace.pending_conflict == nil
+    refute MingaEditor.State.ModalOverlay.match(state.shell_state.modal, :conflict)
   end
 
   @tag :tmp_dir
@@ -126,7 +126,7 @@ defmodule MingaEditor.FileChangeTest do
     _ = :sys.get_state(ctx.editor)
 
     state = :sys.get_state(ctx.editor)
-    assert state.workspace.pending_conflict != nil
+    assert MingaEditor.State.ModalOverlay.match(state.shell_state.modal, :conflict)
   end
 
   @tag :tmp_dir
@@ -139,7 +139,7 @@ defmodule MingaEditor.FileChangeTest do
     # Send notification for a different file
     send(ctx.editor, {:file_changed_on_disk, "/tmp/nonexistent.txt"})
     state = :sys.get_state(ctx.editor)
-    assert state.workspace.pending_conflict == nil
+    refute MingaEditor.State.ModalOverlay.match(state.shell_state.modal, :conflict)
     assert state.shell_state.status_msg == nil
   end
 

--- a/test/minga_editor/input/dashboard_test.exs
+++ b/test/minga_editor/input/dashboard_test.exs
@@ -2,23 +2,31 @@ defmodule MingaEditor.Input.DashboardTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.Dashboard
+  alias MingaEditor.Input.Dashboard, as: DashInput
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Dashboard, as: DashboardPayload
   alias MingaEditor.Viewport
-  alias MingaEditor.Input.Dashboard, as: DashInput
 
   defp state_with_dashboard do
-    dash = Dashboard.new_state()
-
-    %EditorState{
+    base = %EditorState{
       port_manager: self(),
       workspace: %MingaEditor.Workspace.State{
         viewport: Viewport.new(24, 80),
         buffers: %Buffers{active: nil}
       },
-      focus_stack: MingaEditor.Input.default_stack(),
-      shell_state: %MingaEditor.Shell.Traditional.State{dashboard: dash}
+      focus_stack: MingaEditor.Input.default_stack()
     }
+
+    ModalOverlay.open(base, :dashboard, DashboardPayload.new(Dashboard.new_state()))
+  end
+
+  defp dashboard_payload(state) do
+    case state.shell_state.modal do
+      {:dashboard, payload} -> payload
+      _ -> nil
+    end
   end
 
   # Kitty keyboard protocol arrow key codepoints
@@ -28,48 +36,48 @@ defmodule MingaEditor.Input.DashboardTest do
   describe "handle_key/3 when dashboard is active" do
     test "j moves cursor down" do
       state = state_with_dashboard()
-      assert state.shell_state.dashboard.cursor == 0
+      assert dashboard_payload(state).state.cursor == 0
 
       {:handled, new_state} = DashInput.handle_key(state, ?j, 0)
-      assert new_state.shell_state.dashboard.cursor == 1
+      assert dashboard_payload(new_state).state.cursor == 1
     end
 
     test "k moves cursor up (wraps)" do
       state = state_with_dashboard()
-      assert state.shell_state.dashboard.cursor == 0
+      assert dashboard_payload(state).state.cursor == 0
 
       {:handled, new_state} = DashInput.handle_key(state, ?k, 0)
+      payload = dashboard_payload(state)
 
-      assert new_state.shell_state.dashboard.cursor ==
-               length(state.shell_state.dashboard.items) - 1
+      assert dashboard_payload(new_state).state.cursor == length(payload.state.items) - 1
     end
 
     test "arrow down moves cursor down" do
       state = state_with_dashboard()
-      assert state.shell_state.dashboard.cursor == 0
+      assert dashboard_payload(state).state.cursor == 0
 
       {:handled, new_state} = DashInput.handle_key(state, @arrow_down, 0)
-      assert new_state.shell_state.dashboard.cursor == 1
+      assert dashboard_payload(new_state).state.cursor == 1
     end
 
     test "arrow up moves cursor up (wraps)" do
       state = state_with_dashboard()
-      assert state.shell_state.dashboard.cursor == 0
+      assert dashboard_payload(state).state.cursor == 0
 
       {:handled, new_state} = DashInput.handle_key(state, @arrow_up, 0)
+      payload = dashboard_payload(state)
 
-      assert new_state.shell_state.dashboard.cursor ==
-               length(state.shell_state.dashboard.items) - 1
+      assert dashboard_payload(new_state).state.cursor == length(payload.state.items) - 1
     end
 
     test "space selects the current item and clears dashboard" do
       state = state_with_dashboard()
       # First item is :find_file which opens a picker; the picker open
-      # call will fail in this test context but the dashboard should
+      # call may fail in this test context but the dashboard should
       # still be cleared. Catch the error and verify the intent.
       result = DashInput.handle_key(state, 32, 0)
       assert {:handled, new_state} = result
-      assert new_state.shell_state.dashboard == nil
+      refute ModalOverlay.match(new_state.shell_state.modal, :dashboard)
     end
 
     test "other keys pass through" do
@@ -79,7 +87,7 @@ defmodule MingaEditor.Input.DashboardTest do
   end
 
   describe "handle_key/3 when no dashboard" do
-    test "passes through when buffers.active is set" do
+    test "passes through when buffers.active is set and modal is :none" do
       alias Minga.Buffer.Server, as: BufferServer
       {:ok, buf} = BufferServer.start_link(content: "hello")
 
@@ -95,15 +103,14 @@ defmodule MingaEditor.Input.DashboardTest do
       {:passthrough, _} = DashInput.handle_key(state, ?j, 0)
     end
 
-    test "passes through when dashboard state is nil" do
+    test "passes through when modal is :none" do
       state = %EditorState{
         port_manager: self(),
         workspace: %MingaEditor.Workspace.State{
           viewport: Viewport.new(24, 80),
           buffers: %Buffers{active: nil}
         },
-        focus_stack: MingaEditor.Input.default_stack(),
-        shell_state: %MingaEditor.Shell.Traditional.State{dashboard: nil}
+        focus_stack: MingaEditor.Input.default_stack()
       }
 
       {:passthrough, _} = DashInput.handle_key(state, ?j, 0)

--- a/test/minga_editor/input/handler_test.exs
+++ b/test/minga_editor/input/handler_test.exs
@@ -6,6 +6,8 @@ defmodule MingaEditor.Input.HandlerTest do
   alias Minga.Buffer.Server, as: BufferServer
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
   alias MingaEditor.Frontend.Protocol
@@ -44,10 +46,10 @@ defmodule MingaEditor.Input.HandlerTest do
     test "handles 'r' key during conflict by reloading" do
       state = base_state()
       buf = state.workspace.buffers.active
-      state = %{state | workspace: %{state.workspace | pending_conflict: {buf, "/tmp/test.txt"}}}
+      state = ModalOverlay.open(state, :conflict, ConflictPayload.new(buf, "/tmp/test.txt"))
 
       assert {:handled, new_state} = ConflictPrompt.handle_key(state, ?r, 0)
-      assert new_state.workspace.pending_conflict == nil
+      refute ModalOverlay.match(new_state.shell_state.modal, :conflict)
       assert new_state.shell_state.status_msg =~ "reloaded"
     end
 
@@ -56,20 +58,20 @@ defmodule MingaEditor.Input.HandlerTest do
       File.write!(path, "hello\nworld")
       state = base_state(buffer_opts: [file_path: path])
       buf = state.workspace.buffers.active
-      state = %{state | workspace: %{state.workspace | pending_conflict: {buf, path}}}
+      state = ModalOverlay.open(state, :conflict, ConflictPayload.new(buf, path))
 
       assert {:handled, new_state} = ConflictPrompt.handle_key(state, ?k, 0)
-      assert new_state.workspace.pending_conflict == nil
+      refute ModalOverlay.match(new_state.shell_state.modal, :conflict)
     end
 
     test "swallows unrecognized keys during conflict" do
       state = base_state()
       buf = state.workspace.buffers.active
-      state = %{state | workspace: %{state.workspace | pending_conflict: {buf, "/tmp/test.txt"}}}
+      state = ModalOverlay.open(state, :conflict, ConflictPayload.new(buf, "/tmp/test.txt"))
 
       assert {:handled, new_state} = ConflictPrompt.handle_key(state, ?x, 0)
       # State unchanged except for swallowing the key
-      assert new_state.workspace.pending_conflict == {buf, "/tmp/test.txt"}
+      assert new_state.shell_state.modal == state.shell_state.modal
     end
   end
 

--- a/test/minga_editor/input/interrupt_test.exs
+++ b/test/minga_editor/input/interrupt_test.exs
@@ -6,6 +6,7 @@ defmodule MingaEditor.Input.InterruptTest do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.Picker
   alias MingaEditor.State.WhichKey
@@ -172,10 +173,10 @@ defmodule MingaEditor.Input.InterruptTest do
     test "dismisses conflict prompt" do
       state = base_state()
       buf = state.workspace.buffers.active
-      state = %{state | workspace: %{state.workspace | pending_conflict: {buf, "/tmp/test.txt"}}}
+      state = ModalOverlay.open(state, :conflict, ConflictPayload.new(buf, "/tmp/test.txt"))
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
-      assert new_state.workspace.pending_conflict == nil
+      refute ModalOverlay.match(new_state.shell_state.modal, :conflict)
     end
 
     test "closes completion menu" do
@@ -198,7 +199,6 @@ defmodule MingaEditor.Input.InterruptTest do
   describe "combined resets" do
     test "resets everything at once" do
       state = base_state()
-      buf = state.workspace.buffers.active
       picker = MingaEditor.UI.Picker.new(["x"])
       completion = %Completion{items: [], trigger_position: {0, 0}}
 
@@ -210,11 +210,14 @@ defmodule MingaEditor.Input.InterruptTest do
             state.workspace
             | keymap_scope: :agent,
               editing: vim,
-              pending_conflict: {buf, "/tmp/x"},
               completion: completion
           }
       }
 
+      # Only one modal can be active at a time under the ModalOverlay sum
+      # type, so this combined-reset case exercises picker plus the
+      # non-modal axes (scope/mode/whichkey/completion/status). The
+      # conflict-reset path has its own focused test above.
       state = ModalOverlay.open(state, :picker, PickerPayload.new(%Picker{picker: picker}))
       state = MingaEditor.State.set_whichkey(state, %WhichKey{node: %{}, show: true})
       state = MingaEditor.State.set_status(state, "hello")
@@ -225,7 +228,6 @@ defmodule MingaEditor.Input.InterruptTest do
       assert new_state.shell_state.modal == :none
       assert new_state.shell_state.whichkey.node == nil
       assert new_state.shell_state.whichkey.show == false
-      assert new_state.workspace.pending_conflict == nil
       assert new_state.workspace.completion == nil
       assert new_state.shell_state.status_msg == nil
     end

--- a/test/minga_editor/input/prompt_test.exs
+++ b/test/minga_editor/input/prompt_test.exs
@@ -1,8 +1,10 @@
 defmodule MingaEditor.Input.PromptTest do
   use ExUnit.Case, async: true
 
-  alias MingaEditor.State.Prompt, as: PromptState
   alias MingaEditor.Input.Prompt, as: InputPrompt
+  alias MingaEditor.PromptUI
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
 
   defmodule TestHandler do
     @behaviour MingaEditor.UI.Prompt.Handler
@@ -11,40 +13,43 @@ defmodule MingaEditor.Input.PromptTest do
     def label, do: "Input: "
 
     @impl true
-    def on_submit(text, state), do: put_in(state[:submitted], text)
+    def on_submit(text, state) do
+      Process.put(:submitted, text)
+      state
+    end
 
     @impl true
-    def on_cancel(state), do: put_in(state[:cancelled], true)
+    def on_cancel(state) do
+      Process.put(:cancelled, true)
+      state
+    end
   end
 
-  defp make_state(prompt_overrides \\ %{}) do
-    prompt = struct(%PromptState{}, prompt_overrides)
-
-    %{
-      shell_state: %MingaEditor.Shell.Traditional.State{
-        prompt_ui: prompt
-      },
-      submitted: nil,
-      cancelled: nil
+  defp base_state do
+    %EditorState{
+      port_manager: nil,
+      workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)}
     }
   end
 
   describe "handle_key/3" do
     test "routes keys to PromptUI when prompt is active" do
-      state = make_state(%{handler: TestHandler, label: "Input: ", text: "", cursor: 0})
+      state = PromptUI.open(base_state(), TestHandler)
       assert {:handled, new_state} = InputPrompt.handle_key(state, ?a, 0)
-      assert new_state.shell_state.prompt_ui.text == "a"
+
+      {:prompt, %{prompt_ui: pui}} = new_state.shell_state.modal
+      assert pui.text == "a"
     end
 
     test "passes through when no prompt is active" do
-      state = make_state()
+      state = base_state()
       assert {:passthrough, ^state} = InputPrompt.handle_key(state, ?a, 0)
     end
   end
 
   describe "handle_mouse/7" do
     test "always passes through" do
-      state = make_state(%{handler: TestHandler, label: "Input: ", text: "hello", cursor: 5})
+      state = PromptUI.open(base_state(), TestHandler, default: "hello")
       assert {:passthrough, ^state} = InputPrompt.handle_mouse(state, 10, 5, :left, 0, :press, 1)
     end
   end

--- a/test/minga_editor/input/router_test.exs
+++ b/test/minga_editor/input/router_test.exs
@@ -46,9 +46,12 @@ defmodule MingaEditor.Input.RouterTest do
     end
 
     test "conflict prompt takes priority over mode FSM" do
+      alias MingaEditor.State.ModalOverlay
+      alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
+
       state = base_state()
       buf = state.workspace.buffers.active
-      state = %{state | workspace: %{state.workspace | pending_conflict: {buf, "/tmp/test.txt"}}}
+      state = ModalOverlay.open(state, :conflict, ConflictPayload.new(buf, "/tmp/test.txt"))
 
       # 'j' is swallowed by conflict prompt, not forwarded to mode
       new_state = Router.dispatch(state, ?j, 0)

--- a/test/minga_editor/prompt_ui_test.exs
+++ b/test/minga_editor/prompt_ui_test.exs
@@ -2,9 +2,14 @@ defmodule MingaEditor.PromptUITest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.PromptUI
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.Prompt, as: PromptState
+  alias MingaEditor.Viewport
 
-  # Test handler that records what happened
+  # Test handlers record their callbacks via the test process dictionary.
+  # The state passed in/out is the editor state; the side channel keeps
+  # the assertions simple while letting the modal flow stay realistic.
   defmodule TestHandler do
     @behaviour MingaEditor.UI.Prompt.Handler
 
@@ -13,12 +18,14 @@ defmodule MingaEditor.PromptUITest do
 
     @impl true
     def on_submit(text, state) do
-      put_in(state[:submitted], text)
+      Process.put(:submitted, text)
+      state
     end
 
     @impl true
     def on_cancel(state) do
-      put_in(state[:cancelled], true)
+      Process.put(:cancelled, true)
+      state
     end
   end
 
@@ -30,7 +37,8 @@ defmodule MingaEditor.PromptUITest do
 
     @impl true
     def on_submit(text, state) do
-      put_in(state[:new_name], text)
+      Process.put(:new_name, text)
+      state
     end
 
     @impl true
@@ -42,55 +50,51 @@ defmodule MingaEditor.PromptUITest do
   @backspace 127
   @delete 57_348
 
-  defp make_state(overrides \\ %{}) do
-    shell_overrides = Map.take(overrides, [:prompt_ui])
-    other_overrides = Map.drop(overrides, [:prompt_ui])
-
-    shell = %MingaEditor.Shell.Traditional.State{
-      prompt_ui: Map.get(shell_overrides, :prompt_ui, %PromptState{})
+  defp base_state do
+    %EditorState{
+      port_manager: nil,
+      workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)}
     }
+  end
 
-    base = %{
-      shell_state: shell,
-      submitted: nil,
-      cancelled: nil,
-      new_name: nil
-    }
+  defp prompt_state(state) do
+    case state.shell_state.modal do
+      {:prompt, %{prompt_ui: pui}} -> pui
+      _ -> %PromptState{}
+    end
+  end
 
-    Map.merge(base, other_overrides)
+  defp set_cursor(state, cursor) do
+    pui = %{prompt_state(state) | cursor: cursor}
+    PromptUI.update_prompt(state, fn _ -> pui end)
   end
 
   describe "open/3" do
     test "sets handler, label, and empty text" do
-      state = make_state()
-      state = PromptUI.open(state, TestHandler)
+      state = base_state() |> PromptUI.open(TestHandler)
+      pui = prompt_state(state)
 
-      assert state.shell_state.prompt_ui.handler == TestHandler
-      assert state.shell_state.prompt_ui.label == "Test prompt: "
-      assert state.shell_state.prompt_ui.text == ""
-      assert state.shell_state.prompt_ui.cursor == 0
+      assert pui.handler == TestHandler
+      assert pui.label == "Test prompt: "
+      assert pui.text == ""
+      assert pui.cursor == 0
     end
 
     test "sets default text when provided" do
-      state = make_state()
-      state = PromptUI.open(state, RenameHandler, default: "old_name")
+      state = base_state() |> PromptUI.open(RenameHandler, default: "old_name")
+      pui = prompt_state(state)
 
-      assert state.shell_state.prompt_ui.text == "old_name"
-      assert state.shell_state.prompt_ui.cursor == 8
+      assert pui.text == "old_name"
+      assert pui.cursor == 8
     end
 
     test "stores context when provided" do
-      state = make_state()
-      state = PromptUI.open(state, TestHandler, context: %{template: "todo"})
-
-      assert state.shell_state.prompt_ui.context == %{template: "todo"}
+      state = base_state() |> PromptUI.open(TestHandler, context: %{template: "todo"})
+      assert prompt_state(state).context == %{template: "todo"}
     end
 
-    test "closes active picker when opening prompt" do
-      alias MingaEditor.State, as: EditorState
-      alias MingaEditor.State.ModalOverlay
+    test "replaces an active picker via the gate's replacement policy" do
       alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
-      alias MingaEditor.Viewport
 
       picker_struct = %MingaEditor.State.Picker{
         picker: %MingaEditor.UI.Picker{
@@ -103,142 +107,150 @@ defmodule MingaEditor.PromptUITest do
         source: SomeSource
       }
 
-      state = %EditorState{
-        port_manager: nil,
-        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)}
-      }
+      state =
+        base_state()
+        |> ModalOverlay.open(:picker, PickerPayload.new(picker_struct))
+        |> PromptUI.open(TestHandler)
 
-      state = ModalOverlay.open(state, :picker, PickerPayload.new(picker_struct))
-      state = PromptUI.open(state, TestHandler)
-
-      assert state.shell_state.prompt_ui.handler == TestHandler
+      assert prompt_state(state).handler == TestHandler
       refute ModalOverlay.match(state.shell_state.modal, :picker)
     end
   end
 
   describe "open?/1" do
     test "returns false when no prompt is active" do
-      state = make_state()
-      refute PromptUI.open?(state)
+      refute PromptUI.open?(base_state())
     end
 
     test "returns true when prompt is active" do
-      state = make_state() |> PromptUI.open(TestHandler)
-      assert PromptUI.open?(state)
+      assert base_state() |> PromptUI.open(TestHandler) |> PromptUI.open?()
     end
   end
 
   describe "handle_key/3 — text insertion" do
     test "inserts a character" do
-      state = make_state() |> PromptUI.open(TestHandler)
+      state = base_state() |> PromptUI.open(TestHandler)
       {state, nil} = PromptUI.handle_key(state, ?h, 0)
       {state, nil} = PromptUI.handle_key(state, ?i, 0)
 
-      assert state.shell_state.prompt_ui.text == "hi"
-      assert state.shell_state.prompt_ui.cursor == 2
+      pui = prompt_state(state)
+      assert pui.text == "hi"
+      assert pui.cursor == 2
     end
 
     test "inserts at cursor position" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "ac")
+      state = base_state() |> PromptUI.open(TestHandler, default: "ac")
       # Move cursor left once (between a and c)
       {state, nil} = PromptUI.handle_key(state, 57_350, 0)
       # Insert 'b' at position 1
       {state, nil} = PromptUI.handle_key(state, ?b, 0)
 
-      assert state.shell_state.prompt_ui.text == "abc"
-      assert state.shell_state.prompt_ui.cursor == 2
+      pui = prompt_state(state)
+      assert pui.text == "abc"
+      assert pui.cursor == 2
     end
 
     test "handles unicode characters" do
-      state = make_state() |> PromptUI.open(TestHandler)
+      state = base_state() |> PromptUI.open(TestHandler)
       {state, nil} = PromptUI.handle_key(state, 0x1F600, 0)
 
-      assert state.shell_state.prompt_ui.text == "😀"
-      assert state.shell_state.prompt_ui.cursor == 1
+      pui = prompt_state(state)
+      assert pui.text == "😀"
+      assert pui.cursor == 1
     end
   end
 
   describe "handle_key/3 — backspace" do
     test "deletes character before cursor" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "abc")
+      state = base_state() |> PromptUI.open(TestHandler, default: "abc")
       {state, nil} = PromptUI.handle_key(state, @backspace, 0)
 
-      assert state.shell_state.prompt_ui.text == "ab"
-      assert state.shell_state.prompt_ui.cursor == 2
+      pui = prompt_state(state)
+      assert pui.text == "ab"
+      assert pui.cursor == 2
     end
 
     test "does nothing at start of text" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "abc")
-      # Move to start
-      state = MingaEditor.State.set_prompt_ui(state, %{state.shell_state.prompt_ui | cursor: 0})
+      state =
+        base_state()
+        |> PromptUI.open(TestHandler, default: "abc")
+        |> set_cursor(0)
+
       {state, nil} = PromptUI.handle_key(state, @backspace, 0)
 
-      assert state.shell_state.prompt_ui.text == "abc"
-      assert state.shell_state.prompt_ui.cursor == 0
+      pui = prompt_state(state)
+      assert pui.text == "abc"
+      assert pui.cursor == 0
     end
   end
 
   describe "handle_key/3 — cursor movement" do
     test "arrow left moves cursor left" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "abc")
-      assert state.shell_state.prompt_ui.cursor == 3
+      state = base_state() |> PromptUI.open(TestHandler, default: "abc")
+      assert prompt_state(state).cursor == 3
 
       {state, nil} = PromptUI.handle_key(state, 57_350, 0)
-      assert state.shell_state.prompt_ui.cursor == 2
+      assert prompt_state(state).cursor == 2
     end
 
     test "arrow left stops at 0" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "a")
-      state = MingaEditor.State.set_prompt_ui(state, %{state.shell_state.prompt_ui | cursor: 0})
+      state =
+        base_state()
+        |> PromptUI.open(TestHandler, default: "a")
+        |> set_cursor(0)
+
       {state, nil} = PromptUI.handle_key(state, 57_350, 0)
-      assert state.shell_state.prompt_ui.cursor == 0
+      assert prompt_state(state).cursor == 0
     end
 
     test "arrow right moves cursor right" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "abc")
-      state = MingaEditor.State.set_prompt_ui(state, %{state.shell_state.prompt_ui | cursor: 1})
+      state =
+        base_state()
+        |> PromptUI.open(TestHandler, default: "abc")
+        |> set_cursor(1)
+
       {state, nil} = PromptUI.handle_key(state, 57_351, 0)
-      assert state.shell_state.prompt_ui.cursor == 2
+      assert prompt_state(state).cursor == 2
     end
 
     test "arrow right stops at end of text" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "abc")
+      state = base_state() |> PromptUI.open(TestHandler, default: "abc")
       {state, nil} = PromptUI.handle_key(state, 57_351, 0)
-      assert state.shell_state.prompt_ui.cursor == 3
+      assert prompt_state(state).cursor == 3
     end
   end
 
   describe "handle_key/3 — submit" do
     test "Enter calls on_submit with the text and closes prompt" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "hello world")
+      state = base_state() |> PromptUI.open(TestHandler, default: "hello world")
       {state, nil} = PromptUI.handle_key(state, @enter, 0)
 
-      assert state.submitted == "hello world"
+      assert Process.get(:submitted) == "hello world"
       refute PromptUI.open?(state)
     end
 
     test "Enter submits empty text when no input given" do
-      state = make_state() |> PromptUI.open(TestHandler)
+      state = base_state() |> PromptUI.open(TestHandler)
       {state, nil} = PromptUI.handle_key(state, @enter, 0)
 
-      assert state.submitted == ""
+      assert Process.get(:submitted) == ""
       refute PromptUI.open?(state)
     end
   end
 
   describe "handle_key/3 — cancel" do
     test "Escape calls on_cancel and closes prompt" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "draft")
+      state = base_state() |> PromptUI.open(TestHandler, default: "draft")
       {state, nil} = PromptUI.handle_key(state, @escape, 0)
 
-      assert state.cancelled == true
+      assert Process.get(:cancelled) == true
       refute PromptUI.open?(state)
     end
   end
 
   describe "render_data/1" do
     test "returns label, text, and cursor position" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "hello")
+      state = base_state() |> PromptUI.open(TestHandler, default: "hello")
       {label, text, cursor} = PromptUI.render_data(state)
 
       assert label == "Test prompt: "
@@ -249,86 +261,102 @@ defmodule MingaEditor.PromptUITest do
 
   describe "close/1" do
     test "clears prompt state" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "hello")
-      state = PromptUI.close(state)
+      state =
+        base_state()
+        |> PromptUI.open(TestHandler, default: "hello")
+        |> PromptUI.close()
 
       refute PromptUI.open?(state)
-      assert state.shell_state.prompt_ui.handler == nil
-      assert state.shell_state.prompt_ui.text == ""
+      assert state.shell_state.modal == :none
     end
   end
 
   describe "handle_key/3 — delete (forward)" do
     test "removes character after cursor" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "abc")
-      state = MingaEditor.State.set_prompt_ui(state, %{state.shell_state.prompt_ui | cursor: 0})
+      state =
+        base_state()
+        |> PromptUI.open(TestHandler, default: "abc")
+        |> set_cursor(0)
+
       {state, nil} = PromptUI.handle_key(state, @delete, 0)
 
-      assert state.shell_state.prompt_ui.text == "bc"
-      assert state.shell_state.prompt_ui.cursor == 0
+      pui = prompt_state(state)
+      assert pui.text == "bc"
+      assert pui.cursor == 0
     end
 
     test "does nothing at end of text" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "abc")
+      state = base_state() |> PromptUI.open(TestHandler, default: "abc")
       # cursor is at 3 (end)
       {state, nil} = PromptUI.handle_key(state, @delete, 0)
 
-      assert state.shell_state.prompt_ui.text == "abc"
-      assert state.shell_state.prompt_ui.cursor == 3
+      pui = prompt_state(state)
+      assert pui.text == "abc"
+      assert pui.cursor == 3
     end
 
     test "deletes in middle of text" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "abc")
-      state = MingaEditor.State.set_prompt_ui(state, %{state.shell_state.prompt_ui | cursor: 1})
+      state =
+        base_state()
+        |> PromptUI.open(TestHandler, default: "abc")
+        |> set_cursor(1)
+
       {state, nil} = PromptUI.handle_key(state, @delete, 0)
 
-      assert state.shell_state.prompt_ui.text == "ac"
-      assert state.shell_state.prompt_ui.cursor == 1
+      pui = prompt_state(state)
+      assert pui.text == "ac"
+      assert pui.cursor == 1
     end
   end
 
   describe "handle_key/3 — edge cases" do
     test "control characters are ignored" do
-      state = make_state() |> PromptUI.open(TestHandler)
+      state = base_state() |> PromptUI.open(TestHandler)
       {state, nil} = PromptUI.handle_key(state, 0x01, 0)
 
-      assert state.shell_state.prompt_ui.text == ""
+      assert prompt_state(state).text == ""
     end
 
     test "surrogate codepoints are ignored" do
-      state = make_state() |> PromptUI.open(TestHandler)
+      state = base_state() |> PromptUI.open(TestHandler)
       {state, nil} = PromptUI.handle_key(state, 0xD800, 0)
 
-      assert state.shell_state.prompt_ui.text == ""
+      assert prompt_state(state).text == ""
     end
 
     test "backspace on multi-byte unicode deletes one grapheme" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "a😀b")
-      # cursor at 3 (end), move back once to position 2 (after 😀)
-      state = MingaEditor.State.set_prompt_ui(state, %{state.shell_state.prompt_ui | cursor: 2})
+      state =
+        base_state()
+        |> PromptUI.open(TestHandler, default: "a😀b")
+        # cursor at 3 (end), move back once to position 2 (after 😀)
+        |> set_cursor(2)
+
       {state, nil} = PromptUI.handle_key(state, @backspace, 0)
 
-      assert state.shell_state.prompt_ui.text == "ab"
-      assert state.shell_state.prompt_ui.cursor == 1
+      pui = prompt_state(state)
+      assert pui.text == "ab"
+      assert pui.cursor == 1
     end
 
     test "inserting at position 0 prepends to text" do
-      state = make_state() |> PromptUI.open(TestHandler, default: "bc")
-      state = MingaEditor.State.set_prompt_ui(state, %{state.shell_state.prompt_ui | cursor: 0})
+      state =
+        base_state()
+        |> PromptUI.open(TestHandler, default: "bc")
+        |> set_cursor(0)
+
       {state, nil} = PromptUI.handle_key(state, ?a, 0)
 
-      assert state.shell_state.prompt_ui.text == "abc"
-      assert state.shell_state.prompt_ui.cursor == 1
+      pui = prompt_state(state)
+      assert pui.text == "abc"
+      assert pui.cursor == 1
     end
   end
 
   describe "composability — picker then prompt" do
     test "on_select can open a prompt for multi-step flow" do
       # Simulate: picker selects a template, then prompt opens for title input
-      state = make_state()
-
       # Step 1: open prompt with empty default (simulating a picker's on_select)
-      state = PromptUI.open(state, RenameHandler)
+      state = base_state() |> PromptUI.open(RenameHandler)
 
       # Step 2: type new name
       state =
@@ -340,7 +368,7 @@ defmodule MingaEditor.PromptUITest do
       # Step 3: submit
       {state, nil} = PromptUI.handle_key(state, @enter, 0)
 
-      assert state.new_name == "NewName"
+      assert Process.get(:new_name) == "NewName"
       refute PromptUI.open?(state)
     end
   end

--- a/test/minga_editor/shell/traditional/on_buffer_added_test.exs
+++ b/test/minga_editor/shell/traditional/on_buffer_added_test.exs
@@ -1,0 +1,66 @@
+defmodule MingaEditor.Shell.Traditional.OnBufferAddedTest do
+  @moduledoc """
+  Focused tests for `Shell.Traditional.on_buffer_added/4`.
+
+  Covers the dashboard auto-dismiss hook (#1425): when a buffer becomes
+  active, any open dashboard modal is dismissed so the splash does not
+  stick visually behind the buffer view.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias MingaEditor.Dashboard
+  alias MingaEditor.Shell.Traditional
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
+  alias MingaEditor.State.ModalOverlay.Dashboard, as: DashboardPayload
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+  alias MingaEditor.State.Picker, as: PickerLegacy
+  alias MingaEditor.UI.Picker, as: UIPicker
+  alias MingaEditor.Viewport
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  defp blank_workspace do
+    %WorkspaceState{viewport: Viewport.new(24, 80)}
+  end
+
+  describe "dashboard auto-dismiss" do
+    test "dismisses an active dashboard modal when a buffer is added" do
+      shell_state = %ShellState{
+        modal: {:dashboard, DashboardPayload.new(Dashboard.new_state())}
+      }
+
+      {:ok, buf} = BufferServer.start_link(content: "hello")
+
+      {new_shell, _ws} = Traditional.on_buffer_added(shell_state, blank_workspace(), buf, :open)
+
+      assert new_shell.modal == :none
+    end
+
+    test "leaves an active picker modal alone when a buffer is added" do
+      picker_payload =
+        PickerPayload.new(%PickerLegacy{
+          picker: UIPicker.new([], title: "test"),
+          source: nil,
+          restore: 0
+        })
+
+      shell_state = %ShellState{modal: {:picker, picker_payload}}
+
+      {:ok, buf} = BufferServer.start_link(content: "hello")
+
+      {new_shell, _ws} = Traditional.on_buffer_added(shell_state, blank_workspace(), buf, :open)
+
+      assert new_shell.modal == {:picker, picker_payload}
+    end
+
+    test "is a no-op when no modal is active" do
+      shell_state = %ShellState{modal: :none}
+      {:ok, buf} = BufferServer.start_link(content: "hello")
+
+      {new_shell, _ws} = Traditional.on_buffer_added(shell_state, blank_workspace(), buf, :open)
+
+      assert new_shell.modal == :none
+    end
+  end
+end

--- a/test/minga_editor/state/modal_overlay_test.exs
+++ b/test/minga_editor/state/modal_overlay_test.exs
@@ -92,7 +92,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
   end
 
   describe "open/3 from :none" do
-    test "writes the modal field and mirrors picker payload to the legacy slot" do
+    test "writes the picker variant" do
       state = base_state()
       payload = picker_payload()
 
@@ -101,24 +101,22 @@ defmodule MingaEditor.State.ModalOverlayTest do
       assert result.shell_state.modal == {:picker, payload}
     end
 
-    test "writes the prompt legacy field" do
+    test "writes the prompt variant" do
       state = base_state()
       payload = prompt_payload()
 
       result = ModalOverlay.open(state, :prompt, payload)
 
       assert result.shell_state.modal == {:prompt, payload}
-      assert result.shell_state.prompt_ui == payload.prompt_ui
     end
 
-    test "writes the dashboard legacy field" do
+    test "writes the dashboard variant" do
       state = base_state()
       payload = dashboard_payload()
 
       result = ModalOverlay.open(state, :dashboard, payload)
 
       assert result.shell_state.modal == {:dashboard, payload}
-      assert result.shell_state.dashboard == payload.state
     end
 
     test "writes the completion legacy field on workspace" do
@@ -131,7 +129,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       assert result.workspace.completion == payload.completion
     end
 
-    test "writes the conflict legacy field as a {pid, message} tuple" do
+    test "writes the conflict variant" do
       state = base_state()
       buffer = self()
       payload = conflict_payload(buffer)
@@ -139,12 +137,11 @@ defmodule MingaEditor.State.ModalOverlayTest do
       result = ModalOverlay.open(state, :conflict, payload)
 
       assert result.shell_state.modal == {:conflict, payload}
-      assert result.workspace.pending_conflict == {buffer, payload.message}
     end
   end
 
   describe "open/3 displacement" do
-    test "replacing a picker with a prompt clears the picker legacy slot" do
+    test "replacing a picker with a prompt swaps the active modal" do
       state =
         base_state()
         |> ModalOverlay.open(:picker, picker_payload())
@@ -153,7 +150,6 @@ defmodule MingaEditor.State.ModalOverlayTest do
       result = ModalOverlay.open(state, :prompt, prompt)
 
       assert result.shell_state.modal == {:prompt, prompt}
-      assert result.shell_state.prompt_ui == prompt.prompt_ui
     end
 
     test "replacing completion with picker clears workspace.completion" do
@@ -168,7 +164,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       assert result.workspace.completion == nil
     end
 
-    test "replacing dashboard clears the dashboard legacy field" do
+    test "replacing dashboard with picker swaps the active modal" do
       state =
         base_state()
         |> ModalOverlay.open(:dashboard, dashboard_payload())
@@ -177,7 +173,6 @@ defmodule MingaEditor.State.ModalOverlayTest do
       result = ModalOverlay.open(state, :picker, picker)
 
       assert result.shell_state.modal == {:picker, picker}
-      assert result.shell_state.dashboard == nil
     end
   end
 
@@ -192,17 +187,25 @@ defmodule MingaEditor.State.ModalOverlayTest do
       assert result == state
     end
 
+    test "open(:prompt) while conflict is active is suppressed and returns state unchanged" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:conflict, conflict_payload())
+
+      result = ModalOverlay.open(state, :prompt, prompt_payload())
+
+      assert result == state
+    end
+
     test "open(:conflict) over an existing conflict replaces (same-variant transition)" do
       state =
         base_state()
         |> ModalOverlay.open(:conflict, conflict_payload(self()))
 
-      other = self()
-      next = ConflictPayload.new(other, "different message", opened_at: 2_000)
+      next = ConflictPayload.new(self(), "different message", opened_at: 2_000)
       result = ModalOverlay.open(state, :conflict, next)
 
       assert result.shell_state.modal == {:conflict, next}
-      assert result.workspace.pending_conflict == {other, "different message"}
     end
   end
 
@@ -216,12 +219,11 @@ defmodule MingaEditor.State.ModalOverlayTest do
       result = ModalOverlay.transition(state, :picker, picker)
 
       assert result.shell_state.modal == {:picker, picker}
-      assert result.workspace.pending_conflict == nil
     end
   end
 
   describe "close/1 and dismiss/1" do
-    test "close clears the active picker and resets the legacy slot" do
+    test "close clears the active picker" do
       state =
         base_state()
         |> ModalOverlay.open(:picker, picker_payload())
@@ -231,7 +233,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       assert result.shell_state.modal == :none
     end
 
-    test "dismiss clears the active prompt and resets the legacy slot" do
+    test "dismiss clears the active prompt" do
       state =
         base_state()
         |> ModalOverlay.open(:prompt, prompt_payload())
@@ -239,7 +241,16 @@ defmodule MingaEditor.State.ModalOverlayTest do
       result = ModalOverlay.dismiss(state)
 
       assert result.shell_state.modal == :none
-      assert result.shell_state.prompt_ui == %PromptLegacy{}
+    end
+
+    test "dismiss clears an active conflict" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:conflict, conflict_payload())
+
+      result = ModalOverlay.dismiss(state)
+
+      assert result.shell_state.modal == :none
     end
 
     test "close clears workspace.completion when a completion is active" do
@@ -261,21 +272,6 @@ defmodule MingaEditor.State.ModalOverlayTest do
   end
 
   describe "divergence assertion (dev/test only)" do
-    test "raises when prompt_ui is mutated outside the gate" do
-      state =
-        base_state()
-        |> ModalOverlay.open(:prompt, prompt_payload())
-
-      tampered =
-        update_in(state.shell_state.prompt_ui, fn pui ->
-          %{pui | cursor: 999}
-        end)
-
-      assert_raise RuntimeError, ~r/ModalOverlay divergence/, fn ->
-        ModalOverlay.close(tampered)
-      end
-    end
-
     test "raises when workspace.completion is cleared outside the gate" do
       state =
         base_state()
@@ -291,21 +287,21 @@ defmodule MingaEditor.State.ModalOverlayTest do
     test "tolerates legacy mutation while modal is :none" do
       state = base_state()
 
+      # Stuff a stray completion onto workspace before any modal opens.
       tampered =
-        put_in(state.shell_state.prompt_ui, %PromptLegacy{
-          handler: SomeHandler,
-          text: "x",
-          cursor: 1,
-          label: ":"
-        })
+        put_in(
+          state.workspace.completion,
+          Completion.new([], {0, 0})
+        )
 
       payload = picker_payload()
       result = ModalOverlay.open(tampered, :picker, payload)
 
+      # The gate clears completion when displacing it (it tracks completion
+      # via the legacy mirror), but only because completion was the
+      # previously-tracked variant. Here completion was never tracked, so
+      # it should be left as-is by `:picker`'s open path.
       assert result.shell_state.modal == {:picker, payload}
-      # The mutated prompt_ui is preserved: the gate makes no claims about
-      # legacy fields whose variant is not currently tracked.
-      assert result.shell_state.prompt_ui.text == "x"
     end
   end
 end

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -63,7 +63,6 @@ defmodule MingaEditor.State.SnapshotTest do
       assert ctx.completion_trigger == state.workspace.completion_trigger
       assert ctx.injection_ranges == state.workspace.injection_ranges
       assert ctx.search == state.workspace.search
-      assert ctx.pending_conflict == state.workspace.pending_conflict
     end
   end
 


### PR DESCRIPTION
## Summary

Implements #1425 (step 3 of 5 of Epic #1421). The prompt UI, dashboard splash, and file-change conflict prompt are now represented exclusively as `ModalOverlay` variants on `shell_state.modal`. Their legacy mirror fields (`shell_state.prompt_ui`, `shell_state.dashboard`, `workspace.pending_conflict`) have been removed.

- **Prompt:** `PromptUI.open/3` and `close/1` route through `ModalOverlay.open/dismiss`. A new `update_prompt/2` helper mirrors the picker's `update_picker/2` for internal mutations. The previous `maybe_close_picker` workaround is gone — the gate's replacement policy handles it.
- **Dashboard:** `Input.Dashboard` reads/writes via the modal. The renderer falls back to a fresh dashboard state when the modal isn't `:dashboard`. **Auto-dismiss hook** in `Shell.Traditional.on_buffer_added` clears an active dashboard modal whenever a buffer becomes active (AC #3).
- **Conflict:** `file_watcher_helpers`, `Input.ConflictPrompt`, and `Input.Interrupt.maybe_close_conflict` go through `ModalOverlay`. The conflict-sticky precedence rule (AC #4) is preserved by `ModalOverlay.open/3`.
- `ModalOverlay`'s `mirror_to_legacy` / `clear_displaced_legacy` / divergence assertion drop the three migrated variants. Only completion remains on dual-write (#1426 will handle it). Module docstring updated to reflect step 3 of 5.
- `Workspace.State` drops `pending_conflict` (and its setter); the snapshot helpers, `Tab.context()` typespec, and the credo state-machine-write check are updated to match.

## Test plan

- [x] `mix test` for `prompt_ui_test`, `input/{prompt,dashboard,handler,interrupt,router,conflict_prompt}_test`, `state/{modal_overlay,snapshot}_test`, `dashboard_test`, `file_change_test`, and the new `shell/traditional/on_buffer_added_test`
- [x] New regression test: `Shell.Traditional.on_buffer_added` auto-dismisses an active dashboard modal but leaves picker modals untouched
- [x] New tests on `ModalOverlay.open(:picker, ...)` and `open(:prompt, ...)` returning state unchanged while a conflict is active
- [x] Full `mix test.llm` suite: 7513 tests, 0 failures
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean (no new warnings; the three removed fields actually reduce ShellState/WorkspaceState field counts)

Closes #1425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)