### PR TITLE
feat(render): skip clean-window pipeline work

### DIFF
--- a/lib/minga_editor/display_list.ex
+++ b/lib/minga_editor/display_list.ex
@@ -104,7 +104,8 @@ defmodule MingaEditor.DisplayList do
               tilde_lines: %{},
               modeline: %{},
               cursor: nil,
-              semantic: nil
+              semantic: nil,
+              changed: true
 
     @type t :: %__MODULE__{
             rect: Layout.rect(),
@@ -113,7 +114,8 @@ defmodule MingaEditor.DisplayList do
             tilde_lines: DisplayList.render_layer(),
             modeline: DisplayList.render_layer(),
             cursor: Cursor.t() | nil,
-            semantic: SemanticWindow.t() | nil
+            semantic: SemanticWindow.t() | nil,
+            changed: boolean()
           }
   end
 
@@ -159,7 +161,8 @@ defmodule MingaEditor.DisplayList do
               regions: [],
               splash: nil,
               title: nil,
-              window_bg: nil
+              window_bg: nil,
+              damage: true
 
     @type t :: %__MODULE__{
             cursor: Cursor.t(),
@@ -175,7 +178,8 @@ defmodule MingaEditor.DisplayList do
             regions: [binary()],
             splash: [DisplayList.draw()] | nil,
             title: String.t() | nil,
-            window_bg: non_neg_integer() | nil
+            window_bg: non_neg_integer() | nil,
+            damage: boolean()
           }
   end
 
@@ -316,7 +320,9 @@ defmodule MingaEditor.DisplayList do
         ]
       end
 
-    [Protocol.encode_clear()] ++
+    clear = if Keyword.get(opts, :clear, true), do: [Protocol.encode_clear()], else: []
+
+    clear ++
       frame.regions ++
       draws_to_commands(before_windows) ++
       windows_to_commands(frame.windows) ++

--- a/lib/minga_editor/display_list.ex
+++ b/lib/minga_editor/display_list.ex
@@ -81,6 +81,12 @@ defmodule MingaEditor.DisplayList do
     def new(row, col, shape) when is_integer(row) and is_integer(col) do
       %__MODULE__{row: row, col: col, shape: shape}
     end
+
+    @doc "Returns the cursor with an updated shape."
+    @spec with_shape(t(), shape()) :: t()
+    def with_shape(%__MODULE__{} = cursor, shape) do
+      %{cursor | shape: shape}
+    end
   end
 
   defmodule WindowFrame do
@@ -117,6 +123,22 @@ defmodule MingaEditor.DisplayList do
             semantic: SemanticWindow.t() | nil,
             changed: boolean()
           }
+
+    @doc "Marks a cached frame as unchanged for frame-damage calculation."
+    @spec mark_unchanged(t()) :: t()
+    def mark_unchanged(%__MODULE__{} = frame), do: %{frame | changed: false}
+
+    @doc "Updates the cached cursor shape for both cell and semantic render data."
+    @spec with_cursor_shape(t(), Cursor.shape()) :: t()
+    def with_cursor_shape(%__MODULE__{cursor: nil} = frame, _shape), do: frame
+
+    def with_cursor_shape(%__MODULE__{cursor: cursor, semantic: semantic} = frame, shape) do
+      %{
+        frame
+        | cursor: Cursor.with_shape(cursor, shape),
+          semantic: SemanticWindow.with_cursor_shape(semantic, shape)
+      }
+    end
   end
 
   defmodule Overlay do
@@ -289,6 +311,8 @@ defmodule MingaEditor.DisplayList do
   - `batch_end: false` — omit the trailing `batch_end` command. Used by
     the GUI emit path which appends Metal-critical chrome commands before
     sending `batch_end` to ensure atomic frame delivery.
+  - `clear: false` — omit the leading clear command when the frame has no
+    window or chrome damage.
   """
   @spec to_commands(Frame.t(), keyword()) :: [binary()]
   def to_commands(%Frame{} = frame, opts \\ []) do

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -56,7 +56,7 @@ defmodule MingaEditor.Frontend.Emit do
     frame_cmds =
       frame
       |> EmitGUI.filter_frame_for_gui()
-      |> DisplayList.to_commands(batch_end: false)
+      |> DisplayList.to_commands(batch_end: false, clear: frame.damage)
 
     # Semantic window content (0x80 opcode)
     window_content_cmds = build_gui_window_content_commands(frame)

--- a/lib/minga_editor/frontend/emit/tui.ex
+++ b/lib/minga_editor/frontend/emit/tui.ex
@@ -58,7 +58,7 @@ defmodule MingaEditor.Frontend.Emit.TUI do
   """
   @spec build_commands_from_deltas(Frame.t(), [scroll_delta()] | nil) :: [binary()]
   def build_commands_from_deltas(frame, nil) do
-    DisplayList.to_commands(frame)
+    DisplayList.to_commands(frame, clear: frame.damage)
   end
 
   def build_commands_from_deltas(frame, scroll_deltas) do

--- a/lib/minga_editor/render_pipeline.ex
+++ b/lib/minga_editor/render_pipeline.ex
@@ -34,6 +34,7 @@ defmodule MingaEditor.RenderPipeline do
   alias MingaEditor.RenderPipeline.Compose
   alias MingaEditor.RenderPipeline.Content
   alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.RenderPipeline.Invalidation
   alias MingaEditor.RenderPipeline.Scroll
   alias MingaEditor.WindowTree
   alias MingaEditor.Frontend.Emit
@@ -92,10 +93,12 @@ defmodule MingaEditor.RenderPipeline do
   """
   @spec run_windows_pipeline(input(), Layout.t()) :: input()
   def run_windows_pipeline(input, layout) do
+    invalidation = Invalidation.from_input(input, layout)
+
     # Stage 3: Scroll (also runs per-window invalidation detection)
     {scrolls, input} =
       Telemetry.span([:minga, :render, :stage], %{stage: :scroll}, fn ->
-        Scroll.scroll_windows(input, layout)
+        Scroll.scroll_windows(input, layout, invalidation)
       end)
 
     # Scroll updates per-window viewports; rebuild the tree so overlay hit regions match what chrome renders.
@@ -104,7 +107,7 @@ defmodule MingaEditor.RenderPipeline do
     # Stage 4: Content (skips clean lines, updates window caches)
     {buffer_frames, cursor_info, input} =
       Telemetry.span([:minga, :render, :stage], %{stage: :content}, fn ->
-        Content.build_content(input, scrolls)
+        Content.build_content(input, scrolls, invalidation)
       end)
 
     # Stage 4b: Agent chat window content (buffer pipeline + prompt chrome)
@@ -153,7 +156,7 @@ defmodule MingaEditor.RenderPipeline do
     # Stage 6: Compose
     frame =
       Telemetry.span([:minga, :render, :stage], %{stage: :compose}, fn ->
-        Compose.compose_windows(window_frames, chrome, cursor_info, input)
+        Compose.compose_windows(window_frames, chrome, cursor_info, input, invalidation)
       end)
 
     # Stage 7: Emit

--- a/lib/minga_editor/render_pipeline.ex
+++ b/lib/minga_editor/render_pipeline.ex
@@ -42,9 +42,9 @@ defmodule MingaEditor.RenderPipeline do
 
   # The Invalidation type lives in its own module
   # (MingaEditor.RenderPipeline.Invalidation) carrying first-class
-  # per-window and per-region dirty info. Stage 1's producer always
-  # returns full_redraw: true today; the consumers' dirty-bit gating
-  # is the Phase 1/2 follow-up work in #1431.
+  # per-window and per-region dirty info. Stage 1 synthesizes dirty entries
+  # from render caches and cheap metadata before downstream stages apply
+  # their own safety checks.
 
   # ── Orchestrator ───────────────────────────────────────────────────────────
 
@@ -170,7 +170,7 @@ defmodule MingaEditor.RenderPipeline do
   # ── Stage 1: Invalidation ─────────────────────────────────────────────────
 
   @doc """
-  Invalidation stage (Stage 1). Currently a pass-through.
+  Invalidation stage (Stage 1). Currently a pass-through wrapper.
 
   All invalidation is handled by two mechanisms downstream:
 

--- a/lib/minga_editor/render_pipeline/compose.ex
+++ b/lib/minga_editor/render_pipeline/compose.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.RenderPipeline.Compose do
   alias MingaEditor.RenderPipeline.Chrome
   alias MingaEditor.RenderPipeline.ComposeHelpers
   alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.RenderPipeline.Invalidation
 
   @typedoc "Render pipeline input."
   @type state :: Input.t()
@@ -27,9 +28,10 @@ defmodule MingaEditor.RenderPipeline.Compose do
           [WindowFrame.t()],
           Chrome.t(),
           Cursor.t() | nil,
-          state()
+          state(),
+          Invalidation.t() | nil
         ) :: Frame.t()
-  def compose_windows(window_frames, chrome, cursor_info, state) do
+  def compose_windows(window_frames, chrome, cursor_info, state, invalidation \\ nil) do
     layout = Layout.get(state)
 
     # Resolve cursor from window frames, overlays, and fallbacks.
@@ -68,8 +70,15 @@ defmodule MingaEditor.RenderPipeline.Compose do
       agent_panel: chrome.agent_panel,
       minibuffer: chrome.minibuffer,
       overlays: chrome.overlays,
-      regions: chrome.regions
+      regions: chrome.regions,
+      damage: frame_damage?(window_frames, invalidation)
     }
+  end
+
+  @spec frame_damage?([WindowFrame.t()], Invalidation.t() | nil) :: boolean()
+  defp frame_damage?(window_frames, invalidation) do
+    Enum.any?(window_frames, fn frame -> frame.changed end) or
+      Invalidation.chrome_dirty?(invalidation)
   end
 
   # Resolves the final frame cursor from the priority chain.

--- a/lib/minga_editor/render_pipeline/content.ex
+++ b/lib/minga_editor/render_pipeline/content.ex
@@ -21,7 +21,9 @@ defmodule MingaEditor.RenderPipeline.Content do
 
   alias Minga.Core.Face
   alias MingaEditor.RenderPipeline.ContentHelpers
+  alias MingaEditor.RenderPipeline.Invalidation
   alias MingaEditor.RenderPipeline.Scroll.WindowScroll
