### PR TITLE
feat(agent): load context artifacts explicitly

### DIFF
--- a/.pr-body-1418.md
+++ b/.pr-body-1418.md
@@ -1,0 +1,19 @@
+## Summary
+
+- Complete the context artifact loop with explicit picker-loading instead of hidden auto-load or deletion.
+- Add `/context`, `:agent_context_artifacts`, `:agent-context`, and `SPC a c` to insert a selected `.minga/context/session-summary-*.md` artifact as an `@` mention in the agent prompt.
+- Restrict artifact listing to generated `session-summary-*.md` files.
+- Document the decision and user flow in `AGENTS.md` and `docs/AGENTIC-KEYMAP.md`.
+
+Part of #1404.
+Closes #1418.
+
+## Testing
+
+- `mix test.llm test/minga_agent/context_artifact_test.exs test/minga_editor/ui/picker/context_artifact_source_test.exs test/minga_editor/agent/slash_command_test.exs test/minga_editor/commands/agent_commands_test.exs test/minga/command/registry_test.exs`
+- `make lint`
+- `mix test.llm`
+
+## Review
+
+- Reviewer gate: PASS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -824,6 +824,9 @@ Agent tools live in `lib/minga_agent/tools/`. When adding or modifying a tool th
 2. **Batch edits into a single call** rather than making N separate calls. One call = one undo entry, one version bump.
 3. **Test the tool function** in `test/minga_agent/tools/`.
 
+### Context artifacts
+Context artifacts in `.minga/context/session-summary-*.md` are explicit handoff files, not hidden memory. Minga must not auto-load them into new sessions. Users load one with `/context` or `SPC a c`, which inserts an `@.minga/context/...` mention into the prompt so the existing file-mention resolver reads it on submit. Keep this single ingestion path unless there is a new architecture decision that justifies hidden context.
+
 ### New render command (requires BEAM + frontend changes)
 1. Add opcode constant and encoder in `Minga.Port.Protocol` (BEAM side, canonical source of truth)
 2. **macOS GUI:** Add decoder in `macos/Sources/Protocol/ProtocolDecoder.swift`, constant in `ProtocolConstants.swift`, handler in `CommandDispatcher.swift`

