### PR TITLE
fix(editor): start agent session when zooming into persisted board cards

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -1728,6 +1728,12 @@ defmodule MingaEditor do
     case action do
       {:board_select_card, card_id} ->
         card = Map.get(shell_state.cards, card_id)
+
+        {new_board, state} =
+          MingaEditor.Shell.Board.SessionLifecycle.ensure_session(state.shell_state, card, state)
+
+        state = EditorState.update_shell_state(state, fn _ -> new_board end)
+        card = new_board.cards[card_id]
         MingaEditor.AgentActivation.activate_for_card(state, card)
 
       _ ->

--- a/lib/minga_editor/shell/board/input.ex
+++ b/lib/minga_editor/shell/board/input.ex
@@ -276,8 +276,11 @@ defmodule MingaEditor.Shell.Board.Input do
             EditorState.restore_tab_context(state, fresh_context)
         end
 
-      # For agent cards, activate the agentic view so the user sees
-      # the agent chat, not a plain buffer
+      # For persisted agent cards with no live session, start one now.
+      {new_board, state} = SessionLifecycle.ensure_session(state.shell_state, card, state)
+      state = EditorState.update_shell_state(state, fn _ -> new_board end)
+      card = new_board.cards[card.id]
+
       MingaEditor.AgentActivation.activate_for_card(state, card)
     else
       state

