### PR TITLE
feat(editor): add explicit file tree states

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -63,11 +63,15 @@ The BEAM-side encoder must use a documented length-prefixed envelope for all new
 
 The native file tree receives the same semantic row model that the TUI renderer uses. The BEAM remains the source of truth for row identity, depth, selected/focused state, expansion state, git status, diagnostics, guide columns, icons, labels, and inline editing state. Swift should render this state directly and send user actions back through the existing file-tree action opcodes.
 
+Legacy note: early GUI prototypes used the low 0x70 chrome range and inferred hidden state from an empty entry list. New frontends must ignore that sentinel behavior. `0x93` v2 is the canonical file-tree protocol, and `tree_state` is the only source of truth for hidden, loading, empty, ready, and error states.
+
 ```
 opcode(1) + payload_len(4) + payload(payload_len)
 
-Payload:
-  version(1) + tree_flags(1) + selected_id_len(2) + selected_id(selected_id_len) + root_len(2) + root(root_len) + tree_width(2) + row_count(2) + rows...
+Payload v2:
+  version(1) + tree_flags(1) + tree_state(1) + selected_id_len(2) + selected_id(selected_id_len) + root_len(2) + root(root_len) + tree_width(2) + row_count(2) + error_reason_len(2) + error_reason(error_reason_len) + rows...
+
+Payload v1, kept for decoder compatibility, omitted `tree_state` and `error_reason`. Frontends should derive v1 state from `visible` and `empty`, but all new BEAM payloads use v2.
 
 Per row:
   path_hash(4) + row_flags(2) + depth(1) + git_status(1) + diagnostic_error_count(2) + diagnostic_warning_count(2) + diagnostic_info_count(2) + diagnostic_hint_count(2) + guide_count(1) + guides(guide_count) + id_len(2) + id(id_len) + path_len(2) + path(path_len) + rel_path_len(2) + rel_path(rel_path_len) + name_len(2) + name(name_len) + icon_len(1) + icon(icon_len) + editing_type(1) + editing_text_len(2) + editing_text(editing_text_len)
@@ -76,6 +80,13 @@ Tree flag bits:
   bit 0: visible
   bit 1: focused
   bit 4: empty
+
+Tree state values:
+  0 = hidden
+  1 = loading
+  2 = empty
+  3 = ready
+  4 = error
 
 Row flag bits:
   bit 0: is_dir
@@ -94,7 +105,11 @@ Editing type values:
   0 = new_file, 1 = new_folder, 2 = rename, 255 = none
 ```
 
-When `visible` is false, the frontend should hide the file tree. Hidden payloads still include the root path when the BEAM knows it, so Swift can preserve context while clearing visible rows.
+When `tree_state == 0`, the frontend should hide the file tree. Hidden payloads still include the root path when the BEAM knows it, so Swift can preserve context while clearing visible rows.
+
+`row_count == 0` only means the payload contains no entry rows. It does not imply hidden. Use `tree_state` to distinguish hidden (`0`), loading (`1`), visible-empty (`2`), and error (`4`) states. The `empty` flag bit is retained for compatibility and is set only for `tree_state == 2`.
+
+When `tree_state == 4`, `error_reason` contains a short user-displayable reason. For all other states, `error_reason` is an empty string.
 
 ### 0x71 — gui_tab_bar
 
@@ -764,8 +779,8 @@ opcode(1) + action_type(1) + payload...
 | 0x0A | panel_dismiss | (empty) | User dismissed the bottom panel |
 | 0x0B | panel_resize | height_percent(1) | User resized the bottom panel |
 | 0x0C | open_file | path_len(2) + path(path_len) | Open or switch to a file |
-| 0x0D | file_tree_new_file | (empty) | Create new file at selected entry |
-| 0x0E | file_tree_new_folder | (empty) | Create new folder at selected entry |
+| 0x0D | file_tree_new_file | parent_index(2) | Create new file under or near the selected entry |
+| 0x0E | file_tree_new_folder | parent_index(2) | Create new folder under or near the selected entry |
 | 0x0F | file_tree_collapse_all | (empty) | Collapse all directories in tree |
 | 0x10 | file_tree_refresh | (empty) | Refresh file tree |
 | 0x11 | tool_install | name_len(2) + name(name_len) | Install a tool by name |

--- a/docs/SNAPSHOT_TESTING.md
+++ b/docs/SNAPSHOT_TESTING.md
@@ -104,7 +104,7 @@ When you first run a new test, it will fail because no baseline exists. Run with
 
 Some tests depend on external state that varies between runs:
 
-- **File tree tests**: the tree shows real project files, so file counts and names change.
+- **File tree tests**: the tree shows real project files, so file counts and names change. Prefer deterministic fixtures plus semantic row tests, draw tuple assertions, GUI protocol encoder/decoder tests, and Swift view-structure tests for selected, active, dirty, git, diagnostics, editing, nested, hidden, loading, empty, and error states.
 - **Agent panel tests**: agent initialization state varies depending on what's running.
 - **File picker**: file counts change as the project evolves.
 

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -125,8 +125,13 @@ defmodule MingaEditor.Commands.FileTree do
 
   def new_file(%{workspace: %{file_tree: %{tree: tree}}} = state) do
     {index, tree} = editing_insertion_index(tree)
-    ft = FileTreeState.start_editing(state.workspace.file_tree, index, :new_file)
-    state = put_in(state.workspace.file_tree, %{ft | tree: tree})
+
+    ft =
+      state.workspace.file_tree
+      |> FileTreeState.start_editing(index, :new_file)
+      |> FileTreeState.replace_tree(tree)
+
+    state = put_in(state.workspace.file_tree, ft)
     sync_buffer(state)
   end
 
@@ -140,8 +145,13 @@ defmodule MingaEditor.Commands.FileTree do
 
   def new_folder(%{workspace: %{file_tree: %{tree: tree}}} = state) do
     {index, tree} = editing_insertion_index(tree)
-    ft = FileTreeState.start_editing(state.workspace.file_tree, index, :new_folder)
-    state = put_in(state.workspace.file_tree, %{ft | tree: tree})
+
+    ft =
+      state.workspace.file_tree
+      |> FileTreeState.start_editing(index, :new_folder)
+      |> FileTreeState.replace_tree(tree)
+
+    state = put_in(state.workspace.file_tree, ft)
     sync_buffer(state)
   end
 
@@ -465,7 +475,10 @@ defmodule MingaEditor.Commands.FileTree do
             EditorState.switch_buffer(state, idx)
           end
 
-        put_in(state.workspace.file_tree.tree, FileTree.reveal(tree, path))
+        put_in(
+          state.workspace.file_tree,
+          FileTreeState.replace_tree(state.workspace.file_tree, FileTree.reveal(tree, path))
+        )
     end
   end
 
@@ -508,11 +521,18 @@ defmodule MingaEditor.Commands.FileTree do
   defp sync_and_update(%{workspace: %{file_tree: %{buffer: buf}}} = state, new_tree)
        when is_pid(buf) do
     BufferSync.sync(buf, new_tree)
-    put_in(state.workspace.file_tree.tree, new_tree)
+
+    put_in(
+      state.workspace.file_tree,
+      FileTreeState.replace_tree(state.workspace.file_tree, new_tree)
+    )
   end
 
   defp sync_and_update(state, new_tree) do
-    put_in(state.workspace.file_tree.tree, new_tree)
+    put_in(
+      state.workspace.file_tree,
+      FileTreeState.replace_tree(state.workspace.file_tree, new_tree)
+    )
   end
 
   # Computes the insertion index for a new file/folder.

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -35,6 +35,7 @@ defmodule MingaEditor.Frontend.Emit.GUI do
   alias MingaEditor.Renderer.Gutter
   alias MingaEditor.Shell.Traditional.Chrome.Helpers, as: ChromeHelpers
   alias MingaEditor.RenderPipeline.ContentHelpers
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.TabBar
   alias MingaEditor.StatusBar.Data, as: StatusBarData
   alias MingaEditor.Viewport
@@ -271,18 +272,27 @@ defmodule MingaEditor.Frontend.Emit.GUI do
         selected_index: tree.cursor
       )
 
-    fp = :erlang.phash2({tree.root, tree.width, file_tree_focused?(file_tree), rows})
+    tree_status = FileTreeState.status(file_tree)
+    rows = if tree_status == :ready, do: rows, else: []
+    fp = :erlang.phash2({tree.root, tree.width, file_tree_focused?(file_tree), tree_status, rows})
 
     if fp != caches.last_gui_file_tree_fp do
       {ProtocolGUI.encode_gui_file_tree(
          tree.root,
          tree.width,
-         true,
+         tree_status,
          file_tree_focused?(file_tree),
          rows
        ), %{caches | last_gui_file_tree_fp: fp}}
     else
       {nil, caches}
+    end
+  end
+
+  defp build_gui_file_tree_cmd(%{file_tree: %FileTreeState{} = file_tree}, caches) do
+    case FileTreeState.status(file_tree) do
+      :hidden -> build_hidden_gui_file_tree_cmd(file_tree.project_root, caches)
+      status -> build_gui_file_tree_state_cmd(file_tree, status, caches)
     end
   end
 
