### PR TITLE
feat(agent): add inline tool approvals

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -290,7 +290,7 @@ Agent conversation view state. Uses sectioned envelope: `opcode(1) + section_cou
 | 0x01 | Header | visible, status |
 | 0x02 | Model | model name |
 | 0x03 | Prompt | prompt text |
-| 0x04 | Pending | pending approval (tool name + summary) |
+| 0x04 | Pending | legacy pending approval banner payload. Current BEAM frames send `0` and render approvals inline as message type `0x09`. |
 | 0x05 | Help | help overlay visibility + groups |
 | 0x06 | Messages | message_count + messages (same nested format as before) |
 
@@ -314,6 +314,7 @@ Per message (type byte first):
   0x06 (usage):      type(1) + input(4) + output(4) + cache_read(4) + cache_write(4) + cost_micros(4)
   0x07 (styled_assistant): type(1) + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1)
   0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1)
+  0x09 (approval_tool_call): type(1) + status(1) + name_len(2) + name + summary_len(2) + summary + tool_call_id_len(2) + tool_call_id + preview_kind(1) + preview_line_count(2), per line: line_len(2) + line
 
 When hidden:
   opcode(1) + 0(1)

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -289,10 +289,11 @@ Agent conversation view state. Uses sectioned envelope: `opcode(1) + section_cou
 |-----------|------|--------|
 | 0x01 | Header | visible, status |
 | 0x02 | Model | model name |
-| 0x03 | Prompt | prompt text |
+| 0x03 | Prompt | prompt text plus prompt line/cursor/mode metadata |
 | 0x04 | Pending | legacy pending approval banner payload. Current BEAM frames send `0` and render approvals inline as message type `0x09`. |
 | 0x05 | Help | help overlay visibility + groups |
 | 0x06 | Messages | message_count + messages (same nested format as before) |
