### PR TITLE
feat(command): add built-in interactive tutorial (:Tutor)

### DIFF
--- a/lib/minga/command/parser.ex
+++ b/lib/minga/command/parser.ex
@@ -92,6 +92,7 @@ defmodule Minga.Command.Parser do
           | {:describe_command_named, [String.t()]}
           | {:describe_option, []}
           | {:describe_option_named, [String.t()]}
+          | {:tutor, []}
           | {:agent_abort, []}
           | {:agent_new_session, []}
           | {:agent_set_model, [String.t()]}
@@ -279,6 +280,8 @@ defmodule Minga.Command.Parser do
   defp do_parse("sp"), do: {:split_horizontal, []}
   defp do_parse("close"), do: {:window_close, []}
   defp do_parse("rename " <> name), do: {:rename, String.trim(name)}
+  defp do_parse("Tutor"), do: {:tutor, []}
+  defp do_parse("tutor"), do: {:tutor, []}
   defp do_parse("buffers"), do: {:buffers, []}
   defp do_parse("ls"), do: {:buffers, []}
   defp do_parse("bnext"), do: {:buffer_next, []}

--- a/lib/minga/command/registry.ex
+++ b/lib/minga/command/registry.ex
@@ -57,6 +57,7 @@ defmodule Minga.Command.Registry do
     MingaEditor.Commands.Macros,
     MingaEditor.Commands.Formatting,
     MingaEditor.Commands.Help,
+    MingaEditor.Commands.Tutor,
     MingaEditor.Commands.UI,
     MingaEditor.Commands.Tool,
     MingaEditor.Commands.AgentGroup

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -82,6 +82,7 @@ defmodule Minga.Keymap.Defaults do
     {[{?h, @none}, {?e, @none}, {?l, @none}], :extension_list, "List extensions"},
     {[{?h, @none}, {?e, @none}, {?u, @none}], :extension_update_all, "Update all extensions"},
     {[{?h, @none}, {?e, @none}, {?U, @none}], :extension_update, "Update extension"},
+    {[{?h, @none}, {?T, @none}], :tutor, "Interactive tutorial"},
 
     # ── Code ────────────────────────────────────────────────────────────────────
     {[{?c, @none}, {?a, @none}], :code_action, "Code actions"},

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -33,6 +33,7 @@ defmodule MingaEditor.Commands do
   alias MingaEditor.Commands.Extensions, as: ExtCommands
   alias MingaEditor.Commands.Help
   alias MingaEditor.Commands.Lsp, as: LspCommands
+  alias MingaEditor.Commands.Tutor
   alias MingaEditor.Commands.Marks
   alias MingaEditor.Commands.Movement
   alias MingaEditor.Commands.Operators
@@ -511,6 +512,10 @@ defmodule MingaEditor.Commands do
 
   def execute(state, {:execute_ex_command, {:describe_command_named, [name]}}) do
     Help.execute(state, {:describe_command_named, name})
+  end
+
+  def execute(state, {:execute_ex_command, {:tutor, []}}) do
+    Tutor.execute(state, :tutor)
   end
 
   def execute(state, {:execute_ex_command, {:describe_option, []}}) do

--- a/lib/minga_editor/commands/tutor.ex
+++ b/lib/minga_editor/commands/tutor.ex
@@ -37,7 +37,11 @@ defmodule MingaEditor.Commands.Tutor do
       nil ->
         {:ok, pid} = start_tutor_buffer(content)
         state = Commands.add_buffer(state, pid)
-        EditorState.set_status(state, "Welcome to the Minga Tutorial! Follow the instructions to learn.")
+
+        EditorState.set_status(
+          state,
+          "Welcome to the Minga Tutorial! Follow the instructions to learn."
+        )
 
       pid ->
         replace_content(pid, content)

