### PR TITLE
refactor(events): thread registry through editor state

### DIFF
--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -58,7 +58,9 @@ defmodule Minga.Buffer do
   undo integration, without depending on the Editor (Layer 2).
   """
   @spec ensure_for_path(String.t()) :: {:ok, pid()} | {:error, term()}
-  def ensure_for_path(path) when is_binary(path) do
+  @spec ensure_for_path(String.t(), Minga.Events.registry()) :: {:ok, pid()} | {:error, term()}
+  def ensure_for_path(path, events_registry \\ Minga.Events.default_registry())
+      when is_binary(path) do
     abs_path = Path.expand(path)
 
     case pid_for_path(abs_path) do
@@ -67,24 +69,29 @@ defmodule Minga.Buffer do
 
       :not_found ->
         if File.exists?(abs_path) do
-          start_buffer_for_path(abs_path)
+          start_buffer_for_path(abs_path, events_registry)
         else
           {:error, :enoent}
         end
     end
   end
 
-  @spec start_buffer_for_path(String.t()) :: {:ok, pid()} | {:error, term()}
-  defp start_buffer_for_path(abs_path) do
+  @spec start_buffer_for_path(String.t(), Minga.Events.registry()) ::
+          {:ok, pid()} | {:error, term()}
+  defp start_buffer_for_path(abs_path, events_registry) do
     case DynamicSupervisor.start_child(
            Minga.Buffer.Supervisor,
-           {__MODULE__, file_path: abs_path}
+           {__MODULE__, file_path: abs_path, events_registry: events_registry}
          ) do
       {:ok, pid} ->
-        Minga.Events.broadcast(:buffer_opened, %Minga.Events.BufferEvent{
-          buffer: pid,
-          path: abs_path
-        })
+        Minga.Events.broadcast(
+          :buffer_opened,
+          %Minga.Events.BufferEvent{
+            buffer: pid,
+            path: abs_path
+          },
+          events_registry
+        )
 
         {:ok, pid}
 

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -42,6 +42,7 @@ defmodule Minga.Buffer.Server do
           | {:read_only, boolean()}
           | {:unlisted, boolean()}
           | {:persistent, boolean()}
+          | {:events_registry, Minga.Events.registry()}
 
   @typedoc "Internal state of the buffer server."
   @type state :: BufState.t()
@@ -842,7 +843,8 @@ defmodule Minga.Buffer.Server do
           persistent: Keyword.get(opts, :persistent, false),
           options: seed_options(filetype),
           explicit_options: MapSet.new(),
-          swap_dir: Keyword.get(opts, :swap_dir)
+          swap_dir: Keyword.get(opts, :swap_dir),
+          events_registry: Keyword.get(opts, :events_registry, Minga.Events.default_registry())
         }
 
         register_path(path)
@@ -1364,13 +1366,13 @@ defmodule Minga.Buffer.Server do
 
   def handle_call({:remap_face, face_name, attrs}, _from, state) do
     overrides = Map.put(state.face_overrides, face_name, attrs)
-    notify_face_overrides_changed(overrides)
+    notify_face_overrides_changed(state, overrides)
     {:reply, :ok, %{state | face_overrides: overrides}}
   end
 
   def handle_call({:clear_face_override, face_name}, _from, state) do
     overrides = Map.delete(state.face_overrides, face_name)
-    notify_face_overrides_changed(overrides)
+    notify_face_overrides_changed(state, overrides)
     {:reply, :ok, %{state | face_overrides: overrides}}
   end
 
@@ -1728,7 +1730,7 @@ defmodule Minga.Buffer.Server do
 
   @impl true
   def handle_info({:deferred_broadcast, topic, payload}, state) do
-    Events.broadcast(topic, payload)
+    Events.broadcast(topic, payload, state.events_registry)
     {:noreply, state}
   end
 
@@ -1928,12 +1930,16 @@ defmodule Minga.Buffer.Server do
   # Broadcasts a face_overrides_changed event so any subscriber (typically
   # the Editor) can pre-compute the merged face registry. Using Events
   # decouples Buffer.Server from the Editor module.
-  @spec notify_face_overrides_changed(%{String.t() => keyword()}) :: :ok
-  defp notify_face_overrides_changed(overrides) do
-    Minga.Events.broadcast(:face_overrides_changed, %Minga.Events.FaceOverridesChangedEvent{
-      buffer: self(),
-      overrides: overrides
-    })
+  @spec notify_face_overrides_changed(BufState.t(), %{String.t() => keyword()}) :: :ok
+  defp notify_face_overrides_changed(state, overrides) do
+    Minga.Events.broadcast(
+      :face_overrides_changed,
+      %Minga.Events.FaceOverridesChangedEvent{
+        buffer: self(),
+        overrides: overrides
+      },
+      state.events_registry
+    )
 
     :ok
   end

--- a/lib/minga/buffer/state.ex
+++ b/lib/minga/buffer/state.ex
@@ -61,7 +61,8 @@ defmodule Minga.Buffer.State do
             options: %{},
             explicit_options: MapSet.new(),
             swap_timer: nil,
-            swap_dir: nil
+            swap_dir: nil,
+            events_registry: Minga.Events.default_registry()
 
   @type t :: %__MODULE__{
           document: Document.t(),
@@ -89,7 +90,8 @@ defmodule Minga.Buffer.State do
           options: %{atom() => term()},
           explicit_options: MapSet.t(atom()),
           swap_timer: reference() | nil,
-          swap_dir: String.t() | nil
+          swap_dir: String.t() | nil,
+          events_registry: Minga.Events.registry()
         }
 
   @max_undo_stack 1000

--- a/lib/minga/command_output.ex
+++ b/lib/minga/command_output.ex
@@ -23,7 +23,8 @@ defmodule Minga.CommandOutput do
           command: String.t() | nil,
           cwd: String.t() | nil,
           exit_code: non_neg_integer() | nil,
-          running?: boolean()
+          running?: boolean(),
+          events_registry: Minga.Events.registry()
         }
 
   defstruct name: nil,
@@ -33,7 +34,8 @@ defmodule Minga.CommandOutput do
             command: nil,
             cwd: nil,
             exit_code: nil,
-            running?: false
+            running?: false,
+            events_registry: Minga.Events.default_registry()
 
   # ── Public API ─────────────────────────────────────────────────────────────
 
@@ -108,7 +110,8 @@ defmodule Minga.CommandOutput do
   @spec init(keyword()) :: {:ok, t()}
   def init(opts) do
     name = Keyword.fetch!(opts, :name)
-    {:ok, %__MODULE__{name: name}}
+    events_registry = Keyword.get(opts, :events_registry, Minga.Events.default_registry())
+    {:ok, %__MODULE__{name: name, events_registry: events_registry}}
   end
 
   @impl true
@@ -160,7 +163,8 @@ defmodule Minga.CommandOutput do
 
     Minga.Events.broadcast(
       :command_done,
-      %Minga.Events.CommandDoneEvent{name: state.name, exit_code: code}
+      %Minga.Events.CommandDoneEvent{name: state.name, exit_code: code},
+      state.events_registry
     )
 
     {:noreply, %{state | port: nil, exit_code: code, running?: false}}

--- a/lib/minga/config/hooks.ex
+++ b/lib/minga/config/hooks.ex
@@ -42,15 +42,18 @@ defmodule Minga.Config.Hooks do
   @type event :: :after_save | :after_open | :on_mode_change
 
   @typedoc "Hook state: event name → list of hook functions."
-  @type state :: %{event() => [function()]}
+  @type state :: %{
+          hooks: %{event() => [function()]},
+          events_registry: Minga.Events.registry()
+        }
 
   # ── Client API ──────────────────────────────────────────────────────────────
 
   @doc "Starts the hooks registry and subscribes to the event bus."
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    {name, _opts} = Keyword.pop(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, [], name: name)
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
   end
 
   @doc """
@@ -105,24 +108,25 @@ defmodule Minga.Config.Hooks do
 
   @impl true
   @spec init(keyword()) :: {:ok, state()}
-  def init(_opts) do
-    subscribe_to_events()
-    {:ok, initial_state()}
+  def init(opts) do
+    events_registry = Keyword.get(opts, :events_registry, Minga.Events.default_registry())
+    subscribe_to_events(events_registry)
+    {:ok, %{hooks: initial_hooks(), events_registry: events_registry}}
   end
 
   @impl true
   def handle_call({:register, event, fun}, _from, state) do
