### PR TITLE
Replace percent matching with parser match items

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -58,6 +58,13 @@ The frontend runs as a child process of the BEAM. Communication uses stdin (BEAM
 | `0x24` | set_injection_query | 5 + query_len | Set a custom injection query |
 | `0x25` | query_language_at | 9 | Query the language at a byte offset |
 | `0x26` | edit_buffer | 7 + variable | Incremental edit deltas |
+| `0x28` | set_fold_query | 5 + query_len | Set a custom fold query |
+| `0x29` | set_indent_query | 5 + query_len | Set a custom indent query |
+| `0x2A` | request_indent | 13 | Request indent level for a line |
+| `0x2B` | set_textobject_query | 5 + query_len | Set a custom text object query |
+| `0x2C` | request_textobject | variable | Request a text object range |
+| `0x2D` | close_buffer | 5 | Free parser state for a buffer |
+| `0x2E` | request_match_item | 17 | Request structural delimiter, keyword, quote, or tag match |
 
 ### Frontend → BEAM (Input Events)
 
@@ -83,7 +90,9 @@ The frontend runs as a child process of the BEAM. Communication uses stdin (BEAM
 | `0x37` | indent_result | 13 | Indent level result for a line |
 | `0x38` | textobject_result | variable | Text object range result (or nil) |
 | `0x39` | textobject_positions | 9 + count × 9 | Proactive text object position cache |
+| `0x3A` | conceal_spans | variable | Conceal byte ranges and replacement text |
 | `0x3B` | request_reparse | 5 | Parser requests full reparse after stale edit deltas |
+| `0x3C` | match_item_result | 6 or 14 | Structural match position result (or nil) |
 
 ### Frontend → BEAM (Diagnostics)
 
@@ -582,6 +591,22 @@ Total size: 9 + count × 9 bytes.
 
 **Behavior:** The Zig parser runs the `textobjects.scm` query against the parse tree and collects the start positions of all `.around` captures (e.g., `@function.around`, `@class.around`). Entries are sorted by (row, col) before sending. The BEAM decodes them into a `%{atom => [{row, col}]}` map and stores them on the active window struct. Navigation commands (`]f`, `[f`, etc.) scan this cached data with no further IPC to Zig.
 
+### `0x3C` match_item_result
+
+Response to `request_match_item`. The parser returns one cursor position for the matching structural item, or `found = 0` when the cursor is not on a matchable item or the buffer has no grammar.
+
+```
+opcode:     u8  = 0x3C
+request_id: u32           correlation ID from the request
+found:      u8            1 if a match was found, 0 otherwise
+row:        u32           present only when found = 1
+col:        u32           present only when found = 1
+```
+
+Total size: 6 bytes when not found, 14 bytes when found.
+
+**Behavior:** Used by `%` in normal, visual, and operator-pending modes. The Zig parser walks the tree-sitter AST to match structural brackets, block keywords such as `def`/`end`, string delimiters, and HTML/XML tags without falling back to text scanning.
+
 ### `0x3B` request_reparse
 
 Sent by the parser when it receives an `edit_buffer` command with stale edit deltas (byte offsets that don't match the parser's stored source for that buffer). This typically happens after system sleep/wake, when the BEAM's view of the buffer has drifted from the parser's. The parser discards the buffer's tree and source and asks the BEAM to resend the full content via `parse_buffer`.
@@ -641,7 +666,7 @@ Total size: 4 + msg_len bytes.
 
 ### Current design
 
-Tree-sitter parsing runs in a dedicated `minga-parser` Zig process, separate from the rendering frontend. The renderer process handles only render commands (`0x10`-`0x1B` plus GUI chrome `0x70`-`0x78`). The parser process handles highlight commands (`0x20`-`0x26`) and sends highlight responses (`0x30`-`0x3B`). Both use the same `{:packet, 4}` framing on their respective stdin/stdout pipes. The BEAM manages both Port processes, routing commands to the appropriate one.
+Tree-sitter parsing runs in a dedicated `minga-parser` Zig process, separate from the rendering frontend. The renderer process handles only render commands (`0x10`-`0x1B` plus GUI chrome `0x70`-`0x78`). The parser process handles highlight commands (`0x20`-`0x2E`) and sends highlight responses (`0x30`-`0x3C`). Both use the same `{:packet, 4}` framing on their respective stdin/stdout pipes. The BEAM manages both Port processes, routing commands to the appropriate one.
 
 This separation means rendering frontends (Swift/Metal, GTK4, Zig/libvaxis) only need to implement render commands. Tree-sitter parsing is handled by the shared parser process regardless of which frontend is active.
 

--- a/lib/minga/editing/motion.ex
+++ b/lib/minga/editing/motion.ex
@@ -260,13 +260,15 @@ defmodule Minga.Editing.Motion do
   defdelegate till_char_backward(buf, pos, char), to: Char
 
   @doc """
-  Jump to the matching bracket/paren/brace (Vim's `%`).
+  No-op pure fallback for `%` matching.
+
+  The editor command layer resolves `%` through tree-sitter because it owns the active parser buffer id. Pure motion callers intentionally get no text-scanning fallback.
 
   ## Examples
 
       iex> buf = Minga.Buffer.Document.new("(hello)")
       iex> Minga.Editing.Motion.match_bracket(buf, {0, 0})
-      {0, 6}
+      {0, 0}
   """
   @spec match_bracket(Readable.t(), position()) :: position()
   defdelegate match_bracket(buf, pos), to: Char

--- a/lib/minga/editing/motion/char.ex
+++ b/lib/minga/editing/motion/char.ex
@@ -7,24 +7,10 @@ defmodule Minga.Editing.Motion.Char do
   """
 
   alias Minga.Core.Unicode
-  alias Minga.Editing.Motion.Helpers
   alias Minga.Editing.Text.Readable
 
   @typedoc "A zero-indexed {line, byte_col} cursor position."
   @type position :: {non_neg_integer(), non_neg_integer()}
-
-  @bracket_pairs %{
-    "(" => {"(", ")", :forward},
-    ")" => {"(", ")", :backward},
-    "[" => {"[", "]", :forward},
-    "]" => {"[", "]", :backward},
-    "{" => {"{", "}", :forward},
-    "}" => {"{", "}", :backward},
-    "<" => {"<", ">", :forward},
-    ">" => {"<", ">", :backward}
-  }
-
-  @bracket_chars MapSet.new(["(", ")", "[", "]", "{", "}", "<", ">"])
 
   @doc """
   Move forward to the next occurrence of `char` on the current line (Vim's `f`).
@@ -124,60 +110,12 @@ defmodule Minga.Editing.Motion.Char do
   end
 
   @doc """
-  Jump to the matching bracket/paren/brace (Vim's `%`).
+  Tree-sitter-backed `%` matching is resolved by the editor command layer, which has the active parser buffer id.
 
-  Scans forward from cursor to find the first bracket character, then
-  finds its match counting nesting. Returns original position if no
-  bracket is found or match is unbalanced.
-
-  ## Examples
-
-      iex> buf = Minga.Buffer.Document.new("(hello)")
-      iex> Minga.Editing.Motion.Char.match_bracket(buf, {0, 0})
-      {0, 6}
+  Pure motion callers keep the old arity as a no-op because there is no text-scanning fallback for grammar-less buffers.
   """
   @spec match_bracket(Readable.t(), position()) :: position()
-  def match_bracket(buf, {line, col} = pos) do
-    current_line_text = Readable.line_at(buf, line) || ""
-    {graphemes, byte_offsets} = Helpers.graphemes_with_byte_offsets(current_line_text)
-    g_col = Helpers.byte_offset_to_grapheme_index(byte_offsets, col)
-
-    case find_bracket_on_line(graphemes, g_col, tuple_size(graphemes)) do
-      nil -> pos
-      bracket_g_idx -> do_match_bracket(buf, pos, graphemes, byte_offsets, bracket_g_idx)
-    end
-  end
-
-  @spec do_match_bracket(Readable.t(), position(), tuple(), tuple(), non_neg_integer()) ::
-          position()
-  defp do_match_bracket(buf, {line, col} = pos, line_graphemes, line_byte_offsets, bracket_g_idx) do
-    bracket_char = elem(line_graphemes, bracket_g_idx)
-
-    case Map.get(@bracket_pairs, bracket_char) do
-      nil ->
-        pos
-
-      {open, close, direction} ->
-        text = Readable.content(buf)
-        {graphemes, byte_offsets} = Helpers.graphemes_with_byte_offsets(text)
-        all_lines = :binary.split(text, "\n", [:global])
-        g_col = Helpers.byte_offset_to_grapheme_index(line_byte_offsets, col)
-        byte_off = Helpers.offset_for(all_lines, line, col)
-        g_offset = Helpers.byte_offset_to_grapheme_index(byte_offsets, byte_off)
-        abs_g_offset = g_offset - g_col + bracket_g_idx
-
-        case scan_for_match(graphemes, abs_g_offset, open, close, direction) do
-          nil ->
-            pos
-
-          match_g_idx ->
-            match_byte =
-              Helpers.grapheme_index_to_byte_offset(byte_offsets, match_g_idx, byte_size(text))
-
-            Readable.offset_to_position(buf, match_byte)
-        end
-    end
-  end
+  def match_bracket(_buf, pos), do: pos
 
   # ── Private helpers ──────────────────────────────────────────────────────────
 
@@ -240,103 +178,5 @@ defmodule Minga.Editing.Motion.Char do
       nil ->
         last_match
     end
-  end
-
-  @spec find_bracket_on_line(tuple(), non_neg_integer(), non_neg_integer()) ::
-          non_neg_integer() | nil
-  defp find_bracket_on_line(_graphemes, col, size) when col >= size, do: nil
-
-  defp find_bracket_on_line(graphemes, col, size) do
-    g = elem(graphemes, col)
-
-    if MapSet.member?(@bracket_chars, g) do
-      col
-    else
-      find_bracket_on_line(graphemes, col + 1, size)
-    end
-  end
-
-  @spec scan_for_match(
-          tuple(),
-          non_neg_integer(),
-          String.t(),
-          String.t(),
-          :forward | :backward
-        ) :: non_neg_integer() | nil
-  defp scan_for_match(graphemes, offset, open, close, :forward) do
-    do_scan_forward(graphemes, offset + 1, tuple_size(graphemes), open, close, 1)
-  end
-
-  defp scan_for_match(graphemes, offset, open, close, :backward) do
-    do_scan_backward(graphemes, offset - 1, open, close, 1)
-  end
-
-  @spec do_scan_forward(
-          tuple(),
-          non_neg_integer(),
-          non_neg_integer(),
-          String.t(),
-          String.t(),
-          non_neg_integer()
-        ) :: non_neg_integer() | nil
-  defp do_scan_forward(_graphemes, idx, total, _open, _close, _depth) when idx >= total, do: nil
-
-  defp do_scan_forward(graphemes, idx, total, open, close, depth) do
-    g = elem(graphemes, idx)
-    do_scan_forward_match(graphemes, idx, total, open, close, depth, g)
-  end
-
-  @spec do_scan_forward_match(
-          tuple(),
-          non_neg_integer(),
-          non_neg_integer(),
-          String.t(),
-          String.t(),
-          non_neg_integer(),
-          String.t()
-        ) :: non_neg_integer() | nil
-  defp do_scan_forward_match(_graphemes, idx, _total, _open, close, 1, g) when g == close, do: idx
-
-  defp do_scan_forward_match(graphemes, idx, total, open, close, depth, g) when g == close do
-    do_scan_forward(graphemes, idx + 1, total, open, close, depth - 1)
-  end
-
-  defp do_scan_forward_match(graphemes, idx, total, open, close, depth, g) when g == open do
-    do_scan_forward(graphemes, idx + 1, total, open, close, depth + 1)
-  end
-
-  defp do_scan_forward_match(graphemes, idx, total, open, close, depth, _g) do
-    do_scan_forward(graphemes, idx + 1, total, open, close, depth)
-  end
-
-  @spec do_scan_backward(tuple(), integer(), String.t(), String.t(), non_neg_integer()) ::
-          non_neg_integer() | nil
-  defp do_scan_backward(_graphemes, idx, _open, _close, _depth) when idx < 0, do: nil
-
-  defp do_scan_backward(graphemes, idx, open, close, depth) do
-    g = elem(graphemes, idx)
-    do_scan_backward_match(graphemes, idx, open, close, depth, g)
-  end
-
-  @spec do_scan_backward_match(
-          tuple(),
-          integer(),
-          String.t(),
-          String.t(),
-          non_neg_integer(),
-          String.t()
-        ) :: non_neg_integer() | nil
-  defp do_scan_backward_match(_graphemes, idx, open, _close, 1, g) when g == open, do: idx
-
-  defp do_scan_backward_match(graphemes, idx, open, close, depth, g) when g == open do
-    do_scan_backward(graphemes, idx - 1, open, close, depth - 1)
-  end
-
-  defp do_scan_backward_match(graphemes, idx, open, close, depth, g) when g == close do
-    do_scan_backward(graphemes, idx - 1, open, close, depth + 1)
-  end
-
-  defp do_scan_backward_match(graphemes, idx, open, close, depth, _g) do
-    do_scan_backward(graphemes, idx - 1, open, close, depth)
   end
 end

--- a/lib/minga/parser/manager.ex
+++ b/lib/minga/parser/manager.ex
@@ -49,6 +49,7 @@ defmodule Minga.Parser.Manager do
   @default_highlight_timeout_ms 50
   @default_indent_request_timeout_ms 2_000
   @default_textobject_request_timeout_ms 2_000
+  @default_match_item_request_timeout_ms 2_000
   @request_client_timeout_slack_ms 50
 
   @typedoc "Options for starting the parser manager."
@@ -210,6 +211,28 @@ defmodule Minga.Parser.Manager do
   end
 
   @doc """
+  Requests the structural match item at the given buffer position synchronously.
+
+  Returns `{row, col}` for the matched delimiter/keyword/tag/quote, or `nil` if no tree-sitter match is available.
+  """
+  @spec request_match_item(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          GenServer.server()
+        ) :: {non_neg_integer(), non_neg_integer()} | nil
+  def request_match_item(buffer_id, row, col, server \\ __MODULE__)
+      when is_integer(buffer_id) and is_integer(row) and is_integer(col) do
+    GenServer.call(
+      server,
+      {:request_match_item, buffer_id, row, col, @default_match_item_request_timeout_ms},
+      @default_match_item_request_timeout_ms + @request_client_timeout_slack_ms
+    )
+  catch
+    :exit, _ -> nil
+  end
+
+  @doc """
   Sets the active tree-sitter language for a buffer.
   """
   @spec set_language(non_neg_integer(), String.t(), GenServer.server()) :: :ok
@@ -365,12 +388,7 @@ defmodule Minga.Parser.Manager do
   def handle_call({:request_indent, buffer_id, line, timeout_ms}, from, state) do
     request_id = state.next_request_id
     cmd = Protocol.encode_request_indent(buffer_id, request_id, line)
-    Port.command(state.port, cmd)
-
-    pending = Map.put(state.pending_requests, request_id, from)
-    Process.send_after(self(), {:request_timeout, request_id}, timeout_ms)
-
-    {:noreply, %{state | next_request_id: request_id + 1, pending_requests: pending}}
+    enqueue_pending_request(state, from, request_id, cmd, timeout_ms)
   end
 
   def handle_call(
@@ -388,12 +406,21 @@ defmodule Minga.Parser.Manager do
       ) do
     request_id = state.next_request_id
     cmd = Protocol.encode_request_textobject(buffer_id, request_id, row, col, capture_name)
-    Port.command(state.port, cmd)
+    enqueue_pending_request(state, from, request_id, cmd, timeout_ms)
+  end
 
-    pending = Map.put(state.pending_requests, request_id, from)
-    Process.send_after(self(), {:request_timeout, request_id}, timeout_ms)
+  def handle_call(
+        {:request_match_item, _buffer_id, _row, _col, _timeout_ms},
+        _from,
+        %{port: nil} = state
+      ) do
+    {:reply, nil, state}
+  end
 
-    {:noreply, %{state | next_request_id: request_id + 1, pending_requests: pending}}
+  def handle_call({:request_match_item, buffer_id, row, col, timeout_ms}, from, state) do
+    request_id = state.next_request_id
+    cmd = Protocol.encode_request_match_item(buffer_id, request_id, row, col)
+    enqueue_pending_request(state, from, request_id, cmd, timeout_ms)
   end
 
   def handle_call({:highlight_source, _language, _source, _timeout}, _from, %{port: nil} = state) do
@@ -466,6 +493,9 @@ defmodule Minga.Parser.Manager do
         reply_to_pending_request(state, request_id, indent_level)
 
       {:ok, {:textobject_result, request_id, result}} ->
+        reply_to_pending_request(state, request_id, result)
+
+      {:ok, {:match_item_result, request_id, result}} ->
         reply_to_pending_request(state, request_id, result)
 
       {:ok, {:highlight_names, _buffer_id, _names} = event} ->
@@ -839,6 +869,20 @@ defmodule Minga.Parser.Manager do
           Protocol.encode_parse_buffer(buffer_id, 0, text)
         ]
     end
+  end
+
+  @spec enqueue_pending_request(
+          State.t(),
+          GenServer.from(),
+          non_neg_integer(),
+          binary(),
+          pos_integer()
+        ) :: {:noreply, State.t()}
+  defp enqueue_pending_request(state, from, request_id, cmd, timeout_ms) do
+    Port.command(state.port, cmd)
+    pending = Map.put(state.pending_requests, request_id, from)
+    Process.send_after(self(), {:request_timeout, request_id}, timeout_ms)
+    {:noreply, %{state | next_request_id: request_id + 1, pending_requests: pending}}
   end
 
   @spec fail_pending_requests(State.t()) :: State.t()

--- a/lib/minga/parser/protocol.ex
+++ b/lib/minga/parser/protocol.ex
@@ -29,6 +29,7 @@ defmodule Minga.Parser.Protocol do
   @op_set_textobject_query 0x2B
   @op_request_textobject 0x2C
   @op_close_buffer 0x2D
+  @op_request_match_item 0x2E
 
   # ── Opcodes: responses (Zig parser → BEAM) ──
 
@@ -43,6 +44,7 @@ defmodule Minga.Parser.Protocol do
   @op_textobject_positions 0x39
   @op_conceal_spans 0x3A
   @op_request_reparse 0x3B
+  @op_match_item_result 0x3C
 
   # Log messages (Zig → BEAM)
   @op_log_message 0x60
@@ -171,6 +173,19 @@ defmodule Minga.Parser.Protocol do
       byte_size(capture_name)::16, capture_name::binary>>
   end
 
+  @doc "Encodes a request_match_item command: buffer_id(4) + request_id(4) + row(4) + col(4)."
+  @spec encode_request_match_item(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: binary()
+  def encode_request_match_item(buffer_id, request_id, row, col)
+      when is_integer(buffer_id) and buffer_id >= 0 and
+             is_integer(request_id) and is_integer(row) and is_integer(col) do
+    <<@op_request_match_item, buffer_id::32, request_id::32, row::32, col::32>>
+  end
+
   @doc "Encodes a load_grammar command."
   @spec encode_load_grammar(String.t(), String.t()) :: binary()
   def encode_load_grammar(name, path) when is_binary(name) and is_binary(path) do
@@ -253,6 +268,14 @@ defmodule Minga.Parser.Protocol do
 
   def decode_event(<<@op_textobject_result, request_id::32, 0>>) do
     {:ok, {:textobject_result, request_id, nil}}
+  end
+
+  def decode_event(<<@op_match_item_result, request_id::32, 1, row::32, col::32>>) do
+    {:ok, {:match_item_result, request_id, {row, col}}}
+  end
+
+  def decode_event(<<@op_match_item_result, request_id::32, 0>>) do
+    {:ok, {:match_item_result, request_id, nil}}
   end
 
   def decode_event(

--- a/lib/minga_editor/commands/editing.ex
+++ b/lib/minga_editor/commands/editing.ex
@@ -327,12 +327,11 @@ defmodule MingaEditor.Commands.Editing do
   # ── Indent / dedent (single line) ────────────────────────────────────────
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, :indent_line) do
-    tw = tab_width(buf)
-    indent = String.duplicate(" ", tw)
+    {indent, indent_bytes} = indent_string(buf)
     {line, col} = Buffer.cursor(buf)
     Buffer.move_to(buf, {line, 0})
-    Buffer.insert_char(buf, indent)
-    Buffer.move_to(buf, {line, col + tw})
+    Buffer.insert_text(buf, indent)
+    Buffer.move_to(buf, {line, col + indent_bytes})
     state
   end
 
@@ -366,26 +365,24 @@ defmodule MingaEditor.Commands.Editing do
   end
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, {:indent_motion, motion}) do
-    gb = Buffer.snapshot(buf)
-    cursor = Document.cursor(gb)
-    target = Helpers.resolve_motion(gb, cursor, motion)
-    {cursor_line, _} = cursor
-    {target_line, _} = target
-    start_line = min(cursor_line, target_line)
-    end_line = max(cursor_line, target_line)
-    do_indent_lines(buf, start_line, end_line)
+    {state, range} = motion_line_range(state, buf, motion)
+
+    case range do
+      nil -> :ok
+      {start_line, end_line} -> do_indent_lines(buf, start_line, end_line)
+    end
+
     state
   end
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, {:dedent_motion, motion}) do
-    gb = Buffer.snapshot(buf)
-    cursor = Document.cursor(gb)
-    target = Helpers.resolve_motion(gb, cursor, motion)
-    {cursor_line, _} = cursor
-    {target_line, _} = target
-    start_line = min(cursor_line, target_line)
-    end_line = max(cursor_line, target_line)
-    do_dedent_lines(buf, start_line, end_line)
+    {state, range} = motion_line_range(state, buf, motion)
+
+    case range do
+      nil -> :ok
+      {start_line, end_line} -> do_dedent_lines(buf, start_line, end_line)
+    end
+
     state
   end
 
@@ -430,14 +427,13 @@ defmodule MingaEditor.Commands.Editing do
   end
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, {:reindent_motion, motion}) do
-    gb = Buffer.snapshot(buf)
-    cursor = Document.cursor(gb)
-    target = Helpers.resolve_motion(gb, cursor, motion)
-    {cursor_line, _} = cursor
-    {target_line, _} = target
-    start_line = min(cursor_line, target_line)
-    end_line = max(cursor_line, target_line)
-    do_reindent_lines(state, buf, start_line, end_line)
+    {state, range} = motion_line_range(state, buf, motion)
+
+    case range do
+      nil -> :ok
+      {start_line, end_line} -> do_reindent_lines(state, buf, start_line, end_line)
+    end
+
     state
   end
 
