### PR TITLE
feat(macos): add draggable split divider affordances

### DIFF
--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -39,6 +39,7 @@ defmodule MingaEditor.Mouse do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Mouse, as: MouseState
+  alias MingaEditor.State.Windows
   alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.State.WhichKey, as: WhichKeyState
   alias MingaEditor.Viewport
@@ -421,9 +422,12 @@ defmodule MingaEditor.Mouse do
     handle_goto_definition_click(state, row, col)
   end
 
-  # Double-click: word selection
+  # Double-click: reset split divider or select word
   defp handle_left_press_modifiers(state, row, col, _mods, 2) do
-    handle_double_click(state, row, col)
+    case reset_split_at_separator(state, row, col) do
+      {:ok, reset_state} -> reset_state
+      :error -> handle_double_click(state, row, col)
+    end
   end
 
   # Triple-click: line selection
@@ -733,6 +737,30 @@ defmodule MingaEditor.Mouse do
     end
   end
 
+  @spec reset_split_at_separator(state(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, state()} | :error
+  defp reset_split_at_separator(%{workspace: %{windows: %{tree: nil}}}, _row, _col), do: :error
+
+  defp reset_split_at_separator(state, row, col) do
+    screen = Layout.get(state).editor_area
+
+    with {:ok, {_dir, _sep_pos}} <-
+           WindowTree.separator_at(state.workspace.windows.tree, screen, row, col),
+         {:ok, new_tree} <-
+           WindowTree.reset_split_at_coordinate(state.workspace.windows.tree, screen, row, col) do
+      windows = Windows.set_tree(state.workspace.windows, new_tree)
+
+      state =
+        EditorState.update_workspace(state, fn workspace ->
+          WorkspaceState.set_windows(workspace, windows)
+        end)
+
+      {:ok, resize_windows_to_layout(state)}
+    else
+      :error -> :error
+    end
+  end
+
   @spec handle_separator_drag(state(), WindowTree.direction(), non_neg_integer(), integer()) ::
           state()
   defp handle_separator_drag(state, dir, sep_pos, new_pos) do
@@ -740,14 +768,15 @@ defmodule MingaEditor.Mouse do
 
     case WindowTree.resize_at(state.workspace.windows.tree, screen, dir, sep_pos, new_pos) do
       {:ok, new_tree} ->
-        state = %{
-          state
-          | workspace: %{
-              state.workspace
-              | windows: %{state.workspace.windows | tree: new_tree},
-                mouse: MouseState.update_resize(state.workspace.mouse, dir, new_pos)
-            }
-        }
+        windows = Windows.set_tree(state.workspace.windows, new_tree)
+        mouse = MouseState.update_resize(state.workspace.mouse, dir, new_pos)
+
+        state =
+          EditorState.update_workspace(state, fn workspace ->
+            workspace
+            |> WorkspaceState.set_windows(windows)
+            |> WorkspaceState.set_mouse(mouse)
+          end)
 
         resize_windows_to_layout(state)
 

--- a/lib/minga_editor/state/windows.ex
+++ b/lib/minga_editor/state/windows.ex
@@ -33,6 +33,12 @@ defmodule MingaEditor.State.Windows do
   def split?(%__MODULE__{tree: {:leaf, _}}), do: false
   def split?(%__MODULE__{tree: {:split, _, _, _, _}}), do: true
 
+  @doc "Replaces the window layout tree."
+  @spec set_tree(t(), WindowTree.t() | nil) :: t()
+  def set_tree(%__MODULE__{} = windows, tree) do
+    %{windows | tree: tree}
+  end
+
   @doc """
   Updates the window struct for the given window id.
 

--- a/lib/minga_editor/window_tree.ex
+++ b/lib/minga_editor/window_tree.ex
@@ -343,8 +343,7 @@ defmodule MingaEditor.WindowTree do
 
   @doc """
   Resizes the split that owns the separator at `separator_pos` to place
-  that separator at `new_pos`. Only resizes vertical splits (by column)
-  for now.
+  that separator at `new_pos`.
 
   Returns `{:ok, new_tree}` or `:error` if no matching split is found.
   """
@@ -354,6 +353,196 @@ defmodule MingaEditor.WindowTree do
     case do_resize(tree, screen_rect, direction, separator_pos, new_pos) do
       {:ok, _} = result -> result
       :not_found -> :error
+    end
+  end
+
+  @doc """
+  Resets the split that owns `separator_pos` to equal halves.
+
+  The stored split size is set to `0`, which `clamp_size/2` resolves to an even split during layout. If multiple separators share the same row or column, this returns `:error` rather than guessing.
+  """
+  @spec reset_split_at(t(), rect(), direction(), non_neg_integer()) :: {:ok, t()} | :error
+  def reset_split_at(tree, screen_rect, direction, separator_pos) do
+    case do_reset_split(tree, screen_rect, direction, separator_pos) do
+      [new_tree] -> {:ok, new_tree}
+      _none_or_ambiguous -> :error
+    end
+  end
+
+  @doc """
+  Resets the split separator under the exact screen coordinate to equal halves.
+
+  Use this for mouse interactions because multiple separators can share the same row or column in different panes.
+  """
+  @spec reset_split_at_coordinate(t(), rect(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, t()} | :error
+  def reset_split_at_coordinate(tree, screen_rect, row, col) do
+    case do_reset_split_at_coordinate(tree, screen_rect, row, col) do
+      {:ok, _} = result -> result
+      :not_found -> :error
+    end
+  end
+
+  @spec do_reset_split(t(), rect(), direction(), non_neg_integer()) :: [t()]
+  defp do_reset_split({:leaf, _}, _rect, _dir, _sep), do: []
+
+  defp do_reset_split(
+         {:split, :vertical, left, right, size},
+         {rect_row, rect_col, width, height},
+         :vertical,
+         separator_pos
+       ) do
+    usable = width - 1
+    left_width = clamp_size(size, usable)
+    sep_col = rect_col + left_width
+    left_rect = {rect_row, rect_col, left_width, height}
+    right_rect = {rect_row, sep_col + 1, max(usable - left_width, 1), height}
+    node = {:split, :vertical, left, right, size}
+    child_matches = reset_child_matches(node, left_rect, right_rect, :vertical, separator_pos)
+
+    if sep_col == separator_pos do
+      [{:split, :vertical, left, right, 0} | child_matches]
+    else
+      child_matches
+    end
+  end
+
+  defp do_reset_split(
+         {:split, :horizontal, top, bottom, size},
+         {rect_row, rect_col, width, height},
+         :horizontal,
+         separator_pos
+       ) do
+    top_height = clamp_size(size, height)
+    bottom_height = max(height - top_height, 1)
+    modeline_row = rect_row + top_height - 1
+    top_rect = {rect_row, rect_col, width, top_height}
+    bottom_rect = {rect_row + top_height, rect_col, width, bottom_height}
+    node = {:split, :horizontal, top, bottom, size}
+    child_matches = reset_child_matches(node, top_rect, bottom_rect, :horizontal, separator_pos)
+
+    if modeline_row == separator_pos do
+      [{:split, :horizontal, top, bottom, 0} | child_matches]
+    else
+      child_matches
+    end
+  end
+
+  defp do_reset_split(
+         {:split, :vertical, left, right, size},
+         {rect_row, rect_col, width, height},
+         :horizontal,
+         separator_pos
+       ) do
+    usable = width - 1
+    left_width = clamp_size(size, usable)
+    left_rect = {rect_row, rect_col, left_width, height}
+    right_rect = {rect_row, rect_col + left_width + 1, max(usable - left_width, 1), height}
+    node = {:split, :vertical, left, right, size}
+
+    reset_child_matches(node, left_rect, right_rect, :horizontal, separator_pos)
+  end
+
+  defp do_reset_split(
+         {:split, :horizontal, top, bottom, size},
+         {rect_row, rect_col, width, height},
+         :vertical,
+         separator_pos
+       ) do
+    top_height = clamp_size(size, height)
+    bottom_height = max(height - top_height, 1)
+    top_rect = {rect_row, rect_col, width, top_height}
+    bottom_rect = {rect_row + top_height, rect_col, width, bottom_height}
+    node = {:split, :horizontal, top, bottom, size}
+
+    reset_child_matches(node, top_rect, bottom_rect, :vertical, separator_pos)
+  end
+
+  @spec reset_child_matches(t(), rect(), rect(), direction(), non_neg_integer()) :: [t()]
+  defp reset_child_matches(
+         {:split, dir, left, right, size},
+         left_rect,
+         right_rect,
+         search_dir,
+         sep_pos
+       ) do
+    left_matches =
+      Enum.map(do_reset_split(left, left_rect, search_dir, sep_pos), fn new_left ->
+        {:split, dir, new_left, right, size}
+      end)
+
+    right_matches =
+      Enum.map(do_reset_split(right, right_rect, search_dir, sep_pos), fn new_right ->
+        {:split, dir, left, new_right, size}
+      end)
+
+    left_matches ++ right_matches
+  end
+
+  @spec do_reset_split_at_coordinate(t(), rect(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, t()} | :not_found
+  defp do_reset_split_at_coordinate({:leaf, _}, _rect, _row, _col), do: :not_found
+
+  defp do_reset_split_at_coordinate(
+         {:split, :vertical, left, right, size},
+         {rect_row, rect_col, width, height},
+         row,
+         col
+       ) do
+    usable = width - 1
+    left_width = clamp_size(size, usable)
+    sep_col = rect_col + left_width
+
+    if col == sep_col and row >= rect_row and row < rect_row + height do
+      {:ok, {:split, :vertical, left, right, 0}}
+    else
+      left_rect = {rect_row, rect_col, left_width, height}
+      right_rect = {rect_row, sep_col + 1, max(usable - left_width, 1), height}
+      node = {:split, :vertical, left, right, size}
+
+      reset_child_at_coordinate(node, left_rect, right_rect, row, col)
+    end
+  end
+
+  defp do_reset_split_at_coordinate(
+         {:split, :horizontal, top, bottom, size},
+         {rect_row, rect_col, width, height},
+         row,
+         col
+       ) do
+    top_height = clamp_size(size, height)
+    bottom_height = max(height - top_height, 1)
+    modeline_row = rect_row + top_height - 1
+
+    if row == modeline_row and col >= rect_col and col < rect_col + width do
+      {:ok, {:split, :horizontal, top, bottom, 0}}
+    else
+      top_rect = {rect_row, rect_col, width, top_height}
+      bottom_rect = {rect_row + top_height, rect_col, width, bottom_height}
+      node = {:split, :horizontal, top, bottom, size}
+
+      reset_child_at_coordinate(node, top_rect, bottom_rect, row, col)
+    end
+  end
+
+  @spec reset_child_at_coordinate(t(), rect(), rect(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, t()} | :not_found
+  defp reset_child_at_coordinate(
+         {:split, dir, left, right, size},
+         left_rect,
+         right_rect,
+         row,
+         col
+       ) do
+    case do_reset_split_at_coordinate(left, left_rect, row, col) do
+      {:ok, new_left} ->
+        {:ok, {:split, dir, new_left, right, size}}
+
+      :not_found ->
+        case do_reset_split_at_coordinate(right, right_rect, row, col) do
+          {:ok, new_right} -> {:ok, {:split, dir, left, new_right, size}}
+          :not_found -> :not_found
+        end
     end
   end
 

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -11,6 +11,12 @@ import AppKit
 import os
 import MetalKit
 
+private enum DividerCursorState: Equatable {
+    case none
+    case vertical
+    case horizontal
+}
+
 /// The main editor view. Uses MTKView's built-in display link for
 /// vsync-driven rendering with automatic frame coalescing.
 final class EditorNSView: MTKView {
@@ -45,6 +51,12 @@ final class EditorNSView: MTKView {
     /// redundant mouse move events.
     private var lastMoveRow: Int16 = -1
     private var lastMoveCol: Int16 = -1
+
+    /// Current resize cursor pushed for split divider hover or drag.
+    private var dividerCursorState: DividerCursorState = .none
+
+    /// Divider direction captured at mouse-down so drag keeps the resize cursor.
+    private var dividerDragState: DividerCursorState = .none
 
     /// Whether the ready event has been sent to the BEAM. Deferred until
     /// setFrameSize so we send the actual window dimensions, not hardcoded defaults.
@@ -163,6 +175,8 @@ final class EditorNSView: MTKView {
         scrollFadeWorkItem = nil
         spaceGraceTimer?.cancel()
         spaceGraceTimer = nil
+        dividerDragState = .none
+        setDividerCursorState(.none)
         removeWindowObservers()
         removeAgentKeyMonitor()
         firstResponderGuard = nil
@@ -507,7 +521,7 @@ final class EditorNSView: MTKView {
         }
         let area = NSTrackingArea(
             rect: bounds,
-            options: [.mouseMoved, .activeInKeyWindow, .inVisibleRect],
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
             owner: self,
             userInfo: nil
         )
@@ -860,6 +874,10 @@ final class EditorNSView: MTKView {
         }
 
         resetCursorBlink()
+        dividerDragState = dividerHitState(at: point)
+        if dividerDragState != .none {
+            setDividerCursorState(dividerDragState)
+        }
         let (row, col) = cellPosition(from: event)
         let cc = UInt8(clamping: event.clickCount)
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_LEFT,
@@ -874,10 +892,15 @@ final class EditorNSView: MTKView {
             return
         }
 
+        let point = convert(event.locationInWindow, from: nil)
         let (row, col) = cellPosition(from: event)
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_LEFT,
                                modifiers: modifierBits(from: event.modifierFlags),
                                eventType: MOUSE_RELEASE)
+        if dividerDragState != .none {
+            dividerDragState = .none
+            setDividerCursorState(dividerHitState(at: point))
+        }
     }
 
     override func rightMouseDown(with event: NSEvent) {
@@ -916,6 +939,9 @@ final class EditorNSView: MTKView {
             return
         }
 
+        if dividerDragState != .none {
+            setDividerCursorState(dividerDragState)
+        }
         let (row, col) = cellPosition(from: event)
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_LEFT,
                                modifiers: modifierBits(from: event.modifierFlags),
@@ -923,6 +949,8 @@ final class EditorNSView: MTKView {
     }
 
     override func mouseMoved(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        setDividerCursorState(dividerHitState(at: point))
         let (row, col) = cellPosition(from: event)
         guard row != lastMoveRow || col != lastMoveCol else { return }
         lastMoveRow = row
@@ -930,6 +958,13 @@ final class EditorNSView: MTKView {
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_NONE,
                                modifiers: modifierBits(from: event.modifierFlags),
                                eventType: MOUSE_MOTION)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        if dividerDragState == .none {
+            setDividerCursorState(.none)
+        }
+        super.mouseExited(with: event)
     }
 
     /// Scroll accumulator for smooth trackpad scrolling. Extracted into a
@@ -1027,7 +1062,7 @@ final class EditorNSView: MTKView {
 
         // Vertical: smooth sub-line pixel offset
         let vEvents = scrollAccumulator.accumulateVertical(
-            deltaY: event.scrollingDeltaY, cellHeight: cellHeight)
+            deltaY: event.scrollingDeltaY, cellHeight: effectiveCellHeight)
         for e in vEvents {
             sendScrollEvent(e, row: row, col: col, mods: mods)
         }
@@ -1111,10 +1146,63 @@ final class EditorNSView: MTKView {
 
     // MARK: - Helpers
 
+    private var effectiveCellHeight: CGFloat {
+        cellHeight * CGFloat(dispatcher.frameState.lineSpacing)
+    }
+
+    private var dividerHitHalfTolerance: CGFloat {
+        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1.0
+        return 2.5 / scale
+    }
+
+    private func dividerHitState(at point: NSPoint) -> DividerCursorState {
+        let fs = dispatcher.frameState
+        let hitHalfTolerance = dividerHitHalfTolerance
+        let displayCellH = effectiveCellHeight
+
+        for vertical in fs.verticalSeparators {
+            let x = CGFloat(vertical.col) * cellWidth
+            let startY = CGFloat(vertical.startRow) * displayCellH
+            let endY = CGFloat(Int(vertical.endRow) + 1) * displayCellH
+            if abs(point.x - x) <= hitHalfTolerance && point.y >= startY && point.y < endY {
+                return .vertical
+            }
+        }
+
+        for horizontal in fs.horizontalSeparators {
+            let x = CGFloat(horizontal.col) * cellWidth
+            let y = CGFloat(horizontal.row) * displayCellH + (displayCellH * 0.5) - (0.5 / (window?.backingScaleFactor ?? 1.0))
+            let width = CGFloat(horizontal.width) * cellWidth
+            if abs(point.y - y) <= hitHalfTolerance && point.x >= x && point.x < x + width {
+                return .horizontal
+            }
+        }
+
+        return .none
+    }
+
+    private func setDividerCursorState(_ nextState: DividerCursorState) {
+        guard dividerCursorState != nextState else { return }
+        if dividerCursorState != .none {
+            NSCursor.pop()
+        }
+
+        switch nextState {
+        case .none:
+            break
+        case .vertical:
+            NSCursor.resizeLeftRight.push()
+        case .horizontal:
+            NSCursor.resizeUpDown.push()
+        }
+
+        dividerCursorState = nextState
+    }
+
     private func cellPosition(from event: NSEvent) -> (row: Int16, col: Int16) {
         let point = convert(event.locationInWindow, from: nil)
         let col = Int16(point.x / cellWidth)
-        let row = Int16(point.y / cellHeight)
+        let row = Int16(point.y / effectiveCellHeight)
         return (row, col)
     }
 }

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -5,6 +5,9 @@ defmodule MingaEditor.MouseTest do
   alias MingaEditor
   alias MingaEditor.Commands.Movement
   alias MingaEditor.Layout
+  alias MingaEditor.State.Windows
+  alias MingaEditor.WindowTree
+  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   # Content starts at row 1 because the tab bar occupies row 0.
   @content_row 1
@@ -311,6 +314,50 @@ defmodule MingaEditor.MouseTest do
       {line, col} = BufferServer.cursor(buffer)
       assert line == 1
       assert col == 2
+    end
+  end
+
+  describe "split separator double-click" do
+    test "double-clicking a separator resets split size without entering visual mode" do
+      {editor, _buffer} = start_editor("hello world")
+
+      :sys.replace_state(editor, fn state -> Movement.execute(state, :split_vertical) end)
+      state = state(editor)
+      screen = Layout.get(state).editor_area
+      {screen_row, screen_col, screen_width, screen_height} = screen
+      row = screen_row + div(screen_height, 2)
+      initial_sep_col = screen_col + div(screen_width - 1, 2)
+
+      {:ok, {:vertical, sep_pos}} =
+        WindowTree.separator_at(state.workspace.windows.tree, screen, row, initial_sep_col)
+
+      {:ok, resized_tree} =
+        WindowTree.resize_at(
+          state.workspace.windows.tree,
+          screen,
+          :vertical,
+          sep_pos,
+          sep_pos - 5
+        )
+
+      :sys.replace_state(editor, fn state ->
+        windows = Windows.set_tree(state.workspace.windows, resized_tree)
+
+        MingaEditor.State.update_workspace(state, fn workspace ->
+          WorkspaceState.set_windows(workspace, windows)
+        end)
+      end)
+
+      state = state(editor)
+      screen = Layout.get(state).editor_area
+
+      {:ok, {:vertical, resized_sep_pos}} =
+        WindowTree.separator_at(state.workspace.windows.tree, screen, row, sep_pos - 5)
+
+      send_mouse(editor, row, resized_sep_pos, :left, :press, 0, 2)
+
+      assert {:split, :vertical, _left, _right, 0} = state(editor).workspace.windows.tree
+      assert state(editor).workspace.editing.mode == :normal
     end
   end
 

--- a/test/minga_editor/window_tree_test.exs
+++ b/test/minga_editor/window_tree_test.exs
@@ -338,6 +338,85 @@ defmodule MingaEditor.WindowTreeTest do
     end
   end
 
+  # ── reset_split_at/4 ─────────────────────────────────────────────────────────
+
+  describe "reset_split_at/4" do
+    @screen {0, 0, 80, 24}
+
+    test "vertical reset stores equal split size" do
+      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
+      {:ok, resized} = WindowTree.resize_at(tree, @screen, :vertical, 39, 30)
+
+      assert {:ok, {:split, :vertical, {:leaf, 1}, {:leaf, 2}, 0} = reset} =
+               WindowTree.reset_split_at(resized, @screen, :vertical, 30)
+
+      [{1, {_, _, left_w, _}}, {2, {_, _, right_w, _}}] = WindowTree.layout(reset, @screen)
+      assert left_w == 39
+      assert right_w == 40
+    end
+
+    test "horizontal reset stores equal split size" do
+      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
+      {:ok, resized} = WindowTree.resize_at(tree, @screen, :horizontal, 11, 16)
+
+      assert {:ok, {:split, :horizontal, {:leaf, 1}, {:leaf, 2}, 0} = reset} =
+               WindowTree.reset_split_at(resized, @screen, :horizontal, 16)
+
+      [{1, {_, _, _, top_h}}, {2, {bottom_row, _, _, bottom_h}}] =
+        WindowTree.layout(reset, @screen)
+
+      assert top_h == 12
+      assert bottom_row == 12
+      assert bottom_h == 12
+    end
+
+    test "nested reset only resets matching separator" do
+      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
+      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
+      {:ok, resized} = WindowTree.resize_at(tree, @screen, :horizontal, 11, 16)
+
+      assert {:ok,
+              {:split, :vertical, {:leaf, 1}, {:split, :horizontal, {:leaf, 2}, {:leaf, 3}, 0}, 0}} =
+               WindowTree.reset_split_at(resized, @screen, :horizontal, 16)
+    end
+
+    test "returns error for missing separator" do
+      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
+      assert :error = WindowTree.reset_split_at(tree, @screen, :vertical, 99)
+    end
+
+    test "returns error instead of guessing when separator position is ambiguous" do
+      tree = {
+        :split,
+        :horizontal,
+        {:split, :vertical, {:leaf, 1}, {:leaf, 2}, 39},
+        {:split, :vertical, {:leaf, 3}, {:leaf, 4}, 39},
+        0
+      }
+
+      assert :error = WindowTree.reset_split_at(tree, @screen, :vertical, 39)
+    end
+  end
+
+  describe "reset_split_at_coordinate/4" do
+    @screen {0, 0, 80, 24}
+
+    test "resets the exact separator under the clicked coordinate" do
+      tree = {
+        :split,
+        :horizontal,
+        {:split, :vertical, {:leaf, 1}, {:leaf, 2}, 39},
+        {:split, :vertical, {:leaf, 3}, {:leaf, 4}, 39},
+        0
+      }
+
+      assert {:ok,
+              {:split, :horizontal, {:split, :vertical, {:leaf, 1}, {:leaf, 2}, 39},
+               {:split, :vertical, {:leaf, 3}, {:leaf, 4}, 0}, 0}} =
+               WindowTree.reset_split_at_coordinate(tree, @screen, 18, 39)
+    end
+  end
+
   # ── window_at/4 ──────────────────────────────────────────────────────────────
 
   describe "window_at/4" do


### PR DESCRIPTION
# TL;DR
Split dividers now behave like native GUI resize handles: hover shows the right resize cursor, drag keeps the cursor active, and double-click resets the split to an even size.

Closes #717

## Context
Issue #717 covers the missing GUI affordances around split resizing. The BEAM already handled separator drag events and layout updates, but the macOS frontend did not show cursor feedback or provide a forgiving divider hit area, and double-click reset was not wired through the editor mouse handler.

## Changes
- Added macOS divider hit-testing in `EditorNSView` using the rendered split separator metadata, with a scale-aware 5px hit region and resize cursors for vertical and horizontal dividers.
- Kept the resize cursor active while dragging a divider, while still forwarding normal mouse press, drag, release, and motion events to the BEAM.
- Aligned outgoing mouse row coordinates with the line-spacing-adjusted render grid so hover, drag, and BEAM hit-testing agree.
- Added `WindowTree.reset_split_at/4` and coordinate-targeted `reset_split_at_coordinate/4` so double-click reset can handle nested separators that share the same row or column.
- Routed double-clicks on separators to split reset before normal word-selection handling.
- Added tests for split reset, ambiguous separator targeting, exact coordinate reset, and double-click reset through the mouse handler.

## Verification
- `mix test.llm test/minga_editor/window_tree_test.exs test/minga_editor/mouse_test.exs`: PASS, 99 tests
- `mix swift.build`: PASS
- `mix swift.harness`: PASS
- `make lint`: PASS
- `mix test.debug test/minga_editor/integration/mouse_test.exs:363`: PASS, 1 test
- `mix test.llm test/minga_editor/integration/mouse_test.exs`: PASS, 22 tests
- `mix test.llm`: PASS, 54 doctests, 97 properties, 8412 tests, 0 failures, 5 skipped, 115 excluded
- `git diff --check`: PASS

Manual GUI verification is still recommended for cursor feel and flicker, since those are visual interaction details that automated tests cannot fully prove.

## Acceptance Criteria Addressed
- Cursor changes to `resizeLeftRight` or `resizeUpDown` on GUI split divider hover, with a scale-aware ~5px hit region and cursor reset off the divider ✅
- Dragging a divider continues to send the existing BEAM mouse drag flow and keeps the resize cursor active ✅
- Minimum pane size remains enforced by `WindowTree.clamp_size/2` during drag ✅
- Double-clicking a divider resets the split to equal size ✅
- Split ratios persist by storing the updated tree on workspace windows ✅
