### PR TITLE
fix(buffer): add debounced auto-save

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -31,6 +31,7 @@ That's it. Save the file and restart Minga. Your options take effect immediately
 | `:trim_trailing_whitespace` | boolean | `false` | Strip trailing whitespace on save |
 | `:insert_final_newline` | boolean | `false` | Ensure file ends with a newline on save |
 | `:format_on_save` | boolean | `false` | Run the filetype's formatter before saving |
+| `:auto_save_delay_ms` | non-negative integer | `1000` | Debounce before dirty file-backed buffers auto-save; `0` disables auto-save |
 | `:formatter` | string or `nil` | `nil` | Override the default formatter command (see [Formatters](#formatters)) |
 | `:title_format` | string | `"{filename} {dirty}({directory}) - Minga"` | Terminal window title format (see [Window Title](#window-title)) |
 | `:recent_files_limit` | positive integer | `200` | Max recent files tracked per project |
@@ -117,15 +118,16 @@ The two options are orthogonal. `:agent_tool_approval` controls *whether* to pro
 
 For the full option API, see [`Minga.Config.Options`](https://jsmestad.github.io/minga/Minga.Config.Options.html).
 
-### Planned: buffer-aware agent options
+### Buffer-aware agent options
 
-When agent tools are [routed through `Buffer.Server`](BUFFER-AWARE-AGENTS.md), additional configuration options will control the new editing behavior:
+When agent tools are [routed through `Buffer.Server`](BUFFER-AWARE-AGENTS.md), file-backed buffers auto-save after `:auto_save_delay_ms` so agent edits are not stranded only in memory. Set it to `0` if you want every dirty buffer to wait for an explicit save.
 
-- Whether agent edits auto-save to disk or stay in-memory until explicit save
+Some buffer-aware controls are still planned:
+
 - Whether buffer forks merge automatically (clean merges only) or always go through diff review
 - Whether to flush dirty buffers before agent shell commands
 
-These options don't exist yet. See [BUFFER-AWARE-AGENTS.md](BUFFER-AWARE-AGENTS.md) for the design.
+See [BUFFER-AWARE-AGENTS.md](BUFFER-AWARE-AGENTS.md) for the design.
 
 ## Startup view
 

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -1435,7 +1435,7 @@ defmodule Minga.Buffer.Server do
             explicit_options: MapSet.put(state.explicit_options, name)
         }
 
-        {:reply, {:ok, value}, new_state}
+        {:reply, {:ok, value}, apply_option_change(new_state, name)}
 
       {:error, _} = err ->
         {:reply, err, state}
@@ -1763,10 +1763,31 @@ defmodule Minga.Buffer.Server do
     {:noreply, %{state | swap_timer: nil}}
   end
 
+  def handle_info(
+        {:auto_save, token},
+        %{buffer_type: :file, file_path: path, dirty: true, auto_save_token: token} = state
+      )
+      when is_binary(path) do
+    if auto_save_enabled?(state) do
+      auto_save_file(state, path)
+    else
+      {:noreply, clear_auto_save_timer(state)}
+    end
+  end
+
+  def handle_info({:auto_save, token}, %{auto_save_token: token} = state) do
+    {:noreply, clear_auto_save_timer(state)}
+  end
+
+  def handle_info({:auto_save, _token}, state) do
+    {:noreply, state}
+  end
+
   @impl true
   @spec terminate(term(), state()) :: :ok
   def terminate(_reason, state) do
-    # Clean up swap file on orderly shutdown (buffer closed, editor quit).
+    # Clean up timers and swap files on orderly shutdown (buffer closed, editor quit).
+    state = cancel_auto_save_timer(state)
     delete_swap_file(state)
     :ok
   end
@@ -1971,6 +1992,7 @@ defmodule Minga.Buffer.Server do
     :trim_trailing_whitespace,
     :insert_final_newline,
     :format_on_save,
+    :auto_save_delay_ms,
     :formatter,
     :line_numbers
   ]
@@ -2003,7 +2025,8 @@ defmodule Minga.Buffer.Server do
   # Different mtime OR different size = changed.
   @spec file_changed_on_disk?(BufState.t(), integer() | nil, non_neg_integer() | nil) ::
           boolean()
-  defp file_changed_on_disk?(%{mtime: nil}, _disk_mtime, _disk_size), do: false
+  defp file_changed_on_disk?(%{mtime: nil}, nil, _disk_size), do: false
+  defp file_changed_on_disk?(%{mtime: nil}, _disk_mtime, _disk_size), do: true
   defp file_changed_on_disk?(_state, nil, _disk_size), do: false
 
   defp file_changed_on_disk?(state, disk_mtime, disk_size) do
@@ -2045,17 +2068,27 @@ defmodule Minga.Buffer.Server do
   @spec mark_dirty(state()) :: state()
   defp mark_dirty(state) do
     state = BufState.mark_dirty(state)
-    schedule_swap_write(state)
+    state = schedule_swap_write(state)
+    schedule_auto_save(state)
   end
 
   @spec sync_dirty(state()) :: state()
-  defp sync_dirty(state), do: BufState.sync_dirty(state)
+  defp sync_dirty(state) do
+    state = BufState.sync_dirty(state)
+
+    if state.dirty do
+      schedule_auto_save(state)
+    else
+      cancel_auto_save_timer(state)
+    end
+  end
 
   @spec mark_saved(state()) :: state()
   defp mark_saved(state) do
     state = BufState.mark_saved(state)
     :ok = delete_swap_file(state)
-    cancel_swap_timer(state)
+    state = cancel_swap_timer(state)
+    cancel_auto_save_timer(state)
   end
 
   # Schedule a debounced swap file write. Cancels any pending timer
@@ -2076,6 +2109,93 @@ defmodule Minga.Buffer.Server do
   defp cancel_swap_timer(%{swap_timer: ref} = state) when is_reference(ref) do
     Process.cancel_timer(ref)
     %{state | swap_timer: nil}
+  end
+
+  @spec apply_option_change(state(), atom()) :: state()
+  defp apply_option_change(%{dirty: true} = state, :auto_save_delay_ms),
+    do: schedule_auto_save(state)
+
+  defp apply_option_change(state, :auto_save_delay_ms), do: cancel_auto_save_timer(state)
+  defp apply_option_change(state, _name), do: state
+
+  @spec auto_save_file(state(), String.t()) :: {:noreply, state()}
+  defp auto_save_file(state, path) do
+    {disk_mtime, disk_size} = file_stat_info(path)
+
+    if file_changed_on_disk?(state, disk_mtime, disk_size) do
+      {:noreply, clear_auto_save_timer(state)}
+    else
+      write_auto_save_file(state, path)
+    end
+  end
+
+  @spec write_auto_save_file(state(), String.t()) :: {:noreply, state()}
+  defp write_auto_save_file(state, path) do
+    content = Document.content(state.document)
+
+    case write_file(path, content) do
+      :ok ->
+        {new_mtime, new_size} = file_stat_info(path)
+        Minga.Log.info(:editor, "Auto-saved: #{Path.basename(path)}")
+        {:noreply, mark_saved(%{state | mtime: new_mtime, file_size: new_size})}
+
+      {:error, reason} ->
+        Minga.Log.warning(
+          :editor,
+          "Failed to auto-save #{Path.basename(path)}: #{inspect(reason)}"
+        )
+
+        {:noreply, clear_auto_save_timer(state)}
+    end
+  end
+
+  @spec auto_save_enabled?(state()) :: boolean()
+  defp auto_save_enabled?(state) do
+    case resolve_option(state, :auto_save_delay_ms) do
+      delay when is_integer(delay) and delay > 0 -> true
+      _ -> false
+    end
+  end
+
+  # Schedule a debounced auto-save. A value of 0 disables auto-save.
+  @spec schedule_auto_save(state()) :: state()
+  defp schedule_auto_save(%{buffer_type: :file, file_path: path} = state) when is_binary(path) do
+    delay_ms = resolve_option(state, :auto_save_delay_ms)
+
+    case delay_ms do
+      delay when is_integer(delay) and delay > 0 ->
+        state = cancel_auto_save_timer(state)
+        token = make_ref()
+        timer = Process.send_after(self(), {:auto_save, token}, delay)
+        %{state | auto_save_timer: timer, auto_save_token: token}
+
+      _ ->
+        cancel_auto_save_timer(state)
+    end
+  end
+
+  defp schedule_auto_save(state), do: state
+
+  @spec cancel_auto_save_timer(state()) :: state()
+  defp cancel_auto_save_timer(%{auto_save_timer: nil} = state), do: clear_auto_save_timer(state)
+
+  defp cancel_auto_save_timer(%{auto_save_timer: timer, auto_save_token: token} = state)
+       when is_reference(timer) and is_reference(token) do
+    Process.cancel_timer(timer)
+    flush_auto_save_message(token)
+    clear_auto_save_timer(state)
+  end
+
+  @spec clear_auto_save_timer(state()) :: state()
+  defp clear_auto_save_timer(state), do: %{state | auto_save_timer: nil, auto_save_token: nil}
+
+  @spec flush_auto_save_message(reference()) :: :ok
+  defp flush_auto_save_message(token) do
+    receive do
+      {:auto_save, ^token} -> :ok
+    after
+      0 -> :ok
+    end
   end
 
   @spec delete_swap_file(state()) :: :ok

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -4,7 +4,7 @@ defmodule Minga.Buffer.Server do
 
   Each open file gets its own `Buffer.Server` process, managed by
   the `Buffer.Supervisor` (DynamicSupervisor). If a buffer process
-  crashes, only that buffer is lost — all other buffers and the
+  crashes, only that buffer is lost, and all other buffers and the
   editor continue running.
 
   ## Examples
@@ -837,6 +837,7 @@ defmodule Minga.Buffer.Server do
           buffer_type: buffer_type,
           mtime: mtime,
           file_size: size,
+          file_hash: saved_content_hash(path, mtime, text),
           name: Keyword.get(opts, :buffer_name),
           read_only: read_only,
           unlisted: Keyword.get(opts, :unlisted, false),
@@ -873,6 +874,7 @@ defmodule Minga.Buffer.Server do
             dirty: false,
             mtime: mtime,
             file_size: size,
+            file_hash: content_hash(text),
             decorations: Decorations.new(),
             undo_stack: [],
             redo_stack: []
@@ -1135,10 +1137,19 @@ defmodule Minga.Buffer.Server do
     if file_changed_on_disk?(state, disk_mtime, disk_size) do
       {:reply, {:error, :file_changed}, state}
     else
-      case write_file(state.file_path, Document.content(state.document)) do
+      content = Document.content(state.document)
+
+      case write_file(state.file_path, content) do
         :ok ->
           {new_mtime, new_size} = file_stat_info(state.file_path)
-          {:reply, :ok, mark_saved(%{state | mtime: new_mtime, file_size: new_size})}
+
+          {:reply, :ok,
+           mark_saved(%{
+             state
+             | mtime: new_mtime,
+               file_size: new_size,
+               file_hash: content_hash(content)
+           })}
 
         {:error, reason} ->
           {:reply, {:error, reason}, state}
@@ -1156,10 +1167,19 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call(:force_save, _from, state) do
-    case write_file(state.file_path, Document.content(state.document)) do
+    content = Document.content(state.document)
+
+    case write_file(state.file_path, content) do
       :ok ->
         {new_mtime, new_size} = file_stat_info(state.file_path)
-        {:reply, :ok, mark_saved(%{state | mtime: new_mtime, file_size: new_size})}
+
+        {:reply, :ok,
+         mark_saved(%{
+           state
+           | mtime: new_mtime,
+             file_size: new_size,
+             file_hash: content_hash(content)
+         })}
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}
@@ -1201,6 +1221,7 @@ defmodule Minga.Buffer.Server do
             dirty: false,
             mtime: new_mtime,
             file_size: new_size,
+            file_hash: content_hash(text),
             undo_stack: [],
             redo_stack: [],
             decorations: Decorations.new()
@@ -1215,14 +1236,22 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call({:save_as, file_path}, _from, state) do
-    case write_file(file_path, Document.content(state.document)) do
+    content = Document.content(state.document)
+
+    case write_file(file_path, content) do
       :ok ->
         {new_mtime, new_size} = file_stat_info(file_path)
         unregister_path(state.file_path)
         register_path(file_path)
 
         {:reply, :ok,
-         mark_saved(%{state | file_path: file_path, mtime: new_mtime, file_size: new_size})}
+         mark_saved(%{
+           state
+           | file_path: file_path,
+             mtime: new_mtime,
+             file_size: new_size,
+             file_hash: content_hash(content)
+         })}
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}
@@ -2020,9 +2049,8 @@ defmodule Minga.Buffer.Server do
     end
   end
 