-    new_state = Map.update!(state, event, &[fun | &1])
+    new_state = update_in(state.hooks, &Map.update!(&1, event, fn hooks -> [fun | hooks] end))
     {:reply, :ok, new_state}
   end
 
-  def handle_call(:reset, _from, _state) do
-    {:reply, :ok, initial_state()}
+  def handle_call(:reset, _from, state) do
+    {:reply, :ok, %{state | hooks: initial_hooks()}}
   end
 
   @impl true
   def handle_cast({:run, event, args}, state) do
-    do_run(state, event, args)
+    do_run(state.hooks, event, args)
     {:noreply, state}
   end
 
@@ -131,7 +135,7 @@ defmodule Minga.Config.Hooks do
     case Map.fetch(@topic_to_event, topic) do
       {:ok, event} ->
         args = payload_to_args(topic, payload)
-        do_run(state, event, args)
+        do_run(state.hooks, event, args)
 
       :error ->
         :ok
@@ -144,10 +148,10 @@ defmodule Minga.Config.Hooks do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
-  @spec subscribe_to_events() :: :ok
-  defp subscribe_to_events do
+  @spec subscribe_to_events(Minga.Events.registry()) :: :ok
+  defp subscribe_to_events(events_registry) do
     for topic <- Map.keys(@topic_to_event) do
-      Minga.Events.subscribe(topic)
+      Minga.Events.subscribe(topic, events_registry)
     end
 
     :ok
@@ -160,9 +164,9 @@ defmodule Minga.Config.Hooks do
   defp payload_to_args(_topic, %Minga.Events.ModeEvent{old: old_mode, new: new_mode}),
     do: [old_mode, new_mode]
 
-  @spec do_run(state(), event(), [term()]) :: :ok
-  defp do_run(state, event, args) do
-    hooks = Map.get(state, event, []) |> Enum.reverse()
+  @spec do_run(%{event() => [function()]}, event(), [term()]) :: :ok
+  defp do_run(hooks_by_event, event, args) do
+    hooks = Map.get(hooks_by_event, event, []) |> Enum.reverse()
 
     for hook <- hooks do
       Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
@@ -184,8 +188,8 @@ defmodule Minga.Config.Hooks do
     :ok
   end
 
-  @spec initial_state() :: state()
-  defp initial_state do
+  @spec initial_hooks() :: %{event() => [function()]}
+  defp initial_hooks do
     Map.new(@valid_events, &{&1, []})
   end
 end

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -306,7 +306,12 @@ defmodule Minga.Config.Loader do
 
   @spec load_user_themes() :: :ok
   defp load_user_themes do
-    Minga.Events.broadcast(:load_user_themes, %Minga.Events.LoadUserThemesEvent{})
+    Minga.Events.broadcast(
+      :load_user_themes,
+      %Minga.Events.LoadUserThemesEvent{},
+      Minga.Events.default_registry()
+    )
+
     :ok
   end
 

--- a/lib/minga/diagnostics.ex
+++ b/lib/minga/diagnostics.ex
@@ -396,7 +396,8 @@ defmodule Minga.Diagnostics do
   defp broadcast_diagnostics_updated(uri, source) do
     Minga.Events.broadcast(
       :diagnostics_updated,
-      %Minga.Events.DiagnosticsUpdatedEvent{uri: uri, source: source}
+      %Minga.Events.DiagnosticsUpdatedEvent{uri: uri, source: source},
+      Minga.Events.default_registry()
     )
   end
 

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -50,7 +50,14 @@ defmodule Minga.Events do
   a one-file change if distributed events are ever needed.
   """
 
-  @registry Minga.EventBus
+  @default_registry Minga.EventBus
+
+  @typedoc "Registry process name used by the event bus."
+  @type registry :: atom()
+
+  @doc "Returns the production event bus registry name."
+  @spec default_registry() :: registry()
+  def default_registry, do: @default_registry
 
   # ── Payload structs ─────────────────────────────────────────────────────────
 
@@ -263,14 +270,14 @@ defmodule Minga.Events do
   Add this to your supervision tree before any process that subscribes.
   """
   @spec child_spec(keyword()) :: Supervisor.child_spec()
-  def child_spec(_opts) do
-    Registry.child_spec(keys: :duplicate, name: @registry)
+  def child_spec(opts) do
+    Registry.child_spec(keys: :duplicate, name: Keyword.get(opts, :name, default_registry()))
   end
 
   # ── Subscribe / Unsubscribe ─────────────────────────────────────────────────
 
   @doc """
-  Subscribes the calling process to a topic.
+  Subscribes the calling process to a topic on the default registry.
 
   The process will be included in `Registry.dispatch/3` callbacks when
   `broadcast/2` is called for this topic. A process can subscribe to
@@ -279,35 +286,35 @@ defmodule Minga.Events do
   """
   @spec subscribe(topic()) :: :ok
   def subscribe(topic) when is_atom(topic) do
-    if Process.whereis(@registry) do
-      already? =
-        Registry.lookup(@registry, topic)
-        |> Enum.any?(fn {pid, _} -> pid == self() end)
-
-      unless already?, do: {:ok, _} = Registry.register(@registry, topic, [])
-    end
-
-    :ok
+    subscribe_topic(topic, [], default_registry())
   end
 
   @doc """
-  Subscribes the calling process to a topic with metadata.
+  Subscribes the calling process to a topic with metadata or a registry.
+
+  If the second argument is the name of a running Registry process, it is
+  treated as the event registry. Otherwise it is preserved as metadata on
+  the default registry for backward compatibility.
+  """
+  @spec subscribe(topic(), registry() | term()) :: :ok
+  def subscribe(topic, registry_or_value) when is_atom(topic) do
+    if registry_process?(registry_or_value) do
+      subscribe_topic(topic, [], registry_or_value)
+    else
+      subscribe_topic(topic, registry_or_value, default_registry())
+    end
+  end
+
+  @doc """
+  Subscribes the calling process to a topic with metadata on a registry.
 
   The metadata value is passed to the dispatch callback alongside the pid,
   which lets subscribers filter or tag their registrations. Subscribing
   with the same topic and value from the same process is a no-op.
   """
-  @spec subscribe(topic(), term()) :: :ok
-  def subscribe(topic, value) when is_atom(topic) do
-    if Process.whereis(@registry) do
-      already? =
-        Registry.lookup(@registry, topic)
-        |> Enum.any?(fn {pid, v} -> pid == self() and v == value end)
-
-      unless already?, do: {:ok, _} = Registry.register(@registry, topic, value)
-    end
-
-    :ok
+  @spec subscribe(topic(), term(), registry()) :: :ok
+  def subscribe(topic, value, registry) when is_atom(topic) do
+    subscribe_topic(topic, value, registry)
   end
 
   @doc """
@@ -316,8 +323,13 @@ defmodule Minga.Events do
   Removes all registrations for this process under the given topic key.
   """
   @spec unsubscribe(topic()) :: :ok
-  def unsubscribe(topic) when is_atom(topic) do
-    Registry.unregister(@registry, topic)
+  @spec unsubscribe(topic(), registry()) :: :ok
+  def unsubscribe(topic, registry \\ default_registry()) when is_atom(topic) do
+    if registry_process?(registry) do
+      Registry.unregister(registry, topic)
+    end
+
+    :ok
   end
 
   # ── Broadcast ───────────────────────────────────────────────────────────────
@@ -354,12 +366,14 @@ defmodule Minga.Events do
   @spec broadcast(:load_user_themes, LoadUserThemesEvent.t()) :: :ok
   @spec broadcast(:buffer_fork_conflict, map()) :: :ok
   @spec broadcast(:extension_updates_available, Minga.Extension.UpdatesAvailableEvent.t()) :: :ok
