### PR TITLE
fix(cli): open file arguments in editor mode

### DIFF
--- a/lib/minga/cli.ex
+++ b/lib/minga/cli.ex
@@ -9,6 +9,8 @@ defmodule Minga.CLI do
   By default, Minga boots into the agentic view (controlled by the `:startup_view` config option). CLI flags can override the config:
 
   - `--editor` forces the traditional file editing view
+  - File arguments open in the traditional file editing view by default
+  - Directory arguments open the agentic view with the directory as context
   - `--no-context` opens the agentic view but skips loading the CLI file argument as preview context
   - `--headless` starts only the services and agent runtime, plus the JSON-RPC Gateway
   """
@@ -21,9 +23,12 @@ defmodule Minga.CLI do
           {:open, file :: String.t() | nil, flags()}
           | {:error, String.t()}
 
+  @typedoc "Startup view mode requested by CLI flags."
+  @type view_mode :: :auto | :editor | :agentic
+
   @typedoc "CLI flags that override config options."
   @type flags :: %{
-          force_editor: boolean(),
+          view_mode: view_mode(),
           no_context: boolean(),
           config_file: String.t() | nil,
           headless: boolean(),
@@ -37,7 +42,7 @@ defmodule Minga.CLI do
         }
 
   @default_flags %{
-    force_editor: false,
+    view_mode: :auto,
     no_context: false,
     config_file: nil,
     headless: false,
@@ -57,7 +62,7 @@ defmodule Minga.CLI do
   def main(args) do
     case parse_args(args) do
       {:open, file, flags} ->
-        store_startup_flags(flags)
+        store_startup_flags(flags, file)
 
         case maybe_start_distribution(flags) do
           :ok -> launch(flags, file)
@@ -100,7 +105,8 @@ defmodule Minga.CLI do
   @doc "Returns the startup flags stored by the CLI, or defaults if none were set."
   @spec startup_flags() :: flags()
   def startup_flags do
-    Application.get_env(:minga, :cli_startup_flags, @default_flags)
+    stored = Application.get_env(:minga, :cli_startup_flags, %{})
+    Map.merge(@default_flags, stored)
   end
 
   # ── Argument parsing ────────────────────────────────────────────────────────
@@ -114,7 +120,7 @@ defmodule Minga.CLI do
   defp parse_args(["-v" | _], _file, _flags), do: {:error, "minga #{Minga.version()}"}
 
   defp parse_args(["--editor" | rest], file, flags) do
-    parse_args(rest, file, %{flags | force_editor: true})
+    parse_args(rest, file, %{flags | view_mode: :editor})
   end
 
   defp parse_args(["--no-context" | rest], file, flags) do
@@ -247,14 +253,21 @@ defmodule Minga.CLI do
     end
   end
 
-  defp launch(_flags, file) do
+  defp launch(%{headless: false}, file) do
     log_startup(file)
-    open_editor(file)
+    open_startup_target(file)
   end
 
   @spec log_startup(String.t() | nil) :: :ok
   defp log_startup(nil), do: Minga.Log.debug(:editor, "Starting with empty buffer")
-  defp log_startup(file), do: Minga.Log.debug(:editor, "Opening file: #{file}")
+
+  defp log_startup(path) do
+    if File.dir?(path) do
+      Minga.Log.debug(:editor, "Opening project: #{path}")
+    else
+      Minga.Log.debug(:editor, "Opening file: #{path}")
+    end
+  end
 
   @spec start_headless_gateway(pos_integer(), :inet.ip_address(), String.t() | nil) :: :ok
   defp start_headless_gateway(port, ip, auth_token) do
@@ -474,17 +487,41 @@ defmodule Minga.CLI do
     exit({:shutdown, 1})
   end
 
-  @doc "Applies flag implications (e.g., minimal implies force_editor) to a flags map."
+  @doc "Applies flag implications to a flags map."
   @spec apply_flag_implications(flags()) :: flags()
-  def apply_flag_implications(%{minimal: true} = flags), do: %{flags | force_editor: true}
-  def apply_flag_implications(flags), do: flags
+  def apply_flag_implications(flags), do: apply_flag_implications(flags, nil)
 
-  @spec store_startup_flags(flags()) :: :ok
-  defp store_startup_flags(flags) do
-    effective = apply_flag_implications(flags)
+  @doc "Applies flag implications with file-aware startup view resolution."
+  @spec apply_flag_implications(flags(), String.t() | nil) :: flags()
+  def apply_flag_implications(%{minimal: true} = flags, _file) do
+    %{flags | view_mode: :editor}
+  end
+
+  def apply_flag_implications(%{view_mode: :editor} = flags, _file), do: flags
+  def apply_flag_implications(%{view_mode: :agentic} = flags, _file), do: flags
+
+  def apply_flag_implications(%{view_mode: :auto, no_context: true} = flags, _file),
+    do: %{flags | view_mode: :agentic}
+
+  def apply_flag_implications(%{view_mode: :auto} = flags, nil), do: flags
+
+  def apply_flag_implications(%{view_mode: :auto} = flags, file),
+    do: resolve_auto_view_mode(flags, file)
+
+  @spec resolve_auto_view_mode(flags(), String.t()) :: flags()
+  defp resolve_auto_view_mode(flags, file) do
+    resolve_auto_view_mode_for_directory(flags, File.dir?(file))
+  end
+
+  @spec resolve_auto_view_mode_for_directory(flags(), boolean()) :: flags()
+  defp resolve_auto_view_mode_for_directory(flags, true), do: %{flags | view_mode: :agentic}
+  defp resolve_auto_view_mode_for_directory(flags, false), do: %{flags | view_mode: :editor}
+
+  @spec store_startup_flags(flags(), String.t() | nil) :: :ok
+  defp store_startup_flags(flags, file) do
+    effective = apply_flag_implications(flags, file)
     Application.put_env(:minga, :cli_startup_flags, effective)
     if effective.minimal, do: Application.put_env(:minga, :minimal_mode, true)
-    if effective.force_editor, do: Application.put_env(:minga, :force_editor, true)
     :ok
   end
 
@@ -501,7 +538,7 @@ defmodule Minga.CLI do
       --config <path>        Use a custom config file instead of the default
       --editor               Start in file editing mode (skip agentic view)
       --minimal              Minimal mode: editor-only, no services/agent (for GIT_EDITOR use)
-      --no-context           Don't load the file as agent context
+      --no-context           Keep agentic view and don't load the file as agent context
       --headless             Start services and agent runtime without a GUI frontend
       --name <name@host>     Distributed Erlang long node name
       --sname <name>         Distributed Erlang short node name
@@ -512,26 +549,38 @@ defmodule Minga.CLI do
 
     Examples:
       minga                              Start agentic view
-      minga README.md                    Start agentic view with file as context
+      minga README.md                    Open file for editing
+      minga .                            Start agentic view with project as context
       minga --editor README.md           Open file in traditional editor
       MINGA_COOKIE=$(openssl rand -base64 32 | tr -d '/+=') minga --headless   Start detachable agent server
       minga --config ~/minimal.exs       Use a custom config profile
     """
   end
 
