### PR TITLE
feat(ui): separate file tree row states

### DIFF
--- a/lib/minga_editor/shell/traditional/tree_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tree_renderer.ex
@@ -375,13 +375,17 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
 
   # ── Style helpers ──────────────────────────────────────────────────────
 
+  # Visual state priority is layered, not mutually exclusive:
+  # inline editing owns the whole row, then selection owns the row background.
+  # Active file owns name/icon emphasis, dirty owns the modified-buffer marker.
+  # Git owns the git marker, and directory emphasis is the base fallback.
   @spec row_background(boolean(), boolean(), Theme.t()) :: Face.t()
   defp row_background(true = _is_cursor, true = _focused, theme) do
-    Face.new(bg: theme.tree.dir_fg)
+    Face.new(bg: theme.tree.cursor_bg)
   end
 
   defp row_background(true = _is_cursor, false = _focused, theme) do
-    Face.new(bg: theme.tree.cursor_bg)
+    Face.new(bg: theme.tree.separator_fg)
   end
 
   defp row_background(false = _is_cursor, _focused, theme) do
@@ -389,46 +393,19 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   end
 
   @spec guide_draw_style(boolean(), boolean(), Theme.t()) :: Face.t()
-  defp guide_draw_style(true = _is_cursor, true = _focused, theme) do
-    Face.new(fg: theme.tree.bg, bg: theme.tree.dir_fg)
-  end
-
-  defp guide_draw_style(true = _is_cursor, false = _focused, theme) do
-    Face.new(fg: theme.tree.separator_fg, bg: theme.tree.cursor_bg)
-  end
-
-  defp guide_draw_style(_is_cursor, _focused, theme) do
-    Face.new(fg: theme.tree.separator_fg, bg: theme.tree.bg)
+  defp guide_draw_style(is_cursor, focused, theme) do
+    Face.new(fg: theme.tree.separator_fg, bg: row_bg_color(is_cursor, focused, theme))
   end
 
   @spec icon_draw_style(non_neg_integer(), boolean(), boolean(), Theme.t()) :: Face.t()
-  defp icon_draw_style(_icon_color, true = _is_cursor, true = _focused, theme) do
-    # Focused cursor row: invert, use bg as fg
-    Face.new(fg: theme.tree.bg, bg: theme.tree.dir_fg)
-  end
-
-  defp icon_draw_style(icon_color, true = _is_cursor, false = _focused, theme) do
-    Face.new(fg: icon_color, bg: theme.tree.cursor_bg)
-  end
-
-  defp icon_draw_style(icon_color, _is_cursor, _focused, theme) do
-    Face.new(fg: icon_color, bg: theme.tree.bg)
+  defp icon_draw_style(icon_color, is_cursor, focused, theme) do
+    Face.new(fg: icon_color, bg: row_bg_color(is_cursor, focused, theme))
   end
 
   @spec dirty_indicator_style(boolean(), boolean(), Theme.t()) :: Face.t()
-  defp dirty_indicator_style(true = _is_cursor, true = _focused, theme) do
+  defp dirty_indicator_style(is_cursor, focused, theme) do
     color = theme.tree.modified_fg || theme.tree.fg
-    Face.new(fg: theme.tree.bg, bg: color)
-  end
-
-  defp dirty_indicator_style(true = _is_cursor, false = _focused, theme) do
-    color = theme.tree.modified_fg || theme.tree.fg
-    Face.new(fg: color, bg: theme.tree.cursor_bg)
-  end
-
-  defp dirty_indicator_style(_is_cursor, _focused, theme) do
-    color = theme.tree.modified_fg || theme.tree.fg
-    Face.new(fg: color, bg: theme.tree.bg)
+    Face.new(fg: color, bg: row_bg_color(is_cursor, focused, theme), bold: true)
   end
 
   @spec git_indicator_style(
@@ -437,17 +414,12 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
           boolean(),
           Theme.t()
         ) :: Face.t()
-  defp git_indicator_style(status, true = _is_cursor, true = _focused, theme) do
-    # Focused cursor row: invert
-    Face.new(fg: theme.tree.bg, bg: git_status_color(status, theme))
-  end
-
-  defp git_indicator_style(status, true = _is_cursor, false = _focused, theme) do
-    Face.new(fg: git_status_color(status, theme), bg: theme.tree.cursor_bg)
-  end
-
-  defp git_indicator_style(status, _is_cursor, _focused, theme) do
-    Face.new(fg: git_status_color(status, theme), bg: theme.tree.bg)
+  defp git_indicator_style(status, is_cursor, focused, theme) do
+    Face.new(
+      fg: git_status_color(status, theme),
+      bg: row_bg_color(is_cursor, focused, theme),
+      bold: status == :conflict
+    )
   end
 
   @spec git_status_color(Minga.Project.FileTree.GitStatus.file_status(), Theme.t()) ::
@@ -459,28 +431,24 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   defp git_status_color(:renamed, theme), do: theme.tree.git_staged_fg || theme.tree.fg
   defp git_status_color(:deleted, theme), do: theme.tree.git_conflict_fg || theme.tree.fg
 
+  @spec row_bg_color(boolean(), boolean(), Theme.t()) :: non_neg_integer()
+  defp row_bg_color(is_cursor, focused, theme), do: row_background(is_cursor, focused, theme).bg
+
   @spec name_draw_style(Row.t(), boolean(), boolean(), boolean(), Theme.t()) :: Face.t()
   defp name_draw_style(tree_row, is_cursor, is_active, focused, theme) do
-    tree = theme.tree
+    base_fg = name_foreground(tree_row, is_active, theme)
 
-    base_fg =
-      case {tree_row.directory?, is_active} do
-        {true, _} -> tree.dir_fg
-        {_, true} -> tree.active_fg
-        _ -> tree.fg
-      end
-
-    case {is_cursor, focused} do
-      {true, true} ->
-        Face.new(fg: tree.bg, bg: base_fg, bold: tree_row.directory?)
-
-      {true, false} ->
-        Face.new(fg: base_fg, bg: tree.cursor_bg, bold: tree_row.directory?)
-
-      _ ->
-        Face.new(fg: base_fg, bg: tree.bg, bold: tree_row.directory?)
-    end
+    Face.new(
+      fg: base_fg,
+      bg: row_bg_color(is_cursor, focused, theme),
+      bold: is_active or tree_row.directory?
+    )
   end
+
+  @spec name_foreground(Row.t(), boolean(), Theme.t()) :: non_neg_integer()
+  defp name_foreground(_tree_row, true = _is_active, theme), do: theme.tree.active_fg
+  defp name_foreground(%Row{directory?: true}, false = _is_active, theme), do: theme.tree.dir_fg
+  defp name_foreground(_tree_row, false = _is_active, theme), do: theme.tree.fg
 
   # ── Blanks, separator, scroll ──────────────────────────────────────────
 

--- a/lib/minga_editor/shell/traditional/tree_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tree_renderer.ex
@@ -3,9 +3,9 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   Renders the file tree panel into draw tuples for the left side of the screen.
 
   Produces a list of `DisplayList.draw()` tuples for the tree entries,
