### PR TITLE
perf(render): reduce dirty-row render latency

### DIFF
--- a/autoresearch.checks.sh
+++ b/autoresearch.checks.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export MIX_ENV=test
+mix compile --warnings-as-errors >/dev/null
+mix test.llm test/minga/telemetry_test.exs test/minga/telemetry/integration_test.exs test/minga_editor/render_pipeline_test.exs >/tmp/minga-autoresearch-checks.log 2>&1 || { tail -80 /tmp/minga-autoresearch-checks.log; exit 1; }

--- a/autoresearch.checks.sh
+++ b/autoresearch.checks.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-./autoresearch.sh >/tmp/minga-swift-render-bench-check.log
-mix swift.harness >/tmp/minga-swift-harness-check.log 2>&1 || { tail -80 /tmp/minga-swift-harness-check.log; exit 1; }
+./autoresearch.sh >/tmp/minga-tree-sitter-highlight-bench-check.log
+mix zig.lint >/tmp/minga-zig-lint-check.log 2>&1 || { tail -80 /tmp/minga-zig-lint-check.log; exit 1; }

--- a/autoresearch.checks.sh
+++ b/autoresearch.checks.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-export MIX_ENV=test
-mix compile --warnings-as-errors >/dev/null
-mix test.llm test/minga/telemetry_test.exs test/minga/telemetry/integration_test.exs test/minga_editor/render_pipeline_test.exs >/tmp/minga-autoresearch-checks.log 2>&1 || { tail -80 /tmp/minga-autoresearch-checks.log; exit 1; }
+./autoresearch.sh >/tmp/minga-swift-render-bench-check.log
+mix swift.harness >/tmp/minga-swift-harness-check.log 2>&1 || { tail -80 /tmp/minga-swift-harness-check.log; exit 1; }

--- a/autoresearch.checks.sh
+++ b/autoresearch.checks.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-./autoresearch.sh >/tmp/minga-tree-sitter-highlight-bench-check.log
-mix zig.lint >/tmp/minga-zig-lint-check.log 2>&1 || { tail -80 /tmp/minga-zig-lint-check.log; exit 1; }
+MIX_ENV=test mix test.llm test/minga_editor/render_pipeline test/minga_editor/frontend test/minga_editor/shell 2>/tmp/minga-render-check.err || { cat /tmp/minga-render-check.err; exit 1; }

--- a/autoresearch.md
+++ b/autoresearch.md
@@ -1,35 +1,36 @@
-# Autoresearch: keystroke latency
+# Autoresearch: Swift rendering speed
 
 ## Objective
-Make Minga feel as snappy as Neovim by reducing the measured headless keystroke-to-render latency for a realistic editing workload. The benchmark starts a headless editor on a 2,000-line Elixir-like buffer, warms up normal-mode motion and insert-mode typing, then measures 120 insert-mode keystrokes across 5 fresh editor runs.
+Make the macOS GUI frontend feel as snappy as the headless BEAM path by reducing the measured Swift semantic window rendering cost for a realistic editing workload. The benchmark renders 80 visible semantic rows through `WindowContentRenderer` and `LineTextureAtlas`, warms the row texture cache, then measures 220 frame-style updates where one row changes and the rest are cache hits.
 
 ## Metrics
-- **Primary**: `key_latency_us` (µs, lower is better) — median insert-mode keypress wall time from sending the key event to receiving the rendered frame.
-- **Secondary**: `insert_p95_us`, `motion_latency_us`, `input_dispatch_us`, `render_us`, `port_emit_us`, `content_stage_us`, `chrome_stage_us`, `emit_stage_us` — tradeoff and localization metrics from telemetry.
+- **Primary**: `swift_frame_us` (µs, lower is better) — median time to render one semantic frame through the Swift window-content renderer and atlas path.
+- **Secondary**: `swift_frame_p95_us`, `swift_cold_frame_us`, `swift_cache_hit_frame_us`, `swift_rows` — tradeoff and localization metrics for tail latency, cold rasterization, all-cache-hit overhead, and workload size.
 
 ## How to Run
 `./autoresearch.sh` outputs `METRIC name=value` lines.
 
 ## Files in Scope
-- `lib/minga_editor.ex` — Editor GenServer input hot path and key event routing.
-- `lib/minga_editor/input/router.ex` — focus-stack dispatch, snapshots, and post-action housekeeping.
-- `lib/minga_editor/renderer.ex` and `lib/minga_editor/renderer/server.ex` — synchronous and split render entry points.
-- `lib/minga_editor/render_pipeline*.ex` and `lib/minga_editor/render_pipeline/*.ex` — render pipeline stages and caches.
-- `lib/minga_editor/frontend/*.ex` — command emission and protocol conversion.
-- `lib/minga/buffer/server.ex`, `lib/minga/buffer/document.ex`, `lib/minga/editing/**/*.ex`, `lib/minga/mode/**/*.ex` — buffer, motion, and insert-mode hot path code when the benchmark points there.
-- `bench/key_latency_bench.exs`, `autoresearch.sh`, `autoresearch.checks.sh` — benchmark and validation harness.
+- `macos/Sources/Renderer/WindowContentRenderer.swift` — semantic row to attributed string, CoreText rasterization, texture and atlas upload path.
+- `macos/Sources/Renderer/BitmapRasterizer.swift` — pooled CoreGraphics/CoreText bitmap rasterization.
+- `macos/Sources/Renderer/LineTextureAtlas.swift`, `macos/Sources/Renderer/SlotAllocator.swift`, `macos/Sources/Renderer/CachedLineTexture.swift` — atlas allocation, cache hits, and uploads.
+- `macos/Sources/Renderer/CoreTextMetalRenderer.swift` — frame render loop that calls `WindowContentRenderer`, line instance construction, overlay quads, and Metal draw setup when benchmark work points there.
+- `macos/Sources/Font/FontFace.swift`, `macos/Sources/Font/FontManager.swift` — font lookup and per-span font selection hot paths.
+- `macos/Sources/Protocol/ProtocolDecoder.swift`, `macos/Sources/Renderer/CommandDispatcher.swift`, `macos/Sources/Renderer/WindowContent.swift` — semantic content decode and state update path when benchmark work points there.
+- `bench/swift_render_bench.swift`, `autoresearch.sh`, `autoresearch.checks.sh` — benchmark and validation harness.
 
 ## Off Limits
 - Do not change public protocol wire formats unless a benchmark result clearly requires it and tests/docs are updated in the same kept experiment.
-- Do not disable rendering, telemetry, syntax/decorations correctness, undo behavior, or input semantics to win the benchmark.
+- Do not skip rasterization, atlas upload, cache invalidation, or semantic content correctness to win the benchmark.
+- Do not make the Swift frontend interpret editor semantics; the BEAM remains the source of truth.
 - Do not add new dependencies for micro-optimizations.
-- Do not use `Process.sleep/1` in production code.
+- Do not use private AppKit, CoreText, or Metal APIs.
 
 ## Constraints
-- Primary metric decides keep/discard. Keep only lower `key_latency_us` unless a secondary metric exposes a correctness or catastrophic regression.
+- Primary metric decides keep/discard. Keep only lower `swift_frame_us` unless a secondary metric exposes a correctness or catastrophic regression.
 - `./autoresearch.checks.sh` must pass before keeping any code change.
-- Preserve user-visible behavior. Any optimization that skips needed housekeeping must be discarded even if faster.
-- Prefer structural hot-path reductions: fewer snapshots, fewer allocations, narrower invalidation, less protocol work, better cache reuse.
+- Preserve user-visible rendering behavior: text, styles, font fallback, cache invalidation, and atlas contents must remain correct.
+- Prefer structural hot-path reductions: fewer attributed-string allocations, fewer CoreText objects, better cache reuse, less atlas churn, less per-row work on cache hits.
 
 ## What's Been Tried
-- Restarted clean from `main` after prior benchmark history was invalidated by external CPU saturation. Copied only the benchmark harness and autoresearch scripts, not app-code optimizations.
+- Switched from the headless BEAM keystroke benchmark after reaching about 1.8ms p50 internally. New target focuses on macOS Swift semantic rendering.

--- a/autoresearch.md
+++ b/autoresearch.md
@@ -1,10 +1,10 @@
 # Autoresearch: tree-sitter highlight speed
 
 ## Objective
-Make syntax highlighting fast enough that parser/highlight work never shows up as editor latency. The benchmark runs the Zig `minga-parser` highlighter directly on a 2,000-line Elixir-like buffer, warms up parsing and highlight query execution, then measures repeated full parse plus `highlightWithInjections` cycles after a small source mutation.
+Make syntax highlighting fast enough that parser/highlight work never shows up as editor latency. The benchmark runs the Zig `minga-parser` highlighter directly on a 2,000-line Elixir-like buffer, warms up parsing and highlight query execution, then measures repeated incremental parse plus `highlightWithInjections` cycles after a small source mutation.
 
 ## Metrics
-- **Primary**: `ts_update_highlight_us` (µs, lower is better) — median time for parse plus highlight query execution after one source mutation.
+- **Primary**: `ts_update_highlight_us` (µs, lower is better) — median time for incremental parse plus highlight query execution after one source mutation.
 - **Secondary**: `ts_update_highlight_p95_us`, `ts_parse_us`, `ts_highlight_us`, `ts_highlight_p95_us`, `ts_span_count`, `ts_line_count` — tradeoff and localization metrics for tail latency, parse/query split, output size, and workload size.
 
 ## How to Run
@@ -27,7 +27,7 @@ Make syntax highlighting fast enough that parser/highlight work never shows up a
 - Primary metric decides keep/discard. Keep only lower `ts_update_highlight_us` unless a secondary metric exposes a correctness or catastrophic regression.
 - `./autoresearch.checks.sh` must pass before keeping any code change.
 - Preserve user-visible highlighting behavior across frontends.
-- Prefer structural hot-path reductions: fewer query cursor allocations, fewer per-match C API calls, better reuse of capture names, cheaper sorting, less allocation churn, and safe incremental parse/query improvements.
+- Prefer structural hot-path reductions: correct incremental parse usage, changed-range highlighting, fewer full-document query passes, fewer query cursor allocations, fewer per-match C API calls, better reuse of capture names, cheaper sorting, and less allocation churn.
 
 ## What's Been Tried
 - Switched from Swift semantic rendering after reducing `swift_frame_us` from roughly 266µs to 165µs. New target focuses on the Zig tree-sitter parser/highlighter shared by all frontends.

--- a/autoresearch.md
+++ b/autoresearch.md
@@ -1,33 +1,33 @@
-# Autoresearch: tree-sitter highlight speed
+# Autoresearch: render dirty-row update speed
 
 ## Objective
-Make syntax highlighting fast enough that parser/highlight work never shows up as editor latency. The benchmark runs the Zig `minga-parser` highlighter directly on a 2,000-line Elixir-like buffer, warms up parsing and highlight query execution, then measures repeated incremental parse plus `highlightWithInjections` cycles after a small source mutation in the middle of the file.
+Apply the same structural-update mentality from tree-sitter highlighting to editor rendering. The benchmark runs the headless editor on a 2,000-line buffer, sends repeated insert-mode keys, and measures end-to-end key latency plus render stage timings. Optimize for preserving previous render state and recomputing/emitting only what changed after a one-line edit, without breaking visible output.
 
 ## Metrics
-- **Primary**: `ts_update_highlight_us` (µs, lower is better) — median time for incremental parse plus highlight query execution after one source mutation.
-- **Secondary**: `ts_update_highlight_p95_us`, `ts_parse_us`, `ts_highlight_us`, `ts_highlight_p95_us`, `ts_span_count`, `ts_line_count` — tradeoff and localization metrics for tail latency, parse/query split, output size, and workload size.
+- **Primary**: `key_latency_us` (µs, lower is better) — median wall-clock time from key input to collected headless frame for insert-mode edits.
+- **Secondary**: `insert_p95_us`, `motion_latency_us`, `input_dispatch_us`, `render_us`, `port_emit_us`, `content_stage_us`, `chrome_stage_us`, `emit_stage_us` — tradeoff and localization metrics for tail latency and render/emit stages.
 
 ## How to Run
-`./autoresearch.sh` outputs `METRIC name=value` lines.
+`./autoresearch.sh` outputs `METRIC name=value` lines from `mix run bench/key_latency_bench.exs`.
 
 ## Files in Scope
-- `zig/src/highlighter.zig` — tree-sitter parsing, query execution, capture collection, predicate handling, sorting, capture-name construction, injections, folds, indents, and textobjects.
-- `zig/src/predicates.zig`, `zig/src/posix_regex.zig`, `zig/src/query_loader.zig` — predicate and query handling when profiling points there.
-- `zig/src/parser_main.zig`, `zig/src/protocol.zig`, `zig/src/port_writer.zig` — parser port protocol and response encoding when benchmark work points there.
-- `zig/src/highlight_bench.zig`, `zig/build.zig`, `autoresearch.sh`, `autoresearch.checks.sh` — benchmark and validation harness.
-- `zig/src/queries/**/*.scm` — highlight query shape, only when correctness is preserved and language behavior remains intended.
+- `lib/minga_editor/render_pipeline/**/*.ex`, `lib/minga_editor/render_pipeline.ex` — invalidation, content, chrome, compose, emit, render cache, and frame assembly.
+- `lib/minga_editor/window*.ex`, `lib/minga_editor/workspace/**/*.ex`, `lib/minga_editor/shell/**/*.ex` — dirty state, window render cache, shell frame/layer assembly, and update ownership.
+- `lib/minga_editor/frontend/**/*.ex`, `lib/minga/parser/**/*.ex`, `lib/minga/port/**/*.ex` — protocol/emit paths only when benchmark evidence points there.
+- `bench/key_latency_bench.exs`, `autoresearch.sh`, `autoresearch.checks.sh` — benchmark and validation harness.
 
 ## Off Limits
-- Do not skip parsing, query execution, predicate evaluation, sorting, injection handling, or capture-name output to win the benchmark.
-- Do not remove captures or weaken highlight correctness unless tests and intended behavior are updated in the same kept experiment.
-- Do not change public parser port protocol wire formats unless benchmark evidence clearly requires it and Elixir/Swift/Zig protocol tests are updated.
-- Do not add new dependencies for micro-optimizations.
+- Do not skip rendering required visible changes to win the benchmark.
+- Do not change user-visible output semantics unless tests/snapshots are updated intentionally.
+- Do not weaken HeadlessPort/test frame contracts unless a dedicated compatibility path preserves existing tests.
+- Do not hardcode benchmark dimensions, document contents, or key sequences in production code.
 
 ## Constraints
-- Primary metric decides keep/discard. Keep only lower `ts_update_highlight_us` unless a secondary metric exposes a correctness or catastrophic regression.
+- Primary metric decides keep/discard. Keep only lower `key_latency_us` unless a secondary metric exposes a correctness or catastrophic regression.
 - `./autoresearch.checks.sh` must pass before keeping any code change.
-- Preserve user-visible highlighting behavior across frontends.
-- Prefer structural hot-path reductions: correct incremental parse usage, changed-range highlighting, fewer full-document query passes, fewer query cursor allocations, fewer per-match C API calls, better reuse of capture names, cheaper sorting, and less allocation churn.
+- Preserve GUI-first architecture and TUI/headless compatibility.
+- Prefer structural update reductions: dirty-row caches, per-window render cache reuse, chrome fingerprinting, delta emit, avoiding full command-list/frame rebuilds, and incremental splicing over full recomputation.
 
 ## What's Been Tried
-- Switched from Swift semantic rendering after reducing `swift_frame_us` from roughly 266µs to 165µs. New target focuses on the Zig tree-sitter parser/highlighter shared by all frontends.
+- Earlier render autoresearch kept several micro-optimizations: direct TUI full-frame layer emit, render-cache dirty checks, and no-wrap single-row inlining. Those helped but were edge trimming.
+- Tree-sitter structural autoresearch showed the intended pattern: incremental parse plus changed-range highlight caching cut update latency by an order of magnitude. Apply that mindset here.

--- a/autoresearch.md
+++ b/autoresearch.md
@@ -4,8 +4,8 @@
 Apply the same structural-update mentality from tree-sitter highlighting to editor rendering. The benchmark runs the headless editor on a 2,000-line buffer, sends repeated insert-mode keys, and measures end-to-end key latency plus render stage timings. Optimize for preserving previous render state and recomputing/emitting only what changed after a one-line edit, without breaking visible output.
 
 ## Metrics
-- **Primary**: `key_latency_us` (µs, lower is better) — median wall-clock time from key input to collected headless frame for insert-mode edits.
-- **Secondary**: `insert_p95_us`, `motion_latency_us`, `input_dispatch_us`, `render_us`, `port_emit_us`, `content_stage_us`, `chrome_stage_us`, `emit_stage_us` — tradeoff and localization metrics for tail latency and render/emit stages.
+- **Primary**: `render_us` (µs, lower is better) — median render pipeline duration for insert-mode edits.
+- **Secondary**: `key_latency_us`, `insert_p95_us`, `motion_latency_us`, `input_dispatch_us`, `port_emit_us`, `content_stage_us`, `chrome_stage_us`, `emit_stage_us` — tradeoff and localization metrics for end-to-end latency and render/emit stages.
 
 ## How to Run
 `./autoresearch.sh` outputs `METRIC name=value` lines from `mix run bench/key_latency_bench.exs`.
@@ -23,7 +23,7 @@ Apply the same structural-update mentality from tree-sitter highlighting to edit
 - Do not hardcode benchmark dimensions, document contents, or key sequences in production code.
 
 ## Constraints
-- Primary metric decides keep/discard. Keep only lower `key_latency_us` unless a secondary metric exposes a correctness or catastrophic regression.
+- Primary metric decides keep/discard. Keep only lower `render_us` unless a secondary metric exposes a correctness or catastrophic regression.
 - `./autoresearch.checks.sh` must pass before keeping any code change.
 - Preserve GUI-first architecture and TUI/headless compatibility.
 - Prefer structural update reductions: dirty-row caches, per-window render cache reuse, chrome fingerprinting, delta emit, avoiding full command-list/frame rebuilds, and incremental splicing over full recomputation.

--- a/autoresearch.md
+++ b/autoresearch.md
@@ -1,7 +1,7 @@
 # Autoresearch: tree-sitter highlight speed
 
 ## Objective
-Make syntax highlighting fast enough that parser/highlight work never shows up as editor latency. The benchmark runs the Zig `minga-parser` highlighter directly on a 2,000-line Elixir-like buffer, warms up parsing and highlight query execution, then measures repeated incremental parse plus `highlightWithInjections` cycles after a small source mutation.
+Make syntax highlighting fast enough that parser/highlight work never shows up as editor latency. The benchmark runs the Zig `minga-parser` highlighter directly on a 2,000-line Elixir-like buffer, warms up parsing and highlight query execution, then measures repeated incremental parse plus `highlightWithInjections` cycles after a small source mutation in the middle of the file.
 
 ## Metrics
 - **Primary**: `ts_update_highlight_us` (µs, lower is better) — median time for incremental parse plus highlight query execution after one source mutation.

--- a/autoresearch.md
+++ b/autoresearch.md
@@ -1,0 +1,35 @@
+# Autoresearch: keystroke latency
+
+## Objective
+Make Minga feel as snappy as Neovim by reducing the measured headless keystroke-to-render latency for a realistic editing workload. The benchmark starts a headless editor on a 2,000-line Elixir-like buffer, warms up normal-mode motion and insert-mode typing, then measures 120 insert-mode keystrokes across 5 fresh editor runs.
+
+## Metrics
+- **Primary**: `key_latency_us` (µs, lower is better) — median insert-mode keypress wall time from sending the key event to receiving the rendered frame.
+- **Secondary**: `insert_p95_us`, `motion_latency_us`, `input_dispatch_us`, `render_us`, `port_emit_us`, `content_stage_us`, `chrome_stage_us`, `emit_stage_us` — tradeoff and localization metrics from telemetry.
+
+## How to Run
+`./autoresearch.sh` outputs `METRIC name=value` lines.
+
+## Files in Scope
+- `lib/minga_editor.ex` — Editor GenServer input hot path and key event routing.
+- `lib/minga_editor/input/router.ex` — focus-stack dispatch, snapshots, and post-action housekeeping.
+- `lib/minga_editor/renderer.ex` and `lib/minga_editor/renderer/server.ex` — synchronous and split render entry points.
+- `lib/minga_editor/render_pipeline*.ex` and `lib/minga_editor/render_pipeline/*.ex` — render pipeline stages and caches.
+- `lib/minga_editor/frontend/*.ex` — command emission and protocol conversion.
+- `lib/minga/buffer/server.ex`, `lib/minga/buffer/document.ex`, `lib/minga/editing/**/*.ex`, `lib/minga/mode/**/*.ex` — buffer, motion, and insert-mode hot path code when the benchmark points there.
+- `bench/key_latency_bench.exs`, `autoresearch.sh`, `autoresearch.checks.sh` — benchmark and validation harness.
+
+## Off Limits
+- Do not change public protocol wire formats unless a benchmark result clearly requires it and tests/docs are updated in the same kept experiment.
+- Do not disable rendering, telemetry, syntax/decorations correctness, undo behavior, or input semantics to win the benchmark.
+- Do not add new dependencies for micro-optimizations.
+- Do not use `Process.sleep/1` in production code.
+
+## Constraints
+- Primary metric decides keep/discard. Keep only lower `key_latency_us` unless a secondary metric exposes a correctness or catastrophic regression.
+- `./autoresearch.checks.sh` must pass before keeping any code change.
+- Preserve user-visible behavior. Any optimization that skips needed housekeeping must be discarded even if faster.
+- Prefer structural hot-path reductions: fewer snapshots, fewer allocations, narrower invalidation, less protocol work, better cache reuse.
+
+## What's Been Tried
+- Restarted clean from `main` after prior benchmark history was invalidated by external CPU saturation. Copied only the benchmark harness and autoresearch scripts, not app-code optimizations.

--- a/autoresearch.md
+++ b/autoresearch.md
@@ -1,36 +1,33 @@
-# Autoresearch: Swift rendering speed
+# Autoresearch: tree-sitter highlight speed
 
 ## Objective
-Make the macOS GUI frontend feel as snappy as the headless BEAM path by reducing the measured Swift semantic window rendering cost for a realistic editing workload. The benchmark renders 80 visible semantic rows through `WindowContentRenderer` and `LineTextureAtlas`, warms the row texture cache, then measures 220 frame-style updates where one row changes and the rest are cache hits.
+Make syntax highlighting fast enough that parser/highlight work never shows up as editor latency. The benchmark runs the Zig `minga-parser` highlighter directly on a 2,000-line Elixir-like buffer, warms up parsing and highlight query execution, then measures repeated full parse plus `highlightWithInjections` cycles after a small source mutation.
 
 ## Metrics
-- **Primary**: `swift_frame_us` (µs, lower is better) — median time to render one semantic frame through the Swift window-content renderer and atlas path.
-- **Secondary**: `swift_frame_p95_us`, `swift_cold_frame_us`, `swift_cache_hit_frame_us`, `swift_rows` — tradeoff and localization metrics for tail latency, cold rasterization, all-cache-hit overhead, and workload size.
+- **Primary**: `ts_update_highlight_us` (µs, lower is better) — median time for parse plus highlight query execution after one source mutation.
+- **Secondary**: `ts_update_highlight_p95_us`, `ts_parse_us`, `ts_highlight_us`, `ts_highlight_p95_us`, `ts_span_count`, `ts_line_count` — tradeoff and localization metrics for tail latency, parse/query split, output size, and workload size.
 
 ## How to Run
 `./autoresearch.sh` outputs `METRIC name=value` lines.
 
 ## Files in Scope
