### PR TITLE
feat(editor): shell buffer callbacks return effects

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -723,10 +723,11 @@ defmodule MingaEditor do
     else
       # Background session: dispatch to shell for presentation updates
       # (tab badges, card status, attention flags, etc.)
-      {shell_state, workspace} =
+      {shell_state, workspace, shell_effects} =
         state.shell.on_agent_event(state.shell_state, state.workspace, session_pid, event)
 
       state = %{state | shell_state: shell_state, workspace: workspace}
+      state = apply_effects(state, shell_effects)
       {:noreply, schedule_render(state, 16)}
     end
   end

--- a/lib/minga_editor/shell/board.ex
+++ b/lib/minga_editor/shell/board.ex
@@ -432,35 +432,35 @@ defmodule MingaEditor.Shell.Board do
           MingaEditor.Workspace.State.t(),
           pid(),
           atom()
-        ) :: {BoardState.t(), MingaEditor.Workspace.State.t()}
+        ) :: {BoardState.t(), MingaEditor.Workspace.State.t(), [MingaEditor.effect()]}
   def on_buffer_added(shell_state, _prev_workspace, workspace, _buffer_pid, _context) do
     # Board: sync the active window buffer. A1's content-type guard
     # ensures agent_chat windows are left untouched.
     workspace = MingaEditor.Workspace.State.sync_active_window_buffer(workspace)
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   @spec on_buffer_added(BoardState.t(), MingaEditor.Workspace.State.t(), pid(), atom()) ::
-          {BoardState.t(), MingaEditor.Workspace.State.t()}
+          {BoardState.t(), MingaEditor.Workspace.State.t(), [MingaEditor.effect()]}
   def on_buffer_added(shell_state, workspace, buffer_pid, context \\ :open) do
     on_buffer_added(shell_state, workspace, workspace, buffer_pid, context)
   end
 
   @impl true
   @spec on_buffer_switched(BoardState.t(), MingaEditor.Workspace.State.t()) ::
-          {BoardState.t(), MingaEditor.Workspace.State.t()}
+          {BoardState.t(), MingaEditor.Workspace.State.t(), [MingaEditor.effect()]}
   def on_buffer_switched(shell_state, workspace) do
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   @impl true
   @spec on_buffer_died(BoardState.t(), MingaEditor.Workspace.State.t(), pid()) ::
-          {BoardState.t(), MingaEditor.Workspace.State.t()}
+          {BoardState.t(), MingaEditor.Workspace.State.t(), [MingaEditor.effect()]}
   def on_buffer_died(shell_state, workspace, _dead_pid) do
     # Board: sync the window if it's showing a buffer. The content-type
     # guard in sync_active_window_buffer ensures agent_chat is untouched.
     workspace = MingaEditor.Workspace.State.sync_active_window_buffer(workspace)
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   # -------------------------------------------------------------------
@@ -498,14 +498,14 @@ defmodule MingaEditor.Shell.Board do
 
   @impl true
   @spec on_agent_event(BoardState.t(), MingaEditor.Workspace.State.t(), pid(), term()) ::
-          {BoardState.t(), MingaEditor.Workspace.State.t()}
+          {BoardState.t(), MingaEditor.Workspace.State.t(), [MingaEditor.effect()]}
   def on_agent_event(shell_state, workspace, session_pid, {:status_changed, status}) do
     card_status = Card.from_agent_status(status)
 
     shell_state =
       update_card_by_session(shell_state, session_pid, &Card.set_status(&1, card_status))
 
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   # Cards have no separate attention flag; status :needs_you carries the alert.
@@ -513,18 +513,18 @@ defmodule MingaEditor.Shell.Board do
     shell_state =
       update_card_by_session(shell_state, session_pid, &Card.set_status(&1, :needs_you))
 
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   def on_agent_event(shell_state, workspace, session_pid, {:error, _message}) do
     shell_state =
       update_card_by_session(shell_state, session_pid, &Card.set_status(&1, :errored))
 
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   def on_agent_event(shell_state, workspace, _session_pid, _event) do
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   @spec card_for_session?(BoardState.t(), pid()) :: boolean()

--- a/lib/minga_editor/shell/buffer_lifecycle.ex
+++ b/lib/minga_editor/shell/buffer_lifecycle.ex
@@ -28,15 +28,15 @@ defmodule MingaEditor.Shell.BufferLifecycle do
               workspace(),
               buffer_pid :: pid(),
               context :: buffer_add_context()
