### PR TITLE
refactor(buffer): extract change log

### DIFF
--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -42,6 +42,7 @@ defmodule Minga.Credo.DependencyDirectionCheck do
   # Entire directories (Minga.Core, Minga.Mode) are Layer 0.
   # Individual modules from mixed directories (buffer/, editing/) are listed explicitly.
   @layer_0_prefixes [
+    "Minga.Buffer.ChangeLog",
     "Minga.Buffer.Document",
     "Minga.Buffer.EditDelta",
     "Minga.Buffer.EditSource",

--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -394,8 +394,8 @@ defmodule Minga.Buffer do
 
   # ── Edit deltas (for LSP incremental sync) ─────────────────────────
 
-  @doc "Consume edit deltas accumulated since the given consumer's last read."
-  @spec consume_edit_deltas(t(), atom()) :: [Minga.Buffer.EditDelta.t()]
+  @doc "Consume edit deltas accumulated since the given consumer's last read, or return `:reset_required` when the consumer must full-sync."
+  @spec consume_edit_deltas(t(), atom()) :: BufferProcess.edit_delta_update()
   defdelegate consume_edit_deltas(server, consumer_id), to: BufferProcess
 
   # ── Decorations ────────────────────────────────────────────────────

--- a/lib/minga/buffer/change_log.ex
+++ b/lib/minga/buffer/change_log.ex
@@ -1,0 +1,119 @@
+defmodule Minga.Buffer.ChangeLog do
+  @moduledoc """
+  Ordered record of edit deltas that lets sync consumers catch up independently.
+
+  The buffer process applies edits to the document immediately. This struct remembers the resulting `Minga.Buffer.EditDelta` values for systems that sync incrementally, such as highlighting or language tooling. Each consumer keeps its own cursor, so one consumer reading changes does not steal them from another consumer.
+
+  This module is pure state. It does not broadcast events, adjust decorations, or know about GenServer calls.
+  """
+
+  alias Minga.Buffer.EditDelta
+
+  @max_single_consumer_entries 1000
+
+  @type consumer :: atom()
+  @type sequence :: non_neg_integer()
+  @type entry :: {sequence(), EditDelta.t()}
+  @type unseen_changes :: {:ok, [EditDelta.t()]} | :reset_required
+
+  defstruct pending_changes: [],
+            sequence: 0,
+            entries: [],
+            consumer_cursors: %{}
+
+  @opaque t :: %__MODULE__{
+            pending_changes: [EditDelta.t()],
+            sequence: sequence(),
+            entries: [entry()],
+            consumer_cursors: %{consumer() => sequence()}
+          }
+
+  @doc "Creates an empty change log."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Records a new edit delta."
+  @spec record_change(t(), EditDelta.t()) :: t()
+  def record_change(%__MODULE__{} = log, %EditDelta{} = delta) do
+    sequence = log.sequence + 1
+
+    %{
+      log
+      | pending_changes: [delta | log.pending_changes],
+        sequence: sequence,
+        entries: [{sequence, delta} | log.entries]
+    }
+  end
+
+  @doc "Returns globally pending changes in edit order and clears that legacy pending list."
+  @spec drain_pending_changes(t()) :: {[EditDelta.t()], t()}
+  def drain_pending_changes(%__MODULE__{} = log) do
+    {Enum.reverse(log.pending_changes), %{log | pending_changes: []}}
+  end
+
+  @doc """
+  Returns changes unseen by `consumer` in edit order and advances that consumer's cursor.
+
+  Returns `:reset_required` when older retained entries were compacted before the consumer caught up. Callers must full-sync their downstream state in that case.
+  """
+  @spec take_unseen_changes(t(), consumer()) :: {unseen_changes(), t()}
+  def take_unseen_changes(%__MODULE__{} = log, consumer) when is_atom(consumer) do
+    cursor = Map.get(log.consumer_cursors, consumer, 0)
+    result = unseen_changes(log, cursor)
+    consumer_cursors = Map.put(log.consumer_cursors, consumer, log.sequence)
+    log = %{log | consumer_cursors: consumer_cursors}
+
+    {result, compact(log)}
+  end
+
+  @doc "Clears all recorded changes and consumer cursors."
+  @spec clear(t()) :: t()
+  def clear(%__MODULE__{} = log) do
+    %{log | pending_changes: [], entries: [], consumer_cursors: %{}}
+  end
+
+  @doc false
+  @spec retained_count(t()) :: non_neg_integer()
+  def retained_count(%__MODULE__{} = log), do: length(log.entries)
+
+  @spec unseen_changes(t(), sequence()) :: unseen_changes()
+  defp unseen_changes(%__MODULE__{sequence: sequence}, cursor) when cursor >= sequence,
+    do: {:ok, []}
+
+  defp unseen_changes(%__MODULE__{entries: []}, _cursor), do: :reset_required
+
+  defp unseen_changes(%__MODULE__{} = log, cursor) do
+    earliest = earliest_retained_sequence(log.entries)
+
+    if cursor + 1 < earliest do
+      :reset_required
+    else
+      {:ok, changes_after(log.entries, cursor)}
+    end
+  end
+
+  @spec changes_after([entry()], sequence()) :: [EditDelta.t()]
+  defp changes_after(entries, cursor) do
+    entries
+    |> Enum.filter(fn {sequence, _delta} -> sequence > cursor end)
+    |> Enum.sort_by(fn {sequence, _delta} -> sequence end)
+    |> Enum.map(fn {_sequence, delta} -> delta end)
+  end
+
+  @spec earliest_retained_sequence([entry()]) :: sequence()
+  defp earliest_retained_sequence(entries) do
+    entries
+    |> Enum.map(fn {sequence, _delta} -> sequence end)
+    |> Enum.min()
+  end
+
+  @spec compact(t()) :: t()
+  defp compact(%__MODULE__{consumer_cursors: cursors} = log) when map_size(cursors) >= 2 do
+    min_cursor = cursors |> Map.values() |> Enum.min()
+    %{log | entries: Enum.filter(log.entries, fn {sequence, _delta} -> sequence > min_cursor end)}
+  end
+
+  defp compact(%__MODULE__{} = log) do
+    %{log | entries: Enum.take(log.entries, @max_single_consumer_entries)}
+  end
+end

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -18,7 +18,17 @@ defmodule Minga.Buffer.Process do
 
   use GenServer
 
-  alias Minga.Buffer.{Cursor, Document, Lines, Operation, Persistence, Position, Replace}
+  alias Minga.Buffer.{
+    ChangeLog,
+    Cursor,
+    Document,
+    Lines,
+    Operation,
+    Persistence,
+    Position,
+    Replace
+  }
+
   alias Minga.Buffer.EditDelta
   alias Minga.Buffer.EditSource
   alias Minga.Config
@@ -47,6 +57,7 @@ defmodule Minga.Buffer.Process do
 
   @typedoc "Internal state of the buffer server."
   @type state :: BufState.t()
+  @type edit_delta_update :: {:ok, [EditDelta.t()]} | :reset_required
 
   # ── Child Spec ──
 
@@ -323,7 +334,7 @@ defmodule Minga.Buffer.Process do
   Returns and clears pending edit deltas accumulated since the last legacy consumer read.
 
   Deprecated: use `consume_edit_deltas/2` with a consumer_id for per-consumer cursors.
-  This legacy version destructively drains the shared pending_edits list.
+  This legacy version destructively drains the shared pending changes list.
   """
   @deprecated "Use consume_edit_deltas/2 with a consumer_id instead"
   @spec consume_edit_deltas(GenServer.server()) :: [EditDelta.t()]
@@ -335,7 +346,8 @@ defmodule Minga.Buffer.Process do
   Each consumer is identified by an atom (e.g., `:lsp`, `:highlight`).
   The buffer tracks a per-consumer cursor (sequence number). On each call,
   deltas since that cursor are returned and the cursor advances. The buffer
-  trims deltas that all registered consumers have read.
+  trims deltas that all registered consumers have read. Returns `:reset_required`
+  if older retained deltas were compacted before the consumer caught up.
 
   This avoids the data race where two consumers calling `consume_edit_deltas/1`
   would each miss the other's deltas.
@@ -345,7 +357,7 @@ defmodule Minga.Buffer.Process do
   HighlightSync still uses this during the migration period since it runs
   synchronously inside the Editor GenServer before the deferred broadcast fires.
   """
-  @spec consume_edit_deltas(GenServer.server(), atom()) :: [EditDelta.t()]
+  @spec consume_edit_deltas(GenServer.server(), atom()) :: edit_delta_update()
   def consume_edit_deltas(server, consumer_id) do
     GenServer.call(server, {:consume_edit_deltas, consumer_id})
   end
@@ -1158,7 +1170,7 @@ defmodule Minga.Buffer.Process do
       state
       | document: new_buf,
         version: state.version + 1,
-        pending_edits: [],
+        change_log: ChangeLog.clear(state.change_log),
         decorations: Decorations.new()
     }
 
