### PR TITLE
refactor(config): thread Events registry into Config.Hooks

### DIFF
--- a/lib/minga/config/hooks.ex
+++ b/lib/minga/config/hooks.ex
@@ -41,16 +41,22 @@ defmodule Minga.Config.Hooks do
   @typedoc "Valid event names."
   @type event :: :after_save | :after_open | :on_mode_change
 
-  @typedoc "Hook state: event name → list of hook functions."
-  @type state :: %{event() => [function()]}
+  @typedoc "Registered hooks keyed by event name."
+  @type hooks :: %{event() => [function()]}
+
+  @typedoc "Hook server state."
+  @type state :: %{
+          hooks: hooks(),
+          events_registry: atom()
+        }
 
   # ── Client API ──────────────────────────────────────────────────────────────
 
   @doc "Starts the hooks registry and subscribes to the event bus."
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    {name, _opts} = Keyword.pop(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, [], name: name)
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
   end
 
   @doc """
@@ -105,19 +111,21 @@ defmodule Minga.Config.Hooks do
 
   @impl true
   @spec init(keyword()) :: {:ok, state()}
-  def init(_opts) do
-    subscribe_to_events()
-    {:ok, initial_state()}
+  def init(opts) do
+    events_registry = Keyword.get(opts, :events_registry, Minga.EventBus)
+    state = initial_state(events_registry)
+    subscribe_to_events(state)
+    {:ok, state}
   end
 
   @impl true
   def handle_call({:register, event, fun}, _from, state) do
-    new_state = Map.update!(state, event, &[fun | &1])
+    new_state = %{state | hooks: Map.update!(state.hooks, event, &[fun | &1])}
     {:reply, :ok, new_state}
   end
 
-  def handle_call(:reset, _from, _state) do
-    {:reply, :ok, initial_state()}
+  def handle_call(:reset, _from, state) do
+    {:reply, :ok, initial_state(state.events_registry)}
   end
 
   @impl true
@@ -144,10 +152,10 @@ defmodule Minga.Config.Hooks do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
-  @spec subscribe_to_events() :: :ok
-  defp subscribe_to_events do
+  @spec subscribe_to_events(state()) :: :ok
+  defp subscribe_to_events(state) do
     for topic <- Map.keys(@topic_to_event) do
-      Minga.Events.subscribe(topic)
+      Minga.Events.subscribe(topic, registry: state.events_registry)
     end
 
     :ok
@@ -162,7 +170,7 @@ defmodule Minga.Config.Hooks do
 
   @spec do_run(state(), event(), [term()]) :: :ok
   defp do_run(state, event, args) do
-    hooks = Map.get(state, event, []) |> Enum.reverse()
+    hooks = Map.get(state.hooks, event, []) |> Enum.reverse()
 
     for hook <- hooks do
       Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
@@ -184,8 +192,8 @@ defmodule Minga.Config.Hooks do
     :ok
   end
 
-  @spec initial_state() :: state()
-  defp initial_state do
-    Map.new(@valid_events, &{&1, []})
+  @spec initial_state(atom()) :: state()
+  defp initial_state(events_registry) do
+    %{hooks: Map.new(@valid_events, &{&1, []}), events_registry: events_registry}
   end
 end

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -266,6 +266,7 @@ defmodule Minga.Events do
   Returns the child spec for the event bus Registry.
 
   Add this to your supervision tree before any process that subscribes.
+  Pass `name:` to start an isolated registry for tests.
   """
   @spec child_spec(keyword()) :: Supervisor.child_spec()
   def child_spec(opts) do
@@ -292,16 +293,16 @@ defmodule Minga.Events do
   Subscribes the calling process to a topic with metadata.
 
   The metadata value is passed to the dispatch callback alongside the pid,
