### PR TITLE
feat(ui): migrate completion menu to ModalOverlay (#1426)

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -564,10 +564,13 @@ defmodule MingaEditor do
   # Completion debounce timer fired — send the actual completion request
   def handle_info({:completion_debounce, clients, buffer_pid}, state) do
     new_bridge =
-      CompletionTrigger.flush_debounce(state.workspace.completion_trigger, clients, buffer_pid)
+      CompletionTrigger.flush_debounce(
+        MingaEditor.State.ModalOverlay.completion_trigger(state),
+        clients,
+        buffer_pid
+      )
 
-    {:noreply,
-     EditorState.update_workspace(state, &WorkspaceState.set_completion_trigger(&1, new_bridge))}
+    {:noreply, MingaEditor.State.ModalOverlay.put_completion_trigger(state, new_bridge)}
   end
 
   # LSP async response — route to the appropriate handler based on lsp.pending
@@ -1757,12 +1760,12 @@ defmodule MingaEditor do
   end
 
   defp handle_gui_action(state, {:completion_select, index}) do
-    case state.workspace.completion do
+    case MingaEditor.State.ModalOverlay.completion(state) do
       %Completion{} = comp ->
         updated = %{comp | selected: index}
 
         do_accept_completion(
-          EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, updated)),
+          MingaEditor.State.ModalOverlay.update_completion(state, fn _ -> updated end),
           updated
         )
 

--- a/lib/minga_editor/completion_handling.ex
+++ b/lib/minga_editor/completion_handling.ex
@@ -14,8 +14,8 @@ defmodule MingaEditor.CompletionHandling do
   alias MingaEditor.CompletionTrigger
   alias MingaEditor.SignatureHelp
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
   alias Minga.LSP.Client
-  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias Minga.LSP.SyncServer
 
   @resolve_debounce_ms 150
@@ -28,9 +28,18 @@ defmodule MingaEditor.CompletionHandling do
   item doesn't already have documentation and the server supports resolve.
   """
   @spec maybe_resolve_selected(EditorState.t()) :: EditorState.t()
-  def maybe_resolve_selected(%{workspace: %{completion: nil}} = state), do: state
+  def maybe_resolve_selected(state) do
+    case ModalOverlay.completion(state) do
+      nil ->
+        state
 
-  def maybe_resolve_selected(%{workspace: %{completion: completion}} = state) do
+      completion ->
+        do_maybe_resolve_selected(state, completion)
+    end
+  end
+
+  @spec do_maybe_resolve_selected(EditorState.t(), Completion.t()) :: EditorState.t()
+  defp do_maybe_resolve_selected(state, completion) do
     item = Completion.selected_item(completion)
     selected_idx = completion.selected
 
@@ -49,8 +58,7 @@ defmodule MingaEditor.CompletionHandling do
           Process.send_after(self(), {:completion_resolve, selected_idx}, @resolve_debounce_ms)
         end
 
-      completion = %{completion | resolve_timer: timer}
-      EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, completion))
+      ModalOverlay.update_completion(state, fn _ -> %{completion | resolve_timer: timer} end)
     end
   end
 
@@ -60,12 +68,15 @@ defmodule MingaEditor.CompletionHandling do
   Called from MingaEditor.handle_info({:completion_resolve, index}).
   """
   @spec flush_resolve(EditorState.t(), non_neg_integer()) :: EditorState.t()
-  def flush_resolve(%{workspace: %{completion: nil}} = state, _index), do: state
+  def flush_resolve(state, index) do
+    case ModalOverlay.completion(state) do
+      nil -> state
+      completion -> do_flush_resolve(state, completion, index)
+    end
+  end
 
-  def flush_resolve(
-        %{workspace: %{completion: completion, buffers: %{active: buf}}} = state,
-        index
-      ) do
+  @spec do_flush_resolve(EditorState.t(), Completion.t(), non_neg_integer()) :: EditorState.t()
+  defp do_flush_resolve(%{workspace: %{buffers: %{active: buf}}} = state, completion, index) do
     item = Enum.at(completion.filtered, index)
 
     if item == nil or item.raw == nil do
@@ -94,15 +105,22 @@ defmodule MingaEditor.CompletionHandling do
   """
   @spec handle_resolve_response(EditorState.t(), {:ok, term()} | {:error, term()}) ::
           EditorState.t()
-  def handle_resolve_response(%{workspace: %{completion: nil}} = state, _result), do: state
-
   def handle_resolve_response(state, {:error, _error}), do: state
 
-  def handle_resolve_response(%{workspace: %{completion: completion}} = state, {:ok, resolved}) do
-    doc_text = extract_resolve_documentation(resolved)
-    completion = Completion.update_selected_documentation(completion, doc_text)
-    completion = %{completion | last_resolved_index: completion.selected}
-    EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, completion))
+  def handle_resolve_response(state, {:ok, resolved}) do
+    case ModalOverlay.completion(state) do
+      nil ->
+        state
+
+      _completion ->
+        doc_text = extract_resolve_documentation(resolved)
+
+        ModalOverlay.update_completion(state, fn completion ->
+          completion
+          |> Completion.update_selected_documentation(doc_text)
+          |> Map.put(:last_resolved_index, completion.selected)
+        end)
+    end
   end
 
   @doc """
@@ -146,16 +164,29 @@ defmodule MingaEditor.CompletionHandling do
 
   @doc """
   Dismisses the active completion popup and resets trigger state.
+
+  No-op when the active modal is something other than `:completion` — the
+  caller may invoke this on every non-insert keypress, so we mustn't
+  displace the picker / prompt / etc.
   """
   @spec dismiss(EditorState.t()) :: EditorState.t()
   def dismiss(state) do
-    # Cancel any pending resolve timer to avoid stale messages
-    if state.workspace.completion && state.workspace.completion.resolve_timer do
-      Process.cancel_timer(state.workspace.completion.resolve_timer)
-    end
+    if ModalOverlay.match(state.shell_state.modal, :completion) do
+      # Cancel any pending resolve timer and dismiss the trigger to cancel
+      # debounce timers and forget pending refs before the modal closes.
+      case ModalOverlay.completion(state) do
+        %Completion{resolve_timer: timer} when is_reference(timer) ->
+          Process.cancel_timer(timer)
 
-    new_bridge = CompletionTrigger.dismiss(state.workspace.completion_trigger)
-    EditorState.update_workspace(state, &WorkspaceState.clear_completion(&1, new_bridge))
+        _ ->
+          :ok
+      end
+
+      _ = CompletionTrigger.dismiss(ModalOverlay.completion_trigger(state))
+      ModalOverlay.dismiss(state)
+    else
+      state
+    end
   end
 
   # ── Private helpers ────────────────────────────────────────────────────────
@@ -218,11 +249,15 @@ defmodule MingaEditor.CompletionHandling do
   end
 
   @spec update_filter(EditorState.t(), pid()) :: EditorState.t()
-  defp update_filter(%{workspace: %{completion: nil}} = state, _buf), do: state
+  defp update_filter(state, buf) do
+    case ModalOverlay.completion(state) do
+      nil ->
+        state
 
-  defp update_filter(%{workspace: %{completion: %Completion{} = completion}} = state, buf) do
-    prefix = completion_prefix(buf, completion.trigger_position)
-    apply_filter(state, completion, prefix)
+      %Completion{} = completion ->
+        prefix = completion_prefix(buf, completion.trigger_position)
+        apply_filter(state, completion, prefix)
+    end
   end
 
   @spec apply_filter(EditorState.t(), Completion.t(), String.t() | nil) :: EditorState.t()
@@ -233,7 +268,7 @@ defmodule MingaEditor.CompletionHandling do
     filtered = Completion.filter(completion, prefix)
 
     if Completion.active?(filtered) do
