### PR TITLE
Route mouse input through focus tree

### DIFF
--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -680,7 +680,7 @@ defmodule MingaEditor.Commands.Movement do
   defp maybe_repin_agent_chat(state) do
     case EditorState.active_window_struct(state) do
       %Window{id: win_id, content: {:agent_chat, _}} ->
-        EditorState.update_window(state, win_id, fn w -> %{w | pinned: true} end)
+        EditorState.update_window(state, win_id, &Window.set_pinned(&1, true))
 
       _ ->
         state

--- a/lib/minga_editor/completion_ui.ex
+++ b/lib/minga_editor/completion_ui.ex
@@ -53,29 +53,26 @@ defmodule MingaEditor.CompletionUI do
     end
   end
 
+  @doc "Returns the screen rect for the visible completion menu, or nil when it is empty."
+  @spec menu_rect(Completion.t() | nil, render_opts()) :: MingaEditor.Layout.rect() | nil
+  def menu_rect(nil, _opts), do: nil
+
+  def menu_rect(%Completion{} = completion, opts) do
+    {visible, _selected_offset} = Completion.visible_items(completion)
+
+    case menu_geometry(visible, opts) do
+      nil -> nil
+      %{row: row, col: col, width: width, height: height} -> {row, col, width, height}
+    end
+  end
+
   @spec do_render([Completion.item()], non_neg_integer(), render_opts(), map()) ::
           [DisplayList.draw()]
   defp do_render(items, selected_offset, opts, theme) do
-    item_count = min(length(items), @max_rows)
+    %{row: start_row, col: start_col, width: popup_width, height: item_count} =
+      menu_geometry(items, opts)
+
     visible_items = Enum.take(items, item_count)
-
-    # Calculate popup width based on longest label
-    label_widths = Enum.map(visible_items, fn item -> String.length(item.label) + 4 end)
-    popup_width = label_widths |> Enum.max() |> max(@min_width) |> min(@max_width)
-    popup_width = min(popup_width, opts.viewport_cols - opts.cursor_col)
-
-    # Position: below cursor if room, above if not
-    space_below = opts.viewport_rows - opts.cursor_row - 2
-    space_above = opts.cursor_row
-
-    {start_row, _direction} =
-      cond do
-        space_below >= item_count -> {opts.cursor_row + 1, :below}
-        space_above >= item_count -> {opts.cursor_row - item_count, :above}
-        true -> {opts.cursor_row + 1, :below}
-      end
-
-    start_col = min(opts.cursor_col, max(0, opts.viewport_cols - popup_width))
 
     # Theme colors (reuse picker colors)
     pc = theme.picker
@@ -104,6 +101,50 @@ defmodule MingaEditor.CompletionUI do
         []
       end
     end)
