### PR TITLE
refactor(input): introduce FocusTree foundation for mouse routing

### DIFF
--- a/lib/minga_editor/focus_tree.ex
+++ b/lib/minga_editor/focus_tree.ex
@@ -126,17 +126,28 @@ defmodule MingaEditor.FocusTree do
 
   defp hit_path(%TreeNode{} = node, row, col, acc) do
     if TreeNode.contains?(node, row, col) do
-      acc = [node | acc]
-
-      Enum.reduce_while(Enum.reverse(node.children), acc, fn child, inner_acc ->
-        case hit_path(child, row, col, inner_acc) do
-          ^inner_acc -> {:cont, inner_acc}
-          deeper -> {:halt, deeper}
-        end
-      end)
+      new_acc = [node | acc]
+      deepest_child_path(node.children, row, col, new_acc) || new_acc
     else
       acc
     end
+  end
+
+  # Walks children in reverse z-order and returns the first child path that
+  # extends beyond `acc` (i.e., a child whose subtree contained the point).
+  # Returns `nil` when no child contained the point so the caller falls back
+  # to its own `acc`.
+  @spec deepest_child_path([TreeNode.t()], non_neg_integer(), non_neg_integer(), [TreeNode.t()]) ::
+          [TreeNode.t()] | nil
+  defp deepest_child_path(children, row, col, acc) do
+    children
+    |> Enum.reverse()
+    |> Enum.find_value(fn child ->
+      case hit_path(child, row, col, acc) do
+        ^acc -> nil
+        deeper -> deeper
+      end
+    end)
   end
 
   # ── Builders ───────────────────────────────────────────────────────────────

