### PR TITLE
feat(command): add describe-function help

### DIFF
--- a/lib/minga/help/docs.ex
+++ b/lib/minga/help/docs.ex
@@ -1,0 +1,145 @@
+defmodule Minga.Help.Docs do
+  @moduledoc """
+  Formats loaded module and function documentation as markdown for the help buffer.
+  """
+
+  @type arity_t :: non_neg_integer()
+  @type docs_result :: {:ok, docs_payload()} | :error
+  @type docs_payload :: %{
+          required(:format) => String.t(),
+          required(:moduledoc) => doc_content(),
+          required(:docs) => [doc_entry()]
+        }
+  @type doc_content :: map() | String.t() | :none | :hidden | nil
+  @type doc_entry :: {doc_id(), term(), [String.t()], doc_content(), map()}
+  @type doc_id :: {:function | :macro | :callback | :macrocallback, atom(), arity_t()}
+  @type spec_entry :: {{atom(), arity_t()}, [tuple()]}
+
+  @no_docs "No documentation available"
+
+  @doc "Formats the moduledoc for `module` as markdown."
+  @spec format_module(module()) :: String.t()
+  def format_module(module) when is_atom(module) do
+    with {:ok, %{format: "text/markdown", moduledoc: moduledoc}} <- fetch_docs(module),
+         {:ok, doc} <- doc_text(moduledoc) do
+      ["# #{inspect(module)}", "", doc]
+      |> Enum.join("\n")
+      |> ensure_trailing_newline()
+    else
+      _ -> @no_docs
+    end
+  end
+
+  @doc "Formats the docs, signature, and specs for `module.function/arity` as markdown."
+  @spec format_function(module(), atom(), arity_t()) :: String.t()
+  def format_function(module, function, arity)
+      when is_atom(module) and is_atom(function) and is_integer(arity) and arity >= 0 do
+    with {:ok, %{format: "text/markdown", docs: docs}} <- fetch_docs(module),
+         {:ok, {_id, _line, signatures, doc, _metadata}} <-
+           find_function_doc(docs, function, arity),
+         {:ok, doc_text} <- doc_text(doc) do
+      [
+        "# #{inspect(module)}.#{function}/#{arity}",
+        "",
+        signature_block(module, function, signatures),
+        "",
+        spec_block(module, function, arity),
+        "",
+        doc_text
+      ]
+      |> Enum.join("\n")
+      |> ensure_trailing_newline()
+    else
+      _ -> @no_docs
+    end
+  end
+
+  @spec fetch_docs(module()) :: docs_result()
+  defp fetch_docs(module) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _anno, _language, format, moduledoc, _metadata, docs} ->
+        {:ok, %{format: format, moduledoc: moduledoc, docs: docs}}
+
+      _ ->
+        :error
+    end
+  end
+
+  @spec find_function_doc([doc_entry()], atom(), arity_t()) :: {:ok, doc_entry()} | :error
+  defp find_function_doc(docs, function, arity) do
+    case Enum.find(docs, &function_doc?(&1, function, arity)) do
+      nil -> :error
+      doc -> {:ok, doc}
+    end
+  end
+
+  @spec function_doc?(doc_entry(), atom(), arity_t()) :: boolean()
+  defp function_doc?(
+         {{:function, function, arity}, _line, _signatures, _doc, _metadata},
+         function,
+         arity
+       ),
+       do: true
+
+  defp function_doc?(_entry, _function, _arity), do: false
+
+  @spec doc_text(doc_content()) :: {:ok, String.t()} | :error
+  defp doc_text(%{"en" => doc}) when is_binary(doc), do: {:ok, doc}
+  defp doc_text(doc) when is_binary(doc), do: {:ok, doc}
+  defp doc_text(_doc), do: :error
+
+  @spec signature_block(module(), atom(), [String.t()]) :: String.t()
+  defp signature_block(module, function, signatures) do
+    signatures
+    |> module_qualified_signatures(module, function)
+    |> fenced_elixir()
+  end
+
+  @spec module_qualified_signatures([String.t()], module(), atom()) :: [String.t()]
+  defp module_qualified_signatures([], module, function),
+    do: ["#{inspect(module)}.#{function}(...)"]
+
+  defp module_qualified_signatures(signatures, module, _function) do
+    Enum.map(signatures, fn signature -> "#{inspect(module)}.#{signature}" end)
+  end
+
+  @spec spec_block(module(), atom(), arity_t()) :: String.t()
+  defp spec_block(module, function, arity) do
+    case specs(module, function, arity) do
+      [] -> "No @spec available"
+      specs -> fenced_elixir(specs)
+    end
+  end
+
+  @spec specs(module(), atom(), arity_t()) :: [String.t()]
+  defp specs(module, function, arity) do
+    case Code.Typespec.fetch_specs(module) do
+      {:ok, specs} -> format_matching_specs(specs, function, arity)
+      _ -> []
+    end
+  end
+
+  @spec format_matching_specs([spec_entry()], atom(), arity_t()) :: [String.t()]
+  defp format_matching_specs(specs, function, arity) do
+    specs
+    |> Enum.filter(fn {{name, spec_arity}, _specs} ->
+      name == function and spec_arity == arity
+    end)
+    |> Enum.flat_map(fn {{name, _spec_arity}, spec_list} ->
+      Enum.map(spec_list, fn spec ->
+        "@spec #{Macro.to_string(Code.Typespec.spec_to_quoted(name, spec))}"
+      end)
+    end)
+  end
+
+  @spec fenced_elixir([String.t()]) :: String.t()
+  defp fenced_elixir(lines) do
+    ["```elixir", Enum.join(lines, "\n"), "```"]
+    |> Enum.join("\n")
+  end
+
+  @spec ensure_trailing_newline(String.t()) :: String.t()
+  defp ensure_trailing_newline(content) do
+    if String.ends_with?(content, "\n"), do: content, else: content <> "\n"
+  end
+end

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -75,6 +75,7 @@ defmodule Minga.Keymap.Defaults do
     # ── Help ──────────────────────────────────────────────────────────────────
     {[{?h, @none}, {?b, @none}], :describe_bindings, "Describe bindings"},
     {[{?h, @none}, {?c, @none}], :describe_command, "Describe command"},
