### PR TITLE
feat(editor): keep file tree fresh

### DIFF
--- a/lib/minga/file_watcher.ex
+++ b/lib/minga/file_watcher.ex
@@ -27,6 +27,7 @@ defmodule Minga.FileWatcher do
             watcher: nil,
             watched_dirs: %{},
             watched_files: MapSet.new(),
+            watched_project_dirs: MapSet.new(),
             pending: %{},
             events_registry: Minga.Events.default_registry()
 
@@ -35,6 +36,7 @@ defmodule Minga.FileWatcher do
            watcher: pid() | nil,
            watched_dirs: %{String.t() => pos_integer()},
            watched_files: MapSet.t(String.t()),
+           watched_project_dirs: MapSet.t(String.t()),
            pending: %{String.t() => reference()},
            debounce_ms: pos_integer(),
            events_registry: Minga.Events.registry()
@@ -57,10 +59,28 @@ defmodule Minga.FileWatcher do
     GenServer.call(server, {:watch_path, Path.expand(path)})
   end
 
+  @doc "Registers a directory so child create, delete, rename, and modify events refresh project surfaces."
+  @spec watch_directory(GenServer.server(), String.t()) :: :ok
+  def watch_directory(server \\ __MODULE__, path) when is_binary(path) do
+    GenServer.call(server, {:watch_directory, Path.expand(path)})
+  end
+
   @doc "Unregisters a file path. Stops watching the directory when no files remain in it."
   @spec unwatch_path(GenServer.server(), String.t()) :: :ok
   def unwatch_path(server \\ __MODULE__, path) when is_binary(path) do
     GenServer.call(server, {:unwatch_path, Path.expand(path)})
+  end
+
+  @doc "Unregisters a watched directory."
+  @spec unwatch_directory(GenServer.server(), String.t()) :: :ok
+  def unwatch_directory(server \\ __MODULE__, path) when is_binary(path) do
+    GenServer.call(server, {:unwatch_directory, Path.expand(path)})
+  end
+
+  @doc "Unregisters all watched project directories under a root."
+  @spec unwatch_directory_tree(GenServer.server(), String.t()) :: :ok
+  def unwatch_directory_tree(server \\ __MODULE__, root) when is_binary(root) do
+    GenServer.call(server, {:unwatch_directory_tree, Path.expand(root)})
   end
 
   @doc "Sets the subscriber process that receives `{:file_changed_on_disk, path}` messages."
@@ -110,34 +130,44 @@ defmodule Minga.FileWatcher do
     {:reply, :ok, do_watch_path(state, path)}
   end
 
+  def handle_call({:watch_directory, path}, _from, %__MODULE__{} = state) do
+    {:reply, :ok, do_watch_directory(state, path)}
+  end
+
   def handle_call({:unwatch_path, path}, _from, %__MODULE__{} = state) do
     dir = Path.dirname(path)
-
-    new_dirs =
-      case Map.get(state.watched_dirs, dir) do
-        nil -> state.watched_dirs
-        1 -> Map.delete(state.watched_dirs, dir)
-        n -> Map.put(state.watched_dirs, dir, n - 1)
-      end
-
+    new_dirs = decrement_watched_dir(state.watched_dirs, dir)
     new_files = MapSet.delete(state.watched_files, path)
+    new_watcher = reconcile_watcher(state.watcher, state.watched_dirs, new_dirs)
 
-    {:reply, :ok, %__MODULE__{state | watched_dirs: new_dirs, watched_files: new_files}}
+    {:reply, :ok,
+     %__MODULE__{state | watched_dirs: new_dirs, watched_files: new_files, watcher: new_watcher}}
+  end
+
+  def handle_call({:unwatch_directory, path}, _from, %__MODULE__{} = state) do
+    {:reply, :ok, unwatch_project_dirs(state, [Path.expand(path)])}
+  end
+
+  def handle_call({:unwatch_directory_tree, root}, _from, %__MODULE__{} = state) do
+    root = Path.expand(root)
+    dirs = Enum.filter(state.watched_project_dirs, &path_under_root?(&1, root))
+    {:reply, :ok, unwatch_project_dirs(state, dirs)}
   end
 
   @impl true
   @spec handle_cast(term(), state()) :: {:noreply, state()}
   def handle_cast(:check_all, %__MODULE__{} = state) do
     notify_all_watched(state)
+    notify_all_watched_project_dirs(state)
     {:noreply, state}
   end
 
   @impl true
   @spec handle_info(term(), state()) :: {:noreply, state()}
   def handle_info({:file_event, _watcher_pid, {path, _events}}, %__MODULE__{} = state) do
-    path = to_string(path)
+    path = Path.expand(to_string(path))
 
-    if MapSet.member?(state.watched_files, path) do
+    if watched_path_event?(state, path) do
       {:noreply, schedule_debounce(state, path)}
     else
       {:noreply, state}
@@ -179,6 +209,92 @@ defmodule Minga.FileWatcher do
     new_files = MapSet.put(state.watched_files, path)
     new_watcher = ensure_watcher(state.watcher, new_dirs)
     %__MODULE__{state | watched_dirs: new_dirs, watched_files: new_files, watcher: new_watcher}
