### PR TITLE
fix(buffer): scrub dead buffer pids from inactive tab snapshots

### DIFF
--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -518,42 +518,14 @@ defmodule MingaEditor.State do
          %__MODULE__{workspace: %{buffers: %Buffers{} = bs}, buffer_monitors: monitors} = state,
          pid
        ) do
-    # Clean up monitor ref
     monitors = Map.delete(monitors, pid)
-
-    # Remove from buffer list
-    new_list = Enum.reject(bs.list, &(&1 == pid))
-
-    # Clear special buffer slots if they match
-    messages = if bs.messages == pid, do: nil, else: bs.messages
-    help = if bs.help == pid, do: nil, else: bs.help
-
-    # Determine new active buffer
-    {new_active, new_index} =
-      case new_list do
-        [] ->
-          {nil, 0}
-
-        _ ->
-          new_index = min(bs.active_index, length(new_list) - 1)
-          {Enum.at(new_list, new_index), new_index}
-      end
-
-    new_bs = %Buffers{
-      bs
-      | list: new_list,
-        active: new_active,
-        active_index: new_index,
-        messages: messages,
-        help: help
-    }
+    new_bs = Buffers.remove(bs, pid)
 
     state = %{
       update_workspace(state, &WorkspaceState.set_buffers(&1, new_bs))
       | buffer_monitors: monitors
     }
 
-    # Clear agent buffer or prompt buffer if the dead pid matches
     state =
       if state.shell_state.agent.buffer == pid do
         AgentAccess.update_agent(state, fn a -> %{a | buffer: nil} end)
@@ -570,7 +542,10 @@ defmodule MingaEditor.State do
         state
       end
 
-    state
+    case tab_bar(state) do
+      nil -> state
+      tb -> set_tab_bar(state, TabBar.scrub_dead_buffer(tb, pid))
+    end
   end
 
   # ── Active content context ───────────────────────────────────────────────────

--- a/lib/minga_editor/state/buffers.ex
+++ b/lib/minga_editor/state/buffers.ex
@@ -56,4 +56,31 @@ defmodule MingaEditor.State.Buffers do
       idx -> %{bs | active_index: idx, active: pid}
     end
   end
+
+  @doc "Removes a buffer pid, selecting a neighbor as the new active."
+  @spec remove(t(), pid()) :: t()
+  def remove(%__MODULE__{} = bs, pid) do
+    new_list = Enum.reject(bs.list, &(&1 == pid))
+    messages = if bs.messages == pid, do: nil, else: bs.messages
+    help = if bs.help == pid, do: nil, else: bs.help
+
+    {new_active, new_index} =
+      case new_list do
+        [] ->
+          {nil, 0}
+
+        _ ->
+          idx = min(bs.active_index, length(new_list) - 1)
+          {Enum.at(new_list, idx), idx}
+      end
+
+    %__MODULE__{
+      bs
+      | list: new_list,
+        active: new_active,
+        active_index: new_index,
+        messages: messages,
+        help: help
+    }
+  end
 end

