### PR TITLE
fix(macos): pre-clip line textures for horizontal scroll

### DIFF
--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -601,7 +601,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.fontManager = fm
 
         // Initial grid dimensions.
-        let cols = UInt16(defaultWindowWidth / CGFloat(face.cellWidth))
+        let usableWidth = defaultWindowWidth - CoreTextMetalRenderer.gutterPixelPaddingPt
+        let cols = UInt16(max(usableWidth / CGFloat(face.cellWidth), 1))
         let rows = UInt16(defaultWindowHeight / CGFloat(face.cellHeight))
 
         // CoreText renderer.
@@ -859,7 +860,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Re-send ready event so the new BEAM knows our dimensions.
         if let nsView = editorNSView {
-            let cols = UInt16(nsView.bounds.width / CGFloat(nsView.cellWidth))
+            let usableWidth = nsView.bounds.width - CoreTextMetalRenderer.gutterPixelPaddingPt
+            let cols = UInt16(max(usableWidth / CGFloat(nsView.cellWidth), 1))
             let rows = UInt16(nsView.bounds.height / CGFloat(nsView.cellHeight))
             enc.sendReady(cols: cols, rows: rows)
         }

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -600,9 +600,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let fm = FontManager(name: defaultFontName, size: defaultFontSize, scale: scale)
         self.fontManager = fm
 
-        // Initial grid dimensions.
-        let usableWidth = defaultWindowWidth - CoreTextMetalRenderer.gutterPixelPaddingPt
-        let cols = UInt16(max(usableWidth / CGFloat(face.cellWidth), 1))
+        // Initial grid dimensions (no gutter padding subtraction yet; the first
+        // setFrameSize call will send corrected cols once the gutter is established).
+        let cols = UInt16(max(defaultWindowWidth / CGFloat(face.cellWidth), 1))
         let rows = UInt16(defaultWindowHeight / CGFloat(face.cellHeight))
 
         // CoreText renderer.
