### PR TITLE
feat(lsp): support workspace configuration requests

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -127,6 +127,30 @@ When agent tools are [routed through `Buffer.Server`](BUFFER-AWARE-AGENTS.md), a
 
 These options don't exist yet. See [BUFFER-AWARE-AGENTS.md](BUFFER-AWARE-AGENTS.md) for the design.
 
+## LSP settings
+
+Some language servers ask the editor for project settings with `workspace/configuration`. Use `lsp_settings/2` when you want Minga to answer those requests for a server.
+
+The first argument is the server name from the language definition. The second argument is the settings map that server expects. Minga deep-merges your settings with built-in language defaults, and your config wins when both define the same key.
+
+```elixir
+# Disable rust-analyzer's all-features cargo check default
+lsp_settings :rust_analyzer, %{
+  "rust-analyzer" => %{
+    "cargo" => %{"allFeatures" => false}
+  }
+}
+
+# Disable TypeScript formatting through typescript-language-server
+lsp_settings :typescript_language_server, %{
+  "typescript" => %{
+    "format" => %{"enable" => false}
+  }
+}
+```
+
+Use string keys when the LSP section contains punctuation, such as `"rust-analyzer"`. Atom keys are converted to strings, which works well for simple nested keys like `format` and `enable`.
+
 ## Startup view
 
 Minga boots into the full-screen agentic view by default. The chat panel is visible, the input is focused, and an agent session starts automatically. You're ready to talk to the agent the moment Minga opens.

--- a/lib/minga/config.ex
+++ b/lib/minga/config.ex
@@ -41,8 +41,12 @@ defmodule Minga.Config do
   alias Minga.Config.Options
   alias Minga.Extension.Registry, as: ExtRegistry
   alias Minga.Keymap
+  alias Minga.LSP.ServerConfig
+  alias Minga.LSP.ServerRegistry
   alias Minga.Popup.Registry, as: PopupRegistry
   alias Minga.Popup.Rule, as: PopupRule
+
+  @type lsp_settings :: %{String.t() => term()}
 
   @spec keymap_server() :: Keymap.server()
   defp keymap_server do
@@ -103,6 +107,37 @@ defmodule Minga.Config do
   @spec get_extension_option_for_filetype(atom(), atom(), atom() | nil) :: term()
   def get_extension_option_for_filetype(ext_name, opt_name, filetype),
     do: Options.get_extension_option_for_filetype(options_server(), ext_name, opt_name, filetype)
+
+  @doc """
+  Returns merged LSP settings for a server.
+
+  Language defaults from `ServerConfig.settings` are deep-merged with user overrides from `lsp_settings/2`. User config wins when both maps define the same nested key.
+  """
+  @spec get_lsp_settings(ServerConfig.t() | atom()) :: lsp_settings()
+  @spec get_lsp_settings(ServerConfig.t() | atom(), GenServer.server()) :: lsp_settings()
+  def get_lsp_settings(server_or_name, loader \\ Loader)
+
+  def get_lsp_settings(%ServerConfig{} = server_config, loader) do
+    overrides = loader |> Loader.lsp_settings() |> Map.get(server_config.name, %{})
+
+    server_config.settings
+    |> normalize_settings()
+    |> deep_merge(overrides)
+  end
+
+  def get_lsp_settings(server_name, loader) when is_atom(server_name) do
+    defaults =
+      case ServerRegistry.find_config(server_name) do
+        %ServerConfig{} = server_config -> server_config.settings
+        nil -> %{}
+      end
+
+    overrides = loader |> Loader.lsp_settings() |> Map.get(server_name, %{})
+
+    defaults
+    |> normalize_settings()
+    |> deep_merge(overrides)
+  end
 
   # ── Write options (non-raising) ────────────────────────────────────
 