-  @spec open_editor(String.t() | nil) :: :ok
-  defp open_editor(file_path) do
-    case file_path do
-      nil ->
-        :ok
+  @spec open_startup_target(String.t() | nil) :: :ok
+  defp open_startup_target(nil), do: :ok
 
-      path ->
-        {interval, retries} = editor_wait_params()
+  defp open_startup_target(path) do
+    if File.dir?(path) do
+      open_project(path)
+    else
+      open_file(path)
+    end
+  end
 
-        case wait_for_editor(interval, retries) do
-          :ok -> MingaEditor.open_file(path)
-          :timeout -> Minga.Log.error(:editor, "Editor process did not start in time")
-        end
+  @spec open_project(String.t()) :: :ok
+  defp open_project(path) do
+    Minga.Project.switch(path)
+    :ok
+  end
+
+  @spec open_file(String.t()) :: :ok
+  defp open_file(path) do
+    {interval, retries} = editor_wait_params()
+
+    case wait_for_editor(interval, retries) do
+      :ok -> MingaEditor.open_file(path)
+      :timeout -> Minga.Log.error(:editor, "Editor process did not start in time")
     end
 
     :ok

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -231,27 +231,38 @@ defmodule MingaEditor.Startup do
   Returns `{keymap_scope, agentic_state}`. Called before window creation
   so the correct window type can be built in a single pass.
 
