### PR TITLE
fix(ui): clamp picker popup height and increase default window size

### DIFF
--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -456,8 +456,7 @@ defmodule MingaEditor.PickerUI do
       }) do
     {visible, selected_offset} = Picker.visible_items(picker)
 
-    # Clamp to available vertical space: prompt takes 1 row, separator takes 1 row,
-    # leave at least 1 row of editor content visible at the top.
+    # Clamp so items + separator + prompt never exceed viewport height.
     max_items_for_viewport = max(viewport.rows - 3, 1)
     visible = Enum.take(visible, max_items_for_viewport)
     selected_offset = min(selected_offset, max(length(visible) - 1, 0))

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -95,9 +95,7 @@ defmodule MingaEditor.PickerUI do
         state
 
       _ ->
-        # Use terminal height minus 3 (separator + prompt + at least 1 buffer line visible)
-        max_vis = state.terminal_viewport.rows - 3
-        max_vis = max(5, min(max_vis, state.terminal_viewport.rows - 3))
+        max_vis = max(state.terminal_viewport.rows - 3, 5)
         picker = Picker.new(items, title: source_module.title(), max_visible: max_vis)
 
         # Clear whichkey state if active
@@ -457,6 +455,12 @@ defmodule MingaEditor.PickerUI do
         viewport: viewport
       }) do
     {visible, selected_offset} = Picker.visible_items(picker)
+
+    # Clamp to available vertical space: prompt takes 1 row, separator takes 1 row,
+    # leave at least 1 row of editor content visible at the top.
+    max_items_for_viewport = max(viewport.rows - 3, 1)
+    visible = Enum.take(visible, max_items_for_viewport)
+    selected_offset = min(selected_offset, max(length(visible) - 1, 0))
     item_count = length(visible)
 
     # Layout: items grow upward from row N-2, prompt on row N-1
@@ -853,8 +857,7 @@ defmodule MingaEditor.PickerUI do
        ) do
     ctx = Context.from_editor_state(state)
     items = new_source.candidates(ctx)
-    max_vis = state.terminal_viewport.rows - 3
-    max_vis = max(5, min(max_vis, state.terminal_viewport.rows - 3))
+    max_vis = max(state.terminal_viewport.rows - 3, 5)
     picker = Picker.new(items, title: new_source.title(), max_visible: max_vis)
     layout = MingaEditor.UI.Picker.Source.layout(new_source)
     original = orig_src || current_source
@@ -879,8 +882,7 @@ defmodule MingaEditor.PickerUI do
        ) do
     ctx = Context.from_editor_state(state)
     items = orig.candidates(ctx)
-    max_vis = state.terminal_viewport.rows - 3
-    max_vis = max(5, min(max_vis, state.terminal_viewport.rows - 3))
+    max_vis = max(state.terminal_viewport.rows - 3, 5)
     picker = Picker.new(items, title: orig.title(), max_visible: max_vis)
     layout = MingaEditor.UI.Picker.Source.layout(orig)
 

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -459,8 +459,8 @@ defmodule MingaEditor.PickerUI do
     # Clamp so items + separator + prompt never exceed viewport height.
     max_items_for_viewport = max(viewport.rows - 3, 1)
     visible = Enum.take(visible, max_items_for_viewport)
-    selected_offset = min(selected_offset, max(length(visible) - 1, 0))
     item_count = length(visible)
+    selected_offset = if item_count > 0, do: min(selected_offset, item_count - 1), else: 0
 
     # Layout: items grow upward from row N-2, prompt on row N-1
     prompt_row = viewport.rows - 1

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -78,7 +78,7 @@ defmodule MingaEditor.RenderPipeline.Input do
     # Workspace as a plain map (enables state.workspace.X pattern-matching)
     :workspace,
     # Terminal-level viewport (screen dimensions reported by frontend on resize)
-    terminal_viewport: Viewport.new(50, 160),
+    terminal_viewport: Viewport.new(24, 80),
     # Render-pipeline caches (replaces process-dictionary entries)
     caches: %Caches{},
     # Renderer-owned font registration state. Editor snapshots use a fresh

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -78,7 +78,7 @@ defmodule MingaEditor.RenderPipeline.Input do
     # Workspace as a plain map (enables state.workspace.X pattern-matching)
     :workspace,
     # Terminal-level viewport (screen dimensions reported by frontend on resize)
-    terminal_viewport: Viewport.new(24, 80),
+    terminal_viewport: Viewport.new(50, 160),
     # Render-pipeline caches (replaces process-dictionary entries)
     caches: %Caches{},
     # Renderer-owned font registration state. Editor snapshots use a fresh

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -18,8 +18,8 @@ private let defaultFontName = "Menlo"
 private let defaultFontSize: CGFloat = 13.0
 
 /// Default window dimensions in pixels.
