### PR TITLE
refactor(buffer): extract undo history

### DIFF
--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -48,6 +48,7 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     "Minga.Buffer.EditSource",
     "Minga.Buffer.RenderSnapshot",
     "Minga.Buffer.State",
+    "Minga.Buffer.UndoHistory",
     "Minga.Editing.Motion",
     "Minga.Editing.Operator",
     "Minga.Editing.TextObject",

--- a/lib/minga/buffer/edit_source.ex
+++ b/lib/minga/buffer/edit_source.ex
@@ -3,8 +3,8 @@ defmodule Minga.Buffer.EditSource do
   Identifies who made an edit to a buffer.
 
   The rich source type flows through events, ghost cursors, and the edit
-  timeline. The undo stack uses a simpler atom-based source (see
-  `Minga.Buffer.State.edit_source`); use `to_undo_source/1` to bridge.
+  timeline. The undo history uses a simpler atom-based source; use
+  `to_undo_source/1` to bridge.
 
   ## Creating sources
 
@@ -36,6 +36,9 @@ defmodule Minga.Buffer.EditSource do
           | {:lsp, server_name :: atom()}
           | :formatter
           | :unknown
+
+  @typedoc "Simple edit source for undo/redo attribution."
+  @type undo_source :: :user | :agent | :lsp | :recovery
 
   # ── Constructors ──────────────────────────────────────────────────────
 
@@ -72,7 +75,7 @@ defmodule Minga.Buffer.EditSource do
   This bridge exists so the undo system can continue using atom-based
   guards until Provenance Undo (#1108) migrates it to the rich type.
   """
-  @spec to_undo_source(t()) :: Minga.Buffer.State.edit_source()
+  @spec to_undo_source(t()) :: undo_source()
   def to_undo_source(:user), do: :user
   def to_undo_source({:agent, _session_id, _tool_call_id}), do: :agent
   def to_undo_source({:lsp, _server_name}), do: :lsp
@@ -89,7 +92,7 @@ defmodule Minga.Buffer.EditSource do
   not an agent session PID. The undo stack doesn't preserve the original session
   reference. Treat it as a sentinel indicating "some agent edit, origin unknown."
   """
-  @spec from_undo_source(Minga.Buffer.State.edit_source()) :: t()
+  @spec from_undo_source(undo_source()) :: t()
   def from_undo_source(:user), do: user()
   def from_undo_source(:agent), do: agent(self(), "unknown")
   def from_undo_source(:lsp), do: lsp(:unknown)

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -26,7 +26,8 @@ defmodule Minga.Buffer.Process do
     Operation,
     Persistence,
     Position,
-    Replace
+    Replace,
+    UndoHistory
   }
 
   alias Minga.Buffer.EditDelta
@@ -245,7 +246,7 @@ defmodule Minga.Buffer.Process do
     GenServer.call(server, :force_save, @file_io_call_timeout)
   end
 
-  @doc "Reloads the buffer from disk, preserving cursor position (clamped). Clears undo/redo."
+  @doc "Reloads the buffer from disk, preserving cursor position (clamped). Clears undo/redo history."
   @spec reload(GenServer.server()) :: :ok | {:error, term()}
   def reload(server) do
     GenServer.call(server, :reload, @file_io_call_timeout)
@@ -876,8 +877,7 @@ defmodule Minga.Buffer.Process do
             file_size: size,
             file_hash: Persistence.content_fingerprint(text),
             decorations: Decorations.new(),
-            undo_stack: [],
-            redo_stack: []
+            undo_history: UndoHistory.clear(state.undo_history)
         }
 
         unregister_path(state.file_path)
@@ -1114,8 +1114,7 @@ defmodule Minga.Buffer.Process do
             mtime: new_mtime,
             file_size: new_size,
             file_hash: Persistence.content_fingerprint(text),
-            undo_stack: [],
-            redo_stack: [],
+            undo_history: UndoHistory.clear(state.undo_history),
             decorations: Decorations.new()
         }
 
@@ -1191,8 +1190,7 @@ defmodule Minga.Buffer.Process do
         mtime: mtime,
         file_size: size,
         file_hash: Persistence.content_fingerprint(new_content),