@@ -292,6 +302,20 @@ defmodule MingaEditor.Frontend.Emit.GUI do
 
   defp build_gui_file_tree_cmd(_ctx, caches) do
     build_hidden_gui_file_tree_cmd(nil, caches)
+  end
+
+  @spec build_gui_file_tree_state_cmd(FileTreeState.t(), FileTreeState.tree_status(), Caches.t()) ::
+          {binary() | nil, Caches.t()}
+  defp build_gui_file_tree_state_cmd(%FileTreeState{} = file_tree, status, caches) do
+    width = FileTreeState.width(file_tree)
+    fp = {:file_tree_state, file_tree.project_root || "", width, status}
+
+    if caches.last_gui_file_tree_fp != fp do
+      {ProtocolGUI.encode_gui_file_tree(file_tree.project_root, width, status, false, []),
+       %{caches | last_gui_file_tree_fp: fp}}
+    else
+      {nil, caches}
+    end
   end
 
   @spec build_hidden_gui_file_tree_cmd(String.t() | nil, Caches.t()) ::

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -95,6 +95,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   alias MingaEditor.FileTree.Row
   alias MingaEditor.MinibufferData
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
@@ -1020,9 +1021,9 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
       opcode(1) + payload_len(4) + payload(payload_len)
 
-  Payload:
+  Payload v2:
 
-      version(1) + tree_flags(1) + selected_id_len(2) + selected_id + root_len(2) + root + tree_width(2) + row_count(2) + rows...
+      version(1) + tree_flags(1) + tree_state(1) + selected_id_len(2) + selected_id + root_len(2) + root + tree_width(2) + row_count(2) + error_reason_len(2) + error_reason + rows...
 
   Per row:
 
@@ -1030,18 +1031,23 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
   String fields use uint16 byte lengths except icon, which uses a uint8 byte length.
   """
-  @spec encode_gui_file_tree(String.t() | nil, non_neg_integer(), boolean(), boolean(), [Row.t()]) ::
-          binary()
-  def encode_gui_file_tree(root_path, tree_width, visible?, focused?, rows) when is_list(rows) do
+  @type file_tree_status :: FileTreeState.tree_status()
+
+  @spec encode_gui_file_tree(String.t() | nil, non_neg_integer(), file_tree_status(), boolean(), [
+          Row.t()
+        ]) :: binary()
+  def encode_gui_file_tree(root_path, tree_width, status, focused?, rows) when is_list(rows) do
     root = root_path || ""
     selected_id = selected_row_id(rows)
+    error_reason = file_tree_error_reason(status)
 
     payload =
       IO.iodata_to_binary([
-        <<1::8, file_tree_flags(visible?, focused?, rows)::8>>,
+        <<2::8, file_tree_flags(status, focused?)::8, encode_file_tree_status(status)::8>>,
         encode_string16(selected_id),
         encode_string16(root),
         <<tree_width::16, length(rows)::16>>,
+        encode_string16(error_reason),
         Enum.map(rows, &encode_file_tree_row(&1, root))
       ])
 
@@ -1051,7 +1057,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   @doc "Encodes a hidden semantic GUI file-tree command while preserving the project root."
   @spec encode_hidden_gui_file_tree(String.t() | nil) :: binary()
   def encode_hidden_gui_file_tree(root_path),
-    do: encode_gui_file_tree(root_path, 0, false, false, [])
+    do: encode_gui_file_tree(root_path, 0, :hidden, false, [])
 
   @spec encode_file_tree_row(Row.t(), String.t()) :: iodata()
   defp encode_file_tree_row(%Row{} = row, root) do
@@ -1096,13 +1102,24 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     end
   end
 
-  @spec file_tree_flags(boolean(), boolean(), [Row.t()]) :: non_neg_integer()
-  defp file_tree_flags(visible?, focused?, rows) do
+  @spec file_tree_flags(FileTreeState.tree_status(), boolean()) :: non_neg_integer()
+  defp file_tree_flags(status, focused?) do
     0
-    |> maybe_flag(visible?, 0)
+    |> maybe_flag(FileTreeState.visible_status?(status), 0)
     |> maybe_flag(focused?, 1)
-    |> maybe_flag(rows == [], 4)
+    |> maybe_flag(status == :empty, 4)
   end
+
+  @spec encode_file_tree_status(FileTreeState.tree_status()) :: non_neg_integer()
+  defp encode_file_tree_status(:hidden), do: 0
+  defp encode_file_tree_status(:loading), do: 1
+  defp encode_file_tree_status(:empty), do: 2
+  defp encode_file_tree_status(:ready), do: 3
+  defp encode_file_tree_status({:error, _reason}), do: 4
+
+  @spec file_tree_error_reason(FileTreeState.tree_status()) :: String.t()
+  defp file_tree_error_reason({:error, reason}), do: reason
+  defp file_tree_error_reason(_status), do: ""
 
   @spec file_tree_row_flags(Row.t()) :: non_neg_integer()
   defp file_tree_row_flags(%Row{} = row) do

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   """
 
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias Minga.Project.FileTree
 
   @typedoc "Effects that the file event handler may return."
@@ -112,6 +113,10 @@ defmodule MingaEditor.Handlers.FileEventHandler do
 
   defp refresh_tree_git_status(%{workspace: %{file_tree: %{tree: tree}}} = state) do
     updated_tree = FileTree.refresh_git_status(tree)
-    put_in(state.workspace.file_tree.tree, updated_tree)
+
+    put_in(
+      state.workspace.file_tree,
+      FileTreeState.replace_tree(state.workspace.file_tree, updated_tree)
+    )
   end
 end

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -197,7 +197,11 @@ defmodule MingaEditor.Input.FileTreeHandler do
   @spec sync_tree_cursor_from_buffer(EditorState.t(), pid()) :: EditorState.t()
   defp sync_tree_cursor_from_buffer(%{workspace: %{file_tree: %{tree: tree}}} = state, buf) do
     {cursor_line, _col} = Buffer.cursor(buf)
-    put_in(state.workspace.file_tree.tree, FileTree.select(tree, cursor_line))
+
+    put_in(
+      state.workspace.file_tree,
+      FileTreeState.replace_tree(state.workspace.file_tree, FileTree.select(tree, cursor_line))
+    )
   end
 
   # ── File tree mouse helpers ────────────────────────────────────────────
@@ -214,7 +218,14 @@ defmodule MingaEditor.Input.FileTreeHandler do
   defp handle_file_tree_click(state, tree, _row, _ft_row, _ft_height, button, _click_count)
        when button in [:wheel_up, :wheel_down] do
     delta = if button == :wheel_down, do: 3, else: -3
-    put_in(state.workspace.file_tree.tree, FileTree.select(tree, tree.cursor + delta))
+
+    put_in(
+      state.workspace.file_tree,
+      FileTreeState.replace_tree(
+        state.workspace.file_tree,
+        FileTree.select(tree, tree.cursor + delta)
+      )
+    )
   end
 
   defp handle_file_tree_click(state, tree, row, ft_row, ft_height, :left, click_count) do
@@ -233,7 +244,15 @@ defmodule MingaEditor.Input.FileTreeHandler do
           state
 
         entry ->
-          state = put_in(state.workspace.file_tree.tree, FileTree.select(tree, entry_idx))
+          state =
+            put_in(
+              state.workspace.file_tree,
+              FileTreeState.replace_tree(
+                state.workspace.file_tree,
+                FileTree.select(tree, entry_idx)
+              )
+            )
+
           handle_tree_entry_click(state, entry, click_count)
       end
     end

--- a/lib/minga_editor/shell/traditional/tree_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tree_renderer.ex
@@ -52,7 +52,8 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
       editing: nil,
       git_status: %{},
       dirty_paths: MapSet.new(),
-      rows: nil
+      rows: nil,
+      status: :ready
     ]
 
     @type t :: %__MODULE__{
@@ -64,7 +65,8 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
             editing: FileTreeState.editing() | nil,
             git_status: Minga.Project.FileTree.GitStatus.status_map(),
             dirty_paths: MapSet.t(String.t()),
-            rows: [Row.t()] | nil
+            rows: [Row.t()] | nil,
+            status: FileTreeState.tree_status()
           }
   end
 
@@ -89,7 +91,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
           git_status: input.git_status
         )
 
-    do_render(input.tree, input.rect, input.theme, rows)
+    do_render(input.tree, input.rect, input.theme, effective_status(input.status, rows), rows)
   end
 
   @spec render(EditorState.t() | map()) :: [DisplayList.draw()]
@@ -108,7 +110,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
 
   @spec render_from_workspace(map(), MingaEditor.UI.Theme.t(), map()) :: [DisplayList.draw()]
   defp render_from_workspace(
-         %{file_tree: %{tree: tree, focused: focused}} = _ws,
+         %{file_tree: %{tree: tree, focused: focused} = file_tree} = _ws,
          _theme,
          state
        ) do
@@ -120,18 +122,21 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
       focused: focused,
       theme: state.theme,
       active_path: nil,
-      rows: Rows.from_state(state)
+      rows: Rows.from_state(state),
+      status: status_from_file_tree(file_tree)
     }
 
     render(input)
   end
 
