### PR TITLE
feat(editor): use tree-sitter for indentation

### DIFF
--- a/lib/minga/parser/manager.ex
+++ b/lib/minga/parser/manager.ex
@@ -43,6 +43,9 @@ defmodule Minga.Parser.Manager do
   @max_backoff_ms 5_000
   @max_restart_attempts 5
   @restart_window_ms 30_000
+  @default_indent_request_timeout_ms 2_000
+  @default_textobject_request_timeout_ms 2_000
+  @request_client_timeout_slack_ms 50
 
   @typedoc "Options for starting the parser manager."
   @type start_opt ::
@@ -122,10 +125,43 @@ defmodule Minga.Parser.Manager do
   end
 
   @doc """
+  Requests a tree-sitter indent level synchronously.
+
+  Sends a `request_indent` command to the Zig parser and blocks until the
+  result arrives. Keystroke-path callers can pass a short timeout; callers fall back to copy-indent if the parser is slow or unavailable.
+
+  Returns a non-negative indent level, or `nil` if the parser is unavailable.
+  """
+  @spec request_indent(non_neg_integer(), non_neg_integer()) :: integer() | nil
+  @spec request_indent(non_neg_integer(), non_neg_integer(), GenServer.server()) ::
+          integer() | nil
+  @spec request_indent(non_neg_integer(), non_neg_integer(), GenServer.server(), pos_integer()) ::
+          integer() | nil
+  def request_indent(buffer_id, line), do: request_indent(buffer_id, line, __MODULE__)
+
+  def request_indent(buffer_id, line, server) do
+    request_indent(buffer_id, line, server, @default_indent_request_timeout_ms)
+  end
+
+  def request_indent(buffer_id, line, server, timeout_ms)
+      when is_integer(buffer_id) and buffer_id > 0 and is_integer(line) and line >= 0 and
+             is_integer(timeout_ms) and timeout_ms > 0 do
+    GenServer.call(
+      server,
+      {:request_indent, buffer_id, line, timeout_ms},
+      timeout_ms + @request_client_timeout_slack_ms
+    )
+  catch
+    :exit, _ -> nil
+  end
+
+  def request_indent(_buffer_id, _line, _server, _timeout_ms), do: nil
+
+  @doc """
   Requests a tree-sitter text object range synchronously.
 
   Sends a `request_textobject` command to the Zig parser and blocks until
-  the result arrives (or times out after 2 seconds).
+  the result arrives or the request times out.
 
   Returns `{start_row, start_col, end_row, end_col}` or `nil` if no match.
   """
@@ -140,7 +176,12 @@ defmodule Minga.Parser.Manager do
   def request_textobject(buffer_id, row, col, capture_name, server \\ __MODULE__)
       when is_integer(buffer_id) and is_integer(row) and is_integer(col) and
              is_binary(capture_name) do
-    GenServer.call(server, {:request_textobject, buffer_id, row, col, capture_name}, 2_000)
+    GenServer.call(
+      server,
+      {:request_textobject, buffer_id, row, col, capture_name,
+       @default_textobject_request_timeout_ms},
+      @default_textobject_request_timeout_ms + @request_client_timeout_slack_ms
+    )
   catch
     :exit, _ -> nil
   end
@@ -256,19 +297,48 @@ defmodule Minga.Parser.Manager do
   end
 
   def handle_call(
-        {:request_textobject, _buffer_id, _row, _col, _capture},
+        {:request_indent, _buffer_id, _line, _timeout_ms},
         _from,
         %{port: nil} = state
       ) do
     {:reply, nil, state}
   end
 
-  def handle_call({:request_textobject, buffer_id, row, col, capture_name}, from, state) do
+  def handle_call({:request_indent, buffer_id, _line, _timeout_ms}, _from, state)
+      when not is_map_key(state.buffer_registry, buffer_id) do
+    {:reply, nil, state}
+  end
+
+  def handle_call({:request_indent, buffer_id, line, timeout_ms}, from, state) do
+    request_id = state.next_request_id
+    cmd = Protocol.encode_request_indent(buffer_id, request_id, line)
+    Port.command(state.port, cmd)
+
+    pending = Map.put(state.pending_requests, request_id, from)
+    Process.send_after(self(), {:request_timeout, request_id}, timeout_ms)
+
+    {:noreply, %{state | next_request_id: request_id + 1, pending_requests: pending}}
+  end
+
+  def handle_call(
+        {:request_textobject, _buffer_id, _row, _col, _capture, _timeout_ms},
+        _from,
+        %{port: nil} = state
+      ) do
+    {:reply, nil, state}
+  end
+
+  def handle_call(
+        {:request_textobject, buffer_id, row, col, capture_name, timeout_ms},
+        from,
+        state
+      ) do
     request_id = state.next_request_id
     cmd = Protocol.encode_request_textobject(buffer_id, request_id, row, col, capture_name)
     Port.command(state.port, cmd)
 
     pending = Map.put(state.pending_requests, request_id, from)
+    Process.send_after(self(), {:request_timeout, request_id}, timeout_ms)
 
     {:noreply, %{state | next_request_id: request_id + 1, pending_requests: pending}}
   end
@@ -325,15 +395,11 @@ defmodule Minga.Parser.Manager do
   @impl true
   def handle_info({port, {:data, data}}, %{port: port} = state) do
     case Protocol.decode_event(data) do
-      {:ok, {:textobject_result, request_id, result}} ->
-        case Map.pop(state.pending_requests, request_id) do
-          {nil, _pending} ->
-            {:noreply, state}
+      {:ok, {:indent_result, request_id, _line, indent_level}} ->
+        reply_to_pending_request(state, request_id, indent_level)
 
-          {from, pending} ->
-            GenServer.reply(from, result)
-            {:noreply, %{state | pending_requests: pending}}
-        end
+      {:ok, {:textobject_result, request_id, result}} ->
+        reply_to_pending_request(state, request_id, result)
 
       {:ok, {:log_message, _level, _text} = event} ->
         broadcast(state.subscribers, {:minga_highlight, event})
@@ -373,6 +439,10 @@ defmodule Minga.Parser.Manager do
   def handle_info(:restart_parser, state) do
     state = attempt_restart(state)
     {:noreply, state}
+  end
+
+  def handle_info({:request_timeout, request_id}, state) do
+    reply_to_pending_request(state, request_id, nil)
   end
 
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
@@ -556,6 +626,18 @@ defmodule Minga.Parser.Manager do
     end)
 
     %{state | pending_requests: %{}}
+  end
+
+  @spec reply_to_pending_request(State.t(), non_neg_integer(), term()) :: {:noreply, State.t()}
+  defp reply_to_pending_request(state, request_id, result) do
+    case Map.pop(state.pending_requests, request_id) do
+      {nil, _pending} ->
+        {:noreply, state}
+
+      {from, pending} ->
+        GenServer.reply(from, result)
+        {:noreply, %{state | pending_requests: pending}}
+    end
   end
 
   @spec broadcast([pid()], term()) :: :ok

--- a/lib/minga_editor/commands/editing.ex
+++ b/lib/minga_editor/commands/editing.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.Commands.Editing do
 
   alias Minga.Buffer
   alias Minga.Buffer.Document
+  alias Minga.Parser.Manager, as: ParserManager
 
   alias MingaEditor.Commands.Helpers
   alias MingaEditor.HighlightSync
@@ -92,8 +93,12 @@ defmodule MingaEditor.Commands.Editing do
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, :insert_newline) do
     {line, _col} = Buffer.cursor(buf)
-    indent = Indent.compute_for_newline(buf, line)
-    Buffer.insert_char(buf, "\n" <> indent)
+    Buffer.insert_char(buf, "\n")
+
+    state = HighlightSync.request_reparse(state)
+    indent = Indent.compute_for_line(buf, line + 1, indent_opts(state, buf))
+    insert_indent(buf, indent)
+
     state
   end
 
@@ -119,18 +124,29 @@ defmodule MingaEditor.Commands.Editing do
         [] -> 0
       end
 
-    indent = Indent.compute_for_newline(buf, line)
     Buffer.move_to(buf, {line, end_col})
-    Buffer.insert_char(buf, "\n" <> indent)
+    Buffer.insert_char(buf, "\n")
+
+    state = HighlightSync.request_reparse(state)
+    indent = Indent.compute_for_line(buf, line + 1, indent_opts(state, buf))
+    insert_indent(buf, indent)
+
     state
   end
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, :insert_line_above) do
     {line, _col} = Buffer.cursor(buf)
-    indent = Indent.compute_for_newline(buf, max(line - 1, 0))
+    fallback_indent = copy_indent_for_line_above(buf, line)
+
     Buffer.move_to(buf, {line, 0})
