### PR TITLE
fix(agent): only set status on session-down events the editor owns

### DIFF
--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -802,45 +802,70 @@ defmodule MingaEditor.Commands.BufferManagement do
     # Find the card with this session and clear its session pid (the
     # process is dead, so AgentAccess.session/1 must not keep returning
     # it). Update status in the same pass.
-    board =
+    {board, owned?} =
       case Enum.find(board.cards, fn {_id, card} -> card.session == session_pid end) do
         {card_id, _card} ->
-          MingaEditor.Shell.Board.State.update_card(board, card_id, fn card ->
-            card
-            |> MingaEditor.Shell.Board.Card.set_status(card_status)
-            |> MingaEditor.Shell.Board.Card.detach_session()
-          end)
+          updated =
+            MingaEditor.Shell.Board.State.update_card(board, card_id, fn card ->
+              card
+              |> MingaEditor.Shell.Board.Card.set_status(card_status)
+              |> MingaEditor.Shell.Board.Card.detach_session()
+            end)
+
+          {updated, true}
 
         nil ->
-          board
+          {board, false}
       end
 
     state = %{state | shell_state: board}
     state = AgentAccess.update_agent(state, &AgentState.stop_spinner_timer/1)
     state = AgentAccess.update_agent(state, &AgentState.reset_cache/1)
 
-    msg =
-      if reason in [:normal, :shutdown],
-        do: "Agent session ended",
-        else: "Agent session crashed"
+    if owned? do
+      msg =
+        if reason in [:normal, :shutdown],
+          do: "Agent session ended",
+          else: "Agent session crashed"
 
-    EditorState.set_status(state, msg)
+      EditorState.set_status(state, msg)
+    else
+      Minga.Log.debug(
+        :agent,
+        "ignoring session-down for non-owned pid #{inspect(session_pid)}"
+      )
+
+      state
+    end
   end
 
   def handle_agent_session_down(
-        %{shell_state: %{tab_bar: %TabBar{}}} = state,
+        %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
         session_pid,
         reason
       ) do
+    owned? =
+      Enum.any?(tb.tabs, &(&1.session == session_pid)) or
+        TabBar.find_group_by_session(tb, session_pid) != nil
+
     tab_status = if reason in [:normal, :shutdown], do: :idle, else: :error
     state = scrub_agent_tab_state(state, session_pid, tab_status)
 
-    msg =
-      if reason in [:normal, :shutdown],
-        do: "Agent session ended",
-        else: "Agent session crashed (SPC a n to restart)"
+    if owned? do
+      msg =
+        if reason in [:normal, :shutdown],
+          do: "Agent session ended",
+          else: "Agent session crashed (SPC a n to restart)"
 
-    EditorState.set_status(state, msg)
+      EditorState.set_status(state, msg)
+    else
+      Minga.Log.debug(
+        :agent,
+        "ignoring session-down for non-owned pid #{inspect(session_pid)}"
+      )
+
+      state
+    end
   end
 
   # Shared state cleanup for agent sessions: stops spinner, clears

