### PR TITLE
feat(agent): forward subagent configuration

### DIFF
--- a/lib/minga_agent/provider.ex
+++ b/lib/minga_agent/provider.ex
@@ -45,7 +45,11 @@ defmodule MingaAgent.Provider do
 
   @typedoc "Session state returned by the provider."
   @type session_state :: %{
-          model: model_info() | nil,
+          optional(:system_prompt) => String.t() | nil,
+          optional(:thinking_level) => String.t() | nil,
+          optional(:active_skill_names) => [String.t()],
+          optional(:project_root) => String.t() | nil,
+          model: model_info() | String.t() | nil,
           is_streaming: boolean(),
           token_usage: Event.token_usage() | nil
         }

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -290,11 +290,12 @@ defmodule MingaAgent.Providers.Native do
           parent_session: subscriber
         )
 
+    active_skills = load_active_skills(project_root, Keyword.get(opts, :active_skill_names, []))
     internal_tools = build_internal_tools(provider_pid)
     reserved_tool_names = Enum.map(base_tools ++ internal_tools, & &1.name)
     {mcp_registry, mcp_tools} = start_mcp_servers(opts, config, subscriber, reserved_tool_names)
     tools = base_tools ++ mcp_tools ++ internal_tools
-    system_prompt = build_system_prompt(project_root)
+    system_prompt = build_system_prompt(project_root, active_skills)
     context = Context.new([Context.system(system_prompt)])
 
     # Resolve API key from credentials (env var or credentials file).
@@ -318,7 +319,7 @@ defmodule MingaAgent.Providers.Native do
       streaming: false,
       interrupted: false,
       last_user_prompt: nil,
-      active_skills: [],
+      active_skills: active_skills,
       internal_state: InternalState.new(),
       max_turns: max_turns,
       max_cost: max_cost,
@@ -488,7 +489,7 @@ defmodule MingaAgent.Providers.Native do
       Task.shutdown(state.task, 150)
     end
 
-    system_prompt = build_system_prompt(state.project_root)
+    system_prompt = build_system_prompt(state.project_root, state.active_skills)
     context = Context.new([Context.system(system_prompt)])
 
     state = %{state | context: context, task: nil, streaming: false, session_cost: 0.0}
@@ -498,11 +499,7 @@ defmodule MingaAgent.Providers.Native do
   end
 
   def handle_call(:get_state, _from, state) do
-    system_prompt =
-      case state.context.messages do
-        [%{role: :system, content: content} | _] when is_binary(content) -> content
-        _ -> nil
-      end
+    system_prompt = system_prompt_from_context(state.context)
 
     session_state = %{
       model: %{
@@ -512,7 +509,10 @@ defmodule MingaAgent.Providers.Native do
       },
       is_streaming: state.streaming,
       token_usage: nil,
-      system_prompt: system_prompt
+      system_prompt: system_prompt,
+      thinking_level: state.thinking_level,
+      active_skill_names: Enum.map(state.active_skills, & &1.name),
+      project_root: state.project_root
     }
 
     {:reply, {:ok, session_state}, state}
@@ -1860,8 +1860,48 @@ defmodule MingaAgent.Providers.Native do
     ]
   end
 
+  @spec system_prompt_from_context(Context.t()) :: String.t() | nil
+  defp system_prompt_from_context(%Context{
+         messages: [%ReqLLM.Message{role: :system, content: content} | _messages]
+       }) do
+    text_from_content(content)
+  end
+
+  defp system_prompt_from_context(_context), do: nil
+
+  @spec text_from_content(String.t() | [term()]) :: String.t() | nil
+  defp text_from_content(content) when is_binary(content), do: content
+
+  defp text_from_content(content) when is_list(content) do
+    content
+    |> Enum.map(&content_part_text/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  @spec content_part_text(term()) :: String.t()
+  defp content_part_text(%{text: text}) when is_binary(text), do: text
+  defp content_part_text(_part), do: ""
+
+  @spec load_active_skills(String.t(), [String.t()]) :: [Skills.skill()]
+  defp load_active_skills(_project_root, []), do: []
+
+  defp load_active_skills(project_root, names) do
+    names
+    |> Enum.uniq()
+    |> Enum.flat_map(&load_active_skill(project_root, &1))
+  end
+
+  @spec load_active_skill(String.t(), String.t()) :: [Skills.skill()]
+  defp load_active_skill(project_root, name) do
+    case Skills.find(name, project_root) do
+      {:ok, skill} -> [skill]
+      :not_found -> []
+    end
+  end
+
   @spec build_system_prompt(String.t(), [Skills.skill()]) :: String.t()
-  defp build_system_prompt(project_root, active_skills \\ []) do
+  defp build_system_prompt(project_root, active_skills) do
     base = resolve_base_prompt(project_root)
     instructions = Instructions.assemble(project_root)
     memory = Memory.for_prompt()

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1503,7 +1503,11 @@ defmodule MingaAgent.Session do
     end
   catch
     :exit, reason ->
-      Minga.Log.warning(:agent, "[Session] provider unreachable for subagent context: #{inspect(reason)}")
+      Minga.Log.warning(
+        :agent,
+        "[Session] provider unreachable for subagent context: #{inspect(reason)}"
+      )
+
       %{}
   end
 

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -32,6 +32,7 @@ defmodule MingaAgent.Session do
   alias MingaAgent.SessionMetadata
   alias MingaAgent.SessionStore
   alias MingaAgent.EditBoundary
+  alias MingaAgent.SubagentContext
   alias MingaAgent.ToolCall
   alias MingaAgent.TurnUsage
 
@@ -47,6 +48,9 @@ defmodule MingaAgent.Session do
           action: :created | :modified | :deleted,
           timestamp: integer()
         }
