### PR TITLE
feat(git): AI-generated commit messages from staged diff

### DIFF
--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -126,6 +126,8 @@ defmodule Minga.Keymap.Defaults do
     {[{?g, @none}, {?c, @none}, {?c, @none}], :git_commit_open, "Commit"},
     {[{?g, @none}, {?c, @none}, {?a, @none}], :git_amend_open, "Amend commit"},
     {[{?g, @none}, {?D, @none}], :git_diff_toggle_staged, "Toggle staged/unstaged diff"},
+    {[{?g, @none}, {?c, @none}, {?g, @none}], :git_generate_commit_message,
+     "Generate AI commit message"},
 
     # ── Project ────────────────────────────────────────────────────────────────
     {[{?p, @none}, {?f, @none}], :project_find_file, "Find file in project"},

--- a/lib/minga/keymap/scope/git_status.ex
+++ b/lib/minga/keymap/scope/git_status.ex
@@ -66,7 +66,8 @@ defmodule Minga.Keymap.Scope.GitStatus do
          {"l", "Pull from remote"},
          {"f", "Fetch from remote"},
          {"cc", "Start commit (enter message)"},
-         {"ca", "Amend last commit"}
+         {"ca", "Amend last commit"},
+         {"cg", "Generate AI commit message"}
        ]},
       {"Discard Confirmation",
        [
@@ -107,6 +108,11 @@ defmodule Minga.Keymap.Scope.GitStatus do
     |> Bindings.bind([{@enter, 0}], :git_status_open_file, "Open file")
     |> Bindings.bind([{?c, 0}, {?c, 0}], :git_status_start_commit, "Start commit")
     |> Bindings.bind([{?c, 0}, {?a, 0}], :git_status_amend, "Amend last commit")
+    |> Bindings.bind(
+      [{?c, 0}, {?g, 0}],
+      :git_generate_commit_message,
+      "Generate AI commit message"
+    )
     # Discard confirmation
     |> Bindings.bind([{?y, 0}], :git_status_confirm_discard, "Confirm discard")
     |> Bindings.bind([{?n, 0}], :git_status_cancel_discard, "Cancel discard")

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -777,6 +777,25 @@ defmodule MingaEditor do
     {:noreply, Renderer.render_or_async(state)}
   end
 
+  # ── AI commit message generation ───────────────────────────────────────────
+
+  def handle_info({:git_commit_message_generated, {:ok, message}}, state) do
+    state = MingaEditor.PromptUI.open(state, MingaEditor.UI.Prompt.GitCommit, default: message)
+    state = EditorState.set_status(state, "Commit message generated")
+    {:noreply, Renderer.render_or_async(state)}
+  end
+
+  def handle_info({:git_commit_message_generated, {:error, reason}}, state) do
+    state = EditorState.set_status(state, reason)
+    {:noreply, Renderer.render_or_async(state)}
+  end
+
+  def handle_info(:git_generate_timeout, state) do
+    # Only matters if the task hasn't responded yet; the status will be
+    # overwritten by the actual result if it arrives later.
+    {:noreply, state}
+  end
+
   # ── File/git events (delegated to FileEventHandler) ─────────────────────────
 
   def handle_info({:git_remote_result, ref, _result} = msg, state) when is_reference(ref) do

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -780,19 +780,34 @@ defmodule MingaEditor do
   # ── AI commit message generation ───────────────────────────────────────────
 
   def handle_info({:git_commit_message_generated, {:ok, message}}, state) do
-    state = MingaEditor.PromptUI.open(state, MingaEditor.UI.Prompt.GitCommit, default: message)
-    state = EditorState.set_status(state, "Commit message generated")
+    state = %{state | git_commit_gen_ref: nil}
+
+    state =
+      if MingaEditor.State.ModalOverlay.active?(EditorState.modal(state)) do
+        EditorState.set_status(state, "Commit message ready (prompt already open)")
+      else
+        state
+        |> MingaEditor.PromptUI.open(MingaEditor.UI.Prompt.GitCommit, default: message)
+        |> EditorState.set_status("Commit message generated")
+      end
+
     {:noreply, Renderer.render_or_async(state)}
   end
 
   def handle_info({:git_commit_message_generated, {:error, reason}}, state) do
+    state = %{state | git_commit_gen_ref: nil}
     state = EditorState.set_status(state, reason)
     {:noreply, Renderer.render_or_async(state)}
   end
 
+  def handle_info(:git_generate_timeout, %{git_commit_gen_ref: ref} = state)
+      when ref != nil do
+    state = %{state | git_commit_gen_ref: nil}
+    state = EditorState.set_status(state, "Commit message generation timed out")
+    {:noreply, Renderer.render_or_async(state)}
+  end
+
   def handle_info(:git_generate_timeout, state) do
-    # Only matters if the task hasn't responded yet; the status will be
-    # overwritten by the actual result if it arrives later.
     {:noreply, state}
   end
 

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -40,7 +40,8 @@ defmodule MingaEditor.Commands.Git do
     {:git_blame_line, "Blame line", true},
     {:git_commit_open, "Open commit panel", false},
     {:git_amend_open, "Open amend panel", false},
-    {:git_diff_toggle_staged, "Toggle diff staged/unstaged", true}
+    {:git_diff_toggle_staged, "Toggle diff staged/unstaged", true},
+    {:git_generate_commit_message, "Generate AI commit message", false}
   ]
 
   @spec execute(state(), atom()) :: state()
@@ -102,6 +103,12 @@ defmodule MingaEditor.Commands.Git do
   def execute(state, :git_diff_toggle_staged) do
     active_buf = state.workspace.buffers.active
     toggle_diff_staged(state, active_buf)
+  end
+
+  # ── AI commit message ──────────────────────────────────────────────────────
+
+  def execute(state, :git_generate_commit_message) do
+    generate_commit_message(state)
   end
 
   # ── Navigation ─────────────────────────────────────────────────────────────
@@ -1193,6 +1200,51 @@ defmodule MingaEditor.Commands.Git do
   defp get_base_lines(git_pid) do
     # Access the base_lines from the git buffer's state
     :sys.get_state(git_pid).base_lines
+  end
+
+  @spec generate_commit_message(state()) :: state()
+  defp generate_commit_message(state) do
+    case resolve_git_root() do
+      nil -> EditorState.set_status(state, "Not in a git repository")
+      git_root -> generate_from_staged_diff(state, git_root)
+    end
+  end
+
+  @spec generate_from_staged_diff(state(), String.t()) :: state()
+  defp generate_from_staged_diff(state, git_root) do
+    case Git.diff(git_root, staged: true) do
+      {:ok, ""} ->
+        EditorState.set_status(state, "Nothing staged to generate a message for")
+
+      {:ok, diff} ->
+        spawn_commit_message_task(state, diff)
+
+      {:error, reason} ->
+        EditorState.set_status(state, "Failed to read staged diff: #{reason}")
+    end
+  end
+
+  @spec spawn_commit_message_task(state(), String.t()) :: state()
+  defp spawn_commit_message_task(state, diff) do
+    case MingaEditor.Git.CommitMessageGenerator.generate(diff, self()) do
+      {:ok, _pid} ->
+        timeout = MingaEditor.Git.CommitMessageGenerator.timeout_ms()
+        Process.send_after(self(), :git_generate_timeout, timeout)
+        EditorState.set_status(state, "Generating commit message…")
+
+      {:error, reason} ->
+        EditorState.set_status(state, reason)
+    end
+  end
+
+  @spec resolve_git_root() :: String.t() | nil
+  defp resolve_git_root do
+    root = Minga.Project.resolve_root()
+
+    case Git.root_for(root) do
+      {:ok, git_root} -> git_root
+      :not_git -> nil
+    end
   end
 
   @impl Minga.Command.Provider

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -1203,6 +1203,11 @@ defmodule MingaEditor.Commands.Git do
   end
 
   @spec generate_commit_message(state()) :: state()
+  defp generate_commit_message(%{git_commit_gen_ref: ref} = state)
+       when ref != nil do
+    EditorState.set_status(state, "Commit message generation already in progress")
+  end
+
   defp generate_commit_message(state) do
     case resolve_git_root() do
       nil -> EditorState.set_status(state, "Not in a git repository")
@@ -1228,12 +1233,16 @@ defmodule MingaEditor.Commands.Git do
   defp spawn_commit_message_task(state, diff) do
     case MingaEditor.Git.CommitMessageGenerator.generate(diff, self()) do
       {:ok, _pid} ->
+        ref = make_ref()
         timeout = MingaEditor.Git.CommitMessageGenerator.timeout_ms()
         Process.send_after(self(), :git_generate_timeout, timeout)
-        EditorState.set_status(state, "Generating commit message…")
+
+        state
+        |> Map.put(:git_commit_gen_ref, ref)
+        |> EditorState.set_status("Generating commit message…")
 
       {:error, reason} ->
-        EditorState.set_status(state, reason)
+        EditorState.set_status(state, "AI generation failed: #{inspect(reason)}")
     end
   end
 

--- a/lib/minga_editor/git/commit_message_generator.ex
+++ b/lib/minga_editor/git/commit_message_generator.ex
@@ -1,0 +1,112 @@
+defmodule MingaEditor.Git.CommitMessageGenerator do
+  @moduledoc """
+  Generates conventional commit messages from staged diffs using the configured AI provider.
+
+  Spawns a one-shot LLM task via Eval.TaskSupervisor that sends the result
+  back to the Editor GenServer as {:git_commit_message_generated, result}.
+  """
+
+  alias ReqLLM.StreamResponse
+
+  @max_diff_chars 4000
+  @timeout_ms 15_000
+
+  @system_prompt """
+  You are a commit message generator. Given a git diff, write a commit message following the conventional commit format:
+
+  type(scope): short description
+
+  Optional body explaining what changed and why.
+
+  Types: feat, fix, refactor, test, docs, chore, perf, style, build, ci
+  Scope: infer from the file paths and module names in the diff.
+  Rules:
+  - First line under 72 characters
+  - Use imperative mood ("add", not "added")
+  - Body lines under 72 characters
+  - No period at the end of the subject line
+  - Only include a body if the change is non-obvious
+  - Output ONLY the commit message, no explanation or markdown formatting
+  """
+
+  @doc """
+  Returns the timeout duration in milliseconds for the LLM generation task.
+  """
+  @spec timeout_ms() :: pos_integer()
+  def timeout_ms, do: @timeout_ms
+
+  @doc """
+  Spawns an async task that generates a commit message from the staged diff.
+
+  On completion, sends `{:git_commit_message_generated, result}` to `reply_to`
+  where result is `{:ok, message}` or `{:error, reason}`.
+
+  Returns `{:ok, pid}` on success or `{:error, reason}` if no AI model is configured.
+  """
+  @spec generate(String.t(), GenServer.server()) :: {:ok, pid()} | {:error, String.t()}
+  def generate(staged_diff, reply_to) do
+    model = MingaAgent.ProviderResolver.configured_model() || MingaAgent.Config.default_model()
+
+    spawn_task(model, staged_diff, reply_to)
+  end
+
+  @spec spawn_task(String.t(), String.t(), GenServer.server()) :: {:ok, pid()}
+  defp spawn_task(model, staged_diff, reply_to) do
+    Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
+      result = run_generation(model, staged_diff)
+      send(reply_to, {:git_commit_message_generated, result})
+    end)
+  end
+
+  @spec run_generation(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp run_generation(model, staged_diff) do
+    diff_text = truncate_diff(staged_diff)
+    config = MingaAgent.Config.resolve()
+
+    messages = [
+      %{role: "system", content: @system_prompt},
+      %{role: "user", content: diff_text}
+    ]
+
+    stream_opts = [max_tokens: 300]
+    stream_opts = maybe_add_base_url(stream_opts, model, config)
+
+    call_llm(model, messages, stream_opts)
+  rescue
+    e -> {:error, "AI generation error: #{Exception.message(e)}"}
+  end
+
+  @spec call_llm(String.t(), [map()], keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  defp call_llm(model, messages, stream_opts) do
+    with {:ok, stream_response} <- ReqLLM.stream_text(model, messages, stream_opts),
+         {:ok, response} <- StreamResponse.process_stream(stream_response) do
+      {:ok, String.trim(ReqLLM.Response.text(response) || "")}
+    else
+      {:error, reason} -> {:error, "AI generation failed: #{inspect(reason)}"}
+    end
+  end
+
+  @spec truncate_diff(String.t()) :: String.t()
+  defp truncate_diff(diff) when byte_size(diff) <= @max_diff_chars, do: diff
+
+  defp truncate_diff(diff) do
+    truncated = String.slice(diff, 0, @max_diff_chars)
+    truncated <> "\n\n[diff truncated at #{@max_diff_chars} characters]"
+  end
+
+  @spec maybe_add_base_url(keyword(), String.t(), MingaAgent.Config.t()) :: keyword()
+  defp maybe_add_base_url(opts, _model, config) do
+    url = non_empty(config.api_base_url_override) || non_empty(config.api_base_url)
+
+    if url do
+      Keyword.put(opts, :base_url, url)
+    else
+      opts
+    end
+  end
+
+  @spec non_empty(String.t() | nil) :: String.t() | nil
+  defp non_empty(nil), do: nil
+  defp non_empty(""), do: nil
+  defp non_empty(s) when is_binary(s), do: s
+end

--- a/lib/minga_editor/git/commit_message_generator.ex
+++ b/lib/minga_editor/git/commit_message_generator.ex
@@ -29,9 +29,6 @@ defmodule MingaEditor.Git.CommitMessageGenerator do
   - Output ONLY the commit message, no explanation or markdown formatting
   """
 
-  @doc """
-  Returns the timeout duration in milliseconds for the LLM generation task.
-  """
   @spec timeout_ms() :: pos_integer()
   def timeout_ms, do: @timeout_ms
 
@@ -40,17 +37,15 @@ defmodule MingaEditor.Git.CommitMessageGenerator do
 
   On completion, sends `{:git_commit_message_generated, result}` to `reply_to`
   where result is `{:ok, message}` or `{:error, reason}`.
-
-  Returns `{:ok, pid}` on success or `{:error, reason}` if no AI model is configured.
   """
-  @spec generate(String.t(), GenServer.server()) :: {:ok, pid()} | {:error, String.t()}
+  @spec generate(String.t(), GenServer.server()) :: {:ok, pid()} | {:error, term()}
   def generate(staged_diff, reply_to) do
     model = MingaAgent.ProviderResolver.configured_model() || MingaAgent.Config.default_model()
 
     spawn_task(model, staged_diff, reply_to)
   end
 
-  @spec spawn_task(String.t(), String.t(), GenServer.server()) :: {:ok, pid()}
+  @spec spawn_task(String.t(), String.t(), GenServer.server()) :: {:ok, pid()} | {:error, term()}
   defp spawn_task(model, staged_diff, reply_to) do
     Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
       result = run_generation(model, staged_diff)
@@ -73,15 +68,19 @@ defmodule MingaEditor.Git.CommitMessageGenerator do
 
     call_llm(model, messages, stream_opts)
   rescue
-    e -> {:error, "AI generation error: #{Exception.message(e)}"}
+    e ->
+      Minga.Log.warning(:agent, "AI commit message generation failed: #{Exception.message(e)}")
+      {:error, "AI generation error: #{Exception.message(e)}"}
   end
 
   @spec call_llm(String.t(), [map()], keyword()) :: {:ok, String.t()} | {:error, String.t()}
   defp call_llm(model, messages, stream_opts) do
     with {:ok, stream_response} <- ReqLLM.stream_text(model, messages, stream_opts),
-         {:ok, response} <- StreamResponse.process_stream(stream_response) do
-      {:ok, String.trim(ReqLLM.Response.text(response) || "")}
+         {:ok, response} <- StreamResponse.process_stream(stream_response),
+         text when text != "" <- String.trim(ReqLLM.Response.text(response) || "") do
+      {:ok, text}
     else
+      "" -> {:error, "AI returned an empty commit message"}
       {:error, reason} -> {:error, "AI generation failed: #{inspect(reason)}"}
     end
   end
@@ -90,8 +89,8 @@ defmodule MingaEditor.Git.CommitMessageGenerator do
   defp truncate_diff(diff) when byte_size(diff) <= @max_diff_chars, do: diff
 
   defp truncate_diff(diff) do
-    truncated = String.slice(diff, 0, @max_diff_chars)
-    truncated <> "\n\n[diff truncated at #{@max_diff_chars} characters]"
+    truncated = binary_slice(diff, 0, @max_diff_chars)
+    truncated <> "\n\n[diff truncated at #{@max_diff_chars} bytes]"
   end
 
   @spec maybe_add_base_url(keyword(), String.t(), MingaAgent.Config.t()) :: keyword()

--- a/lib/minga_editor/input/git_status.ex
+++ b/lib/minga_editor/input/git_status.ex
@@ -240,6 +240,10 @@ defmodule MingaEditor.Input.GitStatus do
     close_panel(state)
   end
 
+  defp execute_command(state, :git_generate_commit_message) do
+    Commands.Git.execute(state, :git_generate_commit_message)
+  end
+
   defp execute_command(state, _cmd), do: state
 
   # ── TUI state helpers ──────────────────────────────────────────────────

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -118,7 +118,8 @@ defmodule MingaEditor.State do
             buffer_add_context: :open,
             remote: %Remote{},
             stashed_board_state: nil,
-            keystroke_history: KeystrokeHistory.new()
+            keystroke_history: KeystrokeHistory.new(),
+            git_commit_gen_ref: nil
 
   @type backend :: :tui | :gui | :native_gui | :headless
 
@@ -157,7 +158,8 @@ defmodule MingaEditor.State do
           remote: Remote.t(),
           session: SessionState.t(),
           stashed_board_state: MingaEditor.Shell.Board.State.t() | nil,
-          keystroke_history: KeystrokeHistory.t()
+          keystroke_history: KeystrokeHistory.t(),
+          git_commit_gen_ref: reference() | nil
         }
 
   @spec set_renderer(t(), pid() | nil) :: t()


### PR DESCRIPTION
## Summary

- Add `git_generate_commit_message` command that reads `git diff --cached`, spawns a one-shot LLM task, and generates a conventional commit message
- Uses `ReqLLM.stream_text/3` with the configured AI provider (no full Agent.Session needed)
- Generated message pre-fills a commit prompt for the user to review and edit before committing
- Keybindings: `SPC g c g` (leader) and `cg` (git status panel)
- Empty staging guard: "Nothing staged to generate a message for"
- Large diff handling: truncates at 4000 characters with a note
- Async with status feedback: "Generating commit message..." while waiting, 15s timeout safety
- Error handling: network failures, rate limits, missing config all show clear status messages

Closes #987

## Test plan

- [x] `mix compile`: 0 errors, 0 warnings
- [x] `mix test.llm`: 8317 tests, 0 failures
- [x] `mix format`: clean
- [ ] Manual: stage some changes, press `SPC g c g`, verify "Generating..." status appears
- [ ] Manual: wait for LLM response, verify commit prompt opens with generated message
- [ ] Manual: edit the message and press Enter to commit
- [ ] Manual: with nothing staged, press `SPC g c g`, verify error message
- [ ] Manual: in git status panel, press `cg`, verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)