### PR TITLE
refactor(buffer): extract shared replace operations

### DIFF
--- a/lib/minga/buffer/fork.ex
+++ b/lib/minga/buffer/fork.ex
@@ -28,6 +28,7 @@ defmodule Minga.Buffer.Fork do
   use GenServer
 
   alias Minga.Buffer.Document
+  alias Minga.Buffer.Replace
   alias Minga.Buffer.Server, as: BufServer
   alias Minga.Core.Diff
 
@@ -160,10 +161,8 @@ defmodule Minga.Buffer.Fork do
     {:reply, state.version, state}
   end
 
-  def handle_call({:find_and_replace, old_text, new_text, _boundary}, _from, state) do
-    content = Document.content(state.document)
-
-    case do_find_and_replace(content, old_text, new_text) do
+  def handle_call({:find_and_replace, old_text, new_text, boundary}, _from, state) do
+    case Replace.unique(state.document, old_text, new_text, boundary) do
       {:ok, new_doc, msg} ->
         {:reply, {:ok, msg},
          %{state | document: new_doc, dirty: true, version: state.version + 1}}
@@ -178,26 +177,11 @@ defmodule Minga.Buffer.Fork do
     {:reply, :ok, %{state | document: new_doc, dirty: true, version: state.version + 1}}
   end
 
-  def handle_call({:find_and_replace_batch, edits, _boundary}, _from, state) do
-    {final_doc, results_reversed} =
-      Enum.reduce(edits, {state.document, []}, fn
-        {"", _new_text}, {doc, acc} ->
-          {doc, [{:error, "old_text is empty"} | acc]}
-
-        {old_text, new_text}, {doc, acc} ->
-          content = Document.content(doc)
-
-          case do_find_and_replace(content, old_text, new_text) do
-            {:ok, new_doc, msg} -> {new_doc, [{:ok, msg} | acc]}
-            {:error, _} = err -> {doc, [err | acc]}
-          end
-      end)
-
-    results = Enum.reverse(results_reversed)
-    any_applied = Enum.any?(results, &match?({:ok, _}, &1))
+  def handle_call({:find_and_replace_batch, edits, boundary}, _from, state) do
+    {final_doc, results, any_applied?} = Replace.batch(state.document, edits, boundary)
 
     new_state =
-      if any_applied do
+      if any_applied? do
         %{state | document: final_doc, dirty: true, version: state.version + 1}
       else
         state
@@ -236,28 +220,6 @@ defmodule Minga.Buffer.Fork do
   end
 
   # ── Private ─────────────────────────────────────────────────────────────────
-
-  @spec do_find_and_replace(String.t(), String.t(), String.t()) ::
-          {:ok, Document.t(), String.t()} | {:error, String.t()}
-  defp do_find_and_replace(_content, "", _new_text) do
-    {:error, "old_text is empty"}
-  end
-
-  defp do_find_and_replace(content, old_text, new_text) do
-    case :binary.matches(content, old_text) do
-      [] ->
-        {:error, "old_text not found"}
-
-      [{offset, len}] ->
-        before_match = binary_part(content, 0, offset)
-        after_match = binary_part(content, offset + len, byte_size(content) - offset - len)
-        new_content = before_match <> new_text <> after_match
-        {:ok, Document.new(new_content), "applied"}
-
-      matches ->
-        {:error, "old_text found #{length(matches)} times (ambiguous)"}
-    end
-  end
 
   @spec format_merge_result(Diff.merge3_result()) ::
           {:ok, String.t()} | {:conflict, [Diff.merge_hunk()]}