+  alias MingaEditor.RenderPipeline.WindowDirty
   alias MingaEditor.SemanticWindow
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.Viewport
@@ -37,12 +39,13 @@ defmodule MingaEditor.RenderPipeline.Content do
   without modeline; modeline is in the Chrome stage) and the absolute
   cursor position for the active window.
   """
-  @spec build_content(state(), %{Window.id() => WindowScroll.t()}) ::
+  @spec build_content(state(), %{Window.id() => WindowScroll.t()}, Invalidation.t() | nil) ::
           {[WindowFrame.t()], Cursor.t() | nil, state()}
-  def build_content(state, scrolls) do
+  def build_content(state, scrolls, invalidation \\ nil) do
     {frames, cursor_info, state} =
-      Enum.reduce(scrolls, {[], nil, state}, fn {_win_id, scroll}, {frames, cursor_info, st} ->
-        {wf, ci, st} = build_window_content(st, scroll)
+      Enum.reduce(scrolls, {[], nil, state}, fn {win_id, scroll}, {frames, cursor_info, st} ->
+        dirty = Invalidation.window_dirty(invalidation, win_id)
+        {wf, ci, st} = build_window_content(st, scroll, dirty)
         new_cursor = if scroll.is_active and ci != nil, do: ci, else: cursor_info
         {[wf | frames], new_cursor, st}
       end)
@@ -71,9 +74,20 @@ defmodule MingaEditor.RenderPipeline.Content do
 
   # ── Private ──────────────────────────────────────────────────────────────
 
-  @spec build_window_content(state(), WindowScroll.t()) ::
+  @spec build_window_content(state(), WindowScroll.t(), WindowDirty.t()) ::
           {WindowFrame.t(), Cursor.t() | nil, state()}
-  defp build_window_content(state, scroll) do
+  defp build_window_content(state, scroll, dirty) do
+    scroll = apply_window_dirty(scroll, dirty)
+
+    case reusable_window_frame(scroll) do
+      {:ok, frame} -> {frame, frame.cursor, state}
+      :rebuild -> rebuild_window_content(state, scroll)
+    end
+  end
+
+  @spec rebuild_window_content(state(), WindowScroll.t()) ::
+          {WindowFrame.t(), Cursor.t() | nil, state()}
+  defp rebuild_window_content(state, scroll) do
     %WindowScroll{
       win_layout: win_layout,
       is_active: is_active,
@@ -137,21 +151,7 @@ defmodule MingaEditor.RenderPipeline.Content do
     }
 
     {gutter_layer, line_layer, rows_used, window} =
-      cond do
-        wrap_on ->
-          # Wrapping and folding are mutually exclusive for now.
-          # Strip fold-specific keys so the type matches line_render_opts.
-          wrap_opts = Map.drop(line_opts, [:visible_line_map, :fold_map])
-          {g, l, r} = ContentHelpers.render_lines_wrapped(lines, visible_rows, wrap_opts)
-          {DisplayList.draws_to_layer_sorted(g), DisplayList.draws_to_layer_sorted(l), r, window}
-
-        scroll.visible_line_map == nil ->
-          ContentHelpers.render_lines_nowrap_layers(lines, line_opts)
-
-        true ->
-          {g, l, r, window} = ContentHelpers.render_lines_nowrap(lines, line_opts)
-          {DisplayList.draws_to_layer_sorted(g), DisplayList.draws_to_layer_sorted(l), r, window}
-      end
+      render_window_layers(wrap_on, scroll.visible_line_map, lines, visible_rows, line_opts)
 
     # Tilde lines for empty space below content
     tilde_draws =
@@ -228,16 +228,76 @@ defmodule MingaEditor.RenderPipeline.Content do
         gutter_w,
         snapshot.line_count,
         cursor_line,
+        cursor_byte_col,
         scroll.buf_version,
         ctx_fp
       )
       |> Window.prune_cache(first_line, last_visible)
+      |> Window.cache_window_frame(win_frame)
 
     new_map = Map.put(state.workspace.windows.map, scroll.win_id, updated_window)
     ws = state.workspace
     state = %{state | workspace: %{ws | windows: %{ws.windows | map: new_map}}}
 
     {win_frame, cursor_info, state}
+  end
+
+  @spec render_window_layers(boolean(), list() | nil, [String.t()], pos_integer(), map()) ::
+          {DisplayList.render_layer(), DisplayList.render_layer(), non_neg_integer(), Window.t()}
+  defp render_window_layers(true, _visible_line_map, lines, visible_rows, line_opts) do
+    # Wrapping and folding are mutually exclusive for now.
+    # Strip fold-specific keys so the type matches line_render_opts.
+    wrap_opts = Map.drop(line_opts, [:visible_line_map, :fold_map])
+
+    {gutter, line_draws, rows} =
+      ContentHelpers.render_lines_wrapped(lines, visible_rows, wrap_opts)
+
+    {
+      DisplayList.draws_to_layer_sorted(gutter),
+      DisplayList.draws_to_layer_sorted(line_draws),
+      rows,
+      Map.fetch!(line_opts, :window)
+    }
+  end
+
+  defp render_window_layers(false, nil, lines, _visible_rows, line_opts) do
+    ContentHelpers.render_lines_nowrap_layers(lines, line_opts)
+  end
+
+  defp render_window_layers(false, _visible_line_map, lines, _visible_rows, line_opts) do
+    {gutter, line_draws, rows, window} = ContentHelpers.render_lines_nowrap(lines, line_opts)
+
+    {
+      DisplayList.draws_to_layer_sorted(gutter),
+      DisplayList.draws_to_layer_sorted(line_draws),
+      rows,
+      window
+    }
+  end
+
+  @spec apply_window_dirty(WindowScroll.t(), WindowDirty.t()) :: WindowScroll.t()
+  defp apply_window_dirty(%WindowScroll{window: window} = scroll, %WindowDirty{mode: :all}) do
+    %{scroll | window: Window.mark_dirty(window, :all)}
+  end
+
+  defp apply_window_dirty(
+         %WindowScroll{window: window} = scroll,
+         %WindowDirty{mode: :rows} = dirty
+       ) do
+    %{scroll | window: Window.mark_dirty(window, Map.keys(dirty.dirty_rows))}
+  end
+
+  defp apply_window_dirty(%WindowScroll{} = scroll, %WindowDirty{mode: :clean}), do: scroll
+
+  @spec reusable_window_frame(WindowScroll.t()) :: {:ok, WindowFrame.t()} | :rebuild
+  defp reusable_window_frame(%WindowScroll{window: window}) do
+    cache = window.render_cache
+
+    if cache.dirty_lines == %{} and cache.last_window_frame != nil do
+      {:ok, %{cache.last_window_frame | changed: false}}
+    else
+      :rebuild
+    end
   end
 
   defp maybe_render_agent_window(
@@ -473,6 +533,7 @@ defmodule MingaEditor.RenderPipeline.Content do
         gutter_w,
         line_count,
         cursor_line,
+        cursor_byte_col,
         buf_version,
         ctx_fp
       )

--- a/lib/minga_editor/render_pipeline/content.ex
+++ b/lib/minga_editor/render_pipeline/content.ex
@@ -79,7 +79,7 @@ defmodule MingaEditor.RenderPipeline.Content do
   defp build_window_content(state, scroll, dirty) do
     scroll = apply_window_dirty(scroll, dirty)
 
-    case reusable_window_frame(scroll) do
+    case reusable_window_frame(state, scroll) do
       {:ok, frame} -> {frame, frame.cursor, state}
       :rebuild -> rebuild_window_content(state, scroll)
     end
@@ -232,6 +232,8 @@ defmodule MingaEditor.RenderPipeline.Content do
         scroll.buf_version,
         ctx_fp
       )
+      |> Window.cache_content_rect(win_layout.content)
+      |> Window.cache_buffer_dirty(snapshot.dirty)
       |> Window.prune_cache(first_line, last_visible)
       |> Window.cache_window_frame(win_frame)
 
@@ -289,15 +291,27 @@ defmodule MingaEditor.RenderPipeline.Content do
 
   defp apply_window_dirty(%WindowScroll{} = scroll, %WindowDirty{mode: :clean}), do: scroll
 
-  @spec reusable_window_frame(WindowScroll.t()) :: {:ok, WindowFrame.t()} | :rebuild
-  defp reusable_window_frame(%WindowScroll{window: window}) do
+  @spec reusable_window_frame(state(), WindowScroll.t()) :: {:ok, WindowFrame.t()} | :rebuild
+  defp reusable_window_frame(state, %WindowScroll{window: window, is_active: is_active}) do
     cache = window.render_cache
 
     if cache.dirty_lines == %{} and cache.last_window_frame != nil do
-      {:ok, %{cache.last_window_frame | changed: false}}
+      frame =
+        cache.last_window_frame
+        |> refresh_cursor_shape(state, is_active)
+        |> WindowFrame.mark_unchanged()
+
+      {:ok, frame}
     else
       :rebuild
     end
+  end
+
+  @spec refresh_cursor_shape(WindowFrame.t(), state(), boolean()) :: WindowFrame.t()
+  defp refresh_cursor_shape(%WindowFrame{} = frame, _state, false), do: frame
+
+  defp refresh_cursor_shape(%WindowFrame{} = frame, state, true) do
+    WindowFrame.with_cursor_shape(frame, Minga.Editing.cursor_shape(state))
   end
 
   defp maybe_render_agent_window(

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -187,16 +187,26 @@ defmodule MingaEditor.RenderPipeline.Input do
 
     fingerprint_data =
       case Map.get(scrolls, active) do
-        %{cursor_line: line, cursor_byte_col: col, buf_version: version} -> {{line, col}, version}
-        _ -> buffer_fingerprint_data(input.workspace.buffers.active)
+        %{
+          cursor_line: line,
+          cursor_byte_col: col,
+          buf_version: version,
+          snapshot: %{dirty: dirty?}
+        } ->
+          {{line, col}, version, dirty?}
+
+        _ ->
+          buffer_fingerprint_data(input.workspace.buffers.active)
       end
 
     chrome_fingerprint(input, fingerprint_data)
   end
 
-  @spec chrome_fingerprint(t(), {{non_neg_integer(), non_neg_integer()}, non_neg_integer()}) ::
-          integer()
-  def chrome_fingerprint(%__MODULE__{} = input, {buf_cursor, buf_version}) do
+  @spec chrome_fingerprint(
+          t(),
+          {{non_neg_integer(), non_neg_integer()}, non_neg_integer(), boolean()}
+        ) :: integer()
+  def chrome_fingerprint(%__MODULE__{} = input, {buf_cursor, buf_version, dirty?}) do
     # Hash the fields that drive chrome output. We use :erlang.phash2
     # for speed (no crypto needed, just change detection).
     #
@@ -209,6 +219,7 @@ defmodule MingaEditor.RenderPipeline.Input do
       # Buffer state for status bar (cursor pos, version/dirty)
       buf_cursor,
       buf_version,
+      dirty?,
       # Mode affects status bar label, minibuffer content, cursor shape
       input.workspace.editing.mode,
       input.workspace.editing.mode_state,
@@ -243,13 +254,13 @@ defmodule MingaEditor.RenderPipeline.Input do
   end
 
   @spec buffer_fingerprint_data(pid() | nil) ::
-          {{non_neg_integer(), non_neg_integer()}, non_neg_integer()}
-  defp buffer_fingerprint_data(nil), do: {{0, 0}, 0}
+          {{non_neg_integer(), non_neg_integer()}, non_neg_integer(), boolean()}
+  defp buffer_fingerprint_data(nil), do: {{0, 0}, 0, false}
 
   defp buffer_fingerprint_data(buf) when is_pid(buf) do
-    {Minga.Buffer.cursor(buf), Minga.Buffer.version(buf)}
+    {Minga.Buffer.cursor(buf), Minga.Buffer.version(buf), Minga.Buffer.dirty?(buf)}
   catch
-    :exit, _ -> {{0, 0}, 0}
+    :exit, _ -> {{0, 0}, 0, false}
   end
 
   @doc """