-        undo_stack: [],
-        redo_stack: [],
+        undo_history: UndoHistory.clear(state.undo_history),
         change_log: ChangeLog.clear(state.change_log),
         decorations: Decorations.new()
     }
@@ -1475,79 +1473,62 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call(:undo, _from, state) do
-    case state.undo_stack do
-      [] ->
+    case UndoHistory.undo(state.undo_history, state.version, state.document) do
+      :empty ->
         {:reply, :ok, state}
 
-      [{prev_version, prev_buf, source} | rest_undo] ->
-        redo_entry = {state.version, state.document, source}
-
-        event_source = EditSource.from_undo_source(source)
+      {:ok, restore, undo_history} ->
+        event_source = EditSource.from_undo_source(restore.source)
 
         new_state =
           %{
             state
-            | document: prev_buf,
-              version: prev_version,
-              undo_stack: rest_undo,
-              redo_stack: [redo_entry | state.redo_stack]
+            | document: restore.document,
+              version: restore.version,
+              undo_history: undo_history
           }
           |> sync_dirty()
           |> clear_edits(event_source)
 
-        log_undo_source(:undo, source)
+        log_undo_source(:undo, restore.source)
         {:reply, :ok, new_state}
     end
   end
 
   def handle_call(:redo, _from, state) do
-    case state.redo_stack do
-      [] ->
+    case UndoHistory.redo(state.undo_history, state.version, state.document) do
+      :empty ->
         {:reply, :ok, state}
 
-      [{next_version, next_buf, source} | rest_redo] ->
-        undo_entry = {state.version, state.document, source}
-
-        event_source = EditSource.from_undo_source(source)
+      {:ok, restore, undo_history} ->
+        event_source = EditSource.from_undo_source(restore.source)
 
         new_state =
           %{
             state
-            | document: next_buf,
-              version: next_version,
-              redo_stack: rest_redo,
-              undo_stack: [undo_entry | state.undo_stack]
+            | document: restore.document,
+              version: restore.version,
+              undo_history: undo_history
           }
           |> sync_dirty()
           |> clear_edits(event_source)
 
-        log_undo_source(:redo, source)
+        log_undo_source(:redo, restore.source)
         {:reply, :ok, new_state}
     end
   end
 
   def handle_call(:break_undo_coalescing, _from, state) do
-    {:reply, :ok, BufState.break_undo_coalescing(state)}
+    undo_history = UndoHistory.break_coalescing(state.undo_history)
+    {:reply, :ok, %{state | undo_history: undo_history}}
   end
 
   def handle_call(:last_undo_source, _from, state) do
-    source =
-      case state.undo_stack do
-        [] -> nil
-        [{_version, _doc, source} | _] -> source
-      end
-
-    {:reply, source, state}
+    {:reply, UndoHistory.last_undo_source(state.undo_history), state}
   end
 
   def handle_call(:last_redo_source, _from, state) do
-    source =
-      case state.redo_stack do
-        [] -> nil
-        [{_version, _doc, source} | _] -> source
-      end
-
-    {:reply, source, state}
+    {:reply, UndoHistory.last_redo_source(state.undo_history), state}
   end
 
   # ── Decoration callbacks ──
@@ -1821,15 +1802,21 @@ defmodule Minga.Buffer.Process do
     :exit, _ -> %{}
   end
 
-  # Delegates to BufState for time-based undo coalescing.
   @spec push_undo(state(), Document.t(), BufState.edit_source()) :: state()
-  defp push_undo(state, new_buf, source), do: BufState.push_undo(state, new_buf, source)
+  defp push_undo(state, new_buf, source) do
+    undo_history =
+      UndoHistory.record_edit(state.undo_history, state.version, state.document, source)
 
-  # Force-pushes an undo entry, bypassing coalescing. Used for agent
-  # batch edits and explicit actions like :replace_content.
+    %{state | document: new_buf, undo_history: undo_history}
+  end
+
   @spec push_undo_force(state(), Document.t(), BufState.edit_source()) :: state()
