### PR TITLE
refactor(state): introduce terminal_viewport + current_viewport accessors

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -377,11 +377,12 @@ defmodule MingaEditor do
     line_spacing = Config.get(:line_spacing) || 1.0
     effective_height = Viewport.effective_rows(height, line_spacing)
 
+    vp = Viewport.new(effective_height, width)
+
     new_state = %{
-      EditorState.update_workspace(
-        state,
-        &WorkspaceState.set_viewport(&1, Viewport.new(effective_height, width))
-      )
+      (state
+       |> EditorState.set_terminal_viewport(vp)
+       |> EditorState.update_workspace(&WorkspaceState.set_viewport(&1, vp)))
       | capabilities: caps,
         layout: nil
     }
@@ -424,11 +425,12 @@ defmodule MingaEditor do
     line_spacing = Config.get(:line_spacing) || 1.0
     effective_height = Viewport.effective_rows(height, line_spacing)
 
+    vp = Viewport.new(effective_height, width)
+
     new_state =
-      EditorState.update_workspace(
-        state,
-        &WorkspaceState.set_viewport(&1, Viewport.new(effective_height, width))
-      )
+      state
+      |> EditorState.set_terminal_viewport(vp)
+      |> EditorState.update_workspace(&WorkspaceState.set_viewport(&1, vp))
 
     # Invalidate the cached layout so resize_all_windows computes fresh
     # rectangles from the new viewport dimensions.

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -111,8 +111,8 @@ defmodule MingaEditor.Commands.Agent do
         # Build a windows context with an agent_chat window so the tab
         # renders through the buffer pipeline.
         win_id = 1
-        rows = max(state.workspace.viewport.rows, 1)
-        cols = max(state.workspace.viewport.cols, 1)
+        rows = max(state.terminal_viewport.rows, 1)
+        cols = max(state.terminal_viewport.cols, 1)
         agent_window = Window.new_agent_chat(win_id, agent_buf, rows, cols)
 
         windows = %Windows{
@@ -1040,7 +1040,7 @@ defmodule MingaEditor.Commands.Agent do
 
   @spec panel_height(state()) :: non_neg_integer()
   defp panel_height(state) do
-    div(state.workspace.viewport.rows * 35, 100)
+    div(state.terminal_viewport.rows * 35, 100)
   end
 
   @spec abort_if_active(state()) :: state()

--- a/lib/minga_editor/commands/lsp.ex
+++ b/lib/minga_editor/commands/lsp.ex
@@ -42,7 +42,7 @@ defmodule MingaEditor.Commands.Lsp do
 
       _ ->
         markdown = build_lsp_info_markdown(clients)
-        vp = state.workspace.viewport
+        vp = state.terminal_viewport
         popup = HoverPopup.new(markdown, div(vp.rows, 2), div(vp.cols, 4))
         popup = HoverPopup.focus(popup)
         EditorState.set_hover_popup(state, popup)

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -600,7 +600,7 @@ defmodule MingaEditor.Commands.Movement do
 
   @spec content_width(state()) :: pos_integer()
   defp content_width(state) do
-    vp = Viewport.new(state.workspace.viewport.rows, state.workspace.viewport.cols)
+    vp = Viewport.new(state.terminal_viewport.rows, state.terminal_viewport.cols)
     line_count = Buffer.line_count(state.workspace.buffers.active)
     Viewport.content_cols(vp, line_count)
   end
@@ -649,10 +649,10 @@ defmodule MingaEditor.Commands.Movement do
   # ── Viewport helpers for scroll commands ──────────────────────────────────
 
   # Delegates to EditorState shared helpers.
-  defp active_viewport(state), do: EditorState.active_window_viewport(state)
+  defp active_viewport(state), do: EditorState.current_viewport(state)
 
   defp put_active_viewport(state, new_vp),
-    do: EditorState.put_active_window_viewport(state, new_vp)
+    do: EditorState.update_current_viewport(state, new_vp)
 
   @spec scroll_margin(pid()) :: non_neg_integer()
   defp scroll_margin(buf) do

--- a/lib/minga_editor/completion_handling.ex
+++ b/lib/minga_editor/completion_handling.ex
@@ -645,12 +645,12 @@ defmodule MingaEditor.CompletionHandling do
 
     if buf do
       {line, col} = Buffer.cursor(buf)
-      vp = state.workspace.viewport
+      vp = state.terminal_viewport
       screen_row = max(line - vp.top + 1, 1)
       screen_col = min(col + 4, vp.cols - 1)
       {screen_row, screen_col}
     else
-      {div(state.workspace.viewport.rows, 2), div(state.workspace.viewport.cols, 2)}
+      {div(state.terminal_viewport.rows, 2), div(state.terminal_viewport.cols, 2)}
     end
   end
 

--- a/lib/minga_editor/floating_window.ex
+++ b/lib/minga_editor/floating_window.ex
@@ -20,7 +20,7 @@ defmodule MingaEditor.FloatingWindow do
         height: {:rows, 15},
         border: :rounded,
         theme: state.theme.popup,
-        viewport: {state.workspace.viewport.rows, state.workspace.viewport.cols}
+        viewport: {state.terminal_viewport.rows, state.terminal_viewport.cols}
       }
 
       draws = FloatingWindow.render(spec)

--- a/lib/minga_editor/frontend/emit/context.ex
+++ b/lib/minga_editor/frontend/emit/context.ex
@@ -80,7 +80,7 @@ defmodule MingaEditor.Frontend.Emit.Context do
       shell_state: state.shell_state,
       tab_bar: Map.get(state.shell_state, :tab_bar),
       buffers: state.workspace.buffers,