-- `macos/Sources/Renderer/WindowContentRenderer.swift` — semantic row to attributed string, CoreText rasterization, texture and atlas upload path.
-- `macos/Sources/Renderer/BitmapRasterizer.swift` — pooled CoreGraphics/CoreText bitmap rasterization.
-- `macos/Sources/Renderer/LineTextureAtlas.swift`, `macos/Sources/Renderer/SlotAllocator.swift`, `macos/Sources/Renderer/CachedLineTexture.swift` — atlas allocation, cache hits, and uploads.
-- `macos/Sources/Renderer/CoreTextMetalRenderer.swift` — frame render loop that calls `WindowContentRenderer`, line instance construction, overlay quads, and Metal draw setup when benchmark work points there.
-- `macos/Sources/Font/FontFace.swift`, `macos/Sources/Font/FontManager.swift` — font lookup and per-span font selection hot paths.
-- `macos/Sources/Protocol/ProtocolDecoder.swift`, `macos/Sources/Renderer/CommandDispatcher.swift`, `macos/Sources/Renderer/WindowContent.swift` — semantic content decode and state update path when benchmark work points there.
-- `bench/swift_render_bench.swift`, `autoresearch.sh`, `autoresearch.checks.sh` — benchmark and validation harness.
+- `zig/src/highlighter.zig` — tree-sitter parsing, query execution, capture collection, predicate handling, sorting, capture-name construction, injections, folds, indents, and textobjects.
+- `zig/src/predicates.zig`, `zig/src/posix_regex.zig`, `zig/src/query_loader.zig` — predicate and query handling when profiling points there.
+- `zig/src/parser_main.zig`, `zig/src/protocol.zig`, `zig/src/port_writer.zig` — parser port protocol and response encoding when benchmark work points there.
+- `zig/src/highlight_bench.zig`, `zig/build.zig`, `autoresearch.sh`, `autoresearch.checks.sh` — benchmark and validation harness.
+- `zig/src/queries/**/*.scm` — highlight query shape, only when correctness is preserved and language behavior remains intended.
 
 ## Off Limits
-- Do not change public protocol wire formats unless a benchmark result clearly requires it and tests/docs are updated in the same kept experiment.
-- Do not skip rasterization, atlas upload, cache invalidation, or semantic content correctness to win the benchmark.
-- Do not make the Swift frontend interpret editor semantics; the BEAM remains the source of truth.
+- Do not skip parsing, query execution, predicate evaluation, sorting, injection handling, or capture-name output to win the benchmark.
+- Do not remove captures or weaken highlight correctness unless tests and intended behavior are updated in the same kept experiment.
+- Do not change public parser port protocol wire formats unless benchmark evidence clearly requires it and Elixir/Swift/Zig protocol tests are updated.
 - Do not add new dependencies for micro-optimizations.
-- Do not use private AppKit, CoreText, or Metal APIs.
 
 ## Constraints
-- Primary metric decides keep/discard. Keep only lower `swift_frame_us` unless a secondary metric exposes a correctness or catastrophic regression.
+- Primary metric decides keep/discard. Keep only lower `ts_update_highlight_us` unless a secondary metric exposes a correctness or catastrophic regression.
 - `./autoresearch.checks.sh` must pass before keeping any code change.
-- Preserve user-visible rendering behavior: text, styles, font fallback, cache invalidation, and atlas contents must remain correct.
-- Prefer structural hot-path reductions: fewer attributed-string allocations, fewer CoreText objects, better cache reuse, less atlas churn, less per-row work on cache hits.
+- Preserve user-visible highlighting behavior across frontends.
+- Prefer structural hot-path reductions: fewer query cursor allocations, fewer per-match C API calls, better reuse of capture names, cheaper sorting, less allocation churn, and safe incremental parse/query improvements.
 
 ## What's Been Tried
-- Switched from the headless BEAM keystroke benchmark after reaching about 1.8ms p50 internally. New target focuses on macOS Swift semantic rendering.
+- Switched from Swift semantic rendering after reducing `swift_frame_us` from roughly 266µs to 165µs. New target focuses on the Zig tree-sitter parser/highlighter shared by all frontends.

--- a/autoresearch.sh
+++ b/autoresearch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export MIX_ENV=test
+mix compile --warnings-as-errors >/dev/null
+mix run bench/key_latency_bench.exs

--- a/autoresearch.sh
+++ b/autoresearch.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd zig
-zig build highlight-bench -Doptimize=ReleaseFast
+MIX_ENV=test mix run bench/key_latency_bench.exs

--- a/autoresearch.sh
+++ b/autoresearch.sh
@@ -1,19 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-mkdir -p _build/autoresearch
-swiftc -O \
-  macos/Sources/Protocol/ProtocolConstants.swift \
-  macos/Sources/Protocol/ProtocolTypes.swift \
-  macos/Sources/Protocol/ProtocolEncoder.swift \
-  macos/Sources/Protocol/PortLogger.swift \
-  macos/Sources/Font/FontFace.swift \
-  macos/Sources/Font/FontManager.swift \
-  macos/Sources/Renderer/SlotAllocator.swift \
-  macos/Sources/Renderer/CachedLineTexture.swift \
-  macos/Sources/Renderer/LineTextureAtlas.swift \
-  macos/Sources/Renderer/BitmapRasterizer.swift \
-  macos/Sources/Renderer/WindowContent.swift \
-  macos/Sources/Renderer/WindowContentRenderer.swift \
-  bench/swift_render_bench.swift \
-  -o _build/autoresearch/swift-render-bench
-_build/autoresearch/swift-render-bench
+cd zig
+zig build highlight-bench -Doptimize=ReleaseFast

--- a/autoresearch.sh
+++ b/autoresearch.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
-export MIX_ENV=test
-mix compile --warnings-as-errors >/dev/null
-mix run bench/key_latency_bench.exs
+mkdir -p _build/autoresearch
+swiftc -O \
+  macos/Sources/Protocol/ProtocolConstants.swift \
+  macos/Sources/Protocol/ProtocolTypes.swift \
+  macos/Sources/Protocol/ProtocolEncoder.swift \
+  macos/Sources/Protocol/PortLogger.swift \
+  macos/Sources/Font/FontFace.swift \
+  macos/Sources/Font/FontManager.swift \
+  macos/Sources/Renderer/SlotAllocator.swift \
+  macos/Sources/Renderer/CachedLineTexture.swift \
+  macos/Sources/Renderer/LineTextureAtlas.swift \
+  macos/Sources/Renderer/BitmapRasterizer.swift \
+  macos/Sources/Renderer/WindowContent.swift \
+  macos/Sources/Renderer/WindowContentRenderer.swift \
+  bench/swift_render_bench.swift \
+  -o _build/autoresearch/swift-render-bench
+_build/autoresearch/swift-render-bench

--- a/bench/key_latency_bench.exs
+++ b/bench/key_latency_bench.exs
@@ -1,0 +1,200 @@
+defmodule Minga.Bench.KeyLatency do
+  @moduledoc false
+
+  alias Minga.Test.EditorCase
+  alias Minga.Test.HeadlessPort
+
+  @events [
+    [:minga, :input, :dispatch, :stop],
+    [:minga, :render, :pipeline, :stop],
+    [:minga, :render, :stage, :stop],
+    [:minga, :port, :emit, :stop]
+  ]
+
+  @runs 5
+  @warmup_keys 20
+  @measured_keys 120
+  @width 100
+  @height 40
+
+  def run do
+    parent = self()
+    handler_id = "minga-key-latency-bench-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      @events,
+      fn event, measurements, metadata, _config ->
+        send(parent, {:bench_telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    try do
+      results = for _ <- 1..@runs, do: run_once()
+      emit_metrics(results)
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  defp run_once do
+    registry = :"minga_bench_events_#{System.unique_integer([:positive])}"
+    {:ok, _events} = Registry.start_link(keys: :duplicate, name: registry)
+
+    ctx =
+      EditorCase.start_editor(
+        document(),
+        width: @width,
+        height: @height,
+        file_path: "bench_elixir.ex",
+        events_registry: registry
+      )
+
+    try do
+      warmup_motion(ctx)
+      motion = measure_keys(ctx, List.duplicate(?j, @measured_keys))
+      enter_insert(ctx)
+      warmup_insert(ctx)
+      insert = measure_keys(ctx, List.duplicate(?a, @measured_keys))
+
+      %{
+        motion: summarize(motion),
+        insert: summarize(insert)
+      }
+    after
+      stop_if_alive(ctx.editor)
+      stop_if_alive(ctx.buffer)
+      stop_if_alive(ctx.port)
+      stop_if_alive(Process.whereis(registry))
+    end
+  end
+
+  defp document do
+    1..2_000
+    |> Enum.map_join("\n", fn i -> "line #{i} alpha beta gamma delta epsilon zeta eta theta" end)
+  end
+
+  defp warmup_motion(ctx), do: Enum.each(List.duplicate(?j, @warmup_keys), &send_key(ctx, &1))
+
+  defp enter_insert(ctx), do: send_key(ctx, ?i)
+
+  defp warmup_insert(ctx), do: Enum.each(List.duplicate(?a, @warmup_keys), &send_key(ctx, &1))
+
+  defp measure_keys(ctx, keys) do
+    drain_events([])
+    Enum.map(keys, fn key -> send_key(ctx, key) end)
+  end
+
+  defp send_key(%{editor: editor, port: port}, codepoint) do
+    _ = :sys.get_state(editor)
+    ref = HeadlessPort.prepare_await(port)
+    started_at = System.monotonic_time(:microsecond)
+    send(editor, {:minga_input, {:key_press, codepoint, 0}})
+
+    case HeadlessPort.collect_frame(ref, 5_000) do
+      {:ok, _snapshot} ->
+        stopped_at = System.monotonic_time(:microsecond)
+        events = drain_events([])
+        %{wall_us: stopped_at - started_at, events: events}
+
+      {:error, :timeout} ->
+        raise "timed out waiting for rendered frame after key #{inspect(codepoint)}"
+    end
+  end
+
+  defp drain_events(acc) do
+    receive do
+      {:bench_telemetry, event, measurements, metadata} ->
+        drain_events([%{event: event, measurements: measurements, metadata: metadata} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  defp summarize(samples) do
+    wall = Enum.map(samples, & &1.wall_us)
+    events = Enum.flat_map(samples, & &1.events)
+
+    %{
+      median_wall_us: median(wall),
+      p95_wall_us: percentile(wall, 0.95),
+      input_us: median_duration(events, [:minga, :input, :dispatch, :stop]),
+      render_us: median_duration(events, [:minga, :render, :pipeline, :stop]),
+      port_us: median_duration(events, [:minga, :port, :emit, :stop]),
+      content_us: median_stage_duration(events, :content),
+      chrome_us: median_stage_duration(events, :chrome),
+      emit_us: median_stage_duration(events, :emit)
+    }
+  end
+
+  defp median_duration(events, event_name) do
+    events
+    |> Enum.filter(&(&1.event == event_name))
+    |> Enum.map(&native_to_us(&1.measurements.duration))
+    |> median()
+  end
+
+  defp median_stage_duration(events, stage) do
+    events
+    |> Enum.filter(&(&1.event == [:minga, :render, :stage, :stop] and &1.metadata.stage == stage))
+    |> Enum.map(&native_to_us(&1.measurements.duration))
+    |> median()
+  end
+
+  defp native_to_us(duration), do: System.convert_time_unit(duration, :native, :microsecond)
+
+  defp emit_metrics(results) do
+    insert_summaries = Enum.map(results, & &1.insert)
+    motion_summaries = Enum.map(results, & &1.motion)
+
+    metrics = %{
+      "key_latency_us" => median_field(insert_summaries, :median_wall_us),
+      "insert_p95_us" => median_field(insert_summaries, :p95_wall_us),
+      "motion_latency_us" => median_field(motion_summaries, :median_wall_us),
+      "input_dispatch_us" => median_field(insert_summaries, :input_us),
+      "render_us" => median_field(insert_summaries, :render_us),
+      "port_emit_us" => median_field(insert_summaries, :port_us),
+      "content_stage_us" => median_field(insert_summaries, :content_us),
+      "chrome_stage_us" => median_field(insert_summaries, :chrome_us),
+      "emit_stage_us" => median_field(insert_summaries, :emit_us)
+    }
+
+    Enum.each(metrics, fn {name, value} -> IO.puts("METRIC #{name}=#{format_number(value)}") end)
+  end
+
+  defp median_field(summaries, field), do: summaries |> Enum.map(&Map.fetch!(&1, field)) |> median()
+
+  defp median([]), do: 0
+
+  defp median(values) do
+    sorted = Enum.sort(values)
+    count = length(sorted)
+    middle = div(count, 2)
+
+    if rem(count, 2) == 1 do
+      Enum.at(sorted, middle)
+    else
+      (Enum.at(sorted, middle - 1) + Enum.at(sorted, middle)) / 2
+    end
+  end
+
+  defp percentile([], _ratio), do: 0
+
+  defp percentile(values, ratio) do
+    sorted = Enum.sort(values)
+    index = max(0, ceil(length(sorted) * ratio) - 1)
+    Enum.at(sorted, index)
+  end
+
+  defp format_number(value) when is_integer(value), do: Integer.to_string(value)
+  defp format_number(value) when is_float(value), do: :erlang.float_to_binary(value, decimals: 2)
+
+  defp stop_if_alive(pid) when is_pid(pid) do
+    if Process.alive?(pid), do: GenServer.stop(pid, :normal, 1_000)
+  catch
+    :exit, _ -> :ok
+  end
+end
+
+Minga.Bench.KeyLatency.run()

--- a/bench/swift_render_bench.swift
+++ b/bench/swift_render_bench.swift
@@ -1,0 +1,118 @@
+import AppKit
+import Foundation
+import Metal
+
+@main
+struct SwiftRenderBench {
+    static let rowCount = 80
+    static let frameCount = 220
+    static let warmupFrames = 40
+    static let columnCount = 140
+
+    @MainActor
+    static func main() {
+        setenv("MINGA_DISABLE_OSLOG", "1", 1)
+
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            fputs("Swift render benchmark requires a Metal device\n", stderr)
+            exit(1)
+        }
+
+        let fontManager = FontManager(name: "Menlo", size: 14.0, scale: 2.0)
+        let rasterizer = BitmapRasterizer()
+        let renderer = WindowContentRenderer(device: device, fontManager: fontManager, rasterizer: rasterizer)
+        let atlas = LineTextureAtlas(device: device, slotHeight: renderer.linePixelHeight)
+        let atlasWidth = Int(ceil(CGFloat(columnCount) * fontManager.cellWidth * fontManager.scale))
+        atlas.ensureCapacity(maxSlots: rowCount * 3, width: atlasWidth)
+
+        var rows = makeRows(frame: 0)
+        for frame in 0..<warmupFrames {
+            rows = mutateRows(rows, frame: frame)
+            renderFrame(renderer: renderer, atlas: atlas, rows: rows)
+        }
+
+        var frameTimes: [Double] = []
+        frameTimes.reserveCapacity(frameCount)
+
+        for frame in 0..<frameCount {
+            rows = mutateRows(rows, frame: frame + warmupFrames)
+            let start = DispatchTime.now().uptimeNanoseconds
+            renderFrame(renderer: renderer, atlas: atlas, rows: rows)
+            let end = DispatchTime.now().uptimeNanoseconds
+            frameTimes.append(Double(end - start) / 1_000.0)
+        }
+
+        let coldRows = makeRows(frame: 10_000)
+        renderer.invalidateAll()
+        atlas.invalidateAll()
+        let coldStart = DispatchTime.now().uptimeNanoseconds
+        renderFrame(renderer: renderer, atlas: atlas, rows: coldRows)
+        let coldEnd = DispatchTime.now().uptimeNanoseconds
+        let coldFrameUs = Double(coldEnd - coldStart) / 1_000.0
+
+        let hitStart = DispatchTime.now().uptimeNanoseconds
+        renderFrame(renderer: renderer, atlas: atlas, rows: coldRows)
+        let hitEnd = DispatchTime.now().uptimeNanoseconds
+        let cacheHitFrameUs = Double(hitEnd - hitStart) / 1_000.0
+
+        printMetric("swift_frame_us", percentile(frameTimes, 0.50))
+        printMetric("swift_frame_p95_us", percentile(frameTimes, 0.95))
+        printMetric("swift_cold_frame_us", coldFrameUs)
+        printMetric("swift_cache_hit_frame_us", cacheHitFrameUs)
+        printMetric("swift_rows", Double(rowCount))
+    }
+
+    @MainActor
+    static func renderFrame(renderer: WindowContentRenderer, atlas: LineTextureAtlas, rows: [GUIVisualRow]) {
+        renderer.beginFrame()
+        atlas.beginFrame()
+        for (index, row) in rows.enumerated() {
+            _ = renderer.renderRowToAtlas(displayRow: UInt16(index), row: row, atlas: atlas)
+        }
+    }
+
+    static func makeRows(frame: Int) -> [GUIVisualRow] {
+        (0..<rowCount).map { rowIndex in
+            makeRow(rowIndex: rowIndex, frame: frame, revision: 0)
+        }
+    }
+
+    static func mutateRows(_ rows: [GUIVisualRow], frame: Int) -> [GUIVisualRow] {
+        var next = rows
+        let rowIndex = frame % rowCount
+        next[rowIndex] = makeRow(rowIndex: rowIndex, frame: frame, revision: frame + 1)
+        return next
+    }
+
+    static func makeRow(rowIndex: Int, frame: Int, revision: Int) -> GUIVisualRow {
+        let text = "def render_row_\(rowIndex)(_arg), do: {:ok, \(revision), \"The quick brown fox jumps over semantic row \(rowIndex) at frame \(frame)\"}"
+        let spans = [
+            GUIHighlightSpan(startCol: 0, endCol: 3, fg: 0xC678DD, bg: 0, attrs: 0x01, fontWeight: 2, fontId: 0),
+            GUIHighlightSpan(startCol: 4, endCol: 18, fg: 0x61AFEF, bg: 0, attrs: 0x00, fontWeight: 2, fontId: 0),
+            GUIHighlightSpan(startCol: 34, endCol: 38, fg: 0x98C379, bg: 0, attrs: 0x00, fontWeight: 2, fontId: 0),
+            GUIHighlightSpan(startCol: 44, endCol: UInt16(min(text.count, 100)), fg: 0xE5C07B, bg: 0, attrs: 0x00, fontWeight: 2, fontId: 0)
+        ]
+
+        return GUIVisualRow(rowType: .normal, bufLine: UInt32(rowIndex), contentHash: stableHash(text), text: text, spans: spans)
+    }
+
+    static func stableHash(_ text: String) -> UInt32 {
+        var hash: UInt32 = 2_166_136_261
+        for byte in text.utf8 {
+            hash ^= UInt32(byte)
+            hash = hash &* 16_777_619
+        }
+        return hash
+    }
+
+    static func percentile(_ values: [Double], _ p: Double) -> Double {
+        let sorted = values.sorted()
+        guard !sorted.isEmpty else { return 0 }
+        let idx = min(sorted.count - 1, max(0, Int(Double(sorted.count - 1) * p)))
+        return sorted[idx]
+    }
+
+    static func printMetric(_ name: String, _ value: Double) {
+        print(String(format: "METRIC %@=%.2f", name, value))
+    }
+}

--- a/lib/minga_editor/display_list.ex
+++ b/lib/minga_editor/display_list.ex
@@ -331,9 +331,7 @@ defmodule MingaEditor.DisplayList do
   @spec draws_to_commands([draw()]) :: [binary()]
   def draws_to_commands(draws) do
     Enum.flat_map(draws, fn {row, col, text, %Face{} = face} ->
-      style = Face.to_style(face)
-      {style, registration_cmds} = resolve_font_family(style)
-      registration_cmds ++ [Protocol.encode_draw_smart(row, col, text, style)]
+      draw_to_commands(row, col, text, face)
     end)
   end
 
@@ -375,11 +373,27 @@ defmodule MingaEditor.DisplayList do
   defp layer_to_commands(layer, row_off, col_off) when is_map(layer) do
     Enum.flat_map(layer, fn {row, runs} ->
       Enum.flat_map(runs, fn {col, text, %Face{} = face} ->
-        style = Face.to_style(face)
-        {style, registration_cmds} = resolve_font_family(style)
-        registration_cmds ++ [Protocol.encode_draw_smart(row + row_off, col + col_off, text, style)]
+        draw_to_commands(row + row_off, col + col_off, text, face)
       end)
     end)
+  end
+
+  @spec draw_to_commands(non_neg_integer(), non_neg_integer(), String.t(), Face.t()) :: [binary()]
+  defp draw_to_commands(row, col, text, %Face{} = face) do
+    if simple_draw_face?(face) do
+      [Protocol.encode_draw_face(row, col, text, face)]
+    else
+      style = Face.to_style(face)
+      {style, registration_cmds} = resolve_font_family(style)
+      registration_cmds ++ [Protocol.encode_draw_smart(row, col, text, style)]
+    end
+  end
+
+  @spec simple_draw_face?(Face.t()) :: boolean()
+  defp simple_draw_face?(%Face{} = face) do
+    face.strikethrough != true and (face.underline_style == nil or face.underline_style == :line) and
+      face.underline_color == nil and (face.blend == nil or face.blend == 100) and
+      face.font_family == nil and (face.font_weight == nil or face.font_weight == :regular)
   end
 
   # ── Layer ↔ draws ──────────────────────────────────────────────────────────

--- a/lib/minga_editor/display_list.ex
+++ b/lib/minga_editor/display_list.ex
@@ -216,6 +216,27 @@ defmodule MingaEditor.DisplayList do
     end)
   end
 
+  @doc """
+  Groups row-sorted draws into a render layer in one pass.
+
+  Use this only when all draws for a row are contiguous and rows are emitted in ascending order.
+  """
+  @spec draws_to_layer_sorted([draw()]) :: render_layer()
+  def draws_to_layer_sorted([]), do: %{}
+
+  def draws_to_layer_sorted([{row, col, text, style} | rest]) do
+    {layer, current_row, runs_rev} =
+      Enum.reduce(rest, {%{}, row, [{col, text, style}]}, fn {next_row, col, text, style}, {layer, row, runs} ->
+        if next_row == row do
+          {layer, row, [{col, text, style} | runs]}
+        else
+          {Map.put(layer, row, Enum.reverse(runs)), next_row, [{col, text, style}]}
+        end
+      end)
+
+    Map.put(layer, current_row, Enum.reverse(runs_rev))
+  end
+
   # ── Draw offsetting ────────────────────────────────────────────────────────
 
   @doc "Offsets draw tuples by the given row and column amounts."

--- a/lib/minga_editor/display_list.ex
+++ b/lib/minga_editor/display_list.ex
@@ -330,9 +330,11 @@ defmodule MingaEditor.DisplayList do
   """
   @spec draws_to_commands([draw()]) :: [binary()]
   def draws_to_commands(draws) do
-    Enum.flat_map(draws, fn {row, col, text, %Face{} = face} ->
-      draw_to_commands(row, col, text, face)
+    draws
+    |> Enum.reduce([], fn {row, col, text, %Face{} = face}, acc ->
+      prepend_draw_commands(acc, row, col, text, face)
     end)
+    |> Enum.reverse()
   end
 
   # Resolves font_family in a style keyword list to a font_id.
@@ -371,21 +373,24 @@ defmodule MingaEditor.DisplayList do
 
   @spec layer_to_commands(render_layer(), non_neg_integer(), non_neg_integer()) :: [binary()]
   defp layer_to_commands(layer, row_off, col_off) when is_map(layer) do
-    Enum.flat_map(layer, fn {row, runs} ->
-      Enum.flat_map(runs, fn {col, text, %Face{} = face} ->
-        draw_to_commands(row + row_off, col + col_off, text, face)
+    layer
+    |> Enum.reduce([], fn {row, runs}, acc ->
+      Enum.reduce(runs, acc, fn {col, text, %Face{} = face}, row_acc ->
+        prepend_draw_commands(row_acc, row + row_off, col + col_off, text, face)
       end)
     end)
+    |> Enum.reverse()
   end
 
-  @spec draw_to_commands(non_neg_integer(), non_neg_integer(), String.t(), Face.t()) :: [binary()]
-  defp draw_to_commands(row, col, text, %Face{} = face) do
+  @spec prepend_draw_commands([binary()], non_neg_integer(), non_neg_integer(), String.t(), Face.t()) :: [binary()]
+  defp prepend_draw_commands(acc, row, col, text, %Face{} = face) do
     if simple_draw_face?(face) do
-      [Protocol.encode_draw_face(row, col, text, face)]
+      [Protocol.encode_draw_face(row, col, text, face) | acc]
     else
       style = Face.to_style(face)
       {style, registration_cmds} = resolve_font_family(style)
-      registration_cmds ++ [Protocol.encode_draw_smart(row, col, text, style)]
+      command = Protocol.encode_draw_smart(row, col, text, style)
+      Enum.reduce(registration_cmds ++ [command], acc, fn cmd, next_acc -> [cmd | next_acc] end)
     end
   end
 

--- a/lib/minga_editor/display_list.ex
+++ b/lib/minga_editor/display_list.ex
@@ -226,7 +226,8 @@ defmodule MingaEditor.DisplayList do
 
   def draws_to_layer_sorted([{row, col, text, style} | rest]) do
     {layer, current_row, runs_rev} =
-      Enum.reduce(rest, {%{}, row, [{col, text, style}]}, fn {next_row, col, text, style}, {layer, row, runs} ->
+      Enum.reduce(rest, {%{}, row, [{col, text, style}]}, fn {next_row, col, text, style},
+                                                             {layer, row, runs} ->
         if next_row == row do
           {layer, row, [{col, text, style} | runs]}
         else
@@ -294,7 +295,11 @@ defmodule MingaEditor.DisplayList do
       end
 
     before_windows = frame.tab_bar ++ frame.file_tree ++ frame.agentic_view
-    after_windows = frame.separators ++ frame.status_bar ++ frame.agent_panel ++ frame.minibuffer ++ splash_draws
+
+    after_windows =
+      frame.separators ++
+        frame.status_bar ++ frame.agent_panel ++ frame.minibuffer ++ splash_draws
+
     overlay_draws = Enum.flat_map(frame.overlays, fn %Overlay{draws: draws} -> draws end)
 
     tail =
@@ -382,7 +387,13 @@ defmodule MingaEditor.DisplayList do
     |> Enum.reverse()
   end
 
-  @spec prepend_draw_commands([binary()], non_neg_integer(), non_neg_integer(), String.t(), Face.t()) :: [binary()]
+  @spec prepend_draw_commands(
+          [binary()],
+          non_neg_integer(),
+          non_neg_integer(),
+          String.t(),
+          Face.t()
+        ) :: [binary()]
   defp prepend_draw_commands(acc, row, col, text, %Face{} = face) do
     if simple_draw_face?(face) do
       [Protocol.encode_draw_face(row, col, text, face) | acc]

--- a/lib/minga_editor/display_list.ex
+++ b/lib/minga_editor/display_list.ex
@@ -266,35 +266,14 @@ defmodule MingaEditor.DisplayList do
   """
   @spec to_commands(Frame.t(), keyword()) :: [binary()]
   def to_commands(%Frame{} = frame, opts \\ []) do
-    window_draws =
-      Enum.flat_map(frame.windows, fn wf ->
-        {row_off, col_off, _w, _h} = wf.rect
-
-        # Window-relative draws get offset to absolute screen coordinates
-        gutter = layer_to_draws(wf.gutter)
-        lines = layer_to_draws(wf.lines)
-        tildes = layer_to_draws(wf.tilde_lines)
-
-        offset_draws(gutter ++ lines ++ tildes, row_off, col_off)
-      end)
-
     splash_draws =
       case frame.splash do
         nil -> []
         draws -> draws
       end
 
-    all_draws =
-      frame.tab_bar ++
-        frame.file_tree ++
-        frame.agentic_view ++
-        window_draws ++
-        frame.separators ++
-        frame.status_bar ++
-        frame.agent_panel ++
-        frame.minibuffer ++
-        splash_draws
-
+    before_windows = frame.tab_bar ++ frame.file_tree ++ frame.agentic_view
+    after_windows = frame.separators ++ frame.status_bar ++ frame.agent_panel ++ frame.minibuffer ++ splash_draws
     overlay_draws = Enum.flat_map(frame.overlays, fn %Overlay{draws: draws} -> draws end)
 
     tail =
@@ -313,7 +292,9 @@ defmodule MingaEditor.DisplayList do
 
     [Protocol.encode_clear()] ++
       frame.regions ++
-      draws_to_commands(all_draws) ++
+      draws_to_commands(before_windows) ++
+      windows_to_commands(frame.windows) ++
+      draws_to_commands(after_windows) ++
       draws_to_commands(overlay_draws) ++
       tail
   end
@@ -356,6 +337,28 @@ defmodule MingaEditor.DisplayList do
         reg_cmds = if new?, do: [Protocol.encode_register_font(font_id, family)], else: []
         {style_with_id, reg_cmds}
     end
+  end
+
+  @spec windows_to_commands([WindowFrame.t()]) :: [binary()]
+  defp windows_to_commands(windows) do
+    Enum.flat_map(windows, fn wf ->
+      {row_off, col_off, _w, _h} = wf.rect
+
+      layer_to_commands(wf.gutter, row_off, col_off) ++
+        layer_to_commands(wf.lines, row_off, col_off) ++
+        layer_to_commands(wf.tilde_lines, row_off, col_off)
+    end)
+  end
+
+  @spec layer_to_commands(render_layer(), non_neg_integer(), non_neg_integer()) :: [binary()]
+  defp layer_to_commands(layer, row_off, col_off) when is_map(layer) do
+    Enum.flat_map(layer, fn {row, runs} ->
+      Enum.flat_map(runs, fn {col, text, %Face{} = face} ->
+        style = Face.to_style(face)
+        {style, registration_cmds} = resolve_font_family(style)
+        registration_cmds ++ [Protocol.encode_draw_smart(row + row_off, col + col_off, text, style)]
+      end)
+    end)
   end
 
   # ── Layer ↔ draws ──────────────────────────────────────────────────────────

--- a/lib/minga_editor/display_map.ex
+++ b/lib/minga_editor/display_map.ex
@@ -122,6 +122,8 @@ defmodule MingaEditor.DisplayMap do
 
   @doc "Returns true when folds, virtual lines, or block decorations require a display map."
   @spec required?(FoldMap.t(), Decorations.t()) :: boolean()
+  def required?(%FoldMap{folds: []}, %Decorations{fold_regions: [], virtual_texts: [], block_decorations: []}), do: false
+
   def required?(fold_map, decorations) do
     required?(fold_map, decorations, Decorations.closed_fold_regions(decorations))
   end

--- a/lib/minga_editor/display_map.ex
+++ b/lib/minga_editor/display_map.ex
@@ -98,13 +98,9 @@ defmodule MingaEditor.DisplayMap do
         total_lines,
         content_width \\ 80
       ) do
-    has_window_folds = not FoldMap.empty?(fold_map)
     closed_dec_folds = Decorations.closed_fold_regions(decorations)
-    has_virtual_lines = has_virtual_lines?(decorations)
-    has_blocks = Decorations.has_block_decorations?(decorations)
 
-    if not has_window_folds and closed_dec_folds == [] and not has_virtual_lines and
-         not has_blocks do
+    if not required?(fold_map, decorations, closed_dec_folds) do
       nil
     else
       ctx = %{
@@ -122,6 +118,20 @@ defmodule MingaEditor.DisplayMap do
         total_display_lines: length(entries)
       }
     end
+  end
+
+  @doc "Returns true when folds, virtual lines, or block decorations require a display map."
+  @spec required?(FoldMap.t(), Decorations.t()) :: boolean()
+  def required?(fold_map, decorations) do
+    required?(fold_map, decorations, Decorations.closed_fold_regions(decorations))
+  end
+
+  @spec required?(FoldMap.t(), Decorations.t(), [FoldRegion.t()]) :: boolean()
+  defp required?(fold_map, decorations, closed_dec_folds) do
+    has_window_folds = not FoldMap.empty?(fold_map)
+    has_virtual_lines = has_virtual_lines?(decorations)
+    has_blocks = Decorations.has_block_decorations?(decorations)
+    has_window_folds or closed_dec_folds != [] or has_virtual_lines or has_blocks
   end
 
   # ── Public query API ─────────────────────────────────────────────────────

--- a/lib/minga_editor/display_map.ex
+++ b/lib/minga_editor/display_map.ex
@@ -100,9 +100,7 @@ defmodule MingaEditor.DisplayMap do
       ) do
     closed_dec_folds = Decorations.closed_fold_regions(decorations)
 
