### PR TITLE
fix(macos): preserve spaces after entering insert mode

### DIFF
--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -901,6 +901,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         disp.onModeChanged = { [weak nsView] modeName in
             guard let nsView else { return }
+            nsView.statusBarModeDidChange()
             NSAccessibility.post(
                 element: nsView,
                 notification: .announcementRequested,

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -17,6 +17,14 @@ private enum DividerCursorState: Equatable {
     case horizontal
 }
 
+private enum EditorStatusMode {
+    static let normal: UInt8 = 0
+    static let insert: UInt8 = 1
+    static let command: UInt8 = 3
+    static let search: UInt8 = 5
+    static let replace: UInt8 = 6
+}
+
 /// The main editor view. Uses MTKView's built-in display link for
 /// vsync-driven rendering with automatic frame coalescing.
 final class EditorNSView: MTKView {
@@ -109,10 +117,19 @@ final class EditorNSView: MTKView {
     /// Border overlay shown during file drag-and-drop hover.
     private var dropHighlightLayer: CAShapeLayer?
 
-    /// Status bar state from the BEAM. Used by the space leader key-chord
-    /// logic to check whether insert mode is active (SPC is always literal
-    /// in insert mode, never a leader key).
+    /// Status bar state from the BEAM. Used by the space leader key-chord logic to decide whether SPC is typed text or a leader key.
     var statusBarState: StatusBarState?
+
+    /// Short-lived local prediction that the BEAM is about to enter a text-input mode.
+    /// The status bar update is authoritative, but it arrives asynchronously after Vim-normal keys that enter insert-like input.
+    /// Without this guard, a fast `i` then `set :` sequence can still see NORMAL on the Swift side and treat the space as a leader chord instead of literal text.
+    private var optimisticTextInputMode: Bool = false
+
+    /// Token used to expire stale optimistic text-input predictions without racing newer predictions.
+    private var optimisticTextInputModeToken: UInt64 = 0
+
+    /// Maximum time to trust the local text-input prediction if the BEAM has not confirmed it through the status bar yet.
+    private let optimisticTextInputModeTimeoutMs: Int = 500
 
     // MARK: - Space leader key-chord state
 
@@ -804,12 +821,9 @@ final class EditorNSView: MTKView {
         }
 
         // ── Space leader key-chord interception ──
-        // When SPC is pending or held, intercept chord keys before any
-        // other processing. Skip when:
-        // - IME is composing (SPC is the commit key in CJK input methods)
-        // - Insert mode is active (SPC is always a literal space, never a leader)
-        let isInsertMode = statusBarState?.isInsertMode ?? false
-        if !imeComposition.hasMarkedText && !isInsertMode {
+        // When SPC is pending or held, intercept chord keys before any other processing.
+        // Skip when IME is composing or when the current mode treats SPC as typed text.
+        if !imeComposition.hasMarkedText && !spaceLeaderShouldTreatSpaceLiterally() {
             if let chars = event.charactersIgnoringModifiers, chars == " ", mods == 0 {
                 // Bare SPC keyDown (no modifiers)
                 if event.isARepeat {
@@ -1308,8 +1322,81 @@ final class EditorNSView: MTKView {
 
     /// Sends a key press and updates recovery tracking in one place.
     private func sendKeyPress(codepoint: UInt32, modifiers: UInt8) {
+        updateOptimisticTextInputMode(codepoint: codepoint, modifiers: modifiers)
         recoveryManager?.onKeySent()
         encoder.sendKeyPress(codepoint: codepoint, modifiers: modifiers)
+    }
+
+    /// Clears stale local text-input prediction when the authoritative BEAM mode changes.
+    func statusBarModeDidChange() {
+        if !Self.statusModeUsesLiteralSpace(statusMode: statusBarState?.mode) {
+            clearOptimisticTextInputMode()
+        }
+    }
+
+    /// Returns whether frontend space-leader interception should stand down.
+    /// BEAM state remains authoritative; this adds a short local prediction so text typed immediately after `i` is not misclassified as a normal-mode leader chord before the status bar message catches up.
+    private func spaceLeaderShouldTreatSpaceLiterally() -> Bool {
+        if Self.statusModeUsesLiteralSpace(statusMode: statusBarState?.mode) { return true }
+        return optimisticTextInputMode
+    }
+
+    /// Returns true for BEAM modes where SPC is typed text, not a leader chord.
+    /// CUA is encoded as normal mode, so it intentionally stays false here.
+    nonisolated static func statusModeUsesLiteralSpace(statusMode: UInt8?) -> Bool {
+        switch statusMode {
+        case EditorStatusMode.insert, EditorStatusMode.command, EditorStatusMode.search, EditorStatusMode.replace:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Keeps the short-lived text-input prediction in sync with outgoing keys.
+    private func updateOptimisticTextInputMode(codepoint: UInt32, modifiers: UInt8) {
+        if codepoint == 27 {
+            clearOptimisticTextInputMode()
+            return
+        }
+
+        guard modifiers == 0 else { return }
+        let statusMode = statusBarState?.mode
+        guard !Self.statusModeUsesLiteralSpace(statusMode: statusMode) else { return }
+        guard Self.shouldOptimisticallyEnterTextInputMode(codepoint: codepoint, statusMode: statusMode, cursorShape: dispatcher.frameState.cursorShape) else { return }
+
+        markOptimisticTextInputMode()
+    }
+
+    /// Returns true for Vim-normal keys that immediately enter insert-like text input.
+    /// The cursor-shape gate avoids applying Vim assumptions while CUA mode is active.
+    nonisolated static func shouldOptimisticallyEnterTextInputMode(codepoint: UInt32, statusMode: UInt8?, cursorShape: CursorShape) -> Bool {
+        guard statusMode == EditorStatusMode.normal, cursorShape == .block else { return false }
+
+        switch codepoint {
+        case 0x69, 0x49, 0x61, 0x41, 0x6F, 0x4F, 0x73, 0x53, 0x43, 0x52:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Starts or refreshes the short optimistic text-input window.
+    private func markOptimisticTextInputMode() {
+        optimisticTextInputMode = true
+        optimisticTextInputModeToken &+= 1
+        let token = optimisticTextInputModeToken
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(optimisticTextInputModeTimeoutMs)) { [weak self] in
+            guard let self, self.optimisticTextInputModeToken == token else { return }
+            self.optimisticTextInputMode = false
+        }
+    }
+
+    /// Clears the local text-input prediction immediately.
+    private func clearOptimisticTextInputMode() {
+        guard optimisticTextInputMode else { return }
+        optimisticTextInputMode = false
+        optimisticTextInputModeToken &+= 1
     }
 
     private func sendSpaceLeaderChord(codepoint: UInt32, modifiers: UInt8) {

--- a/macos/Tests/MingaTests/KeyboardInputTests.swift
+++ b/macos/Tests/MingaTests/KeyboardInputTests.swift
@@ -211,6 +211,36 @@ struct KeyboardInputTests {
         #expect(!EditorNSView.shouldYieldSystemCommandShortcut(modifiedQuit))
     }
 
+    @Test("Text input modes treat space as literal")
+    func statusModesUsingLiteralSpace() throws {
+        #expect(!EditorNSView.statusModeUsesLiteralSpace(statusMode: nil))
+        #expect(!EditorNSView.statusModeUsesLiteralSpace(statusMode: 0))
+        #expect(EditorNSView.statusModeUsesLiteralSpace(statusMode: 1))
+        #expect(!EditorNSView.statusModeUsesLiteralSpace(statusMode: 2))
+        #expect(EditorNSView.statusModeUsesLiteralSpace(statusMode: 3))
+        #expect(!EditorNSView.statusModeUsesLiteralSpace(statusMode: 4))
+        #expect(EditorNSView.statusModeUsesLiteralSpace(statusMode: 5))
+        #expect(EditorNSView.statusModeUsesLiteralSpace(statusMode: 6))
+    }
+
+    @Test("Vim normal insert-entering keys use optimistic text input mode")
+    func optimisticTextInputModeKeys() throws {
+        let insertKeys: [(String, UInt32)] = [
+            ("i", 0x69), ("I", 0x49), ("a", 0x61), ("A", 0x41), ("o", 0x6F),
+            ("O", 0x4F), ("s", 0x73), ("S", 0x53), ("C", 0x43), ("R", 0x52)
+        ]
+
+        for (key, scalar) in insertKeys {
+            #expect(EditorNSView.shouldOptimisticallyEnterTextInputMode(codepoint: scalar, statusMode: 0, cursorShape: .block), "\(key) should predict text input mode")
+        }
+
+        #expect(!EditorNSView.shouldOptimisticallyEnterTextInputMode(codepoint: UnicodeScalar("x").value, statusMode: 0, cursorShape: .block))
+        #expect(!EditorNSView.shouldOptimisticallyEnterTextInputMode(codepoint: UnicodeScalar(" ").value, statusMode: 0, cursorShape: .block))
+        #expect(!EditorNSView.shouldOptimisticallyEnterTextInputMode(codepoint: UnicodeScalar("s").value, statusMode: 0, cursorShape: .beam))
+        #expect(!EditorNSView.shouldOptimisticallyEnterTextInputMode(codepoint: UnicodeScalar("i").value, statusMode: 1, cursorShape: .beam))
+        #expect(!EditorNSView.shouldOptimisticallyEnterTextInputMode(codepoint: UnicodeScalar("i").value, statusMode: nil, cursorShape: .block))
+    }
+
     // MARK: - Control key bypass
 
     @Test("Ctrl+A sends character codepoint with control modifier")

--- a/test/minga/lsp/sync_server_test.exs
+++ b/test/minga/lsp/sync_server_test.exs
@@ -64,7 +64,7 @@ defmodule Minga.LSP.SyncServerTest do
 
     test "buffer_closed cleans up ETS entries" do
       buf =
-        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/cleanup.ex"})
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/cleanup.txt"})
 
       # Manually insert a fake entry to simulate an open buffer with clients.
       :ets.insert(SyncServer.Registry, {buf, [self()]})
@@ -72,7 +72,7 @@ defmodule Minga.LSP.SyncServerTest do
 
       Events.broadcast(
         :buffer_closed,
-        %Events.BufferClosedEvent{buffer: buf, path: "/tmp/cleanup.ex"}
+        %Events.BufferClosedEvent{buffer: buf, path: "/tmp/cleanup.txt"}
       )
 
       # Sync call to flush.
@@ -96,7 +96,7 @@ defmodule Minga.LSP.SyncServerTest do
 
     test "schedules debounced didChange" do
       buf =
-        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/debounce.ex"})
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/debounce.txt"})
 
       # Insert a fake client entry.
       :ets.insert(SyncServer.Registry, {buf, [self()]})
@@ -115,7 +115,7 @@ defmodule Minga.LSP.SyncServerTest do
 
     test "accumulates deltas from events" do
       buf =
-        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/accum.ex"})
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/accum.txt"})
 
       delta = Minga.Buffer.EditDelta.insertion(0, {0, 0}, "x", {0, 1})
 
@@ -138,7 +138,7 @@ defmodule Minga.LSP.SyncServerTest do
     end
 
     test "ignores changes for remote buffers without LSP clients" do
-      path = "/tmp/remote-no-lsp.ex"
+      path = "/tmp/remote-no-lsp.txt"
       buf = start_supervised!({BufferServer, file_path: path, storage: {:remote, node(), path}})
       delta = Minga.Buffer.EditDelta.insertion(0, {0, 0}, "x", {0, 1})
 
@@ -159,7 +159,7 @@ defmodule Minga.LSP.SyncServerTest do
 
     test "nil delta marks accumulator as full_sync" do
       buf =
-        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/fullsync.ex"})
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/fullsync.txt"})
 
       delta = Minga.Buffer.EditDelta.insertion(0, {0, 0}, "x", {0, 1})
       :ets.insert(SyncServer.Registry, {buf, [self()]})
@@ -196,7 +196,7 @@ defmodule Minga.LSP.SyncServerTest do
   describe "client monitoring" do
     test "crashed client is removed from ETS registry" do
       buf =
-        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/monitor.ex"})
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/monitor.txt"})
 
       client = spawn(fn -> receive do: (_ -> :ok) end)
       :ets.insert(SyncServer.Registry, {buf, [client]})
@@ -222,7 +222,7 @@ defmodule Minga.LSP.SyncServerTest do
 
     test "crashed client is removed but other clients for same buffer remain" do
       buf =
-        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/multi.ex"})
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/multi.txt"})
 
       doomed = spawn(fn -> receive do: (_ -> :ok) end)
       survivor = spawn(fn -> receive do: (_ -> :ok) end)
@@ -247,7 +247,7 @@ defmodule Minga.LSP.SyncServerTest do
 
     test "no stale monitors remain after buffer_closed" do
       buf =
-        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/close_mon.ex"})
+        start_supervised!({BufferServer, content: "hello", file_path: "/tmp/close_mon.txt"})
 
       client = spawn(fn -> receive do: (_ -> :ok) end)
 
@@ -262,11 +262,14 @@ defmodule Minga.LSP.SyncServerTest do
 
       Events.broadcast(
         :buffer_closed,
-        %Events.BufferClosedEvent{buffer: buf, path: "/tmp/close_mon.ex"}
+        %Events.BufferClosedEvent{buffer: buf, path: "/tmp/close_mon.txt"}
       )
 
       final_state = :sys.get_state(SyncServer)
-      assert final_state.client_monitors == %{}
+
+      refute Enum.any?(final_state.client_monitors, fn {_ref, {buffer_pid, _client_pid}} ->
+               buffer_pid == buf
+             end)
     end
   end
 end

--- a/test/minga_agent/tools/lsp_workspace_symbols_test.exs
+++ b/test/minga_agent/tools/lsp_workspace_symbols_test.exs
@@ -1,7 +1,15 @@
 defmodule MingaAgent.Tools.LspWorkspaceSymbolsTest do
-  use ExUnit.Case, async: true
+  # Uses the global LSP supervisor to verify the no-active-server fallback.
+  use ExUnit.Case, async: false
 
+  alias Minga.Test.LspIsolation
   alias MingaAgent.Tools.LspWorkspaceSymbols
+
+  setup do
+    LspIsolation.stop_lsp_clients()
+    on_exit(&LspIsolation.stop_lsp_clients/0)
+    :ok
+  end
 
   describe "execute/1 without running LSP servers" do
     test "returns helpful message when no LSP servers are running" do

--- a/test/minga_editor/agent/view/dashboard_renderer_test.exs
+++ b/test/minga_editor/agent/view/dashboard_renderer_test.exs
@@ -1,6 +1,8 @@
 defmodule MingaEditor.Agent.View.DashboardRendererTest do
-  use ExUnit.Case, async: true
+  # Uses the global LSP supervisor because dashboard render input includes active LSP names.
+  use ExUnit.Case, async: false
 
+  alias Minga.Test.LspIsolation
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.View.DashboardRenderer
   alias MingaEditor.Agent.ViewContext
@@ -14,6 +16,12 @@ defmodule MingaEditor.Agent.View.DashboardRendererTest do
   alias MingaEditor.VimState
   alias MingaEditor.Input
   alias MingaEditor.UI.Theme
+
+  setup do
+    LspIsolation.stop_lsp_clients()
+    on_exit(&LspIsolation.stop_lsp_clients/0)
+    :ok
+  end
 
   defp base_state(opts \\ []) do
     rows = Keyword.get(opts, :rows, 40)

--- a/test/minga_editor/commands/editing_test.exs
+++ b/test/minga_editor/commands/editing_test.exs
@@ -2,20 +2,31 @@ defmodule MingaEditor.Commands.EditingTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Config.Options
+  alias Minga.Keymap.Active, as: KeymapActive
   alias MingaEditor
 
   defp start_editor(content) do
-    {:ok, buffer} = BufferServer.start_link(content: content)
+    id = :erlang.unique_integer([:positive])
+    events_registry = :"editing_test_events_#{id}"
+    {:ok, _events} = Registry.start_link(keys: :duplicate, name: events_registry)
+    {:ok, options_server} = Options.start_link(name: nil)
+    {:ok, _} = Options.set(options_server, :clipboard, :none)
+    {:ok, keymap_server} = KeymapActive.start_link(name: nil)
+    {:ok, buffer} = BufferServer.start_link(content: content, events_registry: events_registry)
     BufferServer.set_option(buffer, :clipboard, :none)
 
     {:ok, editor} =
       MingaEditor.start_link(
-        name: :"editor_#{:erlang.unique_integer([:positive])}",
+        name: :"editor_#{id}",
         port_manager: nil,
         buffer: buffer,
         width: 40,
         height: 10,
-        editing_model: :vim
+        editing_model: :vim,
+        events_registry: events_registry,
+        keymap_server: keymap_server,
+        options_server: options_server
       )
 
     {editor, buffer}

--- a/test/minga_editor/commands/lsp_test.exs
+++ b/test/minga_editor/commands/lsp_test.exs
@@ -1,9 +1,17 @@
 defmodule MingaEditor.Commands.LspTest do
-  use ExUnit.Case, async: true
+  # Uses the global LSP supervisor to exercise command behavior with no active clients.
+  use ExUnit.Case, async: false
 
+  alias Minga.Test.LspIsolation
   alias MingaEditor.Commands.Lsp, as: LspCommands
 
   import MingaEditor.RenderPipeline.TestHelpers
+
+  setup do
+    LspIsolation.stop_lsp_clients()
+    on_exit(&LspIsolation.stop_lsp_clients/0)
+    :ok
+  end
 
   describe "execute/2 :lsp_info" do
     test "shows 'no language servers running' when none active" do

--- a/test/minga_editor/config_completion_integration_test.exs
+++ b/test/minga_editor/config_completion_integration_test.exs
@@ -1,0 +1,38 @@
+defmodule MingaEditor.ConfigCompletionIntegrationTest do
+  use Minga.Test.EditorCase, async: true
+
+  alias MingaEditor.State.ModalOverlay
+
+  @moduletag :tmp_dir
+
+  describe "config DSL completion" do
+    test "typing set colon in insert mode opens option completion", %{tmp_dir: tmp_dir} do
+      ctx = start_editor("", file_path: tmp_project_config_path(tmp_dir))
+
+      state = send_keys_sync(ctx, "iset :")
+      completion = ModalOverlay.completion(state)
+
+      assert completion != nil
+      assert Enum.any?(completion.filtered, fn item -> item.label == ":tab_width" end)
+      assert completion.filter_text == ""
+    end
+
+    test "typing set colon in cua mode opens option completion", %{tmp_dir: tmp_dir} do
+      ctx = start_editor("", file_path: tmp_project_config_path(tmp_dir), editing_model: :cua)
+
+      state = send_keys_sync(ctx, "set :")
+      completion = ModalOverlay.completion(state)
+
+      assert completion != nil
+      assert Enum.any?(completion.filtered, fn item -> item.label == ":tab_width" end)
+      assert completion.filter_text == ""
+    end
+  end
+
+  @spec tmp_project_config_path(String.t()) :: String.t()
+  defp tmp_project_config_path(tmp_dir) do
+    path = Path.join(tmp_dir, ".minga.exs")
+    File.write!(path, "")
+    path
+  end
+end

--- a/test/minga_editor/integration/agent_cursor_test.exs
+++ b/test/minga_editor/integration/agent_cursor_test.exs
@@ -12,6 +12,8 @@ defmodule Minga.Integration.AgentCursorTest do
 
   alias MingaEditor.Agent.BufferSync, as: AgentBufferSync
   alias Minga.Buffer.Server, as: BufferServer
+  alias Minga.Config.Options
+  alias Minga.Keymap.Active, as: KeymapActive
   alias MingaEditor
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
@@ -28,13 +30,25 @@ defmodule Minga.Integration.AgentCursorTest do
     width = Keyword.get(opts, :width, 80)
     height = Keyword.get(opts, :height, 24)
     id = :erlang.unique_integer([:positive])
+    events_registry = :"agent_cursor_events_#{id}"
+    {:ok, _events} = Registry.start_link(keys: :duplicate, name: events_registry)
+    {:ok, options_server} = Options.start_link(name: nil)
+    {:ok, _} = Options.set(options_server, :clipboard, :none)
+    {:ok, keymap_server} = KeymapActive.start_link(name: nil)
 
     {:ok, port} = HeadlessPort.start_link(width: width, height: height)
 
     agent_buf = AgentBufferSync.start_buffer()
     assert is_pid(agent_buf), "Failed to start agent buffer"
 
-    {:ok, file_buf} = BufferServer.start_link(content: "", buffer_name: "unnamed")
+    {:ok, file_buf} =
+      BufferServer.start_link(
+        content: "",
+        buffer_name: "unnamed",
+        events_registry: events_registry
+      )
+
+    BufferServer.set_option(file_buf, :clipboard, :none)
 
     {:ok, editor} =
       MingaEditor.start_link(
@@ -43,7 +57,10 @@ defmodule Minga.Integration.AgentCursorTest do
         buffer: file_buf,
         width: width,
         height: height,
-        editing_model: :vim
+        editing_model: :vim,
+        events_registry: events_registry,
+        keymap_server: keymap_server,
+        options_server: options_server
       )
 
     {:ok, fake_session} = StubServer.start_link()

--- a/test/minga_editor/ui/picker/file_source_test.exs
+++ b/test/minga_editor/ui/picker/file_source_test.exs
@@ -21,7 +21,7 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
 
   test "on_select opens project-relative paths from the project root and records the selection",
        %{tmp_dir: tmp_dir} do
-    project = Path.join(tmp_dir, "frecency_select_project")
+    project = Path.join(tmp_dir, "frecency_select_project_#{:erlang.unique_integer([:positive])}")
     lib = Path.join(project, "lib")
     File.mkdir_p!(lib)
     File.write!(Path.join(project, "mix.exs"), "")
@@ -43,7 +43,9 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
   end
 
   test "preview selections do not record frecency until confirmed", %{tmp_dir: tmp_dir} do
-    project = Path.join(tmp_dir, "frecency_preview_project")
+    project =
+      Path.join(tmp_dir, "frecency_preview_project_#{:erlang.unique_integer([:positive])}")
+
     lib = Path.join(project, "lib")
     File.mkdir_p!(lib)
     File.write!(Path.join(project, "mix.exs"), "")
@@ -66,7 +68,7 @@ defmodule MingaEditor.UI.Picker.FileSourceTest do
   end
 
   test "files opened more often rank above files opened once", %{tmp_dir: tmp_dir} do
-    project = Path.join(tmp_dir, "frecency_picker_project")
+    project = Path.join(tmp_dir, "frecency_picker_project_#{:erlang.unique_integer([:positive])}")
     lib = Path.join(project, "lib")
     File.mkdir_p!(lib)
     File.write!(Path.join(project, "mix.exs"), "")

--- a/test/support/lsp_isolation.ex
+++ b/test/support/lsp_isolation.ex
@@ -1,0 +1,16 @@
+defmodule Minga.Test.LspIsolation do
+  @moduledoc false
+
+  alias Minga.LSP.Supervisor, as: LSPSupervisor
+
+  @spec stop_lsp_clients() :: :ok
+  def stop_lsp_clients do
+    for pid <- LSPSupervisor.all_clients() do
+      DynamicSupervisor.terminate_child(LSPSupervisor, pid)
+    end
+
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+end


### PR DESCRIPTION
# TL;DR
Fixes a macOS GUI input race where typing immediately after entering insert mode could treat the first space as a Space-leader chord. Fast `i` then `set :` now reaches the BEAM as literal text, so config option completion can open.

## Context
The config completion backend already detects `set :` in Minga config files. The failure was in the macOS frontend input path: the Swift side can still have the previous NORMAL status for a brief moment after sending `i`, so the Space-leader chord logic could intercept the space before the status bar update confirmed text input.

## Changes
- Adds a short-lived optimistic text-input prediction in `EditorNSView` after Vim-normal keys that immediately enter insert-like input.
- Gates that prediction on NORMAL status plus block cursor shape so CUA mode keeps its Space-leader chord behavior.
- Treats confirmed insert, command, search, and replace modes as literal-space modes so the frontend does not run leader-chord detection while the BEAM is already in text input.
- Clears stale optimistic prediction when the authoritative status mode changes back out of text input.
- Adds Swift keyboard tests for literal-space modes, optimistic prediction, and negative cases.
- Adds editor integration coverage that `set :` opens config option completion in Vim insert mode and CUA mode.
- Isolates test helpers that touched global clipboard, LSP supervisor, project frecency, and event state so CI does not depend on local tool availability or persisted test state.

## Verification
- `mix test.debug test/minga_editor/ui/picker/file_source_test.exs test/minga/lsp/sync_server_test.exs` passed: 15 tests, 0 failures.
- `mix test.debug test/minga_editor/commands/lsp_test.exs test/minga_editor/agent/view/dashboard_renderer_test.exs test/minga_agent/tools/lsp_workspace_symbols_test.exs test/minga/lsp/sync_server_test.exs` passed: 25 tests, 0 failures.
- `mix test.llm` passed: 54 doctests, 97 properties, 8509 tests, 0 failures, 5 skipped, 118 excluded.
- `make lint` passed.
- `mix swift.build` passed.
- `cd macos && xcodebuild test -project Minga.xcodeproj -scheme Minga -destination 'platform=macOS' -only-testing:MingaTests/KeyboardInputTests` passed: 16 tests.
- `git diff --check` passed.

## Acceptance Criteria Addressed
- Typing `set :` while editing a config file can open config option completion. ✅
- Fast typing immediately after entering insert-like input preserves literal spaces in the macOS frontend. ✅
- CUA Space-leader behavior is not disabled by ordinary printable keys. ✅
- Confirmed command, search, and replace modes do not run Space-leader chord detection for spaces. ✅