-            ) :: {shell_state(), workspace()}
+            ) :: {shell_state(), workspace(), [MingaEditor.effect()]}
 
   @doc "The active buffer changed."
   @callback on_buffer_switched(shell_state(), workspace()) ::
-              {shell_state(), workspace()}
+              {shell_state(), workspace(), [MingaEditor.effect()]}
 
   @doc "A buffer process died."
   @callback on_buffer_died(shell_state(), workspace(), dead_pid :: pid()) ::
-              {shell_state(), workspace()}
+              {shell_state(), workspace(), [MingaEditor.effect()]}
 
   @doc """
   An agent session emitted an event. The shell reflects the status
@@ -49,5 +49,5 @@ defmodule MingaEditor.Shell.BufferLifecycle do
               workspace(),
               session_pid :: pid(),
               event :: term()
-            ) :: {shell_state(), workspace()}
+            ) :: {shell_state(), workspace(), [MingaEditor.effect()]}
 end

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -185,7 +185,7 @@ defmodule MingaEditor.Shell.Traditional do
           WorkspaceState.t(),
           pid(),
           atom()
-        ) :: {ShellState.t(), WorkspaceState.t()}
+        ) :: {ShellState.t(), WorkspaceState.t(), [MingaEditor.effect()]}
   def on_buffer_added(shell_state, prev_workspace, workspace, buffer_pid, context) do
     do_on_buffer_added(
       maybe_dismiss_dashboard(shell_state),
@@ -197,7 +197,7 @@ defmodule MingaEditor.Shell.Traditional do
   end
 
   @spec on_buffer_added(ShellState.t(), WorkspaceState.t(), pid(), atom()) ::
-          {ShellState.t(), WorkspaceState.t()}
+          {ShellState.t(), WorkspaceState.t(), [MingaEditor.effect()]}
   def on_buffer_added(shell_state, workspace, buffer_pid, context \\ :open) do
     on_buffer_added(shell_state, workspace, workspace, buffer_pid, context)
   end
@@ -218,7 +218,7 @@ defmodule MingaEditor.Shell.Traditional do
           WorkspaceState.t(),
           pid(),
           atom()
-        ) :: {ShellState.t(), WorkspaceState.t()}
+        ) :: {ShellState.t(), WorkspaceState.t(), [MingaEditor.effect()]}
   defp do_on_buffer_added(
          %ShellState{tab_bar: nil} = shell_state,
          _prev_workspace,
@@ -227,7 +227,7 @@ defmodule MingaEditor.Shell.Traditional do
          _context
        ) do
     workspace = WorkspaceState.sync_active_window_buffer(workspace)
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   defp do_on_buffer_added(
@@ -254,7 +254,7 @@ defmodule MingaEditor.Shell.Traditional do
             # The tab label stays as-is so confirm can detect "no tab for
             # this buffer" and create a new one.
             workspace = WorkspaceState.sync_active_window_buffer(workspace)
-            {shell_state, workspace}
+            {shell_state, workspace, []}
 
           {_, :agent} ->
             open_buffer_from_agent_tab(shell_state, prev_workspace, workspace, label)
@@ -267,9 +267,9 @@ defmodule MingaEditor.Shell.Traditional do
 
   @impl true
   @spec on_buffer_switched(ShellState.t(), WorkspaceState.t()) ::
-          {ShellState.t(), WorkspaceState.t()}
+          {ShellState.t(), WorkspaceState.t(), [MingaEditor.effect()]}
   def on_buffer_switched(%ShellState{tab_bar: nil} = shell_state, workspace) do
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   def on_buffer_switched(%ShellState{tab_bar: %TabBar{} = tb} = shell_state, workspace) do
@@ -278,19 +278,19 @@ defmodule MingaEditor.Shell.Traditional do
         label = buffer_label(workspace.buffers.active)
         tb = TabBar.update_label(tb, tb.active_id, label)
         tb = TabBar.update_context(tb, tb.active_id, WorkspaceState.to_tab_context(workspace))
-        {%{shell_state | tab_bar: tb}, workspace}
+        {%{shell_state | tab_bar: tb}, workspace, []}
 
       _ ->
-        {shell_state, workspace}
+        {shell_state, workspace, []}
     end
   end
 
   @impl true
   @spec on_buffer_died(ShellState.t(), WorkspaceState.t(), pid()) ::
-          {ShellState.t(), WorkspaceState.t()}
+          {ShellState.t(), WorkspaceState.t(), [MingaEditor.effect()]}
   def on_buffer_died(shell_state, workspace, _dead_pid) do
     workspace = WorkspaceState.sync_active_window_buffer(workspace)
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   # -------------------------------------------------------------------
@@ -299,9 +299,9 @@ defmodule MingaEditor.Shell.Traditional do
 
   @impl true
   @spec on_agent_event(ShellState.t(), WorkspaceState.t(), pid(), term()) ::
-          {ShellState.t(), WorkspaceState.t()}
+          {ShellState.t(), WorkspaceState.t(), [MingaEditor.effect()]}
   def on_agent_event(%ShellState{tab_bar: nil} = shell_state, workspace, _session_pid, _event) do
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   def on_agent_event(
@@ -325,7 +325,7 @@ defmodule MingaEditor.Shell.Traditional do
         tb
       end
 
-    {%{shell_state | tab_bar: tb}, workspace}
+    {%{shell_state | tab_bar: tb}, workspace, []}
   end
 
   def on_agent_event(
@@ -335,7 +335,7 @@ defmodule MingaEditor.Shell.Traditional do
         {:approval_pending, _}
       ) do
     tb = TabBar.set_attention_by_session(tb, session_pid, true)
-    {%{shell_state | tab_bar: tb}, workspace}
+    {%{shell_state | tab_bar: tb}, workspace, []}
   end
 
   # A direct :error event raises attention so a background tab whose session
@@ -349,11 +349,11 @@ defmodule MingaEditor.Shell.Traditional do
         {:error, _message}
       ) do
     tb = TabBar.set_attention_by_session(tb, session_pid, true)
-    {%{shell_state | tab_bar: tb}, workspace}
+    {%{shell_state | tab_bar: tb}, workspace, []}
   end
 
   def on_agent_event(shell_state, workspace, _session_pid, _event) do
-    {shell_state, workspace}
+    {shell_state, workspace, []}
   end
 
   # -------------------------------------------------------------------
@@ -456,13 +456,13 @@ defmodule MingaEditor.Shell.Traditional do
 
   # Switch to an existing file tab that matches the buffer being opened.
   @spec switch_to_buffer_tab(ShellState.t(), WorkspaceState.t(), Tab.id()) ::
-          {ShellState.t(), WorkspaceState.t()}
+          {ShellState.t(), WorkspaceState.t(), [MingaEditor.effect()]}
   defp switch_to_buffer_tab(shell_state, workspace, target_id) do
     switch_to_buffer_tab(shell_state, workspace, workspace, target_id)
   end
 
   @spec switch_to_buffer_tab(ShellState.t(), WorkspaceState.t(), WorkspaceState.t(), Tab.id()) ::
-          {ShellState.t(), WorkspaceState.t()}
+          {ShellState.t(), WorkspaceState.t(), [MingaEditor.effect()]}
   defp switch_to_buffer_tab(
          %ShellState{tab_bar: tb} = shell_state,
          prev_workspace,
@@ -472,7 +472,7 @@ defmodule MingaEditor.Shell.Traditional do
     current_id = tb.active_id
 
     if current_id == target_id do
-      {shell_state, workspace}
+      {shell_state, workspace, []}
     else
       # Snapshot the outgoing tab before the buffer-pool mutation that triggered this switch.
       context = WorkspaceState.to_tab_context(prev_workspace)
@@ -487,18 +487,20 @@ defmodule MingaEditor.Shell.Traditional do
       tb = TabBar.update_tab(tb, target_id, &Tab.set_attention(&1, false))
 
       workspace = WorkspaceState.invalidate_all_windows(workspace)
-      {%{shell_state | tab_bar: tb}, workspace}
+      {%{shell_state | tab_bar: tb}, workspace, []}
     end
   end
 
   # Opens a file buffer when the active tab is an agent tab.
   # Creates a new file tab, resets agent UI state, and syncs the window.
+  # Returns a :stop_spinner effect so the Editor cancels the outgoing
+  # agent spinner timer when leaving the agent context.
   @spec open_buffer_from_agent_tab(
           ShellState.t(),
           WorkspaceState.t(),
           WorkspaceState.t(),
           String.t()
-        ) :: {ShellState.t(), WorkspaceState.t()}
+        ) :: {ShellState.t(), WorkspaceState.t(), [MingaEditor.effect()]}
   defp open_buffer_from_agent_tab(
          %ShellState{tab_bar: tb} = shell_state,
          prev_workspace,
@@ -523,7 +525,7 @@ defmodule MingaEditor.Shell.Traditional do
 
     Log.debug(:editor, fn -> "[tab] on_buffer_added new tab=#{new_tab.id} label=#{label}" end)
 
-    {%{shell_state | tab_bar: tb}, workspace}
+    {%{shell_state | tab_bar: tb}, workspace, [:stop_spinner]}
   end
 
   # Opens a file buffer when the active tab is already a file tab.
@@ -534,7 +536,7 @@ defmodule MingaEditor.Shell.Traditional do
           WorkspaceState.t(),
           WorkspaceState.t(),
           String.t()
-        ) :: {ShellState.t(), WorkspaceState.t()}
+        ) :: {ShellState.t(), WorkspaceState.t(), [MingaEditor.effect()]}
   defp open_buffer_in_file_tab(
          %ShellState{tab_bar: tb} = shell_state,
          prev_workspace,
@@ -553,7 +555,7 @@ defmodule MingaEditor.Shell.Traditional do
     new_context = WorkspaceState.to_tab_context(workspace)
     tb = TabBar.update_context(tb, new_tab.id, new_context)
 
-    {%{shell_state | tab_bar: tb}, workspace}
+    {%{shell_state | tab_bar: tb}, workspace, []}
   end
 
   # Resets the active window's content type from agent_chat back to buffer.

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -511,10 +511,10 @@ defmodule MingaEditor.State do
     state = do_remove_dead_buffer(state, pid)
 
     # Dispatch to the shell for presentation cleanup (tab removal, card updates, etc.)
-    {shell_state, workspace} =
+    {shell_state, workspace, shell_effects} =
       state.shell.on_buffer_died(state.shell_state, state.workspace, pid)
 
-    {%{state | shell_state: shell_state, workspace: workspace}, []}
+    {%{state | shell_state: shell_state, workspace: workspace}, shell_effects}
   end
 
   @doc """