-      viewport: state.workspace.viewport,
+      viewport: state.terminal_viewport,
       file_tree: state.workspace.file_tree,
       highlight: state.workspace.highlight,
       agent_ui: state.workspace.agent_ui,

--- a/lib/minga_editor/input/completion.ex
+++ b/lib/minga_editor/input/completion.ex
@@ -107,7 +107,7 @@ defmodule MingaEditor.Input.Completion do
 
     # Popup position: same logic as CompletionUI
     {cursor_row, cursor_col} = cursor_screen_pos(state)
-    space_below = state.workspace.viewport.rows - cursor_row - 2
+    space_below = state.terminal_viewport.rows - cursor_row - 2
 
     popup_start_row =
       if space_below >= item_count do
@@ -121,8 +121,8 @@ defmodule MingaEditor.Input.Completion do
       Enum.map(Enum.take(visible, item_count), fn item -> String.length(item.label) + 4 end)
 
     popup_width = label_widths |> Enum.max(fn -> 20 end) |> max(20) |> min(50)
-    popup_width = min(popup_width, state.workspace.viewport.cols - cursor_col)
-    start_col = min(cursor_col, max(0, state.workspace.viewport.cols - popup_width))
+    popup_width = min(popup_width, state.terminal_viewport.cols - cursor_col)
+    start_col = min(cursor_col, max(0, state.terminal_viewport.cols - popup_width))
 
     clicked_idx = row - popup_start_row
 
@@ -151,7 +151,7 @@ defmodule MingaEditor.Input.Completion do
 
     if buf do
       {line, col} = Buffer.cursor(buf)
-      screen_row = line - state.workspace.viewport.top
+      screen_row = line - state.terminal_viewport.top
       total_lines = Buffer.line_count(buf)
 
       number_w =
@@ -160,7 +160,7 @@ defmodule MingaEditor.Input.Completion do
           else: Viewport.gutter_width(total_lines)
 
       gutter_w = MingaEditor.Renderer.Gutter.total_width(number_w)
-      screen_col = col + gutter_w - state.workspace.viewport.left
+      screen_col = col + gutter_w - state.terminal_viewport.left
 
       {max(screen_row, 0), max(screen_col, 0)}
     else

--- a/lib/minga_editor/input/picker.ex
+++ b/lib/minga_editor/input/picker.ex
@@ -124,7 +124,7 @@ defmodule MingaEditor.Input.Picker do
   defp bottom_click_index(state, picker, row) do
     {visible, _} = PickerData.visible_items(picker)
     item_count = length(visible)
-    prompt_row = state.workspace.viewport.rows - 1
+    prompt_row = state.terminal_viewport.rows - 1
     first_item_row = prompt_row - item_count
     row - first_item_row
   end
@@ -132,7 +132,7 @@ defmodule MingaEditor.Input.Picker do
   # Centered: items start at the top of the FloatingWindow interior.
   @spec centered_click_index(EditorState.t(), PickerData.t(), integer()) :: integer()
   defp centered_click_index(state, _picker, row) do
-    vp_rows = state.workspace.viewport.rows
+    vp_rows = state.terminal_viewport.rows
 
     # Match the 60%x70% dimensions used by PickerUI.render_centered
     box_h = max(div(vp_rows * 70, 100), 1)
@@ -146,8 +146,8 @@ defmodule MingaEditor.Input.Picker do
   # Returns true when {row, col} falls inside the centered picker's box.
   @spec inside_centered_box?(EditorState.t(), integer(), integer()) :: boolean()
   defp inside_centered_box?(state, row, col) do
-    vp_rows = state.workspace.viewport.rows
-    vp_cols = state.workspace.viewport.cols
+    vp_rows = state.terminal_viewport.rows
+    vp_cols = state.terminal_viewport.cols
 
     box_w = max(div(vp_cols * 60, 100), 1)
     box_h = max(div(vp_rows * 70, 100), 1)