--- a/docs/AGENTIC-KEYMAP.md
+++ b/docs/AGENTIC-KEYMAP.md
@@ -101,6 +101,10 @@ See [Agent tool approval](CONFIGURATION.md#agent-tool-approval) for how to confi
 |-----|--------|
 | `s` | Open session switcher |
 | `SPC a h` | Browse session history (load past conversations) |
+| `SPC a e` | Summarize the current session to `.minga/context/` |
+| `SPC a c` | Pick a saved context artifact and insert it into the prompt as an `@` mention |
+
+Context artifacts are explicit handoff files. Minga never auto-loads them into new sessions because stale hidden context is hard to notice. Use `/context` or `SPC a c` when you want to continue from a saved summary; the picker inserts an `@.minga/context/session-summary-...md` mention, and the normal file-mention pipeline reads it when you submit.
 
 ### Panel Management
 
@@ -135,6 +139,8 @@ See [Agent tool approval](CONFIGURATION.md#agent-tool-approval) for how to confi
 | `SPC a s` | Stop / abort agent |
 | `SPC a m` | Pick agent model |
 | `SPC a T` | Cycle thinking level |
+| `SPC a e` | Summarize session to context artifact |
+| `SPC a c` | Load context artifact into the prompt |
 | `SPC a t` | Toggle agentic view (close) |
 
 ## Chat Input Mode

--- a/lib/minga/command/parser.ex
+++ b/lib/minga/command/parser.ex
@@ -153,6 +153,7 @@ defmodule Minga.Command.Parser do
   defp do_parse("agent-models"), do: {:agent_pick_model, []}
   defp do_parse("agent-cycle-model"), do: {:agent_cycle_model, []}
   defp do_parse("agent-summarize"), do: {:agent_summarize, []}
+  defp do_parse("agent-context"), do: {:agent_context_artifacts, []}
   defp do_parse("agent-thinking"), do: {:agent_cycle_thinking, []}
   defp do_parse("ToolInstall " <> name), do: {:tool_install_named, [String.trim(name)]}
   defp do_parse("ToolUninstall " <> name), do: {:tool_uninstall_named, [String.trim(name)]}

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -137,6 +137,7 @@ defmodule Minga.Keymap.Defaults do
     {[{?a, @none}, {?h, @none}], :agent_session_history, "Session history"},
     {[{?a, @none}, {?T, @none}], :agent_cycle_thinking, "Cycle thinking level"},
     {[{?a, @none}, {?e, @none}], :agent_summarize, "Summarize session to artifact"},
+    {[{?a, @none}, {?c, @none}], :agent_context_artifacts, "Load context artifact"},
     {[{?a, @none}, {?q, @none}], :agent_dequeue, "Dequeue queued messages to editor"},
     {[{?a, @none}, {?f, @none}], :agent_queue_follow_up, "Queue current input as follow-up"},
 

--- a/lib/minga_agent/context_artifact.ex
+++ b/lib/minga_agent/context_artifact.ex
@@ -80,7 +80,7 @@ defmodule MingaAgent.ContextArtifact do
     if File.dir?(dir) do
       dir
       |> File.ls!()
-      |> Enum.filter(&String.ends_with?(&1, ".md"))
+      |> Enum.filter(&session_summary?/1)
       |> Enum.sort()
       |> Enum.map(&Path.join(dir, &1))
     else
@@ -99,6 +99,11 @@ defmodule MingaAgent.ContextArtifact do
   def summarizable?(messages) do
     non_system = Enum.reject(messages, &(&1.role == :system))
     length(non_system) >= 2
+  end
+
+  @spec session_summary?(String.t()) :: boolean()
+  defp session_summary?(filename) do
+    String.starts_with?(filename, "session-summary-") and String.ends_with?(filename, ".md")
   end
 
   @spec short_id() :: String.t()

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -75,6 +75,10 @@ defmodule MingaEditor.Agent.SlashCommand do
       description: "Generate a context artifact from this session for future use"
     },
     %Command{
+      name: "context",
+      description: "Pick a saved context artifact and insert it as an @mention"
+    },
+    %Command{
       name: "remember",
       description: "Save a learning to persistent memory: /remember <text>"
     },
@@ -139,6 +143,7 @@ defmodule MingaEditor.Agent.SlashCommand do
   defp dispatch(state, "export", _args), do: do_export(state, :markdown)
   defp dispatch(state, "skills", _args), do: {:ok, do_skills(state)}
   defp dispatch(state, "summarize", _args), do: do_summarize(state)
+  defp dispatch(state, "context", _args), do: {:ok, AgentCommands.context_artifacts(state)}
   defp dispatch(state, "remember", args), do: do_remember(state, args)
   defp dispatch(state, "memory", _args), do: {:ok, do_memory(state)}
   defp dispatch(state, "forget", _args), do: do_forget(state)

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.Commands.Agent do
 
   alias MingaEditor.Agent.BufferSync, as: AgentBufferSync
   alias MingaEditor.Agent.DiffReview
+  alias MingaAgent.ContextArtifact
   alias MingaAgent.FileMention
   alias MingaAgent.Markdown
   alias MingaAgent.Message
@@ -569,6 +570,20 @@ defmodule MingaEditor.Commands.Agent do
         {:error, reason} ->
           EditorState.set_status(state, "Error: #{inspect(reason)}")
       end
+    end
+  end
+
+  @doc "Opens the picker for loading saved context artifacts into the prompt."
+  @spec context_artifacts(state()) :: state()
+  def context_artifacts(state) do
+    root = project_root()
+
+    case ContextArtifact.list(root) do
+      [] ->
+        EditorState.set_status(state, "No context artifacts found")
+
+      _artifacts ->
+        PickerUI.open(state, MingaEditor.UI.Picker.ContextArtifactSource, %{project_root: root})
     end
   end
 
@@ -1209,6 +1224,7 @@ defmodule MingaEditor.Commands.Agent do
     {:agent_new_session, "New AI agent session", :new_agent_session},
     {:agent_cycle_model, "Cycle AI agent model", :cycle_model},
     {:agent_summarize, "Summarize session to context artifact", :summarize},
+    {:agent_context_artifacts, "Load context artifact into prompt", :context_artifacts},
     {:agent_cycle_thinking, "Cycle AI thinking level", :cycle_thinking_level},
     {:agent_clear_history, "Clear all saved agent sessions", :clear_session_history},
     # Input commands shared between editor scope (side panel) and agent scope

--- a/lib/minga_editor/ui/picker/context_artifact_source.ex
+++ b/lib/minga_editor/ui/picker/context_artifact_source.ex
@@ -1,0 +1,70 @@
+defmodule MingaEditor.UI.Picker.ContextArtifactSource do
+  @moduledoc """
+  Picker source for loading saved agent context artifacts into the prompt.
+
+  Context artifacts are explicit one-off prompt attachments, not hidden session
+  memory. Selecting an artifact inserts an `@.minga/context/...` mention into
+  the active prompt so the existing file-mention resolver reads the file when
+  the user submits.
+  """
+
+  @behaviour MingaEditor.UI.Picker.Source
+
+  alias MingaAgent.ContextArtifact
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.State.AgentAccess
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.Item
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Context Artifacts"
+
+  @impl true
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{} = ctx) do
+    project_root = project_root(ctx)
+
+    project_root
+    |> ContextArtifact.list()
+    |> Enum.map(&artifact_item(&1, project_root))
+  end
+
+  @impl true
+  @spec on_select(Item.t(), term()) :: term()
+  def on_select(%Item{id: relative_path}, state) when is_binary(relative_path) do
+    mention = "@#{relative_path} "
+
+    AgentAccess.update_agent_ui(state, fn ui ->
+      ui
+      |> UIState.ensure_prompt_buffer()
+      |> UIState.insert_paste(mention)
+      |> UIState.set_input_focused(true)
+    end)
+  end
+
+  @impl true
+  @spec on_cancel(term()) :: term()
+  def on_cancel(state), do: state
+
+  @spec artifact_item(String.t(), String.t()) :: Item.t()
+  defp artifact_item(path, project_root) do
+    relative = Path.relative_to(path, project_root)
+    basename = Path.basename(path, ".md")
+
+    %Item{
+      id: relative,
+      label: basename,
+      description: Path.dirname(relative),
+      two_line: true
+    }
+  end
+
+  @spec project_root(Context.t()) :: String.t()
+  defp project_root(%Context{picker_ui: %{context: %{project_root: root}}})
+       when is_binary(root) do
+    root
+  end
+
+  defp project_root(_ctx), do: Minga.Project.resolve_root()
+end

