### PR TITLE
feat(git): diff view colored backgrounds, live update, staged toggle

### DIFF
--- a/lib/minga/git.ex
+++ b/lib/minga/git.ex
@@ -84,6 +84,15 @@ defmodule Minga.Git do
   def show_head(git_root, relative_path), do: impl().show_head(git_root, relative_path)
 
   @doc """
+  Reads the staged (index) version of a file from git.
+
+  Returns `{:ok, content}` with the file content in the index, or `:error`
+  if the file is not staged.
+  """
+  @spec show_staged(String.t(), String.t()) :: {:ok, String.t()} | :error
+  def show_staged(git_root, relative_path), do: impl().show_staged(git_root, relative_path)
+
+  @doc """
   Applies a unified diff patch to the git index (staging area).
   """
   @spec stage_patch(String.t(), String.t()) :: :ok | {:error, String.t()}

--- a/lib/minga/git/backend.ex
+++ b/lib/minga/git/backend.ex
@@ -17,6 +17,9 @@ defmodule Minga.Git.Backend do
   @callback show_head(git_root :: String.t(), relative_path :: String.t()) ::
               {:ok, String.t()} | :error
 
+  @callback show_staged(git_root :: String.t(), relative_path :: String.t()) ::
+              {:ok, String.t()} | :error
+
   @callback blame_line(
               git_root :: String.t(),
               relative_path :: String.t(),

--- a/lib/minga/git/system.ex
+++ b/lib/minga/git/system.ex
@@ -41,6 +41,21 @@ defmodule Minga.Git.System do
   end
 
   @impl true
+  @spec show_staged(String.t(), String.t()) :: {:ok, String.t()} | :error
+  def show_staged(git_root, relative_path)
+      when is_binary(git_root) and is_binary(relative_path) do
+    case System.cmd("git", ["show", ":#{relative_path}"],
+           cd: git_root,
+           stderr_to_stdout: true
+         ) do
+      {content, 0} -> {:ok, content}
+      _ -> :error
+    end
+  rescue
+    _ -> :error
+  end
+
+  @impl true
   @spec stage_patch(String.t(), String.t()) :: :ok | {:error, String.t()}
   def stage_patch(git_root, patch) when is_binary(git_root) and is_binary(patch) do
     port =

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -122,6 +122,7 @@ defmodule Minga.Keymap.Defaults do
     {[{?g, @none}, {?r, @none}], :git_revert_hunk, "Revert hunk"},
     {[{?g, @none}, {?v, @none}], :git_preview_hunk, "Preview hunk"},
     {[{?g, @none}, {?b, @none}], :git_blame_line, "Blame line"},
+    {[{?g, @none}, {?D, @none}], :git_diff_toggle_staged, "Toggle staged/unstaged diff"},
 
     # ── Project ────────────────────────────────────────────────────────────────
     {[{?p, @none}, {?f, @none}], :project_find_file, "Find file in project"},

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -189,13 +189,12 @@ defmodule MingaEditor.Commands.Git do
   have an open buffer. Creates a temporary buffer for the current content
   and opens a diff view against HEAD.
   """
-  @spec open_diff_for_path(state(), String.t(), String.t(), String.t(), String.t()) :: state()
-  def open_diff_for_path(state, git_root, rel_path, _abs_path, current_content) do
-    base_content =
-      case Git.show_head(git_root, rel_path) do
-        {:ok, content} -> content
-        :error -> ""
-      end
+  @spec open_diff_for_path(state(), String.t(), String.t(), String.t(), String.t(), keyword()) ::
+          state()
+  def open_diff_for_path(state, git_root, rel_path, _abs_path, current_content, opts \\ []) do
+    base_content = head_content(git_root, rel_path)
+    staged = Keyword.get(opts, :staged, false)
+    label = if staged, do: "staged", else: "unstaged"
 
     diff_result = DiffView.build(base_content, current_content)
     filename = Path.basename(rel_path)
@@ -205,7 +204,7 @@ defmodule MingaEditor.Commands.Git do
            content: diff_result.text,
            buffer_type: :nofile,
            read_only: true,
-           buffer_name: "#{filename} [diff:unstaged]",
+           buffer_name: "#{filename} [diff:#{label}]",
            filetype: filetype
          ) do
       {:ok, diff_buf} ->
@@ -215,14 +214,16 @@ defmodule MingaEditor.Commands.Git do
           source_buf: nil,
           git_root: git_root,
           rel_path: rel_path,
-          staged: false,
+          staged: staged,
           line_metadata: diff_result.line_metadata
         }
 
         state
         |> EditorState.register_diff_view(diff_buf, diff_info)
         |> Commands.add_buffer(diff_buf)
-        |> EditorState.set_status("Diff: #{filename} (#{length(diff_result.hunk_lines)} hunks)")
+        |> EditorState.set_status(
+          "Diff (#{label}): #{filename} (#{length(diff_result.hunk_lines)} hunks)"
+        )
 
       {:error, reason} ->
         EditorState.set_status(state, "Failed to open diff: #{inspect(reason)}")
@@ -278,31 +279,53 @@ defmodule MingaEditor.Commands.Git do
 
   @spec diff_contents(String.t(), String.t(), pid(), boolean()) :: {String.t(), String.t()}
   defp diff_contents(git_root, rel_path, buf, false) do
-    base_content =
-      case Git.show_head(git_root, rel_path) do
-        {:ok, content} -> content
-        :error -> ""
-      end
-
+    base_content = head_content(git_root, rel_path)
     {current_content, _cursor} = Buffer.content_and_cursor(buf)
     {base_content, current_content}
   end
 
   defp diff_contents(git_root, rel_path, _buf, true) do
-    base_content =
-      case Git.show_head(git_root, rel_path) do
-        {:ok, content} -> content
-        :error -> ""
-      end
-
-    staged_content =
-      case Git.show_staged(git_root, rel_path) do
-        {:ok, content} -> content
-        :error -> base_content
-      end
-
-    {base_content, staged_content}
+    base_content = head_content(git_root, rel_path)
+    {base_content, staged_content(git_root, rel_path)}
   end
+
+  @spec head_content(String.t(), String.t()) :: String.t()
+  defp head_content(git_root, rel_path) do
+    case Git.show_head(git_root, rel_path) do
+      {:ok, content} -> content
+      :error -> ""
+    end
+  end
+
+  @spec staged_content(String.t(), String.t()) :: String.t()
+  defp staged_content(git_root, rel_path) do
+    case Git.show_staged(git_root, rel_path) do
+      {:ok, content} -> content
+      :error -> staged_content_fallback(git_root, rel_path)
+    end
+  end
+
+  @spec staged_content_fallback(String.t(), String.t()) :: String.t()
+  defp staged_content_fallback(git_root, rel_path) do
+    if staged_deleted?(git_root, rel_path), do: "", else: head_content(git_root, rel_path)
+  end
+
+  @spec staged_deleted?(String.t(), String.t()) :: boolean()
+  defp staged_deleted?(git_root, rel_path) do
+    case Git.status(git_root) do
+      {:ok, entries} -> Enum.any?(entries, &staged_deleted_entry?(&1, rel_path))
+      {:error, _reason} -> false
+    end
+  end
+
+  @spec staged_deleted_entry?(Git.StatusEntry.t(), String.t()) :: boolean()
+  defp staged_deleted_entry?(
+         %Git.StatusEntry{path: path, status: :deleted, staged: true},
+         rel_path
+       ),
+       do: path == rel_path
+
+  defp staged_deleted_entry?(%Git.StatusEntry{}, _rel_path), do: false
 
   @spec apply_diff_decorations(pid(), [DiffView.line_meta()], MingaEditor.UI.Theme.t()) :: :ok
   defp apply_diff_decorations(diff_buf, line_metadata, theme) do
@@ -401,13 +424,13 @@ defmodule MingaEditor.Commands.Git do
   """
   @spec refresh_diff_views_for_buffer(state(), pid()) :: state()
   def refresh_diff_views_for_buffer(state, saved_buf) do
-    case EditorState.diff_view_for_source(state, saved_buf) do
-      nil ->
-        state
+    diff_views = EditorState.diff_views_for_source(state, saved_buf)
 
-      {diff_buf, %{git_root: git_root, rel_path: rel_path, staged: staged}} ->
-        refresh_diff_buffer(state, diff_buf, saved_buf, git_root, rel_path, staged)
-    end
+    Enum.reduce(diff_views, state, fn {diff_buf,
+                                       %{git_root: git_root, rel_path: rel_path, staged: staged}},
+                                      acc ->
+      refresh_diff_buffer(acc, diff_buf, saved_buf, git_root, rel_path, staged)
+    end)
   end
 
   @spec refresh_diff_buffer(state(), pid(), pid(), String.t(), String.t(), boolean()) :: state()

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.Commands.Git do
   alias Minga.Buffer
   alias Minga.Core.Diff
   alias Minga.Core.DiffView
+  alias Minga.Core.Face
   alias MingaEditor.Commands
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
@@ -32,7 +33,8 @@ defmodule MingaEditor.Commands.Git do
     {:git_stage_hunk, "Stage hunk", true},
     {:git_revert_hunk, "Revert hunk", true},
     {:git_preview_hunk, "Preview hunk", true},
-    {:git_blame_line, "Blame line", true}
+    {:git_blame_line, "Blame line", true},
+    {:git_diff_toggle_staged, "Toggle diff staged/unstaged", true}
   ]
 
   @spec execute(state(), atom()) :: state()