-  # Detects external changes by comparing mtime and file size.
-  # Same mtime + same size = no change (covers same-second writes that don't alter size).
-  # Different mtime OR different size = changed.
+  # Detects external changes by comparing mtime, file size, and saved-content hash.
+  # The hash closes the same-second, same-size hole in coarse filesystem mtimes.
   @spec file_changed_on_disk?(BufState.t(), integer() | nil, non_neg_integer() | nil) ::
           boolean()
   defp file_changed_on_disk?(%{mtime: nil}, nil, _disk_size), do: false
@@ -2030,8 +2058,27 @@ defmodule Minga.Buffer.Server do
   defp file_changed_on_disk?(_state, nil, _disk_size), do: false
 
   defp file_changed_on_disk?(state, disk_mtime, disk_size) do
-    disk_mtime > state.mtime or disk_size != state.file_size
+    metadata_changed? = disk_mtime != state.mtime or disk_size != state.file_size
+
+    case saved_content_status(state) do
+      :same -> false
+      :changed -> true
+      :unknown -> metadata_changed?
+    end
   end
+
+  @typep saved_content_status :: :same | :changed | :unknown
+
+  @spec saved_content_status(BufState.t()) :: saved_content_status()
+  defp saved_content_status(%{file_path: path, file_hash: hash})
+       when is_binary(path) and is_binary(hash) do
+    case File.read(path) do
+      {:ok, content} -> if content_hash(content) == hash, do: :same, else: :changed
+      {:error, _reason} -> :changed
+    end
+  end
+
+  defp saved_content_status(_state), do: :unknown
 
   @spec file_stat_info(String.t()) :: {integer() | nil, non_neg_integer() | nil}
   defp file_stat_info(path) do