-      EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, filtered))
+      ModalOverlay.update_completion(state, fn _ -> filtered end)
     else
       dismiss(state)
     end
@@ -247,12 +282,9 @@ defmodule MingaEditor.CompletionHandling do
 
       char ->
         {new_bridge, _comp} =
-          CompletionTrigger.maybe_trigger(state.workspace.completion_trigger, char, buf)
+          CompletionTrigger.maybe_trigger(ModalOverlay.completion_trigger(state), char, buf)
 
-        EditorState.update_workspace(
-          state,
-          &WorkspaceState.set_completion_trigger(&1, new_bridge)
-        )
+        ModalOverlay.put_completion_trigger(state, new_bridge)
     end
   end
 
@@ -358,16 +390,15 @@ defmodule MingaEditor.CompletionHandling do
 
   @spec maybe_trigger_config_completion(EditorState.t(), pid(), active_config_context()) ::
           EditorState.t()
-  defp maybe_trigger_config_completion(state, _buf, _context)
-       when state.workspace.completion != nil do
-    # Already showing a completion; update_filter handles narrowing.
-    state
-  end
-
   defp maybe_trigger_config_completion(state, buf, context) do
-    case config_items_for_context(context) do
-      [] -> state
-      items -> build_config_completion(state, buf, items, context)
+    if ModalOverlay.completion(state) != nil do
+      # Already showing a completion; update_filter handles narrowing.
+      state
+    else
+      case config_items_for_context(context) do
+        [] -> state
+        items -> build_config_completion(state, buf, items, context)
+      end
     end
   end
 
@@ -386,11 +417,26 @@ defmodule MingaEditor.CompletionHandling do
     completion = Completion.filter(completion, prefix)
 
     if Completion.active?(completion) do
-      EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, completion))
+      open_completion(state, completion)
     else
       state
     end
   end
+
+  @spec open_completion(EditorState.t(), Completion.t()) :: EditorState.t()
+  defp open_completion(state, completion) do
+    payload =
+      MingaEditor.State.ModalOverlay.Completion.new(active_tab_id(state),
+        completion: completion,
+        trigger: ModalOverlay.completion_trigger(state)
+      )
+
+    ModalOverlay.open(state, :completion, payload)
+  end
+
+  @spec active_tab_id(EditorState.t()) :: term() | nil
+  defp active_tab_id(%{shell_state: %{tab_bar: %{active_id: id}}}), do: id
+  defp active_tab_id(_), do: nil
 
   @typedoc "Config contexts that produce completion items (excludes :none)."
   @type active_config_context :: :option_name | {:option_value, atom()} | :filetype
@@ -481,21 +527,22 @@ defmodule MingaEditor.CompletionHandling do
 
     {new_bridge, completion} =
       CompletionTrigger.handle_response(
-        state.workspace.completion_trigger,
+        ModalOverlay.completion_trigger(state),
         ref,
         result,
         buffer_pid
       )
 
-    new_state =
-      EditorState.update_workspace(state, &WorkspaceState.set_completion_trigger(&1, new_bridge))
+    new_state = ModalOverlay.put_completion_trigger(state, new_bridge)
 
     case completion do
       nil ->
         new_state
 
       %Completion{} ->
-        put_in(new_state.workspace.completion, completion)
+        # The trigger update above guarantees a `:completion` modal is
+        # open (any LSP response implies the trigger had pending refs).
+        ModalOverlay.update_completion(new_state, fn _ -> completion end)
 
       {:merge, items, trigger_pos} ->
         # Merge items from a secondary server into the existing completion
@@ -511,7 +558,7 @@ defmodule MingaEditor.CompletionHandling do
   defp merge_completion_items(state, [], _trigger_pos), do: state
 
   defp merge_completion_items(state, new_items, trigger_pos) do
-    case state.workspace.completion do
+    case ModalOverlay.completion(state) do
       nil ->
         # No existing completion; create a new one from the merged items
         completion = Completion.new(new_items, trigger_pos)
@@ -520,7 +567,7 @@ defmodule MingaEditor.CompletionHandling do
           CompletionTrigger.get_typed_since_trigger(state.workspace.buffers.active, trigger_pos)
 
         completion = Completion.filter(completion, prefix)
-        EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, completion))
+        open_completion(state, completion)
 
       %Completion{} = existing ->
         # Merge into existing completion
@@ -534,7 +581,7 @@ defmodule MingaEditor.CompletionHandling do
           )
 
         completion = Completion.filter(completion, prefix)
-        EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, completion))
+        ModalOverlay.update_completion(state, fn _ -> completion end)
     end
   end
 

--- a/lib/minga_editor/frontend/emit/context.ex
+++ b/lib/minga_editor/frontend/emit/context.ex
@@ -84,7 +84,7 @@ defmodule MingaEditor.Frontend.Emit.Context do
       file_tree: state.workspace.file_tree,
       highlight: state.workspace.highlight,
       agent_ui: state.workspace.agent_ui,
-      completion: state.workspace.completion,
+      completion: MingaEditor.State.ModalOverlay.completion(state),
       editing: state.workspace.editing,
       message_store: state.message_store,
       title: title,

--- a/lib/minga_editor/input/completion.ex
+++ b/lib/minga_editor/input/completion.ex
@@ -19,8 +19,8 @@ defmodule MingaEditor.Input.Completion do
   alias Minga.Editing.Completion
   alias MingaEditor.CompletionHandling
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
   alias MingaEditor.Viewport
-  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   @ctrl MingaEditor.Input.mod_ctrl()
   @escape 27
@@ -34,14 +34,16 @@ defmodule MingaEditor.Input.Completion do
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
-  def handle_key(
-        %{workspace: %{editing: %{mode: :insert}, completion: %Completion{} = completion}} = state,
-        cp,
-        mods
-      ) do
-    case do_handle(state, completion, cp, mods) do
-      {:handled, new_state} -> {:handled, new_state}
-      :passthrough -> {:passthrough, state}
+  def handle_key(%{workspace: %{editing: %{mode: :insert}}} = state, cp, mods) do
+    case ModalOverlay.completion(state) do
+      %Completion{} = completion ->
+        case do_handle(state, completion, cp, mods) do
+          {:handled, new_state} -> {:handled, new_state}
+          :passthrough -> {:passthrough, state}
+        end
+
+      _ ->
+        {:passthrough, state}
     end
   end
 
@@ -62,7 +64,7 @@ defmodule MingaEditor.Input.Completion do
 
   # Completion popup active: intercept scroll and clicks
   def handle_mouse(
-        %{workspace: %{editing: %{mode: :insert}, completion: %Completion{} = completion}} = state,
+        %{workspace: %{editing: %{mode: :insert}}} = state,
         row,
         col,
         button,
@@ -70,23 +72,9 @@ defmodule MingaEditor.Input.Completion do
         :press,
         _cc
       ) do
-    case button do
-      :wheel_down ->
-        {:handled,
-         EditorState.update_workspace(
-           state,
-           &WorkspaceState.set_completion(&1, Completion.move_down(completion))
-         )}
-
-      :wheel_up ->
-        {:handled,
-         EditorState.update_workspace(
-           state,
-           &WorkspaceState.set_completion(&1, Completion.move_up(completion))
-         )}
-
-      :left ->
-        handle_completion_click(state, completion, row, col)
+    case ModalOverlay.completion(state) do
+      %Completion{} = completion ->
+        do_handle_mouse(state, completion, row, col, button)
 
       _ ->
         {:passthrough, state}
@@ -95,6 +83,24 @@ defmodule MingaEditor.Input.Completion do
 
   def handle_mouse(state, _row, _col, _button, _mods, _event_type, _cc) do
     {:passthrough, state}
