### PR TITLE
fix(macos): restore tab bar visibility and align toolbar with traffic lights

### DIFF
--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -35,7 +35,7 @@ struct MingaApp: App {
                 .focusable(false)
                 .focusEffectDisabled()
         }
-        .windowStyle(.titleBar)
+        .windowStyle(.hiddenTitleBar)
         .commands {
             MingaMenuCommands(appState: appDelegate.appState)
         }
@@ -266,7 +266,7 @@ struct ContentView: View {
     private var theme: ThemeColors { appState.gui.themeColors }
 
     private var titleBarLeadingPadding: CGFloat {
-        appState.isFullScreen ? 10 : 78
+        appState.isFullScreen ? 10 : 84
     }
 
     private var projectName: String {
@@ -304,42 +304,52 @@ struct ContentView: View {
 
     /// Single toolbar row spanning the full window width. Contains the
     /// sidebar header (when visible) and the tab bar, sharing one background.
+    private let contentHeight: CGFloat = 28
+
+    private var toolbarTopPadding: CGFloat {
+        max(appState.trafficLightMidY - contentHeight / 2, 0)
+    }
+
     @ViewBuilder
     private var unifiedToolbar: some View {
-        HStack(spacing: 0) {
-            if showSidebar {
-                sidebarHeaderContent
-                    .frame(width: sidebarWidth + 8) // +8 aligns with resize handle
+        ZStack(alignment: .bottom) {
+            HStack(spacing: 0) {
+                if showSidebar {
+                    sidebarHeaderContent
+                        .frame(width: sidebarWidth + 8) // +8 aligns with resize handle
 
-                // Thin vertical separator between sidebar header and tab bar
-                Rectangle()
-                    .fill(theme.tabSeparatorFg.opacity(0.4))
-                    .frame(width: 1, height: 16)
-            } else {
-                compactProjectBranchHeader
-            }
+                    // Thin vertical separator between sidebar header and tab bar
+                    Rectangle()
+                        .fill(theme.tabSeparatorFg.opacity(0.4))
+                        .frame(width: 1, height: 16)
+                } else {
+                    compactProjectBranchHeader
+                }
 
-            if !appState.gui.tabBarState.tabs.isEmpty {
-                TabBarView(
-                    tabBarState: appState.gui.tabBarState,
-                    theme: theme,
-                    encoder: appState.encoder
-                )
-            } else {
-                Spacer()
+                if !appState.gui.tabBarState.tabs.isEmpty {
+                    TabBarView(
+                        tabBarState: appState.gui.tabBarState,
+                        theme: theme,
+                        encoder: appState.encoder
+                    )
+                } else {
+                    Spacer()
+                }
             }
+            .frame(height: contentHeight)
+            .padding(.top, toolbarTopPadding)
+            .frame(maxHeight: .infinity, alignment: .top)
+
+            Rectangle()
+                .fill(theme.tabSeparatorFg.opacity(0.3))
+                .frame(height: 1)
         }
-        .frame(height: 38)
+        .frame(height: contentHeight + toolbarTopPadding + 4)
         .background {
             ZStack {
                 theme.tabBg
                 TitleBarDragRegion()
             }
-        }
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(theme.tabSeparatorFg.opacity(0.3))
-                .frame(height: 1)
         }
     }
 
@@ -391,7 +401,6 @@ struct ContentView: View {
         }
         .padding(.leading, titleBarLeadingPadding)
         .padding(.trailing, 12)
-        .frame(height: 38)
     }
 
     // MARK: - Sidebar Body
@@ -721,6 +730,8 @@ final class AppState {
     var windowBgIsDark: Bool = true
     /// Whether the window is currently in macOS full-screen mode.
     var isFullScreen: Bool = false
+    /// Vertical center of the traffic light buttons, measured from the window top.
+    var trafficLightMidY: CGFloat = 14
     /// Flipped once when the first complete frame (batch_end) arrives from
     /// the BEAM. The startup overlay fades out when this becomes true.
     var hasReceivedFirstFrame: Bool = false
@@ -865,6 +876,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 appState?.isFullScreen = isFullScreen
             }
         }
+        nsView.onTrafficLightMeasured = { [weak appState] midY in
+            Task { @MainActor in
+                appState?.trafficLightMidY = midY
+            }
+        }
         nsView.recoveryManager = recovery
         nsView.onScaleFactorChanged = { [weak self] newScale in
             self?.handleScaleChange(newScale: newScale)
@@ -907,8 +923,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 let b = color.blueComponent
                 let isDark = (r * 0.299 + g * 0.587 + b * 0.114) < 0.5
                 appState.windowBgIsDark = isDark
+                let bgColor = NSColor(red: r, green: g, blue: b, alpha: 1)
                 for window in NSApp.windows {
                     window.appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)
+                    window.backgroundColor = bgColor
                 }
             }
         }

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -41,6 +41,9 @@ final class EditorNSView: MTKView {
     /// Called when the view moves to a display with a different backing scale factor.
     var onScaleFactorChanged: ((CGFloat) -> Void)?
 
+    /// Notifies SwiftUI of the traffic light vertical center for toolbar alignment.
+    var onTrafficLightMeasured: ((CGFloat) -> Void)?
+
     /// Tracks BEAM responsiveness and handles Ctrl-G recovery.
     var recoveryManager: RecoveryManager?
 
@@ -370,6 +373,7 @@ final class EditorNSView: MTKView {
         window.titleVisibility = .hidden
         window.styleMask.insert(.fullSizeContentView)
 
+        measureTrafficLightPosition(in: window)
         installWindowObserversIfNeeded(for: window)
 
         registerForDraggedTypes([.fileURL])
@@ -430,6 +434,15 @@ final class EditorNSView: MTKView {
         }
 
         PortLogger.info("\(reason): \(cols)x\(rows) cells")
+    }
+
+    private func measureTrafficLightPosition(in window: NSWindow) {
+        guard let closeButton = window.standardWindowButton(.closeButton),
+              let titleBarView = closeButton.superview else { return }
+        let buttonInTitleBar = closeButton.frame
+        let titleBarHeight = titleBarView.frame.height
+        let topDownMidY = titleBarHeight - buttonInTitleBar.midY
+        onTrafficLightMeasured?(topDownMidY)
     }
 
     /// Registers for key-window notifications exactly once per window.

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -531,6 +531,7 @@ final class EditorNSView: MTKView {
 
     @objc private func windowDidExitFullScreen(_ notification: Notification) {
         onFullScreenChanged?(false)
+        if let window { measureTrafficLightPosition(in: window) }
     }
 
     @objc private func windowDidResignKey(_ notification: Notification) {

--- a/macos/Sources/Views/FileTreeHeaderContent.swift
+++ b/macos/Sources/Views/FileTreeHeaderContent.swift
@@ -13,6 +13,8 @@ struct FileTreeHeaderContent: View {
     let branchName: String
     let leadingPadding: CGFloat
 
+    @State private var isHovered = false
+
     var body: some View {
         HStack(spacing: 6) {
             Text("\u{F024B}")
@@ -37,25 +39,34 @@ struct FileTreeHeaderContent: View {
                     .truncationMode(.middle)
             }
 
-            Spacer()
+            Spacer(minLength: 4)
 
-            HStack(spacing: 2) {
-                headerButton(systemName: "doc.badge.plus", tooltip: "New File…") {
-                    encoder?.sendFileTreeNewFile(parentIndex: UInt16(fileTreeState.selectedIndex))
+            if isHovered {
+                HStack(spacing: 2) {
+                    headerButton(systemName: "doc.badge.plus", tooltip: "New File…") {
+                        encoder?.sendFileTreeNewFile(parentIndex: UInt16(fileTreeState.selectedIndex))
+                    }
+                    headerButton(systemName: "folder.badge.plus", tooltip: "New Folder…") {
+                        encoder?.sendFileTreeNewFolder(parentIndex: UInt16(fileTreeState.selectedIndex))
+                    }
+                    headerButton(systemName: "arrow.clockwise", tooltip: "Refresh") {
+                        encoder?.sendFileTreeRefresh()
+                    }
+                    headerButton(systemName: "arrow.down.right.and.arrow.up.left", tooltip: "Collapse All") {
+                        encoder?.sendFileTreeCollapseAll()
+                    }
                 }
-                headerButton(systemName: "folder.badge.plus", tooltip: "New Folder…") {
-                    encoder?.sendFileTreeNewFolder(parentIndex: UInt16(fileTreeState.selectedIndex))
-                }
-                headerButton(systemName: "arrow.clockwise", tooltip: "Refresh") {
-                    encoder?.sendFileTreeRefresh()
-                }
-                headerButton(systemName: "arrow.down.right.and.arrow.up.left", tooltip: "Collapse All") {
-                    encoder?.sendFileTreeCollapseAll()
-                }
+                .transition(.opacity)
             }
         }
         .padding(.leading, leadingPadding)
         .padding(.trailing, 10)
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isHovered = hovering
+            }
+        }
     }
 
     @ViewBuilder

--- a/macos/Sources/Views/GitStatusHeaderContent.swift
+++ b/macos/Sources/Views/GitStatusHeaderContent.swift
@@ -22,6 +22,7 @@ struct GitStatusHeaderContent: View {
                 .foregroundStyle(theme.tabActiveFg)
                 .lineLimit(1)
                 .truncationMode(.tail)
+                .layoutPriority(1)
 
             // Git branch icon (Nerd Font)
             Text("\u{E725}")

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -153,15 +153,15 @@ struct FileTreeViewTests {
         #expect(strings.contains("Project"))
     }
 
-    @Test("Header has four action buttons (new file, new folder, refresh, collapse all)")
-    @MainActor func headerHasFourActionButtons() throws {
+    @Test("Header action buttons are hidden at rest (shown on hover)")
+    @MainActor func headerActionButtonsHiddenAtRest() throws {
         let state = FileTreeState()
         state.visible = true
 
         let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "", leadingPadding: 10)
         let body = try sut.inspect()
         let buttons = body.findAll(ViewType.Button.self)
-        #expect(buttons.count >= 4)
+        #expect(buttons.count == 0)
     }
 
     @Test("File entries render their names")


### PR DESCRIPTION
## Summary
- The title bar integration (#1621) hid the tab bar behind the native macOS title bar and broke theme color matching. This switches to `.hiddenTitleBar` window style so the custom unified toolbar (sidebar header + tab bar) is the visible title bar, matching Zed/VS Code behavior.
- Measures the actual traffic light button position at runtime via `NSWindow.standardWindowButton` for pixel-perfect vertical alignment of toolbar content.
- Sets `window.backgroundColor` from the BEAM theme color so native chrome (traffic light area) matches the editor theme.
- Sidebar header action buttons (new file, new folder, refresh, collapse) now show on hover only, preventing project name truncation in narrow sidebars.

## Test plan
- [x] Build succeeds, all 515 Swift tests pass
- [ ] Verify tab bar is visible with sidebar open and closed
- [ ] Verify toolbar content is vertically aligned with traffic lights
- [ ] Verify title bar background matches editor theme color
- [ ] Verify sidebar header shows project name and branch; action buttons appear on hover
- [ ] Verify full-screen mode works correctly (no extra padding)
- [ ] Verify window drag works from the toolbar area

🤖 Generated with [Claude Code](https://claude.com/claude-code)