@@ -2040,6 +2087,16 @@ defmodule Minga.Buffer.Server do
       {:error, _} -> {nil, nil}
     end
   end
+
+  @spec content_hash(String.t()) :: binary()
+  defp content_hash(content), do: :crypto.hash(:sha256, content)
+
+  @spec saved_content_hash(String.t() | nil, integer() | nil, String.t()) :: binary() | nil
+  defp saved_content_hash(path, mtime, content) when is_binary(path) and is_integer(mtime) do
+    content_hash(content)
+  end
+
+  defp saved_content_hash(_path, _mtime, _content), do: nil
 
   # Delegates to BufState for time-based undo coalescing.
   @spec push_undo(state(), Document.t(), BufState.edit_source()) :: state()
@@ -2120,13 +2177,40 @@ defmodule Minga.Buffer.Server do
 
   @spec auto_save_file(state(), String.t()) :: {:noreply, state()}
   defp auto_save_file(state, path) do
-    {disk_mtime, disk_size} = file_stat_info(path)
+    case File.stat(path, time: :posix) do
+      {:ok, %{mtime: disk_mtime, size: disk_size}} ->
+        maybe_write_auto_save_file(state, path, disk_mtime, disk_size)
 
+      {:error, :enoent} when is_nil(state.mtime) ->
+        write_auto_save_file(state, path)
+
+      {:error, :enoent} ->
+        skip_auto_save(state, path, "file was deleted on disk")
+
+      {:error, reason} ->
+        skip_auto_save(state, path, "could not stat file: #{inspect(reason)}")
+    end
+  end
+
+  @spec maybe_write_auto_save_file(state(), String.t(), integer(), non_neg_integer()) ::
+          {:noreply, state()}
+  defp maybe_write_auto_save_file(state, path, disk_mtime, disk_size) do
     if file_changed_on_disk?(state, disk_mtime, disk_size) do