+
+  @typedoc "Context inherited by child subagent sessions."
+  @type subagent_context :: SubagentContext.t()
 
   @typedoc "Internal session state."
   @type state :: %{
@@ -126,6 +130,12 @@ defmodule MingaAgent.Session do
   @spec enter_exec(GenServer.server()) :: :ok
   def enter_exec(session) do
     GenServer.call(session, :enter_exec)
+  end
+
+  @doc "Returns the provider context that should be inherited by a subagent."
+  @spec subagent_context(GenServer.server()) :: subagent_context()
+  def subagent_context(session) do
+    GenServer.call(session, :subagent_context)
   end
 
   @doc "Returns the conversation messages."
@@ -488,7 +498,9 @@ defmodule MingaAgent.Session do
       provider_module: provider_module,
       provider_opts: provider_opts,
       status: :idle,
-      messages: [Message.system("Session started · #{timestamp}")],
+      messages: [
+        Message.system(initial_system_message(timestamp, Keyword.get(opts, :startup_notice)))
+      ],
       message_ids: [1],
       next_message_id: 2,
       subscribers: MapSet.new(),
@@ -744,6 +756,10 @@ defmodule MingaAgent.Session do
 
   def handle_call(:status, _from, state) do
     {:reply, state.status, state}
+  end
+
+  def handle_call(:subagent_context, _from, state) do
+    {:reply, build_subagent_context(state), state}
   end
 
   def handle_call(:messages, _from, state) do
@@ -1457,6 +1473,73 @@ defmodule MingaAgent.Session do
   @spec start_provider(state()) :: {:ok, pid()} | {:error, term()}
   defp start_provider(state) do
     state.provider_module.start_link(state.provider_opts)
+  end
+
+  @spec initial_system_message(String.t(), String.t() | nil) :: String.t()
+  defp initial_system_message(timestamp, nil), do: "Session started · #{timestamp}"
+  defp initial_system_message(timestamp, notice), do: "Session started · #{timestamp} · #{notice}"
+
+  @spec build_subagent_context(state()) :: subagent_context()
+  defp build_subagent_context(state) do
+    provider_state = provider_state(state)
+
+    %SubagentContext{
+      provider_module: state.provider_module,
+      provider_name: provider_name(provider_state, state),
+      model: provider_model(provider_state, state),
+      thinking_level: provider_thinking_level(provider_state),
+      active_skill_names: provider_active_skill_names(provider_state),
+      project_root: provider_project_root(provider_state, state)
+    }
+  end
+
+  @spec provider_state(state()) :: map()
+  defp provider_state(%{provider: nil}), do: %{}
+
+  defp provider_state(state) do
+    case state.provider_module.get_state(state.provider) do
+      {:ok, provider_state} when is_map(provider_state) -> provider_state
+      _other -> %{}
+    end
+  catch
+    :exit, _ -> %{}
+  end
+
+  @spec provider_name(map(), state()) :: String.t()
+  defp provider_name(%{model: %{provider: provider}}, _state) when is_binary(provider),
+    do: provider
+
+  defp provider_name(%{provider: provider}, _state) when is_binary(provider), do: provider
+  defp provider_name(_provider_state, state), do: state.provider_name
+
+  @spec provider_model(map(), state()) :: String.t() | nil
+  defp provider_model(%{model: %{id: id}}, _state) when is_binary(id), do: id
+  defp provider_model(%{model: model}, _state) when is_binary(model), do: model
+  defp provider_model(_provider_state, %{model_name: "unknown"}), do: nil
+  defp provider_model(_provider_state, state), do: state.model_name
+
+  @spec provider_thinking_level(map()) :: String.t() | nil
+  defp provider_thinking_level(%{thinking_level: level}) when is_binary(level), do: level
+  defp provider_thinking_level(_provider_state), do: nil
+
+  @spec provider_active_skill_names(map()) :: [String.t()]
+  defp provider_active_skill_names(%{active_skill_names: names}) when is_list(names) do
+    Enum.filter(names, &is_binary/1)
+  end
+
+  defp provider_active_skill_names(_provider_state), do: []
+
+  @spec provider_project_root(map(), state()) :: String.t() | nil
+  defp provider_project_root(%{project_root: project_root}, _state)
+       when is_binary(project_root) do
+    project_root
+  end
+
+  defp provider_project_root(_provider_state, state) do
+    case Keyword.get(state.provider_opts, :project_root) do
+      project_root when is_binary(project_root) -> project_root
+      _other -> nil
+    end
   end
 
   @spec format_error(term()) :: String.t()

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1483,14 +1483,14 @@ defmodule MingaAgent.Session do
   defp build_subagent_context(state) do
     provider_state = provider_state(state)
 
-    %SubagentContext{
+    SubagentContext.new(
       provider_module: state.provider_module,
       provider_name: provider_name(provider_state, state),
       model: provider_model(provider_state, state),
       thinking_level: provider_thinking_level(provider_state),
       active_skill_names: provider_active_skill_names(provider_state),
       project_root: provider_project_root(provider_state, state)
-    }
+    )
   end
 
   @spec provider_state(state()) :: map()
@@ -1502,7 +1502,9 @@ defmodule MingaAgent.Session do
       _other -> %{}
     end
   catch
-    :exit, _ -> %{}
+    :exit, reason ->
+      Minga.Log.warning(:agent, "[Session] provider unreachable for subagent context: #{inspect(reason)}")
+      %{}
   end
 
   @spec provider_name(map(), state()) :: String.t()

--- a/lib/minga_agent/subagent_context.ex
+++ b/lib/minga_agent/subagent_context.ex
@@ -15,31 +15,32 @@ defmodule MingaAgent.SubagentContext do
           project_root: String.t() | nil
         }
 