--- a/lib/minga_editor/commands/tutor.ex
+++ b/lib/minga_editor/commands/tutor.ex
@@ -1,0 +1,100 @@
+defmodule MingaEditor.Commands.Tutor do
+  @moduledoc """
+  Interactive tutorial command. Opens a writable scratch buffer with vimtutor-style
+  lessons that the user edits directly to practice motions and operators.
+  """
+
+  @behaviour Minga.Command.Provider
+
+  alias Minga.Buffer
+  alias Minga.Buffer.Document
+  alias Minga.Command
+  alias MingaEditor.Commands
+  alias MingaEditor.State, as: EditorState
+
+  @type state :: EditorState.t()
+
+  @tutor_buffer_name "*Tutor*"
+
+  @impl Minga.Command.Provider
+  @spec __commands__() :: [Command.t()]
+  def __commands__ do
+    [
+      %Command{
+        name: :tutor,
+        description: "Interactive Minga tutorial",
+        requires_buffer: false,
+        execute: fn state -> execute(state, :tutor) end
+      }
+    ]
+  end
+
+  @spec execute(state(), :tutor) :: state()
+  def execute(state, :tutor) do
+    content = load_tutorial_content()
+
+    case find_tutor_buffer(state) do
+      nil ->
+        {:ok, pid} = start_tutor_buffer(content)
+        state = Commands.add_buffer(state, pid)
+        EditorState.set_status(state, "Welcome to the Minga Tutorial! Follow the instructions to learn.")
+
+      pid ->
+        replace_content(pid, content)
+        switch_to_buffer(state, pid)
+    end
+  end
+
+  @spec load_tutorial_content() :: String.t()
+  defp load_tutorial_content do
+    :minga
+    |> Application.app_dir("priv/tutor.txt")
+    |> File.read!()
+  end
+
+  @spec start_tutor_buffer(String.t()) :: {:ok, pid()} | {:error, term()}
+  defp start_tutor_buffer(content) do
+    DynamicSupervisor.start_child(
+      Minga.Buffer.Supervisor,
+      {Minga.Buffer,
+       content: content,
+       buffer_name: @tutor_buffer_name,
+       buffer_type: :nofile,
+       read_only: false,
+       filetype: :text}
+    )
+  end
+
+  @spec find_tutor_buffer(state()) :: pid() | nil
+  defp find_tutor_buffer(state) do
+    Enum.find(state.workspace.buffers.list, fn pid ->
+      Buffer.buffer_name(pid) == @tutor_buffer_name
+    end)
+  catch
+    :exit, _ -> nil
+  end
+
+  @spec replace_content(pid(), String.t()) :: :ok
+  defp replace_content(pid, content) do
+    :sys.replace_state(pid, fn s ->
+      %{s | document: Document.new(content)}
+    end)
+
+    Buffer.move_to(pid, {0, 0})
+  end
+
+  @spec switch_to_buffer(state(), pid()) :: state()
+  defp switch_to_buffer(state, buffer) do
+    idx = Enum.find_index(state.workspace.buffers.list, &(&1 == buffer))
+
+    state =
+      if idx do
+        put_in(state.workspace.buffers.active_index, idx)
+        |> then(fn s -> put_in(s.workspace.buffers.active, buffer) end)
+      else
+        Commands.add_buffer(state, buffer)
+      end
+
+    EditorState.set_status(state, "Tutorial reset. Follow the instructions to learn!")
+  end
+end

