### PR TITLE
feat(ui): surface file tree status badges

### DIFF
--- a/lib/minga/diagnostics.ex
+++ b/lib/minga/diagnostics.ex
@@ -193,10 +193,23 @@ defmodule Minga.Diagnostics do
   @spec count_tuple(GenServer.server(), uri()) ::
           {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil
   def count_tuple(server \\ __MODULE__, uri) when is_binary(uri) do
-    case count(server, uri) do
-      %{error: 0, warning: 0, info: 0, hint: 0} -> nil
-      %{error: e, warning: w, info: i, hint: h} -> {e, w, i, h}
-    end
+    server
+    |> table_name()
+    |> count_tuple_from_table(uri)
+  end
+
+  @doc """
+  Returns diagnostic count tuples for URIs under a prefix.
+
+  This is used by project-level status surfaces, such as the file tree, to build a path-keyed diagnostic summary without scanning unrelated diagnostic payloads or walking the filesystem.
+  """
+  @spec count_tuples_by_uri_prefix(GenServer.server(), uri()) :: %{
+          uri() => {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
+        }
+  def count_tuples_by_uri_prefix(server \\ __MODULE__, uri_prefix) when is_binary(uri_prefix) do
+    server
+    |> table_name()
+    |> do_count_tuples_by_uri_prefix(uri_prefix)
   end
 
   @doc """
@@ -244,8 +257,7 @@ defmodule Minga.Diagnostics do
 
   @impl GenServer
   def handle_call({:publish, source, uri, diagnostics}, _from, state) do
-    :ets.insert(state.table, {{source, uri}, diagnostics})
-    update_uri_index(state.uri_index, uri, source, :add)
+    store_published_diagnostics(state, source, uri, diagnostics)
     invalidate_cache(state.merge_cache, uri)
     gen = state.generation + 1
     broadcast_diagnostics_updated(uri, source)
@@ -295,6 +307,17 @@ defmodule Minga.Diagnostics do
 
   # ── Private ────────────────────────────────────────────────────────────────
 
+  @spec store_published_diagnostics(state(), source(), uri(), [Diagnostic.t()]) :: :ok
+  defp store_published_diagnostics(state, source, uri, []) do
+    :ets.delete(state.table, {source, uri})
+    update_uri_index(state.uri_index, uri, source, :remove)
+  end
+
+  defp store_published_diagnostics(state, source, uri, diagnostics) do
+    :ets.insert(state.table, {{source, uri}, diagnostics})
+    update_uri_index(state.uri_index, uri, source, :add)
+  end
+
   # Merged diagnostics for a URI, using the URI index for O(1) source
   # lookup and a generation-based cache to avoid re-merging on every call.
   @spec merged_for_uri(:ets.table(), uri()) :: [Diagnostic.t()]
@@ -330,6 +353,65 @@ defmodule Minga.Diagnostics do
       end
     end)
     |> Diagnostic.sort()
+  end
+
+  @spec do_count_tuples_by_uri_prefix(:ets.table(), uri()) :: %{
+          uri() => {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
+        }
+  defp do_count_tuples_by_uri_prefix(table, uri_prefix) do
+    {uri_index, _cache_table} = :persistent_term.get({__MODULE__, table})
+
+    :ets.foldl(
+      fn {uri, _sources}, acc ->
+        maybe_put_count_tuple(acc, table, uri, uri_prefix)
+      end,
+      %{},
+      uri_index
+    )
+  end
+
+  @spec maybe_put_count_tuple(map(), :ets.table(), uri(), uri()) :: map()
+  defp maybe_put_count_tuple(acc, table, uri, uri_prefix) do
+    if uri_under_prefix?(uri, uri_prefix) do
+      case count_tuple_from_table(table, uri) do
+        nil -> acc
+        counts -> Map.put(acc, uri, counts)
+      end
+    else
+      acc
+    end
+  end
+
+  @spec uri_under_prefix?(uri(), uri()) :: boolean()
+  defp uri_under_prefix?(uri, uri_prefix),
+    do: uri == uri_prefix or String.starts_with?(uri, prefix_dir(uri_prefix))
+
+  @spec prefix_dir(uri()) :: uri()
+  defp prefix_dir(uri_prefix) do
+    if String.ends_with?(uri_prefix, "/"), do: uri_prefix, else: uri_prefix <> "/"
+  end
+
+  @spec count_tuple_from_table(:ets.table(), uri()) ::
+          {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil
+  defp count_tuple_from_table(table, uri) do
+    case count_from_table(table, uri) do
+      %{error: 0, warning: 0, info: 0, hint: 0} -> nil
+      %{error: e, warning: w, info: i, hint: h} -> {e, w, i, h}
+    end
+  end
+
+  @spec count_from_table(:ets.table(), uri()) :: %{
+          error: non_neg_integer(),
+          warning: non_neg_integer(),
+          info: non_neg_integer(),
+          hint: non_neg_integer()
+        }
+  defp count_from_table(table, uri) do
+    table
+    |> merged_for_uri(uri)
+    |> Enum.reduce(%{error: 0, warning: 0, info: 0, hint: 0}, fn diag, acc ->
+      Map.update!(acc, diag.severity, &(&1 + 1))
+    end)
   end
 
   @spec find_next([Diagnostic.t()], non_neg_integer()) :: Diagnostic.t() | nil

--- a/lib/minga/project/file_tree/git_status.ex
+++ b/lib/minga/project/file_tree/git_status.ex
@@ -33,6 +33,7 @@ defmodule Minga.Project.FileTree.GitStatus do
           {:ok, entries} ->
             entries
             |> entries_to_status_map(git_root)
+            |> filter_under_root(root_path)
             |> propagate_to_directories(root_path)
 
           {:error, _} ->
@@ -97,6 +98,15 @@ defmodule Minga.Project.FileTree.GitStatus do
     end)
   end
 
+  @spec filter_under_root(status_map(), String.t()) :: status_map()
+  defp filter_under_root(file_statuses, root_path) do
+    expanded_root = Path.expand(root_path)
+
+    Map.filter(file_statuses, fn {path, _status} ->
+      path |> Path.expand() |> path_under_root?(expanded_root)
+    end)
+  end
+
   @spec propagate_to_directories(status_map(), String.t()) :: status_map()
   defp propagate_to_directories(file_statuses, root_path) do
     expanded_root = Path.expand(root_path)
@@ -119,10 +129,19 @@ defmodule Minga.Project.FileTree.GitStatus do
   defp do_ancestor_dirs(dir, root, acc) when dir == root, do: acc
 
   defp do_ancestor_dirs(dir, root, acc) do
-    if String.starts_with?(dir, root) do
+    if path_under_root?(dir, root) do
       do_ancestor_dirs(Path.dirname(dir), root, [dir | acc])
     else
       acc
     end
   end
+
+  @spec path_under_root?(String.t(), String.t()) :: boolean()
+  defp path_under_root?(path, root) do
+    path == root or String.starts_with?(path, path_prefix(root))
+  end
+
+  @spec path_prefix(String.t()) :: String.t()
+  defp path_prefix("/"), do: "/"
+  defp path_prefix(root), do: root <> "/"
 end

--- a/lib/minga_editor/file_tree/diagnostics.ex
+++ b/lib/minga_editor/file_tree/diagnostics.ex
@@ -1,0 +1,137 @@
+defmodule MingaEditor.FileTree.Diagnostics do
+  @moduledoc """
+  Diagnostic status carried by a semantic file-tree row.
+
+  Rows keep diagnostic counts separate from dirty and git state so renderers can show each status independently without re-querying LSP or diagnostics state.
+  """
+
+  @type severity :: :error | :warning | :info | :hint
+  @type counts :: {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
+
+  @type t :: %__MODULE__{
+          error_count: non_neg_integer(),
+          warning_count: non_neg_integer(),
+          info_count: non_neg_integer(),
+          hint_count: non_neg_integer()
+        }
+
+  @map_keys [
+    :error_count,
+    :warning_count,
+    :info_count,
+    :hint_count,
+    :error,
+    :warning,
+    :info,
+    :hint,
+    :errors,
+    :warnings,
+    :hints
+  ]
+
+  defstruct error_count: 0,
+            warning_count: 0,
+            info_count: 0,
+            hint_count: 0
+
+  @doc "Returns an empty diagnostic status."
+  @spec empty() :: t()
+  def empty, do: %__MODULE__{}
+
+  @doc "Builds diagnostic status from a count tuple, map, keyword list, or existing struct."
+  @spec new(t() | counts() | map() | keyword() | nil) :: t()
+  def new(%__MODULE__{} = diagnostics), do: diagnostics
+
+  def new({errors, warnings, info, hints}) do
+    %__MODULE__{
+      error_count: max(errors, 0),
+      warning_count: max(warnings, 0),
+      info_count: max(info, 0),
+      hint_count: max(hints, 0)
+    }
+  end
+
+  def new(attrs) when is_list(attrs) do
+    attrs
+    |> Map.new()
+    |> new()
+  end
+
+  def new(attrs) when is_map(attrs) do
+    validate_map_keys!(attrs)
+
+    %__MODULE__{
+      error_count:
+        max(Map.get(attrs, :error_count, Map.get(attrs, :errors, Map.get(attrs, :error, 0))), 0),
+      warning_count:
+        max(
+          Map.get(attrs, :warning_count, Map.get(attrs, :warnings, Map.get(attrs, :warning, 0))),
+          0
+        ),
+      info_count: max(Map.get(attrs, :info_count, Map.get(attrs, :info, 0)), 0),
+      hint_count:
+        max(Map.get(attrs, :hint_count, Map.get(attrs, :hints, Map.get(attrs, :hint, 0))), 0)
+    }
+  end
+
+  def new(nil), do: empty()
+
+  @spec validate_map_keys!(map()) :: :ok
+  defp validate_map_keys!(attrs) do
+    attrs
+    |> Map.keys()
+    |> Enum.reject(&(&1 in @map_keys))
+    |> raise_on_unknown_keys()
+  end
+
+  @spec raise_on_unknown_keys([term()]) :: :ok
+  defp raise_on_unknown_keys([]), do: :ok
+
+  defp raise_on_unknown_keys(keys) do
+    raise ArgumentError, "unknown file-tree diagnostic keys: #{inspect(keys)}"
+  end
+
+  @doc "Returns the total number of diagnostics."
+  @spec total_count(t()) :: non_neg_integer()
+  def total_count(%__MODULE__{} = diagnostics) do
+    diagnostics.error_count + diagnostics.warning_count + diagnostics.info_count +
+      diagnostics.hint_count
+  end
+
+  @doc "Returns the highest severity represented by the counts."
+  @spec highest_severity(t()) :: severity() | nil
+  def highest_severity(%__MODULE__{error_count: count}) when count > 0, do: :error
+  def highest_severity(%__MODULE__{warning_count: count}) when count > 0, do: :warning
+  def highest_severity(%__MODULE__{info_count: count}) when count > 0, do: :info
+  def highest_severity(%__MODULE__{hint_count: count}) when count > 0, do: :hint
+  def highest_severity(%__MODULE__{}), do: nil
+
+  @doc "Returns the count for a severity."
+  @spec count_for(t(), severity()) :: non_neg_integer()
+  def count_for(%__MODULE__{} = diagnostics, :error), do: diagnostics.error_count
+  def count_for(%__MODULE__{} = diagnostics, :warning), do: diagnostics.warning_count
+  def count_for(%__MODULE__{} = diagnostics, :info), do: diagnostics.info_count
+  def count_for(%__MODULE__{} = diagnostics, :hint), do: diagnostics.hint_count
+
+  @doc "Merges two diagnostic count sets."
+  @spec merge(t() | counts() | map() | keyword() | nil, t() | counts() | map() | keyword() | nil) ::
+          t()
+  def merge(left, right) do
+    left = new(left)
+    right = new(right)
+
+    %__MODULE__{
+      error_count: left.error_count + right.error_count,
+      warning_count: left.warning_count + right.warning_count,
+      info_count: left.info_count + right.info_count,
+      hint_count: left.hint_count + right.hint_count
+    }
+  end
+
+  @doc "Returns counts as the file-tree wire tuple."
+  @spec to_tuple(t()) :: counts()
+  def to_tuple(%__MODULE__{} = diagnostics) do
+    {diagnostics.error_count, diagnostics.warning_count, diagnostics.info_count,
+     diagnostics.hint_count}
+  end
+end

--- a/lib/minga_editor/file_tree/row.ex
+++ b/lib/minga_editor/file_tree/row.ex
@@ -7,12 +7,12 @@ defmodule MingaEditor.FileTree.Row do
 
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.GitStatus
+  alias MingaEditor.FileTree.Diagnostics
   alias MingaEditor.State.FileTree, as: FileTreeState
 
   @type t :: %__MODULE__{
           id: String.t(),
           path: String.t(),
-          relative_path: String.t(),
           name: String.t(),
           directory?: boolean(),
           expanded?: boolean(),
@@ -21,6 +21,7 @@ defmodule MingaEditor.FileTree.Row do
           active?: boolean(),
           dirty?: boolean(),
           git_status: GitStatus.file_status() | nil,
+          diagnostics: Diagnostics.t(),
           depth: non_neg_integer(),
           guides: [boolean()],
           last_child?: boolean(),
@@ -30,7 +31,6 @@ defmodule MingaEditor.FileTree.Row do
   @enforce_keys [
     :id,
     :path,
-    :relative_path,
     :name,
     :directory?,
     :expanded?,
@@ -40,7 +40,6 @@ defmodule MingaEditor.FileTree.Row do
   ]
   defstruct id: nil,
             path: nil,
-            relative_path: nil,
             name: nil,
             directory?: false,
             expanded?: false,
@@ -49,6 +48,7 @@ defmodule MingaEditor.FileTree.Row do
             active?: false,
             dirty?: false,
             git_status: nil,
+            diagnostics: %Diagnostics{},
             depth: 0,
             guides: [],
             last_child?: false,
@@ -57,7 +57,9 @@ defmodule MingaEditor.FileTree.Row do
   @doc "Constructs a semantic file-tree row."
   @spec new(keyword()) :: t()
   def new(attrs) when is_list(attrs) do
-    struct!(__MODULE__, attrs)
+    attrs
+    |> Keyword.drop([:relative_path])
+    |> then(&struct!(__MODULE__, &1))
   end
 
   @doc "Builds a stable row identity for a file-tree entry."

--- a/lib/minga_editor/file_tree/rows.ex
+++ b/lib/minga_editor/file_tree/rows.ex
@@ -6,8 +6,11 @@ defmodule MingaEditor.FileTree.Rows do
   """
 
   alias Minga.Buffer
+  alias Minga.Diagnostics, as: DiagnosticStore
+  alias Minga.LSP.SyncServer
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.GitStatus
+  alias MingaEditor.FileTree.Diagnostics
   alias MingaEditor.FileTree.Row
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -18,6 +21,8 @@ defmodule MingaEditor.FileTree.Rows do
           active_path: String.t() | nil,
           dirty_paths: MapSet.t(String.t()),
           git_status: GitStatus.status_map(),
+          diagnostics: %{String.t() => Diagnostics.t() | Diagnostics.counts() | map() | keyword()},
+          diagnostics_server: GenServer.server(),
           editing: FileTreeState.editing() | nil
         ]
 
@@ -25,6 +30,16 @@ defmodule MingaEditor.FileTree.Rows do
   @spec from_tree(FileTree.t(), options()) :: [Row.t()]
   def from_tree(%FileTree{} = tree, opts \\ []) do
     git_status = Keyword.get(opts, :git_status, tree.git_status)
+
+    diagnostics_server = Keyword.get(opts, :diagnostics_server, DiagnosticStore)
+
+    diagnostics =
+      opts
+      |> Keyword.get_lazy(:diagnostics, fn ->
+        diagnostic_map_for_root(tree.root, diagnostics_server)
+      end)
+      |> propagated_diagnostics(tree.root)
+
     dirty_paths = Keyword.get(opts, :dirty_paths, MapSet.new())
     active_path = opts |> Keyword.get(:active_path) |> expand_optional_path()
     selected_index = Keyword.get(opts, :selected_index, tree.cursor)
@@ -39,6 +54,7 @@ defmodule MingaEditor.FileTree.Rows do
         active_path: active_path,
         dirty_paths: dirty_paths,
         editing: editing,
+        diagnostics: diagnostics,
         focused: focused,
         git_status: git_status,
         selected_index: selected_index
@@ -70,7 +86,6 @@ defmodule MingaEditor.FileTree.Rows do
     Row.new(
       id: Row.id_for(entry),
       path: path,
-      relative_path: Path.relative_to(path, tree.root),
       name: entry.name,
       directory?: entry.dir?,
       expanded?: entry.dir? and MapSet.member?(tree.expanded, path),
@@ -79,6 +94,7 @@ defmodule MingaEditor.FileTree.Rows do
       active?: active?(path, opts.active_path),
       dirty?: dirty?(entry, path, opts.dirty_paths),
       git_status: Map.get(opts.git_status, path),
+      diagnostics: Map.get(opts.diagnostics, path, Diagnostics.empty()),
       depth: entry.depth,
       guides: entry.guides,
       last_child?: entry.last_child?,
@@ -99,6 +115,80 @@ defmodule MingaEditor.FileTree.Rows do
   defp editing_for_index(_index, nil), do: nil
   defp editing_for_index(index, %{index: index} = editing), do: editing
   defp editing_for_index(_index, _editing), do: nil
+
+  @spec diagnostic_map_for_root(String.t(), GenServer.server()) :: %{
+          String.t() => Diagnostics.t()
+        }
+  defp diagnostic_map_for_root(root, diagnostics_server) when is_binary(root) do
+    diagnostics_server
+    |> DiagnosticStore.count_tuples_by_uri_prefix(SyncServer.path_to_uri(root))
+    |> Map.new(fn {uri, counts} -> {SyncServer.uri_to_path(uri), Diagnostics.new(counts)} end)
+  rescue
+    ArgumentError -> %{}
+  catch
+    :exit, _ -> %{}
+  end
+
+  @spec propagated_diagnostics(map(), String.t()) :: %{String.t() => Diagnostics.t()}
+  defp propagated_diagnostics(diagnostics, root) when is_map(diagnostics) do
+    expanded_root = Path.expand(root)
+
+    Enum.reduce(diagnostics, %{}, fn {path, row_diagnostics}, acc ->
+      diagnostics = Diagnostics.new(row_diagnostics)
+      expanded_path = Path.expand(path)
+      put_propagated_diagnostics(acc, expanded_path, expanded_root, diagnostics)
+    end)
+  end
+
+  @spec put_propagated_diagnostics(
+          %{String.t() => Diagnostics.t()},
+          String.t(),
+          String.t(),
+          Diagnostics.t()
+        ) :: %{String.t() => Diagnostics.t()}
+  defp put_propagated_diagnostics(acc, path, root, diagnostics) do
+    if path_under_root?(path, root) do
+      path
+      |> diagnostic_ancestor_dirs(root)
+      |> Enum.reduce(put_diagnostics(acc, path, diagnostics), fn dir, inner_acc ->
+        put_diagnostics(inner_acc, dir, diagnostics)
+      end)
+    else
+      acc
+    end
+  end
+
+  @spec put_diagnostics(%{String.t() => Diagnostics.t()}, String.t(), Diagnostics.t()) :: %{
+          String.t() => Diagnostics.t()
+        }
+  defp put_diagnostics(acc, path, diagnostics) do
+    Map.update(acc, path, diagnostics, &Diagnostics.merge(&1, diagnostics))
+  end
+
+  @spec diagnostic_ancestor_dirs(String.t(), String.t()) :: [String.t()]
+  defp diagnostic_ancestor_dirs(path, root) do
+    do_diagnostic_ancestor_dirs(Path.dirname(path), root, [])
+  end
+
+  @spec do_diagnostic_ancestor_dirs(String.t(), String.t(), [String.t()]) :: [String.t()]
+  defp do_diagnostic_ancestor_dirs(dir, root, acc) when dir == root, do: acc
+
+  defp do_diagnostic_ancestor_dirs(dir, root, acc) do
+    if path_under_root?(dir, root) do
+      do_diagnostic_ancestor_dirs(Path.dirname(dir), root, [dir | acc])
+    else
+      acc
+    end
+  end
+
+  @spec path_under_root?(String.t(), String.t()) :: boolean()
+  defp path_under_root?(path, root) do
+    path == root or String.starts_with?(path, path_prefix(root))
+  end
+
+  @spec path_prefix(String.t()) :: String.t()
+  defp path_prefix("/"), do: "/"
+  defp path_prefix(root), do: root <> "/"
 
   @spec expand_optional_path(String.t() | nil) :: String.t() | nil
   defp expand_optional_path(nil), do: nil

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -89,6 +89,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   import Bitwise
 
   alias Minga.Buffer
+  alias MingaEditor.FileTree.Diagnostics, as: FileTreeDiagnostics
   alias MingaEditor.FileTree.Row
   alias MingaEditor.MinibufferData
   alias MingaEditor.State.Buffers
@@ -1037,7 +1038,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
         encode_string16(selected_id),
         encode_string16(root),
         <<tree_width::16, length(rows)::16>>,
-        Enum.map(rows, &encode_file_tree_row/1)
+        Enum.map(rows, &encode_file_tree_row(&1, root))
       ])
 
     <<@op_gui_file_tree, byte_size(payload)::32, payload::binary>>