--- a/lib/minga/buffer/replace.ex
+++ b/lib/minga/buffer/replace.ex
@@ -1,0 +1,94 @@
+defmodule Minga.Buffer.Replace do
+  @moduledoc """
+  Pure unique text replacement operations for buffer documents.
+
+  This module owns the domain semantics for agent-style find-and-replace edits: the old text must exist exactly once, optional line boundaries are enforced against that unique match, and batch replacements apply sequentially while preserving per-edit results. `Buffer.Server` and `Buffer.Fork` wrap these pure operations with their own process, undo, version, and merge concerns.
+  """
+
+  alias Minga.Buffer.Document
+
+  @typedoc "An edit boundary as `{start_line, end_line}` (both inclusive, 0-indexed), or nil for unbounded."
+  @type boundary :: {non_neg_integer(), non_neg_integer()} | nil
+
+  @typedoc "A find-and-replace edit pair for batch operations."
+  @type edit :: {old_text :: String.t(), new_text :: String.t()}
+
+  @typedoc "Result of a single replacement."
+  @type result :: {:ok, String.t()} | {:error, String.t()}
+
+  @typedoc "Result of applying a batch of replacement edits."
+  @type batch_result :: {Document.t(), [result()], any_applied? :: boolean()}
+
+  @doc "Replaces `old_text` with `new_text` when the old text has exactly one match in the document."
+  @spec unique(Document.t(), String.t(), String.t(), boundary()) ::
+          {:ok, Document.t(), String.t()} | {:error, String.t()}
+  def unique(%Document{} = doc, old_text, new_text, boundary \\ nil)
+      when is_binary(old_text) and is_binary(new_text) do
+    content = Document.content(doc)
+
+    with {:ok, match} <- unique_match(content, old_text),
+         :ok <- check_boundary(content, match, boundary) do
+      {:ok, replace_match(content, match, new_text), "applied"}
+    end
+  end
+
+  @doc "Applies unique replacements sequentially and returns the final document plus per-edit results."
+  @spec batch(Document.t(), [edit()], boundary()) :: batch_result()
+  def batch(%Document{} = doc, edits, boundary \\ nil) when is_list(edits) do
+    {final_doc, results_reversed} =
+      Enum.reduce(edits, {doc, []}, fn {old_text, new_text}, {current_doc, acc} ->
+        case unique(current_doc, old_text, new_text, boundary) do
+          {:ok, new_doc, msg} -> {new_doc, [{:ok, msg} | acc]}
+          {:error, _} = err -> {current_doc, [err | acc]}
+        end
+      end)
+
+    results = Enum.reverse(results_reversed)
+    {final_doc, results, Enum.any?(results, &match?({:ok, _}, &1))}
+  end
+
+  @spec unique_match(String.t(), String.t()) ::
+          {:ok, {non_neg_integer(), pos_integer()}} | {:error, String.t()}
+  defp unique_match(_content, ""), do: {:error, "old_text is empty"}
+
+  defp unique_match(content, old_text) do
+    case :binary.matches(content, old_text) do
+      [] -> {:error, "old_text not found"}
+      [match] -> {:ok, match}
+      matches -> {:error, "old_text found #{length(matches)} times (ambiguous)"}
+    end
+  end
+
+  @spec check_boundary(String.t(), {non_neg_integer(), pos_integer()}, boundary()) ::
+          :ok | {:error, String.t()}
+  defp check_boundary(_content, _match, nil), do: :ok
+
+  defp check_boundary(content, {offset, len}, {boundary_start, boundary_end}) do
+    match_start_line = content |> binary_part(0, offset) |> count_newlines()
+
+    match_end_line =
+      content |> binary_part(offset, len) |> count_newlines() |> Kernel.+(match_start_line)
+
+    if match_start_line >= boundary_start and match_end_line <= boundary_end do
+      :ok
+    else
+      {:error,
+       "edit outside boundary: match spans lines #{match_start_line}-#{match_end_line}, " <>
+         "allowed range is #{boundary_start}-#{boundary_end}"}
+    end
+  end
+
+  @spec count_newlines(binary()) :: non_neg_integer()
+  defp count_newlines(binary) do
+    binary
+    |> :binary.matches("\n")
+    |> length()
+  end
+
+  @spec replace_match(String.t(), {non_neg_integer(), pos_integer()}, String.t()) :: Document.t()
+  defp replace_match(content, {offset, len}, new_text) do
+    before_match = binary_part(content, 0, offset)
+    after_match = binary_part(content, offset + len, byte_size(content) - offset - len)
+    Document.new(before_match <> new_text <> after_match)
+  end
+end