+  end
+
+  @spec do_watch_directory(state(), String.t()) :: state()
+  defp do_watch_directory(%__MODULE__{} = state, path) do
+    dir = Path.expand(path)
+
+    if MapSet.member?(state.watched_project_dirs, dir) do
+      state
+    else
+      new_dirs = Map.update(state.watched_dirs, dir, 1, &(&1 + 1))
+      new_project_dirs = MapSet.put(state.watched_project_dirs, dir)
+      new_watcher = ensure_watcher(state.watcher, new_dirs)
+
+      %__MODULE__{
+        state
+        | watched_dirs: new_dirs,
+          watched_project_dirs: new_project_dirs,
+          watcher: new_watcher
+      }
+    end
+  end
+
+  @spec unwatch_project_dirs(state(), [String.t()]) :: state()
+  defp unwatch_project_dirs(%__MODULE__{} = state, dirs) when is_list(dirs) do
+    dirs_to_remove = Enum.filter(dirs, &MapSet.member?(state.watched_project_dirs, &1))
+
+    if dirs_to_remove == [] do
+      state
+    else
+      new_dirs = Enum.reduce(dirs_to_remove, state.watched_dirs, &decrement_watched_dir(&2, &1))
+
+      new_project_dirs =
+        Enum.reduce(dirs_to_remove, state.watched_project_dirs, &MapSet.delete(&2, &1))
+
+      new_watcher = reconcile_watcher(state.watcher, state.watched_dirs, new_dirs)
+
+      %__MODULE__{
+        state
+        | watched_dirs: new_dirs,
+          watched_project_dirs: new_project_dirs,
+          watcher: new_watcher
+      }
+    end
+  end
+
+  @spec decrement_watched_dir(%{String.t() => pos_integer()}, String.t()) :: %{
+          String.t() => pos_integer()
+        }
+  defp decrement_watched_dir(watched_dirs, dir) do
+    case Map.get(watched_dirs, dir) do
+      nil -> watched_dirs
+      1 -> Map.delete(watched_dirs, dir)
+      n -> Map.put(watched_dirs, dir, n - 1)
+    end
+  end
+
+  @spec watched_path_event?(state(), String.t()) :: boolean()
+  defp watched_path_event?(%__MODULE__{} = state, path) do
+    MapSet.member?(state.watched_files, path) or
+      watched_project_child?(state.watched_project_dirs, path)
+  end
+
+  @spec watched_project_child?(MapSet.t(String.t()), String.t()) :: boolean()
+  defp watched_project_child?(watched_project_dirs, path) do
+    Enum.any?(watched_project_dirs, fn dir -> path_under_root?(path, dir) end)
+  end
+
+  @spec path_under_root?(String.t(), String.t()) :: boolean()
+  defp path_under_root?(path, root) do
+    path == root or String.starts_with?(path, path_prefix(root))
+  end
+
+  @spec path_prefix(String.t()) :: String.t()
+  defp path_prefix("/"), do: "/"
+  defp path_prefix(root), do: root <> "/"
+
+  @spec reconcile_watcher(pid() | nil, %{String.t() => pos_integer()}, %{
+          String.t() => pos_integer()
+        }) ::
+          pid() | nil
+  defp reconcile_watcher(existing_watcher, old_dirs, new_dirs) do
+    if MapSet.new(Map.keys(old_dirs)) == MapSet.new(Map.keys(new_dirs)) do
+      existing_watcher
+    else
+      ensure_watcher(existing_watcher, new_dirs)
+    end
   end
 
   @spec ensure_watcher(pid() | nil, %{String.t() => pos_integer()}) :: pid() | nil
@@ -249,6 +365,13 @@ defmodule Minga.FileWatcher do
   @spec notify_all_watched(state()) :: :ok
   defp notify_all_watched(%__MODULE__{} = state) do
     Enum.each(state.watched_files, fn path ->
+      notify_subscriber(state.subscriber, path)
+    end)
+  end
+
+  @spec notify_all_watched_project_dirs(state()) :: :ok
+  defp notify_all_watched_project_dirs(%__MODULE__{} = state) do
+    Enum.each(state.watched_project_dirs, fn path ->
       notify_subscriber(state.subscriber, path)
     end)
   end

--- a/lib/minga/project/file_tree.ex
+++ b/lib/minga/project/file_tree.ex
@@ -248,7 +248,13 @@ defmodule Minga.Project.FileTree do
   @doc "Refreshes git status for the tree root. Returns the updated tree."
   @spec refresh_git_status(t()) :: t()
   def refresh_git_status(%__MODULE__{} = tree) do
-    %{tree | git_status: GitStatus.compute(tree.root)}
+    replace_git_status(tree, GitStatus.compute(tree.root))
+  end
+
+  @doc "Replaces the cached git status map for the tree."
+  @spec replace_git_status(t(), GitStatus.status_map()) :: t()
+  def replace_git_status(%__MODULE__{} = tree, git_status) when is_map(git_status) do
+    %{tree | git_status: git_status}
   end
 
   @doc """

--- a/lib/minga/project/file_tree/git_status.ex
+++ b/lib/minga/project/file_tree/git_status.ex
@@ -30,19 +30,27 @@ defmodule Minga.Project.FileTree.GitStatus do
     case Minga.Git.root_for(root_path) do
       {:ok, git_root} ->
         case Minga.Git.status(git_root) do
-          {:ok, entries} ->
-            entries
-            |> entries_to_status_map(git_root)
-            |> filter_under_root(root_path)
-            |> propagate_to_directories(root_path)
-
-          {:error, _} ->
-            %{}
+          {:ok, entries} -> from_entries(entries, git_root, root_path)
+          {:error, _} -> %{}
         end
 
       :not_git ->
         %{}
     end
+  end
+
+  @doc """
+  Builds file-tree git status from an already-fetched git status event.
+
+  This lets event handlers refresh badges without shelling out during render or recomputing status that `Minga.Git.Repo` already fetched.
+  """
+  @spec from_entries([Minga.Git.status_entry()], String.t(), String.t()) :: status_map()
+  def from_entries(entries, git_root, root_path)
+      when is_list(entries) and is_binary(git_root) and is_binary(root_path) do
+    entries
+    |> entries_to_status_map(git_root)
+    |> filter_under_root(root_path)
+    |> propagate_to_directories(root_path)
   end
 
   @doc """

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -215,8 +215,11 @@ defmodule MingaEditor do
     Minga.Events.subscribe(:diagnostics_updated, events_registry)
     Minga.Events.subscribe(:lsp_status_changed, events_registry)
 
-    # Refresh file tree git status when any buffer is saved.
+    # Refresh file tree state when buffers, project files, git, diagnostics, or project roots change.
     Minga.Events.subscribe(:buffer_saved, events_registry)
+    Minga.Events.subscribe(:buffer_changed, events_registry)
+    Minga.Events.subscribe(:file_written, events_registry)
+    Minga.Events.subscribe(:project_rebuilt, events_registry)
     Minga.Events.subscribe(:git_status_changed, events_registry)
 
     # Tool manager progress: show install/update status in the status line.
@@ -477,11 +480,11 @@ defmodule MingaEditor do
   end
 
   # ── File watcher notification ──
-  def handle_info({:file_changed_on_disk, path}, state) do
+  def handle_info({:file_changed_on_disk, path} = msg, state) do
     new_state = FileWatcherHelpers.handle_file_change(state, path)
     new_state = log_message(new_state, "External change detected: #{path}")
