### PR TITLE
feat(agent): complete hook lifecycle events epic

### DIFF
--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -194,16 +194,16 @@ defmodule Minga.Events do
 
   defmodule AgentHookEvent do
     @moduledoc "Payload for `:agent_hook` lifecycle telemetry events."
-    @enforce_keys [:event, :phase, :tool_name, :tool_call_id, :tool_pattern]
+    @enforce_keys [:event, :phase]
     defstruct [:event, :phase, :tool_name, :tool_call_id, :tool_pattern, :exit_status, :reason]
 
     @type phase :: :started | :allowed | :vetoed
     @type t :: %__MODULE__{
             event: String.t(),
             phase: phase(),
-            tool_name: String.t(),
-            tool_call_id: String.t(),
-            tool_pattern: String.t(),
+            tool_name: String.t() | nil,
+            tool_call_id: String.t() | nil,
+            tool_pattern: String.t() | nil,
             exit_status: non_neg_integer() | nil,
             reason: term()
           }

--- a/lib/minga_agent/hooks/command_runner.ex
+++ b/lib/minga_agent/hooks/command_runner.ex
@@ -15,16 +15,16 @@ defmodule MingaAgent.Hooks.CommandRunner do
   @typedoc "Options used by tests to inject helper behavior."
   @type run_opts :: [helper_path: String.t()]
 
-  @doc "Runs a `PreToolUse` shell hook for a payload."
-  @spec run_pre_tool_use(Hook.t(), PreToolUsePayload.t()) :: Result.t()
-  def run_pre_tool_use(%Hook{} = hook, %PreToolUsePayload{} = payload) do
-    run_pre_tool_use(hook, payload, [])
+  @doc "Runs a shell hook with any Jason-encodable payload map."
+  @spec run(Hook.t(), map()) :: Result.t()
+  def run(%Hook{} = hook, payload_map) when is_map(payload_map) do
+    run(hook, payload_map, [])
   end
 
   @doc false
-  @spec run_pre_tool_use(Hook.t(), PreToolUsePayload.t(), run_opts()) :: Result.t()
-  def run_pre_tool_use(%Hook{} = hook, %PreToolUsePayload{} = payload, opts) when is_list(opts) do
-    with {:ok, payload_json} <- encode_payload(payload),
+  @spec run(Hook.t(), map(), run_opts()) :: Result.t()
+  def run(%Hook{} = hook, payload_map, opts) when is_map(payload_map) and is_list(opts) do
+    with {:ok, payload_json} <- encode_map(payload_map),
          {:ok, helper_path} <- helper_path(opts) do
       run_helper(hook, helper_path, payload_json)
     else
@@ -32,9 +32,21 @@ defmodule MingaAgent.Hooks.CommandRunner do
     end
   end
 
-  @spec encode_payload(PreToolUsePayload.t()) :: {:ok, String.t()} | {:error, term()}
-  defp encode_payload(%PreToolUsePayload{} = payload) do
-    case Jason.encode(PreToolUsePayload.to_map(payload)) do
+  @doc "Runs a `PreToolUse` shell hook for a payload."
+  @spec run_pre_tool_use(Hook.t(), PreToolUsePayload.t()) :: Result.t()
+  def run_pre_tool_use(%Hook{} = hook, %PreToolUsePayload{} = payload) do
+    run(hook, PreToolUsePayload.to_map(payload))
+  end
+
+  @doc false
+  @spec run_pre_tool_use(Hook.t(), PreToolUsePayload.t(), run_opts()) :: Result.t()
+  def run_pre_tool_use(%Hook{} = hook, %PreToolUsePayload{} = payload, opts) when is_list(opts) do
+    run(hook, PreToolUsePayload.to_map(payload), opts)
+  end
+
+  @spec encode_map(map()) :: {:ok, String.t()} | {:error, term()}
+  defp encode_map(payload_map) do
+    case Jason.encode(payload_map) do
       {:ok, json} -> {:ok, json}
       {:error, reason} -> {:error, safe_encode_reason(reason)}
     end
@@ -224,7 +236,8 @@ defmodule MingaAgent.Hooks.CommandRunner do
 
   @spec timeout_stderr(Hook.t(), String.t()) :: String.t()
   defp timeout_stderr(hook, stderr) do
-    message = "PreToolUse hook timed out after #{hook.timeout_ms}ms and was killed"
+    label = Hook.event_label(hook.event)
+    message = "#{label} hook timed out after #{hook.timeout_ms}ms and was killed"
 
     case String.trim(stderr) do
       "" -> message

--- a/lib/minga_agent/hooks/dispatcher.ex
+++ b/lib/minga_agent/hooks/dispatcher.ex
@@ -70,6 +70,24 @@ defmodule MingaAgent.Hooks.Dispatcher do
     :ok
   end
 
+  @doc "Runs all matching `SessionStart` hooks (notification-only)."
+  @spec session_start([Hook.t()], map()) :: :ok
+  @spec session_start([Hook.t()], map(), keyword()) :: :ok
+  def session_start(hooks, payload_map, opts \\ [])
+      when is_list(hooks) and is_map(payload_map) do
+    dispatch(:session_start, hooks, payload_map, Keyword.put(opts, :veto_capable, false))
+    :ok
+  end
+
+  @doc "Runs all matching `SessionEnd` hooks (notification-only)."
+  @spec session_end([Hook.t()], map()) :: :ok
+  @spec session_end([Hook.t()], map(), keyword()) :: :ok
+  def session_end(hooks, payload_map, opts \\ [])
+      when is_list(hooks) and is_map(payload_map) do
+    dispatch(:session_end, hooks, payload_map, Keyword.put(opts, :veto_capable, false))
+    :ok
+  end
+
   @spec run_matching_hooks([Hook.t()], Hook.event(), map(), runner(), boolean()) ::
           :ok | {:error, Result.t()}
   defp run_matching_hooks([], _event, _payload_map, _runner, _veto_capable), do: :ok

--- a/lib/minga_agent/hooks/dispatcher.ex
+++ b/lib/minga_agent/hooks/dispatcher.ex
@@ -88,6 +88,15 @@ defmodule MingaAgent.Hooks.Dispatcher do
     :ok
   end
 
+  @doc "Runs all matching `Stop` hooks (notification-only)."
+  @spec stop([Hook.t()], map()) :: :ok
+  @spec stop([Hook.t()], map(), keyword()) :: :ok
+  def stop(hooks, payload_map, opts \\ [])
+      when is_list(hooks) and is_map(payload_map) do
+    dispatch(:stop, hooks, payload_map, Keyword.put(opts, :veto_capable, false))
+    :ok
+  end
+
   @spec run_matching_hooks([Hook.t()], Hook.event(), map(), runner(), boolean()) ::
           :ok | {:error, Result.t()}
   defp run_matching_hooks([], _event, _payload_map, _runner, _veto_capable), do: :ok

--- a/lib/minga_agent/hooks/dispatcher.ex
+++ b/lib/minga_agent/hooks/dispatcher.ex
@@ -174,8 +174,10 @@ defmodule MingaAgent.Hooks.Dispatcher do
       reason: if(result, do: result.reason, else: nil)
     })
   rescue
-    ArgumentError -> :ok
+    e ->
+      Minga.Log.warning(:agent, "Hook event broadcast failed: #{Exception.message(e)}")
   catch
-    :exit, _ -> :ok
+    :exit, reason ->
+      Minga.Log.warning(:agent, "Hook event broadcast failed: #{inspect(reason)}")
   end
 end

--- a/lib/minga_agent/hooks/dispatcher.ex
+++ b/lib/minga_agent/hooks/dispatcher.ex
@@ -1,10 +1,12 @@
 defmodule MingaAgent.Hooks.Dispatcher do
   @moduledoc """
-  Dispatches normalized agent hooks for a tool lifecycle event.
+  Dispatches normalized agent hooks for lifecycle events.
 
   The dispatcher is intentionally stateless. It receives a list of hooks from
   `MingaAgent.Config`, filters matching hooks in registration order, and asks a
-  runner to execute each hook. The first veto short-circuits later hooks.
+  runner to execute each hook. For veto-capable events the first veto
+  short-circuits later hooks; for notification-only events vetoes are logged
+  but do not block.
   """
 
   alias Minga.Events
@@ -14,7 +16,25 @@ defmodule MingaAgent.Hooks.Dispatcher do
   alias MingaAgent.Hooks.Result
 
   @typedoc "Hook runner used by tests and production command execution."
-  @type runner :: (Hook.t(), PreToolUsePayload.t() -> Result.t())
+  @type runner :: (Hook.t(), map() -> Result.t())
+
+  @doc "Runs all matching hooks for an event in registration order."
+  @spec dispatch(Hook.event(), [Hook.t()], map(), keyword()) :: :ok | {:error, Result.t()}
+  def dispatch(event, hooks, payload_map, opts \\ [])
+      when is_atom(event) and is_list(hooks) and is_map(payload_map) and is_list(opts) do
+    runner = Keyword.get(opts, :runner, &CommandRunner.run/2)
+    veto_capable = Keyword.get(opts, :veto_capable, true)
+    tool_name = Map.get(payload_map, "tool_name")
+
+    matching =
+      if Hook.tool_event?(event) and is_binary(tool_name) do
+        Enum.filter(hooks, &Hook.matches?(&1, event, tool_name))
+      else
+        Enum.filter(hooks, &Hook.matches?(&1, event))
+      end
+
+    run_matching_hooks(matching, event, payload_map, runner, veto_capable)
+  end
 
   @doc "Runs all matching `PreToolUse` hooks in registration order."
   @spec pre_tool_use([Hook.t()], PreToolUsePayload.t()) :: :ok | {:error, Result.t()}
@@ -26,43 +46,71 @@ defmodule MingaAgent.Hooks.Dispatcher do
   @spec pre_tool_use([Hook.t()], PreToolUsePayload.t(), keyword()) :: :ok | {:error, Result.t()}
   def pre_tool_use(hooks, %PreToolUsePayload{} = payload, opts)
       when is_list(hooks) and is_list(opts) do
-    runner = Keyword.get(opts, :runner, &CommandRunner.run_pre_tool_use/2)
+    legacy_runner = Keyword.get(opts, :runner)
 
-    hooks
-    |> Enum.filter(&Hook.matches?(&1, :pre_tool_use, payload.tool_name))
-    |> run_matching_hooks(payload, runner)
+    runner =
+      if legacy_runner do
+        fn hook, payload_map -> legacy_runner.(hook, PreToolUsePayload.new(payload_map)) end
+      else
+        nil
+      end
+
+    dispatch_opts =
+      if runner, do: [runner: runner, veto_capable: true], else: [veto_capable: true]
+
+    dispatch(:pre_tool_use, hooks, PreToolUsePayload.to_map(payload), dispatch_opts)
   end
 
-  @spec run_matching_hooks([Hook.t()], PreToolUsePayload.t(), runner()) ::
+  @doc "Runs all matching `PostToolUse` hooks (notification-only)."
+  @spec post_tool_use([Hook.t()], map()) :: :ok
+  @spec post_tool_use([Hook.t()], map(), keyword()) :: :ok
+  def post_tool_use(hooks, payload_map, opts \\ [])
+      when is_list(hooks) and is_map(payload_map) do
+    dispatch(:post_tool_use, hooks, payload_map, Keyword.put(opts, :veto_capable, false))
+    :ok
+  end
+
+  @spec run_matching_hooks([Hook.t()], Hook.event(), map(), runner(), boolean()) ::
           :ok | {:error, Result.t()}
-  defp run_matching_hooks([], _payload, _runner), do: :ok
+  defp run_matching_hooks([], _event, _payload_map, _runner, _veto_capable), do: :ok
 
-  defp run_matching_hooks([hook | rest], payload, runner) do
-    broadcast(:started, hook, payload, nil)
+  defp run_matching_hooks([hook | rest], event, payload_map, runner, veto_capable) do
+    broadcast(:started, event, hook, payload_map, nil)
 
-    case runner.(hook, payload) do
+    case runner.(hook, payload_map) do
       %Result{status: :allow} = result ->
-        broadcast(:allowed, hook, payload, result)
-        run_matching_hooks(rest, payload, runner)
+        broadcast(:allowed, event, hook, payload_map, result)
+        run_matching_hooks(rest, event, payload_map, runner, veto_capable)
 
       %Result{status: :veto} = result ->
-        broadcast(:vetoed, hook, payload, result)
-        {:error, result}
+        broadcast(:vetoed, event, hook, payload_map, result)
+
+        if veto_capable do
+          {:error, result}
+        else
+          Minga.Log.warning(
+            :agent,
+            "#{Hook.event_label(event)} hook veto ignored (notification-only): #{Result.message(result)}"
+          )
+
+          run_matching_hooks(rest, event, payload_map, runner, veto_capable)
+        end
     end
   end
 
   @spec broadcast(
           :started | :allowed | :vetoed,
+          Hook.event(),
           Hook.t(),
-          PreToolUsePayload.t(),
+          map(),
           Result.t() | nil
         ) :: :ok
