### PR TITLE
fix(macos): buffer stdout writes and add recovery dialog

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		6860E9D6217B72EAA8AD71A5 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */; };
 		686DD6EB8AFDCAFC79EA100A /* ProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F220A60775A252A728477659 /* ProtocolTests.swift */; };
 		6BA7D7FBA7A05CDEA428811D /* FileTreeHeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */; };
+		6EE7C16703E92B31CC9CE9C0 /* NonBlockingEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3DDF1EB804D4E31EDFA519 /* NonBlockingEncoderTests.swift */; };
 		6F7F50CEC5067770E4865C2A /* CompletionOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */; };
 		73955B38CEFC09D29EADAD85 /* FloatPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C47F406747CA6DD924A1AB /* FloatPopupOverlay.swift */; };
 		74D29226F82E6ADE18E2E108 /* MinibufferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D2D3B0C9A042E9A5C485E1 /* MinibufferState.swift */; };
@@ -105,6 +106,7 @@
 		854BCC1151B43E9A161C95B5 /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912755A61AF5BAF6ED3A480 /* IMEComposition.swift */; };
 		87C92A93D274184D1608DAC5 /* BlinkingCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3927622EC3475A69EE524899 /* BlinkingCursor.swift */; };
 		888A35D1348A7A3CAE935561 /* DecoderFuzzTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053D515EC453DEBFF51FB6CB /* DecoderFuzzTests.swift */; };
+		8A0B62C670C71DB327CE1A29 /* RecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A6769D066EC44A58791CFC /* RecoveryManager.swift */; };
 		8AB3B55F301192FA4F4A4E41 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
 		8B944E100C80DFF282D25D4C /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */; };
 		8CB3E1EEDEA109F6C0183597 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EED42A8B64B9CDFEF37ED9D /* SignatureHelpState.swift */; };
@@ -118,6 +120,7 @@
 		94DCAF47E7E66035A1073E12 /* DispatchSheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4322CD8BEEFC8C2FB832438 /* DispatchSheetState.swift */; };
 		95F6DCD24E2D261CF64EC8EB /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		9758BF46BB0EC7FEEB14FBA3 /* SwiftUIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86478D5660213F165B7E1E35 /* SwiftUIViewTests.swift */; };
+		9C0676A96179F6068B85CCA1 /* RecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A6769D066EC44A58791CFC /* RecoveryManager.swift */; };
 		A0351D1D024158F048BA1C25 /* WorkspaceIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F9A4109AB33ABF7FB441EE /* WorkspaceIconPicker.swift */; };
 		A1AFA4551E04034C5FF5D39B /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD30A2572AE2608F099407 /* ScrollAccumulator.swift */; };
 		A409AE210CBAE48D4DCE47F7 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
@@ -125,6 +128,7 @@
 		A613934E53A1D3B8BAEB69FB /* SignatureHelpOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0070B497768FE68A63F5F114 /* SignatureHelpOverlay.swift */; };
 		A6327C6FAB3DCFD57327FBF4 /* DecoderRobustnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B35E8311966948B1BA7AEF /* DecoderRobustnessTests.swift */; };
 		A78FBA1CD5BB02EEBA8ACB45 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
+		A9EE5F81AE818C176D03A6E3 /* RecoveryManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */; };
 		AB804A6366BEFE62E30C929B /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
 		AFE31388980EE451C8F734A3 /* CachedLineTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */; };
 		B0A5712B943D48F8F72C1DDA /* KeyboardInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */; };
