### PR TITLE
fix(buffer): address PR #1595 review fallout

### DIFF
--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -222,28 +222,30 @@ defmodule Minga.Buffer.Server do
     GenServer.call(server, {:move_to, pos})
   end
 
+  @file_io_call_timeout 30_000
+
   @doc "Saves the buffer content to the associated file."
   @spec save(GenServer.server()) :: :ok | {:error, term()}
   def save(server) do
-    GenServer.call(server, :save)
+    GenServer.call(server, :save, @file_io_call_timeout)
   end
 
   @doc "Force-saves the buffer, skipping mtime conflict detection."
   @spec force_save(GenServer.server()) :: :ok | {:error, term()}
   def force_save(server) do
-    GenServer.call(server, :force_save)
+    GenServer.call(server, :force_save, @file_io_call_timeout)
   end
 
   @doc "Reloads the buffer from disk, preserving cursor position (clamped). Clears undo/redo."
   @spec reload(GenServer.server()) :: :ok | {:error, term()}
   def reload(server) do
-    GenServer.call(server, :reload)
+    GenServer.call(server, :reload, @file_io_call_timeout)
   end
 
   @doc "Saves the buffer content to a specific file path."
   @spec save_as(GenServer.server(), String.t()) :: :ok | {:error, term()}
   def save_as(server, file_path) when is_binary(file_path) do
-    GenServer.call(server, {:save_as, file_path})
+    GenServer.call(server, {:save_as, file_path}, @file_io_call_timeout)
   end
 
   @doc "Replaces the entire buffer content, pushing the old content onto the undo stack."
@@ -263,7 +265,7 @@ defmodule Minga.Buffer.Server do
   @doc "Replaces content and records it as the saved base revision."
   @spec replace_saved_content(GenServer.server(), String.t()) :: :ok
   def replace_saved_content(server, new_content) when is_binary(new_content) do
-    GenServer.call(server, {:replace_saved_content, new_content})
+    GenServer.call(server, {:replace_saved_content, new_content}, @file_io_call_timeout)
   end
 
   @doc "Returns the full text content of the buffer."
@@ -2140,9 +2142,16 @@ defmodule Minga.Buffer.Server do
   defp read_file(:local, path), do: File.read(path)
 
   defp read_file({:remote, node, _base_path}, path) do
-    :erpc.call(node, Minga.Distribution.File, :read_local, [path, 1_000_000], 5_000)
+    :erpc.call(
+      node,
+      Minga.Distribution.File,
+      :read_local,
+      [path, Minga.Distribution.File.max_file_bytes()],
+      5_000
+    )
   catch
-    :exit, reason -> {:error, {:remote_unavailable, reason}}
+    :exit, reason -> remote_unavailable(reason)
+    :error, {:erpc, _reason} = reason -> remote_unavailable(reason)
   end
 
   @spec file_stat_info(BufState.t() | BufState.storage(), String.t() | nil) ::
@@ -2164,8 +2173,12 @@ defmodule Minga.Buffer.Server do
   defp file_stat_result({:remote, node, _base_path}, path) do
     :erpc.call(node, File, :stat, [path, [time: :posix]], 5_000)
   catch
-    :exit, reason -> {:error, {:remote_unavailable, reason}}
+    :exit, reason -> remote_unavailable(reason)
+    :error, {:erpc, _reason} = reason -> remote_unavailable(reason)
   end
+
+  @spec remote_unavailable(term()) :: {:error, {:remote_unavailable, term()}}
+  defp remote_unavailable(reason), do: {:error, {:remote_unavailable, reason}}
 
   @spec content_hash(String.t()) :: binary()
   defp content_hash(content), do: :crypto.hash(:sha256, content)
@@ -2415,7 +2428,8 @@ defmodule Minga.Buffer.Server do
   defp write_file(%{storage: {:remote, node, _base_path}}, file_path, content) do
     :erpc.call(node, File, :write, [file_path, content], 10_000)
   catch
-    :exit, reason -> {:error, {:remote_unavailable, reason}}
+    :exit, reason -> remote_unavailable(reason)
+    :error, {:erpc, _reason} = reason -> remote_unavailable(reason)
   end
 
   # ── Edit delta tracking ──

--- a/lib/minga/distribution/connection_manager.ex
+++ b/lib/minga/distribution/connection_manager.ex
@@ -68,10 +68,12 @@ defmodule Minga.Distribution.ConnectionManager do
     call_or_default({:connected?, server_name}, false)
   end
 
-  @doc "Returns the retry delay for `retry_count`, starting at 1s and doubling until the 30s cap."
+  @doc "Returns the retry delay for `retry_count`, starting at 1s and doubling until the 30s cap. Clamps once the doubled value would exceed 30s."
   @spec backoff_ms(non_neg_integer()) :: pos_integer()
+  def backoff_ms(retry_count) when is_integer(retry_count) and retry_count >= 5, do: 30_000
+
   def backoff_ms(retry_count) when is_integer(retry_count) and retry_count >= 0 do
-    min(1_000 * Integer.pow(2, retry_count), 30_000)
+    1_000 * Integer.pow(2, retry_count)
   end
 
   @impl GenServer

--- a/lib/minga/distribution/file.ex
+++ b/lib/minga/distribution/file.ex
@@ -17,10 +17,20 @@ defmodule Minga.Distribution.File do
   @doc "Reads a file from a remote node with options."
   @spec read(node(), String.t(), keyword()) :: {:ok, binary()} | {:error, term()}
   def read(node, path, opts) when is_atom(node) and is_binary(path) and is_list(opts) do
-    max_bytes = Keyword.get(opts, :max_bytes, @default_max_file_bytes)
+    max_bytes = Keyword.get(opts, :max_bytes, max_file_bytes())
     :erpc.call(node, __MODULE__, :read_local, [path, max_bytes], 5_000)
   catch
     :exit, reason -> {:error, {:remote_unavailable, reason}}
