### PR TITLE
Complete agent chat markdown links and scrolling

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -283,43 +283,48 @@ When hidden:
 
 ### 0x78 — gui_agent_chat (sectioned format)
 
-Agent conversation view state. Uses sectioned envelope: `opcode(1) + section_count(1) + sections...`. Hidden: section_count=0.
+Agent conversation view state. Uses sectioned envelope: `opcode(1) + section_count(1) + sections...`. Hidden frames use `section_count=0`.
+
+Each section uses `section_id(1) + section_len(2) + payload(section_len)`. Section payloads must fit in 65,535 bytes.
 
 | Section ID | Name | Content |
 |-----------|------|--------|
-| 0x01 | Header | visible, status |
-| 0x02 | Model | model name |
-| 0x03 | Prompt | prompt text plus prompt line/cursor/mode metadata |
+| 0x01 | Header | `visible(1) + status(1)` |
+| 0x02 | Model | `model_len(2) + model` |
+| 0x03 | Prompt | `prompt_len(2) + prompt + line_count(1) + cursor_line(2) + cursor_col(2) + vim_mode(1) + visible_rows(1)` |
 | 0x04 | Pending | legacy pending approval banner payload. Current BEAM frames send `0` and render approvals inline as message type `0x09`. |
-| 0x05 | Help | help overlay visibility + groups |
-| 0x06 | Messages | message_count + messages (same nested format as before) |
+| 0x05 | Help | `visible(1) + optional groups` |
+| 0x06 | Messages | `message_count(2) + messages...` |
 | 0x07 | Completion | prompt completion popup state |
-
-**Legacy positional format (deprecated):**
-```
-When visible:
-  opcode(1) + 1(1) + status(1) + model_len(2) + model(model_len) + prompt_len(2) + prompt(prompt_len) + pending_approval + message_count(2) + messages...
 
 Status values: 0 = idle, 1 = thinking, 2 = tool_executing, 3 = error
 
-Pending approval:
-  0(1) — no pending approval
-  1(1) + name_len(2) + name(name_len) + summary_len(2) + summary(summary_len)
-
-Per message (type byte first):
-  0x01 (user):      type(1) + text_len(4) + text
-  0x02 (assistant):  type(1) + text_len(4) + text
-  0x03 (thinking):   type(1) + collapsed(1) + text_len(4) + text
-  0x04 (tool_call):  type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + result_len(4) + result
-  0x05 (system):     type(1) + level(1) + text_len(4) + text
-  0x06 (usage):      type(1) + input(4) + output(4) + cache_read(4) + cache_write(4) + cost_micros(4)
-  0x07 (styled_assistant): type(1) + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1)
-  0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1)
-  0x09 (approval_tool_call): type(1) + status(1) + name_len(2) + name + summary_len(2) + summary + tool_call_id_len(2) + tool_call_id + preview_kind(1) + preview_line_count(2), per line: line_len(2) + line
-
-When hidden:
-  opcode(1) + 0(1)
+Pending approval payload:
 ```
