### PR TITLE
fix(macos): handle display scale changes

### DIFF
--- a/macos/Sources/Font/FontFace.swift
+++ b/macos/Sources/Font/FontFace.swift
@@ -19,6 +19,8 @@ import AppKit
 /// thread already (rendering, font commands, protocol dispatch).
 @MainActor
 final class FontFace {
+    /// Font family or PostScript name requested by the caller.
+    let requestedName: String
     let ctFont: CTFont
     /// Bold variant, or nil if the font family doesn't have one.
     let ctFontBold: CTFont?
@@ -64,6 +66,9 @@ final class FontFace {
         7: 10   // black
     ]
 
+    /// The protocol weight byte used to resolve this font.
+    let protocolWeight: UInt8
+
     /// The NSFontManager weight used to resolve this font.
     let fontWeight: Int
 
@@ -78,6 +83,8 @@ final class FontFace {
     /// `weight` is the protocol weight byte (0-7), mapped to NSFontManager's scale.
     init(name: String, size: CGFloat, scale: CGFloat, ligatures: Bool = true, weight: UInt8 = 2) {
         let nsFontWeight = FontFace.weightMap[weight] ?? 5
+        self.requestedName = name
+        self.protocolWeight = weight
         self.fontWeight = nsFontWeight
         self.familyName = name
         let font = FontFace.resolveFont(name: name, size: size, weight: nsFontWeight)

--- a/macos/Sources/Font/FontManager.swift
+++ b/macos/Sources/Font/FontManager.swift
@@ -24,6 +24,12 @@ final class FontManager {
     /// Secondary fonts keyed by font_id (1-255).
     private var secondaryFonts: [UInt8: FontFace] = [:]
 
+    /// Registered secondary font families keyed by font_id, retained so primary font rebuilds can preserve them.
+    private var registeredFontFamilies: [UInt8: String] = [:]
+
+    /// User-configured fallback families, retained so primary font rebuilds can preserve them.
+    private var fallbackFamilies: [String] = []
+
     /// Cell dimensions from the primary font (all fonts use these for layout).
     var cellWidth: CGFloat { primary.cellWidth }
     var cellHeight: Int { primary.cellHeight }
@@ -36,12 +42,19 @@ final class FontManager {
                                  ligatures: ligatures, weight: weight)
     }
 
-    /// Replace the primary font (e.g., after a set_font command).
+    /// Replace the primary font after a set_font command or display scale change.
     func setPrimaryFont(name: String, size: CGFloat, scale: CGFloat,
                         ligatures: Bool, weight: UInt8) {
         self.primary = FontFace(name: name, size: size, scale: scale,
                                  ligatures: ligatures, weight: weight)
-        secondaryFonts.removeAll()
+        primary.setFallbackFonts(fallbackFamilies)
+        rebuildSecondaryFonts()
+    }
+
+    /// Configure the primary font fallback chain and preserve it across primary font rebuilds.
+    func setFallbackFonts(_ families: [String]) {
+        fallbackFamilies = families
+        primary.setFallbackFonts(families)
     }
 
     /// Register a secondary font at the given ID.
@@ -51,6 +64,27 @@ final class FontManager {
             return
         }
 
+        registeredFontFamilies[id] = name
+        secondaryFonts[id] = makeSecondaryFont(id: id, name: name)
+        PortLogger.info("Registered font '\(name)' at id=\(id)")
+    }
+
+    /// Returns the FontFace for a given font_id. Falls back to primary if not found.
+    func fontFace(for fontId: UInt8) -> FontFace {
+        if fontId == 0 { return primary }
+        return secondaryFonts[fontId] ?? primary
+    }
+
+    /// Rebuilds registered secondary fonts after the primary font's size or scale changes.
+    private func rebuildSecondaryFonts() {
+        secondaryFonts.removeAll(keepingCapacity: true)
+        for (id, name) in registeredFontFamilies {
+            secondaryFonts[id] = makeSecondaryFont(id: id, name: name)
+        }
+    }
+
+    /// Creates a secondary font using the current primary font's size, scale, and ligature setting.
+    private func makeSecondaryFont(id: UInt8, name: String) -> FontFace {
         let size = CTFontGetSize(primary.ctFont)
         let secondary = FontFace(name: name, size: size, scale: primary.scale,
                                   ligatures: primary.ligaturesEnabled, weight: 2)
@@ -65,13 +99,6 @@ final class FontManager {
             )
         }
 
-        secondaryFonts[id] = secondary
-        PortLogger.info("Registered font '\(name)' at id=\(id)")
-    }
-
-    /// Returns the FontFace for a given font_id. Falls back to primary if not found.
-    func fontFace(for fontId: UInt8) -> FontFace {
-        if fontId == 0 { return primary }
-        return secondaryFonts[fontId] ?? primary
+        return secondary
     }
 }

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -764,7 +764,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate()
 
