### PR TITLE
fix(agent): use unified reasoning effort

### DIFF
--- a/lib/minga_agent/config.ex
+++ b/lib/minga_agent/config.ex
@@ -49,6 +49,7 @@ defmodule MingaAgent.Config do
 
     # API endpoint
     api_base_url: "",
+    api_base_url_override: nil,
     api_endpoints: nil,
 
     # MCP
@@ -102,6 +103,7 @@ defmodule MingaAgent.Config do
           system_prompt: String.t(),
           append_system_prompt: String.t(),
           api_base_url: String.t(),
+          api_base_url_override: String.t() | nil,
           api_endpoints: map() | nil,
           mcp_servers: [MingaAgent.MCP.ServerConfig.t() | map()],
           compaction_threshold: float() | nil,
@@ -152,6 +154,7 @@ defmodule MingaAgent.Config do
       system_prompt: get(:agent_system_prompt, ""),
       append_system_prompt: get(:agent_append_system_prompt, ""),
       api_base_url: get(:agent_api_base_url, ""),
+      api_base_url_override: non_empty_env("MINGA_API_BASE_URL"),
       api_endpoints: get(:agent_api_endpoints, nil),
       mcp_servers: get(:agent_mcp_servers, []),
       compaction_threshold: get(:agent_compaction_threshold, 0.80),
@@ -229,6 +232,14 @@ defmodule MingaAgent.Config do
     case String.split(model, ":", parts: 2) do
       [_provider, name] -> name
       [name] -> name
+    end
+  end
+
+  @spec non_empty_env(String.t()) :: String.t() | nil
+  defp non_empty_env(name) do
+    case System.get_env(name) do
+      value when is_binary(value) and value != "" -> value
+      _ -> nil
     end
   end
 

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -65,10 +65,10 @@ defmodule MingaAgent.Providers.Native do
   # Thinking levels and cycle order (not config-driven; mode-specific constants).
 
   @thinking_levels %{
-    "off" => 0,
-    "low" => 4_096,
-    "medium" => 16_384,
-    "high" => 32_768
+    "off" => nil,
+    "low" => :low,
+    "medium" => :medium,
+    "high" => :high
   }
 
   @thinking_cycle ["off", "low", "medium", "high"]
@@ -300,8 +300,11 @@ defmodule MingaAgent.Providers.Native do
 
     # Resolve API key from credentials (env var or credentials file).
     # If found in the file but not in the env, set the env var so ReqLLM
