### PR TITLE
fix(macos): prevent indent guides from bleeding through text

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -865,13 +865,16 @@ This convention is enforced on the BEAM side: all new opcodes >= 0x90 must use t
 
 ### 0x91 — gui_indent_guides
 
-Sends indent guide column positions for one window. Each guide is a vertical line the frontend draws at the given character column. The active guide (containing the cursor) is identified so the frontend can highlight it.
+Sends indent guide column positions and per-line indent levels for one window. Each guide is a vertical line the frontend draws at the given character column. The active guide (containing the cursor) is identified so the frontend can highlight it. Per-line indent levels let the frontend draw guide segments only in leading whitespace, preventing guides from bleeding through text content.
 
 ```
-opcode(1=0x91) + payload_length(2) + window_id(2) + tab_width(1) + active_guide_col(2) + guide_count(1) + guide_cols...
+opcode(1=0x91) + payload_length(2) + window_id(2) + tab_width(1) + active_guide_col(2) + guide_count(1) + guide_cols... + line_count(2) + indent_levels...
 
 Per guide:
   col(2)
+
+Per line:
+  indent_level(1)
 ```
 
 Fields:
@@ -880,6 +883,10 @@ Fields:
 - `active_guide_col`: the character column of the active guide (0xFFFF = no active guide)
 - `guide_count`: number of guide columns that follow
 - `col`: character column offset from content start (not screen left). The frontend converts to pixel position using `col * cellWidth + gutterPixelWidth`
+- `line_count`: number of visible lines with indent level data that follow
+- `indent_level`: effective indent level for this visible line (0-255, capped). A guide at column `col` should only be drawn on a line whose `indent_level >= col / tab_width`. Blank lines inherit the indent level of the next non-blank line below them so guides span through blank lines
+
+The `line_count` + `indent_levels` section is optional for backward compatibility. If `payload_length` does not leave room for it after the guide columns, the frontend should fall back to drawing full-height guide columns (the pre-v0.4 behavior).
 
 The BEAM sends this per frame as part of the atomic Metal command batch. Guides are gated by the `indent_guides` config option (default `true`). When disabled, no opcode is sent.
 

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -884,7 +884,7 @@ Fields:
 - `guide_count`: number of guide columns that follow
 - `col`: character column offset from content start (not screen left). The frontend converts to pixel position using `col * cellWidth + gutterPixelWidth`
 - `line_count`: number of visible lines with indent level data that follow
-- `indent_level`: effective indent level for this visible line (0-255, capped). A guide at column `col` should only be drawn on a line whose `indent_level >= col / tab_width`. Blank lines inherit the indent level of the next non-blank line below them so guides span through blank lines
+- `indent_level`: effective indent level for this visible line (0-255, capped). A guide at column `col` should only be drawn on a line whose `indent_level > col / tab_width` (strict greater-than, so guides appear only in whitespace, not at the text-start column). Blank lines inherit the indent level of the next non-blank line below them so guides span through blank lines
 
 The `line_count` + `indent_levels` section is optional for backward compatibility. If `payload_length` does not leave room for it after the guide columns, the frontend should fall back to drawing full-height guide columns (the pre-v0.4 behavior).
 

--- a/lib/minga/core/indent_guide.ex
+++ b/lib/minga/core/indent_guide.ex
@@ -47,18 +47,35 @@ defmodule Minga.Core.IndentGuide do
   def compute(lines, tab_width, cursor_col)
       when is_list(lines) and is_integer(tab_width) and tab_width > 0 and
              is_integer(cursor_col) and cursor_col >= 0 do
-    # Compute the effective indentation level of each line, propagating
-    # through blank lines by looking ahead to the next non-blank line.
+    {guides, _levels} = compute_with_levels(lines, tab_width, cursor_col)
+    guides
+  end
+
+  @doc """
+  Like `compute/3` but also returns the per-line effective indent levels.
+
+  Returns `{guides, indent_levels}` where `indent_levels` has one entry
+  per input line. Use this when the caller needs both guide columns and
+  per-line indentation (e.g. to send over the wire for per-line rendering).
+  """
+  @spec compute_with_levels(
+          lines :: [String.t()],
+          tab_width :: pos_integer(),
+          cursor_col :: non_neg_integer()
+        ) ::
+          {[guide()], [non_neg_integer()]}
+  def compute_with_levels(lines, tab_width, cursor_col)
+      when is_list(lines) and is_integer(tab_width) and tab_width > 0 and
+             is_integer(cursor_col) and cursor_col >= 0 do
     indent_levels = effective_indent_levels(lines, tab_width)
 