+| 0x07 | Completion | prompt completion popup state |
 
 **Legacy positional format (deprecated):**
 ```
@@ -309,11 +310,11 @@ Per message (type byte first):
   0x01 (user):      type(1) + text_len(4) + text
   0x02 (assistant):  type(1) + text_len(4) + text
   0x03 (thinking):   type(1) + collapsed(1) + text_len(4) + text
-  0x04 (tool_call):  type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + result_len(4) + result
+  0x04 (tool_call):  type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + result_len(4) + result
   0x05 (system):     type(1) + level(1) + text_len(4) + text
   0x06 (usage):      type(1) + input(4) + output(4) + cache_read(4) + cache_write(4) + cost_micros(4)
   0x07 (styled_assistant): type(1) + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1)
-  0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1)
+  0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1)
   0x09 (approval_tool_call): type(1) + status(1) + name_len(2) + name + summary_len(2) + summary + tool_call_id_len(2) + tool_call_id + preview_kind(1) + preview_line_count(2), per line: line_len(2) + line
 
 When hidden:

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -163,7 +163,8 @@ defmodule MingaAgent.Session do
   on `receive`, then clears the pending approval and broadcasts
   the resolution to subscribers.
   """
-  @spec respond_to_approval(GenServer.server(), :approve | :reject | :approve_all) :: :ok
+  @spec respond_to_approval(GenServer.server(), :approve | :reject | :approve_all) ::
+          :ok | {:error, :no_pending_approval}
   def respond_to_approval(session, decision) when decision in [:approve, :reject, :approve_all] do
     GenServer.call(session, {:respond_to_approval, decision})
   end

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -763,7 +763,7 @@ defmodule MingaAgent.Session do
   def handle_call(:editor_snapshot, _from, state) do
     snapshot = %{
       status: state.status,
-      pending_approval: state.pending_approval,
+      pending_approval: public_pending_approval(state.pending_approval),
       error: state.error_message
     }
 
@@ -790,12 +790,14 @@ defmodule MingaAgent.Session do
   end
 
   def handle_call({:respond_to_approval, decision}, _from, state) do
-    %{tool_call_id: tool_call_id, reply_to: reply_to} = state.pending_approval
+    %{tool_call_id: tool_call_id, reply_to: reply_to} = approval = state.pending_approval
 
     # Send the decision directly to the blocked Task process
     send(reply_to, {:tool_approval_response, tool_call_id, decision})
 
+    state = maybe_record_rejection(state, approval, decision)
     state = %{state | pending_approval: nil}
+    state = notify_messages_changed(state)
     broadcast(state, {:approval_resolved, decision})
     {:reply, :ok, state}
   end
@@ -1163,15 +1165,16 @@ defmodule MingaAgent.Session do
   defp handle_provider_event(%Event.ToolApproval{} = event, state) do
     Notifier.notify(:approval, "Approval needed: #{event.name}")
 
-    approval = %MingaAgent.ToolApproval{
-      tool_call_id: event.tool_call_id,
-      name: event.name,
-      args: event.args,
-      reply_to: event.reply_to
-    }
+    approval =
+      MingaAgent.ToolApproval.new(
+        tool_call_id: event.tool_call_id,
+        name: event.name,
+        args: event.args,
+        reply_to: event.reply_to
+      )
 
     state = %{state | pending_approval: approval}
-    broadcast(state, {:approval_pending, approval})
+    broadcast(state, {:approval_pending, MingaAgent.ToolApproval.public(approval)})
     state
   end
 
@@ -1272,6 +1275,23 @@ defmodule MingaAgent.Session do
     msg = Message.system(text, level)
     append_msg(state, msg)
   end
+
+  @spec maybe_record_rejection(state(), MingaAgent.ToolApproval.t(), atom()) :: state()
+  defp maybe_record_rejection(state, approval, :reject) do
+    append_system_message(
+      state,
+      "Denied #{approval.name}: the tool was refused and the agent was notified.",
+      :info
+    )
+  end
+
+  defp maybe_record_rejection(state, _approval, _decision), do: state
+
+  @spec public_pending_approval(MingaAgent.ToolApproval.t() | nil) :: map() | nil
+  defp public_pending_approval(nil), do: nil
+
+  defp public_pending_approval(%MingaAgent.ToolApproval{} = approval),
+    do: MingaAgent.ToolApproval.public(approval)
 
   @spec append_to_last_assistant([Message.t()], String.t()) ::
           {:updated, [Message.t()]} | {:appended, Message.t()}

--- a/lib/minga_agent/tool_approval.ex
+++ b/lib/minga_agent/tool_approval.ex
@@ -8,17 +8,182 @@ defmodule MingaAgent.ToolApproval do
   handling, chat decorations, and GUI protocol encoding.
   """
 
+  alias MingaAgent.ToolRouter
+
+  @typedoc "Structured preview kind for an approval card."
+  @type preview_kind :: :diff | :command | :target | :args
+
+  @typedoc "A public, editor-safe approval preview."
+  @type preview :: %{
+          kind: preview_kind(),
+          summary: String.t(),
+          lines: [String.t()]
+        }
+
   @typedoc "A pending tool approval."
   @type t :: %__MODULE__{
           tool_call_id: String.t(),
           name: String.t(),
           args: map(),
+          preview: preview(),
           reply_to: pid() | nil
         }
 
-  @enforce_keys [:tool_call_id, :name]
+  @enforce_keys [:tool_call_id, :name, :preview]
   defstruct tool_call_id: nil,
             name: nil,
             args: %{},
+            preview: %{kind: :args, summary: "", lines: []},
             reply_to: nil
+
+  @doc "Creates a pending approval with a structured preview card."
+  @spec new(keyword()) :: t()
+  def new(opts) do
+    name = Keyword.fetch!(opts, :name)
+    args = Keyword.get(opts, :args, %{})
+
+    %__MODULE__{
+      tool_call_id: Keyword.fetch!(opts, :tool_call_id),
+      name: name,
+      args: args,
+      preview: build_preview(name, args),
+      reply_to: Keyword.get(opts, :reply_to)
+    }
+  end
+
+  @doc "Returns an editor-safe map without the private reply PID."
+  @spec public(t()) :: map()
+  def public(%__MODULE__{} = approval) do
+    %{
+      tool_call_id: approval.tool_call_id,
+      name: approval.name,
+      args: approval.args,
+      preview: approval.preview
+    }
+  end
+
+  @doc "Builds the structured preview shown in inline approval cards."
+  @spec build_preview(String.t(), map()) :: preview()
+  def build_preview(name, args) when is_binary(name) and is_map(args) do
+    do_build_preview(name, stringify_keys(args))
+  end
+
+  @spec do_build_preview(String.t(), map()) :: preview()
+  defp do_build_preview("shell", %{"command" => command} = args) do
+    cwd = Map.get(args, "cwd") || Map.get(args, "working_directory") || File.cwd!()
+
+    %{
+      kind: :command,
+      summary: truncate(command, 120),
+      lines: ["$ #{command}", "cwd: #{cwd}"]
+    }
+  end
+
+  defp do_build_preview("write_file", %{"path" => path} = args) when is_binary(path) do
+    content = Map.get(args, "content", "") |> to_string()
+    before = read_existing(path)
+    lines = diff_preview_lines(before, content)
+
+    %{
+      kind: :diff,
+      summary: path,
+      lines: ["file: #{path}" | lines]
+    }
+  end
+
+  defp do_build_preview(name, %{"path" => path} = args)
+       when name in ["edit_file", "multi_edit_file"] do
+    %{
+      kind: :target,
+      summary: path,
+      lines: ["file: #{path}", edit_summary(name, args)]
+    }
+  end
+
+  defp do_build_preview(name, %{"paths" => paths})
+       when is_list(paths) and name in ["git_stage"] do
+    joined = Enum.map_join(paths, ", ", &to_string/1)
+
+    %{
+      kind: :target,
+      summary: joined,
+      lines: ["paths: #{joined}"]
+    }
+  end
+
+  defp do_build_preview("git_commit", %{"message" => message}) do
+    %{
+      kind: :target,
+      summary: message,
+      lines: ["commit message: #{message}"]
+    }
+  end
+
+  defp do_build_preview(_name, args) when map_size(args) == 0 do
+    %{kind: :args, summary: "", lines: []}
+  end
+
+  defp do_build_preview(_name, args) do
+    summary = inspect(args, limit: 20, printable_limit: 120)
+    %{kind: :args, summary: summary, lines: [summary]}
+  end
+
+  @spec read_existing(String.t()) :: String.t()
+  defp read_existing(path) do
+    case ToolRouter.read_file(ToolRouter.context(nil, nil), path) do
+      {:ok, content} -> content
+      _ -> ""
+    end
+  end
+
+  @spec diff_preview_lines(String.t(), String.t()) :: [String.t()]
+  defp diff_preview_lines(before, after_text) do
+    before_lines = String.split(before, "\n")
+    after_lines = String.split(after_text, "\n")
+
+    before_lines
+    |> List.myers_difference(after_lines)
+    |> Enum.flat_map(&diff_op_preview_lines/1)
+    |> Enum.reject(&(&1 == "+" or &1 == "-"))
+    |> Enum.take(20)
+    |> case do
+      [] -> ["No textual changes detected"]
+      lines -> lines
+    end
+  end
+
+  @spec diff_op_preview_lines({:eq | :ins | :del, [String.t()]}) :: [String.t()]
+  defp diff_op_preview_lines({:eq, _lines}), do: []
+  defp diff_op_preview_lines({:ins, lines}), do: Enum.map(lines, &("+" <> &1))
+  defp diff_op_preview_lines({:del, lines}), do: Enum.map(lines, &("-" <> &1))
+
+  @spec edit_summary(String.t(), map()) :: String.t()
+  defp edit_summary("edit_file", args) do
+    old_text = Map.get(args, "old_text") || Map.get(args, "find") || ""
+    new_text = Map.get(args, "new_text") || Map.get(args, "replace") || ""
+    "replace #{inspect(truncate(old_text, 40))} with #{inspect(truncate(new_text, 40))}"
+  end
+
+  defp edit_summary("multi_edit_file", args) do
+    edits = Map.get(args, "edits", [])
+    count = if is_list(edits), do: length(edits), else: 0
+    "#{count} edit(s)"
+  end
+
+  @spec stringify_keys(map()) :: map()
+  defp stringify_keys(map) do
+    Map.new(map, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+      {key, value} -> {key, value}
+    end)
+  end
+
+  @spec truncate(String.t(), non_neg_integer()) :: String.t()
+  defp truncate(text, max_len) when is_binary(text) do
+    if String.length(text) > max_len do
+      String.slice(text, 0, max_len - 3) <> "..."
+    else
+      text
+    end
+  end
 end

--- a/lib/minga_agent/tool_approval.ex
+++ b/lib/minga_agent/tool_approval.ex
@@ -8,17 +8,14 @@ defmodule MingaAgent.ToolApproval do
   handling, chat decorations, and GUI protocol encoding.
   """
 
+  alias MingaAgent.ToolApproval.Preview
   alias MingaAgent.ToolRouter
 
   @typedoc "Structured preview kind for an approval card."
-  @type preview_kind :: :diff | :command | :target | :args
+  @type preview_kind :: Preview.kind()
 
   @typedoc "A public, editor-safe approval preview."
-  @type preview :: %{
-          kind: preview_kind(),
-          summary: String.t(),
-          lines: [String.t()]
-        }
+  @type preview :: Preview.t()
 
   @typedoc "A pending tool approval."
   @type t :: %__MODULE__{
@@ -33,7 +30,7 @@ defmodule MingaAgent.ToolApproval do
   defstruct tool_call_id: nil,
             name: nil,
             args: %{},
-            preview: %{kind: :args, summary: "", lines: []},
+            preview: %Preview{kind: :args, summary: "", lines: []},
             reply_to: nil
 
   @doc "Creates a pending approval with a structured preview card."
@@ -70,62 +67,49 @@ defmodule MingaAgent.ToolApproval do
 
   @spec do_build_preview(String.t(), map()) :: preview()
   defp do_build_preview("shell", %{"command" => command} = args) do
-    cwd = Map.get(args, "cwd") || Map.get(args, "working_directory") || File.cwd!()
+    command = stringify_value(command)
 
-    %{
-      kind: :command,
-      summary: truncate(command, 120),
-      lines: ["$ #{command}", "cwd: #{cwd}"]
-    }
+    cwd =
+      stringify_value(Map.get(args, "cwd") || Map.get(args, "working_directory") || File.cwd!())
+
+    Preview.new(:command, truncate(command, 120), preview_lines(["$ #{command}", "cwd: #{cwd}"]))
   end
 
   defp do_build_preview("write_file", %{"path" => path} = args) when is_binary(path) do
-    content = Map.get(args, "content", "") |> to_string()
+    content = stringify_value(Map.get(args, "content", ""))
     before = read_existing(path)
     lines = diff_preview_lines(before, content)
 
-    %{
-      kind: :diff,
-      summary: path,
-      lines: ["file: #{path}" | lines]
-    }
+    Preview.new(:diff, path, preview_lines(["file: #{path}" | lines]))
   end
 
   defp do_build_preview(name, %{"path" => path} = args)
        when name in ["edit_file", "multi_edit_file"] do
-    %{
-      kind: :target,
-      summary: path,
-      lines: ["file: #{path}", edit_summary(name, args)]
-    }
+    path = stringify_value(path)
+
+    Preview.new(:target, path, preview_lines(["file: #{path}", edit_summary(name, args)]))
   end
 
   defp do_build_preview(name, %{"paths" => paths})
        when is_list(paths) and name in ["git_stage"] do
-    joined = Enum.map_join(paths, ", ", &to_string/1)
+    joined = Enum.map_join(paths, ", ", &stringify_value/1)
 
-    %{
-      kind: :target,
-      summary: joined,
-      lines: ["paths: #{joined}"]
-    }
+    Preview.new(:target, joined, preview_lines(["paths: #{joined}"]))
   end
 
   defp do_build_preview("git_commit", %{"message" => message}) do
-    %{
-      kind: :target,
-      summary: message,
-      lines: ["commit message: #{message}"]
-    }
+    message = stringify_value(message)
+
+    Preview.new(:target, message, preview_lines(["commit message: #{message}"]))
   end
 
   defp do_build_preview(_name, args) when map_size(args) == 0 do
-    %{kind: :args, summary: "", lines: []}
+    Preview.new(:args, "", [])
   end
 
   defp do_build_preview(_name, args) do
     summary = inspect(args, limit: 20, printable_limit: 120)
-    %{kind: :args, summary: summary, lines: [summary]}
+    Preview.new(:args, summary, [summary])
   end
 
   @spec read_existing(String.t()) :: String.t()
@@ -144,7 +128,6 @@ defmodule MingaAgent.ToolApproval do
     before_lines
     |> List.myers_difference(after_lines)
     |> Enum.flat_map(&diff_op_preview_lines/1)
-    |> Enum.reject(&(&1 == "+" or &1 == "-"))
     |> Enum.take(20)
     |> case do
       [] -> ["No textual changes detected"]
@@ -159,8 +142,8 @@ defmodule MingaAgent.ToolApproval do
 
   @spec edit_summary(String.t(), map()) :: String.t()
   defp edit_summary("edit_file", args) do
-    old_text = Map.get(args, "old_text") || Map.get(args, "find") || ""
-    new_text = Map.get(args, "new_text") || Map.get(args, "replace") || ""
+    old_text = stringify_value(Map.get(args, "old_text") || Map.get(args, "find") || "")
+    new_text = stringify_value(Map.get(args, "new_text") || Map.get(args, "replace") || "")
     "replace #{inspect(truncate(old_text, 40))} with #{inspect(truncate(new_text, 40))}"
   end
 
@@ -177,6 +160,13 @@ defmodule MingaAgent.ToolApproval do
       {key, value} -> {key, value}
     end)
   end
+
+  @spec stringify_value(term()) :: String.t()
+  defp stringify_value(value) when is_binary(value), do: value
+  defp stringify_value(value), do: inspect(value, printable_limit: 120)
+
+  @spec preview_lines([String.t()]) :: [String.t()]
+  defp preview_lines(lines), do: Enum.map(lines, &truncate(&1, 300))
 
   @spec truncate(String.t(), non_neg_integer()) :: String.t()
   defp truncate(text, max_len) when is_binary(text) do

--- a/lib/minga_agent/tool_approval/preview.ex
+++ b/lib/minga_agent/tool_approval/preview.ex
@@ -1,0 +1,25 @@
+defmodule MingaAgent.ToolApproval.Preview do
+  @moduledoc """
+  Structured, editor-safe preview shown on an inline tool approval card.
+  """
+
+  @typedoc "Structured preview kind for an approval card."
+  @type kind :: :diff | :command | :target | :args
+
+  @typedoc "A public approval preview rendered by editor frontends."
+  @type t :: %__MODULE__{
+          kind: kind(),
+          summary: String.t(),
+          lines: [String.t()]
+        }
+
+  @enforce_keys [:kind, :summary, :lines]
+  defstruct [:kind, :summary, :lines]
+
+  @doc "Creates an approval preview."
+  @spec new(kind(), String.t(), [String.t()]) :: t()
+  def new(kind, summary, lines)
+      when kind in [:diff, :command, :target, :args] and is_binary(summary) and is_list(lines) do
+    %__MODULE__{kind: kind, summary: summary, lines: lines}
+  end
+end

--- a/lib/minga_editor/agent/chat_decorations.ex
+++ b/lib/minga_editor/agent/chat_decorations.ex
@@ -257,8 +257,8 @@ defmodule MingaEditor.Agent.ChatDecorations do
          _streaming,
          pending_approval
        ) do
-    awaiting_approval = tool_awaiting_approval?(tc, pending_approval)
-    apply_tool_call_decorations(decs, tc, line, line_count, theme, awaiting_approval)
+    matching_approval = matching_tool_approval(tc, pending_approval)
+    apply_tool_call_decorations(decs, tc, line, line_count, theme, matching_approval)
   end
 
   defp apply_message_decorations(
@@ -325,11 +325,11 @@ defmodule MingaEditor.Agent.ChatDecorations do
 
   # ── Tool call decorations ────────────────────────────────────────────────────
 
-  @spec tool_awaiting_approval?(MingaAgent.ToolCall.t(), map() | nil) :: boolean()
-  defp tool_awaiting_approval?(_tc, nil), do: false
+  @spec matching_tool_approval(MingaAgent.ToolCall.t(), map() | nil) :: map() | nil
+  defp matching_tool_approval(_tc, nil), do: nil
 
-  defp tool_awaiting_approval?(tc, approval) when is_map(approval) do
-    Map.get(approval, :tool_call_id) == tc.id
+  defp matching_tool_approval(tc, approval) when is_map(approval) do
+    if Map.get(approval, :tool_call_id) == tc.id, do: approval, else: nil
   end
 
   @spec apply_tool_call_decorations(
@@ -338,9 +338,10 @@ defmodule MingaEditor.Agent.ChatDecorations do
           non_neg_integer(),
           non_neg_integer(),
           MingaEditor.UI.Theme.Agent.t(),
-          boolean()
+          map() | nil
         ) :: Decorations.t()
-  defp apply_tool_call_decorations(decs, tc, line, line_count, theme, awaiting_approval) do
+  defp apply_tool_call_decorations(decs, tc, line, line_count, theme, approval) do
+    awaiting_approval = approval != nil
     {status_icon, status_fg} = tool_status_display(tc, theme, awaiting_approval)
 
     has_result = tc.result != ""
@@ -387,17 +388,21 @@ defmodule MingaEditor.Agent.ChatDecorations do
     # Left border (│) on each content line
     decs = add_tool_border_virtual_text(decs, line, line_count, theme.tool_border)
 
-    # Bottom border
+    # Bottom border or pending approval card.
     last_line = line + line_count - 1
 
-    {_id, decs} =
-      add_block(decs, last_line,
-        placement: :below,
-        render: fn _w -> [{"└─", Face.new(fg: status_fg)}] end,
-        priority: 5
-      )
+    if awaiting_approval do
+      add_approval_card(decs, last_line, tc, approval, theme, status_fg)
+    else
+      {_id, decs} =
+        add_block(decs, last_line,
+          placement: :below,
+          render: fn _w -> [{"└─", Face.new(fg: status_fg)}] end,
+          priority: 5
+        )
 
-    decs
+      decs
+    end
   end
 
   @spec tool_status_display(MingaAgent.ToolCall.t(), MingaEditor.UI.Theme.Agent.t(), boolean()) ::
@@ -413,6 +418,73 @@ defmodule MingaEditor.Agent.ChatDecorations do
       :error -> {"✗", theme.status_error}
     end
   end
+
+  @spec add_approval_card(
+          Decorations.t(),
+          non_neg_integer(),
+          MingaAgent.ToolCall.t(),
+          map() | nil,
+          MingaEditor.UI.Theme.Agent.t(),
+          non_neg_integer()
+        ) :: Decorations.t()
+  defp add_approval_card(decs, line, tc, approval, theme, status_fg) do
+    preview = approval_preview(tc, approval)
+
+    {_id, decs} =
+      add_block(decs, line,
+        placement: :below,
+        render: fn _w -> approval_card_lines(preview, theme, status_fg) end,
+        priority: 6
+      )
+
+    decs
+  end
+
+  @spec approval_preview(MingaAgent.ToolCall.t(), map() | nil) ::
+          MingaAgent.ToolApproval.preview()
+  defp approval_preview(_tc, %{preview: preview}) when is_map(preview), do: preview
+
+  defp approval_preview(%{args: %{} = args, name: name}, _approval) do
+    MingaAgent.ToolApproval.build_preview(name, args)
+  end
+
+  @spec approval_card_lines(
+          MingaAgent.ToolApproval.preview(),
+          MingaEditor.UI.Theme.Agent.t(),
+          non_neg_integer()
+        ) :: [
+          {String.t(), Face.t()}
+        ]
+  defp approval_card_lines(preview, theme, status_fg) do
+    base = [
+      {"│ Approval required", Face.new(fg: status_fg, bold: true)},
+      {"\n│ #{preview_label(preview.kind)}: #{preview.summary}", Face.new(fg: theme.text_fg)}
+    ]
+
+    preview_lines =
+      preview.lines
+      |> Enum.take(6)
+      |> Enum.map(fn line -> {"\n│   #{line}", Face.new(fg: theme.text_fg)} end)
+
+    actions = [
+      {"\n│ ", Face.new(fg: status_fg)},
+      {"[y]", Face.new(fg: theme.tool_header, bold: true)},
+      {" approve  ", Face.new(fg: status_fg)},
+      {"[n]", Face.new(fg: theme.status_error, bold: true)},
+      {" deny  ", Face.new(fg: status_fg)},
+      {"[Y]", Face.new(fg: theme.tool_header, bold: true)},
+      {" approve all", Face.new(fg: status_fg)},
+      {"\n└─", Face.new(fg: status_fg)}
+    ]
+
+    base ++ preview_lines ++ actions
+  end
+
+  @spec preview_label(atom()) :: String.t()
+  defp preview_label(:diff), do: "Diff"
+  defp preview_label(:command), do: "Command"
+  defp preview_label(:target), do: "Target"
+  defp preview_label(_kind), do: "Args"
 
   @spec tool_header_render(
           String.t(),

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -182,7 +182,7 @@ defmodule MingaEditor.Agent.Events do
   end
 
   def handle(state, {:approval_pending, approval}) do
-    cached = Map.take(approval, [:tool_call_id, :name, :args])
+    cached = Map.take(approval, [:tool_call_id, :name, :args, :preview])
     state = AgentAccess.update_agent(state, &AgentState.set_pending_approval(&1, cached))
 
     # Unfocus the prompt input so the ToolApproval input handler can

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -968,6 +968,9 @@ defmodule MingaEditor.Commands.Agent do
   @spec scope_approve_tool(state()) :: state()
   defdelegate scope_approve_tool(state), to: AgentSubStates, as: :approve_tool
 
+  @spec scope_approve_all_tools(state()) :: state()
+  defdelegate scope_approve_all_tools(state), to: AgentSubStates, as: :approve_all_tools
+
   @spec scope_deny_tool(state()) :: state()
   defdelegate scope_deny_tool(state), to: AgentSubStates, as: :deny_tool
 
@@ -1263,6 +1266,7 @@ defmodule MingaEditor.Commands.Agent do
     {:agent_accept_all_hunks, "Accept all agent hunks", :scope_accept_all_hunks},
     {:agent_reject_all_hunks, "Reject all agent hunks", :scope_reject_all_hunks},
     {:agent_approve_tool, "Approve agent tool", :scope_approve_tool},
+    {:agent_approve_all_tools, "Approve all agent tools", :scope_approve_all_tools},
     {:agent_deny_tool, "Deny agent tool", :scope_deny_tool}
   ]
 

--- a/lib/minga_editor/commands/agent_sub_states.ex
+++ b/lib/minga_editor/commands/agent_sub_states.ex
@@ -258,28 +258,24 @@ defmodule MingaEditor.Commands.AgentSubStates do
 
   @doc "Approves the pending tool execution."
   @spec approve_tool(state()) :: state()
-  def approve_tool(state) do
-    agent = AgentAccess.agent(state)
-    session = AgentAccess.session(state)
-    approval = agent.pending_approval
+  def approve_tool(state), do: respond_to_tool_approval(state, :approve)
 
-    if is_pid(session) and is_map(approval) do
-      Session.respond_to_approval(session, :approve)
-      update_agent(state, &AgentState.clear_pending_approval/1)
-    else
-      state
-    end
-  end
+  @doc "Approves the current and all subsequent tool executions in this turn."
+  @spec approve_all_tools(state()) :: state()
+  def approve_all_tools(state), do: respond_to_tool_approval(state, :approve_all)
 
   @doc "Denies the pending tool execution."
   @spec deny_tool(state()) :: state()
-  def deny_tool(state) do
+  def deny_tool(state), do: respond_to_tool_approval(state, :reject)
+
+  @spec respond_to_tool_approval(state(), :approve | :approve_all | :reject) :: state()
+  defp respond_to_tool_approval(state, decision) do
     agent = AgentAccess.agent(state)
     session = AgentAccess.session(state)
     approval = agent.pending_approval
 
     if is_pid(session) and is_map(approval) do
-      Session.respond_to_approval(session, :reject)
+      Session.respond_to_approval(session, decision)
       update_agent(state, &AgentState.clear_pending_approval/1)
     else
       state

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -836,8 +836,17 @@ defmodule MingaEditor.Frontend.Emit.GUI do
   defp maybe_style_message({{id, {:assistant, _text}}, styled_lines}, _pending_approval),
     do: {id, {:styled_assistant, styled_lines}}
 
-  defp maybe_style_message({{id, {:tool_call, _tc} = msg}, _styled_lines}, pending_approval) do
-    maybe_inline_approval({id, msg}, pending_approval)
+  defp maybe_style_message({{id, {:tool_call, tc} = msg}, styled_lines}, pending_approval) do
+    case maybe_inline_approval({id, msg}, pending_approval) do
+      {^id, {:approval_tool_call, _tc, _approval}} = approval_message ->
+        approval_message
+
+      {^id, {:tool_call, _tc}} when is_list(styled_lines) ->
+        {id, {:styled_tool_call, tc, styled_lines}}
+
+      unchanged ->
+        unchanged
+    end
   end
 
   defp maybe_style_message({{id, msg}, _cache_entry}, _pending_approval), do: {id, msg}

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -764,7 +764,8 @@ defmodule MingaEditor.Frontend.Emit.GUI do
       # Use cached styled runs for assistant messages when available.
       # This avoids recomputing tree-sitter/markdown styling per frame.
       styled_cache = ctx.agent_ui.panel.cached_styled_messages
-      gui_messages = build_gui_messages(messages_with_ids, styled_cache)
+      pending_approval = ctx.shell_state.agent.pending_approval
+      gui_messages = build_gui_messages(messages_with_ids, styled_cache, pending_approval)
 
       view = ctx.agent_ui.view
       help_visible = view.help_visible
@@ -789,7 +790,7 @@ defmodule MingaEditor.Frontend.Emit.GUI do
         status: ctx.shell_state.agent.runtime.status || :idle,
         model: ctx.agent_ui.panel.model_name,
         prompt: prompt_text,
-        pending_approval: ctx.shell_state.agent.pending_approval,
+        pending_approval: nil,
         help_visible: help_visible,
         help_groups: help_groups,
         prompt_line_count: UIState.input_line_count(panel),
@@ -811,27 +812,43 @@ defmodule MingaEditor.Frontend.Emit.GUI do
   # Input: list of `{id, Message.t()}` pairs from `messages_with_ids/1`.
   # Uses Enum.zip (O(n)) instead of Enum.at in a loop (O(n²)) since this
   # runs every render frame at 60fps.
-  @spec build_gui_messages([{pos_integer(), term()}], [term()] | nil) :: [{pos_integer(), term()}]
-  defp build_gui_messages(messages_with_ids, nil), do: messages_with_ids
+  @spec build_gui_messages([{pos_integer(), term()}], [term()] | nil, map() | nil) :: [
+          {pos_integer(), term()}
+        ]
+  defp build_gui_messages(messages_with_ids, nil, pending_approval) do
+    Enum.map(messages_with_ids, &maybe_inline_approval(&1, pending_approval))
+  end
 
-  defp build_gui_messages(messages_with_ids, styled_cache) when is_list(styled_cache) do
+  defp build_gui_messages(messages_with_ids, styled_cache, pending_approval)
+       when is_list(styled_cache) do
     # Pad the cache to match message length if needed (messages may have grown)
     padded = pad_cache(styled_cache, length(messages_with_ids))
 
     Enum.zip(messages_with_ids, padded)
-    |> Enum.map(&maybe_style_message/1)
+    |> Enum.map(&maybe_style_message(&1, pending_approval))
   end
 
-  @spec maybe_style_message({{pos_integer(), term()}, term()}) :: {pos_integer(), term()}
-  defp maybe_style_message({{id, {:assistant, _text} = msg}, nil}), do: {id, msg}
+  @spec maybe_style_message({{pos_integer(), term()}, term()}, map() | nil) ::
+          {pos_integer(), term()}
+  defp maybe_style_message({{id, {:assistant, _text} = msg}, nil}, _pending_approval),
+    do: {id, msg}
 
-  defp maybe_style_message({{id, {:assistant, _text}}, styled_lines}),
+  defp maybe_style_message({{id, {:assistant, _text}}, styled_lines}, _pending_approval),
     do: {id, {:styled_assistant, styled_lines}}
 
-  defp maybe_style_message({{id, {:tool_call, tc}}, styled_lines}) when is_list(styled_lines),
-    do: {id, {:styled_tool_call, tc, styled_lines}}
+  defp maybe_style_message({{id, {:tool_call, _tc} = msg}, _styled_lines}, pending_approval) do
+    maybe_inline_approval({id, msg}, pending_approval)
+  end
 
-  defp maybe_style_message({{id, msg}, _cache_entry}), do: {id, msg}
+  defp maybe_style_message({{id, msg}, _cache_entry}, _pending_approval), do: {id, msg}
+
+  @spec maybe_inline_approval({pos_integer(), term()}, map() | nil) :: {pos_integer(), term()}
+  defp maybe_inline_approval({id, {:tool_call, tc}}, %{tool_call_id: tool_call_id} = approval)
+       when tc.id == tool_call_id do
+    {id, {:approval_tool_call, tc, approval}}
+  end
+
+  defp maybe_inline_approval({id, msg}, _pending_approval), do: {id, msg}
 
   @spec pad_cache([term()], non_neg_integer()) :: [term()]
   defp pad_cache(cache, target_len) when length(cache) >= target_len, do: cache

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -1639,6 +1639,12 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     summarize_tool_args(name, args) |> String.slice(0, 100)
   end
 
+  @spec preview_kind_byte(atom()) :: non_neg_integer()
+  defp preview_kind_byte(:diff), do: 1
+  defp preview_kind_byte(:command), do: 2
+  defp preview_kind_byte(:target), do: 3
+  defp preview_kind_byte(_), do: 0
+
   @spec summarize_tool_args(String.t(), map()) :: String.t()
   defp summarize_tool_args("shell", %{"command" => cmd}), do: cmd
   defp summarize_tool_args("shell", %{command: cmd}), do: cmd
@@ -1679,6 +1685,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
                duration_ms: non_neg_integer() | nil,
                result: String.t() | nil
              }, [[styled_run()]]}
+          | {:approval_tool_call, MingaAgent.ToolCall.t(), map()}
 
   # Unwrap {id, message} tuple: prefix with the stable uint32 ID, then encode the message.
   @spec encode_chat_message({pos_integer(), gui_chat_message()} | gui_chat_message()) :: binary()
@@ -1750,6 +1757,34 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     <<0x04::8, status_byte::8, error_byte::8, collapsed_byte::8, duration::32,
       byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
       summary_bytes::binary, byte_size(result_bytes)::32, result_bytes::binary>>
+  end
+
+  # Approval tool call: inline approval card attached to the tool message.
+  # Sub-opcode 0x09. Layout:
+  #   0x09, status::8, name_len::16, name, summary_len::16, summary,
+  #   tool_call_id_len::16, tool_call_id, preview_kind::8,
+  #   preview_line_count::16, [line_len::16, line]*
+  defp encode_chat_message_body({:approval_tool_call, tc, approval}) do
+    preview = Map.get(approval, :preview, MingaAgent.ToolApproval.build_preview(tc.name, tc.args))
+    name_bytes = :erlang.iolist_to_binary([tc.name])
+    summary_bytes = :erlang.iolist_to_binary([Map.get(preview, :summary, tool_call_summary(tc))])
+    id_bytes = :erlang.iolist_to_binary([Map.get(approval, :tool_call_id, tc.id)])
+
+    line_binaries =
+      preview
+      |> Map.get(:lines, [])
+      |> Enum.take(20)
+      |> Enum.map(fn line ->
+        bytes = :erlang.iolist_to_binary([line])
+        <<byte_size(bytes)::16, bytes::binary>>
+      end)
+
+    preview_bytes = IO.iodata_to_binary(line_binaries)
+
+    <<0x09::8, 0::8, byte_size(name_bytes)::16, name_bytes::binary, byte_size(summary_bytes)::16,
+      summary_bytes::binary, byte_size(id_bytes)::16, id_bytes::binary,
+      preview_kind_byte(Map.get(preview, :kind, :args))::8, length(line_binaries)::16,
+      preview_bytes::binary>>
   end
 
   # Styled tool call: same header fields as tool_call (0x04), but result is styled runs.

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -1645,6 +1645,18 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   defp preview_kind_byte(:target), do: 3
   defp preview_kind_byte(_), do: 0
 
+  @spec preview_text_bytes(term(), pos_integer()) :: binary()
+  defp preview_text_bytes(value, max_length) when is_binary(value) do
+    value |> String.slice(0, max_length) |> :erlang.iolist_to_binary()
+  end
+
+  defp preview_text_bytes(value, max_length) do
+    value
+    |> inspect(printable_limit: max_length)
+    |> String.slice(0, max_length)
+    |> :erlang.iolist_to_binary()
+  end
+
   @spec summarize_tool_args(String.t(), map()) :: String.t()
   defp summarize_tool_args("shell", %{"command" => cmd}), do: cmd
   defp summarize_tool_args("shell", %{command: cmd}), do: cmd
@@ -1766,16 +1778,16 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   #   preview_line_count::16, [line_len::16, line]*
   defp encode_chat_message_body({:approval_tool_call, tc, approval}) do
     preview = Map.get(approval, :preview, MingaAgent.ToolApproval.build_preview(tc.name, tc.args))
-    name_bytes = :erlang.iolist_to_binary([tc.name])
-    summary_bytes = :erlang.iolist_to_binary([Map.get(preview, :summary, tool_call_summary(tc))])
-    id_bytes = :erlang.iolist_to_binary([Map.get(approval, :tool_call_id, tc.id)])
+    name_bytes = preview_text_bytes(tc.name, 120)
+    summary_bytes = preview_text_bytes(Map.get(preview, :summary, tool_call_summary(tc)), 300)
+    id_bytes = preview_text_bytes(Map.get(approval, :tool_call_id, tc.id), 120)
 
     line_binaries =
       preview
       |> Map.get(:lines, [])
       |> Enum.take(20)
       |> Enum.map(fn line ->
-        bytes = :erlang.iolist_to_binary([line])
+        bytes = preview_text_bytes(line, 1_000)
         <<byte_size(bytes)::16, bytes::binary>>
       end)
 

--- a/lib/minga_editor/input/tool_approval.ex
+++ b/lib/minga_editor/input/tool_approval.ex
@@ -1,6 +1,6 @@
 defmodule MingaEditor.Input.ToolApproval do
   @moduledoc """
-  Input handler for the tool approval sub-state (y/n/Y/N).
+  Input handler for the tool approval sub-state (y/n/Y).
 
   Active when `agent.pending_approval` is non-nil and the panel
   input is not focused. Handles y (approve), n (deny), Y (approve all),

--- a/lib/minga_editor/input/tool_approval.ex
+++ b/lib/minga_editor/input/tool_approval.ex
@@ -31,6 +31,6 @@ defmodule MingaEditor.Input.ToolApproval do
   @spec dispatch_approval(EditorState.t(), non_neg_integer()) :: EditorState.t()
   defp dispatch_approval(state, ?y), do: Commands.execute(state, :agent_approve_tool)
   defp dispatch_approval(state, ?n), do: Commands.execute(state, :agent_deny_tool)
-  defp dispatch_approval(state, ?Y), do: Commands.execute(state, :agent_approve_tool)
+  defp dispatch_approval(state, ?Y), do: Commands.execute(state, :agent_approve_all_tools)
   defp dispatch_approval(state, _cp), do: state
 end

--- a/lib/minga_editor/state/agent.ex
+++ b/lib/minga_editor/state/agent.ex
@@ -27,8 +27,13 @@ defmodule MingaEditor.State.Agent do
   @typedoc "Agent status (delegated from RuntimeState)."
   @type status :: RuntimeState.status()
 
-  @typedoc "Pending tool approval data."
-  @type approval :: MingaAgent.ToolApproval.t()
+  @typedoc "Public pending tool approval data cached for rendering."
+  @type approval :: %{
+          required(:tool_call_id) => String.t(),
+          required(:name) => String.t(),
+          required(:args) => map(),
+          optional(:preview) => MingaAgent.ToolApproval.preview()
+        }
 
   @typedoc "Agent rendering cache."
   @type t :: %__MODULE__{

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1018,6 +1018,32 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 }
                 messages.append(Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, durationMs: stcDuration, resultLines: stcLines)))
                 pos = stcPos
+            case 0x09: // approval_tool_call
+                guard data.count >= pos + 8 else { throw ProtocolDecodeError.malformed }
+                let nameLen = Int(readU16(data, pos + 2))
+                guard data.count >= pos + 4 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
+                let name = String(data: data[(pos + 4)..<(pos + 4 + nameLen)], encoding: .utf8) ?? ""
+                let summaryLen = Int(readU16(data, pos + 4 + nameLen))
+                guard data.count >= pos + 6 + nameLen + summaryLen + 2 else { throw ProtocolDecodeError.malformed }
+                let summary = String(data: data[(pos + 6 + nameLen)..<(pos + 6 + nameLen + summaryLen)], encoding: .utf8) ?? ""
+                let idLen = Int(readU16(data, pos + 6 + nameLen + summaryLen))
+                guard data.count >= pos + 8 + nameLen + summaryLen + idLen + 3 else { throw ProtocolDecodeError.malformed }
+                let toolCallId = String(data: data[(pos + 8 + nameLen + summaryLen)..<(pos + 8 + nameLen + summaryLen + idLen)], encoding: .utf8) ?? ""
+                let previewKind = data[pos + 8 + nameLen + summaryLen + idLen]
+                let lineCount = Int(readU16(data, pos + 9 + nameLen + summaryLen + idLen))
+                var approvalPos = pos + 11 + nameLen + summaryLen + idLen
+                var previewLines: [String] = []
+                previewLines.reserveCapacity(lineCount)
+                for _ in 0..<lineCount {
+                    guard data.count >= approvalPos + 2 else { throw ProtocolDecodeError.malformed }
+                    let lineLen = Int(readU16(data, approvalPos))
+                    guard data.count >= approvalPos + 2 + lineLen else { throw ProtocolDecodeError.malformed }
+                    let line = String(data: data[(approvalPos + 2)..<(approvalPos + 2 + lineLen)], encoding: .utf8) ?? ""
+                    previewLines.append(line)
+                    approvalPos += 2 + lineLen
+                }
+                messages.append(Wire.ChatMessage(beamId: beamId, content: .approvalToolCall(name: name, summary: summary, toolCallId: toolCallId, previewKind: previewKind, previewLines: previewLines)))
+                pos = approvalPos
             default:
                 break
             }

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -362,6 +362,7 @@ enum Wire {
         case toolCall(name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, durationMs: UInt32, result: String)
         /// Tool call with pre-styled result runs from tree-sitter.
         case styledToolCall(name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, durationMs: UInt32, resultLines: [[StyledTextRun]])
+        case approvalToolCall(name: String, summary: String, toolCallId: String, previewKind: UInt8, previewLines: [String])
         case system(text: String, isError: Bool)
         case usage(input: UInt32, output: UInt32, cacheRead: UInt32, cacheWrite: UInt32, costMicros: UInt32)
     }

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -256,13 +256,13 @@ final class CommandDispatcher {
                 guiState.pickerState.clearPreview()
             }
 
-        case .guiAgentChat(let visible, let status, let model, let prompt, let promptLineCount, let promptCursorLine, let promptCursorCol, let promptVimMode, let promptVisibleRows, let promptCompletion, let pendingToolName, let pendingToolSummary, let helpVisible, let helpGroups, let messages):
+        case .guiAgentChat(let visible, let status, let model, let prompt, let promptLineCount, let promptCursorLine, let promptCursorCol, let promptVimMode, let promptVisibleRows, let promptCompletion, _, _, let helpVisible, let helpGroups, let messages):
             let wasVisible = guiState.agentChatState.visible
             if visible {
                 let groups = helpGroups.map { g in
                     HelpGroup(title: g.title, bindings: g.bindings.map { ($0.key, $0.description) })
                 }
-                guiState.agentChatState.update(visible: true, status: status, model: model, prompt: prompt, promptLineCount: promptLineCount, promptCursorLine: promptCursorLine, promptCursorCol: promptCursorCol, promptVimMode: promptVimMode, promptVisibleRows: promptVisibleRows, promptCompletion: promptCompletion, pendingToolName: pendingToolName, pendingToolSummary: pendingToolSummary, helpVisible: helpVisible, helpGroups: groups, rawMessages: messages)
+                guiState.agentChatState.update(visible: true, status: status, model: model, prompt: prompt, promptLineCount: promptLineCount, promptCursorLine: promptCursorLine, promptCursorCol: promptCursorCol, promptVimMode: promptVimMode, promptVisibleRows: promptVisibleRows, promptCompletion: promptCompletion, helpVisible: helpVisible, helpGroups: groups, rawMessages: messages)
             } else {
                 guiState.agentChatState.hide()
             }

--- a/macos/Sources/Views/AgentChatState.swift
+++ b/macos/Sources/Views/AgentChatState.swift
@@ -45,7 +45,6 @@ final class AgentChatState {
     var model: String = ""
     var prompt: String = ""
     var messages: [ChatMessageEntry] = []
-    var pendingApproval: PendingApproval?
     var helpVisible: Bool = false
     var helpGroups: [HelpGroup] = []
 
@@ -74,11 +73,6 @@ final class AgentChatState {
     /// Active completion popup for @-mention or /slash commands. Nil when no popup is showing.
     var promptCompletion: Wire.PromptCompletion?
 
-    struct PendingApproval {
-        let toolName: String
-        let summary: String
-    }
-
     var statusLabel: String {
         switch status {
         case 0: return "idle"
@@ -91,7 +85,7 @@ final class AgentChatState {
 
     var isThinking: Bool { status == 1 || status == 2 }
 
-    func update(visible: Bool, status: UInt8, model: String, prompt: String, promptLineCount: UInt8, promptCursorLine: UInt16, promptCursorCol: UInt16, promptVimMode: UInt8, promptVisibleRows: UInt8, promptCompletion: Wire.PromptCompletion?, pendingToolName: String?, pendingToolSummary: String, helpVisible: Bool, helpGroups: [HelpGroup], rawMessages: [Wire.ChatMessage]) {
+    func update(visible: Bool, status: UInt8, model: String, prompt: String, promptLineCount: UInt8, promptCursorLine: UInt16, promptCursorCol: UInt16, promptVimMode: UInt8, promptVisibleRows: UInt8, promptCompletion: Wire.PromptCompletion?, helpVisible: Bool, helpGroups: [HelpGroup], rawMessages: [Wire.ChatMessage]) {
         self.visible = visible
         self.status = status
         self.model = model
@@ -103,7 +97,6 @@ final class AgentChatState {
         self.promptVisibleRows = promptVisibleRows
         self.promptCompletion = promptCompletion
         self.promptVersion += 1
-        self.pendingApproval = pendingToolName.map { PendingApproval(toolName: $0, summary: pendingToolSummary) }
         self.helpVisible = helpVisible
         self.helpGroups = helpGroups
         self.messages = rawMessages.map { msg in

--- a/macos/Sources/Views/AgentChatState.swift
+++ b/macos/Sources/Views/AgentChatState.swift
@@ -11,7 +11,7 @@ enum ChatMessageEntry: Identifiable {
     case thinking(id: Int, text: String, collapsed: Bool)
     case toolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, durationMs: UInt32, result: String)
     case styledToolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, durationMs: UInt32, resultLines: [[Wire.StyledTextRun]])
-    case approvalToolCall(id: Int, name: String, summary: String, toolCallId: String, previewKind: UInt8, previewLines: [String])
+    case approvalToolCall(id: Int, name: String, summary: String, previewKind: UInt8, previewLines: [String])
     case system(id: Int, text: String, isError: Bool)
     case usage(id: Int, input: UInt32, output: UInt32, cacheRead: UInt32, cacheWrite: UInt32, costMicros: UInt32)
 
@@ -21,7 +21,7 @@ enum ChatMessageEntry: Identifiable {
              .thinking(let id, _, _),
              .toolCall(let id, _, _, _, _, _, _, _),
              .styledToolCall(let id, _, _, _, _, _, _, _),
-             .approvalToolCall(let id, _, _, _, _, _),
+             .approvalToolCall(let id, _, _, _, _),
              .system(let id, _, _),
              .usage(let id, _, _, _, _, _):
             return id
@@ -121,8 +121,8 @@ final class AgentChatState {
                 return .toolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, durationMs: duration, result: result)
             case .styledToolCall(let name, let summary, let st, let isError, let collapsed, let duration, let resultLines):
                 return .styledToolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, durationMs: duration, resultLines: resultLines)
-            case .approvalToolCall(let name, let summary, let toolCallId, let previewKind, let previewLines):
-                return .approvalToolCall(id: id, name: name, summary: summary, toolCallId: toolCallId, previewKind: previewKind, previewLines: previewLines)
+            case .approvalToolCall(let name, let summary, _, let previewKind, let previewLines):
+                return .approvalToolCall(id: id, name: name, summary: summary, previewKind: previewKind, previewLines: previewLines)
             case .system(let text, let isError):
                 return .system(id: id, text: text, isError: isError)
             case .usage(let inp, let outp, let cacheR, let cacheW, let costM):

--- a/macos/Sources/Views/AgentChatState.swift
+++ b/macos/Sources/Views/AgentChatState.swift
@@ -11,6 +11,7 @@ enum ChatMessageEntry: Identifiable {
     case thinking(id: Int, text: String, collapsed: Bool)
     case toolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, durationMs: UInt32, result: String)
     case styledToolCall(id: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, durationMs: UInt32, resultLines: [[Wire.StyledTextRun]])
+    case approvalToolCall(id: Int, name: String, summary: String, toolCallId: String, previewKind: UInt8, previewLines: [String])
     case system(id: Int, text: String, isError: Bool)
     case usage(id: Int, input: UInt32, output: UInt32, cacheRead: UInt32, cacheWrite: UInt32, costMicros: UInt32)
 
@@ -20,6 +21,7 @@ enum ChatMessageEntry: Identifiable {
              .thinking(let id, _, _),
              .toolCall(let id, _, _, _, _, _, _, _),
              .styledToolCall(let id, _, _, _, _, _, _, _),
+             .approvalToolCall(let id, _, _, _, _, _),
              .system(let id, _, _),
              .usage(let id, _, _, _, _, _):
             return id
@@ -119,6 +121,8 @@ final class AgentChatState {
                 return .toolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, durationMs: duration, result: result)
             case .styledToolCall(let name, let summary, let st, let isError, let collapsed, let duration, let resultLines):
                 return .styledToolCall(id: id, name: name, summary: summary, status: st, isError: isError, collapsed: collapsed, durationMs: duration, resultLines: resultLines)
+            case .approvalToolCall(let name, let summary, let toolCallId, let previewKind, let previewLines):
+                return .approvalToolCall(id: id, name: name, summary: summary, toolCallId: toolCallId, previewKind: previewKind, previewLines: previewLines)
             case .system(let text, let isError):
                 return .system(id: id, text: text, isError: isError)
             case .usage(let inp, let outp, let cacheR, let cacheW, let costM):

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -204,7 +204,7 @@ struct AgentChatView: View {
             toolCallCard(messageIndex: id, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, durationMs: duration, result: result, resultLines: nil)
         case .styledToolCall(let id, let name, let summary, let status, let isError, let collapsed, let duration, let resultLines):
             toolCallCard(messageIndex: id, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, durationMs: duration, result: nil, resultLines: resultLines)
-        case .approvalToolCall(_, let name, let summary, _, let previewKind, let previewLines):
+        case .approvalToolCall(_, let name, let summary, let previewKind, let previewLines):
             approvalToolCallCard(name: name, summary: summary, previewKind: previewKind, previewLines: previewLines)
         case .system(_, let text, let isError):
             systemMessage(text, isError: isError)
@@ -469,70 +469,108 @@ struct AgentChatView: View {
 
     @ViewBuilder
     private func approvalToolCallCard(name: String, summary: String, previewKind: UInt8, previewLines: [String]) -> some View {
+        let visiblePreviewLines = Array(previewLines.prefix(8))
+
         VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 8) {
-                Image(systemName: "exclamationmark.shield")
-                    .font(.system(size: 13))
-                    .foregroundStyle(Color.orange)
-
-                Text("Approval required")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(theme.agentTextFg)
-
-                Text(name)
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(theme.agentToolHeader)
-
-                Spacer()
-            }
+            approvalToolCallHeader(name: name)
 
             if !summary.isEmpty {
-                Text("\(approvalPreviewLabel(previewKind)): \(summary)")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(theme.agentTextFg.opacity(0.75))
-                    .lineLimit(2)
+                approvalToolCallSummary(summary: summary, previewKind: previewKind)
             }
 
-            if !previewLines.isEmpty {
-                VStack(alignment: .leading, spacing: 2) {
-                    ForEach(Array(previewLines.prefix(8).enumerated()), id: \.offset) { _, line in
-                        Text(line)
-                            .font(.system(size: 10, design: .monospaced))
-                            .foregroundStyle(theme.agentTextFg.opacity(0.65))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-                }
-                .padding(8)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(RoundedRectangle(cornerRadius: 6).fill(theme.agentCodeBg.opacity(0.8)))
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(theme.agentCodeBorder.opacity(0.35), lineWidth: 1))
+            if !visiblePreviewLines.isEmpty {
+                approvalPreviewLines(visiblePreviewLines)
             }
 
-            HStack(spacing: 8) {
-                Button("Approve") {
-                    encoder?.sendKeyPress(codepoint: 0x79, modifiers: 0)
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-
-                Button("Deny") {
-                    encoder?.sendKeyPress(codepoint: 0x6E, modifiers: 0)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-
-                Button("Approve all") {
-                    encoder?.sendKeyPress(codepoint: 0x59, modifiers: 0)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-            }
+            approvalButtons
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(RoundedRectangle(cornerRadius: 10).fill(theme.agentCodeBg.opacity(0.9)))
-        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.orange.opacity(0.5), lineWidth: 1))
+        .background(approvalCardBackground)
+        .overlay(approvalCardBorder)
+    }
+
+    private func approvalToolCallHeader(name: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.shield")
+                .font(.system(size: 13))
+                .foregroundStyle(Color.orange)
+
+            Text("Approval required")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(theme.agentTextFg)
+
+            Text(name)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(theme.agentToolHeader)
+
+            Spacer()
+        }
+    }
+
+    private func approvalToolCallSummary(summary: String, previewKind: UInt8) -> some View {
+        Text("\(approvalPreviewLabel(previewKind)): \(summary)")
+            .font(.system(size: 11, design: .monospaced))
+            .foregroundStyle(theme.agentTextFg.opacity(0.75))
+            .lineLimit(2)
+    }
+
+    private func approvalPreviewLines(_ lines: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                approvalPreviewLine(line)
+            }
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(approvalPreviewBackground)
+        .overlay(approvalPreviewBorder)
+    }
+
+    private func approvalPreviewLine(_ line: String) -> some View {
+        Text(line)
+            .font(.system(size: 10, design: .monospaced))
+            .foregroundStyle(theme.agentTextFg.opacity(0.65))
+            .lineLimit(1)
+            .truncationMode(.tail)
+    }
+
+    private var approvalButtons: some View {
+        HStack(spacing: 8) {
+            Button("Approve") {
+                encoder?.sendKeyPress(codepoint: 0x79, modifiers: 0)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+
+            Button("Deny") {
+                encoder?.sendKeyPress(codepoint: 0x6E, modifiers: 0)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+
+            Button("Approve all") {
+                encoder?.sendKeyPress(codepoint: 0x59, modifiers: 0)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
+
+    private var approvalCardBackground: some View {
+        RoundedRectangle(cornerRadius: 10).fill(theme.agentCodeBg.opacity(0.9))
+    }
+
+    private var approvalCardBorder: some View {
+        RoundedRectangle(cornerRadius: 10).stroke(Color.orange.opacity(0.5), lineWidth: 1)
+    }
+
+    private var approvalPreviewBackground: some View {
+        RoundedRectangle(cornerRadius: 6).fill(theme.agentCodeBg.opacity(0.8))
+    }
+
+    private var approvalPreviewBorder: some View {
+        RoundedRectangle(cornerRadius: 6).stroke(theme.agentCodeBorder.opacity(0.35), lineWidth: 1)
     }
 
     private func approvalPreviewLabel(_ kind: UInt8) -> String {

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -112,11 +112,6 @@ struct AgentChatView: View {
                 }
             }
 
-            // Approval banner (when tool needs user confirmation)
-            if let approval = state.pendingApproval {
-                approvalBanner(approval)
-            }
-
             // Prompt completion popup (floats above the prompt area)
             if let completion = state.promptCompletion {
                 promptCompletionPopup(completion)
@@ -209,6 +204,8 @@ struct AgentChatView: View {
             toolCallCard(messageIndex: id, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, durationMs: duration, result: result, resultLines: nil)
         case .styledToolCall(let id, let name, let summary, let status, let isError, let collapsed, let duration, let resultLines):
             toolCallCard(messageIndex: id, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, durationMs: duration, result: nil, resultLines: resultLines)
+        case .approvalToolCall(_, let name, let summary, _, let previewKind, let previewLines):
+            approvalToolCallCard(name: name, summary: summary, previewKind: previewKind, previewLines: previewLines)
         case .system(_, let text, let isError):
             systemMessage(text, isError: isError)
         case .usage(_, let input, let output, _, _, let costMicros):
@@ -470,69 +467,84 @@ struct AgentChatView: View {
         .foregroundStyle(theme.agentTextFg.opacity(0.3))
     }
 
-    // MARK: - Prompt
-
-    // MARK: - Approval banner
-
     @ViewBuilder
-    private func approvalBanner(_ approval: AgentChatState.PendingApproval) -> some View {
-        VStack(spacing: 6) {
-            Rectangle()
-                .fill(theme.agentCodeBorder.opacity(0.3))
-                .frame(height: 1)
-
-            HStack(spacing: 10) {
+    private func approvalToolCallCard(name: String, summary: String, previewKind: UInt8, previewLines: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
                 Image(systemName: "exclamationmark.shield")
-                    .font(.system(size: 14))
+                    .font(.system(size: 13))
                     .foregroundStyle(Color.orange)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Tool needs approval")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(theme.agentTextFg)
+                Text("Approval required")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(theme.agentTextFg)
 
-                    HStack(spacing: 4) {
-                        Text(approval.toolName)
-                            .font(.system(size: 11, weight: .medium, design: .monospaced))
-                            .foregroundStyle(theme.agentToolHeader)
-
-                        if !approval.summary.isEmpty {
-                            Text(approval.summary)
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundStyle(theme.agentTextFg.opacity(0.6))
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                        }
-                    }
-                }
+                Text(name)
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(theme.agentToolHeader)
 
                 Spacer()
-
-                Text("y")
-                    .font(.system(size: 11, weight: .bold, design: .monospaced))
-                    .foregroundStyle(Color.green)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(RoundedRectangle(cornerRadius: 4).fill(Color.green.opacity(0.1)))
-                Text("approve")
-                    .font(.system(size: 10))
-                    .foregroundStyle(theme.agentTextFg.opacity(0.5))
-
-                Text("n")
-                    .font(.system(size: 11, weight: .bold, design: .monospaced))
-                    .foregroundStyle(Color.red)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(RoundedRectangle(cornerRadius: 4).fill(Color.red.opacity(0.1)))
-                Text("reject")
-                    .font(.system(size: 10))
-                    .foregroundStyle(theme.agentTextFg.opacity(0.5))
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
-            .background(Color.orange.opacity(0.05))
+
+            if !summary.isEmpty {
+                Text("\(approvalPreviewLabel(previewKind)): \(summary)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(theme.agentTextFg.opacity(0.75))
+                    .lineLimit(2)
+            }
+
+            if !previewLines.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(previewLines.prefix(8).enumerated()), id: \.offset) { _, line in
+                        Text(line)
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundStyle(theme.agentTextFg.opacity(0.65))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(RoundedRectangle(cornerRadius: 6).fill(theme.agentCodeBg.opacity(0.8)))
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(theme.agentCodeBorder.opacity(0.35), lineWidth: 1))
+            }
+
+            HStack(spacing: 8) {
+                Button("Approve") {
+                    encoder?.sendKeyPress(codepoint: 0x79, modifiers: 0)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+
+                Button("Deny") {
+                    encoder?.sendKeyPress(codepoint: 0x6E, modifiers: 0)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button("Approve all") {
+                    encoder?.sendKeyPress(codepoint: 0x59, modifiers: 0)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 10).fill(theme.agentCodeBg.opacity(0.9)))
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.orange.opacity(0.5), lineWidth: 1))
+    }
+
+    private func approvalPreviewLabel(_ kind: UInt8) -> String {
+        switch kind {
+        case 1: return "Diff"
+        case 2: return "Command"
+        case 3: return "Target"
+        default: return "Args"
         }
     }
+
+    // MARK: - Prompt
 
     // MARK: - Prompt area
 

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -334,6 +334,13 @@ func chatMessageToJSON(_ msg: Wire.ChatMessage) -> [String: Any] {
         result["kind"] = "styled_tool_call"; result["name"] = name; result["summary"] = summary
         result["status"] = Int(status); result["is_error"] = isError; result["collapsed"] = collapsed
         result["duration_ms"] = Int(durationMs); result["result_lines"] = linesJSON
+    case .approvalToolCall(let name, let summary, let toolCallId, let previewKind, let previewLines):
+        result["kind"] = "approval_tool_call"
+        result["name"] = name
+        result["summary"] = summary
+        result["tool_call_id"] = toolCallId
+        result["preview_kind"] = Int(previewKind)
+        result["preview_lines"] = previewLines
     case .system(let text, let isError):
         result["kind"] = "system"; result["text"] = text; result["is_error"] = isError
     case .usage(let input, let output, let cacheRead, let cacheWrite, let costMicros):

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -1165,6 +1165,32 @@ struct GUIAgentChatDecoderTests {
         #expect(tcResult == "file contents here")
     }
 
+    @Test("Decode gui_agent_chat with inline approval tool call (sectioned)")
+    func decodeApprovalToolCall() throws {
+        var msgs = Data()
+        appendU32(&msgs, 9)
+        msgs.append(0x09) // approval_tool_call
+        msgs.append(0) // status placeholder
+        appendString16(&msgs, "write_file")
+        appendString16(&msgs, "config.toml")
+        appendString16(&msgs, "tc_1")
+        msgs.append(3) // target preview
+        appendU16(&msgs, 2)
+        appendString16(&msgs, "file: config.toml")
+        appendString16(&msgs, "1 edit(s)")
+
+        let data = buildChatData(status: 2, model: "claude", messages: buildMessagesPayload(count: 1, msgs))
+        let (cmd, _) = try decodeCommand(data: data, offset: 0)
+        guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
+        guard messages.count == 1 else { Issue.record("Expected 1 message"); return }
+        guard case .approvalToolCall(let name, let summary, let toolCallId, let previewKind, let previewLines) = messages[0].content else { Issue.record("Expected .approvalToolCall"); return }
+        #expect(name == "write_file")
+        #expect(summary == "config.toml")
+        #expect(toolCallId == "tc_1")
+        #expect(previewKind == 3)
+        #expect(previewLines == ["file: config.toml", "1 edit(s)"])
+    }
+
     @Test("Decode gui_agent_chat with system message (sectioned)")
     func decodeSystem() throws {
         var msgs = Data()

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -295,17 +295,13 @@ struct AgentChatStateLifecycleTests {
         state.update(visible: true, status: 1, model: "claude", prompt: "fix bug",
                      promptLineCount: 1, promptCursorLine: 0, promptCursorCol: 0,
                      promptVimMode: 1, promptVisibleRows: 1,
-                     promptCompletion: nil, pendingToolName: "write_file",
-                     pendingToolSummary: "Writing config.toml",
-                     helpVisible: false, helpGroups: [],
+                     promptCompletion: nil, helpVisible: false, helpGroups: [],
                      rawMessages: raw)
 
         #expect(state.visible == true)
         #expect(state.status == 1)
         #expect(state.model == "claude")
         #expect(state.prompt == "fix bug")
-        #expect(state.pendingApproval?.toolName == "write_file")
-        #expect(state.pendingApproval?.summary == "Writing config.toml")
         #expect(state.messages.count == 6)
         #expect(state.isThinking == true)
         #expect(state.statusLabel == "thinking")
@@ -317,8 +313,7 @@ struct AgentChatStateLifecycleTests {
         state.update(visible: true, status: 1, model: "claude", prompt: "test",
                      promptLineCount: 1, promptCursorLine: 0, promptCursorCol: 0,
                      promptVimMode: 1, promptVisibleRows: 1,
-                     promptCompletion: nil, pendingToolName: nil, pendingToolSummary: "",
-                     helpVisible: false, helpGroups: [],
+                     promptCompletion: nil, helpVisible: false, helpGroups: [],
                      rawMessages: [Wire.ChatMessage(beamId: 1, content: .user(text: "hi"))])
         state.hide()
 

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -751,6 +751,23 @@ defmodule MingaAgent.SessionTest do
       assert Enum.any?(messages, &match?({:system, "Denied shell" <> _, :info}, &1))
     end
 
+    test "respond_to_approval with :approve_all sends approve_all", %{session: session} do
+      approval = %Event.ToolApproval{
+        tool_call_id: "tc1",
+        name: "shell",
+        args: %{},
+        reply_to: self()
+      }
+
+      send(session, {:agent_provider_event, approval})
+      assert_receive {:agent_event, _, {:approval_pending, _}}, 200
+
+      :ok = Session.respond_to_approval(session, :approve_all)
+      assert_receive {:tool_approval_response, "tc1", :approve_all}
+      assert_receive {:agent_event, _, {:approval_resolved, :approve_all}}, 200
+      assert {:error, :no_pending_approval} = Session.respond_to_approval(session, :approve)
+    end
+
     test "respond_to_approval with no pending returns error", %{session: session} do
       assert {:error, :no_pending_approval} = Session.respond_to_approval(session, :approve)
     end

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -708,6 +708,9 @@ defmodule MingaAgent.SessionTest do
       assert_receive {:agent_event, _, {:approval_pending, data}}, 200
       assert data.name == "shell"
       assert data.tool_call_id == "tc1"
+      assert data.preview.kind == :command
+      assert data.preview.summary == "rm -rf /"
+      refute Map.has_key?(data, :reply_to)
     end
 
     test "respond_to_approval sends decision to reply_to pid", %{session: session} do
@@ -743,6 +746,9 @@ defmodule MingaAgent.SessionTest do
 
       :ok = Session.respond_to_approval(session, :reject)
       assert_receive {:tool_approval_response, "tc1", :reject}
+
+      messages = Session.messages(session)
+      assert Enum.any?(messages, &match?({:system, "Denied shell" <> _, :info}, &1))
     end
 
     test "respond_to_approval with no pending returns error", %{session: session} do

--- a/test/minga_agent/tool_approval_test.exs
+++ b/test/minga_agent/tool_approval_test.exs
@@ -1,0 +1,34 @@
+defmodule MingaAgent.ToolApprovalTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.ToolApproval
+
+  describe "build_preview/2" do
+    test "builds command preview for shell tools" do
+      preview = ToolApproval.build_preview("shell", %{"command" => "rm -rf tmp/build"})
+
+      assert preview.kind == :command
+      assert preview.summary == "rm -rf tmp/build"
+      assert "$ rm -rf tmp/build" in preview.lines
+    end
+
+    test "builds diff preview for write_file tools" do
+      path =
+        Path.join(
+          System.tmp_dir!(),
+          "minga-approval-preview-#{System.unique_integer([:positive])}.txt"
+        )
+
+      File.write!(path, "old\n")
+
+      preview = ToolApproval.build_preview("write_file", %{"path" => path, "content" => "new\n"})
+
+      assert preview.kind == :diff
+      assert preview.summary == path
+      assert "-old" in preview.lines
+      assert "+new" in preview.lines
+
+      File.rm(path)
+    end
+  end
+end

--- a/test/minga_agent/tool_approval_test.exs
+++ b/test/minga_agent/tool_approval_test.exs
@@ -20,6 +20,7 @@ defmodule MingaAgent.ToolApprovalTest do
         )
 
       File.write!(path, "old\n")
+      on_exit(fn -> File.rm(path) end)
 
       preview = ToolApproval.build_preview("write_file", %{"path" => path, "content" => "new\n"})
 
@@ -27,8 +28,70 @@ defmodule MingaAgent.ToolApprovalTest do
       assert preview.summary == path
       assert "-old" in preview.lines
       assert "+new" in preview.lines
+    end
 
-      File.rm(path)
+    test "keeps blank-line-only write_file diffs visible" do
+      path =
+        Path.join(
+          System.tmp_dir!(),
+          "minga-approval-preview-#{System.unique_integer([:positive])}.txt"
+        )
+
+      File.write!(path, "old")
+      on_exit(fn -> File.rm(path) end)
+
+      preview = ToolApproval.build_preview("write_file", %{"path" => path, "content" => "old\n"})
+
+      assert "+" in preview.lines
+      refute "No textual changes detected" in preview.lines
+    end
+
+    test "truncates oversized preview lines" do
+      preview = ToolApproval.build_preview("shell", %{"command" => String.duplicate("x", 1_000)})
+
+      assert Enum.all?(preview.lines, &(String.length(&1) <= 300))
+    end
+
+    test "builds target preview for edit_file tools" do
+      preview =
+        ToolApproval.build_preview("edit_file", %{
+          "path" => "lib/a.ex",
+          "old_text" => "old",
+          "new_text" => "new"
+        })
+
+      assert preview.kind == :target
+      assert preview.summary == "lib/a.ex"
+      assert "file: lib/a.ex" in preview.lines
+      assert ~s(replace "old" with "new") in preview.lines
+    end
+
+    test "builds edit-count preview for multi_edit_file tools" do
+      preview =
+        ToolApproval.build_preview("multi_edit_file", %{
+          "path" => "lib/a.ex",
+          "edits" => [%{}, %{}]
+        })
+
+      assert preview.kind == :target
+      assert preview.summary == "lib/a.ex"
+      assert "2 edit(s)" in preview.lines
+    end
+
+    test "builds target preview for git_stage tools" do
+      preview = ToolApproval.build_preview("git_stage", %{"paths" => ["lib/a.ex", "mix.exs"]})
+
+      assert preview.kind == :target
+      assert preview.summary == "lib/a.ex, mix.exs"
+      assert "paths: lib/a.ex, mix.exs" in preview.lines
+    end
+
+    test "builds commit-message preview for git_commit tools" do
+      preview = ToolApproval.build_preview("git_commit", %{"message" => "fix approval flow"})
+
+      assert preview.kind == :target
+      assert preview.summary == "fix approval flow"
+      assert "commit message: fix approval flow" in preview.lines
     end
   end
 end

--- a/test/minga_editor/agent/chat_decorations_test.exs
+++ b/test/minga_editor/agent/chat_decorations_test.exs
@@ -123,6 +123,47 @@ defmodule MingaEditor.Agent.ChatDecorationsTest do
       assert rendered_text =~ "[Y]"
     end
 
+    test "tool call awaiting approval renders preview content" do
+      tc = %MingaAgent.ToolCall{
+        id: "tc_123",
+        name: "write_file",
+        status: :running,
+        result: "",
+        collapsed: false
+      }
+
+      decs = Decorations.new()
+      messages = [{:tool_call, tc}]
+      offsets = [{0, 0, 1}]
+
+      pending_approval = %{
+        tool_call_id: "tc_123",
+        name: "write_file",
+        args: %{},
+        preview:
+          MingaAgent.ToolApproval.Preview.new(:diff, "config.toml", [
+            "file: config.toml",
+            "-old",
+            "+new"
+          ])
+      }
+
+      result =
+        ChatDecorations.build_decorations(decs, messages, offsets, test_theme(),
+          pending_approval: pending_approval
+        )
+
+      {_above, below} = Decorations.blocks_for_line(result, 0)
+      [block_dec] = below
+      rendered = block_dec.render.(80)
+      rendered_text = Enum.map_join(rendered, "", fn {text, _style} -> text end)
+
+      assert rendered_text =~ "Approval required"
+      assert rendered_text =~ "config.toml"
+      assert rendered_text =~ "-old"
+      assert rendered_text =~ "+new"
+    end
+
     test "tool call without matching approval shows normal header" do
       tc = %MingaAgent.ToolCall{
         id: "tc_456",

--- a/test/minga_editor/agent/chat_decorations_test.exs
+++ b/test/minga_editor/agent/chat_decorations_test.exs
@@ -90,7 +90,7 @@ defmodule MingaEditor.Agent.ChatDecorationsTest do
       refute Decorations.has_fold_regions?(result)
     end
 
-    test "tool call awaiting approval shows approval prompt in header" do
+    test "tool call awaiting approval shows inline approval card" do
       tc = %MingaAgent.ToolCall{
         id: "tc_123",
         name: "write_file",
@@ -110,18 +110,17 @@ defmodule MingaEditor.Agent.ChatDecorationsTest do
           pending_approval: pending_approval
         )
 
-      # Header block decoration should contain approval prompt text
-      {above, _below} = Decorations.blocks_for_line(result, 0)
-      assert length(above) == 1
+      {_above, below} = Decorations.blocks_for_line(result, 0)
+      assert length(below) == 1
 
-      [block_dec] = above
+      [block_dec] = below
       rendered = block_dec.render.(80)
 
-      # The rendered output should contain the approval prompt segments
       rendered_text = Enum.map_join(rendered, "", fn {text, _style} -> text end)
-      assert rendered_text =~ "Approve?"
+      assert rendered_text =~ "Approval required"
       assert rendered_text =~ "[y]"
       assert rendered_text =~ "[n]"
+      assert rendered_text =~ "[Y]"
     end
 
     test "tool call without matching approval shows normal header" do

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -3,6 +3,21 @@ defmodule MingaEditor.Frontend.ProtocolTest do
 
   alias MingaEditor.Frontend.Protocol
 
+  defp gui_agent_chat_section!(sections, target_id),
+    do: do_gui_agent_chat_section!(sections, target_id)
+
+  defp do_gui_agent_chat_section!(
+         <<target_id::8, len::16, payload::binary-size(len), _rest::binary>>,
+         target_id
+       ),
+       do: payload
+
+  defp do_gui_agent_chat_section!(
+         <<_id::8, len::16, _payload::binary-size(len), rest::binary>>,
+         target_id
+       ),
+       do: do_gui_agent_chat_section!(rest, target_id)
+
   # ── Modifier helpers ──
 
   describe "modifier flags" do
@@ -1203,7 +1218,8 @@ defmodule MingaEditor.Frontend.ProtocolTest do
 
       approval = %{
         tool_call_id: "tc_1",
-        preview: %{kind: :target, summary: "demo.ex", lines: ["file: demo.ex", "1 edit(s)"]}
+        preview:
+          MingaAgent.ToolApproval.Preview.new(:target, "demo.ex", ["file: demo.ex", "1 edit(s)"])
       }
 
       data = %{
@@ -1217,11 +1233,23 @@ defmodule MingaEditor.Frontend.ProtocolTest do
 
       encoded = ProtocolGUI.encode_gui_agent_chat(data)
 
-      assert <<0x78, 7, _sections::binary>> = encoded
-      assert :binary.match(encoded, <<0x09>>) != :nomatch
-      assert :binary.match(encoded, "write_file") != :nomatch
-      assert :binary.match(encoded, "demo.ex") != :nomatch
-      assert :binary.match(encoded, "1 edit(s)") != :nomatch
+      assert <<0x78, 7, sections::binary>> = encoded
+      messages_payload = gui_agent_chat_section!(sections, 0x06)
+
+      assert <<1::16, 0::32, 0x09::8, 0::8, name_len::16, rest::binary>> = messages_payload
+      assert <<name::binary-size(name_len), summary_len::16, rest::binary>> = rest
+      assert <<summary::binary-size(summary_len), id_len::16, rest::binary>> = rest
+
+      assert <<tool_call_id::binary-size(id_len), 3::8, 2::16, line1_len::16, rest::binary>> =
+               rest
+
+      assert <<line1::binary-size(line1_len), line2_len::16, rest::binary>> = rest
+      assert <<line2::binary-size(line2_len)>> = rest
+      assert name == "write_file"
+      assert summary == "demo.ex"
+      assert tool_call_id == "tc_1"
+      assert line1 == "file: demo.ex"
+      assert line2 == "1 edit(s)"
     end
 
     test "encodes styled_assistant message with styled runs" do

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -1198,6 +1198,32 @@ defmodule MingaEditor.Frontend.ProtocolTest do
       assert <<0x78, 0::8>> = encoded
     end
 
+    test "encodes inline approval tool call message" do
+      tc = MingaAgent.ToolCall.new("tc_1", "write_file", %{"path" => "demo.ex"})
+
+      approval = %{
+        tool_call_id: "tc_1",
+        preview: %{kind: :target, summary: "demo.ex", lines: ["file: demo.ex", "1 edit(s)"]}
+      }
+
+      data = %{
+        visible: true,
+        messages: [{:approval_tool_call, tc, approval}],
+        status: :thinking,
+        model: "claude",
+        prompt: "",
+        pending_approval: nil
+      }
+
+      encoded = ProtocolGUI.encode_gui_agent_chat(data)
+
+      assert <<0x78, 7, _sections::binary>> = encoded
+      assert :binary.match(encoded, <<0x09>>) != :nomatch
+      assert :binary.match(encoded, "write_file") != :nomatch
+      assert :binary.match(encoded, "demo.ex") != :nomatch
+      assert :binary.match(encoded, "1 edit(s)") != :nomatch
+    end
+
     test "encodes styled_assistant message with styled runs" do
       styled_lines = [
         [{"def ", 0xFF0000, 0, 1}, {"hello", 0xBBC2CF, 0, 0}],

--- a/test/minga_editor/input/sub_state_handlers_test.exs
+++ b/test/minga_editor/input/sub_state_handlers_test.exs
@@ -146,6 +146,11 @@ defmodule MingaEditor.Input.SubStateHandlersTest do
       {:handled, _} = ToolApproval.handle_key(state, ?n, 0)
     end
 
+    test "handles uppercase Y as approve all when approval is pending", %{approval: approval} do
+      state = base_state(keymap_scope: :agent, agentic_active: true, pending_approval: approval)
+      {:handled, _} = ToolApproval.handle_key(state, ?Y, 0)
+    end
+
     test "swallows unrelated keys when approval is pending", %{approval: approval} do
       state = base_state(keymap_scope: :agent, agentic_active: true, pending_approval: approval)
       {:handled, new_state} = ToolApproval.handle_key(state, ?x, 0)


### PR DESCRIPTION
## Summary
- Replaces notification-only destructive tool approval with inline approval cards in agent chat.
- Adds structured approval previews for shell commands, file writes, edit targets, git stage, and commits.
- Wires keyboard `y`, `n`, `Y` and macOS inline buttons to approve, deny, and approve all.
- Keeps existing approval notifications while surfacing denied tools back into the chat transcript.

## Tests
- `make lint`
- `mix test.llm`
- `xcodebuild test -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS' -skipPackagePluginValidation`

Closes #1409