@@ -855,7 +855,7 @@ defmodule MingaEditor.State do
     state = put_in(state.workspace.buffers, new_bs)
 
     # Dispatch to the active shell for presentation logic
-    {shell_state, workspace} =
+    {shell_state, workspace, shell_effects} =
       state.shell.on_buffer_added(
         state.shell_state,
         prev_workspace,
@@ -867,7 +867,7 @@ defmodule MingaEditor.State do
     state = %{state | shell_state: shell_state, workspace: workspace, buffer_add_context: :open}
 
     effects = if already_pooled, do: [], else: [{:monitor, pid}]
-    {state, effects}
+    {state, effects ++ shell_effects}
   end
 
   @doc """
@@ -898,10 +898,11 @@ defmodule MingaEditor.State do
         %{state | buffer_add_context: :open}
 
       :open ->
-        {shell_state, workspace} =
+        {shell_state, workspace, shell_effects} =
           state.shell.on_buffer_switched(state.shell_state, state.workspace)
 
-        %{state | shell_state: shell_state, workspace: workspace}
+        state = %{state | shell_state: shell_state, workspace: workspace}
+        apply_buffer_effects(state, shell_effects)
     end
   end
 

--- a/test/minga_agent/tool/registry_test.exs
+++ b/test/minga_agent/tool/registry_test.exs
@@ -103,7 +103,9 @@ defmodule MingaAgent.Tool.RegistryTest do
       table = :"registry_init_#{:erlang.unique_integer([:positive])}"
       start_supervised!({Registry, name: table, project_root: "."})
 
-      expected_names = MingaAgent.Tools.all(project_root: ".") |> Enum.map(& &1.name) |> MapSet.new()
+      expected_names =
+        MingaAgent.Tools.all(project_root: ".") |> Enum.map(& &1.name) |> MapSet.new()
+
       registered_names = Registry.all(table) |> Enum.map(& &1.name) |> MapSet.new()
 
       assert expected_names == registered_names

--- a/test/minga_editor/agent/event_routing_test.exs
+++ b/test/minga_editor/agent/event_routing_test.exs
@@ -64,7 +64,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
     test "background :status_changed event sets the owning tab's badge without touching the active rendering cache",
          %{shell_state: ss, session_b: session_b} do
-      {ss2, ws2} =
+      {ss2, ws2, effects} =
         Traditional.on_agent_event(ss, workspace(), session_b, {:status_changed, :thinking})
 
       # Background tab's badge updates...
@@ -77,13 +77,14 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       # Workspace is also untouched: background events must not nudge the
       # active tab's editing surface.
       assert ws2 == workspace()
+      assert effects == []
     end
 
     test "background :status_changed -> :idle raises attention on the owning tab", %{
       shell_state: ss,
       session_b: session_b
     } do
-      {ss2, _ws} =
+      {ss2, _ws, _effects} =
         Traditional.on_agent_event(ss, workspace(), session_b, {:status_changed, :idle})
 
       assert tab(ss2.tab_bar, 2).attention == true
@@ -96,7 +97,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
     } do
       approval = %{tool_call_id: "x", name: "shell", args: %{}}
 
-      {ss2, _ws} =
+      {ss2, _ws, _effects} =
         Traditional.on_agent_event(ss, workspace(), session_b, {:approval_pending, approval})
 
       assert tab(ss2.tab_bar, 2).attention == true
@@ -107,7 +108,9 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       shell_state: ss,
       session_b: session_b
     } do
-      {ss2, _ws} = Traditional.on_agent_event(ss, workspace(), session_b, {:error, "boom"})
+      {ss2, _ws, _effects} =
+        Traditional.on_agent_event(ss, workspace(), session_b, {:error, "boom"})
+
       assert tab(ss2.tab_bar, 2).attention == true
       assert tab(ss2.tab_bar, 1).attention == false
     end
@@ -119,16 +122,22 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       # Streaming text from a background session must not reach this callback's
       # mutation path — the delta is purely a no-op so the active tab's UI
       # never re-renders for unrelated streaming.
-      {ss2, ws2} = Traditional.on_agent_event(ss, workspace(), session_b, {:text_delta, "hello"})
+      {ss2, ws2, effects} =
+        Traditional.on_agent_event(ss, workspace(), session_b, {:text_delta, "hello"})
+
       assert ss2 == ss
       assert ws2 == workspace()
+      assert effects == []
     end
 
     test "events from a session that no longer maps to any tab are silently dropped", %{
       shell_state: ss
     } do
       ghost = spawn(fn -> :ok end)
-      {ss2, _ws} = Traditional.on_agent_event(ss, workspace(), ghost, {:status_changed, :error})
+
+      {ss2, _ws, _effects} =
+        Traditional.on_agent_event(ss, workspace(), ghost, {:status_changed, :error})
+
       assert ss2.tab_bar == ss.tab_bar
     end
   end
@@ -153,7 +162,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
     } do
       # Tab.agent_status uses :thinking; Card.status uses :working — the
       # Board callback applies the mapping rather than stamping the raw atom.
-      {board2, _ws} =
+      {board2, _ws, _effects} =
         Board.on_agent_event(board, workspace(), session_b, {:status_changed, :thinking})
 
       [card_b] = Enum.filter(Map.values(board2.cards), &(&1.session == session_b))
@@ -168,7 +177,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       board: board,
       session_b: session_b
     } do
-      {board2, _ws} =
+      {board2, _ws, _effects} =
         Board.on_agent_event(board, workspace(), session_b, {:approval_pending, %{name: "shell"}})
 
       [card_b] = Enum.filter(Map.values(board2.cards), &(&1.session == session_b))
@@ -179,14 +188,19 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       board: board,
       session_b: session_b
     } do
-      {board2, _ws} = Board.on_agent_event(board, workspace(), session_b, {:error, "boom"})
+      {board2, _ws, _effects} =
+        Board.on_agent_event(board, workspace(), session_b, {:error, "boom"})
+
       [card_b] = Enum.filter(Map.values(board2.cards), &(&1.session == session_b))
       assert card_b.status == :errored
     end
 
     test "events for a session not attached to any card are silently dropped", %{board: board} do
       ghost = spawn(fn -> :ok end)
-      {board2, _ws} = Board.on_agent_event(board, workspace(), ghost, {:approval_pending, %{}})
+
+      {board2, _ws, _effects} =
+        Board.on_agent_event(board, workspace(), ghost, {:approval_pending, %{}})
+
       assert board2 == board
     end
   end

--- a/test/minga_editor/shell/traditional/on_buffer_added_test.exs
+++ b/test/minga_editor/shell/traditional/on_buffer_added_test.exs
@@ -32,7 +32,8 @@ defmodule MingaEditor.Shell.Traditional.OnBufferAddedTest do
 
       {:ok, buf} = BufferServer.start_link(content: "hello")
 
-      {new_shell, _ws} = Traditional.on_buffer_added(shell_state, blank_workspace(), buf, :open)
+      {new_shell, _ws, _effects} =
+        Traditional.on_buffer_added(shell_state, blank_workspace(), buf, :open)
 
       assert new_shell.modal == :none
     end
@@ -49,7 +50,8 @@ defmodule MingaEditor.Shell.Traditional.OnBufferAddedTest do
 
       {:ok, buf} = BufferServer.start_link(content: "hello")
 
-      {new_shell, _ws} = Traditional.on_buffer_added(shell_state, blank_workspace(), buf, :open)
+      {new_shell, _ws, _effects} =
+        Traditional.on_buffer_added(shell_state, blank_workspace(), buf, :open)
 
       assert new_shell.modal == {:picker, picker_payload}
     end
@@ -58,7 +60,8 @@ defmodule MingaEditor.Shell.Traditional.OnBufferAddedTest do
       shell_state = %ShellState{modal: :none}
       {:ok, buf} = BufferServer.start_link(content: "hello")
 
-      {new_shell, _ws} = Traditional.on_buffer_added(shell_state, blank_workspace(), buf, :open)
+      {new_shell, _ws, _effects} =
+        Traditional.on_buffer_added(shell_state, blank_workspace(), buf, :open)
 
       assert new_shell.modal == :none
     end

--- a/test/minga_editor/state/buffer_lifecycle_test.exs
+++ b/test/minga_editor/state/buffer_lifecycle_test.exs
@@ -285,6 +285,26 @@ defmodule MingaEditor.State.BufferLifecycleTest do
       assert Content.buffer?(window.content)
     end
 
+    test "opening a file from an agent tab returns :stop_spinner effect" do
+      {state, _agent_buf} = state_with_agent_tab()
+      file_buf = start_buffer("file content")
+
+      {_new_state, effects} = EditorState.add_buffer_pure(state, file_buf, context: :open)
+
+      assert :stop_spinner in effects
+      assert {:monitor, file_buf} in effects
+    end
+
+    test "opening a file from a file tab does not return :stop_spinner effect" do
+      state = state_with_file_tab()
+      file_buf = start_buffer("new file")
+
+      {_new_state, effects} = EditorState.add_buffer_pure(state, file_buf, context: :open)
+
+      refute :stop_spinner in effects
+      assert {:monitor, file_buf} in effects
+    end
+
     test "adds duplicate buffer (switches to existing tab)" do
       state = state_with_file_tab()
       buf = state.workspace.buffers.active


### PR DESCRIPTION
Closes #1590
Epic: #1395 (T2)

## Summary

- Widens return type of all four `Shell.BufferLifecycle` callbacks (`on_buffer_added`, `on_buffer_switched`, `on_buffer_died`, `on_agent_event`) from `{shell_state, workspace}` to `{shell_state, workspace, [effect()]}`
- Traditional shell's `open_buffer_from_agent_tab` returns `[:stop_spinner]` so the agent spinner is properly cancelled when leaving an agent tab via file open
- `add_buffer_pure` and `close_buffer_pure` propagate shell effects in their return lists; `switch_buffer` applies them inline
- Updated all Board shell implementations to return empty effects
- 2 new tests + 15 existing tests updated for the new 3-tuple return

## Test plan

- [x] `mix test.llm test/minga_editor/state/buffer_lifecycle_test.exs` — 21 tests pass (2 new)
- [x] `mix test.llm test/minga_editor/state/shell_callbacks_test.exs` — 19 tests pass
- [x] `mix test.llm test/minga_editor/agent/event_routing_test.exs` — 12 tests pass
- [x] `mix test.llm test/minga_editor/shell/traditional/on_buffer_added_test.exs` — 3 tests pass
- [x] `mix test.llm` — full suite passes (8236 tests, 3 pre-existing flaky failures only)
- [x] `make lint` — passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)