-  def broadcast(topic, %_{} = payload) when is_atom(topic) do
-    Registry.dispatch(@registry, topic, fn entries ->
-      for {pid, _value} <- entries do
-        send(pid, {:minga_event, topic, payload})
-      end
-    end)
+  def broadcast(topic, payload) when is_atom(topic) and is_map(payload) do
+    broadcast(topic, payload, default_registry())
+  end
+
+  @spec broadcast(topic(), payload() | map(), registry()) :: :ok
+  def broadcast(topic, payload, registry) when is_atom(topic) and is_map(payload) do
+    if registry_process?(registry), do: dispatch(registry, topic, payload)
+    :ok
   end
 
   @doc """
@@ -371,11 +385,16 @@ defmodule Minga.Events do
   """
   @deprecated "Buffer.Server now broadcasts :buffer_changed automatically on every edit. No manual broadcast needed."
   @spec notify_buffer_changed(pid()) :: :ok
-  def notify_buffer_changed(buf) when is_pid(buf) do
-    broadcast(:buffer_changed, %BufferChangedEvent{
-      buffer: buf,
-      source: Minga.Buffer.EditSource.unknown()
-    })
+  @spec notify_buffer_changed(pid(), registry()) :: :ok
+  def notify_buffer_changed(buf, registry \\ default_registry()) when is_pid(buf) do
+    broadcast(
+      :buffer_changed,
+      %BufferChangedEvent{
+        buffer: buf,
+        source: Minga.Buffer.EditSource.unknown()
+      },
+      registry
+    )
   end
 
   # ── Query ───────────────────────────────────────────────────────────────────
@@ -387,7 +406,38 @@ defmodule Minga.Events do
   (use `broadcast/2` instead).
   """
   @spec subscribers(topic()) :: [pid()]
-  def subscribers(topic) when is_atom(topic) do
-    Registry.lookup(@registry, topic) |> Enum.map(fn {pid, _} -> pid end)
+  @spec subscribers(topic(), registry()) :: [pid()]
+  def subscribers(topic, registry \\ default_registry()) when is_atom(topic) do
+    if registry_process?(registry) do
+      Registry.lookup(registry, topic) |> Enum.map(fn {pid, _} -> pid end)
+    else
+      []
+    end
   end
+
+  @spec dispatch(registry(), topic(), payload() | map()) :: :ok
+  defp dispatch(registry, topic, payload) do
+    Registry.dispatch(registry, topic, fn entries ->
+      for {pid, _value} <- entries do
+        send(pid, {:minga_event, topic, payload})
+      end
+    end)
+  end
+
+  @spec subscribe_topic(topic(), term(), registry()) :: :ok
+  defp subscribe_topic(topic, value, registry) do
+    if registry_process?(registry) do
+      already? =
+        Registry.lookup(registry, topic)
+        |> Enum.any?(fn {pid, v} -> pid == self() and v == value end)
+
+      unless already?, do: {:ok, _} = Registry.register(registry, topic, value)
+    end
+
+    :ok
+  end
+
+  @spec registry_process?(term()) :: boolean()
+  defp registry_process?(name) when is_atom(name), do: Process.whereis(name) != nil
+  defp registry_process?(_), do: false
 end

--- a/lib/minga/file_watcher.ex
+++ b/lib/minga/file_watcher.ex
@@ -27,7 +27,8 @@ defmodule Minga.FileWatcher do
             watcher: nil,
             watched_dirs: %{},
             watched_files: MapSet.new(),
-            pending: %{}
+            pending: %{},
+            events_registry: Minga.Events.default_registry()
 
   @typep state :: %__MODULE__{
            subscriber: pid() | nil,
@@ -35,7 +36,8 @@ defmodule Minga.FileWatcher do
            watched_dirs: %{String.t() => pos_integer()},
            watched_files: MapSet.t(String.t()),
            pending: %{String.t() => reference()},
-           debounce_ms: pos_integer()
+           debounce_ms: pos_integer(),
+           events_registry: Minga.Events.registry()
          }
 
   @default_debounce_ms 100
@@ -79,17 +81,19 @@ defmodule Minga.FileWatcher do
   def init(opts) do
     debounce_ms = Keyword.get(opts, :debounce_ms, @default_debounce_ms)
     subscriber = Keyword.get(opts, :subscriber)
+    events_registry = Keyword.get(opts, :events_registry, Minga.Events.default_registry())
 
     # Subscribe to buffer-open events so we automatically watch new files.
     # Opt-out via subscribe_events: false (used by tests to avoid global
     # event bus noise from concurrent tests flooding the watcher mailbox).
     if Keyword.get(opts, :subscribe_events, true) do
-      Minga.Events.subscribe(:buffer_opened)
+      Minga.Events.subscribe(:buffer_opened, events_registry)
     end
 
     state = %__MODULE__{
       subscriber: subscriber,
-      debounce_ms: debounce_ms
+      debounce_ms: debounce_ms,
+      events_registry: events_registry
     }
 
     {:ok, state}

--- a/lib/minga/git/repo.ex
+++ b/lib/minga/git/repo.ex
@@ -39,7 +39,8 @@ defmodule Minga.Git.Repo do
     ahead: 0,
     behind: 0,
     watcher_pid: nil,
-    debounce_ref: nil
+    debounce_ref: nil,
+    events_registry: Minga.Events.default_registry()
   ]
 
   @typedoc "Git.Repo internal state."
@@ -51,11 +52,15 @@ defmodule Minga.Git.Repo do
           ahead: non_neg_integer(),
           behind: non_neg_integer(),
           watcher_pid: pid() | nil,
-          debounce_ref: reference() | nil
+          debounce_ref: reference() | nil,
+          events_registry: Minga.Events.registry()
         }
 
   @typedoc "Options for starting a Git.Repo process."
-  @type start_opt :: {:git_root, String.t()} | {:project_root, String.t() | nil}
+  @type start_opt ::
+          {:git_root, String.t()}
+          | {:project_root, String.t() | nil}
+          | {:events_registry, Minga.Events.registry()}
 
   @typedoc "Summary of repo status for display."
   @type summary :: %{
@@ -109,8 +114,14 @@ defmodule Minga.Git.Repo do
   Returns `{:ok, pid}` if one already exists or was started successfully,
   or `{:error, reason}` if it couldn't be started.
   """
-  @spec ensure_started(String.t(), String.t() | nil) :: {:ok, pid()} | {:error, term()}
-  def ensure_started(git_root, project_root \\ nil) when is_binary(git_root) do
+  @spec ensure_started(String.t(), String.t() | nil, Minga.Events.registry()) ::
+          {:ok, pid()} | {:error, term()}
+  def ensure_started(
+        git_root,
+        project_root \\ nil,
+        events_registry \\ Minga.Events.default_registry()
+      )
+      when is_binary(git_root) do
     case lookup(git_root) do
       pid when is_pid(pid) ->
         {:ok, pid}
@@ -118,7 +129,8 @@ defmodule Minga.Git.Repo do
       nil ->
         DynamicSupervisor.start_child(
           @supervisor,
-          {__MODULE__, git_root: git_root, project_root: project_root}
+          {__MODULE__,
+           git_root: git_root, project_root: project_root, events_registry: events_registry}
         )
     end
   end
@@ -154,12 +166,14 @@ defmodule Minga.Git.Repo do
   def init(opts) do
     git_root = Keyword.fetch!(opts, :git_root)
     project_root = Keyword.get(opts, :project_root)
+    events_registry = Keyword.get(opts, :events_registry, Minga.Events.default_registry())
 
-    Minga.Events.subscribe(:buffer_saved)
+    Minga.Events.subscribe(:buffer_saved, events_registry)
 
     state = %__MODULE__{
       git_root: git_root,
-      project_root: project_root
+      project_root: project_root,
+      events_registry: events_registry
     }
 
     # Load initial status and branch synchronously so callers have data immediately
@@ -270,7 +284,8 @@ defmodule Minga.Git.Repo do
           branch: branch,
           ahead: ahead,
           behind: behind
-        }
+        },
+        state.events_registry
       )
     end
 

--- a/lib/minga/git/tracker.ex
+++ b/lib/minga/git/tracker.ex
@@ -27,8 +27,8 @@ defmodule Minga.Git.Tracker do
   @doc "Starts the git tracker."
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    {name, _opts} = Keyword.pop(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, [], name: name)
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
   end
 
   @doc """
@@ -39,8 +39,9 @@ defmodule Minga.Git.Tracker do
   call from any process (including the renderer) without blocking.
   """
   @spec lookup(pid()) :: pid() | nil