--- a/lib/minga_editor/layout/gui.ex
+++ b/lib/minga_editor/layout/gui.ex
@@ -17,7 +17,7 @@ defmodule MingaEditor.Layout.GUI do
   """
   @spec compute(EditorState.t()) :: Layout.t()
   def compute(state) do
-    vp = state.workspace.viewport
+    vp = state.terminal_viewport
     terminal = {0, 0, vp.cols, vp.rows}
 
     # Minibuffer takes the last row (stays in Metal for command-line input).

--- a/lib/minga_editor/layout_preset.ex
+++ b/lib/minga_editor/layout_preset.ex
@@ -130,8 +130,8 @@ defmodule MingaEditor.LayoutPreset do
     else
       # Create a new agent chat window
       next_id = state.workspace.windows.next_id
-      rows = state.workspace.viewport.rows
-      cols = state.workspace.viewport.cols
+      rows = state.terminal_viewport.rows
+      cols = state.terminal_viewport.cols
       agent_window = Window.new_agent_chat(next_id, agent_buffer, rows, cols)
 
       # Split the active window to add the agent pane

--- a/lib/minga_editor/lsp_actions.ex
+++ b/lib/minga_editor/lsp_actions.ex
@@ -576,7 +576,7 @@ defmodule MingaEditor.LspActions do
 
           path ->
             uri = SyncServer.path_to_uri(path)
-            vp = state.workspace.viewport
+            vp = state.terminal_viewport
 
             params = %{
               "textDocument" => %{"uri" => uri},
@@ -630,14 +630,14 @@ defmodule MingaEditor.LspActions do
   end
 
   # Returns the viewport top for the active window, falling back to
-  # state.workspace.viewport.top. Uses EditorState.active_window_viewport when
-  # the state is a proper struct, otherwise reads state.workspace.viewport directly.
+  # state.terminal_viewport.top. Uses EditorState.current_viewport when
+  # the state is a proper struct, otherwise reads state.terminal_viewport directly.
   @spec effective_viewport_top(state()) :: non_neg_integer()
   defp effective_viewport_top(%EditorState{} = state) do
-    EditorState.active_window_viewport(state).top
+    EditorState.current_viewport(state).top
   end
 
-  defp effective_viewport_top(state), do: state.workspace.viewport.top
+  defp effective_viewport_top(state), do: state.terminal_viewport.top
 
   # ── Response handlers ──────────────────────────────────────────────────────
 
@@ -1471,12 +1471,12 @@ defmodule MingaEditor.LspActions do
     if buf do
       {line, col} = Buffer.cursor(buf)
       # Approximate screen position: line offset from viewport top + gutter
-      vp = state.workspace.viewport
+      vp = state.terminal_viewport
       screen_row = line - vp.top + 1
       screen_col = col + 4
       {clamp(screen_row, 1, vp.rows - 2), clamp(screen_col, 0, vp.cols - 1)}
     else
-      {div(state.workspace.viewport.rows, 2), div(state.workspace.viewport.cols, 2)}
+      {div(state.terminal_viewport.rows, 2), div(state.terminal_viewport.cols, 2)}
     end
   end
 

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -100,31 +100,31 @@ defmodule MingaEditor.Mouse do
       ) do
     total_lines = Buffer.line_count(buf)
     lines = scroll_lines(state)
-    vp = active_window_viewport(state)
+    vp = current_viewport(state)
     new_vp = scroll_viewport(vp, lines, total_lines)
-    put_active_window_viewport(state, new_vp) |> clamp_cursor_to_viewport(:down)
+    update_current_viewport(state, new_vp) |> clamp_cursor_to_viewport(:down)
   end
 
   def handle(%{workspace: %{buffers: %{active: buf}}} = state, _r, _c, :wheel_up, _m, :press, _cc) do
     total_lines = Buffer.line_count(buf)
     lines = scroll_lines(state)
-    vp = active_window_viewport(state)
+    vp = current_viewport(state)
     new_vp = scroll_viewport(vp, -lines, total_lines)
-    put_active_window_viewport(state, new_vp) |> clamp_cursor_to_viewport(:up)
+    update_current_viewport(state, new_vp) |> clamp_cursor_to_viewport(:up)
   end
 
   # ── Scroll wheel (horizontal) ──
 
   def handle(state, _r, _c, :wheel_right, _m, :press, _cc) do
-    vp = active_window_viewport(state)
+    vp = current_viewport(state)
     new_left = vp.left + @scroll_cols
-    put_active_window_viewport(state, %{vp | left: new_left})
+    update_current_viewport(state, %{vp | left: new_left})
   end
 
   def handle(state, _r, _c, :wheel_left, _m, :press, _cc) do
-    vp = active_window_viewport(state)
+    vp = current_viewport(state)
     new_left = max(vp.left - @scroll_cols, 0)
-    put_active_window_viewport(state, %{vp | left: new_left})
+    update_current_viewport(state, %{vp | left: new_left})
   end
 
   # ── Middle-click paste ──
@@ -995,7 +995,7 @@ defmodule MingaEditor.Mouse do
   end
 
   @spec scroll_left(state(), pid()) :: non_neg_integer()
-  defp scroll_left(state, _buf), do: active_window_viewport(state).left
+  defp scroll_left(state, _buf), do: current_viewport(state).left
 
   # ── Viewport helpers ───────────────────────────────────────────────────────
 
@@ -1016,7 +1016,7 @@ defmodule MingaEditor.Mouse do
   # - Scrolling DOWN: enforce top margin (push cursor toward bottom)
   @spec clamp_cursor_to_viewport(state(), :up | :down) :: state()
   defp clamp_cursor_to_viewport(%{workspace: %{buffers: %{active: buf}}} = state, direction) do
-    vp = active_window_viewport(state)
+    vp = current_viewport(state)
     {cursor_line, cursor_col} = Buffer.cursor(buf)
     {first_line, last_line} = Viewport.visible_range(vp)
 
@@ -1069,13 +1069,13 @@ defmodule MingaEditor.Mouse do
 
   @spec maybe_auto_scroll(state(), integer()) :: state()
   defp maybe_auto_scroll(%{workspace: %{buffers: %{active: buf}}} = state, row) when row <= 0 do
-    vp = active_window_viewport(state)
+    vp = current_viewport(state)
     page_move(buf, vp, -1)
     state
   end
 
   defp maybe_auto_scroll(%{workspace: %{buffers: %{active: buf}}} = state, row) do
-    vp = active_window_viewport(state)
+    vp = current_viewport(state)
     scroll_threshold = Viewport.content_rows(vp) - 1
     maybe_scroll_down(state, buf, vp, row, scroll_threshold)
   end
@@ -1258,10 +1258,10 @@ defmodule MingaEditor.Mouse do
   end
 
   # Delegates to EditorState shared helpers.
-  defp active_window_viewport(state), do: EditorState.active_window_viewport(state)
+  defp current_viewport(state), do: EditorState.current_viewport(state)
 
-  defp put_active_window_viewport(state, new_vp),
-    do: EditorState.put_active_window_viewport(state, new_vp)
+  defp update_current_viewport(state, new_vp),
+    do: EditorState.update_current_viewport(state, new_vp)
 
   @spec find_click_region(
           [MingaEditor.Shell.Traditional.Modeline.click_region()],

--- a/lib/minga_editor/mouse_hover_tooltip.ex
+++ b/lib/minga_editor/mouse_hover_tooltip.ex
@@ -29,7 +29,7 @@ defmodule MingaEditor.MouseHoverTooltip do
   def check_hover(%{workspace: %{mouse: %{hover_pos: {row, col}}}} = state) do
     # Convert screen position to buffer position
     buf = state.workspace.buffers.active
-    vp = state.workspace.viewport
+    vp = state.terminal_viewport
 
     buf_line = row + vp.top - 1
     # Approximate: col minus gutter width

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -96,8 +96,8 @@ defmodule MingaEditor.PickerUI do
 
       _ ->
         # Use terminal height minus 3 (separator + prompt + at least 1 buffer line visible)
-        max_vis = state.workspace.viewport.rows - 3
-        max_vis = max(5, min(max_vis, state.workspace.viewport.rows - 3))
+        max_vis = state.terminal_viewport.rows - 3
+        max_vis = max(5, min(max_vis, state.terminal_viewport.rows - 3))
         picker = Picker.new(items, title: source_module.title(), max_visible: max_vis)
 
         # Clear whichkey state if active
@@ -848,8 +848,8 @@ defmodule MingaEditor.PickerUI do
        ) do
     ctx = Context.from_editor_state(state)
     items = new_source.candidates(ctx)
-    max_vis = state.workspace.viewport.rows - 3
-    max_vis = max(5, min(max_vis, state.workspace.viewport.rows - 3))
+    max_vis = state.terminal_viewport.rows - 3
+    max_vis = max(5, min(max_vis, state.terminal_viewport.rows - 3))
     picker = Picker.new(items, title: new_source.title(), max_visible: max_vis)
     layout = MingaEditor.UI.Picker.Source.layout(new_source)
     original = orig_src || current_source
@@ -874,8 +874,8 @@ defmodule MingaEditor.PickerUI do
        ) do
     ctx = Context.from_editor_state(state)
     items = orig.candidates(ctx)
-    max_vis = state.workspace.viewport.rows - 3
-    max_vis = max(5, min(max_vis, state.workspace.viewport.rows - 3))
+    max_vis = state.terminal_viewport.rows - 3
+    max_vis = max(5, min(max_vis, state.terminal_viewport.rows - 3))
     picker = Picker.new(items, title: orig.title(), max_visible: max_vis)
     layout = MingaEditor.UI.Picker.Source.layout(orig)
 

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -70,6 +70,8 @@ defmodule MingaEditor.RenderPipeline.Input do
     :parser_status,
     # Workspace as a plain map (enables state.workspace.X pattern-matching)
     :workspace,
+    # Terminal-level viewport (screen dimensions reported by frontend on resize)
+    terminal_viewport: Viewport.new(24, 80),
     # Render-pipeline caches (replaces process-dictionary entries)
     caches: %Caches{}
   ]
@@ -110,6 +112,7 @@ defmodule MingaEditor.RenderPipeline.Input do
           lsp: LSPState.t(),
           parser_status: atom(),
           caches: Caches.t(),
+          terminal_viewport: Viewport.t(),
           workspace: workspace()
         }
 
@@ -137,6 +140,7 @@ defmodule MingaEditor.RenderPipeline.Input do
       lsp: state.lsp,
       parser_status: state.parser_status,
       caches: state.caches,
+      terminal_viewport: state.terminal_viewport,
       workspace: %{
         windows: ws.windows,
         buffers: ws.buffers,
@@ -210,8 +214,8 @@ defmodule MingaEditor.RenderPipeline.Input do
       # Agent state (status, pending approval)
       input.shell_state |> Map.get(:agent),
       # Viewport dimensions (overlay positioning)
-      input.workspace.viewport.rows,
-      input.workspace.viewport.cols,
+      input.terminal_viewport.rows,
+      input.terminal_viewport.cols,
       # Window splits (separator rendering)
       input.workspace.windows.tree,
       # Bottom panel

--- a/lib/minga_editor/renderer.ex
+++ b/lib/minga_editor/renderer.ex
@@ -59,9 +59,9 @@ defmodule MingaEditor.Renderer do
   """
   @spec render_dashboard(state()) :: state()
   def render_dashboard(%{workspace: %{buffers: %{active: nil}}} = state) do