--- a/priv/tutor.txt
+++ b/priv/tutor.txt
@@ -1,0 +1,289 @@
+===============================================================================
+=    W e l c o m e   t o   t h e   M i n g a   T u t o r                     =
+===============================================================================
+
+Minga is a modal text editor. This tutorial teaches you the basics by
+having you edit this text directly. Each lesson explains a concept, then
+gives you practice lines to try it on. Take your time; there is no rush.
+
+TIP: If you mess up a practice line, type  u  to undo your last change.
+     You can rerun  :Tutor  at any time to get a fresh copy.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 1: MOVING THE CURSOR
+
+In Normal mode (the mode you start in), these keys move the cursor:
+
+      h   move left
+      j   move down
+      k   move up
+      l   move right
+
+Practice: move the cursor to the X on each line below, then press  x  to
+delete it.
+
+  The coXw jumped over the moon.
+  ThXe quick brown fox.
+  Hello worXld!
+
+TIP: If you get stuck, press  Esc  to return to Normal mode.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 2: ENTERING INSERT MODE
+
+To type new text, you need to enter Insert mode. There are several ways:
+
+      i   insert before the cursor
+      a   insert after the cursor
+      o   open a new line below and insert
+      O   open a new line above and insert
+
+Press  Esc  to return to Normal mode when you are done typing.
+
+Practice 1: position your cursor on the [ ] below and press  i  to insert
+the missing word, then press  Esc  when done.
+
+  The quick brown fox [ ] over the lazy dog.
+  Minga is a [ ] text editor.
+
+Practice 2: move to the end of each line and press  a  to append text.
+
+  This sentence is not
+  Learning Minga is
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 3: DELETING TEXT
+
+In Normal mode you can delete text without entering Insert mode:
+
+      x    delete the character under the cursor
+      dd   delete the entire line
+      dw   delete from the cursor to the start of the next word
+      d$   delete from the cursor to the end of the line
+      D    same as d$ (shorthand)
+
+Practice 1: delete the EXTRA words using  dw .
+
+  The quick EXTRA brown fox jumped over the EXTRA lazy dog.
+  Minga EXTRA uses the EXTRA BEAM for all state.
+
+Practice 2: delete these entire lines using  dd .
+
+  DELETE THIS LINE.
+  THIS LINE SHOULD ALSO GO.
+  REMOVE ME TOO.
+
+Practice 3: place your cursor on the | and use  d$  to delete to end of line.
+
+  This part stays. | but this part should go away.
+  Keep this. | remove everything after here.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 4: UNDO AND REDO
+
+Made a mistake? No problem:
+
+      u       undo the last change
+      Ctrl-r  redo (undo the undo)
+
+Practice: delete some words on the line below using  dw , then press  u
+repeatedly to bring them back. Try  Ctrl-r  to redo your deletions.
+
+  The quick brown fox jumped over the lazy dog near the river bank.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 5: MOTIONS AND COUNTS
+
+You can combine a count with a motion to move faster:
+
+      2w   move forward 2 words
+      3j   move down 3 lines
+      5l   move right 5 characters
+      0    move to the start of the line
+      $    move to the end of the line
+      gg   move to the first line of the file
+      G    move to the last line of the file
+
+Counts also work with operators:
+
+      3dd  delete 3 lines
+      2dw  delete 2 words
+      d2w  also delete 2 words (count can go on either side)
+
+Practice: use  3dd  to delete exactly 3 lines below.
+
+  DELETE LINE ONE
+  DELETE LINE TWO
+  DELETE LINE THREE
+  This line should remain.
+
+Practice: use  2dw  to delete the first 2 words of this line.
+
+  REMOVE THESE but keep the rest of this sentence intact.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 6: VISUAL MODE
+
+Visual mode lets you select text before acting on it:
+
+      v    character-wise visual mode (select individual characters)
+      V    line-wise visual mode (select whole lines)
+
+Once you have a selection, you can:
+
+      d    delete the selection
+      y    yank (copy) the selection
+      c    change the selection (delete and enter Insert mode)
+
+Practice 1: press  V  to select the two lines marked DELETE, then press  d .
+
+  Keep this line.
+  DELETE THIS LINE
+  DELETE THIS LINE TOO
+  Keep this line as well.
+
+Practice 2: use  v  to select the word REPLACE below, then press  c  to
+change it to something else. Press  Esc  when done.
+
+  The REPLACE sat on the mat.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 7: YANK, PUT, AND REGISTERS
+
+Yank (copy) and put (paste) work with any motion or visual selection:
+
+      yy   yank the entire current line
+      yw   yank from cursor to start of next word
+      p    put (paste) after the cursor
+      P    put (paste) before the cursor
+
+Practice: yank the KEEP line with  yy , move to the blank line, press  p .
+
+  KEEP THIS LINE (yank me with yy)
+
+  (move here and press p to paste)
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 8: SEARCH
+
+Search jumps the cursor to matching text:
+
+      /pattern   search forward for "pattern"
+      ?pattern   search backward for "pattern"
+      n          jump to the next match
+      N          jump to the previous match
+      *          search forward for the word under the cursor
+
+Practice: type  /needle  and press Enter to find the hidden word.
+
+  You are looking for a very specific word hidden in this haystack
+  of text. Keep searching through these lines until you find the
+  needle somewhere in these practice sentences. Once found, press
+  n  to cycle through the remaining matches. There is one more
+  needle hiding further down.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 9: THE LEADER KEY
+
+Minga uses  SPC  (spacebar) as the leader key. Pressing it in Normal mode
+opens the which-key popup, showing all available command groups.
+
+Try it now: press  SPC  and wait for the popup to appear. You will see
+groups like:
+
+      f   +file         (file operations)
+      b   +buffer        (buffer switching)
+      s   +search        (search commands)
+      c   +code          (LSP actions)
+      h   +help          (help and options)
+      a   +agent         (AI agent)
+      g   +git           (git operations)
+
+Press  Esc  or  q  to close the popup without choosing anything.
+
+Practice: press  SPC  to open which-key, look at the groups, then press
+Esc  to close it. Do this a few times to get comfortable with the popup.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 10: FILE AND BUFFER NAVIGATION
+
+Minga's most-used leader commands for navigating files and buffers:
+
+      SPC f f   find file (fuzzy finder for files in the project)
+      SPC f r   recent files
+      SPC f p   open your config file
+      SPC b b   switch between open buffers
+      SPC b d   close the current buffer
+
+Practice: press  SPC b b  to see the buffer list. You should see *Tutor*
+listed. Press  Esc  to cancel and stay in the tutorial.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 11: THE AGENT PANEL
+
+Minga has a built-in AI agent you can chat with for help:
+
+      SPC a a   toggle the agent panel
+      SPC a n   start a new agent session
+      SPC a m   pick a model
+
+Practice: press  SPC a a  to open the agent panel, look around, then
+press  SPC a a  again to close it and return to the tutorial.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 12: EX COMMANDS
+
+You have been using  :Tutor  to open this tutorial. The  :  key opens the
+command line at the bottom of the screen, where you can type commands:
+
+      :w         save the current file
+      :q         quit (close the current buffer)
+      :wq        save and quit
+      :e path    open a file at the given path
+      :buffers   list open buffers
+
+Since this tutorial buffer is not backed by a file,  :w  will not do
+anything harmful. Try it if you like.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        Lesson 13: PUTTING IT ALL TOGETHER
+
+Here is a final exercise combining what you have learned.
+
+  1. Delete the line that says "REMOVE ME" using  dd
+  2. Change the word BROKEN to "fixed" using  cw
+  3. Yank the line that says "COPY ME" with  yy
+  4. Paste it below the blank line with  p
+  5. Search for "congratulations" with  /congratulations
+
+  REMOVE ME
+  The status is BROKEN and needs attention.
+  COPY ME
+
+  (paste above this line)
+
+  If you made it this far, congratulations! You know enough to be
+  productive in Minga.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SUMMARY
+
+  h/j/k/l .......... move cursor          v/V ........ visual select
+  i/a/o/O .......... enter Insert mode     y/p ........ yank and put
+  Esc .............. back to Normal mode   / .......... search forward
+  x ................ delete character      n/N ........ next/prev match
+  dd ............... delete line           u/Ctrl-r ... undo/redo
+  dw ............... delete word           SPC ........ leader key
+  d$/D ............. delete to end         :command ... ex command
+
+  SPC f f .. find file       SPC a a .. agent panel
+  SPC b b .. buffers         SPC h T .. reopen this tutorial
+  SPC f p .. config file     :Tutor ... reopen this tutorial
+
+  To learn more, press  SPC h b  to see all keybindings, or
+  press  SPC h v  to browse options.
+
+  Happy editing!
+
+===============================================================================

