### PR TITLE
feat(agent): add resume session picker

### DIFF
--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -134,7 +134,7 @@ defmodule Minga.Keymap.Defaults do
     {[{?a, @none}, {?n, @none}], :agent_new_session, "New agent session"},
     {[{?a, @none}, {?m, @none}], :agent_pick_model, "Pick agent model"},
     {[{?a, @none}, {?M, @none}], :agent_cycle_model, "Cycle agent model"},
-    {[{?a, @none}, {?h, @none}], :agent_session_history, "Session history"},
+    {[{?a, @none}, {?h, @none}], :agent_session_history, "Resume session"},
     {[{?a, @none}, {?T, @none}], :agent_cycle_thinking, "Cycle thinking level"},
     {[{?a, @none}, {?e, @none}], :agent_summarize, "Summarize session to artifact"},
     {[{?a, @none}, {?q, @none}], :agent_dequeue, "Dequeue queued messages to editor"},

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -25,6 +25,7 @@ defmodule MingaAgent.Session do
   alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.Credentials
   alias MingaAgent.Event
+  alias MingaAgent.Memory
   alias MingaAgent.Message
   alias MingaAgent.Notifier
   alias MingaAgent.ProviderResolver
@@ -65,6 +66,9 @@ defmodule MingaAgent.Session do
           model_name: String.t(),
           provider_name: String.t(),
           save_timer: reference() | nil,
+          session_store_dir: String.t() | nil,
+          created_at: DateTime.t(),
+          last_message_at: DateTime.t(),
           branches: [Branch.t()],
           steering_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
           follow_up_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
@@ -177,9 +181,7 @@ defmodule MingaAgent.Session do
   @doc """
   Loads a previously saved session, replacing the current conversation history.
 
-  The provider's conversation context is not synced; the loaded messages
-  are for display only until the user sends a new prompt, which re-establishes
-  the provider context.
+  The current session is saved before replacement. The restored conversation history, branches, model, and metadata become the active session state.
   """
   @spec load_session(GenServer.server(), String.t()) :: :ok | {:error, term()}
   def load_session(session, session_id) when is_binary(session_id) do
@@ -469,6 +471,8 @@ defmodule MingaAgent.Session do
       |> Keyword.get(:provider, "unknown")
       |> to_string()
 
+    now = DateTime.utc_now()
+
     state = %{
       session_id: session_id,
       provider: nil,
@@ -486,7 +490,9 @@ defmodule MingaAgent.Session do
       model_name: model_name,
       provider_name: provider_name,
       save_timer: nil,
-      created_at: DateTime.utc_now(),
+      session_store_dir: Keyword.get(opts, :session_store_dir),
+      created_at: now,
+      last_message_at: now,
       branches: [],
       steering_queue: [],
       follow_up_queue: [],
@@ -661,7 +667,8 @@ defmodule MingaAgent.Session do
       state.provider_module.new_session(state.provider)
     end
 
-    timestamp = Calendar.strftime(DateTime.utc_now(), "%H:%M:%S UTC")
+    now = DateTime.utc_now()
+    timestamp = Calendar.strftime(now, "%H:%M:%S UTC")
 
     state = cancel_save_timer(state)
 
@@ -672,6 +679,8 @@ defmodule MingaAgent.Session do
         total_usage: TurnUsage.new(),
         error_message: nil,
         pending_approval: nil,
+        created_at: now,
+        last_message_at: now,
         steering_queue: [],
         follow_up_queue: [],
         touched_files: %{},
@@ -710,29 +719,12 @@ defmodule MingaAgent.Session do
   end
 
   def handle_call({:load_session, session_id}, _from, state) do
-    case SessionStore.load(session_id) do
+    case SessionStore.load(session_id, state.session_store_dir) do
       {:ok, data} ->
-        state = cancel_save_timer(state)
-
-        state = %{
-          state
-          | session_id: data.id,
-            total_usage: data.usage,
-            model_name: data.model_name,
-            status: :idle,
-            error_message: nil,
-            pending_approval: nil,
-            steering_queue: [],
-            follow_up_queue: [],
-            touched_files: %{},
-            boundaries: %{}
-        }
-
-        state = reset_messages(state, data.messages)
-
-        broadcast(state, {:status_changed, :idle})
-        state = notify_messages_changed(state)
-        {:reply, :ok, state}
+        case restore_loaded_session(state, data) do
+          {:ok, state} -> {:reply, :ok, state}
+          {:error, reason} -> {:reply, {:error, reason}, state}
+        end
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}
@@ -771,12 +763,18 @@ defmodule MingaAgent.Session do
   end
 
   def handle_call(:metadata, _from, state) do
+    first_prompt = first_user_prompt(state.messages)
+
     meta = %SessionMetadata{
       id: state.session_id,
+      title: readable_title(first_prompt),
       model_name: state.model_name,
+      provider_name: state.provider_name,
       created_at: state.created_at,
+      last_message_at: state.last_message_at,
       message_count: length(state.messages),
-      first_prompt: first_user_prompt(state.messages),
+      turn_count: count_user_turns(state.messages),
+      first_prompt: first_prompt,
       cost: state.total_usage.cost,
       status: state.status
     }
@@ -1402,6 +1400,7 @@ defmodule MingaAgent.Session do
   @doc false
   @spec notify_messages_changed(state()) :: state()
   defp notify_messages_changed(state) do
+    state = %{state | last_message_at: DateTime.utc_now()}
     broadcast(state, :messages_changed)
     schedule_save(state)
   end
@@ -1490,17 +1489,143 @@ defmodule MingaAgent.Session do
     %{state | save_timer: nil}
   end
 
-  @spec save_to_disk(state()) :: :ok
+  @spec save_to_disk(state()) :: :ok | {:error, term()}
   defp save_to_disk(state) do
+    now = DateTime.to_iso8601(DateTime.utc_now())
+    last_message_at = DateTime.to_iso8601(state.last_message_at)
+
     data = %{
       id: state.session_id,
-      timestamp: DateTime.to_iso8601(DateTime.utc_now()),
+      timestamp: now,
+      last_message_at: last_message_at,
+      title: readable_title(first_user_prompt(state.messages)),
       model_name: state.model_name,
+      provider_name: state.provider_name,
       messages: state.messages,
-      usage: state.total_usage
+      usage: state.total_usage,
+      branches: state.branches,
+      memory: Memory.read(state.session_store_dir)
     }
 
