### PR TITLE
refactor(shell): split Shell behaviour into 5 focused sub-behaviours

### DIFF
--- a/lib/minga_editor/shell.ex
+++ b/lib/minga_editor/shell.ex
@@ -1,22 +1,41 @@
 defmodule MingaEditor.Shell do
   @moduledoc """
-  Behaviour for pluggable presentation shells.
+  Umbrella behaviour for pluggable presentation shells.
 
-  A shell owns layout, chrome, input routing, and rendering for a
-  specific UX model. The traditional editor, The Board, and headless
-  mode are all shells. The workspace (core editing state) is shared;
-  the shell decides how to present it.
+  A shell owns layout, chrome, input routing, buffer lifecycle, and
+  tab queries. Each responsibility is a focused sub-behaviour:
+
+  - `MingaEditor.Shell.Layout`           — `compute_layout/1`
+  - `MingaEditor.Shell.Chrome`           — `build_chrome/4`, `render/1`
+  - `MingaEditor.Shell.InputRouter`      — `input_handlers/1`,
+    `handle_event/3`, `handle_gui_action/3`
+  - `MingaEditor.Shell.BufferLifecycle`  — `on_buffer_added/4`,
+    `on_buffer_switched/2`, `on_buffer_died/3`, `on_agent_event/4`
+  - `MingaEditor.Shell.TabQueries`       — `active_tab/1`,
+    `find_tab_by_buffer/2`, `active_tab_kind/1`, `set_tab_session/3`,
+    `active_session/1`
+
+  This umbrella declares only `init/1` (the constructor every shell
+  needs); all other callbacks live on their respective sub-behaviours.
+  Existing shells (`Traditional`, `Board`) implement the umbrella plus
+  every sub-behaviour. A future tab-less shell can implement just the
+  sub-behaviours it cares about (e.g., skip `TabQueries` entirely if
+  no tab UI is rendered) and `EditorState`/`AgentAccess` callers that
+  go through `Shell.active_session/1` will continue to work because
+  they read through the field, not the type.
 
   ## Implementation
 
-  Implement all callbacks in a module and set it as the `:shell` field
-  on `MingaEditor.State`. The Editor GenServer dispatches to the active
-  shell for presentation concerns.
+  Implement `init/1` plus the sub-behaviours your shell needs, then
+  set the module as the `:shell` field on `MingaEditor.State`. The
+  Editor GenServer dispatches to the active shell for presentation
+  concerns.
 
   ## Available shells
 
-  - `MingaEditor.Shell.Traditional` — tab-based editor with file tree, modeline,
-    picker, and agent panel. The default shell and the only one today.
+  - `MingaEditor.Shell.Traditional` — tab-based editor with file tree,
+    modeline, picker, and agent panel. The default shell.
+  - `MingaEditor.Shell.Board` — agent supervisor card view.
   """
 
   @typedoc "Shell-specific state. Each shell defines its own struct."
@@ -25,194 +44,16 @@ defmodule MingaEditor.Shell do
   @typedoc "Workspace state (the editing context shared by all shells)."
   @type workspace :: MingaEditor.Workspace.State.t()
 