-    new_state = Renderer.render_or_async(new_state)
-    {:noreply, new_state}
+    {new_state, effects} = FileEventHandler.handle(new_state, msg)
+    {:noreply, apply_effects(new_state, effects)}
   end
 
   def handle_info(
@@ -655,6 +658,12 @@ defmodule MingaEditor do
     state = maybe_trigger_nav_flash(state)
     state = Renderer.render_or_async(state)
     {:noreply, %{state | render_timer: nil}}
+  end
+
+  # Debounced file-tree refresh timer fired — rescan the cached tree once for a burst of filesystem events.
+  def handle_info(:file_tree_refresh_timer, state) do
+    {state, effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
+    {:noreply, apply_effects(state, effects)}
   end
 
   # Renderer.Server writeback after each async frame completes.
@@ -864,7 +873,13 @@ defmodule MingaEditor do
     :tool_missing
   ]
 
-  @file_events [:git_status_changed, :buffer_saved]
+  @file_events [
+    :git_status_changed,
+    :buffer_saved,
+    :buffer_changed,
+    :file_written,
+    :project_rebuilt
+  ]
 
   @spec dispatch_minga_event(EditorState.t(), atom(), term(), term()) :: EditorState.t()
   defp dispatch_minga_event(state, event, _payload, msg) when event in @tool_events do
@@ -893,10 +908,16 @@ defmodule MingaEditor do
          state,
          :diagnostics_updated,
          %Minga.Events.DiagnosticsUpdatedEvent{uri: uri},
-         _msg
+         msg
        ) do
     apply_diagnostic_decorations(state, uri)
