### PR TITLE
fix(editor): write synthesized defaults back to tab context on first switch

### DIFF
--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -1027,11 +1027,22 @@ defmodule MingaEditor.State do
   """
   @spec restore_tab_context(t(), Tab.context()) :: t()
   def restore_tab_context(%__MODULE__{} = state, context) when is_map(context) do
-    context =
+    {context, state} =
       if map_size(context) == 0 do
-        build_file_tab_defaults(state)
+        synthesized = build_file_tab_defaults(state)
+
+        state =
+          case tab_bar(state) do
+            %TabBar{active_id: id} = tb ->
+              set_tab_bar(state, TabBar.update_context(tb, id, synthesized))
+
+            _ ->
+              state
+          end
+
+        {synthesized, state}
       else
-        context
+        {context, state}
       end
 
     %{state | workspace: WorkspaceState.restore_tab_context(state.workspace, context)}

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -137,6 +137,26 @@ defmodule MingaEditor.State.SnapshotTest do
       assert restored.workspace.editing.mode == :normal
       assert restored.workspace.keymap_scope == :editor
     end
+
+    test "writes synthesized defaults back into the active tab on empty context" do
+      {:ok, buf} = BufferServer.start_link(content: "new file")
+
+      tab = Tab.new_file(1, "new.ex")
+      tb = TabBar.new(tab)
+
+      state = make_state(buffer: buf, tab_bar: tb)
+      assert TabBar.active(tb).context == %{}
+
+      restored = EditorState.restore_tab_context(state, %{})
+
+      updated_tb = restored.shell_state.tab_bar
+      stored_ctx = TabBar.get(updated_tb, tab.id).context
+
+      assert map_size(stored_ctx) > 0
+      assert stored_ctx.keymap_scope == :editor
+      assert stored_ctx.editing.mode == :normal
+      assert stored_ctx.buffers.active == buf
+    end
   end
 
   describe "switch_tab/2" do
@@ -180,6 +200,24 @@ defmodule MingaEditor.State.SnapshotTest do
       tb = TabBar.new(Tab.new_file(1, "a"))
       state = make_state(tab_bar: tb)
       assert EditorState.switch_tab(state, 1) == state
+    end
+
+    test "switching to a brand-new tab writes context into tab bar immediately" do
+      {:ok, buf} = BufferServer.start_link(content: "original")
+
+      tab_a = Tab.new_file(1, "a.ex")
+      tb = TabBar.new(tab_a)
+
+      {tb, tab_b} = TabBar.add(tb, :file, "b.ex")
+      tb = TabBar.switch_to(tb, tab_a.id)
+      assert TabBar.get(tb, tab_b.id).context == %{}
+
+      state = make_state(buffer: buf, tab_bar: tb, mode: :normal, keymap_scope: :editor)
+      switched = EditorState.switch_tab(state, tab_b.id)
+
+      stored_ctx = TabBar.get(switched.shell_state.tab_bar, tab_b.id).context
+      assert map_size(stored_ctx) > 0
+      assert stored_ctx.buffers.active == buf
     end
 
     test "switching with nil tab_bar is a no-op" do

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -217,6 +217,7 @@ defmodule MingaEditor.State.SnapshotTest do
 
       stored_ctx = TabBar.get(switched.shell_state.tab_bar, tab_b.id).context
       assert map_size(stored_ctx) > 0
+      assert stored_ctx.keymap_scope == :editor
       assert stored_ctx.buffers.active == buf
     end
 


### PR DESCRIPTION
Closes #1400

## Summary
- When switching into a brand-new tab with empty context, `restore_tab_context` synthesized defaults via `build_file_tab_defaults` but never wrote them back to `tab.context`. Until the next switch, any code reading `tab.context` directly (dirty marker, `find_tab_by_buffer`) saw an empty map and returned nil.
- Now the synthesized context is written back to the active tab via `TabBar.update_context` immediately, guarded by `map_size(context) == 0`.
- Two regression tests: one unit test on `restore_tab_context` directly, one integration test through `switch_tab`.

## Test plan
- [x] Unit test: `restore_tab_context` with empty context writes synthesized defaults into tab bar
- [x] Integration test: `switch_tab` to a brand-new tab populates `tab.context` immediately
- [x] Full test suite passes (7791 tests, 0 failures)
- [x] `make lint` passes (format, credo, compile warnings, dialyzer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)