--- a/test/minga/command/registry_test.exs
+++ b/test/minga/command/registry_test.exs
@@ -112,6 +112,7 @@ defmodule Minga.Command.RegistryTest do
           :agent_pick_model,
           :agent_cycle_model,
           :agent_summarize,
+          :agent_context_artifacts,
           :agent_cycle_thinking,
 
           # Line display

--- a/test/minga_agent/context_artifact_test.exs
+++ b/test/minga_agent/context_artifact_test.exs
@@ -91,16 +91,28 @@ defmodule MingaAgent.ContextArtifactTest do
   end
 
   describe "list/1" do
-    test "lists existing context artifacts", %{tmp_dir: dir} do
+    test "lists only session summary markdown artifacts", %{tmp_dir: dir} do
       context_dir = Path.join(dir, ".minga/context")
       File.mkdir_p!(context_dir)
-      File.write!(Path.join(context_dir, "session-summary-a.md"), "summary a")
       File.write!(Path.join(context_dir, "session-summary-b.md"), "summary b")
-      File.write!(Path.join(context_dir, "other.txt"), "not a summary")
+      File.write!(Path.join(context_dir, "session-summary-a.md"), "summary a")
+      File.write!(Path.join(context_dir, "other.md"), "not a session summary")
+      File.write!(Path.join(context_dir, "session-summary-c.txt"), "wrong extension")
 
       artifacts = ContextArtifact.list(dir)
