### PR TITLE
feat(agent): enforce plan mode

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -98,7 +98,7 @@ Flags bits:
   bit 1: is_dirty
   bit 2: is_agent (agent chat tab vs file tab)
   bit 3: has_attention
-  bits 4-7: agent_status (0=idle, 1=thinking, 2=tool_executing, 3=error, 4=plan)
+  bits 4-6: agent_status (0=idle, 1=thinking, 2=tool_executing, 3=error, 4=plan)
 
 group_id: workspace group this tab belongs to. 0 = manual/ungrouped workspace.
 Non-zero values match workspace IDs from gui_workspace_bar (0x86). The frontend

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -98,7 +98,7 @@ Flags bits:
   bit 1: is_dirty
   bit 2: is_agent (agent chat tab vs file tab)
   bit 3: has_attention
-  bits 4-5: agent_status (0=idle, 1=thinking, 2=tool_executing, 3=error)
+  bits 4-7: agent_status (0=idle, 1=thinking, 2=tool_executing, 3=error, 4=plan)
 
 group_id: workspace group this tab belongs to. 0 = manual/ungrouped workspace.
 Non-zero values match workspace IDs from gui_workspace_bar (0x86). The frontend
@@ -210,9 +210,9 @@ LSP status: 0=none, 1=ready, 2=initializing, 3=starting, 4=error
 
 Parser status: 0=available, 1=unavailable, 2=restarting
 
-Agent status: 0=idle, 1=thinking, 2=tool_executing, 3=error
+Agent status: 0=idle, 1=thinking, 2=tool_executing, 3=error, 4=plan
 
-Session status (agent variant): 0=idle, 1=thinking, 2=tool_executing, 3=error
+Session status (agent variant): 0=idle, 1=thinking, 2=tool_executing, 3=error, 4=plan
 
 Macro recording: 0=not recording, 1-26=recording register a-z
 
@@ -689,7 +689,7 @@ Per workspace:
   + tab_count(2) + label_len(1) + label(label_len)
 
 kind: 0 = manual (default user workspace), 1 = agent
