### PR TITLE
chore(zig): upgrade Zig 0.15.2 → 0.16.0 and libvaxis 0.5.1 → 0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Cache deps
         uses: actions/cache@v4
@@ -55,7 +55,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Cache deps
         uses: actions/cache@v4
@@ -78,7 +78,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Run Zig tests
         run: cd zig && zig build test
@@ -135,7 +135,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Install XcodeGen
         run: brew install xcodegen
@@ -172,7 +172,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       # Separate cache from test jobs: dialyzer needs _build/dev, not _build/test.
       # The PLT and compiled deps are both under _build/dev.
@@ -211,7 +211,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Cache deps
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 env:
   MIX_ENV: prod
   ELIXIR_VERSION: "1.19.5"
-  OTP_VERSION: "28.3.3"
+  OTP_VERSION: "28.4.1"
   ZIG_VERSION: "0.16.0"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
   MIX_ENV: prod
   ELIXIR_VERSION: "1.19.5"
   OTP_VERSION: "28.3.3"
-  ZIG_VERSION: "0.15.2"
+  ZIG_VERSION: "0.16.0"
 
 jobs:
   # ── Gate: validate tag matches mix.exs version ─────────────────────────

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ Thumbs.db
 .env
 .env.local
 PLAN.md
-PLAN.md
 .build/
 test/tmp/
 autoresearch.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ minga-*.tar
 # Zig
 zig/zig-out/
 zig/.zig-cache/
+zig/zig-pkg/
 
 # Swift / Xcode
 macos/.build/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 erlang 28.4.1
 elixir 1.19.5-otp-28
-zig 0.15.2
+zig 0.16.0

--- a/lib/minga_agent/hooks/command_runner.ex
+++ b/lib/minga_agent/hooks/command_runner.ex
@@ -106,7 +106,7 @@ defmodule MingaAgent.Hooks.CommandRunner do
       ])
 
     os_pid = port_os_pid(port)
-    true = Port.command(port, payload_json)
+    send_payload_to_helper(port, payload_json)
     guard_deadline_ms = System.monotonic_time(:millisecond) + hook.timeout_ms + @guard_timeout_ms
     collect_helper_result(port, hook, "", guard_deadline_ms, os_pid)
   rescue
@@ -123,6 +123,18 @@ defmodule MingaAgent.Hooks.CommandRunner do
         "failed to start hook runner: #{inspect(kind)} #{inspect(reason)}",
         {:failed_to_start, {kind, reason}}
       )
+  end
+
+  @spec send_payload_to_helper(port(), String.t()) :: :ok
+  defp send_payload_to_helper(port, payload_json) do
+    case Port.command(port, payload_json) do
+      true -> :ok
+      false -> :ok
+    end
+  rescue
+    ArgumentError -> :ok
+  catch
+    :exit, _reason -> :ok
   end
 
   @spec collect_helper_result(port(), Hook.t(), String.t(), integer(), pos_integer() | nil) ::

--- a/lib/minga_agent/hooks/command_runner.ex
+++ b/lib/minga_agent/hooks/command_runner.ex
@@ -127,10 +127,8 @@ defmodule MingaAgent.Hooks.CommandRunner do
 
   @spec send_payload_to_helper(port(), String.t()) :: :ok
   defp send_payload_to_helper(port, payload_json) do
-    case Port.command(port, payload_json) do
-      true -> :ok
-      false -> :ok
-    end
+    Port.command(port, payload_json)
+    :ok
   rescue
     ArgumentError -> :ok
   catch

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -109,6 +109,7 @@ pub fn build(b: *std.Build) void {
     });
     exe.root_module.addImport("vaxis", vaxis.module("vaxis"));
     exe.root_module.addImport("build_options", build_options.createModule());
+    exe.root_module.link_libc = true;
     // Note: tree-sitter and grammars are linked only to minga-parser, not the renderer.
 
     b.installArtifact(exe);

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -124,9 +124,9 @@ pub fn build(b: *std.Build) void {
     });
     parser_exe.root_module.addIncludePath(b.path("vendor/tree-sitter/include"));
     parser_exe.root_module.link_libc = true;
-    parser_exe.addCSourceFile(.{ .file = b.path("src/regex_sizeof.c"), .flags = &.{"-std=c11"} });
-    parser_exe.linkLibrary(ts_lib);
-    for (grammar_libs) |gl| parser_exe.linkLibrary(gl);
+    parser_exe.root_module.addCSourceFile(.{ .file = b.path("src/regex_sizeof.c"), .flags = &.{"-std=c11"} });
+    parser_exe.root_module.linkLibrary(ts_lib);
+    for (grammar_libs) |gl| parser_exe.root_module.linkLibrary(gl);
     b.installArtifact(parser_exe);
 
     // ── Hook runner executable (one-shot POSIX process-group helper) ─────
