### PR TITLE
feat(editor): Credo guard for Map.from_struct(workspace)

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -30,6 +30,7 @@
           {Minga.Credo.NoDirectLoggerCheck, [exit_status: 0]},
           {Minga.Credo.NoDirectStateMachineWriteCheck, []},
           {Minga.Credo.NoDirectModalOverlayWriteCheck, []},
+          {Minga.Credo.NoRawWorkspaceSnapshotCheck, []},
 
           # ── Readability ────────────────────────────────────────────────────
           {Credo.Check.Readability.AliasOrder, false},

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,6 +388,19 @@ LLM agents hit these repeatedly. Read before writing any Elixir:
 - **Don't use map access syntax on structs.** `my_struct[:field]` doesn't work (structs don't implement Access). Use `my_struct.field` or pattern match.
 - **`mix deps.clean --all` is almost never needed.** Don't nuke deps as a first troubleshooting step. Try `mix deps.get` or `mix compile --force` first.
 
+### Custom Credo Checks
+
+Minga has project-specific Credo checks in `credo/checks/`. These enforce architectural rules that are easy to violate accidentally and hard to catch in review. All run as part of `make lint`.
+
+| Check | ID | What it guards |
+|-------|----|----------------|
+| `DependencyDirectionCheck` | EX9001 | Layer 0/1/2 dependency direction (Rule 1). Flags `alias`/`import` from a lower layer to a higher one. |
+| `NoProcessSleepCheck` | EX9002 | No `Process.sleep/1` in production code. Use `Process.send_after/3` or state machines. |
+| `NoDirectLoggerCheck` | EX9003 | No direct `Logger` calls. Use `Minga.Log.{level}(:subsystem, msg)` for filtered logging. |
+| `NoDirectStateMachineWriteCheck` | EX9004 | State machine fields (`mode:`, nested struct fields on `editing:`, `workspace:`) must go through gate functions, not raw map updates. |
+| `NoDirectModalOverlayWriteCheck` | EX9005 | Modal overlay writes must flow through `MingaEditor.State.ModalOverlay`, not raw `%{state \| modal: ...}`. |
+| `NoRawWorkspaceSnapshotCheck` | EX9006 | No `Map.from_struct` on workspace structs. Use `TabContext.from_workspace/1` instead of converting to an intermediate map. See #1403. |
+
 ### Pre-commit Checks (enforced by commit-gate extension)
 
 The `commit-gate` extension blocks every `git commit` until all checks pass. You don't need to remember this; the extension catches it automatically. But you should still run all relevant checks proactively, not just wait for the gate to yell at you. Running checks proactively is faster than getting blocked and re-running the review cycle.

--- a/credo/checks/no_raw_workspace_snapshot_check.exs
+++ b/credo/checks/no_raw_workspace_snapshot_check.exs
@@ -1,0 +1,108 @@
+defmodule Minga.Credo.NoRawWorkspaceSnapshotCheck do
+  @moduledoc """
+  Forbids `Map.from_struct/1` on workspace structs. Use `TabContext.from_workspace/1` instead.
+
+  ## Why this exists
+
+  `Map.from_struct(workspace)` produces a bare map that strips the struct
+  tag and loses compile-time key checking. Code that snapshots a workspace
+  this way silently breaks whenever a field is added or removed from
+  `WorkspaceState`, because the intermediate map has no contract.
+
+  Issue #1592 replaced the last `Map.from_struct(workspace)` call site with
+  `TabContext.from_workspace/1`, which constructs the snapshot struct
+  directly from the workspace fields. This check prevents the fragile
+  intermediate-map pattern from being reintroduced.
+
+  ## What this checks
+
+  Any call to `Map.from_struct(arg)` where `arg` looks workspace-related:
+  - A variable named `workspace` or `ws`
+  - A dot access ending in `.workspace` (e.g., `state.workspace`)
+
+  ## What to do instead
+
+      # Bad: loses struct tag, silently breaks on field changes
+      map = Map.from_struct(workspace)
+
+      # Good: type-safe, explicit field selection
+      context = TabContext.from_workspace(workspace)
+
+  ## Exceptions
+
+  - Test files are skipped
+  - Modules listed in the `:allowed_files` param are skipped
+  """
+
+  use Credo.Check,
+    id: "EX9006",
+    base_priority: :normal,
+    category: :design,
+    param_defaults: [
+      allowed_files: []
+    ],
+    explanations: [
+      check: """
+      Use `TabContext.from_workspace/1` instead of `Map.from_struct` on
+      workspace structs. The intermediate map loses the struct tag and
+      silently breaks when WorkspaceState fields change. See #1403.
+      """,
+      params: [
+        allowed_files:
+          "Filename suffixes or path fragments where Map.from_struct on workspace is permitted."
+      ]
+    ]
+
+  @impl Credo.Check
+  @spec run(Credo.SourceFile.t(), keyword()) :: [Credo.Issue.t()]
+  def run(%SourceFile{} = source_file, params) do
+    if skip_file?(source_file, params) do
+      []
+    else
+      issue_meta = IssueMeta.for(source_file, params)
+
+      source_file
+      |> Credo.Code.prewalk(&find_raw_workspace_snapshot(&1, &2, issue_meta))
+      |> List.flatten()
+    end
+  end
+
+  # Match `Map.from_struct(arg)` where arg is workspace-related
+  defp find_raw_workspace_snapshot(
+         {{:., _, [{:__aliases__, _, [:Map]}, :from_struct]}, meta, [arg]} = ast,
+         issues,
+         issue_meta
+       ) do
+    if workspace_arg?(arg) do
+      issue =
+        format_issue(issue_meta,
+          message:
+            "Use TabContext.from_workspace/1 instead of Map.from_struct on workspace structs. See #1403.",
+          trigger: "Map.from_struct",
+          line_no: meta[:line]
+        )
+
+      {ast, [issue | issues]}
+    else
+      {ast, issues}
+    end
+  end
+
+  defp find_raw_workspace_snapshot(ast, issues, _issue_meta), do: {ast, issues}
+
+  # Variable named :workspace or :ws
+  defp workspace_arg?({name, _, _}) when name in [:workspace, :ws], do: true
+
+  # Dot access ending in .workspace (e.g., state.workspace, s.workspace)
+  defp workspace_arg?({{:., _, [_, :workspace]}, _, _}), do: true
+
+  defp workspace_arg?(_), do: false
+
+  defp skip_file?(%SourceFile{} = source_file, params) do
+    filename = Path.expand(source_file.filename)
+    allowed = Params.get(params, :allowed_files, __MODULE__)
+
+    String.contains?(filename, "/test/") or
+      Enum.any?(allowed, fn suffix -> String.contains?(filename, suffix) end)
+  end
+end

--- a/lib/minga_editor/state/tab/context.ex
+++ b/lib/minga_editor/state/tab/context.ex
@@ -16,6 +16,7 @@ defmodule MingaEditor.State.Tab.Context do
   alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   @version 1
 
@@ -114,7 +115,33 @@ defmodule MingaEditor.State.Tab.Context do
     end
   end
 
-  @doc "Builds a complete context from canonical workspace fields."
+  @doc "Creates a tab context directly from a workspace struct, without intermediate map conversion."
+  @spec from_workspace(WorkspaceState.t()) :: t()
+  def from_workspace(%WorkspaceState{} = ws) do
+    editing = VimState.normalize(ws.editing)
+
+    %__MODULE__{
+      version: @version,
+      keymap_scope: ws.keymap_scope,
+      buffers: ws.buffers,
+      windows: ws.windows,
+      file_tree: ws.file_tree,
+      dired: ws.dired,
+      viewport: ws.viewport,
+      mouse: ws.mouse,
+      highlight: ws.highlight,
+      lsp_pending: ws.lsp_pending,
+      injection_ranges: ws.injection_ranges,
+      search: ws.search,
+      editing: editing,
+      document_highlights: ws.document_highlights,
+      agent_ui: ws.agent_ui,
+      present_fields: @workspace_fields
+    }
+  end
+
+  @doc deprecated:
+         "Use from_workspace/1 for struct inputs. This remains for legacy map inputs only."
   @spec from_workspace_map(map()) :: t()
   def from_workspace_map(map) when is_map(map), do: from_map(map)
 

--- a/lib/minga_editor/workspace/state.ex
+++ b/lib/minga_editor/workspace/state.ex
@@ -68,19 +68,11 @@ defmodule MingaEditor.Workspace.State do
   @doc """
   Converts a workspace into a typed tab context suitable for storing on a `MingaEditor.State.Tab` and later restoring via `restore_tab_context/2`.
 
-  The single chokepoint for snapshots. Beyond the `Map.from_struct/1`
-  conversion, this normalises `editing` so the snapshotted vim state is a
-  valid resting state — not a transient mid-transition pair where
-  `mode_state` belongs to the leaving mode (see `VimState.normalize/1`).
-  Use this everywhere the editor captures `state.workspace` into a tab
-  context.
+  The single chokepoint for snapshots. Delegates to `TabContext.from_workspace/1` which constructs the context struct directly from the workspace struct (no intermediate map). The vim state is normalised so the snapshotted editing state is a valid resting state, not a transient mid-transition pair where `mode_state` belongs to the leaving mode (see `VimState.normalize/1`). Use this everywhere the editor captures `state.workspace` into a tab context.
   """
   @spec to_tab_context(t()) :: TabContext.t()
   def to_tab_context(%__MODULE__{} = ws) do
-    ws
-    |> Map.update!(:editing, &VimState.normalize/1)
-    |> Map.from_struct()
-    |> TabContext.from_workspace_map()
+    TabContext.from_workspace(ws)
   end
 
   @doc "Restores a tab context into a workspace. Empty contexts are ignored by this pure helper; EditorState handles brand-new tab defaults because those need editor dimensions."

--- a/test/minga/credo/no_raw_workspace_snapshot_check_test.exs
+++ b/test/minga/credo/no_raw_workspace_snapshot_check_test.exs
@@ -1,0 +1,103 @@
+Code.require_file("credo/checks/no_raw_workspace_snapshot_check.exs")
+
+defmodule Minga.Credo.NoRawWorkspaceSnapshotCheckTest do
+  use Credo.Test.Case, async: true
+
+  alias Minga.Credo.NoRawWorkspaceSnapshotCheck
+
+  @moduletag :credo
+
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  defp check(source_code, filename \\ "lib/minga_editor/workspace/snapshot.ex") do
+    source_code
+    |> to_source_file(filename)
+    |> run_check(NoRawWorkspaceSnapshotCheck, [])
+  end
+
+  describe "flags workspace-related Map.from_struct calls" do
+    test "flags Map.from_struct(workspace)" do
+      """
+      defmodule MingaEditor.BadSnapshot do
+        def snapshot(workspace) do
+          Map.from_struct(workspace)
+        end
+      end
+      """
+      |> check()
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "TabContext.from_workspace/1"
+        assert issue.message =~ "#1403"
+      end)
+    end
+
+    test "flags Map.from_struct(state.workspace)" do
+      """
+      defmodule MingaEditor.BadSnapshot do
+        def snapshot(state) do
+          Map.from_struct(state.workspace)
+        end
+      end
+      """
+      |> check()
+      |> assert_issue(fn issue ->
+        assert issue.trigger == "Map.from_struct"
+      end)
+    end
+
+    test "flags Map.from_struct(ws)" do
+      """
+      defmodule MingaEditor.BadSnapshot do
+        def snapshot(ws) do
+          Map.from_struct(ws)
+        end
+      end
+      """
+      |> check()
+      |> assert_issue()
+    end
+  end
+
+  describe "ignores non-workspace Map.from_struct calls" do
+    test "allows Map.from_struct(theme)" do
+      """
+      defmodule MingaEditor.ThemeConverter do
+        def to_map(theme) do
+          Map.from_struct(theme)
+        end
+      end
+      """
+      |> check()
+      |> refute_issues()
+    end
+
+    test "allows Map.from_struct(tb)" do
+      """
+      defmodule MingaEditor.ToolbarConverter do
+        def to_map(tb) do
+          Map.from_struct(tb)
+        end
+      end
+      """
+      |> check()
+      |> refute_issues()
+    end
+  end
+
+  describe "skips test files" do
+    test "allows Map.from_struct(workspace) in test files" do
+      """
+      defmodule MingaEditor.WorkspaceTest do
+        def test_helper(workspace) do
+          Map.from_struct(workspace)
+        end
+      end
+      """
+      |> check("test/minga_editor/workspace_test.exs")
+      |> refute_issues()
+    end
+  end
+end

