### PR TITLE
fix(render): invalidate stale render caches

### DIFF
--- a/lib/minga_editor/render_pipeline/content.ex
+++ b/lib/minga_editor/render_pipeline/content.ex
@@ -111,7 +111,9 @@ defmodule MingaEditor.RenderPipeline.Content do
         has_sign_column: has_sign_column,
         file_path: snapshot.file_path,
         is_active: is_active,
-        is_gui: MingaEditor.Frontend.gui?(state.capabilities)
+        is_gui: MingaEditor.Frontend.gui?(state.capabilities),
+        wrap_on: wrap_on,
+        line_number_style: line_number_style
       })
 
     # Compute context fingerprint and check for context changes.
@@ -408,7 +410,9 @@ defmodule MingaEditor.RenderPipeline.Content do
         content_w: content_w,
         has_sign_column: true,
         is_active: is_active,
-        is_gui: MingaEditor.Frontend.gui?(state.capabilities)
+        is_gui: MingaEditor.Frontend.gui?(state.capabilities),
+        wrap_on: true,
+        line_number_style: line_number_style
       })
 
     # Compute the display map (block decorations, fold regions, virtual lines).

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -160,7 +160,11 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       git_colors: state.theme.git,
       show_invisible: show_invisible,
       tab_width: tab_width,
-      whitespace_face: whitespace_face
+      whitespace_face: whitespace_face,
+      search_colors: state.theme.search,
+      document_highlight_colors: document_highlight_colors(state.theme),
+      wrap_on: Map.get(params, :wrap_on, false),
+      line_number_style: Map.get(params, :line_number_style, :absolute)
     }
 
     {ctx, state}
@@ -907,7 +911,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
           search_cache()
         ) :: {Decorations.t(), search_cache()}
   def merge_search_decorations(decs, matches, confirm_match, colors, cached) do
-    fingerprint = {matches, confirm_match}
+    fingerprint = {matches, confirm_match, colors}
 
     case cached do
       {^fingerprint, base_version, cached_decs} when base_version == decs.version ->
@@ -973,7 +977,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
   defp merge_document_highlight_decorations(decs, [], _theme, cache), do: {decs, cache}
 
   defp merge_document_highlight_decorations(decs, highlights, theme, cached) do
-    fingerprint = {highlights, decs.version}
+    fingerprint = {highlights, decs.version, document_highlight_colors(theme)}
 
     case cached do
       {^fingerprint, cached_decs} ->
@@ -1016,8 +1020,17 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
   # search highlights (priority -10) or selection.
   @spec document_highlight_bg(Minga.LSP.DocumentHighlight.kind(), MingaEditor.UI.Theme.t()) ::
           MingaEditor.UI.Theme.color()