-    rows = state.workspace.viewport.rows
-    cols = state.workspace.viewport.cols
-    viewport = state.workspace.viewport
+    rows = state.terminal_viewport.rows
+    cols = state.terminal_viewport.cols
+    viewport = state.terminal_viewport
 
     # Dashboard state is initialized by the editor when buffers empty,
     # but fall back to an empty state if somehow nil.

--- a/lib/minga_editor/shell/board.ex
+++ b/lib/minga_editor/shell/board.ex
@@ -218,7 +218,7 @@ defmodule MingaEditor.Shell.Board do
   @spec compute_board_tui_layout(term()) :: MingaEditor.Layout.t()
   defp compute_board_tui_layout(editor_state) do
     alias MingaEditor.Layout
-    vp = editor_state.workspace.viewport
+    vp = editor_state.terminal_viewport
     {rows, cols} = {vp.rows, vp.cols}
 
     if BoardState.grid_view?(editor_state.shell_state) do
@@ -273,7 +273,7 @@ defmodule MingaEditor.Shell.Board do
   defp build_zoom_context_bar(editor_state) do
     board = editor_state.shell_state
     card = BoardState.zoomed(board)
-    cols = editor_state.workspace.viewport.cols
+    cols = editor_state.terminal_viewport.cols
     theme = editor_state.theme
 
     if card do
