### PR TITLE
feat(command): ex-command completion popup in TUI minibuffer

### DIFF
--- a/lib/minga/mode/command.ex
+++ b/lib/minga/mode/command.ex
@@ -28,6 +28,8 @@ defmodule Minga.Mode.Command do
 
   @behaviour Minga.Mode
 
+  import Bitwise
+
   alias Minga.Command.Parser, as: CommandParser
   alias Minga.Mode
   alias Minga.Mode.CommandState
@@ -36,6 +38,7 @@ defmodule Minga.Mode.Command do
   @escape 27
   @enter 13
   @tab 9
+  @ctrl 0x02
 
   # Arrow key codepoints sent by libvaxis (exclude from printable range)
   @arrow_up 57_352
@@ -51,7 +54,13 @@ defmodule Minga.Mode.Command do
   """
   @spec handle_key(Mode.key(), CommandState.t()) :: Mode.result()
 
-  # Enter → parse the accumulated input and emit an :execute_ex_command
+  # Enter → execute the highlighted candidate if navigated, otherwise parse raw input
+  def handle_key({@enter, _mods}, %CommandState{input: input, candidate_index: idx} = state)
+      when idx != 0 do
+    {:execute_then_transition, [{:execute_command_candidate, input, idx}], :normal,
+     %{state | input: ""}}
+  end
+
   def handle_key({@enter, _mods}, %CommandState{input: input} = state) do
     parsed = CommandParser.parse(input)
     {:execute_then_transition, [{:execute_ex_command, parsed}], :normal, %{state | input: ""}}
@@ -91,6 +100,18 @@ defmodule Minga.Mode.Command do
 
   # Arrow down → move candidate selection down
   def handle_key({@arrow_down, _mods}, %CommandState{candidate_index: idx} = state) do
+    {:continue, %{state | candidate_index: idx + 1}}
+  end
+
+  # C-p → move candidate selection up (vim convention)
+  def handle_key({?p, mods}, %CommandState{candidate_index: idx} = state)
+      when band(mods, @ctrl) != 0 do
+    {:continue, %{state | candidate_index: idx - 1}}
+  end
+
+  # C-n → move candidate selection down (vim convention)
+  def handle_key({?n, mods}, %CommandState{candidate_index: idx} = state)
+      when band(mods, @ctrl) != 0 do
     {:continue, %{state | candidate_index: idx + 1}}
   end
 

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -462,6 +462,10 @@ defmodule MingaEditor.Commands do
     end
   end
 
+  def execute(state, {:execute_command_candidate, input, candidate_index}) do
+    execute_command_candidate(state, input, candidate_index)
+  end
+
   # ── Ex commands (tuple dispatch) ──────────────────────────────────────────
 
   def execute(state, {:execute_ex_command, {:lsp_info, []}}),
@@ -601,10 +605,8 @@ defmodule MingaEditor.Commands do
   @spec accept_command_candidate(state()) :: state()
   defp accept_command_candidate(state) do
     ms = Editing.mode_state(state)
-    {candidates, _total} = MinibufferData.complete_ex_command(ms.input)
-    idx = MinibufferData.clamp_index(ms.candidate_index, length(candidates))
 
-    case Enum.at(candidates, idx) do
+    case resolve_command_candidate(ms.input, ms.candidate_index) do
       nil ->
         state
 
@@ -612,6 +614,25 @@ defmodule MingaEditor.Commands do
         new_ms = %{ms | input: label, candidate_index: 0}
         Editing.update_mode_state(state, fn _ -> new_ms end)
     end
+  end
+
+  @spec execute_command_candidate(state(), String.t(), integer()) :: state()
+  defp execute_command_candidate(state, input, candidate_index) do
+    case resolve_command_candidate(input, candidate_index) do
+      nil ->
+        EditorState.set_status(state, "No matching command")
+
+      %{label: label} ->
+        parsed = Minga.Command.Parser.parse(label)
+        BufferManagement.execute(state, {:execute_ex_command, parsed})
+    end
+  end
+
+  @spec resolve_command_candidate(String.t(), integer()) :: map() | nil
+  defp resolve_command_candidate(input, candidate_index) do
+    {candidates, _total} = MinibufferData.complete_ex_command(input)
+    idx = MinibufferData.clamp_index(candidate_index, length(candidates))
+    Enum.at(candidates, idx)
   end
 
   # ── Filetype trie substitution ────────────────────────────────────────────

--- a/lib/minga_editor/key_dispatch.ex
+++ b/lib/minga_editor/key_dispatch.ex
@@ -18,9 +18,12 @@ defmodule MingaEditor.KeyDispatch do
   alias MingaEditor.Commands
   alias MingaEditor.Editing
   alias MingaEditor.MacroReplay
+  alias MingaEditor.MinibufferData
   alias MingaEditor.ModeTransitions
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.CommandCompletion, as: CommandCompletionPayload
   alias Minga.Keymap
   alias Minga.Mode
 
@@ -80,6 +83,8 @@ defmodule MingaEditor.KeyDispatch do
         EditorState.events_registry(base_state)
       )
     end
+
+    base_state = sync_command_completion_overlay(base_state, old_mode, new_mode)
 
     after_commands =
       Enum.reduce(commands, base_state, fn cmd, acc ->
@@ -225,6 +230,35 @@ defmodule MingaEditor.KeyDispatch do
   catch
     :exit, _ -> :text
   end
+
+  # ── Command completion overlay lifecycle ──────────────────────────────────
+
+  @spec sync_command_completion_overlay(EditorState.t(), Mode.mode(), Mode.mode()) ::
+          EditorState.t()
+  defp sync_command_completion_overlay(state, _old_mode, :command) do
+    ms = Editing.mode_state(state)
+    {candidates, total} = MinibufferData.complete_ex_command(ms.input)
+    selected = MinibufferData.clamp_index(ms.candidate_index, length(candidates))
+
+    payload =
+      CommandCompletionPayload.new(
+        candidates: candidates,
+        selected: selected,
+        filter_text: ms.input,
+        total: total
+      )
+
+    ModalOverlay.open(state, :command_completion, payload)
+  end
+
+  defp sync_command_completion_overlay(state, :command, new_mode) when new_mode != :command do
+    case state.shell_state.modal do
+      {:command_completion, _} -> ModalOverlay.close(state)
+      _ -> state
+    end
+  end
+
+  defp sync_command_completion_overlay(state, _old_mode, _new_mode), do: state
 
   # ── Mode trie population ──────────────────────────────────────────────────
   # Populates leader_trie, normal_bindings, and mode_trie on the mode state

--- a/lib/minga_editor/renderer/command_completion_ui.ex
+++ b/lib/minga_editor/renderer/command_completion_ui.ex
@@ -1,0 +1,190 @@
+defmodule MingaEditor.Renderer.CommandCompletionUI do
+  @moduledoc """
+  Renders the ex-command completion popup above the TUI minibuffer.
+
+  Produces `DisplayList.draw()` tuples for a cell-painted popup showing
+  matching commands with label, description, keybinding annotation, and
+  fuzzy match character highlighting.
+  """
+
+  alias Minga.Core.Face
+  alias MingaEditor.DisplayList
+  alias MingaEditor.State.ModalOverlay.CommandCompletion, as: Payload
+
+  @max_rows 10
+  @label_col_width 22
+
+  @typedoc "Render context with minibuffer position and viewport dimensions."
+  @type render_opts :: %{
+          minibuffer_row: non_neg_integer(),
+          top_boundary: non_neg_integer(),
+          viewport_rows: non_neg_integer(),
+          viewport_cols: non_neg_integer()
+        }
+
+  @spec render(Payload.t() | nil, render_opts(), map()) :: [DisplayList.draw()]
+  def render(nil, _opts, _theme), do: []
+
+  def render(%Payload{candidates: []}, _opts, _theme), do: []
+
+  def render(%Payload{} = payload, opts, theme) do
+    visible_count = min(length(payload.candidates), max_visible(opts))
+    visible = Enum.take(payload.candidates, visible_count)
+    start_row = opts.minibuffer_row - visible_count
+    popup_width = opts.viewport_cols
+
+    pc = theme.picker
+    bg = pc.bg
+    sel_bg = pc.sel_bg
+    text_fg = pc.text_fg
+    highlight_fg = pc.highlight_fg
+    dim_fg = pc.dim_fg
+    accent_fg = Map.get(theme, :accent, highlight_fg)
+
+    visible
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {candidate, idx} ->
+      row = start_row + idx
+
+      if row >= 0 and row < opts.viewport_rows do
+        is_selected = idx == payload.selected
+
+        render_candidate_row(row, popup_width, candidate, is_selected, %{
+          bg: bg,
+          sel_bg: sel_bg,
+          text_fg: text_fg,
+          highlight_fg: highlight_fg,
+          accent_fg: accent_fg,
+          dim_fg: dim_fg
+        })
+      else
+        []
+      end
+    end)
+  end
+
+  @spec max_visible(render_opts()) :: pos_integer()
+  defp max_visible(opts) do
+    available = opts.minibuffer_row - opts.top_boundary
+    min(@max_rows, max(available, 0))
+  end
+
+  @spec render_candidate_row(
+          non_neg_integer(),
+          pos_integer(),
+          map(),
+          boolean(),
+          map()
+        ) :: [DisplayList.draw()]
+  defp render_candidate_row(row, width, candidate, is_selected, colors) do
+    bg = if is_selected, do: colors.sel_bg, else: colors.bg
+    text_fg = if is_selected, do: colors.highlight_fg, else: colors.text_fg
+
+    label = candidate.label
+    description = Map.get(candidate, :description, "")
+    annotation = Map.get(candidate, :annotation, "")
+    match_positions = MapSet.new(Map.get(candidate, :match_positions, []))
+
+    label_col = 2
+    label_width = min(String.length(label), @label_col_width)
+    desc_col = label_col + @label_col_width + 1
+    annotation_width = String.length(annotation)
+
+    desc_max =
+      if annotation_width > 0 do
+        width - desc_col - annotation_width - 3
+      else
+        width - desc_col - 1
+      end
+
+    desc_text =
+      if desc_max > 5 do
+        String.slice(description, 0, desc_max)
+      else
+        ""
+      end
+
+    annotation_col = width - annotation_width - 2
+
+    bg_draw =
+      DisplayList.draw(
+        row,
+        0,
+        String.duplicate(" ", width),
+        Face.new(fg: text_fg, bg: bg)
+      )
+
+    kind_draw =
+      DisplayList.draw(row, 0, " :", Face.new(fg: colors.dim_fg, bg: bg))
+
+    label_draws =
+      render_highlighted_label(
+        row,
+        label_col,
+        label,
+        label_width,
+        match_positions,
+        is_selected,
+        bg,
+        colors
+      )
+
+    desc_draws =
+      if desc_text != "" do
+        [DisplayList.draw(row, desc_col, desc_text, Face.new(fg: colors.dim_fg, bg: bg))]
+      else
+        []
+      end
+
+    annotation_draws =
+      if annotation_width > 0 and annotation_col > desc_col do
+        [DisplayList.draw(row, annotation_col, annotation, Face.new(fg: colors.dim_fg, bg: bg))]
+      else
+        []
+      end
+
+    [bg_draw, kind_draw] ++ label_draws ++ desc_draws ++ annotation_draws
+  end
+
+  @spec render_highlighted_label(
+          non_neg_integer(),
+          non_neg_integer(),
+          String.t(),
+          pos_integer(),
+          MapSet.t(),
+          boolean(),
+          non_neg_integer(),
+          map()
+        ) :: [DisplayList.draw()]
+  defp render_highlighted_label(
+         row,
+         col,
+         label,
+         max_width,
+         match_positions,
+         is_selected,
+         bg,
+         colors
+       ) do
+    label
+    |> String.graphemes()
+    |> Enum.take(max_width)
+    |> Enum.with_index()
+    |> Enum.map(fn {char, char_idx} ->
+      is_match = MapSet.member?(match_positions, char_idx)
+      fg = char_fg(is_match, is_selected, colors)
+
+      DisplayList.draw(
+        row,
+        col + char_idx,
+        char,
+        Face.new(fg: fg, bg: bg, bold: is_match)
+      )
+    end)
+  end
+
+  @spec char_fg(boolean(), boolean(), map()) :: non_neg_integer()
+  defp char_fg(_is_match, true, colors), do: colors.highlight_fg
+  defp char_fg(true, false, colors), do: colors.accent_fg
+  defp char_fg(false, false, colors), do: colors.text_fg
+end

--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -14,11 +14,13 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
   alias MingaEditor.Layout
   alias MingaEditor.PickerUI
   alias MingaEditor.Renderer.Caps
+  alias MingaEditor.Renderer.CommandCompletionUI
   alias MingaEditor.Renderer.Minibuffer
   alias MingaEditor.Renderer.Regions
   alias MingaEditor.RenderPipeline.Chrome
   alias MingaEditor.RenderPipeline.Scroll.WindowScroll
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
   alias MingaEditor.StatusBar.Data, as: StatusBarData
   alias MingaEditor.Shell.Traditional.Chrome.Helpers, as: ChromeHelpers
   alias MingaEditor.Shell.Traditional.Modeline
@@ -97,7 +99,22 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
       end
 
     # Overlays (all types for TUI)
-    overlays = build_overlays(state, full_viewport, cursor_info)
+    {minibuffer_row_for_overlay, _, _, _} = layout.minibuffer
+
+    status_bar_bottom =
+      case layout.status_bar do
+        {sb_row, _, _, sb_h} -> sb_row + sb_h
+        nil -> 0
+      end
+
+    overlays =
+      build_overlays(
+        state,
+        full_viewport,
+        cursor_info,
+        minibuffer_row_for_overlay,
+        status_bar_bottom
+      )
 
     %Chrome{
       status_bar_draws: status_bar_draws,
@@ -184,8 +201,14 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
 
   # ── Overlays ──────────────────────────────────────────────────────────────
 
-  @spec build_overlays(state(), MingaEditor.Viewport.t(), Cursor.t() | nil) :: [Overlay.t()]
-  defp build_overlays(state, viewport, cursor_info) do
+  @spec build_overlays(
+          state(),
+          MingaEditor.Viewport.t(),
+          Cursor.t() | nil,
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [Overlay.t()]
+  defp build_overlays(state, viewport, cursor_info, minibuffer_row, status_bar_bottom) do
     render_overlays_flag = Caps.render_overlays?(state.capabilities)
 
     {picker_draws, picker_cursor} = PickerUI.render(state, viewport)
@@ -197,6 +220,10 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
         else: []
 
     completion_draws = build_completion_draws(state, cursor_info)
+
+    command_completion_draws =
+      build_command_completion_draws(state, viewport, minibuffer_row, status_bar_bottom)
+
     hover_draws = Chrome.render_hover_popup(state)
     sig_help_draws = Chrome.render_signature_help(state)
     float_overlays = PopupLifecycle.render_float_overlays(state)
@@ -207,6 +234,7 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
          %Overlay{draws: sig_help_draws},
          %Overlay{draws: whichkey_draws},
          %Overlay{draws: completion_draws},
+         %Overlay{draws: command_completion_draws},
          %Overlay{draws: picker_draws, cursor: picker_cursor},
          %Overlay{draws: prompt_draws, cursor: prompt_cursor}
        ])
@@ -228,4 +256,23 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
   end
 
   defp build_completion_draws(_state, nil), do: []
+
+  @spec build_command_completion_draws(
+          state(),
+          MingaEditor.Viewport.t(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: [DisplayList.draw()]
+  defp build_command_completion_draws(state, viewport, minibuffer_row, top_boundary) do
+    CommandCompletionUI.render(
+      ModalOverlay.command_completion(state),
+      %{
+        minibuffer_row: minibuffer_row,
+        top_boundary: top_boundary,
+        viewport_rows: viewport.rows,
+        viewport_cols: viewport.cols
+      },
+      state.theme
+    )
+  end
 end

--- a/lib/minga_editor/state/modal_overlay.ex
+++ b/lib/minga_editor/state/modal_overlay.ex
@@ -15,10 +15,11 @@ defmodule MingaEditor.State.ModalOverlay do
       | {:picker, ModalOverlay.Picker.t()}
       | {:prompt, ModalOverlay.Prompt.t()}
       | {:completion, ModalOverlay.Completion.t()}
+      | {:command_completion, ModalOverlay.CommandCompletion.t()}
       | {:conflict, ModalOverlay.Conflict.t()}
       | {:dashboard, ModalOverlay.Dashboard.t()}
 
-  The modal field is the only storage location for these five variants. There is no dual-write migration path and no dev/test divergence assertion; future modal changes must go through this gate directly.
+  The modal field is the only storage location for these six variants. There is no dual-write migration path and no dev/test divergence assertion; future modal changes must go through this gate directly.
 
   **Do not mutate `:modal` directly**: always call this module's
   `open/3`, `transition/3`, `close/1`, `dismiss/1`, `update_completion/2`,
@@ -49,18 +50,20 @@ defmodule MingaEditor.State.ModalOverlay do
   alias Minga.Editing.Completion
   alias MingaEditor.CompletionTrigger
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay.CommandCompletion, as: CommandCompletionPayload
   alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
   alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
   alias MingaEditor.State.ModalOverlay.Dashboard, as: DashboardPayload
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.ModalOverlay.Prompt, as: PromptPayload
 
-  @type variant :: :picker | :prompt | :completion | :conflict | :dashboard
+  @type variant :: :picker | :prompt | :completion | :command_completion | :conflict | :dashboard
 
   @type payload ::
           PickerPayload.t()
           | PromptPayload.t()
           | CompletionPayload.t()
+          | CommandCompletionPayload.t()
           | ConflictPayload.t()
           | DashboardPayload.t()
 
@@ -69,13 +72,14 @@ defmodule MingaEditor.State.ModalOverlay do
           | {:picker, PickerPayload.t()}
           | {:prompt, PromptPayload.t()}
           | {:completion, CompletionPayload.t()}
+          | {:command_completion, CommandCompletionPayload.t()}
           | {:conflict, ConflictPayload.t()}
           | {:dashboard, DashboardPayload.t()}
 
-  # Single source of truth for the variant tag list. Adding a sixth modal
+  # Single source of truth for the variant tag list. Adding a seventh modal
   # later means adding to this attribute plus the `t()` and `payload()`
-  # types — the guards below stay correct automatically.
-  @variants [:picker, :prompt, :completion, :conflict, :dashboard]
+  # types; the guards below stay correct automatically.
+  @variants [:picker, :prompt, :completion, :command_completion, :conflict, :dashboard]
 
   # ── Pure queries on the modal value ────────────────────────────────────────
 
@@ -261,6 +265,20 @@ defmodule MingaEditor.State.ModalOverlay do
   end
 
   defp trigger_active?(_), do: false
+
+  # ── Command completion accessors and updaters ──────────────────────────────
+
+  @doc """
+  Returns the active `CommandCompletionPayload.t()` when the modal is
+  `{:command_completion, _}`, otherwise `nil`.
+  """
+  @spec command_completion(map()) :: CommandCompletionPayload.t() | nil
+  def command_completion(%{
+        shell_state: %{modal: {:command_completion, %CommandCompletionPayload{} = p}}
+      }),
+      do: p
+
+  def command_completion(_), do: nil
 
   # ── Per-tab dismissal hook ─────────────────────────────────────────────────
 

--- a/lib/minga_editor/state/modal_overlay/command_completion.ex
+++ b/lib/minga_editor/state/modal_overlay/command_completion.ex
@@ -1,0 +1,49 @@
+defmodule MingaEditor.State.ModalOverlay.CommandCompletion do
+  @moduledoc """
+  Modal-overlay payload for the ex-command completion popup.
+
+  Unlike the LSP `:completion` variant, this overlay is a rendering-oriented
+  state container. The command mode FSM owns all key routing; this payload
+  holds pre-computed candidate data so the TUI renderer avoids recomputing
+  fuzzy scores during rendering.
+
+  Opened when entering command mode, updated on each keystroke, and closed
+  on mode exit. No trigger lifecycle or tab ownership needed since command
+  mode is inherently single-context.
+  """
+
+  alias MingaEditor.MinibufferData
+
+  @type t :: %__MODULE__{
+          candidates: [MinibufferData.candidate()],
+          selected: non_neg_integer(),
+          filter_text: String.t(),
+          total: non_neg_integer()
+        }
+
+  defstruct candidates: [],
+            selected: 0,
+            filter_text: "",
+            total: 0
+
+  @spec new(keyword()) :: t()
+  def new(opts \\ []) do
+    %__MODULE__{
+      candidates: Keyword.get(opts, :candidates, []),
+      selected: Keyword.get(opts, :selected, 0),
+      filter_text: Keyword.get(opts, :filter_text, ""),
+      total: Keyword.get(opts, :total, 0)
+    }
+  end
+
+  @spec update(t(), keyword()) :: t()
+  def update(%__MODULE__{} = payload, opts) do
+    %{
+      payload
+      | candidates: Keyword.get(opts, :candidates, payload.candidates),
+        selected: Keyword.get(opts, :selected, payload.selected),
+        filter_text: Keyword.get(opts, :filter_text, payload.filter_text),
+        total: Keyword.get(opts, :total, payload.total)
+    }
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a cell-painted TUI popup above the minibuffer showing matching ex-commands with label, description, keybinding annotation, and fuzzy match character highlighting
- Adds C-n/C-p as navigation alternatives to Up/Down arrows in command mode
- Enter now accepts and executes the highlighted candidate when the user has navigated (candidate_index != 0)
- Introduces `:command_completion` as a new `ModalOverlay` variant for consistent overlay lifecycle management
- The BEAM backend (`MinibufferData.complete_ex_command/1`) and macOS GUI (`MinibufferView.swift`) were already fully working; this closes the TUI rendering gap

Closes #863

## Test plan

- [x] `mix test.llm` — 8,158 tests pass, 0 failures
- [x] `make lint` — format, credo, compile warnings, dialyzer all clean
- [x] Snapshot tests for command mode entry and typing verified (no status bar overlap)
- [x] Existing command mode FSM tests pass (28 tests)
- [x] Existing ModalOverlay tests pass (24 tests)
- [ ] Manual: type `:` in TUI, verify popup appears with candidates
- [ ] Manual: type `:w` and verify list narrows, matched chars are highlighted
- [ ] Manual: C-n/C-p navigate selection, Enter executes highlighted candidate
- [ ] Manual: Tab accepts candidate into input without executing

🤖 Generated with [Claude Code](https://claude.com/claude-code)