@@ -1181,7 +1193,7 @@ defmodule Minga.Buffer.Process do
         file_hash: Persistence.content_fingerprint(new_content),
         undo_stack: [],
         redo_stack: [],
-        pending_edits: [],
+        change_log: ChangeLog.clear(state.change_log),
         decorations: Decorations.new()
     }
 
@@ -1235,39 +1247,13 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call(:consume_edit_deltas, _from, state) do
-    edits = Enum.reverse(state.pending_edits)
-    {:reply, edits, %{state | pending_edits: []}}
+    {edits, change_log} = ChangeLog.drain_pending_changes(state.change_log)
+    {:reply, edits, %{state | change_log: change_log}}
   end
 
   def handle_call({:consume_edit_deltas, consumer_id}, _from, state) do
-    cursor = Map.get(state.consumer_cursors, consumer_id, 0)
-
-    deltas =
-      state.edit_log
-      |> Enum.filter(fn {seq, _delta} -> seq > cursor end)
-      |> Enum.sort_by(fn {seq, _delta} -> seq end)
-      |> Enum.map(fn {_seq, delta} -> delta end)
-
-    new_cursor = state.edit_seq
-    new_cursors = Map.put(state.consumer_cursors, consumer_id, new_cursor)
-
-    # Trim log entries that all *registered* consumers have read.
-    # When only one consumer is registered, cap the log at @max_single_consumer_log
-    # to prevent unbounded growth if the second consumer never arrives.
-    trimmed_log =
-      if map_size(new_cursors) >= 2 do
-        min_cursor =
-          new_cursors
-          |> Map.values()
-          |> Enum.min()
-
-        Enum.filter(state.edit_log, fn {seq, _} -> seq > min_cursor end)
-      else
-        cap_log(state.edit_log)
-      end
-
-    new_state = %{state | consumer_cursors: new_cursors, edit_log: trimmed_log}
-    {:reply, deltas, new_state}
+    {result, change_log} = ChangeLog.take_unseen_changes(state.change_log, consumer_id)
+    {:reply, result, %{state | change_log: change_log}}
   end
 
   def handle_call(:version, _from, state) do
