### PR TITLE
chore(input): finalize modal overlay reset gate

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -29,6 +29,7 @@
           {Minga.Credo.NoProcessSleepCheck, []},
           {Minga.Credo.NoDirectLoggerCheck, [exit_status: 0]},
           {Minga.Credo.NoDirectStateMachineWriteCheck, []},
+          {Minga.Credo.NoDirectModalOverlayWriteCheck, []},
 
           # ── Readability ────────────────────────────────────────────────────
           {Credo.Check.Readability.AliasOrder, false},

--- a/credo/checks/no_direct_modal_overlay_write_check.exs
+++ b/credo/checks/no_direct_modal_overlay_write_check.exs
@@ -1,0 +1,82 @@
+defmodule Minga.Credo.NoDirectModalOverlayWriteCheck do
+  @moduledoc """
+  Forbids direct writes to the modal overlay field. Use `MingaEditor.State.ModalOverlay` instead.
+
+  The modal overlay is a tagged union with a single write gate. Raw map updates like `%{shell_state | modal: ...}` bypass the replacement policy and make it easy to reintroduce independent nullable modal state.
+
+  This check flags map or struct updates that write `modal:` outside the small set of modules that own the gate and shell state structs.
+  """
+
+  use Credo.Check,
+    id: "EX9005",
+    base_priority: :normal,
+    category: :design,
+    param_defaults: [
+      allowed_files: [
+        "lib/minga_editor/state/modal_overlay.ex",
+        "lib/minga_editor/shell/traditional/state.ex",
+        "lib/minga_editor/shell/board/state.ex",
+        "test/support/"
+      ]
+    ],
+    explanations: [
+      check: """
+      Modal overlay writes must flow through `MingaEditor.State.ModalOverlay`.
+      Use `ModalOverlay.open/3`, `transition/3`, `close/1`, or `dismiss/1` instead of raw `%{state | modal: ...}` updates.
+      """,
+      params: [
+        allowed_files:
+          "Filename suffixes or path fragments where direct modal writes are permitted."
+      ]
+    ]
+
+  @impl Credo.Check
+  @spec run(Credo.SourceFile.t(), keyword()) :: [Credo.Issue.t()]
+  def run(%SourceFile{} = source_file, params) do
+    if allowed_file?(source_file, params) do
+      []
+    else
+      issue_meta = IssueMeta.for(source_file, params)
+
+      source_file
+      |> Credo.Code.prewalk(&find_modal_writes(&1, &2, issue_meta))
+      |> List.flatten()
+    end
+  end
+
+  defp find_modal_writes({:%{}, _meta, [{:|, _, [_map, updates]}]} = ast, issues, issue_meta)
+       when is_list(updates) do
+    new_issues =
+      updates
+      |> Enum.filter(fn
+        {:modal, _value} -> true
+        _ -> false
+      end)
+      |> Enum.map(fn {:modal, value} ->
+        line_no = extract_line(value) || extract_line(ast)
+
+        format_issue(issue_meta,
+          message:
+            "Direct write to `modal:` bypasses MingaEditor.State.ModalOverlay. " <>
+              "Use ModalOverlay.open/3, transition/3, close/1, or dismiss/1 instead.",
+          trigger: "modal:",
+          line_no: line_no
+        )
+      end)
+
+    {ast, new_issues ++ issues}
+  end
+
+  defp find_modal_writes(ast, issues, _issue_meta), do: {ast, issues}
+
+  defp extract_line({_, meta, _}) when is_list(meta), do: meta[:line]
+  defp extract_line({:%{}, meta, _}) when is_list(meta), do: meta[:line]
+  defp extract_line(_), do: nil
+
+  defp allowed_file?(%SourceFile{} = source_file, params) do
+    filename = Path.expand(source_file.filename)
+    allowed = Params.get(params, :allowed_files, __MODULE__)
+
+    Enum.any?(allowed, fn allowed_path -> String.contains?(filename, allowed_path) end)
+  end
+end

