### PR TITLE
chore(dev): add cached worktree helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,9 @@ jobs:
       - run: mix deps.get --only prod
       - run: mix release minga
 
+      - name: Check release contents
+        run: scripts/check-release-contents _build/prod/rel/minga
+
       - name: Smoke test
         run: |
           binary="burrito_out/${{ matrix.artifact }}"
@@ -217,6 +220,9 @@ jobs:
           fi
           echo "app_path=$APP_PATH" >> "$GITHUB_OUTPUT"
           echo "Found: $APP_PATH"
+
+      - name: Check app release contents
+        run: scripts/check-release-contents "${{ steps.find_app.outputs.app_path }}/Contents/Resources/release"
 
       # Import Developer ID certificate into a temporary keychain
       - name: Import signing certificate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,16 +136,17 @@ All feature branches use git worktrees. This keeps the main checkout clean and l
 
 **Starting work:**
 
-1. Create the worktree and branch:
+1. Create the worktree and branch with the helper script:
    ```bash
-   git worktree add ../minga-worktrees/<branch-name> -b <branch-name>
+   scripts/create_worktree <branch-name>
    ```
-2. Do all work inside `../minga-worktrees/<branch-name>`. The agent's working directory must be set to the worktree, not the main checkout.
-3. The first build in a new worktree needs `mix deps.get` and a full compile. This is a one-time cost.
+2. Do all work inside the created worktree under `../minga-worktrees/`. The agent's working directory must be set to the worktree, not the main checkout.
+3. The helper copies `deps/`, `_build/`, and ElixirLS PLTs into the new worktree when `mix.lock` matches, which keeps first-run `mix` commands and Dialyzer fast. If the helper skips the copy, run `mix deps.get` and let the worktree rebuild normally.
+4. Run the helper from any Minga checkout, but only when no `mix` command is active in the source checkout or target worktree. Copying build caches while they are being written can produce confusing compile or Dialyzer failures.
 
 **After the PR is merged:**
 
-1. Clean up: `git worktree remove ../minga-worktrees/<branch-name>`
+1. Clean up using the path printed by `scripts/create_worktree`: `git worktree remove ../minga-worktrees/<worktree-name>`
 2. Prune stale refs: `git worktree prune`
 3. Pull main in the primary checkout: `cd <your-main-checkout> && git pull origin main`
 

--- a/scripts/check-release-contents
+++ b/scripts/check-release-contents
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check-release-contents [release-dir]
+
+Fails if the repo-root scripts directory is present in an assembled release directory. The default release directory is _build/prod/rel/minga.
+USAGE
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+release_dir=${1:-_build/prod/rel/minga}
+
+if [[ ! -d "$release_dir" ]]; then
+  echo "Release directory not found: $release_dir" >&2
+  exit 1
+fi
+
+scripts_dir="$release_dir/scripts"
+leaked_paths=""
+
+if [[ -e "$scripts_dir" || -L "$scripts_dir" ]]; then
+  leaked_paths=$(find "$scripts_dir" -print)
+fi
+
+if [[ -n "$leaked_paths" ]]; then
+  echo "Repo-root scripts leaked into release:" >&2
+  echo "$leaked_paths" >&2
+  exit 1
+fi
+
+echo "Release contents check passed: no repo-root scripts found in $release_dir"