@@ -1048,26 +1049,40 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   def encode_hidden_gui_file_tree(root_path),
     do: encode_gui_file_tree(root_path, 0, false, false, [])
 
-  @spec encode_file_tree_row(Row.t()) :: iodata()
-  defp encode_file_tree_row(%Row{} = row) do
+  @spec encode_file_tree_row(Row.t(), String.t()) :: iodata()
+  defp encode_file_tree_row(%Row{} = row, root) do
     icon = file_tree_row_icon(row)
     editing_type = if row.editing, do: encode_editing_type(row.editing.type), else: 0xFF
     editing_text = if row.editing, do: row.editing.text, else: ""
     guides = Enum.map(row.guides, fn guide? -> if guide?, do: <<1>>, else: <<0>> end)
 
+    {diagnostic_errors, diagnostic_warnings, diagnostic_info, diagnostic_hints} =
+      row.diagnostics
+      |> FileTreeDiagnostics.to_tuple()
+      |> clamp_file_tree_diagnostics()
+
     [
       <<:erlang.phash2(row.id, 0xFFFFFFFF)::32, file_tree_row_flags(row)::16, row.depth::8,
-        encode_git_status(row.git_status)::8, 0::16, 0::16, 0::16, 0::16, length(row.guides)::8>>,
+        encode_git_status(row.git_status)::8, diagnostic_errors::16, diagnostic_warnings::16,
+        diagnostic_info::16, diagnostic_hints::16, length(row.guides)::8>>,
       guides,
       encode_string16(row.id),
       encode_string16(row.path),
-      encode_string16(row.relative_path),
+      encode_string16(Path.relative_to(row.path, root)),
       encode_string16(row.name),
       encode_string8(icon),
       <<editing_type::8>>,
       encode_string16(editing_text)
     ]
   end