-    SessionStore.save(data)
+    SessionStore.save(data, state.session_store_dir)
+  end
+
+  @spec restore_loaded_session(state(), SessionStore.session_data()) ::
+          {:ok, state()} | {:error, term()}
+  defp restore_loaded_session(state, data) do
+    case persist_current_before_replacement(state, data.id) do
+      :ok ->
+        state = cancel_save_timer(state)
+        loaded_at = parse_datetime(Map.get(data, :last_message_at)) || DateTime.utc_now()
+
+        state = %{
+          state
+          | session_id: data.id,
+            total_usage: data.usage,
+            model_name: data.model_name,
+            provider_name: Map.get(data, :provider_name, state.provider_name),
+            status: :idle,
+            error_message: nil,
+            pending_approval: nil,
+            created_at: loaded_at,
+            last_message_at: loaded_at,
+            branches: Map.get(data, :branches, []),
+            steering_queue: [],
+            follow_up_queue: [],
+            touched_files: %{},
+            boundaries: %{}
+        }
+
+        apply_loaded_model_to_provider(state)
+        finish_loaded_session_restore(state, data)
+
+      {:error, reason} ->
+        {:error, {:save_current_failed, reason}}
+    end
+  end
+
+  @spec finish_loaded_session_restore(state(), SessionStore.session_data()) ::
+          {:ok, state()} | {:error, term()}
+  defp finish_loaded_session_restore(state, data) do
+    case restore_memory_snapshot_if_recorded(state, data) do
+      :ok ->
+        state = reset_messages(state, data.messages)
+
+        broadcast(state, {:status_changed, :idle})
+        broadcast(state, :messages_changed)
+        {:ok, state}
+
+      {:error, reason} ->
+        {:error, {:memory_restore_failed, reason}}
+    end
+  end
+
+  @spec persist_current_before_replacement(state(), String.t()) :: :ok | {:error, term()}
+  defp persist_current_before_replacement(%{session_id: target_id}, target_id), do: :ok
+  defp persist_current_before_replacement(state, _target_id), do: save_to_disk(state)
+
+  @spec apply_loaded_model_to_provider(state()) :: :ok
+  defp apply_loaded_model_to_provider(%{provider: nil}), do: :ok
+
+  defp apply_loaded_model_to_provider(state) do
+    dispatch_optional(state.provider_module, :set_model, [state.provider, state.model_name])
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  @spec restore_memory_snapshot_if_recorded(state(), SessionStore.session_data()) ::
+          :ok | {:error, term()}
+  defp restore_memory_snapshot_if_recorded(state, data) do
+    if Map.has_key?(data, :memory) do
+      restore_memory_snapshot(state, Map.get(data, :memory))
+    else
+      :ok
+    end
+  end
+
+  @spec restore_memory_snapshot(state(), String.t() | nil) :: :ok | {:error, term()}
+  defp restore_memory_snapshot(state, nil), do: Memory.clear(state.session_store_dir)
+
+  defp restore_memory_snapshot(state, memory) when is_binary(memory) do
+    path = Memory.path(state.session_store_dir)
+
+    with :ok <- File.mkdir_p(Path.dirname(path)) do
+      File.write(path, memory)
+    end
+  end
+
+  @spec parse_datetime(String.t() | nil) :: DateTime.t() | nil
+  defp parse_datetime(nil), do: nil
+
+  defp parse_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> dt
+      _ -> nil
+    end
+  end
+
+  @spec count_user_turns([Message.t()]) :: non_neg_integer()
+  defp count_user_turns(messages) do
+    Enum.count(messages, fn
+      {:user, _} -> true
+      {:user, _, _attachments} -> true
+      _ -> false
+    end)
+  end
+
+  @spec readable_title(String.t() | nil) :: String.t() | nil
+  defp readable_title(nil), do: nil
+
+  defp readable_title(text) do
+    text
+    |> String.split("\n")
+    |> hd()
+    |> String.trim()
+    |> case do
+      "" -> nil
+      title -> title
+    end
   end
 
   @spec generate_session_id() :: String.t()

--- a/lib/minga_agent/session_manager.ex
+++ b/lib/minga_agent/session_manager.ex
@@ -257,10 +257,13 @@ defmodule MingaAgent.SessionManager do
     Session.metadata(pid)
   catch
     :exit, _ ->
+      now = DateTime.utc_now()
+
       %SessionMetadata{
         id: "unknown",
         model_name: "unknown",
-        created_at: DateTime.utc_now()
+        created_at: now,
+        last_message_at: now
       }
   end
 end

--- a/lib/minga_agent/session_metadata.ex
+++ b/lib/minga_agent/session_metadata.ex
@@ -10,19 +10,27 @@ defmodule MingaAgent.SessionMetadata do
   @typedoc "Session metadata."
   @type t :: %__MODULE__{
           id: String.t(),
+          title: String.t() | nil,
           model_name: String.t(),
+          provider_name: String.t(),
           created_at: DateTime.t(),
+          last_message_at: DateTime.t(),
           message_count: non_neg_integer(),
+          turn_count: non_neg_integer(),
           first_prompt: String.t() | nil,
           cost: float(),
           status: MingaAgent.Session.status()
         }
 
-  @enforce_keys [:id, :model_name, :created_at]
+  @enforce_keys [:id, :model_name, :created_at, :last_message_at]
   defstruct id: nil,
+            title: nil,
             model_name: nil,
+            provider_name: "unknown",
             created_at: nil,
+            last_message_at: nil,
             message_count: 0,
+            turn_count: 0,
             first_prompt: nil,
             cost: 0.0,
             status: :idle

--- a/lib/minga_agent/session_store.ex
+++ b/lib/minga_agent/session_store.ex
@@ -15,25 +15,37 @@ defmodule MingaAgent.SessionStore do
   @type session_meta :: %{
           id: String.t(),
           timestamp: String.t(),
+          last_message_at: String.t(),
+          title: String.t(),
           model_name: String.t(),
+          provider_name: String.t(),
           preview: String.t(),
+          recent_messages: String.t(),
           message_count: non_neg_integer(),
+          turn_count: non_neg_integer(),
           cost: float()
         }
 
   @typedoc "Full session data for save/load."
   @type session_data :: %{
-          id: String.t(),
-          timestamp: String.t(),
-          model_name: String.t(),
-          messages: [map()],
-          usage: map()
+          required(:id) => String.t(),
+          required(:timestamp) => String.t(),
+          required(:model_name) => String.t(),
+          required(:messages) => [MingaAgent.Message.t()],
+          required(:usage) => MingaAgent.TurnUsage.t(),
+          optional(:last_message_at) => String.t(),
+          optional(:title) => String.t(),
+          optional(:provider_name) => String.t(),
+          optional(:branches) => [MingaAgent.Branch.t()],
+          optional(:memory) => String.t() | nil
         }
 
   @doc "Returns the sessions directory path."
-  @spec sessions_dir() :: String.t()
-  def sessions_dir do
-    config_dir = System.get_env("XDG_CONFIG_HOME") || Path.join(System.user_home!(), ".config")
+  @spec sessions_dir(String.t() | nil) :: String.t()
+  def sessions_dir(config_dir \\ nil) do
+    config_dir =
+      config_dir || System.get_env("XDG_CONFIG_HOME") || Path.join(System.user_home!(), ".config")
+
     Path.join([config_dir, "minga", "agent", "sessions"])
   end
 
@@ -43,19 +55,18 @@ defmodule MingaAgent.SessionStore do
   Creates the sessions directory if it doesn't exist. Writes atomically
   via a temp file to avoid corruption.
   """
-  @spec save(session_data()) :: :ok | {:error, term()}
-  def save(%{id: id} = data) when is_binary(id) do
-    dir = sessions_dir()
-    File.mkdir_p!(dir)
+  @spec save(session_data(), String.t() | nil) :: :ok | {:error, term()}
+  def save(%{id: id} = data, config_dir \\ nil) when is_binary(id) do
+    dir = sessions_dir(config_dir)
     path = Path.join(dir, "#{id}.json")
     tmp_path = path <> ".tmp"
-
     json = JSON.encode!(serialize(data))
 
-    case File.write(tmp_path, json) do
-      :ok ->
-        File.rename(tmp_path, path)
-
+    with :ok <- File.mkdir_p(dir),
+         :ok <- File.write(tmp_path, json),
+         :ok <- File.rename(tmp_path, path) do
+      :ok
+    else
       {:error, reason} ->
         Minga.Log.warning(:agent, "[SessionStore] failed to save #{id}: #{reason}")
         {:error, reason}
@@ -67,9 +78,9 @@ defmodule MingaAgent.SessionStore do
 
   Returns `{:ok, session_data}` or `{:error, reason}`.
   """
