### PR TITLE
feat(git): commit message buffer and inline blame annotations

### DIFF
--- a/lib/minga/git.ex
+++ b/lib/minga/git.ex
@@ -100,6 +100,19 @@ defmodule Minga.Git do
   def blame_line(git_root, relative_path, line_number),
     do: impl().blame_line(git_root, relative_path, line_number)
 
+  @typedoc "Blame info for a single line."
+  @type blame_info :: %{author: String.t(), date: String.t(), summary: String.t()}
+
+  @doc """
+  Gets blame information for all lines of a file.
+
+  Returns `{:ok, %{0-indexed-line => blame_info}}` or `:error`.
+  """
+  @spec blame_file(String.t(), String.t()) ::
+          {:ok, %{non_neg_integer() => blame_info()}} | :error
+  def blame_file(git_root, relative_path),
+    do: impl().blame_file(git_root, relative_path)
+
   @doc """
   Returns a structured list of changed files with their status.
   """
@@ -133,6 +146,12 @@ defmodule Minga.Git do
   """
   @spec commit(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def commit(git_root, message), do: impl().commit(git_root, message)
+
+  @doc """
+  Amends the last commit with the given message.
+  """
+  @spec commit_amend(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def commit_amend(git_root, message), do: impl().commit_amend(git_root, message)
 
   @doc """
   Returns the current branch name for a git repository.

--- a/lib/minga/git/backend.ex
+++ b/lib/minga/git/backend.ex
@@ -24,6 +24,12 @@ defmodule Minga.Git.Backend do
             ) ::
               {:ok, String.t()} | :error
 
+  @typedoc "Blame info for a single line."
+  @type blame_info :: %{author: String.t(), date: String.t(), summary: String.t()}
+
+  @callback blame_file(git_root :: String.t(), relative_path :: String.t()) ::
+              {:ok, %{non_neg_integer() => blame_info()}} | :error
+
   @callback status(git_root :: String.t()) ::
               {:ok, [Minga.Git.status_entry()]} | {:error, String.t()}
 
@@ -37,6 +43,9 @@ defmodule Minga.Git.Backend do
               :ok | {:error, String.t()}
 
   @callback commit(git_root :: String.t(), message :: String.t()) ::
+              {:ok, String.t()} | {:error, String.t()}
+
+  @callback commit_amend(git_root :: String.t(), message :: String.t()) ::
               {:ok, String.t()} | {:error, String.t()}
 
   @callback stage_patch(git_root :: String.t(), patch :: String.t()) ::

--- a/lib/minga/git/buffer.ex
+++ b/lib/minga/git/buffer.ex
@@ -235,6 +235,7 @@ defmodule Minga.Git.Buffer do
          hunks: hunks,
          signs: signs,
          branch: branch,
+         blame_enabled: false,
          blame_cache: nil
      }}
   end

--- a/lib/minga/git/buffer.ex
+++ b/lib/minga/git/buffer.ex
@@ -23,7 +23,9 @@ defmodule Minga.Git.Buffer do
           base_lines: [String.t()],
           hunks: [Diff.hunk()],
           signs: %{non_neg_integer() => Diff.hunk_type()},
-          branch: String.t() | nil
+          branch: String.t() | nil,
+          blame_enabled: boolean(),
+          blame_cache: %{non_neg_integer() => map()} | nil
         }
 
   # ── Client API ─────────────────────────────────────────────────────────────
@@ -68,6 +70,24 @@ defmodule Minga.Git.Buffer do
   @spec hunk_at(GenServer.server(), non_neg_integer()) :: Diff.hunk() | nil
   def hunk_at(server, line) when is_integer(line) do
     GenServer.call(server, {:hunk_at, line})
+  end
+
+  @doc "Toggles blame annotations and fetches blame data if enabling."
+  @spec toggle_blame(GenServer.server()) :: :ok
+  def toggle_blame(server) do
+    GenServer.call(server, :toggle_blame)
+  end
+
+  @doc "Returns whether blame annotations are currently enabled."
+  @spec blame_enabled?(GenServer.server()) :: boolean()
+  def blame_enabled?(server) do
+    GenServer.call(server, :blame_enabled?)
+  end
+
+  @doc "Returns the cached blame data, or nil if not fetched."
+  @spec blame_data(GenServer.server()) :: %{non_neg_integer() => map()} | nil
+  def blame_data(server) do
+    GenServer.call(server, :blame_data)
   end
 
   @doc "Returns the git root path."
@@ -134,7 +154,9 @@ defmodule Minga.Git.Buffer do
       base_lines: base_lines,
       hunks: hunks,
       signs: signs,
-      branch: branch
+      branch: branch,
+      blame_enabled: false,
+      blame_cache: nil
     }
 
     {:ok, state}
@@ -170,6 +192,27 @@ defmodule Minga.Git.Buffer do
     {:reply, state.relative_path, state}
   end
 
+  def handle_call(:toggle_blame, _from, state) do
+    new_enabled = not state.blame_enabled
+
+    new_cache =
+      if new_enabled and state.blame_cache == nil do
+        fetch_blame_data(state.git_root, state.relative_path)
+      else
+        state.blame_cache
+      end
+
+    {:reply, :ok, %{state | blame_enabled: new_enabled, blame_cache: new_cache}}
+  end
+
+  def handle_call(:blame_enabled?, _from, state) do
+    {:reply, state.blame_enabled, state}
+  end
+
+  def handle_call(:blame_data, _from, state) do
+    {:reply, state.blame_cache, state}
+  end
+
   @impl true
   def handle_cast({:update, content}, state) do
     current_lines = split_lines(content)
@@ -184,7 +227,16 @@ defmodule Minga.Git.Buffer do
     hunks = Diff.diff_lines(base_lines, current_lines)
     signs = Diff.signs_for_hunks(hunks)
     branch = read_branch(state.git_root)
-    {:noreply, %{state | base_lines: base_lines, hunks: hunks, signs: signs, branch: branch}}
+
+    {:noreply,
+     %{
+       state
+       | base_lines: base_lines,
+         hunks: hunks,
+         signs: signs,
+         branch: branch,
+         blame_cache: nil
+     }}
   end
 
   # ── Private ────────────────────────────────────────────────────────────────
