### PR TITLE
feat(command): SPC h l keystroke history (lossage)

### DIFF
--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -75,6 +75,7 @@ defmodule Minga.Keymap.Defaults do
     # ── Help ──────────────────────────────────────────────────────────────────
     {[{?h, @none}, {?b, @none}], :describe_bindings, "Describe bindings"},
     {[{?h, @none}, {?k, @none}], :describe_key, "Describe key"},
+    {[{?h, @none}, {?l, @none}], :describe_lossage, "Show keystroke history"},
     {[{?h, @none}, {?v, @none}], :describe_option, "Describe option"},
     {[{?h, @none}, {?r, @none}], :reload_config, "Reload config"},
     {[{?h, @none}, {?t, @none}], :theme_picker, "Pick theme"},

--- a/lib/minga_editor/commands/help.ex
+++ b/lib/minga_editor/commands/help.ex
@@ -15,6 +15,7 @@ defmodule MingaEditor.Commands.Help do
   alias Minga.Keymap.Bindings
   alias Minga.Keymap.Defaults
   alias MingaEditor.Commands
+  alias MingaEditor.KeystrokeHistory
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
   alias Minga.Mode
@@ -43,6 +44,12 @@ defmodule MingaEditor.Commands.Help do
         description: "Describe option",
         requires_buffer: false,
         execute: fn state -> execute(state, :describe_option) end
+      },
+      %Command{
+        name: :describe_lossage,
+        description: "Show keystroke history",
+        requires_buffer: false,
+        execute: fn state -> execute(state, :describe_lossage) end
       }
     ]
   end
@@ -64,6 +71,10 @@ defmodule MingaEditor.Commands.Help do
 
   def execute(state, :describe_option) do
     PickerUI.open(state, MingaEditor.UI.Picker.OptionSource)
+  end
+
+  def execute(state, :describe_lossage) do
+    show_in_buffer(state, "*Keystrokes*", lossage_content(state))
   end
 
   def execute(state, {:describe_option_named, name}) when is_binary(name) do
@@ -621,6 +632,175 @@ defmodule MingaEditor.Commands.Help do
   defp format_type(:float_or_nil), do: "positive number or nil"
   defp format_type(:any), do: "any"
   defp format_type({:enum, values}), do: "one of: #{Enum.map_join(values, ", ", &inspect/1)}"