-  Agent-first startup only applies to the TUI. GUI frontends always
-  start with the editor view because agent mode is designed around the
-  TUI's full-screen chat layout.
+  Explicit CLI view modes are final. Auto startup keeps the existing
+  behavior: TUI consults the startup config, while GUI frontends default
+  to the editor view.
   """
   @spec startup_view_state(EditorState.backend()) :: {atom(), UIState.t()}
   def startup_view_state(backend) do
     cli_flags = Minga.CLI.startup_flags()
-
-    want_agent? =
-      backend == :tui and
-        not cli_flags.force_editor and
-        Config.get(:startup_view) == :agent
-
-    if want_agent? do
-      base = UIState.new()
-      av = %UIState{base | view: %{base.view | active: true, focus: :chat}}
-      {:agent, av}
-    else
-      {:editor, UIState.new()}
-    end
+    startup_view_state(backend, cli_flags.view_mode)
   end
+
+  @spec startup_view_state(EditorState.backend(), Minga.CLI.view_mode()) :: {atom(), UIState.t()}
+  defp startup_view_state(_backend, :editor), do: editor_view_state()
+  defp startup_view_state(_backend, :agentic), do: agent_view_state()
+
+  defp startup_view_state(:tui, :auto),
+    do: startup_view_state_from_config(Config.get(:startup_view))
+
+  defp startup_view_state(_backend, :auto), do: editor_view_state()
+
+  @spec startup_view_state_from_config(atom()) :: {atom(), UIState.t()}
+  defp startup_view_state_from_config(:agent), do: agent_view_state()
+  defp startup_view_state_from_config(_startup_view), do: editor_view_state()
+
+  @spec agent_view_state() :: {atom(), UIState.t()}
+  defp agent_view_state do
+    base = UIState.new()
+    av = %UIState{base | view: %{base.view | active: true, focus: :chat}}
+    {:agent, av}
+  end
+
+  @spec editor_view_state() :: {atom(), UIState.t()}
+  defp editor_view_state, do: {:editor, UIState.new()}
 
   @doc """
   Fetches port capabilities, returning defaults if no port manager is configured.

--- a/test/minga/cli_test.exs
+++ b/test/minga/cli_test.exs
@@ -1,11 +1,12 @@
 defmodule Minga.CLITest do
-  use ExUnit.Case, async: true
+  # Not async: CLI startup flag tests mutate Application env, which races with editor startup tests.
+  use ExUnit.Case, async: false
 
   alias Minga.CLI
 
   describe "parse_args/1" do
     test "no arguments returns {:open, nil, default_flags}" do
-      assert {:open, nil, %{force_editor: false, no_context: false, config_file: nil}} =
+      assert {:open, nil, %{view_mode: :auto, no_context: false, config_file: nil}} =
                CLI.parse_args([])
     end
 
@@ -33,12 +34,12 @@ defmodule Minga.CLITest do
     end
 
     test "single file argument returns {:open, path, flags}" do
-      assert {:open, "README.md", %{force_editor: false, no_context: false, config_file: nil}} =
+      assert {:open, "README.md", %{view_mode: :auto, no_context: false, config_file: nil}} =
                CLI.parse_args(["README.md"])
     end
 
     test "file argument with extra non-flag args takes the last file" do
-      assert {:open, "other.txt", %{force_editor: false, no_context: false, config_file: nil}} =
+      assert {:open, "other.txt", %{view_mode: :auto, no_context: false, config_file: nil}} =
                CLI.parse_args(["file.txt", "other.txt"])
     end
 
@@ -46,33 +47,33 @@ defmodule Minga.CLITest do
       assert {:error, _} = CLI.parse_args(["--help", "file.txt"])
     end
 
-    test "--editor flag sets force_editor" do
-      assert {:open, nil, %{force_editor: true, no_context: false, config_file: nil}} =
+    test "--editor flag sets view_mode" do
+      assert {:open, nil, %{view_mode: :editor, no_context: false, config_file: nil}} =
                CLI.parse_args(["--editor"])
     end
 
     test "--editor flag with file" do
-      assert {:open, "foo.ex", %{force_editor: true, no_context: false, config_file: nil}} =
+      assert {:open, "foo.ex", %{view_mode: :editor, no_context: false, config_file: nil}} =
                CLI.parse_args(["--editor", "foo.ex"])
     end
 
     test "--no-context flag sets no_context" do