-  @spec load(String.t()) :: {:ok, session_data()} | {:error, term()}
-  def load(session_id) when is_binary(session_id) do
-    path = Path.join(sessions_dir(), "#{session_id}.json")
+  @spec load(String.t(), String.t() | nil) :: {:ok, session_data()} | {:error, term()}
+  def load(session_id, config_dir \\ nil) when is_binary(session_id) do
+    path = Path.join(sessions_dir(config_dir), "#{session_id}.json")
 
     with {:ok, json} <- File.read(path),
          {:ok, data} <- decode_json(json) do
@@ -80,11 +91,11 @@ defmodule MingaAgent.SessionStore do
   @doc """
   Lists all saved sessions as metadata (without full messages).
 
-  Returns sessions sorted by timestamp, most recent first.
+  Returns sessions sorted by last message timestamp, most recent first.
   """
-  @spec list() :: [session_meta()]
-  def list do
-    dir = sessions_dir()
+  @spec list(String.t() | nil) :: [session_meta()]
+  def list(config_dir \\ nil) do
+    dir = sessions_dir(config_dir)
 
     case File.ls(dir) do
       {:ok, files} ->
@@ -93,7 +104,7 @@ defmodule MingaAgent.SessionStore do
         |> Enum.reject(&String.ends_with?(&1, ".tmp"))
         |> Enum.map(fn file -> load_meta(Path.join(dir, file)) end)
         |> Enum.reject(&is_nil/1)
-        |> Enum.sort_by(& &1.timestamp, :desc)
+        |> Enum.sort_by(& &1.last_message_at, :desc)
 
       {:error, _} ->
         []
@@ -101,16 +112,16 @@ defmodule MingaAgent.SessionStore do
   end
 
   @doc "Deletes a saved session."
-  @spec delete(String.t()) :: :ok | {:error, term()}
-  def delete(session_id) when is_binary(session_id) do
-    path = Path.join(sessions_dir(), "#{session_id}.json")
+  @spec delete(String.t(), String.t() | nil) :: :ok | {:error, term()}
+  def delete(session_id, config_dir \\ nil) when is_binary(session_id) do
+    path = Path.join(sessions_dir(config_dir), "#{session_id}.json")
     File.rm(path)
   end
 
   @doc "Deletes all saved sessions."
-  @spec clear_all() :: :ok
-  def clear_all do
-    dir = sessions_dir()
+  @spec clear_all(String.t() | nil) :: :ok
+  def clear_all(config_dir \\ nil) do
+    dir = sessions_dir(config_dir)
 
     case File.ls(dir) do
       {:ok, files} ->