-agent_status: 0 = idle, 1 = thinking, 2 = tool_executing, 3 = error
+agent_status: 0 = idle, 1 = thinking, 2 = tool_executing, 3 = error, 4 = plan
 color: 24-bit sRGB accent color for group separators and workspace indicator
 tab_count: number of tabs currently in this workspace
 ```

--- a/lib/minga_agent/event.ex
+++ b/lib/minga_agent/event.ex
@@ -22,6 +22,7 @@ defmodule MingaAgent.Event do
           | tool_end()
           | tool_approval()
           | tool_file_changed()
+          | system_message()
           | context_usage()
           | turn_limit_reached()
           | error()
@@ -74,6 +75,12 @@ defmodule MingaAgent.Event do
           path: String.t(),
           before_content: String.t(),
           after_content: String.t()
+        }
+
+  @typedoc "A provider-emitted system message for the chat transcript."
+  @type system_message :: %__MODULE__.SystemMessage{
+          message: String.t(),
+          level: MingaAgent.Message.system_level()
         }
 
   @typedoc "Pre-send estimated context usage."
@@ -172,6 +179,17 @@ defmodule MingaAgent.Event do
             path: String.t(),
             before_content: String.t(),
             after_content: String.t()
+          }
+  end
+
+  defmodule SystemMessage do
+    @moduledoc false
+    @enforce_keys [:message]
+    defstruct [:message, level: :info]
+
+    @type t :: %__MODULE__{
+            message: String.t(),
+            level: MingaAgent.Message.system_level()
           }
   end
 

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -1463,7 +1463,6 @@ defmodule MingaAgent.Providers.Native do
     Session.status(session_pid) == :plan and PlanMode.blocked?(name, args)
   catch
     # Session crashed; fail-closed so destructive tools stay blocked.
-    # Session crashed; fail-closed so destructive tools stay blocked.
     :exit, _ -> PlanMode.blocked?(name, args)
   end
 

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -1460,13 +1460,24 @@ defmodule MingaAgent.Providers.Native do
 
   @spec plan_mode_blocks_tool?(pid() | nil, String.t(), map()) :: boolean()
   defp plan_mode_blocks_tool?(session_pid, name, args) when is_pid(session_pid) do
-    Session.status(session_pid) == :plan and PlanMode.blocked?(name, args)
-  catch
-    # Session crashed; fail-closed so destructive tools stay blocked.
-    :exit, _ -> PlanMode.blocked?(name, args)
+    session_in_plan_mode?(session_pid) and PlanMode.blocked?(name, args)
   end
 
   defp plan_mode_blocks_tool?(_session_pid, _name, _args), do: false
+
+  @spec session_in_plan_mode?(pid()) :: boolean()
+  defp session_in_plan_mode?(session_pid) when is_pid(session_pid) do
+    case Process.info(session_pid, :dictionary) do
+      {:dictionary, dict} ->
+        Keyword.get(dict, :"$initial_call") == {Session, :init, 1} and
+          Session.status(session_pid) == :plan
+
+      nil ->
+        false
+    end
+  catch
+    :exit, _ -> false
+  end
 
   @spec emit_plan_mode_refusal(pid() | nil, String.t()) :: :ok
   defp emit_plan_mode_refusal(session_pid, message) when is_pid(session_pid) do

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -50,6 +50,7 @@ defmodule MingaAgent.Providers.Native do
   alias MingaAgent.Session
   alias MingaAgent.Skills
   alias MingaAgent.TokenEstimator
+  alias MingaAgent.Tool.PlanMode
   alias MingaAgent.Tools
   alias MingaAgent.Tools.Notebook
   alias MingaAgent.Tools.Shell
@@ -1001,6 +1002,7 @@ defmodule MingaAgent.Providers.Native do
     context =
       execute_tools(
         lctx.provider_pid,
+        lctx.session_pid,
         context,
         tool_calls,
         lctx.tools,
@@ -1057,6 +1059,7 @@ defmodule MingaAgent.Providers.Native do
 
   @spec execute_tools(
           pid(),
+          pid() | nil,
           Context.t(),
           [map()],
           [ReqLLM.Tool.t()],
@@ -1064,7 +1067,15 @@ defmodule MingaAgent.Providers.Native do
           hook_runner()
         ) ::
           Context.t()
-  defp execute_tools(provider_pid, context, tool_calls, available_tools, config, hook_runner) do
+  defp execute_tools(
+         provider_pid,
+         session_pid,
+         context,
+         tool_calls,
+         available_tools,
+         config,
+         hook_runner
+       ) do
     initial_mode = approval_mode(config)
 
     {final_ctx, _mode} =
@@ -1074,6 +1085,7 @@ defmodule MingaAgent.Providers.Native do
         {result_text, is_error, new_mode} =
           execute_with_approval(
             provider_pid,
+            session_pid,
             tool_call,
             available_tools,
             approval_mode,
@@ -1105,6 +1117,7 @@ defmodule MingaAgent.Providers.Native do
 
   @spec execute_with_approval(
           pid(),
+          pid() | nil,
           map(),
           [ReqLLM.Tool.t()],
           approval_mode(),
@@ -1112,36 +1125,68 @@ defmodule MingaAgent.Providers.Native do
           hook_runner()
         ) ::
           {String.t(), boolean(), approval_mode()}
-  defp execute_with_approval(provider_pid, tool_call, available_tools, mode, config, hook_runner) do
-    # Per-tool permissions override the global approval mode.
-    case tool_permission(tool_call.name, config) do
-      :allow ->
-        {result, is_error} =
-          run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+  defp execute_with_approval(
+         provider_pid,
+         session_pid,
+         tool_call,
+         available_tools,
+         mode,
+         config,
+         hook_runner
+       ) do
+    args = tool_call.arguments || %{}
 
-        {result, is_error, mode}
+    if plan_mode_blocks_tool?(session_pid, tool_call.name, args) do
+      message = PlanMode.refusal_message(tool_call.name)
+      emit_plan_mode_refusal(session_pid, message)
+      {message, true, mode}
+    else
+      # Per-tool permissions override the global approval mode.
+      case tool_permission(tool_call.name, config) do
+        :allow ->
+          {result, is_error} =
+            run_single_tool(
+              tool_call,
+              available_tools,
+              provider_pid,
+              session_pid,
+              config,
+              hook_runner
+            )
 
-      :deny ->
-        {"Tool '#{tool_call.name}' is denied by per-tool permissions", true, mode}
+          {result, is_error, mode}
 
-      :ask ->
-        request_approval(provider_pid, tool_call, available_tools, config, hook_runner)
+        :deny ->
+          {"Tool '#{tool_call.name}' is denied by per-tool permissions", true, mode}
 
-      nil ->
-        # No per-tool override; fall through to global approval mode.
-        execute_with_global_mode(
-          provider_pid,
-          tool_call,
-          available_tools,
-          mode,
-          config,
-          hook_runner
-        )
+        :ask ->
+          request_approval(
+            provider_pid,
+            session_pid,
+            tool_call,
+            available_tools,
+            config,
+            hook_runner
+          )
+
+        nil ->
+          # No per-tool override; fall through to global approval mode.
+          execute_with_global_mode(
+            provider_pid,
+            session_pid,
+            tool_call,
+            available_tools,
+            mode,
+            config,
+            hook_runner
+          )
+      end
     end
   end
 
   @spec execute_with_global_mode(
           pid(),
+          pid() | nil,
           map(),
           [ReqLLM.Tool.t()],
           approval_mode(),
@@ -1151,6 +1196,7 @@ defmodule MingaAgent.Providers.Native do
           {String.t(), boolean(), approval_mode()}
   defp execute_with_global_mode(
          provider_pid,
+         session_pid,
          tool_call,
          available_tools,
          :none,
@@ -1158,13 +1204,14 @@ defmodule MingaAgent.Providers.Native do
          hook_runner
        ) do
     {result, is_error} =
-      run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+      run_single_tool(tool_call, available_tools, provider_pid, session_pid, config, hook_runner)
 
     {result, is_error, :none}
   end
 
   defp execute_with_global_mode(
          provider_pid,
+         session_pid,
          tool_call,
          available_tools,
          :approve_all,
@@ -1172,24 +1219,26 @@ defmodule MingaAgent.Providers.Native do
          hook_runner
        ) do
     {result, is_error} =
-      run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+      run_single_tool(tool_call, available_tools, provider_pid, session_pid, config, hook_runner)
 
     {result, is_error, :approve_all}
   end
 
   defp execute_with_global_mode(
          provider_pid,
+         session_pid,
          tool_call,
          available_tools,
          :ask_all,
          config,
          hook_runner
        ) do
-    request_approval(provider_pid, tool_call, available_tools, config, hook_runner)
+    request_approval(provider_pid, session_pid, tool_call, available_tools, config, hook_runner)
   end
 
   defp execute_with_global_mode(
          provider_pid,
+         session_pid,
          tool_call,
          available_tools,
          :ask,
@@ -1197,10 +1246,17 @@ defmodule MingaAgent.Providers.Native do
          hook_runner
        ) do
     if Tools.destructive?(tool_call.name, tool_call.arguments || %{}) do
-      request_approval(provider_pid, tool_call, available_tools, config, hook_runner)
+      request_approval(provider_pid, session_pid, tool_call, available_tools, config, hook_runner)
     else
       {result, is_error} =
-        run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+        run_single_tool(
+          tool_call,
+          available_tools,
+          provider_pid,
+          session_pid,
+          config,
+          hook_runner
+        )
 
       {result, is_error, :ask}
     end
@@ -1236,9 +1292,23 @@ defmodule MingaAgent.Providers.Native do
     end
   end
 
-  @spec request_approval(pid(), map(), [ReqLLM.Tool.t()], AgentConfig.t(), hook_runner()) ::
+  @spec request_approval(
+          pid(),
+          pid() | nil,
+          map(),
+          [ReqLLM.Tool.t()],
+          AgentConfig.t(),
+          hook_runner()
+        ) ::
           {String.t(), boolean(), :ask | :approve_all}
-  defp request_approval(provider_pid, tool_call, available_tools, config, hook_runner) do
+  defp request_approval(
+         provider_pid,
+         session_pid,
+         tool_call,
+         available_tools,
+         config,
+         hook_runner
+       ) do
     # Send approval request through the event pipeline (Task → Provider → Session)
     send(
       provider_pid,
@@ -1255,13 +1325,27 @@ defmodule MingaAgent.Providers.Native do
     receive do
       {:tool_approval_response, _tool_call_id, :approve} ->
         {result, is_error} =
-          run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+          run_single_tool(
+            tool_call,
+            available_tools,
+            provider_pid,
+            session_pid,
+            config,
+            hook_runner
+          )
 
         {result, is_error, :ask}
 
       {:tool_approval_response, _tool_call_id, :approve_all} ->
         {result, is_error} =
-          run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+          run_single_tool(
+            tool_call,
+            available_tools,
+            provider_pid,
+            session_pid,
+            config,
+            hook_runner
+          )
 
         {result, is_error, :approve_all}
 
@@ -1315,9 +1399,32 @@ defmodule MingaAgent.Providers.Native do
 
   defp maybe_emit_file_changed(_provider_pid, _tool_call, _before_content, _is_error), do: :ok
 
-  @spec run_single_tool(map(), [ReqLLM.Tool.t()], pid(), AgentConfig.t(), hook_runner()) ::
+  # Re-checks plan mode after approval: the user may have entered /plan between
+  # the approval prompt and the approval response.
+  @spec run_single_tool(
+          map(),
+          [ReqLLM.Tool.t()],
+          pid(),
+          pid() | nil,
+          AgentConfig.t(),
+          hook_runner()
+        ) ::
           {String.t(), boolean()}
-  defp run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner) do
+  defp run_single_tool(tool_call, available_tools, provider_pid, session_pid, config, hook_runner) do
+    args = tool_call.arguments || %{}
+
+    if plan_mode_blocks_tool?(session_pid, tool_call.name, args) do
+      message = PlanMode.refusal_message(tool_call.name)
+      emit_plan_mode_refusal(session_pid, message)
+      {message, true}
+    else
+      run_single_tool_unchecked(tool_call, available_tools, provider_pid, config, hook_runner)
+    end
+  end
+
+  @spec run_single_tool_unchecked(map(), [ReqLLM.Tool.t()], pid(), AgentConfig.t(), hook_runner()) ::
+          {String.t(), boolean()}
+  defp run_single_tool_unchecked(tool_call, available_tools, provider_pid, config, hook_runner) do
     case Enum.find(available_tools, fn t -> t.name == tool_call.name end) do
       nil ->
         {"Tool '#{tool_call.name}' not found", true}
@@ -1350,6 +1457,28 @@ defmodule MingaAgent.Providers.Native do
     send(provider_pid, {:agent_event, %Event.Error{message: HookResult.message(result)}})
     :ok
   end
+
+  @spec plan_mode_blocks_tool?(pid() | nil, String.t(), map()) :: boolean()
+  defp plan_mode_blocks_tool?(session_pid, name, args) when is_pid(session_pid) do
+    Session.status(session_pid) == :plan and PlanMode.blocked?(name, args)
+  catch
+    # Session crashed; fail-closed so destructive tools stay blocked.
+    :exit, _ -> PlanMode.blocked?(name, args)
+  end
+
+  defp plan_mode_blocks_tool?(_session_pid, _name, _args), do: false
+
+  @spec emit_plan_mode_refusal(pid() | nil, String.t()) :: :ok
+  defp emit_plan_mode_refusal(session_pid, message) when is_pid(session_pid) do
+    send(
+      session_pid,
+      {:agent_provider_event, %Event.SystemMessage{message: message, level: :info}}
+    )
+
+    :ok
+  end
+
+  defp emit_plan_mode_refusal(_session_pid, _message), do: :ok
 
   @spec execute_found_tool(ReqLLM.Tool.t(), map(), pid() | nil) :: {String.t(), boolean()}
   defp execute_found_tool(_tool, %{name: "shell"} = tool_call, provider_pid)

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -1463,6 +1463,7 @@ defmodule MingaAgent.Providers.Native do
     Session.status(session_pid) == :plan and PlanMode.blocked?(name, args)
   catch
     # Session crashed; fail-closed so destructive tools stay blocked.
+    # Session crashed; fail-closed so destructive tools stay blocked.
     :exit, _ -> PlanMode.blocked?(name, args)
   end
 

--- a/lib/minga_agent/runtime_state.ex
+++ b/lib/minga_agent/runtime_state.ex
@@ -12,7 +12,7 @@ defmodule MingaAgent.RuntimeState do
   """
 
   @typedoc "Agent lifecycle status."
-  @type status :: :idle | :thinking | :tool_executing | :error | nil
+  @type status :: :idle | :plan | :thinking | :tool_executing | :error | nil
 
   @typedoc "Domain-only agent runtime state."
   @type t :: %__MODULE__{

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -652,7 +652,7 @@ defmodule MingaAgent.Session do
     state = %{state | messages: messages, pending_approval: nil}
     state = append_system_message(state, "Aborted", :info)
     state = notify_messages_changed(state)
-    state = set_status(state, :idle)
+    state = set_idle_or_plan(state)
     {:reply, :ok, state}
   end
 
@@ -698,10 +698,14 @@ defmodule MingaAgent.Session do
     {:reply, :ok, state}
   end
 
-  def handle_call(:enter_exec, _from, state) do
+  def handle_call(:enter_exec, _from, %{status: :plan} = state) do
     state = append_system_message(state, exec_mode_message(), :info)
     state = notify_messages_changed(state)
     state = set_status(state, :idle)
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:enter_exec, _from, state) do
     {:reply, :ok, state}
   end
 
@@ -1014,8 +1018,8 @@ defmodule MingaAgent.Session do
 
       {:error, reason} ->
         Minga.Log.error(:agent, "[Agent.Session] failed to start provider: #{inspect(reason)}")
-        state = set_status(state, :error)
         state = %{state | error_message: format_error(reason)}
+        state = set_error_status(state)
         broadcast(state, {:error, state.error_message})
         {:noreply, state}
     end
@@ -1028,8 +1032,8 @@ defmodule MingaAgent.Session do
 
   def handle_info({:DOWN, _ref, :process, pid, reason}, %{provider: pid} = state) do
     Minga.Log.warning(:agent, "[Agent.Session] provider process died: #{inspect(reason)}")
-    state = set_status(state, :error)
     state = %{state | provider: nil, error_message: "Agent provider crashed"}
+    state = set_error_status(state)
     broadcast(state, {:error, state.error_message})
 
     # Try to restart the provider after a brief delay
@@ -1210,7 +1214,7 @@ defmodule MingaAgent.Session do
 
   defp handle_provider_event(%Event.Error{message: message}, state) do
     Notifier.notify(:error, message)
-    state = set_status(state, :error)
+    state = set_error_status(state)
     state = %{state | error_message: message}
     state = append_system_message(state, "Error: #{message}", :error)
     broadcast(state, {:error, message})
@@ -1335,6 +1339,10 @@ defmodule MingaAgent.Session do
   @spec set_idle_or_plan(state()) :: state()
   defp set_idle_or_plan(%{status: :plan} = state), do: state
   defp set_idle_or_plan(state), do: set_status(state, :idle)
+
+  @spec set_error_status(state()) :: state()
+  defp set_error_status(%{status: :plan} = state), do: state
+  defp set_error_status(state), do: set_status(state, :error)
 
   @spec plan_mode_message() :: String.t()
   defp plan_mode_message do

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -35,7 +35,7 @@ defmodule MingaAgent.Session do
   alias MingaAgent.TurnUsage
 
   @typedoc "Agent session status."
-  @type status :: :idle | :thinking | :tool_executing | :error
+  @type status :: :idle | :plan | :thinking | :tool_executing | :error
 
   @typedoc "Pending tool approval data."
   @type pending_approval :: MingaAgent.ToolApproval.t()
@@ -108,6 +108,18 @@ defmodule MingaAgent.Session do
   @spec status(GenServer.server()) :: status()
   def status(session) do
     GenServer.call(session, :status)
+  end
+
+  @doc "Enters plan mode, where destructive tools are refused before execution."
+  @spec enter_plan(GenServer.server()) :: :ok
+  def enter_plan(session) do
+    GenServer.call(session, :enter_plan)
+  end
+
+  @doc "Leaves plan mode and returns the session to execution mode."
+  @spec enter_exec(GenServer.server()) :: :ok
+  def enter_exec(session) do
+    GenServer.call(session, :enter_exec)
   end
 
   @doc "Returns the conversation messages."
@@ -677,6 +689,22 @@ defmodule MingaAgent.Session do
     {:reply, state.session_id, state}
   end
 
+  def handle_call(:enter_plan, _from, state) do
+    reject_pending_approval(state.pending_approval)
+    state = %{state | pending_approval: nil}
+    state = append_system_message(state, plan_mode_message(), :info)
+    state = notify_messages_changed(state)
+    state = set_status(state, :plan)
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:enter_exec, _from, state) do
+    state = append_system_message(state, exec_mode_message(), :info)
+    state = notify_messages_changed(state)
+    state = set_status(state, :idle)
+    {:reply, :ok, state}
+  end
+
   def handle_call({:load_session, session_id}, _from, state) do
     case SessionStore.load(session_id) do
       {:ok, data} ->
@@ -1029,7 +1057,7 @@ defmodule MingaAgent.Session do
   @spec handle_provider_event(Event.t(), state()) :: state()
   defp handle_provider_event(%Event.AgentStart{}, state) do
     state = %{state | pending_approval: nil}
-    set_status(state, :thinking)
+    set_working_status(state, :thinking)
   end
 
   defp handle_provider_event(%Event.AgentEnd{usage: usage}, state) do
@@ -1055,7 +1083,7 @@ defmodule MingaAgent.Session do
 
     case all_pending do
       [] ->
-        set_status(state, :idle)
+        set_idle_or_plan(state)
 
       pending ->
         # Auto-send queued messages as a new turn. Combine all pending
@@ -1073,7 +1101,7 @@ defmodule MingaAgent.Session do
             state
 
           {:error, _reason} ->
-            set_status(state, :idle)
+            set_idle_or_plan(state)
         end
     end
   end
@@ -1112,7 +1140,7 @@ defmodule MingaAgent.Session do
   defp handle_provider_event(%Event.ToolStart{} = event, state) do
     msg = Message.tool_call(event.tool_call_id, event.name, event.args)
     state = append_msg(state, msg)
-    state = set_status(state, :tool_executing)
+    state = set_working_status(state, :tool_executing)
     broadcast(state, {:tool_started, event.name, event.args})
     notify_messages_changed(state)
   end
@@ -1121,6 +1149,11 @@ defmodule MingaAgent.Session do
     broadcast(state, {:file_changed, event.path, event.before_content, event.after_content})
     state = record_file_touch(state, event.path, event.before_content, event.after_content)
     state
+  end
+
+  defp handle_provider_event(%Event.SystemMessage{} = event, state) do
+    state = append_system_message(state, event.message, event.level)
+    notify_messages_changed(state)
   end
 
   defp handle_provider_event(%Event.ToolApproval{} = event, state) do
@@ -1280,11 +1313,37 @@ defmodule MingaAgent.Session do
 
   # ── Status management ──────────────────────────────────────────────────────
 
+  @spec reject_pending_approval(pending_approval() | nil) :: :ok
+  defp reject_pending_approval(nil), do: :ok
+
+  defp reject_pending_approval(%{tool_call_id: tool_call_id, reply_to: reply_to}) do
+    send(reply_to, {:tool_approval_response, tool_call_id, :reject})
+    :ok
+  end
+
   @spec set_status(state(), status()) :: state()
   defp set_status(state, new_status) do
     state = %{state | status: new_status}
     broadcast(state, {:status_changed, new_status})
     state
+  end
+
+  @spec set_working_status(state(), :thinking | :tool_executing) :: state()
+  defp set_working_status(%{status: :plan} = state, _new_status), do: state
+  defp set_working_status(state, new_status), do: set_status(state, new_status)
+
+  @spec set_idle_or_plan(state()) :: state()
+  defp set_idle_or_plan(%{status: :plan} = state), do: state
+  defp set_idle_or_plan(state), do: set_status(state, :idle)
+
+  @spec plan_mode_message() :: String.t()
+  defp plan_mode_message do
+    "Plan mode enabled. Destructive tools are blocked before execution. Read-only and search tools still work. Use /exec when you are ready to make changes."
+  end
+
+  @spec exec_mode_message() :: String.t()
+  defp exec_mode_message do
+    "Execution mode enabled. Destructive tools can run again after normal approval checks. Use /plan to return to planning."
   end
 
   # ── Broadcasting ────────────────────────────────────────────────────────────

--- a/lib/minga_agent/tool/executor.ex
+++ b/lib/minga_agent/tool/executor.ex
@@ -31,12 +31,16 @@ defmodule MingaAgent.Tool.Executor do
   alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
   alias MingaAgent.Hooks.PreToolUsePayload
   alias MingaAgent.Hooks.Result, as: HookResult
+  alias MingaAgent.Tool.PlanMode
   alias MingaAgent.Tool.Registry
   alias MingaAgent.Tool.Spec
 
   @typedoc "Result of tool execution."
   @type result :: {:ok, term()} | {:error, term()} | {:needs_approval, Spec.t(), map()}
   @type hook_runner :: (MingaAgent.Hooks.Hook.t(), PreToolUsePayload.t() -> HookResult.t())
+
+  @typedoc "Execution mode: `:exec` allows all tools, `:plan` refuses destructive tools before approval."
+  @type execution_mode :: :exec | :plan
 
   @doc """
   Executes a tool by name with the given arguments.
@@ -56,18 +60,26 @@ defmodule MingaAgent.Tool.Executor do
   @spec execute(String.t(), map(), atom()) :: result()
   def execute(name, args, registry_table)
       when is_binary(name) and is_map(args) and is_atom(registry_table) do
-    execute(name, args, registry_table, [])
+    execute(name, args, registry_table, :exec)
+  end
+
+  @spec execute(String.t(), map(), atom(), execution_mode()) :: result()
+  def execute(name, args, registry_table, mode)
+      when is_binary(name) and is_map(args) and is_atom(registry_table) and
+             mode in [:exec, :plan] do
+    execute(name, args, registry_table, mode, [])
   end
 
   @doc false
-  @spec execute(String.t(), map(), atom(), keyword()) :: result()
-  def execute(name, args, registry_table, opts)
-      when is_binary(name) and is_map(args) and is_atom(registry_table) and is_list(opts) do
+  @spec execute(String.t(), map(), atom(), execution_mode(), keyword()) :: result()
+  def execute(name, args, registry_table, mode, opts)
+      when is_binary(name) and is_map(args) and is_atom(registry_table) and
+             mode in [:exec, :plan] and is_list(opts) do
     config = Keyword.get_lazy(opts, :config, &AgentConfig.resolve/0)
     hook_runner = Keyword.get(opts, :hook_runner, &CommandRunner.run_pre_tool_use/2)
 
     case Registry.lookup(registry_table, name) do
-      {:ok, spec} -> check_and_execute(spec, args, config, hook_runner)
+      {:ok, spec} -> check_and_execute(spec, args, mode, config, hook_runner)
       :error -> {:error, {:tool_not_found, name}}
     end
   end
@@ -82,31 +94,52 @@ defmodule MingaAgent.Tool.Executor do
   """
   @spec execute_approved(Spec.t(), map()) :: {:ok, term()} | {:error, term()}
   def execute_approved(%Spec{} = spec, args) when is_map(args) do
-    execute_approved(spec, args, [])
+    execute_approved(spec, args, :exec)
   end
 
-  @doc false
-  @spec execute_approved(Spec.t(), map(), keyword()) :: {:ok, term()} | {:error, term()}
-  def execute_approved(%Spec{} = spec, args, opts) when is_map(args) and is_list(opts) do
-    config = Keyword.get_lazy(opts, :config, &AgentConfig.resolve/0)
-    hook_runner = Keyword.get(opts, :hook_runner, &CommandRunner.run_pre_tool_use/2)
-    run_callback(spec, args, config, hook_runner)
+  @doc """
+  Executes an already-approved tool in the given execution mode.
+
+  Plan mode still refuses destructive tools even when a prior approval exists.
+  """
+  @spec execute_approved(Spec.t(), map(), execution_mode()) :: {:ok, term()} | {:error, term()}
+  def execute_approved(%Spec{} = spec, args, mode) when is_map(args) and mode in [:exec, :plan] do
+    if plan_mode_blocked?(mode, spec.name, args) do
+      {:error, PlanMode.refusal(spec.name)}
+    else
+      config = AgentConfig.resolve()
+      hook_runner = &CommandRunner.run_pre_tool_use/2
+      run_callback(spec, args, config, hook_runner)
+    end
   end
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
-  @spec check_and_execute(Spec.t(), map(), AgentConfig.t(), hook_runner()) :: result()
-  defp check_and_execute(%Spec{approval_level: :deny} = spec, _args, _config, _hook_runner) do
+  @spec check_and_execute(Spec.t(), map(), execution_mode(), AgentConfig.t(), hook_runner()) ::
+          result()
+  defp check_and_execute(%Spec{} = spec, args, :plan, config, hook_runner) do
+    if plan_mode_blocked?(:plan, spec.name, args) do
+      {:error, PlanMode.refusal(spec.name)}
+    else
+      check_and_execute(spec, args, :exec, config, hook_runner)
+    end
+  end
+
+  defp check_and_execute(%Spec{approval_level: :deny} = spec, _args, :exec, _config, _hook_runner) do
     {:error, {:tool_denied, spec.name}}
   end
 
-  defp check_and_execute(%Spec{approval_level: :ask} = spec, args, _config, _hook_runner) do
+  defp check_and_execute(%Spec{approval_level: :ask} = spec, args, :exec, _config, _hook_runner) do
     {:needs_approval, spec, args}
   end
 
-  defp check_and_execute(%Spec{approval_level: :auto} = spec, args, config, hook_runner) do
+  defp check_and_execute(%Spec{approval_level: :auto} = spec, args, :exec, config, hook_runner) do
     run_callback(spec, args, config, hook_runner)
   end
+
+  @spec plan_mode_blocked?(execution_mode(), String.t(), map()) :: boolean()
+  defp plan_mode_blocked?(:plan, name, args), do: PlanMode.blocked?(name, args)
+  defp plan_mode_blocked?(:exec, _name, _args), do: false
 
   @spec run_callback(Spec.t(), map(), AgentConfig.t(), hook_runner()) ::
           {:ok, term()} | {:error, term()}

--- a/lib/minga_agent/tool/executor.ex
+++ b/lib/minga_agent/tool/executor.ex
@@ -54,7 +54,7 @@ defmodule MingaAgent.Tool.Executor do
   """
   @spec execute(String.t(), map()) :: result()
   def execute(name, args) when is_binary(name) and is_map(args) do
-    execute(name, args, MingaAgent.Tool.Registry, [])
+    execute(name, args, MingaAgent.Tool.Registry, :exec)
   end
 
   @spec execute(String.t(), map(), atom()) :: result()

--- a/lib/minga_agent/tool/plan_mode.ex
+++ b/lib/minga_agent/tool/plan_mode.ex
@@ -1,0 +1,30 @@
+defmodule MingaAgent.Tool.PlanMode do
+  @moduledoc """
+  Plan-mode guard for agent tool execution.
+
+  Plan mode is a session-level safety state. While active, read-only tools keep working, but destructive tools are refused before their callbacks run.
+  """
+
+  alias MingaAgent.Tools
+
+  @typedoc "Tool refusal reason returned to callers."
+  @type refusal :: {:plan_mode_refused, String.t(), String.t()}
+
+  @doc "Returns true when the tool call must be blocked in plan mode."
+  @spec blocked?(String.t(), map()) :: boolean()
+  def blocked?(name, args) when is_binary(name) and is_map(args) do
+    Tools.destructive?(name, args)
+  end
+
+  @doc "Returns the user-facing refusal message for a blocked plan-mode tool call."
+  @spec refusal_message(String.t()) :: String.t()
+  def refusal_message(name) when is_binary(name) do
+    "Plan mode is active. Refusing destructive tool #{name}. Use /exec to leave plan mode before running tools that change files, shell state, git state, or LSP edits."
+  end
+
+  @doc "Returns the structured refusal tuple for a blocked plan-mode tool call."
+  @spec refusal(String.t()) :: refusal()
+  def refusal(name) when is_binary(name) do
+    {:plan_mode_refused, name, refusal_message(name)}
+  end
+end

--- a/lib/minga_agent/tool/plan_mode.ex
+++ b/lib/minga_agent/tool/plan_mode.ex
@@ -8,7 +8,7 @@ defmodule MingaAgent.Tool.PlanMode do
   alias MingaAgent.Tools
 
   @typedoc "Tool refusal reason returned to callers."
-  @type refusal :: {:plan_mode_refused, String.t(), String.t()}
+  @type refusal :: {:plan_mode_refused, String.t()}
 
   @doc "Returns true when the tool call must be blocked in plan mode."
   @spec blocked?(String.t(), map()) :: boolean()
@@ -25,6 +25,6 @@ defmodule MingaAgent.Tool.PlanMode do
   @doc "Returns the structured refusal tuple for a blocked plan-mode tool call."
   @spec refusal(String.t()) :: refusal()
   def refusal(name) when is_binary(name) do
-    {:plan_mode_refused, name, refusal_message(name)}
+    {:plan_mode_refused, refusal_message(name)}
   end
 end

--- a/lib/minga_agent/tools.ex
+++ b/lib/minga_agent/tools.ex
@@ -67,14 +67,13 @@ defmodule MingaAgent.Tools do
           fork_store: pid() | nil
         ]
 
-  @default_destructive_tools ~w(write_file edit_file multi_edit multi_edit_file shell git_stage git_commit rename)
+  @default_destructive_tools ~w(write_file edit_file multi_edit_file shell git_stage git_commit rename)
 
   @doc """
   Returns true if the named tool is classified as destructive.
 
-  Reads the configured list from `:agent_destructive_tools` (defaults to
-  `["write_file", "edit_file", "shell"]`). Accepts an optional list override
-  for testing without starting the Options agent.
+  Reads the configured list from `:agent_destructive_tools`. Accepts an
+  optional list override for testing without starting the Options agent.
 
   Some tools have conditional destructiveness based on their arguments.
   Pass the tool arguments map to check parameter-dependent cases like

--- a/lib/minga_agent/tools.ex
+++ b/lib/minga_agent/tools.ex
@@ -67,7 +67,7 @@ defmodule MingaAgent.Tools do
           fork_store: pid() | nil
         ]
 
-  @default_destructive_tools ~w(write_file edit_file multi_edit_file shell git_stage git_commit rename)
+  @default_destructive_tools ~w(write_file edit_file multi_edit multi_edit_file shell git_stage git_commit rename)
 
   @doc """
   Returns true if the named tool is classified as destructive.

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -18,6 +18,7 @@ defmodule MingaEditor.Agent.SlashCommand do
   alias Minga.Config
   alias MingaEditor.Commands.Agent, as: AgentCommands
   alias MingaEditor.PickerUI
+  alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
 
   @typedoc "Editor state (same as EditorState.t())."
@@ -39,6 +40,8 @@ defmodule MingaEditor.Agent.SlashCommand do
     },
     %Command{name: "model", description: "Set the model: /model <name>"},
     %Command{name: "help", description: "Show available slash commands"},
+    %Command{name: "plan", description: "Enter plan mode (destructive tools blocked)"},
+    %Command{name: "exec", description: "Leave plan mode and allow execution"},
     %Command{name: "sessions", description: "Browse and switch between sessions"},
     %Command{
       name: "auth",
@@ -128,6 +131,10 @@ defmodule MingaEditor.Agent.SlashCommand do
   defp dispatch(state, "model", args), do: do_model(state, args)
   defp dispatch(state, "help", _args), do: {:ok, do_help(state)}
   defp dispatch(state, "?", _args), do: {:ok, do_help(state)}
+  defp dispatch(state, "plan", _args), do: do_plan(state)
+  defp dispatch(state, "exec", _args), do: do_exec(state)
+  defp dispatch(state, "skill:plan", _args), do: do_plan(state)
+  defp dispatch(state, "skill:off:plan", _args), do: do_exec(state)
   defp dispatch(state, "sessions", _args), do: {:ok, do_sessions(state)}
   defp dispatch(state, "auth", args), do: {:ok, do_auth(state, args)}
   defp dispatch(state, "instructions", _args), do: {:ok, do_instructions(state)}
@@ -210,6 +217,34 @@ defmodule MingaEditor.Agent.SlashCommand do
     end
 
     MingaEditor.State.set_status(state, "Commands listed in chat")
+  end
+
+  @spec do_plan(state()) :: {:ok, state()} | {:error, String.t()}
+  defp do_plan(state) do
+    with {:ok, session} <- require_session(state) do
+      :ok = Session.enter_plan(session)
+
+      state =
+        state
+        |> AgentAccess.update_agent(&AgentState.set_status(&1, :plan))
+        |> MingaEditor.State.set_status("Plan mode enabled")
+
+      {:ok, state}
+    end
+  end
+
+  @spec do_exec(state()) :: {:ok, state()} | {:error, String.t()}
+  defp do_exec(state) do
+    with {:ok, session} <- require_session(state) do
+      :ok = Session.enter_exec(session)
+
+      state =
+        state
+        |> AgentAccess.update_agent(&AgentState.set_status(&1, :idle))
+        |> MingaEditor.State.set_status("Execution mode enabled")
+
+      {:ok, state}
+    end
   end
 
   @spec do_sessions(state()) :: state()

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -650,6 +650,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   defp encode_agent_status(:thinking), do: 1
   defp encode_agent_status(:tool_executing), do: 2
   defp encode_agent_status(:error), do: 3
+  defp encode_agent_status(:plan), do: 4
   defp encode_agent_status(_), do: 0
 
   @spec tab_icon(Tab.t()) :: String.t()
@@ -669,7 +670,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     + tab_count(2) + label_len(1) + label(label_len) + icon_len(1) + icon(icon_len)
 
   Kind: 0 = manual, 1 = agent.
-  Agent status: 0 = idle, 1 = thinking, 2 = tool_executing, 3 = error.
+  Agent status: 0 = idle, 1 = thinking, 2 = tool_executing, 3 = error, 4 = plan.
   """
   @spec encode_gui_agent_groups(TabBar.t()) :: binary()
   def encode_gui_agent_groups(%TabBar{} = tb) do
@@ -1328,6 +1329,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   defp encode_agent_session_status(:thinking), do: 1
   defp encode_agent_session_status(:tool_executing), do: 2
   defp encode_agent_session_status(:error), do: 3
+  defp encode_agent_session_status(:plan), do: 4
   defp encode_agent_session_status(_), do: 0
 
   # ── Picker ──

--- a/lib/minga_editor/shell/board/card.ex
+++ b/lib/minga_editor/shell/board/card.ex
@@ -110,12 +110,13 @@ defmodule MingaEditor.Shell.Board.Card do
   @doc """
   Maps an agent session lifecycle status to the corresponding card status.
 
-  Agent sessions speak in `Tab.agent_status` (`:idle | :thinking | :tool_executing
+  Agent sessions speak in `Tab.agent_status` (`:idle | :plan | :thinking | :tool_executing
   | :error | nil`); cards have a richer status vocabulary intended for the Board
   grid. This mapping is the single source of truth so foreground (active session)
   and background (non-active session) routing apply the same translation.
   """
   @spec from_agent_status(MingaEditor.State.Tab.agent_status()) :: status()
+  def from_agent_status(:plan), do: :needs_you
   def from_agent_status(:thinking), do: :working
   def from_agent_status(:tool_executing), do: :iterating
   def from_agent_status(:error), do: :errored

--- a/lib/minga_editor/shell/traditional/modeline.ex
+++ b/lib/minga_editor/shell/traditional/modeline.ex
@@ -251,6 +251,7 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
     case {status, colors} do
       {nil, _} -> []
       {:idle, c} -> [{" ◯ ", c.status_idle, bar_bg, []}]
+      {:plan, c} -> [{" PLAN ", c.status_thinking, bar_bg, bold: true}]
       {:thinking, c} -> [{" ⟳ ", c.status_thinking, bar_bg, bold: true}]
       {:tool_executing, c} -> [{" ⚡ ", c.status_tool, bar_bg, bold: true}]
       {:error, c} -> [{" ✗ ", c.status_error, bar_bg, bold: true}]

--- a/lib/minga_editor/shell/traditional/tab_bar_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tab_bar_renderer.ex
@@ -435,6 +435,7 @@ defmodule MingaEditor.Shell.Traditional.TabBarRenderer do
   defp tab_dirty_marker(_, _), do: ""
 
   @spec agent_status_indicator(Tab.t()) :: String.t()
+  defp agent_status_indicator(%Tab{kind: :agent, agent_status: :plan}), do: " ✎"
   defp agent_status_indicator(%Tab{kind: :agent, agent_status: :thinking}), do: " \u{25CF}"
   defp agent_status_indicator(%Tab{kind: :agent, agent_status: :tool_executing}), do: " \u{2699}"
   defp agent_status_indicator(%Tab{kind: :agent, agent_status: :error}), do: " \u{2717}"

--- a/lib/minga_editor/state/agent_group.ex
+++ b/lib/minga_editor/state/agent_group.ex
@@ -17,7 +17,7 @@ defmodule MingaEditor.State.AgentGroup do
   """
 
   @typedoc "Agent status for group display."