@@ -486,11 +482,13 @@ defmodule MingaEditor.Commands.Editing do
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, {:comment_motion, motion})
       when is_pid(buf) do
-    {cursor_line, _col} = Buffer.cursor(buf)
-    target_line = resolve_motion_line(buf, motion, cursor_line)
-    start_line = min(cursor_line, target_line)
-    end_line = max(cursor_line, target_line)
-    toggle_comment(buf, start_line, end_line, state)
+    {state, range} = motion_line_range(state, buf, motion)
+
+    case range do
+      nil -> :ok
+      {start_line, end_line} -> toggle_comment(buf, start_line, end_line, state)
+    end
+
     state
   end
 
@@ -663,6 +661,30 @@ defmodule MingaEditor.Commands.Editing do
     :ok
   end
 
+  # ── Private motion range helpers ─────────────────────────────────────────
+
+  @spec motion_line_range(state(), pid(), atom()) ::
+          {state(), {non_neg_integer(), non_neg_integer()} | nil}
+  defp motion_line_range(state, buf, motion) do
+    state = Helpers.setup_for_motion(state, motion)
+    gb = Buffer.snapshot(buf)
+    cursor = Document.cursor(gb)
+    buffer_id = Helpers.buffer_id_for_motion(state, buf, motion)
+
+    range =
+      case Helpers.resolve_motion_target(gb, cursor, motion, buffer_id) do
+        nil ->
+          nil
+
+        target ->
+          {cursor_line, _} = cursor
+          {target_line, _} = target
+          {min(cursor_line, target_line), max(cursor_line, target_line)}
+      end
+
+    {state, range}
+  end
+
   # ── Private reindent helpers ──────────────────────────────────────────────
 
   @keystroke_indent_timeout_ms 200
