### PR TITLE
refactor(log): move messages buffer owner

### DIFF
--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -20,7 +20,7 @@ defmodule Minga.Application do
       │   └── Minga.Language.Filetype.Registry
       ├── Minga.Buffer.Registry (Registry, :unique)
       ├── Minga.Buffer.Supervisor (DynamicSupervisor, one_for_one)
-      ├── Minga.Buffer.Messages           (singleton *Messages* buffer owner)
+      ├── Minga.Log.MessagesBuffer           (singleton *Messages* buffer owner)
       ├── Minga.Services.Supervisor (rest_for_one)
       │   ├── Minga.Services.Independent (one_for_one)
       │   │   ├── Minga.Git.Tracker
@@ -62,8 +62,8 @@ defmodule Minga.Application do
   @spec start(Application.start_type(), term()) :: {:ok, pid()} | {:error, term()}
   def start(_type, _args) do
     # Create the log buffer ETS table owned by the supervisor process.
-    # This table survives Editor crashes so the LoggerHandler can queue
-    # messages while the Editor is restarting. The Editor flushes it on init.
+    # This table survives process crashes so LoggerHandler can queue messages
+    # before Minga.Log.MessagesBuffer subscribes and drains it on init.
     Minga.LoggerHandler.ensure_buffer_table()
     Grammar.init_registry()
     DevHandler.attach()
@@ -81,7 +81,7 @@ defmodule Minga.Application do
     end
 
     # Install the :log_message broadcast handler before the supervision
-    # tree starts so headless and pre-editor logs reach Minga.Buffer.Messages
+    # tree starts so headless and pre-editor logs reach Minga.Log.MessagesBuffer
     # via the same path as logs from a running editor.
     Minga.LoggerHandler.install_messages_handler()
 
@@ -92,7 +92,7 @@ defmodule Minga.Application do
         Minga.Foundation.Supervisor,
         {Registry, keys: :unique, name: Minga.Buffer.Registry},
         {DynamicSupervisor, name: Minga.Buffer.Supervisor, strategy: :one_for_one},
-        Minga.Buffer.Messages
+        Minga.Log.MessagesBuffer
       ] ++
         if minimal? do
           []

--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -43,15 +43,6 @@ defmodule Minga.Buffer do
   defdelegate pid_for_path(path), to: BufferProcess
 
   @doc """
-  Returns the pid of the BEAM-wide singleton `*Messages*` buffer.
-
-  Available in headless mode, before any editor exists. Returns `nil`
-  only if `Minga.Buffer.Messages` is not running (e.g. boot ordering bug).
-  """
-  @spec messages() :: pid() | nil
-  defdelegate messages(), to: Minga.Buffer.Messages, as: :pid
-
-  @doc """
   Returns the pid for a buffer at `path`, starting one if it doesn't exist.
 
   If a buffer is already registered for `path`, returns its pid immediately.

--- a/lib/minga/log.ex
+++ b/lib/minga/log.ex
@@ -66,6 +66,10 @@ defmodule Minga.Log do
     distribution: :log_level_distribution
   }
 
+  @doc "Returns the pid of the BEAM-wide singleton `*Messages*` buffer."
+  @spec messages_buffer() :: pid() | nil
+  def messages_buffer, do: Minga.Log.MessagesBuffer.pid()
+
   @doc "Logs a debug message for the given subsystem (if its level permits)."
   @spec debug(subsystem(), String.t() | (-> String.t())) :: :ok
   def debug(subsystem, message_or_fun) do

--- a/lib/minga/log/messages_buffer.ex
+++ b/lib/minga/log/messages_buffer.ex
@@ -1,4 +1,4 @@
-defmodule Minga.Buffer.Messages do
+defmodule Minga.Log.MessagesBuffer do
   @moduledoc """
   Owner of the BEAM-wide singleton `*Messages*` buffer.
 

--- a/lib/minga/logger_handler.ex
+++ b/lib/minga/logger_handler.ex
@@ -181,7 +181,7 @@ defmodule Minga.LoggerHandler do
 
     # Buffer when the Events registry isn't yet up (very early boot, before
     # Foundation.Supervisor has started) or when no subscribers are listening
