### PR TITLE
fix(editor): preserve tab buffer snapshots

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -323,8 +323,7 @@ defmodule MingaEditor do
     # Register a buffer that was started by Buffer.ensure_for_path (called
     # from agent tools or Editor.ensure_buffer_for_path). Only register if
     # the buffer isn't already tracked in the workspace.
-    already_tracked? =
-      Enum.any?(state.workspace.buffers.list, fn {_, bp} -> bp == pid end)
+    already_tracked? = pid in state.workspace.buffers.list
 
     if already_tracked? do
       {:noreply, state}

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -323,7 +323,7 @@ defmodule MingaEditor do
     # Register a buffer that was started by Buffer.ensure_for_path (called
     # from agent tools or Editor.ensure_buffer_for_path). Only register if
     # the buffer isn't already tracked in the workspace.
-    already_tracked? = pid in state.workspace.buffers.list
+    already_tracked? = buffer_tracked?(state, pid)
 
     if already_tracked? do
       {:noreply, state}
@@ -1604,6 +1604,21 @@ defmodule MingaEditor do
 
     state
   end
+
+  @spec buffer_tracked?(state(), pid()) :: boolean()
+  defp buffer_tracked?(state, pid) when is_pid(pid) do
+    pid in state.workspace.buffers.list or buffer_tracked_in_tabs?(state, pid)
+  end
+
+  @spec buffer_tracked_in_tabs?(state(), pid()) :: boolean()
+  defp buffer_tracked_in_tabs?(%{shell_state: %{tab_bar: %{tabs: tabs}}}, pid) do
+    Enum.any?(tabs, fn
+      %{context: %{buffers: %{list: buffers}}} -> pid in buffers
+      _ -> false
+    end)
+  end
+
+  defp buffer_tracked_in_tabs?(_state, _pid), do: false
 
   # Like register_buffer but adds the buffer in the background without
   # switching the active window. Used by ensure_buffer_for_path so agent

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -552,13 +552,19 @@ defmodule MingaEditor.Commands do
 
   # ── Public buffer helpers (called directly from Editor) ───────────────────
 
-  @doc "Starts a new buffer process for the given file path."
+  @doc "Returns the existing buffer for a file path, or starts one if needed."
   @spec start_buffer(String.t()) :: {:ok, pid()} | {:error, term()}
   def start_buffer(file_path) do
-    DynamicSupervisor.start_child(
-      Minga.Buffer.Supervisor,
-      {Minga.Buffer, file_path: file_path}
-    )
+    case Buffer.pid_for_path(file_path) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      :not_found ->
+        DynamicSupervisor.start_child(
+          Minga.Buffer.Supervisor,
+          {Minga.Buffer, file_path: file_path}
+        )
+    end
   end
 
   @doc "Adds a new buffer to the list and makes it active."

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -597,42 +597,70 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp switch_to_buffer(state, idx), do: EditorState.switch_buffer(state, idx)
 
   @spec next_buffer(state()) :: state()
-  defp next_buffer(
-         %{workspace: %{buffers: %{list: [_, _ | _] = buffers, active_index: idx}}} = state
-       ) do
-    cycle_buffer_in_tab(state, rem(idx + 1, Enum.count(buffers)))
+  defp next_buffer(%{workspace: %{buffers: %{active: active, list: buffers}}} = state) do
+    buffers
+    |> buffer_cycle_order(state)
+    |> cycle_buffer_from_active(state, active, 1)
   end
 
   defp next_buffer(state), do: state
 
   @spec prev_buffer(state()) :: state()
-  defp prev_buffer(
-         %{workspace: %{buffers: %{list: [_, _ | _] = buffers, active_index: idx}}} = state
-       ) do
-    count = Enum.count(buffers)
-    cycle_buffer_in_tab(state, rem(idx - 1 + count, count))
+  defp prev_buffer(%{workspace: %{buffers: %{active: active, list: buffers}}} = state) do
+    buffers
+    |> buffer_cycle_order(state)
+    |> cycle_buffer_from_active(state, active, -1)
   end
 
   defp prev_buffer(state), do: state
 
-  # Cycles to the buffer at `idx`. If that buffer has its own dedicated
-  # file tab, switches to that tab so the tab bar tracks what the user
-  # sees; otherwise switches in-place inside the current tab. This keeps
-  # `SPC b n` / `SPC b p` consistent with the per-tab snapshot model:
-  # each open file should normally live in its own tab, and cycling
-  # buffers should move tab focus accordingly.
-  @spec cycle_buffer_in_tab(state(), non_neg_integer()) :: state()
-  defp cycle_buffer_in_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, idx) do
-    target_buf = Enum.at(state.workspace.buffers.list, idx)
+  # Cycles through the current tab's buffer list plus active buffers from dedicated file tabs.
+  # Dedicated targets switch tab focus; inline targets switch in-place inside the current tab.
+  @spec cycle_buffer_from_active([pid()], state(), pid() | nil, 1 | -1) :: state()
+  defp cycle_buffer_from_active([_, _ | _] = buffers, state, active, step) do
+    active_index = Enum.find_index(buffers, &(&1 == active)) || 0
+    target_index = rem(active_index + step + length(buffers), length(buffers))
+    cycle_buffer_in_tab(state, Enum.at(buffers, target_index))
+  end
 
+  defp cycle_buffer_from_active(_buffers, state, _active, _step), do: state
+
+  @spec buffer_cycle_order([pid()], state()) :: [pid()]
+  defp buffer_cycle_order(buffers, %{shell_state: %{tab_bar: %TabBar{} = tb}}) do
+    tab_buffers = file_tab_buffers(tb)
+    buffers ++ Enum.reject(tab_buffers, &(&1 in buffers))
+  end
+
+  defp buffer_cycle_order(buffers, _state), do: buffers
+
+  @spec file_tab_buffers(TabBar.t()) :: [pid()]
+  defp file_tab_buffers(%TabBar{tabs: tabs}) do
+    Enum.flat_map(tabs, fn
+      %{kind: :file, context: %{buffers: %{active: pid}}} when is_pid(pid) -> [pid]
+      _ -> []
+    end)
+  end
+
+  @spec cycle_buffer_in_tab(state(), pid() | nil) :: state()
+  defp cycle_buffer_in_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, target_buf) do
     case find_tab_for_buffer(tb, target_buf) do
-      nil -> EditorState.switch_buffer(state, idx)
-      tab_id when tab_id == tb.active_id -> EditorState.switch_buffer(state, idx)
+      nil -> switch_to_buffer_pid(state, target_buf)
+      tab_id when tab_id == tb.active_id -> switch_to_buffer_pid(state, target_buf)
       tab_id -> EditorState.switch_tab(state, tab_id)
     end
   end
 