@@ -1602,7 +1588,7 @@ defmodule Minga.Buffer.Process do
       state
       | document: new_doc,
         version: state.version + 1,
-        pending_edits: [],
+        change_log: ChangeLog.clear(state.change_log),
         decorations: new_decs
     }
 
@@ -2068,14 +2054,7 @@ defmodule Minga.Buffer.Process do
 
   @spec record_edit(state(), EditDelta.t(), EditSource.t()) :: state()
   defp record_edit(state, delta, source) do
-    new_seq = state.edit_seq + 1
-
-    state = %{
-      state
-      | pending_edits: [delta | state.pending_edits],
-        edit_seq: new_seq,
-        edit_log: [{new_seq, delta} | state.edit_log]
-    }
+    state = %{state | change_log: ChangeLog.record_change(state.change_log, delta)}
 
     # Adjust decoration anchors based on the edit
     state =
@@ -2103,21 +2082,8 @@ defmodule Minga.Buffer.Process do
   @spec clear_edits(state(), EditSource.t()) :: state()
   defp clear_edits(state, source) do
     defer_buffer_changed(state, nil, source)
-    %{state | pending_edits: [], edit_log: [], consumer_cursors: %{}}
+    %{state | change_log: ChangeLog.clear(state.change_log)}
   end
-
-  # Maximum edit_log entries retained when only one consumer is registered.
-  # Prevents unbounded growth if the second consumer never calls consume_edit_deltas.
-  # At this limit, older entries are dropped (the lagging consumer will get a
-  # partial log and must fall back to full sync).
-  @max_single_consumer_log 1000
-
-  # Keeps only the most recent @max_single_consumer_log entries.
-  # The edit_log is stored newest-first (prepended in record_edit),
-  # so Enum.take gets the most recent entries. Enum.take is a no-op
-  # when the list is already shorter than the limit.
-  @spec cap_log([{non_neg_integer(), EditDelta.t()}]) :: [{non_neg_integer(), EditDelta.t()}]
-  defp cap_log(log), do: Enum.take(log, @max_single_consumer_log)
 
   # ── move_if_possible helpers ──
 

