### PR TITLE
fix(editor): guard against dead buffer pid on tab context restore

### DIFF
--- a/lib/minga_editor/state/buffers.ex
+++ b/lib/minga_editor/state/buffers.ex
@@ -57,6 +57,37 @@ defmodule MingaEditor.State.Buffers do
     end
   end
 
+  @doc """
+  Removes dead pids from the buffer list and selects a live neighbor as active.
+
+  If `active` is nil, not a pid, or still alive, returns unchanged.
+  If `active` is dead, filters all dead pids from `list` and selects
+  a neighbor using the same logic as `remove/2`.
+  """
+  @spec scrub_dead_active(t()) :: t()
+  def scrub_dead_active(%__MODULE__{active: nil} = bs), do: bs
+  def scrub_dead_active(%__MODULE__{active: active} = bs) when not is_pid(active), do: bs
+
+  def scrub_dead_active(%__MODULE__{active: active} = bs) do
+    if Process.alive?(active) do
+      bs
+    else
+      live_list = Enum.filter(bs.list, &Process.alive?/1)
+
+      {new_active, new_index} =
+        case live_list do
+          [] ->
+            {nil, 0}
+
+          _ ->
+            idx = min(bs.active_index, length(live_list) - 1)
+            {Enum.at(live_list, idx), idx}
+        end
+
+      %{bs | list: live_list, active: new_active, active_index: new_index}
+    end
+  end
+
   @doc "Removes a buffer pid, selecting a neighbor as the new active."
   @spec remove(t(), pid()) :: t()
   def remove(%__MODULE__{} = bs, pid) do

--- a/lib/minga_editor/workspace/state.ex
+++ b/lib/minga_editor/workspace/state.ex
@@ -83,12 +83,15 @@ defmodule MingaEditor.Workspace.State do
     |> TabContext.from_workspace_map()
   end
 
-  @doc "Restores a tab context into a workspace. Empty contexts are ignored by this pure helper; EditorState handles brand-new tab defaults because those need editor dimensions."
+  @doc "Restores a tab context into a workspace. Empty contexts are ignored by this pure helper; EditorState handles brand-new tab defaults because those need editor dimensions. Dead buffer pids in the restored context are scrubbed to prevent activating a dead process."
   @spec restore_tab_context(t(), TabContext.t() | TabContext.legacy()) :: t()
   def restore_tab_context(%__MODULE__{} = ws, context) when is_map(context) do
-    context
-    |> TabContext.to_workspace_map()
-    |> Enum.reduce(ws, fn {field, value}, acc -> Map.put(acc, field, value) end)
+    ws =
+      context
+      |> TabContext.to_workspace_map()
+      |> Enum.reduce(ws, fn {field, value}, acc -> Map.put(acc, field, value) end)
+
+    update_in(ws.buffers, &Buffers.scrub_dead_active/1)
   end
 
   # ── Pure workspace operations ─────────────────────────────────────────────

--- a/test/minga_agent/tool/registry_test.exs
+++ b/test/minga_agent/tool/registry_test.exs
@@ -103,7 +103,9 @@ defmodule MingaAgent.Tool.RegistryTest do
       table = :"registry_init_#{:erlang.unique_integer([:positive])}"
       start_supervised!({Registry, name: table, project_root: "."})
 
-      expected_names = MingaAgent.Tools.all(project_root: ".") |> Enum.map(& &1.name) |> MapSet.new()
+      expected_names =
+        MingaAgent.Tools.all(project_root: ".") |> Enum.map(& &1.name) |> MapSet.new()
+
       registered_names = Registry.all(table) |> Enum.map(& &1.name) |> MapSet.new()
 
       assert expected_names == registered_names

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -189,6 +189,90 @@ defmodule MingaEditor.State.SnapshotTest do
     end
   end
 