-  which lets subscribers filter or tag their registrations. Subscribing
-  with the same topic and value from the same process is a no-op.
+  which lets subscribers filter or tag their registrations. Pass `registry:`
+  as the second argument to subscribe without metadata on an isolated registry.
+  Subscribing with the same topic and value from the same process is a no-op.
   """
-  @spec subscribe(topic(), keyword() | term()) :: :ok
+  @spec subscribe(topic(), term()) :: :ok
   def subscribe(topic, opts) when is_atom(topic) and is_list(opts) do
-    registry = Keyword.get(opts, :registry)
-
-    case registry do
-      nil -> subscribe(topic, opts, registry: @registry)
-      registry -> subscribe(topic, [], registry: registry)
+    if registry_opts?(opts) do
+      subscribe(topic, [], registry: Keyword.fetch!(opts, :registry))
+    else
+      subscribe(topic, opts, registry: @registry)
     end
   end
 
@@ -327,6 +328,11 @@ defmodule Minga.Events do
     :ok
   end
 
+  @spec registry_opts?(list()) :: boolean()
+  defp registry_opts?(opts) do
+    Keyword.keyword?(opts) and Keyword.has_key?(opts, :registry)
+  end
+
   @doc """
   Unsubscribes the calling process from a topic.
 
@@ -348,7 +354,8 @@ defmodule Minga.Events do
   before the event ever reaches subscribers.
 
   Returns `:ok`. If no processes are subscribed to the topic, this is a
-  no-op with negligible cost.
+  no-op with negligible cost. Pass `registry:` as the third argument to
+  broadcast through an isolated registry.
   """
   @spec broadcast(:buffer_saved | :buffer_opened | :content_replaced, BufferEvent.t()) :: :ok
   @spec broadcast(:buffer_closed, BufferClosedEvent.t()) :: :ok

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -253,7 +253,12 @@ defmodule Minga.Events do
           | SupervisorRestartedEvent.t()
           | LogMessageEvent.t()
           | FaceOverridesChangedEvent.t()
+          | LoadUserThemesEvent.t()
           | MingaAgent.SessionManager.SessionStoppedEvent.t()
+          | MingaAgent.Changeset.MergedEvent.t()
+          | MingaAgent.Changeset.BudgetExhaustedEvent.t()
+          | Minga.Extension.UpdatesAvailableEvent.t()
+          | map()
 
   # ── Child spec ──────────────────────────────────────────────────────────────
 
@@ -263,8 +268,9 @@ defmodule Minga.Events do
   Add this to your supervision tree before any process that subscribes.
   """
   @spec child_spec(keyword()) :: Supervisor.child_spec()
-  def child_spec(_opts) do
-    Registry.child_spec(keys: :duplicate, name: @registry)
+  def child_spec(opts) do
+    registry = Keyword.get(opts, :name, @registry)
+    Registry.child_spec(keys: :duplicate, name: registry)
   end
 
   # ── Subscribe / Unsubscribe ─────────────────────────────────────────────────
@@ -279,15 +285,7 @@ defmodule Minga.Events do
   """
   @spec subscribe(topic()) :: :ok
   def subscribe(topic) when is_atom(topic) do
-    if Process.whereis(@registry) do
-      already? =
-        Registry.lookup(@registry, topic)
-        |> Enum.any?(fn {pid, _} -> pid == self() end)
-
-      unless already?, do: {:ok, _} = Registry.register(@registry, topic, [])
-    end
-
-    :ok
+    subscribe(topic, registry: @registry)
   end
 
   @doc """
