### PR TITLE
refactor(editor): move space_leader fields from EditorState to ShellState

### DIFF
--- a/lib/minga_editor/input/cua/tui_space_leader.ex
+++ b/lib/minga_editor/input/cua/tui_space_leader.ex
@@ -125,25 +125,25 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
   # ── Private ──────────────────────────────────────────────────────────────
 
   @spec pending?(map()) :: boolean()
-  defp pending?(%{space_leader_pending: true}), do: true
+  defp pending?(%{shell_state: %{space_leader_pending: true}}), do: true
   defp pending?(_state), do: false
 
   @spec put_space_leader_pending(EditorState.t(), boolean()) :: EditorState.t()
   defp put_space_leader_pending(state, value) do
-    %{state | space_leader_pending: value}
+    %{state | shell_state: %{state.shell_state | space_leader_pending: value}}
   end
 
   @spec put_space_leader_timer(EditorState.t(), reference() | nil) :: EditorState.t()
   defp put_space_leader_timer(state, timer) do
-    %{state | space_leader_timer: timer}
+    %{state | shell_state: %{state.shell_state | space_leader_timer: timer}}
   end
 
   @spec cancel_timer(EditorState.t()) :: EditorState.t()
-  defp cancel_timer(%{space_leader_timer: nil} = state), do: state
+  defp cancel_timer(%{shell_state: %{space_leader_timer: nil}} = state), do: state
 
-  defp cancel_timer(%{space_leader_timer: timer} = state) do
+  defp cancel_timer(%{shell_state: %{space_leader_timer: timer}} = state) do
     Process.cancel_timer(timer)
-    %{state | space_leader_timer: nil}
+    %{state | shell_state: %{state.shell_state | space_leader_timer: nil}}
   end
 
   @spec retract_space(EditorState.t()) :: EditorState.t()

--- a/lib/minga_editor/shell/board/state.ex
+++ b/lib/minga_editor/shell/board/state.ex
@@ -50,7 +50,9 @@ defmodule MingaEditor.Shell.Board.State do
           signature_help: nil,
           tool_declined: MapSet.t(),
           tool_prompt_queue: [atom()],
-          suppress_tool_prompts: boolean()
+          suppress_tool_prompts: boolean(),
+          space_leader_pending: boolean(),
+          space_leader_timer: nil
         }
 
   defstruct cards: %{},
@@ -76,7 +78,9 @@ defmodule MingaEditor.Shell.Board.State do
             signature_help: nil,
             tool_declined: MapSet.new(),
             tool_prompt_queue: [],
-            suppress_tool_prompts: false
+            suppress_tool_prompts: false,
+            space_leader_pending: false,
+            space_leader_timer: nil
 
   @doc "Creates a fresh Board state with an empty card grid."
   @spec new() :: t()

--- a/lib/minga_editor/shell/traditional/state.ex
+++ b/lib/minga_editor/shell/traditional/state.ex
@@ -37,7 +37,9 @@ defmodule MingaEditor.Shell.Traditional.State do
           signature_help: MingaEditor.SignatureHelp.t() | nil,
           tool_declined: MapSet.t(),
           tool_prompt_queue: [atom()],
-          suppress_tool_prompts: boolean()
+          suppress_tool_prompts: boolean(),
+          space_leader_pending: boolean(),
+          space_leader_timer: reference() | nil
         }
 
   defstruct nav_flash: nil,
@@ -55,7 +57,9 @@ defmodule MingaEditor.Shell.Traditional.State do
             signature_help: nil,
             tool_declined: MapSet.new(),
             tool_prompt_queue: [],
-            suppress_tool_prompts: false
+            suppress_tool_prompts: false,
+            space_leader_pending: false,
+            space_leader_timer: nil
 
   # ── Status message ─────────────────────────────────────────────────────────
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -17,8 +17,7 @@ defmodule MingaEditor.State do
 
   **Global fields** are shared across all tabs and never snapshotted:
   `port_manager`, `theme`, `render_timer`, `focus_stack`,
-  `tab_bar`, `capabilities`, `layout`, `modeline_click_regions`,
-  `tab_bar_click_regions`, `agent`, `whichkey`.
+  `capabilities`.
 
   ## Composed sub-structs
 
@@ -111,8 +110,6 @@ defmodule MingaEditor.State do
             caches: MingaEditor.Renderer.Caches.new(),
             session: %SessionState{},
             buffer_add_context: :open,