-    if not required?(fold_map, decorations, closed_dec_folds) do
-      nil
-    else
+    if required?(fold_map, decorations, closed_dec_folds) do
       ctx = %{
         fold_map: fold_map,
         dec_folds: closed_dec_folds,
@@ -117,12 +115,19 @@ defmodule MingaEditor.DisplayMap do
         entries: entries,
         total_display_lines: length(entries)
       }
+    else
+      nil
     end
   end
 
   @doc "Returns true when folds, virtual lines, or block decorations require a display map."
   @spec required?(FoldMap.t(), Decorations.t()) :: boolean()
-  def required?(%FoldMap{folds: []}, %Decorations{fold_regions: [], virtual_texts: [], block_decorations: []}), do: false
+  def required?(%FoldMap{folds: []}, %Decorations{
+        fold_regions: [],
+        virtual_texts: [],
+        block_decorations: []
+      }),
+      do: false
 
   def required?(fold_map, decorations) do
     required?(fold_map, decorations, Decorations.closed_fold_regions(decorations))

--- a/lib/minga_editor/frontend/protocol.ex
+++ b/lib/minga_editor/frontend/protocol.ex
@@ -48,6 +48,7 @@ defmodule MingaEditor.Frontend.Protocol do
   @op_paste_event 0x06
   @op_gui_action 0x07
 
+  alias Minga.Core.Face
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
 
@@ -233,6 +234,18 @@ defmodule MingaEditor.Frontend.Protocol do
     fg = Keyword.get(style, :fg, 0xFFFFFF)
     bg = Keyword.get(style, :bg, 0x000000)
     attrs = encode_attrs(style)
+    text_len = byte_size(text)
+
+    <<@op_draw_text, row::16, col::16, fg::24, bg::24, attrs::8, text_len::16, text::binary>>
+  end
+
+  @doc "Encodes a draw_text command directly from a simple face."
+  @spec encode_draw_face(non_neg_integer(), non_neg_integer(), String.t(), Face.t()) :: binary()
+  def encode_draw_face(row, col, text, %Face{} = face)
+      when is_integer(row) and row >= 0 and is_integer(col) and col >= 0 and is_binary(text) do
+    fg = if face.fg && face.fg != 0xBBC2CF, do: face.fg, else: 0xFFFFFF
+    bg = if face.bg && face.bg != 0x282C34, do: face.bg, else: 0x000000
+    attrs = encode_face_attrs(face)
     text_len = byte_size(text)
 
     <<@op_draw_text, row::16, col::16, fg::24, bg::24, attrs::8, text_len::16, text::binary>>
@@ -705,6 +718,16 @@ defmodule MingaEditor.Frontend.Protocol do
     end)
     |> then(fn a -> if Keyword.get(style, :italic, false), do: a ||| @attr_italic, else: a end)
     |> then(fn a -> if Keyword.get(style, :reverse, false), do: a ||| @attr_reverse, else: a end)
+  end
+
+  @spec encode_face_attrs(Face.t()) :: non_neg_integer()
+  defp encode_face_attrs(%Face{} = face) do
+    import Bitwise
+
+    attrs = if face.bold, do: @attr_bold, else: 0
+    attrs = if face.underline, do: attrs ||| @attr_underline, else: attrs
+    attrs = if face.italic, do: attrs ||| @attr_italic, else: attrs
+    if face.reverse, do: attrs ||| @attr_reverse, else: attrs
   end
 
   @spec encode_attrs_extended(style()) :: non_neg_integer()

--- a/lib/minga_editor/lsp_actions.ex
+++ b/lib/minga_editor/lsp_actions.ex
@@ -177,6 +177,12 @@ defmodule MingaEditor.LspActions do
 
   @doc "Cancels the debounce timer and clears highlights."
   @spec clear_document_highlights(state()) :: state()
+  def clear_document_highlights(
+        %{workspace: %{document_highlights: nil}, lsp: %{highlight_debounce_timer: nil}} = state
+      ) do
+    state
+  end
+
   def clear_document_highlights(state) do
     state
     |> cancel_highlight_timer()

--- a/lib/minga_editor/render_pipeline.ex
+++ b/lib/minga_editor/render_pipeline.ex
@@ -115,7 +115,7 @@ defmodule MingaEditor.RenderPipeline do
     window_frames = buffer_frames ++ agent_chat_frames
 
     # Stage 5: Chrome (skip rebuild when inputs unchanged)
-    chrome_fp = Input.chrome_fingerprint(input)
+    chrome_fp = Input.chrome_fingerprint(input, scrolls)
     prev_chrome_fp = input.caches.chrome_prev_fingerprint
     prev_chrome = input.caches.chrome_prev_result
 

--- a/lib/minga_editor/render_pipeline/chrome.ex
+++ b/lib/minga_editor/render_pipeline/chrome.ex
@@ -30,7 +30,8 @@ defmodule MingaEditor.RenderPipeline.Chrome do
             file_tree: [],
             agent_panel: [],
             overlays: [],
-            regions: []
+            regions: [],
+            stable_fingerprint: nil
 
   @type t :: %__MODULE__{
           status_bar_draws: [DisplayList.draw()],
@@ -44,7 +45,8 @@ defmodule MingaEditor.RenderPipeline.Chrome do
           file_tree: [DisplayList.draw()],
           agent_panel: [DisplayList.draw()],
           overlays: [DisplayList.Overlay.t()],
-          regions: [binary()]
+          regions: [binary()],
+          stable_fingerprint: integer() | nil
         }
 
   @typedoc "Editor state or render pipeline input."

--- a/lib/minga_editor/render_pipeline/content.ex
+++ b/lib/minga_editor/render_pipeline/content.ex
@@ -201,9 +201,9 @@ defmodule MingaEditor.RenderPipeline.Content do
 
     win_frame = %WindowFrame{
       rect: {0, 0, content_width, content_height},
-      gutter: DisplayList.draws_to_layer(gutter_draws),
-      lines: DisplayList.draws_to_layer(line_draws),
-      tilde_lines: DisplayList.draws_to_layer(tilde_draws),
+      gutter: DisplayList.draws_to_layer_sorted(gutter_draws),
+      lines: DisplayList.draws_to_layer_sorted(line_draws),
+      tilde_lines: DisplayList.draws_to_layer_sorted(tilde_draws),
       modeline: %{},
       cursor: buf_cursor,
       semantic: semantic

--- a/lib/minga_editor/render_pipeline/content.ex
+++ b/lib/minga_editor/render_pipeline/content.ex
@@ -135,15 +135,21 @@ defmodule MingaEditor.RenderPipeline.Content do
       fold_map: window.fold_map
     }
 
-    {gutter_draws, line_draws, rows_used, window} =
-      if wrap_on do
-        # Wrapping and folding are mutually exclusive for now.
-        # Strip fold-specific keys so the type matches line_render_opts.
-        wrap_opts = Map.drop(line_opts, [:visible_line_map, :fold_map])
-        {g, l, r} = ContentHelpers.render_lines_wrapped(lines, visible_rows, wrap_opts)
-        {g, l, r, window}
-      else
-        ContentHelpers.render_lines_nowrap(lines, line_opts)
+    {gutter_layer, line_layer, rows_used, window} =
+      cond do
+        wrap_on ->
+          # Wrapping and folding are mutually exclusive for now.
+          # Strip fold-specific keys so the type matches line_render_opts.
+          wrap_opts = Map.drop(line_opts, [:visible_line_map, :fold_map])
+          {g, l, r} = ContentHelpers.render_lines_wrapped(lines, visible_rows, wrap_opts)
+          {DisplayList.draws_to_layer_sorted(g), DisplayList.draws_to_layer_sorted(l), r, window}
+
+        scroll.visible_line_map == nil ->
+          ContentHelpers.render_lines_nowrap_layers(lines, line_opts)
+
+        true ->
+          {g, l, r, window} = ContentHelpers.render_lines_nowrap(lines, line_opts)
+          {DisplayList.draws_to_layer_sorted(g), DisplayList.draws_to_layer_sorted(l), r, window}
       end
 
     # Tilde lines for empty space below content
@@ -201,8 +207,8 @@ defmodule MingaEditor.RenderPipeline.Content do
 
     win_frame = %WindowFrame{
       rect: {0, 0, content_width, content_height},
-      gutter: DisplayList.draws_to_layer_sorted(gutter_draws),
-      lines: DisplayList.draws_to_layer_sorted(line_draws),
+      gutter: gutter_layer,
+      lines: line_layer,
       tilde_lines: DisplayList.draws_to_layer_sorted(tilde_draws),
       modeline: %{},
       cursor: buf_cursor,

--- a/lib/minga_editor/render_pipeline/content.ex
+++ b/lib/minga_editor/render_pipeline/content.ex
@@ -109,6 +109,7 @@ defmodule MingaEditor.RenderPipeline.Content do
         gutter_w: gutter_w,
         content_w: content_w,
         has_sign_column: has_sign_column,
+        file_path: snapshot.file_path,
         is_active: is_active,
         is_gui: MingaEditor.Frontend.gui?(state.capabilities)
       })

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -211,44 +211,38 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
         List.duplicate(nil, max_rows)
       end
 
-    {gutter_layer, content_layer, _byte_off, window} =
-      lines
-      |> Enum.zip(highlight_segments_list)
-      |> Enum.with_index()
-      |> Enum.reduce(
-        {%{}, %{}, first_byte_off, window},
-        fn {{line_text, hl_segments}, screen_row}, {g_layer, c_layer, byte_off, win} ->
-          buf_line = first_line + screen_row
-          next_byte_off = byte_off + byte_size(line_text) + 1
+    {gutter_layer, content_layer, _byte_off, window, _screen_row} =
+      Enum.zip_reduce(lines, highlight_segments_list, {%{}, %{}, first_byte_off, window, 0}, fn line_text, hl_segments, {g_layer, c_layer, byte_off, win, screen_row} ->
+        buf_line = first_line + screen_row
+        next_byte_off = byte_off + byte_size(line_text) + 1
 
-          if Window.dirty?(win, buf_line) do
-            {g_cmds, c_cmds, _rows} =
-              BufferLine.render(%{
-                line_text: line_text,
-                buf_line: buf_line,
-                cursor_line: cursor_line,
-                byte_offset: byte_off,
-                screen_row: screen_row,
-                ctx: ctx,
-                ln_style: ln_style,
-                gutter_w: gutter_w,
-                sign_w: sign_w,
-                wrap_entry: nil,
-                max_rows: max_rows,
-                row_offset: row_off,
-                col_offset: col_off,
-                highlight_segments: hl_segments
-              })
+        if Window.dirty?(win, buf_line) do
+          {g_cmds, c_cmds, _rows} =
+            BufferLine.render(%{
+              line_text: line_text,
+              buf_line: buf_line,
+              cursor_line: cursor_line,
+              byte_offset: byte_off,
+              screen_row: screen_row,
+              ctx: ctx,
+              ln_style: ln_style,
+              gutter_w: gutter_w,
+              sign_w: sign_w,
+              wrap_entry: nil,
+              max_rows: max_rows,
+              row_offset: row_off,
+              col_offset: col_off,
+              highlight_segments: hl_segments
+            })
 
-            win = Window.cache_line(win, buf_line, g_cmds, c_cmds)
-            {put_draws(g_layer, g_cmds), put_draws(c_layer, c_cmds), next_byte_off, win}
-          else
-            g_cmds = Map.get(win.render_cache.cached_gutter, buf_line, [])
-            c_cmds = Map.get(win.render_cache.cached_content, buf_line, [])
-            {put_draws(g_layer, g_cmds), put_draws(c_layer, c_cmds), next_byte_off, win}
-          end
+          win = Window.cache_line(win, buf_line, g_cmds, c_cmds)
+          {put_draws(g_layer, g_cmds), put_draws(c_layer, c_cmds), next_byte_off, win, screen_row + 1}
+        else
+          g_cmds = Map.get(win.render_cache.cached_gutter, buf_line, [])
+          c_cmds = Map.get(win.render_cache.cached_content, buf_line, [])
+          {put_draws(g_layer, g_cmds), put_draws(c_layer, c_cmds), next_byte_off, win, screen_row + 1}
         end
-      )
+      end)
 
     {gutter_layer, content_layer, length(lines), window}
   end

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -179,6 +179,84 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
     end
   end
 
+  @doc "Renders non-wrapped, non-folded lines directly into render layers."
+  @spec render_lines_nowrap_layers([String.t()], map()) ::
+          {DisplayList.render_layer(), DisplayList.render_layer(), non_neg_integer(), Window.t()}
+  def render_lines_nowrap_layers(lines, opts) do
+    %{
+      first_line: first_line,
+      cursor_line: cursor_line,
+      ctx: ctx,
+      ln_style: ln_style,
+      gutter_w: gutter_w,
+      first_byte_off: first_byte_off,
+      row_off: row_off,
+      col_off: col_off,
+      window: window
+    } = opts
+
+    sign_w = Gutter.sign_column_width()
+    max_rows = length(lines)
+
+    highlight_segments_list =
+      if ctx.highlight do
+        lines_with_offsets = build_lines_with_offsets(lines, first_byte_off)
+        Highlight.styles_for_visible_lines(ctx.highlight, lines_with_offsets)
+      else
+        List.duplicate(nil, max_rows)
+      end
+
+    {gutter_layer, content_layer, _byte_off, window} =
+      lines
+      |> Enum.zip(highlight_segments_list)
+      |> Enum.with_index()
+      |> Enum.reduce(
+        {%{}, %{}, first_byte_off, window},
+        fn {{line_text, hl_segments}, screen_row}, {g_layer, c_layer, byte_off, win} ->
+          buf_line = first_line + screen_row
+          next_byte_off = byte_off + byte_size(line_text) + 1
+
+          if Window.dirty?(win, buf_line) do
+            {g_cmds, c_cmds, _rows} =
+              BufferLine.render(%{
+                line_text: line_text,
+                buf_line: buf_line,
+                cursor_line: cursor_line,
+                byte_offset: byte_off,
+                screen_row: screen_row,
+                ctx: ctx,
+                ln_style: ln_style,
+                gutter_w: gutter_w,
+                sign_w: sign_w,
+                wrap_entry: nil,
+                max_rows: max_rows,
+                row_offset: row_off,
+                col_offset: col_off,
+                highlight_segments: hl_segments
+              })
+
+            win = Window.cache_line(win, buf_line, g_cmds, c_cmds)
+            {put_draws(g_layer, g_cmds), put_draws(c_layer, c_cmds), next_byte_off, win}
+          else
+            g_cmds = Map.get(win.render_cache.cached_gutter, buf_line, [])
+            c_cmds = Map.get(win.render_cache.cached_content, buf_line, [])
+            {put_draws(g_layer, g_cmds), put_draws(c_layer, c_cmds), next_byte_off, win}
+          end
+        end
+      )
+
+    {gutter_layer, content_layer, length(lines), window}
+  end
+
+  @spec put_draws(DisplayList.render_layer(), [DisplayList.draw()]) :: DisplayList.render_layer()
+  defp put_draws(layer, []), do: layer
+
+  defp put_draws(layer, draws) do
+    Enum.reduce(draws, layer, fn {row, col, text, style}, acc ->
+      Map.update(acc, row, [{col, text, style}], fn runs -> runs ++ [{col, text, style}] end)
+    end)
+  end
+
   # Standard sequential rendering (no folds, zero overhead fast path)
   @spec render_lines_nowrap_sequential([String.t()], map()) ::
           {[DisplayList.draw()], [DisplayList.draw()], non_neg_integer(), Window.t()}

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -933,11 +933,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
   @spec context_fingerprint(Context.t(), boolean()) ::
           MingaEditor.Window.RenderCache.context_fingerprint()
   def context_fingerprint(%Context{} = ctx, is_active) do