-  defp push_undo_force(state, new_buf, source),
-    do: BufState.push_undo_force(state, new_buf, source)
+  defp push_undo_force(state, new_buf, source) do
+    undo_history =
+      UndoHistory.record_edit_force(state.undo_history, state.version, state.document, source)
+
+    %{state | document: new_buf, undo_history: undo_history}
+  end
 
   # Logs undo/redo source for non-user edits (diagnostic, gated by :log_level_editor).
   @spec log_undo_source(:undo | :redo, BufState.edit_source()) :: :ok

--- a/lib/minga/buffer/state.ex
+++ b/lib/minga/buffer/state.ex
@@ -2,22 +2,17 @@ defmodule Minga.Buffer.State do
   @moduledoc """
   Internal state for the Buffer GenServer.
 
-  Holds the gap buffer, file path, dirty flag, and undo/redo stacks.
-
-  ## Undo coalescing
-
-  Rapid edits (e.g., AI-driven or fast typing) that arrive within
-  `@undo_coalesce_ms` of each other are grouped into a single undo entry.
-  Instead of pushing a new snapshot for every mutation, the top of the undo
-  stack is kept and only the document is replaced. This bounds memory usage
-  under burst editing while preserving correct undo for human-speed edits.
+  Holds the document, file path, dirty flag, and buffer-local runtime state.
   """
 
   alias Minga.Buffer.ChangeLog
   alias Minga.Buffer.Document
+  alias Minga.Buffer.EditSource
+  alias Minga.Buffer.UndoHistory
   alias Minga.Core.Decorations
 
   @default_change_log ChangeLog.new()
+  @default_undo_history UndoHistory.new()
 
   @typedoc """
   Buffer type controlling behavior:
@@ -34,11 +29,7 @@ defmodule Minga.Buffer.State do
   @type storage :: :local | {:remote, node(), String.t()}
 
   @typedoc "The source of an edit for undo/redo attribution."
-  @type edit_source :: :user | :agent | :lsp | :recovery
-
-  @typedoc "An undo/redo stack entry: the document snapshot, version, and edit source."
-  @type stack_entry ::
-          {version :: non_neg_integer(), document :: Document.t(), source :: edit_source()}
+  @type edit_source :: EditSource.undo_source()
 
   @enforce_keys [:document]
   defstruct document: nil,
@@ -52,9 +43,7 @@ defmodule Minga.Buffer.State do
             mtime: nil,
             file_size: nil,
             file_hash: nil,
-            undo_stack: [],
-            redo_stack: [],
-            last_undo_at: 0,
+            undo_history: @default_undo_history,
             name: nil,
             read_only: false,
             unlisted: false,
@@ -82,9 +71,7 @@ defmodule Minga.Buffer.State do
           mtime: integer() | nil,
           file_size: non_neg_integer() | nil,
           file_hash: binary() | nil,
-          undo_stack: [stack_entry()],
-          redo_stack: [stack_entry()],
-          last_undo_at: integer(),
+          undo_history: UndoHistory.t(),
           name: String.t() | nil,
           read_only: boolean(),
           unlisted: boolean(),
@@ -101,17 +88,6 @@ defmodule Minga.Buffer.State do
           events_registry: Minga.Events.registry()
         }
 
-  @max_undo_stack 1000
-
-  @doc """
-  The coalescing window in milliseconds. Edits arriving within this window
-  of the previous undo push are merged into the same undo entry.
-  """
-  @spec undo_coalesce_ms() :: pos_integer()
-  def undo_coalesce_ms, do: 300
-
-  @undo_coalesce_ms 300
-
   @doc "Marks the buffer as having unsaved changes (bumps version)."
   @spec mark_dirty(t()) :: t()
   def mark_dirty(%__MODULE__{} = state) do
@@ -121,7 +97,7 @@ defmodule Minga.Buffer.State do
 
   @doc """
   Sets the dirty flag based on whether the given version matches the saved