-      {:noreply, clear_auto_save_timer(state)}
+      skip_auto_save(state, path, "file changed on disk")
     else
       write_auto_save_file(state, path)
     end
+  end
+
+  @spec skip_auto_save(state(), String.t(), String.t()) :: {:noreply, state()}
+  defp skip_auto_save(state, path, reason) do
+    log_to_messages(
+      state,
+      "Auto-save skipped for #{display_path(path)}: #{reason}; reload or save explicitly.",
+      :warning
+    )
+
+    {:noreply, clear_auto_save_timer(state)}
   end
 
   @spec write_auto_save_file(state(), String.t()) :: {:noreply, state()}
@@ -2136,18 +2220,50 @@ defmodule Minga.Buffer.Server do
     case write_file(path, content) do
       :ok ->
         {new_mtime, new_size} = file_stat_info(path)
-        Minga.Log.info(:editor, "Auto-saved: #{Path.basename(path)}")
-        {:noreply, mark_saved(%{state | mtime: new_mtime, file_size: new_size})}
+
+        new_state =
+          mark_saved(%{
+            state
+            | mtime: new_mtime,
+              file_size: new_size,
+              file_hash: content_hash(content)
+          })
+
+        log_to_messages(new_state, "Auto-saved: #{display_path(path)}", :info)
+        broadcast_buffer_saved(new_state, path)
+        {:noreply, new_state}
 
       {:error, reason} ->
-        Minga.Log.warning(
-          :editor,
-          "Failed to auto-save #{Path.basename(path)}: #{inspect(reason)}"
+        log_to_messages(
+          state,
+          "Failed to auto-save #{display_path(path)}: #{inspect(reason)}",
+          :warning
         )
 
         {:noreply, clear_auto_save_timer(state)}
     end
   end
+
+  @spec broadcast_buffer_saved(state(), String.t()) :: :ok
+  defp broadcast_buffer_saved(state, path) do
+    Events.broadcast(
+      :buffer_saved,
+      %Events.BufferEvent{buffer: self(), path: path},
+      state.events_registry
+    )
+  end
+
+  @spec log_to_messages(state(), String.t(), Events.LogMessageEvent.level()) :: :ok
+  defp log_to_messages(state, text, level) do
+    Events.broadcast(
+      :log_message,
+      %Events.LogMessageEvent{text: text, level: level},
+      state.events_registry
+    )
+  end
+
+  @spec display_path(String.t()) :: String.t()
+  defp display_path(path), do: Path.relative_to_cwd(path)
 
   @spec auto_save_enabled?(state()) :: boolean()
   defp auto_save_enabled?(state) do

--- a/lib/minga/buffer/state.ex
+++ b/lib/minga/buffer/state.ex
@@ -61,6 +61,8 @@ defmodule Minga.Buffer.State do
             options: %{},
             explicit_options: MapSet.new(),
             swap_timer: nil,
+            auto_save_timer: nil,
+            auto_save_token: nil,
             swap_dir: nil,
             events_registry: Minga.Events.default_registry()
 
@@ -90,6 +92,8 @@ defmodule Minga.Buffer.State do
           options: %{atom() => term()},
           explicit_options: MapSet.t(atom()),
           swap_timer: reference() | nil,
+          auto_save_timer: reference() | nil,
+          auto_save_token: reference() | nil,
           swap_dir: String.t() | nil,
           events_registry: Minga.Events.registry()
         }

--- a/lib/minga/buffer/state.ex
+++ b/lib/minga/buffer/state.ex
@@ -20,11 +20,11 @@ defmodule Minga.Buffer.State do
   @typedoc """
   Buffer type controlling behavior:
 
-  * `:file` — (default) normal file buffer, supports save/dirty/undo
-  * `:nofile` — no file association, implicitly read-only, no save
-  * `:nowrite` — has a file path for display but cannot save
-  * `:prompt` — like `:nofile` but the last line is editable (for agent input, command input)
-  * `:terminal` — backed by an external process writing into the buffer
+  * `:file`: (default) normal file buffer, supports save/dirty/undo
+  * `:nofile`: no file association, implicitly read-only, no save
+  * `:nowrite`: has a file path for display but cannot save
+  * `:prompt`: like `:nofile` but the last line is editable (for agent input, command input)
+  * `:terminal`: backed by an external process writing into the buffer
   """
   @type buffer_type :: :file | :nofile | :nowrite | :prompt | :terminal
 