+
+  # ── Lossage formatting ─────────────────────────────────────────────────────
+
+  @spec lossage_content(state()) :: String.t()
+  defp lossage_content(state) do
+    entries = KeystrokeHistory.entries(state.keystroke_history)
+
+    case entries do
+      [] ->
+        "# Keystroke History\n\nNo keystrokes recorded yet.\n"
+
+      _ ->
+        groups = group_keystrokes(entries)
+        lines = format_keystroke_groups(groups)
+
+        [
+          "# Keystroke History (last #{length(entries)} keys)",
+          "",
+          String.pad_trailing("Time", 13) <>
+            String.pad_trailing("Mode", 18) <>
+            String.pad_trailing("Keys", 20) <>
+            "Info",
+          String.duplicate("─", 70)
+          | lines
+        ]
+        |> Enum.join("\n")
+        |> ensure_trailing_newline()
+    end
+  end
+
+  @typep keystroke_group :: %{
+           entries: [KeystrokeHistory.entry()],
+           kind: :operator_sequence | :insert_run | :single
+         }
+
+  @spec group_keystrokes([KeystrokeHistory.entry()]) :: [keystroke_group()]
+  defp group_keystrokes(entries) do
+    entries
+    |> Enum.chunk_while(
+      nil,
+      &keystroke_chunk_fun/2,
+      &keystroke_chunk_after/1
+    )
+  end
+
+  @spec keystroke_chunk_fun(KeystrokeHistory.entry(), nil | keystroke_group()) ::
+          {:cont, keystroke_group()} | {:cont, keystroke_group(), keystroke_group()}
+  defp keystroke_chunk_fun(entry, nil) do
+    {:cont, start_group(entry)}
+  end
+
+  defp keystroke_chunk_fun(entry, %{kind: :insert_run} = group) do
+    if entry.mode_before == :insert and entry.mode_after == :insert do
+      {:cont, %{group | entries: group.entries ++ [entry]}}
+    else
+      {:cont, group, start_group(entry)}
+    end
+  end
+
+  defp keystroke_chunk_fun(entry, %{kind: :operator_sequence} = group) do
+    if entry.mode_before == :operator_pending do
+      {:cont, %{group | entries: group.entries ++ [entry]}}
+    else
+      {:cont, group, start_group(entry)}
+    end
+  end
+
+  defp keystroke_chunk_fun(entry, %{kind: :single} = group) do
+    if entry.mode_before == :operator_pending do
+      prev = %{group | kind: :operator_sequence}
+      {:cont, %{prev | entries: prev.entries ++ [entry]}}
+    else
+      {:cont, group, start_group(entry)}
+    end
+  end
+
+  @spec keystroke_chunk_after(nil | keystroke_group()) ::
+          {:cont, keystroke_group(), nil} | {:cont, nil}
+  defp keystroke_chunk_after(nil), do: {:cont, nil}
+  defp keystroke_chunk_after(group), do: {:cont, group, nil}
+
+  @spec start_group(KeystrokeHistory.entry()) :: keystroke_group()
+  defp start_group(entry) do
+    kind =
+      if entry.mode_before == :insert and entry.mode_after == :insert,
+        do: :insert_run,
+        else: :single
+
+    %{entries: [entry], kind: kind}
+  end
+
+  @spec format_keystroke_groups([keystroke_group()]) :: [String.t()]
+  defp format_keystroke_groups(groups) do
+    groups
+    |> Enum.reduce({[], nil}, fn group, {lines, prev_mode} ->
+      first_entry = hd(group.entries)
+      mode = first_entry.mode_before
+
+      mode_annotation =
+        if prev_mode != nil and prev_mode != mode do
+          ["", "  ── mode: #{mode} ──", ""]
+        else
+          []
+        end
+
+      last_entry = List.last(group.entries)
+      next_mode = last_entry.mode_after
+      group_lines = format_group(group)
+
+      {lines ++ mode_annotation ++ group_lines, next_mode}
+    end)
+    |> elem(0)
+  end
+
+  @spec format_group(keystroke_group()) :: [String.t()]
+  defp format_group(%{kind: :insert_run, entries: entries}) when length(entries) > 3 do
+    first = hd(entries)
+    count = length(entries)
+    keys = Enum.map_join(entries, "", fn e -> format_insert_char(e.key) end)
+    display = if String.length(keys) > 18, do: String.slice(keys, 0, 15) <> "...", else: keys
+
+    [
+      String.pad_trailing(format_timestamp(first.timestamp), 13) <>
+        String.pad_trailing("insert", 18) <>
+        String.pad_trailing(inspect(display), 20) <>
+        "(#{count} chars)"
+    ]
+  end
+
+  defp format_group(%{kind: :operator_sequence, entries: entries}) do
+    first = hd(entries)
+    keys = Enum.map_join(entries, " ", fn e -> Bindings.format_key(e.key) end)
+    last = List.last(entries)
+    mode_note = if first.mode_before != last.mode_after, do: "→ #{last.mode_after}", else: ""
+
+    [
+      String.pad_trailing(format_timestamp(first.timestamp), 13) <>
+        String.pad_trailing(to_string(first.mode_before), 18) <>
+        String.pad_trailing(keys, 20) <>
+        mode_note
+    ]
+  end
+
+  defp format_group(%{entries: entries}) do
+    Enum.map(entries, fn entry ->
+      key_str = Bindings.format_key(entry.key)
+      mode_note = if entry.mode_before != entry.mode_after, do: "→ #{entry.mode_after}", else: ""
+
+      String.pad_trailing(format_timestamp(entry.timestamp), 13) <>
+        String.pad_trailing(to_string(entry.mode_before), 18) <>
+        String.pad_trailing(key_str, 20) <>
+        mode_note
+    end)
+  end
+
+  @spec format_insert_char({non_neg_integer(), non_neg_integer()}) :: String.t()
+  defp format_insert_char({cp, _mods}) when cp >= 32 and cp < 127, do: <<cp::utf8>>
+  defp format_insert_char({cp, _mods}) when cp >= 127, do: <<cp::utf8>>
+  defp format_insert_char(_key), do: "·"
+
+  @spec format_timestamp(integer()) :: String.t()
+  defp format_timestamp(ms) do
+    seconds = div(ms, 1000)
+    millis = rem(ms, 1000)
+    {:ok, dt} = DateTime.from_unix(seconds)
+    pad2 = &String.pad_leading(Integer.to_string(&1), 2, "0")
+    pad3 = &String.pad_leading(Integer.to_string(&1), 3, "0")
+    "#{pad2.(dt.hour)}:#{pad2.(dt.minute)}:#{pad2.(dt.second)}.#{pad3.(millis)}"
+  end
 
   # ── Special buffers ────────────────────────────────────────────────────────
 

--- a/lib/minga_editor/commands/help.ex
+++ b/lib/minga_editor/commands/help.ex
@@ -789,18 +789,26 @@ defmodule MingaEditor.Commands.Help do
 
   @spec format_insert_char({non_neg_integer(), non_neg_integer()}) :: String.t()
   defp format_insert_char({cp, _mods}) when cp >= 32 and cp < 127, do: <<cp::utf8>>
-  defp format_insert_char({cp, _mods}) when cp >= 127, do: <<cp::utf8>>
+  defp format_insert_char({cp, _mods}) when cp > 127 and cp <= 0x10FFFF, do: <<cp::utf8>>
   defp format_insert_char(_key), do: "·"
 
