### PR TITLE
feat(editor): toggle invisible character display (SPC t i)

### DIFF
--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -2074,6 +2074,7 @@ defmodule Minga.Buffer.Server do
     :scroll_margin,
     :autopair,
     :clipboard,
+    :show_invisible,
     :trim_trailing_whitespace,
     :insert_final_newline,
     :format_on_save,

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -48,6 +48,7 @@ defmodule Minga.Config.Options do
           | :theme
           | :indent_with
           | :indent_guides
+          | :show_invisible
           | :trim_trailing_whitespace
           | :insert_final_newline
           | :format_on_save
@@ -205,6 +206,8 @@ defmodule Minga.Config.Options do
     {:indent_with, {:enum, [:spaces, :tabs]}, :spaces,
      "Whether indentation inserts spaces or tab characters."},
     {:indent_guides, :boolean, true, "Whether indentation guide decorations are shown."},
+    {:show_invisible, :boolean, false,
+     "Whether invisible characters (tabs, trailing whitespace) are shown with visible markers."},
     {:trim_trailing_whitespace, :boolean, false,
      "Whether trailing whitespace is removed before saving."},
     {:insert_final_newline, :boolean, false, "Whether files are saved with a final newline."},

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -182,6 +182,7 @@ defmodule Minga.Keymap.Defaults do
     # ── Toggle ────────────────────────────────────────────────────────────────
     {[{?t, @none}, {?l, @none}], :cycle_line_numbers, "Toggle line numbers"},
     {[{?t, @none}, {?p, @none}], :toggle_bottom_panel, "Toggle bottom panel"},
+    {[{?t, @none}, {?i, @none}], :toggle_invisible, "Toggle invisible chars"},
     {[{?t, @none}, {?w, @none}], :toggle_wrap, "Toggle word wrap"},
     {[{?t, @none}, {?b, @none}], :toggle_board, "Toggle The Board"}
   ]

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -188,6 +188,14 @@ defmodule MingaEditor.Commands.BufferManagement do
     EditorState.set_status(state, "wrap #{label}")
   end
 
+  def execute(%{workspace: %{buffers: %{active: buf}}} = state, :toggle_invisible)
+      when is_pid(buf) do
+    current = Buffer.get_option(buf, :show_invisible)
+    Buffer.set_option(buf, :show_invisible, !current)
+    label = if current, do: "off", else: "on"
+    EditorState.set_status(state, "invisible #{label}")
+  end
+
   # ── Ex commands ───────────────────────────────────────────────────────────
 
   def execute(state, {:execute_ex_command, {:save, []}}) do
@@ -1821,6 +1829,13 @@ defmodule MingaEditor.Commands.BufferManagement do
         requires_buffer: true,
         execute: fn state -> execute(state, :toggle_wrap) end,
         option_toggle: :wrap
+      },
+      %Minga.Command{
+        name: :toggle_invisible,
+        description: "Toggle invisible characters",
+        requires_buffer: true,
+        execute: fn state -> execute(state, :toggle_invisible) end,
+        option_toggle: :show_invisible
       }
     ]
 

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -134,6 +134,9 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
 
     is_gui = Map.get(params, :is_gui, false)
 
+    {show_invisible, tab_width, whitespace_face} =
+      invisible_char_settings(window.buffer, state.theme)
+
     ctx = %Context{
       viewport: viewport,
       visual_selection: visual_selection,
@@ -152,7 +155,10 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       diagnostic_signs: diagnostic_signs_for_path(Map.get(params, :file_path)),
       git_signs: git_signs_for_window(window),
       gutter_colors: state.theme.gutter,
-      git_colors: state.theme.git
+      git_colors: state.theme.git,
+      show_invisible: show_invisible,
+      tab_width: tab_width,
+      whitespace_face: whitespace_face
     }
 
     {ctx, state}
@@ -1056,11 +1062,31 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       ctx.content_w,
       is_active,
       ctx.confirm_match,
-      ctx.decorations.version
+      ctx.decorations.version,
+      ctx.show_invisible
     }
   end
 
   # ── Private helpers ────────────────────────────────────────────────────────
+
+  @spec invisible_char_settings(pid(), MingaEditor.UI.Theme.t()) ::
+          {boolean(), pos_integer(), Face.t() | nil}
+  defp invisible_char_settings(buf, theme) when is_pid(buf) do
+    show = Buffer.get_option(buf, :show_invisible)
+    tab_w = Buffer.get_option(buf, :tab_width)
+
+    face =
+      if show do
+        fg = theme.editor.whitespace_fg || theme.gutter.fg
+        Face.new(fg: fg)
+      else
+        nil
+      end
+
+    {show, tab_w, face}
+  catch
+    :exit, _ -> {false, 2, nil}
+  end
 
   @spec wrap_option(pid(), atom()) :: boolean()
   defp wrap_option(buf, name) do

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -1063,7 +1063,8 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       is_active,
       ctx.confirm_match,
       ctx.decorations.version,
-      ctx.show_invisible
+      ctx.show_invisible,
+      ctx.tab_width
     }
   end
 

