### PR TITLE
File-tree renderers share semantic rows

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,12 @@
 import Config
 
+# Keep tests hermetic by preventing application startup from loading the developer's real ~/.config/minga/config.exs.
+test_config_home =
+  Path.join(System.tmp_dir!(), "minga-test-config-#{System.unique_integer([:positive])}")
+
+File.mkdir_p!(Path.join(test_config_home, "minga"))
+System.put_env("XDG_CONFIG_HOME", test_config_home)
+
 # Only show warnings and errors during test runs. Info-level messages
 # from app startup (extension loading, grammar registration) would
 # otherwise pollute test output before ExUnit's capture_log kicks in.

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -10,7 +10,7 @@ Minga's rendering pipeline produces two types of output:
 
 1. **Cell-grid commands** (opcodes 0x10-0x1B): draw_text, set_cursor, clear, batch_end, etc. These paint the editor content surface (buffer text, gutter, modeline for splits, minibuffer). In a TUI frontend, these go to the terminal. In a GUI frontend, these go to a Metal/OpenGL surface.
 
-2. **GUI chrome commands** (opcodes 0x70-0x7F): structured data for native chrome elements (tab bar, file tree sidebar, status bar, bottom panel, which-key popup, cursorline, gutter, etc.). These are sent only to GUI frontends. A TUI frontend never sees them.
+2. **GUI chrome commands** (opcodes 0x70+): structured data for native chrome elements (tab bar, file tree sidebar, status bar, bottom panel, which-key popup, cursorline, gutter, etc.). These are sent only to GUI frontends. A TUI frontend never sees them.
 
 Both types are sent within the same render cycle. The BEAM sends cell-grid commands first (one `{:packet, 4}` message containing clear through batch_end), then GUI chrome commands as separate `{:packet, 4}` messages immediately after. GUI chrome commands are not inside the batch_end-terminated cell-grid frame.
 
@@ -35,11 +35,11 @@ The BEAM checks `Capabilities.gui?` (true when `frontend_type == :native_gui`) t
 
 ## GUI Render Opcodes (BEAM → Frontend)
 
-GUI chrome opcodes live in the range 0x70-0x7F. GUI content opcodes (semantic buffer rendering, overlays) start at 0x80. Frontends can classify an opcode as GUI by checking `opcode >= 0x70`.
+GUI chrome opcodes start at 0x70. Older positional commands live in 0x70-0x8F, and newer forward-compatible commands live in 0x90+. GUI content opcodes (semantic buffer rendering, overlays) start at 0x80. Frontends can classify an opcode as GUI by checking `opcode >= 0x70`.
 
 ### Forward-Compatible Opcodes (0x90+)
 
-All opcodes at 0x90 and above use a length-prefixed envelope:
+Most opcodes at 0x90 and above use a 16-bit length-prefixed envelope:
 
 ```
 opcode(1) + payload_length(2, big-endian) + payload(payload_length)
@@ -47,45 +47,54 @@ opcode(1) + payload_length(2, big-endian) + payload(payload_length)
 
 This allows old frontends to skip unknown opcodes without crashing. When a frontend encounters an unrecognized opcode >= 0x90, it reads the 2-byte length, advances past the payload, and continues decoding the rest of the batch.
 
-Opcodes below 0x90 do NOT include a length prefix and retain their existing positional wire format. If a frontend encounters an unknown opcode below 0x90, it cannot determine the message size and must abort decoding.
+Opcodes below 0x90 do NOT include a length prefix and retain their existing positional wire format. If a frontend encounters an unknown opcode below 0x90, it cannot determine the message size and must abort decoding. Known 0x90+ opcodes may document a wider envelope when the payload can exceed 64KB, as `gui_file_tree` does.
 
-The BEAM-side encoder must use this envelope for all new opcodes (0x90+). Currently defined 0x90+ opcodes:
+The BEAM-side encoder must use a documented length-prefixed envelope for all new opcodes (0x90+). Currently defined 0x90+ opcodes:
 
 | Opcode | Name | Description |
 |--------|------|-------------|
 | 0x90 | clipboard_write | Write text to the system clipboard |
 | 0x91 | gui_indent_guides | Indent guide positions per window |
 | 0x92 | gui_line_spacing | Line spacing multiplier for the renderer |
+| 0x93 | gui_file_tree | Semantic file tree rows for the native sidebar view. Uses a 32-bit payload length because expanded project trees can exceed 64KB. |
 | 0x96 | gui_hover_action | Optional action metadata for the hover popup |
 
-### 0x70 — gui_file_tree
+### 0x93 — gui_file_tree
 
-File tree sidebar entries for the native sidebar view.
+The native file tree receives the same semantic row model that the TUI renderer uses. The BEAM remains the source of truth for row identity, depth, selected/focused state, expansion state, git status, diagnostics, guide columns, icons, labels, and inline editing state. Swift should render this state directly and send user actions back through the existing file-tree action opcodes.
 
 ```
-opcode(1) + selected_index(2) + tree_width(2) + entry_count(2) + root_len(2) + root(root_len) + entries...
+opcode(1) + payload_len(4) + payload(payload_len)
 
-Per entry:
-  path_hash(4) + flags(1) + depth(1) + git_status(1) + icon_len(1) + icon(icon_len) + name_len(2) + name(name_len) + rel_path_len(2) + rel_path(rel_path_len)
+Payload:
+  version(1) + tree_flags(1) + selected_id_len(2) + selected_id(selected_id_len) + root_len(2) + root(root_len) + tree_width(2) + row_count(2) + rows...
 
-Root: absolute project root path, sent once in the header.
+Per row:
+  path_hash(4) + row_flags(2) + depth(1) + git_status(1) + diagnostic_error_count(2) + diagnostic_warning_count(2) + diagnostic_info_count(2) + diagnostic_hint_count(2) + guide_count(1) + guides(guide_count) + id_len(2) + id(id_len) + path_len(2) + path(path_len) + rel_path_len(2) + rel_path(rel_path_len) + name_len(2) + name(name_len) + icon_len(1) + icon(icon_len) + editing_type(1) + editing_text_len(2) + editing_text(editing_text_len)
 
-Path hash: erlang:phash2 of the full file path, mod 2^32. Stable across tree
-updates so GUI frontends can use it as a persistent view identity for diffing.
+Tree flag bits:
+  bit 0: visible
+  bit 1: focused
+  bit 4: empty
 
-Rel path: path relative to root (e.g., "lib/minga/editor.ex"). GUI computes
-full path as root + "/" + rel_path for context menu actions.
-
-Flags bits:
+Row flag bits:
   bit 0: is_dir
-  bit 1: is_expanded (only meaningful when is_dir)
+  bit 1: is_expanded
   bit 2: is_selected
+  bit 3: is_focused
+  bit 4: is_active
+  bit 5: is_dirty
+  bit 6: is_editing
+  bit 7: is_last_child
 
 Git status values:
