### PR TITLE
chore(editor): document agent-event tab-switch race analysis

### DIFF
--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -1398,6 +1398,12 @@ defmodule MingaEditor.State do
   defp apply_buffer_effect(state, :start_spinner),
     do: maybe_restart_incoming_spinner(state)
 
+  # Race safety: agent events queued during the blocking editor_snapshot/1 call
+  # cannot misroute. GenServer serialisation means no handle_info runs until this
+  # callback returns. Once it does, stale events from the outgoing session fail
+  # the AgentAccess.session/1 identity check (minga_editor.ex:692) and fall into
+  # the background path, where find_by_session matches by session pid (unique per
+  # tab, never reassigned on switch). See #1401 for the full analysis.
   defp apply_buffer_effect(state, {:rebuild_agent_session, %Tab{kind: :agent} = tab}) do
     state
     |> rebuild_agent_from_session(tab)


### PR DESCRIPTION
## Summary

- Investigated whether queued `:agent_event` messages can reach the wrong tab during a tab switch (#1401)
- Concluded the race is **not reachable**: GenServer callback serialization prevents event dispatch mid-switch, and `find_by_session` routes background events by session pid (unique per tab, never reassigned on switch)
- Added an explanatory comment near `apply_buffer_effects` so future investigators don't redo the analysis

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test.llm` passes (7789 tests, 0 failures)
- [x] `make lint` passes
- [x] No behavioral changes; comment-only addition

Closes #1401

🤖 Generated with [Claude Code](https://claude.com/claude-code)