--- a/lib/minga_editor/renderer/composition.ex
+++ b/lib/minga_editor/renderer/composition.ex
@@ -101,6 +101,30 @@ defmodule MingaEditor.Renderer.Composition do
   end
 
   @doc """
+  Replaces visible whitespace markers in composed styled segments.
+
+  Tabs render as `→` plus fill spaces to the next tab stop. Trailing spaces render as `·`. Marker segments use `whitespace_face`, preserving the original face for non-whitespace runs.
+  """
+  @spec apply_invisible_chars([styled_segment()], pos_integer(), Face.t() | nil) :: [
+          styled_segment()
+        ]
+  def apply_invisible_chars(segments, tab_width, whitespace_face) do
+    face = marker_face(whitespace_face)
+    full_text = Enum.map_join(segments, fn {text, _} -> text end)
+    trailing_idx = trailing_ws_start_index(full_text)
+
+    {result, _col, _idx} =
+      Enum.reduce(segments, {[], 0, 0}, fn {text, segment_face}, {acc, col, idx} ->
+        {segment_parts, new_col, new_idx} =
+          transform_segment_text(text, segment_face, col, idx, tab_width, trailing_idx, face)
+
+        {segment_parts ++ acc, new_col, new_idx}
+      end)
+
+    Enum.reverse(result)
+  end
+
+  @doc """
   Converts a list of composed styled segments into {text, [Span.t()]}
   for the semantic window path.
 
@@ -125,6 +149,87 @@ defmodule MingaEditor.Renderer.Composition do
       end)
 
     {text_parts |> Enum.reverse() |> Enum.join(), Enum.reverse(spans_rev)}
+  end
+
+  # ── Invisible character substitution (private) ─────────────────────────
+
+  @spec marker_face(Face.t() | nil) :: Face.t()
+  defp marker_face(nil), do: Face.new()
+  defp marker_face(%Face{} = face), do: face
+
+  @spec transform_segment_text(
+          String.t(),
+          Face.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pos_integer(),
+          non_neg_integer(),
+          Face.t()
+        ) :: {[styled_segment()], non_neg_integer(), non_neg_integer()}
+  defp transform_segment_text(text, face, col, idx, tab_width, trailing_idx, ws_face) do
+    graphemes = String.graphemes(text)
+
+    {parts, current_run, current_face, new_col, new_idx} =
+      Enum.reduce(graphemes, {[], "", face, col, idx}, fn g, {parts, run, run_face, c, i} ->
+        case g do
+          "\t" ->
+            fill = tab_fill(c, tab_width)
+            tab_text = "→" <> String.duplicate(" ", fill - 1)
+            parts = flush_run(parts, run, run_face)
+            {[{tab_text, ws_face} | parts], "", face, c + fill, i + 1}
+
+          " " when i >= trailing_idx ->
+            parts = flush_run(parts, run, run_face)
+            {[{"·", ws_face} | parts], "", face, c + 1, i + 1}
+
+          _ ->
+            w = Unicode.grapheme_width(g)
+            {p, r, f, nc} = append_grapheme(parts, run, run_face, face, g, c + w)
+            {p, r, f, nc, i + 1}
+        end
+      end)
+
+    parts = flush_run(parts, current_run, current_face)
+    {parts, new_col, new_idx}
+  end
+
+  @spec flush_run([styled_segment()], String.t(), Face.t()) :: [styled_segment()]
+  defp flush_run(parts, "", _face), do: parts
+  defp flush_run(parts, run, face), do: [{run, face} | parts]
+
+  @spec append_grapheme(
+          [styled_segment()],
+          String.t(),
+          Face.t(),
+          Face.t(),
+          String.t(),
+          non_neg_integer()
+        ) :: {[styled_segment()], String.t(), Face.t(), non_neg_integer()}
+  defp append_grapheme(parts, run, run_face, face, g, new_col) when run_face == face do
+    {parts, run <> g, face, new_col}
+  end
+
+  defp append_grapheme(parts, run, run_face, face, g, new_col) do
+    {flush_run(parts, run, run_face), g, face, new_col}
+  end
+
+  @spec tab_fill(non_neg_integer(), pos_integer()) :: pos_integer()
+  defp tab_fill(col, tab_width), do: tab_width - rem(col, tab_width)
+
+  @spec trailing_ws_start_index(String.t()) :: non_neg_integer()
+  defp trailing_ws_start_index(text) do
+    {last_non_ws, _} =
+      text
+      |> String.graphemes()
+      |> Enum.reduce({0, 0}, fn g, {last, idx} ->
+        case g do
+          " " -> {last, idx + 1}
+          "\t" -> {last, idx + 1}
+          _ -> {idx + 1, idx + 1}
+        end
+      end)
+
+    last_non_ws
   end
 
   # ── Inline virtual text injection (private) ──────────────────────────────

--- a/lib/minga_editor/renderer/context.ex
+++ b/lib/minga_editor/renderer/context.ex
@@ -12,6 +12,7 @@ defmodule MingaEditor.Renderer.Context do
   """
 
   alias Minga.Core.Decorations
+  alias Minga.Core.Face
   alias Minga.Diagnostics.Diagnostic
   alias Minga.Editing.Search.Match
   alias MingaEditor.Viewport
@@ -46,7 +47,10 @@ defmodule MingaEditor.Renderer.Context do
               warning_fg: 0xECBE7B,
               info_fg: 0x51AFEF,
               hint_fg: 0x555555
