### PR TITLE
fix(project): prevent test pollution of known-projects file

### DIFF
--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -57,6 +57,7 @@ defmodule Minga.Config.Options do
           | :title_format
           | :recent_files_limit
           | :persist_recent_files
+          | :persist_known_projects
           | :clipboard
           | :wrap
           | :linebreak
@@ -220,6 +221,8 @@ defmodule Minga.Config.Options do
     {:recent_files_limit, :pos_integer, 200, "Maximum number of recent files to keep."},
     {:persist_recent_files, :boolean, true,
      "Whether recent files are written to disk between sessions."},
+    {:persist_known_projects, :boolean, true,
+     "Whether known projects are written to disk between sessions."},
     {:clipboard, {:enum, [:unnamedplus, :unnamed, :none]}, :unnamedplus,
      "Clipboard register integration mode."},
     {:wrap, :boolean, false, "Whether long visual lines wrap in editor windows."},

--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -167,7 +167,7 @@ defmodule Minga.Project do
       Minga.Events.subscribe(:buffer_opened, events_registry)
     end
 
-    known = load_known_projects()
+    known = if persist_known_projects?(), do: load_known_projects(), else: []
     recent = if persist_recent_files?(), do: load_recent_files(), else: %{}
 
     {:ok,
@@ -248,7 +248,7 @@ defmodule Minga.Project do
   def handle_cast({:remove, root_path}, state) do
     expanded = Path.expand(root_path)
     new_known = Enum.reject(state.known_projects, &(&1 == expanded))
-    persist_known_projects(new_known)
+    if persist_known_projects?(), do: persist_known_projects(new_known)
     {:noreply, %{state | known_projects: new_known}}
   end
 
@@ -345,7 +345,7 @@ defmodule Minga.Project do
       state
     else
       new_known = [root | state.known_projects]
-      persist_known_projects(new_known)
+      if persist_known_projects?(), do: persist_known_projects(new_known)
       %{state | known_projects: new_known}
     end
   end
@@ -404,6 +404,11 @@ defmodule Minga.Project do
   @spec recent_files_limit() :: pos_integer()
   defp recent_files_limit do
     Config.get(:recent_files_limit)
+  end
+
+  @spec persist_known_projects?() :: boolean()
+  defp persist_known_projects? do
+    Config.get(:persist_known_projects)
   end
 
   @spec persist_recent_files?() :: boolean()

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -47,6 +47,7 @@ defmodule Minga.Config.OptionsTest do
                title_format: "{filename} {dirty}({directory}) - Minga",
                recent_files_limit: 200,
                persist_recent_files: true,
+               persist_known_projects: true,
                clipboard: :unnamedplus,
                wrap: false,
                linebreak: true,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -41,5 +41,10 @@ Minga.Config.Options.set(:clipboard, :none)
 # unrelated file-buffer tests. Auto-save tests opt in per buffer.
 Minga.Config.Options.set(:auto_save_delay_ms, 0)
 
+# Disable persisting known projects and recent files during tests to avoid
+# polluting ~/.config/minga/known-projects with test fixture directories.
+Minga.Config.Options.set(:persist_known_projects, false)
+Minga.Config.Options.set(:persist_recent_files, false)
+
 # Tests that create editors directly should pass `editing_model:` to
 # `MingaEditor.start_link/1` instead of mutating global config.


### PR DESCRIPTION
## Summary

- Add `persist_known_projects` config option (boolean, default true) mirroring the existing `persist_recent_files` pattern
- Guard `add_to_known/2`, `handle_cast(:remove)`, and `init/1` loading with the new config check
- Disable both `persist_known_projects` and `persist_recent_files` in `test_helper.exs` so test runs never write to `~/.config/minga/known-projects`

The `SPC p p` project picker was showing 257 entries, almost all test fixture directories (e.g. `ProjectTest/test-switch-2-...`). Tests that called `Project.detect_and_set`, `switch`, or `add` persisted temp directories to the global known-projects file, and since those tmp dirs often survive on disk, the existing `File.dir?/1` filter on load didn't prune them.

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test.llm test/minga/project_test.exs` passes (21 tests)
- [x] `mix test.llm test/minga/config/options_test.exs` passes (85 tests)
- [x] Verified `~/.config/minga/known-projects` is not modified during test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)