--- a/test/minga_editor/commands/agent_session_down_test.exs
+++ b/test/minga_editor/commands/agent_session_down_test.exs
@@ -1,0 +1,96 @@
+defmodule MingaEditor.Commands.AgentSessionDownTest do
+  @moduledoc """
+  Pure-function tests for `BufferManagement.handle_agent_session_down/3`.
+
+  The Editor subscribes to the global `Minga.Events` bus for
+  `:agent_session_stopped` events, so handlers receive notifications for
+  every agent session in the BEAM, not only the ones this editor owns.
+  These tests pin the contract: only act on sessions referenced by a tab
+  or agent group on this editor's tab bar.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Commands.BufferManagement
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.Viewport
+  alias MingaEditor.Workspace
+
+  defp build_state(tab_bar) do
+    state = %EditorState{
+      port_manager: nil,
+      workspace: %Workspace.State{viewport: Viewport.new(80, 24)}
+    }
+
+    EditorState.set_tab_bar(state, tab_bar)
+  end
+
+  defp empty_tab_bar do
+    TabBar.new(Tab.new_file(1, "scratch"))
+  end
+
+  defp tab_bar_with_session(session_pid) do
+    {tb, agent_tab} = TabBar.insert(empty_tab_bar(), :agent, "Agent")
+    TabBar.update_tab(tb, agent_tab.id, &Tab.set_session(&1, session_pid))
+  end
+
+  describe "handle_agent_session_down/3 with TabBar shell" do
+    test "ignores crash for session not referenced by any tab" do
+      state =
+        build_state(empty_tab_bar())
+        |> EditorState.set_status("original message")
+
+      foreign_pid = spawn(fn -> :ok end)
+
+      result = BufferManagement.handle_agent_session_down(state, foreign_pid, :killed)
+
+      assert result.shell_state.status_msg == "original message",
+             "status_msg must not be overwritten by crashes from other editors' sessions"
+
+      assert result.shell_state.tab_bar == state.shell_state.tab_bar,
+             "tab_bar must be untouched when no tab references the crashed session"
+    end
+
+    test "ignores normal exit for session not referenced by any tab" do
+      state =
+        build_state(empty_tab_bar())
+        |> EditorState.set_status("original message")
+
+      foreign_pid = spawn(fn -> :ok end)
+
+      result = BufferManagement.handle_agent_session_down(state, foreign_pid, :normal)
+
+      assert result.shell_state.status_msg == "original message"
+    end
+
+    test "sets crash status when a tab references the crashed session" do
+      session_pid = spawn(fn -> :ok end)
+      state = build_state(tab_bar_with_session(session_pid))
+
+      result = BufferManagement.handle_agent_session_down(state, session_pid, :killed)
+
+      assert result.shell_state.status_msg == "Agent session crashed (SPC a n to restart)"
+    end
+
+    test "sets ended status when an owned session exits normally" do
+      session_pid = spawn(fn -> :ok end)
+      state = build_state(tab_bar_with_session(session_pid))
+
+      result = BufferManagement.handle_agent_session_down(state, session_pid, :normal)
+
+      assert result.shell_state.status_msg == "Agent session ended"
+    end
+
+    test "treats agent_groups membership as ownership" do
+      session_pid = spawn(fn -> :ok end)
+      {tb, _group} = TabBar.add_agent_group(empty_tab_bar(), "Workgroup", session_pid)
+      state = build_state(tb)
+
+      result = BufferManagement.handle_agent_session_down(state, session_pid, :killed)
+
+      assert result.shell_state.status_msg == "Agent session crashed (SPC a n to restart)"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`BufferManagement.handle_agent_session_down/3` was setting `status_msg` for every `:agent_session_stopped` event broadcast on the global `Minga.Events` bus, even when no tab or agent group on this editor's tab bar referenced the crashed session pid. In single-editor production this is benign; in parallel tests it clobbered unrelated editors' status messages and produced a flake on `MingaEditor.Commands.GitRemoteTest "Editor clears git_remote_op when task crashes via :DOWN"` whenever `MingaAgent.SessionManagerTest` raced its agent kill against the assertion (seen on full-suite seed 100).

The fix:
- Compute ownership (any tab with `session == session_pid` or any agent group with that session) before scrubbing.
- Only set `status_msg` when ownership holds.
- Apply the same change to the `Shell.Board` clause using the existing `Enum.find` over cards as the ownership check.
- Log `Minga.Log.debug(:agent, ...)` on the not-owned branch so a real ownership bug is observable later.

## Test plan

Added five pure-function tests in `test/minga_editor/commands/agent_session_down_test.exs`:
- ignores crash for session not referenced by any tab
- ignores normal exit for non-owned session
- sets crash status when a tab references the session
- sets ended status on normal exit for an owned session
- treats agent-groups membership as ownership

The existing integration test at `test/minga_editor/commands/git_remote_test.exs:197` is kept because it still covers Editor `:DOWN` routing; it just stops flaking now that unrelated events don't overwrite status.

- [x] `mix format --check-formatted`
- [x] `mix credo --strict` (clean — pre-existing struct-size warnings only)
- [x] `mix compile --warnings-as-errors`
- [x] `mix dialyzer` (passed)
- [x] `mix test test/minga_editor/commands/agent_session_down_test.exs` (5/5)
- [x] `mix test test/minga_editor/commands/git_remote_test.exs test/minga_editor/commands/buffer_management_test.exs test/minga_editor/commands/agent_split_test.exs test/minga_editor/commands/agent_split_toggle_test.exs test/minga_editor/commands/agent_group_test.exs test/minga_editor/commands/agent_commands_test.exs` (66/66)
- [x] Full suite at seeds 0, 1, 100, 12345, 31415, 99999 — no occurrence of the GitRemoteTest flake. Remaining failures across those seeds are the macOS `:tmp_dir` rm_rf / Spotlight race and global `*Messages*` buffer pollution, both tracked under Epic #1456.

Refs #1456

🤖 Generated with [Claude Code](https://claude.com/claude-code)