### PR TITLE
fix(macos): prevent GUI selection range crash

### DIFF
--- a/lib/minga_editor/semantic_window/builder.ex
+++ b/lib/minga_editor/semantic_window/builder.ex
@@ -112,7 +112,14 @@ defmodule MingaEditor.SemanticWindow.Builder do
       end
 
     # Selection in display coordinates
-    selection = Selection.from_visual_selection(ctx.visual_selection, viewport.top)
+    selection =
+      Selection.from_visual_selection(
+        ctx.visual_selection,
+        viewport.top,
+        visible_rows,
+        viewport.left,
+        viewport.cols
+      )
 
     # Search matches in display coordinates
     viewport_bottom = viewport.top + visible_rows

--- a/lib/minga_editor/semantic_window/selection.ex
+++ b/lib/minga_editor/semantic_window/selection.ex
@@ -123,9 +123,9 @@ defmodule MingaEditor.SemanticWindow.Selection do
           non_neg_integer(),
           pos_integer()
         ) :: non_neg_integer()
-  defp char_end_col(visible_end_line, selection_end_line, end_col, _viewport_left, _visible_cols)
+  defp char_end_col(visible_end_line, selection_end_line, end_col, viewport_left, visible_cols)
        when visible_end_line == selection_end_line do
-    clamp_u16(end_col)
+    clamp_u16(min(end_col, viewport_left + visible_cols))
   end
 
   defp char_end_col(_visible_end_line, _selection_end_line, _end_col, viewport_left, visible_cols) do

--- a/lib/minga_editor/semantic_window/selection.ex
+++ b/lib/minga_editor/semantic_window/selection.ex
@@ -24,33 +24,114 @@ defmodule MingaEditor.SemanticWindow.Selection do
           end_col: non_neg_integer()
         }
 