-    Buffer.insert_char(buf, indent <> "\n")
-    Buffer.move_to(buf, {line, byte_size(indent)})
+    Buffer.insert_char(buf, "\n")
+    Buffer.move_to(buf, {line, 0})
+
+    state = HighlightSync.request_reparse(state)
+    opts = Keyword.put(indent_opts(state, buf), :fallback, fallback_indent)
+    indent = Indent.compute_for_line(buf, line, opts)
+    insert_indent(buf, indent)
+
     state
   end
 
@@ -409,7 +425,7 @@ defmodule MingaEditor.Commands.Editing do
     {cursor_line, _} = Buffer.cursor(buf)
     total = Buffer.line_count(buf)
     end_line = min(cursor_line + n - 1, total - 1)
-    do_reindent_lines(buf, cursor_line, end_line)
+    do_reindent_lines(state, buf, cursor_line, end_line)
     state
   end
 
@@ -421,7 +437,7 @@ defmodule MingaEditor.Commands.Editing do
     {target_line, _} = target
     start_line = min(cursor_line, target_line)
     end_line = max(cursor_line, target_line)
-    do_reindent_lines(buf, start_line, end_line)
+    do_reindent_lines(state, buf, start_line, end_line)
     state
   end
 
@@ -436,7 +452,7 @@ defmodule MingaEditor.Commands.Editing do
     {cursor_line, _} = cursor
     start_line = min(anchor_line, cursor_line)
     end_line = max(anchor_line, cursor_line)
-    do_reindent_lines(buf, start_line, end_line)
+    do_reindent_lines(state, buf, start_line, end_line)
     state
   end
 
@@ -455,7 +471,7 @@ defmodule MingaEditor.Commands.Editing do
         state
 
       {{start_line, _}, {end_line, _}} ->
-        do_reindent_lines(buf, start_line, end_line)
+        do_reindent_lines(state, buf, start_line, end_line)
         state
     end
   end
@@ -649,12 +665,44 @@ defmodule MingaEditor.Commands.Editing do
 
   # ── Private reindent helpers ──────────────────────────────────────────────
 
-  @spec do_reindent_lines(pid(), non_neg_integer(), non_neg_integer()) :: :ok
-  defp do_reindent_lines(buf, start_line, end_line) do
+  @keystroke_indent_timeout_ms 200
+
+  @spec indent_opts(state(), pid()) :: [Indent.compute_opt()]
+  defp indent_opts(state, buf) do
+    [
+      buffer_id: HighlightSync.buffer_id_for(state, buf),
+      request_indent: &request_indent_on_keystroke/2
+    ]
+  end
+
+  @spec copy_indent_for_line_above(pid(), non_neg_integer()) :: String.t()
+  defp copy_indent_for_line_above(buf, 0), do: copy_line_indent(buf, 0)
+  defp copy_indent_for_line_above(buf, line), do: copy_line_indent(buf, line - 1)
+
+  @spec copy_line_indent(pid(), non_neg_integer()) :: String.t()
+  defp copy_line_indent(buf, line) do
+    case Buffer.lines(buf, line, 1) do
+      [text] -> Indent.extract_leading_ws(text)
+      [] -> ""
+    end
+  end
+
+  @spec request_indent_on_keystroke(non_neg_integer(), non_neg_integer()) :: integer() | nil
+  defp request_indent_on_keystroke(buffer_id, line) do
+    ParserManager.request_indent(buffer_id, line, ParserManager, @keystroke_indent_timeout_ms)
+  end
+
+  @spec insert_indent(pid(), String.t()) :: :ok
+  defp insert_indent(_buf, ""), do: :ok
+  defp insert_indent(buf, indent), do: Buffer.insert_text(buf, indent)
+
+  @spec do_reindent_lines(state(), pid(), non_neg_integer(), non_neg_integer()) :: :ok
+  defp do_reindent_lines(state, buf, start_line, end_line) do
     {cursor_line, _} = Buffer.cursor(buf)
+    opts = indent_opts(state, buf)
 
     for line <- start_line..end_line do
-      reindent_single_line(buf, line)
+      reindent_single_line(buf, line, opts)
     end
 
     # Move cursor to first non-blank on cursor line
@@ -670,23 +718,9 @@ defmodule MingaEditor.Commands.Editing do
     :ok
   end
 
-  @spec reindent_single_line(pid(), non_neg_integer()) :: :ok
-  defp reindent_single_line(buf, line) do
-    # Compute the desired indent for this line based on the previous line
-    desired_indent =
-      if line == 0 do
-        ""
-      else
-        Indent.compute_for_newline(buf, line - 1)
-      end
-
-    # Check if current line starts with a dedent trigger
-    desired_indent =
-      if Indent.should_dedent_line?(buf, line) do
-        Indent.remove_one_indent_level(desired_indent, buf)
-      else
-        desired_indent
-      end
+  @spec reindent_single_line(pid(), non_neg_integer(), [Indent.compute_opt()]) :: :ok
+  defp reindent_single_line(buf, line, opts) do
+    desired_indent = Indent.compute_for_line(buf, line, opts)
 
     # Get current line text and its existing indent
     case Buffer.lines(buf, line, 1) do
@@ -694,9 +728,7 @@ defmodule MingaEditor.Commands.Editing do
         current_indent = Indent.extract_leading_ws(text)
 
         if current_indent != desired_indent do
-          # Replace leading whitespace using apply_text_edit
-          indent_end_col = byte_size(current_indent)
-          Buffer.apply_edit(buf, line, 0, line, indent_end_col, desired_indent)
+          apply_indent_change(buf, line, current_indent, desired_indent)
         end
 
         :ok
@@ -704,6 +736,17 @@ defmodule MingaEditor.Commands.Editing do
       [] ->
         :ok
     end
+  end
+
+  @spec apply_indent_change(pid(), non_neg_integer(), String.t(), String.t()) :: :ok
+  defp apply_indent_change(buf, line, "", desired_indent) do
+    Buffer.move_to(buf, {line, 0})
+    insert_indent(buf, desired_indent)
+  end
+
+  defp apply_indent_change(buf, line, current_indent, desired_indent) do
+    indent_end_col = byte_size(current_indent) - 1
+    Buffer.apply_edit(buf, line, 0, line, indent_end_col, desired_indent)
   end
 
   # ── Private indent helpers ────────────────────────────────────────────────

--- a/lib/minga_editor/indent.ex
+++ b/lib/minga_editor/indent.ex
@@ -1,64 +1,31 @@
 defmodule MingaEditor.Indent do
   @moduledoc """
-  Computes indentation for new lines.
+  Computes indentation for new lines and reindent commands.
 
-  Uses a two-step approach:
-  1. Copy the previous line's leading whitespace as the baseline indent
-  2. Apply a tree-sitter-informed delta: indent after lines ending with
-     indent triggers (do, fn, {, [, etc.), dedent on lines starting with
-     dedent triggers (end, }, ], etc.)
-
-  The indent triggers are defined per-language. Languages without triggers
-  fall back to pure copy-indent.
+  Tree-sitter is the source of truth when the active buffer has a parser buffer ID. The parser returns an indent level from the language's `indents.scm` query, and this module converts that level into spaces or tabs using the buffer's indentation options. Buffers without a tree-sitter grammar, unavailable parsers, and unsupported parser responses fall back to copy-indent.
   """
 
   alias Minga.Buffer
+  alias Minga.Parser.Manager, as: ParserManager
 
-  @typedoc "A computed indentation result."
-  @type indent_result :: %{indent: String.t(), dedent: boolean()}
+  @typedoc "Function used to request a parser indent level."
+  @type request_indent_fun :: (non_neg_integer(), non_neg_integer() -> integer() | nil)
 
-  @doc """
-  Computes the indentation string for a new line inserted after `line_num`.
-
-  Returns the whitespace string that should be inserted after the newline.
-  """
-  @spec compute_for_newline(pid(), non_neg_integer()) :: String.t()
-  def compute_for_newline(buf, line_num) do
-    base_indent = leading_whitespace(buf, line_num)
-    tab_size = Buffer.get_option(buf, :tab_size) || 2
-    indent_with = Buffer.get_option(buf, :indent_with) || :spaces
-    unit = indent_unit(indent_with, tab_size)
-
-    filetype = Buffer.filetype(buf)
-
-    case get_line_text(buf, line_num) do
-      nil ->
-        base_indent
-
-      line_text ->
-        trimmed = String.trim_trailing(line_text)
-
-        if should_indent_after?(trimmed, filetype) do
-          base_indent <> unit
-        else
-          base_indent
-        end
-    end
-  end
+  @typedoc "Options for tree-sitter indentation."
+  @type compute_opt ::
+          {:buffer_id, non_neg_integer()}
+          | {:fallback, String.t()}
+          | {:request_indent, request_indent_fun()}
 
   @doc """
-  Checks if the current line (after cursor) starts with a dedent trigger
-  and returns the adjusted indentation.
+  Computes the indentation string for an existing line.
 
-  Call this after inserting the newline and indent to check if the cursor
-  line should be dedented.
+  Tree-sitter is queried for `line_num` when a parser buffer ID is available. Otherwise, the result falls back to either the explicit `:fallback` option or copy-indent from the previous line.
   """