@@ -213,6 +265,14 @@ defmodule Minga.Git.Buffer do
     case Git.show_head(git_root, relative_path) do
       {:ok, content} -> split_lines(content)
       :error -> []
+    end
+  end
+
+  @spec fetch_blame_data(String.t(), String.t()) :: %{non_neg_integer() => map()} | nil
+  defp fetch_blame_data(git_root, relative_path) do
+    case Git.blame_file(git_root, relative_path) do
+      {:ok, data} -> data
+      :error -> nil
     end
   end
 

--- a/lib/minga/git/system.ex
+++ b/lib/minga/git/system.ex
@@ -229,11 +229,21 @@ defmodule Minga.Git.System do
            cd: git_root,
            stderr_to_stdout: true
          ) do
-      {output, 0} -> {:ok, parse_porcelain_blame_file(output)}
-      _ -> :error
+      {output, 0} ->
+        {:ok, parse_porcelain_blame_file(output)}
+
+      {output, code} ->
+        Minga.Log.warning(
+          :git,
+          "git blame failed (exit #{code}): #{String.slice(output, 0, 200)}"
+        )
+
+        :error
     end
   rescue
-    _ -> :error
+    e ->
+      Minga.Log.warning(:git, "git blame error: #{Exception.message(e)}")
+      :error
   end
 
   @impl true

--- a/lib/minga/git/system.ex
+++ b/lib/minga/git/system.ex
@@ -197,6 +197,46 @@ defmodule Minga.Git.System do
   end
 
   @impl true