@@ -45,6 +45,7 @@ defmodule Minga.Buffer.State do
             saved_version: 0,
             mtime: nil,
             file_size: nil,
+            file_hash: nil,
             undo_stack: [],
             redo_stack: [],
             last_undo_at: 0,
@@ -76,6 +77,7 @@ defmodule Minga.Buffer.State do
           saved_version: non_neg_integer(),
           mtime: integer() | nil,
           file_size: non_neg_integer() | nil,
+          file_hash: binary() | nil,
           undo_stack: [stack_entry()],
           redo_stack: [stack_entry()],
           last_undo_at: integer(),

--- a/lib/minga/config/completion.ex
+++ b/lib/minga/config/completion.ex
@@ -219,6 +219,10 @@ defmodule Minga.Config.Completion do
   defp option_description(:format_on_save),
     do: "Run the configured formatter when saving a buffer."
 
+  defp option_description(:auto_save_delay_ms),
+    do:
+      "Debounce before dirty file-backed buffers auto-save, in milliseconds. Set to 0 to disable."
+
   defp option_description(:formatter),
     do:
       "External formatter command (e.g., \"mix format\"). Nil uses the default for the filetype."

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -26,6 +26,7 @@ defmodule Minga.Config.Options do
   | `:trim_trailing_whitespace` | boolean                             | `false`    |
   | `:insert_final_newline`     | boolean                             | `false`    |
   | `:format_on_save`           | boolean                             | `false`    |
+  | `:auto_save_delay_ms`       | non-negative integer (0 disables)   | `1000`     |
   | `:formatter`    | string or `nil`                                  | `nil`      |
   | `:title_format` | string with `{placeholder}` tokens               | `"{filename} {dirty}({directory}) - Minga"` |
   | `:recent_files_limit` | positive integer                            | `200`      |
@@ -97,6 +98,7 @@ defmodule Minga.Config.Options do
           | :trim_trailing_whitespace
           | :insert_final_newline
           | :format_on_save
+          | :auto_save_delay_ms
           | :formatter
           | :title_format
           | :recent_files_limit
@@ -229,6 +231,7 @@ defmodule Minga.Config.Options do
     {:trim_trailing_whitespace, :boolean, false},
     {:insert_final_newline, :boolean, false},
     {:format_on_save, :boolean, false},
+    {:auto_save_delay_ms, :non_neg_integer, 1000},
     {:formatter, :string_or_nil, nil},
     {:title_format, :string, "{filename} {dirty}({directory}) - Minga"},
     {:recent_files_limit, :pos_integer, 200},

--- a/test/minga/buffer/auto_save_test.exs
+++ b/test/minga/buffer/auto_save_test.exs
@@ -16,19 +16,20 @@ defmodule Minga.Buffer.AutoSaveTest do
     path = Path.join(dir, "auto-save.txt")
     File.write!(path, "hello")
     {:ok, pid} = Server.start_link(file_path: path)
-    assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
+    assert {:ok, 1} = Server.set_option(pid, :auto_save_delay_ms, 1)
 
     Events.subscribe(:log_message)
+    Events.subscribe(:buffer_saved)
 
     try do
       :ok = Server.insert_text(pid, "!")
-      token = :sys.get_state(pid).auto_save_token
-      send(pid, {:auto_save, token})
 
-      assert_log_contains("Auto-saved: auto-save.txt")
+      assert_buffer_saved(path)
+      assert_log_contains("Auto-saved: #{Path.relative_to_cwd(path)}")
       assert File.read!(path) == "!hello"
       refute Server.dirty?(pid)
     after
+      Events.unsubscribe(:buffer_saved)
       Events.unsubscribe(:log_message)
     end
   end
@@ -160,15 +161,81 @@ defmodule Minga.Buffer.AutoSaveTest do
     {:ok, pid} = Server.start_link(file_path: path)
     assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
 
-    :ok = Server.insert_text(pid, "buffer")
+    Events.subscribe(:log_message)
+
+    try do
+      :ok = Server.insert_text(pid, "buffer")
+      token = :sys.get_state(pid).auto_save_token
+      File.write!(path, "external")
+
+      send(pid, {:auto_save, token})
+      :sys.get_state(pid)
+
+      assert_log_contains(
+        "Auto-save skipped for #{Path.relative_to_cwd(path)}: file changed on disk"
+      )
+
+      assert File.read!(path) == "external"
+      assert Server.dirty?(pid)
+    after
+      Events.unsubscribe(:log_message)
+    end
+  end
+
+  test "auto-save skips when an existing file changes before the timer fires", %{tmp_dir: dir} do
+    path = Path.join(dir, "externally-modified.txt")
+    File.write!(path, "hello")
+    {:ok, pid} = Server.start_link(file_path: path)
+    assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
+
+    original_mtime = :sys.get_state(pid).mtime
+    :ok = Server.insert_text(pid, "!")
     token = :sys.get_state(pid).auto_save_token
-    File.write!(path, "external")
+    File.write!(path, "HELLO")
+    File.touch!(path, original_mtime)
 
-    send(pid, {:auto_save, token})
-    :sys.get_state(pid)
+    Events.subscribe(:log_message)
 