--- a/lib/minga_editor/render_pipeline/invalidation.ex
+++ b/lib/minga_editor/render_pipeline/invalidation.ex
@@ -23,13 +23,9 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
     `:focus_change`, etc.). Carried for telemetry; no behavioral
     effect today.
 
-  ## Phase 1 status
+  ## Dirty classification
 
-  This struct is the contract Stage 1 will produce when the dirty
-  tracking arrives. Today the producer always returns a struct with
-  `full_redraw: true` and empty maps, so behavior is unchanged.
-  Stage 2 (#1431 Phase 2) implements the per-row dirty algebra and
-  Stage 3 lifts it into the pipeline consumers.
+  Stage 1 now builds per-window dirty entries from render caches and cheap current metadata. Downstream stages still keep their own safety checks, so a clean classification only skips work when the existing cache proves the frame is reusable.
   """
 
   alias Minga.Buffer
@@ -111,18 +107,21 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
 
   @spec dirty_windows(Input.t(), Layout.t()) :: %{integer() => WindowDirty.t()}
   defp dirty_windows(input, layout) do
-    Map.new(layout.window_layouts, fn {win_id, _win_layout} ->
+    Map.new(layout.window_layouts, fn {win_id, win_layout} ->
       window = Map.get(input.workspace.windows.map, win_id)
-      {win_id, dirty_for_window(input, window)}
+      {win_id, dirty_for_window(input, window, win_layout)}
     end)
   end
 
-  @spec dirty_for_window(Input.t(), MingaEditor.Window.t() | nil) :: WindowDirty.t()
-  defp dirty_for_window(_input, nil), do: WindowDirty.all(:missing_window)
+  @spec dirty_for_window(Input.t(), MingaEditor.Window.t() | nil, Layout.window_layout()) ::
+          WindowDirty.t()
+  defp dirty_for_window(_input, nil, _win_layout), do: WindowDirty.all(:missing_window)
 
-  defp dirty_for_window(_input, %{content: {:agent_chat, _}}), do: WindowDirty.all(:agent_chat)
+  defp dirty_for_window(_input, %{content: {:agent_chat, _}}, _win_layout) do
+    WindowDirty.all(:agent_chat)
+  end
 
-  defp dirty_for_window(input, window) do
+  defp dirty_for_window(input, window, win_layout) do
     cache = window.render_cache
 
     case cache.dirty_lines do
@@ -133,22 +132,29 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
         WindowDirty.rows(Map.keys(dirty), :cached_rows)
 
       _ ->
-        dirty_from_context(input, window)
+        dirty_from_context(input, window, win_layout)
     end
   end
 
-  @spec dirty_from_context(Input.t(), MingaEditor.Window.t()) :: WindowDirty.t()
-  defp dirty_from_context(input, window) do
-    if context_requires_rebuild?(input, window) do
+  @spec dirty_from_context(Input.t(), MingaEditor.Window.t(), Layout.window_layout()) ::
+          WindowDirty.t()
+  defp dirty_from_context(input, window, win_layout) do
+    if context_requires_rebuild?(input, window, win_layout) do
       WindowDirty.all(:context_changed)
     else
       dirty_from_metadata(input, window)
     end
   end
 
-  @spec context_requires_rebuild?(Input.t(), MingaEditor.Window.t()) :: boolean()
-  defp context_requires_rebuild?(input, window) do
-    visual_context_changed?(input, window) or decorations_changed?(window)
+  @spec context_requires_rebuild?(Input.t(), MingaEditor.Window.t(), Layout.window_layout()) ::
+          boolean()
+  defp context_requires_rebuild?(input, window, win_layout) do
+    visual_context_changed?(input, window) or
+      viewport_context_changed?(window, win_layout) or
+      active_context_changed?(input, window) or
+      search_context_active_or_cached?(input, window) or
+      sign_context_changed?(window) or
+      decorations_changed?(window)
   end
 
   @spec visual_context_changed?(Input.t(), MingaEditor.Window.t()) :: boolean()
@@ -162,6 +168,107 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
     do: visual_selection
 
   defp cached_visual_selection(_fingerprint), do: nil
+
+  @spec viewport_context_changed?(MingaEditor.Window.t(), Layout.window_layout()) :: boolean()
+  defp viewport_context_changed?(window, win_layout) do
+    {_row, _col, content_width, _content_height} = win_layout.content
+    cache = window.render_cache
+    line_count = safe_line_count(window.buffer, cache.last_line_count)
+    gutter_w = current_gutter_width(window.buffer, line_count, cache.last_gutter_w)
+    content_w = max(content_width - gutter_w, 1)
+
+    cache.last_content_rect != win_layout.content or
+      cache.last_viewport_top != window.viewport.top or
+      cached_viewport_left(cache.last_context_fingerprint) != window.viewport.left or
+      cached_viewport_cols(cache.last_context_fingerprint) != content_width or
+      cached_content_w(cache.last_context_fingerprint) != content_w
+  end
+
+  @spec cached_viewport_left(term()) :: non_neg_integer() | nil
+  defp cached_viewport_left({_, _, _, _, _, viewport_left, _, _, _, _, _}), do: viewport_left
+  defp cached_viewport_left(_fingerprint), do: nil
+
+  @spec cached_viewport_cols(term()) :: pos_integer() | nil
+  defp cached_viewport_cols({_, _, _, _, _, _, viewport_cols, _, _, _, _}), do: viewport_cols
+  defp cached_viewport_cols(_fingerprint), do: nil
+
+  @spec cached_content_w(term()) :: pos_integer() | nil
+  defp cached_content_w({_, _, _, _, _, _, _, content_w, _, _, _}), do: content_w
+  defp cached_content_w(_fingerprint), do: nil
+
+  @spec active_context_changed?(Input.t(), MingaEditor.Window.t()) :: boolean()
+  defp active_context_changed?(input, window) do
+    cached_active?(window.render_cache.last_context_fingerprint) !=
+      (window.id == input.workspace.windows.active)
+  end
+
+  @spec cached_active?(term()) :: boolean() | nil
+  defp cached_active?({_, _, _, _, _, _, _, _, active?, _, _}), do: active?
+  defp cached_active?(_fingerprint), do: nil
+
+  @spec search_context_active_or_cached?(Input.t(), MingaEditor.Window.t()) :: boolean()
+  defp search_context_active_or_cached?(input, window) do
+    search_mode?(input.workspace.editing.mode) or
+      active_search_pattern?(input) or
+      cached_search_matches?(window.render_cache.last_context_fingerprint) or
+      cached_confirm_match?(window.render_cache.last_context_fingerprint)
+  end
+
+  @spec search_mode?(atom()) :: boolean()
+  defp search_mode?(mode) when mode in [:search, :command, :substitute_confirm], do: true
+  defp search_mode?(_mode), do: false
+
+  @spec active_search_pattern?(Input.t()) :: boolean()
+  defp active_search_pattern?(input) do
+    pattern = input.workspace.search.last_pattern
+    is_binary(pattern) and pattern != ""
+  end
+
+  @spec cached_search_matches?(term()) :: boolean()
+  defp cached_search_matches?({_, search_matches, _, _, _, _, _, _, _, _, _}) do
+    search_matches != []
+  end
+
+  defp cached_search_matches?(_fingerprint), do: false
+
+  @spec cached_confirm_match?(term()) :: boolean()
+  defp cached_confirm_match?({_, _, _, _, _, _, _, _, _, confirm_match, _}) do
+    confirm_match != nil
+  end
+
+  defp cached_confirm_match?(_fingerprint), do: false
+
+  @spec sign_context_changed?(MingaEditor.Window.t()) :: boolean()
+  defp sign_context_changed?(window) do
+    cached_diagnostic_signs(window.render_cache.last_context_fingerprint) !=
+      safe_diagnostic_signs(window) or
+      cached_git_signs(window.render_cache.last_context_fingerprint) != safe_git_signs(window)
+  end
+
+  @spec safe_diagnostic_signs(MingaEditor.Window.t()) :: %{non_neg_integer() => atom()}
+  defp safe_diagnostic_signs(window) do
+    MingaEditor.RenderPipeline.ContentHelpers.diagnostic_signs_for_window(window)
+  catch
+    :exit, _ -> %{}
+  end
+
+  @spec safe_git_signs(MingaEditor.Window.t()) :: %{non_neg_integer() => atom()}
+  defp safe_git_signs(window) do
+    MingaEditor.RenderPipeline.ContentHelpers.git_signs_for_window(window)
+  catch
+    :exit, _ -> %{}
+  end
+
+  @spec cached_diagnostic_signs(term()) :: %{non_neg_integer() => atom()} | nil
+  defp cached_diagnostic_signs({_, _, _, diagnostic_signs, _, _, _, _, _, _, _}) do
+    diagnostic_signs
+  end
+
+  defp cached_diagnostic_signs(_fingerprint), do: nil
+
+  @spec cached_git_signs(term()) :: %{non_neg_integer() => atom()} | nil
+  defp cached_git_signs({_, _, _, _, git_signs, _, _, _, _, _, _}), do: git_signs
+  defp cached_git_signs(_fingerprint), do: nil
 
   @spec decorations_changed?(MingaEditor.Window.t()) :: boolean()
   defp decorations_changed?(window) do
@@ -202,12 +309,14 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
     {cursor_line, cursor_col} = current_cursor(input, window)
     line_count = safe_line_count(window.buffer, cache.last_line_count)
     version = safe_version(window.buffer, cache.last_buf_version)
+    dirty? = safe_dirty?(window.buffer, cache.last_buffer_dirty)
     gutter_w = current_gutter_width(window.buffer, line_count, cache.last_gutter_w)
 
     classify_metadata_change(
       cache,
       line_count,
       version,
+      dirty?,
       gutter_w,
       cursor_line,
       cursor_col,
@@ -221,6 +330,7 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
           MingaEditor.Window.RenderCache.t(),
           non_neg_integer(),
           non_neg_integer(),
+          boolean(),
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
@@ -230,6 +340,7 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
          cache,
          line_count,
          version,
+         dirty?,
          gutter_w,
          cursor_line,
          cursor_col,
@@ -240,8 +351,25 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
     if first_frame or line_count != cache.last_line_count or gutter_w != cache.last_gutter_w do
       WindowDirty.all(:structural_change)
     else
-      classify_version_change(cache, version, cursor_line, cursor_col, buffer)
+      classify_dirty_flag_change(cache, version, dirty?, cursor_line, cursor_col, buffer)
     end
+  end
+
+  @spec classify_dirty_flag_change(
+          MingaEditor.Window.RenderCache.t(),
+          non_neg_integer(),
+          boolean(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pid()
+        ) :: WindowDirty.t()
+  defp classify_dirty_flag_change(cache, _version, dirty?, _cursor_line, _cursor_col, _buffer)
+       when dirty? != cache.last_buffer_dirty do
+    WindowDirty.all(:buffer_dirty_changed)
+  end
+
+  defp classify_dirty_flag_change(cache, version, _dirty?, cursor_line, cursor_col, buffer) do
+    classify_version_change(cache, version, cursor_line, cursor_col, buffer)
   end
 
   @spec classify_version_change(
@@ -320,6 +448,13 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
   @spec safe_version(pid(), non_neg_integer()) :: non_neg_integer()
   defp safe_version(buffer, fallback) do
     Buffer.version(buffer)
+  catch
+    :exit, _ -> fallback
+  end
+
+  @spec safe_dirty?(pid(), boolean()) :: boolean()
+  defp safe_dirty?(buffer, fallback) do
+    Buffer.dirty?(buffer)
   catch
     :exit, _ -> fallback
   end

--- a/lib/minga_editor/render_pipeline/invalidation.ex
+++ b/lib/minga_editor/render_pipeline/invalidation.ex
@@ -32,7 +32,12 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
   Stage 3 lifts it into the pipeline consumers.
   """
 
+  alias Minga.Buffer
+  alias MingaEditor.Layout
+  alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.WindowDirty
+  alias MingaEditor.Renderer.Gutter
+  alias MingaEditor.Viewport
 
   @typedoc "Chrome region tags."
   @type region_tag ::
@@ -43,11 +48,14 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
           | :minibuffer
           | :modeline
 
+  @typedoc "Dirty chrome regions tracked as a MapSet of region tags."
+  @type chrome_regions :: %MapSet{map: %{optional(region_tag()) => []}} | nil
+
   @typedoc "Output of Stage 1."
   @type t :: %__MODULE__{
           full_redraw: boolean(),
           windows: %{integer() => WindowDirty.t()},
-          chrome_regions: MapSet.t(region_tag()),
+          chrome_regions: chrome_regions(),
           global_reasons: [atom()]
         }
 
@@ -68,6 +76,276 @@ defmodule MingaEditor.RenderPipeline.Invalidation do
       chrome_regions: MapSet.new(),
       global_reasons: reasons
     }
