### PR TITLE
refactor(buffer): extract pure edit operations

### DIFF
--- a/lib/minga/buffer/operation.ex
+++ b/lib/minga/buffer/operation.ex
@@ -1,0 +1,155 @@
+defmodule Minga.Buffer.Operation do
+  @moduledoc """
+  Pure buffer edit operations with delta generation.
+
+  `Document` owns the gap-buffer data structure. This module owns domain edits that need both the updated document and the sync delta describing the change. `Buffer.Server` wraps these operations with process concerns like read-only checks, undo, dirty tracking, events, and persistence.
+  """
+
+  alias Minga.Buffer.Document
+  alias Minga.Buffer.EditDelta
+  alias Minga.Buffer.Position
+  alias Minga.Buffer.Selection
+  alias Minga.Buffer.Span
+
+  @typedoc "Result of a pure edit operation."
+  @type result :: :unchanged | {:edited, Document.t(), EditDelta.t()}
+
+  @typedoc "A range replacement edit using Buffer's characterwise inclusive range semantics."
+  @type range_edit :: {Document.position(), Document.position(), String.t()}
+
+  @doc "Inserts text at the current cursor and returns the updated document plus insertion delta."
+  @spec insert_at_cursor(Document.t(), String.t()) :: {:edited, Document.t(), EditDelta.t()}
+  def insert_at_cursor(%Document{} = doc, text) when is_binary(text) do
+    start_byte = Document.cursor_offset(doc)
+    start_position = Document.cursor(doc)
+    new_doc = Document.insert_text(doc, text)
+    delta = EditDelta.insertion(start_byte, start_position, text, Document.cursor(new_doc))
+
+    {:edited, new_doc, delta}
+  end
+
+  @doc "Replaces a characterwise range and returns the updated document plus replacement delta."
+  @spec replace_range(Document.t(), Document.position(), Document.position(), String.t()) ::
+          result()
+  def replace_range(%Document{} = doc, from_pos, to_pos, replacement)
+      when is_binary(replacement) do
+    selection = Selection.characterwise(doc, from_pos, to_pos)
+    %Span{start: start_byte, stop: old_end_byte} = selection.span
+
+    new_doc =
+      doc
+      |> Document.delete_range(from_pos, to_pos)
+      |> Document.insert_text(replacement)
+
+    delta =
+      EditDelta.replacement(
+        start_byte,
+        old_end_byte,
+        Position.from_point(doc, start_byte),
+        Position.from_point(doc, old_end_byte),
+        replacement,
+        Document.cursor(new_doc)
+      )
+
+    {:edited, new_doc, delta}
+  end
+
+  @doc "Applies multiple range replacements from the end of the document toward the start."
+  @spec replace_ranges(Document.t(), [range_edit()]) :: Document.t()
+  def replace_ranges(%Document{} = doc, edits) when is_list(edits) do
+    edits
+    |> Enum.sort(fn {from_a, _, _}, {from_b, _, _} -> from_a >= from_b end)
+    |> Enum.reduce(doc, fn {from_pos, to_pos, replacement}, acc ->
+      {:edited, new_doc, _delta} = replace_range(acc, from_pos, to_pos, replacement)
+      new_doc
+    end)
+  end
+
+  @doc "Deletes the character before the cursor."
+  @spec backspace(Document.t()) :: result()
+  def backspace(%Document{} = doc) do
+    new_doc = Document.delete_before(doc)
+
+    if new_doc == doc do
+      :unchanged
+    else
+      delta =
+        EditDelta.deletion(
+          Document.cursor_offset(new_doc),
+          Document.cursor_offset(doc),
+          Document.cursor(new_doc),
+          Document.cursor(doc)
+        )
+
+      {:edited, new_doc, delta}
+    end
+  end
+
+  @doc "Deletes the character at the cursor."
+  @spec delete_forward(Document.t()) :: result()
+  def delete_forward(%Document{} = doc) do
+    new_doc = Document.delete_at(doc)
+
+    if new_doc == doc do
+      :unchanged
+    else
+      start_byte = Document.cursor_offset(doc)
+      old_end_byte = Position.after_character_at(Document.content(doc), start_byte)
+
+      delta =
+        EditDelta.deletion(
+          start_byte,
+          old_end_byte,
+          Document.cursor(doc),
+          Position.from_point(doc, old_end_byte)
+        )
+
+      {:edited, new_doc, delta}
+    end
+  end
+
+  @doc "Deletes a characterwise range and returns a deletion delta."
+  @spec delete_range(Document.t(), Document.position(), Document.position()) :: result()
+  def delete_range(%Document{} = doc, from_pos, to_pos) do
+    selection = Selection.characterwise(doc, from_pos, to_pos)
+    %Span{start: start_byte, stop: old_end_byte} = selection.span
+    new_doc = Document.delete_range(doc, from_pos, to_pos)
+
+    if new_doc == doc do
+      :unchanged
+    else
+      delta =
+        EditDelta.deletion(
+          start_byte,
+          old_end_byte,
+          Position.from_point(doc, start_byte),
+          Position.from_point(doc, old_end_byte)
+        )
+
+      {:edited, new_doc, delta}
+    end
+  end
+
+  @doc "Deletes a linewise range and returns a deletion delta."
+  @spec delete_lines(Document.t(), non_neg_integer(), non_neg_integer()) :: result()
+  def delete_lines(%Document{} = doc, start_line, end_line)
+      when start_line >= 0 and end_line >= 0 do
+    selection = Selection.linewise(doc, start_line, end_line)
+    %Span{start: start_byte, stop: old_end_byte} = selection.span
+    new_doc = Document.delete_lines(doc, start_line, end_line)
+
+    if new_doc == doc do
+      :unchanged
+    else
+      delta =
+        EditDelta.deletion(
+          start_byte,
+          old_end_byte,
+          Position.from_point(doc, start_byte),
+          Position.from_point(doc, old_end_byte)
+        )
+
+      {:edited, new_doc, delta}
+    end
+  end
+end

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -18,7 +18,7 @@ defmodule Minga.Buffer.Server do
 
   use GenServer
 