-  @doc """
-  Initialize shell state from config and initial workspace.
+  @typedoc """
+  Why a buffer was added — re-exported here from `Shell.BufferLifecycle`
+  so existing call sites that use `MingaEditor.Shell.buffer_add_context/0`
+  keep compiling.
+  """
+  @type buffer_add_context :: MingaEditor.Shell.BufferLifecycle.buffer_add_context()
 
-  Called once during Editor startup. Returns the shell's initial state.
+  @doc """
+  Initialize shell state from config. Called once during Editor startup.
+  Returns the shell's initial state.
   """
   @callback init(opts :: keyword()) :: shell_state()
-
-  @doc """
-  Handle a shell-specific event (tool prompt, nav flash, git status, etc.).
-
-  Returns the updated shell state and workspace. The Editor GenServer
-  calls this for events that are presentation concerns, not core editing.
-  """
-  @callback handle_event(shell_state(), workspace(), event :: term()) ::
-              {shell_state(), workspace()}
-
-  @doc """
-  Handle a shell-specific GUI action from the native frontend.
-
-  Returns the updated shell state and workspace.
-  """
-  @callback handle_gui_action(shell_state(), workspace(), action :: term()) ::
-              {shell_state(), workspace()}
-
-  @doc """
-  Returns the input handler stack for this shell.
-
-  Overlay handlers (picker, completion, conflict prompt) sit above
-  the surface and intercept keys first. Surface handlers (dashboard,
-  file tree, agent panel, mode dispatch) handle keys when no overlay
-  claims them. The Editor walks overlays first, then surfaces.
-  """
-  @callback input_handlers(editor_state :: term()) :: %{overlay: [module()], surface: [module()]}
-
-  @doc """
-  Compute spatial layout for the current state.
-
-  Returns a layout struct with named rectangles for each UI region.
-  The shell decides what regions exist (tab bar, modeline, file tree,
-  editor panes, agent panel, bottom panel, etc.).
-  """
-  @callback compute_layout(editor_state :: term()) :: MingaEditor.Layout.t()
-
-  @doc """
-  Build chrome (tab bar, modeline, file tree, overlays, etc.).
-
-  Returns a chrome struct with draw lists for each UI region. The
-  shell decides which chrome elements exist and how they render.
-  """
-  @callback build_chrome(
-              editor_state :: term(),
-              layout :: MingaEditor.Layout.t(),
-              scrolls :: map(),
-              cursor_info :: term()
-            ) :: MingaEditor.RenderPipeline.Chrome.t()
-
-  @doc """
-  Render a complete frame.
-
-  Runs the full render pipeline (content, chrome, compose, emit) and
-  sends commands to the frontend. Returns updated state with cached
-  render data.
-  """
-  @callback render(editor_state :: term()) :: term()
-
-  # -------------------------------------------------------------------
-  # Buffer lifecycle callbacks
-  #
-  # The Editor GenServer calls these when buffers are added, switched,
-  # or die. Each shell decides how to present the change (e.g.,
-  # Traditional manages tab bar state, Board ignores or routes to cards).
-  #
-  # Callbacks receive (shell_state, workspace, ...) — never full
-  # EditorState — so they cannot touch process monitors, render timers,
-  # or port managers. Generic concerns stay in EditorState.
-  # -------------------------------------------------------------------
-
-  @typedoc """
-  Why a buffer was added. Shells use this to decide tab presentation.
-
-  - `:open` — permanent open (file tree, `:e`, LSP jump, picker confirm).
-    Creates a new tab or switches to an existing one.
-  - `:preview` — transient picker preview. Updates the current tab
-    in-place so navigating the picker doesn't spawn new tabs.
-  """
-  @type buffer_add_context :: :open | :preview
-
-  @doc """
-  A buffer was added to the workspace.
-
-  Called after the buffer pid is in `workspace.buffers` and monitored.
-  The shell decides how to present it (e.g., create/update tabs, route
-  to a card, or ignore). `context` tells the shell WHY the buffer was
-  added so it can choose the right presentation strategy.
-  """
-  @callback on_buffer_added(
-              shell_state(),
-              workspace(),
-              buffer_pid :: pid(),
-              context :: buffer_add_context()
-            ) ::
-              {shell_state(), workspace()}
-
-  @doc """
-  The active buffer changed.
-
-  Called after `workspace.buffers.active` has been updated. The shell
-  decides whether to sync the active window, update chrome, etc.
-  """
-  @callback on_buffer_switched(shell_state(), workspace()) ::
-              {shell_state(), workspace()}
-
-  @doc """
-  A buffer process died.
-
-  Called after the dead buffer has been removed from `workspace.buffers`.
-  The shell cleans up any references (tab entries, card associations, etc.).
-  """
-  @callback on_buffer_died(shell_state(), workspace(), dead_pid :: pid()) ::
-              {shell_state(), workspace()}
-
-  # -------------------------------------------------------------------
-  # Agent event callbacks
-  #
-  # Called by the Editor GenServer when an agent session emits an event
-  # for a background tab/card (not the active one). Each shell decides
-  # how to reflect the status change in its chrome (tab badges, card
-  # status icons, etc.).
-  # -------------------------------------------------------------------
-
-  @doc """
-  A background agent session emitted an event.
-
-  Called when `session_pid` is not the active session. The shell updates
-  its presentation state (tab badges, card status, attention flags, etc.).
-  """
-  @callback on_agent_event(
-              shell_state(),
-              workspace(),
-              session_pid :: pid(),
-              event :: term()
-            ) :: {shell_state(), workspace()}
-
-  # -------------------------------------------------------------------
-  # Tab query/mutation delegates
-  #
-  # EditorState delegates these to the active shell so it never
-  # pattern-matches on `tab_bar:` directly. Traditional implements
-  # with TabBar lookups; Board returns static defaults.
-  # -------------------------------------------------------------------
-
-  @doc """
-  Returns the currently active tab, or `nil` if the shell has no tabs.
-  """
-  @callback active_tab(shell_state()) :: MingaEditor.State.Tab.t() | nil
-
-  @doc """
-  Finds the file tab whose snapshotted workspace has `pid` as active buffer.
-
-  Returns `nil` if the shell has no tabs or no matching tab exists.
-  """
-  @callback find_tab_by_buffer(shell_state(), pid()) :: MingaEditor.State.Tab.t() | nil
-
-  @doc """
-  Returns the kind (`:file` or `:agent`) of the active tab.
-
-  Shells without tabs return `:file` (the default content kind).
-  """
-  @callback active_tab_kind(shell_state()) :: atom()
-
-  @doc """
-  Associates a session pid with a tab. Returns updated shell state.
-
-  No-op for shells without tabs.
-  """
-  @callback set_tab_session(shell_state(), tab_id :: term(), pid() | nil) :: shell_state()
-
-  @doc """
-  Returns the agent session pid associated with the user's current view.
-
-  For Traditional, this is the active tab's `:session`. For Board, this is
-  the zoomed card's `:session`. Returns `nil` when no session is in scope
-  (no tab/card, or that tab/card has no session yet).
-
-  This callback is the source of truth for "which agent session is the user
-  looking at right now". The editor's `state.shell_state.agent` struct holds
-  rendering caches (status, error, pending_approval) populated from this pid;
-  the pid itself lives on the tab or card.
-  """
-  @callback active_session(shell_state()) :: pid() | nil
 end

--- a/lib/minga_editor/shell/board.ex
+++ b/lib/minga_editor/shell/board.ex
@@ -21,6 +21,11 @@ defmodule MingaEditor.Shell.Board do
   """
 
   @behaviour MingaEditor.Shell