-    # Find the maximum indentation level across all visible lines.
     max_level =
       case indent_levels do
         [] -> 0
         levels -> Enum.max(levels)
       end
 
-    build_guides(indent_levels, max_level, tab_width, cursor_col)
+    {build_guides(indent_levels, max_level, tab_width, cursor_col), indent_levels}
   end
 
   @doc """

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -1508,15 +1508,20 @@ defmodule MingaEditor.Frontend.Emit.GUI do
         :exit, _ -> []
       end
 
-    guides = Minga.Core.IndentGuide.compute(lines, tab_width, cursor_col)
-    encode_guides(guides, win_id, tab_width)
+    {guides, indent_levels} = Minga.Core.IndentGuide.compute_with_levels(lines, tab_width, cursor_col)
+    encode_guides(guides, win_id, tab_width, indent_levels)
   end
 
-  @spec encode_guides([Minga.Core.IndentGuide.guide()], pos_integer(), pos_integer()) ::
+  @spec encode_guides(
+          [Minga.Core.IndentGuide.guide()],
+          pos_integer(),
+          pos_integer(),
+          [non_neg_integer()]
+        ) ::
           [binary()]
-  defp encode_guides([], win_id, _tab_width), do: return_empty_guides(win_id)
+  defp encode_guides([], win_id, _tab_width, _indent_levels), do: return_empty_guides(win_id)
 
-  defp encode_guides(guides, win_id, tab_width) do
+  defp encode_guides(guides, win_id, tab_width, indent_levels) do
     active_guide = Enum.find(guides, fn g -> g.active end)
     active_col = if active_guide, do: active_guide.col, else: 0xFFFF
 
@@ -1524,7 +1529,8 @@ defmodule MingaEditor.Frontend.Emit.GUI do
       window_id: win_id,
       tab_width: tab_width,
       active_guide_col: active_col,
-      guide_cols: Enum.map(guides, & &1.col)
+      guide_cols: Enum.map(guides, & &1.col),
+      line_indent_levels: indent_levels
     }
 
     [ProtocolGUI.encode_gui_indent_guides(guide_data)]

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -1508,7 +1508,9 @@ defmodule MingaEditor.Frontend.Emit.GUI do
         :exit, _ -> []
       end
 
-    {guides, indent_levels} = Minga.Core.IndentGuide.compute_with_levels(lines, tab_width, cursor_col)
+    {guides, indent_levels} =
+      Minga.Core.IndentGuide.compute_with_levels(lines, tab_width, cursor_col)
+
     encode_guides(guides, win_id, tab_width, indent_levels)
   end
 

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -912,32 +912,39 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
           window_id: non_neg_integer(),
           tab_width: pos_integer(),
           active_guide_col: non_neg_integer(),
-          guide_cols: [non_neg_integer()]
+          guide_cols: [non_neg_integer()],
+          line_indent_levels: [non_neg_integer()]
         }
 
   @doc """
   Encodes a gui_indent_guides command for one window.
 
   Uses the forward-compatible 0x90+ format: opcode(1) + payload_length(2) + payload.
-  Payload: window_id(2) + tab_width(1) + active_guide_col(2) + guide_count(1) + guide_cols(2 each).
+  Payload: window_id(2) + tab_width(1) + active_guide_col(2) + guide_count(1) + guide_cols(2 each)
+           + line_count(2) + indent_levels(1 each).
 
   `active_guide_col` of 0xFFFF means no active guide. Guide columns are
   character-unit offsets from the content start (not screen left).