--- a/lib/minga_editor/state/tab.ex
+++ b/lib/minga_editor/state/tab.ex
@@ -13,6 +13,8 @@ defmodule MingaEditor.State.Tab do
   editing state, viewport, etc.) stored directly. Restore reads only fields that exist on `MingaEditor.Workspace.State`; unknown legacy fields are ignored.
   """
 
+  alias MingaEditor.State.Buffers
+
   # Tab contexts store per-tab fields directly as flat maps.
 
   @typedoc "Unique tab identifier."
@@ -143,4 +145,12 @@ defmodule MingaEditor.State.Tab do
     do: true
 
   def background_subagent?(%__MODULE__{}), do: false
+
+  @doc "Removes a dead buffer pid from this tab's context snapshot."
+  @spec scrub_buffer(t(), pid()) :: t()
+  def scrub_buffer(%__MODULE__{context: %{buffers: %Buffers{} = bs} = context} = tab, pid) do
+    %{tab | context: %{context | buffers: Buffers.remove(bs, pid)}}
+  end
+
+  def scrub_buffer(%__MODULE__{} = tab, _pid), do: tab
 end

--- a/lib/minga_editor/state/tab_bar.ex
+++ b/lib/minga_editor/state/tab_bar.ex
@@ -249,6 +249,12 @@ defmodule MingaEditor.State.TabBar do
     %{tb | tabs: new_tabs}
   end
 
+  @doc "Removes a dead buffer pid from all tab context snapshots."
+  @spec scrub_dead_buffer(t(), pid()) :: t()
+  def scrub_dead_buffer(%__MODULE__{tabs: tabs} = tb, pid) do
+    %{tb | tabs: Enum.map(tabs, &Tab.scrub_buffer(&1, pid))}
+  end
+
   @doc "Returns all tabs matching the given kind."
   @spec filter_by_kind(t(), Tab.kind()) :: [Tab.t()]
   def filter_by_kind(%__MODULE__{tabs: tabs}, kind) do

--- a/test/minga_editor/state/buffer_lifecycle_test.exs
+++ b/test/minga_editor/state/buffer_lifecycle_test.exs
@@ -510,4 +510,113 @@ defmodule MingaEditor.State.BufferLifecycleTest do
              "window buffer pid should remain the agent buffer"
     end
   end
+
+  # ── Inactive tab scrubbing on buffer death ──────────────────────────────────
+
+  describe "close_buffer_pure/2 scrubs inactive tab snapshots" do
+    test "removes dead pid from inactive tab's context.buffers" do
+      # Tab A is active with buf_a; Tab B is inactive holding buf_b
+      buf_a = start_buffer("file A")
+      buf_b = start_buffer("file B")
+
+      win_id = 1
+      window = Window.new(win_id, buf_a, 24, 80)
+
+      state = %EditorState{
+        port_manager: self(),
+        workspace: %WorkspaceState{
+          viewport: Viewport.new(24, 80),
+          editing: VimState.new(),
+          buffers: %Buffers{active: buf_a, list: [buf_a, buf_b], active_index: 0},
+          windows: %Windows{
+            tree: WindowTree.new(win_id),
+            map: %{win_id => window},
+            active: win_id,
+            next_id: win_id + 1
+          }
+        }
+      }
+
+      state = EditorState.monitor_buffer(state, buf_a)
+      state = EditorState.monitor_buffer(state, buf_b)
+
+      # Set up two tabs: Tab A (active, id=1), Tab B (inactive, id=2)
+      tab_a = Tab.new_file(1, "a.ex")
+      {tb, tab_b} = TabBar.insert(TabBar.new(tab_a), :file, "b.ex")
+
+      # Snapshot Tab B with buf_b as its active buffer
+      tab_b_context = %{
+        buffers: %Buffers{active: buf_b, list: [buf_b], active_index: 0},
+        editing: VimState.new(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      tb = TabBar.update_context(tb, tab_b.id, tab_b_context)
+
+      # Snapshot Tab A (active) with current workspace
+      context_a = EditorState.snapshot_tab_context(EditorState.set_tab_bar(state, tb))
+      tb = TabBar.update_context(tb, 1, context_a)
+      state = EditorState.set_tab_bar(state, tb)
+
+      # Kill buf_b via close_buffer_pure
+      {new_state, _effects} = EditorState.close_buffer_pure(state, buf_b)
+
+      # AC1 + AC2: Tab B's snapshot should be scrubbed
+      tb_after = EditorState.tab_bar(new_state)
+      tab_b_after = TabBar.get(tb_after, tab_b.id)
+
+      refute buf_b in tab_b_after.context.buffers.list
+      assert tab_b_after.context.buffers.active != buf_b
+
+      # AC3: Restoring Tab B's context produces a usable workspace
+      restored_ws = WorkspaceState.restore_tab_context(new_state.workspace, tab_b_after.context)
+      refute buf_b in restored_ws.buffers.list
+      assert restored_ws.buffers.active != buf_b
+    end
+
+    test "handles tab whose only buffer died (empty list after scrub)" do
+      buf_only = start_buffer("only buffer")
+      win_id = 1
+      window = Window.new(win_id, buf_only, 24, 80)
+
+      state = %EditorState{
+        port_manager: self(),
+        workspace: %WorkspaceState{
+          viewport: Viewport.new(24, 80),
+          editing: VimState.new(),
+          buffers: %Buffers{active: buf_only, list: [buf_only], active_index: 0},
+          windows: %Windows{
+            tree: WindowTree.new(win_id),
+            map: %{win_id => window},
+            active: win_id,
+            next_id: win_id + 1
+          }
+        }
+      }
+
+      state = EditorState.monitor_buffer(state, buf_only)
+
+      tab_a = Tab.new_file(1, "a.ex")
+      {tb, tab_b} = TabBar.insert(TabBar.new(tab_a), :file, "b.ex")
+
+      tab_b_context = %{
+        buffers: %Buffers{active: buf_only, list: [buf_only], active_index: 0},
+        editing: VimState.new(),
+        viewport: Viewport.new(24, 80)
+      }
+
+      tb = TabBar.update_context(tb, tab_b.id, tab_b_context)
+      context_a = EditorState.snapshot_tab_context(EditorState.set_tab_bar(state, tb))
+      tb = TabBar.update_context(tb, 1, context_a)
+      state = EditorState.set_tab_bar(state, tb)
+
+      {new_state, _effects} = EditorState.close_buffer_pure(state, buf_only)
+
+      tb_after = EditorState.tab_bar(new_state)
+      tab_b_after = TabBar.get(tb_after, tab_b.id)
+
+      assert tab_b_after.context.buffers.list == []
+      assert tab_b_after.context.buffers.active == nil
+    end
+  end
 end

--- a/test/minga_editor/state/buffers_test.exs
+++ b/test/minga_editor/state/buffers_test.exs
@@ -3,6 +3,65 @@ defmodule MingaEditor.State.BuffersTest do
 
   alias MingaEditor.State.Buffers
 
+  describe "remove/2" do
+    test "removes pid from list and selects neighbor" do
+      bs = %Buffers{list: [:a, :b, :c], active: :b, active_index: 1}
+      result = Buffers.remove(bs, :b)
+
+      assert result.list == [:a, :c]
+      assert result.active == :c
+      assert result.active_index == 1
+    end
+
+    test "removes only buffer leaving empty state" do
+      bs = %Buffers{list: [:a], active: :a, active_index: 0}
+      result = Buffers.remove(bs, :a)
+
+      assert result.list == []
+      assert result.active == nil
+      assert result.active_index == 0
+    end
+
+    test "clears messages slot when it matches" do
+      bs = %Buffers{list: [:a, :msg], active: :a, active_index: 0, messages: :msg}
+      result = Buffers.remove(bs, :msg)
+
+      assert result.messages == nil
+      refute :msg in result.list
+    end
+
+    test "clears help slot when it matches" do
+      bs = %Buffers{list: [:a, :h], active: :a, active_index: 0, help: :h}
+      result = Buffers.remove(bs, :h)
+
+      assert result.help == nil
+      refute :h in result.list
+    end
+
+    test "preserves messages slot when it does not match" do
+      bs = %Buffers{list: [:a, :b], active: :b, active_index: 1, messages: :a}
+      result = Buffers.remove(bs, :b)
+
+      assert result.messages == :a
+    end
+
+    test "no-op when pid is not present" do
+      bs = %Buffers{list: [:a, :b], active: :a, active_index: 0}
+      result = Buffers.remove(bs, :z)
+
+      assert result == bs
+    end
+
+    test "clamps active_index when last element is removed" do
+      bs = %Buffers{list: [:a, :b, :c], active: :c, active_index: 2}
+      result = Buffers.remove(bs, :c)
+
+      assert result.list == [:a, :b]
+      assert result.active == :b
+      assert result.active_index == 1
+    end
+  end
+
   describe "add_background/2" do
     test "appends pid without changing active or active_index" do
       bs = %Buffers{list: [:existing], active: :existing, active_index: 0}

--- a/test/minga_editor/state/tab_bar_test.exs
+++ b/test/minga_editor/state/tab_bar_test.exs
@@ -626,7 +626,11 @@ defmodule MingaEditor.State.TabBarTest do
       live = :live_pid
 
       tab1 = file_tab(1, "active")
-      tab2 = %{file_tab(2, "inactive") | context: %{buffers: %Buffers{list: [dead, live], active: dead, active_index: 0}}}
+
+      tab2 = %{
+        file_tab(2, "inactive")
+        | context: %{buffers: %Buffers{list: [dead, live], active: dead, active_index: 0}}
+      }
 
       tb = %TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
       result = TabBar.scrub_dead_buffer(tb, dead)
@@ -650,8 +654,15 @@ defmodule MingaEditor.State.TabBarTest do
 
       dead = :dead_pid
 
-      tab1 = %{file_tab(1, "a") | context: %{buffers: %Buffers{list: [dead], active: dead, active_index: 0}}}
-      tab2 = %{file_tab(2, "b") | context: %{buffers: %Buffers{list: [:live, dead], active: :live, active_index: 0}}}
+      tab1 = %{
+        file_tab(1, "a")
+        | context: %{buffers: %Buffers{list: [dead], active: dead, active_index: 0}}
+      }
+
+      tab2 = %{
+        file_tab(2, "b")
+        | context: %{buffers: %Buffers{list: [:live, dead], active: :live, active_index: 0}}
+      }
 
       tb = %TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
       result = TabBar.scrub_dead_buffer(tb, dead)

--- a/test/minga_editor/state/tab_bar_test.exs
+++ b/test/minga_editor/state/tab_bar_test.exs
@@ -617,4 +617,49 @@ defmodule MingaEditor.State.TabBarTest do
       assert TabBar.get_group(tb, ws.id).agent_status == :error
     end
   end
+
+  describe "scrub_dead_buffer/2" do
+    test "removes dead pid from inactive tab's context.buffers" do
+      alias MingaEditor.State.Buffers
+
+      dead = :dead_pid
+      live = :live_pid
+
+      tab1 = file_tab(1, "active")
+      tab2 = %{file_tab(2, "inactive") | context: %{buffers: %Buffers{list: [dead, live], active: dead, active_index: 0}}}
+
+      tb = %TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
+      result = TabBar.scrub_dead_buffer(tb, dead)
+
+      scrubbed = TabBar.get(result, 2)
+      assert scrubbed.context.buffers.list == [live]
+      assert scrubbed.context.buffers.active == live
+      refute dead in scrubbed.context.buffers.list
+    end
+
+    test "no-op for tabs without context.buffers" do
+      tab1 = file_tab(1, "empty context")
+      tb = TabBar.new(tab1)
+      result = TabBar.scrub_dead_buffer(tb, :some_pid)
+
+      assert result == tb
+    end
+
+    test "scrubs multiple tabs in one pass" do
+      alias MingaEditor.State.Buffers
+
+      dead = :dead_pid
+
+      tab1 = %{file_tab(1, "a") | context: %{buffers: %Buffers{list: [dead], active: dead, active_index: 0}}}
+      tab2 = %{file_tab(2, "b") | context: %{buffers: %Buffers{list: [:live, dead], active: :live, active_index: 0}}}
+
+      tb = %TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
+      result = TabBar.scrub_dead_buffer(tb, dead)
+
+      assert TabBar.get(result, 1).context.buffers.list == []
+      assert TabBar.get(result, 1).context.buffers.active == nil
+      assert TabBar.get(result, 2).context.buffers.list == [:live]
+      refute dead in TabBar.get(result, 2).context.buffers.list
+    end
+  end
 end

--- a/test/minga_editor/state/tab_test.exs
+++ b/test/minga_editor/state/tab_test.exs
@@ -1,6 +1,7 @@
 defmodule MingaEditor.State.TabTest do
   use ExUnit.Case, async: true
 
+  alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
 
   describe "new_file/2" do
@@ -74,6 +75,32 @@ defmodule MingaEditor.State.TabTest do
 
     test "defaults to false" do
       assert Tab.new_agent(1).attention == false
+    end
+  end
+
+  describe "scrub_buffer/2" do
+    test "removes dead pid from context.buffers" do
+      bs = %Buffers{list: [:dead, :live], active: :dead, active_index: 0}
+      tab = Tab.new_file(1) |> Tab.set_context(%{buffers: bs})
+
+      result = Tab.scrub_buffer(tab, :dead)
+
+      assert result.context.buffers.list == [:live]
+      assert result.context.buffers.active == :live
+    end
+
+    test "no-op when context is empty" do
+      tab = Tab.new_file(1)
+      result = Tab.scrub_buffer(tab, :some_pid)
+
+      assert result == tab
+    end
+
+    test "no-op when context has no buffers key" do
+      tab = Tab.new_file(1) |> Tab.set_context(%{editing: :normal})
+      result = Tab.scrub_buffer(tab, :some_pid)
+
+      assert result == tab
     end
   end
 end


### PR DESCRIPTION
## Summary

- Extract `Buffers.remove/2` as a reusable pure function for removing a pid from a Buffers struct
- Add `Tab.scrub_buffer/2` and `TabBar.scrub_dead_buffer/2` to walk inactive tab context snapshots
- Wire the tab-bar scrub into `do_remove_dead_buffer/2` so dead pids never survive in inactive tab contexts
- Refactor: replaces 30 lines of inline Buffers reconstruction with a single `Buffers.remove/2` call

## Test plan

- [x] Unit tests for `Buffers.remove/2` (7 cases: neighbor selection, empty list, special slot clearing, clamping, no-op)
- [x] Unit tests for `Tab.scrub_buffer/2` (3 cases: scrub with Buffers, empty context, missing buffers key)
- [x] Unit tests for `TabBar.scrub_dead_buffer/2` (3 cases: single tab, no-op, multi-tab pass)
- [x] Integration tests for `close_buffer_pure/2` inactive tab scrubbing (2 cases: multi-buffer tab, only-buffer tab)
- [x] Full suite passes (7747 tests, 0 failures)
- [x] Lint clean (format + credo + dialyzer)

Closes #1399

🤖 Generated with [Claude Code](https://claude.com/claude-code)