@@ -484,6 +519,25 @@ defmodule Minga.Config do
   end
 
   @doc """
+  Sets per-server LSP settings.
+
+  Settings are deep-merged with language defaults from `ServerConfig.settings`. Use the server name from the language definition, such as `:lexical`, `:rust_analyzer`, or `:typescript_language_server`.
+
+  ## Examples
+
+      lsp_settings :rust_analyzer, %{"rust-analyzer" => %{"cargo" => %{"allFeatures" => false}}}
+      lsp_settings :typescript_language_server, %{"typescript" => %{"format" => %{"enable" => false}}}
+  """
+  @spec lsp_settings(atom(), keyword() | map()) :: :ok
+  def lsp_settings(server_name, settings) when is_atom(server_name) and is_list(settings) do
+    put_lsp_settings(server_name, normalize_settings(settings))
+  end
+
+  def lsp_settings(server_name, settings) when is_atom(server_name) and is_map(settings) do
+    put_lsp_settings(server_name, normalize_settings(settings))
+  end
+
+  @doc """
   Declares filetype-scoped keybindings.
 
   Bindings declared inside the block are scoped to the given filetype
@@ -634,4 +688,55 @@ defmodule Minga.Config do
 
     ExtRegistry.register_hex(name, package, rest)
   end
+
+  @spec put_lsp_settings(atom(), lsp_settings()) :: :ok
+  defp put_lsp_settings(server_name, settings) do
+    existing = Process.get(:minga_config_lsp_settings, %{})
+    merged = Map.update(existing, server_name, settings, &deep_merge(&1, settings))
+    Process.put(:minga_config_lsp_settings, merged)
+    :ok
+  end
+
+  @spec normalize_settings(keyword() | map()) :: lsp_settings()
+  defp normalize_settings(settings) when is_list(settings) do
+    settings
+    |> Map.new(fn {key, value} -> {normalize_key(key), normalize_value(value)} end)
+  end
+
+  defp normalize_settings(settings) when is_map(settings) do
+    settings
+    |> Map.new(fn {key, value} -> {normalize_key(key), normalize_value(value)} end)
+  end
+
+  @spec normalize_value(term()) :: term()
+  defp normalize_value([]), do: []
+
+  defp normalize_value(value) when is_list(value) do
+    if Keyword.keyword?(value) do
+      normalize_settings(value)
+    else
+      Enum.map(value, &normalize_value/1)
+    end
+  end
+
+  defp normalize_value(value) when is_map(value), do: normalize_settings(value)
+  defp normalize_value(value), do: value
+
+  @spec normalize_key(term()) :: String.t()
+  defp normalize_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp normalize_key(key) when is_binary(key), do: key
+  defp normalize_key(key), do: to_string(key)
+
+  @spec deep_merge(lsp_settings(), lsp_settings()) :: lsp_settings()
+  defp deep_merge(left, right) when is_map(left) and is_map(right) do
+    Map.merge(left, right, fn _key, left_value, right_value ->
+      merge_lsp_setting(left_value, right_value)
+    end)
+  end
+
+  @spec merge_lsp_setting(term(), term()) :: term()
+  defp merge_lsp_setting(left, right) when is_map(left) and is_map(right),
+    do: deep_merge(left, right)
+
+  defp merge_lsp_setting(_left, right), do: right
 end

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -46,6 +46,7 @@ defmodule Minga.Config.Loader do
           project_config_path: String.t() | nil,
           project_config_error: String.t() | nil,
           after_error: String.t() | nil,
+          lsp_settings: %{atom() => map()},
           keymap_server: keymap_server(),
           options_server: options_server()
         }
@@ -127,6 +128,24 @@ defmodule Minga.Config.Loader do
   def after_error, do: after_error(__MODULE__)
   def after_error(server), do: Agent.get(server, & &1.after_error)
 
+  @doc "Returns LSP settings overrides loaded from user config."
+  @spec lsp_settings() :: %{atom() => map()}
+  @spec lsp_settings(GenServer.server()) :: %{atom() => map()}
+  def lsp_settings, do: lsp_settings(__MODULE__)
+
+  def lsp_settings(server) when is_atom(server) do
+    case Process.whereis(server) do
+      nil -> %{}
+      _pid -> get_lsp_settings(server)
+    end
+  end
+
+  def lsp_settings(server) when is_pid(server) do
+    if Process.alive?(server), do: get_lsp_settings(server), else: %{}
+  end
+
+  def lsp_settings(server), do: get_lsp_settings(server)
+
   @doc """
   Reloads all config from scratch.
 
@@ -200,16 +219,17 @@ defmodule Minga.Config.Loader do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
-  # The process dictionary bridges `keymap_server` and `options_server` into
-  # `Minga.Config.bind/3,4,5` and `Minga.Config.set/2`, which run synchronously
-  # while `.exs` configs evaluate. Code that calls those helpers from a separate
-  # process (e.g., a GenServer started by an extension callback) won't see this
-  # dict and will fall back to the registered defaults. Extensions are skipped
-  # in test mode, so this only affects long-lived runtime callers.
+  # The process dictionary bridges per-loader state into config DSL functions,
+  # which run synchronously while `.exs` configs evaluate. Code that calls those
+  # helpers from a separate process (e.g., a GenServer started by an extension
+  # callback) won't see this dict and will fall back to registered defaults.
+  # Extensions are skipped in test mode, so this only affects long-lived runtime
+  # callers.
   @spec load_all(keymap_server(), options_server()) :: state()
   defp load_all(keymap_server, options_server) do
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
     previous_options_server = Process.put(:minga_config_options, options_server)
+    previous_lsp_settings = Process.put(:minga_config_lsp_settings, %{})
 
     try do
       config_path = resolve_config_path()
@@ -262,6 +282,8 @@ defmodule Minga.Config.Loader do
         ExtSupervisor.start_all()
       end
 