-  def lookup(buffer_pid) when is_pid(buffer_pid) do
-    case :ets.lookup(@registry_table, buffer_pid) do
+  @spec lookup(pid(), atom()) :: pid() | nil
+  def lookup(buffer_pid, registry_table \\ @registry_table) when is_pid(buffer_pid) do
+    case :ets.lookup(registry_table, buffer_pid) do
       [{^buffer_pid, git_pid}] -> git_pid
       [] -> nil
     end
@@ -54,8 +55,9 @@ defmodule Minga.Git.Tracker do
   Same direct ETS read as `lookup/1`.
   """
   @spec tracked?(pid()) :: boolean()
-  def tracked?(buffer_pid) when is_pid(buffer_pid) do
-    :ets.member(@registry_table, buffer_pid)
+  @spec tracked?(pid(), atom()) :: boolean()
+  def tracked?(buffer_pid, registry_table \\ @registry_table) when is_pid(buffer_pid) do
+    :ets.member(registry_table, buffer_pid)
   rescue
     ArgumentError -> false
   end
@@ -64,24 +66,35 @@ defmodule Minga.Git.Tracker do
 
   @typep tracker_state :: %{
            monitors: %{reference() => {pid(), String.t()}},
-           repo_buffer_counts: %{String.t() => pos_integer()}
+           repo_buffer_counts: %{String.t() => pos_integer()},
+           events_registry: Minga.Events.registry(),
+           registry_table: atom()
          }
 
   @impl true
   @spec init(keyword()) :: {:ok, tracker_state()}
-  def init(_opts) do
-    :ets.new(@registry_table, [
+  def init(opts) do
+    events_registry = Keyword.get(opts, :events_registry, Minga.Events.default_registry())
+    registry_table = Keyword.get(opts, :registry_table, @registry_table)
+
+    :ets.new(registry_table, [
       :named_table,
       :public,
       :set,
       read_concurrency: true
     ])
 
-    Minga.Events.subscribe(:buffer_opened)
-    Minga.Events.subscribe(:buffer_saved)
-    Minga.Events.subscribe(:buffer_changed)
+    Minga.Events.subscribe(:buffer_opened, events_registry)
+    Minga.Events.subscribe(:buffer_saved, events_registry)
+    Minga.Events.subscribe(:buffer_changed, events_registry)
 
-    {:ok, %{monitors: %{}, repo_buffer_counts: %{}}}
+    {:ok,
+     %{
+       monitors: %{},
+       repo_buffer_counts: %{},
+       events_registry: events_registry,
+       registry_table: registry_table
+     }}
   end
 
   @impl true
@@ -91,7 +104,7 @@ defmodule Minga.Git.Tracker do
         state
       )
       when is_pid(buf) do
-    do_notify_change(buf)
+    do_notify_change(buf, state.registry_table)
     {:noreply, state}
   end
 
@@ -103,7 +116,7 @@ defmodule Minga.Git.Tracker do
     # Start Git.Repo for the git root (if not already running) before
     # per-buffer tracking. This ensures repo-wide state is available
     # for the status panel and modeline even before per-buffer diffs.
-    ensure_repo_for_path(path)
+    ensure_repo_for_path(path, state.events_registry)
     state = maybe_start_git_buffer(state, buf, path)
     {:noreply, state}
   end
@@ -113,7 +126,7 @@ defmodule Minga.Git.Tracker do
         state
       )
       when is_pid(buf) do
-    invalidate_on_save(buf)
+    invalidate_on_save(buf, state.registry_table)
     {:noreply, state}
   end
 
@@ -124,7 +137,7 @@ defmodule Minga.Git.Tracker do
 
       {{buffer_pid, git_root}, monitors} ->
         # Clean up the git buffer registry entry
-        :ets.delete(@registry_table, buffer_pid)
+        :ets.delete(state.registry_table, buffer_pid)
 
         # Decrement repo buffer count; stop Git.Repo when no buffers remain
         repo_counts = maybe_decrement_repo_count(state.repo_buffer_counts, git_root)
@@ -136,9 +149,9 @@ defmodule Minga.Git.Tracker do
 
   # ── Private ────────────────────────────────────────────────────────────
 
-  @spec do_notify_change(pid()) :: :ok
-  defp do_notify_change(buffer_pid) do
-    case lookup(buffer_pid) do
+  @spec do_notify_change(pid(), atom()) :: :ok
+  defp do_notify_change(buffer_pid, registry_table) do
+    case lookup(buffer_pid, registry_table) do
       nil ->
         :ok
 
@@ -160,14 +173,18 @@ defmodule Minga.Git.Tracker do
              Minga.Buffer.Supervisor,
              {GitBuffer, git_root: git_root, file_path: path, initial_content: content}
            ) do
-      :ets.insert(@registry_table, {buffer_pid, git_pid})
+      :ets.insert(state.registry_table, {buffer_pid, git_pid})
       ref = Process.monitor(buffer_pid)
       rel_path = Path.relative_to(path, git_root)
 
-      Minga.Events.broadcast(:log_message, %Minga.Events.LogMessageEvent{
-        text: "Git: tracking #{rel_path}",
-        level: :info
-      })
+      Minga.Events.broadcast(
+        :log_message,
+        %Minga.Events.LogMessageEvent{
+          text: "Git: tracking #{rel_path}",
+          level: :info
+        },
+        state.events_registry
+      )
 
       repo_counts = Map.update(state.repo_buffer_counts, git_root, 1, &(&1 + 1))
 
@@ -185,16 +202,16 @@ defmodule Minga.Git.Tracker do
     :exit, _ -> state
   end
 
-  @spec ensure_repo_for_path(String.t()) :: :ok
-  defp ensure_repo_for_path(path) do
+  @spec ensure_repo_for_path(String.t(), Minga.Events.registry()) :: :ok
+  defp ensure_repo_for_path(path, events_registry) do
     case Git.root_for(path) do
-      {:ok, git_root} -> ensure_repo(git_root)
+      {:ok, git_root} -> ensure_repo(git_root, events_registry)
       :not_git -> :ok
     end
   end
 
-  @spec ensure_repo(String.t()) :: :ok
-  defp ensure_repo(git_root) do
+  @spec ensure_repo(String.t(), Minga.Events.registry()) :: :ok
+  defp ensure_repo(git_root, events_registry) do
     project_root =
       try do
         Minga.Project.root()
@@ -202,7 +219,7 @@ defmodule Minga.Git.Tracker do
         :exit, _ -> nil
       end
 
-    case Git.Repo.ensure_started(git_root, project_root) do
+    case Git.Repo.ensure_started(git_root, project_root, events_registry) do
       {:ok, _pid} ->
         :ok
 
@@ -253,9 +270,9 @@ defmodule Minga.Git.Tracker do
     :exit, _ -> :ok
   end
 
-  @spec invalidate_on_save(pid()) :: :ok
-  defp invalidate_on_save(buf) do
-    case lookup(buf) do
+  @spec invalidate_on_save(pid(), atom()) :: :ok
+  defp invalidate_on_save(buf, registry_table) do
+    case lookup(buf, registry_table) do
       nil ->
         :ok
 

--- a/lib/minga/lsp/sync_server.ex
+++ b/lib/minga/lsp/sync_server.ex
@@ -48,7 +48,8 @@ defmodule Minga.LSP.SyncServer do
           debounce_timers: %{pid() => reference()},
           client_monitors: %{reference() => {buffer_pid :: pid(), client_pid :: pid()}},
           pending_tool_buffers: %{String.t() => [pid()]},
-          delta_accumulators: %{pid() => delta_accumulator()}
+          delta_accumulators: %{pid() => delta_accumulator()},
+          events_registry: Events.registry()
         }
 
   # ── Client API ─────────────────────────────────────────────────────────
@@ -80,7 +81,7 @@ defmodule Minga.LSP.SyncServer do
 
   @impl true
   @spec init(keyword()) :: {:ok, state()}
-  def init(_opts) do
+  def init(opts) do
     :ets.new(@registry_table, [
       :named_table,
       :public,
@@ -88,11 +89,13 @@ defmodule Minga.LSP.SyncServer do
       read_concurrency: true
     ])
 
-    Events.subscribe(:buffer_opened)
-    Events.subscribe(:buffer_saved)
-    Events.subscribe(:buffer_closed)
-    Events.subscribe(:buffer_changed)
-    Events.subscribe(:tool_install_complete)
+    events_registry = Keyword.get(opts, :events_registry, Events.default_registry())
+
+    Events.subscribe(:buffer_opened, events_registry)
+    Events.subscribe(:buffer_saved, events_registry)
+    Events.subscribe(:buffer_closed, events_registry)
+    Events.subscribe(:buffer_changed, events_registry)
+    Events.subscribe(:tool_install_complete, events_registry)
 
     {:ok,
      %{
@@ -101,7 +104,8 @@ defmodule Minga.LSP.SyncServer do
        pending_tool_buffers: %{},
        # Accumulated deltas per buffer pid. When a delta is nil (bulk op),
        # the value is set to :full_sync to force full content sync.
-       delta_accumulators: %{}
+       delta_accumulators: %{},
+       events_registry: events_registry
      }}
   end
 
@@ -232,7 +236,12 @@ defmodule Minga.LSP.SyncServer do
     results
     |> Enum.filter(&failed_with_recipe?/1)
     |> Enum.reduce(state, fn {config, _}, acc ->
-      Events.broadcast(:tool_missing, %ToolMissingEvent{command: config.command})
+      Events.broadcast(
+        :tool_missing,
+        %ToolMissingEvent{command: config.command},
+        state.events_registry
+      )
+
       track_buffer_for_command(acc, config.command, buffer_pid)
     end)
   end

--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -35,7 +35,8 @@ defmodule Minga.Project do
             known_projects: [],
             recent_files: %{},
             rebuilding?: false,
-            rebuild_ref: nil
+            rebuild_ref: nil,
+            events_registry: Minga.Events.default_registry()
 
   @typedoc "Per-project recent files map: project root => list of relative paths (most recent first)."
   @type recent_files_map :: %{String.t() => [String.t()]}
@@ -48,7 +49,8 @@ defmodule Minga.Project do
           known_projects: [String.t()],
           recent_files: recent_files_map(),
           rebuilding?: boolean(),
-          rebuild_ref: reference() | nil
+          rebuild_ref: reference() | nil,
+          events_registry: Minga.Events.registry()
         }
 
   @known_projects_file "known-projects"
@@ -159,13 +161,17 @@ defmodule Minga.Project do
     # Subscribe to buffer-open events so we detect projects and record
     # recent files automatically, without the Editor wiring it up.
     # Tests pass subscribe: false to avoid cross-test event contamination.
+    events_registry = Keyword.get(opts, :events_registry, Minga.Events.default_registry())
+
     unless Keyword.get(opts, :subscribe) == false do
-      Minga.Events.subscribe(:buffer_opened)
+      Minga.Events.subscribe(:buffer_opened, events_registry)
     end
 
     known = load_known_projects()
     recent = if persist_recent_files?(), do: load_recent_files(), else: %{}
-    {:ok, %__MODULE__{known_projects: known, recent_files: recent}}
+
+    {:ok,
+     %__MODULE__{known_projects: known, recent_files: recent, events_registry: events_registry}}
   end
 
   @impl true
@@ -254,7 +260,12 @@ defmodule Minga.Project do
     Process.demonitor(ref, [:flush])
 
     if root == state.current_root do
-      Minga.Events.broadcast(:project_rebuilt, %Minga.Events.ProjectRebuiltEvent{root: root})
+      Minga.Events.broadcast(
+        :project_rebuilt,
+        %Minga.Events.ProjectRebuiltEvent{root: root},
+        state.events_registry
+      )
+
       {:noreply, %{state | cached_files: files, rebuilding?: false, rebuild_ref: nil}}
     else
       # Root changed while rebuild was in progress; discard stale result

--- a/lib/minga/tool/manager.ex
+++ b/lib/minga/tool/manager.ex
@@ -534,22 +534,17 @@ defmodule Minga.Tool.Manager do
 
   @spec broadcast(atom(), map()) :: :ok
   defp broadcast(topic, payload) do
-    unless is_nil(Process.whereis(Minga.EventBus)) do
-      Registry.dispatch(Minga.EventBus, topic, &notify_subscribers(&1, topic, payload))
-    end
-
-    :ok
-  end
-
-  @spec notify_subscribers([{pid(), term()}], atom(), map()) :: :ok
-  defp notify_subscribers(entries, topic, payload) do
-    for {pid, _value} <- entries, do: send(pid, {:minga_event, topic, payload})
-    :ok
+    Minga.Events.broadcast(topic, payload, Minga.Events.default_registry())
   end
 
   @spec log_message(String.t()) :: :ok
   defp log_message(text) do
-    Minga.Events.broadcast(:log_message, %Minga.Events.LogMessageEvent{text: text, level: :info})
+    Minga.Events.broadcast(
+      :log_message,
+      %Minga.Events.LogMessageEvent{text: text, level: :info},
+      Minga.Events.default_registry()
+    )
+
     :ok
   end
 end

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -61,6 +61,7 @@ defmodule MingaEditor do
           | {:port_manager, GenServer.server()}
           | {:keymap_server, GenServer.server()}
           | {:options_server, GenServer.server()}
+          | {:events_registry, Minga.Events.registry()}
           | {:buffer, pid()}
           | {:width, pos_integer()}
           | {:height, pos_integer()}
@@ -185,25 +186,26 @@ defmodule MingaEditor do
       end
 
     state = Startup.apply_config_options(state)
-    Minga.Events.subscribe(:diagnostics_updated)
-    Minga.Events.subscribe(:lsp_status_changed)
+    events_registry = EditorState.events_registry(state)
+    Minga.Events.subscribe(:diagnostics_updated, events_registry)
+    Minga.Events.subscribe(:lsp_status_changed, events_registry)
 
     # Refresh file tree git status when any buffer is saved.
-    Minga.Events.subscribe(:buffer_saved)
-    Minga.Events.subscribe(:git_status_changed)
+    Minga.Events.subscribe(:buffer_saved, events_registry)
+    Minga.Events.subscribe(:git_status_changed, events_registry)
 
     # Tool manager progress: show install/update status in the status line.
-    Minga.Events.subscribe(:tool_install_started)
-    Minga.Events.subscribe(:tool_install_progress)
-    Minga.Events.subscribe(:tool_install_complete)
-    Minga.Events.subscribe(:tool_install_failed)
-    Minga.Events.subscribe(:tool_uninstall_complete)
-    Minga.Events.subscribe(:tool_missing)
-    Minga.Events.subscribe(:log_message)
-    Minga.Events.subscribe(:face_overrides_changed)
-    Minga.Events.subscribe(:agent_session_stopped)
-    Minga.Events.subscribe(:load_user_themes)
-    Minga.Events.subscribe(:extension_updates_available)
+    Minga.Events.subscribe(:tool_install_started, events_registry)
+    Minga.Events.subscribe(:tool_install_progress, events_registry)
+    Minga.Events.subscribe(:tool_install_complete, events_registry)
+    Minga.Events.subscribe(:tool_install_failed, events_registry)
+    Minga.Events.subscribe(:tool_uninstall_complete, events_registry)
+    Minga.Events.subscribe(:tool_missing, events_registry)
+    Minga.Events.subscribe(:log_message, events_registry)
+    Minga.Events.subscribe(:face_overrides_changed, events_registry)
+    Minga.Events.subscribe(:agent_session_stopped, events_registry)
+    Minga.Events.subscribe(:load_user_themes, events_registry)
+    Minga.Events.subscribe(:extension_updates_available, events_registry)
 
     # Monitor all initial buffers so we get :DOWN when they die.
     all_initial_pids =
@@ -1580,10 +1582,14 @@ defmodule MingaEditor do
     state = Commands.add_buffer(state, buffer_pid)
     state = log_message(state, "Opened: #{file_path}")
 
-    Minga.Events.broadcast(:buffer_opened, %Minga.Events.BufferEvent{
-      buffer: buffer_pid,
-      path: file_path
-    })
+    Minga.Events.broadcast(
+      :buffer_opened,
+      %Minga.Events.BufferEvent{
+        buffer: buffer_pid,
+        path: file_path
+      },
+      EditorState.events_registry(state)
+    )
 
     # Eagerly set up syntax highlighting for this specific buffer.
     # Uses the PID-targeted variant so each restored buffer gets its

--- a/lib/minga_editor/buffer_lifecycle.ex
+++ b/lib/minga_editor/buffer_lifecycle.ex
@@ -43,7 +43,8 @@ defmodule MingaEditor.BufferLifecycle do
         do:
           Minga.Events.broadcast(
             :buffer_saved,
-            %Minga.Events.BufferEvent{buffer: buf, path: path}
+            %Minga.Events.BufferEvent{buffer: buf, path: path},
+            EditorState.events_registry(state)
           )
     end
 

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -717,7 +717,8 @@ defmodule MingaEditor.Commands.BufferManagement do
 
           Minga.Events.broadcast(
             :buffer_closed,
-            %Minga.Events.BufferClosedEvent{buffer: buf, path: path}
+            %Minga.Events.BufferClosedEvent{buffer: buf, path: path},
+            EditorState.events_registry(state)
           )
 
           GenServer.stop(buf, :normal)

--- a/lib/minga_editor/commands/lsp.ex
+++ b/lib/minga_editor/commands/lsp.ex
@@ -139,7 +139,7 @@ defmodule MingaEditor.Commands.Lsp do
       case LSPSupervisor.ensure_client(config, root) do
         {:ok, _pid} ->
           Minga.Log.info(:lsp, "Started LSP server #{config.name}")
-          maybe_broadcast_buffer_opened(buf)
+          maybe_broadcast_buffer_opened(st, buf)
           {[{:ok, config.name} | results], st}
 
         {:error, reason} ->
@@ -153,12 +153,16 @@ defmodule MingaEditor.Commands.Lsp do
 
   # Re-broadcasts :buffer_opened so SyncServer attaches clients for newly
   # started LSP servers.
-  @spec maybe_broadcast_buffer_opened(pid()) :: :ok
-  defp maybe_broadcast_buffer_opened(buf) do
+  @spec maybe_broadcast_buffer_opened(state(), pid()) :: :ok
+  defp maybe_broadcast_buffer_opened(state, buf) do
     path = Buffer.file_path(buf)
 
     if path do
-      Minga.Events.broadcast(:buffer_opened, %Minga.Events.BufferEvent{buffer: buf, path: path})
+      Minga.Events.broadcast(
+        :buffer_opened,
+        %Minga.Events.BufferEvent{buffer: buf, path: path},
+        EditorState.events_registry(state)
+      )
     end
 
     :ok

--- a/lib/minga_editor/key_dispatch.ex
+++ b/lib/minga_editor/key_dispatch.ex
@@ -74,7 +74,11 @@ defmodule MingaEditor.KeyDispatch do
       if base_state.workspace.buffers.active,
         do: Buffer.break_undo_coalescing(base_state.workspace.buffers.active)
 
-      Minga.Events.broadcast(:mode_changed, %Minga.Events.ModeEvent{old: old_mode, new: new_mode})
+      Minga.Events.broadcast(
+        :mode_changed,
+        %Minga.Events.ModeEvent{old: old_mode, new: new_mode},
+        EditorState.events_registry(base_state)
+      )
     end
 
     after_commands =

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -45,6 +45,7 @@ defmodule MingaEditor.Startup do
     backend = Keyword.get(opts, :backend, :headless)
     port_manager = Keyword.get(opts, :port_manager, MingaEditor.Frontend.Manager)
     keymap_server = Keyword.get(opts, :keymap_server, Minga.Keymap.default_server())
+    events_registry = Keyword.get(opts, :events_registry, Minga.Events.default_registry())
 
     options_server =
       opts
@@ -125,6 +126,7 @@ defmodule MingaEditor.Startup do
       port_manager: port_manager,
       keymap_server: keymap_server,
       options_server: options_server,
+      events_registry: events_registry,
       editing_model: editing_model,
       focus_stack: MingaEditor.Input.default_stack(),
       shell: resolve_shell(opts),

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -73,8 +73,12 @@ defmodule MingaEditor.State do
   @typedoc "Re-export of `Minga.Config.Options.server/0` for editor-state callers."
   @type options_server :: Minga.Config.Options.server()
 
+  @typedoc "Event bus registry used by this editor instance."
+  @type events_registry :: Minga.Events.registry()
+
   @default_keymap_server Minga.Keymap.default_server()
   @default_options_server Minga.Config.Options.default_server()
+  @default_events_registry Minga.Events.default_registry()
 
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.Shell.Board.State, as: BoardState
@@ -84,6 +88,7 @@ defmodule MingaEditor.State do
             port_manager: nil,
             keymap_server: @default_keymap_server,
             options_server: @default_options_server,
+            events_registry: @default_events_registry,
             workspace: nil,
             terminal_viewport: Viewport.new(24, 80),
             editing_model: :vim,
@@ -118,6 +123,7 @@ defmodule MingaEditor.State do
           port_manager: GenServer.server() | nil,
           keymap_server: keymap_server(),
           options_server: options_server(),
+          events_registry: events_registry(),
           workspace: WorkspaceState.t(),
           terminal_viewport: Viewport.t(),
           editing_model: :vim | :cua,
@@ -161,6 +167,10 @@ defmodule MingaEditor.State do
   @doc "Returns the options server used for typed option lookups."
   @spec options_server(t()) :: options_server()
   def options_server(%__MODULE__{options_server: options_server}), do: options_server
+
+  @doc "Returns the event bus registry used by this editor instance."
+  @spec events_registry(t()) :: events_registry()
+  def events_registry(%__MODULE__{events_registry: events_registry}), do: events_registry
 
   # ── Workspace helpers ──────────────────────────────────────────────────────
 

--- a/test/minga/config/hooks_registry_test.exs
+++ b/test/minga/config/hooks_registry_test.exs
@@ -1,0 +1,52 @@
+defmodule Minga.Config.HooksRegistryTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Config.Hooks
+  alias Minga.Events
+
+  defp start_registry(label) do
+    name = :"#{label}_#{System.unique_integer([:positive])}"
+    start_supervised!({Events, name: name})
+    name
+  end
+
+  defp fake_buffer do
+    pid = spawn(fn -> receive do: (:stop -> :ok) end)
+
+    on_exit(fn ->
+      if Process.alive?(pid), do: send(pid, :stop)
+    end)
+
+    pid
+  end
+
+  test "hooks receive events from their configured registry only" do
+    registry_a = start_registry(:hooks_events_a)
+    registry_b = start_registry(:hooks_events_b)
+    hooks_name = :"hooks_#{System.unique_integer([:positive])}"
+    {:ok, hooks} = start_supervised({Hooks, name: hooks_name, events_registry: registry_a})
+    test_pid = self()
+    buf = fake_buffer()
+
+    Hooks.register(hooks_name, :after_save, fn buf_arg, path ->
+      send(test_pid, {:hook_fired, buf_arg, path})
+    end)
+
+    Events.broadcast(
+      :buffer_saved,
+      %Events.BufferEvent{buffer: buf, path: "/wrong.ex"},
+      registry_b
+    )
+
+    _ = :sys.get_state(hooks)
+    refute_receive {:hook_fired, ^buf, "/wrong.ex"}, 50
+
+    Events.broadcast(
+      :buffer_saved,
+      %Events.BufferEvent{buffer: buf, path: "/right.ex"},
+      registry_a
+    )
+
+    assert_receive {:hook_fired, ^buf, "/right.ex"}, 500
+  end
+end

--- a/test/minga/events_registry_test.exs
+++ b/test/minga/events_registry_test.exs
@@ -1,0 +1,72 @@
+defmodule Minga.EventsRegistryTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Events
+
+  defp start_registry(label) do
+    name = :"#{label}_#{System.unique_integer([:positive])}"
+    start_supervised!({Events, name: name})
+    name
+  end
+
+  defp fake_buffer do
+    pid = spawn(fn -> receive do: (:stop -> :ok) end)
+
+    on_exit(fn ->
+      if Process.alive?(pid), do: send(pid, :stop)
+    end)
+
+    pid
+  end
+
+  test "broadcast only reaches subscribers registered with the same registry" do
+    registry_a = start_registry(:events_a)
+    registry_b = start_registry(:events_b)
+    buf = fake_buffer()
+
+    Events.subscribe(:buffer_saved, registry_a)
+
+    Events.broadcast(
+      :buffer_saved,
+      %Events.BufferEvent{buffer: buf, path: "/wrong.ex"},
+      registry_b
+    )
+
+    refute_receive {:minga_event, :buffer_saved, _}, 50
+
+    Events.broadcast(
+      :buffer_saved,
+      %Events.BufferEvent{buffer: buf, path: "/right.ex"},
+      registry_a
+    )
+
+    assert_receive {:minga_event, :buffer_saved,
+                    %Events.BufferEvent{buffer: ^buf, path: "/right.ex"}}
+  end
+
+  test "subscribers are scoped by registry" do
+    registry_a = start_registry(:events_a)
+    registry_b = start_registry(:events_b)
+
+    Events.subscribe(:buffer_saved, registry_a)
+
+    assert self() in Events.subscribers(:buffer_saved, registry_a)
+    refute self() in Events.subscribers(:buffer_saved, registry_b)
+  end
+
+  test "metadata de-duplication still works on a custom registry" do
+    registry = start_registry(:events_metadata)
+
+    Events.subscribe(:mode_changed, :my_component, registry)
+    Events.subscribe(:mode_changed, :my_component, registry)
+
+    Events.broadcast(
+      :mode_changed,
+      %Events.ModeEvent{old: :normal, new: :insert},
+      registry
+    )
+
+    assert_receive {:minga_event, :mode_changed, %Events.ModeEvent{old: :normal, new: :insert}}
+    refute_receive {:minga_event, :mode_changed, _}, 50
+  end
+end

--- a/test/minga/git/backend_operations_test.exs
+++ b/test/minga/git/backend_operations_test.exs
@@ -7,6 +7,7 @@ defmodule Minga.Git.BackendOperationsTest do
   with committed files and verifies the git CLI-backed operations.
   """
 