-  defp broadcast(phase, hook, payload, result) do
+  defp broadcast(phase, event, hook, payload_map, result) do
     Events.broadcast(:agent_hook, %Events.AgentHookEvent{
-      event: "PreToolUse",
+      event: Hook.event_label(event),
       phase: phase,
-      tool_name: payload.tool_name,
-      tool_call_id: payload.tool_call_id,
+      tool_name: Map.get(payload_map, "tool_name"),
+      tool_call_id: Map.get(payload_map, "tool_call_id"),
       tool_pattern: hook.tool_pattern,
       exit_status: if(result, do: result.exit_status, else: nil),
       reason: if(result, do: result.reason, else: nil)

--- a/lib/minga_agent/hooks/dispatcher.ex
+++ b/lib/minga_agent/hooks/dispatcher.ex
@@ -105,6 +105,23 @@ defmodule MingaAgent.Hooks.Dispatcher do
     dispatch(:user_prompt_submit, hooks, payload_map, Keyword.put(opts, :veto_capable, true))
   end
 
+  @doc "Runs all matching `PreCompact` hooks (veto-capable)."
+  @spec pre_compact([Hook.t()], map()) :: :ok | {:error, Result.t()}
+  @spec pre_compact([Hook.t()], map(), keyword()) :: :ok | {:error, Result.t()}
+  def pre_compact(hooks, payload_map, opts \\ [])
+      when is_list(hooks) and is_map(payload_map) do
+    dispatch(:pre_compact, hooks, payload_map, Keyword.put(opts, :veto_capable, true))
+  end
+
+  @doc "Runs all matching `Notification` hooks (notification-only)."
+  @spec notification([Hook.t()], map()) :: :ok
+  @spec notification([Hook.t()], map(), keyword()) :: :ok
+  def notification(hooks, payload_map, opts \\ [])
+      when is_list(hooks) and is_map(payload_map) do
+    dispatch(:notification, hooks, payload_map, Keyword.put(opts, :veto_capable, false))
+    :ok
+  end
+
   @spec run_matching_hooks([Hook.t()], Hook.event(), map(), runner(), boolean()) ::
           :ok | {:error, Result.t()}
   defp run_matching_hooks([], _event, _payload_map, _runner, _veto_capable), do: :ok

--- a/lib/minga_agent/hooks/dispatcher.ex
+++ b/lib/minga_agent/hooks/dispatcher.ex
@@ -12,6 +12,7 @@ defmodule MingaAgent.Hooks.Dispatcher do
   alias Minga.Events
   alias MingaAgent.Hooks.CommandRunner
   alias MingaAgent.Hooks.Hook
+  alias MingaAgent.Hooks.ModuleRunner
   alias MingaAgent.Hooks.PreToolUsePayload
   alias MingaAgent.Hooks.Result
 
@@ -22,7 +23,7 @@ defmodule MingaAgent.Hooks.Dispatcher do
   @spec dispatch(Hook.event(), [Hook.t()], map(), keyword()) :: :ok | {:error, Result.t()}
   def dispatch(event, hooks, payload_map, opts \\ [])
       when is_atom(event) and is_list(hooks) and is_map(payload_map) and is_list(opts) do
-    runner = Keyword.get(opts, :runner, &CommandRunner.run/2)
+    runner_override = Keyword.get(opts, :runner)
     veto_capable = Keyword.get(opts, :veto_capable, true)
     tool_name = Map.get(payload_map, "tool_name")
 
@@ -33,7 +34,7 @@ defmodule MingaAgent.Hooks.Dispatcher do
         Enum.filter(hooks, &Hook.matches?(&1, event))
       end
 
-    run_matching_hooks(matching, event, payload_map, runner, veto_capable)
+    run_matching_hooks(matching, event, payload_map, runner_override, veto_capable)
   end
 
   @doc "Runs all matching `PreToolUse` hooks in registration order."
@@ -122,17 +123,18 @@ defmodule MingaAgent.Hooks.Dispatcher do
     :ok
   end
 
-  @spec run_matching_hooks([Hook.t()], Hook.event(), map(), runner(), boolean()) ::
+  @spec run_matching_hooks([Hook.t()], Hook.event(), map(), runner() | nil, boolean()) ::
           :ok | {:error, Result.t()}
-  defp run_matching_hooks([], _event, _payload_map, _runner, _veto_capable), do: :ok
+  defp run_matching_hooks([], _event, _payload_map, _runner_override, _veto_capable), do: :ok
 
-  defp run_matching_hooks([hook | rest], event, payload_map, runner, veto_capable) do
+  defp run_matching_hooks([hook | rest], event, payload_map, runner_override, veto_capable) do
+    runner = runner_override || runner_for_hook(hook)
     broadcast(:started, event, hook, payload_map, nil)
 
     case runner.(hook, payload_map) do
       %Result{status: :allow} = result ->
         broadcast(:allowed, event, hook, payload_map, result)
-        run_matching_hooks(rest, event, payload_map, runner, veto_capable)
+        run_matching_hooks(rest, event, payload_map, runner_override, veto_capable)
 
       %Result{status: :veto} = result ->
         broadcast(:vetoed, event, hook, payload_map, result)
@@ -145,10 +147,14 @@ defmodule MingaAgent.Hooks.Dispatcher do
             "#{Hook.event_label(event)} hook veto ignored (notification-only): #{Result.message(result)}"
           )
 
-          run_matching_hooks(rest, event, payload_map, runner, veto_capable)
+          run_matching_hooks(rest, event, payload_map, runner_override, veto_capable)
         end
     end
   end
+
+  @spec runner_for_hook(Hook.t()) :: runner()
+  defp runner_for_hook(%Hook{type: :module}), do: &ModuleRunner.run/2
+  defp runner_for_hook(%Hook{}), do: &CommandRunner.run/2
 
   @spec broadcast(
           :started | :allowed | :vetoed,

--- a/lib/minga_agent/hooks/dispatcher.ex
+++ b/lib/minga_agent/hooks/dispatcher.ex
@@ -5,8 +5,8 @@ defmodule MingaAgent.Hooks.Dispatcher do
   The dispatcher is intentionally stateless. It receives a list of hooks from
   `MingaAgent.Config`, filters matching hooks in registration order, and asks a
   runner to execute each hook. For veto-capable events the first veto
-  short-circuits later hooks; for notification-only events vetoes are logged
-  but do not block.
+  short-circuits later hooks; for notification-only events vetoes are
+  broadcast as events and logged as warnings but do not block.
   """
 
   alias Minga.Events

--- a/lib/minga_agent/hooks/dispatcher.ex
+++ b/lib/minga_agent/hooks/dispatcher.ex
@@ -97,6 +97,14 @@ defmodule MingaAgent.Hooks.Dispatcher do
     :ok
   end
 
+  @doc "Runs all matching `UserPromptSubmit` hooks (veto-capable)."
+  @spec user_prompt_submit([Hook.t()], map()) :: :ok | {:error, Result.t()}
+  @spec user_prompt_submit([Hook.t()], map(), keyword()) :: :ok | {:error, Result.t()}
+  def user_prompt_submit(hooks, payload_map, opts \\ [])
+      when is_list(hooks) and is_map(payload_map) do
+    dispatch(:user_prompt_submit, hooks, payload_map, Keyword.put(opts, :veto_capable, true))
+  end
+
   @spec run_matching_hooks([Hook.t()], Hook.event(), map(), runner(), boolean()) ::
           :ok | {:error, Result.t()}
   defp run_matching_hooks([], _event, _payload_map, _runner, _veto_capable), do: :ok

--- a/lib/minga_agent/hooks/hook.ex
+++ b/lib/minga_agent/hooks/hook.ex
@@ -13,7 +13,13 @@ defmodule MingaAgent.Hooks.Hook do
   @tool_events [:pre_tool_use, :post_tool_use]
 
   @typedoc "Supported hook event names."
-  @type event :: :pre_tool_use | :post_tool_use | :session_start | :session_end | :stop
+  @type event ::
+          :pre_tool_use
+          | :post_tool_use
+          | :session_start
+          | :session_end
+          | :stop
+          | :user_prompt_submit
 
   @typedoc "Normalized hook declaration."
   @type t :: %__MODULE__{
@@ -81,6 +87,7 @@ defmodule MingaAgent.Hooks.Hook do
   def event_label(:session_start), do: "SessionStart"
   def event_label(:session_end), do: "SessionEnd"
   def event_label(:stop), do: "Stop"
+  def event_label(:user_prompt_submit), do: "UserPromptSubmit"
 
   @spec map_from_list(list()) :: {:ok, map()} | :error
   defp map_from_list(raw) do
@@ -111,6 +118,10 @@ defmodule MingaAgent.Hooks.Hook do
   defp normalize_event(:Stop), do: {:ok, :stop}
   defp normalize_event("Stop"), do: {:ok, :stop}
   defp normalize_event("stop"), do: {:ok, :stop}
+  defp normalize_event(:user_prompt_submit), do: {:ok, :user_prompt_submit}
+  defp normalize_event(:UserPromptSubmit), do: {:ok, :user_prompt_submit}
+  defp normalize_event("UserPromptSubmit"), do: {:ok, :user_prompt_submit}
+  defp normalize_event("user_prompt_submit"), do: {:ok, :user_prompt_submit}
   defp normalize_event(other), do: {:error, "unsupported agent hook event: #{inspect(other)}"}
 
   @spec normalize_tool_pattern(map(), event()) :: {:ok, String.t() | nil} | {:error, String.t()}

--- a/lib/minga_agent/hooks/hook.ex
+++ b/lib/minga_agent/hooks/hook.ex
@@ -13,7 +13,7 @@ defmodule MingaAgent.Hooks.Hook do
   @tool_events [:pre_tool_use, :post_tool_use]
 
   @typedoc "Supported hook event names."
-  @type event :: :pre_tool_use | :post_tool_use | :session_start | :session_end
+  @type event :: :pre_tool_use | :post_tool_use | :session_start | :session_end | :stop
 
   @typedoc "Normalized hook declaration."
   @type t :: %__MODULE__{
@@ -80,6 +80,7 @@ defmodule MingaAgent.Hooks.Hook do
   def event_label(:post_tool_use), do: "PostToolUse"
   def event_label(:session_start), do: "SessionStart"
   def event_label(:session_end), do: "SessionEnd"
+  def event_label(:stop), do: "Stop"
 
   @spec map_from_list(list()) :: {:ok, map()} | :error
   defp map_from_list(raw) do
@@ -106,6 +107,10 @@ defmodule MingaAgent.Hooks.Hook do
   defp normalize_event(:SessionEnd), do: {:ok, :session_end}
   defp normalize_event("SessionEnd"), do: {:ok, :session_end}
   defp normalize_event("session_end"), do: {:ok, :session_end}
+  defp normalize_event(:stop), do: {:ok, :stop}
+  defp normalize_event(:Stop), do: {:ok, :stop}
+  defp normalize_event("Stop"), do: {:ok, :stop}
+  defp normalize_event("stop"), do: {:ok, :stop}
   defp normalize_event(other), do: {:error, "unsupported agent hook event: #{inspect(other)}"}
 
   @spec normalize_tool_pattern(map(), event()) :: {:ok, String.t() | nil} | {:error, String.t()}

--- a/lib/minga_agent/hooks/hook.ex
+++ b/lib/minga_agent/hooks/hook.ex
@@ -38,7 +38,15 @@ defmodule MingaAgent.Hooks.Hook do
         }
 
   @enforce_keys [:event]
-  defstruct [:event, :tool_pattern, :command, :module, :function, type: :shell, timeout_ms: @default_timeout_ms]
+  defstruct [
+    :event,
+    :tool_pattern,
+    :command,
+    :module,
+    :function,
+    type: :shell,
+    timeout_ms: @default_timeout_ms
+  ]
 
   @doc "Returns the default per-hook timeout in milliseconds."
   @spec default_timeout_ms() :: pos_integer()
@@ -57,16 +65,18 @@ defmodule MingaAgent.Hooks.Hook do
     with {:ok, event} <- normalize_event(fetch(raw, :event)),
          {:ok, type} <- normalize_type(raw),
          {:ok, tool_pattern} <- normalize_tool_pattern(raw, event),
-         {:ok, fields} <- normalize_type_fields(raw, type),
+         {:ok, command, mod, fun} <- normalize_type_fields(raw, type),
          {:ok, timeout_ms} <- normalize_timeout(fetch(raw, :timeout_ms)) do
       {:ok,
        %__MODULE__{
          event: event,
          type: type,
          tool_pattern: tool_pattern,
+         command: command,
+         module: mod,
+         function: fun,
          timeout_ms: timeout_ms
-       }
-       |> Map.merge(fields)}
+       }}
     end
   end
 
@@ -108,41 +118,50 @@ defmodule MingaAgent.Hooks.Hook do
     ArgumentError -> :error
   end
 
+  @event_aliases Map.new(
+                   for {canonical, aliases} <- %{
+                         pre_tool_use: [:pre_tool_use, :PreToolUse, "PreToolUse", "pre_tool_use"],
+                         post_tool_use: [
+                           :post_tool_use,
+                           :PostToolUse,
+                           "PostToolUse",
+                           "post_tool_use"
+                         ],
+                         session_start: [
+                           :session_start,
+                           :SessionStart,
+                           "SessionStart",
+                           "session_start"
+                         ],
+                         session_end: [:session_end, :SessionEnd, "SessionEnd", "session_end"],
+                         stop: [:stop, :Stop, "Stop", "stop"],
+                         user_prompt_submit: [
+                           :user_prompt_submit,
+                           :UserPromptSubmit,
+                           "UserPromptSubmit",
+                           "user_prompt_submit"
+                         ],
+                         pre_compact: [:pre_compact, :PreCompact, "PreCompact", "pre_compact"],
+                         notification: [
+                           :notification,
+                           :Notification,
+                           "Notification",
+                           "notification"
+                         ]
+                       },
+                       alias_val <- aliases,
+                       do: {alias_val, canonical}
+                 )
+
   @spec normalize_event(term()) :: {:ok, event()} | {:error, String.t()}
   defp normalize_event(nil), do: {:error, "agent hook requires :event"}
-  defp normalize_event(:pre_tool_use), do: {:ok, :pre_tool_use}
-  defp normalize_event(:PreToolUse), do: {:ok, :pre_tool_use}
-  defp normalize_event("PreToolUse"), do: {:ok, :pre_tool_use}
-  defp normalize_event("pre_tool_use"), do: {:ok, :pre_tool_use}
-  defp normalize_event(:post_tool_use), do: {:ok, :post_tool_use}
-  defp normalize_event(:PostToolUse), do: {:ok, :post_tool_use}
-  defp normalize_event("PostToolUse"), do: {:ok, :post_tool_use}
-  defp normalize_event("post_tool_use"), do: {:ok, :post_tool_use}
-  defp normalize_event(:session_start), do: {:ok, :session_start}
-  defp normalize_event(:SessionStart), do: {:ok, :session_start}
-  defp normalize_event("SessionStart"), do: {:ok, :session_start}
-  defp normalize_event("session_start"), do: {:ok, :session_start}
-  defp normalize_event(:session_end), do: {:ok, :session_end}
-  defp normalize_event(:SessionEnd), do: {:ok, :session_end}
-  defp normalize_event("SessionEnd"), do: {:ok, :session_end}
-  defp normalize_event("session_end"), do: {:ok, :session_end}
-  defp normalize_event(:stop), do: {:ok, :stop}
-  defp normalize_event(:Stop), do: {:ok, :stop}
-  defp normalize_event("Stop"), do: {:ok, :stop}
-  defp normalize_event("stop"), do: {:ok, :stop}
-  defp normalize_event(:user_prompt_submit), do: {:ok, :user_prompt_submit}
-  defp normalize_event(:UserPromptSubmit), do: {:ok, :user_prompt_submit}
-  defp normalize_event("UserPromptSubmit"), do: {:ok, :user_prompt_submit}
-  defp normalize_event("user_prompt_submit"), do: {:ok, :user_prompt_submit}
-  defp normalize_event(:pre_compact), do: {:ok, :pre_compact}
-  defp normalize_event(:PreCompact), do: {:ok, :pre_compact}
-  defp normalize_event("PreCompact"), do: {:ok, :pre_compact}
-  defp normalize_event("pre_compact"), do: {:ok, :pre_compact}
-  defp normalize_event(:notification), do: {:ok, :notification}
-  defp normalize_event(:Notification), do: {:ok, :notification}
-  defp normalize_event("Notification"), do: {:ok, :notification}
-  defp normalize_event("notification"), do: {:ok, :notification}
-  defp normalize_event(other), do: {:error, "unsupported agent hook event: #{inspect(other)}"}
+
+  defp normalize_event(value) do
+    case Map.fetch(@event_aliases, value) do
+      {:ok, event} -> {:ok, event}
+      :error -> {:error, "unsupported agent hook event: #{inspect(value)}"}
+    end
+  end
 
   @spec normalize_tool_pattern(map(), event()) :: {:ok, String.t() | nil} | {:error, String.t()}
   defp normalize_tool_pattern(raw, event) do
@@ -161,12 +180,7 @@ defmodule MingaAgent.Hooks.Hook do
   @spec normalize_type(map()) :: {:ok, hook_type()} | {:error, String.t()}
   defp normalize_type(raw) do
     case fetch(raw, :type) do
-      nil ->
-        cond do
-          fetch(raw, :module) != nil -> {:ok, :module}
-          true -> {:ok, :shell}
-        end
-
+      nil -> infer_type(raw)
       :shell -> {:ok, :shell}
       "shell" -> {:ok, :shell}
       :module -> {:ok, :module}
@@ -175,12 +189,16 @@ defmodule MingaAgent.Hooks.Hook do
     end
   end
 
+  @spec infer_type(map()) :: {:ok, hook_type()}
+  defp infer_type(raw) do
+    if fetch(raw, :module) != nil, do: {:ok, :module}, else: {:ok, :shell}
+  end
+
   @spec normalize_type_fields(map(), hook_type()) ::
-          {:ok, %{command: String.t()} | %{module: module(), function: atom()}}
-          | {:error, String.t()}
+          {:ok, String.t() | nil, module() | nil, atom() | nil} | {:error, String.t()}
   defp normalize_type_fields(raw, :shell) do
     case normalize_non_empty_string(fetch(raw, :command), "shell hook requires :command") do
-      {:ok, command} -> {:ok, %{command: command}}
+      {:ok, command} -> {:ok, command, nil, nil}
       error -> error
     end
   end
@@ -188,7 +206,7 @@ defmodule MingaAgent.Hooks.Hook do
   defp normalize_type_fields(raw, :module) do
     with {:ok, mod} <- normalize_module(fetch(raw, :module)),
          {:ok, fun} <- normalize_function(fetch(raw, :function)) do
-      {:ok, %{module: mod, function: fun}}
+      {:ok, nil, mod, fun}
     end
   end
 
@@ -197,12 +215,14 @@ defmodule MingaAgent.Hooks.Hook do
   defp normalize_module(mod) when is_atom(mod), do: {:ok, mod}
 
   defp normalize_module(mod) when is_binary(mod) do
-    {:ok, String.to_existing_atom("Elixir." <> mod)}
+    full_name = if String.starts_with?(mod, "Elixir."), do: mod, else: "Elixir." <> mod
+    {:ok, String.to_existing_atom(full_name)}
   rescue
     ArgumentError -> {:error, "module hook :module #{inspect(mod)} is not a loaded module"}
   end
 
-  defp normalize_module(other), do: {:error, "module hook :module must be an atom, got: #{inspect(other)}"}
+  defp normalize_module(other),
+    do: {:error, "module hook :module must be an atom, got: #{inspect(other)}"}
 
   @spec normalize_function(term()) :: {:ok, atom()} | {:error, String.t()}
   defp normalize_function(nil), do: {:error, "module hook requires :function"}
@@ -214,7 +234,8 @@ defmodule MingaAgent.Hooks.Hook do
     ArgumentError -> {:error, "module hook :function #{inspect(fun)} is not a known atom"}
   end
 
-  defp normalize_function(other), do: {:error, "module hook :function must be an atom, got: #{inspect(other)}"}
+  defp normalize_function(other),
+    do: {:error, "module hook :function must be an atom, got: #{inspect(other)}"}
 
   @spec normalize_timeout(term()) :: {:ok, pos_integer()} | {:error, String.t()}
   defp normalize_timeout(nil), do: {:ok, @default_timeout_ms}

--- a/lib/minga_agent/hooks/hook.ex
+++ b/lib/minga_agent/hooks/hook.ex
@@ -20,6 +20,8 @@ defmodule MingaAgent.Hooks.Hook do
           | :session_end
           | :stop
           | :user_prompt_submit
+          | :pre_compact
+          | :notification
 
   @typedoc "Normalized hook declaration."
   @type t :: %__MODULE__{
@@ -88,6 +90,8 @@ defmodule MingaAgent.Hooks.Hook do
   def event_label(:session_end), do: "SessionEnd"
   def event_label(:stop), do: "Stop"
   def event_label(:user_prompt_submit), do: "UserPromptSubmit"
+  def event_label(:pre_compact), do: "PreCompact"
+  def event_label(:notification), do: "Notification"
 
   @spec map_from_list(list()) :: {:ok, map()} | :error
   defp map_from_list(raw) do
@@ -122,6 +126,14 @@ defmodule MingaAgent.Hooks.Hook do
   defp normalize_event(:UserPromptSubmit), do: {:ok, :user_prompt_submit}
   defp normalize_event("UserPromptSubmit"), do: {:ok, :user_prompt_submit}
   defp normalize_event("user_prompt_submit"), do: {:ok, :user_prompt_submit}
+  defp normalize_event(:pre_compact), do: {:ok, :pre_compact}
+  defp normalize_event(:PreCompact), do: {:ok, :pre_compact}
+  defp normalize_event("PreCompact"), do: {:ok, :pre_compact}
+  defp normalize_event("pre_compact"), do: {:ok, :pre_compact}
+  defp normalize_event(:notification), do: {:ok, :notification}
+  defp normalize_event(:Notification), do: {:ok, :notification}
+  defp normalize_event("Notification"), do: {:ok, :notification}
+  defp normalize_event("notification"), do: {:ok, :notification}
   defp normalize_event(other), do: {:error, "unsupported agent hook event: #{inspect(other)}"}
 
   @spec normalize_tool_pattern(map(), event()) :: {:ok, String.t() | nil} | {:error, String.t()}

--- a/lib/minga_agent/hooks/hook.ex
+++ b/lib/minga_agent/hooks/hook.ex
@@ -3,25 +3,27 @@ defmodule MingaAgent.Hooks.Hook do
   Normalized agent hook declaration.
 
   Hooks are declared in user config as maps or keyword lists, then normalized
-  by `MingaAgent.Config.resolve/0` into this struct. Only `:pre_tool_use` is
-  executable today, but the event field is explicit so later lifecycle events
-  can share the same config shape.
+  by `MingaAgent.Config.resolve/0` into this struct. The event field selects
+  the lifecycle point; `tool_pattern` is required only for tool-related events
+  (`:pre_tool_use`, `:post_tool_use`).
   """
 
   @default_timeout_ms 30_000
 
+  @tool_events [:pre_tool_use, :post_tool_use]
+
   @typedoc "Supported hook event names."
-  @type event :: :pre_tool_use
+  @type event :: :pre_tool_use | :post_tool_use
 
   @typedoc "Normalized hook declaration."
   @type t :: %__MODULE__{
           event: event(),
-          tool_pattern: String.t(),
+          tool_pattern: String.t() | nil,
           command: String.t(),
           timeout_ms: pos_integer()
         }
 
-  @enforce_keys [:event, :tool_pattern, :command]
+  @enforce_keys [:event, :command]
   defstruct [:event, :tool_pattern, :command, timeout_ms: @default_timeout_ms]
 
   @doc "Returns the default per-hook timeout in milliseconds."
@@ -39,7 +41,7 @@ defmodule MingaAgent.Hooks.Hook do
 
   def normalize(raw) when is_map(raw) do
     with {:ok, event} <- normalize_event(fetch(raw, :event)),
-         {:ok, tool_pattern} <- normalize_tool_pattern(raw),
+         {:ok, tool_pattern} <- normalize_tool_pattern(raw, event),
          {:ok, command} <- normalize_command(fetch(raw, :command)),
          {:ok, timeout_ms} <- normalize_timeout(fetch(raw, :timeout_ms)) do
       {:ok,
@@ -54,6 +56,11 @@ defmodule MingaAgent.Hooks.Hook do
 
   def normalize(_raw), do: {:error, "agent hook must be a map or keyword list"}
 
+  @doc "Returns true when this hook applies to the given non-tool event."
+  @spec matches?(t(), event()) :: boolean()
+  def matches?(%__MODULE__{event: event}, event), do: true
+  def matches?(%__MODULE__{}, _event), do: false
+
   @doc "Returns true when this hook applies to the event and tool name."
   @spec matches?(t(), event(), String.t()) :: boolean()
   def matches?(%__MODULE__{event: event, tool_pattern: pattern}, event, tool_name)
@@ -62,6 +69,15 @@ defmodule MingaAgent.Hooks.Hook do
   end
 
   def matches?(%__MODULE__{}, _event, _tool_name), do: false
+
+  @doc "Returns true if the event is tool-related and uses `tool_pattern` matching."
+  @spec tool_event?(event()) :: boolean()
+  def tool_event?(event), do: event in @tool_events
+
+  @doc "Returns the human-readable label for an event atom."
+  @spec event_label(event()) :: String.t()
+  def event_label(:pre_tool_use), do: "PreToolUse"
+  def event_label(:post_tool_use), do: "PostToolUse"
 
   @spec map_from_list(list()) :: {:ok, map()} | :error
   defp map_from_list(raw) do
@@ -76,14 +92,24 @@ defmodule MingaAgent.Hooks.Hook do
   defp normalize_event(:PreToolUse), do: {:ok, :pre_tool_use}
   defp normalize_event("PreToolUse"), do: {:ok, :pre_tool_use}
   defp normalize_event("pre_tool_use"), do: {:ok, :pre_tool_use}
+  defp normalize_event(:post_tool_use), do: {:ok, :post_tool_use}
+  defp normalize_event(:PostToolUse), do: {:ok, :post_tool_use}
+  defp normalize_event("PostToolUse"), do: {:ok, :post_tool_use}
+  defp normalize_event("post_tool_use"), do: {:ok, :post_tool_use}
   defp normalize_event(other), do: {:error, "unsupported agent hook event: #{inspect(other)}"}
 
-  @spec normalize_tool_pattern(map()) :: {:ok, String.t()} | {:error, String.t()}
-  defp normalize_tool_pattern(raw) do
-    raw
-    |> fetch(:tool_pattern)
-    |> fallback(fetch(raw, :tool))
-    |> normalize_non_empty_string("agent hook requires :tool_pattern or :tool")
+  @spec normalize_tool_pattern(map(), event()) :: {:ok, String.t() | nil} | {:error, String.t()}
+  defp normalize_tool_pattern(raw, event) do
+    value =
+      raw
+      |> fetch(:tool_pattern)
+      |> fallback(fetch(raw, :tool))
+
+    if event in @tool_events do
+      normalize_non_empty_string(value, "agent hook requires :tool_pattern or :tool")
+    else
+      {:ok, nil}
+    end
   end
 
   @spec normalize_command(term()) :: {:ok, String.t()} | {:error, String.t()}

--- a/lib/minga_agent/hooks/hook.ex
+++ b/lib/minga_agent/hooks/hook.ex
@@ -13,7 +13,7 @@ defmodule MingaAgent.Hooks.Hook do
   @tool_events [:pre_tool_use, :post_tool_use]
 
   @typedoc "Supported hook event names."
-  @type event :: :pre_tool_use | :post_tool_use
+  @type event :: :pre_tool_use | :post_tool_use | :session_start | :session_end
 
   @typedoc "Normalized hook declaration."
   @type t :: %__MODULE__{
@@ -78,6 +78,8 @@ defmodule MingaAgent.Hooks.Hook do
   @spec event_label(event()) :: String.t()
   def event_label(:pre_tool_use), do: "PreToolUse"
   def event_label(:post_tool_use), do: "PostToolUse"
+  def event_label(:session_start), do: "SessionStart"
+  def event_label(:session_end), do: "SessionEnd"
 
   @spec map_from_list(list()) :: {:ok, map()} | :error
   defp map_from_list(raw) do
@@ -96,6 +98,14 @@ defmodule MingaAgent.Hooks.Hook do
   defp normalize_event(:PostToolUse), do: {:ok, :post_tool_use}
   defp normalize_event("PostToolUse"), do: {:ok, :post_tool_use}
   defp normalize_event("post_tool_use"), do: {:ok, :post_tool_use}
+  defp normalize_event(:session_start), do: {:ok, :session_start}
+  defp normalize_event(:SessionStart), do: {:ok, :session_start}
+  defp normalize_event("SessionStart"), do: {:ok, :session_start}
+  defp normalize_event("session_start"), do: {:ok, :session_start}
+  defp normalize_event(:session_end), do: {:ok, :session_end}
+  defp normalize_event(:SessionEnd), do: {:ok, :session_end}
+  defp normalize_event("SessionEnd"), do: {:ok, :session_end}
+  defp normalize_event("session_end"), do: {:ok, :session_end}
   defp normalize_event(other), do: {:error, "unsupported agent hook event: #{inspect(other)}"}
 
   @spec normalize_tool_pattern(map(), event()) :: {:ok, String.t() | nil} | {:error, String.t()}

--- a/lib/minga_agent/hooks/hook.ex
+++ b/lib/minga_agent/hooks/hook.ex
@@ -23,16 +23,22 @@ defmodule MingaAgent.Hooks.Hook do
           | :pre_compact
           | :notification
 
+  @typedoc "Hook type: shell command or in-process Elixir module."
+  @type hook_type :: :shell | :module
+
   @typedoc "Normalized hook declaration."
   @type t :: %__MODULE__{
           event: event(),
+          type: hook_type(),
           tool_pattern: String.t() | nil,
-          command: String.t(),
+          command: String.t() | nil,
+          module: module() | nil,
+          function: atom() | nil,
           timeout_ms: pos_integer()
         }
 
-  @enforce_keys [:event, :command]
-  defstruct [:event, :tool_pattern, :command, timeout_ms: @default_timeout_ms]
+  @enforce_keys [:event]
+  defstruct [:event, :tool_pattern, :command, :module, :function, type: :shell, timeout_ms: @default_timeout_ms]
 
   @doc "Returns the default per-hook timeout in milliseconds."
   @spec default_timeout_ms() :: pos_integer()
@@ -49,16 +55,18 @@ defmodule MingaAgent.Hooks.Hook do
 
   def normalize(raw) when is_map(raw) do
     with {:ok, event} <- normalize_event(fetch(raw, :event)),
+         {:ok, type} <- normalize_type(raw),
          {:ok, tool_pattern} <- normalize_tool_pattern(raw, event),
-         {:ok, command} <- normalize_command(fetch(raw, :command)),
+         {:ok, fields} <- normalize_type_fields(raw, type),
          {:ok, timeout_ms} <- normalize_timeout(fetch(raw, :timeout_ms)) do
       {:ok,
        %__MODULE__{
          event: event,
+         type: type,
          tool_pattern: tool_pattern,
-         command: command,
          timeout_ms: timeout_ms
-       }}
+       }
+       |> Map.merge(fields)}
     end
   end
 
@@ -150,9 +158,63 @@ defmodule MingaAgent.Hooks.Hook do
     end
   end
 
-  @spec normalize_command(term()) :: {:ok, String.t()} | {:error, String.t()}
-  defp normalize_command(value),
-    do: normalize_non_empty_string(value, "agent hook requires :command")
+  @spec normalize_type(map()) :: {:ok, hook_type()} | {:error, String.t()}
+  defp normalize_type(raw) do
+    case fetch(raw, :type) do
+      nil ->
+        cond do
+          fetch(raw, :module) != nil -> {:ok, :module}
+          true -> {:ok, :shell}
+        end
+
+      :shell -> {:ok, :shell}
+      "shell" -> {:ok, :shell}
+      :module -> {:ok, :module}
+      "module" -> {:ok, :module}
+      other -> {:error, "agent hook type must be :shell or :module, got: #{inspect(other)}"}
+    end
+  end
+
+  @spec normalize_type_fields(map(), hook_type()) ::
+          {:ok, %{command: String.t()} | %{module: module(), function: atom()}}
+          | {:error, String.t()}
+  defp normalize_type_fields(raw, :shell) do
+    case normalize_non_empty_string(fetch(raw, :command), "shell hook requires :command") do
+      {:ok, command} -> {:ok, %{command: command}}
+      error -> error
+    end
+  end
+
+  defp normalize_type_fields(raw, :module) do
+    with {:ok, mod} <- normalize_module(fetch(raw, :module)),
+         {:ok, fun} <- normalize_function(fetch(raw, :function)) do
+      {:ok, %{module: mod, function: fun}}
+    end
+  end
+
+  @spec normalize_module(term()) :: {:ok, module()} | {:error, String.t()}
+  defp normalize_module(nil), do: {:error, "module hook requires :module"}
+  defp normalize_module(mod) when is_atom(mod), do: {:ok, mod}
+
+  defp normalize_module(mod) when is_binary(mod) do
+    {:ok, String.to_existing_atom("Elixir." <> mod)}
+  rescue
+    ArgumentError -> {:error, "module hook :module #{inspect(mod)} is not a loaded module"}
+  end
+
+  defp normalize_module(other), do: {:error, "module hook :module must be an atom, got: #{inspect(other)}"}
+
+  @spec normalize_function(term()) :: {:ok, atom()} | {:error, String.t()}
+  defp normalize_function(nil), do: {:error, "module hook requires :function"}
+  defp normalize_function(fun) when is_atom(fun), do: {:ok, fun}
+
+  defp normalize_function(fun) when is_binary(fun) do
+    {:ok, String.to_existing_atom(fun)}
+  rescue
+    ArgumentError -> {:error, "module hook :function #{inspect(fun)} is not a known atom"}
+  end
+
+  defp normalize_function(other), do: {:error, "module hook :function must be an atom, got: #{inspect(other)}"}
 
   @spec normalize_timeout(term()) :: {:ok, pos_integer()} | {:error, String.t()}
   defp normalize_timeout(nil), do: {:ok, @default_timeout_ms}

--- a/lib/minga_agent/hooks/module_runner.ex
+++ b/lib/minga_agent/hooks/module_runner.ex
@@ -1,0 +1,88 @@
+defmodule MingaAgent.Hooks.ModuleRunner do
+  @moduledoc """
+  Executes Elixir-module hooks in a monitored process with timeout enforcement.
+
+  Module hooks receive the payload map as a single argument and return
+  `:allow` or `{:veto, reason}`. The hook runs in a spawned process
+  (not linked) so crashes don't propagate to the caller.
+  """
+
+  alias MingaAgent.Hooks.Hook
+  alias MingaAgent.Hooks.Result
+
+  @doc "Runs a module hook with a payload map."
+  @spec run(Hook.t(), map()) :: Result.t()
+  def run(%Hook{type: :module, module: mod, function: fun} = hook, payload_map)
+      when is_atom(mod) and is_atom(fun) and is_map(payload_map) do
+    caller = self()
+    tag = make_ref()
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        result = apply(mod, fun, [payload_map])
+        send(caller, {tag, result})
+      end)
+
+    receive do
+      {^tag, :allow} ->
+        flush_down(ref)
+        Result.allow(hook)
+
+      {^tag, {:veto, reason}} when is_binary(reason) ->
+        flush_down(ref)
+        Result.veto(hook, reason, {:exit, 1})
+
+      {^tag, other} ->
+        flush_down(ref)
+
+        Result.veto(
+          hook,
+          "module hook returned unexpected value: #{inspect(other)}",
+          {:failed_to_start, :bad_return}
+        )
+
+      {:DOWN, ^ref, :process, ^pid, :normal} ->
+        Result.allow(hook)
+
+      {:DOWN, ^ref, :process, ^pid, reason} ->
+        Result.veto(
+          hook,
+          "module hook crashed: #{format_crash(reason)}",
+          {:failed_to_start, reason}
+        )
+    after
+      hook.timeout_ms ->
+        Process.exit(pid, :kill)
+        flush_down(ref)
+
+        Result.veto(
+          hook,
+          "#{Hook.event_label(hook.event)} module hook timed out after #{hook.timeout_ms}ms",
+          :timeout
+        )
+    end
+  rescue
+    e ->
+      Result.veto(
+        hook,
+        "module hook raised: #{Exception.message(e)}",
+        {:failed_to_start, e}
+      )
+  end
+
+  @spec flush_down(reference()) :: :ok
+  defp flush_down(ref) do
+    receive do
+      {:DOWN, ^ref, :process, _, _} -> :ok
+    after
+      0 -> :ok
+    end
+  end
+
+  @spec format_crash(term()) :: String.t()
+  defp format_crash({exception, _stacktrace}) when is_exception(exception) do
+    Exception.message(exception)
+  end
+
+  defp format_crash(reason), do: inspect(reason)
+end

--- a/lib/minga_agent/hooks/module_runner.ex
+++ b/lib/minga_agent/hooks/module_runner.ex
@@ -42,7 +42,11 @@ defmodule MingaAgent.Hooks.ModuleRunner do
         )
 
       {:DOWN, ^ref, :process, ^pid, :normal} ->