-  @spec should_dedent_line?(pid(), non_neg_integer()) :: boolean()
-  def should_dedent_line?(buf, line_num) do
-    case get_line_text(buf, line_num) do
-      nil -> false
-      text -> dedent_trigger?(String.trim(text), Buffer.filetype(buf))
-    end
+  @spec compute_for_line(pid(), non_neg_integer(), [compute_opt()]) :: String.t()
+  def compute_for_line(buf, line_num, opts \\ []) do
+    fallback = explicit_or_default_fallback(buf, line_num, opts)
+    compute_with_tree_sitter(buf, line_num, fallback, opts)
   end
 
   @doc "Extracts leading whitespace from a line of text."
@@ -76,25 +43,51 @@ defmodule MingaEditor.Indent do
     byte_size(extract_leading_ws(text))
   end
 
-  @doc """
-  Removes one level of indentation from the given whitespace string.
+  # ── Private ────────────────────────────────────────────────────────────────
 
-  If the whitespace ends with a tab, removes one tab. Otherwise removes
-  `tab_size` spaces (or whatever is available).
-  """
-  @spec remove_one_indent_level(String.t(), pid()) :: String.t()
-  def remove_one_indent_level(indent, buf) do
-    tab_size = Buffer.get_option(buf, :tab_size) || 2
+  @spec compute_with_tree_sitter(pid(), non_neg_integer(), String.t(), [compute_opt()]) ::
+          String.t()
+  defp compute_with_tree_sitter(buf, line_num, fallback, opts) do
+    buffer_id = Keyword.get(opts, :buffer_id, 0)
+    request_indent = Keyword.get(opts, :request_indent, &ParserManager.request_indent/2)
 
-    if String.ends_with?(indent, "\t") do
-      String.slice(indent, 0, String.length(indent) - 1)
-    else
-      remove_len = min(tab_size, byte_size(indent))
-      binary_part(indent, 0, byte_size(indent) - remove_len)
+    case request_indent_level(buffer_id, line_num, request_indent) do
+      level when is_integer(level) and level >= 0 -> whitespace_for_level(buf, level)
+      _ -> fallback
     end
   end
 
-  # ── Private ────────────────────────────────────────────────────────────────
+  @spec request_indent_level(term(), non_neg_integer(), request_indent_fun()) :: integer() | nil
+  defp request_indent_level(buffer_id, line_num, request_indent)
+       when is_integer(buffer_id) and buffer_id > 0 do
+    request_indent.(buffer_id, line_num)
+  rescue
+    _ -> nil
+  catch
+    :exit, _ -> nil
+  end
+
+  defp request_indent_level(_buffer_id, _line_num, _request_indent), do: nil
+
+  @spec whitespace_for_level(pid(), non_neg_integer()) :: String.t()
+  defp whitespace_for_level(buf, level) do
+    tab_size = Buffer.get_option(buf, :tab_size) || 2
+    indent_with = Buffer.get_option(buf, :indent_with) || :spaces
+    unit = indent_unit(indent_with, tab_size)
+    String.duplicate(unit, level)
+  end
+
+  @spec fallback_for_line(pid(), non_neg_integer()) :: String.t()
+  defp fallback_for_line(_buf, 0), do: ""
+  defp fallback_for_line(buf, line_num), do: leading_whitespace(buf, line_num - 1)
+
+  @spec explicit_or_default_fallback(pid(), non_neg_integer(), [compute_opt()]) :: String.t()
+  defp explicit_or_default_fallback(buf, line_num, opts) do
+    case Keyword.fetch(opts, :fallback) do
+      {:ok, fallback} -> fallback
+      :error -> fallback_for_line(buf, line_num)
+    end
+  end
 
   @spec leading_whitespace(pid(), non_neg_integer()) :: String.t()
   defp leading_whitespace(buf, line_num) do
@@ -116,68 +109,4 @@ defmodule MingaEditor.Indent do
   defp indent_unit(:tabs, _tab_size), do: "\t"
   defp indent_unit(:spaces, tab_size), do: String.duplicate(" ", tab_size)
   defp indent_unit(_, tab_size), do: String.duplicate(" ", tab_size)
-
-  # ── Indent triggers (per-language) ─────────────────────────────────────────
-  #
-  # These are simplified heuristics that work well for the common case.
-  # The tree-sitter indent query provides the definitive answer, but
-  # these patterns give instant feedback without a protocol roundtrip.
-
-  @spec should_indent_after?(String.t(), atom() | String.t()) :: boolean()
-  defp should_indent_after?(trimmed, filetype) when filetype in [:elixir, "elixir"] do
-    String.ends_with?(trimmed, " do") or
-      String.ends_with?(trimmed, "do") or
-      String.ends_with?(trimmed, "->") or
-      String.ends_with?(trimmed, "fn") or
-      String.ends_with?(trimmed, "{") or
-      String.ends_with?(trimmed, "[") or
-      String.ends_with?(trimmed, "(")
-  end
-
-  defp should_indent_after?(trimmed, filetype) when filetype in [:ruby, "ruby"] do
-    String.ends_with?(trimmed, " do") or
-      String.ends_with?(trimmed, "do") or
-      String.ends_with?(trimmed, "{") or
-      String.ends_with?(trimmed, "[") or
-      String.ends_with?(trimmed, "(") or
-      Regex.match?(~r/\b(def|class|module|if|unless|while|until|for|begin|case)\b/, trimmed)
-  end
-
-  defp should_indent_after?(trimmed, filetype) when filetype in [:python, "python"] do
-    String.ends_with?(trimmed, ":") or
-      String.ends_with?(trimmed, "{") or
-      String.ends_with?(trimmed, "[") or
-      String.ends_with?(trimmed, "(")
-  end
-
-  # C-family languages (c, cpp, java, javascript, typescript, go, rust, etc.)
-  defp should_indent_after?(trimmed, _filetype) do
-    String.ends_with?(trimmed, "{") or
-      String.ends_with?(trimmed, "[") or
-      String.ends_with?(trimmed, "(")
-  end
-
-  @spec dedent_trigger?(String.t(), atom() | String.t()) :: boolean()
-  defp dedent_trigger?(trimmed, filetype) when filetype in [:elixir, "elixir"] do
-    trimmed == "end" or
-      String.starts_with?(trimmed, "end ") or
-      trimmed == ")" or trimmed == "]" or trimmed == "}"
-  end
-
-  defp dedent_trigger?(trimmed, filetype) when filetype in [:ruby, "ruby"] do
-    trimmed == "end" or
-      trimmed == ")" or trimmed == "]" or trimmed == "}"
-  end
-
-  defp dedent_trigger?(trimmed, filetype) when filetype in [:python, "python"] do
-    String.starts_with?(trimmed, "return ") or
-      String.starts_with?(trimmed, "pass") or
-      String.starts_with?(trimmed, "break") or
-      String.starts_with?(trimmed, "continue") or
-      trimmed == ")" or trimmed == "]" or trimmed == "}"
-  end
-
-  defp dedent_trigger?(trimmed, _filetype) do
-    trimmed == "}" or trimmed == ")" or trimmed == "]"
-  end
 end

--- a/lib/minga_editor/input/router.ex
+++ b/lib/minga_editor/input/router.ex
@@ -320,6 +320,11 @@ defmodule MingaEditor.Input.Router do
           atom(),
           pos_integer()
         ) :: EditorState.t()