+  # async: false — spawns real git CLI processes, which can hit the BEAM erl_child_setup EPIPE race under concurrency.
   use ExUnit.Case, async: false
 
   @moduletag timeout: 20_000
@@ -14,6 +15,7 @@ defmodule Minga.Git.BackendOperationsTest do
   # Isolate from CI runner's global git config
   @git_env [
     {"GIT_CONFIG_NOSYSTEM", "1"},
+    {"GIT_CONFIG_GLOBAL", "/dev/null"},
     {"GIT_AUTHOR_NAME", "Test"},
     {"GIT_AUTHOR_EMAIL", "test@test.com"},
     {"GIT_COMMITTER_NAME", "Test"},

--- a/test/minga/git/tracker_registry_test.exs
+++ b/test/minga/git/tracker_registry_test.exs
@@ -1,0 +1,48 @@
+defmodule Minga.Git.TrackerRegistryTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Events
+  alias Minga.Git.Stub, as: GitStub
+  alias Minga.Git.Tracker
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: dir} do
+    GitStub.set_root(dir, dir)
+    on_exit(fn -> GitStub.clear(dir) end)
+    %{root: dir}
+  end
+
+  defp start_registry(label) do
+    name = :"#{label}_#{System.unique_integer([:positive])}"
+    start_supervised!({Events, name: name})
+    name
+  end
+
+  test "tracker starts tracking only for events from its configured registry", %{root: dir} do
+    registry_a = start_registry(:tracker_events_a)
+    registry_b = start_registry(:tracker_events_b)
+    table = :"tracker_registry_#{System.unique_integer([:positive])}"
+    tracker_name = :"tracker_#{System.unique_integer([:positive])}"
+
+    tracker =
+      start_supervised!(
+        {Tracker, name: tracker_name, events_registry: registry_a, registry_table: table},
+        id: table
+      )
+
+    path = Path.join(dir, "tracker_registry_test.ex")
+    File.write!(path, "x = 1\n")
+    GitStub.set_head(dir, Path.relative_to(path, dir), "x = 1\n")
+    {:ok, buf} = BufferServer.start_link(content: "x = 1\n", file_path: path)
+
+    Events.broadcast(:buffer_opened, %Events.BufferEvent{buffer: buf, path: path}, registry_b)
+    _ = :sys.get_state(tracker)
+    refute Tracker.tracked?(buf, table)
+
+    Events.broadcast(:buffer_opened, %Events.BufferEvent{buffer: buf, path: path}, registry_a)
+    _ = :sys.get_state(tracker)
+    assert Tracker.tracked?(buf, table)
+  end
+end