+  end
+
+  @doc "Builds per-window dirty data from the current render caches and cheap buffer metadata."
+  @spec from_input(Input.t(), Layout.t()) :: t()
+  def from_input(%Input{} = input, %Layout{} = layout) do
+    windows = dirty_windows(input, layout)
+
+    %__MODULE__{
+      full_redraw: false,
+      windows: windows,
+      chrome_regions: chrome_regions(input),
+      global_reasons: []
+    }
+  end
+
+  @doc "Returns the dirty entry for a window, defaulting to full redraw when detail is unavailable."
+  @spec window_dirty(t() | nil, integer()) :: WindowDirty.t()
+  def window_dirty(nil, _win_id), do: WindowDirty.all(:missing_invalidation)
+  def window_dirty(%__MODULE__{full_redraw: true}, _win_id), do: WindowDirty.all(:full_redraw)
+
+  def window_dirty(%__MODULE__{windows: windows}, win_id) do
+    Map.get(windows, win_id, WindowDirty.all(:missing_window))
+  end
+
+  @doc "Returns true when any chrome region is dirty."
+  @spec chrome_dirty?(t() | nil) :: boolean()
+  def chrome_dirty?(nil), do: true
+  def chrome_dirty?(%__MODULE__{full_redraw: true}), do: true
+  def chrome_dirty?(%__MODULE__{chrome_regions: nil}), do: true
+  def chrome_dirty?(%__MODULE__{chrome_regions: regions}), do: MapSet.size(regions) > 0
+
+  # ── Private ──────────────────────────────────────────────────────────────
+
+  @spec dirty_windows(Input.t(), Layout.t()) :: %{integer() => WindowDirty.t()}
+  defp dirty_windows(input, layout) do
+    Map.new(layout.window_layouts, fn {win_id, _win_layout} ->
+      window = Map.get(input.workspace.windows.map, win_id)
+      {win_id, dirty_for_window(input, window)}
+    end)
+  end
+
+  @spec dirty_for_window(Input.t(), MingaEditor.Window.t() | nil) :: WindowDirty.t()
+  defp dirty_for_window(_input, nil), do: WindowDirty.all(:missing_window)
+
+  defp dirty_for_window(_input, %{content: {:agent_chat, _}}), do: WindowDirty.all(:agent_chat)
+
+  defp dirty_for_window(input, window) do
+    cache = window.render_cache
+
+    case cache.dirty_lines do
+      :all ->
+        WindowDirty.all(:cached_dirty)
+
+      dirty when map_size(dirty) > 0 ->
+        WindowDirty.rows(Map.keys(dirty), :cached_rows)
+
+      _ ->
+        dirty_from_context(input, window)
+    end
+  end
+
+  @spec dirty_from_context(Input.t(), MingaEditor.Window.t()) :: WindowDirty.t()
+  defp dirty_from_context(input, window) do
+    if context_requires_rebuild?(input, window) do
+      WindowDirty.all(:context_changed)
+    else
+      dirty_from_metadata(input, window)
+    end
+  end
+
+  @spec context_requires_rebuild?(Input.t(), MingaEditor.Window.t()) :: boolean()
+  defp context_requires_rebuild?(input, window) do
+    visual_context_changed?(input, window) or decorations_changed?(window)
+  end
+
+  @spec visual_context_changed?(Input.t(), MingaEditor.Window.t()) :: boolean()
+  defp visual_context_changed?(input, window) do
+    cached_visual = cached_visual_selection(window.render_cache.last_context_fingerprint)
+    input.workspace.editing.mode == :visual or cached_visual != nil
+  end
+
+  @spec cached_visual_selection(term()) :: term()
+  defp cached_visual_selection({visual_selection, _, _, _, _, _, _, _, _, _, _}),
+    do: visual_selection
+
+  defp cached_visual_selection(_fingerprint), do: nil
+
+  @spec decorations_changed?(MingaEditor.Window.t()) :: boolean()
+  defp decorations_changed?(window) do
+    cached_version = cached_decorations_version(window.render_cache.last_context_fingerprint)
+
+    cached_version != nil and
+      safe_decorations_version(window.buffer, cached_version) != cached_version
+  end
+
+  @spec cached_decorations_version(term()) :: non_neg_integer() | nil
+  defp cached_decorations_version({_, _, _, _, _, _, _, _, _, _, decorations_version}) do
+    decorations_version
+  end
+
+  defp cached_decorations_version(_fingerprint), do: nil
+
+  @spec safe_decorations_version(pid(), non_neg_integer()) :: non_neg_integer()
+  defp safe_decorations_version(buffer, fallback) do
+    Buffer.decorations_version(buffer)
+  catch
+    :exit, _ -> fallback
+  end
+
+  @spec dirty_from_metadata(Input.t(), MingaEditor.Window.t()) :: WindowDirty.t()
+  defp dirty_from_metadata(input, window) do
+    cache = window.render_cache
+
+    if cache.last_window_frame == nil or cache.last_buf_version < 0 do
+      WindowDirty.all(:first_frame)
+    else
+      compare_metadata(input, window)
+    end
+  end
+
+  @spec compare_metadata(Input.t(), MingaEditor.Window.t()) :: WindowDirty.t()
+  defp compare_metadata(input, window) do
+    cache = window.render_cache
+    {cursor_line, cursor_col} = current_cursor(input, window)
+    line_count = safe_line_count(window.buffer, cache.last_line_count)
+    version = safe_version(window.buffer, cache.last_buf_version)
+    gutter_w = current_gutter_width(window.buffer, line_count, cache.last_gutter_w)
+
+    classify_metadata_change(
+      cache,
+      line_count,
+      version,
+      gutter_w,
+      cursor_line,
+      cursor_col,
+      window.buffer
+    )
+  catch
+    :exit, _ -> WindowDirty.all(:buffer_unavailable)
+  end
+
+  @spec classify_metadata_change(
+          MingaEditor.Window.RenderCache.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pid()
+        ) :: WindowDirty.t()
+  defp classify_metadata_change(
+         cache,
+         line_count,
+         version,
+         gutter_w,
+         cursor_line,
+         cursor_col,
+         buffer
+       ) do
+    first_frame = cache.last_line_count < 0 or cache.last_gutter_w < 0
+
+    if first_frame or line_count != cache.last_line_count or gutter_w != cache.last_gutter_w do
+      WindowDirty.all(:structural_change)
+    else
+      classify_version_change(cache, version, cursor_line, cursor_col, buffer)
+    end
+  end
+
+  @spec classify_version_change(
+          MingaEditor.Window.RenderCache.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pid()
+        ) :: WindowDirty.t()
+  defp classify_version_change(cache, version, cursor_line, cursor_col, buffer) do
+    if version != cache.last_buf_version do
+      WindowDirty.all(:buffer_version_changed)
+    else
+      classify_cursor_change(cache, cursor_line, cursor_col, buffer)
+    end
+  end
+
+  @spec classify_cursor_change(
+          MingaEditor.Window.RenderCache.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pid()
+        ) :: WindowDirty.t()
+  defp classify_cursor_change(cache, cursor_line, cursor_col, buffer) do
+    if cursor_line == cache.last_cursor_line and cursor_col == cache.last_cursor_col do
+      WindowDirty.clean()
+    else
+      line_number_style = safe_option(buffer, :line_numbers, :absolute)
+      dirty_cursor_rows(cache.last_cursor_line, cursor_line, line_number_style)
+    end
+  end
+
+  @spec dirty_cursor_rows(integer(), non_neg_integer(), atom()) :: WindowDirty.t()
+  defp dirty_cursor_rows(_old_cursor, _cursor_line, style) when style in [:relative, :hybrid] do
+    WindowDirty.all(:cursor_moved)
+  end
+
+  defp dirty_cursor_rows(old_cursor, _cursor_line, _style) when old_cursor < 0 do
+    WindowDirty.all(:cursor_moved)
+  end
+
+  defp dirty_cursor_rows(old_cursor, cursor_line, _style) do
+    WindowDirty.rows([old_cursor, cursor_line], :cursor_moved)
+  end
+
+  @spec current_cursor(Input.t(), MingaEditor.Window.t()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp current_cursor(input, window) do
+    if window.id == input.workspace.windows.active do
+      Buffer.cursor(window.buffer)
+    else
+      window.cursor
+    end
+  end
+
+  @spec current_gutter_width(pid(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp current_gutter_width(buffer, line_count, fallback) do
+    line_number_style = safe_option(buffer, :line_numbers, :absolute)
+
+    if line_number_style == :none do
+      Gutter.total_width(0)
+    else
+      line_count |> Viewport.gutter_width() |> Gutter.total_width()
+    end
+  catch
+    :exit, _ -> fallback
+  end
+
+  @spec safe_line_count(pid(), non_neg_integer()) :: non_neg_integer()
+  defp safe_line_count(buffer, fallback) do
+    Buffer.line_count(buffer)
+  catch
+    :exit, _ -> fallback
+  end
+
+  @spec safe_version(pid(), non_neg_integer()) :: non_neg_integer()
+  defp safe_version(buffer, fallback) do
+    Buffer.version(buffer)
+  catch
+    :exit, _ -> fallback
+  end
+
+  @spec safe_option(pid(), atom(), term()) :: term()
+  defp safe_option(buffer, option, fallback) do
+    Buffer.get_option(buffer, option)
+  catch
+    :exit, _ -> fallback
+  end
+
+  @spec chrome_regions(Input.t()) :: chrome_regions()
+  defp chrome_regions(input) do
+    fingerprint = Input.chrome_fingerprint(input)
+
+    if fingerprint == input.caches.chrome_prev_fingerprint and
+         input.caches.chrome_prev_result != nil do
+      MapSet.new()
+    else
+      all_chrome_regions()
+    end
+  end
+
+  @spec all_chrome_regions() :: chrome_regions()
+  defp all_chrome_regions do
+    MapSet.new([:tab_bar, :status_bar, :file_tree, :agent_panel, :minibuffer, :modeline])
   end
 
   @doc """

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.RenderPipeline.Scroll do
   """
 
   alias Minga.Buffer
+  alias Minga.Buffer.RenderSnapshot
   alias Minga.Core.Decorations
   alias Minga.Core.Unicode
   alias MingaEditor.DisplayMap
@@ -20,6 +21,8 @@ defmodule MingaEditor.RenderPipeline.Scroll do
   alias MingaEditor.Renderer.Gutter
   alias MingaEditor.Renderer.SearchHighlight
   alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.RenderPipeline.Invalidation
+  alias MingaEditor.RenderPipeline.WindowDirty
   alias MingaEditor.Viewport
   alias MingaEditor.Window
 
@@ -112,8 +115,9 @@ defmodule MingaEditor.RenderPipeline.Scroll do
   Returns `{scrolls, updated_state}` where `updated_state` has the
   windows map updated with invalidation results.
   """
-  @spec scroll_windows(state(), Layout.t()) :: {%{Window.id() => WindowScroll.t()}, state()}
-  def scroll_windows(input, layout) do
+  @spec scroll_windows(state(), Layout.t(), Invalidation.t() | nil) ::
+          {%{Window.id() => WindowScroll.t()}, state()}
+  def scroll_windows(input, layout, invalidation \\ nil) do
     layout.window_layouts
     |> Enum.reduce({%{}, input}, fn {win_id, win_layout}, {acc, st} ->
       window = Map.get(st.workspace.windows.map, win_id)
@@ -122,7 +126,8 @@ defmodule MingaEditor.RenderPipeline.Scroll do
         # Skip nil windows and agent chat windows (rendered by build_agent_chat_content)
         {acc, st}
       else
-        scroll_and_invalidate(input, st, acc, win_id, window, win_layout)
+        dirty = Invalidation.window_dirty(invalidation, win_id)
+        scroll_and_invalidate(input, st, acc, win_id, window, win_layout, dirty)
       end
     end)
   end
@@ -139,12 +144,13 @@ defmodule MingaEditor.RenderPipeline.Scroll do
           %{Window.id() => WindowScroll.t()},
           Window.id(),
           Window.t(),
-          Layout.window_layout()
+          Layout.window_layout(),
+          WindowDirty.t()
         ) :: {%{Window.id() => WindowScroll.t()}, state()}
-  defp scroll_and_invalidate(state, st, acc, win_id, window, win_layout) do
+  defp scroll_and_invalidate(state, st, acc, win_id, window, win_layout, dirty) do
     is_active = win_id == state.workspace.windows.active
 
-    case safe_scroll_window(st, win_id, window, win_layout, is_active) do
+    case safe_scroll_window(st, win_id, window, win_layout, is_active, dirty) do
       :skip ->
         {acc, st}
 
@@ -176,10 +182,16 @@ defmodule MingaEditor.RenderPipeline.Scroll do
 
   # Wraps scroll_window with a catch for dead buffer processes. Returns
   # {:ok, scroll} on success, :skip if the buffer died mid-call.
-  @spec safe_scroll_window(state(), Window.id(), Window.t(), Layout.window_layout(), boolean()) ::
-          {:ok, WindowScroll.t()} | :skip
-  defp safe_scroll_window(state, win_id, window, win_layout, is_active) do
-    {:ok, scroll_window(state, win_id, window, win_layout, is_active)}
+  @spec safe_scroll_window(
+          state(),
+          Window.id(),
+          Window.t(),
+          Layout.window_layout(),
+          boolean(),
+          WindowDirty.t()
+        ) :: {:ok, WindowScroll.t()} | :skip
+  defp safe_scroll_window(state, win_id, window, win_layout, is_active, dirty) do
+    {:ok, scroll_window(state, win_id, window, win_layout, is_active, dirty)}
   catch
     :exit, _ ->
       Minga.Log.debug(:render, "[scroll] skipped window #{win_id}: buffer process dead")
@@ -191,9 +203,10 @@ defmodule MingaEditor.RenderPipeline.Scroll do
           Window.id(),
           Window.t(),
           Layout.window_layout(),
-          boolean()
+          boolean(),
+          WindowDirty.t()
         ) :: WindowScroll.t()
-  defp scroll_window(state, win_id, window, win_layout, is_active) do
+  defp scroll_window(state, win_id, window, win_layout, is_active, dirty) do
     {_row_off, _col_off, content_width, content_height} = win_layout.content
 
     # Cursor: active window reads live from buffer; inactive uses stored
@@ -279,9 +292,15 @@ defmodule MingaEditor.RenderPipeline.Scroll do
           {buf_first, buf_last - buf_first + 1}
       end
 
-    snapshot = Buffer.render_snapshot(window.buffer, fetch_first, fetch_count)
-    lines = snapshot.lines
-    line_count = snapshot.line_count
+    {snapshot, lines, line_count} =
+      fetch_window_lines(
+        window.buffer,
+        fetch_first,
+        fetch_count,
+        cursor_line,
+        cursor_byte_col,
+        dirty
+      )
 
     # Cursor byte → display col
     cursor_line_text = cursor_line_text(lines, cursor_line, first_line)
@@ -335,6 +354,59 @@ defmodule MingaEditor.RenderPipeline.Scroll do
       buf_version: snapshot.version,
       visible_line_map: visible_line_map
     }
+  end
+
+  @spec fetch_window_lines(
+          pid(),
+          non_neg_integer(),
+          pos_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          WindowDirty.t()
+        ) :: {RenderSnapshot.t(), [String.t()], non_neg_integer()}
+  defp fetch_window_lines(
+         buffer,
+         fetch_first,
+         fetch_count,
+         _cursor_line,
+         _cursor_col,
+         %WindowDirty{
+           mode: mode
+         }
+       )
+       when mode in [:all, :rows] do
+    snapshot = Buffer.render_snapshot(buffer, fetch_first, fetch_count)
+    {snapshot, snapshot.lines, snapshot.line_count}
+  end
+
+  defp fetch_window_lines(
+         buffer,
+         fetch_first,
+         _fetch_count,
+         cursor_line,
+         cursor_col,
+         %WindowDirty{
+           mode: :clean
+         }
+       ) do
+    line_count = Buffer.line_count(buffer)
+    version = Buffer.version(buffer)
+
+    snapshot = %RenderSnapshot{
+      cursor: {cursor_line, cursor_col},
+      line_count: line_count,
+      lines: [],
+      file_path: Buffer.file_path(buffer),
+      filetype: Buffer.filetype(buffer),
+      buffer_type: Buffer.buffer_type(buffer),
+      dirty: Buffer.dirty?(buffer),
+      name: Buffer.buffer_name(buffer),
+      read_only: Buffer.read_only?(buffer),
+      first_line_byte_offset: fetch_first,
+      version: version
+    }
+
+    {snapshot, [], line_count}
   end
 
   @spec maybe_scroll_active_window_to_cursor(

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -206,6 +206,10 @@ defmodule MingaEditor.RenderPipeline.Scroll do
           boolean(),
           WindowDirty.t()
         ) :: WindowScroll.t()
+  defp scroll_window(state, win_id, window, win_layout, is_active, %WindowDirty{mode: :clean}) do
+    clean_window_scroll(state, win_id, window, win_layout, is_active)
+  end
+
   defp scroll_window(state, win_id, window, win_layout, is_active, dirty) do
     {_row_off, _col_off, content_width, content_height} = win_layout.content
 
@@ -302,9 +306,7 @@ defmodule MingaEditor.RenderPipeline.Scroll do
         dirty
       )
 
-    # Cursor byte → display col
-    cursor_line_text = cursor_line_text(lines, cursor_line, first_line)
-    cursor_col = Unicode.display_col(cursor_line_text, cursor_byte_col)
+    cursor_col = cursor_display_col(lines, cursor_line, cursor_byte_col, first_line)
 
     # Gutter dimensions
     line_number_style = Buffer.get_option(window.buffer, :line_numbers)
@@ -319,11 +321,15 @@ defmodule MingaEditor.RenderPipeline.Scroll do
     # so the cursor triggers scroll when it reaches the content edge,
     # not the full viewport edge.
     viewport =
-      if is_active do
-        scroll_horizontal(viewport, cursor_line, cursor_col, wrap_on, content_w, scroll_margin)
-      else
-        viewport
-      end
+      maybe_scroll_horizontal(
+        viewport,
+        cursor_line,
+        cursor_col,
+        wrap_on,
+        content_w,
+        scroll_margin,
+        is_active
+      )
 
     # Substitution preview (active window only)
     {lines, preview_matches} =
@@ -356,6 +362,51 @@ defmodule MingaEditor.RenderPipeline.Scroll do
     }
   end
 
+  @spec clean_window_scroll(state(), Window.id(), Window.t(), Layout.window_layout(), boolean()) ::
+          WindowScroll.t()
+  defp clean_window_scroll(_state, win_id, window, win_layout, is_active) do
+    {_row_off, _col_off, content_width, content_height} = win_layout.content
+    cache = window.render_cache
+    viewport = %{window.viewport | rows: content_height, cols: content_width, reserved: 0}
+    gutter_w = max(cache.last_gutter_w, 0)
+
+    snapshot = %RenderSnapshot{
+      cursor: {max(cache.last_cursor_line, 0), max(cache.last_cursor_col, 0)},
+      line_count: max(cache.last_line_count, 1),
+      lines: [],
+      file_path: nil,
+      filetype: :text,
+      buffer_type: :scratch,
+      dirty: cache.last_buffer_dirty,
+      name: nil,
+      read_only: false,
+      first_line_byte_offset: 0,
+      version: max(cache.last_buf_version, 0)
+    }
+
+    %WindowScroll{
+      win_id: win_id,
+      window: window,
+      win_layout: win_layout,
+      is_active: is_active,
+      viewport: viewport,
+      cursor_line: max(cache.last_cursor_line, 0),
+      cursor_byte_col: max(cache.last_cursor_col, 0),
+      cursor_col: max(cache.last_cursor_col, 0),
+      first_line: viewport.top,
+      lines: [],
+      snapshot: snapshot,
+      gutter_w: gutter_w,
+      content_w: max(content_width - gutter_w, 1),
+      has_sign_column: false,
+      preview_matches: [],
+      line_number_style: :absolute,
+      wrap_on: false,
+      buf_version: snapshot.version,
+      visible_line_map: nil
+    }
+  end
+
   @spec fetch_window_lines(
           pid(),
           non_neg_integer(),
@@ -379,34 +430,47 @@ defmodule MingaEditor.RenderPipeline.Scroll do
     {snapshot, snapshot.lines, snapshot.line_count}
   end
 
-  defp fetch_window_lines(
-         buffer,
-         fetch_first,
-         _fetch_count,
+  @spec cursor_display_col(
+          [String.t()],
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: non_neg_integer()
+  defp cursor_display_col(lines, cursor_line, cursor_byte_col, first_line) do
+    cursor_line_text = cursor_line_text(lines, cursor_line, first_line)
+    Unicode.display_col(cursor_line_text, cursor_byte_col)
+  end
+
+  @spec maybe_scroll_horizontal(
+          Viewport.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean(),
+          pos_integer(),
+          non_neg_integer(),
+          boolean()
+        ) :: Viewport.t()
+  defp maybe_scroll_horizontal(
+         viewport,
+         _cursor_line,
+         _cursor_col,
+         _wrap_on,
+         _content_w,
+         _margin,
+         false
+       ),
+       do: viewport
+
+  defp maybe_scroll_horizontal(
+         viewport,
          cursor_line,
          cursor_col,
-         %WindowDirty{
-           mode: :clean
-         }
+         wrap_on,
+         content_w,
+         margin,
+         true
        ) do
-    line_count = Buffer.line_count(buffer)
-    version = Buffer.version(buffer)
-
-    snapshot = %RenderSnapshot{
-      cursor: {cursor_line, cursor_col},
-      line_count: line_count,
-      lines: [],
-      file_path: Buffer.file_path(buffer),
-      filetype: Buffer.filetype(buffer),
-      buffer_type: Buffer.buffer_type(buffer),
-      dirty: Buffer.dirty?(buffer),
-      name: Buffer.buffer_name(buffer),
-      read_only: Buffer.read_only?(buffer),
-      first_line_byte_offset: fetch_first,
-      version: version
-    }
-
-    {snapshot, [], line_count}
+    scroll_horizontal(viewport, cursor_line, cursor_col, wrap_on, content_w, margin)
   end
 
   @spec maybe_scroll_active_window_to_cursor(

--- a/lib/minga_editor/semantic_window.ex
+++ b/lib/minga_editor/semantic_window.ex
@@ -73,4 +73,12 @@ defmodule MingaEditor.SemanticWindow do
           annotations: [ResolvedAnnotation.t()],
           full_refresh: boolean()
         }
+
+  @doc "Returns semantic window content with an updated cursor shape."
+  @spec with_cursor_shape(t() | nil, cursor_shape()) :: t() | nil
+  def with_cursor_shape(nil, _shape), do: nil
+
+  def with_cursor_shape(%__MODULE__{} = semantic, shape) do
+    %{semantic | cursor_shape: shape}
+  end
 end

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -23,15 +23,13 @@ defmodule MingaEditor.Window do
   relative line numbering dirties every gutter entry without changing
   content. This avoids re-rendering line text when only line numbers change.
 
-  Tracking fields (`last_viewport_top`, `last_gutter_w`, `last_line_count`,
-  `last_cursor_line`, `last_buf_version`) store the values from the previous
-  frame. The Scroll stage compares current values against these to detect
-  full-invalidation triggers automatically.
+  Tracking fields (`last_viewport_top`, `last_gutter_w`, `last_line_count`, `last_cursor_line`, `last_cursor_col`, `last_buf_version`, `last_content_rect`, and the context fingerprint) store values from the previous frame. The render pipeline compares current values against these to detect full-invalidation triggers and reuse `last_window_frame` only when the cached output is still valid.
   """
 
   alias Minga.Buffer
   alias MingaEditor.DisplayList
   alias MingaEditor.FoldMap
+  alias MingaEditor.Layout
   alias Minga.Editing.Fold.Range, as: FoldRange
   alias MingaEditor.Viewport
   alias MingaEditor.Window.Content
@@ -540,6 +538,18 @@ defmodule MingaEditor.Window do
             ctx_fingerprint
           )
     }
+  end
+
+  @doc "Stores the content rect used by the last rendered window frame."
+  @spec cache_content_rect(t(), Layout.rect()) :: t()
+  def cache_content_rect(%__MODULE__{render_cache: cache} = window, content_rect) do
+    %{window | render_cache: RenderCache.store_content_rect(cache, content_rect)}
+  end
+
+  @doc "Stores the last rendered buffer dirty flag for clean-window metadata reuse."
+  @spec cache_buffer_dirty(t(), boolean()) :: t()
+  def cache_buffer_dirty(%__MODULE__{render_cache: cache} = window, dirty?) do
+    %{window | render_cache: RenderCache.store_buffer_dirty(cache, dirty?)}
   end
 
   @doc """

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -456,6 +456,15 @@ defmodule MingaEditor.Window do
     %{window | render_cache: RenderCache.cache_line(cache, buf_line, gutter_draws, content_draws)}
   end
 
+  @doc "Stores the last rendered window frame for clean-window reuse."
+  @spec cache_window_frame(t(), DisplayList.WindowFrame.t()) :: t()
+  def cache_window_frame(
+        %__MODULE__{render_cache: cache} = window,
+        %DisplayList.WindowFrame{} = frame
+      ) do
+    %{window | render_cache: RenderCache.store_window_frame(cache, frame)}
+  end
+
   @doc """
   Snapshots tracking fields after a successful render pass.
 
@@ -491,6 +500,42 @@ defmodule MingaEditor.Window do
             gutter_w,
             line_count,
             cursor_line,
+            buf_version,
+            ctx_fingerprint
+          )
+    }
+  end
+
+  @spec snapshot_after_render(
+          t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          RenderCache.context_fingerprint()
+        ) :: t()
+  def snapshot_after_render(
+        %__MODULE__{render_cache: cache} = window,
+        viewport_top,
+        gutter_w,
+        line_count,
+        cursor_line,
+        cursor_col,
+        buf_version,
+        ctx_fingerprint
+      ) do
+    %{
+      window
+      | render_cache:
+          RenderCache.snapshot(
+            cache,
+            viewport_top,
+            gutter_w,
+            line_count,
+            cursor_line,
+            cursor_col,
             buf_version,
             ctx_fingerprint
           )

--- a/lib/minga_editor/window/render_cache.ex
+++ b/lib/minga_editor/window/render_cache.ex
@@ -31,6 +31,7 @@ defmodule MingaEditor.Window.RenderCache do
   """
 
   alias MingaEditor.DisplayList
+  alias MingaEditor.DisplayList.WindowFrame
 
   @compile {:inline, dirty?: 2}
 
@@ -53,8 +54,10 @@ defmodule MingaEditor.Window.RenderCache do
           last_gutter_w: integer(),
           last_line_count: integer(),
           last_cursor_line: integer(),
+          last_cursor_col: integer(),
           last_buf_version: integer(),
-          last_context_fingerprint: context_fingerprint()
+          last_context_fingerprint: context_fingerprint(),
+          last_window_frame: WindowFrame.t() | nil
         }
 
   defstruct dirty_lines: %{},
@@ -64,8 +67,10 @@ defmodule MingaEditor.Window.RenderCache do
             last_gutter_w: -1,
             last_line_count: -1,
             last_cursor_line: -1,
+            last_cursor_col: -1,
             last_buf_version: -1,
-            last_context_fingerprint: nil
+            last_context_fingerprint: nil,
+            last_window_frame: nil
 
   @doc """
   Returns a fresh cache with all lines dirty and no cached draws.
@@ -220,6 +225,38 @@ defmodule MingaEditor.Window.RenderCache do
         buf_version,
         ctx_fingerprint
       ) do