+  @spec commit_amend(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def commit_amend(git_root, message) when is_binary(git_root) and is_binary(message) do
+    case System.cmd("git", ["commit", "--amend", "-m", message],
+           cd: git_root,
+           stderr_to_stdout: true
+         ) do
+      {output, 0} ->
+        short_hash =
+          case Regex.run(~r"\[[\w/.-]+ ([a-f0-9]+)\]", output) do
+            [_, hash] -> hash
+            _ -> "unknown"
+          end
+
+        {:ok, short_hash}
+
+      {output, _} ->
+        {:error, "git commit --amend failed: #{String.trim(output)}"}
+    end
+  rescue
+    e in [ErlangError, ArgumentError] ->
+      {:error, "git commit --amend error: #{Exception.message(e)}"}
+  end
+
+  @impl true
+  @spec blame_file(String.t(), String.t()) ::
+          {:ok, %{non_neg_integer() => Minga.Git.Backend.blame_info()}} | :error
+  def blame_file(git_root, relative_path)
+      when is_binary(git_root) and is_binary(relative_path) do
+    case System.cmd("git", ["blame", "--porcelain", relative_path],
+           cd: git_root,
+           stderr_to_stdout: true
+         ) do
+      {output, 0} -> {:ok, parse_porcelain_blame_file(output)}
+      _ -> :error
+    end
+  rescue
+    _ -> :error
+  end
+
+  @impl true
   @spec ahead_behind(String.t()) :: {:ok, non_neg_integer(), non_neg_integer()} | :error
   def ahead_behind(git_root) when is_binary(git_root) do
     case System.cmd("git", ["rev-list", "--left-right", "--count", "HEAD...@{upstream}"],
@@ -608,5 +648,131 @@ defmodule Minga.Git.System do
       end)
 
     "#{author} (#{date}): #{summary}"
+  end
+
+  @spec parse_porcelain_blame_file(String.t()) :: %{
+          non_neg_integer() => Minga.Git.Backend.blame_info()
+        }
+  defp parse_porcelain_blame_file(output) do
+    output
+    |> String.split("\n")
+    |> parse_blame_lines(%{}, %{}, nil)
+  end
+
+  # Recursive parser for porcelain blame output. Accumulates per-commit
+  # metadata in `commits` and builds the final `result` map keyed by
+  # 0-indexed line number.
+  @spec parse_blame_lines(
+          [String.t()],
+          %{String.t() => Minga.Git.Backend.blame_info()},
+          %{non_neg_integer() => Minga.Git.Backend.blame_info()},
+          {String.t(), non_neg_integer(), map()} | nil
+        ) :: %{non_neg_integer() => Minga.Git.Backend.blame_info()}
+  defp parse_blame_lines([], _commits, result, _current), do: result
+
+  defp parse_blame_lines(["" | rest], commits, result, current) do
+    parse_blame_lines(rest, commits, result, current)
+  end
+
+  defp parse_blame_lines([line | rest], commits, result, current) do
+    parse_blame_line(line, rest, commits, result, current)
+  end
+
+  @spec parse_blame_line(
+          String.t(),
+          [String.t()],
+          %{String.t() => Minga.Git.Backend.blame_info()},
+          %{non_neg_integer() => Minga.Git.Backend.blame_info()},
+          {String.t(), non_neg_integer(), map()} | nil
+        ) :: %{non_neg_integer() => Minga.Git.Backend.blame_info()}
+
+  # Content line (starts with tab): finalize this entry
+  defp parse_blame_line(<<?\t, _content::binary>>, rest, commits, result, {sha, final_line, meta}) do
+    info = finalize_blame_entry(sha, meta, commits)
+    commits = Map.put_new(commits, sha, info)
+    # Store as 0-indexed
+    result = Map.put(result, final_line - 1, info)
+    parse_blame_lines(rest, commits, result, nil)
+  end
+
+  # Header line: 40-char SHA + original_line + final_line [+ num_lines]
+  defp parse_blame_line(line, rest, commits, result, nil) do
+    case parse_blame_header(line) do
+      {:ok, sha, final_line} ->
+        # Check if we already have metadata for this commit
+        case Map.fetch(commits, sha) do
+          {:ok, info} ->
+            # Reuse: skip metadata lines until we hit the content line
+            parse_blame_lines(rest, commits, Map.put(result, final_line - 1, info), nil)
+
+          :error ->
+            parse_blame_lines(rest, commits, result, {sha, final_line, %{}})
+        end
+
+      :not_header ->
+        # Unknown line, skip
+        parse_blame_lines(rest, commits, result, nil)
+    end
+  end
+
+  # Metadata line while accumulating fields for a commit
+  defp parse_blame_line("author " <> name, rest, commits, result, {sha, fl, meta}) do
+    parse_blame_lines(rest, commits, result, {sha, fl, Map.put(meta, :author, name)})
+  end
+
+  defp parse_blame_line("author-time " <> ts, rest, commits, result, {sha, fl, meta}) do
+    date = format_unix_timestamp(ts)
+    parse_blame_lines(rest, commits, result, {sha, fl, Map.put(meta, :date, date)})
+  end
+
+  defp parse_blame_line("summary " <> msg, rest, commits, result, {sha, fl, meta}) do
+    parse_blame_lines(rest, commits, result, {sha, fl, Map.put(meta, :summary, msg)})
+  end
+
+  # Other metadata fields (author-mail, committer, etc.): skip
+  defp parse_blame_line(_line, rest, commits, result, current) do
+    parse_blame_lines(rest, commits, result, current)
+  end
+
+  @spec parse_blame_header(String.t()) ::
+          {:ok, String.t(), non_neg_integer()} | :not_header
+  defp parse_blame_header(line) do
+    case String.split(line, " ") do
+      [sha, _orig, final | _] when byte_size(sha) == 40 ->
+        case Integer.parse(final) do
+          {final_line, _} -> {:ok, sha, final_line}
+          :error -> :not_header
+        end
+
+      _ ->
+        :not_header
+    end
+  end
+
+  @spec finalize_blame_entry(
+          String.t(),
+          map(),
+          %{String.t() => Minga.Git.Backend.blame_info()}
+        ) :: Minga.Git.Backend.blame_info()
+  defp finalize_blame_entry(sha, meta, commits) do
+    case Map.fetch(commits, sha) do
+      {:ok, existing} ->
+        existing
+
+      :error ->
+        %{
+          author: Map.get(meta, :author, "unknown"),
+          date: Map.get(meta, :date, ""),
+          summary: Map.get(meta, :summary, "")
+        }
+    end
+  end
+
+  @spec format_unix_timestamp(String.t()) :: String.t()
+  defp format_unix_timestamp(ts) do
+    case Integer.parse(ts) do
+      {unix, _} -> DateTime.from_unix!(unix) |> Calendar.strftime("%Y-%m-%d")
+      _ -> ""
+    end
   end
 end

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -114,7 +114,7 @@ defmodule Minga.Keymap.Defaults do
     {[{?g, @none}, {?s, @none}], :git_stage_hunk, "Stage hunk"},
     {[{?g, @none}, {?r, @none}], :git_revert_hunk, "Revert hunk"},
     {[{?g, @none}, {?v, @none}], :git_preview_hunk, "Preview hunk"},
-    {[{?g, @none}, {?b, @none}], :git_blame_line, "Blame line"},
+    {[{?g, @none}, {?b, @none}], :git_blame_toggle, "Toggle blame"},
 
     # ── Project ────────────────────────────────────────────────────────────────
     {[{?p, @none}, {?f, @none}], :project_find_file, "Find file in project"},

--- a/lib/minga/keymap/scope.ex
+++ b/lib/minga/keymap/scope.ex
@@ -29,6 +29,7 @@ defmodule Minga.Keymap.Scope do
   * `:agent` — agent chat view (Board zoom or side panel)
   * `:file_tree` — file tree panel
   * `:git_status` — git status panel
+  * `:git_commit` — git commit message buffer
 
   ## Resolution layers
 
@@ -59,7 +60,7 @@ defmodule Minga.Keymap.Scope do
   @type context :: keyword()
 
   @typedoc "A scope name atom."
-  @type scope_name :: :editor | :agent | :file_tree | :git_status
+  @type scope_name :: :editor | :agent | :file_tree | :git_status | :git_commit
 
   @typedoc "Vim state relevant to scope resolution."
   @type vim_state :: :normal | :insert | :input_normal | :cua
@@ -144,7 +145,8 @@ defmodule Minga.Keymap.Scope do
     editor: Minga.Keymap.Scope.Editor,
     agent: Minga.Keymap.Scope.Agent,
     file_tree: Minga.Keymap.Scope.FileTree,
-    git_status: Minga.Keymap.Scope.GitStatus
+    git_status: Minga.Keymap.Scope.GitStatus,
+    git_commit: Minga.Keymap.Scope.GitCommit
   }
 
   @doc "Returns the scope module for a given scope name."

--- a/lib/minga/keymap/scope/git_commit.ex
+++ b/lib/minga/keymap/scope/git_commit.ex
@@ -1,0 +1,73 @@
+defmodule Minga.Keymap.Scope.GitCommit do
+  @moduledoc """
+  Keymap scope for the git commit message buffer (Magit-style).
+
+  Provides C-c C-c to commit, C-c C-k to abort, and q (normal mode)
+  as a convenience quit. In insert mode, unmatched keys pass through
+  to the Mode FSM for normal text editing.
+  """
+
+  use Minga.Keymap.Scope.Builder,
+    name: :git_commit,
+    display_name: "Git Commit"
+
+  alias Minga.Keymap.Bindings
+
+  @escape 27
+  @ctrl 0x02
+
+  # ── Keymap ─────────────────────────────────────────────────────────────────
+
+  @impl true
+  @spec keymap(Minga.Keymap.Scope.vim_state(), Minga.Keymap.Scope.context()) ::
+          Bindings.node_t()
+  def keymap(:normal, _context), do: normal_trie()
+  def keymap(:insert, _context), do: insert_trie()
+  def keymap(_state, _context), do: Bindings.new()
+
+  @impl true
+  @spec shared_keymap() :: Bindings.node_t()
+  def shared_keymap, do: shared_trie()
+
+  @impl true
+  @spec help_groups(atom()) :: [Minga.Keymap.Scope.help_group()]
+  def help_groups(_focus) do
+    [
+      {"Commit",
+       [
+         {"C-c C-c", "Commit and close"},
+         {"C-c C-k", "Abort and close"}
+       ]},
+      {"View",
+       [
+         {"q", "Abort (normal mode)"},
+         {"Esc", "Return to normal mode (from insert)"}
+       ]}
+    ]
+  end
+
+  # ── Shared bindings (both normal and insert) ───────────────────────────
+
+  @spec shared_trie() :: Bindings.node_t()
+  defp shared_trie do
+    Bindings.new()
+    |> Bindings.bind([{?c, @ctrl}, {?c, @ctrl}], :git_commit_execute, "Commit and close")
+    |> Bindings.bind([{?c, @ctrl}, {?k, @ctrl}], :git_commit_abort, "Abort and close")
+  end
+
+  # ── Normal mode bindings ───────────────────────────────────────────────
+
+  @spec normal_trie() :: Bindings.node_t()
+  defp normal_trie do
+    Bindings.new()
+    |> Bindings.bind([{?q, 0}], :git_commit_abort, "Abort commit")
+  end
+
+  # ── Insert mode bindings ───────────────────────────────────────────────
+
+  @spec insert_trie() :: Bindings.node_t()
+  defp insert_trie do
+    Bindings.new()
+    |> Bindings.bind([{@escape, 0}], :git_commit_to_normal, "Normal mode")
+  end
+end

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -182,22 +182,19 @@ defmodule MingaEditor.Commands.Git do
         EditorState.set_status(state, "No commit in progress")
 
       %{git_root: git_root, amend: amend, buffer_pid: buf_pid} ->