-  @spec format_timestamp(integer()) :: String.t()
-  defp format_timestamp(ms) do
+  @spec format_timestamp(non_neg_integer()) :: String.t()
+  defp format_timestamp(ms) when is_integer(ms) and ms >= 0 do
     seconds = div(ms, 1000)
     millis = rem(ms, 1000)
-    {:ok, dt} = DateTime.from_unix(seconds)
-    pad2 = &String.pad_leading(Integer.to_string(&1), 2, "0")
-    pad3 = &String.pad_leading(Integer.to_string(&1), 3, "0")
-    "#{pad2.(dt.hour)}:#{pad2.(dt.minute)}:#{pad2.(dt.second)}.#{pad3.(millis)}"
+
+    case DateTime.from_unix(seconds) do
+      {:ok, dt} ->
+        pad2 = &String.pad_leading(Integer.to_string(&1), 2, "0")
+        pad3 = &String.pad_leading(Integer.to_string(&1), 3, "0")
+        "#{pad2.(dt.hour)}:#{pad2.(dt.minute)}:#{pad2.(dt.second)}.#{pad3.(millis)}"
+
+      {:error, _} ->
+        "??:??:??.???"
+    end
   end
+
+  defp format_timestamp(_ms), do: "??:??:??.???"
 
   # ── Special buffers ────────────────────────────────────────────────────────
 

--- a/lib/minga_editor/input/router.ex
+++ b/lib/minga_editor/input/router.ex
@@ -19,6 +19,7 @@ defmodule MingaEditor.Input.Router do
   alias MingaEditor
   alias MingaEditor.FocusTree
   alias MingaEditor.FocusTree.Node, as: FocusNode
+  alias MingaEditor.KeystrokeHistory
   alias MingaEditor.LspActions
   alias MingaEditor.State, as: EditorState
 
@@ -108,6 +109,7 @@ defmodule MingaEditor.Input.Router do
     state = EditorState.clear_status(state)
 
     state = dispatch_split(state, codepoint, modifiers)
+    state = record_keystroke(state, codepoint, modifiers, old_mode)
 
     post_key_housekeeping(
       state,
@@ -420,6 +422,19 @@ defmodule MingaEditor.Input.Router do
         {:passthrough, new_state} -> {:cont, {:passthrough, new_state}}
       end
     end)
+  end
+
+  @spec record_keystroke(EditorState.t(), non_neg_integer(), non_neg_integer(), atom()) ::
+          EditorState.t()
+  defp record_keystroke(state, codepoint, modifiers, mode_before) do
+    entry = %{
+      key: {codepoint, modifiers},
+      mode_before: mode_before,
+      mode_after: Editing.mode(state),
+      timestamp: :os.system_time(:millisecond)
+    }
+
+    %{state | keystroke_history: KeystrokeHistory.record(state.keystroke_history, entry)}
   end
 
   @spec buffer_version(EditorState.t()) :: non_neg_integer()

--- a/lib/minga_editor/input/router.ex
+++ b/lib/minga_editor/input/router.ex
@@ -427,7 +427,7 @@ defmodule MingaEditor.Input.Router do
   @spec record_keystroke(EditorState.t(), non_neg_integer(), non_neg_integer(), atom()) ::
           EditorState.t()
   defp record_keystroke(state, codepoint, modifiers, mode_before) do
