### PR TITLE
feat(editor): add :cq command and --minimal flag for GIT_EDITOR use

### DIFF
--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -85,14 +85,18 @@ defmodule Minga.Application do
     # via the same path as logs from a running editor.
     Minga.LoggerHandler.install_messages_handler()
 
-    base_children = [
-      Minga.Foundation.Supervisor,
-      {Registry, keys: :unique, name: Minga.Buffer.Registry},
-      {DynamicSupervisor, name: Minga.Buffer.Supervisor, strategy: :one_for_one},
-      Minga.Buffer.Messages,
-      Minga.Services.Supervisor,
-      MingaAgent.Supervisor
-    ]
+    base_children =
+      [
+        Minga.Foundation.Supervisor,
+        {Registry, keys: :unique, name: Minga.Buffer.Registry},
+        {DynamicSupervisor, name: Minga.Buffer.Supervisor, strategy: :one_for_one},
+        Minga.Buffer.Messages
+      ] ++
+        if Application.get_env(:minga, :minimal_mode, false) do
+          []
+        else
+          [Minga.Services.Supervisor, MingaAgent.Supervisor]
+        end
 
     editor_children =
       if start_editor?() do

--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -85,6 +85,8 @@ defmodule Minga.Application do
     # via the same path as logs from a running editor.
     Minga.LoggerHandler.install_messages_handler()
 
+    minimal? = minimal_mode?()
+
     base_children =
       [
         Minga.Foundation.Supervisor,
@@ -92,7 +94,7 @@ defmodule Minga.Application do
         {DynamicSupervisor, name: Minga.Buffer.Supervisor, strategy: :one_for_one},
         Minga.Buffer.Messages
       ] ++
-        if Application.get_env(:minga, :minimal_mode, false) do
+        if minimal? do
           []
         else
           [Minga.Services.Supervisor, MingaAgent.Supervisor]
@@ -121,17 +123,20 @@ defmodule Minga.Application do
     opts = [strategy: :rest_for_one, name: Minga.Supervisor]
     result = Supervisor.start_link(children, opts)
 
-    # Prune old agent sessions using the supervised Task.Supervisor
-    # (not fire-and-forget Task.start) so crashes are visible.
-    if match?({:ok, _}, result) do
-      Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, &prune_old_sessions/0)
+    unless minimal? do
+      if match?({:ok, _}, result) do
+        Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, &prune_old_sessions/0)
+      end
     end
 
-    # In Burrito standalone mode, kick off the CLI
     if Burrito.Util.running_standalone?() do
-      Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
-        Minga.CLI.start_from_cli()
-      end)
+      if minimal? do
+        Task.start_link(fn -> Minga.CLI.start_from_cli() end)
+      else
+        Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
+          Minga.CLI.start_from_cli()
+        end)
+      end
     end
 
     result
@@ -164,6 +169,11 @@ defmodule Minga.Application do
       (Burrito.Util.running_standalone?() and not standalone_headless?())
   end
 
+  @spec minimal_mode?() :: boolean()
+  defp minimal_mode? do
+    Application.get_env(:minga, :minimal_mode, false) or standalone_minimal?()
+  end
+
   @spec standalone_headless?() :: boolean()
   defp standalone_headless? do
     Minga.CLI.headless_args?(Burrito.Util.Args.argv())
@@ -171,6 +181,13 @@ defmodule Minga.Application do
     error ->
       Minga.Log.debug(:editor, "Could not inspect standalone CLI args: #{inspect(error)}")
       false
+  end
+
+  @spec standalone_minimal?() :: boolean()
+  defp standalone_minimal? do
+    Minga.CLI.minimal_args?(Burrito.Util.Args.argv())
+  rescue
+    _ -> false
   end
 
   @spec prune_old_sessions() :: :ok

--- a/lib/minga/cli.ex
+++ b/lib/minga/cli.ex
@@ -91,6 +91,12 @@ defmodule Minga.CLI do
     Enum.member?(args, "--headless")
   end
 
+  @doc "Returns true when args request minimal mode (for GIT_EDITOR use)."
+  @spec minimal_args?([String.t()]) :: boolean()
+  def minimal_args?(args) do
+    Enum.member?(args, "--minimal")
+  end
+
   @doc "Returns the startup flags stored by the CLI, or defaults if none were set."
   @spec startup_flags() :: flags()
   def startup_flags do