-  the separator column, and the header line. Uses Nerd Font icons per
-  filetype, box-drawing indent guides, and a project-name header to
-  match neo-tree.nvim's visual style.
+  the separator column, and the header line. Uses stable disclosure,
+  icon, name, and status columns with quiet ancestor guides so the tree
+  stays scannable without connector-heavy branch art.
   """
 
   alias Minga.Core.Face
@@ -20,11 +20,12 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   alias MingaEditor.UI.Theme
   alias MingaEditor.WindowTree
 
-  # Box-drawing characters for indent guides
+  # Row anatomy: faint ancestor guides, disclosure, icon, name, spacer, dirty marker, git marker.
   @guide_pipe "│ "
-  @guide_tee "├─"
-  @guide_elbow "└─"
   @guide_blank "  "
+  @disclosure_expanded "▾ "
+  @disclosure_collapsed "▸ "
+  @disclosure_file "  "
 
   # Nerd Font folder icons (nf-md-folder / nf-md-folder-open)
   @folder_closed "\u{F024B}"
@@ -183,8 +184,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     focused = tree_row.focused?
     is_dirty = tree_row.dirty?
 
-    # Build the guide prefix from the entry's ancestor guide flags
+    # Build the structure columns from ancestor guides plus a dedicated disclosure column.
     guide_prefix = build_guides(tree_row.guides, tree_row.last_child?)
+    disclosure = disclosure_marker(tree_row)
+    structure_prefix = guide_prefix <> disclosure
 
     # Pick the icon and its color
     {icon, icon_color} = entry_icon(tree_row)
@@ -199,8 +202,8 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     dirty_width = if is_dirty, do: 1, else: 0
     indicator_width = dirty_width + git_width
 
-    # Compose the full line: guides + icon + space + name
-    prefix = guide_prefix <> icon <> " "
+    # Compose the full line: structure columns + icon + space + name
+    prefix = structure_prefix <> icon <> " "
     prefix_width = String.length(prefix)
 
     # Truncate name to fit, accounting for indicator space
@@ -210,25 +213,17 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     # Background style for the full row
     row_bg = row_background(is_cursor, focused, theme)
 
-    # Build draw commands: guide, icon, name, (dirty dot), (git indicator)
+    # Build draw commands: structure, icon, name, dirty marker, and git marker.
     guide_style = guide_draw_style(is_cursor, focused, theme)
     icon_style = icon_draw_style(icon_color, is_cursor, focused, theme)
     name_style = name_draw_style(tree_row, is_cursor, tree_row.active?, focused, theme)
-
-    guide_len = String.length(guide_prefix)
+    structure_len = String.length(structure_prefix)
 
     draws = []
-
-    # Guide segment (if any depth > 0)
-    draws =
-      if guide_len > 0 do
-        draws ++ [DisplayList.draw(row, col, guide_prefix, guide_style)]
-      else
-        draws
-      end
+    draws = draws ++ [DisplayList.draw(row, col, structure_prefix, guide_style)]
 
     # Icon segment
-    icon_col = col + guide_len
+    icon_col = col + structure_len
     draws = draws ++ [DisplayList.draw(row, icon_col, icon <> " ", icon_style)]
 
     # Name segment: pad to fill space between name and indicators
@@ -279,9 +274,11 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     %{col_off: col, width: width, theme: theme} = opts
     editing = tree_row.editing
 
-    # Build indent guides (same depth as the entry being edited/created)
+    # Build the same structure columns as normal rows so inline editing does not shift columns.
     guide_prefix = build_guides(tree_row.guides, tree_row.last_child?)
-    guide_len = String.length(guide_prefix)
+    disclosure = disclosure_marker(tree_row)
+    structure_prefix = guide_prefix <> disclosure
+    structure_len = String.length(structure_prefix)
 
     # Type indicator: file icon for new file, folder icon for new folder,
     # the entry's own icon for rename
@@ -292,7 +289,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
         :rename -> entry_icon(tree_row)
       end
 
-    prefix = guide_prefix <> icon <> " "
+    prefix = structure_prefix <> icon <> " "
     prefix_len = String.length(prefix)
 
     # Editing text with cursor
@@ -317,15 +314,9 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     text_style = Face.new(fg: editing_fg, bg: editing_bg, bold: true)
 
     draws = []
+    draws = draws ++ [DisplayList.draw(row, col, structure_prefix, guide_style)]
 
-    draws =
-      if guide_len > 0 do
-        draws ++ [DisplayList.draw(row, col, guide_prefix, guide_style)]
-      else
-        draws
-      end
-
-    icon_col = col + guide_len
+    icon_col = col + structure_len
     draws = draws ++ [DisplayList.draw(row, icon_col, icon <> " ", icon_style)]
 
     text_col = col + prefix_len
@@ -337,25 +328,17 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   # ── Indent guides ──────────────────────────────────────────────────────
 
   @spec build_guides([boolean()], boolean()) :: String.t()
-  defp build_guides(ancestor_guides, last_child?) do
-    # Ancestor columns: each is either │ (more siblings) or blank (last child)
-    ancestor_part =
-      Enum.map_join(ancestor_guides, fn
-        true -> @guide_pipe
-        false -> @guide_blank
-      end)
-
-    # The connector at this entry's own depth
-    # Depth-0 entries (direct children of root) also get a connector
-    connector =
-      if last_child? do
-        @guide_elbow
-      else
-        @guide_tee
-      end
-
-    ancestor_part <> connector
+  defp build_guides(ancestor_guides, _last_child?) do
+    Enum.map_join(ancestor_guides, fn
+      true -> @guide_pipe
+      false -> @guide_blank
+    end)
   end
+
+  @spec disclosure_marker(Row.t()) :: String.t()
+  defp disclosure_marker(%Row{directory?: true, expanded?: true}), do: @disclosure_expanded
+  defp disclosure_marker(%Row{directory?: true}), do: @disclosure_collapsed
+  defp disclosure_marker(_tree_row), do: @disclosure_file
 
   # ── Icon selection ──────────────────────────────────────────────────────
 

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		19BF036E1B3A3CF589C5F578 /* SidebarHeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */; };
 		19E561E5F7841B2CF1ABB085 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
 		1F9F7B302A2A8598C1391FA0 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
+		20DE27562883B504C119A22F /* FileTreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */; };
 		23DA463A92D1EC2F7BFA5B5A /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		25B21FDC79D3F65CAA270C99 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
 		26DAAF2C2CCC2713AD30C539 /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
@@ -67,6 +68,7 @@
 		527C7DB557EFD09B3161BC20 /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		531166B714D49278BA811033 /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E892F827AFBE959F9DF25C05 /* StatusBarView.swift */; };
 		5311F1060367B40B4077309F /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5458552EC58E44C7CD15A98A /* FileTreeView.swift */; };
+		53736DA2E4420D55D3D4E0A4 /* FileTreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */; };
 		58D1135E113BF3A33EF7815F /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
 		59546703C9DBB4BA6E15DE28 /* BottomPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */; };
 		5BEEC2FD4D95EBA70FE036E7 /* BottomPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */; };
@@ -291,6 +293,7 @@
 		CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbBar.swift; sourceTree = "<group>"; };
 		D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusHeaderContent.swift; sourceTree = "<group>"; };
 		D2D59D9EEB390C8DF351D595 /* FrameState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameState.swift; sourceTree = "<group>"; };
+		D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowView.swift; sourceTree = "<group>"; };
 		DD14027C8C7BD17057DE820B /* AgentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatView.swift; sourceTree = "<group>"; };
 		DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionOverlay.swift; sourceTree = "<group>"; };
 		E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryManagerTests.swift; sourceTree = "<group>"; };
@@ -408,6 +411,7 @@
 				83165B89231936674C54B513 /* EditorNSView.swift */,
 				0C26E064D810299C0302F439 /* EditorView.swift */,
 				59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */,
+				D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */,
 				CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */,
 				5458552EC58E44C7CD15A98A /* FileTreeView.swift */,
 				84C47F406747CA6DD924A1AB /* FloatPopupOverlay.swift */,
@@ -701,6 +705,7 @@
 				82E444261F28262834866B20 /* EditorNSView.swift in Sources */,
 				E5CE1B3EBAABD914418D892F /* EditorView.swift in Sources */,
 				E04EB44BCBE0CEB501618F1A /* FileTreeHeaderContent.swift in Sources */,
+				53736DA2E4420D55D3D4E0A4 /* FileTreeRowView.swift in Sources */,
 				E073657EE87B3F145830B7C7 /* FileTreeState.swift in Sources */,
 				5311F1060367B40B4077309F /* FileTreeView.swift in Sources */,
 				73955B38CEFC09D29EADAD85 /* FloatPopupOverlay.swift in Sources */,
@@ -790,6 +795,7 @@
 				D1EEFBDAE315F717373F82BD /* EditorNSView.swift in Sources */,
 				7A21099CFC922D178A3079DF /* EditorView.swift in Sources */,
 				6BA7D7FBA7A05CDEA428811D /* FileTreeHeaderContent.swift in Sources */,
+				20DE27562883B504C119A22F /* FileTreeRowView.swift in Sources */,
 				C8FAD7BE37506758A1DBF8F6 /* FileTreeState.swift in Sources */,
 				31E0D1C2347322703DA6CC71 /* FileTreeView.swift in Sources */,
 				654E7E631260BE13502E1C32 /* FloatPopupOverlay.swift in Sources */,

--- a/macos/Sources/Views/FileTreeHeaderContent.swift
+++ b/macos/Sources/Views/FileTreeHeaderContent.swift
@@ -15,7 +15,45 @@ struct FileTreeHeaderContent: View {
 
     @State private var isHovered = false
 
+    private var reduceMotion: Bool {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    }
+
+    private var headerAnimationDuration: Double {
+        reduceMotion ? 0 : 0.15
+    }
+
     var body: some View {
+        HStack(spacing: 8) {
+            projectContext
+                .layoutPriority(2)
+
+            secondaryContext
+                .layoutPriority(0)
+
+            Spacer(minLength: 4)
+
+            actionButtons
+                .opacity(isHovered ? 1.0 : 0.72)
+                .animation(reduceMotion ? nil : .easeInOut(duration: headerAnimationDuration), value: isHovered)
+        }
+        .padding(.leading, leadingPadding)
+        .padding(.trailing, 10)
+        .contentShape(Rectangle())
+        .accessibilityLabel(accessibilityLabelText)
+        .onHover { hovering in
+            if reduceMotion {
+                isHovered = hovering
+            } else {
+                withAnimation(.easeInOut(duration: headerAnimationDuration)) {
+                    isHovered = hovering
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var projectContext: some View {
         HStack(spacing: 6) {
             Text("\u{F024B}")
                 .font(.custom("Symbols Nerd Font Mono", size: 12))
@@ -26,45 +64,42 @@ struct FileTreeHeaderContent: View {
                 .foregroundStyle(theme.tabActiveFg)
                 .lineLimit(1)
                 .truncationMode(.tail)
+        }
+    }
 
-            if !branchName.isEmpty {
+    @ViewBuilder
+    private var secondaryContext: some View {
+        if !branchName.isEmpty {
+            HStack(spacing: 4) {
                 Text("\u{E725}")
-                    .font(.custom("Symbols Nerd Font Mono", size: 12))
-                    .foregroundStyle(theme.treeDirFg.opacity(0.7))
+                    .font(.custom("Symbols Nerd Font Mono", size: 11))
+                    .foregroundStyle(theme.treeDirFg.opacity(0.55))
 
                 Text(branchName)
-                    .font(.system(size: 12, weight: .regular))
-                    .foregroundStyle(theme.tabActiveFg.opacity(0.7))
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(theme.tabActiveFg.opacity(0.62))
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-
-            Spacer(minLength: 4)
-
-            if isHovered {
-                HStack(spacing: 2) {
-                    headerButton(systemName: "doc.badge.plus", tooltip: "New File…") {
-                        encoder?.sendFileTreeNewFile(parentIndex: UInt16(fileTreeState.selectedIndex))
-                    }
-                    headerButton(systemName: "folder.badge.plus", tooltip: "New Folder…") {
-                        encoder?.sendFileTreeNewFolder(parentIndex: UInt16(fileTreeState.selectedIndex))
-                    }
-                    headerButton(systemName: "arrow.clockwise", tooltip: "Refresh") {
-                        encoder?.sendFileTreeRefresh()
-                    }
-                    headerButton(systemName: "arrow.down.right.and.arrow.up.left", tooltip: "Collapse All") {
-                        encoder?.sendFileTreeCollapseAll()
-                    }
-                }
-                .transition(.opacity)
-            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(theme.treeHeaderFg.opacity(0.08), in: Capsule())
         }
-        .padding(.leading, leadingPadding)
-        .padding(.trailing, 10)
-        .contentShape(Rectangle())
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.15)) {
-                isHovered = hovering
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: 2) {
+            headerButton(systemName: "doc.badge.plus", tooltip: "New File…") {
+                encoder?.sendFileTreeNewFile(parentIndex: UInt16(fileTreeState.selectedIndex))
+            }
+            headerButton(systemName: "folder.badge.plus", tooltip: "New Folder…") {
+                encoder?.sendFileTreeNewFolder(parentIndex: UInt16(fileTreeState.selectedIndex))
+            }
+            headerButton(systemName: "arrow.clockwise", tooltip: "Refresh") {
+                encoder?.sendFileTreeRefresh()
+            }
+            headerButton(systemName: "arrow.down.right.and.arrow.up.left", tooltip: "Collapse All") {
+                encoder?.sendFileTreeCollapseAll()
             }
         }
     }
@@ -77,6 +112,13 @@ struct FileTreeHeaderContent: View {
             tooltip: tooltip,
             action: action
         )
+    }
+
+    var accessibilityLabelText: String {
+        if branchName.isEmpty {
+            return "File tree for \(projectName)"
+        }
+        return "File tree for \(projectName), branch \(branchName)"
     }
 
     private var projectName: String {

--- a/macos/Sources/Views/FileTreeRowView.swift
+++ b/macos/Sources/Views/FileTreeRowView.swift
@@ -1,0 +1,203 @@
+/// Visual row component for the semantic file tree.
+///
+/// FileTreeView owns list behavior and action wiring. This view owns the row anatomy and visual layers:
+/// disclosure, icon, name, spacer, dirty marker, git marker, then background/accent layers.
+
+import SwiftUI
+
+struct FileTreeRowView: View {
+    let entry: FileTreeEntry
+    let theme: ThemeColors
+    let rowHeight: CGFloat
+    let indentWidth: CGFloat
+    let chevronWidth: CGFloat
+    let isHovered: Bool
+    let isDropTarget: Bool
+    let animDuration: Double
+    let onEditCommit: (String) -> Void
+    let onEditCancel: () -> Void
+
+    var body: some View {
+        rowContent
+            .padding(.leading, leadingPadding)
+            .padding(.trailing, 8)
+            .frame(height: rowHeight)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(rowBackground)
+            .overlay(alignment: .leading) {
+                activeFileAccent
+            }
+            .overlay(alignment: .leading) {
+                indentGuides
+            }
+            .accessibilityLabel(accessibilityLabelText)
+            .accessibilityHint(accessibilityHintText)
+    }
+
+    @ViewBuilder
+    private var rowContent: some View {
+        HStack(spacing: 0) {
+            disclosureChevron
+
+            Text(entry.icon)
+                .font(.custom("Symbols Nerd Font Mono", size: 12))
+                .foregroundStyle(iconColor)
+                .frame(width: 16, alignment: .center)
+
+            Spacer().frame(width: 4)
+
+            if entry.isEditing {
+                InlineEditField(
+                    initialText: entry.editingText,
+                    selectStem: entry.editingType == 2,
+                    onCommit: onEditCommit,
+                    onCancel: onEditCancel
+                )
+                .frame(height: rowHeight)
+            } else {
+                Text(entry.name)
+                    .font(.system(size: 12, weight: entry.showsActiveAccent ? .semibold : .regular))
+                    .foregroundStyle(nameColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer(minLength: 0)
+
+                dirtyMarker
+                gitStatusDot
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var disclosureChevron: some View {
+        if entry.isDir {
+            Image(systemName: "chevron.right")
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(theme.treeFg.opacity(0.5))
+                .rotationEffect(.degrees(entry.isExpanded ? 90 : 0))
+                .animation(.easeInOut(duration: animDuration), value: entry.isExpanded)
+                .frame(width: chevronWidth, height: rowHeight)
+        } else {
+            Spacer().frame(width: chevronWidth)
+        }
+    }
+
+    @ViewBuilder
+    private var dirtyMarker: some View {
+        if entry.showsDirtyMarker {
+            Text("●")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(theme.treeGitModified)
+                .padding(.trailing, entry.showsGitMarker ? 4 : 2)
+        }
+    }
+
+    @ViewBuilder
+    private var gitStatusDot: some View {
+        if let color = gitDotColor {
+            Circle()
+                .fill(color)
+                .frame(width: entry.hasConflictStatus ? 7 : 6, height: entry.hasConflictStatus ? 7 : 6)
+                .padding(.trailing, 2)
+        }
+    }
+
+    private var gitDotColor: Color? {
+        switch entry.gitStatusValue {
+        case .modified: return theme.treeGitModified
+        case .staged: return theme.treeGitStaged
+        case .untracked: return theme.treeGitUntracked
+        case .conflict: return theme.gutterErrorFg
+        case .renamed: return theme.treeGitStaged
+        case .deleted: return theme.gitDeletedFg
+        case .clean: return nil
+        }
+    }
+
+    @ViewBuilder
+    private var indentGuides: some View {
+        if !entry.guides.isEmpty {
+            Canvas { context, size in
+                for (level, shouldDraw) in entry.guides.enumerated() where shouldDraw {
+                    let x = 8 + CGFloat(level) * indentWidth + chevronWidth / 2
+                    let rect = CGRect(x: x, y: 0, width: 1, height: size.height)
+                    context.fill(Path(rect), with: .color(theme.treeGuideFg))
+                }
+            }
+            .allowsHitTesting(false)
+            .frame(height: rowHeight)
+        }
+    }
+
+    @ViewBuilder
+    private var rowBackground: some View {
+        if entry.isEditing {
+            rowFill(theme.treeSelectionBg)
+        } else if isDropTarget {
+            rowFill(theme.treeSelectionBg.opacity(0.55))
+        } else if entry.isSelected {
+            rowFill(theme.treeSelectionBg.opacity(entry.isFocused ? 1.0 : 0.42))
+        } else if isHovered {
+            rowFill(theme.treeFg.opacity(0.06))
+                .animation(.easeInOut(duration: animDuration), value: isHovered)
+        }
+    }
+
+    @ViewBuilder
+    private var activeFileAccent: some View {
+        if entry.showsActiveAccent {
+            RoundedRectangle(cornerRadius: 1)
+                .fill(theme.treeActiveFg)
+                .frame(width: 2, height: rowHeight - 8)
+                .padding(.leading, 4)
+        }
+    }
+
+    private func rowFill(_ color: Color) -> some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(color)
+            .padding(.horizontal, 4)
+    }
+
+    private var leadingPadding: CGFloat {
+        8 + CGFloat(entry.depth) * indentWidth
+    }
+
+    private var iconColor: Color {
+        if entry.showsActiveAccent {
+            return theme.treeActiveFg
+        }
+        if entry.isDir {
+            return theme.treeDirFg
+        }
+        return theme.treeFg.opacity(0.7)
+    }
+
+    private var nameColor: Color {
+        if entry.showsActiveAccent {
+            return theme.treeActiveFg
+        }
+        if entry.isSelected {
+            return theme.treeSelectionFg
+        }
+        return entry.isDir ? theme.treeDirFg : theme.treeFg
+    }
+
+    var accessibilityLabelText: String {
+        if entry.isEditing {
+            return "Editing: \(entry.name)"
+        }
+        return entry.isDir ? "Folder: \(entry.name)" : "File: \(entry.name)"
+    }
+
+    var accessibilityHintText: String {
+        if entry.isEditing {
+            return "Type a new name, then press Return to confirm or Escape to cancel."
+        }
+        if entry.isDir {
+            return entry.isExpanded ? "Expanded folder. Press Return to collapse." : "Collapsed folder. Press Return to expand."
+        }
+        return "Press Return to open."
+    }
+}

--- a/macos/Sources/Views/FileTreeState.swift
+++ b/macos/Sources/Views/FileTreeState.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 /// A single file tree entry for SwiftUI rendering.
 struct FileTreeEntry: Identifiable {
+    /// Visual states are layered in the same priority order as the BEAM TUI renderer: inline editing, drop target, selected row, active file, dirty buffer, git status, then directory emphasis.
     /// Stable 32-bit hash of the file path, sent by the BEAM. Persists across
     /// tree updates so SwiftUI's diffing correctly identifies unchanged rows
     /// instead of treating every row below a change as new.
@@ -36,6 +37,38 @@ struct FileTreeEntry: Identifiable {
     let editingType: UInt8
     /// Pre-filled text for the editing field. Only meaningful when isEditing is true.
     let editingText: String
+}
+
+enum FileTreeGitStatus: UInt8 {
+    case clean = 0
+    case modified = 1
+    case staged = 2
+    case untracked = 3
+    case conflict = 4
+    case renamed = 5
+    case deleted = 6
+}
+
+extension FileTreeEntry {
+    var gitStatusValue: FileTreeGitStatus {
+        FileTreeGitStatus(rawValue: gitStatus) ?? .clean
+    }
+
+    var showsActiveAccent: Bool {
+        isActive && !isEditing
+    }
+
+    var showsDirtyMarker: Bool {
+        isDirty && !isDir
+    }
+
+    var showsGitMarker: Bool {
+        gitStatusValue != .clean
+    }
+
+    var hasConflictStatus: Bool {
+        gitStatusValue == .conflict
+    }
 }
 
 /// Observable state for the file tree sidebar, driven by BEAM protocol messages.

--- a/macos/Sources/Views/FileTreeView.swift
+++ b/macos/Sources/Views/FileTreeView.swift
@@ -159,115 +159,56 @@ struct FileTreeView: View {
     @ViewBuilder
     private func entryRow(_ entry: FileTreeEntry) -> some View {
         if entry.isEditing {
-            editingEntryRow(entry)
+            fileTreeRow(entry)
+                .id(entry.id)
         } else {
-            normalEntryRow(entry)
-        }
-    }
-
-    @ViewBuilder
-    private func editingEntryRow(_ entry: FileTreeEntry) -> some View {
-        HStack(spacing: 0) {
-            disclosureChevron(entry)
-
-            Text(entry.icon)
-                .font(.custom("Symbols Nerd Font Mono", size: 12))
-                .foregroundStyle(iconColor(entry))
-                .frame(width: 16, alignment: .center)
-
-            Spacer().frame(width: 4)
-
-            InlineEditField(
-                initialText: entry.editingText,
-                selectStem: entry.editingType == 2,  // rename
-                onCommit: { text in
-                    encoder?.sendFileTreeEditConfirm(text: text)
-                },
-                onCancel: {
-                    encoder?.sendFileTreeEditCancel()
+            fileTreeRow(entry)
+                .id(entry.id)
+                .contentShape(Rectangle())
+                .onHover { isHovered in
+                    hoveredEntryId = isHovered ? entry.id : nil
+                    if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                 }
-            )
-            .frame(height: rowHeight)
+                .onTapGesture {
+                    handleEntryTap(entry)
+                }
+                .contextMenu { entryContextMenu(entry) }
+                .draggable(URL(fileURLWithPath: fileTreeState.fullPath(for: entry))) {
+                    HStack(spacing: 4) {
+                        Text(entry.icon)
+                            .font(.system(size: 12))
+                        Text(entry.name)
+                            .font(.system(size: 12))
+                    }
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(theme.popupBg, in: RoundedRectangle(cornerRadius: 4))
+                }
+                .dropDestination(for: URL.self) { urls, _ in
+                    handleDrop(urls: urls, onto: entry)
+                } isTargeted: { isTargeted in
+                    dropTargetEntryId = isTargeted && entry.isDir ? entry.id : nil
+                }
         }
-        .padding(.leading, leadingPadding(entry))
-        .padding(.trailing, 8)
-        .frame(height: rowHeight)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 4)
-                .fill(theme.treeSelectionBg)
-                .padding(.horizontal, 4)
-        )
-        .overlay(alignment: .leading) {
-            indentGuides(entry)
-        }
-        .id(entry.id)
     }
 
-    @ViewBuilder
-    private func normalEntryRow(_ entry: FileTreeEntry) -> some View {
-        HStack(spacing: 0) {
-            // Disclosure chevron (directories) or alignment spacer (files)
-            disclosureChevron(entry)
-
-            // Nerd Font icon
-            Text(entry.icon)
-                .font(.custom("Symbols Nerd Font Mono", size: 12))
-                .foregroundStyle(iconColor(entry))
-                .frame(width: 16, alignment: .center)
-
-            Spacer().frame(width: 4)
-
-            // Name
-            Text(entry.name)
-                .font(.system(size: 12, weight: entry.showsActiveAccent ? .semibold : .regular))
-                .foregroundStyle(nameColor(entry))
-                .lineLimit(1)
-                .truncationMode(.tail)
-
-            Spacer(minLength: 0)
-
-            dirtyMarker(entry)
-            gitStatusDot(entry)
-        }
-        .padding(.leading, leadingPadding(entry))
-        .padding(.trailing, 8)
-        .frame(height: rowHeight)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(rowBackground(entry))
-        .overlay(alignment: .leading) {
-            activeFileAccent(entry)
-        }
-        .overlay(alignment: .leading) {
-            indentGuides(entry)
-        }
-        .id(entry.id)
-        .contentShape(Rectangle())
-        .onHover { isHovered in
-            hoveredEntryId = isHovered ? entry.id : nil
-            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
-        .onTapGesture {
-            handleEntryTap(entry)
-        }
-        .contextMenu { entryContextMenu(entry) }
-        .draggable(URL(fileURLWithPath: fileTreeState.fullPath(for: entry))) {
-            HStack(spacing: 4) {
-                Text(entry.icon)
-                    .font(.system(size: 12))
-                Text(entry.name)
-                    .font(.system(size: 12))
+    private func fileTreeRow(_ entry: FileTreeEntry) -> FileTreeRowView {
+        FileTreeRowView(
+            entry: entry,
+            theme: theme,
+            rowHeight: rowHeight,
+            indentWidth: indentWidth,
+            chevronWidth: chevronWidth,
+            isHovered: hoveredEntryId == entry.id,
+            isDropTarget: dropTargetEntryId == entry.id,
+            animDuration: animDuration,
+            onEditCommit: { text in
+                encoder?.sendFileTreeEditConfirm(text: text)
+            },
+            onEditCancel: {
+                encoder?.sendFileTreeEditCancel()
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(theme.popupBg, in: RoundedRectangle(cornerRadius: 4))
-        }
-        .dropDestination(for: URL.self) { urls, _ in
-            handleDrop(urls: urls, onto: entry)
-        } isTargeted: { isTargeted in
-            dropTargetEntryId = isTargeted && entry.isDir ? entry.id : nil
-        }
-        .accessibilityLabel(entry.isDir ? "Folder: \(entry.name)" : "File: \(entry.name)")
+        )
     }
 
     // MARK: - Context menu
@@ -435,120 +376,12 @@ struct FileTreeView: View {
         }
     }
 
-    // MARK: - Indent guides
-
-    // MARK: - Dirty and git markers
-
-    /// Dirty buffers use their own marker so unsaved edits stay visible independently from git status.
-    @ViewBuilder
-    private func dirtyMarker(_ entry: FileTreeEntry) -> some View {
-        if entry.showsDirtyMarker {
-            Text("●")
-                .font(.system(size: 9, weight: .bold))
-                .foregroundStyle(theme.treeGitModified)
-                .padding(.trailing, entry.showsGitMarker ? 4 : 2)
-        }
-    }
-
-    /// Small colored dot indicating git status, right-aligned in the row.
-    @ViewBuilder
-    private func gitStatusDot(_ entry: FileTreeEntry) -> some View {
-        if let color = gitDotColor(entry) {
-            Circle()
-                .fill(color)
-                .frame(width: entry.hasConflictStatus ? 7 : 6, height: entry.hasConflictStatus ? 7 : 6)
-                .padding(.trailing, 2)
-        }
-    }
-
-    private func gitDotColor(_ entry: FileTreeEntry) -> Color? {
-        switch entry.gitStatusValue {
-        case .modified: return theme.treeGitModified
-        case .staged: return theme.treeGitStaged
-        case .untracked: return theme.treeGitUntracked
-        case .conflict: return theme.gutterErrorFg
-        case .renamed: return theme.treeGitStaged
-        case .deleted: return theme.gitDeletedFg
-        case .clean: return nil
-        }
-    }
-
-    /// Draws thin vertical indent guide lines using the BEAM-supplied semantic ancestor guide mask.
-    @ViewBuilder
-    private func indentGuides(_ entry: FileTreeEntry) -> some View {
-        if !entry.guides.isEmpty {
-            Canvas { context, size in
-                for (level, shouldDraw) in entry.guides.enumerated() where shouldDraw {
-                    // Align guide with the center of each ancestor's chevron column.
-                    let x = 8 + CGFloat(level) * indentWidth + chevronWidth / 2
-                    let rect = CGRect(x: x, y: 0, width: 1, height: size.height)
-                    context.fill(Path(rect), with: .color(theme.treeGuideFg))
-                }
-            }
-            .allowsHitTesting(false)
-            .frame(height: rowHeight)
-        }
-    }
-
-    // MARK: - Row layers (drop target, selection, active file, hover)
-
-    @ViewBuilder
-    private func rowBackground(_ entry: FileTreeEntry) -> some View {
-        if dropTargetEntryId == entry.id {
-            RoundedRectangle(cornerRadius: 4)
-                .fill(theme.treeSelectionBg.opacity(0.55))
-                .padding(.horizontal, 4)
-        } else if entry.isSelected {
-            RoundedRectangle(cornerRadius: 4)
-                .fill(theme.treeSelectionBg.opacity(entry.isFocused ? 1.0 : 0.42))
-                .padding(.horizontal, 4)
-        } else if hoveredEntryId == entry.id {
-            RoundedRectangle(cornerRadius: 4)
-                .fill(theme.treeFg.opacity(0.06))
-                .padding(.horizontal, 4)
-                .animation(.easeInOut(duration: animDuration), value: hoveredEntryId)
-        } else {
-            Color.clear
-        }
-    }
-
-    @ViewBuilder
-    private func activeFileAccent(_ entry: FileTreeEntry) -> some View {
-        if entry.showsActiveAccent {
-            RoundedRectangle(cornerRadius: 1)
-                .fill(theme.treeActiveFg)
-                .frame(width: 2, height: rowHeight - 8)
-                .padding(.leading, 4)
-        }
-    }
-
     // MARK: - Layout helpers
 
     private func leadingPadding(_ entry: FileTreeEntry) -> CGFloat {
         8 + CGFloat(entry.depth) * indentWidth
     }
 
-    // MARK: - Colors
-
-    private func iconColor(_ entry: FileTreeEntry) -> Color {
-        if entry.showsActiveAccent {
-            return theme.treeActiveFg
-        }
-        if entry.isDir {
-            return theme.treeDirFg
-        }
-        return theme.treeFg.opacity(0.7)
-    }
-
-    private func nameColor(_ entry: FileTreeEntry) -> Color {
-        if entry.showsActiveAccent {
-            return theme.treeActiveFg
-        }
-        if entry.isSelected {
-            return theme.treeSelectionFg
-        }
-        return entry.isDir ? theme.treeDirFg : theme.treeFg
-    }
 }
 
 /// Preference key for tracking scroll offset within the file tree.

--- a/macos/Sources/Views/FileTreeView.swift
+++ b/macos/Sources/Views/FileTreeView.swift
@@ -220,14 +220,14 @@ struct FileTreeView: View {
 
             // Name
             Text(entry.name)
-                .font(.system(size: 12))
+                .font(.system(size: 12, weight: entry.showsActiveAccent ? .semibold : .regular))
                 .foregroundStyle(nameColor(entry))
                 .lineLimit(1)
                 .truncationMode(.tail)
 
             Spacer(minLength: 0)
 
-            // Git status dot
+            dirtyMarker(entry)
             gitStatusDot(entry)
         }
         .padding(.leading, leadingPadding(entry))
@@ -235,6 +235,9 @@ struct FileTreeView: View {
         .frame(height: rowHeight)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(rowBackground(entry))
+        .overlay(alignment: .leading) {
+            activeFileAccent(entry)
+        }
         .overlay(alignment: .leading) {
             indentGuides(entry)
         }
@@ -434,7 +437,18 @@ struct FileTreeView: View {
 
     // MARK: - Indent guides
 
-    // MARK: - Git status dot
+    // MARK: - Dirty and git markers
+
+    /// Dirty buffers use their own marker so unsaved edits stay visible independently from git status.
+    @ViewBuilder
+    private func dirtyMarker(_ entry: FileTreeEntry) -> some View {
+        if entry.showsDirtyMarker {
+            Text("●")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(theme.treeGitModified)
+                .padding(.trailing, entry.showsGitMarker ? 4 : 2)
+        }
+    }
 
     /// Small colored dot indicating git status, right-aligned in the row.
     @ViewBuilder
@@ -442,20 +456,20 @@ struct FileTreeView: View {
         if let color = gitDotColor(entry) {
             Circle()
                 .fill(color)
-                .frame(width: 6, height: 6)
+                .frame(width: entry.hasConflictStatus ? 7 : 6, height: entry.hasConflictStatus ? 7 : 6)
                 .padding(.trailing, 2)
         }
     }
 
     private func gitDotColor(_ entry: FileTreeEntry) -> Color? {
-        switch entry.gitStatus {
-        case 1: return theme.treeGitModified
-        case 2: return theme.treeGitStaged
-        case 3: return theme.treeGitUntracked
-        case 4: return theme.gutterErrorFg  // conflict
-        case 5: return theme.treeGitModified  // renamed
-        case 6: return theme.gitDeletedFg
-        default: return nil
+        switch entry.gitStatusValue {
+        case .modified: return theme.treeGitModified
+        case .staged: return theme.treeGitStaged
+        case .untracked: return theme.treeGitUntracked
+        case .conflict: return theme.gutterErrorFg
+        case .renamed: return theme.treeGitStaged
+        case .deleted: return theme.gitDeletedFg
+        case .clean: return nil
         }
     }
 
@@ -476,17 +490,17 @@ struct FileTreeView: View {
         }
     }
 
-    // MARK: - Row background (selection + hover)
+    // MARK: - Row layers (drop target, selection, active file, hover)
 
     @ViewBuilder
     private func rowBackground(_ entry: FileTreeEntry) -> some View {
         if dropTargetEntryId == entry.id {
             RoundedRectangle(cornerRadius: 4)
-                .fill(theme.treeSelectionBg.opacity(0.5))
+                .fill(theme.treeSelectionBg.opacity(0.55))
                 .padding(.horizontal, 4)
         } else if entry.isSelected {
             RoundedRectangle(cornerRadius: 4)
-                .fill(theme.treeSelectionBg)
+                .fill(theme.treeSelectionBg.opacity(entry.isFocused ? 1.0 : 0.42))
                 .padding(.horizontal, 4)
         } else if hoveredEntryId == entry.id {
             RoundedRectangle(cornerRadius: 4)
@@ -495,6 +509,16 @@ struct FileTreeView: View {
                 .animation(.easeInOut(duration: animDuration), value: hoveredEntryId)
         } else {
             Color.clear
+        }
+    }
+
+    @ViewBuilder
+    private func activeFileAccent(_ entry: FileTreeEntry) -> some View {
+        if entry.showsActiveAccent {
+            RoundedRectangle(cornerRadius: 1)
+                .fill(theme.treeActiveFg)
+                .frame(width: 2, height: rowHeight - 8)
+                .padding(.leading, 4)
         }
     }
 
@@ -507,34 +531,23 @@ struct FileTreeView: View {
     // MARK: - Colors
 
     private func iconColor(_ entry: FileTreeEntry) -> Color {
+        if entry.showsActiveAccent {
+            return theme.treeActiveFg
+        }
         if entry.isDir {
             return theme.treeDirFg
         }
-        switch entry.gitStatus {
-        case 1: return theme.treeGitModified
-        case 2: return theme.treeGitStaged
-        case 3: return theme.treeGitUntracked
-        case 4: return theme.gutterErrorFg
-        case 5: return theme.treeGitModified
-        case 6: return theme.gitDeletedFg
-        default: return theme.treeFg.opacity(0.7)
-        }
+        return theme.treeFg.opacity(0.7)
     }
 
     private func nameColor(_ entry: FileTreeEntry) -> Color {
+        if entry.showsActiveAccent {
+            return theme.treeActiveFg
+        }
         if entry.isSelected {
             return theme.treeSelectionFg
         }
-        switch entry.gitStatus {
-        case 1: return theme.treeGitModified
-        case 2: return theme.treeGitStaged
-        case 3: return theme.treeGitUntracked
-        case 4: return theme.gutterErrorFg
-        case 5: return theme.treeGitModified
-        case 6: return theme.gitDeletedFg
-        default:
-            return entry.isDir ? theme.treeDirFg : theme.treeFg
-        }
+        return entry.isDir ? theme.treeDirFg : theme.treeFg
     }
 }
 

--- a/macos/Sources/Views/SidebarHeaderButton.swift
+++ b/macos/Sources/Views/SidebarHeaderButton.swift
@@ -36,6 +36,7 @@ struct SidebarHeaderButton: View {
         }
         .buttonStyle(.plain)
         .help(tooltip)
+        .accessibilityLabel(tooltip)
         .onHover { hovering in
             if reduceMotion {
                 isHovered = hovering

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -182,6 +182,23 @@ struct FileTreeViewTests {
         #expect(strings.contains("lib"))
         #expect(strings.contains("editor.ex"))
     }
+
+    @Test("Dirty marker renders independently from selected and git state")
+    @MainActor func dirtyMarkerRendersWithSelectedAndGitState() throws {
+        let state = FileTreeState()
+        state.visible = true
+        state.entries = [
+            sidebarFileTreeEntry(id: 1, index: 0, isSelected: true, isFocused: false, isDirty: true, gitStatus: 1,
+                                 icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"),
+        ]
+
+        let sut = FileTreeView(fileTreeState: state, theme: ThemeColors(), encoder: nil)
+        let body = try sut.inspect()
+        let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("editor.ex"))
+        #expect(strings.contains("●"))
+    }
 }
 
 // MARK: - GitStatusView Section Headers
@@ -243,14 +260,18 @@ private func sidebarFileTreeEntry(
     isDir: Bool = false,
     isExpanded: Bool = false,
     isSelected: Bool = false,
+    isFocused: Bool = false,
+    isActive: Bool = false,
+    isDirty: Bool = false,
+    gitStatus: UInt8 = 0,
     depth: Int = 0,
     icon: String,
     name: String,
     relPath: String
 ) -> FileTreeEntry {
     FileTreeEntry(id: id, index: index, isDir: isDir, isExpanded: isExpanded, isSelected: isSelected,
-                  isFocused: false, isActive: false, isDirty: false, isEditing: false,
-                  isLastChild: false, depth: depth, gitStatus: 0, diagnosticErrorCount: 0,
+                  isFocused: isFocused, isActive: isActive, isDirty: isDirty, isEditing: false,
+                  isLastChild: false, depth: depth, gitStatus: gitStatus, diagnosticErrorCount: 0,
                   diagnosticWarningCount: 0, diagnosticInfoCount: 0, diagnosticHintCount: 0,
                   guides: [], icon: icon, name: name, relPath: relPath, path: relPath,
                   editingType: 0xFF, editingText: "")

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -41,6 +41,18 @@ struct SidebarHeaderButtonTests {
         try button.tap()
         #expect(tapped)
     }
+
+    @Test("Tooltip also backs the accessibility label")
+    @MainActor func tooltipBacksAccessibilityLabel() throws {
+        let sut = SidebarHeaderButton(
+            systemName: "plus",
+            barFg: .white,
+            tooltip: "New File…",
+            action: {}
+        )
+        let button = try sut.inspect().find(ViewType.Button.self)
+        #expect(try button.accessibilityLabel().string() == "New File…")
+    }
 }
 
 // MARK: - GitStatusView Empty States
@@ -153,15 +165,49 @@ struct FileTreeViewTests {
         #expect(strings.contains("Project"))
     }
 
-    @Test("Header action buttons are hidden at rest (shown on hover)")
-    @MainActor func headerActionButtonsHiddenAtRest() throws {
+    @Test("Header action buttons reserve layout space at rest")
+    @MainActor func headerActionButtonsReserveLayoutSpaceAtRest() throws {
         let state = FileTreeState()
         state.visible = true
 
         let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "", leadingPadding: 10)
         let body = try sut.inspect()
         let buttons = body.findAll(ViewType.Button.self)
-        #expect(buttons.count == 0)
+        #expect(buttons.count == 4)
+    }
+
+    @Test("Header action buttons send file-tree actions")
+    @MainActor func headerActionButtonsSendFileTreeActions() throws {
+        let state = FileTreeState()
+        state.visible = true
+        state.selectedIndex = 7
+        let spy = SpyEncoder()
+
+        let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: spy, branchName: "main", leadingPadding: 10)
+        let buttons = try sut.inspect().findAll(ViewType.Button.self)
+
+        try buttons[0].tap()
+        try buttons[1].tap()
+        try buttons[2].tap()
+        try buttons[3].tap()
+
+        #expect(spy.guiActions == [
+            .fileTreeNewFile(parentIndex: 7),
+            .fileTreeNewFolder(parentIndex: 7),
+            .fileTreeRefresh,
+            .fileTreeCollapseAll,
+        ])
+    }
+
+    @Test("Header accessibility summarizes project and branch context")
+    @MainActor func headerAccessibilitySummarizesProjectAndBranchContext() throws {
+        let state = FileTreeState()
+        state.visible = true
+        state.projectRoot = "/Users/test/code/minga"
+
+        let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "main", leadingPadding: 10)
+
+        #expect(sut.accessibilityLabelText == "File tree for minga, branch main")
     }
 
     @Test("File entries render their names")
@@ -198,6 +244,69 @@ struct FileTreeViewTests {
 
         #expect(strings.contains("editor.ex"))
         #expect(strings.contains("●"))
+    }
+
+    @Test("Editing row renders inline edit field")
+    @MainActor func editingRowRendersInlineEditField() throws {
+        let state = FileTreeState()
+        state.visible = true
+        state.entries = [
+            sidebarFileTreeEntry(id: 1, index: 0, isEditing: true, editingType: 2, editingText: "renamed.ex",
+                                 icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"),
+        ]
+
+        let sut = FileTreeView(fileTreeState: state, theme: ThemeColors(), encoder: nil)
+        let body = try sut.inspect()
+        let fields = body.findAll(InlineEditField.self)
+
+        #expect(fields.count == 1)
+    }
+}
+
+// MARK: - FileTreeRowView
+
+@Suite("FileTreeRowView View Structure")
+struct FileTreeRowViewTests {
+
+    @Test("Accessibility labels and hints describe row state")
+    @MainActor func accessibilityLabelsAndHintsDescribeRowState() throws {
+        let file = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        #expect(file.accessibilityLabelText == "File: editor.ex")
+        #expect(file.accessibilityHintText == "Press Return to open.")
+
+        let collapsedDir = fileTreeRowView(entry: sidebarFileTreeEntry(id: 2, index: 1, isDir: true, icon: "\u{F024B}", name: "lib", relPath: "lib"))
+        #expect(collapsedDir.accessibilityLabelText == "Folder: lib")
+        #expect(collapsedDir.accessibilityHintText == "Collapsed folder. Press Return to expand.")
+
+        let expandedDir = fileTreeRowView(entry: sidebarFileTreeEntry(id: 3, index: 2, isDir: true, isExpanded: true, icon: "\u{F0256}", name: "test", relPath: "test"))
+        #expect(expandedDir.accessibilityHintText == "Expanded folder. Press Return to collapse.")
+
+        let editing = fileTreeRowView(entry: sidebarFileTreeEntry(id: 4, index: 3, isEditing: true, editingType: 2, editingText: "renamed.ex", icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        #expect(editing.accessibilityLabelText == "Editing: editor.ex")
+        #expect(editing.accessibilityHintText == "Type a new name, then press Return to confirm or Escape to cancel.")
+    }
+
+    @Test("Files directories and expanded folders have distinct row affordances")
+    @MainActor func filesDirectoriesAndExpandedFoldersHaveDistinctAffordances() throws {
+        let file = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        let collapsedDir = fileTreeRowView(entry: sidebarFileTreeEntry(id: 2, index: 1, isDir: true, icon: "\u{F024B}", name: "lib", relPath: "lib"))
+        let expandedDir = fileTreeRowView(entry: sidebarFileTreeEntry(id: 3, index: 2, isDir: true, isExpanded: true, icon: "\u{F0256}", name: "test", relPath: "test"))
+
+        #expect(try file.inspect().findAll(ViewType.Image.self).isEmpty)
+        #expect(try collapsedDir.inspect().findAll(ViewType.Image.self).count == 1)
+        #expect(try expandedDir.inspect().findAll(ViewType.Image.self).count == 1)
+        #expect(try collapsedDir.inspect().find(ViewType.Image.self).rotation().angle.degrees == 0)
+        #expect(try expandedDir.inspect().find(ViewType.Image.self).rotation().angle.degrees == 90)
+    }
+
+    @Test("Status markers remain separate from name text")
+    @MainActor func statusMarkersRemainSeparateFromNameText() throws {
+        let row = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, isSelected: true, isFocused: true, isActive: true, isDirty: true, gitStatus: 1, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        let strings = try row.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("editor.ex"))
+        #expect(strings.contains("●"))
+        #expect(try row.inspect().findAll(ViewType.Shape.self).count >= 1)
     }
 }
 
@@ -254,6 +363,22 @@ struct GitStatusViewSectionTests {
     }
 }
 
+@MainActor
+private func fileTreeRowView(entry: FileTreeEntry, isHovered: Bool = false, isDropTarget: Bool = false) -> FileTreeRowView {
+    FileTreeRowView(
+        entry: entry,
+        theme: ThemeColors(),
+        rowHeight: 22,
+        indentWidth: 14,
+        chevronWidth: 12,
+        isHovered: isHovered,
+        isDropTarget: isDropTarget,
+        animDuration: 0,
+        onEditCommit: { _ in },
+        onEditCancel: {}
+    )
+}
+
 private func sidebarFileTreeEntry(
     id: UInt32,
     index: Int,
@@ -264,15 +389,18 @@ private func sidebarFileTreeEntry(
     isActive: Bool = false,
     isDirty: Bool = false,
     gitStatus: UInt8 = 0,
+    isEditing: Bool = false,
+    editingType: UInt8 = 0xFF,
+    editingText: String = "",
     depth: Int = 0,
     icon: String,
     name: String,
     relPath: String
 ) -> FileTreeEntry {
     FileTreeEntry(id: id, index: index, isDir: isDir, isExpanded: isExpanded, isSelected: isSelected,
-                  isFocused: isFocused, isActive: isActive, isDirty: isDirty, isEditing: false,
+                  isFocused: isFocused, isActive: isActive, isDirty: isDirty, isEditing: isEditing,
                   isLastChild: false, depth: depth, gitStatus: gitStatus, diagnosticErrorCount: 0,
                   diagnosticWarningCount: 0, diagnosticInfoCount: 0, diagnosticHintCount: 0,
                   guides: [], icon: icon, name: name, relPath: relPath, path: relPath,
-                  editingType: 0xFF, editingText: "")
+                  editingType: editingType, editingText: editingText)
 }

--- a/macos/Tests/MingaTests/ViewModelComputedTests.swift
+++ b/macos/Tests/MingaTests/ViewModelComputedTests.swift
@@ -222,6 +222,37 @@ struct WhichKeyBindingTests {
     }
 }
 
+// MARK: - FileTreeState and FileTreeEntry computed state
+
+@Suite("FileTreeState and FileTreeEntry Computed State")
+struct FileTreeStateComputedTests {
+
+    @Test("BEAM protocol fields drive active dirty selected and git state")
+    @MainActor func protocolFieldsDriveSemanticState() {
+        let state = FileTreeState()
+        state.update(version: 2, selectedId: "/project/lib/editor.ex", focused: false, treeWidth: 30, rootPath: "/project", rawEntries: [
+            computedWireFileTreeEntry(id: "/project/lib/editor.ex", isSelected: true, isFocused: false, isActive: true, isDirty: true, gitStatus: 4),
+        ])
+
+        let entry = state.entries[0]
+        #expect(entry.isSelected == true)
+        #expect(entry.isFocused == false)
+        #expect(entry.isActive == true)
+        #expect(entry.isDirty == true)
+        #expect(entry.gitStatusValue == .conflict)
+        #expect(entry.showsActiveAccent == true)
+        #expect(entry.showsDirtyMarker == true)
+        #expect(entry.showsGitMarker == true)
+        #expect(entry.hasConflictStatus == true)
+    }
+
+    @Test("Dirty marker is suppressed for directories")
+    @MainActor func directoryDirtyMarkerSuppressed() {
+        let entry = computedFileTreeEntry(path: "/project/lib", relPath: "lib", isDir: true, isDirty: true)
+        #expect(entry.showsDirtyMarker == false)
+    }
+}
+
 // MARK: - FileTreeState fullPath
 
 @Suite("FileTreeState Path Computation")
@@ -244,11 +275,21 @@ struct FileTreePathTests {
     }
 }
 
-private func computedFileTreeEntry(path: String, relPath: String) -> FileTreeEntry {
-    FileTreeEntry(id: 1, index: 0, isDir: false, isExpanded: false, isSelected: false,
-                  isFocused: false, isActive: false, isDirty: false, isEditing: false,
+private func computedFileTreeEntry(path: String, relPath: String, isDir: Bool = false, isDirty: Bool = false) -> FileTreeEntry {
+    FileTreeEntry(id: 1, index: 0, isDir: isDir, isExpanded: false, isSelected: false,
+                  isFocused: false, isActive: false, isDirty: isDirty, isEditing: false,
                   isLastChild: false, depth: 0, gitStatus: 0, diagnosticErrorCount: 0,
                   diagnosticWarningCount: 0, diagnosticInfoCount: 0, diagnosticHintCount: 0,
                   guides: [], icon: "", name: "test", relPath: relPath, path: path,
                   editingType: 0xFF, editingText: "")
+}
+
+private func computedWireFileTreeEntry(id: String, isSelected: Bool, isFocused: Bool, isActive: Bool, isDirty: Bool, gitStatus: UInt8) -> Wire.FileTreeEntry {
+    Wire.FileTreeEntry(pathHash: 1, id: id, path: id, isDir: false, isExpanded: false,
+                       isSelected: isSelected, isFocused: isFocused, isActive: isActive,
+                       isDirty: isDirty, isEditing: false, isLastChild: false, depth: 0,
+                       gitStatus: gitStatus, diagnosticErrorCount: 0, diagnosticWarningCount: 0,
+                       diagnosticInfoCount: 0, diagnosticHintCount: 0, guides: [], icon: "",
+                       name: "editor.ex", relPath: "lib/editor.ex", editingType: 0xFF,
+                       editingText: "")
 }

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -275,20 +275,102 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       assert lib_row_draws == []
     end
 
-    test "highlights active file path", %{tmp_dir: tmp_dir} do
-      main_path = Path.join(tmp_dir, "lib/main.ex")
+    test "active plus selected keeps selection background and active name accent", %{
+      tmp_dir: tmp_dir
+    } do
+      theme = Theme.get!(:doom_one)
+      row = semantic_file_row(tmp_dir, selected?: true, focused?: true, active?: true)
 
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 30, 10},
-        focused: true,
-        theme: Theme.get!(:doom_one),
-        active_path: main_path
-      }
+      draws = render_semantic_rows(tmp_dir, [row], theme)
+      {_r, _c, _text, style} = draw_containing(draws, "main.ex")
 
-      draws = TreeRenderer.render(input)
-      assert [_ | _] = draws
+      assert style.fg == theme.tree.active_fg
+      assert style.bg == theme.tree.cursor_bg
+      assert style.bold == true
     end
+
+    test "active plus git modified preserves independent git marker", %{tmp_dir: tmp_dir} do
+      theme = Theme.get!(:doom_one)
+      row = semantic_file_row(tmp_dir, active?: true, git_status: :modified)
+
+      draws = render_semantic_rows(tmp_dir, [row], theme)
+      {_r, _c, _text, name_style} = draw_containing(draws, "main.ex")
+      {_r, _c, _text, git_style} = draw_matching(draws, " ●")
+
+      assert name_style.fg == theme.tree.active_fg
+      assert git_style.fg == theme.tree.git_modified_fg
+      assert git_style.bg == theme.tree.bg
+    end
+
+    test "selected plus dirty keeps dirty marker visible on selection background", %{
+      tmp_dir: tmp_dir
+    } do
+      theme = Theme.get!(:doom_one)
+      row = semantic_file_row(tmp_dir, selected?: true, focused?: true, dirty?: true)
+
+      draws = render_semantic_rows(tmp_dir, [row], theme)
+      {_r, _c, _text, dirty_style} = draw_matching(draws, "●")
+
+      assert dirty_style.fg == theme.tree.modified_fg
+      assert dirty_style.bg == theme.tree.cursor_bg
+      assert dirty_style.bold == true
+    end
+
+    test "unfocused selected row uses subdued selection background", %{tmp_dir: tmp_dir} do
+      theme = Theme.get!(:doom_one)
+      row = semantic_file_row(tmp_dir, selected?: true, focused?: false)
+
+      draws = render_semantic_rows(tmp_dir, [row], theme)
+      {_r, _c, _text, style} = draw_containing(draws, "main.ex")
+
+      assert style.bg == theme.tree.separator_fg
+      refute style.bg == theme.tree.cursor_bg
+    end
+  end
+
+  defp semantic_file_row(tmp_dir, attrs) do
+    file_path = Path.join(tmp_dir, "main.ex")
+
+    Row.new(
+      Keyword.merge(
+        [
+          id: file_path,
+          path: file_path,
+          relative_path: "main.ex",
+          name: "main.ex",
+          directory?: false,
+          expanded?: false,
+          selected?: false,
+          focused?: false,
+          active?: false,
+          dirty?: false,
+          git_status: nil,
+          depth: 0,
+          guides: [],
+          last_child?: true
+        ],
+        attrs
+      )
+    )
+  end
+
+  defp render_semantic_rows(tmp_dir, rows, theme) do
+    TreeRenderer.render(%RenderInput{
+      tree: FileTree.new(tmp_dir, width: 30),
+      rect: {0, 0, 30, 5},
+      focused: false,
+      theme: theme,
+      active_path: nil,
+      rows: rows
+    })
+  end
+
+  defp draw_containing(draws, text) do
+    Enum.find(draws, fn {_r, _c, draw_text, _style} -> String.contains?(draw_text, text) end)
+  end
+
+  defp draw_matching(draws, text) do
+    Enum.find(draws, fn {_r, _c, draw_text, _style} -> draw_text == text end)
   end
 
   describe "editing entry rendering" do

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -38,8 +38,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
     end
 
     test "includes a header row with project name and folder icon", %{tmp_dir: tmp_dir} do
+      root = Path.join(tmp_dir, "minga")
+
       input = %RenderInput{
-        tree: sample_tree(tmp_dir),
+        tree: sample_tree(root),
         rect: {0, 0, 20, 10},
         focused: false,
         theme: Theme.get!(:doom_one),
@@ -51,8 +53,9 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       header = Enum.find(draws, fn {r, c, _t, _s} -> r == 0 and c == 0 end)
       assert header != nil
       {_r, _c, text, style} = header
-      # Contains the folder open icon (nf-md-folder-open U+F0256)
+      # Contains the folder open icon (nf-md-folder-open U+F0256) and project/root context.
       assert String.contains?(text, "\u{F0256}")
+      assert String.contains?(text, "minga")
       assert style.bold == true
     end
 
@@ -84,10 +87,12 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       texts = Enum.map(draws, fn {_r, _c, text, _s} -> text end)
       all_text = Enum.join(texts)
 
-      # Box-drawing guide characters should be present
-      assert String.contains?(all_text, "├─")
-      assert String.contains?(all_text, "└─")
-      # Expanded lib/ should produce a pipe guide for its children
+      # Disclosure symbols replace heavy connector branch art.
+      assert String.contains?(all_text, "▾ ")
+      assert String.contains?(all_text, "▸ ")
+      refute String.contains?(all_text, "├─")
+      refute String.contains?(all_text, "└─")
+      # Expanded lib/ should still produce a quiet ancestor guide for its children.
       assert String.contains?(all_text, "│ ")
 
       # Directory names should have trailing slashes
@@ -109,9 +114,25 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
 
       draws = TreeRenderer.render(input)
       # Row 1 is the first entry (lib/ directory). It should have multiple draws:
-      # guide segment, icon segment, name segment
+      # structure segment, icon segment, name segment
       row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
-      assert length(row1_draws) >= 2
+      assert length(row1_draws) >= 3
+    end
+
+    test "uses stable disclosure icon and name columns", %{tmp_dir: tmp_dir} do
+      draws =
+        TreeRenderer.render(%RenderInput{
+          tree: sample_tree(tmp_dir),
+          rect: {0, 0, 30, 10},
+          focused: false,
+          theme: Theme.get!(:doom_one),
+          active_path: nil
+        })
+
+      assert {1, 0, "▾ ", _style} = draw_matching(draws, "▾ ")
+      assert {1, 2, "\u{F0256} ", _style} = draw_matching(draws, "\u{F0256} ")
+      assert {1, 4, name, _style} = draw_containing(draws, "lib/")
+      assert String.starts_with?(name, "lib/")
     end
 
     test "renders supplied semantic rows", %{tmp_dir: tmp_dir} do
@@ -456,8 +477,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       texts = Enum.map(row2_draws, fn {_r, _c, text, _s} -> text end)
       all_text = Enum.join(texts)
 
-      # The entry at depth 1 should have a guide connector (└─ since it's last child)
-      assert String.contains?(all_text, "└─") or String.contains?(all_text, "├─")
+      # The entry at depth 1 should keep a quiet structure column without heavy branch art.
+      assert String.contains?(all_text, "│ ") or String.contains?(all_text, "  ")
+      refute String.contains?(all_text, "└─")
+      refute String.contains?(all_text, "├─")
     end
 
     test "non-editing entries render normally when editing is active", %{tmp_dir: tmp_dir} do


### PR DESCRIPTION
# TL;DR
File tree rows now render selection, active-file state, focus, dirty buffers, git status, and directory emphasis as separate visual layers in both TUI and macOS. This keeps combined states readable instead of letting one color overwrite the rest.

Closes #1641

## Context
This is the next child ticket in the file-tree visual polish epic (#1638). It builds on the semantic file-tree row contract and the macOS semantic opcode so both frontends render BEAM-owned row state consistently.

## Changes
- Updated the TUI tree renderer to treat selection as row background, active file as name emphasis, dirty state as its own marker, and git status as its own right-aligned marker.
- Added focused vs unfocused selected-row styling so the tree can show selection without looking equally active in every focus state.
- Updated the macOS file tree to layer drop target, selection, active-file accent, dirty marker, git marker, and directory emphasis independently.
- Added Swift `FileTreeEntry` computed state helpers so active, dirty, and git behavior uses decoded semantic protocol fields rather than path inference.
- Kept git color isolated to the git marker after review found it was still tinting names/icons on macOS.

## Verification
- `mix test.llm test/minga_editor/shell/traditional/tree_renderer_test.exs test/minga_editor/integration/file_tree_test.exs`
- `mix swift.build`
- `xcodebuild test -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS'`
- `make lint`
- `mix test.llm`
- `git diff --check`

## Acceptance Criteria Addressed
- Selected tree row and active/open file are visually distinct in both macOS and TUI. ✅
- Focused and unfocused tree states are distinguishable without making the selected row overly loud. ✅
- Dirty buffer state appears independently from git state. ✅
- Git state remains visible when a row is selected, hovered, active, or unfocused. ✅
- macOS uses decoded active-file and dirty-state fields from the file-tree protocol instead of inferring them locally. ✅
- TUI and macOS use the same state priority order: inline editing, drop target, selected row, active file, dirty buffer, git status, directory emphasis. ✅
- Tests cover combined states such as active plus selected, active plus git modified, selected plus dirty, and unfocused selected row. ✅