--- a/lib/minga_editor/input/interrupt.ex
+++ b/lib/minga_editor/input/interrupt.ex
@@ -16,12 +16,10 @@ defmodule MingaEditor.Input.Interrupt do
 
   - `keymap_scope` → `:editor`
   - Vim mode → `:normal` with fresh mode state
-  - Picker → closed
+  - Modal overlay → dismissed
   - Which-key popup → dismissed
-  - Conflict prompt → dismissed
-  - Completion menu → closed
-  - Status message → cleared
   - Agent pending prefix → cleared
+  - Status message → cleared
 
   A `*Messages*` log entry records what was reset for debuggability.
   """
@@ -61,12 +59,10 @@ defmodule MingaEditor.Input.Interrupt do
 
     {state, resets} = maybe_reset_scope(state, resets)
     {state, resets} = maybe_reset_mode(state, resets)
-    {state, resets} = maybe_close_picker(state, resets)
-    {state, resets} = maybe_close_whichkey(state, resets)
-    {state, resets} = maybe_close_conflict(state, resets)
-    {state, resets} = maybe_close_completion(state, resets)
+    {state, resets} = maybe_dismiss_modal(state, resets)
+    {state, resets} = maybe_clear_whichkey(state, resets)
     {state, resets} = maybe_clear_agent_prefix(state, resets)
-    state = EditorState.clear_status(state)
+    {state, resets} = maybe_clear_status(state, resets)
 
     {state, resets}
   end
@@ -99,53 +95,39 @@ defmodule MingaEditor.Input.Interrupt do
     end
   end
 
-  # Checks if mode_state has any pending state that should be cleared.
-  @spec mode_state_dirty?(Mode.state(), Mode.state()) :: boolean()
-  defp mode_state_dirty?(current, fresh) do
+  @spec mode_state_dirty?(term(), Minga.Mode.State.t()) :: boolean()
+  defp mode_state_dirty?(%Minga.Mode.State{} = current, %Minga.Mode.State{} = fresh) do
     current.leader_node != fresh.leader_node or
+      current.leader_keys != fresh.leader_keys or
       current.prefix_node != fresh.prefix_node or
+      current.prefix_keys != fresh.prefix_keys or
       current.pending != fresh.pending or
       current.describe_key != fresh.describe_key or
-      current.count != fresh.count
+      current.count != fresh.count or
+      current.insert_changed != fresh.insert_changed
   end
 
-  @spec maybe_close_picker(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
-  defp maybe_close_picker(state, resets) do
-    if ModalOverlay.match(state.shell_state.modal, :picker) do
-      {ModalOverlay.dismiss(state), ["picker closed" | resets]}
+  defp mode_state_dirty?(_current, _fresh), do: true
+
+  @spec maybe_dismiss_modal(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
+  defp maybe_dismiss_modal(state, resets) do
+    if ModalOverlay.active?(EditorState.modal(state)) do
+      {ModalOverlay.dismiss(state), ["modal dismissed" | resets]}
     else
       {state, resets}
     end
   end
 
-  @spec maybe_close_whichkey(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
-  defp maybe_close_whichkey(
+  @spec maybe_clear_whichkey(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
+  defp maybe_clear_whichkey(
          %{shell_state: %{whichkey: %WhichKey{node: nil, show: false}}} = state,
          resets
        ),
        do: {state, resets}
 
-  defp maybe_close_whichkey(state, resets) do
+  defp maybe_clear_whichkey(state, resets) do
     wk = EditorState.whichkey(state)
     {EditorState.set_whichkey(state, WhichKey.clear(wk)), ["which-key dismissed" | resets]}
-  end
-
-  @spec maybe_close_conflict(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
-  defp maybe_close_conflict(state, resets) do
-    if ModalOverlay.match(state.shell_state.modal, :conflict) do
-      {ModalOverlay.dismiss(state), ["conflict prompt dismissed" | resets]}
-    else
-      {state, resets}
-    end
-  end
-
-  @spec maybe_close_completion(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
-  defp maybe_close_completion(state, resets) do
-    if ModalOverlay.match(state.shell_state.modal, :completion) do
-      {ModalOverlay.dismiss(state), ["completion closed" | resets]}
-    else
-      {state, resets}
-    end
   end
 
   @spec maybe_clear_agent_prefix(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
@@ -158,6 +140,13 @@ defmodule MingaEditor.Input.Interrupt do
         new_state = AgentAccess.update_agent_ui(state, &UIState.clear_prefix/1)
         {new_state, ["agent prefix cleared" | resets]}
     end
+  end
+
+  @spec maybe_clear_status(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
+  defp maybe_clear_status(%{shell_state: %{status_msg: nil}} = state, resets), do: {state, resets}
+
+  defp maybe_clear_status(state, resets) do
+    {EditorState.clear_status(state), ["status cleared" | resets]}
   end
 
   # ── Logging ──────────────────────────────────────────────────────────────

--- a/lib/minga_editor/state/modal_overlay.ex
+++ b/lib/minga_editor/state/modal_overlay.ex
@@ -18,17 +18,11 @@ defmodule MingaEditor.State.ModalOverlay do
       | {:conflict, ModalOverlay.Conflict.t()}
       | {:dashboard, ModalOverlay.Dashboard.t()}
 
-  ## Migration status (#1421)
-
-  All five variants are now tracked exclusively on `state.shell_state.modal`.
-  The legacy nullable fields (`shell_state.dashboard`, `shell_state.prompt_ui`,
-  `workspace.pending_conflict`, `workspace.completion`,
-  `workspace.completion_trigger`) have all been removed. #1427 finalises by
-  collapsing `Input.Interrupt` and adding a Credo enforcement rule.
+  The modal field is the only storage location for these five variants. There is no dual-write migration path and no dev/test divergence assertion; future modal changes must go through this gate directly.
 
   **Do not mutate `:modal` directly**: always call this module's
   `open/3`, `transition/3`, `close/1`, `dismiss/1`, `update_completion/2`,
-  or `update_completion_trigger/2`.
+  or `put_completion_trigger/2`.
 
   ## Replacement policy
 

--- a/lib/minga_editor/state/modal_overlay/conflict.ex
+++ b/lib/minga_editor/state/modal_overlay/conflict.ex
@@ -38,8 +38,4 @@ defmodule MingaEditor.State.ModalOverlay.Conflict do
       opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
     }
   end
-
-  @doc "Returns the legacy `{buffer, message}` tuple shape."
-  @spec to_legacy(t()) :: {pid(), String.t()}
-  def to_legacy(%__MODULE__{buffer: buf, message: msg}), do: {buf, msg}
 end

--- a/test/minga/chaos/editor_fuzzer_test.exs
+++ b/test/minga/chaos/editor_fuzzer_test.exs
@@ -10,8 +10,8 @@ defmodule Minga.Chaos.EditorFuzzerTest do
 
   ## Running
 
-      mix test test/minga/chaos/ --include chaos
-      mix test test/minga/chaos/ --include chaos --seed 12345  # reproduce
+      mix test.heavy test/minga/chaos/
+      mix test.heavy test/minga/chaos/ --seed 12345  # reproduce
   """
 
   # Mutates Application env (:minga, :shutdown_fn); must not run concurrently with other tests.