--- a/lib/minga/buffer/state.ex
+++ b/lib/minga/buffer/state.ex
@@ -13,9 +13,11 @@ defmodule Minga.Buffer.State do
   under burst editing while preserving correct undo for human-speed edits.
   """
 
+  alias Minga.Buffer.ChangeLog
   alias Minga.Buffer.Document
-  alias Minga.Buffer.EditDelta
   alias Minga.Core.Decorations
+
+  @default_change_log ChangeLog.new()
 
   @typedoc """
   Buffer type controlling behavior:
@@ -57,10 +59,7 @@ defmodule Minga.Buffer.State do
             read_only: false,
             unlisted: false,
             persistent: false,
-            pending_edits: [],
-            edit_seq: 0,
-            edit_log: [],
-            consumer_cursors: %{},
+            change_log: @default_change_log,
             decorations: %Decorations{},
             face_overrides: %{},
             options: %{},
@@ -90,10 +89,7 @@ defmodule Minga.Buffer.State do
           read_only: boolean(),
           unlisted: boolean(),
           persistent: boolean(),
-          pending_edits: [EditDelta.t()],
-          edit_seq: non_neg_integer(),
-          edit_log: [{non_neg_integer(), EditDelta.t()}],
-          consumer_cursors: %{atom() => non_neg_integer()},
+          change_log: ChangeLog.t(),
           decorations: Decorations.t(),
           face_overrides: %{String.t() => keyword()},
           options: %{atom() => term()},

--- a/lib/minga_editor/highlight_sync.ex
+++ b/lib/minga_editor/highlight_sync.ex
@@ -471,16 +471,20 @@ defmodule MingaEditor.HighlightSync do
 
     # Try incremental sync first: if the buffer has pending edit deltas,
     # send them as an edit_buffer command instead of the full content.
-    edits = Buffer.consume_edit_deltas(state.workspace.buffers.active, :highlight)
-
     commands =
-      if edits != [] do
-        delta_maps = Enum.map(edits, &Map.from_struct/1)
-        [Protocol.encode_edit_buffer(buffer_id, version, delta_maps)]
-      else
-        # No deltas (e.g., undo/redo, content replaced externally): full sync
-        content = Buffer.content(state.workspace.buffers.active)
-        [Protocol.encode_parse_buffer(buffer_id, version, content)]
+      case Buffer.consume_edit_deltas(state.workspace.buffers.active, :highlight) do
+        {:ok, []} ->
+          # No deltas (e.g., undo/redo, content replaced externally): full sync
+          content = Buffer.content(state.workspace.buffers.active)
+          [Protocol.encode_parse_buffer(buffer_id, version, content)]
+
+        {:ok, edits} ->
+          delta_maps = Enum.map(edits, &Map.from_struct/1)
+          [Protocol.encode_edit_buffer(buffer_id, version, delta_maps)]
+
+        :reset_required ->
+          content = Buffer.content(state.workspace.buffers.active)
+          [Protocol.encode_parse_buffer(buffer_id, version, content)]
       end
 
     ParserManager.send_commands(commands)