+  end
+
+  @spec do_handle_mouse(EditorState.t(), Completion.t(), integer(), integer(), atom()) ::
+          MingaEditor.Input.Handler.result()
+  defp do_handle_mouse(state, completion, row, col, button) do
+    case button do
+      :wheel_down ->
+        {:handled, ModalOverlay.update_completion(state, &Completion.move_down/1)}
+
+      :wheel_up ->
+        {:handled, ModalOverlay.update_completion(state, &Completion.move_up/1)}
+
+      :left ->
+        handle_completion_click(state, completion, row, col)
+
+      _ ->
+        {:passthrough, state}
+    end
   end
 
   # ── Completion click ─────────────────────────────────────────────────────
@@ -191,26 +197,16 @@ defmodule MingaEditor.Input.Completion do
   end
 
   # C-n or arrow down: move selection down
-  defp do_handle(state, completion, cp, mods)
+  defp do_handle(state, _completion, cp, mods)
        when (cp == ?n and band(mods, @ctrl) != 0) or cp == @arrow_down do
-    state =
-      EditorState.update_workspace(
-        state,
-        &WorkspaceState.set_completion(&1, Completion.move_down(completion))
-      )
-
+    state = ModalOverlay.update_completion(state, &Completion.move_down/1)
     {:handled, CompletionHandling.maybe_resolve_selected(state)}
   end
 
   # C-p or arrow up: move selection up
-  defp do_handle(state, completion, cp, mods)
+  defp do_handle(state, _completion, cp, mods)
        when (cp == ?p and band(mods, @ctrl) != 0) or cp == @arrow_up do
-    state =
-      EditorState.update_workspace(
-        state,
-        &WorkspaceState.set_completion(&1, Completion.move_up(completion))
-      )
-
+    state = ModalOverlay.update_completion(state, &Completion.move_up/1)
     {:handled, CompletionHandling.maybe_resolve_selected(state)}
   end
 

--- a/lib/minga_editor/input/interrupt.ex
+++ b/lib/minga_editor/input/interrupt.ex
@@ -31,7 +31,6 @@ defmodule MingaEditor.Input.Interrupt do
   @type state :: MingaEditor.Input.Handler.handler_state()
 
   alias MingaEditor.Agent.UIState