--- a/lib/minga/buffer/server.ex
+++ b/lib/minga/buffer/server.ex
@@ -18,7 +18,7 @@ defmodule Minga.Buffer.Server do
 
   use GenServer
 
-  alias Minga.Buffer.{Cursor, Document, Lines, Operation, Position}
+  alias Minga.Buffer.{Cursor, Document, Lines, Operation, Position, Replace}
   alias Minga.Buffer.EditDelta
   alias Minga.Buffer.EditSource
   alias Minga.Config
@@ -947,25 +947,13 @@ defmodule Minga.Buffer.Server do
     {:reply, {:error, "buffer is read-only"}, state}
   end
 
-  def handle_call({:find_and_replace, "", _new, _boundary}, _from, state) do
-    {:reply, {:error, "old_text is empty"}, state}
-  end
-
   def handle_call({:find_and_replace, old_text, new_text, boundary}, _from, state) do
-    content = Document.content(state.document)
-
-    case do_find_and_replace(content, old_text, new_text) do
+    case Replace.unique(state.document, old_text, new_text, boundary) do
       {:ok, new_doc, msg} ->
-        case check_boundary(content, old_text, boundary) do
-          :ok ->
-            {:reply, {:ok, msg},
-             push_undo_force(state, new_doc, :agent)
-             |> mark_dirty()
-             |> clear_edits(EditSource.agent(self(), "unknown"))}
-
-          {:error, _} = err ->
-            {:reply, err, state}
-        end
+        {:reply, {:ok, msg},
+         push_undo_force(state, new_doc, :agent)
+         |> mark_dirty()
+         |> clear_edits(EditSource.agent(self(), "unknown"))}
 
       {:error, _} = err ->
         {:reply, err, state}
@@ -981,16 +969,10 @@ defmodule Minga.Buffer.Server do
   end
 
   def handle_call({:find_and_replace_batch, edits, boundary}, _from, state) do
-    {final_doc, results_reversed} =
-      Enum.reduce(edits, {state.document, []}, fn edit, acc ->
-        apply_batch_edit(edit, acc, boundary)
-      end)
-
-    results = Enum.reverse(results_reversed)
-    any_applied = Enum.any?(results, &match?({:ok, _}, &1))
+    {final_doc, results, any_applied?} = Replace.batch(state.document, edits, boundary)
 
     new_state =
-      if any_applied do
+      if any_applied? do
         push_undo_force(state, final_doc, :agent)
         |> mark_dirty()
         |> clear_edits(EditSource.agent(self(), "unknown"))
@@ -1756,90 +1738,6 @@ defmodule Minga.Buffer.Server do
   end
 
   # ── Find and Replace helpers ──