@@ -25,6 +25,7 @@ defmodule Minga.Chaos.EditorFuzzerTest do
   alias Minga.Test.HeadlessPort
 
   @moduletag :chaos
+  @moduletag :heavy
   @moduletag timeout: 180_000
 
   # Prevent :q/:qa/:wq from calling System.stop(0) and killing the VM.
@@ -111,7 +112,14 @@ defmodule Minga.Chaos.EditorFuzzerTest do
 
     {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
 
-    %{editor: editor, buffer: buffer, port: port, width: width, height: height}
+    %{
+      editor: editor,
+      buffer: buffer,
+      port: port,
+      clipboard_table: clipboard_table,
+      width: width,
+      height: height
+    }
   end
 
   # ── Command implementations (called by PropEr) ──────────────────────────
@@ -342,21 +350,21 @@ defmodule Minga.Chaos.EditorFuzzerTest do
       # failure instead of the EXIT signal killing us.
       prev_trap = Process.flag(:trap_exit, true)
 
-      ctx = start_chaos_editor(content)
-      store_ctx(ctx)
+      try do
+        ctx = start_chaos_editor(content)
+        store_ctx(ctx)
 
-      {_history, _state, result} = run_commands(__MODULE__, cmds)
-
-      # Clean up
-      if Process.alive?(ctx.editor), do: GenServer.stop(ctx.editor, :normal, 1000)
-      if Process.alive?(ctx.port), do: GenServer.stop(ctx.port, :normal, 1000)
-
-      # Drain any EXIT messages from crashed child processes
-      drain_exit_messages()
-
-      Process.flag(:trap_exit, prev_trap)
-
-      result == :ok
+        try do
+          {_history, _state, result} = run_commands(__MODULE__, cmds)
+          result == :ok
+        after
+          cleanup_ctx(ctx)
+        end
+      after
+        Process.delete(:chaos_editor_ctx)
+        drain_exit_messages()
+        Process.flag(:trap_exit, prev_trap)
+      end
     end
   end
 
@@ -387,6 +395,30 @@ defmodule Minga.Chaos.EditorFuzzerTest do
         List.to_string(chars)
       end
     end
+  end
+
+  defp cleanup_ctx(%{
+         editor: editor,
+         buffer: buffer,
+         port: port,
+         clipboard_table: clipboard_table
+       }) do
+    stop_process(editor)
+    stop_process(port)
+    stop_process(buffer)
+    delete_table(clipboard_table)
+  end
+
+  defp stop_process(pid) when is_pid(pid) do
+    GenServer.stop(pid, :normal, 1000)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp delete_table(table) do
+    :ets.delete(table)
+  catch
+    :error, :badarg -> :ok
   end
 
   # Drain any {:EXIT, pid, reason} messages left in the mailbox from

--- a/test/minga/credo/dependency_direction_check_test.exs
+++ b/test/minga/credo/dependency_direction_check_test.exs
@@ -1,7 +1,7 @@
 Code.require_file("credo/checks/dependency_direction_check.exs")
 
 defmodule Minga.Credo.DependencyDirectionCheckTest do
-  use Credo.Test.Case, async: false
+  use Credo.Test.Case, async: true
 
   alias Minga.Credo.DependencyDirectionCheck
 

--- a/test/minga/credo/no_direct_modal_overlay_write_check_test.exs
+++ b/test/minga/credo/no_direct_modal_overlay_write_check_test.exs
@@ -1,0 +1,73 @@
+Code.require_file("credo/checks/no_direct_modal_overlay_write_check.exs")
+
+defmodule Minga.Credo.NoDirectModalOverlayWriteCheckTest do
+  use Credo.Test.Case, async: true
+
+  alias Minga.Credo.NoDirectModalOverlayWriteCheck
+
+  @moduletag :credo
+
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  defp check(source_code, filename) do
+    source_code
+    |> to_source_file(filename)
+    |> run_check(NoDirectModalOverlayWriteCheck, [])
+  end
+
+  test "flags direct modal map updates" do
+    """
+    defmodule MingaEditor.BadModalWriter do
+      def close(shell_state) do
+        %{shell_state | modal: :none}
+      end
+    end
+    """
+    |> check("lib/minga_editor/bad_modal_writer.ex")
+    |> assert_issue(fn issue ->
+      assert issue.message =~ "Direct write to `modal:`"
+      assert issue.message =~ "ModalOverlay"
+    end)
+  end
+
+  test "flags direct modal struct updates" do
+    """
+    defmodule MingaEditor.BadModalStructWriter do
+      def close(shell_state) do
+        %MingaEditor.Shell.Traditional.State{shell_state | modal: :none}
+      end
+    end
+    """
+    |> check("lib/minga_editor/bad_modal_struct_writer.ex")
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "modal:"
+    end)
+  end
+
+  test "allows the modal overlay gate" do
+    """
+    defmodule MingaEditor.State.ModalOverlay do
+      def close(state) do
+        %{state.shell_state | modal: :none}
+      end
+    end
+    """
+    |> check("lib/minga_editor/state/modal_overlay.ex")
+    |> refute_issues()
+  end
+
+  test "allows shell state owner modules" do
+    """
+    defmodule MingaEditor.Shell.Traditional.State do
+      def set_modal(shell_state, modal) do
+        %{shell_state | modal: modal}
+      end
+    end
+    """
+    |> check("lib/minga_editor/shell/traditional/state.ex")
+    |> refute_issues()
+  end
+end