-  0 = none, 1 = modified, 2 = staged, 3 = untracked, 4 = conflict, 5 = ignored
+  0 = none, 1 = modified, 2 = staged, 3 = untracked, 4 = conflict, 5 = renamed, 6 = deleted
+
+Editing type values:
+  0 = new_file, 1 = new_folder, 2 = rename, 255 = none
 ```
 
-When `entry_count == 0`, the file tree should be hidden.
+When `visible` is false, the frontend should hide the file tree. Hidden payloads still include the root path when the BEAM knows it, so Swift can preserve context while clearing visible rows.
 
 ### 0x71 — gui_tab_bar
 
@@ -904,29 +913,30 @@ Mode color slots fall back to `modeline.bar_fg` / `modeline.bar_bg` when a mode 
 
 ## Forward-Compatibility: Skip-Length for Unknown Opcodes
 
-All new opcodes >= 0x90 use a mandatory 2-byte big-endian length prefix after the opcode byte:
+Standard new opcodes >= 0x90 use a 2-byte big-endian length prefix after the opcode byte:
 
 ```
 <<opcode::8, payload_length::16-big, payload::binary-size(payload_length)>>
 ```
 
-This allows older frontends to skip unknown opcodes gracefully without crashing. When a decoder encounters an opcode >= 0x90 that it doesn't recognize, it:
+This allows older frontends to skip unknown standard-envelope opcodes gracefully without crashing. When a decoder encounters an opcode >= 0x90 that it doesn't recognize, it:
 
 1. Reads the 2-byte length field
 2. Skips `length` bytes forward
 3. Continues decoding the next command
 
-For opcodes < 0x90 that are unknown, the decoder must throw an error (it cannot determine the payload size).
+For opcodes < 0x90 that are unknown, the decoder must throw an error (it cannot determine the payload size). Known opcodes may document a wider envelope when the payload can exceed 64KB. `gui_file_tree` (0x93) is one of those exceptions and uses a 4-byte length field.
 
-**Example:** A BEAM running version 0.3.0 introduces a new `OP_GUI_NEW_FEATURE = 0x91`. A macOS frontend running 0.2.0 receives this opcode. Because 0x91 >= 0x90, it reads the length prefix, skips that many bytes, and continues. The frontend remains functional even though it doesn't render the new feature.
+**Example:** A BEAM running version 0.3.0 introduces a new `OP_GUI_NEW_FEATURE = 0x91`. A macOS frontend running 0.2.0 receives this opcode. Because 0x91 >= 0x90 and uses the standard envelope, it reads the length prefix, skips that many bytes, and continues. The frontend remains functional even though it doesn't render the new feature.
 
-This convention is enforced on the BEAM side: all new opcodes >= 0x90 must use the length-prefixed encoding. See `lib/minga/frontend/protocol/gui.ex` for the encoder implementation.
+This convention is enforced on the BEAM side: all new opcodes >= 0x90 must use a documented length-prefixed encoding. See `lib/minga_editor/frontend/protocol/gui.ex` for the encoder implementation.
 
 **Current 0x90+ opcodes:**
-- `OP_CLIPBOARD_WRITE (0x90)` — clipboard write command (length-prefixed)
-- `OP_GUI_INDENT_GUIDES (0x91)` — indent guide positions per window (length-prefixed)
-- `OP_GUI_LINE_SPACING (0x92)` — renderer line spacing multiplier (length-prefixed)
-- `OP_GUI_HOVER_ACTION (0x96)` — optional hover popup action metadata (length-prefixed)
+- `OP_CLIPBOARD_WRITE (0x90)` — clipboard write command (16-bit length-prefixed)
+- `OP_GUI_INDENT_GUIDES (0x91)` — indent guide positions per window (16-bit length-prefixed)
+- `OP_GUI_LINE_SPACING (0x92)` — renderer line spacing multiplier (16-bit length-prefixed)
+- `OP_GUI_FILE_TREE (0x93)` — semantic file tree rows (32-bit length-prefixed)
+- `OP_GUI_HOVER_ACTION (0x96)` — optional hover popup action metadata (16-bit length-prefixed)
 
 ### 0x96 — gui_hover_action
 
@@ -990,7 +1000,7 @@ A GUI frontend must satisfy these requirements:
 
 4. **Send `gui_action` events for user interactions with chrome.** When a user clicks a tab, selects a completion item, or toggles a panel, encode the action and send it to the BEAM on stdout.
 
-5. **Handle missing opcodes gracefully.** New GUI opcodes may be added in the 0x70-0x8F range. Frontends should skip unknown opcodes rather than crashing. All new opcodes (0x90+) use a length-prefixed envelope (`opcode + payload_length:2 + payload`) so frontends can skip unknown opcodes by reading the length. See "Forward-Compatible Opcodes (0x90+)" above.
+5. **Handle missing opcodes gracefully.** New GUI opcodes may be added in the 0x70-0x8F range. Frontends should skip unknown opcodes rather than crashing. New opcodes in 0x90+ use a documented length-prefixed envelope so frontends can skip unknown standard-envelope opcodes by reading the length. See "Forward-Compatible Opcodes (0x90+)" above.
 
 6. **Process `gui_theme` before rendering other chrome.** The theme command typically arrives early in the first frame. Apply colors before rendering chrome elements to avoid a flash of unstyled content.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -666,7 +666,7 @@ Total size: 4 + msg_len bytes.
 
 ### Current design
 
-Tree-sitter parsing runs in a dedicated `minga-parser` Zig process, separate from the rendering frontend. The renderer process handles only render commands (`0x10`-`0x1B` plus GUI chrome `0x70`-`0x78`). The parser process handles highlight commands (`0x20`-`0x2E`) and sends highlight responses (`0x30`-`0x3C`). Both use the same `{:packet, 4}` framing on their respective stdin/stdout pipes. The BEAM manages both Port processes, routing commands to the appropriate one.
+Tree-sitter parsing runs in a dedicated `minga-parser` Zig process, separate from the rendering frontend. The renderer process handles only render commands (`0x10`-`0x1B` plus GUI chrome `0x70+`). The parser process handles highlight commands (`0x20`-`0x2E`) and sends highlight responses (`0x30`-`0x3C`). Both use the same `{:packet, 4}` framing on their respective stdin/stdout pipes. The BEAM manages both Port processes, routing commands to the appropriate one.
 
 This separation means rendering frontends (Swift/Metal, GTK4, Zig/libvaxis) only need to implement render commands. Tree-sitter parsing is handled by the shared parser process regardless of which frontend is active.
 
@@ -886,7 +886,7 @@ Total size: 7 + (40 + text_len) per edit.
 
 ## GUI Chrome Protocol
 
-Native GUI frontends (SwiftUI, GTK4) receive additional structured data opcodes for chrome elements like tab bars, file trees, status bars, and popups. These opcodes live in the 0x70-0x78 range and are sent only when the frontend reports `frontend_type = native_gui` in its capabilities.
+Native GUI frontends (SwiftUI, GTK4) receive additional structured data opcodes for chrome elements like tab bars, file trees, status bars, and popups. These opcodes start at 0x70 and are sent only when the frontend reports `frontend_type = native_gui` in its capabilities.
 
 See [GUI_PROTOCOL.md](GUI_PROTOCOL.md) for the complete specification of GUI chrome opcodes, gui_action input events, theme color slots, and the behavioral contract for GUI frontends.
 

--- a/docs/protocol_schema.json
+++ b/docs/protocol_schema.json
@@ -46,8 +46,8 @@
       "measure_text":        { "hex": "0x27" }
     },
     "gui_chrome": {
-      "description": "BEAM → GUI-only chrome commands (0x70-0x7F range)",
-      "gui_file_tree":      { "hex": "0x70" },
+      "description": "BEAM → GUI-only chrome commands (0x70+ range)",
+      "gui_file_tree":      { "hex": "0x93" },
       "gui_tab_bar":        { "hex": "0x71" },
       "gui_which_key":      { "hex": "0x72" },
       "gui_completion":     { "hex": "0x73" },

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -53,6 +53,7 @@ defmodule Minga.Config.Options do
           | :insert_final_newline
           | :format_on_save
           | :auto_save_delay_ms
+          | :lsp_auto_start
           | :formatter
           | :title_format
           | :recent_files_limit
@@ -216,6 +217,8 @@ defmodule Minga.Config.Options do
     {:format_on_save, :boolean, false, "Whether the configured formatter runs before saving."},
     {:auto_save_delay_ms, :non_neg_integer, 1000,
      "Delay before automatic save work runs; zero disables the timer."},
+    {:lsp_auto_start, :boolean, true,
+     "Whether buffer-open events automatically start configured language servers."},
     {:formatter, :string_or_nil, nil, "External formatter command for the current buffer."},
     {:title_format, :string, "{filename} {dirty}({directory}) - Minga",
      "Window title template with placeholder tokens."},

--- a/lib/minga/lsp/sync_server.ex
+++ b/lib/minga/lsp/sync_server.ex
@@ -29,6 +29,7 @@ defmodule Minga.LSP.SyncServer do
   use GenServer
 
   alias Minga.Buffer
+  alias Minga.Config.Options
   alias Minga.Events
   alias Minga.Events.ToolMissingEvent
   alias Minga.LSP.Client
@@ -220,6 +221,15 @@ defmodule Minga.LSP.SyncServer do
 
   @spec open_local_buffer(state(), pid()) :: state()
   defp open_local_buffer(state, buffer_pid) do
+    if lsp_auto_start?() do
+      do_open_local_buffer(state, buffer_pid)
+    else
+      state
+    end
+  end
+
+  @spec do_open_local_buffer(state(), pid()) :: state()
+  defp do_open_local_buffer(state, buffer_pid) do
     filetype = Buffer.filetype(buffer_pid)
     file_path = Buffer.file_path(buffer_pid)
 
@@ -264,6 +274,13 @@ defmodule Minga.LSP.SyncServer do
     _ -> state
   catch
     :exit, _ -> state
+  end
+
+  @spec lsp_auto_start?() :: boolean()
+  defp lsp_auto_start? do
+    Options.get(:lsp_auto_start)
+  catch
+    :exit, _ -> true
   end
 
   @spec remote_buffer?(pid()) :: boolean()

--- a/lib/minga/project/file_tree.ex
+++ b/lib/minga/project/file_tree.ex
@@ -81,6 +81,14 @@ defmodule Minga.Project.FileTree do
     %{tree | cursor: min(tree.cursor + 1, max_idx)}
   end
 
+  @doc "Selects the visible entry at the given index, clamped to the current visible range."
+  @spec select(t(), integer()) :: t()
+  def select(%__MODULE__{} = tree, index) when is_integer(index) do
+    tree = ensure_entries(tree)
+    max_idx = max(length(tree.entries) - 1, 0)
+    %{tree | cursor: index |> max(0) |> min(max_idx)}
+  end
+
   # ── Expand / Collapse ─────────────────────────────────────────────────────
 
   @doc """
@@ -148,6 +156,12 @@ defmodule Minga.Project.FileTree do
       _ ->
         cached
     end
+  end
+
+  @doc "Marks a directory path as expanded and invalidates cached entries."
+  @spec expand_path(t(), String.t()) :: t()
+  def expand_path(%__MODULE__{} = tree, path) when is_binary(path) do
+    invalidate_entries(%{tree | expanded: MapSet.put(tree.expanded, Path.expand(path))})
   end
 
   @spec expand_or_enter(t(), String.t()) :: t()

--- a/lib/minga_editor/file_tree/row.ex
+++ b/lib/minga_editor/file_tree/row.ex
@@ -1,0 +1,66 @@
+defmodule MingaEditor.FileTree.Row do
+  @moduledoc """
+  Semantic presentation row for file-tree renderers.
+
+  This Layer 2 contract keeps filesystem topology in `Minga.Project.FileTree` while collecting the editor-owned visual state that TUI and GUI renderers need to present the same meaning.
+  """
+
+  alias Minga.Project.FileTree
+  alias Minga.Project.FileTree.GitStatus
+  alias MingaEditor.State.FileTree, as: FileTreeState
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          path: String.t(),
+          relative_path: String.t(),
+          name: String.t(),
+          directory?: boolean(),
+          expanded?: boolean(),
+          selected?: boolean(),
+          focused?: boolean(),
+          active?: boolean(),
+          dirty?: boolean(),
+          git_status: GitStatus.file_status() | nil,
+          depth: non_neg_integer(),
+          guides: [boolean()],
+          last_child?: boolean(),
+          editing: FileTreeState.editing() | nil
+        }
+
+  @enforce_keys [
+    :id,
+    :path,
+    :relative_path,
+    :name,
+    :directory?,
+    :expanded?,
+    :depth,
+    :guides,
+    :last_child?
+  ]
+  defstruct id: nil,
+            path: nil,
+            relative_path: nil,
+            name: nil,
+            directory?: false,
+            expanded?: false,
+            selected?: false,
+            focused?: false,
+            active?: false,
+            dirty?: false,
+            git_status: nil,
+            depth: 0,
+            guides: [],
+            last_child?: false,
+            editing: nil
+
+  @doc "Constructs a semantic file-tree row."
+  @spec new(keyword()) :: t()
+  def new(attrs) when is_list(attrs) do
+    struct!(__MODULE__, attrs)
+  end
+
+  @doc "Builds a stable row identity for a file-tree entry."
+  @spec id_for(FileTree.entry()) :: String.t()
+  def id_for(%{path: path}), do: Path.expand(path)
+end

--- a/lib/minga_editor/file_tree/rows.ex
+++ b/lib/minga_editor/file_tree/rows.ex
@@ -1,0 +1,138 @@
+defmodule MingaEditor.FileTree.Rows do
+  @moduledoc """
+  Builds semantic file-tree rows from pure tree data and editor state.
+
+  `Minga.Project.FileTree` owns filesystem topology. This module adds Layer 2 presentation semantics such as selection, focus, active file, dirty buffers, git status, and inline editing.
+  """
+
+  alias Minga.Buffer
+  alias Minga.Project.FileTree
+  alias Minga.Project.FileTree.GitStatus
+  alias MingaEditor.FileTree.Row
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
+
+  @type options :: [
+          selected_index: non_neg_integer(),
+          focused: boolean(),
+          active_path: String.t() | nil,
+          dirty_paths: MapSet.t(String.t()),
+          git_status: GitStatus.status_map(),
+          editing: FileTreeState.editing() | nil
+        ]
+
+  @doc "Builds semantic rows from a pure file tree and explicit presentation inputs."
+  @spec from_tree(FileTree.t(), options()) :: [Row.t()]
+  def from_tree(%FileTree{} = tree, opts \\ []) do
+    git_status = Keyword.get(opts, :git_status, tree.git_status)
+    dirty_paths = Keyword.get(opts, :dirty_paths, MapSet.new())
+    active_path = opts |> Keyword.get(:active_path) |> expand_optional_path()
+    selected_index = Keyword.get(opts, :selected_index, tree.cursor)
+    focused = Keyword.get(opts, :focused, false)
+    editing = Keyword.get(opts, :editing)
+
+    tree
+    |> FileTree.visible_entries()
+    |> Enum.with_index()
+    |> Enum.map(fn {entry, index} ->
+      row_from_entry(entry, index, tree, %{
+        active_path: active_path,
+        dirty_paths: dirty_paths,
+        editing: editing,
+        focused: focused,
+        git_status: git_status,
+        selected_index: selected_index
+      })
+    end)
+  end
+
+  @doc "Builds semantic rows from editor state when the file tree is open."
+  @spec from_state(EditorState.t() | map()) :: [Row.t()]
+  def from_state(%{workspace: %{file_tree: %{tree: nil}}}), do: []
+
+  def from_state(%{workspace: %{file_tree: %{tree: %FileTree{} = tree} = file_tree}} = state) do
+    from_tree(tree,
+      active_path: active_buffer_path(state),
+      dirty_paths: dirty_paths(state),
+      editing: Map.get(file_tree, :editing),
+      focused: Map.get(file_tree, :focused, false),
+      git_status: tree.git_status,
+      selected_index: tree.cursor
+    )
+  end
+
+  def from_state(_state), do: []
+
+  @spec row_from_entry(FileTree.entry(), non_neg_integer(), FileTree.t(), map()) :: Row.t()
+  defp row_from_entry(entry, index, tree, opts) do
+    path = Path.expand(entry.path)
+
+    Row.new(
+      id: Row.id_for(entry),
+      path: path,
+      relative_path: Path.relative_to(path, tree.root),
+      name: entry.name,
+      directory?: entry.dir?,
+      expanded?: entry.dir? and MapSet.member?(tree.expanded, path),
+      selected?: index == opts.selected_index,
+      focused?: opts.focused,
+      active?: active?(path, opts.active_path),
+      dirty?: dirty?(entry, path, opts.dirty_paths),
+      git_status: Map.get(opts.git_status, path),
+      depth: entry.depth,
+      guides: entry.guides,
+      last_child?: entry.last_child?,
+      editing: editing_for_index(index, opts.editing)
+    )
+  end
+
+  @spec active?(String.t(), String.t() | nil) :: boolean()
+  defp active?(_path, nil), do: false
+  defp active?(path, active_path), do: path == active_path
+
+  @spec dirty?(FileTree.entry(), String.t(), MapSet.t(String.t())) :: boolean()
+  defp dirty?(%{dir?: true}, _path, _dirty_paths), do: false
+  defp dirty?(_entry, path, dirty_paths), do: MapSet.member?(dirty_paths, path)
+
+  @spec editing_for_index(non_neg_integer(), FileTreeState.editing() | nil) ::
+          FileTreeState.editing() | nil
+  defp editing_for_index(_index, nil), do: nil
+  defp editing_for_index(index, %{index: index} = editing), do: editing
+  defp editing_for_index(_index, _editing), do: nil
+
+  @spec expand_optional_path(String.t() | nil) :: String.t() | nil
+  defp expand_optional_path(nil), do: nil
+  defp expand_optional_path(path), do: Path.expand(path)
+
+  @spec active_buffer_path(EditorState.t() | map()) :: String.t() | nil
+  defp active_buffer_path(%{workspace: %{buffers: %{active: nil}}}), do: nil
+
+  defp active_buffer_path(%{workspace: %{buffers: %{active: buf}}}) do
+    case Buffer.file_path(buf) do
+      nil -> nil
+      path -> Path.expand(path)
+    end
+  end
+
+  defp active_buffer_path(_state), do: nil
+
+  defp dirty_paths(%{workspace: %{buffers: %{list: buffer_list}}}) do
+    buffer_list
+    |> Enum.flat_map(&dirty_buffer_path/1)
+    |> Enum.map(&Path.expand/1)
+    |> MapSet.new()
+  end
+
+  defp dirty_paths(_state), do: MapSet.new()
+
+  @spec dirty_buffer_path(pid()) :: [String.t()]
+  defp dirty_buffer_path(pid) when is_pid(pid) do
+    if Buffer.dirty?(pid), do: present_path(Buffer.file_path(pid)), else: []
+  catch
+    :exit, _ -> []
+  end
+
+  @spec present_path(String.t() | nil) :: [String.t()]
+  defp present_path(nil), do: []
+  defp present_path(path), do: [path]
+end

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -27,6 +27,7 @@ defmodule MingaEditor.Frontend.Emit.GUI do
 
   alias MingaEditor.DisplayList.Frame
   alias MingaEditor.DisplayMap
+  alias MingaEditor.FileTree.Rows
   alias MingaEditor.FoldMap
   alias MingaEditor.Layout
   alias MingaEditor.MinibufferData
@@ -256,13 +257,29 @@ defmodule MingaEditor.Frontend.Emit.GUI do
 
   @spec build_gui_file_tree_cmd(ctx(), Caches.t()) :: {binary() | nil, Caches.t()}
   defp build_gui_file_tree_cmd(
-         %{file_tree: %{tree: %Minga.Project.FileTree{} = tree, editing: editing}},
+         %{file_tree: %{tree: %Minga.Project.FileTree{} = tree} = file_tree} = ctx,
          caches
        ) do
-    fp = :erlang.phash2({tree, editing})
+    rows =
+      Rows.from_tree(tree,
+        active_path: active_buffer_path(ctx),
+        dirty_paths: dirty_paths(ctx.buffers),
+        editing: Map.get(file_tree, :editing),
+        focused: file_tree_focused?(file_tree),
+        git_status: tree.git_status,
+        selected_index: tree.cursor
+      )
+
+    fp = :erlang.phash2({tree.root, tree.width, file_tree_focused?(file_tree), rows})
 
     if fp != caches.last_gui_file_tree_fp do
-      {ProtocolGUI.encode_gui_file_tree(tree, editing), %{caches | last_gui_file_tree_fp: fp}}
+      {ProtocolGUI.encode_gui_file_tree(
+         tree.root,
+         tree.width,
+         true,
+         file_tree_focused?(file_tree),
+         rows
+       ), %{caches | last_gui_file_tree_fp: fp}}
     else
       {nil, caches}
     end
@@ -287,6 +304,30 @@ defmodule MingaEditor.Frontend.Emit.GUI do
       {nil, caches}
     end
   end
+
+  @spec file_tree_focused?(map()) :: boolean()
+  defp file_tree_focused?(file_tree), do: Map.get(file_tree, :focused, false)
+
+  @spec dirty_paths(MingaEditor.State.Buffers.t() | nil) :: MapSet.t(String.t())
+  defp dirty_paths(nil), do: MapSet.new()
+
+  defp dirty_paths(%{list: buffer_list}) do
+    buffer_list
+    |> Enum.flat_map(&dirty_buffer_path/1)
+    |> Enum.map(&Path.expand/1)
+    |> MapSet.new()
+  end
+
+  @spec dirty_buffer_path(pid()) :: [String.t()]
+  defp dirty_buffer_path(pid) when is_pid(pid) do
+    if Buffer.dirty?(pid), do: present_path(Buffer.file_path(pid)), else: []
+  catch
+    :exit, _ -> []
+  end
+
+  @spec present_path(String.t() | nil) :: [String.t()]
+  defp present_path(nil), do: []
+  defp present_path(path), do: [path]
 
   # ── Git status panel ──
 

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -9,11 +9,11 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
   ## GUI Chrome Commands (BEAM → Frontend)
 
-  Contiguous range 0x70-0x7F for easy classification by frontends.
+  GUI chrome opcodes start at 0x70. Newer commands use the 0x90+ length-prefixed envelope so frontends can skip unknown messages.
 
   | Opcode | Name            | Description                    |
   |--------|-----------------|--------------------------------|
-  | 0x70   | gui_file_tree   | File tree entries              |
+  | 0x93   | gui_file_tree   | Semantic file tree state       |
   | 0x71   | gui_tab_bar     | Tab bar with tab entries       |
   | 0x72   | gui_which_key   | Which-key popup bindings       |
   | 0x73   | gui_completion  | Completion popup items         |
@@ -89,6 +89,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   import Bitwise
 
   alias Minga.Buffer
+  alias MingaEditor.FileTree.Row
   alias MingaEditor.MinibufferData
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
@@ -99,9 +100,9 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   alias MingaEditor.UI.Theme.Slots
 
   # ── GUI chrome opcodes (BEAM → Frontend) ──
-  # Contiguous range 0x70-0x7F for easy range-check classification.
+  # GUI chrome opcodes start at 0x70. Opcodes >= 0x90 include a 2-byte length prefix.
 
-  @op_gui_file_tree 0x70
+  @op_gui_file_tree 0x93
   @op_gui_tab_bar 0x71
   @op_gui_which_key 0x72
   @op_gui_completion 0x73
@@ -170,9 +171,10 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   @section_chat_messages 0x06
   @section_chat_completion 0x07
 
-  # ── Forward-compatible opcodes (0x90+, include 2-byte length prefix) ──
-  # New opcodes >= 0x90 start with: opcode(1) + payload_length(2) + payload.
-  # Old frontends skip unknown 0x90+ opcodes by reading the length and
+  # ── Forward-compatible opcodes (0x90+, include a length prefix) ──
+  # Most opcodes >= 0x90 start with: opcode(1) + payload_length(2) + payload.
+  # gui_file_tree uses a 32-bit payload length because expanded project trees can exceed 64KB.
+  # Old frontends skip unknown 0x90+ opcodes by reading the standard 16-bit length and
   # advancing, instead of crashing. See ProtocolDecoder.swift default case.
 
   @op_clipboard_write 0x90
@@ -1007,96 +1009,109 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   # ── File tree ──
 
   @doc """
-  Encodes a gui_file_tree command with the visible file tree entries.
+  Encodes the semantic GUI file-tree command.
 
-  Sends: selected_index, tree_width, entry_count, root_len, root, then per entry:
-  path_hash, flags (is_dir, is_expanded), depth, git_status, icon, name, rel_path.
+  Wire format uses a 32-bit length-prefixed envelope:
+
+      opcode(1) + payload_len(4) + payload(payload_len)
+
+  Payload:
+
+      version(1) + tree_flags(1) + selected_id_len(2) + selected_id + root_len(2) + root + tree_width(2) + row_count(2) + rows...
+
+  Per row:
+
+      stable_hash(4) + row_flags(2) + depth(1) + git_status(1) + diagnostics(8) + guide_count(1) + guides + id + path + rel_path + name + icon + editing_type(1) + editing_text
+
+  String fields use uint16 byte lengths except icon, which uses a uint8 byte length.
   """
-  @spec encode_gui_file_tree(
-          Minga.Project.FileTree.t() | nil,
-          MingaEditor.State.FileTree.editing() | nil
-        ) ::
+  @spec encode_gui_file_tree(String.t() | nil, non_neg_integer(), boolean(), boolean(), [Row.t()]) ::
           binary()
-  def encode_gui_file_tree(tree, editing \\ nil)
+  def encode_gui_file_tree(root_path, tree_width, visible?, focused?, rows) when is_list(rows) do
+    root = root_path || ""
+    selected_id = selected_row_id(rows)
 
-  def encode_gui_file_tree(nil, _editing),
-    do: <<@op_gui_file_tree, 0::16, 0::16, 0::16, 0::16>>
+    payload =
+      IO.iodata_to_binary([
+        <<1::8, file_tree_flags(visible?, focused?, rows)::8>>,
+        encode_string16(selected_id),
+        encode_string16(root),
+        <<tree_width::16, length(rows)::16>>,
+        Enum.map(rows, &encode_file_tree_row/1)
+      ])
 
-  def encode_gui_file_tree(%Minga.Project.FileTree{} = tree, editing) do
-    entries = Minga.Project.FileTree.visible_entries(tree)
-    count = length(entries)
-    root_bytes = :erlang.iolist_to_binary([tree.root])
-
-    entry_binaries =
-      entries
-      |> Enum.with_index()
-      |> Enum.map(fn {entry, index} ->
-        is_editing = editing != nil and index == editing.index
-        encode_file_tree_entry(entry, tree, index == tree.cursor, is_editing, editing)
-      end)
-
-    IO.iodata_to_binary([
-      @op_gui_file_tree,
-      <<tree.cursor::16, tree.width::16, count::16, byte_size(root_bytes)::16,
-        root_bytes::binary>>
-      | entry_binaries
-    ])
+    <<@op_gui_file_tree, byte_size(payload)::32, payload::binary>>
   end
 
-  @doc "Encodes a hidden gui_file_tree command that still carries the project root for shared GUI chrome."
+  @doc "Encodes a hidden semantic GUI file-tree command while preserving the project root."
   @spec encode_hidden_gui_file_tree(String.t() | nil) :: binary()
-  def encode_hidden_gui_file_tree(root_path) when is_binary(root_path) do
-    root_bytes = :erlang.iolist_to_binary([root_path])
-    <<@op_gui_file_tree, 0::16, 0::16, 0::16, byte_size(root_bytes)::16, root_bytes::binary>>
+  def encode_hidden_gui_file_tree(root_path),
+    do: encode_gui_file_tree(root_path, 0, false, false, [])
+
+  @spec encode_file_tree_row(Row.t()) :: iodata()
+  defp encode_file_tree_row(%Row{} = row) do
+    icon = file_tree_row_icon(row)
+    editing_type = if row.editing, do: encode_editing_type(row.editing.type), else: 0xFF
+    editing_text = if row.editing, do: row.editing.text, else: ""
+    guides = Enum.map(row.guides, fn guide? -> if guide?, do: <<1>>, else: <<0>> end)
+
+    [
+      <<:erlang.phash2(row.id, 0xFFFFFFFF)::32, file_tree_row_flags(row)::16, row.depth::8,
+        encode_git_status(row.git_status)::8, 0::16, 0::16, 0::16, 0::16, length(row.guides)::8>>,
+      guides,
+      encode_string16(row.id),
+      encode_string16(row.path),
+      encode_string16(row.relative_path),
+      encode_string16(row.name),
+      encode_string8(icon),
+      <<editing_type::8>>,
+      encode_string16(editing_text)
+    ]
   end
 
-  def encode_hidden_gui_file_tree(nil), do: encode_gui_file_tree(nil)
-
-  @spec encode_file_tree_entry(
-          Minga.Project.FileTree.entry(),
-          Minga.Project.FileTree.t(),
-          boolean(),
-          boolean(),
-          MingaEditor.State.FileTree.editing() | nil
-        ) :: binary()
-  defp encode_file_tree_entry(entry, tree, is_selected?, is_editing, editing) do
-    is_dir = if entry[:dir?], do: 1, else: 0
-    is_expanded = if entry[:dir?] && MapSet.member?(tree.expanded, entry.path), do: 1, else: 0
-    selected_bit = if is_selected?, do: 1, else: 0
-    editing_bit = if is_editing, do: 1, else: 0
-
-    flags =
-      bor(
-        is_dir,
-        bor(bsl(is_expanded, 1), bor(bsl(selected_bit, 2), bsl(editing_bit, 3)))
-      )
-
-    git_status = encode_git_status(Map.get(tree.git_status, entry.path))
-
-    icon = file_tree_icon(entry)
-    icon_bytes = :erlang.iolist_to_binary([icon])
-    name_bytes = :erlang.iolist_to_binary([entry.name])
-    rel_path = Path.relative_to(entry.path, tree.root)
-    rel_path_bytes = :erlang.iolist_to_binary([rel_path])
-
-    # Stable 32-bit hash of the file path so the GUI can use it as a
-    # persistent SwiftUI identity across tree updates.
-    path_hash = :erlang.phash2(entry.path, 0xFFFFFFFF)
-
-    base =
-      <<path_hash::32, flags::8, entry.depth::8, git_status::8, byte_size(icon_bytes)::8,
-        icon_bytes::binary, byte_size(name_bytes)::16, name_bytes::binary,
-        byte_size(rel_path_bytes)::16, rel_path_bytes::binary>>
-
-    # Append editing payload only when this entry is being edited
-    if is_editing and editing != nil do
-      editing_type = encode_editing_type(editing.type)
-      editing_text_bytes = :erlang.iolist_to_binary([editing.text])
-
-      base <> <<editing_type::8, byte_size(editing_text_bytes)::16, editing_text_bytes::binary>>
-    else
-      base
+  @spec selected_row_id([Row.t()]) :: String.t()
+  defp selected_row_id(rows) do
+    case Enum.find(rows, & &1.selected?) do
+      %Row{id: id} -> id
+      nil -> ""
     end
+  end
+
+  @spec file_tree_flags(boolean(), boolean(), [Row.t()]) :: non_neg_integer()
+  defp file_tree_flags(visible?, focused?, rows) do
+    0
+    |> maybe_flag(visible?, 0)
+    |> maybe_flag(focused?, 1)
+    |> maybe_flag(rows == [], 4)
+  end
+
+  @spec file_tree_row_flags(Row.t()) :: non_neg_integer()
+  defp file_tree_row_flags(%Row{} = row) do
+    0
+    |> maybe_flag(row.directory?, 0)
+    |> maybe_flag(row.expanded?, 1)
+    |> maybe_flag(row.selected?, 2)
+    |> maybe_flag(row.focused?, 3)
+    |> maybe_flag(row.active?, 4)
+    |> maybe_flag(row.dirty?, 5)
+    |> maybe_flag(row.editing != nil, 6)
+    |> maybe_flag(row.last_child?, 7)
+  end
+
+  @spec maybe_flag(non_neg_integer(), boolean(), non_neg_integer()) :: non_neg_integer()
+  defp maybe_flag(flags, true, bit), do: bor(flags, bsl(1, bit))
+  defp maybe_flag(flags, false, _bit), do: flags
+
+  @spec encode_string16(String.t()) :: binary()
+  defp encode_string16(value) do
+    bytes = :erlang.iolist_to_binary([value])
+    <<byte_size(bytes)::16, bytes::binary>>
+  end
+
+  @spec encode_string8(String.t()) :: binary()
+  defp encode_string8(value) do
+    bytes = :erlang.iolist_to_binary([value])
+    <<byte_size(bytes)::8, bytes::binary>>
   end
 
   @spec encode_editing_type(atom()) :: non_neg_integer()
@@ -1107,9 +1122,9 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   # Nerd Font folder icon (nf-md-folder)
   @folder_icon "\u{F024B}"
 
-  @spec file_tree_icon(Minga.Project.FileTree.entry()) :: String.t()
-  defp file_tree_icon(%{dir?: true}), do: @folder_icon
-  defp file_tree_icon(%{name: name}), do: Devicon.icon(Language.detect_filetype(name))
+  @spec file_tree_row_icon(Row.t()) :: String.t()
+  defp file_tree_row_icon(%Row{directory?: true}), do: @folder_icon
+  defp file_tree_row_icon(%Row{name: name}), do: Devicon.icon(Language.detect_filetype(name))
 
   @spec encode_git_status(atom() | nil) :: non_neg_integer()
   defp encode_git_status(nil), do: 0
@@ -1117,8 +1132,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   defp encode_git_status(:staged), do: 2
   defp encode_git_status(:untracked), do: 3
   defp encode_git_status(:conflict), do: 4
-  defp encode_git_status(:ignored), do: 5
-  defp encode_git_status(_), do: 0
+  defp encode_git_status(:renamed), do: 5
+  defp encode_git_status(:deleted), do: 6
 
   # ── Completion ──
 

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -197,10 +197,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
   @spec sync_tree_cursor_from_buffer(EditorState.t(), pid()) :: EditorState.t()
   defp sync_tree_cursor_from_buffer(%{workspace: %{file_tree: %{tree: tree}}} = state, buf) do
     {cursor_line, _col} = Buffer.cursor(buf)
-    entries = FileTree.visible_entries(tree)
-    max_cursor = max(length(entries) - 1, 0)
-    clamped = min(cursor_line, max_cursor)
-    put_in(state.workspace.file_tree.tree, %{tree | cursor: clamped})
+    put_in(state.workspace.file_tree.tree, FileTree.select(tree, cursor_line))
   end
 
   # ── File tree mouse helpers ────────────────────────────────────────────
@@ -217,10 +214,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
   defp handle_file_tree_click(state, tree, _row, _ft_row, _ft_height, button, _click_count)
        when button in [:wheel_up, :wheel_down] do
     delta = if button == :wheel_down, do: 3, else: -3
-    entries = FileTree.visible_entries(tree)
-    max_idx = max(length(entries) - 1, 0)
-    new_cursor = (tree.cursor + delta) |> max(0) |> min(max_idx)
-    put_in(state.workspace.file_tree.tree, %{tree | cursor: new_cursor})
+    put_in(state.workspace.file_tree.tree, FileTree.select(tree, tree.cursor + delta))
   end
 
   defp handle_file_tree_click(state, tree, row, ft_row, ft_height, :left, click_count) do
@@ -239,8 +233,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
           state
 
         entry ->
-          new_tree = %{tree | cursor: entry_idx}
-          state = put_in(state.workspace.file_tree.tree, new_tree)
+          state = put_in(state.workspace.file_tree.tree, FileTree.select(tree, entry_idx))
           handle_tree_entry_click(state, entry, click_count)
       end
     end

--- a/lib/minga_editor/shell/traditional/tree_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tree_renderer.ex
@@ -8,16 +8,17 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   match neo-tree.nvim's visual style.
   """
 
-  alias Minga.Buffer
   alias Minga.Core.Face
-  alias MingaEditor.DisplayList
-  alias MingaEditor.State, as: EditorState
-  alias MingaEditor.State.FileTree, as: FileTreeState
-  alias MingaEditor.WindowTree
   alias Minga.Language
   alias Minga.Project.FileTree
+  alias MingaEditor.DisplayList
+  alias MingaEditor.FileTree.Row
+  alias MingaEditor.FileTree.Rows
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.UI.Devicon
   alias MingaEditor.UI.Theme
+  alias MingaEditor.WindowTree
 
   # Box-drawing characters for indent guides
   @guide_pipe "│ "
@@ -43,7 +44,8 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
       :active_path,
       editing: nil,
       git_status: %{},
-      dirty_paths: MapSet.new()
+      dirty_paths: MapSet.new(),
+      rows: nil
     ]
 
     @type t :: %__MODULE__{
@@ -54,7 +56,8 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
             active_path: String.t() | nil,
             editing: FileTreeState.editing() | nil,
             git_status: Minga.Project.FileTree.GitStatus.status_map(),
-            dirty_paths: MapSet.t(String.t())
+            dirty_paths: MapSet.t(String.t()),
+            rows: [Row.t()] | nil
           }
   end
 
@@ -69,16 +72,17 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   """
   @spec render(RenderInput.t()) :: [DisplayList.draw()]
   def render(%RenderInput{} = input) do
-    do_render(
-      input.tree,
-      input.rect,
-      input.focused,
-      input.theme,
-      input.active_path,
-      input.editing,
-      input.git_status,
-      input.dirty_paths
-    )
+    rows =
+      input.rows ||
+        Rows.from_tree(input.tree,
+          active_path: input.active_path,
+          dirty_paths: input.dirty_paths,
+          editing: input.editing,
+          focused: input.focused,
+          git_status: input.git_status
+        )
+
+    do_render(input.tree, input.rect, input.theme, rows)
   end
 
   @spec render(EditorState.t() | map()) :: [DisplayList.draw()]
@@ -108,37 +112,15 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
       rect: rect,
       focused: focused,
       theme: state.theme,
-      active_path: active_buffer_path(state),
-      editing: state.workspace.file_tree.editing,
-      git_status: tree.git_status,
-      dirty_paths: compute_dirty_paths(state)
+      active_path: nil,
+      rows: Rows.from_state(state)
     }
 
     render(input)
   end
 
-  @spec do_render(
-          FileTree.t(),
-          WindowTree.rect(),
-          boolean(),
-          Theme.t(),
-          String.t() | nil,
-          FileTreeState.editing() | nil,
-          FileTree.GitStatus.status_map(),
-          MapSet.t(String.t())
-        ) :: [DisplayList.draw()]
-  defp do_render(
-         tree,
-         {row_off, col_off, width, height},
-         focused,
-         theme,
-         active_path,
-         editing,
-         git_status,
-         dirty_paths
-       ) do
-    entries = FileTree.visible_entries(tree)
-
+  @spec do_render(FileTree.t(), WindowTree.rect(), Theme.t(), [Row.t()]) :: [DisplayList.draw()]
+  defp do_render(tree, {row_off, col_off, width, height}, theme, rows) do
     # Header: project directory name with folder icon
     project_name = Path.basename(tree.root)
     header_text = " #{@folder_open} #{project_name}/"
@@ -155,39 +137,31 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
 
     # Entry rows (starting from row 1, leaving row 0 for header)
     content_rows = height - 1
-    scroll_offset = scroll_offset(tree.cursor, content_rows)
+    scroll_offset = scroll_offset(selected_index(rows), content_rows)
 
     render_opts = %{
-      cursor: tree.cursor,
-      focused: focused,
-      active_path: active_path,
       col_off: col_off,
       width: width,
-      theme: theme,
-      expanded: tree.expanded,
-      editing: editing,
-      git_status: git_status,
-      dirty_paths: dirty_paths
+      theme: theme
     }
 
     entry_commands =
-      entries
-      |> Enum.with_index()
+      rows
       |> Enum.drop(scroll_offset)
       |> Enum.take(content_rows)
       |> Enum.with_index()
-      |> Enum.flat_map(fn {{entry, global_idx}, screen_row} ->
+      |> Enum.flat_map(fn {tree_row, screen_row} ->
         row = row_off + 1 + screen_row
 
-        if editing != nil and global_idx == editing.index do
-          render_editing_entry(entry, row, render_opts)
+        if tree_row.editing != nil do
+          render_editing_entry(tree_row, row, render_opts)
         else
-          render_entry(entry, global_idx, row, render_opts)
+          render_entry(tree_row, row, render_opts)
         end
       end)
 
     # Fill remaining rows with blanks
-    visible_count = entries |> Enum.drop(scroll_offset) |> Enum.take(content_rows) |> length()
+    visible_count = rows |> Enum.drop(scroll_offset) |> Enum.take(content_rows) |> length()
 
     blank_commands =
       render_blanks(visible_count, content_rows, row_off + 1, col_off, width, theme)
@@ -201,38 +175,26 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
 
   # ── Entry rendering ──────────────────────────────────────────────────────
 
-  @spec render_entry(FileTree.entry(), non_neg_integer(), non_neg_integer(), map()) ::
-          [DisplayList.draw()]
-  defp render_entry(entry, idx, row, opts) do
-    %{
-      cursor: cursor,
-      focused: focused,
-      active_path: active_path,
-      col_off: col,
-      width: width,
-      theme: theme,
-      expanded: expanded,
-      git_status: git_status,
-      dirty_paths: dirty_paths
-    } = opts
+  @spec render_entry(Row.t(), non_neg_integer(), map()) :: [DisplayList.draw()]
+  defp render_entry(tree_row, row, opts) do
+    %{col_off: col, width: width, theme: theme} = opts
 
-    is_cursor = idx == cursor
-    is_active = active_path != nil and entry.path == active_path
-    is_expanded = entry.dir? and MapSet.member?(expanded, entry.path)
-    is_dirty = not entry.dir? and MapSet.member?(dirty_paths, entry.path)
+    is_cursor = tree_row.selected?
+    focused = tree_row.focused?
+    is_dirty = tree_row.dirty?
 
     # Build the guide prefix from the entry's ancestor guide flags
-    guide_prefix = build_guides(entry.guides, entry.last_child?)
+    guide_prefix = build_guides(tree_row.guides, tree_row.last_child?)
 
     # Pick the icon and its color
-    {icon, icon_color} = entry_icon(entry, is_expanded)
+    {icon, icon_color} = entry_icon(tree_row)
 
     # Entry name (dirs get trailing slash)
-    name = if entry.dir?, do: entry.name <> "/", else: entry.name
+    name = if tree_row.directory?, do: tree_row.name <> "/", else: tree_row.name
 
     # Right-side indicators: [modified_dot] [git_status]
     # Modified dot = 1 col, git status = 2 cols (space + symbol)
-    file_git_status = Map.get(git_status, entry.path)
+    file_git_status = tree_row.git_status
     git_width = if file_git_status, do: 2, else: 0
     dirty_width = if is_dirty, do: 1, else: 0
     indicator_width = dirty_width + git_width
@@ -251,7 +213,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     # Build draw commands: guide, icon, name, (dirty dot), (git indicator)
     guide_style = guide_draw_style(is_cursor, focused, theme)
     icon_style = icon_draw_style(icon_color, is_cursor, focused, theme)
-    name_style = name_draw_style(entry, is_cursor, is_active, focused, theme)
+    name_style = name_draw_style(tree_row, is_cursor, tree_row.active?, focused, theme)
 
     guide_len = String.length(guide_prefix)
 
@@ -312,12 +274,13 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   # Renders the inline editing entry with highlighted styling and a cursor indicator.
   # The editing row shows the entry's indent guides, a type indicator icon, the
   # current editing text, and a block cursor at the insertion point.
-  @spec render_editing_entry(FileTree.entry(), non_neg_integer(), map()) :: [DisplayList.draw()]
-  defp render_editing_entry(entry, row, opts) do
-    %{col_off: col, width: width, theme: theme, editing: editing} = opts
+  @spec render_editing_entry(Row.t(), non_neg_integer(), map()) :: [DisplayList.draw()]
+  defp render_editing_entry(tree_row, row, opts) do
+    %{col_off: col, width: width, theme: theme} = opts
+    editing = tree_row.editing
 
     # Build indent guides (same depth as the entry being edited/created)
-    guide_prefix = build_guides(entry.guides, entry.last_child?)
+    guide_prefix = build_guides(tree_row.guides, tree_row.last_child?)
     guide_len = String.length(guide_prefix)
 
     # Type indicator: file icon for new file, folder icon for new folder,
@@ -326,7 +289,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
       case editing.type do
         :new_file -> {"", 0x519ABA}
         :new_folder -> {@folder_open, 0x519ABA}
-        :rename -> entry_icon(entry, false)
+        :rename -> entry_icon(tree_row)
       end
 
     prefix = guide_prefix <> icon <> " "
@@ -396,16 +359,16 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
 
   # ── Icon selection ──────────────────────────────────────────────────────
 
-  @spec entry_icon(FileTree.entry(), boolean()) :: {String.t(), non_neg_integer()}
-  defp entry_icon(%{dir?: true}, true = _expanded) do
+  @spec entry_icon(Row.t()) :: {String.t(), non_neg_integer()}
+  defp entry_icon(%Row{directory?: true, expanded?: true}) do
     {@folder_open, 0x519ABA}
   end
 
-  defp entry_icon(%{dir?: true}, false = _expanded) do
+  defp entry_icon(%Row{directory?: true}) do
     {@folder_closed, 0x519ABA}
   end
 
-  defp entry_icon(%{path: path}, _expanded) do
+  defp entry_icon(%Row{path: path}) do
     filetype = Language.detect_filetype(path)
     Devicon.icon_and_color(filetype)
   end
@@ -496,12 +459,12 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   defp git_status_color(:renamed, theme), do: theme.tree.git_staged_fg || theme.tree.fg
   defp git_status_color(:deleted, theme), do: theme.tree.git_conflict_fg || theme.tree.fg
 
-  @spec name_draw_style(FileTree.entry(), boolean(), boolean(), boolean(), Theme.t()) :: Face.t()
-  defp name_draw_style(entry, is_cursor, is_active, focused, theme) do
+  @spec name_draw_style(Row.t(), boolean(), boolean(), boolean(), Theme.t()) :: Face.t()
+  defp name_draw_style(tree_row, is_cursor, is_active, focused, theme) do
     tree = theme.tree
 
     base_fg =
-      case {entry.dir?, is_active} do
+      case {tree_row.directory?, is_active} do
         {true, _} -> tree.dir_fg
         {_, true} -> tree.active_fg
         _ -> tree.fg
@@ -509,13 +472,13 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
 
     case {is_cursor, focused} do
       {true, true} ->
-        Face.new(fg: tree.bg, bg: base_fg, bold: entry.dir?)
+        Face.new(fg: tree.bg, bg: base_fg, bold: tree_row.directory?)
 
       {true, false} ->
-        Face.new(fg: base_fg, bg: tree.cursor_bg, bold: entry.dir?)
+        Face.new(fg: base_fg, bg: tree.cursor_bg, bold: tree_row.directory?)
 
       _ ->
-        Face.new(fg: base_fg, bg: tree.bg, bold: entry.dir?)
+        Face.new(fg: base_fg, bg: tree.bg, bold: tree_row.directory?)
     end
   end
 
@@ -565,29 +528,12 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     cursor - visible_rows + 1
   end
 
-  @spec active_buffer_path(EditorState.t()) :: String.t() | nil
-  defp active_buffer_path(%{workspace: %{buffers: %{active: nil}}}), do: nil
-
-  defp active_buffer_path(%{workspace: %{buffers: %{active: buf}}}) do
-    case Buffer.file_path(buf) do
-      nil -> nil
-      path -> Path.expand(path)
+  @spec selected_index([Row.t()]) :: non_neg_integer()
+  defp selected_index(rows) do
+    case Enum.find_index(rows, & &1.selected?) do
+      nil -> 0
+      index -> index
     end
-  end
-
-  @spec compute_dirty_paths(EditorState.t()) :: MapSet.t(String.t())
-  defp compute_dirty_paths(%{workspace: %{buffers: %{list: buffer_list}}}) do
-    buffer_list
-    |> Enum.flat_map(fn pid ->
-      try do
-        if Buffer.dirty?(pid), do: [Buffer.file_path(pid)], else: []
-      catch
-        :exit, _ -> []
-      end
-    end)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.map(&Path.expand/1)
-    |> MapSet.new()
   end
 
   # Computes the tree rect from workspace data without requiring EditorState.

--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -26,9 +26,9 @@ let OP_DESTROY_REGION: UInt8 = 0x19
 let OP_SET_ACTIVE_REGION: UInt8 = 0x1A
 let OP_DRAW_STYLED_TEXT: UInt8 = 0x1C
 
-// MARK: - GUI chrome opcodes (BEAM → frontend, contiguous range 0x70-0x7F)
+// MARK: - GUI chrome opcodes (BEAM → frontend)
 
-let OP_GUI_FILE_TREE: UInt8 = 0x70
+let OP_GUI_FILE_TREE: UInt8 = 0x93
 let OP_GUI_TAB_BAR: UInt8 = 0x71
 let OP_GUI_WHICH_KEY: UInt8 = 0x72
 let OP_GUI_COMPLETION: UInt8 = 0x73
@@ -60,9 +60,10 @@ let OP_GUI_AGENT_CONTEXT: UInt8 = 0x88
 let OP_GUI_CHANGE_SUMMARY: UInt8 = 0x89
 let OP_GUI_HOVER_ACTION: UInt8 = 0x96
 
-// MARK: - Forward-compatible opcodes (0x90+, include 2-byte length prefix)
-// All opcodes >= 0x90 use the format: opcode(1) + payload_length(2) + payload.
-// Old frontends skip unknown 0x90+ opcodes by reading the length.
+// MARK: - Forward-compatible opcodes (0x90+, include a length prefix)
+// Most opcodes >= 0x90 use the format: opcode(1) + payload_length(2) + payload.
+// gui_file_tree uses a 32-bit payload length because expanded project trees can exceed 64KB.
+// Old frontends skip unknown 0x90+ opcodes by reading the standard 16-bit length.
 
 let OP_CLIPBOARD_WRITE: UInt8 = 0x90
 let OP_GUI_INDENT_GUIDES: UInt8 = 0x91

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -32,7 +32,7 @@ enum RenderCommand: Sendable {
     case registerFont(id: UInt8, family: String)
     case guiTheme(slots: [(slotId: UInt8, r: UInt8, g: UInt8, b: UInt8)])
     case guiTabBar(activeIndex: UInt8, tabs: [Wire.TabEntry])
-    case guiFileTree(selectedIndex: UInt16, treeWidth: UInt16, rootPath: String, entries: [Wire.FileTreeEntry])
+    case guiFileTree(version: UInt8, treeFlags: UInt8, selectedId: String, treeWidth: UInt16, rootPath: String, entries: [Wire.FileTreeEntry])
     case guiCompletion(visible: Bool, anchorRow: UInt16, anchorCol: UInt16, selectedIndex: UInt16, items: [Wire.CompletionItem])
     case guiWhichKey(visible: Bool, prefix: String, page: UInt8, pageCount: UInt8, bindings: [Wire.WhichKeyBinding])
     case guiBreadcrumb(segments: [String])
@@ -273,74 +273,118 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
 
     // GUI chrome commands.
     case OP_GUI_FILE_TREE:
-        // Header: selected_index:2, tree_width:2, entry_count:2, root_len:2, root
-        // Per entry: path_hash:4, flags:1, depth:1, git_status:1, icon_len:1, icon,
-        //            name_len:2, name, rel_path_len:2, rel_path
-        guard data.count >= rest + 8 else { throw ProtocolDecodeError.malformed }
-        let selectedIndex = readU16(data, rest)
-        let treeWidth = readU16(data, rest + 2)
-        let entryCount = Int(readU16(data, rest + 4))
-        let rootLen = Int(readU16(data, rest + 6))
-        guard data.count >= rest + 8 + rootLen else { throw ProtocolDecodeError.malformed }
-        let rootData = data[(rest + 8)..<(rest + 8 + rootLen)]
-        let rootPath = String(data: rootData, encoding: .utf8) ?? ""
-        var entries: [Wire.FileTreeEntry] = []
-        entries.reserveCapacity(entryCount)
-        var pos = rest + 8 + rootLen
-        for _ in 0..<entryCount {
-            guard data.count >= pos + 8 else { throw ProtocolDecodeError.malformed }
-            let pathHash = readU32(data, pos)
-            let flags = data[pos + 4]
-            let depth = data[pos + 5]
-            let gitStatus = data[pos + 6]
-            let iconLen = Int(data[pos + 7])
-            guard data.count >= pos + 8 + iconLen + 2 else { throw ProtocolDecodeError.malformed }
-            let iconData = data[(pos + 8)..<(pos + 8 + iconLen)]
-            let icon = String(data: iconData, encoding: .utf8) ?? ""
-            let nameLen = Int(readU16(data, pos + 8 + iconLen))
-            guard data.count >= pos + 10 + iconLen + nameLen + 2 else { throw ProtocolDecodeError.malformed }
-            let nameData = data[(pos + 10 + iconLen)..<(pos + 10 + iconLen + nameLen)]
-            let name = String(data: nameData, encoding: .utf8) ?? ""
-            let relPathLen = Int(readU16(data, pos + 10 + iconLen + nameLen))
-            guard data.count >= pos + 12 + iconLen + nameLen + relPathLen else { throw ProtocolDecodeError.malformed }
-            let relPathData = data[(pos + 12 + iconLen + nameLen)..<(pos + 12 + iconLen + nameLen + relPathLen)]
-            let relPath = String(data: relPathData, encoding: .utf8) ?? ""
-            let isEditing = flags & 0x08 != 0
-            var editingType: UInt8 = 0
-            var editingText = ""
-            var editingPayloadSize = 0
+        // Semantic file tree uses a 32-bit payload length because expanded project trees can exceed 64KB.
+        // opcode(1) + payload_len(4) + version(1) + tree_flags(1) + selected_id + root + tree_width(2) + row_count(2) + rows...
+        guard data.count >= rest + 4 else { throw ProtocolDecodeError.malformed }
+        let payloadLen = Int(readU32(data, rest))
+        let payloadStart = rest + 4
+        guard data.count >= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+        guard payloadLen >= 6 else { throw ProtocolDecodeError.malformed }
 
-            if isEditing {
-                guard data.count >= pos + 12 + iconLen + nameLen + relPathLen + 3 else {
-                    throw ProtocolDecodeError.malformed
-                }
-                editingType = data[pos + 12 + iconLen + nameLen + relPathLen]
-                let editingTextLen = Int(readU16(data, pos + 12 + iconLen + nameLen + relPathLen + 1))
-                guard data.count >= pos + 12 + iconLen + nameLen + relPathLen + 3 + editingTextLen else {
-                    throw ProtocolDecodeError.malformed
-                }
-                let editingTextData = data[(pos + 12 + iconLen + nameLen + relPathLen + 3)..<(pos + 12 + iconLen + nameLen + relPathLen + 3 + editingTextLen)]
-                editingText = String(data: editingTextData, encoding: .utf8) ?? ""
-                editingPayloadSize = 3 + editingTextLen
-            }
+        let version = data[payloadStart]
+        let treeFlags = data[payloadStart + 1]
+        var pos = payloadStart + 2
+
+        guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+        let selectedIdLen = Int(readU16(data, pos)); pos += 2
+        guard pos + selectedIdLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+        let selectedId = String(data: data[pos..<(pos + selectedIdLen)], encoding: .utf8) ?? ""
+        pos += selectedIdLen
+
+        guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+        let rootLen = Int(readU16(data, pos)); pos += 2
+        guard pos + rootLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+        let rootPath = String(data: data[pos..<(pos + rootLen)], encoding: .utf8) ?? ""
+        pos += rootLen
+
+        guard pos + 4 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+        let treeWidth = readU16(data, pos); pos += 2
+        let rowCount = Int(readU16(data, pos)); pos += 2
+
+        var entries: [Wire.FileTreeEntry] = []
+        entries.reserveCapacity(rowCount)
+
+        for _ in 0..<rowCount {
+            guard pos + 17 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let pathHash = readU32(data, pos); pos += 4
+            let flags = readU16(data, pos); pos += 2
+            let depth = data[pos]; pos += 1
+            let gitStatus = data[pos]; pos += 1
+            let diagnosticErrorCount = readU16(data, pos); pos += 2
+            let diagnosticWarningCount = readU16(data, pos); pos += 2
+            let diagnosticInfoCount = readU16(data, pos); pos += 2
+            let diagnosticHintCount = readU16(data, pos); pos += 2
+            let guideCount = Int(data[pos]); pos += 1
+            guard pos + guideCount <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let guides = (0..<guideCount).map { index in data[pos + index] != 0 }
+            pos += guideCount
+
+            guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let idLen = Int(readU16(data, pos)); pos += 2
+            guard pos + idLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let id = String(data: data[pos..<(pos + idLen)], encoding: .utf8) ?? ""
+            pos += idLen
+
+            guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let pathLen = Int(readU16(data, pos)); pos += 2
+            guard pos + pathLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let path = String(data: data[pos..<(pos + pathLen)], encoding: .utf8) ?? ""
+            pos += pathLen
+
+            guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let relPathLen = Int(readU16(data, pos)); pos += 2
+            guard pos + relPathLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let relPath = String(data: data[pos..<(pos + relPathLen)], encoding: .utf8) ?? ""
+            pos += relPathLen
+
+            guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let nameLen = Int(readU16(data, pos)); pos += 2
+            guard pos + nameLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let name = String(data: data[pos..<(pos + nameLen)], encoding: .utf8) ?? ""
+            pos += nameLen
+
+            guard pos + 1 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let iconLen = Int(data[pos]); pos += 1
+            guard pos + iconLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let icon = String(data: data[pos..<(pos + iconLen)], encoding: .utf8) ?? ""
+            pos += iconLen
+
+            guard pos + 3 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let editingType = data[pos]; pos += 1
+            let editingTextLen = Int(readU16(data, pos)); pos += 2
+            guard pos + editingTextLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let editingText = String(data: data[pos..<(pos + editingTextLen)], encoding: .utf8) ?? ""
+            pos += editingTextLen
 
             entries.append(Wire.FileTreeEntry(
                 pathHash: pathHash,
-                isDir: flags & 0x01 != 0,
-                isExpanded: flags & 0x02 != 0,
-                isSelected: flags & 0x04 != 0,
-                isEditing: isEditing,
+                id: id,
+                path: path,
+                isDir: flags & 0x0001 != 0,
+                isExpanded: flags & 0x0002 != 0,
+                isSelected: flags & 0x0004 != 0,
+                isFocused: flags & 0x0008 != 0,
+                isActive: flags & 0x0010 != 0,
+                isDirty: flags & 0x0020 != 0,
+                isEditing: flags & 0x0040 != 0,
+                isLastChild: flags & 0x0080 != 0,
                 depth: depth,
                 gitStatus: gitStatus,
+                diagnosticErrorCount: diagnosticErrorCount,
+                diagnosticWarningCount: diagnosticWarningCount,
+                diagnosticInfoCount: diagnosticInfoCount,
+                diagnosticHintCount: diagnosticHintCount,
+                guides: guides,
                 icon: icon,
                 name: name,
                 relPath: relPath,
                 editingType: editingType,
                 editingText: editingText
             ))
-            pos += 12 + iconLen + nameLen + relPathLen + editingPayloadSize
         }
-        return (.guiFileTree(selectedIndex: selectedIndex, treeWidth: treeWidth, rootPath: rootPath, entries: entries), pos - offset)
+
+        guard pos == payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+        return (.guiFileTree(version: version, treeFlags: treeFlags, selectedId: selectedId, treeWidth: treeWidth, rootPath: rootPath, entries: entries), 5 + payloadLen)
 
     case OP_GUI_TAB_BAR:
         // active_index:1, tab_count:1, then per tab: flags:1, id:4, group_id:2, icon_len:1, icon, label_len:2, label

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -42,21 +42,32 @@ enum Wire {
 
     // MARK: - File tree
 
-    /// A single file tree entry decoded from the gui_file_tree protocol message.
+    /// A single file tree entry decoded from the semantic gui_file_tree protocol message.
     struct FileTreeEntry: Sendable {
         let pathHash: UInt32
+        let id: String
+        let path: String
         let isDir: Bool
         let isExpanded: Bool
         let isSelected: Bool
+        let isFocused: Bool
+        let isActive: Bool
+        let isDirty: Bool
         let isEditing: Bool
+        let isLastChild: Bool
         let depth: UInt8
         let gitStatus: UInt8
+        let diagnosticErrorCount: UInt16
+        let diagnosticWarningCount: UInt16
+        let diagnosticInfoCount: UInt16
+        let diagnosticHintCount: UInt16
+        let guides: [Bool]
         let icon: String
         let name: String
         let relPath: String
-        /// Only present when isEditing is true. 0=new_file, 1=new_folder, 2=rename.
+        /// 0=new_file, 1=new_folder, 2=rename, 255=none.
         let editingType: UInt8
-        /// Only present when isEditing is true. Pre-filled text for the editing field.
+        /// Pre-filled text for the editing field.
         let editingText: String
     }
 

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -203,11 +203,13 @@ final class CommandDispatcher {
         case .clipboardWrite(let target, let text):
             handleClipboardWrite(target: target, text: text)
 
-        case .guiFileTree(let selectedIndex, let treeWidth, let rootPath, let entries):
-            if entries.isEmpty && treeWidth == 0 {
-                guiState.fileTreeState.hide(rootPath: rootPath)
+        case .guiFileTree(let version, let treeFlags, let selectedId, let treeWidth, let rootPath, let entries):
+            let visible = treeFlags & 0x01 != 0
+            let focused = treeFlags & 0x02 != 0
+            if visible {
+                guiState.fileTreeState.update(version: version, selectedId: selectedId, focused: focused, treeWidth: treeWidth, rootPath: rootPath, rawEntries: entries)
             } else {
-                guiState.fileTreeState.update(selectedIndex: selectedIndex, treeWidth: treeWidth, rootPath: rootPath, rawEntries: entries)
+                guiState.fileTreeState.hide(rootPath: rootPath)
             }
 
         case .guiCompletion(let visible, let anchorRow, let anchorCol, let selectedIndex, let items):

--- a/macos/Sources/Views/FileTreeState.swift
+++ b/macos/Sources/Views/FileTreeState.swift
@@ -14,13 +14,24 @@ struct FileTreeEntry: Identifiable {
     let isDir: Bool
     let isExpanded: Bool
     let isSelected: Bool
+    let isFocused: Bool
+    let isActive: Bool
+    let isDirty: Bool
     let isEditing: Bool
+    let isLastChild: Bool
     let depth: Int
     let gitStatus: UInt8
+    let diagnosticErrorCount: UInt16
+    let diagnosticWarningCount: UInt16
+    let diagnosticInfoCount: UInt16
+    let diagnosticHintCount: UInt16
+    let guides: [Bool]
     let icon: String
     let name: String
     /// Path relative to the project root (e.g., "lib/minga/editor.ex").
     let relPath: String
+    /// Absolute path sent by the BEAM. Swift renders this value but does not infer filesystem state from it.
+    let path: String
     /// 0=new_file, 1=new_folder, 2=rename. Only meaningful when isEditing is true.
     let editingType: UInt8
     /// Pre-filled text for the editing field. Only meaningful when isEditing is true.
@@ -32,9 +43,12 @@ struct FileTreeEntry: Identifiable {
 @Observable
 final class FileTreeState {
     var entries: [FileTreeEntry] = []
+    var version: UInt8 = 1
+    var selectedId: String = ""
     var selectedIndex: Int = 0
     var treeWidth: Int = 30
     var visible: Bool = false
+    var focused: Bool = false
     /// Project root path sent by the BEAM (e.g., "/Users/foo/myproject").
     var projectRoot: String = ""
     /// Index of the entry currently being edited, or nil if no editing is active.
@@ -47,11 +61,14 @@ final class FileTreeState {
     /// function is called, the tree data has genuinely changed and the
     /// array rebuild is necessary (git status, file renames, expand/collapse
     /// can change entry content without changing count or selection).
-    func update(selectedIndex: UInt16, treeWidth: UInt16, rootPath: String, rawEntries: [Wire.FileTreeEntry]) {
-        self.selectedIndex = Int(selectedIndex)
+    func update(version: UInt8, selectedId: String, focused: Bool, treeWidth: UInt16, rootPath: String, rawEntries: [Wire.FileTreeEntry]) {
+        self.version = version
+        self.selectedId = selectedId
+        self.selectedIndex = rawEntries.firstIndex(where: { $0.id == selectedId }) ?? 0
         self.treeWidth = Int(treeWidth)
         self.projectRoot = rootPath
         self.visible = true
+        self.focused = focused
         self.entries = rawEntries.enumerated().map { index, entry in
             FileTreeEntry(
                 id: entry.pathHash,
@@ -59,12 +76,22 @@ final class FileTreeState {
                 isDir: entry.isDir,
                 isExpanded: entry.isExpanded,
                 isSelected: entry.isSelected,
+                isFocused: entry.isFocused,
+                isActive: entry.isActive,
+                isDirty: entry.isDirty,
                 isEditing: entry.isEditing,
+                isLastChild: entry.isLastChild,
                 depth: Int(entry.depth),
                 gitStatus: entry.gitStatus,
+                diagnosticErrorCount: entry.diagnosticErrorCount,
+                diagnosticWarningCount: entry.diagnosticWarningCount,
+                diagnosticInfoCount: entry.diagnosticInfoCount,
+                diagnosticHintCount: entry.diagnosticHintCount,
+                guides: entry.guides,
                 icon: entry.icon,
                 name: entry.name,
                 relPath: entry.relPath,
+                path: entry.path,
                 editingType: entry.editingType,
                 editingText: entry.editingText
             )
@@ -75,6 +102,7 @@ final class FileTreeState {
 
     /// Computes the full absolute path for an entry.
     func fullPath(for entry: FileTreeEntry) -> String {
+        if !entry.path.isEmpty { return entry.path }
         guard !projectRoot.isEmpty, !entry.relPath.isEmpty else { return entry.relPath }
         return (projectRoot as NSString).appendingPathComponent(entry.relPath)
     }
@@ -82,7 +110,9 @@ final class FileTreeState {
     /// Hide the file tree (BEAM toggled it off) and keep the shared window chrome in sync with the latest project root.
     func hide(rootPath: String = "") {
         visible = false
+        focused = false
         entries = []
+        selectedId = ""
         editingIndex = nil
         projectRoot = rootPath
     }

--- a/macos/Sources/Views/FileTreeView.swift
+++ b/macos/Sources/Views/FileTreeView.swift
@@ -453,17 +453,19 @@ struct FileTreeView: View {
         case 2: return theme.treeGitStaged
         case 3: return theme.treeGitUntracked
         case 4: return theme.gutterErrorFg  // conflict
+        case 5: return theme.treeGitModified  // renamed
+        case 6: return theme.gitDeletedFg
         default: return nil
         }
     }
 
-    /// Draws thin vertical indent guide lines using a lightweight Canvas.
+    /// Draws thin vertical indent guide lines using the BEAM-supplied semantic ancestor guide mask.
     @ViewBuilder
     private func indentGuides(_ entry: FileTreeEntry) -> some View {
-        if entry.depth > 0 {
+        if !entry.guides.isEmpty {
             Canvas { context, size in
-                for level in 0..<entry.depth {
-                    // Align guide with the center of each ancestor's chevron column
+                for (level, shouldDraw) in entry.guides.enumerated() where shouldDraw {
+                    // Align guide with the center of each ancestor's chevron column.
                     let x = 8 + CGFloat(level) * indentWidth + chevronWidth / 2
                     let rect = CGRect(x: x, y: 0, width: 1, height: size.height)
                     context.fill(Path(rect), with: .color(theme.treeGuideFg))
@@ -512,6 +514,9 @@ struct FileTreeView: View {
         case 1: return theme.treeGitModified
         case 2: return theme.treeGitStaged
         case 3: return theme.treeGitUntracked
+        case 4: return theme.gutterErrorFg
+        case 5: return theme.treeGitModified
+        case 6: return theme.gitDeletedFg
         default: return theme.treeFg.opacity(0.7)
         }
     }
@@ -524,6 +529,9 @@ struct FileTreeView: View {
         case 1: return theme.treeGitModified
         case 2: return theme.treeGitStaged
         case 3: return theme.treeGitUntracked
+        case 4: return theme.gutterErrorFg
+        case 5: return theme.treeGitModified
+        case 6: return theme.gitDeletedFg
         default:
             return entry.isDir ? theme.treeDirFg : theme.treeFg
         }

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -74,13 +74,14 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
         }
         return ["type": "gui_tab_bar", "active_index": Int(activeIndex), "tabs": tabArray]
 
-    case .guiFileTree(let selectedIndex, let treeWidth, let rootPath, let entries):
+    case .guiFileTree(let version, let treeFlags, let selectedId, let treeWidth, let rootPath, let entries):
         let entryArray = entries.map { e -> [String: Any] in
-            ["name": e.name, "depth": Int(e.depth),
-             "is_dir": e.isDir, "is_expanded": e.isExpanded, "is_selected": e.isSelected,
+            ["id": e.id, "path": e.path, "name": e.name, "relative_path": e.relPath, "depth": Int(e.depth),
+             "is_dir": e.isDir, "is_expanded": e.isExpanded, "is_selected": e.isSelected, "is_focused": e.isFocused,
+             "is_active": e.isActive, "is_dirty": e.isDirty, "is_editing": e.isEditing,
              "git_status": Int(e.gitStatus), "icon": e.icon]
         }
-        return ["type": "gui_file_tree", "selected_index": Int(selectedIndex), "tree_width": Int(treeWidth), "root_path": rootPath, "entries": entryArray]
+        return ["type": "gui_file_tree", "version": Int(version), "tree_flags": Int(treeFlags), "selected_id": selectedId, "tree_width": Int(treeWidth), "root_path": rootPath, "entries": entryArray]
 
     case .guiCompletion(let visible, let anchorRow, let anchorCol, let selectedIndex, let items):
         let itemArray = items.map { i -> [String: Any] in

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -94,51 +94,39 @@ struct CommandDispatcherRoutingTests {
     @Test("guiFileTree updates fileTreeState when entries present")
     @MainActor func guiFileTreeRouting() {
         let (dispatcher, gui) = makeDispatcher()
-        let entries = [
-            Wire.FileTreeEntry(pathHash: 123, isDir: true, isExpanded: true,
-                           isSelected: false, isEditing: false, depth: 0, gitStatus: 0,
-                           icon: "", name: "lib", relPath: "lib",
-                           editingType: 0, editingText: "")
-        ]
-        dispatcher.dispatch(.guiFileTree(selectedIndex: 0, treeWidth: 30,
+        let entries = [wireFileTreeEntry(pathHash: 123, isDir: true, isExpanded: true, id: "/project/lib", path: "/project/lib", name: "lib", relPath: "lib")]
+        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x03, selectedId: "/project/lib", treeWidth: 30,
                                           rootPath: "/project", entries: entries))
 
         #expect(gui.fileTreeState.visible == true)
+        #expect(gui.fileTreeState.focused == true)
         #expect(gui.fileTreeState.entries.count == 1)
         #expect(gui.fileTreeState.entries[0].name == "lib")
         #expect(gui.fileTreeState.projectRoot == "/project")
     }
 
-    @Test("guiFileTree hides when an empty zero-width sentinel arrives")
-    @MainActor func guiFileTreeHidesOnEmptySentinel() {
+    @Test("guiFileTree hides when visible flag is cleared")
+    @MainActor func guiFileTreeHidesOnInvisiblePayload() {
         let (dispatcher, gui) = makeDispatcher()
-        dispatcher.dispatch(.guiFileTree(selectedIndex: 0, treeWidth: 30,
+        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x01, selectedId: "/project/a", treeWidth: 30,
                                           rootPath: "/project",
-                                          entries: [Wire.FileTreeEntry(pathHash: 1, isDir: false,
-                                                                     isExpanded: false, isSelected: false,
-                                                                     isEditing: false, depth: 0, gitStatus: 0,
-                                                                     icon: "", name: "a", relPath: "a",
-                                                                     editingType: 0, editingText: "")]))
+                                          entries: [wireFileTreeEntry(pathHash: 1, id: "/project/a", path: "/project/a", name: "a", relPath: "a")]))
         #expect(gui.fileTreeState.visible == true)
 
-        dispatcher.dispatch(.guiFileTree(selectedIndex: 0, treeWidth: 0,
+        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x10, selectedId: "", treeWidth: 0,
                                           rootPath: "/project", entries: []))
         #expect(gui.fileTreeState.visible == false)
         #expect(gui.fileTreeState.projectRoot == "/project")
     }
 
-    @Test("guiFileTree clears project root when hidden sentinel has no root")
-    @MainActor func guiFileTreeClearsRootOnEmptyHiddenSentinel() {
+    @Test("guiFileTree clears project root when hidden payload has no root")
+    @MainActor func guiFileTreeClearsRootOnHiddenPayload() {
         let (dispatcher, gui) = makeDispatcher()
-        dispatcher.dispatch(.guiFileTree(selectedIndex: 0, treeWidth: 30,
+        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x01, selectedId: "/project/a", treeWidth: 30,
                                           rootPath: "/project",
-                                          entries: [Wire.FileTreeEntry(pathHash: 1, isDir: false,
-                                                                     isExpanded: false, isSelected: false,
-                                                                     isEditing: false, depth: 0, gitStatus: 0,
-                                                                     icon: "", name: "a", relPath: "a",
-                                                                     editingType: 0, editingText: "")]))
+                                          entries: [wireFileTreeEntry(pathHash: 1, id: "/project/a", path: "/project/a", name: "a", relPath: "a")]))
 
-        dispatcher.dispatch(.guiFileTree(selectedIndex: 0, treeWidth: 0,
+        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x10, selectedId: "", treeWidth: 0,
                                           rootPath: "", entries: []))
 
         #expect(gui.fileTreeState.visible == false)
@@ -149,7 +137,7 @@ struct CommandDispatcherRoutingTests {
     @MainActor func guiFileTreeKeepsEmptyVisibleTreeOpen() {
         let (dispatcher, gui) = makeDispatcher()
 
-        dispatcher.dispatch(.guiFileTree(selectedIndex: 0, treeWidth: 30,
+        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x11, selectedId: "", treeWidth: 30,
                                           rootPath: "/empty-project", entries: []))
 
         #expect(gui.fileTreeState.visible == true)
@@ -559,4 +547,48 @@ struct CommandDispatcherRoutingTests {
         #expect(dispatcher.frameState.gutterColors.fg == expected)
         #expect(gui.themeColors.gutterFgRGB == expected)
     }
+}
+
+private func wireFileTreeEntry(
+    pathHash: UInt32,
+    isDir: Bool = false,
+    isExpanded: Bool = false,
+    isSelected: Bool = false,
+    isFocused: Bool = false,
+    isActive: Bool = false,
+    isDirty: Bool = false,
+    isEditing: Bool = false,
+    isLastChild: Bool = false,
+    id: String,
+    path: String,
+    name: String,
+    relPath: String,
+    editingType: UInt8 = 0xFF,
+    editingText: String = ""
+) -> Wire.FileTreeEntry {
+    Wire.FileTreeEntry(
+        pathHash: pathHash,
+        id: id,
+        path: path,
+        isDir: isDir,
+        isExpanded: isExpanded,
+        isSelected: isSelected,
+        isFocused: isFocused,
+        isActive: isActive,
+        isDirty: isDirty,
+        isEditing: isEditing,
+        isLastChild: isLastChild,
+        depth: 0,
+        gitStatus: 0,
+        diagnosticErrorCount: 0,
+        diagnosticWarningCount: 0,
+        diagnosticInfoCount: 0,
+        diagnosticHintCount: 0,
+        guides: [],
+        icon: "",
+        name: name,
+        relPath: relPath,
+        editingType: editingType,
+        editingText: editingText
+    )
 }

--- a/macos/Tests/MingaTests/DecoderRobustnessTests.swift
+++ b/macos/Tests/MingaTests/DecoderRobustnessTests.swift
@@ -221,14 +221,18 @@ struct DecoderTruncatedGUIChromeTests {
 
     @Test("gui_file_tree truncated entry")
     func truncatedFileTree() {
+        var payload = Data()
+        payload.append(1) // version
+        payload.append(0x03) // visible + focused
+        payload.append(contentsOf: [0x00, 0x00]) // selected_id_len
+        payload.append(contentsOf: [0x00, 0x00]) // root_len
+        payload.append(contentsOf: [0x00, 0x1E]) // treeWidth
+        payload.append(contentsOf: [0x00, 0x01]) // rowCount=1
+        payload.append(0xAA) // incomplete row
+
         var data = Data([OP_GUI_FILE_TREE])
-        data.append(contentsOf: [0x00, 0x00]) // selectedIndex
-        data.append(contentsOf: [0x00, 0x1E]) // treeWidth
-        data.append(contentsOf: [0x00, 0x01]) // entryCount=1
-        data.append(contentsOf: [0x00, 0x00]) // rootPath_len=0
-        // Entry needs path_hash(4)+flags(1)+depth(1)+git(1)+icon_len(1)+...
-        // Provide only 3 bytes
-        data.append(contentsOf: [0x00, 0x00, 0x00])
+        data.append(contentsOf: [0x00, 0x00, 0x00, UInt8(payload.count)])
+        data.append(payload)
 
         #expect(throws: ProtocolDecodeError.self) {
             try decodeCommand(data: data, offset: 0)

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -649,45 +649,68 @@ struct GUICursorlineDecoderTests {
     }
 }
 
-// MARK: - gui_file_tree (0x70)
+// MARK: - gui_file_tree (semantic, length-prefixed)
 
 @Suite("GUI File Tree Decoder")
 struct GUIFileTreeDecoderTests {
-    @Test("Decode gui_file_tree with entries")
+    @Test("Decode semantic gui_file_tree with entries")
     func decodeWithEntries() throws {
+        var payload = Data()
+        payload.append(1) // version
+        payload.append(0x03) // visible + focused
+        appendString16(&payload, "/home/user/project/lib") // selectedId
+        appendString16(&payload, "/home/user/project") // rootPath
+        appendU16(&payload, 30) // treeWidth
+        appendU16(&payload, 2) // rowCount
+
+        appendSemanticRow(
+            &payload,
+            hash: 0xAABBCCDD,
+            flags: 0x0001 | 0x0002 | 0x0004 | 0x0008 | 0x0080,
+            depth: 0,
+            gitStatus: 0,
+            guides: [],
+            id: "/home/user/project/lib",
+            path: "/home/user/project/lib",
+            relPath: "lib",
+            name: "lib",
+            icon: "󰉋",
+            editingType: 0xFF,
+            editingText: ""
+        )
+
+        appendSemanticRow(
+            &payload,
+            hash: 0x11223344,
+            flags: 0x0010 | 0x0020,
+            depth: 1,
+            gitStatus: 1,
+            guides: [true],
+            id: "/home/user/project/lib/editor.ex",
+            path: "/home/user/project/lib/editor.ex",
+            relPath: "lib/editor.ex",
+            name: "editor.ex",
+            icon: "",
+            editingType: 0xFF,
+            editingText: ""
+        )
+
         var data = Data()
         data.append(OP_GUI_FILE_TREE)
-        appendU16(&data, 1) // selectedIndex
-        appendU16(&data, 30) // treeWidth
-        appendU16(&data, 2) // entryCount
-        appendString16(&data, "/home/user/project") // rootPath
-
-        // Entry 1: directory, expanded, selected
-        appendU32(&data, 0xAABBCCDD) // pathHash
-        data.append(0x01 | 0x02 | 0x04) // flags: isDir + isExpanded + isSelected
-        data.append(0) // depth
-        data.append(0) // gitStatus
-        appendString8(&data, "") // icon
-        appendString16(&data, "lib") // name
-        appendString16(&data, "lib") // relPath
-
-        // Entry 2: file, git modified
-        appendU32(&data, 0x11223344) // pathHash
-        data.append(0) // flags: none
-        data.append(1) // depth
-        data.append(1) // gitStatus = modified
-        appendString8(&data, "") // icon
-        appendString16(&data, "editor.ex") // name
-        appendString16(&data, "lib/editor.ex") // relPath
+        appendU32(&data, UInt32(payload.count))
+        data.append(payload)
 
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiFileTree(let selectedIndex, let treeWidth, let rootPath, let entries) = cmd else {
+        guard case .guiFileTree(let version, let treeFlags, let selectedId, let treeWidth, let rootPath, let entries) = cmd else {
             Issue.record("Expected .guiFileTree"); return
         }
 
-        #expect(selectedIndex == 1)
+        #expect(version == 1)
+        #expect(treeFlags & 0x01 != 0)
+        #expect(treeFlags & 0x02 != 0)
+        #expect(selectedId == "/home/user/project/lib")
         #expect(treeWidth == 30)
         #expect(rootPath == "/home/user/project")
         #expect(entries.count == 2)
@@ -695,29 +718,143 @@ struct GUIFileTreeDecoderTests {
         #expect(entries[0].isDir == true)
         #expect(entries[0].isExpanded == true)
         #expect(entries[0].isSelected == true)
-        #expect(entries[0].name == "lib")
+        #expect(entries[0].isFocused == true)
+        #expect(entries[0].isLastChild == true)
+        #expect(entries[0].id == "/home/user/project/lib")
+        #expect(entries[0].path == "/home/user/project/lib")
         #expect(entries[1].depth == 1)
         #expect(entries[1].gitStatus == 1)
+        #expect(entries[1].isActive == true)
+        #expect(entries[1].isDirty == true)
+        #expect(entries[1].guides == [true])
         #expect(entries[1].name == "editor.ex")
         #expect(entries[1].relPath == "lib/editor.ex")
     }
 
-    @Test("Decode gui_file_tree empty (hide)")
-    func decodeEmpty() throws {
+    @Test("Decode semantic gui_file_tree hidden")
+    func decodeHidden() throws {
+        var payload = Data()
+        payload.append(1) // version
+        payload.append(0x10) // empty, not visible
+        appendString16(&payload, "")
+        appendString16(&payload, "/home/user/project")
+        appendU16(&payload, 0)
+        appendU16(&payload, 0)
+
         var data = Data()
         data.append(OP_GUI_FILE_TREE)
-        appendU16(&data, 0)
-        appendU16(&data, 0)
-        appendU16(&data, 0)
-        appendString16(&data, "")
+        appendU32(&data, UInt32(payload.count))
+        data.append(payload)
 
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiFileTree(_, _, _, let entries) = cmd else {
+        guard case .guiFileTree(_, let treeFlags, _, let treeWidth, let rootPath, let entries) = cmd else {
             Issue.record("Expected .guiFileTree"); return
         }
+        #expect(treeFlags & 0x01 == 0)
+        #expect(treeFlags & 0x10 != 0)
+        #expect(treeWidth == 0)
+        #expect(rootPath == "/home/user/project")
         #expect(entries.isEmpty)
+    }
+
+    @Test("Decode semantic gui_file_tree editing row")
+    func decodeEditingRow() throws {
+        var payload = Data()
+        payload.append(1)
+        payload.append(0x03)
+        appendString16(&payload, "/project/ñ📄.txt")
+        appendString16(&payload, "/project")
+        appendU16(&payload, 30)
+        appendU16(&payload, 1)
+        appendSemanticRow(
+            &payload,
+            hash: 1,
+            flags: 0x0004 | 0x0040 | 0x0080,
+            depth: 0,
+            gitStatus: 0,
+            guides: [],
+            id: "/project/ñ📄.txt",
+            path: "/project/ñ📄.txt",
+            relPath: "ñ📄.txt",
+            name: "ñ📄.txt",
+            icon: "📄",
+            editingType: 2,
+            editingText: "renombré📄.txt"
+        )
+
+        var data = Data()
+        data.append(OP_GUI_FILE_TREE)
+        appendU32(&data, UInt32(payload.count))
+        data.append(payload)
+
+        let (cmd, _) = try decodeCommand(data: data, offset: 0)
+        guard case .guiFileTree(_, _, _, _, _, let entries) = cmd else {
+            Issue.record("Expected .guiFileTree"); return
+        }
+        #expect(entries.count == 1)
+        #expect(entries[0].id == "/project/ñ📄.txt")
+        #expect(entries[0].name == "ñ📄.txt")
+        #expect(entries[0].icon == "📄")
+        #expect(entries[0].isEditing == true)
+        #expect(entries[0].editingType == 2)
+        #expect(entries[0].editingText == "renombré📄.txt")
+    }
+
+    @Test("Decode semantic gui_file_tree rejects truncated row")
+    func decodeMalformedRow() throws {
+        var payload = Data()
+        payload.append(1)
+        payload.append(0x03)
+        appendString16(&payload, "")
+        appendString16(&payload, "/project")
+        appendU16(&payload, 30)
+        appendU16(&payload, 1)
+        payload.append(0xAA) // incomplete row
+
+        var data = Data()
+        data.append(OP_GUI_FILE_TREE)
+        appendU32(&data, UInt32(payload.count))
+        data.append(payload)
+
+        #expect(throws: ProtocolDecodeError.self) {
+            _ = try decodeCommand(data: data, offset: 0)
+        }
+    }
+
+    private func appendSemanticRow(
+        _ data: inout Data,
+        hash: UInt32,
+        flags: UInt16,
+        depth: UInt8,
+        gitStatus: UInt8,
+        guides: [Bool],
+        id: String,
+        path: String,
+        relPath: String,
+        name: String,
+        icon: String,
+        editingType: UInt8,
+        editingText: String
+    ) {
+        appendU32(&data, hash)
+        appendU16(&data, flags)
+        data.append(depth)
+        data.append(gitStatus)
+        appendU16(&data, 0) // diagnostic errors
+        appendU16(&data, 0) // diagnostic warnings
+        appendU16(&data, 0) // diagnostic infos
+        appendU16(&data, 0) // diagnostic hints
+        data.append(UInt8(guides.count))
+        for guide in guides { data.append(guide ? 1 : 0) }
+        appendString16(&data, id)
+        appendString16(&data, path)
+        appendString16(&data, relPath)
+        appendString16(&data, name)
+        appendString8(&data, icon)
+        data.append(editingType)
+        appendString16(&data, editingText)
     }
 }
 

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -169,18 +169,10 @@ struct FileTreeViewTests {
         let state = FileTreeState()
         state.visible = true
         state.entries = [
-            FileTreeEntry(
-                id: 1, index: 0, isDir: true, isExpanded: true,
-                isSelected: false, isEditing: false, depth: 0, gitStatus: 0,
-                icon: "\u{F024B}", name: "lib", relPath: "lib",
-                editingType: 0, editingText: ""
-            ),
-            FileTreeEntry(
-                id: 2, index: 1, isDir: false, isExpanded: false,
-                isSelected: true, isEditing: false, depth: 1, gitStatus: 0,
-                icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex",
-                editingType: 0, editingText: ""
-            ),
+            sidebarFileTreeEntry(id: 1, index: 0, isDir: true, isExpanded: true,
+                                 icon: "\u{F024B}", name: "lib", relPath: "lib"),
+            sidebarFileTreeEntry(id: 2, index: 1, isSelected: true, depth: 1,
+                                 icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"),
         ]
 
         let sut = FileTreeView(fileTreeState: state, theme: ThemeColors(), encoder: nil)
@@ -243,4 +235,23 @@ struct GitStatusViewSectionTests {
         #expect(strings.contains("M"))
         #expect(strings.contains("editor.ex"))
     }
+}
+
+private func sidebarFileTreeEntry(
+    id: UInt32,
+    index: Int,
+    isDir: Bool = false,
+    isExpanded: Bool = false,
+    isSelected: Bool = false,
+    depth: Int = 0,
+    icon: String,
+    name: String,
+    relPath: String
+) -> FileTreeEntry {
+    FileTreeEntry(id: id, index: index, isDir: isDir, isExpanded: isExpanded, isSelected: isSelected,
+                  isFocused: false, isActive: false, isDirty: false, isEditing: false,
+                  isLastChild: false, depth: depth, gitStatus: 0, diagnosticErrorCount: 0,
+                  diagnosticWarningCount: 0, diagnosticInfoCount: 0, diagnosticHintCount: 0,
+                  guides: [], icon: icon, name: name, relPath: relPath, path: relPath,
+                  editingType: 0xFF, editingText: "")
 }

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -164,18 +164,15 @@ struct FileTreeStateLifecycleTests {
     @MainActor func updateConverts() {
         let state = FileTreeState()
         let raw = [
-            Wire.FileTreeEntry(pathHash: 0xAABB, isDir: true, isExpanded: true,
-                           isSelected: false, isEditing: false, depth: 0, gitStatus: 0,
-                           icon: "", name: "lib", relPath: "lib",
-                           editingType: 0, editingText: ""),
-            Wire.FileTreeEntry(pathHash: 0xCCDD, isDir: false, isExpanded: false,
-                           isSelected: true, isEditing: false, depth: 1, gitStatus: 1,
-                           icon: "", name: "editor.ex", relPath: "lib/editor.ex",
-                           editingType: 0, editingText: "")
+            stateWireFileTreeEntry(pathHash: 0xAABB, isDir: true, isExpanded: true,
+                                   id: "/project/lib", path: "/project/lib", name: "lib", relPath: "lib"),
+            stateWireFileTreeEntry(pathHash: 0xCCDD, isSelected: true,
+                                   id: "/project/lib/editor.ex", path: "/project/lib/editor.ex", name: "editor.ex", relPath: "lib/editor.ex")
         ]
-        state.update(selectedIndex: 1, treeWidth: 30, rootPath: "/project", rawEntries: raw)
+        state.update(version: 1, selectedId: "/project/lib/editor.ex", focused: true, treeWidth: 30, rootPath: "/project", rawEntries: raw)
 
         #expect(state.visible == true)
+        #expect(state.focused == true)
         #expect(state.selectedIndex == 1)
         #expect(state.projectRoot == "/project")
         #expect(state.entries.count == 2)
@@ -185,16 +182,15 @@ struct FileTreeStateLifecycleTests {
         #expect(state.entries[1].relPath == "lib/editor.ex")
     }
 
-    @Test("fullPath() computes correct absolute path")
+    @Test("fullPath() uses BEAM-supplied absolute path")
     @MainActor func fullPathComputation() {
         let state = FileTreeState()
-        state.update(selectedIndex: 0, treeWidth: 30, rootPath: "/home/user/project",
-                     rawEntries: [Wire.FileTreeEntry(pathHash: 1, isDir: false,
-                                                   isExpanded: false, isSelected: false,
-                                                   isEditing: false, depth: 1, gitStatus: 0, icon: "",
-                                                   name: "editor.ex",
-                                                   relPath: "lib/editor.ex",
-                                                   editingType: 0, editingText: "")])
+        state.update(version: 1, selectedId: "/home/user/project/lib/editor.ex", focused: false, treeWidth: 30, rootPath: "/home/user/project",
+                     rawEntries: [stateWireFileTreeEntry(pathHash: 1,
+                                                         id: "/home/user/project/lib/editor.ex",
+                                                         path: "/home/user/project/lib/editor.ex",
+                                                         name: "editor.ex",
+                                                         relPath: "lib/editor.ex")])
 
         let path = state.fullPath(for: state.entries[0])
         #expect(path == "/home/user/project/lib/editor.ex")
@@ -203,12 +199,9 @@ struct FileTreeStateLifecycleTests {
     @Test("hide(rootPath:) clears entries while preserving supplied projectRoot")
     @MainActor func hideWithRootClearsEntriesOnly() {
         let state = FileTreeState()
-        state.update(selectedIndex: 0, treeWidth: 30, rootPath: "/project",
-                     rawEntries: [Wire.FileTreeEntry(pathHash: 1, isDir: false,
-                                                   isExpanded: false, isSelected: false,
-                                                   isEditing: true, depth: 0, gitStatus: 0, icon: "",
-                                                   name: "a", relPath: "a",
-                                                   editingType: 0, editingText: "")])
+        state.update(version: 1, selectedId: "/project/a", focused: true, treeWidth: 30, rootPath: "/project",
+                     rawEntries: [stateWireFileTreeEntry(pathHash: 1, isEditing: true,
+                                                         id: "/project/a", path: "/project/a", name: "a", relPath: "a")])
         #expect(state.editingIndex == 0)
 
         state.hide(rootPath: "/project")
@@ -222,12 +215,9 @@ struct FileTreeStateLifecycleTests {
     @Test("hide() clears projectRoot when no root is supplied")
     @MainActor func hideWithoutRootClearsProjectRoot() {
         let state = FileTreeState()
-        state.update(selectedIndex: 0, treeWidth: 30, rootPath: "/project",
-                     rawEntries: [Wire.FileTreeEntry(pathHash: 1, isDir: false,
-                                                   isExpanded: false, isSelected: false,
-                                                   isEditing: false, depth: 0, gitStatus: 0, icon: "",
-                                                   name: "a", relPath: "a",
-                                                   editingType: 0, editingText: "")])
+        state.update(version: 1, selectedId: "/project/a", focused: false, treeWidth: 30, rootPath: "/project",
+                     rawEntries: [stateWireFileTreeEntry(pathHash: 1,
+                                                         id: "/project/a", path: "/project/a", name: "a", relPath: "a")])
 
         state.hide()
 
@@ -235,6 +225,44 @@ struct FileTreeStateLifecycleTests {
         #expect(state.entries.isEmpty)
         #expect(state.projectRoot == "")
     }
+}
+
+private func stateWireFileTreeEntry(
+    pathHash: UInt32,
+    isDir: Bool = false,
+    isExpanded: Bool = false,
+    isSelected: Bool = false,
+    isEditing: Bool = false,
+    id: String,
+    path: String,
+    name: String,
+    relPath: String
+) -> Wire.FileTreeEntry {
+    Wire.FileTreeEntry(
+        pathHash: pathHash,
+        id: id,
+        path: path,
+        isDir: isDir,
+        isExpanded: isExpanded,
+        isSelected: isSelected,
+        isFocused: false,
+        isActive: false,
+        isDirty: false,
+        isEditing: isEditing,
+        isLastChild: false,
+        depth: 0,
+        gitStatus: 0,
+        diagnosticErrorCount: 0,
+        diagnosticWarningCount: 0,
+        diagnosticInfoCount: 0,
+        diagnosticHintCount: 0,
+        guides: [],
+        icon: "",
+        name: name,
+        relPath: relPath,
+        editingType: isEditing ? 2 : 0xFF,
+        editingText: isEditing ? name : ""
+    )
 }
 
 // MARK: - TabBarState

--- a/macos/Tests/MingaTests/ViewModelComputedTests.swift
+++ b/macos/Tests/MingaTests/ViewModelComputedTests.swift
@@ -231,12 +231,7 @@ struct FileTreePathTests {
     @MainActor func emptyRoot() {
         let state = FileTreeState()
         state.projectRoot = ""
-        let entry = FileTreeEntry(id: 1, index: 0, isDir: false,
-                                  isExpanded: false, isSelected: false,
-                                  isEditing: false,
-                                  depth: 0, gitStatus: 0, icon: "",
-                                  name: "test", relPath: "lib/test.ex",
-                                  editingType: 0, editingText: "")
+        let entry = computedFileTreeEntry(path: "", relPath: "lib/test.ex")
         #expect(state.fullPath(for: entry) == "lib/test.ex")
     }
 
@@ -244,12 +239,16 @@ struct FileTreePathTests {
     @MainActor func emptyRelPath() {
         let state = FileTreeState()
         state.projectRoot = "/project"
-        let entry = FileTreeEntry(id: 1, index: 0, isDir: false,
-                                  isExpanded: false, isSelected: false,
-                                  isEditing: false,
-                                  depth: 0, gitStatus: 0, icon: "",
-                                  name: "test", relPath: "",
-                                  editingType: 0, editingText: "")
+        let entry = computedFileTreeEntry(path: "", relPath: "")
         #expect(state.fullPath(for: entry) == "")
     }
+}
+
+private func computedFileTreeEntry(path: String, relPath: String) -> FileTreeEntry {
+    FileTreeEntry(id: 1, index: 0, isDir: false, isExpanded: false, isSelected: false,
+                  isFocused: false, isActive: false, isDirty: false, isEditing: false,
+                  isLastChild: false, depth: 0, gitStatus: 0, diagnosticErrorCount: 0,
+                  diagnosticWarningCount: 0, diagnosticInfoCount: 0, diagnosticHintCount: 0,
+                  guides: [], icon: "", name: "test", relPath: relPath, path: path,
+                  editingType: 0xFF, editingText: "")
 }

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -256,11 +256,12 @@ defmodule Minga.Config.LoaderTest do
       empty_dir =
         Path.join(System.tmp_dir!(), "minga_empty_#{System.unique_integer([:positive])}")
 
+      previous_xdg_config_home = System.get_env("XDG_CONFIG_HOME")
       File.mkdir_p!(empty_dir)
       System.put_env("XDG_CONFIG_HOME", empty_dir)
 
       on_exit(fn ->
-        System.delete_env("XDG_CONFIG_HOME")
+        restore_xdg_config_home(previous_xdg_config_home)
         File.rm_rf!(empty_dir)
       end)
 
@@ -697,12 +698,13 @@ defmodule Minga.Config.LoaderTest do
       empty_dir =
         Path.join(System.tmp_dir!(), "minga_empty_#{System.unique_integer([:positive])}")
 
+      previous_xdg_config_home = System.get_env("XDG_CONFIG_HOME")
       File.mkdir_p!(empty_dir)
       System.put_env("XDG_CONFIG_HOME", empty_dir)
 
       on_exit(fn ->
         Application.delete_env(:minga, :cli_startup_flags)
-        System.delete_env("XDG_CONFIG_HOME")
+        restore_xdg_config_home(previous_xdg_config_home)
         File.rm_rf!(empty_dir)
       end)
 
@@ -877,15 +879,27 @@ defmodule Minga.Config.LoaderTest do
     minga_dir = Path.join(base, "minga")
     File.mkdir_p!(minga_dir)
     File.write!(Path.join(minga_dir, "config.exs"), config_content)
+    previous_xdg_config_home = System.get_env("XDG_CONFIG_HOME")
     System.put_env("XDG_CONFIG_HOME", base)
 
     # The per-test Options server started in setup is auto-cleaned by
     # start_supervised!, so no explicit reset is needed here.
     cleanup = fn ->
-      System.delete_env("XDG_CONFIG_HOME")
+      restore_xdg_config_home(previous_xdg_config_home)
       File.rm_rf!(base)
     end
 
     {minga_dir, cleanup}
+  end
+
+  @spec restore_xdg_config_home(String.t() | nil) :: :ok
+  defp restore_xdg_config_home(nil) do
+    System.delete_env("XDG_CONFIG_HOME")
+    :ok
+  end
+
+  defp restore_xdg_config_home(path) when is_binary(path) do
+    System.put_env("XDG_CONFIG_HOME", path)
+    :ok
   end
 end

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -43,6 +43,7 @@ defmodule Minga.Config.OptionsTest do
                insert_final_newline: false,
                format_on_save: false,
                auto_save_delay_ms: 1000,
+               lsp_auto_start: true,
                formatter: nil,
                title_format: "{filename} {dirty}({directory}) - Minga",
                recent_files_limit: 200,
@@ -172,6 +173,12 @@ defmodule Minga.Config.OptionsTest do
       assert Options.get(s, :auto_save_delay_ms) == 0
       assert {:ok, 250} = Options.set(s, :auto_save_delay_ms, 250)
       assert Options.get(s, :auto_save_delay_ms) == 250
+    end
+
+    test "set and get lsp_auto_start", %{server: s} do
+      assert Options.get(s, :lsp_auto_start) == true
+      assert {:ok, false} = Options.set(s, :lsp_auto_start, false)
+      assert Options.get(s, :lsp_auto_start) == false
     end
 
     test "set and get startup_view", %{server: s} do

--- a/test/minga/core/overlay_test.exs
+++ b/test/minga/core/overlay_test.exs
@@ -83,10 +83,11 @@ defmodule Minga.Core.OverlayTest do
 
     test "rejects traversal that escapes the overlay", %{project: project} do
       {:ok, overlay} = Overlay.create(project)
-      escaped = Path.join(Path.dirname(overlay.overlay_dir), "escape.txt")
+      escaped_name = "escape-#{System.unique_integer([:positive])}.txt"
+      escaped = Path.join(Path.dirname(overlay.overlay_dir), escaped_name)
 
       assert {:error, :path_traversal} =
-               Overlay.materialize_file(overlay, "../escape.txt", "pwned")
+               Overlay.materialize_file(overlay, "../#{escaped_name}", "pwned")
 
       refute File.exists?(escaped)
 

--- a/test/minga/log_test.exs
+++ b/test/minga/log_test.exs
@@ -1,5 +1,6 @@
 defmodule Minga.LogTest do
-  use ExUnit.Case, async: true
+  # async: false — mutates global log options and uses capture_log, which captures global Logger output.
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
 

--- a/test/minga_agent/providers/native_hooks_test.exs
+++ b/test/minga_agent/providers/native_hooks_test.exs
@@ -68,9 +68,10 @@ defmodule MingaAgent.Providers.NativeHooksTest do
       )
 
     assert :ok = Native.send_prompt(pid, "run shell")
-    events = collect_events(1_000)
 
-    assert_received {:hook_payload, "tc_hook", "shell", %{"command" => "date"}}
+    assert_receive {:hook_payload, "tc_hook", "shell", %{"command" => "date"}}, 2_000
+
+    events = collect_events(2_000)
     refute_received :tool_callback_ran
 
     assert %Event.Error{message: error_message} = Enum.find(events, &match?(%Event.Error{}, &1))

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -345,7 +345,7 @@ defmodule MingaAgent.SessionTest do
       assert :ok = Session.send_prompt(session, "write a file")
 
       assert_receive {:provider_tool_result, {:error, {:plan_mode_refused, message}}},
-                     200
+                     @event_timeout
 
       assert message =~ "Plan mode"
       assert message =~ "write_file"

--- a/test/minga_editor/file_tree/rows_test.exs
+++ b/test/minga_editor/file_tree/rows_test.exs
@@ -1,0 +1,94 @@
+defmodule MingaEditor.FileTree.RowsTest do
+  @moduledoc "Tests semantic row construction for file-tree renderers."
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.Rows
+
+  @moduletag :tmp_dir
+
+  describe "from_tree/2" do
+    test "marks selected and focused rows", %{tmp_dir: tmp_dir} do
+      tree =
+        tmp_dir
+        |> flat_tree()
+        |> FileTree.select(1)
+
+      rows = Rows.from_tree(tree, focused: true)
+
+      assert Enum.at(rows, 0).selected? == false
+      selected = Enum.at(rows, 1)
+      assert selected.selected? == true
+      assert selected.focused? == true
+    end
+
+    test "marks active, dirty, and git state independently", %{tmp_dir: tmp_dir} do
+      tree = flat_tree(tmp_dir)
+      file_path = Path.join(tmp_dir, "alpha.ex")
+
+      [row | _] =
+        Rows.from_tree(tree,
+          active_path: file_path,
+          dirty_paths: MapSet.new([file_path]),
+          git_status: %{file_path => :modified}
+        )
+
+      assert row.path == file_path
+      assert row.active? == true
+      assert row.dirty? == true
+      assert row.git_status == :modified
+    end
+
+    test "does not mark directories dirty", %{tmp_dir: tmp_dir} do
+      File.mkdir_p!(Path.join(tmp_dir, "lib"))
+      tree = FileTree.new(tmp_dir)
+      dir_path = Path.join(tmp_dir, "lib")
+
+      [row] = Rows.from_tree(tree, dirty_paths: MapSet.new([dir_path]))
+
+      assert row.directory? == true
+      assert row.dirty? == false
+    end
+
+    test "attaches inline editing metadata only to the edited index", %{tmp_dir: tmp_dir} do
+      tree = flat_tree(tmp_dir)
+      editing = %{index: 1, text: "renamed.ex", type: :rename, original_name: "beta.ex"}
+
+      rows = Rows.from_tree(tree, editing: editing)
+
+      assert Enum.at(rows, 0).editing == nil
+      assert Enum.at(rows, 1).editing == editing
+    end
+
+    test "preserves nested depth, guides, and last-child metadata", %{tmp_dir: tmp_dir} do
+      File.mkdir_p!(Path.join([tmp_dir, "lib", "minga"]))
+      File.write!(Path.join([tmp_dir, "lib", "minga", "editor.ex"]), "")
+
+      tree =
+        FileTree.new(tmp_dir)
+        |> FileTree.expand_path(Path.join(tmp_dir, "lib"))
+        |> FileTree.expand_path(Path.join([tmp_dir, "lib", "minga"]))
+
+      row =
+        tree
+        |> Rows.from_tree()
+        |> Enum.find(&(&1.name == "editor.ex"))
+
+      assert row.depth == 2
+      assert row.guides == [false, false]
+      assert row.last_child? == true
+      assert row.relative_path == "lib/minga/editor.ex"
+    end
+
+    test "returns no rows for an empty visible tree", %{tmp_dir: tmp_dir} do
+      assert Rows.from_tree(FileTree.new(tmp_dir)) == []
+    end
+  end
+
+  defp flat_tree(tmp_dir) do
+    File.write!(Path.join(tmp_dir, "alpha.ex"), "")
+    File.write!(Path.join(tmp_dir, "beta.ex"), "")
+    FileTree.new(tmp_dir)
+  end
+end

--- a/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
+++ b/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
@@ -179,8 +179,13 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
       root_len = byte_size(root)
 
       assert Enum.any?(all_cmds, fn
-               <<0x70, 0::16, 0::16, 0::16, ^root_len::16, root_path::binary>> ->
-                 root_path == root
+               <<0x93, payload_len::32, payload::binary-size(payload_len)>> ->
+                 match?(
+                   <<1::8, tree_flags::8, 0::16, ^root_len::16, ^root::binary-size(root_len),
+                     0::16, 0::16>>
+                   when Bitwise.band(tree_flags, 0x10) != 0,
+                   payload
+                 )
 
                _ ->
                  false
@@ -221,8 +226,13 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
       assert caches.last_gui_file_tree_fp == {:no_tree, second_root}
 
       assert Enum.any?(all_cmds, fn
-               <<0x70, 0::16, 0::16, 0::16, ^root_len::16, root_path::binary>> ->
-                 root_path == second_root
+               <<0x93, payload_len::32, payload::binary-size(payload_len)>> ->
+                 match?(
+                   <<1::8, tree_flags::8, 0::16, ^root_len::16,
+                     ^second_root::binary-size(root_len), 0::16, 0::16>>
+                   when Bitwise.band(tree_flags, 0x10) != 0,
+                   payload
+                 )
 
                _ ->
                  false

--- a/test/minga_editor/frontend/protocol_schema_test.exs
+++ b/test/minga_editor/frontend/protocol_schema_test.exs
@@ -37,7 +37,7 @@ defmodule MingaEditor.Frontend.ProtocolSchemaTest do
     test "all GUI chrome opcode hex values match", %{schema: schema} do
       expected = schema["opcodes"]["gui_chrome"]
 
-      assert_opcode(expected, "gui_file_tree", 0x70)
+      assert_opcode(expected, "gui_file_tree", 0x93)
       assert_opcode(expected, "gui_tab_bar", 0x71)
       assert_opcode(expected, "gui_which_key", 0x72)
       assert_opcode(expected, "gui_completion", 0x73)

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -18,6 +18,9 @@ defmodule MingaEditor.Frontend.ProtocolTest do
        ),
        do: do_gui_agent_chat_section!(rest, target_id)
 
+  defp take_string16(<<len::16, value::binary-size(len), rest::binary>>), do: {value, rest}
+  defp take_string8(<<len::8, value::binary-size(len), rest::binary>>), do: {value, rest}
+
   # ── Modifier helpers ──
 
   describe "modifier flags" do
@@ -1070,118 +1073,172 @@ defmodule MingaEditor.Frontend.ProtocolTest do
       end
     end
 
-    @tag :tmp_dir
-    test "encodes gui_file_tree with root, path_hash, and rel_path per entry", %{
-      tmp_dir: tmp_dir
-    } do
-      File.write!(Path.join(tmp_dir, "hello.ex"), "")
+    test "encodes semantic gui_file_tree with length prefix, root, selection, and row fields" do
+      row =
+        MingaEditor.FileTree.Row.new(
+          id: "/project/lib/hello.ex",
+          path: "/project/lib/hello.ex",
+          relative_path: "lib/hello.ex",
+          name: "hello.ex",
+          directory?: false,
+          expanded?: false,
+          selected?: true,
+          focused?: true,
+          active?: true,
+          dirty?: true,
+          git_status: :modified,
+          depth: 1,
+          guides: [true, false],
+          last_child?: true,
+          editing: nil
+        )
 
-      tree = %Minga.Project.FileTree{
-        root: tmp_dir,
-        expanded: MapSet.new([tmp_dir]),
-        cursor: 0,
-        width: 30
-      }
+      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, true, true, [row])
 
-      encoded = ProtocolGUI.encode_gui_file_tree(tree)
+      assert <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
+      assert <<1::8, tree_flags::8, rest::binary>> = payload
+      assert Bitwise.band(tree_flags, 0x01) != 0
+      assert Bitwise.band(tree_flags, 0x02) != 0
 
-      # Header: opcode + cursor + width + count + root_len + root
-      root_len = byte_size(tmp_dir)
+      <<selected_len::16, selected::binary-size(selected_len), rest::binary>> = rest
+      assert selected == row.id
 
-      assert <<0x70, cursor::16, width::16, count::16, ^root_len::16, root::binary-size(root_len),
-               entry_rest::binary>> = encoded
+      <<root_len::16, root::binary-size(root_len), 30::16, 1::16, row_payload::binary>> = rest
+      assert root == "/project"
 
-      assert cursor == 0
-      assert width == 30
-      assert count == 1
-      assert root == tmp_dir
+      expected_hash = :erlang.phash2(row.id, 0xFFFFFFFF)
 
-      # Entry: path_hash + flags + depth + git_status + icon + name + rel_path
-      expected_path = Path.join(tmp_dir, "hello.ex")
-      expected_hash = :erlang.phash2(expected_path, 0xFFFFFFFF)
+      assert <<^expected_hash::32, row_flags::16, 1::8, 1::8, 0::16, 0::16, 0::16, 0::16, 2::8,
+               1::8, 0::8, strings::binary>> = row_payload
 
-      assert <<^expected_hash::32, flags::8, depth::8, _git::8, icon_len::8,
-               _icon::binary-size(icon_len), name_len::16, name::binary-size(name_len),
-               rel_path_len::16, rel_path::binary-size(rel_path_len)>> = entry_rest
+      assert Bitwise.band(row_flags, 0x04) != 0
+      assert Bitwise.band(row_flags, 0x08) != 0
+      assert Bitwise.band(row_flags, 0x10) != 0
+      assert Bitwise.band(row_flags, 0x20) != 0
+      assert Bitwise.band(row_flags, 0x80) != 0
 
-      assert flags == 0x04
-      assert depth == 0
-      assert name == "hello.ex"
-      assert rel_path == "hello.ex"
+      {id, strings} = take_string16(strings)
+      {path, strings} = take_string16(strings)
+      {rel_path, strings} = take_string16(strings)
+      {name, strings} = take_string16(strings)
+      {icon, strings} = take_string8(strings)
+      <<255::8, 0::16>> = strings
+
+      assert id == row.id
+      assert path == row.path
+      assert rel_path == row.relative_path
+      assert name == row.name
+      assert icon != ""
     end
 
-    @tag :tmp_dir
-    test "path_hash is stable across encodes", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "stable.txt"), "")
+    test "encodes semantic gui_file_tree string lengths as UTF-8 byte counts" do
+      row =
+        MingaEditor.FileTree.Row.new(
+          id: "/project/lib/ñ📄.ex",
+          path: "/project/lib/ñ📄.ex",
+          relative_path: "lib/ñ📄.ex",
+          name: "ñ📄.ex",
+          directory?: false,
+          expanded?: false,
+          selected?: true,
+          depth: 0,
+          guides: [],
+          last_child?: true,
+          editing: nil
+        )
 
-      tree = %Minga.Project.FileTree{
-        root: tmp_dir,
-        expanded: MapSet.new([tmp_dir]),
-        cursor: 0,
-        width: 30
-      }
+      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, true, false, [row])
+      <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
 
-      encoded1 = ProtocolGUI.encode_gui_file_tree(tree)
-      encoded2 = ProtocolGUI.encode_gui_file_tree(tree)
+      <<_version::8, _tree_flags::8, selected_len::16, selected::binary-size(selected_len),
+        root_len::16, _root::binary-size(root_len), _width::16, _count::16, _hash::32,
+        _row_flags::16, _depth::8, _git::8, _diag::binary-size(8), 0::8, strings::binary>> =
+        payload
 
-      # Skip header: opcode(1) + cursor(2) + width(2) + count(2) + root_len(2) + root
-      header_size = 9 + byte_size(tmp_dir)
-      <<_header1::binary-size(header_size), entry1::binary>> = encoded1
-      <<_header2::binary-size(header_size), entry2::binary>> = encoded2
-
-      <<hash1::32, _::binary>> = entry1
-      <<hash2::32, _::binary>> = entry2
-
-      assert hash1 == hash2
+      assert selected == row.id
+      assert selected_len == byte_size(row.id)
+      {_id, strings} = take_string16(strings)
+      {_path, strings} = take_string16(strings)
+      {rel_path, strings} = take_string16(strings)
+      {name, _strings} = take_string16(strings)
+      assert rel_path == row.relative_path
+      assert name == row.name
+      assert byte_size(name) > String.length(name)
     end
 
-    test "encodes gui_file_tree nil as zero entries" do
-      encoded = ProtocolGUI.encode_gui_file_tree(nil)
-      assert <<0x70, 0::16, 0::16, 0::16, 0::16>> = encoded
+    test "encodes semantic gui_file_tree payloads larger than 64KB without length truncation" do
+      rows =
+        for index <- 1..220 do
+          suffix = String.duplicate("nested-segment-", 20) <> Integer.to_string(index)
+
+          MingaEditor.FileTree.Row.new(
+            id: "/project/#{suffix}.ex",
+            path: "/project/#{suffix}.ex",
+            relative_path: "lib/#{suffix}.ex",
+            name: "#{suffix}.ex",
+            directory?: false,
+            expanded?: false,
+            selected?: index == 1,
+            depth: 2,
+            guides: [true, false],
+            last_child?: index == 220,
+            editing: nil
+          )
+        end
+
+      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, true, false, rows)
+
+      assert <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
+      assert payload_len == byte_size(payload)
+      assert payload_len > 65_535
     end
 
-    test "encodes hidden gui_file_tree with project root and zero entries" do
-      root = "/tmp/minga-project"
-      root_len = byte_size(root)
+    test "encodes hidden semantic gui_file_tree with project root and empty bit" do
+      encoded = ProtocolGUI.encode_hidden_gui_file_tree("/tmp/minga-project")
 
-      encoded = ProtocolGUI.encode_hidden_gui_file_tree(root)
+      assert <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
 
-      assert <<0x70, 0::16, 0::16, 0::16, ^root_len::16, root_path::binary>> = encoded
-      assert root_path == root
+      assert <<1::8, tree_flags::8, selected_len::16, selected::binary-size(selected_len),
+               root_len::16, root::binary-size(root_len), 0::16, 0::16>> = payload
+
+      assert selected == ""
+
+      refute Bitwise.band(tree_flags, 0x01) != 0
+      assert Bitwise.band(tree_flags, 0x10) != 0
+      assert root == "/tmp/minga-project"
     end
 
-    @tag :tmp_dir
-    test "encodes gui_file_tree with editing payload on the editing entry", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "target.txt"), "")
+    test "encodes semantic gui_file_tree editing payload" do
+      row =
+        MingaEditor.FileTree.Row.new(
+          id: "/project/target.txt",
+          path: "/project/target.txt",
+          relative_path: "target.txt",
+          name: "target.txt",
+          directory?: false,
+          expanded?: false,
+          selected?: true,
+          depth: 0,
+          guides: [],
+          last_child?: true,
+          editing: %{index: 0, text: "renamed.txt", type: :rename, original_name: "target.txt"}
+        )
 
-      tree = %Minga.Project.FileTree{
-        root: tmp_dir,
-        expanded: MapSet.new([tmp_dir]),
-        cursor: 0,
-        width: 30
-      }
+      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, true, true, [row])
+      <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
+      # Skip tree header and fixed row prefix.
+      <<_version::8, _tree_flags::8, selected_len::16, _selected::binary-size(selected_len),
+        root_len::16, _root::binary-size(root_len), _width::16, _count::16, _hash::32,
+        row_flags::16, _depth::8, _git::8, _diag::binary-size(8), 0::8, strings::binary>> =
+        payload
 
-      editing = %{index: 0, text: "renamed.txt", type: :rename, original_name: "target.txt"}
-      encoded = ProtocolGUI.encode_gui_file_tree(tree, editing)
-
-      # Skip header
-      root_len = byte_size(tmp_dir)
-
-      <<0x70, _cursor::16, _width::16, _count::16, ^root_len::16, _root::binary-size(root_len),
-        entry_rest::binary>> = encoded
-
-      # Entry fields: path_hash(4) + flags(1) + depth(1) + git(1) + icon_len(1) + icon
-      # + name_len(2) + name + rel_path_len(2) + rel_path + editing_payload
-      <<_hash::32, flags::8, _depth::8, _git::8, icon_len::8, _icon::binary-size(icon_len),
-        name_len::16, _name::binary-size(name_len), rel_path_len::16,
-        _rel_path::binary-size(rel_path_len), editing_type::8, editing_text_len::16,
-        editing_text::binary-size(editing_text_len)>> =
-        entry_rest
-
-      # flags bit 3 should be set (is_editing)
-      assert Bitwise.band(flags, 0x08) != 0
-      # editing_type 2 = rename
-      assert editing_type == 2
+      assert Bitwise.band(row_flags, 0x40) != 0
+      {_id, strings} = take_string16(strings)
+      {_path, strings} = take_string16(strings)
+      {_rel_path, strings} = take_string16(strings)
+      {_name, strings} = take_string16(strings)
+      {_icon, strings} = take_string8(strings)
+      <<2::8, editing_text_len::16, editing_text::binary-size(editing_text_len)>> = strings
       assert editing_text == "renamed.txt"
     end
 

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -866,48 +866,78 @@ defmodule Minga.Integration.GUIProtocolTest do
   end
 
   describe "gui_file_tree visible" do
-    test "round-trips visible file tree with entries", %{port: port} do
-      # Raw binary: selected_index(2), tree_width(2), entry_count(2), root_len(2), root
-      # Per entry: path_hash(4), flags(1), depth(1), git_status(1), icon_len(1), icon,
-      #            name_len(2), name, rel_path_len(2), rel_path
+    test "round-trips semantic visible file tree with entries", %{port: port} do
       root = "/project"
-      name1 = "lib"
-      rel1 = "lib"
-      icon1 = <<0xF0, 0x9F, 0x93, 0x81>>
-      name2 = "editor.ex"
-      rel2 = "lib/editor.ex"
 
-      entry1 =
-        <<0xAA, 0xBB, 0xCC, 0xDD::8, 0x07::8, 0::8, 0::8, byte_size(icon1)::8, icon1::binary,
-          byte_size(name1)::16, name1::binary, byte_size(rel1)::16, rel1::binary>>
+      rows = [
+        MingaEditor.FileTree.Row.new(
+          id: "/project/lib",
+          path: "/project/lib",
+          relative_path: "lib",
+          name: "lib",
+          directory?: true,
+          expanded?: true,
+          selected?: true,
+          focused?: true,
+          depth: 0,
+          guides: [],
+          last_child?: false,
+          editing: nil
+        ),
+        MingaEditor.FileTree.Row.new(
+          id: "/project/lib/editor.ex",
+          path: "/project/lib/editor.ex",
+          relative_path: "lib/editor.ex",
+          name: "editor.ex",
+          directory?: false,
+          expanded?: false,
+          active?: true,
+          dirty?: true,
+          git_status: :modified,
+          depth: 1,
+          guides: [true],
+          last_child?: true,
+          editing: %{
+            index: 1,
+            text: "editor_renamed.ex",
+            type: :rename,
+            original_name: "editor.ex"
+          }
+        )
+      ]
 
-      entry2 =
-        <<0x11, 0x22, 0x33, 0x44::8, 0x00::8, 1::8, 1::8, 0::8, byte_size(name2)::16,
-          name2::binary, byte_size(rel2)::16, rel2::binary>>
-
-      cmd =
-        <<0x70, 1::16, 30::16, 2::16, byte_size(root)::16, root::binary, entry1::binary,
-          entry2::binary>>
-
-      Port.command(port, cmd)
+      Port.command(port, ProtocolGUI.encode_gui_file_tree(root, 30, true, true, rows))
 
       assert_receive {^port, {:data, json}}, 5_000
       decoded = Jason.decode!(json)
 
       assert decoded["type"] == "gui_file_tree"
-      assert decoded["selected_index"] == 1
+      assert decoded["version"] == 1
+      assert Bitwise.band(decoded["tree_flags"], 0x01) != 0
+      assert Bitwise.band(decoded["tree_flags"], 0x02) != 0
+      assert decoded["selected_id"] == "/project/lib"
       assert decoded["tree_width"] == 30
       assert decoded["root_path"] == "/project"
       assert length(decoded["entries"]) == 2
 
       [e1, e2] = decoded["entries"]
+      assert e1["id"] == "/project/lib"
+      assert e1["path"] == "/project/lib"
       assert e1["name"] == "lib"
+      assert e1["relative_path"] == "lib"
       assert e1["is_dir"] == true
       assert e1["is_expanded"] == true
       assert e1["is_selected"] == true
+      assert e1["is_focused"] == true
       assert e1["depth"] == 0
+
+      assert e2["id"] == "/project/lib/editor.ex"
       assert e2["name"] == "editor.ex"
+      assert e2["relative_path"] == "lib/editor.ex"
       assert e2["is_dir"] == false
+      assert e2["is_active"] == true
+      assert e2["is_dirty"] == true
+      assert e2["is_editing"] == true
       assert e2["depth"] == 1
       assert e2["git_status"] == 1
     end

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -117,7 +117,7 @@ defmodule MingaEditor.Renderer.ServerTest do
 
       RendererServer.cast_snapshot(renderer, snapshot, 124)
 
-      assert_receive {:render_done, %{frame_seq: 124}}
+      assert_receive {:render_done, %{frame_seq: 124}}, 1_000
       server_state = drain_renderer_until_idle(renderer)
       assert FontRegistry.lookup(server_state.font_registry, "Fira Code") == 1
       refute Map.has_key?(Map.from_struct(state), :font_registry)

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -3,9 +3,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.Row
   alias MingaEditor.Shell.Traditional.TreeRenderer
   alias MingaEditor.Shell.Traditional.TreeRenderer.RenderInput
-  alias Minga.Project.FileTree
   alias MingaEditor.UI.Theme
 
   @moduletag :tmp_dir
@@ -18,9 +19,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
     File.write!(Path.join(tmp_dir, "test/main_test.exs"), "defmodule MainTest do\nend\n")
 
     tree = FileTree.new(tmp_dir, width: 20)
-    # Expand lib directory
-    lib_path = Path.join(tmp_dir, "lib")
-    %{tree | expanded: MapSet.put(tree.expanded, lib_path)}
+    FileTree.expand_path(tree, Path.join(tmp_dir, "lib"))
   end
 
   describe "render/1 with RenderInput" do
@@ -113,6 +112,46 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       # guide segment, icon segment, name segment
       row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
       assert length(row1_draws) >= 2
+    end
+
+    test "renders supplied semantic rows", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "main.ex")
+      File.write!(file_path, "defmodule Main do\nend\n")
+      tree = FileTree.new(tmp_dir, width: 30)
+
+      rows = [
+        Row.new(
+          id: file_path,
+          path: file_path,
+          relative_path: "main.ex",
+          name: "main.ex",
+          directory?: false,
+          expanded?: false,
+          selected?: true,
+          focused?: true,
+          active?: true,
+          dirty?: true,
+          git_status: :modified,
+          depth: 0,
+          guides: [],
+          last_child?: true
+        )
+      ]
+
+      input = %RenderInput{
+        tree: tree,
+        rect: {0, 0, 30, 5},
+        focused: false,
+        theme: Theme.get!(:doom_one),
+        active_path: nil,
+        rows: rows
+      }
+
+      draws = TreeRenderer.render(input)
+      all_text = Enum.map_join(draws, fn {_r, _c, text, _s} -> text end)
+
+      assert String.contains?(all_text, "main.ex")
+      assert String.contains?(all_text, "●")
     end
 
     test "renders git status indicators right-aligned", %{tmp_dir: tmp_dir} do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -19,6 +19,15 @@ System.put_env("GIT_CONFIG_COUNT", "1")
 System.put_env("GIT_CONFIG_KEY_0", "init.defaultBranch")
 System.put_env("GIT_CONFIG_VALUE_0", "main")
 
+# Keep direct test invocations hermetic if config/test.exs was not loaded first.
+unless System.get_env("XDG_CONFIG_HOME") do
+  test_config_home =
+    Path.join(System.tmp_dir!(), "minga-test-config-#{System.unique_integer([:positive])}")
+
+  File.mkdir_p!(Path.join(test_config_home, "minga"))
+  System.put_env("XDG_CONFIG_HOME", test_config_home)
+end
+
 # Auto-build the Swift test harness on macOS if swiftc is available.
 # On Linux (CI), the harness tests are excluded automatically.
 harness_path = Path.join(:code.priv_dir(:minga), "minga-test-harness")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -41,6 +41,10 @@ Minga.Config.Options.set(:clipboard, :none)
 # unrelated file-buffer tests. Auto-save tests opt in per buffer.
 Minga.Config.Options.set(:auto_save_delay_ms, 0)
 
+# Disable LSP auto-start globally in tests so unrelated buffer-open events do
+# not leak real language-server clients into tests that assert no LSP is active.
+Minga.Config.Options.set(:lsp_auto_start, false)
+
 # Disable persisting known projects and recent files during tests to avoid
 # polluting ~/.config/minga/known-projects with test fixture directories.
 Minga.Config.Options.set(:persist_known_projects, false)


### PR DESCRIPTION
## Summary

- Add `MingaEditor.FileTree.Row` and `MingaEditor.FileTree.Rows` as the shared Layer 2 semantic row contract for file-tree renderers.
- Keep `Minga.Project.FileTree` presentation-agnostic while adding ownership helpers for selection and path expansion.
- Refactor the traditional TUI tree renderer and file-tree input cursor handling to consume row semantics instead of reconstructing them locally.
- Stabilize full-suite flakes found while validating this work by disabling test LSP auto-start and fixing async/global-state test assumptions.

Closes #1639.
Relates to #1638.

## Validation

- `mix test.llm` passed: 8515 tests, 54 doctests, 97 properties, 0 failures
- `make lint` passed
- `git diff --check` passed
- Final reviewer targeted re-check: PASS