-  @enforce_keys [
+  @enforce_keys [:provider_module, :provider_name]
+  defstruct [
     :provider_module,
     :provider_name,
     :model,
     :thinking_level,
-    :active_skill_names,
-    :project_root
+    :project_root,
+    active_skill_names: []
   ]
-  defstruct provider_module: MingaAgent.Providers.Native,
-            provider_name: "native",
-            model: nil,
-            thinking_level: nil,
-            active_skill_names: [],
-            project_root: nil
+
+  @doc "Builds a context from the given attributes."
+  @spec new(keyword()) :: t()
+  def new(attrs) when is_list(attrs) do
+    struct!(__MODULE__, attrs)
+  end
 
   @doc "Returns the default context used when no parent session is available."
   @spec default() :: t()
   def default do
-    %__MODULE__{
+    new(
       provider_module: MingaAgent.Providers.Native,
       provider_name: "native",
       model: nil,
       thinking_level: nil,
       active_skill_names: [],
       project_root: nil
-    }
+    )
   end
 end

--- a/lib/minga_agent/subagent_context.ex
+++ b/lib/minga_agent/subagent_context.ex
@@ -1,0 +1,45 @@
+defmodule MingaAgent.SubagentContext do
+  @moduledoc """
+  Configuration context inherited by child subagent sessions.
+
+  The subagent tool uses this struct to carry the parent session's provider, model, thinking level, active skills, and project root across module boundaries without relying on a raw map shape.
+  """
+
+  @typedoc "Inherited context for a child subagent session."
+  @type t :: %__MODULE__{
+          provider_module: module(),
+          provider_name: String.t(),
+          model: String.t() | nil,
+          thinking_level: String.t() | nil,
+          active_skill_names: [String.t()],
+          project_root: String.t() | nil
+        }
+
+  @enforce_keys [
+    :provider_module,
+    :provider_name,
+    :model,
+    :thinking_level,
+    :active_skill_names,
+    :project_root
+  ]
+  defstruct provider_module: MingaAgent.Providers.Native,
+            provider_name: "native",
+            model: nil,
+            thinking_level: nil,
+            active_skill_names: [],
+            project_root: nil
+
+  @doc "Returns the default context used when no parent session is available."
+  @spec default() :: t()
+  def default do
+    %__MODULE__{
+      provider_module: MingaAgent.Providers.Native,
+      provider_name: "native",
+      model: nil,
+      thinking_level: nil,
+      active_skill_names: [],
+      project_root: nil
+    }
+  end
+end

--- a/lib/minga_agent/tools.ex
+++ b/lib/minga_agent/tools.ex
@@ -65,7 +65,7 @@ defmodule MingaAgent.Tools do
           project_root: String.t(),
           changeset: pid() | nil,
           fork_store: pid() | nil,
-          parent_session: pid() | nil
+          parent_session: GenServer.server() | nil
         ]
 
   @default_destructive_tools ~w(write_file edit_file multi_edit_file shell git_stage git_commit rename)
@@ -504,7 +504,7 @@ defmodule MingaAgent.Tools do
     )
   end
 
-  @spec subagent(String.t(), pid() | nil) :: Tool.t()
+  @spec subagent(String.t(), GenServer.server() | nil) :: Tool.t()
   defp subagent(root, parent_session) do
     Tool.new!(
       name: "subagent",
@@ -527,6 +527,12 @@ defmodule MingaAgent.Tools do
             "description" =>
               "Model to use for the subagent (e.g., \"anthropic:claude-sonnet-4-20250514\"). Defaults to the parent's model."
           },
