### PR TITLE
fix(agent): tighten remote session follow-ups

### DIFF
--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -164,7 +164,9 @@ defmodule Minga.Application do
   defp standalone_headless? do
     Minga.CLI.headless_args?(Burrito.Util.Args.argv())
   rescue
-    _ -> false
+    error ->
+      Minga.Log.debug(:editor, "Could not inspect standalone CLI args: #{inspect(error)}")
+      false
   end
 
   @spec prune_old_sessions() :: :ok

--- a/lib/minga/cli.ex
+++ b/lib/minga/cli.ex
@@ -225,11 +225,12 @@ defmodule Minga.CLI do
 
   @spec launch(flags(), String.t() | nil) :: :ok
   defp launch(%{headless: true} = flags, _file) do
-    port = gateway_port(flags)
     auth_token = gateway_auth_token()
 
-    case gateway_ip(flags) do
-      {:ok, ip} -> start_headless_gateway(port, ip, auth_token)
+    with {:ok, port} <- gateway_port(flags),
+         {:ok, ip} <- gateway_ip(flags) do
+      start_headless_gateway(port, ip, auth_token)
+    else
       {:error, message} -> abort_startup(message)
     end
   end
@@ -281,18 +282,19 @@ defmodule Minga.CLI do
   defp ensure_distribution_started(role, flags) do
     name = distribution_node_name(role, flags)
     mode = if flags.short_name, do: :shortnames, else: :longnames
-    cookie = explicit_cookie(flags)
 
-    case start_node_if_needed(name, mode) do
-      :ok ->
-        set_cookie_and_log(cookie, :ok, name)
+    with {:ok, cookie} <- distribution_cookie(flags) do
+      case start_node_if_needed(name, mode) do
+        :ok ->
+          set_cookie_and_log(cookie, :ok, name)
 
-      {:ok, _pid} = result ->
-        set_cookie_and_log(cookie, result, name)
+        {:ok, _pid} = result ->
+          set_cookie_and_log(cookie, result, name)
 
-      {:error, reason} = result ->
-        log_distribution_result(result, name)
-        {:error, inspect(reason)}
+        {:error, reason} = result ->
+          log_distribution_result(result, name)
+          {:error, inspect(reason)}
+      end
     end
   end
 
@@ -314,20 +316,23 @@ defmodule Minga.CLI do
   end
 
   @spec hostname(boolean()) :: String.t()
-  defp hostname(true) do
+  defp hostname(short_name?) do
     {:ok, name} = :inet.gethostname()
-    name |> List.to_string() |> String.split(".") |> hd()
+    format_hostname(name, short_name?)
+  rescue
+    error in MatchError ->
+      abort_startup("Failed to resolve local hostname: #{inspect(error.term)}")
   end
 
-  defp hostname(false) do
-    {:ok, name} = :inet.gethostname()
-    List.to_string(name)
-  end
+  @spec format_hostname(charlist(), boolean()) :: String.t()
+  defp format_hostname(name, true), do: name |> List.to_string() |> String.split(".") |> hd()
+  defp format_hostname(name, false), do: List.to_string(name)
 
-  @spec explicit_cookie(flags()) :: String.t() | nil
-  defp explicit_cookie(%{cookie_file: path}) when is_binary(path), do: read_cookie_file(path)
-  defp explicit_cookie(%{cookie: cookie}) when is_binary(cookie), do: cookie
-  defp explicit_cookie(_flags), do: System.get_env("MINGA_COOKIE")
+  @doc false
+  @spec distribution_cookie(flags()) :: {:ok, String.t() | nil} | {:error, String.t()}
+  def distribution_cookie(%{cookie_file: path}) when is_binary(path), do: read_cookie_file(path)
+  def distribution_cookie(%{cookie: cookie}) when is_binary(cookie), do: {:ok, cookie}
+  def distribution_cookie(_flags), do: {:ok, System.get_env("MINGA_COOKIE")}
 
   @spec set_cookie_if_present(String.t() | nil) :: :ok | {:error, String.t()}
   defp set_cookie_if_present(nil), do: :ok
