### PR TITLE
refactor(editor): type tab context snapshots

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -88,6 +88,7 @@ defmodule MingaEditor do
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Tab.Context, as: TabContext
 
   alias MingaEditor.MinibufferData
   alias MingaEditor.MouseHoverTooltip
@@ -1677,10 +1678,7 @@ defmodule MingaEditor do
 
   @spec buffer_tracked_in_tabs?(state(), pid()) :: boolean()
   defp buffer_tracked_in_tabs?(%{shell_state: %{tab_bar: %{tabs: tabs}}}, pid) do
-    Enum.any?(tabs, fn
-      %{context: %{buffers: %{list: buffers}}} -> pid in buffers
-      _ -> false
-    end)
+    Enum.any?(tabs, fn tab -> pid in tab_buffer_list(tab) end)
   end
 
   defp buffer_tracked_in_tabs?(_state, _pid), do: false
@@ -2211,8 +2209,11 @@ defmodule MingaEditor do
   end
 
   @spec tab_buffer_list(MingaEditor.State.Tab.t() | term()) :: [pid()]
-  defp tab_buffer_list(%MingaEditor.State.Tab{context: %{buffers: %Buffers{list: buffers}}}) do
-    Enum.filter(buffers, &is_pid/1)
+  defp tab_buffer_list(%MingaEditor.State.Tab{context: context}) when is_map(context) do
+    case TabContext.to_workspace_map(context) do
+      %{buffers: %Buffers{list: buffers}} -> Enum.filter(buffers, &is_pid/1)
+      _ -> []
+    end
   end
 
   defp tab_buffer_list(_tab), do: []

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -21,7 +21,9 @@ defmodule MingaEditor.Commands.BufferManagement do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
   alias MingaEditor.Window
   alias Minga.Mode
@@ -698,9 +700,11 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec file_tab_buffers(TabBar.t()) :: [pid()]
   defp file_tab_buffers(%TabBar{tabs: tabs}) do