-  defp cycle_buffer_in_tab(state, idx), do: EditorState.switch_buffer(state, idx)
+  defp cycle_buffer_in_tab(state, target_buf), do: switch_to_buffer_pid(state, target_buf)
+
+  @spec switch_to_buffer_pid(state(), pid() | nil) :: state()
+  defp switch_to_buffer_pid(state, nil), do: state
+
+  defp switch_to_buffer_pid(%{workspace: %{buffers: %{list: buffers}}} = state, target_buf) do
+    case Enum.find_index(buffers, &(&1 == target_buf)) do
+      nil -> state
+      idx -> EditorState.switch_buffer(state, idx)
+    end
+  end
 
   # Finds the file tab whose snapshotted context has `target_buf` as the
   # active buffer. Returns `nil` when no tab matches (the buffer was
@@ -733,6 +761,7 @@ defmodule MingaEditor.Commands.BufferManagement do
       MingaEditor.log_to_messages("Closed: #{buf_name}")
 
       new_buffers = List.delete_at(buffers, idx)
+      had_neighbor_tab? = has_neighbor_tab?(state)
 
       # Remove the current tab from the tab bar (if present).
       # TabBar.remove handles neighbor selection.
@@ -740,7 +769,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
       case new_buffers do
         [] ->
-          create_fallback_buffer(state, bs)
+          restore_neighbor_tab_or_create_fallback(state, bs, had_neighbor_tab?)
 
         _ ->
           new_idx = min(idx, Enum.count(new_buffers) - 1)
@@ -1060,6 +1089,29 @@ defmodule MingaEditor.Commands.BufferManagement do
     state
     |> remove_current_tab()
     |> restore_active_tab_context()
+  end
+
+  @spec has_neighbor_tab?(state()) :: boolean()
+  defp has_neighbor_tab?(%{shell_state: %{tab_bar: %TabBar{tabs: [_, _ | _]}}}), do: true
+  defp has_neighbor_tab?(_state), do: false
+
+  @spec restore_neighbor_tab_or_create_fallback(
+          state(),
+          MingaEditor.State.Buffers.t(),
+          boolean()
+        ) :: state()
+  defp restore_neighbor_tab_or_create_fallback(state, _old_buffers, true) do
+    state = restore_active_tab_context(state)
+
+    if state.workspace.buffers.active do
+      EditorState.sync_active_window_buffer(state)
+    else
+      create_fallback_buffer(state, state.workspace.buffers)
+    end
+  end
+
+  defp restore_neighbor_tab_or_create_fallback(state, old_buffers, false) do
+    create_fallback_buffer(state, old_buffers)
   end
 
   @spec remove_current_tab(state()) :: state()

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -419,8 +419,11 @@ defmodule MingaEditor.PickerUI do
   @spec promote_previewed_buffer(EditorState.t()) :: EditorState.t()
   defp promote_previewed_buffer(state) do
     previewed_pid = state.workspace.buffers.active
-    new_state = close(state)
-    EditorState.add_buffer(new_state, previewed_pid, context: :open)
+
+    state
+    |> restore_picker_origin()
+    |> close()
+    |> EditorState.add_buffer(previewed_pid, context: :open)
   end
 
   @spec run_select_and_close(EditorState.t(), Picker.item(), module()) ::
@@ -894,8 +897,19 @@ defmodule MingaEditor.PickerUI do
 
   # ── Private helpers ──────────────────────────────────────────────────────────
 
-  # Preview: temporarily apply the source's on_select for the highlighted item.
-  # Sets buffer_add_context to :preview so any add_buffer calls inside
+  # Restores the buffer that was active when the picker opened before promoting a preview.
+  # Preview leaves the tab bar unchanged, so the outgoing tab must be snapshotted from
+  # the original buffer, not the preview buffer currently shown in the window.
+  @spec restore_picker_origin(state()) :: state()
+  defp restore_picker_origin(
+         %{shell_state: %{modal: {:picker, %{picker_ui: %{restore: idx}}}}} = state
+       )
+       when is_integer(idx) do
+    EditorState.switch_buffer(state, idx)
+  end
+
+  defp restore_picker_origin(state), do: state
+
   # Returns true when preview navigation changed the active buffer from
   # what it was when the picker opened (stored in the picker payload's `restore` field).
   @spec previewed?(state()) :: boolean()
@@ -909,7 +923,9 @@ defmodule MingaEditor.PickerUI do
 
   defp previewed?(_state), do: false
 