-  defp document_highlight_bg(:write, _theme), do: 0x4A3F2B
-  defp document_highlight_bg(_kind, _theme), do: 0x3A3F4B
+  defp document_highlight_bg(:write, theme), do: elem(document_highlight_colors(theme), 1)
+  defp document_highlight_bg(_kind, theme), do: elem(document_highlight_colors(theme), 0)
+
+  @spec document_highlight_colors(MingaEditor.UI.Theme.t()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp document_highlight_colors(theme) do
+    {
+      theme.editor.highlight_read_bg || 0x3A3F4B,
+      theme.editor.highlight_write_bg || 0x4A3F2B
+    }
+  end
 
   @doc "Returns the decorations for a window's buffer."
   @spec window_decorations(Window.t()) :: Decorations.t()
@@ -1176,12 +1189,10 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
   @spec context_fingerprint(Context.t(), boolean()) ::
           MingaEditor.Window.RenderCache.context_fingerprint()
   def context_fingerprint(%Context{} = ctx, is_active) do
-    hl_id = nil
-
     {
       ctx.visual_selection,
       ctx.search_matches,
-      hl_id,
+      highlight_fingerprint(ctx.highlight),
       ctx.diagnostic_signs,
       ctx.git_signs,
       ctx.viewport.left,
@@ -1191,8 +1202,26 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       ctx.confirm_match,
       ctx.decorations.version,
       ctx.show_invisible,
-      ctx.tab_width
+      ctx.tab_width,
+      ctx.cursorline_bg,
+      ctx.nav_flash,
+      ctx.nav_flash_bg,
+      ctx.editor_bg,
+      ctx.gutter_colors,
+      ctx.git_colors,
+      ctx.whitespace_face,
+      ctx.search_colors,
+      ctx.document_highlight_colors,
+      ctx.wrap_on,
+      ctx.line_number_style
     }
+  end
+
+  @spec highlight_fingerprint(Highlight.t() | nil) :: integer() | nil
+  defp highlight_fingerprint(nil), do: nil
+
+  defp highlight_fingerprint(%Highlight{} = highlight) do
+    :erlang.phash2(highlight)
   end
 
   # ── Private helpers ────────────────────────────────────────────────────────

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -54,6 +54,7 @@ defmodule MingaEditor.RenderPipeline.Input do
   alias MingaEditor.Shell.Board.State, as: BoardState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.LSP, as: LSPState
+  alias MingaEditor.StatusBar.Data, as: StatusBarData
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.UI.FontRegistry
   alias MingaEditor.UI.Panel.MessageStore
@@ -214,15 +215,20 @@ defmodule MingaEditor.RenderPipeline.Input do
     # Hash the fields that drive chrome output. We use :erlang.phash2
     # for speed (no crypto needed, just change detection).
     #
-    # Includes the active buffer's cursor and version because the status
-    # bar displays cursor position, line count, and dirty state. The render
+    # Includes the active buffer identity, cursor, and version because the status
+    # bar displays file name, filetype, cursor position, line count, and dirty state. The render
     # pipeline passes scroll-stage buffer data when available so this does
     # not need duplicate GenServer calls in the hot path.
 
     :erlang.phash2({
-      # Buffer state for status bar (cursor pos, version/dirty)
+      # Buffer state for status bar (identity, cursor pos, version/dirty)
+      input.workspace.buffers.active,
       buf_cursor,
       buf_version,
+      # Theme affects status bar, tab bar, file tree, minibuffer, and overlay styling.
+      input.theme,
+      # Status bar metadata can change without a content version bump, such as save clearing dirty.
+      status_bar_fingerprint(input),
       # Mode affects status bar label, minibuffer content, cursor shape
       input.workspace.editing.mode,
       input.workspace.editing.mode_state,
@@ -256,6 +262,15 @@ defmodule MingaEditor.RenderPipeline.Input do
       # Shell-owned chrome state that does not belong in the generic pipeline contract
       input.shell.chrome_fingerprint(input)
     })
+  end
+
+  @spec status_bar_fingerprint(t()) :: integer()
+  defp status_bar_fingerprint(%__MODULE__{} = input) do
+    input
+    |> StatusBarData.from_state()
+    |> :erlang.phash2()
+  catch
+    :exit, _ -> 0
   end
 
   @spec buffer_fingerprint_data(pid() | nil) ::

--- a/lib/minga_editor/renderer/context.ex
+++ b/lib/minga_editor/renderer/context.ex
@@ -51,7 +51,11 @@ defmodule MingaEditor.Renderer.Context do
             },
             show_invisible: false,
             tab_width: 2,