@@ -860,8 +860,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Re-send ready event so the new BEAM knows our dimensions.
         if let nsView = editorNSView {
-            let usableWidth = nsView.bounds.width - CoreTextMetalRenderer.gutterPixelPaddingPt
-            let cols = UInt16(max(usableWidth / CGFloat(nsView.cellWidth), 1))
+            let gutterPad: CGFloat = nsView.dispatcher.frameState.gutterCol > 0 ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
+            let cols = UInt16(max((nsView.bounds.width - gutterPad) / CGFloat(nsView.cellWidth), 1))
             let rows = UInt16(nsView.bounds.height / CGFloat(nsView.cellHeight))
             enc.sendReady(cols: cols, rows: rows)
         }

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -63,6 +63,11 @@ private let ctBgClearColorDefault = MTLClearColor(red: 0.01298, green: 0.01298, 
 /// in the render path, and all callers are on the main thread already.
 @MainActor
 final class CoreTextMetalRenderer {
+    /// Total gutter pixel padding in points (left margin + right separator gap).
+    /// Subtracted from the view width when computing cols for the BEAM so
+    /// `content_w` accurately reflects the visible content area.
+    static let gutterPixelPaddingPt: CGFloat = 14.0  // 6pt left margin + 8pt right gap
+
     let device: MTLDevice
     let commandQueue: MTLCommandQueue
     private let bgPipeline: MTLRenderPipelineState
@@ -417,8 +422,7 @@ final class CoreTextMetalRenderer {
                 // so each texture is at most viewport-wide. Fixes gutter bleedthrough
                 // (no leftward position shift) and text truncation (texture always
                 // covers the visible portion).
-                let gutterPaddingCols = Int(ceil((gutterLeftMarginPx + gutterPaddingPx) / (cellW * scale)))
-                let contentCols = max(Int(frameState.cols) - Int(gutter.lineNumberWidth) - Int(gutter.signColWidth) - gutterPaddingCols, 1)
+                let contentCols = max(Int(frameState.cols) - Int(gutter.lineNumberWidth) - Int(gutter.signColWidth), 1)
                 let scrollLeftInt = Int(content.scrollLeft)
                 var clippedRows: [GUIVisualRow] = []
                 clippedRows.reserveCapacity(content.rows.count)

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -417,7 +417,8 @@ final class CoreTextMetalRenderer {
                 // so each texture is at most viewport-wide. Fixes gutter bleedthrough
                 // (no leftward position shift) and text truncation (texture always
                 // covers the visible portion).
-                let contentCols = max(Int(frameState.cols) - Int(gutter.lineNumberWidth) - Int(gutter.signColWidth), 1)
+                let gutterPaddingCols = Int(ceil((gutterLeftMarginPx + gutterPaddingPx) / (cellW * scale)))
+                let contentCols = max(Int(frameState.cols) - Int(gutter.lineNumberWidth) - Int(gutter.signColWidth) - gutterPaddingCols, 1)
                 let scrollLeftInt = Int(content.scrollLeft)
                 var clippedRows: [GUIVisualRow] = []
                 clippedRows.reserveCapacity(content.rows.count)

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -412,16 +412,30 @@ final class CoreTextMetalRenderer {
                     semanticOverlayQuads.append(quad)
                 }
 
-                // Render line textures from semantic content into atlas.
-                for (rowIdx, row) in content.rows.enumerated() {
-                    if let atlas, let entry = wcr.renderRowToAtlas(displayRow: UInt16(rowIdx), row: row, atlas: atlas) {
+                // Pre-clip all rows to the visible viewport window.
+                // Drops scrollLeft columns from the start and limits to viewport width,
+                // so each texture is at most viewport-wide. Fixes gutter bleedthrough
+                // (no leftward position shift) and text truncation (texture always
+                // covers the visible portion).
+                let contentCols = max(Int(frameState.cols) - Int(gutter.lineNumberWidth) - Int(gutter.signColWidth), 1)
+                let scrollLeftInt = Int(content.scrollLeft)
+                var clippedRows: [GUIVisualRow] = []
+                clippedRows.reserveCapacity(content.rows.count)
+                for row in content.rows {
+                    clippedRows.append(
+                        wcr.clipRowToViewport(row, scrollLeft: scrollLeftInt, viewportCols: contentCols)
+                    )
+                }
+
+                // Render pre-clipped line textures into atlas.
+                for (rowIdx, clippedRow) in clippedRows.enumerated() {
+                    if let atlas, let entry = wcr.renderRowToAtlas(displayRow: UInt16(rowIdx), row: clippedRow, atlas: atlas) {
                         let yPos = windowRowOffset + Float(rowIdx) * displayCellH * scale
-                        // Center text vertically within the expanded row when line spacing > 1.0.
                         let textYOffset = (displayCellH - cellH) * scale * 0.5
 
                         let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
                         var lineGPU = LineGPU()
-                        lineGPU.position = SIMD2<Float>(contentColOffset - hScrollPx, yPos + textYOffset)
+                        lineGPU.position = SIMD2<Float>(contentColOffset, yPos + textYOffset)
                         lineGPU.size = SIMD2<Float>(Float(entry.pixelWidth), Float(entry.pixelHeight))
                         lineGPU.uvOrigin = uvOrigin
                         lineGPU.uvSize = uvSize
@@ -437,13 +451,10 @@ final class CoreTextMetalRenderer {
                     }
 
                     for (rowIndex, rowAnnotations) in annotationsByRow {
-                        // Re-call renderRowToAtlas to get the cached line width.
-                        // Returns the entry computed in the content pass above
-                        // (content hash matches, no re-rasterization).
                         let linePixelWidth: Float
-                        if Int(rowIndex) < content.rows.count {
-                            let row = content.rows[Int(rowIndex)]
-                            if let lineEntry = wcr.renderRowToAtlas(displayRow: rowIndex, row: row, atlas: atlas) {
+                        if Int(rowIndex) < clippedRows.count {
+                            let clippedRow = clippedRows[Int(rowIndex)]
+                            if let lineEntry = wcr.renderRowToAtlas(displayRow: rowIndex, row: clippedRow, atlas: atlas) {
                                 linePixelWidth = Float(lineEntry.pixelWidth)
                             } else {
                                 linePixelWidth = 0
@@ -453,7 +464,7 @@ final class CoreTextMetalRenderer {
                         }
 
                         let rowY = windowRowOffset + Float(rowIndex) * displayCellH * scale
-                        var cursorX = contentColOffset - hScrollPx + linePixelWidth
+                        var cursorX = contentColOffset + linePixelWidth
                             + Float(wcr.annotationGap) * scale
 
                         for (annIdx, ann) in rowAnnotations.enumerated() {

--- a/macos/Sources/Renderer/WindowContentRenderer.swift
+++ b/macos/Sources/Renderer/WindowContentRenderer.swift
@@ -376,6 +376,83 @@ final class WindowContentRenderer {
         return hasher.finalize()
     }
 
+    // MARK: - Horizontal Scroll Clipping
+
+    /// Clips a visual row's text and spans to the visible viewport window.
+    ///
+    /// Drops `scrollLeft` display columns from the start and keeps at most
+    /// `viewportCols` display columns. Span boundaries are adjusted to
+    /// the clipped coordinate system (0-based from the visible left edge).
+    func clipRowToViewport(_ row: GUIVisualRow, scrollLeft: Int, viewportCols: Int) -> GUIVisualRow {
+        let text = row.text
+        guard !text.isEmpty else { return row }
+
+        let totalDisplayCols: Int
+        let clippedText: String
+
+        if text.utf8.allSatisfy({ $0 < 0x80 }) {
+            totalDisplayCols = text.count
+            let clipStart = min(scrollLeft, totalDisplayCols)
+            let clipEnd = min(scrollLeft + viewportCols, totalDisplayCols)
+            guard clipStart < clipEnd else {
+                return GUIVisualRow(rowType: row.rowType, bufLine: row.bufLine,
+                                   contentHash: scrollContentHash(row.contentHash, scrollLeft: scrollLeft),
+                                   text: "", spans: [])
+            }
+            let startIndex = text.index(text.startIndex, offsetBy: clipStart)
+            let endIndex = text.index(text.startIndex, offsetBy: clipEnd)
+            clippedText = String(text[startIndex..<endIndex])
+        } else {
+            let columnMap = buildDisplayColumnMap(for: text)
+            totalDisplayCols = max(columnMap.count - 1, 0)
+            let clipStart = min(scrollLeft, totalDisplayCols)
+            let clipEnd = min(scrollLeft + viewportCols, totalDisplayCols)
+            guard clipStart < clipEnd, clipEnd < columnMap.count else {
+                return GUIVisualRow(rowType: row.rowType, bufLine: row.bufLine,
+                                   contentHash: scrollContentHash(row.contentHash, scrollLeft: scrollLeft),
+                                   text: "", spans: [])
+            }
+            let startIdx = columnMap[clipStart]
+            let endIdx = columnMap[clipEnd]
+            clippedText = String(text[startIdx..<endIdx])
+        }
+
+        let clippedSpans = clipSpans(row.spans, scrollLeft: scrollLeft, viewportCols: viewportCols)
+        let newHash = scrollContentHash(row.contentHash, scrollLeft: scrollLeft)
+
+        return GUIVisualRow(
+            rowType: row.rowType, bufLine: row.bufLine,
+            contentHash: newHash, text: clippedText, spans: clippedSpans
+        )
+    }
+
+    private func clipSpans(_ spans: [GUIHighlightSpan], scrollLeft: Int, viewportCols: Int) -> [GUIHighlightSpan] {
+        spans.compactMap { span in
+            let spanStart = Int(span.startCol)
+            let spanEnd = Int(span.endCol)
+
+            guard spanEnd > scrollLeft, spanStart < scrollLeft + viewportCols else { return nil }
+
+            let newStart = UInt16(max(spanStart - scrollLeft, 0))
+            let newEnd = UInt16(min(spanEnd - scrollLeft, viewportCols))
+            guard newStart < newEnd else { return nil }
+
+            return GUIHighlightSpan(
+                startCol: newStart, endCol: newEnd,
+                fg: span.fg, bg: span.bg,
+                attrs: span.attrs, fontWeight: span.fontWeight, fontId: span.fontId
+            )
+        }
+    }
+
+    private func scrollContentHash(_ baseHash: UInt32, scrollLeft: Int) -> UInt32 {
+        guard scrollLeft > 0 else { return baseHash }
+        var hasher = Hasher()
+        hasher.combine(baseHash)
+        hasher.combine(scrollLeft)
+        return UInt32(truncatingIfNeeded: hasher.finalize())
+    }
+
     // MARK: - Attributed String Building
 
     /// Builds an NSAttributedString from composed text and pre-resolved spans.

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -278,8 +278,8 @@ final class EditorNSView: MTKView {
         let newCellH = CGFloat(newFace.cellHeight)
         guard newCellW > 0, newCellH > 0 else { return }
 
-        let usableWidth = frame.width - CoreTextMetalRenderer.gutterPixelPaddingPt
-        let newCols = UInt16(max(usableWidth / newCellW, 1))
+        let gutterPad: CGFloat = dispatcher.frameState.gutterCol > 0 ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
+        let newCols = UInt16(max((frame.width - gutterPad) / newCellW, 1))
         let newRows = UInt16(max(frame.height / newCellH, 1))
 
         if newCols != dispatcher.frameState.cols || newRows != dispatcher.frameState.rows {
@@ -401,8 +401,8 @@ final class EditorNSView: MTKView {
 
         guard newSize.width > 0, newSize.height > 0 else { return }
 
-        let usableWidth = newSize.width - CoreTextMetalRenderer.gutterPixelPaddingPt
-        let newCols = UInt16(max(usableWidth / cellWidth, 1))
+        let gutterPad: CGFloat = dispatcher.frameState.gutterCol > 0 ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
+        let newCols = UInt16(max((newSize.width - gutterPad) / cellWidth, 1))
         let newRows = UInt16(max(newSize.height / cellHeight, 1))
 
         if !readySent {
@@ -459,8 +459,8 @@ final class EditorNSView: MTKView {
         guard effectiveCellH > 0 else { return }
 
         let newRows = UInt16(max(frame.height / effectiveCellH, 1))
-        let usableWidth = frame.width - CoreTextMetalRenderer.gutterPixelPaddingPt
-        let cols = UInt16(max(usableWidth / cellWidth, 1))
+        let gutterPad: CGFloat = dispatcher.frameState.gutterCol > 0 ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
+        let cols = UInt16(max((frame.width - gutterPad) / cellWidth, 1))
 
         if newRows != dispatcher.frameState.rows {
             dispatcher.frameState.resize(newCols: cols, newRows: newRows)

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -278,7 +278,8 @@ final class EditorNSView: MTKView {
         let newCellH = CGFloat(newFace.cellHeight)
         guard newCellW > 0, newCellH > 0 else { return }
 
-        let newCols = UInt16(max(frame.width / newCellW, 1))
+        let usableWidth = frame.width - CoreTextMetalRenderer.gutterPixelPaddingPt
+        let newCols = UInt16(max(usableWidth / newCellW, 1))
         let newRows = UInt16(max(frame.height / newCellH, 1))
 
         if newCols != dispatcher.frameState.cols || newRows != dispatcher.frameState.rows {
@@ -400,7 +401,8 @@ final class EditorNSView: MTKView {
 
         guard newSize.width > 0, newSize.height > 0 else { return }
 
-        let newCols = UInt16(max(newSize.width / cellWidth, 1))
+        let usableWidth = newSize.width - CoreTextMetalRenderer.gutterPixelPaddingPt
+        let newCols = UInt16(max(usableWidth / cellWidth, 1))
         let newRows = UInt16(max(newSize.height / cellHeight, 1))
 
         if !readySent {
@@ -457,7 +459,8 @@ final class EditorNSView: MTKView {
         guard effectiveCellH > 0 else { return }
 
         let newRows = UInt16(max(frame.height / effectiveCellH, 1))
-        let cols = UInt16(max(frame.width / cellWidth, 1))
+        let usableWidth = frame.width - CoreTextMetalRenderer.gutterPixelPaddingPt
+        let cols = UInt16(max(usableWidth / cellWidth, 1))
 
         if newRows != dispatcher.frameState.rows {
             dispatcher.frameState.resize(newCols: cols, newRows: newRows)


### PR DESCRIPTION
## Summary

- Pre-clips line texture text and spans to the visible viewport window before Metal rasterization, fixing two horizontal scroll rendering bugs in `bin/minga-mac`:
  - **Text truncation**: characters stopped rendering past ~200 columns because `maxLinePixelWidth` clamped textures to viewport width
  - **Gutter bleedthrough**: line content rendered over line numbers because the full-line texture was shifted left by `hScrollPx` with no clip boundary
- Textures are now at most viewport-wide and positioned at the content edge; overlay positioning (selection, search, diagnostics, cursor) unchanged

## Test plan

- [x] Xcode build succeeds
- [x] All 487 Mac tests pass
- [x] Manual: open `bin/minga-mac`, type a long line (200+ chars), verify text renders correctly at all scroll positions
- [x] Manual: verify gutter line numbers stay clean when scrolled horizontally
- [x] Manual: verify syntax highlighting spans render correctly on long scrolled lines
- [x] Manual: verify search highlights and selection overlays track correctly during horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)