-  version. Used by undo/redo which restore a version from the stack rather
+  version. Used by undo/redo which restore a version from history rather
   than incrementing.
   """
   @spec sync_dirty(t()) :: t()
@@ -133,75 +109,5 @@ defmodule Minga.Buffer.State do
   @spec mark_saved(t()) :: t()
   def mark_saved(%__MODULE__{} = state) do
     %{state | dirty: false, saved_version: state.version}
-  end
-
-  @doc """
-  Pushes the current document onto the undo stack and replaces it with
-  `new_buf`. Clears the redo stack. The undo stack is capped at
-  #{@max_undo_stack} entries.
-
-  If the previous undo push happened within #{@undo_coalesce_ms}ms, the
-  new document replaces the current one without pushing another snapshot
-  onto the stack. This coalesces rapid edits (AI, fast typing) into a
-  single undo step while preserving distinct undo entries for edits
-  separated by a pause.
-  """
-  @spec push_undo(t(), Document.t(), edit_source()) :: t()
-  def push_undo(%__MODULE__{} = state, new_buf, source)
-      when source in [:user, :agent, :lsp, :recovery] do
-    now = System.monotonic_time(:millisecond)
-    elapsed = now - state.last_undo_at
-
-    do_push_undo(state, new_buf, source, now, elapsed)
-  end
-
-  # First undo ever, or enough time has passed: push a new entry.
-  @spec do_push_undo(t(), Document.t(), edit_source(), integer(), integer()) :: t()
-  defp do_push_undo(%__MODULE__{} = state, new_buf, source, now, elapsed)
-       when state.last_undo_at == 0 or elapsed >= @undo_coalesce_ms do
-    entry = {state.version, state.document, source}
-
-    new_undo =
-      [entry | state.undo_stack]
-      |> Enum.take(@max_undo_stack)
-
-    %{state | document: new_buf, undo_stack: new_undo, redo_stack: [], last_undo_at: now}
-  end
-
-  # Within the coalescing window: replace document, keep stack as-is.
-  # Source is ignored here; the stack entry was already recorded with the
-  # source from the first edit in this coalescing window.
-  defp do_push_undo(%__MODULE__{} = state, new_buf, _source, now, _elapsed) do
-    %{state | document: new_buf, redo_stack: [], last_undo_at: now}
-  end
-
-  @doc """
-  Pushes an undo entry unconditionally, bypassing time-based coalescing.
-
-  Use this for explicit actions (like `:replace_content`, agent batch edits)
-  where each invocation should always be a separate undo step regardless of
-  timing.
-  """
-  @spec push_undo_force(t(), Document.t(), edit_source()) :: t()
-  def push_undo_force(%__MODULE__{} = state, new_buf, source)
-      when source in [:user, :agent, :lsp, :recovery] do
-    now = System.monotonic_time(:millisecond)
-    entry = {state.version, state.document, source}
-
-    new_undo =
-      [entry | state.undo_stack]
-      |> Enum.take(@max_undo_stack)
-
-    %{state | document: new_buf, undo_stack: new_undo, redo_stack: [], last_undo_at: now}
-  end
-
-  @doc """
-  Resets the coalescing timer so the next `push_undo/2` will always
-  create a new undo entry. Call this at undo boundaries (e.g., mode
-  transitions like leaving insert mode).
-  """
-  @spec break_undo_coalescing(t()) :: t()
-  def break_undo_coalescing(%__MODULE__{} = state) do
-    %{state | last_undo_at: 0}
   end
 end

--- a/lib/minga/buffer/undo_history.ex
+++ b/lib/minga/buffer/undo_history.ex
@@ -1,0 +1,147 @@
+defmodule Minga.Buffer.UndoHistory do
+  @moduledoc """
+  Undo and redo history for a buffer document.
+
+  The buffer process owns the live document and version counter. This struct remembers the snapshots needed to move backward and forward through document history, including the source of each edit for diagnostics and attribution.
+
+  This module is pure state. It does not mark buffers dirty, broadcast events, or mutate documents.
+  """
+
+  alias Minga.Buffer.Document
+  alias Minga.Buffer.EditSource
+  alias Minga.Buffer.UndoHistory.Restore
+
+  @max_entries 1000
+  @coalesce_ms 300
+
+  @type edit_source :: EditSource.undo_source()
+  @type version :: non_neg_integer()
+  @type entry :: {version(), Document.t(), edit_source()}
+
+  defstruct undo_entries: [],
+            redo_entries: [],
+            last_recorded_at: 0
+
+  @opaque t :: %__MODULE__{
+            undo_entries: [entry()],
+            redo_entries: [entry()],
+            last_recorded_at: integer()
+          }
+
+  @doc "Creates an empty undo history."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Returns the coalescing window in milliseconds."
+  @spec coalesce_ms() :: pos_integer()
+  def coalesce_ms, do: @coalesce_ms
+
+  @doc "Records an undo snapshot, coalescing rapid edits into one history entry."
+  @spec record_edit(t(), version(), Document.t(), edit_source()) :: t()
+  def record_edit(%__MODULE__{} = history, version, %Document{} = document, source)
+      when source in [:user, :agent, :lsp, :recovery] do
+    now = System.monotonic_time(:millisecond)
+    elapsed = now - history.last_recorded_at
+
+    do_record_edit(history, version, document, source, now, elapsed)
+  end
+
+  @doc "Records an undo snapshot without time-based coalescing."
+  @spec record_edit_force(t(), version(), Document.t(), edit_source()) :: t()
+  def record_edit_force(%__MODULE__{} = history, version, %Document{} = document, source)
+      when source in [:user, :agent, :lsp, :recovery] do
+    now = System.monotonic_time(:millisecond)
+    entry = {version, document, source}
+
+    %{
+      history
+      | undo_entries: cap_entries([entry | history.undo_entries]),
+        redo_entries: [],
+        last_recorded_at: now
+    }
+  end
+
+  @doc "Returns the previous document/version and updates history, or `:empty` when undo is unavailable."
+  @spec undo(t(), version(), Document.t()) :: {:ok, Restore.t(), t()} | :empty
+  def undo(%__MODULE__{undo_entries: []}, _current_version, %Document{}), do: :empty
+
+  def undo(%__MODULE__{} = history, current_version, %Document{} = current_document) do
+    [{previous_version, previous_document, source} | remaining_undo] = history.undo_entries
+    redo_entry = {current_version, current_document, source}
+
+    new_history = %{
+      history
+      | undo_entries: remaining_undo,
+        redo_entries: [redo_entry | history.redo_entries]
+    }
+
+    {:ok, Restore.new(previous_version, previous_document, source), new_history}
+  end
+
+  @doc "Returns the next document/version and updates history, or `:empty` when redo is unavailable."
+  @spec redo(t(), version(), Document.t()) :: {:ok, Restore.t(), t()} | :empty
+  def redo(%__MODULE__{redo_entries: []}, _current_version, %Document{}), do: :empty
+
+  def redo(%__MODULE__{} = history, current_version, %Document{} = current_document) do
+    [{next_version, next_document, source} | remaining_redo] = history.redo_entries
+    undo_entry = {current_version, current_document, source}
+
+    new_history = %{
+      history
+      | redo_entries: remaining_redo,
+        undo_entries: cap_entries([undo_entry | history.undo_entries])
+    }
+
+    {:ok, Restore.new(next_version, next_document, source), new_history}
+  end
+
+  @doc "Clears undo and redo entries and resets coalescing state."
+  @spec clear(t()) :: t()
+  def clear(%__MODULE__{} = history) do
+    %{history | undo_entries: [], redo_entries: [], last_recorded_at: 0}
+  end
+
+  @doc "Resets the coalescing timer so the next recorded edit creates a new undo entry."
+  @spec break_coalescing(t()) :: t()
+  def break_coalescing(%__MODULE__{} = history) do
+    %{history | last_recorded_at: 0}
+  end
+
+  @doc "Returns the source of the most recent undo entry, or `nil` if undo is unavailable."
+  @spec last_undo_source(t()) :: edit_source() | nil
+  def last_undo_source(%__MODULE__{undo_entries: []}), do: nil
+  def last_undo_source(%__MODULE__{undo_entries: [{_version, _document, source} | _]}), do: source
+
+  @doc "Returns the source of the most recent redo entry, or `nil` if redo is unavailable."
+  @spec last_redo_source(t()) :: edit_source() | nil
+  def last_redo_source(%__MODULE__{redo_entries: []}), do: nil
+  def last_redo_source(%__MODULE__{redo_entries: [{_version, _document, source} | _]}), do: source
+
+  @doc false
+  @spec undo_count(t()) :: non_neg_integer()
+  def undo_count(%__MODULE__{} = history), do: length(history.undo_entries)
+
+  @doc false
+  @spec redo_count(t()) :: non_neg_integer()
+  def redo_count(%__MODULE__{} = history), do: length(history.redo_entries)
+
+  @spec do_record_edit(t(), version(), Document.t(), edit_source(), integer(), integer()) :: t()
+  defp do_record_edit(%__MODULE__{} = history, version, document, source, now, elapsed)
+       when history.last_recorded_at == 0 or elapsed >= @coalesce_ms do
+    entry = {version, document, source}
+
+    %{
+      history
+      | undo_entries: cap_entries([entry | history.undo_entries]),
+        redo_entries: [],
+        last_recorded_at: now
+    }
+  end
+
+  defp do_record_edit(%__MODULE__{} = history, _version, _document, _source, now, _elapsed) do
+    %{history | redo_entries: [], last_recorded_at: now}
+  end
+
+  @spec cap_entries([entry()]) :: [entry()]
+  defp cap_entries(entries), do: Enum.take(entries, @max_entries)
+end

--- a/lib/minga/buffer/undo_history/restore.ex
+++ b/lib/minga/buffer/undo_history/restore.ex
@@ -1,0 +1,26 @@
+defmodule Minga.Buffer.UndoHistory.Restore do
+  @moduledoc """
+  Document snapshot returned by an undo or redo transition.
+
+  The history owns which snapshot should be restored. The buffer process owns applying that snapshot to the live buffer state.
+  """
+
+  alias Minga.Buffer.Document
+  alias Minga.Buffer.EditSource
+
+  @enforce_keys [:version, :document, :source]
+  defstruct [:version, :document, :source]
+
+  @type t :: %__MODULE__{
+          version: non_neg_integer(),
+          document: Document.t(),
+          source: EditSource.undo_source()
+        }
+
+  @doc "Creates a restore snapshot."
+  @spec new(non_neg_integer(), Document.t(), EditSource.undo_source()) :: t()
+  def new(version, %Document{} = document, source)
+      when source in [:user, :agent, :lsp, :recovery] do
+    %__MODULE__{version: version, document: document, source: source}
+  end
+end

--- a/test/minga/buffer/mtime_test.exs
+++ b/test/minga/buffer/mtime_test.exs
@@ -118,7 +118,7 @@ defmodule Minga.Buffer.MtimeTest do
   end
 
   @tag :tmp_dir
-  test ":e! clears undo/redo stacks", %{tmp_dir: tmp_dir} do
+  test ":e! clears undo/redo history", %{tmp_dir: tmp_dir} do
     path = Path.join(tmp_dir, "undo.txt")
     File.write!(path, "original")
 
@@ -126,14 +126,12 @@ defmodule Minga.Buffer.MtimeTest do
     BufferProcess.insert_char(buf, "change1")
     BufferProcess.insert_char(buf, "change2")
 
-    state_before = :sys.get_state(buf)
-    assert state_before.undo_stack != []
+    assert BufferProcess.last_undo_source(buf) != nil
 
     :ok = BufferProcess.reload(buf)
 
-    state_after = :sys.get_state(buf)
-    assert state_after.undo_stack == []
-    assert state_after.redo_stack == []
+    assert BufferProcess.last_undo_source(buf) == nil
+    assert BufferProcess.last_redo_source(buf) == nil
   end
 
   @tag :tmp_dir

--- a/test/minga/buffer/process_test.exs
+++ b/test/minga/buffer/process_test.exs
@@ -744,7 +744,7 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.undo(pid)
       assert BufferProcess.last_redo_source(pid) == :agent
 
-      # Redo pushes it back to undo_stack
+      # Redo pushes it back to undo history
       BufferProcess.redo(pid)
       assert BufferProcess.last_undo_source(pid) == :agent
     end

--- a/test/minga/buffer/undo_history_test.exs
+++ b/test/minga/buffer/undo_history_test.exs
@@ -1,0 +1,112 @@
+defmodule Minga.Buffer.UndoHistoryTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Document
+  alias Minga.Buffer.UndoHistory
+
+  defp doc(text), do: Document.new(text)
+
+  describe "record_edit/4" do
+    test "records an undo snapshot with source attribution" do
+      history = UndoHistory.record_edit(UndoHistory.new(), 0, doc("before"), :agent)
+
+      assert UndoHistory.undo_count(history) == 1
+      assert UndoHistory.redo_count(history) == 0
+      assert UndoHistory.last_undo_source(history) == :agent
+    end
+
+    test "coalesces rapid edits into one undo entry" do
+      history =
+        UndoHistory.new()
+        |> UndoHistory.record_edit(0, doc("a"), :user)
+        |> UndoHistory.record_edit(1, doc("ab"), :user)
+
+      assert UndoHistory.undo_count(history) == 1
+    end
+
+    test "break_coalescing makes the next edit create a new entry" do
+      history =
+        UndoHistory.new()
+        |> UndoHistory.record_edit(0, doc("a"), :user)
+        |> UndoHistory.break_coalescing()
+        |> UndoHistory.record_edit(1, doc("ab"), :user)
+
+      assert UndoHistory.undo_count(history) == 2
+    end
+
+    test "force recording bypasses coalescing and clears redo entries" do
+      history = UndoHistory.record_edit_force(UndoHistory.new(), 0, doc("before"), :agent)
+
+      assert {:ok, restore, history} = UndoHistory.undo(history, 1, doc("after"))
+      assert restore.source == :agent
+      assert UndoHistory.redo_count(history) == 1
+
+      history = UndoHistory.record_edit_force(history, 1, doc("new"), :user)
+
+      assert UndoHistory.undo_count(history) == 1
+      assert UndoHistory.redo_count(history) == 0
+      assert UndoHistory.last_undo_source(history) == :user
+    end
+
+    test "caps undo entries" do
+      history =
+        Enum.reduce(1..1100, UndoHistory.new(), fn version, history ->
+          UndoHistory.record_edit_force(history, version, doc(Integer.to_string(version)), :user)
+        end)
+
+      assert UndoHistory.undo_count(history) == 1000
+    end
+  end
+
+  describe "undo/3 and redo/3" do
+    test "undo returns the previous snapshot and creates a redo entry" do
+      history = UndoHistory.record_edit_force(UndoHistory.new(), 0, doc("before"), :lsp)
+
+      assert {:ok, restore, history} = UndoHistory.undo(history, 1, doc("after"))
+      assert restore.version == 0
+      assert restore.source == :lsp
+      assert Document.content(restore.document) == "before"
+      assert UndoHistory.undo_count(history) == 0
+      assert UndoHistory.redo_count(history) == 1
+      assert UndoHistory.last_redo_source(history) == :lsp
+    end
+
+    test "redo returns the next snapshot and restores undo history" do
+      history = UndoHistory.record_edit_force(UndoHistory.new(), 0, doc("before"), :recovery)
+
+      assert {:ok, restore, history} = UndoHistory.undo(history, 1, doc("after"))
+      assert restore.source == :recovery
+
+      assert {:ok, restore, history} = UndoHistory.redo(history, 0, doc("before"))
+      assert restore.version == 1
+      assert restore.source == :recovery
+      assert Document.content(restore.document) == "after"
+      assert UndoHistory.undo_count(history) == 1
+      assert UndoHistory.redo_count(history) == 0
+      assert UndoHistory.last_undo_source(history) == :recovery
+    end
+
+    test "empty history cannot undo or redo" do
+      history = UndoHistory.new()
+
+      assert :empty = UndoHistory.undo(history, 0, doc("current"))
+      assert :empty = UndoHistory.redo(history, 0, doc("current"))
+    end
+  end
+
+  describe "clear/1" do
+    test "removes undo and redo entries" do
+      history = UndoHistory.record_edit_force(UndoHistory.new(), 0, doc("before"), :user)
+
+      assert {:ok, restore, history} = UndoHistory.undo(history, 1, doc("after"))
+      assert restore.source == :user
+
+      history = UndoHistory.clear(history)
+
+      assert UndoHistory.undo_count(history) == 0
+      assert UndoHistory.redo_count(history) == 0
+      assert UndoHistory.last_undo_source(history) == nil
+      assert UndoHistory.last_redo_source(history) == nil
+    end
+  end
+end

--- a/test/minga/git/tracker_registry_test.exs
+++ b/test/minga/git/tracker_registry_test.exs
@@ -20,6 +20,21 @@ defmodule Minga.Git.TrackerRegistryTest do
     name
   end
 
+  defp assert_eventually(fun, attempts \\ 200)
+
+  defp assert_eventually(fun, attempts) when attempts > 0 do
+    if fun.() do
+      :ok
+    else
+      receive do
+      after
+        50 -> assert_eventually(fun, attempts - 1)
+      end
+    end
+  end
+
+  defp assert_eventually(_fun, 0), do: flunk("condition did not become true")
+
   test "tracker starts tracking only for events from its configured registry", %{root: dir} do
     registry_a = start_registry(:tracker_events_a)
     registry_b = start_registry(:tracker_events_b)
@@ -42,7 +57,6 @@ defmodule Minga.Git.TrackerRegistryTest do
     refute Tracker.tracked?(buf, table)
 
     Events.broadcast(:buffer_opened, %Events.BufferEvent{buffer: buf, path: path}, registry_a)
-    _ = :sys.get_state(tracker)
-    assert Tracker.tracked?(buf, table)
+    assert_eventually(fn -> Tracker.tracked?(buf, table) end)
   end
 end


### PR DESCRIPTION
# TL;DR
Extracts buffer undo/redo bookkeeping into `Minga.Buffer.UndoHistory`, so `Minga.Buffer.State` no longer exposes raw undo stack, redo stack, or coalescing timer fields. The buffer process now applies named undo/redo restore snapshots while the history module owns stack capacity, coalescing, redo clearing, and source attribution.

## Context
This continues the buffer architecture simplification sequence after `ChangeLog`. The goal is to keep `Minga.Buffer.Process` focused on process orchestration and live document state, while pure buffer-domain modules own the rules for specific submodels.

## Changes
- Added `Minga.Buffer.UndoHistory` as an opaque pure state module for undo entries, redo entries, coalescing, stack caps, source lookup, undo, redo, clear, and coalescing boundaries.
- Added `Minga.Buffer.UndoHistory.Restore` so undo/redo transitions return a named restore snapshot instead of a positional tuple.
- Replaced `undo_stack`, `redo_stack`, and `last_undo_at` in `Minga.Buffer.State` with `undo_history: UndoHistory.t()`.
- Updated `Minga.Buffer.Process` to delegate history recording, forced recording, undo, redo, last-source lookup, history clearing, and coalescing resets to `UndoHistory`.
- Added `Minga.Buffer.EditSource.undo_source/0` as the shared simple source type used by undo history.
- Stabilized `test/minga/git/tracker_registry_test.exs` by replacing a fragile `:sys.get_state` barrier after async event delivery with an eventual assertion against the ETS-backed tracker registry.

## Verification
- `mix compile --warnings-as-errors`
- `mix test.llm test/minga/buffer/undo_history_test.exs test/minga/buffer/process_test.exs test/minga/buffer/undo_test.exs test/minga/buffer/dirty_flag_verification_test.exs test/minga/buffer/mtime_test.exs`
- `mix test.llm test/minga/buffer`
- `make lint`
- `mix test.llm` (8636 tests, 97 properties, 52 doctests, 0 failures)

## Review Notes
- `prtk-code-reviewer`: no high-confidence issues after adding `UndoHistory.Restore`.
- `prtk-type-design-analyzer`: approved after replacing restore tuples with `UndoHistory.Restore` and centralizing the simple undo source type.
- Final reviewer gate: PASS.
