### PR TITLE
feat(project): add persistent frecency ranking for file picker

### DIFF
--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -34,12 +34,19 @@ defmodule Minga.Project do
             cached_files: [],
             known_projects: [],
             recent_files: %{},
+            frecency_events: %{},
             rebuilding?: false,
             rebuild_ref: nil,
             events_registry: Minga.Events.default_registry()
 
   @typedoc "Per-project recent files map: project root => list of relative paths (most recent first)."
   @type recent_files_map :: %{String.t() => [String.t()]}
+
+  @typedoc "Per-file access event history (most recent first, unix seconds)."
+  @type file_accesses_map :: %{String.t() => [non_neg_integer()]}
+
+  @typedoc "Per-project frecency map: project root => %{relative_path => access_timestamps}."
+  @type frecency_events_map :: %{String.t() => file_accesses_map()}
 
   @typedoc "Project GenServer state."
   @type t :: %__MODULE__{
@@ -48,6 +55,7 @@ defmodule Minga.Project do
           cached_files: [String.t()],
           known_projects: [String.t()],
           recent_files: recent_files_map(),
+          frecency_events: frecency_events_map(),
           rebuilding?: boolean(),
           rebuild_ref: reference() | nil,
           events_registry: Minga.Events.registry()
@@ -55,6 +63,8 @@ defmodule Minga.Project do
 
   @known_projects_file "known-projects"
   @recent_files_file "recent-files"
+  @frecency_file "frecency"
+  @frecency_events_per_file_limit 10
 
   # ── Client API ──────────────────────────────────────────────────────────────
 
@@ -153,6 +163,18 @@ defmodule Minga.Project do
     GenServer.call(server, :recent_files)
   end
 
+  @doc "Returns frecency scores for files in the current project (relative path => score)."
+  @spec frecency_scores(GenServer.server()) :: %{String.t() => non_neg_integer()}
+  def frecency_scores(server \\ __MODULE__) do
+    GenServer.call(server, :frecency_scores)
+  end
+
+  @doc "Scores a file's access timestamps using frecency decay buckets."
+  @spec score_accesses([non_neg_integer()], non_neg_integer()) :: non_neg_integer()
+  def score_accesses(timestamps, now_unix) when is_list(timestamps) and is_integer(now_unix) do
+    Enum.reduce(timestamps, 0, fn ts, score -> score + bucket_points(now_unix - ts) end)
+  end
+
   # ── GenServer Callbacks ─────────────────────────────────────────────────────
 
   @impl true
@@ -169,9 +191,15 @@ defmodule Minga.Project do
 
     known = if persist_known_projects?(), do: load_known_projects(), else: []
     recent = if persist_recent_files?(), do: load_recent_files(), else: %{}
+    frecency = if persist_recent_files?(), do: load_frecency_events(), else: %{}
 
     {:ok,
-     %__MODULE__{known_projects: known, recent_files: recent, events_registry: events_registry}}
+     %__MODULE__{
+       known_projects: known,
+       recent_files: recent,
+       frecency_events: frecency,
+       events_registry: events_registry
+     }}
   end
 
   @impl true
@@ -195,6 +223,24 @@ defmodule Minga.Project do
   def handle_call(:recent_files, _from, state) do
     files = Map.get(state.recent_files, state.current_root, [])
     {:reply, files, state}
+  end
+
+  def handle_call(:frecency_scores, _from, %{current_root: nil} = state) do
+    {:reply, %{}, state}
+  end
+
+  def handle_call(:frecency_scores, _from, state) do
+    root = state.current_root
+    now_unix = System.system_time(:second)
+
+    scores =
+      state.frecency_events
+      |> Map.get(root, %{})
+      |> Map.new(fn {rel_path, timestamps} ->
+        {rel_path, score_accesses(timestamps, now_unix)}
+      end)
+
+    {:reply, scores, state}
   end
 
   @impl true
@@ -328,8 +374,24 @@ defmodule Minga.Project do
         updated = [rel_path | Enum.reject(existing, &(&1 == rel_path))]
         updated = Enum.take(updated, limit)
         new_recent = Map.put(state.recent_files, root, updated)