+    :error, {:erpc, _reason} = reason -> {:error, {:remote_unavailable, reason}}
+  end
+
+  @doc "Returns the configured maximum bytes for remote file reads."
+  @spec max_file_bytes() :: pos_integer()
+  def max_file_bytes do
+    case Application.get_env(:minga, :remote_read_max_bytes, @default_max_file_bytes) do
+      bytes when is_integer(bytes) and bytes > 0 -> bytes
+      _ -> @default_max_file_bytes
+    end
   end
 
   @doc "Reads a local file for remote `:erpc.call/5` use."
@@ -46,6 +56,7 @@ defmodule Minga.Distribution.File do
     :erpc.call(node, __MODULE__, :list_local_files, [root, max_files, max_depth], timeout)
   catch
     :exit, reason -> {:error, {:remote_unavailable, reason}}
+    :error, {:erpc, _reason} = reason -> {:error, {:remote_unavailable, reason}}
   end
 
   @doc "Lists text files below `root` on the current node. Intended for remote `:erpc.call/5` use."

--- a/lib/minga_editor/agent/diff_review.ex
+++ b/lib/minga_editor/agent/diff_review.ex
@@ -11,6 +11,8 @@ defmodule MingaEditor.Agent.DiffReview do
   alias Minga.Core.Diff
   alias Minga.Git
 
+  @default_context_lines 3
+
   @typedoc "Resolution status for a single hunk."
   @type resolution :: :accepted | :rejected
 
@@ -221,9 +223,11 @@ defmodule MingaEditor.Agent.DiffReview do
           {String.t(), :context | :added | :removed | :hunk_header, non_neg_integer() | nil}
 
   @spec to_display_lines(t()) :: [diff_line()]
-  def to_display_lines(%__MODULE__{before_lines: before, after_lines: after_lines, hunks: hunks}) do
-    context_lines = 3
-    build_display(before, after_lines, hunks, 0, context_lines)
+  @spec to_display_lines(t(), non_neg_integer()) :: [diff_line()]
+  def to_display_lines(%__MODULE__{} = review, context_lines \\ @default_context_lines)
+      when is_integer(context_lines) and context_lines >= 0 do
+    %__MODULE__{before_lines: before, after_lines: after_lines, hunks: hunks} = review
+    build_display(before, after_lines, hunks, context_lines)
   end
 
   # ── Private ─────────────────────────────────────────────────────────────────
@@ -236,8 +240,8 @@ defmodule MingaEditor.Agent.DiffReview do
           [Diff.hunk()]
         ) :: t()
   defp build_updated_review(review, path, before_lines, new_after_lines, new_hunks) do
-    old_hunk_sigs = hunk_signatures(review.hunks)
-    new_hunk_sigs = hunk_signatures(new_hunks)
+    old_hunk_sigs = hunk_signatures(review.hunks, review.after_lines)
+    new_hunk_sigs = hunk_signatures(new_hunks, new_after_lines)
 
     new_resolutions =
       preserve_matching_resolutions(old_hunk_sigs, new_hunk_sigs, review.resolutions)
@@ -255,47 +259,73 @@ defmodule MingaEditor.Agent.DiffReview do
     }
   end
 
+  @typep hunk_signature :: {atom(), non_neg_integer(), [String.t()], [String.t()]}
+  @typep resolution_queues :: %{hunk_signature() => [resolution()]}
+
   @spec preserve_matching_resolutions(
-          [{atom(), non_neg_integer(), non_neg_integer(), [String.t()]}],
-          [{atom(), non_neg_integer(), non_neg_integer(), [String.t()]}],
+          [hunk_signature()],
+          [hunk_signature()],
           %{non_neg_integer() => resolution()}
         ) :: %{non_neg_integer() => resolution()}
   defp preserve_matching_resolutions(old_sigs, new_sigs, old_resolutions) do
-    new_sigs
-    |> Enum.with_index()
-    |> Enum.reduce(%{}, fn {sig, new_idx}, acc ->
-      case find_resolved_match(old_sigs, sig, old_resolutions) do
-        nil -> acc
-        resolution -> Map.put(acc, new_idx, resolution)
-      end
-    end)
+    queues = resolved_signature_queues(old_sigs, old_resolutions)
+
+    {resolutions, _queues} =
+      new_sigs
+      |> Enum.with_index()
+      |> Enum.reduce({%{}, queues}, fn {sig, new_idx}, {acc, available} ->
+        case pop_resolution(available, sig) do
+          {{:ok, resolution}, updated_available} ->
+            {Map.put(acc, new_idx, resolution), updated_available}
+
+          {:error, updated_available} ->
+            {acc, updated_available}
+        end
+      end)
+
+    resolutions
   end
 
-  # A hunk signature captures the essential content for matching across re-diffs.
-  # Two hunks are "the same" if they have the same type, same old lines, and
-  # appear at the same position in the after-content.
-  @spec hunk_signatures([Diff.hunk()]) :: [
-          {atom(), non_neg_integer(), non_neg_integer(), [String.t()]}
-        ]
-  defp hunk_signatures(hunks) do
-    Enum.map(hunks, fn hunk ->
-      {hunk.type, hunk.start_line, hunk.old_start, hunk.old_lines}
-    end)
-  end
-
-  @spec find_resolved_match(
-          [{atom(), non_neg_integer(), non_neg_integer(), [String.t()]}],
-          {atom(), non_neg_integer(), non_neg_integer(), [String.t()]},
-          %{non_neg_integer() => resolution()}
-        ) :: resolution() | nil
-  defp find_resolved_match(old_sigs, target_sig, resolutions) do
+  @spec resolved_signature_queues([hunk_signature()], %{non_neg_integer() => resolution()}) ::
+          resolution_queues()
+  defp resolved_signature_queues(old_sigs, old_resolutions) do
     old_sigs
     |> Enum.with_index()