-    # yet (Minga.Buffer.Messages hasn't booted). Once the wrapper subscribes,
+    # yet (Minga.Log.MessagesBuffer hasn't booted). Once the wrapper subscribes,
     # broadcasts reach it directly and the ETS buffer is drained on its init.
     if has_subscribers?() do
       event_level = if level in [:warning, :error], do: :warning, else: :info
@@ -203,11 +203,11 @@ defmodule Minga.LoggerHandler do
     # isn't started yet, which is expected during the very first phase
     # of Application boot. Treat it as "no subscribers"; the entry will
     # land in the LoggerHandler ETS pre-buffer and get drained by
-    # Minga.Buffer.Messages on init.
+    # Minga.Log.MessagesBuffer on init.
     ArgumentError -> false
   end
 
-  # ── Buffer for messages during Editor downtime ─────────────────────────────
+  # ── Buffer messages until the messages buffer subscriber is ready ──────────
 
   @spec buffer_message(String.t(), atom()) :: :ok
   defp buffer_message(text, level) do

--- a/lib/minga/runtime.ex
+++ b/lib/minga/runtime.ex
@@ -11,7 +11,7 @@ defmodule Minga.Runtime do
       ├── Minga.Foundation.Supervisor
       ├── Minga.Buffer.Registry
       ├── Minga.Buffer.Supervisor
-      ├── Minga.Buffer.Messages
+      ├── Minga.Log.MessagesBuffer
       ├── Minga.Services.Supervisor
       └── MingaAgent.Supervisor
 
@@ -34,7 +34,7 @@ defmodule Minga.Runtime do
       Minga.Foundation.Supervisor,
       {Registry, keys: :unique, name: Minga.Buffer.Registry},
       {DynamicSupervisor, name: Minga.Buffer.Supervisor, strategy: :one_for_one},
-      Minga.Buffer.Messages,
+      Minga.Log.MessagesBuffer,
       Minga.Services.Supervisor,
       MingaAgent.Supervisor
     ]

--- a/lib/minga_editor/message_log.ex
+++ b/lib/minga_editor/message_log.ex
@@ -67,7 +67,7 @@ defmodule MingaEditor.MessageLog do
 
   Used by the editor's `:log_message` subscription so external broadcasts
   (LSP, parser, git, agent) still surface in the GUI Messages tab. The
