### PR TITLE
refactor(editor): introduce Renderer.Server process behind feature flag (#1432 PR-2)

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -271,7 +271,7 @@ defmodule MingaEditor do
       {:ok, pid} ->
         new_state = register_buffer(state, pid, file_path)
         new_state = AgentLifecycle.maybe_set_auto_context(new_state, file_path, pid)
-        new_state = Renderer.render(new_state)
+        new_state = Renderer.render_or_async(new_state)
         {:reply, :ok, new_state}
 
       {:error, reason} ->
@@ -307,13 +307,13 @@ defmodule MingaEditor do
           state
       end
 
-    new_state = Renderer.render(new_state)
+    new_state = Renderer.render_or_async(new_state)
     {:reply, result, new_state}
   end
 
   def handle_call({:api_execute_command, cmd}, _from, state) do
     new_state = dispatch_command(state, cmd)
-    new_state = Renderer.render(new_state)
+    new_state = Renderer.render_or_async(new_state)
     {:reply, :ok, new_state}
   end
 
@@ -327,7 +327,7 @@ defmodule MingaEditor do
           EditorState.update_window(state, id, &Window.set_fold_ranges(&1, ranges))
       end
 
-    new_state = Renderer.render(new_state)
+    new_state = Renderer.render_or_async(new_state)
     {:reply, :ok, new_state}
   end
 
@@ -363,7 +363,7 @@ defmodule MingaEditor do
   end
 
   def handle_cast(:render, state) do
-    state = Renderer.render(state)
+    state = Renderer.render_or_async(state)
     {:noreply, state}
   end
 
@@ -387,7 +387,7 @@ defmodule MingaEditor do
     }
 
     Startup.send_font_config(new_state)
-    new_state = Renderer.render(new_state)
+    new_state = Renderer.render_or_async(new_state)
     # Setup highlighting after first paint with correct viewport
     new_state = setup_highlight_or_defer(new_state)
 
@@ -434,7 +434,7 @@ defmodule MingaEditor do
     # rectangles from the new viewport dimensions.
     new_state = Layout.invalidate(new_state)
     new_state = resize_all_windows(new_state)
-    new_state = Renderer.render(new_state)
+    new_state = Renderer.render_or_async(new_state)
     {:noreply, new_state}
   end
 
@@ -457,7 +457,7 @@ defmodule MingaEditor do
   # ── Paste event (bracketed paste from TUI, Cmd+V from GUI) ──
   def handle_info({:minga_input, {:paste_event, text}}, state) do
     new_state = handle_paste_event(state, text)
-    new_state = Renderer.render(new_state)
+    new_state = Renderer.render_or_async(new_state)
     {:noreply, new_state}
   end
 
@@ -465,7 +465,7 @@ defmodule MingaEditor do
   def handle_info({:file_changed_on_disk, path}, state) do
     new_state = FileWatcherHelpers.handle_file_change(state, path)
     new_state = log_message(new_state, "External change detected: #{path}")
-    new_state = Renderer.render(new_state)
+    new_state = Renderer.render_or_async(new_state)
     {:noreply, new_state}
   end
 
@@ -506,7 +506,7 @@ defmodule MingaEditor do
     if ref == state.shell_state.whichkey.timer do
       wk = EditorState.whichkey(state)
       new_state = EditorState.set_whichkey(state, %{wk | show: true})
-      {:noreply, Renderer.render(new_state)}
+      {:noreply, Renderer.render_or_async(new_state)}
     else
       # Stale timer — ignore.
       {:noreply, state}
@@ -574,27 +574,27 @@ defmodule MingaEditor do
       {:completion_resolve, pending} ->
         new_state = put_in(state.workspace.lsp_pending, pending)
         new_state = CompletionHandling.handle_resolve_response(new_state, result)
-        {:noreply, Renderer.render(new_state)}
+        {:noreply, Renderer.render_or_async(new_state)}
 
       {:signature_help, pending} ->
         new_state = put_in(state.workspace.lsp_pending, pending)
         new_state = CompletionHandling.handle_signature_help_response(new_state, result)