+  `line_indent_levels` gives the effective indent level per visible line so the
+  frontend can draw guide segments only in whitespace, not through text.
   """
   @spec encode_gui_indent_guides(indent_guide_data()) :: binary()
   def encode_gui_indent_guides(%{
         window_id: win_id,
         tab_width: tab_width,
         active_guide_col: active_col,
-        guide_cols: cols
+        guide_cols: cols,
+        line_indent_levels: levels
       }) do
     guide_count = length(cols)
     guide_bytes = for col <- cols, into: <<>>, do: <<col::16>>
-    # 2 (win_id) + 1 (tab_width) + 2 (active_col) + 1 (guide_count) + 2*guide_count
-    payload_len = 6 + 2 * guide_count
+    line_count = length(levels)
+    level_bytes = for lvl <- levels, into: <<>>, do: <<min(lvl, 255)::8>>
+    # 2 (win_id) + 1 (tab_width) + 2 (active_col) + 1 (guide_count) + 2*guide_count + 2 (line_count) + line_count
+    payload_len = 6 + 2 * guide_count + 2 + line_count
 
     <<@op_gui_indent_guides, payload_len::16, win_id::16, tab_width::8, active_col::16,
-      guide_count::8, guide_bytes::binary>>
+      guide_count::8, guide_bytes::binary, line_count::16, level_bytes::binary>>
   end
 
   @doc """

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -940,6 +940,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     guide_bytes = for col <- cols, into: <<>>, do: <<col::16>>
     line_count = length(levels)
     level_bytes = for lvl <- levels, into: <<>>, do: <<min(lvl, 255)::8>>
+
     # 2 (win_id) + 1 (tab_width) + 2 (active_col) + 1 (guide_count) + 2*guide_count + 2 (line_count) + line_count
     payload_len = 6 + 2 * guide_count + 2 + line_count
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -1944,8 +1944,21 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             igCols.append(readU16(data, igPos))
             igPos += 2
         }