-    hl_id =
-      case ctx.highlight do
-        nil -> nil
-        hl -> hl.version
-      end
+    hl_id = nil
 
     {
       ctx.visual_selection,

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -201,12 +201,11 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
 
     highlight_segments_list =
       if ctx.highlight do
-        lines_with_offsets = build_lines_with_offsets(lines, first_byte_off)
-
         if MapSet.size(dirty_rows) == max_rows do
+          lines_with_offsets = build_lines_with_offsets(lines, first_byte_off)
           Highlight.styles_for_visible_lines(ctx.highlight, lines_with_offsets)
         else
-          Highlight.styles_for_visible_lines_masked(ctx.highlight, lines_with_offsets, dirty_rows)
+          Highlight.styles_for_text_lines_masked(ctx.highlight, lines, first_byte_off, dirty_rows)
         end
       else
         List.duplicate(nil, max_rows)

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -149,7 +149,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       is_gui: is_gui,
       has_sign_column: has_sign_column,
       decorations: decorations,
-      diagnostic_signs: diagnostic_signs_for_window(window),
+      diagnostic_signs: diagnostic_signs_for_path(Map.get(params, :file_path)),
       git_signs: git_signs_for_window(window),
       gutter_colors: state.theme.gutter,
       git_colors: state.theme.git
@@ -966,8 +966,16 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
   def diagnostic_signs_for_window(%{buffer: buf}) when is_pid(buf) do
     case Buffer.file_path(buf) do
       nil -> %{}
-      path -> Diagnostics.severity_by_line(SyncServer.path_to_uri(path))
+      path -> diagnostic_signs_for_path(path)
     end
+  end
+
+  @doc "Returns diagnostic signs for a buffer path."
+  @spec diagnostic_signs_for_path(String.t() | nil) :: %{non_neg_integer() => atom()}
+  def diagnostic_signs_for_path(nil), do: %{}
+
+  def diagnostic_signs_for_path(path) when is_binary(path) do
+    Diagnostics.severity_by_line(SyncServer.path_to_uri(path))
   end
 
   # ── Visual selection ───────────────────────────────────────────────────────

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -197,11 +197,17 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
 
     sign_w = Gutter.sign_column_width()
     max_rows = length(lines)
+    dirty_rows = dirty_screen_rows(lines, first_line, window)
 
     highlight_segments_list =
       if ctx.highlight do
         lines_with_offsets = build_lines_with_offsets(lines, first_byte_off)
-        Highlight.styles_for_visible_lines(ctx.highlight, lines_with_offsets)
+
+        if MapSet.size(dirty_rows) == max_rows do
+          Highlight.styles_for_visible_lines(ctx.highlight, lines_with_offsets)
+        else
+          Highlight.styles_for_visible_lines_masked(ctx.highlight, lines_with_offsets, dirty_rows)
+        end
       else
         List.duplicate(nil, max_rows)
       end
@@ -246,6 +252,15 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       )
 
     {gutter_layer, content_layer, length(lines), window}
+  end
+
+  @spec dirty_screen_rows([String.t()], non_neg_integer(), Window.t()) :: MapSet.t(non_neg_integer())
+  defp dirty_screen_rows(lines, first_line, window) do
+    lines
+    |> Enum.with_index()
+    |> Enum.reduce(MapSet.new(), fn {_line, index}, acc ->
+      if Window.dirty?(window, first_line + index), do: MapSet.put(acc, index), else: acc
+    end)
   end
 
   @spec put_draws(DisplayList.render_layer(), [DisplayList.draw()]) :: DisplayList.render_layer()

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -212,42 +212,52 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       end
 
     {gutter_layer, content_layer, _byte_off, window, _screen_row} =
-      Enum.zip_reduce(lines, highlight_segments_list, {%{}, %{}, first_byte_off, window, 0}, fn line_text, hl_segments, {g_layer, c_layer, byte_off, win, screen_row} ->
-        buf_line = first_line + screen_row
-        next_byte_off = byte_off + byte_size(line_text) + 1
+      Enum.zip_reduce(
+        lines,
+        highlight_segments_list,
+        {%{}, %{}, first_byte_off, window, 0},
+        fn line_text, hl_segments, {g_layer, c_layer, byte_off, win, screen_row} ->
+          buf_line = first_line + screen_row
+          next_byte_off = byte_off + byte_size(line_text) + 1
 
-        if Window.dirty?(win, buf_line) do
-          {g_cmds, c_cmds, _rows} =
-            BufferLine.render(%{
-              line_text: line_text,
-              buf_line: buf_line,
-              cursor_line: cursor_line,
-              byte_offset: byte_off,
-              screen_row: screen_row,
-              ctx: ctx,
-              ln_style: ln_style,
-              gutter_w: gutter_w,
-              sign_w: sign_w,
-              wrap_entry: nil,
-              max_rows: max_rows,
-              row_offset: row_off,
-              col_offset: col_off,
-              highlight_segments: hl_segments
-            })
+          if Window.dirty?(win, buf_line) do
+            {g_cmds, c_cmds, _rows} =
+              BufferLine.render(%{
+                line_text: line_text,
+                buf_line: buf_line,
+                cursor_line: cursor_line,
+                byte_offset: byte_off,
+                screen_row: screen_row,
+                ctx: ctx,
+                ln_style: ln_style,
+                gutter_w: gutter_w,
+                sign_w: sign_w,
+                wrap_entry: nil,
+                max_rows: max_rows,
+                row_offset: row_off,
+                col_offset: col_off,
+                highlight_segments: hl_segments
+              })
 
-          win = Window.cache_line(win, buf_line, g_cmds, c_cmds)
-          {put_draws(g_layer, g_cmds), put_draws(c_layer, c_cmds), next_byte_off, win, screen_row + 1}
-        else
-          g_cmds = Map.get(win.render_cache.cached_gutter, buf_line, [])
-          c_cmds = Map.get(win.render_cache.cached_content, buf_line, [])
-          {put_draws(g_layer, g_cmds), put_draws(c_layer, c_cmds), next_byte_off, win, screen_row + 1}
+            win = Window.cache_line(win, buf_line, g_cmds, c_cmds)
+
+            {put_draws(g_layer, g_cmds), put_draws(c_layer, c_cmds), next_byte_off, win,
+             screen_row + 1}
+          else
+            g_cmds = Map.get(win.render_cache.cached_gutter, buf_line, [])
+            c_cmds = Map.get(win.render_cache.cached_content, buf_line, [])
+
+            {put_draws(g_layer, g_cmds), put_draws(c_layer, c_cmds), next_byte_off, win,
+             screen_row + 1}
+          end
         end
-      end)
+      )
 
     {gutter_layer, content_layer, length(lines), window}
   end
 
-  @spec dirty_screen_rows([String.t()], non_neg_integer(), Window.t()) :: MapSet.t(non_neg_integer())
+  @spec dirty_screen_rows([String.t()], non_neg_integer(), Window.t()) ::
+          MapSet.t(non_neg_integer())
   defp dirty_screen_rows(lines, first_line, window) do
     lines
     |> Enum.with_index()
@@ -913,7 +923,9 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
 
   @spec maybe_build_vt_line_cache(Decorations.t()) :: Decorations.t()
   defp maybe_build_vt_line_cache(%Decorations{virtual_texts: []} = decorations), do: decorations
-  defp maybe_build_vt_line_cache(%Decorations{} = decorations), do: Decorations.build_vt_line_cache(decorations)
+
+  defp maybe_build_vt_line_cache(%Decorations{} = decorations),
+    do: Decorations.build_vt_line_cache(decorations)
 
   @doc "Returns the highlight state for a window's buffer."
   @spec window_highlight(state(), Window.t()) :: MingaEditor.UI.Highlight.t() | nil

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -920,11 +920,10 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
   @spec window_highlight(state(), Window.t()) :: MingaEditor.UI.Highlight.t() | nil
   def window_highlight(state, window) do
     hl =
-      Map.get(
-        state.workspace.highlight.highlights,
-        window.buffer,
-        MingaEditor.UI.Highlight.from_theme(state.theme)
-      )
+      case Map.fetch(state.workspace.highlight.highlights, window.buffer) do
+        {:ok, highlight} -> highlight
+        :error -> MingaEditor.UI.Highlight.from_theme(state.theme)
+      end
 
     if hl.capture_names == {} do
       nil

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -908,13 +908,18 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
   @doc "Returns the decorations for a window's buffer."
   @spec window_decorations(Window.t()) :: Decorations.t()
   def window_decorations(%{buffer: buf}) when is_pid(buf) do
-    Buffer.decorations(buf)
-    |> Decorations.build_vt_line_cache()
+    buf
+    |> Buffer.decorations()
+    |> maybe_build_vt_line_cache()
   catch
     :exit, _ -> Decorations.new()
   end
 
   def window_decorations(_window), do: Decorations.new()
+
+  @spec maybe_build_vt_line_cache(Decorations.t()) :: Decorations.t()
+  defp maybe_build_vt_line_cache(%Decorations{virtual_texts: []} = decorations), do: decorations
+  defp maybe_build_vt_line_cache(%Decorations{} = decorations), do: Decorations.build_vt_line_cache(decorations)
 
   @doc "Returns the highlight state for a window's buffer."
   @spec window_highlight(state(), Window.t()) :: MingaEditor.UI.Highlight.t() | nil

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -191,7 +191,8 @@ defmodule MingaEditor.RenderPipeline.Input do
     chrome_fingerprint(input, fingerprint_data)
   end
 
-  @spec chrome_fingerprint(t(), {{non_neg_integer(), non_neg_integer()}, non_neg_integer()}) :: integer()
+  @spec chrome_fingerprint(t(), {{non_neg_integer(), non_neg_integer()}, non_neg_integer()}) ::
+          integer()
   def chrome_fingerprint(%__MODULE__{} = input, {buf_cursor, buf_version}) do
     # Hash the fields that drive chrome output. We use :erlang.phash2
     # for speed (no crypto needed, just change detection).

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -174,15 +174,32 @@ defmodule MingaEditor.RenderPipeline.Input do
   """
   @spec chrome_fingerprint(t()) :: integer()
   def chrome_fingerprint(%__MODULE__{} = input) do
+    buf = input.workspace.buffers.active
+    chrome_fingerprint(input, buffer_fingerprint_data(buf))
+  end
+
+  @spec chrome_fingerprint(t(), map()) :: integer()
+  def chrome_fingerprint(%__MODULE__{} = input, scrolls) when is_map(scrolls) do
+    active = input.workspace.windows.active
+
+    fingerprint_data =
+      case Map.get(scrolls, active) do
+        %{cursor_line: line, cursor_byte_col: col, buf_version: version} -> {{line, col}, version}
+        _ -> buffer_fingerprint_data(input.workspace.buffers.active)
+      end
+
+    chrome_fingerprint(input, fingerprint_data)
+  end
+
+  @spec chrome_fingerprint(t(), {{non_neg_integer(), non_neg_integer()}, non_neg_integer()}) :: integer()
+  def chrome_fingerprint(%__MODULE__{} = input, {buf_cursor, buf_version}) do
     # Hash the fields that drive chrome output. We use :erlang.phash2
     # for speed (no crypto needed, just change detection).
     #
     # Includes the active buffer's cursor and version because the status
-    # bar displays cursor position, line count, and dirty state. These
-    # are fetched from the buffer GenServer, so we read them here to
-    # ensure the fingerprint changes when they do.
-    buf = input.workspace.buffers.active
-    {buf_cursor, buf_version} = buffer_fingerprint_data(buf)
+    # bar displays cursor position, line count, and dirty state. The render
+    # pipeline passes scroll-stage buffer data when available so this does
+    # not need duplicate GenServer calls in the hot path.
 
     :erlang.phash2({
       # Buffer state for status bar (cursor pos, version/dirty)

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -386,7 +386,14 @@ defmodule MingaEditor.RenderPipeline.Scroll do
           pos_integer(),
           non_neg_integer()
         ) :: Viewport.t()
-  defp scroll_horizontal(vp, _cursor_line, _cursor_col, true = _wrap_on, _content_w, _scroll_margin) do
+  defp scroll_horizontal(
+         vp,
+         _cursor_line,
+         _cursor_col,
+         true = _wrap_on,
+         _content_w,
+         _scroll_margin
+       ) do
     # Wrapping: no horizontal scroll needed. Just reset left to 0.
     # Vertical scroll is handled separately above (save/restore pattern).
     %{vp | left: 0}

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -155,7 +155,8 @@ defmodule MingaEditor.RenderPipeline.Scroll do
             scroll.viewport.top,
             scroll.gutter_w,
             scroll.snapshot.line_count,
-            scroll.buf_version
+            scroll.buf_version,
+            scroll.cursor_line
           )
 
         updated_window =

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -203,6 +203,7 @@ defmodule MingaEditor.RenderPipeline.Scroll do
     # Ctrl-e/y, zz/zt/zb, and mouse wheel scroll actually persist.
     # scroll_to_cursor only adjusts top when the cursor moves off-screen.
     wrap_on = wrap_enabled?(window.buffer)
+    scroll_margin = scroll_margin(window.buffer)
     fold_map = window.fold_map
     %Viewport{} = win_vp = window.viewport
     viewport = %{win_vp | rows: content_height, cols: content_width, reserved: 0}
@@ -224,7 +225,7 @@ defmodule MingaEditor.RenderPipeline.Scroll do
     # that only modifies `top`. The same trap exists in mouse.ex:934 and
     # content.ex:470 where {cursor_line, 0} silently resets left.
     saved_left = viewport.left
-    viewport = Viewport.scroll_to_cursor(viewport, {visible_cursor_line, 0}, window.buffer)
+    viewport = Viewport.scroll_to_cursor(viewport, {visible_cursor_line, 0}, scroll_margin)
     viewport = %{viewport | left: saved_left}
     visible_rows = Viewport.content_rows(viewport)
 
@@ -296,7 +297,7 @@ defmodule MingaEditor.RenderPipeline.Scroll do
     # so the cursor triggers scroll when it reaches the content edge,
     # not the full viewport edge.
     viewport =
-      scroll_horizontal(viewport, cursor_line, cursor_col, wrap_on, content_w, window.buffer)
+      scroll_horizontal(viewport, cursor_line, cursor_col, wrap_on, content_w, scroll_margin)
 
     # Substitution preview (active window only)
     {lines, preview_matches} =
@@ -383,20 +384,27 @@ defmodule MingaEditor.RenderPipeline.Scroll do
           non_neg_integer(),
           boolean(),
           pos_integer(),
-          pid()
+          non_neg_integer()
         ) :: Viewport.t()
-  defp scroll_horizontal(vp, _cursor_line, _cursor_col, true = _wrap_on, _content_w, _buf) do
+  defp scroll_horizontal(vp, _cursor_line, _cursor_col, true = _wrap_on, _content_w, _scroll_margin) do
     # Wrapping: no horizontal scroll needed. Just reset left to 0.
     # Vertical scroll is handled separately above (save/restore pattern).
     %{vp | left: 0}
   end
 
-  defp scroll_horizontal(vp, cursor_line, cursor_col, false = _wrap_on, content_w, buf) do
+  defp scroll_horizontal(vp, cursor_line, cursor_col, false = _wrap_on, content_w, scroll_margin) do
     # Temporarily set cols to content_w (excluding gutter) so adjust_left
     # triggers scroll at the content edge, not the full viewport edge.
     content_vp = %{vp | cols: content_w}
-    adjusted = Viewport.scroll_to_cursor(content_vp, {cursor_line, cursor_col}, buf)
+    adjusted = Viewport.scroll_to_cursor(content_vp, {cursor_line, cursor_col}, scroll_margin)
     %{vp | left: adjusted.left}
+  end
+
+  @spec scroll_margin(pid()) :: non_neg_integer()
+  defp scroll_margin(buf) do
+    Buffer.get_option(buf, :scroll_margin)
+  catch
+    :exit, _ -> 5
   end
 
   @spec wrap_enabled?(pid()) :: boolean()

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -393,11 +393,15 @@ defmodule MingaEditor.RenderPipeline.Scroll do
   end
 
   defp scroll_horizontal(vp, cursor_line, cursor_col, false = _wrap_on, content_w, scroll_margin) do
-    # Temporarily set cols to content_w (excluding gutter) so adjust_left
-    # triggers scroll at the content edge, not the full viewport edge.
-    content_vp = %{vp | cols: content_w}
-    adjusted = Viewport.scroll_to_cursor(content_vp, {cursor_line, cursor_col}, scroll_margin)
-    %{vp | left: adjusted.left}
+    if cursor_col >= vp.left and cursor_col < vp.left + content_w do
+      vp
+    else
+      # Temporarily set cols to content_w (excluding gutter) so adjust_left
+      # triggers scroll at the content edge, not the full viewport edge.
+      content_vp = %{vp | cols: content_w}
+      adjusted = Viewport.scroll_to_cursor(content_vp, {cursor_line, cursor_col}, scroll_margin)
+      %{vp | left: adjusted.left}
+    end
   end
 
   @spec scroll_margin(pid()) :: non_neg_integer()

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -430,8 +430,11 @@ defmodule MingaEditor.RenderPipeline.Scroll do
   defp cursor_line_text(lines, cursor_line, first_line) do
     index = cursor_line - first_line
 
-    if index >= 0 and index < length(lines) do
-      Enum.at(lines, index)
+    if index >= 0 do
+      case Enum.fetch(lines, index) do
+        {:ok, line} -> line
+        :error -> ""
+      end
     else
       ""
     end

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -242,21 +242,26 @@ defmodule MingaEditor.RenderPipeline.Scroll do
     # The DisplayMap merges per-window folds, decoration folds, and virtual
     # lines into a unified mapping. Falls back to VisibleLines when there
     # are no decoration folds or virtual lines (pure window-fold case).
-    line_count_approx = Buffer.line_count(window.buffer)
     decorations = fetch_decorations(window.buffer)
 
     # Two-pass scroll: compute DisplayMap, then verify cursor is visible.
     # If decorations push the cursor off-screen, adjust first_line and recompute.
     {first_line, visible_line_map} =
-      compute_display_map_with_cursor_check(
-        fold_map,
-        decorations,
-        first_line,
-        visible_rows,
-        line_count_approx,
-        content_width,
-        cursor_line
-      )
+      if DisplayMap.required?(fold_map, decorations) do
+        line_count_approx = Buffer.line_count(window.buffer)
+
+        compute_display_map_with_cursor_check(
+          fold_map,
+          decorations,
+          first_line,
+          visible_rows,
+          line_count_approx,
+          content_width,
+          cursor_line
+        )
+      else
+        {first_line, nil}
+      end
 
     # Fetch buffer data: need to cover all visible buffer lines
     {fetch_first, fetch_count} =

--- a/lib/minga_editor/renderer/buffer_line.ex
+++ b/lib/minga_editor/renderer/buffer_line.ex
@@ -29,6 +29,8 @@ defmodule MingaEditor.Renderer.BufferLine do
   alias Minga.Core.WrapMap
   alias MingaEditor.UI.Highlight
 
+  @compile {:inline, render_single_row: 1}
+
   @typedoc """
   Per-line values that vary across lines in a render pass.
 

--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -44,54 +44,88 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
     {status_bar_draws, status_bar_data, modeline_click_regions} =
       build_status_bar(state, layout)
 
-    # Vertical split borders
-    vertical_separators =
-      if MingaEditor.State.Windows.split?(state.workspace.windows) do
-        ChromeHelpers.render_separators(
-          state.workspace.windows.tree,
-          layout.editor_area,
-          elem(layout.editor_area, 3),
-          state.theme
-        )
-      else
-        []
+    stable_fp = stable_chrome_fingerprint(state, layout)
+
+    stable =
+      case state.caches.chrome_prev_result do
+        %Chrome{stable_fingerprint: ^stable_fp} = prev ->
+          prev
+
+        _ ->
+          # Vertical split borders
+          vertical_separators =
+            if MingaEditor.State.Windows.split?(state.workspace.windows) do
+              ChromeHelpers.render_separators(
+                state.workspace.windows.tree,
+                layout.editor_area,
+                elem(layout.editor_area, 3),
+                state.theme
+              )
+            else
+              []
+            end
+
+          # Horizontal split separators (filename bars)
+          horizontal_separators =
+            ChromeHelpers.render_horizontal_separators(layout.horizontal_separators, state.theme)
+
+          separator_draws = vertical_separators ++ horizontal_separators
+
+          # File tree
+          tree_draws = TreeRenderer.render(state)
+
+          # Minibuffer
+          {minibuffer_row, _mbc, _mbw, _mbh} = layout.minibuffer
+          minibuffer_draw = Minibuffer.render(state, minibuffer_row, full_viewport.cols)
+
+          # Tab bar
+          {tab_bar_draws, tab_bar_regions} = ChromeHelpers.render_tab_bar(state, layout)
+
+          # Region definitions
+          regions = Regions.define_regions(layout)
+
+          %Chrome{
+            stable_fingerprint: stable_fp,
+            tab_bar: tab_bar_draws,
+            tab_bar_click_regions: tab_bar_regions,
+            minibuffer: [minibuffer_draw],
+            separators: separator_draws,
+            file_tree: tree_draws,
+            regions: regions
+          }
       end
-
-    # Horizontal split separators (filename bars)
-    horizontal_separators =
-      ChromeHelpers.render_horizontal_separators(layout.horizontal_separators, state.theme)
-
-    separator_draws = vertical_separators ++ horizontal_separators
-
-    # File tree
-    tree_draws = TreeRenderer.render(state)
-
-    # Minibuffer
-    {minibuffer_row, _mbc, _mbw, _mbh} = layout.minibuffer
-    minibuffer_draw = Minibuffer.render(state, minibuffer_row, full_viewport.cols)
 
     # Overlays (all types for TUI)
     overlays = build_overlays(state, full_viewport, cursor_info)