-        {content, _cursor} = Buffer.content_and_cursor(buf_pid)
-        message = strip_commit_comments(content)
+        content =
+          try do
+            {text, _cursor} = Buffer.content_and_cursor(buf_pid)
+            text
+          catch
+            :exit, _ -> nil
+          end
 
-        if String.trim(message) == "" do
+        if is_nil(content) do
           state = close_commit_buffer(state, buf_pid)
-          EditorState.set_status(state, "Aborting commit due to empty message")
+          EditorState.set_status(state, "Commit buffer lost")
         else
-          result =
-            if amend do
-              Git.commit_amend(git_root, message)
-            else
-              Git.commit(git_root, message)
-            end
-
-          state = close_commit_buffer(state, buf_pid)
-          handle_commit_result(state, result, git_root, amend)
+          execute_commit(state, content, git_root, amend, buf_pid)
         end
     end
   end
@@ -214,6 +211,26 @@ defmodule MingaEditor.Commands.Git do
   end
 
   # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec execute_commit(state(), String.t(), String.t(), boolean(), pid()) :: state()
+  defp execute_commit(state, content, git_root, amend, buf_pid) do
+    message = strip_commit_comments(content)
+
+    if String.trim(message) == "" do
+      state = close_commit_buffer(state, buf_pid)
+      EditorState.set_status(state, "Aborting commit due to empty message")
+    else
+      result =
+        if amend do
+          Git.commit_amend(git_root, message)
+        else
+          Git.commit(git_root, message)
+        end
+
+      state = close_commit_buffer(state, buf_pid)
+      handle_commit_result(state, result, git_root, amend)
+    end
+  end
 
   # Mutual exclusivity: close file tree when opening git status.
   @spec close_file_tree_if_open(state()) :: state()
@@ -482,35 +499,14 @@ defmodule MingaEditor.Commands.Git do
     state =
       EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, restore_scope))
 
-    # Remove the commit buffer from the buffer list
-    buffers = state.workspace.buffers
-    buf_list = buffers.list
-    idx = Enum.find_index(buf_list, &(&1 == buf_pid))
-
-    # Stop the buffer process
     try do
       GenServer.stop(buf_pid, :normal)
     catch
       :exit, _ -> :ok
     end
 
-    case idx do
-      nil ->
-        state
-
-      i ->
-        new_list = List.delete_at(buf_list, i)
-        new_idx = min(max(i - 1, 0), max(length(new_list) - 1, 0))
-        new_active = Enum.at(new_list, new_idx)
-
-        put_in(state.workspace.buffers, %{
-          buffers
-          | list: new_list,
-            active_index: new_idx,
-            active: new_active
-        })
-        |> EditorState.sync_active_window_buffer()
-    end
+    {state, _effects} = EditorState.close_buffer_pure(state, buf_pid)
+    state
   end
 
   @spec handle_commit_result(

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -32,7 +32,9 @@ defmodule MingaEditor.Commands.Git do
     {:git_stage_hunk, "Stage hunk", true},
     {:git_revert_hunk, "Revert hunk", true},
     {:git_preview_hunk, "Preview hunk", true},
-    {:git_blame_line, "Blame line", true}
+    {:git_blame_toggle, "Toggle blame", true},
+    {:git_commit_execute, "Commit", false},
+    {:git_commit_abort, "Abort commit", false}
   ]
 
   @spec execute(state(), atom()) :: state()
@@ -153,19 +155,62 @@ defmodule MingaEditor.Commands.Git do
     end)
   end
 
-  # ── Blame line ─────────────────────────────────────────────────────────────
+  # ── Toggle blame annotations ───────────────────────────────────────────────
 
-  def execute(state, :git_blame_line) do
+  def execute(state, :git_blame_toggle) do
     with_git_buffer(state, fn git_pid, buf ->
-      {cursor_line, _col} = Buffer.cursor(buf)
-      git_root = Git.Buffer.git_root(git_pid)
-      rel_path = Git.Buffer.relative_path(git_pid)
+      Git.Buffer.toggle_blame(git_pid)
+      enabled = Git.Buffer.blame_enabled?(git_pid)
 
-      case Git.blame_line(git_root, rel_path, cursor_line) do
-        {:ok, blame_text} -> EditorState.set_status(state, blame_text)
-        :error -> EditorState.set_status(state, "Blame unavailable")
+      if enabled do
+        apply_blame_annotations(state, git_pid, buf)
+      else
+        Buffer.batch_decorations(buf, fn decs ->
+          Minga.Core.Decorations.remove_group(decs, :git_blame)
+        end)
+
+        EditorState.set_status(state, "Blame annotations disabled")
       end
     end)
