### PR TITLE
refactor(editor): direct Tab.Context construction without Map.from_struct

### DIFF
--- a/lib/minga_editor/state/tab/context.ex
+++ b/lib/minga_editor/state/tab/context.ex
@@ -16,6 +16,7 @@ defmodule MingaEditor.State.Tab.Context do
   alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   @version 1
 
@@ -114,7 +115,33 @@ defmodule MingaEditor.State.Tab.Context do
     end
   end
 
-  @doc "Builds a complete context from canonical workspace fields."
+  @doc "Creates a tab context directly from a workspace struct, without intermediate map conversion."
+  @spec from_workspace(WorkspaceState.t()) :: t()
+  def from_workspace(%WorkspaceState{} = ws) do
+    editing = VimState.normalize(ws.editing)
+
+    %__MODULE__{
+      version: @version,
+      keymap_scope: ws.keymap_scope,
+      buffers: ws.buffers,
+      windows: ws.windows,
+      file_tree: ws.file_tree,
+      dired: ws.dired,
+      viewport: ws.viewport,
+      mouse: ws.mouse,
+      highlight: ws.highlight,
+      lsp_pending: ws.lsp_pending,
+      injection_ranges: ws.injection_ranges,
+      search: ws.search,
+      editing: editing,
+      document_highlights: ws.document_highlights,
+      agent_ui: ws.agent_ui,
+      present_fields: @workspace_fields
+    }
+  end
+
+  @doc deprecated:
+         "Use from_workspace/1 for struct inputs. This remains for legacy map inputs only."
   @spec from_workspace_map(map()) :: t()
   def from_workspace_map(map) when is_map(map), do: from_map(map)
 

--- a/lib/minga_editor/workspace/state.ex
+++ b/lib/minga_editor/workspace/state.ex
@@ -68,19 +68,11 @@ defmodule MingaEditor.Workspace.State do
   @doc """
   Converts a workspace into a typed tab context suitable for storing on a `MingaEditor.State.Tab` and later restoring via `restore_tab_context/2`.
 
-  The single chokepoint for snapshots. Beyond the `Map.from_struct/1`
-  conversion, this normalises `editing` so the snapshotted vim state is a
-  valid resting state — not a transient mid-transition pair where
-  `mode_state` belongs to the leaving mode (see `VimState.normalize/1`).
-  Use this everywhere the editor captures `state.workspace` into a tab
-  context.
+  The single chokepoint for snapshots. Delegates to `TabContext.from_workspace/1` which constructs the context struct directly from the workspace struct (no intermediate map). The vim state is normalised so the snapshotted editing state is a valid resting state, not a transient mid-transition pair where `mode_state` belongs to the leaving mode (see `VimState.normalize/1`). Use this everywhere the editor captures `state.workspace` into a tab context.
   """
   @spec to_tab_context(t()) :: TabContext.t()
   def to_tab_context(%__MODULE__{} = ws) do
-    ws
-    |> Map.update!(:editing, &VimState.normalize/1)
-    |> Map.from_struct()
-    |> TabContext.from_workspace_map()
+    TabContext.from_workspace(ws)
   end
 
   @doc "Restores a tab context into a workspace. Empty contexts are ignored by this pure helper; EditorState handles brand-new tab defaults because those need editor dimensions."

--- a/test/minga_agent/tool/registry_test.exs
+++ b/test/minga_agent/tool/registry_test.exs
@@ -103,7 +103,9 @@ defmodule MingaAgent.Tool.RegistryTest do
       table = :"registry_init_#{:erlang.unique_integer([:positive])}"
       start_supervised!({Registry, name: table, project_root: "."})
 
-      expected_names = MingaAgent.Tools.all(project_root: ".") |> Enum.map(& &1.name) |> MapSet.new()
+      expected_names =
+        MingaAgent.Tools.all(project_root: ".") |> Enum.map(& &1.name) |> MapSet.new()
+
       registered_names = Registry.all(table) |> Enum.map(& &1.name) |> MapSet.new()
 
       assert expected_names == registered_names

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -257,6 +257,89 @@ defmodule MingaEditor.State.SnapshotTest do
     end
   end
 