+
+  @spec clamp_file_tree_diagnostics(FileTreeDiagnostics.counts()) :: FileTreeDiagnostics.counts()
+  defp clamp_file_tree_diagnostics({errors, warnings, info, hints}) do
+    {clamp_u16(errors), clamp_u16(warnings), clamp_u16(info), clamp_u16(hints)}
+  end
+
+  @spec clamp_u16(non_neg_integer()) :: non_neg_integer()
+  defp clamp_u16(value), do: min(value, @max_u16)
 
   @spec selected_row_id([Row.t()]) :: String.t()
   defp selected_row_id(rows) do

--- a/lib/minga_editor/shell/traditional/tree_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tree_renderer.ex
@@ -12,6 +12,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   alias Minga.Language
   alias Minga.Project.FileTree
   alias MingaEditor.DisplayList
+  alias MingaEditor.FileTree.Diagnostics
   alias MingaEditor.FileTree.Row
   alias MingaEditor.FileTree.Rows
   alias MingaEditor.State, as: EditorState
@@ -20,7 +21,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   alias MingaEditor.UI.Theme
   alias MingaEditor.WindowTree
 
-  # Row anatomy: faint ancestor guides, disclosure, icon, name, spacer, dirty marker, git marker.
+  # Row anatomy: faint ancestor guides, disclosure, icon, name, spacer, diagnostic marker, dirty marker, git marker.
   @guide_pipe "│ "
   @guide_blank "  "
   @disclosure_expanded "▾ "
@@ -183,6 +184,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     is_cursor = tree_row.selected?
     focused = tree_row.focused?
     is_dirty = tree_row.dirty?
+    diagnostic_text = diagnostic_indicator_text(tree_row.diagnostics)
 
     # Build the structure columns from ancestor guides plus a dedicated disclosure column.
     guide_prefix = build_guides(tree_row.guides, tree_row.last_child?)
@@ -195,25 +197,25 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     # Entry name (dirs get trailing slash)
     name = if tree_row.directory?, do: tree_row.name <> "/", else: tree_row.name
 
-    # Right-side indicators: [modified_dot] [git_status]
-    # Modified dot = 1 col, git status = 2 cols (space + symbol)
-    file_git_status = tree_row.git_status
-    git_width = if file_git_status, do: 2, else: 0
-    dirty_width = if is_dirty, do: 1, else: 0
-    indicator_width = dirty_width + git_width
-
     # Compose the full line: structure columns + icon + space + name
     prefix = structure_prefix <> icon <> " "
     prefix_width = String.length(prefix)
+
+    # Right-side indicators: [diagnostic] [modified_dot] [git_status].
+    # Fit them into the available suffix so narrow panes never let badges overlap the row prefix.
+    {diagnostic_text, is_dirty, file_git_status} =
+      fit_indicators(diagnostic_text, is_dirty, tree_row.git_status, max(width - prefix_width, 0))
+
+    diagnostic_width = String.length(diagnostic_text)
+    git_width = if file_git_status, do: 2, else: 0
+    dirty_width = if is_dirty, do: 1, else: 0
+    indicator_width = diagnostic_width + dirty_width + git_width
 
     # Truncate name to fit, accounting for indicator space
     max_name_len = max(width - prefix_width - indicator_width, 0)
     display_name = String.slice(name, 0, max_name_len)
 
-    # Background style for the full row
-    row_bg = row_background(is_cursor, focused, theme)
-
-    # Build draw commands: structure, icon, name, dirty marker, and git marker.
+    # Build draw commands: structure, icon, name, diagnostic marker, dirty marker, and git marker.
     guide_style = guide_draw_style(is_cursor, focused, theme)
     icon_style = icon_draw_style(icon_color, is_cursor, focused, theme)
     name_style = name_draw_style(tree_row, is_cursor, tree_row.active?, focused, theme)
@@ -232,36 +234,25 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     padded_name = String.pad_trailing(display_name, name_pad_width)
     draws = draws ++ [DisplayList.draw(row, name_col, padded_name, name_style)]
 
-    # Right-aligned indicators start here
+    # Right-aligned indicators start here.
     indicator_col = col + width - indicator_width
 
-    # Modified buffer dot (between name and git status)
     draws =
