### PR TITLE
fix(macos): align completion popup and arrow navigation

### DIFF
--- a/lib/minga/editing/completion.ex
+++ b/lib/minga/editing/completion.ex
@@ -148,6 +148,21 @@ defmodule Minga.Editing.Completion do
 
   # ── Selection ────────────────────────────────────────────────────────────────
 
+  @doc "Selects an item by its offset in the current visible completion window."
+  @spec select_visible(t(), non_neg_integer()) :: t()
+  def select_visible(%__MODULE__{filtered: []} = completion, _offset), do: completion
+
+  def select_visible(%__MODULE__{} = completion, offset)
+      when is_integer(offset) and offset >= 0 do
+    {visible, _selected_offset} = visible_items(completion)
+
+    if Enum.at(visible, offset) == nil do
+      completion
+    else
+      %{completion | selected: visible_start(completion) + offset}
+    end
+  end
+
   @doc "Returns the currently selected item, or nil if no items."
   @spec selected_item(t()) :: item() | nil
   def selected_item(%__MODULE__{filtered: []}), do: nil
@@ -188,27 +203,26 @@ defmodule Minga.Editing.Completion do
   @spec visible_items(t()) :: {[item()], non_neg_integer()}
   def visible_items(%__MODULE__{filtered: []}), do: {[], 0}
 
-  def visible_items(%__MODULE__{filtered: filtered, selected: sel, max_visible: max_vis}) do
-    total = length(filtered)
-
-    {start, count} =
-      cond do
-        total <= max_vis ->
-          {0, total}
-
-        sel < div(max_vis, 2) ->
-          {0, max_vis}
-
-        sel >= total - div(max_vis, 2) ->
-          {total - max_vis, max_vis}
-
-        true ->
-          {sel - div(max_vis, 2), max_vis}
-      end
-
-    visible = Enum.slice(filtered, start, count)
+  def visible_items(%__MODULE__{filtered: filtered, selected: sel, max_visible: max_vis} = c) do
+    start = visible_start(c)
+    visible = Enum.slice(filtered, start, min(length(filtered), max_vis))
     {visible, sel - start}
   end
+
+  @spec visible_start(t()) :: non_neg_integer()
+  defp visible_start(%__MODULE__{filtered: filtered, selected: sel, max_visible: max_vis}) do
+    visible_start(length(filtered), sel, max_vis)
+  end
+
+  @spec visible_start(non_neg_integer(), non_neg_integer(), pos_integer()) :: non_neg_integer()
+  defp visible_start(total, _sel, max_vis) when total <= max_vis, do: 0
+  defp visible_start(_total, sel, max_vis) when sel < div(max_vis, 2), do: 0
+
+  defp visible_start(total, sel, max_vis) when sel >= total - div(max_vis, 2) do
+    total - max_vis
+  end
+
+  defp visible_start(_total, sel, max_vis), do: sel - div(max_vis, 2)
 
   @doc "Returns true if there are any filtered items to show."
   @spec active?(t()) :: boolean()

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -2118,12 +2118,7 @@ defmodule MingaEditor do
   defp handle_gui_action(state, {:completion_select, index}) do
     case MingaEditor.State.ModalOverlay.completion(state) do
       %Completion{} = comp ->
-        updated = %{comp | selected: index}
-
-        do_accept_completion(
-          MingaEditor.State.ModalOverlay.update_completion(state, fn _ -> updated end),
-          updated
-        )
+        accept_visible_completion(state, comp, index)
 
       nil ->
         state
@@ -2427,6 +2422,24 @@ defmodule MingaEditor do
     state
     |> EditorState.clear_git_toast()
     |> Commands.Git.execute(:git_pull_and_retry)
+  end
+
+  @spec accept_visible_completion(state(), Completion.t(), non_neg_integer()) :: state()
+  defp accept_visible_completion(state, comp, index) do
+    {visible, _selected_offset} = Completion.visible_items(comp)
+
+    case Enum.at(visible, index) do
+      nil ->
+        state
+
+      _item ->
+        updated = Completion.select_visible(comp, index)
+
+        do_accept_completion(
+          MingaEditor.State.ModalOverlay.update_completion(state, fn _ -> updated end),
+          updated
+        )
+    end
   end
 
   # Project.switch/1 is a cast; the picker opens against current state while the

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -31,6 +31,7 @@ defmodule MingaEditor.Frontend.Emit.GUI do
   alias MingaEditor.Layout
   alias MingaEditor.MinibufferData
   alias MingaEditor.Renderer.Caches