-  # on_select update the current tab in-place instead of creating a new tab.
+  # Preview: temporarily apply the source's on_select for the highlighted item.
+  # Sets buffer_add_context to :preview so add_buffer calls inside on_select update
+  # the current tab in-place instead of creating a new tab.
   @spec maybe_preview_selection(state()) :: state()
   defp maybe_preview_selection(
          %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =

--- a/lib/minga_editor/shell.ex
+++ b/lib/minga_editor/shell.ex
@@ -9,7 +9,7 @@ defmodule MingaEditor.Shell do
   - `MingaEditor.Shell.Chrome`           — `build_chrome/4`, `render/1`
   - `MingaEditor.Shell.InputRouter`      — `input_handlers/1`,
     `handle_event/3`, `handle_gui_action/3`
-  - `MingaEditor.Shell.BufferLifecycle`  — `on_buffer_added/4`,
+  - `MingaEditor.Shell.BufferLifecycle`  — `on_buffer_added/5`,
     `on_buffer_switched/2`, `on_buffer_died/3`, `on_agent_event/4`
   - `MingaEditor.Shell.TabQueries`       — `active_tab/1`,
     `find_tab_by_buffer/2`, `active_tab_kind/1`, `set_tab_session/3`,

--- a/lib/minga_editor/shell/board.ex
+++ b/lib/minga_editor/shell/board.ex
@@ -411,13 +411,24 @@ defmodule MingaEditor.Shell.Board do
   # -------------------------------------------------------------------
 
   @impl true
-  @spec on_buffer_added(BoardState.t(), MingaEditor.Workspace.State.t(), pid(), atom()) ::
-          {BoardState.t(), MingaEditor.Workspace.State.t()}
-  def on_buffer_added(shell_state, workspace, _buffer_pid, _context \\ :open) do
+  @spec on_buffer_added(
+          BoardState.t(),
+          MingaEditor.Workspace.State.t(),
+          MingaEditor.Workspace.State.t(),
+          pid(),
+          atom()
+        ) :: {BoardState.t(), MingaEditor.Workspace.State.t()}
+  def on_buffer_added(shell_state, _prev_workspace, workspace, _buffer_pid, _context) do
     # Board: sync the active window buffer. A1's content-type guard
     # ensures agent_chat windows are left untouched.
     workspace = MingaEditor.Workspace.State.sync_active_window_buffer(workspace)
     {shell_state, workspace}
+  end
+
+  @spec on_buffer_added(BoardState.t(), MingaEditor.Workspace.State.t(), pid(), atom()) ::
+          {BoardState.t(), MingaEditor.Workspace.State.t()}
+  def on_buffer_added(shell_state, workspace, buffer_pid, context \\ :open) do
+    on_buffer_added(shell_state, workspace, workspace, buffer_pid, context)
   end
 
   @impl true

--- a/lib/minga_editor/shell/buffer_lifecycle.ex
+++ b/lib/minga_editor/shell/buffer_lifecycle.ex
@@ -2,10 +2,7 @@ defmodule MingaEditor.Shell.BufferLifecycle do
   @moduledoc """
   Behaviour: shell-side reactions to buffer and agent events.
 
-  Carved out of `MingaEditor.Shell`. Callbacks receive
-  `(shell_state, workspace, ...)` — never full EditorState — so they
-  cannot touch process monitors, render timers, or port managers.
-  Generic concerns stay in EditorState.
+  Carved out of `MingaEditor.Shell`. Callbacks receive shell state and workspace values, never full EditorState, so they cannot touch process monitors, render timers, or port managers. Generic concerns stay in EditorState.
   """
 
   @typedoc "Shell-specific state. Each shell defines its own struct."

--- a/lib/minga_editor/shell/buffer_lifecycle.ex
+++ b/lib/minga_editor/shell/buffer_lifecycle.ex
@@ -24,9 +24,10 @@ defmodule MingaEditor.Shell.BufferLifecycle do
   """
   @type buffer_add_context :: :open | :preview
 
-  @doc "A buffer was added to the workspace."
+  @doc "A buffer was added to the workspace. Receives both the workspace before the buffer-pool mutation and the workspace after it, so shells can snapshot outgoing presentation state without capturing the newly activated buffer."
   @callback on_buffer_added(
               shell_state(),
+              prev_workspace :: workspace(),
               workspace(),
               buffer_pid :: pid(),
               context :: buffer_add_context()

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -138,10 +138,27 @@ defmodule MingaEditor.Shell.Traditional do
   # -------------------------------------------------------------------
 
   @impl true
+  @spec on_buffer_added(
+          ShellState.t(),
+          WorkspaceState.t(),
+          WorkspaceState.t(),
+          pid(),
+          atom()
+        ) :: {ShellState.t(), WorkspaceState.t()}
+  def on_buffer_added(shell_state, prev_workspace, workspace, buffer_pid, context) do
+    do_on_buffer_added(
+      maybe_dismiss_dashboard(shell_state),
+      prev_workspace,
+      workspace,
+      buffer_pid,
+      context
+    )
+  end
+
   @spec on_buffer_added(ShellState.t(), WorkspaceState.t(), pid(), atom()) ::
           {ShellState.t(), WorkspaceState.t()}
   def on_buffer_added(shell_state, workspace, buffer_pid, context \\ :open) do
-    do_on_buffer_added(maybe_dismiss_dashboard(shell_state), workspace, buffer_pid, context)
+    on_buffer_added(shell_state, workspace, workspace, buffer_pid, context)
   end
 
   # Dismisses the dashboard modal when a buffer becomes active. The
@@ -154,10 +171,16 @@ defmodule MingaEditor.Shell.Traditional do
 
   defp maybe_dismiss_dashboard(shell_state), do: shell_state
 
-  @spec do_on_buffer_added(ShellState.t(), WorkspaceState.t(), pid(), atom()) ::
-          {ShellState.t(), WorkspaceState.t()}
+  @spec do_on_buffer_added(
+          ShellState.t(),
+          WorkspaceState.t(),
+          WorkspaceState.t(),
+          pid(),
+          atom()
+        ) :: {ShellState.t(), WorkspaceState.t()}
   defp do_on_buffer_added(
          %ShellState{tab_bar: nil} = shell_state,
+         _prev_workspace,
          workspace,
          _buffer_pid,
          _context
@@ -168,6 +191,7 @@ defmodule MingaEditor.Shell.Traditional do
 
   defp do_on_buffer_added(
          %ShellState{tab_bar: %TabBar{} = tb} = shell_state,
+         prev_workspace,
          workspace,
          buffer_pid,
          context
@@ -180,7 +204,7 @@ defmodule MingaEditor.Shell.Traditional do
 
     case find_tab_for_buffer(tb, label) do
       %Tab{id: tab_id} ->
-        switch_to_buffer_tab(shell_state, workspace, tab_id)
+        switch_to_buffer_tab(shell_state, prev_workspace, workspace, tab_id)
 
       nil ->
         case {context, TabBar.active(tb).kind} do
@@ -192,10 +216,10 @@ defmodule MingaEditor.Shell.Traditional do
             {shell_state, workspace}
 
           {_, :agent} ->
-            open_buffer_from_agent_tab(shell_state, workspace, label)
+            open_buffer_from_agent_tab(shell_state, prev_workspace, workspace, label)
 
           {_, :file} ->
-            open_buffer_in_file_tab(shell_state, workspace, label)
+            open_buffer_in_file_tab(shell_state, prev_workspace, workspace, label)
         end
     end
   end
@@ -353,20 +377,31 @@ defmodule MingaEditor.Shell.Traditional do
   # Switch to an existing file tab that matches the buffer being opened.
   @spec switch_to_buffer_tab(ShellState.t(), WorkspaceState.t(), Tab.id()) ::
           {ShellState.t(), WorkspaceState.t()}
-  defp switch_to_buffer_tab(%ShellState{tab_bar: tb} = shell_state, workspace, target_id) do
+  defp switch_to_buffer_tab(shell_state, workspace, target_id) do
+    switch_to_buffer_tab(shell_state, workspace, workspace, target_id)
+  end
+
+  @spec switch_to_buffer_tab(ShellState.t(), WorkspaceState.t(), WorkspaceState.t(), Tab.id()) ::
+          {ShellState.t(), WorkspaceState.t()}
+  defp switch_to_buffer_tab(
+         %ShellState{tab_bar: tb} = shell_state,
+         prev_workspace,
+         workspace,
+         target_id
+       ) do
     current_id = tb.active_id
 
     if current_id == target_id do
       {shell_state, workspace}
     else
-      # Snapshot current workspace onto outgoing tab
-      context = WorkspaceState.to_tab_context(workspace)
+      # Snapshot the outgoing tab before the buffer-pool mutation that triggered this switch.
+      context = WorkspaceState.to_tab_context(prev_workspace)
       tb = TabBar.update_context(tb, current_id, context)
 
       # Switch pointer and restore target tab's workspace
       tb = TabBar.switch_to(tb, target_id)
       target = TabBar.active(tb)
-      workspace = restore_workspace(workspace, target.context)
+      workspace = WorkspaceState.restore_tab_context(workspace, target.context)
 
       # Clear attention flag on the tab we're switching to
       tb = TabBar.update_tab(tb, target_id, &Tab.set_attention(&1, false))
@@ -378,11 +413,20 @@ defmodule MingaEditor.Shell.Traditional do
 
   # Opens a file buffer when the active tab is an agent tab.
   # Creates a new file tab, resets agent UI state, and syncs the window.
-  @spec open_buffer_from_agent_tab(ShellState.t(), WorkspaceState.t(), String.t()) ::
-          {ShellState.t(), WorkspaceState.t()}
-  defp open_buffer_from_agent_tab(%ShellState{tab_bar: tb} = shell_state, workspace, label) do
+  @spec open_buffer_from_agent_tab(
+          ShellState.t(),
+          WorkspaceState.t(),
+          WorkspaceState.t(),
+          String.t()
+        ) :: {ShellState.t(), WorkspaceState.t()}
+  defp open_buffer_from_agent_tab(
+         %ShellState{tab_bar: tb} = shell_state,
+         prev_workspace,
+         workspace,
+         label
+       ) do
     # Snapshot current agent tab before leaving
-    context = WorkspaceState.to_tab_context(workspace)
+    context = WorkspaceState.to_tab_context(prev_workspace)
     tb = TabBar.update_context(tb, tb.active_id, context)
 
     # Create file tab (TabBar.add auto-activates it)
@@ -405,11 +449,20 @@ defmodule MingaEditor.Shell.Traditional do
   # Opens a file buffer when the active tab is already a file tab.
   # Creates a new file tab and syncs the buffer into the window.
   # Used for permanent opens: file tree, `:e`, picker confirm, LSP jump.
-  @spec open_buffer_in_file_tab(ShellState.t(), WorkspaceState.t(), String.t()) ::
-          {ShellState.t(), WorkspaceState.t()}
-  defp open_buffer_in_file_tab(%ShellState{tab_bar: tb} = shell_state, workspace, label) do
+  @spec open_buffer_in_file_tab(
+          ShellState.t(),
+          WorkspaceState.t(),
+          WorkspaceState.t(),
+          String.t()
+        ) :: {ShellState.t(), WorkspaceState.t()}
+  defp open_buffer_in_file_tab(
+         %ShellState{tab_bar: tb} = shell_state,
+         prev_workspace,
+         workspace,
+         label
+       ) do
     # Snapshot current tab before leaving
-    context = WorkspaceState.to_tab_context(workspace)
+    context = WorkspaceState.to_tab_context(prev_workspace)
     tb = TabBar.update_context(tb, tb.active_id, context)
 
     # Create file tab (TabBar.add auto-activates it)
@@ -422,18 +475,6 @@ defmodule MingaEditor.Shell.Traditional do
 
     {%{shell_state | tab_bar: tb}, workspace}
   end
-
-  @spec restore_workspace(WorkspaceState.t(), map()) :: WorkspaceState.t()
-  defp restore_workspace(workspace, context) when is_map(context) and map_size(context) > 0 do
-    Enum.reduce(WorkspaceState.field_names(), workspace, fn field, acc ->
-      case Map.fetch(context, field) do
-        {:ok, value} -> Map.put(acc, field, value)
-        :error -> acc
-      end
-    end)
-  end
-
-  defp restore_workspace(workspace, _context), do: workspace
 
   # Resets the active window's content type from agent_chat back to buffer.
   @spec reset_active_window_to_buffer(WorkspaceState.t()) :: WorkspaceState.t()

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -202,7 +202,7 @@ defmodule MingaEditor.Shell.Traditional do
       "[tab] on_buffer_added label=#{label} context=#{context} tab=#{tb.active_id}"
     end)
 
-    case find_tab_for_buffer(tb, label) do
+    case find_tab_for_buffer(tb, buffer_pid) do
       %Tab{id: tab_id} ->
         switch_to_buffer_tab(shell_state, prev_workspace, workspace, tab_id)
 
@@ -367,10 +367,10 @@ defmodule MingaEditor.Shell.Traditional do
   # Buffer lifecycle helpers
   # -------------------------------------------------------------------
 
-  @spec find_tab_for_buffer(TabBar.t(), String.t()) :: Tab.t() | nil
-  defp find_tab_for_buffer(%TabBar{tabs: tabs}, label) do
+  @spec find_tab_for_buffer(TabBar.t(), pid()) :: Tab.t() | nil
+  defp find_tab_for_buffer(%TabBar{tabs: tabs}, pid) when is_pid(pid) do
     Enum.find(tabs, fn tab ->
-      tab.kind == :file and tab.label == label
+      tab.kind == :file and tab_has_active_buffer?(tab, pid)
     end)
   end
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -33,7 +33,6 @@ defmodule MingaEditor.State do
   alias Minga.Buffer
 
   alias MingaEditor.BottomPanel
-  alias MingaEditor.CompletionTrigger
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.LSP, as: LSPState
@@ -894,7 +893,7 @@ defmodule MingaEditor.State do
 
   @spec snapshot_workspace_fields(WorkspaceState.t()) :: Tab.context()
   defp snapshot_workspace_fields(%WorkspaceState{} = ws) do
-    Map.from_struct(ws)
+    WorkspaceState.to_tab_context(ws)
   end
 
   @doc """
@@ -956,8 +955,6 @@ defmodule MingaEditor.State do
       mouse: %Mouse{},
       highlight: %Highlighting{},
       lsp_pending: %{},
-      completion: nil,
-      completion_trigger: CompletionTrigger.new(),
       injection_ranges: %{},
       search: %Search{},
       editing: VimState.new(),
@@ -988,8 +985,6 @@ defmodule MingaEditor.State do
       mouse: %Mouse{},
       highlight: %Highlighting{},
       lsp_pending: %{},
-      completion: nil,
-      completion_trigger: CompletionTrigger.new(),
       injection_ranges: %{},
       search: %Search{},
       editing: VimState.new(),

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -697,7 +697,7 @@ defmodule MingaEditor.State do
 
   Generic concerns (buffer pool) are handled here. Shell-specific
   presentation logic (tab bar, card routing) is dispatched through
-  `shell.on_buffer_added/4`. The only effect returned is `{:monitor, pid}`.
+  `shell.on_buffer_added/5`. The only effect returned is `{:monitor, pid}`.
 
   The buffer-add context is read from `state.buffer_add_context` (set by
   picker preview) or overridden via `opts[:context]`. After dispatch the
@@ -719,11 +719,18 @@ defmodule MingaEditor.State do
         Buffers.add(bs, pid)
       end
 
+    prev_workspace = state.workspace
     state = put_in(state.workspace.buffers, new_bs)
 
     # Dispatch to the active shell for presentation logic
     {shell_state, workspace} =
-      state.shell.on_buffer_added(state.shell_state, state.workspace, pid, context)
+      state.shell.on_buffer_added(
+        state.shell_state,
+        prev_workspace,
+        state.workspace,
+        pid,
+        context
+      )
 
     state = %{state | shell_state: shell_state, workspace: workspace, buffer_add_context: :open}
 
@@ -906,17 +913,7 @@ defmodule MingaEditor.State do
         context
       end
 
-    ws = state.workspace
-
-    new_ws =
-      Enum.reduce(WorkspaceState.field_names(), ws, fn field, acc ->
-        case Map.fetch(context, field) do
-          {:ok, value} -> Map.put(acc, field, value)
-          :error -> acc
-        end
-      end)
-
-    %{state | workspace: new_ws}
+    %{state | workspace: WorkspaceState.restore_tab_context(state.workspace, context)}
   end
 
   # Builds a file-tab context for a brand-new tab. Returns the flat format

--- a/lib/minga_editor/state/tab.ex
+++ b/lib/minga_editor/state/tab.ex
@@ -9,9 +9,8 @@ defmodule MingaEditor.State.Tab do
 
   ## Context format
 
-  The canonical context is a flat map with per-tab fields (buffers, windows,
-  vim state, viewport, etc.) stored directly. Legacy contexts with nested
-  structure are auto-migrated on first restore.
+  The canonical context is a flat map with workspace fields (buffers, windows,
+  editing state, viewport, etc.) stored directly. Restore reads only fields that exist on `MingaEditor.Workspace.State`; unknown legacy fields are ignored.
   """
 
   # Tab contexts store per-tab fields directly as flat maps.
@@ -37,8 +36,6 @@ defmodule MingaEditor.State.Tab do
           optional(:mouse) => term(),
           optional(:highlight) => term(),
           optional(:lsp_pending) => term(),
-          optional(:completion) => term(),
-          optional(:completion_trigger) => term(),
           optional(:injection_ranges) => term(),
           optional(:search) => term(),
           optional(:editing) => MingaEditor.VimState.t(),

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -120,7 +120,7 @@ defmodule MingaEditor.UI.Picker.Source do
   """
   @spec preview?(module()) :: boolean()
   def preview?(module) do
-    if function_exported?(module, :preview?, 0) do
+    if exported?(module, :preview?, 0) do
       module.preview?()
     else
       false
@@ -132,7 +132,7 @@ defmodule MingaEditor.UI.Picker.Source do
   """
   @spec has_actions?(module()) :: boolean()
   def has_actions?(module) do
-    function_exported?(module, :actions, 1) and function_exported?(module, :on_action, 3)
+    exported?(module, :actions, 1) and exported?(module, :on_action, 3)
   end
 
   @doc """
@@ -152,7 +152,7 @@ defmodule MingaEditor.UI.Picker.Source do
   """
   @spec layout(module()) :: layout()
   def layout(module) do
-    if function_exported?(module, :layout, 0) do
+    if exported?(module, :layout, 0) do
       module.layout()
     else
       :bottom
@@ -164,10 +164,15 @@ defmodule MingaEditor.UI.Picker.Source do
   """
   @spec keep_open_on_select?(module()) :: boolean()
   def keep_open_on_select?(module) do
-    if function_exported?(module, :keep_open_on_select?, 0) do
+    if exported?(module, :keep_open_on_select?, 0) do
       module.keep_open_on_select?()
     else
       false
     end
+  end
+
+  @spec exported?(module(), atom(), non_neg_integer()) :: boolean()
+  defp exported?(module, function, arity) do
+    Code.ensure_loaded?(module) and function_exported?(module, function, arity)
   end
 end

--- a/lib/minga_editor/workspace/state.ex
+++ b/lib/minga_editor/workspace/state.ex
@@ -68,7 +68,7 @@ defmodule MingaEditor.Workspace.State do
   @doc """
   Converts a workspace into a flat-map tab context suitable for storing
   on a `MingaEditor.State.Tab` and later restoring via
-  `EditorState.restore_tab_context/2`.
+  `restore_tab_context/2`.
 
   The single chokepoint for snapshots. Beyond the `Map.from_struct/1`
   conversion, this normalises `editing` so the snapshotted vim state is a
@@ -82,6 +82,17 @@ defmodule MingaEditor.Workspace.State do
     ws
     |> Map.update!(:editing, &VimState.normalize/1)
     |> Map.from_struct()
+  end
+
+  @doc "Restores a flat tab context into a workspace. Empty contexts are ignored by this pure helper; EditorState handles brand-new tab defaults because those need editor dimensions."
+  @spec restore_tab_context(t(), map()) :: t()
+  def restore_tab_context(%__MODULE__{} = ws, context) when is_map(context) do
+    Enum.reduce(field_names(), ws, fn field, acc ->
+      case Map.fetch(context, field) do
+        {:ok, value} -> Map.put(acc, field, value)
+        :error -> acc
+      end
+    end)
   end
 
   # ── Pure workspace operations ─────────────────────────────────────────────

--- a/test/minga/buffer_management_test.exs
+++ b/test/minga/buffer_management_test.exs
@@ -10,6 +10,9 @@ defmodule Minga.BufferManagementTest do
 
   use Minga.Test.EditorCase, async: true
 
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.TabBar
+
   describe "single buffer baseline" do
     test "editor starts with one buffer" do
       ctx = start_editor("hello")
@@ -32,6 +35,13 @@ defmodule Minga.BufferManagementTest do
       send_keys(ctx, ":e #{path2}<CR>")
 
       assert active_content(ctx) == "second file"
+
+      state = editor_state(ctx)
+      tb = state.shell_state.tab_bar
+      assert %Buffers{active: original_buf} = TabBar.get(tb, 1).context.buffers
+      assert original_buf == ctx.buffer
+      assert %Buffers{active: active_buf} = TabBar.active(tb).context.buffers
+      assert active_buf == state.workspace.buffers.active
     end
 
     @tag :tmp_dir
@@ -70,17 +80,22 @@ defmodule Minga.BufferManagementTest do
       # Now on buffer 3/3 (gamma)
       assert active_content(ctx) == "gamma"
 
+      assert editor_state(ctx).shell_state.tab_bar.active_id == 3
+
       # SPC b n wraps to buffer 1 (alpha)
       send_keys_sync(ctx, "<SPC>bn")
       assert active_content(ctx) == "alpha"
+      assert editor_state(ctx).shell_state.tab_bar.active_id == 1
 
       # SPC b n to buffer 2 (beta)
       send_keys_sync(ctx, "<SPC>bn")
       assert active_content(ctx) == "beta"
+      assert editor_state(ctx).shell_state.tab_bar.active_id == 2
 
       # SPC b p back to buffer 1 (alpha)
       send_keys_sync(ctx, "<SPC>bp")
       assert active_content(ctx) == "alpha"
+      assert editor_state(ctx).shell_state.tab_bar.active_id == 1
     end
 
     @tag :tmp_dir

--- a/test/minga/buffer_management_test.exs
+++ b/test/minga/buffer_management_test.exs
@@ -125,8 +125,7 @@ defmodule Minga.BufferManagementTest do
       send_keys_sync(ctx, "<SPC>bp")
       send_keys_sync(ctx, "<SPC>bn")
 
-      # Editor still alive and processing keys.
-      assert Process.alive?(ctx.editor)
+      # The synchronous content query proves the editor is still alive and processing keys.
       assert active_content(ctx) in ["alpha", "beta", "gamma"]
     end
 

--- a/test/minga_editor/commands/start_buffer_test.exs
+++ b/test/minga_editor/commands/start_buffer_test.exs
@@ -1,0 +1,23 @@
+defmodule MingaEditor.Commands.StartBufferTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer
+  alias MingaEditor.Commands
+
+  @moduletag :tmp_dir
+
+  describe "start_buffer/1" do
+    test "returns an existing registered file buffer instead of starting a duplicate", %{
+      tmp_dir: tmp_dir
+    } do
+      path = Path.join(tmp_dir, "already-open.ex")
+      File.write!(path, "already open")
+      existing = start_supervised!({Buffer, file_path: path})
+
+      assert {:ok, ^existing} = Commands.start_buffer(path)
+      assert {:ok, ^existing} = Buffer.pid_for_path(path)
+    end
+  end
+end

--- a/test/minga_editor/ensure_buffer_editor_test.exs
+++ b/test/minga_editor/ensure_buffer_editor_test.exs
@@ -44,5 +44,26 @@ defmodule MingaEditor.EnsureBufferEditorTest do
 
       Process.demonitor(monitor, [:flush])
     end
+
+    test "skips a buffer already tracked in an inactive tab", %{tmp_dir: dir} do
+      path1 = Path.join(dir, "one.ex")
+      path2 = Path.join(dir, "two.ex")
+      File.write!(path1, "one")
+      File.write!(path2, "two")
+      ctx = start_editor("one", file_path: path1)
+      editor = ctx.editor
+      path1_pid = active_buffer(ctx)
+
+      send_keys_sync(ctx, ":e #{path2}<CR>")
+      path2_pid = active_buffer(ctx)
+      Minga.API.execute(:tab_prev, editor)
+
+      assert {:ok, ^path2_pid} = MingaEditor.ensure_buffer_for_path(path2, editor)
+
+      state = editor_state(ctx)
+      assert state.workspace.buffers.active == path1_pid
+      assert state.workspace.buffers.list == [path1_pid]
+      refute path2_pid in state.workspace.buffers.list
+    end
   end
 end

--- a/test/minga_editor/ensure_buffer_editor_test.exs
+++ b/test/minga_editor/ensure_buffer_editor_test.exs
@@ -1,0 +1,48 @@
+defmodule MingaEditor.EnsureBufferEditorTest do
+  @moduledoc false
+
+  use Minga.Test.EditorCase, async: true
+
+  @moduletag :tmp_dir
+
+  describe "ensure_buffer_for_path/2 with a running editor" do
+    test "registers a different file in the background without crashing", %{tmp_dir: dir} do
+      path = Path.join(dir, "tracked.ex")
+      other_path = Path.join(dir, "other.ex")
+      File.write!(path, "tracked")
+      File.write!(other_path, "other")
+      ctx = start_editor("tracked", file_path: path)
+      editor = ctx.editor
+      original = active_buffer(ctx)
+      monitor = Process.monitor(editor)
+
+      assert {:ok, new_buf} = MingaEditor.ensure_buffer_for_path(other_path, editor)
+      on_exit(fn -> if Process.alive?(new_buf), do: GenServer.stop(new_buf) end)
+
+      state = editor_state(ctx)
+      assert state.workspace.buffers.active == original
+      assert state.workspace.buffers.list == [original, new_buf]
+      refute_receive {:DOWN, ^monitor, :process, ^editor, _reason}, 0
+
+      Process.demonitor(monitor, [:flush])
+    end
+
+    test "skips an already tracked editor buffer without crashing", %{tmp_dir: dir} do
+      path = Path.join(dir, "tracked.ex")
+      File.write!(path, "tracked")
+      ctx = start_editor("tracked", file_path: path)
+      editor = ctx.editor
+      original = active_buffer(ctx)
+      monitor = Process.monitor(editor)
+
+      assert {:ok, ^original} = MingaEditor.ensure_buffer_for_path(path, editor)
+
+      state = editor_state(ctx)
+      assert state.workspace.buffers.active == original
+      assert state.workspace.buffers.list == [original]
+      refute_receive {:DOWN, ^monitor, :process, ^editor, _reason}, 0
+
+      Process.demonitor(monitor, [:flush])
+    end
+  end
+end

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -1,18 +1,76 @@
 defmodule MingaEditor.PickerUITest do
-  @moduledoc "Tests PickerUI.render with focused RenderInput (no EditorState needed)."
+  @moduledoc "Tests PickerUI rendering and picker-state transitions."
 
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer.Server, as: BufferServer
   alias MingaEditor.PickerUI
   alias MingaEditor.PickerUI.RenderInput
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.Picker, as: PickerState
-  alias MingaEditor.Viewport
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Windows
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.UI.Picker
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Theme
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias MingaEditor.Window
+  alias MingaEditor.WindowTree
+  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   defp theme_picker do
     Theme.get!(:doom_one).picker
+  end
+
+  defp preview_promotion_state do
+    {:ok, original_buf} = BufferServer.start_link(content: "original")
+    {:ok, preview_buf} = BufferServer.start_link(content: "preview")
+    win_id = 1
+    original_window = Window.new(win_id, original_buf, 24, 80)
+    preview_window = %{original_window | buffer: preview_buf, content: {:buffer, preview_buf}}
+
+    original_workspace = %WorkspaceState{
+      viewport: Viewport.new(24, 80),
+      editing: VimState.new(),
+      buffers: %Buffers{active: original_buf, list: [original_buf], active_index: 0},
+      windows: %Windows{
+        tree: WindowTree.new(win_id),
+        map: %{win_id => original_window},
+        active: win_id,
+        next_id: win_id + 1
+      }
+    }
+
+    preview_workspace = %{
+      original_workspace
+      | buffers: %Buffers{active: preview_buf, list: [original_buf, preview_buf], active_index: 1},
+        windows: %{original_workspace.windows | map: %{win_id => preview_window}}
+    }
+
+    tab = Tab.new_file(1, "original.ex")
+    tb = TabBar.new(tab)
+    tb = TabBar.update_context(tb, 1, WorkspaceState.to_tab_context(original_workspace))
+
+    picker = Picker.new([%Item{id: "preview", label: "preview.ex"}], title: "Files")
+
+    picker_state = %PickerState{
+      picker: picker,
+      source: MingaEditor.UI.Picker.FileSource,
+      restore: 0
+    }
+
+    state = %EditorState{
+      port_manager: self(),
+      workspace: preview_workspace,
+      shell_state: %ShellState{tab_bar: tb, modal: {:picker, PickerPayload.new(picker_state)}}
+    }
+
+    {state, original_buf, preview_buf}
   end
 
   describe "render/1 with RenderInput" do
@@ -84,6 +142,21 @@ defmodule MingaEditor.PickerUITest do
         assert is_binary(text)
         assert %Minga.Core.Face{} = style
       end)
+    end
+  end
+
+  describe "preview promotion" do
+    test "restores the original tab before creating the promoted preview tab" do
+      {state, original_buf, preview_buf} = preview_promotion_state()
+
+      new_state = PickerUI.handle_key(state, 13, 0)
+
+      tb = new_state.shell_state.tab_bar
+      assert new_state.shell_state.modal == :none
+      assert TabBar.count(tb) == 2
+      assert %Buffers{active: ^original_buf} = TabBar.get(tb, 1).context.buffers
+      assert %Buffers{active: ^preview_buf} = TabBar.get(tb, 2).context.buffers
+      assert new_state.workspace.buffers.active == preview_buf
     end
   end
 

--- a/test/minga_editor/state/buffer_lifecycle_test.exs
+++ b/test/minga_editor/state/buffer_lifecycle_test.exs
@@ -44,6 +44,35 @@ defmodule MingaEditor.State.BufferLifecycleTest do
     EditorState.set_tab_bar(state, tb)
   end
 
+  @spec state_with_file_tab_for_path(String.t(), String.t()) :: {EditorState.t(), pid()}
+  defp state_with_file_tab_for_path(path, content) do
+    buf = start_file_buffer(path, content)
+    win_id = 1
+    window = Window.new(win_id, buf, 24, 80)
+
+    state = %EditorState{
+      port_manager: self(),
+      workspace: %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        editing: VimState.new(),
+        buffers: %Buffers{active: buf, list: [buf], active_index: 0},
+        windows: %Windows{
+          tree: WindowTree.new(win_id),
+          map: %{win_id => window},
+          active: win_id,
+          next_id: win_id + 1
+        }
+      }
+    }
+
+    tab = Tab.new_file(1, Path.basename(path))
+    context = EditorState.snapshot_tab_context(state)
+    tb = TabBar.new(tab)
+    tb = TabBar.update_context(tb, 1, context)
+
+    {EditorState.set_tab_bar(state, tb), buf}
+  end
+
   # Creates a state with an agent tab active and an agent_chat window.
   @spec state_with_agent_tab() :: {EditorState.t(), pid()}
   defp state_with_agent_tab do
@@ -80,6 +109,13 @@ defmodule MingaEditor.State.BufferLifecycleTest do
   @spec start_buffer(String.t()) :: pid()
   defp start_buffer(content) do
     {:ok, pid} = BufferServer.start_link(content: content)
+    pid
+  end
+
+  @spec start_file_buffer(String.t(), String.t()) :: pid()
+  defp start_file_buffer(path, content) do
+    File.write!(path, content)
+    {:ok, pid} = BufferServer.start_link(file_path: path)
     pid
   end
 
@@ -120,6 +156,79 @@ defmodule MingaEditor.State.BufferLifecycleTest do
       # The key invariant is that the new buffer is now active
       assert new_state.workspace.buffers.active == new_buf
       refute new_state.workspace.buffers.active == original_buf
+    end
+
+    test "opening a file from a file tab snapshots the outgoing tab before activating the new buffer" do
+      state = state_with_file_tab()
+      original_buf = state.workspace.buffers.active
+      opened_buf = start_buffer("opened")
+
+      {new_state, effects} = EditorState.add_buffer_pure(state, opened_buf, context: :open)
+
+      assert {:monitor, opened_buf} in effects
+
+      tb = new_state.shell_state.tab_bar
+      assert TabBar.count(tb) == 2
+      assert tb.active_id == 2
+      assert %Buffers{active: ^original_buf} = TabBar.get(tb, 1).context.buffers
+      assert %Buffers{active: ^opened_buf} = TabBar.get(tb, 2).context.buffers
+      assert new_state.workspace.buffers.active == opened_buf
+    end
+
+    test "opening a file from an agent tab snapshots the agent tab with the agent buffer" do
+      {state, agent_buf} = state_with_agent_tab()
+      file_buf = start_buffer("file content")
+
+      {new_state, _effects} = EditorState.add_buffer_pure(state, file_buf, context: :open)
+
+      tb = new_state.shell_state.tab_bar
+      agent_tab = TabBar.get(tb, 1)
+      file_tab = TabBar.active(tb)
+
+      assert agent_tab.kind == :agent
+      assert %Buffers{active: ^agent_buf} = agent_tab.context.buffers
+      assert agent_tab.context.keymap_scope == :agent
+      assert file_tab.kind == :file
+      assert %Buffers{active: ^file_buf} = file_tab.context.buffers
+      assert file_tab.context.keymap_scope == :editor
+    end
+
+    test "previewing a file does not overwrite the current tab context with the preview buffer" do
+      state = state_with_file_tab()
+      original_buf = state.workspace.buffers.active
+      preview_buf = start_buffer("preview")
+
+      {new_state, _effects} = EditorState.add_buffer_pure(state, preview_buf, context: :preview)
+
+      tb = new_state.shell_state.tab_bar
+      assert TabBar.count(tb) == 1
+      assert tb.active_id == 1
+      assert new_state.workspace.buffers.active == preview_buf
+      assert %Buffers{active: ^original_buf} = TabBar.get(tb, 1).context.buffers
+      assert new_state.buffer_add_context == :open
+    end
+
+    @tag :tmp_dir
+    test "opening a file that already has a tab snapshots the outgoing tab before switching", %{
+      tmp_dir: tmp_dir
+    } do
+      path1 = Path.join(tmp_dir, "one.ex")
+      path2 = Path.join(tmp_dir, "two.ex")
+      {state, buf1} = state_with_file_tab_for_path(path1, "one")
+      buf2 = start_file_buffer(path2, "two")
+
+      {state, _effects} = EditorState.add_buffer_pure(state, buf2, context: :open)
+      assert state.workspace.buffers.active == buf2
+
+      {new_state, effects} = EditorState.add_buffer_pure(state, buf1, context: :open)
+
+      assert effects == []
+
+      tb = new_state.shell_state.tab_bar
+      assert tb.active_id == 1
+      assert new_state.workspace.buffers.active == buf1
+      assert %Buffers{active: ^buf1} = TabBar.get(tb, 1).context.buffers
+      assert %Buffers{active: ^buf2} = TabBar.get(tb, 2).context.buffers
     end
 
     test "adds buffer when agent tab active (new file tab)" do

--- a/test/minga_editor/state/buffer_lifecycle_test.exs
+++ b/test/minga_editor/state/buffer_lifecycle_test.exs
@@ -231,6 +231,31 @@ defmodule MingaEditor.State.BufferLifecycleTest do
       assert %Buffers{active: ^buf2} = TabBar.get(tb, 2).context.buffers
     end
 
+    @tag :tmp_dir
+    test "opening a different file with the same basename creates a distinct tab", %{
+      tmp_dir: tmp_dir
+    } do
+      dir1 = Path.join(tmp_dir, "one")
+      dir2 = Path.join(tmp_dir, "two")
+      File.mkdir_p!(dir1)
+      File.mkdir_p!(dir2)
+      path1 = Path.join(dir1, "same.ex")
+      path2 = Path.join(dir2, "same.ex")
+      {state, buf1} = state_with_file_tab_for_path(path1, "one")
+      buf2 = start_file_buffer(path2, "two")
+
+      {new_state, effects} = EditorState.add_buffer_pure(state, buf2, context: :open)
+
+      assert {:monitor, buf2} in effects
+      tb = new_state.shell_state.tab_bar
+      assert TabBar.count(tb) == 2
+      assert tb.active_id == 2
+      assert TabBar.get(tb, 1).label == "same.ex"
+      assert TabBar.get(tb, 2).label == "same.ex"
+      assert %Buffers{active: ^buf1} = TabBar.get(tb, 1).context.buffers
+      assert %Buffers{active: ^buf2} = TabBar.get(tb, 2).context.buffers
+    end
+
     test "adds buffer when agent tab active (new file tab)" do
       {state, _agent_buf} = state_with_agent_tab()
       file_buf = start_buffer("file content")

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -62,6 +62,17 @@ defmodule MingaEditor.State.SnapshotTest do
       assert ctx.injection_ranges == state.workspace.injection_ranges
       assert ctx.search == state.workspace.search
     end
+
+    test "normalises transient editing state before snapshotting" do
+      state = make_state(mode: :normal)
+      command_state = %Mode.CommandState{input: ""}
+      state = put_in(state.workspace.editing, %VimState{mode: :normal, mode_state: command_state})
+
+      ctx = EditorState.snapshot_tab_context(state)
+
+      assert ctx.editing.mode == :normal
+      assert match?(%Mode.State{}, ctx.editing.mode_state)
+    end
   end
 
   describe "restore_tab_context/2" do

--- a/test/minga_editor/workspace/state_test.exs
+++ b/test/minga_editor/workspace/state_test.exs
@@ -66,6 +66,27 @@ defmodule MingaEditor.Workspace.StateTest do
     end
   end
 
+  describe "restore_tab_context/2" do
+    test "restores flat workspace fields from a tab context" do
+      ws = base_state().workspace
+      replacement = %{ws.buffers | active: nil, list: [], active_index: 0}
+
+      restored = WorkspaceState.restore_tab_context(ws, %{buffers: replacement})
+
+      assert restored.buffers == replacement
+      assert restored.windows == ws.windows
+      assert restored.viewport == ws.viewport
+    end
+
+    test "ignores fields that are not part of the workspace" do
+      ws = base_state().workspace
+
+      restored = WorkspaceState.restore_tab_context(ws, %{unknown_field: :ignored})
+
+      assert restored == ws
+    end
+  end
+
   describe "to_tab_context/1" do
     test "returns a flat map of workspace fields" do
       ws = base_state().workspace


### PR DESCRIPTION
# TL;DR
This fixes the tab-state corruption cluster by snapshotting outgoing tabs before buffer activation changes live workspace state. It also fixes the `ensure_buffer_for_path/2` crash path and restores buffer cycling so dedicated file tabs stay aligned with the buffer being shown.

Closes #1396
Closes #1397
Closes #1479
Part of #1395

## Context
Tabs are a trust boundary for the editor. Before this PR, opening or previewing files could save the newly activated buffer into the tab the user was leaving, which made tab restoration and `SPC b n` / `SPC b p` point at the wrong file. A separate background-buffer registration path could also crash the running editor because it treated the flat buffer pid list as a tuple list.

## Changes
- Fix `{:register_background_buffer, ...}` to check the flat buffer pid list directly.
- Change the shell buffer-added callback to receive both the previous workspace and the post-buffer-mutation workspace.
- Snapshot outgoing Traditional tabs from the previous workspace, then snapshot the new or target tab from the new workspace.
- Keep Board shell behavior unchanged under the new callback signature.
- Move flat tab-context restoration into `WorkspaceState.restore_tab_context/2` so EditorState and Traditional shell use the same pure restore path.
- Restore buffer cycling over dedicated file tabs even when the current tab's buffer list is narrower than the global set of file tabs.
- When killing a per-tab last buffer with a neighboring tab available, restore the neighbor tab instead of creating an empty fallback buffer.
- Add regression coverage that reads `tab_bar.tabs[id].context` directly for open, preview, existing-tab switch, and command-mode open flows.
- Add running-Editor regressions for `ensure_buffer_for_path/2`, covering both background registration of a different file and already-tracked skip behavior.

## Verification
- `make lint` passed.
- `mix test.llm` passed: 54 doctests, 98 properties, 7625 tests, 0 failures, 6 skipped, 95 excluded.
- `mix test.debug test/minga_editor/ensure_buffer_editor_test.exs` passed after adding the stricter running-Editor regression.
- Project reviewer returned PASS.

## Acceptance Criteria Addressed
- #1396: running editor no longer crashes when `ensure_buffer_for_path/2` registers or skips a buffer. ✅
- #1396: regression tests cover running-editor background registration and already-tracked skip. ✅
- #1397: opening, previewing, or switching to an existing file tab preserves the outgoing tab's context. ✅
- #1397: context restore now routes through the shared pure `WorkspaceState.restore_tab_context/2` helper. ✅
- #1397: snapshot-level tests inspect `tab_bar.tabs[id].context` directly. ✅
- #1397: closing a per-tab last buffer restores the neighboring tab instead of replacing the workspace with an empty buffer. ✅
- #1479: `:e <path>` creates a new file tab without recording the new buffer as the leaving tab's active buffer. ✅
- #1479: `SPC b n` / `SPC b p` focus dedicated file tabs when they exist. ✅