--- a/test/minga/buffer/change_log_test.exs
+++ b/test/minga/buffer/change_log_test.exs
@@ -1,0 +1,100 @@
+defmodule Minga.Buffer.ChangeLogTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.ChangeLog
+  alias Minga.Buffer.EditDelta
+
+  defp delta(text) do
+    EditDelta.insertion(0, {0, 0}, text, {0, byte_size(text)})
+  end
+
+  describe "record_change/2" do
+    test "records pending changes in edit order" do
+      log =
+        ChangeLog.new()
+        |> ChangeLog.record_change(delta("a"))
+        |> ChangeLog.record_change(delta("b"))
+
+      assert {[a, b], log} = ChangeLog.drain_pending_changes(log)
+      assert a.inserted_text == "a"
+      assert b.inserted_text == "b"
+      assert {[], _log} = ChangeLog.drain_pending_changes(log)
+    end
+  end
+
+  describe "take_unseen_changes/2" do
+    test "readers see their own unseen changes without stealing from each other" do
+      log =
+        ChangeLog.new()
+        |> ChangeLog.record_change(delta("a"))
+        |> ChangeLog.record_change(delta("b"))
+
+      assert {{:ok, [lsp_a, lsp_b]}, log} = ChangeLog.take_unseen_changes(log, :lsp)
+
+      assert {{:ok, [highlight_a, highlight_b]}, _log} =
+               ChangeLog.take_unseen_changes(log, :highlight)
+
+      assert Enum.map([lsp_a, lsp_b], & &1.inserted_text) == ["a", "b"]
+      assert Enum.map([highlight_a, highlight_b], & &1.inserted_text) == ["a", "b"]
+    end
+
+    test "a reader only sees changes recorded after its last read" do
+      log =
+        ChangeLog.new()
+        |> ChangeLog.record_change(delta("a"))
+        |> ChangeLog.record_change(delta("b"))
+
+      assert {{:ok, [_a, _b]}, log} = ChangeLog.take_unseen_changes(log, :lsp)
+
+      log = ChangeLog.record_change(log, delta("c"))
+
+      assert {{:ok, [c]}, log} = ChangeLog.take_unseen_changes(log, :lsp)
+      assert c.inserted_text == "c"
+      assert {{:ok, []}, _log} = ChangeLog.take_unseen_changes(log, :lsp)
+    end
+
+    test "entries are trimmed after all registered readers catch up" do
+      log =
+        ChangeLog.new()
+        |> ChangeLog.record_change(delta("a"))
+        |> ChangeLog.record_change(delta("b"))
+
+      assert {{:ok, [_a, _b]}, log} = ChangeLog.take_unseen_changes(log, :lsp)
+      assert ChangeLog.retained_count(log) == 2
+
+      assert {{:ok, [_a, _b]}, log} = ChangeLog.take_unseen_changes(log, :highlight)
+      assert ChangeLog.retained_count(log) == 0
+      assert {:reset_required, _log} = ChangeLog.take_unseen_changes(log, :late_reader)
+    end
+
+    test "entries are capped while only one reader is registered" do
+      log =
+        Enum.reduce(1..1100, ChangeLog.new(), fn i, acc ->
+          ChangeLog.record_change(acc, delta(Integer.to_string(i)))
+        end)
+
+      assert {{:ok, changes}, log} = ChangeLog.take_unseen_changes(log, :lsp)
+      assert length(changes) == 1100
+      assert ChangeLog.retained_count(log) == 1000
+
+      assert {:reset_required, _log} = ChangeLog.take_unseen_changes(log, :late_reader)
+    end
+  end
+
+  describe "clear/1" do
+    test "removes pending changes, retained entries, and reader positions" do
+      log =
+        ChangeLog.new()
+        |> ChangeLog.record_change(delta("a"))
+        |> ChangeLog.record_change(delta("b"))
+
+      assert {{:ok, [_a, _b]}, log} = ChangeLog.take_unseen_changes(log, :lsp)
+
+      log = ChangeLog.clear(log)
+
+      assert {[], log} = ChangeLog.drain_pending_changes(log)
+      assert {:reset_required, _log} = ChangeLog.take_unseen_changes(log, :lsp)
+      assert ChangeLog.retained_count(log) == 0
+    end
+  end
+end

--- a/test/minga/buffer/process_test.exs
+++ b/test/minga/buffer/process_test.exs
@@ -7,6 +7,13 @@ defmodule Minga.Buffer.ProcessTest do
 
   @moduletag :tmp_dir
 
+  defp consume_edit_deltas(buffer, consumer_id) do
+    case BufferProcess.consume_edit_deltas(buffer, consumer_id) do
+      {:ok, deltas} -> deltas
+      :reset_required -> flunk("expected edit deltas, got reset_required")
+    end
+  end
+
   describe "child_spec/1" do
     test "uses restart: :temporary so crashed buffers stay dead" do
       spec = BufferProcess.child_spec(file_path: "test.ex")
@@ -819,7 +826,7 @@ defmodule Minga.Buffer.ProcessTest do
       {:ok, pid} = BufferProcess.start_link(content: "hello")
       BufferProcess.move_to(pid, {0, 5})
       BufferProcess.insert_char(pid, "!")
-      edits = BufferProcess.consume_edit_deltas(pid, :test)
+      edits = consume_edit_deltas(pid, :test)
       assert [delta] = edits
       assert delta.start_byte == 5
       assert delta.old_end_byte == 5
@@ -831,7 +838,7 @@ defmodule Minga.Buffer.ProcessTest do
       {:ok, pid} = BufferProcess.start_link(content: "hello")
       BufferProcess.move_to(pid, {0, 5})
       BufferProcess.delete_before(pid)
-      edits = BufferProcess.consume_edit_deltas(pid, :test)
+      edits = consume_edit_deltas(pid, :test)
       assert [delta] = edits
       assert delta.start_byte == 4
       assert delta.old_end_byte == 5