--- a/test/minga_editor/input/interrupt_test.exs
+++ b/test/minga_editor/input/interrupt_test.exs
@@ -3,24 +3,33 @@ defmodule MingaEditor.Input.InterruptTest do
 
   alias Minga.Buffer.Server, as: BufferServer
   alias Minga.Editing.Completion
+  alias Minga.Mode
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.Dashboard
+  alias MingaEditor.HoverPopup
+  alias MingaEditor.Input
+  alias MingaEditor.Input.Interrupt
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
   alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
+  alias MingaEditor.State.ModalOverlay.Dashboard, as: DashboardPayload
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+  alias MingaEditor.State.ModalOverlay.Prompt, as: PromptPayload
   alias MingaEditor.State.Picker
+  alias MingaEditor.State.Prompt, as: PromptState
   alias MingaEditor.State.WhichKey
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
-  alias MingaEditor.Input
-  alias MingaEditor.Input.Interrupt
-  alias Minga.Mode
 
   @ctrl_g 7
+  @modal_variants [:picker, :prompt, :completion, :conflict, :dashboard]
 
   defp base_state(opts \\ []) do
     buf_opts = Keyword.get(opts, :buffer_opts, content: "hello\nworld")
-    {:ok, buf} = BufferServer.start_link(buf_opts)
+    buf = start_supervised!({BufferServer, buf_opts})
 
     %EditorState{
       port_manager: self(),
@@ -35,6 +44,76 @@ defmodule MingaEditor.Input.InterruptTest do
       },
       focus_stack: Input.default_stack()
     }