@@ -758,7 +780,7 @@ defmodule MingaEditor.Commands.Editing do
 
     for line <- start_line..end_line do
       Buffer.move_to(buf, {line, 0})
-      Buffer.insert_char(buf, indent)
+      Buffer.insert_text(buf, indent)
     end
 
     new_col =
@@ -821,7 +843,7 @@ defmodule MingaEditor.Commands.Editing do
   # If the line starts with a tab, remove 1 character.
   # Otherwise, remove up to tab_width spaces.
   @spec dedent_amount(pid(), String.t()) :: non_neg_integer()
-  defp dedent_amount(buf, <<"\t", _::binary>>), do: if(uses_tabs?(buf), do: 1, else: 1)
+  defp dedent_amount(_buf, <<"\t", _::binary>>), do: 1
 
   defp dedent_amount(buf, text) do
     min(count_leading_spaces(text), tab_width(buf))
@@ -866,61 +888,6 @@ defmodule MingaEditor.Commands.Editing do
     Buffer.get_option(buf, :tab_width)
   catch
     :exit, _ -> 2
-  end
-
-  @spec resolve_motion_line(pid(), atom(), non_neg_integer()) :: non_neg_integer()
-  defp resolve_motion_line(_buf, :line_down, cursor_line), do: cursor_line + 1
-
-  defp resolve_motion_line(_buf, :line_up, cursor_line),
-    do: max(0, cursor_line - 1)
-
-  defp resolve_motion_line(_buf, :document_start, _cursor_line), do: 0
-
-  defp resolve_motion_line(buf, :document_end, _cursor_line) do
-    max(0, Buffer.line_count(buf) - 1)
-  end
-
-  defp resolve_motion_line(buf, :paragraph_forward, cursor_line) do
-    content = Buffer.content(buf)
-    lines = String.split(content, "\n")
-    find_paragraph_boundary(lines, cursor_line, :forward)
-  end
-
-  defp resolve_motion_line(buf, :paragraph_backward, cursor_line) do
-    content = Buffer.content(buf)
-    lines = String.split(content, "\n")
-    find_paragraph_boundary(lines, cursor_line, :backward)
-  end
-
-  defp resolve_motion_line(_buf, _motion, cursor_line), do: cursor_line
-
-  @spec find_paragraph_boundary([String.t()], non_neg_integer(), :forward | :backward) ::
-          non_neg_integer()
-  defp find_paragraph_boundary(lines, cursor_line, :forward) do
-    total = length(lines)
-
-    lines
-    |> Enum.drop(cursor_line + 1)
-    |> Enum.with_index(cursor_line + 1)
-    |> Enum.drop_while(fn {line, _idx} -> String.trim(line) != "" end)
-    |> Enum.find(fn {line, _idx} -> String.trim(line) == "" end)
-    |> case do
-      {_, idx} -> idx
-      nil -> max(0, total - 1)
-    end
-  end
-
-  defp find_paragraph_boundary(lines, cursor_line, :backward) do
-    lines
-    |> Enum.take(cursor_line)
-    |> Enum.with_index()
-    |> Enum.reverse()
-    |> Enum.drop_while(fn {line, _idx} -> String.trim(line) != "" end)
-    |> Enum.find(fn {line, _idx} -> String.trim(line) == "" end)
-    |> case do
-      {_, idx} -> idx
-      nil -> 0
-    end
   end
 
   # ── Paste helpers ──────────────────────────────────────────────────────────

--- a/lib/minga_editor/commands/helpers.ex
+++ b/lib/minga_editor/commands/helpers.ex
@@ -377,48 +377,96 @@ defmodule MingaEditor.Commands.Helpers do
     Buffer.move_to(buf, new_pos)
   end
 
+  @doc "Sets up parser state only for motions that need tree-sitter."
+  @spec setup_for_motion(state(), atom()) :: state()
+  def setup_for_motion(%{workspace: %{buffers: %{active: buf}}} = state, :match_bracket)
+      when is_pid(buf) do
+    if HighlightSync.buffer_id_for(state, buf) == 0 do
+      HighlightSync.setup_for_buffer(state)
+    else
+      state
+    end
+  end
+
+  def setup_for_motion(state, :match_bracket), do: state
+  def setup_for_motion(state, _motion), do: state
+
+  @doc "Returns the parser buffer id only for motions that need tree-sitter."
+  @spec buffer_id_for_motion(state(), pid(), atom()) :: non_neg_integer()
+  def buffer_id_for_motion(state, buf, :match_bracket),
+    do: HighlightSync.buffer_id_for(state, buf)
+
+  def buffer_id_for_motion(_state, _buf, _motion), do: 0
+
   @doc "Resolves a motion atom to a new position in the buffer."
-  @spec resolve_motion(Buffer.document(), Minga.Editing.Motion.position(), atom()) ::
-          Minga.Editing.Motion.position()
-  def resolve_motion(buf, cursor, :word_forward),
+  @spec resolve_motion(
+          Buffer.document(),
+          Minga.Editing.Motion.position(),
+          atom(),
+          non_neg_integer()
+        ) :: Minga.Editing.Motion.position()
+  def resolve_motion(buf, cursor, :word_forward, _buffer_id),
     do: Minga.Editing.word_forward(buf, cursor)
 
-  def resolve_motion(buf, cursor, :word_backward),
+  def resolve_motion(buf, cursor, :word_backward, _buffer_id),
     do: Minga.Editing.word_backward(buf, cursor)
 
-  def resolve_motion(buf, cursor, :word_end), do: Minga.Editing.word_end(buf, cursor)
-  def resolve_motion(buf, cursor, :line_start), do: Minga.Editing.line_start(buf, cursor)
-  def resolve_motion(buf, cursor, :line_end), do: Minga.Editing.line_end(buf, cursor)
-  def resolve_motion(buf, _cursor, :document_start), do: Minga.Editing.document_start(buf)
-  def resolve_motion(buf, _cursor, :document_end), do: Minga.Editing.document_end(buf)
+  def resolve_motion(buf, cursor, :word_end, _buffer_id), do: Minga.Editing.word_end(buf, cursor)
 
-  def resolve_motion(buf, cursor, :first_non_blank),
+  def resolve_motion(buf, cursor, :line_start, _buffer_id),
+    do: Minga.Editing.line_start(buf, cursor)
+
+  def resolve_motion(buf, cursor, :line_end, _buffer_id), do: Minga.Editing.line_end(buf, cursor)
+
+  def resolve_motion(buf, _cursor, :document_start, _buffer_id),
+    do: Minga.Editing.document_start(buf)
+
+  def resolve_motion(buf, _cursor, :document_end, _buffer_id), do: Minga.Editing.document_end(buf)
+
+  def resolve_motion(buf, cursor, :first_non_blank, _buffer_id),
     do: Minga.Editing.first_non_blank(buf, cursor)
 
-  def resolve_motion(_buf, cursor, :half_page_down), do: cursor
-  def resolve_motion(_buf, cursor, :half_page_up), do: cursor
-  def resolve_motion(_buf, cursor, :page_down), do: cursor
-  def resolve_motion(_buf, cursor, :page_up), do: cursor
+  def resolve_motion(_buf, cursor, :half_page_down, _buffer_id), do: cursor
+  def resolve_motion(_buf, cursor, :half_page_up, _buffer_id), do: cursor
+  def resolve_motion(_buf, cursor, :page_down, _buffer_id), do: cursor
+  def resolve_motion(_buf, cursor, :page_up, _buffer_id), do: cursor
 
-  def resolve_motion(buf, cursor, :word_forward_big),
+  def resolve_motion(buf, cursor, :word_forward_big, _buffer_id),
     do: Minga.Editing.word_forward_big(buf, cursor)
 
-  def resolve_motion(buf, cursor, :word_backward_big),
+  def resolve_motion(buf, cursor, :word_backward_big, _buffer_id),
     do: Minga.Editing.word_backward_big(buf, cursor)
 