--- a/test/minga_editor/events_registry_test.exs
+++ b/test/minga_editor/events_registry_test.exs
@@ -1,0 +1,33 @@
+defmodule MingaEditor.EventsRegistryTest do
+  use Minga.Test.EditorCase, async: true
+
+  alias Minga.Events
+
+  test "editor subscribes to its configured events registry" do
+    wrong_registry = :"editor_wrong_events_#{System.unique_integer([:positive])}"
+    start_supervised!({Events, name: wrong_registry})
+    ctx = start_editor("hello")
+    wrong_tag = "wrong-registry-#{System.unique_integer([:positive])}"
+    right_tag = "right-registry-#{System.unique_integer([:positive])}"
+
+    Events.broadcast(
+      :log_message,
+      %Events.LogMessageEvent{text: wrong_tag, level: :info},
+      wrong_registry
+    )
+
+    refute Enum.any?(message_store_entries(ctx), fn entry ->
+             String.contains?(entry.text, wrong_tag)
+           end)
+
+    Events.broadcast(
+      :log_message,
+      %Events.LogMessageEvent{text: right_tag, level: :info},
+      ctx.events_registry
+    )
+
+    assert Enum.any?(message_store_entries(ctx), fn entry ->
+             String.contains?(entry.text, right_tag)
+           end)
+  end
+end