@@ -468,11 +474,17 @@ defmodule Minga.CLI do
     exit({:shutdown, 1})
   end
 
+  @doc "Applies flag implications (e.g., minimal implies force_editor) to a flags map."
+  @spec apply_flag_implications(flags()) :: flags()
+  def apply_flag_implications(%{minimal: true} = flags), do: %{flags | force_editor: true}
+  def apply_flag_implications(flags), do: flags
+
   @spec store_startup_flags(flags()) :: :ok
   defp store_startup_flags(flags) do
-    Application.put_env(:minga, :cli_startup_flags, flags)
-    if flags.minimal, do: Application.put_env(:minga, :minimal_mode, true)
-    if flags.minimal or flags.force_editor, do: Application.put_env(:minga, :force_editor, true)
+    effective = apply_flag_implications(flags)
+    Application.put_env(:minga, :cli_startup_flags, effective)
+    if effective.minimal, do: Application.put_env(:minga, :minimal_mode, true)
+    if effective.force_editor, do: Application.put_env(:minga, :force_editor, true)
     :ok
   end
 

--- a/lib/minga/cli.ex
+++ b/lib/minga/cli.ex
@@ -27,6 +27,7 @@ defmodule Minga.CLI do
           no_context: boolean(),
           config_file: String.t() | nil,
           headless: boolean(),
+          minimal: boolean(),
           node_name: String.t() | nil,
           short_name: boolean(),
           cookie: String.t() | nil,
@@ -40,6 +41,7 @@ defmodule Minga.CLI do
     no_context: false,
     config_file: nil,
     headless: false,
+    minimal: false,
     node_name: nil,
     short_name: false,
     cookie: nil,
@@ -211,6 +213,10 @@ defmodule Minga.CLI do
 
   defp parse_args(["--config"], _file, _flags) do
     {:error, "--config requires a path argument\n\n#{usage()}"}
+  end
+
+  defp parse_args(["--minimal" | rest], file, flags) do
+    parse_args(rest, file, %{flags | minimal: true})
   end
 
   defp parse_args([<<"--", _::binary>> = flag | _], _file, _flags) do
@@ -465,6 +471,9 @@ defmodule Minga.CLI do
   @spec store_startup_flags(flags()) :: :ok
   defp store_startup_flags(flags) do
     Application.put_env(:minga, :cli_startup_flags, flags)
+    if flags.minimal, do: Application.put_env(:minga, :minimal_mode, true)
+    if flags.minimal or flags.force_editor, do: Application.put_env(:minga, :force_editor, true)
+    :ok
   end
 
   @spec usage() :: String.t()
@@ -479,6 +488,7 @@ defmodule Minga.CLI do
       -v, --version          Show version
       --config <path>        Use a custom config file instead of the default
       --editor               Start in file editing mode (skip agentic view)
+      --minimal              Minimal mode: editor-only, no services/agent (for GIT_EDITOR use)
       --no-context           Don't load the file as agent context
       --headless             Start services and agent runtime without a GUI frontend
       --name <name@host>     Distributed Erlang long node name

--- a/lib/minga/command/parser.ex
+++ b/lib/minga/command/parser.ex
@@ -235,7 +235,9 @@ defmodule Minga.Command.Parser do
   defp do_parse("qall"), do: {:quit_all, []}
   defp do_parse("qall!"), do: {:force_quit_all, []}
   defp do_parse("cq"), do: {:abort_quit, []}
+  defp do_parse("cq!"), do: {:abort_quit, []}
   defp do_parse("cquit"), do: {:abort_quit, []}
+  defp do_parse("cquit!"), do: {:abort_quit, []}
   defp do_parse("wq"), do: {:save_quit, []}
   defp do_parse("wqa"), do: {:save_quit_all, []}
   defp do_parse("wqall"), do: {:save_quit_all, []}