+    {[{?h, @none}, {?f, @none}], :describe_function, "Describe function"},
     {[{?h, @none}, {?k, @none}], :describe_key, "Describe key"},
     {[{?h, @none}, {?l, @none}], :describe_lossage, "Show keystroke history"},
     {[{?h, @none}, {?v, @none}], :describe_option, "Describe option"},

--- a/lib/minga_editor/commands/help.ex
+++ b/lib/minga_editor/commands/help.ex
@@ -8,13 +8,13 @@ defmodule MingaEditor.Commands.Help do
   @behaviour Minga.Command.Provider
 
   alias Minga.Buffer
-  alias Minga.Buffer.Document
   alias Minga.Command
   alias Minga.Config.Options
   alias Minga.Keymap
   alias Minga.Keymap.Bindings
   alias Minga.Keymap.Defaults
   alias MingaEditor.Commands
+  alias MingaEditor.HighlightSync
   alias MingaEditor.KeystrokeHistory
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
@@ -56,6 +56,12 @@ defmodule MingaEditor.Commands.Help do
         description: "Show keystroke history",
         requires_buffer: false,
         execute: fn state -> execute(state, :describe_lossage) end
+      },
+      %Command{
+        name: :describe_function,
+        description: "Describe function",
+        requires_buffer: false,
+        execute: fn state -> execute(state, :describe_function) end
       }
     ]
   end
@@ -95,14 +101,19 @@ defmodule MingaEditor.Commands.Help do
     show_in_buffer(state, "*Keystrokes*", lossage_content(state))
   end
 
+  def execute(state, :describe_function) do
+    PickerUI.open(state, MingaEditor.UI.Picker.HelpSource)
+  end
+
   def execute(state, {:describe_option_named, name}) when is_binary(name) do
     describe_option_named(state, name)
   end
 
   @doc "Shows content in the shared `*Help*` buffer."
   @spec show_in_help_buffer(state(), String.t()) :: state()
-  def show_in_help_buffer(state, content) do
-    show_in_buffer(state, "*Help*", content)
+  @spec show_in_help_buffer(state(), String.t(), keyword()) :: state()
+  def show_in_help_buffer(state, content, opts \\ []) do
+    show_in_buffer(state, "*Help*", content, default_help_options(opts))
   end
 
   @doc "Shows the option help page for `name`."
@@ -830,17 +841,32 @@ defmodule MingaEditor.Commands.Help do
 
   # ── Special buffers ────────────────────────────────────────────────────────
 