@@ -177,9 +177,9 @@ pub fn build(b: *std.Build) void {
     parser_tests.root_module.addImport("build_options", build_options.createModule());
     parser_tests.root_module.addIncludePath(b.path("vendor/tree-sitter/include"));
     parser_tests.root_module.link_libc = true;
-    parser_tests.addCSourceFile(.{ .file = b.path("src/regex_sizeof.c"), .flags = &.{"-std=c11"} });
-    parser_tests.linkLibrary(ts_lib);
-    for (grammar_libs) |gl| parser_tests.linkLibrary(gl);
+    parser_tests.root_module.addCSourceFile(.{ .file = b.path("src/regex_sizeof.c"), .flags = &.{"-std=c11"} });
+    parser_tests.root_module.linkLibrary(ts_lib);
+    for (grammar_libs) |gl| parser_tests.root_module.linkLibrary(gl);
 
     const run_parser_tests = b.addRunArtifact(parser_tests);
     test_step.dependOn(&run_parser_tests.step);

--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -5,8 +5,8 @@
 
     .dependencies = .{
         .vaxis = .{
-            .url = "git+https://github.com/rockorager/libvaxis.git#a3ae1d53feeeeaeb6218de3d38837559811acae4",
-            .hash = "vaxis-0.5.1-BWNV_JxLCQDqWG6pB_gLLit8NgtHbnMcVyQmTMw6Qil9",
+            .url = "git+https://github.com/rockorager/libvaxis.git#1dbbe575dff4586fe51e3217aa5c3fecdcbb6089",
+            .hash = "vaxis-0.6.0-BWNV_CrbCQCscGpzsAlR402rYQ_tV3aAl081c2iRRkka",
         },
     },
 

--- a/zig/src/apprt/tui.zig
+++ b/zig/src/apprt/tui.zig
@@ -429,6 +429,7 @@ pub const TuiRuntime = struct {
         // any stored pointers to self's fields (especially tty_write_buf)
         // are stale. We must reinitialize them here where self is stable.
         self.tty.tty_writer = self.tty.fd.writerStreaming(root.g_io, &self.tty_write_buf);
+        vaxis.tty.global_tty = self.tty;
         self.surface.vx = &self.vx;
         self.surface.tty_writer = self.tty.writer();
         self.rend.surface = &self.surface;
@@ -613,15 +614,17 @@ pub const TuiRuntime = struct {
 
             // tty readable (terminal input)
             if (pollfds[1].revents & std.posix.POLL.IN != 0) {
-                const n = try self.tty.read(tty_read_buf[tty_read_start..]);
+                const read_start = tty_read_start;
+                const n = try self.tty.read(tty_read_buf[read_start..]);
                 if (n == 0) break :main_loop;
 
+                const total_read = read_start + n;
                 var seq_start: usize = 0;
-                tty_parse_loop: while (seq_start < n) {
-                    const result = try tty_parser.parse(tty_read_buf[seq_start..n], null);
+                tty_parse_loop: while (seq_start < total_read) {
+                    const result = try tty_parser.parse(tty_read_buf[seq_start..total_read], null);
                     if (result.n == 0) {
-                        const remaining_bytes = n - seq_start;
-                        std.mem.copyForwards(u8, tty_read_buf[0..remaining_bytes], tty_read_buf[seq_start..n]);
+                        const remaining_bytes = total_read - seq_start;
+                        std.mem.copyForwards(u8, tty_read_buf[0..remaining_bytes], tty_read_buf[seq_start..total_read]);
                         tty_read_start = remaining_bytes;
                         break :tty_parse_loop;
                     }

--- a/zig/src/apprt/tui.zig
+++ b/zig/src/apprt/tui.zig
@@ -314,11 +314,11 @@ fn cellToStyle(cell: Cell) vaxis.Cell.Style {
 var g_winch: std.atomic.Value(bool) = .init(false);
 var g_quit: std.atomic.Value(bool) = .init(false);
 
-fn sigwinchHandler(_: c_int) callconv(.c) void {
+fn sigwinchHandler(_: std.posix.SIG) callconv(.c) void {
     g_winch.store(true, .release);
 }
 
-fn sigquitHandler(_: c_int) callconv(.c) void {
+fn sigquitHandler(_: std.posix.SIG) callconv(.c) void {
     g_quit.store(true, .release);
 }
 
@@ -369,7 +369,7 @@ pub const TuiRuntime = struct {
             return err;
         };
 
-        self.vx = try vaxis.init(alloc, .{
+        self.vx = try vaxis.init(root.g_io, alloc, root.g_env_map, .{
             // Request only "disambiguate" from the Kitty keyboard protocol.
             // This lets the terminal report modifiers on keys like Enter
             // (so Shift+Enter differs from Enter) without the side effects
@@ -385,7 +385,7 @@ pub const TuiRuntime = struct {
         });
 
         // Allocate screen buffers at the real terminal size.
-        const initial_ws = try vaxis.Tty.getWinsize(self.tty.fd);
+        const initial_ws = try self.tty.getWinsize();
         try self.vx.resize(alloc, self.tty.writer(), initial_ws);
 
         // Save the current terminal title so we can restore it on exit.
@@ -428,8 +428,7 @@ pub const TuiRuntime = struct {
         // final location on the caller's stack. init() returns by value, so
         // any stored pointers to self's fields (especially tty_write_buf)
         // are stale. We must reinitialize them here where self is stable.
-        const tty_file = std.fs.File{ .handle = self.tty.fd };
-        self.tty.tty_writer = .initStreaming(tty_file, &self.tty_write_buf);
+        self.tty.tty_writer = self.tty.fd.writerStreaming(root.g_io, &self.tty_write_buf);
         self.surface.vx = &self.vx;
         self.surface.tty_writer = self.tty.writer();
         self.rend.surface = &self.surface;
@@ -454,14 +453,14 @@ pub const TuiRuntime = struct {
         // The ready event must be sent before entering non-blocking mode,
         // because the BEAM waits for it synchronously before proceeding.
         var stdout_buf: [4096]u8 = undefined;
-        var stdout_writer_obj = std.fs.File.stdout().writer(&stdout_buf);
+        var stdout_writer_obj = std.Io.File.stdout().writer(root.g_io, &stdout_buf);
         const blocking_stdout: *std.Io.Writer = &stdout_writer_obj.interface;
 
         // Enable log routing for startup messages (before event loop).
         root.g_port_writer = blocking_stdout;
 
         // Send ready event with initial dimensions and default capabilities.
-        const initial_ws = try vaxis.Tty.getWinsize(self.tty.fd);
+        const initial_ws = try self.tty.getWinsize();
         self.last_cols = initial_ws.cols;
         self.last_rows = initial_ws.rows;
         var ready_payload: [13]u8 = undefined;
@@ -514,7 +513,7 @@ pub const TuiRuntime = struct {
         // stdout (Zig→BEAM events, only polled when there's pending data).
         var pollfds = [3]std.posix.pollfd{
             .{ .fd = stdin_fd, .events = std.posix.POLL.IN, .revents = 0 },
-            .{ .fd = self.tty.fd, .events = std.posix.POLL.IN, .revents = 0 },
+            .{ .fd = self.tty.fd.handle, .events = std.posix.POLL.IN, .revents = 0 },
             .{ .fd = stdout_fd, .events = 0, .revents = 0 },
         };
 
@@ -614,7 +613,7 @@ pub const TuiRuntime = struct {
 
             // tty readable (terminal input)
             if (pollfds[1].revents & std.posix.POLL.IN != 0) {
-                const n = try std.posix.read(self.tty.fd, tty_read_buf[tty_read_start..]);
+                const n = try self.tty.read(tty_read_buf[tty_read_start..]);
                 if (n == 0) break :main_loop;
 
                 var seq_start: usize = 0;
@@ -653,14 +652,14 @@ pub const TuiRuntime = struct {
     }
 
     fn pollResize(self: *TuiRuntime, pw: *port_writer) !void {
-        const ws = vaxis.Tty.getWinsize(self.tty.fd) catch return;
+        const ws = self.tty.getWinsize() catch return;
         if (ws.cols != self.last_cols or ws.rows != self.last_rows) {
             try self.applyResize(pw, ws);
         }
     }
 
     fn handleResize(self: *TuiRuntime, pw: *port_writer) !void {
-        const ws = try vaxis.Tty.getWinsize(self.tty.fd);
+        const ws = try self.tty.getWinsize();
         try self.applyResize(pw, ws);
     }
 
@@ -689,21 +688,27 @@ pub const TuiRuntime = struct {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Initializes a PosixTty, preferring the MINGA_TTY env var over /dev/tty.
+///
+/// The standard vaxis.Tty.init() always opens /dev/tty. We need custom
+/// initialization to support the MINGA_TTY env var, which lets the BEAM
+/// VM tell the renderer which TTY to use.
 fn initTty(buffer: []u8) !vaxis.Tty {
     const posix = std.posix;
+    const io = root.g_io;
 
-    const tty_path: [*:0]const u8 = std.posix.getenvZ("MINGA_TTY") orelse "/dev/tty";
+    const tty_path: [*:0]const u8 = std.c.getenv("MINGA_TTY") orelse "/dev/tty";
     std.log.info("Opening tty: {s}", .{tty_path});
 
-    const fd = try posix.openZ(tty_path, .{ .ACCMODE = .RDWR }, 0);
+    const fd = try posix.openatZ(posix.AT.FDCWD, tty_path, .{ .ACCMODE = .RDWR }, 0);
     const termios = try vaxis.Tty.makeRaw(fd);
 
-    const file = std.fs.File{ .handle = fd };
+    const file = std.Io.File{ .handle = fd, .flags = .{ .nonblocking = false } };
 
     const tty: vaxis.Tty = .{
-        .fd = fd,
+        .io = io,
+        .fd = file,
         .termios = termios,
-        .tty_writer = .initStreaming(file, buffer),
+        .tty_writer = file.writerStreaming(io, buffer),
     };
 
     vaxis.tty.global_tty = tty;
@@ -837,7 +842,7 @@ fn handleTtyEvent(self: *TuiRuntime, event: vaxis.Event, pw: *port_writer, recov
         .cap_color_scheme_updates => vx.caps.color_scheme_updates = true,
         .cap_multi_cursor => vx.caps.multi_cursor = true,
         .cap_da1 => {
-            std.Thread.Futex.wake(&vx.query_futex, 10);
+            std.Io.futexWake(vx.io, std.atomic.Value(u32), &vx.query_futex, 10);
             vx.queries_done.store(true, .unordered);
 
             try vx.enableDetectedFeatures(self.tty.writer());
@@ -981,16 +986,16 @@ test "cellToStyle max color values" {
 
 test "readExact on empty buf succeeds immediately" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
-    const fd = try std.posix.open("/dev/null", .{ .ACCMODE = .RDONLY }, 0);
-    defer std.posix.close(fd);
+    const fd = try std.posix.openatZ(std.posix.AT.FDCWD, "/dev/null", .{ .ACCMODE = .RDONLY }, 0);
+    defer _ = std.c.close(fd);
     const result = try readExact(fd, &[_]u8{});
     try std.testing.expect(result == true);
 }
 
 test "readExact returns false on EOF reading from /dev/null" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
-    const fd = try std.posix.open("/dev/null", .{ .ACCMODE = .RDONLY }, 0);
-    defer std.posix.close(fd);
+    const fd = try std.posix.openatZ(std.posix.AT.FDCWD, "/dev/null", .{ .ACCMODE = .RDONLY }, 0);
+    defer _ = std.c.close(fd);
     var buf: [4]u8 = undefined;
     const result = try readExact(fd, &buf);
     try std.testing.expect(result == false);
@@ -998,11 +1003,12 @@ test "readExact returns false on EOF reading from /dev/null" {
 
 test "readExact pipe: reads exact bytes written" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
-    const fds = try std.posix.pipe();
-    defer std.posix.close(fds[0]);
-    defer std.posix.close(fds[1]);
+    var fds: [2]std.posix.fd_t = undefined;
+    if (std.c.pipe(&fds) != 0) return error.PipeCreateFailed;
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
     const payload: []const u8 = "ABCD";
-    _ = try std.posix.write(fds[1], payload);
+    _ = std.c.write(fds[1], payload.ptr, payload.len);
     var buf: [4]u8 = undefined;
     const result = try readExact(fds[0], &buf);
     try std.testing.expect(result == true);
@@ -1011,11 +1017,12 @@ test "readExact pipe: reads exact bytes written" {
 
 test "readExact assembles bytes from partial writes" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
-    const fds = try std.posix.pipe();
-    defer std.posix.close(fds[0]);
-    defer std.posix.close(fds[1]);
-    _ = try std.posix.write(fds[1], "AB");
-    _ = try std.posix.write(fds[1], "CD");
+    var fds: [2]std.posix.fd_t = undefined;
+    if (std.c.pipe(&fds) != 0) return error.PipeCreateFailed;
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+    _ = std.c.write(fds[1], "AB", 2);
+    _ = std.c.write(fds[1], "CD", 2);
     var buf: [4]u8 = undefined;
     const result = try readExact(fds[0], &buf);
     try std.testing.expect(result == true);

--- a/zig/src/font/main.zig
+++ b/zig/src/font/main.zig
@@ -34,7 +34,7 @@ pub const Face = struct {
     atlas: Atlas,
     cache: std.AutoHashMapUnmanaged(u32, Glyph),
     alloc: Allocator,
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.atomic.Mutex = .unlocked,
 
     /// Cell dimensions in pixels — use these for grid layout.
     cell_width: u32,
@@ -70,7 +70,7 @@ pub const Face = struct {
 
     /// Look up a glyph by codepoint. Rasterizes on first access.
     pub fn getGlyph(self: *Face, codepoint: u32) !Glyph {
-        self.mutex.lock();
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
         defer self.mutex.unlock();
 
         if (self.cache.get(codepoint)) |g| return g;

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -74,7 +74,7 @@ pub const Highlighter = struct {
     textobject_query_cache: std.StringHashMapUnmanaged(*c.TSQuery),
     /// Currently active predicate table (set during setLanguage)
     current_predicates: ?*const predicates_mod.PredicateTable = null,
-    cache_mutex: std.Thread.Mutex = .{},
+    cache_mutex: std.atomic.Mutex = .unlocked,
     allocator: std.mem.Allocator,
 
     /// After `highlightWithInjections`, holds the injection language regions.
@@ -153,7 +153,7 @@ pub const Highlighter = struct {
     ) void {
         // Check if already compiled (e.g. by a setLanguage call on the main thread)
         {
-            self.cache_mutex.lock();
+            while (!self.cache_mutex.tryLock()) std.atomic.spinLoopHint();
             defer self.cache_mutex.unlock();
             if (cache.get(name) != null) return;
         }
@@ -173,7 +173,7 @@ pub const Highlighter = struct {
 
         // Insert into cache under lock
         {
-            self.cache_mutex.lock();
+            while (!self.cache_mutex.tryLock()) std.atomic.spinLoopHint();
             defer self.cache_mutex.unlock();
             // Double-check: main thread may have compiled it while we worked
             if (cache.get(name) != null) {
@@ -188,7 +188,7 @@ pub const Highlighter = struct {
 
     /// Build predicate table for a language's highlight query (background thread).
     fn prewarmPredicates(self: *Highlighter, name: []const u8) void {
-        self.cache_mutex.lock();
+        while (!self.cache_mutex.tryLock()) std.atomic.spinLoopHint();
         defer self.cache_mutex.unlock();
         if (self.predicate_cache.get(name) != null) return;
         const query = self.query_cache.get(name) orelse return;
@@ -267,7 +267,7 @@ pub const Highlighter = struct {
         // Restore cached queries (may have been pre-compiled on background thread),
         // or lazily compile from embedded source.
         {
-            self.cache_mutex.lock();
+            while (!self.cache_mutex.tryLock()) std.atomic.spinLoopHint();
             defer self.cache_mutex.unlock();
 
             // Highlight query
@@ -385,7 +385,7 @@ pub const Highlighter = struct {
         const lang = self.current_language orelse return error.NoLanguageSet;
         const name = self.current_language_name orelse return error.NoLanguageSet;
 
-        self.cache_mutex.lock();
+        while (!self.cache_mutex.tryLock()) std.atomic.spinLoopHint();
         defer self.cache_mutex.unlock();
 
         // If we already have a cached query for this language, skip recompilation
@@ -420,7 +420,7 @@ pub const Highlighter = struct {
         const lang = self.current_language orelse return error.NoLanguageSet;
         const name = self.current_language_name orelse return error.NoLanguageSet;
 
-        self.cache_mutex.lock();
+        while (!self.cache_mutex.tryLock()) std.atomic.spinLoopHint();
         defer self.cache_mutex.unlock();
 
         // If we already have a cached injection query, skip recompilation
@@ -455,7 +455,7 @@ pub const Highlighter = struct {
         const lang = self.current_language orelse return error.NoLanguageSet;
         const name = self.current_language_name orelse return error.NoLanguageSet;
 
-        self.cache_mutex.lock();
+        while (!self.cache_mutex.tryLock()) std.atomic.spinLoopHint();
         defer self.cache_mutex.unlock();
 
         if (self.fold_query_cache.get(name)) |cached| {
@@ -531,7 +531,7 @@ pub const Highlighter = struct {
         const lang = self.current_language orelse return error.NoLanguageSet;
         const name = self.current_language_name orelse return error.NoLanguageSet;
 
-        self.cache_mutex.lock();
+        while (!self.cache_mutex.tryLock()) std.atomic.spinLoopHint();
         defer self.cache_mutex.unlock();
 
         if (self.indent_query_cache.get(name)) |cached| {
@@ -643,7 +643,7 @@ pub const Highlighter = struct {
         const lang = self.current_language orelse return error.NoLanguageSet;
         const name = self.current_language_name orelse return error.NoLanguageSet;
 
-        self.cache_mutex.lock();
+        while (!self.cache_mutex.tryLock()) std.atomic.spinLoopHint();
         defer self.cache_mutex.unlock();
 
         if (self.textobject_query_cache.get(name)) |cached| {
@@ -803,7 +803,7 @@ pub const Highlighter = struct {
         defer c.ts_query_cursor_delete(cursor);
         c.ts_query_cursor_exec(cursor, tq, root);
 
-        var entries = std.ArrayListUnmanaged(TextobjectEntry){};
+        var entries: std.ArrayListUnmanaged(TextobjectEntry) = .empty;
 
         var match: c.TSQueryMatch = undefined;
         while (c.ts_query_cursor_next_match(cursor, &match)) {
@@ -1186,7 +1186,7 @@ pub const Highlighter = struct {
 
             // Look up the highlight query for this injection language
             const inj_hl_query = blk: {
-                self.cache_mutex.lock();
+                while (!self.cache_mutex.tryLock()) std.atomic.spinLoopHint();
                 defer self.cache_mutex.unlock();
                 if (self.query_cache.get(lang_name)) |cached| break :blk cached;
 
@@ -1275,7 +1275,7 @@ pub const Highlighter = struct {
 
             // Lookup predicate table for this injection language
             const inj_preds: ?*const predicates_mod.PredicateTable = blk: {
-                self.cache_mutex.lock();
+                while (!self.cache_mutex.tryLock()) std.atomic.spinLoopHint();
                 defer self.cache_mutex.unlock();
                 break :blk self.predicate_cache.getPtr(lang_name);
             };

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -84,7 +84,6 @@ pub const Highlighter = struct {
 
     /// Tracks background pre-compilation state.
     prewarm_thread: ?std.Thread = null,
-    prewarm_done: std.atomic.Value(bool) = .init(false),
 
     /// Initialize with compiled-in grammars registered.
     /// Spawns a background thread to pre-compile all embedded queries.
@@ -142,7 +141,6 @@ pub const Highlighter = struct {
                 self.prewarmOne(entry.name, textobj_source, &self.textobject_query_cache);
             }
         }
-        self.prewarm_done.store(true, .release);
     }
 
     fn prewarmOne(
@@ -567,7 +565,7 @@ pub const Highlighter = struct {
     /// 1. Find the deepest node at the start of the given line
     /// 2. Walk up ancestors, checking which ones match @indent or @outdent captures
     /// 3. Net indent = count of @indent ancestors - count of @outdent on this line
-    pub fn computeIndent(self: *Highlighter, line: u32, source: []const u8) i32 {
+    pub fn computeIndent(self: *Highlighter, line: u32) i32 {
         const iq = self.indent_query orelse return 0;
         const tree = self.tree orelse return 0;
         const root = c.ts_tree_root_node(tree);
@@ -587,9 +585,6 @@ pub const Highlighter = struct {
         }
 
         if (indent_id == null and outdent_id == null) return 0;
-
-        // Find byte offset of the start of the target line
-        const line_start = lineStartByte(source, line);
 
         // Run the query, scoped to the area around this line
         const cursor = c.ts_query_cursor_new() orelse return 0;
@@ -634,7 +629,6 @@ pub const Highlighter = struct {
             }
         }
 
-        _ = line_start;
         return indent_count;
     }
 
@@ -830,16 +824,6 @@ pub const Highlighter = struct {
         }.lessThan);
 
         return entries.toOwnedSlice(allocator) catch &.{};
-    }
-
-    /// Find the byte offset where a given line starts in the source.
-    fn lineStartByte(source: []const u8, target_line: u32) usize {
-        var line: u32 = 0;
-        for (source, 0..) |ch, i| {
-            if (line == target_line) return i;
-            if (ch == '\n') line += 1;
-        }
-        return source.len;
     }
 
     /// Parse source text. Full re-parse (no incremental).

--- a/zig/src/hook_runner_main.zig
+++ b/zig/src/hook_runner_main.zig
@@ -190,6 +190,8 @@ fn runHook(alloc: std.mem.Allocator, command: []const u8, payload: []const u8, t
     defer stderr_capture.deinit(alloc);
 
     const start_ms = milliTimestamp();
+    const max_timeout_ms: u64 = @intCast(std.math.maxInt(i64) - start_ms);
+    if (timeout_ms > max_timeout_ms) return error.InvalidTimeout;
     const timeout_i64: i64 = @intCast(timeout_ms);
     const deadline_ms = start_ms + timeout_i64;
     var payload_offset: usize = 0;

--- a/zig/src/hook_runner_main.zig
+++ b/zig/src/hook_runner_main.zig
@@ -5,6 +5,71 @@ const std = @import("std");
 const posix = std.posix;
 const c = std.c;
 
+// ---------------------------------------------------------------------------
+// Thin wrappers for POSIX functions that moved from std.posix to std.c in
+// Zig 0.16. Each wrapper preserves the error-handling style used by the
+// call-sites (error union, void, or noreturn).
+// ---------------------------------------------------------------------------
+
+const PosixError = error{Unexpected};
+
+fn pipeFds() PosixError![2]posix.fd_t {
+    var fds: [2]posix.fd_t = undefined;
+    if (c.pipe(&fds) != 0) return error.Unexpected;
+    return fds;
+}
+
+fn forkPid() PosixError!posix.pid_t {
+    const pid = c.fork();
+    if (pid < 0) return error.Unexpected;
+    return @intCast(pid);
+}
+
+fn closeFd(fd: posix.fd_t) void {
+    _ = c.close(fd);
+}
+
+fn dup2Fd(old: posix.fd_t, new: posix.fd_t) PosixError!void {
+    if (c.dup2(old, new) < 0) return error.Unexpected;
+}
+
+fn setsidSafe() void {
+    _ = c.setsid();
+}
+
+const WriteFdError = error{ WouldBlock, BrokenPipe, Unexpected };
+
+fn writeFd(fd: posix.fd_t, buf: []const u8) WriteFdError!usize {
+    const result = c.write(fd, buf.ptr, buf.len);
+    if (result >= 0) return @intCast(result);
+    return switch (posix.errno(result)) {
+        .AGAIN => error.WouldBlock,
+        .PIPE => error.BrokenPipe,
+        else => error.Unexpected,
+    };
+}
+
+fn setNonBlockingFd(fd: posix.fd_t) void {
+    const flags = c.fcntl(fd, posix.F.GETFL);
+    if (flags < 0) return;
+    const nonblock: u32 = @bitCast(posix.O{ .NONBLOCK = true });
+    _ = c.fcntl(fd, posix.F.SETFL, flags | @as(c_int, @intCast(nonblock)));
+}
+
+const WaitResult = struct { pid: posix.pid_t, status: u32 };
+
+fn waitpidNonBlocking(pid: posix.pid_t) WaitResult {
+    var raw_status: c_int = 0;
+    const ret = c.waitpid(pid, &raw_status, c.W.NOHANG);
+    return .{ .pid = ret, .status = @bitCast(raw_status) };
+}
+
+fn milliTimestamp() i64 {
+    var ts: c.timespec = undefined;
+    _ = c.clock_gettime(c.CLOCK.REALTIME, &ts);
+    return @as(i64, ts.sec) * 1000 + @divTrunc(@as(i64, ts.nsec), 1_000_000);
+}
+
 const stderr_limit: usize = 64 * 1024;
 const truncation_marker = "\n[stderr truncated after 65536 bytes]\n";
 const kill_grace_ms: i64 = 50;
@@ -49,14 +114,14 @@ const StderrCapture = struct {
     }
 };
 
-/// Parses runner arguments, executes the hook, and writes the structured JSON result.
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const alloc = gpa.allocator();
+/// Module-level Io instance set during main(), used by writeResult/writeHelperError.
+var g_io: std.Io = undefined;
 
-    const args = try std.process.argsAlloc(alloc);
-    defer std.process.argsFree(alloc, args);
+/// Parses runner arguments, executes the hook, and writes the structured JSON result.
+pub fn main(init: std.process.Init) !void {
+    g_io = init.io;
+    const alloc = init.gpa;
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     if (args.len != 4) {
         try writeHelperError("usage: minga-hook-runner <timeout_ms> <payload_len> <command>");
@@ -93,38 +158,38 @@ pub fn main() !void {
 }
 
 fn runHook(alloc: std.mem.Allocator, command: []const u8, payload: []const u8, timeout_ms: u64) !RunResult {
-    var stdin_pipe = try posix.pipe();
+    var stdin_pipe = try pipeFds();
     errdefer closePipe(&stdin_pipe);
 
-    var stderr_pipe = try posix.pipe();
+    var stderr_pipe = try pipeFds();
     errdefer closePipe(&stderr_pipe);
 
-    const devnull = try posix.open("/dev/null", .{ .ACCMODE = .WRONLY }, 0);
-    defer posix.close(devnull);
+    const devnull = try posix.openatZ(posix.AT.FDCWD, "/dev/null", .{ .ACCMODE = .WRONLY }, 0);
+    defer closeFd(devnull);
 
     const command_z = try alloc.dupeZ(u8, command);
     defer alloc.free(command_z);
 
-    const pid = try posix.fork();
+    const pid = try forkPid();
 
     if (pid == 0) {
         childExec(stdin_pipe, stderr_pipe, devnull, command_z);
     }
 
-    posix.close(stdin_pipe[0]);
+    closeFd(stdin_pipe[0]);
     stdin_pipe[0] = -1;
-    posix.close(stderr_pipe[1]);
+    closeFd(stderr_pipe[1]);
     stderr_pipe[1] = -1;
     defer closeIfOpen(stdin_pipe[1]);
     defer closeIfOpen(stderr_pipe[0]);
 
-    setNonBlocking(stdin_pipe[1]);
-    setNonBlocking(stderr_pipe[0]);
+    setNonBlockingFd(stdin_pipe[1]);
+    setNonBlockingFd(stderr_pipe[0]);
 
     var stderr_capture = StderrCapture.init();
     defer stderr_capture.deinit(alloc);
 
-    const start_ms = std.time.milliTimestamp();
+    const start_ms = milliTimestamp();
     const timeout_i64: i64 = @intCast(timeout_ms);
     const deadline_ms = start_ms + timeout_i64;
     var payload_offset: usize = 0;
@@ -135,7 +200,7 @@ fn runHook(alloc: std.mem.Allocator, command: []const u8, payload: []const u8, t
     var status: u32 = 0;
 
     while (!child_done) {
-        const now = std.time.milliTimestamp();
+        const now = milliTimestamp();
         if (now >= deadline_ms and !timed_out) {
             timed_out = true;
             killProcessGroup(pid, posix.SIG.TERM);
@@ -145,7 +210,7 @@ fn runHook(alloc: std.mem.Allocator, command: []const u8, payload: []const u8, t
             killProcessGroup(pid, posix.SIG.KILL);
         }
 
-        const wait = posix.waitpid(pid, posix.W.NOHANG);
+        const wait = waitpidNonBlocking(pid);
         if (wait.pid == pid) {
             child_done = true;
             status = wait.status;
@@ -162,10 +227,10 @@ fn runHook(alloc: std.mem.Allocator, command: []const u8, payload: []const u8, t
         _ = posix.poll(&pollfds, poll_timeout) catch 0;
 
         if (stdin_open and pollfds[0].revents & posix.POLL.OUT != 0) {
-            const n = posix.write(stdin_pipe[1], payload[payload_offset..]) catch |err| switch (err) {
+            const n = writeFd(stdin_pipe[1], payload[payload_offset..]) catch |err| switch (err) {
                 error.WouldBlock => 0,
                 error.BrokenPipe => blk: {
-                    posix.close(stdin_pipe[1]);
+                    closeFd(stdin_pipe[1]);
                     stdin_pipe[1] = -1;
                     stdin_open = false;
                     break :blk 0;
@@ -175,14 +240,14 @@ fn runHook(alloc: std.mem.Allocator, command: []const u8, payload: []const u8, t
 
             payload_offset += n;
             if (payload_offset >= payload.len) {
-                posix.close(stdin_pipe[1]);
+                closeFd(stdin_pipe[1]);
                 stdin_pipe[1] = -1;
                 stdin_open = false;
             }
         }
 
         if (stdin_open and payload.len == 0) {
-            posix.close(stdin_pipe[1]);
+            closeFd(stdin_pipe[1]);
             stdin_pipe[1] = -1;
             stdin_open = false;
         }
@@ -195,7 +260,7 @@ fn runHook(alloc: std.mem.Allocator, command: []const u8, payload: []const u8, t
             };
 
             if (n == 0) {
-                posix.close(stderr_pipe[0]);
+                closeFd(stderr_pipe[0]);
                 stderr_pipe[0] = -1;
                 stderr_open = false;
             } else {
@@ -233,25 +298,27 @@ fn runHook(alloc: std.mem.Allocator, command: []const u8, payload: []const u8, t
 }
 
 fn childExec(stdin_pipe: [2]posix.fd_t, stderr_pipe: [2]posix.fd_t, devnull: posix.fd_t, command_z: [:0]const u8) noreturn {
-    _ = posix.setsid() catch {};
+    setsidSafe();
 
-    posix.close(stdin_pipe[1]);
-    posix.close(stderr_pipe[0]);
+    closeFd(stdin_pipe[1]);
+    closeFd(stderr_pipe[0]);
 
-    posix.dup2(stdin_pipe[0], posix.STDIN_FILENO) catch std.process.exit(127);
-    posix.dup2(devnull, posix.STDOUT_FILENO) catch std.process.exit(127);
-    posix.dup2(stderr_pipe[1], posix.STDERR_FILENO) catch std.process.exit(127);
+    dup2Fd(stdin_pipe[0], posix.STDIN_FILENO) catch std.process.exit(127);
+    dup2Fd(devnull, posix.STDOUT_FILENO) catch std.process.exit(127);
+    dup2Fd(stderr_pipe[1], posix.STDERR_FILENO) catch std.process.exit(127);
 
-    posix.close(stdin_pipe[0]);
-    posix.close(stderr_pipe[1]);
-    posix.close(devnull);
+    closeFd(stdin_pipe[0]);
+    closeFd(stderr_pipe[1]);
+    closeFd(devnull);
 
     const argv = [_:null]?[*:0]const u8{ "/bin/sh", "-c", command_z.ptr };
     const envp: [*:null]const ?[*:0]const u8 = @ptrCast(c.environ);
-    posix.execveZ("/bin/sh", &argv, envp) catch std.process.exit(127);
+    _ = c.execve("/bin/sh", &argv, envp);
+    // execve only returns on error
+    std.process.exit(127);
 }
 
-fn killProcessGroup(pid: posix.pid_t, signal: u6) void {
+fn killProcessGroup(pid: posix.pid_t, signal: posix.SIG) void {
     const group_pid: posix.pid_t = -pid;
     posix.kill(group_pid, signal) catch {};
 }
@@ -262,13 +329,7 @@ fn closePipe(pipe: *[2]posix.fd_t) void {
 }
 
 fn closeIfOpen(fd: posix.fd_t) void {
-    if (fd >= 0) posix.close(fd);
-}
-
-fn setNonBlocking(fd: posix.fd_t) void {
-    const flags = posix.fcntl(fd, posix.F.GETFL, 0) catch return;
-    const nonblock: u32 = @bitCast(posix.O{ .NONBLOCK = true });
-    _ = posix.fcntl(fd, posix.F.SETFL, flags | @as(usize, nonblock)) catch return;
+    if (fd >= 0) closeFd(fd);
 }
 
 fn readExact(fd: posix.fd_t, buf: []u8) !bool {
@@ -283,7 +344,7 @@ fn readExact(fd: posix.fd_t, buf: []u8) !bool {
 
 fn writeResult(result: RunResult) !void {
     var stdout_buf: [4096]u8 = undefined;
-    var stdout_writer_obj = std.fs.File.stdout().writer(&stdout_buf);
+    var stdout_writer_obj = std.Io.File.stdout().writer(g_io, &stdout_buf);
     const stdout = &stdout_writer_obj.interface;
 
     switch (result.status) {
@@ -312,7 +373,7 @@ fn writeResult(result: RunResult) !void {
 
 fn writeHelperError(message: []const u8) !void {
     var stdout_buf: [1024]u8 = undefined;
-    var stdout_writer_obj = std.fs.File.stdout().writer(&stdout_buf);
+    var stdout_writer_obj = std.Io.File.stdout().writer(g_io, &stdout_buf);
     const stdout = &stdout_writer_obj.interface;
     try stdout.writeAll("{\"status\":\"error\",\"message\":");
     try writeJsonString(stdout, message);

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -85,10 +85,16 @@ const Runtime = switch (build_options.backend) {
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const alloc = gpa.allocator();
+/// Module-level Io instance, set during main() for file I/O operations.
+pub var g_io: std.Io = undefined;
+
+/// Module-level environment map, required by vaxis 0.6.0 for feature detection.
+pub var g_env_map: *std.process.Environ.Map = undefined;
+
+pub fn main(init: std.process.Init) !void {
+    g_io = init.io;
+    g_env_map = init.environ_map;
+    const alloc = init.gpa;
 
     var runtime = try Runtime.init(alloc);
     defer runtime.deinit();

--- a/zig/src/parser_main.zig
+++ b/zig/src/parser_main.zig
@@ -70,10 +70,8 @@ fn panicImpl(msg: []const u8, ret_addr: ?usize) noreturn {
 
 pub const panic = std.debug.FullPanic(panicImpl);
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const alloc = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const alloc = init.gpa;
 
     var hl = try highlighter_mod.Highlighter.init(alloc);
     defer hl.deinit();
@@ -81,7 +79,7 @@ pub fn main() !void {
 
     // Stdout (Port protocol channel).
     var stdout_buf: [4096]u8 = undefined;
-    var stdout_writer_obj = std.fs.File.stdout().writer(&stdout_buf);
+    var stdout_writer_obj = std.Io.File.stdout().writer(init.io, &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_writer_obj.interface;
 
     // Enable protocol-routed logging (and panic messages) now that stdout is ready.

--- a/zig/src/parser_main.zig
+++ b/zig/src/parser_main.zig
@@ -178,9 +178,8 @@ const BufferState = struct {
 
     /// Set the language name, taking an owned copy.
     fn setLanguageName(self: *BufferState, alloc: std.mem.Allocator, name: []const u8) !void {
+        const copy = try alloc.dupe(u8, name);
         if (self.language_name) |old| alloc.free(old);
-        const copy = try alloc.alloc(u8, name.len);
-        @memcpy(copy, name);
         self.language_name = copy;
     }
 
@@ -555,6 +554,19 @@ fn readExact(fd: std.posix.fd_t, buf: []u8) !bool {
 // ── BufferState.applyEdits tests ──────────────────────────────────────────────
 
 const testing = std.testing;
+
+test "setLanguageName keeps old name if replacing allocation fails" {
+    var backing: [3]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+    const alloc = fba.allocator();
+
+    var bs: BufferState = .{};
+    defer bs.deinit(alloc);
+
+    try bs.setLanguageName(alloc, "zig");
+    try testing.expectError(error.OutOfMemory, bs.setLanguageName(alloc, "elixir"));
+    try testing.expectEqualStrings("zig", bs.language_name.?);
+}
 
 test "applyEdits: valid edit replaces text" {
     var bs: BufferState = .{};

--- a/zig/src/parser_main.zig
+++ b/zig/src/parser_main.zig
@@ -281,7 +281,7 @@ fn handleCommand(
         },
         .set_highlight_query => |shq| {
             if (buffers.getPtr(shq.buffer_id)) |bs| {
-                _ = activateBuffer(hl, bs);
+                if (!activateBuffer(hl, bs)) return;
                 hl.setHighlightQuery(shq.source) catch {};
                 saveTreeToBuffer(hl, bs);
             } else {
@@ -290,7 +290,7 @@ fn handleCommand(
         },
         .set_injection_query => |siq| {
             if (buffers.getPtr(siq.buffer_id)) |bs| {
-                _ = activateBuffer(hl, bs);
+                if (!activateBuffer(hl, bs)) return;
                 hl.setInjectionQuery(siq.source) catch {};
                 saveTreeToBuffer(hl, bs);
             } else {
@@ -299,7 +299,7 @@ fn handleCommand(
         },
         .set_fold_query => |sfq| {
             if (buffers.getPtr(sfq.buffer_id)) |bs| {
-                _ = activateBuffer(hl, bs);
+                if (!activateBuffer(hl, bs)) return;
                 hl.setFoldQuery(sfq.source) catch {};
                 saveTreeToBuffer(hl, bs);
             } else {
@@ -308,7 +308,7 @@ fn handleCommand(
         },
         .set_indent_query => |siq_cmd| {
             if (buffers.getPtr(siq_cmd.buffer_id)) |bs| {
-                _ = activateBuffer(hl, bs);
+                if (!activateBuffer(hl, bs)) return;
                 hl.setIndentQuery(siq_cmd.source) catch {};
                 saveTreeToBuffer(hl, bs);
             } else {
@@ -327,7 +327,7 @@ fn handleCommand(
         },
         .set_textobject_query => |stq| {
             if (buffers.getPtr(stq.buffer_id)) |bs| {
-                _ = activateBuffer(hl, bs);
+                if (!activateBuffer(hl, bs)) return;
                 hl.setTextobjectQuery(stq.source) catch {};
                 saveTreeToBuffer(hl, bs);
             } else {
@@ -365,18 +365,15 @@ fn handleCommand(
         },
         .query_language_at => |q| {
             if (buffers.getPtr(q.buffer_id)) |bs| {
-                _ = activateBuffer(hl, bs);
+                if (!activateBuffer(hl, bs)) {
+                    try sendLanguageAtResponse(stdout, q.request_id, null);
+                    return;
+                }
                 const lang = hl.languageAt(q.byte_offset);
                 saveTreeToBuffer(hl, bs);
-                var rbuf: [260]u8 = undefined;
-                const rlen = protocol.encodeLanguageAtResponse(&rbuf, q.request_id, lang) catch return;
-                try protocol.writeMessage(stdout, rbuf[0..rlen]);
-                try stdout.flush();
+                try sendLanguageAtResponse(stdout, q.request_id, lang);
             } else {
-                var rbuf: [260]u8 = undefined;
-                const rlen = protocol.encodeLanguageAtResponse(&rbuf, q.request_id, null) catch return;
-                try protocol.writeMessage(stdout, rbuf[0..rlen]);
-                try stdout.flush();
+                try sendLanguageAtResponse(stdout, q.request_id, null);
             }
         },
         .close_buffer => {
@@ -465,6 +462,14 @@ fn handleCloseBuffer(
         // BufferState.deinit frees the tree (if any) and source.
         bs.deinit(alloc);
     }
+}
+
+/// Send a language-at-position response to stdout.
+fn sendLanguageAtResponse(stdout: *std.Io.Writer, request_id: u32, language: ?[]const u8) !void {
+    var rbuf: [260]u8 = undefined;
+    const rlen = protocol.encodeLanguageAtResponse(&rbuf, request_id, language) catch return;
+    try protocol.writeMessage(stdout, rbuf[0..rlen]);
+    try stdout.flush();
 }
 
 /// Send textobject positions to stdout.

--- a/zig/src/parser_main.zig
+++ b/zig/src/parser_main.zig
@@ -167,14 +167,12 @@ const BufferState = struct {
             const start: usize = @intCast(edit.start_byte);
             const old_end: usize = @intCast(edit.old_end_byte);
 
-            // Stale delta: old_end before start, or start past source length.
+            // Stale delta: the byte range must fit the source mirror exactly.
             // This means the BEAM's view of the buffer doesn't match ours.
-            if (old_end < edit.start_byte or start > self.source.items.len) return error.StaleEdit;
-            const clamped_old_end = @min(old_end, self.source.items.len);
-            if (clamped_old_end < start) return error.StaleEdit;
+            if (old_end < start or start > self.source.items.len or old_end > self.source.items.len) return error.StaleEdit;
 
             // Replace [start..old_end) with inserted_text.
-            try self.source.replaceRange(alloc, start, clamped_old_end - start, edit.inserted_text);
+            try self.source.replaceRange(alloc, start, old_end - start, edit.inserted_text);
         }
     }
 
@@ -217,7 +215,9 @@ fn activateBuffer(hl: *highlighter_mod.Highlighter, bs: *BufferState) bool {
     if (lang_changed) {
         // setLanguage deletes hl.tree, but we're about to replace it
         // with the buffer's tree anyway.
-        _ = hl.setLanguage(lang_name);
+        if (!hl.setLanguage(lang_name)) return false;
+    } else if (hl.current_language == null) {
+        return false;
     }
 
     // Install this buffer's tree into the highlighter (may be null for first parse).
@@ -249,7 +249,7 @@ fn handleCommand(
             const bs = try getOrCreateBuffer(buffers, alloc, sl.buffer_id);
             bs.setLanguageName(alloc, sl.name) catch return;
             // Set the highlighter's active language so queries get loaded.
-            _ = hl.setLanguage(sl.name);
+            if (bs.language_name) |name| _ = hl.setLanguage(name);
         },
         .parse_buffer => |pb| {
             const bs = try getOrCreateBuffer(buffers, alloc, pb.buffer_id);
@@ -318,7 +318,7 @@ fn handleCommand(
         .request_indent => |req| {
             const bs = buffers.getPtr(req.buffer_id) orelse return;
             if (!activateBuffer(hl, bs)) return;
-            const level = hl.computeIndent(req.line, bs.source.items);
+            const level = hl.computeIndent(req.line);
             saveTreeToBuffer(hl, bs);
             var rbuf: [13]u8 = undefined;
             const rlen = protocol.encodeIndentResult(&rbuf, req.request_id, req.line, level);
@@ -661,26 +661,26 @@ test "applyEdits: valid insert at beginning of source" {
     try testing.expectEqualStrings("hello world", bs.source.items);
 }
 
-test "applyEdits: clamped_old_end < start returns StaleEdit" {
-    // old_end is valid (within source) but less than start after clamping.
+test "applyEdits: returns StaleEdit when old_end_byte exceeds source length" {
     var bs: BufferState = .{};
     defer bs.deinit(testing.allocator);
     try bs.setSource(testing.allocator, "hello world");
 
     const edits = [_]protocol.EditDelta{.{
-        .start_byte = 8,
-        .old_end_byte = 5, // clamped to 5, which is < start(8)
-        .new_end_byte = 8,
+        .start_byte = 6,
+        .old_end_byte = 50,
+        .new_end_byte = 10,
         .start_row = 0,
-        .start_col = 8,
+        .start_col = 6,
         .old_end_row = 0,
-        .old_end_col = 5,
+        .old_end_col = 50,
         .new_end_row = 0,
-        .new_end_col = 8,
-        .inserted_text = "",
+        .new_end_col = 10,
+        .inserted_text = "mars",
     }};
 
     try testing.expectError(error.StaleEdit, bs.applyEdits(testing.allocator, &edits));
+    try testing.expectEqualStrings("hello world", bs.source.items);
 }
 
 // Pull in tests from imported modules for the parser test step.

--- a/zig/src/port_writer.zig
+++ b/zig/src/port_writer.zig
@@ -142,10 +142,13 @@ pub fn drain(self: *Self) !usize {
     if (!self.hasPending()) return 0;
 
     const data = self.buf[self.read_pos..self.len];
-    const n = std.posix.write(self.fd, data) catch |err| {
-        if (err == error.WouldBlock) return 0;
-        return err;
-    };
+    const rc = std.c.write(self.fd, data.ptr, data.len);
+    if (rc < 0) {
+        const e = std.posix.errno(rc);
+        if (e == .AGAIN) return 0;
+        return std.posix.unexpectedErrno(e);
+    }
+    const n: usize = @intCast(rc);
 
     self.read_pos += n;
 
@@ -164,8 +167,9 @@ pub fn drain(self: *Self) !usize {
 pub fn flushBlocking(self: *Self) !void {
     while (self.hasPending()) {
         const data = self.buf[self.read_pos..self.len];
-        const n = try std.posix.write(self.fd, data);
-        self.read_pos += n;
+        const rc = std.c.write(self.fd, data.ptr, data.len);
+        if (rc < 0) return std.posix.unexpectedErrno(std.posix.errno(rc));
+        self.read_pos += @intCast(rc);
     }
     self.read_pos = 0;
     self.len = 0;
@@ -186,9 +190,10 @@ fn compact(self: *Self) void {
 
 /// Set a file descriptor to non-blocking mode.
 pub fn setNonBlocking(fd: std.posix.fd_t) void {
-    const flags = std.posix.fcntl(fd, std.posix.F.GETFL, 0) catch return;
-    const nonblock: u32 = @bitCast(std.posix.O{ .NONBLOCK = true });
-    _ = std.posix.fcntl(fd, std.posix.F.SETFL, flags | @as(usize, nonblock)) catch return;
+    const flags = std.c.fcntl(fd, std.c.F.GETFL);
+    if (flags < 0) return;
+    const nonblock_bits: c_int = @bitCast(@as(c_uint, @bitCast(std.c.O{ .NONBLOCK = true })));
+    _ = std.c.fcntl(fd, std.c.F.SETFL, flags | nonblock_bits);
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -231,9 +236,10 @@ test "multiple enqueues accumulate" {
 
 test "drain writes to a pipe" {
     if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
-    const fds = try std.posix.pipe();
-    defer std.posix.close(fds[0]);
-    defer std.posix.close(fds[1]);
+    var fds: [2]std.posix.fd_t = undefined;
+    if (std.c.pipe(&fds) != 0) return error.PipeCreateFailed;
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
 
     setNonBlocking(fds[1]);
 

--- a/zig/src/port_writer.zig
+++ b/zig/src/port_writer.zig
@@ -33,9 +33,10 @@ dropped_count: u64,
 /// Initial buffer capacity.
 const INITIAL_CAPACITY: usize = 8192;
 
-/// Default max buffer size (64KB). If the BEAM is this far behind,
-/// dropping old key events is acceptable.
-const DEFAULT_MAX_SIZE: usize = 65536;
+/// Default max buffer size (128KB). If the BEAM is this far behind,
+/// dropping old key events is acceptable, while a max-size paste event
+/// still fits as one complete framed message.
+const DEFAULT_MAX_SIZE: usize = 128 * 1024;
 
 /// Initialize a new PortWriter for the given fd.
 pub fn init(alloc: std.mem.Allocator, fd: std.posix.fd_t) !Self {
@@ -67,6 +68,7 @@ pub fn deinit(self: *Self) void {
 /// so the BEAM never sees a corrupt frame.
 pub fn enqueue(self: *Self, payload: []const u8) !void {
     const frame_len = 4 + payload.len;
+    const effective_max = @max(self.max_size, frame_len);
 
     // Compact: move unread data to the front of the buffer.
     if (self.read_pos > 0) {
@@ -77,10 +79,10 @@ pub fn enqueue(self: *Self, payload: []const u8) !void {
     const pending = self.len;
     const needed = pending + frame_len;
 
-    if (needed > self.max_size) {
+    if (needed > effective_max) {
         // Drop whole messages from the front until enough space is free.
         var drop_pos: usize = 0;
-        while (drop_pos < pending and (pending - drop_pos + frame_len) > self.max_size) {
+        while (drop_pos < pending and (pending - drop_pos + frame_len) > effective_max) {
             if (drop_pos + 4 > pending) {
                 // Not enough bytes for a length prefix; drop everything.
                 drop_pos = pending;
@@ -107,10 +109,11 @@ pub fn enqueue(self: *Self, payload: []const u8) !void {
         }
     }
 
-    // Grow the buffer if needed (up to max_size).
+    // Grow the buffer if needed. A single oversized frame is allowed through
+    // intact so the BEAM never receives a corrupt partial message.
     const space_needed = self.len + frame_len;
     if (space_needed > self.buf.len) {
-        const new_cap = @min(self.max_size, @max(self.buf.len * 2, space_needed));
+        const new_cap = @min(effective_max, @max(self.buf.len * 2, space_needed));
         const new_buf = try self.alloc.realloc(self.buf, new_cap);
         self.buf = new_buf;
     }
@@ -159,20 +162,6 @@ pub fn drain(self: *Self) !usize {
     }
 
     return n;
-}
-
-/// Flush all pending data, blocking until complete.
-/// Used during startup (ready event) when we need guaranteed delivery
-/// before entering the non-blocking event loop.
-pub fn flushBlocking(self: *Self) !void {
-    while (self.hasPending()) {
-        const data = self.buf[self.read_pos..self.len];
-        const rc = std.c.write(self.fd, data.ptr, data.len);
-        if (rc < 0) return std.posix.unexpectedErrno(std.posix.errno(rc));
-        self.read_pos += @intCast(rc);
-    }
-    self.read_pos = 0;
-    self.len = 0;
 }
 
 /// Compact the buffer by moving unread data to the front.
@@ -270,4 +259,16 @@ test "compact moves data to front" {
     pw.compact();
     try std.testing.expectEqual(@as(usize, 0), pw.read_pos);
     try std.testing.expectEqual(@as(usize, 4), pw.len);
+}
+
+test "enqueue preserves a single frame larger than max_size" {
+    var pw = try init(std.testing.allocator, 1);
+    defer pw.deinit();
+    pw.max_size = 8;
+
+    try pw.enqueue("payload larger than max");
+
+    try std.testing.expect(pw.pendingBytes() > pw.max_size);
+    try std.testing.expectEqual(@as(u32, 23), std.mem.readInt(u32, pw.buf[0..4], .big));
+    try std.testing.expectEqualSlices(u8, "payload larger than max", pw.buf[4..pw.len]);
 }

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -926,7 +926,7 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
             var i: u8 = 0;
             while (i < count) : (i += 1) {
                 if (rest.len < offset + 2) return error.Malformed;
-                const name_len = std.mem.readInt(u16, rest[offset..][0..2], .big);
+                const name_len: usize = std.mem.readInt(u16, rest[offset..][0..2], .big);
                 offset += 2 + name_len;
                 if (rest.len < offset) return error.Malformed;
             }
@@ -951,7 +951,7 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
 ///   0x10 draw_text:       14 bytes + text_len
 pub fn commandSize(payload: []const u8) usize {
     if (payload.len == 0) return 0;
-    return switch (payload[0]) {
+    const decoded_size = switch (payload[0]) {
         OP_CLEAR => 1,
         OP_BATCH_END => 1,
         OP_SET_CURSOR => 5,
@@ -959,38 +959,38 @@ pub fn commandSize(payload: []const u8) usize {
         OP_DRAW_TEXT => blk: {
             // opcode(1) + row(2) + col(2) + fg(3) + bg(3) + attrs(1) + text_len(2) = 14 fixed bytes
             if (payload.len < 14) break :blk payload.len;
-            const text_len = std.mem.readInt(u16, payload[12..14], .big);
+            const text_len: usize = std.mem.readInt(u16, payload[12..14], .big);
             break :blk 14 + text_len;
         },
         OP_SET_LANGUAGE => blk: {
             // opcode(1) + buffer_id(4) + name_len(2) + name
             if (payload.len < 7) break :blk payload.len;
-            const name_len = std.mem.readInt(u16, payload[5..7], .big);
+            const name_len: usize = std.mem.readInt(u16, payload[5..7], .big);
             break :blk 7 + name_len;
         },
         OP_PARSE_BUFFER => blk: {
             // opcode(1) + buffer_id(4) + version(4) + source_len(4) + source
             if (payload.len < 13) break :blk payload.len;
-            const source_len = std.mem.readInt(u32, payload[9..13], .big);
+            const source_len: usize = std.mem.readInt(u32, payload[9..13], .big);
             break :blk 13 + source_len;
         },
         OP_SET_HIGHLIGHT_QUERY, OP_SET_INJECTION_QUERY, OP_SET_FOLD_QUERY, OP_SET_INDENT_QUERY, OP_SET_TEXTOBJECT_QUERY => blk: {
             // opcode(1) + buffer_id(4) + query_len(4) + query
             if (payload.len < 9) break :blk payload.len;
-            const query_len = std.mem.readInt(u32, payload[5..9], .big);
+            const query_len: usize = std.mem.readInt(u32, payload[5..9], .big);
             break :blk 9 + query_len;
         },
         OP_LOAD_GRAMMAR => blk: {
             if (payload.len < 3) break :blk payload.len;
-            const name_len = std.mem.readInt(u16, payload[1..3], .big);
+            const name_len: usize = std.mem.readInt(u16, payload[1..3], .big);
             const path_off: usize = 3 + name_len;
             if (payload.len < path_off + 2) break :blk payload.len;
-            const path_len = std.mem.readInt(u16, payload[path_off..][0..2], .big);
+            const path_len: usize = std.mem.readInt(u16, payload[path_off..][0..2], .big);
             break :blk path_off + 2 + path_len;
         },
         OP_SET_TITLE => blk: {
             if (payload.len < 3) break :blk payload.len;
-            const title_len = std.mem.readInt(u16, payload[1..3], .big);
+            const title_len: usize = std.mem.readInt(u16, payload[1..3], .big);
             break :blk 3 + title_len;
         },
         OP_QUERY_LANGUAGE_AT => 13, // opcode(1) + buffer_id(4) + request_id(4) + byte_offset(4)
@@ -998,7 +998,7 @@ pub fn commandSize(payload: []const u8) usize {
         OP_REQUEST_TEXTOBJECT => blk: {
             // opcode(1) + buffer_id(4) + request_id(4) + row(4) + col(4) + name_len(2) + name
             if (payload.len < 19) break :blk payload.len;
-            const nl = std.mem.readInt(u16, payload[17..19], .big);
+            const nl: usize = std.mem.readInt(u16, payload[17..19], .big);
             break :blk 19 + nl;
         },
         OP_CLOSE_BUFFER => 5, // opcode(1) + buffer_id(4)
@@ -1010,14 +1010,14 @@ pub fn commandSize(payload: []const u8) usize {
             for (0..edit_count) |_| {
                 // 9 × u32 fields + text_len:u32 = 40 bytes header per edit
                 if (off + 40 > payload.len) break :blk payload.len;
-                const text_len = std.mem.readInt(u32, payload[off + 36 ..][0..4], .big);
+                const text_len: usize = std.mem.readInt(u32, payload[off + 36 ..][0..4], .big);
                 off += 40 + text_len;
             }
             break :blk off;
         },
         OP_MEASURE_TEXT => blk: {
             if (payload.len < 7) break :blk payload.len;
-            const text_len = std.mem.readInt(u16, payload[5..7], .big);
+            const text_len: usize = std.mem.readInt(u16, payload[5..7], .big);
             break :blk 7 + text_len;
         },
         OP_SET_WINDOW_BG => 4, // opcode(1) + r(1) + g(1) + b(1)
@@ -1029,13 +1029,13 @@ pub fn commandSize(payload: []const u8) usize {
         OP_SET_FONT => blk: {
             // opcode(1) + size(2) + weight(1) + ligatures(1) + name_len(2) + name
             if (payload.len < 7) break :blk payload.len;
-            const name_len = std.mem.readInt(u16, payload[5..7], .big);
+            const name_len: usize = std.mem.readInt(u16, payload[5..7], .big);
             break :blk 7 + name_len;
         },
         OP_REGISTER_FONT => blk: {
             // opcode(1) + font_id(1) + name_len(2) + name
             if (payload.len < 4) break :blk payload.len;
-            const name_len = std.mem.readInt(u16, payload[2..4], .big);
+            const name_len: usize = std.mem.readInt(u16, payload[2..4], .big);
             break :blk 4 + name_len;
         },
         OP_SET_FONT_FALLBACK => blk: {
@@ -1046,7 +1046,7 @@ pub fn commandSize(payload: []const u8) usize {
             var i: u8 = 0;
             while (i < count) : (i += 1) {
                 if (payload.len < offset + 2) break :blk payload.len;
-                const name_len = std.mem.readInt(u16, payload[offset..][0..2], .big);
+                const name_len: usize = std.mem.readInt(u16, payload[offset..][0..2], .big);
                 offset += 2 + name_len;
             }
             break :blk offset;
@@ -1054,6 +1054,7 @@ pub fn commandSize(payload: []const u8) usize {
         // Unknown opcode: skip 1 byte so the loop always makes progress.
         else => 1,
     };
+    return @min(decoded_size, payload.len);
 }
 
 /// Fully decodes an edit_buffer command payload (after the opcode byte).
@@ -1804,6 +1805,11 @@ test "commandSize: set_cursor is 5 bytes" {
     try std.testing.expectEqual(@as(usize, 5), commandSize(&data));
 }
 
+test "commandSize: fixed-size commands clamp to available payload" {
+    const data = [_]u8{OP_CLOSE_BUFFER};
+    try std.testing.expectEqual(@as(usize, 1), commandSize(&data));
+}
+
 test "commandSize: set_cursor_shape is 2 bytes" {
     const data = [_]u8{ OP_SET_CURSOR_SHAPE, CURSOR_BLOCK };
     try std.testing.expectEqual(@as(usize, 2), commandSize(&data));
@@ -1846,6 +1852,11 @@ test "commandSize: truncated draw_text returns remaining length" {
     // Only 3 bytes — malformed, returns what's left
     const data = [_]u8{ OP_DRAW_TEXT, 0x00, 0x01 };
     try std.testing.expectEqual(@as(usize, 3), commandSize(&data));
+}
+
+test "commandSize: truncated variable-size commands clamp to available payload" {
+    const data = [_]u8{ OP_SET_FONT_FALLBACK, 0x01, 0xFF, 0xFF };
+    try std.testing.expectEqual(@as(usize, data.len), commandSize(&data));
 }
 
 test "commandSize: unknown opcode returns 1" {

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -907,16 +907,16 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
             if (rest.len < 6) return error.Malformed;
             const name_len = std.mem.readInt(u16, rest[4..6], .big);
             if (rest.len < 6 + name_len) return error.Malformed;
-            // TUI ignores font config; just return a no-op clear.
-            return .clear;
+            // TUI ignores font config.
+            return .noop;
         },
         OP_REGISTER_FONT => {
             // font_id:1, name_len:2, name:bytes
             if (rest.len < 3) return error.Malformed;
             const name_len = std.mem.readInt(u16, rest[1..3], .big);
             if (rest.len < 3 + name_len) return error.Malformed;
-            // TUI ignores font registration; return no-op.
-            return .clear;
+            // TUI ignores font registration.
+            return .noop;
         },
         OP_SET_FONT_FALLBACK => {
             // count:1, then count * (name_len:2, name:bytes)
@@ -930,8 +930,8 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
                 offset += 2 + name_len;
                 if (rest.len < offset) return error.Malformed;
             }
-            // TUI ignores font fallback; just return a no-op clear.
-            return .clear;
+            // TUI ignores font fallback.
+            return .noop;
         },
         else => return error.UnknownOpcode,
     }
@@ -1341,6 +1341,16 @@ test "decode set_window_bg truncated returns malformed" {
     const data = [_]u8{ OP_SET_WINDOW_BG, 0x28, 0x2C };
     const result = decodeCommand(&data);
     try std.testing.expectError(error.Malformed, result);
+}
+
+test "decode font config commands as noops" {
+    const set_font = [_]u8{ OP_SET_FONT, 0x00, 0x0E, 0x04, 0x01, 0x00, 0x05 } ++ "Menlo".*;
+    const register_font = [_]u8{ OP_REGISTER_FONT, 0x01, 0x00, 0x05 } ++ "Menlo".*;
+    const set_fallback = [_]u8{ OP_SET_FONT_FALLBACK, 0x01, 0x00, 0x05 } ++ "Menlo".*;
+
+    try std.testing.expect((try decodeCommand(&set_font)) == .noop);
+    try std.testing.expect((try decodeCommand(&register_font)) == .noop);
+    try std.testing.expect((try decodeCommand(&set_fallback)) == .noop);
 }
 
 test "decode set_cursor_shape block" {

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -699,8 +699,10 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
         OP_BATCH_END => return .batch_end,
         OP_SET_CURSOR_SHAPE => {
             if (rest.len < 1) return error.Malformed;
-            const shape = std.meta.intToEnum(CursorShape, rest[0]) catch return error.Malformed;
-            return .{ .set_cursor_shape = shape };
+            switch (rest[0]) {
+                inline CURSOR_BLOCK, CURSOR_BEAM, CURSOR_UNDERLINE => |v| return .{ .set_cursor_shape = @enumFromInt(v) },
+                else => return error.Malformed,
+            }
         },
         OP_SET_TITLE => {
             if (rest.len < 2) return error.Malformed;
@@ -1714,38 +1716,48 @@ test "decode set_cursor truncated (only 3 bytes after opcode) returns malformed"
 // ── writeMessage ──────────────────────────────────────────────────────────────
 
 test "writeMessage writes correct 4-byte big-endian length prefix" {
-    var out: [12]u8 = undefined;
-    var fbs = std.io.fixedBufferStream(&out);
-    try writeMessage(fbs.writer(), "hello");
-    const written = fbs.getWritten();
-    // First 4 bytes: length = 5
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeMessage(&aw.writer, "hello");
+    const written = aw.written();
     try std.testing.expectEqual(@as(u32, 5), std.mem.readInt(u32, written[0..4], .big));
-    // Payload follows
     try std.testing.expectEqualSlices(u8, "hello", written[4..9]);
 }
 
 test "writeMessage with empty payload writes length 0" {
-    var out: [8]u8 = undefined;
-    var fbs = std.io.fixedBufferStream(&out);
-    try writeMessage(fbs.writer(), "");
-    const written = fbs.getWritten();
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeMessage(&aw.writer, "");
+    const written = aw.written();
     try std.testing.expectEqual(@as(usize, 4), written.len);
     try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, written[0..4], .big));
 }
 
 // ── readMessageLength ─────────────────────────────────────────────────────────
 
+const SliceReader = struct {
+    data: []const u8,
+    pos: usize = 0,
+
+    fn readAll(self: *SliceReader, buf: []u8) !usize {
+        const available = self.data[self.pos..];
+        const n = @min(buf.len, available.len);
+        @memcpy(buf[0..n], available[0..n]);
+        self.pos += n;
+        return n;
+    }
+};
+
 test "readMessageLength returns correct value for known bytes" {
-    const data = [_]u8{ 0x00, 0x00, 0x00, 0x2A }; // big-endian 42
-    var fbs = std.io.fixedBufferStream(&data);
-    const result = try readMessageLength(fbs.reader());
+    const data = [_]u8{ 0x00, 0x00, 0x00, 0x2A };
+    var reader = SliceReader{ .data = &data };
+    const result = try readMessageLength(&reader);
     try std.testing.expectEqual(@as(?u32, 42), result);
 }
 
 test "readMessageLength returns null on EOF (empty reader)" {
-    const data = [_]u8{};
-    var fbs = std.io.fixedBufferStream(&data);
-    const result = try readMessageLength(fbs.reader());
+    var reader = SliceReader{ .data = &.{} };
+    const result = try readMessageLength(&reader);
     try std.testing.expectEqual(@as(?u32, null), result);
 }
 

--- a/zig/src/recovery.zig
+++ b/zig/src/recovery.zig
@@ -32,10 +32,6 @@ const TIMEOUT_MS: i64 = 3000;
 /// Updated when a batch_end command arrives on stdin.
 last_render_ms: i64,
 
-/// Timestamp (ms) of the last key event sent to BEAM.
-/// Updated when a key_press is enqueued to the PortWriter.
-last_key_sent_ms: i64,
-
 /// Number of key events sent since the last render response.
 keys_since_render: u32,
 
@@ -47,7 +43,6 @@ pub fn init() Self {
     const now = milliTimestamp();
     return .{
         .last_render_ms = now,
-        .last_key_sent_ms = 0,
         .keys_since_render = 0,
         .showing = false,
     };
@@ -63,7 +58,6 @@ pub fn onRenderReceived(self: *Self) void {
 
 /// Called when a key event is enqueued to the PortWriter.
 pub fn onKeySent(self: *Self) void {
-    self.last_key_sent_ms = milliTimestamp();
     self.keys_since_render += 1;
 }
 
@@ -218,9 +212,8 @@ test "init starts non-unresponsive" {
 
 test "becomes unresponsive after timeout with pending keys" {
     var r = init();
-    // Simulate: render came 4 seconds ago, key sent 1 second ago
+    // Simulate: render came 4 seconds ago and keys are still waiting for a render response.
     r.last_render_ms = milliTimestamp() - 4000;
-    r.last_key_sent_ms = milliTimestamp() - 1000;
     r.keys_since_render = 3;
     try std.testing.expect(r.isUnresponsive());
 }

--- a/zig/src/recovery.zig
+++ b/zig/src/recovery.zig
@@ -14,6 +14,15 @@ const vaxis = @import("vaxis");
 
 const Self = @This();
 
+/// Portable millisecond timestamp using libc clock_gettime.
+/// Replaces milliTimestamp() which was removed in Zig 0.16.
+fn milliTimestamp() i64 {
+    const c = std.c;
+    var ts: c.timespec = undefined;
+    _ = c.clock_gettime(c.CLOCK.REALTIME, &ts);
+    return @as(i64, ts.sec) * 1000 + @divTrunc(@as(i64, ts.nsec), 1_000_000);
+}
+
 /// How long to wait (in ms) after the last key was sent before
 /// considering the BEAM unresponsive. Only triggers if at least
 /// one key was sent since the last render.
@@ -35,7 +44,7 @@ showing: bool,
 
 /// Initialize with current time.
 pub fn init() Self {
-    const now = std.time.milliTimestamp();
+    const now = milliTimestamp();
     return .{
         .last_render_ms = now,
         .last_key_sent_ms = 0,
@@ -47,21 +56,21 @@ pub fn init() Self {
 /// Called when a batch_end command is received from the BEAM.
 /// Resets the unresponsive timer.
 pub fn onRenderReceived(self: *Self) void {
-    self.last_render_ms = std.time.milliTimestamp();
+    self.last_render_ms = milliTimestamp();
     self.keys_since_render = 0;
     self.showing = false;
 }
 
 /// Called when a key event is enqueued to the PortWriter.
 pub fn onKeySent(self: *Self) void {
-    self.last_key_sent_ms = std.time.milliTimestamp();
+    self.last_key_sent_ms = milliTimestamp();
     self.keys_since_render += 1;
 }
 
 /// Returns true if the BEAM appears unresponsive.
 pub fn isUnresponsive(self: *const Self) bool {
     if (self.keys_since_render == 0) return false;
-    const now = std.time.milliTimestamp();
+    const now = milliTimestamp();
     const elapsed = now - self.last_render_ms;
     return elapsed > TIMEOUT_MS;
 }
@@ -210,22 +219,22 @@ test "init starts non-unresponsive" {
 test "becomes unresponsive after timeout with pending keys" {
     var r = init();
     // Simulate: render came 4 seconds ago, key sent 1 second ago
-    r.last_render_ms = std.time.milliTimestamp() - 4000;
-    r.last_key_sent_ms = std.time.milliTimestamp() - 1000;
+    r.last_render_ms = milliTimestamp() - 4000;
+    r.last_key_sent_ms = milliTimestamp() - 1000;
     r.keys_since_render = 3;
     try std.testing.expect(r.isUnresponsive());
 }
 
 test "not unresponsive if no keys sent" {
     var r = init();
-    r.last_render_ms = std.time.milliTimestamp() - 10000;
+    r.last_render_ms = milliTimestamp() - 10000;
     r.keys_since_render = 0;
     try std.testing.expect(!r.isUnresponsive());
 }
 
 test "render resets unresponsive state" {
     var r = init();
-    r.last_render_ms = std.time.milliTimestamp() - 4000;
+    r.last_render_ms = milliTimestamp() - 4000;
     r.keys_since_render = 5;
     r.showing = true;
     r.onRenderReceived();


### PR DESCRIPTION
## Summary

- Upgrades Zig toolchain from 0.15.2 to 0.16.0, fixing the macOS 26 build-runner/linker failure (`__availability_version_check`/libSystem)
- Upgrades libvaxis from 0.5.1 to 0.6.0 (minimum_zig_version: 0.16.0)
- Ports all 12 Zig source files to the new stdlib and vaxis APIs

Closes #1506

## Changes

**Toolchain & deps:** `.tool-versions` → zig 0.16.0, `build.zig.zon` → libvaxis 0.6.0

**Build system:** `build.zig` migrates `addCSourceFile`/`linkLibrary` calls to `root_module.*` (required by 0.16)

**Entry points:** All three binaries (`main.zig`, `parser_main.zig`, `hook_runner_main.zig`) adopt `std.process.Init` main signature for access to `gpa`, `io`, and `arena` (replaces removed `GeneralPurposeAllocator`)

**POSIX API migration (`hook_runner_main.zig`, `port_writer.zig`):** Fork/exec/pipe/close/write/fcntl/waitpid moved from `std.posix` to `std.c`; thin wrappers preserve error handling style

**Threading (`highlighter.zig`, `font/main.zig`):** `std.Thread.Mutex` → `std.atomic.Mutex` spin lock (avoids `std.Io.Mutex` which requires an `Io` parameter incompatible with background threads)

**I/O (`tui.zig`, `protocol.zig`, `recovery.zig`):** `std.fs.File` → `std.Io.File`, `std.time.milliTimestamp` → `c.clock_gettime`, `std.io.fixedBufferStream` → `Io.Writer.Allocating`/`SliceReader`, `getenvZ` → `c.getenv`

**vaxis 0.6.0 (`tui.zig`):** Tty struct gains `io` field, `fd` becomes `Io.File`, `getWinsize` moves from class to instance method, `vaxis.init()` signature changes. MINGA_TTY env var support preserved.

## Test plan

- [x] `cd zig && zig build test` — 215 tests pass (exit 0)
- [x] `mix zig.lint` — format check + build test pass
- [x] `mix compile --warnings-as-errors` — all 3 binaries build through Mix compiler
- [x] `zig fmt --check src/` — formatting clean
- [x] `bin/minga` — smoke test (editor launches and renders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)