+  def dispatch_mouse(state, row, col, _button, _mods, _event_type, _click_count)
+      when row < 0 or col < 0 do
+    state
+  end
+
   def dispatch_mouse(state, row, col, button, mods, event_type, click_count) do
     event = %{
       row: row,

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -26,14 +26,14 @@ defmodule MingaEditor.UI.Picker.FileSource do
   def preview?, do: true
 
   @impl true
-  @spec candidates(Context.t()) :: [Item.t()]
-  def candidates(_ctx) do
-    root = project_root()
+  @spec candidates(Context.t() | nil) :: [Item.t()]
+  def candidates(ctx) do
+    root = project_root(ctx)
 
     case Minga.Project.list_files(root) do
       {:ok, paths} ->
         frecency_map = build_frecency_map()
-        git_status_map = build_git_status_map()
+        git_status_map = build_git_status_map(root)
         score_map = build_score_map(frecency_map, git_status_map)
 
         paths
@@ -74,7 +74,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   @impl true
   @spec on_select(Item.t(), term()) :: term()
   def on_select(%Item{id: rel_path}, state) do
-    abs_path = absolute_path(rel_path)
+    abs_path = absolute_path(rel_path, state)
 
     Log.debug(:editor, "[file_picker] on_select path=#{rel_path}")
 
@@ -141,7 +141,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   def on_action(:open, item, state), do: on_select(item, state)
 
   def on_action(:delete, %Item{id: rel_path}, state) do
-    abs_path = absolute_path(rel_path)
+    abs_path = absolute_path(rel_path, state)
 
     case File.rm(abs_path) do
       :ok ->
@@ -158,8 +158,8 @@ defmodule MingaEditor.UI.Picker.FileSource do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
-  @spec absolute_path(String.t()) :: String.t()
-  defp absolute_path(rel_path), do: Path.expand(rel_path, project_root())
+  @spec absolute_path(String.t(), term()) :: String.t()
+  defp absolute_path(rel_path, state), do: Path.expand(rel_path, project_root(state))
 
   @spec record_selection(String.t(), term()) :: :ok
   defp record_selection(_abs_path, %{buffer_add_context: :preview}), do: :ok
@@ -179,10 +179,8 @@ defmodule MingaEditor.UI.Picker.FileSource do
   end
 
   # Build a map of relative_path → git status atom from Git.Repo.
-  @spec build_git_status_map() :: %{String.t() => atom()}
-  defp build_git_status_map do
-    root = project_root()
-
+  @spec build_git_status_map(String.t()) :: %{String.t() => atom()}
+  defp build_git_status_map(root) do
     with {:ok, git_root} <- Minga.Git.root_for(root),
          repo_pid when is_pid(repo_pid) <- Git.lookup_repo(git_root) do
       Git.Repo.status(repo_pid)
@@ -232,5 +230,15 @@ defmodule MingaEditor.UI.Picker.FileSource do
   defp git_status_annotation(:conflict), do: "!"
   defp git_status_annotation(_), do: nil
 
-  defdelegate project_root, to: Minga.Project, as: :resolve_root
+  @spec project_root(Context.t() | EditorState.t() | nil) :: String.t()
+  defp project_root(%Context{file_tree: %{project_root: root}}) when is_binary(root), do: root
+
+  defp project_root(%Context{picker_ui: %{context: %{project_root: root}}}) when is_binary(root),
+    do: root
+
+  defp project_root(%EditorState{workspace: %{file_tree: %{project_root: root}}})
+       when is_binary(root),
+       do: root
+
+  defp project_root(_ctx), do: Minga.Project.resolve_root()
 end

--- a/test/minga/dot_repeat_test.exs
+++ b/test/minga/dot_repeat_test.exs
@@ -11,13 +11,15 @@ defmodule Minga.DotRepeatTest do
   alias MingaEditor
 
   @escape 27
+  @sync_timeout 15_000
 
   # ── Helpers ──────────────────────────────────────────────────────────────────
 
   defp start_editor(content) do
     id = :erlang.unique_integer([:positive])
     events_registry = :"dot_repeat_events_#{id}"
-    {:ok, _} = Registry.start_link(keys: :duplicate, name: events_registry)
+    project_root = isolated_project_root(id)
+    start_supervised!({Minga.Events, name: events_registry})
     {:ok, buffer} = BufferServer.start_link(content: content, events_registry: events_registry)
 
     {:ok, editor} =
@@ -28,15 +30,23 @@ defmodule Minga.DotRepeatTest do
         width: 80,
         height: 24,
         editing_model: :vim,
-        events_registry: events_registry
+        events_registry: events_registry,
+        project_root: project_root,
+        suppress_tool_prompts: true
       )
 
     {editor, buffer}
   end
 
+  defp isolated_project_root(id) do
+    root = Path.join(System.tmp_dir!(), "minga-dot-repeat-#{id}")
+    File.mkdir_p!(root)
+    root
+  end
+
   defp send_key(editor, codepoint, mods \\ 0) do
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor)
+    _ = :sys.get_state(editor, @sync_timeout)
   end
 
   defp type_string(editor, text) do

--- a/test/minga/parser/manager_test.exs
+++ b/test/minga/parser/manager_test.exs
@@ -1,0 +1,59 @@
+defmodule Minga.Parser.ManagerTest do
+  # Spawns the real Zig parser Port, so this test must not run concurrently with other OS-process tests.
+  use ExUnit.Case, async: false
+
+  @moduletag :heavy
+  @moduletag timeout: 10_000
+
+  alias Minga.Parser.Manager
+  alias Minga.Parser.Protocol
+
+  describe "request_indent/3" do
+    test "returns nil without waiting when the parser port is unavailable" do
+      server = start_parser_manager(parser_path: "/missing/minga-parser")
+
+      assert Manager.request_indent(1, 0, server) == nil
+    end
+
+    test "returns tree-sitter indent levels from the parser" do
+      server = start_parser_manager()
+      content = "def foo do\nif bar do\nbaz\nend\nend"
+      buffer_id = 1
+
+      setup_buffer(server, buffer_id, content)
+
+      assert Manager.request_indent(buffer_id, 2, server) == 2
+      assert Manager.request_indent(buffer_id, 3, server) == 1
+    end
+
+    test "returns first-enter indentation after the newline is present in a complete block" do
+      server = start_parser_manager()
+      content = "def foo do\n\nend"
+      buffer_id = 1
+
+      setup_buffer(server, buffer_id, content)
+
+      assert Manager.request_indent(buffer_id, 1, server) == 1
+    end
+  end
+
+  defp setup_buffer(server, buffer_id, content) do
+    Manager.send_commands(server, [
+      Protocol.encode_set_language(buffer_id, "elixir"),
+      Protocol.encode_parse_buffer(buffer_id, 0, content)
+    ])
+
+    Manager.register_buffer(buffer_id, "elixir", fn -> content end, server: server)
+  end
+
+  defp start_parser_manager(opts \\ []) do
+    parser_path = Keyword.get(opts, :parser_path, parser_path())
+    name = Module.concat(__MODULE__, "Server#{System.unique_integer([:positive])}")
+    start_supervised!({Manager, name: name, parser_path: parser_path})
+    name
+  end
+
+  defp parser_path do
+    Path.expand("../../../zig/zig-out/bin/minga-parser", __DIR__)
+  end
+end

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -13,6 +13,7 @@ defmodule MingaAgent.SessionTest do
   alias MingaAgent.Tool.Spec
 
   @moduletag :tmp_dir
+  @event_timeout 2_000
 
   # ── Mock provider ──────────────────────────────────────────────────────────
 
@@ -241,7 +242,12 @@ defmodule MingaAgent.SessionTest do
   # final action when a turn completes, so receiving that event guarantees
   # all handle_info callbacks have run.
   defp await_turn_complete do
-    assert_receive {:agent_event, _, {:status_changed, :idle}}, 1_000
+    assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
+  end
+
+  defp send_provider_event(session, event) do
+    send(session, {:agent_provider_event, event})
+    :sys.get_state(session)
   end
 
   defp mcp_session_builtin_tool do
@@ -306,7 +312,7 @@ defmodule MingaAgent.SessionTest do
     test "enter_plan sets status, broadcasts, and writes a system message", %{session: session} do
       assert :ok = Session.enter_plan(session)
       assert Session.status(session) == :plan
