### PR TITLE
fix(agent): clarify MCP env validation

### DIFF
--- a/lib/minga_agent/mcp/server_config.ex
+++ b/lib/minga_agent/mcp/server_config.ex
@@ -126,7 +126,8 @@ defmodule MingaAgent.MCP.ServerConfig do
         normalize_env(env)
 
       other ->
-        {:error, "MCP server env must be a map of string keys and values, got: #{inspect(other)}"}
+        {:error,
+         "MCP server env must be a map of string or atom keys and string values, got: #{inspect(other)}"}
     end
   end
 
@@ -155,7 +156,8 @@ defmodule MingaAgent.MCP.ServerConfig do
     if Enum.all?(pairs, fn {key, value} -> is_binary(key) and is_binary(value) end) do
       {:ok, Map.new(pairs)}
     else
-      {:error, "MCP server env must contain string keys and values, got: #{inspect(env)}"}
+      {:error,
+       "MCP server env must contain string or atom keys and string values, got: #{inspect(env)}"}
     end
   end
 

--- a/test/minga_agent/mcp/registry_test.exs
+++ b/test/minga_agent/mcp/registry_test.exs
@@ -17,7 +17,7 @@ defmodule MingaAgent.MCP.RegistryTest do
     }
   end
 
-  test "starts multiple healthy servers and builds a combined tool index" do
+  test "starts multiple healthy servers and returns all tools" do
     {registry, tools, failures} =
       Registry.start_all([config("Alpha"), config("Beta")], self(),
         transport: FakeTransport,

--- a/test/minga_agent/mcp/server_config_test.exs
+++ b/test/minga_agent/mcp/server_config_test.exs
@@ -31,6 +31,18 @@ defmodule MingaAgent.MCP.ServerConfigTest do
     assert config.enabled == false
   end
 
+  test "env errors explain atom keys are allowed but values must be strings" do
+    assert {:error, reason} =
+             ServerConfig.normalize(%{
+               name: "local-tools",
+               command: "node",
+               env: %{TOKEN: :not_a_string}
+             })
+
+    assert reason =~ "string or atom keys"
+    assert reason =~ "string values"
+  end
+
   test "rejects missing command" do
     assert {:error, reason} = ServerConfig.normalize(%{name: "local"})
     assert reason =~ "command is required"


### PR DESCRIPTION
# TL;DR
Clarifies MCP env validation text so it matches the accepted config shape, and cleans up one stale registry test name after the tool-index cleanup.

Follow-up to #1512 and #1519.

## Context
PR #1519 added multi-server MCP support and was merged while a final fresh-eyes pass was in progress. This PR carries the small cleanup found during that pass onto current `main`.

## Changes
- Updates MCP env validation errors to say env keys may be strings or atoms, while values must be strings.
- Adds focused coverage for the env validation message.
- Renames a registry test that still mentioned a removed internal tool index.

## Verification
- `mix test test/minga_agent/mcp/server_config_test.exs test/minga_agent/mcp/registry_test.exs`
- `mix test test/minga_agent/mcp test/minga_agent/providers/native_mcp_test.exs test/minga_agent/config_test.exs test/minga/config/options_test.exs test/minga_agent/session_test.exs`
- `mix compile --warnings-as-errors`
- `make lint`
- `mix test.llm`
