### PR TITLE
feat(agent): add pre-tool hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ macos/Minga.xcodeproj/project.xcworkspace/xcuserdata/
 erl_crash.dump
 /priv/minga-renderer
 /priv/minga-parser
+/priv/minga-hook-runner
 /priv/minga-test-harness
 /burrito_out/
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -21,7 +21,7 @@ set :agent_hooks, [
 
 `tool` can be an exact tool name, `*` for all tools, or a simple glob with `*` and `?`, such as `*_file`. Hooks run in the order you declare them. The first veto stops later hooks and prevents the tool from running.
 
-`timeout_ms` is optional. The default is `30_000` milliseconds. If a hook exceeds its timeout, Minga blocks the tool call, terminates the hook process tree on supported Unix systems, and shows a clear error in the agent chat. Hooks should not launch detached background processes; timeout cleanup is not a sandbox.
+`timeout_ms` is optional. The default is `30_000` milliseconds. If a hook exceeds its timeout, Minga blocks the tool call, terminates the POSIX process group it created for the hook, and shows a clear error in the agent chat. Hooks should not launch detached background processes; timeout cleanup is not a sandbox.
 
 ## PreToolUse payload
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -21,7 +21,7 @@ set :agent_hooks, [
 
 `tool` can be an exact tool name, `*` for all tools, or a simple glob with `*` and `?`, such as `*_file`. Hooks run in the order you declare them. The first veto stops later hooks and prevents the tool from running.
 
-`timeout_ms` is optional. The default is `30_000` milliseconds. If a hook exceeds its timeout, Minga kills it, blocks the tool call, and shows a clear error in the agent chat.
+`timeout_ms` is optional. The default is `30_000` milliseconds. If a hook exceeds its timeout, Minga blocks the tool call, terminates the hook process tree on supported Unix systems, and shows a clear error in the agent chat. Hooks should not launch detached background processes; timeout cleanup is not a sandbox.
 
 ## PreToolUse payload
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,0 +1,95 @@
+# Agent hooks
+
+Agent hooks let your config run local policy checks around agent tool use. The first implemented event is `PreToolUse`: Minga runs your shell command before a matching agent tool executes, sends JSON about the call on stdin, and treats any non-zero exit as a veto.
+
+## Configure a PreToolUse hook
+
+Add hooks to your Minga config with the `:agent_hooks` option:
+
+```elixir
+use Minga.Config
+
+set :agent_hooks, [
+  %{
+    event: "PreToolUse",
+    tool: "shell",
+    command: "~/.config/minga/hooks/check-shell-command.sh",
+    timeout_ms: 10_000
+  }
+]
+```
+
+`tool` can be an exact tool name, `*` for all tools, or a simple glob with `*` and `?`, such as `*_file`. Hooks run in the order you declare them. The first veto stops later hooks and prevents the tool from running.
+
+`timeout_ms` is optional. The default is `30_000` milliseconds. If a hook exceeds its timeout, Minga kills it, blocks the tool call, and shows a clear error in the agent chat.
+
+## PreToolUse payload
+
+Minga writes one JSON object to the hook command's stdin:
+
+```json
+{
+  "event": "PreToolUse",
+  "tool_call_id": "tc_123",
+  "tool_name": "shell",
+  "arguments": {
+    "command": "git status --short"
+  }
+}
+```
+
+These fields are the public contract for `PreToolUse`:
+
+- `event`: always `PreToolUse` for this event.
+- `tool_call_id`: stable ID for this model-requested tool call.
+- `tool_name`: the Minga agent tool name, such as `shell`, `read_file`, or `write_file`.
+- `arguments`: the exact argument object the tool will receive if the hook allows it.
+
+A zero exit code allows the tool to run. A non-zero exit code blocks the tool. Minga ignores stdout and displays stderr as a system error in the chat, so write user-facing veto reasons to stderr.
+
+## Worked example: block risky shell commands
+
+`~/.config/minga/hooks/check-shell-command.sh`:
+
+```sh
+#!/bin/sh
+payload=$(cat)
+
+case "$payload" in
+  *'"command":"rm -rf /"'*)
+    echo "Blocked dangerous shell command: rm -rf /" >&2
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+```
+
+Config:
+
+```elixir
+use Minga.Config
+
+set :agent_hooks, [
+  %{event: "PreToolUse", tool: "shell", command: "~/.config/minga/hooks/check-shell-command.sh"}
+]
+```
+
+## Event taxonomy
+
+The hook config includes an explicit event name because hooks will cover more agent lifecycle points over time. Only `PreToolUse` is active today. Other names are reserved so future config and docs have a stable vocabulary, but declaring them is rejected until they are implemented.
+
+| Event | Implemented | Can veto | When it runs | Payload fields |
+| --- | --- | --- | --- | --- |
+| `PreToolUse` | Yes | Yes | Before a matching tool callback executes. | `event`, `tool_call_id`, `tool_name`, `arguments` |
+| `PostToolUse` | No | No | After a tool completes. | `event`, `tool_call_id`, `tool_name`, `arguments`, `result`, `is_error` |
+| `SessionStart` | No | No | When an agent session starts. | `event`, `session_id`, `model`, `provider`, `project_root` |
+| `SessionEnd` | No | No | When an agent session ends or is cleared. | `event`, `session_id`, `reason`, `status` |
+| `UserPromptSubmit` | No | Yes | Before a user prompt is sent to the model. | `event`, `session_id`, `prompt`, `attachments` |
+| `Stop` | No | No | When the main agent turn stops. | `event`, `session_id`, `reason`, `last_message` |
+| `SubagentStop` | No | No | When a sub-agent finishes. | `event`, `parent_session_id`, `subagent_session_id`, `result`, `is_error` |
+| `PreCompact` | No | Yes | Before conversation compaction runs. | `event`, `session_id`, `message_count`, `token_estimate` |
+| `Notification` | No | No | When the agent sends a user notification. | `event`, `session_id`, `kind`, `message` |
+
+Payload fields for reserved events are a planned contract, not a runtime guarantee in this ticket. The implemented `PreToolUse` payload above is the only schema user scripts can rely on today.

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -35,6 +35,7 @@ defmodule Minga.Config.Options do
   | `:breakindent`          | boolean                                    | `true`     |
   | `:agent_tool_approval`  | `:destructive`, `:all`, or `:none`          | `:destructive` |
   | `:agent_destructive_tools` | list of tool name strings                | `["write_file", "edit_file", "shell"]` |
+  | `:agent_hooks`            | list of agent hook declarations            | `[]`       |
   | `:agent_panel_split`      | positive integer (30-80)                   | `65`       |
   | `:startup_view`           | `:agent` or `:editor`                       | `:agent`   |
   | `:agent_auto_context`     | boolean                                     | `true`     |
@@ -107,6 +108,7 @@ defmodule Minga.Config.Options do
           | :agent_tool_approval
           | :agent_destructive_tools
           | :agent_tool_permissions
+          | :agent_hooks
           | :agent_session_retention_days
           | :agent_panel_split
           | :startup_view
@@ -237,6 +239,7 @@ defmodule Minga.Config.Options do
     {:agent_destructive_tools, :string_list,
      ["write_file", "edit_file", "multi_edit_file", "shell", "git_stage", "git_commit", "rename"]},
     {:agent_tool_permissions, :map_or_nil, nil},
+    {:agent_hooks, :any, []},
     {:agent_session_retention_days, :pos_integer, 30},
     {:agent_panel_split, :pos_integer, 65},
     {:startup_view, {:enum, [:agent, :editor]}, :agent},
@@ -788,8 +791,8 @@ defmodule Minga.Config.Options do
   end
 
   # :any is used for options whose values are complex types (lists of atoms,
-  # nested keywords) that don't fit the simple type validators. Currently only
-  # used by :agent_notify_on which accepts a list of event atoms.
+  # nested keywords) that don't fit the simple type validators. Agent hooks use
+  # it because they are normalized by MingaAgent.Config into typed structs.
   defp validate_type(:any, _name, _value), do: :ok
 
   defp validate_type(:theme_atom, _name, value) when is_atom(value) do

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -39,6 +39,7 @@ defmodule Minga.Events do
   | `:project_rebuilt` | `ProjectRebuiltEvent` | `root: String.t()` |
   | `:command_done`    | `CommandDoneEvent`    | `name: String.t(), exit_code: non_neg_integer()` |
   | `:log_message`     | `LogMessageEvent`     | `text: String.t(), level: :info \| :warning \| :error` |
+  | `:agent_hook`      | `AgentHookEvent`        | `event, phase, tool_name, tool_call_id, tool_pattern` |
   | `:face_overrides_changed` | `FaceOverridesChangedEvent` | `buffer: pid(), overrides: map()` |
 
   ## Why Registry?
@@ -181,6 +182,23 @@ defmodule Minga.Events do
     @type t :: %__MODULE__{text: String.t(), level: level()}
   end
 
+  defmodule AgentHookEvent do
+    @moduledoc "Payload for `:agent_hook` lifecycle telemetry events."
+    @enforce_keys [:event, :phase, :tool_name, :tool_call_id, :tool_pattern]
+    defstruct [:event, :phase, :tool_name, :tool_call_id, :tool_pattern, :exit_status, :reason]
+
+    @type phase :: :started | :allowed | :vetoed
+    @type t :: %__MODULE__{
+            event: String.t(),
+            phase: phase(),
+            tool_name: String.t(),
+            tool_call_id: String.t(),
+            tool_pattern: String.t(),
+            exit_status: non_neg_integer() | nil,
+            reason: term()
+          }
+  end
+
   defmodule FaceOverridesChangedEvent do
     @moduledoc """
     Payload for `:face_overrides_changed` events.
@@ -239,6 +257,7 @@ defmodule Minga.Events do
           | :log_message
           | :face_overrides_changed
           | :agent_session_stopped
+          | :agent_hook
           | :changeset_merged
           | :changeset_budget_exhausted
           | :load_user_themes
@@ -259,6 +278,7 @@ defmodule Minga.Events do
           | LspStatusEvent.t()
           | SupervisorRestartedEvent.t()
           | LogMessageEvent.t()
+          | AgentHookEvent.t()
           | FaceOverridesChangedEvent.t()
           | LoadUserThemesEvent.t()
           | MingaAgent.SessionManager.SessionStoppedEvent.t()
@@ -382,6 +402,7 @@ defmodule Minga.Events do
   @spec broadcast(:changeset_budget_exhausted, MingaAgent.Changeset.BudgetExhaustedEvent.t()) ::
           :ok
   @spec broadcast(:load_user_themes, LoadUserThemesEvent.t()) :: :ok
+  @spec broadcast(:agent_hook, AgentHookEvent.t()) :: :ok
   @spec broadcast(:buffer_fork_conflict, map()) :: :ok
   @spec broadcast(:extension_updates_available, Minga.Extension.UpdatesAvailableEvent.t()) :: :ok
   def broadcast(topic, payload) when is_atom(topic) and is_map(payload) do

--- a/lib/minga_agent/config.ex
+++ b/lib/minga_agent/config.ex
@@ -18,6 +18,8 @@ defmodule MingaAgent.Config do
   4. If internal-only, the struct default is sufficient
   """
 
+  alias MingaAgent.Hooks.Hook
+
   @default_model "anthropic:claude-sonnet-4"
 
   defstruct [
@@ -35,10 +37,11 @@ defmodule MingaAgent.Config do
     max_retries: 3,
     max_cost: nil,
 
-    # Tool approval
+    # Tool approval and hooks
     tool_approval: :destructive,
     destructive_tools: ~w(write_file edit_file multi_edit_file shell git_stage git_commit),
     tool_permissions: nil,
+    agent_hooks: [],
 
     # System prompt
     system_prompt: "",
@@ -92,6 +95,7 @@ defmodule MingaAgent.Config do
           tool_approval: :destructive | :all | :none,
           destructive_tools: [String.t()],
           tool_permissions: map() | nil,
+          agent_hooks: [Hook.t()],
           system_prompt: String.t(),
           append_system_prompt: String.t(),
           api_base_url: String.t(),
@@ -140,6 +144,7 @@ defmodule MingaAgent.Config do
           ~w(write_file edit_file multi_edit_file shell git_stage git_commit)
         ),
       tool_permissions: get(:agent_tool_permissions, nil),
+      agent_hooks: normalize_hooks(get(:agent_hooks, [])),
       system_prompt: get(:agent_system_prompt, ""),
       append_system_prompt: get(:agent_append_system_prompt, ""),
       api_base_url: get(:agent_api_base_url, ""),
@@ -162,6 +167,21 @@ defmodule MingaAgent.Config do
   @doc "Returns the default model string (with provider prefix)."
   @spec default_model() :: String.t()
   def default_model, do: @default_model
+
+  @doc "Normalizes raw `:agent_hooks` config declarations into hook structs."
+  @spec normalize_hooks(term()) :: [Hook.t()]
+  def normalize_hooks(nil), do: []
+
+  def normalize_hooks(raw_hooks) when is_list(raw_hooks) do
+    raw_hooks
+    |> Enum.map(&Hook.normalize/1)
+    |> Enum.flat_map(fn
+      {:ok, hook} -> [hook]
+      {:error, message} -> raise ArgumentError, message
+    end)
+  end
+
+  def normalize_hooks(_raw_hooks), do: raise(ArgumentError, ":agent_hooks must be a list")
 
   @doc """
   Returns the configured model, falling back to the default.

--- a/lib/minga_agent/hooks/command_runner.ex
+++ b/lib/minga_agent/hooks/command_runner.ex
@@ -11,6 +11,8 @@ defmodule MingaAgent.Hooks.CommandRunner do
   alias MingaAgent.Hooks.PreToolUsePayload
   alias MingaAgent.Hooks.Result
 
+  @payload_dir_attempts 5
+
   @doc "Runs a `PreToolUse` shell hook for a payload."
   @spec run_pre_tool_use(Hook.t(), PreToolUsePayload.t()) :: Result.t()
   def run_pre_tool_use(%Hook{} = hook, %PreToolUsePayload{} = payload) do
@@ -21,7 +23,7 @@ defmodule MingaAgent.Hooks.CommandRunner do
         try do
           run_shell(hook, payload_path)
         after
-          File.rm(payload_path)
+          cleanup_payload(payload_path)
         end
 
       {:error, reason} ->
@@ -35,12 +37,76 @@ defmodule MingaAgent.Hooks.CommandRunner do
 
   @spec write_payload(String.t()) :: {:ok, String.t()} | {:error, term()}
   defp write_payload(payload_json) do
-    path = Path.join(System.tmp_dir!(), "minga-hook-#{:erlang.unique_integer([:positive])}.json")
-
-    case File.write(path, payload_json) do
-      :ok -> {:ok, path}
+    case create_payload_dir() do
+      {:ok, dir} -> write_payload_file(dir, payload_json)
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  @spec write_payload_file(String.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  defp write_payload_file(dir, payload_json) do
+    path = Path.join(dir, "payload.json")
+
+    case write_private_file(path, payload_json) do
+      :ok -> {:ok, path}
+      {:error, reason} -> cleanup_failed_payload(path, dir, reason)
+    end
+  end
+
+  @spec write_private_file(String.t(), String.t()) :: :ok | {:error, term()}
+  defp write_private_file(path, payload_json) do
+    case File.write(path, payload_json, [:binary]) do
+      :ok -> File.chmod(path, 0o600)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec create_payload_dir(non_neg_integer()) :: {:ok, String.t()} | {:error, term()}
+  defp create_payload_dir(attempts \\ @payload_dir_attempts)
+
+  defp create_payload_dir(0), do: {:error, :payload_dir_collision}
+
+  defp create_payload_dir(attempts) do
+    dir = Path.join(System.tmp_dir!(), "minga-hook-#{random_suffix()}")
+
+    case File.mkdir(dir) do
+      :ok -> chmod_payload_dir(dir)
+      {:error, :eexist} -> create_payload_dir(attempts - 1)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec chmod_payload_dir(String.t()) :: {:ok, String.t()} | {:error, term()}
+  defp chmod_payload_dir(dir) do
+    case File.chmod(dir, 0o700) do
+      :ok ->
+        {:ok, dir}
+
+      {:error, reason} ->
+        File.rmdir(dir)
+        {:error, reason}
+    end
+  end
+
+  @spec random_suffix() :: String.t()
+  defp random_suffix do
+    18
+    |> :crypto.strong_rand_bytes()
+    |> Base.url_encode64(padding: false)
+  end
+
+  @spec cleanup_payload(String.t()) :: :ok
+  defp cleanup_payload(path) do
+    File.rm(path)
+    File.rmdir(Path.dirname(path))
+    :ok
+  end
+
+  @spec cleanup_failed_payload(String.t(), String.t(), term()) :: {:error, term()}
+  defp cleanup_failed_payload(path, dir, reason) do
+    File.rm(path)
+    File.rmdir(dir)
+    {:error, reason}
   end
 
   @spec run_shell(Hook.t(), String.t()) :: Result.t()
@@ -55,7 +121,8 @@ defmodule MingaAgent.Hooks.CommandRunner do
         args: ["-c", wrapper]
       ])
 
-    collect(port, hook, "")
+    deadline = System.monotonic_time(:millisecond) + hook.timeout_ms
+    collect_until(port, hook, "", deadline)
   rescue
     e ->
       Result.veto(
@@ -72,23 +139,89 @@ defmodule MingaAgent.Hooks.CommandRunner do
       )
   end
 
-  @spec collect(port(), Hook.t(), String.t()) :: Result.t()
-  defp collect(port, hook, stderr) do
-    receive do
-      {^port, {:data, data}} ->
-        collect(port, hook, stderr <> data)
+  @spec collect_until(port(), Hook.t(), String.t(), integer()) :: Result.t()
+  defp collect_until(port, hook, stderr, deadline_ms) do
+    remaining_ms = deadline_ms - System.monotonic_time(:millisecond)
 
-      {^port, {:exit_status, 0}} ->
-        Result.allow(hook)
+    if remaining_ms <= 0 do
+      timeout(hook, port)
+    else
+      receive do
+        {^port, {:data, data}} ->
+          collect_until(port, hook, stderr <> data, deadline_ms)
 
-      {^port, {:exit_status, status}} ->
-        Result.veto(hook, stderr, {:exit, status})
-    after
-      hook.timeout_ms ->
-        close_port(port)
-        message = "PreToolUse hook timed out after #{hook.timeout_ms}ms and was killed"
-        Result.veto(hook, message, :timeout)
+        {^port, {:exit_status, 0}} ->
+          Result.allow(hook)
+
+        {^port, {:exit_status, status}} ->
+          Result.veto(hook, stderr, {:exit, status})
+      after
+        remaining_ms ->
+          timeout(hook, port)
+      end
     end
+  end
+
+  @spec timeout(Hook.t(), port()) :: Result.t()
+  defp timeout(hook, port) do
+    kill_port_process_tree(port)
+    close_port(port)
+    message = "PreToolUse hook timed out after #{hook.timeout_ms}ms and was killed"
+    Result.veto(hook, message, :timeout)
+  end
+
+  @spec kill_port_process_tree(port()) :: :ok
+  defp kill_port_process_tree(port) do
+    case Port.info(port, :os_pid) do
+      {:os_pid, pid} when is_integer(pid) -> kill_process_tree(pid)
+      _other -> :ok
+    end
+  rescue
+    ArgumentError -> :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  @spec kill_process_tree(non_neg_integer()) :: :ok
+  defp kill_process_tree(pid) do
+    pid
+    |> child_pids()
+    |> Enum.each(&kill_process_tree/1)
+
+    kill_pid(pid)
+  end
+
+  @spec child_pids(non_neg_integer()) :: [non_neg_integer()]
+  defp child_pids(pid) do
+    case System.cmd("pgrep", ["-P", Integer.to_string(pid)], stderr_to_stdout: true) do
+      {output, 0} -> parse_pids(output)
+      {_output, _status} -> []
+    end
+  rescue
+    ErlangError -> []
+  end
+
+  @spec parse_pids(String.t()) :: [non_neg_integer()]
+  defp parse_pids(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.flat_map(&parse_pid/1)
+  end
+
+  @spec parse_pid(String.t()) :: [non_neg_integer()]
+  defp parse_pid(raw) do
+    case Integer.parse(String.trim(raw)) do
+      {pid, ""} when pid >= 0 -> [pid]
+      _other -> []
+    end
+  end
+
+  @spec kill_pid(non_neg_integer()) :: :ok
+  defp kill_pid(pid) do
+    System.cmd("kill", ["-KILL", Integer.to_string(pid)], stderr_to_stdout: true)
+    :ok
+  rescue
+    ErlangError -> :ok
   end
 
   @spec close_port(port()) :: :ok

--- a/lib/minga_agent/hooks/command_runner.ex
+++ b/lib/minga_agent/hooks/command_runner.ex
@@ -1,0 +1,108 @@
+defmodule MingaAgent.Hooks.CommandRunner do
+  @moduledoc """
+  Executes shell-backed agent hooks.
+
+  Commands run through `/bin/sh -c`. The hook payload is JSON on standard
+  input, stdout is ignored, stderr is captured for veto messages, and each
+  hook has an independent timeout.
+  """
+
+  alias MingaAgent.Hooks.Hook
+  alias MingaAgent.Hooks.PreToolUsePayload
+  alias MingaAgent.Hooks.Result
+
+  @doc "Runs a `PreToolUse` shell hook for a payload."
+  @spec run_pre_tool_use(Hook.t(), PreToolUsePayload.t()) :: Result.t()
+  def run_pre_tool_use(%Hook{} = hook, %PreToolUsePayload{} = payload) do
+    payload_json = Jason.encode!(PreToolUsePayload.to_map(payload))
+
+    case write_payload(payload_json) do
+      {:ok, payload_path} ->
+        try do
+          run_shell(hook, payload_path)
+        after
+          File.rm(payload_path)
+        end
+
+      {:error, reason} ->
+        Result.veto(
+          hook,
+          "failed to prepare hook payload: #{inspect(reason)}",
+          {:failed_to_start, reason}
+        )
+    end
+  end
+
+  @spec write_payload(String.t()) :: {:ok, String.t()} | {:error, term()}
+  defp write_payload(payload_json) do
+    path = Path.join(System.tmp_dir!(), "minga-hook-#{:erlang.unique_integer([:positive])}.json")
+
+    case File.write(path, payload_json) do
+      :ok -> {:ok, path}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec run_shell(Hook.t(), String.t()) :: Result.t()
+  defp run_shell(%Hook{} = hook, payload_path) do
+    wrapper = "exec < #{shell_quote(payload_path)}; exec 1>/dev/null; #{hook.command}"
+
+    port =
+      Port.open({:spawn_executable, "/bin/sh"}, [
+        :binary,
+        :exit_status,
+        :stderr_to_stdout,
+        args: ["-c", wrapper]
+      ])
+
+    collect(port, hook, "")
+  rescue
+    e ->
+      Result.veto(
+        hook,
+        "failed to start hook command: #{Exception.message(e)}",
+        {:failed_to_start, e}
+      )
+  catch
+    kind, reason ->
+      Result.veto(
+        hook,
+        "failed to start hook command: #{inspect(kind)} #{inspect(reason)}",
+        {:failed_to_start, {kind, reason}}
+      )
+  end
+
+  @spec collect(port(), Hook.t(), String.t()) :: Result.t()
+  defp collect(port, hook, stderr) do
+    receive do
+      {^port, {:data, data}} ->
+        collect(port, hook, stderr <> data)
+
+      {^port, {:exit_status, 0}} ->
+        Result.allow(hook)
+
+      {^port, {:exit_status, status}} ->
+        Result.veto(hook, stderr, {:exit, status})
+    after
+      hook.timeout_ms ->
+        close_port(port)
+        message = "PreToolUse hook timed out after #{hook.timeout_ms}ms and was killed"
+        Result.veto(hook, message, :timeout)
+    end
+  end
+
+  @spec close_port(port()) :: :ok
+  defp close_port(port) do
+    Port.close(port)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  @spec shell_quote(String.t()) :: String.t()
+  defp shell_quote(value) do
+    "'" <> String.replace(value, "'", "'\\''") <> "'"
+  end
+end

--- a/lib/minga_agent/hooks/command_runner.ex
+++ b/lib/minga_agent/hooks/command_runner.ex
@@ -1,30 +1,32 @@
 defmodule MingaAgent.Hooks.CommandRunner do
   @moduledoc """
-  Executes shell-backed agent hooks.
+  Executes shell-backed agent hooks through the `minga-hook-runner` helper.
 
-  Commands run through `/bin/sh -c`. The hook payload is JSON on standard
-  input, stdout is ignored, stderr is captured for veto messages, and each
-  hook has an independent timeout.
+  The helper runs `/bin/sh -c` in a dedicated POSIX process group, feeds the hook payload on stdin, discards stdout, captures bounded stderr, and enforces each hook's timeout. This module owns payload encoding and maps the helper's structured JSON result into `MingaAgent.Hooks.Result`.
   """
 
   alias MingaAgent.Hooks.Hook
   alias MingaAgent.Hooks.PreToolUsePayload
   alias MingaAgent.Hooks.Result
 
-  @payload_dir_attempts 5
-  @pgrep_paths ~w(/usr/bin/pgrep /bin/pgrep)
-  @kill_paths ~w(/bin/kill /usr/bin/kill)
+  @helper_name "minga-hook-runner"
+  @guard_timeout_ms 1_000
+
+  @typedoc "Options used by tests to inject helper behavior."
+  @type run_opts :: [helper_path: String.t()]
 
   @doc "Runs a `PreToolUse` shell hook for a payload."
   @spec run_pre_tool_use(Hook.t(), PreToolUsePayload.t()) :: Result.t()
   def run_pre_tool_use(%Hook{} = hook, %PreToolUsePayload{} = payload) do
+    run_pre_tool_use(hook, payload, [])
+  end
+
+  @doc false
+  @spec run_pre_tool_use(Hook.t(), PreToolUsePayload.t(), run_opts()) :: Result.t()
+  def run_pre_tool_use(%Hook{} = hook, %PreToolUsePayload{} = payload, opts) when is_list(opts) do
     with {:ok, payload_json} <- encode_payload(payload),
-         {:ok, payload_path} <- write_payload(payload_json) do
-      try do
-        run_shell(hook, payload_path)
-      after
-        cleanup_payload(payload_path)
-      end
+         {:ok, helper_path} <- helper_path(opts) do
+      run_helper(hook, helper_path, payload_json)
     else
       {:error, reason} -> payload_preparation_veto(hook, reason)
     end
@@ -67,208 +69,166 @@ defmodule MingaAgent.Hooks.CommandRunner do
 
   defp format_prepare_reason(reason), do: inspect(reason)
 
-  @spec write_payload(String.t()) :: {:ok, String.t()} | {:error, term()}
-  defp write_payload(payload_json) do
-    case create_payload_dir() do
-      {:ok, dir} -> write_payload_file(dir, payload_json)
-      {:error, reason} -> {:error, reason}
+  @spec helper_path(run_opts()) :: {:ok, String.t()} | {:error, term()}
+  defp helper_path(opts) do
+    case Keyword.get(opts, :helper_path) do
+      nil -> discover_helper_path()
+      path when is_binary(path) -> {:ok, path}
+      other -> {:error, {:invalid_helper_path, other}}
     end
   end
 
-  @spec write_payload_file(String.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
-  defp write_payload_file(dir, payload_json) do
-    path = Path.join(dir, "payload.json")
+  @spec discover_helper_path() :: {:ok, String.t()} | {:error, term()}
+  defp discover_helper_path do
+    candidates = [
+      Path.join(:code.priv_dir(:minga), @helper_name),
+      Path.join([File.cwd!(), "priv", @helper_name]),
+      Path.join([File.cwd!(), "zig", "zig-out", "bin", @helper_name])
+    ]
 
-    case write_private_file(path, payload_json) do
-      :ok -> {:ok, path}
-      {:error, reason} -> cleanup_failed_payload(path, dir, reason)
+    case Enum.find(candidates, &File.exists?/1) do
+      nil -> {:error, {:helper_not_found, candidates}}
+      path -> {:ok, path}
     end
   end
 
-  @spec write_private_file(String.t(), String.t()) :: :ok | {:error, term()}
-  defp write_private_file(path, payload_json) do
-    case File.write(path, payload_json, [:binary]) do
-      :ok -> File.chmod(path, 0o600)
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  @spec create_payload_dir(non_neg_integer()) :: {:ok, String.t()} | {:error, term()}
-  defp create_payload_dir(attempts \\ @payload_dir_attempts)
-
-  defp create_payload_dir(0), do: {:error, :payload_dir_collision}
-
-  defp create_payload_dir(attempts) do
-    dir = Path.join(System.tmp_dir!(), "minga-hook-#{random_suffix()}")
-
-    case File.mkdir(dir) do
-      :ok -> chmod_payload_dir(dir)
-      {:error, :eexist} -> create_payload_dir(attempts - 1)
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  @spec chmod_payload_dir(String.t()) :: {:ok, String.t()} | {:error, term()}
-  defp chmod_payload_dir(dir) do
-    case File.chmod(dir, 0o700) do
-      :ok ->
-        {:ok, dir}
-
-      {:error, reason} ->
-        File.rmdir(dir)
-        {:error, reason}
-    end
-  end
-
-  @spec random_suffix() :: String.t()
-  defp random_suffix do
-    18
-    |> :crypto.strong_rand_bytes()
-    |> Base.url_encode64(padding: false)
-  end
-
-  @spec cleanup_payload(String.t()) :: :ok
-  defp cleanup_payload(path) do
-    File.rm(path)
-    File.rmdir(Path.dirname(path))
-    :ok
-  end
-
-  @spec cleanup_failed_payload(String.t(), String.t(), term()) :: {:error, term()}
-  defp cleanup_failed_payload(path, dir, reason) do
-    File.rm(path)
-    File.rmdir(dir)
-    {:error, reason}
-  end
-
-  @spec run_shell(Hook.t(), String.t()) :: Result.t()
-  defp run_shell(%Hook{} = hook, payload_path) do
-    wrapper = "exec < #{shell_quote(payload_path)}; exec 1>/dev/null; #{hook.command}"
-
+  @spec run_helper(Hook.t(), String.t(), String.t()) :: Result.t()
+  defp run_helper(%Hook{} = hook, helper_path, payload_json) do
     port =
-      Port.open({:spawn_executable, "/bin/sh"}, [
+      Port.open({:spawn_executable, helper_path}, [
         :binary,
         :exit_status,
-        :stderr_to_stdout,
-        args: ["-c", wrapper]
+        args: [
+          Integer.to_string(hook.timeout_ms),
+          Integer.to_string(byte_size(payload_json)),
+          hook.command
+        ]
       ])
 
-    deadline = System.monotonic_time(:millisecond) + hook.timeout_ms
-    collect_until(port, hook, "", deadline)
+    os_pid = port_os_pid(port)
+    true = Port.command(port, payload_json)
+    guard_deadline_ms = System.monotonic_time(:millisecond) + hook.timeout_ms + @guard_timeout_ms
+    collect_helper_result(port, hook, "", guard_deadline_ms, os_pid)
   rescue
     e ->
       Result.veto(
         hook,
-        "failed to start hook command: #{Exception.message(e)}",
+        "failed to start hook runner: #{Exception.message(e)}",
         {:failed_to_start, e}
       )
   catch
     kind, reason ->
       Result.veto(
         hook,
-        "failed to start hook command: #{inspect(kind)} #{inspect(reason)}",
+        "failed to start hook runner: #{inspect(kind)} #{inspect(reason)}",
         {:failed_to_start, {kind, reason}}
       )
   end
 
-  @spec collect_until(port(), Hook.t(), String.t(), integer()) :: Result.t()
-  defp collect_until(port, hook, stderr, deadline_ms) do
-    remaining_ms = deadline_ms - System.monotonic_time(:millisecond)
+  @spec collect_helper_result(port(), Hook.t(), String.t(), integer(), pos_integer() | nil) ::
+          Result.t()
+  defp collect_helper_result(port, hook, stdout, guard_deadline_ms, os_pid) do
+    remaining_ms = guard_deadline_ms - System.monotonic_time(:millisecond)
 
     if remaining_ms <= 0 do
-      timeout(hook, port)
+      helper_timeout(port, hook, os_pid)
     else
       receive do
         {^port, {:data, data}} ->
-          collect_until(port, hook, stderr <> data, deadline_ms)
+          collect_helper_result(port, hook, stdout <> data, guard_deadline_ms, os_pid)
 
         {^port, {:exit_status, 0}} ->
-          Result.allow(hook)
+          decode_helper_result(hook, stdout)
 
         {^port, {:exit_status, status}} ->
-          Result.veto(hook, stderr, {:exit, status})
+          Result.veto(
+            hook,
+            "hook runner exited with status #{status}",
+            {:failed_to_start, {:helper_exit, status}}
+          )
       after
-        remaining_ms ->
-          timeout(hook, port)
+        remaining_ms -> helper_timeout(port, hook, os_pid)
       end
     end
   end
 
-  @spec timeout(Hook.t(), port()) :: Result.t()
-  defp timeout(hook, port) do
-    kill_port_process_tree(port)
+  @spec helper_timeout(port(), Hook.t(), pos_integer() | nil) :: Result.t()
+  defp helper_timeout(port, hook, os_pid) do
+    kill_helper_process(os_pid)
     close_port(port)
-    message = "PreToolUse hook timed out after #{hook.timeout_ms}ms and was killed"
-    Result.veto(hook, message, :timeout)
+
+    Result.veto(
+      hook,
+      "hook runner timed out after #{hook.timeout_ms + @guard_timeout_ms}ms",
+      {:failed_to_start, :helper_timeout}
+    )
   end
 
-  @spec kill_port_process_tree(port()) :: :ok
-  defp kill_port_process_tree(port) do
+  @spec port_os_pid(port()) :: pos_integer() | nil
+  defp port_os_pid(port) do
     case Port.info(port, :os_pid) do
-      {:os_pid, pid} when is_integer(pid) -> kill_process_tree(pid)
-      _other -> :ok
-    end
-  rescue
-    ArgumentError -> :ok
-  catch
-    :exit, _ -> :ok
-  end
-
-  @spec kill_process_tree(non_neg_integer()) :: :ok
-  defp kill_process_tree(pid) do
-    pid
-    |> child_pids()
-    |> Enum.each(&kill_process_tree/1)
-
-    kill_pid(pid)
-  end
-
-  @spec child_pids(non_neg_integer()) :: [non_neg_integer()]
-  defp child_pids(pid) do
-    case executable_path(@pgrep_paths) do
-      nil ->
-        []
-
-      pgrep ->
-        case System.cmd(pgrep, ["-P", Integer.to_string(pid)], stderr_to_stdout: true) do
-          {output, 0} -> parse_pids(output)
-          {_output, _status} -> []
-        end
-    end
-  rescue
-    ErlangError -> []
-  end
-
-  @spec parse_pids(String.t()) :: [non_neg_integer()]
-  defp parse_pids(output) do
-    output
-    |> String.split("\n", trim: true)
-    |> Enum.flat_map(&parse_pid/1)
-  end
-
-  @spec parse_pid(String.t()) :: [non_neg_integer()]
-  defp parse_pid(raw) do
-    case Integer.parse(String.trim(raw)) do
-      {pid, ""} when pid >= 0 -> [pid]
-      _other -> []
+      {:os_pid, pid} when is_integer(pid) and pid > 0 -> pid
+      _other -> nil
     end
   end
 
-  @spec kill_pid(non_neg_integer()) :: :ok
-  defp kill_pid(pid) do
-    case executable_path(@kill_paths) do
-      nil -> :ok
-      kill -> System.cmd(kill, ["-KILL", Integer.to_string(pid)], stderr_to_stdout: true)
-    end
+  @spec kill_helper_process(pos_integer() | nil) :: :ok
+  defp kill_helper_process(nil), do: :ok
 
+  defp kill_helper_process(pid) do
+    pid_arg = Integer.to_string(pid)
+    System.cmd("kill", ["-TERM", pid_arg], stderr_to_stdout: true)
+    System.cmd("kill", ["-KILL", pid_arg], stderr_to_stdout: true)
     :ok
   rescue
-    ErlangError -> :ok
+    _ -> :ok
   end
 
-  @spec executable_path([String.t()]) :: String.t() | nil
-  defp executable_path(paths) do
-    Enum.find(paths, &File.regular?/1)
+  @spec decode_helper_result(Hook.t(), String.t()) :: Result.t()
+  defp decode_helper_result(hook, stdout) do
+    case Jason.decode(stdout) do
+      {:ok, %{"status" => "allow"}} ->
+        Result.allow(hook)
+
+      {:ok, %{"status" => "veto", "reason" => %{"type" => "exit", "status" => status}} = result}
+      when is_integer(status) and status >= 0 ->
+        Result.veto(hook, result_stderr(result), {:exit, status})
+
+      {:ok, %{"status" => "veto", "reason" => %{"type" => "timeout"}} = result} ->
+        Result.veto(hook, timeout_stderr(hook, result_stderr(result)), :timeout)
+
+      {:ok, %{"status" => "error", "message" => message}} when is_binary(message) ->
+        Result.veto(hook, "hook runner failed: #{message}", {:failed_to_start, :helper_error})
+
+      {:ok, _other} ->
+        malformed_result(hook)
+
+      {:error, _reason} ->
+        malformed_result(hook)
+    end
+  end
+
+  @spec result_stderr(map()) :: String.t()
+  defp result_stderr(%{"stderr" => stderr}) when is_binary(stderr), do: stderr
+  defp result_stderr(_result), do: ""
+
+  @spec timeout_stderr(Hook.t(), String.t()) :: String.t()
+  defp timeout_stderr(hook, stderr) do
+    message = "PreToolUse hook timed out after #{hook.timeout_ms}ms and was killed"
+
+    case String.trim(stderr) do
+      "" -> message
+      _non_empty -> stderr <> "\n" <> message
+    end
+  end
+
+  @spec malformed_result(Hook.t()) :: Result.t()
+  defp malformed_result(hook) do
+    Result.veto(
+      hook,
+      "malformed hook runner result",
+      {:failed_to_start, :malformed_helper_result}
+    )
   end
 
   @spec close_port(port()) :: :ok
@@ -279,10 +239,5 @@ defmodule MingaAgent.Hooks.CommandRunner do
     ArgumentError -> :ok
   catch
     :exit, _ -> :ok
-  end
-
-  @spec shell_quote(String.t()) :: String.t()
-  defp shell_quote(value) do
-    "'" <> String.replace(value, "'", "'\\''") <> "'"
   end
 end

--- a/lib/minga_agent/hooks/command_runner.ex
+++ b/lib/minga_agent/hooks/command_runner.ex
@@ -12,28 +12,60 @@ defmodule MingaAgent.Hooks.CommandRunner do
   alias MingaAgent.Hooks.Result
 
   @payload_dir_attempts 5
+  @pgrep_paths ~w(/usr/bin/pgrep /bin/pgrep)
+  @kill_paths ~w(/bin/kill /usr/bin/kill)
 
   @doc "Runs a `PreToolUse` shell hook for a payload."
   @spec run_pre_tool_use(Hook.t(), PreToolUsePayload.t()) :: Result.t()
   def run_pre_tool_use(%Hook{} = hook, %PreToolUsePayload{} = payload) do
-    payload_json = Jason.encode!(PreToolUsePayload.to_map(payload))
-
-    case write_payload(payload_json) do
-      {:ok, payload_path} ->
-        try do
-          run_shell(hook, payload_path)
-        after
-          cleanup_payload(payload_path)
-        end
-
-      {:error, reason} ->
-        Result.veto(
-          hook,
-          "failed to prepare hook payload: #{inspect(reason)}",
-          {:failed_to_start, reason}
-        )
+    with {:ok, payload_json} <- encode_payload(payload),
+         {:ok, payload_path} <- write_payload(payload_json) do
+      try do
+        run_shell(hook, payload_path)
+      after
+        cleanup_payload(payload_path)
+      end
+    else
+      {:error, reason} -> payload_preparation_veto(hook, reason)
     end
   end
+
+  @spec encode_payload(PreToolUsePayload.t()) :: {:ok, String.t()} | {:error, term()}
+  defp encode_payload(%PreToolUsePayload{} = payload) do
+    case Jason.encode(PreToolUsePayload.to_map(payload)) do
+      {:ok, json} -> {:ok, json}
+      {:error, reason} -> {:error, safe_encode_reason(reason)}
+    end
+  rescue
+    e -> {:error, safe_encode_reason(e)}
+  catch
+    kind, _reason -> {:error, {:encode_failed, kind}}
+  end
+
+  @spec payload_preparation_veto(Hook.t(), term()) :: Result.t()
+  defp payload_preparation_veto(hook, reason) do
+    Result.veto(
+      hook,
+      "failed to prepare hook payload: #{format_prepare_reason(reason)}",
+      {:failed_to_start, reason}
+    )
+  end
+
+  @spec safe_encode_reason(Exception.t()) :: {:encode_failed, module()}
+  defp safe_encode_reason(%Protocol.UndefinedError{protocol: protocol}) do
+    {:encode_failed, protocol}
+  end
+
+  defp safe_encode_reason(%{__struct__: module}) when is_atom(module) do
+    {:encode_failed, module}
+  end
+
+  @spec format_prepare_reason(term()) :: String.t()
+  defp format_prepare_reason({:encode_failed, reason}) do
+    "could not JSON encode payload with #{inspect(reason)}"
+  end
+
+  defp format_prepare_reason(reason), do: inspect(reason)
 
   @spec write_payload(String.t()) :: {:ok, String.t()} | {:error, term()}
   defp write_payload(payload_json) do
@@ -193,9 +225,15 @@ defmodule MingaAgent.Hooks.CommandRunner do
 
   @spec child_pids(non_neg_integer()) :: [non_neg_integer()]
   defp child_pids(pid) do
-    case System.cmd("pgrep", ["-P", Integer.to_string(pid)], stderr_to_stdout: true) do
-      {output, 0} -> parse_pids(output)
-      {_output, _status} -> []
+    case executable_path(@pgrep_paths) do
+      nil ->
+        []
+
+      pgrep ->
+        case System.cmd(pgrep, ["-P", Integer.to_string(pid)], stderr_to_stdout: true) do
+          {output, 0} -> parse_pids(output)
+          {_output, _status} -> []
+        end
     end
   rescue
     ErlangError -> []
@@ -218,10 +256,19 @@ defmodule MingaAgent.Hooks.CommandRunner do
 
   @spec kill_pid(non_neg_integer()) :: :ok
   defp kill_pid(pid) do
-    System.cmd("kill", ["-KILL", Integer.to_string(pid)], stderr_to_stdout: true)
+    case executable_path(@kill_paths) do
+      nil -> :ok
+      kill -> System.cmd(kill, ["-KILL", Integer.to_string(pid)], stderr_to_stdout: true)
+    end
+
     :ok
   rescue
     ErlangError -> :ok
+  end
+
+  @spec executable_path([String.t()]) :: String.t() | nil
+  defp executable_path(paths) do
+    Enum.find(paths, &File.regular?/1)
   end
 
   @spec close_port(port()) :: :ok

--- a/lib/minga_agent/hooks/dispatcher.ex
+++ b/lib/minga_agent/hooks/dispatcher.ex
@@ -1,0 +1,75 @@
+defmodule MingaAgent.Hooks.Dispatcher do
+  @moduledoc """
+  Dispatches normalized agent hooks for a tool lifecycle event.
+
+  The dispatcher is intentionally stateless. It receives a list of hooks from
+  `MingaAgent.Config`, filters matching hooks in registration order, and asks a
+  runner to execute each hook. The first veto short-circuits later hooks.
+  """
+
+  alias Minga.Events
+  alias MingaAgent.Hooks.CommandRunner
+  alias MingaAgent.Hooks.Hook
+  alias MingaAgent.Hooks.PreToolUsePayload
+  alias MingaAgent.Hooks.Result
+
+  @typedoc "Hook runner used by tests and production command execution."
+  @type runner :: (Hook.t(), PreToolUsePayload.t() -> Result.t())
+
+  @doc "Runs all matching `PreToolUse` hooks in registration order."
+  @spec pre_tool_use([Hook.t()], PreToolUsePayload.t()) :: :ok | {:error, Result.t()}
+  def pre_tool_use(hooks, %PreToolUsePayload{} = payload) when is_list(hooks) do
+    pre_tool_use(hooks, payload, [])
+  end
+
+  @doc "Runs matching `PreToolUse` hooks with an injected runner."
+  @spec pre_tool_use([Hook.t()], PreToolUsePayload.t(), keyword()) :: :ok | {:error, Result.t()}
+  def pre_tool_use(hooks, %PreToolUsePayload{} = payload, opts)
+      when is_list(hooks) and is_list(opts) do
+    runner = Keyword.get(opts, :runner, &CommandRunner.run_pre_tool_use/2)
+
+    hooks
+    |> Enum.filter(&Hook.matches?(&1, :pre_tool_use, payload.tool_name))
+    |> run_matching_hooks(payload, runner)
+  end
+
+  @spec run_matching_hooks([Hook.t()], PreToolUsePayload.t(), runner()) ::
+          :ok | {:error, Result.t()}
+  defp run_matching_hooks([], _payload, _runner), do: :ok
+
+  defp run_matching_hooks([hook | rest], payload, runner) do
+    broadcast(:started, hook, payload, nil)
+
+    case runner.(hook, payload) do
+      %Result{status: :allow} = result ->
+        broadcast(:allowed, hook, payload, result)
+        run_matching_hooks(rest, payload, runner)
+
+      %Result{status: :veto} = result ->
+        broadcast(:vetoed, hook, payload, result)
+        {:error, result}
+    end
+  end
+
+  @spec broadcast(
+          :started | :allowed | :vetoed,
+          Hook.t(),
+          PreToolUsePayload.t(),
+          Result.t() | nil
+        ) :: :ok
+  defp broadcast(phase, hook, payload, result) do
+    Events.broadcast(:agent_hook, %Events.AgentHookEvent{
+      event: "PreToolUse",
+      phase: phase,
+      tool_name: payload.tool_name,
+      tool_call_id: payload.tool_call_id,
+      tool_pattern: hook.tool_pattern,
+      exit_status: if(result, do: result.exit_status, else: nil),
+      reason: if(result, do: result.reason, else: nil)
+    })
+  rescue
+    ArgumentError -> :ok
+  catch
+    :exit, _ -> :ok
+  end
+end

--- a/lib/minga_agent/hooks/hook.ex
+++ b/lib/minga_agent/hooks/hook.ex
@@ -31,7 +31,10 @@ defmodule MingaAgent.Hooks.Hook do
   @doc "Normalizes a user config hook declaration into a `%Hook{}`."
   @spec normalize(term()) :: {:ok, t()} | {:error, String.t()}
   def normalize(raw) when is_list(raw) do
-    raw |> Map.new() |> normalize()
+    case map_from_list(raw) do
+      {:ok, map} -> normalize(map)
+      :error -> {:error, "agent hook must be a map or keyword list"}
+    end
   end
 
   def normalize(raw) when is_map(raw) do
@@ -59,6 +62,13 @@ defmodule MingaAgent.Hooks.Hook do
   end
 
   def matches?(%__MODULE__{}, _event, _tool_name), do: false
+
+  @spec map_from_list(list()) :: {:ok, map()} | :error
+  defp map_from_list(raw) do
+    {:ok, Map.new(raw)}
+  rescue
+    ArgumentError -> :error
+  end
 
   @spec normalize_event(term()) :: {:ok, event()} | {:error, String.t()}
   defp normalize_event(nil), do: {:error, "agent hook requires :event"}

--- a/lib/minga_agent/hooks/hook.ex
+++ b/lib/minga_agent/hooks/hook.ex
@@ -1,0 +1,137 @@
+defmodule MingaAgent.Hooks.Hook do
+  @moduledoc """
+  Normalized agent hook declaration.
+
+  Hooks are declared in user config as maps or keyword lists, then normalized
+  by `MingaAgent.Config.resolve/0` into this struct. Only `:pre_tool_use` is
+  executable today, but the event field is explicit so later lifecycle events
+  can share the same config shape.
+  """
+
+  @default_timeout_ms 30_000
+
+  @typedoc "Supported hook event names."
+  @type event :: :pre_tool_use
+
+  @typedoc "Normalized hook declaration."
+  @type t :: %__MODULE__{
+          event: event(),
+          tool_pattern: String.t(),
+          command: String.t(),
+          timeout_ms: pos_integer()
+        }
+
+  @enforce_keys [:event, :tool_pattern, :command]
+  defstruct [:event, :tool_pattern, :command, timeout_ms: @default_timeout_ms]
+
+  @doc "Returns the default per-hook timeout in milliseconds."
+  @spec default_timeout_ms() :: pos_integer()
+  def default_timeout_ms, do: @default_timeout_ms
+
+  @doc "Normalizes a user config hook declaration into a `%Hook{}`."
+  @spec normalize(term()) :: {:ok, t()} | {:error, String.t()}
+  def normalize(raw) when is_list(raw) do
+    raw |> Map.new() |> normalize()
+  end
+
+  def normalize(raw) when is_map(raw) do
+    with {:ok, event} <- normalize_event(fetch(raw, :event)),
+         {:ok, tool_pattern} <- normalize_tool_pattern(raw),
+         {:ok, command} <- normalize_command(fetch(raw, :command)),
+         {:ok, timeout_ms} <- normalize_timeout(fetch(raw, :timeout_ms)) do
+      {:ok,
+       %__MODULE__{
+         event: event,
+         tool_pattern: tool_pattern,
+         command: command,
+         timeout_ms: timeout_ms
+       }}
+    end
+  end
+
+  def normalize(_raw), do: {:error, "agent hook must be a map or keyword list"}
+
+  @doc "Returns true when this hook applies to the event and tool name."
+  @spec matches?(t(), event(), String.t()) :: boolean()
+  def matches?(%__MODULE__{event: event, tool_pattern: pattern}, event, tool_name)
+      when is_binary(tool_name) do
+    match_tool_pattern?(pattern, tool_name)
+  end
+
+  def matches?(%__MODULE__{}, _event, _tool_name), do: false
+
+  @spec normalize_event(term()) :: {:ok, event()} | {:error, String.t()}
+  defp normalize_event(nil), do: {:error, "agent hook requires :event"}
+  defp normalize_event(:pre_tool_use), do: {:ok, :pre_tool_use}
+  defp normalize_event(:PreToolUse), do: {:ok, :pre_tool_use}
+  defp normalize_event("PreToolUse"), do: {:ok, :pre_tool_use}
+  defp normalize_event("pre_tool_use"), do: {:ok, :pre_tool_use}
+  defp normalize_event(other), do: {:error, "unsupported agent hook event: #{inspect(other)}"}
+
+  @spec normalize_tool_pattern(map()) :: {:ok, String.t()} | {:error, String.t()}
+  defp normalize_tool_pattern(raw) do
+    raw
+    |> fetch(:tool_pattern)
+    |> fallback(fetch(raw, :tool))
+    |> normalize_non_empty_string("agent hook requires :tool_pattern or :tool")
+  end
+
+  @spec normalize_command(term()) :: {:ok, String.t()} | {:error, String.t()}
+  defp normalize_command(value),
+    do: normalize_non_empty_string(value, "agent hook requires :command")
+
+  @spec normalize_timeout(term()) :: {:ok, pos_integer()} | {:error, String.t()}
+  defp normalize_timeout(nil), do: {:ok, @default_timeout_ms}
+  defp normalize_timeout(value) when is_integer(value) and value > 0, do: {:ok, value}
+
+  defp normalize_timeout(value),
+    do: {:error, "agent hook timeout_ms must be a positive integer, got: #{inspect(value)}"}
+
+  @spec normalize_non_empty_string(term(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp normalize_non_empty_string(value, error) when is_binary(value) do
+    trimmed = String.trim(value)
+
+    if trimmed == "" do
+      {:error, error}
+    else
+      {:ok, value}
+    end
+  end
+
+  defp normalize_non_empty_string(_value, error), do: {:error, error}
+
+  @spec fetch(map(), atom()) :: term()
+  defp fetch(map, key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  @spec fallback(term(), term()) :: term()
+  defp fallback(nil, fallback_value), do: fallback_value
+  defp fallback(value, _fallback_value), do: value
+
+  @spec match_tool_pattern?(String.t(), String.t()) :: boolean()
+  defp match_tool_pattern?("*", _tool_name), do: true
+
+  defp match_tool_pattern?(pattern, tool_name) do
+    if String.contains?(pattern, ["*", "?"]) do
+      pattern
+      |> glob_to_regex()
+      |> Regex.match?(tool_name)
+    else
+      pattern == tool_name
+    end
+  end
+
+  @spec glob_to_regex(String.t()) :: Regex.t()
+  defp glob_to_regex(pattern) do
+    pattern
+    |> String.graphemes()
+    |> Enum.map_join(&glob_char_to_regex/1)
+    |> then(&Regex.compile!("^" <> &1 <> "$"))
+  end
+
+  @spec glob_char_to_regex(String.t()) :: String.t()
+  defp glob_char_to_regex("*"), do: ".*"
+  defp glob_char_to_regex("?"), do: "."
+  defp glob_char_to_regex(char), do: Regex.escape(char)
+end

--- a/lib/minga_agent/hooks/pre_tool_use_payload.ex
+++ b/lib/minga_agent/hooks/pre_tool_use_payload.ex
@@ -1,0 +1,60 @@
+defmodule MingaAgent.Hooks.PreToolUsePayload do
+  @moduledoc """
+  Public payload passed to `PreToolUse` hooks.
+
+  The shell runner encodes this payload as JSON and writes it to the hook
+  command's standard input. Keep field names stable because user scripts may
+  depend on them.
+  """
+
+  @derive {Jason.Encoder, only: [:event, :tool_call_id, :tool_name, :arguments]}
+  @enforce_keys [:tool_call_id, :tool_name, :arguments]
+  defstruct [:tool_call_id, :tool_name, :arguments, event: "PreToolUse"]
+
+  @typedoc "Payload for a tool call about to execute."
+  @type t :: %__MODULE__{
+          event: String.t(),
+          tool_call_id: String.t(),
+          tool_name: String.t(),
+          arguments: map()
+        }
+
+  @doc "Builds a payload from a native provider or runtime tool call map."
+  @spec new(map()) :: t()
+  def new(tool_call) when is_map(tool_call) do
+    %__MODULE__{
+      tool_call_id: normalize_id(value(tool_call, :id) || value(tool_call, :tool_call_id)),
+      tool_name: to_string(value(tool_call, :name) || value(tool_call, :tool_name)),
+      arguments: normalize_arguments(value(tool_call, :arguments) || value(tool_call, :args))
+    }
+  end
+
+  @doc "Builds a payload from explicit tool call fields."
+  @spec new(String.t(), String.t(), map()) :: t()
+  def new(tool_call_id, tool_name, arguments)
+      when is_binary(tool_call_id) and is_binary(tool_name) and is_map(arguments) do
+    %__MODULE__{tool_call_id: tool_call_id, tool_name: tool_name, arguments: arguments}
+  end
+
+  @doc "Converts the payload to the JSON object shape used on stdin."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = payload) do
+    %{
+      "event" => payload.event,
+      "tool_call_id" => payload.tool_call_id,
+      "tool_name" => payload.tool_name,
+      "arguments" => payload.arguments
+    }
+  end
+
+  @spec value(map(), atom()) :: term()
+  defp value(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+
+  @spec normalize_id(term()) :: String.t()
+  defp normalize_id(nil), do: "tool_#{:erlang.unique_integer([:positive])}"
+  defp normalize_id(id), do: to_string(id)
+
+  @spec normalize_arguments(term()) :: map()
+  defp normalize_arguments(args) when is_map(args), do: args
+  defp normalize_arguments(_args), do: %{}
+end

--- a/lib/minga_agent/hooks/result.ex
+++ b/lib/minga_agent/hooks/result.ex
@@ -1,0 +1,71 @@
+defmodule MingaAgent.Hooks.Result do
+  @moduledoc """
+  Structured result returned by agent hook runners.
+
+  `:allow` means execution may continue. `:veto` means the hook blocked the
+  tool call and the tool callback must not run.
+  """
+
+  alias MingaAgent.Hooks.Hook
+
+  @typedoc "Why a hook vetoed or failed."
+  @type reason :: {:exit, non_neg_integer()} | :timeout | {:failed_to_start, term()}
+
+  @typedoc "Structured hook result."
+  @type t :: %__MODULE__{
+          status: :allow | :veto,
+          hook: Hook.t() | nil,
+          stderr: String.t(),
+          exit_status: non_neg_integer() | nil,
+          reason: reason() | nil
+        }
+
+  defstruct status: :allow, hook: nil, stderr: "", exit_status: nil, reason: nil
+
+  @doc "Builds an allow result."
+  @spec allow(Hook.t() | nil) :: t()
+  def allow(hook \\ nil), do: %__MODULE__{status: :allow, hook: hook}
+
+  @doc "Builds a veto result."
+  @spec veto(Hook.t(), String.t(), reason()) :: t()
+  def veto(%Hook{} = hook, stderr, {:exit, status}) when is_binary(stderr) do
+    %__MODULE__{
+      status: :veto,
+      hook: hook,
+      stderr: stderr,
+      exit_status: status,
+      reason: {:exit, status}
+    }
+  end
+
+  def veto(%Hook{} = hook, stderr, reason) when is_binary(stderr) do
+    %__MODULE__{status: :veto, hook: hook, stderr: stderr, reason: reason}
+  end
+
+  @doc "Returns a concise user-facing error for a veto result."
+  @spec message(t()) :: String.t()
+  def message(%__MODULE__{status: :veto, stderr: stderr, reason: :timeout, hook: hook}) do
+    details =
+      non_empty(stderr) || "PreToolUse hook timed out after #{hook.timeout_ms}ms and was killed"
+
+    "PreToolUse hook vetoed tool execution: #{details}"
+  end
+
+  def message(%__MODULE__{status: :veto, stderr: stderr, reason: {:exit, status}}) do
+    details = non_empty(stderr) || "hook exited with status #{status}"
+    "PreToolUse hook vetoed tool execution: #{details}"
+  end
+
+  def message(%__MODULE__{status: :veto, stderr: stderr}) do
+    details = non_empty(stderr) || "hook failed"
+    "PreToolUse hook vetoed tool execution: #{details}"
+  end
+
+  def message(%__MODULE__{}), do: "PreToolUse hook allowed tool execution"
+
+  @spec non_empty(String.t()) :: String.t() | nil
+  defp non_empty(text) do
+    trimmed = String.trim(text)
+    if trimmed == "", do: nil, else: trimmed
+  end
+end

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -37,6 +37,10 @@ defmodule MingaAgent.Providers.Native do
   alias MingaAgent.CostCalculator
   alias MingaAgent.Credentials
   alias MingaAgent.Event
+  alias MingaAgent.Hooks.CommandRunner
+  alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
+  alias MingaAgent.Hooks.PreToolUsePayload
+  alias MingaAgent.Hooks.Result, as: HookResult
   alias MingaAgent.Instructions
   alias MingaAgent.InternalState
   alias MingaAgent.Memory
@@ -77,6 +81,7 @@ defmodule MingaAgent.Providers.Native do
       :max_tokens,
       :max_retries,
       :llm_client,
+      :hook_runner,
       :max_turns,
       :max_cost
     ]
@@ -89,6 +94,7 @@ defmodule MingaAgent.Providers.Native do
       :max_tokens,
       :max_retries,
       :llm_client,
+      :hook_runner,
       :max_turns,
       :max_cost,
       :session_pid,
@@ -105,6 +111,7 @@ defmodule MingaAgent.Providers.Native do
             max_tokens: pos_integer(),
             max_retries: non_neg_integer(),
             llm_client: term(),
+            hook_runner: MingaAgent.Providers.Native.hook_runner(),
             max_turns: pos_integer(),
             max_cost: float() | nil,
             session_pid: pid() | nil,
@@ -120,6 +127,9 @@ defmodule MingaAgent.Providers.Native do
   @type llm_client :: (String.t(), [ReqLLM.Message.t()], keyword() ->
                          {:ok, StreamResponse.t()} | {:error, term()})
 
+  @typedoc "Function that executes a matching hook."
+  @type hook_runner :: (MingaAgent.Hooks.Hook.t(), PreToolUsePayload.t() -> HookResult.t())
+
   @typedoc "Internal state for the native provider."
   @type state :: %{
           subscriber: pid(),
@@ -132,6 +142,7 @@ defmodule MingaAgent.Providers.Native do
           max_tokens: pos_integer(),
           max_retries: non_neg_integer(),
           llm_client: llm_client(),
+          hook_runner: hook_runner(),
           task: Task.t() | nil,
           streaming: boolean(),
           interrupted: boolean(),
@@ -237,6 +248,7 @@ defmodule MingaAgent.Providers.Native do
     max_turns = Keyword.get(opts, :max_turns, config.max_turns)
     max_cost = Keyword.get(opts, :max_cost, config.max_cost)
     llm_client = Keyword.get(opts, :llm_client, &ReqLLM.stream_text/3)
+    hook_runner = Keyword.get(opts, :hook_runner, &CommandRunner.run_pre_tool_use/2)
     provider_pid = self()
     # Start a fork store for in-memory buffer isolation. Forks are created
     # lazily when agent tools write to files that have open buffers.
@@ -290,6 +302,7 @@ defmodule MingaAgent.Providers.Native do
       max_tokens: max_tokens,
       max_retries: max_retries,
       llm_client: llm_client,
+      hook_runner: hook_runner,
       task: nil,
       streaming: false,
       interrupted: false,
@@ -348,6 +361,7 @@ defmodule MingaAgent.Providers.Native do
         max_tokens: state.max_tokens,
         max_retries: state.max_retries,
         llm_client: state.llm_client,
+        hook_runner: state.hook_runner,
         max_turns: state.max_turns,
         max_cost: state.max_cost,
         session_cost: state.session_cost
@@ -407,6 +421,7 @@ defmodule MingaAgent.Providers.Native do
       max_tokens: state.max_tokens,
       max_retries: state.max_retries,
       llm_client: state.llm_client,
+      hook_runner: state.hook_runner,
       max_turns: state.max_turns,
       max_cost: state.max_cost,
       session_cost: state.session_cost
@@ -983,7 +998,15 @@ defmodule MingaAgent.Providers.Native do
     assistant_msg = Context.assistant(text, tool_calls: reqllm_tool_calls)
     context = Context.append(context, assistant_msg)
 
-    context = execute_tools(lctx.provider_pid, context, tool_calls, lctx.tools, lctx.config)
+    context =
+      execute_tools(
+        lctx.provider_pid,
+        context,
+        tool_calls,
+        lctx.tools,
+        lctx.config,
+        lctx.hook_runner
+      )
 
     # Inject any steering messages queued by the user while tools were executing.
     context = inject_steering_messages(lctx, context)
@@ -1032,9 +1055,16 @@ defmodule MingaAgent.Providers.Native do
     end
   end
 
-  @spec execute_tools(pid(), Context.t(), [map()], [ReqLLM.Tool.t()], AgentConfig.t()) ::
+  @spec execute_tools(
+          pid(),
+          Context.t(),
+          [map()],
+          [ReqLLM.Tool.t()],
+          AgentConfig.t(),
+          hook_runner()
+        ) ::
           Context.t()
-  defp execute_tools(provider_pid, context, tool_calls, available_tools, config) do
+  defp execute_tools(provider_pid, context, tool_calls, available_tools, config, hook_runner) do
     initial_mode = approval_mode(config)
 
     {final_ctx, _mode} =
@@ -1042,7 +1072,14 @@ defmodule MingaAgent.Providers.Native do
         before_content = capture_file_before(tool_call)
 
         {result_text, is_error, new_mode} =
-          execute_with_approval(provider_pid, tool_call, available_tools, approval_mode, config)
+          execute_with_approval(
+            provider_pid,
+            tool_call,
+            available_tools,
+            approval_mode,
+            config,
+            hook_runner
+          )
 
         send(
           provider_pid,
@@ -1066,24 +1103,40 @@ defmodule MingaAgent.Providers.Native do
 
   @typep approval_mode :: :none | :ask | :ask_all | :approve_all
 
-  @spec execute_with_approval(pid(), map(), [ReqLLM.Tool.t()], approval_mode(), AgentConfig.t()) ::
+  @spec execute_with_approval(
+          pid(),
+          map(),
+          [ReqLLM.Tool.t()],
+          approval_mode(),
+          AgentConfig.t(),
+          hook_runner()
+        ) ::
           {String.t(), boolean(), approval_mode()}
-  defp execute_with_approval(provider_pid, tool_call, available_tools, mode, config) do
+  defp execute_with_approval(provider_pid, tool_call, available_tools, mode, config, hook_runner) do
     # Per-tool permissions override the global approval mode.
     case tool_permission(tool_call.name, config) do
       :allow ->
-        {result, is_error} = run_single_tool(tool_call, available_tools, provider_pid)
+        {result, is_error} =
+          run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+
         {result, is_error, mode}
 
       :deny ->
         {"Tool '#{tool_call.name}' is denied by per-tool permissions", true, mode}
 
       :ask ->
-        request_approval(provider_pid, tool_call, available_tools, config)
+        request_approval(provider_pid, tool_call, available_tools, config, hook_runner)
 
       nil ->
         # No per-tool override; fall through to global approval mode.
-        execute_with_global_mode(provider_pid, tool_call, available_tools, mode, config)
+        execute_with_global_mode(
+          provider_pid,
+          tool_call,
+          available_tools,
+          mode,
+          config,
+          hook_runner
+        )
     end
   end
 
@@ -1092,28 +1145,63 @@ defmodule MingaAgent.Providers.Native do
           map(),
           [ReqLLM.Tool.t()],
           approval_mode(),
-          AgentConfig.t()
+          AgentConfig.t(),
+          hook_runner()
         ) ::
           {String.t(), boolean(), approval_mode()}
-  defp execute_with_global_mode(provider_pid, tool_call, available_tools, :none, _config) do
-    {result, is_error} = run_single_tool(tool_call, available_tools, provider_pid)
+  defp execute_with_global_mode(
+         provider_pid,
+         tool_call,
+         available_tools,
+         :none,
+         config,
+         hook_runner
+       ) do
+    {result, is_error} =
+      run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+
     {result, is_error, :none}
   end
 
-  defp execute_with_global_mode(provider_pid, tool_call, available_tools, :approve_all, _config) do
-    {result, is_error} = run_single_tool(tool_call, available_tools, provider_pid)
+  defp execute_with_global_mode(
+         provider_pid,
+         tool_call,
+         available_tools,
+         :approve_all,
+         config,
+         hook_runner
+       ) do
+    {result, is_error} =
+      run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+
     {result, is_error, :approve_all}
   end
 
-  defp execute_with_global_mode(provider_pid, tool_call, available_tools, :ask_all, config) do
-    request_approval(provider_pid, tool_call, available_tools, config)
+  defp execute_with_global_mode(
+         provider_pid,
+         tool_call,
+         available_tools,
+         :ask_all,
+         config,
+         hook_runner
+       ) do
+    request_approval(provider_pid, tool_call, available_tools, config, hook_runner)
   end
 
-  defp execute_with_global_mode(provider_pid, tool_call, available_tools, :ask, config) do
+  defp execute_with_global_mode(
+         provider_pid,
+         tool_call,
+         available_tools,
+         :ask,
+         config,
+         hook_runner
+       ) do
     if Tools.destructive?(tool_call.name, tool_call.arguments || %{}) do
-      request_approval(provider_pid, tool_call, available_tools, config)
+      request_approval(provider_pid, tool_call, available_tools, config, hook_runner)
     else
-      {result, is_error} = run_single_tool(tool_call, available_tools, provider_pid)
+      {result, is_error} =
+        run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+
       {result, is_error, :ask}
     end
   end
@@ -1148,9 +1236,9 @@ defmodule MingaAgent.Providers.Native do
     end
   end
 
-  @spec request_approval(pid(), map(), [ReqLLM.Tool.t()], AgentConfig.t()) ::
+  @spec request_approval(pid(), map(), [ReqLLM.Tool.t()], AgentConfig.t(), hook_runner()) ::
           {String.t(), boolean(), :ask | :approve_all}
-  defp request_approval(provider_pid, tool_call, available_tools, config) do
+  defp request_approval(provider_pid, tool_call, available_tools, config, hook_runner) do
     # Send approval request through the event pipeline (Task → Provider → Session)
     send(
       provider_pid,
@@ -1166,11 +1254,15 @@ defmodule MingaAgent.Providers.Native do
     # Block until the user responds (or timeout after 5 minutes)
     receive do
       {:tool_approval_response, _tool_call_id, :approve} ->
-        {result, is_error} = run_single_tool(tool_call, available_tools, provider_pid)
+        {result, is_error} =
+          run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+
         {result, is_error, :ask}
 
       {:tool_approval_response, _tool_call_id, :approve_all} ->
-        {result, is_error} = run_single_tool(tool_call, available_tools, provider_pid)
+        {result, is_error} =
+          run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner)
+
         {result, is_error, :approve_all}
 
       {:tool_approval_response, _tool_call_id, :reject} ->
@@ -1223,21 +1315,52 @@ defmodule MingaAgent.Providers.Native do
 
   defp maybe_emit_file_changed(_provider_pid, _tool_call, _before_content, _is_error), do: :ok
 
-  @spec run_single_tool(map(), [ReqLLM.Tool.t()], pid() | nil) ::
+  @spec run_single_tool(map(), [ReqLLM.Tool.t()], pid(), AgentConfig.t(), hook_runner()) ::
           {String.t(), boolean()}
-  defp run_single_tool(tool_call, available_tools, provider_pid) do
+  defp run_single_tool(tool_call, available_tools, provider_pid, config, hook_runner) do
     case Enum.find(available_tools, fn t -> t.name == tool_call.name end) do
       nil ->
         {"Tool '#{tool_call.name}' not found", true}
 
-      _tool when tool_call.name == "shell" and is_pid(provider_pid) ->
-        run_shell_with_streaming(tool_call, provider_pid)
-
       tool ->
-        case ReqLLM.Tool.execute(tool, tool_call.arguments) do
-          {:ok, result} -> {format_tool_result(result), false}
-          {:error, reason} -> {format_error(reason), true}
+        case dispatch_pre_tool_use(tool_call, config, hook_runner, provider_pid) do
+          :ok -> execute_found_tool(tool, tool_call, provider_pid)
+          {:error, %HookResult{} = result} -> {HookResult.message(result), true}
         end
+    end
+  end
+
+  @spec dispatch_pre_tool_use(map(), AgentConfig.t(), hook_runner(), pid()) ::
+          :ok | {:error, HookResult.t()}
+  defp dispatch_pre_tool_use(tool_call, config, hook_runner, provider_pid) do
+    payload = PreToolUsePayload.new(tool_call)
+
+    case HookDispatcher.pre_tool_use(config.agent_hooks, payload, runner: hook_runner) do
+      :ok ->
+        :ok
+
+      {:error, result} = error ->
+        emit_hook_veto(provider_pid, result)
+        error
+    end
+  end
+
+  @spec emit_hook_veto(pid(), HookResult.t()) :: :ok
+  defp emit_hook_veto(provider_pid, %HookResult{} = result) do
+    send(provider_pid, {:agent_event, %Event.Error{message: HookResult.message(result)}})
+    :ok
+  end
+
+  @spec execute_found_tool(ReqLLM.Tool.t(), map(), pid() | nil) :: {String.t(), boolean()}
+  defp execute_found_tool(_tool, %{name: "shell"} = tool_call, provider_pid)
+       when is_pid(provider_pid) do
+    run_shell_with_streaming(tool_call, provider_pid)
+  end
+
+  defp execute_found_tool(tool, tool_call, _provider_pid) do
+    case ReqLLM.Tool.execute(tool, tool_call.arguments) do
+      {:ok, result} -> {format_tool_result(result), false}
+      {:error, reason} -> {format_error(reason), true}
     end
   end
 

--- a/lib/minga_agent/tool/executor.ex
+++ b/lib/minga_agent/tool/executor.ex
@@ -26,11 +26,17 @@ defmodule MingaAgent.Tool.Executor do
   before calling `execute_approved/2`.
   """
 
+  alias MingaAgent.Config, as: AgentConfig
+  alias MingaAgent.Hooks.CommandRunner
+  alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
+  alias MingaAgent.Hooks.PreToolUsePayload
+  alias MingaAgent.Hooks.Result, as: HookResult
   alias MingaAgent.Tool.Registry
   alias MingaAgent.Tool.Spec
 
   @typedoc "Result of tool execution."
   @type result :: {:ok, term()} | {:error, term()} | {:needs_approval, Spec.t(), map()}
+  @type hook_runner :: (MingaAgent.Hooks.Hook.t(), PreToolUsePayload.t() -> HookResult.t())
 
   @doc """
   Executes a tool by name with the given arguments.
@@ -44,14 +50,24 @@ defmodule MingaAgent.Tool.Executor do
   """
   @spec execute(String.t(), map()) :: result()
   def execute(name, args) when is_binary(name) and is_map(args) do
-    execute(name, args, MingaAgent.Tool.Registry)
+    execute(name, args, MingaAgent.Tool.Registry, [])
   end
 
   @spec execute(String.t(), map(), atom()) :: result()
   def execute(name, args, registry_table)
       when is_binary(name) and is_map(args) and is_atom(registry_table) do
+    execute(name, args, registry_table, [])
+  end
+
+  @doc false
+  @spec execute(String.t(), map(), atom(), keyword()) :: result()
+  def execute(name, args, registry_table, opts)
+      when is_binary(name) and is_map(args) and is_atom(registry_table) and is_list(opts) do
+    config = Keyword.get_lazy(opts, :config, &AgentConfig.resolve/0)
+    hook_runner = Keyword.get(opts, :hook_runner, &CommandRunner.run_pre_tool_use/2)
+
     case Registry.lookup(registry_table, name) do
-      {:ok, spec} -> check_and_execute(spec, args)
+      {:ok, spec} -> check_and_execute(spec, args, config, hook_runner)
       :error -> {:error, {:tool_not_found, name}}
     end
   end
@@ -66,32 +82,58 @@ defmodule MingaAgent.Tool.Executor do
   """
   @spec execute_approved(Spec.t(), map()) :: {:ok, term()} | {:error, term()}
   def execute_approved(%Spec{} = spec, args) when is_map(args) do
-    run_callback(spec, args)
+    execute_approved(spec, args, [])
+  end
+
+  @doc false
+  @spec execute_approved(Spec.t(), map(), keyword()) :: {:ok, term()} | {:error, term()}
+  def execute_approved(%Spec{} = spec, args, opts) when is_map(args) and is_list(opts) do
+    config = Keyword.get_lazy(opts, :config, &AgentConfig.resolve/0)
+    hook_runner = Keyword.get(opts, :hook_runner, &CommandRunner.run_pre_tool_use/2)
+    run_callback(spec, args, config, hook_runner)
   end
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
-  @spec check_and_execute(Spec.t(), map()) :: result()
-  defp check_and_execute(%Spec{approval_level: :deny} = spec, _args) do
+  @spec check_and_execute(Spec.t(), map(), AgentConfig.t(), hook_runner()) :: result()
+  defp check_and_execute(%Spec{approval_level: :deny} = spec, _args, _config, _hook_runner) do
     {:error, {:tool_denied, spec.name}}
   end
 
-  defp check_and_execute(%Spec{approval_level: :ask} = spec, args) do
+  defp check_and_execute(%Spec{approval_level: :ask} = spec, args, _config, _hook_runner) do
     {:needs_approval, spec, args}
   end
 
-  defp check_and_execute(%Spec{approval_level: :auto} = spec, args) do
-    run_callback(spec, args)
+  defp check_and_execute(%Spec{approval_level: :auto} = spec, args, config, hook_runner) do
+    run_callback(spec, args, config, hook_runner)
   end
 
-  @spec run_callback(Spec.t(), map()) :: {:ok, term()} | {:error, term()}
-  defp run_callback(%Spec{} = spec, args) do
+  @spec run_callback(Spec.t(), map(), AgentConfig.t(), hook_runner()) ::
+          {:ok, term()} | {:error, term()}
+  defp run_callback(%Spec{} = spec, args, config, hook_runner) do
+    case dispatch_pre_tool_use(spec, args, config, hook_runner) do
+      :ok -> run_callback_with_advice(spec, args)
+      {:error, %HookResult{} = result} -> {:error, {:hook_veto, HookResult.message(result)}}
+    end
+  end
+
+  @spec run_callback_with_advice(Spec.t(), map()) :: {:ok, term()} | {:error, term()}
+  defp run_callback_with_advice(%Spec{} = spec, args) do
     tool_atom = String.to_existing_atom(spec.name)
     execute_with_advice(spec, args, tool_atom)
   rescue
     ArgumentError ->
       # Atom doesn't exist yet; no advice can be registered for it.
       execute_raw(spec, args)
+  end
+
+  @spec dispatch_pre_tool_use(Spec.t(), map(), AgentConfig.t(), hook_runner()) ::
+          :ok | {:error, HookResult.t()}
+  defp dispatch_pre_tool_use(%Spec{} = spec, args, config, hook_runner) do
+    payload =
+      PreToolUsePayload.new("direct_#{:erlang.unique_integer([:positive])}", spec.name, args)
+
+    HookDispatcher.pre_tool_use(config.agent_hooks, payload, runner: hook_runner)
   end
 
   @spec execute_with_advice(Spec.t(), map(), atom()) :: {:ok, term()} | {:error, term()}

--- a/lib/mix/tasks/compile.minga_zig.ex
+++ b/lib/mix/tasks/compile.minga_zig.ex
@@ -13,6 +13,7 @@ defmodule Mix.Tasks.Compile.MingaZig do
   @priv_dir "priv"
   @renderer_name "minga-renderer"
   @parser_name "minga-parser"
+  @hook_runner_name "minga-hook-runner"
 
   # File extensions that should trigger a Zig rebuild when modified.
   @zig_source_extensions ~w(.zig .zon .c .h .scm)
@@ -21,10 +22,10 @@ defmodule Mix.Tasks.Compile.MingaZig do
   @spec run(keyword()) :: {:ok, []} | {:error, []}
   def run(_opts) do
     if File.dir?(@zig_dir) do
-      output = Path.join(@priv_dir, @renderer_name)
+      outputs = required_outputs()
 
-      if needs_rebuild?(output) do
-        compile_zig_backend("tui", @renderer_name)
+      if needs_rebuild?(outputs) do
+        compile_zig_backend("tui")
       else
         {:ok, []}
       end
@@ -33,12 +34,27 @@ defmodule Mix.Tasks.Compile.MingaZig do
     end
   end
 
-  @spec needs_rebuild?(String.t()) :: boolean()
-  defp needs_rebuild?(output_path) do
-    case File.stat(output_path, time: :posix) do
-      {:error, :enoent} -> true
-      {:ok, %{mtime: output_mtime}} -> any_source_newer?(output_mtime)
+  @spec required_outputs() :: [String.t()]
+  defp required_outputs do
+    Enum.map([@renderer_name, @parser_name, @hook_runner_name], &Path.join(@priv_dir, &1))
+  end
+
+  @spec needs_rebuild?([String.t()]) :: boolean()
+  defp needs_rebuild?(output_paths) do
+    case oldest_output_mtime(output_paths) do
+      nil -> true
+      output_mtime -> any_source_newer?(output_mtime)
     end
+  end
+
+  @spec oldest_output_mtime([String.t()]) :: integer() | nil
+  defp oldest_output_mtime(output_paths) do
+    Enum.reduce_while(output_paths, nil, fn path, oldest ->
+      case File.stat(path, time: :posix) do
+        {:ok, %{mtime: mtime}} -> {:cont, if(oldest, do: min(mtime, oldest), else: mtime)}
+        {:error, _reason} -> {:halt, nil}
+      end
+    end)
   end
 
   @spec any_source_newer?(integer()) :: boolean()
@@ -64,17 +80,20 @@ defmodule Mix.Tasks.Compile.MingaZig do
     end)
   end
 
-  @spec compile_zig_backend(String.t(), String.t()) :: {:ok, []} | {:error, []}
-  defp compile_zig_backend(backend, output_name) do
-    Mix.shell().info("Compiling Zig renderer (#{backend})...")
+  @spec compile_zig_backend(String.t()) :: {:ok, []} | {:error, []}
+  defp compile_zig_backend(backend) do
+    Mix.shell().info("Compiling Zig binaries (#{backend})...")
 
-    args = ["build"] ++ if(backend != "tui", do: ["-Dbackend=#{backend}"], else: [])
+    args =
+      ["build"] ++
+        zig_target_args() ++ if(backend != "tui", do: ["-Dbackend=#{backend}"], else: [])
 
     case System.cmd("zig", args, cd: @zig_dir, stderr_to_stdout: true) do
       {_output, 0} ->
-        Mix.shell().info("Zig renderer (#{backend}) compiled successfully")
-        copy_to_priv(@renderer_name, output_name)
-        copy_to_priv(@parser_name, @parser_name)
+        Mix.shell().info("Zig binaries (#{backend}) compiled successfully")
+        copy_to_priv(@renderer_name)
+        copy_to_priv(@parser_name)
+        copy_to_priv(@hook_runner_name)
         {:ok, []}
 
       {output, _code} ->
@@ -83,18 +102,27 @@ defmodule Mix.Tasks.Compile.MingaZig do
     end
   end
 
-  @spec copy_to_priv(String.t(), String.t()) :: :ok
-  defp copy_to_priv(src_name, dest_name) do
-    src = Path.join([@zig_dir, "zig-out", "bin", src_name])
+  @spec zig_target_args() :: [String.t()]
+  defp zig_target_args do
+    case {:os.type(), :erlang.system_info(:system_architecture) |> List.to_string()} do
+      {{:unix, :darwin}, "aarch64" <> _rest} -> ["-Dtarget=aarch64-macos.15.0"]
+      {{:unix, :darwin}, "x86_64" <> _rest} -> ["-Dtarget=x86_64-macos.15.0"]
+      _other -> []
+    end
+  end
+
+  @spec copy_to_priv(String.t()) :: :ok
+  defp copy_to_priv(name) do
+    src = Path.join([@zig_dir, "zig-out", "bin", name])
     File.mkdir_p!(@priv_dir)
-    dest = Path.join(@priv_dir, dest_name)
+    dest = Path.join(@priv_dir, name)
 
     if File.exists?(src) do
       File.cp!(src, dest)
       # Ensure executable
       File.chmod!(dest, 0o755)
       codesign_if_macos(dest)
-      Mix.shell().info("Copied renderer to #{dest}")
+      Mix.shell().info("Copied #{name} to #{dest}")
     end
 
     :ok

--- a/lib/mix/tasks/zig.lint.ex
+++ b/lib/mix/tasks/zig.lint.ex
@@ -24,9 +24,18 @@ defmodule Mix.Tasks.Zig.Lint do
     end
 
     run_step("zig fmt --check", zig_root, ["fmt", "--check", "src/"])
-    run_step("zig build test", zig_root, ["build", "test"])
+    run_step("zig build test", zig_root, ["build", "test"] ++ zig_target_args())
 
     Mix.shell().info([:green, "Zig lint passed.", :reset])
+  end
+
+  @spec zig_target_args() :: [String.t()]
+  defp zig_target_args do
+    case {:os.type(), :erlang.system_info(:system_architecture) |> List.to_string()} do
+      {{:unix, :darwin}, "aarch64" <> _rest} -> ["-Dtarget=aarch64-macos.15.0"]
+      {{:unix, :darwin}, "x86_64" <> _rest} -> ["-Dtarget=x86_64-macos.15.0"]
+      _other -> []
+    end
   end
 
   @spec run_step(String.t(), String.t(), [String.t()]) :: :ok

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -87,6 +87,7 @@ defmodule Minga.Config.OptionsTest do
                agent_system_prompt: "",
                agent_append_system_prompt: "",
                agent_tool_permissions: nil,
+               agent_hooks: [],
                agent_diff_size_threshold: 1_048_576,
                whichkey_layout: :bottom,
                line_spacing: 1.0,

--- a/test/minga/extension/git_test.exs
+++ b/test/minga/extension/git_test.exs
@@ -47,6 +47,12 @@ defmodule Minga.Extension.GitIntegrationTest do
   # Isolate from CI runner's global git config
   @git_env [
     {"GIT_CONFIG_NOSYSTEM", "1"},
+    {"GIT_CONFIG_GLOBAL", "/dev/null"},
+    {"GIT_CONFIG_COUNT", "2"},
+    {"GIT_CONFIG_KEY_0", "commit.gpgsign"},
+    {"GIT_CONFIG_VALUE_0", "false"},
+    {"GIT_CONFIG_KEY_1", "tag.gpgsign"},
+    {"GIT_CONFIG_VALUE_1", "false"},
     {"GIT_AUTHOR_NAME", "Test"},
     {"GIT_AUTHOR_EMAIL", "test@test.com"},
     {"GIT_COMMITTER_NAME", "Test"},

--- a/test/minga_agent/config_test.exs
+++ b/test/minga_agent/config_test.exs
@@ -15,6 +15,7 @@ defmodule MingaAgent.ConfigTest do
       assert is_boolean(config.prompt_cache)
       assert is_boolean(config.notifications)
       assert is_list(config.destructive_tools)
+      assert is_list(config.agent_hooks)
       assert is_list(config.notify_on)
     end
 
@@ -30,6 +31,7 @@ defmodule MingaAgent.ConfigTest do
       assert config.max_retries == 3
       assert config.max_cost == nil
       assert config.tool_approval == :destructive
+      assert config.agent_hooks == []
       assert config.prompt_cache == true
       assert config.compaction_threshold == 0.80
       assert config.compaction_keep_recent == 6
@@ -51,6 +53,20 @@ defmodule MingaAgent.ConfigTest do
   describe "default_model/0" do
     test "returns the Sonnet model string" do
       assert Config.default_model() =~ "anthropic:claude"
+    end
+  end
+
+  describe "normalize_hooks/1" do
+    test "normalizes PreToolUse hooks from config maps" do
+      assert [hook] =
+               Config.normalize_hooks([
+                 %{event: "PreToolUse", tool: "shell", command: "echo policy >&2"}
+               ])
+
+      assert hook.event == :pre_tool_use
+      assert hook.tool_pattern == "shell"
+      assert hook.command == "echo policy >&2"
+      assert hook.timeout_ms == 30_000
     end
   end
 end

--- a/test/minga_agent/hooks/command_runner_test.exs
+++ b/test/minga_agent/hooks/command_runner_test.exs
@@ -9,34 +9,33 @@ defmodule MingaAgent.Hooks.CommandRunnerTest do
 
   @moduletag :heavy
 
-  test "passes JSON payload on stdin and treats non-zero exit as veto with stderr" do
+  test "allows when hook exits zero and receives JSON payload on stdin" do
     hook = %Hook{
       event: :pre_tool_use,
       tool_pattern: "shell",
       command:
-        "payload=$(cat); case \"$payload\" in *'\"tool_name\":\"shell\"'*) echo blocked >&2; exit 4;; *) echo missing payload >&2; exit 5;; esac"
+        "payload=$(cat); case \"$payload\" in *'\"tool_name\":\"shell\"'*) exit 0;; *) echo missing payload >&2; exit 9;; esac"
     }
 
     payload = PreToolUsePayload.new("tc_1", "shell", %{"command" => "date"})
 
-    assert %Result{status: :veto, exit_status: 4, stderr: stderr} =
+    assert %Result{status: :allow, stderr: "", exit_status: nil, reason: nil} =
+             CommandRunner.run_pre_tool_use(hook, payload)
+  end
+
+  test "treats non-zero exit as veto with stderr" do
+    hook = %Hook{
+      event: :pre_tool_use,
+      tool_pattern: "shell",
+      command: "echo blocked >&2; exit 4"
+    }
+
+    payload = PreToolUsePayload.new("tc_1", "shell", %{"command" => "date"})
+
+    assert %Result{status: :veto, exit_status: 4, reason: {:exit, 4}, stderr: stderr} =
              CommandRunner.run_pre_tool_use(hook, payload)
 
     assert stderr =~ "blocked"
-  end
-
-  test "removes private payload directory after hook exits" do
-    tmp_root = temp_path("payload-root")
-    File.mkdir_p!(tmp_root)
-    with_tmpdir(tmp_root)
-
-    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: "cat >/dev/null"}
-    payload = PreToolUsePayload.new("tc_1", "read_file", %{"path" => "README.md"})
-
-    assert %Result{status: :allow} = CommandRunner.run_pre_tool_use(hook, payload)
-    assert File.ls!(tmp_root) == []
-
-    File.rmdir(tmp_root)
   end
 
   test "vetoes when hook payload cannot be encoded as JSON" do
@@ -54,23 +53,25 @@ defmodule MingaAgent.Hooks.CommandRunnerTest do
     refute stderr =~ "secret"
   end
 
-  test "times out long-running hooks and returns a clear veto" do
-    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: "sleep 1", timeout_ms: 20}
-    payload = PreToolUsePayload.new("tc_1", "read_file", %{"path" => "README.md"})
+  test "child stdout is discarded and cannot corrupt helper result" do
+    command =
+      "i=0; while [ \"$i\" -lt 20000 ]; do printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n'; i=$((i + 1)); done; exit 0"
 
-    assert %Result{status: :veto, reason: :timeout, stderr: stderr} =
-             CommandRunner.run_pre_tool_use(hook, payload)
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: command, timeout_ms: 2_000}
+    payload = PreToolUsePayload.new("tc_1", "shell", %{})
 
-    assert stderr =~ "timed out after 20ms"
-    assert stderr =~ "killed"
+    assert %Result{status: :allow} = CommandRunner.run_pre_tool_use(hook, payload)
   end
 
   @tag timeout: 2_000
   test "times out by wall clock even when hook keeps writing stderr" do
-    command =
-      "i=0; while [ \"$i\" -lt 20 ]; do echo tick $i >&2; i=$((i + 1)); sleep 0.05; done; sleep 1"
+    hook = %Hook{
+      event: :pre_tool_use,
+      tool_pattern: "*",
+      command: "i=0; while :; do echo tick-$i >&2; i=$((i + 1)); done",
+      timeout_ms: 100
+    }
 
-    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: command, timeout_ms: 100}
     payload = PreToolUsePayload.new("tc_1", "read_file", %{"path" => "README.md"})
     started_ms = System.monotonic_time(:millisecond)
 
@@ -79,20 +80,25 @@ defmodule MingaAgent.Hooks.CommandRunnerTest do
 
     elapsed_ms = System.monotonic_time(:millisecond) - started_ms
 
+    assert stderr =~ "tick-"
     assert stderr =~ "timed out after 100ms"
     assert stderr =~ "killed"
     assert elapsed_ms < 500
   end
 
   @tag timeout: 2_000
-  test "timeout kills the hook shell and its child process" do
+  test "timeout kills the hook shell and its child process group" do
     shell_pid_path = temp_path("shell-pid")
     child_pid_path = temp_path("child-pid")
+    grandchild_pid_path = temp_path("grandchild-pid")
 
     command =
-      "echo $$ > #{shell_quote(shell_pid_path)}; sleep 5 & echo $! > #{shell_quote(child_pid_path)}; wait"
+      "echo $$ > #{shell_quote(shell_pid_path)}; " <>
+        "((while :; do :; done) & echo $! > #{shell_quote(grandchild_pid_path)}; wait) & " <>
+        "echo $! > #{shell_quote(child_pid_path)}; " <>
+        "while [ ! -s #{shell_quote(grandchild_pid_path)} ]; do :; done; wait"
 
-    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: command, timeout_ms: 50}
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: command, timeout_ms: 100}
     payload = PreToolUsePayload.new("tc_1", "read_file", %{"path" => "README.md"})
 
     assert %Result{status: :veto, reason: :timeout} =
@@ -100,30 +106,90 @@ defmodule MingaAgent.Hooks.CommandRunnerTest do
 
     shell_pid = read_pid!(shell_pid_path)
     child_pid = read_pid!(child_pid_path)
+    grandchild_pid = read_pid!(grandchild_pid_path)
 
     refute_process_alive(shell_pid)
     refute_process_alive(child_pid)
+    refute_process_alive(grandchild_pid)
 
     File.rm(shell_pid_path)
     File.rm(child_pid_path)
+    File.rm(grandchild_pid_path)
+  end
+
+  test "stderr is bounded and marked truncated" do
+    command =
+      "i=0; while [ \"$i\" -lt 50000 ]; do printf '0123456789abcdef0123456789abcdef\\n' >&2; i=$((i + 1)); done; exit 7"
+
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: command, timeout_ms: 2_000}
+    payload = PreToolUsePayload.new("tc_1", "shell", %{})
+
+    assert %Result{status: :veto, exit_status: 7, stderr: stderr} =
+             CommandRunner.run_pre_tool_use(hook, payload)
+
+    assert byte_size(stderr) < 70_000
+    assert stderr =~ "truncated"
+  end
+
+  test "vetoes clearly when helper executable cannot be started" do
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: "exit 0"}
+    payload = PreToolUsePayload.new("tc_1", "shell", %{})
+    missing = temp_path("missing-helper")
+
+    assert %Result{status: :veto, reason: {:failed_to_start, _reason}, stderr: stderr} =
+             CommandRunner.run_pre_tool_use(hook, payload, helper_path: missing)
+
+    assert stderr =~ "failed to start hook runner"
+  end
+
+  test "vetoes clearly when helper returns malformed JSON" do
+    helper = fake_helper("malformed-helper", "#!/bin/sh\nprintf 'not json'\n")
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: "exit 0"}
+    payload = PreToolUsePayload.new("tc_secret", "shell", %{"secret" => "do-not-leak"})
+
+    assert %Result{
+             status: :veto,
+             reason: {:failed_to_start, :malformed_helper_result},
+             stderr: stderr
+           } =
+             CommandRunner.run_pre_tool_use(hook, payload, helper_path: helper)
+
+    assert stderr =~ "malformed hook runner result"
+    refute stderr =~ "do-not-leak"
+
+    File.rm(helper)
+  end
+
+  @tag timeout: 2_000
+  test "guard timeout is absolute even if a broken helper keeps writing stdout" do
+    helper =
+      fake_helper("noisy-helper", "#!/bin/sh\nexec 2>/dev/null\nwhile :; do printf x; done\n")
+
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: "exit 0", timeout_ms: 10}
+    payload = PreToolUsePayload.new("tc_1", "shell", %{})
+    started_ms = System.monotonic_time(:millisecond)
+
+    assert %Result{status: :veto, reason: {:failed_to_start, :helper_timeout}, stderr: stderr} =
+             CommandRunner.run_pre_tool_use(hook, payload, helper_path: helper)
+
+    elapsed_ms = System.monotonic_time(:millisecond) - started_ms
+
+    assert stderr =~ "hook runner timed out after 1010ms"
+    assert elapsed_ms < 1_500
+
+    File.rm(helper)
   end
 
   defp temp_path(label) do
     Path.join(System.tmp_dir!(), "minga-hook-#{label}-#{System.unique_integer([:positive])}")
   end
 
-  defp with_tmpdir(tmp_root) do
-    previous = System.get_env("TMPDIR")
-    System.put_env("TMPDIR", tmp_root)
-
-    on_exit(fn ->
-      restore_tmpdir(previous)
-      File.rm_rf(tmp_root)
-    end)
+  defp fake_helper(label, content) do
+    path = temp_path(label)
+    File.write!(path, content)
+    File.chmod!(path, 0o755)
+    path
   end
-
-  defp restore_tmpdir(nil), do: System.delete_env("TMPDIR")
-  defp restore_tmpdir(previous), do: System.put_env("TMPDIR", previous)
 
   defp shell_quote(value) do
     "'" <> String.replace(value, "'", "'\\''") <> "'"

--- a/test/minga_agent/hooks/command_runner_test.exs
+++ b/test/minga_agent/hooks/command_runner_test.exs
@@ -39,6 +39,21 @@ defmodule MingaAgent.Hooks.CommandRunnerTest do
     File.rmdir(tmp_root)
   end
 
+  test "vetoes when hook payload cannot be encoded as JSON" do
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: "cat >/dev/null"}
+    payload = PreToolUsePayload.new("tc_1", "read_file", %{{:bad, :key} => "secret"})
+
+    assert %Result{
+             status: :veto,
+             reason: {:failed_to_start, {:encode_failed, String.Chars}},
+             stderr: stderr
+           } = CommandRunner.run_pre_tool_use(hook, payload)
+
+    assert stderr =~ "failed to prepare hook payload"
+    assert stderr =~ "String.Chars"
+    refute stderr =~ "secret"
+  end
+
   test "times out long-running hooks and returns a clear veto" do
     hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: "sleep 1", timeout_ms: 20}
     payload = PreToolUsePayload.new("tc_1", "read_file", %{"path" => "README.md"})

--- a/test/minga_agent/hooks/command_runner_test.exs
+++ b/test/minga_agent/hooks/command_runner_test.exs
@@ -25,6 +25,20 @@ defmodule MingaAgent.Hooks.CommandRunnerTest do
     assert stderr =~ "blocked"
   end
 
+  test "removes private payload directory after hook exits" do
+    tmp_root = temp_path("payload-root")
+    File.mkdir_p!(tmp_root)
+    with_tmpdir(tmp_root)
+
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: "cat >/dev/null"}
+    payload = PreToolUsePayload.new("tc_1", "read_file", %{"path" => "README.md"})
+
+    assert %Result{status: :allow} = CommandRunner.run_pre_tool_use(hook, payload)
+    assert File.ls!(tmp_root) == []
+
+    File.rmdir(tmp_root)
+  end
+
   test "times out long-running hooks and returns a clear veto" do
     hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: "sleep 1", timeout_ms: 20}
     payload = PreToolUsePayload.new("tc_1", "read_file", %{"path" => "README.md"})
@@ -34,5 +48,104 @@ defmodule MingaAgent.Hooks.CommandRunnerTest do
 
     assert stderr =~ "timed out after 20ms"
     assert stderr =~ "killed"
+  end
+
+  @tag timeout: 2_000
+  test "times out by wall clock even when hook keeps writing stderr" do
+    command =
+      "i=0; while [ \"$i\" -lt 20 ]; do echo tick $i >&2; i=$((i + 1)); sleep 0.05; done; sleep 1"
+
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: command, timeout_ms: 100}
+    payload = PreToolUsePayload.new("tc_1", "read_file", %{"path" => "README.md"})
+    started_ms = System.monotonic_time(:millisecond)
+
+    assert %Result{status: :veto, reason: :timeout, stderr: stderr} =
+             CommandRunner.run_pre_tool_use(hook, payload)
+
+    elapsed_ms = System.monotonic_time(:millisecond) - started_ms
+
+    assert stderr =~ "timed out after 100ms"
+    assert stderr =~ "killed"
+    assert elapsed_ms < 500
+  end
+
+  @tag timeout: 2_000
+  test "timeout kills the hook shell and its child process" do
+    shell_pid_path = temp_path("shell-pid")
+    child_pid_path = temp_path("child-pid")
+
+    command =
+      "echo $$ > #{shell_quote(shell_pid_path)}; sleep 5 & echo $! > #{shell_quote(child_pid_path)}; wait"
+
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: command, timeout_ms: 50}
+    payload = PreToolUsePayload.new("tc_1", "read_file", %{"path" => "README.md"})
+
+    assert %Result{status: :veto, reason: :timeout} =
+             CommandRunner.run_pre_tool_use(hook, payload)
+
+    shell_pid = read_pid!(shell_pid_path)
+    child_pid = read_pid!(child_pid_path)
+
+    refute_process_alive(shell_pid)
+    refute_process_alive(child_pid)
+
+    File.rm(shell_pid_path)
+    File.rm(child_pid_path)
+  end
+
+  defp temp_path(label) do
+    Path.join(System.tmp_dir!(), "minga-hook-#{label}-#{System.unique_integer([:positive])}")
+  end
+
+  defp with_tmpdir(tmp_root) do
+    previous = System.get_env("TMPDIR")
+    System.put_env("TMPDIR", tmp_root)
+
+    on_exit(fn ->
+      restore_tmpdir(previous)
+      File.rm_rf(tmp_root)
+    end)
+  end
+
+  defp restore_tmpdir(nil), do: System.delete_env("TMPDIR")
+  defp restore_tmpdir(previous), do: System.put_env("TMPDIR", previous)
+
+  defp shell_quote(value) do
+    "'" <> String.replace(value, "'", "'\\''") <> "'"
+  end
+
+  defp read_pid!(path) do
+    path
+    |> File.read!()
+    |> String.trim()
+    |> String.to_integer()
+  end
+
+  defp refute_process_alive(pid) do
+    if process_exited?(pid, 10) do
+      :ok
+    else
+      flunk("expected OS process #{pid} to exit")
+    end
+  end
+
+  defp process_exited?(_pid, 0), do: false
+
+  defp process_exited?(pid, attempts) do
+    if process_alive?(pid) do
+      receive do
+      after
+        20 -> process_exited?(pid, attempts - 1)
+      end
+    else
+      true
+    end
+  end
+
+  defp process_alive?(pid) do
+    case System.cmd("kill", ["-0", Integer.to_string(pid)], stderr_to_stdout: true) do
+      {_output, 0} -> true
+      {_output, _status} -> false
+    end
   end
 end

--- a/test/minga_agent/hooks/command_runner_test.exs
+++ b/test/minga_agent/hooks/command_runner_test.exs
@@ -1,0 +1,38 @@
+defmodule MingaAgent.Hooks.CommandRunnerTest do
+  # Runs real /bin/sh commands through Port, so keep it out of async test runs.
+  use ExUnit.Case, async: false
+
+  alias MingaAgent.Hooks.CommandRunner
+  alias MingaAgent.Hooks.Hook
+  alias MingaAgent.Hooks.PreToolUsePayload
+  alias MingaAgent.Hooks.Result
+
+  @moduletag :heavy
+
+  test "passes JSON payload on stdin and treats non-zero exit as veto with stderr" do
+    hook = %Hook{
+      event: :pre_tool_use,
+      tool_pattern: "shell",
+      command:
+        "payload=$(cat); case \"$payload\" in *'\"tool_name\":\"shell\"'*) echo blocked >&2; exit 4;; *) echo missing payload >&2; exit 5;; esac"
+    }
+
+    payload = PreToolUsePayload.new("tc_1", "shell", %{"command" => "date"})
+
+    assert %Result{status: :veto, exit_status: 4, stderr: stderr} =
+             CommandRunner.run_pre_tool_use(hook, payload)
+
+    assert stderr =~ "blocked"
+  end
+
+  test "times out long-running hooks and returns a clear veto" do
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "*", command: "sleep 1", timeout_ms: 20}
+    payload = PreToolUsePayload.new("tc_1", "read_file", %{"path" => "README.md"})
+
+    assert %Result{status: :veto, reason: :timeout, stderr: stderr} =
+             CommandRunner.run_pre_tool_use(hook, payload)
+
+    assert stderr =~ "timed out after 20ms"
+    assert stderr =~ "killed"
+  end
+end

--- a/test/minga_agent/hooks/dispatcher_test.exs
+++ b/test/minga_agent/hooks/dispatcher_test.exs
@@ -110,6 +110,10 @@ defmodule MingaAgent.Hooks.DispatcherTest do
              Hook.normalize(%{event: "PreToolUse", tool: "shell", command: "echo checking >&2"})
   end
 
+  test "normalization rejects malformed keyword-list declarations" do
+    assert {:error, "agent hook must be a map or keyword list"} = Hook.normalize(["bad"])
+  end
+
   defp hook(pattern) do
     %Hook{event: :pre_tool_use, tool_pattern: pattern, command: "echo checking >&2"}
   end

--- a/test/minga_agent/hooks/dispatcher_test.exs
+++ b/test/minga_agent/hooks/dispatcher_test.exs
@@ -1,0 +1,116 @@
+defmodule MingaAgent.Hooks.DispatcherTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Hooks.Dispatcher
+  alias MingaAgent.Hooks.Hook
+  alias MingaAgent.Hooks.PreToolUsePayload
+  alias MingaAgent.Hooks.Result
+
+  test "matching PreToolUse hook runs with stable payload fields before callback boundary" do
+    test_pid = self()
+    hook = hook("read_file")
+    payload = PreToolUsePayload.new("tc_1", "read_file", %{"path" => "README.md"})
+
+    runner = fn received_hook, received_payload ->
+      send(test_pid, {:hook_ran, received_hook, received_payload})
+      Result.allow(received_hook)
+    end
+
+    assert :ok = Dispatcher.pre_tool_use([hook], payload, runner: runner)
+
+    assert_receive {:hook_ran, ^hook, %PreToolUsePayload{} = received_payload}
+    assert received_payload.event == "PreToolUse"
+    assert received_payload.tool_call_id == "tc_1"
+    assert received_payload.tool_name == "read_file"
+    assert received_payload.arguments == %{"path" => "README.md"}
+  end
+
+  test "non-matching hooks do not run" do
+    test_pid = self()
+    hook = hook("write_file")
+    payload = PreToolUsePayload.new("tc_1", "read_file", %{})
+
+    runner = fn received_hook, _payload ->
+      send(test_pid, {:unexpected_hook, received_hook})
+      Result.allow(received_hook)
+    end
+
+    assert :ok = Dispatcher.pre_tool_use([hook], payload, runner: runner)
+    refute_receive {:unexpected_hook, _}, 20
+  end
+
+  test "glob patterns match tool names" do
+    test_pid = self()
+    hook = hook("*_file")
+    payload = PreToolUsePayload.new("tc_1", "read_file", %{})
+
+    runner = fn received_hook, _payload ->
+      send(test_pid, :hook_ran)
+      Result.allow(received_hook)
+    end
+
+    assert :ok = Dispatcher.pre_tool_use([hook], payload, runner: runner)
+    assert_receive :hook_ran
+  end
+
+  test "first veto short-circuits later hooks" do
+    test_pid = self()
+    first = hook("*")
+    second = hook("*")
+    payload = PreToolUsePayload.new("tc_1", "shell", %{"command" => "rm -rf /tmp/nope"})
+
+    runner = fn
+      ^first, _payload ->
+        send(test_pid, :first_hook)
+        Result.veto(first, "blocked by policy", {:exit, 2})
+
+      ^second, _payload ->
+        send(test_pid, :second_hook)
+        Result.allow(second)
+    end
+
+    assert {:error, %Result{status: :veto, stderr: "blocked by policy"}} =
+             Dispatcher.pre_tool_use([first, second], payload, runner: runner)
+
+    assert_receive :first_hook
+    refute_receive :second_hook, 20
+  end
+
+  test "broadcasts typed hook lifecycle events" do
+    Minga.Events.subscribe(:agent_hook)
+
+    hook = hook("read_file")
+    payload = PreToolUsePayload.new("tc_typed_event", "read_file", %{"path" => "README.md"})
+
+    runner = fn received_hook, _payload -> Result.allow(received_hook) end
+
+    assert :ok = Dispatcher.pre_tool_use([hook], payload, runner: runner)
+
+    assert_receive {:minga_event, :agent_hook,
+                    %Minga.Events.AgentHookEvent{
+                      event: "PreToolUse",
+                      phase: :started,
+                      tool_call_id: "tc_typed_event",
+                      tool_name: "read_file",
+                      tool_pattern: "read_file"
+                    }}
+
+    assert_receive {:minga_event, :agent_hook,
+                    %Minga.Events.AgentHookEvent{
+                      event: "PreToolUse",
+                      phase: :allowed,
+                      tool_call_id: "tc_typed_event",
+                      tool_name: "read_file",
+                      tool_pattern: "read_file"
+                    }}
+  end
+
+  test "normalization defaults timeout to 30 seconds" do
+    assert {:ok, %Hook{timeout_ms: 30_000}} =
+             Hook.normalize(%{event: "PreToolUse", tool: "shell", command: "echo checking >&2"})
+  end
+
+  defp hook(pattern) do
+    %Hook{event: :pre_tool_use, tool_pattern: pattern, command: "echo checking >&2"}
+  end
+end

--- a/test/minga_agent/providers/native_hooks_test.exs
+++ b/test/minga_agent/providers/native_hooks_test.exs
@@ -1,0 +1,114 @@
+defmodule MingaAgent.Providers.NativeHooksTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Config, as: AgentConfig
+  alias MingaAgent.Event
+  alias MingaAgent.Hooks.Hook
+  alias MingaAgent.Hooks.Result
+  alias MingaAgent.Providers.Native
+  alias ReqLLM.StreamResponse.MetadataHandle
+
+  @moduletag :tmp_dir
+
+  test "PreToolUse veto prevents native provider tool execution and emits stderr", %{tmp_dir: dir} do
+    test_pid = self()
+    call_count = :counters.new(1, [:atomics])
+
+    client = fn _model, _messages, _opts ->
+      count = :counters.get(call_count, 1)
+      :counters.add(call_count, 1, 1)
+
+      chunks =
+        if count == 0 do
+          [
+            ReqLLM.StreamChunk.tool_call("shell", %{"command" => "date"}, %{
+              id: "tc_hook",
+              index: 0
+            }),
+            ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+          ]
+        else
+          [
+            ReqLLM.StreamChunk.text("handled hook veto"),
+            ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
+          ]
+        end
+
+      build_stream_response(chunks)
+    end
+
+    tool =
+      ReqLLM.Tool.new!(
+        name: "shell",
+        description: "fake shell",
+        parameter_schema: %{},
+        callback: fn _args ->
+          send(test_pid, :tool_callback_ran)
+          {:ok, "should not run"}
+        end
+      )
+
+    hook = %Hook{event: :pre_tool_use, tool_pattern: "shell", command: "policy"}
+    config = %AgentConfig{tool_approval: :none, agent_hooks: [hook]}
+
+    hook_runner = fn ^hook, payload ->
+      send(test_pid, {:hook_payload, payload.tool_call_id, payload.tool_name, payload.arguments})
+      Result.veto(hook, "blocked by policy", {:exit, 7})
+    end
+
+    {:ok, pid} =
+      Native.start_link(
+        subscriber: self(),
+        model: "anthropic:claude-sonnet-4-20250514",
+        project_root: dir,
+        tools: [tool],
+        llm_client: client,
+        config: config,
+        hook_runner: hook_runner
+      )
+
+    assert :ok = Native.send_prompt(pid, "run shell")
+    events = collect_events(1_000)
+
+    assert_received {:hook_payload, "tc_hook", "shell", %{"command" => "date"}}
+    refute_received :tool_callback_ran
+
+    assert %Event.Error{message: error_message} = Enum.find(events, &match?(%Event.Error{}, &1))
+    assert error_message =~ "blocked by policy"
+
+    assert %Event.ToolEnd{is_error: true, result: result} =
+             Enum.find(events, &match?(%Event.ToolEnd{}, &1))
+
+    assert result =~ "blocked by policy"
+  end
+
+  defp build_stream_response(chunks) do
+    {:ok, handle} = MetadataHandle.start_link(fn -> %{usage: %{}, finish_reason: :stop} end)
+
+    stream_response = %ReqLLM.StreamResponse{
+      stream: chunks,
+      metadata_handle: handle,
+      cancel: fn -> :ok end,
+      model: elem(ReqLLM.model("anthropic:claude-sonnet-4-20250514"), 1),
+      context: ReqLLM.Context.new()
+    }
+
+    {:ok, stream_response}
+  end
+
+  defp collect_events(timeout) do
+    collect_events_acc([], timeout)
+  end
+
+  defp collect_events_acc(acc, timeout) do
+    receive do
+      {:agent_provider_event, %Event.AgentEnd{} = event} ->
+        Enum.reverse([event | acc])
+
+      {:agent_provider_event, event} ->
+        collect_events_acc([event | acc], timeout)
+    after
+      timeout -> Enum.reverse(acc)
+    end
+  end
+end

--- a/test/minga_agent/tool/executor_test.exs
+++ b/test/minga_agent/tool/executor_test.exs
@@ -1,6 +1,9 @@
 defmodule MingaAgent.Tool.ExecutorTest do
   use ExUnit.Case, async: true
 
+  alias MingaAgent.Config, as: AgentConfig
+  alias MingaAgent.Hooks.Hook
+  alias MingaAgent.Hooks.Result
   alias MingaAgent.Tool.Executor
   alias MingaAgent.Tool.Registry
   alias MingaAgent.Tool.Spec
@@ -90,6 +93,58 @@ defmodule MingaAgent.Tool.ExecutorTest do
     test "passes through {:error, reason} from callback", %{table: table} do
       register_tool(table, "failing", callback: fn _args -> {:error, :not_found} end)
       assert {:error, :not_found} = Executor.execute("failing", %{}, table)
+    end
+
+    test "runs matching PreToolUse hook before tool callback", %{table: table} do
+      test_pid = self()
+
+      register_tool(table, "echo",
+        callback: fn args ->
+          send(test_pid, {:callback_ran, args})
+          {:ok, "success"}
+        end
+      )
+
+      hook = %Hook{event: :pre_tool_use, tool_pattern: "echo", command: "policy"}
+      config = %AgentConfig{agent_hooks: [hook]}
+
+      runner = fn ^hook, payload ->
+        send(test_pid, {:hook_ran, payload.tool_name, payload.arguments})
+        Result.allow(hook)
+      end
+
+      assert {:ok, "success"} =
+               Executor.execute("echo", %{"msg" => "hello"}, table,
+                 config: config,
+                 hook_runner: runner
+               )
+
+      assert_received {:hook_ran, "echo", %{"msg" => "hello"}}
+      assert_received {:callback_ran, %{"msg" => "hello"}}
+    end
+
+    test "veto prevents tool callback", %{table: table} do
+      test_pid = self()
+
+      register_tool(table, "shell",
+        callback: fn _args ->
+          send(test_pid, :callback_ran)
+          {:ok, "should not run"}
+        end
+      )
+
+      hook = %Hook{event: :pre_tool_use, tool_pattern: "shell", command: "policy"}
+      config = %AgentConfig{agent_hooks: [hook]}
+      runner = fn ^hook, _payload -> Result.veto(hook, "blocked by policy", {:exit, 9}) end
+
+      assert {:error, {:hook_veto, message}} =
+               Executor.execute("shell", %{"command" => "date"}, table,
+                 config: config,
+                 hook_runner: runner
+               )
+
+      assert message =~ "blocked by policy"
+      refute_received :callback_ran
     end
   end
 

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -91,7 +91,6 @@ pub fn build(b: *std.Build) void {
         .{ .name = "elisp", .has_scanner = false },
         .{ .name = "clojure", .has_scanner = false },
         .{ .name = "objc", .has_scanner = false },
-
     };
 
     var grammar_libs: [grammars.len]*std.Build.Step.Compile = undefined;
@@ -129,6 +128,18 @@ pub fn build(b: *std.Build) void {
     parser_exe.linkLibrary(ts_lib);
     for (grammar_libs) |gl| parser_exe.linkLibrary(gl);
     b.installArtifact(parser_exe);
+
+    // ── Hook runner executable (one-shot POSIX process-group helper) ─────
+    const hook_runner_exe = b.addExecutable(.{
+        .name = "minga-hook-runner",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/hook_runner_main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    hook_runner_exe.root_module.link_libc = true;
+    b.installArtifact(hook_runner_exe);
 
     // Run step
     const run_cmd = b.addRunArtifact(exe);
@@ -172,6 +183,18 @@ pub fn build(b: *std.Build) void {
 
     const run_parser_tests = b.addRunArtifact(parser_tests);
     test_step.dependOn(&run_parser_tests.step);
+
+    const hook_runner_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/hook_runner_main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    hook_runner_tests.root_module.link_libc = true;
+
+    const run_hook_runner_tests = b.addRunArtifact(hook_runner_tests);
+    test_step.dependOn(&run_hook_runner_tests.step);
 }
 
 /// Build a static library for a tree-sitter grammar.
@@ -223,5 +246,3 @@ fn addGrammar(
 
     return lib;
 }
-
-

--- a/zig/src/hook_runner_main.zig
+++ b/zig/src/hook_runner_main.zig
@@ -1,0 +1,346 @@
+/// One-shot hook runner for Minga agent hooks.
+///
+/// Runs one `/bin/sh -c` command in its own POSIX session/process group, feeds the hook payload on stdin, discards stdout, captures bounded stderr, and emits one JSON result on stdout.
+const std = @import("std");
+const posix = std.posix;
+const c = std.c;
+
+const stderr_limit: usize = 64 * 1024;
+const truncation_marker = "\n[stderr truncated after 65536 bytes]\n";
+const kill_grace_ms: i64 = 50;
+
+const RunResult = struct {
+    status: Status,
+    exit_status: ?u8 = null,
+    timed_out: bool = false,
+    stderr: []const u8 = "",
+};
+
+const Status = enum { allow, veto };
+
+const StderrCapture = struct {
+    buf: std.ArrayList(u8),
+    truncated: bool = false,
+
+    fn init() StderrCapture {
+        return .{ .buf = .empty };
+    }
+
+    fn deinit(self: *StderrCapture, alloc: std.mem.Allocator) void {
+        self.buf.deinit(alloc);
+    }
+
+    fn append(self: *StderrCapture, alloc: std.mem.Allocator, bytes: []const u8) !void {
+        if (bytes.len == 0) return;
+        if (self.truncated) return;
+
+        const remaining = stderr_limit - self.buf.items.len;
+        if (bytes.len <= remaining) {
+            try self.buf.appendSlice(alloc, bytes);
+            return;
+        }
+
+        if (remaining > 0) {
+            try self.buf.appendSlice(alloc, bytes[0..remaining]);
+        }
+
+        try self.buf.appendSlice(alloc, truncation_marker);
+        self.truncated = true;
+    }
+};
+
+/// Parses runner arguments, executes the hook, and writes the structured JSON result.
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    const args = try std.process.argsAlloc(alloc);
+    defer std.process.argsFree(alloc, args);
+
+    if (args.len != 4) {
+        try writeHelperError("usage: minga-hook-runner <timeout_ms> <payload_len> <command>");
+        std.process.exit(2);
+    }
+
+    const timeout_ms = std.fmt.parseInt(u64, args[1], 10) catch {
+        try writeHelperError("invalid timeout_ms");
+        std.process.exit(2);
+    };
+
+    const payload_len = std.fmt.parseInt(usize, args[2], 10) catch {
+        try writeHelperError("invalid payload_len");
+        std.process.exit(2);
+    };
+
+    const payload = try alloc.alloc(u8, payload_len);
+    defer alloc.free(payload);
+
+    if (!try readExact(posix.STDIN_FILENO, payload)) {
+        try writeHelperError("stdin ended before payload was complete");
+        std.process.exit(2);
+    }
+
+    const result = runHook(alloc, args[3], payload, timeout_ms) catch |err| {
+        var msg_buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&msg_buf, "hook runner failed: {}", .{err}) catch "hook runner failed";
+        try writeHelperError(msg);
+        std.process.exit(2);
+    };
+    defer alloc.free(result.stderr);
+
+    try writeResult(result);
+}
+
+fn runHook(alloc: std.mem.Allocator, command: []const u8, payload: []const u8, timeout_ms: u64) !RunResult {
+    var stdin_pipe = try posix.pipe();
+    errdefer closePipe(&stdin_pipe);
+
+    var stderr_pipe = try posix.pipe();
+    errdefer closePipe(&stderr_pipe);
+
+    const devnull = try posix.open("/dev/null", .{ .ACCMODE = .WRONLY }, 0);
+    defer posix.close(devnull);
+
+    const command_z = try alloc.dupeZ(u8, command);
+    defer alloc.free(command_z);
+
+    const pid = try posix.fork();
+
+    if (pid == 0) {
+        childExec(stdin_pipe, stderr_pipe, devnull, command_z);
+    }
+
+    posix.close(stdin_pipe[0]);
+    stdin_pipe[0] = -1;
+    posix.close(stderr_pipe[1]);
+    stderr_pipe[1] = -1;
+    defer closeIfOpen(stdin_pipe[1]);
+    defer closeIfOpen(stderr_pipe[0]);
+
+    setNonBlocking(stdin_pipe[1]);
+    setNonBlocking(stderr_pipe[0]);
+
+    var stderr_capture = StderrCapture.init();
+    defer stderr_capture.deinit(alloc);
+
+    const start_ms = std.time.milliTimestamp();
+    const timeout_i64: i64 = @intCast(timeout_ms);
+    const deadline_ms = start_ms + timeout_i64;
+    var payload_offset: usize = 0;
+    var stdin_open = true;
+    var stderr_open = true;
+    var timed_out = false;
+    var child_done = false;
+    var status: u32 = 0;
+
+    while (!child_done) {
+        const now = std.time.milliTimestamp();
+        if (now >= deadline_ms and !timed_out) {
+            timed_out = true;
+            killProcessGroup(pid, posix.SIG.TERM);
+        }
+
+        if (timed_out and now >= deadline_ms + kill_grace_ms) {
+            killProcessGroup(pid, posix.SIG.KILL);
+        }
+
+        const wait = posix.waitpid(pid, posix.W.NOHANG);
+        if (wait.pid == pid) {
+            child_done = true;
+            status = wait.status;
+            break;
+        }
+
+        var pollfds = [_]posix.pollfd{
+            .{ .fd = if (stdin_open and payload_offset < payload.len) stdin_pipe[1] else -1, .events = posix.POLL.OUT, .revents = 0 },
+            .{ .fd = if (stderr_open) stderr_pipe[0] else -1, .events = posix.POLL.IN, .revents = 0 },
+        };
+
+        const remaining_ms = if (timed_out) kill_grace_ms else @max(deadline_ms - now, 0);
+        const poll_timeout: i32 = @intCast(@min(remaining_ms, 50));
+        _ = posix.poll(&pollfds, poll_timeout) catch 0;
+
+        if (stdin_open and pollfds[0].revents & posix.POLL.OUT != 0) {
+            const n = posix.write(stdin_pipe[1], payload[payload_offset..]) catch |err| switch (err) {
+                error.WouldBlock => 0,
+                error.BrokenPipe => blk: {
+                    posix.close(stdin_pipe[1]);
+                    stdin_pipe[1] = -1;
+                    stdin_open = false;
+                    break :blk 0;
+                },
+                else => return err,
+            };
+
+            payload_offset += n;
+            if (payload_offset >= payload.len) {
+                posix.close(stdin_pipe[1]);
+                stdin_pipe[1] = -1;
+                stdin_open = false;
+            }
+        }
+
+        if (stdin_open and payload.len == 0) {
+            posix.close(stdin_pipe[1]);
+            stdin_pipe[1] = -1;
+            stdin_open = false;
+        }
+
+        if (stderr_open and pollfds[1].revents & (posix.POLL.IN | posix.POLL.HUP | posix.POLL.ERR) != 0) {
+            var read_buf: [4096]u8 = undefined;
+            const n = posix.read(stderr_pipe[0], &read_buf) catch |err| switch (err) {
+                error.WouldBlock => 0,
+                else => return err,
+            };
+
+            if (n == 0) {
+                posix.close(stderr_pipe[0]);
+                stderr_pipe[0] = -1;
+                stderr_open = false;
+            } else {
+                try stderr_capture.append(alloc, read_buf[0..n]);
+            }
+        }
+    }
+
+    // Drain any stderr written just before the child exited.
+    while (stderr_open) {
+        var read_buf: [4096]u8 = undefined;
+        const n = posix.read(stderr_pipe[0], &read_buf) catch |err| switch (err) {
+            error.WouldBlock => 0,
+            else => return err,
+        };
+        if (n == 0) break;
+        try stderr_capture.append(alloc, read_buf[0..n]);
+    }
+
+    const stderr_copy = try alloc.dupe(u8, stderr_capture.buf.items);
+
+    if (timed_out) {
+        return .{ .status = .veto, .timed_out = true, .stderr = stderr_copy };
+    }
+
+    if (posix.W.IFEXITED(status)) {
+        const code: u8 = @intCast(posix.W.EXITSTATUS(status));
+        if (code == 0) {
+            return .{ .status = .allow, .exit_status = 0, .stderr = stderr_copy };
+        }
+        return .{ .status = .veto, .exit_status = code, .stderr = stderr_copy };
+    }
+
+    return .{ .status = .veto, .stderr = stderr_copy };
+}
+
+fn childExec(stdin_pipe: [2]posix.fd_t, stderr_pipe: [2]posix.fd_t, devnull: posix.fd_t, command_z: [:0]const u8) noreturn {
+    _ = posix.setsid() catch {};
+
+    posix.close(stdin_pipe[1]);
+    posix.close(stderr_pipe[0]);
+
+    posix.dup2(stdin_pipe[0], posix.STDIN_FILENO) catch std.process.exit(127);
+    posix.dup2(devnull, posix.STDOUT_FILENO) catch std.process.exit(127);
+    posix.dup2(stderr_pipe[1], posix.STDERR_FILENO) catch std.process.exit(127);
+
+    posix.close(stdin_pipe[0]);
+    posix.close(stderr_pipe[1]);
+    posix.close(devnull);
+
+    const argv = [_:null]?[*:0]const u8{ "/bin/sh", "-c", command_z.ptr };
+    const envp: [*:null]const ?[*:0]const u8 = @ptrCast(c.environ);
+    posix.execveZ("/bin/sh", &argv, envp) catch std.process.exit(127);
+}
+
+fn killProcessGroup(pid: posix.pid_t, signal: u6) void {
+    const group_pid: posix.pid_t = -pid;
+    posix.kill(group_pid, signal) catch {};
+}
+
+fn closePipe(pipe: *[2]posix.fd_t) void {
+    closeIfOpen(pipe[0]);
+    closeIfOpen(pipe[1]);
+}
+
+fn closeIfOpen(fd: posix.fd_t) void {
+    if (fd >= 0) posix.close(fd);
+}
+
+fn setNonBlocking(fd: posix.fd_t) void {
+    const flags = posix.fcntl(fd, posix.F.GETFL, 0) catch return;
+    const nonblock: u32 = @bitCast(posix.O{ .NONBLOCK = true });
+    _ = posix.fcntl(fd, posix.F.SETFL, flags | @as(usize, nonblock)) catch return;
+}
+
+fn readExact(fd: posix.fd_t, buf: []u8) !bool {
+    var total: usize = 0;
+    while (total < buf.len) {
+        const n = try posix.read(fd, buf[total..]);
+        if (n == 0) return false;
+        total += n;
+    }
+    return true;
+}
+
+fn writeResult(result: RunResult) !void {
+    var stdout_buf: [4096]u8 = undefined;
+    var stdout_writer_obj = std.fs.File.stdout().writer(&stdout_buf);
+    const stdout = &stdout_writer_obj.interface;
+
+    switch (result.status) {
+        .allow => try stdout.writeAll("{\"status\":\"allow\",\"stderr\":"),
+        .veto => try stdout.writeAll("{\"status\":\"veto\",\"stderr\":"),
+    }
+
+    try writeJsonString(stdout, result.stderr);
+
+    if (result.status == .veto) {
+        if (result.timed_out) {
+            try stdout.writeAll(",\"reason\":{\"type\":\"timeout\"}}");
+        } else if (result.exit_status) |code| {
+            try stdout.writeAll(",\"reason\":{\"type\":\"exit\",\"status\":");
+            try stdout.print("{d}", .{code});
+            try stdout.writeAll("}}");
+        } else {
+            try stdout.writeAll(",\"reason\":{\"type\":\"failed\"}}");
+        }
+    } else {
+        try stdout.writeAll("}");
+    }
+
+    try stdout.flush();
+}
+
+fn writeHelperError(message: []const u8) !void {
+    var stdout_buf: [1024]u8 = undefined;
+    var stdout_writer_obj = std.fs.File.stdout().writer(&stdout_buf);
+    const stdout = &stdout_writer_obj.interface;
+    try stdout.writeAll("{\"status\":\"error\",\"message\":");
+    try writeJsonString(stdout, message);
+    try stdout.writeAll("}");
+    try stdout.flush();
+}
+
+fn writeJsonString(writer: *std.Io.Writer, value: []const u8) !void {
+    try std.json.Stringify.value(value, .{}, writer);
+}
+
+test "stderr capture appends truncation marker once" {
+    var cap = StderrCapture.init();
+    defer cap.deinit(std.testing.allocator);
+
+    const chunk = "0123456789abcdef" ** 5000;
+    try cap.append(std.testing.allocator, chunk);
+    try cap.append(std.testing.allocator, chunk);
+
+    try std.testing.expect(cap.truncated);
+    try std.testing.expect(cap.buf.items.len <= stderr_limit + truncation_marker.len);
+    try std.testing.expect(std.mem.endsWith(u8, cap.buf.items, truncation_marker));
+}
+
+test "json string escapes stderr" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+
+    try writeJsonString(&out.writer, "hello \"world\"\n");
+    try std.testing.expectEqualStrings("\"hello \\\"world\\\"\\n\"", out.written());
+}


### PR DESCRIPTION
# TL;DR
Adds the first agent hook surface: `PreToolUse`. Users can declare shell hooks in config, receive the pending tool call as JSON on stdin, and veto execution with a non-zero exit.

Closes #1405
Part of #1404

## Changes
- Added `:agent_hooks` config and normalization into typed hook structs.
- Added stateless hook infrastructure under `MingaAgent.Hooks`:
  - `Hook` for normalized declarations and tool-pattern matching.
  - `PreToolUsePayload` for the public JSON payload.
  - `Result` for allow/veto outcomes.
  - `Dispatcher` for ordered matching and first-veto short-circuiting.
  - `CommandRunner` for `/bin/sh -c` hooks with JSON stdin, stderr capture, and timeout handling.
- Wired hooks into both native provider tool execution and the direct `MingaAgent.Tool.Executor` path.
- Added typed `Minga.Events.AgentHookEvent` telemetry for hook lifecycle events.
- Documented the hook model, `PreToolUse` payload, planned event taxonomy, and a worked shell-policy example in `docs/HOOKS.md`.
- Hardened extension git integration tests against global git signing config for local fixture commits.

## Verification
- `make lint`
- `mix test.llm`
- `mix test.llm test/minga_agent/hooks/dispatcher_test.exs test/minga_agent/providers/native_hooks_test.exs test/minga_agent/tool/executor_test.exs test/minga_agent/config_test.exs test/minga/config/options_test.exs`
- `mix test.debug test/minga_agent/hooks/command_runner_test.exs`
- Test-advisor: consulted before implementation
- Archie: consulted before implementation
- Minga reviewer gate: PASS
