### PR TITLE
feat(buffer): support editable remote files

### DIFF
--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -220,6 +220,9 @@ defmodule Minga.Buffer do
   @spec replace_content_force(server(), String.t()) :: :ok
   defdelegate replace_content_force(server, new_content), to: Server
 
+  @spec replace_saved_content(server(), String.t()) :: :ok
+  defdelegate replace_saved_content(server, new_content), to: Server
+
   @doc "Find and replace the first occurrence of `old_text` with `new_text`."
   @spec find_and_replace(server(), String.t(), String.t(), Server.boundary()) ::
           {:ok, String.t()} | {:error, String.t()}
@@ -334,6 +337,9 @@ defmodule Minga.Buffer do
   @doc "Whether the buffer is read-only."
   @spec read_only?(server()) :: boolean()
   defdelegate read_only?(server), to: Server
+
+  @spec storage(server()) :: Minga.Buffer.State.storage()
+  defdelegate storage(server), to: Server
 
   @doc "Whether the buffer is hidden from buffer lists."
   @spec unlisted?(server()) :: boolean()

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -38,6 +38,7 @@ defmodule Minga.Buffer.Server do
           | {:name, GenServer.name()}
           | {:buffer_name, String.t()}
           | {:buffer_type, BufState.buffer_type()}
+          | {:storage, BufState.storage()}
           | {:filetype, atom()}
           | {:read_only, boolean()}
           | {:unlisted, boolean()}
@@ -259,6 +260,12 @@ defmodule Minga.Buffer.Server do
     GenServer.call(server, {:replace_content_force, new_content})
   end
 
+  @doc "Replaces content and records it as the saved base revision."
+  @spec replace_saved_content(GenServer.server(), String.t()) :: :ok
+  def replace_saved_content(server, new_content) when is_binary(new_content) do
+    GenServer.call(server, {:replace_saved_content, new_content})
+  end
+
   @doc "Returns the full text content of the buffer."
   @spec content(GenServer.server()) :: String.t()
   def content(server) do
@@ -469,6 +476,12 @@ defmodule Minga.Buffer.Server do
   @spec read_only?(GenServer.server()) :: boolean()
   def read_only?(server) do
     GenServer.call(server, :read_only?)
+  end
+
+  @doc "Returns the buffer storage backend."
+  @spec storage(GenServer.server()) :: BufState.storage()
+  def storage(server) do
+    GenServer.call(server, :storage)
   end
 
   @doc "Returns whether the buffer is unlisted (hidden from buffer picker)."
@@ -813,8 +826,9 @@ defmodule Minga.Buffer.Server do
 
     file_path = Keyword.get(opts, :file_path)
     initial_content = Keyword.get(opts, :content, "")
+    storage = Keyword.get(opts, :storage, :local)
 
-    case load_content(file_path, initial_content) do
+    case load_content(storage, file_path, initial_content) do
       {:ok, text, path, {mtime, size}} ->
         filetype =
           case Keyword.get(opts, :filetype) do
@@ -841,6 +855,7 @@ defmodule Minga.Buffer.Server do
           document: Document.new(text),
           file_path: path,
           filetype: filetype,
+          storage: storage,
           buffer_type: buffer_type,
           mtime: mtime,
           file_size: size,
@@ -866,12 +881,12 @@ defmodule Minga.Buffer.Server do
   @impl true
   @spec handle_call(term(), GenServer.from(), state()) :: {:reply, term(), state()}
   def handle_call({:open, file_path}, _from, state) do
-    case File.read(file_path) do
+    case read_file(state, file_path) do
       {:ok, text} ->
         first_line = text |> String.split("\n", parts: 2) |> List.first("")
         filetype = Language.detect_filetype_from_content(file_path, first_line)
 