+          "provider" => %{
+            "type" => "string",
+            "enum" => ["native", "pi_rpc"],
+            "description" =>
+              "Provider to use for the subagent. Defaults to the parent's provider; explicit overrides are shown in the subagent's first system message."
+          },
           "background" => %{
             "type" => "boolean",
             "description" =>
@@ -539,6 +545,7 @@ defmodule MingaAgent.Tools do
         Subagent.execute(args["task"],
           project_root: root,
           model: args["model"],
+          provider: args["provider"],
           background: args["background"] == true,
           parent_session: parent_session
         )

--- a/lib/minga_agent/tools/subagent.ex
+++ b/lib/minga_agent/tools/subagent.ex
@@ -8,17 +8,28 @@ defmodule MingaAgent.Tools.Subagent do
   alias MingaAgent.Session
   alias MingaAgent.SessionManager
   alias MingaAgent.Subagent.Handle
+  alias MingaAgent.SubagentContext
   alias MingaAgent.Supervisor, as: AgentSupervisor
+
+  @typedoc "Provider override accepted by direct callers and the tool schema."
+  @type provider_override :: :native | :pi_rpc | module() | String.t() | nil
+
+  @typedoc "Context inherited from the parent agent session."
+  @type parent_context :: SubagentContext.t()
+
+  @typedoc "Resolved provider for a child session."
+  @type resolved_provider :: %{module: module(), name: String.t()}
 
   @typedoc "Options for subagent execution."
   @type opts :: [
           model: String.t() | nil,
+          provider: provider_override(),
+          parent_session: GenServer.server() | nil,
           project_root: String.t() | nil,
-          background: boolean(),
-          parent_session: pid() | nil,
-          provider: module(),
           provider_opts: keyword(),
-          session_manager: GenServer.server()
+          background: boolean(),
+          session_manager: GenServer.server(),
+          notifier: module() | {module(), term()}
         ]
 
   @subagent_timeout_ms 300_000
@@ -144,19 +155,52 @@ defmodule MingaAgent.Tools.Subagent do
     :exit, _ -> :ok
   end
 
+  # ── Session opts (shared by foreground and background) ─────────────────────
+
   @spec session_opts(opts()) :: keyword()
   defp session_opts(opts) do
-    project_root = Keyword.get(opts, :project_root, detect_project_root())
-    model = Keyword.get(opts, :model)
-    provider = Keyword.get(opts, :provider, MingaAgent.Providers.Native)
+    parent_ctx = parent_context(opts)
 
-    provider_opts =
-      opts
-      |> Keyword.get(:provider_opts, [])
-      |> Keyword.merge(build_provider_opts(project_root, model))
+    case resolve_provider(Keyword.get(opts, :provider), parent_ctx) do
+      {:ok, resolved_provider} ->
+        model = Keyword.get(opts, :model) || parent_ctx.model
 
-    [provider: provider, provider_opts: provider_opts, model_name: model || "unknown"]
-    |> maybe_put_notifier(opts)
+        project_root =
+          Keyword.get(opts, :project_root) || parent_ctx.project_root || detect_project_root()
+
+        thinking_level = parent_ctx.thinking_level
+        active_skill_names = parent_ctx.active_skill_names
+        extra_provider_opts = Keyword.get(opts, :provider_opts, [])
+
+        [
+          provider: resolved_provider.module,
+          model_name: model || "unknown",
+          startup_notice:
+            startup_notice(
+              Keyword.get(opts, :provider),
+              Keyword.get(opts, :model),
+              resolved_provider,
+              model
+            ),
+          provider_opts:
+            build_provider_opts(
+              project_root,
+              resolved_provider.name,
+              model,
+              thinking_level,
+              active_skill_names,
+              extra_provider_opts
+            )
+        ]
+        |> maybe_put_thinking_level(thinking_level)
+        |> maybe_put_notifier(opts)
+
+      {:error, reason} ->
+        # Fall back to a minimal opts that will produce a clear error at session start.
+        # This path is unlikely since resolve_provider only fails for unknown string overrides.
+        Minga.Log.warning(:agent, "[Subagent] provider resolution failed: #{reason}")
+        [provider: MingaAgent.Providers.Native, model_name: "unknown", provider_opts: []]
+    end
   end
 
   @spec maybe_put_notifier(keyword(), opts()) :: keyword()
@@ -167,24 +211,137 @@ defmodule MingaAgent.Tools.Subagent do
     end
   end
 
-  @spec build_provider_opts(String.t(), String.t() | nil) :: keyword()
-  defp build_provider_opts(project_root, model) do
-    opts = [
-      project_root: project_root,
-      provider: "native"
-    ]
-
-    if model do
-      [{:model, model} | opts]
-    else
-      opts
-    end
-  end
-
   @spec background_result(Handle.t()) :: String.t()
   defp background_result(%Handle{} = handle) do
     "Background subagent started. Handle: #{Handle.id(handle)}. Use the agent session picker to inspect its chat."
   end
+
+  # ── Context inheritance ────────────────────────────────────────────────────
+
+  @spec parent_context(opts()) :: parent_context()
+  defp parent_context(opts) do
+    case Keyword.get(opts, :parent_session) do
+      nil -> default_parent_context()
+      parent_session -> fetch_parent_context(parent_session)
+    end
+  end
+
+  @spec fetch_parent_context(GenServer.server()) :: parent_context()
+  defp fetch_parent_context(parent_session) do
+    Session.subagent_context(parent_session)
+  catch
+    :exit, {reason, _} ->
+      Minga.Log.warning(
+        :agent,
+        "[Subagent] parent session #{inspect(parent_session)} unreachable: #{inspect(reason)}"
+      )
+
+      default_parent_context()
+
+    :exit, reason ->
+      Minga.Log.warning(
+        :agent,
+        "[Subagent] parent session #{inspect(parent_session)} unreachable: #{inspect(reason)}"
+      )
+
+      default_parent_context()
+  end
+
+  @spec default_parent_context() :: parent_context()
+  defp default_parent_context do
+    SubagentContext.default()
+  end
+
+  @spec resolve_provider(provider_override(), parent_context()) ::
+          {:ok, resolved_provider()} | {:error, String.t()}
+  defp resolve_provider(nil, parent_context) do
+    {:ok, %{module: parent_context.provider_module, name: parent_context.provider_name}}
+  end
+
+  defp resolve_provider(:native, _parent_context) do
+    {:ok, %{module: MingaAgent.Providers.Native, name: "native"}}
+  end
+
+  defp resolve_provider(:pi_rpc, _parent_context) do
+    {:ok, %{module: MingaAgent.Providers.PiRpc, name: "pi_rpc"}}
+  end
+
+  defp resolve_provider(provider, _parent_context) when is_atom(provider) do
+    {:ok, %{module: provider, name: inspect(provider)}}
+  end
+
+  defp resolve_provider("native", parent_context), do: resolve_provider(:native, parent_context)
+  defp resolve_provider("pi_rpc", parent_context), do: resolve_provider(:pi_rpc, parent_context)
+
+  defp resolve_provider(provider, _parent_context) do
+    {:error, "Unknown subagent provider override: #{inspect(provider)}"}
+  end
+
+  @spec build_provider_opts(
+          String.t(),
+          String.t(),
+          String.t() | nil,
+          String.t() | nil,
+          [String.t()],
+          keyword()
+        ) :: keyword()
+  defp build_provider_opts(
+         project_root,
+         provider_name,
+         model,
+         thinking_level,
+         active_skill_names,
+         extra_provider_opts
+       ) do
+    [project_root: project_root, provider: provider_name]
+    |> maybe_put(:model, model)
+    |> maybe_put(:thinking_level, thinking_level)
+    |> maybe_put_active_skill_names(active_skill_names)
+    |> Keyword.merge(Keyword.delete(extra_provider_opts, :subscriber))
+  end
+
+  @spec maybe_put(keyword(), atom(), term()) :: keyword()
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+
+  @spec maybe_put_active_skill_names(keyword(), [String.t()]) :: keyword()
+  defp maybe_put_active_skill_names(opts, []), do: opts
+
+  defp maybe_put_active_skill_names(opts, names),
+    do: Keyword.put(opts, :active_skill_names, names)
+
+  @spec maybe_put_thinking_level(keyword(), String.t() | nil) :: keyword()
+  defp maybe_put_thinking_level(opts, nil), do: opts
+
+  defp maybe_put_thinking_level(opts, thinking_level),
+    do: Keyword.put(opts, :thinking_level, thinking_level)
+
+  @spec startup_notice(
+          provider_override(),
+          String.t() | nil,
+          resolved_provider(),
+          String.t() | nil
+        ) ::
+          String.t() | nil
+  defp startup_notice(nil, nil, _resolved_provider, _model), do: nil
+
+  defp startup_notice(provider_override, model_override, resolved_provider, model) do
+    [provider_notice(provider_override, resolved_provider), model_notice(model_override, model)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
+    |> then(&("Subagent overrides · " <> &1))
+  end
+
+  @spec provider_notice(provider_override(), resolved_provider()) :: String.t() | nil
+  defp provider_notice(nil, _resolved_provider), do: nil
+
+  defp provider_notice(_provider_override, resolved_provider),
+    do: "provider override: #{resolved_provider.name}"
+
+  @spec model_notice(String.t() | nil, String.t() | nil) :: String.t() | nil
+  defp model_notice(nil, _model), do: nil
+  defp model_notice(_model_override, nil), do: "model override: unknown"
+  defp model_notice(_model_override, model), do: "model override: #{model}"
 
   defdelegate detect_project_root, to: Minga.Project, as: :resolve_root
 end

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -59,6 +59,20 @@ defmodule MingaAgent.Providers.NativeTest do
     Native.start_link(merged)
   end
 
+  defp write_project_skill(dir, name, instructions) do
+    skill_dir = Path.join([dir, ".minga", "skills", name])
+    File.mkdir_p!(skill_dir)
+
+    File.write!(Path.join(skill_dir, "SKILL.md"), """
+    ---
+    name: #{name}
+    description: #{name} skill
+    ---
+
+    #{instructions}
+    """)
+  end
+
   # Wait for events with a helper that collects all events within a timeout.
   defp collect_events(timeout) do
     collect_events_acc([], timeout)
@@ -86,6 +100,29 @@ defmodule MingaAgent.Providers.NativeTest do
       assert {:ok, session_state} = Native.get_state(pid)
       assert session_state.model.provider == "native"
       assert session_state.is_streaming == false
+    end
+
+    test "get_state exposes context fields used by subagents", %{tmp_dir: dir} do
+      write_project_skill(dir, "plan", "PLAN SKILL 1419")
+
+      {:ok, pid} =
+        start_provider(tmp_dir: dir, thinking_level: "high", active_skill_names: ["plan"])
+
+      assert {:ok, session_state} = Native.get_state(pid)
+      assert session_state.model.id == "anthropic:claude-sonnet-4-20250514"
+      assert session_state.thinking_level == "high"
+      assert session_state.active_skill_names == ["plan"]
+      assert session_state.project_root == dir
+      assert session_state.system_prompt =~ "PLAN SKILL 1419"
+    end
+
+    test "system prompt includes project AGENTS.md instructions for the inherited project root",
+         %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "AGENTS.md"), "PROJECT RULE 1419")
+      {:ok, pid} = start_provider(tmp_dir: dir)
+
+      assert {:ok, session_state} = Native.get_state(pid)
+      assert session_state.system_prompt =~ "PROJECT RULE 1419"
     end
   end
 

