### PR TITLE
File tree header gives project context without layout noise

### DIFF
--- a/macos/Sources/Views/FileTreeHeaderContent.swift
+++ b/macos/Sources/Views/FileTreeHeaderContent.swift
@@ -15,7 +15,45 @@ struct FileTreeHeaderContent: View {
 
     @State private var isHovered = false
 
+    private var reduceMotion: Bool {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    }
+
+    private var headerAnimationDuration: Double {
+        reduceMotion ? 0 : 0.15
+    }
+
     var body: some View {
+        HStack(spacing: 8) {
+            projectContext
+                .layoutPriority(2)
+
+            secondaryContext
+                .layoutPriority(0)
+
+            Spacer(minLength: 4)
+
+            actionButtons
+                .opacity(isHovered ? 1.0 : 0.72)
+                .animation(reduceMotion ? nil : .easeInOut(duration: headerAnimationDuration), value: isHovered)
+        }
+        .padding(.leading, leadingPadding)
+        .padding(.trailing, 10)
+        .contentShape(Rectangle())
+        .accessibilityLabel(accessibilityLabelText)
+        .onHover { hovering in
+            if reduceMotion {
+                isHovered = hovering
+            } else {
+                withAnimation(.easeInOut(duration: headerAnimationDuration)) {
+                    isHovered = hovering
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var projectContext: some View {
         HStack(spacing: 6) {
             Text("\u{F024B}")
                 .font(.custom("Symbols Nerd Font Mono", size: 12))
@@ -26,45 +64,42 @@ struct FileTreeHeaderContent: View {
                 .foregroundStyle(theme.tabActiveFg)
                 .lineLimit(1)
                 .truncationMode(.tail)
+        }
+    }
 
-            if !branchName.isEmpty {
+    @ViewBuilder
+    private var secondaryContext: some View {
+        if !branchName.isEmpty {
+            HStack(spacing: 4) {
                 Text("\u{E725}")
-                    .font(.custom("Symbols Nerd Font Mono", size: 12))
-                    .foregroundStyle(theme.treeDirFg.opacity(0.7))
+                    .font(.custom("Symbols Nerd Font Mono", size: 11))
+                    .foregroundStyle(theme.treeDirFg.opacity(0.55))
 
                 Text(branchName)
-                    .font(.system(size: 12, weight: .regular))
-                    .foregroundStyle(theme.tabActiveFg.opacity(0.7))
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(theme.tabActiveFg.opacity(0.62))
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-
-            Spacer(minLength: 4)
-
-            if isHovered {
-                HStack(spacing: 2) {
-                    headerButton(systemName: "doc.badge.plus", tooltip: "New File…") {
-                        encoder?.sendFileTreeNewFile(parentIndex: UInt16(fileTreeState.selectedIndex))
-                    }
-                    headerButton(systemName: "folder.badge.plus", tooltip: "New Folder…") {
-                        encoder?.sendFileTreeNewFolder(parentIndex: UInt16(fileTreeState.selectedIndex))
-                    }
-                    headerButton(systemName: "arrow.clockwise", tooltip: "Refresh") {
-                        encoder?.sendFileTreeRefresh()
-                    }
-                    headerButton(systemName: "arrow.down.right.and.arrow.up.left", tooltip: "Collapse All") {
-                        encoder?.sendFileTreeCollapseAll()
-                    }
-                }
-                .transition(.opacity)
-            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(theme.treeHeaderFg.opacity(0.08), in: Capsule())
         }
-        .padding(.leading, leadingPadding)
-        .padding(.trailing, 10)
-        .contentShape(Rectangle())
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.15)) {
-                isHovered = hovering
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: 2) {
+            headerButton(systemName: "doc.badge.plus", tooltip: "New File…") {
+                encoder?.sendFileTreeNewFile(parentIndex: UInt16(fileTreeState.selectedIndex))
+            }
+            headerButton(systemName: "folder.badge.plus", tooltip: "New Folder…") {
+                encoder?.sendFileTreeNewFolder(parentIndex: UInt16(fileTreeState.selectedIndex))
+            }
+            headerButton(systemName: "arrow.clockwise", tooltip: "Refresh") {
+                encoder?.sendFileTreeRefresh()
+            }
+            headerButton(systemName: "arrow.down.right.and.arrow.up.left", tooltip: "Collapse All") {
+                encoder?.sendFileTreeCollapseAll()
             }
         }
     }
@@ -77,6 +112,13 @@ struct FileTreeHeaderContent: View {
             tooltip: tooltip,
             action: action
         )
+    }
+
+    var accessibilityLabelText: String {
+        if branchName.isEmpty {
+            return "File tree for \(projectName)"
+        }
+        return "File tree for \(projectName), branch \(branchName)"
     }
 
     private var projectName: String {

--- a/macos/Sources/Views/SidebarHeaderButton.swift
+++ b/macos/Sources/Views/SidebarHeaderButton.swift
@@ -36,6 +36,7 @@ struct SidebarHeaderButton: View {
         }
         .buttonStyle(.plain)
         .help(tooltip)
+        .accessibilityLabel(tooltip)
         .onHover { hovering in
             if reduceMotion {
                 isHovered = hovering

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -41,6 +41,18 @@ struct SidebarHeaderButtonTests {
         try button.tap()
         #expect(tapped)
     }
+
+    @Test("Tooltip also backs the accessibility label")
+    @MainActor func tooltipBacksAccessibilityLabel() throws {
+        let sut = SidebarHeaderButton(
+            systemName: "plus",
+            barFg: .white,
+            tooltip: "New File…",
+            action: {}
+        )
+        let button = try sut.inspect().find(ViewType.Button.self)
+        #expect(try button.accessibilityLabel().string() == "New File…")
+    }
 }
 
 // MARK: - GitStatusView Empty States
@@ -153,15 +165,49 @@ struct FileTreeViewTests {
         #expect(strings.contains("Project"))
     }
 
-    @Test("Header action buttons are hidden at rest (shown on hover)")
-    @MainActor func headerActionButtonsHiddenAtRest() throws {
+    @Test("Header action buttons reserve layout space at rest")
+    @MainActor func headerActionButtonsReserveLayoutSpaceAtRest() throws {
         let state = FileTreeState()
         state.visible = true
 
         let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "", leadingPadding: 10)
         let body = try sut.inspect()
         let buttons = body.findAll(ViewType.Button.self)
-        #expect(buttons.count == 0)
+        #expect(buttons.count == 4)
+    }
+
+    @Test("Header action buttons send file-tree actions")
+    @MainActor func headerActionButtonsSendFileTreeActions() throws {
+        let state = FileTreeState()
+        state.visible = true
+        state.selectedIndex = 7
+        let spy = SpyEncoder()
+
+        let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: spy, branchName: "main", leadingPadding: 10)
+        let buttons = try sut.inspect().findAll(ViewType.Button.self)
+
+        try buttons[0].tap()
+        try buttons[1].tap()
+        try buttons[2].tap()
+        try buttons[3].tap()
+
+        #expect(spy.guiActions == [
+            .fileTreeNewFile(parentIndex: 7),
+            .fileTreeNewFolder(parentIndex: 7),
+            .fileTreeRefresh,
+            .fileTreeCollapseAll,
+        ])
+    }
+
+    @Test("Header accessibility summarizes project and branch context")
+    @MainActor func headerAccessibilitySummarizesProjectAndBranchContext() throws {
+        let state = FileTreeState()
+        state.visible = true
+        state.projectRoot = "/Users/test/code/minga"
+
+        let sut = FileTreeHeaderContent(fileTreeState: state, theme: ThemeColors(), encoder: nil, branchName: "main", leadingPadding: 10)
+
+        #expect(sut.accessibilityLabelText == "File tree for minga, branch main")
     }
 
     @Test("File entries render their names")

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -38,8 +38,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
     end
 
     test "includes a header row with project name and folder icon", %{tmp_dir: tmp_dir} do
+      root = Path.join(tmp_dir, "minga")
+
       input = %RenderInput{
-        tree: sample_tree(tmp_dir),
+        tree: sample_tree(root),
         rect: {0, 0, 20, 10},
         focused: false,
         theme: Theme.get!(:doom_one),
@@ -51,8 +53,9 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       header = Enum.find(draws, fn {r, c, _t, _s} -> r == 0 and c == 0 end)
       assert header != nil
       {_r, _c, text, style} = header
-      # Contains the folder open icon (nf-md-folder-open U+F0256)
+      # Contains the folder open icon (nf-md-folder-open U+F0256) and project/root context.
       assert String.contains?(text, "\u{F0256}")
+      assert String.contains?(text, "minga")
       assert style.bold == true
     end
 


### PR DESCRIPTION
## Summary
- Make the file-tree header lead with the project/root name, with branch context rendered as secondary metadata.
- Keep macOS header action buttons in the layout at rest so hover changes opacity without shifting rows.
- Add accessibility labels and action-wiring coverage for the header controls, plus TUI header coverage for project context.

## Validation
- `mix test.llm test/minga_editor/shell/traditional/tree_renderer_test.exs`
- `mix swift.build`
- `xcodebuild test -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS'`
- `make lint`
- `mix test.llm`
- `git diff --check`

Closes #1643

Stacked on #1668 / `feat-file-tree-row-hierarchy`.