-  shared buffer is updated by `Minga.Buffer.Messages` directly from the
+  shared buffer is updated by `Minga.Log.MessagesBuffer` directly from the
   same broadcast, so we deliberately do not append twice here.
   """
   @spec append_to_store(EditorState.t(), String.t(), MessageStore.level()) ::

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -60,7 +60,7 @@ defmodule MingaEditor.Startup do
     subscribe_to_parser(Keyword.get(opts, :parser_manager))
     FileWatcherHelpers.maybe_watch_buffer(buffer)
 
-    messages_buf = Minga.Buffer.messages()
+    messages_buf = Minga.Log.messages_buffer()
 
     # Always ensure an active buffer exists. The editor's render pipeline,
     # command dispatch, and input routing all assume buffers.active is a

--- a/test/minga/buffer/auto_save_test.exs
+++ b/test/minga/buffer/auto_save_test.exs
@@ -12,7 +12,7 @@ defmodule Minga.Buffer.AutoSaveTest do
   @moduletag :tmp_dir
   @delay_ms 5_000
 
-  test "dirty file-backed buffer auto-saves after the configured delay", %{tmp_dir: dir} do
+  test "dirty file-backed buffer auto-saves when the debounce timer fires", %{tmp_dir: dir} do
     path = Path.join(dir, "auto-save.txt")
     File.write!(path, "hello")
     {:ok, pid} = BufferProcess.start_link(file_path: path)
@@ -23,6 +23,10 @@ defmodule Minga.Buffer.AutoSaveTest do
 
     try do
       :ok = BufferProcess.insert_text(pid, "!")
+      token = :sys.get_state(pid).auto_save_token
+      assert is_reference(token)
+
+      send(pid, {:auto_save, token})
 
       assert_buffer_saved(path)
       assert_log_contains("Auto-saved: #{Path.relative_to_cwd(path)}")

--- a/test/minga/distribution/cookie_test.exs
+++ b/test/minga/distribution/cookie_test.exs
@@ -3,22 +3,24 @@ defmodule Minga.Distribution.CookieTest do
 
   alias Minga.Distribution.Cookie
 
-  test "read_file/1 accepts a regular owner-only cookie file" do
-    path = temp_cookie_file("abcdefghijklmnopqrstuvwxyz123456")
+  @moduletag :tmp_dir
+
+  test "read_file/1 accepts a regular owner-only cookie file", %{tmp_dir: dir} do
+    path = temp_cookie_file(dir, "abcdefghijklmnopqrstuvwxyz123456")
     File.chmod!(path, 0o600)
 
     assert Cookie.read_file(path) == {:ok, "abcdefghijklmnopqrstuvwxyz123456"}
   end
 
-  test "read_file/1 rejects group or other readable cookie files" do
-    path = temp_cookie_file("abcdefghijklmnopqrstuvwxyz123456")
+  test "read_file/1 rejects group or other readable cookie files", %{tmp_dir: dir} do
+    path = temp_cookie_file(dir, "abcdefghijklmnopqrstuvwxyz123456")
     File.chmod!(path, 0o644)
 
     assert Cookie.read_file(path) == {:error, :insecure_permissions}
   end
 
-  test "read_file/1 rejects symlinks before following the target" do
-    target = temp_cookie_file("abcdefghijklmnopqrstuvwxyz123456")
+  test "read_file/1 rejects symlinks before following the target", %{tmp_dir: dir} do
+    target = temp_cookie_file(dir, "abcdefghijklmnopqrstuvwxyz123456")
     File.chmod!(target, 0o600)
     link = target <> "-link"
     File.ln_s!(target, link)
@@ -36,10 +38,8 @@ defmodule Minga.Distribution.CookieTest do
              Cookie.to_atom("abcdefghijklmnopqrstuvwxyz123456")
   end
 
-  @spec temp_cookie_file(String.t()) :: String.t()
-  defp temp_cookie_file(content) do
-    dir = Path.join(System.tmp_dir!(), "minga-cookie-test-#{System.unique_integer([:positive])}")
-    File.mkdir_p!(dir)
+  @spec temp_cookie_file(String.t(), String.t()) :: String.t()
+  defp temp_cookie_file(dir, content) do
     path = Path.join(dir, "cookie")
     File.write!(path, content)
     path

--- a/test/minga/log/messages_buffer_test.exs
+++ b/test/minga/log/messages_buffer_test.exs
@@ -1,4 +1,4 @@
-defmodule Minga.Buffer.MessagesTest do
+defmodule Minga.Log.MessagesBufferTest do
   @moduledoc """
   Tests for the BEAM-wide singleton `*Messages*` buffer (#1483).
 
@@ -17,38 +17,37 @@ defmodule Minga.Buffer.MessagesTest do
     "#{prefix}-#{System.unique_integer([:positive])}"
   end
 
-  defp wait_for_text(buf, tag, timeout_ms \\ 500) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_for_text(buf, tag, deadline)
+  defp assert_messages_buffer_contains(tag) do
+    :sys.get_state(Minga.Log.MessagesBuffer)
+    content = Buffer.content(Minga.Log.messages_buffer())
+
+    assert String.contains?(content, tag),
+           "expected #{inspect(tag)} in *Messages*; got:\n#{content}"
   end
 
-  defp do_wait_for_text(buf, tag, deadline) do
-    if String.contains?(Buffer.content(buf), tag) do
-      :ok
-    else
-      retry_or_fail(buf, tag, deadline)
-    end
-  end
-
-  defp retry_or_fail(buf, tag, deadline) do
-    if System.monotonic_time(:millisecond) >= deadline do
-      flunk("expected #{inspect(tag)} in *Messages*; got:\n#{Buffer.content(buf)}")
-    else
-      Process.sleep(5)
-      do_wait_for_text(buf, tag, deadline)
+  defp assert_log_message_contains(tag) do
+    receive do
+      {:minga_event, :log_message, %LogMessageEvent{text: message}} ->
+        if String.contains?(message, tag) do
+          :ok
+        else
+          assert_log_message_contains(tag)
+        end
+    after
+      500 -> flunk("expected log message containing #{inspect(tag)}")
     end
   end
 
   describe "singleton lifecycle" do
-    test "Minga.Buffer.messages/0 returns a pid in headless mode (no editor running)" do
+    test "Minga.Log.messages_buffer/0 returns a pid in headless mode (no editor running)" do
       refute Process.whereis(MingaEditor)
-      pid = Buffer.messages()
+      pid = Minga.Log.messages_buffer()
       assert is_pid(pid)
       assert Process.alive?(pid)
     end
 
     test "the buffer is unlisted, persistent and read-only" do
-      pid = Buffer.messages()
+      pid = Minga.Log.messages_buffer()
       assert Buffer.unlisted?(pid)
       assert Buffer.persistent?(pid)
       assert Buffer.read_only?(pid)
@@ -60,10 +59,16 @@ defmodule Minga.Buffer.MessagesTest do
     test "Minga.Log.* calls land in the shared buffer with no editor running" do
       refute Process.whereis(MingaEditor)
       tag = unique_tag("headless-info")
+      Events.subscribe(:log_message)
 
-      Minga.Log.info(:editor, tag)
+      try do
+        Minga.Log.info(:editor, tag)
 
-      assert wait_for_text(Buffer.messages(), tag)
+        assert_log_message_contains(tag)
+        assert_messages_buffer_contains(tag)
+      after
+        Events.unsubscribe(:log_message)
+      end
     end
 
     test ":log_message broadcasts append to the shared buffer" do
@@ -71,7 +76,7 @@ defmodule Minga.Buffer.MessagesTest do
 
       Events.broadcast(:log_message, %LogMessageEvent{text: tag, level: :info})
 
-      assert wait_for_text(Buffer.messages(), tag)
+      assert_messages_buffer_contains(tag)
     end
   end
 
@@ -87,7 +92,7 @@ defmodule Minga.Buffer.MessagesTest do
                         %LogMessageEvent{text: ^tag, level: :warning}},
                        500
 