-  def resolve_motion(buf, cursor, :word_end_big),
+  def resolve_motion(buf, cursor, :word_end_big, _buffer_id),
     do: Minga.Editing.word_end_big(buf, cursor)
 
-  def resolve_motion(buf, cursor, :paragraph_forward),
+  def resolve_motion(buf, cursor, :paragraph_forward, _buffer_id),
     do: Minga.Editing.paragraph_forward(buf, cursor)
 
-  def resolve_motion(buf, cursor, :paragraph_backward),
+  def resolve_motion(buf, cursor, :paragraph_backward, _buffer_id),
     do: Minga.Editing.paragraph_backward(buf, cursor)
 
-  def resolve_motion(buf, cursor, :match_bracket),
-    do: Minga.Editing.match_bracket(buf, cursor)
+  def resolve_motion(_buf, cursor, :match_bracket, buffer_id) do
+    case request_match_item(buffer_id, cursor) do
+      nil -> cursor
+      match -> match
+    end
+  end
 
-  def resolve_motion(_buf, cursor, _unknown), do: cursor
+  def resolve_motion(_buf, cursor, _unknown, _buffer_id), do: cursor
+
+  @doc "Resolves a motion target, preserving no-match results for tree-sitter motions."
+  @spec resolve_motion_target(
+          Buffer.document(),
+          Minga.Editing.Motion.position(),
+          atom(),
+          non_neg_integer()
+        ) :: Minga.Editing.Motion.position() | nil
+  def resolve_motion_target(_buf, cursor, :match_bracket, buffer_id),
+    do: request_match_item(buffer_id, cursor)
+
+  def resolve_motion_target(buf, cursor, motion, buffer_id),
+    do: resolve_motion(buf, cursor, motion, buffer_id)
 
   @doc "Applies a find-char motion in the given direction."
   @spec apply_find_char(pid(), ModeState.find_direction(), String.t()) :: :ok
@@ -450,22 +498,68 @@ defmodule MingaEditor.Commands.Helpers do
   @doc "Applies a delete or yank operator over a motion range."
   @spec apply_operator_motion(pid(), state(), atom(), operator_action()) :: state()
   def apply_operator_motion(buf, state, motion, action) do
+    state = setup_for_motion(state, motion)
     gb = Buffer.snapshot(buf)
     cursor = Document.cursor(gb)
-    target = resolve_motion(gb, cursor, motion)
-    {start_pos, end_pos} = sort_positions(cursor, target)
+    buffer_id = buffer_id_for_motion(state, buf, motion)
 
-    case action do
-      :delete ->
-        text = Document.get_range(gb, start_pos, end_pos)
-        Buffer.delete_range(buf, start_pos, end_pos)
-        put_register(state, text, :delete)
+    case resolve_motion_target(gb, cursor, motion, buffer_id) do
+      nil ->
+        state
 
-      :yank ->
-        text = Document.get_range(gb, start_pos, end_pos)
-        state = put_register(state, text, :yank)
-        maybe_start_yank_flash(state, buf, start_pos, end_pos, :charwise)
+      target ->
+        {start_pos, end_pos} = sort_positions(cursor, target)
+        end_pos = operator_target(gb, motion, end_pos)
+
+        case action do
+          :delete ->
+            text = Document.get_range(gb, start_pos, end_pos)
+            Buffer.delete_range(buf, start_pos, end_pos)
+            put_register(state, text, :delete)
+
+          :yank ->
+            text = Document.get_range(gb, start_pos, end_pos)
+            state = put_register(state, text, :yank)
+            maybe_start_yank_flash(state, buf, start_pos, end_pos, :charwise)
+        end
     end
+  end
+
+  @spec operator_target(Buffer.document(), atom(), Minga.Editing.Motion.position()) ::
+          Minga.Editing.Motion.position()
+  defp operator_target(buf, :match_bracket, {line, col}) do
+    line_text = Document.line_at(buf, line) || ""
+    {line, match_item_operator_col(line_text, col)}
+  end
+
+  defp operator_target(_buf, _motion, target), do: target
+
+  @spec match_item_operator_col(String.t(), non_neg_integer()) :: non_neg_integer()
+  defp match_item_operator_col(line_text, col) when col >= byte_size(line_text), do: col
+
+  defp match_item_operator_col(line_text, col) do
+    if match_item_token_byte?(:binary.at(line_text, col)) do
+      match_item_token_end_col(line_text, col + 1)
+    else
+      col
+    end
+  end
+
+  @spec match_item_token_end_col(String.t(), non_neg_integer()) :: non_neg_integer()
+  defp match_item_token_end_col(line_text, col) when col >= byte_size(line_text),
+    do: byte_size(line_text) - 1
+
+  defp match_item_token_end_col(line_text, col) do
+    if match_item_token_byte?(:binary.at(line_text, col)) do
+      match_item_token_end_col(line_text, col + 1)
+    else
+      col - 1
+    end
+  end
+
+  @spec match_item_token_byte?(byte()) :: boolean()
+  defp match_item_token_byte?(byte) do
+    byte in ?a..?z or byte in ?A..?Z or byte in ?0..?9 or byte in [?_, ?-, ?:]
   end
 
   @doc "Applies a delete or yank operator over a text object range."
@@ -583,5 +677,11 @@ defmodule MingaEditor.Commands.Helpers do
     ParserManager.request_textobject(buffer_id, row, col, capture_name)
   catch
     :exit, _ -> nil
+  end
+
+  @spec request_match_item(non_neg_integer(), Minga.Editing.Motion.position()) ::
+          Minga.Editing.Motion.position() | nil
+  defp request_match_item(buffer_id, {line, col}) do
+    ParserManager.request_match_item(buffer_id, line, col)
   end
 end

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -274,7 +274,13 @@ defmodule MingaEditor.Commands.Movement do
   # ── Bracket matching ──────────────────────────────────────────────────────
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, :match_bracket) do
-    Helpers.apply_motion(buf, &Minga.Editing.match_bracket/2)
+    state = Helpers.setup_for_motion(state, :match_bracket)
+    buffer_id = Helpers.buffer_id_for_motion(state, buf, :match_bracket)
+
+    Helpers.apply_motion(buf, fn gb, cursor ->
+      Helpers.resolve_motion(gb, cursor, :match_bracket, buffer_id)
+    end)
+
     state
   end
 

--- a/lib/minga_editor/frontend/protocol.ex
+++ b/lib/minga_editor/frontend/protocol.ex
@@ -171,6 +171,8 @@ defmodule MingaEditor.Frontend.Protocol do
              result ::
                {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
                | nil}
+          | {:match_item_result, request_id :: non_neg_integer(),
+             result :: {non_neg_integer(), non_neg_integer()} | nil}
           | {:textobject_positions, buffer_id :: non_neg_integer(), version :: non_neg_integer(),
              %{atom() => [{non_neg_integer(), non_neg_integer()}]}}
           | {:request_reparse, buffer_id :: non_neg_integer()}
@@ -498,6 +500,9 @@ defmodule MingaEditor.Frontend.Protocol do
   defdelegate encode_request_textobject(buffer_id, request_id, row, col, capture_name),
     to: Minga.Parser.Protocol
 
+  defdelegate encode_request_match_item(buffer_id, request_id, row, col),
+    to: Minga.Parser.Protocol
+
   defdelegate encode_load_grammar(name, path), to: Minga.Parser.Protocol
 
   defdelegate encode_query_language_at(buffer_id, request_id, byte_offset),
@@ -575,7 +580,7 @@ defmodule MingaEditor.Frontend.Protocol do
   # Parser events are decoded by Minga.Parser.Protocol. Try it first,
   # then fall through to input event decoders.
   def decode_event(<<opcode::8, _rest::binary>> = data)
-      when opcode in 0x30..0x3B or opcode == 0x60 do
+      when opcode in 0x30..0x3C or opcode == 0x60 do
     case Minga.Parser.Protocol.decode_event(data) do
       {:ok, _} = result -> result
       :unknown -> {:error, :unknown_opcode}

--- a/test/minga/editing/motion/char_test.exs
+++ b/test/minga/editing/motion/char_test.exs
@@ -55,51 +55,9 @@ defmodule Minga.Editing.Motion.CharTest do
   end
 
   describe "match_bracket/2" do
-    test "jumps from ( to matching )" do
+    test "returns original position when no parser match is available" do
       b = buf("(hello)")
-      assert Motion.match_bracket(b, {0, 0}) == {0, 6}
-    end
-
-    test "jumps from ) to matching (" do
-      b = buf("(hello)")
-      assert Motion.match_bracket(b, {0, 6}) == {0, 0}
-    end
-
-    test "handles nested brackets" do
-      b = buf("(a (b) c)")
-      assert Motion.match_bracket(b, {0, 0}) == {0, 8}
-      assert Motion.match_bracket(b, {0, 3}) == {0, 5}
-    end
-
-    test "jumps from < to matching >" do
-      b = buf("<div>")
-      assert Motion.match_bracket(b, {0, 0}) == {0, 4}
-    end
-
-    test "jumps from > to matching <" do
-      b = buf("<div>")
-      assert Motion.match_bracket(b, {0, 4}) == {0, 0}
-    end
-
-    test "handles nested angle brackets" do
-      b = buf("<a <b>>")
-      assert Motion.match_bracket(b, {0, 0}) == {0, 6}
-      assert Motion.match_bracket(b, {0, 3}) == {0, 5}
-    end
-
-    test "returns original position when no bracket found" do
-      b = buf("hello world")
       assert Motion.match_bracket(b, {0, 0}) == {0, 0}
-    end
-
-    test "returns original position on unmatched bracket" do
-      b = buf("(hello")
-      assert Motion.match_bracket(b, {0, 0}) == {0, 0}
-    end
-
-    test "works across multiple lines" do
-      b = buf("(\nhello\n)")
-      assert Motion.match_bracket(b, {0, 0}) == {2, 0}
     end
   end
 end

--- a/test/minga/parser/protocol_match_item_test.exs
+++ b/test/minga/parser/protocol_match_item_test.exs
@@ -1,0 +1,25 @@
+defmodule Minga.Parser.ProtocolMatchItemTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Parser.Protocol
+
+  @op_request_match_item 0x2E
+  @op_match_item_result 0x3C
+
+  describe "request_match_item" do
+    test "encodes buffer id, request id, row, and column" do
+      assert <<@op_request_match_item, 7::32, 42::32, 3::32, 11::32>> =
+               Protocol.encode_request_match_item(7, 42, 3, 11)
+    end
+
+    test "decodes a found match_item_result" do
+      payload = <<@op_match_item_result, 42::32, 1, 9::32, 4::32>>
+      assert {:ok, {:match_item_result, 42, {9, 4}}} = Protocol.decode_event(payload)
+    end
+
+    test "decodes an empty match_item_result" do
+      payload = <<@op_match_item_result, 42::32, 0>>
+      assert {:ok, {:match_item_result, 42, nil}} = Protocol.decode_event(payload)
+    end
+  end
+end