@@ -128,16 +139,16 @@ defmodule MingaAgent.SessionStore do
 
   Returns the number of sessions deleted.
   """
-  @spec prune(non_neg_integer()) :: non_neg_integer()
-  def prune(days) when is_integer(days) and days > 0 do
+  @spec prune(non_neg_integer(), String.t() | nil) :: non_neg_integer()
+  def prune(days, config_dir \\ nil) when is_integer(days) and days > 0 do
     cutoff = DateTime.add(DateTime.utc_now(), -days * 86_400, :second)
     cutoff_str = DateTime.to_iso8601(cutoff)
 
     pruned =
-      list()
+      list(config_dir)
       |> Enum.filter(fn meta -> meta.timestamp < cutoff_str end)
 
-    Enum.each(pruned, fn meta -> delete(meta.id) end)
+    Enum.each(pruned, fn meta -> delete(meta.id, config_dir) end)
     length(pruned)
   end
 
@@ -145,17 +156,28 @@ defmodule MingaAgent.SessionStore do
 
   @spec serialize(session_data()) :: map()
   defp serialize(data) do
+    messages = Map.get(data, :messages, [])
+    timestamp = Map.get(data, :timestamp) || DateTime.to_iso8601(DateTime.utc_now())
+
     %{
       "id" => data.id,
-      "timestamp" => data.timestamp,
+      "timestamp" => timestamp,
+      "last_message_at" => Map.get(data, :last_message_at, timestamp),
+      "title" => Map.get(data, :title) || title_from_messages(messages),
       "model_name" => data.model_name,
-      "messages" => Enum.map(data.messages, &serialize_message/1),
-      "usage" => serialize_usage(data.usage)
+      "provider_name" => Map.get(data, :provider_name, "unknown"),
+      "messages" => Enum.map(messages, &serialize_message/1),
+      "usage" => serialize_usage(data.usage),
+      "branches" => Enum.map(Map.get(data, :branches, []), &serialize_branch/1),
+      "memory" => Map.get(data, :memory)
     }
   end
 
   @spec serialize_message(MingaAgent.Message.t()) :: map()
-  defp serialize_message({:user, text, _attachments}), do: %{"type" => "user", "text" => text}
+  defp serialize_message({:user, text, attachments}) do
+    %{"type" => "user", "text" => text, "attachments" => attachments}
+  end
+
   defp serialize_message({:user, text}), do: %{"type" => "user", "text" => text}
   defp serialize_message({:assistant, text}), do: %{"type" => "assistant", "text" => text}
 
@@ -197,16 +219,34 @@ defmodule MingaAgent.SessionStore do
 
   @spec deserialize(map()) :: session_data()
   defp deserialize(data) do
-    %{
+    messages = Enum.map(data["messages"] || [], &deserialize_message/1)
+    timestamp = data["timestamp"] || ""
+
+    session = %{
       id: data["id"],
-      timestamp: data["timestamp"],
+      timestamp: timestamp,
+      last_message_at: data["last_message_at"] || timestamp,
+      title: data["title"] || title_from_messages(messages),
       model_name: data["model_name"] || "unknown",
-      messages: Enum.map(data["messages"] || [], &deserialize_message/1),
-      usage: deserialize_turn_usage(data["usage"] || %{})
+      provider_name: data["provider_name"] || "unknown",
+      messages: messages,
+      usage: deserialize_turn_usage(data["usage"] || %{}),
+      branches: Enum.map(data["branches"] || [], &deserialize_branch/1)
     }
+
+    if Map.has_key?(data, "memory") do
+      Map.put(session, :memory, data["memory"])
+    else
+      session
+    end
   end
 
   @spec deserialize_message(map()) :: MingaAgent.Message.t()
+  defp deserialize_message(%{"type" => "user", "text" => text, "attachments" => attachments})
+       when is_list(attachments) do
+    {:user, text, Enum.map(attachments, &deserialize_attachment/1)}
+  end
+
   defp deserialize_message(%{"type" => "user", "text" => text}), do: {:user, text}
   defp deserialize_message(%{"type" => "assistant", "text" => text}), do: {:assistant, text}
 
@@ -220,7 +260,7 @@ defmodule MingaAgent.SessionStore do
        id: raw["id"],
        name: raw["name"],
        args: raw["args"] || %{},
-       status: String.to_existing_atom(raw["status"] || "complete"),
+       status: deserialize_tool_status(raw["status"]),
        result: raw["result"] || "",
        is_error: raw["is_error"] || false,
        collapsed: raw["collapsed"] || true,
@@ -230,7 +270,7 @@ defmodule MingaAgent.SessionStore do
   end
 
   defp deserialize_message(%{"type" => "system", "text" => text, "level" => level}) do
-    {:system, text, String.to_existing_atom(level)}
+    {:system, text, deserialize_system_level(level)}
   end
 
   defp deserialize_message(%{"type" => "usage", "data" => data}) do
@@ -240,6 +280,42 @@ defmodule MingaAgent.SessionStore do
   # Fallback for unknown message types
   defp deserialize_message(%{"type" => type} = msg) do
     {:system, "Unknown message type: #{type} - #{inspect(msg)}", :info}
+  end
+
+  @spec deserialize_attachment(map()) :: MingaAgent.Message.image_attachment()
+  defp deserialize_attachment(attachment) do
+    %{
+      filename: attachment["filename"] || attachment[:filename] || "image",
+      size_kb: attachment["size_kb"] || attachment[:size_kb] || 0
+    }
+  end
+
+  @spec deserialize_tool_status(String.t() | nil) :: MingaAgent.ToolCall.status()
+  defp deserialize_tool_status("running"), do: :running
+  defp deserialize_tool_status("complete"), do: :complete
+  defp deserialize_tool_status("error"), do: :error
+  defp deserialize_tool_status(_status), do: :complete
+
+  @spec deserialize_system_level(String.t() | nil) :: MingaAgent.Message.system_level()
+  defp deserialize_system_level("error"), do: :error
+  defp deserialize_system_level(_level), do: :info
+
+  @spec serialize_branch(MingaAgent.Branch.t()) :: map()
+  defp serialize_branch(%MingaAgent.Branch{} = branch) do
+    %{
+      "name" => branch.name,
+      "messages" => Enum.map(branch.messages, &serialize_message/1),
+      "created_at" => DateTime.to_iso8601(branch.created_at)
+    }
+  end
+
+  @spec deserialize_branch(map()) :: MingaAgent.Branch.t()
+  defp deserialize_branch(data) do
+    %MingaAgent.Branch{
+      name: data["name"] || "branch",
+      messages: Enum.map(data["messages"] || [], &deserialize_message/1),
+      created_at: parse_datetime(data["created_at"])
+    }
   end
 
   @spec deserialize_turn_usage(map()) :: MingaAgent.TurnUsage.t()
@@ -253,6 +329,16 @@ defmodule MingaAgent.SessionStore do
     }
   end
 
+  @spec parse_datetime(String.t() | nil) :: DateTime.t()
+  defp parse_datetime(nil), do: DateTime.utc_now()
+
+  defp parse_datetime(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> dt
+      _ -> DateTime.utc_now()
+    end
+  end
+
   # ── Private: metadata extraction ───────────────────────────────────────────
 
   @spec load_meta(String.t()) :: session_meta() | nil
@@ -260,29 +346,96 @@ defmodule MingaAgent.SessionStore do
     with {:ok, json} <- File.read(path),
          {:ok, data} <- decode_json(json) do
       messages = data["messages"] || []
-      first_user = Enum.find(messages, fn m -> m["type"] == "user" end)
-
-      preview =
-        case first_user do
-          %{"text" => text} -> String.slice(text, 0, 80)
-          nil -> "(empty)"
-        end
-
-      total_cost =
-        messages
-        |> Enum.filter(fn m -> m["type"] == "usage" end)
-        |> Enum.reduce(0.0, fn m, acc -> acc + (get_in(m, ["data", "cost"]) || 0.0) end)
+      preview = first_user_preview(messages)
+      timestamp = data["timestamp"] || ""
+      last_message_at = data["last_message_at"] || timestamp
 
       %{
         id: data["id"],
-        timestamp: data["timestamp"] || "",
+        timestamp: timestamp,
+        last_message_at: last_message_at,
+        title: data["title"] || preview,
         model_name: data["model_name"] || "unknown",
+        provider_name: data["provider_name"] || "unknown",
         preview: preview,
+        recent_messages: recent_messages(messages),
         message_count: length(messages),
-        cost: total_cost
+        turn_count: count_user_messages(messages),
+        cost: total_cost(data, messages)
       }
     else
       _ -> nil
+    end
+  end
+
+  @spec title_from_messages([MingaAgent.Message.t()]) :: String.t()
+  defp title_from_messages(messages) do
+    messages
+    |> Enum.find_value(fn
+      {:user, text} when is_binary(text) -> text
+      {:user, text, _attachments} when is_binary(text) -> text
+      _ -> nil
+    end)
+    |> readable_title()
+  end
+
+  @spec first_user_preview([map()]) :: String.t()
+  defp first_user_preview(messages) do
+    messages
+    |> Enum.find_value(fn
+      %{"type" => "user", "text" => text} when is_binary(text) -> text
+      _ -> nil
+    end)
+    |> readable_title()
+  end
+
+  @spec readable_title(String.t() | nil) :: String.t()
+  defp readable_title(nil), do: "(empty)"
+
+  defp readable_title(text) do
+    text
+    |> String.split("\n")
+    |> hd()
+    |> String.trim()
+    |> truncate(80)
+    |> case do
+      "" -> "(empty)"
+      title -> title
+    end
+  end
+
+  @spec recent_messages([map()]) :: String.t()
+  defp recent_messages(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.filter(fn m -> m["type"] in ["user", "assistant"] end)
+    |> Enum.take(6)
+    |> Enum.reverse()
+    |> Enum.map_join(" ", fn m -> m["text"] || "" end)
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+    |> truncate(240)
+  end
+
+  @spec count_user_messages([map()]) :: non_neg_integer()
+  defp count_user_messages(messages) do
+    Enum.count(messages, fn m -> m["type"] == "user" end)
+  end
+
+  @spec total_cost(map(), [map()]) :: float()
+  defp total_cost(data, messages) do
+    case data["usage"] do
+      %{"cost" => cost} when is_number(cost) -> cost
+      _ -> Enum.reduce(messages, 0.0, fn m, acc -> acc + (get_in(m, ["data", "cost"]) || 0.0) end)
+    end
+  end
+
+  @spec truncate(String.t(), pos_integer()) :: String.t()
+  defp truncate(text, max_length) do
+    if String.length(text) > max_length do
+      String.slice(text, 0, max_length - 3) <> "..."
+    else
+      text
     end
   end
 

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -42,6 +42,7 @@ defmodule MingaEditor.Agent.SlashCommand do
     %Command{name: "help", description: "Show available slash commands"},
     %Command{name: "plan", description: "Enter plan mode (destructive tools blocked)"},
     %Command{name: "exec", description: "Leave plan mode and allow execution"},
+    %Command{name: "resume", description: "Resume a saved agent session"},
     %Command{name: "sessions", description: "Browse and switch between sessions"},
     %Command{
       name: "auth",
@@ -135,6 +136,7 @@ defmodule MingaEditor.Agent.SlashCommand do
   defp dispatch(state, "exec", _args), do: do_exec(state)
   defp dispatch(state, "skill:plan", _args), do: do_plan(state)
   defp dispatch(state, "skill:off:plan", _args), do: do_exec(state)
+  defp dispatch(state, "resume", _args), do: {:ok, do_resume(state)}
   defp dispatch(state, "sessions", _args), do: {:ok, do_sessions(state)}
   defp dispatch(state, "auth", args), do: {:ok, do_auth(state, args)}
   defp dispatch(state, "instructions", _args), do: {:ok, do_instructions(state)}
@@ -245,6 +247,11 @@ defmodule MingaEditor.Agent.SlashCommand do
 
       {:ok, state}
     end
+  end
+
+  @spec do_resume(state()) :: state()
+  defp do_resume(state) do
+    PickerUI.open(state, MingaEditor.UI.Picker.AgentSessionSource, %{persisted_only: true})
   end
 
   @spec do_sessions(state()) :: state()

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -1298,9 +1298,11 @@ defmodule MingaEditor.Commands.Agent do
       },
       %Minga.Command{
         name: :agent_session_history,
-        description: "Agent session history",
+        description: "Resume agent session",
         requires_buffer: false,
-        execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.SessionHistorySource) end
+        execute: fn state ->
+          PickerUI.open(state, MingaEditor.UI.Picker.AgentSessionSource, %{persisted_only: true})
+        end
       }
     ]
 

--- a/lib/minga_editor/ui/picker/agent_session_source.ex
+++ b/lib/minga_editor/ui/picker/agent_session_source.ex
@@ -2,9 +2,7 @@ defmodule MingaEditor.UI.Picker.AgentSessionSource do
   @moduledoc """
   Picker source for agent sessions.
 