-      assert {:open, nil, %{force_editor: false, no_context: true, config_file: nil}} =
+      assert {:open, nil, %{view_mode: :auto, no_context: true, config_file: nil}} =
                CLI.parse_args(["--no-context"])
     end
 
     test "--no-context flag with file" do
-      assert {:open, "foo.ex", %{force_editor: false, no_context: true, config_file: nil}} =
+      assert {:open, "foo.ex", %{view_mode: :auto, no_context: true, config_file: nil}} =
                CLI.parse_args(["--no-context", "foo.ex"])
     end
 
     test "--editor and --no-context together" do
-      assert {:open, "foo.ex", %{force_editor: true, no_context: true, config_file: nil}} =
+      assert {:open, "foo.ex", %{view_mode: :editor, no_context: true, config_file: nil}} =
                CLI.parse_args(["--editor", "--no-context", "foo.ex"])
     end
 
     test "flags can appear after file argument" do
-      assert {:open, "foo.ex", %{force_editor: true, no_context: false, config_file: nil}} =
+      assert {:open, "foo.ex", %{view_mode: :editor, no_context: false, config_file: nil}} =
                CLI.parse_args(["foo.ex", "--editor"])
     end
 
@@ -93,7 +94,7 @@ defmodule Minga.CLITest do
     end
 
     test "--config combined with --editor" do
-      assert {:open, "foo.ex", %{force_editor: true, config_file: "/tmp/c.exs"}} =
+      assert {:open, "foo.ex", %{view_mode: :editor, config_file: "/tmp/c.exs"}} =
                CLI.parse_args(["--config", "/tmp/c.exs", "--editor", "foo.ex"])
     end
 
@@ -187,29 +188,59 @@ defmodule Minga.CLITest do
       assert message =~ "--config"
       assert message =~ "--minimal"
     end
+
+    test "usage text describes file and directory startup behavior" do
+      assert {:error, message} = CLI.parse_args(["--help"])
+      assert message =~ "minga README.md                    Open file for editing"
+
+      assert message =~
+               "minga .                            Start agentic view with project as context"
+
+      assert message =~ "Keep agentic view and don't load the file as agent context"
+    end
   end
 
   describe "startup_flags/0" do
     test "returns default flags when no CLI flags were set" do
-      # Clear any flags from other tests
       Application.delete_env(:minga, :cli_startup_flags)
-      assert %{force_editor: false, no_context: false, config_file: nil} = CLI.startup_flags()
+      assert %{view_mode: :auto, no_context: false, config_file: nil} = CLI.startup_flags()
+    end
+
+    test "merges sparse stored flags with defaults" do
+      Application.put_env(:minga, :cli_startup_flags, %{config_file: "/tmp/custom.exs"})
+
+      assert %{view_mode: :auto, no_context: false, config_file: "/tmp/custom.exs"} =
+               CLI.startup_flags()
+    after
+      Application.delete_env(:minga, :cli_startup_flags)
     end
   end
 
   describe "main/1" do
     test "no arguments returns :ok without crashing" do
       assert :ok = CLI.main([])
+    after
+      Application.delete_env(:minga, :cli_startup_flags)
     end
 
     test "file argument returns :ok even when editor isn't running" do
       assert :ok = CLI.main(["nonexistent_file.txt"])
+    after
+      Application.delete_env(:minga, :cli_startup_flags)
+    end
+
+    test "directory argument stores agentic startup mode" do
+      Application.delete_env(:minga, :cli_startup_flags)
+      assert :ok = CLI.main([System.tmp_dir!()])
+      assert %{view_mode: :agentic, no_context: false, config_file: nil} = CLI.startup_flags()
+    after
+      Application.delete_env(:minga, :cli_startup_flags)
     end
 
     test "main stores startup flags in application env" do
       Application.delete_env(:minga, :cli_startup_flags)
       CLI.main(["--editor", "some_file.ex"])
-      assert %{force_editor: true, no_context: false, config_file: nil} = CLI.startup_flags()
+      assert %{view_mode: :editor, no_context: false, config_file: nil} = CLI.startup_flags()
     after
       Application.delete_env(:minga, :cli_startup_flags)
     end
@@ -217,32 +248,81 @@ defmodule Minga.CLITest do
     test "main stores config_file flag from --config" do
       Application.delete_env(:minga, :cli_startup_flags)
       CLI.main(["--config", "/tmp/test_config.exs"])