-  @type agent_status :: :idle | :thinking | :tool_executing | :error | nil
+  @type agent_status :: :idle | :plan | :thinking | :tool_executing | :error | nil
 
   @typedoc "SF Symbol name for group icon."
   @type icon :: String.t()

--- a/lib/minga_editor/state/tab.ex
+++ b/lib/minga_editor/state/tab.ex
@@ -44,7 +44,7 @@ defmodule MingaEditor.State.Tab do
         }
 
   @typedoc "Agent tab status (nil for file tabs)."
-  @type agent_status :: :idle | :thinking | :tool_executing | :error | nil
+  @type agent_status :: :idle | :plan | :thinking | :tool_executing | :error | nil
 
   @typedoc "Workspace group id. 0 = manual/ungrouped workspace."
   @type group_id :: non_neg_integer()

--- a/lib/minga_editor/ui/picker/agent_group_source.ex
+++ b/lib/minga_editor/ui/picker/agent_group_source.ex
@@ -88,6 +88,7 @@ defmodule MingaEditor.UI.Picker.AgentGroupSource do
   defp agent_status_text(%AgentGroup{agent_status: :tool_executing}),
     do: " \u{2699} executing"
 
+  defp agent_status_text(%AgentGroup{agent_status: :plan}), do: " ✎ plan"
   defp agent_status_text(%AgentGroup{agent_status: :error}), do: " \u{26A0} error"
   defp agent_status_text(%AgentGroup{agent_status: :idle}), do: " \u{2713} idle"
   defp agent_status_text(_), do: ""
