### PR TITLE
chore(session): drop legacy tab-context migration paths

### DIFF
--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -21,6 +21,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   alias MingaEditor.Window
   alias Minga.Mode
@@ -579,43 +580,13 @@ defmodule MingaEditor.Commands.BufferManagement do
   # ── Private buffer helpers ────────────────────────────────────────────────
 
   @spec switch_to_buffer(state(), non_neg_integer()) :: state()
-  defp switch_to_buffer(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}, workspace: %{buffers: %{list: buffers}}} =
-           state,
-         idx
-       ) do
-    target_buf = Enum.at(buffers, idx)
-
-    # Find the file tab whose context holds this buffer
-    case find_tab_for_buffer(tb, target_buf) do
-      nil ->
-        # No tab found, fall back to index-based switching
-        EditorState.switch_buffer(state, idx)
-
-      tab_id ->
-        EditorState.switch_tab(state, tab_id)
-    end
-  end
-
   defp switch_to_buffer(state, idx), do: EditorState.switch_buffer(state, idx)
-
-  alias MingaEditor.State.Tab
-
-  @spec find_tab_for_buffer(TabBar.t(), pid() | nil) :: Tab.id() | nil
-  defp find_tab_for_buffer(_tb, nil), do: nil
-
-  defp find_tab_for_buffer(%TabBar{tabs: tabs}, target_buf) do
-    Enum.find_value(tabs, fn
-      %{kind: :file, id: id, context: %{active_buffer: ^target_buf}} -> id
-      _ -> nil
-    end)
-  end
 
   @spec next_buffer(state()) :: state()
   defp next_buffer(
          %{workspace: %{buffers: %{list: [_, _ | _] = buffers, active_index: idx}}} = state
        ) do
-    cycle_buffer_in_tab(state, rem(idx + 1, Enum.count(buffers)))
+    EditorState.switch_buffer(state, rem(idx + 1, Enum.count(buffers)))
   end
 
   defp next_buffer(state), do: state
@@ -625,35 +596,10 @@ defmodule MingaEditor.Commands.BufferManagement do
          %{workspace: %{buffers: %{list: [_, _ | _] = buffers, active_index: idx}}} = state
        ) do
     count = Enum.count(buffers)
-    cycle_buffer_in_tab(state, rem(idx - 1 + count, count))
+    EditorState.switch_buffer(state, rem(idx - 1 + count, count))
   end
 
   defp prev_buffer(state), do: state
-
-  # Cycles the buffer in the current tab. If the target buffer already
-  # has its own file tab, switches to that tab instead.
-  @spec cycle_buffer_in_tab(state(), non_neg_integer()) :: state()
-  defp cycle_buffer_in_tab(%{shell_state: %{tab_bar: %TabBar{}}} = state, idx) do
-    target_buf = Enum.at(state.workspace.buffers.list, idx)
-
-    case find_tab_for_buffer(state.shell_state.tab_bar, target_buf) do
-      nil ->
-        # Buffer has no dedicated tab; switch in-place.
-        EditorState.switch_buffer(state, idx)
-
-      tab_id when tab_id == state.shell_state.tab_bar.active_id ->
-        # Buffer's tab is the current tab; switch in-place.
-        EditorState.switch_buffer(state, idx)
-
-      tab_id ->
-        # Buffer lives in another tab; switch to it.
-        EditorState.switch_tab(state, tab_id)
-    end
-  end
-
-  defp cycle_buffer_in_tab(state, idx) do
-    EditorState.switch_buffer(state, idx)
-  end
 
   @spec next_tab(state()) :: state()
   defp next_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -481,8 +481,6 @@ defmodule MingaEditor.Shell.Traditional do
   defp tab_has_active_buffer?(tab, pid) do
     case tab.context do
       %{buffers: %{active: ^pid}} -> true
-      %{surface_state: %{buffers: %{active: ^pid}}} -> true
-      %{active_buffer: ^pid} -> true
       _ -> false
     end
   end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -42,7 +42,6 @@ defmodule MingaEditor.State do
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Highlighting
   alias MingaEditor.State.Mouse