--- a/test/minga_agent/tool/registry_test.exs
+++ b/test/minga_agent/tool/registry_test.exs
@@ -103,7 +103,9 @@ defmodule MingaAgent.Tool.RegistryTest do
       table = :"registry_init_#{:erlang.unique_integer([:positive])}"
       start_supervised!({Registry, name: table, project_root: "."})
 
-      expected_names = MingaAgent.Tools.all(project_root: ".") |> Enum.map(& &1.name) |> MapSet.new()
+      expected_names =
+        MingaAgent.Tools.all(project_root: ".") |> Enum.map(& &1.name) |> MapSet.new()
+
       registered_names = Registry.all(table) |> Enum.map(& &1.name) |> MapSet.new()
 
       assert expected_names == registered_names

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -257,6 +257,89 @@ defmodule MingaEditor.State.SnapshotTest do
     end
   end
 
+  describe "from_workspace/1 (direct struct-to-struct)" do
+    test "produces identical output to the legacy Map.from_struct path" do
+      {:ok, buf} = BufferServer.start_link(content: "hello")
+
+      ws = %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: %VimState{mode: :insert, mode_state: Mode.initial_state()},
+        buffers: %Buffers{active: buf, list: [buf]},
+        keymap_scope: :agent
+      }
+
+      # New direct path
+      new_ctx = Context.from_workspace(ws)
+
+      # Old path: normalize editing, Map.from_struct, from_workspace_map
+      old_ctx =
+        ws
+        |> Map.update!(:editing, &VimState.normalize/1)
+        |> Map.from_struct()
+        |> Context.from_workspace_map()
+
+      # All workspace data fields must match exactly
+      assert new_ctx.version == old_ctx.version
+      assert new_ctx.keymap_scope == old_ctx.keymap_scope
+      assert new_ctx.buffers == old_ctx.buffers
+      assert new_ctx.windows == old_ctx.windows
+      assert new_ctx.file_tree == old_ctx.file_tree
+      assert new_ctx.dired == old_ctx.dired
+      assert new_ctx.viewport == old_ctx.viewport
+      assert new_ctx.mouse == old_ctx.mouse
+      assert new_ctx.highlight == old_ctx.highlight
+      assert new_ctx.lsp_pending == old_ctx.lsp_pending
+      assert new_ctx.injection_ranges == old_ctx.injection_ranges
+      assert new_ctx.search == old_ctx.search
+      assert new_ctx.editing == old_ctx.editing
+      assert new_ctx.document_highlights == old_ctx.document_highlights
+      assert new_ctx.agent_ui == old_ctx.agent_ui
+
+      # present_fields contain the same fields (order is not semantically significant)
+      assert Enum.sort(new_ctx.present_fields) == Enum.sort(old_ctx.present_fields)
+
+      # Both produce the same workspace map on round-trip
+      assert Context.to_workspace_map(new_ctx) == Context.to_workspace_map(old_ctx)
+    end
+
+    test "round-trips through to_workspace_map preserving all fields" do
+      {:ok, buf} = BufferServer.start_link(content: "round-trip")
+
+      ws = %MingaEditor.Workspace.State{
+        viewport: Viewport.new(30, 100),
+        editing: %VimState{mode: :normal, mode_state: Mode.initial_state()},
+        buffers: %Buffers{active: buf, list: [buf]},
+        keymap_scope: :editor
+      }
+
+      ctx = Context.from_workspace(ws)
+      restored_map = Context.to_workspace_map(ctx)
+
+      assert restored_map.keymap_scope == :editor
+      assert restored_map.editing.mode == :normal
+      assert restored_map.buffers.active == buf
+      assert restored_map.viewport == ws.viewport
+      assert restored_map.windows == ws.windows
+      assert restored_map.mouse == ws.mouse
+      assert restored_map.highlight == ws.highlight
+      assert restored_map.search == ws.search
+    end
+
+    test "normalises transient vim state" do
+      ws = %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: %VimState{mode: :normal, mode_state: %Mode.CommandState{input: ""}},
+        buffers: %Buffers{},
+        keymap_scope: :editor
+      }
+
+      ctx = Context.from_workspace(ws)
+
+      assert ctx.editing.mode == :normal
+      assert match?(%Mode.State{}, ctx.editing.mode_state)
+    end
+  end
+
   describe "active_tab/1 and active_tab_kind/1" do
     test "returns the active tab" do
       tb = TabBar.new(Tab.new_file(1, "a"))


### PR DESCRIPTION
Closes #1403
Epic: #1395 (T5)
Depends on: #1596

## Summary

- New custom Credo check `NoRawWorkspaceSnapshotCheck` (EX9006) rejects `Map.from_struct/1` on workspace-related arguments (`workspace`, `ws`, `*.workspace`)
- Prevents reintroduction of the fragile intermediate-map pattern that T4 (#1592) eliminated
- Configurable allowlist for future exemptions (currently empty)
- Documented all 6 custom Credo checks (EX9001-EX9006) in AGENTS.md
- 6 tests: 3 positive (flags workspace variants), 2 negative (ignores non-workspace), 1 skip (test files)

## Test plan

- [x] `mix test.llm test/minga/credo/no_raw_workspace_snapshot_check_test.exs` — 6 tests pass
- [x] `make lint` — passes (no violations in current codebase)
- [x] Manual: added `Map.from_struct(workspace)` to a lib file, confirmed Credo flags it, reverted

🤖 Generated with [Claude Code](https://claude.ai/claude-code)