-        // Backing scale factor for Retina rendering.
+        // Initial backing scale for Retina rendering. The window does not exist yet, so NSScreen.main is the only safe source here. EditorNSView.viewDidMoveToWindow/viewDidChangeBackingProperties corrects this if the window lands on another display.
         let scale = NSScreen.main?.backingScaleFactor ?? 2.0
 
         // Initialize font.
@@ -865,6 +865,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
         nsView.recoveryManager = recovery
+        nsView.onScaleFactorChanged = { [weak self] newScale in
+            self?.handleScaleChange(newScale: newScale)
+        }
         self.editorNSView = nsView
         appState.editorNSView = nsView
         observeWorkspaceLifecycleNotifications()
@@ -1047,6 +1050,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     PortLogger.info("Screens did wake; resuming Metal rendering")
                     self.editorNSView?.resumeAfterScreenWake()
                 }
+            },
+            Task { @MainActor [weak self] in
+                for await _ in NotificationCenter.default.notifications(named: NSApplication.didChangeScreenParametersNotification) {
+                    guard let self else { return }
+                    let scale = self.currentBackingScaleFactor()
+                    PortLogger.info("Display configuration changed; current scale: \(scale)x")
+                    self.editorNSView?.displayConfigurationChanged(newScale: scale, forceResizeEvent: true)
+                }
             }
         ]
     }
@@ -1114,14 +1125,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Font change
 