-  alias MingaEditor.State.Registers
   alias MingaEditor.State.Search
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
@@ -887,9 +886,6 @@ defmodule MingaEditor.State do
   The context carries workspace fields as a flat map. Empty context means a
   brand-new tab; we build defaults with the current active buffer and
   viewport dimensions.
-
-  Backward compatibility: old contexts with nested structure are migrated
-  to the new flat format via `maybe_migrate_legacy_context/2`.
   """
   @spec restore_tab_context(t(), Tab.context()) :: t()
   def restore_tab_context(%__MODULE__{} = state, context) when is_map(context) do
@@ -898,11 +894,8 @@ defmodule MingaEditor.State do
         build_file_tab_defaults(state)
       else
         context
-        |> maybe_migrate_legacy_context(state)
-        |> maybe_migrate_vim_fields()
       end
 
-    # Build a new workspace from the context fields
     ws = state.workspace
 
     new_ws =
@@ -1034,71 +1027,6 @@ defmodule MingaEditor.State do
 
   defp build_agent_card_windows(_agent_buf, _rows, _cols), do: %Windows{}
 
-  # Migrates legacy contexts (old nested format or oldest
-  # bare-field format) to the new flat format. If the context already
-  # has the :buffers key (new format), returns it unchanged.
-  @spec maybe_migrate_legacy_context(Tab.context(), t()) :: Tab.context()
-  defp maybe_migrate_legacy_context(%{buffers: _} = context, _state), do: context
-
-  defp maybe_migrate_legacy_context(%{surface_state: %{buffers: _} = ss} = context, _state) do
-    # Extract fields from old nested snapshot format
-    vim_map = ss.editing || %{}
-
-    vim = %VimState{
-      mode: Map.get(vim_map, :mode, :normal),
-      mode_state: Map.get(vim_map, :mode_state, Mode.initial_state()),
-      reg: Map.get(vim_map, :reg, %Registers{}),
-      marks: Map.get(vim_map, :marks, %{}),
-      last_jump_pos: Map.get(vim_map, :last_jump_pos),
-      last_find_char: Map.get(vim_map, :last_find_char)
-    }
-
-    %{
-      keymap_scope: Map.get(context, :keymap_scope, :editor),
-      buffers: ss.buffers,
-      windows: ss.windows,
-      file_tree: ss.file_tree,
-      viewport: ss.viewport,
-      mouse: Map.get(ss, :mouse, %Mouse{}),
-      highlight: Map.get(ss, :highlight, %Highlighting{}),
-      lsp_pending: Map.get(ss, :lsp_pending, %{}),
-      completion: Map.get(ss, :completion),
-      completion_trigger: Map.get(ss, :completion_trigger, CompletionTrigger.new()),
-      injection_ranges: Map.get(ss, :injection_ranges, %{}),
-      search: Map.get(ss, :search, %Search{}),
-      editing: vim
-    }
-  end
-
-  defp maybe_migrate_legacy_context(context, state) do
-    # Oldest format: bare fields like :active_buffer, :windows, :mode
-    ws = state.workspace
-
-    ws = maybe_restore_ws(ws, :windows, context)
-    ws = maybe_restore_ws(ws, :file_tree, context)
-
-    ws =
-      case Map.fetch(context, :active_buffer) do
-        {:ok, buf_pid} ->
-          idx = Map.get(context, :active_buffer_index, ws.buffers.active_index)
-          %{ws | buffers: %{ws.buffers | active: buf_pid, active_index: idx}}
-
-        :error ->
-          ws
-      end
-
-    ws = %{ws | keymap_scope: Map.get(context, :keymap_scope, :editor)}
-
-    # Build vim state from old fields (will be migrated by maybe_migrate_vim_fields)
-    # Preserve vim-related fields from the original context so they can be migrated
-    # Drop the vim field from the snapshot so maybe_migrate_vim_fields will migrate the flat fields
-    snapshot_workspace_fields(ws)
-    |> Map.drop([:vim, :editing])
-    |> Map.merge(
-      Map.take(context, [:mode, :mode_state, :reg, :marks, :last_jump_pos, :last_find_char])
-    )
-  end
-
   @spec log_switch_tab(TabBar.t(), Tab.id(), Tab.id()) :: :ok
   defp log_switch_tab(tb, current_id, target_id) do
     Log.debug(:editor, fn ->
@@ -1118,49 +1046,6 @@ defmodule MingaEditor.State do
       "[tab] switch_tab restored: scope=#{state.workspace.keymap_scope} buf=#{inspect(state.workspace.buffers.active)}"
     end)
   end
-
-  # Restores a workspace field from a context map.
-  @spec maybe_restore_ws(WorkspaceState.t(), atom(), Tab.context()) :: WorkspaceState.t()
-  defp maybe_restore_ws(ws, key, context) do
-    case Map.fetch(context, key) do
-      {:ok, value} -> Map.put(ws, key, value)
-      :error -> ws
-    end
-  end
-
-  # Migrates old contexts with separate vim fields to the new VimState substruct.
-  # The :editing and :vim guards are defensive: earlier migration steps strip
-  # these keys before calling here, but persisted session data may have them.
-  @dialyzer {:no_match, maybe_migrate_vim_fields: 1}
-  @spec maybe_migrate_vim_fields(Tab.context()) :: Tab.context()
-  defp maybe_migrate_vim_fields(%{editing: _} = context), do: context
-  defp maybe_migrate_vim_fields(%{vim: _} = context), do: context
-
-  defp maybe_migrate_vim_fields(%{mode: mode} = context) do
-    vim = %VimState{
-      mode: mode,
-      mode_state: Map.get(context, :mode_state, Mode.initial_state()),
-      reg: Map.get(context, :reg, %Registers{}),
-      marks: Map.get(context, :marks, %{}),
-      last_jump_pos: Map.get(context, :last_jump_pos),
-      last_find_char: Map.get(context, :last_find_char)
-    }
-
-    context
-    |> Map.drop([
-      :mode,
-      :mode_state,
-      :reg,
-      :marks,
-      :last_jump_pos,
-      :last_find_char,
-      :change_recorder,
-      :macro_recorder
-    ])
-    |> Map.put(:editing, vim)
-  end
-
-  defp maybe_migrate_vim_fields(context), do: context
 
   @doc """
   Pure variant of `switch_tab/2`. Returns `{state, effects}` instead of