+  @behaviour MingaEditor.Shell.Layout
+  @behaviour MingaEditor.Shell.Chrome
+  @behaviour MingaEditor.Shell.InputRouter
+  @behaviour MingaEditor.Shell.BufferLifecycle
+  @behaviour MingaEditor.Shell.TabQueries
 
   alias MingaEditor.DisplayList
   alias MingaEditor.DisplayList.{Cursor, Frame}

--- a/lib/minga_editor/shell/buffer_lifecycle.ex
+++ b/lib/minga_editor/shell/buffer_lifecycle.ex
@@ -1,0 +1,55 @@
+defmodule MingaEditor.Shell.BufferLifecycle do
+  @moduledoc """
+  Behaviour: shell-side reactions to buffer and agent events.
+
+  Carved out of `MingaEditor.Shell`. Callbacks receive
+  `(shell_state, workspace, ...)` — never full EditorState — so they
+  cannot touch process monitors, render timers, or port managers.
+  Generic concerns stay in EditorState.
+  """
+
+  @typedoc "Shell-specific state. Each shell defines its own struct."
+  @type shell_state :: term()
+
+  @typedoc "Workspace state."
+  @type workspace :: MingaEditor.Workspace.State.t()
+
+  @typedoc """
+  Why a buffer was added. Shells use this to decide tab presentation.
+
+  - `:open` — permanent open (file tree, `:e`, LSP jump, picker confirm).
+    Creates a new tab or switches to an existing one.
+  - `:preview` — transient picker preview. Updates the current tab
+    in-place so navigating the picker doesn't spawn new tabs.
+  """
+  @type buffer_add_context :: :open | :preview
+
+  @doc "A buffer was added to the workspace."
+  @callback on_buffer_added(
+              shell_state(),
+              workspace(),
+              buffer_pid :: pid(),
+              context :: buffer_add_context()
+            ) :: {shell_state(), workspace()}
+
+  @doc "The active buffer changed."
+  @callback on_buffer_switched(shell_state(), workspace()) ::
+              {shell_state(), workspace()}
+
+  @doc "A buffer process died."
+  @callback on_buffer_died(shell_state(), workspace(), dead_pid :: pid()) ::
+              {shell_state(), workspace()}
+
+  @doc """
+  An agent session emitted an event. The shell reflects the status
+  change in its chrome (tab badges, card status icons, attention flags).
+  Foreground/background routing happens in `MingaEditor.handle_info/2`;
+  this callback receives only background events.
+  """
+  @callback on_agent_event(
+              shell_state(),
+              workspace(),
+              session_pid :: pid(),
+              event :: term()
+            ) :: {shell_state(), workspace()}
+end