-            whitespace_face: nil
+            whitespace_face: nil,
+            search_colors: nil,
+            document_highlight_colors: nil,
+            wrap_on: false,
+            line_number_style: :absolute
 
   @typedoc """
   Represents the bounds of a visual selection for rendering.
@@ -87,6 +91,10 @@ defmodule MingaEditor.Renderer.Context do
           gutter_colors: MingaEditor.UI.Theme.Gutter.t(),
           show_invisible: boolean(),
           tab_width: pos_integer(),
-          whitespace_face: Face.t() | nil
+          whitespace_face: Face.t() | nil,
+          search_colors: MingaEditor.UI.Theme.Search.t() | nil,
+          document_highlight_colors: term(),
+          wrap_on: boolean(),
+          line_number_style: atom()
         }
 end

--- a/lib/minga_editor/shell/traditional/chrome/tui.ex
+++ b/lib/minga_editor/shell/traditional/chrome/tui.ex
@@ -9,7 +9,6 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
 
   alias MingaEditor.CompletionUI
   alias MingaEditor.DisplayList
-  alias Minga.Buffer
   alias MingaEditor.DisplayList.{Cursor, Overlay}
   alias MingaEditor.Layout
   alias MingaEditor.PickerUI
@@ -157,7 +156,7 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
       state.workspace.editing.mode_state,
       status_bar_dirty?(status_bar_data),
       state.shell_state.status_msg,
-      state.theme.name
+      state.theme
     })
   end
 
@@ -177,20 +176,8 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
   end
 
   @spec cached_or_fresh_status_bar_data(state(), map() | nil) :: StatusBarData.t()
-  defp cached_or_fresh_status_bar_data(state, active_scroll) do
-    buf = state.workspace.buffers.active
-
-    case state.caches.chrome_prev_result do
-      %Chrome{status_bar_data: {:buffer, data}} when is_pid(buf) ->
-        {line, col} = scroll_cursor(active_scroll, buf)
-        {line_count, dirty} = scroll_buffer_status(active_scroll, data)
-
-        {:buffer,
-         StatusBarData.refresh_cached_buffer_data(data, state, line, col, line_count, dirty)}
-
-      _ ->
-        StatusBarData.from_state(state)
-    end
+  defp cached_or_fresh_status_bar_data(state, _active_scroll) do
+    StatusBarData.from_state(state)
   catch
     :exit, _ -> StatusBarData.from_state(state)
   end
@@ -198,17 +185,6 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUI do
   @spec status_bar_dirty?(StatusBarData.t()) :: boolean()
   defp status_bar_dirty?({:buffer, %{dirty: dirty}}), do: dirty
   defp status_bar_dirty?({:agent, %{dirty: dirty}}), do: dirty
-
-  @spec scroll_cursor(map() | nil, pid()) :: {non_neg_integer(), non_neg_integer()}
-  defp scroll_cursor(%{cursor_line: line, cursor_byte_col: col}, _buf), do: {line, col}
-  defp scroll_cursor(_active_scroll, buf), do: Buffer.cursor(buf)
-
-  @spec scroll_buffer_status(map() | nil, StatusBarData.buffer_data()) ::
-          {non_neg_integer(), boolean()}
-  defp scroll_buffer_status(%{snapshot: %{line_count: line_count, dirty: dirty}}, _data),
-    do: {line_count, dirty}
-
-  defp scroll_buffer_status(_active_scroll, data), do: {data.line_count, data.dirty}
 
   # ── Overlays ──────────────────────────────────────────────────────────────
 

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -114,28 +114,6 @@ defmodule MingaEditor.StatusBar.Data do
     end
   end
 
-  @doc "Updates cached buffer status data with the dynamic fields that can change every frame."
-  @spec refresh_cached_buffer_data(
-          buffer_data(),
-          EditorState.t() | map(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer(),
-          boolean()
-        ) :: buffer_data()
-  def refresh_cached_buffer_data(data, state, line, col, line_count, dirty) do
-    Map.merge(data, %{
-      mode: Minga.Editing.mode(state),
-      mode_state: Editing.mode_state(state),
-      cursor_line: line,
-      cursor_col: col,
-      line_count: line_count,
-      dirty: dirty,
-      macro_recording: Minga.Editing.macro_recording_status(state),
-      status_msg: state.shell_state.status_msg
-    })
-  end
-
   # ── Buffer variant ─────────────────────────────────────────────────────────
 
   @spec build_buffer_data(EditorState.t() | map()) :: buffer_data()

--- a/lib/minga_editor/window/render_cache.ex
+++ b/lib/minga_editor/window/render_cache.ex
@@ -141,7 +141,7 @@ defmodule MingaEditor.Window.RenderCache do
         gutter_w,
         line_count,
         buf_version,
-        cursor_line
+        _cursor_line
       ) do
     first_frame = cache.last_buf_version < 0
 
@@ -154,11 +154,7 @@ defmodule MingaEditor.Window.RenderCache do
     cache = if needs_full, do: %{cache | dirty_lines: :all}, else: cache
 
     if cache.last_buf_version != buf_version and cache.last_buf_version >= 0 do
-      if cache.last_line_count == line_count and cache.dirty_lines != :all do
-        mark_dirty(cache, [cache.last_cursor_line, cursor_line])
-      else
-        %{cache | dirty_lines: :all}
-      end
+      %{cache | dirty_lines: :all}
     else
       cache
     end

--- a/test/minga/lsp/supervisor_test.exs
+++ b/test/minga/lsp/supervisor_test.exs
@@ -12,6 +12,8 @@ defmodule Minga.LSP.SupervisorTest do
   alias Minga.LSP.Supervisor, as: LSPSupervisor
   alias Minga.Test.MockLSPServer
 
+  @ready_timeout 15_000
+
   setup do
     diag_name = :"diag_sup_#{System.unique_integer()}"
     sup_name = :"lsp_sup_#{System.unique_integer()}"
@@ -35,7 +37,7 @@ defmodule Minga.LSP.SupervisorTest do
       _ ->
         assert_receive {:minga_event, :lsp_status_changed,
                         %Minga.Events.LspStatusEvent{name: :mock_lsp, status: :ready}},
-                       5_000
+                       @ready_timeout
     end
   end
 

--- a/test/minga_editor/commands/editing_test.exs
+++ b/test/minga_editor/commands/editing_test.exs
@@ -6,6 +6,7 @@ defmodule MingaEditor.Commands.EditingTest do
 
   defp start_editor(content) do
     {:ok, buffer} = BufferServer.start_link(content: content)
+    BufferServer.set_option(buffer, :clipboard, :none)
 
     {:ok, editor} =
       MingaEditor.start_link(

--- a/test/minga_editor/render_pipeline/chrome_dirty_test.exs
+++ b/test/minga_editor/render_pipeline/chrome_dirty_test.exs
@@ -1,8 +1,10 @@
 defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer.Server, as: BufferServer
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.Shell.Traditional.GitStatus.TuiState
   alias MingaEditor.Shell.Traditional.State, as: ShellState
 
@@ -29,6 +31,40 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
       fp_insert = Input.chrome_fingerprint(input2)
 
       assert fp_normal != fp_insert
+    end
+
+    test "changing theme changes fingerprint" do
+      state = TestHelpers.base_state()
+      input = Input.from_editor_state(state)
+      fp_before = Input.chrome_fingerprint(input)
+
+      input2 = %{input | theme: MingaEditor.UI.Theme.get!(:one_light)}
+      fp_after = Input.chrome_fingerprint(input2)
+
+      assert fp_before != fp_after
+    end
+
+    test "saving a dirty buffer changes fingerprint without changing buffer version" do
+      dir =
+        Path.join(System.tmp_dir!(), "minga-chrome-save-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(dir)
+      path = Path.join(dir, "saved.ex")
+      File.write!(path, "defmodule Saved do\nend\n")
+
+      state = TestHelpers.base_state(content: File.read!(path))
+      buf = state.workspace.buffers.active
+      :ok = BufferServer.save_as(buf, path)
+      :ok = BufferServer.insert_text(buf, "# dirty\n")
+      version_before = BufferServer.version(buf)
+      fp_dirty = state |> Input.from_editor_state() |> Input.chrome_fingerprint()
+
+      :ok = BufferServer.save(buf)
+      version_after = BufferServer.version(buf)
+      fp_clean = state |> Input.from_editor_state() |> Input.chrome_fingerprint()
+
+      assert version_after == version_before
+      assert fp_dirty != fp_clean
     end
 
     test "moving cursor changes fingerprint" do
@@ -126,6 +162,42 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
       fp_after = state2.caches.chrome_prev_fingerprint
 
       assert fp_before != fp_after, "cursor move should change chrome fingerprint"
+    end
+
+    test "render after active buffer changes rebuilds status bar data" do
+      dir =
+        Path.join(System.tmp_dir!(), "minga-chrome-dirty-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(dir)
+      first_path = Path.join(dir, "first.ex")
+      second_path = Path.join(dir, "second.ex")
+      File.write!(first_path, "defmodule First do\nend\n")
+      File.write!(second_path, "defmodule Second do\nend\n")
+
+      state = TestHelpers.base_state(content: File.read!(first_path))
+      first_buf = state.workspace.buffers.active
+      :ok = BufferServer.save_as(first_buf, first_path)
+      {:ok, second_buf} = BufferServer.start_link(content: File.read!(second_path))
+      :ok = BufferServer.save_as(second_buf, second_path)
+
+      state1 = TestHelpers.run_pipeline(state)
+      fp_before = state1.caches.chrome_prev_fingerprint
+
+      switched =
+        put_in(state1.workspace.buffers, %{
+          state1.workspace.buffers
+          | active: second_buf,
+            list: [first_buf, second_buf],
+            active_index: 1
+        })
+        |> update_in([Access.key!(:workspace)], &WorkspaceState.sync_active_window_buffer/1)
+
+      state2 = TestHelpers.run_pipeline(switched)
+      fp_after = state2.caches.chrome_prev_fingerprint
+      {:buffer, status_bar_data} = state2.caches.chrome_prev_result.status_bar_data
+
+      assert fp_before != fp_after
+      assert status_bar_data.file_name == "second.ex"
     end
   end
 end

--- a/test/minga_editor/render_pipeline/content_helpers_test.exs
+++ b/test/minga_editor/render_pipeline/content_helpers_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
   alias MingaEditor.UI.Theme
   alias MingaEditor.Renderer.Context
   alias MingaEditor.RenderPipeline.ContentHelpers
+  alias MingaEditor.UI.Highlight
   alias MingaEditor.Viewport
   alias MingaEditor.Window
 
@@ -18,6 +19,131 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
 
   defp make_match(line, col, len) do
     %Minga.Editing.Search.Match{line: line, col: col, length: len}
+  end
+
+  describe "context_fingerprint/2" do
+    test "changes when syntax highlight spans arrive" do
+      ctx = %Context{viewport: Viewport.new(20, 80), gutter_w: 4, content_w: 76}
+      before_fp = ContentHelpers.context_fingerprint(ctx, true)
+
+      highlight =
+        Highlight.new()
+        |> Highlight.put_names(["keyword"])
+        |> Highlight.put_spans(1, [%{start_byte: 0, end_byte: 3, capture_id: 0}])
+
+      after_fp = ContentHelpers.context_fingerprint(%{ctx | highlight: highlight}, true)
+
+      refute before_fp == after_fp
+    end
+
+    test "changes when syntax highlight version changes" do
+      highlight_v1 =
+        Highlight.new()
+        |> Highlight.put_names(["keyword"])
+        |> Highlight.put_spans(1, [%{start_byte: 0, end_byte: 3, capture_id: 0}])
+
+      highlight_v2 =
+        Highlight.put_spans(highlight_v1, 2, [%{start_byte: 4, end_byte: 7, capture_id: 0}])
+
+      ctx = %Context{
+        viewport: Viewport.new(20, 80),
+        gutter_w: 4,
+        content_w: 76,
+        highlight: highlight_v1
+      }
+
+      refute ContentHelpers.context_fingerprint(ctx, true) ==
+               ContentHelpers.context_fingerprint(%{ctx | highlight: highlight_v2}, true)
+    end
+
+    test "changes when highlight theme changes with the same spans" do
+      highlight =
+        Highlight.new()
+        |> Highlight.put_names(["keyword"])
+        |> Highlight.put_spans(1, [%{start_byte: 0, end_byte: 3, capture_id: 0}])
+
+      themed_highlight = Highlight.new(Theme.get!(:one_light).syntax)
+
+      themed_highlight = %{
+        themed_highlight
+        | version: highlight.version,
+          spans: highlight.spans,
+          capture_names: highlight.capture_names
+      }
+
+      ctx = %Context{
+        viewport: Viewport.new(20, 80),
+        gutter_w: 4,
+        content_w: 76,
+        highlight: highlight
+      }
+
+      refute ContentHelpers.context_fingerprint(ctx, true) ==
+               ContentHelpers.context_fingerprint(%{ctx | highlight: themed_highlight}, true)
+    end
+
+    test "changes when chrome theme colors used by content change" do
+      ctx = %Context{
+        viewport: Viewport.new(20, 80),
+        gutter_w: 4,
+        content_w: 76,
+        editor_bg: 0x111111
+      }
+
+      refute ContentHelpers.context_fingerprint(ctx, true) ==
+               ContentHelpers.context_fingerprint(%{ctx | editor_bg: 0x222222}, true)
+    end
+
+    test "changes when search colors change" do
+      ctx = %Context{
+        viewport: Viewport.new(20, 80),
+        gutter_w: 4,
+        content_w: 76,
+        search_colors: @search_colors
+      }
+
+      alt_colors = %{@search_colors | highlight_bg: 0x123456}
+
+      refute ContentHelpers.context_fingerprint(ctx, true) ==
+               ContentHelpers.context_fingerprint(%{ctx | search_colors: alt_colors}, true)
+    end
+
+    test "changes when document highlight colors change" do
+      ctx = %Context{
+        viewport: Viewport.new(20, 80),
+        gutter_w: 4,
+        content_w: 76,
+        document_highlight_colors: {0x111111, 0x222222}
+      }
+
+      refute ContentHelpers.context_fingerprint(ctx, true) ==
+               ContentHelpers.context_fingerprint(
+                 %{
+                   ctx
+                   | document_highlight_colors: {0x333333, 0x444444}
+                 },
+                 true
+               )
+    end
+
+    test "changes when wrap mode changes" do
+      ctx = %Context{viewport: Viewport.new(20, 80), gutter_w: 4, content_w: 76, wrap_on: false}
+
+      refute ContentHelpers.context_fingerprint(ctx, true) ==
+               ContentHelpers.context_fingerprint(%{ctx | wrap_on: true}, true)
+    end
+
+    test "changes when line number style changes" do
+      ctx = %Context{
+        viewport: Viewport.new(20, 80),
+        gutter_w: 4,
+        content_w: 76,
+        line_number_style: :absolute
+      }
+
+      refute ContentHelpers.context_fingerprint(ctx, true) ==
+               ContentHelpers.context_fingerprint(%{ctx | line_number_style: :relative}, true)
+    end
   end
 
   describe "merge_search_decorations/5" do
@@ -96,6 +222,21 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
       # Different matches: must rebuild, not return cached
       highlights = Decorations.highlights_for_line(result2, 1)
       assert highlights != [], "new search match on line 1 should produce a highlight"
+    end
+
+    test "different search colors rebuild cached decorations" do
+      decs = Decorations.new()
+      matches = [make_match(0, 0, 3)]
+      alt_colors = %{@search_colors | highlight_bg: 0x123456}
+
+      {_result1, cache1} =
+        ContentHelpers.merge_search_decorations(decs, matches, nil, @search_colors, nil)
+
+      {result2, _cache2} =
+        ContentHelpers.merge_search_decorations(decs, matches, nil, alt_colors, cache1)
+
+      [highlight] = Decorations.highlights_for_line(result2, 0)
+      assert highlight.style.bg == 0x123456
     end
   end
 

--- a/test/minga_editor/render_pipeline_test.exs
+++ b/test/minga_editor/render_pipeline_test.exs
@@ -190,8 +190,8 @@ defmodule MingaEditor.RenderPipelineTest do
 
       window2 = Map.get(state.workspace.windows.map, win_id)
 
-      # Buffer version changed without a line-count change → only the edited cursor line is dirty.
-      assert window2.render_cache.dirty_lines == %{0 => true}
+      # Redraw all visible lines so same-line-count edits cannot leave stale rows.
+      assert window2.render_cache.dirty_lines == :all
 
       # Verify version actually changed
       snapshot = BufferServer.render_snapshot(buf, 0, 3)

--- a/test/minga_editor/shell/traditional/chrome/tui_test.exs
+++ b/test/minga_editor/shell/traditional/chrome/tui_test.exs
@@ -90,6 +90,24 @@ defmodule MingaEditor.Shell.Traditional.Chrome.TUITest do
       assert is_list(chrome.regions)
       assert Enum.all?(chrome.regions, &is_binary/1)
     end
+
+    test "same-named theme color changes rebuild stable chrome" do
+      state = base_state()
+      {scrolls, cursor_info, state, layout} = run_through_content(state)
+      chrome1 = ChromeTUI.build(state, layout, scrolls, cursor_info)
+
+      changed_theme = %{state.theme | editor: %{state.theme.editor | split_border_fg: 0x123456}}
+
+      state = %{
+        state
+        | theme: changed_theme,
+          caches: %{state.caches | chrome_prev_result: chrome1}
+      }
+
+      chrome2 = ChromeTUI.build(state, layout, scrolls, cursor_info)
+
+      refute chrome1.stable_fingerprint == chrome2.stable_fingerprint
+    end
   end
 
   # ── Status bar mode badges ──────────────────────────────────────────────

--- a/test/minga_editor/window/render_cache_test.exs
+++ b/test/minga_editor/window/render_cache_test.exs
@@ -1,0 +1,27 @@
+defmodule MingaEditor.Window.RenderCacheTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Window.RenderCache
+
+  describe "detect_invalidation/6" do
+    test "marks all lines dirty when buffer version changes with the same line count" do
+      cache =
+        RenderCache.reset()
+        |> RenderCache.snapshot(0, 4, 3, 2, 1, :ctx)
+
+      cache = RenderCache.detect_invalidation(cache, 0, 4, 3, 2, 2)
+
+      assert cache.dirty_lines == :all
+    end
+
+    test "does not mark all lines dirty for cursor-only movement" do
+      cache =
+        RenderCache.reset()
+        |> RenderCache.snapshot(0, 4, 3, 1, 1, :ctx)
+
+      cache = RenderCache.detect_invalidation(cache, 0, 4, 3, 1, 2)
+
+      assert cache.dirty_lines == %{}
+    end
+  end
+end

--- a/test/minga_editor/window_test.exs
+++ b/test/minga_editor/window_test.exs
@@ -205,11 +205,11 @@ defmodule MingaEditor.WindowTest do
       assert result.render_cache.dirty_lines == :all
     end
 
-    test "targeted invalidation when buffer version changed without line count change", %{
+    test "full invalidation when buffer version changed without line count change", %{
       window: window
     } do
       result = Window.detect_invalidation(window, 0, 4, 100, 6)
-      assert result.render_cache.dirty_lines == %{10 => true}
+      assert result.render_cache.dirty_lines == :all
     end
 
     test "full invalidation on first frame (sentinel tracking values)", %{window: _window} do
@@ -401,10 +401,10 @@ defmodule MingaEditor.WindowTest do
 
       window = Window.snapshot_after_render(window, 0, 4, 100, 5, 1, :test_fp)
 
-      # User types a character on line 5 → buffer version bumps to 2.
-      # Same-line edits with unchanged line count only dirty the previous/current cursor line.
+      # User types a character on line 5, bumping the buffer version.
+      # Redraw all visible lines so same-line-count edits cannot leave stale rows.
       window = Window.detect_invalidation(window, 0, 4, 100, 2)
-      assert window.render_cache.dirty_lines == %{5 => true}
+      assert window.render_cache.dirty_lines == :all
 
       # After rendering, snapshot with new version
       window = Window.snapshot_after_render(window, 0, 4, 100, 5, 2, :test_fp)


### PR DESCRIPTION
# TL;DR
Fix stale render-cache invalidation so newly highlighted buffers, same-line-count edits, theme changes, and status metadata changes repaint correctly instead of reusing old rows or chrome.

## Context
This started from a bug where the second opened Elixir file was recognized as Elixir but did not syntax highlight. The root cause was that highlight arrival did not change the content render context fingerprint, so cached plain-text rows could be reused.

## Changes
- Include syntax highlight state and theme-dependent content inputs in the content context fingerprint.
- Invalidate all visible rows on buffer version changes, avoiding stale rows when edits keep the same line count or cursor line.
- Include wrap mode and line-number style in content invalidation.
- Include theme and status-bar data in the top-level chrome fingerprint, including dirty state changes from save operations.
- Rebuild TUI stable chrome when same-named theme contents change.
- Remove unsafe same-buffer status bar partial-refresh caching and recompute status data when chrome runs.
- Add regression coverage for render-cache, chrome-cache, theme, search, document-highlight, wrap, line-number, save, and buffer-switch cases.

## Verification
- `make lint`
- `mix test.llm test/minga_editor/render_pipeline test/minga_editor/render_pipeline_test.exs test/minga_editor/renderer test/minga_editor/window_test.exs test/minga_editor/window/render_cache_test.exs test/minga_editor/shell/traditional/chrome test/minga_editor/frontend/emit/gui_chrome_cache_test.exs test/minga_editor/status_bar/data_test.exs`
- Reviewer gate passed after blocker fixes.