@@ -99,6 +100,7 @@ defmodule MingaEditor.UI.Picker.AgentGroupSource do
   defp status_annotation(%AgentGroup{agent_status: :tool_executing}),
     do: "\u{2699} executing"
 
+  defp status_annotation(%AgentGroup{agent_status: :plan}), do: "✎ plan"
   defp status_annotation(%AgentGroup{agent_status: :error}), do: "\u{26A0} error"
   defp status_annotation(%AgentGroup{agent_status: :idle}), do: "\u{2713} idle"
   defp status_annotation(_), do: nil

--- a/macos/Sources/Views/StatusBarView.swift
+++ b/macos/Sources/Views/StatusBarView.swift
@@ -166,6 +166,7 @@ final class StatusBarState {
         case 1: return "thinking"
         case 2: return "executing"
         case 3: return "error"
+        case 4: return "plan"
         default: return "idle"
         }
     }
@@ -311,6 +312,11 @@ struct StatusBarView: View {
             Image(systemName: "exclamationmark.circle.fill")
                 .font(.system(size: 9))
                 .foregroundStyle(theme.gutterErrorFg)
+                .frame(width: 14, height: barHeight)
+        case 4: // plan
+            Image(systemName: "pencil.and.outline")
+                .font(.system(size: 9))
+                .foregroundStyle(theme.agentStatusNeedsYou)
                 .frame(width: 14, height: barHeight)
         default: // idle: show nothing
             EmptyView()

--- a/macos/Sources/Views/TabBarView.swift
+++ b/macos/Sources/Views/TabBarView.swift
@@ -373,6 +373,7 @@ struct TabBarView: View {
         case 1: return accent   // thinking
         case 2: return accent   // tool_executing
         case 3: return Color.red  // error
+        case 4: return theme.agentStatusNeedsYou  // plan
         default: return theme.tabInactiveFg  // idle
         }
     }