-        Result.allow(hook)
+        Result.veto(
+          hook,
+          "module hook exited without responding",
+          {:failed_to_start, :no_response}
+        )
 
       {:DOWN, ^ref, :process, ^pid, reason} ->
         Result.veto(

--- a/lib/minga_agent/hooks/notification_payload.ex
+++ b/lib/minga_agent/hooks/notification_payload.ex
@@ -1,0 +1,38 @@
+defmodule MingaAgent.Hooks.NotificationPayload do
+  @moduledoc """
+  Public payload passed to `Notification` hooks.
+
+  Sent to the hook command's stdin as JSON when the agent sends an OS
+  notification. Notification-only (never blocks).
+  """
+
+  @derive {Jason.Encoder, only: [:event, :session_id, :kind, :message]}
+  @enforce_keys [:session_id, :kind, :message]
+  defstruct [:session_id, :kind, :message, event: "Notification"]
+
+  @typedoc "Payload for an agent notification."
+  @type t :: %__MODULE__{
+          event: String.t(),
+          session_id: String.t(),
+          kind: String.t(),
+          message: String.t()
+        }
+
+  @doc "Builds a payload from session and notification fields."
+  @spec new(String.t(), atom(), String.t()) :: t()
+  def new(session_id, kind, message)
+      when is_binary(session_id) and is_atom(kind) and is_binary(message) do
+    %__MODULE__{session_id: session_id, kind: to_string(kind), message: message}
+  end
+
+  @doc "Converts the payload to the JSON object shape used on stdin."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = payload) do
+    %{
+      "event" => payload.event,
+      "session_id" => payload.session_id,
+      "kind" => payload.kind,
+      "message" => payload.message
+    }
+  end
+end

