### PR TITLE
fix(state): normalise editing at tab-context snapshot time (#1476)

### DIFF
--- a/lib/minga_editor/shell/board/input.ex
+++ b/lib/minga_editor/shell/board/input.ex
@@ -20,6 +20,7 @@ defmodule MingaEditor.Shell.Board.Input do
   alias MingaAgent.Config, as: AgentConfig
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.Shell.Board
   alias MingaEditor.Shell.Board.Card
   alias MingaEditor.Shell.Board.State, as: BoardState
@@ -253,7 +254,7 @@ defmodule MingaEditor.Shell.Board.Input do
     if card do
       # Store the current workspace as the "board grid" snapshot on
       # the zoomed card. This gets restored when zooming back out.
-      current_workspace = Map.from_struct(state.workspace)
+      current_workspace = WorkspaceState.to_tab_context(state.workspace)
       new_board = BoardState.zoom_into(board, card.id, current_workspace)
       state = %{state | shell_state: new_board}
 
@@ -295,7 +296,7 @@ defmodule MingaEditor.Shell.Board.Input do
     {board, state} = start_and_attach_session(board, card.id, model, state)
 
     # Snapshot current workspace and zoom into the card
-    workspace_snapshot = Map.from_struct(state.workspace)
+    workspace_snapshot = WorkspaceState.to_tab_context(state.workspace)
     board = BoardState.zoom_into(board, card.id, workspace_snapshot)
     state = %{state | shell_state: board}
 

--- a/lib/minga_editor/shell/board/zoom_out.ex
+++ b/lib/minga_editor/shell/board/zoom_out.ex
@@ -12,6 +12,7 @@ defmodule MingaEditor.Shell.Board.ZoomOut do
   @behaviour MingaEditor.Input.Handler
 
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.Shell.Board
   alias MingaEditor.Shell.Board.AgentDeactivation
   alias MingaEditor.Shell.Board.Card
@@ -65,7 +66,7 @@ defmodule MingaEditor.Shell.Board.ZoomOut do
     grid_workspace = if card, do: card.workspace, else: nil
 
     # Store the live (zoomed) workspace onto the card for next zoom-in
-    live_workspace = Map.from_struct(state.workspace)
+    live_workspace = WorkspaceState.to_tab_context(state.workspace)
 
     board =
       BoardState.update_card(board, card_id, fn c ->

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -360,7 +360,7 @@ defmodule MingaEditor.Shell.Traditional do
       {shell_state, workspace}
     else
       # Snapshot current workspace onto outgoing tab
-      context = Map.from_struct(workspace)
+      context = WorkspaceState.to_tab_context(workspace)
       tb = TabBar.update_context(tb, current_id, context)
 
       # Switch pointer and restore target tab's workspace
@@ -382,7 +382,7 @@ defmodule MingaEditor.Shell.Traditional do
           {ShellState.t(), WorkspaceState.t()}
   defp open_buffer_from_agent_tab(%ShellState{tab_bar: tb} = shell_state, workspace, label) do
     # Snapshot current agent tab before leaving
-    context = Map.from_struct(workspace)
+    context = WorkspaceState.to_tab_context(workspace)
     tb = TabBar.update_context(tb, tb.active_id, context)
 
     # Create file tab (TabBar.add auto-activates it)
@@ -394,7 +394,7 @@ defmodule MingaEditor.Shell.Traditional do
     workspace = WorkspaceState.sync_active_window_buffer(workspace)
 
     # Snapshot the new tab's context
-    new_context = Map.from_struct(workspace)
+    new_context = WorkspaceState.to_tab_context(workspace)
     tb = TabBar.update_context(tb, new_tab.id, new_context)
 
     Log.debug(:editor, fn -> "[tab] on_buffer_added new tab=#{new_tab.id} label=#{label}" end)
@@ -409,7 +409,7 @@ defmodule MingaEditor.Shell.Traditional do
           {ShellState.t(), WorkspaceState.t()}
   defp open_buffer_in_file_tab(%ShellState{tab_bar: tb} = shell_state, workspace, label) do
     # Snapshot current tab before leaving
-    context = Map.from_struct(workspace)
+    context = WorkspaceState.to_tab_context(workspace)
     tb = TabBar.update_context(tb, tb.active_id, context)
 
     # Create file tab (TabBar.add auto-activates it)
@@ -417,7 +417,7 @@ defmodule MingaEditor.Shell.Traditional do
     workspace = WorkspaceState.sync_active_window_buffer(workspace)
 
     # Snapshot the new tab's context
-    new_context = Map.from_struct(workspace)
+    new_context = WorkspaceState.to_tab_context(workspace)
     tb = TabBar.update_context(tb, new_tab.id, new_context)
 
     {%{shell_state | tab_bar: tb}, workspace}

--- a/lib/minga_editor/vim_state.ex
+++ b/lib/minga_editor/vim_state.ex
@@ -62,6 +62,50 @@ defmodule MingaEditor.VimState do
   end
 
   @doc """
+  Returns a vim state whose `mode_state` matches `mode`.
+
+  The Mode FSM carries the leaving mode's state through `Mode.apply_result/2`
+  so commands that fire on `:execute_then_transition` can read the leaving
+  state (e.g. `:yank_visual_selection` reads `%VisualState{}` to find the
+  selection range). During that window `workspace.editing.mode_state` is
+  the leaving struct while `mode` is already the new mode.
+
+  Code paths that snapshot the workspace into long-lived storage (tab
+  contexts, session save) must not capture that in-flight pair, because
+  restoring it would put `:normal` next to a `%CommandState{}` (or similar)
+  and break the next leader keypress with a `KeyError`. Call this before
+  snapshotting.
+
+  Pass-through if `mode_state` is already the right struct for `mode`.
+  Otherwise rebuild via `transition/3` with `nil` to use the default for
+  default-state modes; raises for context-required modes (which should
+  never be a snapshot's resting state).
+  """
+  @spec normalize(t()) :: t()
+  def normalize(%__MODULE__{mode: mode, mode_state: mode_state} = vim) do
+    if is_struct(mode_state, expected_struct(mode)) do
+      vim
+    else
+      transition(vim, mode, nil)
+    end
+  end
+
+  @spec expected_struct(Mode.mode()) :: module()
+  defp expected_struct(:normal), do: Minga.Mode.State
+  defp expected_struct(:insert), do: Minga.Mode.State
+  defp expected_struct(:command), do: Minga.Mode.CommandState
+  defp expected_struct(:eval), do: Minga.Mode.EvalState
+  defp expected_struct(:replace), do: Minga.Mode.ReplaceState
+  defp expected_struct(:visual), do: Minga.Mode.VisualState
+  defp expected_struct(:operator_pending), do: Minga.Mode.OperatorPendingState
+  defp expected_struct(:search), do: Minga.Mode.SearchState
+  defp expected_struct(:search_prompt), do: Minga.Mode.SearchPromptState
+  defp expected_struct(:substitute_confirm), do: Minga.Mode.SubstituteConfirmState
+  defp expected_struct(:extension_confirm), do: Minga.Mode.ExtensionConfirmState
+  defp expected_struct(:tool_confirm), do: Minga.Mode.ToolConfirmState
+  defp expected_struct(:delete_confirm), do: Minga.Mode.DeleteConfirmState
+
+  @doc """
   Transitions to a new mode, returning an updated VimState.
 
   This is the single gate function for all mode changes. Every mode

--- a/lib/minga_editor/workspace/state.ex
+++ b/lib/minga_editor/workspace/state.ex
@@ -71,6 +71,25 @@ defmodule MingaEditor.Workspace.State do
     |> Enum.reject(&(&1 == :__struct__))
   end
 
+  @doc """
+  Converts a workspace into a flat-map tab context suitable for storing
+  on a `MingaEditor.State.Tab` and later restoring via
+  `EditorState.restore_tab_context/2`.
+
+  The single chokepoint for snapshots. Beyond the `Map.from_struct/1`
+  conversion, this normalises `editing` so the snapshotted vim state is a
+  valid resting state — not a transient mid-transition pair where
+  `mode_state` belongs to the leaving mode (see `VimState.normalize/1`).
+  Use this everywhere the editor captures `state.workspace` into a tab
+  context.
+  """
+  @spec to_tab_context(t()) :: map()
+  def to_tab_context(%__MODULE__{} = ws) do
+    ws
+    |> Map.update!(:editing, &VimState.normalize/1)
+    |> Map.from_struct()
+  end
+
   # ── Pure workspace operations ─────────────────────────────────────────────
   #
   # These are pure functions (no side effects) on WorkspaceState. The

--- a/test/minga_editor/vim_state_test.exs
+++ b/test/minga_editor/vim_state_test.exs
@@ -1,0 +1,132 @@
+defmodule MingaEditor.VimStateTest do
+  @moduledoc """
+  Pure-function tests for `MingaEditor.VimState`.
+
+  Focused on the snapshot/restore contract: `VimState.normalize/1` is the
+  chokepoint that ensures a vim state captured into long-lived storage
+  (tab context) is a valid resting state — `mode` and `mode_state`
+  agreeing on which struct holds the FSM context.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Minga.Mode
+  alias MingaEditor.VimState
+
+  alias Minga.Mode.{
+    CommandState,
+    EvalState,
+    OperatorPendingState,
+    ReplaceState,
+    SearchPromptState,
+    SearchState,
+    State,
+    VisualState
+  }
+
+  describe "normalize/1" do
+    test "rebuilds %CommandState{} -> %Mode.State{} when mode is :normal" do
+      # Reproduces the post-`:e <path><CR>` window where Command.handle_key
+      # returned a CommandState alongside the new :normal mode.
+      vim = %VimState{mode: :normal, mode_state: %CommandState{input: ""}}
+
+      result = VimState.normalize(vim)
+
+      assert result.mode == :normal
+      assert match?(%State{}, result.mode_state)
+    end
+
+    test "rebuilds %EvalState{} -> %Mode.State{} when mode is :normal" do
+      vim = %VimState{mode: :normal, mode_state: %EvalState{input: "1+1"}}
+      result = VimState.normalize(vim)
+      assert match?(%State{}, result.mode_state)
+    end
+
+    test "rebuilds %SearchState{} -> %Mode.State{} when mode is :normal" do
+      vim = %VimState{
+        mode: :normal,
+        mode_state: %SearchState{direction: :forward, input: "foo"}
+      }
+
+      result = VimState.normalize(vim)
+      assert match?(%State{}, result.mode_state)
+    end
+
+    test "passes through when mode_state already matches mode" do
+      vim = %VimState{mode: :normal, mode_state: Mode.initial_state()}
+      assert VimState.normalize(vim) == vim
+    end
+
+    test "passes through a properly-typed VisualState (preserves visual_anchor)" do
+      visual = %VisualState{visual_type: :char, visual_anchor: {3, 7}}
+      vim = %VimState{mode: :visual, mode_state: visual}
+
+      result = VimState.normalize(vim)
+
+      assert result.mode == :visual
+      assert result.mode_state == visual
+    end
+
+    test "rebuilds when mode is :command but mode_state is the wrong struct" do
+      vim = %VimState{mode: :command, mode_state: Mode.initial_state()}
+      result = VimState.normalize(vim)
+      assert match?(%CommandState{}, result.mode_state)
+    end
+
+    test "raises for context-required modes carrying a wrong mode_state struct" do
+      # Visual is a context-required mode. Arriving here with %Mode.State{}
+      # in mode_state means the caller bypassed the proper transition path;
+      # surfacing the bug at snapshot time is better than silently writing
+      # nonsense into a tab context.
+      vim = %VimState{mode: :visual, mode_state: Mode.initial_state()}
+
+      assert_raise ArgumentError, ~r/requires an explicit mode_state/, fn ->
+        VimState.normalize(vim)
+      end
+    end
+  end
+
+  describe "normalize/1 — property: mode and mode_state always agree after normalize" do
+    @default_state_modes [:normal, :insert, :command, :eval, :replace]
+
+    # Maps each default-state mode to the struct module its mode_state should be.
+    @expected_struct %{
+      normal: State,
+      insert: State,
+      command: CommandState,
+      eval: EvalState,
+      replace: ReplaceState
+    }
+
+    # Generators for various mode_state struct types. The set is deliberately
+    # broad so the property explores cross-mode mismatches the way the bug
+    # manifests in production (`:normal` carrying a leaving `%CommandState{}`).
+    defp mismatch_state_gen do
+      StreamData.one_of([
+        StreamData.constant(%State{}),
+        StreamData.constant(%CommandState{}),
+        StreamData.constant(%EvalState{}),
+        StreamData.constant(%ReplaceState{}),
+        StreamData.constant(%SearchState{direction: :forward}),
+        StreamData.constant(%SearchPromptState{}),
+        StreamData.constant(%VisualState{visual_type: :char}),
+        StreamData.constant(%OperatorPendingState{operator: :delete})
+      ])
+    end
+
+    property "default-state modes always produce the expected struct after normalize" do
+      check all(
+              mode <- StreamData.member_of(@default_state_modes),
+              mode_state <- mismatch_state_gen()
+            ) do
+        vim = %VimState{mode: mode, mode_state: mode_state}
+        result = VimState.normalize(vim)
+
+        expected_module = Map.fetch!(@expected_struct, mode)
+        assert is_struct(result.mode_state, expected_module)
+        assert result.mode == mode
+      end
+    end
+  end
+end

--- a/test/minga_editor/workspace/state_test.exs
+++ b/test/minga_editor/workspace/state_test.exs
@@ -8,6 +8,8 @@ defmodule MingaEditor.Workspace.StateTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Mode
+  alias MingaEditor.VimState
   alias MingaEditor.Window.Content
   alias MingaEditor.Workspace.State, as: WorkspaceState
 
@@ -61,6 +63,49 @@ defmodule MingaEditor.Workspace.StateTest do
       assert result_window.content == {:agent_chat, agent_pid}
       # buffer field should remain unchanged (still the original, not new_buf)
       assert result_window.buffer == window.buffer
+    end
+  end
+
+  describe "to_tab_context/1" do
+    test "returns a flat map of workspace fields" do
+      ws = base_state().workspace
+      ctx = WorkspaceState.to_tab_context(ws)
+
+      assert is_map(ctx)
+      refute Map.has_key?(ctx, :__struct__)
+      assert ctx.buffers == ws.buffers
+      assert ctx.windows == ws.windows
+      assert ctx.viewport == ws.viewport
+    end
+
+    test "normalises an in-flight CommandState back to %Mode.State{} when mode is :normal" do
+      # Simulates the moment after Command.handle_key/2 returns
+      # `{:execute_then_transition, [...], :normal, %CommandState{input: ""}}`
+      # and the dispatch wrote that pair into workspace.editing before the
+      # ex-command ran (the same moment :e <path> would snapshot).
+      ws = base_state().workspace
+      mismatched = %VimState{mode: :normal, mode_state: %Mode.CommandState{input: ""}}
+      ws = %{ws | editing: mismatched}
+
+      ctx = WorkspaceState.to_tab_context(ws)
+
+      assert ctx.editing.mode == :normal
+      assert match?(%Mode.State{}, ctx.editing.mode_state)
+    end
+
+    test "passes through editing when mode_state already matches mode" do
+      ws = base_state().workspace
+      visual_state = %Mode.VisualState{visual_type: :char, visual_anchor: {3, 0}}
+      vim = %VimState{mode: :visual, mode_state: visual_state}
+      ws = %{ws | editing: vim}
+
+      ctx = WorkspaceState.to_tab_context(ws)
+
+      # Visual is a context-required mode and the snapshot already had a
+      # properly-typed VisualState — the visual_anchor must be preserved
+      # so the context can be restored verbatim.
+      assert ctx.editing.mode == :visual
+      assert ctx.editing.mode_state == visual_state
     end
   end
 end


### PR DESCRIPTION
## Summary

- Resolves #1476: `workspace.editing.mode = :normal` while `mode_state = %CommandState{}` (or other leaving-mode struct) when a tab context is captured during `:e <path>` execution. Restoring such a tab later crashes the next leader keypress with `KeyError, key :leader_trie not found in: %CommandState{...}`.
- Fix is at snapshot time, not transition time — `Mode.process/3` legitimately carries the leaving mode's state forward so `:execute_then_transition` commands can read it (e.g. visual ops need `%VisualState{}`'s `visual_anchor`). Normalising at the FSM level breaks that semantic; normalising at snapshot time doesn't.
- New `VimState.normalize/1` rebuilds `mode_state` to match `mode` for default-state modes, passes through when already aligned, and raises for context-required modes (`:visual`, `:operator_pending`, `:search`, etc.) where arriving with a wrong struct is a real bug worth surfacing.
- New `Workspace.State.to_tab_context/1` is the single chokepoint for workspace-to-context snapshots, wrapping `Map.from_struct/1` and running the vim normaliser. Replaces eight bare `Map.from_struct/1` callsites across `Shell.Traditional` and `Shell.Board`.

## Why this won't break visual / operator / search workflows

The Mode FSM contract has not changed: `apply_result/2` still returns the leaving mode's state alongside the new mode, and `key_dispatch.handle_key/3` still installs that pair into `workspace.editing` before running the resulting commands. Visual ops, operator-pending continuations, and similar code that pattern-matches on `mode_state: %SomeMode.State{}` continue to work exactly as before.

The normaliser only fires when the workspace is being captured into a tab context — i.e. when the editor decides "this is a resting state worth persisting." At that point a mismatched mode/mode_state pair has no useful information to preserve (the leaving handler already extracted what it needed into the command tuple).

## Test plan

- [x] `mix test test/minga_editor/vim_state_test.exs` — new file with 8 unit cases + 1 property
- [x] `mix test test/minga_editor/workspace/state_test.exs` — new `to_tab_context/1` cases covering the regression and the visual-anchor pass-through
- [x] `mix test --seed 0 / 1 / 12345 / 99999` — full suite at four seeds, 0 failures
- [ ] CI

## Follow-up

- Unblocks #1477 (restore `SPC b n` smart-cycle), which now no longer needs to fear the snapshot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)