-
-  @spec apply_batch_edit({String.t(), String.t()}, {Document.t(), [replace_result()]}, boundary()) ::
-          {Document.t(), [replace_result()]}
-  defp apply_batch_edit({"", _new_text}, {doc, acc}, _boundary) do
-    {doc, [{:error, "old_text is empty"} | acc]}
-  end
-
-  defp apply_batch_edit({old_text, new_text}, {doc, acc}, boundary) do
-    content = Document.content(doc)
-
-    case do_find_and_replace(content, old_text, new_text) do
-      {:ok, new_doc, msg} ->
-        case check_boundary(content, old_text, boundary) do
-          :ok -> {new_doc, [{:ok, msg} | acc]}
-          {:error, _} = err -> {doc, [err | acc]}
-        end
-
-      {:error, _} = err ->
-        {doc, [err | acc]}
-    end
-  end
-
-  # Checks whether a text match falls within the allowed boundary.
-  # Returns :ok if no boundary is set or the match is within bounds.
-  # Returns {:error, reason} if the match is outside the boundary.
-  @spec check_boundary(String.t(), String.t(), boundary()) :: :ok | {:error, String.t()}
-  defp check_boundary(_content, _old_text, nil), do: :ok
-
-  defp check_boundary(content, old_text, {boundary_start, boundary_end}) do
-    case :binary.matches(content, old_text) do
-      [{offset, len}] ->
-        # Count newlines before the match to determine the start line
-        before_match = binary_part(content, 0, offset)
-        match_start_line = count_newlines(before_match)
-
-        # Count newlines within the match to determine the end line
-        match_text = binary_part(content, offset, len)
-        match_end_line = match_start_line + count_newlines(match_text)
-
-        if match_start_line >= boundary_start and match_end_line <= boundary_end do
-          :ok
-        else
-          {:error,
-           "edit outside boundary: match spans lines #{match_start_line}-#{match_end_line}, " <>
-             "allowed range is #{boundary_start}-#{boundary_end}"}
-        end
-
-      # Not found or ambiguous: let do_find_and_replace handle the error
-      _ ->
-        :ok
-    end
-  end
-
-  @spec count_newlines(binary()) :: non_neg_integer()
-  defp count_newlines(binary) do
-    binary
-    |> :binary.matches("\n")
-    |> length()
-  end
-
-  # Performs the actual string search and replace on raw content.
-  # Returns a new Document built from the replaced content. Note: this
-  # resets the cursor to {0, 0}. This matches the behavior of
-  # replace_content/2 which also rebuilds via Document.new/1.
-  @spec do_find_and_replace(String.t(), String.t(), String.t()) ::
-          {:ok, Document.t(), String.t()} | {:error, String.t()}
-  defp do_find_and_replace(content, old_text, new_text) do
-    case :binary.matches(content, old_text) do
-      [] ->
-        {:error, "old_text not found"}
-
-      [{offset, len}] ->
-        # Build new content by splicing: before_match <> new_text <> after_match
-        before_match = binary_part(content, 0, offset)
-        after_match = binary_part(content, offset + len, byte_size(content) - offset - len)
-        new_content = before_match <> new_text <> after_match
-        new_doc = Document.new(new_content)
-
-        {:ok, new_doc, "applied"}
-
-      matches ->
-        {:error, "old_text found #{length(matches)} times (ambiguous)"}
-    end
-  end
 
   # ── Registry helpers ──
 

--- a/test/minga/buffer/fork_test.exs
+++ b/test/minga/buffer/fork_test.exs
@@ -83,6 +83,39 @@ defmodule Minga.Buffer.ForkTest do
       assert Fork.version(fork) == 0
     end
 
+    test "find_and_replace honors boundaries" do
+      parent = start_parent!("line1\ntarget\nline3")
+
+      {:ok, fork} = Fork.create(parent)
+
+      assert {:error, msg} =
+               GenServer.call(fork, {:find_and_replace, "target", "changed", {0, 0}})
+
+      assert msg =~ "edit outside boundary"
+      refute Fork.dirty?(fork)
+      assert Fork.version(fork) == 0
+
+      assert {:ok, "applied"} =
+               GenServer.call(fork, {:find_and_replace, "target", "changed", {1, 1}})
+
+      assert Fork.content(fork) == "line1\nchanged\nline3"
+      assert Fork.dirty?(fork)
+      assert Fork.version(fork) == 1
+    end
+
+    test "find_and_replace_batch honors boundaries per edit" do
+      parent = start_parent!("one\ntwo\nthree")
+
+      {:ok, fork} = Fork.create(parent)
+      edits = [{"one", "1"}, {"two", "2"}, {"three", "3"}]
+      {:ok, results} = GenServer.call(fork, {:find_and_replace_batch, edits, {1, 1}})
+
+      assert [{:error, _}, {:ok, "applied"}, {:error, _}] = results
+      assert Fork.content(fork) == "one\n2\nthree"
+      assert Fork.dirty?(fork)
+      assert Fork.version(fork) == 1
+    end
+
     test "find_and_replace_batch with all failures does not mark dirty" do
       parent = start_parent!("hello")
 