@@ -297,14 +295,33 @@ defmodule Minga.Events do
   which lets subscribers filter or tag their registrations. Subscribing
   with the same topic and value from the same process is a no-op.
   """
-  @spec subscribe(topic(), term()) :: :ok
+  @spec subscribe(topic(), keyword() | term()) :: :ok
+  def subscribe(topic, opts) when is_atom(topic) and is_list(opts) do
+    registry = Keyword.get(opts, :registry)
+
+    case registry do
+      nil -> subscribe(topic, opts, registry: @registry)
+      registry -> subscribe(topic, [], registry: registry)
+    end
+  end
+
   def subscribe(topic, value) when is_atom(topic) do
-    if Process.whereis(@registry) do
+    subscribe(topic, value, registry: @registry)
+  end
+
+  @doc """
+  Subscribes the calling process to a topic with metadata on a specific registry.
+  """
+  @spec subscribe(topic(), term(), keyword()) :: :ok
+  def subscribe(topic, value, opts) when is_atom(topic) and is_list(opts) do
+    registry = Keyword.get(opts, :registry, @registry)
+
+    if Process.whereis(registry) do
       already? =
-        Registry.lookup(@registry, topic)
+        Registry.lookup(registry, topic)
         |> Enum.any?(fn {pid, v} -> pid == self() and v == value end)
 
-      unless already?, do: {:ok, _} = Registry.register(@registry, topic, value)
+      unless already?, do: {:ok, _} = Registry.register(registry, topic, value)
     end
 
     :ok
@@ -354,8 +371,15 @@ defmodule Minga.Events do
   @spec broadcast(:load_user_themes, LoadUserThemesEvent.t()) :: :ok
   @spec broadcast(:buffer_fork_conflict, map()) :: :ok
   @spec broadcast(:extension_updates_available, Minga.Extension.UpdatesAvailableEvent.t()) :: :ok
-  def broadcast(topic, %_{} = payload) when is_atom(topic) do
-    Registry.dispatch(@registry, topic, fn entries ->
+  def broadcast(topic, payload) when is_atom(topic) do
+    broadcast(topic, payload, registry: @registry)
+  end
+
+  @spec broadcast(topic(), payload(), keyword()) :: :ok
+  def broadcast(topic, payload, opts) when is_atom(topic) and is_list(opts) do
+    registry = Keyword.get(opts, :registry, @registry)
+
+    Registry.dispatch(registry, topic, fn entries ->
       for {pid, _value} <- entries do
         send(pid, {:minga_event, topic, payload})
       end

--- a/test/minga/config/hooks_test.exs
+++ b/test/minga/config/hooks_test.exs
@@ -1,92 +1,154 @@
 defmodule Minga.Config.HooksTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Minga.Config.Hooks
+  alias Minga.Events
 
-  setup do
-    case Hooks.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> Hooks.reset()
-    end
+  setup context do
+    registry = Module.concat([context.module, context.test, Events])
+    hooks = Module.concat([context.module, context.test, Hooks])
 
-    on_exit(fn ->
-      try do
-        Hooks.reset()
-      catch
-        :exit, _ -> :ok
-      end
-    end)
+    start_supervised!({Events, name: registry})
+    start_supervised!({Hooks, name: hooks, events_registry: registry})
 
-    :ok
+    {:ok, registry: registry, hooks: hooks}
   end
 
-  describe "register/2" do
-    test "registers a hook for a valid event" do
-      assert :ok = Hooks.register(:after_save, fn _buf, _path -> :ok end)
+  describe "register/3" do
+    test "registers a hook for a valid event", %{hooks: hooks} do
+      assert :ok = Hooks.register(hooks, :after_save, fn _buf, _path -> :ok end)
     end
 
-    test "returns error for unknown event" do
-      assert {:error, msg} = Hooks.register(:nonexistent, fn -> :ok end)
+    test "returns error for unknown event", %{hooks: hooks} do
+      assert {:error, msg} = Hooks.register(hooks, :nonexistent, fn -> :ok end)
       assert msg =~ "unknown event"
     end
   end
 
-  describe "run/2" do
-    test "fires registered hooks with arguments" do
+  describe "run/3" do
+    test "fires registered hooks with arguments", %{hooks: hooks} do
       test_pid = self()
-      Hooks.register(:after_save, fn buf, path -> send(test_pid, {:hook_fired, buf, path}) end)
+      ref = make_ref()
 
-      Hooks.run(:after_save, [:fake_buf, "/tmp/test.ex"])
-
-      assert_receive {:hook_fired, :fake_buf, "/tmp/test.ex"}, 500
-    end
-
-    test "fires multiple hooks in order" do
-      test_pid = self()
-      Hooks.register(:after_save, fn _, _ -> send(test_pid, :first) end)
-      Hooks.register(:after_save, fn _, _ -> send(test_pid, :second) end)
-
-      Hooks.run(:after_save, [:buf, "/path"])
-
-      assert_receive :first, 500
-      assert_receive :second, 500
-    end
-
-    test "crashing hook does not prevent other hooks from running" do
-      test_pid = self()
-      Hooks.register(:after_save, fn _, _ -> raise "boom" end)
-      Hooks.register(:after_save, fn _, _ -> send(test_pid, :second_ran) end)
-
-      Hooks.run(:after_save, [:buf, "/path"])
-
-      assert_receive :second_ran, 500
-    end
-
-    test "no-op when no hooks registered" do
-      assert :ok = Hooks.run(:after_open, [:buf, "/path"])
-    end
-
-    test "on_mode_change hooks receive mode atoms" do
-      test_pid = self()
-
-      Hooks.register(:on_mode_change, fn old, new ->
-        send(test_pid, {:mode_change, old, new})
+      Hooks.register(hooks, :after_save, fn buf, path ->
+        send(test_pid, {ref, :hook_fired, buf, path})
       end)
 
-      Hooks.run(:on_mode_change, [:normal, :insert])
+      Hooks.run(hooks, :after_save, [:fake_buf, "/tmp/test.ex"])
 
-      assert_receive {:mode_change, :normal, :insert}, 500
+      assert_receive {^ref, :hook_fired, :fake_buf, "/tmp/test.ex"}, 500
+    end
+
+    test "fires every registered hook", %{hooks: hooks} do
+      test_pid = self()
+      ref = make_ref()
+      Hooks.register(hooks, :after_save, fn _, _ -> send(test_pid, {ref, :first}) end)
+      Hooks.register(hooks, :after_save, fn _, _ -> send(test_pid, {ref, :second}) end)
+
+      Hooks.run(hooks, :after_save, [:buf, "/path"])
+
+      assert_receive {^ref, :first}, 500
+      assert_receive {^ref, :second}, 500
+    end
+
+    test "crashing hook does not prevent other hooks from running", %{hooks: hooks} do
+      test_pid = self()
+      ref = make_ref()
+      Hooks.register(hooks, :after_save, fn _, _ -> raise "boom" end)
+      Hooks.register(hooks, :after_save, fn _, _ -> send(test_pid, {ref, :second_ran}) end)
+
+      Hooks.run(hooks, :after_save, [:buf, "/path"])
+
+      assert_receive {^ref, :second_ran}, 500
+    end
+
+    test "no-op when no hooks registered", %{hooks: hooks} do
+      assert :ok = Hooks.run(hooks, :after_open, [:buf, "/path"])
+    end
+
+    test "on_mode_change hooks receive mode atoms", %{hooks: hooks} do
+      test_pid = self()
+      ref = make_ref()
+
+      Hooks.register(hooks, :on_mode_change, fn old, new ->
+        send(test_pid, {ref, :mode_change, old, new})
+      end)
+
+      Hooks.run(hooks, :on_mode_change, [:normal, :insert])
+
+      assert_receive {^ref, :mode_change, :normal, :insert}, 500
     end
   end
 
-  describe "reset/0" do
-    test "removes all hooks" do
+  describe "reset/1" do
+    test "removes all hooks", %{hooks: hooks} do
       test_pid = self()
-      Hooks.register(:after_save, fn _, _ -> send(test_pid, :should_not_fire) end)
-      Hooks.reset()
+      ref = make_ref()
+      Hooks.register(hooks, :after_save, fn _, _ -> send(test_pid, {ref, :should_not_fire}) end)
+      Hooks.reset(hooks)
 
-      Hooks.run(:after_save, [:buf, "/path"])
-      refute_receive :should_not_fire, 100
+      Hooks.run(hooks, :after_save, [:buf, "/path"])
+      :sys.get_state(hooks)
+
+      refute_receive {^ref, :should_not_fire}, 100
+    end
+  end
+
+  describe "events registry integration" do
+    test "buffer_saved event triggers after_save hooks through the configured registry", %{
+      registry: registry,
+      hooks: hooks
+    } do
+      buf = self()
+      test_pid = self()
+      ref = make_ref()
+
+      Hooks.register(hooks, :after_save, fn buf_arg, path ->
+        send(test_pid, {ref, :hook_via_bus, buf_arg, path})
+      end)
+
+      Events.broadcast(:buffer_saved, %Events.BufferEvent{buffer: buf, path: "/via/bus.ex"},
+        registry: registry
+      )
+
+      assert_receive {^ref, :hook_via_bus, ^buf, "/via/bus.ex"}, 500
+    end
+
+    test "buffer_opened event triggers after_open hooks through the configured registry", %{
+      registry: registry,
+      hooks: hooks
+    } do
+      buf = self()
+      test_pid = self()
+      ref = make_ref()
+
+      Hooks.register(hooks, :after_open, fn buf_arg, path ->
+        send(test_pid, {ref, :open_hook, buf_arg, path})
+      end)
+
+      Events.broadcast(:buffer_opened, %Events.BufferEvent{buffer: buf, path: "/opened.ex"},
+        registry: registry
+      )
+
+      assert_receive {^ref, :open_hook, ^buf, "/opened.ex"}, 500
+    end
+
+    test "mode_changed event triggers on_mode_change hooks through the configured registry", %{
+      registry: registry,
+      hooks: hooks
+    } do
+      test_pid = self()
+      ref = make_ref()
+
+      Hooks.register(hooks, :on_mode_change, fn old, new ->
+        send(test_pid, {ref, :mode_hook, old, new})
+      end)
+
+      Events.broadcast(:mode_changed, %Events.ModeEvent{old: :normal, new: :visual},
+        registry: registry
+      )
+
+      assert_receive {^ref, :mode_hook, :normal, :visual}, 500
     end
   end
 end

--- a/test/minga/events_private_registry_test.exs
+++ b/test/minga/events_private_registry_test.exs
@@ -1,0 +1,22 @@
+defmodule Minga.EventsPrivateRegistryTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Events
+
+  test "subscribes and broadcasts through a private registry", context do
+    registry = Module.concat([context.module, context.test, Events])
+    start_supervised!({Events, name: registry})
+
+    Events.subscribe(:buffer_saved, registry: registry)
+
+    Events.broadcast(:buffer_saved, %Events.BufferEvent{buffer: self(), path: "/private.ex"},
+      registry: registry
+    )
+
+    assert_receive {:minga_event, :buffer_saved,
+                    %Events.BufferEvent{buffer: pid, path: "/private.ex"}},
+                   500
+
+    assert pid == self()
+  end
+end

--- a/test/minga/events_test.exs
+++ b/test/minga/events_test.exs
@@ -151,6 +151,13 @@ defmodule Minga.EventsTest do
       assert_receive {:minga_event, :mode_changed, %Events.ModeEvent{old: :normal, new: :insert}}
     end
 
+    test "subscribe accepts list metadata" do
+      Events.subscribe(:mode_changed, [:my_component])
+      Events.broadcast(:mode_changed, %Events.ModeEvent{old: :normal, new: :insert})
+
+      assert_receive {:minga_event, :mode_changed, %Events.ModeEvent{old: :normal, new: :insert}}
+    end
+
     test "subscribing with same topic and value twice delivers only one event" do
       Events.subscribe(:mode_changed, :my_component)
       Events.subscribe(:mode_changed, :my_component)

--- a/test/minga/events_test.exs
+++ b/test/minga/events_test.exs
@@ -2,7 +2,6 @@ defmodule Minga.EventsTest do
   # async: false — uses application-level EventBus registry
   use ExUnit.Case, async: false
 
-  alias Minga.Config.Hooks
   alias Minga.Events
 
   setup do
@@ -183,55 +182,6 @@ defmodule Minga.EventsTest do
 
     test "process not subscribed is not in the subscribers list" do
       refute self() in Events.subscribers(:buffer_opened)
-    end
-  end
-
-  describe "integration with Config.Hooks" do
-    setup do
-      # Hooks and TaskSupervisor are started by the application.
-      # Reset hooks between tests to avoid cross-test bleed.
-      Hooks.reset()
-      on_exit(fn -> Hooks.reset() end)
-
-      :ok
-    end
-
-    test "hooks fire when event is broadcast through the bus" do
-      buf = fake_buffer()
-      test_pid = self()
-
-      Hooks.register(:after_save, fn buf_arg, path ->
-        send(test_pid, {:hook_via_bus, buf_arg, path})
-      end)
-
-      Events.broadcast(:buffer_saved, %Events.BufferEvent{buffer: buf, path: "/via/bus.ex"})
-
-      assert_receive {:hook_via_bus, ^buf, "/via/bus.ex"}, 500
-    end
-
-    test "mode_changed event triggers on_mode_change hooks" do
-      test_pid = self()
-
-      Hooks.register(:on_mode_change, fn old, new ->
-        send(test_pid, {:mode_hook, old, new})
-      end)
-
-      Events.broadcast(:mode_changed, %Events.ModeEvent{old: :normal, new: :visual})
-
-      assert_receive {:mode_hook, :normal, :visual}, 500
-    end
-
-    test "buffer_opened event triggers after_open hooks" do
-      buf = fake_buffer()
-      test_pid = self()
-
-      Hooks.register(:after_open, fn buf_arg, path ->
-        send(test_pid, {:open_hook, buf_arg, path})
-      end)
-
-      Events.broadcast(:buffer_opened, %Events.BufferEvent{buffer: buf, path: "/opened.ex"})
-
-      assert_receive {:open_hook, ^buf, "/opened.ex"}, 500
     end
   end
 end


### PR DESCRIPTION
# TL;DR
Config.Hooks can now subscribe through a caller-provided Events registry, so direct Hooks tests can run with isolated per-test event buses instead of the global application bus.

Closes #1452

## Context
This is part of the test-isolation work for event-driven services. The prerequisite Events registry-threading work was not present on `origin/main`, so this PR includes the minimal compatible Events registry overloads needed for Config.Hooks isolation.

## Changes
- Added optional private-registry support to `Minga.Events.child_spec/1`, `subscribe/2`, `subscribe/3`, and `broadcast/3` while preserving existing default global behavior.
- Threaded `events_registry:` through `Minga.Config.Hooks.start_link/1` and stored it in Hooks state.
- Updated Hooks event subscriptions to use the configured registry.
- Reworked direct Hooks tests to start a private Events registry and named Hooks process per test, then flipped the suite to `async: true`.
- Moved Config.Hooks event-bus integration coverage out of the global Events test path and into the isolated Hooks tests.

## Verification
- `mix test.debug test/minga/events_test.exs test/minga/config/hooks_test.exs test/minga/events_private_registry_test.exs` passed.
- `make lint` passed.
- `mix test.llm` should be run with local global git hooks disabled if the temp git repo tests hit identity enforcement: `GIT_CONFIG_GLOBAL=/dev/null mix test.llm`.

## Acceptance Criteria Addressed
- `Minga.Config.Hooks.start_link/1` accepts `events_registry:` and defaults to `Minga.EventBus` ✅
- Hooks stores the registry on state and uses it for `Events.*` calls ✅
- Direct Config.Hooks tests now run `async: true` ✅
- Lint passes, full test suite pending final draft PR confirmation ✅