-    |> Enum.find(fn {sig, _idx} -> sig == target_sig end)
-    |> case do
-      {_, old_idx} -> Map.get(resolutions, old_idx)
-      nil -> nil
+    |> Enum.reduce(%{}, fn {sig, idx}, acc ->
+      case Map.fetch(old_resolutions, idx) do
+        {:ok, resolution} ->
+          Map.update(acc, sig, [resolution], fn queue -> [resolution | queue] end)
+
+        :error ->
+          acc
+      end
+    end)
+    |> Map.new(fn {sig, queue} -> {sig, Enum.reverse(queue)} end)
+  end
+
+  @spec pop_resolution(resolution_queues(), hunk_signature()) ::
+          {{:ok, resolution()}, resolution_queues()} | {:error, resolution_queues()}
+  defp pop_resolution(queues, sig) do
+    case Map.get(queues, sig, []) do
+      [resolution | rest] -> {{:ok, resolution}, Map.put(queues, sig, rest)}
+      [] -> {:error, queues}
     end
+  end
+
+  # A hunk signature captures the changed content and baseline location for matching across re-diffs.
+  # After-content line numbers are intentionally excluded so resolved hunks survive edits above them.
+  @spec hunk_signatures([Diff.hunk()], [String.t()]) :: [hunk_signature()]
+  defp hunk_signatures(hunks, after_lines) do
+    Enum.map(hunks, fn hunk ->
+      {hunk.type, hunk.old_start, hunk.old_lines, after_hunk_lines(hunk, after_lines)}
+    end)
+  end
+
+  @spec after_hunk_lines(Diff.hunk(), [String.t()]) :: [String.t()]
+  defp after_hunk_lines(%{type: :deleted}, _after_lines), do: []
+
+  defp after_hunk_lines(hunk, after_lines) do
+    Enum.slice(after_lines, hunk.start_line, hunk.count)
   end
 
   @spec put_resolution(t(), non_neg_integer(), resolution()) :: t()
@@ -329,23 +359,44 @@ defmodule MingaEditor.Agent.DiffReview do
     |> Enum.find(normalized, fn idx -> not Map.has_key?(resolutions, idx) end)
   end
 
-  # Build unified diff display lines with context around each hunk
-  @spec build_display(
+  # Build unified diff display lines with context around each hunk.
+  @spec build_display([String.t()], [String.t()], [Diff.hunk()], non_neg_integer()) :: [
+          diff_line()
+        ]
+  defp build_display(_before, _after, [], _ctx), do: []
+
+  defp build_display(before, after_lines, hunks, ctx) do
+    before
+    |> do_build_display(after_lines, hunks, ctx, 0, 0, [])
+    |> Enum.reverse()
+  end
+
+  @spec do_build_display(
           [String.t()],
           [String.t()],
           [Diff.hunk()],
           non_neg_integer(),
-          non_neg_integer()
+          non_neg_integer(),
+          non_neg_integer(),
+          [diff_line()]
         ) :: [diff_line()]
-  defp build_display(_before, _after, [], _hunk_idx, _ctx), do: []
+  defp do_build_display(_before, _after_lines, [], _ctx, _idx, _displayed_until, acc), do: acc
 
-  defp build_display(before, after_lines, hunks, _hunk_idx, ctx) do
-    # Compute ranges: for each hunk, show context before/after + the hunk itself
-    hunks
-    |> Enum.with_index()
-    |> Enum.flat_map(fn {hunk, idx} ->
-      hunk_display_lines(before, after_lines, hunk, idx, ctx)
-    end)
+  defp do_build_display(before, after_lines, [hunk | rest], ctx, idx, displayed_until, acc) do
+    next_hunk = List.first(rest)
+
+    {lines, new_displayed_until} =
+      hunk_display_lines(before, after_lines, hunk, idx, ctx, displayed_until, next_hunk)
+
+    do_build_display(
+      before,
+      after_lines,
+      rest,
+      ctx,
+      idx + 1,
+      new_displayed_until,
+      Enum.reverse(lines, acc)
+    )
   end
 
   @spec hunk_display_lines(
@@ -353,35 +404,41 @@ defmodule MingaEditor.Agent.DiffReview do
           [String.t()],
           Diff.hunk(),
           non_neg_integer(),
-          non_neg_integer()
-        ) :: [diff_line()]
-  defp hunk_display_lines(before, after_lines, hunk, hunk_idx, ctx) do
-    # Context lines before the hunk (from the after-content for added/modified, from before for deleted)
-    before_ctx_start = max(0, hunk.start_line - ctx)
+          non_neg_integer(),
+          non_neg_integer(),
+          Diff.hunk() | nil
+        ) :: {[diff_line()], non_neg_integer()}
+  defp hunk_display_lines(before, after_lines, hunk, hunk_idx, ctx, displayed_until, next_hunk) do
+    before_ctx_start = max(max(0, hunk.start_line - ctx), displayed_until)
 
     before_ctx_lines =
       Enum.slice(after_lines, before_ctx_start, hunk.start_line - before_ctx_start)
 
     before_ctx = Enum.map(before_ctx_lines, fn line -> {line, :context, nil} end)
-
-    # The hunk itself
     hunk_lines = render_hunk_lines(before, after_lines, hunk, hunk_idx)
 
-    # Context lines after the hunk
     after_start = hunk.start_line + hunk.count
-    after_end = min(after_start + ctx, length(after_lines))
+
+    after_end =
+      (after_start + ctx) |> min(length(after_lines)) |> cap_context_before_next_hunk(next_hunk)
+
     after_ctx_lines = Enum.slice(after_lines, after_start, after_end - after_start)
     after_ctx = Enum.map(after_ctx_lines, fn line -> {line, :context, nil} end)
 
-    # Separator header
     {added, removed} = hunk_counts(hunk)
 
     header =
       {"@@ -#{hunk.old_start + 1},#{hunk.old_count} +#{hunk.start_line + 1},#{hunk.count} @@ (+#{added}, -#{removed})",
        :hunk_header, hunk_idx}
 
