### PR TITLE
fix(editor): align mouse selection with evil behavior

### DIFF
--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -244,16 +244,7 @@ defmodule MingaEditor.Mouse do
         :drag,
         _cc
       ) do
-    state =
-      state
-      |> maybe_auto_scroll(row)
-      |> move_to_mouse_pos(row, col)
-
-    case dcc do
-      2 -> snap_selection_to_words(state, anchor)
-      3 -> snap_selection_to_lines(state, anchor)
-      _ -> enter_visual_if_needed(state, anchor)
-    end
+    handle_left_drag(state, row, col, anchor, dcc)
   end
 
   # ── Left release ──
@@ -288,8 +279,7 @@ defmodule MingaEditor.Mouse do
         &WorkspaceState.set_mouse(&1, MouseState.stop_drag(&1.mouse))
       )
 
-    # Auto-copy selection to system clipboard on mouse release.
-    # Standard terminal behavior: selecting text copies it.
+    # TUI keeps legacy selection auto-copy. Native GUI selection stays separate from the clipboard.
     auto_copy_selection(state)
   end
 
@@ -331,6 +321,44 @@ defmodule MingaEditor.Mouse do
   # ── Ignore all other mouse events ──
 
   def handle(state, _row, _col, _button, _mods, _type, _cc), do: state