-      if is_dirty do
-        dirty_style = dirty_indicator_style(is_cursor, focused, theme)
-        draws ++ [DisplayList.draw(row, indicator_col, "●", dirty_style)]
-      else
-        draws
-      end
+      draw_diagnostic_indicator(
+        draws,
+        tree_row.diagnostics,
+        diagnostic_text,
+        row,
+        indicator_col,
+        is_cursor,
+        focused,
+        theme
+      )
 
-    # Git status indicator (rightmost)
-    if file_git_status do
-      git_col = col + width - git_width
-      git_symbol = " " <> Minga.Project.FileTree.GitStatus.symbol(file_git_status)
-      git_style = git_indicator_style(file_git_status, is_cursor, focused, theme)
-      draws ++ [DisplayList.draw(row, git_col, git_symbol, git_style)]
-    else
-      # Pad remaining space if no indicators
-      drawn_width = prefix_width + String.length(padded_name) + dirty_width
-
-      if drawn_width < width do
-        pad = String.duplicate(" ", width - drawn_width)
-        pad_face = %{row_bg | fg: theme.tree.fg}
-        draws ++ [DisplayList.draw(row, col + drawn_width, pad, pad_face)]
-      else
-        draws
-      end
-    end
+    dirty_col = indicator_col + diagnostic_width
+    draws = draw_dirty_indicator(draws, is_dirty, row, dirty_col, is_cursor, focused, theme)
+    git_col = dirty_col + dirty_width
+    draw_git_indicator(draws, file_git_status, row, git_col, is_cursor, focused, theme)
   end
 
   # ── Editing entry rendering ─────────────────────────────────────────────
@@ -385,10 +376,173 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     Face.new(fg: icon_color, bg: row_bg_color(is_cursor, focused, theme))
   end
 