--- a/lib/minga/command/parser.ex
+++ b/lib/minga/command/parser.ex
@@ -20,6 +20,7 @@ defmodule Minga.Command.Parser do
   | `wq`             | `{:save_quit, []}`             |
   | `e <filename>`   | `{:edit, filename}`            |
   | `e!`             | `{:force_edit, []}`            |
+  | `cq`             | `{:abort_quit, []}`             |
   | `<number>`       | `{:goto_line, number}`         |
   | `1,10s/x/y/`     | `{:substitute, range, ...}`    |
   | anything else    | `{:unknown, original_string}`  |
@@ -50,6 +51,7 @@ defmodule Minga.Command.Parser do
   * `{:force_quit, []}` — force close tab or quit without saving (`:q!`)
   * `{:quit_all, []}` — quit the entire editor (`:qa`)
   * `{:force_quit_all, []}` — force quit the entire editor (`:qa!`)
+  * `{:abort_quit, []}` — abort and quit with error exit code (`:cq` / `:cquit`)
   * `{:save_quit, []}` — save and close tab, or save and quit if last tab (`:wq`)
   * `{:save_quit_all, []}` — save all buffers and quit (`:wqa`)
   * `{:edit, filename}` — open a file (`:e filename`)
@@ -74,6 +76,7 @@ defmodule Minga.Command.Parser do
           | {:force_quit, []}
           | {:quit_all, []}
           | {:force_quit_all, []}
+          | {:abort_quit, []}
           | {:save_quit, []}
           | {:save_quit_all, []}
           | {:edit, String.t()}
@@ -231,6 +234,8 @@ defmodule Minga.Command.Parser do
   defp do_parse("qa!"), do: {:force_quit_all, []}
   defp do_parse("qall"), do: {:quit_all, []}
   defp do_parse("qall!"), do: {:force_quit_all, []}