+  alias MingaEditor.Renderer.Gutter
   alias MingaEditor.Shell.Traditional.Chrome.Helpers, as: ChromeHelpers
   alias MingaEditor.RenderPipeline.ContentHelpers
   alias MingaEditor.State.TabBar
@@ -356,23 +357,40 @@ defmodule MingaEditor.Frontend.Emit.GUI do
 
   @spec current_cursor_screen_pos(ctx()) :: {non_neg_integer(), non_neg_integer()}
   defp current_cursor_screen_pos(ctx) do
+    active = ctx.windows.active
     layout = ctx.layout
 
-    case Map.get(layout.window_layouts, ctx.windows.active) do
-      %{content: {row, col, _w, _h}} ->
-        buf = ctx.buffers.active
+    case {Map.get(layout.window_layouts, active), Map.get(ctx.windows.map, active)} do
+      {%{content: {row, col, _w, _h}}, %{buffer: buf, viewport: viewport} = window}
+      when is_pid(buf) ->
+        {line, column} = Buffer.cursor(buf)
+        total_lines = Buffer.line_count(buf)
+        line_number_style = Buffer.get_option(buf, :line_numbers)
 
-        if buf do
-          {line, column} = Buffer.cursor(buf)
-          vp = ctx.viewport
-          {row + line - vp.top, col + column}
-        else
-          {row, col}
-        end
+        number_width =
+          if line_number_style == :none, do: 0, else: Viewport.gutter_width(total_lines)
 
-      nil ->
+        gutter_width = Gutter.total_width(number_width)
+        visible_line = visible_cursor_line(window, line)
+
+        {
+          max(row + visible_line - viewport.top, 0),
+          max(col + column + gutter_width - viewport.left, 0)
+        }
+
+      {%{content: {row, col, _w, _h}}, _window} ->
+        {row, col}
+
+      _ ->
         {0, 0}
     end
+  catch
+    :exit, _ -> {0, 0}
+  end
+
+  @spec visible_cursor_line(MingaEditor.Window.t(), non_neg_integer()) :: non_neg_integer()
+  defp visible_cursor_line(%{fold_map: fold_map}, line) do
+    if FoldMap.empty?(fold_map), do: line, else: FoldMap.buffer_to_visible(fold_map, line)
   end
 
   # ── Breadcrumb ──

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -1136,7 +1136,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   end
 
   def encode_gui_completion(%Minga.Editing.Completion{} = comp, cursor_row, cursor_col) do