@@ -356,7 +356,7 @@ defmodule MingaEditor.Shell.Board do
       %{editor_state | caches: new_caches}
     else
       # TUI: render card grid as cell grid commands
-      vp = editor_state.workspace.viewport
+      vp = editor_state.terminal_viewport
       board = editor_state.shell_state
 
       splash_draws =

--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -38,7 +38,7 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
           Cursor.t() | nil
         ) :: Chrome.t()
   def build(state, layout, _scrolls, cursor_info) do
-    full_viewport = state.workspace.viewport
+    full_viewport = state.terminal_viewport
 
     # Global status bar (one render for the focused window)
     {status_bar_draws, status_bar_data, modeline_click_regions} =
@@ -147,8 +147,8 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
       %{
         cursor_row: cur_row,
         cursor_col: cur_col,
-        viewport_rows: state.workspace.viewport.rows,
-        viewport_cols: state.workspace.viewport.cols
+        viewport_rows: state.terminal_viewport.rows,
+        viewport_cols: state.terminal_viewport.cols
       },
       state.theme
     )

--- a/lib/minga_editor/shell/traditional/layout/tui.ex
+++ b/lib/minga_editor/shell/traditional/layout/tui.ex
@@ -27,7 +27,7 @@ defmodule MingaEditor.Shell.Traditional.Layout.TUI do
   """
   @spec compute(EditorState.t() | map()) :: Layout.t()
   def compute(state) do
-    vp = state.workspace.viewport
+    vp = state.terminal_viewport
     terminal = {0, 0, vp.cols, vp.rows}
 
     # 0. Tab bar takes row 0.
@@ -189,8 +189,8 @@ defmodule MingaEditor.Shell.Traditional.Layout.TUI do
          total_cols
        ) do
     # Same logic as compute/1: reserve 2 rows at the bottom when possible, else 1.
-    bottom_reserve = if state.workspace.viewport.rows - 2 > @content_start, do: 2, else: 1
-    tree_height = state.workspace.viewport.rows - @content_start - bottom_reserve
+    bottom_reserve = if state.terminal_viewport.rows - 2 > @content_start, do: 2, else: 1
+    tree_height = state.terminal_viewport.rows - @content_start - bottom_reserve
     min_editor_w = 3
     max_tree_w = max(total_cols - 1 - min_editor_w, 1)
     clamped_tw = min(tw, max_tree_w)
@@ -208,7 +208,7 @@ defmodule MingaEditor.Shell.Traditional.Layout.TUI do
     panel = AgentAccess.panel(state)
 
     if panel.visible do
-      panel_height = div(state.workspace.viewport.rows * 35, 100)
+      panel_height = div(state.terminal_viewport.rows * 35, 100)
       editor_height = remaining_height - panel_height
       agent_row = @content_start + editor_height
       agent_rect = {agent_row, editor_col, editor_width, panel_height}

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -643,12 +643,13 @@ defmodule MingaEditor.State do
   minibuffer row and reserving space for the file tree panel when open.
   """
   @spec screen_rect(t()) :: WindowTree.rect()
-  def screen_rect(%__MODULE__{workspace: %{viewport: vp, file_tree: %{tree: nil}}}) do
+  def screen_rect(%__MODULE__{terminal_viewport: vp, workspace: %{file_tree: %{tree: nil}}}) do
     {0, 0, vp.cols, vp.rows - 1}
   end
 
   def screen_rect(%__MODULE__{
-        workspace: %{viewport: vp, file_tree: %{tree: %FileTree{width: tw}}}
+        terminal_viewport: vp,
+        workspace: %{file_tree: %{tree: %FileTree{width: tw}}}
       }) do
     # Tree occupies columns 0..tw-1, separator at column tw,
     # editor content starts at column tw+1.
@@ -661,7 +662,10 @@ defmodule MingaEditor.State do
   @spec tree_rect(t()) :: WindowTree.rect() | nil
   def tree_rect(%__MODULE__{workspace: %{file_tree: %{tree: nil}}}), do: nil
 
-  def tree_rect(%__MODULE__{workspace: %{viewport: vp, file_tree: %{tree: %FileTree{width: tw}}}}) do
+  def tree_rect(%__MODULE__{
+        terminal_viewport: vp,
+        workspace: %{file_tree: %{tree: %FileTree{width: tw}}}
+      }) do
     # Row 0 is the tab bar; file tree starts at row 1.
     {1, 0, tw, vp.rows - 2}
   end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -88,6 +88,7 @@ defmodule MingaEditor.State do
             keymap_server: @default_keymap_server,
             options_server: @default_options_server,
             workspace: nil,
+            terminal_viewport: Viewport.new(24, 80),
             editing_model: :vim,
             shell: MingaEditor.Shell.Traditional,
             shell_state: %ShellState{},
@@ -121,6 +122,7 @@ defmodule MingaEditor.State do
           keymap_server: keymap_server(),
           options_server: options_server(),
           workspace: WorkspaceState.t(),