-    [header | before_ctx] ++ hunk_lines ++ after_ctx
+    {[header | before_ctx] ++ hunk_lines ++ after_ctx, after_end}
   end
+
+  @spec cap_context_before_next_hunk(non_neg_integer(), Diff.hunk() | nil) :: non_neg_integer()
+  defp cap_context_before_next_hunk(after_end, nil), do: after_end
+
+  defp cap_context_before_next_hunk(after_end, next_hunk),
+    do: min(after_end, next_hunk.start_line)
 
   @spec render_hunk_lines([String.t()], [String.t()], Diff.hunk(), non_neg_integer()) :: [
           diff_line()

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.Agent.Events do
   GenServer to apply.
   """
 
+  alias Minga.Distribution.ConnectionManager
   alias MingaEditor.Agent.DiffReview
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.Panel
@@ -289,18 +290,74 @@ defmodule MingaEditor.Agent.Events do
     :erpc.call(remote_node, Path, :expand, [path], 5_000)
   catch
     :exit, _reason -> path
+    :error, {:erpc, _reason} -> path
   end
 
   @spec reload_tracked_remote_buffers(EditorState.t(), String.t(), String.t()) ::
           {EditorState.t(), [effect()]}
   defp reload_tracked_remote_buffers(state, path, after_content) do
     state.remote
-    |> Remote.buffers_for_path(path)
-    |> Enum.reduce({state, []}, fn {_server_name, pid}, {acc_state, acc_effects} ->
-      {new_state, effects} = reload_remote_buffer_content(acc_state, pid, path, after_content)
+    |> matching_remote_buffers(path)
+    |> Enum.reduce({state, []}, fn {_server_name, remote_path, pid}, {acc_state, acc_effects} ->
+      {new_state, effects} =
+        reload_remote_buffer_content(acc_state, pid, remote_path, after_content)
+
       {new_state, effects ++ acc_effects}
     end)
   end
+
+  @spec matching_remote_buffers(Remote.t(), String.t()) :: [{String.t(), String.t(), pid()}]
+  defp matching_remote_buffers(remote, path) do
+    {direct_matches, fallback_candidates} =
+      remote
+      |> Remote.all_buffers()
+      |> Enum.split_with(fn {_server_name, remote_path, _pid} -> remote_path == path end)
+
+    fallback_matches =
+      fallback_candidates
+      |> Enum.group_by(fn {server_name, _remote_path, _pid} -> server_name end)
+      |> Enum.flat_map(fn {server_name, buffers} ->
+        normalized_path = normalize_remote_path_for_server(server_name, path, buffers)
+
+        Enum.filter(buffers, fn {_server_name, remote_path, _pid} ->
+          remote_path == normalized_path
+        end)
+      end)
+
+    direct_matches ++ fallback_matches
+  end
+
+  @spec normalize_remote_path_for_server(String.t(), String.t(), [{String.t(), String.t(), pid()}]) ::
+          String.t()
+  defp normalize_remote_path_for_server(server_name, path, buffers) do
+    case remote_node_for_server(server_name, buffers) do
+      {:ok, remote_node} -> normalize_remote_path(remote_node, path)
+      :error -> path
+    end
+  end
+
+  @spec remote_node_for_server(String.t(), [{String.t(), String.t(), pid()}]) ::
+          {:ok, node()} | :error
+  defp remote_node_for_server(server_name, buffers) do
+    case ConnectionManager.node_for_server(server_name) do
+      {:ok, remote_node} -> {:ok, remote_node}
+      {:error, _reason} -> remote_node_from_buffers(buffers)
+    end
+  catch
+    :exit, _reason -> remote_node_from_buffers(buffers)
+  end
+
+  @spec remote_node_from_buffers([{String.t(), String.t(), pid()}]) :: {:ok, node()} | :error
+  defp remote_node_from_buffers([{_server_name, _remote_path, pid} | _rest]) do
+    case Buffer.storage(pid) do
+      {:remote, remote_node, _base_path} -> {:ok, remote_node}
+      _ -> :error
+    end
+  catch
+    :exit, _reason -> :error
+  end
+
+  defp remote_node_from_buffers([]), do: :error
 
   @spec reload_remote_buffer(EditorState.t(), String.t(), String.t(), String.t()) ::
           {EditorState.t(), [effect()]}

--- a/lib/minga_editor/commands/agent_group.ex
+++ b/lib/minga_editor/commands/agent_group.ex
@@ -26,12 +26,6 @@ defmodule MingaEditor.Commands.AgentGroup do
     switch_via_group(state, TabBar.prev_agent_group(tb))
   end
 
-  @doc "Switch to the next agent group (same as next)."
-  @spec agent_group_next_agent(state()) :: state()
-  def agent_group_next_agent(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
-    switch_via_group(state, TabBar.next_agent_group(tb))
-  end
-
   @doc "Switch to the first ungrouped (user) tab."
   @spec switch_to_ungrouped(state()) :: state()
   def switch_to_ungrouped(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
@@ -92,14 +86,12 @@ defmodule MingaEditor.Commands.AgentGroup do
 
   @doc "Jump to agent group by number (1-based, 0 = ungrouped)."
   @spec workspace_goto(state(), non_neg_integer()) :: state()
-  def workspace_goto(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, number) do
-    ws =
-      case number do
-        0 -> TabBar.get_group(tb, 0)
-        n -> Enum.at(tb.agent_groups, n)
-      end
+  def workspace_goto(%{shell_state: %{tab_bar: %TabBar{}}} = state, 0) do
+    switch_to_ungrouped(state)
+  end
 
-    case ws do
+  def workspace_goto(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, number) do
+    case Enum.at(tb.agent_groups, number - 1) do
       nil -> state
       %{id: id} -> switch_via_group(state, TabBar.switch_to_group(tb, id))
     end
@@ -129,7 +121,8 @@ defmodule MingaEditor.Commands.AgentGroup do
   @workspace_command_specs [
     {:agent_group_next, "Next workspace", :agent_group_next},
     {:agent_group_prev, "Previous workspace", :agent_group_prev},
-    {:agent_group_next_agent, "Next agent workspace", :agent_group_next_agent},
+    # Kept as a command alias for the existing SPC TAB A default binding.
+    {:agent_group_next_agent, "Next agent workspace", :agent_group_next},
     {:ungrouped_tabs, "Switch to my tabs", :switch_to_ungrouped},
     {:agent_group_toggle, "Toggle last workspace", :agent_group_toggle},
     {:agent_group_close, "Close workspace", :agent_group_close},

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -55,7 +55,7 @@ defmodule MingaEditor.Commands.BufferManagement do
         EditorState.set_status(state, "Wrote #{name}")
 
       {:error, :file_changed} ->
-        EditorState.set_status(state, "WARNING: File changed on disk. Use :w! to force save.")
+        handle_file_changed_on_save(state, buf)
 
       {:error, :no_file_path} ->
         EditorState.set_status(state, "No file name — use :w <filename>")
@@ -1952,6 +1952,57 @@ defmodule MingaEditor.Commands.BufferManagement do
       buffer_pid ->
         Commands.add_buffer(state, buffer_pid)
     end
+  end
+
+  @spec handle_file_changed_on_save(state(), GenServer.server()) :: state()
+  defp handle_file_changed_on_save(state, buf) do
+    case Buffer.storage(buf) do
+      {:remote, node, _base_path} -> handle_remote_file_changed_on_save(state, buf, node)
+      _ -> EditorState.set_status(state, "WARNING: File changed on disk. Use :w! to force save.")
+    end
+  catch
+    :exit, _reason ->
+      EditorState.set_status(state, "WARNING: File changed on disk. Use :w! to force save.")
+  end
+
+  @spec handle_remote_file_changed_on_save(state(), GenServer.server(), node()) :: state()
+  defp handle_remote_file_changed_on_save(state, buf, remote_node) do
+    path = Buffer.file_path(buf)
+
+    case read_remote_conflict_content(remote_node, path) do
+      {:ok, content} ->
+        state
+        |> EditorState.set_status(
+          "File changed on server since you opened it. Reload first, keep editing, show diff, or force save."
+        )
+        |> PickerUI.open(MingaEditor.UI.Picker.RemoteFileConflictSource, %{
+          buffer: buf,
+          path: path,
+          content: content
+        })
+
+      {:error, reason} ->
+        EditorState.set_status(
+          state,
+          "File changed on server since you opened it. Reload first, or force save. Could not load remote version: #{inspect(reason)}"
+        )
+    end
+  catch
+    :exit, reason ->
+      EditorState.set_status(
+        state,
+        "File changed on server since you opened it. Reload first, or force save. Could not inspect remote conflict: #{inspect(reason)}"
+      )
+  end
+
+  @spec read_remote_conflict_content(node(), String.t() | nil) ::
+          {:ok, binary()} | {:error, term()}
+  defp read_remote_conflict_content(_remote_node, nil), do: {:error, :no_file_path}
+
+  defp read_remote_conflict_content(remote_node, path) do
+    Minga.Distribution.File.read(remote_node, path,
+      max_bytes: Minga.Distribution.File.max_file_bytes()
+    )
   end
 
   # ── :global command ────────────────────────────────────────────────────────

--- a/lib/minga_editor/commands/remote_files.ex
+++ b/lib/minga_editor/commands/remote_files.ex
@@ -9,7 +9,6 @@ defmodule MingaEditor.Commands.RemoteFiles do
 
   alias Minga.Buffer
   alias Minga.Distribution.ConnectionManager
-  alias Minga.Distribution.File, as: RemoteFile
   alias Minga.Language
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
@@ -63,22 +62,15 @@ defmodule MingaEditor.Commands.RemoteFiles do
 
   @spec open_remote_file(state(), String.t(), node(), String.t()) :: state()
   defp open_remote_file(state, server_name, remote_node, remote_path) do
-    case RemoteFile.read(remote_node, remote_path) do
-      {:ok, content} ->
-        start_remote_buffer(state, server_name, remote_node, remote_path, content)
-
-      {:error, reason} ->
-        EditorState.set_status(state, "Failed to read remote file: #{inspect(reason)}")
-    end
+    start_remote_buffer(state, server_name, remote_node, remote_path)
   end
 
-  @spec start_remote_buffer(state(), String.t(), node(), String.t(), binary()) :: state()
-  defp start_remote_buffer(state, server_name, remote_node, remote_path, content) do
+  @spec start_remote_buffer(state(), String.t(), node(), String.t()) :: state()
+  defp start_remote_buffer(state, server_name, remote_node, remote_path) do
     name = "[#{server_name}] #{Path.basename(remote_path)}"
     filetype = Language.detect_filetype(remote_path)
 
     case Buffer.start_link(
-           content: content,
            file_path: remote_path,
            buffer_name: name,
            filetype: filetype,
@@ -92,7 +84,7 @@ defmodule MingaEditor.Commands.RemoteFiles do
         |> EditorState.update_remote(&Remote.put_buffer(&1, server_name, remote_path, buffer))
 
       {:error, reason} ->
-        EditorState.set_status(state, "Failed to open remote file: #{inspect(reason)}")
+        EditorState.set_status(state, "Failed to open remote file: #{format_open_error(reason)}")
     end
   end
 
@@ -138,5 +130,13 @@ defmodule MingaEditor.Commands.RemoteFiles do
     {:ok, :erpc.call(remote_node, File, :cwd!, [], 5_000)}
   catch
     :exit, reason -> {:error, "Remote server unavailable: #{inspect(reason)}"}
+    :error, {:erpc, _reason} = reason -> {:error, "Remote server unavailable: #{inspect(reason)}"}
   end
+
+  @spec format_open_error(term()) :: String.t()
+  defp format_open_error(:file_too_large) do
+    "file exceeds the remote edit read limit; set :minga, :remote_read_max_bytes to raise it"
+  end
+
+  defp format_open_error(reason), do: inspect(reason)
 end

--- a/lib/minga_editor/state/remote.ex
+++ b/lib/minga_editor/state/remote.ex
@@ -62,4 +62,12 @@ defmodule MingaEditor.State.Remote do
     |> Enum.filter(fn {{_server_name, remote_path}, _buffer} -> remote_path == path end)
     |> Enum.map(fn {{server_name, _remote_path}, buffer} -> {server_name, buffer} end)
   end
+
+  @doc "Returns all tracked remote buffers with their server names and paths."
+  @spec all_buffers(t()) :: [{String.t(), String.t(), pid()}]
+  def all_buffers(%__MODULE__{} = remote) do
+    Enum.map(remote.buffers, fn {{server_name, remote_path}, buffer} ->
+      {server_name, remote_path, buffer}
+    end)
+  end
 end

--- a/lib/minga_editor/ui/picker/remote_file_conflict_source.ex
+++ b/lib/minga_editor/ui/picker/remote_file_conflict_source.ex
@@ -4,7 +4,11 @@ defmodule MingaEditor.UI.Picker.RemoteFileConflictSource do
   @behaviour MingaEditor.UI.Picker.Source
 
   alias Minga.Buffer
+  alias MingaEditor.Agent.DiffReview
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.View.Preview
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.Item
 
@@ -68,13 +72,35 @@ defmodule MingaEditor.UI.Picker.RemoteFileConflictSource do
     )
   end
 
-  def on_select(%Item{id: {:remote_conflict, :show_diff, _buffer, path, _content}}, state) do
-    EditorState.set_status(state, "Showing diff for #{Path.basename(path)}")
+  def on_select(%Item{id: {:remote_conflict, :show_diff, buffer, path, content}}, state) do
+    case DiffReview.new(path, Buffer.content(buffer), content) do
+      %DiffReview{} = review ->
+        show_diff(state, path, review)
+
+      nil ->
+        EditorState.set_status(state, "No remote changes to show for #{Path.basename(path)}")
+    end
+  catch
+    :exit, reason -> EditorState.set_status(state, "Remote diff failed: #{inspect(reason)}")
   end
 
   @impl true
   @spec on_cancel(EditorState.t()) :: EditorState.t()
   def on_cancel(state), do: state
+
+  @spec show_diff(EditorState.t(), String.t(), DiffReview.t()) :: EditorState.t()
+  defp show_diff(state, path, review) do
+    state
+    |> AgentAccess.update_agent_ui(&set_diff_preview(&1, review))
+    |> EditorState.set_status("Showing diff for #{Path.basename(path)}")
+  end
+
+  @spec set_diff_preview(UIState.t(), DiffReview.t()) :: UIState.t()
+  defp set_diff_preview(ui, review) do
+    ui
+    |> UIState.update_preview(fn _ -> Preview.set_diff(Preview.new(), review) end)
+    |> UIState.set_focus(:file_viewer)
+  end
 
   @spec item(action(), pid(), String.t(), String.t(), String.t(), String.t()) :: Item.t()
   defp item(action, buffer, path, content, label, description) do

--- a/test/minga/buffer/remote_storage_test.exs
+++ b/test/minga/buffer/remote_storage_test.exs
@@ -45,6 +45,21 @@ defmodule Minga.Buffer.RemoteStorageTest do
     end
   end
 
+  test "remote storage reports erpc errors without crashing" do
+    missing_node = :"missing_remote@127.0.0.1"
+    previous = Process.flag(:trap_exit, true)
+
+    try do
+      assert {:error, {:remote_unavailable, {:erpc, _reason}}} =
+               Server.start_link(
+                 file_path: "/tmp/missing.txt",
+                 storage: {:remote, missing_node, "/tmp/missing.txt"}
+               )
+    after
+      Process.flag(:trap_exit, previous)
+    end
+  end
+
   test "remote storage detects save conflicts against server changes", %{tmp_dir: tmp_dir} do
     path = Path.join(tmp_dir, "remote.txt")
     File.write!(path, "base")

--- a/test/minga_editor/agent/diff_review_test.exs
+++ b/test/minga_editor/agent/diff_review_test.exs
@@ -254,6 +254,27 @@ defmodule MingaEditor.Agent.DiffReviewTest do
       assert 0 in indices
       assert 1 in indices
     end
+
+    test "accepts a custom context line count" do
+      review = DiffReview.new("f.ex", "a\nb\nc\n", "a\nB\nc\n")
+      lines = DiffReview.to_display_lines(review, 0)
+
+      refute Enum.any?(lines, fn {_text, type, _idx} -> type == :context end)
+    end
+
+    test "does not duplicate overlapping context lines for nearby hunks" do
+      before = "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\n"
+      after_ = "l1\nL2\nl3\nl4\nL5\nl6\nl7\nl8\n"
+      review = DiffReview.new("f.ex", before, after_)
+
+      context_lines =
+        review
+        |> DiffReview.to_display_lines()
+        |> Enum.filter(fn {_text, type, _idx} -> type == :context end)
+        |> Enum.map(fn {text, _type, _idx} -> text end)
+
+      assert context_lines == ["l1", "l3", "l4", "l6", "l7", "l8"]
+    end
   end
 
   # ── update_after/2 ──────────────────────────────────────────────────────────
@@ -301,6 +322,77 @@ defmodule MingaEditor.Agent.DiffReviewTest do
       # The original hunk's resolution should be preserved
       # (It's the same modification: bbb -> BBB at the same position)
       assert DiffReview.resolution_at(updated, 0) == :accepted
+    end
+
+    test "preserves resolutions when an unchanged hunk shifts down" do
+      before = "aaa\nbbb\nccc\nddd\neee\nfff\nggg"
+      after_v1 = "aaa\nbbb\nccc\nddd\neee\nFFF\nggg"
+      review = DiffReview.new("test.ex", before, after_v1)
+      assert review != nil
+
+      review = DiffReview.accept_current(review)
+      assert DiffReview.resolution_at(review, 0) == :accepted
+
+      after_v2 = "inserted\naaa\nbbb\nccc\nddd\neee\nFFF\nggg"
+      updated = DiffReview.update_after(review, after_v2)
+
+      assert updated != nil
+      assert DiffReview.resolution_at(updated, 0) == nil
+      assert DiffReview.resolution_at(updated, 1) == :accepted
+    end
+
+    test "preserves duplicate hunk resolutions one-to-one" do
+      before = "a\nx\nb\nc\nd\nx\ne"
+      after_v1 = "a\nX\nb\nc\nd\nX\ne"
+      review = DiffReview.new("test.ex", before, after_v1)
+      assert review != nil
+
+      review = DiffReview.accept_current(review)
+      review = DiffReview.reject_current(review)
+      assert DiffReview.resolution_at(review, 0) == :accepted
+      assert DiffReview.resolution_at(review, 1) == :rejected
+
+      after_v2 = "a\nX\nb\nc\nd\nX\ne\nnew"
+      updated = DiffReview.update_after(review, after_v2)
+
+      assert updated != nil
+      assert DiffReview.resolution_at(updated, 0) == :accepted
+      assert DiffReview.resolution_at(updated, 1) == :rejected
+      assert DiffReview.resolution_at(updated, 2) == nil
+    end
+
+    test "does not reuse one resolved hunk for multiple identical new hunks" do
+      before = "a\nx\nb\nc\nd\nx\ne"
+      after_v1 = "a\nX\nb\nc\nd\nx\ne"
+      review = DiffReview.new("test.ex", before, after_v1)
+      assert review != nil
+
+      review = DiffReview.accept_current(review)
+      assert DiffReview.resolution_at(review, 0) == :accepted
+
+      after_v2 = "a\nX\nb\nc\nd\nX\ne"
+      updated = DiffReview.update_after(review, after_v2)
+
+      assert updated != nil
+      assert DiffReview.resolution_at(updated, 0) == :accepted
+      assert DiffReview.resolution_at(updated, 1) == nil
+    end
+
+    test "does not assign a lower hunk resolution to a new identical upper hunk" do
+      before = "a\nx\nb\nc\nd\nx\ne"
+      after_v1 = "a\nx\nb\nc\nd\nX\ne"
+      review = DiffReview.new("test.ex", before, after_v1)
+      assert review != nil
+
+      review = DiffReview.accept_current(review)
+      assert DiffReview.resolution_at(review, 0) == :accepted
+
+      after_v2 = "a\nX\nb\nc\nd\nX\ne"
+      updated = DiffReview.update_after(review, after_v2)
+
+      assert updated != nil
+      assert DiffReview.resolution_at(updated, 0) == nil
+      assert DiffReview.resolution_at(updated, 1) == :accepted
     end
 
     test "drops resolutions for hunks that changed" do

--- a/test/minga_editor/agent/remote_file_events_test.exs
+++ b/test/minga_editor/agent/remote_file_events_test.exs
@@ -2,8 +2,12 @@ defmodule MingaEditor.Agent.RemoteFileEventsTest do
   use Minga.Test.EditorCase, async: true
 
   alias Minga.Buffer
+  alias MingaEditor.Agent.DiffReview
   alias MingaEditor.Agent.Events
+  alias MingaEditor.Agent.View.Preview
+  alias MingaEditor.Commands.BufferManagement
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Remote
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Picker.RemoteFileConflictSource
@@ -27,6 +31,29 @@ defmodule MingaEditor.Agent.RemoteFileEventsTest do
     refute Buffer.dirty?(buffer)
     assert {:log_message, "Agent updated file.ex"} in effects
     assert %EditorState{} = state
+  end
+
+  test "agent file_changed matches tracked remote buffers with normalized fallback paths", %{
+    tmp_dir: tmp_dir
+  } do
+    ctx = start_editor("initial")
+    file = "remote_event_#{:erlang.unique_integer([:positive])}.ex"
+    path = Path.join(tmp_dir, file)
+    event_path = tmp_dir <> "/./" <> file
+    File.write!(path, "before")
+
+    {:ok, buffer} = Buffer.start_link(file_path: path, storage: {:remote, node(), path})
+
+    state =
+      ctx
+      |> editor_state()
+      |> EditorState.update_remote(&Remote.put_buffer(&1, "home", path, buffer))
+
+    {_state, effects} = Events.handle(state, {:file_changed, event_path, "before", "after"})
+
+    assert Buffer.content(buffer) == "after"
+    refute Buffer.dirty?(buffer)
+    assert {:log_message, "Agent updated #{Path.basename(path)}"} in effects
   end
 
   test "agent file_changed keeps dirty remote buffer content and warns about conflict", %{
@@ -90,7 +117,7 @@ defmodule MingaEditor.Agent.RemoteFileEventsTest do
     assert state.shell_state.status_msg =~ "Keeping local edits"
   end
 
-  test "remote conflict prompt show diff action leaves content untouched", %{tmp_dir: tmp_dir} do
+  test "remote conflict prompt show diff action opens a diff review", %{tmp_dir: tmp_dir} do
     ctx = start_editor("initial")
     path = Path.join(tmp_dir, "file.ex")
     File.write!(path, "before")
@@ -107,5 +134,34 @@ defmodule MingaEditor.Agent.RemoteFileEventsTest do
     assert Buffer.content(buffer) == "local before"
     assert Buffer.dirty?(buffer)
     assert state.shell_state.status_msg == "Showing diff for file.ex"
+    assert %DiffReview{path: ^path} = Preview.diff_review(AgentAccess.view(state).preview)
+    assert AgentAccess.focus(state) == :file_viewer
+  end
+
+  test "remote save conflict opens the remote conflict prompt", %{tmp_dir: tmp_dir} do
+    ctx = start_editor("initial")
+    path = Path.join(tmp_dir, "file.ex")
+    File.write!(path, "before")
+    {:ok, buffer} = Buffer.start_link(file_path: path, storage: {:remote, node(), path})
+    :ok = Buffer.insert_text(buffer, "local ")
+    File.write!(path, "server changed")
+
+    state =
+      ctx
+      |> editor_state()
+      |> EditorState.add_buffer(buffer)
+      |> BufferManagement.execute(:save)
+
+    assert Buffer.dirty?(buffer)
+    assert state.shell_state.status_msg =~ "File changed on server since you opened it"
+
+    assert {:picker,
+            %{
+              picker_ui: %{
+                source: RemoteFileConflictSource,
+                context: %{buffer: ^buffer, path: ^path, content: "server changed"}
+              }
+            }} =
+             state.shell_state.modal
   end
 end

--- a/test/minga_editor/commands/agent_group_test.exs
+++ b/test/minga_editor/commands/agent_group_test.exs
@@ -50,37 +50,59 @@ defmodule MingaEditor.Commands.AgentGroupTest do
   end
 
   describe "agent_group_next/1" do
-    test "does not crash on EditorState struct" do
+    test "switches to the next agent group's first tab" do
       state = make_state()
-      # Before the fix, this crashed with KeyError because
-      # switch_via_group accessed state.tab_bar instead of
-      # state.shell_state.tab_bar
       result = AgentGroup.agent_group_next(state)
+
       assert %EditorState{} = result
+      assert result.shell_state.tab_bar.active_id == 2
     end
   end
 
   describe "agent_group_prev/1" do
-    test "does not crash on EditorState struct" do
+    test "switches to the previous agent group's first tab" do
       state = make_state()
       result = AgentGroup.agent_group_prev(state)
+
       assert %EditorState{} = result
+      assert result.shell_state.tab_bar.active_id == 3
     end
   end
 
   describe "agent_group_toggle/1" do
-    test "does not crash on EditorState struct" do
+    test "switches from ungrouped tabs to the last agent group" do
       state = make_state()
       result = AgentGroup.agent_group_toggle(state)
+
       assert %EditorState{} = result
+      assert result.shell_state.tab_bar.active_id == 3
     end
   end
 
   describe "switch_to_ungrouped/1" do
-    test "does not crash on EditorState struct" do
-      state = make_state()
+    test "switches to the first ungrouped tab" do
+      state = make_state() |> AgentGroup.agent_group_next()
       result = AgentGroup.switch_to_ungrouped(state)
+
       assert %EditorState{} = result
+      assert result.shell_state.tab_bar.active_id == 1
+    end
+  end
+
+  describe "workspace_goto/2" do
+    test "workspace 0 switches to ungrouped tabs" do
+      state = make_state() |> AgentGroup.agent_group_next()
+      result = AgentGroup.workspace_goto(state, 0)
+
+      assert %EditorState{} = result
+      assert result.shell_state.tab_bar.active_id == 1
+    end
+
+    test "workspace numbers are one-based" do
+      state = make_state()
+
+      assert AgentGroup.workspace_goto(state, 1).shell_state.tab_bar.active_id == 2
+      assert AgentGroup.workspace_goto(state, 2).shell_state.tab_bar.active_id == 3
     end
   end
 end


### PR DESCRIPTION
# TL;DR
This PR hardens editable remote file workflows after PR #1595 so remote buffers handle conflicts, unavailable nodes, and repeated agent edits predictably. It also tightens the diff review experience used when a user needs to inspect remote or agent-side changes before deciding what to keep.

## Context
Editable remote files keep editing local and defer network work to open, save, reload, and conflict checks. That model needs clear behavior when the server copy changes, when `:erpc` fails, and when agent file events arrive with paths that do not exactly match the tracked remote buffer path.

## Changes
- Remote save conflicts now open the remote conflict picker with the server version loaded, rather than showing the generic local disk warning.
- The remote conflict picker’s `Show diff` action opens the agent file viewer with a real `DiffReview`, so users can inspect the local buffer against the remote content before reloading or continuing.
- Remote file reads, stats, writes, directory browsing, path normalization, and remote CWD lookup now convert both exit and `:erpc` error-class failures into user-facing errors instead of crashing the editor path.
- Remote file open now lets `Buffer.Server` perform the initial remote read directly, avoiding a duplicate read and keeping open errors tied to buffer startup.
- Remote file reads use the configurable `:minga, :remote_read_max_bytes` cap through `Minga.Distribution.File.max_file_bytes/0`, with clearer open errors when a file exceeds the edit limit.
- Agent `file_changed` events can match tracked remote buffers by direct path or normalized fallback path, while grouping fallback normalization by server to avoid per-buffer remote round trips.
- Diff review now preserves hunk resolutions by changed content and baseline position, handles duplicate hunks one-to-one, supports custom context line counts, and avoids duplicated overlapping context lines.
- Agent group workspace navigation now treats numbered jumps as one-based and handles workspace `0` as the ungrouped workspace.

## Verification
- `mix test.llm test/minga_editor/agent/remote_file_events_test.exs test/minga_editor/agent/diff_review_test.exs test/minga_editor/commands/agent_group_test.exs test/minga/distribution/connection_manager_test.exs test/minga/buffer/remote_storage_test.exs test/minga_editor/commands/buffer_management_test.exs`
- `make lint`
- `mix test --warnings-as-errors --exclude system_clipboard`

## Notes for reviewers
- This is a follow-up to PR #1595 and does not introduce a new remote editing model. It makes the existing model safer around conflicts, path matching, and remote failures.
- The `:agent_group_next_agent` command name remains as a compatibility alias for the existing `SPC TAB A` binding.
