### PR TITLE
test(editor): isolate reindent test event bus

### DIFF
--- a/test/minga_editor/commands/editing_reindent_test.exs
+++ b/test/minga_editor/commands/editing_reindent_test.exs
@@ -12,16 +12,22 @@ defmodule MingaEditor.Commands.EditingReindentTest do
   alias MingaEditor
 
   defp start_editor(content) do
-    {:ok, buffer} = BufferServer.start_link(content: content)
+    id = :erlang.unique_integer([:positive])
+    events_registry = :"reindent_events_#{id}"
+    start_supervised!({Minga.Events, name: events_registry})
+
+    {:ok, buffer} = BufferServer.start_link(content: content, events_registry: events_registry)
 
     {:ok, editor} =
       MingaEditor.start_link(
-        name: :"reindent_editor_#{:erlang.unique_integer([:positive])}",
+        name: :"reindent_editor_#{id}",
         port_manager: nil,
         buffer: buffer,
         width: 80,
         height: 24,
-        editing_model: :vim
+        editing_model: :vim,
+        events_registry: events_registry,
+        suppress_tool_prompts: true
       )
 
     {editor, buffer}
@@ -122,6 +128,20 @@ defmodule MingaEditor.Commands.EditingReindentTest do
 
       state = :sys.get_state(editor)
       assert state.workspace.editing.mode == :normal
+    end
+
+    test "default bus tool prompts cannot interrupt reindent dispatch" do
+      {editor, _buffer} = start_editor("hello world")
+      state = :sys.get_state(editor)
+
+      refute editor in Minga.Events.subscribers(:tool_missing)
+      assert editor in Minga.Events.subscribers(:tool_missing, state.events_registry)
+
+      Minga.Events.broadcast(:tool_missing, %Minga.Events.ToolMissingEvent{command: "rg"})
+      state = :sys.get_state(editor)
+
+      assert state.workspace.editing.mode == :normal
+      assert state.shell_state.tool_prompt_queue == []
     end
   end
 

--- a/test/minga_editor/commands/movement_test.exs
+++ b/test/minga_editor/commands/movement_test.exs
@@ -7,16 +7,22 @@ defmodule MingaEditor.Commands.MovementTest do
   @sync_timeout 15_000
 
   defp start_editor(content \\ "hello\nworld\nfoo") do
-    {:ok, buffer} = BufferServer.start_link(content: content)
+    id = :erlang.unique_integer([:positive])
+    events_registry = :"movement_events_#{id}"
+    start_supervised!({Minga.Events, name: events_registry})
+
+    {:ok, buffer} = BufferServer.start_link(content: content, events_registry: events_registry)
 
     {:ok, editor} =
       MingaEditor.start_link(
-        name: :"editor_#{:erlang.unique_integer([:positive])}",
+        name: :"editor_#{id}",
         port_manager: nil,
         buffer: buffer,
         width: 40,
         height: 10,
-        editing_model: :vim
+        editing_model: :vim,
+        events_registry: events_registry,
+        suppress_tool_prompts: true
       )
 
     {editor, buffer}
@@ -28,6 +34,22 @@ defmodule MingaEditor.Commands.MovementTest do
   end
 
   describe "Normal mode — movements" do
+    test "default bus tool prompts cannot interrupt movement dispatch" do
+      {editor, buffer} = start_editor("hello")
+      state = :sys.get_state(editor, @sync_timeout)
+
+      refute editor in Minga.Events.subscribers(:tool_missing)
+      assert editor in Minga.Events.subscribers(:tool_missing, state.events_registry)
+
+      Minga.Events.broadcast(:tool_missing, %Minga.Events.ToolMissingEvent{command: "rg"})
+      send_key(editor, ?l)
+
+      assert BufferServer.cursor(buffer) == {0, 1}
+      state = :sys.get_state(editor, @sync_timeout)
+      assert state.workspace.editing.mode == :normal
+      assert state.shell_state.tool_prompt_queue == []
+    end
+
     test "h moves cursor left" do
       {editor, buffer} = start_editor("hello")
       send_key(editor, ?l)


### PR DESCRIPTION
# TL;DR
Isolates direct editor command tests from the global event bus so unrelated `:tool_missing` broadcasts cannot push them into `:tool_confirm`. This fixes the CI flakes seen on #1538 where reindent and movement tests expected normal command behavior but observed state left over from a global tool prompt.

## Context
The failing runs reported states that did not match the command under test: `EditingReindentTest` saw `:tool_confirm`, and `MovementTest` left the cursor at `{0, 1}` because the next `f`/`a` keys were ignored. Both files started real `MingaEditor` processes without an isolated `events_registry`, so async tests could receive default-bus `:tool_missing` events from unrelated work.

## Changes
- Starts a per-test `Minga.Events` registry in `EditingReindentTest.start_editor/1` and `MovementTest.start_editor/1`.
- Threads the isolated registry into both the buffer and editor.
- Sets `suppress_tool_prompts: true` for these command-test harnesses because tool installation prompts are outside their scope.
- Adds regressions that prove each editor is not subscribed to the default event bus, is subscribed to its private registry, and still handles command input after a default-bus `:tool_missing` broadcast.

## Verification
- `mix test.debug test/minga_editor/commands/editing_reindent_test.exs --seed 542024 --max-cases 8`
- `mix test.debug test/minga_editor/commands/movement_test.exs:299 --seed 542024 --max-cases 8`
- `mix test.llm test/minga_editor/commands/movement_test.exs test/minga_editor/commands/editing_reindent_test.exs`
- `mix test --warnings-as-errors --exclude system_clipboard --seed 542024 --max-cases 8`
- `make lint`
- Project reviewer: PASS