+          terminal_viewport: Viewport.t(),
           editing_model: :vim | :cua,
           shell: module(),
           shell_state: ShellState.t() | BoardState.t(),
@@ -551,31 +553,54 @@ defmodule MingaEditor.State do
   end
 
   @doc """
-  Returns the active window's viewport, falling back to `state.workspace.viewport`
-  when no window is active. Use this for scroll commands that need to
-  read/write the viewport of the focused window (not the terminal-level
-  viewport).
+  Returns the terminal-level viewport: total screen rows/cols reported by
+  the frontend on resize. Used for screen-spanning chrome (picker,
+  popups, dashboard, completion menu placement) and for layout
+  computation that needs the editor's full canvas.
+
+  This is distinct from `current_viewport/1`, which scopes to the
+  active window's viewport.
   """
-  @spec active_window_viewport(t()) :: Viewport.t()
-  def active_window_viewport(%__MODULE__{} = state) do
+  @spec terminal_viewport(t()) :: Viewport.t()
+  def terminal_viewport(%__MODULE__{terminal_viewport: vp}), do: vp
+
+  @doc """
+  Stores a new terminal viewport. Called by the editor's resize handler
+  when the frontend reports a new screen size.
+  """
+  @spec set_terminal_viewport(t(), Viewport.t()) :: t()
+  def set_terminal_viewport(%__MODULE__{} = state, %Viewport{} = vp) do
+    %{state | terminal_viewport: vp}
+  end
+
+  @doc """
+  Returns the viewport for the user's current focus: the active window's
+  viewport when a window is active, otherwise a derived terminal-size
+  viewport (the no-window dashboard case). Use this for scroll commands
+  that read/write the focused window's viewport.
+
+  Replaces the older `active_window_viewport/1` (renamed for symmetry
+  with `terminal_viewport/1`).
+  """
+  @spec current_viewport(t()) :: Viewport.t()
+  def current_viewport(%__MODULE__{} = state) do
     case active_window_struct(state) do
-      nil -> state.workspace.viewport
+      nil -> terminal_viewport(state)
       %Window{viewport: vp} -> vp
     end
   end
 
   @doc """
-  Updates the active window's viewport. Falls back to updating
-  `state.workspace.viewport` when no window is active.
-  """
-  @spec put_active_window_viewport(t(), Viewport.t()) :: t()
-  def put_active_window_viewport(%__MODULE__{} = state, new_vp) do
-    case active_window_struct(state) do
-      nil ->
-        put_in(state.workspace.viewport, new_vp)
+  Updates the active window's viewport. No-op when no window is active
+  (the dashboard case has no per-window viewport to write).
 