-    # picks it up automatically.
-    ensure_api_key_in_env(model)
+    # picks it up automatically. Tests can disable this to avoid mutating
+    # process-wide environment state.
+    unless Keyword.get(opts, :skip_api_key_env, false) do
+      ensure_api_key_in_env(model)
+    end
 
     state = %{
       subscriber: subscriber,
@@ -519,7 +522,7 @@ defmodule MingaAgent.Providers.Native do
   end
 
   def handle_call({:set_thinking_level, level}, _from, state) do
-    if Map.has_key?(@thinking_levels, level) do
+    if valid_thinking_level?(level) do
       Minga.Log.info(:agent, "[Agent.Native] thinking level set to #{level}")
       {:reply, :ok, %{state | thinking_level: level}}
     else
@@ -582,23 +585,31 @@ defmodule MingaAgent.Providers.Native do
   end
 
   def handle_call(:cycle_model, _from, state) do
-    model_list = read_config_model_list()
+    model_list = config_model_list(state.config)
 
     if model_list == [] do
       {:reply, {:error, "No model rotation configured. Set :agent_models in your config."}, state}
     else
       {next_model, next_thinking} = parse_model_entry(next_in_cycle(model_list, state.model))
+      thinking_level = next_thinking || state.thinking_level
 
       new_state = %{
         state
         | model: next_model,
-          thinking_level: next_thinking || state.thinking_level
+          thinking_level: thinking_level
       }
 
       total = length(model_list)
       index = Enum.find_index(model_list, &String.starts_with?(&1, next_model)) || 0
 
-      {:reply, {:ok, %{"model" => next_model, "index" => index + 1, "total" => total}}, new_state}
+      response = %{
+        "model" => next_model,
+        "index" => index + 1,
+        "total" => total,
+        "thinking_level" => thinking_level
+      }
+
+      {:reply, {:ok, response}, new_state}
     end
   end
 
@@ -1713,21 +1724,16 @@ defmodule MingaAgent.Providers.Native do
         opts
       end
 
+    maybe_add_reasoning_effort(opts, thinking_level)
+  end
+
+  @spec maybe_add_reasoning_effort(keyword(), String.t()) :: keyword()
+  defp maybe_add_reasoning_effort(opts, thinking_level) do
     case Map.get(@thinking_levels, thinking_level) do
-      budget when is_integer(budget) and budget > 0 ->
-        # Merge thinking config into existing provider_options
-        existing = Keyword.get(opts, :provider_options, [])
+      effort when effort in [:low, :medium, :high] ->
+        Keyword.put(opts, :reasoning_effort, effort)
 
-        merged =
-          Keyword.merge(existing,
-            additional_model_request_fields: %{
-              thinking: %{type: "enabled", budget_tokens: budget}
-            }
-          )
-
-        Keyword.put(opts, :provider_options, merged)
-
-      _ ->
+      nil ->
         opts
     end
   end
@@ -1743,14 +1749,14 @@ defmodule MingaAgent.Providers.Native do
 
   # Resolves the API base URL for the current request. Precedence:
   #
-  # 1. MINGA_API_BASE_URL env var (global override for all providers)
+  # 1. MINGA_API_BASE_URL captured in AgentConfig.resolve/0 (global override for all providers)
   # 2. Per-provider endpoint from :agent_api_endpoints map
   # 3. Global :agent_api_base_url config
   # 4. No override (use provider default)
   @spec maybe_add_base_url(keyword(), String.t(), AgentConfig.t()) :: keyword()
   defp maybe_add_base_url(opts, model, config) do
     url =
-      non_empty(System.get_env("MINGA_API_BASE_URL")) ||
+      non_empty(config.api_base_url_override) ||
         per_provider_url(model, config) ||
         non_empty(config.api_base_url)
 
@@ -2027,13 +2033,9 @@ defmodule MingaAgent.Providers.Native do
     end
   end
 
-  # read_config_model_list is still needed by cycle_model which reads
-  # the list at call time (not at init). This will migrate when the
-  # remaining consumer functions are updated to use config from state.
-  @spec read_config_model_list() :: [String.t()]
-  defp read_config_model_list do
-    Config.get(:agent_models)
-  end
+  @spec config_model_list(AgentConfig.t()) :: [String.t()]
+  defp config_model_list(%AgentConfig{models: models}) when is_list(models), do: models
+  defp config_model_list(_config), do: []
 
   # Works with both LoopCtx and state since both have max_cost/session_cost fields.
   @spec over_budget?(LoopCtx.t() | state()) :: boolean()
@@ -2081,11 +2083,24 @@ defmodule MingaAgent.Providers.Native do
   # Parses "provider:model:thinking_level" or "provider:model" into {model_str, thinking | nil}.
   @spec parse_model_entry(String.t()) :: {String.t(), String.t() | nil}
   defp parse_model_entry(entry) do
-    case String.split(entry, ":") do
-      [provider, model, thinking] -> {"#{provider}:#{model}", thinking}
-      _ -> {entry, nil}
+    parts = String.split(entry, ":")
+
+    case Enum.reverse(parts) do
+      [thinking | reversed_model_parts] when reversed_model_parts != [] ->
+        if valid_thinking_level?(thinking) do
+          model = reversed_model_parts |> Enum.reverse() |> Enum.join(":")
+          {model, thinking}
+        else
+          {entry, nil}
+        end
+
+      _ ->
+        {entry, nil}
     end
   end
+
+  @spec valid_thinking_level?(String.t()) :: boolean()
+  defp valid_thinking_level?(level), do: Map.has_key?(@thinking_levels, level)
 
   @spec detect_project_root() :: String.t()
   # Rebuilds the system prompt with current active skills and replaces it

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -579,8 +579,9 @@ defmodule MingaEditor.Commands.Agent do
       EditorState.set_status(state, "No agent session")
     else
       case Session.cycle_model(AgentAccess.session(state)) do
-        {:ok, %{"model" => model, "index" => index, "total" => total}} ->
+        {:ok, %{"model" => model, "index" => index, "total" => total} = result} ->
           state = update_agent_ui(state, &UIState.set_model_name(&1, model))
+          state = maybe_update_thinking_level(state, Map.get(result, "thinking_level"))
 
           Session.add_system_message(
             AgentAccess.session(state),
@@ -597,6 +598,13 @@ defmodule MingaEditor.Commands.Agent do
       end
     end
   end
+
+  @spec maybe_update_thinking_level(state(), term()) :: state()
+  defp maybe_update_thinking_level(state, level) when is_binary(level) do
+    update_agent_ui(state, &UIState.set_thinking_level(&1, level))
+  end
+
+  defp maybe_update_thinking_level(state, _level), do: state
 
   @doc "Sets the agent model without resetting conversation context."
   @spec set_model(state(), String.t()) :: state()

--- a/test/minga_agent/providers/native_cycle_model_config_test.exs
+++ b/test/minga_agent/providers/native_cycle_model_config_test.exs
@@ -1,0 +1,55 @@
+defmodule MingaAgent.Providers.NativeCycleModelConfigTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Config, as: AgentConfig
+  alias MingaAgent.Providers.Native
+
+  @moduletag :tmp_dir
+  @moduletag :heavy
+
+  defp start_provider(opts) do
+    defaults = [
+      subscriber: self(),
+      model: "anthropic:claude-sonnet-4-20250514",
+      config: %AgentConfig{},
+      project_root: opts[:tmp_dir] || System.tmp_dir!(),
+      tools: [],
+      skip_api_key_env: true
+    ]
+
+    defaults
+    |> Keyword.merge(opts)
+    |> Native.start_link()
+  end
+
+  describe "cycle_model/1 with configured model list" do
+    test "returns the active thinking level and only parses valid thinking suffixes", %{
+      tmp_dir: dir
+    } do
+      config = %AgentConfig{
+        models: [
+          "anthropic:claude-sonnet-4-20250514",
+          "bedrock:anthropic.claude-3-sonnet-20240229-v1:0:medium",
+          "openai:o3:turbo"
+        ]
+      }
+
+      {:ok, pid} = start_provider(tmp_dir: dir, config: config, thinking_level: "low")
+
+      assert {:ok,
+              %{
+                "model" => "bedrock:anthropic.claude-3-sonnet-20240229-v1:0",
+                "thinking_level" => "medium"
+              }} = Native.cycle_model(pid)
+
+      assert {:ok, state} = Native.get_state(pid)
+      assert state.model.id == "bedrock:anthropic.claude-3-sonnet-20240229-v1:0"
+      assert state.thinking_level == "medium"
+
+      assert {:ok, %{"model" => "openai:o3:turbo", "thinking_level" => "medium"}} =
+               Native.cycle_model(pid)
+    end
+  end
+end

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -1,10 +1,10 @@
 defmodule MingaAgent.Providers.NativeTest do
   use ExUnit.Case, async: true
 
+  alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.Event
   alias MingaAgent.Providers.Native
   alias MingaAgent.Tools
-  alias Minga.Config.Options
   alias ReqLLM.StreamResponse.MetadataHandle
 
   @moduletag :tmp_dir
@@ -51,12 +51,18 @@ defmodule MingaAgent.Providers.NativeTest do
     defaults = [
       subscriber: self(),
       model: "anthropic:claude-sonnet-4-20250514",
+      config: %AgentConfig{},
       project_root: opts[:tmp_dir] || System.tmp_dir!(),
-      tools: []
+      tools: [],
+      skip_api_key_env: true
     ]
 
     merged = Keyword.merge(defaults, opts)
     Native.start_link(merged)
+  end
+
+  defp agent_config(fields) do
+    struct!(AgentConfig, fields)
   end
 
   defp write_project_skill(dir, name, instructions) do
@@ -152,6 +158,47 @@ defmodule MingaAgent.Providers.NativeTest do
       assert {:ok, %{"level" => "high"}} = Native.cycle_thinking_level(pid)
       assert {:ok, %{"level" => "off"}} = Native.cycle_thinking_level(pid)
     end
+
+    test "send_prompt passes semantic reasoning_effort for each provider", %{tmp_dir: dir} do
+      cases = [
+        {"anthropic:claude-sonnet-4-20250514", "high", :high},
+        {"openai:o4-mini", "medium", :medium},
+        {"deepseek:deepseek-reasoner", "low", :low},
+        {"openai:o3-mini", "off", nil}
+      ]
+
+      Enum.each(cases, fn {model, thinking_level, expected_effort} ->
+        test_pid = self()
+        ref = make_ref()
+
+        client = fn captured_model, _messages, opts ->
+          send(test_pid, {ref, captured_model, opts})
+          build_stream_response([ReqLLM.StreamChunk.text("ok")])
+        end
+
+        {:ok, pid} =
+          start_provider(
+            tmp_dir: dir,
+            model: model,
+            thinking_level: thinking_level,
+            llm_client: client
+          )
+
+        assert :ok = Native.send_prompt(pid, "test")
+        assert_receive {^ref, ^model, opts}, 2_000
+
+        if expected_effort do
+          assert Keyword.get(opts, :reasoning_effort) == expected_effort
+        else
+          refute Keyword.has_key?(opts, :reasoning_effort)
+        end
+
+        provider_options = Keyword.get(opts, :provider_options, [])
+        refute Keyword.has_key?(provider_options, :additional_model_request_fields)
+
+        collect_events(500)
+      end)
+    end
   end
 
   describe "set_model" do
@@ -206,6 +253,16 @@ defmodule MingaAgent.Providers.NativeTest do
 
       assert {:ok, state} = Native.get_state(pid)
       assert state.model.id == "openai:gpt-4o"
+    end
+
+    test "set_model preserves the semantic thinking level across providers", %{tmp_dir: dir} do
+      {:ok, pid} = start_provider(tmp_dir: dir, thinking_level: "medium")
+
+      assert :ok = Native.set_model(pid, "openai:o4-mini")
+
+      assert {:ok, state} = Native.get_state(pid)
+      assert state.model.id == "openai:o4-mini"
+      assert state.thinking_level == "medium"
     end
   end
 
@@ -900,7 +957,7 @@ defmodule MingaAgent.Providers.NativeTest do
   end
 
   describe "custom API base URL" do
-    test "MINGA_API_BASE_URL env var injects base_url into stream opts", %{tmp_dir: dir} do
+    test "API base URL override injects base_url into stream opts", %{tmp_dir: dir} do
       test_pid = self()
 
       capturing_client = fn _model, _messages, opts ->
@@ -908,9 +965,13 @@ defmodule MingaAgent.Providers.NativeTest do
         build_stream_response([{:text, "ok"}])
       end
 
-      System.put_env("MINGA_API_BASE_URL", "https://gateway.corp.com/v1")
+      {:ok, pid} =
+        start_provider(
+          tmp_dir: dir,
+          llm_client: capturing_client,
+          config: agent_config(api_base_url_override: "https://gateway.corp.com/v1")
+        )
 
-      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: capturing_client)
       :ok = Native.send_prompt(pid, "test")
 
       assert_receive {:captured_opts, opts}, 2_000
@@ -918,19 +979,15 @@ defmodule MingaAgent.Providers.NativeTest do
 
       # Collect remaining events so the process winds down
       collect_events(500)
-    after
-      System.delete_env("MINGA_API_BASE_URL")
     end
 
-    test "no base_url when env var is not set", %{tmp_dir: dir} do
+    test "no base_url when no base URL config is set", %{tmp_dir: dir} do
       test_pid = self()
 
       capturing_client = fn _model, _messages, opts ->
         send(test_pid, {:captured_opts, opts})
         build_stream_response([{:text, "ok"}])
       end
-
-      System.delete_env("MINGA_API_BASE_URL")
 
       {:ok, pid} = start_provider(tmp_dir: dir, llm_client: capturing_client)
       :ok = Native.send_prompt(pid, "test")
@@ -949,21 +1006,21 @@ defmodule MingaAgent.Providers.NativeTest do
         build_stream_response([{:text, "ok"}])
       end
 
-      System.delete_env("MINGA_API_BASE_URL")
-
-      # Set both global and per-provider endpoints
-      Options.set(:agent_api_base_url, "https://global.example.com/v1")
-
-      Options.set(:agent_api_endpoints, %{
-        "anthropic" => "https://anthropic-gw.corp.com/v1",
-        "openai" => "https://openai-gw.corp.com/v1"
-      })
+      config =
+        agent_config(
+          api_base_url: "https://global.example.com/v1",
+          api_endpoints: %{
+            "anthropic" => "https://anthropic-gw.corp.com/v1",
+            "openai" => "https://openai-gw.corp.com/v1"
+          }
+        )
 
       {:ok, pid} =
         start_provider(
           tmp_dir: dir,
           llm_client: capturing_client,
-          model: "anthropic:claude-sonnet-4-20250514"
+          model: "anthropic:claude-sonnet-4-20250514",
+          config: config
         )
 
       :ok = Native.send_prompt(pid, "test")
@@ -972,9 +1029,6 @@ defmodule MingaAgent.Providers.NativeTest do
       assert Keyword.get(opts, :base_url) == "https://anthropic-gw.corp.com/v1"
 
       collect_events(500)
-    after
-      Options.set(:agent_api_base_url, "")
-      Options.set(:agent_api_endpoints, nil)
     end
 
     test "global base_url is used when no per-provider match", %{tmp_dir: dir} do
@@ -985,16 +1039,18 @@ defmodule MingaAgent.Providers.NativeTest do
         build_stream_response([{:text, "ok"}])
       end
 
-      System.delete_env("MINGA_API_BASE_URL")
-
-      Options.set(:agent_api_base_url, "https://global.example.com/v1")
-      Options.set(:agent_api_endpoints, %{"openai" => "https://openai-only.com/v1"})
+      config =
+        agent_config(
+          api_base_url: "https://global.example.com/v1",
+          api_endpoints: %{"openai" => "https://openai-only.com/v1"}
+        )
 
       {:ok, pid} =
         start_provider(
           tmp_dir: dir,
           llm_client: capturing_client,
-          model: "anthropic:claude-sonnet-4-20250514"
+          model: "anthropic:claude-sonnet-4-20250514",
+          config: config
         )
 
       :ok = Native.send_prompt(pid, "test")
@@ -1003,12 +1059,9 @@ defmodule MingaAgent.Providers.NativeTest do
       assert Keyword.get(opts, :base_url) == "https://global.example.com/v1"
 
       collect_events(500)
-    after
-      Options.set(:agent_api_base_url, "")
-      Options.set(:agent_api_endpoints, nil)
     end
 
-    test "env var overrides per-provider endpoint", %{tmp_dir: dir} do
+    test "base URL override takes precedence over per-provider endpoint", %{tmp_dir: dir} do
       test_pid = self()
 
       capturing_client = fn _model, _messages, opts ->
@@ -1016,19 +1069,19 @@ defmodule MingaAgent.Providers.NativeTest do
         build_stream_response([{:text, "ok"}])
       end
 
-      System.put_env("MINGA_API_BASE_URL", "https://env-override.com/v1")
-      Options.set(:agent_api_endpoints, %{"anthropic" => "https://should-lose.com"})
+      config =
+        agent_config(
+          api_base_url_override: "https://env-override.com/v1",
+          api_endpoints: %{"anthropic" => "https://should-lose.com"}
+        )
 
-      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: capturing_client)
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: capturing_client, config: config)
       :ok = Native.send_prompt(pid, "test")
 
       assert_receive {:captured_opts, opts}, 2_000
       assert Keyword.get(opts, :base_url) == "https://env-override.com/v1"
 
       collect_events(500)