@@ -842,7 +849,7 @@ defmodule Minga.Buffer.ProcessTest do
     test "apply_edit records byte-accurate unicode replacement delta" do
       {:ok, pid} = BufferProcess.start_link(content: "aébc")
       BufferProcess.apply_edit(pid, 0, 1, 0, 1, "X")
-      edits = BufferProcess.consume_edit_deltas(pid, :test)
+      edits = consume_edit_deltas(pid, :test)
       assert [delta] = edits
       assert BufferProcess.content(pid) == "aXbc"
       assert delta.start_byte == 1
@@ -858,8 +865,8 @@ defmodule Minga.Buffer.ProcessTest do
       {:ok, pid} = BufferProcess.start_link(content: "hello")
       BufferProcess.move_to(pid, {0, 5})
       BufferProcess.insert_char(pid, "!")
-      assert [_] = BufferProcess.consume_edit_deltas(pid, :test)
-      assert [] = BufferProcess.consume_edit_deltas(pid, :test)
+      assert [_] = consume_edit_deltas(pid, :test)
+      assert [] = consume_edit_deltas(pid, :test)
     end
 
     test "multiple edits accumulate in order" do
@@ -867,7 +874,7 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.move_to(pid, {0, 2})
       BufferProcess.insert_char(pid, "c")
       BufferProcess.insert_char(pid, "d")
-      edits = BufferProcess.consume_edit_deltas(pid, :test)
+      edits = consume_edit_deltas(pid, :test)
       assert length(edits) == 2
       assert [first, second] = edits
       assert first.inserted_text == "c"
@@ -877,7 +884,7 @@ defmodule Minga.Buffer.ProcessTest do
     test "delete_range records a deletion delta" do
       {:ok, pid} = BufferProcess.start_link(content: "hello world")
       BufferProcess.delete_range(pid, {0, 5}, {0, 11})
-      edits = BufferProcess.consume_edit_deltas(pid, :test)
+      edits = consume_edit_deltas(pid, :test)
       assert [delta] = edits
       assert delta.start_byte == 5
       assert delta.old_end_byte == 11
@@ -889,12 +896,12 @@ defmodule Minga.Buffer.ProcessTest do
       {:ok, pid} = BufferProcess.start_link(content: "hello")
       BufferProcess.move_to(pid, {0, 5})
       BufferProcess.insert_char(pid, "!")
-      assert [_] = BufferProcess.consume_edit_deltas(pid, :test)
+      assert [_] = consume_edit_deltas(pid, :test)
       # Make another edit then undo
       BufferProcess.insert_char(pid, "?")
       BufferProcess.undo(pid)
       # Undo clears edits to force full sync
-      assert [] = BufferProcess.consume_edit_deltas(pid, :test)
+      assert :reset_required = BufferProcess.consume_edit_deltas(pid, :test)
     end
 
     test "replace_content clears pending edits" do
@@ -902,7 +909,7 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.move_to(pid, {0, 5})
       BufferProcess.insert_char(pid, "!")
       BufferProcess.replace_content(pid, "goodbye")
-      assert [] = BufferProcess.consume_edit_deltas(pid, :test)
+      assert :reset_required = BufferProcess.consume_edit_deltas(pid, :test)
     end
   end
 
@@ -916,8 +923,8 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.insert_char(pid, "y")
 
       # Both consumers should see the same 2 deltas
-      lsp_deltas = BufferProcess.consume_edit_deltas(pid, :lsp)
-      hl_deltas = BufferProcess.consume_edit_deltas(pid, :highlight)
+      lsp_deltas = consume_edit_deltas(pid, :lsp)
+      hl_deltas = consume_edit_deltas(pid, :highlight)
 
       assert length(lsp_deltas) == 2
       assert length(hl_deltas) == 2
@@ -932,7 +939,7 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.insert_char(pid, "b")
 
       # First flush gets both deltas
-      assert [d1, d2] = BufferProcess.consume_edit_deltas(pid, :lsp)
+      assert [d1, d2] = consume_edit_deltas(pid, :lsp)
       assert d1.inserted_text == "a"
       assert d2.inserted_text == "b"
 
@@ -940,7 +947,7 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.insert_char(pid, "c")
 
       # Second flush gets only the new one
-      assert [d3] = BufferProcess.consume_edit_deltas(pid, :lsp)
+      assert [d3] = consume_edit_deltas(pid, :lsp)
       assert d3.inserted_text == "c"
     end
 