@@ -353,19 +358,14 @@ defmodule Minga.CLI do
     end
   end
 
-  @spec read_cookie_file(String.t()) :: String.t() | nil
+  @spec read_cookie_file(String.t()) :: {:ok, String.t()} | {:error, String.t()}
   defp read_cookie_file(path) do
     case Cookie.read_file(path) do
       {:ok, cookie} ->
-        cookie
+        {:ok, cookie}
 
       {:error, reason} ->
-        Minga.Log.warning(
-          :distribution,
-          "Ignoring Erlang cookie file #{path}: #{inspect(reason)}"
-        )
-
-        nil
+        {:error, "Failed to read Erlang cookie file #{path}: #{inspect(reason)}"}
     end
   end
 
@@ -385,12 +385,13 @@ defmodule Minga.CLI do
     )
   end
 
-  @spec gateway_port(flags()) :: pos_integer()
-  defp gateway_port(%{gateway_port: port}) when is_integer(port), do: port
+  @doc false
+  @spec gateway_port(flags()) :: {:ok, pos_integer()} | {:error, String.t()}
+  def gateway_port(%{gateway_port: port}) when is_integer(port), do: {:ok, port}
 
-  defp gateway_port(_flags) do
+  def gateway_port(_flags) do
     case System.get_env("MINGA_GATEWAY_PORT") do
-      nil -> @default_gateway_port
+      nil -> {:ok, @default_gateway_port}
       value -> env_gateway_port(value)
     end
   end
@@ -424,11 +425,11 @@ defmodule Minga.CLI do
   @spec gateway_auth_token() :: String.t() | nil
   defp gateway_auth_token, do: System.get_env("MINGA_GATEWAY_TOKEN")
 
-  @spec env_gateway_port(String.t()) :: pos_integer()
+  @spec env_gateway_port(String.t()) :: {:ok, pos_integer()} | {:error, String.t()}
   defp env_gateway_port(value) do
     case parse_port(value) do
-      {:ok, port} -> port
-      :error -> @default_gateway_port
+      {:ok, port} -> {:ok, port}
+      :error -> {:error, "MINGA_GATEWAY_PORT must be a TCP port between 1 and 65535"}
     end
   end
 
@@ -516,6 +517,7 @@ defmodule Minga.CLI do
 
   @spec editor_wait_params() :: {non_neg_integer(), non_neg_integer()}
   defp editor_wait_params do
+    # Tests can override the polling interval and retry count; production waits up to one second by default.
     Application.get_env(:minga, :editor_wait_params, {50, 20})
   end
 

--- a/lib/minga/distribution/config.ex
+++ b/lib/minga/distribution/config.ex
@@ -66,7 +66,9 @@ defmodule Minga.Distribution.Config do
       normalized = %{name: name, node: node, cookie: cookie}
       {:cont, {:ok, [normalized | entries]}}
     else
-      {:halt, {:error, "invalid server entry: cookie must be at least 32 characters"}}
+      {:halt,
+       {:error,
+        "invalid server entry: cookie must be at least 32 bytes and contain only letters, numbers, dot, underscore, at, or hyphen"}}
     end
   end
 

--- a/lib/minga/distribution/connection_manager.ex
+++ b/lib/minga/distribution/connection_manager.ex
@@ -11,8 +11,11 @@ defmodule Minga.Distribution.ConnectionManager do
   alias Minga.Distribution.Events.NodeConnectedEvent
   alias Minga.Distribution.Events.NodeDisconnectedEvent
 