--- a/test/minga_agent/runtime_state_test.exs
+++ b/test/minga_agent/runtime_state_test.exs
@@ -13,11 +13,17 @@ defmodule MingaAgent.RuntimeStateTest do
       rt =
         %RuntimeState{}
         |> RuntimeState.set_status(:idle)
+        |> RuntimeState.set_status(:plan)
         |> RuntimeState.set_status(:thinking)
         |> RuntimeState.set_status(:tool_executing)
         |> RuntimeState.set_status(:idle)
 
       assert rt.status == :idle
+    end
+
+    test "supports plan mode" do
+      rt = %RuntimeState{} |> RuntimeState.set_status(:plan)
+      assert rt.status == :plan
     end
   end
 
@@ -32,6 +38,10 @@ defmodule MingaAgent.RuntimeStateTest do
 
     test "false for :idle" do
       refute RuntimeState.busy?(%RuntimeState{status: :idle})
+    end
+
+    test "false for :plan" do
+      refute RuntimeState.busy?(%RuntimeState{status: :plan})
     end
 
     test "false for :error" do

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -216,7 +216,7 @@ defmodule MingaAgent.SessionTest do
     defp execution_mode(_status), do: :exec
 
     @spec maybe_emit_plan_refusal(pid(), Executor.result()) :: :ok