@@ -76,6 +78,11 @@ defmodule MingaEditor.Commands.Git do
     with_git_buffer(state, fn git_pid, buf ->
       open_diff_view(state, git_pid, buf)
     end)
+  end
+
+  def execute(state, :git_diff_toggle_staged) do
+    active_buf = state.workspace.buffers.active
+    toggle_diff_staged(state, active_buf)
   end
 
   # ── Navigation ─────────────────────────────────────────────────────────────
@@ -175,12 +182,15 @@ defmodule MingaEditor.Commands.Git do
   defp close_file_tree_if_open(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
   defp close_file_tree_if_open(state), do: Commands.FileTree.close(state)
 
-  @spec open_diff_view(state(), pid(), pid()) :: state()
-  defp open_diff_view(state, git_pid, buf) do
-    git_root = Git.Buffer.git_root(git_pid)
-    rel_path = Git.Buffer.relative_path(git_pid)
-    {current_content, _cursor} = Buffer.content_and_cursor(buf)
+  @doc """
+  Opens a diff view for a file specified by path.
 
+  Used by the git status panel when opening diffs for files that may not
+  have an open buffer. Creates a temporary buffer for the current content
+  and opens a diff view against HEAD.
+  """
+  @spec open_diff_for_path(state(), String.t(), String.t(), String.t(), String.t()) :: state()
+  def open_diff_for_path(state, git_root, rel_path, _abs_path, current_content) do
     base_content =
       case Git.show_head(git_root, rel_path) do
         {:ok, content} -> content
@@ -195,20 +205,251 @@ defmodule MingaEditor.Commands.Git do
            content: diff_result.text,
            buffer_type: :nofile,
            read_only: true,
-           buffer_name: "#{filename} [diff]",
+           buffer_name: "#{filename} [diff:unstaged]",
            filetype: filetype
          ) do
       {:ok, diff_buf} ->
-        state = Commands.add_buffer(state, diff_buf)
+        apply_diff_decorations(diff_buf, diff_result.line_metadata, state.theme)
 
