### PR TITLE
feat(buffer): restore SPC b n / b p smart-cycle (#1477)

### DIFF
--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -580,13 +580,27 @@ defmodule MingaEditor.Commands.BufferManagement do
   # ── Private buffer helpers ────────────────────────────────────────────────
 
   @spec switch_to_buffer(state(), non_neg_integer()) :: state()
+  defp switch_to_buffer(
+         %{shell_state: %{tab_bar: %TabBar{} = tb}, workspace: %{buffers: %{list: buffers}}} =
+           state,
+         idx
+       ) do
+    target_buf = Enum.at(buffers, idx)
+
+    case find_tab_for_buffer(tb, target_buf) do
+      nil -> EditorState.switch_buffer(state, idx)
+      tab_id when tab_id == tb.active_id -> EditorState.switch_buffer(state, idx)
+      tab_id -> EditorState.switch_tab(state, tab_id)
+    end
+  end
+
   defp switch_to_buffer(state, idx), do: EditorState.switch_buffer(state, idx)
 
   @spec next_buffer(state()) :: state()
   defp next_buffer(
          %{workspace: %{buffers: %{list: [_, _ | _] = buffers, active_index: idx}}} = state
        ) do
-    EditorState.switch_buffer(state, rem(idx + 1, Enum.count(buffers)))
+    cycle_buffer_in_tab(state, rem(idx + 1, Enum.count(buffers)))
   end
 
   defp next_buffer(state), do: state
@@ -596,10 +610,42 @@ defmodule MingaEditor.Commands.BufferManagement do
          %{workspace: %{buffers: %{list: [_, _ | _] = buffers, active_index: idx}}} = state
        ) do
     count = Enum.count(buffers)
-    EditorState.switch_buffer(state, rem(idx - 1 + count, count))
+    cycle_buffer_in_tab(state, rem(idx - 1 + count, count))
   end
 
   defp prev_buffer(state), do: state
+
+  # Cycles to the buffer at `idx`. If that buffer has its own dedicated
+  # file tab, switches to that tab so the tab bar tracks what the user
+  # sees; otherwise switches in-place inside the current tab. This keeps
+  # `SPC b n` / `SPC b p` consistent with the per-tab snapshot model:
+  # each open file should normally live in its own tab, and cycling
+  # buffers should move tab focus accordingly.
+  @spec cycle_buffer_in_tab(state(), non_neg_integer()) :: state()
+  defp cycle_buffer_in_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, idx) do
+    target_buf = Enum.at(state.workspace.buffers.list, idx)
+
+    case find_tab_for_buffer(tb, target_buf) do
+      nil -> EditorState.switch_buffer(state, idx)
+      tab_id when tab_id == tb.active_id -> EditorState.switch_buffer(state, idx)
+      tab_id -> EditorState.switch_tab(state, tab_id)
+    end
+  end
+
+  defp cycle_buffer_in_tab(state, idx), do: EditorState.switch_buffer(state, idx)
+
+  # Finds the file tab whose snapshotted context has `target_buf` as the
+  # active buffer. Returns `nil` when no tab matches (the buffer was
+  # opened inline in the current tab via `:b<n>` or similar).
+  @spec find_tab_for_buffer(TabBar.t(), pid() | nil) :: Tab.id() | nil
+  defp find_tab_for_buffer(_tb, nil), do: nil
+
+  defp find_tab_for_buffer(%TabBar{tabs: tabs}, target_buf) do
+    Enum.find_value(tabs, fn
+      %{kind: :file, id: id, context: %{buffers: %{active: ^target_buf}}} -> id
+      _ -> nil
+    end)
+  end
 
   @spec next_tab(state()) :: state()
   defp next_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do

--- a/test/minga/buffer_management_test.exs
+++ b/test/minga/buffer_management_test.exs
@@ -83,6 +83,38 @@ defmodule Minga.BufferManagementTest do
       assert active_content(ctx) == "alpha"
     end
 
+    @tag :tmp_dir
+    test "leader keys keep working through buffer cycling after :e", %{tmp_dir: tmp_dir} do
+      # Regression for #1476 (the snapshot bug surfaced via #1477's
+      # smart-cycle): after `:e <path>` the leaving mode's CommandState
+      # used to leak into the tab's editing.mode_state snapshot. When
+      # smart-cycle later restored that tab via tab-switch, the next
+      # leader keypress crashed with `KeyError, key :leader_trie not
+      # found in: %CommandState{}`. With the fix in #1476, every tab
+      # snapshot is a valid resting state, so leader handling stays
+      # alive across multiple cycle/`<SPC>` rounds.
+      path1 = Path.join(tmp_dir, "a.txt")
+      path2 = Path.join(tmp_dir, "b.txt")
+      path3 = Path.join(tmp_dir, "c.txt")
+      File.write!(path1, "alpha")
+      File.write!(path2, "beta")
+      File.write!(path3, "gamma")
+
+      ctx = start_editor("alpha", file_path: path1)
+      send_keys(ctx, ":e #{path2}<CR>")
+      send_keys(ctx, ":e #{path3}<CR>")
+
+      # Several leader rounds across cycle should never raise.
+      send_keys_sync(ctx, "<SPC>bn")
+      send_keys_sync(ctx, "<SPC>bn")
+      send_keys_sync(ctx, "<SPC>bp")
+      send_keys_sync(ctx, "<SPC>bn")
+
+      # Editor still alive and processing keys.
+      assert Process.alive?(ctx.editor)
+      assert active_content(ctx) in ["alpha", "beta", "gamma"]
+    end
+
     test "next/prev with single buffer is a no-op" do
       ctx = start_editor("only one")
 


### PR DESCRIPTION
## Summary

- Resolves #1477 (depends on #1478/#1476, base is set to that branch).
- Reintroduces \`find_tab_for_buffer/2\` with the new flat-context shape (\`%{buffers: %{active: ^pid}}\`), and restores the three-way dispatch (\`nil → in-place\`, \`active tab → in-place\`, \`other tab → switch_tab\`) in \`cycle_buffer_in_tab/2\` and \`switch_to_buffer/2\`.
- The original implementation was removed in #1468 because the matcher relied on a legacy \`:active_buffer\` key the migration code injected, and updating it to the new shape uncovered #1476 (\`%CommandState{}\` leaking into snapshots → \`KeyError\` on next leader key after a tab restore). With #1476 landed, smart-cycle is safe to bring back.

## What this delivers

- Smart-cycle wiring: when the next/previous buffer has a dedicated file tab, focus moves to that tab. Falls back to in-place switching otherwise.
- Leader-key safety: the regression test exercises \`<SPC>\` rounds across multiple cycle/`:e` operations, asserting the editor stays alive — the property #1476 protects.

## Known gap, filed separately as #1479

Tab snapshots taken during \`:e <path>\` record the **newly-added** buffer as the leaving tab's active (because \`add_buffer_pure\` mutates \`buffers.active\` before \`on_buffer_added\` snapshots). So \`find_tab_for_buffer/2\` doesn't match for tabs created via \`:e\` and the smart-cycle silently falls through to in-place. The fix is at \`add_buffer_pure\` / the \`BufferLifecycle\` callback signature and is out of scope for this PR; once #1479 lands the cycle test can be strengthened to assert tab focus actually changes.

## Test plan

- [x] \`mix test test/minga/buffer_management_test.exs\` (pre-#1468 cycle test + new leader-key safety test)
- [x] \`mix test --seed 0\` — full suite, 0 failures
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)