--- a/lib/minga_agent/hooks/post_tool_use_payload.ex
+++ b/lib/minga_agent/hooks/post_tool_use_payload.ex
@@ -77,6 +77,7 @@ defmodule MingaAgent.Hooks.PostToolUsePayload do
   defp truncate_result(result) when byte_size(result) <= @max_result_bytes, do: result
 
   defp truncate_result(result) do
-    String.slice(result, 0, @max_result_bytes) <> "\n... (truncated)"
+    truncated = String.byte_slice(result, 0, @max_result_bytes)
+    truncated <> "\n... (truncated)"
   end
 end

--- a/lib/minga_agent/hooks/post_tool_use_payload.ex
+++ b/lib/minga_agent/hooks/post_tool_use_payload.ex
@@ -8,7 +8,8 @@ defmodule MingaAgent.Hooks.PostToolUsePayload do
 
   @max_result_bytes 10_240
 
-  @derive {Jason.Encoder, only: [:event, :tool_call_id, :tool_name, :arguments, :result, :is_error]}
+  @derive {Jason.Encoder,
+           only: [:event, :tool_call_id, :tool_name, :arguments, :result, :is_error]}
   @enforce_keys [:tool_call_id, :tool_name, :arguments, :result, :is_error]
   defstruct [:tool_call_id, :tool_name, :arguments, :result, :is_error, event: "PostToolUse"]
 
@@ -76,6 +77,6 @@ defmodule MingaAgent.Hooks.PostToolUsePayload do
   defp truncate_result(result) when byte_size(result) <= @max_result_bytes, do: result
 
   defp truncate_result(result) do
-    binary_part(result, 0, @max_result_bytes) <> "\n... (truncated)"
+    String.slice(result, 0, @max_result_bytes) <> "\n... (truncated)"
   end
 end

--- a/lib/minga_agent/hooks/post_tool_use_payload.ex
+++ b/lib/minga_agent/hooks/post_tool_use_payload.ex
@@ -1,0 +1,81 @@
+defmodule MingaAgent.Hooks.PostToolUsePayload do
+  @moduledoc """
+  Public payload passed to `PostToolUse` hooks.
+
+  Sent to the hook command's stdin as JSON after a tool has finished executing.
+  The `result` field is truncated to avoid massive payloads from verbose tools.
+  """
+
+  @max_result_bytes 10_240
+
+  @derive {Jason.Encoder, only: [:event, :tool_call_id, :tool_name, :arguments, :result, :is_error]}
+  @enforce_keys [:tool_call_id, :tool_name, :arguments, :result, :is_error]
+  defstruct [:tool_call_id, :tool_name, :arguments, :result, :is_error, event: "PostToolUse"]
+
+  @typedoc "Payload for a tool call that just finished executing."
+  @type t :: %__MODULE__{
+          event: String.t(),
+          tool_call_id: String.t(),
+          tool_name: String.t(),
+          arguments: map(),
+          result: String.t(),
+          is_error: boolean()
+        }
+
+  @doc "Builds a payload from explicit tool call fields."
+  @spec new(String.t(), String.t(), map(), String.t(), boolean()) :: t()
+  def new(tool_call_id, tool_name, arguments, result, is_error)
+      when is_binary(tool_call_id) and is_binary(tool_name) and is_map(arguments) and
+             is_binary(result) and is_boolean(is_error) do
+    %__MODULE__{
+      tool_call_id: tool_call_id,
+      tool_name: tool_name,
+      arguments: arguments,
+      result: truncate_result(result),
+      is_error: is_error
+    }
+  end
+
+  @doc "Builds a payload from a map (e.g. from a tool call struct and its result)."
+  @spec new(map()) :: t()
+  def new(attrs) when is_map(attrs) do
+    %__MODULE__{
+      tool_call_id: normalize_id(value(attrs, :tool_call_id) || value(attrs, :id)),
+      tool_name: to_string(value(attrs, :tool_name) || value(attrs, :name)),
+      arguments: normalize_arguments(value(attrs, :arguments) || value(attrs, :args)),
+      result: truncate_result(to_string(value(attrs, :result) || "")),
+      is_error: value(attrs, :is_error) == true
+    }
+  end
+
+  @doc "Converts the payload to the JSON object shape used on stdin."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = payload) do
+    %{
+      "event" => payload.event,
+      "tool_call_id" => payload.tool_call_id,
+      "tool_name" => payload.tool_name,
+      "arguments" => payload.arguments,
+      "result" => payload.result,
+      "is_error" => payload.is_error
+    }
+  end
+
+  @spec value(map(), atom()) :: term()
+  defp value(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+
+  @spec normalize_id(term()) :: String.t()
+  defp normalize_id(nil), do: "tool_#{:erlang.unique_integer([:positive])}"
+  defp normalize_id(id), do: to_string(id)
+
+  @spec normalize_arguments(term()) :: map()
+  defp normalize_arguments(args) when is_map(args), do: args
+  defp normalize_arguments(_args), do: %{}
+
+  @spec truncate_result(String.t()) :: String.t()
+  defp truncate_result(result) when byte_size(result) <= @max_result_bytes, do: result
+
+  defp truncate_result(result) do
+    binary_part(result, 0, @max_result_bytes) <> "\n... (truncated)"
+  end
+end

--- a/lib/minga_agent/hooks/pre_compact_payload.ex
+++ b/lib/minga_agent/hooks/pre_compact_payload.ex
@@ -1,0 +1,35 @@
+defmodule MingaAgent.Hooks.PreCompactPayload do
+  @moduledoc """
+  Public payload passed to `PreCompact` hooks.
+
+  Sent to the hook command's stdin as JSON before context compaction runs.
+  A non-zero exit from the hook vetoes compaction (context stays as-is).
+  """
+
+  @derive {Jason.Encoder, only: [:event, :session_id, :message_count]}
+  @enforce_keys [:message_count]
+  defstruct [:session_id, :message_count, event: "PreCompact"]
+
+  @typedoc "Payload for a compaction about to run."
+  @type t :: %__MODULE__{
+          event: String.t(),
+          session_id: String.t() | nil,
+          message_count: non_neg_integer()
+        }
+
+  @doc "Builds a payload from context information."
+  @spec new(non_neg_integer(), String.t() | nil) :: t()
+  def new(message_count, session_id \\ nil) when is_integer(message_count) do
+    %__MODULE__{message_count: message_count, session_id: session_id}
+  end
+
+  @doc "Converts the payload to the JSON object shape used on stdin."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = payload) do
+    %{
+      "event" => payload.event,
+      "session_id" => payload.session_id,
+      "message_count" => payload.message_count
+    }
+  end
+end

--- a/lib/minga_agent/hooks/pre_compact_payload.ex
+++ b/lib/minga_agent/hooks/pre_compact_payload.ex
@@ -4,6 +4,9 @@ defmodule MingaAgent.Hooks.PreCompactPayload do
 
   Sent to the hook command's stdin as JSON before context compaction runs.
   A non-zero exit from the hook vetoes compaction (context stays as-is).
+
+  `session_id` is optional because compaction runs inside the provider
+  process (`native.ex`), which does not have direct access to the session ID.
   """
 
   @derive {Jason.Encoder, only: [:event, :session_id, :message_count]}

--- a/lib/minga_agent/hooks/result.ex
+++ b/lib/minga_agent/hooks/result.ex
@@ -42,6 +42,12 @@ defmodule MingaAgent.Hooks.Result do
     %__MODULE__{status: :veto, hook: hook, stderr: stderr, reason: reason}
   end
 
+  @doc "Builds a veto result for dispatch-level failures (no hook context available)."
+  @spec dispatch_error(String.t()) :: t()
+  def dispatch_error(detail) when is_binary(detail) do
+    %__MODULE__{status: :veto, stderr: "hook dispatch failed: #{detail}", reason: {:failed_to_start, :dispatch_error}}
+  end
+
   @doc "Returns a concise user-facing error for a veto result."
   @spec message(t()) :: String.t()
   def message(%__MODULE__{status: :veto, stderr: stderr, reason: :timeout, hook: hook}) do

--- a/lib/minga_agent/hooks/result.ex
+++ b/lib/minga_agent/hooks/result.ex
@@ -45,7 +45,11 @@ defmodule MingaAgent.Hooks.Result do
   @doc "Builds a veto result for dispatch-level failures (no hook context available)."
   @spec dispatch_error(String.t()) :: t()
   def dispatch_error(detail) when is_binary(detail) do
-    %__MODULE__{status: :veto, stderr: "hook dispatch failed: #{detail}", reason: {:failed_to_start, :dispatch_error}}
+    %__MODULE__{
+      status: :veto,
+      stderr: "hook dispatch failed: #{detail}",
+      reason: {:failed_to_start, :dispatch_error}
+    }
   end
 
   @doc "Returns a concise user-facing error for a veto result."

--- a/lib/minga_agent/hooks/result.ex
+++ b/lib/minga_agent/hooks/result.ex
@@ -45,23 +45,33 @@ defmodule MingaAgent.Hooks.Result do
   @doc "Returns a concise user-facing error for a veto result."
   @spec message(t()) :: String.t()
   def message(%__MODULE__{status: :veto, stderr: stderr, reason: :timeout, hook: hook}) do
+    label = event_label(hook)
+
     details =
-      non_empty(stderr) || "PreToolUse hook timed out after #{hook.timeout_ms}ms and was killed"
+      non_empty(stderr) || "#{label} hook timed out after #{hook.timeout_ms}ms and was killed"
 
-    "PreToolUse hook vetoed tool execution: #{details}"
+    "#{label} hook vetoed execution: #{details}"
   end
 
-  def message(%__MODULE__{status: :veto, stderr: stderr, reason: {:exit, status}}) do
+  def message(%__MODULE__{status: :veto, stderr: stderr, reason: {:exit, status}, hook: hook}) do
+    label = event_label(hook)
     details = non_empty(stderr) || "hook exited with status #{status}"
-    "PreToolUse hook vetoed tool execution: #{details}"
+    "#{label} hook vetoed execution: #{details}"
   end
 
-  def message(%__MODULE__{status: :veto, stderr: stderr}) do
+  def message(%__MODULE__{status: :veto, stderr: stderr, hook: hook}) do
+    label = event_label(hook)
     details = non_empty(stderr) || "hook failed"
-    "PreToolUse hook vetoed tool execution: #{details}"
+    "#{label} hook vetoed execution: #{details}"
   end
 
-  def message(%__MODULE__{}), do: "PreToolUse hook allowed tool execution"
+  def message(%__MODULE__{hook: hook}) do
+    "#{event_label(hook)} hook allowed execution"
+  end
+
+  @spec event_label(Hook.t() | nil) :: String.t()
+  defp event_label(%Hook{event: event}), do: Hook.event_label(event)
+  defp event_label(nil), do: "Hook"
 
   @spec non_empty(String.t()) :: String.t() | nil
   defp non_empty(text) do

--- a/lib/minga_agent/hooks/session_end_payload.ex
+++ b/lib/minga_agent/hooks/session_end_payload.ex
@@ -1,0 +1,47 @@
+defmodule MingaAgent.Hooks.SessionEndPayload do
+  @moduledoc """
+  Public payload passed to `SessionEnd` hooks.
+
+  Sent to the hook command's stdin as JSON when an agent session terminates.
+  """
+
+  @derive {Jason.Encoder, only: [:event, :session_id, :reason, :status]}
+  @enforce_keys [:session_id, :reason, :status]
+  defstruct [:session_id, :reason, :status, event: "SessionEnd"]
+
+  @typedoc "Payload for a session that just ended."
+  @type t :: %__MODULE__{
+          event: String.t(),
+          session_id: String.t(),
+          reason: String.t(),
+          status: String.t()
+        }
+
+  @doc "Builds a payload from session state and terminate reason."
+  @spec new(String.t(), term(), atom()) :: t()
+  def new(session_id, reason, status)
+      when is_binary(session_id) and is_atom(status) do
+    %__MODULE__{
+      session_id: session_id,
+      reason: normalize_reason(reason),
+      status: to_string(status)
+    }
+  end
+
+  @doc "Converts the payload to the JSON object shape used on stdin."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = payload) do
+    %{
+      "event" => payload.event,
+      "session_id" => payload.session_id,
+      "reason" => payload.reason,
+      "status" => payload.status
+    }
+  end
+
+  @spec normalize_reason(term()) :: String.t()
+  defp normalize_reason(:normal), do: "normal"
+  defp normalize_reason(:shutdown), do: "shutdown"
+  defp normalize_reason({:shutdown, _}), do: "shutdown"
+  defp normalize_reason(_other), do: "crash"
+end

--- a/lib/minga_agent/hooks/session_start_payload.ex
+++ b/lib/minga_agent/hooks/session_start_payload.ex
@@ -7,7 +7,7 @@ defmodule MingaAgent.Hooks.SessionStartPayload do
   """
 
   @derive {Jason.Encoder, only: [:event, :session_id, :model, :provider, :project_root]}
-  @enforce_keys [:session_id, :model, :provider, :project_root]
+  @enforce_keys [:session_id, :model, :provider]
   defstruct [:session_id, :model, :provider, :project_root, event: "SessionStart"]
 
   @typedoc "Payload for a session that just started."

--- a/lib/minga_agent/hooks/session_start_payload.ex
+++ b/lib/minga_agent/hooks/session_start_payload.ex
@@ -1,0 +1,52 @@
+defmodule MingaAgent.Hooks.SessionStartPayload do
+  @moduledoc """
+  Public payload passed to `SessionStart` hooks.
+
+  Sent to the hook command's stdin as JSON when an agent session's provider
+  becomes ready.
+  """
+
+  @derive {Jason.Encoder, only: [:event, :session_id, :model, :provider, :project_root]}
+  @enforce_keys [:session_id, :model, :provider, :project_root]
+  defstruct [:session_id, :model, :provider, :project_root, event: "SessionStart"]
+
+  @typedoc "Payload for a session that just started."
+  @type t :: %__MODULE__{
+          event: String.t(),
+          session_id: String.t(),
+          model: String.t(),
+          provider: String.t(),
+          project_root: String.t()
+        }
+
+  @doc "Builds a payload from session state fields."
+  @spec new(String.t(), String.t(), String.t()) :: t()
+  def new(session_id, model, provider)
+      when is_binary(session_id) and is_binary(model) and is_binary(provider) do
+    %__MODULE__{
+      session_id: session_id,
+      model: model,
+      provider: provider,
+      project_root: project_root()
+    }
+  end
+
+  @doc "Converts the payload to the JSON object shape used on stdin."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = payload) do
+    %{
+      "event" => payload.event,
+      "session_id" => payload.session_id,
+      "model" => payload.model,
+      "provider" => payload.provider,
+      "project_root" => payload.project_root
+    }
+  end
+
+  @spec project_root() :: String.t()
+  defp project_root do
+    File.cwd!()
+  rescue
+    _ -> ""
+  end
+end

--- a/lib/minga_agent/hooks/stop_payload.ex
+++ b/lib/minga_agent/hooks/stop_payload.ex
@@ -47,6 +47,6 @@ defmodule MingaAgent.Hooks.StopPayload do
   defp truncate_message(msg) when byte_size(msg) <= @max_message_bytes, do: msg
 
   defp truncate_message(msg) do
-    binary_part(msg, 0, @max_message_bytes) <> "\n... (truncated)"
+    String.slice(msg, 0, @max_message_bytes) <> "\n... (truncated)"
   end
 end