--- a/test/minga_agent/tools/subagent_test.exs
+++ b/test/minga_agent/tools/subagent_test.exs
@@ -494,6 +494,26 @@ defmodule MingaAgent.Tools.SubagentTest do
       assert {:ok, "blocked child response"} = Task.await(task, 1_000)
     end
 
+    test "falls back to default context when parent session is already dead", %{tmp_dir: dir} do
+      ref = make_ref()
+      parent = start_parent_session(dir, ref)
+      MingaAgent.Supervisor.stop_session(parent)
+      Process.sleep(50)
+
+      assert {:ok, "child response"} =
+               Subagent.execute("do child task",
+                 project_root: dir,
+                 parent_session: parent,
+                 provider: RecordingProvider,
+                 provider_opts: [test_pid: self(), test_ref: ref]
+               )
+
+      assert_child_started(ref, fn opts ->
+        refute Keyword.has_key?(opts, :thinking_level)
+        assert Keyword.get(opts, :active_skill_names, []) == []
+      end)
+    end
+
     test "stops the child session after success", %{tmp_dir: dir} do
       ref = make_ref()
       parent = start_parent_session(dir, ref)

--- a/test/minga_agent/tools/subagent_test.exs
+++ b/test/minga_agent/tools/subagent_test.exs
@@ -9,6 +9,10 @@ defmodule MingaAgent.Tools.SubagentTest do
   alias MingaAgent.Subagent.Handle
   alias MingaAgent.Tools.Subagent
 