-    schedule_render(state, 16)
+    {state, effects} = FileEventHandler.handle(state, msg)
+
+    if effects == [] do
+      schedule_render(state, 16)
+    else
+      apply_effects(state, effects)
+    end
   end
 
   defp dispatch_minga_event(
@@ -1328,6 +1349,7 @@ defmodule MingaEditor do
   * `{:request_code_lens}` — request fresh code lenses from LSP
   * `{:request_inlay_hints}` — request fresh inlay hints from LSP
   * `{:save_session_deferred}` — send :save_session to self
+  * `{:schedule_file_tree_refresh, delay}` — debounce one filesystem tree refresh
   * `{:handle_git_remote_result, ref, result}` — process git remote result
   """
   @type effect ::
@@ -1363,6 +1385,7 @@ defmodule MingaEditor do
           | {:request_code_lens}
           | {:request_inlay_hints}
           | {:save_session_deferred}
+          | {:schedule_file_tree_refresh, non_neg_integer()}
           | {:handle_git_remote_result, reference(), term()}
 
   @doc """
@@ -1460,6 +1483,15 @@ defmodule MingaEditor do
     end
 
     state
+  end
+
+  defp apply_effect(state, {:schedule_file_tree_refresh, delay}) when is_integer(delay) do
+    if MingaEditor.FileTree.Freshness.refresh_scheduled?(state) do
+      state
+    else
+      ref = Process.send_after(self(), :file_tree_refresh_timer, delay)
+      MingaEditor.FileTree.Freshness.schedule_refresh(state, ref)
+    end
   end
 
   defp apply_effect(state, {:conceal_spans, pid, spans}) when is_pid(pid) do

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -16,6 +16,7 @@ defmodule MingaEditor.Commands.FileTree do
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.BufferSync
   alias MingaEditor.FileTree.DropIntent
+  alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
 
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
@@ -23,9 +24,23 @@ defmodule MingaEditor.Commands.FileTree do
   @spec toggle(state()) :: state()
   def toggle(%{workspace: %{file_tree: %{tree: nil}}} = state), do: open(state)
 
-  def toggle(%{workspace: %{file_tree: %{buffer: buf}}} = state) when is_pid(buf) do
+  def toggle(%{workspace: %{file_tree: %{tree: tree, buffer: buf}}} = state) when is_pid(buf) do
+    FileTreeFreshness.unwatch_expanded_dirs(tree)
     GenServer.stop(buf, :normal)
 
+    scope = restore_scope(state)
+
+    EditorState.update_workspace(state, fn ws ->
+      ws
+      |> Map.put(:file_tree, FileTreeState.close(ws.file_tree))
+      |> WorkspaceState.set_keymap_scope(scope)
+    end)
+    |> Layout.invalidate()
+    |> EditorState.invalidate_all_windows()
+  end
+
+  def toggle(%{workspace: %{file_tree: %{tree: %FileTree{} = tree}}} = state) do
+    FileTreeFreshness.unwatch_expanded_dirs(tree)
     scope = restore_scope(state)
 
     EditorState.update_workspace(state, fn ws ->
@@ -496,6 +511,7 @@ defmodule MingaEditor.Commands.FileTree do
     tree = FileTree.new(root)
     tree = FileTree.refresh_git_status(tree)
     tree = reveal_active(tree, state.workspace.buffers.active)
+    FileTreeFreshness.watch_expanded_dirs(tree)
     buf = BufferSync.start_buffer(tree)
 
     EditorState.update_workspace(state, fn ws ->
@@ -520,6 +536,7 @@ defmodule MingaEditor.Commands.FileTree do
   @spec sync_and_update(state(), FileTree.t()) :: state()
   defp sync_and_update(%{workspace: %{file_tree: %{buffer: buf}}} = state, new_tree)
        when is_pid(buf) do
+    FileTreeFreshness.watch_expanded_dirs(new_tree)
     BufferSync.sync(buf, new_tree)
 
     put_in(
@@ -529,6 +546,8 @@ defmodule MingaEditor.Commands.FileTree do
   end
 
   defp sync_and_update(state, new_tree) do
+    FileTreeFreshness.watch_expanded_dirs(new_tree)
+
     put_in(
       state.workspace.file_tree,
       FileTreeState.replace_tree(state.workspace.file_tree, new_tree)

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -1,0 +1,230 @@
+defmodule MingaEditor.FileTree.Freshness do
+  @moduledoc """
+  Keeps the editor file tree fresh in response to filesystem, git, diagnostics, buffer, and project events.
+
+  The renderer reads current row state, but this module owns the event-time invalidation work that should not happen during rendering.
+  """
+
+  alias Minga.Buffer
+  alias Minga.LSP.SyncServer
+  alias Minga.Project.FileTree
+  alias Minga.Project.FileTree.BufferSync
+  alias Minga.Project.FileTree.GitStatus
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  @type state :: EditorState.t()
+
+  @doc "Returns true when the file tree is open."
+  @spec open?(state()) :: boolean()
+  def open?(%{workspace: %{file_tree: %FileTreeState{tree: %FileTree{}}}}), do: true
+  def open?(_state), do: false
+
+  @doc "Returns true when the path is under the current tree root."
+  @spec path_under_tree?(state(), String.t() | nil) :: boolean()
+  def path_under_tree?(_state, nil), do: false
+
+  def path_under_tree?(
+        %{workspace: %{file_tree: %FileTreeState{tree: %FileTree{root: root}}}},
+        path
+      )
+      when is_binary(path) do
+    path_under_root?(Path.expand(path), Path.expand(root))
+  end
+
+  def path_under_tree?(%{workspace: %{file_tree: %FileTreeState{project_root: root}}}, path)
+      when is_binary(root) and is_binary(path) do
+    path_under_root?(Path.expand(path), Path.expand(root))
+  end
+
+  def path_under_tree?(_state, _path), do: false
+
+  @doc "Returns true when the diagnostic URI maps to a path under the current tree root."
+  @spec diagnostic_uri_under_tree?(state(), String.t()) :: boolean()
+  def diagnostic_uri_under_tree?(state, uri) when is_binary(uri) do
+    path_under_tree?(state, SyncServer.uri_to_path(uri))
+  rescue
+    ArgumentError -> false
+  end
+
+  @doc "Returns true when the buffer belongs to a path under the current tree root."
+  @spec buffer_under_tree?(state(), pid()) :: boolean()
+  def buffer_under_tree?(state, buffer) when is_pid(buffer) do
+    path_under_tree?(state, Buffer.file_path(buffer))
+  catch
+    :exit, _ -> false
+  end
+
+  @doc "Marks a debounced filesystem refresh as scheduled."
+  @spec schedule_refresh(state(), reference()) :: state()
+  def schedule_refresh(%{workspace: %{file_tree: %FileTreeState{} = file_tree}} = state, ref)
+      when is_reference(ref) do
+    set_file_tree(state, FileTreeState.schedule_refresh(file_tree, ref))
+  end
+
+  @doc "Returns true when a filesystem refresh timer is already pending."
+  @spec refresh_scheduled?(state()) :: boolean()
+  def refresh_scheduled?(%{workspace: %{file_tree: %FileTreeState{} = file_tree}}) do
+    FileTreeState.refresh_scheduled?(file_tree)
+  end
+
+  def refresh_scheduled?(_state), do: false
+
+  @doc "Refreshes cached filesystem entries after the debounce timer fires."
+  @spec flush_refresh(state()) :: state()
+  def flush_refresh(%{workspace: %{file_tree: %FileTreeState{tree: nil} = file_tree}} = state) do
+    set_file_tree(state, FileTreeState.clear_refresh(file_tree))
+  end
+
+  def flush_refresh(
+        %{workspace: %{file_tree: %FileTreeState{tree: %FileTree{} = tree} = file_tree}} = state
+      ) do
+    refreshed_tree = tree |> FileTree.refresh() |> FileTree.refresh_git_status()
+    watch_expanded_dirs(refreshed_tree)
+
+    file_tree =
+      file_tree
+      |> FileTreeState.clear_refresh()
+      |> FileTreeState.replace_tree(refreshed_tree)
+
+    state
+    |> set_file_tree(file_tree)
+    |> sync_buffer(refreshed_tree)
+  end
+
+  def flush_refresh(state), do: state
+
+  @doc "Updates tree git badges from an already-fetched git status event."
+  @spec refresh_git_status(state(), Minga.Events.GitStatusEvent.t()) :: state()
+  def refresh_git_status(%{workspace: %{file_tree: %FileTreeState{tree: nil}}} = state, _event),
+    do: state
+
+  def refresh_git_status(
+        %{workspace: %{file_tree: %FileTreeState{tree: %FileTree{} = tree} = file_tree}} = state,
+        %Minga.Events.GitStatusEvent{git_root: git_root, entries: entries}
+      ) do
+    status = GitStatus.from_entries(entries, git_root, tree.root)
+    updated_tree = FileTree.replace_git_status(tree, status)
+    file_tree = FileTreeState.replace_tree(file_tree, updated_tree)
+
+    state
+    |> set_file_tree(file_tree)
+    |> sync_buffer(updated_tree)
+  end
+
+  @doc "Refreshes tree git badges by querying the current git backend."
+  @spec refresh_git_status_from_disk(state()) :: state()
+  def refresh_git_status_from_disk(%{workspace: %{file_tree: %FileTreeState{tree: nil}}} = state),
+    do: state
+
+  def refresh_git_status_from_disk(
+        %{workspace: %{file_tree: %FileTreeState{tree: %FileTree{} = tree} = file_tree}} = state
+      ) do
+    updated_tree = FileTree.refresh_git_status(tree)
+    file_tree = FileTreeState.replace_tree(file_tree, updated_tree)
+
+    state
+    |> set_file_tree(file_tree)
+    |> sync_buffer(updated_tree)
+  end
+
+  @doc "Updates the remembered project root and replaces visible stale tree entries when the project changes."
+  @spec update_project_root(state(), String.t()) :: state()
+  def update_project_root(%{workspace: %{file_tree: %FileTreeState{} = file_tree}} = state, root)
+      when is_binary(root) do
+    expanded_root = Path.expand(root)
+
+    case file_tree.tree do
+      %FileTree{root: ^expanded_root} ->
+        set_file_tree(state, FileTreeState.set_project_root(file_tree, expanded_root))
+
+      %FileTree{} = old_tree ->
+        unwatch_expanded_dirs(old_tree)
+
+        new_tree =
+          expanded_root
+          |> FileTree.new(width: old_tree.width)
+          |> FileTree.refresh_git_status()
+
+        watch_expanded_dirs(new_tree)
+
+        file_tree =
+          file_tree
+          |> FileTreeState.set_project_root(expanded_root)
+          |> FileTreeState.replace_tree(new_tree)
+
+        state
+        |> set_file_tree(file_tree)
+        |> sync_buffer(new_tree)
+
+      nil ->
+        set_file_tree(state, FileTreeState.set_project_root(file_tree, expanded_root))
+    end
+  end
+
+  @doc "Registers expanded tree directories with the external file watcher when it is running."
+  @spec watch_expanded_dirs(FileTree.t()) :: :ok
+  def watch_expanded_dirs(%FileTree{expanded: expanded}) do
+    Enum.each(expanded, &safe_watch_directory/1)
+  end
+
+  @doc "Unregisters every watched project directory under the tree root when the file tree closes or changes root."
+  @spec unwatch_expanded_dirs(FileTree.t()) :: :ok
+  def unwatch_expanded_dirs(%FileTree{root: root}) do
+    safe_unwatch_directory_tree(root)
+  end
+
+  @spec sync_buffer(state(), FileTree.t()) :: state()
+  defp sync_buffer(%{workspace: %{file_tree: %FileTreeState{buffer: buffer}}} = state, tree)
+       when is_pid(buffer) do
+    BufferSync.sync(buffer, tree)
+    state
+  catch
+    :exit, reason ->
+      Minga.Log.warning(
+        :editor,
+        "File tree buffer sync failed for #{tree.root}: #{inspect(reason)}"
+      )
+
+      state
+  end
+
+  defp sync_buffer(state, _tree), do: state
+
+  @spec set_file_tree(state(), FileTreeState.t()) :: state()
+  defp set_file_tree(%EditorState{} = state, %FileTreeState{} = file_tree) do
+    EditorState.update_workspace(state, &WorkspaceState.set_file_tree(&1, file_tree))
+  end
+
+  @spec safe_watch_directory(String.t()) :: :ok
+  defp safe_watch_directory(path) when is_binary(path) do
+    Minga.FileWatcher.watch_directory(path)
+  catch
+    :exit, reason ->
+      Minga.Log.warning(
+        :editor,
+        "File tree watch registration failed for #{path}: #{inspect(reason)}"
+      )
+
+      :ok
+  end
+
+  @spec safe_unwatch_directory_tree(String.t()) :: :ok
+  defp safe_unwatch_directory_tree(path) when is_binary(path) do
+    Minga.FileWatcher.unwatch_directory_tree(path)
+  catch
+    :exit, reason ->
+      Minga.Log.warning(:editor, "File tree watch cleanup failed for #{path}: #{inspect(reason)}")
+      :ok
+  end
+
+  @spec path_under_root?(String.t(), String.t()) :: boolean()
+  defp path_under_root?(path, root) do
+    path == root or String.starts_with?(path, path_prefix(root))
+  end
+
+  @spec path_prefix(String.t()) :: String.t()
+  defp path_prefix("/"), do: "/"
+  defp path_prefix(root), do: root <> "/"
+end

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -8,16 +8,15 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   functions.
   """
 
+  alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.State.FileTree, as: FileTreeState
-  alias Minga.Project.FileTree
 
   @typedoc "Effects that the file event handler may return."
   @type file_effect ::
           :render
           | {:render, pos_integer()}
           | {:log_message, String.t()}
-          | {:refresh_tree_git_status}
+          | {:schedule_file_tree_refresh, non_neg_integer()}
           | {:request_code_lens}
           | {:request_inlay_hints}
           | {:save_session_deferred}
@@ -39,6 +38,40 @@ defmodule MingaEditor.Handlers.FileEventHandler do
     handle_buffer_saved(state, buf)
   end
 
+  def handle(
+        state,
+        {:minga_event, :buffer_changed, %Minga.Events.BufferChangedEvent{buffer: buf}}
+      ) do
+    handle_buffer_changed(state, buf)
+  end
+
+  def handle(
+        state,
+        {:minga_event, :diagnostics_updated, %Minga.Events.DiagnosticsUpdatedEvent{uri: uri}}
+      ) do
+    handle_diagnostics_updated(state, uri)
+  end
+
+  def handle(state, {:minga_event, :file_written, %Minga.Events.FileWrittenEvent{path: path}}) do
+    handle_file_changed(state, path)
+  end
+
+  def handle(
+        state,
+        {:minga_event, :project_rebuilt, %Minga.Events.ProjectRebuiltEvent{root: root}}
+      ) do
+    handle_project_rebuilt(state, root)
+  end
+
+  def handle(state, {:file_changed_on_disk, path}) when is_binary(path) do
+    handle_file_changed(state, path)
+  end
+
+  def handle(state, :file_tree_refresh_timer) do
+    state = FileTreeFreshness.flush_refresh(state)
+    {state, [{:render, 16}]}
+  end
+
   def handle(state, {:git_remote_result, ref, result}) when is_reference(ref) do
     {state, [{:handle_git_remote_result, ref, result}]}
   end
@@ -51,15 +84,20 @@ defmodule MingaEditor.Handlers.FileEventHandler do
 
   @spec handle_git_status_changed(EditorState.t(), Minga.Events.GitStatusEvent.t()) ::
           {EditorState.t(), [file_effect()]}
-  defp handle_git_status_changed(state, %Minga.Events.GitStatusEvent{
-         entries: entries,
-         branch: branch,
-         ahead: ahead,
-         behind: behind
-       }) do
+  defp handle_git_status_changed(
+         state,
+         %Minga.Events.GitStatusEvent{
+           entries: entries,
+           branch: branch,
+           ahead: ahead,
+           behind: behind
+         } = event
+       ) do
+    state = FileTreeFreshness.refresh_git_status(state, event)
+
     case EditorState.git_status_panel(state) do
       nil ->
-        {state, []}
+        if FileTreeFreshness.open?(state), do: {state, [{:render, 16}]}, else: {state, []}
 
       _panel ->
         git_status_data = %{
@@ -89,12 +127,13 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   defp handle_buffer_saved(state, saved_buf) do
     new_state =
       state
-      |> refresh_tree_git_status()
+      |> FileTreeFreshness.refresh_git_status_from_disk()
       |> MingaEditor.Commands.Git.refresh_diff_views_for_buffer(saved_buf)
 
     effects = [
       {:request_code_lens},
-      {:request_inlay_hints}
+      {:request_inlay_hints},
+      {:render, 16}
     ]
 
     effects =
@@ -107,16 +146,37 @@ defmodule MingaEditor.Handlers.FileEventHandler do
     {new_state, effects}
   end
 
-  # Refreshes the file tree's git status annotations.
-  @spec refresh_tree_git_status(EditorState.t()) :: EditorState.t()
-  defp refresh_tree_git_status(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+  @spec handle_buffer_changed(EditorState.t(), pid()) :: {EditorState.t(), [file_effect()]}
+  defp handle_buffer_changed(state, buffer) do
+    if FileTreeFreshness.buffer_under_tree?(state, buffer) do
+      {state, [{:render, 16}]}
+    else
+      {state, []}
+    end
+  end
 
-  defp refresh_tree_git_status(%{workspace: %{file_tree: %{tree: tree}}} = state) do
-    updated_tree = FileTree.refresh_git_status(tree)
+  @spec handle_diagnostics_updated(EditorState.t(), String.t()) ::
+          {EditorState.t(), [file_effect()]}
+  defp handle_diagnostics_updated(state, uri) do
+    if FileTreeFreshness.diagnostic_uri_under_tree?(state, uri) do
+      {state, [{:render, 16}]}
+    else
+      {state, []}
+    end
+  end
 
-    put_in(
-      state.workspace.file_tree,
-      FileTreeState.replace_tree(state.workspace.file_tree, updated_tree)
-    )
+  @spec handle_file_changed(EditorState.t(), String.t()) :: {EditorState.t(), [file_effect()]}
+  defp handle_file_changed(state, path) do
+    if FileTreeFreshness.path_under_tree?(state, path) do
+      {state, [{:schedule_file_tree_refresh, 50}]}
+    else
+      {state, []}
+    end
+  end
+
+  @spec handle_project_rebuilt(EditorState.t(), String.t()) :: {EditorState.t(), [file_effect()]}
+  defp handle_project_rebuilt(state, root) do
+    state = FileTreeFreshness.update_project_root(state, root)
+    {state, [{:render, 16}]}
   end
 end

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -37,7 +37,8 @@ defmodule MingaEditor.State.FileTree do
           editing: editing() | nil,
           project_root: String.t() | nil,
           tree_status: tree_status(),
-          tree_width: pos_integer()
+          tree_width: pos_integer(),
+          refresh_timer: reference() | nil
         }
 
   defstruct tree: nil,
@@ -46,7 +47,8 @@ defmodule MingaEditor.State.FileTree do
             editing: nil,
             project_root: nil,
             tree_status: :hidden,
-            tree_width: 30
+            tree_width: 30,
+            refresh_timer: nil
 
   @doc "Returns true when the file tree is open."
   @spec open?(t()) :: boolean()
@@ -98,6 +100,7 @@ defmodule MingaEditor.State.FileTree do
       | tree: tree,
         focused: true,
         buffer: buffer,
+        project_root: tree.root,
         tree_status: classify_tree(tree),
         tree_width: tree.width
     }
@@ -114,6 +117,29 @@ defmodule MingaEditor.State.FileTree do
   def loading(%__MODULE__{} = ft) do
     %{ft | focused: false, editing: nil, tree_status: :loading}
   end
+
+  @doc "Updates the project root associated with the file tree."
+  @spec set_project_root(t(), String.t() | nil) :: t()
+  def set_project_root(%__MODULE__{} = ft, nil), do: %{ft | project_root: nil}
+
+  def set_project_root(%__MODULE__{} = ft, root) when is_binary(root) do
+    %{ft | project_root: Path.expand(root)}
+  end
+
+  @doc "Returns true when a filesystem refresh timer is pending."
+  @spec refresh_scheduled?(t()) :: boolean()
+  def refresh_scheduled?(%__MODULE__{refresh_timer: ref}) when is_reference(ref), do: true
+  def refresh_scheduled?(%__MODULE__{}), do: false
+
+  @doc "Stores the pending filesystem refresh timer reference."
+  @spec schedule_refresh(t(), reference()) :: t()
+  def schedule_refresh(%__MODULE__{} = ft, ref) when is_reference(ref) do
+    %{ft | refresh_timer: ref}
+  end
+
+  @doc "Clears the pending filesystem refresh timer reference."
+  @spec clear_refresh(t()) :: t()
+  def clear_refresh(%__MODULE__{} = ft), do: %{ft | refresh_timer: nil}
 
   @doc "Marks the sidebar as failed with a displayable reason."
   @spec error(t(), term()) :: t()

--- a/test/minga/file_watcher_test.exs
+++ b/test/minga/file_watcher_test.exs
@@ -26,6 +26,12 @@ defmodule Minga.FileWatcherTest do
     assert :ok == FileWatcher.unwatch_path(watcher, "/tmp/test.txt")
   end
 
+  test "watch_directory and unwatch_directory succeed" do
+    watcher = start_watcher()
+    assert :ok == FileWatcher.watch_directory(watcher, "/tmp/project")
+    assert :ok == FileWatcher.unwatch_directory(watcher, "/tmp/project")
+  end
+
   test "subscribe registers the caller" do
     watcher = start_watcher()
     assert :ok == FileWatcher.subscribe(watcher, self())
@@ -79,6 +85,71 @@ defmodule Minga.FileWatcherTest do
     # Flush the watcher's mailbox so the event is processed
     :sys.get_state(watcher)
     refute_receive {:file_changed_on_disk, _}, 50
+  end
+
+  test "events under watched project directories are forwarded" do
+    watcher = start_watcher(subscriber: self(), debounce_ms: 10)
+    root = "/tmp/project-tree-watch"
+    path = Path.join(root, "new_file.ex")
+
+    FileWatcher.watch_directory(watcher, root)
+    send(watcher, {:file_event, nil, {path, [:created]}})
+    :sys.get_state(watcher)
+
+    assert_receive {:file_changed_on_disk, ^path}, 500
+  end
+
+  test "unwatch_directory stops forwarding project directory events" do
+    watcher = start_watcher(subscriber: self(), debounce_ms: 10)
+    root = "/tmp/project-tree-unwatch"
+    path = Path.join(root, "new_file.ex")
+
+    FileWatcher.watch_directory(watcher, root)
+    FileWatcher.unwatch_directory(watcher, root)
+    send(watcher, {:file_event, nil, {path, [:created]}})
+    :sys.get_state(watcher)
+
+    refute_receive {:file_changed_on_disk, ^path}, 50
+  end
+
+  test "watch_directory is idempotent for project directory registrations" do
+    watcher = start_watcher(subscriber: self())
+    root = "/tmp/project-tree-idempotent"
+
+    FileWatcher.watch_directory(watcher, root)
+    first_state = :sys.get_state(watcher)
+    FileWatcher.watch_directory(watcher, root)
+    second_state = :sys.get_state(watcher)
+
+    assert first_state.watched_dirs == second_state.watched_dirs
+    assert first_state.watcher == second_state.watcher
+  end
+
+  test "check_all notifies watched project directories" do
+    watcher = start_watcher(subscriber: self())
+    root = "/tmp/project-tree-check-all"
+
+    FileWatcher.watch_directory(watcher, root)
+    FileWatcher.check_all(watcher)
+    :sys.get_state(watcher)
+
+    assert_receive {:file_changed_on_disk, ^root}, 50
+  end
+
+  test "unwatch_directory_tree removes nested project directory registrations" do
+    watcher = start_watcher(subscriber: self(), debounce_ms: 10)
+    root = "/tmp/project-tree-root-unwatch"
+    nested = Path.join(root, "lib")
+    path = Path.join(nested, "new_file.ex")
+
+    FileWatcher.watch_directory(watcher, root)
+    FileWatcher.watch_directory(watcher, nested)
+    FileWatcher.unwatch_directory_tree(watcher, root)
+    send(watcher, {:file_event, nil, {path, [:created]}})
+    state = :sys.get_state(watcher)
+
+    assert state.watched_project_dirs == MapSet.new()
+    refute_receive {:file_changed_on_disk, ^path}, 50
   end
 
   test "check_all is safe after subscriber dies" do

--- a/test/minga_editor/file_tree/rows_test.exs
+++ b/test/minga_editor/file_tree/rows_test.exs
@@ -3,12 +3,18 @@ defmodule MingaEditor.FileTree.RowsTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Diagnostics
   alias Minga.Diagnostics.Diagnostic
   alias Minga.Project.FileTree
   alias MingaEditor.FileTree.Diagnostics, as: RowDiagnostics
   alias MingaEditor.FileTree.Rows
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  import MingaEditor.RenderPipeline.TestHelpers
 
   @moduletag :tmp_dir
 
@@ -190,6 +196,28 @@ defmodule MingaEditor.FileTree.RowsTest do
     end
   end
 
+  describe "from_state/1" do
+    test "active row follows buffer switches without reopening the tree", %{tmp_dir: tmp_dir} do
+      alpha_path = Path.join(tmp_dir, "alpha.ex")
+      beta_path = Path.join(tmp_dir, "beta.ex")
+      File.write!(alpha_path, "alpha")
+      File.write!(beta_path, "beta")
+      {:ok, alpha_buffer} = BufferProcess.start_link(file_path: alpha_path)
+      {:ok, beta_buffer} = BufferProcess.start_link(file_path: beta_path)
+
+      state =
+        tmp_dir
+        |> state_with_tree()
+        |> put_buffers([alpha_buffer, beta_buffer])
+
+      assert active_row_name(state) == "alpha.ex"
+
+      switched_state = EditorState.switch_buffer(state, 1)
+
+      assert active_row_name(switched_state) == "beta.ex"
+    end
+  end
+
   describe "FileTreeState.status/1" do
     test "distinguishes hidden, empty, ready, loading, and error states", %{tmp_dir: tmp_dir} do
       assert FileTreeState.status(%FileTreeState{}) == :hidden
@@ -242,6 +270,25 @@ defmodule MingaEditor.FileTree.RowsTest do
     File.write!(Path.join(tmp_dir, "alpha.ex"), "")
     File.write!(Path.join(tmp_dir, "beta.ex"), "")
     FileTree.new(tmp_dir)
+  end
+
+  defp state_with_tree(root) do
+    tree = FileTree.new(root)
+    file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
+
+    EditorState.update_workspace(base_state(), &WorkspaceState.set_file_tree(&1, file_tree))
+  end
+
+  defp put_buffers(state, [active | _rest] = buffers) do
+    buffer_state = %Buffers{active: active, list: buffers, active_index: 0}
+    EditorState.update_workspace(state, &%{&1 | buffers: buffer_state})
+  end
+
+  defp active_row_name(state) do
+    state
+    |> Rows.from_state()
+    |> Enum.find(& &1.active?)
+    |> Map.fetch!(:name)
   end
 
   defp diagnostic(severity) do

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -8,11 +8,19 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
 
   use ExUnit.Case, async: true
 
+  @moduletag :tmp_dir
+
+  alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Git.StatusEntry
+  alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.Handlers.FileEventHandler
   alias MingaEditor.Shell.Traditional.GitStatus.TuiState
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.FileTree, as: FileTreeState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -110,7 +118,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       refute Map.has_key?(EditorState.git_status_panel(new_state), :tui_state)
     end
 
-    test "without git panel open is a no-op" do
+    test "without git panel or file tree open is a no-op" do
       state = base_state()
 
       event =
@@ -126,6 +134,204 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       {new_state, effects} = FileEventHandler.handle(state, event)
       assert new_state == state
       assert effects == []
+    end
+
+    test "without git panel open refreshes file tree badges from the event", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "alpha.ex")
+      File.write!(file_path, "")
+      state = state_with_tree(tmp_dir)
+
+      event =
+        {:minga_event, :git_status_changed,
+         %Minga.Events.GitStatusEvent{
+           git_root: tmp_dir,
+           entries: [%StatusEntry{path: "alpha.ex", status: :modified, staged: false}],
+           branch: "main",
+           ahead: 0,
+           behind: 0
+         }}
+
+      {new_state, effects} = FileEventHandler.handle(state, event)
+
+      assert new_state.workspace.file_tree.tree.git_status[file_path] == :modified
+      assert {:render, 16} in effects
+    end
+  end
+
+  describe "file tree freshness" do
+    @describetag :tmp_dir
+
+    test "file change under the tree root schedules one debounced refresh", %{tmp_dir: tmp_dir} do
+      state = state_with_tree(tmp_dir)
+      changed_path = Path.join(tmp_dir, "created.ex")
+
+      {_state, effects} = FileEventHandler.handle(state, {:file_changed_on_disk, changed_path})
+
+      assert effects == [{:schedule_file_tree_refresh, 50}]
+    end
+
+    test "file change outside the tree root does not refresh", %{tmp_dir: tmp_dir} do
+      state = state_with_tree(tmp_dir)
+      outside_path = Path.join(tmp_dir <> "_sibling", "created.ex")
+
+      {_state, effects} = FileEventHandler.handle(state, {:file_changed_on_disk, outside_path})
+
+      assert effects == []
+    end
+
+    test "file_written under the tree root schedules a debounced refresh", %{tmp_dir: tmp_dir} do
+      state = state_with_tree(tmp_dir)
+      changed_path = Path.join(tmp_dir, "created_by_agent.ex")
+
+      {_state, effects} =
+        FileEventHandler.handle(state, {
+          :minga_event,
+          :file_written,
+          %Minga.Events.FileWrittenEvent{path: changed_path, change_type: :created}
+        })
+
+      assert effects == [{:schedule_file_tree_refresh, 50}]
+    end
+
+    test "file_written outside the tree root does not refresh", %{tmp_dir: tmp_dir} do
+      state = state_with_tree(tmp_dir)
+      outside_path = Path.join(tmp_dir <> "_sibling", "created_by_agent.ex")
+
+      {_state, effects} =
+        FileEventHandler.handle(state, {
+          :minga_event,
+          :file_written,
+          %Minga.Events.FileWrittenEvent{path: outside_path, change_type: :created}
+        })
+
+      assert effects == []
+    end
+
+    test "applying repeated refresh effects keeps one pending timer", %{tmp_dir: tmp_dir} do
+      state = state_with_tree(tmp_dir)
+
+      first_state = MingaEditor.apply_effects(state, [{:schedule_file_tree_refresh, 1_000}])
+      first_ref = first_state.workspace.file_tree.refresh_timer
+
+      second_state =
+        MingaEditor.apply_effects(first_state, [{:schedule_file_tree_refresh, 1_000}])
+
+      assert is_reference(first_ref)
+      assert second_state.workspace.file_tree.refresh_timer == first_ref
+      Process.cancel_timer(first_ref)
+    end
+
+    test "refresh timer rescans entries and clears pending timer", %{tmp_dir: tmp_dir} do
+      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
+
+      state =
+        tmp_dir
+        |> state_with_tree()
+        |> FileTreeFreshness.schedule_refresh(make_ref())
+
+      File.write!(Path.join(tmp_dir, "beta.ex"), "")
+
+      {new_state, effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
+
+      names =
+        new_state.workspace.file_tree.tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
+
+      assert "beta.ex" in names
+      refute FileTreeFreshness.refresh_scheduled?(new_state)
+      assert {:render, 16} in effects
+    end
+
+    test "diagnostics under the tree root schedule render", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "alpha.ex")
+      state = state_with_tree(tmp_dir)
+      uri = Minga.LSP.SyncServer.path_to_uri(file_path)
+
+      {_state, effects} =
+        FileEventHandler.handle(state, {
+          :minga_event,
+          :diagnostics_updated,
+          %Minga.Events.DiagnosticsUpdatedEvent{uri: uri, source: :test}
+        })
+
+      assert effects == [{:render, 16}]
+    end
+
+    test "diagnostics outside the tree root do not render the tree", %{tmp_dir: tmp_dir} do
+      state = state_with_tree(tmp_dir)
+      uri = Minga.LSP.SyncServer.path_to_uri(Path.join(tmp_dir <> "_sibling", "alpha.ex"))
+
+      {_state, effects} =
+        FileEventHandler.handle(state, {
+          :minga_event,
+          :diagnostics_updated,
+          %Minga.Events.DiagnosticsUpdatedEvent{uri: uri, source: :test}
+        })
+
+      assert effects == []
+    end
+
+    test "buffer changes under the tree root schedule render", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "alpha.ex")
+      File.write!(file_path, "alpha")
+      {:ok, buffer} = BufferProcess.start_link(file_path: file_path)
+
+      state =
+        tmp_dir
+        |> state_with_tree()
+        |> put_active_buffer(buffer)
+
+      {_state, effects} =
+        FileEventHandler.handle(state, {
+          :minga_event,
+          :buffer_changed,
+          %Minga.Events.BufferChangedEvent{buffer: buffer, source: :test}
+        })
+
+      assert effects == [{:render, 16}]
+    end
+
+    test "buffer changes outside the tree root do not render the tree", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir <> "_sibling", "alpha.ex")
+      File.mkdir_p!(Path.dirname(file_path))
+      File.write!(file_path, "alpha")
+      {:ok, buffer} = BufferProcess.start_link(file_path: file_path)
+
+      state = state_with_tree(tmp_dir)
+
+      {_state, effects} =
+        FileEventHandler.handle(state, {
+          :minga_event,
+          :buffer_changed,
+          %Minga.Events.BufferChangedEvent{buffer: buffer, source: :test}
+        })
+
+      assert effects == []
+    end
+
+    test "project rebuild changes the visible tree root", %{tmp_dir: tmp_dir} do
+      old_root = Path.join(tmp_dir, "old")
+      new_root = Path.join(tmp_dir, "new")
+      File.mkdir_p!(old_root)
+      File.mkdir_p!(new_root)
+      File.write!(Path.join(old_root, "old.ex"), "")
+      File.write!(Path.join(new_root, "new.ex"), "")
+
+      state = state_with_tree(old_root)
+
+      {new_state, effects} =
+        FileEventHandler.handle(state, {
+          :minga_event,
+          :project_rebuilt,
+          %Minga.Events.ProjectRebuiltEvent{root: new_root}
+        })
+
+      names =
+        new_state.workspace.file_tree.tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
+
+      assert new_state.workspace.file_tree.project_root == Path.expand(new_root)
+      assert "new.ex" in names
+      refute "old.ex" in names
+      assert {:render, 16} in effects
     end
   end
 
@@ -189,5 +395,17 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       assert new_state == state
       assert effects == []
     end
+  end
+
+  defp state_with_tree(root) do
+    tree = FileTree.new(root)
+    file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
+
+    EditorState.update_workspace(base_state(), &WorkspaceState.set_file_tree(&1, file_tree))
+  end
+
+  defp put_active_buffer(state, buffer) do
+    buffers = %Buffers{active: buffer, list: [buffer], active_index: 0}
+    EditorState.update_workspace(state, &%{&1 | buffers: buffers})
   end
 end


### PR DESCRIPTION
# TL;DR
The file tree now stays fresh as project files, git status, diagnostics, buffer dirty state, active buffers, and project roots change. Refresh work happens from event handlers with debounced filesystem rescans, not from render functions.

Closes #1649

## Context
The file tree is becoming a project status surface. That only works if its entries and badges update when the project changes outside direct file-tree commands.

## Changes
- Added a file-tree freshness helper that centralizes event-time refresh decisions for filesystem, git, diagnostics, buffer, and project-root events.
- Extended the file watcher with idempotent project-directory watches, tree-root cleanup, and `check_all` notifications for watched project directories.
- Updated the editor event subscriptions and file event handler so tree entries, git badges, diagnostic badges, and dirty indicators render from current state after relevant events.
- Added a `FileTree.replace_git_status/2` owner function so cached git status updates stay behind the file-tree struct boundary.
- Kept filesystem rescans debounced through a single pending tree refresh timer and refreshed git badges during the debounce flush.

## Verification
- `mix test.llm test/minga_editor/handlers/file_event_handler_test.exs test/minga_editor/file_tree/rows_test.exs test/minga/file_watcher_test.exs`
- `mix compile --warnings-as-errors`
- `make lint`
- `mix test.llm`
- Final reviewer gate: PASS after targeted AC #5 re-review

## Acceptance Criteria Addressed
- File-tree entries refresh when watched project files are created, deleted, renamed, or changed outside Minga ✅
- Git badges refresh when `:git_status_changed` events arrive ✅
- Diagnostic badges refresh when `:diagnostics_updated` events affect a file under the tree root ✅
- Dirty-buffer indicators refresh when a buffer changes dirty or clean state ✅
- Active-file highlighting follows buffer switches without requiring the tree to be reopened ✅
- Project-root changes update visible or hidden tree state instead of leaving stale entries ✅
- Refresh work is debounced or coalesced ✅
- Tests cover each event source with deterministic assertions and no `Process.sleep/1` ✅