--- a/lib/minga_editor/shell/chrome.ex
+++ b/lib/minga_editor/shell/chrome.ex
@@ -1,0 +1,28 @@
+defmodule MingaEditor.Shell.Chrome do
+  @moduledoc """
+  Behaviour: how a shell builds chrome (tab bar, modeline, file tree,
+  overlays) and renders complete frames.
+
+  Carved out of `MingaEditor.Shell` so the rendering responsibility is
+  declared as a focused contract independent of input routing or buffer
+  lifecycle.
+  """
+
+  @doc """
+  Returns a chrome struct with draw lists for each UI region. The shell
+  decides which chrome elements exist and how they render.
+  """
+  @callback build_chrome(
+              editor_state :: term(),
+              layout :: MingaEditor.Layout.t(),
+              scrolls :: map(),
+              cursor_info :: term()
+            ) :: MingaEditor.RenderPipeline.Chrome.t()
+
+  @doc """
+  Runs the full render pipeline (content, chrome, compose, emit) and
+  sends commands to the frontend. Returns updated state with cached
+  render data.
+  """
+  @callback render(editor_state :: term()) :: term()
+end

--- a/lib/minga_editor/shell/input_router.ex
+++ b/lib/minga_editor/shell/input_router.ex
@@ -1,0 +1,37 @@
+defmodule MingaEditor.Shell.InputRouter do
+  @moduledoc """
+  Behaviour: how a shell routes input.
+
+  Carved out of `MingaEditor.Shell`. This is the natural home for the
+  focus-tree mouse routing in #1435 and any future "click-to-focus"
+  semantics — those are presentation concerns the shell owns, not
+  the editing model.
+  """
+
+  @typedoc "Shell-specific state. Each shell defines its own struct."
+  @type shell_state :: term()
+
+  @typedoc "Workspace state (the editing context shared by all shells)."
+  @type workspace :: MingaEditor.Workspace.State.t()
+
+  @doc """
+  Returns the input handler stack for this shell. Overlay handlers
+  (picker, completion, conflict prompt) sit above the surface and
+  intercept keys first; surface handlers (dashboard, file tree, agent
+  panel, mode dispatch) handle keys when no overlay claims them.
+  """
+  @callback input_handlers(editor_state :: term()) ::
+              %{overlay: [module()], surface: [module()]}
+
+  @doc """
+  Handle a shell-specific event (tool prompt, nav flash, git status, etc.).
+  """
+  @callback handle_event(shell_state(), workspace(), event :: term()) ::
+              {shell_state(), workspace()}
+
+  @doc """
+  Handle a shell-specific GUI action from the native frontend.
+  """
+  @callback handle_gui_action(shell_state(), workspace(), action :: term()) ::
+              {shell_state(), workspace()}
+end

--- a/lib/minga_editor/shell/layout.ex
+++ b/lib/minga_editor/shell/layout.ex
@@ -1,0 +1,16 @@
+defmodule MingaEditor.Shell.Layout do
+  @moduledoc """
+  Behaviour: how a shell computes spatial layout for the current state.
+
+  Carved out of `MingaEditor.Shell` so a shell that only contributes
+  layout (e.g., a hypothetical pane-only test fixture) can implement
+  this contract alone without the full shell surface.
+  """
+
+  @doc """
+  Returns a layout struct with named rectangles for each UI region.
+  The shell decides what regions exist (tab bar, modeline, file tree,
+  editor panes, agent panel, bottom panel, etc.).
+  """
+  @callback compute_layout(editor_state :: term()) :: MingaEditor.Layout.t()
+end

