### PR TITLE
fix(mode): support x in visual mode

### DIFF
--- a/lib/minga/mode/visual.ex
+++ b/lib/minga/mode/visual.ex
@@ -337,8 +337,8 @@ defmodule Minga.Mode.Visual do
     {:execute_then_transition, [:reindent_visual_selection], :normal, state}
   end
 
-  # d — delete selection, return to Normal
-  def handle_key({?d, 0}, state) do
+  # d / x: delete selection, return to Normal
+  def handle_key({key, 0}, state) when key in [?d, ?x] do
     {:execute_then_transition, [:delete_visual_selection], :normal, state}
   end
 

--- a/test/minga/mode/visual_test.exs
+++ b/test/minga/mode/visual_test.exs
@@ -189,6 +189,35 @@ defmodule Minga.Mode.VisualTest do
     end
   end
 
+  describe "x deletes selection and transitions to Normal" do
+    test "x behaves exactly like d for visual delete" do
+      state = visual_state({0, 0}, :char)
+
+      assert Visual.handle_key({?x, 0}, state) == Visual.handle_key({?d, 0}, state)
+    end
+
+    test "x emits :delete_visual_selection and transitions to :normal" do
+      state = visual_state({0, 0}, :char)
+
+      assert {:execute_then_transition, [:delete_visual_selection], :normal, _} =
+               Visual.handle_key({?x, 0}, state)
+    end
+
+    test "Mode.process: x returns :normal mode with :delete_visual_selection command" do
+      state = visual_state()
+      {new_mode, commands, _} = Mode.process(:visual, {?x, 0}, state)
+      assert new_mode == :normal
+      assert commands == [:delete_visual_selection]
+    end
+
+    test "x works identically in linewise visual mode" do
+      state = visual_state({2, 0}, :line)
+
+      assert {:execute_then_transition, [:delete_visual_selection], :normal, _} =
+               Visual.handle_key({?x, 0}, state)
+    end
+  end
+
   describe "c — delete selection, transition to Insert" do
     test "c emits :delete_visual_selection and transitions to :insert" do
       state = visual_state({0, 3}, :char)


### PR DESCRIPTION
# TL;DR
Visual mode now treats plain `x` as a cut/delete command, matching Vim behavior and the existing `d` visual delete path.

## Context
Plain `x` in visual mode previously fell through as an unknown key, so selected text was not cut. This PR maps `x` to the existing visual delete command instead of introducing a separate deletion path.

## Changes
- Handle `x` and `d` through the same visual-mode delete branch.
- Keep the transition behavior unchanged: delete the selection, then return to normal mode.
- Add FSM tests for `x`, including direct parity with `d`, dispatcher output, and linewise visual selection.

## Verification
- `mix test.llm test/minga/mode/visual_test.exs`
- `mix format --check-formatted lib/minga/mode/visual.ex test/minga/mode/visual_test.exs`
- `make lint`

Note: a full `mix test.llm` run showed two unrelated agent OS-process/concurrency failures. Both failed tests passed when rerun individually:
- `mix test test/minga_agent/session_test.exs:559`
- `mix test test/minga_agent/providers/pi_rpc_test.exs:467`