@@ -231,6 +235,7 @@
 		48E21C30D142028698027567 /* CoreTextShaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = CoreTextShaders.metal; sourceTree = "<group>"; };
 		4A647814918768E62822D4A1 /* MingaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MingaApp.swift; sourceTree = "<group>"; };
 		4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolReader.swift; sourceTree = "<group>"; };
+		4B3DDF1EB804D4E31EDFA519 /* NonBlockingEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonBlockingEncoderTests.swift; sourceTree = "<group>"; };
 		4BC98120D82BD7548347875E /* FontFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFace.swift; sourceTree = "<group>"; };
 		4C874A0099721763D5109D99 /* BoardTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTypes.swift; sourceTree = "<group>"; };
 		4D02E1034A8BFBDB7E15FCE9 /* MingaWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MingaWindow.swift; sourceTree = "<group>"; };
@@ -273,6 +278,7 @@
 		BEA9C2BB0C840BE88B0FEA52 /* CompletionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionState.swift; sourceTree = "<group>"; };
 		BEFD30A2572AE2608F099407 /* ScrollAccumulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollAccumulator.swift; sourceTree = "<group>"; };
 		BF5A488C20326CCE3A7FC46E /* DispatchSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchSheetView.swift; sourceTree = "<group>"; };
+		C1A6769D066EC44A58791CFC /* RecoveryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryManager.swift; sourceTree = "<group>"; };
 		C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandDispatcher.swift; sourceTree = "<group>"; };
 		C2AC58C2F81C6E5B2C7004B3 /* GUIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIState.swift; sourceTree = "<group>"; };
 		C441427A427E23B912F70092 /* ProtocolConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolConstants.swift; sourceTree = "<group>"; };
@@ -287,6 +293,7 @@
 		D2D59D9EEB390C8DF351D595 /* FrameState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameState.swift; sourceTree = "<group>"; };
 		DD14027C8C7BD17057DE820B /* AgentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatView.swift; sourceTree = "<group>"; };
 		DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionOverlay.swift; sourceTree = "<group>"; };
+		E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryManagerTests.swift; sourceTree = "<group>"; };
 		E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatState.swift; sourceTree = "<group>"; };
 		E2C629D58FF3305F579BA5E2 /* GUIActionEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIActionEncoderTests.swift; sourceTree = "<group>"; };
 		E892F827AFBE959F9DF25C05 /* StatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarView.swift; sourceTree = "<group>"; };
@@ -312,6 +319,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0AA3147316DFBDDC375B279C /* Recovery */ = {
+			isa = PBXGroup;
+			children = (
+				C1A6769D066EC44A58791CFC /* RecoveryManager.swift */,
+			);
+			path = Recovery;
+			sourceTree = "<group>";
+		};
 		11BD8FE058FA53674B42329F /* Renderer */ = {
 			isa = PBXGroup;
 			children = (
@@ -454,6 +469,7 @@
 				4A647814918768E62822D4A1 /* MingaApp.swift */,
 				4AACF7C989E8FDB12B3EC840 /* Font */,
 				BE05074760AA9D5983E99402 /* Protocol */,
+				0AA3147316DFBDDC375B279C /* Recovery */,
 				11BD8FE058FA53674B42329F /* Renderer */,
 				B26C6BDB50303355902FB133 /* Views */,
 			);
@@ -502,11 +518,13 @@
 				F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */,
 				7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */,
 				AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */,
+				4B3DDF1EB804D4E31EDFA519 /* NonBlockingEncoderTests.swift */,
 				321E4E28F5F49F089CCE2E1D /* PipelineCacheTests.swift */,
 				47BD56B7D6D195D236F9BF40 /* ProtocolEncoderBinaryTests.swift */,
 				19D226D16EF96375868F716D /* ProtocolEncoderDisconnectTests.swift */,
 				3DC281B7F9F7E4C0BA793B1E /* ProtocolSchemaTests.swift */,
 				F220A60775A252A728477659 /* ProtocolTests.swift */,
+				E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */,
 				211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */,
 				1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */,
 				9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */,
@@ -715,6 +733,7 @@
 				BF41C04B7AF7C400A4DC1474 /* ProtocolEncoder.swift in Sources */,
 				364C48575BB95C9CA535A9C8 /* ProtocolReader.swift in Sources */,
 				F5DA741E5CBCF22184C6C712 /* ProtocolTypes.swift in Sources */,
+				8A0B62C670C71DB327CE1A29 /* RecoveryManager.swift in Sources */,
 				A1AFA4551E04034C5FF5D39B /* ScrollAccumulator.swift in Sources */,
 				ED8D3D1F950A66E95AA3093F /* SidebarContainer.swift in Sources */,
 				19BF036E1B3A3CF589C5F578 /* SidebarHeaderButton.swift in Sources */,
@@ -799,6 +818,7 @@
 				74D29226F82E6ADE18E2E108 /* MinibufferState.swift in Sources */,
 				3943C8DF3827347B61E6B725 /* MinibufferView.swift in Sources */,
 				058481A528AFB6C7225A067D /* MouseInputTests.swift in Sources */,
+				6EE7C16703E92B31CC9CE9C0 /* NonBlockingEncoderTests.swift in Sources */,
 				F560D385A1FB0A46824F7B1F /* PickerOverlay.swift in Sources */,
 				32171233224FC90E1E956631 /* PickerState.swift in Sources */,
 				BF4E98B0BE647893CB5DA85C /* PipelineCache.swift in Sources */,
@@ -813,6 +833,8 @@
 				F0A2BCCA095F1CA4FBE9BE3F /* ProtocolSchemaTests.swift in Sources */,
 				686DD6EB8AFDCAFC79EA100A /* ProtocolTests.swift in Sources */,
 				4515011E135C9FAE8D843610 /* ProtocolTypes.swift in Sources */,
+				9C0676A96179F6068B85CCA1 /* RecoveryManager.swift in Sources */,
+				A9EE5F81AE818C176D03A6E3 /* RecoveryManagerTests.swift in Sources */,
 				793247C2AB95598A1AC4C6EC /* ScrollAccumulator.swift in Sources */,
 				D42695D627BD38405475ECFF /* ScrollAccumulatorTests.swift in Sources */,
 				17338247D6D83DAF4DE5B9EA /* SidebarContainer.swift in Sources */,

--- a/macos/Sources/BEAMProcessManager.swift
+++ b/macos/Sources/BEAMProcessManager.swift
@@ -169,6 +169,12 @@ final class BEAMProcessManager {
         return urls
     }
 
+    /// Sends SIGUSR1 to the BEAM so the Watchdog restarts the editor core while preserving buffers.
+    func sendRecoveryRestartSignal() {
+        guard let proc = process, proc.isRunning else { return }
+        kill(proc.processIdentifier, SIGUSR1)
+    }
+
     /// Sends SIGTERM to the BEAM and waits briefly for clean shutdown.
     /// Used during Cmd+Q / applicationShouldTerminate.
     func shutdownGracefully(timeout: TimeInterval = 3.0) {

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -11,6 +11,7 @@
 
 import SwiftUI
 import AppKit
+import Darwin
 import os
 
 /// Default font settings.
@@ -570,6 +571,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var protocolReader: ProtocolReader?
     private var encoder: ProtocolEncoder?
     private var dispatcher: CommandDispatcher?
+    private var recoveryManager: RecoveryManager?
     private var fontFace: FontFace?
     private var fontManager: FontManager?
     private var editorNSView: EditorNSView?
@@ -668,16 +670,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         self.dispatcher = disp
 
+        // Recovery manager tracks key input and render responses so Ctrl-G
+        // can present a native restart dialog if the BEAM stops responding.
+        let recovery = RecoveryManager { [weak self] in
+            if let manager = self?.beamManager {
+                manager.sendRecoveryRestartSignal()
+            } else {
+                let parentPid = getppid()
+                if parentPid > 1 { kill(parentPid, SIGUSR1) }
+            }
+        }
+        self.recoveryManager = recovery
+
         // Create the editor view.
         let nsView = EditorNSView(encoder: enc, fontFace: face, dispatcher: disp,
                                    coreTextRenderer: ctRenderer, fontManager: fm)
         nsView.guiState = appState.gui
         nsView.statusBarState = appState.gui.statusBarState
+        nsView.recoveryManager = recovery
         self.editorNSView = nsView
         appState.editorNSView = nsView
         observeWorkspaceLifecycleNotifications()
         os_signpost(.event, log: startupLog, name: "EditorViewCreated")
 
+        disp.onBatchEnd = { [weak recovery] in
+            recovery?.onRenderReceived()
+        }
         disp.onFrameReady = { [weak nsView] in
             nsView?.renderFrame()
         }

--- a/macos/Sources/Protocol/ProtocolEncoder.swift
+++ b/macos/Sources/Protocol/ProtocolEncoder.swift
@@ -1,9 +1,11 @@
 /// Encodes input events from the GUI to the BEAM via stdout.
 ///
 /// All events are length-prefixed with a 4-byte big-endian header
-/// (`{:packet, 4}` framing). The encoder writes directly to stdout
-/// with a lock to prevent interleaved writes from multiple threads.
+/// (`{:packet, 4}` framing). The encoder enqueues frames on a serial
+/// write queue and drains stdout asynchronously so UI threads never block
+/// behind pipe backpressure.
 
+import Darwin
 import Foundation
 
 /// Protocol for sending input events to the BEAM. The real implementation
@@ -110,24 +112,78 @@ extension InputEncoder {
 /// -1 with `errno = EPIPE`, which we handle by marking the encoder as
 /// disconnected and silently dropping subsequent writes.
 final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
-    private let lock = NSLock()
     private let fd: Int32
+    private let writeQueue = DispatchQueue(label: "minga.encoder.write", qos: .userInteractive)
+    private let writeQueueKey = DispatchSpecificKey<Void>()
+    private let maxBufferSize: Int
+    private let retryDelay: DispatchTimeInterval = .milliseconds(10)
+
     /// Once a write fails with EPIPE, all subsequent writes are dropped.
     private var connected: Bool = true
+    private var writeBuffer = Data()
+    private var bufferSize: Int = 0
+    private var drainRetryScheduled: Bool = false
+    private var droppedCount: UInt64 = 0
 
     /// Creates an encoder. Defaults to stdout for production use.
     /// Pass a pipe's write handle for testing binary layout.
-    init(output: FileHandle = .standardOutput) {
+    init(output: FileHandle = .standardOutput, maxBufferSize: Int = 64 * 1024) {
         self.fd = output.fileDescriptor
+        self.maxBufferSize = maxBufferSize
+        writeQueue.setSpecific(key: writeQueueKey, value: ())
+        setNonBlocking(fd: fd)
     }
 
     /// Mark the encoder as disconnected. Called by the reader's
     /// `onDisconnect` callback so writes stop immediately without
     /// waiting for the next EPIPE.
     func disconnect() {
-        lock.lock()
-        defer { lock.unlock() }
-        connected = false
+        writeQueue.async { [weak self] in
+            guard let self else { return }
+            self.connected = false
+            self.writeBuffer.removeAll(keepingCapacity: false)
+            self.bufferSize = 0
+        }
+    }
+
+    /// Snapshot of dropped messages for diagnostics and tests.
+    var droppedMessageCount: UInt64 {
+        if DispatchQueue.getSpecific(key: writeQueueKey) != nil {
+            return droppedCount
+        }
+        return writeQueue.sync { droppedCount }
+    }
+
+    /// Snapshot of buffered bytes for diagnostics and tests.
+    var bufferedByteCount: Int {
+        if DispatchQueue.getSpecific(key: writeQueueKey) != nil {
+            return bufferSize
+        }
+        return writeQueue.sync { bufferSize }
+    }
+
+    /// Snapshot of currently buffered framed bytes for unit tests.
+    func bufferedDataForTesting() -> Data {
+        if DispatchQueue.getSpecific(key: writeQueueKey) != nil {
+            return writeBuffer
+        }
+        return writeQueue.sync { writeBuffer }
+    }
+
+    /// Blocks until previously enqueued writes have had a chance to drain.
+    /// This is for unit tests only; production callers must not use it.
+    @discardableResult
+    func waitForPendingWritesForTesting(timeout: TimeInterval = 1.0) -> Bool {
+        if DispatchQueue.getSpecific(key: writeQueueKey) != nil {
+            return true
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        writeQueue.async { [weak self] in
+            self?.drainBuffer()
+            semaphore.signal()
+        }
+        return semaphore.wait(timeout: .now() + timeout) == .success
     }
 
     /// Send the ready event with initial dimensions and capabilities.
@@ -746,18 +802,25 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
 
     // MARK: - Private
 
-    /// Write a length-prefixed frame using POSIX `write()`.
+    /// Enqueue a length-prefixed frame for asynchronous POSIX `write()`.
     ///
     /// `FileHandle.write()` raises an ObjC `NSFileHandleOperationException`
     /// on EPIPE that Swift cannot catch, zombifying the app. POSIX `write()`
     /// returns -1 and sets `errno = EPIPE`, which we handle by flipping
-    /// `connected` to false.
+    /// `connected` to false. The file descriptor is non-blocking, so pipe
+    /// backpressure returns EAGAIN instead of freezing the caller.
     private func writeFrame(_ payload: Data) {
-        lock.lock()
-        defer { lock.unlock() }
+        let frame = makeFrame(payload)
+        writeQueue.async { [weak self] in
+            guard let self, self.connected else { return }
+            self.writeBuffer.append(frame)
+            self.bufferSize += frame.count
+            self.dropOldestFramesIfNeeded()
+            self.drainBuffer()
+        }
+    }
 
-        guard connected else { return }
-
+    private func makeFrame(_ payload: Data) -> Data {
         var frame = Data(count: 4 + payload.count)
         let len = UInt32(payload.count)
         frame[0] = UInt8((len >> 24) & 0xFF)
@@ -765,23 +828,88 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
         frame[2] = UInt8((len >> 8) & 0xFF)
         frame[3] = UInt8(len & 0xFF)
         frame.replaceSubrange(4..<(4 + payload.count), with: payload)
+        return frame
+    }
 
-        frame.withUnsafeBytes { buffer in
-            guard let ptr = buffer.baseAddress else { return }
-            var remaining = frame.count
-            var offset = 0
-            while remaining > 0 {
-                let written = Darwin.write(fd, ptr + offset, remaining)
-                if written < 0 {
-                    if errno == EINTR { continue }
-                    // EPIPE or other fatal error: pipe is broken.
-                    connected = false
-                    return
-                }
-                offset += written
-                remaining -= written
+    private func drainBuffer() {
+        guard connected else { return }
+
+        while bufferSize > 0 {
+            let written = writeBuffer.withUnsafeBytes { buffer -> Int in
+                guard let ptr = buffer.baseAddress else { return 0 }
+                return Darwin.write(fd, ptr, bufferSize)
             }
+
+            if written > 0 {
+                writeBuffer.removeSubrange(0..<written)
+                bufferSize -= written
+                continue
+            }
+
+            if written == 0 {
+                scheduleDrainRetry()
+                return
+            }
+
+            let error = errno
+            if error == EINTR {
+                continue
+            }
+            if error == EAGAIN || error == EWOULDBLOCK {
+                scheduleDrainRetry()
+                return
+            }
+
+            connected = false
+            writeBuffer.removeAll(keepingCapacity: false)
+            bufferSize = 0
+            return
         }
+    }
+
+    private func scheduleDrainRetry() {
+        guard !drainRetryScheduled, connected else { return }
+        drainRetryScheduled = true
+        writeQueue.asyncAfter(deadline: .now() + retryDelay) { [weak self] in
+            guard let self else { return }
+            self.drainRetryScheduled = false
+            self.drainBuffer()
+        }
+    }
+
+    private func dropOldestFramesIfNeeded() {
+        guard bufferSize > maxBufferSize else { return }
+
+        var droppedThisPass: UInt64 = 0
+        while bufferSize > maxBufferSize, writeBuffer.count >= 4 {
+            let payloadLength = Int(writeBuffer[0]) << 24 | Int(writeBuffer[1]) << 16 | Int(writeBuffer[2]) << 8 | Int(writeBuffer[3])
+            let frameLength = 4 + payloadLength
+            guard frameLength > 4, frameLength <= writeBuffer.count else {
+                writeBuffer.removeAll(keepingCapacity: false)
+                bufferSize = 0
+                droppedThisPass += 1
+                break
+            }
+
+            // A single valid frame can be slightly larger than the default
+            // threshold, for example a maximum-size paste event. Preserve it
+            // rather than silently dropping user input before a drain attempt.
+            guard frameLength < writeBuffer.count else { break }
+
+            writeBuffer.removeSubrange(0..<frameLength)
+            bufferSize -= frameLength
+            droppedThisPass += 1
+        }
+
+        guard droppedThisPass > 0 else { return }
+        droppedCount += droppedThisPass
+        PortLogger.warn("GUI output buffer exceeded \(maxBufferSize) bytes; dropped \(droppedThisPass) oldest messages (total \(droppedCount))")
+    }
+
+    private func setNonBlocking(fd: Int32) {
+        let flags = fcntl(fd, F_GETFL, 0)
+        guard flags >= 0 else { return }
+        _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
     }
 
     private func writeU16(_ buf: inout Data, _ offset: Int, _ value: UInt16) {

--- a/macos/Sources/Recovery/RecoveryManager.swift
+++ b/macos/Sources/Recovery/RecoveryManager.swift
@@ -1,0 +1,84 @@
+/// Detects frontend-to-BEAM stalls and presents a native recovery dialog.
+///
+/// The macOS frontend keeps accepting keyboard events even when the BEAM stops
+/// reading from its port. If key events have been sent and no render batch has
+/// completed for a few seconds, Ctrl-G becomes an explicit recovery gesture.
+
+import AppKit
+import Darwin
+import Foundation
+
+@MainActor
+final class RecoveryManager {
+    private let timeoutSeconds: CFTimeInterval
+    private let restartAction: @MainActor () -> Void
+
+    private(set) var lastBatchEndTime: CFAbsoluteTime
+    private(set) var keysSinceLastRender: Int = 0
+    private(set) var isShowingAlert: Bool = false
+
+    init(timeoutSeconds: CFTimeInterval = 3.0, restartAction: @escaping @MainActor () -> Void = RecoveryManager.sendRestartSignalToParent) {
+        self.timeoutSeconds = timeoutSeconds
+        self.restartAction = restartAction
+        self.lastBatchEndTime = CFAbsoluteTimeGetCurrent()
+    }
+
+    /// Records that a complete render batch arrived from the BEAM.
+    func onRenderReceived() {
+        lastBatchEndTime = CFAbsoluteTimeGetCurrent()
+        keysSinceLastRender = 0
+        isShowingAlert = false
+    }
+
+    /// Records that a key event was sent to the BEAM.
+    func onKeySent() {
+        keysSinceLastRender += 1
+    }
+
+    /// Returns true when user input is pending and the BEAM has not rendered within the timeout.
+    func isUnresponsive(now: CFAbsoluteTime = CFAbsoluteTimeGetCurrent()) -> Bool {
+        keysSinceLastRender > 0 && now - lastBatchEndTime > timeoutSeconds
+    }
+
+    /// Handles Ctrl-G. Returns true when the recovery gesture was consumed.
+    @discardableResult
+    func handleCtrlG() -> Bool {
+        guard isUnresponsive() else { return false }
+        guard !isShowingAlert else { return true }
+        showRecoveryAlert()
+        return true
+    }
+
+    /// Test helper for deterministic timeout checks.
+    func setLastBatchEndTimeForTesting(_ time: CFAbsoluteTime) {
+        lastBatchEndTime = time
+    }
+
+    private func showRecoveryAlert() {
+        isShowingAlert = true
+        defer { isShowingAlert = false }
+
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = "Editor Unresponsive"
+        alert.informativeText = "Minga has sent input to the editor core, but no render response has arrived. You can restart the editor core while preserving buffers, quit Minga, or wait for it to recover."
+        alert.addButton(withTitle: "Restart Editor")
+        alert.addButton(withTitle: "Quit Minga")
+        alert.addButton(withTitle: "Wait")
+
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            restartAction()
+        case .alertSecondButtonReturn:
+            NSApp.terminate(nil)
+        default:
+            break
+        }
+    }
+
+    private static func sendRestartSignalToParent() {
+        let parentPid = getppid()
+        guard parentPid > 1 else { return }
+        kill(parentPid, SIGUSR1)
+    }
+}

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -34,6 +34,10 @@ final class CommandDispatcher {
     /// this to trigger a GPU frame.
     var onFrameReady: (() -> Void)?
 
+    /// Called after each `batch_end` command so recovery logic knows the
+    /// BEAM is still responding to input.
+    var onBatchEnd: (() -> Void)?
+
     /// Called when the window title should change.
     var onTitleChanged: ((String) -> Void)?
 
@@ -103,6 +107,7 @@ final class CommandDispatcher {
                 firstRender()
                 onFirstRender = nil
             }
+            onBatchEnd?()
             onFrameReady?()
 
         case .setTitle(let title):

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -29,6 +29,9 @@ final class EditorNSView: MTKView {
     /// GUI state for semantic window content (0x80) and theme colors.
     var guiState: GUIState?
 
+    /// Tracks BEAM responsiveness and handles Ctrl-G recovery.
+    var recoveryManager: RecoveryManager?
+
     private var trackingArea: NSTrackingArea?
 
     /// IME composition state (marked text tracking).
@@ -627,6 +630,13 @@ final class EditorNSView: MTKView {
         resetCursorBlink()
         let mods = modifierBits(from: event.modifierFlags)
 
+        if event.modifierFlags.contains(.control),
+           event.charactersIgnoringModifiers == "g",
+           recoveryManager?.handleCtrlG() == true
+        {
+            return
+        }
+
         // ── Space leader key-chord interception ──
         // When SPC is pending or held, intercept chord keys before any
         // other processing. Skip when:
@@ -640,7 +650,7 @@ final class EditorNSView: MTKView {
                     // User holding SPC for repeated spaces. Cancel chord detection.
                     cancelSpaceGrace()
                     spaceKeyDown = false
-                    encoder.sendKeyPress(codepoint: 0x20, modifiers: 0)
+                    sendKeyPress(codepoint: 0x20, modifiers: 0)
                     return
                 }
 
@@ -652,7 +662,7 @@ final class EditorNSView: MTKView {
                     // Grace period expired. Send the space now.
                     self.spacePending = false
                     self.spaceKeyDown = true
-                    self.encoder.sendKeyPress(codepoint: 0x20, modifiers: 0)
+                    self.sendKeyPress(codepoint: 0x20, modifiers: 0)
                 }
                 spaceGraceTimer?.cancel()
                 spaceGraceTimer = timer
@@ -667,7 +677,7 @@ final class EditorNSView: MTKView {
                 cancelSpaceGrace()
                 spacePending = false
                 spaceKeyDown = false
-                encoder.sendSpaceLeaderChord(codepoint: codepoint(from: event, mods: mods), modifiers: mods)
+                sendSpaceLeaderChord(codepoint: codepoint(from: event, mods: mods), modifiers: mods)
                 return
             }
 
@@ -675,7 +685,7 @@ final class EditorNSView: MTKView {
                 // Fallback chord: SPC was already sent (grace timer fired).
                 // Tell BEAM to retract the space and enter leader.
                 spaceKeyDown = false
-                encoder.sendSpaceLeaderRetract(codepoint: codepoint(from: event, mods: mods), modifiers: mods)
+                sendSpaceLeaderRetract(codepoint: codepoint(from: event, mods: mods), modifiers: mods)
                 return
             }
         }
@@ -720,7 +730,7 @@ final class EditorNSView: MTKView {
                     return
                 }
             }
-            encoder.sendKeyPress(codepoint: codepoint, modifiers: mods)
+            sendKeyPress(codepoint: codepoint, modifiers: mods)
             return
         }
 
@@ -733,7 +743,7 @@ final class EditorNSView: MTKView {
                 ? event.charactersIgnoringModifiers : event.characters
             if let characters = chars, !characters.isEmpty {
                 for scalar in characters.unicodeScalars {
-                    encoder.sendKeyPress(codepoint: scalar.value, modifiers: textMods)
+                    sendKeyPress(codepoint: scalar.value, modifiers: textMods)
                 }
             }
             return
@@ -765,7 +775,7 @@ final class EditorNSView: MTKView {
                 // Send the space now (clean, no flash).
                 cancelSpaceGrace()
                 spacePending = false
-                encoder.sendKeyPress(codepoint: 0x20, modifiers: 0)
+                sendKeyPress(codepoint: 0x20, modifiers: 0)
             }
             spaceKeyDown = false
         }
@@ -1041,8 +1051,24 @@ final class EditorNSView: MTKView {
     /// Send committed text from IME to the BEAM as individual key presses.
     private func commitIMEText(_ text: String) {
         for scalar in text.unicodeScalars {
-            encoder.sendKeyPress(codepoint: scalar.value, modifiers: 0)
+            sendKeyPress(codepoint: scalar.value, modifiers: 0)
         }
+    }
+
+    /// Sends a key press and updates recovery tracking in one place.
+    private func sendKeyPress(codepoint: UInt32, modifiers: UInt8) {
+        recoveryManager?.onKeySent()
+        encoder.sendKeyPress(codepoint: codepoint, modifiers: modifiers)
+    }
+
+    private func sendSpaceLeaderChord(codepoint: UInt32, modifiers: UInt8) {
+        recoveryManager?.onKeySent()
+        encoder.sendSpaceLeaderChord(codepoint: codepoint, modifiers: modifiers)
+    }
+
+    private func sendSpaceLeaderRetract(codepoint: UInt32, modifiers: UInt8) {
+        recoveryManager?.onKeySent()
+        encoder.sendSpaceLeaderRetract(codepoint: codepoint, modifiers: modifiers)
     }
 
     // MARK: - Helpers

--- a/macos/Tests/MingaTests/NonBlockingEncoderTests.swift
+++ b/macos/Tests/MingaTests/NonBlockingEncoderTests.swift
@@ -1,0 +1,135 @@
+/// Tests for ProtocolEncoder's asynchronous, non-blocking write buffer.
+
+import Darwin
+import Foundation
+import Testing
+
+private func fillPipeUntilWouldBlock(_ fd: Int32) {
+    var chunk = [UInt8](repeating: 0, count: 4096)
+    while true {
+        let written = chunk.withUnsafeMutableBytes { buffer in
+            Darwin.write(fd, buffer.baseAddress, buffer.count)
+        }
+        if written >= 0 { continue }
+        if errno == EINTR { continue }
+        #expect(errno == EAGAIN || errno == EWOULDBLOCK)
+        return
+    }
+}
+
+private func parseFrames(_ raw: Data) -> [Data]? {
+    var frames: [Data] = []
+    var offset = 0
+
+    while offset < raw.count {
+        guard raw.count - offset >= 4 else { return nil }
+        let length = Int(raw[offset]) << 24 | Int(raw[offset + 1]) << 16 | Int(raw[offset + 2]) << 8 | Int(raw[offset + 3])
+        let frameStart = offset + 4
+        let frameEnd = frameStart + length
+        guard length > 0, frameEnd <= raw.count else { return nil }
+        frames.append(raw.subdata(in: frameStart..<frameEnd))
+        offset = frameEnd
+    }
+
+    return frames
+}
+
+@Suite("Encoder: Non-blocking Buffer")
+struct NonBlockingEncoderTests {
+    @Test("writes are buffered and delivered asynchronously")
+    func writesDeliveredAsynchronously() {
+        let pipe = Pipe()
+        let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting)
+
+        encoder.sendKeyPress(codepoint: 0x61, modifiers: 0)
+        encoder.sendKeyPress(codepoint: 0x62, modifiers: 0)
+        encoder.sendResize(cols: 120, rows: 40)
+
+        #expect(encoder.waitForPendingWritesForTesting())
+        pipe.fileHandleForWriting.closeFile()
+
+        let raw = pipe.fileHandleForReading.readDataToEndOfFile()
+        let frames = parseFrames(raw)
+        #expect(frames?.count == 3)
+        #expect(frames?[0].first == OP_KEY_PRESS)
+        #expect(frames?[1].first == OP_KEY_PRESS)
+        #expect(frames?[2].first == OP_RESIZE)
+    }
+
+    @Test("single frame larger than threshold is preserved when writable")
+    func singleLargeFrameIsPreservedWhenWritable() {
+        let pipe = Pipe()
+        let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting, maxBufferSize: 16)
+
+        encoder.sendPasteEvent(text: String(repeating: "x", count: 128))
+
+        #expect(encoder.waitForPendingWritesForTesting())
+        pipe.fileHandleForWriting.closeFile()
+
+        let raw = pipe.fileHandleForReading.readDataToEndOfFile()
+        let frames = parseFrames(raw)
+        #expect(encoder.droppedMessageCount == 0)
+        #expect(frames?.count == 1)
+        #expect(frames?.first?.first == OP_PASTE_EVENT)
+    }
+
+    @Test("buffer overflow drops complete oldest messages")
+    func bufferOverflowDropsCompleteMessages() {
+        let pipe = Pipe()
+        let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting, maxBufferSize: 16)
+        fillPipeUntilWouldBlock(pipe.fileHandleForWriting.fileDescriptor)
+
+        encoder.sendPasteEvent(text: String(repeating: "x", count: 128))
+        encoder.sendKeyPress(codepoint: 0x63, modifiers: 0)
+
+        #expect(encoder.waitForPendingWritesForTesting())
+
+        let frames = parseFrames(encoder.bufferedDataForTesting())
+        #expect(encoder.droppedMessageCount > 0)
+        #expect(frames?.count == 1)
+        #expect(frames?.first?.first == OP_KEY_PRESS)
+
+        pipe.fileHandleForWriting.closeFile()
+        pipe.fileHandleForReading.closeFile()
+    }
+
+    @Test("disconnect discards buffered writes")
+    func disconnectDiscardsBufferedWrites() {
+        let pipe = Pipe()
+        let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting)
+
+        encoder.disconnect()
+        encoder.sendKeyPress(codepoint: 0x61, modifiers: 0)
+        encoder.sendPasteEvent(text: "dropped")
+
+        #expect(encoder.waitForPendingWritesForTesting())
+        pipe.fileHandleForWriting.closeFile()
+
+        let raw = pipe.fileHandleForReading.readDataToEndOfFile()
+        #expect(raw.isEmpty)
+    }
+
+    @Test("concurrent writes from multiple tasks keep frame boundaries")
+    func concurrentWritesKeepFrameBoundaries() async {
+        let pipe = Pipe()
+        let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting)
+
+        await withTaskGroup(of: Void.self) { group in
+            for taskIndex in 0..<8 {
+                group.addTask {
+                    for offset in 0..<25 {
+                        encoder.sendKeyPress(codepoint: UInt32(0x61 + ((taskIndex + offset) % 26)), modifiers: 0)
+                    }
+                }
+            }
+        }
+
+        #expect(encoder.waitForPendingWritesForTesting())
+        pipe.fileHandleForWriting.closeFile()
+
+        let raw = pipe.fileHandleForReading.readDataToEndOfFile()
+        let frames = parseFrames(raw)
+        #expect(frames?.count == 200)
+        #expect(frames?.allSatisfy { $0.count == 6 && $0.first == OP_KEY_PRESS } == true)
+    }
+}

--- a/macos/Tests/MingaTests/ProtocolEncoderBinaryTests.swift
+++ b/macos/Tests/MingaTests/ProtocolEncoderBinaryTests.swift
@@ -13,6 +13,7 @@ private func captureFrame(_ action: (ProtocolEncoder) -> Void) -> Data {
     let pipe = Pipe()
     let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting)
     action(encoder)
+    #expect(encoder.waitForPendingWritesForTesting())
     // Close write end so read doesn't block
     pipe.fileHandleForWriting.closeFile()
     let raw = pipe.fileHandleForReading.readDataToEndOfFile()
@@ -338,6 +339,7 @@ struct EncoderFrameHeaderTests {
         let pipe = Pipe()
         let encoder = ProtocolEncoder(output: pipe.fileHandleForWriting)
         encoder.sendResize(cols: 80, rows: 24)
+        #expect(encoder.waitForPendingWritesForTesting())
         pipe.fileHandleForWriting.closeFile()
         let raw = pipe.fileHandleForReading.readDataToEndOfFile()
 

--- a/macos/Tests/MingaTests/ProtocolEncoderDisconnectTests.swift
+++ b/macos/Tests/MingaTests/ProtocolEncoderDisconnectTests.swift
@@ -20,6 +20,7 @@ struct EncoderDisconnectTests {
 
         // Send one frame before disconnect (should succeed).
         encoder.sendReady(cols: 80, rows: 24)
+        #expect(encoder.waitForPendingWritesForTesting())
 
         // Disconnect the encoder.
         encoder.disconnect()
@@ -33,6 +34,7 @@ struct EncoderDisconnectTests {
         encoder.sendLog(level: 1, message: "test")
         encoder.sendSelectTab(id: 1)
         encoder.sendExecuteCommand(name: "quit")
+        #expect(encoder.waitForPendingWritesForTesting())
 
         // Close write end and read everything that was written.
         pipe.fileHandleForWriting.closeFile()
@@ -53,6 +55,7 @@ struct EncoderDisconnectTests {
 
         // Should not crash. Writes should still be dropped.
         encoder.sendKeyPress(codepoint: 0x61, modifiers: 0)
+        #expect(encoder.waitForPendingWritesForTesting())
 
         pipe.fileHandleForWriting.closeFile()
         let raw = pipe.fileHandleForReading.readDataToEndOfFile()
@@ -83,6 +86,7 @@ struct EncoderDisconnectTests {
         encoder.sendKeyPress(codepoint: 0x62, modifiers: 0)
         encoder.sendResize(cols: 100, rows: 50)
         encoder.sendPasteEvent(text: "should be dropped")
+        #expect(encoder.waitForPendingWritesForTesting())
     }
 
     @Test("encoder survives rapid writes to a broken pipe")
@@ -100,6 +104,7 @@ struct EncoderDisconnectTests {
         for i: UInt32 in 0..<100 {
             encoder.sendKeyPress(codepoint: 0x61 + (i % 26), modifiers: 0)
         }
+        #expect(encoder.waitForPendingWritesForTesting())
     }
 
     // MARK: - Thread safety
@@ -128,6 +133,8 @@ struct EncoderDisconnectTests {
                 encoder.disconnect()
             }
         }
+
+        #expect(encoder.waitForPendingWritesForTesting())
 
         // If we get here without crashing or deadlocking, the test passes.
         // Close the pipe so it doesn't leak.

--- a/macos/Tests/MingaTests/RecoveryManagerTests.swift
+++ b/macos/Tests/MingaTests/RecoveryManagerTests.swift
@@ -1,0 +1,46 @@
+/// Tests for macOS freeze recovery state detection.
+
+import Foundation
+import Testing
+
+@MainActor
+@Suite("RecoveryManager")
+struct RecoveryManagerTests {
+    @Test("not unresponsive initially")
+    func notUnresponsiveInitially() {
+        let manager = RecoveryManager()
+
+        #expect(manager.isUnresponsive() == false)
+        #expect(manager.keysSinceLastRender == 0)
+    }
+
+    @Test("not unresponsive if no keys were sent")
+    func notUnresponsiveWithoutPendingKeys() {
+        let manager = RecoveryManager()
+        manager.setLastBatchEndTimeForTesting(CFAbsoluteTimeGetCurrent() - 10.0)
+
+        #expect(manager.isUnresponsive() == false)
+    }
+
+    @Test("becomes unresponsive after timeout with pending keys")
+    func unresponsiveAfterTimeoutWithPendingKeys() {
+        let manager = RecoveryManager()
+        manager.onKeySent()
+        manager.setLastBatchEndTimeForTesting(CFAbsoluteTimeGetCurrent() - 4.0)
+
+        #expect(manager.isUnresponsive() == true)
+    }
+
+    @Test("render receipt resets pending keys and responsiveness")
+    func renderReceiptResetsState() {
+        let manager = RecoveryManager()
+        manager.onKeySent()
+        manager.setLastBatchEndTimeForTesting(CFAbsoluteTimeGetCurrent() - 4.0)
+        #expect(manager.isUnresponsive() == true)
+
+        manager.onRenderReceived()
+
+        #expect(manager.isUnresponsive() == false)
+        #expect(manager.keysSinceLastRender == 0)
+    }
+}


### PR DESCRIPTION
# TL;DR
The macOS frontend now buffers stdout writes on a non-blocking serial queue, so AppKit input handlers do not freeze when the BEAM stops reading. Ctrl-G also opens a native recovery dialog when input has been sent but no render batch has returned for more than 3 seconds.

Closes #538

## Context
Issue #538 tracks the macOS side of the freeze recovery work from #535. The BEAM Watchdog and SIGUSR1 recovery path already exist, but the Swift frontend still wrote framed input synchronously to stdout and had no native recovery UI.

## Changes
- Replaced `ProtocolEncoder`'s `NSLock` plus synchronous `write()` path with a serial `DispatchQueue`, non-blocking fd setup, buffered framed writes, EAGAIN retry, and EPIPE disconnect handling.
- Added message-boundary-aware overflow dropping with a 64KB default threshold, drop diagnostics, and a guard that preserves a single valid oversized frame long enough to drain.
- Added `RecoveryManager`, which tracks key input versus `batch_end` render responses and shows an `NSAlert` with Restart Editor, Quit Minga, and Wait when Ctrl-G is pressed during an unresponsive period.
- Wired recovery into `CommandDispatcher`, `EditorNSView`, `AppDelegate`, and `BEAMProcessManager` so bundle mode signals the managed BEAM child and dev mode falls back to the parent BEAM process.
- Added Swift tests for async encoder delivery, overflow behavior, frame-boundary preservation, disconnect handling, concurrent writes, and recovery timeout state.

## Verification
- `xcodebuild -project macos/Minga.xcodeproj -scheme Minga test` (500 tests)
- `mix swift.build`
- `make lint`
- `mix test.llm` (54 doctests, 97 properties, 8015 tests, 0 failures, 5 skipped, 115 excluded)

## Acceptance Criteria Addressed
- `ProtocolEncoder` never blocks the main thread on stdout writes; writes are buffered and drained asynchronously. ✅
- The `InputEncoder` contract is preserved. ✅
- The encoder uses a serial `DispatchQueue` instead of `NSLock`. ✅
- Write buffer overflow drops oldest complete messages, preserves framing, and logs a warning. ✅
- Ctrl-G after >3 seconds without `batch_end` opens a native recovery dialog. ✅
- Restart Editor sends SIGUSR1 to the correct BEAM process, Quit terminates via `NSApp.terminate`, and Wait dismisses the dialog. ✅
- Normal input remains AppKit-managed while the modal alert is shown. ✅