+  end
+
+  @spec open_modal_variant(EditorState.t(), ModalOverlay.variant()) :: EditorState.t()
+  defp open_modal_variant(state, :picker) do
+    picker = MingaEditor.UI.Picker.new(["x"])
+    ModalOverlay.open(state, :picker, PickerPayload.new(%Picker{picker: picker}))
+  end
+
+  defp open_modal_variant(state, :prompt) do
+    prompt = %PromptState{handler: __MODULE__, text: "query", cursor: 5, label: "Find"}
+    ModalOverlay.open(state, :prompt, PromptPayload.new(prompt))
+  end
+
+  defp open_modal_variant(state, :completion) do
+    completion = %Completion{items: [], trigger_position: {0, 0}}
+    ModalOverlay.open(state, :completion, CompletionPayload.new(:tab1, completion: completion))
+  end
+
+  defp open_modal_variant(state, :conflict) do
+    ModalOverlay.open(
+      state,
+      :conflict,
+      ConflictPayload.new(state.workspace.buffers.active, "/tmp/test.txt")
+    )
+  end
+
+  defp open_modal_variant(state, :dashboard) do
+    ModalOverlay.open(state, :dashboard, DashboardPayload.new(Dashboard.new_state()))
+  end
+
+  @spec dirty_interrupt_axes(EditorState.t()) :: {EditorState.t(), HoverPopup.t()}
+  defp dirty_interrupt_axes(state) do
+    hover = HoverPopup.new("hover docs", 3, 4)
+
+    mode_state = %{
+      Mode.initial_state()
+      | leader_node: %{?a => :noop},
+        prefix_node: %{?b => :noop},
+        pending: :replace,
+        count: 2
+    }
+
+    vim = %{state.workspace.editing | mode: :insert, mode_state: mode_state}
+
+    state = %{
+      state
+      | workspace: %{state.workspace | keymap_scope: :agent, editing: vim}
+    }
+
+    state =
+      state
+      |> EditorState.set_whichkey(%WhichKey{node: %{}, show: true})
+      |> EditorState.set_status("stale status")
+      |> EditorState.set_hover_popup(hover)
+      |> AgentAccess.update_agent_ui(&UIState.set_prefix(&1, :g))
+
+    {state, hover}
+  end
+
+  @spec assert_known_good_after_interrupt(EditorState.t(), HoverPopup.t()) :: true
+  defp assert_known_good_after_interrupt(state, hover) do
+    assert state.workspace.keymap_scope == :editor
+    assert state.workspace.editing.mode == :normal
+    assert state.workspace.editing.mode_state == Mode.initial_state()
+    assert state.shell_state.modal == :none
+    assert state.shell_state.whichkey.node == nil
+    assert state.shell_state.whichkey.show == false
+    assert AgentAccess.view(state).pending_prefix == nil
+    assert state.shell_state.status_msg == nil
+    assert state.shell_state.hover_popup == hover
   end
 
   describe "Ctrl-G basics" do