-  @spec do_render(FileTree.t(), WindowTree.rect(), Theme.t(), [Row.t()]) :: [DisplayList.draw()]
-  defp do_render(_tree, {_row_off, _col_off, width, height}, _theme, _rows)
+  @spec do_render(FileTree.t(), WindowTree.rect(), Theme.t(), FileTreeState.tree_status(), [
+          Row.t()
+        ]) :: [DisplayList.draw()]
+  defp do_render(_tree, {_row_off, _col_off, width, height}, _theme, _status, _rows)
        when width <= 0 or height <= 0,
        do: []
 
-  defp do_render(tree, {row_off, col_off, width, height}, theme, rows) do
+  defp do_render(tree, {row_off, col_off, width, height}, theme, status, rows) do
     # Header: project directory name with folder icon
     project_name = Path.basename(tree.root)
     header_text = " #{@folder_open} #{project_name}/"
@@ -157,22 +162,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     }
 
     entry_commands =
-      rows
-      |> Enum.drop(scroll_offset)
-      |> Enum.take(content_rows)
-      |> Enum.with_index()
-      |> Enum.flat_map(fn {tree_row, screen_row} ->
-        row = row_off + 1 + screen_row
-
-        if tree_row.editing != nil do
-          render_editing_entry(tree_row, row, render_opts)
-        else
-          render_entry(tree_row, row, render_opts)
-        end
-      end)
+      render_content_rows(status, rows, scroll_offset, content_rows, row_off + 1, render_opts)
 
     # Fill remaining rows with blanks
-    visible_count = rows |> Enum.drop(scroll_offset) |> Enum.take(content_rows) |> length()
+    visible_count = visible_content_count(status, rows, scroll_offset, content_rows)
 
     blank_commands =
       render_blanks(visible_count, content_rows, row_off + 1, col_off, width, theme)
@@ -182,6 +175,74 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     sep_commands = render_separator(sep_col, row_off, height, theme)
 
     header ++ entry_commands ++ blank_commands ++ sep_commands
+  end
+
+  @spec status_from_file_tree(FileTreeState.t() | map()) :: FileTreeState.tree_status()
+  defp status_from_file_tree(%FileTreeState{} = file_tree), do: FileTreeState.status(file_tree)
+  defp status_from_file_tree(_file_tree), do: :ready
+
+  @spec effective_status(FileTreeState.tree_status(), [Row.t()]) :: FileTreeState.tree_status()
+  defp effective_status(:ready, []), do: :empty
+  defp effective_status(status, _rows), do: status
+
+  @spec render_content_rows(
+          FileTreeState.tree_status(),
+          [Row.t()],
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          map()
+        ) :: [DisplayList.draw()]
+  defp render_content_rows(:ready, rows, scroll_offset, content_rows, first_row, opts) do
+    rows
+    |> Enum.drop(scroll_offset)
+    |> Enum.take(content_rows)
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {tree_row, screen_row} ->
+      row = first_row + screen_row
+
+      if tree_row.editing != nil do
+        render_editing_entry(tree_row, row, opts)
+      else
+        render_entry(tree_row, row, opts)
+      end
+    end)
+  end
+
+  defp render_content_rows(status, _rows, _scroll_offset, content_rows, first_row, opts) do
+    status
+    |> state_lines()
+    |> Enum.take(content_rows)
+    |> Enum.with_index()
+    |> Enum.map(fn {line, screen_row} ->
+      render_state_line(line, first_row + screen_row, opts)
+    end)
+  end
+
+  @spec visible_content_count(
+          FileTreeState.tree_status(),
+          [Row.t()],
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: non_neg_integer()
+  defp visible_content_count(:ready, rows, scroll_offset, content_rows) do
+    rows |> Enum.drop(scroll_offset) |> Enum.take(content_rows) |> length()
+  end
+
+  defp visible_content_count(status, _rows, _scroll_offset, content_rows) do
+    status |> state_lines() |> Enum.take(content_rows) |> length()
+  end
+
+  @spec state_lines(FileTreeState.tree_status()) :: [String.t()]
+  defp state_lines(:loading), do: ["  ⏳ Loading files…"]
+  defp state_lines(:empty), do: ["  No files yet", "  Press n to create a file"]
+  defp state_lines({:error, reason}), do: ["  ⚠ File tree error", "  #{reason}"]
+  defp state_lines(_status), do: []
+
+  @spec render_state_line(String.t(), non_neg_integer(), map()) :: DisplayList.draw()
+  defp render_state_line(line, row, %{col_off: col, width: width, theme: theme}) do
+    text = line |> Unicode.truncate_display_width(width) |> Unicode.pad_display_trailing(width)
+    DisplayList.draw(row, col, text, Face.new(fg: theme.tree.fg, bg: theme.tree.bg))
   end
 
   # ── Entry rendering ──────────────────────────────────────────────────────

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -26,20 +26,27 @@ defmodule MingaEditor.State.FileTree do
           original_name: String.t() | nil
         }
 
+  @typedoc "Explicit presentation state for the file tree sidebar."
+  @type tree_status :: :hidden | :loading | :empty | :ready | {:error, String.t()}
+
   @typedoc "File tree sub-state."
   @type t :: %__MODULE__{
           tree: FileTree.t() | nil,
           focused: boolean(),
           buffer: pid() | nil,
           editing: editing() | nil,
-          project_root: String.t() | nil
+          project_root: String.t() | nil,
+          tree_status: tree_status(),
+          tree_width: pos_integer()
         }
 
   defstruct tree: nil,
             focused: false,
             buffer: nil,
             editing: nil,
-            project_root: nil
+            project_root: nil,
+            tree_status: :hidden,
+            tree_width: 30
 
   @doc "Returns true when the file tree is open."
   @spec open?(t()) :: boolean()
@@ -56,6 +63,20 @@ defmodule MingaEditor.State.FileTree do
   def editing?(%__MODULE__{editing: %{}}), do: true
   def editing?(%__MODULE__{}), do: false
 
+  @doc "Returns the explicit presentation status for the file tree."
+  @spec status(t()) :: tree_status()
+  def status(%__MODULE__{tree: nil, tree_status: status}) when status in [:loading], do: status
+  def status(%__MODULE__{tree: nil, tree_status: {:error, _reason} = status}), do: status
+  def status(%__MODULE__{tree: nil}), do: :hidden
+  def status(%__MODULE__{tree_status: :loading}), do: :loading
+  def status(%__MODULE__{tree_status: {:error, _reason} = status}), do: status
+  def status(%__MODULE__{tree: %FileTree{} = tree}), do: classify_tree(tree)
+
+  @doc "Returns true when the explicit tree status should occupy the sidebar."
+  @spec visible_status?(tree_status()) :: boolean()
+  def visible_status?(:hidden), do: false
+  def visible_status?(_status), do: true
+
   @doc "Marks the file tree as focused."
   @spec focus(t()) :: t()
   def focus(%__MODULE__{} = ft), do: %{ft | focused: true}
@@ -64,21 +85,46 @@ defmodule MingaEditor.State.FileTree do
   @spec unfocus(t()) :: t()
   def unfocus(%__MODULE__{} = ft), do: %{ft | focused: false}
 
-  @doc "Returns the tree width, or 0 if the tree is not open."
-  @spec width(t()) :: non_neg_integer()
-  def width(%__MODULE__{tree: nil}), do: 0
-  def width(%__MODULE__{tree: %FileTree{width: w}}), do: w
+  @doc "Returns the tree width, preserving the last sidebar width while state-only payloads are visible."
+  @spec width(t()) :: pos_integer()
+  def width(%__MODULE__{tree: nil, tree_width: width}), do: width
+  def width(%__MODULE__{tree: %FileTree{width: width}}), do: width
 
   @doc "Opens the tree with the given data, buffer, and focused state."
   @spec open(t(), FileTree.t(), pid() | nil) :: t()
   def open(%__MODULE__{} = ft, tree, buffer) do
-    %{ft | tree: tree, focused: true, buffer: buffer}
+    %{
+      ft
+      | tree: tree,
+        focused: true,
+        buffer: buffer,
+        tree_status: classify_tree(tree),
+        tree_width: tree.width
+    }
+  end
+
+  @doc "Replaces the backing tree and refreshes the presentation status."
+  @spec replace_tree(t(), FileTree.t()) :: t()
+  def replace_tree(%__MODULE__{} = ft, %FileTree{} = tree) do
+    %{ft | tree: tree, tree_status: classify_tree(tree), tree_width: tree.width}
+  end
+
+  @doc "Marks the sidebar as loading."
+  @spec loading(t()) :: t()
+  def loading(%__MODULE__{} = ft) do
+    %{ft | focused: false, editing: nil, tree_status: :loading}
+  end
+
+  @doc "Marks the sidebar as failed with a displayable reason."
+  @spec error(t(), term()) :: t()
+  def error(%__MODULE__{} = ft, reason) do
+    %{ft | focused: false, editing: nil, tree_status: {:error, format_error_reason(reason)}}
   end
 
   @doc "Closes the tree and clears the buffer."
   @spec close(t()) :: t()
   def close(%__MODULE__{} = ft) do