-  Lists all live sessions (active + archived) plus persisted sessions
-  from disk. Selecting a session switches the conversation. Includes
-  timestamp, first prompt preview, message count, and cost.
+  Lists all live sessions (active + archived) plus persisted sessions from disk. Selecting a live session switches tabs; selecting a persisted session resumes it into the active agent session. Entries include title, last message time, turn count, model, and recent message text for filtering.
   """
 
   @behaviour MingaEditor.UI.Picker.Source
@@ -29,13 +27,18 @@ defmodule MingaEditor.UI.Picker.AgentSessionSource do
 
   @impl true
   @spec candidates(Context.t()) :: [Item.t()]
-  def candidates(%Context{tab_bar: %TabBar{} = tb}) do
-    live = tab_candidates(tb)
-    disk = disk_candidates()
-    live_ids = MapSet.new(live, fn %Item{id: {id, _}} -> id end)
+  def candidates(%Context{tab_bar: %TabBar{} = tb} = ctx) do
+    disk = disk_candidates(ctx)
 
-    live ++
-      Enum.reject(disk, fn %Item{id: {id, _}} -> MapSet.member?(live_ids, id) end)
+    if persisted_only?(ctx) do
+      disk
+    else
+      live = tab_candidates(tb)
+      live_ids = MapSet.new(live, fn %Item{id: {id, _}} -> id end)
+
+      live ++
+        Enum.reject(disk, fn %Item{id: {id, _}} -> MapSet.member?(live_ids, id) end)
+    end
   end
 
   def candidates(_state), do: []
@@ -95,35 +98,72 @@ defmodule MingaEditor.UI.Picker.AgentSessionSource do
     :exit, _ -> :error
   end
 
-  @spec disk_candidates() :: [Item.t()]
-  defp disk_candidates do
-    SessionStore.list()
+  @spec disk_candidates(Context.t()) :: [Item.t()]
+  defp disk_candidates(ctx) do
+    ctx
+    |> session_store_dir()
+    |> SessionStore.list()
     |> Enum.map(fn meta ->
-      label = "#{meta.preview}"
-
-      desc =
-        "#{meta.model_name} · #{meta.message_count} msgs · $#{Float.round(meta.cost, 4)} · #{meta.timestamp}"
-
-      %Item{id: {meta.id, :disk}, label: label, description: desc}
+      %Item{
+        id: {meta.id, :disk},
+        label: meta.title,
+        description: disk_description(meta),
+        annotation: format_turn_count(meta.turn_count)
+      }
     end)
+  end
+
+  @spec persisted_only?(Context.t()) :: boolean()
+  defp persisted_only?(%Context{picker_ui: %{context: %{persisted_only: true}}}), do: true
+  defp persisted_only?(_ctx), do: false
+
+  @spec session_store_dir(Context.t()) :: String.t() | nil
+  defp session_store_dir(%Context{picker_ui: %{context: %{session_store_dir: dir}}})
+       when is_binary(dir), do: dir
+
+  defp session_store_dir(_ctx), do: nil
+
+  @spec disk_description(SessionStore.session_meta()) :: String.t()
+  defp disk_description(meta) do
+    [
+      "#{meta.provider_name}/#{meta.model_name}",
+      format_turn_count(meta.turn_count),
+      format_disk_timestamp(meta.last_message_at),
+      meta.recent_messages
+    ]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(" · ")
   end
 
   @spec format_label(Session.metadata(), boolean()) :: String.t()
   defp format_label(meta, true) do
-    prompt = truncate_prompt(meta.first_prompt)
+    prompt = truncate_prompt(meta.title || meta.first_prompt)
     "\u{2022} #{prompt}"
   end
 
   defp format_label(meta, false) do
-    truncate_prompt(meta.first_prompt)
+    truncate_prompt(meta.title || meta.first_prompt)
   end
 
   @spec format_desc(Session.metadata()) :: String.t()
   defp format_desc(meta) do
-    time = Calendar.strftime(meta.created_at, "%H:%M")
+    time = Calendar.strftime(meta.last_message_at, "%H:%M")
     cost = Float.round(meta.cost, 4)
-    "#{meta.model_name} · #{meta.message_count} msgs · $#{cost} · #{time}"
+
+    "#{meta.provider_name}/#{meta.model_name} · #{format_turn_count(meta.turn_count)} · #{meta.message_count} msgs · $#{cost} · #{time}"
   end
+
+  @spec format_disk_timestamp(String.t()) :: String.t()
+  defp format_disk_timestamp(timestamp) do
+    case DateTime.from_iso8601(timestamp) do
+      {:ok, dt, _offset} -> Calendar.strftime(dt, "%b %d %H:%M")
+      _ -> timestamp
+    end
+  end
+
+  @spec format_turn_count(non_neg_integer()) :: String.t()
+  defp format_turn_count(1), do: "1 turn"
+  defp format_turn_count(count), do: "#{count} turns"
 
   @spec truncate_prompt(String.t() | nil) :: String.t()
   defp truncate_prompt(nil), do: "(new session)"

--- a/test/minga/keymap/defaults_test.exs
+++ b/test/minga/keymap/defaults_test.exs
@@ -149,6 +149,14 @@ defmodule Minga.Keymap.DefaultsTest do
       assert {:command, :selection_shrink} = Bindings.lookup(c_node, {?V, 0})
     end
 
+    # ── AI agent bindings ─────────────────────────────────────────────────────
+
+    test "SPC a h → :agent_session_history" do
+      trie = Defaults.leader_trie()
+      {:prefix, a_node} = Bindings.lookup(trie, {?a, 0})
+      assert {:command, :agent_session_history} = Bindings.lookup(a_node, {?h, 0})
+    end
+
     # ── Negative cases ─────────────────────────────────────────────────────────
 
     test "unknown leader prefix returns :not_found" do

--- a/test/minga_agent/session_store_test.exs
+++ b/test/minga_agent/session_store_test.exs
@@ -1,6 +1,7 @@
 defmodule MingaAgent.SessionStoreTest do
   use ExUnit.Case, async: true
 
+  alias MingaAgent.Branch
   alias MingaAgent.SessionStore
   alias MingaAgent.ToolCall
   alias MingaAgent.TurnUsage
@@ -11,7 +12,10 @@ defmodule MingaAgent.SessionStoreTest do
     %{
       id: id,
       timestamp: DateTime.to_iso8601(DateTime.utc_now()),
+      last_message_at: DateTime.to_iso8601(DateTime.utc_now()),
+      title: "Hello, how are you?",
       model_name: "claude-sonnet-4",
+      provider_name: "native",
       messages: [
         {:system, "Session started", :info},
         {:user, "Hello, how are you?"},
@@ -31,7 +35,9 @@ defmodule MingaAgent.SessionStoreTest do
         {:thinking, "Let me think about this...", true},
         {:usage, %TurnUsage{input: 100, output: 50, cache_read: 200, cache_write: 0, cost: 0.003}}
       ],
-      usage: %TurnUsage{input: 100, output: 50, cache_read: 200, cache_write: 0, cost: 0.003}
+      usage: %TurnUsage{input: 100, output: 50, cache_read: 200, cache_write: 0, cost: 0.003},
+      branches: [Branch.new("branch-1", [{:user, "branch prompt"}])],
+      memory: "- [2026-01-01 00:00 UTC] Use concise answers\n"
     }
   end
 
@@ -56,6 +62,18 @@ defmodule MingaAgent.SessionStoreTest do
       assert [{:user, "Hello, how are you?"}] = user_msgs
     end
 
+    test "preserves user message attachments" do
+      data = %{
+        sample_data()
+        | messages: [{:user, "see image", [%{filename: "chart.png", size_kb: 42}]}]
+      }
+
+      SessionStore.save(data)
+
+      {:ok, loaded} = SessionStore.load(data.id)
+      assert loaded.messages == [{:user, "see image", [%{filename: "chart.png", size_kb: 42}]}]
+    end
+
     test "preserves assistant messages" do
       data = sample_data()
       SessionStore.save(data)
@@ -74,6 +92,29 @@ defmodule MingaAgent.SessionStoreTest do
       assert tc.name == "read_file"
       assert tc.duration_ms == 42
       assert tc.status == :complete
+    end
+
+    test "loads corrupted message atoms defensively", %{tmp_dir: dir} do
+      sessions_dir = SessionStore.sessions_dir(dir)
+      File.mkdir_p!(sessions_dir)
+
+      File.write!(
+        Path.join(sessions_dir, "bad-atoms.json"),
+        JSON.encode!(%{
+          "id" => "bad-atoms",
+          "timestamp" => "2026-01-01T00:00:00Z",
+          "model_name" => "test-model",
+          "messages" => [
+            %{"type" => "system", "text" => "bad level", "level" => "surprise"},
+            %{"type" => "tool_call", "id" => "tc", "name" => "read_file", "status" => "surprise"}
+          ],
+          "usage" => %{}
+        })
+      )
+
+      assert {:ok, loaded} = SessionStore.load("bad-atoms", dir)
+      assert {:system, "bad level", :info} in loaded.messages
+      assert {:tool_call, %{status: :complete}} = List.last(loaded.messages)
     end
 
     test "preserves thinking messages" do
@@ -114,8 +155,26 @@ defmodule MingaAgent.SessionStoreTest do
       assert loaded.usage.cost == 0.003
     end
 
+    test "preserves resumable metadata, branches, and memory", %{tmp_dir: dir} do
+      data = sample_data()
+      SessionStore.save(data, dir)
+
+      {:ok, loaded} = SessionStore.load(data.id, dir)
+      assert loaded.title == "Hello, how are you?"
+      assert loaded.provider_name == "native"
+      assert [%Branch{name: "branch-1", messages: [{:user, "branch prompt"}]}] = loaded.branches
+      assert loaded.memory =~ "Use concise answers"
+    end
+
     test "returns error for nonexistent session" do
       assert {:error, _} = SessionStore.load("nonexistent-id")
+    end
+
+    test "returns error when the sessions directory cannot be created", %{tmp_dir: dir} do
+      blocked_base = Path.join(dir, "not-a-directory")
+      File.write!(blocked_base, "file blocks mkdir")
+
+      assert {:error, _reason} = SessionStore.save(sample_data("blocked"), blocked_base)
     end
   end
 
@@ -157,6 +216,46 @@ defmodule MingaAgent.SessionStoreTest do
       sessions = SessionStore.list()
       session = Enum.find(sessions, &(&1.id == data.id))
       assert session.model_name == "claude-sonnet-4"
+    end
+
+    test "metadata includes title, last message timestamp, turn count, and recent text", %{
+      tmp_dir: dir
+    } do
+      data = sample_data()
+      SessionStore.save(data, dir)
+
+      sessions = SessionStore.list(dir)
+      session = Enum.find(sessions, &(&1.id == data.id))
+      assert session.title == "Hello, how are you?"
+      assert session.last_message_at == data.last_message_at
+      assert session.turn_count == 1
+      assert session.recent_messages =~ "doing great"
+    end
+
+    test "sorts sessions by last message timestamp descending", %{tmp_dir: dir} do
+      old_data = %{
+        sample_data("old")
+        | timestamp: "2026-01-01T00:00:00Z",
+          last_message_at: "2026-01-01T00:00:00Z"
+      }
+
+      new_data = %{
+        sample_data("new")
+        | timestamp: "2026-01-01T00:00:00Z",
+          last_message_at: "2026-01-03T00:00:00Z"
+      }
+
+      middle_data = %{
+        sample_data("middle")
+        | timestamp: "2026-01-01T00:00:00Z",
+          last_message_at: "2026-01-02T00:00:00Z"
+      }
+
+      SessionStore.save(old_data, dir)
+      SessionStore.save(new_data, dir)
+      SessionStore.save(middle_data, dir)
+
+      assert SessionStore.list(dir) |> Enum.map(& &1.id) == ["new", "middle", "old"]
     end
   end
 

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -1,12 +1,15 @@
 defmodule MingaAgent.SessionTest do
   use ExUnit.Case, async: true
 
+  alias MingaAgent.Branch
   alias MingaAgent.Event
   alias MingaAgent.Session
   alias MingaAgent.SessionStore
   alias MingaAgent.Tool.Executor
   alias MingaAgent.Tool.Registry
   alias MingaAgent.Tool.Spec
+
+  @moduletag :tmp_dir
 
   # ── Mock provider ──────────────────────────────────────────────────────────
 
@@ -673,6 +676,124 @@ defmodule MingaAgent.SessionTest do
 
     test "load_session returns error for missing session", %{session: session} do
       assert {:error, _} = Session.load_session(session, "nonexistent")
+    end
+
+    test "load_session restores messages, model, provider metadata, and branches", %{tmp_dir: dir} do
+      {:ok, session} =
+        Session.start_link(
+          provider: MockProvider,
+          provider_opts: [],
+          session_store_dir: dir
+        )
+
+      SessionStore.save(
+        %{
+          id: "resumable-session",
+          timestamp: "2026-01-01T00:00:00Z",
+          last_message_at: "2026-01-02T00:00:00Z",
+          title: "Restore me",
+          model_name: "anthropic:claude-sonnet-4",
+          provider_name: "native",
+          messages: [{:user, "Restore me"}, {:assistant, "Restored reply"}],
+          usage: %MingaAgent.TurnUsage{
+            input: 20,
+            output: 10,
+            cache_read: 0,
+            cache_write: 0,
+            cost: 0.02
+          },
+          branches: [
+            Branch.new("branch-1", [{:user, "branched prompt"}, {:assistant, "branched reply"}])
+          ],
+          memory: "- [2026-01-01 00:00 UTC] Prefer direct answers\n"
+        },
+        dir
+      )
+
+      assert :ok = Session.load_session(session, "resumable-session")
+      assert Session.session_id(session) == "resumable-session"
+      assert Session.messages(session) == [{:user, "Restore me"}, {:assistant, "Restored reply"}]
+
+      meta = Session.metadata(session)
+      assert meta.model_name == "anthropic:claude-sonnet-4"
+      assert meta.provider_name == "native"
+      assert meta.turn_count == 1
+      assert DateTime.to_iso8601(meta.last_message_at) == "2026-01-02T00:00:00Z"
+      assert MingaAgent.Memory.read(dir) =~ "Prefer direct answers"
+
+      assert {:ok, branches} = Session.list_branches(session)
+      assert branches =~ "branch-1"
+      assert :ok = Session.switch_branch(session, 1)
+
+      assert Session.messages(session) == [
+               {:user, "branched prompt"},
+               {:assistant, "branched reply"}
+             ]
+    end
+
+    test "load_session leaves existing memory untouched for legacy sessions without a memory snapshot",
+         %{
+           tmp_dir: dir
+         } do
+      {:ok, session} =
+        Session.start_link(
+          provider: MockProvider,
+          provider_opts: [],
+          session_store_dir: dir
+        )
+
+      :ok = MingaAgent.Memory.append("keep this memory", dir)
+      sessions_dir = SessionStore.sessions_dir(dir)
+      File.mkdir_p!(sessions_dir)
+
+      File.write!(
+        Path.join(sessions_dir, "legacy-session.json"),
+        JSON.encode!(%{
+          "id" => "legacy-session",
+          "timestamp" => "2026-01-01T00:00:00Z",
+          "last_message_at" => "2026-01-01T00:00:00Z",
+          "title" => "Legacy",
+          "model_name" => "test-model",
+          "provider_name" => "native",
+          "messages" => [%{"type" => "user", "text" => "legacy prompt"}],
+          "usage" => %{}
+        })
+      )
+
+      assert :ok = Session.load_session(session, "legacy-session")
+      assert MingaAgent.Memory.read(dir) =~ "keep this memory"
+    end
+
+    test "load_session saves the current dirty session before replacement", %{tmp_dir: dir} do
+      {:ok, session} =
+        Session.start_link(
+          provider: MockProvider,
+          provider_opts: [],
+          session_store_dir: dir
+        )
+
+      current_id = Session.session_id(session)
+      Session.add_system_message(session, "unsaved local note")
+      :sys.get_state(session)
+
+      SessionStore.save(
+        %{
+          id: "target-session",
+          timestamp: "2026-01-01T00:00:00Z",
+          last_message_at: "2026-01-01T00:00:00Z",
+          title: "Target",
+          model_name: "test-model",
+          provider_name: "native",
+          messages: [{:user, "target prompt"}],
+          usage: %MingaAgent.TurnUsage{}
+        },
+        dir
+      )
+
+      assert :ok = Session.load_session(session, "target-session")
+      assert {:ok, saved_current} = SessionStore.load(current_id, dir)
+      assert {:system, "unsaved local note", :info} in saved_current.messages
+      assert Session.session_id(session) == "target-session"
     end
   end
 

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -1,7 +1,10 @@
 defmodule MingaEditor.Agent.SlashCommandTest do
-  use ExUnit.Case, async: true
+  # Uses XDG_CONFIG_HOME to verify /resume opens persisted sessions through the public slash command path.
+  use ExUnit.Case, async: false
 
   alias MingaAgent.Session
+  alias MingaAgent.SessionStore
+  alias MingaAgent.TurnUsage
   alias MingaEditor.Agent.SlashCommand
   alias MingaEditor.Agent.UIState
   alias MingaEditor.State, as: EditorState
@@ -10,6 +13,8 @@ defmodule MingaEditor.Agent.SlashCommandTest do
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
+
+  @moduletag :tmp_dir
 
   defmodule NoopProvider do
     @behaviour MingaAgent.Provider
@@ -37,6 +42,21 @@ defmodule MingaEditor.Agent.SlashCommandTest do
 
   defp start_session do
     start_supervised!({Session, provider: NoopProvider, provider_opts: []})
+  end
+
+  defp with_xdg_config(dir, fun) do
+    previous = System.get_env("XDG_CONFIG_HOME")
+    System.put_env("XDG_CONFIG_HOME", dir)
+
+    try do
+      fun.()
+    after
+      if previous do
+        System.put_env("XDG_CONFIG_HOME", previous)
+      else
+        System.delete_env("XDG_CONFIG_HOME")
+      end
+    end
   end
 
   describe "slash_command?/1" do
@@ -72,6 +92,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       assert "model" in names
       assert "plan" in names
       assert "exec" in names
+      assert "resume" in names
     end
   end
 
@@ -189,6 +210,39 @@ defmodule MingaEditor.Agent.SlashCommandTest do
     test "command parsing trims whitespace" do
       {:ok, state} = SlashCommand.execute(mock_state(), "/help  ")
       assert state.shell_state.status_msg == "Commands listed in chat"
+    end
+
+    test "/resume opens the persisted agent session picker", %{tmp_dir: dir} do
+      with_xdg_config(dir, fn ->
+        SessionStore.save(
+          %{
+            id: "resume-target",
+            timestamp: "2026-01-01T00:00:00Z",
+            last_message_at: "2026-01-01T00:00:00Z",
+            title: "Resume target",
+            model_name: "test-model",
+            provider_name: "native",
+            messages: [{:user, "Resume target"}],
+            usage: %TurnUsage{}
+          },
+          dir
+        )
+
+        session = start_session()
+        {:ok, state} = SlashCommand.execute(mock_state(session: session), "/resume")
+
+        assert {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+        assert picker_ui.source == MingaEditor.UI.Picker.AgentSessionSource
+        assert picker_ui.context == %{persisted_only: true}
+      end)
+    end
+
+    test "/sessions opens the same agent session picker" do
+      session = start_session()
+      {:ok, state} = SlashCommand.execute(mock_state(session: session), "/sessions")
+
+      assert {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+      assert picker_ui.source == MingaEditor.UI.Picker.AgentSessionSource
     end
 
     test "/plan enters plan mode for the active session" do

--- a/test/minga_editor/commands/window_test.exs
+++ b/test/minga_editor/commands/window_test.exs
@@ -1,5 +1,6 @@
 defmodule MingaEditor.Commands.WindowTest do
-  use Minga.Test.EditingModelCase, async: true
+  # Direct editor key-dispatch tests share global keymap/options servers, so CI concurrency can change leader routing.
+  use Minga.Test.EditingModelCase, async: false
 
   alias Minga.Buffer.Server, as: BufferServer
   alias MingaEditor

--- a/test/minga_editor/ui/picker/agent_session_source_test.exs
+++ b/test/minga_editor/ui/picker/agent_session_source_test.exs
@@ -1,10 +1,13 @@
 defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
   use ExUnit.Case, async: true
 
+  alias MingaEditor.UI.Picker
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.Item
 
   alias MingaAgent.Session
+  alias MingaAgent.SessionStore
+  alias MingaAgent.TurnUsage
   alias MingaEditor.Agent.UIState
   alias MingaEditor.State, as: EditorState
   alias MingaAgent.RuntimeState
@@ -16,6 +19,8 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
   alias MingaEditor.UI.Picker.AgentSessionSource
+
+  @moduletag :tmp_dir
 
   describe "title/0" do
     test "returns Sessions" do
@@ -93,6 +98,62 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
       stop_session(pid)
     end
 
+    test "disk candidates show title, last timestamp, turn count, and most-recent-first order", %{
+      tmp_dir: dir
+    } do
+      save_disk_session(dir, "old", "Old planning", "2026-01-01T00:00:00Z", [
+        {:user, "Old planning"}
+      ])
+
+      save_disk_session(dir, "new", "New architecture", "2026-01-03T00:00:00Z", [
+        {:user, "New architecture"},
+        {:assistant, "Latest notes"}
+      ])
+
+      save_disk_session(dir, "middle", "Middle refactor", "2026-01-02T00:00:00Z", [
+        {:user, "Middle refactor"}
+      ])
+
+      ctx = Context.from_editor_state(state_without_agent_tabs(), %{session_store_dir: dir})
+      candidates = AgentSessionSource.candidates(ctx)
+      disk_entries = Enum.filter(candidates, fn %Item{id: {_, tag}} -> tag == :disk end)
+
+      assert Enum.map(disk_entries, fn %Item{id: {id, :disk}} -> id end) == [
+               "new",
+               "middle",
+               "old"
+             ]
+
+      assert [%Item{label: "New architecture", description: desc, annotation: "1 turn"} | _] =
+               disk_entries
+
+      assert desc =~ "Jan 03 00:00"
+      assert desc =~ "Latest notes"
+    end
+
+    test "disk candidates filter by title and recent message content", %{tmp_dir: dir} do
+      save_disk_session(dir, "auth", "Auth refactor", "2026-01-01T00:00:00Z", [
+        {:user, "Auth refactor"}
+      ])
+
+      save_disk_session(dir, "backoff", "Retry work", "2026-01-02T00:00:00Z", [
+        {:user, "Investigate client"},
+        {:assistant, "Use rate limit backoff"}
+      ])
+
+      ctx = Context.from_editor_state(state_without_agent_tabs(), %{session_store_dir: dir})
+      candidates = AgentSessionSource.candidates(ctx)
+
+      auth_picker =
+        Picker.new(candidates, title: AgentSessionSource.title()) |> Picker.filter("auth")
+
+      backoff_picker =
+        Picker.new(candidates, title: AgentSessionSource.title()) |> Picker.filter("backoff")
+
+      assert Enum.map(auth_picker.filtered, fn %Item{id: {id, :disk}} -> id end) == ["auth"]
+      assert Enum.map(backoff_picker.filtered, fn %Item{id: {id, :disk}} -> id end) == ["backoff"]
+    end
+
     test "background agent tab is not marked with bullet" do
       {:ok, pid1} = start_test_session()
       {:ok, pid2} = start_test_session()
@@ -122,6 +183,26 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
   end
 
   describe "on_select/2" do
+    test "with disk entry restores the active session through the public session path", %{
+      tmp_dir: dir
+    } do
+      {:ok, pid} = start_test_session(session_store_dir: dir)
+
+      save_disk_session(dir, "saved-disk", "Saved session", "2026-01-01T00:00:00Z", [
+        {:user, "Saved session"},
+        {:assistant, "Loaded response"}
+      ])
+
+      state = state_with_agent_tab(pid)
+      item = %Item{id: {"saved-disk", :disk}, label: "Saved session", description: "desc"}
+      _result = AgentSessionSource.on_select(item, state)
+
+      assert Session.session_id(pid) == "saved-disk"
+      assert Session.messages(pid) == [{:user, "Saved session"}, {:assistant, "Loaded response"}]
+
+      stop_session(pid)
+    end
+
     test "with tab entry switches to that tab" do
       {:ok, pid} = start_test_session()
       Session.subscribe(pid)
@@ -146,10 +227,43 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
 
   # ── Helpers ───────────────────────────────────────────────────────────────
 
-  defp start_test_session do
+  defp save_disk_session(dir, id, title, last_message_at, messages) do
+    SessionStore.save(
+      %{
+        id: id,
+        timestamp: "2026-01-01T00:00:00Z",
+        last_message_at: last_message_at,
+        title: title,
+        model_name: "test-model",
+        provider_name: "native",
+        messages: messages,
+        usage: %TurnUsage{}
+      },
+      dir
+    )
+  end
+
+  defp state_without_agent_tabs do
+    %EditorState{
+      port_manager: self(),
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{},
+        windows: %Windows{},
+        editing: VimState.new()
+      },
+      shell_state: %MingaEditor.Shell.Traditional.State{
+        tab_bar: TabBar.new(Tab.new_file(1, "main.ex")),
+        agent: %AgentState{}
+      }
+    }
+  end
+
+  defp start_test_session(opts \\ []) do
     MingaAgent.Supervisor.start_session(
       provider: MingaAgent.Providers.Native,
       model_name: "test-model",
+      session_store_dir: Keyword.get(opts, :session_store_dir),
       provider_opts: [
         llm_client: fn _req -> {:ok, %{status: 200, body: %{"choices" => []}}} end
       ]


### PR DESCRIPTION
# TL;DR
Users can now run `/resume` or `SPC a h` to pick a saved agent session and restore it as the active conversation.

Closes #1411

## Context
This is part of #1404. Minga already persisted agent sessions, but there was no dedicated resume flow that treated disk sessions as first-class resumable state.

## Changes
- Added `/resume` and wired `SPC a h` to a persisted-session picker.
- Extended session metadata with title, last message timestamp, turn count, provider, and recent message text so the picker can sort and filter useful entries.
- Restored saved messages, branches, model, provider metadata, and memory when a disk session is selected.
- Persisted the current session immediately before replacing it, so pending local state is not silently lost.
- Kept `/sessions` as the broader live-plus-disk session switcher while `/resume` opens the persisted-only view.

## Verification
- `mix format --check-formatted`
- `make lint`
- `mix test.llm` (54 doctests, 98 properties, 7681 tests, 0 failures, 6 skipped, 104 excluded)
- Project reviewer: PASS

## Follow-up Review Fixes
- Preserved loaded sessions' saved `last_message_at` instead of updating recency just by resuming.
- Stopped legacy sessions without memory snapshots from clearing existing memory.
- Preserved user message attachments in session store round trips.
- Made persisted tool/system status decoding defensive for corrupted session files.
- Aborted resume if the current session cannot be saved before replacement.

## Acceptance Criteria Addressed
- `/resume` opens a persisted-session picker sorted by recency with title, last timestamp, and turn count. ✅
- Selecting a session restores messages, branches, model, provider metadata, and memory. ✅
- The current dirty session is persisted before replacement. ✅
- Picker filtering matches title and recent message content, and cancel leaves state unchanged. ✅
- Tests create, persist, and restore through the public restore path with key state equivalence assertions. ✅