+    snapshot(
+      cache,
+      viewport_top,
+      gutter_w,
+      line_count,
+      cursor_line,
+      cache.last_cursor_col,
+      buf_version,
+      ctx_fingerprint
+    )
+  end
+
+  @spec snapshot(
+          t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          context_fingerprint()
+        ) :: t()
+  def snapshot(
+        %__MODULE__{} = cache,
+        viewport_top,
+        gutter_w,
+        line_count,
+        cursor_line,
+        cursor_col,
+        buf_version,
+        ctx_fingerprint
+      ) do
     %{
       cache
       | dirty_lines: %{},
@@ -227,9 +264,16 @@ defmodule MingaEditor.Window.RenderCache do
         last_gutter_w: gutter_w,
         last_line_count: line_count,
         last_cursor_line: cursor_line,
+        last_cursor_col: cursor_col,
         last_buf_version: buf_version,
         last_context_fingerprint: ctx_fingerprint
     }
+  end
+
+  @doc "Stores the last fully composed window frame for clean-window reuse."
+  @spec store_window_frame(t(), WindowFrame.t()) :: t()
+  def store_window_frame(%__MODULE__{} = cache, %WindowFrame{} = frame) do
+    %{cache | last_window_frame: frame}
   end
 
   @doc """

--- a/lib/minga_editor/window/render_cache.ex
+++ b/lib/minga_editor/window/render_cache.ex
@@ -23,15 +23,12 @@ defmodule MingaEditor.Window.RenderCache do
   ## Tracking fields
 
   `last_viewport_top`, `last_gutter_w`, `last_line_count`, `last_cursor_line`,
-  and `last_buf_version` store values from the previous frame. The Scroll
-  stage compares current values against these to detect full-invalidation
-  triggers. `last_context_fingerprint` captures all per-frame render context
-  inputs (visual selection, search matches, syntax highlights, signs, etc.)
-  so context changes trigger full redraws.
+  `last_cursor_col`, `last_buf_version`, and `last_content_rect` store values from the previous frame. The invalidation and scroll stages compare current values against these to decide whether a cached frame is safe to reuse. `last_context_fingerprint` captures per-frame render context inputs (visual selection, search matches, syntax highlights, signs, etc.), and `last_window_frame` stores the complete reusable frame for clean windows.
   """
 
   alias MingaEditor.DisplayList
   alias MingaEditor.DisplayList.WindowFrame