+  @moduletag :tmp_dir
+
+  # ── Test providers ────────────────────────────────────────────────────────
+
   defmodule GatedProvider do
     @behaviour MingaAgent.Provider
 
@@ -101,6 +105,142 @@ defmodule MingaAgent.Tools.SubagentTest do
     end
   end
 
+  defmodule RecordingProvider do
+    @behaviour MingaAgent.Provider
+
+    use GenServer
+
+    @impl MingaAgent.Provider
+    def start_link(opts) do
+      GenServer.start_link(__MODULE__, opts)
+    end
+
+    @impl MingaAgent.Provider
+    def send_prompt(pid, text) do
+      GenServer.call(pid, {:send_prompt, text})
+    end
+
+    @impl MingaAgent.Provider
+    def abort(pid) do
+      GenServer.cast(pid, :abort)
+      :ok
+    end
+
+    @impl MingaAgent.Provider
+    def new_session(pid) do
+      GenServer.cast(pid, :new_session)
+      :ok
+    end
+
+    @impl MingaAgent.Provider
+    def get_state(pid) do
+      GenServer.call(pid, :get_state)
+    end
+
+    @impl GenServer
+    def init(opts) do
+      notify_test(opts, {:provider_started, self(), opts})
+
+      state = %{
+        subscriber: Keyword.fetch!(opts, :subscriber),
+        model: Keyword.get(opts, :model),
+        provider: Keyword.get(opts, :provider, "recording"),
+        thinking_level: Keyword.get(opts, :thinking_level),
+        active_skill_names: Keyword.get(opts, :active_skill_names, []),
+        project_root: Keyword.get(opts, :project_root),
+        blocking: Keyword.get(opts, :blocking, false),
+        test_pid: Keyword.get(opts, :test_pid),
+        test_ref: Keyword.get(opts, :test_ref)
+      }
+
+      {:ok, state}
+    end
+
+    @impl GenServer
+    def handle_call({:send_prompt, text}, _from, state) do
+      notify_test(state, {:prompt_received, self(), state.subscriber, text})
+      notify_session(state, %Event.AgentStart{})
+
+      if state.blocking do
+        {:reply, :ok, state}
+      else
+        notify_session(state, %Event.TextDelta{delta: "child response"})
+        notify_session(state, %Event.AgentEnd{usage: nil})
+        {:reply, :ok, state}
+      end
+    end
+
+    def handle_call(:get_state, _from, state) do
+      provider_state = %{
+        model: %{id: state.model, name: state.model, provider: state.provider},
+        is_streaming: false,
+        token_usage: nil,
+        thinking_level: state.thinking_level,
+        active_skill_names: state.active_skill_names,
+        project_root: state.project_root
+      }
+
+      {:reply, {:ok, provider_state}, state}
+    end
+
+    @impl GenServer
+    def handle_cast(:finish, state) do
+      notify_session(state, %Event.TextDelta{delta: "blocked child response"})
+      notify_session(state, %Event.AgentEnd{usage: nil})
+      {:noreply, state}
+    end
+
+    def handle_cast(_message, state), do: {:noreply, state}
+
+    @spec finish(GenServer.server()) :: :ok
+    def finish(pid) do
+      GenServer.cast(pid, :finish)
+    end
+
+    @spec notify_session(map(), Event.t()) :: :ok
+    defp notify_session(state, event) do
+      send(state.subscriber, {:agent_provider_event, event})
+      :ok
+    end
+
+    @spec notify_test(keyword() | map(), tuple()) :: :ok
+    defp notify_test(opts_or_state, message) do
+      test_pid = get_opt(opts_or_state, :test_pid)
+      test_ref = get_opt(opts_or_state, :test_ref)
+
+      if is_pid(test_pid) and test_ref != nil do
+        send(test_pid, {test_ref, message})
+      end
+
+      :ok
+    end
+
+    @spec get_opt(keyword() | map(), atom()) :: term()
+    defp get_opt(opts, key) when is_list(opts), do: Keyword.get(opts, key)
+    defp get_opt(state, key) when is_map(state), do: Map.get(state, key)
+  end
+
+  defmodule OverrideProvider do
+    @behaviour MingaAgent.Provider
+
+    @impl MingaAgent.Provider
+    def start_link(opts), do: RecordingProvider.start_link(opts)
+
+    @impl MingaAgent.Provider
+    def send_prompt(pid, text), do: RecordingProvider.send_prompt(pid, text)
+
+    @impl MingaAgent.Provider
+    def abort(pid), do: RecordingProvider.abort(pid)
+
+    @impl MingaAgent.Provider
+    def new_session(pid), do: RecordingProvider.new_session(pid)
+
+    @impl MingaAgent.Provider
+    def get_state(pid), do: RecordingProvider.get_state(pid)
+  end
+
+  # ── Setup ──────────────────────────────────────────────────────────────────
+
   setup do
     name = :"subagent_manager_#{System.unique_integer([:positive])}"
     {:ok, manager} = GenServer.start(SessionManager, [], name: name)