--- a/lib/minga_agent/hooks/stop_payload.ex
+++ b/lib/minga_agent/hooks/stop_payload.ex
@@ -1,0 +1,52 @@
+defmodule MingaAgent.Hooks.StopPayload do
+  @moduledoc """
+  Public payload passed to `Stop` hooks.
+
+  Sent to the hook command's stdin as JSON when the agent finishes a turn
+  and transitions to idle.
+  """
+
+  @max_message_bytes 1_024
+
+  @derive {Jason.Encoder, only: [:event, :session_id, :reason, :last_message]}
+  @enforce_keys [:session_id, :reason]
+  defstruct [:session_id, :reason, :last_message, event: "Stop"]
+
+  @typedoc "Payload for an agent turn that just completed."
+  @type t :: %__MODULE__{
+          event: String.t(),
+          session_id: String.t(),
+          reason: String.t(),
+          last_message: String.t() | nil
+        }
+
+  @doc "Builds a payload from session state fields."
+  @spec new(String.t(), atom(), String.t() | nil) :: t()
+  def new(session_id, reason, last_message \\ nil)
+      when is_binary(session_id) and is_atom(reason) do
+    %__MODULE__{
+      session_id: session_id,
+      reason: to_string(reason),
+      last_message: truncate_message(last_message)
+    }
+  end
+
+  @doc "Converts the payload to the JSON object shape used on stdin."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = payload) do
+    %{
+      "event" => payload.event,
+      "session_id" => payload.session_id,
+      "reason" => payload.reason,
+      "last_message" => payload.last_message
+    }
+  end
+
+  @spec truncate_message(String.t() | nil) :: String.t() | nil
+  defp truncate_message(nil), do: nil
+  defp truncate_message(msg) when byte_size(msg) <= @max_message_bytes, do: msg
+
+  defp truncate_message(msg) do
+    binary_part(msg, 0, @max_message_bytes) <> "\n... (truncated)"
+  end
+end

--- a/lib/minga_agent/hooks/stop_payload.ex
+++ b/lib/minga_agent/hooks/stop_payload.ex
@@ -47,6 +47,7 @@ defmodule MingaAgent.Hooks.StopPayload do
   defp truncate_message(msg) when byte_size(msg) <= @max_message_bytes, do: msg
 
   defp truncate_message(msg) do
-    String.slice(msg, 0, @max_message_bytes) <> "\n... (truncated)"
+    truncated = String.byte_slice(msg, 0, @max_message_bytes)
+    truncated <> "\n... (truncated)"
   end
 end

--- a/lib/minga_agent/hooks/user_prompt_submit_payload.ex
+++ b/lib/minga_agent/hooks/user_prompt_submit_payload.ex
@@ -1,0 +1,51 @@
+defmodule MingaAgent.Hooks.UserPromptSubmitPayload do
+  @moduledoc """
+  Public payload passed to `UserPromptSubmit` hooks.
+
+  Sent to the hook command's stdin as JSON before a user prompt is forwarded
+  to the LLM provider. A non-zero exit from the hook vetoes the prompt.
+  """
+
+  @derive {Jason.Encoder, only: [:event, :session_id, :prompt]}
+  @enforce_keys [:session_id, :prompt]
+  defstruct [:session_id, :prompt, event: "UserPromptSubmit"]
+
+  @typedoc "Payload for a user prompt about to be sent."
+  @type t :: %__MODULE__{
+          event: String.t(),
+          session_id: String.t(),
+          prompt: String.t()
+        }
+
+  @doc "Builds a payload from session_id and prompt content."
+  @spec new(String.t(), String.t() | [term()]) :: t()
+  def new(session_id, content) when is_binary(session_id) and is_binary(content) do
+    %__MODULE__{session_id: session_id, prompt: content}
+  end
+
+  def new(session_id, content) when is_binary(session_id) and is_list(content) do
+    %__MODULE__{session_id: session_id, prompt: extract_text(content)}
+  end
+
+  @doc "Converts the payload to the JSON object shape used on stdin."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = payload) do
+    %{
+      "event" => payload.event,
+      "session_id" => payload.session_id,
+      "prompt" => payload.prompt
+    }
+  end
+
+  @spec extract_text([term()]) :: String.t()
+  defp extract_text(parts) do
+    parts
+    |> Enum.reduce([], fn
+      %{type: :text, text: text}, acc when is_binary(text) -> [text | acc]
+      part, acc when is_binary(part) -> [part | acc]
+      _other, acc -> acc
+    end)
+    |> Enum.reverse()
+    |> Enum.join("\n")
+  end
+end

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -1554,6 +1554,10 @@ defmodule MingaAgent.Providers.Native do
       )
 
     HookDispatcher.post_tool_use(config.agent_hooks, PostToolUsePayload.to_map(payload))
+  rescue
+    e -> Minga.Log.warning(:agent, "PostToolUse hook dispatch failed: #{Exception.message(e)}")
+  catch
+    _, reason -> Minga.Log.warning(:agent, "PostToolUse hook dispatch failed: #{inspect(reason)}")
   end
 
   @spec dispatch_pre_compact(Context.t(), AgentConfig.t()) :: :ok | {:error, HookResult.t()}
@@ -1562,9 +1566,13 @@ defmodule MingaAgent.Providers.Native do
     payload = PreCompactPayload.new(message_count)
     HookDispatcher.pre_compact(config.agent_hooks, PreCompactPayload.to_map(payload))
   rescue
-    _ -> :ok
+    e ->
+      Minga.Log.warning(:agent, "PreCompact hook dispatch failed: #{Exception.message(e)}")
+      :ok
   catch
-    _, _ -> :ok
+    _, reason ->
+      Minga.Log.warning(:agent, "PreCompact hook dispatch failed: #{inspect(reason)}")
+      :ok
   end
 
   @spec emit_hook_veto(pid(), HookResult.t()) :: :ok

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -1568,11 +1568,11 @@ defmodule MingaAgent.Providers.Native do
   rescue
     e ->
       Minga.Log.warning(:agent, "PreCompact hook dispatch failed: #{Exception.message(e)}")
-      :ok
+      {:error, %HookResult{status: :veto, stderr: "hook dispatch failed: #{Exception.message(e)}"}}
   catch
     _, reason ->
       Minga.Log.warning(:agent, "PreCompact hook dispatch failed: #{inspect(reason)}")
-      :ok
+      {:error, %HookResult{status: :veto, stderr: "hook dispatch failed: #{inspect(reason)}"}}
   end
 
   @spec emit_hook_veto(pid(), HookResult.t()) :: :ok

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -39,6 +39,7 @@ defmodule MingaAgent.Providers.Native do
   alias MingaAgent.Event
   alias MingaAgent.Hooks.CommandRunner
   alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
+  alias MingaAgent.Hooks.PostToolUsePayload
   alias MingaAgent.Hooks.PreToolUsePayload
   alias MingaAgent.Hooks.Result, as: HookResult
   alias MingaAgent.Instructions
@@ -1181,6 +1182,7 @@ defmodule MingaAgent.Providers.Native do
            }}
         )
 
+        dispatch_post_tool_use(tool_call, result_text, is_error, config)
         maybe_emit_file_changed(provider_pid, tool_call, before_content, is_error)
 
         meta = if is_error, do: %{is_error: true}, else: %{}
@@ -1531,6 +1533,20 @@ defmodule MingaAgent.Providers.Native do
         emit_hook_veto(provider_pid, result)
         error
     end
+  end
+
+  @spec dispatch_post_tool_use(map(), String.t(), boolean(), AgentConfig.t()) :: :ok
+  defp dispatch_post_tool_use(tool_call, result_text, is_error, config) do
+    payload =
+      PostToolUsePayload.new(
+        to_string(tool_call.id),
+        to_string(tool_call.name),
+        tool_call.arguments || %{},
+        result_text,
+        is_error
+      )
+
+    HookDispatcher.post_tool_use(config.agent_hooks, PostToolUsePayload.to_map(payload))
   end
 
   @spec emit_hook_veto(pid(), HookResult.t()) :: :ok

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -1568,7 +1568,9 @@ defmodule MingaAgent.Providers.Native do
   rescue
     e ->
       Minga.Log.warning(:agent, "PreCompact hook dispatch failed: #{Exception.message(e)}")
-      {:error, %HookResult{status: :veto, stderr: "hook dispatch failed: #{Exception.message(e)}"}}
+
+      {:error,
+       %HookResult{status: :veto, stderr: "hook dispatch failed: #{Exception.message(e)}"}}
   catch
     _, reason ->
       Minga.Log.warning(:agent, "PreCompact hook dispatch failed: #{inspect(reason)}")

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -1568,13 +1568,11 @@ defmodule MingaAgent.Providers.Native do
   rescue
     e ->
       Minga.Log.warning(:agent, "PreCompact hook dispatch failed: #{Exception.message(e)}")
-
-      {:error,
-       %HookResult{status: :veto, stderr: "hook dispatch failed: #{Exception.message(e)}"}}
+      {:error, HookResult.dispatch_error(Exception.message(e))}
   catch
     _, reason ->
       Minga.Log.warning(:agent, "PreCompact hook dispatch failed: #{inspect(reason)}")
-      {:error, %HookResult{status: :veto, stderr: "hook dispatch failed: #{inspect(reason)}"}}
+      {:error, HookResult.dispatch_error(inspect(reason))}
   end
 
   @spec emit_hook_veto(pid(), HookResult.t()) :: :ok

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -40,6 +40,7 @@ defmodule MingaAgent.Providers.Native do
   alias MingaAgent.Hooks.CommandRunner
   alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
   alias MingaAgent.Hooks.PostToolUsePayload
+  alias MingaAgent.Hooks.PreCompactPayload
   alias MingaAgent.Hooks.PreToolUsePayload
   alias MingaAgent.Hooks.Result, as: HookResult
   alias MingaAgent.Instructions
@@ -549,21 +550,27 @@ defmodule MingaAgent.Providers.Native do
   end
 
   def handle_call(:compact, _from, state) do
-    compact_opts = [
-      model: state.model,
-      llm_client: summary_client(state.llm_client, state.config)
-    ]
+    case dispatch_pre_compact(state.context, state.config) do
+      :ok ->
+        compact_opts = [
+          model: state.model,
+          llm_client: summary_client(state.llm_client, state.config)
+        ]
 
-    case Compaction.compact(state.context, compact_opts) do
-      {:compacted, new_context, summary_info} ->
-        notify(state.subscriber, %Event.TextDelta{delta: "\n📦 #{summary_info}\n"})
-        {:reply, {:ok, summary_info}, %{state | context: new_context}}
+        case Compaction.compact(state.context, compact_opts) do
+          {:compacted, new_context, summary_info} ->
+            notify(state.subscriber, %Event.TextDelta{delta: "\n📦 #{summary_info}\n"})
+            {:reply, {:ok, summary_info}, %{state | context: new_context}}
 
-      {:ok, _context} ->
-        {:reply, {:ok, "Context is already small enough, no compaction needed."}, state}
+          {:ok, _context} ->
+            {:reply, {:ok, "Context is already small enough, no compaction needed."}, state}
 
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
+          {:error, reason} ->
+            {:reply, {:error, reason}, state}
+        end
+
+      {:error, _result} ->
+        {:reply, {:error, "compaction blocked by hook"}, state}
     end
   end
 
@@ -1549,6 +1556,17 @@ defmodule MingaAgent.Providers.Native do
     HookDispatcher.post_tool_use(config.agent_hooks, PostToolUsePayload.to_map(payload))
   end
 
+  @spec dispatch_pre_compact(Context.t(), AgentConfig.t()) :: :ok | {:error, HookResult.t()}
+  defp dispatch_pre_compact(context, config) do
+    message_count = length(context.messages)
+    payload = PreCompactPayload.new(message_count)
+    HookDispatcher.pre_compact(config.agent_hooks, PreCompactPayload.to_map(payload))
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
   @spec emit_hook_veto(pid(), HookResult.t()) :: :ok
   defp emit_hook_veto(provider_pid, %HookResult{} = result) do
     send(provider_pid, {:agent_event, %Event.Error{message: HookResult.message(result)}})
@@ -1634,6 +1652,17 @@ defmodule MingaAgent.Providers.Native do
   # Checks if context needs compaction and performs it, notifying the subscriber.
   @spec maybe_compact_context(loop_ctx(), Context.t()) :: Context.t()
   defp maybe_compact_context(lctx, context) do
+    case dispatch_pre_compact(context, lctx.config) do
+      :ok ->
+        do_maybe_compact(lctx, context)
+
+      {:error, _result} ->
+        context
+    end
+  end
+
+  @spec do_maybe_compact(loop_ctx(), Context.t()) :: Context.t()
+  defp do_maybe_compact(lctx, context) do
     compact_opts = [
       model: lctx.model,
       llm_client: summary_client(lctx.llm_client, lctx.config)

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1955,13 +1955,11 @@ defmodule MingaAgent.Session do
   rescue
     e ->
       Minga.Log.warning(:agent, "UserPromptSubmit hook dispatch failed: #{Exception.message(e)}")
-
-      {:error,
-       %HookResult{status: :veto, stderr: "hook dispatch failed: #{Exception.message(e)}"}}
+      {:error, HookResult.dispatch_error(Exception.message(e))}
   catch
     _, caught ->
       Minga.Log.warning(:agent, "UserPromptSubmit hook dispatch failed: #{inspect(caught)}")
-      {:error, %HookResult{status: :veto, stderr: "hook dispatch failed: #{inspect(caught)}"}}
+      {:error, HookResult.dispatch_error(inspect(caught))}
   end
 
   @spec extract_last_assistant_text([Message.t()]) :: String.t() | nil

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1955,7 +1955,9 @@ defmodule MingaAgent.Session do
   rescue
     e ->
       Minga.Log.warning(:agent, "UserPromptSubmit hook dispatch failed: #{Exception.message(e)}")
-      {:error, %HookResult{status: :veto, stderr: "hook dispatch failed: #{Exception.message(e)}"}}
+
+      {:error,
+       %HookResult{status: :veto, stderr: "hook dispatch failed: #{Exception.message(e)}"}}
   catch
     _, caught ->
       Minga.Log.warning(:agent, "UserPromptSubmit hook dispatch failed: #{inspect(caught)}")

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -25,6 +25,9 @@ defmodule MingaAgent.Session do
   alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.Credentials
   alias MingaAgent.Event
+  alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
+  alias MingaAgent.Hooks.SessionEndPayload
+  alias MingaAgent.Hooks.SessionStartPayload
   alias MingaAgent.Memory
   alias MingaAgent.Message
   alias MingaAgent.Notifier
@@ -1041,6 +1044,7 @@ defmodule MingaAgent.Session do
         state = %{state | provider: pid}
         state = apply_pending_thinking_level(state)
         state = maybe_show_auth_onboarding(state)
+        dispatch_session_start(state)
         {:noreply, state}
 
       {:error, reason} ->
@@ -1849,7 +1853,9 @@ defmodule MingaAgent.Session do
   end
 
   @impl GenServer
-  def terminate(reason, _state) do
+  def terminate(reason, state) do
+    dispatch_session_end(state, reason)
+
     case reason do
       :normal ->
         :ok
@@ -1866,5 +1872,27 @@ defmodule MingaAgent.Session do
           "[Agent.Session] crashed: #{inspect(reason, pretty: true, limit: 1000)}"
         )
     end
+  end
+
+  # ── Hook dispatching ──────────────────────────────────────────────────────
+
+  @spec dispatch_session_start(state()) :: :ok
+  defp dispatch_session_start(state) do
+    payload = SessionStartPayload.new(state.session_id, state.model_name, state.provider_name)
+    HookDispatcher.session_start(AgentConfig.resolve().agent_hooks, SessionStartPayload.to_map(payload))
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  @spec dispatch_session_end(state(), term()) :: :ok
+  defp dispatch_session_end(state, reason) do
+    payload = SessionEndPayload.new(state.session_id, reason, state.status)
+    HookDispatcher.session_end(AgentConfig.resolve().agent_hooks, SessionEndPayload.to_map(payload))
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
   end
 end

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1890,21 +1890,30 @@ defmodule MingaAgent.Session do
   @spec dispatch_session_start(state()) :: :ok
   defp dispatch_session_start(state) do
     payload = SessionStartPayload.new(state.session_id, state.model_name, state.provider_name)
-    HookDispatcher.session_start(AgentConfig.resolve().agent_hooks, SessionStartPayload.to_map(payload))
+
+    HookDispatcher.session_start(
+      AgentConfig.resolve().agent_hooks,
+      SessionStartPayload.to_map(payload)
+    )
   rescue
-    _ -> :ok
+    e -> Minga.Log.warning(:agent, "SessionStart hook dispatch failed: #{Exception.message(e)}")
   catch
-    _, _ -> :ok
+    _, reason ->
+      Minga.Log.warning(:agent, "SessionStart hook dispatch failed: #{inspect(reason)}")
   end
 
   @spec dispatch_session_end(state(), term()) :: :ok
   defp dispatch_session_end(state, reason) do
     payload = SessionEndPayload.new(state.session_id, reason, state.status)