-      assert length(artifacts) == 2
+      filenames = Enum.map(artifacts, &Path.basename/1)
+
+      assert filenames == ["session-summary-a.md", "session-summary-b.md"]
       assert Enum.all?(artifacts, &String.ends_with?(&1, ".md"))
+    end
+
+    test "returns empty list when context directory has no summaries", %{tmp_dir: dir} do
+      context_dir = Path.join(dir, ".minga/context")
+      File.mkdir_p!(context_dir)
+      File.write!(Path.join(context_dir, "notes.md"), "notes")
+      File.write!(Path.join(context_dir, "session-summary.txt"), "wrong name")
+
+      assert ContextArtifact.list(dir) == []
     end
 
     test "returns empty list when no context directory", %{tmp_dir: dir} do

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -41,6 +41,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       assert "stop" in names
       assert "thinking" in names
       assert "model" in names
+      assert "context" in names
     end
   end
 
@@ -61,6 +62,13 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       matches = SlashCommand.completions("/he")
       names = Enum.map(matches, & &1.name)
       assert "help" in names
+    end
+
+    test "includes context artifact command by prefix" do
+      matches = SlashCommand.completions("/con")
+      names = Enum.map(matches, & &1.name)
+      assert "context" in names
+      assert "continue" in names
     end
 
     test "returns empty list for no match" do
@@ -143,6 +151,11 @@ defmodule MingaEditor.Agent.SlashCommandTest do
     test "/model with name sets model (triggers restart)" do
       {:ok, state} = SlashCommand.execute(mock_state(), "/model gpt-4o")
       assert AgentAccess.panel(state).model_name == "gpt-4o"
+    end
+
+    test "/context opens explicit context artifact loading path" do
+      {:ok, state} = SlashCommand.execute(mock_state(), "/context")
+      assert state.shell_state.status_msg == "No context artifacts found"
     end
 
     test "/? is an alias for /help" do

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -162,6 +162,18 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
     end
   end
 
+  describe "context_artifacts/1" do
+    test "sets a status message when no context artifacts exist" do
+      state = AgentCommands.context_artifacts(base_state())
+      assert state.shell_state.status_msg == "No context artifacts found"
+    end
+
+    test "is registered as an agent command" do
+      names = AgentCommands.__commands__() |> Enum.map(& &1.name)
+      assert :agent_context_artifacts in names
+    end
+  end
+
   # ── abort_agent ──────────────────────────────────────────────────────────
 
   describe "abort_agent/1" do