+  end
+
+  # ── Commit message buffer ─────────────────────────────────────────────────
+
+  def execute(state, :git_commit_execute) do
+    case EditorState.git_commit_meta(state) do
+      nil ->
+        EditorState.set_status(state, "No commit in progress")
+
+      %{git_root: git_root, amend: amend, buffer_pid: buf_pid} ->
+        {content, _cursor} = Buffer.content_and_cursor(buf_pid)
+        message = strip_commit_comments(content)
+
+        if String.trim(message) == "" do
+          state = close_commit_buffer(state, buf_pid)
+          EditorState.set_status(state, "Aborting commit due to empty message")
+        else
+          result =
+            if amend do
+              Git.commit_amend(git_root, message)
+            else
+              Git.commit(git_root, message)
+            end
+
+          state = close_commit_buffer(state, buf_pid)
+          handle_commit_result(state, result, git_root, amend)
+        end
+    end
+  end
+
+  def execute(state, :git_commit_abort) do
+    case EditorState.git_commit_meta(state) do
+      nil ->
+        EditorState.set_status(state, "No commit in progress")
+
+      %{buffer_pid: buf_pid} ->
+        state = close_commit_buffer(state, buf_pid)
+        EditorState.set_status(state, "Commit aborted")
+    end
   end
 
   # ── Private ────────────────────────────────────────────────────────────────
@@ -410,6 +455,127 @@ defmodule MingaEditor.Commands.Git do
   defp get_base_lines(git_pid) do
     # Access the base_lines from the git buffer's state
     :sys.get_state(git_pid).base_lines
+  end
+
+  # ── Commit buffer helpers ─────────────────────────────────────────────────
+
+  @spec strip_commit_comments(String.t()) :: String.t()
+  defp strip_commit_comments(content) do
+    content
+    |> String.split("\n")
+    |> Enum.reject(&String.starts_with?(&1, "#"))
+    |> Enum.join("\n")
+    |> String.trim()
+  end
+
+  @spec close_commit_buffer(state(), pid()) :: state()
+  defp close_commit_buffer(state, buf_pid) do
+    # Restore scope: if git status panel is open, go back to git_status; otherwise editor
+    restore_scope =
+      if EditorState.git_status_panel(state) != nil,
+        do: :git_status,
+        else: :editor
+
+    state = EditorState.clear_git_commit(state)
+    state = EditorState.transition_mode(state, :normal)
+
+    state =
+      EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, restore_scope))
+
+    # Remove the commit buffer from the buffer list
+    buffers = state.workspace.buffers
+    buf_list = buffers.list
+    idx = Enum.find_index(buf_list, &(&1 == buf_pid))
+
+    # Stop the buffer process
+    try do
+      GenServer.stop(buf_pid, :normal)
+    catch
+      :exit, _ -> :ok
+    end
+
+    case idx do
+      nil ->
+        state
+
+      i ->
+        new_list = List.delete_at(buf_list, i)
+        new_idx = min(max(i - 1, 0), max(length(new_list) - 1, 0))
+        new_active = Enum.at(new_list, new_idx)
+
+        put_in(state.workspace.buffers, %{
+          buffers
+          | list: new_list,
+            active_index: new_idx,
+            active: new_active
+        })
+        |> EditorState.sync_active_window_buffer()
+    end
+  end
+
+  @spec handle_commit_result(
+          state(),
+          {:ok, String.t()} | {:error, String.t()},
+          String.t(),
+          boolean()
+        ) ::
+          state()
+  defp handle_commit_result(state, {:ok, short_hash}, git_root, amend) do
+    refresh_repo(git_root)
+    verb = if amend, do: "Amended", else: "Committed"
+    EditorState.set_status(state, "#{verb} [#{short_hash}]")
+  end
+
+  defp handle_commit_result(state, {:error, reason}, _git_root, _amend) do
+    MingaEditor.log_to_messages("Commit failed: #{reason}")
+    EditorState.set_status(state, "Commit failed: #{reason}")
+  end
+
+  # ── Blame annotation helpers ──────────────────────────────────────────────
+
+  @spec apply_blame_annotations(state(), pid(), pid()) :: state()
+  defp apply_blame_annotations(state, git_pid, buf) do
+    case Git.Buffer.blame_data(git_pid) do
+      nil ->
+        EditorState.set_status(state, "Blame data unavailable")
+
+      blame_data when map_size(blame_data) == 0 ->
+        EditorState.set_status(state, "Blame annotations enabled (no data)")
+
+      blame_data ->
+        alias Minga.Core.Decorations
+
+        Buffer.batch_decorations(buf, fn decs ->
+          decs = Decorations.remove_group(decs, :git_blame)
+
+          Enum.reduce(blame_data, decs, fn {line, info}, acc ->
+            text = format_blame_annotation(info)
+
+            {_id, acc} =
+              Decorations.add_annotation(acc, line, text,
+                kind: :inline_text,
+                fg: 0x6B7280,
+                group: :git_blame,
+                priority: -10
+              )
+
+            acc
+          end)
+        end)
+
+        EditorState.set_status(state, "Blame annotations enabled")
+    end
+  end
+
+  @spec format_blame_annotation(Minga.Git.blame_info()) :: String.t()
+  defp format_blame_annotation(%{author: author, date: date, summary: summary}) do
+    text = "#{author} (#{date}): #{summary}"
+
+    if String.length(text) > 60 do
+      String.slice(text, 0, 57) <> "..."
+    else
+      text
+    end
   end
 
   @impl Minga.Command.Provider

--- a/lib/minga_editor/input.ex
+++ b/lib/minga_editor/input.ex
@@ -26,6 +26,7 @@ defmodule MingaEditor.Input do
   alias MingaEditor.Input.Dashboard
   alias MingaEditor.Input.DiffReview
   alias MingaEditor.Input.FileTreeHandler
+  alias MingaEditor.Input.GitCommit
   alias MingaEditor.Input.GitStatus
   alias MingaEditor.Input.GlobalBindings
   alias MingaEditor.Input.Hover