-      %Window{id: win_id} ->
-        update_window(state, win_id, fn w -> %{w | viewport: new_vp} end)
+  Replaces the older `put_active_window_viewport/2`.
+  """
+  @spec update_current_viewport(t(), Viewport.t()) :: t()
+  def update_current_viewport(%__MODULE__{} = state, %Viewport{} = new_vp) do
+    case active_window_struct(state) do
+      nil -> state
+      %Window{id: win_id} -> update_window(state, win_id, fn w -> %{w | viewport: new_vp} end)
     end
   end
 
@@ -906,8 +931,8 @@ defmodule MingaEditor.State do
   @spec build_file_tab_defaults(t()) :: Tab.context()
   defp build_file_tab_defaults(state) do
     win_id = state.workspace.windows.next_id
-    rows = state.workspace.viewport.rows
-    cols = state.workspace.viewport.cols
+    rows = state.terminal_viewport.rows
+    cols = state.terminal_viewport.cols
     buf = state.workspace.buffers.active
 
     windows =
@@ -937,7 +962,7 @@ defmodule MingaEditor.State do
       },
       windows: windows,
       file_tree: %FileTreeState{project_root: state.workspace.file_tree.project_root},
-      viewport: state.workspace.viewport,
+      viewport: state.terminal_viewport,
       mouse: %Mouse{},
       highlight: %Highlighting{},
       lsp_pending: %{},
@@ -970,7 +995,7 @@ defmodule MingaEditor.State do
       },
       windows: windows,
       file_tree: %FileTreeState{project_root: state.workspace.file_tree.project_root},
-      viewport: state.workspace.viewport,
+      viewport: state.terminal_viewport,
       mouse: %Mouse{},
       highlight: %Highlighting{},
       lsp_pending: %{},

--- a/lib/minga_editor/ui/picker/context.ex
+++ b/lib/minga_editor/ui/picker/context.ex
@@ -85,7 +85,7 @@ defmodule MingaEditor.UI.Picker.Context do
       editing: state.workspace.editing,
       file_tree: Map.get(state.workspace, :file_tree),
       search: state.workspace.search,
-      viewport: state.workspace.viewport,
+      viewport: state.terminal_viewport,
       tab_bar: state.shell_state.tab_bar,
       agent_session: agent_session,
       picker_ui: picker_ui,

--- a/lib/minga_editor/ui/popup/lifecycle.ex
+++ b/lib/minga_editor/ui/popup/lifecycle.ex
@@ -164,7 +164,7 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   @spec inside_float_box?(state(), Window.t(), integer(), integer()) :: boolean()
   defp inside_float_box?(state, window, row, col) do
     rule = window.popup_meta.rule
-    vp = state.workspace.viewport
+    vp = state.terminal_viewport
 
     box_w = resolve_float_dim(float_width(rule), vp.cols)
     box_h = resolve_float_dim(float_height(rule), vp.rows)
@@ -183,7 +183,7 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   @spec render_float_overlay(state(), Window.t()) :: DisplayList.Overlay.t()
   defp render_float_overlay(state, window) do
     rule = window.popup_meta.rule
-    vp = state.workspace.viewport
+    vp = state.terminal_viewport
     theme = state.theme.popup
 
     # Build content draws from the buffer

--- a/test/minga_editor/input/picker_mouse_test.exs
+++ b/test/minga_editor/input/picker_mouse_test.exs
@@ -28,11 +28,14 @@ defmodule MingaEditor.Input.PickerMouseTest do
     picker =
       PickerData.new(items, max_visible: 10, title: "Test")
 
+    vp = Viewport.new(30, 80)
+
     %EditorState{
       port_manager: nil,
+      terminal_viewport: vp,
       workspace: %MingaEditor.Workspace.State{
         editing: VimState.new(),
-        viewport: Viewport.new(30, 80)
+        viewport: vp
       },
       shell_state: %MingaEditor.Shell.Traditional.State{
         modal:

--- a/test/minga_editor/layout_test.exs
+++ b/test/minga_editor/layout_test.exs
@@ -16,10 +16,13 @@ defmodule MingaEditor.LayoutTest do
   # ── Helpers ──────────────────────────────────────────────────────────────────
 
   defp new_state(rows, cols) do
+    vp = Viewport.new(rows, cols)
+
     %EditorState{
       port_manager: nil,
+      terminal_viewport: vp,
       workspace: %MingaEditor.Workspace.State{
-        viewport: Viewport.new(rows, cols),
+        viewport: vp,
         editing: VimState.new()
       }
     }
@@ -427,7 +430,8 @@ defmodule MingaEditor.LayoutTest do
       assert layout.file_tree != nil
       assert layout.agent_panel != nil
 
-      short_state = %{state | workspace: %{state.workspace | viewport: Viewport.new(7, 80)}}
+      vp = Viewport.new(7, 80)
+      short_state = %{state | workspace: %{state.workspace | viewport: vp}, terminal_viewport: vp}
       layout = Layout.compute(short_state)
       assert layout.agent_panel == nil
       assert layout.file_tree != nil
@@ -436,7 +440,14 @@ defmodule MingaEditor.LayoutTest do
     test "shrinking width collapses file tree, agent panel unaffected" do
       state = new_state(24, 80) |> with_window() |> with_file_tree(20) |> with_agent_panel()
 
-      narrow_state = %{state | workspace: %{state.workspace | viewport: Viewport.new(24, 25)}}
+      vp = Viewport.new(24, 25)
+
+      narrow_state = %{
+        state
+        | workspace: %{state.workspace | viewport: vp},
+          terminal_viewport: vp
+      }
+
       layout = Layout.compute(narrow_state)
       assert layout.file_tree == nil
       assert layout.agent_panel != nil
@@ -448,7 +459,8 @@ defmodule MingaEditor.LayoutTest do
       assert layout.agent_panel == nil
       assert layout.file_tree == nil
 
-      big_state = %{state | workspace: %{state.workspace | viewport: Viewport.new(30, 100)}}
+      vp = Viewport.new(30, 100)
+      big_state = %{state | workspace: %{state.workspace | viewport: vp}, terminal_viewport: vp}
       layout = Layout.compute(big_state)
       assert layout.agent_panel != nil
       assert layout.file_tree != nil
@@ -462,7 +474,8 @@ defmodule MingaEditor.LayoutTest do
       state = new_state(24, 80) |> with_window()
       layout1 = Layout.compute(state)
 
-      state2 = %{state | workspace: %{state.workspace | viewport: Viewport.new(40, 120)}}
+      vp = Viewport.new(40, 120)
+      state2 = %{state | workspace: %{state.workspace | viewport: vp}, terminal_viewport: vp}
       layout2 = Layout.compute(state2)
 
       assert layout2.terminal == {0, 0, 120, 40}

--- a/test/minga_editor/lsp_actions_test.exs
+++ b/test/minga_editor/lsp_actions_test.exs
@@ -377,13 +377,13 @@ defmodule MingaEditor.LspActionsTest do
 
       state = %{fake_state() | backend: :zig}
 
-      ws = %{
-        state.workspace
-        | buffers: %{state.workspace.buffers | active: buf},
-          viewport: %{state.workspace.viewport | top: 10}
-      }
+      ws = %{state.workspace | buffers: %{state.workspace.buffers | active: buf}}
 
-      state = %{state | workspace: ws}
+      state = %{
+        state
+        | workspace: ws,
+          terminal_viewport: %{state.terminal_viewport | top: 10}
+      }
 
       result = LspActions.schedule_inlay_hints_on_scroll(state)
       assert result.lsp.inlay_hint_debounce_timer != nil
@@ -398,13 +398,13 @@ defmodule MingaEditor.LspActionsTest do
 
       state = fake_state()
 
-      ws = %{
-        state.workspace
-        | buffers: %{state.workspace.buffers | active: buf},
-          viewport: %{state.workspace.viewport | top: 10}
-      }
+      ws = %{state.workspace | buffers: %{state.workspace.buffers | active: buf}}
 
-      state = %{state | workspace: ws}
+      state = %{
+        state
+        | workspace: ws,
+          terminal_viewport: %{state.terminal_viewport | top: 10}
+      }
 
       result = LspActions.schedule_inlay_hints_on_scroll(state)
       assert result.lsp.inlay_hint_debounce_timer == nil
@@ -416,21 +416,18 @@ defmodule MingaEditor.LspActionsTest do
 
       state = %{fake_state() | backend: :zig}
 
-      ws = %{
-        state.workspace
-        | buffers: %{state.workspace.buffers | active: buf},
-          viewport: %{state.workspace.viewport | top: 5}
-      }
+      ws = %{state.workspace | buffers: %{state.workspace.buffers | active: buf}}
 
-      state = %{state | workspace: ws}
+      state = %{
+        state
+        | workspace: ws,
+          terminal_viewport: %{state.terminal_viewport | top: 5}
+      }
 
       state1 = LspActions.schedule_inlay_hints_on_scroll(state)
       timer1 = state1.lsp.inlay_hint_debounce_timer
 
-      state2 = %{
-        state1
-        | workspace: %{state1.workspace | viewport: %{state1.workspace.viewport | top: 15}}
-      }
+      state2 = %{state1 | terminal_viewport: %{state1.terminal_viewport | top: 15}}
 
       state2 = LspActions.schedule_inlay_hints_on_scroll(state2)
       timer2 = state2.lsp.inlay_hint_debounce_timer
@@ -621,10 +618,13 @@ defmodule MingaEditor.LspActionsTest do
   # ── Helpers ────────────────────────────────────────────────────────────────
 
   defp fake_state do
+    vp = Viewport.new(24, 80)
+
     %EditorState{
       port_manager: nil,
+      terminal_viewport: vp,
       workspace: %WorkspaceState{
-        viewport: Viewport.new(24, 80),
+        viewport: vp,
         highlight: %Highlighting{}
       }
     }

--- a/test/support/render_pipeline_test_helpers.ex
+++ b/test/support/render_pipeline_test_helpers.ex
@@ -40,10 +40,13 @@ defmodule MingaEditor.RenderPipeline.TestHelpers do
     win_id = 1
     window = Window.new(win_id, buf, rows, cols)
 
+    vp = Viewport.new(rows, cols)
+
     %EditorState{
       port_manager: self(),
+      terminal_viewport: vp,
       workspace: %MingaEditor.Workspace.State{
-        viewport: Viewport.new(rows, cols),
+        viewport: vp,
         editing: VimState.new(),
         buffers: %Buffers{active: buf, list: [buf], active_index: 0},
         windows: %Windows{


### PR DESCRIPTION
Closes #1436.

## Summary

Introduces a top-level `state.terminal_viewport` field that holds the screen-level viewport (rows/cols reported by the frontend on resize), distinct from per-window viewports. Migrates all 60+ direct `state.workspace.viewport` readers — the overwhelmingly common case is chrome/popup/picker/dashboard positioning and layout sizing, all of which want terminal dimensions, not "active window viewport with workspace fallback."

The discovered scope: while the ticket framed this as a small mechanical rename, the audit showed that `workspace.viewport` was effectively serving as terminal-size storage everywhere (60+ direct reads across 22 files). The clean fix moves that storage to a top-level field and reserves the active-window concept for the renamed accessors.

### Renames
- `active_window_viewport/1` → `current_viewport/1` (returns active window's viewport, falls back to terminal_viewport when no window is active — the dashboard case).
- `put_active_window_viewport/2` → `update_current_viewport/2` (no-op when no window is active, instead of writing to `workspace.viewport`).

### New
- `MingaEditor.State.terminal_viewport/1` — accessor for the new field.
- `MingaEditor.State.set_terminal_viewport/2` — writer used by the resize handler.
- `state.terminal_viewport` field on EditorState (default `Viewport.new(24, 80)`).
- Same `terminal_viewport` field on `RenderPipeline.Input` so pipeline stages read it directly without going through the workspace.

### Migration scope
- 22 lib files updated (mechanical `state.workspace.viewport` → `state.terminal_viewport`).
- 4 test setup helpers updated (`base_state` in `render_pipeline_test_helpers`, `new_state` in `layout_test`, `fake_state` in `lsp_actions_test`, `picker_state` in `picker_mouse_test`) to populate both fields since those bypass the resize handler.

### Deferred
The workspace.viewport field is **not** removed in this PR. Both fields are written on resize so existing readers still work. AC #1 (strict removal) requires:
- Removing `:viewport` from `WorkspaceState.field_names()` (snapshot semantics change)
- Removing `:viewport` from `Tab.context()` type and all `build_*_tab_defaults` helpers
- Removing the field from `WorkspaceState`'s `defstruct` and `@enforce_keys`

Each of those is a small follow-up; deferring keeps this PR mergeable without re-touching tab-context migration paths (which were just cleaned up in #1468).

## Verification

| AC | How proved |
| --- | --- |
| 1. `state.workspace.viewport` removed | **Partially deferred.** The new accessors and storage exist; readers migrated; the field itself stays as a parallel write during the transition. Documented above. |
| 2. `current_viewport/1` replaces `active_window_viewport/1` | Done; rename + falls back to `terminal_viewport` instead of `workspace.viewport`. |
| 3. `update_current_viewport/2` replaces `put_active_window_viewport/2` | Done; now a true no-op when no window is active (instead of writing to `workspace.viewport`). |
| 4. All direct `state.workspace.viewport` readers updated | Done; 22 files migrated. `grep -rln 'state.workspace.viewport\|input.workspace.viewport\|editor_state.workspace.viewport' lib --include='*.ex'` returns no matches outside `state.ex`'s own field setup. |
| 5. Existing tests pass; snapshot tests byte-identical | `mix test.llm` — 7,526 tests, 0 failures. `make lint` exit 0. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)