-
-    # Tab bar
-    {tab_bar_draws, tab_bar_regions} = ChromeHelpers.render_tab_bar(state, layout)
-
-    # Region definitions
-    regions = Regions.define_regions(layout)
 
     %Chrome{
       status_bar_draws: status_bar_draws,
       status_bar_data: status_bar_data,
       modeline_click_regions: modeline_click_regions,
-      tab_bar: tab_bar_draws,
-      tab_bar_click_regions: tab_bar_regions,
-      minibuffer: [minibuffer_draw],
-      separators: separator_draws,
-      file_tree: tree_draws,
+      tab_bar: stable.tab_bar,
+      tab_bar_click_regions: stable.tab_bar_click_regions,
+      minibuffer: stable.minibuffer,
+      separators: stable.separators,
+      file_tree: stable.file_tree,
       agent_panel: [],
       overlays: overlays,
-      regions: regions
+      regions: stable.regions,
+      stable_fingerprint: stable_fp
     }
+  end
+
+  @spec stable_chrome_fingerprint(state(), Layout.t()) :: integer()
+  defp stable_chrome_fingerprint(state, layout) do
+    :erlang.phash2({
+      layout.editor_area,
+      layout.horizontal_separators,
+      layout.minibuffer,
+      layout.status_bar,
+      state.workspace.windows.tree,
+      state.workspace.file_tree,
+      state.shell_state |> Map.get(:tab_bar),
+      state.theme
+    })
   end
 
   @spec build_status_bar(state(), Layout.t()) ::

--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -45,7 +45,7 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
     {status_bar_draws, status_bar_data, modeline_click_regions} =
       build_status_bar(state, layout, Map.get(scrolls, state.workspace.windows.active))
 
-    stable_fp = stable_chrome_fingerprint(state, layout)
+    stable_fp = stable_chrome_fingerprint(state, layout, status_bar_data)
 
     stable =
       case state.caches.chrome_prev_result do
@@ -115,8 +115,8 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
     }
   end
 
-  @spec stable_chrome_fingerprint(state(), Layout.t()) :: integer()
-  defp stable_chrome_fingerprint(state, layout) do
+  @spec stable_chrome_fingerprint(state(), Layout.t(), StatusBarData.t()) :: integer()
+  defp stable_chrome_fingerprint(state, layout, status_bar_data) do
     :erlang.phash2({
       layout.editor_area,
       layout.horizontal_separators,
@@ -125,6 +125,10 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
       state.workspace.windows.tree,
       state.workspace.file_tree,
       state.shell_state |> Map.get(:tab_bar),
+      state.workspace.editing.mode,
+      state.workspace.editing.mode_state,
+      status_bar_dirty?(status_bar_data),
+      state.shell_state.status_msg,
       state.theme.name
     })
   end
@@ -151,16 +155,10 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
     case state.caches.chrome_prev_result do
       %Chrome{status_bar_data: {:buffer, data}} when is_pid(buf) ->
         {line, col} = scroll_cursor(active_scroll, buf)
+        {line_count, dirty} = scroll_buffer_status(active_scroll, data)
 
         {:buffer,
-         %{
-           data
-           | mode: Minga.Editing.mode(state),
-             mode_state: state.workspace.editing.mode_state,
-             cursor_line: line,
-             cursor_col: col,
-             status_msg: state.shell_state.status_msg
-         }}
+         StatusBarData.refresh_cached_buffer_data(data, state, line, col, line_count, dirty)}
 
       _ ->
         StatusBarData.from_state(state)
@@ -169,9 +167,20 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
     :exit, _ -> StatusBarData.from_state(state)
   end
 
+  @spec status_bar_dirty?(StatusBarData.t()) :: boolean()
+  defp status_bar_dirty?({:buffer, %{dirty: dirty}}), do: dirty
+  defp status_bar_dirty?({:agent, %{dirty: dirty}}), do: dirty
+
   @spec scroll_cursor(map() | nil, pid()) :: {non_neg_integer(), non_neg_integer()}
   defp scroll_cursor(%{cursor_line: line, cursor_byte_col: col}, _buf), do: {line, col}
   defp scroll_cursor(_active_scroll, buf), do: Buffer.cursor(buf)
+
+  @spec scroll_buffer_status(map() | nil, StatusBarData.buffer_data()) ::
+          {non_neg_integer(), boolean()}
+  defp scroll_buffer_status(%{snapshot: %{line_count: line_count, dirty: dirty}}, _data),
+    do: {line_count, dirty}
+
+  defp scroll_buffer_status(_active_scroll, data), do: {data.line_count, data.dirty}
 
   # ── Overlays ──────────────────────────────────────────────────────────────
 

--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
 
   alias MingaEditor.CompletionUI
   alias MingaEditor.DisplayList
+  alias Minga.Buffer
   alias MingaEditor.DisplayList.{Cursor, Overlay}
   alias MingaEditor.Layout
   alias MingaEditor.PickerUI
@@ -137,10 +138,39 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
 
   defp build_status_bar(state, layout) do
     {sb_row, _sb_col, sb_width, _sb_h} = layout.status_bar
-    status_bar_data = StatusBarData.from_state(state)
+    status_bar_data = cached_or_fresh_status_bar_data(state)
     modeline_data = StatusBarData.to_modeline_data(status_bar_data)
     {draws, click_regions} = Modeline.render(sb_row, sb_width, modeline_data, state.theme)
     {draws, status_bar_data, click_regions}
+  end
+
+  @spec cached_or_fresh_status_bar_data(state()) :: StatusBarData.t()
+  defp cached_or_fresh_status_bar_data(state) do
+    buf = state.workspace.buffers.active
+
+    case state.caches.chrome_prev_result do
+      %Chrome{status_bar_data: {:buffer, data}} when is_pid(buf) ->
+        {line, col} = Buffer.cursor(buf)
+        line_count = Buffer.line_count(buf)
+        dirty = Buffer.dirty?(buf)
+
+        {:buffer,
+         %{
+           data
+           | mode: Minga.Editing.mode(state),
+             mode_state: state.workspace.editing.mode_state,
+             cursor_line: line,
+             cursor_col: col,
+             line_count: line_count,
+             dirty: dirty,
+             status_msg: state.shell_state.status_msg
+         }}
+
+      _ ->
+        StatusBarData.from_state(state)
+    end
+  catch
+    :exit, _ -> StatusBarData.from_state(state)
   end
 
   # ── Overlays ──────────────────────────────────────────────────────────────

--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -38,12 +38,12 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
           %{MingaEditor.Window.id() => WindowScroll.t()},
           Cursor.t() | nil
         ) :: Chrome.t()
-  def build(state, layout, _scrolls, cursor_info) do
+  def build(state, layout, scrolls, cursor_info) do
     full_viewport = state.terminal_viewport
 
     # Global status bar (one render for the focused window)
     {status_bar_draws, status_bar_data, modeline_click_regions} =
-      build_status_bar(state, layout)
+      build_status_bar(state, layout, Map.get(scrolls, state.workspace.windows.active))
 
     stable_fp = stable_chrome_fingerprint(state, layout)
 
@@ -129,28 +129,28 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
     })
   end
 
-  @spec build_status_bar(state(), Layout.t()) ::
+  @spec build_status_bar(state(), Layout.t(), map() | nil) ::
           {[DisplayList.draw()], StatusBarData.t(),
            [MingaEditor.Shell.Traditional.Modeline.click_region()]}
-  defp build_status_bar(_state, %{status_bar: nil}) do
+  defp build_status_bar(_state, %{status_bar: nil}, _active_scroll) do
     {[], nil, []}
   end
 
-  defp build_status_bar(state, layout) do
+  defp build_status_bar(state, layout, active_scroll) do
     {sb_row, _sb_col, sb_width, _sb_h} = layout.status_bar
-    status_bar_data = cached_or_fresh_status_bar_data(state)
+    status_bar_data = cached_or_fresh_status_bar_data(state, active_scroll)
     modeline_data = StatusBarData.to_modeline_data(status_bar_data)
     {draws, click_regions} = Modeline.render(sb_row, sb_width, modeline_data, state.theme)
     {draws, status_bar_data, click_regions}
   end
 
-  @spec cached_or_fresh_status_bar_data(state()) :: StatusBarData.t()
-  defp cached_or_fresh_status_bar_data(state) do
+  @spec cached_or_fresh_status_bar_data(state(), map() | nil) :: StatusBarData.t()
+  defp cached_or_fresh_status_bar_data(state, active_scroll) do
     buf = state.workspace.buffers.active
 
     case state.caches.chrome_prev_result do
       %Chrome{status_bar_data: {:buffer, data}} when is_pid(buf) ->
-        {line, col} = Buffer.cursor(buf)
+        {line, col} = scroll_cursor(active_scroll, buf)
 
         {:buffer,
          %{
@@ -168,6 +168,10 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
   catch
     :exit, _ -> StatusBarData.from_state(state)
   end
+
+  @spec scroll_cursor(map() | nil, pid()) :: {non_neg_integer(), non_neg_integer()}
+  defp scroll_cursor(%{cursor_line: line, cursor_byte_col: col}, _buf), do: {line, col}
+  defp scroll_cursor(_active_scroll, buf), do: Buffer.cursor(buf)
 
   # ── Overlays ──────────────────────────────────────────────────────────────
 

--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -151,8 +151,6 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
     case state.caches.chrome_prev_result do
       %Chrome{status_bar_data: {:buffer, data}} when is_pid(buf) ->
         {line, col} = Buffer.cursor(buf)
-        line_count = Buffer.line_count(buf)
-        dirty = Buffer.dirty?(buf)
 
         {:buffer,
          %{
@@ -161,8 +159,6 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
              mode_state: state.workspace.editing.mode_state,
              cursor_line: line,
              cursor_col: col,
-             line_count: line_count,
-             dirty: dirty,
              status_msg: state.shell_state.status_msg
          }}
 

--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -124,7 +124,7 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
       state.workspace.windows.tree,
       state.workspace.file_tree,
       state.shell_state |> Map.get(:tab_bar),
-      state.theme
+      state.theme.name
     })
   end
 

--- a/lib/minga_editor/shell/traditional/modeline.ex
+++ b/lib/minga_editor/shell/traditional/modeline.ex
@@ -74,7 +74,10 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
     ml = theme.modeline
 
     {mode_fg, mode_bg} =
-      Map.get(ml.mode_colors, data.mode, {0x000000, ml.mode_colors.normal |> elem(1)})
+      case Map.fetch(ml.mode_colors, data.mode) do
+        {:ok, colors} -> colors
+        :error -> {0x000000, elem(ml.mode_colors.normal, 1)}
+      end
 
     bar_fg = ml.bar_fg
     bar_bg = ml.bar_bg

--- a/lib/minga_editor/shell/traditional/state.ex
+++ b/lib/minga_editor/shell/traditional/state.ex
@@ -78,6 +78,8 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   @doc "Clears the transient status message."
   @spec clear_status(t()) :: t()
+  def clear_status(%{status_msg: nil} = ss), do: ss
+
   def clear_status(%{} = ss) do
     %{ss | status_msg: nil}
   end

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -120,13 +120,14 @@ defmodule MingaEditor.StatusBar.Data do
     file_name = if buf, do: buf_display_name(buf), else: "[no file]"
     dirty = buf != nil and Buffer.dirty?(buf)
     filetype = if buf, do: buffer_filetype(buf), else: :text
+    file_path = if buf, do: buffer_file_path(buf), else: nil
 
     {git_branch, git_diff_summary} = git_modeline_data(buf)
-    diagnostic_counts = diagnostic_modeline_data(buf)
+    diagnostic_counts = diagnostic_modeline_data_from_path(file_path)
 
     # Fetch diagnostic hint for the current cursor line (shown in status bar
     # center segment when idle, replaces the old cell-grid minibuffer hint)
-    diagnostic_hint = cursor_line_diagnostic_hint(buf, line)
+    diagnostic_hint = cursor_line_diagnostic_hint_from_path(file_path, line)
 
     agent = AgentAccess.agent(state)
 
@@ -168,6 +169,13 @@ defmodule MingaEditor.StatusBar.Data do
     :exit, _ -> :text
   end
 
+  @spec buffer_file_path(pid()) :: String.t() | nil
+  defp buffer_file_path(buf) do
+    Buffer.file_path(buf)
+  catch
+    :exit, _ -> nil
+  end
+
   # ── Agent variant ──────────────────────────────────────────────────────────
 
   @spec build_agent_data(EditorState.t() | map()) :: agent_data()
@@ -196,10 +204,11 @@ defmodule MingaEditor.StatusBar.Data do
     file_name = if buf, do: buf_display_name(buf), else: "[no file]"
     dirty = buf != nil and Buffer.dirty?(buf)
     filetype = if buf, do: buffer_filetype(buf), else: :text
+    file_path = if buf, do: buffer_file_path(buf), else: nil
 
     {git_branch, git_diff_summary} = git_modeline_data(buf)