-        state = %{state | recent_files: new_recent}
-        if persist_recent_files?(), do: persist_recent_files(new_recent)
+
+        now_unix = System.system_time(:second)
+
+        new_frecency =
+          state.frecency_events
+          |> Map.get(root, %{})
+          |> Map.update(rel_path, [now_unix], fn timestamps ->
+            [now_unix | timestamps] |> Enum.take(@frecency_events_per_file_limit)
+          end)
+          |> then(&Map.put(state.frecency_events, root, &1))
+
+        state = %{state | recent_files: new_recent, frecency_events: new_frecency}
+
+        if persist_recent_files?() do
+          persist_recent_files(new_recent)
+          persist_frecency_events(new_frecency)
+        end
+
         state
     end
   end
@@ -488,6 +550,103 @@ defmodule Minga.Project do
       Minga.Log.warning(:editor, "Failed to persist recent files: #{Exception.message(e)}")
       :ok
   end
+
+  @spec frecency_path() :: String.t()
+  defp frecency_path do
+    config_dir = Path.expand("~/.config/minga")
+    Path.join(config_dir, @frecency_file)
+  end
+
+  @spec load_frecency_events() :: frecency_events_map()
+  defp load_frecency_events do
+    path = frecency_path()
+
+    case File.read(path) do
+      {:ok, content} -> parse_frecency_events(content)
+      {:error, _} -> %{}
+    end
+  end
+
+  @spec parse_frecency_events(String.t()) :: frecency_events_map()
+  defp parse_frecency_events(content) do
+    content
+    |> String.split("\n", trim: true)
+    |> Enum.reduce(%{}, fn line, acc ->
+      case parse_frecency_line(line) do
+        {:ok, root, rel_path, timestamp} -> update_frecency_event(acc, root, rel_path, timestamp)
+        :error -> acc
+      end
+    end)
+  end
+
+  @spec parse_frecency_line(String.t()) ::
+          {:ok, String.t(), String.t(), non_neg_integer()} | :error
+  defp parse_frecency_line(line) do
+    case String.split(line, "\t", parts: 3) do
+      [root, rel_path, ts] -> parse_frecency_timestamp(root, rel_path, ts)
+      _ -> :error
+    end
+  end
+
+  @spec parse_frecency_timestamp(String.t(), String.t(), String.t()) ::
+          {:ok, String.t(), String.t(), non_neg_integer()} | :error
+  defp parse_frecency_timestamp(root, rel_path, ts) do
+    case Integer.parse(ts) do
+      {timestamp, ""} when timestamp >= 0 -> {:ok, root, rel_path, timestamp}
+      _ -> :error
+    end
+  end
+
+  @spec update_frecency_event(frecency_events_map(), String.t(), String.t(), non_neg_integer()) ::
+          frecency_events_map()
+  defp update_frecency_event(events, root, rel_path, timestamp) do
+    root_map = Map.get(events, root, %{})
+
+    updated_root_map =
+      Map.update(root_map, rel_path, [timestamp], fn timestamps ->
+        timestamps
+        |> Kernel.++([timestamp])
+        |> Enum.take(@frecency_events_per_file_limit)
+      end)
+
+    Map.put(events, root, updated_root_map)
+  end
+
+  @spec persist_frecency_events(frecency_events_map()) :: :ok
+  defp persist_frecency_events(frecency_events) do
+    path = frecency_path()
+    dir = Path.dirname(path)
+    File.mkdir_p!(dir)
+
+    content = frecency_lines(frecency_events) |> Enum.join("\n") |> Kernel.<>("\n")
+    File.write!(path, content)
+    :ok
+  rescue
+    e ->
+      Minga.Log.warning(:editor, "Failed to persist frecency data: #{Exception.message(e)}")
+      :ok
+  end
+
+  @spec frecency_lines(frecency_events_map()) :: [String.t()]
+  defp frecency_lines(frecency_events) do
+    Enum.flat_map(frecency_events, fn {root, file_accesses} ->
+      file_accesses_to_lines(root, file_accesses)
+    end)
+  end
+
+  @spec file_accesses_to_lines(String.t(), file_accesses_map()) :: [String.t()]
+  defp file_accesses_to_lines(root, file_accesses) do
+    Enum.flat_map(file_accesses, fn {rel_path, timestamps} ->
+      Enum.map(timestamps, fn ts -> "#{root}\t#{rel_path}\t#{ts}" end)
+    end)
+  end
+
+  @spec bucket_points(integer()) :: non_neg_integer()
+  defp bucket_points(age_seconds) when age_seconds <= 4 * 60 * 60, do: 100
+  defp bucket_points(age_seconds) when age_seconds <= 24 * 60 * 60, do: 80
+  defp bucket_points(age_seconds) when age_seconds <= 7 * 24 * 60 * 60, do: 60
+  defp bucket_points(age_seconds) when age_seconds <= 30 * 24 * 60 * 60, do: 40
+  defp bucket_points(_age_seconds), do: 20
 
   # ── Domain delegates ──────────────────────────────────────────────────────
 

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -418,10 +418,24 @@ defmodule MingaEditor.PickerUI do
   defp promote_previewed_buffer(state) do
     previewed_pid = state.workspace.buffers.active
 