@@ -117,6 +257,8 @@ defmodule MingaAgent.Tools.SubagentTest do
 
     %{manager: manager}
   end
+
+  # ── Background subagent tests ──────────────────────────────────────────────
 
   test "background subagent returns a stable handle before the child finishes", %{
     manager: manager
@@ -241,6 +383,8 @@ defmodule MingaAgent.Tools.SubagentTest do
     refute_receive {:notified, :complete, _}, 50
   end
 
+  # ── Foreground subagent tests ──────────────────────────────────────────────
+
   test "foreground subagent still blocks and returns final text" do
     test_pid = self()
 
@@ -257,6 +401,120 @@ defmodule MingaAgent.Tools.SubagentTest do
     assert {:ok, "foreground done"} = Task.await(task)
   end
 
+  # ── Context inheritance tests ──────────────────────────────────────────────
+
+  describe "execute/2 context inheritance" do
+    test "inherits parent provider model thinking level and active skills by default", %{
+      tmp_dir: dir
+    } do
+      ref = make_ref()
+      parent = start_parent_session(dir, ref)
+
+      assert {:ok, "child response"} =
+               Subagent.execute("do child task",
+                 parent_session: parent,
+                 project_root: dir,
+                 provider_opts: [test_pid: self(), test_ref: ref]
+               )
+
+      assert_child_started(ref, fn opts ->
+        assert Keyword.fetch!(opts, :model) == "parent-model"
+        assert Keyword.fetch!(opts, :provider) == "recording"
+        assert Keyword.fetch!(opts, :thinking_level) == "high"
+        assert Keyword.fetch!(opts, :active_skill_names) == ["plan", "review"]
+        assert Keyword.fetch!(opts, :project_root) == dir
+      end)
+    end
+
+    test "explicit model override wins while other parent context is inherited", %{tmp_dir: dir} do
+      ref = make_ref()
+      parent = start_parent_session(dir, ref)
+
+      assert {:ok, "child response"} =
+               Subagent.execute("do child task",
+                 parent_session: parent,
+                 project_root: dir,
+                 model: "override-model",
+                 provider_opts: [test_pid: self(), test_ref: ref]
+               )
+
+      assert_child_started(ref, fn opts ->
+        assert Keyword.fetch!(opts, :model) == "override-model"
+        assert Keyword.fetch!(opts, :provider) == "recording"
+        assert Keyword.fetch!(opts, :thinking_level) == "high"
+        assert Keyword.fetch!(opts, :active_skill_names) == ["plan", "review"]
+      end)
+    end
+
+    test "explicit provider override wins over the parent provider", %{tmp_dir: dir} do
+      ref = make_ref()
+      parent = start_parent_session(dir, ref)
+
+      assert {:ok, "child response"} =
+               Subagent.execute("do child task",
+                 parent_session: parent,
+                 project_root: dir,
+                 provider: OverrideProvider,
+                 provider_opts: [test_pid: self(), test_ref: ref]
+               )
+
+      assert_child_started(ref, fn opts ->
+        assert Keyword.fetch!(opts, :provider) == inspect(OverrideProvider)
+        assert Keyword.fetch!(opts, :model) == "parent-model"
+        assert Keyword.fetch!(opts, :thinking_level) == "high"
+        assert Keyword.fetch!(opts, :active_skill_names) == ["plan", "review"]
+      end)
+    end
+
+    test "explicit provider and model overrides are visible in the child first system message", %{
+      tmp_dir: dir
+    } do
+      ref = make_ref()
+      test_pid = self()
+
+      task =
+        Task.async(fn ->
+          Subagent.execute("do child task",
+            project_root: dir,
+            provider: OverrideProvider,
+            model: "override-model",
+            provider_opts: [test_pid: test_pid, test_ref: ref, blocking: true]
+          )
+        end)
+
+      assert_receive {^ref, {:prompt_received, provider_pid, child_session, "do child task"}},
+                     1_000
+
+      [{:system, first_system_message, :info} | _rest] = Session.messages(child_session)
+      assert first_system_message =~ "Subagent overrides"
+      assert first_system_message =~ "provider override: #{inspect(OverrideProvider)}"
+      assert first_system_message =~ "model override: override-model"
+
+      RecordingProvider.finish(provider_pid)
+      assert {:ok, "blocked child response"} = Task.await(task, 1_000)
+    end
+
+    test "stops the child session after success", %{tmp_dir: dir} do
+      ref = make_ref()
+      parent = start_parent_session(dir, ref)
+
+      assert {:ok, "child response"} =
+               Subagent.execute("do child task",
+                 parent_session: parent,
+                 project_root: dir,
+                 provider_opts: [test_pid: self(), test_ref: ref]
+               )
+
+      assert_receive {^ref, {:prompt_received, _provider_pid, child_session, "do child task"}},
+                     1_000
+
+      monitor_ref = Process.monitor(child_session)
+      assert_receive {:DOWN, ^monitor_ref, :process, ^child_session, _reason}, 1_000
+    end
+  end
+
+  # ── Helpers ────────────────────────────────────────────────────────────────
+
   defp assert_eventually_idle(session_pid) do
     Session.subscribe(session_pid)
 
@@ -269,5 +527,35 @@ defmodule MingaAgent.Tools.SubagentTest do
         1_000 -> flunk("session did not become idle")
       end
     end
+  end
+
+  @spec start_parent_session(String.t(), reference()) :: pid()
+  defp start_parent_session(dir, ref) do
+    {:ok, parent} =
+      MingaAgent.Supervisor.start_session(
+        provider: RecordingProvider,
+        model_name: "parent-model",
+        provider_opts: [
+          provider: "recording",
+          model: "parent-model",
+          thinking_level: "high",
+          active_skill_names: ["plan", "review"],
+          project_root: dir,
+          test_pid: self(),
+          test_ref: ref
+        ]
+      )
+
+    assert_receive {^ref, {:provider_started, _provider_pid, opts}}, 1_000
+    assert Keyword.fetch!(opts, :subscriber) == parent
+    on_exit(fn -> MingaAgent.Supervisor.stop_session(parent) end)
+    parent
+  end
+
+  @spec assert_child_started(reference(), (keyword() -> any())) :: :ok
+  defp assert_child_started(ref, assertions) do
+    assert_receive {^ref, {:provider_started, _provider_pid, opts}}, 1_000
+    assertions.(opts)
+    :ok
   end
 end

--- a/test/minga_agent/tools_test.exs
+++ b/test/minga_agent/tools_test.exs
@@ -69,14 +69,26 @@ defmodule MingaAgent.ToolsTest do
       end
     end
 
-    test "subagent schema accepts optional background flag", %{tmp_dir: dir} do
+    test "subagent schema accepts optional background flag and provider overrides", %{
+      tmp_dir: dir
+    } do
       subagent = Tools.all(project_root: dir) |> Enum.find(&(&1.name == "subagent"))
       schema = subagent.parameter_schema
 
+      assert schema["required"] == ["task"]
+      assert Map.has_key?(schema["properties"], "task")
+
+      # Background flag
       assert schema["properties"]["background"]["type"] == "boolean"
-      assert "task" in schema["required"]
       refute "background" in schema["required"]
       assert subagent.description =~ "Background mode"
+
+      # Provider and model overrides
+      assert schema["properties"]["model"]["description"] =~ "Defaults to the parent's model"
+      assert schema["properties"]["provider"]["enum"] == ["native", "pi_rpc"]
+
+      assert schema["properties"]["provider"]["description"] =~
+               "Defaults to the parent's provider"
     end
   end
 


### PR DESCRIPTION
# TL;DR
Sub-agents now inherit the parent agent's execution context by default: provider, model, thinking level, active skills, and project instructions. Explicit provider/model overrides are still supported and are shown in the child session's first system message.

Closes #1419
Part of #1404

## Context
#1419 closes a trust gap in the sub-agent tool. A child agent should not silently run with a different model, provider, or prompt context than the user expects.

## Changes
- Added `MingaAgent.SubagentContext` as the typed context shape passed from parent sessions to child sub-agents.
- Added `Session.subagent_context/1` to expose provider, model, thinking level, active skill names, and project root from the parent session/provider.
- Updated the sub-agent tool to inherit parent config by default and accept explicit `provider` and `model` overrides.
- Added startup notices so explicit overrides are visible in the child session's first system message.
- Updated the native provider to expose sub-agent context fields from `get_state/1` and seed inherited active skills on child startup.
- Passed parent session context into tool construction so sub-agent calls have access to the active session.
- Hardened git integration tests so fixture commits ignore global signing config, avoiding local 1Password signing failures during `mix test.llm`.

## Verification
- `mix test.llm test/minga_agent/tools/subagent_test.exs test/minga_agent/tools_test.exs test/minga_agent/providers/native_test.exs`
- `mix test.llm test/minga_agent/providers/native_test.exs --include heavy`
- `mix test.llm test/minga/extension/git_test.exs`
- `mix test.llm test/minga_agent/tools/subagent_test.exs test/minga_agent/session_test.exs`
- `make lint`
- `mix test.llm`
- Test-advisor: consulted before implementation
- Minga reviewer gate: PASS

## Acceptance Criteria Addressed
- Sub-agents inherit the parent's provider, model, thinking level, loaded skills, and project instructions by default. ✅
- Explicit provider/model overrides are accepted and visible in the sub-agent's first system message. ✅
- Tests launch a sub-agent and assert inherited config matches the parent. ✅
- The sub-agent tool remains available because forwarding shipped. ✅
