### PR TITLE
Fix deep file tree row readability

### DIFF
--- a/lib/minga/core/unicode.ex
+++ b/lib/minga/core/unicode.ex
@@ -401,6 +401,68 @@ defmodule Minga.Core.Unicode do
   end
 
   @doc """
+  Truncates a string to fit within `max_width` display columns.
+
+  The result never splits a grapheme and never exceeds the requested display width. Wide graphemes that would cross the boundary are omitted.
+
+  ## Examples
+
+      iex> Minga.Core.Unicode.truncate_display_width("hello", 3)
+      "hel"
+
+      iex> Minga.Core.Unicode.truncate_display_width("你好world", 5)
+      "你好w"
+  """
+  @spec truncate_display_width(String.t(), non_neg_integer()) :: String.t()
+  def truncate_display_width(_text, 0), do: ""
+
+  def truncate_display_width(text, max_width) when is_binary(text) and max_width > 0 do
+    do_truncate_display_width(text, max_width, 0, [])
+  end
+
+  @spec do_truncate_display_width(String.t(), non_neg_integer(), non_neg_integer(), [String.t()]) ::
+          String.t()
+  defp do_truncate_display_width("", _max_width, _width, acc) do
+    acc |> Enum.reverse() |> IO.iodata_to_binary()
+  end
+
+  defp do_truncate_display_width(text, max_width, width, acc) do
+    case String.next_grapheme(text) do
+      {grapheme, rest} ->
+        next_width = width + grapheme_width(grapheme)
+
+        if next_width > max_width do
+          acc |> Enum.reverse() |> IO.iodata_to_binary()
+        else
+          do_truncate_display_width(rest, max_width, next_width, [grapheme | acc])
+        end
+
+      nil ->
+        acc |> Enum.reverse() |> IO.iodata_to_binary()
+    end
+  end
+
+  @doc """
+  Pads or truncates a string so the result occupies exactly `target_width` display columns.
+
+  Use this at rendering boundaries where row segments must align in terminal columns even when text contains CJK, emoji, or combining characters.
+
+  ## Examples
+
+      iex> Minga.Core.Unicode.pad_display_trailing("hi", 4)
+      "hi  "
+
+      iex> Minga.Core.Unicode.pad_display_trailing("你好", 3)
+      "你 "
+  """
+  @spec pad_display_trailing(String.t(), non_neg_integer()) :: String.t()
+  def pad_display_trailing(text, target_width) when is_binary(text) do
+    truncated = truncate_display_width(text, target_width)
+    padding_width = target_width - display_width(truncated)
+    truncated <> String.duplicate(" ", padding_width)
+  end
+
+  @doc """
   Converts a display column (terminal columns) to a byte offset.
 
   Walks graphemes from the start of `text`, accumulating display width,

--- a/lib/minga_editor/shell/traditional/tree_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tree_renderer.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   """
 
   alias Minga.Core.Face
+  alias Minga.Core.Unicode
   alias Minga.Language
   alias Minga.Project.FileTree
   alias MingaEditor.DisplayList
@@ -27,6 +28,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   @disclosure_expanded "▾ "
   @disclosure_collapsed "▸ "
   @disclosure_file "  "
+  @guide_ellipsis "… "
+  @name_ellipsis "…"
+  @minimum_name_width 4
+  @minimum_editing_text_width 1
 
   # Nerd Font folder icons (nf-md-folder / nf-md-folder-open)
   @folder_closed "\u{F024B}"
@@ -126,7 +131,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     # Header: project directory name with folder icon
     project_name = Path.basename(tree.root)
     header_text = " #{@folder_open} #{project_name}/"