-    Enum.flat_map(tabs, fn
-      %{kind: :file, context: %{buffers: %{active: pid}}} when is_pid(pid) -> [pid]
-      _ -> []
+    Enum.flat_map(tabs, fn tab ->
+      case tab_context_active_buffer(tab) do
+        pid when is_pid(pid) -> [pid]
+        _ -> []
+      end
     end)
   end
 
@@ -733,10 +737,26 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   defp find_tab_for_buffer(%TabBar{tabs: tabs}, target_buf) do
     Enum.find_value(tabs, fn
-      %{kind: :file, id: id, context: %{buffers: %{active: ^target_buf}}} -> id
-      _ -> nil
+      %{kind: :file, id: id} = tab ->
+        case tab_context_active_buffer(tab) do
+          ^target_buf -> id
+          _ -> nil
+        end
+
+      _ ->
+        nil
     end)
   end
+
+  @spec tab_context_active_buffer(Tab.t() | term()) :: pid() | nil
+  defp tab_context_active_buffer(%{context: context}) when is_map(context) do
+    case TabContext.to_workspace_map(context) do
+      %{buffers: %Buffers{active: pid}} when is_pid(pid) -> pid
+      _ -> nil
+    end
+  end
+
+  defp tab_context_active_buffer(_tab), do: nil
 
   @spec next_tab(state()) :: state()
   defp next_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
@@ -1192,8 +1212,12 @@ defmodule MingaEditor.Commands.BufferManagement do
   @spec restore_active_tab_context(state()) :: state()
   defp restore_active_tab_context(state) do
     case EditorState.active_tab(state) do
-      %Tab{context: context} when is_map(context) and map_size(context) > 0 ->
-        EditorState.restore_tab_context(state, context)
+      %Tab{context: context} when is_map(context) ->
+        if TabContext.empty?(context) do
+          state
+        else
+          EditorState.restore_tab_context(state, context)
+        end
 
       _ ->
         state

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -87,7 +87,9 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
   alias Minga.Buffer
   alias MingaEditor.MinibufferData
+  alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
   alias Minga.Language
   alias MingaEditor.UI.Devicon
@@ -644,12 +646,18 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   end
 
   @spec resolve_tab_buffer(Tab.t(), 0 | 1, pid() | nil) :: pid() | nil
-  defp resolve_tab_buffer(%{context: %{buffers: %{active: pid}}}, _is_active, _buf)
-       when is_pid(pid),
-       do: pid
+  defp resolve_tab_buffer(%{context: context}, is_active, buf) when is_map(context) do
+    case TabContext.to_workspace_map(context) do
+      %{buffers: %Buffers{active: pid}} when is_pid(pid) -> pid
+      _ -> active_tab_buffer(is_active, buf)
+    end
+  end
 
-  defp resolve_tab_buffer(_tab, 1, buf) when is_pid(buf), do: buf
-  defp resolve_tab_buffer(_tab, _is_active, _buf), do: nil
+  defp resolve_tab_buffer(_tab, is_active, buf), do: active_tab_buffer(is_active, buf)
+
+  @spec active_tab_buffer(0 | 1, pid() | nil) :: pid() | nil
+  defp active_tab_buffer(1, buf) when is_pid(buf), do: buf
+  defp active_tab_buffer(_is_active, _buf), do: nil
 
   @spec encode_agent_status(atom() | nil) :: non_neg_integer()
   defp encode_agent_status(:idle), do: 0

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -39,6 +39,7 @@ defmodule MingaEditor.Shell.Traditional do
   alias MingaEditor.State.AgentGroup
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Windows
   alias MingaEditor.Window
@@ -414,13 +415,14 @@ defmodule MingaEditor.Shell.Traditional do
     rows = max(workspace.viewport.rows, 1)
     cols = max(workspace.viewport.cols, 1)
 
-    context = WorkspaceState.to_tab_context(workspace)
-
-    context
-    |> Map.put(:keymap_scope, :agent)
-    |> Map.put(:agent_ui, UIState.new())
-    |> Map.put(:buffers, background_agent_buffers(agent_buf))
-    |> Map.put(:windows, background_agent_windows(agent_buf, rows, cols))
+    workspace
+    |> WorkspaceState.to_tab_context()
+    |> TabContext.put_fields(%{
+      keymap_scope: :agent,
+      agent_ui: UIState.new(),
+      buffers: background_agent_buffers(agent_buf),
+      windows: background_agent_windows(agent_buf, rows, cols)
+    })
   end
 
   @spec background_agent_buffers(pid() | nil) :: Buffers.t()
@@ -597,9 +599,9 @@ defmodule MingaEditor.Shell.Traditional do
   defp buffer_label(_), do: "[unknown]"
 
   @spec tab_has_active_buffer?(Tab.t(), pid()) :: boolean()
-  defp tab_has_active_buffer?(tab, pid) do
-    case tab.context do
-      %{buffers: %{active: ^pid}} -> true
+  defp tab_has_active_buffer?(%Tab{context: context}, pid) do
+    case TabContext.to_workspace_map(context) do
+      %{buffers: %Buffers{active: ^pid}} -> true
       _ -> false
     end
   end

--- a/lib/minga_editor/shell/traditional/tab_bar_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tab_bar_renderer.ex
@@ -22,7 +22,9 @@ defmodule MingaEditor.Shell.Traditional.TabBarRenderer do
   alias Minga.Core.Face
   alias Minga.Core.Unicode
   alias MingaEditor.DisplayList
+  alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
   alias Minga.Language
   alias MingaEditor.UI.Devicon
@@ -442,8 +444,12 @@ defmodule MingaEditor.Shell.Traditional.TabBarRenderer do
   defp agent_status_indicator(_), do: ""
 
   @spec tab_active_buffer(Tab.t()) :: pid() | nil
-  defp tab_active_buffer(%Tab{context: %{buffers: %{active: buf}}}), do: buf
-  defp tab_active_buffer(_), do: nil
+  defp tab_active_buffer(%Tab{context: context}) do
+    case TabContext.to_workspace_map(context) do
+      %{buffers: %Buffers{active: buf}} -> buf
+      _ -> nil
+    end
+  end
 
   @spec tab_bar_colors(Theme.t()) :: map()
   defp tab_bar_colors(%Theme{tab_bar: %Theme.TabBar{} = tb}), do: Map.from_struct(tb)

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -43,6 +43,7 @@ defmodule MingaEditor.State do
   alias MingaEditor.State.Mouse
   alias MingaEditor.State.Search
   alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.WhichKey
   alias MingaEditor.State.Windows
@@ -1001,9 +1002,9 @@ defmodule MingaEditor.State do
   # ── Tab bar helpers ───────────────────────────────────────────────────────
 
   @doc """
-  Captures the current per-tab fields into a context map.
+  Captures the current per-tab fields into a context struct.
 
-  The returned map is stored in the outgoing tab so it can be restored
+  The returned struct is stored in the outgoing tab so it can be restored
   when the user switches back.
   """
   @spec snapshot_tab_context(t()) :: Tab.context()
@@ -1025,14 +1026,12 @@ defmodule MingaEditor.State do
   @doc """
   Writes a tab context back into the live editor state.
 
-  The context carries workspace fields as a flat map. Empty context means a
-  brand-new tab; we build defaults with the current active buffer and
-  viewport dimensions.
+  The context carries workspace fields as an explicit struct. Empty context means a brand-new tab; we build defaults with the current active buffer and viewport dimensions.
   """
-  @spec restore_tab_context(t(), Tab.context()) :: t()
+  @spec restore_tab_context(t(), Tab.context() | Tab.legacy_context()) :: t()
   def restore_tab_context(%__MODULE__{} = state, context) when is_map(context) do
     {context, state} =
-      if map_size(context) == 0 do
+      if TabContext.empty?(context) do
         synthesized = build_file_tab_defaults(state)
 
         state =
@@ -1046,14 +1045,13 @@ defmodule MingaEditor.State do
 
         {synthesized, state}
       else
-        {context, state}
+        {TabContext.from_map(context), state}
       end
 
     %{state | workspace: WorkspaceState.restore_tab_context(state.workspace, context)}
   end
 
-  # Builds a file-tab context for a brand-new tab. Returns the flat format
-  # with per-tab fields directly.
+  # Builds a typed file-tab context for a brand-new tab.
   @spec build_file_tab_defaults(t()) :: Tab.context()
   defp build_file_tab_defaults(state) do
     win_id = state.workspace.windows.next_id
@@ -1079,7 +1077,7 @@ defmodule MingaEditor.State do
         %Windows{}
       end
 
-    %{
+    TabContext.from_workspace_map(%{
       keymap_scope: :editor,
       buffers: %Buffers{
         active: buf,
@@ -1097,7 +1095,7 @@ defmodule MingaEditor.State do
       editing: VimState.new(),
       document_highlights: nil,
       agent_ui: UIState.new()
-    }
+    })
   end
 
   @doc """
@@ -1109,7 +1107,7 @@ defmodule MingaEditor.State do
   """
   @spec build_agent_tab_defaults(t(), Windows.t(), pid() | nil) :: Tab.context()
   def build_agent_tab_defaults(state, windows, agent_buf) do
-    %{
+    TabContext.from_workspace_map(%{
       keymap_scope: :agent,
       buffers: %Buffers{
         active: agent_buf,
@@ -1127,7 +1125,7 @@ defmodule MingaEditor.State do
       editing: VimState.new(),
       document_highlights: nil,
       agent_ui: UIState.new()
-    }
+    })
   end
 
   @doc """

--- a/lib/minga_editor/state/tab.ex
+++ b/lib/minga_editor/state/tab.ex
@@ -3,19 +3,16 @@ defmodule MingaEditor.State.Tab do
   A single tab in the tab bar.
 
   Each tab has a unique id, a kind (`:file` or `:agent`), a display label,
-  and a context map that stores snapshotted per-tab state when the tab is
+  and a typed context that stores snapshotted per-tab state when the tab is
   inactive. The active tab's context is "live" on EditorState; inactive
   tabs carry a frozen snapshot that gets restored when you switch to them.
 
   ## Context format
 
-  The canonical context is a flat map with workspace fields (buffers, windows,
-  editing state, viewport, etc.) stored directly. Restore reads only fields that exist on `MingaEditor.Workspace.State`; unknown legacy fields are ignored.
+  The canonical context is `MingaEditor.State.Tab.Context`, a struct with explicit workspace fields. Restore still accepts legacy maps for migration, including empty maps for brand-new tabs.
   """
 
-  alias MingaEditor.State.Buffers
-
-  # Tab contexts store per-tab fields directly as flat maps.
+  alias MingaEditor.State.Tab.Context
 
   @typedoc "Unique tab identifier."
   @type id :: pos_integer()
@@ -26,24 +23,12 @@ defmodule MingaEditor.State.Tab do
   @typedoc """
   Snapshotted per-tab state.
 
-  Stores per-tab fields directly as a flat map (buffers, windows, editing,
-  etc.). Empty context means a brand-new tab.
+  Stores per-tab workspace fields in an explicit struct. Empty context means a brand-new tab.
   """
-  @type context :: %{
-          optional(:keymap_scope) => atom(),
-          optional(:buffers) => term(),
-          optional(:windows) => term(),
-          optional(:file_tree) => term(),
-          optional(:viewport) => term(),
-          optional(:mouse) => term(),
-          optional(:highlight) => term(),
-          optional(:lsp_pending) => term(),
-          optional(:injection_ranges) => term(),
-          optional(:search) => term(),
-          optional(:editing) => MingaEditor.VimState.t(),
-          optional(:document_highlights) => term(),
-          optional(:agent_ui) => term()
-        }
+  @type context :: Context.t()
+
+  @typedoc "Legacy context map accepted at migration boundaries."
+  @type legacy_context :: Context.legacy()
 
   @typedoc "Agent tab status (nil for file tabs)."
   @type agent_status :: :idle | :plan | :thinking | :tool_executing | :error | nil
@@ -68,7 +53,7 @@ defmodule MingaEditor.State.Tab do
   defstruct id: nil,
             kind: nil,
             label: "",
-            context: %{},
+            context: Context.empty(),
             session: nil,
             agent_status: nil,
             attention: false,
@@ -94,9 +79,13 @@ defmodule MingaEditor.State.Tab do
   end
 
   @doc "Stores a context snapshot into the tab."
-  @spec set_context(t(), context()) :: t()
-  def set_context(%__MODULE__{} = tab, context) when is_map(context) do
+  @spec set_context(t(), context() | legacy_context()) :: t()
+  def set_context(%__MODULE__{} = tab, %Context{} = context) do
     %{tab | context: context}
+  end
+
+  def set_context(%__MODULE__{} = tab, context) when is_map(context) do
+    %{tab | context: Context.from_map(context)}
   end
 
   @doc "Returns true if this is a file tab."
@@ -148,9 +137,7 @@ defmodule MingaEditor.State.Tab do
 
   @doc "Removes a dead buffer pid from this tab's context snapshot."
   @spec scrub_buffer(t(), pid()) :: t()
-  def scrub_buffer(%__MODULE__{context: %{buffers: %Buffers{} = bs} = context} = tab, pid) do
-    %{tab | context: %{context | buffers: Buffers.remove(bs, pid)}}
+  def scrub_buffer(%__MODULE__{context: context} = tab, pid) do
+    %{tab | context: Context.scrub_buffer(context, pid)}
   end
-
-  def scrub_buffer(%__MODULE__{} = tab, _pid), do: tab
 end

--- a/lib/minga_editor/state/tab/context.ex
+++ b/lib/minga_editor/state/tab/context.ex
@@ -1,0 +1,265 @@
+defmodule MingaEditor.State.Tab.Context do
+  @moduledoc """
+  Typed per-tab workspace snapshot stored on `MingaEditor.State.Tab`.
+
+  Contexts replace the old free-form map while still accepting legacy maps at API boundaries. `present_fields` records which workspace fields were actually present in a legacy map so partial migration inputs do not overwrite live workspace state with nil defaults.
+  """
+
+  alias Minga.Keymap.Scope
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.FileTree, as: FileTreeState
+  alias MingaEditor.State.Highlighting
+  alias MingaEditor.State.Mouse
+  alias MingaEditor.State.Search
+  alias MingaEditor.State.Windows
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+
+  @version 1
+
+  @workspace_fields [
+    :keymap_scope,
+    :buffers,
+    :windows,
+    :file_tree,
+    :viewport,
+    :mouse,
+    :highlight,
+    :lsp_pending,
+    :injection_ranges,
+    :search,
+    :editing,
+    :document_highlights,
+    :agent_ui
+  ]
+
+  @typedoc "Workspace fields carried by a tab context."
+  @type field_name ::
+          :keymap_scope
+          | :buffers
+          | :windows
+          | :file_tree
+          | :viewport
+          | :mouse
+          | :highlight
+          | :lsp_pending
+          | :injection_ranges
+          | :search
+          | :editing
+          | :document_highlights
+          | :agent_ui
+
+  @typedoc "Legacy map persisted or built before tab contexts became typed structs."
+  @type legacy :: map()
+
+  @typedoc "A document highlight range from the LSP server."
+  @type document_highlight :: Minga.LSP.DocumentHighlight.t()
+
+  @type t :: %__MODULE__{
+          version: pos_integer(),
+          present_fields: [field_name()],
+          keymap_scope: Scope.scope_name() | nil,
+          buffers: Buffers.t() | nil,
+          windows: Windows.t() | nil,
+          file_tree: FileTreeState.t() | nil,
+          viewport: Viewport.t() | nil,
+          mouse: Mouse.t() | nil,
+          highlight: Highlighting.t() | nil,
+          lsp_pending: %{reference() => atom() | tuple()} | nil,
+          injection_ranges: %{pid() => [Minga.Language.Highlight.InjectionRange.t()]} | nil,
+          search: Search.t() | nil,
+          editing: VimState.t() | nil,
+          document_highlights: [document_highlight()] | nil,
+          agent_ui: UIState.t() | nil
+        }
+
+  defstruct version: @version,
+            present_fields: [],
+            keymap_scope: nil,
+            buffers: nil,
+            windows: nil,
+            file_tree: nil,
+            viewport: nil,
+            mouse: nil,
+            highlight: nil,
+            lsp_pending: nil,
+            injection_ranges: nil,
+            search: nil,
+            editing: nil,
+            document_highlights: nil,
+            agent_ui: nil
+
+  @doc "Returns the workspace field names represented by this context."
+  @spec field_names() :: [field_name()]
+  def field_names, do: @workspace_fields
+
+  @doc "Returns an empty context for a brand-new tab with no saved workspace yet."
+  @spec empty() :: t()
+  def empty, do: %__MODULE__{}
+
+  @doc "Returns true when the context has no workspace fields to restore."
+  @spec empty?(t() | legacy()) :: boolean()
+  def empty?(%__MODULE__{} = context), do: map_size(to_workspace_map(context)) == 0
+
+  def empty?(context) when is_map(context) do
+    case fetch_present_fields(context) do
+      nil -> map_size(context) == 0
+      _fields -> context |> from_map() |> empty?()
+    end
+  end
+
+  @doc "Builds a complete context from canonical workspace fields."
+  @spec from_workspace_map(map()) :: t()
+  def from_workspace_map(map) when is_map(map), do: from_map(map)
+
+  @doc "Normalizes a legacy context map into a typed context struct."
+  @spec from_map(t() | legacy()) :: t()
+  def from_map(%__MODULE__{} = context), do: context
+
+  def from_map(map) when is_map(map) do
+    context = %__MODULE__{version: fetch_version(map)}
+    fields = fetch_present_fields(map) || @workspace_fields
+
+    Enum.reduce(fields, context, fn field, acc ->
+      case fetch_field(map, field) do
+        {:ok, value} -> put_valid_field(acc, field, value)
+        :error -> acc
+      end
+    end)
+  end
+
+  @doc "Returns a context with valid workspace field overrides applied."
+  @spec put_fields(t(), map() | keyword()) :: t()
+  def put_fields(%__MODULE__{} = context, attrs) when is_list(attrs) do
+    put_fields(context, Map.new(attrs))
+  end
+
+  def put_fields(%__MODULE__{} = context, attrs) when is_map(attrs) do
+    Enum.reduce(@workspace_fields, context, fn field, acc ->
+      case fetch_field(attrs, field) do
+        {:ok, value} -> put_valid_field(acc, field, value)
+        :error -> acc
+      end
+    end)
+  end
+
+  @doc "Returns a workspace map containing only fields present in this context."
+  @spec to_workspace_map(t() | legacy()) :: map()
+  def to_workspace_map(%__MODULE__{} = context) do
+    context.present_fields
+    |> normalize_present_fields()
+    |> Enum.reduce(%{}, fn field, acc -> put_workspace_field(acc, context, field) end)
+  end
+
+  def to_workspace_map(map) when is_map(map) do
+    map
+    |> from_map()
+    |> to_workspace_map()
+  end
+
+  @doc "Returns a context with the dead buffer removed from its `buffers` snapshot when present."
+  @spec scrub_buffer(t() | legacy(), pid()) :: t()
+  def scrub_buffer(context, pid) do
+    context
+    |> from_map()
+    |> scrub_context_buffer(pid)
+  end
+
+  @spec scrub_context_buffer(t(), pid()) :: t()
+  defp scrub_context_buffer(%__MODULE__{buffers: %Buffers{} = buffers} = context, pid) do
+    put_field(context, :buffers, Buffers.remove(buffers, pid))
+  end
+
+  defp scrub_context_buffer(%__MODULE__{} = context, _pid), do: context
+
+  @spec put_valid_field(t(), field_name(), term()) :: t()
+  defp put_valid_field(%__MODULE__{} = context, field, value) do
+    if valid_field?(field, value), do: put_field(context, field, value), else: context
+  end
+
+  @spec put_field(t(), field_name(), term()) :: t()
+  defp put_field(%__MODULE__{present_fields: present_fields} = context, field, value) do
+    context
+    |> Map.put(field, value)
+    |> Map.put(:present_fields, add_present_field(present_fields, field))
+  end
+
+  @spec add_present_field([field_name()], field_name()) :: [field_name()]
+  defp add_present_field(present_fields, field) do
+    if field in present_fields, do: present_fields, else: [field | present_fields]
+  end
+
+  @spec put_workspace_field(map(), t(), field_name()) :: map()
+  defp put_workspace_field(acc, %__MODULE__{} = context, field) do
+    value = Map.fetch!(context, field)
+    if valid_field?(field, value), do: Map.put(acc, field, value), else: acc
+  end
+
+  @spec valid_field?(field_name(), term()) :: boolean()
+  defp valid_field?(:keymap_scope, value) when is_atom(value), do: value in Scope.all_scopes()
+  defp valid_field?(:keymap_scope, _value), do: false
+  defp valid_field?(:buffers, %Buffers{}), do: true
+  defp valid_field?(:windows, %Windows{}), do: true
+  defp valid_field?(:file_tree, %FileTreeState{}), do: true
+  defp valid_field?(:viewport, %Viewport{}), do: true
+  defp valid_field?(:mouse, %Mouse{}), do: true
+  defp valid_field?(:highlight, %Highlighting{}), do: true
+  defp valid_field?(:lsp_pending, value) when is_map(value), do: true
+  defp valid_field?(:injection_ranges, value) when is_map(value), do: true
+  defp valid_field?(:search, %Search{}), do: true
+  defp valid_field?(:editing, %VimState{}), do: true
+  defp valid_field?(:document_highlights, nil), do: true
+  defp valid_field?(:document_highlights, value) when is_list(value), do: true
+  defp valid_field?(:agent_ui, %UIState{}), do: true
+  defp valid_field?(_field, _value), do: false
+
+  @spec fetch_version(map()) :: pos_integer()
+  defp fetch_version(map) do
+    case fetch_any(map, [:version, "version"]) do
+      {:ok, version} when is_integer(version) and version > 0 -> version
+      _ -> @version
+    end
+  end
+
+  @spec fetch_present_fields(map()) :: [field_name()] | nil
+  defp fetch_present_fields(map) do
+    case fetch_any(map, [:present_fields, "present_fields"]) do
+      {:ok, fields} when is_list(fields) -> normalize_present_fields(fields)
+      _ -> nil
+    end
+  end
+
+  @spec normalize_present_fields([term()]) :: [field_name()]
+  defp normalize_present_fields(fields) do
+    Enum.flat_map(fields, &normalize_present_field/1)
+  end
+
+  @spec normalize_present_field(term()) :: [field_name()]
+  defp normalize_present_field(field) when is_atom(field) do
+    if field in @workspace_fields, do: [field], else: []
+  end
+
+  defp normalize_present_field(field) when is_binary(field) do
+    case Enum.find(@workspace_fields, &(Atom.to_string(&1) == field)) do
+      nil -> []
+      workspace_field -> [workspace_field]
+    end
+  end
+
+  defp normalize_present_field(_field), do: []
+
+  @spec fetch_field(map(), field_name()) :: {:ok, term()} | :error
+  defp fetch_field(map, :editing), do: fetch_any(map, [:editing, "editing", :vim, "vim"])
+  defp fetch_field(map, field), do: fetch_any(map, [field, Atom.to_string(field)])
+
+  @spec fetch_any(map(), [atom() | String.t()]) :: {:ok, term()} | :error
+  defp fetch_any(map, [key | rest]) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> {:ok, value}
+      :error -> fetch_any(map, rest)
+    end
+  end
+
+  defp fetch_any(_map, []), do: :error
+end

--- a/lib/minga_editor/state/tab_bar.ex
+++ b/lib/minga_editor/state/tab_bar.ex
@@ -186,7 +186,7 @@ defmodule MingaEditor.State.TabBar do
   end
 
   @doc "Updates the context of the tab with the given id."
-  @spec update_context(t(), Tab.id(), Tab.context()) :: t()
+  @spec update_context(t(), Tab.id(), Tab.context() | Tab.legacy_context()) :: t()
   def update_context(%__MODULE__{tabs: tabs} = tb, id, context) do
     new_tabs =
       Enum.map(tabs, fn

--- a/lib/minga_editor/workspace/state.ex
+++ b/lib/minga_editor/workspace/state.ex
@@ -18,6 +18,7 @@ defmodule MingaEditor.Workspace.State do
   alias MingaEditor.State.Highlighting
   alias MingaEditor.State.Mouse
   alias MingaEditor.State.Search
+  alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
@@ -58,17 +59,11 @@ defmodule MingaEditor.Workspace.State do
             agent_ui: UIState.new()
 
   @doc "Returns the list of field names (for snapshot/restore compatibility)."
-  @spec field_names() :: [atom()]
-  def field_names do
-    %__MODULE__{viewport: %Viewport{top: 0, left: 0, rows: 1, cols: 1}}
-    |> Map.keys()
-    |> Enum.reject(&(&1 == :__struct__))
-  end
+  @spec field_names() :: [TabContext.field_name()]
+  def field_names, do: TabContext.field_names()
 
   @doc """
-  Converts a workspace into a flat-map tab context suitable for storing
-  on a `MingaEditor.State.Tab` and later restoring via
-  `restore_tab_context/2`.
+  Converts a workspace into a typed tab context suitable for storing on a `MingaEditor.State.Tab` and later restoring via `restore_tab_context/2`.
 
   The single chokepoint for snapshots. Beyond the `Map.from_struct/1`
   conversion, this normalises `editing` so the snapshotted vim state is a
@@ -77,22 +72,20 @@ defmodule MingaEditor.Workspace.State do
   Use this everywhere the editor captures `state.workspace` into a tab
   context.
   """
-  @spec to_tab_context(t()) :: map()
+  @spec to_tab_context(t()) :: TabContext.t()
   def to_tab_context(%__MODULE__{} = ws) do
     ws
     |> Map.update!(:editing, &VimState.normalize/1)
     |> Map.from_struct()
+    |> TabContext.from_workspace_map()
   end
 
-  @doc "Restores a flat tab context into a workspace. Empty contexts are ignored by this pure helper; EditorState handles brand-new tab defaults because those need editor dimensions."
-  @spec restore_tab_context(t(), map()) :: t()
+  @doc "Restores a tab context into a workspace. Empty contexts are ignored by this pure helper; EditorState handles brand-new tab defaults because those need editor dimensions."
+  @spec restore_tab_context(t(), TabContext.t() | TabContext.legacy()) :: t()
   def restore_tab_context(%__MODULE__{} = ws, context) when is_map(context) do
-    Enum.reduce(field_names(), ws, fn field, acc ->
-      case Map.fetch(context, field) do
-        {:ok, value} -> Map.put(acc, field, value)
-        :error -> acc
-      end
-    end)
+    context
+    |> TabContext.to_workspace_map()
+    |> Enum.reduce(ws, fn {field, value}, acc -> Map.put(acc, field, value) end)
   end
 
   # ── Pure workspace operations ─────────────────────────────────────────────

--- a/test/minga_editor/commands/agent_split_test.exs
+++ b/test/minga_editor/commands/agent_split_test.exs
@@ -10,6 +10,7 @@ defmodule MingaEditor.Commands.AgentSplitTest do
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
   alias MingaEditor.Window
   alias MingaEditor.Window.Content
@@ -33,7 +34,7 @@ defmodule MingaEditor.Commands.AgentSplitTest do
 
     file_context = %{
       keymap_scope: :editor,
-      windows: %{
+      windows: %Windows{
         tree: {:leaf, 1},
         map: %{1 => window},
         active: 1,
@@ -41,7 +42,7 @@ defmodule MingaEditor.Commands.AgentSplitTest do
       }
     }
 
-    file_tab = %{file_tab | context: file_context}
+    file_tab = Tab.set_context(file_tab, file_context)
 
     # Agent tab with context containing an agent_chat window. The session
     # pid lives on the tab; AgentAccess.session/1 reads it through the
@@ -52,7 +53,7 @@ defmodule MingaEditor.Commands.AgentSplitTest do
 
     agent_context = %{
       keymap_scope: :agent,
-      windows: %{
+      windows: %Windows{
         tree: {:leaf, 1},
         map: %{1 => agent_win},
         active: 1,
@@ -60,7 +61,7 @@ defmodule MingaEditor.Commands.AgentSplitTest do
       }
     }
 
-    agent_tab = %{agent_tab | context: agent_context}
+    agent_tab = Tab.set_context(agent_tab, agent_context)
 
     tb = %TabBar{
       tabs: [file_tab, agent_tab],
@@ -74,7 +75,7 @@ defmodule MingaEditor.Commands.AgentSplitTest do
       workspace: %MingaEditor.Workspace.State{
         viewport: Viewport.new(24, 80),
         buffers: %Buffers{active: buf, list: [buf]},
-        windows: %MingaEditor.State.Windows{
+        windows: %Windows{
           tree: {:leaf, 1},
           map: %{1 => window},
           active: 1,

--- a/test/minga_editor/shell/board/gui_action_test.exs
+++ b/test/minga_editor/shell/board/gui_action_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.Shell.Board.GUIActionTest do
   alias MingaAgent.Subagent.Handle
   alias MingaEditor.Shell.Board
   alias MingaEditor.Shell.Board.State, as: BoardState
+  alias MingaEditor.State.Tab.Context
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
   alias MingaEditor.Workspace.State, as: WorkspaceState
@@ -115,7 +116,7 @@ defmodule MingaEditor.Shell.Board.GUIActionTest do
       zoomed = board.cards[card.id]
       assert board.focused_card == card.id
       assert board.zoomed_into == card.id
-      refute Map.has_key?(zoomed.workspace, :__struct__)
+      assert %Context{} = zoomed.workspace
       assert zoomed.workspace.editing.mode == :normal
       assert %Minga.Mode.State{} = zoomed.workspace.editing.mode_state
       assert restored_workspace.viewport.rows == 10

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.State.SnapshotTest do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context
   alias MingaEditor.State.TabBar
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
@@ -131,6 +132,35 @@ defmodule MingaEditor.State.SnapshotTest do
       assert restored.workspace.buffers.active == buf_a
     end
 
+    test "migrates legacy vim field into editing" do
+      state = make_state(mode: :normal)
+      legacy_vim = %VimState{mode: :insert, mode_state: Mode.initial_state()}
+
+      restored = EditorState.restore_tab_context(state, %{vim: legacy_vim})
+
+      assert restored.workspace.editing == legacy_vim
+    end
+
+    test "restores string-key encoded contexts using present_fields" do
+      {:ok, buf_a} = BufferServer.start_link(content: "a")
+      {:ok, buf_b} = BufferServer.start_link(content: "b")
+      state = make_state(buffer: buf_a, keymap_scope: :editor)
+      legacy_vim = %VimState{mode: :insert, mode_state: Mode.initial_state()}
+      buffers = %Buffers{active: buf_b, list: [buf_b], active_index: 0}
+
+      restored =
+        EditorState.restore_tab_context(state, %{
+          "version" => 1,
+          "present_fields" => ["buffers", "editing"],
+          "vim" => legacy_vim,
+          "buffers" => buffers
+        })
+
+      assert restored.workspace.editing == legacy_vim
+      assert restored.workspace.buffers == buffers
+      assert restored.workspace.keymap_scope == :editor
+    end
+
     test "handles empty context gracefully" do
       state = make_state()
       restored = EditorState.restore_tab_context(state, %{})
@@ -145,14 +175,14 @@ defmodule MingaEditor.State.SnapshotTest do
       tb = TabBar.new(tab)
 
       state = make_state(buffer: buf, tab_bar: tb)
-      assert TabBar.active(tb).context == %{}
+      assert Context.empty?(TabBar.active(tb).context)
 
       restored = EditorState.restore_tab_context(state, %{})
 
       updated_tb = restored.shell_state.tab_bar
       stored_ctx = TabBar.get(updated_tb, tab.id).context
 
-      assert map_size(stored_ctx) > 0
+      refute Context.empty?(stored_ctx)
       assert stored_ctx.keymap_scope == :editor
       assert stored_ctx.editing.mode == :normal
       assert stored_ctx.buffers.active == buf
@@ -210,13 +240,13 @@ defmodule MingaEditor.State.SnapshotTest do
 
       {tb, tab_b} = TabBar.add(tb, :file, "b.ex")
       tb = TabBar.switch_to(tb, tab_a.id)
-      assert TabBar.get(tb, tab_b.id).context == %{}
+      assert Context.empty?(TabBar.get(tb, tab_b.id).context)
 
       state = make_state(buffer: buf, tab_bar: tb, mode: :normal, keymap_scope: :editor)
       switched = EditorState.switch_tab(state, tab_b.id)
 
       stored_ctx = TabBar.get(switched.shell_state.tab_bar, tab_b.id).context
-      assert map_size(stored_ctx) > 0
+      refute Context.empty?(stored_ctx)
       assert stored_ctx.keymap_scope == :editor
       assert stored_ctx.buffers.active == buf
     end

--- a/test/minga_editor/state/tab_bar_test.exs
+++ b/test/minga_editor/state/tab_bar_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.State.TabBarTest do
   alias MingaEditor.State.AgentGroup
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
+  alias MingaEditor.VimState
 
   defp file_tab(id, label \\ ""), do: Tab.new_file(id, label)
 
@@ -155,9 +156,9 @@ defmodule MingaEditor.State.TabBarTest do
   describe "update_context/3" do
     test "stores context on the given tab" do
       tb = TabBar.new(file_tab(1))
-      ctx = %{mode: :insert}
-      tb = TabBar.update_context(tb, 1, ctx)
-      assert TabBar.get(tb, 1).context == ctx
+      editing = VimState.new()
+      tb = TabBar.update_context(tb, 1, %{editing: editing})
+      assert TabBar.get(tb, 1).context.editing == editing
     end
   end
 
@@ -627,10 +628,11 @@ defmodule MingaEditor.State.TabBarTest do
 
       tab1 = file_tab(1, "active")
 
-      tab2 = %{
+      tab2 =
         file_tab(2, "inactive")
-        | context: %{buffers: %Buffers{list: [dead, live], active: dead, active_index: 0}}
-      }
+        |> Tab.set_context(%{
+          buffers: %Buffers{list: [dead, live], active: dead, active_index: 0}
+        })
 
       tb = %TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
       result = TabBar.scrub_dead_buffer(tb, dead)
@@ -654,15 +656,15 @@ defmodule MingaEditor.State.TabBarTest do
 
       dead = :dead_pid
 
-      tab1 = %{
+      tab1 =
         file_tab(1, "a")
-        | context: %{buffers: %Buffers{list: [dead], active: dead, active_index: 0}}
-      }
+        |> Tab.set_context(%{buffers: %Buffers{list: [dead], active: dead, active_index: 0}})
 
-      tab2 = %{
+      tab2 =
         file_tab(2, "b")
-        | context: %{buffers: %Buffers{list: [:live, dead], active: :live, active_index: 0}}
-      }
+        |> Tab.set_context(%{
+          buffers: %Buffers{list: [:live, dead], active: :live, active_index: 0}
+        })
 
       tb = %TabBar{tabs: [tab1, tab2], active_id: 1, next_id: 3}
       result = TabBar.scrub_dead_buffer(tb, dead)

--- a/test/minga_editor/state/tab_switch_test.exs
+++ b/test/minga_editor/state/tab_switch_test.exs
@@ -198,7 +198,7 @@ defmodule MingaEditor.State.TabSwitchTest do
       # Tab 1's context should be snapshotted (preserved for later restore)
       tb = new_state.shell_state.tab_bar
       tab1 = TabBar.get(tb, 1)
-      assert tab1.context[:buffers].active == buf1
+      assert tab1.context.buffers.active == buf1
     end
 
     test "file-to-agent sets keymap_scope to :agent" do
@@ -222,7 +222,7 @@ defmodule MingaEditor.State.TabSwitchTest do
 
       # The file tab's context should be snapshotted
       file_tab = TabBar.get(tb, file_tab_id)
-      assert file_tab.context[:keymap_scope] == :editor
+      assert file_tab.context.keymap_scope == :editor
     end
 
     test "agent-to-file sets keymap_scope to :editor" do
@@ -242,7 +242,7 @@ defmodule MingaEditor.State.TabSwitchTest do
       # The agent tab's context should be preserved
       tb = new_state.shell_state.tab_bar
       agent_tab = TabBar.get(tb, agent_tab_id)
-      assert agent_tab.context[:keymap_scope] == :agent
+      assert agent_tab.context.keymap_scope == :agent
     end
 
     test "round-trip invariant: switch away and back restores equivalent state" do

--- a/test/minga_editor/state/tab_test.exs
+++ b/test/minga_editor/state/tab_test.exs
@@ -3,6 +3,8 @@ defmodule MingaEditor.State.TabTest do
 
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context
+  alias MingaEditor.VimState
 
   describe "new_file/2" do
     test "creates a file tab with default label" do
@@ -10,7 +12,7 @@ defmodule MingaEditor.State.TabTest do
       assert tab.id == 1
       assert tab.kind == :file
       assert tab.label == ""
-      assert tab.context == %{}
+      assert Context.empty?(tab.context)
     end
 
     test "creates a file tab with a label" do
@@ -41,10 +43,45 @@ defmodule MingaEditor.State.TabTest do
   end
 
   describe "set_context/2" do
-    test "stores a context snapshot" do
-      ctx = %{mode: :insert, keymap_scope: :editor}
+    test "stores a context snapshot as a typed struct" do
+      editing = VimState.new()
+      ctx = %{editing: editing, keymap_scope: :editor}
       tab = Tab.new_file(1) |> Tab.set_context(ctx)
-      assert tab.context == ctx
+      assert %Context{} = tab.context
+      assert tab.context.editing == editing
+      assert tab.context.keymap_scope == :editor
+    end
+
+    test "migrates legacy vim field into editing" do
+      legacy_vim = VimState.new()
+      tab = Tab.new_file(1) |> Tab.set_context(%{vim: legacy_vim})
+      assert tab.context.editing == legacy_vim
+    end
+
+    test "honors encoded present fields during migration" do
+      tab = Tab.new_file(1) |> Tab.set_context(%{"present_fields" => [], "editing" => nil})
+      assert Context.empty?(tab.context)
+    end
+
+    test "drops malformed legacy fields instead of marking them present" do
+      tab = Tab.new_file(1) |> Tab.set_context(%{editing: :insert})
+      assert Context.empty?(tab.context)
+    end
+
+    test "drops invalid keymap scopes" do
+      tab = Tab.new_file(1) |> Tab.set_context(%{keymap_scope: :unknown_scope})
+      assert Context.empty?(tab.context)
+    end
+
+    test "ignores malformed present_fields on externally built structs" do
+      context = %Context{present_fields: [:missing_field, "keymap_scope"], keymap_scope: :editor}
+      assert Context.to_workspace_map(context) == %{keymap_scope: :editor}
+    end
+
+    test "drops malformed values from externally built structs" do
+      context = %Context{present_fields: [:keymap_scope], keymap_scope: :unknown_scope}
+      assert Context.empty?(context)
+      assert Context.to_workspace_map(context) == %{}
     end
   end
 
@@ -97,7 +134,7 @@ defmodule MingaEditor.State.TabTest do
     end
 
     test "no-op when context has no buffers key" do
-      tab = Tab.new_file(1) |> Tab.set_context(%{editing: :normal})
+      tab = Tab.new_file(1) |> Tab.set_context(%{editing: VimState.new()})
       result = Tab.scrub_buffer(tab, :some_pid)
 
       assert result == tab

--- a/test/minga_editor/state_test.exs
+++ b/test/minga_editor/state_test.exs
@@ -419,7 +419,7 @@ defmodule MingaEditor.StateTest do
       # The new file tab's snapshotted context should also have the correct
       # window content type, so switching tabs restores it properly.
       active_tab = TabBar.active(new_state.shell_state.tab_bar)
-      tab_windows = active_tab.context[:windows]
+      tab_windows = active_tab.context.windows
 
       if tab_windows do
         active_win_id = tab_windows.active

--- a/test/minga_editor/workspace/state_test.exs
+++ b/test/minga_editor/workspace/state_test.exs
@@ -10,6 +10,7 @@ defmodule MingaEditor.Workspace.StateTest do
 
   alias Minga.Mode
   alias MingaEditor.VimState
+  alias MingaEditor.State.Tab.Context
   alias MingaEditor.Window.Content
   alias MingaEditor.Workspace.State, as: WorkspaceState
 
@@ -88,15 +89,15 @@ defmodule MingaEditor.Workspace.StateTest do
   end
 
   describe "to_tab_context/1" do
-    test "returns a flat map of workspace fields" do
+    test "returns a typed context of workspace fields" do
       ws = base_state().workspace
       ctx = WorkspaceState.to_tab_context(ws)
 
-      assert is_map(ctx)
-      refute Map.has_key?(ctx, :__struct__)
+      assert %Context{} = ctx
       assert ctx.buffers == ws.buffers
       assert ctx.windows == ws.windows
       assert ctx.viewport == ws.viewport
+      assert Enum.sort(WorkspaceState.field_names()) == Enum.sort(ctx.present_fields)
     end
 
     test "normalises an in-flight CommandState back to %Mode.State{} when mode is :normal" do


### PR DESCRIPTION
# TL;DR
Tab snapshots now use a typed `MingaEditor.State.Tab.Context` struct instead of free-form maps, so per-tab restore data has an explicit shape and legacy migration is centralized.

Closes #1402

## Context
Issue #1402 is part of the tab-bar state hardening work in #1395. The old `Tab.context()` map accepted missing or misspelled fields silently, which made tab restore corruption hard to catch in review or type checks.

## Changes
- Added `MingaEditor.State.Tab.Context`, with typed per-tab workspace fields, context versioning, and `present_fields` tracking for partial legacy maps.
- Updated snapshot, restore, tab-bar, GUI, TUI, and background-agent paths to normalize through the context API instead of reading or mutating raw context maps.
- Preserved migration behavior for empty contexts, string-key decoded contexts, and the legacy `:vim` or `"vim"` alias for `:editing`.
- Added validation so malformed legacy values are dropped instead of becoming typed context fields.
- Updated tests to assert typed contexts, legacy migration, string-key persisted context handling, and affected tab-switching paths.

## Verification
- `make lint` passed.
- `mix test.llm` passed: 8015 tests, 54 doctests, 97 properties, 0 failures, 5 skipped, 115 excluded.

## Acceptance Criteria Addressed
- `MingaEditor.State.Tab.Context` exists as a struct with per-tab fields enumerated and typed. ✅
- `Tab.context()` is typed as `Context.t()` and callers compile against the new type. ✅
- `restore_tab_context` accepts legacy maps and new structs, then emits typed structs through snapshot and tab storage paths. ✅
- Existing serialized or legacy context data continues to load through string-key, `present_fields`, empty-context, and `:vim` alias migration coverage. ✅
- Tests and type checks run green with tighter context validation. ✅