-    HookDispatcher.session_end(AgentConfig.resolve().agent_hooks, SessionEndPayload.to_map(payload))
+
+    HookDispatcher.session_end(
+      AgentConfig.resolve().agent_hooks,
+      SessionEndPayload.to_map(payload)
+    )
   rescue
-    _ -> :ok
+    e -> Minga.Log.warning(:agent, "SessionEnd hook dispatch failed: #{Exception.message(e)}")
   catch
-    _, _ -> :ok
+    _, reason -> Minga.Log.warning(:agent, "SessionEnd hook dispatch failed: #{inspect(reason)}")
   end
 
   @spec dispatch_stop(state()) :: :ok
@@ -1913,19 +1922,24 @@ defmodule MingaAgent.Session do
     payload = StopPayload.new(state.session_id, :end_turn, last_message)
     HookDispatcher.stop(AgentConfig.resolve().agent_hooks, StopPayload.to_map(payload))
   rescue
-    _ -> :ok
+    e -> Minga.Log.warning(:agent, "Stop hook dispatch failed: #{Exception.message(e)}")
   catch
-    _, _ -> :ok
+    _, reason -> Minga.Log.warning(:agent, "Stop hook dispatch failed: #{inspect(reason)}")
   end
 
   @spec dispatch_notification(state(), atom(), String.t()) :: :ok
   defp dispatch_notification(state, trigger, message) do
     payload = NotificationPayload.new(state.session_id, trigger, message)
-    HookDispatcher.notification(AgentConfig.resolve().agent_hooks, NotificationPayload.to_map(payload))
+
+    HookDispatcher.notification(
+      AgentConfig.resolve().agent_hooks,
+      NotificationPayload.to_map(payload)
+    )
   rescue
-    _ -> :ok
+    e -> Minga.Log.warning(:agent, "Notification hook dispatch failed: #{Exception.message(e)}")
   catch
-    _, _ -> :ok
+    _, reason ->
+      Minga.Log.warning(:agent, "Notification hook dispatch failed: #{inspect(reason)}")
   end
 
   @spec dispatch_user_prompt_submit(state(), String.t() | [term()]) ::
@@ -1938,9 +1952,13 @@ defmodule MingaAgent.Session do
       UserPromptSubmitPayload.to_map(payload)
     )
   rescue
-    _ -> :ok
+    e ->
+      Minga.Log.warning(:agent, "UserPromptSubmit hook dispatch failed: #{Exception.message(e)}")
+      :ok
   catch
-    _, _ -> :ok
+    _, reason ->
+      Minga.Log.warning(:agent, "UserPromptSubmit hook dispatch failed: #{inspect(reason)}")
+      :ok
   end
 
   @spec extract_last_assistant_text([Message.t()]) :: String.t() | nil

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -28,7 +28,9 @@ defmodule MingaAgent.Session do
   alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
   alias MingaAgent.Hooks.SessionEndPayload
   alias MingaAgent.Hooks.SessionStartPayload
+  alias MingaAgent.Hooks.Result, as: HookResult
   alias MingaAgent.Hooks.StopPayload
+  alias MingaAgent.Hooks.UserPromptSubmitPayload
   alias MingaAgent.Memory
   alias MingaAgent.Message
   alias MingaAgent.Notifier
@@ -548,19 +550,22 @@ defmodule MingaAgent.Session do
   end
 
   def handle_call({:send_prompt, content}, _from, state) do
-    # Add user message to conversation.
-    # Content may be a plain string or a list of ContentPart structs
-    # (when images are attached via @image.png mentions).
-    {user_msg, send_content} = build_user_message(content)
-    state = append_msg(state, user_msg)
-    state = notify_messages_changed(state)
-
-    case state.provider_module.send_prompt(state.provider, send_content) do
+    case dispatch_user_prompt_submit(state, content) do
       :ok ->
-        {:reply, :ok, state}
+        {user_msg, send_content} = build_user_message(content)
+        state = append_msg(state, user_msg)
+        state = notify_messages_changed(state)
 
-      {:error, _} = err ->
-        {:reply, err, state}
+        case state.provider_module.send_prompt(state.provider, send_content) do
+          :ok ->
+            {:reply, :ok, state}
+
+          {:error, _} = err ->
+            {:reply, err, state}
+        end
+
+      {:error, %HookResult{} = result} ->
+        {:reply, {:error, {:hook_veto, HookResult.message(result)}}, state}
     end
   end
 
@@ -1904,6 +1909,21 @@ defmodule MingaAgent.Session do
     last_message = extract_last_assistant_text(state.messages)
     payload = StopPayload.new(state.session_id, :end_turn, last_message)
     HookDispatcher.stop(AgentConfig.resolve().agent_hooks, StopPayload.to_map(payload))
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  @spec dispatch_user_prompt_submit(state(), String.t() | [term()]) ::
+          :ok | {:error, HookResult.t()}
+  defp dispatch_user_prompt_submit(state, content) do
+    payload = UserPromptSubmitPayload.new(state.session_id, content)
+
+    HookDispatcher.user_prompt_submit(
+      AgentConfig.resolve().agent_hooks,
+      UserPromptSubmitPayload.to_map(payload)
+    )
   rescue
     _ -> :ok
   catch

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -28,6 +28,7 @@ defmodule MingaAgent.Session do
   alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
   alias MingaAgent.Hooks.SessionEndPayload
   alias MingaAgent.Hooks.SessionStartPayload
+  alias MingaAgent.Hooks.NotificationPayload
   alias MingaAgent.Hooks.Result, as: HookResult
   alias MingaAgent.Hooks.StopPayload
   alias MingaAgent.Hooks.UserPromptSubmitPayload
@@ -1269,11 +1270,13 @@ defmodule MingaAgent.Session do
   defp completion_notification(_state), do: "Agent finished"
 
   @spec notify(state(), atom(), String.t()) :: :ok
-  defp notify(%{notifier: {module, arg}}, trigger, message) when is_atom(module) do
+  defp notify(%{notifier: {module, arg}} = state, trigger, message) when is_atom(module) do
+    dispatch_notification(state, trigger, message)
     module.notify(trigger, message, arg)
   end
 
-  defp notify(%{notifier: module}, trigger, message) when is_atom(module) do
+  defp notify(%{notifier: module} = state, trigger, message) when is_atom(module) do
+    dispatch_notification(state, trigger, message)
     module.notify(trigger, message)
   end
 
@@ -1909,6 +1912,16 @@ defmodule MingaAgent.Session do
     last_message = extract_last_assistant_text(state.messages)
     payload = StopPayload.new(state.session_id, :end_turn, last_message)
     HookDispatcher.stop(AgentConfig.resolve().agent_hooks, StopPayload.to_map(payload))
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  @spec dispatch_notification(state(), atom(), String.t()) :: :ok
+  defp dispatch_notification(state, trigger, message) do
+    payload = NotificationPayload.new(state.session_id, trigger, message)
+    HookDispatcher.notification(AgentConfig.resolve().agent_hooks, NotificationPayload.to_map(payload))
   rescue
     _ -> :ok
   catch

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1955,11 +1955,11 @@ defmodule MingaAgent.Session do
   rescue
     e ->
       Minga.Log.warning(:agent, "UserPromptSubmit hook dispatch failed: #{Exception.message(e)}")
-      :ok
+      {:error, %HookResult{status: :veto, stderr: "hook dispatch failed: #{Exception.message(e)}"}}
   catch
-    _, reason ->
-      Minga.Log.warning(:agent, "UserPromptSubmit hook dispatch failed: #{inspect(reason)}")
-      :ok
+    _, caught ->
+      Minga.Log.warning(:agent, "UserPromptSubmit hook dispatch failed: #{inspect(caught)}")
+      {:error, %HookResult{status: :veto, stderr: "hook dispatch failed: #{inspect(caught)}"}}
   end
 
   @spec extract_last_assistant_text([Message.t()]) :: String.t() | nil

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -28,6 +28,7 @@ defmodule MingaAgent.Session do
   alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
   alias MingaAgent.Hooks.SessionEndPayload
   alias MingaAgent.Hooks.SessionStartPayload
+  alias MingaAgent.Hooks.StopPayload
   alias MingaAgent.Memory
   alias MingaAgent.Message
   alias MingaAgent.Notifier
@@ -1110,6 +1111,8 @@ defmodule MingaAgent.Session do
         state
       end
 
+    dispatch_stop(state)
+
     # Collect pending messages from both queues. Steering messages that arrived
     # after the last tool call (or just before AgentEnd) would otherwise be
     # orphaned because dequeue_steering is only called between tool calls during
@@ -1894,5 +1897,26 @@ defmodule MingaAgent.Session do
     _ -> :ok
   catch
     _, _ -> :ok
+  end
+
+  @spec dispatch_stop(state()) :: :ok
+  defp dispatch_stop(state) do
+    last_message = extract_last_assistant_text(state.messages)
+    payload = StopPayload.new(state.session_id, :end_turn, last_message)
+    HookDispatcher.stop(AgentConfig.resolve().agent_hooks, StopPayload.to_map(payload))
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  @spec extract_last_assistant_text([Message.t()]) :: String.t() | nil
+  defp extract_last_assistant_text(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value(fn
+      %{role: :assistant, content: content} when is_binary(content) -> content
+      _ -> nil
+    end)
   end
 end

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -1913,7 +1913,8 @@ defmodule MingaAgent.Session do
   rescue
     e -> Minga.Log.warning(:agent, "SessionEnd hook dispatch failed: #{Exception.message(e)}")
   catch
-    _, reason -> Minga.Log.warning(:agent, "SessionEnd hook dispatch failed: #{inspect(reason)}")
+    _, caught ->
+      Minga.Log.warning(:agent, "SessionEnd hook dispatch failed: #{inspect(caught)}")
   end
 
   @spec dispatch_stop(state()) :: :ok
@@ -1966,7 +1967,7 @@ defmodule MingaAgent.Session do
     messages
     |> Enum.reverse()
     |> Enum.find_value(fn
-      %{role: :assistant, content: content} when is_binary(content) -> content
+      {:assistant, content} when is_binary(content) -> content
       _ -> nil
     end)
   end

--- a/lib/minga_agent/tool/executor.ex
+++ b/lib/minga_agent/tool/executor.ex
@@ -29,6 +29,7 @@ defmodule MingaAgent.Tool.Executor do
   alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.Hooks.CommandRunner
   alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
+  alias MingaAgent.Hooks.PostToolUsePayload
   alias MingaAgent.Hooks.PreToolUsePayload
   alias MingaAgent.Hooks.Result, as: HookResult
   alias MingaAgent.Tool.PlanMode
@@ -145,8 +146,13 @@ defmodule MingaAgent.Tool.Executor do
           {:ok, term()} | {:error, term()}
   defp run_callback(%Spec{} = spec, args, config, hook_runner) do
     case dispatch_pre_tool_use(spec, args, config, hook_runner) do
-      :ok -> run_callback_with_advice(spec, args)
-      {:error, %HookResult{} = result} -> {:error, {:hook_veto, HookResult.message(result)}}
+      :ok ->
+        result = run_callback_with_advice(spec, args)
+        dispatch_post_tool_use(spec, args, result, config)
+        result
+
+      {:error, %HookResult{} = result} ->
+        {:error, {:hook_veto, HookResult.message(result)}}
     end
   end
 
@@ -167,6 +173,27 @@ defmodule MingaAgent.Tool.Executor do
       PreToolUsePayload.new("direct_#{:erlang.unique_integer([:positive])}", spec.name, args)
 
     HookDispatcher.pre_tool_use(config.agent_hooks, payload, runner: hook_runner)
+  end
+
+  @spec dispatch_post_tool_use(Spec.t(), map(), {:ok, term()} | {:error, term()}, AgentConfig.t()) ::
+          :ok
+  defp dispatch_post_tool_use(%Spec{} = spec, args, result, config) do
+    {result_text, is_error} =
+      case result do
+        {:ok, value} -> {inspect(value), false}
+        {:error, reason} -> {inspect(reason), true}
+      end
+
+    payload =
+      PostToolUsePayload.new(
+        "direct_#{:erlang.unique_integer([:positive])}",
+        spec.name,
+        args,
+        result_text,
+        is_error
+      )
+
+    HookDispatcher.post_tool_use(config.agent_hooks, PostToolUsePayload.to_map(payload))
   end
 
   @spec execute_with_advice(Spec.t(), map(), atom()) :: {:ok, term()} | {:error, term()}

--- a/lib/minga_agent/tool/executor.ex
+++ b/lib/minga_agent/tool/executor.ex
@@ -194,6 +194,10 @@ defmodule MingaAgent.Tool.Executor do
       )
 
     HookDispatcher.post_tool_use(config.agent_hooks, PostToolUsePayload.to_map(payload))
+  rescue
+    e -> Minga.Log.warning(:agent, "PostToolUse hook dispatch failed: #{Exception.message(e)}")
+  catch
+    _, reason -> Minga.Log.warning(:agent, "PostToolUse hook dispatch failed: #{inspect(reason)}")
   end
 
   @spec execute_with_advice(Spec.t(), map(), atom()) :: {:ok, term()} | {:error, term()}

--- a/test/minga_agent/hooks/dispatcher_test.exs
+++ b/test/minga_agent/hooks/dispatcher_test.exs
@@ -322,6 +322,62 @@ defmodule MingaAgent.Hooks.DispatcherTest do
     assert_receive :ups_ran
   end
 
+  # ── PreCompact ──────────────────────────────────────────────────────────────
+
+  test "PreCompact hooks can veto compaction" do
+    hook = session_hook(:pre_compact)
+
+    runner = fn received_hook, _payload_map ->
+      Result.veto(received_hook, "preserve context", {:exit, 1})
+    end
+
+    payload = %{"event" => "PreCompact", "message_count" => 50}
+
+    assert {:error, %Result{status: :veto}} =
+             Dispatcher.pre_compact([hook], payload, runner: runner)
+  end
+
+  test "PreCompact hooks proceed when allowed" do
+    test_pid = self()
+    hook = session_hook(:pre_compact)
+
+    runner = fn received_hook, _payload_map ->
+      send(test_pid, :compact_allowed)
+      Result.allow(received_hook)
+    end
+
+    payload = %{"event" => "PreCompact", "message_count" => 10}
+    assert :ok = Dispatcher.pre_compact([hook], payload, runner: runner)
+    assert_receive :compact_allowed
+  end
+
+  # ── Notification ───────────────────────────────────────────────────────────
+
+  test "Notification hooks run and are notification-only" do
+    test_pid = self()
+    hook = session_hook(:notification)
+
+    runner = fn received_hook, _payload_map ->
+      send(test_pid, :notif_ran)
+      Result.allow(received_hook)
+    end
+
+    payload = %{"event" => "Notification", "session_id" => "s_n", "kind" => "complete", "message" => "done"}
+    assert :ok = Dispatcher.notification([hook], payload, runner: runner)
+    assert_receive :notif_ran
+  end
+
+  test "Notification veto is ignored" do
+    hook = session_hook(:notification)
+
+    runner = fn received_hook, _payload_map ->
+      Result.veto(received_hook, "blocked", {:exit, 1})
+    end
+
+    payload = %{"event" => "Notification", "session_id" => "s_n2", "kind" => "error", "message" => "fail"}
+    assert :ok = Dispatcher.notification([hook], payload, runner: runner)
+  end
+
   # ── Normalization ──────────────────────────────────────────────────────────
 
   test "Session hooks do not require tool_pattern" do

--- a/test/minga_agent/hooks/dispatcher_test.exs
+++ b/test/minga_agent/hooks/dispatcher_test.exs
@@ -302,7 +302,11 @@ defmodule MingaAgent.Hooks.DispatcherTest do
       Result.veto(received_hook, "blocked by policy", {:exit, 1})
     end
 
-    payload = %{"event" => "UserPromptSubmit", "session_id" => "s_ups", "prompt" => "do something"}
+    payload = %{
+      "event" => "UserPromptSubmit",
+      "session_id" => "s_ups",
+      "prompt" => "do something"
+    }
 
     assert {:error, %Result{status: :veto, stderr: "blocked by policy"}} =
              Dispatcher.user_prompt_submit([hook], payload, runner: runner)
@@ -362,7 +366,13 @@ defmodule MingaAgent.Hooks.DispatcherTest do
       Result.allow(received_hook)
     end
 
-    payload = %{"event" => "Notification", "session_id" => "s_n", "kind" => "complete", "message" => "done"}
+    payload = %{
+      "event" => "Notification",
+      "session_id" => "s_n",
+      "kind" => "complete",
+      "message" => "done"
+    }
+
     assert :ok = Dispatcher.notification([hook], payload, runner: runner)
     assert_receive :notif_ran
   end
@@ -374,7 +384,13 @@ defmodule MingaAgent.Hooks.DispatcherTest do
       Result.veto(received_hook, "blocked", {:exit, 1})
     end
 