--- a/test/minga_editor/commands/editing_test.exs
+++ b/test/minga_editor/commands/editing_test.exs
@@ -283,6 +283,19 @@ defmodule MingaEditor.Commands.EditingTest do
     end
   end
 
+  describe "indent commands" do
+    test ">> respects tab indentation" do
+      {editor, buffer} = start_editor("hello")
+      BufferServer.set_option(buffer, :indent_with, :tabs)
+
+      send_key(editor, ?>)
+      send_key(editor, ?>)
+
+      assert BufferServer.content(buffer) == "\thello"
+      assert BufferServer.cursor(buffer) == {0, 1}
+    end
+  end
+
   describe "linewise paste (dd + p/P)" do
     test "dd then p moves deleted line below current line" do
       {editor, buffer} = start_editor("aaa\nbbb\nccc")

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -703,6 +703,11 @@ defmodule MingaEditor.Frontend.ProtocolTest do
       payload = <<0x30, 0::32, 1::32, 2::32, 0::32, 9::32, 0::16, 0::16, 0::16>>
       assert {:error, :malformed} = Protocol.decode_event(payload)
     end
+
+    test "decode_event match_item_result" do
+      payload = <<0x3C, 42::32, 1, 9::32, 4::32>>
+      assert {:ok, {:match_item_result, 42, {9, 4}}} = Protocol.decode_event(payload)
+    end
   end
 
   describe "log_message protocol" do

--- a/test/minga_editor/integration/match_item_test.exs
+++ b/test/minga_editor/integration/match_item_test.exs
@@ -1,0 +1,132 @@
+defmodule MingaEditor.Integration.MatchItemTest do
+  # Uses the global ParserManager because commands request match items through the production parser.
+  use Minga.Test.EditorCase, async: false
+
+  setup do
+    if Process.whereis(Minga.Parser.Manager) == nil do
+      start_supervised!({Minga.Parser.Manager, []})
+    end
+
+    :ok
+  end
+
+  describe "% match item motion" do
+    test "jumps from Elixir def to matching end" do
+      content = "def foo do\n  :ok\nend\n"
+      ctx = start_editor(content, file_path: tmp_file("match_item.ex", content))
+      assert Minga.Buffer.Server.filetype(ctx.buffer) == :elixir
+      wait_for_highlight(ctx)
+
+      send_keys_sync(ctx, "%")
+
+      assert buffer_cursor(ctx) == {2, 0}
+    end
+
+    test "jumps between string delimiters" do
+      content = "message = \"hello\"\n"
+      ctx = start_editor(content, file_path: tmp_file("match_item.js", content))
+      wait_for_highlight(ctx)
+      assert editor_mode(ctx) == :normal
+      assert buffer_content(ctx) == content
+      send_keys_sync(ctx, "llllllllll")
+      assert buffer_cursor(ctx) == {0, 10}
+
+      send_keys_sync(ctx, "%")
+
+      assert buffer_cursor(ctx) == {0, 16}
+    end
+
+    test "delete operator with match item deletes through keyword" do
+      content = "def foo do\n  :ok\nend\n"
+      ctx = start_editor(content, file_path: tmp_file("match_item_delete.ex", content))
+      wait_for_highlight(ctx)
+
+      send_keys_sync(ctx, "d%")
+
+      assert buffer_content(ctx) == "\n"
+    end
+
+    test "delete operator with reverse match item deletes the full keyword range" do
+      content = "def foo do\n  :ok\nend\n"
+      ctx = start_editor(content, file_path: tmp_file("match_item_reverse_delete.ex", content))
+      wait_for_highlight(ctx)
+
+      send_keys_sync(ctx, "%d%")
+
+      assert buffer_content(ctx) == "\n"
+    end
+
+    test "delete operator with no match is a no-op" do
+      content = "word\n"
+      ctx = start_editor(content, file_path: tmp_file("match_item_no_match.txt", content))
+
+      send_keys_sync(ctx, "d%")
+
+      assert buffer_content(ctx) == content
+      assert buffer_cursor(ctx) == {0, 0}
+    end
+
+    test "comment operator with match item comments the matched keyword range" do
+      content = "def foo do\n  :ok\nend\n"
+      ctx = start_editor(content, file_path: tmp_file("match_item_comment.ex", content))
+      wait_for_highlight(ctx)
+
+      send_keys_sync(ctx, "gc%")
+
+      assert buffer_content(ctx) == "# def foo do\n#   :ok\n# end\n"
+    end
+
+    test "delete operator with tag match item deletes the full tag name token" do
+      content = "<h1>x</h1>\n"
+      ctx = start_editor(content, file_path: tmp_file("match_item_tag_delete.html", content))
+      wait_for_highlight(ctx)
+
+      send_keys_sync(ctx, "ld%")
+
+      assert buffer_content(ctx) == "<>\n"
+    end
+
+    test "visual match item extends selection cursor to match" do
+      content = "def foo do\n  :ok\nend\n"
+      ctx = start_editor(content, file_path: tmp_file("match_item_visual.ex", content))
+      wait_for_highlight(ctx)
+
+      send_keys_sync(ctx, "v%")
+
+      assert editor_mode(ctx) == :visual
+      assert buffer_cursor(ctx) == {2, 0}
+    end
+
+    test "plain text without a grammar is a no-op" do
+      content = "(hello)\n"
+      ctx = start_editor(content, file_path: tmp_file("match_item.txt", content))
+
+      send_keys_sync(ctx, "%")
+
+      assert buffer_cursor(ctx) == {0, 0}
+    end
+  end
+
+  defp wait_for_highlight(ctx) do
+    wait_until(
+      ctx,
+      fn state ->
+        highlight = MingaEditor.HighlightSync.get_active_highlight(state)
+        is_tuple(highlight.spans) and tuple_size(highlight.spans) > 0
+      end,
+      max_attempts: 100,
+      interval_ms: 20
+    )
+  end
+
+  defp tmp_file(name, content) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "minga_match_item_#{System.unique_integer([:positive])}_#{name}"
+      )
+
+    File.write!(path, content)
+    path
+  end
+end

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -756,6 +756,29 @@ pub const Highlighter = struct {
         return best;
     }
 
+    /// Alias for the shared MatchItemResult type.
+    pub const MatchItemResult = protocol.MatchItemResult;
+
+    /// Find the tree-sitter item that structurally matches the delimiter, keyword, quote, or tag at the cursor.
+    pub fn findMatchingItem(self: *Highlighter, row: u32, col: u32) ?MatchItemResult {
+        const tree = self.tree orelse return null;
+        const source = self.current_source orelse return null;
+        const root = c.ts_tree_root_node(tree);
+        const node = nodeAtPoint(root, row, col);
+        if (isNullNode(node)) return null;
+        if (hasCommentAncestor(node)) return null;
+
+        if (matchStringBoundary(node, source, row, col)) |matched| return matched;
+        if (matchHtmlTag(node)) |matched| return resultForNodeStart(matched);
+
+        if (!hasStringAncestorBeforeInterpolation(node)) {
+            if (matchBracketToken(node, source)) |matched| return resultForNodeStart(matched);
+            if (matchKeywordToken(node, source, self.current_language_name)) |matched| return resultForNodeStart(matched);
+        }
+
+        return null;
+    }
+
     /// Alias for the shared TextobjectEntry type (defined in protocol to avoid circular imports).
     pub const TextobjectEntry = protocol.TextobjectEntry;
 
@@ -1554,6 +1577,414 @@ pub const Highlighter = struct {
     }
 };
 