--- a/scripts/create_worktree
+++ b/scripts/create_worktree
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/create_worktree <branch-name> [base-ref]
+
+Creates a worktree under ../minga-worktrees/ relative to the primary checkout and copies local Mix caches into it so the first mix command does not start cold.
+
+Run this from any Minga checkout when no mix command is active in the source checkout.
+USAGE
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage >&2
+  exit 64
+fi
+
+branch=$1
+base_ref=${2:-main}
+repo_root=$(git rev-parse --show-toplevel)
+main_worktree=$(git -C "$repo_root" worktree list --porcelain | awk '
+  NR == 1 && $1 == "worktree" {
+    sub(/^worktree /, "")
+    print
+    exit
+  }
+')
+
+if [[ -z "$main_worktree" ]]; then
+  echo "Unable to locate the primary worktree" >&2
+  exit 1
+fi
+
+worktree_name=${branch//\//-}
+worktree_parent="$(cd "$main_worktree/.." && pwd -P)/minga-worktrees"
+worktree_path="$worktree_parent/$worktree_name"
+
+if [[ -e "$worktree_path" ]]; then
+  echo "Worktree path already exists: $worktree_path" >&2
+  exit 1
+fi
+
+mkdir -p "$worktree_parent"
+
+echo "Creating worktree: $worktree_path"
+git -C "$repo_root" worktree add "$worktree_path" -b "$branch" "$base_ref"
+
+source_lock="$repo_root/mix.lock"
+target_lock="$worktree_path/mix.lock"
+if [[ -f "$source_lock" && -f "$target_lock" ]] && ! cmp -s "$source_lock" "$target_lock"; then
+  echo "mix.lock differs between source checkout and new worktree; skipping cache copy." >&2
+  echo "Run mix deps.get in the new worktree." >&2
+  exit 0
+fi
+
+copy_dir() {
+  local name=$1
+  if [[ -d "$repo_root/$name" ]]; then
+    echo "Copying $name/"
+    rsync -a "$repo_root/$name/" "$worktree_path/$name/"
+  fi
+}
+
+copy_elixir_ls_plts() {
+  local source_dir="$repo_root/.elixir_ls"
+  local target_dir="$worktree_path/.elixir_ls"
+  if [[ ! -d "$source_dir" ]]; then
+    return 0
+  fi
+
+  shopt -s nullglob
+  local plts=("$source_dir"/iplt-*)
+  shopt -u nullglob
+
+  if [[ ${#plts[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  echo "Copying .elixir_ls PLTs"
+  mkdir -p "$target_dir"
+  rsync -a "${plts[@]}" "$target_dir/"
+}
+
+copy_dir deps
+copy_dir _build
+copy_elixir_ls_plts
+
+echo "Worktree ready: $worktree_path"
+echo "Next: cd $worktree_path && mix deps.get"


### PR DESCRIPTION
# TL;DR
Add a repo helper for creating Minga worktrees with warm Mix caches, and add release guards so development helper scripts do not leak into Burrito or macOS app release contents.

## Context
Minga agents work from git worktrees, but fresh worktrees start with cold `deps/`, `_build/`, and PLT state. This makes the first `mix` and Dialyzer commands slower than necessary.

## Changes
- Added `scripts/create_worktree`, which creates a branch worktree under `../minga-worktrees/` relative to the primary checkout and copies `deps/`, `_build/`, and ElixirLS PLTs when `mix.lock` matches.
- Made the helper safe to run from any Minga checkout, including an existing worktree, while still placing the new worktree in the shared `../minga-worktrees/` directory.
- Updated `AGENTS.md` so future pi sessions use the helper instead of calling `git worktree add` directly.
- Added `scripts/check-release-contents` and wired it into both Burrito/TUI and macOS app release jobs.

## Verification
- `bash -n scripts/create_worktree scripts/check-release-contents`
- `shellcheck scripts/create_worktree scripts/check-release-contents`
- `scripts/check-release-contents` against temp clean release dirs, confirmed it passes
- `scripts/check-release-contents` against temp release dirs containing root `scripts/`, confirmed it fails
- `scripts/create_worktree` smoke test from an existing worktree, confirmed it creates the new checkout under the shared `../minga-worktrees/` directory and cleanup removes the smoke branch/worktree
- `git diff --check`
- Fresh-eyes bug review found the missing macOS app guard; targeted re-review confirmed the fix

## Acceptance Criteria Addressed
- Worktree creation helper copies Mix and PLT caches for faster first commands ✅
- pi session instructions point agents to the helper ✅
- Burrito and macOS app release workflows check that development helper scripts are not in release contents ✅