### PR TITLE
feat(command): add help for bindings and options

### DIFF
--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -361,6 +361,10 @@ defmodule Minga.Buffer do
   @spec set_option(server(), atom(), term()) :: {:ok, term()} | {:error, String.t()}
   defdelegate set_option(server, name, value), to: Server
 
+  @doc "Returns only options explicitly overridden on this buffer."
+  @spec local_option_overrides(server()) :: %{atom() => term()}
+  defdelegate local_option_overrides(server), to: Server
+
   # ── Snapshots ──────────────────────────────────────────────────────
 
   @doc "Capture a snapshot of the document state (for undo boundaries and tab switching)."

--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -361,6 +361,10 @@ defmodule Minga.Buffer do
   @spec set_option(server(), atom(), term()) :: {:ok, term()} | {:error, String.t()}
   defdelegate set_option(server, name, value), to: Server
 
+  @doc "Returns all buffer option values currently cached on this buffer."
+  @spec local_options(server()) :: %{atom() => term()}
+  defdelegate local_options(server), to: Server
+
   @doc "Returns only options explicitly overridden on this buffer."
   @spec local_option_overrides(server()) :: %{atom() => term()}
   defdelegate local_option_overrides(server), to: Server

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -519,12 +519,19 @@ defmodule Minga.Buffer.Server do
   end
 
   @doc """
-  Returns all buffer-local option overrides (not the resolved values,
-  just the overrides set on this buffer).
+  Returns all buffer option values currently cached on this buffer.
   """
   @spec local_options(GenServer.server()) :: %{atom() => term()}
   def local_options(server) do
     GenServer.call(server, :local_options)
+  end
+
+  @doc """
+  Returns only options explicitly overridden on this buffer.
+  """
+  @spec local_option_overrides(GenServer.server()) :: %{atom() => term()}
+  def local_option_overrides(server) do
+    GenServer.call(server, :local_option_overrides)
   end
 
   @doc "Appends text to the end of the buffer, bypassing read-only. For programmatic writes."
@@ -1473,6 +1480,11 @@ defmodule Minga.Buffer.Server do
 
   def handle_call(:local_options, _from, state) do
     {:reply, state.options, state}
+  end
+
+  def handle_call(:local_option_overrides, _from, state) do
+    overrides = Map.take(state.options, MapSet.to_list(state.explicit_options))
+    {:reply, overrides, state}
   end
 
   def handle_call({:append, text}, _from, state) do

--- a/lib/minga/command/parser.ex
+++ b/lib/minga/command/parser.ex
@@ -88,6 +88,8 @@ defmodule Minga.Command.Parser do
           | {:extension_update, []}
           | {:extension_update_all, []}
           | {:parser_restart, []}
+          | {:describe_option, []}
+          | {:describe_option_named, [String.t()]}
           | {:agent_abort, []}
           | {:agent_new_session, []}
           | {:agent_set_model, [String.t()]}
@@ -265,6 +267,8 @@ defmodule Minga.Command.Parser do
   defp do_parse("ToolList"), do: {:tool_list, []}
   defp do_parse("ToolManage"), do: {:tool_manage, []}
   defp do_parse("warnings"), do: {:view_warnings, []}
+  defp do_parse("describe"), do: {:describe_option, []}
+  defp do_parse("describe " <> name), do: {:describe_option_named, [String.trim(name)]}
   defp do_parse("vsplit"), do: {:split_vertical, []}
   defp do_parse("vs"), do: {:split_vertical, []}
   defp do_parse("split"), do: {:split_horizontal, []}

--- a/lib/minga/command/registry.ex
+++ b/lib/minga/command/registry.ex
@@ -56,6 +56,7 @@ defmodule Minga.Command.Registry do
     MingaEditor.Commands.Extensions,
     MingaEditor.Commands.Macros,
     MingaEditor.Commands.Formatting,
+    MingaEditor.Commands.Help,
     MingaEditor.Commands.UI,
     MingaEditor.Commands.Tool,
     MingaEditor.Commands.AgentGroup

--- a/lib/minga/config/completion.ex
+++ b/lib/minga/config/completion.ex
@@ -39,7 +39,7 @@ defmodule Minga.Config.Completion do
   @spec option_name_items() :: [item()]
   def option_name_items do
     Options.option_specs()
