### PR TITLE
refactor(agent): complete per-tab routing for background agent events

### DIFF
--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -267,7 +267,10 @@ defmodule MingaEditor.Agent.Events do
 
     if session do
       update_board_card_by_session(state, session, fn card ->
-        MingaEditor.Shell.Board.Card.set_status(card, agent_status_to_card_status(status))
+        MingaEditor.Shell.Board.Card.set_status(
+          card,
+          MingaEditor.Shell.Board.Card.from_agent_status(status)
+        )
       end)
     else
       state
@@ -312,13 +315,6 @@ defmodule MingaEditor.Agent.Events do
         state
     end
   end
-
-  @spec agent_status_to_card_status(Tab.agent_status()) :: MingaEditor.Shell.Board.Card.status()
-  defp agent_status_to_card_status(:thinking), do: :working
-  defp agent_status_to_card_status(:tool_executing), do: :iterating
-  defp agent_status_to_card_status(:error), do: :errored
-  defp agent_status_to_card_status(:idle), do: :done
-  defp agent_status_to_card_status(_), do: :idle
 
   # Syncs the agent_status field on the current agent tab so the tab bar
   # can render status indicators without querying the Session process.

--- a/lib/minga_editor/shell/board.ex
+++ b/lib/minga_editor/shell/board.ex
@@ -469,7 +469,26 @@ defmodule MingaEditor.Shell.Board do
   @spec on_agent_event(BoardState.t(), MingaEditor.Workspace.State.t(), pid(), term()) ::
           {BoardState.t(), MingaEditor.Workspace.State.t()}
   def on_agent_event(shell_state, workspace, session_pid, {:status_changed, status}) do
-    shell_state = update_card_by_session(shell_state, session_pid, &Card.set_status(&1, status))
+    card_status = Card.from_agent_status(status)
+
+    shell_state =
+      update_card_by_session(shell_state, session_pid, &Card.set_status(&1, card_status))
+
+    {shell_state, workspace}
+  end
+
+  # Cards have no separate attention flag; status :needs_you carries the alert.
+  def on_agent_event(shell_state, workspace, session_pid, {:approval_pending, _}) do
+    shell_state =
+      update_card_by_session(shell_state, session_pid, &Card.set_status(&1, :needs_you))
+
+    {shell_state, workspace}
+  end
+
+  def on_agent_event(shell_state, workspace, session_pid, {:error, _message}) do
+    shell_state =
+      update_card_by_session(shell_state, session_pid, &Card.set_status(&1, :errored))
+
     {shell_state, workspace}
   end
 

--- a/lib/minga_editor/shell/board/card.ex
+++ b/lib/minga_editor/shell/board/card.ex
@@ -106,4 +106,19 @@ defmodule MingaEditor.Shell.Board.Card do
   @spec you_card?(t()) :: boolean()
   def you_card?(%__MODULE__{kind: :you}), do: true
   def you_card?(%__MODULE__{}), do: false
+
+  @doc """
+  Maps an agent session lifecycle status to the corresponding card status.
+
+  Agent sessions speak in `Tab.agent_status` (`:idle | :thinking | :tool_executing
+  | :error | nil`); cards have a richer status vocabulary intended for the Board
+  grid. This mapping is the single source of truth so foreground (active session)
+  and background (non-active session) routing apply the same translation.
+  """
+  @spec from_agent_status(MingaEditor.State.Tab.agent_status()) :: status()
+  def from_agent_status(:thinking), do: :working
+  def from_agent_status(:tool_executing), do: :iterating
+  def from_agent_status(:error), do: :errored
+  def from_agent_status(:idle), do: :done
+  def from_agent_status(_), do: :idle
 end

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -248,6 +248,20 @@ defmodule MingaEditor.Shell.Traditional do
     {%{shell_state | tab_bar: tb}, workspace}
   end
 