--- a/test/minga_editor/ui/picker/context_artifact_source_test.exs
+++ b/test/minga_editor/ui/picker/context_artifact_source_test.exs
@@ -1,0 +1,137 @@
+defmodule MingaEditor.UI.Picker.ContextArtifactSourceTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias MingaAgent.FileMention
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.AgentAccess
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Windows
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.ContextArtifactSource
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias MingaEditor.Window
+
+  @moduletag :tmp_dir
+
+  defp picker_context(project_root) do
+    state = base_state()
+    Context.from_editor_state(state, %{project_root: project_root})
+  end
+
+  defp base_state(opts \\ []) do
+    buf = start_buffer(Keyword.get(opts, :content, "hello"))
+    prompt_buf = start_buffer(Keyword.get(opts, :prompt, ""))
+
+    agent_ui = %UIState{
+      panel: %UIState.Panel{visible: true, input_focused: true, prompt_buffer: prompt_buf}
+    }
+
+    agent_tab = Tab.new_agent(1, "Agent")
+
+    %EditorState{
+      port_manager: nil,
+      shell: MingaEditor.Shell.Traditional,
+      terminal_viewport: Viewport.new(24, 80),
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: VimState.new(),
+        buffers: %Buffers{active: buf, list: [buf], active_index: 0},
+        windows: %Windows{
+          tree: {:leaf, 1},
+          map: %{1 => Window.new(1, buf, 24, 80)},
+          active: 1,
+          next_id: 2
+        },
+        agent_ui: agent_ui
+      },
+      shell_state: %MingaEditor.Shell.Traditional.State{
+        agent: %AgentState{},
+        tab_bar: TabBar.new(agent_tab)
+      }
+    }
+  end
+
+  defp start_buffer(content) do
+    start_supervised!(
+      Supervisor.child_spec({BufferServer, content: content}, id: {BufferServer, make_ref()})
+    )
+  end
+
+  defp write_artifact(project_root, filename, content \\ "summary") do
+    context_dir = Path.join(project_root, ".minga/context")
+    File.mkdir_p!(context_dir)
+    path = Path.join(context_dir, filename)
+    File.write!(path, content)
+    path
+  end
+
+  describe "candidates/1" do
+    test "lists context artifacts as mentionable relative paths", %{tmp_dir: dir} do
+      write_artifact(dir, "session-summary-abc123-2026-05-09.md")
+
+      assert [%Item{} = item] = ContextArtifactSource.candidates(picker_context(dir))
+      assert item.id == ".minga/context/session-summary-abc123-2026-05-09.md"
+      assert item.label == "session-summary-abc123-2026-05-09"
+      assert item.description == ".minga/context"
+    end
+
+    test "ignores non-session markdown files", %{tmp_dir: dir} do
+      write_artifact(dir, "session-summary-good.md")
+      write_artifact(dir, "other.md")
+
+      items = ContextArtifactSource.candidates(picker_context(dir))
+
+      assert Enum.map(items, & &1.id) == [".minga/context/session-summary-good.md"]
+    end
+
+    test "returns no candidates when there are no artifacts", %{tmp_dir: dir} do
+      assert ContextArtifactSource.candidates(picker_context(dir)) == []
+    end
+  end
+
+  describe "on_select/2" do
+    test "inserts an artifact @mention into an empty prompt" do
+      state = base_state()
+      item = %Item{id: ".minga/context/session-summary-abc123.md", label: "summary"}
+
+      new_state = ContextArtifactSource.on_select(item, state)
+
+      assert UIState.input_text(AgentAccess.panel(new_state)) ==
+               "@.minga/context/session-summary-abc123.md "
+
+      assert AgentAccess.input_focused?(new_state)
+    end
+
+    test "inserts at the prompt cursor and preserves existing text" do
+      state = base_state(prompt: "please  now")
+      BufferServer.set_cursor(AgentAccess.panel(state).prompt_buffer, {0, 7})
+      item = %Item{id: ".minga/context/session-summary-abc123.md", label: "summary"}
+
+      new_state = ContextArtifactSource.on_select(item, state)
+
+      assert UIState.input_text(AgentAccess.panel(new_state)) ==
+               "please @.minga/context/session-summary-abc123.md  now"
+    end
+
+    test "inserted mention resolves through FileMention", %{tmp_dir: dir} do
+      write_artifact(dir, "session-summary-abc123.md", "## Decisions\n- Keep writer")
+      state = base_state(prompt: "continue from ")
+      item = %Item{id: ".minga/context/session-summary-abc123.md", label: "summary"}
+
+      new_state = ContextArtifactSource.on_select(item, state)
+      prompt = UIState.prompt_text(AgentAccess.panel(new_state))
+
+      assert {:ok, resolved} = FileMention.resolve_prompt(prompt, dir)
+      assert resolved =~ "Contents of .minga/context/session-summary-abc123.md:"
+      assert resolved =~ "Keep writer"
+      assert resolved =~ "continue from"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Complete the context artifact loop with explicit picker-loading instead of hidden auto-load or deletion.
- Add `/context`, `:agent_context_artifacts`, `:agent-context`, and `SPC a c` to insert a selected `.minga/context/session-summary-*.md` artifact as an `@` mention in the agent prompt.
- Restrict artifact listing to generated `session-summary-*.md` files.
- Document the decision and user flow in `AGENTS.md` and `docs/AGENTIC-KEYMAP.md`.

Part of #1404.
Closes #1418.

## Testing

- `mix test.llm test/minga_agent/context_artifact_test.exs test/minga_editor/ui/picker/context_artifact_source_test.exs test/minga_editor/agent/slash_command_test.exs test/minga_editor/commands/agent_commands_test.exs test/minga/command/registry_test.exs`
- `make lint`
- `mix test.llm`

## Review

- Reviewer gate: PASS
