### PR TITLE
feat(macos): file drag-and-drop from Finder

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -1904,25 +1904,10 @@ defmodule MingaEditor do
   end
 
   defp handle_gui_action(state, {:open_file, path}) do
-    # Check if already open in buffer list
-    idx =
-      Enum.find_index(state.workspace.buffers.list, fn buf ->
-        try do
-          Buffer.file_path(buf) == path
-        catch
-          :exit, _ -> false
-        end
-      end)
-
-    case idx do
-      nil ->
-        case Commands.start_buffer(path) do
-          {:ok, pid} -> Commands.add_buffer(state, pid)
-          {:error, _reason} -> EditorState.set_status(state, "Could not open #{path}")
-        end
-
-      i ->
-        EditorState.switch_buffer(state, i)
+    if File.dir?(path) do
+      open_dropped_directory(state, path)
+    else
+      open_dropped_file(state, path)
     end
   end
 
@@ -2126,6 +2111,35 @@ defmodule MingaEditor do
         abs_path = Path.join(git_root, path)
         open_file_by_path(state, abs_path)
     end
+  end
+
+  @spec open_dropped_file(state(), String.t()) :: state()
+  defp open_dropped_file(state, path) do
+    idx =
+      Enum.find_index(state.workspace.buffers.list, fn buf ->
+        try do
+          Buffer.file_path(buf) == path
+        catch
+          :exit, _ -> false
+        end
+      end)
+
+    case idx do
+      nil ->
+        case Commands.start_buffer(path) do
+          {:ok, pid} -> Commands.add_buffer(state, pid)
+          {:error, _reason} -> EditorState.set_status(state, "Could not open #{path}")
+        end
+
+      i ->
+        EditorState.switch_buffer(state, i)
+    end
+  end
+
+  @spec open_dropped_directory(state(), String.t()) :: state()
+  defp open_dropped_directory(state, dir_path) do
+    Minga.Project.switch(dir_path)
+    PickerUI.open(state, MingaEditor.UI.Picker.FileSource)
   end
 
   # Moves the tree cursor to a specific index (used by GUI context menu / header actions).

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -1907,7 +1907,7 @@ defmodule MingaEditor do
     if File.dir?(path) do
       open_dropped_directory(state, path)
     else
-      open_dropped_file(state, path)
+      open_file_by_path(state, path)
     end
   end
 
@@ -2113,29 +2113,9 @@ defmodule MingaEditor do
     end
   end
 
-  @spec open_dropped_file(state(), String.t()) :: state()
-  defp open_dropped_file(state, path) do
-    idx =
-      Enum.find_index(state.workspace.buffers.list, fn buf ->
-        try do
-          Buffer.file_path(buf) == path
-        catch
-          :exit, _ -> false
-        end
-      end)
-
-    case idx do
-      nil ->
-        case Commands.start_buffer(path) do
-          {:ok, pid} -> Commands.add_buffer(state, pid)
-          {:error, _reason} -> EditorState.set_status(state, "Could not open #{path}")
-        end
-
-      i ->
-        EditorState.switch_buffer(state, i)
-    end
-  end
-
+  # Project.switch/1 is a cast; the picker opens against current state while the
+  # file cache rebuilds asynchronously. BEAM message ordering from the Editor
+  # process guarantees the cast reaches Project before any subsequent call.
   @spec open_dropped_directory(state(), String.t()) :: state()
   defp open_dropped_directory(state, dir_path) do
     Minga.Project.switch(dir_path)

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -77,6 +77,9 @@ final class EditorNSView: MTKView {
     /// interception when NSWindow subclassing isn't available.
     private var agentKeyMonitor: Any?
 
+    /// Border overlay shown during file drag-and-drop hover.
+    private var dropHighlightLayer: CAShapeLayer?
+
     /// Status bar state from the BEAM. Used by the space leader key-chord
     /// logic to check whether insert mode is active (SPC is always literal
     /// in insert mode, never a leader key).
@@ -342,6 +345,8 @@ final class EditorNSView: MTKView {
         window.setFrameAutosaveName("MingaEditorWindow")
 
         installWindowObserversIfNeeded(for: window)
+
+        registerForDraggedTypes([.fileURL])
 
         updateTrackingArea()
         claimFirstResponder()
@@ -1288,5 +1293,63 @@ private func mapKeyCode(_ event: NSEvent) -> UInt32? {
     case 103: return 57374  // F11
     case 111: return 57375  // F12
     default:  return nil
+    }
+}
+
+// MARK: - Drag and drop
+
+extension EditorNSView {
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard sender.draggingPasteboard.canReadObject(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) else {
+            return []
+        }
+        showDropHighlight()
+        return .copy
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        hideDropHighlight()
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        hideDropHighlight()
+
+        guard let urls = sender.draggingPasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL], !urls.isEmpty else {
+            return false
+        }
+
+        for url in urls {
+            encoder.sendOpenFile(path: url.path)
+        }
+
+        claimFirstResponder()
+        return true
+    }
+
+    private func showDropHighlight() {
+        guard dropHighlightLayer == nil, let metalLayer = layer else { return }
+        let highlight = CAShapeLayer()
+        highlight.path = CGPath(
+            roundedRect: bounds.insetBy(dx: 2, dy: 2),
+            cornerWidth: 6,
+            cornerHeight: 6,
+            transform: nil
+        )
+        highlight.strokeColor = NSColor.controlAccentColor.cgColor
+        highlight.fillColor = NSColor.controlAccentColor.withAlphaComponent(0.08).cgColor
+        highlight.lineWidth = 3
+        metalLayer.addSublayer(highlight)
+        dropHighlightLayer = highlight
+    }
+
+    private func hideDropHighlight() {
+        dropHighlightLayer?.removeFromSuperlayer()
+        dropHighlightLayer = nil
     }
 }