-    payload = %{"event" => "Notification", "session_id" => "s_n2", "kind" => "error", "message" => "fail"}
+    payload = %{
+      "event" => "Notification",
+      "session_id" => "s_n2",
+      "kind" => "error",
+      "message" => "fail"
+    }
+
     assert :ok = Dispatcher.notification([hook], payload, runner: runner)
   end
 

--- a/test/minga_agent/hooks/dispatcher_test.exs
+++ b/test/minga_agent/hooks/dispatcher_test.exs
@@ -3,6 +3,7 @@ defmodule MingaAgent.Hooks.DispatcherTest do
 
   alias MingaAgent.Hooks.Dispatcher
   alias MingaAgent.Hooks.Hook
+  alias MingaAgent.Hooks.PostToolUsePayload
   alias MingaAgent.Hooks.PreToolUsePayload
   alias MingaAgent.Hooks.Result
 
@@ -114,7 +115,121 @@ defmodule MingaAgent.Hooks.DispatcherTest do
     assert {:error, "agent hook must be a map or keyword list"} = Hook.normalize(["bad"])
   end
 
+  # ── PostToolUse ──────────────────────────────────────────────────────────────
+
+  test "PostToolUse hooks run after tool execution" do
+    test_pid = self()
+    hook = post_hook("read_file")
+    payload = PostToolUsePayload.new("tc_post_1", "read_file", %{}, "result", false)
+
+    runner = fn received_hook, _payload_map ->
+      send(test_pid, :post_hook_ran)
+      Result.allow(received_hook)
+    end
+
+    assert :ok =
+             Dispatcher.post_tool_use([hook], PostToolUsePayload.to_map(payload), runner: runner)
+
+    assert_receive :post_hook_ran
+  end
+
+  test "PostToolUse veto is ignored (notification-only)" do
+    hook = post_hook("*")
+    payload = PostToolUsePayload.new("tc_post_2", "shell", %{}, "result", false)
+
+    runner = fn received_hook, _payload_map ->
+      Result.veto(received_hook, "tried to block", {:exit, 1})
+    end
+
+    assert :ok =
+             Dispatcher.post_tool_use([hook], PostToolUsePayload.to_map(payload), runner: runner)
+  end
+
+  test "PostToolUse non-matching hooks do not run" do
+    test_pid = self()
+    hook = post_hook("write_file")
+    payload = PostToolUsePayload.new("tc_post_3", "read_file", %{}, "result", false)
+
+    runner = fn received_hook, _payload_map ->
+      send(test_pid, :unexpected)
+      Result.allow(received_hook)
+    end
+
+    Dispatcher.post_tool_use([hook], PostToolUsePayload.to_map(payload), runner: runner)
+    refute_receive :unexpected, 20
+  end
+
+  test "PostToolUse broadcasts lifecycle events" do
+    Minga.Events.subscribe(:agent_hook)
+
+    hook = post_hook("shell")
+    payload = PostToolUsePayload.new("tc_post_event", "shell", %{"cmd" => "ls"}, "ok", false)
+
+    runner = fn received_hook, _payload_map -> Result.allow(received_hook) end
+
+    Dispatcher.post_tool_use([hook], PostToolUsePayload.to_map(payload), runner: runner)
+
+    assert_receive {:minga_event, :agent_hook,
+                    %Minga.Events.AgentHookEvent{
+                      event: "PostToolUse",
+                      phase: :started,
+                      tool_name: "shell",
+                      tool_call_id: "tc_post_event"
+                    }}
+
+    assert_receive {:minga_event, :agent_hook,
+                    %Minga.Events.AgentHookEvent{
+                      event: "PostToolUse",
+                      phase: :allowed,
+                      tool_name: "shell",
+                      tool_call_id: "tc_post_event"
+                    }}
+  end
+
+  test "PostToolUse normalization accepts PostToolUse event name variants" do
+    assert {:ok, %Hook{event: :post_tool_use}} =
+             Hook.normalize(%{event: "PostToolUse", tool: "shell", command: "echo ok"})
+
+    assert {:ok, %Hook{event: :post_tool_use}} =
+             Hook.normalize(%{event: :post_tool_use, tool: "*", command: "echo ok"})
+  end
+
+  # ── generic dispatch ───────────────────────────────────────────────────────
+
+  test "dispatch/4 with veto_capable: false ignores veto and continues" do
+    test_pid = self()
+    hook1 = %Hook{event: :post_tool_use, tool_pattern: "*", command: "echo first"}
+    hook2 = %Hook{event: :post_tool_use, tool_pattern: "*", command: "echo second"}
+
+    runner = fn hook, _map ->
+      case hook.command do
+        "echo first" ->
+          send(test_pid, :first)
+          Result.veto(hook, "nope", {:exit, 1})
+
+        "echo second" ->
+          send(test_pid, :second)
+          Result.allow(hook)
+      end
+    end
+
+    payload_map = %{"tool_name" => "shell", "tool_call_id" => "tc_gen"}
+
+    assert :ok =
+             Dispatcher.dispatch(:post_tool_use, [hook1, hook2], payload_map,
+               runner: runner,
+               veto_capable: false
+             )
+
+    assert_receive :first
+    assert_receive :second
+  end
+
   defp hook(pattern) do
     %Hook{event: :pre_tool_use, tool_pattern: pattern, command: "echo checking >&2"}
+  end
+
+  defp post_hook(pattern) do
+    %Hook{event: :post_tool_use, tool_pattern: pattern, command: "echo post >&2"}
   end
 end

--- a/test/minga_agent/hooks/dispatcher_test.exs
+++ b/test/minga_agent/hooks/dispatcher_test.exs
@@ -266,6 +266,35 @@ defmodule MingaAgent.Hooks.DispatcherTest do
     assert :ok = Dispatcher.session_start([hook], payload, runner: runner)
   end
 
+  # ── Stop ────────────────────────────────────────────────────────────────────
+
+  test "Stop hooks run and are notification-only" do
+    test_pid = self()
+    hook = session_hook(:stop)
+
+    runner = fn received_hook, _payload_map ->
+      send(test_pid, :stop_ran)
+      Result.allow(received_hook)
+    end
+
+    payload = %{"event" => "Stop", "session_id" => "s_stop", "reason" => "end_turn"}
+    assert :ok = Dispatcher.stop([hook], payload, runner: runner)
+    assert_receive :stop_ran
+  end
+
+  test "Stop veto is ignored" do
+    hook = session_hook(:stop)
+
+    runner = fn received_hook, _payload_map ->
+      Result.veto(received_hook, "blocked", {:exit, 1})
+    end
+
+    payload = %{"event" => "Stop", "session_id" => "s_stop2"}
+    assert :ok = Dispatcher.stop([hook], payload, runner: runner)
+  end
+
+  # ── Normalization ──────────────────────────────────────────────────────────
+
   test "Session hooks do not require tool_pattern" do
     assert {:ok, %Hook{event: :session_start, tool_pattern: nil}} =
              Hook.normalize(%{event: "SessionStart", command: "echo start"})

--- a/test/minga_agent/hooks/dispatcher_test.exs
+++ b/test/minga_agent/hooks/dispatcher_test.exs
@@ -293,6 +293,35 @@ defmodule MingaAgent.Hooks.DispatcherTest do
     assert :ok = Dispatcher.stop([hook], payload, runner: runner)
   end
 
+  # ── UserPromptSubmit ────────────────────────────────────────────────────────
+
+  test "UserPromptSubmit hooks run and can veto" do
+    hook = session_hook(:user_prompt_submit)
+
+    runner = fn received_hook, _payload_map ->
+      Result.veto(received_hook, "blocked by policy", {:exit, 1})
+    end
+
+    payload = %{"event" => "UserPromptSubmit", "session_id" => "s_ups", "prompt" => "do something"}
+
+    assert {:error, %Result{status: :veto, stderr: "blocked by policy"}} =
+             Dispatcher.user_prompt_submit([hook], payload, runner: runner)
+  end
+
+  test "UserPromptSubmit hooks proceed when allowed" do
+    test_pid = self()
+    hook = session_hook(:user_prompt_submit)
+
+    runner = fn received_hook, _payload_map ->
+      send(test_pid, :ups_ran)
+      Result.allow(received_hook)
+    end
+
+    payload = %{"event" => "UserPromptSubmit", "session_id" => "s_ups2", "prompt" => "hello"}
+    assert :ok = Dispatcher.user_prompt_submit([hook], payload, runner: runner)
+    assert_receive :ups_ran
+  end
+
   # ── Normalization ──────────────────────────────────────────────────────────
 
   test "Session hooks do not require tool_pattern" do

--- a/test/minga_agent/hooks/dispatcher_test.exs
+++ b/test/minga_agent/hooks/dispatcher_test.exs
@@ -225,11 +225,64 @@ defmodule MingaAgent.Hooks.DispatcherTest do
     assert_receive :second
   end
 
+  # ── SessionStart / SessionEnd ────────────────────────────────────────────────
+
+  test "SessionStart hooks run and are notification-only" do
+    test_pid = self()
+    hook = session_hook(:session_start)
+
+    runner = fn received_hook, _payload_map ->
+      send(test_pid, :session_start_ran)
+      Result.allow(received_hook)
+    end
+
+    payload = %{"event" => "SessionStart", "session_id" => "s1"}
+    assert :ok = Dispatcher.session_start([hook], payload, runner: runner)
+    assert_receive :session_start_ran
+  end
+
+  test "SessionEnd hooks run and are notification-only" do
+    test_pid = self()
+    hook = session_hook(:session_end)
+
+    runner = fn received_hook, _payload_map ->
+      send(test_pid, :session_end_ran)
+      Result.allow(received_hook)
+    end
+
+    payload = %{"event" => "SessionEnd", "session_id" => "s2", "reason" => "normal"}
+    assert :ok = Dispatcher.session_end([hook], payload, runner: runner)
+    assert_receive :session_end_ran
+  end
+
+  test "SessionStart veto is ignored" do
+    hook = session_hook(:session_start)
+
+    runner = fn received_hook, _payload_map ->
+      Result.veto(received_hook, "blocked", {:exit, 1})
+    end
+
+    payload = %{"event" => "SessionStart", "session_id" => "s3"}
+    assert :ok = Dispatcher.session_start([hook], payload, runner: runner)
+  end
+
+  test "Session hooks do not require tool_pattern" do
+    assert {:ok, %Hook{event: :session_start, tool_pattern: nil}} =
+             Hook.normalize(%{event: "SessionStart", command: "echo start"})
+
+    assert {:ok, %Hook{event: :session_end, tool_pattern: nil}} =
+             Hook.normalize(%{event: "SessionEnd", command: "echo end"})
+  end
+
   defp hook(pattern) do
     %Hook{event: :pre_tool_use, tool_pattern: pattern, command: "echo checking >&2"}
   end
 
   defp post_hook(pattern) do
     %Hook{event: :post_tool_use, tool_pattern: pattern, command: "echo post >&2"}
+  end
+
+  defp session_hook(event) do
+    %Hook{event: event, tool_pattern: nil, command: "echo hook >&2"}
   end
 end

--- a/test/minga_agent/hooks/dispatcher_test.exs
+++ b/test/minga_agent/hooks/dispatcher_test.exs
@@ -404,6 +404,23 @@ defmodule MingaAgent.Hooks.DispatcherTest do
              Hook.normalize(%{event: "SessionEnd", command: "echo end"})
   end
 
+  test "event aliases normalize all supported events" do
+    for {atom_form, string_form} <- [
+          {:session_start, "SessionStart"},
+          {:session_end, "SessionEnd"},
+          {:stop, "Stop"},
+          {:user_prompt_submit, "UserPromptSubmit"},
+          {:pre_compact, "PreCompact"},
+          {:notification, "Notification"}
+        ] do
+      assert {:ok, %Hook{event: ^atom_form}} =
+               Hook.normalize(%{event: string_form, command: "echo ok"})
+
+      assert {:ok, %Hook{event: ^atom_form}} =
+               Hook.normalize(%{event: atom_form, command: "echo ok"})
+    end
+  end
+
   defp hook(pattern) do
     %Hook{event: :pre_tool_use, tool_pattern: pattern, command: "echo checking >&2"}
   end

--- a/test/minga_agent/hooks/module_runner_test.exs
+++ b/test/minga_agent/hooks/module_runner_test.exs
@@ -1,0 +1,123 @@
+defmodule MingaAgent.Hooks.ModuleRunnerTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Hooks.Hook
+  alias MingaAgent.Hooks.ModuleRunner
+  alias MingaAgent.Hooks.Result
+
+  defmodule AllowPolicy do
+    @spec check(map()) :: :allow
+    def check(_payload), do: :allow
+  end
+
+  defmodule VetoPolicy do
+    @spec check(map()) :: {:veto, String.t()}
+    def check(_payload), do: {:veto, "blocked by policy"}
+  end
+
+  defmodule SlowPolicy do
+    @spec check(map()) :: :allow
+    def check(_payload) do
+      Process.sleep(5_000)
+      :allow
+    end
+  end
+
+  defmodule CrashPolicy do
+    @spec check(map()) :: no_return()
+    def check(_payload), do: raise("boom")
+  end
+
+  defmodule BadReturnPolicy do
+    @spec check(map()) :: :bad
+    def check(_payload), do: :bad
+  end
+
+  test "allows when module returns :allow" do
+    hook = module_hook(AllowPolicy, :check)
+    result = ModuleRunner.run(hook, %{"event" => "PreToolUse", "tool_name" => "shell"})
+
+    assert %Result{status: :allow, hook: ^hook} = result
+  end
+
+  test "vetoes when module returns {:veto, reason}" do
+    hook = module_hook(VetoPolicy, :check)
+    result = ModuleRunner.run(hook, %{"event" => "PreToolUse", "tool_name" => "shell"})
+
+    assert %Result{status: :veto, stderr: "blocked by policy"} = result
+  end
+
+  test "vetoes on timeout" do
+    hook = module_hook(SlowPolicy, :check, 50)
+    result = ModuleRunner.run(hook, %{"event" => "PreToolUse"})
+
+    assert %Result{status: :veto, reason: :timeout} = result
+    assert result.stderr =~ "timed out"
+  end
+
+  test "vetoes when module raises" do
+    hook = module_hook(CrashPolicy, :check)
+    result = ModuleRunner.run(hook, %{"event" => "PreToolUse"})
+
+    assert %Result{status: :veto} = result
+    assert result.stderr =~ "boom"
+  end
+
+  test "vetoes on unexpected return value" do
+    hook = module_hook(BadReturnPolicy, :check)
+    result = ModuleRunner.run(hook, %{"event" => "PreToolUse"})
+
+    assert %Result{status: :veto} = result
+    assert result.stderr =~ "unexpected value"
+  end
+
+  test "dispatcher routes module hooks to ModuleRunner" do
+    hook = module_hook(AllowPolicy, :check)
+    payload = %{"event" => "PreToolUse", "tool_name" => "shell", "tool_call_id" => "tc_mod"}
+
+    assert :ok =
+             MingaAgent.Hooks.Dispatcher.dispatch(:pre_tool_use, [hook], payload, veto_capable: true)
+  end
+
+  test "normalization accepts module hook config" do
+    assert {:ok, %Hook{type: :module, module: AllowPolicy, function: :check}} =
+             Hook.normalize(%{
+               event: "PreToolUse",
+               tool: "shell",
+               type: :module,
+               module: AllowPolicy,
+               function: :check
+             })
+  end
+
+  test "normalization auto-detects module type" do
+    assert {:ok, %Hook{type: :module}} =
+             Hook.normalize(%{
+               event: "PreToolUse",
+               tool: "*",
+               module: AllowPolicy,
+               function: :check
+             })
+  end
+
+  test "normalization rejects module hook without function" do
+    assert {:error, "module hook requires :function"} =
+             Hook.normalize(%{event: "PreToolUse", tool: "*", type: :module, module: AllowPolicy})
+  end
+
+  test "normalization rejects module hook without module" do
+    assert {:error, "module hook requires :module"} =
+             Hook.normalize(%{event: "PreToolUse", tool: "*", type: :module, function: :check})
+  end
+
+  defp module_hook(mod, fun, timeout_ms \\ 30_000) do
+    %Hook{
+      event: :pre_tool_use,
+      type: :module,
+      tool_pattern: "*",
+      module: mod,
+      function: fun,
+      timeout_ms: timeout_ms
+    }
+  end
+end

--- a/test/minga_agent/hooks/module_runner_test.exs
+++ b/test/minga_agent/hooks/module_runner_test.exs
@@ -76,7 +76,9 @@ defmodule MingaAgent.Hooks.ModuleRunnerTest do
     payload = %{"event" => "PreToolUse", "tool_name" => "shell", "tool_call_id" => "tc_mod"}
 
     assert :ok =
-             MingaAgent.Hooks.Dispatcher.dispatch(:pre_tool_use, [hook], payload, veto_capable: true)
+             MingaAgent.Hooks.Dispatcher.dispatch(:pre_tool_use, [hook], payload,
+               veto_capable: true
+             )
   end
 
   test "normalization accepts module hook config" do