--- a/lib/minga_editor/shell/tab_queries.ex
+++ b/lib/minga_editor/shell/tab_queries.ex
@@ -1,0 +1,47 @@
+defmodule MingaEditor.Shell.TabQueries do
+  @moduledoc """
+  Behaviour: tab and session queries that EditorState delegates to the
+  active shell so it never pattern-matches on `tab_bar:` directly.
+
+  Carved out of `MingaEditor.Shell`. Tab-less shells (a hypothetical
+  Headless-with-UI shell, for instance) skip this contract entirely;
+  callers should always go through `MingaEditor.State.AgentAccess` or
+  `EditorState.active_tab/1` rather than calling these callbacks
+  directly so the no-tabs case stays implicit.
+  """
+
+  @typedoc "Shell-specific state."
+  @type shell_state :: term()
+
+  @doc "Returns the currently active tab, or `nil` if the shell has no tabs."
+  @callback active_tab(shell_state()) :: MingaEditor.State.Tab.t() | nil
+
+  @doc """
+  Finds the file tab whose snapshotted workspace has `pid` as active buffer.
+  Returns `nil` if the shell has no tabs or no matching tab exists.
+  """
+  @callback find_tab_by_buffer(shell_state(), pid()) :: MingaEditor.State.Tab.t() | nil
+
+  @doc """
+  Returns the kind (`:file` or `:agent`) of the active tab. Shells
+  without tabs return `:file` (the default content kind).
+  """
+  @callback active_tab_kind(shell_state()) :: atom()
+
+  @doc """
+  Associates a session pid with a tab. Returns updated shell state.
+  No-op for shells without tabs.
+  """
+  @callback set_tab_session(shell_state(), tab_id :: term(), pid() | nil) :: shell_state()
+
+  @doc """
+  Returns the agent session pid for the user's current view. For
+  Traditional this is the active tab's `:session`; for Board it's the
+  zoomed card's `:session`. Returns `nil` when no session is in scope.
+
+  This callback is the source of truth for "which agent session is the
+  user looking at right now". `state.shell_state.agent` holds rendering
+  caches populated from this pid; the pid itself lives on the tab/card.
+  """
+  @callback active_session(shell_state()) :: pid() | nil
+end

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -27,6 +27,11 @@ defmodule MingaEditor.Shell.Traditional do
   """
 
   @behaviour MingaEditor.Shell
+  @behaviour MingaEditor.Shell.Layout
+  @behaviour MingaEditor.Shell.Chrome
+  @behaviour MingaEditor.Shell.InputRouter
+  @behaviour MingaEditor.Shell.BufferLifecycle
+  @behaviour MingaEditor.Shell.TabQueries
 
   alias MingaEditor.Agent.UIState
   alias Minga.Buffer


### PR DESCRIPTION
Closes #1434.

## Summary

Carves the 14-callback `MingaEditor.Shell` behaviour into five focused contracts so adding a new shell becomes feasible without inheriting the full surface, and so the layering of \"what kind of presentation responsibility is this\" is explicit:

| Sub-behaviour | Callbacks |
| --- | --- |
| `MingaEditor.Shell.Layout` | `compute_layout/1` |
| `MingaEditor.Shell.Chrome` | `build_chrome/4`, `render/1` |
| `MingaEditor.Shell.InputRouter` | `input_handlers/1`, `handle_event/3`, `handle_gui_action/3` |
| `MingaEditor.Shell.BufferLifecycle` | `on_buffer_added/4`, `on_buffer_switched/2`, `on_buffer_died/3`, `on_agent_event/4` |
| `MingaEditor.Shell.TabQueries` | `active_tab/1`, `find_tab_by_buffer/2`, `active_tab_kind/1`, `set_tab_session/3`, `active_session/1` |

The umbrella `MingaEditor.Shell` shrinks to a single callback (`init/1`) plus a moduledoc that points at the sub-behaviours, and re-exports the `buffer_add_context` type so existing `MingaEditor.Shell.buffer_add_context()` references keep compiling.

Both shells (`Traditional`, `Board`) declare `@behaviour` for each sub-behaviour they implement; today both implement all five. A future tab-less shell can drop `Shell.TabQueries`; a layout-only test fixture can implement `Shell.Layout` alone.

### Why no dispatch site changes

`state.shell` is still a single module reference; `state.shell.compute_layout(state)` works whether the callback is declared on `Shell` or `Shell.Layout` because Elixir dispatches by function name and arity, not by behaviour. The existing `@impl true` annotations on the shells stay permissive across every declared behaviour. Per the ticket: \"the simpler approach is one module that implements all sub-behaviours because that preserves the current dispatch syntax\" — taken.

### Unblocks

- **#1435** (focus-tree mouse routing) — `Shell.InputRouter` is the natural home for the focus-tree hit-test API.
- Any future split-only or headless-with-UI shell that wants to opt out of tabs.

## Verification

| AC | How proved |
| --- | --- |
| 1. Five sub-behaviour modules exist with focused callbacks | `lib/minga_editor/shell/{layout,chrome,input_router,buffer_lifecycle,tab_queries}.ex`. |
| 2. The umbrella becomes a thin compose-by-aliasing module or stays for `init/1` | Kept; reduced to `init/1` + re-exported types. The moduledoc enumerates the sub-behaviours. |
| 3. Both shells implement only the sub-behaviours they need | `traditional.ex` and `board.ex` declare `@behaviour` for each of the 5 sub-behaviours plus the umbrella. A future shell can omit any. |
| 4. Editor dispatch sites route to the correct sub-behaviour module | The dispatch is via `state.shell` which still points to a single module that implements all sub-behaviours. Function-name dispatch routes correctly without code changes. |
| 5. Existing shell tests pass with at most mechanical changes | `mix test.llm` — 7,526 tests, 0 failures. No test changes required. `make lint` exit 0. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)