### PR TITLE
fix(editor,macos): fix horizontal scroll sticking and GUI mouse click offset

### DIFF
--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -430,11 +430,13 @@ defmodule MingaEditor.RenderPipeline.Scroll do
     if cursor_col >= vp.left and cursor_col < vp.left + content_w do
       vp
     else
-      # Temporarily set cols to content_w (excluding gutter) so adjust_left
-      # triggers scroll at the content edge, not the full viewport edge.
-      content_vp = %{vp | cols: content_w}
-      adjusted = Viewport.scroll_to_cursor(content_vp, {cursor_line, cursor_col}, scroll_margin)
-      %{vp | left: adjusted.left}
+      if cursor_col < content_w do
+        %{vp | left: 0}
+      else
+        content_vp = %{vp | cols: content_w}
+        adjusted = Viewport.scroll_to_cursor(content_vp, {cursor_line, cursor_col}, scroll_margin)
+        %{vp | left: adjusted.left}
+      end
     end
   end
 

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -430,6 +430,7 @@ defmodule MingaEditor.RenderPipeline.Scroll do
     if cursor_col >= vp.left and cursor_col < vp.left + content_w do
       vp
     else
+      # Cursor fits within the first viewport-width of content; reset scroll rather than re-computing
       if cursor_col < content_w do
         %{vp | left: 0}
       else

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -320,9 +320,9 @@ final class CoreTextMetalRenderer {
 
         // Gutter spacing: left margin for breathing room, right padding before separator.
         // The sign column is always reserved (2 cell widths) for consistent layout.
-        let gutterLeftMarginPt: Float = frameState.gutterCol > 0 ? round(6.0 * scale) / scale : 0
+        let gutterLeftMarginPt: Float = frameState.gutterCol > 0 ? round(Float(Self.gutterLeftMarginPt) * scale) / scale : 0
         let gutterLeftMarginPx = gutterLeftMarginPt * scale
-        let gutterPaddingPt: Float = frameState.gutterCol > 0 ? round(8.0 * scale) / scale : 0
+        let gutterPaddingPt: Float = frameState.gutterCol > 0 ? round(Float(Self.gutterRightGapPt) * scale) / scale : 0
         let gutterPaddingPx = gutterPaddingPt * scale
 
         let renderCursor = CoreTextMetalRenderer.resolveCursor(

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -63,10 +63,14 @@ private let ctBgClearColorDefault = MTLClearColor(red: 0.01298, green: 0.01298, 
 /// in the render path, and all callers are on the main thread already.
 @MainActor
 final class CoreTextMetalRenderer {
+    /// Left margin before the gutter (breathing room from the window edge).
+    static let gutterLeftMarginPt: CGFloat = 6.0
+    /// Right gap between gutter and content (separator breathing room).
+    static let gutterRightGapPt: CGFloat = 8.0
     /// Total gutter pixel padding in points (left margin + right separator gap).
     /// Subtracted from the view width when computing cols for the BEAM so
     /// `content_w` accurately reflects the visible content area.
-    static let gutterPixelPaddingPt: CGFloat = 14.0  // 6pt left margin + 8pt right gap
+    static let gutterPixelPaddingPt: CGFloat = gutterLeftMarginPt + gutterRightGapPt
 
     let device: MTLDevice
     let commandQueue: MTLCommandQueue

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -1470,8 +1470,16 @@ extension EditorNSView: @preconcurrency NSTextInputClient {
         // Position at the cursor location.
         let col = CGFloat(dispatcher.frameState.cursorCol)
         let row = CGFloat(dispatcher.frameState.cursorRow)
-        let gutterPad: CGFloat = (dispatcher.frameState.gutterCol > 0 && dispatcher.frameState.cursorCol >= dispatcher.frameState.gutterCol)
-            ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
+        let gutterPad: CGFloat
+        if dispatcher.frameState.gutterCol > 0 {
+            if dispatcher.frameState.cursorCol >= dispatcher.frameState.gutterCol {
+                gutterPad = CoreTextMetalRenderer.gutterLeftMarginPt + CoreTextMetalRenderer.gutterRightGapPt
+            } else {
+                gutterPad = CoreTextMetalRenderer.gutterLeftMarginPt
+            }
+        } else {
+            gutterPad = 0
+        }
         let localRect = NSRect(x: col * cellWidth + gutterPad, y: row * cellHeight,
                                 width: cellWidth, height: cellHeight)
 
@@ -1486,9 +1494,20 @@ extension EditorNSView: @preconcurrency NSTextInputClient {
         guard let window else { return 0 }
         let windowPoint = window.convertPoint(fromScreen: point)
         let localPoint = convert(windowPoint, from: nil)
-        let gutterPad: CGFloat = dispatcher.frameState.gutterCol > 0
-            ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
-        let col = max(0, Int((localPoint.x - gutterPad) / cellWidth))
+        let gutterCols = CGFloat(dispatcher.frameState.gutterCol)
+        let col: Int
+        if gutterCols > 0 {
+            let leftMargin = CoreTextMetalRenderer.gutterLeftMarginPt
+            let rightGap = CoreTextMetalRenderer.gutterRightGapPt
+            let gutterPixelEnd = leftMargin + gutterCols * cellWidth
+            if localPoint.x < gutterPixelEnd {
+                col = max(0, Int((localPoint.x - leftMargin) / cellWidth))
+            } else {
+                col = max(0, Int((localPoint.x - leftMargin - rightGap) / cellWidth))
+            }
+        } else {
+            col = max(0, Int(localPoint.x / cellWidth))
+        }
         let row = Int(localPoint.y / cellHeight)
         return row * Int(dispatcher.frameState.cols) + col
     }

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -1368,8 +1368,20 @@ final class EditorNSView: MTKView {
 
     private func cellPosition(from event: NSEvent) -> (row: Int16, col: Int16) {
         let point = convert(event.locationInWindow, from: nil)
-        let col = Int16(point.x / cellWidth)
         let row = Int16(point.y / effectiveCellHeight)
+        let gutterCols = CGFloat(dispatcher.frameState.gutterCol)
+        guard gutterCols > 0 else {
+            return (row, max(0, Int16(point.x / cellWidth)))
+        }
+        let leftMargin = CoreTextMetalRenderer.gutterLeftMarginPt
+        let rightGap = CoreTextMetalRenderer.gutterRightGapPt
+        let gutterPixelEnd = leftMargin + gutterCols * cellWidth
+        let col: Int16
+        if point.x < gutterPixelEnd {
+            col = max(0, Int16((point.x - leftMargin) / cellWidth))
+        } else {
+            col = max(0, Int16((point.x - leftMargin - rightGap) / cellWidth))
+        }
         return (row, col)
     }
 }
@@ -1458,7 +1470,9 @@ extension EditorNSView: @preconcurrency NSTextInputClient {
         // Position at the cursor location.
         let col = CGFloat(dispatcher.frameState.cursorCol)
         let row = CGFloat(dispatcher.frameState.cursorRow)
-        let localRect = NSRect(x: col * cellWidth, y: row * cellHeight,
+        let gutterPad: CGFloat = (dispatcher.frameState.gutterCol > 0 && dispatcher.frameState.cursorCol >= dispatcher.frameState.gutterCol)
+            ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
+        let localRect = NSRect(x: col * cellWidth + gutterPad, y: row * cellHeight,
                                 width: cellWidth, height: cellHeight)
 
         // Convert to screen coordinates.
@@ -1472,7 +1486,9 @@ extension EditorNSView: @preconcurrency NSTextInputClient {
         guard let window else { return 0 }
         let windowPoint = window.convertPoint(fromScreen: point)
         let localPoint = convert(windowPoint, from: nil)
-        let col = Int(localPoint.x / cellWidth)
+        let gutterPad: CGFloat = dispatcher.frameState.gutterCol > 0
+            ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
+        let col = max(0, Int((localPoint.x - gutterPad) / cellWidth))
         let row = Int(localPoint.y / cellHeight)
         return row * Int(dispatcher.frameState.cols) + col
     }

--- a/test/minga_editor/render_pipeline/scroll_test.exs
+++ b/test/minga_editor/render_pipeline/scroll_test.exs
@@ -79,5 +79,22 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
       # First frame: sentinel values trigger full invalidation
       assert window.render_cache.dirty_lines == :all
     end
+
+    test "resets horizontal scroll when cursor fits on screen" do
+      state = base_state(content: "short line\nanother short line")
+
+      # Inject a stale left offset into the window's viewport
+      win_id = state.workspace.windows.active
+      window = Map.get(state.workspace.windows.map, win_id)
+      scrolled_vp = %{window.viewport | left: 40}
+      updated_window = %{window | viewport: scrolled_vp}
+      new_map = Map.put(state.workspace.windows.map, win_id, updated_window)
+      state = put_in(state.workspace.windows.map, new_map)
+
+      {scrolls, _state, _layout} = run_through_scroll(state)
+      [{_win_id, scroll}] = Map.to_list(scrolls)
+
+      assert scroll.viewport.left == 0
+    end
   end
 end


### PR DESCRIPTION
## Summary

- **Horizontal scroll sticking**: `scroll_horizontal` preserved stale `viewport.left` when the cursor moved to a shorter line that fits on screen. Now resets `left` to 0 when `cursor_col < content_w` in the not-visible branch, so the view snaps back instead of staying scrolled right.
- **GUI mouse click offset**: The Metal renderer adds 14pt of gutter pixel padding (6pt left margin + 8pt right gap between gutter and content). `cellPosition` divided raw pixel x by `cellWidth` without subtracting this padding, causing all clicks to land 1-2 columns to the right of the intended character. Now uses piecewise subtraction: 6pt for gutter-area clicks, 14pt for content-area clicks. Also fixes `characterIndex(for:)` and `firstRect(forCharacterRange:)` (IME popup positioning) for the same offset.

## Test plan

- [x] Existing mouse tests pass (37 tests)
- [x] Existing scroll tests pass (7 tests, including new test)
- [x] Full test suite passes (8633 tests, 0 failures)
- [x] Lint passes
- [ ] Manual: open a file, scroll right with a long line, move cursor to a short line — viewport should snap back to left=0
- [ ] Manual (GUI): click on a character in the editor — cursor should land exactly on the clicked character, not 1-2 columns to the right
- [ ] Manual (GUI): fold gutter click should still toggle folds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)