-  @spec show_in_buffer(state(), String.t(), String.t()) :: state()
-  defp show_in_buffer(state, "*Help*", content) do
-    {state, help_buf} = ensure_help_buffer(state)
-    replace_help_content(help_buf, content)
-    switch_to_buffer(state, help_buf)
+  @spec default_help_options(keyword()) :: keyword()
+  defp default_help_options(opts) do
+    Keyword.put(opts, :filetype, Keyword.get(opts, :filetype) || :text)
   end
 
-  defp show_in_buffer(state, buffer_name, content) do
+  @spec show_in_buffer(state(), String.t(), String.t(), keyword()) :: state()
+  defp show_in_buffer(state, buffer_name, content, opts \\ [])
+
+  defp show_in_buffer(state, "*Help*", content, opts) do
+    {state, help_buf} = ensure_help_buffer(state)
+    replace_help_content(help_buf, content)
+    apply_help_options(help_buf, opts)
+
+    state
+    |> switch_to_buffer(help_buf)
+    |> setup_highlight_or_defer()
+  end
+
+  defp show_in_buffer(state, buffer_name, content, opts) do
     {state, buffer} = ensure_named_buffer(state, buffer_name)
     replace_help_content(buffer, content)
-    switch_to_buffer(state, buffer)
+    apply_help_options(buffer, opts)
+
+    state
+    |> switch_to_buffer(buffer)
+    |> setup_highlight_or_defer()
   end
 
   @spec ensure_help_buffer(state()) :: {state(), pid()}
@@ -903,8 +929,7 @@ defmodule MingaEditor.Commands.Help do
 
     state =
       if idx do
-        put_in(state.workspace.buffers.active_index, idx)
-        |> then(fn s -> put_in(s.workspace.buffers.active, buffer) end)
+        EditorState.switch_buffer(state, idx)
       else
         Commands.add_buffer(state, buffer)
       end
@@ -914,11 +939,26 @@ defmodule MingaEditor.Commands.Help do
 
   @spec replace_help_content(pid(), String.t()) :: :ok
   defp replace_help_content(buf, content) do
-    :sys.replace_state(buf, fn s ->
-      %{s | document: Document.new(content)}
-    end)
-
+    :ok = Buffer.replace_content_force(buf, content)
     Buffer.move_to(buf, {0, 0})
+  end
+
+  @spec apply_help_options(pid(), keyword()) :: :ok
+  defp apply_help_options(buf, opts) do
+    case Keyword.fetch(opts, :filetype) do
+      {:ok, filetype} when is_atom(filetype) -> Buffer.set_filetype(buf, filetype)
+      _ -> :ok
+    end
+  end
+
+  @spec setup_highlight_or_defer(state()) :: state()
+  defp setup_highlight_or_defer(%{backend: :headless} = state) do
+    HighlightSync.setup_for_buffer(state)
+  end
+
+  defp setup_highlight_or_defer(state) do
+    send(self(), :setup_highlight)
+    state
   end
 
   # ── Command description ─────────────────────────────────────────────────────