-  alias Minga.Editing.Completion
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.ModalOverlay
@@ -141,12 +140,12 @@ defmodule MingaEditor.Input.Interrupt do
   end
 
   @spec maybe_close_completion(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
-  defp maybe_close_completion(%{workspace: %{completion: nil}} = state, resets),
-    do: {state, resets}
-
-  defp maybe_close_completion(%{workspace: %{completion: %Completion{}}} = state, resets) do
-    {EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, nil)),
-     ["completion closed" | resets]}
+  defp maybe_close_completion(state, resets) do
+    if ModalOverlay.match(state.shell_state.modal, :completion) do
+      {ModalOverlay.dismiss(state), ["completion closed" | resets]}
+    else
+      {state, resets}
+    end
   end
 
   @spec maybe_clear_agent_prefix(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -148,7 +148,6 @@ defmodule MingaEditor.RenderPipeline.Input do
         file_tree: ws.file_tree,
         highlight: ws.highlight,
         agent_ui: ws.agent_ui,
-        completion: ws.completion,
         editing: ws.editing,
         document_highlights: ws.document_highlights,
         mouse: ws.mouse,
@@ -198,8 +197,6 @@ defmodule MingaEditor.RenderPipeline.Input do
       input.shell_state |> Map.get(:nav_flash),
       # File tree
       input.workspace.file_tree,
-      # Completion overlay
-      input.workspace.completion,
       # Hover popup and signature help
       input.shell_state |> Map.get(:hover_popup),
       input.shell_state |> Map.get(:signature_help),

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -27,12 +27,15 @@ defmodule MingaEditor.RenderPipeline.Input do
 
   **From `state.workspace` (per-tab editing context, stored as `workspace` map):**
   `windows`, `buffers`, `viewport`, `file_tree`, `highlight`,
-  `agent_ui`, `completion`, `editing`, `document_highlights`,
+  `agent_ui`, `editing`, `document_highlights`,
   `search`, `keymap_scope`
+
+  Note: completion lives on `state.shell_state.modal` after #1426; the
+  fingerprint includes the modal sum type, so completion changes are
+  picked up there.
   """
 
   alias MingaEditor.Agent.UIState
-  alias Minga.Editing.Completion
   alias MingaEditor.Layout
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree
@@ -89,7 +92,6 @@ defmodule MingaEditor.RenderPipeline.Input do
           file_tree: FileTree.t(),
           highlight: Highlighting.t(),
           agent_ui: UIState.t(),
-          completion: Completion.t() | nil,
           editing: VimState.t(),
           document_highlights: [EditorState.document_highlight()] | nil,
           mouse: Mouse.t(),

--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -143,7 +143,7 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
   @spec build_completion_draws(state(), Cursor.t() | nil) :: [DisplayList.draw()]
   defp build_completion_draws(state, %Cursor{row: cur_row, col: cur_col}) do
     CompletionUI.render(
-      state.workspace.completion,
+      MingaEditor.State.ModalOverlay.completion(state),
       %{
         cursor_row: cur_row,
         cursor_col: cur_col,

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -1085,6 +1085,10 @@ defmodule MingaEditor.State do
 
         state = restore_tab_context(state, target.context)
 
+        # If the active modal is completion belonging to the leaving tab,
+        # dismiss it so it doesn't follow us to the new tab.
+        state = MingaEditor.State.ModalOverlay.dismiss_if_stale(state)
+
         # Clear attention flag on the tab we're switching to.
         state =
           set_tab_bar(

--- a/lib/minga_editor/state/modal_overlay.ex
+++ b/lib/minga_editor/state/modal_overlay.ex
@@ -18,47 +18,48 @@ defmodule MingaEditor.State.ModalOverlay do
       | {:conflict, ModalOverlay.Conflict.t()}
       | {:dashboard, ModalOverlay.Dashboard.t()}
 
-  ## Migration phase: dual-write
+  ## Migration status (#1421)
 
-  This is step 3 of 5 (Epic #1421). The picker, prompt, dashboard, and
-  conflict variants have been fully migrated — all reads and writes go
-  through this gate, and their legacy fields have been removed from
-  `Shell.Traditional.State` and `Workspace.State`.
-
-  The completion variant still uses dual-write: every gate function writes
-  both `state.shell_state.modal` and `workspace.completion` so existing
-  readers continue to work during the migration.
-
-  Migration #1426 points completion reads at the new field. When all
-  variants have migrated, #1427 removes the remaining dual-write and
-  adds a Credo rule that forbids direct writes to the legacy field.
+  All five variants are now tracked exclusively on `state.shell_state.modal`.
+  The legacy nullable fields (`shell_state.dashboard`, `shell_state.prompt_ui`,
+  `workspace.pending_conflict`, `workspace.completion`,
+  `workspace.completion_trigger`) have all been removed. #1427 finalises by
+  collapsing `Input.Interrupt` and adding a Credo enforcement rule.
 
   **Do not mutate `:modal` directly**: always call this module's
-  `open/3`, `transition/3`, `close/1`, or `dismiss/1`. A runtime
-  assertion in `:dev` and `:test` builds crashes when the gate detects
-  that its tracked variant has diverged from the legacy mirror.
+  `open/3`, `transition/3`, `close/1`, `dismiss/1`, `update_completion/2`,
+  or `update_completion_trigger/2`.
 
   ## Replacement policy
 
-  `open/3` while a modal is already active replaces the previous one and
-  clears its legacy slot. There is no queue. The exception is
-  `:conflict`: while a conflict prompt is active, other `open/3` calls
-  are logged and return state unchanged. This matches today's behavior
-  where `ConflictPrompt` sits before every other handler in the input
-  stack.
+  `open/3` while a modal is already active replaces the previous one. There
+  is no queue. The exception is `:conflict`: while a conflict prompt is
+  active, other `open/3` calls are logged and return state unchanged. This
+  matches the original behaviour where `ConflictPrompt` sat before every
+  other handler in the input stack.
 
   `transition/3` performs the same replacement but without the sticky
   rule; it is intended for FSM-style steps where the caller has already
   decided that a transition must happen (e.g., picker → prompt).
+
+  ## Per-tab semantics for completion
+
+  Completion is logically per-tab — it tracks the cursor of the buffer
+  that triggered it. The `Completion` payload carries an `owner` tab id;
+  `dismiss_if_stale/1` runs from `EditorState.switch_tab/2` after the new
+  context is restored, dismissing completion that no longer belongs to
+  the active tab. Other variants live on shell state, which isn't
+  snapshotted per tab, so they don't need this hook.
   """
 
+  alias Minga.Editing.Completion
+  alias MingaEditor.CompletionTrigger
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
   alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
   alias MingaEditor.State.ModalOverlay.Dashboard, as: DashboardPayload
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.ModalOverlay.Prompt, as: PromptPayload
-  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   @type variant :: :picker | :prompt | :completion | :conflict | :dashboard
 
@@ -76,8 +77,6 @@ defmodule MingaEditor.State.ModalOverlay do
           | {:completion, CompletionPayload.t()}
           | {:conflict, ConflictPayload.t()}
           | {:dashboard, DashboardPayload.t()}
-
-  @assert_consistency Mix.env() in [:dev, :test]
 
   # Single source of truth for the variant tag list. Adding a sixth modal
   # later means adding to this attribute plus the `t()` and `payload()`
@@ -122,17 +121,21 @@ defmodule MingaEditor.State.ModalOverlay do
   to `open/3` for any other variant are logged and return state
   unchanged. To force a transition out of a conflict modal, call
   `close/1` or `dismiss/1` first, or use `transition/3`.
-
-  Dual-write phase: in addition to setting `state.shell_state.modal`,
-  this function mirrors the payload's underlying state into the variant's
-  legacy field so existing readers continue to work.
   """
   @spec open(EditorState.t(), variant(), payload()) :: EditorState.t()
   def open(%EditorState{} = state, variant, payload) do
-    state
-    |> assert_consistency!()
-    |> do_open(variant, payload)
-    |> assert_consistency!()
+    case state.shell_state.modal do
+      {:conflict, _} when variant != :conflict ->
+        Minga.Log.info(
+          :editor,
+          "ModalOverlay.open(#{inspect(variant)}) suppressed: conflict prompt is active"
+        )
+
+        state
+
+      _ ->
+        EditorState.set_modal(state, {variant, payload})
+    end
   end
 
   @doc """
@@ -144,10 +147,7 @@ defmodule MingaEditor.State.ModalOverlay do
   """
   @spec transition(EditorState.t(), variant(), payload()) :: EditorState.t()
   def transition(%EditorState{} = state, variant, payload) do
-    state
-    |> assert_consistency!()
-    |> do_set_modal(variant, payload)
-    |> assert_consistency!()
+    EditorState.set_modal(state, {variant, payload})
   end
 
   @doc """
@@ -162,150 +162,138 @@ defmodule MingaEditor.State.ModalOverlay do
   @doc """
   Dismisses the active modal as a cancellation.
 
-  Used when the user backs out (Esc, Ctrl-G). Behavior is identical to
-  `close/1` in the dual-write phase; the distinction exists so callers
-  can express intent and so future per-variant cleanup hooks can branch
-  on it.
+  Used when the user backs out (Esc, Ctrl-G). Identical to `close/1` —
+  the distinction exists so callers can express intent and future
+  per-variant cleanup hooks can branch on it.
   """
   @spec dismiss(EditorState.t()) :: EditorState.t()
   def dismiss(%EditorState{} = state), do: do_close(state, :dismiss)
 
-  # ── Internals ──────────────────────────────────────────────────────────────
-
-  @spec do_open(EditorState.t(), variant(), payload()) :: EditorState.t()
-  defp do_open(state, variant, payload) do
-    case state.shell_state.modal do
-      {:conflict, _} when variant != :conflict ->
-        Minga.Log.info(
-          :editor,
-          "ModalOverlay.open(#{inspect(variant)}) suppressed: conflict prompt is active"
-        )
-
-        # Sticky-conflict early return: state is unchanged, so the entry
-        # assertion already proved consistency and there is nothing new to
-        # check on the way out.
-        state
-
-      _ ->
-        do_set_modal(state, variant, payload)
-    end
-  end
-
-  @spec do_set_modal(EditorState.t(), variant(), payload()) :: EditorState.t()
-  defp do_set_modal(state, variant, payload) do
-    state
-    |> clear_displaced_legacy()
-    |> put_modal({variant, payload})
-    |> mirror_to_legacy({variant, payload})
-  end
-
-  # `_kind` is intentionally unused in the dual-write phase. It is plumbed
-  # through so future per-variant cleanup hooks (introduced once the legacy
-  # mirror is removed in #1427) can branch on `:close` vs `:dismiss` without
-  # changing the public API.
   @spec do_close(EditorState.t(), :close | :dismiss) :: EditorState.t()
   defp do_close(state, _kind) do
-    state = assert_consistency!(state)
-
     case state.shell_state.modal do
+      :none -> state
+      _ -> EditorState.set_modal(state, :none)
+    end
+  end
+
+  # ── Completion accessors and updaters ──────────────────────────────────────
+
+  @doc """
+  Returns the active `Completion.t()` when the modal is `{:completion, _}`,
+  otherwise `nil`. Read site for chrome rendering, render-pipeline input
+  build, and any code path that historically read `workspace.completion`.
+
+  Accepts any struct or map that carries `shell_state.modal` so the
+  RenderPipeline.Input flavour of state works the same as EditorState.
+  """
+  @spec completion(map()) :: Completion.t() | nil
+  def completion(%{shell_state: %{modal: {:completion, %CompletionPayload{} = p}}}),
+    do: p.completion
+
+  def completion(_), do: nil
+
+  @doc """
+  Returns the active `CompletionTrigger.t()` from the completion payload,
+  or a fresh trigger when no completion modal is active. Callers that just
+  want to consult the trigger lifecycle (debounce, pending refs) without
+  caring about completion state itself use this.
+  """
+  @spec completion_trigger(map()) :: CompletionTrigger.t()
+  def completion_trigger(%{shell_state: %{modal: {:completion, %CompletionPayload{} = p}}}),
+    do: p.trigger || CompletionTrigger.new()
+
+  def completion_trigger(_), do: CompletionTrigger.new()
+
+  @doc """
+  Updates the inner `Completion.t()` of the active completion modal via
+  `fun`. No-op when no completion modal is active. Use for menu-navigation
+  events (move_up/move_down) that mutate `Completion` without changing
+  the gate's variant.
+  """
+  @spec update_completion(EditorState.t(), (Completion.t() -> Completion.t())) :: EditorState.t()
+  def update_completion(%EditorState{} = state, fun) when is_function(fun, 1) do
+    case state.shell_state.modal do
+      {:completion, %CompletionPayload{completion: comp} = payload} ->
+        new_comp = fun.(comp)
+        new_payload = CompletionPayload.put_completion(payload, new_comp)
+        EditorState.set_modal(state, {:completion, new_payload})
+
+      _ ->
+        state
+    end
+  end
+
+  @doc """
+  Updates the completion trigger.
+
+  Behaviour by current modal:
+  - `:completion` — update the payload's trigger in place.
+  - `:none` and trigger has pending activity (debounce timer or pending
+    request) — open a new completion modal with `completion: nil` and the
+    given trigger so the bridge state has somewhere to live until the LSP
+    response arrives.
+  - `:none` and trigger is empty — no-op.
+  - any other variant — no-op (don't displace another modal for a backend
+    bookkeeping update).
+  """
+  @spec put_completion_trigger(EditorState.t(), CompletionTrigger.t()) :: EditorState.t()
+  def put_completion_trigger(%EditorState{} = state, trigger) do
+    case state.shell_state.modal do
+      {:completion, %CompletionPayload{} = payload} ->
+        new_payload = CompletionPayload.put_trigger(payload, trigger)
+        EditorState.set_modal(state, {:completion, new_payload})
+
       :none ->
-        state
+        if trigger_active?(trigger) do
+          payload = CompletionPayload.new(active_tab_id(state), trigger: trigger)
+          EditorState.set_modal(state, {:completion, payload})
+        else
+          state
+        end
 
       _ ->
         state
-        |> clear_displaced_legacy()
-        |> put_modal(:none)
-        |> assert_consistency!()
     end
   end
 
-  # Clears the legacy slot of whichever variant is currently tracked in
-  # `state.shell_state.modal`. No-op when the modal is `:none` or when the
-  # tracked variant has no legacy mirror left.
-  @spec clear_displaced_legacy(EditorState.t()) :: EditorState.t()
-  defp clear_displaced_legacy(state) do
+  @spec trigger_active?(CompletionTrigger.t()) :: boolean()
+  defp trigger_active?(%{
+         debounce_timer: timer,
+         pending_ref: ref,
+         pending_refs: refs
+       }) do
+    timer != nil or ref != nil or MapSet.size(refs) > 0
+  end
+
+  defp trigger_active?(_), do: false
+
+  # ── Per-tab dismissal hook ─────────────────────────────────────────────────
+
+  @doc """
+  Dismisses the active completion modal when its `owner` no longer
+  matches the now-active tab. Called from `EditorState.switch_tab/2` after
+  the target tab's context is restored.
+
+  Only completion has per-tab semantics; other modals live on shell state
+  and don't snapshot per tab, so this is a no-op for them.
+  """
+  @spec dismiss_if_stale(EditorState.t()) :: EditorState.t()
+  def dismiss_if_stale(%EditorState{} = state) do
     case state.shell_state.modal do
-      {:completion, _} ->
-        EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, nil))
+      {:completion, %CompletionPayload{owner: owner}} ->
+        if active_tab_id(state) == owner do
+          state
+        else
+          dismiss(state)
+        end
 
       _ ->
         state
     end
   end
 