-    diagnostic_counts = diagnostic_modeline_data(buf)
-    diagnostic_hint = cursor_line_diagnostic_hint(buf, line)
+    diagnostic_counts = diagnostic_modeline_data_from_path(file_path)
+    diagnostic_hint = cursor_line_diagnostic_hint_from_path(file_path, line)
 
     %{
       mode: Minga.Editing.mode(state),
@@ -262,10 +271,15 @@ defmodule MingaEditor.StatusBar.Data do
         :exit, _ -> nil
       end
 
-    case path do
-      nil -> nil
-      path -> Diagnostics.count_tuple(SyncServer.path_to_uri(path))
-    end
+    diagnostic_modeline_data_from_path(path)
+  end
+
+  @spec diagnostic_modeline_data_from_path(String.t() | nil) ::
+          {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil
+  defp diagnostic_modeline_data_from_path(nil), do: nil
+
+  defp diagnostic_modeline_data_from_path(path) do
+    Diagnostics.count_tuple(SyncServer.path_to_uri(path))
   end
 
   # ── Diagnostic hint for status bar ──────────────────────────────────────────
@@ -289,18 +303,18 @@ defmodule MingaEditor.StatusBar.Data do
         :exit, _ -> nil
       end
 
-    case file_path do
-      nil ->
-        nil
+    cursor_line_diagnostic_hint_from_path(file_path, line)
+  end
 
-      path ->
-        uri = SyncServer.path_to_uri(path)
+  @spec cursor_line_diagnostic_hint_from_path(String.t() | nil, non_neg_integer()) :: String.t() | nil
+  defp cursor_line_diagnostic_hint_from_path(nil, _line), do: nil
 
-        uri
-        |> Diagnostics.for_uri()
-        |> Enum.find(fn d -> d.range.start_line == line end)
-        |> format_diagnostic_hint()
-    end
+  defp cursor_line_diagnostic_hint_from_path(path, line) do
+    path
+    |> SyncServer.path_to_uri()
+    |> Diagnostics.for_uri()
+    |> Enum.find(fn d -> d.range.start_line == line end)
+    |> format_diagnostic_hint()
   end
 
   @spec format_diagnostic_hint(Diagnostics.Diagnostic.t() | nil) :: String.t() | nil

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -110,6 +110,28 @@ defmodule MingaEditor.StatusBar.Data do
     end
   end
 
+  @doc "Updates cached buffer status data with the dynamic fields that can change every frame."
+  @spec refresh_cached_buffer_data(
+          buffer_data(),
+          EditorState.t() | map(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean()
+        ) :: buffer_data()
+  def refresh_cached_buffer_data(data, state, line, col, line_count, dirty) do
+    Map.merge(data, %{
+      mode: Minga.Editing.mode(state),
+      mode_state: Editing.mode_state(state),
+      cursor_line: line,
+      cursor_col: col,
+      line_count: line_count,
+      dirty: dirty,
+      macro_recording: Minga.Editing.macro_recording_status(state),
+      status_msg: state.shell_state.status_msg
+    })
+  end
+
   # ── Buffer variant ─────────────────────────────────────────────────────────
 
   @spec build_buffer_data(EditorState.t() | map()) :: buffer_data()
@@ -306,7 +328,8 @@ defmodule MingaEditor.StatusBar.Data do
     cursor_line_diagnostic_hint_from_path(file_path, line)
   end
 
-  @spec cursor_line_diagnostic_hint_from_path(String.t() | nil, non_neg_integer()) :: String.t() | nil
+  @spec cursor_line_diagnostic_hint_from_path(String.t() | nil, non_neg_integer()) ::
+          String.t() | nil
   defp cursor_line_diagnostic_hint_from_path(nil, _line), do: nil
 
   defp cursor_line_diagnostic_hint_from_path(path, line) do

--- a/lib/minga_editor/ui/highlight.ex
+++ b/lib/minga_editor/ui/highlight.ex
@@ -171,45 +171,47 @@ defmodule MingaEditor.UI.Highlight do
     Enum.reverse(results_rev)
   end
 
-  @doc """
-  Batch-computes styled segments only for selected line indexes.
-
-  Clean lines return nil while the span watermark still advances through every visible line.
-  """
-  @spec styles_for_visible_lines_masked(t(), [{String.t(), non_neg_integer()}], MapSet.t(non_neg_integer()), style_resolver() | nil) ::
-          [[styled_segment()] | nil]
-  def styles_for_visible_lines_masked(hl, lines, dirty_rows, resolver \\ nil)
-
-  def styles_for_visible_lines_masked(%__MODULE__{spans: spans}, lines, dirty_rows, _resolver)
-      when (is_tuple(spans) and tuple_size(spans) == 0) or spans == [] do
-    lines
-    |> Enum.with_index()
-    |> Enum.map(fn {{text, _}, index} -> if MapSet.member?(dirty_rows, index), do: [{text, Face.new()}], else: nil end)
-  end
-
-  def styles_for_visible_lines_masked(%__MODULE__{spans: spans} = hl, lines, dirty_rows, resolver)
-      when is_tuple(spans) and is_list(lines) do
-    span_count = tuple_size(spans)
-    {results_rev, _watermark, _index} = batch_lines_masked(lines, spans, span_count, hl, resolver, dirty_rows, 0, 0, [])
-    Enum.reverse(results_rev)
-  end
-
   @doc "Batch-computes masked styled segments from raw consecutive line text and a starting byte offset."
-  @spec styles_for_text_lines_masked(t(), [String.t()], non_neg_integer(), MapSet.t(non_neg_integer()), style_resolver() | nil) ::
+  @spec styles_for_text_lines_masked(
+          t(),
+          [String.t()],
+          non_neg_integer(),
+          MapSet.t(non_neg_integer()),
+          style_resolver() | nil
+        ) ::
           [[styled_segment()] | nil]
   def styles_for_text_lines_masked(hl, lines, first_byte_offset, dirty_rows, resolver \\ nil)
 
-  def styles_for_text_lines_masked(%__MODULE__{spans: spans}, lines, _first_byte_offset, dirty_rows, _resolver)
+  def styles_for_text_lines_masked(
+        %__MODULE__{spans: spans},
+        lines,
+        _first_byte_offset,
+        dirty_rows,
+        _resolver
+      )
       when (is_tuple(spans) and tuple_size(spans) == 0) or spans == [] do
     lines
     |> Enum.with_index()
-    |> Enum.map(fn {text, index} -> if MapSet.member?(dirty_rows, index), do: [{text, Face.new()}], else: nil end)
+    |> Enum.map(fn {text, index} ->
+      if MapSet.member?(dirty_rows, index), do: [{text, Face.new()}], else: nil
+    end)
   end
 
-  def styles_for_text_lines_masked(%__MODULE__{spans: spans} = hl, lines, first_byte_offset, dirty_rows, resolver)
+  def styles_for_text_lines_masked(
+        %__MODULE__{spans: spans} = hl,
+        lines,
+        first_byte_offset,
+        dirty_rows,
+        resolver
+      )
       when is_tuple(spans) and is_list(lines) do
     span_count = tuple_size(spans)
-    {results_rev, _watermark, _offset, _index} = batch_text_lines_masked(lines, spans, span_count, hl, resolver, dirty_rows, 0, first_byte_offset, 0, [])
+
+    batch = {spans, span_count, hl, resolver, dirty_rows}
+
+    {results_rev, _watermark, _offset, _index} =
+      batch_text_lines_masked(lines, batch, 0, first_byte_offset, 0, [])
+
     Enum.reverse(results_rev)
   end
 
@@ -242,53 +244,28 @@ defmodule MingaEditor.UI.Highlight do
     batch_lines(rest, spans, count, hl, resolver, watermark, [segments | acc])
   end
 
-  @spec batch_lines_masked(
-          [{String.t(), non_neg_integer()}],
-          tuple(),
-          non_neg_integer(),
-          t(),
-          style_resolver() | nil,
-          MapSet.t(non_neg_integer()),
-          non_neg_integer(),
-          non_neg_integer(),
-          [[styled_segment()] | nil]
-        ) :: {[[styled_segment()] | nil], non_neg_integer(), non_neg_integer()}
-  defp batch_lines_masked([], _spans, _count, _hl, _resolver, _dirty_rows, watermark, index, acc), do: {acc, watermark, index}
-
-  defp batch_lines_masked([{line_text, line_start} | rest], spans, count, hl, resolver, dirty_rows, watermark, index, acc) do
-    watermark = advance_watermark(spans, count, watermark, line_start)
-
-    segments =
-      if MapSet.member?(dirty_rows, index) do
-        line_end = line_start + byte_size(line_text)
-        overlapping = collect_overlapping(spans, count, watermark, line_start, line_end, [])
-
-        case overlapping do
-          [] -> [{line_text, Face.new()}]
-          _ -> build_segments(line_text, line_start, overlapping, hl, resolver)
-        end
-      else
-        nil
-      end
-
-    batch_lines_masked(rest, spans, count, hl, resolver, dirty_rows, watermark, index + 1, [segments | acc])
-  end
+  @typep text_mask_batch ::
+           {tuple(), non_neg_integer(), t(), style_resolver() | nil, MapSet.t(non_neg_integer())}
 
   @spec batch_text_lines_masked(
           [String.t()],
-          tuple(),
-          non_neg_integer(),
-          t(),
-          style_resolver() | nil,
-          MapSet.t(non_neg_integer()),
+          text_mask_batch(),
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
           [[styled_segment()] | nil]
         ) :: {[[styled_segment()] | nil], non_neg_integer(), non_neg_integer(), non_neg_integer()}
-  defp batch_text_lines_masked([], _spans, _count, _hl, _resolver, _dirty_rows, watermark, offset, index, acc), do: {acc, watermark, offset, index}
+  defp batch_text_lines_masked([], _batch, watermark, offset, index, acc),
+    do: {acc, watermark, offset, index}
 
-  defp batch_text_lines_masked([line_text | rest], spans, count, hl, resolver, dirty_rows, watermark, line_start, index, acc) do
+  defp batch_text_lines_masked(
+         [line_text | rest],
+         {spans, count, hl, resolver, dirty_rows} = batch,
+         watermark,
+         line_start,
+         index,
+         acc
+       ) do
     watermark = advance_watermark(spans, count, watermark, line_start)
     next_line_start = line_start + byte_size(line_text) + 1
 
@@ -305,7 +282,7 @@ defmodule MingaEditor.UI.Highlight do
         nil
       end
 
-    batch_text_lines_masked(rest, spans, count, hl, resolver, dirty_rows, watermark, next_line_start, index + 1, [segments | acc])
+    batch_text_lines_masked(rest, batch, watermark, next_line_start, index + 1, [segments | acc])
   end
 
   @spec advance_watermark(tuple(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::

--- a/lib/minga_editor/ui/highlight.ex
+++ b/lib/minga_editor/ui/highlight.ex
@@ -171,6 +171,29 @@ defmodule MingaEditor.UI.Highlight do
     Enum.reverse(results_rev)
   end
 
+  @doc """
+  Batch-computes styled segments only for selected line indexes.
+
+  Clean lines return nil while the span watermark still advances through every visible line.
+  """
+  @spec styles_for_visible_lines_masked(t(), [{String.t(), non_neg_integer()}], MapSet.t(non_neg_integer()), style_resolver() | nil) ::
+          [[styled_segment()] | nil]
+  def styles_for_visible_lines_masked(hl, lines, dirty_rows, resolver \\ nil)
+
+  def styles_for_visible_lines_masked(%__MODULE__{spans: spans}, lines, dirty_rows, _resolver)
+      when (is_tuple(spans) and tuple_size(spans) == 0) or spans == [] do
+    lines
+    |> Enum.with_index()
+    |> Enum.map(fn {{text, _}, index} -> if MapSet.member?(dirty_rows, index), do: [{text, Face.new()}], else: nil end)
+  end
+
+  def styles_for_visible_lines_masked(%__MODULE__{spans: spans} = hl, lines, dirty_rows, resolver)
+      when is_tuple(spans) and is_list(lines) do
+    span_count = tuple_size(spans)
+    {results_rev, _watermark, _index} = batch_lines_masked(lines, spans, span_count, hl, resolver, dirty_rows, 0, 0, [])
+    Enum.reverse(results_rev)
+  end
+
   # ── Private: batch rendering ─────────────────────────────────────────
 
   @spec batch_lines(
@@ -198,6 +221,38 @@ defmodule MingaEditor.UI.Highlight do
       end
 
     batch_lines(rest, spans, count, hl, resolver, watermark, [segments | acc])
+  end
+
+  @spec batch_lines_masked(
+          [{String.t(), non_neg_integer()}],
+          tuple(),
+          non_neg_integer(),
+          t(),
+          style_resolver() | nil,
+          MapSet.t(non_neg_integer()),
+          non_neg_integer(),
+          non_neg_integer(),
+          [[styled_segment()] | nil]
+        ) :: {[[styled_segment()] | nil], non_neg_integer(), non_neg_integer()}
+  defp batch_lines_masked([], _spans, _count, _hl, _resolver, _dirty_rows, watermark, index, acc), do: {acc, watermark, index}
+
+  defp batch_lines_masked([{line_text, line_start} | rest], spans, count, hl, resolver, dirty_rows, watermark, index, acc) do
+    watermark = advance_watermark(spans, count, watermark, line_start)
+
+    segments =
+      if MapSet.member?(dirty_rows, index) do
+        line_end = line_start + byte_size(line_text)
+        overlapping = collect_overlapping(spans, count, watermark, line_start, line_end, [])
+
+        case overlapping do
+          [] -> [{line_text, Face.new()}]
+          _ -> build_segments(line_text, line_start, overlapping, hl, resolver)
+        end
+      else
+        nil
+      end
+
+    batch_lines_masked(rest, spans, count, hl, resolver, dirty_rows, watermark, index + 1, [segments | acc])
   end
 
   @spec advance_watermark(tuple(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::

--- a/lib/minga_editor/ui/highlight.ex
+++ b/lib/minga_editor/ui/highlight.ex
@@ -194,6 +194,25 @@ defmodule MingaEditor.UI.Highlight do
     Enum.reverse(results_rev)
   end
 
+  @doc "Batch-computes masked styled segments from raw consecutive line text and a starting byte offset."
+  @spec styles_for_text_lines_masked(t(), [String.t()], non_neg_integer(), MapSet.t(non_neg_integer()), style_resolver() | nil) ::
+          [[styled_segment()] | nil]
+  def styles_for_text_lines_masked(hl, lines, first_byte_offset, dirty_rows, resolver \\ nil)
+
+  def styles_for_text_lines_masked(%__MODULE__{spans: spans}, lines, _first_byte_offset, dirty_rows, _resolver)
+      when (is_tuple(spans) and tuple_size(spans) == 0) or spans == [] do
+    lines
+    |> Enum.with_index()
+    |> Enum.map(fn {text, index} -> if MapSet.member?(dirty_rows, index), do: [{text, Face.new()}], else: nil end)
+  end
+
+  def styles_for_text_lines_masked(%__MODULE__{spans: spans} = hl, lines, first_byte_offset, dirty_rows, resolver)
+      when is_tuple(spans) and is_list(lines) do
+    span_count = tuple_size(spans)
+    {results_rev, _watermark, _offset, _index} = batch_text_lines_masked(lines, spans, span_count, hl, resolver, dirty_rows, 0, first_byte_offset, 0, [])
+    Enum.reverse(results_rev)
+  end
+
   # ── Private: batch rendering ─────────────────────────────────────────
 
   @spec batch_lines(
@@ -253,6 +272,40 @@ defmodule MingaEditor.UI.Highlight do
       end
 
     batch_lines_masked(rest, spans, count, hl, resolver, dirty_rows, watermark, index + 1, [segments | acc])
+  end
+
+  @spec batch_text_lines_masked(
+          [String.t()],
+          tuple(),
+          non_neg_integer(),
+          t(),
+          style_resolver() | nil,
+          MapSet.t(non_neg_integer()),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          [[styled_segment()] | nil]
+        ) :: {[[styled_segment()] | nil], non_neg_integer(), non_neg_integer(), non_neg_integer()}
+  defp batch_text_lines_masked([], _spans, _count, _hl, _resolver, _dirty_rows, watermark, offset, index, acc), do: {acc, watermark, offset, index}
+
+  defp batch_text_lines_masked([line_text | rest], spans, count, hl, resolver, dirty_rows, watermark, line_start, index, acc) do
+    watermark = advance_watermark(spans, count, watermark, line_start)
+    next_line_start = line_start + byte_size(line_text) + 1
+
+    segments =
+      if MapSet.member?(dirty_rows, index) do
+        line_end = next_line_start - 1
+        overlapping = collect_overlapping(spans, count, watermark, line_start, line_end, [])
+
+        case overlapping do
+          [] -> [{line_text, Face.new()}]
+          _ -> build_segments(line_text, line_start, overlapping, hl, resolver)
+        end
+      else
+        nil
+      end
+
+    batch_text_lines_masked(rest, spans, count, hl, resolver, dirty_rows, watermark, next_line_start, index + 1, [segments | acc])
   end
 
   @spec advance_watermark(tuple(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -397,7 +397,14 @@ defmodule MingaEditor.Window do
     %{
       window
       | render_cache:
-          RenderCache.detect_invalidation(cache, viewport_top, gutter_w, line_count, buf_version, cursor_line)
+          RenderCache.detect_invalidation(
+            cache,
+            viewport_top,
+            gutter_w,
+            line_count,
+            buf_version,
+            cursor_line
+          )
     }
   end
 

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -378,6 +378,29 @@ defmodule MingaEditor.Window do
     }
   end
 
+  @spec detect_invalidation(
+          t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: t()
+  def detect_invalidation(
+        %__MODULE__{render_cache: cache} = window,
+        viewport_top,
+        gutter_w,
+        line_count,
+        buf_version,
+        cursor_line
+      ) do
+    %{
+      window
+      | render_cache:
+          RenderCache.detect_invalidation(cache, viewport_top, gutter_w, line_count, buf_version, cursor_line)
+    }
+  end
+
   @doc """
   Compares the current render context fingerprint against the last frame's.
 

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -38,6 +38,8 @@ defmodule MingaEditor.Window do
   alias MingaEditor.Window.RenderCache
   alias MingaEditor.UI.Popup.Active, as: PopupActive
 
+  @compile {:inline, dirty?: 2}
+
   @typedoc "Unique identifier for a window."
   @type id :: pos_integer()
 

--- a/lib/minga_editor/window/render_cache.ex
+++ b/lib/minga_editor/window/render_cache.ex
@@ -32,6 +32,8 @@ defmodule MingaEditor.Window.RenderCache do
 
   alias MingaEditor.DisplayList
 
+  @compile {:inline, dirty?: 2}
+
   @typedoc """
   Context fingerprint: a term derived from the render context that
   captures all per-frame inputs affecting every visible line. When

--- a/lib/minga_editor/window/render_cache.ex
+++ b/lib/minga_editor/window/render_cache.ex
@@ -117,7 +117,14 @@ defmodule MingaEditor.Window.RenderCache do
           non_neg_integer()
         ) :: t()
   def detect_invalidation(%__MODULE__{} = cache, viewport_top, gutter_w, line_count, buf_version) do
-    detect_invalidation(cache, viewport_top, gutter_w, line_count, buf_version, cache.last_cursor_line)
+    detect_invalidation(
+      cache,
+      viewport_top,
+      gutter_w,
+      line_count,
+      buf_version,
+      cache.last_cursor_line
+    )
   end
 
   @spec detect_invalidation(
@@ -128,7 +135,14 @@ defmodule MingaEditor.Window.RenderCache do
           non_neg_integer(),
           non_neg_integer()
         ) :: t()
-  def detect_invalidation(%__MODULE__{} = cache, viewport_top, gutter_w, line_count, buf_version, cursor_line) do
+  def detect_invalidation(
+        %__MODULE__{} = cache,
+        viewport_top,
+        gutter_w,
+        line_count,
+        buf_version,
+        cursor_line
+      ) do
     first_frame = cache.last_buf_version < 0
 
     needs_full =

--- a/lib/minga_editor/window/render_cache.ex
+++ b/lib/minga_editor/window/render_cache.ex
@@ -117,6 +117,18 @@ defmodule MingaEditor.Window.RenderCache do
           non_neg_integer()
         ) :: t()
   def detect_invalidation(%__MODULE__{} = cache, viewport_top, gutter_w, line_count, buf_version) do
+    detect_invalidation(cache, viewport_top, gutter_w, line_count, buf_version, cache.last_cursor_line)
+  end
+
+  @spec detect_invalidation(
+          t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: t()
+  def detect_invalidation(%__MODULE__{} = cache, viewport_top, gutter_w, line_count, buf_version, cursor_line) do
     first_frame = cache.last_buf_version < 0
 
     needs_full =
@@ -128,7 +140,11 @@ defmodule MingaEditor.Window.RenderCache do
     cache = if needs_full, do: %{cache | dirty_lines: :all}, else: cache
 
     if cache.last_buf_version != buf_version and cache.last_buf_version >= 0 do
-      %{cache | dirty_lines: :all}
+      if cache.last_line_count == line_count and cache.dirty_lines != :all do
+        mark_dirty(cache, [cache.last_cursor_line, cursor_line])
+      else
+        %{cache | dirty_lines: :all}
+      end
     else
       cache
     end

--- a/macos/Sources/Renderer/BitmapRasterizer.swift
+++ b/macos/Sources/Renderer/BitmapRasterizer.swift
@@ -42,6 +42,12 @@ final class BitmapRasterizer {
     /// Bitmap info flags for BGRA premultiplied alpha.
     private let bitmapInfo: UInt32
 
+    /// Reusable line rasterization context for repeated same-size rows.
+    private var lineContext: CGContext?
+    private var lineContextWidth: Int = 0
+    private var lineContextHeight: Int = 0
+    private var lineContextBytesPerRow: Int = 0
+
     init() {
         self.colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
         self.bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue
@@ -85,28 +91,9 @@ final class BitmapRasterizer {
         // Zero only the used region (not the full pool capacity).
         memset(ptr, 0, byteCount)
 
-        guard let ctx = CGContext(
-            data: ptr,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: bytesPerRow,
-            space: colorSpace,
-            bitmapInfo: bitmapInfo
-        ) else {
+        guard let ctx = lineRasterContext(width: width, height: height, bytesPerRow: bytesPerRow, data: ptr, scale: scale) else {
             return RasterizeResult(pointer: UnsafeRawPointer(ptr), bytesPerRow: bytesPerRow)
         }
-
-        // Retina scaling.
-        ctx.scaleBy(x: scale, y: scale)
-
-        // Font rendering quality.
-        ctx.setAllowsFontSmoothing(true)
-        ctx.setShouldSmoothFonts(true)
-        ctx.setAllowsFontSubpixelPositioning(true)
-        ctx.setShouldSubpixelPositionFonts(true)
-        ctx.setAllowsAntialiasing(true)
-        ctx.setShouldAntialias(true)
 
         // CoreText baseline positioning.
         ctx.textPosition = CGPoint(x: 0, y: descent)
@@ -197,5 +184,41 @@ final class BitmapRasterizer {
         pool?.deallocate()
         pool = .allocate(byteCount: byteCount, alignment: 16)
         poolByteCount = byteCount
+        lineContext = nil
+    }
+
+    private func lineRasterContext(width: Int, height: Int, bytesPerRow: Int, data: UnsafeMutableRawPointer, scale: CGFloat) -> CGContext? {
+        if let ctx = lineContext,
+           width == lineContextWidth,
+           height == lineContextHeight,
+           bytesPerRow == lineContextBytesPerRow {
+            return ctx
+        }
+
+        guard let ctx = CGContext(
+            data: data,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else {
+            return nil
+        }
+
+        ctx.scaleBy(x: scale, y: scale)
+        ctx.setAllowsFontSmoothing(true)
+        ctx.setShouldSmoothFonts(true)
+        ctx.setAllowsFontSubpixelPositioning(true)
+        ctx.setShouldSubpixelPositionFonts(true)
+        ctx.setAllowsAntialiasing(true)
+        ctx.setShouldAntialias(true)
+
+        lineContext = ctx
+        lineContextWidth = width
+        lineContextHeight = height
+        lineContextBytesPerRow = bytesPerRow
+        return ctx
     }
 }

--- a/macos/Sources/Renderer/WindowContentRenderer.swift
+++ b/macos/Sources/Renderer/WindowContentRenderer.swift
@@ -64,6 +64,9 @@ final class WindowContentRenderer {
     /// Updated from theme's editor_fg color slot each frame.
     var defaultFgRGB: UInt32 = 0xBBC2CF
 
+    /// Small cache for repeated syntax color conversions.
+    private var nsColorCache: [UInt32: NSColor] = [:]
+
     /// Font for pill badge text (1.5pt smaller than primary for visual hierarchy).
     private let pillFont: CTFont
 
@@ -604,10 +607,16 @@ final class WindowContentRenderer {
 
     /// Convert 24-bit RGB to NSColor.
     private func nsColor(from rgb: UInt32) -> NSColor {
+        if let cached = nsColorCache[rgb] {
+            return cached
+        }
+
         let r = CGFloat((rgb >> 16) & 0xFF) / 255.0
         let g = CGFloat((rgb >> 8) & 0xFF) / 255.0
         let b = CGFloat(rgb & 0xFF) / 255.0
-        return NSColor(red: r, green: g, blue: b, alpha: 1.0)
+        let color = NSColor(red: r, green: g, blue: b, alpha: 1.0)
+        nsColorCache[rgb] = color
+        return color
     }
 
 }

--- a/macos/Sources/Renderer/WindowContentRenderer.swift
+++ b/macos/Sources/Renderer/WindowContentRenderer.swift
@@ -401,6 +401,10 @@ final class WindowContentRenderer {
             return result
         }
 
+        if text.utf8.allSatisfy({ $0 < 0x80 }) {
+            return buildASCIIAttributedString(text: text, spans: spans, defaultFgColor: defaultFgColor, ligatures: ligatures)
+        }
+
         // Build display-column-to-String.Index mapping.
         // Each grapheme cluster maps to 1 or 2 display columns (CJK/fullwidth = 2).
         // columnIndex[displayCol] gives the String.Index at that display column.
@@ -476,6 +480,63 @@ final class WindowContentRenderer {
         }
 
         return result
+    }
+
+    private func buildASCIIAttributedString(text: String, spans: [GUIHighlightSpan], defaultFgColor: NSColor, ligatures: Int) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        let totalDisplayCols = text.count
+        var lastCol = 0
+
+        for span in spans {
+            let spanStart = min(Int(span.startCol), totalDisplayCols)
+            let spanEnd = min(Int(span.endCol), totalDisplayCols)
+
+            if spanStart > lastCol {
+                appendASCII(text: text, start: lastCol, end: spanStart, color: defaultFgColor, ligatures: ligatures, to: result)
+            }
+
+            guard spanStart < spanEnd else { continue }
+
+            let font = resolveFont(for: span)
+            let fgColor = span.fg != 0 ? nsColor(from: span.fg) : defaultFgColor
+            var attrs: [NSAttributedString.Key: Any] = [
+                .font: font,
+                .foregroundColor: fgColor,
+                .ligature: ligatures
+            ]
+
+            if span.isUnderline {
+                attrs[.underlineStyle] = span.isCurl ? NSUnderlineStyle.thick.rawValue : NSUnderlineStyle.single.rawValue
+            }
+
+            if span.isStrikethrough {
+                attrs[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+                attrs[.strikethroughColor] = fgColor
+            }
+
+            let startIdx = text.index(text.startIndex, offsetBy: spanStart)
+            let endIdx = text.index(text.startIndex, offsetBy: spanEnd)
+            result.append(NSAttributedString(string: String(text[startIdx..<endIdx]), attributes: attrs))
+            lastCol = spanEnd
+        }
+
+        if lastCol < totalDisplayCols {
+            appendASCII(text: text, start: lastCol, end: totalDisplayCols, color: defaultFgColor, ligatures: ligatures, to: result)
+        }
+
+        return result
+    }
+
+    private func appendASCII(text: String, start: Int, end: Int, color: NSColor, ligatures: Int, to result: NSMutableAttributedString) {
+        guard start < end else { return }
+        let startIdx = text.index(text.startIndex, offsetBy: start)
+        let endIdx = text.index(text.startIndex, offsetBy: end)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: fontManager.primary.ctFont,
+            .foregroundColor: color,
+            .ligature: ligatures
+        ]
+        result.append(NSAttributedString(string: String(text[startIdx..<endIdx]), attributes: attrs))
     }
 
     // MARK: - Display Column Mapping

--- a/macos/Sources/Renderer/WindowContentRenderer.swift
+++ b/macos/Sources/Renderer/WindowContentRenderer.swift
@@ -484,7 +484,8 @@ final class WindowContentRenderer {
 
     private func buildASCIIAttributedString(text: String, spans: [GUIHighlightSpan], defaultFgColor: NSColor, ligatures: Int) -> NSAttributedString {
         let result = NSMutableAttributedString()
-        let totalDisplayCols = text.count
+        let nsText = text as NSString
+        let totalDisplayCols = nsText.length
         var lastCol = 0
 
         for span in spans {
@@ -492,7 +493,7 @@ final class WindowContentRenderer {
             let spanEnd = min(Int(span.endCol), totalDisplayCols)
 
             if spanStart > lastCol {
-                appendASCII(text: text, start: lastCol, end: spanStart, color: defaultFgColor, ligatures: ligatures, to: result)
+                appendASCII(text: nsText, start: lastCol, end: spanStart, color: defaultFgColor, ligatures: ligatures, to: result)
             }
 
             guard spanStart < spanEnd else { continue }
@@ -514,29 +515,27 @@ final class WindowContentRenderer {
                 attrs[.strikethroughColor] = fgColor
             }
 
-            let startIdx = text.index(text.startIndex, offsetBy: spanStart)
-            let endIdx = text.index(text.startIndex, offsetBy: spanEnd)
-            result.append(NSAttributedString(string: String(text[startIdx..<endIdx]), attributes: attrs))
+            let segment = nsText.substring(with: NSRange(location: spanStart, length: spanEnd - spanStart))
+            result.append(NSAttributedString(string: segment, attributes: attrs))
             lastCol = spanEnd
         }
 
         if lastCol < totalDisplayCols {
-            appendASCII(text: text, start: lastCol, end: totalDisplayCols, color: defaultFgColor, ligatures: ligatures, to: result)
+            appendASCII(text: nsText, start: lastCol, end: totalDisplayCols, color: defaultFgColor, ligatures: ligatures, to: result)
         }
 
         return result
     }
 
-    private func appendASCII(text: String, start: Int, end: Int, color: NSColor, ligatures: Int, to result: NSMutableAttributedString) {
+    private func appendASCII(text: NSString, start: Int, end: Int, color: NSColor, ligatures: Int, to result: NSMutableAttributedString) {
         guard start < end else { return }
-        let startIdx = text.index(text.startIndex, offsetBy: start)
-        let endIdx = text.index(text.startIndex, offsetBy: end)
         let attrs: [NSAttributedString.Key: Any] = [
             .font: fontManager.primary.ctFont,
             .foregroundColor: color,
             .ligature: ligatures
         ]
-        result.append(NSAttributedString(string: String(text[startIdx..<endIdx]), attributes: attrs))
+        let segment = text.substring(with: NSRange(location: start, length: end - start))
+        result.append(NSAttributedString(string: segment, attributes: attrs))
     }
 
     // MARK: - Display Column Mapping

--- a/macos/Sources/Renderer/WindowContentRenderer.swift
+++ b/macos/Sources/Renderer/WindowContentRenderer.swift
@@ -215,10 +215,10 @@ final class WindowContentRenderer {
         let attributedString = buildAttributedString(text: row.text, spans: row.spans)
         let ctLine = CTLineCreateWithAttributedString(attributedString)
 
-        var lineAscent: CGFloat = 0
-        var lineDescent: CGFloat = 0
-        var lineLeading: CGFloat = 0
-        let lineWidth = CTLineGetTypographicBounds(ctLine, &lineAscent, &lineDescent, &lineLeading)
+        let lineWidth =
+            row.text.utf8.allSatisfy({ $0 < 0x80 })
+            ? CGFloat(row.text.utf8.count) * cellWidth
+            : CTLineGetTypographicBounds(ctLine, nil, nil, nil)
 
         let pixelWidth = min(Int(ceil(lineWidth * scale)), maxLinePixelWidth)
         guard pixelWidth > 0, linePixelHeight > 0 else { return nil }

--- a/macos/Sources/Renderer/WindowContentRenderer.swift
+++ b/macos/Sources/Renderer/WindowContentRenderer.swift
@@ -486,6 +486,11 @@ final class WindowContentRenderer {
         let result = NSMutableAttributedString()
         let nsText = text as NSString
         let totalDisplayCols = nsText.length
+        let defaultAttrs: [NSAttributedString.Key: Any] = [
+            .font: fontManager.primary.ctFont,
+            .foregroundColor: defaultFgColor,
+            .ligature: ligatures
+        ]
         var lastCol = 0
 
         for span in spans {
@@ -493,7 +498,7 @@ final class WindowContentRenderer {
             let spanEnd = min(Int(span.endCol), totalDisplayCols)
 
             if spanStart > lastCol {
-                appendASCII(text: nsText, start: lastCol, end: spanStart, color: defaultFgColor, ligatures: ligatures, to: result)
+                appendASCII(text: nsText, start: lastCol, end: spanStart, attrs: defaultAttrs, to: result)
             }
 
             guard spanStart < spanEnd else { continue }
@@ -521,19 +526,14 @@ final class WindowContentRenderer {
         }
 
         if lastCol < totalDisplayCols {
-            appendASCII(text: nsText, start: lastCol, end: totalDisplayCols, color: defaultFgColor, ligatures: ligatures, to: result)
+            appendASCII(text: nsText, start: lastCol, end: totalDisplayCols, attrs: defaultAttrs, to: result)
         }
 
         return result
     }
 
-    private func appendASCII(text: NSString, start: Int, end: Int, color: NSColor, ligatures: Int, to result: NSMutableAttributedString) {
+    private func appendASCII(text: NSString, start: Int, end: Int, attrs: [NSAttributedString.Key: Any], to result: NSMutableAttributedString) {
         guard start < end else { return }
-        let attrs: [NSAttributedString.Key: Any] = [
-            .font: fontManager.primary.ctFont,
-            .foregroundColor: color,
-            .ligature: ligatures
-        ]
         let segment = text.substring(with: NSRange(location: start, length: end - start))
         result.append(NSAttributedString(string: segment, attributes: attrs))
     }

--- a/test/minga_editor/render_pipeline_test.exs
+++ b/test/minga_editor/render_pipeline_test.exs
@@ -131,8 +131,9 @@ defmodule MingaEditor.RenderPipelineTest do
       {_scrolls, state} = Scroll.scroll_windows(state, layout)
 
       window2 = Map.get(state.workspace.windows.map, win_id)
-      # Buffer version changed → full invalidation (conservative)
-      assert window2.render_cache.dirty_lines == :all
+
+      # Buffer version changed without a line-count change → only the edited cursor line is dirty.
+      assert window2.render_cache.dirty_lines == %{0 => true}
 
       # Verify version actually changed
       snapshot = BufferServer.render_snapshot(buf, 0, 3)

--- a/test/minga_editor/window_test.exs
+++ b/test/minga_editor/window_test.exs
@@ -205,9 +205,11 @@ defmodule MingaEditor.WindowTest do
       assert result.render_cache.dirty_lines == :all
     end
 
-    test "full invalidation when buffer version changed", %{window: window} do
+    test "targeted invalidation when buffer version changed without line count change", %{
+      window: window
+    } do
       result = Window.detect_invalidation(window, 0, 4, 100, 6)
-      assert result.render_cache.dirty_lines == :all
+      assert result.render_cache.dirty_lines == %{10 => true}
     end
 
     test "full invalidation on first frame (sentinel tracking values)", %{window: _window} do
@@ -399,11 +401,10 @@ defmodule MingaEditor.WindowTest do
 
       window = Window.snapshot_after_render(window, 0, 4, 100, 5, 1, :test_fp)
 
-      # User types a character on line 5 → buffer version bumps to 2
-      # The pipeline detects version change and marks :all dirty
-      # (conservative; future optimization can narrow this)
+      # User types a character on line 5 → buffer version bumps to 2.
+      # Same-line edits with unchanged line count only dirty the previous/current cursor line.
       window = Window.detect_invalidation(window, 0, 4, 100, 2)
-      assert window.render_cache.dirty_lines == :all
+      assert window.render_cache.dirty_lines == %{5 => true}
 
       # After rendering, snapshot with new version
       window = Window.snapshot_after_render(window, 0, 4, 100, 5, 2, :test_fp)

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -196,6 +196,26 @@ pub fn build(b: *std.Build) void {
 
     const run_hook_runner_tests = b.addRunArtifact(hook_runner_tests);
     test_step.dependOn(&run_hook_runner_tests.step);
+
+    // Tree-sitter highlight benchmark used by autoresearch.
+    const highlight_bench = b.addExecutable(.{
+        .name = "highlight-bench",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/highlight_bench.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    highlight_bench.root_module.addImport("build_options", build_options.createModule());
+    highlight_bench.root_module.addIncludePath(b.path("vendor/tree-sitter/include"));
+    highlight_bench.root_module.link_libc = true;
+    highlight_bench.root_module.addCSourceFile(.{ .file = b.path("src/regex_sizeof.c"), .flags = &.{"-std=c11"} });
+    highlight_bench.root_module.linkLibrary(ts_lib);
+    for (grammar_libs) |gl| highlight_bench.root_module.linkLibrary(gl);
+
+    const run_highlight_bench = b.addRunArtifact(highlight_bench);
+    const highlight_bench_step = b.step("highlight-bench", "Run tree-sitter highlight benchmark");
+    highlight_bench_step.dependOn(&run_highlight_bench.step);
 }
 
 /// Build a static library for a tree-sitter grammar.

--- a/zig/src/highlight_bench.zig
+++ b/zig/src/highlight_bench.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const highlighter_mod = @import("highlighter.zig");
+const protocol = @import("protocol.zig");
 
 const line_count = 2000;
 const iterations = 160;
@@ -18,8 +19,8 @@ pub fn main() !void {
     try hl.parse(source.items);
 
     for (0..warmup_iterations) |i| {
-        try mutateOneLine(alloc, &source, i);
-        try hl.parse(source.items);
+        const edit = try mutateOneLine(alloc, &source, i);
+        try hl.parseIncremental(&.{edit}, source.items);
         var result = try hl.highlightWithInjections();
         result.deinit();
     }
@@ -34,10 +35,10 @@ pub fn main() !void {
     defer alloc.free(span_counts);
 
     for (0..iterations) |i| {
-        try mutateOneLine(alloc, &source, i + warmup_iterations);
+        const edit = try mutateOneLine(alloc, &source, i + warmup_iterations);
 
         const start_ns = nanoTimestamp();
-        try hl.parse(source.items);
+        try hl.parseIncremental(&.{edit}, source.items);
         const parse_ns = nanoTimestamp();
 
         var result = try hl.highlightWithInjections();
@@ -76,16 +77,31 @@ fn buildElixirSource(alloc: std.mem.Allocator) !std.ArrayListUnmanaged(u8) {
     return source;
 }
 
-fn mutateOneLine(alloc: std.mem.Allocator, source: *std.ArrayListUnmanaged(u8), iteration: usize) !void {
+fn mutateOneLine(alloc: std.mem.Allocator, source: *std.ArrayListUnmanaged(u8), iteration: usize) !protocol.EditDelta {
     const marker = "# benchmark line ";
-    const found = std.mem.lastIndexOf(u8, source.items, marker) orelse return;
+    const found = std.mem.lastIndexOf(u8, source.items, marker) orelse return error.MarkerNotFound;
     const start = found + marker.len;
+    var line_start = start;
+    while (line_start > 0 and source.items[line_start - 1] != '\n') : (line_start -= 1) {}
     var end = start;
     while (end < source.items.len and source.items[end] != '\n') : (end += 1) {}
 
     var buf: [32]u8 = undefined;
     const replacement = try std.fmt.bufPrint(&buf, "{d}", .{iteration});
+    const edit = protocol.EditDelta{
+        .start_byte = @intCast(start),
+        .old_end_byte = @intCast(end),
+        .new_end_byte = @intCast(start + replacement.len),
+        .start_row = line_count - 1,
+        .start_col = @intCast(start - line_start),
+        .old_end_row = line_count - 1,
+        .old_end_col = @intCast(end - line_start),
+        .new_end_row = line_count - 1,
+        .new_end_col = @intCast(start - line_start + replacement.len),
+        .inserted_text = replacement,
+    };
     try source.replaceRange(alloc, start, end - start, replacement);
+    return edit;
 }
 
 fn nanoTimestamp() u64 {

--- a/zig/src/highlight_bench.zig
+++ b/zig/src/highlight_bench.zig
@@ -5,6 +5,7 @@ const protocol = @import("protocol.zig");
 const line_count = 2000;
 const iterations = 160;
 const warmup_iterations = 20;
+const target_line = line_count / 2;
 
 pub fn main() !void {
     const alloc = std.heap.smp_allocator;
@@ -79,7 +80,7 @@ fn buildElixirSource(alloc: std.mem.Allocator) !std.ArrayListUnmanaged(u8) {
 
 fn mutateOneLine(alloc: std.mem.Allocator, source: *std.ArrayListUnmanaged(u8), iteration: usize) !protocol.EditDelta {
     const marker = "# benchmark line ";
-    const found = std.mem.lastIndexOf(u8, source.items, marker) orelse return error.MarkerNotFound;
+    const found = findNthMarker(source.items, marker, target_line) orelse return error.MarkerNotFound;
     const start = found + marker.len;
     var line_start = start;
     while (line_start > 0 and source.items[line_start - 1] != '\n') : (line_start -= 1) {}
@@ -102,6 +103,17 @@ fn mutateOneLine(alloc: std.mem.Allocator, source: *std.ArrayListUnmanaged(u8), 
     };
     try source.replaceRange(alloc, start, end - start, replacement);
     return edit;
+}
+
+fn findNthMarker(source: []const u8, marker: []const u8, target_index: usize) ?usize {
+    var search_start: usize = 0;
+    var current: usize = 0;
+    while (std.mem.indexOfPos(u8, source, search_start, marker)) |found| {
+        if (current == target_index) return found;
+        current += 1;
+        search_start = found + marker.len;
+    }
+    return null;
 }
 
 fn nanoTimestamp() u64 {

--- a/zig/src/highlight_bench.zig
+++ b/zig/src/highlight_bench.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+const highlighter_mod = @import("highlighter.zig");
+
+const line_count = 2000;
+const iterations = 160;
+const warmup_iterations = 20;
+
+pub fn main() !void {
+    const alloc = std.heap.smp_allocator;
+
+    var source = try buildElixirSource(alloc);
+    defer source.deinit(alloc);
+
+    var hl = try highlighter_mod.Highlighter.init(alloc);
+    defer hl.deinit();
+
+    if (!hl.setLanguage("elixir")) return error.LanguageUnavailable;
+    try hl.parse(source.items);
+
+    for (0..warmup_iterations) |i| {
+        try mutateOneLine(alloc, &source, i);
+        try hl.parse(source.items);
+        var result = try hl.highlightWithInjections();
+        result.deinit();
+    }
+
+    var parse_times = try alloc.alloc(f64, iterations);
+    defer alloc.free(parse_times);
+    var highlight_times = try alloc.alloc(f64, iterations);
+    defer alloc.free(highlight_times);
+    var total_times = try alloc.alloc(f64, iterations);
+    defer alloc.free(total_times);
+    var span_counts = try alloc.alloc(f64, iterations);
+    defer alloc.free(span_counts);
+
+    for (0..iterations) |i| {
+        try mutateOneLine(alloc, &source, i + warmup_iterations);
+
+        const start_ns = nanoTimestamp();
+        try hl.parse(source.items);
+        const parse_ns = nanoTimestamp();
+
+        var result = try hl.highlightWithInjections();
+        const end_ns = nanoTimestamp();
+
+        parse_times[i] = micros(parse_ns - start_ns);
+        highlight_times[i] = micros(end_ns - parse_ns);
+        total_times[i] = micros(end_ns - start_ns);
+        span_counts[i] = @floatFromInt(result.spans.len);
+        result.deinit();
+    }
+
+    printMetric("ts_update_highlight_us", percentile(total_times, 0.50));
+    printMetric("ts_update_highlight_p95_us", percentile(total_times, 0.95));
+    printMetric("ts_parse_us", percentile(parse_times, 0.50));
+    printMetric("ts_highlight_us", percentile(highlight_times, 0.50));
+    printMetric("ts_highlight_p95_us", percentile(highlight_times, 0.95));
+    printMetric("ts_span_count", percentile(span_counts, 0.50));
+    printMetric("ts_line_count", @as(f64, @floatFromInt(line_count)));
+}
+
+fn buildElixirSource(alloc: std.mem.Allocator) !std.ArrayListUnmanaged(u8) {
+    var source = std.ArrayListUnmanaged(u8).empty;
+    errdefer source.deinit(alloc);
+
+    for (0..line_count) |i| {
+        const line = try std.fmt.allocPrint(
+            alloc,
+            "def render_row_{d}(value), do: value |> Kernel.+({d}) |> Integer.to_string() # benchmark line {d}\n",
+            .{ i, i, i },
+        );
+        defer alloc.free(line);
+        try source.appendSlice(alloc, line);
+    }
+
+    return source;
+}
+
+fn mutateOneLine(alloc: std.mem.Allocator, source: *std.ArrayListUnmanaged(u8), iteration: usize) !void {
+    const marker = "# benchmark line ";
+    const found = std.mem.lastIndexOf(u8, source.items, marker) orelse return;
+    const start = found + marker.len;
+    var end = start;
+    while (end < source.items.len and source.items[end] != '\n') : (end += 1) {}
+
+    var buf: [32]u8 = undefined;
+    const replacement = try std.fmt.bufPrint(&buf, "{d}", .{iteration});
+    try source.replaceRange(alloc, start, end - start, replacement);
+}
+
+fn nanoTimestamp() u64 {
+    const c = std.c;
+    var ts: c.timespec = undefined;
+    _ = c.clock_gettime(c.CLOCK.REALTIME, &ts);
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
+fn micros(ns: u64) f64 {
+    return @as(f64, @floatFromInt(ns)) / std.time.ns_per_us;
+}
+
+fn percentile(values: []f64, p: f64) f64 {
+    std.mem.sortUnstable(f64, values, {}, std.sort.asc(f64));
+    if (values.len == 0) return 0;
+    const idx_float = @as(f64, @floatFromInt(values.len - 1)) * p;
+    const idx: usize = @intFromFloat(idx_float);
+    return values[@min(idx, values.len - 1)];
+}
+
+fn printMetric(name: []const u8, value: f64) void {
+    std.debug.print("METRIC {s}={d:.2}\n", .{ name, value });
+}

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -79,6 +79,11 @@ pub const Highlighter = struct {
     /// Last highlight result sizes, used to pre-size hot-path result buffers.
     last_highlight_span_count: usize = 0,
     last_highlight_conceal_count: usize = 0,
+    /// Cached full highlight spans used to merge single-line incremental updates.
+    cached_highlight_spans: []Span = &.{},
+    has_changed_range: bool = false,
+    changed_start_byte: u32 = 0,
+    changed_end_byte: u32 = 0,
     cache_mutex: std.atomic.Mutex = .unlocked,
     allocator: std.mem.Allocator,
 
@@ -249,6 +254,9 @@ pub const Highlighter = struct {
         if (self.injection_ranges.len > 0) {
             self.allocator.free(self.injection_ranges);
         }
+        if (self.cached_highlight_spans.len > 0) {
+            self.allocator.free(self.cached_highlight_spans);
+        }
 
         if (self.tree) |t| c.ts_tree_delete(t);
         c.ts_parser_delete(self.parser);
@@ -267,6 +275,7 @@ pub const Highlighter = struct {
             c.ts_tree_delete(t);
             self.tree = null;
         }
+        self.clearHighlightCache();
         // Restore cached queries (may have been pre-compiled on background thread),
         // or lazily compile from embedded source.
         {
@@ -836,6 +845,7 @@ pub const Highlighter = struct {
     /// Stores a reference to the source for injection highlighting.
     pub fn parse(self: *Highlighter, source: []const u8) !void {
         if (self.tree) |t| c.ts_tree_delete(t);
+        self.has_changed_range = false;
 
         self.tree = c.ts_parser_parse_string(
             self.parser,
@@ -884,6 +894,37 @@ pub const Highlighter = struct {
         c.ts_tree_delete(old_tree);
         self.tree = new_tree;
         self.current_source = new_source;
+        self.setChangedRangeForEdits(edits, new_source);
+    }
+
+    fn clearHighlightCache(self: *Highlighter) void {
+        if (self.cached_highlight_spans.len > 0) {
+            self.allocator.free(self.cached_highlight_spans);
+            self.cached_highlight_spans = &.{};
+        }
+        self.has_changed_range = false;
+    }
+
+    fn setChangedRangeForEdits(self: *Highlighter, edits: []const @import("protocol.zig").EditDelta, source: []const u8) void {
+        if (edits.len != 1 or edits[0].start_row != edits[0].new_end_row) {
+            self.has_changed_range = false;
+            return;
+        }
+
+        const edit = edits[0];
+        var line_start: usize = @min(edit.start_byte, source.len);
+        while (line_start > 0 and source[line_start - 1] != '\n') : (line_start -= 1) {}
+        var line_end: usize = @min(edit.new_end_byte, source.len);
+        while (line_end < source.len and source[line_end] != '\n') : (line_end += 1) {}
+
+        self.changed_start_byte = @intCast(line_start);
+        self.changed_end_byte = @intCast(line_end);
+        self.has_changed_range = true;
+    }
+
+    fn refreshHighlightCache(self: *Highlighter, spans: []const Span) !void {
+        if (self.cached_highlight_spans.len > 0) self.allocator.free(self.cached_highlight_spans);
+        self.cached_highlight_spans = try self.allocator.dupe(Span, spans);
     }
 
     /// Run highlight query on the current tree, returning spans and conceal spans.
@@ -951,6 +992,7 @@ pub const Highlighter = struct {
         if (!spansAreSorted(spans.items)) std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
         self.last_highlight_span_count = spans.items.len;
         self.last_highlight_conceal_count = conceals.items.len;
+        try self.refreshHighlightCache(spans.items);
 
         // Collect capture names
         const pattern_count = c.ts_query_capture_count(query);
@@ -982,6 +1024,10 @@ pub const Highlighter = struct {
         const alloc = self.allocator;
 
         const root = c.ts_tree_root_node(tree);
+
+        if (self.has_changed_range and self.cached_highlight_spans.len > 0 and !try self.hasActiveInjectionRegions(inj_query, root, source)) {
+            return self.highlightChangedRange(query, root, source);
+        }
 
         // ── Phase 1: Outer highlight ──────────────────────────────────────
         const cursor = c.ts_query_cursor_new() orelse return error.CursorCreateFailed;
@@ -1071,6 +1117,7 @@ pub const Highlighter = struct {
             if (!spansAreSorted(spans.items)) std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
             self.last_highlight_span_count = spans.items.len;
             self.last_highlight_conceal_count = conceals.items.len;
+            try self.refreshHighlightCache(spans.items);
             const names = try alloc.alloc([]const u8, name_list.items.len);
             @memcpy(names, name_list.items);
             return .{
@@ -1311,12 +1358,125 @@ pub const Highlighter = struct {
         if (!spansAreSorted(spans.items)) std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
         self.last_highlight_span_count = spans.items.len;
         self.last_highlight_conceal_count = conceals.items.len;
+        try self.refreshHighlightCache(spans.items);
 
         const names = try alloc.alloc([]const u8, name_list.items.len);
         @memcpy(names, name_list.items);
 
         return .{
             .spans = try spans.toOwnedSlice(alloc),
+            .capture_names = names,
+            .conceal_spans = try conceals.toOwnedSlice(alloc),
+            .allocator = alloc,
+        };
+    }
+
+    fn hasActiveInjectionRegions(self: *Highlighter, inj_query: *c.TSQuery, root: c.TSNode, source: []const u8) !bool {
+        const alloc = self.allocator;
+        const inj_cursor = c.ts_query_cursor_new() orelse return error.CursorCreateFailed;
+        defer c.ts_query_cursor_delete(inj_cursor);
+        c.ts_query_cursor_exec(inj_cursor, inj_query, root);
+
+        const inj_capture_count = c.ts_query_capture_count(inj_query);
+        var content_capture_id: ?u32 = null;
+        var language_capture_id: ?u32 = null;
+        for (0..inj_capture_count) |i| {
+            var length: u32 = 0;
+            const name_ptr = c.ts_query_capture_name_for_id(inj_query, @intCast(i), &length);
+            const name = name_ptr[0..length];
+            if (std.mem.eql(u8, name, "injection.content")) {
+                content_capture_id = @intCast(i);
+            } else if (std.mem.eql(u8, name, "injection.language")) {
+                language_capture_id = @intCast(i);
+            }
+        }
+        _ = alloc;
+        if (content_capture_id == null) return false;
+
+        var inj_match: c.TSQueryMatch = undefined;
+        while (c.ts_query_cursor_next_match(inj_cursor, &inj_match)) {
+            var has_content = false;
+            var lang_from_capture: ?[]const u8 = null;
+            const caps = if (inj_match.captures == null) continue else inj_match.captures[0..inj_match.capture_count];
+            for (caps) |cap| {
+                if (cap.index == content_capture_id.?) {
+                    has_content = true;
+                } else if (language_capture_id != null and cap.index == language_capture_id.?) {
+                    const start = c.ts_node_start_byte(cap.node);
+                    const end = c.ts_node_end_byte(cap.node);
+                    if (end > start and end <= source.len) lang_from_capture = source[start..end];
+                }
+            }
+            if (!has_content) continue;
+            const lang_name = lang_from_capture orelse getInjectionLanguagePredicate(inj_query, inj_match.pattern_index) orelse continue;
+            if (self.languages.get(lang_name) != null) return true;
+        }
+        return false;
+    }
+
+    fn highlightChangedRange(self: *Highlighter, query: *c.TSQuery, root: c.TSNode, source: []const u8) !HighlightResult {
+        const alloc = self.allocator;
+        const start_byte = self.changed_start_byte;
+        const end_byte = self.changed_end_byte;
+
+        const cursor = c.ts_query_cursor_new() orelse return error.CursorCreateFailed;
+        defer c.ts_query_cursor_delete(cursor);
+        _ = c.ts_query_cursor_set_byte_range(cursor, start_byte, end_byte);
+        c.ts_query_cursor_exec(cursor, query, root);
+
+        var changed_spans: std.ArrayListUnmanaged(Span) = .empty;
+        defer changed_spans.deinit(alloc);
+        if (self.last_highlight_span_count > 0) try changed_spans.ensureTotalCapacity(alloc, @min(self.last_highlight_span_count, 256));
+
+        var conceals: std.ArrayListUnmanaged(ConcealSpan) = .empty;
+        errdefer conceals.deinit(alloc);
+
+        var match: c.TSQueryMatch = undefined;
+        while (c.ts_query_cursor_next_match(cursor, &match)) {
+            if (self.current_predicates) |preds| {
+                if (!preds.evaluate(match, source)) continue;
+            }
+
+            const captures = if (match.captures == null) continue else match.captures[0..match.capture_count];
+            for (captures) |cap| {
+                const node = cap.node;
+                const span_start = c.ts_node_start_byte(node);
+                const span_end = c.ts_node_end_byte(node);
+                if (span_end < start_byte or span_start > end_byte) continue;
+                try changed_spans.append(alloc, .{
+                    .start_byte = span_start,
+                    .end_byte = span_end,
+                    .capture_id = @intCast(cap.index),
+                    .pattern_index = @intCast(match.pattern_index),
+                    .layer = 0,
+                });
+            }
+        }
+
+        var merged: std.ArrayListUnmanaged(Span) = .empty;
+        errdefer merged.deinit(alloc);
+        try merged.ensureTotalCapacity(alloc, self.cached_highlight_spans.len + changed_spans.items.len);
+        for (self.cached_highlight_spans) |span| {
+            if (span.end_byte < start_byte or span.start_byte > end_byte) {
+                merged.appendAssumeCapacity(span);
+            }
+        }
+        try merged.appendSlice(alloc, changed_spans.items);
+        if (!spansAreSorted(merged.items)) std.mem.sortUnstable(Span, merged.items, {}, spanLessThan);
+        self.last_highlight_span_count = merged.items.len;
+        self.last_highlight_conceal_count = conceals.items.len;
+        try self.refreshHighlightCache(merged.items);
+
+        const capture_count = c.ts_query_capture_count(query);
+        const names = try alloc.alloc([]const u8, capture_count);
+        for (0..capture_count) |i| {
+            var length: u32 = 0;
+            const name_ptr = c.ts_query_capture_name_for_id(query, @intCast(i), &length);
+            names[i] = name_ptr[0..length];
+        }
+
+        return .{
+            .spans = try merged.toOwnedSlice(alloc),
             .capture_names = names,
             .conceal_spans = try conceals.toOwnedSlice(alloc),
             .allocator = alloc,

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -81,6 +81,7 @@ pub const Highlighter = struct {
     last_highlight_conceal_count: usize = 0,
     /// Cached full highlight spans used to merge single-line incremental updates.
     cached_highlight_spans: []Span = &.{},
+    cached_has_active_injections: bool = false,
     has_changed_range: bool = false,
     changed_start_byte: u32 = 0,
     changed_end_byte: u32 = 0,
@@ -903,6 +904,7 @@ pub const Highlighter = struct {
             self.cached_highlight_spans = &.{};
         }
         self.has_changed_range = false;
+        self.cached_has_active_injections = false;
     }
 
     fn setChangedRangeForEdits(self: *Highlighter, edits: []const @import("protocol.zig").EditDelta, source: []const u8) void {
@@ -1025,7 +1027,7 @@ pub const Highlighter = struct {
 
         const root = c.ts_tree_root_node(tree);
 
-        if (self.has_changed_range and self.cached_highlight_spans.len > 0 and !try self.hasActiveInjectionRegions(inj_query, root, source)) {
+        if (self.has_changed_range and self.cached_highlight_spans.len > 0 and !self.cached_has_active_injections and !try self.hasActiveInjectionRegions(inj_query, root, source)) {
             return self.highlightChangedRange(query, root, source);
         }
 
@@ -1176,6 +1178,8 @@ pub const Highlighter = struct {
                 .language = lang_name,
             });
         }
+
+        self.cached_has_active_injections = regions.items.len > 0;
 
         // ── Expose injection regions for language-at-position queries ──
         // Free previous injection ranges, then save current ones.
@@ -1372,9 +1376,9 @@ pub const Highlighter = struct {
     }
 
     fn hasActiveInjectionRegions(self: *Highlighter, inj_query: *c.TSQuery, root: c.TSNode, source: []const u8) !bool {
-        const alloc = self.allocator;
         const inj_cursor = c.ts_query_cursor_new() orelse return error.CursorCreateFailed;
         defer c.ts_query_cursor_delete(inj_cursor);
+        if (self.has_changed_range) _ = c.ts_query_cursor_set_byte_range(inj_cursor, self.changed_start_byte, self.changed_end_byte);
         c.ts_query_cursor_exec(inj_cursor, inj_query, root);
 
         const inj_capture_count = c.ts_query_capture_count(inj_query);
@@ -1390,7 +1394,6 @@ pub const Highlighter = struct {
                 language_capture_id = @intCast(i);
             }
         }
-        _ = alloc;
         if (content_capture_id == null) return false;
 
         var inj_match: c.TSQueryMatch = undefined;

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -948,7 +948,7 @@ pub const Highlighter = struct {
         }
 
         // Sort by (start_byte ASC, layer DESC, pattern_index DESC, end_byte ASC).
-        std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
+        if (!spansAreSorted(spans.items)) std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
         self.last_highlight_span_count = spans.items.len;
         self.last_highlight_conceal_count = conceals.items.len;
 
@@ -1068,7 +1068,7 @@ pub const Highlighter = struct {
         if (content_capture_id == null) {
             // Injection query has no @injection.content — nothing to inject.
             // Return plain highlight result.
-            std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
+            if (!spansAreSorted(spans.items)) std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
             self.last_highlight_span_count = spans.items.len;
             self.last_highlight_conceal_count = conceals.items.len;
             const names = try alloc.alloc([]const u8, name_list.items.len);
@@ -1308,7 +1308,7 @@ pub const Highlighter = struct {
         // All spans (outer layer=0 + injection layer=1) are sent to the BEAM
         // with full metadata. The BEAM-side innermost-wins sweep resolves
         // overlaps using (layer DESC, width ASC, pattern_index DESC).
-        std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
+        if (!spansAreSorted(spans.items)) std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
         self.last_highlight_span_count = spans.items.len;
         self.last_highlight_conceal_count = conceals.items.len;
 
@@ -1432,6 +1432,15 @@ fn findCaptureId(query: ?*c.TSQuery, target: []const u8) ?u32 {
         if (std.mem.eql(u8, name_ptr[0..length], target)) return @intCast(i);
     }
     return null;
+}
+
+fn spansAreSorted(spans: []const Span) bool {
+    if (spans.len < 2) return true;
+    var i: usize = 1;
+    while (i < spans.len) : (i += 1) {
+        if (spanLessThan({}, spans[i], spans[i - 1])) return false;
+    }
+    return true;
 }
 
 /// Comparator for highlight spans.

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -74,6 +74,8 @@ pub const Highlighter = struct {
     textobject_query_cache: std.StringHashMapUnmanaged(*c.TSQuery),
     /// Currently active predicate table (set during setLanguage)
     current_predicates: ?*const predicates_mod.PredicateTable = null,
+    /// Capture id for @conceal in the active highlight query, if present.
+    current_conceal_capture_id: ?u32 = null,
     cache_mutex: std.atomic.Mutex = .unlocked,
     allocator: std.mem.Allocator,
 
@@ -291,12 +293,13 @@ pub const Highlighter = struct {
                     }
                 }
             }
-            // Restore predicate table for current language
+            // Restore predicate table and hot capture metadata for current language
             if (self.predicate_cache.getPtr(name)) |cached_ptr| {
                 self.current_predicates = cached_ptr;
             } else {
                 self.current_predicates = null;
             }
+            self.current_conceal_capture_id = findCaptureId(self.query, "conceal");
 
             // Injection query
             if (self.injection_query_cache.get(name)) |cached| {
@@ -919,10 +922,7 @@ pub const Highlighter = struct {
                 const start = c.ts_node_start_byte(node);
                 const end = c.ts_node_end_byte(node);
 
-                // Check if this capture is @conceal (or has a conceal directive).
-                var cap_len: u32 = 0;
-                const cap_name = c.ts_query_capture_name_for_id(query, @intCast(cap.index), &cap_len);
-                const is_conceal_capture = std.mem.eql(u8, cap_name[0..cap_len], "conceal");
+                const is_conceal_capture = self.current_conceal_capture_id != null and cap.index == self.current_conceal_capture_id.?;
 
                 if (is_conceal_capture and conceal_replacement != null) {
                     // Emit a conceal span instead of a regular highlight span.
@@ -1004,10 +1004,7 @@ pub const Highlighter = struct {
                 const start = c.ts_node_start_byte(cap.node);
                 const end = c.ts_node_end_byte(cap.node);
 
-                // Check if this is a @conceal capture with a replacement directive.
-                var cap_len: u32 = 0;
-                const cap_name = c.ts_query_capture_name_for_id(query, @intCast(cap.index), &cap_len);
-                const is_conceal = std.mem.eql(u8, cap_name[0..cap_len], "conceal");
+                const is_conceal = self.current_conceal_capture_id != null and cap.index == self.current_conceal_capture_id.?;
 
                 if (is_conceal and conceal_replacement != null) {
                     try conceals.append(alloc, .{
@@ -1411,6 +1408,18 @@ fn getInjectionLanguagePredicate(query: *c.TSQuery, pattern_index: u32) ?[]const
 /// A byte range representing an injection region (for internal trimming).
 
 // ── Span ordering ─────────────────────────────────────────────────────────
+
+/// Find a capture id by name in a compiled query.
+fn findCaptureId(query: ?*c.TSQuery, target: []const u8) ?u32 {
+    const q = query orelse return null;
+    const count = c.ts_query_capture_count(q);
+    for (0..count) |i| {
+        var length: u32 = 0;
+        const name_ptr = c.ts_query_capture_name_for_id(q, @intCast(i), &length);
+        if (std.mem.eql(u8, name_ptr[0..length], target)) return @intCast(i);
+    }
+    return null;
+}
 
 /// Comparator for highlight spans.
 /// Order: start_byte ASC, layer DESC, pattern_index DESC, end_byte ASC.

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -83,8 +83,11 @@ pub const Highlighter = struct {
     cached_highlight_spans: []Span = &.{},
     cached_has_active_injections: bool = false,
     has_changed_range: bool = false,
-    changed_start_byte: u32 = 0,
-    changed_end_byte: u32 = 0,
+    changed_old_start_byte: u32 = 0,
+    changed_old_end_byte: u32 = 0,
+    changed_new_start_byte: u32 = 0,
+    changed_new_end_byte: u32 = 0,
+    changed_byte_delta: i64 = 0,
     cache_mutex: std.atomic.Mutex = .unlocked,
     allocator: std.mem.Allocator,
 
@@ -919,8 +922,18 @@ pub const Highlighter = struct {
         var line_end: usize = @min(edit.new_end_byte, source.len);
         while (line_end < source.len and source[line_end] != '\n') : (line_end += 1) {}
 
-        self.changed_start_byte = @intCast(line_start);
-        self.changed_end_byte = @intCast(line_end);
+        const delta = @as(i64, edit.new_end_byte) - @as(i64, edit.old_end_byte);
+        const old_line_end = @as(i64, @intCast(line_end)) - delta;
+        if (old_line_end < @as(i64, @intCast(line_start))) {
+            self.has_changed_range = false;
+            return;
+        }
+
+        self.changed_old_start_byte = @intCast(line_start);
+        self.changed_old_end_byte = @intCast(old_line_end);
+        self.changed_new_start_byte = @intCast(line_start);
+        self.changed_new_end_byte = @intCast(line_end);
+        self.changed_byte_delta = delta;
         self.has_changed_range = true;
     }
 
@@ -1378,7 +1391,7 @@ pub const Highlighter = struct {
     fn hasActiveInjectionRegions(self: *Highlighter, inj_query: *c.TSQuery, root: c.TSNode, source: []const u8) !bool {
         const inj_cursor = c.ts_query_cursor_new() orelse return error.CursorCreateFailed;
         defer c.ts_query_cursor_delete(inj_cursor);
-        if (self.has_changed_range) _ = c.ts_query_cursor_set_byte_range(inj_cursor, self.changed_start_byte, self.changed_end_byte);
+        if (self.has_changed_range) _ = c.ts_query_cursor_set_byte_range(inj_cursor, self.changed_new_start_byte, self.changed_new_end_byte);
         c.ts_query_cursor_exec(inj_cursor, inj_query, root);
 
         const inj_capture_count = c.ts_query_capture_count(inj_query);
@@ -1419,8 +1432,10 @@ pub const Highlighter = struct {
 
     fn highlightChangedRange(self: *Highlighter, query: *c.TSQuery, root: c.TSNode, source: []const u8) !HighlightResult {
         const alloc = self.allocator;
-        const start_byte = self.changed_start_byte;
-        const end_byte = self.changed_end_byte;
+        const old_start_byte = self.changed_old_start_byte;
+        const old_end_byte = self.changed_old_end_byte;
+        const start_byte = self.changed_new_start_byte;
+        const end_byte = self.changed_new_end_byte;
 
         const cursor = c.ts_query_cursor_new() orelse return error.CursorCreateFailed;
         defer c.ts_query_cursor_delete(cursor);
@@ -1460,8 +1475,10 @@ pub const Highlighter = struct {
         errdefer merged.deinit(alloc);
         try merged.ensureTotalCapacity(alloc, self.cached_highlight_spans.len + changed_spans.items.len);
         for (self.cached_highlight_spans) |span| {
-            if (span.end_byte < start_byte or span.start_byte > end_byte) {
+            if (span.end_byte <= old_start_byte) {
                 merged.appendAssumeCapacity(span);
+            } else if (span.start_byte >= old_end_byte) {
+                merged.appendAssumeCapacity(shiftSpan(span, self.changed_byte_delta));
             }
         }
         try merged.appendSlice(alloc, changed_spans.items);
@@ -1595,6 +1612,18 @@ fn findCaptureId(query: ?*c.TSQuery, target: []const u8) ?u32 {
         if (std.mem.eql(u8, name_ptr[0..length], target)) return @intCast(i);
     }
     return null;
+}
+
+fn shiftSpan(span: Span, delta: i64) Span {
+    const start = @as(i64, span.start_byte) + delta;
+    const end = @as(i64, span.end_byte) + delta;
+    return .{
+        .start_byte = @intCast(start),
+        .end_byte = @intCast(end),
+        .capture_id = span.capture_id,
+        .pattern_index = span.pattern_index,
+        .layer = span.layer,
+    };
 }
 
 fn spansAreSorted(spans: []const Span) bool {

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -917,7 +917,7 @@ pub const Highlighter = struct {
 
             // Check for #set! conceal directive on this pattern.
             const conceal_replacement: ?[]const u8 = if (self.current_predicates) |preds|
-                preds.getConcealReplacement(@intCast(match.pattern_index))
+                if (preds.has_conceal_replacements) preds.getConcealReplacement(@intCast(match.pattern_index)) else null
             else
                 null;
 
@@ -1004,7 +1004,7 @@ pub const Highlighter = struct {
 
             // Check for #set! conceal directive on this pattern.
             const conceal_replacement: ?[]const u8 = if (self.current_predicates) |preds|
-                preds.getConcealReplacement(@intCast(match.pattern_index))
+                if (preds.has_conceal_replacements) preds.getConcealReplacement(@intCast(match.pattern_index)) else null
             else
                 null;
 

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -76,6 +76,9 @@ pub const Highlighter = struct {
     current_predicates: ?*const predicates_mod.PredicateTable = null,
     /// Capture id for @conceal in the active highlight query, if present.
     current_conceal_capture_id: ?u32 = null,
+    /// Last highlight result sizes, used to pre-size hot-path result buffers.
+    last_highlight_span_count: usize = 0,
+    last_highlight_conceal_count: usize = 0,
     cache_mutex: std.atomic.Mutex = .unlocked,
     allocator: std.mem.Allocator,
 
@@ -898,8 +901,10 @@ pub const Highlighter = struct {
         // Collect spans and conceal spans
         var spans: std.ArrayListUnmanaged(Span) = .empty;
         errdefer spans.deinit(alloc);
+        if (self.last_highlight_span_count > 0) try spans.ensureTotalCapacity(alloc, self.last_highlight_span_count);
         var conceals: std.ArrayListUnmanaged(ConcealSpan) = .empty;
         errdefer conceals.deinit(alloc);
+        if (self.last_highlight_conceal_count > 0) try conceals.ensureTotalCapacity(alloc, self.last_highlight_conceal_count);
 
         const source = self.current_source orelse &.{};
 
@@ -944,6 +949,8 @@ pub const Highlighter = struct {
 
         // Sort by (start_byte ASC, layer DESC, pattern_index DESC, end_byte ASC).
         std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
+        self.last_highlight_span_count = spans.items.len;
+        self.last_highlight_conceal_count = conceals.items.len;
 
         // Collect capture names
         const pattern_count = c.ts_query_capture_count(query);
@@ -983,8 +990,10 @@ pub const Highlighter = struct {
 
         var spans: std.ArrayListUnmanaged(Span) = .empty;
         errdefer spans.deinit(alloc);
+        if (self.last_highlight_span_count > 0) try spans.ensureTotalCapacity(alloc, self.last_highlight_span_count);
         var conceals: std.ArrayListUnmanaged(ConcealSpan) = .empty;
         errdefer conceals.deinit(alloc);
+        if (self.last_highlight_conceal_count > 0) try conceals.ensureTotalCapacity(alloc, self.last_highlight_conceal_count);
 
         var match: c.TSQueryMatch = undefined;
         while (c.ts_query_cursor_next_match(cursor, &match)) {
@@ -1060,6 +1069,8 @@ pub const Highlighter = struct {
             // Injection query has no @injection.content — nothing to inject.
             // Return plain highlight result.
             std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
+            self.last_highlight_span_count = spans.items.len;
+            self.last_highlight_conceal_count = conceals.items.len;
             const names = try alloc.alloc([]const u8, name_list.items.len);
             @memcpy(names, name_list.items);
             return .{
@@ -1298,6 +1309,8 @@ pub const Highlighter = struct {
         // with full metadata. The BEAM-side innermost-wins sweep resolves
         // overlaps using (layer DESC, width ASC, pattern_index DESC).
         std.mem.sortUnstable(Span, spans.items, {}, spanLessThan);
+        self.last_highlight_span_count = spans.items.len;
+        self.last_highlight_conceal_count = conceals.items.len;
 
         const names = try alloc.alloc([]const u8, name_list.items.len);
         @memcpy(names, name_list.items);

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -1471,17 +1471,21 @@ pub const Highlighter = struct {
             }
         }
 
+        const cached = self.cached_highlight_spans;
+        var remove_start = lowerBoundSpanStart(cached, old_start_byte);
+        while (remove_start > 0 and cached[remove_start - 1].end_byte > old_start_byte) : (remove_start -= 1) {}
+        var remove_end = remove_start;
+        while (remove_end < cached.len and cached[remove_end].start_byte < old_end_byte) : (remove_end += 1) {}
+
         var merged: std.ArrayListUnmanaged(Span) = .empty;
         errdefer merged.deinit(alloc);
-        try merged.ensureTotalCapacity(alloc, self.cached_highlight_spans.len + changed_spans.items.len);
-        for (self.cached_highlight_spans) |span| {
-            if (span.end_byte <= old_start_byte) {
-                merged.appendAssumeCapacity(span);
-            } else if (span.start_byte >= old_end_byte) {
-                merged.appendAssumeCapacity(shiftSpan(span, self.changed_byte_delta));
-            }
-        }
+        const merged_len = cached.len - (remove_end - remove_start) + changed_spans.items.len;
+        try merged.ensureTotalCapacity(alloc, merged_len);
+        try merged.appendSlice(alloc, cached[0..remove_start]);
         try merged.appendSlice(alloc, changed_spans.items);
+        for (cached[remove_end..]) |span| {
+            merged.appendAssumeCapacity(shiftSpan(span, self.changed_byte_delta));
+        }
         if (!spansAreSorted(merged.items)) std.mem.sortUnstable(Span, merged.items, {}, spanLessThan);
         self.last_highlight_span_count = merged.items.len;
         self.last_highlight_conceal_count = conceals.items.len;
@@ -1612,6 +1616,20 @@ fn findCaptureId(query: ?*c.TSQuery, target: []const u8) ?u32 {
         if (std.mem.eql(u8, name_ptr[0..length], target)) return @intCast(i);
     }
     return null;
+}
+
+fn lowerBoundSpanStart(spans: []const Span, start_byte: u32) usize {
+    var low: usize = 0;
+    var high: usize = spans.len;
+    while (low < high) {
+        const mid = low + (high - low) / 2;
+        if (spans[mid].start_byte < start_byte) {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+    return low;
 }
 
 fn shiftSpan(span: Span, delta: i64) Span {

--- a/zig/src/predicates.zig
+++ b/zig/src/predicates.zig
@@ -24,6 +24,12 @@ pub const Predicate = union(enum) {
         regex: ?*posix_regex.CompiledRegex,
         negate: bool,
     },
+    /// Fast path for simple `^x` match predicates.
+    starts_with_byte: struct {
+        capture_id: u32,
+        byte: u8,
+        negate: bool,
+    },
     /// `#eq? @capture "string"` or `#not-eq?`
     eq_string: struct {
         capture_id: u32,
@@ -142,6 +148,11 @@ fn evaluateOne(pred: Predicate, match: c.TSQueryMatch, source: []const u8) bool 
             const re = mp.regex orelse return true; // regex failed to compile, skip
             const matches = posix_regex.matches(re, text);
             return if (mp.negate) !matches else matches;
+        },
+        .starts_with_byte => |sw| {
+            const text = captureText(match, sw.capture_id, source) orelse return sw.negate;
+            const matches = text.len > 0 and text[0] == sw.byte;
+            return if (sw.negate) !matches else matches;
         },
         .eq_string => |es| {
             const text = captureText(match, es.capture_id, source) orelse return es.negate;
@@ -272,6 +283,13 @@ fn parsePredicate(
         var plen: u32 = 0;
         const pptr = c.ts_query_string_value_for_id(query, args[1].value_id, &plen);
         const pattern = pptr[0..plen];
+        if (pattern.len == 2 and pattern[0] == '^') {
+            return .{ .starts_with_byte = .{
+                .capture_id = capture_id,
+                .byte = pattern[1],
+                .negate = negate,
+            } };
+        }
 
         // Compile regex
         const regex = posix_regex.compile(pattern, allocator);

--- a/zig/src/predicates.zig
+++ b/zig/src/predicates.zig
@@ -49,6 +49,7 @@ pub const PredicateTable = struct {
     entries: []?[]const Predicate,
     /// Conceal replacement per pattern. null = no conceal, empty = hide entirely.
     conceal_replacements: []?[]const u8,
+    has_conceal_replacements: bool,
     allocator: std.mem.Allocator,
     /// Track compiled regexes for cleanup
     regexes: std.ArrayListUnmanaged(*posix_regex.CompiledRegex),
@@ -57,21 +58,24 @@ pub const PredicateTable = struct {
     pub fn init(query: *c.TSQuery, allocator: std.mem.Allocator) PredicateTable {
         const pattern_count = c.ts_query_pattern_count(query);
         const entries = allocator.alloc(?[]const Predicate, pattern_count) catch
-            return .{ .entries = &.{}, .conceal_replacements = &.{}, .allocator = allocator, .regexes = .empty };
+            return .{ .entries = &.{}, .conceal_replacements = &.{}, .has_conceal_replacements = false, .allocator = allocator, .regexes = .empty };
 
         const conceal_reps = allocator.alloc(?[]const u8, pattern_count) catch
-            return .{ .entries = &.{}, .conceal_replacements = &.{}, .allocator = allocator, .regexes = .empty };
+            return .{ .entries = &.{}, .conceal_replacements = &.{}, .has_conceal_replacements = false, .allocator = allocator, .regexes = .empty };
 
         var regexes: std.ArrayListUnmanaged(*posix_regex.CompiledRegex) = .empty;
+        var has_conceal_replacements = false;
 
         for (0..pattern_count) |i| {
             entries[i] = parsePattern(query, @intCast(i), allocator, &regexes);
             conceal_reps[i] = parseConcealDirective(query, @intCast(i));
+            if (conceal_reps[i] != null) has_conceal_replacements = true;
         }
 
         return .{
             .entries = entries,
             .conceal_replacements = conceal_reps,
+            .has_conceal_replacements = has_conceal_replacements,
             .allocator = allocator,
             .regexes = regexes,
         };


### PR DESCRIPTION
# TL;DR
This PR cuts headless dirty-row render latency by moving the render path toward retained/cached work: stable chrome is reused, clean buffer rows avoid highlight/line rebuilds, and simple draw commands avoid keyword-style encoding overhead.

## Context
This came out of an autoresearch pass focused on render dirty-row update speed. The benchmark runs a 2,000-line headless editor buffer, sends repeated insert-mode keys, and tracks render pipeline and key latency metrics.

## Changes
- Targets same-line buffer edits to the affected cursor lines instead of treating every same-line version bump as a full visible-window redraw.
- Caches stable TUI chrome sections and status-bar data across cursor-only frames, with invalidation for status messages, command input, macro recording, and dirty markers.
- Builds common nowrap content layers directly, masks syntax highlight segment construction to dirty rows, and avoids intermediate line-offset allocation on that fast path.
- Avoids eager fallback highlight construction in `window_highlight/2`, which was rebuilding a theme-derived highlight even when a buffer highlight was already cached.
- Reuses render snapshot path data for diagnostic signs and skips display-map work on plain buffers with no folds, virtual lines, or block decorations.
- Speeds up emit by encoding simple face draws directly and building draw command lists with one reverse pass.
- Keeps benchmark scripts and autoresearch notes in the branch so the optimization path and validation workload are reproducible.

## Performance
Final hardened benchmark run:

- `render_us`: 524.5µs baseline to 234.5µs, about 55% faster
- `content_stage_us`: 245µs-class baseline to 57µs
- `chrome_stage_us`: 118µs-class baseline to 35µs
- `key_latency_us`: 1116.5µs baseline to 837.5µs, about 25% faster

The raw autoresearch best reached 205.5µs render median, but the PR keeps the correctness hardening for dirty markers, minibuffer updates, macro recording, and updated tests.

## Verification
- `make lint`
- `mix test.llm`
- `mix zig.lint`
- `mix swift.build`
- `./autoresearch.sh`
- Reviewer gate: PASS

## Notes for reviewers
The diff is intentionally broad because the render hot path crosses scroll, content, chrome, display-list conversion, and frontend protocol encoding. The highest-risk behavior is cache invalidation, so review should focus on status/minibuffer freshness, dirty-line semantics, and GUI/TUI parity around display-list output.