@@ -122,6 +123,7 @@ defmodule MingaEditor.Input do
       DiffReview,
       AgentPanel,
       FileTreeHandler,
+      GitCommit,
       GitStatus,
       Popup,
       MingaEditor.Input.CUA.TUISpaceLeader,

--- a/lib/minga_editor/input/git_commit.ex
+++ b/lib/minga_editor/input/git_commit.ex
@@ -1,0 +1,103 @@
+defmodule MingaEditor.Input.GitCommit do
+  @moduledoc """
+  Input handler for the git commit message buffer.
+
+  When the git commit scope is active (`:git_commit`), this handler
+  intercepts keys and routes them through the git commit keymap scope.
+  C-c C-c commits, C-c C-k aborts, q (normal mode) aborts.
+  Unmatched keys pass through to the Mode FSM for normal text editing.
+
+  Multi-key prefix sequences (C-c followed by C-c or C-k) are tracked
+  via `shell_state.git_commit_prefix`.
+  """
+
+  @behaviour MingaEditor.Input.Handler
+
+  @type state :: MingaEditor.Input.Handler.handler_state()
+
+  alias MingaEditor.Commands
+  alias MingaEditor.State, as: EditorState
+  alias Minga.Keymap
+  alias Minga.Keymap.Bindings
+
+  @impl true
+  @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
+          MingaEditor.Input.Handler.result()
+  def handle_key(%{workspace: %{keymap_scope: :git_commit}} = state, cp, mods) do
+    key = {cp, mods}
+
+    # Check for pending prefix continuation
+    case EditorState.git_commit_prefix(state) do
+      nil ->
+        resolve_fresh(state, key)
+
+      prefix_node when is_map(prefix_node) ->
+        state = EditorState.set_git_commit_prefix(state, nil)
+        resolve_prefix_continuation(state, prefix_node, key)
+    end
+  end
+
+  def handle_key(state, _cp, _mods), do: {:passthrough, state}
+
+  @impl true
+  def handle_mouse(state, _row, _col, _button, _mods, _event_type, _click_count) do
+    {:passthrough, state}
+  end
+
+  # ── Fresh key resolution ──────────────────────────────────────────────
+
+  @spec resolve_fresh(state(), {non_neg_integer(), non_neg_integer()}) ::
+          MingaEditor.Input.Handler.result()
+  defp resolve_fresh(state, key) do
+    binding_state = Minga.Editing.binding_state(state)
+
+    case Keymap.resolve_scoped_key(
+           :git_commit,
+           binding_state,
+           key,
+           EditorState.keymap_context(state)
+         ) do
+      {:command, cmd} ->
+        {:handled, dispatch_command(state, cmd)}
+
+      {:prefix, node} ->
+        {:handled, EditorState.set_git_commit_prefix(state, node)}
+
+      :not_found ->
+        {:passthrough, state}
+    end
+  end
+
+  # ── Prefix continuation ────────────────────────────────────────────────
+
+  @spec resolve_prefix_continuation(
+          state(),
+          Bindings.node_t(),
+          {non_neg_integer(), non_neg_integer()}
+        ) ::
+          MingaEditor.Input.Handler.result()
+  defp resolve_prefix_continuation(state, prefix_node, key) do
+    case Bindings.lookup(prefix_node, key) do
+      {:command, cmd} ->
+        {:handled, dispatch_command(state, cmd)}
+
+      {:prefix, sub_node} ->
+        {:handled, EditorState.set_git_commit_prefix(state, sub_node)}
+
+      :not_found ->
+        # Invalid prefix continuation; re-process as fresh key
+        resolve_fresh(state, key)
+    end
+  end
+
+  # ── Command dispatch ───────────────────────────────────────────────────
+
+  @spec dispatch_command(state(), atom()) :: state()
+  defp dispatch_command(state, :git_commit_to_normal) do
+    EditorState.transition_mode(state, :normal)
+  end
+
+  defp dispatch_command(state, cmd) do
+    Commands.Git.execute(state, cmd)
+  end
+end

--- a/lib/minga_editor/input/git_status.ex
+++ b/lib/minga_editor/input/git_status.ex
@@ -548,7 +548,7 @@ defmodule MingaEditor.Input.GitStatus do
 
   @spec open_commit_buffer(EditorState.t(), String.t(), boolean()) :: EditorState.t()
   defp open_commit_buffer(state, git_root, amend) do
-    initial_content = commit_buffer_content(git_root, amend)
+    {initial_content, warning} = commit_buffer_content(git_root, amend)
 
     case Buffer.start_link(
            content: initial_content,
@@ -568,20 +568,21 @@ defmodule MingaEditor.Input.GitStatus do
             &WorkspaceState.set_keymap_scope(&1, :git_commit)
           )
 
-        EditorState.transition_mode(state, :insert)
+        state = EditorState.transition_mode(state, :insert)
+        if warning, do: EditorState.set_status(state, warning), else: state
 
       {:error, reason} ->
         EditorState.set_status(state, "Failed to open commit buffer: #{inspect(reason)}")
     end
   end
 
-  @spec commit_buffer_content(String.t(), boolean()) :: String.t()
+  @spec commit_buffer_content(String.t(), boolean()) :: {String.t(), String.t() | nil}
   defp commit_buffer_content(git_root, true) do
     case Git.log(git_root, count: 1) do
-      {:ok, [%{message: msg} | _]} -> msg
-      _ -> ""
+      {:ok, [%{message: msg} | _]} -> {msg, nil}
+      _ -> {"", "Could not load previous commit message for amend"}
     end
   end
 
-  defp commit_buffer_content(_git_root, false), do: ""
+  defp commit_buffer_content(_git_root, false), do: {"", nil}
 end

--- a/lib/minga_editor/input/git_status.ex
+++ b/lib/minga_editor/input/git_status.ex
@@ -235,15 +235,18 @@ defmodule MingaEditor.Input.GitStatus do
         EditorState.set_status(state, "Not in a git repository")
 
       git_root ->
-        update_tui_state(state, &put_amend_mode(&1, git_root))
+        open_commit_buffer(state, git_root, true)
     end
   end
 
   defp execute_command(state, :git_status_start_commit) do