-        {:noreply, Renderer.render(new_state)}
+        {:noreply, Renderer.render_or_async(new_state)}
 
       {{:semantic_tokens, buf_pid}, pending} ->
         new_state = put_in(state.workspace.lsp_pending, pending)
         new_state = SemanticTokenSync.handle_response(new_state, buf_pid, result)
-        {:noreply, Renderer.render(new_state)}
+        {:noreply, Renderer.render_or_async(new_state)}
 
       {kind, pending} when is_atom(kind) ->
         new_state = put_in(state.workspace.lsp_pending, pending)
         new_state = dispatch_lsp_response(kind, new_state, result)
-        {:noreply, Renderer.render(new_state)}
+        {:noreply, Renderer.render_or_async(new_state)}
 
       {kind, pending} when is_tuple(kind) ->
         new_state = put_in(state.workspace.lsp_pending, pending)
         new_state = dispatch_lsp_response(kind, new_state, result)
-        {:noreply, Renderer.render(new_state)}
+        {:noreply, Renderer.render_or_async(new_state)}
 
       {nil, _} ->
         # Not a tracked request — try completion handler
@@ -635,8 +635,31 @@ defmodule MingaEditor do
   # Debounced render timer fired — perform the actual render.
   def handle_info(:debounced_render, state) do
     state = maybe_trigger_nav_flash(state)
-    state = Renderer.render(state)
+    state = Renderer.render_or_async(state)
     {:noreply, %{state | render_timer: nil}}
+  end
+
+  # Renderer.Server writeback (only fires when split-renderer is enabled):
+  # merge cache, layout, and click-region updates that the renderer
+  # computed in its own process. Stale frame_seqs still apply because
+  # regions are advisory and the next frame is in flight anyway.
+  def handle_info({:render_done, %{caches: caches, layout: layout} = wb}, state) do
+    ws = state.workspace
+    new_state = %{state | caches: caches, layout: layout}
+
+    new_state =
+      case Map.fetch(wb, :windows) do
+        {:ok, windows} -> %{new_state | workspace: %{ws | windows: windows}}
+        :error -> new_state
+      end
+
+    new_state =
+      case Map.fetch(wb, :shell_state) do
+        {:ok, ss} -> %{new_state | shell_state: ss}
+        :error -> new_state
+      end
+
+    {:noreply, new_state}
   end
 
   # Nav-flash timer step — advance the fade or clear the flash.
@@ -649,10 +672,10 @@ defmodule MingaEditor do
         case NavFlash.advance(flash) do
           {:continue, updated, effects} ->
             state = EditorState.set_nav_flash(state, apply_flash_effects(state, updated, effects))
-            {:noreply, Renderer.render(state)}
+            {:noreply, Renderer.render_or_async(state)}
 
           :done ->
-            {:noreply, Renderer.render(EditorState.cancel_nav_flash(state))}
+            {:noreply, Renderer.render_or_async(EditorState.cancel_nav_flash(state))}
         end
     end
   end
@@ -699,10 +722,10 @@ defmodule MingaEditor do
       :buffer ->
         Minga.Log.info(:editor, "Buffer process #{inspect(pid)} died, removing from state")
         state = EditorState.remove_dead_buffer(state, pid)
-        {:noreply, Renderer.render(state)}
+        {:noreply, Renderer.render_or_async(state)}
 
       {:git_remote_task, updated_state} ->
-        {:noreply, Renderer.render(updated_state)}
+        {:noreply, Renderer.render_or_async(updated_state)}
 
       :unknown ->
         {:noreply, state}
@@ -714,7 +737,7 @@ defmodule MingaEditor do
   # Mouse hover timeout: check if the mouse is over a diagnostic or symbol
   def handle_info(:mouse_hover_timeout, state) do
     state = MouseHoverTooltip.check_hover(state)
-    {:noreply, Renderer.render(state)}
+    {:noreply, Renderer.render_or_async(state)}
   end
 
   def handle_info(:dismiss_toast, state) do