@@ -951,7 +958,7 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.insert_char(pid, "c")
 
       # :lsp reads all 3
-      lsp_first = BufferProcess.consume_edit_deltas(pid, :lsp)
+      lsp_first = consume_edit_deltas(pid, :lsp)
       assert length(lsp_first) == 3
 
       # More edits
@@ -959,12 +966,12 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.insert_char(pid, "e")
 
       # :highlight hasn't read yet, should get all 5
-      hl_all = BufferProcess.consume_edit_deltas(pid, :highlight)
+      hl_all = consume_edit_deltas(pid, :highlight)
       assert length(hl_all) == 5
       assert Enum.map(hl_all, & &1.inserted_text) == ["a", "b", "c", "d", "e"]
 
       # :lsp should get only the 2 new ones
-      lsp_second = BufferProcess.consume_edit_deltas(pid, :lsp)
+      lsp_second = consume_edit_deltas(pid, :lsp)
       assert length(lsp_second) == 2
       assert Enum.map(lsp_second, & &1.inserted_text) == ["d", "e"]
     end
@@ -975,12 +982,13 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.insert_char(pid, "b")
 
       # Both consumers flush
-      BufferProcess.consume_edit_deltas(pid, :lsp)
-      BufferProcess.consume_edit_deltas(pid, :highlight)
+      consume_edit_deltas(pid, :lsp)
+      consume_edit_deltas(pid, :highlight)
 
-      # Once both registered consumers have caught up, the log is trimmed —
-      # a new consumer registering after the fact sees no historical deltas.
-      assert [] = BufferProcess.consume_edit_deltas(pid, :late_arrival)
+      # Once both registered consumers have caught up, the log is trimmed.
+      # A new consumer registering after the fact needs a full sync because
+      # there is no retained history for its baseline.
+      assert :reset_required = BufferProcess.consume_edit_deltas(pid, :late_arrival)
     end
 
     test "new consumer starts from sequence 0 and gets entire log" do
@@ -990,25 +998,15 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.insert_char(pid, "c")
 
       # :lsp reads all 3
-      BufferProcess.consume_edit_deltas(pid, :lsp)
+      consume_edit_deltas(pid, :lsp)
 
       # More edits
       BufferProcess.insert_char(pid, "d")
       BufferProcess.insert_char(pid, "e")
 
-      # New consumer never registered before, gets everything still in log
-      # (log is trimmed based on min cursor; :lsp cursor is at 3, so a-c may be trimmed)
-      # But :new_consumer has cursor 0, so as long as log entries exist, it gets them.
-      # Since :lsp flushed 3 but :new_consumer hasn't, the log won't be fully trimmed.
-      # Actually, the log was trimmed based on registered consumers only.
-      # Since :new_consumer wasn't registered, its cursor defaults to 0 on first call.
-      # The log entries for d and e (seq 4, 5) are still there because :lsp hasn't
-      # read them yet. Entries for a,b,c (seq 1,2,3) may or may not be trimmed
-      # depending on whether other consumers exist. Since only :lsp is registered
-      # and its cursor is at 3, entries 1-3 got trimmed on that flush.
-      new_deltas = BufferProcess.consume_edit_deltas(pid, :new_consumer)
-      # Gets at least the 2 unread by all consumers (d, e)
-      assert length(new_deltas) >= 2
+      # New consumer never registered before, but the complete history is still retained.
+      new_deltas = consume_edit_deltas(pid, :new_consumer)
+      assert Enum.map(new_deltas, & &1.inserted_text) == ["a", "b", "c", "d", "e"]
     end
 
     test "undo clears the edit log for all consumers" do
@@ -1018,15 +1016,15 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.insert_char(pid, "b")
 
       # :lsp reads
-      assert [_, _] = BufferProcess.consume_edit_deltas(pid, :lsp)
+      assert [_, _] = consume_edit_deltas(pid, :lsp)
 
       # More edits then undo
       BufferProcess.insert_char(pid, "c")
       BufferProcess.undo(pid)
 
-      # Both consumers get empty (forces full sync)
-      assert [] = BufferProcess.consume_edit_deltas(pid, :lsp)
-      assert [] = BufferProcess.consume_edit_deltas(pid, :highlight)
+      # Both consumers must full-sync after history is cleared.
+      assert :reset_required = BufferProcess.consume_edit_deltas(pid, :lsp)
+      assert :reset_required = BufferProcess.consume_edit_deltas(pid, :highlight)
     end
 
     test "replace_content clears the edit log for all consumers" do