+  alias MingaEditor.Layout
 
   @compile {:inline, dirty?: 2}
 
@@ -56,6 +53,8 @@ defmodule MingaEditor.Window.RenderCache do
           last_cursor_line: integer(),
           last_cursor_col: integer(),
           last_buf_version: integer(),
+          last_buffer_dirty: boolean(),
+          last_content_rect: Layout.rect() | nil,
           last_context_fingerprint: context_fingerprint(),
           last_window_frame: WindowFrame.t() | nil
         }
@@ -69,6 +68,8 @@ defmodule MingaEditor.Window.RenderCache do
             last_cursor_line: -1,
             last_cursor_col: -1,
             last_buf_version: -1,
+            last_buffer_dirty: false,
+            last_content_rect: nil,
             last_context_fingerprint: nil,
             last_window_frame: nil
 
@@ -268,6 +269,18 @@ defmodule MingaEditor.Window.RenderCache do
         last_buf_version: buf_version,
         last_context_fingerprint: ctx_fingerprint
     }
+  end
+
+  @doc "Stores the content rect used by the last rendered window frame."
+  @spec store_content_rect(t(), Layout.rect()) :: t()
+  def store_content_rect(%__MODULE__{} = cache, content_rect) do
+    %{cache | last_content_rect: content_rect}
+  end
+
+  @doc "Stores the last rendered buffer dirty flag for clean-window metadata reuse."
+  @spec store_buffer_dirty(t(), boolean()) :: t()
+  def store_buffer_dirty(%__MODULE__{} = cache, dirty?) when is_boolean(dirty?) do
+    %{cache | last_buffer_dirty: dirty?}
   end
 
   @doc "Stores the last fully composed window frame for clean-window reuse."