--- a/test/minga_editor/drop_open_test.exs
+++ b/test/minga_editor/drop_open_test.exs
@@ -1,7 +1,8 @@
 defmodule MingaEditor.DropOpenTest do
   @moduledoc """
-  Tests for the gui_action {:open_file, path} handler's file-vs-directory branching,
-  exercised via drag-and-drop from Finder or the macOS Open With menu.
+  Tests for the gui_action {:open_file, path} handler's file-vs-directory
+  branching. This handler is triggered by drag-and-drop from Finder, the
+  macOS Open With menu, and `open -a Minga` from the terminal.
   """
 
   use Minga.Test.EditorCase, async: true
@@ -54,6 +55,7 @@ defmodule MingaEditor.DropOpenTest do
       state = editor_state(ctx)
 
       assert length(state.workspace.buffers.list) == initial_count
+      assert Minga.Buffer.Server.file_path(state.workspace.buffers.active) == path
     end
   end
 

--- a/test/minga_editor/drop_open_test.exs
+++ b/test/minga_editor/drop_open_test.exs
@@ -1,0 +1,75 @@
+defmodule MingaEditor.DropOpenTest do
+  @moduledoc """
+  Tests for the gui_action {:open_file, path} handler's file-vs-directory branching,
+  exercised via drag-and-drop from Finder or the macOS Open With menu.
+  """
+
+  use Minga.Test.EditorCase, async: true
+
+  describe "drop file" do
+    @tag :tmp_dir
+    test "opening a file via gui_action creates a new buffer", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "dropped.txt")
+      File.write!(path, "dropped content")
+
+      ctx = start_editor("initial")
+
+      send(ctx.editor, {:minga_input, {:gui_action, {:open_file, path}}})
+      state = editor_state(ctx)
+
+      assert length(state.workspace.buffers.list) == 2
+      assert Minga.Buffer.Server.file_path(state.workspace.buffers.active) == path
+    end
+
+    @tag :tmp_dir
+    test "opening multiple files via gui_action opens each, last one active", %{tmp_dir: tmp_dir} do
+      paths =
+        for i <- 1..3 do
+          p = Path.join(tmp_dir, "file#{i}.txt")
+          File.write!(p, "content #{i}")
+          p
+        end
+
+      ctx = start_editor("initial")
+
+      for path <- paths do
+        send(ctx.editor, {:minga_input, {:gui_action, {:open_file, path}}})
+      end
+
+      state = editor_state(ctx)
+
+      assert length(state.workspace.buffers.list) == 4
+      assert Minga.Buffer.Server.file_path(state.workspace.buffers.active) == List.last(paths)
+    end
+
+    @tag :tmp_dir
+    test "opening an already-open file switches to it without duplicating", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "existing.txt")
+      File.write!(path, "existing")
+
+      ctx = start_editor("existing", file_path: path)
+      initial_count = buffer_count(ctx)
+
+      send(ctx.editor, {:minga_input, {:gui_action, {:open_file, path}}})
+      state = editor_state(ctx)
+
+      assert length(state.workspace.buffers.list) == initial_count
+    end
+  end
+
+  describe "drop directory" do
+    @tag :tmp_dir
+    test "dropping a directory opens the file picker", %{tmp_dir: tmp_dir} do
+      subdir = Path.join(tmp_dir, "project")
+      File.mkdir_p!(subdir)
+      File.write!(Path.join(subdir, "main.ex"), "defmodule Main do\nend")
+
+      ctx = start_editor("initial")
+
+      send(ctx.editor, {:minga_input, {:gui_action, {:open_file, subdir}}})
+      state = editor_state(ctx)
+
+      assert {:picker, _payload} = state.shell_state.modal
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Register `EditorNSView` as an `NSDraggingDestination` for `.fileURL` types, enabling file drag-and-drop from Finder
- Dropped files are sent to BEAM via the existing `sendOpenFile` protocol opcode (no new opcodes needed)
- Directories switch the project root via `Project.switch/1` and open the file picker
- An accent-colored `CAShapeLayer` border overlay appears during drag hover and disappears on exit/drop
- First responder is reclaimed after the drop completes so the editor regains keyboard focus

Closes #560

## Test plan

- [x] 4 new Elixir tests in `drop_open_test.exs`: single file open, multi-file open, duplicate detection, directory picker
- [x] `mix test.llm` passes (8109 tests, 0 failures)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo` clean (no new warnings)
- [x] `mix dialyzer` passes
- [ ] Manual: drag single file from Finder onto editor window
- [ ] Manual: drag multiple files from Finder
- [ ] Manual: drag a directory from Finder
- [ ] Manual: verify accent border appears during hover
- [ ] Manual: verify keyboard input works after drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)