--- a/lib/minga_editor/ui/picker/help_source.ex
+++ b/lib/minga_editor/ui/picker/help_source.ex
@@ -1,0 +1,143 @@
+defmodule MingaEditor.UI.Picker.HelpSource do
+  @moduledoc """
+  Picker source for looking up loaded module and function documentation.
+  """
+
+  @behaviour MingaEditor.UI.Picker.Source
+
+  alias Minga.Help.Docs
+  alias MingaEditor.Commands.Help
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.Item
+
+  @type arity_t :: non_neg_integer()
+  @type module_exports :: {module(), [{atom(), arity_t()}]}
+
+  @cache_key {__MODULE__, :candidates}
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Describe function"
+
+  @impl true
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{}) do
+    entries = module_exports()
+    cached_candidates(entries)
+  end
+
+  @impl true
+  @spec on_select(Item.t(), term()) :: term()
+  def on_select(%Item{id: {:module, module}}, state) when is_atom(module) do
+    Help.show_in_help_buffer(state, Docs.format_module(module), filetype: :markdown)
+  end
+
+  def on_select(%Item{id: {:function, module, function, arity}}, state)
+      when is_atom(module) and is_atom(function) and is_integer(arity) and arity >= 0 do
+    Help.show_in_help_buffer(state, Docs.format_function(module, function, arity),
+      filetype: :markdown
+    )
+  end
+
+  def on_select(_item, state), do: state
+
+  @impl true
+  @spec on_cancel(term()) :: term()
+  def on_cancel(state), do: state
+
+  @spec cached_candidates([module_exports()]) :: [Item.t()]
+  defp cached_candidates(entries) do
+    case :persistent_term.get(@cache_key, :missing) do
+      {^entries, candidates} -> candidates
+      _missing_or_stale -> build_and_cache_candidates(entries)
+    end
+  end
+
+  @spec build_and_cache_candidates([module_exports()]) :: [Item.t()]
+  defp build_and_cache_candidates(entries) do
+    candidates = build_candidates(entries)
+    :persistent_term.put(@cache_key, {entries, candidates})
+    candidates
+  end
+
+  @spec build_candidates([module_exports()]) :: [Item.t()]
+  defp build_candidates(entries) do
+    entries
+    |> Enum.flat_map(&module_items/1)
+    |> Enum.sort_by(& &1.label)
+  end
+
+  @spec module_exports() :: [module_exports()]
+  defp module_exports do
+    loaded_modules = Enum.map(:code.all_loaded(), fn {module, _path} -> module end)
+    app_modules = Application.spec(:minga, :modules) || []
+
+    (loaded_modules ++ app_modules)
+    |> Enum.uniq()
+    |> Enum.filter(fn module -> public_elixir_module?(module) and Code.ensure_loaded?(module) end)
+    |> Enum.sort_by(&Atom.to_string/1)
+    |> Enum.map(fn module -> {module, public_functions(module)} end)
+  end
+
+  @spec public_elixir_module?(module()) :: boolean()
+  defp public_elixir_module?(module) when is_atom(module) do
+    name = Atom.to_string(module)
+
+    String.starts_with?(name, "Elixir.") and not generated_or_internal_module?(name)
+  end
+
+  @spec generated_or_internal_module?(String.t()) :: boolean()
+  defp generated_or_internal_module?(name) do
+    String.contains?(name, [".$", ".-", ".__", ".Protocol."]) or
+      String.starts_with?(name, "Elixir.JSON.Encoder.") or
+      String.starts_with?(name, "Elixir.Jason.Encoder.") or
+      String.starts_with?(name, "Elixir.Inspect.") or
+      String.starts_with?(name, "Elixir.Collectable.") or
+      String.starts_with?(name, "Elixir.Enumerable.") or
+      String.starts_with?(name, "Elixir.String.Chars.")
+  end
+
+  @spec module_items(module_exports()) :: [Item.t()]
+  defp module_items({module, functions}) do
+    [module_item(module) | function_items(module, functions)]
+  end
+
+  @spec module_item(module()) :: Item.t()
+  defp module_item(module) do
+    %Item{
+      id: {:module, module},
+      label: inspect(module),
+      description: "Module documentation",
+      annotation: "module"
+    }
+  end
+
+  @spec public_functions(module()) :: [{atom(), arity_t()}]
+  defp public_functions(module) do
+    module.__info__(:functions)
+    |> Enum.reject(&internal_function?/1)
+    |> Enum.sort()
+  end
+
+  @spec function_items(module(), [{atom(), arity_t()}]) :: [Item.t()]
+  defp function_items(module, functions) do
+    Enum.map(functions, fn {function, arity} -> function_item(module, function, arity) end)
+  end
+
+  @spec internal_function?({atom(), arity_t()}) :: boolean()
+  defp internal_function?({function, _arity}) do
+    function
+    |> Atom.to_string()
+    |> String.starts_with?("__")
+  end
+
+  @spec function_item(module(), atom(), arity_t()) :: Item.t()
+  defp function_item(module, function, arity) do
+    %Item{
+      id: {:function, module, function, arity},
+      label: "#{inspect(module)}.#{function}/#{arity}",
+      description: "Function documentation",
+      annotation: "function"
+    }
+  end
+end