--- a/test/minga_agent/hooks/module_runner_test.exs
+++ b/test/minga_agent/hooks/module_runner_test.exs
@@ -112,6 +112,19 @@ defmodule MingaAgent.Hooks.ModuleRunnerTest do
              Hook.normalize(%{event: "PreToolUse", tool: "*", type: :module, function: :check})
   end
 
+  test "normalization accepts module name with Elixir. prefix" do
+    full_name = "Elixir.MingaAgent.Hooks.ModuleRunnerTest.AllowPolicy"
+
+    assert {:ok, %Hook{module: AllowPolicy}} =
+             Hook.normalize(%{
+               event: "PreToolUse",
+               tool: "*",
+               type: :module,
+               module: full_name,
+               function: :check
+             })
+  end
+
   defp module_hook(mod, fun, timeout_ms \\ 30_000) do
     %Hook{
       event: :pre_tool_use,

--- a/test/minga_agent/hooks/notification_payload_test.exs
+++ b/test/minga_agent/hooks/notification_payload_test.exs
@@ -1,0 +1,34 @@
+defmodule MingaAgent.Hooks.NotificationPayloadTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Hooks.NotificationPayload
+
+  test "new/3 builds a payload with all fields" do
+    payload = NotificationPayload.new("sess_1", :complete, "Agent finished")
+
+    assert payload.event == "Notification"
+    assert payload.session_id == "sess_1"
+    assert payload.kind == "complete"
+    assert payload.message == "Agent finished"
+  end
+
+  test "to_map/1 produces the expected JSON shape" do
+    payload = NotificationPayload.new("sess_2", :approval, "Tool needs approval")
+    map = NotificationPayload.to_map(payload)
+
+    assert map == %{
+             "event" => "Notification",
+             "session_id" => "sess_2",
+             "kind" => "approval",
+             "message" => "Tool needs approval"
+           }
+  end
+
+  test "payload is Jason-encodable" do
+    payload = NotificationPayload.new("sess_3", :error, "Something failed")
+    assert {:ok, json} = Jason.encode(payload)
+    assert {:ok, decoded} = Jason.decode(json)
+    assert decoded["event"] == "Notification"
+    assert decoded["kind"] == "error"
+  end
+end

--- a/test/minga_agent/hooks/post_tool_use_payload_test.exs
+++ b/test/minga_agent/hooks/post_tool_use_payload_test.exs
@@ -4,7 +4,8 @@ defmodule MingaAgent.Hooks.PostToolUsePayloadTest do
   alias MingaAgent.Hooks.PostToolUsePayload
 
   test "new/5 builds a payload with all fields" do
-    payload = PostToolUsePayload.new("tc_1", "read_file", %{"path" => "a.txt"}, "file contents", false)
+    payload =
+      PostToolUsePayload.new("tc_1", "read_file", %{"path" => "a.txt"}, "file contents", false)
 
     assert payload.event == "PostToolUse"
     assert payload.tool_call_id == "tc_1"
@@ -54,7 +55,9 @@ defmodule MingaAgent.Hooks.PostToolUsePayloadTest do
   end
 
   test "new/1 defaults missing id to a generated value" do
-    payload = PostToolUsePayload.new(%{name: "test", arguments: %{}, result: "ok", is_error: false})
+    payload =
+      PostToolUsePayload.new(%{name: "test", arguments: %{}, result: "ok", is_error: false})
+
     assert String.starts_with?(payload.tool_call_id, "tool_")
   end
 

--- a/test/minga_agent/hooks/post_tool_use_payload_test.exs
+++ b/test/minga_agent/hooks/post_tool_use_payload_test.exs
@@ -1,0 +1,70 @@
+defmodule MingaAgent.Hooks.PostToolUsePayloadTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Hooks.PostToolUsePayload
+
+  test "new/5 builds a payload with all fields" do
+    payload = PostToolUsePayload.new("tc_1", "read_file", %{"path" => "a.txt"}, "file contents", false)
+
+    assert payload.event == "PostToolUse"
+    assert payload.tool_call_id == "tc_1"
+    assert payload.tool_name == "read_file"
+    assert payload.arguments == %{"path" => "a.txt"}
+    assert payload.result == "file contents"
+    assert payload.is_error == false
+  end
+
+  test "new/1 builds a payload from a map" do
+    payload =
+      PostToolUsePayload.new(%{
+        id: "tc_2",
+        name: "shell",
+        arguments: %{"command" => "ls"},
+        result: "dir listing",
+        is_error: false
+      })
+
+    assert payload.tool_call_id == "tc_2"
+    assert payload.tool_name == "shell"
+    assert payload.arguments == %{"command" => "ls"}
+    assert payload.result == "dir listing"
+    assert payload.is_error == false
+  end
+
+  test "to_map/1 produces the expected JSON shape" do
+    payload = PostToolUsePayload.new("tc_3", "write_file", %{"path" => "b.txt"}, "ok", false)
+    map = PostToolUsePayload.to_map(payload)
+
+    assert map == %{
+             "event" => "PostToolUse",
+             "tool_call_id" => "tc_3",
+             "tool_name" => "write_file",
+             "arguments" => %{"path" => "b.txt"},
+             "result" => "ok",
+             "is_error" => false
+           }
+  end
+
+  test "result is truncated when it exceeds 10KB" do
+    large_result = String.duplicate("x", 20_000)
+    payload = PostToolUsePayload.new("tc_4", "shell", %{}, large_result, false)
+
+    assert byte_size(payload.result) < 20_000
+    assert String.ends_with?(payload.result, "\n... (truncated)")
+  end
+
+  test "new/1 defaults missing id to a generated value" do
+    payload = PostToolUsePayload.new(%{name: "test", arguments: %{}, result: "ok", is_error: false})
+    assert String.starts_with?(payload.tool_call_id, "tool_")
+  end
+
+  test "new/1 defaults missing arguments to empty map" do
+    payload = PostToolUsePayload.new(%{id: "tc_5", name: "test", result: "ok", is_error: false})
+    assert payload.arguments == %{}
+  end
+
+  test "is_error true is preserved" do
+    payload = PostToolUsePayload.new("tc_6", "shell", %{}, "error msg", true)
+    assert payload.is_error == true
+  end
+end

--- a/test/minga_agent/hooks/pre_compact_payload_test.exs
+++ b/test/minga_agent/hooks/pre_compact_payload_test.exs
@@ -1,0 +1,39 @@
+defmodule MingaAgent.Hooks.PreCompactPayloadTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Hooks.PreCompactPayload
+
+  test "new/1 builds a payload with message_count" do
+    payload = PreCompactPayload.new(42)
+
+    assert payload.event == "PreCompact"
+    assert payload.message_count == 42
+    assert payload.session_id == nil
+  end
+
+  test "new/2 accepts an optional session_id" do
+    payload = PreCompactPayload.new(10, "sess_1")
+
+    assert payload.session_id == "sess_1"
+    assert payload.message_count == 10
+  end
+
+  test "to_map/1 produces the expected JSON shape" do
+    payload = PreCompactPayload.new(5, "sess_2")
+    map = PreCompactPayload.to_map(payload)
+
+    assert map == %{
+             "event" => "PreCompact",
+             "session_id" => "sess_2",
+             "message_count" => 5
+           }
+  end
+
+  test "payload is Jason-encodable" do
+    payload = PreCompactPayload.new(3)
+    assert {:ok, json} = Jason.encode(payload)
+    assert {:ok, decoded} = Jason.decode(json)
+    assert decoded["event"] == "PreCompact"
+    assert decoded["message_count"] == 3
+  end
+end

--- a/test/minga_agent/hooks/session_end_payload_test.exs
+++ b/test/minga_agent/hooks/session_end_payload_test.exs
@@ -1,0 +1,49 @@
+defmodule MingaAgent.Hooks.SessionEndPayloadTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Hooks.SessionEndPayload
+
+  test "new/3 normalizes :normal reason" do
+    payload = SessionEndPayload.new("sess_1", :normal, :idle)
+
+    assert payload.event == "SessionEnd"
+    assert payload.session_id == "sess_1"
+    assert payload.reason == "normal"
+    assert payload.status == "idle"
+  end
+
+  test "new/3 normalizes :shutdown reason" do
+    payload = SessionEndPayload.new("sess_2", :shutdown, :thinking)
+    assert payload.reason == "shutdown"
+  end
+
+  test "new/3 normalizes {:shutdown, _} reason" do
+    payload = SessionEndPayload.new("sess_3", {:shutdown, :timeout}, :error)
+    assert payload.reason == "shutdown"
+  end
+
+  test "new/3 normalizes unexpected reasons as crash" do
+    payload = SessionEndPayload.new("sess_4", {:badarg, []}, :thinking)
+    assert payload.reason == "crash"
+  end
+
+  test "to_map/1 produces the expected JSON shape" do
+    payload = SessionEndPayload.new("sess_5", :normal, :idle)
+    map = SessionEndPayload.to_map(payload)
+
+    assert map == %{
+             "event" => "SessionEnd",
+             "session_id" => "sess_5",
+             "reason" => "normal",
+             "status" => "idle"
+           }
+  end
+
+  test "payload is Jason-encodable" do
+    payload = SessionEndPayload.new("sess_6", :shutdown, :idle)
+    assert {:ok, json} = Jason.encode(payload)
+    assert {:ok, decoded} = Jason.decode(json)
+    assert decoded["event"] == "SessionEnd"
+    assert decoded["reason"] == "shutdown"
+  end
+end

--- a/test/minga_agent/hooks/session_start_payload_test.exs
+++ b/test/minga_agent/hooks/session_start_payload_test.exs
@@ -1,0 +1,34 @@
+defmodule MingaAgent.Hooks.SessionStartPayloadTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Hooks.SessionStartPayload
+
+  test "new/3 builds a payload with all fields" do
+    payload = SessionStartPayload.new("sess_1", "claude-sonnet", "anthropic")
+
+    assert payload.event == "SessionStart"
+    assert payload.session_id == "sess_1"
+    assert payload.model == "claude-sonnet"
+    assert payload.provider == "anthropic"
+    assert is_binary(payload.project_root)
+  end
+
+  test "to_map/1 produces the expected JSON shape" do
+    payload = SessionStartPayload.new("sess_2", "gpt-4", "openai")
+    map = SessionStartPayload.to_map(payload)
+
+    assert map["event"] == "SessionStart"
+    assert map["session_id"] == "sess_2"
+    assert map["model"] == "gpt-4"
+    assert map["provider"] == "openai"
+    assert is_binary(map["project_root"])
+  end
+
+  test "payload is Jason-encodable" do
+    payload = SessionStartPayload.new("sess_3", "claude-opus", "anthropic")
+    assert {:ok, json} = Jason.encode(payload)
+    assert {:ok, decoded} = Jason.decode(json)
+    assert decoded["event"] == "SessionStart"
+    assert decoded["session_id"] == "sess_3"
+  end
+end

--- a/test/minga_agent/hooks/stop_payload_test.exs
+++ b/test/minga_agent/hooks/stop_payload_test.exs
@@ -1,0 +1,48 @@
+defmodule MingaAgent.Hooks.StopPayloadTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Hooks.StopPayload
+
+  test "new/3 builds a payload with all fields" do
+    payload = StopPayload.new("sess_1", :end_turn, "Here is the result")
+
+    assert payload.event == "Stop"
+    assert payload.session_id == "sess_1"
+    assert payload.reason == "end_turn"
+    assert payload.last_message == "Here is the result"
+  end
+
+  test "new/2 defaults last_message to nil" do
+    payload = StopPayload.new("sess_2", :end_turn)
+
+    assert payload.last_message == nil
+  end
+
+  test "last_message is truncated when it exceeds 1KB" do
+    large_msg = String.duplicate("x", 2_000)
+    payload = StopPayload.new("sess_3", :end_turn, large_msg)
+
+    assert byte_size(payload.last_message) < 2_000
+    assert String.ends_with?(payload.last_message, "\n... (truncated)")
+  end
+
+  test "to_map/1 produces the expected JSON shape" do
+    payload = StopPayload.new("sess_4", :end_turn, "done")
+    map = StopPayload.to_map(payload)
+
+    assert map == %{
+             "event" => "Stop",
+             "session_id" => "sess_4",
+             "reason" => "end_turn",
+             "last_message" => "done"
+           }
+  end
+
+  test "payload is Jason-encodable" do
+    payload = StopPayload.new("sess_5", :end_turn, "result text")
+    assert {:ok, json} = Jason.encode(payload)
+    assert {:ok, decoded} = Jason.decode(json)
+    assert decoded["event"] == "Stop"
+    assert decoded["reason"] == "end_turn"
+  end
+end

--- a/test/minga_agent/hooks/user_prompt_submit_payload_test.exs
+++ b/test/minga_agent/hooks/user_prompt_submit_payload_test.exs
@@ -1,0 +1,49 @@
+defmodule MingaAgent.Hooks.UserPromptSubmitPayloadTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Hooks.UserPromptSubmitPayload
+
+  test "new/2 builds a payload from a string prompt" do
+    payload = UserPromptSubmitPayload.new("sess_1", "hello world")
+
+    assert payload.event == "UserPromptSubmit"
+    assert payload.session_id == "sess_1"
+    assert payload.prompt == "hello world"
+  end
+
+  test "new/2 extracts text from content parts list" do
+    parts = [
+      %{type: :text, text: "first part"},
+      %{type: :image, url: "http://example.com/img.png"},
+      %{type: :text, text: "second part"}
+    ]
+
+    payload = UserPromptSubmitPayload.new("sess_2", parts)
+    assert payload.prompt == "first part\nsecond part"
+  end
+
+  test "new/2 handles plain string list entries" do
+    parts = ["hello", "world"]
+    payload = UserPromptSubmitPayload.new("sess_3", parts)
+    assert payload.prompt == "hello\nworld"
+  end
+
+  test "to_map/1 produces the expected JSON shape" do
+    payload = UserPromptSubmitPayload.new("sess_4", "test prompt")
+    map = UserPromptSubmitPayload.to_map(payload)
+
+    assert map == %{
+             "event" => "UserPromptSubmit",
+             "session_id" => "sess_4",
+             "prompt" => "test prompt"
+           }
+  end
+
+  test "payload is Jason-encodable" do
+    payload = UserPromptSubmitPayload.new("sess_5", "encode me")
+    assert {:ok, json} = Jason.encode(payload)
+    assert {:ok, decoded} = Jason.decode(json)
+    assert decoded["event"] == "UserPromptSubmit"
+    assert decoded["prompt"] == "encode me"
+  end
+end


### PR DESCRIPTION
## Summary

Completes the agent hook lifecycle events epic (parent: #1405). Generalizes the hook infrastructure from PreToolUse-only to event-agnostic, then adds all remaining lifecycle events and Elixir-module hooks as an alternative to shell hooks.

- Generalize Hook, Dispatcher, CommandRunner, and Result to support any event type (#1543)
- Add PostToolUse notification-only hooks fired after tool execution (#1543)
- Add SessionStart/SessionEnd hooks at provider start and session terminate (#1544)
- Add Stop hook when agent finishes a turn (#1546)
- Add UserPromptSubmit veto-capable hook before prompts reach the LLM (#1545)
- Add PreCompact veto-capable hook before context compaction (#1547)
- Add Notification hook before OS notifications (#1547)
- Add Elixir-module hooks as an in-process alternative to shell commands (#1548)

### Veto semantics

| Event | Veto-capable |
|-------|-------------|
| PreToolUse | Yes (existing) |
| UserPromptSubmit | Yes |
| PreCompact | Yes |
| PostToolUse | No |
| SessionStart/End | No |
| Stop | No |
| Notification | No |

Veto-capable dispatchers fail closed: if hook dispatch itself crashes, the operation is blocked (via `Result.dispatch_error/1`) rather than silently allowed. Notification-only dispatchers return `:ok` on error with a warning log.

### Notable review-driven changes

- `normalize_event/1` collapsed from 32 pattern-match clauses to a data-driven `@event_aliases` map lookup
- Module hooks run in a spawned+monitored process (not Task.async) so crashes don't propagate to the caller
- All dispatch rescue/catch blocks log via `Minga.Log.warning(:agent, ...)` instead of silently swallowing
- Truncation uses `String.byte_slice/3` for byte-accurate limits without splitting UTF-8 codepoints
- `extract_last_assistant_text/1` matches the tuple message format `{:assistant, text}` (not a map)

## Test plan

- [x] 80 hook tests pass (payload structs, dispatcher routing, veto/notification-only semantics, module runner timeout/crash/bad-return, event alias normalization, "Elixir." prefix handling)
- [x] 7,947 total tests pass, 0 failures
- [x] `make lint` clean (format + credo + compile warnings + dialyzer)
- [x] Three review passes (6 agents first pass, 3 agents second and third), all findings addressed

Closes #1543, closes #1544, closes #1545, closes #1546, closes #1547, closes #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)