@@ -1205,7 +1228,7 @@ defmodule MingaEditor do
   end
 
   defp apply_effect(state, {:handle_git_remote_result, ref, result}),
-    do: Renderer.render(Commands.Git.handle_remote_result(state, ref, result))
+    do: Renderer.render_or_async(Commands.Git.handle_remote_result(state, ref, result))
 
   # Dispatches a log effect to the appropriate Minga.Log function.
   @spec apply_log_effect(atom(), atom(), String.t()) :: :ok
@@ -1258,7 +1281,7 @@ defmodule MingaEditor do
   @spec handle_lsp_completion_response(reference(), term(), state()) :: {:noreply, state()}
   defp handle_lsp_completion_response(ref, result, state) do
     new_state = CompletionHandling.handle_response(state, ref, result)
-    new_state = Renderer.render(new_state)
+    new_state = Renderer.render_or_async(new_state)
     {:noreply, new_state}
   end
 
@@ -1288,7 +1311,7 @@ defmodule MingaEditor do
   # display to coalesce frames for.
   defp schedule_render(%{backend: :headless} = state, _delay_ms) do
     state = maybe_trigger_nav_flash(state)
-    state = Renderer.render(state)
+    state = Renderer.render_or_async(state)
     %{state | render_timer: nil}
   end
 
@@ -1995,7 +2018,7 @@ defmodule MingaEditor do
         new_win = %{window | viewport: new_vp}
         new_map = Map.put(win_map, active_win_id, new_win)
         new_state = put_in(state.workspace.windows.map, new_map)
-        Renderer.render(new_state)
+        Renderer.render_or_async(new_state)
     end
   end
 
@@ -2184,7 +2207,7 @@ defmodule MingaEditor do
   @doc false
   @spec do_render(state()) :: state()
   def do_render(state) do
-    Renderer.render(state)
+    Renderer.render_or_async(state)
   end
 
   @doc false

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -639,10 +639,18 @@ defmodule MingaEditor do
     {:noreply, %{state | render_timer: nil}}
   end
 
-  # Renderer.Server writeback (only fires when split-renderer is enabled):
-  # merge cache, layout, and click-region updates that the renderer
-  # computed in its own process. Stale frame_seqs still apply because
-  # regions are advisory and the next frame is in flight anyway.
+  # Renderer.Server writeback (only fires when split-renderer is enabled).
+  #
+  # Known race the Phase-1 follow-up must address before turning the flag
+  # on in production: `windows` and `shell_state` carry both
+  # renderer-derived data (per-window render caches, click regions) AND
+  # editor-owned state that the input handlers may have mutated between
+  # snapshot-time and writeback-arrival. Merging the whole struct can
+  # regress those edits. Today the flag is off by default and the
+  # writeback path is dormant, so we accept the merge as-is. A future
+  # change should narrow the writeback contract to renderer-owned fields
+  # only (caches, layout, click regions, per-window render_cache) and
+  # leave `windows`/`shell_state` editor-owned.
   def handle_info({:render_done, %{caches: caches, layout: layout} = wb}, state) do
     ws = state.workspace
     new_state = %{state | caches: caches, layout: layout}

--- a/lib/minga_editor/renderer.ex
+++ b/lib/minga_editor/renderer.ex
@@ -71,8 +71,9 @@ defmodule MingaEditor.Renderer do
       snapshot = Input.from_editor_state(state)
       # Monotonic time stands in for a frame sequence number; the renderer
       # only uses it for telemetry tagging and pending-snapshot identity.
-      seq = System.monotonic_time(:microsecond)
-      seq = if seq < 0, do: -seq, else: seq
+      # `abs/1` because monotonic_time/1 can return negative values and the
+      # @spec on cast_snapshot/3 requires a non_neg_integer.
+      seq = abs(System.monotonic_time(:microsecond))
       RendererServer.cast_snapshot(snapshot, seq)
       state
     else