+    state =
+      state
+      |> restore_picker_origin()
+      |> close()
+      |> EditorState.add_buffer(previewed_pid, context: :open)
+
+    record_previewed_buffer_access(previewed_pid)
     state
-    |> restore_picker_origin()
-    |> close()
-    |> EditorState.add_buffer(previewed_pid, context: :open)
+  end
+
+  @spec record_previewed_buffer_access(pid()) :: :ok
+  defp record_previewed_buffer_access(buffer) when is_pid(buffer) do
+    case Minga.Buffer.file_path(buffer) do
+      path when is_binary(path) -> Minga.Project.record_file(path)
+      _ -> :ok
+    end
+  catch
+    :exit, _ -> :ok
   end
 
   @spec run_select_and_close(EditorState.t(), Picker.item(), module()) ::

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -32,9 +32,9 @@ defmodule MingaEditor.UI.Picker.FileSource do
 
     case Minga.Project.list_files(root) do
       {:ok, paths} ->
-        recency_map = build_recency_map()
+        frecency_map = build_frecency_map()
         git_status_map = build_git_status_map()
-        score_map = build_score_map(recency_map, git_status_map)
+        score_map = build_score_map(frecency_map, git_status_map)
 
         paths
         |> Enum.map(&format_file_candidate(&1, git_status_map))
@@ -74,7 +74,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   @impl true
   @spec on_select(Item.t(), term()) :: term()
   def on_select(%Item{id: rel_path}, state) do
-    abs_path = Path.expand(rel_path)
+    abs_path = absolute_path(rel_path)
 
     Log.debug(:editor, "[file_picker] on_select path=#{rel_path}")
 
@@ -83,7 +83,9 @@ defmodule MingaEditor.UI.Picker.FileSource do
         case EditorState.start_buffer(abs_path) do
           {:ok, pid} ->
             Log.debug(:editor, "[file_picker] new buffer pid=#{inspect(pid)}")
-            EditorState.add_buffer(state, pid)
+            new_state = EditorState.add_buffer(state, pid)
+            record_selection(abs_path, state)
+            new_state
 
           {:error, reason} ->
             Minga.Log.error(:editor, "Failed to open file: #{inspect(reason)}")
@@ -91,7 +93,9 @@ defmodule MingaEditor.UI.Picker.FileSource do
         end
 
       idx ->
-        switch_existing_buffer(state, idx)
+        new_state = switch_existing_buffer(state, idx)
+        record_selection(abs_path, state)
+        new_state
     end
   end
 
@@ -137,7 +141,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   def on_action(:open, item, state), do: on_select(item, state)
 
   def on_action(:delete, %Item{id: rel_path}, state) do
-    abs_path = Path.expand(rel_path)
+    abs_path = absolute_path(rel_path)
 
     case File.rm(abs_path) do
       :ok ->
@@ -154,19 +158,22 @@ defmodule MingaEditor.UI.Picker.FileSource do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
-  # Build a map of relative_path → recency_score from Project.recent_files.
-  # Most recently opened files get the highest score.
-  @spec build_recency_map() :: %{String.t() => non_neg_integer()}
-  defp build_recency_map do
-    recent = Minga.Project.recent_files()
-    total = length(recent)
+  @spec absolute_path(String.t()) :: String.t()
+  defp absolute_path(rel_path), do: Path.expand(rel_path, project_root())
 
-    recent
-    |> Enum.with_index()
-    |> Enum.into(%{}, fn {path, idx} ->
-      # Most recent = highest score. Score decays linearly.
-      {path, total - idx}
-    end)
+  @spec record_selection(String.t(), term()) :: :ok
+  defp record_selection(_abs_path, %{buffer_add_context: :preview}), do: :ok
+
+  defp record_selection(abs_path, _state) do
+    Minga.Project.record_file(abs_path)
+  catch
+    :exit, _ -> :ok
+  end
+
+  # Build a map of relative_path → frecency_score from Project.frecency_scores/0.
+  @spec build_frecency_map() :: %{String.t() => non_neg_integer()}
+  defp build_frecency_map do
+    Minga.Project.frecency_scores()
   catch
     :exit, _ -> %{}
   end