-    defp maybe_emit_plan_refusal(subscriber, {:error, {:plan_mode_refused, _name, message}}) do
+    defp maybe_emit_plan_refusal(subscriber, {:error, {:plan_mode_refused, message}}) do
       send(
         subscriber,
         {:agent_provider_event, %Event.SystemMessage{message: message, level: :info}}
@@ -307,8 +307,7 @@ defmodule MingaAgent.SessionTest do
       assert :ok = Session.enter_plan(session)
       assert :ok = Session.send_prompt(session, "write a file")
 
-      assert_receive {:provider_tool_result,
-                      {:error, {:plan_mode_refused, "write_file", message}}},
+      assert_receive {:provider_tool_result, {:error, {:plan_mode_refused, message}}},
                      200
 
       assert message =~ "Plan mode"
@@ -331,6 +330,46 @@ defmodule MingaAgent.SessionTest do
         {:agent_provider_event, %Event.ToolStart{tool_call_id: "tc", name: "read_file"}}
       )
 
+      assert Session.status(session) == :plan
+    end
+
+    test "AgentEnd preserves plan mode status" do
+      {:ok, session} =
+        Session.start_link(
+          provider: SlowMockProvider,
+          provider_opts: []
+        )
+
+      Session.subscribe(session)
+      assert :ok = Session.enter_plan(session)
+      assert :ok = Session.send_prompt(session, "hello")
+      SlowMockProvider.proceed(Session.get_provider(session))
+      assert_receive {:agent_event, _, :messages_changed}, 200
+      assert Session.status(session) == :plan
+    end
+
+    test "abort preserves plan mode", %{session: session} do
+      assert :ok = Session.enter_plan(session)
+      assert :ok = Session.abort(session)
+      assert Session.status(session) == :plan
+    end
+
+    test "enter_exec is a no-op when not in plan mode", %{session: session} do
+      msg_count_before = length(Session.messages(session))
+      assert :ok = Session.enter_exec(session)
+      assert Session.status(session) == :idle
+      assert length(Session.messages(session)) == msg_count_before
+    end
+
+    test "error event preserves plan mode", %{session: session} do
+      assert :ok = Session.enter_plan(session)
+
+      send(
+        session,
+        {:agent_provider_event, %Event.Error{message: "something broke"}}
+      )
+
+      # Sync via a GenServer.call to ensure the handle_info has been processed
       assert Session.status(session) == :plan
     end
   end

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -4,6 +4,9 @@ defmodule MingaAgent.SessionTest do
   alias MingaAgent.Event
   alias MingaAgent.Session
   alias MingaAgent.SessionStore
+  alias MingaAgent.Tool.Executor
+  alias MingaAgent.Tool.Registry
+  alias MingaAgent.Tool.Spec
 
   # ── Mock provider ──────────────────────────────────────────────────────────
 
@@ -138,6 +141,93 @@ defmodule MingaAgent.SessionTest do
     end
   end
 
+  defmodule PlanToolProvider do
+    @behaviour MingaAgent.Provider
+
+    use GenServer
+
+    @impl MingaAgent.Provider
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl MingaAgent.Provider
+    def send_prompt(pid, _text) do
+      GenServer.cast(pid, :attempt_write)
+      :ok
+    end
+
+    @impl MingaAgent.Provider
+    def abort(pid) do
+      GenServer.cast(pid, :abort)
+      :ok
+    end
+
+    @impl MingaAgent.Provider
+    def new_session(pid) do
+      GenServer.cast(pid, :new_session)
+      :ok
+    end
+
+    @impl MingaAgent.Provider
+    def get_state(_pid), do: {:ok, %{model: nil, is_streaming: false, token_usage: nil}}
+
+    @impl GenServer
+    def init(opts) do
+      subscriber = Keyword.fetch!(opts, :subscriber)
+      parent = Keyword.fetch!(opts, :parent)
+      registry = :"plan_tool_provider_#{System.unique_integer([:positive])}"
+
+      :ets.new(registry, [:named_table, :set, :public, read_concurrency: true])
+
+      spec =
+        Spec.new!(
+          name: "write_file",
+          description: "test write",
+          parameter_schema: %{},
+          callback: fn args ->
+            send(parent, {:write_callback_called, args})
+            {:ok, "wrote"}
+          end
+        )
+
+      Registry.register(registry, spec)
+      {:ok, %{subscriber: subscriber, parent: parent, registry: registry}}
+    end
+
+    @impl GenServer
+    def handle_cast(:attempt_write, state) do
+      result =
+        Executor.execute(
+          "write_file",
+          %{"path" => "plan-mode.txt", "content" => "changed"},
+          state.registry,
+          execution_mode(MingaAgent.Session.status(state.subscriber))
+        )
+
+      maybe_emit_plan_refusal(state.subscriber, result)
+      send(state.parent, {:provider_tool_result, result})
+      {:noreply, state}
+    end
+
+    def handle_cast(:abort, state), do: {:noreply, state}
+    def handle_cast(:new_session, state), do: {:noreply, state}
+
+    @spec execution_mode(MingaAgent.Session.status()) :: Executor.execution_mode()
+    defp execution_mode(:plan), do: :plan
+    defp execution_mode(_status), do: :exec
+
+    @spec maybe_emit_plan_refusal(pid(), Executor.result()) :: :ok
+    defp maybe_emit_plan_refusal(subscriber, {:error, {:plan_mode_refused, _name, message}}) do
+      send(
+        subscriber,
+        {:agent_provider_event, %Event.SystemMessage{message: message, level: :info}}
+      )
+
+      :ok
+    end
+
+    defp maybe_emit_plan_refusal(_subscriber, _result), do: :ok
+  end
+
   # ── Helpers ─────────────────────────────────────────────────────────────────
 
   # Waits for all provider events to be processed by the session after