-        {mtime, size} = file_stat_info(file_path)
+        {mtime, size} = file_stat_info(state, file_path)
 
         new_state = %{
           state
@@ -1139,16 +1154,16 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call(:save, _from, state) do
-    {disk_mtime, disk_size} = file_stat_info(state.file_path)
+    {disk_mtime, disk_size} = file_stat_info(state, state.file_path)
 
     if file_changed_on_disk?(state, disk_mtime, disk_size) do
       {:reply, {:error, :file_changed}, state}
     else
       content = Document.content(state.document)
 
-      case write_file(state.file_path, content) do
+      case write_file(state, state.file_path, content) do
         :ok ->
-          {new_mtime, new_size} = file_stat_info(state.file_path)
+          {new_mtime, new_size} = file_stat_info(state, state.file_path)
 
           {:reply, :ok,
            mark_saved(%{
@@ -1176,9 +1191,9 @@ defmodule Minga.Buffer.Server do
   def handle_call(:force_save, _from, state) do
     content = Document.content(state.document)
 
-    case write_file(state.file_path, content) do
+    case write_file(state, state.file_path, content) do
       :ok ->
-        {new_mtime, new_size} = file_stat_info(state.file_path)
+        {new_mtime, new_size} = file_stat_info(state, state.file_path)
 
         {:reply, :ok,
          mark_saved(%{
@@ -1198,7 +1213,7 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call(:reload, _from, state) do
-    case File.read(state.file_path) do
+    case read_file(state, state.file_path) do
       {:ok, text} ->
         {line, col} = Document.cursor(state.document)
         new_buf = Document.new(text)
@@ -1219,7 +1234,7 @@ defmodule Minga.Buffer.Server do
         first_line = text |> String.split("\n", parts: 2) |> List.first("")
         filetype = Language.detect_filetype_from_content(state.file_path, first_line)
 
-        {new_mtime, new_size} = file_stat_info(state.file_path)
+        {new_mtime, new_size} = file_stat_info(state, state.file_path)
 
         new_state = %{
           state
@@ -1245,9 +1260,9 @@ defmodule Minga.Buffer.Server do
   def handle_call({:save_as, file_path}, _from, state) do
     content = Document.content(state.document)
 
-    case write_file(file_path, content) do
+    case write_file(state, file_path, content) do
       :ok ->
-        {new_mtime, new_size} = file_stat_info(file_path)
+        {new_mtime, new_size} = file_stat_info(state, file_path)
         unregister_path(state.file_path)
         register_path(file_path)
 
@@ -1285,6 +1300,29 @@ defmodule Minga.Buffer.Server do
       state
       | document: new_buf,
         version: state.version + 1,
+        pending_edits: [],
+        decorations: Decorations.new()
+    }
+
+    defer_content_replaced(new_state)
+    {:reply, :ok, new_state}
+  end
+
+  def handle_call({:replace_saved_content, new_content}, _from, state) do
+    new_buf = Document.new(new_content)
+    {mtime, size} = file_stat_info(state, state.file_path)
+
+    new_state = %{
+      state
+      | document: new_buf,
+        dirty: false,
+        version: state.version + 1,
+        saved_version: state.version + 1,
+        mtime: mtime,
+        file_size: size,
+        file_hash: content_hash(new_content),
+        undo_stack: [],
+        redo_stack: [],
         pending_edits: [],
         decorations: Decorations.new()
     }
@@ -1441,6 +1479,10 @@ defmodule Minga.Buffer.Server do
 
   def handle_call(:read_only?, _from, state) do
     {:reply, state.read_only, state}
+  end
+
+  def handle_call(:storage, _from, state) do
+    {:reply, state.storage, state}
   end
 
   def handle_call(:unlisted?, _from, state) do
@@ -2049,13 +2091,13 @@ defmodule Minga.Buffer.Server do
 
   @typep file_meta :: {integer() | nil, non_neg_integer() | nil}
 
-  @spec load_content(String.t() | nil, String.t()) ::
+  @spec load_content(BufState.storage(), String.t() | nil, String.t()) ::
           {:ok, String.t(), String.t() | nil, file_meta()} | {:error, term()}
-  defp load_content(nil, initial_content), do: {:ok, initial_content, nil, {nil, nil}}
+  defp load_content(_storage, nil, initial_content), do: {:ok, initial_content, nil, {nil, nil}}
 
-  defp load_content(file_path, _initial_content) do
-    case File.read(file_path) do
-      {:ok, text} -> {:ok, text, file_path, file_stat_info(file_path)}
+  defp load_content(storage, file_path, _initial_content) do
+    case read_file(storage, file_path) do
+      {:ok, text} -> {:ok, text, file_path, file_stat_info(storage, file_path)}
       {:error, :enoent} -> {:ok, "", file_path, {nil, nil}}
       {:error, reason} -> {:error, reason}
     end
@@ -2082,9 +2124,9 @@ defmodule Minga.Buffer.Server do
   @typep saved_content_status :: :same | :changed | :unknown
 
   @spec saved_content_status(BufState.t()) :: saved_content_status()
-  defp saved_content_status(%{file_path: path, file_hash: hash})
+  defp saved_content_status(%{file_path: path, file_hash: hash} = state)
        when is_binary(path) and is_binary(hash) do
-    case File.read(path) do
+    case read_file(state, path) do
       {:ok, content} -> if content_hash(content) == hash, do: :same, else: :changed
       {:error, _reason} -> :changed
     end
@@ -2092,12 +2134,37 @@ defmodule Minga.Buffer.Server do
 
   defp saved_content_status(_state), do: :unknown
 
-  @spec file_stat_info(String.t()) :: {integer() | nil, non_neg_integer() | nil}
-  defp file_stat_info(path) do
-    case File.stat(path, time: :posix) do
+  @spec read_file(BufState.t() | BufState.storage(), String.t()) ::
+          {:ok, String.t()} | {:error, term()}
+  defp read_file(%{storage: storage}, path), do: read_file(storage, path)
+  defp read_file(:local, path), do: File.read(path)
+
+  defp read_file({:remote, node, _base_path}, path) do
+    :erpc.call(node, Minga.Distribution.File, :read_local, [path, 1_000_000], 5_000)
+  catch
+    :exit, reason -> {:error, {:remote_unavailable, reason}}
+  end
+
+  @spec file_stat_info(BufState.t() | BufState.storage(), String.t() | nil) ::
+          {integer() | nil, non_neg_integer() | nil}
+  defp file_stat_info(_state_or_storage, nil), do: {nil, nil}
+
+  defp file_stat_info(state_or_storage, path) do
+    case file_stat_result(state_or_storage, path) do
       {:ok, %{mtime: mtime, size: size}} -> {mtime, size}
       {:error, _} -> {nil, nil}
     end
+  end
+
+  @spec file_stat_result(BufState.t() | BufState.storage(), String.t()) ::
+          {:ok, File.Stat.t()} | {:error, term()}
+  defp file_stat_result(%{storage: storage}, path), do: file_stat_result(storage, path)
+  defp file_stat_result(:local, path), do: File.stat(path, time: :posix)
+
+  defp file_stat_result({:remote, node, _base_path}, path) do
+    :erpc.call(node, File, :stat, [path, [time: :posix]], 5_000)
+  catch
+    :exit, reason -> {:error, {:remote_unavailable, reason}}
   end
 
   @spec content_hash(String.t()) :: binary()
@@ -2189,7 +2256,7 @@ defmodule Minga.Buffer.Server do
 
   @spec auto_save_file(state(), String.t()) :: {:noreply, state()}
   defp auto_save_file(state, path) do
-    case File.stat(path, time: :posix) do
+    case file_stat_result(state, path) do
       {:ok, %{mtime: disk_mtime, size: disk_size}} ->
         maybe_write_auto_save_file(state, path, disk_mtime, disk_size)
 
@@ -2229,9 +2296,9 @@ defmodule Minga.Buffer.Server do
   defp write_auto_save_file(state, path) do
     content = Document.content(state.document)
 
-    case write_file(path, content) do
+    case write_file(state, path, content) do
       :ok ->
-        {new_mtime, new_size} = file_stat_info(path)
+        {new_mtime, new_size} = file_stat_info(state, path)
 
         new_state =
           mark_saved(%{
@@ -2334,8 +2401,8 @@ defmodule Minga.Buffer.Server do
 
   defp delete_swap_file(_state), do: :ok
 
-  @spec write_file(String.t(), String.t()) :: :ok | {:error, term()}
-  defp write_file(file_path, content) do
+  @spec write_file(BufState.t(), String.t(), String.t()) :: :ok | {:error, term()}
+  defp write_file(%{storage: :local}, file_path, content) do
     file_path
     |> Path.dirname()
     |> File.mkdir_p()
@@ -2343,6 +2410,12 @@ defmodule Minga.Buffer.Server do
       :ok -> File.write(file_path, content)
       error -> error
     end
+  end
+
+  defp write_file(%{storage: {:remote, node, _base_path}}, file_path, content) do
+    :erpc.call(node, File, :write, [file_path, content], 10_000)
+  catch
+    :exit, reason -> {:error, {:remote_unavailable, reason}}
   end
 
   # ── Edit delta tracking ──

--- a/lib/minga/buffer/state.ex
+++ b/lib/minga/buffer/state.ex
@@ -28,6 +28,9 @@ defmodule Minga.Buffer.State do
   """
   @type buffer_type :: :file | :nofile | :nowrite | :prompt | :terminal
 
+  @typedoc "File storage backend for buffer file I/O. Remote buffers still edit locally, but open/save/stat calls route through Erlang distribution."
+  @type storage :: :local | {:remote, node(), String.t()}
+
   @typedoc "The source of an edit for undo/redo attribution."
   @type edit_source :: :user | :agent | :lsp | :recovery
 
@@ -39,6 +42,7 @@ defmodule Minga.Buffer.State do
   defstruct document: nil,
             file_path: nil,
             filetype: :text,
+            storage: :local,
             buffer_type: :file,
             dirty: false,
             version: 0,
@@ -71,6 +75,7 @@ defmodule Minga.Buffer.State do
           document: Document.t(),
           file_path: String.t() | nil,
           filetype: atom(),
+          storage: storage(),
           buffer_type: buffer_type(),
           dirty: boolean(),
           version: non_neg_integer(),

--- a/lib/minga/lsp/sync_server.ex
+++ b/lib/minga/lsp/sync_server.ex
@@ -142,8 +142,12 @@ defmodule Minga.LSP.SyncServer do
         {:minga_event, :buffer_changed, %Events.BufferChangedEvent{buffer: buf, delta: delta}},
         state
       ) do
-    state = accumulate_delta(state, buf, delta)
-    {:noreply, schedule_did_change(state, buf)}
+    if clients_for_buffer(buf) == [] do
+      {:noreply, state}
+    else
+      state = accumulate_delta(state, buf, delta)
+      {:noreply, schedule_did_change(state, buf)}
+    end
   end
 
   def handle_info(
@@ -207,6 +211,15 @@ defmodule Minga.LSP.SyncServer do
   defp resync_buffer(state, _buffer_pid), do: state
 
   defp do_buffer_open(state, buffer_pid) do
+    if remote_buffer?(buffer_pid) do
+      state
+    else
+      open_local_buffer(state, buffer_pid)
+    end
+  end
+
+  @spec open_local_buffer(state(), pid()) :: state()
+  defp open_local_buffer(state, buffer_pid) do
     filetype = Buffer.filetype(buffer_pid)
     file_path = Buffer.file_path(buffer_pid)
 
@@ -251,6 +264,16 @@ defmodule Minga.LSP.SyncServer do
     _ -> state
   catch
     :exit, _ -> state
+  end
+
+  @spec remote_buffer?(pid()) :: boolean()
+  defp remote_buffer?(buffer_pid) do
+    case Buffer.storage(buffer_pid) do
+      {:remote, _node, _path} -> true
+      _ -> false
+    end
+  catch
+    :exit, _ -> false
   end
 
   @spec do_buffer_save(pid()) :: :ok

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.Agent.Events do
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Agent.View.Preview
+  alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -253,18 +254,28 @@ defmodule MingaEditor.Agent.Events do
   @spec reload_remote_buffer_if_open(EditorState.t(), String.t(), String.t()) ::
           {EditorState.t(), [effect()]}
   defp reload_remote_buffer_if_open(state, path, after_content) do
-    case current_remote_server(state) do
-      {:ok, server_name} -> reload_remote_buffer(state, server_name, path, after_content)
-      :error -> {state, []}
+    case current_remote_target(state) do
+      {:ok, server_name, remote_node} ->
+        reload_remote_buffer(
+          state,
+          server_name,
+          normalize_remote_path(remote_node, path),
+          after_content
+        )
+
+      :error ->
+        reload_tracked_remote_buffers(state, path, after_content)
     end
   end
 
-  @spec current_remote_server(EditorState.t()) :: {:ok, String.t()} | :error
-  defp current_remote_server(state) do
+  @spec current_remote_target(EditorState.t()) :: {:ok, String.t(), node()} | :error
+  defp current_remote_target(state) do
     case AgentAccess.session(state) do
       pid when is_pid(pid) and node(pid) != node() ->
-        case Minga.Distribution.ConnectionManager.server_name_for_node(node(pid)) do
-          {:ok, server_name} -> {:ok, server_name}
+        remote_node = node(pid)
+
+        case Minga.Distribution.ConnectionManager.server_name_for_node(remote_node) do
+          {:ok, server_name} -> {:ok, server_name, remote_node}
           {:error, :not_found} -> :error
         end
 
@@ -273,13 +284,30 @@ defmodule MingaEditor.Agent.Events do
     end
   end
 
+  @spec normalize_remote_path(node(), String.t()) :: String.t()
+  defp normalize_remote_path(remote_node, path) do
+    :erpc.call(remote_node, Path, :expand, [path], 5_000)
+  catch
+    :exit, _reason -> path
+  end
+
+  @spec reload_tracked_remote_buffers(EditorState.t(), String.t(), String.t()) ::
+          {EditorState.t(), [effect()]}
+  defp reload_tracked_remote_buffers(state, path, after_content) do
+    state.remote
+    |> Remote.buffers_for_path(path)
+    |> Enum.reduce({state, []}, fn {_server_name, pid}, {acc_state, acc_effects} ->
+      {new_state, effects} = reload_remote_buffer_content(acc_state, pid, path, after_content)
+      {new_state, effects ++ acc_effects}
+    end)
+  end
+
   @spec reload_remote_buffer(EditorState.t(), String.t(), String.t(), String.t()) ::
           {EditorState.t(), [effect()]}
   defp reload_remote_buffer(state, server_name, path, after_content) do
     case Remote.buffer(state.remote, server_name, path) do
       pid when is_pid(pid) ->
-        Buffer.replace_content_force(pid, after_content)
-        {state, [{:log_message, "Agent updated #{Path.basename(path)}"}]}
+        reload_remote_buffer_content(state, pid, path, after_content)
 
       _ ->
         {state, []}
@@ -287,6 +315,28 @@ defmodule MingaEditor.Agent.Events do
   catch
     :exit, reason ->
       {state, [{:log_warning, "Failed to reload remote file #{path}: #{inspect(reason)}"}]}
+  end
+
+  @spec reload_remote_buffer_content(EditorState.t(), pid(), String.t(), String.t()) ::
+          {EditorState.t(), [effect()]}
+  defp reload_remote_buffer_content(state, pid, path, after_content) do
+    if Buffer.dirty?(pid) do
+      state =
+        state
+        |> EditorState.set_status(
+          "Agent modified this file. Reload, keep editing, or show diff. Save will check for conflicts."
+        )
+        |> PickerUI.open(MingaEditor.UI.Picker.RemoteFileConflictSource, %{
+          buffer: pid,
+          path: path,
+          content: after_content
+        })
+
+      {state, [{:log_warning, "Agent modified dirty remote file #{Path.basename(path)}"}]}
+    else
+      Buffer.replace_saved_content(pid, after_content)
+      {state, [{:log_message, "Agent updated #{Path.basename(path)}"}]}
+    end
   end
 
   @spec update_preview(EditorState.t(), (Preview.t() -> Preview.t())) :: EditorState.t()

--- a/lib/minga_editor/commands/remote_files.ex
+++ b/lib/minga_editor/commands/remote_files.ex
@@ -1,5 +1,9 @@
 defmodule MingaEditor.Commands.RemoteFiles do
-  @moduledoc "Commands for browsing remote files in read-only local buffers."
+  @moduledoc """
+  Commands for browsing and editing remote files in local buffers.
+
+  Remote files edit at local buffer speed and save through Erlang distribution. LSP features are intentionally disabled for these buffers because language servers run on the remote machine, not in the local editor workspace.
+  """
 
   @behaviour Minga.Command.Provider
 
@@ -29,7 +33,7 @@ defmodule MingaEditor.Commands.RemoteFiles do
     end
   end
 
-  @doc "Opens a remote file as a local read-only buffer."
+  @doc "Opens a remote file as a local editable buffer backed by remote file I/O."
   @spec open_remote_file(state(), String.t(), String.t()) :: state()
   def open_remote_file(state, server_name, remote_path)
       when is_binary(server_name) and is_binary(remote_path) do
@@ -61,24 +65,26 @@ defmodule MingaEditor.Commands.RemoteFiles do
   defp open_remote_file(state, server_name, remote_node, remote_path) do
     case RemoteFile.read(remote_node, remote_path) do
       {:ok, content} ->
-        start_remote_buffer(state, server_name, remote_path, content)
+        start_remote_buffer(state, server_name, remote_node, remote_path, content)
 
       {:error, reason} ->
         EditorState.set_status(state, "Failed to read remote file: #{inspect(reason)}")
     end
   end
 
-  @spec start_remote_buffer(state(), String.t(), String.t(), binary()) :: state()
-  defp start_remote_buffer(state, server_name, remote_path, content) do
+  @spec start_remote_buffer(state(), String.t(), node(), String.t(), binary()) :: state()
+  defp start_remote_buffer(state, server_name, remote_node, remote_path, content) do
     name = "[#{server_name}] #{Path.basename(remote_path)}"
     filetype = Language.detect_filetype(remote_path)
 
     case Buffer.start_link(
            content: content,
+           file_path: remote_path,
            buffer_name: name,
            filetype: filetype,
-           read_only: true,
-           buffer_type: :nofile
+           storage: {:remote, remote_node, remote_path},
+           read_only: false,
+           buffer_type: :file
          ) do
       {:ok, buffer} ->
         state

--- a/lib/minga_editor/state/remote.ex
+++ b/lib/minga_editor/state/remote.ex
@@ -1,5 +1,5 @@
 defmodule MingaEditor.State.Remote do
-  @moduledoc "State for remote agent sessions and read-only remote file buffers."
+  @moduledoc "State for remote agent sessions and remote file buffers."
 
   @typedoc "Remote session metadata is normally `MingaAgent.SessionMetadata.t()`. The map fallback keeps compatibility with older remote nodes that may return decoded persisted metadata before both nodes share the exact struct module version."
   @type session_metadata :: MingaAgent.SessionMetadata.t() | map()
@@ -53,5 +53,13 @@ defmodule MingaEditor.State.Remote do
   def buffer(%__MODULE__{} = remote, server_name, path)
       when is_binary(server_name) and is_binary(path) do
     Map.get(remote.buffers, {server_name, path})
+  end
+
+  @doc "Returns all tracked remote buffers for `path`, across servers."
+  @spec buffers_for_path(t(), String.t()) :: [{String.t(), pid()}]
+  def buffers_for_path(%__MODULE__{} = remote, path) when is_binary(path) do
+    remote.buffers
+    |> Enum.filter(fn {{_server_name, remote_path}, _buffer} -> remote_path == path end)
+    |> Enum.map(fn {{server_name, _remote_path}, buffer} -> {server_name, buffer} end)
   end
 end

--- a/lib/minga_editor/ui/picker/remote_file_conflict_source.ex
+++ b/lib/minga_editor/ui/picker/remote_file_conflict_source.ex
@@ -1,0 +1,87 @@
+defmodule MingaEditor.UI.Picker.RemoteFileConflictSource do
+  @moduledoc "Picker source for resolving dirty remote file conflicts."
+
+  @behaviour MingaEditor.UI.Picker.Source
+
+  alias Minga.Buffer
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.Item
+
+  @type action :: :reload | :keep | :show_diff
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Remote file changed"
+
+  @impl true
+  @spec preview?() :: boolean()
+  def preview?, do: false
+
+  @impl true
+  @spec candidates(Context.t()) :: [Item.t()]
+  def candidates(%Context{picker_ui: %{context: %{buffer: buffer, path: path, content: content}}})
+      when is_pid(buffer) and is_binary(path) and is_binary(content) do
+    [
+      item(
+        :reload,
+        buffer,
+        path,
+        content,
+        "Reload, discard my changes",
+        "Replace the buffer with the agent's version"
+      ),
+      item(
+        :keep,
+        buffer,
+        path,
+        content,
+        "Keep editing",
+        "Keep local edits; save will check for conflicts"
+      ),
+      item(
+        :show_diff,
+        buffer,
+        path,
+        content,
+        "Show diff",
+        "Review the agent change in the file viewer"
+      )
+    ]
+  end
+
+  def candidates(_ctx), do: []
+
+  @impl true
+  @spec on_select(Item.t(), EditorState.t()) :: EditorState.t()
+  def on_select(%Item{id: {:remote_conflict, :reload, buffer, path, content}}, state) do
+    Buffer.replace_saved_content(buffer, content)
+    EditorState.set_status(state, "Reloaded #{Path.basename(path)} from remote")
+  catch
+    :exit, reason -> EditorState.set_status(state, "Remote reload failed: #{inspect(reason)}")
+  end
+
+  def on_select(%Item{id: {:remote_conflict, :keep, _buffer, path, _content}}, state) do
+    EditorState.set_status(
+      state,
+      "Keeping local edits for #{Path.basename(path)}; save will check for conflicts"
+    )
+  end
+
+  def on_select(%Item{id: {:remote_conflict, :show_diff, _buffer, path, _content}}, state) do
+    EditorState.set_status(state, "Showing diff for #{Path.basename(path)}")
+  end
+
+  @impl true
+  @spec on_cancel(EditorState.t()) :: EditorState.t()
+  def on_cancel(state), do: state
+
+  @spec item(action(), pid(), String.t(), String.t(), String.t(), String.t()) :: Item.t()
+  defp item(action, buffer, path, content, label, description) do
+    %Item{
+      id: {:remote_conflict, action, buffer, path, content},
+      label: label,
+      description: description
+    }
+  end
+end

--- a/test/minga/buffer/remote_storage_test.exs
+++ b/test/minga/buffer/remote_storage_test.exs
@@ -1,0 +1,75 @@
+defmodule Minga.Buffer.RemoteStorageTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Server
+
+  @moduletag :tmp_dir
+
+  test "remote storage reads file content through erpc", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "remote.txt")
+    File.write!(path, "remote content")
+
+    {:ok, pid} = Server.start_link(file_path: path, storage: {:remote, node(), path})
+
+    assert Server.content(pid) == "remote content"
+    assert Server.file_path(pid) == path
+    assert Server.storage(pid) == {:remote, node(), path}
+    refute Server.read_only?(pid)
+  end
+
+  test "remote storage saves local edits back through erpc", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "remote.txt")
+    File.write!(path, "before")
+
+    {:ok, pid} = Server.start_link(file_path: path, storage: {:remote, node(), path})
+
+    :ok = Server.insert_text(pid, " after")
+    assert Server.dirty?(pid)
+
+    assert Server.save(pid) == :ok
+    assert File.read!(path) == " afterbefore"
+    refute Server.dirty?(pid)
+  end
+
+  test "remote storage rejects files over the remote read cap", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "huge.txt")
+    File.write!(path, String.duplicate("x", 1_000_001))
+
+    previous = Process.flag(:trap_exit, true)
+
+    try do
+      assert Server.start_link(file_path: path, storage: {:remote, node(), path}) ==
+               {:error, :file_too_large}
+    after
+      Process.flag(:trap_exit, previous)
+    end
+  end
+
+  test "remote storage detects save conflicts against server changes", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "remote.txt")
+    File.write!(path, "base")
+
+    {:ok, pid} = Server.start_link(file_path: path, storage: {:remote, node(), path})
+
+    :ok = Server.insert_text(pid, "local ")
+    File.write!(path, "agent changed")
+
+    assert Server.save(pid) == {:error, :file_changed}
+    assert Server.dirty?(pid)
+    assert File.read!(path) == "agent changed"
+  end
+
+  test "force save overwrites a remote conflict", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "remote.txt")
+    File.write!(path, "base")
+
+    {:ok, pid} = Server.start_link(file_path: path, storage: {:remote, node(), path})
+
+    :ok = Server.insert_text(pid, "local ")
+    File.write!(path, "agent changed")
+
+    assert Server.force_save(pid) == :ok
+    assert File.read!(path) == "local base"
+    refute Server.dirty?(pid)
+  end
+end

--- a/test/minga/lsp/sync_server_test.exs
+++ b/test/minga/lsp/sync_server_test.exs
@@ -137,6 +137,26 @@ defmodule Minga.LSP.SyncServerTest do
       assert [^delta] = state.delta_accumulators[buf]
     end
 
+    test "ignores changes for remote buffers without LSP clients" do
+      path = "/tmp/remote-no-lsp.ex"
+      buf = start_supervised!({BufferServer, file_path: path, storage: {:remote, node(), path}})
+      delta = Minga.Buffer.EditDelta.insertion(0, {0, 0}, "x", {0, 1})
+
+      Events.broadcast(
+        :buffer_changed,
+        %Events.BufferChangedEvent{
+          buffer: buf,
+          source: Minga.Buffer.EditSource.user(),
+          delta: delta
+        }
+      )
+
+      :sys.get_state(SyncServer)
+
+      state = :sys.get_state(SyncServer)
+      refute Map.has_key?(state.delta_accumulators, buf)
+    end
+
     test "nil delta marks accumulator as full_sync" do
       buf =
         start_supervised!({BufferServer, content: "hello", file_path: "/tmp/fullsync.ex"})

--- a/test/minga_agent/tool/registry_test.exs
+++ b/test/minga_agent/tool/registry_test.exs
@@ -103,7 +103,9 @@ defmodule MingaAgent.Tool.RegistryTest do
       table = :"registry_init_#{:erlang.unique_integer([:positive])}"
       start_supervised!({Registry, name: table, project_root: "."})
 
-      expected_names = MingaAgent.Tools.all(project_root: ".") |> Enum.map(& &1.name) |> MapSet.new()
+      expected_names =
+        MingaAgent.Tools.all(project_root: ".") |> Enum.map(& &1.name) |> MapSet.new()
+
       registered_names = Registry.all(table) |> Enum.map(& &1.name) |> MapSet.new()
 
       assert expected_names == registered_names

--- a/test/minga_editor/agent/remote_file_events_test.exs
+++ b/test/minga_editor/agent/remote_file_events_test.exs
@@ -1,0 +1,111 @@
+defmodule MingaEditor.Agent.RemoteFileEventsTest do
+  use Minga.Test.EditorCase, async: true
+
+  alias Minga.Buffer
+  alias MingaEditor.Agent.Events
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Remote
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.RemoteFileConflictSource
+
+  @moduletag :tmp_dir
+
+  test "agent file_changed reloads a clean remote buffer", %{tmp_dir: tmp_dir} do
+    ctx = start_editor("initial")
+    path = Path.join(tmp_dir, "file.ex")
+    File.write!(path, "before")
+    {:ok, buffer} = Buffer.start_link(file_path: path, storage: {:remote, node(), path})
+
+    state =
+      ctx
+      |> editor_state()
+      |> EditorState.update_remote(&Remote.put_buffer(&1, "home", path, buffer))
+
+    {state, effects} = Events.handle(state, {:file_changed, path, "before", "after"})
+
+    assert Buffer.content(buffer) == "after"
+    refute Buffer.dirty?(buffer)
+    assert {:log_message, "Agent updated file.ex"} in effects
+    assert %EditorState{} = state
+  end
+
+  test "agent file_changed keeps dirty remote buffer content and warns about conflict", %{
+    tmp_dir: tmp_dir
+  } do
+    ctx = start_editor("initial")
+    path = Path.join(tmp_dir, "file.ex")
+    File.write!(path, "before")
+    {:ok, buffer} = Buffer.start_link(file_path: path, storage: {:remote, node(), path})
+    :ok = Buffer.insert_text(buffer, "local ")
+
+    state =
+      ctx
+      |> editor_state()
+      |> EditorState.update_remote(&Remote.put_buffer(&1, "home", path, buffer))
+
+    {state, effects} = Events.handle(state, {:file_changed, path, "before", "after"})
+
+    assert Buffer.content(buffer) == "local before"
+    assert Buffer.dirty?(buffer)
+    assert state.shell_state.status_msg =~ "Agent modified this file"
+    assert {:log_warning, "Agent modified dirty remote file file.ex"} in effects
+    assert {:picker, %{picker_ui: %{source: RemoteFileConflictSource}}} = state.shell_state.modal
+  end
+
+  test "remote conflict prompt reload action discards local edits", %{tmp_dir: tmp_dir} do
+    ctx = start_editor("initial")
+    path = Path.join(tmp_dir, "file.ex")
+    File.write!(path, "before")
+    {:ok, buffer} = Buffer.start_link(file_path: path, storage: {:remote, node(), path})
+    :ok = Buffer.insert_text(buffer, "local ")
+
+    item = %Item{
+      id: {:remote_conflict, :reload, buffer, path, "after"},
+      label: "Reload"
+    }
+
+    state = RemoteFileConflictSource.on_select(item, editor_state(ctx))
+
+    assert Buffer.content(buffer) == "after"
+    refute Buffer.dirty?(buffer)
+    assert state.shell_state.status_msg == "Reloaded file.ex from remote"
+  end
+
+  test "remote conflict prompt keep action preserves local edits", %{tmp_dir: tmp_dir} do
+    ctx = start_editor("initial")
+    path = Path.join(tmp_dir, "file.ex")
+    File.write!(path, "before")
+    {:ok, buffer} = Buffer.start_link(file_path: path, storage: {:remote, node(), path})
+    :ok = Buffer.insert_text(buffer, "local ")
+
+    item = %Item{
+      id: {:remote_conflict, :keep, buffer, path, "after"},
+      label: "Keep editing"
+    }
+
+    state = RemoteFileConflictSource.on_select(item, editor_state(ctx))
+
+    assert Buffer.content(buffer) == "local before"
+    assert Buffer.dirty?(buffer)
+    assert state.shell_state.status_msg =~ "Keeping local edits"
+  end
+
+  test "remote conflict prompt show diff action leaves content untouched", %{tmp_dir: tmp_dir} do
+    ctx = start_editor("initial")
+    path = Path.join(tmp_dir, "file.ex")
+    File.write!(path, "before")
+    {:ok, buffer} = Buffer.start_link(file_path: path, storage: {:remote, node(), path})
+    :ok = Buffer.insert_text(buffer, "local ")
+
+    item = %Item{
+      id: {:remote_conflict, :show_diff, buffer, path, "after"},
+      label: "Show diff"
+    }
+
+    state = RemoteFileConflictSource.on_select(item, editor_state(ctx))
+
+    assert Buffer.content(buffer) == "local before"
+    assert Buffer.dirty?(buffer)
+    assert state.shell_state.status_msg == "Showing diff for file.ex"
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #1584 by making remote file picker results open as editable file buffers backed by remote storage instead of read-only scratch buffers.

## What changed

- Added remote buffer storage metadata and routed open/save/reload/stat through storage-aware helpers.
- Saved remote buffers write through `:erpc` on the owning node, with existing mtime/hash conflict checks preserved.
- Remote file opens now create normal editable `:file` buffers with remote storage and canonical remote paths.
- Remote agent `file_changed` events auto-reload clean buffers and show an actionable conflict picker for dirty buffers.
- LSP sync skips remote buffers so local language clients do not receive remote file paths.
- Added tests for remote storage, LSP skip behavior, and remote file event conflict actions.

## Validation

- `mix test.llm test/minga_editor/agent/remote_file_events_test.exs test/minga/buffer/remote_storage_test.exs test/minga/lsp/sync_server_test.exs`
- `make lint`
- `mix test --warnings-as-errors --exclude system_clipboard`
- `mix test.llm --max-cases 1`

Note: Normal parallel `mix test.llm` exposed unrelated existing async timeouts outside this diff on some runs. The failed locations passed when rerun directly, and the CI-equivalent full suite above passed cleanly.