-  # Writes the payload's underlying state to the variant's legacy slot.
-  # Only completion still has a legacy mirror; the other variants are
-  # tracked exclusively on `shell_state.modal`.
-  @spec mirror_to_legacy(EditorState.t(), {variant(), payload()}) :: EditorState.t()
-  defp mirror_to_legacy(state, {:completion, %CompletionPayload{completion: comp}}) do
-    EditorState.update_workspace(state, &WorkspaceState.set_completion(&1, comp))
-  end
-
-  defp mirror_to_legacy(state, _other), do: state
-
-  @spec put_modal(EditorState.t(), t()) :: EditorState.t()
-  defp put_modal(state, modal) do
-    EditorState.set_modal(state, modal)
-  end
-
-  # ── Divergence assertion ───────────────────────────────────────────────────
-  #
-  # The assertion runs before and after every gate function in `:dev` and
-  # `:test`. When the gate is tracking a variant, the legacy slot for that
-  # variant must equal the payload's underlying state. Any mismatch means
-  # legacy state was mutated outside this gate; we crash so the offending
-  # caller surfaces in CI.
-  #
-  # When `:modal` is `:none`, the gate makes no claims about legacy slots —
-  # they remain managed by their pre-migration callers.
-
-  if @assert_consistency do
-    @spec assert_consistency!(EditorState.t()) :: EditorState.t()
-    defp assert_consistency!(%EditorState{} = state) do
-      check_consistency!(state)
-      state
-    end
-
-    @spec check_consistency!(EditorState.t()) :: :ok
-    defp check_consistency!(%EditorState{} = state) do
-      ws = state.workspace
-
-      case state.shell_state.modal do
-        :none ->
-          :ok
-
-        # Picker (#1424), prompt/dashboard/conflict (#1425): tracked
-        # exclusively on shell_state.modal — no legacy mirror to compare.
-        {tag, _} when tag in [:picker, :prompt, :dashboard, :conflict] ->
-          :ok
-
-        # NOTE for #1426: completion's legacy mirror lives on `workspace`,
-        # which is snapshotted per tab while shell_state is not. Once a
-        # caller actually opens this variant, switching tabs swaps
-        # workspace.completion out from under the gate and trips this
-        # assertion on the next call. Resolve by either (a) clearing
-        # :modal on tab-switch via a hook, or (b) moving completion's
-        # authoritative state onto workspace.
-        {:completion, %CompletionPayload{completion: comp}} ->
-          if ws.completion != comp, do: raise_divergence!(:completion, comp, ws.completion)
-          :ok
-      end
-    end
-
-    @spec raise_divergence!(variant(), term(), term()) :: no_return()
-    defp raise_divergence!(variant, expected, found) do
-      raise """
-      MingaEditor.State.ModalOverlay divergence: tracked variant #{inspect(variant)} \
-      diverges from its legacy mirror. The gate expected the legacy slot to equal \
-      the payload's underlying state, but found a different value. This means the \
-      legacy field was mutated without going through ModalOverlay.
-
-        expected: #{inspect(expected, pretty: true, limit: :infinity)}
-        found:    #{inspect(found, pretty: true, limit: :infinity)}
-      """
-    end
-  else
-    @spec assert_consistency!(EditorState.t()) :: EditorState.t()
-    defp assert_consistency!(state), do: state
-  end
+  @spec active_tab_id(EditorState.t()) :: term() | nil
+  defp active_tab_id(%EditorState{shell_state: %{tab_bar: %{active_id: id}}}), do: id
+  defp active_tab_id(%EditorState{}), do: nil
 end

--- a/lib/minga_editor/state/modal_overlay/completion.ex
+++ b/lib/minga_editor/state/modal_overlay/completion.ex
@@ -4,11 +4,21 @@ defmodule MingaEditor.State.ModalOverlay.Completion do
 
   The completion menu is logically per-tab: it tracks the cursor position of
   the buffer that triggered it. The `owner` field carries the tab identifier
-  so a future tab-switch hook can auto-dismiss completion that no longer
-  belongs to the active tab.
+  so the tab-switch hook (`ModalOverlay.dismiss_if_stale/1`) can auto-dismiss
+  completion that no longer belongs to the active tab.
+
+  ## Trigger lifecycle
+
+  The completion trigger (debounce/pending-ref machinery) is part of the
+  modal's lifecycle: it only matters while completion is being driven, and
+  resets when completion dismisses. Carrying the trigger on the payload —
+  rather than as an independent field on workspace state — keeps the
+  modal's lifecycle self-contained and removes a per-tab field that other
+  callers had to know about.
   """
 
   alias Minga.Editing.Completion
+  alias MingaEditor.CompletionTrigger
 
   @typedoc """
   Identifier of the tab that triggered completion.