--- a/lib/minga_editor/focus_tree.ex
+++ b/lib/minga_editor/focus_tree.ex
@@ -1,0 +1,180 @@
+defmodule MingaEditor.FocusTree do
+  @moduledoc """
+  Tree of visible regions, built from the per-frame `Layout`.
+
+  Mouse routing today is a flat hit-test stack: each input handler walks
+  the layout rects asking "am I responsible?" and the order of checks
+  encodes z-order implicitly. This module replaces that pattern with a
+  single tree built once per frame; `hit_test/3` walks it top-down to
+  find the deepest matching node, returning the node (and therefore its
+  handler module).
+
+  ## Tree shape
+
+      viewport
+      ├─ file_tree (when present)
+      ├─ tab_bar (when present)
+      ├─ editor_area
+      │  ├─ window 1
+      │  │  ├─ gutter
+      │  │  ├─ buffer_content
+      │  │  └─ modeline
+      │  └─ window 2 (split, if any)
+      ├─ agent_panel (when present)
+      ├─ bottom_panel (when present)
+      ├─ status_bar (when present)
+      └─ minibuffer
+
+  Modal overlays and floats are inserted at the end of the children
+  list of the relevant parent node so the z-order resolves correctly:
+  the last child whose rect contains the click wins.
+
+  ## Status
+
+  This PR introduces the data structure, the basic builder, and the
+  `hit_test/3` API. Migration of the ad-hoc `inside_*?/2` predicates
+  in `Input.{Picker, Completion, AgentMouse, FileTreeHandler}` to use
+  the tree is staged as follow-up work — the existing predicates keep
+  working because the tree is purely additive at this layer.
+  """
+
+  alias MingaEditor.FocusTree.Node, as: TreeNode
+  alias MingaEditor.Layout
+
+  @typedoc "Built focus tree, rooted at the viewport."
+  @type t :: TreeNode.t()
+
+  @doc """
+  Builds a focus tree from a `Layout`. Pure; safe to call any time.
+
+  Modal overlays, hover popups, and floats are added by the caller via
+  `with_overlay/3` after construction so this function stays a pure
+  layout-to-tree projection without coupling to shell state.
+  """
+  @spec from_layout(Layout.t()) :: t()
+  def from_layout(%Layout{} = layout) do
+    {tr, tc, tw, th} = layout.terminal
+
+    # Children are listed in z-order from bottom (background) to top (overlays).
+    # hit_test/3 reverses this list to give later children priority — that's
+    # how file_tree paints over the editor_area at the same column range.
+    children =
+      []
+      |> maybe_add(layout.tab_bar, &TreeNode.new(:tab_bar, &1))
+      |> Kernel.++([editor_area_node(layout)])
+      |> maybe_add(layout.file_tree, &TreeNode.new(:file_tree, &1))
+      |> maybe_add(layout.agent_panel, &TreeNode.new(:agent_panel, &1))
+      |> maybe_add(layout.status_bar, &TreeNode.new(:status_bar, &1))
+      |> Kernel.++([TreeNode.new(:minibuffer, layout.minibuffer)])
+
+    %TreeNode{
+      content_type: :viewport,
+      rect: {tr, tc, tw, th},
+      handler: nil,
+      scrollable?: false,
+      focusable?: false,
+      children: children
+    }
+  end
+
+  @doc """
+  Adds a modal/float overlay node to the tree. Inserted as the last
+  child of the root so hit-tests resolve to it before the underlying
+  editor regions.
+  """
+  @spec with_overlay(t(), TreeNode.content_type(), TreeNode.rect(), keyword()) :: t()
+  def with_overlay(%TreeNode{children: children} = root, content_type, rect, opts \\ []) do
+    overlay = TreeNode.new(content_type, rect, opts)
+    %{root | children: children ++ [overlay]}
+  end
+
+  @doc """
+  Hit-tests `(row, col)` against the tree. Returns the deepest node
+  whose rect contains the point, or `nil` if no node matches.
+
+  Children are searched in reverse order so later children (rendered
+  on top) take precedence over earlier siblings.
+  """
+  @spec hit_test(t(), non_neg_integer(), non_neg_integer()) :: TreeNode.t() | nil
+  def hit_test(%TreeNode{} = root, row, col) do
+    if TreeNode.contains?(root, row, col) do
+      child_hit =
+        root.children
+        |> Enum.reverse()
+        |> Enum.find_value(fn child -> hit_test(child, row, col) end)
+
+      child_hit || root
+    else
+      nil
+    end
+  end
+
+  @doc """
+  Walks from the deepest hit upward through the tree, yielding each
+  ancestor node. Useful for "bubble" dispatch — try the deepest
+  handler first, then bubble up if it returns `:passthrough`.
+
+  Returns a list of nodes ordered from deepest to root. The flat
+  hit-test stack (today's pattern) is equivalent to a one-element
+  list when the deepest match is the only candidate.
+  """
+  @spec hit_path(t(), non_neg_integer(), non_neg_integer()) :: [TreeNode.t()]
+  def hit_path(%TreeNode{} = root, row, col) do
+    hit_path(root, row, col, [])
+    |> Enum.reverse()
+  end
+
+  defp hit_path(%TreeNode{} = node, row, col, acc) do
+    if TreeNode.contains?(node, row, col) do
+      acc = [node | acc]
+
+      Enum.reduce_while(Enum.reverse(node.children), acc, fn child, inner_acc ->
+        case hit_path(child, row, col, inner_acc) do
+          ^inner_acc -> {:cont, inner_acc}
+          deeper -> {:halt, deeper}
+        end
+      end)
+    else
+      acc
+    end
+  end
+
+  # ── Builders ───────────────────────────────────────────────────────────────
+
+  defp editor_area_node(%Layout{editor_area: rect, window_layouts: windows}) do
+    children =
+      windows
+      |> Enum.sort_by(fn {id, _} -> id end)
+      |> Enum.map(fn {win_id, wl} -> window_node(win_id, wl) end)
+
+    TreeNode.new(:editor_area, rect, children: children)
+  end
+
+  defp window_node(win_id, win_layout) do
+    children =
+      [
+        TreeNode.new(:buffer_content, win_layout.content,
+          handler: nil,
+          scrollable?: true,
+          focusable?: true,
+          ref: win_id
+        )
+      ]
+      |> maybe_modeline(win_layout)
+
+    TreeNode.new(:window, win_layout.total,
+      ref: win_id,
+      focusable?: true,
+      children: children
+    )
+  end
+
+  defp maybe_modeline(children, %{modeline: {_, _, _, 0}}), do: children
+
+  defp maybe_modeline(children, %{modeline: rect}) do
+    children ++ [TreeNode.new(:modeline, rect)]
+  end
+
+  defp maybe_add(children, nil, _build), do: children
+  defp maybe_add(children, rect, build), do: children ++ [build.(rect)]
+end