-    %{ft | tree: nil, focused: false, buffer: nil, editing: nil}
+    %{ft | tree: nil, focused: false, buffer: nil, editing: nil, tree_status: :hidden}
   end
 
   @doc """
@@ -109,4 +155,22 @@ defmodule MingaEditor.State.FileTree do
   def cancel_editing(%__MODULE__{} = ft) do
     %{ft | editing: nil}
   end
+
+  @spec classify_tree(FileTree.t()) :: tree_status()
+  defp classify_tree(%FileTree{} = tree) do
+    case File.ls(tree.root) do
+      {:ok, _names} -> classify_entries(FileTree.visible_entries(tree))
+      {:error, reason} -> {:error, format_error_reason(reason)}
+    end
+  end
+
+  @spec classify_entries([FileTree.entry()]) :: tree_status()
+  defp classify_entries([]), do: :empty
+  defp classify_entries(_entries), do: :ready
+
+  @spec format_error_reason(term()) :: String.t()
+  defp format_error_reason(reason) when is_atom(reason),
+    do: :file.format_error(reason) |> to_string()
+
+  defp format_error_reason(reason), do: inspect(reason)
 end

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -32,7 +32,7 @@ enum RenderCommand: Sendable {
     case registerFont(id: UInt8, family: String)
     case guiTheme(slots: [(slotId: UInt8, r: UInt8, g: UInt8, b: UInt8)])
     case guiTabBar(activeIndex: UInt8, tabs: [Wire.TabEntry])
-    case guiFileTree(version: UInt8, treeFlags: UInt8, selectedId: String, treeWidth: UInt16, rootPath: String, entries: [Wire.FileTreeEntry])
+    case guiFileTree(version: UInt8, treeFlags: UInt8, treeState: UInt8, selectedId: String, treeWidth: UInt16, rootPath: String, errorReason: String, entries: [Wire.FileTreeEntry])
     case guiCompletion(visible: Bool, anchorRow: UInt16, anchorCol: UInt16, selectedIndex: UInt16, items: [Wire.CompletionItem])
     case guiWhichKey(visible: Bool, prefix: String, page: UInt8, pageCount: UInt8, bindings: [Wire.WhichKeyBinding])
     case guiBreadcrumb(segments: [String])
@@ -274,7 +274,8 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
     // GUI chrome commands.
     case OP_GUI_FILE_TREE:
         // Semantic file tree uses a 32-bit payload length because expanded project trees can exceed 64KB.
-        // opcode(1) + payload_len(4) + version(1) + tree_flags(1) + selected_id + root + tree_width(2) + row_count(2) + rows...
+        // v1: opcode(1) + payload_len(4) + version(1) + tree_flags(1) + selected_id + root + tree_width(2) + row_count(2) + rows...
+        // v2: adds tree_state(1) after tree_flags and error_reason after row_count.
         guard data.count >= rest + 4 else { throw ProtocolDecodeError.malformed }
         let payloadLen = Int(readU32(data, rest))
         let payloadStart = rest + 4
@@ -284,6 +285,14 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         let version = data[payloadStart]
         let treeFlags = data[payloadStart + 1]
         var pos = payloadStart + 2
+        let treeState: UInt8
+        if version >= 2 {
+            guard pos + 1 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            treeState = data[pos]
+            pos += 1
+        } else {
+            treeState = legacyFileTreeState(treeFlags: treeFlags)
+        }
 
         guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
         let selectedIdLen = Int(readU16(data, pos)); pos += 2
@@ -300,6 +309,17 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         guard pos + 4 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
         let treeWidth = readU16(data, pos); pos += 2
         let rowCount = Int(readU16(data, pos)); pos += 2
+
+        let errorReason: String
+        if version >= 2 {
+            guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            let errorReasonLen = Int(readU16(data, pos)); pos += 2
+            guard pos + errorReasonLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            errorReason = String(data: data[pos..<(pos + errorReasonLen)], encoding: .utf8) ?? ""
+            pos += errorReasonLen
+        } else {
+            errorReason = ""
+        }
 
         var entries: [Wire.FileTreeEntry] = []
         entries.reserveCapacity(rowCount)
@@ -384,7 +404,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         }
 
         guard pos == payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-        return (.guiFileTree(version: version, treeFlags: treeFlags, selectedId: selectedId, treeWidth: treeWidth, rootPath: rootPath, entries: entries), 5 + payloadLen)
+        return (.guiFileTree(version: version, treeFlags: treeFlags, treeState: treeState, selectedId: selectedId, treeWidth: treeWidth, rootPath: rootPath, errorReason: errorReason, entries: entries), 5 + payloadLen)
 
     case OP_GUI_TAB_BAR:
         // active_index:1, tab_count:1, then per tab: flags:1, id:4, group_id:2, icon_len:1, icon, label_len:2, label
@@ -2131,6 +2151,12 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
 }
 
 // MARK: - Binary helpers
+
+private func legacyFileTreeState(treeFlags: UInt8) -> UInt8 {
+    if treeFlags & 0x01 == 0 { return 0 }
+    if treeFlags & 0x10 != 0 { return 2 }
+    return 3
+}
 
 private func readRequiredUTF8(_ data: Data.SubSequence) throws -> String {
     guard let string = String(data: data, encoding: .utf8) else {

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -203,11 +203,11 @@ final class CommandDispatcher {
         case .clipboardWrite(let target, let text):
             handleClipboardWrite(target: target, text: text)
 
-        case .guiFileTree(let version, let treeFlags, let selectedId, let treeWidth, let rootPath, let entries):
-            let visible = treeFlags & 0x01 != 0
+        case .guiFileTree(let version, let treeFlags, let treeState, let selectedId, let treeWidth, let rootPath, let errorReason, let entries):
+            let visible = treeState != FileTreeVisibilityState.hidden.rawValue
             let focused = treeFlags & 0x02 != 0
             if visible {
-                guiState.fileTreeState.update(version: version, selectedId: selectedId, focused: focused, treeWidth: treeWidth, rootPath: rootPath, rawEntries: entries)
+                guiState.fileTreeState.update(version: version, selectedId: selectedId, focused: focused, treeWidth: treeWidth, rootPath: rootPath, rawEntries: entries, treeState: treeState, errorReason: errorReason)
             } else {
                 guiState.fileTreeState.hide(rootPath: rootPath)
             }

--- a/macos/Sources/Views/FileTreeHeaderContent.swift
+++ b/macos/Sources/Views/FileTreeHeaderContent.swift
@@ -70,21 +70,27 @@ struct FileTreeHeaderContent: View {
     @ViewBuilder
     private var secondaryContext: some View {
         if !branchName.isEmpty {
-            HStack(spacing: 4) {
-                Text("\u{E725}")
-                    .font(.custom("Symbols Nerd Font Mono", size: 11))
-                    .foregroundStyle(theme.treeDirFg.opacity(0.55))
-
-                Text(branchName)
-                    .font(.system(size: 11, weight: .regular))
-                    .foregroundStyle(theme.tabActiveFg.opacity(0.62))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(theme.treeHeaderFg.opacity(0.08), in: Capsule())
+            badge(icon: "\u{E725}", label: branchName)
+        } else if let stateLabel = treeStateLabel {
+            badge(icon: treeStateIcon, label: stateLabel)
         }
+    }
+
+    private func badge(icon: String, label: String) -> some View {
+        HStack(spacing: 4) {
+            Text(icon)
+                .font(.custom("Symbols Nerd Font Mono", size: 11))
+                .foregroundStyle(theme.treeDirFg.opacity(0.55))
+
+            Text(label)
+                .font(.system(size: 11, weight: .regular))
+                .foregroundStyle(theme.tabActiveFg.opacity(0.62))
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(theme.treeHeaderFg.opacity(0.08), in: Capsule())
     }
 
     private var actionButtons: some View {
@@ -126,5 +132,21 @@ struct FileTreeHeaderContent: View {
             return (fileTreeState.projectRoot as NSString).lastPathComponent
         }
         return "Project"
+    }
+
+    private var treeStateLabel: String? {
+        switch fileTreeState.treeState {
+        case .loading: return "Loading"
+        case .empty: return "Empty"
+        case .error: return "Error"
+        case .hidden, .ready: return nil
+        }
+    }
+
+    private var treeStateIcon: String {
+        switch fileTreeState.treeState {
+        case .error: return "⚠"
+        default: return ""
+        }
     }
 }

--- a/macos/Sources/Views/FileTreeState.swift
+++ b/macos/Sources/Views/FileTreeState.swift
@@ -56,6 +56,15 @@ enum FileTreeDiagnosticSeverity {
     case hint
 }
 
+/// Explicit sidebar state sent by the BEAM. Row count alone is not enough because hidden, loading, empty, and error states can all have zero rows.
+enum FileTreeVisibilityState: UInt8 {
+    case hidden = 0
+    case loading = 1
+    case empty = 2
+    case ready = 3
+    case error = 4
+}
+
 extension FileTreeEntry {
     var gitStatusValue: FileTreeGitStatus {
         FileTreeGitStatus(rawValue: gitStatus) ?? .clean
@@ -108,6 +117,8 @@ final class FileTreeState {
     var treeWidth: Int = 30
     var visible: Bool = false
     var focused: Bool = false
+    var treeState: FileTreeVisibilityState = .hidden
+    var errorReason: String = ""
     /// Project root path sent by the BEAM (e.g., "/Users/foo/myproject").
     var projectRoot: String = ""
     /// Index of the entry currently being edited, or nil if no editing is active.
@@ -120,14 +131,17 @@ final class FileTreeState {
     /// function is called, the tree data has genuinely changed and the
     /// array rebuild is necessary (git status, file renames, expand/collapse
     /// can change entry content without changing count or selection).
-    func update(version: UInt8, selectedId: String, focused: Bool, treeWidth: UInt16, rootPath: String, rawEntries: [Wire.FileTreeEntry]) {
+    func update(version: UInt8, selectedId: String, focused: Bool, treeWidth: UInt16, rootPath: String, rawEntries: [Wire.FileTreeEntry], treeState: UInt8 = FileTreeVisibilityState.ready.rawValue, errorReason: String = "") {
+        let decodedState = FileTreeVisibilityState(rawValue: treeState) ?? .ready
         self.version = version
         self.selectedId = selectedId
         self.selectedIndex = rawEntries.firstIndex(where: { $0.id == selectedId }) ?? 0
         self.treeWidth = Int(treeWidth)
         self.projectRoot = rootPath
-        self.visible = true
+        self.visible = decodedState != .hidden
         self.focused = focused
+        self.treeState = decodedState
+        self.errorReason = errorReason
         self.entries = rawEntries.enumerated().map { index, entry in
             FileTreeEntry(
                 id: entry.id,
@@ -171,6 +185,8 @@ final class FileTreeState {
     func hide(rootPath: String = "") {
         visible = false
         focused = false
+        treeState = .hidden
+        errorReason = ""
         entries = []
         selectedId = ""
         editingIndex = nil

--- a/macos/Sources/Views/FileTreeView.swift
+++ b/macos/Sources/Views/FileTreeView.swift
@@ -40,37 +40,86 @@ struct FileTreeView: View {
 
     @ViewBuilder
     private var entryList: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.vertical) {
-                LazyVStack(spacing: 0) {
-                    ForEach(fileTreeState.entries) { entry in
-                        entryRow(entry)
+        if fileTreeState.entries.isEmpty && fileTreeState.treeState != .ready {
+            stateContent
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView(.vertical) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(fileTreeState.entries) { entry in
+                            entryRow(entry)
+                        }
+                    }
+                    .padding(.top, 2)
+                    .background(
+                        GeometryReader { geo in
+                            Color.clear.preference(
+                                key: ScrollOffsetKey.self,
+                                value: geo.frame(in: .named("fileTreeScroll")).minY
+                            )
+                        }
+                    )
+                }
+                .coordinateSpace(name: "fileTreeScroll")
+                .onPreferenceChange(ScrollOffsetKey.self) { value in
+                    scrollOffset = value
+                }
+                .safeAreaInset(edge: .top, spacing: 0) {
+                    stickyParentHeader
+                }
+                .onChange(of: fileTreeState.selectedIndex) { _, newIndex in
+                    if let selectedEntry = fileTreeState.entries.first(where: { $0.index == newIndex }) {
+                        withAnimation(nil) {
+                            proxy.scrollTo(selectedEntry.id, anchor: .center)
+                        }
                     }
                 }
-                .padding(.top, 2)
-                .background(
-                    GeometryReader { geo in
-                        Color.clear.preference(
-                            key: ScrollOffsetKey.self,
-                            value: geo.frame(in: .named("fileTreeScroll")).minY
-                        )
-                    }
-                )
             }
-            .coordinateSpace(name: "fileTreeScroll")
-            .onPreferenceChange(ScrollOffsetKey.self) { value in
-                scrollOffset = value
-            }
-            .safeAreaInset(edge: .top, spacing: 0) {
-                stickyParentHeader
-            }
-            .onChange(of: fileTreeState.selectedIndex) { _, newIndex in
-                if let selectedEntry = fileTreeState.entries.first(where: { $0.index == newIndex }) {
-                    withAnimation(nil) {
-                        proxy.scrollTo(selectedEntry.id, anchor: .center)
-                    }
+        }
+    }
+
+    @ViewBuilder
+    private var stateContent: some View {
+        VStack(spacing: 10) {
+            switch fileTreeState.treeState {
+            case .loading:
+                ProgressView()
+                    .controlSize(.small)
+                stateText(title: "Loading files…", subtitle: "Scanning the project tree.")
+            case .empty:
+                stateText(title: "No files yet", subtitle: "Create a file or refresh after adding project files.")
+                Button("New File…") {
+                    encoder?.sendFileTreeNewFile(parentIndex: UInt16(fileTreeState.selectedIndex))
                 }
+                .buttonStyle(.borderless)
+                Button("Refresh") {
+                    encoder?.sendFileTreeRefresh()
+                }
+                .buttonStyle(.borderless)
+            case .error:
+                stateText(title: "Couldn’t load file tree", subtitle: fileTreeState.errorReason.isEmpty ? "Check project permissions, then refresh." : fileTreeState.errorReason)
+                Button("Refresh") {
+                    encoder?.sendFileTreeRefresh()
+                }
+                .buttonStyle(.borderless)
+            case .hidden, .ready:
+                EmptyView()
             }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .padding(20)
+        .background(theme.treeBg)
+    }
+
+    private func stateText(title: String, subtitle: String) -> some View {
+        VStack(spacing: 4) {
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(theme.treeDirFg)
+            Text(subtitle)
+                .font(.system(size: 11))
+                .foregroundStyle(theme.treeFg.opacity(0.65))
+                .multilineTextAlignment(.center)
         }
     }
 

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -74,14 +74,14 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
         }
         return ["type": "gui_tab_bar", "active_index": Int(activeIndex), "tabs": tabArray]
 
-    case .guiFileTree(let version, let treeFlags, let selectedId, let treeWidth, let rootPath, let entries):
+    case .guiFileTree(let version, let treeFlags, let treeState, let selectedId, let treeWidth, let rootPath, let errorReason, let entries):
         let entryArray = entries.map { e -> [String: Any] in
             ["id": e.id, "path": e.path, "name": e.name, "relative_path": e.relPath, "depth": Int(e.depth),
              "is_dir": e.isDir, "is_expanded": e.isExpanded, "is_selected": e.isSelected, "is_focused": e.isFocused,
              "is_active": e.isActive, "is_dirty": e.isDirty, "is_editing": e.isEditing,
              "git_status": Int(e.gitStatus), "icon": e.icon]
         }
-        return ["type": "gui_file_tree", "version": Int(version), "tree_flags": Int(treeFlags), "selected_id": selectedId, "tree_width": Int(treeWidth), "root_path": rootPath, "entries": entryArray]
+        return ["type": "gui_file_tree", "version": Int(version), "tree_flags": Int(treeFlags), "tree_state": Int(treeState), "selected_id": selectedId, "tree_width": Int(treeWidth), "root_path": rootPath, "error_reason": errorReason, "entries": entryArray]
 
     case .guiCompletion(let visible, let anchorRow, let anchorCol, let selectedIndex, let items):
         let itemArray = items.map { i -> [String: Any] in

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -95,26 +95,27 @@ struct CommandDispatcherRoutingTests {
     @MainActor func guiFileTreeRouting() {
         let (dispatcher, gui) = makeDispatcher()
         let entries = [wireFileTreeEntry(pathHash: 123, isDir: true, isExpanded: true, id: "/project/lib", path: "/project/lib", name: "lib", relPath: "lib")]
-        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x03, selectedId: "/project/lib", treeWidth: 30,
-                                          rootPath: "/project", entries: entries))
+        dispatcher.dispatch(.guiFileTree(version: 2, treeFlags: 0x03, treeState: 3, selectedId: "/project/lib", treeWidth: 30,
+                                          rootPath: "/project", errorReason: "", entries: entries))
 
         #expect(gui.fileTreeState.visible == true)
         #expect(gui.fileTreeState.focused == true)
+        #expect(gui.fileTreeState.treeState == .ready)
         #expect(gui.fileTreeState.entries.count == 1)
         #expect(gui.fileTreeState.entries[0].name == "lib")
         #expect(gui.fileTreeState.projectRoot == "/project")
     }
 
-    @Test("guiFileTree hides when visible flag is cleared")
-    @MainActor func guiFileTreeHidesOnInvisiblePayload() {
+    @Test("guiFileTree hides when explicit tree state is hidden")
+    @MainActor func guiFileTreeHidesOnHiddenState() {
         let (dispatcher, gui) = makeDispatcher()
-        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x01, selectedId: "/project/a", treeWidth: 30,
-                                          rootPath: "/project",
+        dispatcher.dispatch(.guiFileTree(version: 2, treeFlags: 0x01, treeState: 3, selectedId: "/project/a", treeWidth: 30,
+                                          rootPath: "/project", errorReason: "",
                                           entries: [wireFileTreeEntry(pathHash: 1, id: "/project/a", path: "/project/a", name: "a", relPath: "a")]))
         #expect(gui.fileTreeState.visible == true)
 
-        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x10, selectedId: "", treeWidth: 0,
-                                          rootPath: "/project", entries: []))
+        dispatcher.dispatch(.guiFileTree(version: 2, treeFlags: 0x00, treeState: 0, selectedId: "", treeWidth: 0,
+                                          rootPath: "/project", errorReason: "", entries: []))
         #expect(gui.fileTreeState.visible == false)
         #expect(gui.fileTreeState.projectRoot == "/project")
     }
@@ -122,12 +123,12 @@ struct CommandDispatcherRoutingTests {
     @Test("guiFileTree clears project root when hidden payload has no root")
     @MainActor func guiFileTreeClearsRootOnHiddenPayload() {
         let (dispatcher, gui) = makeDispatcher()
-        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x01, selectedId: "/project/a", treeWidth: 30,
-                                          rootPath: "/project",
+        dispatcher.dispatch(.guiFileTree(version: 2, treeFlags: 0x01, treeState: 3, selectedId: "/project/a", treeWidth: 30,
+                                          rootPath: "/project", errorReason: "",
                                           entries: [wireFileTreeEntry(pathHash: 1, id: "/project/a", path: "/project/a", name: "a", relPath: "a")]))
 
-        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x10, selectedId: "", treeWidth: 0,
-                                          rootPath: "", entries: []))
+        dispatcher.dispatch(.guiFileTree(version: 2, treeFlags: 0x00, treeState: 0, selectedId: "", treeWidth: 0,
+                                          rootPath: "", errorReason: "", entries: []))
 
         #expect(gui.fileTreeState.visible == false)
         #expect(gui.fileTreeState.projectRoot == "")
@@ -137,12 +138,29 @@ struct CommandDispatcherRoutingTests {
     @MainActor func guiFileTreeKeepsEmptyVisibleTreeOpen() {
         let (dispatcher, gui) = makeDispatcher()
 
-        dispatcher.dispatch(.guiFileTree(version: 1, treeFlags: 0x11, selectedId: "", treeWidth: 30,
-                                          rootPath: "/empty-project", entries: []))
+        dispatcher.dispatch(.guiFileTree(version: 2, treeFlags: 0x11, treeState: 2, selectedId: "", treeWidth: 30,
+                                          rootPath: "/empty-project", errorReason: "", entries: []))
 
         #expect(gui.fileTreeState.visible == true)
+        #expect(gui.fileTreeState.treeState == .empty)
         #expect(gui.fileTreeState.entries.isEmpty)
         #expect(gui.fileTreeState.projectRoot == "/empty-project")
+    }
+
+    @Test("guiFileTree preserves loading and error states with empty entries")
+    @MainActor func guiFileTreePreservesLoadingAndErrorStates() {
+        let (dispatcher, gui) = makeDispatcher()
+
+        dispatcher.dispatch(.guiFileTree(version: 2, treeFlags: 0x01, treeState: 1, selectedId: "", treeWidth: 30,
+                                          rootPath: "/project", errorReason: "", entries: []))
+        #expect(gui.fileTreeState.visible == true)
+        #expect(gui.fileTreeState.treeState == .loading)
+
+        dispatcher.dispatch(.guiFileTree(version: 2, treeFlags: 0x01, treeState: 4, selectedId: "", treeWidth: 30,
+                                          rootPath: "/project", errorReason: "permission denied", entries: []))
+        #expect(gui.fileTreeState.visible == true)
+        #expect(gui.fileTreeState.treeState == .error)
+        #expect(gui.fileTreeState.errorReason == "permission denied")
     }
 
     @Test("guiGitStatus updates state when repo has entries")

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -656,12 +656,14 @@ struct GUIFileTreeDecoderTests {
     @Test("Decode semantic gui_file_tree with entries")
     func decodeWithEntries() throws {
         var payload = Data()
-        payload.append(1) // version
+        payload.append(2) // version
         payload.append(0x03) // visible + focused
+        payload.append(3) // ready tree state
         appendString16(&payload, "/home/user/project/lib") // selectedId
         appendString16(&payload, "/home/user/project") // rootPath
         appendU16(&payload, 30) // treeWidth
         appendU16(&payload, 2) // rowCount
+        appendString16(&payload, "") // errorReason
 
         appendSemanticRow(
             &payload,
@@ -707,16 +709,18 @@ struct GUIFileTreeDecoderTests {
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiFileTree(let version, let treeFlags, let selectedId, let treeWidth, let rootPath, let entries) = cmd else {
+        guard case .guiFileTree(let version, let treeFlags, let treeState, let selectedId, let treeWidth, let rootPath, let errorReason, let entries) = cmd else {
             Issue.record("Expected .guiFileTree"); return
         }
 
-        #expect(version == 1)
+        #expect(version == 2)
         #expect(treeFlags & 0x01 != 0)
         #expect(treeFlags & 0x02 != 0)
+        #expect(treeState == 3)
         #expect(selectedId == "/home/user/project/lib")
         #expect(treeWidth == 30)
         #expect(rootPath == "/home/user/project")
+        #expect(errorReason == "")
         #expect(entries.count == 2)
         #expect(entries[0].pathHash == 0xAABBCCDD)
         #expect(entries[0].isDir == true)
@@ -742,12 +746,14 @@ struct GUIFileTreeDecoderTests {
     @Test("Decode semantic gui_file_tree hidden")
     func decodeHidden() throws {
         var payload = Data()
-        payload.append(1) // version
-        payload.append(0x10) // empty, not visible
+        payload.append(2) // version
+        payload.append(0x00) // not visible
+        payload.append(0) // hidden tree state
         appendString16(&payload, "")
         appendString16(&payload, "/home/user/project")
         appendU16(&payload, 0)
         appendU16(&payload, 0)
+        appendString16(&payload, "")
 
         var data = Data()
         data.append(OP_GUI_FILE_TREE)
@@ -757,25 +763,61 @@ struct GUIFileTreeDecoderTests {
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
-        guard case .guiFileTree(_, let treeFlags, _, let treeWidth, let rootPath, let entries) = cmd else {
+        guard case .guiFileTree(_, let treeFlags, let treeState, _, let treeWidth, let rootPath, _, let entries) = cmd else {
             Issue.record("Expected .guiFileTree"); return
         }
         #expect(treeFlags & 0x01 == 0)
-        #expect(treeFlags & 0x10 != 0)
+        #expect(treeFlags & 0x10 == 0)
+        #expect(treeState == 0)
         #expect(treeWidth == 0)
         #expect(rootPath == "/home/user/project")
         #expect(entries.isEmpty)
     }
 
+    @Test("Decode semantic gui_file_tree loading empty and error states")
+    func decodeExplicitEmptyStates() throws {
+        for (state, flags, reason) in [(UInt8(1), UInt8(0x01), ""), (UInt8(2), UInt8(0x11), ""), (UInt8(4), UInt8(0x01), "permission denied")] {
+            var payload = Data()
+            payload.append(2)
+            payload.append(flags)
+            payload.append(state)
+            appendString16(&payload, "")
+            appendString16(&payload, "/project")
+            appendU16(&payload, 30)
+            appendU16(&payload, 0)
+            appendString16(&payload, reason)
+
+            var data = Data()
+            data.append(OP_GUI_FILE_TREE)
+            appendU32(&data, UInt32(payload.count))
+            data.append(payload)
+
+            let (cmd, size) = try decodeCommand(data: data, offset: 0)
+            #expect(size == data.count)
+
+            guard case .guiFileTree(_, let treeFlags, let treeState, _, let treeWidth, let rootPath, let errorReason, let entries) = cmd else {
+                Issue.record("Expected .guiFileTree"); return
+            }
+            #expect(treeFlags == flags)
+            #expect(treeState == state)
+            #expect(treeWidth == 30)
+            #expect(rootPath == "/project")
+            #expect(errorReason == reason)
+            #expect(entries.isEmpty)
+        }
+    }
+
     @Test("Decode semantic gui_file_tree editing row")
     func decodeEditingRow() throws {
         var payload = Data()
-        payload.append(1)
+        payload.append(2)
         payload.append(0x03)
+        payload.append(3)
         appendString16(&payload, "/project/ñ📄.txt")
         appendString16(&payload, "/project")
         appendU16(&payload, 30)
         appendU16(&payload, 1)
+        appendString16(&payload, "")
         appendSemanticRow(
             &payload,
             hash: 1,
@@ -798,7 +840,7 @@ struct GUIFileTreeDecoderTests {
         data.append(payload)
 
         let (cmd, _) = try decodeCommand(data: data, offset: 0)
-        guard case .guiFileTree(_, _, _, _, _, let entries) = cmd else {
+        guard case .guiFileTree(_, _, _, _, _, _, _, let entries) = cmd else {
             Issue.record("Expected .guiFileTree"); return
         }
         #expect(entries.count == 1)

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -293,6 +293,31 @@ struct FileTreeViewTests {
 
         #expect(fields.count == 1)
     }
+
+    @Test("Empty loading and error states render friendly messages")
+    @MainActor func fileTreeEmptyLoadingErrorStatesRenderMessages() throws {
+        let state = FileTreeState()
+        state.visible = true
+        state.treeState = .empty
+        state.entries = []
+
+        var sut = FileTreeView(fileTreeState: state, theme: ThemeColors(), encoder: nil)
+        var strings = try sut.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+        #expect(strings.contains("No files yet"))
+        #expect(strings.contains("Create a file or refresh after adding project files."))
+
+        state.treeState = .loading
+        sut = FileTreeView(fileTreeState: state, theme: ThemeColors(), encoder: nil)
+        strings = try sut.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+        #expect(strings.contains("Loading files…"))
+
+        state.treeState = .error
+        state.errorReason = "permission denied"
+        sut = FileTreeView(fileTreeState: state, theme: ThemeColors(), encoder: nil)
+        strings = try sut.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+        #expect(strings.contains("Couldn’t load file tree"))
+        #expect(strings.contains("permission denied"))
+    }
 }
 
 // MARK: - FileTreeRowView

--- a/macos/Tests/MingaTests/StateLifecycleTests.swift
+++ b/macos/Tests/MingaTests/StateLifecycleTests.swift
@@ -175,11 +175,30 @@ struct FileTreeStateLifecycleTests {
         #expect(state.focused == true)
         #expect(state.selectedIndex == 1)
         #expect(state.projectRoot == "/project")
+        #expect(state.treeState == .ready)
         #expect(state.entries.count == 2)
         #expect(state.entries[0].isDir == true)
         #expect(state.entries[0].name == "lib")
         #expect(state.entries[1].isSelected == true)
         #expect(state.entries[1].relPath == "lib/editor.ex")
+    }
+
+    @Test("update() preserves explicit empty loading and error states")
+    @MainActor func updatePreservesExplicitStates() {
+        let state = FileTreeState()
+
+        state.update(version: 2, selectedId: "", focused: false, treeWidth: 30, rootPath: "/project", rawEntries: [], treeState: 1)
+        #expect(state.visible == true)
+        #expect(state.treeState == .loading)
+
+        state.update(version: 2, selectedId: "", focused: false, treeWidth: 30, rootPath: "/project", rawEntries: [], treeState: 2)
+        #expect(state.visible == true)
+        #expect(state.treeState == .empty)
+
+        state.update(version: 2, selectedId: "", focused: false, treeWidth: 30, rootPath: "/project", rawEntries: [], treeState: 4, errorReason: "permission denied")
+        #expect(state.visible == true)
+        #expect(state.treeState == .error)
+        #expect(state.errorReason == "permission denied")
     }
 
     @Test("fullPath() uses BEAM-supplied absolute path")

--- a/test/minga_editor/file_tree/rows_test.exs
+++ b/test/minga_editor/file_tree/rows_test.exs
@@ -8,6 +8,7 @@ defmodule MingaEditor.FileTree.RowsTest do
   alias Minga.Project.FileTree
   alias MingaEditor.FileTree.Diagnostics, as: RowDiagnostics
   alias MingaEditor.FileTree.Rows
+  alias MingaEditor.State.FileTree, as: FileTreeState
 
   @moduletag :tmp_dir
 
@@ -186,6 +187,54 @@ defmodule MingaEditor.FileTree.RowsTest do
 
     test "returns no rows for an empty visible tree", %{tmp_dir: tmp_dir} do
       assert Rows.from_tree(FileTree.new(tmp_dir)) == []
+    end
+  end
+
+  describe "FileTreeState.status/1" do
+    test "distinguishes hidden, empty, ready, loading, and error states", %{tmp_dir: tmp_dir} do
+      assert FileTreeState.status(%FileTreeState{}) == :hidden
+
+      empty_tree = FileTree.new(tmp_dir)
+      assert FileTreeState.status(FileTreeState.open(%FileTreeState{}, empty_tree, nil)) == :empty
+
+      ready_tree = flat_tree(tmp_dir)
+      assert FileTreeState.status(FileTreeState.open(%FileTreeState{}, ready_tree, nil)) == :ready
+
+      loading = FileTreeState.loading(%FileTreeState{project_root: tmp_dir})
+      assert FileTreeState.status(loading) == :loading
+
+      missing_tree = FileTree.new(Path.join(tmp_dir, "missing"))
+
+      assert {:error, reason} =
+               FileTreeState.status(FileTreeState.open(%FileTreeState{}, missing_tree, nil))
+
+      assert reason != ""
+    end
+
+    test "replace_tree clears stale loading or error state", %{tmp_dir: tmp_dir} do
+      ready_tree = flat_tree(tmp_dir)
+
+      loading =
+        %FileTreeState{tree: ready_tree}
+        |> FileTreeState.loading()
+        |> FileTreeState.replace_tree(ready_tree)
+
+      assert FileTreeState.status(loading) == :ready
+
+      errored =
+        %FileTreeState{tree: ready_tree}
+        |> FileTreeState.error(:eacces)
+        |> FileTreeState.replace_tree(ready_tree)
+
+      assert FileTreeState.status(errored) == :ready
+    end
+
+    test "width preserves the last sidebar width for state-only payloads", %{tmp_dir: tmp_dir} do
+      tree = FileTree.new(tmp_dir, width: 42)
+      file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
+
+      assert FileTreeState.width(file_tree) == 42
+      assert file_tree |> FileTreeState.close() |> FileTreeState.width() == 42
     end
   end
 

--- a/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
+++ b/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
@@ -181,9 +181,9 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
       assert Enum.any?(all_cmds, fn
                <<0x93, payload_len::32, payload::binary-size(payload_len)>> ->
                  match?(
-                   <<1::8, tree_flags::8, 0::16, ^root_len::16, ^root::binary-size(root_len),
-                     0::16, 0::16>>
-                   when Bitwise.band(tree_flags, 0x10) != 0,
+                   <<2::8, tree_flags::8, 0::8, 0::16, ^root_len::16,
+                     ^root::binary-size(root_len), 0::16, 0::16, 0::16>>
+                   when Bitwise.band(tree_flags, 0x01) == 0,
                    payload
                  )
 
@@ -228,9 +228,9 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
       assert Enum.any?(all_cmds, fn
                <<0x93, payload_len::32, payload::binary-size(payload_len)>> ->
                  match?(
-                   <<1::8, tree_flags::8, 0::16, ^root_len::16,
-                     ^second_root::binary-size(root_len), 0::16, 0::16>>
-                   when Bitwise.band(tree_flags, 0x10) != 0,
+                   <<2::8, tree_flags::8, 0::8, 0::16, ^root_len::16,
+                     ^second_root::binary-size(root_len), 0::16, 0::16, 0::16>>
+                   when Bitwise.band(tree_flags, 0x01) == 0,
                    payload
                  )
 

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -1127,18 +1127,21 @@ defmodule MingaEditor.Frontend.ProtocolTest do
           editing: nil
         )
 
-      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, true, true, [row])
+      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, :ready, true, [row])
 
       assert <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
-      assert <<1::8, tree_flags::8, rest::binary>> = payload
+      assert <<2::8, tree_flags::8, 3::8, rest::binary>> = payload
       assert Bitwise.band(tree_flags, 0x01) != 0
       assert Bitwise.band(tree_flags, 0x02) != 0
 
       <<selected_len::16, selected::binary-size(selected_len), rest::binary>> = rest
       assert selected == row.id
 
-      <<root_len::16, root::binary-size(root_len), 30::16, 1::16, row_payload::binary>> = rest
+      <<root_len::16, root::binary-size(root_len), 30::16, 1::16, error_len::16,
+        error_reason::binary-size(error_len), row_payload::binary>> = rest
+
       assert root == "/project"
+      assert error_reason == ""
 
       expected_hash = :erlang.phash2(row.id, 0xFFFFFFFF)
 
@@ -1182,13 +1185,13 @@ defmodule MingaEditor.Frontend.ProtocolTest do
           editing: nil
         )
 
-      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, true, false, [row])
+      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, :ready, false, [row])
       <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
 
-      <<_version::8, _tree_flags::8, selected_len::16, _selected::binary-size(selected_len),
-        root_len::16, _root::binary-size(root_len), _width::16, _count::16, _hash::32,
-        _row_flags::16, _depth::8, _git::8, 65_535::16, 65_535::16, 3::16, 4::16, _rest::binary>> =
-        payload
+      <<_version::8, _tree_flags::8, _tree_state::8, selected_len::16,
+        _selected::binary-size(selected_len), root_len::16, _root::binary-size(root_len),
+        _width::16, _count::16, 0::16, _hash::32, _row_flags::16, _depth::8, _git::8, 65_535::16,
+        65_535::16, 3::16, 4::16, _rest::binary>> = payload
     end
 
     test "encodes semantic gui_file_tree string lengths as UTF-8 byte counts" do
@@ -1207,13 +1210,13 @@ defmodule MingaEditor.Frontend.ProtocolTest do
           editing: nil
         )
 
-      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, true, false, [row])
+      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, :ready, false, [row])
       <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
 
-      <<_version::8, _tree_flags::8, selected_len::16, selected::binary-size(selected_len),
-        root_len::16, _root::binary-size(root_len), _width::16, _count::16, _hash::32,
-        _row_flags::16, _depth::8, _git::8, _diag::binary-size(8), 0::8, strings::binary>> =
-        payload
+      <<_version::8, _tree_flags::8, _tree_state::8, selected_len::16,
+        selected::binary-size(selected_len), root_len::16, _root::binary-size(root_len),
+        _width::16, _count::16, 0::16, _hash::32, _row_flags::16, _depth::8, _git::8,
+        _diag::binary-size(8), 0::8, strings::binary>> = payload
 
       assert selected == row.id
       assert selected_len == byte_size(row.id)
@@ -1246,26 +1249,51 @@ defmodule MingaEditor.Frontend.ProtocolTest do
           )
         end
 
-      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, true, false, rows)
+      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, :ready, false, rows)
 
       assert <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
       assert payload_len == byte_size(payload)
       assert payload_len > 65_535
     end
 
-    test "encodes hidden semantic gui_file_tree with project root and empty bit" do
+    test "encodes hidden semantic gui_file_tree with explicit hidden state" do
       encoded = ProtocolGUI.encode_hidden_gui_file_tree("/tmp/minga-project")
 
       assert <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
 
-      assert <<1::8, tree_flags::8, selected_len::16, selected::binary-size(selected_len),
-               root_len::16, root::binary-size(root_len), 0::16, 0::16>> = payload
+      assert <<2::8, tree_flags::8, 0::8, selected_len::16, selected::binary-size(selected_len),
+               root_len::16, root::binary-size(root_len), 0::16, 0::16, 0::16>> = payload
 
       assert selected == ""
 
       refute Bitwise.band(tree_flags, 0x01) != 0
-      assert Bitwise.band(tree_flags, 0x10) != 0
+      refute Bitwise.band(tree_flags, 0x10) != 0
       assert root == "/tmp/minga-project"
+    end
+
+    test "encodes visible empty, loading, and error semantic gui_file_tree states without rows" do
+      empty = ProtocolGUI.encode_gui_file_tree("/project", 30, :empty, false, [])
+      loading = ProtocolGUI.encode_gui_file_tree("/project", 30, :loading, false, [])
+
+      error =
+        ProtocolGUI.encode_gui_file_tree("/project", 30, {:error, "permission denied"}, false, [])
+
+      assert <<0x93, _::32, 2::8, empty_flags::8, 2::8, _empty_rest::binary>> = empty
+      assert Bitwise.band(empty_flags, 0x01) != 0
+      assert Bitwise.band(empty_flags, 0x10) != 0
+
+      assert <<0x93, _::32, 2::8, loading_flags::8, 1::8, _loading_rest::binary>> = loading
+      assert Bitwise.band(loading_flags, 0x01) != 0
+      refute Bitwise.band(loading_flags, 0x10) != 0
+
+      assert <<0x93, payload_len::32, payload::binary-size(payload_len)>> = error
+
+      assert <<2::8, error_flags::8, 4::8, selected_len::16, _selected::binary-size(selected_len),
+               root_len::16, _root::binary-size(root_len), 30::16, 0::16, reason_len::16,
+               reason::binary-size(reason_len)>> = payload
+
+      assert Bitwise.band(error_flags, 0x01) != 0
+      assert reason == "permission denied"
     end
 
     test "encodes semantic gui_file_tree editing payload" do
@@ -1284,13 +1312,13 @@ defmodule MingaEditor.Frontend.ProtocolTest do
           editing: %{index: 0, text: "renamed.txt", type: :rename, original_name: "target.txt"}
         )
 
-      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, true, true, [row])
+      encoded = ProtocolGUI.encode_gui_file_tree("/project", 30, :ready, true, [row])
       <<0x93, payload_len::32, payload::binary-size(payload_len)>> = encoded
       # Skip tree header and fixed row prefix.
-      <<_version::8, _tree_flags::8, selected_len::16, _selected::binary-size(selected_len),
-        root_len::16, _root::binary-size(root_len), _width::16, _count::16, _hash::32,
-        row_flags::16, _depth::8, _git::8, _diag::binary-size(8), 0::8, strings::binary>> =
-        payload
+      <<_version::8, _tree_flags::8, _tree_state::8, selected_len::16,
+        _selected::binary-size(selected_len), root_len::16, _root::binary-size(root_len),
+        _width::16, _count::16, 0::16, _hash::32, row_flags::16, _depth::8, _git::8,
+        _diag::binary-size(8), 0::8, strings::binary>> = payload
 
       assert Bitwise.band(row_flags, 0x40) != 0
       {_id, strings} = take_string16(strings)

--- a/test/minga_editor/integration/gui_protocol_test.exs
+++ b/test/minga_editor/integration/gui_protocol_test.exs
@@ -906,13 +906,15 @@ defmodule Minga.Integration.GUIProtocolTest do
         )
       ]
 
-      Port.command(port, ProtocolGUI.encode_gui_file_tree(root, 30, true, true, rows))
+      Port.command(port, ProtocolGUI.encode_gui_file_tree(root, 30, :ready, true, rows))
 
       assert_receive {^port, {:data, json}}, 5_000
       decoded = Jason.decode!(json)
 
       assert decoded["type"] == "gui_file_tree"
-      assert decoded["version"] == 1
+      assert decoded["version"] == 2
+      assert decoded["tree_state"] == 3
+      assert decoded["error_reason"] == ""
       assert Bitwise.band(decoded["tree_flags"], 0x01) != 0
       assert Bitwise.band(decoded["tree_flags"], 0x02) != 0
       assert decoded["selected_id"] == "/project/lib"

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -110,6 +110,53 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       refute Enum.any?(draws, fn {row, col, _text, _style} -> row > 0 and col < 20 end)
     end
 
+    test "renders empty loading and error rows without layout drift", %{tmp_dir: tmp_dir} do
+      tree = FileTree.new(tmp_dir, width: 24)
+      theme = Theme.get!(:doom_one)
+
+      empty_draws =
+        TreeRenderer.render(%RenderInput{
+          tree: tree,
+          rect: {0, 0, 24, 5},
+          focused: false,
+          theme: theme,
+          active_path: nil,
+          rows: []
+        })
+
+      loading_draws =
+        TreeRenderer.render(%RenderInput{
+          tree: tree,
+          rect: {0, 0, 24, 5},
+          focused: false,
+          theme: theme,
+          active_path: nil,
+          rows: [],
+          status: :loading
+        })
+
+      error_draws =
+        TreeRenderer.render(%RenderInput{
+          tree: tree,
+          rect: {0, 0, 24, 5},
+          focused: false,
+          theme: theme,
+          active_path: nil,
+          rows: [],
+          status: {:error, "permission denied"}
+        })
+
+      assert draw_texts(empty_draws) =~ "No files yet"
+      assert draw_texts(loading_draws) =~ "Loading files"
+      assert draw_texts(error_draws) =~ "File tree error"
+      assert draw_texts(error_draws) =~ "permission denied"
+
+      for draws <- [empty_draws, loading_draws, error_draws] do
+        assert Enum.any?(draws, fn {_row, col, text, _style} -> col == 24 and text == "│" end)
+        refute Enum.any?(draws, fn {row, col, _text, _style} -> row < 0 or col < 0 end)
+      end
+    end
+
     test "renders indent guides and file icons", %{tmp_dir: tmp_dir} do
       input = %RenderInput{
         tree: sample_tree(tmp_dir),
@@ -610,6 +657,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       active_path: nil,
       rows: rows
     })
+  end
+
+  defp draw_texts(draws) do
+    Enum.map_join(draws, fn {_r, _c, text, _style} -> text end)
   end
 
   defp draw_containing(draws, text) do


### PR DESCRIPTION
# TL;DR
The file tree now carries explicit hidden, loading, empty, ready, and error states from the BEAM presentation model through the GUI protocol and native frontends. This removes the old `entry_count == 0` ambiguity and gives macOS and TUI intentional visible states for loading, empty projects, and errors.

Closes #1647

## Context
#1647 is part of the file tree polish epic (#1638). The previous protocol shape made an empty list of rows do too much: it could mean hidden, loading, empty, or error depending on caller behavior. This PR makes the tree state explicit so each frontend can render the right UI and future changes have targeted regression coverage.

## Changes
- Added explicit file tree status to `MingaEditor.State.FileTree`: `:hidden`, `:loading`, `:empty`, `:ready`, and `{:error, reason}`.
- Updated file tree mutations to go through `FileTreeState.replace_tree/2` so derived status stays fresh after refreshes, file events, and handler updates.
- Extended the GUI file tree payload to v2 with `tree_state` and `error_reason`, while keeping legacy v1 decoding in Swift.
- Updated GUI emission and chrome caching so status, root, width, and rows are part of the file tree fingerprint.
- Added macOS rendering for friendly loading, empty, and error states, including appropriate refresh/new-file actions where available.
- Added TUI state rows for loading, empty, and error states without changing the sidebar layout contract.
- Documented the v2 protocol semantics and clarified that `row_count == 0` is state-qualified, not a visibility signal by itself.
- Added targeted Elixir and Swift regression tests for protocol encoding/decoding, state lifecycle, GUI dispatch, TUI rendering, and semantic row coverage.

## Verification
- `make lint` passed with only pre-existing struct-field-count warnings.
- `mix test.llm` passed after an unrelated transient agent picker timeout passed in isolation.
- `mix test --failed` reported no persisted failures.
- `mix swift.build` passed.
- `xcodebuild test -project Minga.xcodeproj -scheme Minga -destination 'platform=macOS'` passed with 556 tests.
- Final reviewer gate passed.

## Acceptance Criteria Addressed
- Hidden tree, visible empty tree, loading tree, and error tree states are distinct in the BEAM model and native GUI protocol. ✅
- macOS renders friendly empty/loading/error states with appropriate actions where available, such as refresh or open project. ✅
- TUI renders clear empty/loading/error rows without breaking layout or focus behavior. ✅
- Protocol docs define exactly what `entry_count == 0` means for hidden vs visible-empty states. ✅
- Tests cover selected, active, dirty, git, diagnostics, editing, nested, hidden, loading, empty, and error states at the lightest practical layer. ✅
- Snapshot tests are avoided unless targeted assertions cannot verify the behavior. ✅