-      assert_receive {:agent_event, _, {:status_changed, :plan}}, 200
+      assert_receive {:agent_event, _, {:status_changed, :plan}}, @event_timeout
 
       assert Enum.any?(Session.messages(session), fn
                {:system, text, :info} -> text =~ "Plan mode" and text =~ "/exec"
@@ -318,8 +324,8 @@ defmodule MingaAgent.SessionTest do
       assert :ok = Session.enter_plan(session)
       assert :ok = Session.enter_exec(session)
       assert Session.status(session) == :idle
-      assert_receive {:agent_event, _, {:status_changed, :plan}}, 200
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 200
+      assert_receive {:agent_event, _, {:status_changed, :plan}}, @event_timeout
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
 
       assert Enum.any?(Session.messages(session), fn
                {:system, text, :info} -> text =~ "Execution mode" and text =~ "/plan"
@@ -375,7 +381,7 @@ defmodule MingaAgent.SessionTest do
       assert :ok = Session.enter_plan(session)
       assert :ok = Session.send_prompt(session, "hello")
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, :messages_changed}, 200
+      assert_receive {:agent_event, _, :messages_changed}, @event_timeout
       assert Session.status(session) == :plan
     end
 
@@ -432,15 +438,15 @@ defmodule MingaAgent.SessionTest do
     test "broadcasts status changes", %{session: session} do
       :ok = Session.send_prompt(session, "Test")
 
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 200
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 200
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "broadcasts text deltas", %{session: session} do
       :ok = Session.send_prompt(session, "Test")
 
-      assert_receive {:agent_event, _, {:text_delta, "Hello "}}, 200
-      assert_receive {:agent_event, _, {:text_delta, "world!"}}, 200
+      assert_receive {:agent_event, _, {:text_delta, "Hello "}}, @event_timeout
+      assert_receive {:agent_event, _, {:text_delta, "world!"}}, @event_timeout
     end
   end
 
@@ -851,10 +857,10 @@ defmodule MingaAgent.SessionTest do
         reply_to: self()
       }
 
-      send(session, {:agent_provider_event, approval})
+      send_provider_event(session, approval)
 
       # Broadcast should arrive
-      assert_receive {:agent_event, _, {:approval_pending, data}}, 200
+      assert_receive {:agent_event, _, {:approval_pending, data}}, @event_timeout
       assert data.name == "shell"
       assert data.tool_call_id == "tc1"
       assert data.preview.kind == :command
@@ -871,15 +877,15 @@ defmodule MingaAgent.SessionTest do
         reply_to: self()
       }
 
-      send(session, {:agent_provider_event, approval})
-      assert_receive {:agent_event, _, {:approval_pending, _}}, 200
+      send_provider_event(session, approval)
+      assert_receive {:agent_event, _, {:approval_pending, _}}, @event_timeout
 
       :ok = Session.respond_to_approval(session, :approve)
 
       # Should receive the response directly
       assert_receive {:tool_approval_response, "tc1", :approve}
       # And the resolution broadcast
-      assert_receive {:agent_event, _, {:approval_resolved, :approve}}, 200
+      assert_receive {:agent_event, _, {:approval_resolved, :approve}}, @event_timeout
     end
 
     test "respond_to_approval with :reject sends reject", %{session: session} do
@@ -890,8 +896,8 @@ defmodule MingaAgent.SessionTest do
         reply_to: self()
       }
 
-      send(session, {:agent_provider_event, approval})
-      assert_receive {:agent_event, _, {:approval_pending, _}}, 200
+      send_provider_event(session, approval)
+      assert_receive {:agent_event, _, {:approval_pending, _}}, @event_timeout
 
       :ok = Session.respond_to_approval(session, :reject)
       assert_receive {:tool_approval_response, "tc1", :reject}
@@ -908,12 +914,12 @@ defmodule MingaAgent.SessionTest do
         reply_to: self()
       }
 
-      send(session, {:agent_provider_event, approval})
-      assert_receive {:agent_event, _, {:approval_pending, _}}, 200
+      send_provider_event(session, approval)
+      assert_receive {:agent_event, _, {:approval_pending, _}}, @event_timeout
 
       :ok = Session.respond_to_approval(session, :approve_all)
       assert_receive {:tool_approval_response, "tc1", :approve_all}
-      assert_receive {:agent_event, _, {:approval_resolved, :approve_all}}, 200
+      assert_receive {:agent_event, _, {:approval_resolved, :approve_all}}, @event_timeout
       assert {:error, :no_pending_approval} = Session.respond_to_approval(session, :approve)
     end
 
@@ -929,8 +935,8 @@ defmodule MingaAgent.SessionTest do
         reply_to: self()
       }
 
-      send(session, {:agent_provider_event, approval})
-      assert_receive {:agent_event, _, {:approval_pending, _}}, 200
+      send_provider_event(session, approval)
+      assert_receive {:agent_event, _, {:approval_pending, _}}, @event_timeout
 
       :ok = Session.abort(session)
 
@@ -1016,7 +1022,7 @@ defmodule MingaAgent.SessionTest do
     test "first_prompt returns first user message text", %{session: session} do
       Session.send_prompt(session, "Hello there")
       # Wait for prompt to be added to messages
-      assert_receive {:agent_event, _, :messages_changed}, 1000
+      assert_receive {:agent_event, _, :messages_changed}, @event_timeout
 
       meta = Session.metadata(session)
       assert meta.first_prompt == "Hello there"
@@ -1083,7 +1089,7 @@ defmodule MingaAgent.SessionTest do
     test "send_prompt while streaming queues message as steering", %{slow_session: session} do
       assert :ok = Session.send_prompt(session, "first message")
       # Wait for AgentStart to be processed (status becomes :thinking)
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       # Second send_prompt while streaming: should queue, not submit
       result = Session.send_prompt(session, "steer me")
@@ -1101,12 +1107,12 @@ defmodule MingaAgent.SessionTest do
       # Let the run finish
       SlowMockProvider.proceed(Session.get_provider(session))
 
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "multiple messages accumulate in the steering queue", %{slow_session: session} do
       assert :ok = Session.send_prompt(session, "first")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       assert {:queued, :steering} = Session.send_prompt(session, "steer 1")
       assert {:queued, :steering} = Session.send_prompt(session, "steer 2")
@@ -1118,12 +1124,12 @@ defmodule MingaAgent.SessionTest do
       Session.clear_queues(session)
 
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "queue_follow_up while streaming queues message as follow_up", %{slow_session: session} do
       assert :ok = Session.send_prompt(session, "first")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       result = Session.queue_follow_up(session, "follow this up")
       assert result == {:queued, :follow_up}
@@ -1136,12 +1142,12 @@ defmodule MingaAgent.SessionTest do
       # The follow-up auto-send behaviour is covered by the dedicated describe block.
       Session.clear_queues(session)
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "dequeue_steering returns and clears only the steering queue", %{slow_session: session} do
       assert :ok = Session.send_prompt(session, "first")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       Session.send_prompt(session, "steer me")
       Session.queue_follow_up(session, "follow up later")
@@ -1161,12 +1167,12 @@ defmodule MingaAgent.SessionTest do
       # Clear the follow-up so it doesn't auto-send during cleanup.
       Session.clear_queues(session)
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "recall_queues returns both queues and clears them", %{slow_session: session} do
       assert :ok = Session.send_prompt(session, "first")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       Session.send_prompt(session, "steer")
       Session.queue_follow_up(session, "follow")
@@ -1181,12 +1187,12 @@ defmodule MingaAgent.SessionTest do
       assert f2 == []
 
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "clear_queues empties both queues", %{slow_session: session} do
       assert :ok = Session.send_prompt(session, "first")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       Session.send_prompt(session, "steer")
       Session.queue_follow_up(session, "follow")
@@ -1198,7 +1204,7 @@ defmodule MingaAgent.SessionTest do
       assert follow_up == []
 
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "queue_follow_up when idle sends immediately like send_prompt", %{slow_session: session} do
@@ -1206,17 +1212,17 @@ defmodule MingaAgent.SessionTest do
       assert result == :ok
 
       # Message should be in conversation history right away
-      assert_receive {:agent_event, _, :messages_changed}, 500
+      assert_receive {:agent_event, _, :messages_changed}, @event_timeout
       messages = Session.messages(session)
       assert Enum.any?(messages, &match?({:user, "immediate follow-up"}, &1))
 
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "new_session clears both queues", %{slow_session: session} do
       assert :ok = Session.send_prompt(session, "first")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       Session.send_prompt(session, "steer")
       Session.queue_follow_up(session, "follow")
@@ -1224,11 +1230,11 @@ defmodule MingaAgent.SessionTest do
       # Clear queues before proceeding so follow-up auto-send doesn't trigger.
       Session.clear_queues(session)
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
 
       # Re-queue to verify new_session clears them
       Session.send_prompt(session, "second run")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       Session.send_prompt(session, "steer2")
       Session.queue_follow_up(session, "follow2")
@@ -1236,7 +1242,7 @@ defmodule MingaAgent.SessionTest do
       # new_session while idle-ish (we clear queues first then call new_session)
       Session.clear_queues(session)
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
 
       Session.new_session(session)
       {steering, follow_up} = Session.get_queued_messages(session)
@@ -1247,19 +1253,19 @@ defmodule MingaAgent.SessionTest do
     test "prompt_queued event is broadcast when queuing during streaming",
          %{slow_session: session} do
       assert :ok = Session.send_prompt(session, "first")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       Session.send_prompt(session, "steer me")