--- a/lib/minga_editor/focus_tree/node.ex
+++ b/lib/minga_editor/focus_tree/node.ex
@@ -1,0 +1,78 @@
+defmodule MingaEditor.FocusTree.Node do
+  @moduledoc """
+  A node in the focus tree: a single visible region.
+
+  Each node owns a rect, a content type tag, an optional input handler
+  module, and a list of child nodes (rendered z-order: later children
+  paint above earlier ones, so hit-tests prefer later children).
+
+  See `MingaEditor.FocusTree` for the tree shape and traversal API.
+  """
+
+  @typedoc "Pixel/cell rect. Same shape as `MingaEditor.Layout.rect/0`."
+  @type rect :: {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
+
+  @typedoc """
+  Tag identifying what the node represents. Adding a new content type
+  is the integration point when introducing a new region (e.g.,
+  `:bottom_panel`, `:hover_popup`). The mouse router pattern-matches
+  on this tag to pick a handler.
+  """
+  @type content_type ::
+          :viewport
+          | :tab_bar
+          | :file_tree
+          | :editor_area
+          | :window
+          | :gutter
+          | :buffer_content
+          | :modeline
+          | :agent_panel
+          | :bottom_panel
+          | :minibuffer
+          | :modal_overlay
+          | :hover_popup
+          | :signature_help
+          | :which_key
+          | {:custom, atom()}
+
+  @typedoc "A node in the focus tree."
+  @type t :: %__MODULE__{
+          content_type: content_type(),
+          rect: rect(),
+          handler: module() | nil,
+          scrollable?: boolean(),
+          focusable?: boolean(),
+          ref: term(),
+          children: [t()]
+        }
+
+  @enforce_keys [:content_type, :rect]
+  defstruct content_type: nil,
+            rect: nil,
+            handler: nil,
+            scrollable?: false,
+            focusable?: false,
+            ref: nil,
+            children: []
+
+  @doc "Constructs a node with the given content type and rect."
+  @spec new(content_type(), rect(), keyword()) :: t()
+  def new(content_type, rect, opts \\ []) do
+    %__MODULE__{
+      content_type: content_type,
+      rect: rect,
+      handler: Keyword.get(opts, :handler),
+      scrollable?: Keyword.get(opts, :scrollable?, false),
+      focusable?: Keyword.get(opts, :focusable?, false),
+      ref: Keyword.get(opts, :ref),
+      children: Keyword.get(opts, :children, [])
+    }
+  end
+
+  @doc "Returns true when `(row, col)` is inside the node's rect."
+  @spec contains?(t(), non_neg_integer(), non_neg_integer()) :: boolean()
+  def contains?(%__MODULE__{rect: {r0, c0, w, h}}, row, col) do
+    row >= r0 and row < r0 + h and col >= c0 and col < c0 + w
+  end
+end

--- a/test/minga_editor/focus_tree_test.exs
+++ b/test/minga_editor/focus_tree_test.exs
@@ -1,0 +1,224 @@
+defmodule MingaEditor.FocusTreeTest do
+  @moduledoc """
+  Tests for the focus tree built from `Layout`.
+
+  Covers tree construction from realistic layouts, deepest-match
+  hit-testing semantics, z-order overlay precedence, and boundary
+  conditions (clicks exactly on rect edges).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.FocusTree
+  alias MingaEditor.FocusTree.Node, as: TreeNode
+  alias MingaEditor.Layout
+
+  defp single_window_layout do
+    %Layout{
+      terminal: {0, 0, 80, 24},
+      tab_bar: {0, 0, 80, 1},
+      editor_area: {1, 0, 80, 21},
+      file_tree: nil,
+      window_layouts: %{
+        1 => %{
+          total: {1, 0, 80, 21},
+          content: {1, 0, 80, 21},
+          modeline: {22, 0, 80, 0}
+        }
+      },
+      horizontal_separators: [],
+      agent_panel: nil,
+      status_bar: {22, 0, 80, 1},
+      minibuffer: {23, 0, 80, 1}
+    }
+  end
+
+  defp split_layout do
+    %Layout{
+      terminal: {0, 0, 80, 24},
+      tab_bar: {0, 0, 80, 1},
+      editor_area: {1, 0, 80, 21},
+      file_tree: {1, 0, 30, 21},
+      window_layouts: %{
+        1 => %{total: {1, 30, 25, 21}, content: {1, 30, 25, 21}, modeline: {22, 30, 25, 0}},
+        2 => %{total: {1, 55, 25, 21}, content: {1, 55, 25, 21}, modeline: {22, 55, 25, 0}}
+      },
+      horizontal_separators: [],
+      agent_panel: nil,
+      status_bar: {22, 0, 80, 1},
+      minibuffer: {23, 0, 80, 1}
+    }
+  end
+
+  describe "from_layout/1" do
+    test "produces a viewport-rooted tree with the canonical regions" do
+      tree = FocusTree.from_layout(single_window_layout())
+
+      assert tree.content_type == :viewport
+      assert tree.rect == {0, 0, 80, 24}
+
+      content_types = Enum.map(tree.children, & &1.content_type)
+      # Order is editor_z (back-to-front): tab_bar, editor_area, status_bar, minibuffer.
+      # file_tree, agent_panel only present when their rect is non-nil.
+      assert :tab_bar in content_types
+      assert :editor_area in content_types
+      assert :status_bar in content_types
+      assert :minibuffer in content_types
+      refute :file_tree in content_types
+      refute :agent_panel in content_types
+    end
+
+    test "skips nil chrome regions cleanly" do
+      layout = %{single_window_layout() | tab_bar: nil, status_bar: nil}
+      tree = FocusTree.from_layout(layout)
+
+      content_types = Enum.map(tree.children, & &1.content_type)
+      refute :tab_bar in content_types
+      refute :status_bar in content_types
+      assert :editor_area in content_types
+      assert :minibuffer in content_types
+    end
+
+    test "editor_area carries one window child per window_layout entry" do
+      tree = FocusTree.from_layout(split_layout())
+      editor = Enum.find(tree.children, &(&1.content_type == :editor_area))
+
+      assert length(editor.children) == 2
+      assert Enum.all?(editor.children, &(&1.content_type == :window))
+      refs = Enum.map(editor.children, & &1.ref)
+      assert refs == [1, 2]
+    end
+
+    test "windows carry buffer_content children that are scrollable and focusable" do
+      tree = FocusTree.from_layout(single_window_layout())
+      editor = Enum.find(tree.children, &(&1.content_type == :editor_area))
+      window = hd(editor.children)
+      content = Enum.find(window.children, &(&1.content_type == :buffer_content))
+
+      assert content.scrollable? == true
+      assert content.focusable? == true
+      assert content.ref == 1
+    end
+
+    test "zero-height modelines are not added as children" do
+      tree = FocusTree.from_layout(single_window_layout())
+      editor = Enum.find(tree.children, &(&1.content_type == :editor_area))
+      window = hd(editor.children)
+
+      refute Enum.any?(window.children, &(&1.content_type == :modeline))
+    end
+  end
+
+  describe "hit_test/3 — deepest match" do
+    test "returns the deepest matching node, not just the root" do
+      tree = FocusTree.from_layout(single_window_layout())
+
+      hit = FocusTree.hit_test(tree, 5, 40)
+      # Inside the buffer content of window 1.
+      assert hit.content_type == :buffer_content
+      assert hit.ref == 1
+    end
+
+    test "click on tab bar resolves to :tab_bar" do
+      tree = FocusTree.from_layout(single_window_layout())
+      hit = FocusTree.hit_test(tree, 0, 5)
+      assert hit.content_type == :tab_bar
+    end
+
+    test "click on minibuffer resolves to :minibuffer" do
+      tree = FocusTree.from_layout(single_window_layout())
+      hit = FocusTree.hit_test(tree, 23, 10)
+      assert hit.content_type == :minibuffer
+    end
+
+    test "click outside the viewport returns nil" do
+      tree = FocusTree.from_layout(single_window_layout())
+      assert FocusTree.hit_test(tree, 100, 10) == nil
+      assert FocusTree.hit_test(tree, 5, 200) == nil
+    end
+
+    test "split layout: click in left window resolves to that window's content" do
+      tree = FocusTree.from_layout(split_layout())
+      hit = FocusTree.hit_test(tree, 5, 40)
+      assert hit.ref == 1
+    end
+
+    test "split layout: click in right window resolves to that window's content" do
+      tree = FocusTree.from_layout(split_layout())
+      hit = FocusTree.hit_test(tree, 5, 60)
+      assert hit.ref == 2
+    end
+
+    test "click on file tree resolves to :file_tree (not the editor area below it)" do
+      tree = FocusTree.from_layout(split_layout())
+      hit = FocusTree.hit_test(tree, 5, 10)
+      assert hit.content_type == :file_tree
+    end
+  end
+
+  describe "hit_test/3 — boundary clicks" do
+    test "click exactly at a rect's top-left corner is inside" do
+      tree = FocusTree.from_layout(single_window_layout())
+      # Tab bar starts at (0, 0).
+      assert FocusTree.hit_test(tree, 0, 0).content_type == :tab_bar
+    end
+
+    test "click exactly at a rect's bottom-right edge is outside" do
+      tree = FocusTree.from_layout(single_window_layout())
+      # Terminal is {0, 0, 80, 24} → rows 0..23, cols 0..79.
+      assert FocusTree.hit_test(tree, 24, 80) == nil
+    end
+  end
+
+  describe "with_overlay/3 — z-order" do
+    test "an overlay added to the root takes precedence over underlying regions" do
+      tree =
+        single_window_layout()
+        |> FocusTree.from_layout()
+        |> FocusTree.with_overlay(:modal_overlay, {5, 10, 30, 10}, focusable?: true)
+
+      hit = FocusTree.hit_test(tree, 8, 20)
+      assert hit.content_type == :modal_overlay
+    end
+
+    test "clicks outside the overlay still resolve to underlying regions" do
+      tree =
+        single_window_layout()
+        |> FocusTree.from_layout()
+        |> FocusTree.with_overlay(:modal_overlay, {5, 10, 30, 10})
+
+      hit = FocusTree.hit_test(tree, 0, 0)
+      assert hit.content_type == :tab_bar
+    end
+  end
+
+  describe "hit_path/3 — bubble dispatch" do
+    test "returns nodes from root to deepest" do
+      tree = FocusTree.from_layout(single_window_layout())
+      path = FocusTree.hit_path(tree, 5, 40)
+
+      types = Enum.map(path, & &1.content_type)
+      assert types == [:viewport, :editor_area, :window, :buffer_content]
+    end
+
+    test "click on tab bar produces a one-deep bubble path under the viewport" do
+      tree = FocusTree.from_layout(single_window_layout())
+      path = FocusTree.hit_path(tree, 0, 5)
+      types = Enum.map(path, & &1.content_type)
+      assert types == [:viewport, :tab_bar]
+    end
+  end
+
+  describe "Node.contains?/3" do
+    test "inclusive-on-low, exclusive-on-high (half-open interval)" do
+      node = TreeNode.new(:viewport, {2, 3, 5, 4})
+      # Rows 2..5, cols 3..7
+      assert TreeNode.contains?(node, 2, 3)
+      assert TreeNode.contains?(node, 5, 7)
+      refute TreeNode.contains?(node, 6, 5)
+      refute TreeNode.contains?(node, 3, 8)
+      refute TreeNode.contains?(node, 1, 5)
+      refute TreeNode.contains?(node, 3, 2)
+    end
+  end
+end


### PR DESCRIPTION
Refs #1435 — foundation only; per-handler migration is staged as follow-up work.

## Summary

Introduces `MingaEditor.FocusTree` (and `FocusTree.Node`), a tree-of-regions representation built once per frame from `Layout`. The mouse-routing target is `hit_test/3`, which walks the tree top-down and resolves to the deepest matching node — replacing the flat hit-test stack pattern where every input handler walks `Layout.get(state)` rects asking \"am I responsible?\"

### API
- `FocusTree.from_layout/1` — pure builder
- `FocusTree.with_overlay/3` — appends a modal/float at the root so it takes precedence over underlying regions
- `FocusTree.hit_test/3` — deepest node containing `(row, col)`, or `nil`
- `FocusTree.hit_path/3` — full root-to-deepest path for bubble dispatch (try the deepest handler first, bubble up on `:passthrough`)
- `FocusTree.Node.contains?/3` — half-open rect containment

### Z-order

Children are listed back-to-front (`tab_bar, editor_area, file_tree, agent_panel, status_bar, minibuffer`) and `hit_test/3` reverses for matching. That's how `file_tree` wins over `editor_area` at overlapping columns even though both share the same `(row, col)` range. Modal overlays appended via `with_overlay/3` take precedence over everything beneath.

## Status — what's NOT in this PR

The ad-hoc `inside_*?/2` predicates in `Input.{Picker, Completion, AgentMouse, FileTreeHandler}` are **not** yet removed (AC #3 of the parent ticket). The current predicates keep working because this PR is purely additive at the layer below the input handlers. Migrating each handler to use `FocusTree.hit_test/3` is a per-handler refactor with non-trivial test surface; staging it as follow-ups keeps each step reviewable.

Per-handler removal sequence (suggested):
1. `Input.FileTreeHandler` — simplest, single rect.
2. `Input.Completion` — popup rect; bubble dispatch uses the new `hit_path/3`.
3. `Input.Picker` — has both bottom-anchored and centered variants.
4. `Input.AgentMouse` — multi-region; biggest delta.

## Verification

| AC | How proved |
| --- | --- |
| 1. `MingaEditor.FocusTree` module representing region hierarchy with parent/sibling refs | `lib/minga_editor/focus_tree.ex` and `lib/minga_editor/focus_tree/node.ex`. Parent/sibling navigation is implicit in tree traversal; `hit_path/3` exposes root-to-deepest. |
| 2. `Input.Router.dispatch_mouse/7` walks the tree top-down | **Deferred to follow-up** — the API (`hit_test/3`, `hit_path/3`) is in place; wiring it into `Input.Router` is the next PR. |
| 3. Ad-hoc `inside_*?/2` predicates removed | **Deferred** as above. |
| 4. Scroll-wheel events route to deepest scrollable | The tree carries `scrollable?` per node (set on `:buffer_content`); the dispatcher follow-up will consume it. |
| 5. Click-to-focus inside a window | The tree carries `focusable?` per node (set on `:window` and `:buffer_content`); the dispatcher follow-up will consume it. |
| 6. New tests cover focus-tree resolution at boundaries | 19 tests in `test/minga_editor/focus_tree_test.exs`: tree construction, deepest-match, file-tree-over-editor z-order, split-window resolution, overlay precedence, half-open rect boundaries, bubble-dispatch path. |

### Local verification
- `mix compile --warnings-as-errors` — clean
- `mix test test/minga_editor/focus_tree_test.exs` — 19/19 pass
- `make lint` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)