--- a/test/minga_editor/frontend/emit_test.exs
+++ b/test/minga_editor/frontend/emit_test.exs
@@ -32,6 +32,21 @@ defmodule MingaEditor.Frontend.EmitTest do
       assert [<<0x12>> | _] = commands
     end
 
+    test "TUI path omits clear for an undamaged frame" do
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        splash: [DisplayList.draw(0, 0, "hello")],
+        damage: false
+      }
+
+      state = base_state()
+      ctx = Context.from_editor_state(state)
+      Emit.emit(frame, ctx)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      refute Enum.member?(commands, <<0x12>>)
+    end
+
     test "GUI path produces commands (no clear expected for GUI with to_commands)" do
       frame = %Frame{
         cursor: Cursor.new(0, 0, :block),

--- a/test/minga_editor/frontend/emit_test.exs
+++ b/test/minga_editor/frontend/emit_test.exs
@@ -47,7 +47,7 @@ defmodule MingaEditor.Frontend.EmitTest do
       refute Enum.member?(commands, <<0x12>>)
     end
 
-    test "GUI path produces commands (no clear expected for GUI with to_commands)" do
+    test "GUI path produces commands" do
       frame = %Frame{
         cursor: Cursor.new(0, 0, :block),
         splash: [DisplayList.draw(0, 0, "hello")]
@@ -60,6 +60,21 @@ defmodule MingaEditor.Frontend.EmitTest do
       assert_receive {:"$gen_cast", {:send_commands, commands}}
       assert is_list(commands)
       assert Enum.all?(commands, &is_binary/1)
+    end
+
+    test "GUI path omits clear for an undamaged frame" do
+      frame = %Frame{
+        cursor: Cursor.new(0, 0, :block),
+        splash: [DisplayList.draw(0, 0, "hello")],
+        damage: false
+      }
+
+      state = gui_state()
+      ctx = Context.from_editor_state(state)
+      Emit.emit(frame, ctx)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      refute Enum.member?(commands, <<0x12>>)
     end
   end
 

--- a/test/minga_editor/render_pipeline/content_test.exs
+++ b/test/minga_editor/render_pipeline/content_test.exs
@@ -97,6 +97,22 @@ defmodule MingaEditor.RenderPipeline.ContentTest do
       assert cursor == frame.cursor
     end
 
+    test "clean active windows refresh cached cursor shape" do
+      state = base_state(content: "alpha\nbeta\ngamma")
+      {scrolls, state, layout} = run_through_scroll(state)
+      {_frames, _cursor, state} = Content.build_content(state, scrolls)
+      win_id = state.workspace.windows.active
+      clean = invalidation(win_id, WindowDirty.clean())
+
+      state = put_in(state.workspace.editing.mode, :insert)
+      {scrolls, state} = Scroll.scroll_windows(state, layout, clean)
+      {[frame], cursor, _state} = Content.build_content(state, scrolls, clean)
+
+      assert frame.changed == false
+      assert frame.cursor.shape == :beam
+      assert cursor.shape == :beam
+    end
+
     test "row dirty windows merge rebuilt rows with cached rows" do
       state = base_state(content: "alpha\nbeta\ngamma")
       {scrolls, state, layout} = run_through_scroll(state)

--- a/test/minga_editor/render_pipeline/content_test.exs
+++ b/test/minga_editor/render_pipeline/content_test.exs
@@ -5,12 +5,16 @@ defmodule MingaEditor.RenderPipeline.ContentTest do
 
   use ExUnit.Case, async: true
 
+  alias MingaEditor.DisplayList
   alias MingaEditor.DisplayList.{Cursor, WindowFrame}
   alias MingaEditor.Layout
   alias MingaEditor.RenderPipeline
   alias MingaEditor.RenderPipeline.Content
+  alias MingaEditor.RenderPipeline.Invalidation
   alias MingaEditor.RenderPipeline.Scroll
+  alias MingaEditor.RenderPipeline.WindowDirty
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Window
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -21,6 +25,10 @@ defmodule MingaEditor.RenderPipeline.ContentTest do
     layout = Layout.get(state)
     {scrolls, state} = Scroll.scroll_windows(state, layout)
     {scrolls, state, layout}
+  end
+
+  defp invalidation(win_id, dirty) do
+    %Invalidation{full_redraw: false, windows: %{win_id => dirty}, chrome_regions: MapSet.new()}
   end
 
   describe "build_content/2" do
@@ -71,6 +79,45 @@ defmodule MingaEditor.RenderPipeline.ContentTest do
       assert window.render_cache.last_gutter_w >= 0
       assert window.render_cache.last_line_count > 0
       assert window.render_cache.last_buf_version >= 0
+      assert %WindowFrame{} = window.render_cache.last_window_frame
+    end
+
+    test "clean windows return the cached window frame" do
+      state = base_state(content: "alpha\nbeta\ngamma")
+      {scrolls, state, layout} = run_through_scroll(state)
+      {_frames, _cursor, state} = Content.build_content(state, scrolls)
+      win_id = state.workspace.windows.active
+      cached = Map.fetch!(state.workspace.windows.map, win_id).render_cache.last_window_frame
+      clean = invalidation(win_id, WindowDirty.clean())
+
+      {scrolls, state} = Scroll.scroll_windows(state, layout, clean)
+      {[frame], cursor, _state} = Content.build_content(state, scrolls, clean)
+
+      assert frame == %{cached | changed: false}
+      assert cursor == frame.cursor
+    end
+
+    test "row dirty windows merge rebuilt rows with cached rows" do
+      state = base_state(content: "alpha\nbeta\ngamma")
+      {scrolls, state, layout} = run_through_scroll(state)
+      {_frames, _cursor, state} = Content.build_content(state, scrolls)
+      win_id = state.workspace.windows.active
+      window = Map.fetch!(state.workspace.windows.map, win_id)
+
+      cached_window =
+        window
+        |> Window.cache_line(0, [], [DisplayList.draw(0, 4, "cached row 0")])
+        |> Window.mark_dirty([1])
+
+      state = put_in(state.workspace.windows.map[win_id], cached_window)
+      rows = invalidation(win_id, WindowDirty.rows([1], :buffer_edit))
+
+      {scrolls, state} = Scroll.scroll_windows(state, layout, rows)
+      {[frame], _cursor, _state} = Content.build_content(state, scrolls, rows)
+      draws = DisplayList.layer_to_draws(frame.lines)
+
+      assert Enum.any?(draws, fn {_row, _col, text, _face} -> text == "cached row 0" end)
+      assert Enum.any?(draws, fn {_row, _col, text, _face} -> String.contains?(text, "beta") end)
     end
   end
 end

--- a/test/minga_editor/render_pipeline/input_test.exs
+++ b/test/minga_editor/render_pipeline/input_test.exs
@@ -177,6 +177,24 @@ defmodule MingaEditor.RenderPipeline.InputTest do
     end
   end
 
+  describe "chrome_fingerprint/2" do
+    test "changes when active scroll dirty status changes", %{state: state} do
+      input = Input.from_editor_state(state)
+      win_id = input.workspace.windows.active
+
+      clean_scrolls = %{
+        win_id => %{cursor_line: 0, cursor_byte_col: 0, buf_version: 1, snapshot: %{dirty: false}}
+      }
+
+      dirty_scrolls = %{
+        win_id => %{cursor_line: 0, cursor_byte_col: 0, buf_version: 1, snapshot: %{dirty: true}}
+      }
+
+      refute Input.chrome_fingerprint(input, clean_scrolls) ==
+               Input.chrome_fingerprint(input, dirty_scrolls)
+    end
+  end
+
   describe "sync_active_window_cursor/1" do
     test "syncs cursor from buffer into active window", %{state: state} do
       # Move cursor in the buffer

--- a/test/minga_editor/render_pipeline/invalidation_test.exs
+++ b/test/minga_editor/render_pipeline/invalidation_test.exs
@@ -7,8 +7,18 @@ defmodule MingaEditor.RenderPipeline.InvalidationTest do
   # async: false — `sanity_mode?/0` test mutates `MINGA_RENDER_SANITY` env var
   use ExUnit.Case, async: false
 
+  alias Minga.Buffer
+  alias MingaEditor.Layout
+  alias MingaEditor.RenderPipeline
+  alias MingaEditor.RenderPipeline.Content
+  alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.Invalidation
+  alias MingaEditor.RenderPipeline.Scroll
   alias MingaEditor.RenderPipeline.WindowDirty
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Window
+
+  import MingaEditor.RenderPipeline.TestHelpers
 
   describe "Invalidation struct" do
     test "default is full_redraw with empty per-window and chrome maps" do
@@ -38,6 +48,105 @@ defmodule MingaEditor.RenderPipeline.InvalidationTest do
 
       System.delete_env("MINGA_RENDER_SANITY")
     end
+  end
+
+  describe "from_input/2" do
+    test "marks a previously rendered window dirty when horizontal scroll changes" do
+      state = base_state(content: "hello world") |> run_pipeline()
+      win_id = state.workspace.windows.active
+      assert_receive {:"$gen_cast", {:send_commands, _commands}}
+
+      scrolled_window =
+        state.workspace.windows.map
+        |> Map.fetch!(win_id)
+        |> Window.scroll_horizontal(4)
+
+      state = put_in(state.workspace.windows.map[win_id], scrolled_window)
+      input = state |> Input.from_editor_state() |> Layout.put()
+      invalidation = Invalidation.from_input(input, Layout.get(input))
+
+      assert Invalidation.window_dirty(invalidation, win_id).mode == :all
+      assert Invalidation.window_dirty(invalidation, win_id).reason == :context_changed
+    end
+
+    test "marks a previously rendered window dirty when vertical scroll changes" do
+      state = base_state(content: long_content(20)) |> run_pipeline()
+      win_id = state.workspace.windows.active
+      assert_receive {:"$gen_cast", {:send_commands, _commands}}
+
+      scrolled_window =
+        state.workspace.windows.map
+        |> Map.fetch!(win_id)
+        |> Window.scroll_viewport(1, 20)
+
+      state = put_in(state.workspace.windows.map[win_id], scrolled_window)
+      input = state |> Input.from_editor_state() |> Layout.put()
+      invalidation = Invalidation.from_input(input, Layout.get(input))
+
+      assert Invalidation.window_dirty(invalidation, win_id).mode == :all
+      assert Invalidation.window_dirty(invalidation, win_id).reason == :context_changed
+    end
+
+    test "marks a previously rendered window dirty when content rect changes" do
+      state = base_state(content: long_content(20)) |> run_pipeline()
+      win_id = state.workspace.windows.active
+      assert_receive {:"$gen_cast", {:send_commands, _commands}}
+
+      cached_rect = Map.fetch!(state.workspace.windows.map, win_id).render_cache.last_content_rect
+      resized_viewport = %{state.terminal_viewport | rows: state.terminal_viewport.rows - 1}
+      state = %{state | terminal_viewport: resized_viewport} |> Layout.invalidate()
+      input = state |> Input.from_editor_state() |> Layout.put()
+      layout = Layout.get(input)
+
+      refute Map.fetch!(layout.window_layouts, win_id).content == cached_rect
+
+      invalidation = Invalidation.from_input(input, layout)
+
+      assert Invalidation.window_dirty(invalidation, win_id).mode == :all
+      assert Invalidation.window_dirty(invalidation, win_id).reason == :context_changed
+    end
+
+    test "marks a previously rendered window dirty when buffer dirty flag changes" do
+      {state, _layout} = rendered_state(content: "hello world")
+      win_id = state.workspace.windows.active
+      state = normalize_cached_decorations_version(state, win_id)
+      input = state |> Input.from_editor_state() |> Layout.put()
+      layout = Layout.get(input)
+
+      assert Invalidation.window_dirty(Invalidation.from_input(input, layout), win_id).mode ==
+               :clean
+
+      state = put_in(state.workspace.windows.map[win_id].render_cache.last_buffer_dirty, true)
+      input = state |> Input.from_editor_state() |> Layout.put()
+      invalidation = Invalidation.from_input(input, Layout.get(input))
+
+      assert Invalidation.window_dirty(invalidation, win_id).mode == :all
+      assert Invalidation.window_dirty(invalidation, win_id).reason == :buffer_dirty_changed
+    end
+  end
+
+  defp rendered_state(opts) do
+    state =
+      opts
+      |> base_state()
+      |> EditorState.sync_active_window_cursor()
+      |> RenderPipeline.compute_layout()
+
+    layout = Layout.get(state)
+    {scrolls, state} = Scroll.scroll_windows(state, layout)
+    {_frames, _cursor, state} = Content.build_content(state, scrolls)
+    {state, layout}
+  end
+
+  defp normalize_cached_decorations_version(state, win_id) do
+    window = Map.fetch!(state.workspace.windows.map, win_id)
+    fingerprint = window.render_cache.last_context_fingerprint
+    decorations_version = Buffer.decorations_version(window.buffer)
+
+    put_in(
+      state.workspace.windows.map[win_id].render_cache.last_context_fingerprint,
+      put_elem(fingerprint, 10, decorations_version)
+    )
   end
 
   describe "WindowDirty struct" do

--- a/test/minga_editor/render_pipeline/scroll_test.exs
+++ b/test/minga_editor/render_pipeline/scroll_test.exs
@@ -7,8 +7,11 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
 
   alias MingaEditor.Layout
   alias MingaEditor.RenderPipeline
+  alias MingaEditor.RenderPipeline.Content
+  alias MingaEditor.RenderPipeline.Invalidation
   alias MingaEditor.RenderPipeline.Scroll
   alias MingaEditor.RenderPipeline.Scroll.WindowScroll
+  alias MingaEditor.RenderPipeline.WindowDirty
   alias MingaEditor.State, as: EditorState
 
   import MingaEditor.RenderPipeline.TestHelpers
@@ -20,6 +23,22 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
     layout = Layout.get(state)
     {scrolls, state} = Scroll.scroll_windows(state, layout)
     {scrolls, state, layout}
+  end
+
+  defp clean_invalidation(win_id) do
+    %Invalidation{
+      full_redraw: false,
+      windows: %{win_id => WindowDirty.clean()},
+      chrome_regions: MapSet.new()
+    }
+  end
+
+  defp trace_messages(pid) do
+    receive do
+      {:trace, ^pid, :receive, msg} -> [msg | trace_messages(pid)]
+    after
+      0 -> []
+    end
   end
 
   describe "scroll_windows/2" do
@@ -78,6 +97,26 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
 
       # First frame: sentinel values trigger full invalidation
       assert window.render_cache.dirty_lines == :all
+    end
+
+    test "clean windows skip render_snapshot on later frames" do
+      state = base_state(content: "alpha\nbeta\ngamma")
+      {scrolls, state, layout} = run_through_scroll(state)
+      {_frames, _cursor, state} = Content.build_content(state, scrolls)
+      win_id = state.workspace.windows.active
+      buf = state.workspace.buffers.active
+      invalidation = clean_invalidation(win_id)
+
+      :erlang.trace(buf, true, [:receive])
+      {_scrolls, _state} = Scroll.scroll_windows(state, layout, invalidation)
+      :erlang.trace(buf, false, [:receive])
+
+      messages = trace_messages(buf)
+
+      refute Enum.any?(messages, fn
+               {:"$gen_call", _from, {:render_snapshot, _first, _count}} -> true
+               _ -> false
+             end)
     end
   end
 end

--- a/test/minga_editor/render_pipeline/scroll_test.exs
+++ b/test/minga_editor/render_pipeline/scroll_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer
   alias MingaEditor.Layout
   alias MingaEditor.RenderPipeline
   alias MingaEditor.RenderPipeline.Content
@@ -13,6 +14,7 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
   alias MingaEditor.RenderPipeline.Scroll.WindowScroll
   alias MingaEditor.RenderPipeline.WindowDirty
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Window
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -117,6 +119,45 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
                {:"$gen_call", _from, {:render_snapshot, _first, _count}} -> true
                _ -> false
              end)
+    end
+
+    test "clean active windows preserve horizontal scroll without fetched lines" do
+      state = base_state(content: "alpha beta gamma delta epsilon zeta eta theta")
+      {:ok, false} = Buffer.set_option(state.workspace.buffers.active, :wrap, false)
+      {scrolls, state, layout} = run_through_scroll(state)
+      {_frames, _cursor, state} = Content.build_content(state, scrolls)
+      win_id = state.workspace.windows.active
+
+      scrolled_window =
+        state.workspace.windows.map
+        |> Map.fetch!(win_id)
+        |> Window.scroll_horizontal(12)
+
+      state = put_in(state.workspace.windows.map[win_id], scrolled_window)
+      invalidation = clean_invalidation(win_id)
+
+      {scrolls, state} = Scroll.scroll_windows(state, layout, invalidation)
+      scroll = Map.fetch!(scrolls, win_id)
+      updated_window = Map.fetch!(state.workspace.windows.map, win_id)
+
+      assert scroll.lines == []
+      assert scroll.viewport.left == 12
+      assert updated_window.viewport.left == 12
+    end
+
+    test "clean windows reuse cached buffer dirty status" do
+      state = base_state(content: "alpha\nbeta\ngamma")
+      {scrolls, state, layout} = run_through_scroll(state)
+      {_frames, _cursor, state} = Content.build_content(state, scrolls)
+      win_id = state.workspace.windows.active
+
+      state = put_in(state.workspace.windows.map[win_id].render_cache.last_buffer_dirty, true)
+      invalidation = clean_invalidation(win_id)
+
+      {scrolls, _state} = Scroll.scroll_windows(state, layout, invalidation)
+      scroll = Map.fetch!(scrolls, win_id)
+
+      assert scroll.snapshot.dirty == true
     end
   end
 end


### PR DESCRIPTION
# TL;DR
Clean render frames now skip the expensive buffer snapshot/content rebuild path and avoid sending a full-screen clear when nothing changed. This turns the existing window dirty model into actual downstream render savings.

Closes #1517

## Context
#1431 added first-class dirty information for windows and chrome. This PR wires that dirty state into Scroll, Content, Compose, and TUI Emit so clean frames become cheap no-ops instead of full redraws.

## Changes
- Added per-frame invalidation synthesis from window render caches, cursor metadata, buffer version, decoration version, and chrome fingerprints.
- Added a cached `last_window_frame` on `Window.RenderCache` so Content can return a clean window frame directly.
- Added row-dirty Content handling that marks only dirty rows before using the existing cached line draw merge path.
- Added frame/window damage flags so Compose can tell Emit whether any rows or chrome changed.
- Added a `clear:` option to display-list command encoding and made TUI Emit omit the leading clear command for undamaged frames.

## Verification
- `make lint`
- `mix test.llm`
- `MINGA_RENDER_SANITY=1 mix test.llm`
- `mix test.llm test/minga_editor/render_pipeline/scroll_test.exs test/minga_editor/render_pipeline/content_test.exs test/minga_editor/frontend/emit_test.exs`

## Acceptance Criteria Addressed
- Scroll stage skips `Buffer.render_snapshot/3` for `WindowDirty.mode == :clean`, while still preserving invalidation safety ✅
- Content stage returns cached `WindowFrame` for clean windows and merges row-dirty rebuilds with cached rows ✅
- Emit stage omits leading `Protocol.encode_clear()` when no window frame or chrome damage changed ✅