+  describe "Buffers.scrub_dead_active/1" do
+    test "returns unchanged when active is nil" do
+      bs = %Buffers{active: nil, list: [], active_index: 0}
+      assert Buffers.scrub_dead_active(bs) == bs
+    end
+
+    test "returns unchanged when active pid is alive" do
+      {:ok, buf} = BufferServer.start_link(content: "alive")
+      bs = %Buffers{active: buf, list: [buf], active_index: 0}
+      assert Buffers.scrub_dead_active(bs) == bs
+    end
+
+    test "selects neighbor when active pid is dead" do
+      {:ok, buf_a} = BufferServer.start_link(content: "a")
+      {:ok, buf_b} = BufferServer.start_link(content: "b")
+
+      bs = %Buffers{active: buf_a, list: [buf_a, buf_b], active_index: 0}
+      GenServer.stop(buf_a)
+
+      scrubbed = Buffers.scrub_dead_active(bs)
+      assert scrubbed.active == buf_b
+      assert scrubbed.list == [buf_b]
+      assert scrubbed.active_index == 0
+    end
+
+    test "sets active to nil when all pids are dead" do
+      {:ok, buf_a} = BufferServer.start_link(content: "a")
+      {:ok, buf_b} = BufferServer.start_link(content: "b")
+
+      bs = %Buffers{active: buf_a, list: [buf_a, buf_b], active_index: 0}
+      GenServer.stop(buf_a)
+      GenServer.stop(buf_b)
+
+      scrubbed = Buffers.scrub_dead_active(bs)
+      assert scrubbed.active == nil
+      assert scrubbed.list == []
+      assert scrubbed.active_index == 0
+    end
+
+    test "clamps active_index when dead pid was at the end" do
+      {:ok, buf_a} = BufferServer.start_link(content: "a")
+      {:ok, buf_b} = BufferServer.start_link(content: "b")
+      {:ok, buf_c} = BufferServer.start_link(content: "c")
+
+      bs = %Buffers{active: buf_c, list: [buf_a, buf_b, buf_c], active_index: 2}
+      GenServer.stop(buf_c)
+
+      scrubbed = Buffers.scrub_dead_active(bs)
+      assert scrubbed.active in [buf_a, buf_b]
+      assert scrubbed.list == [buf_a, buf_b]
+      assert scrubbed.active_index == 1
+    end
+  end
+
+  describe "restore_tab_context/2 with dead buffer" do
+    test "scrubs dead active buffer pid on restore" do
+      {:ok, buf_a} = BufferServer.start_link(content: "a")
+      {:ok, buf_b} = BufferServer.start_link(content: "b")
+
+      # Build state with two buffers, buf_a active
+      state_with_both =
+        make_state(buffer: buf_a)
+        |> put_in(
+          [Access.key(:workspace), Access.key(:buffers)],
+          %Buffers{active: buf_a, list: [buf_a, buf_b], active_index: 0}
+        )
+
+      # Snapshot the context
+      ctx = EditorState.snapshot_tab_context(state_with_both)
+
+      # Kill the active buffer
+      GenServer.stop(buf_a)
+
+      # Restore the context into a fresh workspace
+      fresh_state = make_state(buffer: buf_b)
+      restored = EditorState.restore_tab_context(fresh_state, ctx)
+
+      # The dead pid should have been scrubbed; buf_b is active now
+      assert restored.workspace.buffers.active == buf_b
+      assert buf_a not in restored.workspace.buffers.list
+      assert buf_b in restored.workspace.buffers.list
+    end
+  end
+
   describe "switch_tab/2" do
     test "snapshots current tab, restores target tab" do
       {:ok, buf_a} = BufferServer.start_link(content: "file a")


### PR DESCRIPTION
Closes #1589
Epic: #1395 (T1)

## Summary

- Adds `Buffers.scrub_dead_active/1` that replaces dead active buffer pids with the nearest alive neighbor (or nil if none remain)
- Calls the scrub in `WorkspaceState.restore_tab_context/2` after applying context fields, so restoring a tab whose buffer crashed between snapshot and restore never activates a dead pid
- 6 new tests: 5 unit tests for `scrub_dead_active/1` edge cases + 1 integration test for the full snapshot-kill-restore round-trip

## Test plan

- [x] `mix test.llm test/minga_editor/state/snapshot_test.exs` — 22 tests pass (6 new)
- [x] `mix test.llm test/minga_editor/state/buffer_lifecycle_test.exs` — 19 tests pass (no regressions)
- [x] `mix compile --warnings-as-errors` — clean
- [ ] Manual: open file, switch tabs, kill buffer process, switch back — no crash

🤖 Generated with [Claude Code](https://claude.ai/claude-code)