+  defp do_parse("cq"), do: {:abort_quit, []}
+  defp do_parse("cquit"), do: {:abort_quit, []}
   defp do_parse("wq"), do: {:save_quit, []}
   defp do_parse("wqa"), do: {:save_quit_all, []}
   defp do_parse("wqall"), do: {:save_quit_all, []}

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -1720,7 +1720,7 @@ defmodule MingaEditor.Commands.BufferManagement do
       %Minga.Command{
         name: :abort_quit,
         description: "Abort and quit with error exit code",
-        requires_buffer: true,
+        requires_buffer: false,
         execute: fn state -> execute(state, :abort_quit) end
       },
       %Minga.Command{

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -100,6 +100,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   def execute(state, :force_quit), do: close_tab_or_quit(state)
   def execute(state, :quit_all), do: maybe_confirm_quit(state, :quit_all)
   def execute(state, :force_quit_all), do: shutdown_editor(state)
+  def execute(state, :abort_quit), do: abort_quit_editor(state)
 
   def execute(%{pending_quit: kind} = state, :confirm_quit_yes) when kind != nil do
     state = EditorState.clear_pending_quit(state)
@@ -227,6 +228,9 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   def execute(state, {:execute_ex_command, {:force_quit_all, []}}),
     do: execute(state, :force_quit_all)
+
+  def execute(state, {:execute_ex_command, {:abort_quit, []}}),
+    do: execute(state, :abort_quit)
 
   def execute(state, {:execute_ex_command, {:save_quit, []}}) do
     state |> execute(:save) |> close_tab_or_quit()
@@ -1239,6 +1243,15 @@ defmodule MingaEditor.Commands.BufferManagement do
     state
   end
 
+  # Aborts the editor with a non-zero exit code. Used by `:cq` / `:cquit`
+  # so external tools (like `git commit`) can detect the user cancelled.
+  @spec abort_quit_editor(state()) :: state()
+  defp abort_quit_editor(state) do
+    shutdown_fn = Application.get_env(:minga, :shutdown_fn, &System.stop/1)
+    shutdown_fn.(1)
+    state
+  end
+
   # Closes the current file tab without killing the buffer. The buffer
   # stays in the buffer pool (matching Neovim's `:q` which closes the
   # window but leaves the buffer in the background buffer list).
@@ -1703,6 +1716,12 @@ defmodule MingaEditor.Commands.BufferManagement do
         description: "Force quit the editor (all tabs)",
         requires_buffer: true,
         execute: fn state -> execute(state, :force_quit_all) end
+      },
+      %Minga.Command{
+        name: :abort_quit,
+        description: "Abort and quit with error exit code",
+        requires_buffer: true,
+        execute: fn state -> execute(state, :abort_quit) end
       },
       %Minga.Command{
         name: :confirm_quit_yes,

--- a/lib/mix/tasks/minga.ex
+++ b/lib/mix/tasks/minga.ex
@@ -25,6 +25,11 @@ defmodule Mix.Tasks.Minga do
   def run(args) do
     {gui?, remaining_args} = extract_gui_flag(args)
     headless? = Minga.CLI.headless_args?(remaining_args)
+    minimal? = Minga.CLI.minimal_args?(remaining_args)
+
+    if minimal? do
+      Application.put_env(:minga, :minimal_mode, true)
+    end
 
     unless headless? do
       Application.put_env(:minga, :start_editor, true)

--- a/test/minga/cli_test.exs
+++ b/test/minga/cli_test.exs
@@ -180,11 +180,12 @@ defmodule Minga.CLITest do
       assert message =~ "unknown flag: --unknown"
     end
 
-    test "usage text includes --editor, --no-context, and --config" do
+    test "usage text includes --editor, --no-context, --config, and --minimal" do
       assert {:error, message} = CLI.parse_args(["--help"])
       assert message =~ "--editor"
       assert message =~ "--no-context"
       assert message =~ "--config"
+      assert message =~ "--minimal"
     end
   end
 
@@ -219,6 +220,30 @@ defmodule Minga.CLITest do
       assert %{config_file: "/tmp/test_config.exs"} = CLI.startup_flags()
     after
       Application.delete_env(:minga, :cli_startup_flags)
+    end
+
+  end
+
+  describe "apply_flag_implications/1" do
+    test "minimal implies force_editor" do
+      {:open, _, flags} = CLI.parse_args(["--minimal", "COMMIT_EDITMSG"])
+      result = CLI.apply_flag_implications(flags)
+      assert result.force_editor == true
+      assert result.minimal == true
+    end
+
+    test "force_editor alone is preserved, does not set minimal" do
+      {:open, _, flags} = CLI.parse_args(["--editor"])
+      result = CLI.apply_flag_implications(flags)
+      assert result.force_editor == true
+      assert result.minimal == false
+    end
+
+    test "neither flag leaves both false" do
+      {:open, _, flags} = CLI.parse_args([])
+      result = CLI.apply_flag_implications(flags)
+      assert result.force_editor == false
+      assert result.minimal == false
     end
   end
 end

--- a/test/minga/cli_test.exs
+++ b/test/minga/cli_test.exs
@@ -221,7 +221,6 @@ defmodule Minga.CLITest do
     after
       Application.delete_env(:minga, :cli_startup_flags)
     end
-
   end
 
   describe "apply_flag_implications/1" do

--- a/test/minga/cli_test.exs
+++ b/test/minga/cli_test.exs
@@ -121,6 +121,15 @@ defmodule Minga.CLITest do
       assert {:open, nil, %{headless: true}} = CLI.parse_args(["--headless"])
     end
 
+    test "--minimal sets minimal flag" do
+      assert {:open, nil, %{minimal: true}} = CLI.parse_args(["--minimal"])
+    end
+
+    test "--minimal combined with file argument" do
+      assert {:open, "COMMIT_EDITMSG", %{minimal: true}} =
+               CLI.parse_args(["--minimal", "COMMIT_EDITMSG"])
+    end
+
     test "--name, --cookie, --host, and --port set distribution flags" do
       cookie = "abcdefghijklmnopqrstuvwxyz123456"
 

--- a/test/minga/command/parser_test.exs
+++ b/test/minga/command/parser_test.exs
@@ -58,6 +58,14 @@ defmodule Minga.Command.ParserTest do
     test ":cquit parses to {:abort_quit, []}" do
       assert {:abort_quit, []} = Parser.parse("cquit")
     end
+
+    test ":cq! parses to {:abort_quit, []}" do
+      assert {:abort_quit, []} = Parser.parse("cq!")
+    end
+
+    test ":cquit! parses to {:abort_quit, []}" do
+      assert {:abort_quit, []} = Parser.parse("cquit!")
+    end
   end
 
   describe "parse/1 — edit command" do

--- a/test/minga/command/parser_test.exs
+++ b/test/minga/command/parser_test.exs
@@ -50,6 +50,14 @@ defmodule Minga.Command.ParserTest do
     test ":qall! parses to {:force_quit_all, []}" do
       assert {:force_quit_all, []} = Parser.parse("qall!")
     end
+
+    test ":cq parses to {:abort_quit, []}" do
+      assert {:abort_quit, []} = Parser.parse("cq")
+    end
+
+    test ":cquit parses to {:abort_quit, []}" do
+      assert {:abort_quit, []} = Parser.parse("cquit")
+    end
   end
 
   describe "parse/1 — edit command" do

--- a/test/minga/command/registry_test.exs
+++ b/test/minga/command/registry_test.exs
@@ -25,6 +25,7 @@ defmodule Minga.Command.RegistryTest do
           :force_quit,
           :quit_all,
           :force_quit_all,
+          :abort_quit,
           :buffer_list,
           :buffer_list_all,
           :buffer_next,

--- a/test/minga/mode/command_test.exs
+++ b/test/minga/mode/command_test.exs
@@ -106,6 +106,20 @@ defmodule Minga.Mode.CommandTest do
                result
     end
 
+    test ":cq → execute {:abort_quit, []} then transition to normal" do
+      result = Command.handle_key({@enter, 0}, fresh_state("cq"))
+
+      assert {:execute_then_transition, [{:execute_ex_command, {:abort_quit, []}}], :normal, _} =
+               result
+    end
+
+    test ":cquit → execute {:abort_quit, []} then transition to normal" do
+      result = Command.handle_key({@enter, 0}, fresh_state("cquit"))
+
+      assert {:execute_then_transition, [{:execute_ex_command, {:abort_quit, []}}], :normal, _} =
+               result
+    end
+
     test ":e filename → execute {:edit, filename} then transition to normal" do
       result = Command.handle_key({@enter, 0}, fresh_state("e README.md"))
 

--- a/test/minga_editor/commands/buffer_management_shutdown_test.exs
+++ b/test/minga_editor/commands/buffer_management_shutdown_test.exs
@@ -88,5 +88,21 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
       state = :sys.get_state(editor)
       refute state.pending_quit
     end
+
+    test ":cq exits with non-zero exit code" do
+      {editor, _buffer} = start_editor("hello")
+
+      type_string(editor, ":cq\r")
+
+      assert_receive {:shutdown_called, 1}
+    end
+
+    test ":cq! exits with non-zero exit code" do
+      {editor, _buffer} = start_editor("hello")
+
+      type_string(editor, ":cq!\r")
+
+      assert_receive {:shutdown_called, 1}
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Add `:cq` / `:cquit` ex-commands that exit with code 1, letting git detect user cancellation (matching vim's `:cquit` behavior)
- Add `--minimal` CLI flag that skips Services and Agent supervisors for faster startup, suitable for `GIT_EDITOR` use
- `--minimal` implies `--editor` automatically so the user doesn't need to pass both

## Usage

```bash
export GIT_EDITOR="/path/to/minga --minimal"

# git commit → edit message → :wq to commit, :cq to abort
```

## What's included in minimal mode

- Foundation (config, keymaps, language registry)
- Buffer registry/supervisor
- Runtime supervisor (tree-sitter, renderer, editor)

## What's skipped in minimal mode

- Services supervisor (Git tracker, LSP, Extensions, Diagnostics, Project)
- Agent supervisor (agentic AI features)

## Test plan

- [x] `:cq` and `:cquit` parse to `{:abort_quit, []}` (new parser tests)
- [x] `--minimal` flag parses correctly, alone and with file argument (new CLI tests)
- [x] `mix compile --warnings-as-errors` passes (pre-existing warning in native.ex only)
- [x] Full test suite: 141 affected tests, 0 failures
- [ ] Manual: `GIT_EDITOR="minga --minimal" git commit`, `:wq` completes commit, `:cq` aborts

🤖 Generated with [Claude Code](https://claude.com/claude-code)