--- a/test/minga_editor/commands/tutor_test.exs
+++ b/test/minga_editor/commands/tutor_test.exs
@@ -83,6 +83,22 @@ defmodule MingaEditor.Commands.TutorTest do
       assert BufferServer.content(tutor_buf) =~ "M i n g a   T u t o r"
     end
 
+    test "creates a new buffer when the previous tutor buffer process died" do
+      state = build_state()
+      result = Tutor.execute(state, :tutor)
+      old_tutor = result.workspace.buffers.active
+
+      GenServer.stop(old_tutor)
+      refute Process.alive?(old_tutor)
+
+      result2 = Tutor.execute(result, :tutor)
+      new_tutor = result2.workspace.buffers.active
+
+      assert Process.alive?(new_tutor)
+      assert new_tutor != old_tutor
+      assert BufferServer.buffer_name(new_tutor) == "*Tutor*"
+    end
+
     test "sets a status message" do
       state = build_state()
       result = Tutor.execute(state, :tutor)

--- a/test/minga_editor/commands/tutor_test.exs
+++ b/test/minga_editor/commands/tutor_test.exs
@@ -1,0 +1,114 @@
+defmodule MingaEditor.Commands.TutorTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Command.Parser
+  alias Minga.Keymap.Active, as: ActiveKeymap
+  alias MingaEditor.Commands.Tutor
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.Viewport
+
+  defp build_state do
+    {:ok, buf} =
+      DynamicSupervisor.start_child(
+        Minga.Buffer.Supervisor,
+        {BufferServer, content: "hello", buffer_name: "test.txt"}
+      )
+
+    {:ok, keymap} = ActiveKeymap.start_link(name: nil)
+    {:ok, options} = Minga.Config.Options.start_link(name: nil)
+
+    %EditorState{
+      port_manager: nil,
+      keymap_server: keymap,
+      options_server: options,
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        buffers: %Buffers{active: buf, list: [buf]}
+      }
+    }
+  end
+
+  describe "execute/2" do
+    test "creates a *Tutor* buffer with tutorial content" do
+      state = build_state()
+      result = Tutor.execute(state, :tutor)
+
+      tutor_buf = result.workspace.buffers.active
+      assert BufferServer.buffer_name(tutor_buf) == "*Tutor*"
+
+      content = BufferServer.content(tutor_buf)
+      assert content =~ "M i n g a   T u t o r"
+      assert content =~ "Lesson 1"
+      assert content =~ "MOVING THE CURSOR"
+    end
+
+    test "tutor buffer is writable" do
+      state = build_state()
+      result = Tutor.execute(state, :tutor)
+
+      tutor_buf = result.workspace.buffers.active
+      refute BufferServer.read_only?(tutor_buf)
+    end
+
+    test "tutor buffer uses :nofile type" do
+      state = build_state()
+      result = Tutor.execute(state, :tutor)
+
+      tutor_buf = result.workspace.buffers.active
+      assert BufferServer.buffer_type(tutor_buf) == :nofile
+    end
+
+    test "tutor buffer is added to buffer list" do
+      state = build_state()
+      result = Tutor.execute(state, :tutor)
+
+      tutor_buf = result.workspace.buffers.active
+      assert tutor_buf in result.workspace.buffers.list
+    end
+
+    test "re-running :Tutor resets content to a fresh copy" do
+      state = build_state()
+      result = Tutor.execute(state, :tutor)
+      tutor_buf = result.workspace.buffers.active
+
+      BufferServer.insert_text(tutor_buf, "MODIFIED ")
+      assert BufferServer.content(tutor_buf) =~ "MODIFIED"
+
+      result2 = Tutor.execute(result, :tutor)
+      assert result2.workspace.buffers.active == tutor_buf
+      refute BufferServer.content(tutor_buf) =~ "MODIFIED"
+      assert BufferServer.content(tutor_buf) =~ "M i n g a   T u t o r"
+    end
+
+    test "sets a status message" do
+      state = build_state()
+      result = Tutor.execute(state, :tutor)
+
+      assert result.shell_state.status_msg =~ "Tutorial"
+    end
+
+    test "includes Minga-specific lessons" do
+      state = build_state()
+      result = Tutor.execute(state, :tutor)
+
+      content = BufferServer.content(result.workspace.buffers.active)
+      assert content =~ "LEADER KEY"
+      assert content =~ "SPC f f"
+      assert content =~ "AGENT PANEL"
+      assert content =~ "SPC a a"
+    end
+  end
+
+  describe "ex-command parsing" do
+    test ":Tutor parses to {:tutor, []}" do
+      assert {:tutor, []} = Parser.parse("Tutor")
+    end
+
+    test ":tutor (lowercase) parses to {:tutor, []}" do
+      assert {:tutor, []} = Parser.parse("tutor")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `:Tutor` / `:tutor` ex-command and `SPC h T` keybinding that opens a writable scratch buffer with a vimtutor-style interactive tutorial
- Tutorial covers vim fundamentals (movement, insert mode, deletion, undo/redo, visual mode, yank/paste, search) followed by Minga-specific features (leader key, file/buffer pickers, agent panel, config)
- Each invocation loads a fresh copy from `priv/tutor.txt`, so edits are always safe and the buffer resets on re-run

Closes #579

## Test plan

- [x] 9 new tests in `tutor_test.exs` all pass
- [x] `mix test.llm` passes (8042 tests, 3 pre-existing failures unrelated to this change)
- [x] `make lint` passes (format, credo, compile warnings, dialyzer)
- [ ] Manual: run `bin/minga`, type `:Tutor`, verify buffer opens with tutorial content
- [ ] Manual: practice editing a lesson line, re-run `:Tutor` to confirm fresh reset
- [ ] Manual: try `SPC h T` from normal mode
- [ ] Manual: verify `:Tutor` appears in ex-command completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)