-    assert File.read!(path) == "external"
-    assert Server.dirty?(pid)
+    try do
+      send(pid, {:auto_save, token})
+      :sys.get_state(pid)
+
+      assert_log_contains(
+        "Auto-save skipped for #{Path.relative_to_cwd(path)}: file changed on disk"
+      )
+
+      assert File.read!(path) == "HELLO"
+      assert Server.dirty?(pid)
+    after
+      Events.unsubscribe(:log_message)
+    end
+  end
+
+  test "auto-save skips when an existing file is deleted before the timer fires", %{tmp_dir: dir} do
+    path = Path.join(dir, "externally-deleted.txt")
+    File.write!(path, "hello")
+    {:ok, pid} = Server.start_link(file_path: path)
+    assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
+
+    :ok = Server.insert_text(pid, "!")
+    token = :sys.get_state(pid).auto_save_token
+    File.rm!(path)
+
+    Events.subscribe(:log_message)
+
+    try do
+      send(pid, {:auto_save, token})
+      :sys.get_state(pid)
+
+      assert_log_contains(
+        "Auto-save skipped for #{Path.relative_to_cwd(path)}: file was deleted on disk"
+      )
+
+      refute File.exists?(path)
+      assert Server.dirty?(pid)
+    after
+      Events.unsubscribe(:log_message)
+    end
   end
 
   test "stopping a buffer cancels the pending auto-save timer", %{tmp_dir: dir} do
@@ -198,6 +265,16 @@ defmodule Minga.Buffer.AutoSaveTest do
         end
     after
       500 -> flunk("expected log message containing #{inspect(text)}")
+    end
+  end
+
+  defp assert_buffer_saved(path) do
+    receive do
+      {:minga_event, :buffer_saved, %Events.BufferEvent{buffer: buffer, path: ^path}}
+      when is_pid(buffer) ->
+        :ok
+    after
+      500 -> flunk("expected buffer_saved event for #{inspect(path)}")
     end
   end
 end