+  # A direct :error event raises attention so a background tab whose session
+  # crashes mid-stream still surfaces in the tab bar (the broader status_changed
+  # path also raises attention on :error, but a session can emit :error without
+  # a preceding :status_changed transition).
+  def on_agent_event(
+        %ShellState{tab_bar: %TabBar{} = tb} = shell_state,
+        workspace,
+        session_pid,
+        {:error, _message}
+      ) do
+    tb = TabBar.set_attention_by_session(tb, session_pid, true)
+    {%{shell_state | tab_bar: tb}, workspace}
+  end
+
   def on_agent_event(shell_state, workspace, _session_pid, _event) do
     {shell_state, workspace}
   end

--- a/test/minga_editor/agent/event_routing_test.exs
+++ b/test/minga_editor/agent/event_routing_test.exs
@@ -1,0 +1,209 @@
+defmodule MingaEditor.Agent.EventRoutingTest do
+  @moduledoc """
+  Verifies the foreground/background split for agent events.
+
+  The runtime split lives in `MingaEditor.handle_info/2` for `:agent_event`
+  messages: events whose `session_pid` matches `AgentAccess.session/1` go
+  through `Agent.Events.handle/2` (rendering cache + tab status); the
+  rest go through `Shell.on_agent_event/4` (presentation only — never
+  the active tab's rendering cache).
+
+  These tests pin the shell callbacks directly so the routing contract
+  is exercised without booting the editor GenServer.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Shell.Board
+  alias MingaEditor.Shell.Board.Card
+  alias MingaEditor.Shell.Board.State, as: BoardState
+  alias MingaEditor.Shell.Traditional
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  defp workspace, do: %WorkspaceState{viewport: Viewport.new(24, 80), editing: VimState.new()}
+
+  defp tab(%TabBar{tabs: tabs}, id), do: Enum.find(tabs, &(&1.id == id))
+
+  defp tab_bar(tabs, active_id) do
+    [first | rest] = tabs
+    tb = TabBar.new(first)
+
+    tb =
+      Enum.reduce(rest, tb, fn tab, acc ->
+        %{acc | tabs: acc.tabs ++ [tab], next_id: max(acc.next_id, tab.id + 1)}
+      end)
+
+    %{tb | active_id: active_id}
+  end
+
+  # ── Traditional shell ──────────────────────────────────────────────────
+
+  describe "Traditional.on_agent_event/4" do
+    setup do
+      session_a = spawn_link(fn -> Process.sleep(:infinity) end)
+      session_b = spawn_link(fn -> Process.sleep(:infinity) end)
+
+      tabs = [
+        Tab.new_agent(1, "A") |> Tab.set_session(session_a),
+        Tab.new_agent(2, "B") |> Tab.set_session(session_b)
+      ]
+
+      shell_state = %TraditionalState{
+        agent: %AgentState{},
+        tab_bar: tab_bar(tabs, 1)
+      }
+
+      %{shell_state: shell_state, session_a: session_a, session_b: session_b}
+    end
+
+    test "background :status_changed event sets the owning tab's badge without touching the active rendering cache",
+         %{shell_state: ss, session_b: session_b} do
+      {ss2, ws2} =
+        Traditional.on_agent_event(ss, workspace(), session_b, {:status_changed, :thinking})
+
+      # Background tab's badge updates...
+      assert tab(ss2.tab_bar, 2).agent_status == :thinking
+
+      # ...but the active rendering cache is untouched (it routes through
+      # Agent.Events for the foreground path, not through this callback).
+      assert ss2.agent == ss.agent
+
+      # Workspace is also untouched: background events must not nudge the
+      # active tab's editing surface.
+      assert ws2 == workspace()
+    end
+
+    test "background :status_changed -> :idle raises attention on the owning tab", %{
+      shell_state: ss,
+      session_b: session_b
+    } do
+      {ss2, _ws} =
+        Traditional.on_agent_event(ss, workspace(), session_b, {:status_changed, :idle})
+
+      assert tab(ss2.tab_bar, 2).attention == true
+      assert tab(ss2.tab_bar, 1).attention == false
+    end
+
+    test "background :approval_pending raises attention on the owning tab", %{
+      shell_state: ss,
+      session_b: session_b
+    } do
+      approval = %{tool_call_id: "x", name: "shell", args: %{}}
+
+      {ss2, _ws} =
+        Traditional.on_agent_event(ss, workspace(), session_b, {:approval_pending, approval})
+
+      assert tab(ss2.tab_bar, 2).attention == true
+      assert tab(ss2.tab_bar, 1).attention == false
+    end
+
+    test "background :error raises attention on the owning tab", %{
+      shell_state: ss,
+      session_b: session_b
+    } do
+      {ss2, _ws} = Traditional.on_agent_event(ss, workspace(), session_b, {:error, "boom"})
+      assert tab(ss2.tab_bar, 2).attention == true
+      assert tab(ss2.tab_bar, 1).attention == false
+    end
+
+    test "background :text_delta does not mutate state at all", %{
+      shell_state: ss,
+      session_b: session_b
+    } do
+      # Streaming text from a background session must not reach this callback's
+      # mutation path — the delta is purely a no-op so the active tab's UI
+      # never re-renders for unrelated streaming.
+      {ss2, ws2} = Traditional.on_agent_event(ss, workspace(), session_b, {:text_delta, "hello"})
+      assert ss2 == ss
+      assert ws2 == workspace()
+    end
+
+    test "events from a session that no longer maps to any tab are silently dropped", %{
+      shell_state: ss
+    } do
+      ghost = spawn(fn -> :ok end)
+      {ss2, _ws} = Traditional.on_agent_event(ss, workspace(), ghost, {:status_changed, :error})
+      assert ss2.tab_bar == ss.tab_bar
+    end
+  end
+
+  # ── Board shell ─────────────────────────────────────────────────────────
+
+  describe "Board.on_agent_event/4" do
+    setup do
+      session_a = spawn_link(fn -> Process.sleep(:infinity) end)
+      session_b = spawn_link(fn -> Process.sleep(:infinity) end)
+
+      board = BoardState.new()
+      {board, _card_a} = BoardState.create_card(board, task: "A", session: session_a)
+      {board, _card_b} = BoardState.create_card(board, task: "B", session: session_b)
+
+      %{board: board, session_a: session_a, session_b: session_b}
+    end
+
+    test "background :status_changed maps the agent status onto the card vocabulary", %{
+      board: board,
+      session_b: session_b
+    } do
+      # Tab.agent_status uses :thinking; Card.status uses :working — the
+      # Board callback applies the mapping rather than stamping the raw atom.
+      {board2, _ws} =
+        Board.on_agent_event(board, workspace(), session_b, {:status_changed, :thinking})
+
+      [card_b] = Enum.filter(Map.values(board2.cards), &(&1.session == session_b))
+      assert card_b.status == :working
+
+      # Other card untouched.
+      [card_a] = Enum.filter(Map.values(board2.cards), &(&1.task == "A"))
+      assert card_a.status == :idle
+    end
+
+    test "background :approval_pending transitions the owning card to :needs_you", %{
+      board: board,
+      session_b: session_b
+    } do
+      {board2, _ws} =
+        Board.on_agent_event(board, workspace(), session_b, {:approval_pending, %{name: "shell"}})
+
+      [card_b] = Enum.filter(Map.values(board2.cards), &(&1.session == session_b))
+      assert card_b.status == :needs_you
+    end
+
+    test "background :error transitions the owning card to :errored", %{
+      board: board,
+      session_b: session_b
+    } do
+      {board2, _ws} = Board.on_agent_event(board, workspace(), session_b, {:error, "boom"})
+      [card_b] = Enum.filter(Map.values(board2.cards), &(&1.session == session_b))
+      assert card_b.status == :errored
+    end
+
+    test "events for a session not attached to any card are silently dropped", %{board: board} do
+      ghost = spawn(fn -> :ok end)
+      {board2, _ws} = Board.on_agent_event(board, workspace(), ghost, {:approval_pending, %{}})
+      assert board2 == board
+    end
+  end
+
+  # ── Card.from_agent_status pure function ───────────────────────────────
+
+  describe "Card.from_agent_status/1" do
+    test "maps every documented agent status" do
+      assert Card.from_agent_status(:thinking) == :working
+      assert Card.from_agent_status(:tool_executing) == :iterating
+      assert Card.from_agent_status(:error) == :errored
+      assert Card.from_agent_status(:idle) == :done
+    end
+
+    test "unknown atoms fall back to :idle" do
+      assert Card.from_agent_status(nil) == :idle
+      assert Card.from_agent_status(:something_else) == :idle
+    end
+  end
+end


### PR DESCRIPTION
Closes #1430.

## Summary

The foreground/background routing split for agent events lives in `MingaEditor.handle_info/2` — events whose session matches `AgentAccess.session/1` go to `Agent.Events.handle/2`; the rest go to `Shell.on_agent_event/4`. The infrastructure for that split was already in place from #1428's per-tab session work; this PR fills in the gaps in the shell callbacks so the contract holds for both shells across every relevant event type.

- **Traditional shell.** Added `:error` event handler that calls `TabBar.set_attention_by_session/3`. Previously only `:status_changed -> :error` raised attention, so a session that emits a bare `:error` mid-stream (without a preceding status transition) would not surface in the tab bar.
- **Board shell.** Background `:status_changed` was stamping the raw `Tab.agent_status` atom (`:thinking`, `:tool_executing`, …) onto `Card.status` (which uses a different vocabulary: `:working`, `:iterating`, …). Now routes through the new `Card.from_agent_status/1` mapping so foreground and background updates yield identical card statuses. Added `:approval_pending` (→ `:needs_you`) and `:error` (→ `:errored`) — Cards have no separate attention flag, so attention semantics live in the status vocabulary.
- **`Card.from_agent_status/1`.** Single source of truth for the mapping, lifted out of `Agent.Events`'s private `agent_status_to_card_status/1`. Both the foreground (`Events.sync_board_card_status`) and background (`Board.on_agent_event`) paths now share this helper.

## Verification

| AC | How proved |
| --- | --- |
| 1. Routes events by `TabBar.find_by_session/2` lookup | Pre-existing: `lib/minga_editor.ex:673-688` does the dispatch by comparing `AgentAccess.session(state)` against the event's `session_pid`. `lib/minga_editor/agent/events.ex` `sync_tab_agent_status` further uses `TabBar.find_by_session/2` directly. |
| 2. Active-session events update `state.shell_state.agent` and the tab badge | Pre-existing in the foreground path through `Agent.Events.handle/2`. Background tests assert `ss2.agent == ss.agent` to confirm the background path does **not** touch the rendering cache. |
| 3. Non-active events update only the owning tab's badge / card status | `event_routing_test.exs` — Traditional and Board describe blocks both assert that only the owning tab/card mutates. |
| 4. Streaming agent in background tab does not re-render the active editor surface | "background :text_delta does not mutate state at all" pins the no-op behavior at the shell-callback layer; combined with `lib/minga_editor.ex:684-686` (no `:render` effect emitted), the active surface is not invalidated. |
| 5. `Tab.set_attention/2` called for non-active tabs on user-meaningful events | Traditional raises attention on `:approval_pending`, `:status_changed -> :idle/:error`, and now `:error`. Board uses status `:needs_you` / `:errored` (cards have no separate attention flag). |
| 6. New `test/minga_editor/agent/event_routing_test.exs` covers the foreground/background split | 12 tests across Traditional, Board, and `Card.from_agent_status/1`. |

### Local verification

- `mix compile --warnings-as-errors` — clean
- `mix test test/minga_editor/agent/event_routing_test.exs` — 12/12 pass
- `mix test.llm test/minga_editor/agent/ test/minga_editor/shell/` — 586/586 pass
- `make lint` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)