@@ -187,23 +194,22 @@ defmodule MingaEditor.UI.Picker.FileSource do
     :exit, _ -> %{}
   end
 
-  # Combine recency and git-modified scores. Git-modified files get a flat
-  # boost of 5. Recently opened files get position-based score (N..1).
-  # Both boosts stack: recently opened AND modified = highest score.
+  # Combine frecency and git-modified scores. Git-modified files get a flat
+  # boost of 5. Both boosts stack: frequently/recently opened AND modified = highest score.
   @spec build_score_map(%{String.t() => non_neg_integer()}, %{String.t() => atom()}) :: %{
           String.t() => non_neg_integer()
         }
-  defp build_score_map(recency_map, git_status_map) do
-    all_paths = Map.keys(recency_map) ++ Map.keys(git_status_map)
+  defp build_score_map(frecency_map, git_status_map) do
+    all_paths = Map.keys(frecency_map) ++ Map.keys(git_status_map)
 
     Map.new(Enum.uniq(all_paths), fn path ->
-      recency = Map.get(recency_map, path, 0)
+      frecency = Map.get(frecency_map, path, 0)
       git_boost = if Map.has_key?(git_status_map, path), do: 5, else: 0
-      {path, recency + git_boost}
+      {path, frecency + git_boost}
     end)
   end
 
-  # Sort items by combined score (recent + git-modified), preserving filesystem order for unscored.
+  # Sort items by combined score (frecency + git-modified), preserving filesystem order for unscored.
   @spec sort_by_score([Item.t()], %{String.t() => non_neg_integer()}) :: [Item.t()]
   defp sort_by_score(items, score_map) when map_size(score_map) == 0, do: items
 

--- a/test/minga/project_test.exs
+++ b/test/minga/project_test.exs
@@ -1,5 +1,6 @@
 defmodule Minga.ProjectTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias Minga.Project
 
@@ -374,6 +375,56 @@ defmodule Minga.ProjectTest do
       flush(name)
 
       assert Project.recent_files(name) == ["a.ex"]
+    end
+  end
+
+  describe "frecency" do
+    test "score_accesses/2 applies Mozilla-style decay buckets" do
+      now = 1_700_000_000
+
+      timestamps = [
+        now - 60,
+        now - 8 * 60 * 60,
+        now - 2 * 24 * 60 * 60,
+        now - 10 * 24 * 60 * 60,
+        now - 90 * 24 * 60 * 60
+      ]
+
+      assert Project.score_accesses(timestamps, now) == 100 + 80 + 60 + 40 + 20
+    end
+
+    test "score_accesses/2 is monotonic when adding another same-time access" do
+      check all(n <- StreamData.integer(0..20)) do
+        now = 1_700_000_000
+        timestamps = List.duplicate(now - 60, n)
+        with_extra = [now - 60 | timestamps]
+
+        assert Project.score_accesses(with_extra, now) >= Project.score_accesses(timestamps, now)
+      end
+    end
+
+    test "more opens produce a higher frecency score", %{tmp_dir: tmp} do
+      project = Path.join(tmp, "frecency_project")
+      lib = Path.join(project, "lib")
+      File.mkdir_p!(lib)
+      File.write!(Path.join(project, "mix.exs"), "")
+      File.write!(Path.join(lib, "hot.ex"), "")
+      File.write!(Path.join(lib, "cold.ex"), "")
+
+      {_pid, name} = start_project!()
+      Project.detect_and_set(name, Path.join(lib, "hot.ex"))
+      flush(name)
+
+      Enum.each(1..5, fn _ ->
+        Project.record_file(name, Path.join(lib, "hot.ex"))
+        flush(name)
+      end)
+
+      Project.record_file(name, Path.join(lib, "cold.ex"))
+      flush(name)
+
+      scores = Project.frecency_scores(name)
+      assert scores["lib/hot.ex"] > scores["lib/cold.ex"]
     end
   end
 end