-      assert_receive {:agent_event, _, {:prompt_queued, "steer me", :steering}}, 500
+      assert_receive {:agent_event, _, {:prompt_queued, "steer me", :steering}}, @event_timeout
 
       Session.queue_follow_up(session, "follow")
-      assert_receive {:agent_event, _, {:prompt_queued, "follow", :follow_up}}, 500
+      assert_receive {:agent_event, _, {:prompt_queued, "follow", :follow_up}}, @event_timeout
 
       # Clear queues so neither the steering (already dequeued by time proceed is called)
       # nor the follow-up triggers an extra run during cleanup.
       Session.clear_queues(session)
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
   end
 
@@ -1279,7 +1285,7 @@ defmodule MingaAgent.SessionTest do
 
     test "queued follow-up is auto-sent when agent finishes", %{slow_session: session} do
       assert :ok = Session.send_prompt(session, "first")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       Session.queue_follow_up(session, "now follow up")
 
@@ -1287,7 +1293,7 @@ defmodule MingaAgent.SessionTest do
       SlowMockProvider.proceed(Session.get_provider(session))
 
       # Session should NOT go idle yet - it should start a new turn
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       # Follow-up message should appear in conversation history
       messages = Session.messages(session)
@@ -1299,20 +1305,20 @@ defmodule MingaAgent.SessionTest do
 
       # Complete the follow-up run
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "no follow-ups means normal idle transition", %{slow_session: session} do
       assert :ok = Session.send_prompt(session, "simple")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "queued steering messages are auto-sent when agent finishes", %{slow_session: session} do
       assert :ok = Session.send_prompt(session, "first")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       # Queue a steering message (this is what happens when a user sends a prompt
       # while the agent is busy)
@@ -1324,7 +1330,7 @@ defmodule MingaAgent.SessionTest do
 
       # Session should start a new turn (not go idle) because the steering queue
       # had a pending message.
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       # Steering message should appear in conversation history
       messages = Session.messages(session)
@@ -1336,14 +1342,14 @@ defmodule MingaAgent.SessionTest do
 
       # Complete the follow-up run
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "mixed steering and follow-up messages are combined at AgentEnd", %{
       slow_session: session
     } do
       assert :ok = Session.send_prompt(session, "first")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       # Queue both types
       assert {:queued, :steering} = Session.send_prompt(session, "steer this")
@@ -1353,7 +1359,7 @@ defmodule MingaAgent.SessionTest do
       SlowMockProvider.proceed(Session.get_provider(session))
 
       # Should start a new turn
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       # Both queues should be cleared
       {steering, follow_up} = Session.get_queued_messages(session)