--- a/lib/minga_editor/renderer.ex
+++ b/lib/minga_editor/renderer.ex
@@ -27,6 +27,7 @@ defmodule MingaEditor.Renderer do
   alias MingaEditor.PickerUI
   alias MingaEditor.RenderPipeline
   alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.Renderer.Server, as: RendererServer
   alias MingaEditor.State, as: EditorState
 
   @typedoc "Internal editor state."
@@ -50,6 +51,33 @@ defmodule MingaEditor.Renderer do
   @spec render(state()) :: state()
   def render(%{shell: shell} = state) do
     shell.render(state)
+  end
+
+  @doc """
+  Renders synchronously, or pushes a snapshot to the Renderer.Server when
+  the split-renderer feature flag is on. Returns the editor state — in
+  async mode unchanged (the Renderer's `{:render_done, ...}` writeback
+  will update caches and layout later).
+
+  Behind the flag this is the same call as `render/1`. Headless backends
+  always render synchronously regardless of the flag, since the test
+  harness depends on synchronous emit for determinism.
+  """
+  @spec render_or_async(state()) :: state()
+  def render_or_async(%{backend: :headless} = state), do: render(state)
+
+  def render_or_async(state) do
+    if RendererServer.enabled?() do
+      snapshot = Input.from_editor_state(state)
+      # Monotonic time stands in for a frame sequence number; the renderer
+      # only uses it for telemetry tagging and pending-snapshot identity.
+      seq = System.monotonic_time(:microsecond)
+      seq = if seq < 0, do: -seq, else: seq
+      RendererServer.cast_snapshot(snapshot, seq)
+      state
+    else
+      render(state)
+    end
   end
 
   @doc """

--- a/lib/minga_editor/renderer/server.ex
+++ b/lib/minga_editor/renderer/server.ex
@@ -1,0 +1,177 @@
+defmodule MingaEditor.Renderer.Server do
+  @moduledoc """
+  Standalone renderer GenServer. Owns the render pipeline so a slow
+  frame doesn't block input dispatch in the Editor process.
+
+  ## Lifecycle
+
+  Started by `MingaEditor.Supervisor` only when
+  `Application.get_env(:minga, :split_renderer, false)` is true. When
+  the flag is off, the Editor calls `MingaEditor.Renderer.render/1`
+  synchronously and this server is not in the supervision tree.
+
+  ## Snapshot mechanics
+
+  The Editor pushes `RenderPipeline.Input` snapshots via
+  `cast_snapshot/3`. The Renderer holds an in-flight snapshot and a
+  pending one. When a snapshot arrives while a render is in progress,
+  the previous pending snapshot is dropped (most-recent-wins
+  coalescing) and a `[:minga, :render, :coalesced]` telemetry event
+  fires. After each render emit completes, the Renderer pulls any
+  pending snapshot and starts the next frame; otherwise it goes idle.
+
+  ## Click-region writeback
+
+  The render pipeline computes `modeline_click_regions` and
+  `tab_bar_click_regions` as part of chrome rendering. These need to
+  flow back to the Editor so subsequent mouse events can resolve
+  click positions. The Renderer casts
+  `{:render_done, frame_seq, %{caches: c, layout: l, click_regions: cr}}`
+  back to the Editor after every emit; the Editor merges into its
+  state via `apply_renderer_writeback/2`.
+
+  ## Telemetry
+
+  - `[:minga, :render, :pipeline]` span around `RenderPipeline.run/1`.
+  - `[:minga, :render, :coalesced]` event when a pending snapshot is dropped.
+  - `[:minga, :render, :frame_latency]` measurement (push timestamp → emit complete).
+
+  ## Determinism in tests
+
+  EditorCase and snapshot tests run with the flag off. The Editor's
+  existing synchronous render path keeps tests deterministic. This
+  server is not started in the test supervision tree by default.
+  """
+
+  use GenServer
+
+  alias MingaEditor.RenderPipeline
+  alias MingaEditor.RenderPipeline.Input
+
+  @typedoc "Click-region writeback payload sent to the Editor after each frame."
+  @type writeback :: %{
+          required(:caches) => MingaEditor.Renderer.Caches.t(),
+          required(:layout) => MingaEditor.Layout.t() | nil,
+          required(:shell_state) => term(),
+          required(:windows) => term(),
+          required(:frame_seq) => non_neg_integer()
+        }
+
+  @typedoc "Renderer server state."
+  @type t :: %__MODULE__{
+          editor_pid: pid() | nil,
+          rendering?: boolean(),
+          pending: {Input.t(), non_neg_integer(), integer()} | nil,
+          in_flight: {Input.t(), non_neg_integer(), integer()} | nil
+        }
+
+  defstruct editor_pid: nil,
+            rendering?: false,
+            pending: nil,
+            in_flight: nil
+
+  # ── API ────────────────────────────────────────────────────────────────────
+
+  @doc """
+  Starts the Renderer server. The `:editor_pid` option names the Editor
+  process to send `{:render_done, ...}` writebacks to; defaults to
+  `MingaEditor` (the registered name of the Editor GenServer).
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @doc """
+  Pushes a render snapshot. Returns immediately; the actual emit
+  happens asynchronously. If a previous snapshot is still rendering,
+  this snapshot replaces any prior pending one.
+  """
+  @spec cast_snapshot(GenServer.server(), Input.t(), non_neg_integer()) :: :ok
+  def cast_snapshot(server \\ __MODULE__, %Input{} = snapshot, frame_seq)
+      when is_integer(frame_seq) and frame_seq >= 0 do
+    GenServer.cast(server, {:render, snapshot, frame_seq, monotonic_now()})
+  end
+
+  @doc "Returns true when the split-renderer feature flag is enabled."
+  @spec enabled?() :: boolean()
+  def enabled? do
+    Application.get_env(:minga, :split_renderer, false) == true
+  end
+
+  # ── GenServer callbacks ───────────────────────────────────────────────────
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(opts) do
+    editor_pid = Keyword.get(opts, :editor_pid, MingaEditor)
+    {:ok, %__MODULE__{editor_pid: editor_pid}}
+  end
+
+  @impl true
+  @spec handle_cast({:render, Input.t(), non_neg_integer(), integer()}, t()) :: {:noreply, t()}
+  def handle_cast({:render, snap, seq, pushed_at}, %__MODULE__{rendering?: true} = state) do
+    # In-flight render is still going. Drop the previous pending and replace
+    # with this snapshot. Most-recent-wins.
+    if state.pending do
+      :telemetry.execute([:minga, :render, :coalesced], %{count: 1}, %{
+        dropped_seq: elem(state.pending, 1),
+        new_seq: seq
+      })
+    end
+
+    {:noreply, %{state | pending: {snap, seq, pushed_at}}}
+  end
+
+  def handle_cast({:render, snap, seq, pushed_at}, %__MODULE__{rendering?: false} = state) do
+    send(self(), :do_render)
+    {:noreply, %{state | rendering?: true, in_flight: {snap, seq, pushed_at}}}
+  end
+
+  @impl true
+  @spec handle_info(:do_render, t()) :: {:noreply, t()}
+  def handle_info(:do_render, %__MODULE__{in_flight: {snap, seq, pushed_at}} = state) do
+    output =
+      :telemetry.span(
+        [:minga, :render, :pipeline],
+        %{frame_seq: seq},
+        fn -> {RenderPipeline.run(snap), %{}} end
+      )
+
+    emit_complete_at = monotonic_now()
+
+    :telemetry.execute(
+      [:minga, :render, :frame_latency],
+      %{microseconds: emit_complete_at - pushed_at},
+      %{frame_seq: seq}
+    )
+
+    if is_pid(state.editor_pid) or is_atom(state.editor_pid) do
+      writeback = %{
+        caches: output.caches,
+        layout: output.layout,
+        shell_state: output.shell_state,
+        windows: output.workspace.windows,
+        frame_seq: seq
+      }
+
+      send(state.editor_pid, {:render_done, writeback})
+    end
+
+    case state.pending do
+      nil ->
+        {:noreply, %{state | rendering?: false, in_flight: nil}}
+
+      {next_snap, next_seq, next_pushed_at} ->
+        send(self(), :do_render)
+        {:noreply, %{state | in_flight: {next_snap, next_seq, next_pushed_at}, pending: nil}}
+    end
+  end
+
+  def handle_info(_other, state), do: {:noreply, state}
+
+  # ── Helpers ────────────────────────────────────────────────────────────────
+
+  @spec monotonic_now() :: integer()
+  defp monotonic_now, do: System.monotonic_time(:microsecond)
+end