-    items = Enum.take(comp.filtered, comp.max_visible)
+    {items, selected_offset} = Minga.Editing.Completion.visible_items(comp)
 
     entries =
       Enum.map(items, fn item ->
@@ -1150,7 +1150,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
     IO.iodata_to_binary([
       @op_gui_completion,
-      <<1::8, cursor_row::16, cursor_col::16, comp.selected::16, length(items)::16>>
+      <<1::8, cursor_row::16, cursor_col::16, selected_offset::16, length(items)::16>>
       | entries
     ])
   end

--- a/lib/minga_editor/input/completion.ex
+++ b/lib/minga_editor/input/completion.ex
@@ -26,8 +26,12 @@ defmodule MingaEditor.Input.Completion do
   @escape 27
   @tab 9
   @enter 13
-  @arrow_up 0x415B1B
-  @arrow_down 0x425B1B
+  @arrow_up_legacy 0x415B1B
+  @arrow_down_legacy 0x425B1B
+  @arrow_up_kitty 57_352
+  @arrow_down_kitty 57_353
+  @arrow_up_mac 0xF700
+  @arrow_down_mac 0xF701
 
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
@@ -171,14 +175,7 @@ defmodule MingaEditor.Input.Completion do
 
   @spec set_completion_selected(Completion.t(), non_neg_integer()) :: Completion.t()
   defp set_completion_selected(%Completion{} = completion, idx) do
-    # The visible items are a window into filtered. We need to compute
-    # the absolute index in filtered from the visible window offset.
-    {_visible, _selected_offset} = Completion.visible_items(completion)
-    total = length(completion.filtered)
-    scroll_start = max(0, completion.selected - div(completion.max_visible, 2))
-    scroll_start = min(scroll_start, max(0, total - completion.max_visible))
-    absolute_idx = min(scroll_start + idx, total - 1)
-    %{completion | selected: absolute_idx}
+    Completion.select_visible(completion, idx)
   end
 
   # ── Key handling ─────────────────────────────────────────────────────────
@@ -193,14 +190,16 @@ defmodule MingaEditor.Input.Completion do
 
   # C-n or arrow down: move selection down
   defp do_handle(state, _completion, cp, mods)
-       when (cp == ?n and band(mods, @ctrl) != 0) or cp == @arrow_down do
+       when (cp == ?n and band(mods, @ctrl) != 0) or
+              cp in [@arrow_down_legacy, @arrow_down_kitty, @arrow_down_mac] do
     state = ModalOverlay.update_completion(state, &Completion.move_down/1)
     {:handled, CompletionHandling.maybe_resolve_selected(state)}
   end
 
   # C-p or arrow up: move selection up
   defp do_handle(state, _completion, cp, mods)
-       when (cp == ?p and band(mods, @ctrl) != 0) or cp == @arrow_up do
+       when (cp == ?p and band(mods, @ctrl) != 0) or
+              cp in [@arrow_up_legacy, @arrow_up_kitty, @arrow_up_mac] do
     state = ModalOverlay.update_completion(state, &Completion.move_up/1)
     {:handled, CompletionHandling.maybe_resolve_selected(state)}
   end

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -578,6 +578,27 @@ struct ContentView: View {
 
     // MARK: - Editor Surface (Metal + editor-local overlays)
 
+    private func completionOverlayCursor() -> (row: Int, col: Int, gutterPad: CGFloat) {
+        guard let nsView = appState.editorNSView else {
+            return (appState.gui.completionState.anchorRow, appState.gui.completionState.anchorCol, 0)
+        }
+
+        let frameState = nsView.dispatcher.frameState
+        let gutterPad: CGFloat
+
+        if frameState.gutterCol > 0 {
+            if frameState.cursorCol >= frameState.gutterCol {
+                gutterPad = CoreTextMetalRenderer.gutterLeftMarginPt + CoreTextMetalRenderer.gutterRightGapPt
+            } else {
+                gutterPad = CoreTextMetalRenderer.gutterLeftMarginPt
+            }
+        } else {
+            gutterPad = 0
+        }
+
+        return (Int(frameState.cursorRow), Int(frameState.cursorCol), gutterPad)
+    }
+
     private var editorSurface: some View {
         ZStack(alignment: .topLeading) {
             // Metal editor surface (always present for input handling).
@@ -607,15 +628,14 @@ struct ContentView: View {
             if appState.gui.completionState.visible {
                 let cw = CGFloat(appState.editorNSView?.cellWidth ?? 8)
                 let ch = CGFloat(appState.editorNSView?.cellHeight ?? 16)
-                let x = CGFloat(appState.gui.completionState.anchorCol) * cw
-                let y = (CGFloat(appState.gui.completionState.anchorRow) + 1) * ch
+                let cursor = completionOverlayCursor()
+                let x = CGFloat(cursor.col) * cw + cursor.gutterPad
+                let y = (CGFloat(cursor.row) + 1) * ch
 
                 CompletionOverlay(
                     state: appState.gui.completionState,
                     theme: appState.gui.themeColors,
-                    encoder: appState.encoder,
-                    cellWidth: cw,
-                    cellHeight: ch
+                    encoder: appState.encoder
                 )
                 .offset(x: x, y: y)
             }

--- a/macos/Sources/Views/CompletionOverlay.swift
+++ b/macos/Sources/Views/CompletionOverlay.swift
@@ -10,8 +10,6 @@ struct CompletionOverlay: View {
     let state: CompletionState
     let theme: ThemeColors
     let encoder: InputEncoder?
-    let cellWidth: CGFloat
-    let cellHeight: CGFloat
 
     private let maxVisibleItems = 10
     private let itemHeight: CGFloat = 24

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -25,7 +25,7 @@ struct CompletionOverlayViewTests {
 
         let sut = CompletionOverlay(
             state: state, theme: ThemeColors(),
-            encoder: nil, cellWidth: 8, cellHeight: 16
+            encoder: nil
         )
 
         // When not visible, the body should produce no content
@@ -49,7 +49,7 @@ struct CompletionOverlayViewTests {
 
         let sut = CompletionOverlay(
             state: state, theme: ThemeColors(),
-            encoder: nil, cellWidth: 8, cellHeight: 16
+            encoder: nil
         )
 
         let body = try sut.inspect()

--- a/test/minga/editing/completion_test.exs
+++ b/test/minga/editing/completion_test.exs
@@ -42,6 +42,24 @@ defmodule Minga.Editing.CompletionTest do
     }
   ]
 
+  defp many_items_completion(count) do
+    0..(count - 1)
+    |> Enum.map(fn index ->
+      label = "item_" <> String.pad_leading(Integer.to_string(index), 2, "0")
+
+      %{
+        label: label,
+        kind: :function,
+        insert_text: label,
+        filter_text: label,
+        detail: "",
+        sort_text: label,
+        text_edit: nil
+      }
+    end)
+    |> Completion.new({0, 0})
+  end
+
   describe "new/2" do
     test "creates completion with sorted items" do
       comp = Completion.new(@sample_items, {0, 5})
@@ -135,6 +153,25 @@ defmodule Minga.Editing.CompletionTest do
     test "move_up on empty is no-op" do
       comp = Completion.new([], {0, 0})
       assert Completion.move_up(comp) == comp
+    end
+  end
+
+  describe "select_visible/2" do
+    test "selects by visible window offset" do
+      comp = many_items_completion(15)
+      comp = %{comp | selected: 7}
+
+      selected = Completion.select_visible(comp, 3)
+
+      assert selected.selected == 5
+      assert Completion.selected_item(selected).label == "item_05"
+    end
+
+    test "ignores offsets outside the visible window" do
+      comp = many_items_completion(15)
+      comp = %{comp | selected: 7}
+
+      assert Completion.select_visible(comp, 99) == comp
     end
   end
 

--- a/test/minga_editor/frontend/gui_completion_protocol_test.exs
+++ b/test/minga_editor/frontend/gui_completion_protocol_test.exs
@@ -1,0 +1,53 @@
+defmodule MingaEditor.Frontend.GUICompletionProtocolTest do
+  @moduledoc "Tests for GUI completion protocol encoding."
+  use ExUnit.Case, async: true
+
+  alias Minga.Editing.Completion
+  alias MingaEditor.Frontend.Protocol.GUI
+
+  test "encode_gui_completion sends the visible completion window and selected offset" do
+    comp = many_items_completion(15)
+    comp = %{comp | selected: 7}
+
+    <<0x73, 1, 4::16, 12::16, selected_offset::16, count::16, entries::binary>> =
+      GUI.encode_gui_completion(comp, 4, 12)
+
+    assert selected_offset == 5
+    assert count == 10
+    assert decode_labels(entries, count) == Enum.map(2..11, &label/1)
+  end
+
+  defp many_items_completion(count) do
+    0..(count - 1)
+    |> Enum.map(fn index ->
+      label = label(index)
+
+      %{
+        label: label,
+        kind: :function,
+        insert_text: label,
+        filter_text: label,
+        detail: "",
+        documentation: "",
+        sort_text: label,
+        text_edit: nil,
+        raw: nil
+      }
+    end)
+    |> Completion.new({0, 0})
+  end
+
+  defp label(index), do: "item_" <> String.pad_leading(Integer.to_string(index), 2, "0")
+
+  defp decode_labels(entries, count), do: decode_labels(entries, count, [])
+  defp decode_labels(_entries, 0, acc), do: Enum.reverse(acc)
+
+  defp decode_labels(
+         <<_kind, label_len::16, label::binary-size(label_len), detail_len::16,
+           _detail::binary-size(detail_len), rest::binary>>,
+         count,
+         acc
+       ) do
+    decode_labels(rest, count - 1, [label | acc])
+  end
+end

--- a/test/minga_editor/input/completion_key_test.exs
+++ b/test/minga_editor/input/completion_key_test.exs
@@ -1,0 +1,93 @@
+defmodule MingaEditor.Input.CompletionKeyTest do
+  @moduledoc "Tests for keyboard interaction with the completion popup."
+  use ExUnit.Case, async: true
+
+  alias Minga.Editing.Completion
+  alias Minga.Mode
+  alias MingaEditor.Input.Completion, as: CompletionInput
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
+  alias MingaEditor.State.WhichKey
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+
+  @arrow_up_legacy 0x415B1B
+  @arrow_down_legacy 0x425B1B
+  @arrow_up_kitty 57_352
+  @arrow_down_kitty 57_353
+  @arrow_up_mac 0xF700
+  @arrow_down_mac 0xF701
+
+  defp completion_state do
+    completion = Completion.new(sample_items(), {0, 0})
+    payload = CompletionPayload.new(:tab1, completion: completion)
+
+    %EditorState{
+      port_manager: nil,
+      backend: :headless,
+      shell_state: %MingaEditor.Shell.Traditional.State{
+        modal: {:completion, payload},
+        whichkey: %WhichKey{}
+      },
+      workspace: %MingaEditor.Workspace.State{
+        editing: %VimState{mode: :insert, mode_state: Mode.initial_state()},
+        viewport: Viewport.new(30, 80)
+      }
+    }
+  end
+
+  defp sample_items do
+    [
+      completion_item("append"),
+      completion_item("apply"),
+      completion_item("assert")
+    ]
+  end
+
+  defp completion_item(label) do
+    %{
+      label: label,
+      insert_text: label,
+      filter_text: label,
+      kind: :function,
+      detail: "",
+      documentation: "",
+      sort_text: label,
+      text_edit: nil,
+      raw: nil
+    }
+  end
+
+  describe "arrow keys" do
+    test "kitty down/up arrows navigate completion selection" do
+      state = completion_state()
+
+      {:handled, state} = CompletionInput.handle_key(state, @arrow_down_kitty, 0)
+      assert ModalOverlay.completion(state).selected == 1
+
+      {:handled, state} = CompletionInput.handle_key(state, @arrow_up_kitty, 0)
+      assert ModalOverlay.completion(state).selected == 0
+    end
+
+    test "macOS down/up arrows navigate completion selection" do
+      state = completion_state()
+
+      {:handled, state} = CompletionInput.handle_key(state, @arrow_down_mac, 0)
+      assert ModalOverlay.completion(state).selected == 1
+
+      {:handled, state} = CompletionInput.handle_key(state, @arrow_up_mac, 0)
+      assert ModalOverlay.completion(state).selected == 0
+    end
+
+    test "legacy escape-sequence down/up arrows still navigate completion selection" do
+      state = completion_state()
+
+      {:handled, state} = CompletionInput.handle_key(state, @arrow_down_legacy, 0)
+      assert ModalOverlay.completion(state).selected == 1
+
+      {:handled, state} = CompletionInput.handle_key(state, @arrow_up_legacy, 0)
+      assert ModalOverlay.completion(state).selected == 0
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR
Fixes macOS GUI completion so the popup anchors to the rendered cursor and arrow keys navigate the candidate list.

## Context
The completion popup could appear offset from where text was being entered in the native macOS frontend, and pressing Up/Down while the popup was visible did not move the selected candidate.

## Changes
- Position the SwiftUI completion popup from the live Metal `FrameState` cursor, including the same gutter padding used for IME cursor placement.
- Tighten the BEAM-side GUI completion cursor calculation so it accounts for the active window viewport, folds, horizontal scroll, and gutter width.
- Teach the completion input handler to consume Kitty, macOS, and legacy Up/Down arrow encodings while a completion popup is active.
- Send the same visible completion window to GUI frontends that the TUI uses, so scrolling past the first 10 candidates keeps the highlighted item and click targets aligned.
- Move visible-window selection math into `Minga.Editing.Completion` so mouse and GUI actions do not duplicate or mutate completion structs directly.
- Remove unused `cellWidth` and `cellHeight` inputs from `CompletionOverlay`.
- Add focused keyboard, completion model, and GUI protocol tests.

## Verification
- `mix compile --warnings-as-errors`
- `mix test.debug test/minga/editing/completion_test.exs test/minga_editor/frontend/gui_completion_protocol_test.exs test/minga_editor/input/completion_key_test.exs test/minga_editor/input/completion_mouse_test.exs`
- `mix swift.build`
- `XDG_CONFIG_HOME=$(mktemp -d) mix test.llm` (8515 tests, 0 failures)

Note: running the suite without an isolated config currently picks up invalid local user config at `~/.config/minga/config.exs` and fails unrelated tests that assert an empty status message. Isolating `XDG_CONFIG_HOME` avoids that local-only config error.

## Acceptance Criteria Addressed
- Completion popup appears at the typing location in the macOS GUI ✅
- Up/Down arrows navigate the completion list ✅