+      lsp_settings = Process.get(:minga_config_lsp_settings, %{})
+
       %{
         config_path: config_path,
         load_error: load_error,
@@ -270,18 +292,25 @@ defmodule Minga.Config.Loader do
         project_config_path: project_path,
         project_config_error: project_config_error,
         after_error: after_error,
+        lsp_settings: lsp_settings,
         keymap_server: keymap_server,
         options_server: options_server
       }
     after
       restore_pdict(:minga_config_keymap, previous_keymap_server)
       restore_pdict(:minga_config_options, previous_options_server)
+      restore_pdict(:minga_config_lsp_settings, previous_lsp_settings)
     end
   end
 
   @spec restore_pdict(atom(), term() | nil) :: term() | nil
   defp restore_pdict(key, nil), do: Process.delete(key)
   defp restore_pdict(key, value), do: Process.put(key, value)
+
+  @spec get_lsp_settings(GenServer.server()) :: %{atom() => map()}
+  defp get_lsp_settings(server) do
+    Agent.get(server, fn state -> Map.get(state, :lsp_settings, %{}) end)
+  end
 
   # Skips the reset if the persisted options_server is no longer alive (anonymous
   # pid that crashed and was never restarted) or never registered. Otherwise

--- a/lib/minga/language/rust.ex
+++ b/lib/minga/language/rust.ex
@@ -19,7 +19,13 @@ defmodule Minga.Language.Rust do
         %ServerConfig{
           name: :rust_analyzer,
           command: "rust-analyzer",
-          root_markers: ["Cargo.toml"]
+          root_markers: ["Cargo.toml"],
+          settings: %{
+            "rust-analyzer" => %{
+              "cargo" => %{"allFeatures" => true},
+              "procMacro" => %{"enable" => true}
+            }
+          }
         }
       ],
       root_markers: ["Cargo.toml"],

--- a/lib/minga/lsp/client.ex
+++ b/lib/minga/lsp/client.ex
@@ -27,6 +27,7 @@ defmodule Minga.LSP.Client do
 
   use GenServer
 
+  alias Minga.Config
   alias Minga.Diagnostics
   alias Minga.Diagnostics.Diagnostic
   alias Minga.LSP.Client.State
@@ -523,6 +524,11 @@ defmodule Minga.LSP.Client do
     handle_response(id, {:error, error}, state)
   end
 
+  defp handle_message(%{"method" => method, "id" => id, "params" => params}, state)
+       when is_binary(method) do
+    handle_server_request(method, id, params, state)
+  end
+
   defp handle_message(%{"method" => method, "params" => params}, state)
        when is_binary(method) do
     handle_server_notification(method, params, state)
@@ -530,13 +536,12 @@ defmodule Minga.LSP.Client do
 
   defp handle_message(%{"method" => method, "id" => id}, state)
        when is_binary(method) do
-    # Server request — respond with empty result for now
     handle_server_request(method, id, %{}, state)
   end
 
   defp handle_message(_msg, state), do: state
 
-  @spec handle_response(integer(), {:ok, map()} | {:error, map()}, State.t()) :: State.t()
+  @spec handle_response(JsonRpc.id(), {:ok, term()} | {:error, map()}, State.t()) :: State.t()
   defp handle_response(id, result, state) do
     case Map.pop(state.pending, id) do
       {nil, _pending} ->
@@ -561,7 +566,7 @@ defmodule Minga.LSP.Client do
 
   @spec handle_method_response(
           String.t(),
-          {:ok, map()} | {:error, map()},
+          {:ok, term()} | {:error, map()},
           GenServer.from() | nil,
           State.t()
         ) :: State.t()
@@ -681,22 +686,70 @@ defmodule Minga.LSP.Client do
 
   defp handle_server_notification(_method, _params, state), do: state
 
-  @spec handle_server_request(String.t(), integer(), map(), State.t()) :: State.t()
+  @spec handle_server_request(String.t(), JsonRpc.id(), map(), State.t()) :: State.t()
   defp handle_server_request("window/workDoneProgress/create", id, _params, state) do
-    send_response(state, id, %{})
+    send_response(state, id, nil)
     state
   end
 
   defp handle_server_request("client/registerCapability", id, _params, state) do
-    send_response(state, id, %{})
+    send_response(state, id, nil)
+    state
+  end
+
+  defp handle_server_request("workspace/configuration", id, params, state) do
+    settings = Config.get_lsp_settings(state.server_config)
+    results = Enum.map(configuration_items(params), &configuration_item(settings, &1))
+
+    send_response(state, id, results)
     state
   end
 
   defp handle_server_request(method, id, _params, state) do
     Minga.Log.debug(:lsp, "Unhandled server request: #{method} (id=#{id})")
-    send_response(state, id, %{})
+    send_error_response(state, id, -32_601, "Method not found: #{method}")
     state
   end