@@ -18,22 +28,65 @@ defmodule MingaEditor.State.ModalOverlay.Completion do
   """
   @type owner :: term()
 
+  @typedoc """
+  The user-visible completion menu, or `nil` while a request is pending.
+
+  `nil` represents the brief window between the trigger firing an LSP
+  request and the response arriving. The render layer paints nothing
+  while completion is `nil`; the modal exists so the trigger's debounce/
+  pending-ref state has a home.
+  """
+  @type completion_or_nil :: Completion.t() | nil
+
   @type t :: %__MODULE__{
-          completion: Completion.t(),
+          completion: completion_or_nil(),
+          trigger: CompletionTrigger.t(),
           owner: owner(),
           opened_at: integer()
         }
 
-  @enforce_keys [:completion, :owner]
-  defstruct [:completion, :owner, opened_at: 0]
+  @enforce_keys [:owner]
+  defstruct [
+    :owner,
+    completion: nil,
+    trigger: nil,
+    opened_at: 0
+  ]
 
-  @doc "Builds a completion payload bound to `owner` (typically a tab id)."
-  @spec new(Completion.t(), owner(), keyword()) :: t()
-  def new(%Completion{} = completion, owner, opts \\ []) do
+  @doc """
+  Builds a completion payload bound to `owner` (typically a tab id).
+
+  Pass `:completion` to seed an already-resolved completion menu, or
+  omit to open a payload that just tracks the trigger lifecycle while
+  an LSP request is in flight.
+  """
+  @spec new(owner(), keyword()) :: t()
+  def new(owner, opts \\ []) do
     %__MODULE__{
-      completion: completion,
+      completion: Keyword.get(opts, :completion),
+      trigger: Keyword.get(opts, :trigger, CompletionTrigger.new()),
       owner: owner,
       opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
     }
+  end
+
+  @doc """
+  Replaces the inner `Completion.t()` on the payload, preserving owner,
+  trigger, and opened_at. The only sanctioned way to update completion
+  state from outside this module (Rule 2: state ownership).
+  """
+  @spec put_completion(t(), completion_or_nil()) :: t()
+  def put_completion(%__MODULE__{} = payload, completion)
+      when is_struct(completion, Completion) or is_nil(completion) do
+    %{payload | completion: completion}
+  end
+
+  @doc """
+  Replaces the inner trigger on the payload. The only sanctioned way to
+  update the trigger from outside this module.
+  """
+  @spec put_trigger(t(), CompletionTrigger.t()) :: t()
+  def put_trigger(%__MODULE__{} = payload, trigger) do
+    %{payload | trigger: trigger}
   end
 end

--- a/lib/minga_editor/workspace/state.ex
+++ b/lib/minga_editor/workspace/state.ex
@@ -13,8 +13,6 @@ defmodule MingaEditor.Workspace.State do
   """
 
   alias MingaEditor.Agent.UIState
-  alias Minga.Editing.Completion
-  alias MingaEditor.CompletionTrigger
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Highlighting
@@ -37,8 +35,6 @@ defmodule MingaEditor.Workspace.State do
           mouse: Mouse.t(),
           highlight: Highlighting.t(),
           lsp_pending: %{reference() => atom() | tuple()},
-          completion: Completion.t() | nil,
-          completion_trigger: CompletionTrigger.t(),
           injection_ranges: %{pid() => [Minga.Language.Highlight.InjectionRange.t()]},
           search: Search.t(),
           editing: VimState.t(),
@@ -55,8 +51,6 @@ defmodule MingaEditor.Workspace.State do
             mouse: %Mouse{},
             highlight: %Highlighting{},
             lsp_pending: %{},
-            completion: nil,
-            completion_trigger: CompletionTrigger.new(),
             injection_ranges: %{},
             search: %Search{},
             editing: VimState.new(),
@@ -195,24 +189,6 @@ defmodule MingaEditor.Workspace.State do
   @spec set_keymap_scope(t(), Scope.scope_name()) :: t()
   def set_keymap_scope(%__MODULE__{} = wspace, scope) do
     %{wspace | keymap_scope: scope}
-  end
-
-  @doc "Updates the completion state."
-  @spec set_completion(t(), Completion.t() | nil) :: t()
-  def set_completion(%__MODULE__{} = wspace, completion) do
-    %{wspace | completion: completion}
-  end
-
-  @doc "Updates the completion trigger bridge."
-  @spec set_completion_trigger(t(), CompletionTrigger.t()) :: t()
-  def set_completion_trigger(%__MODULE__{} = wspace, trigger) do
-    %{wspace | completion_trigger: trigger}
-  end
-
-  @doc "Clears completion and resets the trigger bridge."
-  @spec clear_completion(t(), CompletionTrigger.t()) :: t()
-  def clear_completion(%__MODULE__{} = wspace, new_bridge) do
-    %{wspace | completion: nil, completion_trigger: new_bridge}
   end
 
   @doc "Updates the highlighting sub-struct."

--- a/test/minga_editor/completion_doc_preview_test.exs
+++ b/test/minga_editor/completion_doc_preview_test.exs
@@ -10,6 +10,8 @@ defmodule MingaEditor.CompletionDocPreviewTest do
   alias MingaEditor.CompletionHandling
   alias MingaEditor.CompletionUI
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
   alias MingaEditor.Viewport
   alias MingaEditor.UI.Theme
   alias MingaEditor.Workspace.State, as: WorkspaceState
@@ -17,16 +19,22 @@ defmodule MingaEditor.CompletionDocPreviewTest do
   @theme Theme.get!(:doom_one)
 
   defp make_state(completion) do
-    ws = %WorkspaceState{
-      viewport: %Viewport{top: 0, left: 0, rows: 24, cols: 80},
-      completion: completion
-    }
+    ws = %WorkspaceState{viewport: %Viewport{top: 0, left: 0, rows: 24, cols: 80}}
+
+    modal =
+      case completion do
+        nil -> :none
+        %Completion{} -> {:completion, CompletionPayload.new(:tab1, completion: completion)}
+      end
 
     %EditorState{
       port_manager: self(),
-      workspace: ws
+      workspace: ws,
+      shell_state: %MingaEditor.Shell.Traditional.State{modal: modal}
     }
   end
+
+  defp completion_from(state), do: ModalOverlay.completion(state)
 
   # ── Completion item parsing ──────────────────────────────────────────────
 
@@ -97,7 +105,7 @@ defmodule MingaEditor.CompletionDocPreviewTest do
       state = make_state(completion)
       result = CompletionHandling.maybe_resolve_selected(state)
       # No timer set because documentation is already present
-      assert result.workspace.completion.resolve_timer == nil
+      assert completion_from(result).resolve_timer == nil
     end
 
     test "sets a resolve timer when documentation is empty" do
@@ -105,7 +113,7 @@ defmodule MingaEditor.CompletionDocPreviewTest do
       completion = Completion.new(items, {0, 0})
       state = %{make_state(completion) | backend: :zig}
       result = CompletionHandling.maybe_resolve_selected(state)
-      assert result.workspace.completion.resolve_timer != nil
+      assert completion_from(result).resolve_timer != nil
     end
 
     test "skips resolve timer in headless mode" do
@@ -113,7 +121,7 @@ defmodule MingaEditor.CompletionDocPreviewTest do
       completion = Completion.new(items, {0, 0})
       state = make_state(completion)
       result = CompletionHandling.maybe_resolve_selected(state)
-      assert result.workspace.completion.resolve_timer == nil
+      assert completion_from(result).resolve_timer == nil
     end
 
     test "skips when already resolved for this index" do
@@ -121,7 +129,7 @@ defmodule MingaEditor.CompletionDocPreviewTest do
       completion = %{Completion.new(items, {0, 0}) | last_resolved_index: 0}
       state = make_state(completion)
       result = CompletionHandling.maybe_resolve_selected(state)
-      assert result.workspace.completion.resolve_timer == nil
+      assert completion_from(result).resolve_timer == nil
     end
   end
 
