### PR TITLE
File tree rows use a calmer modern hierarchy

### DIFF
--- a/lib/minga_editor/shell/traditional/tree_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tree_renderer.ex
@@ -3,9 +3,9 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   Renders the file tree panel into draw tuples for the left side of the screen.
 
   Produces a list of `DisplayList.draw()` tuples for the tree entries,
-  the separator column, and the header line. Uses Nerd Font icons per
-  filetype, box-drawing indent guides, and a project-name header to
-  match neo-tree.nvim's visual style.
+  the separator column, and the header line. Uses stable disclosure,
+  icon, name, and status columns with quiet ancestor guides so the tree
+  stays scannable without connector-heavy branch art.
   """
 
   alias Minga.Core.Face
@@ -20,11 +20,12 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   alias MingaEditor.UI.Theme
   alias MingaEditor.WindowTree
 
-  # Box-drawing characters for indent guides
+  # Row anatomy: faint ancestor guides, disclosure, icon, name, spacer, dirty marker, git marker.
   @guide_pipe "│ "
-  @guide_tee "├─"
-  @guide_elbow "└─"
   @guide_blank "  "
+  @disclosure_expanded "▾ "
+  @disclosure_collapsed "▸ "
+  @disclosure_file "  "
 
   # Nerd Font folder icons (nf-md-folder / nf-md-folder-open)
   @folder_closed "\u{F024B}"
@@ -183,8 +184,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     focused = tree_row.focused?
     is_dirty = tree_row.dirty?
 
-    # Build the guide prefix from the entry's ancestor guide flags
+    # Build the structure columns from ancestor guides plus a dedicated disclosure column.
     guide_prefix = build_guides(tree_row.guides, tree_row.last_child?)
+    disclosure = disclosure_marker(tree_row)
+    structure_prefix = guide_prefix <> disclosure
 
     # Pick the icon and its color
     {icon, icon_color} = entry_icon(tree_row)
@@ -199,8 +202,8 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     dirty_width = if is_dirty, do: 1, else: 0
     indicator_width = dirty_width + git_width
 
-    # Compose the full line: guides + icon + space + name
-    prefix = guide_prefix <> icon <> " "
+    # Compose the full line: structure columns + icon + space + name
+    prefix = structure_prefix <> icon <> " "
     prefix_width = String.length(prefix)
 
     # Truncate name to fit, accounting for indicator space
@@ -210,25 +213,17 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     # Background style for the full row
     row_bg = row_background(is_cursor, focused, theme)
 
-    # Build draw commands: guide, icon, name, (dirty dot), (git indicator)
+    # Build draw commands: structure, icon, name, dirty marker, and git marker.
     guide_style = guide_draw_style(is_cursor, focused, theme)
     icon_style = icon_draw_style(icon_color, is_cursor, focused, theme)
     name_style = name_draw_style(tree_row, is_cursor, tree_row.active?, focused, theme)
-
-    guide_len = String.length(guide_prefix)
+    structure_len = String.length(structure_prefix)
 
     draws = []
-
-    # Guide segment (if any depth > 0)
-    draws =
-      if guide_len > 0 do
-        draws ++ [DisplayList.draw(row, col, guide_prefix, guide_style)]
-      else
-        draws
-      end
+    draws = draws ++ [DisplayList.draw(row, col, structure_prefix, guide_style)]
 
     # Icon segment
-    icon_col = col + guide_len
+    icon_col = col + structure_len
     draws = draws ++ [DisplayList.draw(row, icon_col, icon <> " ", icon_style)]
 
     # Name segment: pad to fill space between name and indicators
@@ -279,9 +274,11 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     %{col_off: col, width: width, theme: theme} = opts
     editing = tree_row.editing
 
-    # Build indent guides (same depth as the entry being edited/created)
+    # Build the same structure columns as normal rows so inline editing does not shift columns.
     guide_prefix = build_guides(tree_row.guides, tree_row.last_child?)
-    guide_len = String.length(guide_prefix)
+    disclosure = disclosure_marker(tree_row)
+    structure_prefix = guide_prefix <> disclosure
+    structure_len = String.length(structure_prefix)
 
     # Type indicator: file icon for new file, folder icon for new folder,
     # the entry's own icon for rename
@@ -292,7 +289,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
         :rename -> entry_icon(tree_row)
       end
 
-    prefix = guide_prefix <> icon <> " "
+    prefix = structure_prefix <> icon <> " "
     prefix_len = String.length(prefix)
 
     # Editing text with cursor
@@ -317,15 +314,9 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     text_style = Face.new(fg: editing_fg, bg: editing_bg, bold: true)
 
     draws = []
+    draws = draws ++ [DisplayList.draw(row, col, structure_prefix, guide_style)]
 
-    draws =
-      if guide_len > 0 do
-        draws ++ [DisplayList.draw(row, col, guide_prefix, guide_style)]
-      else
-        draws
-      end
-
-    icon_col = col + guide_len
+    icon_col = col + structure_len
     draws = draws ++ [DisplayList.draw(row, icon_col, icon <> " ", icon_style)]
 
     text_col = col + prefix_len
@@ -337,25 +328,17 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   # ── Indent guides ──────────────────────────────────────────────────────
 
   @spec build_guides([boolean()], boolean()) :: String.t()
-  defp build_guides(ancestor_guides, last_child?) do
-    # Ancestor columns: each is either │ (more siblings) or blank (last child)
-    ancestor_part =
-      Enum.map_join(ancestor_guides, fn
-        true -> @guide_pipe
-        false -> @guide_blank
-      end)
-
-    # The connector at this entry's own depth
-    # Depth-0 entries (direct children of root) also get a connector
-    connector =
-      if last_child? do
-        @guide_elbow
-      else
-        @guide_tee
-      end
-
-    ancestor_part <> connector
+  defp build_guides(ancestor_guides, _last_child?) do
+    Enum.map_join(ancestor_guides, fn
+      true -> @guide_pipe
+      false -> @guide_blank
+    end)
   end
+
+  @spec disclosure_marker(Row.t()) :: String.t()
+  defp disclosure_marker(%Row{directory?: true, expanded?: true}), do: @disclosure_expanded
+  defp disclosure_marker(%Row{directory?: true}), do: @disclosure_collapsed
+  defp disclosure_marker(_tree_row), do: @disclosure_file
 
   # ── Icon selection ──────────────────────────────────────────────────────
 

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		19BF036E1B3A3CF589C5F578 /* SidebarHeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C991989EF4CA9F705DD3F4E /* SidebarHeaderButton.swift */; };
 		19E561E5F7841B2CF1ABB085 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
 		1F9F7B302A2A8598C1391FA0 /* AgentChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E244758FFE2BDDE3A8108C70 /* AgentChatState.swift */; };
+		20DE27562883B504C119A22F /* FileTreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */; };
 		23DA463A92D1EC2F7BFA5B5A /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		25B21FDC79D3F65CAA270C99 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
 		26DAAF2C2CCC2713AD30C539 /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
@@ -67,6 +68,7 @@
 		527C7DB557EFD09B3161BC20 /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		531166B714D49278BA811033 /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E892F827AFBE959F9DF25C05 /* StatusBarView.swift */; };
 		5311F1060367B40B4077309F /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5458552EC58E44C7CD15A98A /* FileTreeView.swift */; };
+		53736DA2E4420D55D3D4E0A4 /* FileTreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */; };
 		58D1135E113BF3A33EF7815F /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
 		59546703C9DBB4BA6E15DE28 /* BottomPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443B3C2F0C91435E5C5A2E73 /* BottomPanelView.swift */; };
 		5BEEC2FD4D95EBA70FE036E7 /* BottomPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638ED9425257ED4E5A2A9C5A /* BottomPanelState.swift */; };
@@ -291,6 +293,7 @@
 		CFA9D8D41BCA4E6CB45243A2 /* BreadcrumbBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbBar.swift; sourceTree = "<group>"; };
 		D13F0F0C4944C98854B726C0 /* GitStatusHeaderContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusHeaderContent.swift; sourceTree = "<group>"; };
 		D2D59D9EEB390C8DF351D595 /* FrameState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameState.swift; sourceTree = "<group>"; };
+		D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowView.swift; sourceTree = "<group>"; };
 		DD14027C8C7BD17057DE820B /* AgentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatView.swift; sourceTree = "<group>"; };
 		DF1919291250D9AD1375A8C9 /* CompletionOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionOverlay.swift; sourceTree = "<group>"; };
 		E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryManagerTests.swift; sourceTree = "<group>"; };
@@ -408,6 +411,7 @@
 				83165B89231936674C54B513 /* EditorNSView.swift */,
 				0C26E064D810299C0302F439 /* EditorView.swift */,
 				59AF3A14213020EF4F2200B4 /* FileTreeHeaderContent.swift */,
+				D767F7A50F82AD806EA1B86E /* FileTreeRowView.swift */,
 				CC2F98D07FE0F56DDBCD9525 /* FileTreeState.swift */,
 				5458552EC58E44C7CD15A98A /* FileTreeView.swift */,
 				84C47F406747CA6DD924A1AB /* FloatPopupOverlay.swift */,
@@ -701,6 +705,7 @@
 				82E444261F28262834866B20 /* EditorNSView.swift in Sources */,
 				E5CE1B3EBAABD914418D892F /* EditorView.swift in Sources */,
 				E04EB44BCBE0CEB501618F1A /* FileTreeHeaderContent.swift in Sources */,
+				53736DA2E4420D55D3D4E0A4 /* FileTreeRowView.swift in Sources */,
 				E073657EE87B3F145830B7C7 /* FileTreeState.swift in Sources */,
 				5311F1060367B40B4077309F /* FileTreeView.swift in Sources */,
 				73955B38CEFC09D29EADAD85 /* FloatPopupOverlay.swift in Sources */,
@@ -790,6 +795,7 @@
 				D1EEFBDAE315F717373F82BD /* EditorNSView.swift in Sources */,
 				7A21099CFC922D178A3079DF /* EditorView.swift in Sources */,
 				6BA7D7FBA7A05CDEA428811D /* FileTreeHeaderContent.swift in Sources */,
+				20DE27562883B504C119A22F /* FileTreeRowView.swift in Sources */,
 				C8FAD7BE37506758A1DBF8F6 /* FileTreeState.swift in Sources */,
 				31E0D1C2347322703DA6CC71 /* FileTreeView.swift in Sources */,
 				654E7E631260BE13502E1C32 /* FloatPopupOverlay.swift in Sources */,

--- a/macos/Sources/Views/FileTreeHeaderContent.swift
+++ b/macos/Sources/Views/FileTreeHeaderContent.swift
@@ -15,7 +15,45 @@ struct FileTreeHeaderContent: View {
 
     @State private var isHovered = false
 
+    private var reduceMotion: Bool {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    }
+
+    private var headerAnimationDuration: Double {
+        reduceMotion ? 0 : 0.15
+    }
+
     var body: some View {
+        HStack(spacing: 8) {
+            projectContext
+                .layoutPriority(2)
+
+            secondaryContext
+                .layoutPriority(0)
+
+            Spacer(minLength: 4)
+
+            actionButtons
+                .opacity(isHovered ? 1.0 : 0.72)
+                .animation(reduceMotion ? nil : .easeInOut(duration: headerAnimationDuration), value: isHovered)
+        }
+        .padding(.leading, leadingPadding)
+        .padding(.trailing, 10)
+        .contentShape(Rectangle())
+        .accessibilityLabel(accessibilityLabelText)
+        .onHover { hovering in
+            if reduceMotion {
+                isHovered = hovering
+            } else {
+                withAnimation(.easeInOut(duration: headerAnimationDuration)) {
+                    isHovered = hovering
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var projectContext: some View {
         HStack(spacing: 6) {
             Text("\u{F024B}")
                 .font(.custom("Symbols Nerd Font Mono", size: 12))
@@ -26,45 +64,42 @@ struct FileTreeHeaderContent: View {
                 .foregroundStyle(theme.tabActiveFg)
                 .lineLimit(1)
                 .truncationMode(.tail)
+        }
+    }
 
-            if !branchName.isEmpty {
+    @ViewBuilder
+    private var secondaryContext: some View {
+        if !branchName.isEmpty {
+            HStack(spacing: 4) {
                 Text("\u{E725}")
-                    .font(.custom("Symbols Nerd Font Mono", size: 12))
-                    .foregroundStyle(theme.treeDirFg.opacity(0.7))
+                    .font(.custom("Symbols Nerd Font Mono", size: 11))
+                    .foregroundStyle(theme.treeDirFg.opacity(0.55))
 
                 Text(branchName)
-                    .font(.system(size: 12, weight: .regular))
-                    .foregroundStyle(theme.tabActiveFg.opacity(0.7))
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(theme.tabActiveFg.opacity(0.62))
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-
-            Spacer(minLength: 4)
-
-            if isHovered {
-                HStack(spacing: 2) {
-                    headerButton(systemName: "doc.badge.plus", tooltip: "New File…") {
-                        encoder?.sendFileTreeNewFile(parentIndex: UInt16(fileTreeState.selectedIndex))
-                    }
-                    headerButton(systemName: "folder.badge.plus", tooltip: "New Folder…") {
-                        encoder?.sendFileTreeNewFolder(parentIndex: UInt16(fileTreeState.selectedIndex))
-                    }
-                    headerButton(systemName: "arrow.clockwise", tooltip: "Refresh") {
-                        encoder?.sendFileTreeRefresh()
-                    }
-                    headerButton(systemName: "arrow.down.right.and.arrow.up.left", tooltip: "Collapse All") {
-                        encoder?.sendFileTreeCollapseAll()
-                    }
-                }
-                .transition(.opacity)
-            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(theme.treeHeaderFg.opacity(0.08), in: Capsule())
         }
-        .padding(.leading, leadingPadding)
-        .padding(.trailing, 10)
-        .contentShape(Rectangle())
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.15)) {
-                isHovered = hovering
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: 2) {
+            headerButton(systemName: "doc.badge.plus", tooltip: "New File…") {
+                encoder?.sendFileTreeNewFile(parentIndex: UInt16(fileTreeState.selectedIndex))
+            }
+            headerButton(systemName: "folder.badge.plus", tooltip: "New Folder…") {
+                encoder?.sendFileTreeNewFolder(parentIndex: UInt16(fileTreeState.selectedIndex))
+            }
+            headerButton(systemName: "arrow.clockwise", tooltip: "Refresh") {
+                encoder?.sendFileTreeRefresh()
+            }
+            headerButton(systemName: "arrow.down.right.and.arrow.up.left", tooltip: "Collapse All") {
+                encoder?.sendFileTreeCollapseAll()
             }
         }
     }
@@ -77,6 +112,13 @@ struct FileTreeHeaderContent: View {
             tooltip: tooltip,
             action: action
         )
+    }
+
+    var accessibilityLabelText: String {
+        if branchName.isEmpty {
+            return "File tree for \(projectName)"
+        }
+        return "File tree for \(projectName), branch \(branchName)"
     }
 
     private var projectName: String {

--- a/macos/Sources/Views/FileTreeRowView.swift
+++ b/macos/Sources/Views/FileTreeRowView.swift
@@ -1,0 +1,203 @@
+/// Visual row component for the semantic file tree.
+///
+/// FileTreeView owns list behavior and action wiring. This view owns the row anatomy and visual layers:
+/// disclosure, icon, name, spacer, dirty marker, git marker, then background/accent layers.
+
+import SwiftUI
+
+struct FileTreeRowView: View {
+    let entry: FileTreeEntry
+    let theme: ThemeColors
+    let rowHeight: CGFloat
+    let indentWidth: CGFloat
+    let chevronWidth: CGFloat
+    let isHovered: Bool
+    let isDropTarget: Bool
+    let animDuration: Double
+    let onEditCommit: (String) -> Void
+    let onEditCancel: () -> Void
+
+    var body: some View {
+        rowContent
+            .padding(.leading, leadingPadding)
+            .padding(.trailing, 8)
+            .frame(height: rowHeight)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(rowBackground)
+            .overlay(alignment: .leading) {
+                activeFileAccent
+            }
+            .overlay(alignment: .leading) {
+                indentGuides
+            }
+            .accessibilityLabel(accessibilityLabelText)
+            .accessibilityHint(accessibilityHintText)
+    }
+
+    @ViewBuilder
+    private var rowContent: some View {
+        HStack(spacing: 0) {
+            disclosureChevron
+
+            Text(entry.icon)
+                .font(.custom("Symbols Nerd Font Mono", size: 12))
+                .foregroundStyle(iconColor)
+                .frame(width: 16, alignment: .center)
+
+            Spacer().frame(width: 4)
+
+            if entry.isEditing {
+                InlineEditField(
+                    initialText: entry.editingText,
+                    selectStem: entry.editingType == 2,
+                    onCommit: onEditCommit,
+                    onCancel: onEditCancel
+                )
+                .frame(height: rowHeight)
+            } else {
+                Text(entry.name)
+                    .font(.system(size: 12, weight: entry.showsActiveAccent ? .semibold : .regular))
+                    .foregroundStyle(nameColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer(minLength: 0)
+
+                dirtyMarker
+                gitStatusDot
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var disclosureChevron: some View {
+        if entry.isDir {
+            Image(systemName: "chevron.right")
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(theme.treeFg.opacity(0.5))
+                .rotationEffect(.degrees(entry.isExpanded ? 90 : 0))
+                .animation(.easeInOut(duration: animDuration), value: entry.isExpanded)
+                .frame(width: chevronWidth, height: rowHeight)
+        } else {
+            Spacer().frame(width: chevronWidth)
+        }
+    }
+
+    @ViewBuilder
+    private var dirtyMarker: some View {
+        if entry.showsDirtyMarker {
+            Text("●")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(theme.treeGitModified)
+                .padding(.trailing, entry.showsGitMarker ? 4 : 2)
+        }
+    }
+
+    @ViewBuilder
+    private var gitStatusDot: some View {
+        if let color = gitDotColor {
+            Circle()
+                .fill(color)
+                .frame(width: entry.hasConflictStatus ? 7 : 6, height: entry.hasConflictStatus ? 7 : 6)
+                .padding(.trailing, 2)
+        }
+    }
+
+    private var gitDotColor: Color? {
+        switch entry.gitStatusValue {
+        case .modified: return theme.treeGitModified
+        case .staged: return theme.treeGitStaged
+        case .untracked: return theme.treeGitUntracked
+        case .conflict: return theme.gutterErrorFg
+        case .renamed: return theme.treeGitStaged
+        case .deleted: return theme.gitDeletedFg
+        case .clean: return nil
+        }
+    }
+
+    @ViewBuilder
+    private var indentGuides: some View {
+        if !entry.guides.isEmpty {
+            Canvas { context, size in
+                for (level, shouldDraw) in entry.guides.enumerated() where shouldDraw {
+                    let x = 8 + CGFloat(level) * indentWidth + chevronWidth / 2
+                    let rect = CGRect(x: x, y: 0, width: 1, height: size.height)
+                    context.fill(Path(rect), with: .color(theme.treeGuideFg))
+                }
+            }
+            .allowsHitTesting(false)
+            .frame(height: rowHeight)
+        }
+    }
+
+    @ViewBuilder
+    private var rowBackground: some View {
+        if entry.isEditing {
+            rowFill(theme.treeSelectionBg)
+        } else if isDropTarget {
+            rowFill(theme.treeSelectionBg.opacity(0.55))
+        } else if entry.isSelected {
+            rowFill(theme.treeSelectionBg.opacity(entry.isFocused ? 1.0 : 0.42))
+        } else if isHovered {
+            rowFill(theme.treeFg.opacity(0.06))
+                .animation(.easeInOut(duration: animDuration), value: isHovered)
+        }
+    }
+
+    @ViewBuilder
+    private var activeFileAccent: some View {
+        if entry.showsActiveAccent {
+            RoundedRectangle(cornerRadius: 1)
+                .fill(theme.treeActiveFg)
+                .frame(width: 2, height: rowHeight - 8)
+                .padding(.leading, 4)
+        }
+    }
+
+    private func rowFill(_ color: Color) -> some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(color)
+            .padding(.horizontal, 4)
+    }
+
+    private var leadingPadding: CGFloat {
+        8 + CGFloat(entry.depth) * indentWidth
+    }
+
+    private var iconColor: Color {
+        if entry.showsActiveAccent {
+            return theme.treeActiveFg
+        }
+        if entry.isDir {
+            return theme.treeDirFg
+        }
+        return theme.treeFg.opacity(0.7)
+    }
+
+    private var nameColor: Color {
+        if entry.showsActiveAccent {
+            return theme.treeActiveFg
+        }
+        if entry.isSelected {
+            return theme.treeSelectionFg
+        }
+        return entry.isDir ? theme.treeDirFg : theme.treeFg
+    }
+
+    var accessibilityLabelText: String {
+        if entry.isEditing {
+            return "Editing: \(entry.name)"
+        }
+        return entry.isDir ? "Folder: \(entry.name)" : "File: \(entry.name)"
+    }
+
+    var accessibilityHintText: String {
+        if entry.isEditing {
+            return "Type a new name, then press Return to confirm or Escape to cancel."
+        }
+        if entry.isDir {
+            return entry.isExpanded ? "Expanded folder. Press Return to collapse." : "Collapsed folder. Press Return to expand."
+        }
+        return "Press Return to open."
+    }
+}

--- a/macos/Sources/Views/FileTreeView.swift
+++ b/macos/Sources/Views/FileTreeView.swift
@@ -159,115 +159,56 @@ struct FileTreeView: View {
     @ViewBuilder
     private func entryRow(_ entry: FileTreeEntry) -> some View {
         if entry.isEditing {
-            editingEntryRow(entry)
+            fileTreeRow(entry)
+                .id(entry.id)
         } else {
-            normalEntryRow(entry)
-        }
-    }
-
-    @ViewBuilder
-    private func editingEntryRow(_ entry: FileTreeEntry) -> some View {
-        HStack(spacing: 0) {
-            disclosureChevron(entry)
-
-            Text(entry.icon)
-                .font(.custom("Symbols Nerd Font Mono", size: 12))
-                .foregroundStyle(iconColor(entry))
-                .frame(width: 16, alignment: .center)
-
-            Spacer().frame(width: 4)
-
-            InlineEditField(
-                initialText: entry.editingText,
-                selectStem: entry.editingType == 2,  // rename
-                onCommit: { text in
-                    encoder?.sendFileTreeEditConfirm(text: text)
-                },
-                onCancel: {
-                    encoder?.sendFileTreeEditCancel()
+            fileTreeRow(entry)
+                .id(entry.id)
+                .contentShape(Rectangle())
+                .onHover { isHovered in
+                    hoveredEntryId = isHovered ? entry.id : nil
+                    if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                 }
-            )
-            .frame(height: rowHeight)
+                .onTapGesture {
+                    handleEntryTap(entry)
+                }
+                .contextMenu { entryContextMenu(entry) }
+                .draggable(URL(fileURLWithPath: fileTreeState.fullPath(for: entry))) {
+                    HStack(spacing: 4) {
+                        Text(entry.icon)
+                            .font(.system(size: 12))
+                        Text(entry.name)
+                            .font(.system(size: 12))
+                    }
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(theme.popupBg, in: RoundedRectangle(cornerRadius: 4))
+                }
+                .dropDestination(for: URL.self) { urls, _ in
+                    handleDrop(urls: urls, onto: entry)
+                } isTargeted: { isTargeted in
+                    dropTargetEntryId = isTargeted && entry.isDir ? entry.id : nil
+                }
         }
-        .padding(.leading, leadingPadding(entry))
-        .padding(.trailing, 8)
-        .frame(height: rowHeight)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 4)
-                .fill(theme.treeSelectionBg)
-                .padding(.horizontal, 4)
-        )
-        .overlay(alignment: .leading) {
-            indentGuides(entry)
-        }
-        .id(entry.id)
     }
 
-    @ViewBuilder
-    private func normalEntryRow(_ entry: FileTreeEntry) -> some View {
-        HStack(spacing: 0) {
-            // Disclosure chevron (directories) or alignment spacer (files)
-            disclosureChevron(entry)
-
-            // Nerd Font icon
-            Text(entry.icon)
-                .font(.custom("Symbols Nerd Font Mono", size: 12))
-                .foregroundStyle(iconColor(entry))
-                .frame(width: 16, alignment: .center)
-
-            Spacer().frame(width: 4)
-
-            // Name
-            Text(entry.name)
-                .font(.system(size: 12, weight: entry.showsActiveAccent ? .semibold : .regular))
-                .foregroundStyle(nameColor(entry))
-                .lineLimit(1)
-                .truncationMode(.tail)
-
-            Spacer(minLength: 0)
-
-            dirtyMarker(entry)
-            gitStatusDot(entry)
-        }
-        .padding(.leading, leadingPadding(entry))
-        .padding(.trailing, 8)
-        .frame(height: rowHeight)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(rowBackground(entry))
-        .overlay(alignment: .leading) {
-            activeFileAccent(entry)
-        }
-        .overlay(alignment: .leading) {
-            indentGuides(entry)
-        }
-        .id(entry.id)
-        .contentShape(Rectangle())
-        .onHover { isHovered in
-            hoveredEntryId = isHovered ? entry.id : nil
-            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
-        .onTapGesture {
-            handleEntryTap(entry)
-        }
-        .contextMenu { entryContextMenu(entry) }
-        .draggable(URL(fileURLWithPath: fileTreeState.fullPath(for: entry))) {
-            HStack(spacing: 4) {
-                Text(entry.icon)
-                    .font(.system(size: 12))
-                Text(entry.name)
-                    .font(.system(size: 12))
+    private func fileTreeRow(_ entry: FileTreeEntry) -> FileTreeRowView {
+        FileTreeRowView(
+            entry: entry,
+            theme: theme,
+            rowHeight: rowHeight,
+            indentWidth: indentWidth,
+            chevronWidth: chevronWidth,
+            isHovered: hoveredEntryId == entry.id,
+            isDropTarget: dropTargetEntryId == entry.id,
+            animDuration: animDuration,
+            onEditCommit: { text in
+                encoder?.sendFileTreeEditConfirm(text: text)
+            },
+            onEditCancel: {
+                encoder?.sendFileTreeEditCancel()
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(theme.popupBg, in: RoundedRectangle(cornerRadius: 4))
-        }
-        .dropDestination(for: URL.self) { urls, _ in
-            handleDrop(urls: urls, onto: entry)
-        } isTargeted: { isTargeted in
-            dropTargetEntryId = isTargeted && entry.isDir ? entry.id : nil
-        }
-        .accessibilityLabel(entry.isDir ? "Folder: \(entry.name)" : "File: \(entry.name)")
+        )
     }
 
     // MARK: - Context menu
@@ -435,120 +376,12 @@ struct FileTreeView: View {
         }
     }
 
-    // MARK: - Indent guides
-
-    // MARK: - Dirty and git markers
-
-    /// Dirty buffers use their own marker so unsaved edits stay visible independently from git status.
-    @ViewBuilder
-    private func dirtyMarker(_ entry: FileTreeEntry) -> some View {
-        if entry.showsDirtyMarker {
-            Text("●")
-                .font(.system(size: 9, weight: .bold))
-                .foregroundStyle(theme.treeGitModified)
-                .padding(.trailing, entry.showsGitMarker ? 4 : 2)
-        }
-    }
-
-    /// Small colored dot indicating git status, right-aligned in the row.
-    @ViewBuilder
-    private func gitStatusDot(_ entry: FileTreeEntry) -> some View {
-        if let color = gitDotColor(entry) {
-            Circle()
-                .fill(color)
-                .frame(width: entry.hasConflictStatus ? 7 : 6, height: entry.hasConflictStatus ? 7 : 6)
-                .padding(.trailing, 2)
-        }
-    }
-
-    private func gitDotColor(_ entry: FileTreeEntry) -> Color? {
-        switch entry.gitStatusValue {
-        case .modified: return theme.treeGitModified
-        case .staged: return theme.treeGitStaged
-        case .untracked: return theme.treeGitUntracked
-        case .conflict: return theme.gutterErrorFg
-        case .renamed: return theme.treeGitStaged
-        case .deleted: return theme.gitDeletedFg
-        case .clean: return nil
-        }
-    }
-
-    /// Draws thin vertical indent guide lines using the BEAM-supplied semantic ancestor guide mask.
-    @ViewBuilder
-    private func indentGuides(_ entry: FileTreeEntry) -> some View {
-        if !entry.guides.isEmpty {
-            Canvas { context, size in
-                for (level, shouldDraw) in entry.guides.enumerated() where shouldDraw {
-                    // Align guide with the center of each ancestor's chevron column.
-                    let x = 8 + CGFloat(level) * indentWidth + chevronWidth / 2
-                    let rect = CGRect(x: x, y: 0, width: 1, height: size.height)
-                    context.fill(Path(rect), with: .color(theme.treeGuideFg))
-                }
-            }
-            .allowsHitTesting(false)
-            .frame(height: rowHeight)
-        }
-    }
-
-    // MARK: - Row layers (drop target, selection, active file, hover)
-
-    @ViewBuilder
-    private func rowBackground(_ entry: FileTreeEntry) -> some View {
-        if dropTargetEntryId == entry.id {
-            RoundedRectangle(cornerRadius: 4)
-                .fill(theme.treeSelectionBg.opacity(0.55))
-                .padding(.horizontal, 4)
-        } else if entry.isSelected {
-            RoundedRectangle(cornerRadius: 4)
-                .fill(theme.treeSelectionBg.opacity(entry.isFocused ? 1.0 : 0.42))
-                .padding(.horizontal, 4)
-        } else if hoveredEntryId == entry.id {
-            RoundedRectangle(cornerRadius: 4)
-                .fill(theme.treeFg.opacity(0.06))
-                .padding(.horizontal, 4)
-                .animation(.easeInOut(duration: animDuration), value: hoveredEntryId)
-        } else {
-            Color.clear
-        }
-    }
-
-    @ViewBuilder
-    private func activeFileAccent(_ entry: FileTreeEntry) -> some View {
-        if entry.showsActiveAccent {
-            RoundedRectangle(cornerRadius: 1)
-                .fill(theme.treeActiveFg)
-                .frame(width: 2, height: rowHeight - 8)
-                .padding(.leading, 4)
-        }
-    }
-
     // MARK: - Layout helpers
 
     private func leadingPadding(_ entry: FileTreeEntry) -> CGFloat {
         8 + CGFloat(entry.depth) * indentWidth
     }
 
-    // MARK: - Colors
-
-    private func iconColor(_ entry: FileTreeEntry) -> Color {
-        if entry.showsActiveAccent {
-            return theme.treeActiveFg
-        }
-        if entry.isDir {
-            return theme.treeDirFg
-        }
-        return theme.treeFg.opacity(0.7)
-    }
-
-    private func nameColor(_ entry: FileTreeEntry) -> Color {
-        if entry.showsActiveAccent {
-            return theme.treeActiveFg
-        }
-        if entry.isSelected {
-            return theme.treeSelectionFg
-        }
-        return entry.isDir ? theme.treeDirFg : theme.treeFg
-    }
 }
 
 /// Preference key for tracking scroll offset within the file tree.

--- a/macos/Sources/Views/SidebarHeaderButton.swift
+++ b/macos/Sources/Views/SidebarHeaderButton.swift
@@ -36,6 +36,7 @@ struct SidebarHeaderButton: View {
         }
         .buttonStyle(.plain)
         .help(tooltip)
+        .accessibilityLabel(tooltip)
         .onHover { hovering in
             if reduceMotion {
                 isHovered = hovering

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -41,6 +41,18 @@ struct SidebarHeaderButtonTests {
         try button.tap()
         #expect(tapped)
     }
+
+    @Test("Tooltip also backs the accessibility label")
+    @MainActor func tooltipBacksAccessibilityLabel() throws {
+        let sut = SidebarHeaderButton(
+            systemName: "plus",
+            barFg: .white,
+            tooltip: "New File…",
+            action: {}
+        )
+        let button = try sut.inspect().find(ViewType.Button.self)
+        #expect(try button.accessibilityLabel().string() == "New File…")
+    }
 }
 
 // MARK: - GitStatusView Empty States
@@ -153,15 +165,49 @@ struct FileTreeViewTests {
         #expect(strings.contains("Project"))
     }
 
-    @Test("Header action buttons are hidden at rest (shown on hover)")
-    @MainActor func headerActionButtonsHiddenAtRest() throws {
+    @Test("Header action buttons reserve layout space at rest")
+    @MainActor func headerActionButtonsReserveLayoutSpaceAtRest() throws {
         let state = FileTreeState()
         state.visible = true
 
         let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "", leadingPadding: 10)
         let body = try sut.inspect()
         let buttons = body.findAll(ViewType.Button.self)
-        #expect(buttons.count == 0)
+        #expect(buttons.count == 4)
+    }
+
+    @Test("Header action buttons send file-tree actions")
+    @MainActor func headerActionButtonsSendFileTreeActions() throws {
+        let state = FileTreeState()
+        state.visible = true
+        state.selectedIndex = 7
+        let spy = SpyEncoder()
+
+        let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: spy, branchName: "main", leadingPadding: 10)
+        let buttons = try sut.inspect().findAll(ViewType.Button.self)
+
+        try buttons[0].tap()
+        try buttons[1].tap()
+        try buttons[2].tap()
+        try buttons[3].tap()
+
+        #expect(spy.guiActions == [
+            .fileTreeNewFile(parentIndex: 7),
+            .fileTreeNewFolder(parentIndex: 7),
+            .fileTreeRefresh,
+            .fileTreeCollapseAll,
+        ])
+    }
+
+    @Test("Header accessibility summarizes project and branch context")
+    @MainActor func headerAccessibilitySummarizesProjectAndBranchContext() throws {
+        let state = FileTreeState()
+        state.visible = true
+        state.projectRoot = "/Users/test/code/minga"
+
+        let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "main", leadingPadding: 10)
+
+        #expect(sut.accessibilityLabelText == "File tree for minga, branch main")
     }
 
     @Test("File entries render their names")

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -199,6 +199,69 @@ struct FileTreeViewTests {
         #expect(strings.contains("editor.ex"))
         #expect(strings.contains("●"))
     }
+
+    @Test("Editing row renders inline edit field")
+    @MainActor func editingRowRendersInlineEditField() throws {
+        let state = FileTreeState()
+        state.visible = true
+        state.entries = [
+            sidebarFileTreeEntry(id: 1, index: 0, isEditing: true, editingType: 2, editingText: "renamed.ex",
+                                 icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"),
+        ]
+
+        let sut = FileTreeView(fileTreeState: state, theme: ThemeColors(), encoder: nil)
+        let body = try sut.inspect()
+        let fields = body.findAll(InlineEditField.self)
+
+        #expect(fields.count == 1)
+    }
+}
+
+// MARK: - FileTreeRowView
+
+@Suite("FileTreeRowView View Structure")
+struct FileTreeRowViewTests {
+
+    @Test("Accessibility labels and hints describe row state")
+    @MainActor func accessibilityLabelsAndHintsDescribeRowState() throws {
+        let file = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        #expect(file.accessibilityLabelText == "File: editor.ex")
+        #expect(file.accessibilityHintText == "Press Return to open.")
+
+        let collapsedDir = fileTreeRowView(entry: sidebarFileTreeEntry(id: 2, index: 1, isDir: true, icon: "\u{F024B}", name: "lib", relPath: "lib"))
+        #expect(collapsedDir.accessibilityLabelText == "Folder: lib")
+        #expect(collapsedDir.accessibilityHintText == "Collapsed folder. Press Return to expand.")
+
+        let expandedDir = fileTreeRowView(entry: sidebarFileTreeEntry(id: 3, index: 2, isDir: true, isExpanded: true, icon: "\u{F0256}", name: "test", relPath: "test"))
+        #expect(expandedDir.accessibilityHintText == "Expanded folder. Press Return to collapse.")
+
+        let editing = fileTreeRowView(entry: sidebarFileTreeEntry(id: 4, index: 3, isEditing: true, editingType: 2, editingText: "renamed.ex", icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        #expect(editing.accessibilityLabelText == "Editing: editor.ex")
+        #expect(editing.accessibilityHintText == "Type a new name, then press Return to confirm or Escape to cancel.")
+    }
+
+    @Test("Files directories and expanded folders have distinct row affordances")
+    @MainActor func filesDirectoriesAndExpandedFoldersHaveDistinctAffordances() throws {
+        let file = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        let collapsedDir = fileTreeRowView(entry: sidebarFileTreeEntry(id: 2, index: 1, isDir: true, icon: "\u{F024B}", name: "lib", relPath: "lib"))
+        let expandedDir = fileTreeRowView(entry: sidebarFileTreeEntry(id: 3, index: 2, isDir: true, isExpanded: true, icon: "\u{F0256}", name: "test", relPath: "test"))
+
+        #expect(try file.inspect().findAll(ViewType.Image.self).isEmpty)
+        #expect(try collapsedDir.inspect().findAll(ViewType.Image.self).count == 1)
+        #expect(try expandedDir.inspect().findAll(ViewType.Image.self).count == 1)
+        #expect(try collapsedDir.inspect().find(ViewType.Image.self).rotation().angle.degrees == 0)
+        #expect(try expandedDir.inspect().find(ViewType.Image.self).rotation().angle.degrees == 90)
+    }
+
+    @Test("Status markers remain separate from name text")
+    @MainActor func statusMarkersRemainSeparateFromNameText() throws {
+        let row = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, isSelected: true, isFocused: true, isActive: true, isDirty: true, gitStatus: 1, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        let strings = try row.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("editor.ex"))
+        #expect(strings.contains("●"))
+        #expect(try row.inspect().findAll(ViewType.Shape.self).count >= 1)
+    }
 }
 
 // MARK: - GitStatusView Section Headers
@@ -254,6 +317,22 @@ struct GitStatusViewSectionTests {
     }
 }
 
+@MainActor
+private func fileTreeRowView(entry: FileTreeEntry, isHovered: Bool = false, isDropTarget: Bool = false) -> FileTreeRowView {
+    FileTreeRowView(
+        entry: entry,
+        theme: ThemeColors(),
+        rowHeight: 22,
+        indentWidth: 14,
+        chevronWidth: 12,
+        isHovered: isHovered,
+        isDropTarget: isDropTarget,
+        animDuration: 0,
+        onEditCommit: { _ in },
+        onEditCancel: {}
+    )
+}
+
 private func sidebarFileTreeEntry(
     id: UInt32,
     index: Int,
@@ -264,15 +343,18 @@ private func sidebarFileTreeEntry(
     isActive: Bool = false,
     isDirty: Bool = false,
     gitStatus: UInt8 = 0,
+    isEditing: Bool = false,
+    editingType: UInt8 = 0xFF,
+    editingText: String = "",
     depth: Int = 0,
     icon: String,
     name: String,
     relPath: String
 ) -> FileTreeEntry {
     FileTreeEntry(id: id, index: index, isDir: isDir, isExpanded: isExpanded, isSelected: isSelected,
-                  isFocused: isFocused, isActive: isActive, isDirty: isDirty, isEditing: false,
+                  isFocused: isFocused, isActive: isActive, isDirty: isDirty, isEditing: isEditing,
                   isLastChild: false, depth: depth, gitStatus: gitStatus, diagnosticErrorCount: 0,
                   diagnosticWarningCount: 0, diagnosticInfoCount: 0, diagnosticHintCount: 0,
                   guides: [], icon: icon, name: name, relPath: relPath, path: relPath,
-                  editingType: 0xFF, editingText: "")
+                  editingType: editingType, editingText: editingText)
 }

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -38,8 +38,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
     end
 
     test "includes a header row with project name and folder icon", %{tmp_dir: tmp_dir} do
+      root = Path.join(tmp_dir, "minga")
+
       input = %RenderInput{
-        tree: sample_tree(tmp_dir),
+        tree: sample_tree(root),
         rect: {0, 0, 20, 10},
         focused: false,
         theme: Theme.get!(:doom_one),
@@ -51,8 +53,9 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       header = Enum.find(draws, fn {r, c, _t, _s} -> r == 0 and c == 0 end)
       assert header != nil
       {_r, _c, text, style} = header
-      # Contains the folder open icon (nf-md-folder-open U+F0256)
+      # Contains the folder open icon (nf-md-folder-open U+F0256) and project/root context.
       assert String.contains?(text, "\u{F0256}")
+      assert String.contains?(text, "minga")
       assert style.bold == true
     end
 

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -84,10 +84,12 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       texts = Enum.map(draws, fn {_r, _c, text, _s} -> text end)
       all_text = Enum.join(texts)
 
-      # Box-drawing guide characters should be present
-      assert String.contains?(all_text, "├─")
-      assert String.contains?(all_text, "└─")
-      # Expanded lib/ should produce a pipe guide for its children
+      # Disclosure symbols replace heavy connector branch art.
+      assert String.contains?(all_text, "▾ ")
+      assert String.contains?(all_text, "▸ ")
+      refute String.contains?(all_text, "├─")
+      refute String.contains?(all_text, "└─")
+      # Expanded lib/ should still produce a quiet ancestor guide for its children.
       assert String.contains?(all_text, "│ ")
 
       # Directory names should have trailing slashes
@@ -109,9 +111,25 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
 
       draws = TreeRenderer.render(input)
       # Row 1 is the first entry (lib/ directory). It should have multiple draws:
-      # guide segment, icon segment, name segment
+      # structure segment, icon segment, name segment
       row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
-      assert length(row1_draws) >= 2
+      assert length(row1_draws) >= 3
+    end
+
+    test "uses stable disclosure icon and name columns", %{tmp_dir: tmp_dir} do
+      draws =
+        TreeRenderer.render(%RenderInput{
+          tree: sample_tree(tmp_dir),
+          rect: {0, 0, 30, 10},
+          focused: false,
+          theme: Theme.get!(:doom_one),
+          active_path: nil
+        })
+
+      assert {1, 0, "▾ ", _style} = draw_matching(draws, "▾ ")
+      assert {1, 2, "\u{F0256} ", _style} = draw_matching(draws, "\u{F0256} ")
+      assert {1, 4, name, _style} = draw_containing(draws, "lib/")
+      assert String.starts_with?(name, "lib/")
     end
 
     test "renders supplied semantic rows", %{tmp_dir: tmp_dir} do
@@ -456,8 +474,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       texts = Enum.map(row2_draws, fn {_r, _c, text, _s} -> text end)
       all_text = Enum.join(texts)
 
-      # The entry at depth 1 should have a guide connector (└─ since it's last child)
-      assert String.contains?(all_text, "└─") or String.contains?(all_text, "├─")
+      # The entry at depth 1 should keep a quiet structure column without heavy branch art.
+      assert String.contains?(all_text, "│ ") or String.contains?(all_text, "  ")
+      refute String.contains?(all_text, "└─")
+      refute String.contains?(all_text, "├─")
     end
 
     test "non-editing entries render normally when editing is active", %{tmp_dir: tmp_dir} do


### PR DESCRIPTION
## Summary
- Reworks TUI file-tree rows into stable disclosure, icon, name, and status columns with quieter ancestor guides.
- Extracts macOS row rendering into `FileTreeRowView` so row anatomy, state layering, status markers, and accessibility text are easier to reason about.
- Adds targeted TUI and Swift view tests for disclosure variants, stable columns, markers, inline editing, and accessibility labels/hints.

## Stack
- Stacked on #1663 / `feat-file-tree-state-separation`.
- Closes #1642 after the base PR lands.

## Validation
- `mix test.llm test/minga_editor/shell/traditional/tree_renderer_test.exs`
- `mix swift.build`
- `xcodebuild test -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS'`
- `make lint`
- `mix test.llm` (initial run had 3 transient timeouts/poll misses, targeted rerun passed, second full run passed)
- `git diff --check`

## Review
- Bug hunting: `prtk-code-reviewer`, `prtk-test-analyzer`
- Final reviewer: PASS after targeted re-review of the process-only test-advisor block