+
+  @spec configuration_items(map()) :: [term()]
+  defp configuration_items(%{"items" => items}) when is_list(items), do: items
+  defp configuration_items(_params), do: []
+
+  @spec configuration_item(map(), term()) :: term()
+  defp configuration_item(settings, %{"section" => section}) when is_binary(section) do
+    configuration_section(settings, section)
+  end
+
+  defp configuration_item(settings, _item), do: settings
+
+  @spec configuration_section(map(), String.t()) :: term()
+  defp configuration_section(settings, section) do
+    case fetch_configuration_section(settings, section) do
+      {:ok, value} -> value
+      :error -> %{}
+    end
+  end
+
+  @spec fetch_configuration_section(map(), String.t()) :: {:ok, term()} | :error
+  defp fetch_configuration_section(settings, section) do
+    case Map.fetch(settings, section) do
+      {:ok, value} -> {:ok, value}
+      :error -> fetch_configuration_path(settings, String.split(section, "."))
+    end
+  end
+
+  @spec fetch_configuration_path(term(), [String.t()]) :: {:ok, term()} | :error
+  defp fetch_configuration_path(settings, [key]) when is_map(settings),
+    do: Map.fetch(settings, key)
+
+  defp fetch_configuration_path(settings, [key | rest]) when is_map(settings) do
+    case Map.fetch(settings, key) do
+      {:ok, value} -> fetch_configuration_path(value, rest)
+      :error -> :error
+    end
+  end
+
+  defp fetch_configuration_path(_settings, _path), do: :error
 
   # ── Diagnostic Conversion ─────────────────────────────────────────────────
 
@@ -785,9 +838,15 @@ defmodule Minga.LSP.Client do
     port_send(state.port, msg)
   end
 
-  @spec send_response(State.t(), integer(), map()) :: :ok
+  @spec send_response(State.t(), JsonRpc.id(), JsonRpc.json_value()) :: :ok
   defp send_response(state, id, result) do
     msg = JsonRpc.encode_response(id, result)
+    port_send(state.port, msg)
+  end
+
+  @spec send_error_response(State.t(), JsonRpc.id(), integer(), String.t()) :: :ok
+  defp send_error_response(state, id, code, message) do
+    msg = JsonRpc.encode_error_response(id, code, message)
     port_send(state.port, msg)
   end
 