+  end
+
+  @spec menu_geometry([Completion.item()], render_opts()) ::
+          %{
+            row: non_neg_integer(),
+            col: non_neg_integer(),
+            width: pos_integer(),
+            height: pos_integer()
+          }
+          | nil
+  defp menu_geometry([], _opts), do: nil
+
+  defp menu_geometry(items, opts) do
+    item_count = min(length(items), @max_rows)
+    visible_items = Enum.take(items, item_count)
+    label_widths = Enum.map(visible_items, fn item -> String.length(item.label) + 4 end)
+    popup_width = label_widths |> Enum.max() |> max(@min_width) |> min(@max_width)
+    popup_width = min(popup_width, max(opts.viewport_cols - opts.cursor_col, 1))
+    start_row = menu_start_row(opts.cursor_row, opts.viewport_rows, item_count)
+    start_col = min(opts.cursor_col, max(0, opts.viewport_cols - popup_width))
+    %{row: start_row, col: start_col, width: popup_width, height: item_count}
+  end
+
+  @spec menu_start_row(non_neg_integer(), non_neg_integer(), pos_integer()) :: non_neg_integer()
+  defp menu_start_row(cursor_row, viewport_rows, item_count) do
+    space_below = viewport_rows - cursor_row - 2
+    space_above = cursor_row
+    choose_menu_start_row(cursor_row, item_count, space_below, space_above)
+  end
+
+  @spec choose_menu_start_row(non_neg_integer(), pos_integer(), integer(), non_neg_integer()) ::
+          non_neg_integer()
+  defp choose_menu_start_row(cursor_row, item_count, space_below, _space_above)
+       when space_below >= item_count do
+    cursor_row + 1
+  end
+
+  defp choose_menu_start_row(cursor_row, item_count, _space_below, space_above)
+       when space_above >= item_count do
+    cursor_row - item_count
+  end
+
+  defp choose_menu_start_row(cursor_row, _item_count, _space_below, _space_above) do
+    cursor_row + 1
   end
 
   @spec render_completion_item(

--- a/lib/minga_editor/focus_tree.ex
+++ b/lib/minga_editor/focus_tree.ex
@@ -1,73 +1,171 @@
 defmodule MingaEditor.FocusTree do
   @moduledoc """
-  Tree of visible regions, built from the per-frame `Layout`.
+  Tree of visible regions, built from the per-frame `Layout` plus active overlays.
 
-  Mouse routing today is a flat hit-test stack: each input handler walks
-  the layout rects asking "am I responsible?" and the order of checks
-  encodes z-order implicitly. This module replaces that pattern with a
-  single tree built once per frame; `hit_test/3` walks it top-down to
-  find the deepest matching node, returning the node (and therefore its
-  handler module).
+  Mouse routing uses this tree instead of asking every handler to re-check screen coordinates. Hit-testing finds the deepest visible node at a position, and the router dispatches to that node's handler before bubbling to ancestors when a handler returns `{:passthrough, state}`.
 
-  ## Tree shape
-
-      viewport
-      ├─ file_tree (when present)
-      ├─ tab_bar (when present)
-      ├─ editor_area
-      │  ├─ window 1
-      │  │  ├─ gutter
-      │  │  ├─ buffer_content
-      │  │  └─ modeline
-      │  └─ window 2 (split, if any)
-      ├─ agent_panel (when present)
-      ├─ bottom_panel (when present)
-      ├─ status_bar (when present)
-      └─ minibuffer
-
-  Modal overlays and floats are inserted at the end of the children
-  list of the relevant parent node so the z-order resolves correctly:
-  the last child whose rect contains the click wins.
-
-  ## Status
-
-  This PR introduces the data structure, the basic builder, and the
-  `hit_test/3` API. Migration of the ad-hoc `inside_*?/2` predicates
-  in `Input.{Picker, Completion, AgentMouse, FileTreeHandler}` to use
-  the tree is staged as follow-up work — the existing predicates keep
-  working because the tree is purely additive at this layer.
+  Children are stored in rendered z-order from back to front. Hit-tests walk children in reverse order, so later siblings win when regions overlap.
   """
 
+  alias Minga.Buffer
+  alias Minga.Editing.Completion
+  alias MingaEditor.CompletionUI
   alias MingaEditor.FocusTree.Node, as: TreeNode
+  alias MingaEditor.Input
   alias MingaEditor.Layout
+  alias MingaEditor.Renderer.Gutter
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.UI.Picker, as: PickerData
+  alias MingaEditor.Viewport
+  alias MingaEditor.Window.Content
 
   @typedoc "Built focus tree, rooted at the viewport."
   @type t :: TreeNode.t()
 
-  @doc """
-  Builds a focus tree from a `Layout`. Pure; safe to call any time.
+  @typedoc "Mouse route ordered from deepest target to root for bubbling."
+  @type path :: [TreeNode.t()]
 
-  Modal overlays, hover popups, and floats are added by the caller via
-  `with_overlay/3` after construction so this function stays a pure
-  layout-to-tree projection without coupling to shell state.
-  """
+  @doc "Returns the cached focus tree from state, or builds one from the current state."
+  @spec get(map()) :: t()
+  def get(%{focus_tree: %TreeNode{} = cached}), do: cached
+  def get(state), do: from_state(state)
+
+  @doc "Builds a focus tree from editor or render-pipeline state."
+  @spec from_state(map()) :: t()
+  def from_state(state) do
+    layout = Layout.get(state)
+
+    layout
+    |> build_base(window_map(state), Input.editing_dispatch_handler(state))
+    |> add_modal_overlays(state, layout)
+    |> link_tree()
+  end
+
+  @doc "Builds a focus tree from a `Layout`. Pure; safe to call any time."
   @spec from_layout(Layout.t()) :: t()
   def from_layout(%Layout{} = layout) do
+    layout
+    |> build_base(%{}, Input.ModeFSM)
+    |> link_tree()
+  end
+
+  @doc "Adds a modal or float overlay node to the root in front of existing regions."
+  @spec with_overlay(t(), TreeNode.content_type(), TreeNode.rect(), keyword()) :: t()
+  def with_overlay(%TreeNode{children: children} = root, content_type, rect, opts \\ []) do
+    overlay = TreeNode.new(content_type, rect, opts)
+    %{root | children: children ++ [overlay]} |> link_tree()
+  end
+
+  @doc "Hit-tests `(row, col)` and returns the deepest node whose rect contains the point."
+  @spec hit_test(t(), integer(), integer()) :: TreeNode.t() | nil
+  def hit_test(%TreeNode{} = root, row, col) do
+    root
+    |> hit_path(row, col)
+    |> List.first()
+  end
+
+  @doc "Returns the bubble path ordered from deepest node to root."
+  @spec hit_path(t(), integer(), integer()) :: path()
+  def hit_path(%TreeNode{} = root, row, col) do
+    do_hit_path(root, row, col)
+  end
+
+  @doc "Returns the path starting at the deepest scrollable node under `(row, col)`."
+  @spec scroll_path(t(), integer(), integer()) :: path()
+  def scroll_path(%TreeNode{} = root, row, col) do
+    path = hit_path(root, row, col)
+
+    case Enum.find_index(path, & &1.scrollable?) do
+      nil -> []
+      index -> Enum.drop(path, index)
+    end
+  end
+
+  @doc "Links parent and sibling references throughout a tree."
+  @spec link_tree(t()) :: t()
+  def link_tree(%TreeNode{} = root) do
+    link_node(%{root | parent: nil, previous_sibling: nil, next_sibling: nil}, nil, nil, nil)
+  end
+
+  @spec do_hit_path(TreeNode.t(), integer(), integer()) :: path()
+  defp do_hit_path(%TreeNode{} = node, row, col) do
+    if TreeNode.contains?(node, row, col) do
+      node.children
+      |> deepest_child_path(row, col)
+      |> append_node_to_path(node)
+    else
+      []
+    end
+  end
+
+  @spec deepest_child_path([TreeNode.t()], integer(), integer()) :: path() | nil
+  defp deepest_child_path(children, row, col) do
+    children
+    |> Enum.reverse()
+    |> Enum.find_value(fn child ->
+      case do_hit_path(child, row, col) do
+        [] -> nil
+        path -> path
+      end
+    end)
+  end
+
+  @spec append_node_to_path(path() | nil, TreeNode.t()) :: path()
+  defp append_node_to_path(nil, node), do: [node]
+  defp append_node_to_path(path, node), do: path ++ [node]
+
+  @spec link_node(TreeNode.t(), TreeNode.id() | nil, TreeNode.id() | nil, TreeNode.id() | nil) ::
+          TreeNode.t()
+  defp link_node(%TreeNode{} = node, parent, previous_sibling, next_sibling) do
+    linked_children = link_children(node.children, node.id)
+
+    %{
+      node
+      | parent: parent,
+        previous_sibling: previous_sibling,
+        next_sibling: next_sibling,
+        children: linked_children
+    }
+  end
+
+  @spec link_children([TreeNode.t()], TreeNode.id()) :: [TreeNode.t()]
+  defp link_children(children, parent_id) do
+    ids = Enum.map(children, & &1.id)
+
+    children
+    |> Enum.with_index()
+    |> Enum.map(fn {child, index} ->
+      previous_id = sibling_id(ids, index - 1)
+      next_id = sibling_id(ids, index + 1)
+      link_node(child, parent_id, previous_id, next_id)
+    end)
+  end
+
+  @spec sibling_id([TreeNode.id()], integer()) :: TreeNode.id() | nil
+  defp sibling_id(ids, index) when index >= 0, do: Enum.at(ids, index)
+  defp sibling_id(_ids, _index), do: nil
+
+  # ── Builders ───────────────────────────────────────────────────────────────
+
+  @spec window_map(map()) :: map()
+  defp window_map(%{workspace: %{windows: %{map: map}}}) when is_map(map), do: map
+  defp window_map(_state), do: %{}
+
+  @spec build_base(Layout.t(), map(), module()) :: t()
+  defp build_base(%Layout{} = layout, window_map, bottom_handler) do
     {tr, tc, tw, th} = layout.terminal
 
-    # Children are listed in z-order from bottom (background) to top (overlays).
-    # hit_test/3 reverses this list to give later children priority — that's
-    # how file_tree paints over the editor_area at the same column range.
     children =
       []
-      |> maybe_add(layout.tab_bar, &TreeNode.new(:tab_bar, &1))
-      |> Kernel.++([editor_area_node(layout)])
-      |> maybe_add(layout.file_tree, &TreeNode.new(:file_tree, &1))
-      |> maybe_add(layout.agent_panel, &TreeNode.new(:agent_panel, &1))
-      |> maybe_add(layout.status_bar, &TreeNode.new(:status_bar, &1))
-      |> Kernel.++([TreeNode.new(:minibuffer, layout.minibuffer)])
+      |> maybe_add(layout.tab_bar, &TreeNode.new(:tab_bar, &1, handler: bottom_handler))
+      |> Kernel.++([editor_area_node(layout, window_map, bottom_handler)])
+      |> maybe_add(layout.file_tree, &file_tree_node/1)
+      |> maybe_add(layout.agent_panel, &agent_panel_node/1)
+      |> maybe_add(layout.status_bar, &TreeNode.new(:status_bar, &1, handler: bottom_handler))
+      |> Kernel.++([TreeNode.new(:minibuffer, layout.minibuffer, handler: bottom_handler)])
 
     %TreeNode{
+      id: :viewport,
       content_type: :viewport,
       rect: {tr, tc, tw, th},
       handler: nil,
@@ -77,115 +175,253 @@ defmodule MingaEditor.FocusTree do
     }
   end
 
-  @doc """
-  Adds a modal/float overlay node to the tree. Inserted as the last
-  child of the root so hit-tests resolve to it before the underlying
-  editor regions.
-  """
-  @spec with_overlay(t(), TreeNode.content_type(), TreeNode.rect(), keyword()) :: t()
-  def with_overlay(%TreeNode{children: children} = root, content_type, rect, opts \\ []) do
-    overlay = TreeNode.new(content_type, rect, opts)
-    %{root | children: children ++ [overlay]}
+  @spec file_tree_node(Layout.rect()) :: TreeNode.t()
+  defp file_tree_node(rect) do
+    TreeNode.new(:file_tree, rect,
+      handler: Input.FileTreeHandler,
+      scrollable?: true,
+      focusable?: true
+    )
   end
 
-  @doc """
-  Hit-tests `(row, col)` against the tree. Returns the deepest node
-  whose rect contains the point, or `nil` if no node matches.
-
-  Children are searched in reverse order so later children (rendered
-  on top) take precedence over earlier siblings.
-  """
-  @spec hit_test(t(), non_neg_integer(), non_neg_integer()) :: TreeNode.t() | nil
-  def hit_test(%TreeNode{} = root, row, col) do
-    if TreeNode.contains?(root, row, col) do
-      child_hit =
-        root.children
-        |> Enum.reverse()
-        |> Enum.find_value(fn child -> hit_test(child, row, col) end)
-
-      child_hit || root
-    else
-      nil
-    end
+  @spec agent_panel_node(Layout.rect()) :: TreeNode.t()
+  defp agent_panel_node(rect) do
+    TreeNode.new(:agent_panel, rect,
+      handler: Input.AgentMouse,
+      scrollable?: true,
+      focusable?: true
+    )
   end
 
-  @doc """
-  Walks from the deepest hit upward through the tree, yielding each
-  ancestor node. Useful for "bubble" dispatch — try the deepest
-  handler first, then bubble up if it returns `:passthrough`.
-
-  Returns a list of nodes ordered from deepest to root. The flat
-  hit-test stack (today's pattern) is equivalent to a one-element
-  list when the deepest match is the only candidate.
-  """
-  @spec hit_path(t(), non_neg_integer(), non_neg_integer()) :: [TreeNode.t()]
-  def hit_path(%TreeNode{} = root, row, col) do
-    hit_path(root, row, col, [])
-    |> Enum.reverse()
-  end
-
-  defp hit_path(%TreeNode{} = node, row, col, acc) do
-    if TreeNode.contains?(node, row, col) do
-      new_acc = [node | acc]
-      deepest_child_path(node.children, row, col, new_acc) || new_acc
-    else
-      acc
-    end
-  end
-
-  # Walks children in reverse z-order and returns the first child path that
-  # extends beyond `acc` (i.e., a child whose subtree contained the point).
-  # Returns `nil` when no child contained the point so the caller falls back
-  # to its own `acc`.
-  @spec deepest_child_path([TreeNode.t()], non_neg_integer(), non_neg_integer(), [TreeNode.t()]) ::
-          [TreeNode.t()] | nil
-  defp deepest_child_path(children, row, col, acc) do
-    children
-    |> Enum.reverse()
-    |> Enum.find_value(fn child ->
-      case hit_path(child, row, col, acc) do
-        ^acc -> nil
-        deeper -> deeper
-      end
-    end)
-  end
-
-  # ── Builders ───────────────────────────────────────────────────────────────
-
-  defp editor_area_node(%Layout{editor_area: rect, window_layouts: windows}) do
+  @spec editor_area_node(Layout.t(), map(), module()) :: TreeNode.t()
+  defp editor_area_node(
+         %Layout{editor_area: rect, window_layouts: windows},
+         window_map,
+         bottom_handler
+       ) do
     children =
       windows
       |> Enum.sort_by(fn {id, _} -> id end)
-      |> Enum.map(fn {win_id, wl} -> window_node(win_id, wl) end)
+      |> Enum.map(fn {win_id, wl} ->
+        window_node(win_id, wl, Map.get(window_map, win_id), bottom_handler)
+      end)
 
-    TreeNode.new(:editor_area, rect, children: children)
+    TreeNode.new(:editor_area, rect, handler: bottom_handler, children: children)
   end
 
-  defp window_node(win_id, win_layout) do
+  @spec window_node(term(), Layout.window_layout(), term(), module()) :: TreeNode.t()
+  defp window_node(win_id, win_layout, window, bottom_handler) do
+    agent_chat? = agent_chat_window?(window)
+    window_type = if agent_chat?, do: :agent_chat_window, else: :window
+    content_type = if agent_chat?, do: :agent_chat_content, else: :buffer_content
+    content_handler = if agent_chat?, do: Input.AgentMouse, else: bottom_handler
+
     children =
       [
-        TreeNode.new(:buffer_content, win_layout.content,
-          handler: nil,
+        TreeNode.new(content_type, win_layout.content,
+          handler: content_handler,
           scrollable?: true,
           focusable?: true,
           ref: win_id
         )
       ]
-      |> maybe_modeline(win_layout)
+      |> maybe_modeline(win_layout, win_id)
 
-    TreeNode.new(:window, win_layout.total,
+    TreeNode.new(window_type, win_layout.total,
       ref: win_id,
       focusable?: true,
+      handler: bottom_handler,
       children: children
     )
   end
 
-  defp maybe_modeline(children, %{modeline: {_, _, _, 0}}), do: children
+  @spec agent_chat_window?(term()) :: boolean()
+  defp agent_chat_window?(%{content: content}), do: Content.agent_chat?(content)
+  defp agent_chat_window?(_window), do: false
 
-  defp maybe_modeline(children, %{modeline: rect}) do
-    children ++ [TreeNode.new(:modeline, rect)]
+  @spec maybe_modeline([TreeNode.t()], Layout.window_layout(), term()) :: [TreeNode.t()]
+  defp maybe_modeline(children, %{modeline: {_, _, _, 0}}, _win_id), do: children
+
+  defp maybe_modeline(children, %{modeline: rect}, win_id) do
+    children ++ [TreeNode.new(:modeline, rect, handler: Input.ModeFSM, ref: win_id)]
   end
 
+  @spec maybe_add([TreeNode.t()], Layout.rect() | nil, (Layout.rect() -> TreeNode.t())) ::
+          [TreeNode.t()]
   defp maybe_add(children, nil, _build), do: children
   defp maybe_add(children, rect, build), do: children ++ [build.(rect)]
+
+  # ── Overlay builders ──────────────────────────────────────────────────────
+
+  @spec add_modal_overlays(t(), map(), Layout.t()) :: t()
+  defp add_modal_overlays(
+         %TreeNode{} = root,
+         %{shell_state: %{modal: {:picker, payload}}},
+         layout
+       ) do
+    add_picker_overlay(root, payload.picker_ui, layout)
+  end
+
+  defp add_modal_overlays(%TreeNode{} = root, state, layout) do
+    case ModalOverlay.completion(state) do
+      %Completion{} = completion -> add_completion_overlay(root, completion, state, layout)
+      _ -> root
+    end
+  end
+
+  @spec add_picker_overlay(t(), map(), Layout.t()) :: t()
+  defp add_picker_overlay(%TreeNode{} = root, %{picker: %PickerData{}, layout: :centered}, layout) do
+    backdrop =
+      TreeNode.new(:picker_backdrop, layout.terminal,
+        handler: Input.Picker,
+        scrollable?: true,
+        children: [
+          TreeNode.new(:picker, centered_picker_rect(layout),
+            handler: Input.Picker,
+            scrollable?: true,
+            focusable?: true
+          )
+        ]
+      )
+
+    append_root_child(root, backdrop)
+  end
+
+  defp add_picker_overlay(%TreeNode{} = root, %{picker: %PickerData{} = picker}, layout) do
+    backdrop =
+      TreeNode.new(:picker_backdrop, layout.terminal,
+        handler: Input.Picker,
+        scrollable?: true,
+        children: [
+          TreeNode.new(:picker, bottom_picker_rect(layout, picker),
+            handler: Input.Picker,
+            scrollable?: true,
+            focusable?: true
+          )
+        ]
+      )
+
+    append_root_child(root, backdrop)
+  end
+
+  defp add_picker_overlay(%TreeNode{} = root, _picker_state, _layout), do: root
+
+  @spec add_completion_overlay(t(), Completion.t(), map(), Layout.t()) :: t()
+  defp add_completion_overlay(%TreeNode{} = root, completion, state, layout) do
+    case CompletionUI.menu_rect(completion, completion_render_opts(state, layout)) do
+      nil ->
+        root
+
+      rect ->
+        backdrop =
+          TreeNode.new(:completion_backdrop, layout.terminal,
+            handler: Input.Completion,
+            scrollable?: true,
+            children: [
+              TreeNode.new(:completion_menu, rect,
+                handler: Input.Completion,
+                scrollable?: true,
+                focusable?: true
+              )
+            ]
+          )
+
+        append_root_child(root, backdrop)
+    end
+  end
+
+  @spec append_root_child(t(), TreeNode.t()) :: t()
+  defp append_root_child(%TreeNode{children: children} = root, child) do
+    %{root | children: children ++ [child]}
+  end
+
+  @spec centered_picker_rect(Layout.t()) :: Layout.rect()
+  defp centered_picker_rect(%Layout{terminal: {_row, _col, cols, rows}}) do
+    width = max(div(cols * 60, 100), 1)
+    height = max(div(rows * 70, 100), 1)
+    row = max(div(rows - height, 2), 0)
+    col = max(div(cols - width, 2), 0)
+    {row, col, width, height}
+  end
+
+  @spec bottom_picker_rect(Layout.t(), PickerData.t()) :: Layout.rect()
+  defp bottom_picker_rect(%Layout{terminal: {_row, _col, cols, rows}}, picker) do
+    {visible, _selected_offset} = PickerData.visible_items(picker)
+    item_count = length(visible)
+    prompt_row = rows - 1
+    separator_row = prompt_row - item_count - 1
+    first_row = max(separator_row, 0)
+    height = max(prompt_row - first_row + 1, 1)
+    {first_row, 0, cols, height}
+  end
+
+  @spec completion_render_opts(map(), Layout.t()) :: CompletionUI.render_opts()
+  defp completion_render_opts(state, layout) do
+    {cursor_row, cursor_col} = cursor_screen_pos(state, layout)
+
+    %{
+      cursor_row: cursor_row,
+      cursor_col: cursor_col,
+      viewport_rows: state.terminal_viewport.rows,
+      viewport_cols: state.terminal_viewport.cols
+    }
+  end
+
+  @spec cursor_screen_pos(map(), Layout.t()) :: {non_neg_integer(), non_neg_integer()}
+  defp cursor_screen_pos(%{workspace: %{buffers: %{active: buf}}} = state, layout)
+       when is_pid(buf) do
+    {line, col} = Buffer.cursor(buf)
+    total_lines = Buffer.line_count(buf)
+    line_number_style = Buffer.get_option(buf, :line_numbers)
+    number_width = if line_number_style == :none, do: 0, else: Viewport.gutter_width(total_lines)
+    gutter_width = Gutter.total_width(number_width)
+
+    state
+    |> cursor_origin(layout)
+    |> cursor_screen_pos_from_origin(line, col, gutter_width)
+  catch
+    :exit, _ -> {0, 0}
+  end
+
+  defp cursor_screen_pos(_state, _layout), do: {0, 0}
+
+  @spec cursor_origin(map(), Layout.t()) ::
+          {integer(), integer(), non_neg_integer(), non_neg_integer()}
+  defp cursor_origin(state, layout) do
+    with %{content: {row, col, _width, _height}} <- active_window_layout(layout, state),
+         %{viewport: viewport} <- active_window(state) do
+      {row, col, viewport.top, viewport.left}
+    else
+      _ -> {0, 0, state.terminal_viewport.top, state.terminal_viewport.left}
+    end
+  end
+
+  @spec cursor_screen_pos_from_origin(
+          {integer(), integer(), non_neg_integer(), non_neg_integer()},
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: {non_neg_integer(), non_neg_integer()}
+  defp cursor_screen_pos_from_origin({row, col, top, left}, line, cursor_col, gutter_width) do
+    screen_row = row + line - top
+    screen_col = col + cursor_col + gutter_width - left
+    {max(screen_row, 0), max(screen_col, 0)}
+  end
+
+  @spec active_window_layout(Layout.t(), map()) :: Layout.window_layout() | nil
+  defp active_window_layout(%Layout{window_layouts: layouts}, %{
+         workspace: %{windows: %{active: active}}
+       }) do
+    Map.get(layouts, active)
+  end
+
+  defp active_window_layout(_layout, _state), do: nil
+
+  @spec active_window(map()) :: term() | nil
+  defp active_window(%{workspace: %{windows: %{map: windows, active: active}}})
+       when is_map(windows) do
+    Map.get(windows, active)
+  end
+
+  defp active_window(_state), do: nil
 end

--- a/lib/minga_editor/focus_tree/node.ex
+++ b/lib/minga_editor/focus_tree/node.ex
@@ -1,23 +1,19 @@
 defmodule MingaEditor.FocusTree.Node do
   @moduledoc """
-  A node in the focus tree: a single visible region.
+  A node in the focus tree: one visible region that can receive mouse routing.
 
-  Each node owns a rect, a content type tag, an optional input handler
-  module, and a list of child nodes (rendered z-order: later children
-  paint above earlier ones, so hit-tests prefer later children).
+  Each node owns a rect, a content type tag, optional input handler module, and children in rendered z-order. Later children paint above earlier children, so hit-tests prefer later children. The `id`, `parent`, `previous_sibling`, and `next_sibling` fields are stable references inside the tree, not parent structs. That keeps the tree acyclic while still letting routing and tests reason about hierarchy.
 
-  See `MingaEditor.FocusTree` for the tree shape and traversal API.
+  See `MingaEditor.FocusTree` for tree construction and traversal.
   """
 
   @typedoc "Pixel/cell rect. Same shape as `MingaEditor.Layout.rect/0`."
   @type rect :: {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
 
-  @typedoc """
-  Tag identifying what the node represents. Adding a new content type
-  is the integration point when introducing a new region (e.g.,
-  `:bottom_panel`, `:hover_popup`). The mouse router pattern-matches
-  on this tag to pick a handler.
-  """
+  @typedoc "Stable node reference inside a focus tree."
+  @type id :: term()
+
+  @typedoc "Tag identifying what the node represents."
   @type content_type ::
           :viewport
           | :tab_bar
@@ -27,10 +23,17 @@ defmodule MingaEditor.FocusTree.Node do
           | :gutter
           | :buffer_content
           | :modeline
+          | :status_bar
           | :agent_panel
+          | :agent_chat_window
+          | :agent_chat_content
           | :bottom_panel
           | :minibuffer
           | :modal_overlay
+          | :picker_backdrop
+          | :picker
+          | :completion_backdrop
+          | :completion_menu
           | :hover_popup
           | :signature_help
           | :which_key
@@ -38,41 +41,61 @@ defmodule MingaEditor.FocusTree.Node do
 
   @typedoc "A node in the focus tree."
   @type t :: %__MODULE__{
+          id: id(),
           content_type: content_type(),
           rect: rect(),
           handler: module() | nil,
           scrollable?: boolean(),
           focusable?: boolean(),
           ref: term(),
+          parent: id() | nil,
+          previous_sibling: id() | nil,
+          next_sibling: id() | nil,
           children: [t()]
         }
 
-  @enforce_keys [:content_type, :rect]
-  defstruct content_type: nil,
+  @enforce_keys [:id, :content_type, :rect]
+  defstruct id: nil,
+            content_type: nil,
             rect: nil,
             handler: nil,
             scrollable?: false,
             focusable?: false,
             ref: nil,
+            parent: nil,
+            previous_sibling: nil,
+            next_sibling: nil,
             children: []
 
   @doc "Constructs a node with the given content type and rect."
   @spec new(content_type(), rect(), keyword()) :: t()
   def new(content_type, rect, opts \\ []) do
+    ref = Keyword.get(opts, :ref)
+
     %__MODULE__{
+      id: Keyword.get(opts, :id, default_id(content_type, ref)),
       content_type: content_type,
       rect: rect,
       handler: Keyword.get(opts, :handler),
       scrollable?: Keyword.get(opts, :scrollable?, false),
       focusable?: Keyword.get(opts, :focusable?, false),
-      ref: Keyword.get(opts, :ref),
+      ref: ref,
+      parent: Keyword.get(opts, :parent),
+      previous_sibling: Keyword.get(opts, :previous_sibling),
+      next_sibling: Keyword.get(opts, :next_sibling),
       children: Keyword.get(opts, :children, [])
     }
   end
 
-  @doc "Returns true when `(row, col)` is inside the node's rect."
-  @spec contains?(t(), non_neg_integer(), non_neg_integer()) :: boolean()
+  @doc "Returns true when `(row, col)` is inside the node's half-open rect."
+  @spec contains?(t(), integer(), integer()) :: boolean()
   def contains?(%__MODULE__{rect: {r0, c0, w, h}}, row, col) do
     row >= r0 and row < r0 + h and col >= c0 and col < c0 + w
   end
+
+  @spec default_id(content_type(), term()) :: id()
+  defp default_id(content_type, nil) when is_atom(content_type), do: content_type
+  defp default_id(content_type, ref) when is_atom(content_type), do: {content_type, ref}
+  defp default_id({:custom, tag}, nil), do: {:custom, tag}
+  defp default_id({:custom, tag}, ref), do: {{:custom, tag}, ref}
 end

--- a/lib/minga_editor/input/agent_mouse.ex
+++ b/lib/minga_editor/input/agent_mouse.ex
@@ -28,11 +28,12 @@ defmodule MingaEditor.Input.AgentMouse do
   alias MingaEditor.Agent.View.PromptRenderer
   alias MingaEditor.Agent.ViewContext
   alias Minga.Config
+  alias MingaEditor.FocusTree
+  alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
-  alias MingaEditor.Window.Content
-  alias MingaEditor.WindowTree
+  alias MingaEditor.Window
 
   # Mouse event fields grouped for dispatch without exceeding max arity.
   @typep mouse_event :: %{
@@ -61,63 +62,70 @@ defmodule MingaEditor.Input.AgentMouse do
         ) :: MingaEditor.Input.Handler.result()
 
   def handle_mouse(state, row, col, button, mods, event_type, click_count) do
-    layout = Layout.get(state)
-    evt = %{button: button, mods: mods, event_type: event_type, click_count: click_count}
+    case routed_agent_node(state, row, col, button) do
+      %FocusNode{} = node ->
+        handle_mouse_at_node(state, node, row, col, button, mods, event_type, click_count)
 
-    case identify_agent_region(state, layout, row, col) do
-      {:agent_chat_window, win_id} ->
-        dispatch_window(state, layout, win_id, row, col, evt)
-
-      {:agent_panel, panel_rect} ->
-        {:handled, dispatch_panel(state, panel_rect, row, col, evt)}
-
-      :not_agent ->
+      nil ->
         {:passthrough, state}
     end
   end
 
-  # ── Region identification ──────────────────────────────────────────────────
-
-  @spec identify_agent_region(EditorState.t(), Layout.t(), integer(), integer()) ::
-          {:agent_chat_window, pos_integer()}
-          | {:agent_panel, Layout.rect()}
-          | :not_agent
-
-  defp identify_agent_region(state, layout, row, col) do
-    case find_agent_chat_window_at(state, layout, row, col) do
-      {:ok, win_id} ->
-        {:agent_chat_window, win_id}
-
-      :not_found ->
-        case layout.agent_panel do
-          {pr, pc, pw, ph} when row >= pr and row < pr + ph and col >= pc and col < pc + pw ->
-            {:agent_panel, {pr, pc, pw, ph}}
-
-          _ ->
-            :not_agent
-        end
-    end
+  @impl true
+  @spec handle_mouse_at_node(
+          state(),
+          FocusNode.t(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: MingaEditor.Input.Handler.result()
+  def handle_mouse_at_node(
+        state,
+        %FocusNode{content_type: :agent_panel, rect: panel_rect},
+        row,
+        col,
+        button,
+        mods,
+        event_type,
+        click_count
+      ) do
+    evt = %{button: button, mods: mods, event_type: event_type, click_count: click_count}
+    {:handled, dispatch_panel(state, panel_rect, row, col, evt)}
   end
 
-  @spec find_agent_chat_window_at(EditorState.t(), Layout.t(), integer(), integer()) ::
-          {:ok, pos_integer()} | :not_found
-  defp find_agent_chat_window_at(%{workspace: %{windows: %{tree: nil}}}, _layout, _row, _col),
-    do: :not_found
+  def handle_mouse_at_node(
+        state,
+        %FocusNode{content_type: :agent_chat_content, ref: win_id},
+        row,
+        col,
+        button,
+        mods,
+        event_type,
+        click_count
+      )
+      when is_integer(win_id) and win_id > 0 do
+    layout = Layout.get(state)
+    evt = %{button: button, mods: mods, event_type: event_type, click_count: click_count}
+    dispatch_window(state, layout, win_id, row, col, evt)
+  end
 
-  defp find_agent_chat_window_at(state, layout, row, col) do
-    case WindowTree.window_at(state.workspace.windows.tree, layout.editor_area, row, col) do
-      {:ok, win_id, _rect} ->
-        window = Map.get(state.workspace.windows.map, win_id)
+  def handle_mouse_at_node(state, _node, _row, _col, _button, _mods, _event_type, _click_count) do
+    {:passthrough, state}
+  end
 
-        if window != nil and Content.agent_chat?(window.content) do
-          {:ok, win_id}
-        else
-          :not_found
-        end
+  @spec routed_agent_node(EditorState.t(), integer(), integer(), atom()) :: FocusNode.t() | nil
+  defp routed_agent_node(state, row, col, button) do
+    tree = FocusTree.from_state(state)
 
-      :error ->
-        :not_found
-    end
+    path =
+      if button in [:wheel_down, :wheel_up],
+        do: FocusTree.scroll_path(tree, row, col),
+        else: FocusTree.hit_path(tree, row, col)
+
+    Enum.find(path, &(&1.handler == __MODULE__))
   end
 
   # ── Agent chat window (split pane) dispatch ────────────────────────────────
@@ -146,7 +154,7 @@ defmodule MingaEditor.Input.AgentMouse do
 
     if col < cc + chat_width do
       # Chat area scroll: unpin and passthrough to Editor.Mouse
-      state = unpin_agent_chat_window(state)
+      state = unpin_agent_chat_window(state, win_id)
       {:passthrough, state}
     else
       # Preview area scroll: handled here (unique)
@@ -246,15 +254,9 @@ defmodule MingaEditor.Input.AgentMouse do
     rect
   end
 
-  @spec unpin_agent_chat_window(EditorState.t()) :: EditorState.t()
-  defp unpin_agent_chat_window(state) do
-    case EditorState.find_agent_chat_window(state) do
-      nil ->
-        state
-
-      {win_id, _window} ->
-        EditorState.update_window(state, win_id, fn w -> %{w | pinned: false} end)
-    end
+  @spec unpin_agent_chat_window(EditorState.t(), pos_integer()) :: EditorState.t()
+  defp unpin_agent_chat_window(state, win_id) do
+    EditorState.update_window(state, win_id, &Window.set_pinned(&1, false))
   end
 
   # Side panel chat scroll: updates UIState.scroll (used by the panel

--- a/lib/minga_editor/input/agent_nav.ex
+++ b/lib/minga_editor/input/agent_nav.ex
@@ -35,6 +35,7 @@ defmodule MingaEditor.Input.AgentNav do
   alias Minga.Buffer
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.Window
 
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
@@ -169,7 +170,7 @@ defmodule MingaEditor.Input.AgentNav do
         state
 
       {win_id, _window} ->
-        EditorState.update_window(state, win_id, fn w -> %{w | pinned: false} end)
+        EditorState.update_window(state, win_id, &Window.set_pinned(&1, false))
     end
   end
 end

--- a/lib/minga_editor/input/completion.ex
+++ b/lib/minga_editor/input/completion.ex
@@ -15,12 +15,12 @@ defmodule MingaEditor.Input.Completion do
 
   import Bitwise
 
-  alias Minga.Buffer
   alias Minga.Editing.Completion
   alias MingaEditor.CompletionHandling
+  alias MingaEditor.FocusTree
+  alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
-  alias MingaEditor.Viewport
 
   @ctrl MingaEditor.Input.mod_ctrl()
   @escape 27
@@ -28,8 +28,6 @@ defmodule MingaEditor.Input.Completion do
   @enter 13
   @arrow_up 0x415B1B
   @arrow_down 0x425B1B
-
-  @max_rows 10
 
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
@@ -62,11 +60,34 @@ defmodule MingaEditor.Input.Completion do
           pos_integer()
         ) :: MingaEditor.Input.Handler.result()
 
-  # Completion popup active: intercept scroll and clicks
-  def handle_mouse(
+  def handle_mouse(state, row, col, button, mods, event_type, click_count) do
+    case routed_completion_node(state, row, col, button) do
+      %FocusNode{} = node ->
+        handle_mouse_at_node(state, node, row, col, button, mods, event_type, click_count)
+
+      nil ->
+        {:passthrough, state}
+    end
+  end
+
+  @impl true
+  @spec handle_mouse_at_node(
+          state(),
+          FocusNode.t(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: MingaEditor.Input.Handler.result()
+
+  # Completion popup active: intercept scroll and clicks routed by the focus tree.
+  def handle_mouse_at_node(
         %{workspace: %{editing: %{mode: :insert}}} = state,
+        %FocusNode{} = node,
         row,
-        col,
+        _col,
         button,
         _mods,
         :press,
@@ -74,103 +95,77 @@ defmodule MingaEditor.Input.Completion do
       ) do
     case ModalOverlay.completion(state) do
       %Completion{} = completion ->
-        do_handle_mouse(state, completion, row, col, button)
+        do_handle_mouse(state, node, completion, row, button)
 
       _ ->
         {:passthrough, state}
     end
   end
 
-  def handle_mouse(state, _row, _col, _button, _mods, _event_type, _cc) do
+  def handle_mouse_at_node(state, _node, _row, _col, _button, _mods, _event_type, _cc) do
     {:passthrough, state}
   end
 
-  @spec do_handle_mouse(EditorState.t(), Completion.t(), integer(), integer(), atom()) ::
+  @spec do_handle_mouse(EditorState.t(), FocusNode.t(), Completion.t(), integer(), atom()) ::
           MingaEditor.Input.Handler.result()
-  defp do_handle_mouse(state, completion, row, col, button) do
-    case button do
-      :wheel_down ->
-        {:handled, ModalOverlay.update_completion(state, &Completion.move_down/1)}
+  defp do_handle_mouse(state, _node, _completion, _row, :wheel_down) do
+    {:handled, ModalOverlay.update_completion(state, &Completion.move_down/1)}
+  end
 
-      :wheel_up ->
-        {:handled, ModalOverlay.update_completion(state, &Completion.move_up/1)}
+  defp do_handle_mouse(state, _node, _completion, _row, :wheel_up) do
+    {:handled, ModalOverlay.update_completion(state, &Completion.move_up/1)}
+  end
 
-      :left ->
-        handle_completion_click(state, completion, row, col)
+  defp do_handle_mouse(state, node, completion, row, :left) do
+    handle_completion_click(state, node, completion, row)
+  end
 
-      _ ->
-        {:passthrough, state}
-    end
+  defp do_handle_mouse(state, _node, _completion, _row, _button) do
+    {:passthrough, state}
   end
 
   # ── Completion click ─────────────────────────────────────────────────────
 
-  @spec handle_completion_click(EditorState.t(), Completion.t(), integer(), integer()) ::
-          MingaEditor.Input.Handler.result()
-  defp handle_completion_click(state, completion, row, col) do
-    {visible, _selected_offset} = Completion.visible_items(completion)
-    item_count = min(length(visible), @max_rows)
+  @spec routed_completion_node(EditorState.t(), integer(), integer(), atom()) ::
+          FocusNode.t() | nil
+  defp routed_completion_node(state, row, col, button) do
+    tree = FocusTree.from_state(state)
 
-    # Popup position: same logic as CompletionUI
-    {cursor_row, cursor_col} = cursor_screen_pos(state)
-    space_below = state.terminal_viewport.rows - cursor_row - 2
+    path =
+      if button in [:wheel_down, :wheel_up],
+        do: FocusTree.scroll_path(tree, row, col),
+        else: FocusTree.hit_path(tree, row, col)
 
-    popup_start_row =
-      if space_below >= item_count do
-        cursor_row + 1
-      else
-        cursor_row - item_count
-      end
-
-    # Check popup width for column hit-test
-    label_widths =
-      Enum.map(Enum.take(visible, item_count), fn item -> String.length(item.label) + 4 end)
-
-    popup_width = label_widths |> Enum.max(fn -> 20 end) |> max(20) |> min(50)
-    popup_width = min(popup_width, state.terminal_viewport.cols - cursor_col)
-    start_col = min(cursor_col, max(0, state.terminal_viewport.cols - popup_width))
-
-    clicked_idx = row - popup_start_row
-
-    if clicked_idx >= 0 and clicked_idx < item_count and
-         col >= start_col and col < start_col + popup_width do
-      # Navigate to the clicked item and accept it
-      target_item = Enum.at(visible, clicked_idx)
-
-      if target_item do
-        # Set selection to the clicked index, then accept
-        adjusted = set_completion_selected(completion, clicked_idx)
-        new_state = MingaEditor.do_accept_completion(state, adjusted)
-        {:handled, new_state}
-      else
-        {:handled, state}
-      end
-    else
-      # Click outside popup: dismiss completion
-      {:handled, MingaEditor.do_dismiss_completion(state)}
-    end
+    Enum.find(path, &(&1.handler == __MODULE__))
   end
 
-  @spec cursor_screen_pos(EditorState.t()) :: {non_neg_integer(), non_neg_integer()}
-  defp cursor_screen_pos(state) do
-    buf = state.workspace.buffers.active
+  @spec handle_completion_click(EditorState.t(), FocusNode.t(), Completion.t(), integer()) ::
+          MingaEditor.Input.Handler.result()
+  defp handle_completion_click(
+         state,
+         %FocusNode{content_type: :completion_backdrop},
+         _completion,
+         _row
+       ) do
+    {:handled, MingaEditor.do_dismiss_completion(state)}
+  end
 
-    if buf do
-      {line, col} = Buffer.cursor(buf)
-      screen_row = line - state.terminal_viewport.top
-      total_lines = Buffer.line_count(buf)
+  defp handle_completion_click(
+         state,
+         %FocusNode{rect: {start_row, _start_col, _width, _item_count}},
+         completion,
+         row
+       ) do
+    clicked_idx = row - start_row
+    target_item = completion |> Completion.visible_items() |> elem(0) |> Enum.at(clicked_idx)
 
-      number_w =
-        if state.line_numbers == :none,
-          do: 0,
-          else: Viewport.gutter_width(total_lines)
+    case target_item do
+      nil ->
+        {:handled, state}
 
-      gutter_w = MingaEditor.Renderer.Gutter.total_width(number_w)
-      screen_col = col + gutter_w - state.terminal_viewport.left
-
-      {max(screen_row, 0), max(screen_col, 0)}
-    else
-      {0, 0}
+      _item ->
+        adjusted = set_completion_selected(completion, clicked_idx)
+        {:handled, MingaEditor.do_accept_completion(state, adjusted)}
     end
   end
 

--- a/lib/minga_editor/input/cua/dispatch.ex
+++ b/lib/minga_editor/input/cua/dispatch.ex
@@ -23,6 +23,7 @@ defmodule MingaEditor.Input.CUA.Dispatch do
 
   alias Minga.Buffer
   alias MingaEditor.Commands
+  alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.Mouse
   alias MingaEditor.State, as: EditorState
 
@@ -65,6 +66,22 @@ defmodule MingaEditor.Input.CUA.Dispatch do
         ) :: MingaEditor.Input.Handler.result()
   def handle_mouse(state, row, col, button, mods, event_type, click_count) do
     new_state = Mouse.handle(state, row, col, button, mods, event_type, click_count)
+    {:handled, new_state}
+  end
+
+  @impl true
+  @spec handle_mouse_at_node(
+          EditorState.t(),
+          FocusNode.t(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: MingaEditor.Input.Handler.result()
+  def handle_mouse_at_node(state, node, row, col, button, mods, event_type, click_count) do
+    new_state = Mouse.handle_at_node(state, node, row, col, button, mods, event_type, click_count)
     {:handled, new_state}
   end
 end

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -14,12 +14,14 @@ defmodule MingaEditor.Input.FileTreeHandler do
 
   alias Minga.Buffer
   alias MingaEditor.Commands
-  alias MingaEditor.Layout
+  alias MingaEditor.FocusTree
+  alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.Input
   alias Minga.Keymap
   alias Minga.Project.FileTree
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
@@ -62,37 +64,70 @@ defmodule MingaEditor.Input.FileTreeHandler do
           pos_integer()
         ) :: MingaEditor.Input.Handler.result()
 
-  # File tree: left click opens file/toggles dir, scroll wheel scrolls tree
-  def handle_mouse(
-        %{workspace: %{keymap_scope: :file_tree, file_tree: %{tree: %FileTree{} = tree}}} = state,
+  def handle_mouse(state, row, col, button, mods, event_type, click_count) do
+    case routed_file_tree_node(state, row, col, button) do
+      %FocusNode{} = node ->
+        handle_mouse_at_node(state, node, row, col, button, mods, event_type, click_count)
+
+      nil ->
+        {:passthrough, state}
+    end
+  end
+
+  @impl true
+  @spec handle_mouse_at_node(
+          state(),
+          FocusNode.t(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: MingaEditor.Input.Handler.result()
+
+  # File tree: left click opens file/toggles dir, scroll wheel scrolls tree.
+  def handle_mouse_at_node(
+        %{workspace: %{file_tree: %{tree: %FileTree{} = tree}}} = state,
+        %FocusNode{content_type: :file_tree, rect: {ft_row, _ft_col, _ft_width, ft_height}},
         row,
-        col,
+        _col,
         button,
         _mods,
         :press,
         click_count
       ) do
-    layout = Layout.get(state)
-
-    case layout.file_tree do
-      nil ->
-        {:passthrough, state}
-
-      {ft_row, ft_col, ft_width, ft_height} ->
-        if row >= ft_row and row < ft_row + ft_height and col >= ft_col and
-             col < ft_col + ft_width do
-          {:handled,
-           handle_file_tree_click(state, tree, row, ft_row, ft_height, button, click_count)}
-        else
-          {:passthrough, state}
-        end
-    end
+    state = focus_file_tree_for_mouse(state, button)
+    {:handled, handle_file_tree_click(state, tree, row, ft_row, ft_height, button, click_count)}
   end
 
-  # All other scopes
-  def handle_mouse(state, _row, _col, _button, _mods, _event_type, _cc) do
+  def handle_mouse_at_node(state, _node, _row, _col, _button, _mods, _event_type, _cc) do
     {:passthrough, state}
   end
+
+  @spec routed_file_tree_node(EditorState.t(), integer(), integer(), atom()) ::
+          FocusNode.t() | nil
+  defp routed_file_tree_node(state, row, col, button) do
+    tree = FocusTree.from_state(state)
+
+    path =
+      if button in [:wheel_down, :wheel_up],
+        do: FocusTree.scroll_path(tree, row, col),
+        else: FocusTree.hit_path(tree, row, col)
+
+    Enum.find(path, &(&1.handler == __MODULE__))
+  end
+
+  @spec focus_file_tree_for_mouse(EditorState.t(), atom()) :: EditorState.t()
+  defp focus_file_tree_for_mouse(state, :left) do
+    EditorState.update_workspace(state, fn workspace ->
+      workspace
+      |> WorkspaceState.set_file_tree(FileTreeState.focus(workspace.file_tree))
+      |> WorkspaceState.set_keymap_scope(:file_tree)
+    end)
+  end
+
+  defp focus_file_tree_for_mouse(state, _button), do: state
 
   # ── File tree key dispatch ─────────────────────────────────────────────
 

--- a/lib/minga_editor/input/handler.ex
+++ b/lib/minga_editor/input/handler.ex
@@ -61,13 +61,9 @@ defmodule MingaEditor.Input.Handler do
             ) :: result()
 
   @doc """
-  Processes a mouse event.
+  Processes a mouse event routed to this handler by the focus tree.
 
-  Returns `{:handled, state}` if this handler consumed the mouse event,
-  or `{:passthrough, state}` to forward it to the next handler.
-
-  The default implementation passes through all mouse events. Override
-  this callback to intercept mouse events for your UI region.
+  Returns `{:handled, state}` if this handler consumed the mouse event, or `{:passthrough, state}` to bubble to the routed node's ancestors.
   """
   @callback handle_mouse(
               handler_state(),
@@ -79,5 +75,21 @@ defmodule MingaEditor.Input.Handler do
               click_count :: pos_integer()
             ) :: result()
 
-  @optional_callbacks [handle_mouse: 7]
+  @doc """
+  Processes a mouse event with the focus-tree node that received it.
+
+  Handlers that need structural context, such as the routed file-tree rect or picker backdrop node, should implement this callback. Handlers that do not need the node can keep implementing `handle_mouse/7`.
+  """
+  @callback handle_mouse_at_node(
+              handler_state(),
+              MingaEditor.FocusTree.Node.t(),
+              row :: integer(),
+              col :: integer(),
+              button :: atom(),
+              modifiers :: non_neg_integer(),
+              event_type :: atom(),
+              click_count :: pos_integer()
+            ) :: result()
+
+  @optional_callbacks [handle_mouse: 7, handle_mouse_at_node: 8]
 end

--- a/lib/minga_editor/input/mode_fsm.ex
+++ b/lib/minga_editor/input/mode_fsm.ex
@@ -15,6 +15,7 @@ defmodule MingaEditor.Input.ModeFSM do
 
   @type state :: MingaEditor.Input.Handler.handler_state()
 
+  alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.Mouse
 
   @impl true
@@ -37,6 +38,22 @@ defmodule MingaEditor.Input.ModeFSM do
         ) :: MingaEditor.Input.Handler.result()
   def handle_mouse(state, row, col, button, mods, event_type, click_count) do
     new_state = Mouse.handle(state, row, col, button, mods, event_type, click_count)
+    {:handled, new_state}
+  end
+
+  @impl true
+  @spec handle_mouse_at_node(
+          state(),
+          FocusNode.t(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: MingaEditor.Input.Handler.result()
+  def handle_mouse_at_node(state, node, row, col, button, mods, event_type, click_count) do
+    new_state = Mouse.handle_at_node(state, node, row, col, button, mods, event_type, click_count)
     {:handled, new_state}
   end
 end

--- a/lib/minga_editor/input/picker.ex
+++ b/lib/minga_editor/input/picker.ex
@@ -12,6 +12,8 @@ defmodule MingaEditor.Input.Picker do
 
   @type state :: MingaEditor.Input.Handler.handler_state()
 
+  alias MingaEditor.FocusTree
+  alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
@@ -47,15 +49,38 @@ defmodule MingaEditor.Input.Picker do
           pos_integer()
         ) :: MingaEditor.Input.Handler.result()
 
-  # Picker active: intercept scroll and clicks
-  def handle_mouse(
+  def handle_mouse(state, row, col, button, mods, event_type, click_count) do
+    case routed_picker_node(state, row, col, button) do
+      %FocusNode{} = node ->
+        handle_mouse_at_node(state, node, row, col, button, mods, event_type, click_count)
+
+      nil ->
+        {:passthrough, state}
+    end
+  end
+
+  @impl true
+  @spec handle_mouse_at_node(
+          state(),
+          FocusNode.t(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: MingaEditor.Input.Handler.result()
+
+  # Picker active: intercept scroll and clicks routed by the focus tree.
+  def handle_mouse_at_node(
         %{
           shell_state: %{
             modal: {:picker, %{picker_ui: %{picker: %PickerData{} = picker, source: source}}}
           }
         } = state,
+        %FocusNode{} = node,
         row,
-        col,
+        _col,
         button,
         _mods,
         :press,
@@ -71,34 +96,66 @@ defmodule MingaEditor.Input.Picker do
         {:handled, PickerUI.update_picker(state, &%{&1 | picker: new_picker})}
 
       :left ->
-        {:picker, %{picker_ui: %{layout: layout}}} = state.shell_state.modal
-
-        if layout == :centered and not inside_centered_box?(state, row, col) do
-          {:handled, PickerUI.close(state)}
-        else
-          {:handled, handle_picker_click(state, picker, source, row)}
-        end
+        {:handled, handle_picker_left_click(state, node, picker, source, row)}
 
       _ ->
         {:handled, state}
     end
   end
 
-  # Picker not active: pass through
-  def handle_mouse(state, _row, _col, _button, _mods, _event_type, _cc) do
+  def handle_mouse_at_node(state, _node, _row, _col, _button, _mods, _event_type, _cc) do
     {:passthrough, state}
   end
 
   # ── Picker click helpers ────────────────────────────────────────────────
 
-  @spec handle_picker_click(EditorState.t(), PickerData.t(), module(), integer()) ::
+  @spec routed_picker_node(EditorState.t(), integer(), integer(), atom()) :: FocusNode.t() | nil
+  defp routed_picker_node(state, row, col, button) do
+    tree = FocusTree.from_state(state)
+
+    path =
+      if button in [:wheel_down, :wheel_up],
+        do: FocusTree.scroll_path(tree, row, col),
+        else: FocusTree.hit_path(tree, row, col)
+
+    Enum.find(path, &(&1.handler == __MODULE__))
+  end
+
+  @spec handle_picker_left_click(
+          EditorState.t(),
+          FocusNode.t(),
+          PickerData.t(),
+          module(),
+          integer()
+        ) ::
           EditorState.t()
-  defp handle_picker_click(state, picker, source, row) do
+  defp handle_picker_left_click(
+         state,
+         %FocusNode{content_type: :picker_backdrop},
+         _picker,
+         _source,
+         _row
+       ) do
+    {:picker, %{picker_ui: %{layout: layout}}} = state.shell_state.modal
+
+    case layout do
+      :centered -> PickerUI.close(state)
+      _bottom -> state
+    end
+  end
+
+  defp handle_picker_left_click(state, %FocusNode{} = node, picker, source, row) do
+    handle_picker_click(state, node, picker, source, row)
+  end
+
+  @spec handle_picker_click(EditorState.t(), FocusNode.t(), PickerData.t(), module(), integer()) ::
+          EditorState.t()
+  defp handle_picker_click(state, node, picker, source, row) do
     {:picker, %{picker_ui: %{layout: layout}}} = state.shell_state.modal
 
     clicked_idx =
       case layout do
-        :centered -> centered_click_index(state, picker, row)
+        :centered -> centered_click_index(node, row)
         _bottom -> bottom_click_index(state, picker, row)
       end
 
@@ -130,31 +187,9 @@ defmodule MingaEditor.Input.Picker do
   end
 
   # Centered: items start at the top of the FloatingWindow interior.
-  @spec centered_click_index(EditorState.t(), PickerData.t(), integer()) :: integer()
-  defp centered_click_index(state, _picker, row) do
-    vp_rows = state.terminal_viewport.rows
-
-    # Match the 60%x70% dimensions used by PickerUI.render_centered
-    box_h = max(div(vp_rows * 70, 100), 1)
-    box_row = max(div(vp_rows - box_h, 2), 0)
-
-    # Interior starts 1 row below the top border
+  @spec centered_click_index(FocusNode.t(), integer()) :: integer()
+  defp centered_click_index(%FocusNode{rect: {box_row, _box_col, _box_w, _box_h}}, row) do
     interior_row = box_row + 1
     row - interior_row
-  end
-
-  # Returns true when {row, col} falls inside the centered picker's box.
-  @spec inside_centered_box?(EditorState.t(), integer(), integer()) :: boolean()
-  defp inside_centered_box?(state, row, col) do
-    vp_rows = state.terminal_viewport.rows
-    vp_cols = state.terminal_viewport.cols
-
-    box_w = max(div(vp_cols * 60, 100), 1)
-    box_h = max(div(vp_rows * 70, 100), 1)
-    box_row = max(div(vp_rows - box_h, 2), 0)
-    box_col = max(div(vp_cols - box_w, 2), 0)
-
-    row >= box_row and row < box_row + box_h and
-      col >= box_col and col < box_col + box_w
   end
 end

--- a/lib/minga_editor/input/router.ex
+++ b/lib/minga_editor/input/router.ex
@@ -17,6 +17,8 @@ defmodule MingaEditor.Input.Router do
   alias Minga.Buffer
   alias Minga.Editing
   alias MingaEditor
+  alias MingaEditor.FocusTree
+  alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.LspActions
   alias MingaEditor.State, as: EditorState
 
@@ -27,6 +29,15 @@ defmodule MingaEditor.Input.Router do
           old_mode: atom(),
           old_cursor: {non_neg_integer(), non_neg_integer()} | nil
         }
+
+  @typep mouse_event :: %{
+           row: integer(),
+           col: integer(),
+           button: atom(),
+           mods: non_neg_integer(),
+           event_type: atom(),
+           click_count: pos_integer()
+         }
 
   @doc """
   Captures a snapshot of the editor state before an action runs.
@@ -294,13 +305,9 @@ defmodule MingaEditor.Input.Router do
   end
 
   @doc """
-  Dispatches a mouse event through the focus stack.
+  Dispatches a mouse event through the focus tree.
 
-  Walks the focus stack calling `handle_mouse/7` on each handler that
-  implements it. The first handler that returns `{:handled, state}` stops
-  the walk. Handlers that don't implement `handle_mouse/7` are skipped.
-
-  Returns the final state after dispatch.
+  Hit-testing resolves `(row, col)` to the deepest visible node. Dispatch starts at that node's handler and bubbles to ancestors when a handler returns `{:passthrough, state}`. Scroll-wheel events start at the deepest scrollable node under the cursor, so hover location controls scrolling independently of keyboard focus.
   """
   @spec dispatch_mouse(
           EditorState.t(),
@@ -312,73 +319,87 @@ defmodule MingaEditor.Input.Router do
           pos_integer()
         ) :: EditorState.t()
   def dispatch_mouse(state, row, col, button, mods, event_type, click_count) do
-    dispatch_mouse_split(state, row, col, button, mods, event_type, click_count)
+    event = %{
+      row: row,
+      col: col,
+      button: button,
+      mods: mods,
+      event_type: event_type,
+      click_count: click_count
+    }
+
+    state
+    |> FocusTree.get()
+    |> mouse_path(row, col, button)
+    |> dispatch_mouse_path(state, event)
   end
 
-  # Walks overlay handlers first for mouse events, then delegates to surface handlers.
-  @spec dispatch_mouse_split(
-          EditorState.t(),
-          integer(),
-          integer(),
-          atom(),
-          non_neg_integer(),
-          atom(),
-          pos_integer()
-        ) ::
-          EditorState.t()
-  defp dispatch_mouse_split(
-         %EditorState{shell: shell, shell_state: _ss} = state,
-         row,
-         col,
-         button,
-         mods,
-         et,
-         cc
-       ) do
-    %{overlay: overlay_handlers, surface: surface_handlers} = shell.input_handlers(state)
-
-    # Walk overlay handlers first for mouse events.
-    result =
-      Enum.reduce_while(overlay_handlers, {:passthrough, state}, fn handler, {_status, acc} ->
-        case try_mouse_handler(handler, acc, row, col, button, mods, et, cc) do
-          {:halt, new_state} -> {:halt, {:handled, new_state}}
-          {:cont, new_state} -> {:cont, {:passthrough, new_state}}
-        end
-      end)
-
-    case result do
-      {:handled, new_state} ->
-        new_state
-
-      {:passthrough, state_after_overlays} ->
-        # Delegate to surface-level mouse handlers.
-        Enum.reduce_while(surface_handlers, state_after_overlays, fn handler, acc ->
-          try_mouse_handler(handler, acc, row, col, button, mods, et, cc)
-        end)
+  @spec mouse_path(FocusTree.t(), integer(), integer(), atom()) :: FocusTree.path()
+  defp mouse_path(tree, row, col, button)
+       when button in [:wheel_down, :wheel_up, :wheel_left, :wheel_right] do
+    case FocusTree.scroll_path(tree, row, col) do
+      [] -> FocusTree.hit_path(tree, row, col)
+      path -> path
     end
   end
 
-  @spec try_mouse_handler(
-          module(),
-          EditorState.t(),
-          integer(),
-          integer(),
-          atom(),
-          non_neg_integer(),
-          atom(),
-          pos_integer()
-        ) ::
-          {:halt, EditorState.t()} | {:cont, EditorState.t()}
-  defp try_mouse_handler(handler, state, row, col, button, mods, event_type, click_count) do
-    Code.ensure_loaded(handler)
+  defp mouse_path(tree, row, col, _button), do: FocusTree.hit_path(tree, row, col)
 
-    if function_exported?(handler, :handle_mouse, 7) do
-      case handler.handle_mouse(state, row, col, button, mods, event_type, click_count) do
+  @spec dispatch_mouse_path(FocusTree.path(), EditorState.t(), mouse_event()) :: EditorState.t()
+  defp dispatch_mouse_path(path, state, event) do
+    Enum.reduce_while(path, state, fn node, acc ->
+      case dispatch_mouse_to_node(node, acc, event) do
         {:handled, new_state} -> {:halt, new_state}
         {:passthrough, new_state} -> {:cont, new_state}
       end
+    end)
+  end
+
+  @spec dispatch_mouse_to_node(FocusNode.t(), EditorState.t(), mouse_event()) ::
+          MingaEditor.Input.Handler.result()
+  defp dispatch_mouse_to_node(%FocusNode{handler: nil}, state, _event) do
+    {:passthrough, state}
+  end
+
+  defp dispatch_mouse_to_node(%FocusNode{handler: handler} = node, state, event) do
+    Code.ensure_loaded(handler)
+    call_mouse_handler(handler, node, state, event)
+  end
+
+  @spec call_mouse_handler(module(), FocusNode.t(), EditorState.t(), mouse_event()) ::
+          MingaEditor.Input.Handler.result()
+  defp call_mouse_handler(handler, node, state, event) do
+    if function_exported?(handler, :handle_mouse_at_node, 8) do
+      handler.handle_mouse_at_node(
+        state,
+        node,
+        event.row,
+        event.col,
+        event.button,
+        event.mods,
+        event.event_type,
+        event.click_count
+      )
     else
-      {:cont, state}
+      call_legacy_mouse_handler(handler, state, event)
+    end
+  end
+
+  @spec call_legacy_mouse_handler(module(), EditorState.t(), mouse_event()) ::
+          MingaEditor.Input.Handler.result()
+  defp call_legacy_mouse_handler(handler, state, event) do
+    if function_exported?(handler, :handle_mouse, 7) do
+      handler.handle_mouse(
+        state,
+        event.row,
+        event.col,
+        event.button,
+        event.mods,
+        event.event_type,
+        event.click_count
+      )
+    else
+      {:passthrough, state}
     end
   end
 

--- a/lib/minga_editor/layout.ex
+++ b/lib/minga_editor/layout.ex
@@ -24,6 +24,7 @@ defmodule MingaEditor.Layout do
   """
 
   alias Minga.Buffer
+  alias MingaEditor.FocusTree
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
@@ -103,14 +104,18 @@ defmodule MingaEditor.Layout do
   read `state.layout` downstream.
   """
   @spec put(EditorState.t() | map()) :: map()
-  def put(%{shell: shell} = state), do: %{state | layout: shell.compute_layout(state)}
+  def put(%{shell: shell} = state) do
+    layout = shell.compute_layout(state)
+    state = %{state | layout: layout}
+    %{state | focus_tree: FocusTree.from_state(state)}
+  end
 
   @doc """
   Invalidates the cached layout. Call when layout-affecting state changes
   (viewport resize, file tree toggle, agent panel toggle, window split/close).
   """
   @spec invalidate(EditorState.t()) :: EditorState.t()
-  def invalidate(state), do: %{state | layout: nil}
+  def invalidate(state), do: %{state | layout: nil, focus_tree: nil}
 
   @doc """
   Computes the complete layout for the current frame.

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -32,10 +32,12 @@ defmodule MingaEditor.Mouse do
   alias Minga.Core.Decorations
   alias Minga.Core.Unicode
   alias MingaEditor.DisplayMap
+  alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.FoldMap
   alias MingaEditor.Layout
   alias MingaEditor.Renderer.Gutter
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Mouse, as: MouseState
   alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.State.WhichKey, as: WhichKeyState
@@ -59,6 +61,36 @@ defmodule MingaEditor.Mouse do
 
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
+
+  @doc "Dispatches a mouse event routed to a focus-tree node."
+  @spec handle_at_node(
+          state(),
+          FocusNode.t(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: state()
+  def handle_at_node(
+        state,
+        %FocusNode{content_type: content_type, ref: win_id},
+        row,
+        col,
+        button,
+        mods,
+        :press,
+        click_count
+      )
+      when content_type in [:buffer_content, :agent_chat_window] and
+             button in [:wheel_down, :wheel_up, :wheel_left, :wheel_right] do
+    handle_buffer_scroll_at_window(state, win_id, row, col, button, mods, click_count)
+  end
+
+  def handle_at_node(state, _node, row, col, button, mods, event_type, click_count) do
+    handle(state, row, col, button, mods, event_type, click_count)
+  end
 
   @doc "Dispatches a mouse event, returning updated state."
   @spec handle(
@@ -118,13 +150,19 @@ defmodule MingaEditor.Mouse do
   def handle(state, _r, _c, :wheel_right, _m, :press, _cc) do
     vp = current_viewport(state)
     new_left = vp.left + @scroll_cols
-    update_current_viewport(state, %{vp | left: new_left})
+
+    state
+    |> update_current_viewport(%{vp | left: new_left})
+    |> clamp_cursor_to_horizontal_viewport()
   end
 
   def handle(state, _r, _c, :wheel_left, _m, :press, _cc) do
     vp = current_viewport(state)
     new_left = max(vp.left - @scroll_cols, 0)
-    update_current_viewport(state, %{vp | left: new_left})
+
+    state
+    |> update_current_viewport(%{vp | left: new_left})
+    |> clamp_cursor_to_horizontal_viewport()
   end
 
   # ── Middle-click paste ──
@@ -280,6 +318,75 @@ defmodule MingaEditor.Mouse do
   # ── Ignore all other mouse events ──
 
   def handle(state, _row, _col, _button, _mods, _type, _cc), do: state
+
+  @spec handle_buffer_scroll_at_window(
+          state(),
+          term(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          pos_integer()
+        ) :: state()
+  defp handle_buffer_scroll_at_window(
+         %{workspace: %{windows: %{active: win_id}}} = state,
+         win_id,
+         row,
+         col,
+         button,
+         mods,
+         click_count
+       ) do
+    handle(state, row, col, button, mods, :press, click_count)
+  end
+
+  defp handle_buffer_scroll_at_window(state, win_id, _row, _col, :wheel_down, _mods, _click_count) do
+    scroll_window_vertical(state, win_id, scroll_lines(state))
+  end
+
+  defp handle_buffer_scroll_at_window(state, win_id, _row, _col, :wheel_up, _mods, _click_count) do
+    scroll_window_vertical(state, win_id, -scroll_lines(state))
+  end
+
+  defp handle_buffer_scroll_at_window(
+         state,
+         win_id,
+         _row,
+         _col,
+         :wheel_right,
+         _mods,
+         _click_count
+       ) do
+    scroll_window_horizontal(state, win_id, @scroll_cols)
+  end
+
+  defp handle_buffer_scroll_at_window(state, win_id, _row, _col, :wheel_left, _mods, _click_count) do
+    scroll_window_horizontal(state, win_id, -@scroll_cols)
+  end
+
+  @spec scroll_window_vertical(state(), term(), integer()) :: state()
+  defp scroll_window_vertical(state, win_id, delta) do
+    case Map.fetch(state.workspace.windows.map, win_id) do
+      {:ok, %Window{buffer: buf} = window} when is_pid(buf) ->
+        total_lines = Buffer.line_count(buf)
+        updated = Window.scroll_viewport(window, delta, total_lines)
+        EditorState.update_window(state, win_id, fn _window -> updated end)
+
+      _ ->
+        state
+    end
+  end
+
+  @spec scroll_window_horizontal(state(), term(), integer()) :: state()
+  defp scroll_window_horizontal(state, win_id, delta) do
+    case Map.fetch(state.workspace.windows.map, win_id) do
+      {:ok, %Window{}} ->
+        EditorState.update_window(state, win_id, &Window.scroll_horizontal(&1, delta))
+
+      _ ->
+        state
+    end
+  end
 
   # ── Left press dispatcher ──────────────────────────────────────────────────
 
@@ -667,6 +774,7 @@ defmodule MingaEditor.Mouse do
         MingaEditor.dispatch_command(state, cmd)
 
       :not_modeline ->
+        state = maybe_unfocus_file_tree_for_content_click(state)
         state = maybe_focus_window_at(state, row, col)
 
         case mouse_to_buffer_pos(state, row, col) do
@@ -689,6 +797,19 @@ defmodule MingaEditor.Mouse do
         end
     end
   end
+
+  @spec maybe_unfocus_file_tree_for_content_click(state()) :: state()
+  defp maybe_unfocus_file_tree_for_content_click(
+         %{workspace: %{keymap_scope: :file_tree}} = state
+       ) do
+    EditorState.update_workspace(state, fn workspace ->
+      workspace
+      |> WorkspaceState.set_file_tree(FileTreeState.unfocus(workspace.file_tree))
+      |> WorkspaceState.set_keymap_scope(:editor)
+    end)
+  end
+
+  defp maybe_unfocus_file_tree_for_content_click(state), do: state
 
   @spec maybe_focus_window_at(state(), non_neg_integer(), non_neg_integer()) :: state()
   defp maybe_focus_window_at(%{workspace: %{windows: %{tree: nil}}} = state, _row, _col),
@@ -765,7 +886,7 @@ defmodule MingaEditor.Mouse do
         {cursor_line, _} = Buffer.cursor(buf)
         scroll_top = window_scroll_top(window, win_h, content_w, cursor_line, buf)
         local_row = row - win_row
-        local_col = max(col - win_col - gutter_w, 0) + scroll_left(state, buf)
+        local_col = max(col - win_col - gutter_w, 0) + current_viewport(state).left
 
         resolve_with_display_map(
           buf,
@@ -799,7 +920,7 @@ defmodule MingaEditor.Mouse do
         {cursor_line, _} = window.cursor
         scroll_top = window_scroll_top(window, content_h, content_w, cursor_line, buf)
         local_row = row - win_row
-        local_col = max(col - win_col - gutter_w, 0)
+        local_col = max(col - win_col - gutter_w, 0) + window.viewport.left
 
         resolve_with_display_map(
           buf,
@@ -994,9 +1115,6 @@ defmodule MingaEditor.Mouse do
     vp.top
   end
 
-  @spec scroll_left(state(), pid()) :: non_neg_integer()
-  defp scroll_left(state, _buf), do: current_viewport(state).left
-
   # ── Viewport helpers ───────────────────────────────────────────────────────
 
   @spec scroll_viewport(Viewport.t(), integer(), non_neg_integer()) :: Viewport.t()
@@ -1005,6 +1123,68 @@ defmodule MingaEditor.Mouse do
     max_top = max(0, total_lines - visible_rows)
     new_top = (vp.top + delta) |> max(0) |> min(max_top)
     %Viewport{vp | top: new_top}
+  end
+
+  @spec clamp_cursor_to_horizontal_viewport(state()) :: state()
+  defp clamp_cursor_to_horizontal_viewport(%{workspace: %{buffers: %{active: buf}}} = state)
+       when is_pid(buf) do
+    vp = current_viewport(state)
+    {line, byte_col} = Buffer.cursor(buf)
+    line_text = cursor_line_text(buf, line)
+    display_col = Unicode.display_col(line_text, byte_col)
+    target_col = horizontal_cursor_target(display_col, vp.left, vp.cols)
+
+    if target_col == display_col do
+      state
+    else
+      Buffer.move_to(buf, {line, byte_offset_for_visible_col(line_text, target_col)})
+      state
+    end
+  catch
+    :exit, _ -> state
+  end
+
+  defp clamp_cursor_to_horizontal_viewport(state), do: state
+
+  @spec horizontal_cursor_target(non_neg_integer(), non_neg_integer(), pos_integer()) ::
+          non_neg_integer()
+  defp horizontal_cursor_target(display_col, left, _cols) when display_col < left, do: left
+
+  defp horizontal_cursor_target(display_col, left, cols) when display_col >= left + cols do
+    left + cols - 1
+  end
+
+  defp horizontal_cursor_target(display_col, _left, _cols), do: display_col
+
+  @spec byte_offset_for_visible_col(String.t(), non_neg_integer()) :: non_neg_integer()
+  defp byte_offset_for_visible_col(_line_text, 0), do: 0
+
+  defp byte_offset_for_visible_col(line_text, target_col) do
+    line_text
+    |> Unicode.display_col_to_byte(target_col + 1)
+    |> advance_to_visible_col(line_text, target_col)
+  end
+
+  @spec advance_to_visible_col(non_neg_integer(), String.t(), non_neg_integer()) ::
+          non_neg_integer()
+  defp advance_to_visible_col(byte_col, line_text, target_col) do
+    display_col = Unicode.display_col(line_text, byte_col)
+
+    if display_col >= target_col or byte_col >= byte_size(line_text) do
+      byte_col
+    else
+      line_text
+      |> Unicode.next_grapheme_byte_offset(byte_col)
+      |> advance_to_visible_col(line_text, target_col)
+    end
+  end
+
+  @spec cursor_line_text(pid(), non_neg_integer()) :: String.t()
+  defp cursor_line_text(buf, line) do
+    case Buffer.lines(buf, line, 1) do
+      [text] -> text
+      _ -> ""
+    end
   end
 
   # Clamps the cursor to remain visible within the viewport, respecting

--- a/lib/minga_editor/render_pipeline.ex
+++ b/lib/minga_editor/render_pipeline.ex
@@ -28,6 +28,7 @@ defmodule MingaEditor.RenderPipeline do
   is set to `:debug`. Attach custom handlers for histograms or alerting.
   """
 
+  alias MingaEditor.FocusTree
   alias MingaEditor.Layout
 
   alias MingaEditor.RenderPipeline.Compose
@@ -96,6 +97,9 @@ defmodule MingaEditor.RenderPipeline do
       Telemetry.span([:minga, :render, :stage], %{stage: :scroll}, fn ->
         Scroll.scroll_windows(input, layout)
       end)
+
+    # Scroll updates per-window viewports; rebuild the tree so overlay hit regions match what chrome renders.
+    input = %{input | focus_tree: FocusTree.from_state(input)}
 
     # Stage 4: Content (skips clean lines, updates window caches)
     {buffer_frames, cursor_info, input} =

--- a/lib/minga_editor/render_pipeline/content.ex
+++ b/lib/minga_editor/render_pipeline/content.ex
@@ -378,7 +378,7 @@ defmodule MingaEditor.RenderPipeline.Content do
     # a different viewport (e.g., snapped to bottom when pinned), causing
     # clicks to land on wrong buffer lines and visual selections to appear
     # off-screen.
-    window = %{window | viewport: viewport}
+    window = Window.set_viewport(window, viewport)
 
     visible_rows = Viewport.content_rows(viewport)
     {first_line, _} = Viewport.visible_range(viewport)

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -23,7 +23,7 @@ defmodule MingaEditor.RenderPipeline.Input do
   **From `state` (top-level):**
   `theme`, `capabilities`, `shell`, `shell_state`, `port_manager`,
   `font_registry`, `message_store`, `face_override_registries`,
-  `editing_model`, `backend`, `layout`
+  `editing_model`, `backend`, `layout`, `focus_tree`
 
   **From `state.workspace` (per-tab editing context, stored as `workspace` map):**
   `windows`, `buffers`, `viewport`, `file_tree`, `highlight`,
@@ -69,6 +69,7 @@ defmodule MingaEditor.RenderPipeline.Input do
     :editing_model,
     :backend,
     :layout,
+    :focus_tree,
     :lsp,
     :parser_status,
     # Workspace as a plain map (enables state.workspace.X pattern-matching)
@@ -111,6 +112,7 @@ defmodule MingaEditor.RenderPipeline.Input do
           editing_model: :vim | :cua,
           backend: EditorState.backend(),
           layout: Layout.t() | nil,
+          focus_tree: MingaEditor.FocusTree.t() | nil,
           lsp: LSPState.t(),
           parser_status: atom(),
           caches: Caches.t(),
@@ -139,6 +141,7 @@ defmodule MingaEditor.RenderPipeline.Input do
       editing_model: state.editing_model,
       backend: state.backend,
       layout: state.layout,
+      focus_tree: state.focus_tree,
       lsp: state.lsp,
       parser_status: state.parser_status,
       caches: state.caches,

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -150,8 +150,9 @@ defmodule MingaEditor.RenderPipeline.Scroll do
 
       {:ok, scroll} ->
         updated_window =
-          Window.detect_invalidation(
-            window,
+          window
+          |> Window.set_viewport(scroll.viewport)
+          |> Window.detect_invalidation(
             scroll.viewport.top,
             scroll.gutter_w,
             scroll.snapshot.line_count,
@@ -218,15 +219,17 @@ defmodule MingaEditor.RenderPipeline.Scroll do
         FoldMap.buffer_to_visible(fold_map, cursor_line)
       end
 
-    # Vertical-only scroll: preserve horizontal scroll position (viewport.left)
-    # so that horizontal scroll from cursor tracking or mouse wheel persists.
-    # Passing cursor_col=0 would reset left to 0 via adjust_left.
-    # TODO: replace save/restore with Viewport.scroll_to_cursor_vertical/3
-    # that only modifies `top`. The same trap exists in mouse.ex:934 and
-    # content.ex:470 where {cursor_line, 0} silently resets left.
-    saved_left = viewport.left
-    viewport = Viewport.scroll_to_cursor(viewport, {visible_cursor_line, 0}, scroll_margin)
-    viewport = %{viewport | left: saved_left}
+    # Vertical-only scroll for the active window. Inactive windows preserve their
+    # own viewport so hover-wheel scrolling a split does not snap back to the
+    # inactive window's stored cursor during the render that follows the mouse event.
+    viewport =
+      maybe_scroll_active_window_to_cursor(
+        viewport,
+        visible_cursor_line,
+        scroll_margin,
+        is_active
+      )
+
     visible_rows = Viewport.content_rows(viewport)
 
     # Map viewport visible range back to buffer lines
@@ -297,7 +300,11 @@ defmodule MingaEditor.RenderPipeline.Scroll do
     # so the cursor triggers scroll when it reaches the content edge,
     # not the full viewport edge.
     viewport =
-      scroll_horizontal(viewport, cursor_line, cursor_col, wrap_on, content_w, scroll_margin)
+      if is_active do
+        scroll_horizontal(viewport, cursor_line, cursor_col, wrap_on, content_w, scroll_margin)
+      else
+        viewport
+      end
 
     # Substitution preview (active window only)
     {lines, preview_matches} =
@@ -328,6 +335,28 @@ defmodule MingaEditor.RenderPipeline.Scroll do
       buf_version: snapshot.version,
       visible_line_map: visible_line_map
     }
+  end
+
+  @spec maybe_scroll_active_window_to_cursor(
+          Viewport.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean()
+        ) :: Viewport.t()
+  defp maybe_scroll_active_window_to_cursor(
+         viewport,
+         _visible_cursor_line,
+         _scroll_margin,
+         false
+       ),
+       do: viewport
+
+  defp maybe_scroll_active_window_to_cursor(viewport, visible_cursor_line, scroll_margin, true) do
+    saved_left = viewport.left
+
+    viewport
+    |> Viewport.scroll_to_cursor({visible_cursor_line, 0}, scroll_margin)
+    |> Map.put(:left, saved_left)
   end
 
   @spec fetch_decorations(pid()) :: Decorations.t()

--- a/lib/minga_editor/renderer/server.ex
+++ b/lib/minga_editor/renderer/server.ex
@@ -26,7 +26,7 @@ defmodule MingaEditor.Renderer.Server do
   `tab_bar_click_regions` as part of chrome rendering. These need to
   flow back to the Editor so subsequent mouse events can resolve
   click positions. The Renderer casts
-  `{:render_done, frame_seq, %{caches: c, layout: l, click_regions: cr}}`
+  `{:render_done, frame_seq, %{caches: c, layout: l, focus_tree: ft, click_regions: cr}}`
   back to the Editor after every emit; the Editor merges into its
   state via `apply_renderer_writeback/2`.
 
@@ -53,6 +53,7 @@ defmodule MingaEditor.Renderer.Server do
   @type writeback :: %{
           required(:caches) => MingaEditor.Renderer.Caches.t(),
           required(:layout) => MingaEditor.Layout.t() | nil,
+          required(:focus_tree) => MingaEditor.FocusTree.t() | nil,
           required(:shell_state) => term(),
           required(:windows) => term(),
           required(:frame_seq) => non_neg_integer()
@@ -151,6 +152,7 @@ defmodule MingaEditor.Renderer.Server do
       writeback = %{
         caches: output.caches,
         layout: output.layout,
+        focus_tree: output.focus_tree,
         shell_state: output.shell_state,
         windows: output.workspace.windows,
         frame_seq: seq

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -102,6 +102,7 @@ defmodule MingaEditor.State do
             focus_stack: [],
             capabilities: %Capabilities{},
             layout: nil,
+            focus_tree: nil,
             last_cursor_line: nil,
             last_test_command: nil,
             pending_quit: nil,
@@ -137,6 +138,7 @@ defmodule MingaEditor.State do
           focus_stack: [module()],
           capabilities: Capabilities.t(),
           layout: MingaEditor.Layout.t() | nil,
+          focus_tree: MingaEditor.FocusTree.t() | nil,
           last_cursor_line: non_neg_integer() | nil,
           last_test_command: {String.t(), String.t()} | nil,
           pending_quit: :quit | :quit_all | nil,
@@ -194,6 +196,7 @@ defmodule MingaEditor.State do
       | workspace: %{ws | windows: render_output.workspace.windows},
         shell_state: render_output.shell_state,
         layout: render_output.layout,
+        focus_tree: render_output.focus_tree,
         caches: render_output.caches
     }
   end
@@ -209,7 +212,7 @@ defmodule MingaEditor.State do
   """
   @spec apply_renderer_writeback(t(), map()) :: t()
   def apply_renderer_writeback(%__MODULE__{} = state, %{caches: caches, layout: layout} = wb) do
-    state = %{state | caches: caches, layout: layout}
+    state = %{state | caches: caches, layout: layout, focus_tree: Map.get(wb, :focus_tree)}
     state = merge_renderer_windows_from_writeback(state, wb)
     merge_renderer_shell_from_writeback(state, wb)
   end
@@ -732,7 +735,7 @@ defmodule MingaEditor.State do
   def update_current_viewport(%__MODULE__{} = state, %Viewport{} = new_vp) do
     case active_window_struct(state) do
       nil -> state
-      %Window{id: win_id} -> update_window(state, win_id, fn w -> %{w | viewport: new_vp} end)
+      %Window{id: win_id} -> update_window(state, win_id, &Window.set_viewport(&1, new_vp))
     end
   end
 

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -56,6 +56,14 @@ defmodule MingaEditor.State.FileTree do
   def editing?(%__MODULE__{editing: %{}}), do: true
   def editing?(%__MODULE__{}), do: false
 
+  @doc "Marks the file tree as focused."
+  @spec focus(t()) :: t()
+  def focus(%__MODULE__{} = ft), do: %{ft | focused: true}
+
+  @doc "Marks the file tree as unfocused."
+  @spec unfocus(t()) :: t()
+  def unfocus(%__MODULE__{} = ft), do: %{ft | focused: false}
+
   @doc "Returns the tree width, or 0 if the tree is not open."
   @spec width(t()) :: non_neg_integer()
   def width(%__MODULE__{tree: nil}), do: 0

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -135,7 +135,7 @@ defmodule MingaEditor.Window do
       when is_integer(rows) and rows > 0 and is_integer(cols) and cols > 0 do
     window
     |> invalidate()
-    |> Map.put(:viewport, Viewport.new(rows, cols))
+    |> set_viewport(Viewport.new(rows, cols))
   end
 
   # When a window is squeezed to zero dimensions (e.g., terminal resized
@@ -146,6 +146,12 @@ defmodule MingaEditor.Window do
   end
 
   # ── Scroll helpers ──────────────────────────────────────────────────────────
+
+  @doc "Stores the computed viewport for this window."
+  @spec set_viewport(t(), Viewport.t()) :: t()
+  def set_viewport(%__MODULE__{} = window, %Viewport{} = viewport) do
+    %{window | viewport: viewport}
+  end
 
   @doc """
   Scrolls the window's viewport by `delta` lines and updates pinned state.
@@ -165,6 +171,19 @@ defmodule MingaEditor.Window do
     pinned = delta > 0 and new_top >= max_top
 
     %{window | viewport: %{vp | top: new_top}, pinned: pinned}
+  end
+
+  @doc "Scrolls the window horizontally by display columns."
+  @spec scroll_horizontal(t(), integer()) :: t()
+  def scroll_horizontal(%__MODULE__{viewport: viewport} = window, delta) do
+    new_left = max(viewport.left + delta, 0)
+    %{window | viewport: %{viewport | left: new_left}}
+  end
+
+  @doc "Sets whether the window should stay pinned to the bottom while content streams."
+  @spec set_pinned(t(), boolean()) :: t()
+  def set_pinned(%__MODULE__{} = window, pinned?) when is_boolean(pinned?) do
+    %{window | pinned: pinned?}
   end
 
   # ── Popup queries ──────────────────────────────────────────────────────────

--- a/lib/minga_editor/workspace/state.ex
+++ b/lib/minga_editor/workspace/state.ex
@@ -221,6 +221,12 @@ defmodule MingaEditor.Workspace.State do
     %{wspace | keymap_scope: scope}
   end
 
+  @doc "Replaces the file-tree sub-struct."
+  @spec set_file_tree(t(), FileTreeState.t()) :: t()
+  def set_file_tree(%__MODULE__{} = wspace, %FileTreeState{} = file_tree) do
+    %{wspace | file_tree: file_tree}
+  end
+
   @doc "Updates the highlighting sub-struct."
   @spec set_highlight(t(), Highlighting.t()) :: t()
   def set_highlight(%__MODULE__{} = wspace, highlight) do

--- a/test/minga_editor/focus_tree_test.exs
+++ b/test/minga_editor/focus_tree_test.exs
@@ -193,19 +193,63 @@ defmodule MingaEditor.FocusTreeTest do
   end
 
   describe "hit_path/3 — bubble dispatch" do
-    test "returns nodes from root to deepest" do
+    test "returns nodes from deepest to root" do
       tree = FocusTree.from_layout(single_window_layout())
       path = FocusTree.hit_path(tree, 5, 40)
 
       types = Enum.map(path, & &1.content_type)
-      assert types == [:viewport, :editor_area, :window, :buffer_content]
+      assert types == [:buffer_content, :window, :editor_area, :viewport]
     end
 
-    test "click on tab bar produces a one-deep bubble path under the viewport" do
+    test "click on tab bar bubbles from tab bar to viewport" do
       tree = FocusTree.from_layout(single_window_layout())
       path = FocusTree.hit_path(tree, 0, 5)
       types = Enum.map(path, & &1.content_type)
-      assert types == [:viewport, :tab_bar]
+      assert types == [:tab_bar, :viewport]
+    end
+
+    test "hit_test and hit_path agree on the deepest node" do
+      tree = FocusTree.from_layout(single_window_layout())
+      path = FocusTree.hit_path(tree, 5, 40)
+
+      assert List.first(path) == FocusTree.hit_test(tree, 5, 40)
+      assert Enum.all?(path, &TreeNode.contains?(&1, 5, 40))
+    end
+  end
+
+  describe "node references" do
+    test "children carry parent and sibling references" do
+      tree = FocusTree.from_layout(split_layout())
+      editor = Enum.find(tree.children, &(&1.content_type == :editor_area))
+      [left, right] = editor.children
+
+      assert editor.parent == :viewport
+      assert left.parent == :editor_area
+      assert left.previous_sibling == nil
+      assert left.next_sibling == right.id
+      assert right.previous_sibling == left.id
+      assert right.next_sibling == nil
+    end
+  end
+
+  describe "scroll_path/3" do
+    test "starts at the deepest scrollable node under the cursor" do
+      tree = FocusTree.from_layout(single_window_layout())
+      path = FocusTree.scroll_path(tree, 5, 40)
+
+      assert path |> List.first() |> Map.fetch!(:content_type) == :buffer_content
+
+      assert Enum.map(path, & &1.content_type) == [
+               :buffer_content,
+               :window,
+               :editor_area,
+               :viewport
+             ]
+    end
+
+    test "returns no route for non-scrollable chrome" do
+      tree = FocusTree.from_layout(single_window_layout())
+      assert FocusTree.scroll_path(tree, 0, 5) == []
     end
   end
 

--- a/test/minga_editor/input/agent_mouse_test.exs
+++ b/test/minga_editor/input/agent_mouse_test.exs
@@ -18,6 +18,7 @@ defmodule MingaEditor.Input.AgentMouseTest do
   alias MingaEditor.Window
   alias MingaEditor.Window.Content
   alias MingaEditor.Input.AgentMouse
+  alias MingaEditor.Input.Router
   alias Minga.Mode
 
   # ── Test helpers ───────────────────────────────────────────────────────────
@@ -59,8 +60,8 @@ defmodule MingaEditor.Input.AgentMouseTest do
     }
   end
 
-  defp with_agent_split(state) do
-    {:ok, agent_buf} = BufferServer.start_link(content: "")
+  defp with_agent_split(state, agent_content \\ "") do
+    {:ok, agent_buf} = BufferServer.start_link(content: agent_content)
 
     state =
       AgentAccess.update_agent(state, fn agent ->
@@ -145,6 +146,26 @@ defmodule MingaEditor.Input.AgentMouseTest do
 
       # Should not crash and should unpin
       assert %EditorState{} = new_state
+    end
+
+    test "focus-tree routing scrolls inactive agent chat window without moving focus" do
+      agent_content = Enum.map_join(1..80, "\n", &"agent line #{&1}")
+      state = base_state() |> with_agent_split(agent_content) |> Layout.put()
+      active_id = state.workspace.windows.active
+
+      {agent_win_id, _agent_window} =
+        Enum.find(state.workspace.windows.map, fn {_id, window} ->
+          Content.agent_chat?(window.content)
+        end)
+
+      refute active_id == agent_win_id
+      {row, col, _w, _h} = agent_chat_window_rect(state)
+      before_top = Map.fetch!(state.workspace.windows.map, agent_win_id).viewport.top
+
+      new_state = Router.dispatch_mouse(state, row + 2, col + 2, :wheel_down, 0, :press, 1)
+
+      assert new_state.workspace.windows.active == active_id
+      assert Map.fetch!(new_state.workspace.windows.map, agent_win_id).viewport.top > before_top
     end
 
     test "scroll over file viewer sidebar scrolls preview", %{state: state, rect: rect} do

--- a/test/minga_editor/input/router_test.exs
+++ b/test/minga_editor/input/router_test.exs
@@ -2,6 +2,9 @@ defmodule MingaEditor.Input.RouterTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Test.InputRouterMouseProbe
+  alias MingaEditor.FocusTree
+  alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.Viewport
@@ -25,6 +28,69 @@ defmodule MingaEditor.Input.RouterTest do
       },
       focus_stack: Input.default_stack()
     }
+  end
+
+  defp probe_tree(deep_ref) do
+    FocusTree.link_tree(%FocusNode{
+      id: :viewport,
+      content_type: :viewport,
+      rect: {0, 0, 20, 10},
+      children: [
+        FocusNode.new(:editor_area, {0, 0, 20, 10},
+          children: [
+            FocusNode.new(:window, {0, 0, 20, 10},
+              handler: InputRouterMouseProbe,
+              ref: :window,
+              children: [
+                FocusNode.new(:buffer_content, {0, 0, 20, 10},
+                  handler: InputRouterMouseProbe,
+                  ref: deep_ref,
+                  scrollable?: true
+                )
+              ]
+            )
+          ]
+        )
+      ]
+    })
+  end
+
+  defp overlapping_scroll_tree do
+    FocusTree.link_tree(%FocusNode{
+      id: :viewport,
+      content_type: :viewport,
+      rect: {0, 0, 20, 10},
+      children: [
+        FocusNode.new(:buffer_content, {0, 0, 20, 10},
+          handler: InputRouterMouseProbe,
+          ref: :editor,
+          scrollable?: true
+        ),
+        FocusNode.new(:file_tree, {0, 0, 8, 10},
+          handler: InputRouterMouseProbe,
+          ref: :tree,
+          scrollable?: true
+        )
+      ]
+    })
+  end
+
+  defp separator_gap_tree do
+    FocusTree.link_tree(%FocusNode{
+      id: :viewport,
+      content_type: :viewport,
+      rect: {0, 0, 20, 10},
+      children: [
+        FocusNode.new(:buffer_content, {0, 0, 10, 10},
+          handler: InputRouterMouseProbe,
+          ref: :left
+        ),
+        FocusNode.new(:buffer_content, {0, 11, 9, 10},
+          handler: InputRouterMouseProbe,
+          ref: :right
+        )
+      ]
+    })
   end
 
   # Flushes all messages from the process mailbox, returning the count.
@@ -102,6 +168,42 @@ defmodule MingaEditor.Input.RouterTest do
       # Should have moved down then up, back to line 0
       cursor = BufferServer.cursor(state.workspace.buffers.active)
       assert elem(cursor, 0) == 0
+    end
+  end
+
+  describe "dispatch_mouse/7" do
+    test "calls the deepest hit node handler first" do
+      state = %{base_state() | focus_tree: probe_tree(:deep)}
+
+      _state = Router.dispatch_mouse(state, 5, 5, :left, 0, :press, 1)
+
+      assert_receive {:mouse_probe, :buffer_content, :deep}
+      refute_receive {:mouse_probe, :window, :window}, 20
+    end
+
+    test "bubbles to ancestors when the child passes through" do
+      state = %{base_state() | focus_tree: probe_tree({:pass, :child})}
+
+      _state = Router.dispatch_mouse(state, 5, 5, :left, 0, :press, 1)
+
+      assert_receive {:mouse_probe, :buffer_content, {:pass, :child}}
+      assert_receive {:mouse_probe, :window, :window}
+    end
+
+    test "wheel events start at the deepest scrollable node under the cursor" do
+      state = %{base_state() | focus_tree: overlapping_scroll_tree()}
+
+      _state = Router.dispatch_mouse(state, 3, 3, :wheel_down, 0, :press, 1)
+
+      assert_receive {:mouse_probe, :file_tree, :tree}
+      refute_receive {:mouse_probe, :buffer_content, :editor}, 20
+    end
+
+    test "clicking a separator gap without a handler is a no-op" do
+      state = %{base_state() | focus_tree: separator_gap_tree()}
+
+      assert ^state = Router.dispatch_mouse(state, 3, 10, :left, 0, :press, 1)
+      refute_receive {:mouse_probe, _type, _ref}, 20
     end
   end
 

--- a/test/minga_editor/integration/mouse_test.exs
+++ b/test/minga_editor/integration/mouse_test.exs
@@ -360,9 +360,6 @@ defmodule Minga.Integration.MouseTest do
   # ── Multi-region dispatch ──────────────────────────────────────────────────
 
   describe "multi-region dispatch" do
-    # TODO: This test needs rework - clicking in editor area after file tree
-    # open doesn't set :editor scope due to mouse dispatch layout issue.
-    @tag :skip
     test "click dispatches to correct region when file tree is open" do
       ctx = start_editor("hello world")
 
@@ -419,6 +416,16 @@ defmodule Minga.Integration.MouseTest do
 
       assert state.workspace.keymap_scope == :editor,
              "clicking in editor area should set :editor scope, got #{state.workspace.keymap_scope}"
+
+      # Click back inside the file tree area and verify focus follows the click.
+      send_mouse(ctx, 5, max(tree_sep - 2, 0), :left)
+      state = editor_state(ctx)
+
+      assert FileTree.focused?(state.workspace.file_tree),
+             "clicking in file tree should focus the file tree"
+
+      assert state.workspace.keymap_scope == :file_tree,
+             "clicking in file tree should set :file_tree scope, got #{state.workspace.keymap_scope}"
     end
   end
 

--- a/test/minga_editor/mouse_multi_click_test.exs
+++ b/test/minga_editor/mouse_multi_click_test.exs
@@ -157,7 +157,7 @@ defmodule MingaEditor.MouseMultiClickTest do
           "a very long line that extends beyond the viewport width for testing horizontal scroll"
         )
 
-      send_mouse(editor, 0, 0, :wheel_right, :press)
+      send_mouse(editor, @content_row, @gutter, :wheel_right, :press)
 
       vp = active_window_viewport(editor)
       assert vp.left == 6
@@ -169,8 +169,8 @@ defmodule MingaEditor.MouseMultiClickTest do
           "a very long line that extends beyond the viewport width for testing horizontal scroll"
         )
 
-      send_mouse(editor, 0, 0, :wheel_right, :press)
-      send_mouse(editor, 0, 0, :wheel_left, :press)
+      send_mouse(editor, @content_row, @gutter, :wheel_right, :press)
+      send_mouse(editor, @content_row, @gutter, :wheel_left, :press)
 
       vp = active_window_viewport(editor)
       assert vp.left == 0
@@ -178,7 +178,7 @@ defmodule MingaEditor.MouseMultiClickTest do
 
     test "wheel_left doesn't go negative" do
       {editor, _buffer} = start_editor("hello")
-      send_mouse(editor, 0, 0, :wheel_left, :press)
+      send_mouse(editor, @content_row, @gutter, :wheel_left, :press)
 
       vp = active_window_viewport(editor)
       assert vp.left == 0

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -3,6 +3,8 @@ defmodule MingaEditor.MouseTest do
 
   alias Minga.Buffer.Server, as: BufferServer
   alias MingaEditor
+  alias MingaEditor.Commands.Movement
+  alias MingaEditor.Layout
 
   # Content starts at row 1 because the tab bar occupies row 0.
   @content_row 1
@@ -48,6 +50,12 @@ defmodule MingaEditor.MouseTest do
   end
 
   defp state(editor), do: :sys.get_state(editor)
+
+  defp rightmost_window_layout(layout) do
+    Enum.max_by(layout.window_layouts, fn {_id, %{content: {_row, content_col, _w, _h}}} ->
+      content_col
+    end)
+  end
 
   describe "mouse scroll" do
     defp start_mouse_editor do
@@ -124,11 +132,34 @@ defmodule MingaEditor.MouseTest do
       assert line <= 29
     end
 
+    test "scroll over an inactive split window scrolls that window without moving focus" do
+      {editor, _buffer} = start_mouse_editor()
+
+      :sys.replace_state(editor, fn state -> Movement.execute(state, :split_vertical) end)
+      state = state(editor)
+      active_id = state.workspace.windows.active
+      layout = Layout.get(state)
+
+      {target_id, %{content: {row, col, _width, _height}}} =
+        rightmost_window_layout(layout)
+
+      assert target_id != active_id
+      target_before = Map.fetch!(state.workspace.windows.map, target_id).viewport.top
+      active_before = Map.fetch!(state.workspace.windows.map, active_id).viewport.top
+
+      send_mouse(editor, row + 1, col + 1, :wheel_down, :press)
+      state = state(editor)
+
+      assert state.workspace.windows.active == active_id
+      assert Map.fetch!(state.workspace.windows.map, active_id).viewport.top == active_before
+      assert Map.fetch!(state.workspace.windows.map, target_id).viewport.top > target_before
+    end
+
     test "scroll doesn't change mode" do
       {editor, _buffer} = start_mouse_editor()
       send_key(editor, ?i)
       send_mouse(editor, 0, 0, :wheel_down, :press)
-      assert Process.alive?(editor)
+      assert state(editor).workspace.editing.mode == :insert
     end
   end
 
@@ -168,6 +199,51 @@ defmodule MingaEditor.MouseTest do
       {line, _col} = BufferServer.cursor(buffer)
       # Verify cursor moved past the initial view (scrolled at least 4 lines).
       assert line >= 4
+    end
+
+    test "left click in an inactive split window focuses that window" do
+      {editor, _buffer} = start_mouse_editor()
+
+      :sys.replace_state(editor, fn state -> Movement.execute(state, :split_vertical) end)
+      state = state(editor)
+      active_id = state.workspace.windows.active
+      layout = Layout.get(state)
+
+      {target_id, %{content: {row, col, _width, _height}}} =
+        rightmost_window_layout(layout)
+
+      assert target_id != active_id
+
+      send_mouse(editor, row + 1, col + 1, :left, :press)
+      send_mouse(editor, row + 1, col + 1, :left, :release)
+
+      assert state(editor).workspace.windows.active == target_id
+    end
+
+    test "left click in a horizontally scrolled inactive split uses that window's scroll" do
+      {editor, buffer} = start_editor(String.duplicate("abcdefghijklmnopqrstuvwxyz", 2))
+
+      :sys.replace_state(editor, fn state -> Movement.execute(state, :split_vertical) end)
+      state = state(editor)
+      active_id = state.workspace.windows.active
+      layout = Layout.get(state)
+
+      {target_id, %{content: {row, col, _width, _height}}} =
+        rightmost_window_layout(layout)
+
+      assert target_id != active_id
+
+      send_mouse(editor, row, col + @gutter, :wheel_right, :press)
+      state = state(editor)
+      scrolled_left = Map.fetch!(state.workspace.windows.map, target_id).viewport.left
+      assert scrolled_left > 0
+      assert state.workspace.windows.active == active_id
+
+      send_mouse(editor, row, col + @gutter, :left, :press)
+
+      {_line, cursor_col} = BufferServer.cursor(buffer)
+      assert state(editor).workspace.windows.active == target_id
+      assert cursor_col == scrolled_left
     end
 
     test "left click on modeline row is ignored" do
@@ -212,6 +288,7 @@ defmodule MingaEditor.MouseTest do
       {line, col} = BufferServer.cursor(buffer)
       assert line == 1
       assert col == 2
+      assert state(editor).workspace.editing.mode == :normal
     end
 
     test "left click in command mode cancels command, returns to normal" do
@@ -222,6 +299,7 @@ defmodule MingaEditor.MouseTest do
       {line, col} = BufferServer.cursor(buffer)
       assert line == 1
       assert col == 2
+      assert state(editor).workspace.editing.mode == :normal
     end
 
     test "left click in insert mode moves cursor, stays functional" do

--- a/test/minga_editor/render_pipeline_test.exs
+++ b/test/minga_editor/render_pipeline_test.exs
@@ -10,13 +10,45 @@ defmodule MingaEditor.RenderPipelineTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Editing.Completion
+  alias MingaEditor.FocusTree
   alias MingaEditor.Layout
   alias MingaEditor.RenderPipeline
   alias MingaEditor.RenderPipeline.Scroll
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
   alias MingaEditor.Viewport
 
   import MingaEditor.RenderPipeline.TestHelpers
+
+  @spec completion_item(String.t()) :: Completion.item()
+  defp completion_item(label) do
+    %{
+      label: label,
+      kind: :text,
+      insert_text: label,
+      filter_text: label,
+      detail: "",
+      documentation: "",
+      sort_text: label,
+      text_edit: nil,
+      raw: nil
+    }
+  end
+
+  @spec find_focus_node(FocusTree.t() | nil, atom()) :: MingaEditor.FocusTree.Node.t() | nil
+  defp find_focus_node(nil, _content_type), do: nil
+
+  defp find_focus_node(
+         %MingaEditor.FocusTree.Node{content_type: content_type} = node,
+         content_type
+       ),
+       do: node
+
+  defp find_focus_node(%MingaEditor.FocusTree.Node{children: children}, content_type) do
+    Enum.find_value(children, &find_focus_node(&1, content_type))
+  end
 
   # ── Stage 1: Invalidation ─────────────────────────────────────────────────
 
@@ -82,6 +114,32 @@ defmodule MingaEditor.RenderPipelineTest do
         assert %EditorState{} = result
         assert_receive {:"$gen_cast", {:send_commands, _}}
       end
+    end
+
+    test "focus tree completion overlay uses the post-scroll viewport" do
+      state = base_state(content: long_content(80), rows: 10, cols: 80)
+      buffer = state.workspace.buffers.active
+      BufferServer.move_to(buffer, {60, 0})
+
+      completion = Completion.new([completion_item("alpha"), completion_item("beta")], {60, 0})
+
+      state =
+        ModalOverlay.open(
+          state,
+          :completion,
+          CompletionPayload.new(:test, completion: completion)
+        )
+
+      result = run_pipeline(state)
+      window = Map.fetch!(result.workspace.windows.map, result.workspace.windows.active)
+      node = find_focus_node(result.focus_tree, :completion_menu)
+
+      assert window.viewport.top > 0
+      assert node != nil
+      {row, col, _width, height} = node.rect
+      assert row >= 0
+      assert row + height <= result.terminal_viewport.rows
+      assert FocusTree.hit_test(result.focus_tree, row, col).content_type == :completion_menu
     end
   end
 

--- a/test/support/input_router_mouse_probe.ex
+++ b/test/support/input_router_mouse_probe.ex
@@ -1,0 +1,35 @@
+defmodule Minga.Test.InputRouterMouseProbe do
+  @moduledoc "Test-only mouse handler that records focus-tree dispatch order."
+
+  @behaviour MingaEditor.Input.Handler
+
+  @impl true
+  @spec handle_key(
+          MingaEditor.Input.Handler.handler_state(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          MingaEditor.Input.Handler.result()
+  def handle_key(state, _codepoint, _modifiers), do: {:passthrough, state}
+
+  @impl true
+  @spec handle_mouse_at_node(
+          MingaEditor.Input.Handler.handler_state(),
+          MingaEditor.FocusTree.Node.t(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: MingaEditor.Input.Handler.result()
+  def handle_mouse_at_node(state, node, _row, _col, _button, _mods, _event_type, _click_count) do
+    send(self(), {:mouse_probe, node.content_type, node.ref})
+
+    case node.ref do
+      {:pass, _tag} -> {:passthrough, state}
+      :pass -> {:passthrough, state}
+      _ -> {:handled, state}
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR
Mouse input now routes through a cached structural focus tree instead of each handler re-checking screen coordinates. This centralizes z-order, bubbling, scroll targeting, and click-to-focus behavior for editor windows, file tree, agent panel, picker, and completion UI.

Closes #1435

## Context
Issue #1435 replaces the flat mouse hit-test stack with a visible-region tree. The goal is to make mouse dispatch match the UI structure: hit-test the rendered hierarchy, dispatch to the deepest node, and bubble upward only when a handler explicitly passes through.

## Changes
- Added `MingaEditor.FocusTree` and `FocusTree.Node` with stable node ids, parent and sibling references, handler metadata, focusable nodes, and scrollable nodes.
- Build and cache the focus tree from layout and active overlays, including editor windows, gutters, modelines, file tree, agent regions, picker, and completion menu.
- Reworked `Input.Router.dispatch_mouse/7` to route through the focus tree, with wheel events starting at the deepest scrollable node under the cursor.
- Added node-aware mouse callbacks so picker, completion, agent, and file-tree handlers no longer need local `inside_*?` rect predicates.
- Added click-to-focus behavior for inactive editor windows and file tree clicks, while preserving scroll-over-inactive-window behavior without stealing focus.
- Fixed split-window horizontal mouse targeting so clicks use the hovered window's own horizontal viewport offset.
- Fixed focus-tree bubbling for agent chat scrolls so an inactive agent chat window scrolls under the cursor instead of scrolling the active editor window.
- Added shared completion menu geometry through `CompletionUI.menu_rect/2` so rendering and routing use the same bounds.

## Verification
- `mix compile --warnings-as-errors`
- `make lint`
- `mix test.llm` (7747 tests, 0 failures)
- Reviewer gate: PASS after fresh-eyes fixes

## Acceptance Criteria Addressed
- `MingaEditor.FocusTree` represents visible regions as a tree, and nodes carry rect, content type, parent, and sibling refs ✅
- `Input.Router.dispatch_mouse/7` finds the deepest matching node and routes through that node with bubbling ✅
- Ad-hoc `inside_*?` predicates in picker, completion, agent mouse, and file-tree routing were removed in favor of structural routing ✅
- Scroll-wheel routing targets the deepest scrollable node under the cursor, independent of keyboard focus ✅
- Click-to-focus works for editor windows and file tree regions ✅
- Existing mouse tests pass, with added coverage for focus-tree boundaries, scroll routing, horizontal split targeting, agent chat scroll routing, and click-to-focus behavior ✅