+        var igLineLevels: [UInt8] = []
+        let igEnd = rest + 2 + igPayloadLen
+        if igPos + 2 <= igEnd {
+            let igLineCount = Int(readU16(data, igPos))
+            igPos += 2
+            igLineLevels.reserveCapacity(igLineCount)
+            for _ in 0..<igLineCount {
+                guard igPos < igEnd else { break }
+                igLineLevels.append(data[igPos])
+                igPos += 1
+            }
+        }
         let igData = IndentGuideData(windowId: igWinId, tabWidth: igTabWidth,
-                                     activeGuideCol: igActiveCol, guideCols: igCols)
+                                     activeGuideCol: igActiveCol, guideCols: igCols,
+                                     lineIndentLevels: igLineLevels)
         return (.guiIndentGuides(data: igData), 1 + 2 + igPayloadLen)
 
     case OP_GUI_LINE_SPACING:

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -383,4 +383,6 @@ struct IndentGuideData: Sendable {
     let activeGuideCol: UInt16
     /// Character columns where guides appear (content-relative, not screen-relative).
     let guideCols: [UInt16]
+    /// Per visible line indent level. Empty if the sender omitted per-line data (legacy); renderer falls back to full-height guides.
+    let lineIndentLevels: [UInt8]
 }

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -564,39 +564,70 @@ final class CoreTextMetalRenderer {
 
         // Pass 1.25: Indent guides (vertical lines at indentation levels).
         // Drawn after bg fills but before text, cursor, and selection overlays.
+        // When per-line indent levels are available, draw segments only in
+        // leading whitespace so guides don't bleed through text content.
         for (_, guideData) in frameState.windowIndentGuides {
             guard !guideData.guideCols.isEmpty else { continue }
 
-            // Find the window gutter to get the content offset for this window.
             guard let gutter = frameState.windowGutters[guideData.windowId] else { continue }
             let gutterWidth = Float(gutter.lineNumberWidth) + Float(gutter.signColWidth)
             let windowContentColOffset = (Float(gutter.contentCol) + gutterWidth) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
             let contentTopY = Float(gutter.contentRow) * cellH * scale
-            let contentHeightPx = Float(gutter.contentHeight) * cellH * scale
+            let lineCellH = cellH * scale
+
+            let inactiveFg = colorFromU24(frameState.gutterColors.fg, default: SIMD3<Float>(0.33, 0.33, 0.33))
+            let tabW = max(UInt16(guideData.tabWidth), 1)
 
             var guideQuads: [QuadGPU] = []
-            guideQuads.reserveCapacity(guideData.guideCols.count)
 
-            // Default foreground color from theme, at low alpha.
-            let inactiveFg = colorFromU24(frameState.gutterColors.fg, default: SIMD3<Float>(0.33, 0.33, 0.33))
-
-            for col in guideData.guideCols {
-                let guideX = windowContentColOffset + Float(col) * cellW * scale
-                let isActive = col == guideData.activeGuideCol
-
-                var quad = QuadGPU()
-                quad.position = SIMD2<Float>(guideX, contentTopY)
-                quad.size = SIMD2<Float>(1.0 * scale, contentHeightPx)
-                quad.color = inactiveFg
-                quad.alpha = isActive ? 0.4 : 0.15
-                guideQuads.append(quad)
+            if guideData.lineIndentLevels.isEmpty {
+                let contentHeightPx = Float(gutter.contentHeight) * cellH * scale
+                guideQuads.reserveCapacity(guideData.guideCols.count)
+                for col in guideData.guideCols {
+                    let guideX = windowContentColOffset + Float(col) * cellW * scale
+                    let isActive = col == guideData.activeGuideCol
+                    var quad = QuadGPU()
+                    quad.position = SIMD2<Float>(guideX, contentTopY)
+                    quad.size = SIMD2<Float>(1.0 * scale, contentHeightPx)
+                    quad.color = inactiveFg
+                    quad.alpha = isActive ? 0.4 : 0.15
+                    guideQuads.append(quad)
+                }
+            } else {
+                guideQuads.reserveCapacity(guideData.guideCols.count * guideData.lineIndentLevels.count)
+                for (lineIdx, level) in guideData.lineIndentLevels.enumerated() {
+                    let lineY = contentTopY + Float(lineIdx) * lineCellH
+                    for col in guideData.guideCols {
+                        let guideLevel = col / tabW
+                        // Strict < so guides appear only in whitespace, not at the text-start column.
+                        guard guideLevel < level else { continue }
+                        let guideX = windowContentColOffset + Float(col) * cellW * scale
+                        let isActive = col == guideData.activeGuideCol
+                        var quad = QuadGPU()
+                        quad.position = SIMD2<Float>(guideX, lineY)
+                        quad.size = SIMD2<Float>(1.0 * scale, lineCellH)
+                        quad.color = inactiveFg
+                        quad.alpha = isActive ? 0.4 : 0.15
+                        guideQuads.append(quad)
+                    }
+                }
             }
 
             if !guideQuads.isEmpty {
                 encoder.setRenderPipelineState(bgPipeline)
-                encoder.setVertexBytes(&guideQuads, length: guideQuads.count * MemoryLayout<QuadGPU>.stride, index: 0)
-                encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
-                encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: guideQuads.count)
+                // setVertexBytes is capped at 4 KB of inline data by Metal.
+                let maxPerBatch = 4096 / MemoryLayout<QuadGPU>.stride
+                var batchStart = 0
+                while batchStart < guideQuads.count {
+                    let batchCount = min(guideQuads.count - batchStart, maxPerBatch)
+                    guideQuads.withUnsafeMutableBufferPointer { ptr in
+                        let base = ptr.baseAddress! + batchStart
+                        encoder.setVertexBytes(base, length: batchCount * MemoryLayout<QuadGPU>.stride, index: 0)
+                    }
+                    encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+                    encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: batchCount)
+                    batchStart += batchCount
+                }
             }
         }
 

--- a/test/minga/core/indent_guide_test.exs
+++ b/test/minga/core/indent_guide_test.exs
@@ -83,6 +83,23 @@ defmodule Minga.Core.IndentGuideTest do
 
   # ── compute/3 ──
 
+  describe "compute_with_levels/3" do
+    test "returns same guides as compute/3 and levels with one entry per line" do
+      lines = ["def foo", "  bar", "", "  baz", "end"]
+      {guides, levels} = IndentGuide.compute_with_levels(lines, @tw, 2)
+
+      assert guides == IndentGuide.compute(lines, @tw, 2)
+      assert length(levels) == length(lines)
+    end
+
+    test "empty input returns empty guides and empty levels" do
+      {guides, levels} = IndentGuide.compute_with_levels([], @tw, 0)
+
+      assert guides == []
+      assert levels == []
+    end
+  end
+
   describe "compute/3" do
     test "flat code produces no guides" do
       assert IndentGuide.compute(["a", "b", "c"], @tw, 0) == []