-    after
-      System.delete_env("MINGA_API_BASE_URL")
-      Options.set(:agent_api_endpoints, nil)
     end
   end
 

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -192,6 +192,31 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
     end
   end
 
+  describe "cycle_model/1" do
+    test "updates model and thinking level from the session response" do
+      {:ok, session} =
+        StubServer.start_link(
+          cycle_model:
+            {:ok,
+             %{
+               "model" => "openai:o4-mini",
+               "index" => 2,
+               "total" => 3,
+               "thinking_level" => "high"
+             }}
+        )
+
+      state = base_state(session: session)
+      state = AgentAccess.update_agent_ui(state, &UIState.set_thinking_level(&1, "medium"))
+
+      new_state = AgentCommands.cycle_model(state)
+
+      assert AgentAccess.panel(new_state).model_name == "openai:o4-mini"
+      assert AgentAccess.panel(new_state).thinking_level == "high"
+      assert new_state.shell_state.status_msg == "Model: openai:o4-mini [2/3]"
+    end
+  end
+
   # ── scope_* guard functions ──────────────────────────────────────────────
   # These functions guard on agentic/panel state. Test the guard behavior.
 

--- a/test/support/stub_server.ex
+++ b/test/support/stub_server.ex
@@ -26,6 +26,10 @@ defmodule Minga.Test.StubServer do
     do: {:reply, %{input: 0, output: 0, cache_read: 0, cache_write: 0, cost: 0.0}, state}
 
   def handle_call(:status, _from, state), do: {:reply, Map.get(state, :status, :idle), state}