-        assert wait_for_text(Buffer.messages(), tag)
+        assert_messages_buffer_contains(tag)
       after
         Events.unsubscribe(:log_message)
       end

--- a/test/minga/logger_handler_test.exs
+++ b/test/minga/logger_handler_test.exs
@@ -25,15 +25,15 @@ defmodule Minga.LoggerHandlerTest do
   end
 
   describe "log/2 routing to the shared *Messages* buffer" do
-    test "appends entries to Minga.Buffer.messages/0" do
+    test "appends entries to Minga.Log.messages_buffer/0" do
       tag = "logger-handler-shared-#{System.unique_integer([:positive])}"
       event = %{level: :error, msg: {:string, tag}, meta: %{}}
 
       LoggerHandler.log(event, %{})
 
-      buf = Buffer.messages()
+      buf = Minga.Log.messages_buffer()
       assert is_pid(buf)
-      assert wait_for_text(buf, tag)
+      assert_messages_buffer_contains(tag)
     end
 
     test "preserves level prefix in the formatted text" do
@@ -41,8 +41,7 @@ defmodule Minga.LoggerHandlerTest do
 
       LoggerHandler.log(%{level: :warning, msg: {:string, tag}, meta: %{}}, %{})
 
-      buf = Buffer.messages()
-      assert wait_for_text(buf, "[warning] " <> tag)
+      assert_messages_buffer_contains("[warning] " <> tag)
     end
 
     test "formats erlang format strings" do
@@ -53,8 +52,7 @@ defmodule Minga.LoggerHandlerTest do
         %{}
       )
 
-      buf = Buffer.messages()
-      assert wait_for_text(buf, tag)
+      assert_messages_buffer_contains(tag)
     end
   end
 
@@ -73,27 +71,11 @@ defmodule Minga.LoggerHandlerTest do
     end
   end
 
-  defp wait_for_text(buf, tag, timeout_ms \\ 500) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_for_text(buf, tag, deadline)
-  end
+  defp assert_messages_buffer_contains(tag) do
+    :sys.get_state(Minga.Log.MessagesBuffer)
+    content = Buffer.content(Minga.Log.messages_buffer())
 