-    header_display = String.slice(header_text, 0, width) |> String.pad_trailing(width)
+    header_display = Unicode.pad_display_trailing(header_text, width)
 
     header = [
       DisplayList.draw(
@@ -186,52 +191,50 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     is_dirty = tree_row.dirty?
     diagnostic_text = diagnostic_indicator_text(tree_row.diagnostics)
 
-    # Build the structure columns from ancestor guides plus a dedicated disclosure column.
-    guide_prefix = build_guides(tree_row.guides, tree_row.last_child?)
-    disclosure = disclosure_marker(tree_row)
-    structure_prefix = guide_prefix <> disclosure
-
-    # Pick the icon and its color
-    {icon, icon_color} = entry_icon(tree_row)
-
-    # Entry name (dirs get trailing slash)
+    # Entry name (dirs get trailing slash). Middle truncation keeps the useful beginning and extension visible.
     name = if tree_row.directory?, do: tree_row.name <> "/", else: tree_row.name
 
-    # Compose the full line: structure columns + icon + space + name
-    prefix = structure_prefix <> icon <> " "
-    prefix_width = String.length(prefix)
+    # Reserve right-side indicators before spending width on deep indentation.
+    fixed_prefix_width = fixed_prefix_width(tree_row)
 
-    # Right-side indicators: [diagnostic] [modified_dot] [git_status].
-    # Fit them into the available suffix so narrow panes never let badges overlap the row prefix.
     {diagnostic_text, is_dirty, file_git_status} =
-      fit_indicators(diagnostic_text, is_dirty, tree_row.git_status, max(width - prefix_width, 0))
+      fit_indicators(
+        diagnostic_text,
+        is_dirty,
+        tree_row.git_status,
+        max(width - fixed_prefix_width, 0)
+      )
 
-    diagnostic_width = String.length(diagnostic_text)
+    diagnostic_width = Unicode.display_width(diagnostic_text)
     git_width = if file_git_status, do: 2, else: 0
     dirty_width = if is_dirty, do: 1, else: 0
     indicator_width = diagnostic_width + dirty_width + git_width
 
-    # Truncate name to fit, accounting for indicator space
-    max_name_len = max(width - prefix_width - indicator_width, 0)
-    display_name = String.slice(name, 0, max_name_len)
+    {prefix, structure_prefix, icon, icon_color} =
+      row_prefix(tree_row, width, indicator_width, @minimum_name_width)
+
+    prefix_width = Unicode.display_width(prefix)
+
+    # Truncate name to fit in display columns, accounting for wide unicode and indicator space.
+    name_pad_width = max(width - prefix_width - indicator_width, 0)
+    display_name = truncate_name(name, name_pad_width)
 
     # Build draw commands: structure, icon, name, diagnostic marker, dirty marker, and git marker.
     guide_style = guide_draw_style(is_cursor, focused, theme)
     icon_style = icon_draw_style(icon_color, is_cursor, focused, theme)
     name_style = name_draw_style(tree_row, is_cursor, tree_row.active?, focused, theme)
-    structure_len = String.length(structure_prefix)
+    structure_width = Unicode.display_width(structure_prefix)
 
     draws = []
     draws = draws ++ [DisplayList.draw(row, col, structure_prefix, guide_style)]
 
     # Icon segment
-    icon_col = col + structure_len
+    icon_col = col + structure_width
     draws = draws ++ [DisplayList.draw(row, icon_col, icon <> " ", icon_style)]
 
     # Name segment: pad to fill space between name and indicators
     name_col = col + prefix_width
-    name_pad_width = max(width - prefix_width - indicator_width, 0)
-    padded_name = String.pad_trailing(display_name, name_pad_width)
+    padded_name = Unicode.pad_display_trailing(display_name, name_pad_width)
     draws = draws ++ [DisplayList.draw(row, name_col, padded_name, name_style)]
 
     # Right-aligned indicators start here.
@@ -265,12 +268,6 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     %{col_off: col, width: width, theme: theme} = opts
     editing = tree_row.editing
 
-    # Build the same structure columns as normal rows so inline editing does not shift columns.
-    guide_prefix = build_guides(tree_row.guides, tree_row.last_child?)
-    disclosure = disclosure_marker(tree_row)
-    structure_prefix = guide_prefix <> disclosure
-    structure_len = String.length(structure_prefix)
-
     # Type indicator: file icon for new file, folder icon for new folder,
     # the entry's own icon for rename
     {icon, _icon_color} =
@@ -280,8 +277,18 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
         :rename -> entry_icon(tree_row)
       end
 
+    # Build the same structure columns as normal rows, but compact deep guides before they hide the edit text.
+    disclosure = disclosure_marker(tree_row)
+    fixed_prefix = disclosure <> icon <> " "
+
+    guide_width =
+      max(width - Unicode.display_width(fixed_prefix) - @minimum_editing_text_width, 0)
+
+    guide_prefix = build_guides(tree_row.guides, guide_width)
+    structure_prefix = guide_prefix <> disclosure
+    structure_width = Unicode.display_width(structure_prefix)
     prefix = structure_prefix <> icon <> " "
-    prefix_len = String.length(prefix)
+    prefix_width = Unicode.display_width(prefix)
 
     # Editing text with cursor
     text = editing.text
@@ -289,12 +296,9 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     display_text = text <> cursor_char
 
     # Truncate to fit
-    max_text_len = max(width - prefix_len, 0)
-    display_text = String.slice(display_text, 0, max_text_len)
-
-    # Pad to fill the row
-    total_drawn = prefix_len + String.length(display_text)
-    pad = if total_drawn < width, do: String.duplicate(" ", width - total_drawn), else: ""
+    text_width = max(width - prefix_width, 0)
+    display_text = Unicode.truncate_display_width(display_text, text_width)
+    padded_text = Unicode.pad_display_trailing(display_text, text_width)
 
     # Editing row uses inverse video (selection highlight)
     editing_bg = theme.tree.dir_fg
@@ -307,23 +311,143 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     draws = []
     draws = draws ++ [DisplayList.draw(row, col, structure_prefix, guide_style)]
 
-    icon_col = col + structure_len
+    icon_col = col + structure_width
     draws = draws ++ [DisplayList.draw(row, icon_col, icon <> " ", icon_style)]
 
-    text_col = col + prefix_len
-    draws = draws ++ [DisplayList.draw(row, text_col, display_text <> pad, text_style)]
+    text_col = col + prefix_width
+    draws = draws ++ [DisplayList.draw(row, text_col, padded_text, text_style)]
 
     draws
   end
 
   # ── Indent guides ──────────────────────────────────────────────────────
 
-  @spec build_guides([boolean()], boolean()) :: String.t()
-  defp build_guides(ancestor_guides, _last_child?) do
-    Enum.map_join(ancestor_guides, fn
-      true -> @guide_pipe
-      false -> @guide_blank
-    end)
+  @spec fixed_prefix_width(Row.t()) :: non_neg_integer()
+  defp fixed_prefix_width(tree_row) do
+    {icon, _icon_color} = entry_icon(tree_row)
+    Unicode.display_width(disclosure_marker(tree_row) <> icon <> " ")
+  end
+
+  @spec row_prefix(Row.t(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          {String.t(), String.t(), String.t(), non_neg_integer()}
+  defp row_prefix(tree_row, row_width, indicator_width, minimum_name_width) do
+    disclosure = disclosure_marker(tree_row)
+    {icon, icon_color} = entry_icon(tree_row)
+    fixed_prefix = disclosure <> icon <> " "
+
+    guide_width =
+      max(
+        row_width - Unicode.display_width(fixed_prefix) - indicator_width - minimum_name_width,
+        0
+      )
+
+    guide_prefix = build_guides(tree_row.guides, guide_width)
+    structure_prefix = guide_prefix <> disclosure
+    prefix = structure_prefix <> icon <> " "
+
+    {prefix, structure_prefix, icon, icon_color}
+  end
+
+  @spec build_guides([boolean()], non_neg_integer()) :: String.t()
+  defp build_guides(_ancestor_guides, 0), do: ""
+
+  defp build_guides(ancestor_guides, max_width) do
+    ancestor_guides
+    |> guide_text()
+    |> maybe_compact_guides(ancestor_guides, max_width)
+  end
+
+  @spec maybe_compact_guides(String.t(), [boolean()], non_neg_integer()) :: String.t()
+  defp maybe_compact_guides(full_guides, ancestor_guides, max_width) do
+    if Unicode.display_width(full_guides) <= max_width do
+      full_guides
+    else
+      compact_guides(ancestor_guides, max_width)
+    end
+  end
+
+  @spec compact_guides([boolean()], non_neg_integer()) :: String.t()
+  defp compact_guides([], _max_width), do: ""
+  defp compact_guides(_ancestor_guides, max_width) when max_width < 2, do: ""
+
+  defp compact_guides(ancestor_guides, max_width) do
+    suffix_width = max(max_width - Unicode.display_width(@guide_ellipsis), 0)
+
+    suffix =
+      ancestor_guides
+      |> take_suffix_guides(div(suffix_width, 2))
+      |> guide_text()
+
+    Unicode.truncate_display_width(@guide_ellipsis <> suffix, max_width)
+  end
+
+  @spec take_suffix_guides([boolean()], non_neg_integer()) :: [boolean()]
+  defp take_suffix_guides(_ancestor_guides, 0), do: []
+  defp take_suffix_guides(ancestor_guides, count), do: Enum.take(ancestor_guides, -count)
+
+  @spec guide_text([boolean()]) :: String.t()
+  defp guide_text(ancestor_guides) do
+    Enum.map_join(ancestor_guides, &guide_segment/1)
+  end
+
+  @spec guide_segment(boolean()) :: String.t()
+  defp guide_segment(true), do: @guide_pipe
+  defp guide_segment(false), do: @guide_blank
+
+  @spec truncate_name(String.t(), non_neg_integer()) :: String.t()
+  defp truncate_name(_name, 0), do: ""
+
+  defp truncate_name(name, max_width) do
+    if Unicode.display_width(name) <= max_width do
+      name
+    else
+      truncate_name_middle(name, max_width)
+    end
+  end
+
+  @spec truncate_name_middle(String.t(), non_neg_integer()) :: String.t()
+  defp truncate_name_middle(name, 1), do: Unicode.truncate_display_width(name, 1)
+
+  defp truncate_name_middle(name, max_width) do
+    ellipsis_width = Unicode.display_width(@name_ellipsis)
+    available_width = max(max_width - ellipsis_width, 0)
+    suffix_width = suffix_width_for_name(name, available_width)
+    prefix_width = available_width - suffix_width
+
+    Unicode.truncate_display_width(name, prefix_width) <>
+      @name_ellipsis <> trailing_display_width(name, suffix_width)
+  end
+
+  @spec suffix_width_for_name(String.t(), non_neg_integer()) :: non_neg_integer()
+  defp suffix_width_for_name(_name, 0), do: 0
+
+  defp suffix_width_for_name(name, available_width) do
+    extension_width = name |> Path.extname() |> Unicode.display_width()
+    available_width |> div(2) |> max(extension_width) |> min(available_width)
+  end
+
+  @spec trailing_display_width(String.t(), non_neg_integer()) :: String.t()
+  defp trailing_display_width(_text, 0), do: ""
+
+  defp trailing_display_width(text, max_width) do
+    text
+    |> String.graphemes()
+    |> Enum.reverse()
+    |> take_trailing_graphemes(max_width, 0, [])
+  end
+
+  @spec take_trailing_graphemes([String.t()], non_neg_integer(), non_neg_integer(), [String.t()]) ::
+          String.t()
+  defp take_trailing_graphemes([], _max_width, _width, acc), do: Enum.join(acc)
+
+  defp take_trailing_graphemes([grapheme | rest], max_width, width, acc) do
+    next_width = width + Unicode.grapheme_width(grapheme)
+
+    if next_width > max_width do
+      Enum.join(acc)
+    else
+      take_trailing_graphemes(rest, max_width, next_width, [grapheme | acc])
+    end
   end
 
   @spec disclosure_marker(Row.t()) :: String.t()
@@ -395,8 +519,8 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   defp fit_diagnostic_indicator("", available_width), do: {"", available_width}
 
   defp fit_diagnostic_indicator(text, available_width) do
-    fitted = String.slice(text, 0, available_width)
-    {fitted, available_width - String.length(fitted)}
+    fitted = Unicode.truncate_display_width(text, available_width)
+    {fitted, available_width - Unicode.display_width(fitted)}
   end
 
   @spec fit_dirty_indicator(boolean(), non_neg_integer()) :: {boolean(), non_neg_integer()}

--- a/macos/Sources/Views/FileTreeRowView.swift
+++ b/macos/Sources/Views/FileTreeRowView.swift
@@ -17,6 +17,8 @@ struct FileTreeRowView: View {
     let onEditCommit: (String) -> Void
     let onEditCancel: () -> Void
 
+    @Environment(\.displayScale) private var displayScale
+
     var body: some View {
         rowContent
             .padding(.leading, leadingPadding)
@@ -59,13 +61,14 @@ struct FileTreeRowView: View {
                     .font(.system(size: 12, weight: entry.showsActiveAccent ? .semibold : .regular))
                     .foregroundStyle(nameColor)
                     .lineLimit(1)
-                    .truncationMode(.tail)
+                    .truncationMode(.middle)
+                    .layoutPriority(0)
 
                 Spacer(minLength: 0)
 
-                diagnosticMarker
-                dirtyMarker
-                gitStatusDot
+                statusCluster
+                    .fixedSize(horizontal: true, vertical: false)
+                    .layoutPriority(2)
             }
         }
     }
@@ -81,6 +84,15 @@ struct FileTreeRowView: View {
                 .frame(width: chevronWidth, height: rowHeight)
         } else {
             Spacer().frame(width: chevronWidth)
+        }
+    }
+
+    @ViewBuilder
+    private var statusCluster: some View {
+        HStack(spacing: 0) {
+            diagnosticMarker
+            dirtyMarker
+            gitStatusDot
         }
     }
 
@@ -163,9 +175,10 @@ struct FileTreeRowView: View {
         if !entry.guides.isEmpty {
             Canvas { context, size in
                 for (level, shouldDraw) in entry.guides.enumerated() where shouldDraw {
-                    let x = 8 + CGFloat(level) * indentWidth + chevronWidth / 2
-                    let rect = CGRect(x: x, y: 0, width: 1, height: size.height)
-                    context.fill(Path(rect), with: .color(theme.treeGuideFg))
+                    let x = pixelSnapped(guideX(for: level))
+                    let lineWidth = max(1 / displayScale, 0.5)
+                    let rect = CGRect(x: x, y: 0, width: lineWidth, height: size.height)
+                    context.fill(Path(rect), with: .color(theme.treeGuideFg.opacity(indentGuideOpacity)))
                 }
             }
             .allowsHitTesting(false)
@@ -203,8 +216,28 @@ struct FileTreeRowView: View {
             .padding(.horizontal, 4)
     }
 
-    private var leadingPadding: CGFloat {
-        8 + CGFloat(entry.depth) * indentWidth
+    var leadingPadding: CGFloat {
+        8 + depthOffset(for: entry.depth)
+    }
+
+    var indentGuideOpacity: Double {
+        if entry.isSelected || isDropTarget { return 0.22 }
+        return 0.42
+    }
+
+    private func guideX(for level: Int) -> CGFloat {
+        8 + depthOffset(for: level) + chevronWidth / 2
+    }
+
+    private func depthOffset(for depth: Int) -> CGFloat {
+        let fullIndentDepth = min(depth, 4)
+        let compactIndentDepth = max(depth - 4, 0)
+        return CGFloat(fullIndentDepth) * indentWidth + CGFloat(compactIndentDepth) * indentWidth * 0.55
+    }
+
+    private func pixelSnapped(_ value: CGFloat) -> CGFloat {
+        guard displayScale > 0 else { return value }
+        return (value * displayScale).rounded(.toNearestOrAwayFromZero) / displayScale
     }
 
     private var iconColor: Color {

--- a/macos/Sources/Views/FileTreeView.swift
+++ b/macos/Sources/Views/FileTreeView.swift
@@ -61,7 +61,7 @@ struct FileTreeView: View {
             .onPreferenceChange(ScrollOffsetKey.self) { value in
                 scrollOffset = value
             }
-            .overlay(alignment: .top) {
+            .safeAreaInset(edge: .top, spacing: 0) {
                 stickyParentHeader
             }
             .onChange(of: fileTreeState.selectedIndex) { _, newIndex in
@@ -116,6 +116,9 @@ struct FileTreeView: View {
                     .fill(theme.treeSeparatorFg.opacity(0.3))
                     .frame(height: 1)
             }
+            .background(theme.treeBg)
+            .zIndex(1)
+            .allowsHitTesting(false)
         }
     }
 
@@ -379,7 +382,13 @@ struct FileTreeView: View {
     // MARK: - Layout helpers
 
     private func leadingPadding(_ entry: FileTreeEntry) -> CGFloat {
-        8 + CGFloat(entry.depth) * indentWidth
+        8 + depthOffset(for: entry.depth)
+    }
+
+    private func depthOffset(for depth: Int) -> CGFloat {
+        let fullIndentDepth = min(depth, 4)
+        let compactIndentDepth = max(depth - 4, 0)
+        return CGFloat(fullIndentDepth) * indentWidth + CGFloat(compactIndentDepth) * indentWidth * 0.55
     }
 
 }

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -332,6 +332,34 @@ struct FileTreeRowViewTests {
         #expect(noisyStrings.contains("✖9+"))
     }
 
+    @Test("Deep rows compress indentation before it overwhelms names")
+    @MainActor func deepRowsCompressIndentationBeforeItOverwhelmsNames() throws {
+        let shallow = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, depth: 2, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        let deep = fileTreeRowView(entry: sidebarFileTreeEntry(id: 2, index: 1, depth: 8, icon: "\u{E62D}", name: "very_long_component_view.ex", relPath: "lib/minga_editor/shell/traditional/very_long_component_view.ex"))
+
+        #expect(deep.leadingPadding > shallow.leadingPadding)
+        #expect(deep.leadingPadding < 8 + CGFloat(8) * 14)
+    }
+
+    @Test("Selected rows quiet indent guides")
+    @MainActor func selectedRowsQuietIndentGuides() throws {
+        let normal = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, depth: 4, guides: [true, true, false, true], icon: "\u{E62D}", name: "normal.ex", relPath: "lib/normal.ex"))
+        let selected = fileTreeRowView(entry: sidebarFileTreeEntry(id: 2, index: 1, isSelected: true, depth: 4, guides: [true, true, false, true], icon: "\u{E62D}", name: "selected.ex", relPath: "lib/selected.ex"))
+
+        #expect(selected.indentGuideOpacity < normal.indentGuideOpacity)
+    }
+
+    @Test("Nested rows keep names and status badges as independent views")
+    @MainActor func nestedRowsKeepNamesAndStatusBadgesAsIndependentViews() throws {
+        let row = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, isDirty: true, gitStatus: 1, diagnosticWarningCount: 1, depth: 8, guides: [true, true, false, true, false, true, true, false], icon: "\u{E62D}", name: "非常に長い_component_view.ex", relPath: "lib/minga_editor/shell/traditional/非常に長い_component_view.ex"))
+        let strings = try row.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("非常に長い_component_view.ex"))
+        #expect(strings.contains("⚠"))
+        #expect(strings.contains("●"))
+        #expect(try row.inspect().findAll(ViewType.Shape.self).count >= 1)
+    }
+
     @Test("Selected active and hovered rows keep status markers readable")
     @MainActor func selectedActiveAndHoveredRowsKeepStatusMarkersReadable() throws {
         let selected = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, isSelected: true, isFocused: false, isDirty: true, gitStatus: 1, diagnosticWarningCount: 1, icon: "\u{E62D}", name: "selected.ex", relPath: "selected.ex"))
@@ -434,6 +462,7 @@ private func sidebarFileTreeEntry(
     editingType: UInt8 = 0xFF,
     editingText: String = "",
     depth: Int = 0,
+    guides: [Bool] = [],
     icon: String,
     name: String,
     relPath: String
@@ -442,6 +471,6 @@ private func sidebarFileTreeEntry(
                   isFocused: isFocused, isActive: isActive, isDirty: isDirty, isEditing: isEditing,
                   isLastChild: false, depth: depth, gitStatus: gitStatus, diagnosticErrorCount: diagnosticErrorCount,
                   diagnosticWarningCount: diagnosticWarningCount, diagnosticInfoCount: diagnosticInfoCount, diagnosticHintCount: diagnosticHintCount,
-                  guides: [], icon: icon, name: name, relPath: relPath, path: relPath,
+                  guides: guides, icon: icon, name: name, relPath: relPath, path: relPath,
                   editingType: editingType, editingText: editingText)
 }

--- a/test/minga/buffer/unicode_test.exs
+++ b/test/minga/buffer/unicode_test.exs
@@ -348,6 +348,34 @@ defmodule Minga.Core.UnicodeTest do
     end
   end
 
+  # ── truncate_display_width/2 and pad_display_trailing/2 ──────────────────
+
+  describe "display-width truncation helpers" do
+    test "truncate_display_width respects wide grapheme widths" do
+      assert Unicode.truncate_display_width("你好world", 5) == "你好w"
+      assert Unicode.display_width(Unicode.truncate_display_width("你好world", 5)) == 5
+    end
+
+    test "truncate_display_width never splits a wide grapheme" do
+      assert Unicode.truncate_display_width("你", 1) == ""
+      assert Unicode.truncate_display_width("你a", 3) == "你a"
+    end
+
+    test "pad_display_trailing pads to the requested display width" do
+      padded = Unicode.pad_display_trailing("你", 3)
+
+      assert Unicode.display_width(padded) == 3
+      assert padded == "你 "
+    end
+
+    test "pad_display_trailing truncates before padding" do
+      padded = Unicode.pad_display_trailing("你好", 3)
+
+      assert Unicode.display_width(padded) == 3
+      assert padded == "你 "
+    end
+  end
+
   # ── byte_col_for_grapheme/2 ──────────────────────────────────────────────
 
   describe "byte_col_for_grapheme/2" do

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Core.Unicode
   alias Minga.Project.FileTree
   alias MingaEditor.FileTree.Diagnostics, as: RowDiagnostics
   alias MingaEditor.FileTree.Row
@@ -399,6 +400,78 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       assert draw_col(dirty_draw) < draw_col(git_draw)
     end
 
+    test "deep nested unicode rows preserve basename tail and status within display width", %{
+      tmp_dir: tmp_dir
+    } do
+      path = Path.join(tmp_dir, "lib/minga_editor/shell/traditional/非常に長い_component_view.ex")
+
+      row =
+        Row.new(
+          id: path,
+          path: path,
+          relative_path: "lib/minga_editor/shell/traditional/非常に長い_component_view.ex",
+          name: "非常に長い_component_view.ex",
+          directory?: false,
+          expanded?: false,
+          selected?: true,
+          focused?: true,
+          active?: false,
+          dirty?: true,
+          git_status: :modified,
+          diagnostics: RowDiagnostics.new({0, 1, 0, 0}),
+          depth: 8,
+          guides: [true, true, false, true, false, true, true, false],
+          last_child?: true
+        )
+
+      draws =
+        TreeRenderer.render(%RenderInput{
+          tree: FileTree.new(tmp_dir, width: 18),
+          rect: {0, 0, 18, 5},
+          focused: true,
+          theme: Theme.get!(:doom_one),
+          active_path: nil,
+          rows: [row]
+        })
+
+      row_text = rendered_row_text(draws, 1, 18)
+
+      assert Unicode.display_width(row_text) <= 18
+      assert String.contains?(row_text, "…")
+      assert String.contains?(row_text, ".ex")
+      assert draw_matching(draws, "⚠") != nil
+      assert draw_matching(draws, "●") != nil
+      assert draw_matching(draws, " ●") != nil
+    end
+
+    test "deep nested fixture renders long unicode children within narrow tree width", %{
+      tmp_dir: tmp_dir
+    } do
+      tree = nested_fixture_tree(tmp_dir, width: 18)
+
+      target_path =
+        Path.join(tmp_dir, "lib/minga_editor/shell/traditional/非常に長い_component_view.ex")
+
+      draws =
+        TreeRenderer.render(%RenderInput{
+          tree: tree,
+          rect: {0, 0, 18, 12},
+          focused: false,
+          theme: Theme.get!(:doom_one),
+          active_path: nil,
+          git_status: %{target_path => :modified},
+          dirty_paths: MapSet.new([target_path])
+        })
+
+      row_draws = Enum.filter(draws, fn {_r, _c, text, _s} -> String.contains?(text, ".ex") end)
+
+      assert row_draws != []
+
+      for {row, _col, _text, _style} <- row_draws do
+        assert Unicode.display_width(rendered_row_text(draws, row, 18)) <= 18
+      end
+    end
+
     test "large diagnostic counts are capped before narrow-row fitting", %{tmp_dir: tmp_dir} do
       row =
         semantic_file_row(tmp_dir,
@@ -437,6 +510,35 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       assert style.bg == theme.tree.separator_fg
       refute style.bg == theme.tree.cursor_bg
     end
+  end
+
+  defp nested_fixture_tree(tmp_dir, opts) do
+    width = Keyword.fetch!(opts, :width)
+    deep_dir = Path.join(tmp_dir, "lib/minga_editor/shell/traditional")
+    sibling_dir = Path.join(tmp_dir, "lib/minga_editor/shell/board")
+
+    File.mkdir_p!(deep_dir)
+    File.mkdir_p!(sibling_dir)
+
+    File.write!(
+      Path.join(deep_dir, "非常に長い_component_view.ex"),
+      "defmodule ComponentView do\nend\n"
+    )
+
+    File.write!(Path.join(sibling_dir, "card.ex"), "defmodule Card do\nend\n")
+
+    FileTree.new(tmp_dir, width: width)
+    |> FileTree.expand_path(Path.join(tmp_dir, "lib"))
+    |> FileTree.expand_path(Path.join(tmp_dir, "lib/minga_editor"))
+    |> FileTree.expand_path(Path.join(tmp_dir, "lib/minga_editor/shell"))
+    |> FileTree.expand_path(deep_dir)
+  end
+
+  defp rendered_row_text(draws, row, width) do
+    draws
+    |> Enum.filter(fn {draw_row, col, _t, _s} -> draw_row == row and col < width end)
+    |> Enum.sort_by(fn {_r, col, _t, _s} -> col end)
+    |> Enum.map_join(fn {_r, _c, text, _s} -> text end)
   end
 
   defp semantic_file_row(tmp_dir, attrs) do


### PR DESCRIPTION
# TL;DR
Deeply nested file-tree rows now preserve useful filenames and status indicators instead of letting indentation consume the row. The TUI uses display-width-aware truncation, and the macOS sidebar keeps status badges in a fixed cluster with quieter deep indentation.

Closes #1645

## Context
This PR is part of the file-tree polish epic. The goal is to make real project paths like `lib/minga_editor/shell/traditional/...` readable in both the terminal and native macOS sidebar.

## Changes
- Added Unicode display-width truncation and padding helpers for terminal-column-safe file-tree rendering.
- Updated the TUI tree renderer to reserve diagnostic, dirty, and git indicators before spending width on indentation.
- Switched long TUI filenames to middle truncation that keeps the extension visible when space is tight.
- Compacted deep TUI guide columns so nested basenames still get visible space.
- Updated the macOS row layout so the filename truncates in the middle while diagnostic, dirty, and git badges stay separate and fixed-size.
- Reduced deep macOS indentation growth, softened selected-row indent guides, and pixel-snapped guide lines.
- Moved the sticky parent header into a top safe-area inset so it does not cover scroll content.

## Verification
- `mix test.llm test/minga_editor/shell/traditional/tree_renderer_test.exs test/minga/buffer/unicode_test.exs`
- `mix swift.build`
- `xcodebuild test -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS'`
- `make lint`
- `mix test.llm`
- `git diff --check`

Manual visual note: this still deserves a quick macOS smoke test with a deeply nested project tree before merge, especially sticky-parent scrolling behavior.

## Acceptance Criteria Addressed
- Deeply nested files preserve the basename and visible status indicators in both frontends. ✅
- TUI truncation accounts for display width, not only byte count or grapheme count. ✅
- macOS nested rows keep chevrons, icons, names, and status badges aligned at common depths. ✅
- Indent guides are subtle and do not muddy selected or active rows. ✅
- Sticky parent context in macOS does not obscure content while scrolling. ✅
- Tests cover nested fixtures, unicode names, narrow widths, and status indicators on truncated rows. ✅