--- a/lib/minga_editor/shell/board/session_lifecycle.ex
+++ b/lib/minga_editor/shell/board/session_lifecycle.ex
@@ -5,8 +5,11 @@ defmodule MingaEditor.Shell.Board.SessionLifecycle do
   Board cards store agent session PIDs directly, but `MingaAgent.SessionManager` owns process lifecycle and broadcasts stop events. Keeping start/stop here prevents keyboard and GUI Board paths from drifting into different ownership patterns.
   """
 
+  alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.Session, as: AgentSession
   alias MingaAgent.SessionManager
+  alias MingaEditor.Shell.Board.Card
+  alias MingaEditor.Shell.Board.State, as: BoardState
 
   @doc "Starts a managed agent session and subscribes the caller to its events."
   @spec start(keyword()) :: {:ok, pid()} | {:error, term()}
@@ -31,6 +34,55 @@ defmodule MingaEditor.Shell.Board.SessionLifecycle do
   end
 
   def stop(nil), do: :ok
+
+  @doc """
+  Ensures an agent card has a live session. If the card already has a session
+  or is a `:you` card, returns the board unchanged. Otherwise starts a new
+  session using the card's persisted model (falling back to the configured default).
+  """
+  @spec ensure_session(BoardState.t(), Card.t() | nil, MingaEditor.State.t()) ::
+          {BoardState.t(), MingaEditor.State.t()}
+  def ensure_session(board, nil, state), do: {board, state}
+
+  def ensure_session(board, %Card{session: pid} = _card, state) when is_pid(pid) do
+    {board, state}
+  end
+
+  def ensure_session(board, %Card{kind: :you}, state) do
+    {board, state}
+  end
+
+  def ensure_session(board, %Card{id: card_id, model: card_model}, state) do
+    model = card_model || AgentConfig.resolve_model()
+
+    opts = [
+      provider_opts: [
+        provider: AgentConfig.resolve_provider(),
+        model: model
+      ]
+    ]
+
+    case start(opts) do
+      {:ok, pid} ->
+        board = BoardState.update_card(board, card_id, &Card.attach_session(&1, pid))
+
+        Minga.Log.info(
+          :agent,
+          "Board: started agent session for persisted card #{card_id} (#{model})"
+        )
+
+        {board, state}
+
+      {:error, reason} ->
+        Minga.Log.error(
+          :agent,
+          "Board: failed to start agent for card #{card_id}: #{inspect(reason)}"
+        )
+
+        board = BoardState.update_card(board, card_id, &Card.set_status(&1, :errored))
+        {board, state}
+    end
+  end
 
   @spec subscribe(pid()) :: {:ok, pid()} | {:error, term()}
   defp subscribe(pid) do

--- a/test/minga_editor/shell/board/input_test.exs
+++ b/test/minga_editor/shell/board/input_test.exs
@@ -230,6 +230,104 @@ defmodule MingaEditor.Shell.Board.InputTest do
     end
   end
 
+  # ── Persisted card session start ─────────────────────────────────────────
+
+  describe "zoom into persisted agent card (no live session)" do
+    test "starts a new session and activates the agent view" do
+      {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
+
+      board =
+        BoardState.new()
+        |> then(fn b ->
+          {b, _card} = BoardState.create_card(b, task: "Fix tests", model: "test-model")
+          b
+        end)
+        |> Map.put(:agent, %AgentState{buffer: agent_buf})
+
+      focused_id = board.focused_card
+      assert board.cards[focused_id].session == nil
+
+      state = %EditorState{
+        port_manager: self(),
+        shell: Board,
+        shell_state: board,
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+        focus_stack: [BoardInput, MingaEditor.Input.GlobalBindings]
+      }
+
+      {:handled, new_state} = BoardInput.handle_key(state, @enter, 0)
+
+      card = new_state.shell_state.cards[focused_id]
+      on_exit(fn -> stop_session(card.session) end)
+
+      assert is_pid(card.session)
+      assert card.status == :working
+      assert new_state.workspace.keymap_scope == :agent
+    end
+
+    test "uses the card's persisted model for the new session" do
+      {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
+
+      board =
+        BoardState.new()
+        |> then(fn b ->
+          {b, _card} = BoardState.create_card(b, task: "Refactor", model: "persisted-model")
+          b
+        end)
+        |> Map.put(:agent, %AgentState{buffer: agent_buf})
+
+      state = %EditorState{
+        port_manager: self(),
+        shell: Board,
+        shell_state: board,
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+        focus_stack: [BoardInput, MingaEditor.Input.GlobalBindings]
+      }
+
+      {:handled, new_state} = BoardInput.handle_key(state, @enter, 0)
+
+      focused_id = new_state.shell_state.focused_card
+      card = new_state.shell_state.cards[focused_id]
+      on_exit(fn -> stop_session(card.session) end)
+
+      assert is_pid(card.session)
+    end
+
+    test "does not double-start when card already has a session" do
+      {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
+      fake_session = spawn(fn -> Process.sleep(:infinity) end)
+
+      board =
+        BoardState.new()
+        |> then(fn b ->
+          {b, _card} =
+            BoardState.create_card(b,
+              task: "Already running",
+              model: "test-model",
+              session: fake_session
+            )
+
+          b
+        end)
+        |> Map.put(:agent, %AgentState{buffer: agent_buf})
+
+      focused_id = board.focused_card
+
+      state = %EditorState{
+        port_manager: self(),
+        shell: Board,
+        shell_state: board,
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+        focus_stack: [BoardInput, MingaEditor.Input.GlobalBindings]
+      }
+
+      {:handled, new_state} = BoardInput.handle_key(state, @enter, 0)
+
+      card = new_state.shell_state.cards[focused_id]
+      assert card.session == fake_session
+    end
+  end
+
   # ── Zoom out ───────────────────────────────────────────────────────────
 
   describe "Escape zooms out when zoomed" do

--- a/test/minga_editor/shell/board/session_lifecycle_test.exs
+++ b/test/minga_editor/shell/board/session_lifecycle_test.exs
@@ -1,0 +1,114 @@
+defmodule MingaEditor.Shell.Board.SessionLifecycleTest do
+  use ExUnit.Case, async: false
+
+  alias MingaAgent.SessionManager
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
+  alias MingaEditor.Shell.Board
+  alias MingaEditor.Shell.Board.Input, as: BoardInput
+  alias MingaEditor.Shell.Board.SessionLifecycle
+  alias MingaEditor.Shell.Board.State, as: BoardState
+
+  defp stop_session(pid) when is_pid(pid) do
+    SessionManager.stop_session_by_pid(pid)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp stop_session(_pid), do: :ok
+
+  defp make_state(board) do
+    %EditorState{
+      port_manager: self(),
+      shell: Board,
+      shell_state: board,
+      workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+      focus_stack: [BoardInput, MingaEditor.Input.GlobalBindings]
+    }
+  end
+
+  describe "ensure_session/3" do
+    test "no-ops for nil card" do
+      board = BoardState.new()
+      state = make_state(board)
+
+      assert {^board, ^state} = SessionLifecycle.ensure_session(board, nil, state)
+    end
+
+    test "no-ops for :you card" do
+      board = BoardState.new()
+      {board, card} = BoardState.create_card(board, task: "You", kind: :you)
+      state = make_state(board)
+
+      assert {^board, ^state} = SessionLifecycle.ensure_session(board, card, state)
+    end
+
+    test "no-ops when card already has a session" do
+      fake_pid = spawn(fn -> Process.sleep(:infinity) end)
+      board = BoardState.new()
+      {board, card} = BoardState.create_card(board, task: "Agent", session: fake_pid)
+      state = make_state(board)
+
+      assert {^board, ^state} = SessionLifecycle.ensure_session(board, card, state)
+    end
+
+    test "starts a new session for a sessionless agent card" do
+      board = BoardState.new()
+      {board, card} = BoardState.create_card(board, task: "Fix bug", model: "test-model")
+      state = make_state(board)
+
+      assert card.session == nil
+
+      {new_board, _state} = SessionLifecycle.ensure_session(board, card, state)
+
+      updated_card = new_board.cards[card.id]
+      on_exit(fn -> stop_session(updated_card.session) end)
+
+      assert is_pid(updated_card.session)
+      assert updated_card.status == :working
+    end
+
+    test "uses card model when present" do
+      board = BoardState.new()
+      {board, card} = BoardState.create_card(board, task: "Task", model: "custom-model")
+      state = make_state(board)
+
+      {new_board, _state} = SessionLifecycle.ensure_session(board, card, state)
+
+      updated_card = new_board.cards[card.id]
+      on_exit(fn -> stop_session(updated_card.session) end)
+
+      assert is_pid(updated_card.session)
+    end
+
+    @tag :tmp_dir
+    test "sets :errored status when session start fails", %{tmp_dir: _dir} do
+      board = BoardState.new()
+      {board, card} = BoardState.create_card(board, task: "Will fail", model: "test-model")
+      state = make_state(board)
+
+      # Temporarily unregister the SessionManager to make GenServer.call exit
+      original_pid = Process.whereis(MingaAgent.SessionManager)
+      Process.unregister(MingaAgent.SessionManager)
+
+      on_exit(fn ->
+        if original_pid && Process.alive?(original_pid) do
+          try do
+            Process.register(original_pid, MingaAgent.SessionManager)
+          rescue
+            ArgumentError -> :ok
+          end
+        end
+      end)
+
+      {new_board, _state} = SessionLifecycle.ensure_session(board, card, state)
+
+      # Re-register immediately so other tests aren't affected
+      Process.register(original_pid, MingaAgent.SessionManager)
+
+      updated_card = new_board.cards[card.id]
+      assert updated_card.session == nil
+      assert updated_card.status == :errored
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `SessionLifecycle.ensure_session/3` that starts a fresh agent session for persisted cards with `session: nil`, using the card's stored model (falls back to configured default)
- Calls `ensure_session` in both zoom entry points (keyboard Enter and GUI click) before `activate_for_card`
- Failed session starts set card status to `:errored` instead of showing a blank buffer

Closes #1277

## Test plan

- [x] New unit tests for `ensure_session/3`: nil card, :you card, already-has-session, sessionless agent, error path
- [x] Integration tests in `input_test.exs`: persisted card zoom starts session, uses persisted model, no double-start
- [x] Full test suite passes (7810 tests, 0 failures)
- [ ] Manual: restart app with persisted board cards, Enter into one, verify agent chat appears and prompt works

🤖 Generated with [Claude Code](https://claude.com/claude-code)