-  alias Minga.Buffer.{Cursor, Document, Lines, Position}
+  alias Minga.Buffer.{Cursor, Document, Lines, Operation, Position}
   alias Minga.Buffer.EditDelta
   alias Minga.Buffer.EditSource
   alias Minga.Config
@@ -900,17 +900,7 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call({:insert_text, text, source}, _from, state) do
-    old_doc = state.document
-    new_doc = Document.insert_text(old_doc, text)
-
-    delta =
-      EditDelta.insertion(
-        byte_size(old_doc.before),
-        Document.cursor(old_doc),
-        text,
-        Document.cursor(new_doc)
-      )
-
+    {:edited, new_doc, delta} = Operation.insert_at_cursor(state.document, text)
     undo_source = EditSource.to_undo_source(source)
     state = push_undo(state, new_doc, undo_source) |> mark_dirty() |> record_edit(delta, source)
     {:reply, :ok, state}
@@ -925,23 +915,13 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call({:apply_text_edit, from_pos, to_pos, new_text, source}, _from, state) do
-    old_content = Document.content(state.document)
-    start_byte = byte_offset_at(old_content, from_pos)
-    old_end_byte = byte_offset_at(old_content, to_pos)
-
-    doc = Cursor.place(state.document, from_pos)
-    doc = Document.delete_range(doc, from_pos, to_pos)
-    doc = Document.insert_text(doc, new_text)
-
-    new_end_pos = advance_position(from_pos, new_text)
-
-    delta =
-      EditDelta.replacement(start_byte, old_end_byte, from_pos, to_pos, new_text, new_end_pos)
+    {:edited, new_doc, delta} =
+      Operation.replace_range(state.document, from_pos, to_pos, new_text)
 
     undo_source = EditSource.to_undo_source(source)
 
     {:reply, :ok,
-     push_undo(state, doc, undo_source) |> mark_dirty() |> record_edit(delta, source)}
+     push_undo(state, new_doc, undo_source) |> mark_dirty() |> record_edit(delta, source)}
   end
 
   def handle_call({:apply_text_edits, _edits, _source}, _from, %{read_only: true} = state) do