+
+  def handle_call(:cycle_model, _from, state),
+    do: {:reply, Map.get(state, :cycle_model, {:error, :not_configured}), state}
+
   def handle_call({:subscribe, _pid}, _from, state), do: {:reply, :ok, state}
   def handle_call({:unsubscribe, _pid}, _from, state), do: {:reply, :ok, state}
 


### PR DESCRIPTION
# TL;DR
Agent thinking levels now use ReqLLM's unified `:reasoning_effort` option instead of Anthropic-only `budget_tokens`, so the same low/medium/high setting works semantically across providers while `off` omits reasoning configuration.

Closes #1529

## Context
Minga previously built Anthropic-specific `additional_model_request_fields` when a thinking level was enabled. That made the `SPC a T` thinking toggle ineffective or malformed for OpenAI reasoning models and DeepSeek. ReqLLM already owns provider-specific translation for `:reasoning_effort`, so Minga should keep only the semantic thinking level and pass that through.

## Changes
- Replaced Anthropic-specific thinking budget construction in `MingaAgent.Providers.Native` with top-level `reasoning_effort` values for low/medium/high.
- Mapped Minga's semantic levels to ReqLLM effort atoms: `low -> :low`, `medium -> :medium`, `high -> :high`; `off` now omits `:reasoning_effort` instead of sending an invalid provider value.
- Preserved existing prompt cache provider options while removing manual `additional_model_request_fields` thinking config.
- Made model cycling return the active semantic thinking level so the agent UI stays in sync when a model-list entry includes a valid thinking suffix.
- Hardened model-list parsing so model IDs containing colons are preserved, and only valid thinking suffixes are treated as thinking levels.
- Routed model rotation and API endpoint behavior through the injected `MingaAgent.Config`, so provider tests no longer mutate global options or process-wide environment variables.
- Added provider and command tests covering Anthropic, OpenAI, DeepSeek, model switching, thinking-level UI sync, and colon-containing model entries.

## Verification
- `mix test.debug test/minga_agent/providers/native_test.exs test/minga_agent/providers/native_cycle_model_config_test.exs test/minga_editor/commands/agent_commands_test.exs test/minga_agent/config_test.exs` (65 tests, 0 failures)
- `mix test.llm` (7885 tests, 54 doctests, 97 properties, 0 failures, 5 skipped, 115 excluded)
- `make lint` (passed; existing large-struct warnings only)
- Fresh-eyes bug-hunting pass via `prtk-code-reviewer`, then fixed both findings

## Acceptance Criteria Addressed
- Thinking level cycling produces the correct provider-specific configuration for Anthropic, OpenAI, and DeepSeek models ✅
- Reasoning content from OpenAI and DeepSeek streams as `ThinkingDelta` events and appears in the chat panel identically to Anthropic thinking blocks ✅
- The status bar thinking level indicator reflects the active level regardless of provider ✅
- Switching models between providers preserves the thinking level semantically ✅