+// ── Match-item helpers ────────────────────────────────────────────────────
+
+fn nodeAtPoint(root: c.TSNode, row: u32, col: u32) c.TSNode {
+    const start = c.TSPoint{ .row = row, .column = col };
+    const end = c.TSPoint{ .row = row, .column = col + 1 };
+    return c.ts_node_descendant_for_point_range(root, start, end);
+}
+
+fn isNullNode(node: c.TSNode) bool {
+    return c.ts_node_is_null(node);
+}
+
+fn nodeType(node: c.TSNode) []const u8 {
+    return std.mem.span(c.ts_node_type(node));
+}
+
+fn nodeText(source: []const u8, node: c.TSNode) []const u8 {
+    const start: usize = @intCast(c.ts_node_start_byte(node));
+    const end: usize = @intCast(c.ts_node_end_byte(node));
+    if (start > end or end > source.len) return "";
+    return source[start..end];
+}
+
+fn resultForNodeStart(node: c.TSNode) protocol.MatchItemResult {
+    const point = c.ts_node_start_point(node);
+    return .{ .row = point.row, .col = point.column };
+}
+
+fn resultForByte(source: []const u8, byte_offset: usize) protocol.MatchItemResult {
+    const point = pointForByte(source, byte_offset);
+    return .{ .row = point.row, .col = point.column };
+}
+
+fn pointForByte(source: []const u8, byte_offset: usize) c.TSPoint {
+    var row: u32 = 0;
+    var col: u32 = 0;
+    var i: usize = 0;
+    const target = @min(byte_offset, source.len);
+    while (i < target) : (i += 1) {
+        if (source[i] == '\n') {
+            row += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return .{ .row = row, .column = col };
+}
+
+fn byteForPoint(source: []const u8, row: u32, col: u32) usize {
+    var current_row: u32 = 0;
+    var current_col: u32 = 0;
+    var i: usize = 0;
+    while (i < source.len) : (i += 1) {
+        if (current_row == row and current_col == col) return i;
+        if (source[i] == '\n') {
+            current_row += 1;
+            current_col = 0;
+        } else {
+            current_col += 1;
+        }
+    }
+    return source.len;
+}
+
+fn hasCommentAncestor(node: c.TSNode) bool {
+    var current = node;
+    while (!isNullNode(current)) {
+        if (isCommentType(nodeType(current))) return true;
+        current = c.ts_node_parent(current);
+    }
+    return false;
+}
+
+fn isCommentType(typ: []const u8) bool {
+    return std.mem.indexOf(u8, typ, "comment") != null;
+}
+
+fn hasStringAncestorBeforeInterpolation(node: c.TSNode) bool {
+    var current = node;
+    while (!isNullNode(current)) {
+        const typ = nodeType(current);
+        if (isInterpolationType(typ)) return false;
+        if (isStringLikeType(typ)) return true;
+        current = c.ts_node_parent(current);
+    }
+    return false;
+}
+
+fn isInterpolationType(typ: []const u8) bool {
+    return std.mem.indexOf(u8, typ, "interpolation") != null or std.mem.eql(u8, typ, "interpolated_expression");
+}
+
+fn isStringLikeType(typ: []const u8) bool {
+    if (std.mem.indexOf(u8, typ, "string") != null and std.mem.indexOf(u8, typ, "content") == null) return true;
+    if (std.mem.indexOf(u8, typ, "heredoc") != null) return true;
+    return std.mem.eql(u8, typ, "char") or std.mem.eql(u8, typ, "quoted_content");
+}
+
+fn matchStringBoundary(node: c.TSNode, source: []const u8, row: u32, col: u32) ?protocol.MatchItemResult {
+    const string_node = nearestStringLikeNode(node) orelse return null;
+    const start: usize = @intCast(c.ts_node_start_byte(string_node));
+    const end: usize = @intCast(c.ts_node_end_byte(string_node));
+    if (end <= start or end > source.len) return null;
+
+    const text = source[start..end];
+    const delim_len = stringDelimiterLen(text);
+    if (delim_len == 0 or text.len < delim_len * 2) return null;
+
+    const cursor_byte = byteForPoint(source, row, col);
+    const close_start = end - delim_len;
+
+    if (cursor_byte >= start and cursor_byte < start + delim_len) {
+        return resultForByte(source, close_start);
+    }
+    if (cursor_byte >= close_start and cursor_byte < end) {
+        return resultForByte(source, start);
+    }
+    return null;
+}
+
+fn nearestStringLikeNode(node: c.TSNode) ?c.TSNode {
+    var current = node;
+    while (!isNullNode(current)) {
+        const typ = nodeType(current);
+        if (isInterpolationType(typ)) return null;
+        if (isStringContentType(typ)) {
+            current = c.ts_node_parent(current);
+            continue;
+        }
+        if (isStringLikeType(typ)) return current;
+        current = c.ts_node_parent(current);
+    }
+    return null;
+}
+
+fn isStringContentType(typ: []const u8) bool {
+    return std.mem.indexOf(u8, typ, "fragment") != null or
+        std.mem.indexOf(u8, typ, "content") != null or
+        std.mem.indexOf(u8, typ, "escape") != null;
+}
+
+fn stringDelimiterLen(text: []const u8) usize {
+    if (std.mem.startsWith(u8, text, "\"\"\"") and std.mem.endsWith(u8, text, "\"\"\"")) return 3;
+    if (std.mem.startsWith(u8, text, "'''") and std.mem.endsWith(u8, text, "'''")) return 3;
+    if (std.mem.startsWith(u8, text, "\"") and std.mem.endsWith(u8, text, "\"")) return 1;
+    if (std.mem.startsWith(u8, text, "'") and std.mem.endsWith(u8, text, "'")) return 1;
+    if (std.mem.startsWith(u8, text, "`") and std.mem.endsWith(u8, text, "`")) return 1;
+    return 0;
+}
+
+fn matchBracketToken(node: c.TSNode, source: []const u8) ?c.TSNode {
+    const token = tokenText(source, node);
+    const pair = bracketPair(token) orelse return null;
+    return matchSiblingToken(node, pair.open, pair.close, pair.forward);
+}
+
+const BracketPair = struct { open: []const u8, close: []const u8, forward: bool };
+
+fn bracketPair(token: []const u8) ?BracketPair {
+    if (std.mem.eql(u8, token, "(")) return .{ .open = "(", .close = ")", .forward = true };
+    if (std.mem.eql(u8, token, ")")) return .{ .open = "(", .close = ")", .forward = false };
+    if (std.mem.eql(u8, token, "[")) return .{ .open = "[", .close = "]", .forward = true };
+    if (std.mem.eql(u8, token, "]")) return .{ .open = "[", .close = "]", .forward = false };
+    if (std.mem.eql(u8, token, "{")) return .{ .open = "{", .close = "}", .forward = true };
+    if (std.mem.eql(u8, token, "}")) return .{ .open = "{", .close = "}", .forward = false };
+    return null;
+}
+
+fn matchSiblingToken(node: c.TSNode, open: []const u8, close: []const u8, forward: bool) ?c.TSNode {
+    const parent = c.ts_node_parent(node);
+    if (isNullNode(parent)) return null;
+    const count = c.ts_node_child_count(parent);
+    const idx = childIndex(parent, node) orelse return null;
+    var depth: i32 = 1;
+
+    if (forward) {
+        var i = idx + 1;
+        while (i < count) : (i += 1) {
+            const child = c.ts_node_child(parent, i);
+            const typ = nodeType(child);
+            if (std.mem.eql(u8, typ, open)) depth += 1;
+            if (std.mem.eql(u8, typ, close)) {
+                depth -= 1;
+                if (depth == 0) return child;
+            }
+        }
+    } else {
+        var i = idx;
+        while (i > 0) {
+            i -= 1;
+            const child = c.ts_node_child(parent, i);
+            const typ = nodeType(child);
+            if (std.mem.eql(u8, typ, close)) depth += 1;
+            if (std.mem.eql(u8, typ, open)) {
+                depth -= 1;
+                if (depth == 0) return child;
+            }
+        }
+    }
+    return null;
+}
+
+fn childIndex(parent: c.TSNode, node: c.TSNode) ?u32 {
+    const count = c.ts_node_child_count(parent);
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (c.ts_node_eq(c.ts_node_child(parent, i), node)) return i;
+    }
+    return null;
+}
+
+fn tokenText(source: []const u8, node: c.TSNode) []const u8 {
+    const typ = nodeType(node);
+    if (!c.ts_node_is_named(node) and typ.len <= 8) return typ;
+    const text = nodeText(source, node);
+    if (text.len <= 32) return text;
+    return "";
+}
+
+fn matchKeywordToken(node: c.TSNode, source: []const u8, language_name: ?[]const u8) ?c.TSNode {
+    const allow_named_keywords = languageAllowsNamedMatchKeywords(language_name);
+    if (c.ts_node_is_named(node) and !allow_named_keywords) return null;
+
+    const token = tokenText(source, node);
+    if (!isKnownMatchKeyword(token)) return null;
+
+    if (language_name) |lang| {
+        if (std.mem.eql(u8, lang, "elixir") and std.mem.eql(u8, token, "end")) {
+            if (matchElixirEndToHead(node, source)) |head| return head;
+        }
+    }
+
+    if (matchKeywordInAncestors(node, source, token, allow_named_keywords)) |matched| return matched;
+    return null;
+}
+
+fn languageAllowsNamedMatchKeywords(language_name: ?[]const u8) bool {
+    const lang = language_name orelse return false;
+    return std.mem.eql(u8, lang, "elixir");
+}
+
+fn isKnownMatchKeyword(token: []const u8) bool {
+    return std.mem.eql(u8, token, "do") or std.mem.eql(u8, token, "end") or
+        std.mem.eql(u8, token, "fn") or std.mem.eql(u8, token, "def") or
+        std.mem.eql(u8, token, "defp") or std.mem.eql(u8, token, "defmodule") or
+        std.mem.eql(u8, token, "if") or std.mem.eql(u8, token, "unless") or
+        std.mem.eql(u8, token, "begin") or std.mem.eql(u8, token, "case") or
+        std.mem.eql(u8, token, "fi") or std.mem.eql(u8, token, "done") or
+        std.mem.eql(u8, token, "esac") or std.mem.eql(u8, token, "else") or
+        std.mem.eql(u8, token, "elif") or std.mem.eql(u8, token, "class") or
+        std.mem.eql(u8, token, "module") or std.mem.eql(u8, token, "for") or
+        std.mem.eql(u8, token, "while");
+}
+
+fn matchKeywordInAncestors(node: c.TSNode, source: []const u8, token: []const u8, allow_named_keywords: bool) ?c.TSNode {
+    var parent = c.ts_node_parent(node);
+    while (!isNullNode(parent)) : (parent = c.ts_node_parent(parent)) {
+        if (matchKeywordInNode(parent, source, node, token, allow_named_keywords)) |matched| return matched;
+    }
+    return null;
+}
+
+fn matchKeywordInNode(parent: c.TSNode, source: []const u8, original: c.TSNode, token: []const u8, allow_named_keywords: bool) ?c.TSNode {
+    if (std.mem.eql(u8, token, "if")) {
+        if (findLastToken(parent, source, original, matchesFi, allow_named_keywords)) |matched| return matched;
+        if (findLastToken(parent, source, original, matchesEnd, allow_named_keywords)) |matched| return matched;
+        if (findLastToken(parent, source, original, matchesPythonElse, allow_named_keywords)) |matched| return matched;
+    }
+    if (std.mem.eql(u8, token, "do")) {
+        if (findLastToken(parent, source, original, matchesDone, allow_named_keywords)) |matched| return matched;
+        if (findLastToken(parent, source, original, matchesEnd, allow_named_keywords)) |matched| return matched;
+    }
+    if (std.mem.eql(u8, token, "case")) {
+        if (findLastToken(parent, source, original, matchesEsac, allow_named_keywords)) |matched| return matched;
+        if (findLastToken(parent, source, original, matchesEnd, allow_named_keywords)) |matched| return matched;
+    }
+    if (isEndKeyword(token)) return findFirstToken(parent, source, original, matchesEndOpenKeyword, allow_named_keywords);
+    if (std.mem.eql(u8, token, "fi")) return findFirstToken(parent, source, original, matchesIf, allow_named_keywords);
+    if (std.mem.eql(u8, token, "done")) return findFirstToken(parent, source, original, matchesDo, allow_named_keywords);
+    if (std.mem.eql(u8, token, "esac")) return findFirstToken(parent, source, original, matchesCase, allow_named_keywords);
+    if (std.mem.eql(u8, token, "else") or std.mem.eql(u8, token, "elif")) return findFirstToken(parent, source, original, matchesIf, allow_named_keywords);
+    return findLastToken(parent, source, original, matchesEnd, allow_named_keywords);
+}
+
+fn isEndKeyword(token: []const u8) bool {
+    return std.mem.eql(u8, token, "end");
+}
+
+fn matchElixirEndToHead(node: c.TSNode, source: []const u8) ?c.TSNode {
+    const block = c.ts_node_parent(node);
+    if (isNullNode(block) or !std.mem.eql(u8, nodeType(block), "do_block")) return null;
+    const owner = c.ts_node_parent(block);
+    if (isNullNode(owner)) return null;
+    return findFirstToken(owner, source, block, matchesElixirBlockHead, true);
+}
+
+const TokenMatcher = *const fn ([]const u8) bool;
+
+fn findFirstToken(node: c.TSNode, source: []const u8, skip: c.TSNode, matcher: TokenMatcher, allow_named_keywords: bool) ?c.TSNode {
+    if (!c.ts_node_eq(node, skip) and tokenNodeMatches(node, source, matcher, allow_named_keywords)) return node;
+    const count = c.ts_node_child_count(node);
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        const child = c.ts_node_child(node, i);
+        if (c.ts_node_eq(child, skip)) continue;
+        if (findFirstToken(child, source, skip, matcher, allow_named_keywords)) |matched| return matched;
+    }
+    return null;
+}
+
+fn findLastToken(node: c.TSNode, source: []const u8, skip: c.TSNode, matcher: TokenMatcher, allow_named_keywords: bool) ?c.TSNode {
+    var result: ?c.TSNode = null;
+    if (!c.ts_node_eq(node, skip) and tokenNodeMatches(node, source, matcher, allow_named_keywords)) result = node;
+    const count = c.ts_node_child_count(node);
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        const child = c.ts_node_child(node, i);
+        if (c.ts_node_eq(child, skip)) continue;
+        if (findLastToken(child, source, skip, matcher, allow_named_keywords)) |matched| result = matched;
+    }
+    return result;
+}
+
+fn tokenNodeMatches(node: c.TSNode, source: []const u8, matcher: TokenMatcher, allow_named_keywords: bool) bool {
+    if (c.ts_node_is_named(node) and !allow_named_keywords) return false;
+    return matcher(tokenText(source, node));
+}
+
+fn matchesEnd(token: []const u8) bool {
+    return std.mem.eql(u8, token, "end");
+}
+fn matchesDone(token: []const u8) bool {
+    return std.mem.eql(u8, token, "done");
+}
+fn matchesFi(token: []const u8) bool {
+    return std.mem.eql(u8, token, "fi");
+}
+fn matchesEsac(token: []const u8) bool {
+    return std.mem.eql(u8, token, "esac");
+}
+fn matchesIf(token: []const u8) bool {
+    return std.mem.eql(u8, token, "if");
+}
+fn matchesDo(token: []const u8) bool {
+    return std.mem.eql(u8, token, "do");
+}
+fn matchesCase(token: []const u8) bool {
+    return std.mem.eql(u8, token, "case");
+}
+fn matchesPythonElse(token: []const u8) bool {
+    return std.mem.eql(u8, token, "else") or std.mem.eql(u8, token, "elif");
+}
+
+fn matchesElixirBlockHead(token: []const u8) bool {
+    return std.mem.eql(u8, token, "def") or std.mem.eql(u8, token, "defp") or
+        std.mem.eql(u8, token, "defmodule") or std.mem.eql(u8, token, "fn") or
+        std.mem.eql(u8, token, "if") or std.mem.eql(u8, token, "unless") or
+        std.mem.eql(u8, token, "case") or std.mem.eql(u8, token, "for") or
+        std.mem.eql(u8, token, "while");
+}
+
+fn matchesEndOpenKeyword(token: []const u8) bool {
+    return matchesElixirBlockHead(token) or std.mem.eql(u8, token, "do") or
+        std.mem.eql(u8, token, "begin") or std.mem.eql(u8, token, "class") or
+        std.mem.eql(u8, token, "module");
+}
+
+fn matchHtmlTag(node: c.TSNode) ?c.TSNode {
+    if (!std.mem.eql(u8, nodeType(node), "tag_name")) return null;
+    const tag = nearestTagNode(node) orelse return null;
+    const tag_type = nodeType(tag);
+    if (std.mem.eql(u8, tag_type, "self_closing_tag")) return null;
+
+    const element = c.ts_node_parent(tag);
+    if (isNullNode(element)) return null;
+    const want_end = std.mem.eql(u8, tag_type, "start_tag");
+    const count = c.ts_node_child_count(element);
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        const child = c.ts_node_child(element, i);
+        const typ = nodeType(child);
+        if (want_end and std.mem.eql(u8, typ, "end_tag")) return tagNameChild(child) orelse child;
+        if (!want_end and std.mem.eql(u8, typ, "start_tag")) return tagNameChild(child) orelse child;
+    }
+    return null;
+}
+
+fn nearestTagNode(node: c.TSNode) ?c.TSNode {
+    var current = node;
+    while (!isNullNode(current)) : (current = c.ts_node_parent(current)) {
+        const typ = nodeType(current);
+        if (std.mem.eql(u8, typ, "start_tag") or std.mem.eql(u8, typ, "end_tag") or std.mem.eql(u8, typ, "self_closing_tag")) return current;
+        if (std.mem.eql(u8, typ, "element")) return null;
+    }
+    return null;
+}
+
+fn tagNameChild(tag: c.TSNode) ?c.TSNode {
+    const count = c.ts_node_child_count(tag);
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        const child = c.ts_node_child(tag, i);
+        if (std.mem.eql(u8, nodeType(child), "tag_name")) return child;
+    }
+    return null;
+}
+
 // ── Injection helpers ─────────────────────────────────────────────────────
 
 /// Reads `#set! injection.language "..."` predicates from a query pattern.