+
+  @spec handle_left_drag(
+          state(),
+          integer(),
+          integer(),
+          {non_neg_integer(), non_neg_integer()},
+          pos_integer()
+        ) :: state()
+  defp handle_left_drag(%{workspace: %{editing: %{mode: :visual}}} = state, row, col, anchor, dcc) do
+    drag_to_mouse_pos(state, row, col, anchor, dcc)
+  end
+
+  defp handle_left_drag(state, row, col, anchor, dcc) do
+    case mouse_to_buffer_pos(state, row, col) do
+      ^anchor -> state
+      _target -> drag_to_mouse_pos(state, row, col, anchor, dcc)
+    end
+  end
+
+  @spec drag_to_mouse_pos(
+          state(),
+          integer(),
+          integer(),
+          {non_neg_integer(), non_neg_integer()},
+          pos_integer()
+        ) :: state()
+  defp drag_to_mouse_pos(state, row, col, anchor, dcc) do
+    state
+    |> maybe_auto_scroll(row)
+    |> move_to_mouse_pos(row, col)
+    |> update_drag_selection(anchor, dcc)
+  end
+
+  @spec update_drag_selection(state(), {non_neg_integer(), non_neg_integer()}, pos_integer()) ::
+          state()
+  defp update_drag_selection(state, anchor, 2), do: snap_selection_to_words(state, anchor)
+  defp update_drag_selection(state, anchor, 3), do: snap_selection_to_lines(state, anchor)
+  defp update_drag_selection(state, anchor, _dcc), do: enter_visual_if_needed(state, anchor)
 
   @spec handle_buffer_scroll_at_window(
           state(),
@@ -428,9 +456,24 @@ defmodule MingaEditor.Mouse do
     handle_shift_click(state, row, col)
   end
 
-  # Cmd+click (GUI) or Ctrl+click (TUI): go-to-definition
-  defp handle_left_press_modifiers(state, row, col, mods, _cc)
-       when band(mods, @mod_super) != 0 or band(mods, @mod_ctrl) != 0 do
+  # Cmd+click (GUI) or Ctrl+click (TUI): go-to-definition.
+  defp handle_left_press_modifiers(state, row, col, mods, _cc) when band(mods, @mod_super) != 0 do
+    handle_goto_definition_click(state, row, col)
+  end
+
+  # On native GUI frontends, Ctrl-click is reserved for the platform context menu.
+  defp handle_left_press_modifiers(
+         %{capabilities: %Capabilities{frontend_type: :native_gui}} = state,
+         row,
+         col,
+         mods,
+         _cc
+       )
+       when band(mods, @mod_ctrl) != 0 do
+    handle_plain_left_press(state, row, col)
+  end
+
+  defp handle_left_press_modifiers(state, row, col, mods, _cc) when band(mods, @mod_ctrl) != 0 do
     handle_goto_definition_click(state, row, col)
   end
 
@@ -449,6 +492,11 @@ defmodule MingaEditor.Mouse do
 
   # Single click: normal cursor positioning
   defp handle_left_press_modifiers(state, row, col, _mods, _cc) do
+    handle_plain_left_press(state, row, col)
+  end
+
+  @spec handle_plain_left_press(state(), integer(), integer()) :: state()
+  defp handle_plain_left_press(state, row, col) do
     state
     |> maybe_start_separator_drag(row, col)
     |> maybe_handle_content_click(row, col)
@@ -645,21 +693,34 @@ defmodule MingaEditor.Mouse do
   defp word_boundaries_at(buf, line, col) do
     case Buffer.lines(buf, line, 1) do
       [text] when byte_size(text) > 0 ->
-        find_word_at(String.graphemes(text), col)
+        find_word_at(text, col)
 
       _ ->
         nil
     end
   end
 
-  @spec find_word_at([String.t()], non_neg_integer()) ::
+  @spec find_word_at(String.t(), non_neg_integer()) ::
           {non_neg_integer(), non_neg_integer()} | nil
-  defp find_word_at([], _col), do: nil
+  defp find_word_at("", _col), do: nil
 
-  defp find_word_at(graphemes, col) do
-    idx = min(col, length(graphemes) - 1)
-    char = Enum.at(graphemes, idx)
+  defp find_word_at(text, col) do
+    {graphemes, byte_offsets} = Unicode.graphemes_with_byte_offsets(text)
+    byte_col = Unicode.clamp_to_grapheme_boundary(text, col)
+    idx = Unicode.byte_offset_to_grapheme_index(byte_offsets, byte_col)
+    char = elem(graphemes, idx)
 
+    {start_idx, end_idx} = word_boundary_indexes(graphemes, idx, char)
+
+    {
+      Unicode.grapheme_index_to_byte_offset(byte_offsets, start_idx, byte_size(text)),
+      Unicode.grapheme_index_to_byte_offset(byte_offsets, end_idx, byte_size(text))
+    }
+  end
+
+  @spec word_boundary_indexes(tuple(), non_neg_integer(), String.t()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp word_boundary_indexes(graphemes, idx, char) do
     if word_char?(char) do
       {scan_word_start(graphemes, idx), scan_word_end(graphemes, idx)}
     else
@@ -667,33 +728,35 @@ defmodule MingaEditor.Mouse do
     end
   end
 
-  @spec scan_word_start([String.t()], non_neg_integer()) :: non_neg_integer()
-  defp scan_word_start(graphemes, idx) do
-    if idx == 0 do
-      0
-    else
-      prev = Enum.at(graphemes, idx - 1)
+  @spec scan_word_start(tuple(), non_neg_integer()) :: non_neg_integer()
+  defp scan_word_start(_graphemes, 0), do: 0
 
-      if word_char?(prev) do
-        scan_word_start(graphemes, idx - 1)
-      else
-        idx
-      end
+  defp scan_word_start(graphemes, idx) do
+    prev = elem(graphemes, idx - 1)
+
+    if word_char?(prev) do
+      scan_word_start(graphemes, idx - 1)
+    else
+      idx
     end
   end
 
-  @spec scan_word_end([String.t()], non_neg_integer()) :: non_neg_integer()
+  @spec scan_word_end(tuple(), non_neg_integer()) :: non_neg_integer()
   defp scan_word_end(graphemes, idx) do
-    if idx >= length(graphemes) - 1 do
-      idx
-    else
-      next = Enum.at(graphemes, idx + 1)
+    last_idx = tuple_size(graphemes) - 1
+    scan_word_end(graphemes, idx, last_idx)
+  end
 
-      if word_char?(next) do
-        scan_word_end(graphemes, idx + 1)
-      else
-        idx
-      end
+  @spec scan_word_end(tuple(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp scan_word_end(_graphemes, idx, last_idx) when idx >= last_idx, do: idx
+
+  defp scan_word_end(graphemes, idx, last_idx) do
+    next = elem(graphemes, idx + 1)
+
+    if word_char?(next) do
+      scan_word_end(graphemes, idx + 1, last_idx)
+    else
+      idx
     end
   end
 
@@ -1288,13 +1351,16 @@ defmodule MingaEditor.Mouse do
   end
 
   @spec auto_copy_selection(EditorState.t()) :: EditorState.t()
+  defp auto_copy_selection(%{capabilities: %Capabilities{frontend_type: :native_gui}} = state),
+    do: state
+
   defp auto_copy_selection(
          %{workspace: %{editing: %{mode: :visual, mode_state: ms}, buffers: %{active: buf}}} =
            state
        )
        when is_pid(buf) do
     text = selection_text(buf, ms)
-    maybe_copy_to_clipboard(text)
+    maybe_copy_to_clipboard(state, text)
     state
   catch
     :exit, _ -> state
@@ -1313,14 +1379,15 @@ defmodule MingaEditor.Mouse do
     Buffer.lines_content(buf, min(a_line, c_line), max(a_line, c_line))
   end
 
-  defp maybe_copy_to_clipboard(text) when is_binary(text) and text != "" do
-    case Config.get(:clipboard) do
+  defp maybe_copy_to_clipboard(%{workspace: %{buffers: %{active: buf}}}, text)
+       when is_pid(buf) and is_binary(text) and text != "" do
+    case Buffer.get_option(buf, :clipboard) do
       :none -> :ok
       _ -> Minga.Clipboard.write(text)
     end
   end
 
-  defp maybe_copy_to_clipboard(_text), do: :ok
+  defp maybe_copy_to_clipboard(_state, _text), do: :ok
 
   @spec adjust_col_for_virtual_text(pid(), non_neg_integer(), non_neg_integer()) ::
           non_neg_integer()

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -461,7 +461,7 @@ defmodule MingaEditor.Mouse do
     handle_goto_definition_click(state, row, col)
   end
 
-  # On native GUI frontends, Ctrl-click is reserved for the platform context menu.
+  # On native GUI frontends, Ctrl-click follows platform context-menu semantics.
   defp handle_left_press_modifiers(
          %{capabilities: %Capabilities{frontend_type: :native_gui}} = state,
          row,
@@ -470,7 +470,7 @@ defmodule MingaEditor.Mouse do
          _cc
        )
        when band(mods, @mod_ctrl) != 0 do
-    handle_plain_left_press(state, row, col)
+    handle_context_click(state, row, col)
   end
 
   defp handle_left_press_modifiers(state, row, col, mods, _cc) when band(mods, @mod_ctrl) != 0 do

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -70,6 +70,11 @@ final class EditorNSView: MTKView {
     /// Divider direction captured at mouse-down so drag keeps the resize cursor.
     private var dividerDragState: DividerCursorState = .none
 
+    /// Text-selection drag tracking. AppKit can report tiny drags during a normal click, so buffer drags only start after the pointer crosses a small native threshold.
+    private var leftMouseDownPoint: NSPoint?
+    private var leftMouseDragStarted: Bool = false
+    private let textDragThreshold: CGFloat = 4.0
+
     /// Whether the ready event has been sent to the BEAM. Deferred until
     /// setFrameSize so we send the actual window dimensions, not hardcoded defaults.
     private var readySent = false
@@ -983,6 +988,8 @@ final class EditorNSView: MTKView {
         }
 
         resetCursorBlink()
+        leftMouseDownPoint = point
+        leftMouseDragStarted = false
         dividerDragState = dividerHitState(at: point)
         if dividerDragState != .none {
             setDividerCursorState(dividerDragState)
@@ -1006,6 +1013,8 @@ final class EditorNSView: MTKView {
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_LEFT,
                                modifiers: modifierBits(from: event.modifierFlags),
                                eventType: MOUSE_RELEASE)
+        leftMouseDownPoint = nil
+        leftMouseDragStarted = false
         if dividerDragState != .none {
             dividerDragState = .none
             setDividerCursorState(dividerHitState(at: point))
@@ -1108,6 +1117,8 @@ final class EditorNSView: MTKView {
 
         if dividerDragState != .none {
             setDividerCursorState(dividerDragState)
+        } else if !shouldSendTextDrag(for: event) {
+            return
         }
         let (row, col) = cellPosition(from: event)
         encoder.sendMouseEvent(row: row, col: col, button: MOUSE_BUTTON_LEFT,
@@ -1315,6 +1326,27 @@ final class EditorNSView: MTKView {
 
     private var effectiveCellHeight: CGFloat {
         cellHeight * CGFloat(dispatcher.frameState.lineSpacing)
+    }
+
+    private func shouldSendTextDrag(for event: NSEvent) -> Bool {
+        if leftMouseDragStarted {
+            return true
+        }
+
+        let point = convert(event.locationInWindow, from: nil)
+        guard let downPoint = leftMouseDownPoint else {
+            leftMouseDownPoint = point
+            leftMouseDragStarted = true
+            return true
+        }
+
+        let dx = point.x - downPoint.x
+        let dy = point.y - downPoint.y
+        let distance = sqrt(dx * dx + dy * dy)
+        guard distance >= textDragThreshold else { return false }
+
+        leftMouseDragStarted = true
+        return true
     }
 
     private var dividerHitHalfTolerance: CGFloat {

--- a/test/minga_editor/mouse_clipboard_test.exs
+++ b/test/minga_editor/mouse_clipboard_test.exs
@@ -1,0 +1,76 @@
+defmodule MingaEditor.MouseClipboardTest do
+  @moduledoc """
+  Clipboard behavior for mouse selections.
+  """
+
+  # Mutates global clipboard config; async false keeps the setting isolated.
+  use ExUnit.Case, async: false
+
+  alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Config.Options
+  alias Minga.Mode.VisualState
+  alias MingaEditor.Frontend.Capabilities
+  alias MingaEditor.Mouse
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Mouse, as: MouseState
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  setup do
+    original_clipboard = Options.get(:clipboard)
+    {:ok, _} = Options.set(:clipboard, :unnamedplus)
+
+    test_pid = self()
+
+    Mox.stub(Minga.Clipboard.Mock, :write, fn text ->
+      send(test_pid, {:clipboard_written, text})
+      :ok
+    end)
+
+    Mox.stub(Minga.Clipboard.Mock, :read, fn -> nil end)
+
+    on_exit(fn ->
+      Options.set(:clipboard, original_clipboard)
+    end)
+
+    :ok
+  end
+
+  test "native GUI mouse selection release does not copy to clipboard" do
+    state = build_visual_drag_state(:native_gui)
+
+    _state = Mouse.handle(state, 1, 0, :left, 0, :release, 1)
+
+    refute_receive {:clipboard_written, _text}, 50
+  end
+
+  test "TUI mouse selection release keeps legacy auto-copy behavior" do
+    state = build_visual_drag_state(:tui)
+
+    _state = Mouse.handle(state, 1, 0, :left, 0, :release, 1)
+
+    assert_receive {:clipboard_written, "hello"}, 200
+  end
+
+  defp build_visual_drag_state(frontend_type) do
+    buffer = start_supervised!({BufferServer, content: "hello world"})
+    BufferServer.set_option(buffer, :clipboard, :unnamedplus)
+    BufferServer.move_to(buffer, {0, 4})
+
+    visual_state = %VisualState{visual_anchor: {0, 0}, visual_type: :char}
+    editing = VimState.transition(VimState.new(), :visual, visual_state)
+
+    %EditorState{
+      port_manager: nil,
+      capabilities: %Capabilities{frontend_type: frontend_type},
+      workspace: %WorkspaceState{
+        viewport: Viewport.new(10, 40),
+        buffers: %Buffers{active: buffer, list: [buffer]},
+        editing: editing,
+        mouse: %MouseState{dragging: true, anchor: {0, 0}}
+      }
+    }
+  end
+end

--- a/test/minga_editor/mouse_clipboard_test.exs
+++ b/test/minga_editor/mouse_clipboard_test.exs
@@ -3,11 +3,11 @@ defmodule MingaEditor.MouseClipboardTest do
   Clipboard behavior for mouse selections.
   """
 
-  # Mutates global clipboard config; async false keeps the setting isolated.
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
+
+  import Hammox
 
   alias Minga.Buffer.Server, as: BufferServer
-  alias Minga.Config.Options
   alias Minga.Mode.VisualState
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Mouse
@@ -18,22 +18,17 @@ defmodule MingaEditor.MouseClipboardTest do
   alias MingaEditor.VimState
   alias MingaEditor.Workspace.State, as: WorkspaceState
 
-  setup do
-    original_clipboard = Options.get(:clipboard)
-    {:ok, _} = Options.set(:clipboard, :unnamedplus)
+  setup :verify_on_exit!
 
+  setup do
     test_pid = self()
 
-    Mox.stub(Minga.Clipboard.Mock, :write, fn text ->
+    stub(Minga.Clipboard.Mock, :write, fn text ->
       send(test_pid, {:clipboard_written, text})
       :ok
     end)
 
-    Mox.stub(Minga.Clipboard.Mock, :read, fn -> nil end)
-
-    on_exit(fn ->
-      Options.set(:clipboard, original_clipboard)
-    end)
+    stub(Minga.Clipboard.Mock, :read, fn -> nil end)
 
     :ok
   end
@@ -69,7 +64,7 @@ defmodule MingaEditor.MouseClipboardTest do
         viewport: Viewport.new(10, 40),
         buffers: %Buffers{active: buffer, list: [buffer]},
         editing: editing,
-        mouse: %MouseState{dragging: true, anchor: {0, 0}}
+        mouse: MouseState.start_drag(%MouseState{}, {0, 0})
       }
     }
   end

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -221,8 +221,10 @@ defmodule MingaEditor.MouseTest do
 
       send_mouse(editor, @content_row, @gutter + 3, :left, :press, 0x02)
 
+      s = state(editor)
       assert BufferServer.cursor(buffer) == {1, 3}
-      refute EditorState.status_msg(state(editor)) == "No language server"
+      assert s.workspace.mouse.dragging == false
+      refute EditorState.status_msg(s) == "No language server"
     end
 
     test "TUI Ctrl-left click keeps goto-definition behavior" do

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.MouseTest do
   alias MingaEditor
   alias MingaEditor.Commands.Movement
   alias MingaEditor.FoldMap
+  alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Windows
@@ -86,6 +87,15 @@ defmodule MingaEditor.MouseTest do
     Enum.max_by(layout.window_layouts, fn {_id, %{content: {_row, content_col, _w, _h}}} ->
       content_col
     end)
+  end
+
+  defp set_gui_capabilities(editor) do
+    send(
+      editor,
+      {:minga_input, {:capabilities_updated, %Capabilities{frontend_type: :native_gui}}}
+    )
+
+    _ = :sys.get_state(editor, @sync_timeout)
   end
 
   describe "mouse scroll" do
@@ -203,6 +213,25 @@ defmodule MingaEditor.MouseTest do
 
       assert BufferServer.cursor(buffer) == {1, 3}
       assert state(editor).workspace.mouse.dragging == false
+    end
+
+    test "native GUI Ctrl-left click positions cursor without goto-definition" do
+      {editor, buffer} = start_editor("hello\nworld\nfoo bar baz")
+      set_gui_capabilities(editor)
+
+      send_mouse(editor, @content_row, @gutter + 3, :left, :press, 0x02)
+
+      assert BufferServer.cursor(buffer) == {1, 3}
+      refute EditorState.status_msg(state(editor)) == "No language server"
+    end
+
+    test "TUI Ctrl-left click keeps goto-definition behavior" do
+      {editor, buffer} = start_editor("hello\nworld\nfoo bar baz")
+
+      send_mouse(editor, @content_row + 1, @gutter + 3, :left, :press, 0x02)
+
+      assert BufferServer.cursor(buffer) == {1, 3}
+      assert EditorState.status_msg(state(editor)) == "No language server"
     end
 
     test "left click accounts for viewport scroll offset" do
@@ -330,6 +359,21 @@ defmodule MingaEditor.MouseTest do
     end
   end
 
+  describe "mouse multi-click selection" do
+    @gutter 6
+
+    test "double-click selects full Unicode word using byte offsets" do
+      {editor, buffer} = start_editor("éclair test")
+
+      send_mouse(editor, @content_row, @gutter + 1, :left, :press, 0, 2)
+
+      assert BufferServer.cursor(buffer) == {0, 6}
+      s = state(editor)
+      assert s.workspace.editing.mode == :visual
+      assert s.workspace.editing.mode_state.visual_anchor == {0, 0}
+    end
+  end
+
   describe "split separator double-click" do
     test "double-clicking a separator resets split size without entering visual mode" do
       {editor, _buffer} = start_editor("hello world")
@@ -407,6 +451,29 @@ defmodule MingaEditor.MouseTest do
       s = state(editor)
       assert s.workspace.editing.mode == :normal
       assert s.workspace.mouse.dragging == false
+    end
+
+    test "drag event at the original buffer position does not enter visual mode" do
+      {editor, _buffer} = start_editor("hello world")
+
+      send_mouse(editor, @content_row, @gutter + 3, :left, :press)
+      send_mouse(editor, @content_row, @gutter + 3, :left, :drag)
+
+      assert state(editor).workspace.editing.mode == :normal
+
+      send_mouse(editor, @content_row, @gutter + 3, :left, :release)
+      assert state(editor).workspace.mouse.dragging == false
+    end
+
+    test "scroll after click jitter stays in normal mode" do
+      {editor, _buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
+
+      send_mouse(editor, @content_row, @gutter + 3, :left, :press)
+      send_mouse(editor, @content_row, @gutter + 3, :left, :drag)
+      send_mouse(editor, @content_row, @gutter + 3, :left, :release)
+      send_mouse(editor, @content_row, @gutter + 3, :wheel_down, :press)
+
+      assert state(editor).workspace.editing.mode == :normal
     end
 
     test "drag clamps to buffer bounds" do


### PR DESCRIPTION
# TL;DR
This aligns mouse selection behavior with Doom Emacs Evil expectations: plain clicks stay normal, real drags select, native GUI Ctrl-click does not trigger goto-definition, and GUI mouse selection no longer overwrites the clipboard.

## Context
This PR fixes a macOS mouse bug where a tiny AppKit drag after a normal click could leave the editor in visual mode, so later scrolling appeared to highlight text. While fixing that path, it also tightens nearby mouse semantics that should match Evil behavior across GUI and TUI frontends.

## Changes
- Adds a native macOS drag threshold before `EditorNSView` sends text drag events to the BEAM.
- Adds a BEAM-side same-anchor guard so drag jitter that maps to the original buffer position does not enter visual mode.
- Keeps real drags, double-click word selection, triple-click line selection, and drag autoscroll behavior working through the existing mouse path.
- Treats native GUI Ctrl-left-click as a normal click, while preserving TUI Ctrl-click goto-definition and GUI Cmd-click goto-definition.
- Stops native GUI mouse selection release from auto-copying to the system clipboard, while preserving the TUI legacy auto-copy path.
- Fixes double-click word selection to return byte offsets for Unicode text instead of mixing grapheme indexes with buffer byte columns.

## Verification
- `mix test.llm test/minga_editor/mouse_test.exs test/minga_editor/mouse_clipboard_test.exs test/minga_editor/integration/mouse_test.exs` passed, 66 tests, 0 failures.
- `mix swift.build` passed.
- Focused `prtk-code-reviewer` found two issues; both were fixed, and targeted re-review passed.
- `mix test.llm` passed, 8495 tests, 0 failures, 5 skipped, 118 excluded.
- `make lint` passed.

## Acceptance Criteria Addressed
- Single left click positions the cursor and stays in normal mode. ✅
- Click jitter does not enter visual mode. ✅
- Click jitter followed by scroll stays in normal mode. ✅
- Real click-drag still enters visual selection. ✅
- Native GUI Ctrl-click does not run goto-definition; TUI Ctrl-click still does. ✅
- Native GUI mouse selection release does not auto-copy to clipboard; TUI legacy behavior remains. ✅
- Unicode double-click word selection uses buffer byte offsets. ✅