-  @doc "Builds a selection from the render context's visual_selection."
-  @spec from_visual_selection(
+  @max_u16 65_535
+
+  @type visual_selection ::
           nil
           | {:char, {non_neg_integer(), non_neg_integer()},
              {non_neg_integer(), non_neg_integer()}}
-          | {:line, non_neg_integer(), non_neg_integer()},
-          non_neg_integer()
+          | {:line, non_neg_integer(), non_neg_integer()}
+
+  @doc "Builds a selection from the render context's visual_selection."
+  @spec from_visual_selection(visual_selection(), non_neg_integer()) :: t() | nil
+  def from_visual_selection(selection, viewport_top) do
+    from_visual_selection(selection, viewport_top, @max_u16, 0, @max_u16)
+  end
+
+  @doc "Builds a selection clipped to the visible viewport."
+  @spec from_visual_selection(
+          visual_selection(),
+          non_neg_integer(),
+          pos_integer(),
+          non_neg_integer(),
+          pos_integer()
         ) :: t() | nil
-  def from_visual_selection(nil, _viewport_top), do: nil
+  def from_visual_selection(nil, _viewport_top, _visible_rows, _viewport_left, _visible_cols),
+    do: nil
 
-  def from_visual_selection({:char, {sl, sc}, {el, ec}}, viewport_top) do
-    %__MODULE__{
-      type: :char,
-      start_row: sl - viewport_top,
-      start_col: sc,
-      end_row: el - viewport_top,
-      end_col: ec
-    }
+  def from_visual_selection(
+        {:char, {sl, sc}, {el, ec}},
+        viewport_top,
+        visible_rows,
+        viewport_left,
+        visible_cols
+      ) do
+    case visible_line_range(sl, el, viewport_top, visible_rows) do
+      nil ->
+        nil
+
+      {start_line, end_line} ->
+        %__MODULE__{
+          type: :char,
+          start_row: start_line - viewport_top,
+          start_col: char_start_col(start_line, sl, sc, viewport_left),
+          end_row: end_line - viewport_top,
+          end_col: char_end_col(end_line, el, ec, viewport_left, visible_cols)
+        }
+    end
   end
 
-  def from_visual_selection({:line, start_line, end_line}, viewport_top) do
-    %__MODULE__{
-      type: :line,
-      start_row: start_line - viewport_top,
-      start_col: 0,
-      end_row: end_line - viewport_top,
-      end_col: 0
-    }
+  def from_visual_selection(
+        {:line, start_line, end_line},
+        viewport_top,
+        visible_rows,
+        _viewport_left,
+        _visible_cols
+      ) do
+    case visible_line_range(start_line, end_line, viewport_top, visible_rows) do
+      nil ->
+        nil
+
+      {visible_start_line, visible_end_line} ->
+        %__MODULE__{
+          type: :line,
+          start_row: visible_start_line - viewport_top,
+          start_col: 0,
+          end_row: visible_end_line - viewport_top,
+          end_col: 0
+        }
+    end
   end
+
+  @spec visible_line_range(non_neg_integer(), non_neg_integer(), non_neg_integer(), pos_integer()) ::
+          {non_neg_integer(), non_neg_integer()} | nil
+  defp visible_line_range(start_line, end_line, viewport_top, visible_rows) do
+    viewport_bottom = viewport_top + visible_rows - 1
+
+    case {end_line < viewport_top, start_line > viewport_bottom} do
+      {true, _} -> nil
+      {_, true} -> nil
+      _ -> {max(start_line, viewport_top), min(end_line, viewport_bottom)}
+    end
+  end
+
+  @spec char_start_col(non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  defp char_start_col(visible_start_line, selection_start_line, start_col, viewport_left)
+       when visible_start_line == selection_start_line do
+    clamp_u16(max(start_col, viewport_left))
+  end
+
+  defp char_start_col(_visible_start_line, _selection_start_line, _start_col, viewport_left) do
+    clamp_u16(viewport_left)
+  end
+
+  @spec char_end_col(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pos_integer()
+        ) :: non_neg_integer()
+  defp char_end_col(visible_end_line, selection_end_line, end_col, _viewport_left, _visible_cols)
+       when visible_end_line == selection_end_line do
+    clamp_u16(end_col)
+  end
+
+  defp char_end_col(_visible_end_line, _selection_end_line, _end_col, viewport_left, visible_cols) do
+    clamp_u16(viewport_left + visible_cols)
+  end
+
+  @spec clamp_u16(non_neg_integer()) :: non_neg_integer()
+  defp clamp_u16(value), do: min(value, @max_u16)
 end

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -1182,11 +1182,17 @@ final class CoreTextMetalRenderer {
         viewportWidth: Float,
         quads: inout [QuadGPU]
     ) {
-        guard visibleRows > 0, visibleCols > 0, cellW > 0, cellH > 0, scale > 0 else { return }
+        guard visibleRows > 0, visibleCols > 0, cellW > 0, cellH > 0, scale > 0 else {
+            assertionFailure("appendSelectionQuads called with invalid dimensions: rows=\(visibleRows) cols=\(visibleCols) cellW=\(cellW) cellH=\(cellH) scale=\(scale)")
+            return
+        }
 
         let requestedStartRow = Int(sel.startRow)
         let requestedEndRow = Int(sel.endRow)
-        guard requestedStartRow <= requestedEndRow else { return }
+        guard requestedStartRow <= requestedEndRow else {
+            assertionFailure("Selection startRow (\(requestedStartRow)) > endRow (\(requestedEndRow))")
+            return
+        }
 
         let startRow = max(requestedStartRow, 0)
         let endRow = min(requestedEndRow, visibleRows - 1)
@@ -1214,10 +1220,10 @@ final class CoreTextMetalRenderer {
             for row in startRow...endRow {
                 let y = rowOffset + Float(row) * lineHeightPx
                 let requestedCols = requestedSelectionCols(row: row, sel: sel, scrollLeft: scrollLeft, visibleCols: visibleCols)
-                guard let visibleCols = clampSelectionCols(requestedCols, scrollLeft: scrollLeft, visibleCols: visibleCols) else { continue }
+                guard let clampedCols = clampSelectionCols(requestedCols, scrollLeft: scrollLeft, visibleCols: visibleCols) else { continue }
 
-                let visibleStartCol = Float(visibleCols.start - scrollLeft)
-                let visibleEndCol = Float(visibleCols.end - scrollLeft)
+                let visibleStartCol = Float(clampedCols.start - scrollLeft)
+                let visibleEndCol = Float(clampedCols.end - scrollLeft)
 
                 var quad = QuadGPU()
                 quad.position = SIMD2<Float>(colOffset + visibleStartCol * colWidthPx, y)
@@ -1231,10 +1237,10 @@ final class CoreTextMetalRenderer {
             for row in startRow...endRow {
                 let y = rowOffset + Float(row) * lineHeightPx
                 let requestedCols = (start: Int(sel.startCol), end: Int(sel.endCol))
-                guard let visibleCols = clampSelectionCols(requestedCols, scrollLeft: scrollLeft, visibleCols: visibleCols) else { continue }
+                guard let clampedCols = clampSelectionCols(requestedCols, scrollLeft: scrollLeft, visibleCols: visibleCols) else { continue }
 
-                let visibleStartCol = Float(visibleCols.start - scrollLeft)
-                let visibleEndCol = Float(visibleCols.end - scrollLeft)
+                let visibleStartCol = Float(clampedCols.start - scrollLeft)
+                let visibleEndCol = Float(clampedCols.end - scrollLeft)
 
                 var quad = QuadGPU()
                 quad.position = SIMD2<Float>(colOffset + visibleStartCol * colWidthPx, y)

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -366,14 +366,19 @@ final class CoreTextMetalRenderer {
 
                 // Horizontal scroll: shift line textures and overlays left by scrollLeft columns.
                 // The gutter stays fixed; only content past the gutter edge scrolls.
-                let hScrollPx = Float(content.scrollLeft) * cellW * scale
+                let scrollLeftInt = Int(content.scrollLeft)
+                let hScrollPx = Float(scrollLeftInt) * cellW * scale
+                let contentCols = max(Int(frameState.cols) - Int(gutter.lineNumberWidth) - Int(gutter.signColWidth), 1)
 
                 // Selection overlay quads (drawn before text).
                 if let sel = content.selection {
                     appendSelectionQuads(
                         selection: sel,
                         rowOffset: windowRowOffset,
-                        colOffset: contentColOffset - hScrollPx,
+                        colOffset: contentColOffset,
+                        scrollLeft: scrollLeftInt,
+                        visibleRows: content.rows.count,
+                        visibleCols: contentCols,
                         cellW: cellW, cellH: displayCellH, scale: scale,
                         viewportWidth: Float(viewportSize.width),
                         quads: &semanticOverlayQuads
@@ -422,8 +427,6 @@ final class CoreTextMetalRenderer {
                 // so each texture is at most viewport-wide. Fixes gutter bleedthrough
                 // (no leftward position shift) and text truncation (texture always
                 // covers the visible portion).
-                let contentCols = max(Int(frameState.cols) - Int(gutter.lineNumberWidth) - Int(gutter.signColWidth), 1)
-                let scrollLeftInt = Int(content.scrollLeft)
                 var clippedRows: [GUIVisualRow] = []
                 clippedRows.reserveCapacity(content.rows.count)
                 for row in content.rows {
@@ -1172,65 +1175,106 @@ final class CoreTextMetalRenderer {
     private func appendSelectionQuads(
         selection sel: GUISelectionOverlay,
         rowOffset: Float, colOffset: Float,
+        scrollLeft: Int,
+        visibleRows: Int,
+        visibleCols: Int,
         cellW: Float, cellH: Float, scale: Float,
         viewportWidth: Float,
         quads: inout [QuadGPU]
     ) {
+        guard visibleRows > 0, visibleCols > 0, cellW > 0, cellH > 0, scale > 0 else { return }
+
+        let requestedStartRow = Int(sel.startRow)
+        let requestedEndRow = Int(sel.endRow)
+        guard requestedStartRow <= requestedEndRow else { return }
+
+        let startRow = max(requestedStartRow, 0)
+        let endRow = min(requestedEndRow, visibleRows - 1)
+        guard startRow <= endRow else { return }
+
         let selColor = currentThemeColors?.selectionBgSIMD ?? Self.systemSelectionColor
+        let lineHeightPx = cellH * scale
+        let colWidthPx = cellW * scale
+        let rightEdgePx = min(colOffset + Float(visibleCols) * colWidthPx, viewportWidth)
+        let fullLineWidthPx = max(rightEdgePx - colOffset, 0)
+        guard fullLineWidthPx > 0 else { return }
 
         switch sel.type {
         case .line:
-            for row in sel.startRow...sel.endRow {
+            for row in startRow...endRow {
                 var quad = QuadGPU()
-                quad.position = SIMD2<Float>(colOffset, rowOffset + Float(row) * cellH * scale)
-                quad.size = SIMD2<Float>(viewportWidth - colOffset, cellH * scale)
+                quad.position = SIMD2<Float>(colOffset, rowOffset + Float(row) * lineHeightPx)
+                quad.size = SIMD2<Float>(fullLineWidthPx, lineHeightPx)
                 quad.color = selColor
                 quad.alpha = 1.0
                 quads.append(quad)
             }
 
         case .char:
-            for row in sel.startRow...sel.endRow {
-                let y = rowOffset + Float(row) * cellH * scale
-                let startCol: Float
-                let endCol: Float
+            for row in startRow...endRow {
+                let y = rowOffset + Float(row) * lineHeightPx
+                let requestedCols = requestedSelectionCols(row: row, sel: sel, scrollLeft: scrollLeft, visibleCols: visibleCols)
+                guard let visibleCols = clampSelectionCols(requestedCols, scrollLeft: scrollLeft, visibleCols: visibleCols) else { continue }
 
-                if row == sel.startRow && row == sel.endRow {
-                    startCol = Float(sel.startCol)
-                    endCol = Float(sel.endCol)
-                } else if row == sel.startRow {
-                    startCol = Float(sel.startCol)
-                    endCol = (viewportWidth - colOffset) / (cellW * scale)
-                } else if row == sel.endRow {
-                    startCol = 0
-                    endCol = Float(sel.endCol)
-                } else {
-                    startCol = 0
-                    endCol = (viewportWidth - colOffset) / (cellW * scale)
-                }
+                let visibleStartCol = Float(visibleCols.start - scrollLeft)
+                let visibleEndCol = Float(visibleCols.end - scrollLeft)
 
                 var quad = QuadGPU()
-                quad.position = SIMD2<Float>(colOffset + startCol * cellW * scale, y)
-                quad.size = SIMD2<Float>((endCol - startCol) * cellW * scale, cellH * scale)
+                quad.position = SIMD2<Float>(colOffset + visibleStartCol * colWidthPx, y)
+                quad.size = SIMD2<Float>((visibleEndCol - visibleStartCol) * colWidthPx, lineHeightPx)
                 quad.color = selColor
                 quad.alpha = 1.0
                 quads.append(quad)
             }
 
         case .block:
-            for row in sel.startRow...sel.endRow {
-                let y = rowOffset + Float(row) * cellH * scale
-                let x = colOffset + Float(sel.startCol) * cellW * scale
-                let w = Float(sel.endCol - sel.startCol) * cellW * scale
+            for row in startRow...endRow {
+                let y = rowOffset + Float(row) * lineHeightPx
+                let requestedCols = (start: Int(sel.startCol), end: Int(sel.endCol))
+                guard let visibleCols = clampSelectionCols(requestedCols, scrollLeft: scrollLeft, visibleCols: visibleCols) else { continue }
+
+                let visibleStartCol = Float(visibleCols.start - scrollLeft)
+                let visibleEndCol = Float(visibleCols.end - scrollLeft)
 
                 var quad = QuadGPU()
-                quad.position = SIMD2<Float>(x, y)
-                quad.size = SIMD2<Float>(w, cellH * scale)
+                quad.position = SIMD2<Float>(colOffset + visibleStartCol * colWidthPx, y)
+                quad.size = SIMD2<Float>((visibleEndCol - visibleStartCol) * colWidthPx, lineHeightPx)
                 quad.color = selColor
                 quad.alpha = 1.0
                 quads.append(quad)
             }
         }
+    }
+
+    private func requestedSelectionCols(row: Int, sel: GUISelectionOverlay, scrollLeft: Int, visibleCols: Int) -> (start: Int, end: Int) {
+        let fullStart = scrollLeft
+        let fullEnd = scrollLeft + visibleCols
+        let startRow = Int(sel.startRow)
+        let endRow = Int(sel.endRow)
+
+        if row == startRow && row == endRow {
+            return (Int(sel.startCol), Int(sel.endCol))
+        }
+
+        if row == startRow {
+            return (Int(sel.startCol), fullEnd)
+        }
+
+        if row == endRow {
+            return (fullStart, Int(sel.endCol))
+        }
+
+        return (fullStart, fullEnd)
+    }
+
+    private func clampSelectionCols(_ cols: (start: Int, end: Int), scrollLeft: Int, visibleCols: Int) -> (start: Int, end: Int)? {
+        let visibleStart = scrollLeft
+        let visibleEnd = scrollLeft + visibleCols
+        let start = max(cols.start, visibleStart)
+        let end = min(cols.end, visibleEnd)
+
+        guard start < end else { return nil }
+        return (start, end)
     }
 
     /// Calculate the display width (in cell columns) of a string,

--- a/test/minga_editor/semantic_window_test.exs
+++ b/test/minga_editor/semantic_window_test.exs
@@ -346,7 +346,7 @@ defmodule MingaEditor.SemanticWindowTest do
     end
   end
 
-  # ── Selection.from_visual_selection/2 ──────────────────────────────────
+  # ── Selection.from_visual_selection ────────────────────────────────────
 
   describe "Selection.from_visual_selection/2" do
     test "returns nil for no selection" do
@@ -376,6 +376,40 @@ defmodule MingaEditor.SemanticWindowTest do
       assert sel.type == :line
       assert sel.start_row == 5
       assert sel.end_row == 10
+    end
+  end
+
+  describe "Selection.from_visual_selection/5" do
+    test "clips char selection that starts above the viewport" do
+      sel = Selection.from_visual_selection({:char, {2, 4}, {7, 10}}, 5, 4, 0, 80)
+
+      assert sel.type == :char
+      assert sel.start_row == 0
+      assert sel.start_col == 0
+      assert sel.end_row == 2
+      assert sel.end_col == 10
+    end
+
+    test "clips char selection that ends below the viewport" do
+      sel = Selection.from_visual_selection({:char, {5, 4}, {12, 10}}, 5, 4, 2, 80)
+
+      assert sel.type == :char
+      assert sel.start_row == 0
+      assert sel.start_col == 4
+      assert sel.end_row == 3
+      assert sel.end_col == 82
+    end
+
+    test "drops char selection entirely above the viewport" do
+      assert Selection.from_visual_selection({:char, {1, 0}, {3, 4}}, 5, 4, 0, 80) == nil
+    end
+
+    test "clips line selection to visible rows" do
+      sel = Selection.from_visual_selection({:line, 1, 10}, 5, 4, 0, 80)
+
+      assert sel.type == :line
+      assert sel.start_row == 0
+      assert sel.end_row == 3
     end
   end
 

--- a/test/minga_editor/semantic_window_test.exs
+++ b/test/minga_editor/semantic_window_test.exs
@@ -404,12 +404,44 @@ defmodule MingaEditor.SemanticWindowTest do
       assert Selection.from_visual_selection({:char, {1, 0}, {3, 4}}, 5, 4, 0, 80) == nil
     end
 
+    test "drops char selection entirely below the viewport" do
+      assert Selection.from_visual_selection({:char, {20, 0}, {25, 4}}, 5, 4, 0, 80) == nil
+    end
+
+    test "selection at exact viewport bottom boundary is included" do
+      sel = Selection.from_visual_selection({:char, {8, 0}, {8, 5}}, 5, 4, 0, 80)
+
+      assert sel.type == :char
+      assert sel.start_row == 3
+      assert sel.end_row == 3
+    end
+
+    test "selection one row past viewport bottom is dropped" do
+      assert Selection.from_visual_selection({:char, {9, 0}, {9, 5}}, 5, 4, 0, 80) == nil
+    end
+
+    test "clips start_col to viewport_left when selection starts left of viewport" do
+      sel = Selection.from_visual_selection({:char, {5, 2}, {5, 20}}, 5, 4, 10, 80)
+
+      assert sel.start_col == 10
+      assert sel.end_col == 20
+    end
+
+    test "clips end_col to viewport right edge on same-line selection" do
+      sel = Selection.from_visual_selection({:char, {5, 4}, {5, 200}}, 5, 4, 0, 80)
+
+      assert sel.start_col == 4
+      assert sel.end_col == 80
+    end
+
     test "clips line selection to visible rows" do
       sel = Selection.from_visual_selection({:line, 1, 10}, 5, 4, 0, 80)
 
       assert sel.type == :line
       assert sel.start_row == 0
+      assert sel.start_col == 0
       assert sel.end_row == 3
+      assert sel.end_col == 0
     end
   end
 


### PR DESCRIPTION
# TL;DR
Fixes a macOS renderer crash when visual selection coordinates fall outside the visible viewport. The BEAM now clips semantic selection data before encoding it, and Swift validates protocol selection ranges before building Metal quads.

## Context
A local macOS crash report showed Swift failing with `Range requires lowerBound <= upperBound` inside `CoreTextMetalRenderer.appendSelectionQuads`. The crash happened because an off-viewport selection row could become negative in Elixir, then wrap through the unsigned GUI protocol as a large `UInt16` value.

## Changes
- Clip GUI semantic selections to the visible viewport in `MingaEditor.SemanticWindow.Selection`.
- Drop selections that are fully outside the viewport instead of encoding invalid rows.
- Pass viewport row and horizontal scroll bounds into semantic selection construction.
- Add Swift-side guards for invalid row ranges, empty dimensions, offscreen ranges, and zero-width column spans before appending selection quads.
- Add regression tests for clipped char and line selections.

## Verification
- `git diff --check HEAD~1..HEAD`
- `mix test.debug test/minga_editor/semantic_window_test.exs`
- `mix swift.build`
- Also validated before splitting this into its own branch: `make lint`, `mix test.llm`, focused semantic window tests, and `mix swift.build`.

## Acceptance Criteria Addressed
- Elixir never encodes negative viewport-relative GUI selection rows. ✅
- Fully offscreen GUI selections are dropped before protocol encoding. ✅
- Swift treats selection overlay coordinates as untrusted protocol data and skips invalid quads instead of crashing. ✅
- Regression coverage exists for viewport-clipped selections. ✅