-        EditorState.set_status(
-          state,
-          "Diff: #{filename} (#{length(diff_result.hunk_lines)} hunks)"
+        diff_info = %{
+          source_buf: nil,
+          git_root: git_root,
+          rel_path: rel_path,
+          staged: false,
+          line_metadata: diff_result.line_metadata
+        }
+
+        state
+        |> EditorState.register_diff_view(diff_buf, diff_info)
+        |> Commands.add_buffer(diff_buf)
+        |> EditorState.set_status("Diff: #{filename} (#{length(diff_result.hunk_lines)} hunks)")
+
+      {:error, reason} ->
+        EditorState.set_status(state, "Failed to open diff: #{inspect(reason)}")
+    end
+  end
+
+  @spec open_diff_view(state(), pid(), pid()) :: state()
+  defp open_diff_view(state, git_pid, buf) do
+    open_diff_view(state, git_pid, buf, _staged = false)
+  end
+
+  @spec open_diff_view(state(), pid(), pid(), boolean()) :: state()
+  defp open_diff_view(state, git_pid, buf, staged) do
+    git_root = Git.Buffer.git_root(git_pid)
+    rel_path = Git.Buffer.relative_path(git_pid)
+
+    {base_content, current_content} = diff_contents(git_root, rel_path, buf, staged)
+
+    diff_result = DiffView.build(base_content, current_content)
+    filename = Path.basename(rel_path)
+    filetype = Language.detect_filetype(filename)
+    label = if staged, do: "staged", else: "unstaged"
+
+    case Buffer.start_link(
+           content: diff_result.text,
+           buffer_type: :nofile,
+           read_only: true,
+           buffer_name: "#{filename} [diff:#{label}]",
+           filetype: filetype
+         ) do
+      {:ok, diff_buf} ->
+        apply_diff_decorations(diff_buf, diff_result.line_metadata, state.theme)
+
+        diff_info = %{
+          source_buf: buf,
+          git_root: git_root,
+          rel_path: rel_path,
+          staged: staged,
+          line_metadata: diff_result.line_metadata
+        }
+
+        state
+        |> EditorState.register_diff_view(diff_buf, diff_info)
+        |> Commands.add_buffer(diff_buf)
+        |> EditorState.set_status(
+          "Diff (#{label}): #{filename} (#{length(diff_result.hunk_lines)} hunks)"
         )
 
       {:error, reason} ->
         EditorState.set_status(state, "Failed to open diff: #{inspect(reason)}")
     end
+  end
+
+  @spec diff_contents(String.t(), String.t(), pid(), boolean()) :: {String.t(), String.t()}
+  defp diff_contents(git_root, rel_path, buf, false) do
+    base_content =
+      case Git.show_head(git_root, rel_path) do
+        {:ok, content} -> content
+        :error -> ""
+      end
+
+    {current_content, _cursor} = Buffer.content_and_cursor(buf)
+    {base_content, current_content}
+  end
+
+  defp diff_contents(git_root, rel_path, _buf, true) do
+    base_content =
+      case Git.show_head(git_root, rel_path) do
+        {:ok, content} -> content
+        :error -> ""
+      end
+
+    staged_content =
+      case Git.show_staged(git_root, rel_path) do
+        {:ok, content} -> content
+        :error -> base_content
+      end
+
+    {base_content, staged_content}
+  end
+
+  @spec apply_diff_decorations(pid(), [DiffView.line_meta()], MingaEditor.UI.Theme.t()) :: :ok
+  defp apply_diff_decorations(diff_buf, line_metadata, theme) do
+    Buffer.batch_decorations(diff_buf, fn decs ->
+      apply_diff_decorations_to(decs, line_metadata, theme)
+    end)
+  end
+
+  @spec apply_line_decoration(
+          Minga.Core.Decorations.t(),
+          DiffView.line_meta(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: Minga.Core.Decorations.t()
+  defp apply_line_decoration(decs, %{type: :added}, line_idx, added_bg, _removed_bg, _fold_fg) do
+    {_id, decs} =
+      Minga.Core.Decorations.add_highlight(decs, {line_idx, 0}, {line_idx, 9999},
+        style: Face.new(bg: added_bg),
+        priority: 1,
+        group: :diff
+      )
+
+    decs
+  end
+
+  defp apply_line_decoration(decs, %{type: :removed}, line_idx, _added_bg, removed_bg, _fold_fg) do
+    {_id, decs} =
+      Minga.Core.Decorations.add_highlight(decs, {line_idx, 0}, {line_idx, 9999},
+        style: Face.new(bg: removed_bg),
+        priority: 1,
+        group: :diff
+      )
+
+    decs
+  end
+
+  defp apply_line_decoration(decs, %{type: :fold}, line_idx, _added_bg, _removed_bg, fold_fg) do
+    {_id, decs} =
+      Minga.Core.Decorations.add_highlight(decs, {line_idx, 0}, {line_idx, 9999},
+        style: Face.new(fg: fold_fg, italic: true),
+        priority: 1,
+        group: :diff
+      )
+
+    decs
+  end
+
+  defp apply_line_decoration(decs, _meta, _line_idx, _added_bg, _removed_bg, _fold_fg), do: decs
+
+  @spec tint_color(non_neg_integer(), non_neg_integer(), float()) :: non_neg_integer()
+  defp tint_color(fg, bg, alpha) do
+    fg_r = Bitwise.bsr(fg, 16) |> Bitwise.band(0xFF)
+    fg_g = Bitwise.bsr(fg, 8) |> Bitwise.band(0xFF)
+    fg_b = Bitwise.band(fg, 0xFF)
+
+    bg_r = Bitwise.bsr(bg, 16) |> Bitwise.band(0xFF)
+    bg_g = Bitwise.bsr(bg, 8) |> Bitwise.band(0xFF)
+    bg_b = Bitwise.band(bg, 0xFF)
+
+    r = round(fg_r * alpha + bg_r * (1.0 - alpha))
+    g = round(fg_g * alpha + bg_g * (1.0 - alpha))
+    b = round(fg_b * alpha + bg_b * (1.0 - alpha))
+
+    Bitwise.bsl(r, 16) + Bitwise.bsl(g, 8) + b
+  end
+
+  @spec toggle_diff_staged(state(), pid()) :: state()
+  defp toggle_diff_staged(state, active_buf) do
+    case EditorState.diff_view_info(state, active_buf) do
+      nil ->
+        EditorState.set_status(state, "Not a diff view")
+
+      %{source_buf: nil} ->
+        EditorState.set_status(state, "Cannot toggle staged: diff opened from status panel")
+
+      %{source_buf: source_buf, staged: staged} ->
+        new_staged = not staged
+        git_pid = Git.tracking_pid(source_buf)
+
+        if git_pid do
+          GenServer.stop(active_buf, :normal)
+          state = EditorState.unregister_diff_view(state, active_buf)
+          open_diff_view(state, git_pid, source_buf, new_staged)
+        else
+          EditorState.set_status(state, "Source buffer no longer tracked by git")
+        end
+    end
+  end
+
+  @doc """
+  Refreshes all open diff views whose source buffer matches the saved path.
+
+  Called by `MingaEditor.handle_info/2` on `:buffer_saved` events.
+  """
+  @spec refresh_diff_views_for_buffer(state(), pid()) :: state()
+  def refresh_diff_views_for_buffer(state, saved_buf) do
+    case EditorState.diff_view_for_source(state, saved_buf) do
+      nil ->
+        state
+
+      {diff_buf, %{git_root: git_root, rel_path: rel_path, staged: staged}} ->
+        refresh_diff_buffer(state, diff_buf, saved_buf, git_root, rel_path, staged)
+    end
+  end
+
+  @spec refresh_diff_buffer(state(), pid(), pid(), String.t(), String.t(), boolean()) :: state()
+  defp refresh_diff_buffer(state, diff_buf, source_buf, git_root, rel_path, staged) do
+    {base_content, current_content} = diff_contents(git_root, rel_path, source_buf, staged)
+    diff_result = DiffView.build(base_content, current_content)
+
+    Buffer.replace_content_with_decorations(
+      diff_buf,
+      diff_result.text,
+      fn _decs ->
+        decs = Minga.Core.Decorations.new()
+        apply_diff_decorations_to(decs, diff_result.line_metadata, state.theme)
+      end
+    )
+
+    diff_info = %{
+      source_buf: source_buf,
+      git_root: git_root,
+      rel_path: rel_path,
+      staged: staged,
+      line_metadata: diff_result.line_metadata
+    }
+
+    EditorState.register_diff_view(state, diff_buf, diff_info)
+  end
+
+  @spec apply_diff_decorations_to(
+          Minga.Core.Decorations.t(),
+          [DiffView.line_meta()],
+          MingaEditor.UI.Theme.t()
+        ) :: Minga.Core.Decorations.t()
+  defp apply_diff_decorations_to(decs, line_metadata, theme) do
+    added_bg = tint_color(theme.git.added_fg, theme.editor.bg, 0.15)
+    removed_bg = tint_color(theme.git.deleted_fg, theme.editor.bg, 0.15)
+    fold_fg = theme.gutter.fg
+
+    line_metadata
+    |> Enum.with_index()
+    |> Enum.reduce(decs, fn {meta, line_idx}, decs ->
+      apply_line_decoration(decs, meta, line_idx, added_bg, removed_bg, fold_fg)
+    end)
   end
 
   @doc """

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -34,8 +34,8 @@ defmodule MingaEditor.Handlers.FileEventHandler do
     handle_git_status_changed(state, event)
   end
 
-  def handle(state, {:minga_event, :buffer_saved, %Minga.Events.BufferEvent{}}) do
-    handle_buffer_saved(state)
+  def handle(state, {:minga_event, :buffer_saved, %Minga.Events.BufferEvent{buffer: buf}}) do
+    handle_buffer_saved(state, buf)
   end
 
   def handle(state, {:git_remote_result, ref, result}) when is_reference(ref) do
@@ -72,17 +72,18 @@ defmodule MingaEditor.Handlers.FileEventHandler do
     end
   end
 
-  @spec handle_buffer_saved(EditorState.t()) :: {EditorState.t(), [file_effect()]}
-  defp handle_buffer_saved(state) do
-    # Refresh file tree git status
-    new_state = refresh_tree_git_status(state)
+  @spec handle_buffer_saved(EditorState.t(), pid()) :: {EditorState.t(), [file_effect()]}
+  defp handle_buffer_saved(state, saved_buf) do
+    new_state =
+      state
+      |> refresh_tree_git_status()
+      |> MingaEditor.Commands.Git.refresh_diff_views_for_buffer(saved_buf)
 
     effects = [
       {:request_code_lens},
       {:request_inlay_hints}
     ]
 
-    # Save session on file save (skip in headless)
     effects =
       if state.backend != :headless do
         effects ++ [{:save_session_deferred}]

--- a/lib/minga_editor/input/git_status.ex
+++ b/lib/minga_editor/input/git_status.ex
@@ -268,51 +268,12 @@ defmodule MingaEditor.Input.GitStatus do
   defp open_diff_in_editor(state, git_root, rel_path) do
     abs_path = Path.join(git_root, rel_path)
 
-    case Git.show_head(git_root, rel_path) do
-      {:ok, base_content} ->
-        open_diff_with_content(state, abs_path, rel_path, base_content)
-
-      :error ->
-        EditorState.set_status(state, "File not in git HEAD")
-    end
-  end
-
-  @spec open_diff_with_content(EditorState.t(), String.t(), String.t(), String.t()) ::
-          EditorState.t()
-  defp open_diff_with_content(state, abs_path, rel_path, base_content) do
     case File.read(abs_path) do
       {:ok, current_content} ->
-        build_and_open_diff_buffer(state, rel_path, base_content, current_content)
+        Commands.Git.open_diff_for_path(state, git_root, rel_path, abs_path, current_content)
 
       {:error, reason} ->
         EditorState.set_status(state, "Could not read file: #{inspect(reason)}")
-    end
-  end
-
-  @spec build_and_open_diff_buffer(EditorState.t(), String.t(), String.t(), String.t()) ::
-          EditorState.t()
-  defp build_and_open_diff_buffer(state, rel_path, base_content, current_content) do
-    diff_result = Minga.Core.DiffView.build(base_content, current_content)
-    filename = Path.basename(rel_path)
-    filetype = Minga.Language.detect_filetype(filename)
-
-    case Buffer.start_link(
-           content: diff_result.text,
-           buffer_type: :nofile,
-           read_only: true,
-           buffer_name: "#{filename} [diff]",
-           filetype: filetype
-         ) do
-      {:ok, diff_buf} ->
-        state = Commands.add_buffer(state, diff_buf)
-
-        EditorState.set_status(
-          state,
-          "Diff: #{filename} (#{length(diff_result.hunk_lines)} hunks)"
-        )
-
-      {:error, reason} ->
-        EditorState.set_status(state, "Failed to open diff: #{inspect(reason)}")
     end
   end
 

--- a/lib/minga_editor/input/git_status.ex
+++ b/lib/minga_editor/input/git_status.ex
@@ -256,24 +256,46 @@ defmodule MingaEditor.Input.GitStatus do
   # ── TUI state helpers ──────────────────────────────────────────────────
 
   @spec open_diff_for_entry(EditorState.t(), String.t(), Git.StatusEntry.t()) :: EditorState.t()
-  defp open_diff_for_entry(state, git_root, entry) do
+  defp open_diff_for_entry(state, git_root, %Git.StatusEntry{} = entry) do
     closed_state =
       EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor))
       |> EditorState.close_git_status_panel()
 
-    open_diff_in_editor(closed_state, git_root, entry.path)
+    open_diff_in_editor(closed_state, git_root, entry)
   end
 
-  @spec open_diff_in_editor(EditorState.t(), String.t(), String.t()) :: EditorState.t()
-  defp open_diff_in_editor(state, git_root, rel_path) do
-    abs_path = Path.join(git_root, rel_path)
+  @spec open_diff_in_editor(EditorState.t(), String.t(), Git.StatusEntry.t()) :: EditorState.t()
+  defp open_diff_in_editor(state, git_root, %Git.StatusEntry{} = entry) do
+    abs_path = Path.join(git_root, entry.path)
 
-    case File.read(abs_path) do
+    case content_for_entry(git_root, abs_path, entry) do
       {:ok, current_content} ->
-        Commands.Git.open_diff_for_path(state, git_root, rel_path, abs_path, current_content)
+        Commands.Git.open_diff_for_path(state, git_root, entry.path, abs_path, current_content,
+          staged: entry.staged
+        )
 
-      {:error, reason} ->
-        EditorState.set_status(state, "Could not read file: #{inspect(reason)}")
+      {:error, message} ->
+        EditorState.set_status(state, message)
+    end
+  end
+
+  @spec content_for_entry(String.t(), String.t(), Git.StatusEntry.t()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp content_for_entry(_git_root, _abs_path, %Git.StatusEntry{status: :deleted}) do
+    {:ok, ""}
+  end
+
+  defp content_for_entry(git_root, _abs_path, %Git.StatusEntry{path: rel_path, staged: true}) do
+    case Git.show_staged(git_root, rel_path) do
+      {:ok, content} -> {:ok, content}
+      :error -> {:error, "Could not read staged file: #{rel_path}"}
+    end
+  end
+
+  defp content_for_entry(_git_root, abs_path, %Git.StatusEntry{}) do
+    case File.read(abs_path) do
+      {:ok, current_content} -> {:ok, current_content}
+      {:error, reason} -> {:error, "Could not read file: #{inspect(reason)}"}
     end
   end
 

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -150,7 +150,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       has_sign_column: has_sign_column,
       decorations: decorations,
       diagnostic_signs: diagnostic_signs_for_path(Map.get(params, :file_path)),
-      git_signs: git_signs_for_window(window),
+      git_signs: diff_or_git_signs(state, window),
       gutter_colors: state.theme.gutter,
       git_colors: state.theme.git
     }
@@ -953,6 +953,29 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       nil -> hl
       registry -> %{hl | face_registry: registry}
     end
+  end
+
+  @spec diff_or_git_signs(state(), Window.t()) :: %{non_neg_integer() => atom()}
+  defp diff_or_git_signs(%{diff_views: diff_views}, %{buffer: buf} = window)
+       when is_pid(buf) and is_map(diff_views) do
+    case Map.get(diff_views, buf) do
+      nil -> git_signs_for_window(window)
+      info -> diff_signs_from_metadata(info.line_metadata)
+    end
+  end
+
+  defp diff_or_git_signs(_state, window), do: git_signs_for_window(window)
+
+  @spec diff_signs_from_metadata([Minga.Core.DiffView.line_meta()]) ::
+          %{non_neg_integer() => atom()}
+  defp diff_signs_from_metadata(line_metadata) do
+    line_metadata
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn
+      {%{type: :added}, idx}, acc -> Map.put(acc, idx, :added)
+      {%{type: :removed}, idx}, acc -> Map.put(acc, idx, :removed)
+      _, acc -> acc
+    end)
   end
 
   @doc "Returns git signs for a window's buffer."

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -75,6 +75,7 @@ defmodule MingaEditor.RenderPipeline.Input do
     :focus_tree,
     :lsp,
     :parser_status,
+    :diff_views,
     # Workspace as a plain map (enables state.workspace.X pattern-matching)
     :workspace,
     # Terminal-level viewport (screen dimensions reported by frontend on resize)
@@ -121,6 +122,7 @@ defmodule MingaEditor.RenderPipeline.Input do
           focus_tree: MingaEditor.FocusTree.t() | nil,
           lsp: LSPState.t(),
           parser_status: atom(),
+          diff_views: %{pid() => EditorState.diff_view_info()},
           caches: Caches.t(),
           terminal_viewport: Viewport.t(),
           workspace: workspace()
@@ -149,6 +151,7 @@ defmodule MingaEditor.RenderPipeline.Input do
       focus_tree: state.focus_tree,
       lsp: state.lsp,
       parser_status: state.parser_status,
+      diff_views: state.diff_views,
       caches: state.caches,
       terminal_viewport: state.terminal_viewport,
       workspace: %{

--- a/lib/minga_editor/renderer/gutter.ex
+++ b/lib/minga_editor/renderer/gutter.ex
@@ -210,6 +210,9 @@ defmodule MingaEditor.Renderer.Gutter do
       :modified ->
         DisplayList.draw(screen_row, col_offset, "▎ ", Face.new(fg: git_colors.modified_fg))
 
+      :removed ->
+        DisplayList.draw(screen_row, col_offset, "- ", Face.new(fg: git_colors.deleted_fg))
+
       :deleted ->
         DisplayList.draw(screen_row, col_offset, "▁ ", Face.new(fg: git_colors.deleted_fg))
     end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -438,6 +438,11 @@ defmodule MingaEditor.State do
     Enum.find(state.diff_views, fn {_diff_buf, info} -> info.source_buf == source_buf end)
   end
 
+  @spec diff_views_for_source(t(), pid()) :: [{pid(), diff_view_info()}]
+  def diff_views_for_source(%__MODULE__{} = state, source_buf) when is_pid(source_buf) do
+    Enum.filter(state.diff_views, fn {_diff_buf, info} -> info.source_buf == source_buf end)
+  end
+
   @spec set_pending_quit(t(), :quit | :quit_all) :: t()
   def set_pending_quit(%__MODULE__{} = state, kind) when kind in [:quit, :quit_all],
     do: %{state | pending_quit: kind}

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -111,6 +111,7 @@ defmodule MingaEditor.State do
             last_test_command: nil,
             pending_quit: nil,
             buffer_monitors: %{},
+            diff_views: %{},
             face_override_registries: %{},
             caches: MingaEditor.Renderer.Caches.new(),
             session: %SessionState{},
@@ -149,6 +150,7 @@ defmodule MingaEditor.State do
           last_test_command: {String.t(), String.t()} | nil,
           pending_quit: :quit | :quit_all | nil,
           buffer_monitors: %{pid() => reference()},
+          diff_views: %{pid() => diff_view_info()},
           face_override_registries: %{pid() => MingaEditor.UI.Face.Registry.t()},
           caches: MingaEditor.Renderer.Caches.t(),
           buffer_add_context: MingaEditor.Shell.buffer_add_context(),
@@ -396,6 +398,15 @@ defmodule MingaEditor.State do
 
   # ── Global field accessors ─────────────────────────────────────────────────
 
+  @typedoc "Metadata for an open diff view buffer."
+  @type diff_view_info :: %{
+          source_buf: pid() | nil,
+          git_root: String.t(),
+          rel_path: String.t(),
+          staged: boolean(),
+          line_metadata: [Minga.Core.DiffView.line_meta()]
+        }
+
   @typedoc "The git_remote_op tracking tuple, or nil when no operation is in flight."
   @type git_remote_op ::
           {msg_ref :: reference(), task_monitor :: reference(),
@@ -407,6 +418,25 @@ defmodule MingaEditor.State do
 
   @spec clear_git_remote_op(t()) :: t()
   def clear_git_remote_op(%__MODULE__{} = state), do: %{state | git_remote_op: nil}
+
+  @spec register_diff_view(t(), pid(), diff_view_info()) :: t()
+  def register_diff_view(%__MODULE__{} = state, diff_buf, info) when is_pid(diff_buf),
+    do: %{state | diff_views: Map.put(state.diff_views, diff_buf, info)}
+
+  @spec unregister_diff_view(t(), pid()) :: t()
+  def unregister_diff_view(%__MODULE__{} = state, diff_buf) when is_pid(diff_buf),
+    do: %{state | diff_views: Map.delete(state.diff_views, diff_buf)}
+
+  @spec diff_view_info(t(), pid() | nil) :: diff_view_info() | nil
+  def diff_view_info(%__MODULE__{}, nil), do: nil
+
+  def diff_view_info(%__MODULE__{} = state, diff_buf) when is_pid(diff_buf),
+    do: Map.get(state.diff_views, diff_buf)
+
+  @spec diff_view_for_source(t(), pid()) :: {pid(), diff_view_info()} | nil
+  def diff_view_for_source(%__MODULE__{} = state, source_buf) when is_pid(source_buf) do
+    Enum.find(state.diff_views, fn {_diff_buf, info} -> info.source_buf == source_buf end)
+  end
 
   @spec set_pending_quit(t(), :quit | :quit_all) :: t()
   def set_pending_quit(%__MODULE__{} = state, kind) when kind in [:quit, :quit_all],
@@ -561,6 +591,8 @@ defmodule MingaEditor.State do
       else
         state
       end
+
+    state = unregister_diff_view(state, pid)
 
     case tab_bar(state) do
       nil -> state

--- a/test/minga_editor/commands/git_diff_decorations_test.exs
+++ b/test/minga_editor/commands/git_diff_decorations_test.exs
@@ -2,8 +2,14 @@ defmodule MingaEditor.Commands.GitDiffDecorationsTest do
   @moduledoc "Tests for diff view decoration application and sign generation."
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer
   alias Minga.Core.Decorations
   alias Minga.Core.DiffView
+  alias Minga.Git
+  alias Minga.Git.Stub, as: GitStub
+  alias MingaEditor.Commands.Git, as: GitCommands
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
 
   describe "diff sign generation" do
     test "produces :added signs for added lines" do
@@ -111,6 +117,112 @@ defmodule MingaEditor.Commands.GitDiffDecorationsTest do
       highlights = Decorations.highlights_for_lines(decs, 0, 3)
       assert length(highlights) == 2
     end
+
+    test "refresh_diff_views_for_buffer updates every diff for the saved source" do
+      git_root = unique_git_root()
+      rel_path = "file.txt"
+      GitStub.set_head(git_root, rel_path, "old\n")
+      on_exit(fn -> GitStub.clear(git_root) end)
+
+      {:ok, source_buf} = Buffer.start_link(content: "new\n")
+      {:ok, diff_one} = Buffer.start_link(content: "stale one")
+      {:ok, diff_two} = Buffer.start_link(content: "stale two")
+
+      info = %{
+        source_buf: source_buf,
+        git_root: git_root,
+        rel_path: rel_path,
+        staged: false,
+        line_metadata: []
+      }
+
+      state = %{
+        build_state()
+        | diff_views: %{
+            diff_one => info,
+            diff_two => info
+          }
+      }
+
+      state = GitCommands.refresh_diff_views_for_buffer(state, source_buf)
+
+      assert buffer_content(diff_one) =~ "new"
+      assert buffer_content(diff_two) =~ "new"
+      assert state.diff_views[diff_one].line_metadata != []
+      assert state.diff_views[diff_two].line_metadata != []
+    end
+
+    test "staged diff toggle treats staged deletions as empty index content" do
+      git_root = unique_git_root()
+      rel_path = "deleted.txt"
+      abs_path = Path.join(git_root, rel_path)
+
+      GitStub.set_head(git_root, rel_path, "old contents\n")
+
+      GitStub.set_status(git_root, [
+        %Git.StatusEntry{path: rel_path, status: :deleted, staged: true}
+      ])
+
+      on_exit(fn -> GitStub.clear(git_root) end)
+
+      {:ok, source_buf} = Buffer.start_link(content: "old contents\n")
+      {:ok, diff_buf} = Buffer.start_link(content: "placeholder")
+
+      {:ok, git_buf} =
+        Minga.Git.Buffer.start_link(
+          git_root: git_root,
+          file_path: abs_path,
+          initial_content: "old contents\n"
+        )
+
+      put_tracking(source_buf, git_buf)
+
+      state =
+        build_state()
+        |> EditorState.add_buffer(diff_buf)
+        |> EditorState.register_diff_view(diff_buf, %{
+          source_buf: source_buf,
+          git_root: git_root,
+          rel_path: rel_path,
+          staged: false,
+          line_metadata: []
+        })
+
+      state = GitCommands.execute(state, :git_diff_toggle_staged)
+      active_buf = state.workspace.buffers.active
+
+      assert active_buf != diff_buf
+      assert buffer_content(active_buf) =~ "old contents"
+      refute buffer_content(active_buf) =~ "No changes"
+      assert state.diff_views[active_buf].staged == true
+    end
+  end
+
+  defp build_state do
+    %EditorState{
+      port_manager: self(),
+      workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)}
+    }
+  end
+
+  defp buffer_content(buf) do
+    {content, _cursor} = Buffer.content_and_cursor(buf)
+    content
+  end
+
+  defp unique_git_root do
+    Path.join(System.tmp_dir!(), "minga-diff-test-#{System.unique_integer([:positive])}")
+  end
+
+  defp put_tracking(source_buf, git_buf) do
+    table = Minga.Git.Tracker.Registry
+
+    if :ets.whereis(table) == :undefined do
+      :ets.new(table, [:named_table, :public, :set, read_concurrency: true])
+    end
+
+    :ets.insert(table, {source_buf, git_buf})
+    on_exit(fn -> if :ets.whereis(table) != :undefined, do: :ets.delete(table, source_buf) end)
   end
 
   # Mirrors the private function in ContentHelpers for testability

--- a/test/minga_editor/commands/git_diff_decorations_test.exs
+++ b/test/minga_editor/commands/git_diff_decorations_test.exs
@@ -1,0 +1,126 @@
+defmodule MingaEditor.Commands.GitDiffDecorationsTest do
+  @moduledoc "Tests for diff view decoration application and sign generation."
+  use ExUnit.Case, async: true
+
+  alias Minga.Core.Decorations
+  alias Minga.Core.DiffView
+
+  describe "diff sign generation" do
+    test "produces :added signs for added lines" do
+      metadata = [
+        %{type: :context, original_line: 0, fold_count: nil},
+        %{type: :added, original_line: 1, fold_count: nil},
+        %{type: :added, original_line: 2, fold_count: nil},
+        %{type: :context, original_line: 3, fold_count: nil}
+      ]
+
+      signs = diff_signs_from_metadata(metadata)
+
+      assert signs[1] == :added
+      assert signs[2] == :added
+      refute Map.has_key?(signs, 0)
+      refute Map.has_key?(signs, 3)
+    end
+
+    test "produces :removed signs for removed lines" do
+      metadata = [
+        %{type: :context, original_line: 0, fold_count: nil},
+        %{type: :removed, original_line: nil, fold_count: nil},
+        %{type: :context, original_line: 1, fold_count: nil}
+      ]
+
+      signs = diff_signs_from_metadata(metadata)
+
+      assert signs[1] == :removed
+      refute Map.has_key?(signs, 0)
+      refute Map.has_key?(signs, 2)
+    end
+
+    test "handles mixed added and removed lines" do
+      metadata = [
+        %{type: :removed, original_line: nil, fold_count: nil},
+        %{type: :added, original_line: 0, fold_count: nil},
+        %{type: :fold, original_line: nil, fold_count: 5}
+      ]
+
+      signs = diff_signs_from_metadata(metadata)
+
+      assert signs[0] == :removed
+      assert signs[1] == :added
+      refute Map.has_key?(signs, 2)
+    end
+
+    test "returns empty map for all context lines" do
+      metadata = [
+        %{type: :context, original_line: 0, fold_count: nil},
+        %{type: :context, original_line: 1, fold_count: nil}
+      ]
+
+      signs = diff_signs_from_metadata(metadata)
+      assert signs == %{}
+    end
+  end
+
+  describe "diff view integration" do
+    test "DiffView.build produces metadata suitable for decoration" do
+      result = DiffView.build("old line\n", "new line\n")
+
+      assert is_list(result.line_metadata)
+      assert result.line_metadata != []
+
+      types = Enum.map(result.line_metadata, & &1.type)
+      assert :removed in types or :added in types
+    end
+
+    test "decoration application creates highlights for added/removed lines" do
+      metadata = [
+        %{type: :context, original_line: 0, fold_count: nil},
+        %{type: :removed, original_line: nil, fold_count: nil},
+        %{type: :added, original_line: 1, fold_count: nil},
+        %{type: :fold, original_line: nil, fold_count: 3}
+      ]
+
+      decs =
+        metadata
+        |> Enum.with_index()
+        |> Enum.reduce(Decorations.new(), fn {meta, idx}, decs ->
+          case meta.type do
+            :added ->
+              {_id, decs} =
+                Decorations.add_highlight(decs, {idx, 0}, {idx, 9999},
+                  style: Minga.Core.Face.new(bg: 0x224422),
+                  group: :diff
+                )
+
+              decs
+
+            :removed ->
+              {_id, decs} =
+                Decorations.add_highlight(decs, {idx, 0}, {idx, 9999},
+                  style: Minga.Core.Face.new(bg: 0x442222),
+                  group: :diff
+                )
+
+              decs
+
+            _ ->
+              decs
+          end
+        end)
+
+      highlights = Decorations.highlights_for_lines(decs, 0, 3)
+      assert length(highlights) == 2
+    end
+  end
+
+  # Mirrors the private function in ContentHelpers for testability
+  defp diff_signs_from_metadata(line_metadata) do
+    line_metadata
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn
+      {%{type: :added}, idx}, acc -> Map.put(acc, idx, :added)
+      {%{type: :removed}, idx}, acc -> Map.put(acc, idx, :removed)
+      _, acc -> acc
+    end)
+  end
+end

--- a/test/minga_editor/input/git_status_diff_open_test.exs
+++ b/test/minga_editor/input/git_status_diff_open_test.exs
@@ -1,0 +1,98 @@
+defmodule MingaEditor.Input.GitStatusDiffOpenTest do
+  @moduledoc "Tests git status diff opening for staged and deleted entries."
+  # Mutates the global Git.Stub root mapping because GitStatus resolves the project root internally.
+  use ExUnit.Case, async: false
+
+  alias Minga.Buffer
+  alias Minga.Git
+  alias Minga.Git.Stub, as: GitStub
+  alias MingaEditor.Input.GitStatus
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
+
+  @none 0
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: dir} do
+    project_root = Minga.Project.resolve_root()
+    GitStub.set_root(project_root, dir)
+
+    on_exit(fn ->
+      GitStub.clear(project_root)
+      GitStub.clear(dir)
+    end)
+
+    {:ok, git_root: dir}
+  end
+
+  test "previewing a staged status entry opens the staged index diff", %{git_root: git_root} do
+    rel_path = "file.txt"
+    File.write!(Path.join(git_root, rel_path), "worktree\n")
+    GitStub.set_head(git_root, rel_path, "head\n")
+    GitStub.set_staged(git_root, rel_path, "staged\n")
+
+    entry = %Git.StatusEntry{path: rel_path, status: :modified, staged: true}
+    state = state_with_selected_entry(entry)
+
+    {:handled, state} = GitStatus.handle_key(state, ?p, @none)
+    active_buf = state.workspace.buffers.active
+
+    assert Buffer.buffer_name(active_buf) == "file.txt [diff:staged]"
+    assert buffer_content(active_buf) =~ "staged"
+    refute buffer_content(active_buf) =~ "worktree"
+  end
+
+  test "previewing a deleted status entry opens a deletion diff without reading the missing file",
+       %{
+         git_root: git_root
+       } do
+    rel_path = "deleted.txt"
+    GitStub.set_head(git_root, rel_path, "removed\n")
+
+    entry = %Git.StatusEntry{path: rel_path, status: :deleted, staged: true}
+    state = state_with_selected_entry(entry)
+
+    {:handled, state} = GitStatus.handle_key(state, ?p, @none)
+    active_buf = state.workspace.buffers.active
+
+    assert Buffer.buffer_name(active_buf) == "deleted.txt [diff:staged]"
+    assert buffer_content(active_buf) =~ "removed"
+    refute EditorState.status_msg(state) =~ "Could not read"
+  end
+
+  defp state_with_selected_entry(entry) do
+    panel_data = %{
+      repo_state: :normal,
+      branch: "main",
+      ahead: 0,
+      behind: 0,
+      entries: [entry],
+      tui_state: %MingaEditor.Input.GitStatus.TuiState{
+        cursor_index: 1,
+        collapsed: %{},
+        flat_entries: [
+          {:section_header, :staged, 1},
+          {:file, :staged, entry}
+        ],
+        entries: [entry],
+        discard_confirmation: nil,
+        amend_mode: false
+      }
+    }
+
+    %EditorState{
+      port_manager: self(),
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        keymap_scope: :git_status
+      },
+      shell_state: %MingaEditor.Shell.Traditional.State{git_status_panel: panel_data},
+      focus_stack: [MingaEditor.Input.Scoped, MingaEditor.Input.ModeFSM]
+    }
+  end
+
+  defp buffer_content(buf) do
+    {content, _cursor} = Buffer.content_and_cursor(buf)
+    content
+  end
+end

--- a/test/support/git_stub.ex
+++ b/test/support/git_stub.ex
@@ -60,6 +60,13 @@ defmodule Minga.Git.Stub do
     :ok
   end
 
+  @doc "Sets the staged index content for a file in a git root."
+  @spec set_staged(String.t(), String.t(), String.t()) :: :ok
+  def set_staged(git_root, relative_path, content) do
+    :ets.insert(@table, {{:staged, Path.expand(git_root), relative_path}, content})
+    :ok
+  end
+
   @doc "Sets the log entries returned for `git_root`."
   @spec set_log(String.t(), [Minga.Git.log_entry()]) :: :ok
   def set_log(git_root, entries) when is_list(entries) do
@@ -88,6 +95,7 @@ defmodule Minga.Git.Stub do
     :ets.match_delete(@table, {{:root, expanded}, :_})
     :ets.match_delete(@table, {{:status, expanded}, :_})
     :ets.match_delete(@table, {{:head, expanded, :_}, :_})
+    :ets.match_delete(@table, {{:staged, expanded, :_}, :_})
     :ets.match_delete(@table, {{:log, expanded}, :_})
     :ets.match_delete(@table, {{:diff, expanded}, :_})
     :ets.match_delete(@table, {{:branch, expanded}, :_})

--- a/test/support/git_stub.ex
+++ b/test/support/git_stub.ex
@@ -113,6 +113,15 @@ defmodule Minga.Git.Stub do
   end
 
   @impl true
+  @spec show_staged(String.t(), String.t()) :: {:ok, String.t()} | :error
+  def show_staged(git_root, relative_path) do
+    case :ets.lookup(@table, {:staged, Path.expand(git_root), relative_path}) do
+      [{_, content}] -> {:ok, content}
+      [] -> :error
+    end
+  end
+
+  @impl true
   @spec blame_line(String.t(), String.t(), non_neg_integer()) :: :error
   def blame_line(_git_root, _relative_path, _line_number), do: :error
 


### PR DESCRIPTION
## Summary

- Wire up the previously-discarded `line_metadata` from `DiffView.build` to produce colored backgrounds (green tint for added, red tint for removed, dimmed italic for fold lines) via buffer decorations
- Add `+`/`-` signs in the gutter sign column for diff view buffers
- Add live refresh: when the source buffer is saved, the diff view recomputes and updates in place
- Add staged/unstaged toggle via `SPC g D` (closes the diff buffer, reopens with the opposite staged mode)
- Add `Git.show_staged/2` to read the index version of a file
- Refactor the git status panel's click-to-diff to share the decorated diff view path via `Commands.Git.open_diff_for_path`
- Register diff views on EditorState for cleanup on buffer death and render pipeline access

Closes #1031

## Test plan

- [x] `mix compile`: 0 errors, 0 warnings
- [x] `mix test.llm`: 8280 tests, 0 failures
- [x] New test file: `test/minga_editor/commands/git_diff_decorations_test.exs` (6 tests covering sign generation, decoration application, and DiffView integration)
- [x] `mix format`: clean
- [x] `mix credo`: only pre-existing warnings
- [ ] Manual verification: open a file with changes, press `SPC g d` to view diff, verify colored backgrounds and gutter signs appear
- [ ] Manual verification: edit and save the source file, verify the diff view updates live
- [ ] Manual verification: press `SPC g D` in the diff view to toggle staged/unstaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)