-    entry = %{
+    entry = %KeystrokeHistory.Entry{
       key: {codepoint, modifiers},
       mode_before: mode_before,
       mode_after: Editing.mode(state),

--- a/lib/minga_editor/keystroke_history.ex
+++ b/lib/minga_editor/keystroke_history.ex
@@ -1,0 +1,58 @@
+defmodule MingaEditor.KeystrokeHistory do
+  @moduledoc """
+  Bounded ring buffer of recent keystrokes for the lossage display (`SPC h l`).
+
+  A pure functional module, no GenServer. The struct lives on
+  `MingaEditor.State` (global, not per-tab) and is updated on every
+  key press in `Input.Router.dispatch_normal/3`.
+
+  Entries are stored newest-first internally and returned in
+  chronological order by `entries/1`.
+  """
+
+  @default_max_size 200
+
+  defstruct entries: [],
+            count: 0,
+            max_size: @default_max_size
+
+  @typedoc "A single recorded keystroke."
+  @type entry :: %{
+          key: {non_neg_integer(), non_neg_integer()},
+          mode_before: atom(),
+          mode_after: atom(),
+          timestamp: integer()
+        }
+
+  @type t :: %__MODULE__{
+          entries: [entry()],
+          count: non_neg_integer(),
+          max_size: pos_integer()
+        }
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @spec new(pos_integer()) :: t()
+  def new(max_size) when is_integer(max_size) and max_size > 0 do
+    %__MODULE__{max_size: max_size}
+  end
+
+  @spec record(t(), entry()) :: t()
+  def record(%__MODULE__{entries: entries, count: count, max_size: max_size} = history, entry) do
+    new_entries = [entry | entries]
+    new_count = count + 1
+
+    if new_count > max_size do
+      %{history | entries: Enum.take(new_entries, max_size), count: max_size}
+    else
+      %{history | entries: new_entries, count: new_count}
+    end
+  end
+
+  @spec entries(t()) :: [entry()]
+  def entries(%__MODULE__{entries: entries}), do: Enum.reverse(entries)
+
+  @spec size(t()) :: non_neg_integer()
+  def size(%__MODULE__{count: count}), do: count
+end

--- a/lib/minga_editor/keystroke_history.ex
+++ b/lib/minga_editor/keystroke_history.ex
@@ -1,10 +1,10 @@
 defmodule MingaEditor.KeystrokeHistory do
   @moduledoc """
-  Bounded ring buffer of recent keystrokes for the lossage display (`SPC h l`).
+  Bounded list of the most recent keystrokes for the lossage display (`SPC h l`).
 
   A pure functional module, no GenServer. The struct lives on
-  `MingaEditor.State` (global, not per-tab) and is updated on every
-  key press in `Input.Router.dispatch_normal/3`.
+  `MingaEditor.State` (global, not per-tab) and is updated once per
+  key event, after dispatch but before post-key housekeeping.
 
   Entries are stored newest-first internally and returned in
   chronological order by `entries/1`.
@@ -12,21 +12,27 @@ defmodule MingaEditor.KeystrokeHistory do
 
   @default_max_size 200
 
+  defmodule Entry do
+    @moduledoc false
+
+    @enforce_keys [:key, :mode_before, :mode_after, :timestamp]
+    defstruct [:key, :mode_before, :mode_after, :timestamp]
+
+    @type t :: %__MODULE__{
+            key: {non_neg_integer(), non_neg_integer()},
+            mode_before: Minga.Mode.mode(),
+            mode_after: Minga.Mode.mode(),
+            timestamp: non_neg_integer()
+          }
+  end
+
   defstruct entries: [],
-            count: 0,
             max_size: @default_max_size
 
-  @typedoc "A single recorded keystroke."
-  @type entry :: %{
-          key: {non_neg_integer(), non_neg_integer()},
-          mode_before: atom(),
-          mode_after: atom(),
-          timestamp: integer()
-        }
+  @type entry :: Entry.t()
 
   @type t :: %__MODULE__{
           entries: [entry()],
-          count: non_neg_integer(),
           max_size: pos_integer()
         }
 
@@ -39,14 +45,13 @@ defmodule MingaEditor.KeystrokeHistory do
   end
 
   @spec record(t(), entry()) :: t()
-  def record(%__MODULE__{entries: entries, count: count, max_size: max_size} = history, entry) do
+  def record(%__MODULE__{entries: entries, max_size: max_size} = history, %Entry{} = entry) do
     new_entries = [entry | entries]
-    new_count = count + 1
 
-    if new_count > max_size do
-      %{history | entries: Enum.take(new_entries, max_size), count: max_size}
+    if length(new_entries) > max_size do
+      %{history | entries: Enum.take(new_entries, max_size)}
     else
-      %{history | entries: new_entries, count: new_count}
+      %{history | entries: new_entries}
     end
   end
 
@@ -54,5 +59,5 @@ defmodule MingaEditor.KeystrokeHistory do
   def entries(%__MODULE__{entries: entries}), do: Enum.reverse(entries)
 
   @spec size(t()) :: non_neg_integer()
-  def size(%__MODULE__{count: count}), do: count
+  def size(%__MODULE__{entries: entries}), do: length(entries)
 end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -33,6 +33,7 @@ defmodule MingaEditor.State do
   alias Minga.Buffer
 
   alias MingaEditor.BottomPanel
+  alias MingaEditor.KeystrokeHistory
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.LSP, as: LSPState
@@ -113,7 +114,8 @@ defmodule MingaEditor.State do
             caches: MingaEditor.Renderer.Caches.new(),
             session: %SessionState{},
             buffer_add_context: :open,
-            stashed_board_state: nil
+            stashed_board_state: nil,
+            keystroke_history: %KeystrokeHistory{}
 
   @type backend :: :tui | :gui | :native_gui | :headless
 
@@ -149,7 +151,8 @@ defmodule MingaEditor.State do
           caches: MingaEditor.Renderer.Caches.t(),
           buffer_add_context: MingaEditor.Shell.buffer_add_context(),
           session: SessionState.t(),
-          stashed_board_state: MingaEditor.Shell.Board.State.t() | nil
+          stashed_board_state: MingaEditor.Shell.Board.State.t() | nil,
+          keystroke_history: KeystrokeHistory.t()
         }
 
   @spec set_renderer(t(), pid() | nil) :: t()

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -115,7 +115,7 @@ defmodule MingaEditor.State do
             session: %SessionState{},
             buffer_add_context: :open,
             stashed_board_state: nil,
-            keystroke_history: %KeystrokeHistory{}
+            keystroke_history: KeystrokeHistory.new()
 
   @type backend :: :tui | :gui | :native_gui | :headless
 

--- a/test/minga_editor/commands/help_test.exs
+++ b/test/minga_editor/commands/help_test.exs
@@ -241,4 +241,131 @@ defmodule MingaEditor.Commands.HelpTest do
       assert BufferServer.read_only?(result.workspace.buffers.help)
     end
   end
+
+  describe "describe_lossage" do
+    test "creates *Keystrokes* buffer with empty history message" do
+      state = build_state()
+      result = Help.execute(state, :describe_lossage)
+
+      buf = result.workspace.buffers.active
+      assert Process.alive?(buf)
+      assert BufferServer.buffer_name(buf) == "*Keystrokes*"
+
+      content = BufferServer.content(buf)
+      assert content =~ "Keystroke History"
+      assert content =~ "No keystrokes recorded yet."
+    end
+
+    test "*Keystrokes* buffer is read-only" do
+      state = build_state()
+      result = Help.execute(state, :describe_lossage)
+
+      buf = result.workspace.buffers.active
+      assert BufferServer.read_only?(buf)
+    end
+
+    test "shows formatted keystrokes when history has entries" do
+      state = build_state()
+
+      history =
+        MingaEditor.KeystrokeHistory.new()
+        |> MingaEditor.KeystrokeHistory.record(%{
+          key: {?j, 0},
+          mode_before: :normal,
+          mode_after: :normal,
+          timestamp: 1_715_500_800_000
+        })
+        |> MingaEditor.KeystrokeHistory.record(%{
+          key: {?k, 0},
+          mode_before: :normal,
+          mode_after: :normal,
+          timestamp: 1_715_500_801_000
+        })
+
+      state = %{state | keystroke_history: history}
+      result = Help.execute(state, :describe_lossage)
+
+      content = BufferServer.content(result.workspace.buffers.active)
+      assert content =~ "Keystroke History (last 2 keys)"
+      assert content =~ "j"
+      assert content =~ "k"
+    end
+
+    test "annotates mode transitions" do
+      state = build_state()
+
+      history =
+        MingaEditor.KeystrokeHistory.new()
+        |> MingaEditor.KeystrokeHistory.record(%{
+          key: {?j, 0},
+          mode_before: :normal,
+          mode_after: :normal,
+          timestamp: 1_715_500_800_000
+        })
+        |> MingaEditor.KeystrokeHistory.record(%{
+          key: {?h, 0},
+          mode_before: :insert,
+          mode_after: :insert,
+          timestamp: 1_715_500_802_000
+        })
+
+      state = %{state | keystroke_history: history}
+      result = Help.execute(state, :describe_lossage)
+
+      content = BufferServer.content(result.workspace.buffers.active)
+      assert content =~ "── mode: insert ──"
+    end
+
+    test "groups operator-pending sequences" do
+      state = build_state()
+
+      history =
+        MingaEditor.KeystrokeHistory.new()
+        |> MingaEditor.KeystrokeHistory.record(%{
+          key: {?d, 0},
+          mode_before: :normal,
+          mode_after: :operator_pending,
+          timestamp: 1_715_500_800_000
+        })
+        |> MingaEditor.KeystrokeHistory.record(%{
+          key: {?w, 0},
+          mode_before: :operator_pending,
+          mode_after: :normal,
+          timestamp: 1_715_500_800_100
+        })
+
+      state = %{state | keystroke_history: history}
+      result = Help.execute(state, :describe_lossage)
+
+      content = BufferServer.content(result.workspace.buffers.active)
+      assert content =~ "d w"
+    end
+
+    test "collapses insert runs into compact display" do
+      state = build_state()
+
+      entries =
+        Enum.map(?a..?h, fn cp ->
+          %{
+            key: {cp, 0},
+            mode_before: :insert,
+            mode_after: :insert,
+            timestamp: 1_715_500_800_000 + cp
+          }
+        end)
+
+      history =
+        Enum.reduce(
+          entries,
+          MingaEditor.KeystrokeHistory.new(),
+          &MingaEditor.KeystrokeHistory.record(&2, &1)
+        )
+
+      state = %{state | keystroke_history: history}
+      result = Help.execute(state, :describe_lossage)
+
+      content = BufferServer.content(result.workspace.buffers.active)
+      assert content =~ "8 chars"
+    end
+  end
 end

--- a/test/minga_editor/commands/help_test.exs
+++ b/test/minga_editor/commands/help_test.exs
@@ -243,6 +243,18 @@ defmodule MingaEditor.Commands.HelpTest do
   end
 
   describe "describe_lossage" do
+    alias MingaEditor.KeystrokeHistory
+    alias MingaEditor.KeystrokeHistory.Entry
+
+    defp make_lossage_entry(opts) do
+      %Entry{
+        key: Keyword.get(opts, :key, {?j, 0}),
+        mode_before: Keyword.get(opts, :mode_before, :normal),
+        mode_after: Keyword.get(opts, :mode_after, :normal),
+        timestamp: Keyword.get(opts, :timestamp, 1_715_500_800_000)
+      }
+    end
+
     test "creates *Keystrokes* buffer with empty history message" do
       state = build_state()
       result = Help.execute(state, :describe_lossage)
@@ -268,19 +280,9 @@ defmodule MingaEditor.Commands.HelpTest do
       state = build_state()
 
       history =
-        MingaEditor.KeystrokeHistory.new()
-        |> MingaEditor.KeystrokeHistory.record(%{
-          key: {?j, 0},
-          mode_before: :normal,
-          mode_after: :normal,
-          timestamp: 1_715_500_800_000
-        })
-        |> MingaEditor.KeystrokeHistory.record(%{
-          key: {?k, 0},
-          mode_before: :normal,
-          mode_after: :normal,
-          timestamp: 1_715_500_801_000
-        })
+        KeystrokeHistory.new()
+        |> KeystrokeHistory.record(make_lossage_entry(key: {?j, 0}, timestamp: 1_715_500_800_000))
+        |> KeystrokeHistory.record(make_lossage_entry(key: {?k, 0}, timestamp: 1_715_500_801_000))
 
       state = %{state | keystroke_history: history}
       result = Help.execute(state, :describe_lossage)
@@ -291,23 +293,20 @@ defmodule MingaEditor.Commands.HelpTest do
       assert content =~ "k"
     end
 
-    test "annotates mode transitions" do
+    test "annotates mode transitions between groups" do
       state = build_state()
 
       history =
-        MingaEditor.KeystrokeHistory.new()
-        |> MingaEditor.KeystrokeHistory.record(%{
-          key: {?j, 0},
-          mode_before: :normal,
-          mode_after: :normal,
-          timestamp: 1_715_500_800_000
-        })
-        |> MingaEditor.KeystrokeHistory.record(%{
-          key: {?h, 0},
-          mode_before: :insert,
-          mode_after: :insert,
-          timestamp: 1_715_500_802_000
-        })
+        KeystrokeHistory.new()
+        |> KeystrokeHistory.record(make_lossage_entry(key: {?j, 0}, timestamp: 1_715_500_800_000))
+        |> KeystrokeHistory.record(
+          make_lossage_entry(
+            key: {?h, 0},
+            mode_before: :insert,
+            mode_after: :insert,
+            timestamp: 1_715_500_802_000
+          )
+        )
 
       state = %{state | keystroke_history: history}
       result = Help.execute(state, :describe_lossage)
@@ -316,23 +315,43 @@ defmodule MingaEditor.Commands.HelpTest do
       assert content =~ "── mode: insert ──"
     end
 
+    test "shows mode change arrow on single entry" do
+      state = build_state()
+
+      history =
+        KeystrokeHistory.new()
+        |> KeystrokeHistory.record(
+          make_lossage_entry(key: {?i, 0}, mode_before: :normal, mode_after: :insert)
+        )
+
+      state = %{state | keystroke_history: history}
+      result = Help.execute(state, :describe_lossage)
+
+      content = BufferServer.content(result.workspace.buffers.active)
+      assert content =~ "→ insert"
+    end
+
     test "groups operator-pending sequences" do
       state = build_state()
 
       history =
-        MingaEditor.KeystrokeHistory.new()
-        |> MingaEditor.KeystrokeHistory.record(%{
-          key: {?d, 0},
-          mode_before: :normal,
-          mode_after: :operator_pending,
-          timestamp: 1_715_500_800_000
-        })
-        |> MingaEditor.KeystrokeHistory.record(%{
-          key: {?w, 0},
-          mode_before: :operator_pending,
-          mode_after: :normal,
-          timestamp: 1_715_500_800_100
-        })
+        KeystrokeHistory.new()
+        |> KeystrokeHistory.record(
+          make_lossage_entry(
+            key: {?d, 0},
+            mode_before: :normal,
+            mode_after: :operator_pending,
+            timestamp: 1_715_500_800_000
+          )
+        )
+        |> KeystrokeHistory.record(
+          make_lossage_entry(
+            key: {?w, 0},
+            mode_before: :operator_pending,
+            mode_after: :normal,
+            timestamp: 1_715_500_800_100
+          )
+        )
 
       state = %{state | keystroke_history: history}
       result = Help.execute(state, :describe_lossage)
@@ -341,31 +360,48 @@ defmodule MingaEditor.Commands.HelpTest do
       assert content =~ "d w"
     end
 
-    test "collapses insert runs into compact display" do
+    test "3 insert chars are shown individually, not collapsed" do
       state = build_state()
 
       entries =
-        Enum.map(?a..?h, fn cp ->
-          %{
+        Enum.map(?a..?c, fn cp ->
+          make_lossage_entry(
             key: {cp, 0},
             mode_before: :insert,
             mode_after: :insert,
             timestamp: 1_715_500_800_000 + cp
-          }
+          )
         end)
 
-      history =
-        Enum.reduce(
-          entries,
-          MingaEditor.KeystrokeHistory.new(),
-          &MingaEditor.KeystrokeHistory.record(&2, &1)
-        )
+      history = Enum.reduce(entries, KeystrokeHistory.new(), &KeystrokeHistory.record(&2, &1))
 
       state = %{state | keystroke_history: history}
       result = Help.execute(state, :describe_lossage)
 
       content = BufferServer.content(result.workspace.buffers.active)
-      assert content =~ "8 chars"
+      refute content =~ "chars"
+    end
+
+    test "4+ insert chars are collapsed into compact display" do
+      state = build_state()
+
+      entries =
+        Enum.map(?a..?h, fn cp ->
+          make_lossage_entry(
+            key: {cp, 0},
+            mode_before: :insert,
+            mode_after: :insert,
+            timestamp: 1_715_500_800_000 + cp
+          )
+        end)
+
+      history = Enum.reduce(entries, KeystrokeHistory.new(), &KeystrokeHistory.record(&2, &1))
+
+      state = %{state | keystroke_history: history}
+      result = Help.execute(state, :describe_lossage)
+
+      content = BufferServer.content(result.workspace.buffers.active)
+      assert content =~ "(8 chars)"
     end
   end
 end

--- a/test/minga_editor/input/router_test.exs
+++ b/test/minga_editor/input/router_test.exs
@@ -258,4 +258,34 @@ defmodule MingaEditor.Input.RouterTest do
       assert line == 1
     end
   end
+
+  describe "keystroke recording" do
+    alias MingaEditor.KeystrokeHistory
+
+    test "dispatch records a keystroke in the history" do
+      state = base_state()
+      assert KeystrokeHistory.size(state.keystroke_history) == 0
+
+      state = Router.dispatch(state, ?j, 0)
+
+      assert KeystrokeHistory.size(state.keystroke_history) == 1
+      [entry] = KeystrokeHistory.entries(state.keystroke_history)
+      assert entry.key == {?j, 0}
+      assert entry.mode_before == :normal
+    end
+
+    test "multiple dispatches accumulate entries" do
+      state = base_state()
+
+      state =
+        state
+        |> Router.dispatch(?j, 0)
+        |> Router.dispatch(?k, 0)
+        |> Router.dispatch(?l, 0)
+
+      assert KeystrokeHistory.size(state.keystroke_history) == 3
+      keys = Enum.map(KeystrokeHistory.entries(state.keystroke_history), & &1.key)
+      assert keys == [{?j, 0}, {?k, 0}, {?l, 0}]
+    end
+  end
 end

--- a/test/minga_editor/keystroke_history_test.exs
+++ b/test/minga_editor/keystroke_history_test.exs
@@ -3,9 +3,10 @@ defmodule MingaEditor.KeystrokeHistoryTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.KeystrokeHistory
+  alias MingaEditor.KeystrokeHistory.Entry
 
   defp make_entry(opts \\ []) do
-    %{
+    %Entry{
       key: Keyword.get(opts, :key, {?j, 0}),
       mode_before: Keyword.get(opts, :mode_before, :normal),
       mode_after: Keyword.get(opts, :mode_after, :normal),
@@ -17,7 +18,6 @@ defmodule MingaEditor.KeystrokeHistoryTest do
     test "creates empty history with default max size" do
       h = KeystrokeHistory.new()
       assert h.entries == []
-      assert h.count == 0
       assert h.max_size == 200
     end
   end
@@ -26,7 +26,7 @@ defmodule MingaEditor.KeystrokeHistoryTest do
     test "creates empty history with custom max size" do
       h = KeystrokeHistory.new(5)
       assert h.max_size == 5
-      assert h.count == 0
+      assert KeystrokeHistory.size(h) == 0
     end
   end
 
@@ -96,6 +96,19 @@ defmodule MingaEditor.KeystrokeHistoryTest do
         end)
 
       assert KeystrokeHistory.size(h) == 5
+    end
+
+    test "max_size of 1 keeps only the latest entry" do
+      h = KeystrokeHistory.new(1)
+
+      h =
+        h
+        |> KeystrokeHistory.record(make_entry(key: {?a, 0}))
+        |> KeystrokeHistory.record(make_entry(key: {?b, 0}))
+
+      assert KeystrokeHistory.size(h) == 1
+      [entry] = KeystrokeHistory.entries(h)
+      assert entry.key == {?b, 0}
     end
   end
 

--- a/test/minga_editor/keystroke_history_test.exs
+++ b/test/minga_editor/keystroke_history_test.exs
@@ -1,0 +1,116 @@
+defmodule MingaEditor.KeystrokeHistoryTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.KeystrokeHistory
+
+  defp make_entry(opts \\ []) do
+    %{
+      key: Keyword.get(opts, :key, {?j, 0}),
+      mode_before: Keyword.get(opts, :mode_before, :normal),
+      mode_after: Keyword.get(opts, :mode_after, :normal),
+      timestamp: Keyword.get(opts, :timestamp, 1_000_000)
+    }
+  end
+
+  describe "new/0" do
+    test "creates empty history with default max size" do
+      h = KeystrokeHistory.new()
+      assert h.entries == []
+      assert h.count == 0
+      assert h.max_size == 200
+    end
+  end
+
+  describe "new/1" do
+    test "creates empty history with custom max size" do
+      h = KeystrokeHistory.new(5)
+      assert h.max_size == 5
+      assert h.count == 0
+    end
+  end
+
+  describe "record/2" do
+    test "adds an entry" do
+      h = KeystrokeHistory.new() |> KeystrokeHistory.record(make_entry())
+      assert KeystrokeHistory.size(h) == 1
+    end
+
+    test "preserves entry data" do
+      entry = make_entry(key: {?k, 0x02}, mode_before: :insert, mode_after: :normal)
+      h = KeystrokeHistory.new() |> KeystrokeHistory.record(entry)
+      [recorded] = KeystrokeHistory.entries(h)
+      assert recorded.key == {?k, 0x02}
+      assert recorded.mode_before == :insert
+      assert recorded.mode_after == :normal
+    end
+
+    test "multiple entries accumulate" do
+      h =
+        KeystrokeHistory.new()
+        |> KeystrokeHistory.record(make_entry(key: {?a, 0}))
+        |> KeystrokeHistory.record(make_entry(key: {?b, 0}))
+        |> KeystrokeHistory.record(make_entry(key: {?c, 0}))
+
+      assert KeystrokeHistory.size(h) == 3
+    end
+  end
+
+  describe "entries/1" do
+    test "returns entries in chronological order" do
+      h =
+        KeystrokeHistory.new()
+        |> KeystrokeHistory.record(make_entry(key: {?a, 0}, timestamp: 1))
+        |> KeystrokeHistory.record(make_entry(key: {?b, 0}, timestamp: 2))
+        |> KeystrokeHistory.record(make_entry(key: {?c, 0}, timestamp: 3))
+
+      keys = Enum.map(KeystrokeHistory.entries(h), & &1.key)
+      assert keys == [{?a, 0}, {?b, 0}, {?c, 0}]
+    end
+
+    test "empty history returns empty list" do
+      assert KeystrokeHistory.entries(KeystrokeHistory.new()) == []
+    end
+  end
+
+  describe "ring buffer truncation" do
+    test "truncates oldest entries when exceeding max_size" do
+      h = KeystrokeHistory.new(3)
+
+      h =
+        Enum.reduce(1..5, h, fn i, acc ->
+          KeystrokeHistory.record(acc, make_entry(key: {i, 0}, timestamp: i))
+        end)
+
+      assert KeystrokeHistory.size(h) == 3
+      keys = Enum.map(KeystrokeHistory.entries(h), & &1.key)
+      assert keys == [{3, 0}, {4, 0}, {5, 0}]
+    end
+
+    test "stays at max_size after many insertions" do
+      h = KeystrokeHistory.new(5)
+
+      h =
+        Enum.reduce(1..100, h, fn i, acc ->
+          KeystrokeHistory.record(acc, make_entry(key: {i, 0}))
+        end)
+
+      assert KeystrokeHistory.size(h) == 5
+    end
+  end
+
+  describe "size/1" do
+    test "returns 0 for empty history" do
+      assert KeystrokeHistory.size(KeystrokeHistory.new()) == 0
+    end
+
+    test "returns correct count" do
+      h =
+        KeystrokeHistory.new()
+        |> KeystrokeHistory.record(make_entry())
+        |> KeystrokeHistory.record(make_entry())
+
+      assert KeystrokeHistory.size(h) == 2
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `MingaEditor.KeystrokeHistory`, a bounded ring buffer (200 entries) that records every keystroke at the `Input.Router` level, capturing key, mode before/after, and timestamp
- Wire `SPC h l` to `:describe_lossage` command that formats the history into a read-only `*Keystrokes*` buffer with tabular display
- Multi-key sequences (`d w`, `c i "`) are grouped, insert-mode character runs are collapsed with char counts, and mode transitions are annotated between entries

Closes #578

## Test plan

- [x] `mix compile` clean (no warnings)
- [x] `make lint` passes (format, credo, dialyzer)
- [x] 11 new unit tests for `KeystrokeHistory` struct (ring buffer truncation, chronological ordering, custom max_size)
- [x] 5 new integration tests for `:describe_lossage` command (empty state, formatted output, read-only buffer, mode annotations, operator grouping, insert collapsing)
- [x] Full test suite: 8050 tests, 0 failures from these changes
- [ ] Manual: run `bin/minga`, type keys in normal mode, press `SPC h l`, verify `*Keystrokes*` buffer shows recent keys with timestamps and mode info
- [ ] Manual: type `dw` and verify it groups as one entry
- [ ] Manual: enter insert mode, type text, exit, verify insert chars are collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)