@@ -1376,7 +1382,7 @@ defmodule MingaAgent.SessionTest do
 
       # Complete the second run
       SlowMockProvider.proceed(Session.get_provider(session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
   end
 
@@ -1423,7 +1429,7 @@ defmodule MingaAgent.SessionTest do
       :sys.get_state(slow_session)
 
       :ok = Session.send_prompt(slow_session, "hello")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       # Mid-stream: system(1), user(2), assistant(3)
       # The SlowMockProvider sends one TextDelta with the prompt text,
@@ -1445,7 +1451,7 @@ defmodule MingaAgent.SessionTest do
       assert String.contains?(text, "world")
 
       SlowMockProvider.proceed(Session.get_provider(slow_session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
 
       # After turn completes, usage message gets the next ID
       pairs_final = Session.messages_with_ids(slow_session)
@@ -1489,7 +1495,7 @@ defmodule MingaAgent.SessionTest do
 
       :ok = Session.new_session(session)
       # Drain the broadcasts from new_session
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 200
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
 
       pairs_after = Session.messages_with_ids(session)
       assert [{1, {:system, _, :info}}] = pairs_after
@@ -1513,7 +1519,7 @@ defmodule MingaAgent.SessionTest do
 
       :ok = Session.load_session(session, "id-test-session")
       # Drain the broadcasts
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 200
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
 
       pairs = Session.messages_with_ids(session)
       ids = Enum.map(pairs, &elem(&1, 0))
@@ -1637,7 +1643,7 @@ defmodule MingaAgent.SessionTest do
       :sys.get_state(slow_session)
 
       :ok = Session.send_prompt(slow_session, "first")
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
 
       # Queue two steering messages
       assert {:queued, :steering} = Session.send_prompt(slow_session, "steer 1")
@@ -1657,7 +1663,7 @@ defmodule MingaAgent.SessionTest do
       # Clean up
       Session.clear_queues(slow_session)
       SlowMockProvider.proceed(Session.get_provider(slow_session))
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, 500
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
     end
 
     test "add_system_message (cast) assigns a new ID", %{session: session} do
@@ -1727,13 +1733,13 @@ defmodule MingaAgent.SessionTest do
       assert_receive {:mcp_transport_started, "Local Tools", transport}
       FakeTransport.crash(transport)
 
-      assert_receive {:agent_event, ^session, {:error, message}}, 500
+      assert_receive {:agent_event, ^session, {:error, message}}, @event_timeout
       assert message =~ "MCP server Local Tools stopped"
       assert Enum.any?(Session.messages(session), &match?({:system, _text, :error}, &1))
 
       assert :ok = Session.send_prompt(session, "continue")
       await_turn_complete()
-      assert_receive {:session_mcp_tools, tool_names}, 500
+      assert_receive {:session_mcp_tools, tool_names}, @event_timeout
       assert "builtin_echo" in tool_names
       refute "mcp_local_tools__echo_text" in tool_names
 

--- a/test/minga_editor/commands/editing_reindent_test.exs
+++ b/test/minga_editor/commands/editing_reindent_test.exs
@@ -148,6 +148,16 @@ defmodule MingaEditor.Commands.EditingReindentTest do
   # ── Content verification (simple cases) ────────────────────────────────────
 
   describe "content verification" do
+    test "== applies exact copy-indent fallback to the current line" do
+      content = "  parent\nchild"
+      {editor, buffer} = start_editor(content)
+      send_key(editor, ?j)
+      send_key(editor, ?=)
+      send_key(editor, ?=)
+
+      assert BufferServer.content(buffer) == "  parent\n  child"
+    end
+
     test "== does not corrupt buffer content" do
       content = "hello\nworld\nfoo"
       {editor, buffer} = start_editor(content)

--- a/test/minga_editor/commands/editing_test.exs
+++ b/test/minga_editor/commands/editing_test.exs
@@ -79,6 +79,14 @@ defmodule MingaEditor.Commands.EditingTest do
       assert String.contains?(content, "\n")
       assert String.contains?(content, "w")
     end
+
+    test "O above an indented first line preserves fallback indentation" do
+      {editor, buffer} = start_editor("  hello")
+      send_key(editor, ?O)
+      send_key(editor, ?w)
+
+      assert BufferServer.content(buffer) == "  w\n  hello"
+    end
   end
 
   describe "Insert mode operations" do

--- a/test/minga_editor/commands/movement_test.exs
+++ b/test/minga_editor/commands/movement_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.Commands.MovementTest do
   defp start_editor(content \\ "hello\nworld\nfoo") do
     id = :erlang.unique_integer([:positive])
     events_registry = :"movement_events_#{id}"
+    project_root = isolated_project_root(id)
     start_supervised!({Minga.Events, name: events_registry})
 
     {:ok, buffer} = BufferServer.start_link(content: content, events_registry: events_registry)
@@ -22,10 +23,17 @@ defmodule MingaEditor.Commands.MovementTest do
         height: 10,
         editing_model: :vim,
         events_registry: events_registry,
+        project_root: project_root,
         suppress_tool_prompts: true
       )
 
     {editor, buffer}
+  end
+
+  defp isolated_project_root(id) do
+    root = Path.join(System.tmp_dir!(), "minga-movement-#{id}")
+    File.mkdir_p!(root)
+    root
   end
 
   defp send_key(editor, codepoint, mods \\ 0) do
@@ -179,18 +187,25 @@ defmodule MingaEditor.Commands.MovementTest do
 
   describe "page / half-page scrolling" do
     defp start_scroll_editor do
+      id = :erlang.unique_integer([:positive])
       content = Enum.map_join(0..29, "\n", &"line #{&1}")
+      events_registry = :"movement_scroll_events_#{id}"
+      project_root = isolated_project_root(id)
+      start_supervised!({Minga.Events, name: events_registry})
 
-      {:ok, buffer} = BufferServer.start_link(content: content)
+      {:ok, buffer} = BufferServer.start_link(content: content, events_registry: events_registry)
 
       {:ok, editor} =
         MingaEditor.start_link(
-          name: :"editor_#{:erlang.unique_integer([:positive])}",
+          name: :"editor_#{id}",
           port_manager: nil,
           buffer: buffer,
           width: 40,
           height: 10,
-          editing_model: :vim
+          editing_model: :vim,
+          events_registry: events_registry,
+          project_root: project_root,
+          suppress_tool_prompts: true
         )
 
       {editor, buffer}

--- a/test/minga_editor/indent_test.exs
+++ b/test/minga_editor/indent_test.exs
@@ -4,79 +4,79 @@ defmodule MingaEditor.IndentTest do
   alias Minga.Buffer.Server, as: BufferServer
   alias MingaEditor.Indent
 
-  describe "compute_for_newline/2" do
-    test "copies indentation from previous line" do
-      buf = start_buffer("  hello\n  world")
-      assert Indent.compute_for_newline(buf, 0) == "  "
-      assert Indent.compute_for_newline(buf, 1) == "  "
-    end
+  describe "compute_for_line/3" do
+    test "converts tree-sitter indent levels to spaces" do
+      buf = start_buffer("def foo do\nbar\nend", filetype: :elixir)
+      request_indent = fn 42, 1 -> 2 end
 
-    test "no indentation on unindented line" do
-      buf = start_buffer("hello\nworld")
-      assert Indent.compute_for_newline(buf, 0) == ""
-    end
+      indent = Indent.compute_for_line(buf, 1, buffer_id: 42, request_indent: request_indent)
 
-    test "indents after Elixir do block" do
-      buf = start_buffer("  def foo do\n    bar\n  end", filetype: :elixir)
-      indent = Indent.compute_for_newline(buf, 0)
       assert indent == "    "
     end
 
-    test "indents after opening brace" do
-      buf = start_buffer("  fn main() {", filetype: :rust)
-      indent = Indent.compute_for_newline(buf, 0)
-      assert indent == "    "
+    test "converts tree-sitter indent levels to tabs" do
+      buf = start_buffer("fn main() {\nbody\n}", filetype: :rust)
+      {:ok, :tabs} = BufferServer.set_option(buf, :indent_with, :tabs)
+      request_indent = fn 42, 1 -> 2 end
+
+      indent = Indent.compute_for_line(buf, 1, buffer_id: 42, request_indent: request_indent)
+
+      assert indent == "\t\t"
     end
 
-    test "indents after opening bracket" do
-      buf = start_buffer("  items = [", filetype: :elixir)
-      indent = Indent.compute_for_newline(buf, 0)
-      assert indent == "    "
+    test "falls back to previous line copy-indent when parser indentation is unavailable" do
+      buf = start_buffer("  parent\nchild")
+
+      assert Indent.compute_for_line(buf, 1) == "  "
     end
 
-    test "indents after Python colon" do
-      buf = start_buffer("  def foo():", filetype: :python)
-      indent = Indent.compute_for_newline(buf, 0)
-      assert indent == "    "
+    test "falls back to empty indentation for the first line" do
+      buf = start_buffer("  child")
+
+      assert Indent.compute_for_line(buf, 0) == ""
     end
 
-    test "indents after Elixir arrow" do
-      buf = start_buffer("  fn x ->", filetype: :elixir)
-      indent = Indent.compute_for_newline(buf, 0)
-      assert indent == "    "
+    test "uses explicit fallback when provided" do
+      buf = start_buffer("  child")
+
+      assert Indent.compute_for_line(buf, 0, fallback: "  ") == "  "
     end
 
-    test "preserves tab indentation" do
-      buf = start_buffer("\thello", filetype: :c)
-      indent = Indent.compute_for_newline(buf, 0)
-      assert indent == "\t"
+    test "falls back when parser returns nil" do
+      buf = start_buffer("  parent\nchild")
+      request_indent = fn 42, 1 -> nil end
+
+      indent = Indent.compute_for_line(buf, 1, buffer_id: 42, request_indent: request_indent)
+
+      assert indent == "  "
+    end
+
+    test "falls back when parser exits" do
+      buf = start_buffer("  parent\nchild")
+      request_indent = fn 42, 1 -> exit(:noproc) end
+
+      indent = Indent.compute_for_line(buf, 1, buffer_id: 42, request_indent: request_indent)
+
+      assert indent == "  "
+    end
+
+    test "falls back when parser returns a negative level" do
+      buf = start_buffer("  parent\nchild")
+      request_indent = fn 42, 1 -> -1 end
+
+      indent = Indent.compute_for_line(buf, 1, buffer_id: 42, request_indent: request_indent)
+
+      assert indent == "  "
     end
 
     test "returns empty for out-of-range line" do
       buf = start_buffer("hello")
-      assert Indent.compute_for_newline(buf, 99) == ""
+      assert Indent.compute_for_line(buf, 99) == ""
     end
 
     test "handles empty buffer" do
       buf = start_buffer("")
-      assert Indent.compute_for_newline(buf, 0) == ""
-    end
-  end
-
-  describe "should_dedent_line?/2" do
-    test "detects Elixir end keyword" do
-      buf = start_buffer("  end", filetype: :elixir)
-      assert Indent.should_dedent_line?(buf, 0)
-    end
-
-    test "detects closing brace" do
-      buf = start_buffer("  }", filetype: :rust)
-      assert Indent.should_dedent_line?(buf, 0)
-    end
-
-    test "does not dedent normal line" do
-      buf = start_buffer("  hello", filetype: :elixir)
-      refute Indent.should_dedent_line?(buf, 0)
+      assert Indent.compute_for_line(buf, 0) == ""
     end
   end
 

--- a/test/minga_editor/integration/mouse_test.exs
+++ b/test/minga_editor/integration/mouse_test.exs
@@ -15,6 +15,13 @@ defmodule Minga.Integration.MouseTest do
 
   # ── Test helpers ───────────────────────────────────────────────────────────
 
+  defp start_editor_with_project(content) do
+    id = :erlang.unique_integer([:positive])
+    root = Path.join(System.tmp_dir!(), "minga-integration-mouse-#{id}")
+    File.mkdir_p!(root)
+    start_editor(content, project_root: root)
+  end
+
   # Sends a gui_action to the editor and waits for the frame to render.
   defp send_gui_action(%{editor: editor, port: port}, action) do
     _ = :sys.get_state(editor, 15_000)
@@ -157,7 +164,7 @@ defmodule Minga.Integration.MouseTest do
 
   describe "click in file tree region" do
     test "clicking in tree area doesn't move buffer cursor" do
-      ctx = start_editor("hello world")
+      ctx = start_editor_with_project("hello world")
 
       send_keys_sync(ctx, "<Space>op")
       cursor_before = buffer_cursor(ctx)
@@ -361,7 +368,7 @@ defmodule Minga.Integration.MouseTest do
 
   describe "multi-region dispatch" do
     test "click dispatches to correct region when file tree is open" do
-      ctx = start_editor("hello world")
+      ctx = start_editor_with_project("hello world")
 
       # Open file tree and wait for it to render.
       send_keys_sync(ctx, "<Space>op")

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -8,48 +8,71 @@ defmodule MingaEditor.MouseTest do
 
   # Content starts at row 1 because the tab bar occupies row 0.
   @content_row 1
+  @sync_timeout 15_000
 
   defp start_editor(content) do
-    {:ok, buffer} = BufferServer.start_link(content: content)
+    id = :erlang.unique_integer([:positive])
+    events_registry = :"mouse_events_#{id}"
+    project_root = isolated_project_root(id)
+    start_supervised!({Minga.Events, name: events_registry})
+
+    {:ok, buffer} = BufferServer.start_link(content: content, events_registry: events_registry)
 
     {:ok, editor} =
       MingaEditor.start_link(
-        name: :"editor_#{:erlang.unique_integer([:positive])}",
+        name: :"editor_#{id}",
         port_manager: nil,
         buffer: buffer,
         width: 40,
         height: 10,
-        editing_model: :vim
+        editing_model: :vim,
+        events_registry: events_registry,
+        project_root: project_root,
+        suppress_tool_prompts: true
       )
 
     {editor, buffer}
   end
 
   defp start_editor_no_buffer do
+    id = :erlang.unique_integer([:positive])
+    events_registry = :"mouse_events_#{id}"
+    project_root = isolated_project_root(id)
+    start_supervised!({Minga.Events, name: events_registry})
+
     {:ok, editor} =
       MingaEditor.start_link(
-        name: :"editor_#{:erlang.unique_integer([:positive])}",
+        name: :"editor_#{id}",
         port_manager: nil,
         buffer: nil,
         width: 40,
         height: 10,
-        editing_model: :vim
+        editing_model: :vim,
+        events_registry: events_registry,
+        project_root: project_root,
+        suppress_tool_prompts: true
       )
 
     editor
   end
 
+  defp isolated_project_root(id) do
+    root = Path.join(System.tmp_dir!(), "minga-mouse-#{id}")
+    File.mkdir_p!(root)
+    root
+  end
+
   defp send_key(editor, codepoint, mods \\ 0) do
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor)
+    _ = :sys.get_state(editor, @sync_timeout)
   end
 
   defp send_mouse(editor, row, col, button, event_type, mods \\ 0, click_count \\ 1) do
     send(editor, {:minga_input, {:mouse_event, row, col, button, mods, event_type, click_count}})
-    _ = :sys.get_state(editor)
+    _ = :sys.get_state(editor, @sync_timeout)
   end
 
-  defp state(editor), do: :sys.get_state(editor)
+  defp state(editor), do: :sys.get_state(editor, @sync_timeout)
 
   defp rightmost_window_layout(layout) do
     Enum.max_by(layout.window_layouts, fn {_id, %{content: {_row, content_col, _w, _h}}} ->
@@ -59,20 +82,7 @@ defmodule MingaEditor.MouseTest do
 
   describe "mouse scroll" do
     defp start_mouse_editor do
-      content = Enum.map_join(0..29, "\n", &"line #{&1}")
-      {:ok, buffer} = BufferServer.start_link(content: content)
-
-      {:ok, editor} =
-        MingaEditor.start_link(
-          name: :"editor_#{:erlang.unique_integer([:positive])}",
-          port_manager: nil,
-          buffer: buffer,
-          width: 40,
-          height: 10,
-          editing_model: :vim
-        )
-
-      {editor, buffer}
+      start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
     end
 
     test "scroll down clamps cursor to respect scroll margin" do
@@ -179,18 +189,7 @@ defmodule MingaEditor.MouseTest do
     end
 
     test "left click accounts for viewport scroll offset" do
-      content = Enum.map_join(0..29, "\n", &"line #{&1}")
-      {:ok, buffer} = BufferServer.start_link(content: content)
-
-      {:ok, editor} =
-        MingaEditor.start_link(
-          name: :"editor_#{:erlang.unique_integer([:positive])}",
-          port_manager: nil,
-          buffer: buffer,
-          width: 40,
-          height: 10,
-          editing_model: :vim
-        )
+      {editor, buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
 
       # Scroll down then click. Default scroll_lines=1, so 4 scrolls = viewport top at 4.
       for _i <- 1..4, do: send_mouse(editor, 0, 0, :wheel_down, :press)
@@ -397,17 +396,25 @@ defmodule MingaEditor.MouseTest do
     alias MingaEditor.State.TabBar
 
     defp start_two_tab_editor do
-      {:ok, buf1} = BufferServer.start_link(content: "hello")
-      {:ok, buf2} = BufferServer.start_link(content: "world")
+      id = :erlang.unique_integer([:positive])
+      events_registry = :"mouse_tab_events_#{id}"
+      project_root = isolated_project_root(id)
+      start_supervised!({Minga.Events, name: events_registry})
+
+      {:ok, buf1} = BufferServer.start_link(content: "hello", events_registry: events_registry)
+      {:ok, buf2} = BufferServer.start_link(content: "world", events_registry: events_registry)
 
       {:ok, editor} =
         MingaEditor.start_link(
-          name: :"editor_#{:erlang.unique_integer([:positive])}",
+          name: :"editor_#{id}",
           port_manager: nil,
           buffer: buf1,
           width: 80,
           height: 10,
-          editing_model: :vim
+          editing_model: :vim,
+          events_registry: events_registry,
+          project_root: project_root,
+          suppress_tool_prompts: true
         )
 
       # Inject a second tab directly via state manipulation

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -100,7 +100,7 @@ defmodule Minga.Test.EditorCase do
     # Send ready event to trigger initial render
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:ready, width, height}})
-    {:ok, snapshot} = HeadlessPort.collect_frame(ref)
+    {:ok, snapshot} = HeadlessPort.collect_frame(ref, @sync_timeout)
     Process.put({:last_frame_snapshot, port}, snapshot)
 
     # Drain any deferred messages queued by the :ready handler (e.g.
@@ -139,22 +139,28 @@ defmodule Minga.Test.EditorCase do
 
     editing_model = Keyword.get(opts, :editing_model, :vim)
 
-    {:ok, editor} =
-      MingaEditor.start_link(
-        name: :"headless_editor_#{id}",
-        backend: :headless,
-        port_manager: port,
-        buffer: buffer,
-        width: width,
-        height: height,
-        editing_model: editing_model,
-        events_registry: events_registry,
-        suppress_tool_prompts: true
-      )
+    editor_opts = [
+      name: :"headless_editor_#{id}",
+      backend: :headless,
+      port_manager: port,
+      buffer: buffer,
+      width: width,
+      height: height,
+      editing_model: editing_model,
+      events_registry: events_registry,
+      suppress_tool_prompts: true
+    ]
+
+    project_root = Keyword.get(opts, :project_root)
+
+    editor_opts =
+      if project_root, do: [{:project_root, project_root} | editor_opts], else: editor_opts
+
+    {:ok, editor} = MingaEditor.start_link(editor_opts)
 
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:ready, width, height}})
-    {:ok, snapshot} = HeadlessPort.collect_frame(ref)
+    {:ok, snapshot} = HeadlessPort.collect_frame(ref, @sync_timeout)
     Process.put({:last_frame_snapshot, port}, snapshot)
 
     # Drain deferred messages from :ready (see start_editor/2 comment).