-      assert %{config_file: "/tmp/test_config.exs"} = CLI.startup_flags()
+      assert %{view_mode: :auto, config_file: "/tmp/test_config.exs"} = CLI.startup_flags()
     after
       Application.delete_env(:minga, :cli_startup_flags)
     end
   end
 
   describe "apply_flag_implications/1" do
-    test "minimal implies force_editor" do
+    test "minimal implies editor view" do
       {:open, _, flags} = CLI.parse_args(["--minimal", "COMMIT_EDITMSG"])
       result = CLI.apply_flag_implications(flags)
-      assert result.force_editor == true
+      assert result.view_mode == :editor
       assert result.minimal == true
     end
 
-    test "force_editor alone is preserved, does not set minimal" do
+    test "editor view alone is preserved, does not set minimal" do
       {:open, _, flags} = CLI.parse_args(["--editor"])
       result = CLI.apply_flag_implications(flags)
-      assert result.force_editor == true
+      assert result.view_mode == :editor
       assert result.minimal == false
     end
 
-    test "neither flag leaves both false" do
+    test "neither flag leaves view mode auto" do
       {:open, _, flags} = CLI.parse_args([])
       result = CLI.apply_flag_implications(flags)
-      assert result.force_editor == false
+      assert result.view_mode == :auto
       assert result.minimal == false
+    end
+  end
+
+  describe "apply_flag_implications/2" do
+    test "regular file resolves auto view to editor" do
+      path =
+        Path.join(System.tmp_dir!(), "minga_cli_file_#{System.unique_integer([:positive])}.ex")
+
+      File.write!(path, "IO.puts(:ok)\n")
+      on_exit(fn -> File.rm(path) end)
+
+      {:open, _, flags} = CLI.parse_args([path])
+      result = CLI.apply_flag_implications(flags, path)
+      assert result.view_mode == :editor
+    end
+
+    test "directory resolves auto view to agentic" do
+      {:open, _, flags} = CLI.parse_args([System.tmp_dir!()])
+      result = CLI.apply_flag_implications(flags, System.tmp_dir!())
+      assert result.view_mode == :agentic
+    end
+
+    test "nil leaves auto view unresolved" do
+      {:open, _, flags} = CLI.parse_args([])
+      result = CLI.apply_flag_implications(flags, nil)
+      assert result.view_mode == :auto
+    end
+
+    test "no-context resolves auto view to agentic" do
+      {:open, file, flags} = CLI.parse_args(["--no-context", "foo.ex"])
+      result = CLI.apply_flag_implications(flags, file)
+      assert result.view_mode == :agentic
+      assert result.no_context == true
+    end
+
+    test "explicit editor view wins over no-context" do
+      {:open, file, flags} = CLI.parse_args(["--editor", "--no-context", "foo.ex"])
+      result = CLI.apply_flag_implications(flags, file)
+      assert result.view_mode == :editor
+      assert result.no_context == true
+    end
+
+    test "nonexistent file path resolves auto view to editor" do
+      path =
+        Path.join(System.tmp_dir!(), "minga_missing_#{System.unique_integer([:positive])}.ex")
+
+      {:open, _, flags} = CLI.parse_args([path])
+      result = CLI.apply_flag_implications(flags, path)
+      assert result.view_mode == :editor
     end
   end
 end

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -662,7 +662,7 @@ defmodule Minga.Config.LoaderTest do
 
       # Set the CLI flag
       Application.put_env(:minga, :cli_startup_flags, %{
-        force_editor: false,
+        view_mode: :auto,
         no_context: false,
         config_file: custom_path
       })
@@ -688,7 +688,7 @@ defmodule Minga.Config.LoaderTest do
       custom_path = "/tmp/minga_nonexistent_#{System.unique_integer([:positive])}.exs"
 
       Application.put_env(:minga, :cli_startup_flags, %{
-        force_editor: false,
+        view_mode: :auto,
         no_context: false,
         config_file: custom_path
       })
@@ -731,7 +731,7 @@ defmodule Minga.Config.LoaderTest do
       {_dir, cleanup} = make_config_dir("")
 
       Application.put_env(:minga, :cli_startup_flags, %{
-        force_editor: false,
+        view_mode: :auto,
         no_context: false,
         config_file: custom_path
       })