@@ -918,6 +977,7 @@ defmodule Minga.LSP.Client do
         }
       },
       "workspace" => %{
+        "configuration" => true,
         "symbol" => %{
           "dynamicRegistration" => false,
           "symbolKind" => %{

--- a/lib/minga/lsp/json_rpc.ex
+++ b/lib/minga/lsp/json_rpc.ex
@@ -25,6 +25,13 @@ defmodule Minga.LSP.JsonRpc do
   @typedoc "A decoded JSON-RPC message as a map."
   @type message :: map()
 
+  @typedoc "A JSON-RPC request or response ID."
+  @type id :: integer() | String.t()
+
+  @typedoc "A JSON value that can be encoded in a JSON-RPC message."
+  @type json_value ::
+          nil | boolean() | number() | String.t() | [json_value()] | %{String.t() => json_value()}
+
   @doc """
   Encodes a JSON-RPC request (has an `id`, expects a response).
 
@@ -67,8 +74,8 @@ defmodule Minga.LSP.JsonRpc do
   @doc """
   Encodes a JSON-RPC success response.
   """
-  @spec encode_response(integer(), map()) :: iodata()
-  def encode_response(id, result) when is_integer(id) and is_map(result) do
+  @spec encode_response(id(), json_value()) :: iodata()
+  def encode_response(id, result) when is_integer(id) or is_binary(id) do
     encode(%{
       "jsonrpc" => "2.0",
       "id" => id,
@@ -79,9 +86,9 @@ defmodule Minga.LSP.JsonRpc do
   @doc """
   Encodes a JSON-RPC error response.
   """
-  @spec encode_error_response(integer(), integer(), String.t()) :: iodata()
+  @spec encode_error_response(id(), integer(), String.t()) :: iodata()
   def encode_error_response(id, code, message)
-      when is_integer(id) and is_integer(code) and is_binary(message) do
+      when (is_integer(id) or is_binary(id)) and is_integer(code) and is_binary(message) do
     encode(%{
       "jsonrpc" => "2.0",
       "id" => id,

--- a/lib/minga/lsp/server_config.ex
+++ b/lib/minga/lsp/server_config.ex
@@ -6,13 +6,15 @@ defmodule Minga.LSP.ServerConfig do
             command: nil,
             args: [],
             root_markers: [],
-            init_options: %{}
+            init_options: %{},
+            settings: %{}
 
   @type t :: %__MODULE__{
           name: atom(),
           command: String.t(),
           args: [String.t()],
           root_markers: [String.t()],
-          init_options: map()
+          init_options: map(),
+          settings: map()
         }
 end

--- a/lib/minga/lsp/server_registry.ex
+++ b/lib/minga/lsp/server_registry.ex
@@ -2,21 +2,13 @@ defmodule Minga.LSP.ServerRegistry do
   @moduledoc """
   Maps filetypes to language server configurations.
 
-  A pure module with hardcoded defaults for well-known language servers,
-  following the pattern established by `Minga.Language.Filetype`. No GenServer,
-  no config files — if the server binary is on `$PATH`, it just works.
+  A pure lookup module over `Minga.Language` definitions. If the server binary is on `$PATH`, it just works.
 
   ## Adding a new server
 
-  Add an entry to `@servers` mapping a filetype atom to a list of
-  `ServerConfig` structs. Multiple servers per filetype are supported
-  (e.g., TypeScript files may use both `typescript-language-server` and
-  `eslint`).
+  Add a `ServerConfig` to the relevant language definition under `lib/minga/language/`. Multiple servers per filetype are supported, such as using both `typescript-language-server` and `eslint` for TypeScript.
 
-  ## Future
-
-  A config file (`~/.config/minga/lsp.exs`) will allow users to override
-  or extend these defaults without modifying source code.
+  Users can override per-server settings from `config.exs` with `Minga.Config.lsp_settings/2`.
   """
 
   alias Minga.LSP.ServerConfig

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -9,10 +9,12 @@ defmodule Minga.Config.LoaderTest do
   use ExUnit.Case, async: false
 
   alias Minga.Command.Registry, as: CommandRegistry
+  alias Minga.Config
   alias Minga.Config.Hooks
   alias Minga.Config.Loader
   alias Minga.Config.Options
   alias Minga.Keymap.Active, as: KeymapActive
+  alias Minga.LSP.ServerConfig
 
   setup do
     options_server = start_supervised!({Options, name: nil})
@@ -93,6 +95,100 @@ defmodule Minga.Config.LoaderTest do
       assert Loader.load_error(pid) == nil
       assert Options.get(test_options_server(), :tab_width) == 4
       assert Options.get(test_options_server(), :line_numbers) == :relative
+    end
+  end
+
+  describe "loading LSP settings" do
+    test "deep-merges user lsp_settings with server defaults" do
+      {_dir, cleanup} =
+        make_config_dir("""
+        use Minga.Config
+
+        lsp_settings :mock_lsp,
+          mock_lsp: [nested: [enabled: false], extra: true]
+        """)
+
+      on_exit(cleanup)
+
+      name = :"loader_lsp_settings_#{System.unique_integer([:positive])}"
+      {:ok, pid} = Loader.start_link(name: name)
+
+      server_config = %ServerConfig{
+        name: :mock_lsp,
+        command: "mock-lsp",
+        settings: %{
+          "mock_lsp" => %{
+            "nested" => %{"enabled" => true, "default" => 1},
+            "value" => 2
+          }
+        }
+      }
+
+      assert Loader.lsp_settings(pid) == %{
+               mock_lsp: %{
+                 "mock_lsp" => %{"nested" => %{"enabled" => false}, "extra" => true}
+               }
+             }
+
+      assert Config.get_lsp_settings(server_config, pid) == %{
+               "mock_lsp" => %{
+                 "nested" => %{"enabled" => false, "default" => 1},
+                 "value" => 2,
+                 "extra" => true
+               }
+             }
+    end
+
+    test "supports exact LSP section keys with punctuation" do
+      {_dir, cleanup} =
+        make_config_dir("""
+        use Minga.Config
+
+        lsp_settings :rust_analyzer, %{
+          "rust-analyzer" => %{"cargo" => %{"allFeatures" => false}}
+        }
+        """)
+
+      on_exit(cleanup)
+
+      name = :"loader_lsp_section_keys_#{System.unique_integer([:positive])}"
+      {:ok, pid} = Loader.start_link(name: name)
+
+      server_config = %ServerConfig{
+        name: :rust_analyzer,
+        command: "rust-analyzer",
+        settings: %{
+          "rust-analyzer" => %{
+            "cargo" => %{"allFeatures" => true},
+            "procMacro" => %{"enable" => true}
+          }
+        }
+      }
+
+      assert Config.get_lsp_settings(server_config, pid) == %{
+               "rust-analyzer" => %{
+                 "cargo" => %{"allFeatures" => false},
+                 "procMacro" => %{"enable" => true}
+               }
+             }
+    end
+
+    test "preserves empty list setting values" do
+      {_dir, cleanup} =
+        make_config_dir("""
+        use Minga.Config
+
+        lsp_settings :mock_lsp, features: []
+        """)
+
+      on_exit(cleanup)
+
+      name = :"loader_lsp_empty_list_#{System.unique_integer([:positive])}"
+      {:ok, pid} = Loader.start_link(name: name)
+
+      server_config = %ServerConfig{name: :mock_lsp, command: "mock-lsp"}
+
+      assert Config.get_lsp_settings(server_config, pid) == %{"features" => []}
     end
   end
 

--- a/test/minga/lsp/client_test.exs
+++ b/test/minga/lsp/client_test.exs
@@ -11,19 +11,32 @@ defmodule Minga.LSP.ClientTest do
   alias Minga.LSP.Client
   alias Minga.Test.MockLSPServer
 
-  setup do
+  @ready_timeout 10_000
+
+  setup context do
     diag_server = start_supervised!({Diagnostics, name: :"diag_#{System.unique_integer()}"})
+    server_settings = Map.get(context, :server_settings, %{})
+
+    server_config =
+      MockLSPServer.server_config(
+        request_configuration: Map.get(context, :request_configuration, false),
+        request_unknown: Map.get(context, :request_unknown, false),
+        settings: server_settings
+      )
+
+    if Map.get(context, :request_configuration, false) or
+         Map.get(context, :request_unknown, false) do
+      Minga.Events.subscribe(:diagnostics_updated)
+    end
+
+    # Subscribe to LSP status events and wait for the client to be ready.
+    Minga.Events.subscribe(:lsp_status_changed)
 
     client =
       start_supervised!(
         {Client,
-         server_config: MockLSPServer.server_config(),
-         root_path: System.tmp_dir!(),
-         diagnostics: diag_server}
+         server_config: server_config, root_path: System.tmp_dir!(), diagnostics: diag_server}
       )
-
-    # Subscribe to LSP status events and wait for the client to be ready.
-    Minga.Events.subscribe(:lsp_status_changed)
 
     case Client.status(client) do
       :ready ->
@@ -32,7 +45,7 @@ defmodule Minga.LSP.ClientTest do
       _ ->
         assert_receive {:minga_event, :lsp_status_changed,
                         %Minga.Events.LspStatusEvent{name: :mock_lsp, status: :ready}},
-                       5_000
+                       @ready_timeout
     end
 
     %{client: client, diag_server: diag_server}
@@ -133,6 +146,49 @@ defmodule Minga.LSP.ClientTest do
     end
   end
 
+  describe "workspace/configuration" do
+    @tag request_configuration: true,
+         server_settings: %{
+           "mock_lsp" => %{
+             "nested" => %{"enabled" => true},
+             "value" => 1
+           }
+         }
+    test "responds to server configuration requests with section results", %{
+      diag_server: diag_server
+    } do
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{
+                        uri: "file:///tmp/configuration-test.ex"
+                      }},
+                     5_000
+
+      [diag] = Diagnostics.for_uri(diag_server, "file:///tmp/configuration-test.ex")
+
+      assert JSON.decode!(diag.message) == [
+               %{"enabled" => true},
+               %{},
+               %{"mock_lsp" => %{"nested" => %{"enabled" => true}, "value" => 1}}
+             ]
+    end
+  end
+
+  describe "server requests" do
+    @tag request_unknown: true
+    test "unhandled requests receive a method-not-found error", %{diag_server: diag_server} do
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{
+                        uri: "file:///tmp/unknown-request-test.ex"
+                      }},
+                     5_000
+
+      [diag] = Diagnostics.for_uri(diag_server, "file:///tmp/unknown-request-test.ex")
+
+      assert diag.code == "UNKNOWN"
+      assert diag.message == "-32601:Method not found: mock/unknown"
+    end
+  end
+
   describe "status events" do
     test "client broadcasts :lsp_status_changed with :stopped on shutdown", %{client: client} do
       # Setup already proved :ready fires (via assert_receive). Test :stopped.
@@ -160,8 +216,7 @@ defmodule Minga.LSP.ClientTest do
 
       assert is_reference(ref)
 
-      # The mock server doesn't handle completion, so we'll get a timeout.
-      # The key thing is the request was sent without crashing.
+      # This test only verifies the async request can be sent without crashing.
       assert Client.status(client) == :ready
     end
 

--- a/test/minga/lsp/json_rpc_test.exs
+++ b/test/minga/lsp/json_rpc_test.exs
@@ -60,6 +60,41 @@ defmodule Minga.LSP.JsonRpcTest do
       assert decoded["result"] == %{"capabilities" => %{}}
       refute Map.has_key?(decoded, "error")
     end
+
+    test "accepts list results" do
+      msg = JsonRpc.encode_response(2, [%{"enabled" => true}, %{}])
+      binary = IO.iodata_to_binary(msg)
+
+      [_headers, json] = String.split(binary, "\r\n\r\n", parts: 2)
+      decoded = JSON.decode!(json)
+
+      assert decoded["jsonrpc"] == "2.0"
+      assert decoded["id"] == 2
+      assert decoded["result"] == [%{"enabled" => true}, %{}]
+    end
+
+    test "accepts string ids" do
+      msg = JsonRpc.encode_response("configuration-1", [%{}])
+      binary = IO.iodata_to_binary(msg)
+
+      [_headers, json] = String.split(binary, "\r\n\r\n", parts: 2)
+      decoded = JSON.decode!(json)
+
+      assert decoded["id"] == "configuration-1"
+      assert decoded["result"] == [%{}]
+    end
+
+    test "accepts nil results" do
+      msg = JsonRpc.encode_response(3, nil)
+      binary = IO.iodata_to_binary(msg)
+
+      [_headers, json] = String.split(binary, "\r\n\r\n", parts: 2)
+      decoded = JSON.decode!(json)
+
+      assert decoded["id"] == 3
+      assert Map.has_key?(decoded, "result")
+      assert decoded["result"] == nil
+    end
   end
 
   describe "encode_error_response/3" do
@@ -74,6 +109,18 @@ defmodule Minga.LSP.JsonRpcTest do
       assert decoded["id"] == 1
       assert decoded["error"]["code"] == -32_600
       assert decoded["error"]["message"] == "Invalid Request"
+    end
+
+    test "accepts string ids" do
+      msg = JsonRpc.encode_error_response("unknown-1", -32_601, "Method not found")
+      binary = IO.iodata_to_binary(msg)
+
+      [_headers, json] = String.split(binary, "\r\n\r\n", parts: 2)
+      decoded = JSON.decode!(json)
+
+      assert decoded["id"] == "unknown-1"
+      assert decoded["error"]["code"] == -32_601
+      assert decoded["error"]["message"] == "Method not found"
     end
   end
 

--- a/test/minga/lsp/server_registry_test.exs
+++ b/test/minga/lsp/server_registry_test.exs
@@ -28,6 +28,7 @@ defmodule Minga.LSP.ServerRegistryTest do
       assert config.name == :rust_analyzer
       assert config.command == "rust-analyzer"
       assert "Cargo.toml" in config.root_markers
+      assert get_in(config.settings, ["rust-analyzer", "procMacro", "enable"]) == true
     end
 
     test "returns server configs for C" do
@@ -102,6 +103,7 @@ defmodule Minga.LSP.ServerRegistryTest do
         assert is_list(config.args), "#{filetype}: args must be list"
         assert is_list(config.root_markers), "#{filetype}: root_markers must be list"
         assert is_map(config.init_options), "#{filetype}: init_options must be map"
+        assert is_map(config.settings), "#{filetype}: settings must be map"
       end
     end
   end

--- a/test/support/mock_lsp_server.ex
+++ b/test/support/mock_lsp_server.ex
@@ -23,17 +23,32 @@ defmodule Minga.Test.MockLSPServer do
     Path.join([__DIR__, "mock_lsp_server_script.exs"])
   end
 
+  @typedoc "Options for the mock server config."
+  @type server_config_opt ::
+          {:request_configuration, boolean()} | {:request_unknown, boolean()} | {:settings, map()}
+
   @doc """
   Returns a ServerConfig struct suitable for `LSP.Client.start_link/1`.
 
   Uses `elixir` as the command with the mock script as the argument.
   """
-  @spec server_config() :: Minga.LSP.ServerRegistry.server_config()
-  def server_config do
+  @spec server_config([server_config_opt()]) :: Minga.LSP.ServerRegistry.server_config()
+  def server_config(opts \\ []) do
+    request_args =
+      [
+        {Keyword.get(opts, :request_configuration, false), "--request-configuration"},
+        {Keyword.get(opts, :request_unknown, false), "--request-unknown"}
+      ]
+      |> Enum.flat_map(fn
+        {true, arg} -> [arg]
+        {false, _arg} -> []
+      end)
+
     %Minga.LSP.ServerConfig{
       name: :mock_lsp,
       command: "elixir",
-      args: [script_path()]
+      args: [script_path() | request_args],
+      settings: Keyword.get(opts, :settings, %{})
     }
   end
 end

--- a/test/support/mock_lsp_server_script.exs
+++ b/test/support/mock_lsp_server_script.exs
@@ -6,6 +6,8 @@
 # Supports:
 # - initialize/initialized handshake
 # - textDocument/didOpen, didChange, didSave, didClose
+# - Optional workspace/configuration request after initialized
+# - Optional unknown server request after initialized
 # - Publishes a diagnostic on didOpen (for testing)
 # - shutdown/exit lifecycle
 
@@ -89,7 +91,8 @@ defmodule MockServer do
   end
 
   defp handle_message(%{"method" => "initialized"}) do
-    # No response needed
+    if request_configuration?(), do: send_configuration_request()
+    if request_unknown?(), do: send_unknown_request()
     :ok
   end
 
@@ -126,6 +129,18 @@ defmodule MockServer do
     :ok
   end
 
+  defp handle_message(%{"id" => "configuration-900", "result" => result}) when is_list(result) do
+    send_test_diagnostic("file:///tmp/configuration-test.ex", "CONFIG", JSON.encode!(result))
+  end
+
+  defp handle_message(%{"id" => "unknown-900", "error" => %{"code" => code} = error}) do
+    send_test_diagnostic(
+      "file:///tmp/unknown-request-test.ex",
+      "UNKNOWN",
+      "#{code}:#{error["message"]}"
+    )
+  end
+
   defp handle_message(%{"method" => "shutdown", "id" => id}) do
     send_response(id, nil)
   end
@@ -152,9 +167,54 @@ defmodule MockServer do
     write_message(msg)
   end
 
+  defp send_configuration_request do
+    send_request("configuration-900", "workspace/configuration", %{
+      "items" => [
+        %{"scopeUri" => "file:///tmp/configuration-test.ex", "section" => "mock_lsp.nested"},
+        %{"scopeUri" => "file:///tmp/configuration-test.ex", "section" => "missing"},
+        %{"scopeUri" => "file:///tmp/configuration-test.ex"}
+      ]
+    })
+  end
+
+  defp send_unknown_request do
+    send_request("unknown-900", "mock/unknown", %{})
+  end
+
+  defp send_request(id, method, params) do
+    msg = %{"jsonrpc" => "2.0", "id" => id, "method" => method, "params" => params}
+    write_message(msg)
+  end
+
   defp send_notification(method, params) do
     msg = %{"jsonrpc" => "2.0", "method" => method, "params" => params}
     write_message(msg)
+  end
+
+  defp request_configuration? do
+    "--request-configuration" in System.argv()
+  end
+
+  defp request_unknown? do
+    "--request-unknown" in System.argv()
+  end
+
+  defp send_test_diagnostic(uri, code, message) do
+    send_notification("textDocument/publishDiagnostics", %{
+      "uri" => uri,
+      "diagnostics" => [
+        %{
+          "range" => %{
+            "start" => %{"line" => 0, "character" => 0},
+            "end" => %{"line" => 0, "character" => 1}
+          },
+          "severity" => 3,
+          "source" => "mock_lsp",
+          "message" => message,
+          "code" => code
+        }
+      ]
+    })
   end
 
   defp write_message(msg) do


### PR DESCRIPTION
# TL;DR
Minga now responds to LSP `workspace/configuration` server requests with the requested settings array, so servers like rust-analyzer can receive editor-provided configuration instead of timing out or falling back to defaults.

Closes #1271

## Context
Some LSP servers request project settings from the editor after initialization. Minga previously routed requests with both `id` and `params` as notifications, which dropped the response path entirely. This PR fixes that routing bug and adds the configuration plumbing needed to answer those requests.

## Changes
- Route server messages with `method`, `id`, and `params` to `handle_server_request/4` before notification handling.
- Add `workspace/configuration` handling that returns one result per requested item, supports exact section keys and dotted section lookup, tolerates malformed `items`, and returns `%{}` for missing sections.
- Allow JSON-RPC success responses to return arrays or `null`, and preserve string request IDs from servers.
- Return JSON-RPC `Method not found` errors for unhandled server requests instead of reporting false success.
- Add `settings` to `Minga.LSP.ServerConfig` and seed Rust defaults as the proof-of-concept language settings.
- Add `lsp_settings/2` to the config DSL, with loader persistence and deep merge behavior where user overrides win.
- Preserve empty list settings, so array-valued LSP options do not turn into objects.
- Document `lsp_settings/2` in `docs/CONFIGURATION.md` and clean up stale nearby LSP docs/comments.
- Extend the mock LSP server to request configuration and assert the client response through diagnostics.

## Verification
- `make lint`
- `mix test.llm`
- `mix test.llm test/minga/lsp/json_rpc_test.exs test/minga/lsp/server_registry_test.exs test/minga/config/loader_test.exs`
- `mix test test/minga/lsp/client_test.exs --include heavy`
- Final reviewer: PASS

## Acceptance Criteria Addressed
- `workspace/configuration` requests receive an array response matching the requested items, with `%{}` for missing settings ✅
- Language definitions can declare a `settings` map in `ServerConfig` ✅
- Users can override server settings via `config.exs` with `lsp_settings/2` ✅
- Server requests with params are routed to `handle_server_request/4` instead of notification handling ✅

---
**Updated after fresh-eyes review:** Rebased onto current `main`, removed unnecessary TypeScript/JavaScript default settings, narrowed loader fallback behavior, preserved empty list settings, supported JSON-RPC `null` results, sent `null` for void server-request responses, returned `Method not found` for unhandled server requests, and added user-facing docs.