-            space_leader_pending: false,
-            space_leader_timer: nil,
             stashed_board_state: nil
 
   @type backend :: :tui | :native_gui | :headless
@@ -149,8 +146,6 @@ defmodule MingaEditor.State do
           caches: MingaEditor.Renderer.Caches.t(),
           buffer_add_context: MingaEditor.Shell.buffer_add_context(),
           session: SessionState.t(),
-          space_leader_pending: boolean(),
-          space_leader_timer: reference() | nil,
           stashed_board_state: MingaEditor.Shell.Board.State.t() | nil
         }
 

--- a/test/minga_editor/input/cua/tui_space_leader_test.exs
+++ b/test/minga_editor/input/cua/tui_space_leader_test.exs
@@ -35,7 +35,7 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeaderTest do
       send_key_sync(ctx, 0x20)
 
       state = editor_state(ctx)
-      assert state.space_leader_pending == true
+      assert state.shell_state.space_leader_pending == true
 
       # Send 'f' (leader prefix for +file)
       send_key_sync(ctx, ?f)
@@ -44,7 +44,7 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeaderTest do
       # Leader mode should be active
       assert state.shell_state.whichkey.node != nil
       # Space should have been retracted
-      assert state.space_leader_pending == false
+      assert state.shell_state.space_leader_pending == false
       refute String.ends_with?(buffer_content(ctx), " ")
     end
   end
@@ -57,14 +57,14 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeaderTest do
       send_key_sync(ctx, 0x20)
 
       state = editor_state(ctx)
-      assert state.space_leader_pending == true
+      assert state.shell_state.space_leader_pending == true
 
       # Send timeout directly (per AGENTS.md: send timer messages directly)
       send(ctx.editor, :space_leader_timeout)
       _ = :sys.get_state(ctx.editor)
 
       state = editor_state(ctx)
-      assert state.space_leader_pending == false
+      assert state.shell_state.space_leader_pending == false
       # Space should remain in buffer
       assert buffer_content(ctx) == " "
     end
@@ -79,7 +79,7 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeaderTest do
       send_key_sync(ctx, ?!)
 
       state = editor_state(ctx)
-      assert state.space_leader_pending == false
+      assert state.shell_state.space_leader_pending == false
       # Space stays in buffer, '!' passes through to CUA.Dispatch
       assert String.starts_with?(buffer_content(ctx), " ")
     end
@@ -112,7 +112,7 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeaderTest do
       send_key_sync(ctx, 0x20)
 
       state = editor_state(ctx)
-      assert state.space_leader_pending == false
+      assert state.shell_state.space_leader_pending == false
     end
   end
 end

--- a/test/minga_editor/render_pipeline/input_test.exs
+++ b/test/minga_editor/render_pipeline/input_test.exs
@@ -55,8 +55,6 @@ defmodule MingaEditor.RenderPipeline.InputTest do
         :last_test_command,
         :session,
         :git_remote_op,
-        :space_leader_pending,
-        :space_leader_timer,
         :last_cursor_line,
         :buffer_add_context,
         :stashed_board_state


### PR DESCRIPTION
## Summary

- Moves `space_leader_pending` and `space_leader_timer` from EditorState to ShellState (Traditional + Board stubs), reducing EditorState from 31 to 29 fields
- Updates TUISpaceLeader input handler to access fields via `state.shell_state`
- Updates tests to match new field location

## Context

Part of #1490. During implementation, several fields that were originally scoped for migration turned out to be unsafe to move due to shell transition semantics (`shell_state` is replaced entirely during Board/Traditional toggle):

- **`render_timer`, `last_cursor_line`, `last_test_command`, `focus_stack`** — must survive shell transitions (timer leak risk, state loss, input chain reset)
- **`layout`** — deeply embedded in render pipeline via `Layout.get/put/invalidate` bare map patterns used by 20+ call sites
- **`buffer_add_context`** — intentional smuggled parameter between picker and buffer lifecycle; Source behaviour callback doesn't support context args
- **`stashed_board_state`** — not dead code; actively used for Board/Traditional shell toggling

The `space_leader_pending/timer` fields are the correct candidates: they are TUI-specific input state that should be naturally cleared on shell transitions.

## Test plan

- [x] `mix test` — 7630 tests, 0 failures
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix credo --strict` — no new warnings (existing struct field count warnings unchanged)
- [x] `mix dialyzer` — matches main branch (5 errors, all skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)