@@ -1035,35 +1033,33 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.insert_char(pid, "!")
       BufferProcess.replace_content(pid, "goodbye")
 
-      assert [] = BufferProcess.consume_edit_deltas(pid, :lsp)
-      assert [] = BufferProcess.consume_edit_deltas(pid, :highlight)
+      assert :reset_required = BufferProcess.consume_edit_deltas(pid, :lsp)
+      assert :reset_required = BufferProcess.consume_edit_deltas(pid, :highlight)
     end
 
     test "flush with no edits returns empty list" do
       {:ok, pid} = BufferProcess.start_link(content: "hello")
-      assert [] = BufferProcess.consume_edit_deltas(pid, :lsp)
+      assert [] = consume_edit_deltas(pid, :lsp)
     end
 
     test "flush same consumer twice with no intervening edits returns empty" do
       {:ok, pid} = BufferProcess.start_link(content: "hello")
       BufferProcess.insert_char(pid, "!")
-      assert [_] = BufferProcess.consume_edit_deltas(pid, :lsp)
-      assert [] = BufferProcess.consume_edit_deltas(pid, :lsp)
+      assert [_] = consume_edit_deltas(pid, :lsp)
+      assert [] = consume_edit_deltas(pid, :lsp)
     end
 
-    test "edit_log is capped at 1000 entries when only one consumer is registered" do
+    test "change log is capped at 1000 entries when only one consumer is registered" do
       {:ok, pid} = BufferProcess.start_link(content: "")
 
       # Insert more than 1000 chars with only :lsp reading periodically
       for _ <- 1..1100, do: BufferProcess.insert_char(pid, "x")
 
       # Only one consumer has ever called consume_edit_deltas
-      _deltas = BufferProcess.consume_edit_deltas(pid, :lsp)
+      _deltas = consume_edit_deltas(pid, :lsp)
 
-      # A late-arriving consumer would see every retained entry (its cursor
-      # starts at 0). With the cap in place it sees at most 1000, not 1100.
-      late_deltas = BufferProcess.consume_edit_deltas(pid, :late_arrival)
-      assert length(late_deltas) <= 1000
+      # A late-arriving consumer is behind compacted history, so it must full-sync.
+      assert :reset_required = BufferProcess.consume_edit_deltas(pid, :late_arrival)
     end
   end
 


### PR DESCRIPTION
# TL;DR
Extracts buffer edit-delta tracking into `Minga.Buffer.ChangeLog`, so `Minga.Buffer.State` no longer owns four low-level sync bookkeeping fields directly. The new change log preserves legacy draining, supports independent incremental consumers, and explicitly tells consumers to full-sync when retained delta history was compacted.

## Context
This is the next buffer architecture simplification slice. It keeps `Minga.Buffer.Process` responsible for process coordination and document mutation, while moving the pure edit-delta ledger into a domain module with a focused API.

## Changes
- Added `Minga.Buffer.ChangeLog` as an opaque pure state module for pending changes, sequence numbers, retained entries, consumer cursors, compaction, and reset signaling.
- Replaced `pending_edits`, `edit_seq`, `edit_log`, and `consumer_cursors` in `Minga.Buffer.State` with a single `change_log` field.
- Updated `Minga.Buffer.Process` to delegate recording, legacy draining, per-consumer reads, and reset/clear behavior to `ChangeLog`.
- Changed per-consumer delta reads to return `{:ok, deltas}` or `:reset_required`, which prevents a late consumer from silently receiving an incomplete incremental stream after compaction.
- Updated `MingaEditor.HighlightSync` to send a full parse when `:reset_required` is returned.
- Registered `Minga.Buffer.ChangeLog` as a pure Layer 0 module in the dependency-direction Credo check.

## Verification
- `mix compile --warnings-as-errors`
- `mix test.llm test/minga/buffer/change_log_test.exs test/minga/buffer/process_test.exs test/minga_editor/highlight_sync_test.exs`
- `mix test.llm test/minga/buffer`
- `make lint`
- `mix test.llm` (8603 tests, 97 properties, 52 doctests, 0 failures)

## Review Notes
- `prtk-code-reviewer`: no issues found.
- `prtk-type-design-analyzer`: found the risk that compacted history could look like a valid partial delta stream. Fixed by making reset explicit with `:reset_required`, making `ChangeLog.t()` opaque, and full-syncing HighlightSync on reset. Targeted re-check approved.
- Final reviewer gate: PASS.