--- a/lib/minga_editor/supervisor.ex
+++ b/lib/minga_editor/supervisor.ex
@@ -56,7 +56,7 @@ defmodule MingaEditor.Supervisor do
   # Renderer.Server lives between Frontend.Manager (port owner) and
   # MingaEditor (input + state). Only started when the split-renderer
   # feature flag is on; default off keeps current synchronous behavior.
-  @spec renderer_children() :: [Supervisor.child_spec()]
+  @spec renderer_children() :: [module()]
   defp renderer_children do
     if MingaEditor.Renderer.Server.enabled?() do
       [MingaEditor.Renderer.Server]

--- a/lib/minga_editor/supervisor.ex
+++ b/lib/minga_editor/supervisor.ex
@@ -35,17 +35,33 @@ defmodule MingaEditor.Supervisor do
   def init(opts) do
     backend = Keyword.get(opts, :backend, :tui)
 
-    children = [
-      Minga.Parser.Manager,
-      {MingaEditor.Frontend.Manager, [backend: backend]},
-      {MingaEditor,
-       [
-         backend: backend,
-         swap_dir: Minga.Session.swap_dir(),
-         session_dir: Path.dirname(Minga.Session.session_file())
-       ]}
-    ]
+    children =
+      [
+        Minga.Parser.Manager,
+        {MingaEditor.Frontend.Manager, [backend: backend]}
+      ] ++
+        renderer_children() ++
+        [
+          {MingaEditor,
+           [
+             backend: backend,
+             swap_dir: Minga.Session.swap_dir(),
+             session_dir: Path.dirname(Minga.Session.session_file())
+           ]}
+        ]
 
     Supervisor.init(children, strategy: :rest_for_one)