--- a/test/minga/buffer/auto_save_test.exs
+++ b/test/minga/buffer/auto_save_test.exs
@@ -1,0 +1,203 @@
+defmodule Minga.Buffer.AutoSaveTest do
+  @moduledoc """
+  Tests for debounced auto-save on file-backed buffers.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Server
+  alias Minga.Events
+  alias Minga.Events.LogMessageEvent
+
+  @moduletag :tmp_dir
+  @delay_ms 40
+
+  test "dirty file-backed buffer auto-saves after the configured delay", %{tmp_dir: dir} do
+    path = Path.join(dir, "auto-save.txt")
+    File.write!(path, "hello")
+    {:ok, pid} = Server.start_link(file_path: path)
+    assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
+
+    Events.subscribe(:log_message)
+
+    try do
+      :ok = Server.insert_text(pid, "!")
+      token = :sys.get_state(pid).auto_save_token
+      send(pid, {:auto_save, token})
+
+      assert_log_contains("Auto-saved: auto-save.txt")
+      assert File.read!(path) == "!hello"
+      refute Server.dirty?(pid)
+    after
+      Events.unsubscribe(:log_message)
+    end
+  end
+
+  test "rapid edits reset the debounce timer", %{tmp_dir: dir} do
+    path = Path.join(dir, "debounce.txt")
+    File.write!(path, "base")
+    {:ok, pid} = Server.start_link(file_path: path)
+    assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
+
+    :ok = Server.insert_text(pid, "A")
+    first_token = :sys.get_state(pid).auto_save_token
+    assert is_reference(first_token)
+
+    :ok = Server.insert_text(pid, "B")
+    second_token = :sys.get_state(pid).auto_save_token
+    assert is_reference(second_token)
+    refute first_token == second_token
+
+    send(pid, {:auto_save, first_token})
+    :sys.get_state(pid)
+    assert File.read!(path) == "base"
+
+    send(pid, {:auto_save, second_token})
+    :sys.get_state(pid)
+    assert File.read!(path) == "ABbase"
+    refute Server.dirty?(pid)
+  end
+
+  test "explicit save cancels a pending auto-save timer", %{tmp_dir: dir} do
+    path = Path.join(dir, "explicit-save.txt")
+    File.write!(path, "hello")
+    {:ok, pid} = Server.start_link(file_path: path)
+    assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
+
+    :ok = Server.insert_text(pid, "!")
+    state = :sys.get_state(pid)
+    assert is_reference(state.auto_save_timer)
+    assert is_reference(state.auto_save_token)
+
+    assert :ok = Server.save(pid)
+    refute :sys.get_state(pid).auto_save_timer
+
+    send(pid, {:auto_save, state.auto_save_token})
+    :sys.get_state(pid)
+    assert File.read!(path) == "!hello"
+  end
+
+  test "non-file buffers are excluded from auto-save", %{tmp_dir: dir} do
+    for buffer_type <- [:nofile, :nowrite, :prompt, :terminal] do
+      path = Path.join(dir, "#{buffer_type}.txt")
+      File.write!(path, "original")
+      {:ok, pid} = Server.start_link(file_path: path, buffer_type: buffer_type, read_only: false)
+      assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
+
+      :ok = Server.insert_text(pid, "!")
+      refute :sys.get_state(pid).auto_save_timer
+
+      send(pid, {:auto_save, make_ref()})
+      :sys.get_state(pid)
+      assert File.read!(path) == "original"
+      assert Server.dirty?(pid)
+      GenServer.stop(pid)
+    end
+  end
+
+  test "auto-save delay of 0 disables auto-save", %{tmp_dir: dir} do
+    path = Path.join(dir, "disabled.txt")
+    File.write!(path, "hello")
+    {:ok, pid} = Server.start_link(file_path: path)
+    assert {:ok, 0} = Server.set_option(pid, :auto_save_delay_ms, 0)
+
+    :ok = Server.insert_text(pid, "!")
+    refute :sys.get_state(pid).auto_save_timer
+
+    send(pid, {:auto_save, make_ref()})
+    :sys.get_state(pid)
+    assert File.read!(path) == "hello"
+    assert Server.dirty?(pid)
+  end
+
+  test "disabling auto-save cancels an already pending timer", %{tmp_dir: dir} do
+    path = Path.join(dir, "disable-pending.txt")
+    File.write!(path, "hello")
+    {:ok, pid} = Server.start_link(file_path: path)
+    assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
+
+    :ok = Server.insert_text(pid, "!")
+    token = :sys.get_state(pid).auto_save_token
+    assert is_reference(token)
+
+    assert {:ok, 0} = Server.set_option(pid, :auto_save_delay_ms, 0)
+    refute :sys.get_state(pid).auto_save_timer
+
+    send(pid, {:auto_save, token})
+    :sys.get_state(pid)
+    assert File.read!(path) == "hello"
+    assert Server.dirty?(pid)
+  end
+
+  test "undo to a dirty version schedules auto-save", %{tmp_dir: dir} do
+    path = Path.join(dir, "undo-dirty.txt")
+    File.write!(path, "hello")
+    {:ok, pid} = Server.start_link(file_path: path)
+    assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
+
+    :ok = Server.insert_text(pid, "!")
+    token = :sys.get_state(pid).auto_save_token
+    send(pid, {:auto_save, token})
+    :sys.get_state(pid)
+    refute Server.dirty?(pid)
+
+    :ok = Server.undo(pid)
+    state = :sys.get_state(pid)
+    assert Server.dirty?(pid)
+    assert is_reference(state.auto_save_timer)
+    assert is_reference(state.auto_save_token)
+
+    send(pid, {:auto_save, state.auto_save_token})
+    :sys.get_state(pid)
+    assert File.read!(path) == "hello"
+    refute Server.dirty?(pid)
+  end
+
+  test "auto-save skips when a missing file appears on disk before the timer fires", %{
+    tmp_dir: dir
+  } do
+    path = Path.join(dir, "externally-created.txt")
+    {:ok, pid} = Server.start_link(file_path: path)
+    assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
+
+    :ok = Server.insert_text(pid, "buffer")
+    token = :sys.get_state(pid).auto_save_token
+    File.write!(path, "external")
+
+    send(pid, {:auto_save, token})
+    :sys.get_state(pid)
+
+    assert File.read!(path) == "external"
+    assert Server.dirty?(pid)
+  end
+
+  test "stopping a buffer cancels the pending auto-save timer", %{tmp_dir: dir} do
+    path = Path.join(dir, "stopped.txt")
+    File.write!(path, "hello")
+    {:ok, pid} = Server.start_link(file_path: path)
+    assert {:ok, @delay_ms} = Server.set_option(pid, :auto_save_delay_ms, @delay_ms)
+
+    :ok = Server.insert_text(pid, "!")
+    assert is_reference(:sys.get_state(pid).auto_save_timer)
+
+    ref = Process.monitor(pid)
+    GenServer.stop(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 500
+
+    send(pid, {:auto_save, make_ref()})
+    assert File.read!(path) == "hello"
+  end
+
+  defp assert_log_contains(text) do
+    receive do
+      {:minga_event, :log_message, %LogMessageEvent{text: message}} ->
+        if String.contains?(message, text) do
+          :ok
+        else
+          assert_log_contains(text)
+        end
+    after
+      500 -> flunk("expected log message containing #{inspect(text)}")
+    end
+  end
+end

--- a/test/minga/buffer/mtime_test.exs
+++ b/test/minga/buffer/mtime_test.exs
@@ -50,17 +50,31 @@ defmodule Minga.Buffer.MtimeTest do
 
     {:ok, buf} = BufferServer.start_link(file_path: path)
 
-    # Simulate external modification — different size triggers detection
-    # even within the same second
+    # Simulate external modification, different size triggers detection even within the same second.
     File.write!(path, "externally modified with longer content")
 
     BufferServer.insert_char(buf, "x")
     result = BufferServer.save(buf)
 
     assert result == {:error, :file_changed}
-    # Buffer should still be dirty — save was rejected
     state = :sys.get_state(buf)
     assert state.dirty == true
+  end
+
+  @tag :tmp_dir
+  test ":w ignores metadata-only changes when file content still matches", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "touched.txt")
+    File.write!(path, "original")
+
+    {:ok, buf} = BufferServer.start_link(file_path: path)
+    original_mtime = :sys.get_state(buf).mtime
+    File.touch!(path, original_mtime + 10)
+
+    BufferServer.insert_char(buf, "x")
+
+    assert BufferServer.save(buf) == :ok
+    assert File.read!(path) == "xoriginal"
+    refute BufferServer.dirty?(buf)
   end
 
   @tag :tmp_dir
@@ -70,7 +84,7 @@ defmodule Minga.Buffer.MtimeTest do
 
     {:ok, buf} = BufferServer.start_link(file_path: path)
 
-    # Simulate external modification — different size
+    # Simulate external modification with a different size.
     File.write!(path, "externally modified with longer content")
 
     BufferServer.insert_char(buf, "forced")

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -41,6 +41,7 @@ defmodule Minga.Config.OptionsTest do
                trim_trailing_whitespace: false,
                insert_final_newline: false,
                format_on_save: false,
+               auto_save_delay_ms: 1000,
                formatter: nil,
                title_format: "{filename} {dirty}({directory}) - Minga",
                recent_files_limit: 200,
@@ -142,6 +143,14 @@ defmodule Minga.Config.OptionsTest do
       assert Options.get(s, :scroll_margin) == 0
     end
 
+    test "set and get auto_save_delay_ms", %{server: s} do
+      assert Options.get(s, :auto_save_delay_ms) == 1000
+      assert {:ok, 0} = Options.set(s, :auto_save_delay_ms, 0)
+      assert Options.get(s, :auto_save_delay_ms) == 0
+      assert {:ok, 250} = Options.set(s, :auto_save_delay_ms, 250)
+      assert Options.get(s, :auto_save_delay_ms) == 250
+    end
+
     test "set and get startup_view", %{server: s} do
       assert Options.get(s, :startup_view) == :agent
       assert {:ok, :editor} = Options.set(s, :startup_view, :editor)
@@ -194,6 +203,10 @@ defmodule Minga.Config.OptionsTest do
 
     test "scroll_margin rejects negative", %{server: s} do
       assert {:error, _} = Options.set(s, :scroll_margin, -1)
+    end
+
+    test "auto_save_delay_ms rejects negative", %{server: s} do
+      assert {:error, _} = Options.set(s, :auto_save_delay_ms, -1)
     end
 
     test "unknown option returns error", %{server: s} do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -37,5 +37,9 @@ ExUnit.start(capture_log: true, exclude: [:pi | swift_exclude])
 # test clipboard behavior set clipboard: :unnamedplus in their setup.
 Minga.Config.Options.set(:clipboard, :none)
 
+# Disable auto-save globally in tests to avoid background disk writes from
+# unrelated file-buffer tests. Auto-save tests opt in per buffer.
+Minga.Config.Options.set(:auto_save_delay_ms, 0)
+
 # Tests that create editors directly should pass `editing_model:` to
 # `MingaEditor.start_link/1` instead of mutating global config.


### PR DESCRIPTION
# TL;DR
Dirty file-backed buffers now auto-save through a debounced `handle_info` path, reducing the data-loss window for agent-edited buffers. Auto-save is configurable, excludes non-file buffers, logs successful saves, and cancels pending timers on explicit save or shutdown.

Closes #920

## Context
Agent tools can open and edit buffers the user never explicitly saves. If one of those temporary buffer processes crashes before the user notices, unsaved in-memory edits are lost. This PR adds per-buffer debounced auto-save so file-backed dirty buffers are written to disk after a short quiet period.

## Changes
- Added `:auto_save_delay_ms` to `Minga.Config.Options` with a production default of `1000`; `0` disables auto-save.
- Added `auto_save_timer` and `auto_save_token` to buffer state so stale timer messages are ignored after rapid edits reset the debounce window.
- Scheduled auto-save from dirty transitions and canceled it from saved transitions, explicit saves, and buffer termination.
- Implemented auto-save in `handle_info({:auto_save, token}, state)` with synchronous disk writes, mtime conflict checks, and `Minga.Log.info(:editor, "Auto-saved: ...")` logging.
- Treated a file appearing on disk after opening a missing path as a conflict so unattended auto-save does not overwrite external content.
- Disabled auto-save globally in test setup to avoid background disk writes in unrelated tests; auto-save tests opt in per buffer.

## Verification
- `make lint`
- `mix test.llm test/minga/buffer/auto_save_test.exs test/minga/config/options_test.exs test/minga/buffer/mtime_test.exs`
- `mix test --failed`
- `mix test.llm --failed`
- `mix test.llm --max-cases 1`

## Acceptance Criteria Addressed
- Dirty file-backed buffers auto-save after configurable debounce, default 1s ✅
- `:auto_save_delay_ms` supports `0` to disable auto-save ✅
- Rapid edits reset the debounce timer ✅
- Auto-save uses `handle_info`, not `handle_call` ✅
- Explicit `:save` cancels a pending auto-save timer ✅
- Buffer stop cancels a pending timer ✅
- Non-file buffers are excluded ✅
- Auto-save fires are logged to `*Messages*` ✅
- Tests cover debounce reset, explicit save cancellation, non-file exclusion, disable via `0`, stale timer tokens, dirty undo scheduling, and missing-file conflict skip ✅