@@ -136,9 +144,9 @@ defmodule MingaEditor.CompletionDocPreviewTest do
       resolved = %{"documentation" => %{"kind" => "markdown", "value" => "Full docs"}}
       result = CompletionHandling.handle_resolve_response(state, {:ok, resolved})
 
-      selected = Completion.selected_item(result.workspace.completion)
+      selected = Completion.selected_item(completion_from(result))
       assert selected.documentation == "Full docs"
-      assert result.workspace.completion.last_resolved_index == 0
+      assert completion_from(result).last_resolved_index == 0
     end
 
     test "handles plain string documentation in resolve response" do
@@ -149,7 +157,7 @@ defmodule MingaEditor.CompletionDocPreviewTest do
       resolved = %{"documentation" => "Plain text docs"}
       result = CompletionHandling.handle_resolve_response(state, {:ok, resolved})
 
-      selected = Completion.selected_item(result.workspace.completion)
+      selected = Completion.selected_item(completion_from(result))
       assert selected.documentation == "Plain text docs"
     end
 

--- a/test/minga_editor/input/completion_mouse_test.exs
+++ b/test/minga_editor/input/completion_mouse_test.exs
@@ -4,21 +4,28 @@ defmodule MingaEditor.Input.CompletionMouseTest do
 
   alias Minga.Editing.Completion
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
+  alias MingaEditor.State.WhichKey
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
   alias MingaEditor.Input.Completion, as: CompletionInput
   alias Minga.Mode
 
-  defp completion_state(items) do
-    completion =
-      Completion.new(items, max_visible: 10)
+  defp completion_state(items, opts \\ []) do
+    mode = Keyword.get(opts, :mode, :insert)
+    completion = Completion.new(items, max_visible: 10)
+    payload = CompletionPayload.new(:tab1, completion: completion)
 
     %EditorState{
       port_manager: nil,
+      shell_state: %MingaEditor.Shell.Traditional.State{
+        modal: {:completion, payload},
+        whichkey: %WhichKey{}
+      },
       workspace: %MingaEditor.Workspace.State{
-        editing: %VimState{mode: :insert, mode_state: Mode.initial_state()},
-        viewport: Viewport.new(30, 80),
-        completion: completion
+        editing: %VimState{mode: mode, mode_state: Mode.initial_state()},
+        viewport: Viewport.new(30, 80)
       }
     }
   end
@@ -38,14 +45,14 @@ defmodule MingaEditor.Input.CompletionMouseTest do
       {:handled, new_state} =
         CompletionInput.handle_mouse(state, 10, 10, :wheel_down, 0, :press, 1)
 
-      assert new_state.workspace.completion.selected == 1
+      assert ModalOverlay.completion(new_state).selected == 1
     end
 
     test "wheel_up moves completion selection up" do
       state = completion_state(sample_items())
       {:handled, state} = CompletionInput.handle_mouse(state, 10, 10, :wheel_down, 0, :press, 1)
       {:handled, new_state} = CompletionInput.handle_mouse(state, 10, 10, :wheel_up, 0, :press, 1)
-      assert new_state.workspace.completion.selected == 0
+      assert ModalOverlay.completion(new_state).selected == 0
     end
   end
 
@@ -53,10 +60,10 @@ defmodule MingaEditor.Input.CompletionMouseTest do
     test "passes through when no completion is active" do
       state = %EditorState{
         port_manager: nil,
+        shell_state: %MingaEditor.Shell.Traditional.State{whichkey: %WhichKey{}},
         workspace: %MingaEditor.Workspace.State{
           editing: %VimState{mode: :normal, mode_state: Mode.initial_state()},
-          viewport: Viewport.new(30, 80),
-          completion: nil
+          viewport: Viewport.new(30, 80)
         }
       }
 
@@ -64,13 +71,7 @@ defmodule MingaEditor.Input.CompletionMouseTest do
     end
 
     test "passes through when in normal mode even with completion" do
-      state = completion_state(sample_items())
-
-      state = %{
-        state
-        | workspace: %{state.workspace | editing: %{state.workspace.editing | mode: :normal}}
-      }
-
+      state = completion_state(sample_items(), mode: :normal)
       {:passthrough, ^state} = CompletionInput.handle_mouse(state, 10, 10, :left, 0, :press, 1)
     end
   end

--- a/test/minga_editor/input/interrupt_test.exs
+++ b/test/minga_editor/input/interrupt_test.exs
@@ -182,10 +182,15 @@ defmodule MingaEditor.Input.InterruptTest do
     test "closes completion menu" do
       state = base_state()
       completion = %Completion{items: [], trigger_position: {0, 0}}
-      state = %{state | workspace: %{state.workspace | completion: completion}}
+
+      payload =
+        MingaEditor.State.ModalOverlay.Completion.new(:tab1, completion: completion)
+
+      state = ModalOverlay.open(state, :completion, payload)
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
-      assert new_state.workspace.completion == nil
+      assert MingaEditor.State.ModalOverlay.completion(new_state) == nil
+      refute ModalOverlay.match(new_state.shell_state.modal, :completion)
     end
 
     test "clears status message" do
@@ -200,24 +205,18 @@ defmodule MingaEditor.Input.InterruptTest do
     test "resets everything at once" do
       state = base_state()
       picker = MingaEditor.UI.Picker.new(["x"])
-      completion = %Completion{items: [], trigger_position: {0, 0}}
 
       vim = %{state.workspace.editing | mode: :visual, mode_state: Mode.initial_state()}
 
       state = %{
         state
-        | workspace: %{
-            state.workspace
-            | keymap_scope: :agent,
-              editing: vim,
-              completion: completion
-          }
+        | workspace: %{state.workspace | keymap_scope: :agent, editing: vim}
       }
 
       # Only one modal can be active at a time under the ModalOverlay sum
       # type, so this combined-reset case exercises picker plus the
-      # non-modal axes (scope/mode/whichkey/completion/status). The
-      # conflict-reset path has its own focused test above.
+      # non-modal axes (scope/mode/whichkey/status). The conflict-reset
+      # and completion-close paths have focused tests above.
       state = ModalOverlay.open(state, :picker, PickerPayload.new(%Picker{picker: picker}))
       state = MingaEditor.State.set_whichkey(state, %WhichKey{node: %{}, show: true})
       state = MingaEditor.State.set_status(state, "hello")
@@ -228,7 +227,6 @@ defmodule MingaEditor.Input.InterruptTest do
       assert new_state.shell_state.modal == :none
       assert new_state.shell_state.whichkey.node == nil
       assert new_state.shell_state.whichkey.show == false
-      assert new_state.workspace.completion == nil
       assert new_state.shell_state.status_msg == nil
     end
   end

--- a/test/minga_editor/render_pipeline/input_test.exs
+++ b/test/minga_editor/render_pipeline/input_test.exs
@@ -21,7 +21,6 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       assert input.workspace.highlight == state.workspace.highlight
       assert input.workspace.file_tree == state.workspace.file_tree
       assert input.workspace.agent_ui == state.workspace.agent_ui
-      assert input.workspace.completion == state.workspace.completion
       assert input.workspace.document_highlights == state.workspace.document_highlights
       assert input.workspace.search == state.workspace.search
       assert input.workspace.keymap_scope == state.workspace.keymap_scope

--- a/test/minga_editor/state/modal_overlay_test.exs
+++ b/test/minga_editor/state/modal_overlay_test.exs
@@ -49,13 +49,16 @@ defmodule MingaEditor.State.ModalOverlayTest do
   end
 
   defp completion_payload(tab_id \\ 1) do