--- a/lib/minga_editor/state/tab.ex
+++ b/lib/minga_editor/state/tab.ex
@@ -25,11 +25,8 @@ defmodule MingaEditor.State.Tab do
   @typedoc """
   Snapshotted per-tab state.
 
-  The context stores per-tab fields directly (buffers, windows, mode, etc.).
-  Empty context means a brand-new tab.
-
-  Legacy contexts with nested structure (old snapshot format) or
-  bare fields (oldest format) are auto-migrated on first restore.
+  Stores per-tab fields directly as a flat map (buffers, windows, editing,
+  etc.). Empty context means a brand-new tab.
   """
   @type context :: %{
           optional(:keymap_scope) => atom(),
@@ -45,19 +42,8 @@ defmodule MingaEditor.State.Tab do
           optional(:injection_ranges) => term(),
           optional(:search) => term(),
           optional(:editing) => MingaEditor.VimState.t(),
-          # Legacy: old contexts may have :vim instead of :editing
-          optional(:vim) => MingaEditor.VimState.t(),
           optional(:document_highlights) => term(),
-          optional(:agent_ui) => term(),
-          # Legacy fields kept for migration compatibility:
-          optional(:mode) => atom(),
-          optional(:mode_state) => term(),
-          optional(:reg) => term(),
-          optional(:marks) => term(),
-          optional(:last_jump_pos) => term(),
-          optional(:last_find_char) => term(),
-          optional(:change_recorder) => term(),
-          optional(:macro_recorder) => term()
+          optional(:agent_ui) => term()
         }
 
   @typedoc "Agent tab status (nil for file tabs)."

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -97,26 +97,29 @@ defmodule MingaEditor.State.SnapshotTest do
       assert restored.workspace.buffers.active == buf_b
     end
 