-  @type connection_status :: :connected | :disconnected
-  @type connected_node :: {String.t(), node(), connection_status()}
+  @type public_connection_status :: :connected | :disconnected
+  @type connected_node :: {String.t(), node(), public_connection_status()}
+  @type connect_fun :: (node() -> boolean() | :ignored)
+  @type monitor_fun :: (node(), boolean() -> term())
+  @type set_cookie_fun :: (node(), atom() -> term())
   @type server_state :: %{
           node: node(),
           cookie: atom(),
@@ -25,7 +28,10 @@ defmodule Minga.Distribution.ConnectionManager do
   @type state :: %{
           servers: %{String.t() => server_state()},
           node_to_server: %{node() => String.t()},
-          events_registry: Minga.Events.registry()
+          events_registry: Minga.Events.registry(),
+          connect_fun: connect_fun(),
+          monitor_fun: monitor_fun(),
+          set_cookie_fun: set_cookie_fun()
         }
 
   @doc "Starts the connection manager."
@@ -38,7 +44,7 @@ defmodule Minga.Distribution.ConnectionManager do
     end
   end
 
-  @doc "Returns every configured remote node with its current connection status."
+  @doc "Returns every configured remote node with its public connection status. In-progress reconnect attempts are reported as disconnected."
   @spec connected_nodes() :: [connected_node()]
   def connected_nodes do
     call_or_default(:connected_nodes, [])
@@ -62,7 +68,7 @@ defmodule Minga.Distribution.ConnectionManager do
     call_or_default({:connected?, server_name}, false)
   end
 
-  @doc "Returns the exponential backoff delay for a retry count."
+  @doc "Returns the retry delay for `retry_count`, starting at 1s and doubling until the 30s cap."
   @spec backoff_ms(non_neg_integer()) :: pos_integer()
   def backoff_ms(retry_count) when is_integer(retry_count) and retry_count >= 0 do
     min(1_000 * Integer.pow(2, retry_count), 30_000)
@@ -74,7 +80,13 @@ defmodule Minga.Distribution.ConnectionManager do
     servers = Keyword.get_lazy(opts, :servers, fn -> load_servers(opts) end)
 
     state =
-      new_state(servers, Keyword.get(opts, :events_registry, Minga.Events.default_registry()))
+      new_state(
+        servers,
+        Keyword.get(opts, :events_registry, Minga.Events.default_registry()),
+        Keyword.get(opts, :connect_fun, &Node.connect/1),
+        Keyword.get(opts, :monitor_fun, &Node.monitor/2),
+        Keyword.get(opts, :set_cookie_fun, &Node.set_cookie/2)
+      )
 
     if map_size(state.servers) > 0 and Keyword.get(opts, :connect_on_init, true) do
       send(self(), :connect_all)
@@ -142,8 +154,14 @@ defmodule Minga.Distribution.ConnectionManager do
     end
   end
 
-  @spec new_state([Config.server_entry()], Minga.Events.registry()) :: state()
-  defp new_state(entries, events_registry) do
+  @spec new_state(
+          [Config.server_entry()],
+          Minga.Events.registry(),
+          connect_fun(),
+          monitor_fun(),
+          set_cookie_fun()
+        ) :: state()
+  defp new_state(entries, events_registry, connect_fun, monitor_fun, set_cookie_fun) do
     servers =
       Map.new(entries, fn %{name: name, node: node, cookie: cookie} ->
         {name,
@@ -159,10 +177,18 @@ defmodule Minga.Distribution.ConnectionManager do
       end)
 
     node_to_server = Map.new(entries, fn %{name: name, node: node} -> {node, name} end)
-    %{servers: servers, node_to_server: node_to_server, events_registry: events_registry}
+
+    %{
+      servers: servers,
+      node_to_server: node_to_server,
+      events_registry: events_registry,
+      connect_fun: connect_fun,
+      monitor_fun: monitor_fun,
+      set_cookie_fun: set_cookie_fun
+    }
   end
 
-  @spec public_status(:connected | :disconnected | :connecting) :: connection_status()
+  @spec public_status(:connected | :disconnected | :connecting) :: public_connection_status()
   defp public_status(:connected), do: :connected
   defp public_status(_status), do: :disconnected
 
@@ -211,9 +237,9 @@ defmodule Minga.Distribution.ConnectionManager do
   @spec attempt_connect(state(), String.t(), server_state()) :: state()
   defp attempt_connect(state, server_name, server) do
     state = put_server(state, server_name, server)
-    Node.set_cookie(server.node, server.cookie)
+    state.set_cookie_fun.(server.node, server.cookie)
 
-    case Node.connect(server.node) do
+    case state.connect_fun.(server.node) do
       true -> mark_connected(state, server_name, server)
       false -> schedule_retry(state, server_name, server)
       :ignored -> schedule_retry(state, server_name, server)
@@ -227,7 +253,7 @@ defmodule Minga.Distribution.ConnectionManager do
 
   @spec mark_connected(state(), String.t(), server_state()) :: state()
   defp mark_connected(state, server_name, server) do
-    monitor_node(server.node, server.monitored?)
+    monitor_node(state, server.node, server.monitored?)
     connected_at = DateTime.utc_now()
 
     server = %{
@@ -254,15 +280,20 @@ defmodule Minga.Distribution.ConnectionManager do
     put_server(state, server_name, server)
   end
 
-  @spec monitor_node(node(), boolean()) :: :ok
-  defp monitor_node(_node, true), do: :ok
+  @spec monitor_node(state(), node(), boolean()) :: :ok
+  defp monitor_node(_state, _node, true), do: :ok
 
-  defp monitor_node(node, false) do
-    Node.monitor(node, true)
+  defp monitor_node(state, node, false) do
+    state.monitor_fun.(node, true)
     :ok
   end
 
   @spec schedule_retry(state(), String.t(), server_state()) :: state()
+  defp schedule_retry(state, server_name, %{retry_timer: timer} = server)
+       when is_reference(timer) do
+    put_server(state, server_name, %{server | status: :disconnected})
+  end
+
   defp schedule_retry(state, server_name, server) do
     delay = backoff_ms(server.retry_count)
     timer = Process.send_after(self(), {:reconnect, server_name}, delay)

--- a/lib/minga/distribution/cookie.ex
+++ b/lib/minga/distribution/cookie.ex
@@ -6,7 +6,7 @@ defmodule Minga.Distribution.Cookie do
   @doc "Reads a cookie from a regular 0600-style file."
   @spec read_file(String.t()) :: {:ok, String.t()} | {:error, term()}
   def read_file(path) when is_binary(path) do
-    with {:ok, %File.Stat{type: :regular, mode: mode}} <- File.stat(path),
+    with {:ok, %File.Stat{type: :regular, mode: mode}} <- File.lstat(path),
          :ok <- validate_mode(mode),
          {:ok, content} <- File.read(path) do
       {:ok, String.trim(content)}

--- a/lib/minga/distribution/file.ex
+++ b/lib/minga/distribution/file.ex
@@ -7,7 +7,7 @@ defmodule Minga.Distribution.File do
   @default_max_files 5_000
   @default_max_depth 12
 
-  @type listing_acc :: %{files: [String.t()], truncated?: boolean()}
+  @type listing_acc :: %{files: [String.t()], count: non_neg_integer(), truncated?: boolean()}
   @type listing_limits :: %{max_files: pos_integer(), max_depth: non_neg_integer()}
 
   @doc "Reads a file from a remote node. Files larger than the configured cap are rejected."
@@ -62,7 +62,7 @@ defmodule Minga.Distribution.File do
 
     if File.dir?(expanded) do
       limits = %{max_files: max_files, max_depth: max_depth}
-      acc = collect_files(expanded, 0, limits, %{files: [], truncated?: false})
+      acc = collect_files(expanded, 0, limits, %{files: [], count: 0, truncated?: false})
       {:ok, Enum.sort(acc.files)}
     else
       {:error, :enoent}
@@ -143,10 +143,10 @@ defmodule Minga.Distribution.File do
 
   @spec add_file(String.t(), listing_limits(), listing_acc()) :: listing_acc()
   defp add_file(path, %{max_files: max_files}, acc) do
-    if length(acc.files) >= max_files do
+    if acc.count >= max_files do
       %{acc | truncated?: true}
     else
-      %{acc | files: [path | acc.files]}
+      %{acc | files: [path | acc.files], count: acc.count + 1}
     end
   end
 end

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -43,7 +43,7 @@ defmodule Minga.Events do
   | `:face_overrides_changed` | `FaceOverridesChangedEvent` | `buffer: pid(), overrides: map()` |
   | `:background_subagent_started` | `MingaAgent.Subagent.Handle` | `session_id: String.t(), pid: pid(), task: String.t()` |
   | `:node_connected` | `Minga.Distribution.Events.NodeConnectedEvent` | `server_name, node, connected_at` |
-  | `:node_disconnected` | `Minga.Distribution.Events.NodeDisconnectedEvent` | `server_name, node, reason` |
+  | `:node_disconnected` | `Minga.Distribution.Events.NodeDisconnectedEvent` | `server_name, node, reason, disconnected_at` |
 
   ## Why Registry?
 

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -1017,7 +1017,7 @@ defmodule MingaEditor do
     end
   end
 
-  @spec discover_remote_sessions(node(), String.t()) :: [Remote.session_entry()]
+  @spec discover_remote_sessions(node(), String.t()) :: [Remote.remote_session_entry()]
   defp discover_remote_sessions(remote_node, server_name) do
     :erpc.call(remote_node, MingaAgent.SessionManager, :list_sessions, [], 5_000)
   catch

--- a/lib/minga_editor/state/remote.ex
+++ b/lib/minga_editor/state/remote.ex
@@ -1,14 +1,15 @@
 defmodule MingaEditor.State.Remote do
   @moduledoc "State for remote agent sessions and read-only remote file buffers."
 
+  @typedoc "Remote session metadata is normally `MingaAgent.SessionMetadata.t()`. The map fallback keeps compatibility with older remote nodes that may return decoded persisted metadata before both nodes share the exact struct module version."
   @type session_metadata :: MingaAgent.SessionMetadata.t() | map()
-  @type session_entry :: {String.t(), pid(), session_metadata()}
-  @type connection_status :: :connected | :disconnected | :ended | :unavailable
+  @type remote_session_entry :: {String.t(), pid(), session_metadata()}
+  @type remote_connection_status :: :connected | :disconnected | :ended | :unavailable
   @type remote_file_key :: {String.t(), String.t()}
 
   @type t :: %__MODULE__{
-          sessions: %{String.t() => [session_entry()]},
-          server_status: %{String.t() => connection_status()},
+          sessions: %{String.t() => [remote_session_entry()]},
+          server_status: %{String.t() => remote_connection_status()},
           buffers: %{remote_file_key() => pid()}
         }
 
@@ -17,25 +18,25 @@ defmodule MingaEditor.State.Remote do
             buffers: %{}
 
   @doc "Stores the latest discovered remote sessions for a server."
-  @spec put_sessions(t(), String.t(), [session_entry()]) :: t()
+  @spec put_sessions(t(), String.t(), [remote_session_entry()]) :: t()
   def put_sessions(%__MODULE__{} = remote, server_name, sessions)
       when is_binary(server_name) and is_list(sessions) do
     %{remote | sessions: Map.put(remote.sessions, server_name, sessions)}
   end
 
   @doc "Returns all discovered remote sessions grouped by server name."
-  @spec sessions(t()) :: %{String.t() => [session_entry()]}
+  @spec sessions(t()) :: %{String.t() => [remote_session_entry()]}
   def sessions(%__MODULE__{} = remote), do: remote.sessions
 
   @doc "Marks a server's connection status."
-  @spec put_server_status(t(), String.t(), connection_status()) :: t()
+  @spec put_server_status(t(), String.t(), remote_connection_status()) :: t()
   def put_server_status(%__MODULE__{} = remote, server_name, status)
       when is_binary(server_name) and status in [:connected, :disconnected, :ended, :unavailable] do
     %{remote | server_status: Map.put(remote.server_status, server_name, status)}
   end
 
   @doc "Returns a server's known connection status."
-  @spec server_status(t(), String.t()) :: connection_status()
+  @spec server_status(t(), String.t()) :: remote_connection_status()
   def server_status(%__MODULE__{} = remote, server_name) when is_binary(server_name) do
     Map.get(remote.server_status, server_name, :disconnected)
   end

--- a/test/minga/cli_env_test.exs
+++ b/test/minga/cli_env_test.exs
@@ -1,0 +1,46 @@
+defmodule Minga.CLIEnvTest do
+  # Mutates process-wide environment variables used by CLI startup helpers.
+  use ExUnit.Case, async: false
+
+  alias Minga.CLI
+
+  setup do
+    previous_cookie = System.get_env("MINGA_COOKIE")
+    previous_port = System.get_env("MINGA_GATEWAY_PORT")
+
+    on_exit(fn ->
+      restore_env("MINGA_COOKIE", previous_cookie)
+      restore_env("MINGA_GATEWAY_PORT", previous_port)
+    end)
+
+    :ok
+  end
+
+  test "distribution_cookie/1 returns an error when an explicit cookie file cannot be read" do
+    System.put_env("MINGA_COOKIE", "abcdefghijklmnopqrstuvwxyz123456")
+
+    missing_path =
+      Path.join(System.tmp_dir!(), "missing-cookie-#{System.unique_integer([:positive])}")
+
+    assert {:error, message} = CLI.distribution_cookie(%{cookie_file: missing_path})
+    assert message =~ "Failed to read Erlang cookie file"
+    assert message =~ ":enoent"
+  end
+
+  test "gateway_port/1 returns an error for invalid MINGA_GATEWAY_PORT" do
+    System.put_env("MINGA_GATEWAY_PORT", "abc")
+
+    assert CLI.gateway_port(%{gateway_port: nil}) ==
+             {:error, "MINGA_GATEWAY_PORT must be a TCP port between 1 and 65535"}
+  end
+
+  test "gateway_port/1 uses valid MINGA_GATEWAY_PORT" do
+    System.put_env("MINGA_GATEWAY_PORT", "4901")
+
+    assert CLI.gateway_port(%{gateway_port: nil}) == {:ok, 4901}
+  end
+
+  @spec restore_env(String.t(), String.t() | nil) :: :ok
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
+end

--- a/test/minga/distribution/config_test.exs
+++ b/test/minga/distribution/config_test.exs
@@ -35,6 +35,26 @@ defmodule Minga.Distribution.ConfigTest do
     assert Config.load(path) == []
   end
 
+  test "load/1 rejects cookies with unsupported characters" do
+    path =
+      temp_file(
+        "bad_cookie_chars.exs",
+        ~s([%{name: "home", node: :node, cookie: :abcdefghijklmnopqrstuvwxyz12345/}])
+      )
+
+    assert Config.load(path) == []
+  end
+
+  test "load/1 returns [] when config evaluation raises" do
+    path = temp_file("raising_servers.exs", ~s(raise "boom"))
+    assert Config.load(path) == []
+  end
+
+  test "load/1 returns [] when config has a syntax error" do
+    path = temp_file("syntax_error_servers.exs", "[")
+    assert Config.load(path) == []
+  end
+
   @spec temp_file(String.t(), String.t()) :: String.t()
   defp temp_file(name, content) do
     dir = Path.join(System.tmp_dir!(), "minga-config-test-#{System.unique_integer([:positive])}")

--- a/test/minga/distribution/connection_manager_test.exs
+++ b/test/minga/distribution/connection_manager_test.exs
@@ -1,7 +1,11 @@
 defmodule Minga.Distribution.ConnectionManagerTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Distribution.Config
   alias Minga.Distribution.ConnectionManager
+  alias Minga.Distribution.Events.NodeConnectedEvent
+  alias Minga.Distribution.Events.NodeDisconnectedEvent
+  alias Minga.Events
 
   test "connected_nodes/0 is safe when manager is not running" do
     assert is_list(ConnectionManager.connected_nodes())
@@ -37,5 +41,86 @@ defmodule Minga.Distribution.ConnectionManagerTest do
     assert ConnectionManager.backoff_ms(1) == 2_000
     assert ConnectionManager.backoff_ms(5) == 30_000
     assert ConnectionManager.backoff_ms(12) == 30_000
+  end
+
+  test "connect_all broadcasts node_connected" do
+    registry = start_events_registry()
+    Events.subscribe(:node_connected, registry)
+
+    node = :"remote@127.0.0.1"
+    servers = [%{name: "local", node: node, cookie: :abcdefghijklmnopqrstuvwxyz123456}]
+
+    {:ok, pid} = start_connection_manager(servers, registry)
+
+    send(pid, :connect_all)
+
+    assert_receive {:minga_event, :node_connected,
+                    %NodeConnectedEvent{server_name: "local", node: connected_node}}
+
+    assert connected_node == node
+  end
+
+  test "nodedown broadcasts node_disconnected and does not create duplicate retry timers" do
+    registry = start_events_registry()
+    Events.subscribe(:node_connected, registry)
+    Events.subscribe(:node_disconnected, registry)
+
+    node = :"remote@127.0.0.1"
+    servers = [%{name: "local", node: node, cookie: :abcdefghijklmnopqrstuvwxyz123456}]
+
+    {:ok, pid} = start_connection_manager(servers, registry)
+
+    send(pid, :connect_all)
+    assert_receive {:minga_event, :node_connected, %NodeConnectedEvent{}}
+
+    send(pid, {:nodedown, node, :test_down})
+
+    assert_receive {:minga_event, :node_disconnected,
+                    %NodeDisconnectedEvent{
+                      server_name: "local",
+                      node: disconnected_node,
+                      reason: :test_down,
+                      disconnected_at: %DateTime{}
+                    }}
+
+    assert disconnected_node == node
+    first_timer = retry_timer(pid, "local")
+    assert is_reference(first_timer)
+
+    send(pid, {:nodedown, node, :duplicate_down})
+    :sys.get_state(pid)
+
+    assert retry_timer(pid, "local") == first_timer
+    refute_receive {:minga_event, :node_disconnected, %NodeDisconnectedEvent{}}, 50
+  end
+
+  @spec start_connection_manager([Config.server_entry()], Minga.Events.registry()) :: {:ok, pid()}
+  defp start_connection_manager(servers, registry) do
+    start_supervised(
+      {ConnectionManager,
+       name: nil,
+       servers: servers,
+       events_registry: registry,
+       connect_on_init: false,
+       connect_fun: fn _node -> true end,
+       monitor_fun: fn _node, _flag -> true end,
+       set_cookie_fun: fn _node, _cookie -> true end}
+    )
+  end
+
+  @spec start_events_registry() :: atom()
+  defp start_events_registry do
+    name = :"connection_manager_events_#{System.unique_integer([:positive])}"
+    start_supervised!({Registry, keys: :duplicate, name: name})
+    name
+  end
+
+  @spec retry_timer(pid(), String.t()) :: reference() | nil
+  defp retry_timer(pid, server_name) do
+    pid
+    |> :sys.get_state()
+    |> Map.fetch!(:servers)
+    |> Map.fetch!(server_name)
+    |> Map.fetch!(:retry_timer)
   end
 end

--- a/test/minga/distribution/cookie_test.exs
+++ b/test/minga/distribution/cookie_test.exs
@@ -17,6 +17,15 @@ defmodule Minga.Distribution.CookieTest do
     assert Cookie.read_file(path) == {:error, :insecure_permissions}
   end
 
+  test "read_file/1 rejects symlinks before following the target" do
+    target = temp_cookie_file("abcdefghijklmnopqrstuvwxyz123456")
+    File.chmod!(target, 0o600)
+    link = target <> "-link"
+    File.ln_s!(target, link)
+
+    assert Cookie.read_file(link) == {:error, :not_regular_file}
+  end
+
   test "to_atom/1 rejects short or invalid cookies" do
     assert Cookie.to_atom("short") == {:error, :weak_or_invalid}
     assert Cookie.to_atom("abcdefghijklmnopqrstuvwxyz12345!") == {:error, :weak_or_invalid}

--- a/test/minga_agent/gateway/router_test.exs
+++ b/test/minga_agent/gateway/router_test.exs
@@ -28,6 +28,15 @@ defmodule MingaAgent.Gateway.RouterTest do
     assert conn.resp_body == "gateway websocket auth not configured"
   end
 
+  test "websocket route returns 503 when auth token is empty" do
+    Application.put_env(:minga, :gateway_auth_token, "")
+
+    conn = Router.call(conn(:get, "/ws"), [])
+
+    assert conn.status == 503
+    assert conn.resp_body == "gateway websocket auth not configured"
+  end
+
   test "websocket route returns 401 when bearer token is missing" do
     Application.put_env(:minga, :gateway_auth_token, "expected-token")
 


### PR DESCRIPTION
# TL;DR
Fixes the concrete post-merge review follow-ups from remote session Phase 1. The changes remove silent fallback behavior, tighten cookie handling, keep retry timers idempotent, and add the missing lifecycle/security regression tests.

Follow-up to #1587.

## Changes
- Make explicit `--cookie-file` failures fatal instead of falling back to `MINGA_COOKIE` or no cookie.
- Make invalid `MINGA_GATEWAY_PORT` fail with an error instead of silently using the default port.
- Clarify distribution config cookie validation errors so they mention both the 32-byte minimum and the allowed character set.
- Reject symlink cookie files by checking with `File.lstat/1` before reading.
- Restore bounded file listing to O(n) by tracking file count in the listing accumulator.
- Make retry scheduling idempotent when a retry timer already exists, which protects repeated `:nodedown` handling.
- Add tests for empty gateway auth tokens, cookie-file/env startup helpers, config eval errors, cookie symlink rejection, and connection manager node lifecycle broadcasts.
- Rename ambiguous public types where low-risk: `public_connection_status`, `remote_connection_status`, and `remote_session_entry`.
- Clarify docs/comments for connected nodes, retry backoff, remote metadata compatibility, node-disconnected event fields, and editor wait test overrides.

## Intentionally Deferred
- The Tab remote metadata sub-struct/co-invariant cleanup is a broader model refactor. I left it for a dedicated follow-up because this PR is focused on correctness and security follow-ups from the review.

## Verification
- `mix test.llm test/minga/cli_test.exs test/minga/cli_env_test.exs test/minga/distribution/config_test.exs test/minga/distribution/cookie_test.exs test/minga/distribution/file_test.exs test/minga/distribution/connection_manager_test.exs test/minga_agent/gateway/router_test.exs`, 64 tests, 0 failures.
- `make lint` passed. Credo still reports the pre-existing struct-size warnings, and the lint task passes.
- `mix test --warnings-as-errors --exclude system_clipboard`, 54 doctests, 98 properties, 8344 tests, 0 failures, 5 skipped, 3 excluded.
- Security reviewer PASS.
- Final reviewer PASS.