--- a/test/minga_editor/file_tree_integration_test.exs
+++ b/test/minga_editor/file_tree_integration_test.exs
@@ -245,10 +245,14 @@ defmodule MingaEditor.FileTreeIntegrationTest do
       assert state.workspace.file_tree.tree != nil
 
       # Broadcast a :buffer_saved event (simulating what lsp_after_save does)
-      Minga.Events.broadcast(:buffer_saved, %Minga.Events.BufferEvent{
-        buffer: state.workspace.buffers.active,
-        path: file
-      })
+      Minga.Events.broadcast(
+        :buffer_saved,
+        %Minga.Events.BufferEvent{
+          buffer: state.workspace.buffers.active,
+          path: file
+        },
+        ctx.events_registry
+      )
 
       # A synchronous call to the Editor flushes its mailbox, guaranteeing
       # the :minga_event handle_info has been processed before we inspect state.

--- a/test/minga_editor/messages_buffer_test.exs
+++ b/test/minga_editor/messages_buffer_test.exs
@@ -160,16 +160,16 @@ defmodule MingaEditor.MessagesBufferTest do
       tag = unique_tag("store-broadcast")
       ctx = start_editor("hello")
 
-      Minga.Events.broadcast(:log_message, %Minga.Events.LogMessageEvent{
-        text: tag,
-        level: :warning
-      })
+      Minga.Events.broadcast(
+        :log_message,
+        %Minga.Events.LogMessageEvent{
+          text: tag,
+          level: :warning
+        },
+        ctx.events_registry
+      )
 