--- a/test/minga/help/docs_test.exs
+++ b/test/minga/help/docs_test.exs
@@ -1,0 +1,43 @@
+defmodule Minga.Help.DocsTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Minga.Help.Docs
+
+  @doc false
+  @spec undocumented_helper() :: :ok
+  def undocumented_helper, do: :ok
+
+  describe "format_module/1" do
+    test "returns markdown for module docs" do
+      content = Docs.format_module(Enum)
+
+      assert content =~ "# Enum"
+      assert content =~ "Functions for working with collections"
+    end
+
+    test "returns no documentation message for modules without docs" do
+      assert Docs.format_module(__MODULE__) == "No documentation available"
+    end
+  end
+
+  describe "format_function/3" do
+    test "returns signature, spec, and markdown docs for a function" do
+      content = Docs.format_function(Enum, :map, 2)
+
+      assert content =~ "# Enum.map/2"
+      assert content =~ "```elixir\nEnum.map(enumerable, fun)\n```"
+      assert content =~ "@spec map("
+      assert content =~ "Returns a list"
+    end
+
+    test "returns no documentation message for functions without docs" do
+      assert Docs.format_function(__MODULE__, :undocumented_helper, 0) ==
+               "No documentation available"
+    end
+
+    test "returns no documentation message for unknown functions" do
+      assert Docs.format_function(Enum, :definitely_missing, 0) == "No documentation available"
+    end
+  end
+end

--- a/test/minga/keymap/defaults_test.exs
+++ b/test/minga/keymap/defaults_test.exs
@@ -117,6 +117,12 @@ defmodule Minga.Keymap.DefaultsTest do
 
     # ── Help bindings ──────────────────────────────────────────────────────────
 
+    test "SPC h f → :describe_function" do
+      trie = Defaults.leader_trie()
+      {:prefix, h_node} = Bindings.lookup(trie, {?h, 0})
+      assert {:command, :describe_function} = Bindings.lookup(h_node, {?f, 0})
+    end
+
     test "SPC h k → :describe_key" do
       trie = Defaults.leader_trie()
       {:prefix, h_node} = Bindings.lookup(trie, {?h, 0})

--- a/test/minga_editor/commands/help_test.exs
+++ b/test/minga_editor/commands/help_test.exs
@@ -64,11 +64,13 @@ defmodule MingaEditor.Commands.HelpTest do
       state = build_state()
       result1 = Help.execute(state, {:describe_key_result, "j", :move_down, "Move cursor down"})
       help_pid = result1.workspace.buffers.help
+      version = BufferServer.version(help_pid)
 
       result2 =
         Help.execute(result1, {:describe_key_result, "k", :move_up, "Move cursor up"})
 
       assert result2.workspace.buffers.help == help_pid
+      assert BufferServer.version(help_pid) > version
 
       content = BufferServer.content(help_pid)
       assert content =~ "Command:     move_up"
@@ -380,6 +382,31 @@ defmodule MingaEditor.Commands.HelpTest do
       result = Help.execute(state, {:describe_key_result, "j", :move_down, "Move cursor down"})
 
       assert BufferServer.read_only?(result.workspace.buffers.help)
+    end
+
+    test "help buffer can be shown as markdown" do
+      state = build_state()
+      result = Help.show_in_help_buffer(state, "# Help\n", filetype: :markdown)
+
+      assert BufferServer.filetype(result.workspace.buffers.help) == :markdown
+    end
+
+    test "help commands without an explicit filetype reset the help buffer to text" do
+      state = build_state()
+      result = Help.show_in_help_buffer(state, "# Help\n", filetype: :markdown)
+
+      result = Help.execute(result, {:describe_key_result, "j", :move_down, "Move cursor down"})
+
+      assert BufferServer.filetype(result.workspace.buffers.help) == :text
+    end
+
+    test "nil help buffer filetype resets to text" do
+      state = build_state()
+      result = Help.show_in_help_buffer(state, "# Help\n", filetype: :markdown)
+
+      result = Help.show_in_help_buffer(result, "Plain help\n", filetype: nil)
+
+      assert BufferServer.filetype(result.workspace.buffers.help) == :text
     end
   end
 