+  end
+
+  # Renderer.Server lives between Frontend.Manager (port owner) and
+  # MingaEditor (input + state). Only started when the split-renderer
+  # feature flag is on; default off keeps current synchronous behavior.
+  @spec renderer_children() :: [Supervisor.child_spec()]
+  defp renderer_children do
+    if MingaEditor.Renderer.Server.enabled?() do
+      [MingaEditor.Renderer.Server]
+    else
+      []
+    end
   end
 end

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -1,0 +1,129 @@
+defmodule MingaEditor.Renderer.ServerTest do
+  @moduledoc """
+  Unit tests for the standalone Renderer GenServer.
+
+  Tests the snapshot/coalescing/writeback contract directly without
+  booting the editor. The server is normally started under
+  `MingaEditor.Supervisor` only when the `:split_renderer` flag is on;
+  these tests start a process per-test for isolation.
+
+  Tests that would require running the actual `RenderPipeline.run/1`
+  are out of scope for unit tests — pipeline behavior is covered by
+  the existing render pipeline test suite. These tests focus on the
+  state-machine contract: idle → rendering, coalescing, telemetry.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.Renderer.Server, as: RendererServer
+  alias MingaEditor.Viewport
+
+  describe "enabled?/0" do
+    test "returns false when the application env flag is unset" do
+      Application.delete_env(:minga, :split_renderer)
+      refute RendererServer.enabled?()
+    end
+
+    test "returns true when the flag is exactly true" do
+      Application.put_env(:minga, :split_renderer, true)
+      assert RendererServer.enabled?()
+      Application.delete_env(:minga, :split_renderer)
+    end
+
+    test "returns false when the flag is anything other than true" do
+      Application.put_env(:minga, :split_renderer, :maybe)
+      refute RendererServer.enabled?()
+      Application.delete_env(:minga, :split_renderer)
+    end
+  end
+
+  describe "init/1 + start_link/1" do
+    test "starts with no pending or in-flight snapshot" do
+      {:ok, pid} = RendererServer.start_link(name: nil, editor_pid: self())
+      state = :sys.get_state(pid)
+
+      assert state.editor_pid == self()
+      refute state.rendering?
+      assert state.pending == nil
+      assert state.in_flight == nil
+
+      GenServer.stop(pid)
+    end
+  end
+
+  describe "snapshot coalescing (in-flight → pending replacement)" do
+    setup do
+      {:ok, pid} = RendererServer.start_link(name: nil, editor_pid: self())
+
+      # Park the server in "rendering" so subsequent casts go to pending.
+      :sys.replace_state(pid, fn s ->
+        %{s | rendering?: true, in_flight: {stub_snapshot(), 0, 0}}
+      end)
+
+      on_exit(fn ->
+        if Process.alive?(pid), do: GenServer.stop(pid)
+      end)
+
+      %{pid: pid}
+    end
+
+    test "first pending snapshot is stored without a coalesce event", %{pid: pid} do
+      handler = fn name, m, meta, parent -> send(parent, {:tel, name, m, meta}) end
+      :telemetry.attach("test-coalesce-first", [:minga, :render, :coalesced], handler, self())
+
+      RendererServer.cast_snapshot(pid, stub_snapshot(), 1)
+      :sys.get_state(pid)
+      state = :sys.get_state(pid)
+
+      assert {_, 1, _} = state.pending
+      refute_receive {:tel, [:minga, :render, :coalesced], _, _}, 50
+
+      :telemetry.detach("test-coalesce-first")
+    end
+
+    test "subsequent pending snapshot replaces the prior one with a telemetry event", %{pid: pid} do
+      handler = fn name, m, meta, parent -> send(parent, {:tel, name, m, meta}) end
+      :telemetry.attach("test-coalesce-replace", [:minga, :render, :coalesced], handler, self())
+
+      RendererServer.cast_snapshot(pid, stub_snapshot(), 1)
+      :sys.get_state(pid)
+
+      RendererServer.cast_snapshot(pid, stub_snapshot(), 2)
+      :sys.get_state(pid)
+
+      RendererServer.cast_snapshot(pid, stub_snapshot(), 3)
+      :sys.get_state(pid)
+
+      state = :sys.get_state(pid)
+      assert {_, 3, _} = state.pending
+      assert {_, 0, _} = state.in_flight
+
+      assert_receive {:tel, [:minga, :render, :coalesced], %{count: 1},
+                      %{dropped_seq: 1, new_seq: 2}}
+
+      assert_receive {:tel, [:minga, :render, :coalesced], %{count: 1},
+                      %{dropped_seq: 2, new_seq: 3}}
+
+      :telemetry.detach("test-coalesce-replace")
+    end
+  end
+
+  # ── Helpers ────────────────────────────────────────────────────────────────
+
+  # Builds a syntactically valid Input. These tests inspect the server's
+  # state machine, not pipeline output, so the snapshot's contents only
+  # need to satisfy the struct's @enforce_keys.
+  defp stub_snapshot do
+    %Input{
+      port_manager: self(),
+      theme: MingaEditor.UI.Theme.get!(:doom_one),
+      capabilities: %MingaEditor.Frontend.Capabilities{},
+      shell: MingaEditor.Shell.Traditional,
+      workspace: %{
+        windows: %MingaEditor.State.Windows{},
+        viewport: Viewport.new(24, 80)
+      }
+    }
+  end
+end


### PR DESCRIPTION
Refs #1432 — PR-2 of 5 in the Editor/Renderer split sequence.

## Summary

Introduces `MingaEditor.Renderer.Server`, a standalone GenServer that owns the render pipeline. When the `:split_renderer` Application env is true, the Editor pushes `RenderPipeline.Input` snapshots via cast and the renderer runs in its own process; the Editor's `handle_info` clauses are no longer blocked on render emit.

When the flag is off (default — all CI tests), the Editor's existing synchronous `Renderer.render/1` path is unchanged; the new server is not started under the supervisor. The `:headless` backend always renders synchronously regardless of the flag, so EditorCase and snapshot tests stay deterministic.

### Pieces
- **`lib/minga_editor/renderer/server.ex`** — the GenServer. State machine is idle → rendering → [pending] → rendering … with most-recent-wins coalescing (the previous pending snapshot is dropped and a `[:minga, :render, :coalesced]` telemetry event fires).
- **`lib/minga_editor/renderer.ex`** — new `render_or_async/1` wrapper that picks sync or async path based on `RendererServer.enabled?()` and `state.backend`.
- **`lib/minga_editor.ex`** — bulk-replaces 26 `Renderer.render(state)` call sites with `Renderer.render_or_async(state)` (transparent in default config). Adds `handle_info({:render_done, writeback})` to merge the renderer's caches / layout / shell_state / windows back into editor state.
- **`lib/minga_editor/supervisor.ex`** — conditionally adds `Renderer.Server` between `Frontend.Manager` and `MingaEditor` under `rest_for_one`. If Renderer crashes, MingaEditor restarts; if MingaEditor crashes, Renderer survives and its caches stay warm.
- **`test/minga_editor/renderer/server_test.exs`** — 6 tests: `enabled?/0` gating, init defaults, and the in-flight → pending coalescing contract with telemetry assertions.

### Telemetry surface (per ticket spec)
- `[:minga, :render, :pipeline]` span around `RenderPipeline.run/1`
- `[:minga, :render, :coalesced]` event when a pending snapshot drops
- `[:minga, :render, :frame_latency]` microseconds (push → emit complete)

### Deferred to follow-up PRs (per the ticket's PR sequencing)
- **PR-3:** flip the flag default-on for `:tui` and `:gui` (requires a week of dogfood burn-in before flipping; ticket explicitly says "Do not ship PR-4 until PR-3 has burned in for at least a week with no metric regressions")
- **PR-4:** delete the synchronous in-Editor render path
- **PR-5:** move `font_registry` ownership to Renderer

## Verification

| AC | How proved |
| --- | --- |
| 1. `MingaEditor.Renderer.Server` GenServer owns the render pipeline | `lib/minga_editor/renderer/server.ex`. |
| 2. `MingaEditor` no longer calls `RenderPipeline.run/1` directly for non-headless backends | When the flag is on, `render_or_async/1` casts to the server. When off (today's default), behavior is unchanged. PR-3/4 complete the cutover. |
| 3. Most-recent-wins coalescing with telemetry event | `Renderer.Server.handle_cast/2` (rendering=true clause) + tests in `server_test.exs`. |
| 4. Renderer added to supervisor between Frontend.Manager and MingaEditor under rest_for_one | `supervisor.ex` `renderer_children/0`; only added when flag is on. |
| 5. Click-region writeback flows back to Editor as `{:render_done, ...}` | `Renderer.Server.handle_info(:do_render, …)` emits the writeback; `MingaEditor.handle_info({:render_done, …})` merges. |
| 6. Headless backend keeps the synchronous in-Editor render path | `Renderer.render_or_async/1` first clause matches `backend: :headless` → calls `render/1` directly. |
| 7. Input not blocked by render emit when flag is on | Architectural — render runs in its own process when flag is on. End-to-end span verification deferred to PR-3 dogfood burn-in. |
| 8. Telemetry surface | All three events listed above are emitted. |

### Local verification
- `mix compile --warnings-as-errors` — clean
- `mix test test/minga_editor/renderer/server_test.exs` — 6/6 pass
- `mix test.llm` — 7,526 tests, 0 failures (flag stays off in tests; existing sync path unchanged)
- `make lint` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)