-  defp do_wait_for_text(buf, tag, deadline) do
-    content = Buffer.content(buf)
-
-    if String.contains?(content, tag) do
-      true
-    else
-      retry_or_fail(buf, tag, deadline, content)
-    end
-  end
-
-  defp retry_or_fail(buf, tag, deadline, content) do
-    if System.monotonic_time(:millisecond) >= deadline do
-      flunk("expected #{inspect(tag)} in *Messages* buffer; got:\n#{content}")
-    else
-      Process.sleep(10)
-      do_wait_for_text(buf, tag, deadline)
-    end
+    assert String.contains?(content, tag),
+           "expected #{inspect(tag)} in *Messages* buffer; got:\n#{content}"
   end
 end

--- a/test/minga_editor/messages_buffer_test.exs
+++ b/test/minga_editor/messages_buffer_test.exs
@@ -3,7 +3,7 @@ defmodule MingaEditor.MessagesBufferTest do
   Tests for the *Messages* buffer popup and `SPC b m`.
 
   The `*Messages*` buffer is now a BEAM-wide singleton owned by
-  `Minga.Buffer.Messages` (#1483). Each test owns a unique tag it
+  `Minga.Log.MessagesBuffer` (#1483). Each test owns a unique tag it
   writes to the shared buffer, so concurrent tests can run async
   without cross-test pollution.
   """
@@ -22,7 +22,7 @@ defmodule MingaEditor.MessagesBufferTest do
     # before the assertion runs. The wrapper subscribes synchronously in
     # Registry.dispatch, but a :sys.get_state barrier guarantees the cast/info
     # is fully processed.
-    _ = :sys.get_state(Minga.Buffer.Messages)
+    _ = :sys.get_state(Minga.Log.MessagesBuffer)
     :ok
   end
 
@@ -41,7 +41,7 @@ defmodule MingaEditor.MessagesBufferTest do
       _ctx = start_editor("hello")
       emit_log(tag)
 
-      assert String.contains?(Buffer.content(Buffer.messages()), tag)
+      assert String.contains?(Buffer.content(Minga.Log.messages_buffer()), tag)
     end
 
     test "popup is rendered when SPC b m is pressed after emitting our tagged entry" do
@@ -119,17 +119,17 @@ defmodule MingaEditor.MessagesBufferTest do
     end
 
     test "starting an editor does not start a new *Messages* buffer" do
-      pid_before = Buffer.messages()
+      pid_before = Minga.Log.messages_buffer()
       assert is_pid(pid_before)
 
       _ctx = start_editor("hello")
 
-      assert Buffer.messages() == pid_before
+      assert Minga.Log.messages_buffer() == pid_before
       assert Process.alive?(pid_before)
     end
 
     test "killing one editor does not kill the *Messages* buffer" do
-      pid_before = Buffer.messages()
+      pid_before = Minga.Log.messages_buffer()
       assert is_pid(pid_before)
       assert Process.alive?(pid_before)
 
@@ -138,7 +138,7 @@ defmodule MingaEditor.MessagesBufferTest do
       :ok = GenServer.stop(ctx.editor, :normal)
 
       assert Process.alive?(pid_before)
-      assert Buffer.messages() == pid_before
+      assert Minga.Log.messages_buffer() == pid_before
     end
 
     test "entries written by one editor are visible to another" do
@@ -148,7 +148,7 @@ defmodule MingaEditor.MessagesBufferTest do
 
       emit_log(tag)
 
-      assert String.contains?(Buffer.content(Buffer.messages()), tag)
+      assert String.contains?(Buffer.content(Minga.Log.messages_buffer()), tag)
     end
   end
 

--- a/test/minga_editor/ui/picker/agent_session_source_test.exs
+++ b/test/minga_editor/ui/picker/agent_session_source_test.exs
@@ -63,7 +63,6 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
 
     test "returns tab candidates when agent tabs exist" do
       {:ok, pid} = start_test_session()
-      Session.subscribe(pid)
 
       state = state_with_agent_tab(pid)
       ctx = Context.from_editor_state(state)
@@ -75,13 +74,11 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
       assert is_binary(label)
       assert String.contains?(desc, "test-model")
 
-      Session.unsubscribe(pid)
       stop_session(pid)
     end
 
     test "active agent tab is marked with bullet" do
       {:ok, pid} = start_test_session()
-      Session.subscribe(pid)
 
       state = state_with_agent_tab(pid)
       ctx = Context.from_editor_state(state)
@@ -95,15 +92,12 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
 
       assert active != nil
 
-      Session.unsubscribe(pid)
       stop_session(pid)
     end
 
     test "candidates include completed and failed background subagent tabs" do
       {:ok, pid1} = start_test_session()
       {:ok, pid2} = start_test_session()
-      Session.subscribe(pid1)
-      Session.subscribe(pid2)
 
       state =
         state_with_two_agent_tabs(pid1, pid2)
@@ -123,8 +117,6 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
       result = AgentSessionSource.on_select(target, state)
       assert result.shell_state.tab_bar.active_id == elem(elem(target.id, 1), 1)
 
-      Session.unsubscribe(pid1)
-      Session.unsubscribe(pid2)
       stop_session(pid1)
       stop_session(pid2)
     end
@@ -188,8 +180,6 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
     test "background agent tab is not marked with bullet" do
       {:ok, pid1} = start_test_session()
       {:ok, pid2} = start_test_session()
-      Session.subscribe(pid1)
-      Session.subscribe(pid2)
 
       state = state_with_two_agent_tabs(pid1, pid2)
       ctx = Context.from_editor_state(state)
@@ -208,8 +198,6 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
         refute String.contains?(label, "\u{2022}")
       end)
 
-      Session.unsubscribe(pid1)
-      Session.unsubscribe(pid2)
       stop_session(pid1)
       stop_session(pid2)
     end
@@ -238,7 +226,6 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
 
     test "with tab entry switches to that tab" do
       {:ok, pid} = start_test_session()
-      Session.subscribe(pid)
 
       state = state_with_two_tabs_file_active(pid)
       agent_tab_id = Enum.find(state.shell_state.tab_bar.tabs, &(&1.kind == :agent)).id
@@ -246,7 +233,6 @@ defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
       result = AgentSessionSource.on_select(item, state)
       assert result.shell_state.tab_bar.active_id == agent_tab_id
 
-      Session.unsubscribe(pid)
       stop_session(pid)
     end
   end


### PR DESCRIPTION
# TL;DR
The BEAM-wide `*Messages*` owner now lives under `Minga.Log.MessagesBuffer` instead of `Minga.Buffer.Messages`. Callers now access it through `Minga.Log.messages_buffer/0`, so the buffer domain no longer exposes a logging-owned singleton.

## Context
`*Messages*` uses a buffer for storage, but it is part of the logging pipeline: it subscribes to `:log_message`, drains early logger entries, timestamps entries, and trims the log. Moving the owner under `Minga.Log` makes that responsibility explicit without keeping the old buffer-domain facade.

## Changes
- Renamed `Minga.Buffer.Messages` to `Minga.Log.MessagesBuffer` and moved the file to `lib/minga/log/messages_buffer.ex`.
- Added `Minga.Log.messages_buffer/0` as the public logging API for the singleton buffer pid.
- Removed `Minga.Buffer.messages/0` so `Minga.Buffer` stays focused on buffer behavior.
- Updated `Minga.Application` and `Minga.Runtime` supervision to start the renamed owner.
- Updated production callers, comments, docs, and tests to use the new logging API.
- Made related tests deterministic by replacing polling sleeps and real timer waits with process barriers or explicit timer messages.
- Fixed a cookie-test isolation issue by using the project `:tmp_dir` fixture instead of reusable paths under `System.tmp_dir!()`.
- Removed unnecessary `Session.subscribe/1` calls from agent-session picker tests that only read metadata.

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test.llm test/minga/distribution/cookie_test.exs test/minga/log/messages_buffer_test.exs test/minga/logger_handler_test.exs test/minga_editor/messages_buffer_test.exs test/minga_editor/startup_test.exs`
- `make lint`
- `mix test.llm`, passed with 8578 tests, 97 properties, 52 doctests, 0 failures
- Final reviewer gate: PASS

## Acceptance Criteria Addressed
- The singleton `*Messages*` owner is no longer under the buffer domain ✅
- Logging ownership is represented by `Minga.Log.MessagesBuffer` ✅
- Callers use `Minga.Log.messages_buffer/0` instead of a buffer-domain facade ✅
- Message-buffer and related synchronization tests pass without polling sleeps ✅