@@ -2016,6 +2447,146 @@ test "highlighter: Perl shebang predicate does not tag ordinary first comments a
         }
     }
     try std.testing.expect(found_shebang);
+}
+
+test "highlighter: match item finds structural brackets" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("javascript"));
+    try hl.parse("const x = (1 + 2);");
+
+    const result = hl.findMatchingItem(0, 10) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 0), result.row);
+    try std.testing.expectEqual(@as(u32, 16), result.col);
+}
+
+test "highlighter: match item ignores unrelated separators" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("javascript"));
+    try hl.parse("foo(a, b, c);");
+
+    try std.testing.expect(hl.findMatchingItem(0, 5) == null);
+}
+
+test "highlighter: match item ignores brackets inside strings and comments" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("javascript"));
+    try hl.parse("const s = \"(\"; // )\nconst x = (1);\n");
+
+    try std.testing.expect(hl.findMatchingItem(0, 11) == null);
+    try std.testing.expect(hl.findMatchingItem(0, 18) == null);
+
+    const result = hl.findMatchingItem(1, 10) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 1), result.row);
+    try std.testing.expectEqual(@as(u32, 12), result.col);
+}
+
+test "highlighter: match item matches Elixir block keywords" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("elixir"));
+    try hl.parse("def foo do\n  :ok\nend\n");
+
+    const from_def = hl.findMatchingItem(0, 0) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 2), from_def.row);
+    try std.testing.expectEqual(@as(u32, 0), from_def.col);
+
+    const from_do = hl.findMatchingItem(0, 8) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 2), from_do.row);
+    try std.testing.expectEqual(@as(u32, 0), from_do.col);
+
+    const from_end = hl.findMatchingItem(2, 0) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 0), from_end.row);
+    try std.testing.expectEqual(@as(u32, 0), from_end.col);
+}
+
+test "highlighter: match item matches string delimiters" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("javascript"));
+    try hl.parse("const s = \"hello\";");
+
+    const from_open = hl.findMatchingItem(0, 10) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 0), from_open.row);
+    try std.testing.expectEqual(@as(u32, 16), from_open.col);
+
+    const from_close = hl.findMatchingItem(0, 16) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 0), from_close.row);
+    try std.testing.expectEqual(@as(u32, 10), from_close.col);
+}
+
+test "highlighter: match item ignores string content" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("javascript"));
+    try hl.parse("const s = \"hello\";");
+
+    try std.testing.expect(hl.findMatchingItem(0, 11) == null);
+    try std.testing.expect(hl.findMatchingItem(0, 15) == null);
+}
+
+test "highlighter: match item ignores identifiers that look like shell keywords" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("javascript"));
+    try hl.parse("do { done(); } while (ok);");
+
+    try std.testing.expect(hl.findMatchingItem(0, 0) == null);
+    try std.testing.expect(hl.findMatchingItem(0, 5) == null);
+}
+
+test "highlighter: match item keeps HTML attributes out of tag matching" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("html"));
+    try hl.parse("<div title=\"x\"></div>");
+
+    try std.testing.expect(hl.findMatchingItem(0, 11) == null);
+    try std.testing.expect(hl.findMatchingItem(0, 12) == null);
+}
+
+test "highlighter: match item matches HTML tags and ignores self-closing tags" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("html"));
+    try hl.parse("<div><br/></div>");
+
+    const from_open = hl.findMatchingItem(0, 1) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 0), from_open.row);
+    try std.testing.expectEqual(@as(u32, 12), from_open.col);
+
+    const from_close = hl.findMatchingItem(0, 12) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 0), from_close.row);
+    try std.testing.expectEqual(@as(u32, 1), from_close.col);
+
+    try std.testing.expect(hl.findMatchingItem(0, 6) == null);
+}
+
+test "highlighter: match item matches Ruby if end" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("ruby"));
+    try hl.parse("if ok\n  puts :ok\nend\n");
+
+    const result = hl.findMatchingItem(0, 0) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 2), result.row);
+    try std.testing.expectEqual(@as(u32, 0), result.col);
+
+    const reverse = hl.findMatchingItem(2, 0) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 0), reverse.row);
+    try std.testing.expectEqual(@as(u32, 0), reverse.col);
 }
 
 test "highlighter: setLanguage invalidates tree, restores cached query" {

--- a/zig/src/parser_main.zig
+++ b/zig/src/parser_main.zig
@@ -335,19 +335,29 @@ fn handleCommand(
         },
         .request_textobject => |req| {
             const bs = buffers.getPtr(req.buffer_id) orelse {
-                var rbuf: [22]u8 = undefined;
-                const rlen = protocol.encodeTextobjectResult(&rbuf, req.request_id, null);
-                try protocol.writeMessage(stdout, rbuf[0..rlen]);
-                try stdout.flush();
+                try sendTextobjectResult(stdout, req.request_id, null);
                 return;
             };
-            if (!activateBuffer(hl, bs)) return;
+            if (!activateBuffer(hl, bs)) {
+                try sendTextobjectResult(stdout, req.request_id, null);
+                return;
+            }
             const result = hl.findTextobject(req.row, req.col, req.capture_name);
             saveTreeToBuffer(hl, bs);
-            var rbuf: [22]u8 = undefined;
-            const rlen = protocol.encodeTextobjectResult(&rbuf, req.request_id, result);
-            try protocol.writeMessage(stdout, rbuf[0..rlen]);
-            try stdout.flush();
+            try sendTextobjectResult(stdout, req.request_id, result);
+        },
+        .request_match_item => |req| {
+            const bs = buffers.getPtr(req.buffer_id) orelse {
+                try sendMatchItemResult(stdout, req.request_id, null);
+                return;
+            };
+            if (!activateBuffer(hl, bs)) {
+                try sendMatchItemResult(stdout, req.request_id, null);
+                return;
+            }
+            const result = hl.findMatchingItem(req.row, req.col);
+            saveTreeToBuffer(hl, bs);
+            try sendMatchItemResult(stdout, req.request_id, result);
         },
         .load_grammar => |lg| {
             hl.loadGrammar(lg.name, lg.path) catch {
@@ -467,6 +477,20 @@ fn handleCloseBuffer(
 fn sendLanguageAtResponse(stdout: *std.Io.Writer, request_id: u32, language: ?[]const u8) !void {
     var rbuf: [260]u8 = undefined;
     const rlen = protocol.encodeLanguageAtResponse(&rbuf, request_id, language) catch return;
+    try protocol.writeMessage(stdout, rbuf[0..rlen]);
+    try stdout.flush();
+}
+
+fn sendTextobjectResult(stdout: *std.Io.Writer, request_id: u32, result: ?protocol.TextobjectResult) !void {
+    var rbuf: [22]u8 = undefined;
+    const rlen = protocol.encodeTextobjectResult(&rbuf, request_id, result);
+    try protocol.writeMessage(stdout, rbuf[0..rlen]);
+    try stdout.flush();
+}
+
+fn sendMatchItemResult(stdout: *std.Io.Writer, request_id: u32, result: ?protocol.MatchItemResult) !void {
+    var rbuf: [14]u8 = undefined;
+    const rlen = protocol.encodeMatchItemResult(&rbuf, request_id, result);
     try protocol.writeMessage(stdout, rbuf[0..rlen]);
     try stdout.flush();
 }

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -66,6 +66,7 @@ pub const OP_REQUEST_INDENT: u8 = 0x2A;
 pub const OP_SET_TEXTOBJECT_QUERY: u8 = 0x2B;
 pub const OP_REQUEST_TEXTOBJECT: u8 = 0x2C;
 pub const OP_CLOSE_BUFFER: u8 = 0x2D;
+pub const OP_REQUEST_MATCH_ITEM: u8 = 0x2E;
 
 // Highlight responses (Zig → BEAM)
 pub const OP_HIGHLIGHT_SPANS: u8 = 0x30;
@@ -92,6 +93,7 @@ pub const OP_CONCEAL_SPANS: u8 = 0x3A;
 /// Sent when the parser detects stale edit deltas (byte offsets don't match
 /// the stored source), typically after system sleep/wake.
 pub const OP_REQUEST_REPARSE: u8 = 0x3B;
+pub const OP_MATCH_ITEM_RESULT: u8 = 0x3C;
 
 // Log messages (Zig → BEAM)
 pub const OP_LOG_MESSAGE: u8 = 0x60;
@@ -266,6 +268,7 @@ pub const RenderCommand = union(enum) {
     request_indent: RequestIndent,
     set_textobject_query: SetTextobjectQuery,
     request_textobject: RequestTextobject,
+    request_match_item: RequestMatchItem,
     load_grammar: LoadGrammar,
     query_language_at: QueryLanguageAt,
     close_buffer: u32, // buffer_id
@@ -351,6 +354,13 @@ pub const RequestTextobject = struct {
     row: u32,
     col: u32,
     capture_name: []const u8,
+};
+
+pub const RequestMatchItem = struct {
+    buffer_id: u32 = 0,
+    request_id: u32,
+    row: u32,
+    col: u32,
 };
 
 pub const LoadGrammar = struct {
@@ -818,6 +828,16 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
                 .capture_name = rest[18 .. 18 + name_len],
             } };
         },
+        OP_REQUEST_MATCH_ITEM => {
+            // buffer_id:4, request_id:4, row:4, col:4
+            if (rest.len < 16) return error.Malformed;
+            return .{ .request_match_item = .{
+                .buffer_id = std.mem.readInt(u32, rest[0..4], .big),
+                .request_id = std.mem.readInt(u32, rest[4..8], .big),
+                .row = std.mem.readInt(u32, rest[8..12], .big),
+                .col = std.mem.readInt(u32, rest[12..16], .big),
+            } };
+        },
         OP_LOAD_GRAMMAR => {
             // name_len:2, name, path_len:2, path
             if (rest.len < 2) return error.Malformed;
@@ -1001,6 +1021,7 @@ pub fn commandSize(payload: []const u8) usize {
             const nl: usize = std.mem.readInt(u16, payload[17..19], .big);
             break :blk 19 + nl;
         },
+        OP_REQUEST_MATCH_ITEM => 17, // opcode(1) + buffer_id(4) + request_id(4) + row(4) + col(4)
         OP_CLOSE_BUFFER => 5, // opcode(1) + buffer_id(4)
         OP_EDIT_BUFFER => blk: {
             // opcode(1) + buffer_id(4) + version(4) + edit_count(2) + variable per edit
@@ -1189,6 +1210,27 @@ pub fn encodeTextobjectResult(buf: *[22]u8, request_id: u32, result: ?Textobject
         return 22;
     } else {
         buf[5] = 0; // not found
+        return 6;
+    }
+}
+
+/// Match item result (shared between protocol and highlighter).
+pub const MatchItemResult = struct {
+    row: u32,
+    col: u32,
+};
+
+/// Encodes match_item_result: opcode(1) + request_id(4) + found(1) + row(4) + col(4) = 14 bytes
+pub fn encodeMatchItemResult(buf: *[14]u8, request_id: u32, result: ?MatchItemResult) usize {
+    buf[0] = OP_MATCH_ITEM_RESULT;
+    std.mem.writeInt(u32, buf[1..5], request_id, .big);
+    if (result) |r| {
+        buf[5] = 1;
+        std.mem.writeInt(u32, buf[6..10], r.row, .big);
+        std.mem.writeInt(u32, buf[10..14], r.col, .big);
+        return 14;
+    } else {
+        buf[5] = 0;
         return 6;
     }
 }
@@ -2024,6 +2066,44 @@ test "decode load_grammar" {
         },
         else => return error.Malformed,
     }
+}
+
+test "decode request_match_item" {
+    var data: [17]u8 = undefined;
+    data[0] = OP_REQUEST_MATCH_ITEM;
+    std.mem.writeInt(u32, data[1..5], 7, .big);
+    std.mem.writeInt(u32, data[5..9], 42, .big);
+    std.mem.writeInt(u32, data[9..13], 3, .big);
+    std.mem.writeInt(u32, data[13..17], 11, .big);
+
+    const cmd = try decodeCommand(&data);
+    switch (cmd) {
+        .request_match_item => |req| {
+            try std.testing.expectEqual(@as(u32, 7), req.buffer_id);
+            try std.testing.expectEqual(@as(u32, 42), req.request_id);
+            try std.testing.expectEqual(@as(u32, 3), req.row);
+            try std.testing.expectEqual(@as(u32, 11), req.col);
+        },
+        else => return error.Malformed,
+    }
+}
+
+test "encode match_item_result" {
+    var found_buf: [14]u8 = undefined;
+    const found_len = encodeMatchItemResult(&found_buf, 42, .{ .row = 9, .col = 4 });
+    try std.testing.expectEqual(@as(usize, 14), found_len);
+    try std.testing.expectEqual(@as(u8, OP_MATCH_ITEM_RESULT), found_buf[0]);
+    try std.testing.expectEqual(@as(u32, 42), std.mem.readInt(u32, found_buf[1..5], .big));
+    try std.testing.expectEqual(@as(u8, 1), found_buf[5]);
+    try std.testing.expectEqual(@as(u32, 9), std.mem.readInt(u32, found_buf[6..10], .big));
+    try std.testing.expectEqual(@as(u32, 4), std.mem.readInt(u32, found_buf[10..14], .big));
+
+    var empty_buf: [14]u8 = undefined;
+    const empty_len = encodeMatchItemResult(&empty_buf, 43, null);
+    try std.testing.expectEqual(@as(usize, 6), empty_len);
+    try std.testing.expectEqual(@as(u8, OP_MATCH_ITEM_RESULT), empty_buf[0]);
+    try std.testing.expectEqual(@as(u32, 43), std.mem.readInt(u32, empty_buf[1..5], .big));
+    try std.testing.expectEqual(@as(u8, 0), empty_buf[5]);
 }
 
 test "commandSize: set_language" {

--- a/zig/src/renderer.zig
+++ b/zig/src/renderer.zig
@@ -223,7 +223,7 @@ pub fn Renderer(comptime SurfaceT: type) type {
                 },
 
                 // edit_buffer, measure_text and highlight commands are handled by the event loop, not the renderer.
-                .noop, .edit_buffer, .measure_text, .set_language, .parse_buffer, .set_highlight_query, .set_injection_query, .set_fold_query, .set_indent_query, .request_indent, .set_textobject_query, .request_textobject, .load_grammar, .query_language_at, .close_buffer => {},
+                .noop, .edit_buffer, .measure_text, .set_language, .parse_buffer, .set_highlight_query, .set_injection_query, .set_fold_query, .set_indent_query, .request_indent, .set_textobject_query, .request_textobject, .request_match_item, .load_grammar, .query_language_at, .close_buffer => {},
             }
         }
 


### PR DESCRIPTION
# TL;DR
`%` now resolves match items through tree-sitter instead of a text scanner, so brackets, string delimiters, keywords, and HTML tags follow syntax structure and grammar-less buffers no-op safely.

Closes #667

## Context
Issue #667 moves Vim `%` matching out of pure text scanning and into the parser layer. That matters because text scanning cannot reliably distinguish real structural tokens from characters inside comments, strings, or language-specific constructs.

## Changes
- Added parser protocol messages for synchronous match-item requests and responses, including BEAM encoders/decoders, `ParserManager.request_match_item/4`, Zig protocol handling, and parser-main dispatch.
- Replaced the pure `Minga.Editing.Motion.Char.match_bracket/2` scanner with a no-op fallback, then routed editor `%` motions through the active parser buffer when grammar support exists.
- Implemented tree-sitter-backed matching in Zig for structural bracket siblings, string delimiters, keyword pairs, and HTML/XML tags, with self-closing tags treated as no-ops.
- Preserved Vim behavior across normal, visual, operator-pending, comment, indent, dedent, and reindent flows, including no-match operator no-ops and reverse keyword ranges.
- Guarded string, HTML, and keyword edge cases so string content, HTML attribute values, and ordinary identifiers that look like keywords do not become false match targets.
- Cleaned up indent command insertion to use bulk text insertion and respect tab indentation settings.
- Updated the protocol docs and added regression coverage for protocol round trips, parser matching behavior, and grammar-less no-op behavior.

## Verification
- `zig build test` passed.
- `mix zig.lint` passed.
- `make lint` passed.
- `mix test.llm test/minga_editor/frontend/protocol_test.exs test/minga_editor/integration/match_item_test.exs test/minga/parser/protocol_match_item_test.exs test/minga/editing/motion/char_test.exs` passed.
- `mix test.llm` passed: 54 doctests, 97 properties, 8487 tests, 0 failures, 5 skipped, 118 excluded.
- Fresh-eyes targeted code review passed after fixes.

## Acceptance Criteria Addressed
- Structural bracket matching replaces text scanning, and bracket-looking characters inside comments or strings no longer produce false positives. ✅
- Keyword pairs are matched structurally for supported tree-sitter grammars. ✅
- String delimiter matching works from either delimiter. ✅
- HTML/XML tag matching works, and self-closing tags no-op. ✅
- Buffers without a grammar no-op instead of falling back to scanning. ✅
- `%` works through normal, visual, and operator-pending command paths. ✅
- Parser protocol request/response coverage and documentation are in place. ✅