-    test "migrates legacy context with active_buffer field" do
+    test "older bare-field contexts are not migrated; only canonical keys are read" do
+      # Pre-#1440, contexts stored bare fields like :active_buffer / :mode and
+      # were silently migrated. Now restore_tab_context only reads canonical
+      # keys (those in WorkspaceState.field_names()), so legacy fields are
+      # ignored and the workspace falls back to whatever the live state already
+      # holds. No crash, no migration, no warning.
       {:ok, buf_a} = BufferServer.start_link(content: "a")
       {:ok, buf_b} = BufferServer.start_link(content: "b")
 
-      state = make_state(buffer: buf_a)
+      state = make_state(buffer: buf_a, mode: :normal, keymap_scope: :editor)
 
-      # Oldest format: bare fields like :active_buffer
-      ctx = %{
+      legacy_ctx = %{
         mode: :insert,
         mode_state: Mode.initial_state(),
-        keymap_scope: :editor,
         active_buffer: buf_b,
         active_buffer_index: 1
       }
 
-      restored = EditorState.restore_tab_context(state, ctx)
-      assert restored.workspace.keymap_scope == :editor
-      assert restored.workspace.editing.mode == :insert
-      assert restored.workspace.buffers.active == buf_b
-      assert restored.workspace.buffers.active_index == 1
+      restored = EditorState.restore_tab_context(state, legacy_ctx)
+
+      # The legacy keys are silently ignored — workspace fields stay as they were.
+      assert restored.workspace.editing.mode == :normal
+      assert restored.workspace.buffers.active == buf_a
     end
 
     test "handles empty context gracefully" do


### PR DESCRIPTION
Closes #1440.

## Summary

`restore_tab_context/2` previously supported three historical context shapes (the canonical flat format, an older nested `{:surface_state, …}` format, and the oldest bare-fields `{:active_buffer, :mode, :reg, …}` format) and ran two migration passes on every tab restore. Minga has not shipped publicly and nothing persists tab contexts to disk (`state/session.ex` never touches them), so the migration code only served in-process snapshots which are recreated on each editor boot.

Per the ticket's option (b): treat any older format as invalid and let the canonical reader silently skip non-canonical keys. Since nothing persisted them, no warning is needed in practice.

### Removed
- `maybe_migrate_legacy_context/2` (all 3 clauses)
- `maybe_migrate_vim_fields/1` (all clauses) and its `@dialyzer {:no_match, ...}` annotation
- `maybe_restore_ws/3` (only used by the migration)
- Legacy keys from `Tab.context()` `@type`: `:vim`, `:mode`, `:reg`, `:marks`, `:last_jump_pos`, `:last_find_char`, `:change_recorder`, `:macro_recorder`
- Legacy `:surface_state` and `:active_buffer` clauses from `Shell.Traditional.tab_has_active_buffer?/2`
- Now-unused `MingaEditor.State.Registers` alias from `state.ex`

Net: −145 / +16 in `state.ex`, `tab.ex`, `traditional.ex`, and `snapshot_test.exs`.

## Verification

| AC | How proved |
| --- | --- |
| 1. Migration functions removed | Both `maybe_migrate_legacy_context/2` and `maybe_migrate_vim_fields/1` are gone (`lib/minga_editor/state.ex`). `grep maybe_migrate lib/` returns no hits. |
| 2. `restore_tab_context/2` accepts only the canonical flat format | `state.ex` shows `restore_tab_context/2` reads via `WorkspaceState.field_names()` — no other format is recognized. |
| 3. Older-format contexts treated as invalid (option b) | New test "older bare-field contexts are not migrated; only canonical keys are read" verifies legacy keys are silently ignored — workspace fields stay as the live state already had them. No crash, no migration. Since nothing persists older formats, no log message is needed. |
| 4. `mix dialyzer` passes; `@dialyzer {:no_match, …}` annotation removed | `make lint` exit 0. The annotation is gone (lived only on `maybe_migrate_vim_fields/1`). |
| 5. Existing tab-restore tests pass; new test for legacy rejection | `mix test test/minga_editor/state/snapshot_test.exs` — 11/11 pass; `mix test.llm test/minga_editor/state/ test/minga_editor/shell/` — 484/484 pass. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)