--- a/test/minga/buffer/replace_test.exs
+++ b/test/minga/buffer/replace_test.exs
@@ -1,0 +1,57 @@
+defmodule Minga.Buffer.ReplaceTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Document
+  alias Minga.Buffer.Replace
+
+  describe "unique/4" do
+    test "replaces a unique match" do
+      doc = Document.new("hello world")
+
+      assert {:ok, new_doc, "applied"} = Replace.unique(doc, "hello", "goodbye")
+      assert Document.content(new_doc) == "goodbye world"
+    end
+
+    test "rejects missing, empty, and ambiguous matches" do
+      doc = Document.new("foo bar foo")
+
+      assert {:error, "old_text not found"} = Replace.unique(doc, "missing", "x")
+      assert {:error, "old_text is empty"} = Replace.unique(doc, "", "x")
+      assert {:error, msg} = Replace.unique(doc, "foo", "x")
+      assert msg =~ "2 times"
+    end
+
+    test "enforces line boundaries against the unique match" do
+      doc = Document.new("line1\ntarget\nline3")
+
+      assert {:error, msg} = Replace.unique(doc, "target", "changed", {0, 0})
+      assert msg =~ "edit outside boundary"
+
+      assert {:ok, new_doc, "applied"} = Replace.unique(doc, "target", "changed", {1, 1})
+      assert Document.content(new_doc) == "line1\nchanged\nline3"
+    end
+  end
+
+  describe "batch/3" do
+    test "applies edits sequentially and reports per-edit results" do
+      doc = Document.new("one two three")
+
+      {new_doc, results, any_applied?} =
+        Replace.batch(doc, [{"one", "1"}, {"missing", "x"}, {"three", "3"}])
+
+      assert any_applied?
+      assert results == [{:ok, "applied"}, {:error, "old_text not found"}, {:ok, "applied"}]
+      assert Document.content(new_doc) == "1 two 3"
+    end
+
+    test "keeps the document unchanged when every edit fails" do
+      doc = Document.new("hello")
+
+      {new_doc, results, any_applied?} = Replace.batch(doc, [{"missing", "x"}, {"", "y"}])
+
+      refute any_applied?
+      assert results == [{:error, "old_text not found"}, {:error, "old_text is empty"}]
+      assert Document.content(new_doc) == "hello"
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR
Buffer find-and-replace semantics now live in a shared pure module instead of being duplicated in `Buffer.Server` and `Buffer.Fork`. Forks now honor edit boundaries with the same behavior as the live buffer process.

## Context
This is the next buffer architecture slice after extracting pure edit operations. `Buffer.Server` should stay focused on process, undo, dirty-state, event, and persistence concerns; replacement rules belong in pure buffer-domain code that every caller can share.

## Changes
- Added `Minga.Buffer.Replace` for unique find-and-replace and sequential batch replace semantics.
- Refactored `Minga.Buffer.Server` to delegate replacement matching, ambiguity handling, empty-search validation, and boundary checks to the pure module.
- Refactored `Minga.Buffer.Fork` to use the same replacement path, removing its duplicated matching logic.
- Changed fork replacement calls to honor the supplied boundary instead of ignoring it.
- Added pure module tests plus fork boundary coverage for single and batch replacement calls.

## Verification
- `mix test.debug test/minga/buffer/replace_test.exs test/minga/buffer/fork_test.exs test/minga/buffer/server_test.exs`
- `mix test.llm test/minga/buffer`
- `mix test.llm test/minga_agent/buffer_fork_store_test.exs test/minga_agent/tool_router_test.exs test/minga_agent/tools/edit_file_test.exs test/minga_agent/tools/multi_edit_file_test.exs`
- `mix compile --warnings-as-errors`
- `make lint`
- `mix test.llm`
- Final reviewer gate: PASS

## Acceptance Criteria Addressed
- Shared buffer find-and-replace logic extracted into a pure module ✅
- `Buffer.Server` and `Buffer.Fork` use the shared replacement semantics ✅
- Public APIs remain stable ✅
- Fork replacement boundaries are now tested and honored ✅