--- a/test/minga_editor/ui/picker/file_source_test.exs
+++ b/test/minga_editor/ui/picker/file_source_test.exs
@@ -1,0 +1,118 @@
+defmodule MingaEditor.UI.Picker.FileSourceTest do
+  @moduledoc "Tests frecency ordering in FileSource candidates."
+
+  # Uses the global Minga.Project singleton to drive FileSource.project_root/0.
+  use Minga.Test.EditorCase, async: false
+
+  alias MingaEditor.UI.Picker.FileSource
+  alias MingaEditor.UI.Picker.Item
+
+  @moduletag :tmp_dir
+
+  setup do
+    reset_global_project!()
+
+    on_exit(fn ->
+      reset_global_project!()
+    end)
+
+    :ok
+  end
+
+  test "on_select opens project-relative paths from the project root and records the selection",
+       %{tmp_dir: tmp_dir} do
+    project = Path.join(tmp_dir, "frecency_select_project")
+    lib = Path.join(project, "lib")
+    File.mkdir_p!(lib)
+    File.write!(Path.join(project, "mix.exs"), "")
+    File.write!(Path.join(project, "initial.ex"), "initial")
+    File.write!(Path.join(lib, "hot.ex"), "hot")
+
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(project)
+    await_project_rebuild(project)
+
+    ctx =
+      start_editor("initial", file_path: Path.join(project, "initial.ex"), project_root: project)
+
+    state = FileSource.on_select(%Item{id: "lib/hot.ex", label: "hot.ex"}, editor_state(ctx))
+    flush_project()
+
+    assert Minga.Buffer.file_path(state.workspace.buffers.active) == Path.join(lib, "hot.ex")
+    assert Minga.Project.frecency_scores()["lib/hot.ex"] > 0
+  end
+
+  test "preview selections do not record frecency until confirmed", %{tmp_dir: tmp_dir} do
+    project = Path.join(tmp_dir, "frecency_preview_project")
+    lib = Path.join(project, "lib")
+    File.mkdir_p!(lib)
+    File.write!(Path.join(project, "mix.exs"), "")
+    File.write!(Path.join(project, "initial.ex"), "initial")
+    File.write!(Path.join(lib, "previewed.ex"), "previewed")
+
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(project)
+    await_project_rebuild(project)
+
+    ctx =
+      start_editor("initial", file_path: Path.join(project, "initial.ex"), project_root: project)
+
+    state = editor_state(ctx) |> MingaEditor.State.set_buffer_add_context(:preview)
+
+    _state = FileSource.on_select(%Item{id: "lib/previewed.ex", label: "previewed.ex"}, state)
+    flush_project()
+
+    refute Map.has_key?(Minga.Project.frecency_scores(), "lib/previewed.ex")
+  end
+
+  test "files opened more often rank above files opened once", %{tmp_dir: tmp_dir} do
+    project = Path.join(tmp_dir, "frecency_picker_project")
+    lib = Path.join(project, "lib")
+    File.mkdir_p!(lib)
+    File.write!(Path.join(project, "mix.exs"), "")
+    File.write!(Path.join(lib, "hot.ex"), "")
+    File.write!(Path.join(lib, "cold.ex"), "")
+
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(project)
+    await_project_rebuild(project)
+
+    Enum.each(1..5, fn _ ->
+      Minga.Project.record_file(Path.join(lib, "hot.ex"))
+      flush_project()
+    end)
+
+    Minga.Project.record_file(Path.join(lib, "cold.ex"))
+    flush_project()
+
+    ids = FileSource.candidates(nil) |> Enum.map(& &1.id)
+
+    hot_index = Enum.find_index(ids, &(&1 == "lib/hot.ex"))
+    cold_index = Enum.find_index(ids, &(&1 == "lib/cold.ex"))
+
+    assert is_integer(hot_index)
+    assert is_integer(cold_index)
+    assert hot_index < cold_index
+  end
+
+  defp reset_global_project! do
+    root = File.cwd!()
+    Minga.Events.subscribe(:project_rebuilt)
+    Minga.Project.switch(root)
+    await_project_rebuild(root)
+  end
+
+  defp await_project_rebuild(root) do
+    state = :sys.get_state(Minga.Project)
+
+    if state.rebuilding? do
+      assert_receive {:minga_event, :project_rebuilt,
+                      %Minga.Events.ProjectRebuiltEvent{root: ^root}},
+                     5_000
+    end
+
+    :sys.get_state(Minga.Project)
+  end
+
+  defp flush_project, do: :sys.get_state(Minga.Project)
+end


### PR DESCRIPTION
## Summary
- add persistent frecency tracking in Minga.Project using ~/.config/minga/frecency
- score file opens with Mozilla-style decay buckets and expose in-memory frecency_scores/0
- switch file picker ranking from recency-only to frecency + existing git-status boost
- add tests for decay scoring, monotonicity, and picker ordering

## Testing
- make lint
- mix test.llm

Closes #1612