@@ -252,7 +258,7 @@ defmodule Minga.Test.EditorCase do
     _ = get_editor_state(editor)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    {:ok, snapshot} = HeadlessPort.collect_frame(ref)
+    {:ok, snapshot} = HeadlessPort.collect_frame(ref, @sync_timeout)
     # Store snapshot keyed by port pid so concurrent tests don't collide
     Process.put({:last_frame_snapshot, port}, snapshot)
     :ok
@@ -445,7 +451,7 @@ defmodule Minga.Test.EditorCase do
   @doc "Returns MessageStore entries after synchronizing with the editor process."
   @spec message_store_entries(editor_ctx()) :: [map()]
   def message_store_entries(%{editor: editor}) do
-    :sys.get_state(editor).message_store.entries
+    get_editor_state(editor).message_store.entries
   end
 
   @doc "Returns the number of open buffers."
@@ -767,7 +773,7 @@ defmodule Minga.Test.EditorCase do
     _ = get_editor_state(editor)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:mouse_event, row, col, button, mods, event_type, click_count}})
-    {:ok, snapshot} = HeadlessPort.collect_frame(ref)
+    {:ok, snapshot} = HeadlessPort.collect_frame(ref, @sync_timeout)
     Process.put({:last_frame_snapshot, port}, snapshot)
     :ok
   end
@@ -782,7 +788,7 @@ defmodule Minga.Test.EditorCase do
     HeadlessPort.resize(port, new_width, new_height)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:resize, new_width, new_height}})
-    {:ok, snapshot} = HeadlessPort.collect_frame(ref)
+    {:ok, snapshot} = HeadlessPort.collect_frame(ref, @sync_timeout)
     Process.put({:last_frame_snapshot, port}, snapshot)
     %{ctx | width: new_width, height: new_height}
   end


### PR DESCRIPTION
# TL;DR
Indentation now uses tree-sitter indent queries when the parser can answer, so `Enter`, `o`, `O`, and `=` follow language-aware indentation instead of editor-side trigger heuristics. Buffers without parser support still fall back to copy-indent behavior.

## Context
Minga already has tree-sitter indent queries in the parser process. This PR wires those results into editor editing commands so indentation rules live with the language parser instead of being duplicated as simplified Elixir heuristics.

## Changes
- Adds `Minga.Parser.Manager.request_indent/4` with timeouts so editor commands can ask the parser for an indent level without hanging the keystroke path.
- Reuses pending request reply handling for indent and text object responses, including timeout cleanup for synchronous parser requests.
- Updates newline insertion, open-line-above/below, and reindent commands to request the target line's tree-sitter indent after the buffer has been reparsed.
- Converts parser indent levels into spaces or tabs using the buffer's `tab_size` and `indent_with` options.
- Preserves copy-indent fallback when the parser is unavailable, unsupported, slow, or returns no usable indent level, including `O` above an indented first line.
- Hardens async editor and agent tests that were relying on global project state, short event waits, or default frame timeouts under full-suite pressure.
- Adds coverage for parser indent requests, tree-sitter indent conversion, fallback behavior, reindent fallback, and top-of-file `O` fallback indentation.

## Verification
- `make lint`
- `mix test.llm`