--- a/test/minga_editor/ui/picker/help_source_test.exs
+++ b/test/minga_editor/ui/picker/help_source_test.exs
@@ -1,0 +1,86 @@
+defmodule MingaEditor.UI.Picker.HelpSourceTest do
+  @moduledoc false
+  # Uses the global code server and HelpSource persistent_term cache.
+  use ExUnit.Case, async: false
+
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.HelpSource
+
+  describe "candidates/1" do
+    test "includes known modules and public functions" do
+      labels = candidate_labels()
+
+      assert "Enum" in labels
+      assert "Enum.map/2" in labels
+    end
+
+    test "refreshes cached candidates when a new module is loaded" do
+      _initial_labels = candidate_labels()
+      module = Module.concat(__MODULE__, "Dynamic#{System.unique_integer([:positive])}")
+
+      Code.compile_quoted(
+        quote do
+          defmodule unquote(module) do
+            @moduledoc false
+            @spec hello() :: :ok
+            def hello, do: :ok
+          end
+        end
+      )
+
+      assert "#{inspect(module)}.hello/0" in candidate_labels()
+    end
+
+    test "refreshes cached candidates when a module gains a public function" do
+      module = Module.concat(__MODULE__, "Reloaded#{System.unique_integer([:positive])}")
+
+      Code.compile_quoted(
+        quote do
+          defmodule unquote(module) do
+            @moduledoc false
+            def before_reload, do: :ok
+          end
+        end
+      )
+
+      _initial_labels = candidate_labels()
+      :code.purge(module)
+      :code.delete(module)
+
+      Code.compile_quoted(
+        quote do
+          defmodule unquote(module) do
+            @moduledoc false
+            def after_reload, do: :ok
+            def before_reload, do: :ok
+          end
+        end
+      )
+
+      labels = candidate_labels()
+      assert "#{inspect(module)}.after_reload/0" in labels
+      assert "#{inspect(module)}.before_reload/0" in labels
+    end
+  end
+
+  @spec candidate_labels() :: [String.t()]
+  defp candidate_labels do
+    minimal_context()
+    |> HelpSource.candidates()
+    |> Enum.map(& &1.label)
+  end
+
+  @spec minimal_context() :: Context.t()
+  defp minimal_context do
+    struct!(Context,
+      buffers: nil,
+      editing: nil,
+      search: nil,
+      viewport: nil,
+      tab_bar: nil,
+      picker_ui: %{},
+      capabilities: %{},
+      theme: nil
+    )
+  end
+end


### PR DESCRIPTION
# TL;DR
Users can now press `SPC h f` to look up loaded Elixir modules and public functions from the picker, then read module or function docs in the `*Help*` buffer.

Closes #86

## Context
This builds on the merged help command/provider work from #1556. The goal is to make Minga self-documenting for users scripting through eval and public APIs.

## Changes
- Added `Minga.Help.Docs` to fetch ExDoc metadata with `Code.fetch_docs/1`, format moduledocs, signatures, `@spec`s, and raw markdown docs for display.
- Added `MingaEditor.UI.Picker.HelpSource` to list loaded Elixir modules plus public functions as fuzzy-picker candidates.
- Registered `:describe_function` and bound it to `SPC h f`.
- Let `show_in_help_buffer/3` set a dynamic help-buffer filetype so describe-function content opens as `:markdown` and reparses through the existing tree-sitter markdown pipeline.
- Tightened follow-up behavior after fresh-eyes review: normal help pages reset `*Help*` to `:text`, help-buffer switching now goes through `EditorState.switch_buffer/2`, help content replacement uses the buffer owner API, cached picker candidates refresh when modules or their public function exports change, and the cache test no longer mutates global state from an async test.

## Verification
- `mix compile --warnings-as-errors` ✅
- `make lint` ✅
- `mix test.llm test/minga/help/docs_test.exs test/minga_editor/ui/picker/help_source_test.exs test/minga_editor/commands/help_test.exs test/minga/keymap/defaults_test.exs` ✅
- `mix test.llm` was rerun after the first fresh-eyes cleanup and hit 3 unrelated concurrent-suite timeouts; each failed test passed when rerun directly with `mix test.llm test/minga/git/tracker_registry_test.exs:23 test/minga/buffer/auto_save_test.exs:15 test/minga_editor/integration/mouse_test.exs:363` ✅
- Final reviewer before fresh-eyes cleanup: PASS

## Acceptance Criteria Addressed
- `SPC h f` opens a picker listing loaded Elixir modules and public functions ✅
- Typing filters the list with fuzzy matching ✅
- Selecting a module shows its `@moduledoc` in `*Help*` ✅
- Selecting a function shows signature, `@spec`, and `@doc` in `*Help*` ✅
- Missing docs show `No documentation available` ✅
- Markdown docs use the `:markdown` filetype so tree-sitter markdown highlighting can render them ✅