@@ -781,7 +781,7 @@ defmodule Minga.Config.LoaderTest do
       File.cd!(project_dir)
 
       Application.put_env(:minga, :cli_startup_flags, %{
-        force_editor: false,
+        view_mode: :auto,
         no_context: false,
         config_file: custom_path
       })
@@ -839,7 +839,7 @@ defmodule Minga.Config.LoaderTest do
       {_dir, cleanup} = make_config_dir("")
 
       Application.put_env(:minga, :cli_startup_flags, %{
-        force_editor: false,
+        view_mode: :auto,
         no_context: false,
         config_file: custom_path
       })

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -1,5 +1,5 @@
 defmodule MingaEditor.StartupTest do
-  # async: false because the force_editor test mutates Application env,
+  # async: false because the CLI startup flag tests mutate Application env,
   # which races with the first test when run concurrently.
   use ExUnit.Case, async: false
 
@@ -25,8 +25,8 @@ defmodule MingaEditor.StartupTest do
       assert agentic.view.focus == :chat
     end
 
-    test "returns :editor scope when force_editor flag is set" do
-      Application.put_env(:minga, :cli_startup_flags, %{force_editor: true, no_context: false})
+    test "returns :editor scope when editor view mode is set" do
+      Application.put_env(:minga, :cli_startup_flags, %{view_mode: :editor, no_context: false})
 
       {scope, agentic} = Startup.startup_view_state(:tui)
 
@@ -36,10 +36,26 @@ defmodule MingaEditor.StartupTest do
       Application.delete_env(:minga, :cli_startup_flags)
     end
 
-    test "returns :editor scope for native GUI backend" do
+    test "returns :agent scope when agentic view mode is set" do
+      Application.put_env(:minga, :cli_startup_flags, %{view_mode: :agentic, no_context: false})
+
+      {scope, agentic} = Startup.startup_view_state(:native_gui)
+
+      assert scope == :agent
+      assert agentic.view.active == true
+      assert agentic.view.focus == :chat
+    after
+      Application.delete_env(:minga, :cli_startup_flags)
+    end
+
+    test "returns :editor scope for native GUI backend in auto mode" do
+      Application.put_env(:minga, :cli_startup_flags, %{view_mode: :auto, no_context: false})
+
       {scope, _agentic} = Startup.startup_view_state(:native_gui)
 
       assert scope == :editor
+    after
+      Application.delete_env(:minga, :cli_startup_flags)
     end
   end
 


### PR DESCRIPTION
# TL;DR
`minga file.ex` now opens the file in editor mode by default, while no-arg startup and directory startup keep the agentic behavior users expect.

Closes #974

## Context
Issue #974 fixes a surprising launch behavior: passing a file path looked like a request to edit the file, but Minga treated it as agent context. This PR makes file arguments resolve to editor mode while keeping explicit agentic cases intact.

## Changes
- Replaced the CLI `force_editor` boolean with a `view_mode` tri-state: `:auto`, `:editor`, or `:agentic`.
- Made CLI startup flag resolution file-aware: directories and `--no-context` resolve to agentic mode, regular or missing file paths resolve to editor mode, and no file stays `:auto` so config can decide.
- Updated launch handling so directory arguments switch project context instead of trying to open the directory through the file-buffer path.
- Updated editor startup to treat resolved CLI modes as final and only consult `Config.get(:startup_view)` for `:auto` TUI startup.
- Updated CLI help text to show `minga README.md` as file editing and `minga .` as project/agentic startup.
- Updated CLI, startup, and config loader tests for the new flag shape and resolution rules.

## Verification
- `mix test.llm test/minga/cli_test.exs test/minga_editor/startup_test.exs test/minga/config/loader_test.exs` passed 96 tests.
- `make lint` passed.
- `mix test.llm --max-cases 1` passed 8414 tests before the follow-up directory-launch cleanup.
- Default parallel `mix test.llm` hit unrelated timeout/resource failures; `mix test.llm --failed` passed those exact failed tests.

## Acceptance Criteria Addressed
- `minga file.ex` opens the file in editor mode. ✅
- `minga` with no arguments still uses the agentic/config-driven startup path. ✅
- `minga .` opens the agentic view with the project/directory argument. ✅
- `--editor` remains supported and forces editor mode. ✅
- `minga --no-context file.ex` opens agentic mode without loading the file as context. ✅
- The shared CLI startup path now carries the resolved mode through Burrito/TUI/native launcher startup. ✅