+  @spec fit_indicators(
+          String.t(),
+          boolean(),
+          Minga.Project.FileTree.GitStatus.file_status() | nil,
+          non_neg_integer()
+        ) :: {String.t(), boolean(), Minga.Project.FileTree.GitStatus.file_status() | nil}
+  defp fit_indicators(diagnostic_text, dirty?, git_status, available_width) do
+    {diagnostic_text, remaining_width} =
+      fit_diagnostic_indicator(diagnostic_text, available_width)
+
+    {dirty?, remaining_width} = fit_dirty_indicator(dirty?, remaining_width)
+    {git_status, _remaining_width} = fit_git_indicator(git_status, remaining_width)
+    {diagnostic_text, dirty?, git_status}
+  end
+
+  @spec fit_diagnostic_indicator(String.t(), non_neg_integer()) :: {String.t(), non_neg_integer()}
+  defp fit_diagnostic_indicator("", available_width), do: {"", available_width}
+
+  defp fit_diagnostic_indicator(text, available_width) do
+    fitted = String.slice(text, 0, available_width)
+    {fitted, available_width - String.length(fitted)}
+  end
+
+  @spec fit_dirty_indicator(boolean(), non_neg_integer()) :: {boolean(), non_neg_integer()}
+  defp fit_dirty_indicator(true = _dirty?, available_width) when available_width >= 1,
+    do: {true, available_width - 1}
+
+  defp fit_dirty_indicator(_dirty?, available_width), do: {false, available_width}
+
+  @spec fit_git_indicator(Minga.Project.FileTree.GitStatus.file_status() | nil, non_neg_integer()) ::
+          {Minga.Project.FileTree.GitStatus.file_status() | nil, non_neg_integer()}
+  defp fit_git_indicator(nil, available_width), do: {nil, available_width}
+
+  defp fit_git_indicator(git_status, available_width) when available_width >= 2,
+    do: {git_status, available_width - 2}
+
+  defp fit_git_indicator(_git_status, available_width), do: {nil, available_width}
+
+  @spec diagnostic_indicator_text(Diagnostics.t()) :: String.t()
+  defp diagnostic_indicator_text(%Diagnostics{} = diagnostics) do
+    case Diagnostics.highest_severity(diagnostics) do
+      nil ->
+        ""
+
+      severity ->
+        diagnostic_severity_icon(severity) <> diagnostic_count_suffix(diagnostics, severity)
+    end
+  end
+
+  @spec diagnostic_count_suffix(Diagnostics.t(), Diagnostics.severity()) :: String.t()
+  defp diagnostic_count_suffix(diagnostics, severity) do
+    case Diagnostics.count_for(diagnostics, severity) do
+      count when count > 9 -> "9+"
+      count when count > 1 -> Integer.to_string(count)
+      _count -> ""
+    end
+  end
+
+  @spec diagnostic_severity_icon(Diagnostics.severity()) :: String.t()
+  defp diagnostic_severity_icon(:error), do: "✖"
+  defp diagnostic_severity_icon(:warning), do: "⚠"
+  defp diagnostic_severity_icon(:info), do: "ℹ"
+  defp diagnostic_severity_icon(:hint), do: "·"
+
+  @spec draw_diagnostic_indicator(
+          [DisplayList.draw()],
+          Diagnostics.t(),
+          String.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean(),
+          boolean(),
+          Theme.t()
+        ) :: [DisplayList.draw()]
+  defp draw_diagnostic_indicator(
+         draws,
+         %Diagnostics{},
+         "",
+         _row,
+         _col,
+         _is_cursor,
+         _focused,
+         _theme
+       ),
+       do: draws
+
+  defp draw_diagnostic_indicator(
+         draws,
+         %Diagnostics{} = diagnostics,
+         text,
+         row,
+         col,
+         is_cursor,
+         focused,
+         theme
+       ) do
+    case Diagnostics.highest_severity(diagnostics) do
+      nil ->
+        draws
+
+      severity ->
+        draws ++
+          [
+            DisplayList.draw(
+              row,
+              col,
+              text,
+              diagnostic_indicator_style(severity, is_cursor, focused, theme)
+            )
+          ]
+    end
+  end
+
+  @spec diagnostic_indicator_style(Diagnostics.severity(), boolean(), boolean(), Theme.t()) ::
+          Face.t()
+  defp diagnostic_indicator_style(severity, is_cursor, focused, theme) do
+    Face.new(
+      fg: diagnostic_severity_color(severity, theme),
+      bg: row_bg_color(is_cursor, focused, theme),
+      bold: severity in [:error, :warning]
+    )
+  end
+
+  @spec diagnostic_severity_color(Diagnostics.severity(), Theme.t()) :: non_neg_integer()
+  defp diagnostic_severity_color(:error, theme), do: theme.gutter.error_fg
+  defp diagnostic_severity_color(:warning, theme), do: theme.gutter.warning_fg
+  defp diagnostic_severity_color(:info, theme), do: theme.gutter.info_fg
+  defp diagnostic_severity_color(:hint, theme), do: theme.gutter.hint_fg
+
+  @spec draw_dirty_indicator(
+          [DisplayList.draw()],
+          boolean(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean(),
+          boolean(),
+          Theme.t()
+        ) :: [DisplayList.draw()]
+  defp draw_dirty_indicator(draws, true = _is_dirty, row, col, is_cursor, focused, theme) do
+    dirty_style = dirty_indicator_style(is_cursor, focused, theme)
+    draws ++ [DisplayList.draw(row, col, "●", dirty_style)]
+  end
+
+  defp draw_dirty_indicator(draws, false = _is_dirty, _row, _col, _is_cursor, _focused, _theme),
+    do: draws
+
   @spec dirty_indicator_style(boolean(), boolean(), Theme.t()) :: Face.t()
   defp dirty_indicator_style(is_cursor, focused, theme) do
     color = theme.tree.modified_fg || theme.tree.fg
     Face.new(fg: color, bg: row_bg_color(is_cursor, focused, theme), bold: true)
+  end
+
+  @spec draw_git_indicator(
+          [DisplayList.draw()],
+          Minga.Project.FileTree.GitStatus.file_status() | nil,
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean(),
+          boolean(),
+          Theme.t()
+        ) :: [DisplayList.draw()]
+  defp draw_git_indicator(draws, nil, _row, _col, _is_cursor, _focused, _theme), do: draws
+
+  defp draw_git_indicator(draws, file_git_status, row, col, is_cursor, focused, theme) do
+    git_symbol = " " <> Minga.Project.FileTree.GitStatus.symbol(file_git_status)
+    git_style = git_indicator_style(file_git_status, is_cursor, focused, theme)
+    draws ++ [DisplayList.draw(row, col, git_symbol, git_style)]
   end
 
   @spec git_indicator_style(

--- a/macos/Sources/Views/FileTreeRowView.swift
+++ b/macos/Sources/Views/FileTreeRowView.swift
@@ -1,7 +1,7 @@
 /// Visual row component for the semantic file tree.
 ///
 /// FileTreeView owns list behavior and action wiring. This view owns the row anatomy and visual layers:
-/// disclosure, icon, name, spacer, dirty marker, git marker, then background/accent layers.
+/// disclosure, icon, name, spacer, diagnostic marker, dirty marker, git marker, then background/accent layers.
 
 import SwiftUI
 
@@ -63,6 +63,7 @@ struct FileTreeRowView: View {
 
                 Spacer(minLength: 0)
 
+                diagnosticMarker
                 dirtyMarker
                 gitStatusDot
             }
@@ -80,6 +81,48 @@ struct FileTreeRowView: View {
                 .frame(width: chevronWidth, height: rowHeight)
         } else {
             Spacer().frame(width: chevronWidth)
+        }
+    }
+
+    @ViewBuilder
+    private var diagnosticMarker: some View {
+        if let text = diagnosticMarkerText, let color = diagnosticMarkerColor {
+            Text(text)
+                .font(.system(size: 9, weight: entry.highestDiagnosticSeverity == .hint ? .medium : .bold))
+                .foregroundStyle(color)
+                .padding(.trailing, 4)
+        }
+    }
+
+    private var diagnosticMarkerText: String? {
+        guard let severity = entry.highestDiagnosticSeverity else { return nil }
+        let base = diagnosticMarkerSymbol(severity)
+        let countText = diagnosticMarkerCountText(entry.highestDiagnosticCount)
+        return countText.isEmpty ? base : "\(base)\(countText)"
+    }
+
+    private func diagnosticMarkerCountText(_ count: UInt16) -> String {
+        if count > 9 { return "9+" }
+        if count > 1 { return String(count) }
+        return ""
+    }
+
+    private func diagnosticMarkerSymbol(_ severity: FileTreeDiagnosticSeverity) -> String {
+        switch severity {
+        case .error: return "✖"
+        case .warning: return "⚠"
+        case .info: return "ℹ"
+        case .hint: return "·"
+        }
+    }
+
+    private var diagnosticMarkerColor: Color? {
+        guard let severity = entry.highestDiagnosticSeverity else { return nil }
+        switch severity {
+        case .error: return theme.gutterErrorFg
+        case .warning: return theme.gutterWarningFg
+        case .info: return theme.gutterInfoFg
+        case .hint: return theme.gutterHintFg
         }
     }
 
@@ -185,10 +228,64 @@ struct FileTreeRowView: View {
     }
 
     var accessibilityLabelText: String {
+        let base: String
         if entry.isEditing {
-            return "Editing: \(entry.name)"
+            base = "Editing: \(entry.name)"
+        } else {
+            base = entry.isDir ? "Folder: \(entry.name)" : "File: \(entry.name)"
         }
-        return entry.isDir ? "Folder: \(entry.name)" : "File: \(entry.name)"
+
+        let statuses = accessibilityStatusText
+        return statuses.isEmpty ? base : "\(base), \(statuses)"
+    }
+
+    private var accessibilityStatusText: String {
+        statusAccessibilityParts.joined(separator: ", ")
+    }
+
+    private var statusAccessibilityParts: [String] {
+        diagnosticAccessibilityParts + dirtyAccessibilityParts + gitAccessibilityParts
+    }
+
+    private var diagnosticAccessibilityParts: [String] {
+        guard let severity = entry.highestDiagnosticSeverity else { return [] }
+        let count = entry.highestDiagnosticCount
+        let label = count == 1 ? diagnosticSingularLabel(severity) : diagnosticPluralLabel(severity)
+        return ["\(count) \(label)"]
+    }
+
+    private var dirtyAccessibilityParts: [String] {
+        entry.showsDirtyMarker ? ["unsaved changes"] : []
+    }
+
+    private var gitAccessibilityParts: [String] {
+        switch entry.gitStatusValue {
+        case .clean: return []
+        case .modified: return ["git modified"]
+        case .staged: return ["git staged"]
+        case .untracked: return ["git untracked"]
+        case .conflict: return ["git conflict"]
+        case .renamed: return ["git renamed"]
+        case .deleted: return ["git deleted"]
+        }
+    }
+
+    private func diagnosticSingularLabel(_ severity: FileTreeDiagnosticSeverity) -> String {
+        switch severity {
+        case .error: return "error"
+        case .warning: return "warning"
+        case .info: return "info diagnostic"
+        case .hint: return "hint"
+        }
+    }
+
+    private func diagnosticPluralLabel(_ severity: FileTreeDiagnosticSeverity) -> String {
+        switch severity {
+        case .error: return "errors"
+        case .warning: return "warnings"
+        case .info: return "info diagnostics"
+        case .hint: return "hints"
+        }
     }
 
     var accessibilityHintText: String {

--- a/macos/Sources/Views/FileTreeState.swift
+++ b/macos/Sources/Views/FileTreeState.swift
@@ -5,10 +5,10 @@ import SwiftUI
 /// A single file tree entry for SwiftUI rendering.
 struct FileTreeEntry: Identifiable {
     /// Visual states are layered in the same priority order as the BEAM TUI renderer: inline editing, drop target, selected row, active file, dirty buffer, git status, then directory emphasis.
-    /// Stable 32-bit hash of the file path, sent by the BEAM. Persists across
-    /// tree updates so SwiftUI's diffing correctly identifies unchanged rows
-    /// instead of treating every row below a change as new.
-    let id: UInt32
+    /// Stable semantic row identity sent by the BEAM. SwiftUI uses this as the row identity so hover, drop, and diffing state cannot collide on a 32-bit hash.
+    let id: String
+    /// Stable 32-bit hash sent by the BEAM for protocol/debug parity. It is not used as SwiftUI identity because hashes can collide.
+    let pathHash: UInt32
     /// Array index within the current visible entries. Used for click actions
     /// (the BEAM expects an index, not a hash).
     let index: Int
@@ -49,6 +49,13 @@ enum FileTreeGitStatus: UInt8 {
     case deleted = 6
 }
 
+enum FileTreeDiagnosticSeverity {
+    case error
+    case warning
+    case info
+    case hint
+}
+
 extension FileTreeEntry {
     var gitStatusValue: FileTreeGitStatus {
         FileTreeGitStatus(rawValue: gitStatus) ?? .clean
@@ -69,6 +76,25 @@ extension FileTreeEntry {
     var hasConflictStatus: Bool {
         gitStatusValue == .conflict
     }
+
+    var highestDiagnosticSeverity: FileTreeDiagnosticSeverity? {
+        if diagnosticErrorCount > 0 { return .error }
+        if diagnosticWarningCount > 0 { return .warning }
+        if diagnosticInfoCount > 0 { return .info }
+        if diagnosticHintCount > 0 { return .hint }
+        return nil
+    }
+
+    var highestDiagnosticCount: UInt16 {
+        switch highestDiagnosticSeverity {
+        case .error: return diagnosticErrorCount
+        case .warning: return diagnosticWarningCount
+        case .info: return diagnosticInfoCount
+        case .hint: return diagnosticHintCount
+        case nil: return 0
+        }
+    }
+
 }
 
 /// Observable state for the file tree sidebar, driven by BEAM protocol messages.
@@ -104,7 +130,8 @@ final class FileTreeState {
         self.focused = focused
         self.entries = rawEntries.enumerated().map { index, entry in
             FileTreeEntry(
-                id: entry.pathHash,
+                id: entry.id,
+                pathHash: entry.pathHash,
                 index: index,
                 isDir: entry.isDir,
                 isExpanded: entry.isExpanded,

--- a/macos/Sources/Views/FileTreeView.swift
+++ b/macos/Sources/Views/FileTreeView.swift
@@ -22,10 +22,10 @@ struct FileTreeView: View {
         NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.15
     }
 
-    @State private var hoveredEntryId: UInt32? = nil
+    @State private var hoveredEntryId: String? = nil
     @State private var scrollOffset: CGFloat = 0
-    @State private var dropTargetEntryId: UInt32? = nil
-    @State private var lastClickEntryId: UInt32? = nil
+    @State private var dropTargetEntryId: String? = nil
+    @State private var lastClickEntryId: String? = nil
     @State private var lastClickTime: Date? = nil
 
     var body: some View {

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -685,6 +685,10 @@ struct GUIFileTreeDecoderTests {
             flags: 0x0010 | 0x0020,
             depth: 1,
             gitStatus: 1,
+            diagnosticErrorCount: 1,
+            diagnosticWarningCount: 2,
+            diagnosticInfoCount: 3,
+            diagnosticHintCount: 4,
             guides: [true],
             id: "/home/user/project/lib/editor.ex",
             path: "/home/user/project/lib/editor.ex",
@@ -724,6 +728,10 @@ struct GUIFileTreeDecoderTests {
         #expect(entries[0].path == "/home/user/project/lib")
         #expect(entries[1].depth == 1)
         #expect(entries[1].gitStatus == 1)
+        #expect(entries[1].diagnosticErrorCount == 1)
+        #expect(entries[1].diagnosticWarningCount == 2)
+        #expect(entries[1].diagnosticInfoCount == 3)
+        #expect(entries[1].diagnosticHintCount == 4)
         #expect(entries[1].isActive == true)
         #expect(entries[1].isDirty == true)
         #expect(entries[1].guides == [true])
@@ -829,6 +837,10 @@ struct GUIFileTreeDecoderTests {
         flags: UInt16,
         depth: UInt8,
         gitStatus: UInt8,
+        diagnosticErrorCount: UInt16 = 0,
+        diagnosticWarningCount: UInt16 = 0,
+        diagnosticInfoCount: UInt16 = 0,
+        diagnosticHintCount: UInt16 = 0,
         guides: [Bool],
         id: String,
         path: String,
@@ -842,10 +854,10 @@ struct GUIFileTreeDecoderTests {
         appendU16(&data, flags)
         data.append(depth)
         data.append(gitStatus)
-        appendU16(&data, 0) // diagnostic errors
-        appendU16(&data, 0) // diagnostic warnings
-        appendU16(&data, 0) // diagnostic infos
-        appendU16(&data, 0) // diagnostic hints
+        appendU16(&data, diagnosticErrorCount)
+        appendU16(&data, diagnosticWarningCount)
+        appendU16(&data, diagnosticInfoCount)
+        appendU16(&data, diagnosticHintCount)
         data.append(UInt8(guides.count))
         for guide in guides { data.append(guide ? 1 : 0) }
         appendString16(&data, id)

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -301,12 +301,49 @@ struct FileTreeRowViewTests {
 
     @Test("Status markers remain separate from name text")
     @MainActor func statusMarkersRemainSeparateFromNameText() throws {
-        let row = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, isSelected: true, isFocused: true, isActive: true, isDirty: true, gitStatus: 1, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        let row = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, isSelected: true, isFocused: true, isActive: true, isDirty: true, gitStatus: 1, diagnosticErrorCount: 2, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
         let strings = try row.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
 
         #expect(strings.contains("editor.ex"))
+        #expect(strings.contains("✖2"))
         #expect(strings.contains("●"))
         #expect(try row.inspect().findAll(ViewType.Shape.self).count >= 1)
+    }
+
+    @Test("Accessibility labels include independent status summaries")
+    @MainActor func accessibilityLabelsIncludeStatusSummaries() throws {
+        let row = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, isDirty: true, gitStatus: 4, diagnosticWarningCount: 1, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+
+        #expect(row.accessibilityLabelText == "File: editor.ex, 1 warning, unsaved changes, git conflict")
+    }
+
+    @Test("Diagnostic info and hint severities render distinct markers")
+    @MainActor func diagnosticInfoAndHintSeveritiesRenderDistinctMarkers() throws {
+        let info = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, diagnosticInfoCount: 1, icon: "\u{E62D}", name: "info.ex", relPath: "info.ex"))
+        let hint = fileTreeRowView(entry: sidebarFileTreeEntry(id: 2, index: 1, diagnosticHintCount: 3, icon: "\u{E62D}", name: "hint.ex", relPath: "hint.ex"))
+        let noisy = fileTreeRowView(entry: sidebarFileTreeEntry(id: 3, index: 2, diagnosticErrorCount: 120, icon: "\u{E62D}", name: "noisy.ex", relPath: "noisy.ex"))
+
+        let infoStrings = try info.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+        let hintStrings = try hint.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+        let noisyStrings = try noisy.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(infoStrings.contains("ℹ"))
+        #expect(hintStrings.contains("·3"))
+        #expect(noisyStrings.contains("✖9+"))
+    }
+
+    @Test("Selected active and hovered rows keep status markers readable")
+    @MainActor func selectedActiveAndHoveredRowsKeepStatusMarkersReadable() throws {
+        let selected = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, isSelected: true, isFocused: false, isDirty: true, gitStatus: 1, diagnosticWarningCount: 1, icon: "\u{E62D}", name: "selected.ex", relPath: "selected.ex"))
+        let active = fileTreeRowView(entry: sidebarFileTreeEntry(id: 2, index: 1, isSelected: true, isFocused: true, isActive: true, isDirty: true, gitStatus: 4, diagnosticErrorCount: 1, icon: "\u{E62D}", name: "active.ex", relPath: "active.ex"))
+        let hovered = fileTreeRowView(entry: sidebarFileTreeEntry(id: 3, index: 2, isDirty: true, gitStatus: 2, diagnosticInfoCount: 1, icon: "\u{E62D}", name: "hovered.ex", relPath: "hovered.ex"), isHovered: true)
+
+        for row in [selected, active, hovered] {
+            let strings = try row.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+            #expect(strings.contains("●"))
+            #expect(row.accessibilityLabelText.contains("unsaved changes"))
+            #expect(row.accessibilityLabelText.contains("git"))
+        }
     }
 }
 
@@ -389,6 +426,10 @@ private func sidebarFileTreeEntry(
     isActive: Bool = false,
     isDirty: Bool = false,
     gitStatus: UInt8 = 0,
+    diagnosticErrorCount: UInt16 = 0,
+    diagnosticWarningCount: UInt16 = 0,
+    diagnosticInfoCount: UInt16 = 0,
+    diagnosticHintCount: UInt16 = 0,
     isEditing: Bool = false,
     editingType: UInt8 = 0xFF,
     editingText: String = "",
@@ -397,10 +438,10 @@ private func sidebarFileTreeEntry(
     name: String,
     relPath: String
 ) -> FileTreeEntry {
-    FileTreeEntry(id: id, index: index, isDir: isDir, isExpanded: isExpanded, isSelected: isSelected,
+    FileTreeEntry(id: relPath, pathHash: id, index: index, isDir: isDir, isExpanded: isExpanded, isSelected: isSelected,
                   isFocused: isFocused, isActive: isActive, isDirty: isDirty, isEditing: isEditing,
-                  isLastChild: false, depth: depth, gitStatus: gitStatus, diagnosticErrorCount: 0,
-                  diagnosticWarningCount: 0, diagnosticInfoCount: 0, diagnosticHintCount: 0,
+                  isLastChild: false, depth: depth, gitStatus: gitStatus, diagnosticErrorCount: diagnosticErrorCount,
+                  diagnosticWarningCount: diagnosticWarningCount, diagnosticInfoCount: diagnosticInfoCount, diagnosticHintCount: diagnosticHintCount,
                   guides: [], icon: icon, name: name, relPath: relPath, path: relPath,
                   editingType: editingType, editingText: editingText)
 }

--- a/macos/Tests/MingaTests/ViewModelComputedTests.swift
+++ b/macos/Tests/MingaTests/ViewModelComputedTests.swift
@@ -235,6 +235,7 @@ struct FileTreeStateComputedTests {
         ])
 
         let entry = state.entries[0]
+        #expect(entry.id == "/project/lib/editor.ex")
         #expect(entry.isSelected == true)
         #expect(entry.isFocused == false)
         #expect(entry.isActive == true)
@@ -244,6 +245,18 @@ struct FileTreeStateComputedTests {
         #expect(entry.showsDirtyMarker == true)
         #expect(entry.showsGitMarker == true)
         #expect(entry.hasConflictStatus == true)
+    }
+
+    @Test("Diagnostic severity uses error warning info hint priority")
+    @MainActor func diagnosticSeverityUsesPriority() {
+        let state = FileTreeState()
+        state.update(version: 2, selectedId: "/project/lib/editor.ex", focused: false, treeWidth: 30, rootPath: "/project", rawEntries: [
+            computedWireFileTreeEntry(id: "/project/lib/editor.ex", isSelected: false, isFocused: false, isActive: false, isDirty: false, gitStatus: 0, diagnosticErrorCount: 0, diagnosticWarningCount: 2, diagnosticInfoCount: 5, diagnosticHintCount: 8),
+        ])
+
+        let entry = state.entries[0]
+        #expect(entry.highestDiagnosticSeverity == .warning)
+        #expect(entry.highestDiagnosticCount == 2)
     }
 
     @Test("Dirty marker is suppressed for directories")
@@ -276,7 +289,7 @@ struct FileTreePathTests {
 }
 
 private func computedFileTreeEntry(path: String, relPath: String, isDir: Bool = false, isDirty: Bool = false) -> FileTreeEntry {
-    FileTreeEntry(id: 1, index: 0, isDir: isDir, isExpanded: false, isSelected: false,
+    FileTreeEntry(id: relPath, pathHash: 1, index: 0, isDir: isDir, isExpanded: false, isSelected: false,
                   isFocused: false, isActive: false, isDirty: isDirty, isEditing: false,
                   isLastChild: false, depth: 0, gitStatus: 0, diagnosticErrorCount: 0,
                   diagnosticWarningCount: 0, diagnosticInfoCount: 0, diagnosticHintCount: 0,
@@ -284,12 +297,12 @@ private func computedFileTreeEntry(path: String, relPath: String, isDir: Bool = 
                   editingType: 0xFF, editingText: "")
 }
 
-private func computedWireFileTreeEntry(id: String, isSelected: Bool, isFocused: Bool, isActive: Bool, isDirty: Bool, gitStatus: UInt8) -> Wire.FileTreeEntry {
+private func computedWireFileTreeEntry(id: String, isSelected: Bool, isFocused: Bool, isActive: Bool, isDirty: Bool, gitStatus: UInt8, diagnosticErrorCount: UInt16 = 0, diagnosticWarningCount: UInt16 = 0, diagnosticInfoCount: UInt16 = 0, diagnosticHintCount: UInt16 = 0) -> Wire.FileTreeEntry {
     Wire.FileTreeEntry(pathHash: 1, id: id, path: id, isDir: false, isExpanded: false,
                        isSelected: isSelected, isFocused: isFocused, isActive: isActive,
                        isDirty: isDirty, isEditing: false, isLastChild: false, depth: 0,
-                       gitStatus: gitStatus, diagnosticErrorCount: 0, diagnosticWarningCount: 0,
-                       diagnosticInfoCount: 0, diagnosticHintCount: 0, guides: [], icon: "",
+                       gitStatus: gitStatus, diagnosticErrorCount: diagnosticErrorCount, diagnosticWarningCount: diagnosticWarningCount,
+                       diagnosticInfoCount: diagnosticInfoCount, diagnosticHintCount: diagnosticHintCount, guides: [], icon: "",
                        name: "editor.ex", relPath: "lib/editor.ex", editingType: 0xFF,
                        editingText: "")
 }

--- a/test/minga/diagnostics_test.exs
+++ b/test/minga/diagnostics_test.exs
@@ -168,6 +168,28 @@ defmodule Minga.DiagnosticsTest do
     end
   end
 
+  describe "count_tuples_by_uri_prefix/2" do
+    test "returns counts for diagnostics under a URI prefix", %{server: s} do
+      project_file = "file:///tmp/project/lib/a.ex"
+      nested_file = "file:///tmp/project/lib/nested/b.ex"
+      other_file = "file:///tmp/other/c.ex"
+
+      Diagnostics.publish(s, :server_a, project_file, [
+        make_diag(severity: :error),
+        make_diag(severity: :warning)
+      ])
+
+      Diagnostics.publish(s, :server_a, nested_file, [make_diag(severity: :hint)])
+      Diagnostics.publish(s, :server_a, other_file, [make_diag(severity: :error)])
+
+      counts = Diagnostics.count_tuples_by_uri_prefix(s, "file:///tmp/project")
+
+      assert counts[project_file] == {1, 1, 0, 0}
+      assert counts[nested_file] == {0, 0, 0, 1}
+      refute Map.has_key?(counts, other_file)
+    end
+  end
+
   describe "next/3" do
     test "returns the next diagnostic after current line", %{server: s} do
       d1 = make_diag(line: 2, message: "line 2")
@@ -359,6 +381,27 @@ defmodule Minga.DiagnosticsTest do
 
       Diagnostics.publish(s, :server_a, @uri, [])
       assert Diagnostics.for_uri(s, @uri) == []
+    end
+
+    test "publishing empty list removes the source from URI tracking", %{server: s} do
+      uri = @uri
+      Minga.Events.subscribe(:diagnostics_updated)
+
+      Diagnostics.publish(s, :server_a, uri, [make_diag()])
+
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri, source: :server_a}}
+
+      Diagnostics.publish(s, :server_a, uri, [])
+
+      assert_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri, source: :server_a}}
+
+      Diagnostics.clear_source(s, :server_a)
+
+      refute_receive {:minga_event, :diagnostics_updated,
+                      %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri, source: :server_a}},
+                     50
     end
   end
 end

--- a/test/minga/project/file_tree/git_status_test.exs
+++ b/test/minga/project/file_tree/git_status_test.exs
@@ -64,6 +64,23 @@ defmodule Minga.Project.FileTree.GitStatusTest do
       status = GitStatus.compute(dir)
       assert Map.get(status, Path.join(dir, "src")) == :modified
     end
+
+    test "filters repo status to the requested root path", %{root: dir} do
+      root_path = Path.join(dir, "app")
+      File.mkdir_p!(root_path)
+      GitStub.set_root(root_path, dir)
+
+      GitStub.set_status(dir, [
+        %StatusEntry{path: "app/lib/inside.ex", status: :modified, staged: false},
+        %StatusEntry{path: "application/lib/outside.ex", status: :conflict, staged: false}
+      ])
+
+      status = GitStatus.compute(root_path)
+
+      assert Map.get(status, Path.join([dir, "app", "lib"])) == :modified
+      refute Map.has_key?(status, Path.join([dir, "application", "lib"]))
+      refute Map.has_key?(status, Path.join([dir, "application", "lib", "outside.ex"]))
+    end
   end
 
   describe "symbol/1" do

--- a/test/minga_editor/file_tree/rows_test.exs
+++ b/test/minga_editor/file_tree/rows_test.exs
@@ -3,7 +3,10 @@ defmodule MingaEditor.FileTree.RowsTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Diagnostics
+  alias Minga.Diagnostics.Diagnostic
   alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.Diagnostics, as: RowDiagnostics
   alias MingaEditor.FileTree.Rows
 
   @moduletag :tmp_dir
@@ -51,6 +54,106 @@ defmodule MingaEditor.FileTree.RowsTest do
       assert row.dirty? == false
     end
 
+    test "attaches diagnostic counts to file rows", %{tmp_dir: tmp_dir} do
+      tree = flat_tree(tmp_dir)
+      file_path = Path.join(tmp_dir, "alpha.ex")
+
+      [row | _] = Rows.from_tree(tree, diagnostics: %{file_path => {2, 1, 0, 3}})
+
+      assert row.diagnostics.error_count == 2
+      assert row.diagnostics.warning_count == 1
+      assert row.diagnostics.hint_count == 3
+      assert RowDiagnostics.highest_severity(row.diagnostics) == :error
+    end
+
+    test "accepts diagnostics count maps from the diagnostics store", %{tmp_dir: tmp_dir} do
+      tree = flat_tree(tmp_dir)
+      file_path = Path.join(tmp_dir, "alpha.ex")
+
+      [row | _] =
+        Rows.from_tree(tree,
+          diagnostics: %{file_path => %{error: 1, warning: 2, info: 3, hint: 4}}
+        )
+
+      assert row.diagnostics.error_count == 1
+      assert row.diagnostics.warning_count == 2
+      assert row.diagnostics.info_count == 3
+      assert row.diagnostics.hint_count == 4
+    end
+
+    test "reads diagnostics from the diagnostics store by default", %{tmp_dir: tmp_dir} do
+      diagnostics_server =
+        start_supervised!({Diagnostics, name: :"row_diag_#{System.unique_integer()}"})
+
+      File.mkdir_p!(Path.join(tmp_dir, "lib"))
+      file_path = Path.join([tmp_dir, "lib", "a.ex"])
+      File.write!(file_path, "")
+
+      Diagnostics.publish(
+        diagnostics_server,
+        :test,
+        Minga.LSP.SyncServer.path_to_uri(file_path),
+        [diagnostic(:error), diagnostic(:hint)]
+      )
+
+      rows = tmp_dir |> FileTree.new() |> Rows.from_tree(diagnostics_server: diagnostics_server)
+      lib = Enum.find(rows, &(&1.name == "lib"))
+
+      assert lib.diagnostics.error_count == 1
+      assert lib.diagnostics.hint_count == 1
+      assert RowDiagnostics.highest_severity(lib.diagnostics) == :error
+    end
+
+    test "propagates diagnostic status to ancestor directories", %{tmp_dir: tmp_dir} do
+      File.mkdir_p!(Path.join([tmp_dir, "lib", "minga"]))
+      file_path = Path.join([tmp_dir, "lib", "minga", "editor.ex"])
+      File.write!(file_path, "")
+
+      tree = FileTree.new(tmp_dir)
+      rows = Rows.from_tree(tree, diagnostics: %{file_path => {0, 1, 0, 0}})
+      lib = Enum.find(rows, &(&1.name == "lib"))
+
+      assert lib.directory? == true
+      assert lib.diagnostics.warning_count == 1
+      assert RowDiagnostics.highest_severity(lib.diagnostics) == :warning
+    end
+
+    test "merges descendant diagnostic counts on directory rows", %{tmp_dir: tmp_dir} do
+      File.mkdir_p!(Path.join(tmp_dir, "lib"))
+      first_path = Path.join([tmp_dir, "lib", "a.ex"])
+      second_path = Path.join([tmp_dir, "lib", "b.ex"])
+      File.write!(first_path, "")
+      File.write!(second_path, "")
+
+      tree = FileTree.new(tmp_dir)
+
+      rows =
+        Rows.from_tree(tree,
+          diagnostics: %{first_path => {1, 0, 0, 0}, second_path => {0, 2, 0, 0}}
+        )
+
+      lib = Enum.find(rows, &(&1.name == "lib"))
+
+      assert lib.diagnostics.error_count == 1
+      assert lib.diagnostics.warning_count == 2
+      assert RowDiagnostics.highest_severity(lib.diagnostics) == :error
+    end
+
+    test "ignores diagnostics outside sibling paths with the same prefix", %{tmp_dir: tmp_dir} do
+      File.mkdir_p!(Path.join(tmp_dir, "lib"))
+      File.write!(Path.join([tmp_dir, "lib", "inside.ex"]), "")
+      outside_path = Path.join([tmp_dir <> "_sibling", "lib", "outside.ex"])
+
+      rows =
+        tmp_dir
+        |> FileTree.new()
+        |> Rows.from_tree(diagnostics: %{outside_path => {1, 0, 0, 0}})
+
+      lib = Enum.find(rows, &(&1.name == "lib"))
+
+      assert RowDiagnostics.total_count(lib.diagnostics) == 0
+    end
+
     test "attaches inline editing metadata only to the edited index", %{tmp_dir: tmp_dir} do
       tree = flat_tree(tmp_dir)
       editing = %{index: 1, text: "renamed.ex", type: :rename, original_name: "beta.ex"}
@@ -78,7 +181,7 @@ defmodule MingaEditor.FileTree.RowsTest do
       assert row.depth == 2
       assert row.guides == [false, false]
       assert row.last_child? == true
-      assert row.relative_path == "lib/minga/editor.ex"
+      assert row.path == Path.join([tmp_dir, "lib", "minga", "editor.ex"])
     end
 
     test "returns no rows for an empty visible tree", %{tmp_dir: tmp_dir} do
@@ -90,5 +193,15 @@ defmodule MingaEditor.FileTree.RowsTest do
     File.write!(Path.join(tmp_dir, "alpha.ex"), "")
     File.write!(Path.join(tmp_dir, "beta.ex"), "")
     FileTree.new(tmp_dir)
+  end
+
+  defp diagnostic(severity) do
+    %Diagnostic{
+      range: %{start_line: 0, start_col: 0, end_line: 0, end_col: 1},
+      severity: severity,
+      message: "diagnostic",
+      source: "test",
+      code: nil
+    }
   end
 end

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -1087,6 +1087,7 @@ defmodule MingaEditor.Frontend.ProtocolTest do
           active?: true,
           dirty?: true,
           git_status: :modified,
+          diagnostics: MingaEditor.FileTree.Diagnostics.new({1, 2, 3, 4}),
           depth: 1,
           guides: [true, false],
           last_child?: true,
@@ -1108,7 +1109,7 @@ defmodule MingaEditor.Frontend.ProtocolTest do
 
       expected_hash = :erlang.phash2(row.id, 0xFFFFFFFF)
 
-      assert <<^expected_hash::32, row_flags::16, 1::8, 1::8, 0::16, 0::16, 0::16, 0::16, 2::8,
+      assert <<^expected_hash::32, row_flags::16, 1::8, 1::8, 1::16, 2::16, 3::16, 4::16, 2::8,
                1::8, 0::8, strings::binary>> = row_payload
 
       assert Bitwise.band(row_flags, 0x04) != 0
@@ -1126,9 +1127,35 @@ defmodule MingaEditor.Frontend.ProtocolTest do
 
       assert id == row.id
       assert path == row.path
-      assert rel_path == row.relative_path
+      assert rel_path == "lib/hello.ex"
       assert name == row.name
       assert icon != ""
+    end
+
+    test "clamps semantic gui_file_tree diagnostic counts to uint16 wire fields" do
+      row =
+        MingaEditor.FileTree.Row.new(
+          id: "/project/lib/noisy.ex",
+          path: "/project/lib/noisy.ex",
+          relative_path: "lib/noisy.ex",
+          name: "noisy.ex",
+          directory?: false,
+          expanded?: false,
+          selected?: true,
+          diagnostics: MingaEditor.FileTree.Diagnostics.new({70_000, 65_536, 3, 4}),
+          depth: 0,
+          guides: [],
+          last_child?: true,
+          editing: nil
+        )
+
+      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, true, false, [row])
+      <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
+
+      <<_version::8, _tree_flags::8, selected_len::16, _selected::binary-size(selected_len),
+        root_len::16, _root::binary-size(root_len), _width::16, _count::16, _hash::32,
+        _row_flags::16, _depth::8, _git::8, 65_535::16, 65_535::16, 3::16, 4::16, _rest::binary>> =
+        payload
     end
 
     test "encodes semantic gui_file_tree string lengths as UTF-8 byte counts" do
@@ -1161,7 +1188,7 @@ defmodule MingaEditor.Frontend.ProtocolTest do
       {_path, strings} = take_string16(strings)
       {rel_path, strings} = take_string16(strings)
       {name, _strings} = take_string16(strings)
-      assert rel_path == row.relative_path
+      assert rel_path == "lib/ñ📄.ex"
       assert name == row.name
       assert byte_size(name) > String.length(name)
     end

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
   use ExUnit.Case, async: true
 
   alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.Diagnostics, as: RowDiagnostics
   alias MingaEditor.FileTree.Row
   alias MingaEditor.Shell.Traditional.TreeRenderer
   alias MingaEditor.Shell.Traditional.TreeRenderer.RenderInput
@@ -337,6 +338,95 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       assert dirty_style.bold == true
     end
 
+    test "diagnostic dirty and git markers remain separate on selected rows", %{tmp_dir: tmp_dir} do
+      theme = Theme.get!(:doom_one)
+
+      row =
+        semantic_file_row(tmp_dir,
+          selected?: true,
+          focused?: true,
+          dirty?: true,
+          git_status: :conflict,
+          diagnostics: RowDiagnostics.new({2, 0, 0, 0})
+        )
+
+      draws = render_semantic_rows(tmp_dir, [row], theme)
+      {_r, _c, _text, diagnostic_style} = draw_matching(draws, "✖2")
+      {_r, _c, _text, dirty_style} = draw_matching(draws, "●")
+      {_r, _c, _text, git_style} = draw_matching(draws, " !")
+
+      assert diagnostic_style.fg == theme.gutter.error_fg
+      assert diagnostic_style.bg == theme.tree.cursor_bg
+      assert dirty_style.fg == theme.tree.modified_fg
+      assert dirty_style.bg == theme.tree.cursor_bg
+      assert git_style.fg == theme.tree.git_conflict_fg
+      assert git_style.bg == theme.tree.cursor_bg
+    end
+
+    test "right-edge status columns fit by truncating the name first", %{tmp_dir: tmp_dir} do
+      row =
+        semantic_file_row(tmp_dir,
+          dirty?: true,
+          git_status: :modified,
+          diagnostics: RowDiagnostics.new({0, 1, 0, 0})
+        )
+
+      draws =
+        TreeRenderer.render(%RenderInput{
+          tree: FileTree.new(tmp_dir, width: 12),
+          rect: {0, 0, 12, 5},
+          focused: false,
+          theme: Theme.get!(:doom_one),
+          active_path: nil,
+          rows: [row]
+        })
+
+      row_text =
+        draws
+        |> Enum.filter(fn {r, c, _t, _s} -> r == 1 and c < 12 end)
+        |> Enum.sort_by(fn {_r, c, _t, _s} -> c end)
+        |> Enum.map_join(fn {_r, _c, text, _s} -> text end)
+
+      diagnostic_draw = draw_matching(draws, "⚠")
+      dirty_draw = draw_matching(draws, "●")
+      git_draw = draw_matching(draws, " ●")
+
+      assert String.length(row_text) <= 12
+      assert diagnostic_draw != nil
+      assert dirty_draw != nil
+      assert git_draw != nil
+      assert draw_col(diagnostic_draw) < draw_col(dirty_draw)
+      assert draw_col(dirty_draw) < draw_col(git_draw)
+    end
+
+    test "large diagnostic counts are capped before narrow-row fitting", %{tmp_dir: tmp_dir} do
+      row =
+        semantic_file_row(tmp_dir,
+          dirty?: true,
+          git_status: :conflict,
+          diagnostics: RowDiagnostics.new({120, 0, 0, 0})
+        )
+
+      draws =
+        TreeRenderer.render(%RenderInput{
+          tree: FileTree.new(tmp_dir, width: 10),
+          rect: {0, 0, 10, 5},
+          focused: false,
+          theme: Theme.get!(:doom_one),
+          active_path: nil,
+          rows: [row]
+        })
+
+      row_text =
+        draws
+        |> Enum.filter(fn {r, c, _t, _s} -> r == 1 and c < 10 end)
+        |> Enum.sort_by(fn {_r, c, _t, _s} -> c end)
+        |> Enum.map_join(fn {_r, _c, text, _s} -> text end)
+
+      assert String.length(row_text) <= 10
+      assert String.contains?(row_text, "✖9+")
+    end
+
     test "unfocused selected row uses subdued selection background", %{tmp_dir: tmp_dir} do
       theme = Theme.get!(:doom_one)
       row = semantic_file_row(tmp_dir, selected?: true, focused?: false)
@@ -393,6 +483,8 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
   defp draw_matching(draws, text) do
     Enum.find(draws, fn {_r, _c, draw_text, _style} -> draw_text == text end)
   end
+
+  defp draw_col({_r, col, _text, _style}), do: col
 
   describe "editing entry rendering" do
     test "editing entry renders with inverse video styling", %{tmp_dir: tmp_dir} do


### PR DESCRIPTION
## Summary
- Add BEAM-owned diagnostic status to file tree rows and propagate worst descendant diagnostics to directory rows.
- Render diagnostic, dirty, and git status as separate indicators in both the TUI and macOS sidebar rows.
- Extend GUI file-tree decoding/tests so Swift renders semantic row state without querying git, dirty, or diagnostics locally.

## Validation
- `mix test.llm test/minga/diagnostics_test.exs test/minga_editor/file_tree/rows_test.exs test/minga_editor/frontend/protocol_test.exs test/minga_editor/shell/traditional/tree_renderer_test.exs`
- `mix swift.build`
- `xcodebuild test -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS'`
- `make lint`
- `mix test.debug test/minga_editor/ui/picker/agent_session_source_test.exs:82`
- `mix test.debug test/minga/git/tracker_registry_test.exs:23`
- `mix test.llm`
- `git diff --check`

Fixes #1644