-            }
+            },
+            show_invisible: false,
+            tab_width: 2,
+            whitespace_face: nil
 
   @typedoc """
   Represents the bounds of a visual selection for rendering.
@@ -79,6 +83,9 @@ defmodule MingaEditor.Renderer.Context do
           git_signs: %{non_neg_integer() => Minga.Core.Diff.hunk_type()},
           decorations: Decorations.t(),
           git_colors: MingaEditor.UI.Theme.Git.t(),
-          gutter_colors: MingaEditor.UI.Theme.Gutter.t()
+          gutter_colors: MingaEditor.UI.Theme.Gutter.t(),
+          show_invisible: boolean(),
+          tab_width: pos_integer(),
+          whitespace_face: Face.t() | nil
         }
 end

--- a/lib/minga_editor/renderer/line.ex
+++ b/lib/minga_editor/renderer/line.ex
@@ -421,7 +421,7 @@ defmodule MingaEditor.Renderer.Line do
 
     segments =
       if ctx.show_invisible,
-        do: apply_invisible_chars(segments, ctx.tab_width, ctx.whitespace_face),
+        do: Composition.apply_invisible_chars(segments, ctx.tab_width, ctx.whitespace_face),
         else: segments
 
     render_segments_with_scroll(segments, screen_row, ctx)
@@ -459,79 +459,6 @@ defmodule MingaEditor.Renderer.Line do
     Enum.reverse(result)
   end
 
-  @spec apply_invisible_chars([{String.t(), Face.t()}], pos_integer(), Face.t()) ::
-          [{String.t(), Face.t()}]
-  defp apply_invisible_chars(segments, tab_width, ws_face) do
-    full_text = Enum.map_join(segments, fn {text, _} -> text end)
-    trailing_idx = trailing_ws_start_index_text(full_text)
-
-    {result, _col, _idx} =
-      Enum.reduce(segments, {[], 0, 0}, fn {text, face}, {acc, col, idx} ->
-        {seg_parts, new_col, new_idx} =
-          transform_segment_text(text, face, col, idx, tab_width, trailing_idx, ws_face)
-
-        {seg_parts ++ acc, new_col, new_idx}
-      end)
-
-    Enum.reverse(result)
-  end
-
-  @spec transform_segment_text(
-          String.t(),
-          Face.t(),
-          non_neg_integer(),
-          non_neg_integer(),
-          pos_integer(),
-          non_neg_integer(),
-          Face.t()
-        ) :: {[{String.t(), Face.t()}], non_neg_integer(), non_neg_integer()}
-  defp transform_segment_text(text, face, col, idx, tab_width, trailing_idx, ws_face) do
-    graphemes = String.graphemes(text)
-
-    {parts, current_run, current_face, new_col, new_idx} =
-      Enum.reduce(graphemes, {[], "", face, col, idx}, fn g, {parts, run, run_face, c, i} ->
-        case g do
-          "\t" ->
-            fill = tab_fill(c, tab_width)
-            tab_text = "→" <> String.duplicate(" ", fill - 1)
-            parts = flush_run(parts, run, run_face)
-            {[{tab_text, ws_face} | parts], "", face, c + fill, i + 1}
-
-          " " when i >= trailing_idx ->
-            parts = flush_run(parts, run, run_face)
-            {[{"·", ws_face} | parts], "", face, c + 1, i + 1}
-
-          _ ->
-            w = Unicode.grapheme_width(g)
-            {p, r, f, nc} = append_grapheme(parts, run, run_face, face, g, c + w)
-            {p, r, f, nc, i + 1}
-        end
-      end)
-
-    parts = flush_run(parts, current_run, current_face)
-    {parts, new_col, new_idx}
-  end
-
-  @spec flush_run([{String.t(), Face.t()}], String.t(), Face.t()) :: [{String.t(), Face.t()}]
-  defp flush_run(parts, "", _face), do: parts
-  defp flush_run(parts, run, face), do: [{run, face} | parts]
-
-  @spec append_grapheme(
-          [{String.t(), Face.t()}],
-          String.t(),
-          Face.t(),
-          Face.t(),
-          String.t(),
-          non_neg_integer()
-        ) :: {[{String.t(), Face.t()}], String.t(), Face.t(), non_neg_integer()}
-  defp append_grapheme(parts, run, run_face, face, g, new_col) when run_face == face do
-    {parts, run <> g, face, new_col}
-  end
-
-  defp append_grapheme(parts, run, run_face, face, g, new_col) do
-    {flush_run(parts, run, run_face), g, face, new_col}
-  end
-
   @spec tab_fill(non_neg_integer(), pos_integer()) :: pos_integer()
   defp tab_fill(col, tab_width), do: tab_width - rem(col, tab_width)
 
@@ -540,22 +467,6 @@ defmodule MingaEditor.Renderer.Line do
   defp trailing_ws_start_index(pairs) do
     {last_non_ws, _} =
       Enum.reduce(pairs, {0, 0}, fn {g, _w}, {last, idx} ->
-        case g do
-          " " -> {last, idx + 1}
-          "\t" -> {last, idx + 1}
-          _ -> {idx + 1, idx + 1}
-        end
-      end)
-
-    last_non_ws
-  end
-
-  @spec trailing_ws_start_index_text(String.t()) :: non_neg_integer()
-  defp trailing_ws_start_index_text(text) do
-    {last_non_ws, _} =
-      text
-      |> String.graphemes()
-      |> Enum.reduce({0, 0}, fn g, {last, idx} ->
         case g do
           " " -> {last, idx + 1}
           "\t" -> {last, idx + 1}
@@ -690,7 +601,7 @@ defmodule MingaEditor.Renderer.Line do
 
     segments =
       if ctx.show_invisible,
-        do: apply_invisible_chars(segments, ctx.tab_width, ctx.whitespace_face),
+        do: Composition.apply_invisible_chars(segments, ctx.tab_width, ctx.whitespace_face),
         else: segments
 
     render_segments_with_scroll(segments, screen_row, ctx)

--- a/lib/minga_editor/renderer/line.ex
+++ b/lib/minga_editor/renderer/line.ex
@@ -52,7 +52,8 @@ defmodule MingaEditor.Renderer.Line do
         line_byte_offset \\ 0,
         precomputed_segments \\ nil
       ) do
-    pairs = grapheme_pairs(line_text)
+    raw_pairs = grapheme_pairs(line_text)
+    pairs = maybe_substitute_invisible(raw_pairs, ctx)
     line_display_len = display_width_of_pairs(pairs)
 
     visible_pairs =
@@ -70,12 +71,11 @@ defmodule MingaEditor.Renderer.Line do
 
     has_conceals = Decorations.has_conceal_ranges?(ctx.decorations)
 
-    # When conceals are active, apply them to visible_pairs for selection paths.
-    # Without this, selection rendering would show raw text (including concealed
-    # characters) while selection coordinates are conceal-adjusted.
     concealed_pairs =
       if has_conceals do
-        apply_conceals_to_pairs(pairs, ctx.decorations, buf_line)
+        raw_pairs
+        |> apply_conceals_to_pairs(ctx.decorations, buf_line)
+        |> maybe_substitute_invisible(ctx)
       else
         nil
       end
@@ -105,13 +105,10 @@ defmodule MingaEditor.Renderer.Line do
           precomputed_segments
         )
 
-      nil when line_highlights != [] or has_conceals ->
-        # No syntax highlighting but has decorations or conceals:
-        # render through the styled-segment path
+      nil when line_highlights != [] or has_conceals or ctx.show_invisible ->
         render_decorated_plain_line(line_text, screen_row, buf_line, ctx, line_highlights)
 
       nil ->
-        # Plain text, no decorations, no syntax highlighting, no conceals
         visible_text = join_pairs(visible_pairs)
         [DisplayList.draw(screen_row, ctx.gutter_w, visible_text)]
 
@@ -420,7 +417,154 @@ defmodule MingaEditor.Renderer.Line do
     segments = Decorations.merge_highlights(segments, line_highlights, buf_line)
     segments = Composition.apply_conceals(segments, ctx.decorations, buf_line)
     segments = Composition.inject_inline_virtual_text(segments, ctx.decorations, buf_line)
+
+    segments =
+      if ctx.show_invisible,
+        do: apply_invisible_chars(segments, ctx.tab_width, ctx.whitespace_face),
+        else: segments
+
     render_segments_with_scroll(segments, screen_row, ctx)
+  end
+
+  # ── Invisible character substitution ──────────────────────────────────────────
+
+  @spec maybe_substitute_invisible([grapheme_pair()], Context.t()) :: [grapheme_pair()]
+  defp maybe_substitute_invisible(pairs, %{show_invisible: true, tab_width: tw}),
+    do: substitute_invisible_pairs(pairs, tw)
+
+  defp maybe_substitute_invisible(pairs, _ctx), do: pairs
+
+  @doc false
+  @spec substitute_invisible_pairs([grapheme_pair()], pos_integer()) :: [grapheme_pair()]
+  def substitute_invisible_pairs(pairs, tab_width) do
+    trailing_start = trailing_ws_start_pairs(pairs)
+
+    {result, _col} =
+      Enum.reduce(pairs, {[], 0}, fn {g, w}, {acc, col} ->
+        case g do
+          "\t" ->
+            fill = tab_fill(col, tab_width)
+            expanded = [{"→", 1} | List.duplicate({" ", 1}, fill - 1)]
+            {Enum.reverse(expanded) ++ acc, col + fill}
+
+          " " when col >= trailing_start ->
+            {[{"·", 1} | acc], col + 1}
+
+          _ ->
+            {[{g, w} | acc], col + w}
+        end
+      end)
+
+    Enum.reverse(result)
+  end
+
+  @spec apply_invisible_chars([{String.t(), Face.t()}], pos_integer(), Face.t()) ::
+          [{String.t(), Face.t()}]
+  defp apply_invisible_chars(segments, tab_width, ws_face) do
+    full_text = Enum.map_join(segments, fn {text, _} -> text end)
+    trailing_start = trailing_ws_start_text(full_text)
+
+    {result, _col} =
+      Enum.reduce(segments, {[], 0}, fn {text, face}, {acc, col} ->
+        {seg_parts, new_col} =
+          transform_segment_text(text, face, col, tab_width, trailing_start, ws_face)
+
+        {seg_parts ++ acc, new_col}
+      end)
+
+    Enum.reverse(result)
+  end
+
+  @spec transform_segment_text(
+          String.t(),
+          Face.t(),
+          non_neg_integer(),
+          pos_integer(),
+          non_neg_integer(),
+          Face.t()
+        ) :: {[{String.t(), Face.t()}], non_neg_integer()}
+  defp transform_segment_text(text, face, col, tab_width, trailing_start, ws_face) do
+    graphemes = String.graphemes(text)
+
+    {parts, current_run, current_face, new_col} =
+      Enum.reduce(graphemes, {[], "", face, col}, fn g, {parts, run, run_face, c} ->
+        case g do
+          "\t" ->
+            fill = tab_fill(c, tab_width)
+            tab_text = "→" <> String.duplicate(" ", fill - 1)
+            parts = flush_run(parts, run, run_face)
+            {[{tab_text, ws_face} | parts], "", face, c + fill}
+
+          " " when c >= trailing_start ->
+            parts = flush_run(parts, run, run_face)
+            {[{"·", ws_face} | parts], "", face, c + 1}
+
+          _ ->
+            w = Unicode.grapheme_width(g)
+            append_grapheme(parts, run, run_face, face, g, c + w)
+        end
+      end)
+
+    parts = flush_run(parts, current_run, current_face)
+    {parts, new_col}
+  end
+
+  @spec flush_run([{String.t(), Face.t()}], String.t(), Face.t()) :: [{String.t(), Face.t()}]
+  defp flush_run(parts, "", _face), do: parts
+  defp flush_run(parts, run, face), do: [{run, face} | parts]
+
+  @spec append_grapheme(
+          [{String.t(), Face.t()}],
+          String.t(),
+          Face.t(),
+          Face.t(),
+          String.t(),
+          non_neg_integer()
+        ) :: {[{String.t(), Face.t()}], String.t(), Face.t(), non_neg_integer()}
+  defp append_grapheme(parts, run, run_face, face, g, new_col) when run_face == face do
+    {parts, run <> g, face, new_col}
+  end
+
+  defp append_grapheme(parts, run, run_face, face, g, new_col) do
+    {flush_run(parts, run, run_face), g, face, new_col}
+  end
+
+  @spec tab_fill(non_neg_integer(), pos_integer()) :: pos_integer()
+  defp tab_fill(col, tab_width) do
+    fill = tab_width - rem(col, tab_width)
+    if fill == 0, do: tab_width, else: fill
+  end
+
+  @spec trailing_ws_start_pairs([grapheme_pair()]) :: non_neg_integer()
+  defp trailing_ws_start_pairs(pairs) do
+    {last_non_ws, _} =
+      Enum.reduce(pairs, {0, 0}, fn {g, w}, {last, col} ->
+        case g do
+          " " -> {last, col + w}
+          "\t" -> {last, col + w}
+          _ -> {col + w, col + w}
+        end
+      end)
+
+    last_non_ws
+  end
+
+  @spec trailing_ws_start_text(String.t()) :: non_neg_integer()
+  defp trailing_ws_start_text(text) do
+    graphemes = String.graphemes(text)
+
+    {last_non_ws, _} =
+      Enum.reduce(graphemes, {0, 0}, fn g, {last, col} ->
+        w = Unicode.grapheme_width(g)
+
+        case g do
+          " " -> {last, col + w}
+          "\t" -> {last, col + w}
+          _ -> {col + w, col + w}
+        end
+      end)
+
+    last_non_ws
   end
 
   # ── Conceal application to grapheme pairs (for selection paths) ──────────────
@@ -544,6 +688,11 @@ defmodule MingaEditor.Renderer.Line do
     segments = Decorations.merge_highlights(segments, line_highlights, buf_line)
     segments = Composition.apply_conceals(segments, ctx.decorations, buf_line)
     segments = Composition.inject_inline_virtual_text(segments, ctx.decorations, buf_line)
+
+    segments =
+      if ctx.show_invisible,
+        do: apply_invisible_chars(segments, ctx.tab_width, ctx.whitespace_face),
+        else: segments
 
     render_segments_with_scroll(segments, screen_row, ctx)
   end

--- a/lib/minga_editor/renderer/line.ex
+++ b/lib/minga_editor/renderer/line.ex
@@ -71,6 +71,7 @@ defmodule MingaEditor.Renderer.Line do
 
     has_conceals = Decorations.has_conceal_ranges?(ctx.decorations)
 
+    # Conceals first: invisible substitution must see conceal-adjusted positions
     concealed_pairs =
       if has_conceals do
         raw_pairs
@@ -437,21 +438,21 @@ defmodule MingaEditor.Renderer.Line do
   @doc false
   @spec substitute_invisible_pairs([grapheme_pair()], pos_integer()) :: [grapheme_pair()]
   def substitute_invisible_pairs(pairs, tab_width) do
-    trailing_start = trailing_ws_start_pairs(pairs)
+    trailing_idx = trailing_ws_start_index(pairs)
 
-    {result, _col} =
-      Enum.reduce(pairs, {[], 0}, fn {g, w}, {acc, col} ->
+    {result, _col, _idx} =
+      Enum.reduce(pairs, {[], 0, 0}, fn {g, w}, {acc, col, idx} ->
         case g do
           "\t" ->
             fill = tab_fill(col, tab_width)
             expanded = [{"→", 1} | List.duplicate({" ", 1}, fill - 1)]
-            {Enum.reverse(expanded) ++ acc, col + fill}
+            {Enum.reverse(expanded) ++ acc, col + fill, idx + 1}
 
-          " " when col >= trailing_start ->
-            {[{"·", 1} | acc], col + 1}
+          " " when idx >= trailing_idx ->
+            {[{"·", 1} | acc], col + 1, idx + 1}
 
           _ ->
-            {[{g, w} | acc], col + w}
+            {[{g, w} | acc], col + w, idx + 1}
         end
       end)
 
@@ -462,14 +463,14 @@ defmodule MingaEditor.Renderer.Line do
           [{String.t(), Face.t()}]
   defp apply_invisible_chars(segments, tab_width, ws_face) do
     full_text = Enum.map_join(segments, fn {text, _} -> text end)
-    trailing_start = trailing_ws_start_text(full_text)
+    trailing_idx = trailing_ws_start_index_text(full_text)
 
-    {result, _col} =
-      Enum.reduce(segments, {[], 0}, fn {text, face}, {acc, col} ->
-        {seg_parts, new_col} =
-          transform_segment_text(text, face, col, tab_width, trailing_start, ws_face)
+    {result, _col, _idx} =
+      Enum.reduce(segments, {[], 0, 0}, fn {text, face}, {acc, col, idx} ->
+        {seg_parts, new_col, new_idx} =
+          transform_segment_text(text, face, col, idx, tab_width, trailing_idx, ws_face)
 
-        {seg_parts ++ acc, new_col}
+        {seg_parts ++ acc, new_col, new_idx}
       end)
 
     Enum.reverse(result)
@@ -479,34 +480,36 @@ defmodule MingaEditor.Renderer.Line do
           String.t(),
           Face.t(),
           non_neg_integer(),
+          non_neg_integer(),
           pos_integer(),
           non_neg_integer(),
           Face.t()
-        ) :: {[{String.t(), Face.t()}], non_neg_integer()}
-  defp transform_segment_text(text, face, col, tab_width, trailing_start, ws_face) do
+        ) :: {[{String.t(), Face.t()}], non_neg_integer(), non_neg_integer()}
+  defp transform_segment_text(text, face, col, idx, tab_width, trailing_idx, ws_face) do
     graphemes = String.graphemes(text)
 
-    {parts, current_run, current_face, new_col} =
-      Enum.reduce(graphemes, {[], "", face, col}, fn g, {parts, run, run_face, c} ->
+    {parts, current_run, current_face, new_col, new_idx} =
+      Enum.reduce(graphemes, {[], "", face, col, idx}, fn g, {parts, run, run_face, c, i} ->
         case g do
           "\t" ->
             fill = tab_fill(c, tab_width)
             tab_text = "→" <> String.duplicate(" ", fill - 1)
             parts = flush_run(parts, run, run_face)
-            {[{tab_text, ws_face} | parts], "", face, c + fill}
+            {[{tab_text, ws_face} | parts], "", face, c + fill, i + 1}
 
-          " " when c >= trailing_start ->
+          " " when i >= trailing_idx ->
             parts = flush_run(parts, run, run_face)
-            {[{"·", ws_face} | parts], "", face, c + 1}
+            {[{"·", ws_face} | parts], "", face, c + 1, i + 1}
 
           _ ->
             w = Unicode.grapheme_width(g)
-            append_grapheme(parts, run, run_face, face, g, c + w)
+            {p, r, f, nc} = append_grapheme(parts, run, run_face, face, g, c + w)
+            {p, r, f, nc, i + 1}
         end
       end)
 
     parts = flush_run(parts, current_run, current_face)
-    {parts, new_col}
+    {parts, new_col, new_idx}
   end
 
   @spec flush_run([{String.t(), Face.t()}], String.t(), Face.t()) :: [{String.t(), Face.t()}]
@@ -530,37 +533,33 @@ defmodule MingaEditor.Renderer.Line do
   end
 
   @spec tab_fill(non_neg_integer(), pos_integer()) :: pos_integer()
-  defp tab_fill(col, tab_width) do
-    fill = tab_width - rem(col, tab_width)
-    if fill == 0, do: tab_width, else: fill
-  end
+  defp tab_fill(col, tab_width), do: tab_width - rem(col, tab_width)
 
-  @spec trailing_ws_start_pairs([grapheme_pair()]) :: non_neg_integer()
-  defp trailing_ws_start_pairs(pairs) do
+  # Returns the grapheme index where trailing whitespace begins.
+  @spec trailing_ws_start_index([grapheme_pair()]) :: non_neg_integer()
+  defp trailing_ws_start_index(pairs) do
     {last_non_ws, _} =
-      Enum.reduce(pairs, {0, 0}, fn {g, w}, {last, col} ->
+      Enum.reduce(pairs, {0, 0}, fn {g, _w}, {last, idx} ->
         case g do
-          " " -> {last, col + w}
-          "\t" -> {last, col + w}
-          _ -> {col + w, col + w}
+          " " -> {last, idx + 1}
+          "\t" -> {last, idx + 1}
+          _ -> {idx + 1, idx + 1}
         end
       end)
 
     last_non_ws
   end
 
-  @spec trailing_ws_start_text(String.t()) :: non_neg_integer()
-  defp trailing_ws_start_text(text) do
-    graphemes = String.graphemes(text)
-
+  @spec trailing_ws_start_index_text(String.t()) :: non_neg_integer()
+  defp trailing_ws_start_index_text(text) do
     {last_non_ws, _} =
-      Enum.reduce(graphemes, {0, 0}, fn g, {last, col} ->
-        w = Unicode.grapheme_width(g)
-
+      text
+      |> String.graphemes()
+      |> Enum.reduce({0, 0}, fn g, {last, idx} ->
         case g do
-          " " -> {last, col + w}
-          "\t" -> {last, col + w}
-          _ -> {col + w, col + w}
+          " " -> {last, idx + 1}
+          "\t" -> {last, idx + 1}
+          _ -> {idx + 1, idx + 1}
         end
       end)
 

--- a/lib/minga_editor/semantic_window/builder.ex
+++ b/lib/minga_editor/semantic_window/builder.ex
@@ -199,7 +199,7 @@ defmodule MingaEditor.SemanticWindow.Builder do
     |> Enum.with_index()
     |> Enum.map(fn {{line_text, hl_segments}, idx} ->
       buf_line = first_line + idx
-      {composed_text, spans} = compose_line(line_text, hl_segments, ctx.decorations, buf_line)
+      {composed_text, spans} = compose_line(line_text, hl_segments, ctx, buf_line)
 
       %VisualRow{
         row_type: :normal,
@@ -234,7 +234,7 @@ defmodule MingaEditor.SemanticWindow.Builder do
         ) :: VisualRow.t()
   defp build_visual_row_entry(buf_line, :normal, lines, first_line, ctx) do
     line_text = line_at(lines, buf_line, first_line)
-    {composed, spans} = compose_line(line_text, nil, ctx.decorations, buf_line)
+    {composed, spans} = compose_line(line_text, nil, ctx, buf_line)
 
     %VisualRow{
       row_type: :normal,
@@ -248,7 +248,7 @@ defmodule MingaEditor.SemanticWindow.Builder do
   defp build_visual_row_entry(buf_line, {:fold_start, hidden_count}, lines, first_line, ctx) do
     line_text = line_at(lines, buf_line, first_line)
     fold_text = line_text <> " ··· #{hidden_count} lines"
-    {composed, spans} = compose_line(fold_text, nil, ctx.decorations, buf_line)
+    {composed, spans} = compose_line(fold_text, nil, ctx, buf_line)
 
     %VisualRow{
       row_type: :fold_start,
@@ -316,10 +316,10 @@ defmodule MingaEditor.SemanticWindow.Builder do
   @spec compose_line(
           String.t(),
           [Highlight.styled_segment()] | nil,
-          Decorations.t(),
+          Context.t(),
           non_neg_integer()
         ) :: {String.t(), [Span.t()]}
-  defp compose_line(line_text, hl_segments, decorations, buf_line) do
+  defp compose_line(line_text, hl_segments, ctx, buf_line) do
     # Start with highlight segments or plain text
     segments =
       case hl_segments do
@@ -328,11 +328,16 @@ defmodule MingaEditor.SemanticWindow.Builder do
       end
 
     # Merge decoration highlights (search matches, etc.)
-    line_highlights = Decorations.highlights_for_line(decorations, buf_line)
+    line_highlights = Decorations.highlights_for_line(ctx.decorations, buf_line)
     segments = Decorations.merge_highlights(segments, line_highlights, buf_line)
 
     # Apply conceals and inject inline virtual text (shared pipeline)
-    segments = Composition.compose_segments(segments, decorations, buf_line)
+    segments = Composition.compose_segments(segments, ctx.decorations, buf_line)
+
+    segments =
+      if ctx.show_invisible,
+        do: Composition.apply_invisible_chars(segments, ctx.tab_width, ctx.whitespace_face),
+        else: segments
 
     # Convert to composed text + spans
     Composition.segments_to_text_and_spans(segments)

--- a/lib/minga_editor/ui/theme.ex
+++ b/lib/minga_editor/ui/theme.ex
@@ -97,7 +97,8 @@ defmodule MingaEditor.UI.Theme do
       :yank_flash_bg,
       :highlight_read_bg,
       :highlight_write_bg,
-      :selection_bg
+      :selection_bg,
+      :whitespace_fg
     ]
 
     @type t :: %__MODULE__{
@@ -110,7 +111,8 @@ defmodule MingaEditor.UI.Theme do
             yank_flash_bg: MingaEditor.UI.Theme.color() | nil,
             highlight_read_bg: MingaEditor.UI.Theme.color() | nil,
             highlight_write_bg: MingaEditor.UI.Theme.color() | nil,
-            selection_bg: MingaEditor.UI.Theme.color() | nil
+            selection_bg: MingaEditor.UI.Theme.color() | nil,
+            whitespace_fg: MingaEditor.UI.Theme.color() | nil
           }
   end
 

--- a/lib/minga_editor/ui/theme/catppuccin.ex
+++ b/lib/minga_editor/ui/theme/catppuccin.ex
@@ -23,7 +23,8 @@ defmodule MingaEditor.UI.Theme.Catppuccin do
         yank_flash_bg: p.surface1,
         highlight_read_bg: p.surface1,
         highlight_write_bg: p.surface2,
-        selection_bg: p.surface2
+        selection_bg: p.surface2,
+        whitespace_fg: p.overlay0
       },
       gutter: %MingaEditor.UI.Theme.Gutter{
         fg: p.overlay0,

--- a/lib/minga_editor/ui/theme/doom_one.ex
+++ b/lib/minga_editor/ui/theme/doom_one.ex
@@ -41,7 +41,8 @@ defmodule MingaEditor.UI.Theme.DoomOne do
         yank_flash_bg: 0x4B5263,
         highlight_read_bg: 0x3A3F4B,
         highlight_write_bg: 0x4A3F2B,
-        selection_bg: 0x264F78
+        selection_bg: 0x264F78,
+        whitespace_fg: @base5
       },
       gutter: %MingaEditor.UI.Theme.Gutter{
         fg: @base5,

--- a/lib/minga_editor/ui/theme/one_dark.ex
+++ b/lib/minga_editor/ui/theme/one_dark.ex
@@ -38,7 +38,8 @@ defmodule MingaEditor.UI.Theme.OneDark do
         yank_flash_bg: 0x4B5263,
         highlight_read_bg: 0x3A3F4B,
         highlight_write_bg: 0x4A3F2B,
-        selection_bg: 0x264F78
+        selection_bg: 0x264F78,
+        whitespace_fg: @syntax_gutter
       },
       gutter: %MingaEditor.UI.Theme.Gutter{
         fg: @syntax_gutter,

--- a/lib/minga_editor/ui/theme/one_light.ex
+++ b/lib/minga_editor/ui/theme/one_light.ex
@@ -38,7 +38,8 @@ defmodule MingaEditor.UI.Theme.OneLight do
         yank_flash_bg: 0xD5D5D5,
         highlight_read_bg: 0xD0D5DC,
         highlight_write_bg: 0xE8D8B8,
-        selection_bg: 0xBDD5FC
+        selection_bg: 0xBDD5FC,
+        whitespace_fg: @syntax_gutter
       },
       gutter: %MingaEditor.UI.Theme.Gutter{
         fg: @syntax_gutter,

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -38,6 +38,7 @@ defmodule Minga.Config.OptionsTest do
                theme: :doom_one,
                indent_with: :spaces,
                indent_guides: true,
+               show_invisible: false,
                trim_trailing_whitespace: false,
                insert_final_newline: false,
                format_on_save: false,

--- a/test/minga_editor/integration/toggle_invisible_test.exs
+++ b/test/minga_editor/integration/toggle_invisible_test.exs
@@ -1,0 +1,51 @@
+defmodule Minga.Integration.ToggleInvisibleTest do
+  @moduledoc "Integration tests for toggling invisible characters via SPC t i."
+  use Minga.Test.EditorCase, async: true
+
+  alias Minga.Buffer.Server, as: BufferServer
+
+  describe "SPC t i toggles invisible characters" do
+    test "toggles show_invisible option on the buffer" do
+      ctx = start_editor("hello")
+
+      assert BufferServer.get_option(ctx.buffer, :show_invisible) == false
+
+      send_keys_sync(ctx, "<SPC>ti")
+      assert BufferServer.get_option(ctx.buffer, :show_invisible) == true
+
+      send_keys_sync(ctx, "<SPC>ti")
+      assert BufferServer.get_option(ctx.buffer, :show_invisible) == false
+    end
+
+    test "trailing whitespace renders as dots when enabled" do
+      ctx = start_editor("hello   ")
+
+      send_keys_sync(ctx, "<SPC>ti")
+
+      row = screen_row(ctx, 1)
+      assert row =~ "hello···"
+    end
+
+    test "tab characters render as arrow when enabled" do
+      ctx = start_editor("\thello")
+
+      send_keys_sync(ctx, "<SPC>ti")
+
+      row = screen_row(ctx, 1)
+      assert row =~ "→"
+      assert row =~ "hello"
+    end
+
+    test "invisible markers disappear when toggled off" do
+      ctx = start_editor("hello   ")
+
+      send_keys_sync(ctx, "<SPC>ti")
+      row = screen_row(ctx, 1)
+      assert row =~ "·"
+
+      send_keys_sync(ctx, "<SPC>ti")
+      row = screen_row(ctx, 1)
+      refute row =~ "·"
+    end
+  end
+end

--- a/test/minga_editor/renderer/invisible_chars_test.exs
+++ b/test/minga_editor/renderer/invisible_chars_test.exs
@@ -56,6 +56,12 @@ defmodule MingaEditor.Renderer.InvisibleCharsTest do
       assert result == [{"h", 1}, {" ", 1}, {"i", 1}]
     end
 
+    test "interior spaces after tabs are not replaced" do
+      pairs = [{"	", 0}, {" ", 1}, {"x", 1}]
+      result = Line.substitute_invisible_pairs(pairs, 4)
+      assert result == [{"→", 1}, {" ", 1}, {" ", 1}, {" ", 1}, {" ", 1}, {"x", 1}]
+    end
+
     test "line with only spaces becomes all dots" do
       pairs = [{" ", 1}, {" ", 1}, {" ", 1}]
       result = Line.substitute_invisible_pairs(pairs, 4)

--- a/test/minga_editor/renderer/invisible_chars_test.exs
+++ b/test/minga_editor/renderer/invisible_chars_test.exs
@@ -1,0 +1,107 @@
+defmodule MingaEditor.Renderer.InvisibleCharsTest do
+  @moduledoc "Tests for invisible character substitution in the line renderer."
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Renderer.Line
+
+  describe "substitute_invisible_pairs/2" do
+    test "no invisible chars returns pairs unchanged" do
+      pairs = [{"h", 1}, {"i", 1}]
+      assert Line.substitute_invisible_pairs(pairs, 4) == pairs
+    end
+
+    test "tab at column 0 expands to arrow + fill spaces" do
+      pairs = [{"	", 0}, {"x", 1}]
+      result = Line.substitute_invisible_pairs(pairs, 4)
+      assert result == [{"→", 1}, {" ", 1}, {" ", 1}, {" ", 1}, {"x", 1}]
+    end
+
+    test "tab at column 2 with tab_width 4 expands to 2 chars" do
+      pairs = [{"a", 1}, {"b", 1}, {"	", 0}, {"x", 1}]
+      result = Line.substitute_invisible_pairs(pairs, 4)
+      assert result == [{"a", 1}, {"b", 1}, {"→", 1}, {" ", 1}, {"x", 1}]
+    end
+
+    test "tab at tab stop boundary expands to full tab_width" do
+      pairs = [{"a", 1}, {"b", 1}, {"c", 1}, {"d", 1}, {"	", 0}]
+      result = Line.substitute_invisible_pairs(pairs, 4)
+
+      assert result == [
+               {"a", 1},
+               {"b", 1},
+               {"c", 1},
+               {"d", 1},
+               {"→", 1},
+               {" ", 1},
+               {" ", 1},
+               {" ", 1}
+             ]
+    end
+
+    test "tab with tab_width 2" do
+      pairs = [{"	", 0}, {"x", 1}]
+      result = Line.substitute_invisible_pairs(pairs, 2)
+      assert result == [{"→", 1}, {" ", 1}, {"x", 1}]
+    end
+
+    test "trailing spaces become dots" do
+      pairs = [{"h", 1}, {"i", 1}, {" ", 1}, {" ", 1}]
+      result = Line.substitute_invisible_pairs(pairs, 4)
+      assert result == [{"h", 1}, {"i", 1}, {"·", 1}, {"·", 1}]
+    end
+
+    test "interior spaces are not replaced" do
+      pairs = [{"h", 1}, {" ", 1}, {"i", 1}]
+      result = Line.substitute_invisible_pairs(pairs, 4)
+      assert result == [{"h", 1}, {" ", 1}, {"i", 1}]
+    end
+
+    test "line with only spaces becomes all dots" do
+      pairs = [{" ", 1}, {" ", 1}, {" ", 1}]
+      result = Line.substitute_invisible_pairs(pairs, 4)
+      assert result == [{"·", 1}, {"·", 1}, {"·", 1}]
+    end
+
+    test "empty line returns empty" do
+      assert Line.substitute_invisible_pairs([], 4) == []
+    end
+
+    test "mixed tabs and trailing whitespace" do
+      pairs = [{"	", 0}, {"h", 1}, {"i", 1}, {" ", 1}, {"	", 0}]
+      result = Line.substitute_invisible_pairs(pairs, 4)
+
+      assert result == [
+               {"→", 1},
+               {" ", 1},
+               {" ", 1},
+               {" ", 1},
+               {"h", 1},
+               {"i", 1},
+               {"·", 1},
+               {"→", 1}
+             ]
+    end
+
+    test "consecutive tabs expand correctly" do
+      pairs = [{"	", 0}, {"	", 0}]
+      result = Line.substitute_invisible_pairs(pairs, 4)
+
+      assert result == [
+               {"→", 1},
+               {" ", 1},
+               {" ", 1},
+               {" ", 1},
+               {"→", 1},
+               {" ", 1},
+               {" ", 1},
+               {" ", 1}
+             ]
+    end
+
+    test "trailing tab after text expands and becomes visible" do
+      pairs = [{"x", 1}, {"	", 0}]
+      result = Line.substitute_invisible_pairs(pairs, 4)
+      assert result == [{"x", 1}, {"→", 1}, {" ", 1}, {" ", 1}]
+    end
+  end
+end

--- a/test/minga_editor/semantic_window_test.exs
+++ b/test/minga_editor/semantic_window_test.exs
@@ -126,6 +126,21 @@ defmodule MingaEditor.SemanticWindowTest do
       assert semantic_texts == ["alpha", "beta", "gamma", "delta", "epsilon"]
     end
 
+    test "semantic row text includes invisible markers when enabled" do
+      state = gui_state(content: "\thello   ")
+
+      assert {:ok, true} =
+               BufferServer.set_option(state.workspace.buffers.active, :show_invisible, true)
+
+      {[wf], _cursor, _state} = build_content(state)
+
+      [row] = wf.semantic.rows
+      [draw_text] = extract_draw_texts(wf.lines)
+      assert row.text == draw_text
+      assert row.text =~ "→"
+      assert row.text =~ "hello···"
+    end
+
     test "empty buffer produces valid semantic window" do
       state = gui_state(content: "")
       {[wf], _cursor, _state} = build_content(state)


### PR DESCRIPTION
## Summary
- Adds `SPC t i` to toggle invisible character display per-buffer: tabs render as `→` + fill, trailing whitespace renders as `·`
- Styled through a theme-derived `whitespace_fg` face (dim, matches gutter color) across all 4 theme families
- Integrated into all line render paths and GUI semantic window content via shared segment transformation, with render cache invalidation via context fingerprint

Closes #1565

## Test plan
- [x] 13 unit tests for `substitute_invisible_pairs/2`: tab expansion at various columns/tab widths, trailing whitespace detection, mixed scenarios, edge cases (empty line, all-whitespace)
- [x] 1 semantic window regression test: GUI semantic rows include `→` and `·` when invisible characters are enabled
- [x] 4 integration tests: option toggle round-trip, trailing dots on screen, tab arrow on screen, markers disappear on toggle-off
- [x] `mix test.llm` passes (8,292 tests, 0 failures)
- [x] `make lint` passes (format, credo, compile warnings, dialyzer)
- [ ] Manual: open a file with tabs/trailing whitespace, `SPC t i` shows markers in dim color, `SPC t i` again hides them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