-    EditorState.set_status(
-      state,
-      "Commit message input (use :git-commit <message> in command mode)"
-    )
+    case resolve_git_root() do
+      nil ->
+        EditorState.set_status(state, "Not in a git repository")
+
+      git_root ->
+        open_commit_buffer(state, git_root, false)
+    end
   end
 
   defp execute_command(state, :git_status_close) do
@@ -336,11 +339,6 @@ defmodule MingaEditor.Input.GitStatus do
   @spec clear_discard_confirmation(TuiState.t()) :: TuiState.t()
   defp clear_discard_confirmation(tui) do
     %{tui | discard_confirmation: nil}
-  end
-
-  @spec put_amend_mode(TuiState.t(), String.t()) :: TuiState.t()
-  defp put_amend_mode(tui, _git_root) do
-    %{tui | amend_mode: not tui.amend_mode}
   end
 
   @spec do_git_remote_op(
@@ -545,4 +543,45 @@ defmodule MingaEditor.Input.GitStatus do
       nil -> 0
     end
   end
+
+  # ── Commit buffer helpers ─────────────────────────────────────────────────
+
+  @spec open_commit_buffer(EditorState.t(), String.t(), boolean()) :: EditorState.t()
+  defp open_commit_buffer(state, git_root, amend) do
+    initial_content = commit_buffer_content(git_root, amend)
+
+    case Buffer.start_link(
+           content: initial_content,
+           buffer_type: :nofile,
+           read_only: false,
+           buffer_name: "COMMIT_EDITMSG"
+         ) do
+      {:ok, buf_pid} ->
+        state = Commands.add_buffer(state, buf_pid)
+
+        meta = %{git_root: git_root, amend: amend, buffer_pid: buf_pid}
+        state = EditorState.set_git_commit_meta(state, meta)
+
+        state =
+          EditorState.update_workspace(
+            state,
+            &WorkspaceState.set_keymap_scope(&1, :git_commit)
+          )
+
+        EditorState.transition_mode(state, :insert)
+
+      {:error, reason} ->
+        EditorState.set_status(state, "Failed to open commit buffer: #{inspect(reason)}")
+    end
+  end
+
+  @spec commit_buffer_content(String.t(), boolean()) :: String.t()
+  defp commit_buffer_content(git_root, true) do
+    case Git.log(git_root, count: 1) do
+      {:ok, [%{message: msg} | _]} -> msg
+      _ -> ""
+    end
+  end
+
+  defp commit_buffer_content(_git_root, false), do: ""
 end

--- a/lib/minga_editor/shell/traditional/state.ex
+++ b/lib/minga_editor/shell/traditional/state.ex
@@ -22,6 +22,9 @@ defmodule MingaEditor.Shell.Traditional.State do
   alias MingaEditor.State.WhichKey
   alias Minga.Tool.Manager, as: ToolManager
 
+  @typedoc "Metadata for an active git commit message buffer."
+  @type commit_meta :: %{git_root: String.t(), amend: boolean(), buffer_pid: pid()} | nil
+
   @type t :: %__MODULE__{
           nav_flash: NavFlash.t() | nil,
           yank_flash: YankFlash.t() | nil,
@@ -41,7 +44,9 @@ defmodule MingaEditor.Shell.Traditional.State do
           tool_prompt_queue: [atom()],
           suppress_tool_prompts: boolean(),
           space_leader_pending: boolean(),
-          space_leader_timer: reference() | nil
+          space_leader_timer: reference() | nil,
+          git_commit_meta: commit_meta(),
+          git_commit_prefix: Minga.Keymap.Bindings.node_t() | nil
         }
 
   defstruct nav_flash: nil,
@@ -62,7 +67,9 @@ defmodule MingaEditor.Shell.Traditional.State do
             tool_prompt_queue: [],
             suppress_tool_prompts: false,
             space_leader_pending: false,
-            space_leader_timer: nil
+            space_leader_timer: nil,
+            git_commit_meta: nil,
+            git_commit_prefix: nil
 
   # ── Status message ─────────────────────────────────────────────────────────
 
@@ -220,6 +227,34 @@ defmodule MingaEditor.Shell.Traditional.State do
   @spec set_modal(t(), ModalOverlay.t()) :: t()
   def set_modal(%{} = ss, modal) do
     %{ss | modal: modal}
+  end
+
+  # ── Git commit message buffer ──────────────────────────────────────────────
+
+  @doc "Returns the git commit metadata, or nil if no commit buffer is active."
+  @spec git_commit_meta(t()) :: commit_meta()
+  def git_commit_meta(%{git_commit_meta: meta}), do: meta
+
+  @doc "Sets the git commit metadata for an active commit buffer."
+  @spec set_git_commit_meta(t(), commit_meta()) :: t()
+  def set_git_commit_meta(%{} = ss, meta) do
+    %{ss | git_commit_meta: meta}
+  end
+
+  @doc "Clears the git commit metadata and prefix state."
+  @spec clear_git_commit(t()) :: t()
+  def clear_git_commit(%{} = ss) do
+    %{ss | git_commit_meta: nil, git_commit_prefix: nil}
+  end
+
+  @doc "Returns the pending prefix node for git commit key sequences, or nil."
+  @spec git_commit_prefix(t()) :: Minga.Keymap.Bindings.node_t() | nil
+  def git_commit_prefix(%{git_commit_prefix: prefix}), do: prefix
+
+  @doc "Sets the pending prefix node for git commit key sequences."
+  @spec set_git_commit_prefix(t(), Minga.Keymap.Bindings.node_t() | nil) :: t()
+  def set_git_commit_prefix(%{} = ss, prefix) do
+    %{ss | git_commit_prefix: prefix}
   end
 
   # ── Tool prompt helpers ────────────────────────────────────────────────────

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -373,6 +373,20 @@ defmodule MingaEditor.State do
   @spec close_git_status_panel(t()) :: t()
   def close_git_status_panel(s), do: update_shell_state(s, &ShellState.close_git_status_panel/1)
 
+  @spec git_commit_meta(t()) :: ShellState.commit_meta()
+  def git_commit_meta(%{shell_state: ss}), do: ShellState.git_commit_meta(ss)
+  @spec set_git_commit_meta(t(), ShellState.commit_meta()) :: t()
+  def set_git_commit_meta(s, meta),
+    do: update_shell_state(s, &ShellState.set_git_commit_meta(&1, meta))
+
+  @spec clear_git_commit(t()) :: t()
+  def clear_git_commit(s), do: update_shell_state(s, &ShellState.clear_git_commit/1)
+  @spec git_commit_prefix(t()) :: Minga.Keymap.Bindings.node_t() | nil
+  def git_commit_prefix(%{shell_state: ss}), do: ShellState.git_commit_prefix(ss)
+  @spec set_git_commit_prefix(t(), Minga.Keymap.Bindings.node_t() | nil) :: t()
+  def set_git_commit_prefix(s, prefix),
+    do: update_shell_state(s, &ShellState.set_git_commit_prefix(&1, prefix))
+
   @spec tab_bar(t()) :: TabBar.t() | nil
   def tab_bar(%{shell_state: ss}), do: ShellState.tab_bar(ss)
   @spec set_tab_bar(t(), TabBar.t() | nil) :: t()

--- a/test/minga/command/registry_test.exs
+++ b/test/minga/command/registry_test.exs
@@ -95,7 +95,9 @@ defmodule Minga.Command.RegistryTest do
           :git_stage_hunk,
           :git_revert_hunk,
           :git_preview_hunk,
-          :git_blame_line,
+          :git_blame_toggle,
+          :git_commit_execute,
+          :git_commit_abort,
 
           # Folding
           :fold_toggle,

--- a/test/minga/keymap/scope_test.exs
+++ b/test/minga/keymap/scope_test.exs
@@ -29,7 +29,8 @@ defmodule Minga.Keymap.ScopeTest do
       assert :agent in scopes
       assert :file_tree in scopes
       assert :git_status in scopes
-      assert length(scopes) == 4
+      assert :git_commit in scopes
+      assert length(scopes) == 5
     end
   end
 

--- a/test/support/git_stub.ex
+++ b/test/support/git_stub.ex
@@ -117,6 +117,16 @@ defmodule Minga.Git.Stub do
   def blame_line(_git_root, _relative_path, _line_number), do: :error
 
   @impl true
+  @spec blame_file(String.t(), String.t()) ::
+          {:ok, %{non_neg_integer() => Minga.Git.Backend.blame_info()}} | :error
+  def blame_file(git_root, relative_path) do
+    case :ets.lookup(@table, {:blame_file, Path.expand(git_root), relative_path}) do
+      [{_, data}] -> {:ok, data}
+      [] -> {:ok, %{}}
+    end
+  end
+
+  @impl true
   @spec status(String.t()) :: {:ok, [Minga.Git.status_entry()]}
   def status(git_root) do
     case :ets.lookup(@table, {:status, Path.expand(git_root)}) do
@@ -150,6 +160,10 @@ defmodule Minga.Git.Stub do
   @impl true
   @spec commit(String.t(), String.t()) :: {:ok, String.t()}
   def commit(_git_root, _message), do: {:ok, "stub000"}
+
+  @impl true
+  @spec commit_amend(String.t(), String.t()) :: {:ok, String.t()}
+  def commit_amend(_git_root, _message), do: {:ok, "stub001"}
 
   @impl true
   @spec stage_patch(String.t(), String.t()) :: :ok


### PR DESCRIPTION
## Summary

Completes the two remaining gaps in git integration (closes #23):

- **Commit message buffer (Magit-style):** `cc`/`ca` in the git status panel now opens a writable `COMMIT_EDITMSG` buffer in insert mode. `C-c C-c` commits (strips comment lines, shows hash), `C-c C-k` aborts. Amend mode pre-populates with last commit message and uses `--amend`.
- **Inline blame annotations:** `SPC g b` toggles per-line blame annotations (author, date, summary) right-aligned in dimmed text via the existing `LineAnnotation` system. Blame is fetched once per file via `git blame --porcelain`, cached per-buffer, and invalidated on save.

### Files changed (16 files, +734 / -29)

**New modules:**
- `lib/minga/keymap/scope/git_commit.ex` — keymap scope with `C-c C-c` / `C-c C-k` / `q` bindings in insert and normal mode
- `lib/minga_editor/input/git_commit.ex` — input handler with multi-key prefix tracking for C-c chord sequences

**Extended:**
- `lib/minga/git.ex`, `git/backend.ex`, `git/system.ex` — `commit_amend/2` and `blame_file/2` with full porcelain parser
- `lib/minga/git/buffer.ex` — blame state (`blame_enabled`, `blame_cache`), toggle/query API, cache invalidation on save
- `lib/minga_editor/commands/git.ex` — `:git_commit_execute`, `:git_commit_abort`, `:git_blame_toggle` commands
- `lib/minga_editor/input/git_status.ex` — rewired `cc`/`ca` to open commit buffer
- `lib/minga_editor/shell/traditional/state.ex` — `git_commit_meta` and `git_commit_prefix` fields
- `lib/minga_editor/state.ex` — thin wrappers for commit state access
- `lib/minga/keymap/scope.ex` — registered `:git_commit` scope
- `lib/minga/keymap/defaults.ex` — `SPC g b` → `:git_blame_toggle`
- `lib/minga_editor/input.ex` — added GitCommit to surface handler stack

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test.llm` — 8033 tests, 0 failures
- [x] `mix format --check-formatted` — clean
- [x] `mix credo --strict` — clean (only pre-existing struct-size warnings)
- [x] `mix dialyzer` — clean
- [ ] Manual: `SPC g g` → `cc` opens commit buffer in insert mode, type message, `C-c C-c` commits
- [ ] Manual: `SPC g g` → `ca` opens commit buffer pre-populated with last commit message
- [ ] Manual: `C-c C-k` aborts commit, returns to git status panel
- [ ] Manual: `SPC g b` toggles inline blame on/off, annotations appear dimmed at end of line
- [ ] Manual: Save file while blame is on, toggle off/on to verify cache invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)