@@ -953,21 +933,7 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call({:apply_text_edits, edits, source}, _from, state) do
-    # Sort edits in reverse document order so earlier offsets stay valid
-    # as we apply edits from the end of the document backward.
-    sorted =
-      Enum.sort(edits, fn {from_a, _, _}, {from_b, _, _} ->
-        from_a >= from_b
-      end)
-
-    doc =
-      Enum.reduce(sorted, state.document, fn {from_pos, to_pos, new_text}, doc ->
-        doc
-        |> Cursor.place(from_pos)
-        |> Document.delete_range(from_pos, to_pos)
-        |> Document.insert_text(new_text)
-      end)
-
+    doc = Operation.replace_ranges(state.document, edits)
     undo_source = EditSource.to_undo_source(source)
 
     # Multi-edit batches are complex to delta-track (offsets shift between
@@ -1040,23 +1006,12 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call(:delete_before, _from, state) do
-    old_doc = state.document
-    new_buf = Document.delete_before(old_doc)
+    case Operation.backspace(state.document) do
+      :unchanged ->
+        {:reply, :ok, state}
 
-    if new_buf == old_doc do
-      {:reply, :ok, state}
-    else
-      new_cursor = Document.cursor(new_buf)
-
-      delta =
-        EditDelta.deletion(
-          byte_size(new_buf.before),
-          byte_size(old_doc.before),
-          new_cursor,
-          Document.cursor(old_doc)
-        )
-
-      {:reply, :ok, push_undo(state, new_buf, :user) |> mark_dirty() |> record_edit(delta)}
+      {:edited, new_doc, delta} ->
+        {:reply, :ok, push_undo(state, new_doc, :user) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -1065,36 +1020,12 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call(:delete_at, _from, state) do
-    old_doc = state.document
-    new_buf = Document.delete_at(old_doc)
+    case Operation.delete_forward(state.document) do
+      :unchanged ->
+        {:reply, :ok, state}
 
-    if new_buf == old_doc do
-      {:reply, :ok, state}
-    else
-      # delete_at removes the char after cursor; cursor position stays the same
-      old_end_byte =
-        byte_size(old_doc.before) + byte_size(old_doc.after) - byte_size(new_buf.after)
-
-      old_content = Document.content(old_doc)
-      # Compute old_end_position from the removed text
-      removed =
-        binary_part(
-          old_content,
-          byte_size(old_doc.before),
-          old_end_byte - byte_size(old_doc.before)
-        )
-
-      old_end_pos = advance_position(Document.cursor(old_doc), removed)
-
-      delta =
-        EditDelta.deletion(
-          byte_size(old_doc.before),
-          old_end_byte,
-          Document.cursor(old_doc),
-          old_end_pos
-        )
-
-      {:reply, :ok, push_undo(state, new_buf, :user) |> mark_dirty() |> record_edit(delta)}
+      {:edited, new_doc, delta} ->
+        {:reply, :ok, push_undo(state, new_doc, :user) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -1544,17 +1475,12 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call({:delete_range, from_pos, to_pos}, _from, state) do
-    old_doc = state.document
-    new_buf = Document.delete_range(old_doc, from_pos, to_pos)
+    case Operation.delete_range(state.document, from_pos, to_pos) do
+      :unchanged ->
+        {:reply, :ok, state}
 
-    if new_buf == old_doc do
-      {:reply, :ok, state}
-    else
-      old_content = Document.content(old_doc)
-      start_byte = byte_offset_at(old_content, from_pos)
-      old_end_byte = byte_offset_at(old_content, to_pos)
-      delta = EditDelta.deletion(start_byte, old_end_byte, from_pos, to_pos)
-      {:reply, :ok, push_undo(state, new_buf, :user) |> mark_dirty() |> record_edit(delta)}
+      {:edited, new_doc, delta} ->
+        {:reply, :ok, push_undo(state, new_doc, :user) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -1573,20 +1499,12 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call({:delete_lines, start_line, end_line}, _from, state) do
-    old_doc = state.document
-    new_buf = Document.delete_lines(old_doc, start_line, end_line)
+    case Operation.delete_lines(state.document, start_line, end_line) do
+      :unchanged ->
+        {:reply, :ok, state}
 
-    if new_buf == old_doc do
-      {:reply, :ok, state}
-    else
-      old_content = Document.content(old_doc)
-      from_pos = {start_line, 0}
-      # end_line is inclusive; delete through end of that line (including newline)
-      to_pos = {end_line + 1, 0}
-      start_byte = byte_offset_at(old_content, from_pos)
-      old_end_byte = byte_offset_at(old_content, to_pos)
-      delta = EditDelta.deletion(start_byte, old_end_byte, from_pos, to_pos)
-      {:reply, :ok, push_undo(state, new_buf, :user) |> mark_dirty() |> record_edit(delta)}
+      {:edited, new_doc, delta} ->
+        {:reply, :ok, push_undo(state, new_doc, :user) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -2452,44 +2370,6 @@ defmodule Minga.Buffer.Server do
   # when the list is already shorter than the limit.
   @spec cap_log([{non_neg_integer(), EditDelta.t()}]) :: [{non_neg_integer(), EditDelta.t()}]
   defp cap_log(log), do: Enum.take(log, @max_single_consumer_log)
-
-  # Compute byte offset for a {line, col} position in content.
-  @spec byte_offset_at(String.t(), {non_neg_integer(), non_neg_integer()}) :: non_neg_integer()
-  defp byte_offset_at(content, {target_line, target_col}) do
-    lines = String.split(content, "\n")
-
-    bytes_before_line =
-      lines
-      |> Enum.take(target_line)
-      |> Enum.reduce(0, fn line, acc -> acc + byte_size(line) + 1 end)
-
-    line_text = Enum.at(lines, target_line, "")
-
-    col_bytes =
-      line_text
-      |> String.graphemes()
-      |> Enum.take(target_col)
-      |> IO.iodata_to_binary()
-      |> byte_size()
-
-    bytes_before_line + col_bytes
-  end
-
-  @spec advance_position({non_neg_integer(), non_neg_integer()}, String.t()) ::
-          {non_neg_integer(), non_neg_integer()}
-  defp advance_position({line, col}, text) do
-    text
-    |> String.split("\n")
-    |> case do
-      [single] ->
-        {line, col + String.length(single)}
-
-      parts ->
-        new_lines = length(parts) - 1
-        last_part = List.last(parts)
-        {line + new_lines, String.length(last_part)}
-    end
-  end
 
   # ── move_if_possible helpers ──
 

--- a/test/minga/buffer/operation_test.exs
+++ b/test/minga/buffer/operation_test.exs
@@ -1,0 +1,56 @@
+defmodule Minga.Buffer.OperationTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Document
+  alias Minga.Buffer.Operation
+
+  describe "insert_at_cursor/2" do
+    test "returns byte-based delta positions for unicode insertions" do
+      doc = Document.new("abc") |> Document.move_to({0, 1})
+
+      assert {:edited, new_doc, delta} = Operation.insert_at_cursor(doc, "é")
+      assert Document.content(new_doc) == "aébc"
+      assert Document.cursor(new_doc) == {0, 3}
+      assert delta.start_byte == 1
+      assert delta.old_end_byte == 1
+      assert delta.new_end_byte == 3
+      assert delta.start_position == {0, 1}
+      assert delta.old_end_position == {0, 1}
+      assert delta.new_end_position == {0, 3}
+    end
+  end
+
+  describe "replace_range/4" do
+    test "returns exclusive old end byte and position for a multi-byte grapheme" do
+      doc = Document.new("aébc")
+
+      assert {:edited, new_doc, delta} = Operation.replace_range(doc, {0, 1}, {0, 1}, "X")
+      assert Document.content(new_doc) == "aXbc"
+      assert Document.cursor(new_doc) == {0, 2}
+      assert delta.start_byte == 1
+      assert delta.old_end_byte == 3
+      assert delta.new_end_byte == 2
+      assert delta.start_position == {0, 1}
+      assert delta.old_end_position == {0, 3}
+      assert delta.new_end_position == {0, 2}
+      assert delta.inserted_text == "X"
+    end
+  end
+
+  describe "delete_forward/1" do
+    test "returns exclusive old end byte and position for a multi-byte grapheme" do
+      doc = Document.new("aébc") |> Document.move_to({0, 1})
+
+      assert {:edited, new_doc, delta} = Operation.delete_forward(doc)
+      assert Document.content(new_doc) == "abc"
+      assert Document.cursor(new_doc) == {0, 1}
+      assert delta.start_byte == 1
+      assert delta.old_end_byte == 3
+      assert delta.new_end_byte == 1
+      assert delta.start_position == {0, 1}
+      assert delta.old_end_position == {0, 3}
+      assert delta.new_end_position == {0, 1}
+      assert delta.inserted_text == ""
+    end
+  end
+end

--- a/test/minga/buffer/server_test.exs
+++ b/test/minga/buffer/server_test.exs
@@ -833,6 +833,21 @@ defmodule Minga.Buffer.ServerTest do
       assert delta.inserted_text == ""
     end
 
+    test "apply_text_edit records byte-accurate unicode replacement delta" do
+      {:ok, pid} = Server.start_link(content: "aébc")
+      Server.apply_text_edit(pid, 0, 1, 0, 1, "X")
+      edits = Server.flush_edits(pid, :test)
+      assert [delta] = edits
+      assert Server.content(pid) == "aXbc"
+      assert delta.start_byte == 1
+      assert delta.old_end_byte == 3
+      assert delta.new_end_byte == 2
+      assert delta.start_position == {0, 1}
+      assert delta.old_end_position == {0, 3}
+      assert delta.new_end_position == {0, 2}
+      assert delta.inserted_text == "X"
+    end
+
     test "flush_edits clears pending deltas for that consumer" do
       {:ok, pid} = Server.start_link(content: "hello")
       Server.move_to(pid, {0, 5})


### PR DESCRIPTION
# TL;DR
This extracts buffer edit transforms from `Minga.Buffer.Server` into a pure `Minga.Buffer.Operation` module, so the GenServer can stay focused on transactions, undo, dirty tracking, and events. It also fixes byte-accurate unicode edit deltas for replacement and delete-forward style edits.

## Context
This is the first pass at separating buffer domain edits from the buffer process wrapper. The public `Minga.Buffer.Server` and `Minga.Buffer` APIs stay stable in this PR, while the implementation now routes core edit operations through a pure module with domain-oriented names.

## Changes
- Added `Minga.Buffer.Operation` for pure edit operations that return updated documents plus `EditDelta` metadata.
- Moved insert, range replacement, batch replacement, backspace, delete-forward, range delete, and line delete delta generation out of `Minga.Buffer.Server`.
- Removed duplicate byte/position helpers from `Minga.Buffer.Server` and reused `Document`, `Position`, `Selection`, and `Span` for byte-accurate math.
- Added unicode regression coverage for edit deltas, including replacing `é` inside `"aébc"`.

## Verification
- `make lint`
- `mix test.llm`
- `mix test.debug test/minga/buffer/operation_test.exs test/minga/buffer/server_test.exs`
- `mix test.llm test/minga/buffer`
- `mix test.llm test/minga/lsp/sync_server_test.exs`
- `mix test.llm test/minga_editor/highlight_sync_test.exs`
- `mix compile --warnings-as-errors`
- Final reviewer gate: PASS

## Acceptance Criteria Addressed
- Extract pure buffer edit operations from `Minga.Buffer.Server` while keeping public APIs stable ✅
- Fix byte-accurate unicode edit deltas for buffer replacement/delete operations ✅
