### PR TITLE
feat(keymap): add SPC s s and SPC s r leader bindings

### DIFF
--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -40,6 +40,8 @@ defmodule Minga.Keymap.Defaults do
 
     # ── Search ─────────────────────────────────────────────────────────────────
     {[{?s, @none}, {?p, @none}], :search_project, "Search project"},
+    {[{?s, @none}, {?s, @none}], :search_buffer, "Search in buffer"},
+    {[{?s, @none}, {?r, @none}], :search_and_replace, "Search and replace"},
     {[{?s, @none}, {?w, @none}], :workspace_symbols, "Search workspace symbols"},
     {[{?/, @none}], :search_project, "Search project"},
 

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -1749,7 +1749,7 @@ defmodule MingaEditor.Commands.BufferManagement do
         requires_buffer: true,
         execute: fn state -> execute(state, :toggle_wrap) end,
         option_toggle: :wrap
-      },
+      }
     ]
 
     standard ++ tabs ++ scoped

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -1749,7 +1749,7 @@ defmodule MingaEditor.Commands.BufferManagement do
         requires_buffer: true,
         execute: fn state -> execute(state, :toggle_wrap) end,
         option_toggle: :wrap
-      }
+      },
     ]
 
     standard ++ tabs ++ scoped

--- a/lib/minga_editor/commands/search.ex
+++ b/lib/minga_editor/commands/search.ex
@@ -15,6 +15,7 @@ defmodule MingaEditor.Commands.Search do
   alias MingaEditor.Window
   alias MingaEditor.Workspace.State, as: WorkspaceState
   alias Minga.Mode
+  alias Minga.Mode.CommandState
   alias Minga.Mode.SearchState
   alias Minga.Project.ProjectSearch
 
@@ -522,6 +523,22 @@ defmodule MingaEditor.Commands.Search do
         requires_buffer: false,
         execute: fn state ->
           EditorState.transition_mode(state, :search_prompt, %Minga.Mode.SearchPromptState{})
+        end
+      },
+      %Minga.Command{
+        name: :search_buffer,
+        description: "Search in buffer",
+        requires_buffer: true,
+        execute: fn state ->
+          EditorState.transition_mode(state, :search, %SearchState{direction: :forward})
+        end
+      },
+      %Minga.Command{
+        name: :search_and_replace,
+        description: "Search and replace",
+        requires_buffer: true,
+        execute: fn state ->
+          EditorState.transition_mode(state, :command, %CommandState{input: "%s/"})
         end
       }
     ]

--- a/test/minga/command/registry_test.exs
+++ b/test/minga/command/registry_test.exs
@@ -63,6 +63,8 @@ defmodule Minga.Command.RegistryTest do
           :command_palette,
           :find_file,
           :search_project,
+          :search_buffer,
+          :search_and_replace,
           :theme_picker,
           :set_language,
           :diagnostics_list,

--- a/test/minga/keymap/defaults_test.exs
+++ b/test/minga/keymap/defaults_test.exs
@@ -163,6 +163,20 @@ defmodule Minga.Keymap.DefaultsTest do
       assert {:command, :agent_session_history} = Bindings.lookup(a_node, {?h, 0})
     end
 
+    # ── Search bindings ─────────────────────────────────────────────────────────
+
+    test "SPC s s → :search_buffer" do
+      trie = Defaults.leader_trie()
+      {:prefix, s_node} = Bindings.lookup(trie, {?s, 0})
+      assert {:command, :search_buffer} = Bindings.lookup(s_node, {?s, 0})
+    end
+
+    test "SPC s r → :search_and_replace" do
+      trie = Defaults.leader_trie()
+      {:prefix, s_node} = Bindings.lookup(trie, {?s, 0})
+      assert {:command, :search_and_replace} = Bindings.lookup(s_node, {?r, 0})
+    end
+
     # ── Negative cases ─────────────────────────────────────────────────────────
 
     test "unknown leader prefix returns :not_found" do

--- a/test/minga_editor/commands/no_buffer_test.exs
+++ b/test/minga_editor/commands/no_buffer_test.exs
@@ -50,5 +50,11 @@ defmodule MingaEditor.Commands.NoBufferTest do
         assert Commands.execute(state, cmd) == state
       end
     end
+
+    test "search commands are no-ops", %{state: state} do
+      for cmd <- [:search_buffer, :search_and_replace] do
+        assert Commands.execute(state, cmd) == state
+      end
+    end
   end
 end

--- a/test/minga_editor/commands/search_leader_test.exs
+++ b/test/minga_editor/commands/search_leader_test.exs
@@ -1,0 +1,27 @@
+defmodule MingaEditor.Commands.SearchLeaderTest do
+  use Minga.Test.EditorCase, async: true
+
+  describe "search_buffer" do
+    test "transitions to search mode with forward direction" do
+      ctx = start_editor("hello world")
+
+      state = editor_state(ctx)
+      state = MingaEditor.Commands.execute(state, :search_buffer)
+
+      assert state.workspace.editing.mode == :search
+      assert state.workspace.editing.mode_state.direction == :forward
+    end
+  end
+
+  describe "search_and_replace" do
+    test "transitions to command mode with %s/ prefix" do
+      ctx = start_editor("hello world")
+
+      state = editor_state(ctx)
+      state = MingaEditor.Commands.execute(state, :search_and_replace)
+
+      assert state.workspace.editing.mode == :command
+      assert state.workspace.editing.mode_state.input == "%s/"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `SPC s s` → `:search_buffer` (opens forward search in current buffer)
- Adds `SPC s r` → `:search_and_replace` (enters command mode pre-filled with `:%s/`)
- Both are new registered commands in `MingaEditor.Commands.Search`

Closes #11 (remaining AC for `SPC t i` moved to #1565)

## Test plan
- [x] `mix compile` — no warnings
- [x] `mix test.llm` — 8103 tests pass, 0 new failures
- [x] `make lint` — format, credo, dialyzer all pass
- [ ] Manual: launch editor, press `SPC s s` (enters search mode), `SPC s r` (shows `:%s/` in command line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)