@@ -178,6 +268,70 @@ defmodule MingaAgent.SessionTest do
       assert usage.input == 0
       assert usage.output == 0
       assert usage.cost == 0.0
+    end
+  end
+
+  describe "plan mode" do
+    test "enter_plan sets status, broadcasts, and writes a system message", %{session: session} do
+      assert :ok = Session.enter_plan(session)
+      assert Session.status(session) == :plan
+      assert_receive {:agent_event, _, {:status_changed, :plan}}, 200
+
+      assert Enum.any?(Session.messages(session), fn
+               {:system, text, :info} -> text =~ "Plan mode" and text =~ "/exec"
+               _ -> false
+             end)
+    end
+
+    test "enter_exec leaves plan mode and writes a system message", %{session: session} do
+      assert :ok = Session.enter_plan(session)
+      assert :ok = Session.enter_exec(session)
+      assert Session.status(session) == :idle
+      assert_receive {:agent_event, _, {:status_changed, :plan}}, 200
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, 200
+
+      assert Enum.any?(Session.messages(session), fn
+               {:system, text, :info} -> text =~ "Execution mode" and text =~ "/plan"
+               _ -> false
+             end)
+    end
+
+    test "provider write tool is refused through a real plan-mode session" do
+      {:ok, session} =
+        Session.start_link(
+          provider: PlanToolProvider,
+          provider_opts: [parent: self()]
+        )
+
+      Session.subscribe(session)
+      assert :ok = Session.enter_plan(session)
+      assert :ok = Session.send_prompt(session, "write a file")
+
+      assert_receive {:provider_tool_result,
+                      {:error, {:plan_mode_refused, "write_file", message}}},
+                     200
+
+      assert message =~ "Plan mode"
+      assert message =~ "write_file"
+      assert message =~ "/exec"
+      refute_receive {:write_callback_called, _args}, 20
+
+      assert Enum.any?(Session.messages(session), fn
+               {:system, text, :info} -> text == message
+               _ -> false
+             end)
+    end
+
+    test "provider working events do not leave plan mode", %{session: session} do
+      assert :ok = Session.enter_plan(session)
+      send(session, {:agent_provider_event, %Event.AgentStart{}})
+
+      send(
+        session,
+        {:agent_provider_event, %Event.ToolStart{tool_call_id: "tc", name: "read_file"}}
+      )
+
+      assert Session.status(session) == :plan
     end
   end
 

--- a/test/minga_agent/tool/executor_test.exs
+++ b/test/minga_agent/tool/executor_test.exs
@@ -114,7 +114,7 @@ defmodule MingaAgent.Tool.ExecutorTest do
       end
 
       assert {:ok, "success"} =