-    completion =
-      Completion.new(
-        [],
-        {0, 0}
-      )
+    completion = Completion.new([], {0, 0})
+    CompletionPayload.new(tab_id, completion: completion, opened_at: 1_003)
+  end
 
-    CompletionPayload.new(completion, tab_id, opened_at: 1_003)
+  defp tab_bar_with_active(id) do
+    %MingaEditor.State.TabBar{
+      tabs: [%MingaEditor.State.Tab{id: id, kind: :file, label: "test"}],
+      active_id: id,
+      next_id: id + 1
+    }
   end
 
   defp conflict_payload(buffer \\ self()) do
@@ -119,14 +122,14 @@ defmodule MingaEditor.State.ModalOverlayTest do
       assert result.shell_state.modal == {:dashboard, payload}
     end
 
-    test "writes the completion legacy field on workspace" do
+    test "writes the completion modal payload" do
       state = base_state()
       payload = completion_payload(7)
 
       result = ModalOverlay.open(state, :completion, payload)
 
       assert result.shell_state.modal == {:completion, payload}
-      assert result.workspace.completion == payload.completion
+      assert ModalOverlay.completion(result) == payload.completion
     end
 
     test "writes the conflict variant" do
@@ -152,7 +155,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       assert result.shell_state.modal == {:prompt, prompt}
     end
 
-    test "replacing completion with picker clears workspace.completion" do
+    test "replacing completion with picker clears the completion accessor" do
       state =
         base_state()
         |> ModalOverlay.open(:completion, completion_payload(1))
@@ -161,7 +164,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       result = ModalOverlay.open(state, :picker, picker)
 
       assert result.shell_state.modal == {:picker, picker}
-      assert result.workspace.completion == nil
+      assert ModalOverlay.completion(result) == nil
     end
 
     test "replacing dashboard with picker swaps the active modal" do
@@ -253,7 +256,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       assert result.shell_state.modal == :none
     end
 
-    test "close clears workspace.completion when a completion is active" do
+    test "close clears the completion accessor when a completion is active" do
       state =
         base_state()
         |> ModalOverlay.open(:completion, completion_payload(3))
@@ -261,7 +264,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       result = ModalOverlay.close(state)
 
       assert result.shell_state.modal == :none
-      assert result.workspace.completion == nil
+      assert ModalOverlay.completion(result) == nil
     end
 
     test "close on an idle state is a no-op" do
@@ -271,37 +274,44 @@ defmodule MingaEditor.State.ModalOverlayTest do
     end
   end
 
-  describe "divergence assertion (dev/test only)" do
-    test "raises when workspace.completion is cleared outside the gate" do
-      state =
+  describe "dismiss_if_stale/1" do
+    test "dismisses a completion modal whose owner doesn't match the active tab" do
+      state = %{
         base_state()
-        |> ModalOverlay.open(:completion, completion_payload(2))
+        | shell_state: %ShellState{
+            modal: :none,
+            tab_bar: tab_bar_with_active(99)
+          }
+      }
 
-      tampered = put_in(state.workspace.completion, nil)
+      state = ModalOverlay.open(state, :completion, completion_payload(1))
+      assert ModalOverlay.match(state.shell_state.modal, :completion)
 
-      assert_raise RuntimeError, ~r/ModalOverlay divergence/, fn ->
-        ModalOverlay.close(tampered)
-      end
+      result = ModalOverlay.dismiss_if_stale(state)
+      assert result.shell_state.modal == :none
     end
 
-    test "tolerates legacy mutation while modal is :none" do
-      state = base_state()
+    test "leaves completion alone when its owner matches the active tab" do
+      state = %{
+        base_state()
+        | shell_state: %ShellState{
+            modal: :none,
+            tab_bar: tab_bar_with_active(7)
+          }
+      }
 
-      # Stuff a stray completion onto workspace before any modal opens.
-      tampered =
-        put_in(
-          state.workspace.completion,
-          Completion.new([], {0, 0})
-        )
+      state = ModalOverlay.open(state, :completion, completion_payload(7))
+      result = ModalOverlay.dismiss_if_stale(state)
 
-      payload = picker_payload()
-      result = ModalOverlay.open(tampered, :picker, payload)
+      assert ModalOverlay.match(result.shell_state.modal, :completion)
+    end
 
-      # The gate clears completion when displacing it (it tracks completion
-      # via the legacy mirror), but only because completion was the
-      # previously-tracked variant. Here completion was never tracked, so
-      # it should be left as-is by `:picker`'s open path.
-      assert result.shell_state.modal == {:picker, payload}
+    test "no-op for non-completion modals" do
+      state =
+        base_state()
+        |> ModalOverlay.open(:picker, picker_payload())
+
+      assert ModalOverlay.dismiss_if_stale(state) == state
     end
   end
 end

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -59,8 +59,6 @@ defmodule MingaEditor.State.SnapshotTest do
       assert ctx.mouse == state.workspace.mouse
       assert ctx.highlight == state.workspace.highlight
       assert ctx.lsp_pending == state.workspace.lsp_pending
-      assert ctx.completion == state.workspace.completion
-      assert ctx.completion_trigger == state.workspace.completion_trigger
       assert ctx.injection_ranges == state.workspace.injection_ranges
       assert ctx.search == state.workspace.search
     end


### PR DESCRIPTION
## Summary

Resolves #1426 — the fifth and final per-variant migration of the modal-overlay sum type. Completion now lives exclusively on \`state.shell_state.modal\` as \`{:completion, %ModalOverlay.Completion{}}\`; the legacy \`workspace.completion\` and \`workspace.completion_trigger\` fields are gone, and the gate's dual-write / divergence-assertion machinery has been deleted.

## Payload model

\`%ModalOverlay.Completion{}\` carries:

- \`completion: Completion.t() | nil\` — \`nil\` while an LSP request is in flight, so the render layer can paint nothing during that brief window without the modal having to dismiss and reopen.
- \`trigger: CompletionTrigger.t()\` — the debounce/pending-ref bridge. Lives with the modal so resetting completion auto-cancels the trigger.
- \`owner: tab_id\` — drives \`dismiss_if_stale/1\` on tab switch.

## Per-tab semantics

\`ModalOverlay.dismiss_if_stale/1\` runs from \`EditorState.switch_tab/2\` after the new context is restored. If the active modal is a completion whose \`owner\` doesn't match the now-active tab, it dismisses. Other variants live on shell state and don't snapshot per-tab, so this is a no-op for them.

## New gate functions

- \`update_completion/2\` — mutate the inner \`Completion.t()\` (used by \`move_up\`/\`move_down\`, filter narrowing, doc-resolve)
- \`put_completion_trigger/2\` — update the trigger; transparently opens a completion modal with \`completion: nil\` when modal is \`:none\` and the trigger has activity, no-op when another modal is active (so trigger updates can't displace a picker).
- \`dismiss_if_stale/1\` — the tab-switch hook.

## Notable subtle fix

\`CompletionHandling.dismiss/1\` is called on every non-insert keypress (via \`maybe_handle/4\`). The dual-write era cleared completion specifically. After migration, dispatching to \`ModalOverlay.dismiss/1\` would have nuked **any** active modal — so opening a picker via \`SPC b b\` would dismiss itself on the next keystroke. \`dismiss/1\` now gates on \`ModalOverlay.match(state.shell_state.modal, :completion)\` first.

## Test plan

- [x] \`mix test test/minga_editor/state/modal_overlay_test.exs\` — 23 cases including new \`dismiss_if_stale/1\` coverage
- [x] All completion-touching test files pass
- [x] \`mix test --seed 0 / 1 / 12345 / 99999\` — full suite, 0 failures across 4 seeds
- [ ] CI

## Up next

#1427 finalises the modal-overlay arc: collapse \`Input.Interrupt\` and add the single-writer Credo rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)