+0(1) — no pending approval
+1(1) + name_len(2) + name(name_len) + summary_len(2) + summary(summary_len)
+```
+
+Messages payload:
+```
+message_count(2) + messages...
+
+Per message:
+  message_id(4) + typed_payload
+
+Typed payloads:
+  0x01 (user):      type(1) + text_len(4) + text
+  0x02 (assistant): type(1) + text_len(4) + text
+  0x03 (thinking):  type(1) + collapsed(1) + text_len(4) + text
+  0x04 (tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + result_len(4) + result
+  0x05 (system):    type(1) + level(1) + text_len(4) + text
+  0x06 (usage):     type(1) + input(4) + output(4) + cache_read(4) + cache_write(4) + cost_micros(4)
+  0x07 (styled_assistant): type(1) + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url. Link URLs are limited to http, https, and mailto.
+  0x08 (styled_tool_call): type(1) + status(1) + error(1) + collapsed(1) + duration_ms(4) + name_len(2) + name + summary_len(2) + summary + line_count(2), per line: run_count(2), per run: text_len(2) + text + fg(3) + bg(3) + flags(1), and if flags bit 0x08 is set: url_len(2) + url. Link URLs are limited to http, https, and mailto.
+  0x09 (approval_tool_call): type(1) + status(1) + name_len(2) + name + summary_len(2) + summary + tool_call_id_len(2) + tool_call_id + preview_kind(1) + preview_line_count(2), per line: line_len(2) + line
+```
+
+Styled run flags: 0x01=bold, 0x02=italic, 0x04=underline, 0x08=link URL present.
 
 ### 0x79 — gui_gutter_separator
 

--- a/lib/minga_agent/markdown.ex
+++ b/lib/minga_agent/markdown.ex
@@ -11,6 +11,7 @@ defmodule MingaAgent.Markdown do
   - `**bold**` and `__bold__`
   - `*italic*` and `_italic_`
   - `` `inline code` ``
+  - `[link text](https://example.com)`
   - Fenced code blocks (``` with optional language tag)
   - `# Headers` (levels 1-3)
   - `- list items` and `* list items`
@@ -31,6 +32,7 @@ defmodule MingaAgent.Markdown do
           | :italic
           | :bold_italic
           | :code
+          | {:link, String.t()}
           | :code_block
           | {:code_content, String.t()}
           | :header1
@@ -156,48 +158,62 @@ defmodule MingaAgent.Markdown do
 
   # Also match longer horizontal rules
   defp parse_lines([line | rest], acc, nil) do
-    trimmed = String.trim(line)
+    parsed = parse_non_code_line(line, String.trim(line))
+    parse_lines(rest, [parsed | acc], nil)
+  end
 
-    cond do
-      match?("###" <> _, trimmed) ->
-        text = trimmed |> String.trim_leading("#") |> String.trim()
-        parse_lines(rest, [{[{text, :header3}], :header} | acc], nil)
+  @spec parse_non_code_line(String.t(), String.t()) :: parsed_line()
+  defp parse_non_code_line(_line, "###" <> _ = trimmed), do: parse_header_line(trimmed, :header3)
+  defp parse_non_code_line(_line, "##" <> _ = trimmed), do: parse_header_line(trimmed, :header2)
+  defp parse_non_code_line(_line, "#" <> _ = trimmed), do: parse_header_line(trimmed, :header1)
 
-      match?("##" <> _, trimmed) ->
-        text = trimmed |> String.trim_leading("#") |> String.trim()
-        parse_lines(rest, [{[{text, :header2}], :header} | acc], nil)
+  defp parse_non_code_line(_line, ">" <> _ = trimmed) do
+    text = trimmed |> String.replace_prefix(">", "") |> String.trim_leading()
+    segments = parse_inline("│ " <> text)
+    styles = Enum.map(segments, &blockquote_segment/1)
+    {styles, :blockquote}
+  end
 
-      match?("#" <> _, trimmed) ->
-        text = trimmed |> String.trim_leading("#") |> String.trim()
-        parse_lines(rest, [{[{text, :header1}], :header} | acc], nil)
+  defp parse_non_code_line(line, "- " <> text), do: parse_bullet_line(line, text)
+  defp parse_non_code_line(line, "* " <> text), do: parse_bullet_line(line, text)
 
-      match?(">" <> _, trimmed) ->
-        text = String.trim_leading(trimmed, "> ")
-        segments = parse_inline("│ " <> text)
-        styles = Enum.map(segments, fn {t, _s} -> {t, :blockquote} end)
-        parse_lines(rest, [{styles, :blockquote} | acc], nil)
+  defp parse_non_code_line(line, trimmed) do
+    parse_numbered_line(Regex.match?(~r/^\d+\.\s/, trimmed), line, trimmed)
+  end
 
-      match?("- " <> _, trimmed) or match?("* " <> _, trimmed) ->
-        text = String.slice(trimmed, 2..-1//1)
-        indent_level = div(indent_width(line), 2)
-        prefix = String.duplicate("  ", indent_level + 1)
-        segments = parse_inline(prefix <> "• " <> text)
-        parse_lines(rest, [{segments, :list_item} | acc], nil)
+  @spec parse_header_line(String.t(), :header1 | :header2 | :header3) :: parsed_line()
+  defp parse_header_line(trimmed, style) do
+    text = trimmed |> String.trim_leading("#") |> String.trim()
+    {[{text, style}], :header}
+  end
 
-      Regex.match?(~r/^\d+\.\s/, trimmed) ->
-        # Numbered list: keep the number prefix, parse inline for the rest
-        indent_level = div(indent_width(line), 2)
-        prefix = String.duplicate("  ", indent_level + 1)
-        segments = parse_inline(prefix <> trimmed)
-        parse_lines(rest, [{segments, :list_item} | acc], nil)
+  @spec parse_bullet_line(String.t(), String.t()) :: parsed_line()
+  defp parse_bullet_line(line, text) do
+    indent_level = div(indent_width(line), 2)
+    prefix = String.duplicate("  ", indent_level + 1)
+    segments = parse_inline(prefix <> "• " <> text)
+    {segments, :list_item}
+  end
 
-      String.match?(trimmed, ~r/^[-*_]{3,}$/) ->
-        parse_lines(rest, [{[{"─────────────────────", :rule}], :rule} | acc], nil)
+  @spec parse_numbered_line(boolean(), String.t(), String.t()) :: parsed_line()
+  defp parse_numbered_line(true, line, trimmed) do
+    # Numbered list: keep the number prefix, parse inline for the rest
+    indent_level = div(indent_width(line), 2)
+    prefix = String.duplicate("  ", indent_level + 1)
+    segments = parse_inline(prefix <> trimmed)
+    {segments, :list_item}
+  end
 
-      true ->
-        segments = parse_inline(line)
-        parse_lines(rest, [{segments, :text} | acc], nil)
-    end
+  defp parse_numbered_line(false, line, trimmed) do
+    parse_extended_rule_line(String.match?(trimmed, ~r/^[-*_]{3,}$/), line)
+  end
+
+  @spec parse_extended_rule_line(boolean(), String.t()) :: parsed_line()
+  defp parse_extended_rule_line(true, _line), do: {[{"─────────────────────", :rule}], :rule}
+
+  defp parse_extended_rule_line(false, line) do
+    segments = parse_inline(line)
+    {segments, :text}
   end
 
   # ── Inline parsing ─────────────────────────────────────────────────────────
@@ -227,6 +243,17 @@ defmodule MingaAgent.Markdown do
 
       [_no_close] ->
         do_parse_inline(rest, [{"`", :plain} | acc])
+    end
+  end
+
+  # Link: [text](url)
+  defp do_parse_inline("[" <> rest, acc) do
+    case Regex.run(~r/^([^\]]+)\]\(([^)]+)\)(.*)$/s, rest) do
+      [_, label, url, remaining] ->
+        parse_link(label, url, remaining, acc)
+
+      nil ->
+        do_parse_inline(rest, [{"[", :plain} | acc])
     end
   end
 
@@ -276,7 +303,7 @@ defmodule MingaAgent.Markdown do
 
   # Regular character: consume up to next special character
   defp do_parse_inline(text, acc) do
-    case Regex.run(~r/^([^`*_]+)(.*)$/s, text) do
+    case Regex.run(~r/^([^`*_\[]+)(.*)$/s, text) do
       [_, plain, rest] ->
         do_parse_inline(rest, [{plain, :plain} | acc])
 
@@ -288,6 +315,54 @@ defmodule MingaAgent.Markdown do
   end
 
   # ── Helpers ─────────────────────────────────────────────────────────────────
+
+  @spec blockquote_segment(segment()) :: segment()
+  defp blockquote_segment({text, {:link, _url} = style}), do: {text, style}
+  defp blockquote_segment({text, _style}), do: {text, :blockquote}
+
+  @spec parse_link(String.t(), String.t(), String.t(), [segment()]) :: [segment()]
+  defp parse_link(label, url, remaining, acc) do
+    style = if safe_url?(url), do: {:link, url}, else: :plain
+    do_parse_inline(remaining, [{label, style} | acc])
+  end
+
+  @spec safe_url?(String.t()) :: boolean()
+  defp safe_url?(url) do
+    if valid_percent_escapes?(url) do
+      case URI.new(url) do
+        {:ok, uri} -> safe_uri?(uri.scheme, uri)
+        {:error, _part} -> false
+      end
+    else
+      false
+    end
+  end
+
+  @spec valid_percent_escapes?(String.t()) :: boolean()
+  defp valid_percent_escapes?(<<>>), do: true
+
+  defp valid_percent_escapes?(<<"%", first, second, rest::binary>>) do
+    hex_digit?(first) and hex_digit?(second) and valid_percent_escapes?(rest)
+  end
+
+  defp valid_percent_escapes?(<<"%", _rest::binary>>), do: false
+  defp valid_percent_escapes?(<<_char, rest::binary>>), do: valid_percent_escapes?(rest)
+
+  @spec hex_digit?(byte()) :: boolean()
+  defp hex_digit?(char) do
+    (char >= ?0 and char <= ?9) or (char >= ?a and char <= ?f) or (char >= ?A and char <= ?F)
+  end
+
+  @spec safe_uri?(String.t() | nil, URI.t()) :: boolean()
+  defp safe_uri?(scheme, %URI{host: host}) when scheme in ["http", "https"] do
+    is_binary(host) and host != ""
+  end
+
+  defp safe_uri?("mailto", %URI{path: path}) do
+    is_binary(path) and path != ""
+  end
+
+  defp safe_uri?(_scheme, _uri), do: false
 
   @spec merge_adjacent([segment()]) :: [segment()]
   defp merge_adjacent([]), do: []

--- a/lib/minga_editor/agent/markdown_highlight.ex
+++ b/lib/minga_editor/agent/markdown_highlight.ex
@@ -17,8 +17,10 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
   alias MingaAgent.Markdown
   alias MingaEditor.UI.Highlight
 
-  @typedoc "A single styled text run: {text, fg_rgb, bg_rgb, flags}."
-  @type styled_run :: {String.t(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
+  @typedoc "A single styled text run: {text, fg_rgb, bg_rgb, flags} or {text, fg_rgb, bg_rgb, flags, url}."
+  @type styled_run ::
+          {String.t(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
+          | {String.t(), non_neg_integer(), non_neg_integer(), non_neg_integer(), String.t()}
 
   @typedoc "A line of styled runs."
   @type styled_line :: [styled_run()]
@@ -30,6 +32,7 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
   @flag_bold 0x01
   @flag_italic 0x02
   @flag_underline 0x04
+  @flag_link 0x08
 
   @doc """
   Converts assistant message text to styled runs for the GUI.
@@ -53,14 +56,13 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
     base_lines =
       Enum.map(parsed, fn {segments, _line_type} ->
         Enum.map(segments, fn {seg_text, style_atom} ->
-          {fg, bg, flags} = md_style_to_colors(style_atom, theme_syntax)
-          {seg_text, fg, bg, flags}
+          style_to_run(seg_text, style_atom, theme_syntax)
         end)
       end)
 
     # Overlay tree-sitter highlights on code block content lines
     if has_spans?(highlight) do
-      overlay_code_blocks(base_lines, parsed, text, highlight, buffer_byte_offset)
+      overlay_code_blocks(base_lines, parsed, text, highlight, theme_syntax, buffer_byte_offset)
     else
       base_lines
     end
@@ -81,9 +83,17 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
           [Markdown.parsed_line()],
           String.t(),
           Highlight.t(),
+          map(),
           non_neg_integer()
         ) :: [styled_line()]
-  defp overlay_code_blocks(base_lines, parsed, original_text, highlight, buffer_byte_offset) do
+  defp overlay_code_blocks(
+         base_lines,
+         parsed,
+         original_text,
+         highlight,
+         theme_syntax,
+         buffer_byte_offset
+       ) do
     original_lines = String.split(original_text, "\n")
     line_byte_offsets = compute_line_byte_offsets(original_lines)
 
@@ -98,6 +108,7 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
         original_lines,
         line_byte_offsets,
         highlight,
+        theme_syntax,
         buffer_byte_offset
       )
     end)
@@ -114,6 +125,7 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
           [String.t()],
           %{non_neg_integer() => non_neg_integer()},
           Highlight.t(),
+          map(),
           non_neg_integer()
         ) :: styled_line()
   defp overlay_line(
@@ -123,6 +135,7 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
          original_lines,
          line_byte_offsets,
          highlight,
+         theme_syntax,
          buffer_byte_offset
        ) do
     original_line = Enum.at(original_lines, line_idx, "")
@@ -137,12 +150,21 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
 
       case segments do
         [{^original_line, %Minga.Core.Face{fg: nil}}] -> base_runs
-        _ -> Enum.map(segments, &segment_to_run/1)
+        _ -> Enum.map(segments, &segment_to_run(&1, code_bg(theme_syntax)))
       end
     end
   end
 
-  defp overlay_line(base_runs, _line_type, _idx, _orig, _offsets, _hl, _byte_offset) do
+  defp overlay_line(
+         base_runs,
+         _line_type,
+         _idx,
+         _orig,
+         _offsets,
+         _hl,
+         _theme_syntax,
+         _byte_offset
+       ) do
     base_runs
   end
 
@@ -156,10 +178,10 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
     map
   end
 
-  @spec segment_to_run(Highlight.styled_segment()) :: styled_run()
-  defp segment_to_run({text, %Minga.Core.Face{} = face}) do
+  @spec segment_to_run(Highlight.styled_segment(), non_neg_integer()) :: styled_run()
+  defp segment_to_run({text, %Minga.Core.Face{} = face}, default_bg) do
     fg = face.fg || 0
-    bg = face.bg || 0
+    bg = face.bg || default_bg
 
     flags =
       if(face.bold, do: @flag_bold, else: 0) +
@@ -171,6 +193,17 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
 
   # ── Regex-based style mapping ──────────────────────────────────────────────
 
+  @spec style_to_run(String.t(), Markdown.style(), map()) :: styled_run()
+  defp style_to_run(text, {:link, url}, theme) do
+    {fg, bg, flags} = md_style_to_colors({:link, url}, theme)
+    {text, fg, bg, flags, url}
+  end
+
+  defp style_to_run(text, style, theme) do
+    {fg, bg, flags} = md_style_to_colors(style, theme)
+    {text, fg, bg, flags}
+  end
+
   @spec md_style_to_colors(Markdown.style(), map()) ::
           {non_neg_integer(), non_neg_integer(), non_neg_integer()}
   defp md_style_to_colors(:bold, theme), do: {default_fg(theme), 0, @flag_bold}
@@ -180,6 +213,10 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
     do: {default_fg(theme), 0, @flag_bold + @flag_italic}
 
   defp md_style_to_colors(:code, theme), do: {code_fg(theme), code_bg(theme), 0}
+
+  defp md_style_to_colors({:link, _url}, theme),
+    do: {link_fg(theme), 0, @flag_underline + @flag_link}
+
   defp md_style_to_colors(:code_block, theme), do: {code_fg(theme), 0, 0}
   defp md_style_to_colors({:code_content, _lang}, theme), do: {code_fg(theme), code_bg(theme), 0}
   defp md_style_to_colors(:header1, theme), do: {header_fg(theme), 0, @flag_bold}
@@ -207,6 +244,9 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
 
   @spec comment_fg(map()) :: non_neg_integer()
   defp comment_fg(theme), do: theme_color(theme, "comment", 0x5B6268)
+
+  @spec link_fg(map()) :: non_neg_integer()
+  defp link_fg(theme), do: theme_color(theme, "markup.link.label", 0x61AFEF)
 
   @spec theme_color(map(), String.t(), non_neg_integer()) :: non_neg_integer()
   defp theme_color(theme, name, default) do

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -125,6 +125,12 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   @op_gui_agent_context 0x88
   @op_gui_change_summary 0x89
 
+  @max_u16 65_535
+  @chat_message_limit 100
+  @max_chat_text_bytes 60_000
+  @truncation_suffix "\n… [truncated]"
+  @chat_payload_omission_notice "Some agent chat content was omitted because the GUI chat payload exceeded 65KB."
+
   # ── Sectioned format section IDs ──
   # Used by opcodes that encode their fields in self-describing sections.
   # Format: section_id(1) + section_len(2, big-endian) + payload(section_len)
@@ -1559,8 +1565,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
         } = data
       ) do
     status_byte = encode_agent_chat_status(status)
-    model_bytes = :erlang.iolist_to_binary([model || ""])
-    prompt_bytes = :erlang.iolist_to_binary([prompt || ""])
+    model_bytes = utf8_prefix_bytes(model || "", @max_u16 - 2)
+    prompt_bytes = utf8_prefix_bytes(prompt || "", @max_u16 - 9)
 
     # Prompt metadata for the cell-grid renderer (cursor, mode, line count).
     # These fields are appended after the prompt string so existing decoders
@@ -1575,12 +1581,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     pending_bytes = encode_pending_approval(data[:pending_approval])
     help_bytes = encode_help_overlay(data[:help_visible], data[:help_groups])
 
-    msg_binaries =
-      messages
-      |> Enum.take(100)
-      |> Enum.map(&encode_chat_message/1)
-
-    messages_payload = IO.iodata_to_binary([<<length(msg_binaries)::16>> | msg_binaries])
+    messages_payload = encode_chat_messages(messages)
 
     sections = [
       encode_section(@section_chat_header, <<1::8, status_byte::8>>),
@@ -1727,8 +1728,10 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   defp summarize_tool_args(_name, args) when map_size(args) == 0, do: ""
   defp summarize_tool_args(_name, args), do: inspect(args, limit: 80)
 
-  @typedoc "A styled text run for GUI rendering: {text, fg_rgb, bg_rgb, flags}."
-  @type styled_run :: {String.t(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
+  @typedoc "A styled text run for GUI rendering: {text, fg_rgb, bg_rgb, flags} or {text, fg_rgb, bg_rgb, flags, url}."
+  @type styled_run ::
+          {String.t(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
+          | {String.t(), non_neg_integer(), non_neg_integer(), non_neg_integer(), String.t()}
 
   @typedoc "A line of styled runs."
   @type styled_line :: [styled_run()]
@@ -1747,6 +1750,121 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
                result: String.t() | nil
              }, [[styled_run()]]}
           | {:approval_tool_call, MingaAgent.ToolCall.t(), map()}
+
+  @spec encode_chat_messages([gui_chat_message() | {pos_integer(), gui_chat_message()}]) ::
+          binary()
+  defp encode_chat_messages(messages) do
+    messages = messages |> Enum.take(@chat_message_limit) |> Enum.map(&bound_chat_message_text/1)
+    payload = encode_chat_messages_payload(messages)
+
+    if byte_size(payload) <= @max_u16 do
+      payload
+    else
+      stripped_messages = Enum.map(messages, &strip_chat_message_links/1)
+      stripped_payload = encode_chat_messages_payload(stripped_messages)
+
+      if byte_size(stripped_payload) <= @max_u16 do
+        stripped_payload
+      else
+        stripped_messages
+        |> fit_chat_messages_to_payload_limit()
+        |> encode_chat_messages_payload()
+      end
+    end
+  end
+
+  @spec bound_chat_message_text(gui_chat_message() | {pos_integer(), gui_chat_message()}) ::
+          gui_chat_message() | {pos_integer(), gui_chat_message()}
+  defp bound_chat_message_text({id, msg}) when is_integer(id),
+    do: {id, bound_chat_message_text(msg)}
+
+  defp bound_chat_message_text({:user, text}),
+    do: {:user, utf8_prefix_bytes(text, @max_chat_text_bytes)}
+
+  defp bound_chat_message_text({:user, text, attachments}),
+    do: {:user, utf8_prefix_bytes(text, @max_chat_text_bytes), attachments}
+
+  defp bound_chat_message_text({:assistant, text}),
+    do: {:assistant, utf8_prefix_bytes(text, @max_chat_text_bytes)}
+
+  defp bound_chat_message_text({:thinking, text, collapsed}),
+    do: {:thinking, utf8_prefix_bytes(text, @max_chat_text_bytes), collapsed}
+
+  defp bound_chat_message_text({:system, text, level}),
+    do: {:system, utf8_prefix_bytes(text, @max_chat_text_bytes), level}
+
+  defp bound_chat_message_text(msg), do: msg
+
+  @spec fit_chat_messages_to_payload_limit([
+          gui_chat_message() | {pos_integer(), gui_chat_message()}
+        ]) ::
+          [gui_chat_message() | {pos_integer(), gui_chat_message()}]
+  defp fit_chat_messages_to_payload_limit(messages) do
+    {selected, omitted?} =
+      messages
+      |> Enum.reverse()
+      |> Enum.reduce({[], false}, fn msg, {selected, omitted?} ->
+        candidate = [msg | selected]
+
+        if byte_size(encode_chat_messages_payload(candidate)) <= @max_u16 do
+          {candidate, omitted?}
+        else
+          {selected, true}
+        end
+      end)
+
+    if omitted?, do: add_chat_payload_omission_notice(selected), else: selected
+  end
+
+  @spec add_chat_payload_omission_notice([
+          gui_chat_message() | {pos_integer(), gui_chat_message()}
+        ]) ::
+          [gui_chat_message() | {pos_integer(), gui_chat_message()}]
+  defp add_chat_payload_omission_notice([]) do
+    [{:system, @chat_payload_omission_notice, :info}]
+  end
+
+  defp add_chat_payload_omission_notice(messages) do
+    notice = {:system, @chat_payload_omission_notice, :info}
+
+    if byte_size(encode_chat_messages_payload([notice | messages])) <= @max_u16 do
+      [notice | messages]
+    else
+      [_dropped | rest] = messages
+      add_chat_payload_omission_notice(rest)
+    end
+  end
+
+  @spec encode_chat_messages_payload([gui_chat_message() | {pos_integer(), gui_chat_message()}]) ::
+          binary()
+  defp encode_chat_messages_payload(messages) do
+    msg_binaries = Enum.map(messages, &encode_chat_message/1)
+    IO.iodata_to_binary([<<length(msg_binaries)::16>> | msg_binaries])
+  end
+
+  @spec strip_chat_message_links(gui_chat_message() | {pos_integer(), gui_chat_message()}) ::
+          gui_chat_message() | {pos_integer(), gui_chat_message()}
+  defp strip_chat_message_links({id, msg}) when is_integer(id),
+    do: {id, strip_chat_message_links(msg)}
+
+  defp strip_chat_message_links({:styled_assistant, styled_lines}) do
+    {:styled_assistant, strip_styled_lines_links(styled_lines)}
+  end
+
+  defp strip_chat_message_links({:styled_tool_call, tc, styled_lines}) do
+    {:styled_tool_call, tc, strip_styled_lines_links(styled_lines)}
+  end
+
+  defp strip_chat_message_links(msg), do: msg
+
+  @spec strip_styled_lines_links([[styled_run()]]) :: [[styled_run()]]
+  defp strip_styled_lines_links(styled_lines) do
+    Enum.map(styled_lines, fn runs -> Enum.map(runs, &strip_styled_run_link/1) end)
+  end
+
+  @spec strip_styled_run_link(styled_run()) :: styled_run()
+  defp strip_styled_run_link({text, fg, bg, flags, _url}), do: {text, fg, bg, flags &&& 0xF3}
+  defp strip_styled_run_link(run), do: run
 
   # Unwrap {id, message} tuple: prefix with the stable uint32 ID, then encode the message.
   @spec encode_chat_message({pos_integer(), gui_chat_message()} | gui_chat_message()) :: binary()
@@ -1776,16 +1894,13 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   end
 
   # Styled assistant message: opcode 0x07, line_count::16, then per line:
-  # run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8
+  # run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8,
+  # and when flags bit 0x08 is set: url_len::16, url.
   defp encode_chat_message_body({:styled_assistant, styled_lines}) do
     line_binaries =
       Enum.map(styled_lines, fn runs ->
         run_binaries =
-          Enum.map(runs, fn {text, fg, bg, flags} ->
-            text_bytes = :erlang.iolist_to_binary([text])
-
-            <<byte_size(text_bytes)::16, text_bytes::binary, fg::24, bg::24, flags::8>>
-          end)
+          Enum.map(runs, &encode_styled_run/1)
 
         [<<length(runs)::16>> | run_binaries]
       end)
@@ -1851,8 +1966,9 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   # Styled tool call: same header fields as tool_call (0x04), but result is styled runs.
   # Sub-opcode 0x08. Layout:
   #   0x08, status::8, error::8, collapsed::8, duration::32,
-  #   name_len::16, name, line_count::16, then per line:
-  #   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8
+  #   name_len::16, name, summary_len::16, summary, line_count::16, then per line:
+  #   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8,
+  #   and when flags bit 0x08 is set: url_len::16, url.
   defp encode_chat_message_body({:styled_tool_call, tc, styled_lines}) do
     name_bytes = :erlang.iolist_to_binary([tc.name])
     summary_bytes = :erlang.iolist_to_binary([tool_call_summary(tc)])
@@ -1871,10 +1987,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     line_binaries =
       Enum.map(styled_lines, fn runs ->
         run_binaries =
-          Enum.map(runs, fn {text, fg, bg, flags} ->
-            text_bytes = :erlang.iolist_to_binary([text])
-            <<byte_size(text_bytes)::16, text_bytes::binary, fg::24, bg::24, flags::8>>
-          end)
+          Enum.map(runs, &encode_styled_run/1)
 
         [<<length(runs)::16>> | run_binaries]
       end)
@@ -1896,6 +2009,63 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   defp encode_chat_message_body({:usage, u}) do
     cost_int = round((u.cost || 0.0) * 1_000_000)
     <<0x06::8, u.input::32, u.output::32, u.cache_read::32, u.cache_write::32, cost_int::32>>
+  end
+
+  @spec encode_styled_run(styled_run()) :: binary()
+  defp encode_styled_run({text, fg, bg, flags, url}) do
+    text_bytes = utf8_prefix_bytes(text, @max_u16)
+    url_bytes = :erlang.iolist_to_binary([url])
+
+    if byte_size(url_bytes) <= @max_u16 do
+      link_flags = flags ||| 0x08
+
+      <<byte_size(text_bytes)::16, text_bytes::binary, fg::24, bg::24, link_flags::8,
+        byte_size(url_bytes)::16, url_bytes::binary>>
+    else
+      non_link_flags = flags &&& 0xF3
+      encode_styled_run({text, fg, bg, non_link_flags})
+    end
+  end
+
+  defp encode_styled_run({text, fg, bg, flags}) do
+    text_bytes = utf8_prefix_bytes(text, @max_u16)
+    safe_flags = flags &&& 0xF7
+    <<byte_size(text_bytes)::16, text_bytes::binary, fg::24, bg::24, safe_flags::8>>
+  end
+
+  @spec utf8_prefix_bytes(String.t(), non_neg_integer()) :: binary()
+  defp utf8_prefix_bytes(text, max_bytes) when byte_size(text) <= max_bytes do
+    :erlang.iolist_to_binary([text])
+  end
+
+  defp utf8_prefix_bytes(text, max_bytes) do
+    suffix_bytes = :erlang.iolist_to_binary([@truncation_suffix])
+
+    if max_bytes <= byte_size(suffix_bytes) do
+      valid_utf8_prefix(text, max_bytes)
+    else
+      valid_utf8_prefix(text, max_bytes - byte_size(suffix_bytes)) <> suffix_bytes
+    end
+  end
+
+  @spec valid_utf8_prefix(String.t(), non_neg_integer()) :: binary()
+  defp valid_utf8_prefix(_text, 0), do: ""
+
+  defp valid_utf8_prefix(text, max_bytes) do
+    text
+    |> binary_part(0, min(max_bytes, byte_size(text)))
+    |> trim_invalid_utf8_suffix()
+  end
+
+  @spec trim_invalid_utf8_suffix(binary()) :: binary()
+  defp trim_invalid_utf8_suffix(<<>>), do: ""
+
+  defp trim_invalid_utf8_suffix(prefix) do
+    if String.valid?(prefix) do
+      prefix
+    else
+      prefix |> binary_part(0, byte_size(prefix) - 1) |> trim_invalid_utf8_suffix()
+    end
   end
 
   @spec encode_agent_chat_status(atom()) :: non_neg_integer()

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -882,63 +882,64 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 guard csLen >= 2 else { break }
                 let msgCount = Int(readU16(data, csStart))
                 messages.reserveCapacity(msgCount)
+                let messagesEnd = csStart + csLen
                 var pos = csStart + 2
         for _ in 0..<msgCount {
             // Each message is prefixed with a stable uint32 ID from the BEAM
-            guard data.count >= pos + 5 else { throw ProtocolDecodeError.malformed }
+            guard messagesEnd >= pos + 5 else { throw ProtocolDecodeError.malformed }
             let beamId = readU32(data, pos)
             pos += 4
             let msgType = data[pos]
             switch msgType {
             case 0x01: // user
-                guard data.count >= pos + 5 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 5 else { throw ProtocolDecodeError.malformed }
                 let tLen = Int(readU32(data, pos + 1))
-                guard data.count >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
                 let t = String(data: data[(pos + 5)..<(pos + 5 + tLen)], encoding: .utf8) ?? ""
                 messages.append(Wire.ChatMessage(beamId: beamId, content: .user(text: t)))
                 pos += 5 + tLen
             case 0x02: // assistant
-                guard data.count >= pos + 5 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 5 else { throw ProtocolDecodeError.malformed }
                 let tLen = Int(readU32(data, pos + 1))
-                guard data.count >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
                 let t = String(data: data[(pos + 5)..<(pos + 5 + tLen)], encoding: .utf8) ?? ""
                 messages.append(Wire.ChatMessage(beamId: beamId, content: .assistant(text: t)))
                 pos += 5 + tLen
             case 0x03: // thinking
-                guard data.count >= pos + 6 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 6 else { throw ProtocolDecodeError.malformed }
                 let collapsed = data[pos + 1] != 0
                 let tLen = Int(readU32(data, pos + 2))
-                guard data.count >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
                 let t = String(data: data[(pos + 6)..<(pos + 6 + tLen)], encoding: .utf8) ?? ""
                 messages.append(Wire.ChatMessage(beamId: beamId, content: .thinking(text: t, collapsed: collapsed)))
                 pos += 6 + tLen
             case 0x04: // tool_call
-                guard data.count >= pos + 10 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 10 else { throw ProtocolDecodeError.malformed }
                 let tcStatus = data[pos + 1]
                 let isError = data[pos + 2] != 0
                 let tcCollapsed = data[pos + 3] != 0
                 let duration = readU32(data, pos + 4)
                 let nameLen = Int(readU16(data, pos + 8))
-                guard data.count >= pos + 10 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 10 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
                 let name = String(data: data[(pos + 10)..<(pos + 10 + nameLen)], encoding: .utf8) ?? ""
                 let summaryLen = Int(readU16(data, pos + 10 + nameLen))
-                guard data.count >= pos + 12 + nameLen + summaryLen + 4 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 12 + nameLen + summaryLen + 4 else { throw ProtocolDecodeError.malformed }
                 let summary = String(data: data[(pos + 12 + nameLen)..<(pos + 12 + nameLen + summaryLen)], encoding: .utf8) ?? ""
                 let resultLen = Int(readU32(data, pos + 12 + nameLen + summaryLen))
-                guard data.count >= pos + 16 + nameLen + summaryLen + resultLen else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 16 + nameLen + summaryLen + resultLen else { throw ProtocolDecodeError.malformed }
                 let result = String(data: data[(pos + 16 + nameLen + summaryLen)..<(pos + 16 + nameLen + summaryLen + resultLen)], encoding: .utf8) ?? ""
                 messages.append(Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, durationMs: duration, result: result)))
                 pos += 16 + nameLen + summaryLen + resultLen
             case 0x05: // system
-                guard data.count >= pos + 6 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 6 else { throw ProtocolDecodeError.malformed }
                 let isError = data[pos + 1] != 0
                 let tLen = Int(readU32(data, pos + 2))
-                guard data.count >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
                 let t = String(data: data[(pos + 6)..<(pos + 6 + tLen)], encoding: .utf8) ?? ""
                 messages.append(Wire.ChatMessage(beamId: beamId, content: .system(text: t, isError: isError)))
                 pos += 6 + tLen
             case 0x06: // usage
-                guard data.count >= pos + 21 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 21 else { throw ProtocolDecodeError.malformed }
                 let inp = readU32(data, pos + 1)
                 let outp = readU32(data, pos + 5)
                 let cacheR = readU32(data, pos + 9)
@@ -948,22 +949,23 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 pos += 21
             case 0x07: // styled_assistant
                 // Format: 0x07, line_count::16, then per line:
-                //   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8
-                guard data.count >= pos + 3 else { throw ProtocolDecodeError.malformed }
+                //   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8,
+                //   and when flags bit 0x08 is set: url_len::16, url.
+                guard messagesEnd >= pos + 3 else { throw ProtocolDecodeError.malformed }
                 let lineCount = Int(readU16(data, pos + 1))
                 var lines: [[Wire.StyledTextRun]] = []
                 lines.reserveCapacity(lineCount)
                 var rPos = pos + 3
                 for _ in 0..<lineCount {
-                    guard data.count >= rPos + 2 else { throw ProtocolDecodeError.malformed }
+                    guard messagesEnd >= rPos + 2 else { throw ProtocolDecodeError.malformed }
                     let runCount = Int(readU16(data, rPos))
                     var runs: [Wire.StyledTextRun] = []
                     runs.reserveCapacity(runCount)
                     rPos += 2
                     for _ in 0..<runCount {
-                        guard data.count >= rPos + 9 else { throw ProtocolDecodeError.malformed }
+                        guard messagesEnd >= rPos + 9 else { throw ProtocolDecodeError.malformed }
                         let textLen = Int(readU16(data, rPos))
-                        guard data.count >= rPos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
+                        guard messagesEnd >= rPos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
                         let runText = String(data: data[(rPos + 2)..<(rPos + 2 + textLen)], encoding: .utf8) ?? ""
                         let fgOff = rPos + 2 + textLen
                         let fgR = data[fgOff]
@@ -973,15 +975,26 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                         let bgG = data[fgOff + 4]
                         let bgB = data[fgOff + 5]
                         let flags = data[fgOff + 6]
+                        var nextRunPos = fgOff + 7
+                        var linkURL: String? = nil
+                        if (flags & 0x08) != 0 {
+                            guard messagesEnd >= nextRunPos + 2 else { throw ProtocolDecodeError.malformed }
+                            let urlLen = Int(readU16(data, nextRunPos))
+                            guard messagesEnd >= nextRunPos + 2 + urlLen else { throw ProtocolDecodeError.malformed }
+                            guard let decodedLinkURL = String(data: data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+                            linkURL = decodedLinkURL
+                            nextRunPos += 2 + urlLen
+                        }
                         runs.append(Wire.StyledTextRun(
                             text: runText,
                             fgR: fgR, fgG: fgG, fgB: fgB,
                             bgR: bgR, bgG: bgG, bgB: bgB,
                             bold: (flags & 0x01) != 0,
                             italic: (flags & 0x02) != 0,
-                            underline: (flags & 0x04) != 0
+                            underline: (flags & 0x04) != 0,
+                            linkURL: linkURL
                         ))
-                        rPos = fgOff + 7
+                        rPos = nextRunPos
                     }
                     lines.append(runs)
                 }
@@ -991,58 +1004,71 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 // Same header as tool_call (0x04) but result is styled runs instead of plain text.
                 // Format: 0x08, status::8, error::8, collapsed::8, duration::32,
                 //   name_len::16, name, summary_len::16, summary, line_count::16, then per line:
-                //   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8
-                guard data.count >= pos + 10 else { throw ProtocolDecodeError.malformed }
+                //   run_count::16, then per run: text_len::16, text, fg::24, bg::24, flags::8,
+                //   and when flags bit 0x08 is set: url_len::16, url.
+                guard messagesEnd >= pos + 10 else { throw ProtocolDecodeError.malformed }
                 let stcStatus = data[pos + 1]
                 let stcIsError = data[pos + 2] != 0
                 let stcCollapsed = data[pos + 3] != 0
                 let stcDuration = readU32(data, pos + 4)
                 let stcNameLen = Int(readU16(data, pos + 8))
-                guard data.count >= pos + 10 + stcNameLen + 2 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 10 + stcNameLen + 2 else { throw ProtocolDecodeError.malformed }
                 let stcName = String(data: data[(pos + 10)..<(pos + 10 + stcNameLen)], encoding: .utf8) ?? ""
                 let stcSummaryLen = Int(readU16(data, pos + 10 + stcNameLen))
-                guard data.count >= pos + 12 + stcNameLen + stcSummaryLen + 2 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 12 + stcNameLen + stcSummaryLen + 2 else { throw ProtocolDecodeError.malformed }
                 let stcSummary = String(data: data[(pos + 12 + stcNameLen)..<(pos + 12 + stcNameLen + stcSummaryLen)], encoding: .utf8) ?? ""
                 let stcLineCount = Int(readU16(data, pos + 12 + stcNameLen + stcSummaryLen))
                 var stcLines: [[Wire.StyledTextRun]] = []
                 stcLines.reserveCapacity(stcLineCount)
                 var stcPos = pos + 14 + stcNameLen + stcSummaryLen
                 for _ in 0..<stcLineCount {
-                    guard data.count >= stcPos + 2 else { throw ProtocolDecodeError.malformed }
+                    guard messagesEnd >= stcPos + 2 else { throw ProtocolDecodeError.malformed }
                     let runCount = Int(readU16(data, stcPos))
                     var runs: [Wire.StyledTextRun] = []
                     runs.reserveCapacity(runCount)
                     stcPos += 2
                     for _ in 0..<runCount {
-                        guard data.count >= stcPos + 9 else { throw ProtocolDecodeError.malformed }
+                        guard messagesEnd >= stcPos + 9 else { throw ProtocolDecodeError.malformed }
                         let textLen = Int(readU16(data, stcPos))
-                        guard data.count >= stcPos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
+                        guard messagesEnd >= stcPos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
                         let runText = String(data: data[(stcPos + 2)..<(stcPos + 2 + textLen)], encoding: .utf8) ?? ""
                         let fgOff = stcPos + 2 + textLen
+                        let flags = data[fgOff + 6]
+                        var nextRunPos = fgOff + 7
+                        var linkURL: String? = nil
+                        if (flags & 0x08) != 0 {
+                            guard messagesEnd >= nextRunPos + 2 else { throw ProtocolDecodeError.malformed }
+                            let urlLen = Int(readU16(data, nextRunPos))
+                            guard messagesEnd >= nextRunPos + 2 + urlLen else { throw ProtocolDecodeError.malformed }
+                            guard let decodedLinkURL = String(data: data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+                            linkURL = decodedLinkURL
+                            nextRunPos += 2 + urlLen
+                        }
                         runs.append(Wire.StyledTextRun(
                             text: runText,
                             fgR: data[fgOff], fgG: data[fgOff + 1], fgB: data[fgOff + 2],
                             bgR: data[fgOff + 3], bgG: data[fgOff + 4], bgB: data[fgOff + 5],
-                            bold: (data[fgOff + 6] & 0x01) != 0,
-                            italic: (data[fgOff + 6] & 0x02) != 0,
-                            underline: (data[fgOff + 6] & 0x04) != 0
+                            bold: (flags & 0x01) != 0,
+                            italic: (flags & 0x02) != 0,
+                            underline: (flags & 0x04) != 0,
+                            linkURL: linkURL
                         ))
-                        stcPos = fgOff + 7
+                        stcPos = nextRunPos
                     }
                     stcLines.append(runs)
                 }
                 messages.append(Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, durationMs: stcDuration, resultLines: stcLines)))
                 pos = stcPos
             case 0x09: // approval_tool_call
-                guard data.count >= pos + 8 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 8 else { throw ProtocolDecodeError.malformed }
                 let nameLen = Int(readU16(data, pos + 2))
-                guard data.count >= pos + 4 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 4 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
                 let name = String(data: data[(pos + 4)..<(pos + 4 + nameLen)], encoding: .utf8) ?? ""
                 let summaryLen = Int(readU16(data, pos + 4 + nameLen))
-                guard data.count >= pos + 6 + nameLen + summaryLen + 2 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 6 + nameLen + summaryLen + 2 else { throw ProtocolDecodeError.malformed }
                 let summary = String(data: data[(pos + 6 + nameLen)..<(pos + 6 + nameLen + summaryLen)], encoding: .utf8) ?? ""
                 let idLen = Int(readU16(data, pos + 6 + nameLen + summaryLen))
-                guard data.count >= pos + 8 + nameLen + summaryLen + idLen + 3 else { throw ProtocolDecodeError.malformed }
+                guard messagesEnd >= pos + 8 + nameLen + summaryLen + idLen + 3 else { throw ProtocolDecodeError.malformed }
                 let toolCallId = String(data: data[(pos + 8 + nameLen + summaryLen)..<(pos + 8 + nameLen + summaryLen + idLen)], encoding: .utf8) ?? ""
                 let previewKind = data[pos + 8 + nameLen + summaryLen + idLen]
                 let lineCount = Int(readU16(data, pos + 9 + nameLen + summaryLen + idLen))
@@ -1050,9 +1076,9 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 var previewLines: [String] = []
                 previewLines.reserveCapacity(lineCount)
                 for _ in 0..<lineCount {
-                    guard data.count >= approvalPos + 2 else { throw ProtocolDecodeError.malformed }
+                    guard messagesEnd >= approvalPos + 2 else { throw ProtocolDecodeError.malformed }
                     let lineLen = Int(readU16(data, approvalPos))
-                    guard data.count >= approvalPos + 2 + lineLen else { throw ProtocolDecodeError.malformed }
+                    guard messagesEnd >= approvalPos + 2 + lineLen else { throw ProtocolDecodeError.malformed }
                     let line = String(data: data[(approvalPos + 2)..<(approvalPos + 2 + lineLen)], encoding: .utf8) ?? ""
                     previewLines.append(line)
                     approvalPos += 2 + lineLen
@@ -1060,9 +1086,10 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
                 messages.append(Wire.ChatMessage(beamId: beamId, content: .approvalToolCall(name: name, summary: summary, toolCallId: toolCallId, previewKind: previewKind, previewLines: previewLines)))
                 pos = approvalPos
             default:
-                break
+                throw ProtocolDecodeError.malformed
             }
         }
+                guard pos == messagesEnd else { throw ProtocolDecodeError.malformed }
 
             default: break
             }

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -337,6 +337,21 @@ enum Wire {
         let bold: Bool
         let italic: Bool
         let underline: Bool
+        let linkURL: String?
+
+        init(text: String, fgR: UInt8, fgG: UInt8, fgB: UInt8, bgR: UInt8, bgG: UInt8, bgB: UInt8, bold: Bool, italic: Bool, underline: Bool, linkURL: String? = nil) {
+            self.text = text
+            self.fgR = fgR
+            self.fgG = fgG
+            self.fgB = fgB
+            self.bgR = bgR
+            self.bgG = bgG
+            self.bgB = bgB
+            self.bold = bold
+            self.italic = italic
+            self.underline = underline
+            self.linkURL = linkURL
+        }
     }
 
     /// A help group from gui_agent_chat, containing a category title and keybindings.

--- a/macos/Sources/Views/AgentChatView.swift
+++ b/macos/Sources/Views/AgentChatView.swift
@@ -259,16 +259,7 @@ struct AgentChatView: View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
                 ForEach(Array(lines.enumerated()), id: \.offset) { _, runs in
-                    if runs.isEmpty || (runs.count == 1 && runs[0].text.isEmpty) {
-                        // Empty line: render as a spacer with line height
-                        Text(" ")
-                            .font(.system(size: 13))
-                            .foregroundStyle(.clear)
-                    } else {
-                        Text(buildAttributedString(runs))
-                            .font(.system(size: 13))
-                            .textSelection(.enabled)
-                    }
+                    styledLineView(runs, baseFontSize: 13, monospaced: false)
                 }
             }
             Spacer(minLength: 40)
@@ -311,9 +302,53 @@ struct AgentChatView: View {
             if run.underline {
                 attr.underlineStyle = .single
             }
+            if let url = safeLinkURL(run.linkURL) {
+                attr.link = url
+            }
             result += attr
         }
         return result
+    }
+
+    @ViewBuilder
+    private func styledLineView(_ runs: [Wire.StyledTextRun], baseFontSize: CGFloat, monospaced: Bool) -> some View {
+        if runs.isEmpty || (runs.count == 1 && runs[0].text.isEmpty) {
+            Text(" ")
+                .font(.system(size: baseFontSize, design: monospaced ? .monospaced : .default))
+                .foregroundStyle(.clear)
+        } else if shouldScrollHorizontally(runs) {
+            ScrollView(.horizontal) {
+                Text(buildAttributedString(runs, baseFontSize: baseFontSize, monospaced: monospaced))
+                    .font(.system(size: baseFontSize, design: monospaced ? .monospaced : .default))
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+        } else {
+            Text(buildAttributedString(runs, baseFontSize: baseFontSize, monospaced: monospaced))
+                .font(.system(size: baseFontSize, design: monospaced ? .monospaced : .default))
+                .textSelection(.enabled)
+        }
+    }
+
+    private func shouldScrollHorizontally(_ runs: [Wire.StyledTextRun]) -> Bool {
+        let textRuns = runs.filter { !$0.text.isEmpty }
+        return !textRuns.isEmpty && textRuns.allSatisfy { run in
+            run.bgR != 0 || run.bgG != 0 || run.bgB != 0
+        }
+    }
+
+    private func safeLinkURL(_ value: String?) -> URL? {
+        guard let value, let url = URL(string: value), let scheme = url.scheme?.lowercased() else { return nil }
+        switch scheme {
+        case "http", "https":
+            guard let host = url.host, !host.isEmpty else { return nil }
+            return url
+        case "mailto":
+            guard !url.path.isEmpty else { return nil }
+            return url
+        default:
+            return nil
+        }
     }
 
     @ViewBuilder
@@ -403,19 +438,12 @@ struct AgentChatView: View {
                     .fill(theme.agentToolBorder.opacity(0.2))
                     .frame(height: 1)
 
-                ScrollView(.vertical) {
+                ScrollView([.horizontal, .vertical]) {
                     if let lines = resultLines, !lines.isEmpty {
                         // Styled result with tree-sitter/markdown formatting
                         VStack(alignment: .leading, spacing: 2) {
                             ForEach(Array(lines.enumerated()), id: \.offset) { _, runs in
-                                if runs.isEmpty || (runs.count == 1 && runs[0].text.isEmpty) {
-                                    Text(" ")
-                                        .font(.system(size: 11, design: .monospaced))
-                                        .foregroundStyle(.clear)
-                                } else {
-                                    Text(buildAttributedString(runs, baseFontSize: 11, monospaced: true))
-                                        .textSelection(.enabled)
-                                }
+                                styledLineView(runs, baseFontSize: 11, monospaced: true)
                             }
                         }
                         .padding(10)
@@ -425,6 +453,7 @@ struct AgentChatView: View {
                             .font(.system(size: 11, design: .monospaced))
                             .foregroundStyle(theme.agentTextFg.opacity(0.7))
                             .textSelection(.enabled)
+                            .fixedSize(horizontal: true, vertical: false)
                             .padding(10)
                     }
                 }

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -1285,6 +1285,84 @@ struct GUIAgentChatDecoderTests {
         #expect(lines[1][0].text == "  :ok")
         #expect(lines[1][0].underline == true)
     }
+
+    @Test("Decode gui_agent_chat styled_assistant link run")
+    func decodeStyledAssistantLinkRun() throws {
+        var msgs = Data()
+        appendU32(&msgs, 42) // beam_id
+        msgs.append(0x07) // type=styled_assistant
+        appendU16(&msgs, 1) // 1 line
+        appendU16(&msgs, 1) // 1 run
+        appendString16(&msgs, "docs")
+        appendRGB(&msgs, 0x61, 0xAF, 0xEF); appendRGB(&msgs, 0x00, 0x00, 0x00); msgs.append(0x0C) // underline + link
+        appendString16(&msgs, "https://example.com/docs")
+
+        let data = buildChatData(model: "claude", messages: buildMessagesPayload(count: 1, msgs))
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+
+        guard case .guiAgentChat(_, _, _, _, _, _, _, _, _, _, _, _, _, _, let messages) = cmd else { Issue.record("Expected .guiAgentChat"); return }
+        guard case .styledAssistant(let lines) = messages[0].content else { Issue.record("Expected .styledAssistant"); return }
+        #expect(lines[0][0].text == "docs")
+        #expect(lines[0][0].underline == true)
+        #expect(lines[0][0].linkURL == "https://example.com/docs")
+    }
+
+    @Test("Decode gui_agent_chat rejects invalid UTF-8 in styled_assistant link URL")
+    func decodeStyledAssistantRejectsInvalidLinkURLUTF8() {
+        var msgs = Data()
+        appendU32(&msgs, 42)
+        msgs.append(0x07)
+        appendU16(&msgs, 1)
+        appendU16(&msgs, 1)
+        appendString16(&msgs, "docs")
+        appendRGB(&msgs, 0x61, 0xAF, 0xEF); appendRGB(&msgs, 0x00, 0x00, 0x00); msgs.append(0x0C)
+        appendU16(&msgs, 1)
+        msgs.append(0xFF)
+
+        let data = buildChatData(model: "claude", messages: buildMessagesPayload(count: 1, msgs))
+        #expect(throws: ProtocolDecodeError.self) {
+            try decodeCommand(data: data, offset: 0)
+        }
+    }
+
+    @Test("Decode gui_agent_chat rejects styled link URL length crossing section boundary")
+    func decodeStyledAssistantRejectsLinkURLCrossingSectionBoundary() {
+        var headerPayload = Data()
+        headerPayload.append(1)
+        headerPayload.append(0)
+
+        var modelPayload = Data()
+        appendString16(&modelPayload, "claude")
+
+        var promptPayload = Data()
+        appendString16(&promptPayload, "")
+
+        var msgs = Data()
+        appendU32(&msgs, 42)
+        msgs.append(0x07)
+        appendU16(&msgs, 1)
+        appendU16(&msgs, 1)
+        appendString16(&msgs, "docs")
+        appendRGB(&msgs, 0x61, 0xAF, 0xEF); appendRGB(&msgs, 0x00, 0x00, 0x00); msgs.append(0x0C)
+        appendU16(&msgs, 4)
+        msgs.append(contentsOf: "h".utf8)
+
+        var data = Data()
+        data.append(OP_GUI_AGENT_CHAT)
+        data.append(7)
+        data.append(contentsOf: buildSectionData(0x01, headerPayload))
+        data.append(contentsOf: buildSectionData(0x02, modelPayload))
+        data.append(contentsOf: buildSectionData(0x03, promptPayload))
+        data.append(contentsOf: buildSectionData(0x04, Data([0])))
+        data.append(contentsOf: buildSectionData(0x05, Data([0])))
+        data.append(contentsOf: buildSectionData(0x06, buildMessagesPayload(count: 1, msgs)))
+        data.append(contentsOf: buildSectionData(0x07, Data([0, 0, 0, 0])))
+
+        #expect(throws: ProtocolDecodeError.self) {
+            try decodeCommand(data: data, offset: 0)
+        }
+    }
 }
 
 // MARK: - gui_tool_manager (0x7E)

--- a/test/minga_agent/markdown_test.exs
+++ b/test/minga_agent/markdown_test.exs
@@ -38,6 +38,77 @@ defmodule MingaAgent.MarkdownTest do
       assert [{"Use ", :plain}, {"mix compile", :code}, {" here", :plain}] = segments
     end
 
+    test "parses links" do
+      result = Markdown.parse("Read [the docs](https://example.com/docs) today")
+      assert [{segments, :text}] = result
+
+      assert [
+               {"Read ", :plain},
+               {"the docs", {:link, "https://example.com/docs"}},
+               {" today", :plain}
+             ] = segments
+    end
+
+    test "keeps malformed links as plain text" do
+      result = Markdown.parse("Read [the docs](")
+      assert [{segments, :text}] = result
+      assert [{"Read [the docs](", :plain}] = segments
+    end
+
+    test "does not merge bracket text before a later link" do
+      result = Markdown.parse("See [draft] and [docs](https://example.com)")
+      assert [{segments, :text}] = result
+
+      assert [
+               {"See [draft] and ", :plain},
+               {"docs", {:link, "https://example.com"}}
+             ] = segments
+    end
+
+    test "renders unsafe link schemes as plain text" do
+      result = Markdown.parse("Open [local file](file:///etc/passwd) now")
+      assert [{segments, :text}] = result
+      assert [{"Open local file now", :plain}] = segments
+    end
+
+    test "parses uppercase safe link schemes" do
+      result = Markdown.parse("Read [docs](HTTPS://example.com/docs)")
+      assert [{segments, :text}] = result
+      assert [{"Read ", :plain}, {"docs", {:link, "HTTPS://example.com/docs"}}] = segments
+    end
+
+    test "parses mailto links" do
+      result = Markdown.parse("Email [support](mailto:support@example.com)")
+      assert [{segments, :text}] = result
+      assert [{"Email ", :plain}, {"support", {:link, "mailto:support@example.com"}}] = segments
+    end
+
+    test "requires hosts for http links and paths for mailto links" do
+      assert [{[{"Broken link", :plain}], :text}] = Markdown.parse("[Broken link](https://)")
+      assert [{[{"Empty mail", :plain}], :text}] = Markdown.parse("[Empty mail](mailto:)")
+    end
+
+    test "rejects malformed urls with whitespace or invalid host characters" do
+      assert [{[{"Bad host", :plain}], :text}] =
+               Markdown.parse("[Bad host](https://exa mple.com)")
+
+      assert [{[{"Bad chars", :plain}], :text}] =
+               Markdown.parse("[Bad chars](https://exa[mple.com)")
+
+      assert [{[{"Bad escape", :plain}], :text}] = Markdown.parse("[Bad escape](https://%zz)")
+      assert [{[{"Bad mail", :plain}], :text}] = Markdown.parse("[Bad mail](mailto:foo bar)")
+    end
+
+    test "preserves links inside blockquotes" do
+      result = Markdown.parse("> See [docs](https://example.com)")
+      assert [{segments, :blockquote}] = result
+
+      assert [
+               {"│ See ", :blockquote},
+               {"docs", {:link, "https://example.com"}}
+             ] = segments
+    end
+
     test "parses H1 header" do
       result = Markdown.parse("# Title")
       assert [{[{"Title", :header1}], :header}] = result
@@ -68,6 +139,11 @@ defmodule MingaAgent.MarkdownTest do
     test "parses blockquotes" do
       result = Markdown.parse("> Some quote")
       assert [{_segments, :blockquote}] = result
+    end
+
+    test "parses blockquotes without a space after the marker" do
+      result = Markdown.parse(">Some quote")
+      assert [{[{"│ Some quote", :blockquote}], :blockquote}] = result
     end
 
     test "parses horizontal rules" do
@@ -123,7 +199,9 @@ defmodule MingaAgent.MarkdownTest do
     end
 
     test "handles mixed formatting in one line" do
-      result = Markdown.parse("This is **bold** and *italic* and `code`")
+      result =
+        Markdown.parse("This is **bold** and *italic* and `code` and [link](https://example.com)")
+
       assert [{segments, :text}] = result
 
       assert [
@@ -132,7 +210,9 @@ defmodule MingaAgent.MarkdownTest do
                {" and ", :plain},
                {"italic", :italic},
                {" and ", :plain},
-               {"code", :code}
+               {"code", :code},
+               {" and ", :plain},
+               {"link", {:link, "https://example.com"}}
              ] = segments
     end
 

--- a/test/minga_editor/agent/markdown_highlight_test.exs
+++ b/test/minga_editor/agent/markdown_highlight_test.exs
@@ -22,7 +22,8 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
     "string" => [fg: 0x98BE65],
     "comment" => [fg: 0x5B6268],
     "variable" => [fg: 0xBBC2CF],
-    "function" => [fg: 0xC678DD]
+    "function" => [fg: 0xC678DD],
+    "markup.link.label" => [fg: 0x61AFEF]
   }
 
   describe "stylize/4 with no highlight data (fallback path)" do
@@ -79,6 +80,23 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
       assert bg == 0x21242B
     end
 
+    test "link text strips markdown and carries url metadata" do
+      text = "Read [the docs](https://example.com/docs)"
+      result = MarkdownHighlight.stylize(text, nil, @theme_syntax)
+
+      line = hd(result)
+
+      link_run =
+        Enum.find(line, fn
+          {"the docs", _fg, _bg, _flags, _url} -> true
+          _ -> false
+        end)
+
+      assert {"the docs", 0x61AFEF, 0, flags, "https://example.com/docs"} = link_run
+      assert Bitwise.band(flags, 0x04) != 0
+      assert Bitwise.band(flags, 0x08) != 0
+    end
+
     test "multiline text produces multiple lines" do
       text = "line one\nline two\nline three"
       result = MarkdownHighlight.stylize(text, nil, @theme_syntax)
@@ -121,8 +139,9 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
       keyword_run = Enum.find(code_line, fn {t, _, _, _} -> t == "def" end)
       assert keyword_run != nil, "expected tree-sitter to produce a 'def' run"
 
-      {_, fg, _, flags} = keyword_run
+      {_, fg, bg, flags} = keyword_run
       assert fg == 0xFF0000
+      assert bg != 0
       assert Bitwise.band(flags, 0x01) != 0
     end
 

--- a/test/minga_editor/frontend/gui_agent_chat_protocol_test.exs
+++ b/test/minga_editor/frontend/gui_agent_chat_protocol_test.exs
@@ -108,6 +108,130 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
       assert flags == 0x01
     end
 
+    test "encodes styled assistant link runs with url metadata" do
+      styled_lines = [
+        [{"docs", 0x61AFEF, 0, 0x0C, "https://example.com/docs"}]
+      ]
+
+      data = %{
+        visible: true,
+        messages: [{:styled_assistant, styled_lines}],
+        status: :idle,
+        model: "test",
+        prompt: "",
+        pending_approval: nil
+      }
+
+      binary = ProtocolGUI.encode_gui_agent_chat(data)
+      messages_payload = extract_section(binary, 0x06)
+
+      <<1::16, 0::32, 0x07::8, 1::16, 1::16, text_len::16, text::binary-size(text_len), fg::24,
+        bg::24, flags::8, url_len::16, url::binary-size(url_len)>> = messages_payload
+
+      assert text == "docs"
+      assert fg == 0x61AFEF
+      assert bg == 0
+      assert Bitwise.band(flags, 0x08) != 0
+      assert url == "https://example.com/docs"
+    end
+
+    test "masks link flag on styled runs without url metadata" do
+      styled_lines = [
+        [{"not a link", 0xBBC2CF, 0, 0x08}]
+      ]
+
+      data = %{
+        visible: true,
+        messages: [{:styled_assistant, styled_lines}],
+        status: :idle,
+        model: "test",
+        prompt: "",
+        pending_approval: nil
+      }
+
+      binary = ProtocolGUI.encode_gui_agent_chat(data)
+      messages_payload = extract_section(binary, 0x06)
+
+      <<1::16, 0::32, 0x07::8, 1::16, 1::16, text_len::16, _text::binary-size(text_len), _fg::24,
+        _bg::24, flags::8>> = messages_payload
+
+      assert Bitwise.band(flags, 0x08) == 0
+    end
+
+    test "downgrades overlong link urls instead of corrupting styled run framing" do
+      for url <- [String.duplicate("a", 65_535), String.duplicate("a", 65_536)] do
+        styled_lines = [
+          [{"docs", 0x61AFEF, 0, 0x0C, url}]
+        ]
+
+        data = %{
+          visible: true,
+          messages: [{:styled_assistant, styled_lines}],
+          status: :idle,
+          model: "test",
+          prompt: "",
+          pending_approval: nil
+        }
+
+        binary = ProtocolGUI.encode_gui_agent_chat(data)
+        messages_payload = extract_section(binary, 0x06)
+
+        <<1::16, 0::32, 0x07::8, 1::16, 1::16, text_len::16, text::binary-size(text_len), _fg::24,
+          _bg::24, flags::8>> = messages_payload
+
+        assert text == "docs"
+        assert Bitwise.band(flags, 0x08) == 0
+        assert Bitwise.band(flags, 0x04) == 0
+      end
+    end
+
+    test "truncates oversized plain chat text before section encoding" do
+      text = String.duplicate("x", 70_000)
+
+      data = %{
+        visible: true,
+        messages: [{:assistant, text}],
+        status: :idle,
+        model: "test",
+        prompt: "",
+        pending_approval: nil
+      }
+
+      binary = ProtocolGUI.encode_gui_agent_chat(data)
+      messages_payload = extract_section(binary, 0x06)
+
+      assert byte_size(messages_payload) <= 65_535
+
+      <<1::16, 0::32, 0x02::8, text_len::32, encoded_text::binary-size(text_len)>> =
+        messages_payload
+
+      assert byte_size(encoded_text) == 60_000
+      assert String.ends_with?(encoded_text, "… [truncated]")
+    end
+
+    test "omits older chat messages instead of overflowing the messages section" do
+      text = String.duplicate("x", 70_000)
+
+      data = %{
+        visible: true,
+        messages: [{1, {:assistant, text}}, {2, {:assistant, text}}],
+        status: :idle,
+        model: "test",
+        prompt: "",
+        pending_approval: nil
+      }
+
+      binary = ProtocolGUI.encode_gui_agent_chat(data)
+      messages_payload = extract_section(binary, 0x06)
+
+      assert byte_size(messages_payload) <= 65_535
+
+      <<2::16, 0::32, 0x05::8, 0::8, notice_len::32, notice::binary-size(notice_len), 2::32,
+        0x02::8, _rest::binary>> = messages_payload
+
+      assert notice =~ "omitted"
+    end
+
     test "encodes regular tool_call with sub-opcode 0x04" do
       tc = %MingaAgent.ToolCall{
         id: "tc-regular",


### PR DESCRIPTION
# TL;DR
Agent chat markdown now supports clickable safe links and horizontally scrollable long code output in the macOS GUI. This completes the remaining markdown rendering work for #723.

Closes #723

## Context
Issue #723 already had the core markdown rendering work in place. The remaining gaps were link handling and long code output that could not scroll horizontally.

## Changes
- Parse `[text](url)` links in `MingaAgent.Markdown` and keep unsafe or malformed URLs as plain text.
- Validate link schemes on both sides, including host checks for `http` and `https`, non-empty paths for `mailto`, and malformed percent-escape rejection on the BEAM side.
- Preserve clickable link metadata inside blockquotes, including blockquotes without a space after `>`.
- Carry link metadata through agent markdown highlighting and the GUI agent chat protocol using a 5-tuple styled run form with a link flag.
- Keep the existing 4-tuple styled run format backward-compatible, and mask link flags from 4-tuples so Swift never expects a missing URL payload.
- Strip link URL metadata before section encoding when oversized link payloads would exceed the 16-bit message section limit.
- Truncate oversized plain chat text, prompt/model strings, and styled run text before 16-bit protocol length encoding so GUI chat frames do not wrap section lengths.
- Omit older chat messages with a visible notice when the messages section still cannot fit within the 65KB section payload limit.
- Decode link metadata in Swift and render links with `AttributedString.link`.
- Harden Swift GUI chat decoding so styled link URL payloads cannot read across the messages section boundary, invalid UTF-8 URLs fail decoding, unknown message types fail decoding, and trailing bytes in the messages section fail decoding.
- Add horizontal scrolling for long styled/code output in `AgentChatView` without removing the existing vertical scroll behavior.
- Document the GUI protocol extension, including stable message IDs, sectioned agent chat payloads, styled run flags, and link URL payloads.

## Verification
- `mix test.llm test/minga_agent/markdown_test.exs test/minga_editor/agent/markdown_highlight_test.exs test/minga_editor/frontend/gui_agent_chat_protocol_test.exs` → PASS, 72 tests
- `make lint` → PASS, only existing large-struct warnings
- `mix swift.build` → PASS
- `cd macos && xcodebuild test -project Minga.xcodeproj -scheme Minga -destination 'platform=macOS'` → PASS, 503 tests
- `git diff --check` → PASS
- `cd /tmp/minga-723 && mix test.llm --max-cases 1` → PASS: 54 doctests, 97 properties, 8412 tests, 0 failures, 5 skipped, 115 excluded
- Focused fresh-eyes re-check with `prtk-code-reviewer` → PASS, no remaining findings in the previously flagged areas

## Acceptance Criteria Addressed
- Links `[text](url)` are clickable and open in the default browser ✅
- Long code blocks are horizontally scrollable with no clipping ✅