+  describe "from_workspace/1 (direct struct-to-struct)" do
+    test "produces identical output to the legacy Map.from_struct path" do
+      {:ok, buf} = BufferServer.start_link(content: "hello")
+
+      ws = %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: %VimState{mode: :insert, mode_state: Mode.initial_state()},
+        buffers: %Buffers{active: buf, list: [buf]},
+        keymap_scope: :agent
+      }
+
+      # New direct path
+      new_ctx = Context.from_workspace(ws)
+
+      # Old path: normalize editing, Map.from_struct, from_workspace_map
+      old_ctx =
+        ws
+        |> Map.update!(:editing, &VimState.normalize/1)
+        |> Map.from_struct()
+        |> Context.from_workspace_map()
+
+      # All workspace data fields must match exactly
+      assert new_ctx.version == old_ctx.version
+      assert new_ctx.keymap_scope == old_ctx.keymap_scope
+      assert new_ctx.buffers == old_ctx.buffers
+      assert new_ctx.windows == old_ctx.windows
+      assert new_ctx.file_tree == old_ctx.file_tree
+      assert new_ctx.dired == old_ctx.dired
+      assert new_ctx.viewport == old_ctx.viewport
+      assert new_ctx.mouse == old_ctx.mouse
+      assert new_ctx.highlight == old_ctx.highlight
+      assert new_ctx.lsp_pending == old_ctx.lsp_pending
+      assert new_ctx.injection_ranges == old_ctx.injection_ranges
+      assert new_ctx.search == old_ctx.search
+      assert new_ctx.editing == old_ctx.editing
+      assert new_ctx.document_highlights == old_ctx.document_highlights
+      assert new_ctx.agent_ui == old_ctx.agent_ui
+
+      # present_fields contain the same fields (order is not semantically significant)
+      assert Enum.sort(new_ctx.present_fields) == Enum.sort(old_ctx.present_fields)
+
+      # Both produce the same workspace map on round-trip
+      assert Context.to_workspace_map(new_ctx) == Context.to_workspace_map(old_ctx)
+    end
+
+    test "round-trips through to_workspace_map preserving all fields" do
+      {:ok, buf} = BufferServer.start_link(content: "round-trip")
+
+      ws = %MingaEditor.Workspace.State{
+        viewport: Viewport.new(30, 100),
+        editing: %VimState{mode: :normal, mode_state: Mode.initial_state()},
+        buffers: %Buffers{active: buf, list: [buf]},
+        keymap_scope: :editor
+      }
+
+      ctx = Context.from_workspace(ws)
+      restored_map = Context.to_workspace_map(ctx)
+
+      assert restored_map.keymap_scope == :editor
+      assert restored_map.editing.mode == :normal
+      assert restored_map.buffers.active == buf
+      assert restored_map.viewport == ws.viewport
+      assert restored_map.windows == ws.windows
+      assert restored_map.mouse == ws.mouse
+      assert restored_map.highlight == ws.highlight
+      assert restored_map.search == ws.search
+    end
+
+    test "normalises transient vim state" do
+      ws = %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: %VimState{mode: :normal, mode_state: %Mode.CommandState{input: ""}},
+        buffers: %Buffers{},
+        keymap_scope: :editor
+      }
+
+      ctx = Context.from_workspace(ws)
+
+      assert ctx.editing.mode == :normal
+      assert match?(%Mode.State{}, ctx.editing.mode_state)
+    end
+  end
+
   describe "active_tab/1 and active_tab_kind/1" do
     test "returns the active tab" do
       tb = TabBar.new(Tab.new_file(1, "a"))


### PR DESCRIPTION
Closes #1592
Epic: #1395 (T4)

## Summary

- Adds `TabContext.from_workspace/1` that constructs a tab context directly from a `WorkspaceState` struct, copying known `@workspace_fields` explicitly without going through `Map.from_struct`
- Simplifies `WorkspaceState.to_tab_context/1` to a single delegation call
- Deprecates `from_workspace_map/1` (kept for legacy map inputs)
- 3 new tests: equivalence with legacy path, round-trip field preservation, vim state normalization

## Test plan

- [x] `mix test.llm test/minga_editor/state/snapshot_test.exs` — 19 tests pass (3 new)
- [x] `mix test.llm test/minga_editor/state/tab_switch_test.exs` — 9 tests pass
- [x] `mix test.llm test/minga_editor/state/buffer_lifecycle_test.exs` — 19 tests pass
- [x] `mix dialyzer` — passes
- [x] `grep -rn "Map.from_struct" lib/ | grep -i workspace` — zero results

🤖 Generated with [Claude Code](https://claude.ai/claude-code)