-      _ = :sys.get_state(ctx.editor)
-
-      state = :sys.get_state(ctx.editor)
-
-      assert Enum.any?(state.message_store.entries, fn entry ->
+      assert Enum.any?(message_store_entries(ctx), fn entry ->
                String.contains?(entry.text, tag) and entry.level == :warning
              end)
     end

--- a/test/minga_editor/state/events_registry_threading_test.exs
+++ b/test/minga_editor/state/events_registry_threading_test.exs
@@ -1,0 +1,68 @@
+defmodule MingaEditor.State.EventsRegistryThreadingTest do
+  @moduledoc """
+  Integration tests that prove `EditorState.events_registry` is honored by the event bus boundary.
+  """
+  use ExUnit.Case, async: true
+
+  alias Minga.Events
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias Minga.Mode
+
+  defp build_state(events_registry) do
+    %EditorState{
+      port_manager: self(),
+      events_registry: events_registry,
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: %VimState{mode: :normal, mode_state: Mode.initial_state()},
+        buffers: %Buffers{active: nil, list: []}
+      }
+    }
+  end
+
+  test "EditorState.events_registry isolates event delivery between registries" do
+    registry_a = :events_registry_threading_a
+    registry_b = :events_registry_threading_b
+    start_supervised!({Events, name: registry_a})
+    start_supervised!({Events, name: registry_b})
+
+    state_a = build_state(registry_a)
+    state_b = build_state(registry_b)
+    assert EditorState.events_registry(state_a) == registry_a
+    assert EditorState.events_registry(state_b) == registry_b
+
+    Events.subscribe(:log_message, EditorState.events_registry(state_a))
+
+    Events.broadcast(
+      :log_message,
+      %Events.LogMessageEvent{text: "wrong registry", level: :info},
+      EditorState.events_registry(state_b)
+    )
+
+    refute_receive {:minga_event, :log_message, _}, 50
+
+    Events.broadcast(
+      :log_message,
+      %Events.LogMessageEvent{text: "right registry", level: :info},
+      EditorState.events_registry(state_a)
+    )
+
+    assert_receive {:minga_event, :log_message, %Events.LogMessageEvent{text: "right registry"}}
+  end
+
+  test "EditorState defaults events_registry to Minga.Events.default_registry/0" do
+    state = %EditorState{
+      port_manager: self(),
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: %VimState{mode: :normal, mode_state: Mode.initial_state()},
+        buffers: %Buffers{active: nil, list: []}
+      }
+    }
+
+    assert EditorState.events_registry(state) == Events.default_registry()
+  end
+end

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -31,7 +31,8 @@ defmodule Minga.Test.EditorCase do
           buffer: pid(),
           port: pid(),
           width: pos_integer(),
-          height: pos_integer()
+          height: pos_integer(),
+          events_registry: Minga.Events.registry()
         }
   # ── Setup helpers ────────────────────────────────────────────────────────────
   @doc """
@@ -50,8 +51,12 @@ defmodule Minga.Test.EditorCase do
     file_path = Keyword.get(opts, :file_path)
     clipboard = Keyword.get(opts, :clipboard, :none)
     id = :erlang.unique_integer([:positive])
+
+    events_registry =
+      Keyword.get_lazy(opts, :events_registry, fn -> start_events_registry(id) end)
+
     {:ok, port} = HeadlessPort.start_link(width: width, height: height)
-    buffer_opts = [content: content]
+    buffer_opts = [content: content, events_registry: events_registry]
     buffer_opts = if file_path, do: [{:file_path, file_path} | buffer_opts], else: buffer_opts
     {:ok, buffer} = BufferServer.start_link(buffer_opts)
 
@@ -74,6 +79,7 @@ defmodule Minga.Test.EditorCase do
       width: width,
       height: height,
       editing_model: editing_model,
+      events_registry: events_registry,
       suppress_tool_prompts: true
     ]
 
@@ -106,7 +112,8 @@ defmodule Minga.Test.EditorCase do
       buffer: buffer,
       port: port,
       width: width,
-      height: height
+      height: height,
+      events_registry: events_registry
     })
   end
 
@@ -117,6 +124,10 @@ defmodule Minga.Test.EditorCase do
     height = Keyword.get(opts, :height, 24)
     clipboard = Keyword.get(opts, :clipboard, :none)
     id = :erlang.unique_integer([:positive])
+
+    events_registry =
+      Keyword.get_lazy(opts, :events_registry, fn -> start_events_registry(id) end)
+
     {:ok, port} = HeadlessPort.start_link(width: width, height: height)
 
     # Inject clipboard mode directly on the buffer so the Editor never
@@ -134,6 +145,7 @@ defmodule Minga.Test.EditorCase do
         width: width,
         height: height,
         editing_model: editing_model,
+        events_registry: events_registry,
         suppress_tool_prompts: true
       )
 
@@ -151,7 +163,8 @@ defmodule Minga.Test.EditorCase do
       buffer: buffer,
       port: port,
       width: width,
-      height: height
+      height: height,
+      events_registry: events_registry
     }
   end
 
@@ -418,6 +431,12 @@ defmodule Minga.Test.EditorCase do
   @spec editor_state(editor_ctx()) :: MingaEditor.State.t()
   def editor_state(%{editor: editor}) do
     :sys.get_state(editor)
+  end
+
+  @doc "Returns MessageStore entries after synchronizing with the editor process."
+  @spec message_store_entries(editor_ctx()) :: [map()]
+  def message_store_entries(%{editor: editor}) do
+    :sys.get_state(editor).message_store.entries
   end
 
   @doc "Returns the number of open buffers."
@@ -767,6 +786,14 @@ defmodule Minga.Test.EditorCase do
   end
 
   # ── Private helpers ──────────────────────────────────────────────────────────
+
+  @spec start_events_registry(pos_integer()) :: Minga.Events.registry()
+  defp start_events_registry(id) do
+    name = :"minga_events_#{id}"
+    start_supervised!({Minga.Events, name: name})
+    name
+  end
+
   @ctrl 0x02
   @spec parse_key_sequence(String.t()) :: [{non_neg_integer(), non_neg_integer()}]
   defp parse_key_sequence(seq), do: do_parse_keys(seq, [])


### PR DESCRIPTION
# TL;DR
Minga.Events now supports runtime Registry injection, and editor-driven event broadcasts/subscriptions flow through an `events_registry` stored on `MingaEditor.State`. EditorCase now starts a private per-test event registry so headless editor tests can avoid global EventBus contamination.

Closes #1450

## Context
Issue #1450 tracks the migration of the EventBus away from a hardcoded singleton so tests and subscribers can be isolated. This PR keeps the production default as `Minga.EventBus`, while adding runtime registry plumbing for editor state, buffers, hooks, git tracking, LSP sync, project/file watcher subscribers, and the affected editor command paths.

## Changes
- Added `Minga.Events.default_registry/0`, `child_spec(name:)`, `broadcast/3`, `subscribe/2`, `subscribe/3`, `unsubscribe/2`, and registry-aware `subscribers/2`, while preserving the existing 2-arity broadcast shim.
- Added `events_registry` to `MingaEditor.State`, threaded it through startup, editor subscriptions, editor/buffer lifecycle broadcasts, key dispatch mode changes, LSP command rebroadcasts, and buffer close/save paths.
- Updated subscribers such as `Minga.Config.Hooks`, `Minga.Git.Tracker`, `Minga.Git.Repo`, `Minga.LSP.SyncServer`, `Minga.Project`, and `Minga.FileWatcher` to accept or store an `events_registry` option where needed.
- Updated `Minga.Test.EditorCase` to create a unique per-test Registry and pass it into editor and buffer startup.
- Added private-registry tests for Events, Config.Hooks, Git.Tracker, EditorState, and EditorCase editor subscription wiring.
- Isolated `Minga.Git.BackendOperationsTest` from global git hooks by setting `GIT_CONFIG_GLOBAL=/dev/null`, and added the required `async: false` reason comment.

## Verification
- `make lint` passed.
- `mix test.llm` passed: 54 doctests, 98 properties, 7609 tests, 0 failures, 6 skipped, 95 excluded.
- `mix test.debug test/minga/events_registry_test.exs test/minga/config/hooks_registry_test.exs test/minga/git/tracker_registry_test.exs test/minga_editor/events_registry_test.exs test/minga_editor/state/events_registry_threading_test.exs test/minga_editor/messages_buffer_test.exs test/minga_editor/file_tree_integration_test.exs` passed: 29 tests, 0 failures.
- `mix test.debug test/minga/git/backend_operations_test.exs` passed: 6 tests, 0 failures.

## Acceptance Criteria Addressed
- `Minga.Events.broadcast/3` accepts a registry arg with default singleton compatibility ✅
- `Minga.Events.subscribe/2` and subscribe variants accept a runtime registry with default singleton compatibility ✅
- `EditorState` has `events_registry :: atom()` and `EditorState.events_registry/1` ✅
- Broadcast sites touched by editor/buffer state read or receive the configured registry, and subscribers accept `events_registry:` opts where needed ✅
- `EditorCase` starts a unique per-test Registry and passes it into editor/buffer startup ✅
- New direct `Minga.Events.*` registry tests run async with private registries ✅
- `make lint` and `mix test.llm` pass ✅
