### PR TITLE
feat(agent): support multiple MCP servers

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -40,6 +40,7 @@ That's it. Save the file and restart Minga. Your options take effect immediately
 | `:agent_session_retention_days` | positive integer | `30` | Days to keep saved agent sessions before auto-pruning |
 | `:startup_view` | `:agent` or `:editor` | `:agent` | Which view to show on startup (see [Startup view](#startup-view) below) |
 | `:agent_auto_context` | boolean | `true` | Load CLI file as agent preview context on startup |
+| `:agent_mcp_servers` | list of maps | `[]` | MCP servers to launch for native agent sessions (see [MCP servers](MCP.md)) |
 | `:whichkey_layout` | `:bottom` or `:float` | `:bottom` | Which-key popup display mode (see [Which-key popup](#which-key-popup) below) |
 | `:font_family` | string | `"Menlo"` | Font family or name (see [Fonts](#fonts) below) |
 | `:font_size` | positive integer | `13` | Font size in points (see [Fonts](#fonts) below) |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,36 +1,57 @@
 # MCP servers
 
-Minga can attach one Model Context Protocol (MCP) server to each native agent session. This is useful when you already have local tools exposed through MCP and want them to appear next to Minga's built-in file, shell, git, and LSP tools.
+Minga can attach multiple Model Context Protocol (MCP) servers to each native agent session. This is useful when your workflow spans separate local tools for files, GitHub, Linear, browsers, databases, or internal systems, and you want those tools to appear next to Minga's built-in file, shell, git, and LSP tools.
 
-## Configure one stdio server
+## Configure stdio servers
 
-Set `:agent_mcp_server` in your Minga config. The value is a map with a display name, command, optional args, and optional environment variables.
+Set `:agent_mcp_servers` in your Minga config. The value is a list of maps. Each map has a stable display name, launch command, optional args, optional environment variables, and an optional `enabled` flag.
 
 ```elixir
-Minga.Config.set(:agent_mcp_server, %{
-  name: "workspace",
-  command: "node",
-  args: ["/Users/me/tools/workspace-mcp/server.js"],
-  env: %{
-    "WORKSPACE_ROOT" => "/Users/me/code/my-project",
-    "API_TOKEN" => System.fetch_env!("WORKSPACE_MCP_TOKEN")
+Minga.Config.set(:agent_mcp_servers, [
+  %{
+    name: "workspace",
+    command: "node",
+    args: ["/Users/me/tools/workspace-mcp/server.js"],
+    env: %{
+      "WORKSPACE_ROOT" => "/Users/me/code/my-project",
+      "API_TOKEN" => System.fetch_env!("WORKSPACE_MCP_TOKEN")
+    }
+  },
+  %{
+    name: "github",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-github"],
+    env: %{"GITHUB_PERSONAL_ACCESS_TOKEN" => System.fetch_env!("GITHUB_TOKEN")}
   }
-})
+])
 ```
 
-`name` and `command` are required strings. `args` defaults to `[]`. `env` defaults to `%{}` and must contain string keys and string values.
+`name` and `command` are required strings for enabled servers. `args` defaults to `[]`. `env` defaults to `%{}` and may use string or atom keys, but values must be strings. Server names must be unique because they become part of the provider-facing tool name.
 
-The native provider starts the server when the agent session starts. It speaks MCP over JSON lines on stdio, sends `initialize`, sends `notifications/initialized`, then calls `tools/list`. If any step fails, Minga adds a system error message and continues with the built-in tools only.
+Use `enabled: false` to keep a server in your config without launching it:
+
+```elixir
+Minga.Config.set(:agent_mcp_servers, [
+  %{name: "workspace", command: "node", args: ["/Users/me/tools/workspace-mcp/server.js"]},
+  %{name: "browser", enabled: false}
+])
+```
+
+Disabled entries are ignored at session start, so you can leave incomplete or temporarily unavailable server configs in place while you work.
+
+The native provider starts enabled servers when the agent session starts. Each server launches independently. For every healthy server, Minga speaks MCP over JSON lines on stdio, sends `initialize`, sends `notifications/initialized`, then calls `tools/list`. If one server fails, Minga adds a system error message naming that server and continues with built-in tools plus tools from the other healthy MCP servers.
 
 ## Tool names
 
-MCP tool names are prefixed before they are sent to the LLM so they are safe and do not collide with built-ins. A server named `workspace` with a tool named `find symbols` becomes:
+MCP tool names are prefixed before they are sent to the LLM so they are safe and do not collide with built-ins or tools from another MCP server. A server named `workspace` with a tool named `find symbols` becomes:
 
 ```text
 mcp_workspace__find_symbols
 ```
 
-Minga keeps the original MCP tool name internally. When the LLM calls `mcp_workspace__find_symbols`, Minga sends `tools/call` to the MCP server with the original name, `find symbols`, and the arguments from the model.
+The prefix is based on the configured server name. Minga sanitizes characters that model providers do not allow in tool names. If two generated names still collide, Minga adds a numeric suffix to the later tool name.
+
+Minga keeps the original MCP tool name internally. When the LLM calls `mcp_workspace__find_symbols`, Minga sends `tools/call` to the `workspace` MCP server with the original name, `find symbols`, and the arguments from the model.
 
 MCP tools are treated as destructive by default when `:agent_tool_approval` is `:destructive`, so Minga asks before running them unless you add per-tool permissions.
 
@@ -39,13 +60,15 @@ MCP tools are treated as destructive by default when `:agent_tool_approval` is `
 The filesystem reference server is a good first smoke test because it exposes familiar file tools through MCP. Install Node.js, then point the server at the directory it is allowed to read and write:
 
 ```elixir
-Minga.Config.set(:agent_mcp_server, %{
-  name: "filesystem",
-  command: "npx",
-  args: ["-y", "@modelcontextprotocol/server-filesystem", "/Users/me/code/my-project"]
-})
+Minga.Config.set(:agent_mcp_servers, [
+  %{
+    name: "filesystem",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/Users/me/code/my-project"]
+  }
+])
 ```
 
 At session start, Minga lists the server tools and exposes them with the server prefix. For example, a filesystem tool named `read_file` becomes `mcp_filesystem__read_file`. The model can call that tool during a normal agent turn. The result is appended as a normal tool result, just like Minga's built-in `read_file` or `grep`.
 
-If the server exits halfway through the session, Minga adds a system message naming the MCP server and the reason. The provider stays alive, removes the MCP tools from future LLM requests, and built-in tools keep working.
+If one server exits halfway through the session, Minga adds a system message naming the MCP server and the reason. The provider stays alive, removes only that server's MCP tools from future LLM requests, and built-in tools plus other healthy MCP servers keep working.

--- a/lib/minga/config/completion.ex
+++ b/lib/minga/config/completion.ex
@@ -176,6 +176,7 @@ defmodule Minga.Config.Completion do
   defp format_type(:string_or_nil), do: "string or nil"
   defp format_type(:string_list), do: "list of strings"
   defp format_type(:map_or_nil), do: "map or nil"
+  defp format_type(:map_list), do: "list of maps"
   defp format_type(:float_or_nil), do: "float or nil"
   defp format_type(:theme_atom), do: "theme"
   defp format_type(:any), do: "any"
@@ -294,6 +295,9 @@ defmodule Minga.Config.Completion do
 
   defp option_description(:agent_api_base_url), do: "Override the base URL for the agent API."
   defp option_description(:agent_api_endpoints), do: "Per-model API endpoint overrides as a map."
+
+  defp option_description(:agent_mcp_servers),
+    do: "List of MCP server configs to launch for native agent sessions."
 
   defp option_description(:agent_compaction_threshold),
     do: "Context window usage ratio that triggers automatic compaction. Nil to disable."

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -39,7 +39,7 @@ defmodule Minga.Config.Options do
   | `:agent_panel_split`      | positive integer (30-80)                   | `65`       |
   | `:startup_view`           | `:agent` or `:editor`                       | `:agent`   |
   | `:agent_auto_context`     | boolean                                     | `true`     |
-  | `:agent_mcp_server`       | map or `nil`                                | `nil`      |
+  | `:agent_mcp_servers`      | list of server config maps                  | `[]`       |
   | `:font_family`            | string (font name)                          | `"Menlo"`   |
   | `:font_size`              | positive integer (point size)               | `13`        |
   | `:font_weight`            | `:thin` / `:light` / `:regular` / `:medium` / `:semibold` / `:bold` / `:heavy` / `:black` | `:regular` |
@@ -128,7 +128,7 @@ defmodule Minga.Config.Options do
           | :agent_max_cost
           | :agent_api_base_url
           | :agent_api_endpoints
-          | :agent_mcp_server
+          | :agent_mcp_servers
           | :agent_compaction_threshold
           | :agent_compaction_keep_recent
           | :agent_approval_timeout
@@ -178,6 +178,7 @@ defmodule Minga.Config.Options do
           | :string_or_nil
           | :string_list
           | :map_or_nil
+          | :map_list
           | :float_or_nil
           | :any
 
@@ -260,7 +261,7 @@ defmodule Minga.Config.Options do
     {:agent_max_cost, :float_or_nil, nil},
     {:agent_api_base_url, :string, ""},
     {:agent_api_endpoints, :map_or_nil, nil},
-    {:agent_mcp_server, :map_or_nil, nil},
+    {:agent_mcp_servers, :map_list, []},
     {:agent_compaction_threshold, :float_or_nil, 0.8},
     {:agent_compaction_keep_recent, :pos_integer, 6},
     {:agent_approval_timeout, :pos_integer, 300_000},
@@ -789,6 +790,18 @@ defmodule Minga.Config.Options do
 
   defp validate_type(:map_or_nil, name, value) do
     {:error, "#{name} must be a map or nil, got: #{inspect(value)}"}
+  end
+
+  defp validate_type(:map_list, _name, value) when is_list(value) do
+    if Enum.all?(value, &is_map/1) do
+      :ok
+    else
+      {:error, "expected a list of maps, got non-map elements"}
+    end
+  end
+
+  defp validate_type(:map_list, name, value) do
+    {:error, "#{name} must be a list of maps, got: #{inspect(value)}"}
   end
 
   defp validate_type(:float_or_nil, _name, nil), do: :ok

--- a/lib/minga_agent/config.ex
+++ b/lib/minga_agent/config.ex
@@ -52,7 +52,7 @@ defmodule MingaAgent.Config do
     api_endpoints: nil,
 
     # MCP
-    mcp_server: nil,
+    mcp_servers: [],
 
     # Compaction
     compaction_threshold: 0.80,
@@ -103,7 +103,7 @@ defmodule MingaAgent.Config do
           append_system_prompt: String.t(),
           api_base_url: String.t(),
           api_endpoints: map() | nil,
-          mcp_server: MingaAgent.MCP.ServerConfig.t() | map() | nil,
+          mcp_servers: [MingaAgent.MCP.ServerConfig.t() | map()],
           compaction_threshold: float() | nil,
           compaction_keep_recent: pos_integer(),
           approval_timeout_ms: pos_integer(),
@@ -153,7 +153,7 @@ defmodule MingaAgent.Config do
       append_system_prompt: get(:agent_append_system_prompt, ""),
       api_base_url: get(:agent_api_base_url, ""),
       api_endpoints: get(:agent_api_endpoints, nil),
-      mcp_server: get(:agent_mcp_server, nil),
+      mcp_servers: get(:agent_mcp_servers, []),
       compaction_threshold: get(:agent_compaction_threshold, 0.80),
       compaction_keep_recent: get(:agent_compaction_keep_recent, 6),
       approval_timeout_ms: get(:agent_approval_timeout, 300_000),

--- a/lib/minga_agent/mcp/registry.ex
+++ b/lib/minga_agent/mcp/registry.ex
@@ -1,0 +1,209 @@
+defmodule MingaAgent.MCP.Registry do
+  @moduledoc """
+  In-memory registry for MCP clients attached to one native agent session.
+
+  The native provider owns this struct in its GenServer state. Each MCP server
+  still runs as its own client process, but the registry keeps routing data and
+  cleanup logic in-process so tool calls do not need another coordinator hop.
+  """
+
+  alias MingaAgent.Event
+  alias MingaAgent.MCP.Client, as: MCPClient
+  alias MingaAgent.MCP.ServerConfig
+  alias ReqLLM.Tool
+
+  @enforce_keys [:clients]
+  defstruct clients: %{}
+
+  @typedoc "Stable user-facing MCP server name."
+  @type server_name :: String.t()
+
+  @typedoc "Provider-facing safe tool name."
+  @type tool_name :: String.t()
+
+  @typedoc "Tracked state for one MCP server client."
+  @type client_entry :: %{
+          pid: pid(),
+          ref: reference(),
+          tool_names: [tool_name()]
+        }
+
+  @typedoc "MCP client registry owned by the native provider."
+  @type t :: %__MODULE__{clients: %{server_name() => client_entry()}}
+
+  @typedoc "Options forwarded from the native provider to MCP clients."
+  @type start_opt ::
+          {:transport, module()}
+          | {:transport_opts, keyword()}
+          | {:request_timeout, timeout()}
+          | {:notify_pid, pid()}
+          | {:reserved_tool_names, [tool_name()]}
+
+  @doc "Starts all enabled MCP servers and returns the registry, tools, and startup failure messages."
+  @spec start_all([ServerConfig.t()], pid(), [start_opt()]) :: {t(), [Tool.t()], [String.t()]}
+  def start_all(configs, subscriber, opts \\ []) when is_list(configs) and is_pid(subscriber) do
+    seen = MapSet.new(Keyword.get(opts, :reserved_tool_names, []))
+
+    {registry, tools, failures, _seen} =
+      Enum.reduce(configs, {new(), [], [], seen}, fn config, {registry, tools, failures, seen} ->
+        case start_one(config, subscriber, opts) do
+          {:ok, client, client_tools} ->
+            {registry, client_tools, seen} =
+              add_client(registry, config.name, client, client_tools, seen)
+
+            {registry, tools ++ client_tools, failures, seen}
+
+          {:error, message} ->
+            {registry, tools, failures ++ [message], seen}
+        end
+      end)
+
+    {registry, tools, failures}
+  end
+
+  @doc "Returns an empty registry."
+  @spec new() :: t()
+  def new, do: %__MODULE__{clients: %{}}
+
+  @doc "Returns the server name for a monitored client pid."
+  @spec server_for_pid(t() | nil, pid()) :: String.t() | nil
+  def server_for_pid(nil, _pid), do: nil
+
+  def server_for_pid(%__MODULE__{} = registry, pid) when is_pid(pid) do
+    Enum.find_value(registry.clients, fn {server_name, %{pid: client_pid}} ->
+      if client_pid == pid, do: server_name
+    end)
+  end
+
+  @doc "Removes one server from the registry and returns its removed tool names."
+  @spec remove_server(t() | nil, String.t()) :: {t() | nil, [String.t()]}
+  def remove_server(nil, _server_name), do: {nil, []}
+
+  def remove_server(%__MODULE__{} = registry, server_name) when is_binary(server_name) do
+    case Map.pop(registry.clients, server_name) do
+      {nil, _clients} ->
+        {registry, []}
+
+      {%{pid: pid, ref: ref, tool_names: tool_names}, clients} ->
+        Process.demonitor(ref, [:flush])
+        stop_client(pid)
+        {%{registry | clients: clients}, tool_names}
+    end
+  end
+
+  @doc "Stops all tracked MCP clients."
+  @spec stop_all(t() | nil) :: :ok
+  def stop_all(nil), do: :ok
+
+  def stop_all(%__MODULE__{} = registry) do
+    Enum.each(registry.clients, fn {_server_name, %{pid: pid, ref: ref}} ->
+      Process.demonitor(ref, [:flush])
+      stop_client(pid)
+    end)
+
+    :ok
+  end
+
+  @spec add_client(t(), String.t(), pid(), [Tool.t()], MapSet.t(String.t())) ::
+          {t(), [Tool.t()], MapSet.t(String.t())}
+  defp add_client(%__MODULE__{} = registry, server_name, client, tools, seen) do
+    ref = Process.monitor(client)
+    {tool_names, tools, seen} = unique_tool_names(seen, tools)
+
+    entry = %{pid: client, ref: ref, tool_names: tool_names}
+
+    registry = %{registry | clients: Map.put(registry.clients, server_name, entry)}
+
+    {registry, tools, seen}
+  end
+
+  @spec unique_tool_names(MapSet.t(String.t()), [Tool.t()]) ::
+          {[String.t()], [Tool.t()], MapSet.t(String.t())}
+  defp unique_tool_names(seen, tools) do
+    {tool_names, tools, seen} =
+      Enum.reduce(tools, {[], [], seen}, fn tool, {names, acc, seen} ->
+        name = unique_tool_name(tool.name, seen)
+        tool = %{tool | name: name}
+        {[name | names], [tool | acc], MapSet.put(seen, name)}
+      end)
+
+    {Enum.reverse(tool_names), Enum.reverse(tools), seen}
+  end
+
+  @spec unique_tool_name(String.t(), MapSet.t(String.t())) :: String.t()
+  defp unique_tool_name(name, seen) do
+    if MapSet.member?(seen, name) do
+      unique_tool_name(name, seen, 2)
+    else
+      name
+    end
+  end
+
+  @spec unique_tool_name(String.t(), MapSet.t(String.t()), pos_integer()) :: String.t()
+  defp unique_tool_name(name, seen, index) do
+    suffix = "_#{index}"
+    max_base_length = max(1, 64 - String.length(suffix))
+    candidate = String.slice(name, 0, max_base_length) <> suffix
+
+    if MapSet.member?(seen, candidate) do
+      unique_tool_name(name, seen, index + 1)
+    else
+      candidate
+    end
+  end
+
+  @spec start_one(ServerConfig.t(), pid(), keyword()) ::
+          {:ok, pid(), [Tool.t()]} | {:error, String.t()}
+  defp start_one(%ServerConfig{} = config, subscriber, opts) do
+    client_opts = [
+      server_config: config,
+      transport: Keyword.get(opts, :transport, MingaAgent.MCP.StdioTransport),
+      transport_opts: Keyword.get(opts, :transport_opts, []),
+      notify_pid: Keyword.get(opts, :notify_pid, self()),
+      request_timeout: Keyword.get(opts, :request_timeout, 5_000)
+    ]
+
+    case MCPClient.start(client_opts) do
+      {:ok, client} ->
+        tools_for_started_client(client, config, subscriber)
+
+      {:error, reason} ->
+        {:error, notify_start_failure(subscriber, config.name, reason)}
+    end
+  end
+
+  @spec tools_for_started_client(pid(), ServerConfig.t(), pid()) ::
+          {:ok, pid(), [Tool.t()]} | {:error, String.t()}
+  defp tools_for_started_client(client, config, subscriber) do
+    case MCPClient.reqllm_tools(client) do
+      {:ok, tools} ->
+        {:ok, client, tools}
+
+      {:error, reason} ->
+        stop_client(client)
+        {:error, notify_start_failure(subscriber, config.name, reason)}
+    end
+  end
+
+  @spec notify_start_failure(pid(), String.t(), term()) :: String.t()
+  defp notify_start_failure(subscriber, server_name, reason) do
+    message =
+      "MCP server #{server_name} failed to start: #{format_error(reason)}. Built-in tools remain available."
+
+    Minga.Log.warning(:agent, "[Agent.Native] #{message}")
+    send(subscriber, {:agent_provider_event, %Event.Error{message: message}})
+    message
+  end
+
+  @spec stop_client(pid()) :: :ok
+  defp stop_client(pid) when is_pid(pid) do
+    GenServer.stop(pid, :normal, 1_000)
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  @spec format_error(term()) :: String.t()
+  defp format_error(reason) when is_binary(reason), do: reason
+  defp format_error(reason), do: inspect(reason)
+end

--- a/lib/minga_agent/mcp/server_config.ex
+++ b/lib/minga_agent/mcp/server_config.ex
@@ -8,14 +8,15 @@ defmodule MingaAgent.MCP.ServerConfig do
   """
 
   @enforce_keys [:name, :command]
-  defstruct [:name, :command, args: [], env: %{}]
+  defstruct [:name, :command, args: [], env: %{}, enabled: true]
 
   @typedoc "One MCP stdio server declaration."
   @type t :: %__MODULE__{
           name: String.t(),
           command: String.t(),
           args: [String.t()],
-          env: %{String.t() => String.t()}
+          env: %{String.t() => String.t()},
+          enabled: boolean()
         }
 
   @doc "Normalizes a user config map into a `ServerConfig` struct."
@@ -32,13 +33,69 @@ defmodule MingaAgent.MCP.ServerConfig do
     with {:ok, name} <- fetch_string(config, :name),
          {:ok, command} <- fetch_string(config, :command),
          {:ok, args} <- fetch_args(config),
-         {:ok, env} <- fetch_env(config) do
-      {:ok, %__MODULE__{name: name, command: command, args: args, env: env}}
+         {:ok, env} <- fetch_env(config),
+         {:ok, enabled} <- fetch_enabled(config) do
+      {:ok, %__MODULE__{name: name, command: command, args: args, env: env, enabled: enabled}}
     end
   end
 
   def normalize(other),
     do: {:error, "MCP server config must be a map or nil, got: #{inspect(other)}"}
+
+  @doc "Normalizes one or more MCP server configs, filters disabled entries, and rejects duplicate enabled server names."
+  @spec normalize_list(nil | map() | t() | [map() | t()]) :: {:ok, [t()]} | {:error, String.t()}
+  def normalize_list(nil), do: {:ok, []}
+  def normalize_list(%__MODULE__{} = config), do: normalize_list([config])
+  def normalize_list(config) when is_map(config), do: normalize_list([config])
+
+  def normalize_list(configs) when is_list(configs) do
+    configs
+    |> Enum.reduce_while({:ok, []}, &normalize_list_entry/2)
+    |> case do
+      {:ok, normalized} -> reject_duplicate_names(Enum.reverse(normalized))
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def normalize_list(other),
+    do:
+      {:error, "MCP servers config must be a list of maps, a map, or nil, got: #{inspect(other)}"}
+
+  @spec normalize_list_entry(term(), {:ok, [t()]}) ::
+          {:cont, {:ok, [t()]}} | {:halt, {:error, String.t()}}
+  defp normalize_list_entry(nil, {:ok, _acc}) do
+    {:halt, {:error, "MCP servers config list cannot contain nil entries"}}
+  end
+
+  defp normalize_list_entry(config, {:ok, acc}) do
+    if disabled?(config) do
+      {:cont, {:ok, acc}}
+    else
+      case normalize(config) do
+        {:ok, %__MODULE__{} = normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end
+  end
+
+  @spec disabled?(term()) :: boolean()
+  defp disabled?(config) when is_map(config), do: fetch(config, :enabled) == false
+  defp disabled?(_config), do: false
+
+  @spec reject_duplicate_names([t()]) :: {:ok, [t()]} | {:error, String.t()}
+  defp reject_duplicate_names(configs) do
+    duplicate_names =
+      configs
+      |> Enum.map(& &1.name)
+      |> Enum.frequencies()
+      |> Enum.filter(fn {_name, count} -> count > 1 end)
+      |> Enum.map(&elem(&1, 0))
+
+    case duplicate_names do
+      [] -> {:ok, configs}
+      names -> {:error, "MCP server names must be unique, duplicates: #{Enum.join(names, ", ")}"}
+    end
+  end
 
   @spec fetch_string(map(), atom()) :: {:ok, String.t()} | {:error, String.t()}
   defp fetch_string(config, key) do
@@ -70,6 +127,15 @@ defmodule MingaAgent.MCP.ServerConfig do
 
       other ->
         {:error, "MCP server env must be a map of string keys and values, got: #{inspect(other)}"}
+    end
+  end
+
+  @spec fetch_enabled(map()) :: {:ok, boolean()} | {:error, String.t()}
+  defp fetch_enabled(config) do
+    case fetch(config, :enabled) do
+      nil -> {:ok, true}
+      enabled when is_boolean(enabled) -> {:ok, enabled}
+      other -> {:error, "MCP server enabled must be a boolean, got: #{inspect(other)}"}
     end
   end
 

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -43,7 +43,7 @@ defmodule MingaAgent.Providers.Native do
   alias MingaAgent.Hooks.Result, as: HookResult
   alias MingaAgent.Instructions
   alias MingaAgent.InternalState
-  alias MingaAgent.MCP.Client, as: MCPClient
+  alias MingaAgent.MCP.Registry, as: MCPRegistry
   alias MingaAgent.MCP.ServerConfig, as: MCPServerConfig
   alias MingaAgent.Memory
   alias MingaAgent.ModelCatalog
@@ -157,8 +157,7 @@ defmodule MingaAgent.Providers.Native do
           session_cost: float(),
           fork_store: pid() | nil,
           changeset: pid() | nil,
-          mcp_client: pid() | nil,
-          mcp_tool_names: [String.t()]
+          mcp_registry: MCPRegistry.t() | nil
         }
 
   # ── Provider callbacks ──────────────────────────────────────────────────────
@@ -291,8 +290,9 @@ defmodule MingaAgent.Providers.Native do
           parent_session: subscriber
         )
 
-    {mcp_client, mcp_tools, mcp_tool_names} = start_mcp_client(opts, config, subscriber)
     internal_tools = build_internal_tools(provider_pid)
+    reserved_tool_names = Enum.map(base_tools ++ internal_tools, & &1.name)
+    {mcp_registry, mcp_tools} = start_mcp_servers(opts, config, subscriber, reserved_tool_names)
     tools = base_tools ++ mcp_tools ++ internal_tools
     system_prompt = build_system_prompt(project_root)
     context = Context.new([Context.system(system_prompt)])
@@ -325,8 +325,7 @@ defmodule MingaAgent.Providers.Native do
       session_cost: 0.0,
       fork_store: fork_store,
       changeset: changeset,
-      mcp_client: mcp_client,
-      mcp_tool_names: mcp_tool_names
+      mcp_registry: mcp_registry
     }
 
     Minga.Log.info(:agent, "[Agent.Native] started with model=#{model} root=#{project_root}")
@@ -717,26 +716,34 @@ defmodule MingaAgent.Providers.Native do
     {:noreply, %{state | changeset: nil}}
   end
 
-  def handle_info({:mcp_client_down, pid, server_name, reason}, %{mcp_client: pid} = state)
-      when is_pid(pid) do
-    message =
-      "MCP server #{server_name} stopped: #{inspect(reason)}. Built-in tools remain available."
+  def handle_info({:mcp_client_down, pid, server_name, reason}, state) when is_pid(pid) do
+    case MCPRegistry.server_for_pid(state.mcp_registry, pid) do
+      ^server_name ->
+        message =
+          "MCP server #{server_name} stopped: #{inspect(reason)}. Built-in tools remain available."
 
-    Minga.Log.warning(:agent, "[Agent.Native] #{message}")
-    notify(state.subscriber, %Event.Error{message: message})
-    {:noreply, remove_mcp_tools(state)}
+        Minga.Log.warning(:agent, "[Agent.Native] #{message}")
+        notify(state.subscriber, %Event.Error{message: message})
+        {:noreply, remove_mcp_server_tools(state, server_name)}
+
+      _other ->
+        {:noreply, state}
+    end
   end
 
-  def handle_info({:DOWN, _ref, :process, pid, reason}, %{mcp_client: pid} = state)
-      when is_pid(pid) do
-    message = "MCP client crashed: #{inspect(reason)}. Built-in tools remain available."
-    Minga.Log.warning(:agent, "[Agent.Native] #{message}")
-    notify(state.subscriber, %Event.Error{message: message})
-    {:noreply, remove_mcp_tools(state)}
-  end
+  def handle_info({:DOWN, _ref, :process, pid, reason}, state) when is_pid(pid) do
+    case MCPRegistry.server_for_pid(state.mcp_registry, pid) do
+      server_name when is_binary(server_name) ->
+        message =
+          "MCP server #{server_name} crashed: #{inspect(reason)}. Built-in tools remain available."
 
-  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
-    {:noreply, state}
+        Minga.Log.warning(:agent, "[Agent.Native] #{message}")
+        notify(state.subscriber, %Event.Error{message: message})
+        {:noreply, remove_mcp_server_tools(state, server_name)}
+
+      _other ->
+        {:noreply, state}
+    end
   end
 
   def handle_info(_msg, state) do
@@ -747,77 +754,46 @@ defmodule MingaAgent.Providers.Native do
   def terminate(reason, state) do
     cleanup_fork_store(state.fork_store)
     cleanup_changeset(state.changeset, reason)
-    cleanup_mcp_client(state.mcp_client)
+    cleanup_mcp(state.mcp_registry)
     :ok
   catch
     :exit, _ -> :ok
   end
 
-  @spec start_mcp_client(keyword(), AgentConfig.t(), pid()) ::
-          {pid() | nil, [term()], [String.t()]}
-  defp start_mcp_client(opts, config, subscriber) do
-    server_config = Keyword.get(opts, :mcp_server, config.mcp_server)
+  @spec start_mcp_servers(keyword(), AgentConfig.t(), pid(), [String.t()]) ::
+          {MCPRegistry.t() | nil, [term()]}
+  defp start_mcp_servers(opts, config, subscriber, reserved_tool_names) do
+    server_configs = Keyword.get(opts, :mcp_servers, config.mcp_servers)
 
-    case MCPServerConfig.normalize(server_config) do
-      {:ok, nil} ->
-        {nil, [], []}
+    case MCPServerConfig.normalize_list(server_configs) do
+      {:ok, []} ->
+        {nil, []}
 
-      {:ok, %MCPServerConfig{} = normalized} ->
-        do_start_mcp_client(opts, normalized, subscriber)
+      {:ok, normalized} ->
+        registry_opts = [
+          transport: Keyword.get(opts, :mcp_transport, MingaAgent.MCP.StdioTransport),
+          transport_opts: Keyword.get(opts, :mcp_transport_opts, []),
+          notify_pid: self(),
+          request_timeout: Keyword.get(opts, :mcp_request_timeout, 5_000),
+          reserved_tool_names: reserved_tool_names
+        ]
+
+        {registry, tools, _failures} =
+          MCPRegistry.start_all(normalized, subscriber, registry_opts)
+
+        {registry, tools}
 
       {:error, reason} ->
         notify(subscriber, %Event.Error{message: "MCP config error: #{reason}"})
-        {nil, [], []}
+        {nil, []}
     end
   end
 
-  @spec do_start_mcp_client(keyword(), MCPServerConfig.t(), pid()) ::
-          {pid() | nil, [term()], [String.t()]}
-  defp do_start_mcp_client(opts, server_config, subscriber) do
-    client_opts = [
-      server_config: server_config,
-      transport: Keyword.get(opts, :mcp_transport, MingaAgent.MCP.StdioTransport),
-      transport_opts: Keyword.get(opts, :mcp_transport_opts, []),
-      notify_pid: self(),
-      request_timeout: Keyword.get(opts, :mcp_request_timeout, 5_000)
-    ]
-
-    case MCPClient.start(client_opts) do
-      {:ok, client} ->
-        Process.monitor(client)
-
-        case MCPClient.reqllm_tools(client) do
-          {:ok, tools} ->
-            tool_names = Enum.map(tools, & &1.name)
-            {client, tools, tool_names}
-
-          {:error, reason} ->
-            cleanup_mcp_client(client)
-            notify_mcp_start_failure(subscriber, server_config.name, reason)
-            {nil, [], []}
-        end
-
-      {:error, reason} ->
-        notify_mcp_start_failure(subscriber, server_config.name, reason)
-        {nil, [], []}
-    end
-  end
-
-  @spec notify_mcp_start_failure(pid(), String.t(), term()) :: :ok
-  defp notify_mcp_start_failure(subscriber, server_name, reason) do
-    message =
-      "MCP server #{server_name} failed to start: #{format_error(reason)}. Built-in tools remain available."
-
-    Minga.Log.warning(:agent, "[Agent.Native] #{message}")
-    notify(subscriber, %Event.Error{message: message})
-    :ok
-  end
-
-  @spec remove_mcp_tools(map()) :: map()
-  defp remove_mcp_tools(state) do
-    cleanup_mcp_client(state.mcp_client)
-    tools = Enum.reject(state.tools, &(&1.name in state.mcp_tool_names))
-    %{state | tools: tools, mcp_client: nil, mcp_tool_names: []}
+  @spec remove_mcp_server_tools(map(), String.t()) :: map()
+  defp remove_mcp_server_tools(state, server_name) do
+    {registry, removed_tool_names} = MCPRegistry.remove_server(state.mcp_registry, server_name)
+    tools = Enum.reject(state.tools, &(&1.name in removed_tool_names))
+    %{state | tools: tools, mcp_registry: registry}
   end
 
   # ── Terminate cleanup ──────────────────────────────────────────────────────
@@ -861,15 +837,8 @@ defmodule MingaAgent.Providers.Native do
     :ok
   end
 
-  @spec cleanup_mcp_client(pid() | nil) :: :ok
-  defp cleanup_mcp_client(nil), do: :ok
-
-  defp cleanup_mcp_client(pid) when is_pid(pid) do
-    GenServer.stop(pid, :normal, 1_000)
-    :ok
-  catch
-    :exit, _ -> :ok
-  end
+  @spec cleanup_mcp(MCPRegistry.t() | nil) :: :ok
+  defp cleanup_mcp(registry), do: MCPRegistry.stop_all(registry)
 
   @spec merge_changeset(pid()) :: :ok
   defp merge_changeset(cs) do

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -83,7 +83,7 @@ defmodule Minga.Config.OptionsTest do
                agent_flush_before_shell: true,
                agent_api_base_url: "",
                agent_api_endpoints: nil,
-               agent_mcp_server: nil,
+               agent_mcp_servers: [],
                confirm_quit: true,
                agent_system_prompt: "",
                agent_append_system_prompt: "",
@@ -267,11 +267,12 @@ defmodule Minga.Config.OptionsTest do
       assert {:ok, true} = Options.set(s, :agent_auto_context, true)
     end
 
-    test "agent_mcp_server accepts map or nil", %{server: s} do
-      config = %{"name" => "local", "command" => "node"}
-      assert {:ok, ^config} = Options.set(s, :agent_mcp_server, config)
-      assert Options.get(s, :agent_mcp_server) == config
-      assert {:ok, nil} = Options.set(s, :agent_mcp_server, nil)
+    test "agent_mcp_servers accepts a list of maps", %{server: s} do
+      config = [%{"name" => "local", "command" => "node"}]
+      assert {:ok, ^config} = Options.set(s, :agent_mcp_servers, config)
+      assert Options.get(s, :agent_mcp_servers) == config
+      assert {:error, message} = Options.set(s, :agent_mcp_servers, %{"name" => "local"})
+      assert message =~ "list of maps"
     end
 
     test "agent_auto_context rejects non-boolean", %{server: s} do

--- a/test/minga_agent/config_test.exs
+++ b/test/minga_agent/config_test.exs
@@ -52,23 +52,23 @@ defmodule MingaAgent.ConfigTest do
       assert config.diff_size_threshold == 1_048_576
       assert config.session_retention_days == 30
       assert config.save_debounce_ms == 500
-      assert config.mcp_server == nil
+      assert config.mcp_servers == []
     end
   end
 
   describe "MCP config" do
-    test "defaults to nil" do
+    test "defaults to an empty list" do
       config = Config.resolve()
-      assert config.mcp_server == nil
+      assert config.mcp_servers == []
     end
 
     test "keeps raw server maps so provider startup can report config errors" do
       server = start_supervised!({Options, name: nil})
       Process.put(:minga_config_options, server)
 
-      raw_config = %{name: "local"}
-      assert {:ok, ^raw_config} = Options.set(server, :agent_mcp_server, raw_config)
-      assert Config.resolve().mcp_server == raw_config
+      raw_config = [%{name: "local"}]
+      assert {:ok, ^raw_config} = Options.set(server, :agent_mcp_servers, raw_config)
+      assert Config.resolve().mcp_servers == raw_config
     end
   end
 

--- a/test/minga_agent/mcp/registry_test.exs
+++ b/test/minga_agent/mcp/registry_test.exs
@@ -1,0 +1,154 @@
+defmodule MingaAgent.MCP.RegistryTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Event
+  alias MingaAgent.MCP.FakeTransport
+  alias MingaAgent.MCP.Registry
+  alias MingaAgent.MCP.ServerConfig
+  alias ReqLLM.Tool
+
+  defp config(name), do: %ServerConfig{name: name, command: "ignored"}
+
+  defp tool(name) do
+    %{
+      "name" => name,
+      "description" => "Tool #{name}",
+      "inputSchema" => %{"type" => "object", "properties" => %{}}
+    }
+  end
+
+  test "starts multiple healthy servers and builds a combined tool index" do
+    {registry, tools, failures} =
+      Registry.start_all([config("Alpha"), config("Beta")], self(),
+        transport: FakeTransport,
+        transport_opts: [
+          tools_by_server: %{
+            "Alpha" => [tool("echo-text")],
+            "Beta" => [tool("search-code")]
+          },
+          test_pid: self()
+        ],
+        notify_pid: self()
+      )
+
+    assert failures == []
+    tool_names = Enum.map(tools, & &1.name)
+    assert "mcp_alpha__echo_text" in tool_names
+    assert "mcp_beta__search_code" in tool_names
+
+    alpha_tool = Enum.find(tools, &(&1.name == "mcp_alpha__echo_text"))
+    beta_tool = Enum.find(tools, &(&1.name == "mcp_beta__search_code"))
+
+    assert {:ok, _result} = Tool.execute(alpha_tool, %{})
+    assert_receive {:mcp_tool_call, "Alpha", "echo-text", %{}}
+
+    assert {:ok, _result} = Tool.execute(beta_tool, %{})
+    assert_receive {:mcp_tool_call, "Beta", "search-code", %{}}
+
+    Registry.stop_all(registry)
+  end
+
+  test "renames cross-server tool collisions and keeps callbacks routed to the owning server" do
+    {registry, tools, failures} =
+      Registry.start_all([config("Alpha Tools"), config("Alpha_Tools")], self(),
+        transport: FakeTransport,
+        transport_opts: [
+          tools_by_server: %{
+            "Alpha Tools" => [tool("echo-text")],
+            "Alpha_Tools" => [tool("echo-text")]
+          },
+          test_pid: self()
+        ],
+        notify_pid: self()
+      )
+
+    assert failures == []
+    tool_names = Enum.map(tools, & &1.name)
+    assert tool_names == ["mcp_alpha_tools__echo_text", "mcp_alpha_tools__echo_text_2"]
+
+    first_tool = Enum.find(tools, &(&1.name == "mcp_alpha_tools__echo_text"))
+    second_tool = Enum.find(tools, &(&1.name == "mcp_alpha_tools__echo_text_2"))
+
+    assert {:ok, _result} = Tool.execute(first_tool, %{})
+    assert_receive {:mcp_tool_call, "Alpha Tools", "echo-text", %{}}
+
+    assert {:ok, _result} = Tool.execute(second_tool, %{})
+    assert_receive {:mcp_tool_call, "Alpha_Tools", "echo-text", %{}}
+
+    Registry.stop_all(registry)
+  end
+
+  test "renames MCP tools that collide with reserved built-in tool names" do
+    {registry, tools, failures} =
+      Registry.start_all([config("Local Tools")], self(),
+        transport: FakeTransport,
+        transport_opts: [tools: [tool("echo-text")], test_pid: self()],
+        notify_pid: self(),
+        reserved_tool_names: ["mcp_local_tools__echo_text"]
+      )
+
+    assert failures == []
+    assert Enum.map(tools, & &1.name) == ["mcp_local_tools__echo_text_2"]
+
+    [renamed_tool] = tools
+    assert {:ok, _result} = Tool.execute(renamed_tool, %{})
+    assert_receive {:mcp_tool_call, "Local Tools", "echo-text", %{}}
+
+    Registry.stop_all(registry)
+  end
+
+  test "startup failure is isolated to one server" do
+    {registry, tools, failures} =
+      Registry.start_all([config("Broken"), config("Healthy")], self(),
+        transport: FakeTransport,
+        transport_opts: [
+          tools_by_server: %{"Healthy" => [tool("echo-text")]},
+          request_errors_by_server: %{"Broken" => %{"tools/list" => :boom}},
+          test_pid: self()
+        ],
+        notify_pid: self()
+      )
+
+    assert [failure] = failures
+    assert failure =~ "MCP server Broken failed to start"
+    assert_receive {:agent_provider_event, %Event.Error{message: message}}
+    assert message =~ "Broken"
+
+    assert Enum.map(tools, & &1.name) == ["mcp_healthy__echo_text"]
+
+    [healthy_tool] = tools
+    assert {:ok, _result} = Tool.execute(healthy_tool, %{})
+    assert_receive {:mcp_tool_call, "Healthy", "echo-text", %{}}
+
+    Registry.stop_all(registry)
+  end
+
+  test "removing a crashed server removes only its tools" do
+    {registry, tools, []} =
+      Registry.start_all([config("Alpha"), config("Beta")], self(),
+        transport: FakeTransport,
+        transport_opts: [
+          tools_by_server: %{
+            "Alpha" => [tool("echo-text")],
+            "Beta" => [tool("search-code")]
+          },
+          test_pid: self()
+        ],
+        notify_pid: self()
+      )
+
+    assert_receive {:mcp_transport_started, "Alpha", alpha_transport}
+    FakeTransport.crash(alpha_transport)
+    assert_receive {:mcp_client_down, alpha_client, "Alpha", :boom}
+    assert Registry.server_for_pid(registry, alpha_client) == "Alpha"
+
+    {registry, removed_tool_names} = Registry.remove_server(registry, "Alpha")
+    assert removed_tool_names == ["mcp_alpha__echo_text"]
+
+    beta_tool = Enum.find(tools, &(&1.name == "mcp_beta__search_code"))
+    assert {:ok, _result} = Tool.execute(beta_tool, %{})
+    assert_receive {:mcp_tool_call, "Beta", "search-code", %{}}
+
+    Registry.stop_all(registry)
+  end
+end

--- a/test/minga_agent/mcp/server_config_test.exs
+++ b/test/minga_agent/mcp/server_config_test.exs
@@ -17,6 +17,18 @@ defmodule MingaAgent.MCP.ServerConfigTest do
     assert config.command == "node"
     assert config.args == ["server.js"]
     assert config.env == %{"TOKEN" => "secret", "MODE" => "test"}
+    assert config.enabled == true
+  end
+
+  test "normalizes enabled false" do
+    assert {:ok, config} =
+             ServerConfig.normalize(%{
+               name: "local-tools",
+               command: "node",
+               enabled: false
+             })
+
+    assert config.enabled == false
   end
 
   test "rejects missing command" do
@@ -34,5 +46,57 @@ defmodule MingaAgent.MCP.ServerConfigTest do
              ServerConfig.normalize(%{"name" => "local", name: false, command: "node"})
 
     assert reason =~ "name must be a string"
+  end
+
+  test "normalize_list filters disabled configs before validating required launch fields" do
+    assert {:ok, configs} =
+             ServerConfig.normalize_list([
+               %{name: "disabled", enabled: false},
+               %{name: "enabled", command: "node"}
+             ])
+
+    assert Enum.map(configs, & &1.name) == ["enabled"]
+  end
+
+  test "normalize_list accepts nil, one map, and a list" do
+    assert {:ok, []} = ServerConfig.normalize_list(nil)
+
+    assert {:ok, [%ServerConfig{name: "one"}]} =
+             ServerConfig.normalize_list(%{name: "one", command: "node"})
+
+    assert {:ok, [%ServerConfig{name: "one"}, %ServerConfig{name: "two"}]} =
+             ServerConfig.normalize_list([
+               %{name: "one", command: "node"},
+               %{name: "two", command: "node"}
+             ])
+  end
+
+  test "normalize_list rejects nil entries" do
+    assert {:error, reason} =
+             ServerConfig.normalize_list([
+               nil,
+               %{name: "tools", command: "node"}
+             ])
+
+    assert reason =~ "cannot contain nil"
+  end
+
+  test "normalize_list rejects duplicate enabled server names" do
+    assert {:error, reason} =
+             ServerConfig.normalize_list([
+               %{name: "tools", command: "node"},
+               %{name: "tools", command: "python"}
+             ])
+
+    assert reason =~ "unique"
+    assert reason =~ "tools"
+  end
+
+  test "normalize_list ignores disabled duplicate names" do
+    assert {:ok, [%ServerConfig{name: "tools"}]} =
+             ServerConfig.normalize_list([
+               %{name: "tools", enabled: false},
+               %{name: "tools", command: "node"}
+             ])
   end
 end

--- a/test/minga_agent/providers/native_mcp_test.exs
+++ b/test/minga_agent/providers/native_mcp_test.exs
@@ -10,22 +10,22 @@ defmodule MingaAgent.Providers.NativeMCPTest do
 
   @moduletag :tmp_dir
 
-  defp server_config do
-    %ServerConfig{name: "Local Tools", command: "ignored"}
+  defp server_config(name \\ "Local Tools") do
+    %ServerConfig{name: name, command: "ignored"}
   end
 
-  defp agent_config do
-    %AgentConfig{mcp_server: server_config(), tool_approval: :none}
+  defp agent_config(servers \\ [server_config()]) do
+    %AgentConfig{mcp_servers: servers, tool_approval: :none}
   end
 
-  defp mcp_tool_def do
+  defp mcp_tool_def(name \\ "echo-text") do
     %{
-      "name" => "echo-text",
-      "description" => "Echo text through MCP",
+      "name" => name,
+      "description" => "MCP tool #{name}",
       "inputSchema" => %{
         "type" => "object",
         "properties" => %{"text" => %{"type" => "string"}},
-        "required" => ["text"]
+        "required" => []
       }
     }
   end
@@ -79,6 +79,15 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     end
   end
 
+  defp drain_llm_tools_messages do
+    receive do
+      {:llm_tools_before_call_failure, _tool_names} -> drain_llm_tools_messages()
+      {:llm_tools_after_call_failure, _tool_names} -> drain_llm_tools_messages()
+    after
+      0 -> :ok
+    end
+  end
+
   test "passes MCP tools and builtins to the LLM", %{tmp_dir: dir} do
     test_pid = self()
 
@@ -99,6 +108,74 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     assert "todo_write" in tool_names
   end
 
+  test "passes tools from two healthy MCP servers to the LLM", %{tmp_dir: dir} do
+    test_pid = self()
+
+    client = fn _model, _messages, opts ->
+      send(test_pid, {:llm_tools_two_servers, Enum.map(opts[:tools], & &1.name)})
+
+      [ReqLLM.StreamChunk.text("ok"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+      |> build_stream_response()
+    end
+
+    {:ok, provider} =
+      start_provider(
+        tmp_dir: dir,
+        llm_client: client,
+        config: agent_config([server_config("Alpha"), server_config("Beta")]),
+        mcp_transport_opts: [
+          tools_by_server: %{
+            "Alpha" => [mcp_tool_def("echo-text")],
+            "Beta" => [mcp_tool_def("search-code")]
+          },
+          test_pid: self()
+        ]
+      )
+
+    assert :ok = Native.send_prompt(provider, "hello")
+    _events = collect_until_end()
+
+    assert_receive {:llm_tools_two_servers, tool_names}
+    assert "builtin_echo" in tool_names
+    assert "mcp_alpha__echo_text" in tool_names
+    assert "mcp_beta__search_code" in tool_names
+    assert "todo_write" in tool_names
+  end
+
+  test "renames MCP tools that collide with built-in tool names before LLM calls", %{tmp_dir: dir} do
+    test_pid = self()
+
+    conflicting_builtin =
+      ReqLLM.Tool.new!(
+        name: "mcp_local_tools__echo_text",
+        description: "Existing tool with MCP-shaped name",
+        parameter_schema: %{"type" => "object", "properties" => %{}},
+        callback: fn _args -> {:ok, "builtin wins"} end
+      )
+
+    client = fn _model, _messages, opts ->
+      send(test_pid, {:llm_tools_with_reserved_collision, Enum.map(opts[:tools], & &1.name)})
+
+      [ReqLLM.StreamChunk.text("ok"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+      |> build_stream_response()
+    end
+
+    {:ok, provider} =
+      start_provider(
+        tmp_dir: dir,
+        llm_client: client,
+        tools: [conflicting_builtin]
+      )
+
+    assert :ok = Native.send_prompt(provider, "hello")
+    _events = collect_until_end()
+
+    assert_receive {:llm_tools_with_reserved_collision, tool_names}
+    assert "mcp_local_tools__echo_text" in tool_names
+    assert "mcp_local_tools__echo_text_2" in tool_names
+    assert length(tool_names) == length(Enum.uniq(tool_names))
+  end
+
   test "invalid MCP config reports an error and keeps builtins available", %{tmp_dir: dir} do
     test_pid = self()
 
@@ -113,7 +190,7 @@ defmodule MingaAgent.Providers.NativeMCPTest do
       start_provider(
         tmp_dir: dir,
         llm_client: client,
-        config: %AgentConfig{mcp_server: %{name: "Local Tools"}, tool_approval: :none}
+        config: %AgentConfig{mcp_servers: [%{name: "Local Tools"}], tool_approval: :none}
       )
 
     assert_receive {:agent_provider_event, %Event.Error{message: message}}
@@ -126,6 +203,41 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     assert_receive {:llm_tools_with_invalid_mcp, tool_names}
     assert "builtin_echo" in tool_names
     refute "mcp_local_tools__echo_text" in tool_names
+    assert "todo_write" in tool_names
+  end
+
+  test "one failed MCP server leaves a healthy server and builtins available", %{tmp_dir: dir} do
+    test_pid = self()
+
+    client = fn _model, _messages, opts ->
+      send(test_pid, {:llm_tools_with_failed_server, Enum.map(opts[:tools], & &1.name)})
+
+      [ReqLLM.StreamChunk.text("ok"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+      |> build_stream_response()
+    end
+
+    {:ok, provider} =
+      start_provider(
+        tmp_dir: dir,
+        llm_client: client,
+        config: agent_config([server_config("Broken"), server_config("Healthy")]),
+        mcp_transport_opts: [
+          tools_by_server: %{"Healthy" => [mcp_tool_def("echo-text")]},
+          request_errors_by_server: %{"Broken" => %{"tools/list" => :boom}},
+          test_pid: self()
+        ]
+      )
+
+    assert_receive {:agent_provider_event, %Event.Error{message: message}}
+    assert message =~ "MCP server Broken failed to start"
+
+    assert :ok = Native.send_prompt(provider, "hello")
+    _events = collect_until_end()
+
+    assert_receive {:llm_tools_with_failed_server, tool_names}
+    assert "builtin_echo" in tool_names
+    assert "mcp_healthy__echo_text" in tool_names
+    refute "mcp_broken__echo_text" in tool_names
     assert "todo_write" in tool_names
   end
 
@@ -187,7 +299,7 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     end
 
     {:ok, provider} = start_provider(tmp_dir: dir, llm_client: client)
-    assert_receive {:mcp_transport_started, transport}
+    assert_receive {:mcp_transport_started, "Local Tools", transport}
     FakeTransport.crash(transport)
 
     assert_receive {:agent_provider_event, %Event.Error{message: message}}
@@ -201,5 +313,165 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     assert "builtin_echo" in tool_names
     refute "mcp_local_tools__echo_text" in tool_names
     assert Enum.any?(events, &match?(%Event.ToolEnd{name: "builtin_echo", is_error: false}, &1))
+  end
+
+  test "provider shutdown stops all MCP transports", %{tmp_dir: dir} do
+    {:ok, provider} =
+      start_provider(
+        tmp_dir: dir,
+        config: agent_config([server_config("Alpha"), server_config("Beta")]),
+        mcp_transport_opts: [
+          tools_by_server: %{
+            "Alpha" => [mcp_tool_def("echo-text")],
+            "Beta" => [mcp_tool_def("search-code")]
+          },
+          test_pid: self()
+        ]
+      )
+
+    assert_receive {:mcp_transport_started, "Alpha", alpha_transport}
+    assert_receive {:mcp_transport_started, "Beta", beta_transport}
+
+    provider_ref = Process.monitor(provider)
+    GenServer.stop(provider)
+
+    assert_receive {:DOWN, ^provider_ref, :process, ^provider, :normal}
+    assert_receive {:mcp_transport_stopped, "Alpha", ^alpha_transport}
+    assert_receive {:mcp_transport_stopped, "Beta", ^beta_transport}
+  end
+
+  test "MCP tool failure during a call reports an error and keeps provider usable", %{
+    tmp_dir: dir
+  } do
+    test_pid = self()
+    call_count = :counters.new(1, [:atomics])
+
+    client = fn _model, _messages, opts ->
+      count = :counters.get(call_count, 1)
+      :counters.add(call_count, 1, 1)
+
+      label =
+        if count == 0, do: :llm_tools_before_call_failure, else: :llm_tools_after_call_failure
+
+      send(test_pid, {label, Enum.map(opts[:tools], & &1.name)})
+
+      chunks =
+        case count do
+          0 ->
+            [
+              ReqLLM.StreamChunk.tool_call("mcp_local_tools__echo_text", %{"text" => "hi"}, %{
+                id: "tc_mcp",
+                index: 0
+              }),
+              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+            ]
+
+          1 ->
+            [
+              ReqLLM.StreamChunk.tool_call("builtin_echo", %{}, %{id: "tc_builtin", index: 0}),
+              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+            ]
+
+          _done ->
+            [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+        end
+
+      build_stream_response(chunks)
+    end
+
+    {:ok, provider} =
+      start_provider(
+        tmp_dir: dir,
+        llm_client: client,
+        mcp_transport_opts: [
+          tools: [mcp_tool_def()],
+          request_errors: %{"echo-text" => :closed},
+          test_pid: self()
+        ]
+      )
+
+    assert :ok = Native.send_prompt(provider, "use failing mcp")
+    events = collect_until_end()
+
+    assert Enum.any?(
+             events,
+             &match?(%Event.ToolEnd{name: "mcp_local_tools__echo_text", is_error: true}, &1)
+           )
+
+    assert Enum.any?(events, fn
+             %Event.Error{message: message} -> message =~ "MCP server Local Tools stopped"
+             _event -> false
+           end)
+
+    :sys.get_state(provider)
+    drain_llm_tools_messages()
+    assert :ok = Native.send_prompt(provider, "still works")
+    events = collect_until_end()
+
+    assert_receive {:llm_tools_after_call_failure, tool_names}
+    assert "builtin_echo" in tool_names
+    refute "mcp_local_tools__echo_text" in tool_names
+    assert Enum.any?(events, &match?(%Event.AgentEnd{}, &1))
+  end
+
+  test "mid-session crash removes only the crashed server tools", %{tmp_dir: dir} do
+    test_pid = self()
+    call_count = :counters.new(1, [:atomics])
+
+    client = fn _model, _messages, opts ->
+      send(test_pid, {:llm_tools_after_one_server_crash, Enum.map(opts[:tools], & &1.name)})
+      count = :counters.get(call_count, 1)
+      :counters.add(call_count, 1, 1)
+
+      chunks =
+        if count == 0 do
+          [
+            ReqLLM.StreamChunk.tool_call("mcp_beta__search_code", %{"text" => "hi"}, %{
+              id: "tc_beta",
+              index: 0
+            }),
+            ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+          ]
+        else
+          [ReqLLM.StreamChunk.text("ok"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+        end
+
+      build_stream_response(chunks)
+    end
+
+    {:ok, provider} =
+      start_provider(
+        tmp_dir: dir,
+        llm_client: client,
+        config: agent_config([server_config("Alpha"), server_config("Beta")]),
+        mcp_transport_opts: [
+          tools_by_server: %{
+            "Alpha" => [mcp_tool_def("echo-text")],
+            "Beta" => [mcp_tool_def("search-code")]
+          },
+          test_pid: self()
+        ]
+      )
+
+    assert_receive {:mcp_transport_started, "Alpha", alpha_transport}
+    FakeTransport.crash(alpha_transport)
+
+    assert_receive {:agent_provider_event, %Event.Error{message: message}}
+    assert message =~ "MCP server Alpha stopped"
+
+    :sys.get_state(provider)
+    assert :ok = Native.send_prompt(provider, "still works")
+    events = collect_until_end()
+
+    assert_receive {:llm_tools_after_one_server_crash, tool_names}
+    assert "builtin_echo" in tool_names
+    refute "mcp_alpha__echo_text" in tool_names
+    assert "mcp_beta__search_code" in tool_names
+    assert_receive {:mcp_tool_call, "Beta", "search-code", %{"text" => "hi"}}
+
+    assert Enum.any?(
+             events,
+             &match?(%Event.ToolEnd{name: "mcp_beta__search_code", is_error: false}, &1)
+           )
   end
 end

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -241,7 +241,7 @@ defmodule MingaAgent.SessionTest do
   # final action when a turn completes, so receiving that event guarantees
   # all handle_info callbacks have run.
   defp await_turn_complete do
-    assert_receive {:agent_event, _, {:status_changed, :idle}}, 200
+    assert_receive {:agent_event, _, {:status_changed, :idle}}, 1_000
   end
 
   defp mcp_session_builtin_tool do
@@ -1710,7 +1710,7 @@ defmodule MingaAgent.SessionTest do
             project_root: dir,
             tools: [mcp_session_builtin_tool()],
             config: %MingaAgent.Config{
-              mcp_server: %ServerConfig{name: "Local Tools", command: "ignored"},
+              mcp_servers: [%ServerConfig{name: "Local Tools", command: "ignored"}],
               tool_approval: :none
             },
             mcp_transport: FakeTransport,
@@ -1724,7 +1724,7 @@ defmodule MingaAgent.SessionTest do
 
       Session.subscribe(session)
       _provider = Session.get_provider(session)
-      assert_receive {:mcp_transport_started, transport}
+      assert_receive {:mcp_transport_started, "Local Tools", transport}
       FakeTransport.crash(transport)
 
       assert_receive {:agent_event, ^session, {:error, message}}, 500

--- a/test/support/minga_agent/mcp/fake_transport.ex
+++ b/test/support/minga_agent/mcp/fake_transport.ex
@@ -7,22 +7,35 @@ defmodule MingaAgent.MCP.FakeTransport do
 
   alias MingaAgent.MCP.ServerConfig
 
+  @type state :: %{
+          server_name: String.t(),
+          owner: pid(),
+          tools: [map()],
+          call_results: map(),
+          request_errors: map(),
+          test_pid: pid() | nil
+        }
+
   @impl MingaAgent.MCP.Transport
-  def start(%ServerConfig{}, owner, opts) do
-    GenServer.start(__MODULE__, {owner, opts})
+  @spec start(ServerConfig.t(), pid(), keyword()) :: GenServer.on_start()
+  def start(%ServerConfig{} = config, owner, opts) do
+    GenServer.start(__MODULE__, {config.name, owner, opts})
   end
 
   @impl MingaAgent.MCP.Transport
+  @spec request(pid(), map(), timeout()) :: {:ok, map()} | {:error, term()}
   def request(pid, message, timeout) when is_pid(pid) do
     GenServer.call(pid, {:request, message}, timeout)
   end
 
   @impl MingaAgent.MCP.Transport
+  @spec notify(pid(), map()) :: :ok
   def notify(pid, message) when is_pid(pid) do
     GenServer.call(pid, {:notify, message})
   end
 
   @impl MingaAgent.MCP.Transport
+  @spec stop(pid()) :: :ok
   def stop(pid) when is_pid(pid) do
     GenServer.call(pid, :stop, 1_000)
     :ok
@@ -31,19 +44,38 @@ defmodule MingaAgent.MCP.FakeTransport do
   end
 
   @impl MingaAgent.MCP.Transport
+  @spec handle_transport_info(term(), pid()) :: :ignore | {:down, term()}
   def handle_transport_info({:mcp_fake_transport_exit, pid, reason}, pid), do: {:down, reason}
   def handle_transport_info(_message, _pid), do: :ignore
 
+  @spec crash(pid()) :: :ok
   def crash(pid), do: GenServer.call(pid, :crash)
 
   @impl GenServer
-  def init({owner, opts}) do
-    tools = Keyword.get(opts, :tools, [])
-    call_results = Keyword.get(opts, :call_results, %{})
-    request_errors = Keyword.get(opts, :request_errors, %{})
+  @spec init({String.t(), pid(), keyword()}) :: {:ok, state()}
+  def init({server_name, owner, opts}) do
+    tools = per_server(opts, :tools_by_server, server_name, Keyword.get(opts, :tools, []))
+
+    call_results =
+      per_server(
+        opts,
+        :call_results_by_server,
+        server_name,
+        Keyword.get(opts, :call_results, %{})
+      )
+
+    request_errors =
+      per_server(
+        opts,
+        :request_errors_by_server,
+        server_name,
+        Keyword.get(opts, :request_errors, %{})
+      )
+
     test_pid = Keyword.get(opts, :test_pid)
 
     state = %{
+      server_name: server_name,
       owner: owner,
       tools: tools,
       call_results: call_results,
@@ -52,12 +84,16 @@ defmodule MingaAgent.MCP.FakeTransport do
     }
 
     maybe_report(state, {:mcp_transport_started, self()})
+    maybe_report(state, {:mcp_transport_started, server_name, self()})
     {:ok, state}
   end
 
   @impl GenServer
+  @spec handle_call(term(), GenServer.from(), state()) ::
+          {:reply, term(), state()} | {:stop, :normal, :ok, state()}
   def handle_call({:request, %{"method" => "initialize"} = message}, _from, state) do
     maybe_report(state, {:mcp_request, message})
+    maybe_report(state, {:mcp_request, state.server_name, message})
 
     case request_error(state, "initialize") do
       {:error, reason} -> {:reply, {:error, reason}, state}
@@ -67,6 +103,7 @@ defmodule MingaAgent.MCP.FakeTransport do
 
   def handle_call({:request, %{"method" => "tools/list"} = message}, _from, state) do
     maybe_report(state, {:mcp_request, message})
+    maybe_report(state, {:mcp_request, state.server_name, message})
 
     case request_error(state, "tools/list") do
       {:error, reason} -> {:reply, {:error, reason}, state}
@@ -80,9 +117,11 @@ defmodule MingaAgent.MCP.FakeTransport do
         state
       ) do
     maybe_report(state, {:mcp_request, message})
+    maybe_report(state, {:mcp_request, state.server_name, message})
     name = params["name"]
     args = params["arguments"] || %{}
     maybe_report(state, {:mcp_tool_call, name, args})
+    maybe_report(state, {:mcp_tool_call, state.server_name, name, args})
 
     case request_error(state, name) do
       {:error, reason} ->
@@ -100,6 +139,7 @@ defmodule MingaAgent.MCP.FakeTransport do
 
   def handle_call({:notify, message}, _from, state) do
     maybe_report(state, {:mcp_notification, message})
+    maybe_report(state, {:mcp_notification, state.server_name, message})
     {:reply, :ok, state}
   end
 
@@ -110,6 +150,7 @@ defmodule MingaAgent.MCP.FakeTransport do
 
   def handle_call(:stop, _from, state) do
     maybe_report(state, {:mcp_transport_stopped, self()})
+    maybe_report(state, {:mcp_transport_stopped, state.server_name, self()})
     {:stop, :normal, :ok, state}
   end
 
@@ -117,6 +158,13 @@ defmodule MingaAgent.MCP.FakeTransport do
     case Map.fetch(state.request_errors, name) do
       {:ok, reason} -> {:error, reason}
       :error -> :none
+    end
+  end
+
+  defp per_server(opts, key, server_name, default) do
+    case Keyword.get(opts, key) do
+      values when is_map(values) -> Map.get(values, server_name, default)
+      _other -> default
     end
   end
 


### PR DESCRIPTION
# TL;DR
Agents can now launch and use tools from multiple MCP servers in one native session. Enabled servers start independently, failed servers report a targeted system error, and only the failed server's tools are removed when a server goes down.

Closes #1512

## Context
This completes the multi-server MCP follow-up for the native agent provider. The previous MCP path assumed one session-scoped client; this PR moves the provider config to a list of servers and adds an in-memory registry so the provider can track each server's client and tools independently.

## Changes
- Added `MingaAgent.MCP.Registry`, a struct-owned registry held in `MingaAgent.Providers.Native` state, to track MCP client pids, monitor refs, and provider-facing tool names per server.
- Replaced `:agent_mcp_server` with `:agent_mcp_servers`, including option validation, config completion support, and native provider startup changes.
- Extended `ServerConfig` with `enabled: true` and `normalize_list/1`, including disabled-server filtering and duplicate enabled-name rejection.
- Updated MCP failure handling so startup failures and mid-session crashes report the server name and remove only that server's tools.
- Expanded fake MCP transport support for per-server tools and failures so tests can exercise multi-server behavior without OS processes.
- Updated MCP docs and configuration docs for multi-server setup, `enabled: false`, and tool naming.

## Verification
- `mix test test/minga_agent/mcp test/minga_agent/providers/native_mcp_test.exs test/minga_agent/config_test.exs test/minga/config/options_test.exs test/minga_agent/session_test.exs`
- `mix compile --warnings-as-errors`
- `mix test test/minga/config/completion_test.exs`
- `mix test test/minga_editor/file_change_test.exs:112`
- `mix test.llm`
- `make lint` (passes with existing struct-size warnings)
- Reviewer gate: PASS

## Acceptance Criteria Addressed
- A user can configure multiple MCP servers with stable names, launch commands, args, env, and enabled/disabled state. ✅
- At agent session start, enabled servers launch independently and each server's tools are listed. ✅
- Tools from all healthy servers appear alongside built-in tools with collision-safe names. ✅
- One server failing to start or crashing mid-session removes only that server's tools and does not affect built-in tools or other MCP servers. ✅
- The user sees a system message identifying which MCP server failed and why. ✅
- Tests cover two healthy servers, one failed server plus one healthy server, and a mid-session crash of one server. ✅
- `docs/MCP.md` documents multi-server config and the tool naming rule. ✅