-    |> Enum.map(fn {name, type, default} ->
+    |> Enum.map(fn {name, type, default, description} ->
       name_str = Atom.to_string(name)
 
       %{
@@ -48,7 +48,7 @@ defmodule Minga.Config.Completion do
         insert_text: ":#{name_str}",
         filter_text: name_str,
         detail: format_type(type),
-        documentation: option_documentation(name, type, default),
+        documentation: option_documentation(name, type, default, description),
         sort_text: name_str,
         text_edit: nil,
         raw: nil
@@ -182,200 +182,14 @@ defmodule Minga.Config.Completion do
   defp format_type(:any), do: "any"
   defp format_type({:enum, values}), do: Enum.map_join(values, " | ", &inspect/1)
 
-  @spec option_documentation(atom(), Options.type_descriptor(), term()) :: String.t()
-  defp option_documentation(name, type, default) do
+  @spec option_documentation(atom(), Options.type_descriptor(), term(), String.t()) :: String.t()
+  defp option_documentation(_name, type, default, description) do
     type_line = "**Type:** #{format_type(type)}"
     default_line = "**Default:** `#{inspect(default)}`"
-    desc = option_description(name)
 
-    lines = [desc, "", type_line, default_line]
+    lines = [description, "", type_line, default_line]
     Enum.join(lines, "\n")
   end
-
-  @spec option_description(atom()) :: String.t()
-  defp option_description(:editing_model),
-    do: "Editing model: Vim keybindings or CUA (standard) keybindings."
-
-  defp option_description(:tab_width), do: "Number of spaces per tab stop."
-
-  defp option_description(:line_numbers),
-    do: "Line number display: hybrid (relative + current absolute), absolute, relative, or none."
-
-  defp option_description(:show_gutter_separator),
-    do: "Show a vertical separator between the gutter and the buffer content."
-
-  defp option_description(:autopair),
-    do: "Automatically insert matching brackets, quotes, and parentheses."
-
-  defp option_description(:scroll_margin),
-    do: "Minimum lines to keep visible above and below the cursor when scrolling."
-
-  defp option_description(:scroll_lines), do: "Number of lines to scroll per scroll wheel tick."
-  defp option_description(:theme), do: "Color theme for syntax highlighting and UI elements."
-  defp option_description(:indent_with), do: "Use spaces or tabs for indentation."
-  defp option_description(:trim_trailing_whitespace), do: "Remove trailing whitespace on save."
-  defp option_description(:insert_final_newline), do: "Ensure file ends with a newline on save."
-
-  defp option_description(:format_on_save),
-    do: "Run the configured formatter when saving a buffer."
-
-  defp option_description(:auto_save_delay_ms),
-    do:
-      "Debounce before dirty file-backed buffers auto-save, in milliseconds. Set to 0 to disable."
-
-  defp option_description(:formatter),
-    do:
-      "External formatter command (e.g., \"mix format\"). Nil uses the default for the filetype."
-
-  defp option_description(:title_format),
-    do: "Window title template. Placeholders: {filename}, {dirty}, {directory}."
-
-  defp option_description(:recent_files_limit), do: "Maximum number of recent files to remember."
-
-  defp option_description(:persist_recent_files),
-    do: "Persist recent file list across editor restarts."
-
-  defp option_description(:clipboard), do: "Clipboard integration mode."
-  defp option_description(:wrap), do: "Soft-wrap long lines at the viewport edge."
-  defp option_description(:linebreak), do: "Break lines at word boundaries when wrapping."
-  defp option_description(:breakindent), do: "Preserve indentation on wrapped continuation lines."
-
-  defp option_description(:agent_provider),
-    do: "AI agent backend: auto-detect or native (built-in)."
-
-  defp option_description(:agent_model),
-    do: "Override the default AI model. Nil uses the provider's default."
-
-  defp option_description(:agent_tool_approval),
-    do: "When to require approval for agent tool calls: destructive-only, all, or none."
-
-  defp option_description(:agent_destructive_tools),
-    do:
-      "List of tool names considered destructive (require approval when agent_tool_approval is :destructive)."
-
-  defp option_description(:agent_tool_permissions),
-    do: "Per-tool permission overrides as a map of tool name to :allow/:deny/:ask."
-
-  defp option_description(:agent_session_retention_days),
-    do: "Days to keep agent session history before cleanup."
-
-  defp option_description(:agent_panel_split),
-    do: "Agent panel width as a percentage of the viewport (30-80)."
-
-  defp option_description(:startup_view),
-    do: "Which view to show on startup: the agent panel or the editor."
-
-  defp option_description(:agent_auto_context),
-    do: "Automatically include buffer context in agent prompts."
-
-  defp option_description(:agent_max_tokens), do: "Maximum tokens per agent response."
-  defp option_description(:agent_max_retries), do: "Maximum retries on agent API failures."
-
-  defp option_description(:agent_models),
-    do: "List of available model identifiers for the model picker."
-
-  defp option_description(:agent_prompt_cache),
-    do: "Enable prompt caching for supported providers."
-
-  defp option_description(:agent_notifications),
-    do: "Enable desktop notifications for agent events."
-
-  defp option_description(:agent_notify_on),
-    do: "Which agent events trigger notifications: :approval, :complete, :error."
-
-  defp option_description(:agent_system_prompt),
-    do: "Custom system prompt that replaces the default agent system prompt."
-
-  defp option_description(:agent_append_system_prompt),
-    do: "Text appended to the default agent system prompt (additive, not replacing)."
-
-  defp option_description(:agent_diff_size_threshold),
-    do: "Maximum diff size in bytes before truncating in agent context."
-
-  defp option_description(:agent_max_turns), do: "Maximum conversation turns per agent session."
-
-  defp option_description(:agent_max_cost),
-    do: "Maximum cost in dollars per agent session. Nil for unlimited."
-
-  defp option_description(:agent_api_base_url), do: "Override the base URL for the agent API."
-  defp option_description(:agent_api_endpoints), do: "Per-model API endpoint overrides as a map."
-
-  defp option_description(:agent_mcp_servers),
-    do: "List of MCP server configs to launch for native agent sessions."
-
-  defp option_description(:agent_compaction_threshold),
-    do: "Context window usage ratio that triggers automatic compaction. Nil to disable."
-
-  defp option_description(:agent_compaction_keep_recent),
-    do: "Number of recent messages to preserve during compaction."
-
-  defp option_description(:agent_approval_timeout),
-    do: "Timeout in milliseconds for tool approval prompts."
-
-  defp option_description(:agent_subagent_timeout),
-    do: "Timeout in milliseconds for subagent tool calls."
-
-  defp option_description(:agent_mention_max_file_size),
-    do: "Maximum file size in bytes for @file mentions in agent chat."
-
-  defp option_description(:agent_notify_debounce),
-    do: "Debounce interval in milliseconds for agent notifications."
-
-  defp option_description(:confirm_quit),
-    do: "Ask for confirmation before quitting with unsaved changes."
-
-  defp option_description(:font_family), do: "Font family name (GUI frontends only)."
-  defp option_description(:font_size), do: "Font size in points (GUI frontends only)."
-  defp option_description(:font_weight), do: "Font weight (GUI frontends only)."
-  defp option_description(:font_ligatures), do: "Enable font ligatures (GUI frontends only)."
-
-  defp option_description(:font_fallback),
-    do: "Fallback font families for missing glyphs (GUI frontends only)."
-
-  defp option_description(:prettify_symbols),
-    do: "Replace certain symbols with Unicode equivalents (e.g., -> becomes →)."
-
-  defp option_description(:whichkey_layout),
-    do: "Which-key popup position: bottom bar or floating window."
-
-  defp option_description(:log_level), do: "Global log level for the *Messages* buffer."
-
-  defp option_description(:log_level_render),
-    do: "Log level for the render subsystem. :default inherits from :log_level."
-
-  defp option_description(:log_level_lsp),
-    do: "Log level for LSP communication. :default inherits from :log_level."
-
-  defp option_description(:log_level_agent),
-    do: "Log level for the AI agent subsystem. :default inherits from :log_level."
-
-  defp option_description(:log_level_editor),
-    do: "Log level for editor operations. :default inherits from :log_level."
-
-  defp option_description(:log_level_config),
-    do: "Log level for config loading. :default inherits from :log_level."
-
-  defp option_description(:log_level_port),
-    do: "Log level for port/frontend communication. :default inherits from :log_level."
-
-  defp option_description(:cursorline), do: "Highlight the line the cursor is on."
-
-  defp option_description(:nav_flash),
-    do: "Flash the cursor line after large jumps for visual orientation."
-
-  defp option_description(:nav_flash_threshold),
-    do: "Minimum line distance to trigger the navigation flash."
-
-  defp option_description(:yank_flash),
-    do: "Flash the yanked region briefly after a yank operation."
-
-  defp option_description(:parser_tree_ttl),
-    do: "Seconds to keep unused tree-sitter parse trees in memory."
-
-  defp option_description(:event_retention_days),
-    do: "Days to keep event log entries before cleanup."
-
-  defp option_description(_), do: ""
 
   @spec extensions_for_filetype(atom()) :: String.t()
   defp extensions_for_filetype(filetype) do

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -165,8 +165,25 @@ defmodule Minga.Config.Options do
   @typedoc "Line number display style."
   @type line_number_style :: :hybrid | :absolute | :relative | :none
 
-  @typedoc "Option spec: `{name, type_descriptor, default_value}`."
-  @type option_spec :: {option_name(), type_descriptor(), term()}
+  @typedoc "Option spec: `{name, type_descriptor, default_value, description}`."
+  @type option_spec :: {option_name(), type_descriptor(), term(), String.t()}
+
+  @typedoc "Human-readable metadata for one option."
+  @type option_metadata :: %{
+          name: option_name(),
+          type: type_descriptor(),
+          default: term(),
+          description: String.t()
+        }
+
+  @typedoc "Human-readable metadata for an extension option."
+  @type extension_option_metadata :: %{
+          extension: atom(),
+          name: atom(),
+          type: type_descriptor(),
+          default: term(),
+          description: String.t()
+        }
 
   @type type_descriptor ::
           :pos_integer
@@ -217,93 +234,143 @@ defmodule Minga.Config.Options do
   end
 
   @option_specs [
-    {:editing_model, {:enum, [:vim, :cua]}, :vim},
-    {:space_leader, {:enum, [:chord, :off]}, :chord},
-    {:tab_width, :pos_integer, 2},
-    {:line_numbers, {:enum, [:hybrid, :absolute, :relative, :none]}, :hybrid},
-    {:show_gutter_separator, :boolean, true},
-    {:autopair, :boolean, true},
-    {:scroll_margin, :non_neg_integer, 5},
-    {:scroll_lines, :pos_integer, 1},
-    {:theme, :theme_atom, :doom_one},
-    {:indent_with, {:enum, [:spaces, :tabs]}, :spaces},
-    {:indent_guides, :boolean, true},
-    {:trim_trailing_whitespace, :boolean, false},
-    {:insert_final_newline, :boolean, false},
-    {:format_on_save, :boolean, false},
-    {:auto_save_delay_ms, :non_neg_integer, 1000},
-    {:formatter, :string_or_nil, nil},
-    {:title_format, :string, "{filename} {dirty}({directory}) - Minga"},
-    {:recent_files_limit, :pos_integer, 200},
-    {:persist_recent_files, :boolean, true},
-    {:clipboard, {:enum, [:unnamedplus, :unnamed, :none]}, :unnamedplus},
-    {:wrap, :boolean, false},
-    {:linebreak, :boolean, true},
-    {:breakindent, :boolean, true},
-    {:agent_provider, {:enum, [:auto, :native]}, :auto},
-    {:agent_model, :string_or_nil, nil},
-    {:agent_tool_approval, {:enum, [:destructive, :all, :none]}, :destructive},
+    {:editing_model, {:enum, [:vim, :cua]}, :vim,
+     "Editing model used for text input and selection."},
+    {:space_leader, {:enum, [:chord, :off]}, :chord,
+     "How the Space key enters leader-key sequences in normal mode."},
+    {:tab_width, :pos_integer, 2, "Number of spaces per tab stop."},
+    {:line_numbers, {:enum, [:hybrid, :absolute, :relative, :none]}, :hybrid,
+     "Line number style shown in the editor gutter."},
+    {:show_gutter_separator, :boolean, true,
+     "Whether to draw a separator between the gutter and buffer text."},
+    {:autopair, :boolean, true, "Whether insert mode automatically inserts matching delimiters."},
+    {:scroll_margin, :non_neg_integer, 5,
+     "Minimum number of context lines kept around the cursor while scrolling."},
+    {:scroll_lines, :pos_integer, 1, "Number of lines moved for each wheel-scroll step."},
+    {:theme, :theme_atom, :doom_one, "Active color theme."},
+    {:indent_with, {:enum, [:spaces, :tabs]}, :spaces,
+     "Whether indentation inserts spaces or tab characters."},
+    {:indent_guides, :boolean, true, "Whether indentation guide decorations are shown."},
+    {:trim_trailing_whitespace, :boolean, false,
+     "Whether trailing whitespace is removed before saving."},
+    {:insert_final_newline, :boolean, false, "Whether files are saved with a final newline."},
+    {:format_on_save, :boolean, false, "Whether the configured formatter runs before saving."},
+    {:auto_save_delay_ms, :non_neg_integer, 1000,
+     "Delay before automatic save work runs; zero disables the timer."},
+    {:formatter, :string_or_nil, nil, "External formatter command for the current buffer."},
+    {:title_format, :string, "{filename} {dirty}({directory}) - Minga",
+     "Window title template with placeholder tokens."},
+    {:recent_files_limit, :pos_integer, 200, "Maximum number of recent files to keep."},
+    {:persist_recent_files, :boolean, true,
+     "Whether recent files are written to disk between sessions."},
+    {:clipboard, {:enum, [:unnamedplus, :unnamed, :none]}, :unnamedplus,
+     "Clipboard register integration mode."},
+    {:wrap, :boolean, false, "Whether long visual lines wrap in editor windows."},
+    {:linebreak, :boolean, true, "Whether wrapped lines break at word boundaries when possible."},
+    {:breakindent, :boolean, true,
+     "Whether wrapped line continuations align with the original indentation."},
+    {:agent_provider, {:enum, [:auto, :native]}, :auto, "Agent provider backend selection."},
+    {:agent_model, :string_or_nil, nil, "Default model used by new agent sessions."},
+    {:agent_tool_approval, {:enum, [:destructive, :all, :none]}, :destructive,
+     "When agent tool calls require user approval."},
     {:agent_destructive_tools, :string_list,
-     ["write_file", "edit_file", "multi_edit_file", "shell", "git_stage", "git_commit", "rename"]},
-    {:agent_tool_permissions, :map_or_nil, nil},
-    {:agent_hooks, :any, []},
-    {:agent_session_retention_days, :pos_integer, 30},
-    {:agent_panel_split, :pos_integer, 65},
-    {:startup_view, {:enum, [:agent, :editor]}, :agent},
-    {:agent_auto_context, :boolean, true},
-    {:agent_max_tokens, :pos_integer, 16_384},
-    {:agent_max_retries, :non_neg_integer, 3},
-    {:agent_models, :string_list, []},
-    {:agent_prompt_cache, :boolean, true},
-    {:agent_notifications, :boolean, true},
-    {:agent_notify_on, :any, [:approval, :complete, :error]},
-    {:agent_system_prompt, :string, ""},
-    {:agent_append_system_prompt, :string, ""},
-    {:agent_diff_size_threshold, :pos_integer, 1_048_576},
-    {:agent_max_turns, :pos_integer, 100},
-    {:agent_max_cost, :float_or_nil, nil},
-    {:agent_api_base_url, :string, ""},
-    {:agent_api_endpoints, :map_or_nil, nil},
-    {:agent_mcp_servers, :map_list, []},
-    {:agent_compaction_threshold, :float_or_nil, 0.8},
-    {:agent_compaction_keep_recent, :pos_integer, 6},
-    {:agent_approval_timeout, :pos_integer, 300_000},
-    {:agent_subagent_timeout, :pos_integer, 300_000},
-    {:agent_mention_max_file_size, :pos_integer, 262_144},
-    {:agent_notify_debounce, :pos_integer, 5_000},
-    {:agent_diagnostic_feedback, :boolean, true},
-    {:agent_flush_before_shell, :boolean, true},
-    {:confirm_quit, :boolean, true},
-    {:cursorline, :boolean, true},
-    {:nav_flash, :boolean, true},
-    {:nav_flash_threshold, :pos_integer, 5},
-    {:yank_flash, :boolean, true},
-    {:whichkey_layout, {:enum, [:bottom, :float]}, :bottom},
-    {:line_spacing, :float_or_nil, 1.0},
-    {:font_family, :string, "Menlo"},
-    {:font_size, :pos_integer, 13},
+     ["write_file", "edit_file", "multi_edit_file", "shell", "git_stage", "git_commit", "rename"],
+     "Tool names treated as destructive for approval prompts."},
+    {:agent_tool_permissions, :map_or_nil, nil, "Per-tool permission overrides for agent tools."},
+    {:agent_hooks, :any, [], "Agent lifecycle hook declarations loaded from config."},
+    {:agent_session_retention_days, :pos_integer, 30,
+     "Number of days to retain persisted agent sessions."},
+    {:agent_panel_split, :pos_integer, 65,
+     "Percentage of available width assigned to the agent panel."},
+    {:startup_view, {:enum, [:agent, :editor]}, :agent, "Initial view shown when Minga starts."},
+    {:agent_auto_context, :boolean, true,
+     "Whether the active buffer is automatically included in agent context."},
+    {:agent_max_tokens, :pos_integer, 16_384, "Maximum token budget sent to the agent provider."},
+    {:agent_max_retries, :non_neg_integer, 3,
+     "Maximum retry attempts for failed agent provider requests."},
+    {:agent_models, :string_list, [],
+     "Additional model identifiers shown in agent model pickers."},
+    {:agent_prompt_cache, :boolean, true,
+     "Whether prompt caching hints are enabled for supported providers."},
+    {:agent_notifications, :boolean, true,
+     "Whether agent events can produce user notifications."},
+    {:agent_notify_on, :any, [:approval, :complete, :error],
+     "Agent event kinds that trigger notifications."},
+    {:agent_system_prompt, :string, "", "Replacement system prompt text for agent sessions."},
+    {:agent_append_system_prompt, :string, "",
+     "Additional text appended to the default agent system prompt."},
+    {:agent_diff_size_threshold, :pos_integer, 1_048_576,
+     "Maximum diff size shown inline before truncation or summarization."},
+    {:agent_max_turns, :pos_integer, 100, "Maximum number of turns allowed in an agent session."},
+    {:agent_max_cost, :float_or_nil, nil, "Optional cost ceiling for an agent session."},
+    {:agent_api_base_url, :string, "", "Base URL override for agent API requests."},
+    {:agent_api_endpoints, :map_or_nil, nil,
+     "Provider endpoint overrides for agent API requests."},
+    {:agent_mcp_servers, :map_list, [], "MCP server definitions made available to the agent."},
+    {:agent_compaction_threshold, :float_or_nil, 0.8,
+     "Conversation-size threshold that triggers agent context compaction."},
+    {:agent_compaction_keep_recent, :pos_integer, 6,
+     "Number of recent conversation turns preserved during compaction."},
+    {:agent_approval_timeout, :pos_integer, 300_000,
+     "Milliseconds before an agent approval prompt times out."},
+    {:agent_subagent_timeout, :pos_integer, 300_000,
+     "Milliseconds before a delegated subagent task times out."},
+    {:agent_mention_max_file_size, :pos_integer, 262_144,
+     "Maximum file size in bytes that can be inlined from an agent mention."},
+    {:agent_notify_debounce, :pos_integer, 5_000,
+     "Milliseconds used to debounce repeated agent notifications."},
+    {:agent_diagnostic_feedback, :boolean, true,
+     "Whether diagnostics are fed back into agent context."},
+    {:agent_flush_before_shell, :boolean, true,
+     "Whether pending agent output flushes before shell tools run."},
+    {:confirm_quit, :boolean, true,
+     "Whether quitting with unsaved changes asks for confirmation."},
+    {:cursorline, :boolean, true, "Whether the current cursor line is highlighted."},
+    {:nav_flash, :boolean, true, "Whether large cursor jumps briefly highlight the destination."},
+    {:nav_flash_threshold, :pos_integer, 5,
+     "Minimum jump distance that triggers navigation flash."},
+    {:yank_flash, :boolean, true,
+     "Whether yanked text briefly highlights after yank operations."},
+    {:whichkey_layout, {:enum, [:bottom, :float]}, :bottom, "Layout used for which-key popups."},
+    {:line_spacing, :float_or_nil, 1.0, "Additional line spacing multiplier for GUI frontends."},
+    {:font_family, :string, "Menlo", "Primary editor font family used by GUI frontends."},
+    {:font_size, :pos_integer, 13, "Editor font size in points for GUI frontends."},
     {:font_weight, {:enum, [:thin, :light, :regular, :medium, :semibold, :bold, :heavy, :black]},
-     :regular},
-    {:font_ligatures, :boolean, true},
-    {:font_fallback, :string_list, []},
-    {:prettify_symbols, :boolean, false},
-    {:log_level, {:enum, [:debug, :info, :warning, :error, :none]}, :info},
-    {:log_level_render, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
-    {:log_level_lsp, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
-    {:log_level_agent, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
-    {:log_level_editor, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
-    {:log_level_config, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
-    {:log_level_port, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default},
-    {:parser_tree_ttl, :integer, 300},
-    {:event_retention_days, :pos_integer, 90},
-    {:default_shell, {:enum, [:traditional, :board]}, :traditional}
+     :regular, "Editor font weight used by GUI frontends."},
+    {:font_ligatures, :boolean, true, "Whether GUI frontends enable font ligatures."},
+    {:font_fallback, :string_list, [],
+     "Fallback font families used when the primary font lacks a glyph."},
+    {:prettify_symbols, :boolean, false,
+     "Whether symbolic text substitutions are rendered in buffers."},
+    {:log_level, {:enum, [:debug, :info, :warning, :error, :none]}, :info,
+     "Default log verbosity for all subsystems."},
+    {:log_level_render, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default,
+     "Render subsystem log verbosity override."},
+    {:log_level_lsp, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default,
+     "LSP subsystem log verbosity override."},
+    {:log_level_agent, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default,
+     "Agent subsystem log verbosity override."},
+    {:log_level_editor, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default,
+     "Editor subsystem log verbosity override."},
+    {:log_level_config, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default,
+     "Config subsystem log verbosity override."},
+    {:log_level_port, {:enum, [:default, :debug, :info, :warning, :error, :none]}, :default,
+     "Port protocol subsystem log verbosity override."},
+    {:parser_tree_ttl, :integer, 300, "Seconds to keep cached parser trees alive."},
+    {:event_retention_days, :pos_integer, 90,
+     "Number of days to keep persisted event log entries."},
+    {:default_shell, {:enum, [:traditional, :board]}, :traditional,
+     "Shell implementation opened by default."}
   ]
-
   @valid_names Enum.map(@option_specs, &elem(&1, 0))
 
-  @defaults Map.new(@option_specs, fn {name, _type, default} -> {name, default} end)
+  @defaults Map.new(@option_specs, fn {name, _type, default, _description} -> {name, default} end)
 
-  @types Map.new(@option_specs, fn {name, type, _default} -> {name, type} end)
+  @types Map.new(@option_specs, fn {name, type, _default, _description} -> {name, type} end)
+
+  @descriptions Map.new(@option_specs, fn {name, _type, _default, description} ->
+                  {name, description}
+                end)
 
   # ── GenServer (table lifecycle only) ────────────────────────────────────────
 
@@ -684,7 +751,79 @@ defmodule Minga.Config.Options do
   def type_for(name) when is_atom(name), do: Map.get(@types, name)
 
   @doc """
-  Returns the full option spec list: `[{name, type, default}]`.
+  Returns metadata for an option, or `nil` if unknown.
+  """
+  @spec describe(atom()) :: option_metadata() | nil
+  def describe(name) when is_atom(name) do
+    with {:ok, type} <- Map.fetch(@types, name),
+         {:ok, default} <- Map.fetch(@defaults, name),
+         {:ok, description} <- Map.fetch(@descriptions, name) do
+      %{name: name, type: type, default: default, description: description}
+    else
+      :error -> nil
+    end
+  end
+
+  @doc """
+  Returns the config-level provenance chain for an option's effective value.
+  """
+  @spec provenance(option_name(), atom() | nil) :: [String.t()]
+  @spec provenance(server(), option_name(), atom() | nil) :: [String.t()]
+  def provenance(name, filetype), do: provenance(@default_server, name, filetype)
+
+  def provenance(server, name, filetype) when is_atom(name) do
+    ["default"]
+    |> maybe_append(global_override?(server, name), "config.exs")
+    |> maybe_append(filetype_override?(server, name, filetype), "filetype #{inspect(filetype)}")
+  end
+
+  @doc """
+  Returns metadata for all registered extension options.
+  """
+  @spec extension_option_specs(server()) :: [extension_option_metadata()]
+  def extension_option_specs(server \\ @default_server) do
+    table = table_name(server)
+
+    :ets.foldl(
+      fn
+        {{:extension_schema, extension}, schema}, acc
+        when is_atom(extension) and is_list(schema) ->
+          extension_specs(extension, schema) ++ acc
+
+        _entry, acc ->
+          acc
+      end,
+      [],
+      table
+    )
+    |> Enum.sort_by(&{&1.extension, &1.name})
+  end
+
+  @doc """
+  Returns metadata for a registered extension option, or `nil` if unknown.
+  """
+  @spec describe_extension_option(server(), atom(), atom()) :: extension_option_metadata() | nil
+  def describe_extension_option(server \\ @default_server, extension, name)
+      when is_atom(extension) and is_atom(name) do
+    Enum.find(extension_option_specs(server), &(&1.extension == extension and &1.name == name))
+  end
+
+  @doc """
+  Returns the config-level provenance chain for an extension option's effective value.
+  """
+  @spec extension_provenance(server(), atom(), atom(), atom() | nil) :: [String.t()]
+  def extension_provenance(server \\ @default_server, extension, name, filetype)
+      when is_atom(extension) and is_atom(name) do
+    ["default"]
+    |> maybe_append(extension_global_override?(server, extension, name), "config.exs")
+    |> maybe_append(
+      extension_filetype_override?(server, extension, name, filetype),
+      "filetype #{inspect(filetype)}"
+    )
+  end
+
+  @doc """
+  Returns the full option spec list: `[{name, type, default, description}]`.
 
   Used by `Config.Completion` to generate completion items with
   type and default information in the detail text.
@@ -835,6 +974,59 @@ defmodule Minga.Config.Options do
   end
 
   # ── Private helpers ─────────────────────────────────────────────────────────
+
+  @spec maybe_append([String.t()], boolean(), String.t()) :: [String.t()]
+  defp maybe_append(chain, true, label), do: chain ++ [label]
+  defp maybe_append(chain, false, _label), do: chain
+
+  @spec global_override?(server(), atom()) :: boolean()
+  defp global_override?(server, name) do
+    case Map.fetch(@defaults, name) do
+      {:ok, default} -> get(server, name) != default
+      :error -> false
+    end
+  end
+
+  @spec filetype_override?(server(), atom(), atom() | nil) :: boolean()
+  defp filetype_override?(_server, _name, nil), do: false
+
+  defp filetype_override?(server, name, filetype) when is_atom(filetype) do
+    table = table_name(server)
+    :ets.lookup(table, {:filetype, filetype, name}) != []
+  rescue
+    ArgumentError -> false
+  end
+
+  @spec extension_specs(atom(), [Minga.Extension.option_spec()]) :: [extension_option_metadata()]
+  defp extension_specs(extension, schema) do
+    Enum.map(schema, fn {name, type, default, description} ->
+      %{
+        extension: extension,
+        name: name,
+        type: type,
+        default: default,
+        description: description
+      }
+    end)
+  end
+
+  @spec extension_global_override?(server(), atom(), atom()) :: boolean()
+  defp extension_global_override?(server, extension, name) do
+    case describe_extension_option(server, extension, name) do
+      %{default: default} -> get_extension_option(server, extension, name) != default
+      nil -> false
+    end
+  end
+
+  @spec extension_filetype_override?(server(), atom(), atom(), atom() | nil) :: boolean()
+  defp extension_filetype_override?(_server, _extension, _name, nil), do: false
+
+  defp extension_filetype_override?(server, extension, name, filetype) when is_atom(filetype) do
+    table = table_name(server)
+    :ets.lookup(table, {:filetype, filetype, {:extension, extension, name}}) != []
+  rescue
+    ArgumentError -> false
+  end
 
   @spec extension_default(:ets.table(), atom(), atom()) :: term() | nil
   defp extension_default(table, ext_name, opt_name) do

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -14,56 +14,9 @@ defmodule Minga.Config.Options do
 
   ## Supported options
 
-  | Option          | Type                                          | Default   |
-  |-----------------|-----------------------------------------------|-----------|
-  | `:tab_width`    | positive integer                               | `2`       |
-  | `:line_numbers` | `:hybrid`, `:absolute`, `:relative`, `:none`   | `:hybrid` |
-  | `:autopair`     | boolean                                        | `true`    |
-  | `:scroll_margin`| non-negative integer                           | `5`       |
-  | `:scroll_lines` | positive integer                               | `1`       |
-  | `:theme`        | theme name atom (see `Minga.Config.ThemeRegistry.available/0`) | `:doom_one`|
-  | `:indent_with`  | `:spaces` or `:tabs`                            | `:spaces`  |
-  | `:trim_trailing_whitespace` | boolean                             | `false`    |
-  | `:insert_final_newline`     | boolean                             | `false`    |
-  | `:format_on_save`           | boolean                             | `false`    |
-  | `:auto_save_delay_ms`       | non-negative integer (0 disables)   | `1000`     |
-  | `:formatter`    | string or `nil`                                  | `nil`      |
-  | `:title_format` | string with `{placeholder}` tokens               | `"{filename} {dirty}({directory}) - Minga"` |
-  | `:recent_files_limit` | positive integer                            | `200`      |
-  | `:persist_recent_files` | boolean                                  | `true`     |
-  | `:wrap`                 | boolean                                    | `false`    |
-  | `:linebreak`            | boolean                                    | `true`     |
-  | `:breakindent`          | boolean                                    | `true`     |
-  | `:agent_tool_approval`  | `:destructive`, `:all`, or `:none`          | `:destructive` |
-  | `:agent_destructive_tools` | list of tool name strings                | `["write_file", "edit_file", "shell"]` |
-  | `:agent_hooks`            | list of agent hook declarations            | `[]`       |
-  | `:agent_panel_split`      | positive integer (30-80)                   | `65`       |
-  | `:startup_view`           | `:agent` or `:editor`                       | `:agent`   |
-  | `:agent_auto_context`     | boolean                                     | `true`     |
-  | `:agent_mcp_servers`      | list of server config maps                  | `[]`       |
-  | `:font_family`            | string (font name)                          | `"Menlo"`   |
-  | `:font_size`              | positive integer (point size)               | `13`        |
-  | `:font_weight`            | `:thin` / `:light` / `:regular` / `:medium` / `:semibold` / `:bold` / `:heavy` / `:black` | `:regular` |
-  | `:font_ligatures`         | boolean                                     | `true`      |
-  | `:font_fallback`          | list of font family strings                 | `[]`        |
-  | `:prettify_symbols`       | boolean                                     | `false`     |
-  | `:whichkey_layout`        | `:bottom` or `:float`                       | `:bottom`   |
-  | `:cursorline`             | boolean                                        | `true`    |
-  | `:nav_flash`              | boolean                                        | `true`    |
-  | `:nav_flash_threshold`    | positive integer                               | `5`       |
-  | `:yank_flash`             | boolean                                        | `true`    |
-  | `:log_level`              | `:debug` / `:info` / `:warning` / `:error` / `:none` | `:info` |
-  | `:log_level_render`       | log level or `:default`                     | `:default`  |
-  | `:log_level_lsp`          | log level or `:default`                     | `:default`  |
-  | `:log_level_agent`        | log level or `:default`                     | `:default`  |
-  | `:log_level_editor`       | log level or `:default`                     | `:default`  |
-  | `:log_level_config`       | log level or `:default`                     | `:default`  |
-  | `:log_level_port`         | log level or `:default`                     | `:default`  |
-  | `:event_retention_days`   | positive integer (days to keep event log)    | `90`        |
+  Option metadata lives in `@option_specs`, including each option's type, default value, and user-facing description. Use `option_specs/0` for the full list, `describe/1` for one built-in option, and `extension_option_specs/1` for extension-registered options.
 
-  Log level options control per-subsystem verbosity. Subsystem options
-  default to `:default` (inherit from `:log_level`). See `Minga.Log`
-  for the filtering API.
+  Log level options control per-subsystem verbosity. Subsystem options default to `:default` (inherit from `:log_level`). See `Minga.Log` for the filtering API.
 
   ## Per-filetype overrides
 

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -73,7 +73,9 @@ defmodule Minga.Keymap.Defaults do
     {[{?q, @none}, {?q, @none}], :quit_all, "Quit editor"},
 
     # ── Help ──────────────────────────────────────────────────────────────────
+    {[{?h, @none}, {?b, @none}], :describe_bindings, "Describe bindings"},
     {[{?h, @none}, {?k, @none}], :describe_key, "Describe key"},
+    {[{?h, @none}, {?v, @none}], :describe_option, "Describe option"},
     {[{?h, @none}, {?r, @none}], :reload_config, "Reload config"},
     {[{?h, @none}, {?t, @none}], :theme_picker, "Pick theme"},
     {[{?h, @none}, {?e, @none}, {?l, @none}], :extension_list, "List extensions"},
@@ -228,6 +230,12 @@ defmodule Minga.Keymap.Defaults do
   """
   @spec all_bindings() :: [{[Bindings.key()], atom(), String.t()}]
   def all_bindings, do: @leader_bindings
+
+  @doc """
+  Returns leader group prefixes as `{key_sequence, label}` tuples.
+  """
+  @spec group_prefixes() :: [{[Bindings.key()], String.t()}]
+  def group_prefixes, do: @group_prefixes
 
   # filetype_bindings/0 is defined below with all SPC m bindings
 

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -505,6 +505,14 @@ defmodule MingaEditor.Commands do
     ExtCommands.update(state)
   end
 
+  def execute(state, {:execute_ex_command, {:describe_option, []}}) do
+    Help.execute(state, :describe_option)
+  end
+
+  def execute(state, {:execute_ex_command, {:describe_option_named, [name]}}) do
+    Help.execute(state, {:describe_option_named, name})
+  end
+
   def execute(state, {:execute_ex_command, {:rename, new_name}}) do
     LspActions.rename(state, new_name)
   end

--- a/lib/minga_editor/commands/help.ex
+++ b/lib/minga_editor/commands/help.ex
@@ -1,18 +1,51 @@
 defmodule MingaEditor.Commands.Help do
   @moduledoc """
-  Help commands: describe-key result display and `*Help*` buffer management.
+  Help commands and special help buffer management.
 
-  The `*Help*` buffer is created lazily on first use, reused across
-  invocations, and is always read-only.
+  Help content is created lazily, reused across invocations, and always shown in read-only special buffers.
   """
+
+  @behaviour Minga.Command.Provider
 
   alias Minga.Buffer
   alias Minga.Buffer.Document
+  alias Minga.Command
+  alias Minga.Config.Options
+  alias Minga.Keymap
+  alias Minga.Keymap.Bindings
+  alias Minga.Keymap.Defaults
   alias MingaEditor.Commands
+  alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
   alias Minga.Mode
 
   @type state :: EditorState.t()
+  @type binding_entry :: %{
+          required(:keys) => [Bindings.key()],
+          required(:command) => atom() | tuple(),
+          required(:description) => String.t(),
+          required(:source) => :default | :user,
+          optional(:display_key) => String.t()
+        }
+
+  @impl Minga.Command.Provider
+  @spec __commands__() :: [Command.t()]
+  def __commands__ do
+    [
+      %Command{
+        name: :describe_bindings,
+        description: "Describe bindings",
+        requires_buffer: false,
+        execute: fn state -> execute(state, :describe_bindings) end
+      },
+      %Command{
+        name: :describe_option,
+        description: "Describe option",
+        requires_buffer: false,
+        execute: fn state -> execute(state, :describe_option) end
+      }
+    ]
+  end
 
   @spec execute(state(), Mode.command()) :: state()
   def execute(state, {:describe_key_result, key_str, command, description}) do
@@ -25,37 +58,578 @@ defmodule MingaEditor.Commands.Help do
     show_in_help_buffer(state, content)
   end
 
-  # ── Private ──────────────────────────────────────────────────────────────────
-
-  @spec format_describe_key(String.t(), atom(), String.t()) :: String.t()
-  defp format_describe_key(key_str, command, description) do
-    lines = [
-      "Key:         #{key_str}",
-      "Command:     #{command}",
-      "Description: #{description}",
-      ""
-    ]
-
-    Enum.join(lines, "\n")
+  def execute(state, :describe_bindings) do
+    show_in_buffer(state, "*Bindings*", bindings_content(state))
   end
 
+  def execute(state, :describe_option) do
+    PickerUI.open(state, MingaEditor.UI.Picker.OptionSource)
+  end
+
+  def execute(state, {:describe_option_named, name}) when is_binary(name) do
+    describe_option_named(state, name)
+  end
+
+  @doc "Shows content in the shared `*Help*` buffer."
   @spec show_in_help_buffer(state(), String.t()) :: state()
-  defp show_in_help_buffer(state, content) do
+  def show_in_help_buffer(state, content) do
+    show_in_buffer(state, "*Help*", content)
+  end
+
+  @doc "Shows the option help page for `name`."
+  @spec describe_option(state(), atom()) :: state()
+  def describe_option(state, name) when is_atom(name) do
+    case Options.describe(name) do
+      nil -> show_in_help_buffer(state, "Unknown option: #{name}\n")
+      metadata -> show_in_help_buffer(state, option_content(state, metadata))
+    end
+  end
+
+  @doc "Shows the extension option help page for `extension.name`."
+  @spec describe_extension_option(state(), atom(), atom()) :: state()
+  def describe_extension_option(state, extension, name)
+      when is_atom(extension) and is_atom(name) do
+    options_server = EditorState.options_server(state)
+
+    case Options.describe_extension_option(options_server, extension, name) do
+      nil -> show_in_help_buffer(state, "Unknown option: #{extension}.#{name}\n")
+      metadata -> show_in_help_buffer(state, extension_option_content(state, metadata))
+    end
+  end
+
+  @doc "Formats all keybindings active in the current editor state."
+  @spec bindings_content(state()) :: String.t()
+  def bindings_content(state) do
+    sections = leader_sections(state) ++ filetype_sections(state) ++ normal_sections(state)
+
+    ["# Keybindings", "", "Mode: #{current_mode(state)}", "", Enum.join(sections, "\n")]
+    |> Enum.join("\n")
+    |> ensure_trailing_newline()
+  end
+
+  @doc "Formats a detailed option help page."
+  @spec option_content(state(), Options.option_metadata()) :: String.t()
+  def option_content(state, %{name: name, type: type, default: default, description: description}) do
+    filetype = current_filetype(state)
+    buffer = active_buffer(state)
+    current = current_option_value(state, name, filetype, buffer)
+    provenance = option_provenance(state, name, filetype, buffer)
+
+    [
+      "# Option: #{name}",
+      "",
+      "Name: #{name}",
+      "Current value: #{inspect(current)}",
+      "Default: #{inspect(default)}",
+      "Type: #{format_type(type)}",
+      "Set by: #{Enum.join(provenance, " → ")}",
+      "",
+      "Description:",
+      description,
+      ""
+    ]
+    |> Enum.join("\n")
+  end
+
+  @doc "Formats a detailed extension option help page."
+  @spec extension_option_content(state(), Options.extension_option_metadata()) :: String.t()
+  def extension_option_content(state, %{
+        extension: extension,
+        name: name,
+        type: type,
+        default: default,
+        description: description
+      }) do
+    filetype = current_filetype(state)
+    options_server = EditorState.options_server(state)
+    current = Options.get_extension_option_for_filetype(options_server, extension, name, filetype)
+    provenance = Options.extension_provenance(options_server, extension, name, filetype)
+
+    [
+      "# Option: #{extension}.#{name}",
+      "",
+      "Name: #{extension}.#{name}",
+      "Current value: #{inspect(current)}",
+      "Default: #{inspect(default)}",
+      "Type: #{format_type(type)}",
+      "Set by: #{Enum.join(provenance, " → ")}",
+      "",
+      "Description:",
+      description,
+      ""
+    ]
+    |> Enum.join("\n")
+  end
+
+  # ── Binding formatting ──────────────────────────────────────────────────────
+
+  @spec leader_sections(state()) :: [String.t()]
+  defp leader_sections(state) do
+    default_map = default_leader_map()
+
+    state
+    |> active_leader_entries(default_map)
+    |> Enum.group_by(&leader_group/1)
+    |> ordered_group_sections()
+  end
+
+  @spec filetype_sections(state()) :: [String.t()]
+  defp filetype_sections(state) do
+    filetype = current_filetype(state)
+    entries = active_filetype_entries(state, filetype)
+
+    case entries do
+      [] -> []
+      _ -> [format_section("+filetype #{inspect(filetype)}", entries)]
+    end
+  end
+
+  @spec normal_sections(state()) :: [String.t()]
+  defp normal_sections(state) do
+    default_map = Defaults.normal_bindings()
+
+    normal_entries =
+      state
+      |> active_normal_entries(default_map)
+      |> Enum.group_by(&normal_group/1)
+      |> ordered_normal_sections()
+
+    text_objects = format_section("Text objects", text_object_entries())
+    normal_entries ++ [text_objects]
+  end
+
+  @spec active_leader_entries(state(), %{[Bindings.key()] => {atom() | tuple(), String.t()}}) :: [
+          binding_entry()
+        ]
+  defp active_leader_entries(state, default_map) do
+    trie = Keymap.leader_trie(EditorState.keymap_server(state))
+
+    trie
+    |> flatten_trie([])
+    |> Enum.map(&mark_entry_source(&1, default_map))
+    |> Enum.map(&prefix_keys(&1, [Defaults.leader_key()]))
+    |> Enum.sort_by(&format_key_sequence(&1.keys))
+  catch
+    :exit, _ ->
+      Defaults.all_bindings()
+      |> Enum.map(fn {keys, command, description} ->
+        %{
+          keys: [Defaults.leader_key() | keys],
+          command: command,
+          description: description,
+          source: :default
+        }
+      end)
+  end
+
+  @spec active_filetype_entries(state(), atom() | nil) :: [binding_entry()]
+  defp active_filetype_entries(_state, nil), do: []
+
+  defp active_filetype_entries(state, filetype) do
+    default_map = default_filetype_map(filetype)
+    trie = Keymap.filetype_trie(EditorState.keymap_server(state), filetype)
+
+    trie
+    |> flatten_trie([])
+    |> Enum.map(&mark_entry_source(&1, default_map))
+    |> Enum.map(&prefix_keys(&1, [Defaults.leader_key(), {?m, 0}]))
+    |> Enum.sort_by(&format_key_sequence(&1.keys))
+  catch
+    :exit, _ -> []
+  end
+
+  @spec active_normal_entries(state(), %{Bindings.key() => {atom(), String.t()}}) :: [
+          binding_entry()
+        ]
+  defp active_normal_entries(state, default_map) do
+    state
+    |> normal_bindings_for_state()
+    |> Enum.map(fn {key, {command, description}} ->
+      source = entry_source(Map.get(default_map, key), command, description)
+      %{keys: [key], command: command, description: description, source: source}
+    end)
+    |> Enum.sort_by(&format_key_sequence(&1.keys))
+  end
+
+  @spec normal_bindings_for_state(state()) :: %{Bindings.key() => {atom(), String.t()}}
+  defp normal_bindings_for_state(state) do
+    Keymap.normal_bindings(EditorState.keymap_server(state))
+  catch
+    :exit, _ -> Defaults.normal_bindings()
+  end
+
+  @spec flatten_trie(Bindings.node_t(), [Bindings.key()]) :: [binding_entry()]
+  defp flatten_trie(%Bindings.Node{} = node, prefix) do
+    current = current_binding(node, prefix)
+
+    children =
+      node.children
+      |> Enum.flat_map(fn {key, child} -> flatten_trie(child, prefix ++ [key]) end)
+
+    current ++ children
+  end
+
+  @spec current_binding(Bindings.node_t(), [Bindings.key()]) :: [binding_entry()]
+  defp current_binding(%Bindings.Node{command: nil}, _prefix), do: []
+
+  defp current_binding(%Bindings.Node{command: command, description: description}, prefix) do
+    [%{keys: prefix, command: command, description: description || "", source: :default}]
+  end
+
+  @spec mark_entry_source(binding_entry(), %{[Bindings.key()] => {atom() | tuple(), String.t()}}) ::
+          binding_entry()
+  defp mark_entry_source(
+         %{keys: keys, command: command, description: description} = entry,
+         default_map
+       ) do
+    %{entry | source: entry_source(Map.get(default_map, keys), command, description)}
+  end
+
+  @spec entry_source({atom() | tuple(), String.t()} | nil, atom() | tuple(), String.t()) ::
+          :default | :user
+  defp entry_source({command, description}, command, description), do: :default
+  defp entry_source(_default, _command, _description), do: :user
+
+  @spec prefix_keys(binding_entry(), [Bindings.key()]) :: binding_entry()
+  defp prefix_keys(%{keys: keys} = entry, prefix), do: %{entry | keys: prefix ++ keys}
+
+  @spec default_leader_map() :: %{[Bindings.key()] => {atom(), String.t()}}
+  defp default_leader_map do
+    Map.new(Defaults.all_bindings(), fn {keys, command, description} ->
+      {keys, {command, description}}
+    end)
+  end
+
+  @spec default_filetype_map(atom()) :: %{[Bindings.key()] => {atom(), String.t()}}
+  defp default_filetype_map(filetype) do
+    Defaults.filetype_bindings()
+    |> Enum.filter(fn {ft, _keys, _command, _description} -> ft == filetype end)
+    |> Map.new(fn {_ft, keys, command, description} -> {keys, {command, description}} end)
+  end
+
+  @spec leader_group(binding_entry()) :: String.t()
+  defp leader_group(%{keys: [_leader | rest]}) do
+    Defaults.group_prefixes()
+    |> Enum.sort_by(fn {keys, _label} -> -length(keys) end)
+    |> Enum.find_value("Ungrouped", fn {prefix, label} ->
+      if prefix?(prefix, rest), do: label, else: nil
+    end)
+  end
+
+  @spec prefix?([Bindings.key()], [Bindings.key()]) :: boolean()
+  defp prefix?(prefix, keys), do: Enum.take(keys, length(prefix)) == prefix
+
+  @spec normal_group(binding_entry()) :: String.t()
+  defp normal_group(%{command: command})
+       when command in [
+              :move_left,
+              :move_down,
+              :move_up,
+              :move_right,
+              :move_to_line_start,
+              :move_to_line_end,
+              :move_to_first_non_blank,
+              :move_to_document_end,
+              :word_forward,
+              :word_backward,
+              :word_end,
+              :word_forward_big,
+              :word_backward_big,
+              :word_end_big,
+              :match_bracket,
+              :paragraph_backward,
+              :paragraph_forward,
+              :move_to_screen_top,
+              :move_to_screen_middle,
+              :move_to_screen_bottom,
+              :next_line_first_non_blank,
+              :prev_line_first_non_blank
+            ],
+       do: "Movement"
+
+  defp normal_group(%{command: command})
+       when command in [
+              :pending_find_forward,
+              :pending_find_backward,
+              :pending_till_forward,
+              :pending_till_backward,
+              :repeat_find_char,
+              :repeat_find_char_reverse
+            ],
+       do: "Find char"
+
+  defp normal_group(%{command: command})
+       when command in [
+              :operator_delete,
+              :operator_change,
+              :operator_yank,
+              :paste_after,
+              :paste_before,
+              :delete_chars_at,
+              :delete_chars_before,
+              :delete_to_end,
+              :change_to_end,
+              :substitute_char,
+              :substitute_line,
+              :join_lines,
+              :toggle_case,
+              :pending_replace_char,
+              :indent,
+              :dedent
+            ],
+       do: "Operators"
+
+  defp normal_group(%{command: command})
+       when command in [
+              :search_forward,
+              :search_backward,
+              :search_next,
+              :search_prev,
+              :search_word_forward,
+              :search_word_backward
+            ],
+       do: "Search"
+
+  defp normal_group(%{command: command})
+       when command in [
+              :enter_insert,
+              :enter_insert_after,
+              :enter_insert_end_of_line,
+              :enter_insert_start_of_line,
+              :insert_line_below,
+              :insert_line_above,
+              :enter_visual,
+              :enter_visual_line,
+              :enter_replace_mode,
+              :enter_command,
+              :enter_eval
+            ],
+       do: "Mode transitions"
+
+  defp normal_group(%{command: command})
+       when command in [:half_page_down, :half_page_up, :page_down, :page_up], do: "Scrolling"
+
+  defp normal_group(%{command: command}) when command in [:undo, :redo, :dot_repeat],
+    do: "Undo / Redo"
+
+  defp normal_group(%{command: command})
+       when command in [
+              :pending_register,
+              :pending_set_mark,
+              :pending_jump_mark_line,
+              :pending_jump_mark_exact,
+              :toggle_macro_recording,
+              :replay_macro
+            ],
+       do: "Registers / Marks / Macros"
+
+  defp normal_group(_entry), do: "Misc"
+
+  @spec ordered_group_sections(%{String.t() => [binding_entry()]}) :: [String.t()]
+  defp ordered_group_sections(grouped) do
+    ordered_labels =
+      Enum.map(Defaults.group_prefixes(), fn {_keys, label} -> label end) ++ ["Ungrouped"]
+
+    ordered_sections(grouped, ordered_labels)
+  end
+
+  @spec ordered_normal_sections(%{String.t() => [binding_entry()]}) :: [String.t()]
+  defp ordered_normal_sections(grouped) do
+    ordered_sections(grouped, [
+      "Movement",
+      "Find char",
+      "Scrolling",
+      "Mode transitions",
+      "Operators",
+      "Undo / Redo",
+      "Search",
+      "Registers / Marks / Macros",
+      "Misc"
+    ])
+  end
+
+  @spec ordered_sections(%{String.t() => [binding_entry()]}, [String.t()]) :: [String.t()]
+  defp ordered_sections(grouped, labels) do
+    labels
+    |> Enum.flat_map(fn label ->
+      entries = Map.get(grouped, label, [])
+      if entries == [], do: [], else: [format_section(label, entries)]
+    end)
+  end
+
+  @spec format_section(String.t(), [binding_entry()]) :: String.t()
+  defp format_section(title, entries) do
+    key_width = entries |> Enum.map(&String.length(format_entry_key(&1))) |> Enum.max(fn -> 0 end)
+
+    command_width =
+      entries |> Enum.map(&String.length(format_command(&1.command))) |> Enum.max(fn -> 0 end)
+
+    lines = Enum.map(entries, &format_binding_line(&1, key_width, command_width))
+    Enum.join([title, String.duplicate("-", String.length(title)) | lines], "\n")
+  end
+
+  @spec format_binding_line(binding_entry(), non_neg_integer(), non_neg_integer()) :: String.t()
+  defp format_binding_line(entry, key_width, command_width) do
+    marker = if entry.source == :user, do: " *user*", else: ""
+
+    [
+      String.pad_trailing(format_entry_key(entry), key_width),
+      "    ",
+      String.pad_trailing(format_command(entry.command), command_width),
+      "    ",
+      entry.description,
+      marker
+    ]
+    |> Enum.join()
+  end
+
+  @spec text_object_entries() :: [binding_entry()]
+  defp text_object_entries do
+    [
+      {"iw", :text_object_inner_word, "Inner word"},
+      {"aw", :text_object_around_word, "Around word"},
+      {"i\"", :text_object_inner_double_quote, "Inside double quotes"},
+      {"a\"", :text_object_around_double_quote, "Around double quotes"},
+      {"i'", :text_object_inner_single_quote, "Inside single quotes"},
+      {"a'", :text_object_around_single_quote, "Around single quotes"},
+      {"i(", :text_object_inner_paren, "Inside parentheses"},
+      {"a(", :text_object_around_paren, "Around parentheses"},
+      {"i[", :text_object_inner_bracket, "Inside brackets"},
+      {"a[", :text_object_around_bracket, "Around brackets"},
+      {"i{", :text_object_inner_brace, "Inside braces"},
+      {"a{", :text_object_around_brace, "Around braces"},
+      {"if", :text_object_inner_function, "Inside function"},
+      {"af", :text_object_around_function, "Around function"},
+      {"ic", :text_object_inner_class, "Inside class/module"},
+      {"ac", :text_object_around_class, "Around class/module"}
+    ]
+    |> Enum.map(fn {key, command, description} ->
+      %{
+        keys: display_keys(key),
+        command: command,
+        description: description,
+        source: :default,
+        display_key: key
+      }
+    end)
+  end
+
+  @spec display_keys(String.t()) :: [Bindings.key()]
+  defp display_keys(key_string) do
+    key_string
+    |> String.to_charlist()
+    |> Enum.map(&{&1, 0})
+  end
+
+  @spec format_entry_key(binding_entry()) :: String.t()
+  defp format_entry_key(%{display_key: display_key}) when is_binary(display_key), do: display_key
+  defp format_entry_key(%{keys: keys}), do: format_key_sequence(keys)
+
+  @spec format_key_sequence([Bindings.key()]) :: String.t()
+  defp format_key_sequence(keys), do: Enum.map_join(keys, " ", &Bindings.format_key/1)
+
+  @spec format_command(atom() | tuple()) :: String.t()
+  defp format_command(command) when is_atom(command), do: Atom.to_string(command)
+  defp format_command(command), do: inspect(command)
+
+  # ── Option formatting ───────────────────────────────────────────────────────
+
+  @spec describe_option_named(state(), String.t()) :: state()
+  defp describe_option_named(state, raw_name) do
+    case option_name_from_string(state, raw_name) do
+      nil -> show_in_help_buffer(state, "Unknown option: #{String.trim(raw_name)}\n")
+      {:extension, extension, name} -> describe_extension_option(state, extension, name)
+      name -> describe_option(state, name)
+    end
+  end
+
+  @spec option_name_from_string(state(), String.t()) ::
+          atom() | {:extension, atom(), atom()} | nil
+  defp option_name_from_string(state, raw_name) do
+    normalized = raw_name |> String.trim() |> String.trim_leading(":")
+
+    case Enum.find(Options.valid_names(), &(Atom.to_string(&1) == normalized)) do
+      nil -> extension_option_name_from_string(state, normalized)
+      name -> name
+    end
+  end
+
+  @spec extension_option_name_from_string(state(), String.t()) ::
+          {:extension, atom(), atom()} | nil
+  defp extension_option_name_from_string(state, normalized) do
+    options_server = EditorState.options_server(state)
+
+    Options.extension_option_specs(options_server)
+    |> Enum.find_value(fn %{extension: extension, name: name} ->
+      if "#{extension}.#{name}" == normalized, do: {:extension, extension, name}, else: nil
+    end)
+  end
+
+  @spec current_option_value(state(), Options.option_name(), atom() | nil, pid() | nil) :: term()
+  defp current_option_value(state, name, filetype, buffer) when is_pid(buffer) do
+    Buffer.get_option(buffer, name)
+  catch
+    :exit, _ -> Options.get_for_filetype(EditorState.options_server(state), name, filetype)
+  end
+
+  defp current_option_value(state, name, filetype, _buffer) do
+    Options.get_for_filetype(EditorState.options_server(state), name, filetype)
+  end
+
+  @spec option_provenance(state(), Options.option_name(), atom() | nil, pid() | nil) :: [
+          String.t()
+        ]
+  defp option_provenance(state, name, filetype, buffer) do
+    state
+    |> EditorState.options_server()
+    |> Options.provenance(name, filetype)
+    |> maybe_append_buffer_local(buffer_local_override?(buffer, name))
+  end
+
+  @spec maybe_append_buffer_local([String.t()], boolean()) :: [String.t()]
+  defp maybe_append_buffer_local(provenance, true), do: provenance ++ ["buffer-local"]
+  defp maybe_append_buffer_local(provenance, false), do: provenance
+
+  @spec buffer_local_override?(pid() | nil, atom()) :: boolean()
+  defp buffer_local_override?(nil, _name), do: false
+
+  defp buffer_local_override?(buffer, name) when is_pid(buffer) do
+    buffer
+    |> Buffer.local_option_overrides()
+    |> Map.has_key?(name)
+  catch
+    :exit, _ -> false
+  end
+
+  @spec format_type(Options.type_descriptor()) :: String.t()
+  defp format_type(:pos_integer), do: "positive integer"
+  defp format_type(:non_neg_integer), do: "non-negative integer"
+  defp format_type(:integer), do: "integer"
+  defp format_type(:boolean), do: "boolean"
+  defp format_type(:atom), do: "atom"
+  defp format_type(:theme_atom), do: "theme name atom"
+  defp format_type(:string), do: "string"
+  defp format_type(:string_or_nil), do: "string or nil"
+  defp format_type(:string_list), do: "list of strings"
+  defp format_type(:map_or_nil), do: "map or nil"
+  defp format_type(:map_list), do: "list of maps"
+  defp format_type(:float_or_nil), do: "positive number or nil"
+  defp format_type(:any), do: "any"
+  defp format_type({:enum, values}), do: "one of: #{Enum.map_join(values, ", ", &inspect/1)}"
+
+  # ── Special buffers ────────────────────────────────────────────────────────
+
+  @spec show_in_buffer(state(), String.t(), String.t()) :: state()
+  defp show_in_buffer(state, "*Help*", content) do
     {state, help_buf} = ensure_help_buffer(state)
     replace_help_content(help_buf, content)
+    switch_to_buffer(state, help_buf)
+  end
 
-    # Switch to help buffer
-    idx = Enum.find_index(state.workspace.buffers.list, &(&1 == help_buf))
-
-    state =
-      if idx do
-        put_in(state.workspace.buffers.active_index, idx)
-        |> then(fn s -> put_in(s.workspace.buffers.active, help_buf) end)
-      else
-        Commands.add_buffer(state, help_buf)
-      end
-
-    EditorState.clear_status(state)
+  defp show_in_buffer(state, buffer_name, content) do
+    {state, buffer} = ensure_named_buffer(state, buffer_name)
+    replace_help_content(buffer, content)
+    switch_to_buffer(state, buffer)
   end
 
   @spec ensure_help_buffer(state()) :: {state(), pid()}
@@ -71,16 +645,60 @@ defmodule MingaEditor.Commands.Help do
     start_help_buffer(state)
   end
 
+  @spec ensure_named_buffer(state(), String.t()) :: {state(), pid()}
+  defp ensure_named_buffer(state, buffer_name) do
+    case find_buffer_by_name(state.workspace.buffers.list, buffer_name) do
+      nil -> start_named_buffer(state, buffer_name)
+      pid -> {state, pid}
+    end
+  end
+
+  @spec find_buffer_by_name([pid()], String.t()) :: pid() | nil
+  defp find_buffer_by_name(buffers, buffer_name) do
+    Enum.find(buffers, &buffer_name_matches?(&1, buffer_name))
+  end
+
+  @spec buffer_name_matches?(pid(), String.t()) :: boolean()
+  defp buffer_name_matches?(buffer, buffer_name) do
+    Buffer.buffer_name(buffer) == buffer_name
+  catch
+    :exit, _ -> false
+  end
+
   @spec start_help_buffer(state()) :: {state(), pid()}
   defp start_help_buffer(state) do
-    {:ok, pid} =
-      DynamicSupervisor.start_child(
-        Minga.Buffer.Supervisor,
-        {Minga.Buffer,
-         content: "", buffer_name: "*Help*", read_only: true, unlisted: true, persistent: true}
-      )
-
+    {:ok, pid} = start_special_buffer("*Help*")
     {put_in(state.workspace.buffers.help, pid), pid}
+  end
+
+  @spec start_named_buffer(state(), String.t()) :: {state(), pid()}
+  defp start_named_buffer(state, buffer_name) do
+    {:ok, pid} = start_special_buffer(buffer_name)
+    {Commands.add_buffer(state, pid), pid}
+  end
+
+  @spec start_special_buffer(String.t()) :: {:ok, pid()} | {:error, term()}
+  defp start_special_buffer(buffer_name) do
+    DynamicSupervisor.start_child(
+      Minga.Buffer.Supervisor,
+      {Minga.Buffer,
+       content: "", buffer_name: buffer_name, read_only: true, unlisted: true, persistent: true}
+    )
+  end
+
+  @spec switch_to_buffer(state(), pid()) :: state()
+  defp switch_to_buffer(state, buffer) do
+    idx = Enum.find_index(state.workspace.buffers.list, &(&1 == buffer))
+
+    state =
+      if idx do
+        put_in(state.workspace.buffers.active_index, idx)
+        |> then(fn s -> put_in(s.workspace.buffers.active, buffer) end)
+      else
+        Commands.add_buffer(state, buffer)
+      end
+
+    EditorState.clear_status(state)
   end
 
   @spec replace_help_content(pid(), String.t()) :: :ok
@@ -90,5 +708,42 @@ defmodule MingaEditor.Commands.Help do
     end)
 
     Buffer.move_to(buf, {0, 0})
+  end
+
+  # ── Shared helpers ─────────────────────────────────────────────────────────
+
+  @spec format_describe_key(String.t(), atom(), String.t()) :: String.t()
+  defp format_describe_key(key_str, command, description) do
+    lines = [
+      "Key:         #{key_str}",
+      "Command:     #{command}",
+      "Description: #{description}",
+      ""
+    ]
+
+    Enum.join(lines, "\n")
+  end
+
+  @spec current_mode(state()) :: atom()
+  defp current_mode(%{workspace: %{editing: %{mode: mode}}}) when is_atom(mode), do: mode
+  defp current_mode(_state), do: :normal
+
+  @spec current_filetype(state()) :: atom() | nil
+  defp current_filetype(state) do
+    case active_buffer(state) do
+      nil -> nil
+      buffer -> Buffer.filetype(buffer)
+    end
+  catch
+    :exit, _ -> nil
+  end
+
+  @spec active_buffer(state()) :: pid() | nil
+  defp active_buffer(%{workspace: %{buffers: %{active: buffer}}}) when is_pid(buffer), do: buffer
+  defp active_buffer(_state), do: nil
+
+  @spec ensure_trailing_newline(String.t()) :: String.t()
+  defp ensure_trailing_newline(content) do
+    if String.ends_with?(content, "\n"), do: content, else: content <> "\n"
   end
 end

--- a/lib/minga_editor/commands/help.ex
+++ b/lib/minga_editor/commands/help.ex
@@ -567,7 +567,12 @@ defmodule MingaEditor.Commands.Help do
 
   @spec current_option_value(state(), Options.option_name(), atom() | nil, pid() | nil) :: term()
   defp current_option_value(state, name, filetype, buffer) when is_pid(buffer) do
-    Buffer.get_option(buffer, name)
+    options_server = EditorState.options_server(state)
+
+    case Map.fetch(Buffer.local_options(buffer), name) do
+      {:ok, value} -> value
+      :error -> Options.get_for_filetype(options_server, name, filetype)
+    end
   catch
     :exit, _ -> Options.get_for_filetype(EditorState.options_server(state), name, filetype)
   end

--- a/lib/minga_editor/ui/picker/context.ex
+++ b/lib/minga_editor/ui/picker/context.ex
@@ -69,8 +69,8 @@ defmodule MingaEditor.UI.Picker.Context do
           agent_session: pid() | nil,
           picker_ui: map(),
           capabilities: map(),
-          keymap_server: State.keymap_server(),
-          options_server: State.options_server(),
+          keymap_server: State.keymap_server() | nil,
+          options_server: State.options_server() | nil,
           theme: Theme.t()
         }
 

--- a/lib/minga_editor/ui/picker/context.ex
+++ b/lib/minga_editor/ui/picker/context.ex
@@ -18,6 +18,8 @@ defmodule MingaEditor.UI.Picker.Context do
   - `agent_session` — agent session PID (if available)
   - `picker_ui` — picker UI state (context map for sources)
   - `capabilities` — frontend capabilities (GUI detection, etc.)
+  - `keymap_server` — keymap server used by this editor instance
+  - `options_server` — options server used by this editor instance
   - `theme` — active theme
   """
 
@@ -52,6 +54,8 @@ defmodule MingaEditor.UI.Picker.Context do
     :agent_session,
     :picker_ui,
     :capabilities,
+    :keymap_server,
+    :options_server,
     :theme
   ]
 
@@ -65,6 +69,8 @@ defmodule MingaEditor.UI.Picker.Context do
           agent_session: pid() | nil,
           picker_ui: map(),
           capabilities: map(),
+          keymap_server: State.keymap_server(),
+          options_server: State.options_server(),
           theme: Theme.t()
         }
 
@@ -90,6 +96,8 @@ defmodule MingaEditor.UI.Picker.Context do
       agent_session: agent_session,
       picker_ui: picker_ui,
       capabilities: state.capabilities,
+      keymap_server: State.keymap_server(state),
+      options_server: State.options_server(state),
       theme: state.theme
     }
   end

--- a/lib/minga_editor/ui/picker/option_source.ex
+++ b/lib/minga_editor/ui/picker/option_source.ex
@@ -82,10 +82,13 @@ defmodule MingaEditor.UI.Picker.OptionSource do
 
   @spec current_value(Options.server(), Options.option_name(), atom() | nil, pid() | nil) ::
           term()
-  defp current_value(_options_server, name, _filetype, buffer) when is_pid(buffer) do
-    Buffer.get_option(buffer, name)
+  defp current_value(options_server, name, filetype, buffer) when is_pid(buffer) do
+    case Map.fetch(Buffer.local_options(buffer), name) do
+      {:ok, value} -> value
+      :error -> Options.get_for_filetype(options_server, name, filetype)
+    end
   catch
-    :exit, _ -> nil
+    :exit, _ -> Options.get_for_filetype(options_server, name, filetype)
   end
 
   defp current_value(options_server, name, filetype, _buffer) do

--- a/lib/minga_editor/ui/picker/option_source.ex
+++ b/lib/minga_editor/ui/picker/option_source.ex
@@ -1,0 +1,120 @@
+defmodule MingaEditor.UI.Picker.OptionSource do
+  @moduledoc """
+  Picker source for describing editor options.
+  """
+
+  @behaviour MingaEditor.UI.Picker.Source
+
+  alias Minga.Buffer
+  alias Minga.Config.Options
+  alias MingaEditor.Commands.Help
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.Item
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Options"
+
+  @impl true
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{} = context) do
+    options_server = options_server(context)
+    filetype = current_filetype(context)
+    buffer = active_buffer(context)
+
+    (builtin_items(options_server, filetype, buffer) ++ extension_items(options_server, filetype))
+    |> Enum.sort_by(& &1.label)
+  end
+
+  @impl true
+  @spec on_select(Item.t(), term()) :: term()
+  def on_select(%Item{id: {:extension, extension, name}}, state)
+      when is_atom(extension) and is_atom(name) do
+    Help.describe_extension_option(state, extension, name)
+  end
+
+  def on_select(%Item{id: name}, state) when is_atom(name) do
+    Help.describe_option(state, name)
+  end
+
+  def on_select(_item, state), do: state
+
+  @impl true
+  @spec on_cancel(term()) :: term()
+  def on_cancel(state), do: state
+
+  @spec builtin_items(Options.server(), atom() | nil, pid() | nil) :: [Item.t()]
+  defp builtin_items(options_server, filetype, buffer) do
+    Enum.map(Options.option_specs(), fn {name, _type, default, description} ->
+      current = current_value(options_server, name, filetype, buffer)
+      changed? = current != default
+
+      %Item{
+        id: name,
+        label: option_label(name, changed?),
+        description: "#{inspect(current)}  #{description}",
+        annotation: option_annotation(changed?)
+      }
+    end)
+  end
+
+  @spec extension_items(Options.server(), atom() | nil) :: [Item.t()]
+  defp extension_items(options_server, filetype) do
+    Enum.map(Options.extension_option_specs(options_server), fn %{
+                                                                  extension: extension,
+                                                                  name: name,
+                                                                  default: default,
+                                                                  description: description
+                                                                } ->
+      current =
+        Options.get_extension_option_for_filetype(options_server, extension, name, filetype)
+
+      changed? = current != default
+
+      %Item{
+        id: {:extension, extension, name},
+        label: option_label("#{extension}.#{name}", changed?),
+        description: "#{inspect(current)}  #{description}",
+        annotation: option_annotation(changed?)
+      }
+    end)
+  end
+
+  @spec current_value(Options.server(), Options.option_name(), atom() | nil, pid() | nil) ::
+          term()
+  defp current_value(_options_server, name, _filetype, buffer) when is_pid(buffer) do
+    Buffer.get_option(buffer, name)
+  catch
+    :exit, _ -> nil
+  end
+
+  defp current_value(options_server, name, filetype, _buffer) do
+    Options.get_for_filetype(options_server, name, filetype)
+  end
+
+  @spec option_label(atom() | String.t(), boolean()) :: String.t()
+  defp option_label(name, true), do: "● #{name}"
+  defp option_label(name, false), do: "  #{name}"
+
+  @spec option_annotation(boolean()) :: String.t()
+  defp option_annotation(true), do: "modified"
+  defp option_annotation(false), do: ""
+
+  @spec options_server(Context.t()) :: Options.server()
+  defp options_server(%Context{options_server: nil}), do: Options.default_server()
+  defp options_server(%Context{options_server: server}), do: server
+
+  @spec current_filetype(Context.t()) :: atom() | nil
+  defp current_filetype(context) do
+    case active_buffer(context) do
+      nil -> nil
+      buffer -> Buffer.filetype(buffer)
+    end
+  catch
+    :exit, _ -> nil
+  end
+
+  @spec active_buffer(Context.t()) :: pid() | nil
+  defp active_buffer(%Context{buffers: %{active: buffer}}) when is_pid(buffer), do: buffer
+  defp active_buffer(_context), do: nil
+end

--- a/test/minga/buffer/server_test.exs
+++ b/test/minga/buffer/server_test.exs
@@ -1102,6 +1102,14 @@ defmodule Minga.Buffer.ServerTest do
       assert updated[:wrap] == false
     end
 
+    test "local_option_overrides returns only explicitly set options" do
+      {:ok, pid} = Server.start_link(content: "hello")
+      assert Server.local_option_overrides(pid) == %{}
+
+      Server.set_option(pid, :tab_width, 4)
+      assert Server.local_option_overrides(pid) == %{tab_width: 4}
+    end
+
     test "filetype default wins over global when seeded at creation" do
       # Set filetype override BEFORE creating buffer (eager seeding)
       Options.set_for_filetype(:go, :tab_width, 8)

--- a/test/minga/command/parser_test.exs
+++ b/test/minga/command/parser_test.exs
@@ -208,6 +208,16 @@ defmodule Minga.Command.ParserTest do
     end
   end
 
+  describe "parse/1 — describe commands" do
+    test ":describe opens the option picker" do
+      assert {:describe_option, []} = Parser.parse("describe")
+    end
+
+    test ":describe option parses the option name" do
+      assert {:describe_option_named, ["tab_width"]} = Parser.parse("describe tab_width")
+    end
+  end
+
   describe "parse/1 — unknown commands" do
     test "unrecognised command returns {:unknown, raw}" do
       assert {:unknown, "xyz"} = Parser.parse("xyz")

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -592,24 +592,82 @@ defmodule Minga.Config.OptionsTest do
   end
 
   describe "option_specs/0" do
-    test "returns a list of {name, type, default} tuples" do
+    test "returns a list of {name, type, default, description} tuples" do
       specs = Options.option_specs()
 
       assert is_list(specs)
       assert length(specs) == length(Options.valid_names())
 
-      for {name, _type, _default} <- specs do
+      for {name, _type, _default, description} <- specs do
         assert is_atom(name)
         assert name in Options.valid_names()
+        assert is_binary(description)
+        assert description != ""
       end
     end
 
     test "specs match valid_names and defaults" do
       specs = Options.option_specs()
 
-      for {name, _type, default} <- specs do
+      for {name, _type, default, _description} <- specs do
         assert Options.default(name) == default
       end
+    end
+  end
+
+  describe "describe/1" do
+    test "returns option metadata for known options" do
+      assert %{
+               name: :tab_width,
+               type: :pos_integer,
+               default: 2,
+               description: description
+             } = Options.describe(:tab_width)
+
+      assert description =~ "tab"
+    end
+
+    test "returns nil for unknown options" do
+      assert Options.describe(:does_not_exist) == nil
+    end
+  end
+
+  describe "provenance/3" do
+    test "reports default, global, and filetype config sources", %{server: s} do
+      assert Options.provenance(s, :tab_width, :go) == ["default"]
+
+      Options.set(s, :tab_width, 4)
+      assert Options.provenance(s, :tab_width, :go) == ["default", "config.exs"]
+
+      Options.set_for_filetype(s, :go, :tab_width, 8)
+
+      assert Options.provenance(s, :tab_width, :go) == [
+               "default",
+               "config.exs",
+               "filetype :go"
+             ]
+    end
+  end
+
+  describe "extension option introspection" do
+    test "lists and describes registered extension options", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, [])
+
+      assert %{extension: :minga_org, name: :conceal, default: true} =
+               Options.describe_extension_option(s, :minga_org, :conceal)
+
+      assert Enum.any?(Options.extension_option_specs(s), &(&1.extension == :minga_org))
+    end
+
+    test "reports extension option provenance", %{server: s} do
+      Options.register_extension_schema(s, :minga_org, @schema, conceal: false)
+      Options.set_extension_option_for_filetype(s, :minga_org, :org, :conceal, true)
+
+      assert Options.extension_provenance(s, :minga_org, :conceal, :org) == [
+               "default",
+               "config.exs",
+               "filetype :org"
+             ]
     end
   end
 end

--- a/test/minga_editor/commands/help_test.exs
+++ b/test/minga_editor/commands/help_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.Commands.HelpTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Keymap.Active, as: ActiveKeymap
   alias MingaEditor.Commands.Help
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -18,8 +19,13 @@ defmodule MingaEditor.Commands.HelpTest do
         {BufferServer, content: "hello", buffer_name: "test.txt"}
       )
 
+    {:ok, keymap} = ActiveKeymap.start_link(name: nil)
+    {:ok, options} = Minga.Config.Options.start_link(name: nil)
+
     %EditorState{
       port_manager: nil,
+      keymap_server: keymap,
+      options_server: options,
       workspace: %MingaEditor.Workspace.State{
         viewport: Viewport.new(24, 80),
         buffers: %Buffers{active: buf, list: [buf]}
@@ -80,6 +86,99 @@ defmodule MingaEditor.Commands.HelpTest do
 
       content = BufferServer.content(result.workspace.buffers.help)
       assert content =~ "Key not bound: z"
+    end
+  end
+
+  describe "describe_bindings" do
+    test "formats leader, normal, text object, and filetype bindings" do
+      state = build_state()
+      BufferServer.set_filetype(state.workspace.buffers.active, :elixir)
+
+      content = Help.bindings_content(state)
+
+      assert content =~ "+file"
+      assert content =~ "SPC f s"
+      assert content =~ "save"
+      assert content =~ "Movement"
+      assert content =~ "w"
+      assert content =~ "word_forward"
+      assert content =~ "Text objects"
+      assert content =~ "iw"
+      assert content =~ "+filetype :elixir"
+      assert content =~ "SPC m t t"
+    end
+
+    test "marks user-defined bindings" do
+      state = build_state()
+
+      ActiveKeymap.bind(
+        state.keymap_server,
+        :normal,
+        "SPC x y",
+        :custom_command,
+        "Custom command"
+      )
+
+      content = Help.bindings_content(state)
+
+      assert content =~ "SPC x y"
+      assert content =~ "custom_command"
+      assert content =~ "*user*"
+    end
+
+    test "opens a read-only *Bindings* buffer" do
+      state = build_state()
+      result = Help.execute(state, :describe_bindings)
+      buffer = result.workspace.buffers.active
+
+      assert BufferServer.buffer_name(buffer) == "*Bindings*"
+      assert BufferServer.read_only?(buffer)
+      assert BufferServer.content(buffer) =~ "# Keybindings"
+    end
+  end
+
+  describe "describe_option" do
+    test "shows option metadata in *Help*" do
+      state = build_state()
+      result = Help.describe_option(state, :tab_width)
+
+      content = BufferServer.content(result.workspace.buffers.help)
+      assert content =~ "# Option: tab_width"
+      assert content =~ "Current value: 2"
+      assert content =~ "Default: 2"
+      assert content =~ "Type: positive integer"
+      assert content =~ "Set by: default"
+      assert content =~ "Description:"
+    end
+
+    test "includes buffer-local provenance in option help" do
+      state = build_state()
+      BufferServer.set_option(state.workspace.buffers.active, :tab_width, 6)
+
+      result = Help.describe_option(state, :tab_width)
+      content = BufferServer.content(result.workspace.buffers.help)
+
+      assert content =~ "Current value: 6"
+      assert content =~ "Set by: default → buffer-local"
+    end
+
+    test "shows extension option metadata" do
+      state = build_state()
+
+      Minga.Config.Options.register_extension_schema(
+        state.options_server,
+        :minga_org,
+        [{:conceal, :boolean, true, "Hide markup syntax."}],
+        conceal: false
+      )
+
+      result = Help.describe_extension_option(state, :minga_org, :conceal)
+      content = BufferServer.content(result.workspace.buffers.help)
+
+      assert content =~ "# Option: minga_org.conceal"
+      assert content =~ "Current value: false"
+      assert content =~ "Set by: default → config.exs"
+      assert content =~ "Hide markup syntax."
     end
   end
 

--- a/test/minga_editor/commands/help_test.exs
+++ b/test/minga_editor/commands/help_test.exs
@@ -6,6 +6,8 @@ defmodule MingaEditor.Commands.HelpTest do
   alias Minga.Keymap.Active, as: ActiveKeymap
   alias MingaEditor.Commands.Help
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.OptionSource
   alias MingaEditor.State.Buffers
   alias MingaEditor.Viewport
 
@@ -151,6 +153,29 @@ defmodule MingaEditor.Commands.HelpTest do
       assert content =~ "Description:"
     end
 
+    test "uses the editor options server for non-buffer-local option values" do
+      state = build_state()
+      Minga.Config.Options.set(state.options_server, :agent_model, "test-model")
+
+      result = Help.describe_option(state, :agent_model)
+      content = BufferServer.content(result.workspace.buffers.help)
+
+      assert content =~ "Current value: \"test-model\""
+      assert content =~ "Set by: default → config.exs"
+    end
+
+    test "uses filetype-scoped values from the editor options server" do
+      state = build_state()
+      BufferServer.set_filetype(state.workspace.buffers.active, :go)
+      Minga.Config.Options.set_for_filetype(state.options_server, :go, :agent_model, "go-model")
+
+      result = Help.describe_option(state, :agent_model)
+      content = BufferServer.content(result.workspace.buffers.help)
+
+      assert content =~ "Current value: \"go-model\""
+      assert content =~ "Set by: default → filetype :go"
+    end
+
     test "includes buffer-local provenance in option help" do
       state = build_state()
       BufferServer.set_option(state.workspace.buffers.active, :tab_width, 6)
@@ -160,6 +185,32 @@ defmodule MingaEditor.Commands.HelpTest do
 
       assert content =~ "Current value: 6"
       assert content =~ "Set by: default → buffer-local"
+    end
+
+    test "option picker uses the editor options server for non-buffer-local values" do
+      state = build_state()
+      Minga.Config.Options.set(state.options_server, :agent_model, "test-model")
+      context = Context.from_editor_state(state)
+
+      item = Enum.find(OptionSource.candidates(context), &(&1.id == :agent_model))
+
+      assert item.description =~ "\"test-model\""
+      assert item.annotation == "modified"
+    end
+
+    test "option picker falls back to the editor options server if the active buffer died" do
+      state = build_state()
+      Minga.Config.Options.set(state.options_server, :agent_model, "test-model")
+      buffer = state.workspace.buffers.active
+      monitor = Process.monitor(buffer)
+
+      GenServer.stop(buffer)
+      assert_receive {:DOWN, ^monitor, :process, ^buffer, _reason}
+
+      context = Context.from_editor_state(state)
+      item = Enum.find(OptionSource.candidates(context), &(&1.id == :agent_model))
+
+      assert item.description =~ "\"test-model\""
     end
 
     test "shows extension option metadata" do


### PR DESCRIPTION
# TL;DR
Minga now has self-documenting help for active keybindings and editor options. `SPC h b` opens a read-only `*Bindings*` buffer, and `SPC h v` plus `:describe <option>` show option metadata, current values, defaults, types, and provenance.

Closes #575
Closes #576

## Context
These tickets add Emacs-style self-documentation for the two most important discovery questions: "what can I press right now?" and "why does this option have this value?" The implementation builds on the existing help-buffer and picker patterns so the feature behaves like normal editor content and remains searchable.

## Changes
- Added `MingaEditor.Commands.Help` as a command provider and registered `:describe_bindings` and `:describe_option` through the standard command registry.
- Added `SPC h b` to render a grouped `*Bindings*` buffer with leader bindings, normal-mode bindings, text objects, filetype `SPC m` bindings, and `*user*` markers for overrides or custom bindings.
- Added option descriptions to the central option registry and reused that metadata for config completion and option help.
- Added `SPC h v` with a picker source that lists built-in and extension options, shows current values, and marks modified values with `●` plus `modified`.
- Added `:describe <option>` for direct option help, including qualified extension options like `minga_org.conceal`.
- Added provenance reporting for default, config, filetype, and buffer-local sources while keeping buffer-local provenance in the editor/help layer.
- Added tests for binding help, option help, extension option metadata, provenance, parser support, and explicit buffer-local option detection.

## Verification
- `mix compile --warnings-as-errors`
- `mix test.llm` (8021 tests, 0 failures)
- `make lint`
- `prtk-code-reviewer` bug-hunting pass, then targeted re-check after fixes
- Final `reviewer` gate: PASS

## Acceptance Criteria Addressed

### #575
- `SPC h b` opens a `*Bindings*` buffer showing bindings active in the current mode ✅
- Bindings are grouped by leader categories using group labels such as `+file` and `+buffer` ✅
- Entries show key sequence, command name, and description ✅
- Non-leader bindings, motions, operators, and text objects are included ✅
- The `*Bindings*` buffer is read-only and searchable as normal buffer content ✅
- User-defined bindings appear with a `*user*` marker ✅
- Filetype-specific `SPC m` bindings are included for the current buffer filetype ✅

### #576
- `SPC h v` opens a picker listing available options with current values ✅
- Selecting an option opens `*Help*` with name, current value, default, type, provenance, and description ✅
- `:describe <option_name>` opens the same option help directly ✅
- Options that differ from defaults are visually distinguished in the picker ✅