--- a/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
+++ b/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
@@ -266,8 +266,8 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
 
       binary = ProtocolGUI.encode_gui_indent_guides(data)
 
-      <<0x91, _len::16, _win::16, _tw::8, _active::16, _count::8, _col::16,
-        line_count::16, levels::binary>> = binary
+      <<0x91, _len::16, _win::16, _tw::8, _active::16, _count::8, _col::16, line_count::16,
+        levels::binary>> = binary
 
       assert line_count == 4
       assert levels == <<255, 0, 255, 255>>

--- a/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
+++ b/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
@@ -194,12 +194,12 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
         window_id: 1,
         tab_width: 2,
         active_guide_col: 4,
-        guide_cols: [2, 4]
+        guide_cols: [2, 4],
+        line_indent_levels: [1, 2, 2, 1, 0]
       }
 
       binary = ProtocolGUI.encode_gui_indent_guides(data)
 
-      # 0x91 opcode, payload_len, window_id, tab_width, active_col, guide_count, cols
       <<0x91, payload_len::16, win_id::16, tw::8, active_col::16, count::8, rest::binary>> =
         binary
 
@@ -207,11 +207,14 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
       assert tw == 2
       assert active_col == 4
       assert count == 2
-      assert payload_len == 6 + 2 * 2
+      # 6 (header) + 2*2 (guide cols) + 2 (line_count) + 5 (levels)
+      assert payload_len == 6 + 2 * 2 + 2 + 5
 
-      <<col1::16, col2::16>> = rest
+      <<col1::16, col2::16, line_count::16, levels::binary>> = rest
       assert col1 == 2
       assert col2 == 4
+      assert line_count == 5
+      assert levels == <<1, 2, 2, 1, 0>>
     end
 
     test "encodes empty guide list" do
@@ -232,18 +235,42 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
         window_id: 2,
         tab_width: 4,
         active_guide_col: 8,
-        guide_cols: cols
+        guide_cols: cols,
+        line_indent_levels: [2, 4, 4, 3, 1]
       }
 
       binary = ProtocolGUI.encode_gui_indent_guides(data)
 
-      <<0x91, _len::16, _win::16, _tw::8, _active::16, count::8, col_data::binary>> = binary
+      <<0x91, _len::16, _win::16, _tw::8, _active::16, count::8, rest::binary>> = binary
+
+      col_bytes_len = count * 2
+      <<col_data::binary-size(col_bytes_len), line_count::16, levels::binary>> = rest
 
       decoded_cols =
         for <<col::16 <- col_data>>, do: col
 
       assert count == 4
       assert decoded_cols == cols
+      assert line_count == 5
+      assert levels == <<2, 4, 4, 3, 1>>
+    end
+
+    test "indent levels above 255 are clamped to fit uint8 wire format" do
+      data = %{
+        window_id: 1,
+        tab_width: 2,
+        active_guide_col: 0xFFFF,
+        guide_cols: [2],
+        line_indent_levels: [300, 0, 256, 255]
+      }
+
+      binary = ProtocolGUI.encode_gui_indent_guides(data)
+
+      <<0x91, _len::16, _win::16, _tw::8, _active::16, _count::8, _col::16,
+        line_count::16, levels::binary>> = binary
+
+      assert line_count == 4
+      assert levels == <<255, 0, 255, 255>>
     end
   end
 


### PR DESCRIPTION
## Summary

- Indent guides were rendered as full-height vertical quads that showed through text content because line textures have transparent backgrounds. Extended the 0x91 protocol message to include per-line indent levels so the Metal renderer draws guide segments only in leading whitespace.
- Added `compute_with_levels/3` to `IndentGuide` to avoid computing indent levels twice per frame.
- Added Metal `setVertexBytes` batching (4KB limit) since per-line segments can exceed 128 quads on deeply nested files.

## Test plan

- [x] All 8106 Elixir tests pass (`mix test.llm`)
- [x] Swift/Xcode build succeeds
- [x] New test for uint8 clamping boundary (values > 255)
- [x] Protocol docs updated (`docs/GUI_PROTOCOL.md`)
- [ ] Visual verification: open a deeply nested file and confirm guides appear only in whitespace, not through text glyphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)