@@ -121,24 +200,39 @@ defmodule MingaEditor.Input.InterruptTest do
       assert new_state.workspace.editing.mode == :normal
     end
 
-    test "fresh mode_state clears prefix_node" do
+    test "fresh mode_state replaces stale non-normal mode state" do
       state = base_state()
-      mode_state = %{Mode.initial_state() | prefix_node: %{?a => :fold_toggle}}
-      vim = %{state.workspace.editing | mode: :normal, mode_state: mode_state}
+
+      vim = %{
+        state.workspace.editing
+        | mode: :normal,
+          mode_state: %Minga.Mode.CommandState{input: "w"}
+      }
+
       state = %{state | workspace: %{state.workspace | editing: vim}}
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
-      assert new_state.workspace.editing.mode_state.prefix_node == nil
+      assert new_state.workspace.editing.mode == :normal
+      assert new_state.workspace.editing.mode_state == Mode.initial_state()
     end
 
-    test "fresh mode_state clears leader_node" do
+    test "fresh mode_state clears leader sequence state" do
       state = base_state()
-      mode_state = %{Mode.initial_state() | leader_node: %{?b => {:command, :list_buffers}}}
+
+      mode_state = %{
+        Mode.initial_state()
+        | leader_node: %{?b => {:command, :list_buffers}},
+          leader_keys: ["SPC"],
+          prefix_node: %{?g => {:command, :goto_line}},
+          prefix_keys: ["g"],
+          insert_changed: true
+      }
+
       vim = %{state.workspace.editing | mode_state: mode_state}
       state = %{state | workspace: %{state.workspace | editing: vim}}
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
-      assert new_state.workspace.editing.mode_state.leader_node == nil
+      assert new_state.workspace.editing.mode_state == Mode.initial_state()
     end
 
     test "leaves :normal mode unchanged" do
@@ -202,32 +296,18 @@ defmodule MingaEditor.Input.InterruptTest do
   end
 
   describe "combined resets" do