-private let defaultWindowWidth: CGFloat = 800
-private let defaultWindowHeight: CGFloat = 600
+private let defaultWindowWidth: CGFloat = 1200
+private let defaultWindowHeight: CGFloat = 800
 
 @main
 struct MingaApp: App {

--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -33,15 +33,13 @@ struct PickerOverlay: View {
                             encoder?.sendKeyPress(codepoint: 27, modifiers: 0)
                         }
 
-                    let maxListHeight = max(geo.size.height * 0.5, 200)
-
                     VStack(spacing: 0) {
                         searchField
 
                         Divider()
                             .overlay(theme.popupBorder.opacity(0.3))
 
-                        resultsList(maxListHeight: maxListHeight)
+                        resultsList(maxListHeight: max(geo.size.height * 0.5, 200))
 
                         if !state.items.isEmpty {
                             Divider()

--- a/macos/Sources/Views/PickerOverlay.swift
+++ b/macos/Sources/Views/PickerOverlay.swift
@@ -14,7 +14,6 @@ struct PickerOverlay: View {
 
     private let panelWidth: CGFloat = 600
     private let itemHeight: CGFloat = 24
-    private let maxListHeight: CGFloat = 440
 
     /// Transition animation duration. Respects reduced motion.
     private var animDuration: Double {
@@ -23,46 +22,50 @@ struct PickerOverlay: View {
 
     var body: some View {
         if state.visible {
-            ZStack {
-                // Dimmed background: click to dismiss (like Spotlight, Alfred, Xcode Open Quickly)
-                Color.black.opacity(0.3)
-                    .ignoresSafeArea()
-                    .accessibilityHidden(true)
-                    .onTapGesture {
-                        // Send Escape to the BEAM to dismiss the picker via the normal mode transition
-                        encoder?.sendKeyPress(codepoint: 27, modifiers: 0)
-                    }
+            GeometryReader { geo in
+                ZStack {
+                    // Dimmed background: click to dismiss (like Spotlight, Alfred, Xcode Open Quickly)
+                    Color.black.opacity(0.3)
+                        .ignoresSafeArea()
+                        .accessibilityHidden(true)
+                        .onTapGesture {
+                            // Send Escape to the BEAM to dismiss the picker via the normal mode transition
+                            encoder?.sendKeyPress(codepoint: 27, modifiers: 0)
+                        }
 
-                VStack(spacing: 0) {
-                    searchField
+                    let maxListHeight = max(geo.size.height * 0.5, 200)
 
-                    Divider()
-                        .overlay(theme.popupBorder.opacity(0.3))
+                    VStack(spacing: 0) {
+                        searchField
 
-                    resultsList
-
-                    if !state.items.isEmpty {
                         Divider()
                             .overlay(theme.popupBorder.opacity(0.3))
-                        bottomBar
+
+                        resultsList(maxListHeight: maxListHeight)
+
+                        if !state.items.isEmpty {
+                            Divider()
+                                .overlay(theme.popupBorder.opacity(0.3))
+                            bottomBar
+                        }
                     }
-                }
-                .frame(width: panelWidth)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(theme.popupBg)
-                        .shadow(color: .black.opacity(0.5), radius: 20, y: 8)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .strokeBorder(theme.popupBorder.opacity(0.4), lineWidth: 1)
-                )
-                .overlay(alignment: .center) {
-                    if let menu = state.actionMenu {
-                        actionMenuOverlay(menu)
+                    .frame(width: panelWidth)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(theme.popupBg)
+                            .shadow(color: .black.opacity(0.5), radius: 20, y: 8)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(theme.popupBorder.opacity(0.4), lineWidth: 1)
+                    )
+                    .overlay(alignment: .center) {
+                        if let menu = state.actionMenu {
+                            actionMenuOverlay(menu)
+                        }
                     }
+                    .offset(y: -60)
                 }
-                .offset(y: -60)
             }
             .transition(.opacity.animation(.easeInOut(duration: animDuration)))
         }
@@ -102,7 +105,7 @@ struct PickerOverlay: View {
     // MARK: - Results list
 
     @ViewBuilder
-    private var resultsList: some View {
+    private func resultsList(maxListHeight: CGFloat) -> some View {
         ScrollViewReader { proxy in
             ScrollView(.vertical, showsIndicators: true) {
                 LazyVStack(spacing: 0) {


### PR DESCRIPTION
## Summary
- **Picker popup overflow fix (TUI):** The bottom-anchored picker now clamps visible items to the actual viewport height at render time, preventing items from rendering at negative rows when `max_visible` is stale after a terminal resize.
- **Picker popup overflow fix (macOS GUI):** Replaced the hardcoded `maxListHeight: 440` with a dynamic value (50% of window height, min 200px) via `GeometryReader`, so the popup scales with the window.
- **Default window size:** Increased from 800x600 to 1200x800 to better suit a code editor. Only affects first launch since `setFrameAutosaveName` persists the user's preferred size.
- **Simplified redundant `max_visible` calculation** in all three picker open paths (`max(5, min(x, x))` → `max(x, 5)`).

## Test plan
- [x] `mix test.llm` passes (8033 tests, 2 pre-existing flaky failures unrelated to this change)
- [ ] Open the command palette in the macOS GUI with a small window; verify the list doesn't overflow
- [ ] Open the command palette in the TUI with a small terminal (e.g. 24 rows); verify no rendering above row 0
- [ ] Resize the window while the picker is open; verify the list adjusts

🤖 Generated with [Claude Code](https://claude.com/claude-code)