-               Executor.execute("echo", %{"msg" => "hello"}, table,
+               Executor.execute("echo", %{"msg" => "hello"}, table, :exec,
                  config: config,
                  hook_runner: runner
                )
@@ -138,7 +138,7 @@ defmodule MingaAgent.Tool.ExecutorTest do
       runner = fn ^hook, _payload -> Result.veto(hook, "blocked by policy", {:exit, 9}) end
 
       assert {:error, {:hook_veto, message}} =
-               Executor.execute("shell", %{"command" => "date"}, table,
+               Executor.execute("shell", %{"command" => "date"}, table, :exec,
                  config: config,
                  hook_runner: runner
                )

--- a/test/minga_agent/tool/executor_test.exs
+++ b/test/minga_agent/tool/executor_test.exs
@@ -159,7 +159,7 @@ defmodule MingaAgent.Tool.ExecutorTest do
         end
       )
 
-      assert {:error, {:plan_mode_refused, "write_file", message}} =
+      assert {:error, {:plan_mode_refused, message}} =
                Executor.execute("write_file", %{"path" => "x", "content" => "new"}, table, :plan)
 
       assert message =~ "Plan mode"
@@ -206,7 +206,7 @@ defmodule MingaAgent.Tool.ExecutorTest do
 
       assert_receive {:called, %{"path" => "x.ex"}}
 
-      assert {:error, {:plan_mode_refused, "code_actions", message}} =
+      assert {:error, {:plan_mode_refused, message}} =
                Executor.execute(
                  "code_actions",
                  %{"path" => "x.ex", "apply" => "Organize imports"},
@@ -230,7 +230,7 @@ defmodule MingaAgent.Tool.ExecutorTest do
           end
         )
 
-      assert {:error, {:plan_mode_refused, "git_commit", message}} =
+      assert {:error, {:plan_mode_refused, message}} =
                Executor.execute_approved(spec, %{"message" => "test"}, :plan)
 
       assert message =~ "git_commit"

--- a/test/minga_agent/tool/executor_test.exs
+++ b/test/minga_agent/tool/executor_test.exs
@@ -148,6 +148,96 @@ defmodule MingaAgent.Tool.ExecutorTest do
     end
   end
 
+  describe "plan mode" do
+    test "refuses destructive tools before the callback runs", %{table: table} do
+      parent = self()
+
+      register_tool(table, "write_file",
+        callback: fn args ->
+          send(parent, {:called, "write_file", args})
+          {:ok, "wrote"}
+        end
+      )
+
+      assert {:error, {:plan_mode_refused, "write_file", message}} =
+               Executor.execute("write_file", %{"path" => "x", "content" => "new"}, table, :plan)
+
+      assert message =~ "Plan mode"
+      assert message =~ "write_file"
+      assert message =~ "/exec"
+      refute_receive {:called, "write_file", _}, 20
+    end
+
+    test "allows read-only and search tools", %{table: table} do
+      parent = self()
+
+      register_tool(table, "read_file",
+        callback: fn _args ->
+          send(parent, {:called, "read_file"})
+          {:ok, "content"}
+        end
+      )
+
+      register_tool(table, "grep",
+        callback: fn _args ->
+          send(parent, {:called, "grep"})
+          {:ok, "matches"}
+        end
+      )
+
+      assert {:ok, "content"} = Executor.execute("read_file", %{"path" => "x"}, table, :plan)
+      assert {:ok, "matches"} = Executor.execute("grep", %{"pattern" => "x"}, table, :plan)
+      assert_receive {:called, "read_file"}
+      assert_receive {:called, "grep"}
+    end
+
+    test "refuses code actions only when applying changes", %{table: table} do
+      parent = self()
+
+      register_tool(table, "code_actions",
+        callback: fn args ->
+          send(parent, {:called, args})
+          {:ok, "actions"}
+        end
+      )
+
+      assert {:ok, "actions"} =
+               Executor.execute("code_actions", %{"path" => "x.ex"}, table, :plan)
+
+      assert_receive {:called, %{"path" => "x.ex"}}
+
+      assert {:error, {:plan_mode_refused, "code_actions", message}} =
+               Executor.execute(
+                 "code_actions",
+                 %{"path" => "x.ex", "apply" => "Organize imports"},
+                 table,
+                 :plan
+               )
+
+      assert message =~ "Plan mode"
+      refute_receive {:called, %{"apply" => "Organize imports"}}, 20
+    end
+
+    test "refuses already-approved destructive tools before callback runs", %{table: table} do
+      parent = self()
+
+      spec =
+        register_tool(table, "git_commit",
+          approval_level: :ask,
+          callback: fn _args ->
+            send(parent, :called)
+            {:ok, "committed"}
+          end
+        )
+
+      assert {:error, {:plan_mode_refused, "git_commit", message}} =
+               Executor.execute_approved(spec, %{"message" => "test"}, :plan)
+
+      assert message =~ "git_commit"
+      refute_receive :called, 20
+    end
+  end
+
   describe "execute_approved/2" do
     test "skips approval check and runs callback directly", %{table: table} do
       spec =

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -226,6 +226,13 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       assert Session.status(session) == :plan
     end
 
+    test "/skill:off:plan leaves plan mode" do
+      session = start_session()
+      :ok = Session.enter_plan(session)
+      {:ok, _state} = SlashCommand.execute(mock_state(session: session), "/skill:off:plan")
+      assert Session.status(session) == :idle
+    end
+
     test "/plan without an active session returns a clear error" do
       assert {:error, "No active agent session"} = SlashCommand.execute(mock_state(), "/plan")
     end

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -1,6 +1,7 @@
 defmodule MingaEditor.Agent.SlashCommandTest do
   use ExUnit.Case, async: true
 
+  alias MingaAgent.Session
   alias MingaEditor.Agent.SlashCommand
   alias MingaEditor.Agent.UIState
   alias MingaEditor.State, as: EditorState
@@ -9,6 +10,34 @@ defmodule MingaEditor.Agent.SlashCommandTest do
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
+
+  defmodule NoopProvider do
+    @behaviour MingaAgent.Provider
+
+    use GenServer
+
+    @impl MingaAgent.Provider
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl MingaAgent.Provider
+    def send_prompt(_pid, _text), do: :ok
+
+    @impl MingaAgent.Provider
+    def abort(_pid), do: :ok
+
+    @impl MingaAgent.Provider
+    def new_session(_pid), do: :ok
+
+    @impl MingaAgent.Provider
+    def get_state(_pid), do: {:ok, %{model: nil, is_streaming: false, token_usage: nil}}
+
+    @impl GenServer
+    def init(_opts), do: {:ok, %{}}
+  end
+
+  defp start_session do
+    start_supervised!({Session, provider: NoopProvider, provider_opts: []})
+  end
 
   describe "slash_command?/1" do
     test "returns true for slash-prefixed text" do
@@ -41,6 +70,8 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       assert "stop" in names
       assert "thinking" in names
       assert "model" in names
+      assert "plan" in names
+      assert "exec" in names
     end
   end
 
@@ -158,6 +189,45 @@ defmodule MingaEditor.Agent.SlashCommandTest do
     test "command parsing trims whitespace" do
       {:ok, state} = SlashCommand.execute(mock_state(), "/help  ")
       assert state.shell_state.status_msg == "Commands listed in chat"
+    end
+
+    test "/plan enters plan mode for the active session" do
+      session = start_session()
+      {:ok, state} = SlashCommand.execute(mock_state(session: session), "/plan")
+
+      assert Session.status(session) == :plan
+      assert state.shell_state.status_msg == "Plan mode enabled"
+      assert state.shell_state.agent.runtime.status == :plan
+
+      assert Enum.any?(Session.messages(session), fn
+               {:system, text, :info} -> text =~ "Plan mode" and text =~ "/exec"
+               _ -> false
+             end)
+    end
+
+    test "/exec leaves plan mode for the active session" do
+      session = start_session()
+      :ok = Session.enter_plan(session)
+      {:ok, state} = SlashCommand.execute(mock_state(session: session), "/exec")
+
+      assert Session.status(session) == :idle
+      assert state.shell_state.status_msg == "Execution mode enabled"
+      assert state.shell_state.agent.runtime.status == :idle
+
+      assert Enum.any?(Session.messages(session), fn
+               {:system, text, :info} -> text =~ "Execution mode" and text =~ "/plan"
+               _ -> false
+             end)
+    end
+
+    test "/skill:plan is rewritten to enter real plan mode" do
+      session = start_session()
+      {:ok, _state} = SlashCommand.execute(mock_state(session: session), "/skill:plan")
+      assert Session.status(session) == :plan
+    end
+
+    test "/plan without an active session returns a clear error" do
+      assert {:error, "No active agent session"} = SlashCommand.execute(mock_state(), "/plan")
     end
   end
 end

--- a/test/minga_editor/shell/traditional/modeline_test.exs
+++ b/test/minga_editor/shell/traditional/modeline_test.exs
@@ -94,6 +94,17 @@ defmodule MingaEditor.Shell.Traditional.ModelineTest do
       assert Enum.any?(regions, fn {_start, _end, cmd} -> cmd == :filetype_menu end)
     end
 
+    test "agent plan mode indicator shows explicit PLAN text" do
+      theme = MingaEditor.UI.Theme.get!(:doom_one)
+      agent_colors = MingaEditor.UI.Theme.agent_theme(theme)
+      data = Map.merge(@base_data, %{agent_status: :plan, agent_theme_colors: agent_colors})
+      {commands, _regions} = Modeline.render(0, 120, data, theme)
+
+      combined = Enum.map_join(commands, fn {_row, _col, text, _opts} -> text end)
+      assert String.contains?(combined, "NORMAL")
+      assert String.contains?(combined, "PLAN")
+    end
+
     test "LSP indicator shows green dot when ready" do
       data = Map.put(@base_data, :lsp_status, :ready)
       {commands, _regions} = Modeline.render(0, 120, data)

--- a/test/minga_editor/state/agent_test.exs
+++ b/test/minga_editor/state/agent_test.exs
@@ -47,6 +47,7 @@ defmodule MingaEditor.State.AgentTest do
     test "busy? is true for :thinking and :tool_executing" do
       assert new_agent() |> AgentState.set_status(:thinking) |> AgentState.busy?()
       assert new_agent() |> AgentState.set_status(:tool_executing) |> AgentState.busy?()
+      refute new_agent() |> AgentState.set_status(:plan) |> AgentState.busy?()
       refute new_agent() |> AgentState.set_status(:idle) |> AgentState.busy?()
       refute AgentState.busy?(new_agent())
     end


### PR DESCRIPTION
# TL;DR
Adds real agent plan mode: users can enter `/plan`, keep read-only tools available, and have destructive tools refused before approval or execution. `/exec` returns the session to normal execution mode.

Closes #1407
Part of #1404

## Context
Plan mode used to be prompt guidance through the plan skill. This PR makes it an enforced session state so "plan only, do not edit" is protected by the tool execution path instead of relying on model obedience.

## Changes
- Added `:plan` as a valid agent runtime/session status.
- Added `Session.enter_plan/1` and `Session.enter_exec/1`, with chat-visible system messages for mode changes.
- Added `MingaAgent.Tool.PlanMode` and wired plan-mode checks into both the generic tool executor and native provider tool path.
- Refuses destructive tools before callbacks, approval prompts, or approved execution when a session is in plan mode.
- Keeps read-only/search tools available, including non-applying code action lookup.
- Added `/plan`, `/exec`, and compatibility routing from `/skill:plan` and `/skill:off:plan` to real plan mode.
- Surfaced plan mode in TUI modeline/tab rendering, GUI protocol status values, and macOS status/tab views.
- Added tests for status transitions, slash commands, modeline display, executor blocking, read/search allowances, approved-tool blocking, and a session/provider-path write refusal that proves the underlying callback is not called.

## Verification
- `mix test.llm test/minga_agent/runtime_state_test.exs test/minga_editor/state/agent_test.exs test/minga_agent/tool/executor_test.exs test/minga_agent/session_test.exs test/minga_editor/agent/slash_command_test.exs test/minga_editor/shell/traditional/modeline_test.exs`
- `mix test.llm test/minga_agent/session_test.exs test/minga_agent/tool/executor_test.exs`
- `make lint`
- `mix test.llm`
- `mix swift.build`
- `cd macos && xcodebuild -project Minga.xcodeproj -scheme Minga build CODE_SIGNING_ALLOWED=NO`
- `cd macos && xcodebuild test -project Minga.xcodeproj -scheme Minga CODE_SIGNING_ALLOWED=NO`
- Test-advisor: consulted before implementation
- Swift expert: PASS
- Minga reviewer gate: PASS

## Acceptance Criteria Addressed
- `:plan` is a valid agent session status with normal enter and leave transitions. ✅
- Destructive tools are refused in plan mode before execution, with clear chat/system feedback. ✅
- `/plan` and `/exec` enter and leave plan mode, and UI surfaces show the mode. ✅
- Read-only and search tools still work in plan mode. ✅
- Tests cover a real session in plan mode attempting a write through the provider path, proving the callback is not called. ✅
- `/skill:plan` is rewritten to enter real plan mode instead of duplicating it. ✅