-    test "resets everything at once" do
-      state = base_state()
-      picker = MingaEditor.UI.Picker.new(["x"])
+    for variant <- @modal_variants do
+      test "resets stale axes while dismissing #{variant} modal" do
+        variant = unquote(variant)
 
-      vim = %{state.workspace.editing | mode: :visual, mode_state: Mode.initial_state()}
+        {state, hover} =
+          base_state()
+          |> open_modal_variant(variant)
+          |> dirty_interrupt_axes()
 
-      state = %{
-        state
-        | workspace: %{state.workspace | keymap_scope: :agent, editing: vim}
-      }
-
-      # Only one modal can be active at a time under the ModalOverlay sum
-      # type, so this combined-reset case exercises picker plus the
-      # non-modal axes (scope/mode/whichkey/status). The conflict-reset
-      # and completion-close paths have focused tests above.
-      state = ModalOverlay.open(state, :picker, PickerPayload.new(%Picker{picker: picker}))
-      state = MingaEditor.State.set_whichkey(state, %WhichKey{node: %{}, show: true})
-      state = MingaEditor.State.set_status(state, "hello")
-
-      assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
-      assert new_state.workspace.keymap_scope == :editor
-      assert new_state.workspace.editing.mode == :normal
-      assert new_state.shell_state.modal == :none
-      assert new_state.shell_state.whichkey.node == nil
-      assert new_state.shell_state.whichkey.show == false
-      assert new_state.shell_state.status_msg == nil
+        assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
+        assert_known_good_after_interrupt(new_state, hover)
+      end
     end
   end
 


### PR DESCRIPTION
# TL;DR
Finalizes the ModalOverlay migration by making Ctrl-G dismiss the unified modal gate instead of enumerating modal variants, and adds Credo enforcement so future modal writes stay behind the gate.

Closes #1427

## Context
This is the final cleanup step for the ModalOverlay migration. The previous variant migrations moved picker, prompt, completion, conflict, and dashboard state behind `state.shell_state.modal`; this PR removes the remaining interrupt-specific variant handling and makes direct `modal:` writes fail Credo outside the owning modules.

## Changes
- Collapses `MingaEditor.Input.Interrupt.reset_to_known_good/1` to the expected reset sequence: scope, mode, `ModalOverlay.dismiss/1`, which-key, agent prefix, and status.
- Removes the remaining legacy conflict payload adapter and updates ModalOverlay docs to reflect that there is no dual-write path or divergence assertion left.
- Adds `Minga.Credo.NoDirectModalOverlayWriteCheck` and wires it into `.credo.exs`.
- Adds Credo check coverage for map updates, struct updates, and allowlisted owner modules.
- Expands interrupt coverage with a parameterized reset test across all five modal variants, including stale scope, stale mode state, which-key, agent prefix, status, and hover preservation.
- Hardens Ctrl-G against stale normal-mode state, including non-normal mode structs and leftover leader/prefix key sequences.
- Marks the full chaos fuzzer as `:heavy`, documents the `mix test.heavy` entry point, and tightens per-case cleanup for editor, port, buffer, ETS, process dictionary state, and trapped exits.
- Runs custom Credo check tests asynchronously where no global resource requires serialization.

## Verification
- `mix test.llm test/minga/credo/no_direct_modal_overlay_write_check_test.exs test/minga_editor/state/modal_overlay_test.exs test/minga_editor/input/interrupt_test.exs`
- `make lint`
- `mix test.llm`
- Second follow-up reviewer gate: PASS

## Acceptance Criteria Addressed
- `Input.Interrupt.reset_to_known_good/1` collapses to the single reset sequence ✅
- ModalOverlay dual-write paths are removed ✅
- Dev/test divergence assertion is removed ✅
- `Minga.Credo.NoDirectModalOverlayWriteCheck` flags direct `modal:` writes outside the allowlist ✅
- `.credo.exs` includes the new check and Credo passes ✅
- Interrupt tests exercise the consolidated reset path across all five modal variants plus stale axes ✅