+    private func currentBackingScaleFactor() -> CGFloat {
+        editorNSView?.window?.screen?.backingScaleFactor ??
+            editorNSView?.window?.backingScaleFactor ??
+            NSScreen.main?.backingScaleFactor ??
+            2.0
+    }
+
     private func handleFontChange(family: String, size: CGFloat, ligatures: Bool, weight: UInt8) {
+        rebuildFont(family: family, size: size, scale: currentBackingScaleFactor(), ligatures: ligatures, weight: weight, reason: "Font changed")
+    }
+
+    private func handleScaleChange(newScale: CGFloat) {
+        guard let currentFace = fontFace else { return }
+        guard abs(currentFace.scale - newScale) > 0.001 else { return }
+
+        rebuildFont(
+            family: currentFace.requestedName,
+            size: CTFontGetSize(currentFace.ctFont),
+            scale: newScale,
+            ligatures: currentFace.ligaturesEnabled,
+            weight: currentFace.protocolWeight,
+            reason: "Display scale changed"
+        )
+    }
+
+    private func rebuildFont(family: String, size: CGFloat, scale: CGFloat, ligatures: Bool, weight: UInt8, reason: String) {
         guard let nsView = editorNSView else { return }
 
-        let scale = NSScreen.main?.backingScaleFactor ?? 2.0
         let newFace = FontFace(name: family, size: size, scale: scale, ligatures: ligatures, weight: weight)
-
         let fontName = CTFontCopyPostScriptName(newFace.ctFont) as String
-        PortLogger.info("Font changed: \(fontName) \(Int(size))pt, ligatures: \(ligatures), cell: \(newFace.cellWidth)x\(newFace.cellHeight)")
+        PortLogger.info("\(reason): \(fontName) \(Int(size))pt, scale: \(scale)x, ligatures: \(ligatures), cell: \(newFace.cellWidth)x\(newFace.cellHeight)")
 
         self.fontFace = newFace
 

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -151,7 +151,7 @@ final class CommandDispatcher {
             onFontChanged?(family, size, ligatures, weight)
 
         case .setFontFallback(let families):
-            fontManager?.primary.setFallbackFonts(families)
+            fontManager?.setFallbackFonts(families)
 
         case .registerFont(let id, let family):
             fontManager?.registerFont(id: id, name: family)

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -384,9 +384,7 @@ final class EditorNSView: MTKView {
     }
 
     /// Applies a live display configuration update to the Metal surface.
-    /// Returns true when the backing scale changed and the font atlas must be rebuilt.
-    @discardableResult
-    func displayConfigurationChanged(newScale: CGFloat, forceResizeEvent: Bool = false) -> Bool {
+    func displayConfigurationChanged(newScale: CGFloat, forceResizeEvent: Bool = false) {
         updateMetalBackingScale(newScale)
         let scaleChanged = abs(fontFace.scale - newScale) > 0.001
 
@@ -399,8 +397,6 @@ final class EditorNSView: MTKView {
         } else if forceResizeEvent {
             renderFrame()
         }
-
-        return scaleChanged
     }
 
     /// Updates CAMetalLayer and drawable sizing to match the current display scale.

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -356,7 +356,8 @@ final class EditorNSView: MTKView {
             return
         }
 
-        updateMetalBackingScale(window.backingScaleFactor)
+        // Correct the startup scale immediately when the window lands on a display different from NSScreen.main. The first setFrameSize call still owns the initial ready event.
+        displayConfigurationChanged(newScale: window.backingScaleFactor, sendDimensions: false)
 
         // Restore window position and size from previous session.
         // This fires before the window is made key/visible, so the
@@ -384,11 +385,11 @@ final class EditorNSView: MTKView {
     }
 
     /// Applies a live display configuration update to the Metal surface.
-    func displayConfigurationChanged(newScale: CGFloat, forceResizeEvent: Bool = false) {
+    func displayConfigurationChanged(newScale: CGFloat, forceResizeEvent: Bool = false, sendDimensions: Bool = true) {
         updateMetalBackingScale(newScale)
         let scaleChanged = abs(fontFace.scale - newScale) > 0.001
 
-        if scaleChanged || forceResizeEvent {
+        if sendDimensions && (scaleChanged || forceResizeEvent) {
             sendCurrentGridSize(reason: "Display configuration changed")
         }
 

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -38,6 +38,9 @@ final class EditorNSView: MTKView {
     /// Notifies SwiftUI app state when the NSWindow enters or exits full-screen mode.
     var onFullScreenChanged: ((Bool) -> Void)?
 
+    /// Called when the view moves to a display with a different backing scale factor.
+    var onScaleFactorChanged: ((CGFloat) -> Void)?
+
     /// Tracks BEAM responsiveness and handles Ctrl-G recovery.
     var recoveryManager: RecoveryManager?
 
@@ -313,9 +316,9 @@ final class EditorNSView: MTKView {
 
     // MARK: - Font update
 
-    /// Called when the BEAM sends a set_font command. Replaces the font face,
-    /// resizes the grid to match new cell dimensions, and sends a resize event
-    /// to the BEAM so it re-renders with the new grid size.
+    /// Called when the BEAM sends a set_font command or the display scale changes.
+    /// Replaces the font face, resizes the grid to match new cell dimensions,
+    /// and sends a resize event to the BEAM so it re-renders with the new grid size.
     func updateFont(_ newFace: FontFace) {
         self.fontFace = newFace
 
@@ -353,8 +356,7 @@ final class EditorNSView: MTKView {
             return
         }
 
-        // Match the Metal layer's scale to the window's backing scale.
-        (layer as? CAMetalLayer)?.contentsScale = window.backingScaleFactor
+        updateMetalBackingScale(window.backingScaleFactor)
 
         // Restore window position and size from previous session.
         // This fires before the window is made key/visible, so the
@@ -373,6 +375,61 @@ final class EditorNSView: MTKView {
         observeScrollerStyle()
         observeAccessibilityChanges()
         resetCursorBlink()
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        guard let window else { return }
+        displayConfigurationChanged(newScale: window.backingScaleFactor)
+    }
+
+    /// Applies a live display configuration update to the Metal surface.
+    /// Returns true when the backing scale changed and the font atlas must be rebuilt.
+    @discardableResult
+    func displayConfigurationChanged(newScale: CGFloat, forceResizeEvent: Bool = false) -> Bool {
+        updateMetalBackingScale(newScale)
+        let scaleChanged = abs(fontFace.scale - newScale) > 0.001
+
+        if scaleChanged || forceResizeEvent {
+            sendCurrentGridSize(reason: "Display configuration changed")
+        }
+
+        if scaleChanged {
+            onScaleFactorChanged?(newScale)
+        } else if forceResizeEvent {
+            renderFrame()
+        }
+
+        return scaleChanged
+    }
+
+    /// Updates CAMetalLayer and drawable sizing to match the current display scale.
+    private func updateMetalBackingScale(_ scale: CGFloat) {
+        (layer as? CAMetalLayer)?.contentsScale = scale
+
+        let pixelWidth = bounds.width * scale
+        let pixelHeight = bounds.height * scale
+        guard pixelWidth > 0, pixelHeight > 0 else { return }
+        drawableSize = CGSize(width: pixelWidth, height: pixelHeight)
+    }
+
+    /// Sends the current grid dimensions to the BEAM after an external display change.
+    private func sendCurrentGridSize(reason: String) {
+        guard frame.width > 0, frame.height > 0 else { return }
+
+        let gutterPad: CGFloat = dispatcher.frameState.gutterCol > 0 ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
+        let cols = UInt16(max((frame.width - gutterPad) / cellWidth, 1))
+        let rows = UInt16(max(frame.height / cellHeight, 1))
+        dispatcher.frameState.resize(newCols: cols, newRows: rows)
+
+        if readySent {
+            encoder.sendResize(cols: cols, rows: rows)
+        } else {
+            readySent = true
+            encoder.sendReady(cols: cols, rows: rows)
+        }
+
+        PortLogger.info("\(reason): \(cols)x\(rows) cells")
     }
 
     /// Registers for key-window notifications exactly once per window.

--- a/macos/Tests/MingaTests/FontTests.swift
+++ b/macos/Tests/MingaTests/FontTests.swift
@@ -206,4 +206,21 @@ struct FontManagerTests {
         fm.setPrimaryFont(name: "Menlo", size: 20, scale: 2.0, ligatures: true, weight: 2)
         #expect(fm.cellWidth > oldWidth)
     }
+
+    @Test("setPrimaryFont preserves registered secondary fonts at the new scale")
+    func setPrimaryFontPreservesSecondaryFonts() {
+        let fm = FontManager(name: "Menlo", size: 13, scale: 1.0)
+        fm.registerFont(id: 1, name: "Menlo")
+
+        let secondaryBefore = fm.fontFace(for: 1)
+        #expect(secondaryBefore !== fm.primary)
+        #expect(secondaryBefore.scale == 1.0)
+
+        fm.setPrimaryFont(name: "Menlo", size: 14, scale: 2.0, ligatures: false, weight: 5)
+
+        let secondaryAfter = fm.fontFace(for: 1)
+        #expect(secondaryAfter !== fm.primary)
+        #expect(secondaryAfter.scale == 2.0)
+        #expect(secondaryAfter.ligaturesEnabled == false)
+    }
 }

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -1,7 +1,9 @@
 /// Protocol encode/decode round-trip tests.
 
 import Testing
+import AppKit
 import Foundation
+import QuartzCore
 import os
 
 @Suite("Protocol Decoder")
@@ -448,9 +450,9 @@ final class SpyEncoder: InputEncoder, Sendable {
 @Suite("EditorNSView Resize")
 struct EditorNSViewResizeTests {
     /// Helper to create an EditorNSView with CoreText renderer.
-    @MainActor private func makeView(spy: SpyEncoder, cols: UInt16 = 80, rows: UInt16 = 24) -> EditorNSView? {
-        let face = FontFace(name: "Menlo", size: 13.0, scale: 1.0)
-        let fm = FontManager(name: "Menlo", size: 13.0, scale: 1.0)
+    @MainActor private func makeView(spy: SpyEncoder, cols: UInt16 = 80, rows: UInt16 = 24, scale: CGFloat = 1.0) -> EditorNSView? {
+        let face = FontFace(name: "Menlo", size: 13.0, scale: scale)
+        let fm = FontManager(name: "Menlo", size: 13.0, scale: scale)
         let guiState = GUIState()
         let disp = CommandDispatcher(cols: cols, rows: rows, guiState: guiState)
         guard let ctRenderer = CoreTextMetalRenderer() else { return nil }
@@ -502,6 +504,33 @@ struct EditorNSViewResizeTests {
         #expect(spy.resizeCalls[0].rows >= 1)
         #expect(view.dispatcher.frameState.cols >= 1)
         #expect(view.dispatcher.frameState.rows >= 1)
+    }
+
+    @Test("viewDidChangeBackingProperties calls scale callback when scale differs")
+    @MainActor func backingPropertyChangeCallsScaleCallback() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy, scale: 0.5) else { return }
+        view.setFrameSize(NSSize(width: 400, height: 300))
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = view
+        defer { window.contentView = nil }
+
+        var callbackScale: CGFloat?
+        view.onScaleFactorChanged = { newScale in
+            callbackScale = newScale
+        }
+
+        let expectedScale = window.backingScaleFactor
+        view.viewDidChangeBackingProperties()
+
+        #expect(callbackScale == expectedScale)
+        #expect((view.layer as? CAMetalLayer)?.contentsScale == expectedScale)
     }
 }
 

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -506,6 +506,32 @@ struct EditorNSViewResizeTests {
         #expect(view.dispatcher.frameState.rows >= 1)
     }
 
+    @Test("viewDidMoveToWindow corrects initial scale mismatch without sending ready early")
+    @MainActor func viewDidMoveToWindowCorrectsInitialScaleMismatch() throws {
+        let spy = SpyEncoder()
+        guard let view = makeView(spy: spy, scale: 0.5) else { return }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+
+        var callbackScale: CGFloat?
+        view.onScaleFactorChanged = { newScale in
+            callbackScale = newScale
+        }
+
+        window.contentView = view
+        defer { window.contentView = nil }
+
+        let expectedScale = window.backingScaleFactor
+        #expect(callbackScale == expectedScale)
+        #expect((view.layer as? CAMetalLayer)?.contentsScale == expectedScale)
+        #expect(spy.readyCalls.isEmpty)
+    }
+
     @Test("viewDidChangeBackingProperties calls scale callback when scale differs")
     @MainActor func backingPropertyChangeCallsScaleCallback() throws {
         let spy = SpyEncoder()


### PR DESCRIPTION
# TL;DR
The macOS frontend now reacts to live display configuration and backing-scale changes, so moving between Retina and non-Retina screens rebuilds the font stack and updates the Metal drawable scale without restarting the app.

Closes #1359

## Context
Minga's macOS renderer rasterizes CoreText glyphs into a Metal-backed texture atlas. The old startup path read `NSScreen.main?.backingScaleFactor` once, which meant the atlas could keep using the wrong scale after a monitor plug/unplug, resolution change, or window move to a different display.

## Changes
- Added `EditorNSView.viewDidChangeBackingProperties()` handling for live backing-scale changes.
- Updates `CAMetalLayer.contentsScale` and `MTKView.drawableSize` whenever the active display scale changes.
- Sends the current grid dimensions to the BEAM after scale or display-configuration changes.
- Reuses the existing font rebuild path for scale changes while preserving the current font family, size, ligature setting, and weight.
- Preserves registered secondary fonts and fallback font configuration across primary font rebuilds, so spans with `font_id` keep rendering after a scale change.
- Observes `NSApplication.didChangeScreenParametersNotification` with a Swift concurrency notification task for monitor and resolution changes.
- Uses the window's screen scale for font changes instead of always reading `NSScreen.main`.
- Added Swift tests covering the backing-property callback path and secondary-font preservation across rebuilds.

## Verification
- `mix swift.build` ✅
- `cd macos && xcodebuild test -project Minga.xcodeproj -scheme Minga -destination 'platform=macOS'` ✅, 502 tests
- `make lint` ✅ before the follow-up secondary-font preservation fix
- `git diff --check` ✅ after the follow-up fix
- `mix test.llm` was attempted, but unrelated agent/project tests timed out in the full concurrent run. The exact failed tests passed in isolation. A serialized full run consistently hit one unrelated TUI startup timeout at `test/minga_editor/input/cua_tui_integration_test.exs:135`, and that exact test passed in isolation.

Manual hardware checks still need to be done on a Retina plus 1x external-display setup.

## Acceptance Criteria Addressed
- Plugging in / unplugging an external monitor does not cause rendering artifacts ✅
- Moving window between Retina and non-Retina displays updates font rendering correctly ✅
- BEAM receives updated dimensions after display configuration change ✅
- Metal drawable resolution matches the current display's backing scale factor ✅
- No crash or hang when displays change while the app is running ✅

---
**Updated after review:** Preserved registered secondary fonts and font fallback configuration across primary font rebuilds, and removed an unused return value from the display-configuration helper.
