### PR TITLE
Keep file tree rendering bounded in large projects

### DIFF
--- a/docs/FILE_TREE_VISUAL_SPEC.md
+++ b/docs/FILE_TREE_VISUAL_SPEC.md
@@ -187,6 +187,28 @@ blue row = selected, active, dirty, git modified, focused
 
 Review prompt: which part of the row tells me the buffer is dirty after focus moves away? If the answer is only color, split the layers.
 
+## Large-tree validation recipe
+
+Use a generated fixture when reviewing responsiveness, accessibility semantics, or row-level invalidation changes. This keeps the validation repeatable without checking thousands of files into the repo.
+
+```bash
+fixture="$(mktemp -d)/minga-large-tree"
+mkdir -p "$fixture"
+for d in $(seq -w 1 80); do
+  mkdir -p "$fixture/pkg_$d/src/deep/module_$d" "$fixture/pkg_$d/test"
+  for f in $(seq -w 1 40); do
+    printf 'defmodule LargeTree.Pkg%s.File%s do\nend\n' "$d" "$f" > "$fixture/pkg_$d/src/deep/module_$d/file_$f.ex"
+    printf 'defmodule LargeTree.Pkg%s.File%sTest do\nend\n' "$d" "$f" > "$fixture/pkg_$d/test/file_${f}_test.exs"
+  done
+  printf '# package %s\n' "$d" > "$fixture/pkg_$d/README.md"
+done
+printf 'Open this directory in Minga: %s\n' "$fixture"
+```
+
+Validate the same interactions on macOS and TUI: open the file tree, hold cursor movement through several screens, scroll with the mouse or trackpad, hover rows on macOS, expand and collapse mid-depth directories, reveal an active file, and refresh git/status data if the fixture is inside a git worktree. The tree should not visibly stall, TUI rows should keep text markers such as `●`, `✖`, `⚠`, and `+` readable without relying only on color, and macOS VoiceOver should announce file versus folder, selected/current state, expanded/collapsed state, diagnostics, dirty/git status, and the practical row actions.
+
+Record the fixture size, machine, frontend, interactions tested, and any VoiceOver spot-checks in the PR description. Do not add FPS assertions to CI; use deterministic row/protocol/view tests plus this manual smoke test.
+
 ## Regression coverage guidance
 
 Prefer the lightest test layer that proves the state mapping.

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -57,6 +57,7 @@ The BEAM-side encoder must use a documented length-prefixed envelope for all new
 | 0x91 | gui_indent_guides | Indent guide positions per window |
 | 0x92 | gui_line_spacing | Line spacing multiplier for the renderer |
 | 0x93 | gui_file_tree | Semantic file tree rows for the native sidebar view. Uses a 32-bit payload length because expanded project trees can exceed 64KB. |
+| 0x94 | gui_file_tree_selection | Lightweight file tree selection and focus update. |
 | 0x96 | gui_hover_action | Optional action metadata for the hover popup |
 
 ### 0x93 — gui_file_tree
@@ -110,6 +111,22 @@ When `tree_state == 0`, the frontend should hide the file tree. Hidden payloads 
 `row_count == 0` only means the payload contains no entry rows. It does not imply hidden. Use `tree_state` to distinguish hidden (`0`), loading (`1`), visible-empty (`2`), and error (`4`) states. The `empty` flag bit is retained for compatibility and is set only for `tree_state == 2`.
 
 When `tree_state == 4`, `error_reason` contains a short user-displayable reason. For all other states, `error_reason` is an empty string.
+
+### 0x94 — gui_file_tree_selection
+
+Selection and focus changes are common while navigating large trees. The BEAM sends this small update when the row model itself has not changed, so the native sidebar can update selection without receiving or decoding the full tree payload again.
+
+```
+opcode(1) + payload_len(2) + payload(payload_len)
+
+Payload:
+  flags(1) + selected_id_len(2) + selected_id(selected_id_len)
+```
+
+Flag bits:
+  bit 0: focused
+
+Frontends should apply this only to the current file-tree model. If no full `gui_file_tree` payload has been received yet, the update is safe to ignore.
 
 ### 0x71 — gui_tab_bar
 

--- a/docs/protocol_schema.json
+++ b/docs/protocol_schema.json
@@ -48,6 +48,7 @@
     "gui_chrome": {
       "description": "BEAM → GUI-only chrome commands (0x70+ range)",
       "gui_file_tree":      { "hex": "0x93" },
+      "gui_file_tree_selection": { "hex": "0x94" },
       "gui_tab_bar":        { "hex": "0x71" },
       "gui_which_key":      { "hex": "0x72" },
       "gui_completion":     { "hex": "0x73" },

--- a/lib/minga_editor/file_tree/rows.ex
+++ b/lib/minga_editor/file_tree/rows.ex
@@ -15,6 +15,8 @@ defmodule MingaEditor.FileTree.Rows do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
 
+  @type indexed_entry :: {FileTree.entry(), non_neg_integer()}
+
   @type options :: [
           selected_index: non_neg_integer(),
           focused: boolean(),
@@ -29,36 +31,20 @@ defmodule MingaEditor.FileTree.Rows do
   @doc "Builds semantic rows from a pure file tree and explicit presentation inputs."
   @spec from_tree(FileTree.t(), options()) :: [Row.t()]
   def from_tree(%FileTree{} = tree, opts \\ []) do
-    git_status = Keyword.get(opts, :git_status, tree.git_status)
-
-    diagnostics_server = Keyword.get(opts, :diagnostics_server, DiagnosticStore)
-
-    diagnostics =
-      opts
-      |> Keyword.get_lazy(:diagnostics, fn ->
-        diagnostic_map_for_root(tree.root, diagnostics_server)
-      end)
-      |> propagated_diagnostics(tree.root)
-
-    dirty_paths = Keyword.get(opts, :dirty_paths, MapSet.new())
-    active_path = opts |> Keyword.get(:active_path) |> expand_optional_path()
-    selected_index = Keyword.get(opts, :selected_index, tree.cursor)
-    focused = Keyword.get(opts, :focused, false)
-    editing = Keyword.get(opts, :editing)
-
     tree
     |> FileTree.visible_entries()
     |> Enum.with_index()
-    |> Enum.map(fn {entry, index} ->
-      row_from_entry(entry, index, tree, %{
-        active_path: active_path,
-        dirty_paths: dirty_paths,
-        editing: editing,
-        diagnostics: diagnostics,
-        focused: focused,
-        git_status: git_status,
-        selected_index: selected_index
-      })
+    |> from_entries(tree, opts)
+  end
+
+  @doc "Builds semantic rows from already-selected visible entries."
+  @spec from_entries([indexed_entry()], FileTree.t(), options()) :: [Row.t()]
+  def from_entries(indexed_entries, %FileTree{} = tree, opts \\ [])
+      when is_list(indexed_entries) do
+    context = row_context(tree, opts)
+
+    Enum.map(indexed_entries, fn {entry, index} ->
+      row_from_entry(entry, index, tree, context)
     end)
   end
 
@@ -78,6 +64,29 @@ defmodule MingaEditor.FileTree.Rows do
   end
 
   def from_state(_state), do: []
+
+  @spec row_context(FileTree.t(), options()) :: map()
+  defp row_context(%FileTree{} = tree, opts) do
+    git_status = Keyword.get(opts, :git_status, tree.git_status)
+    diagnostics_server = Keyword.get(opts, :diagnostics_server, DiagnosticStore)
+
+    diagnostics =
+      opts
+      |> Keyword.get_lazy(:diagnostics, fn ->
+        diagnostic_map_for_root(tree.root, diagnostics_server)
+      end)
+      |> propagated_diagnostics(tree.root)
+
+    %{
+      active_path: opts |> Keyword.get(:active_path) |> expand_optional_path(),
+      dirty_paths: Keyword.get(opts, :dirty_paths, MapSet.new()),
+      editing: Keyword.get(opts, :editing),
+      diagnostics: diagnostics,
+      focused: Keyword.get(opts, :focused, false),
+      git_status: git_status,
+      selected_index: Keyword.get(opts, :selected_index, tree.cursor)
+    }
+  end
 
   @spec row_from_entry(FileTree.entry(), non_neg_integer(), FileTree.t(), map()) :: Row.t()
   defp row_from_entry(entry, index, tree, opts) do

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -24,13 +24,17 @@ defmodule MingaEditor.Frontend.Emit.GUI do
   alias MingaEditor.Agent.View.PromptSemanticWindow
   alias Minga.Buffer
   alias Minga.Config
+  alias Minga.Diagnostics, as: DiagnosticStore
+  alias Minga.LSP.SyncServer
 
   alias MingaEditor.DisplayList.Frame
   alias MingaEditor.DisplayMap
+  alias MingaEditor.FileTree.Diagnostics, as: FileTreeDiagnostics
   alias MingaEditor.FileTree.Rows
   alias MingaEditor.FoldMap
   alias MingaEditor.Layout
   alias MingaEditor.MinibufferData
+  alias Minga.Project.FileTree
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.Renderer.Gutter
   alias MingaEditor.Shell.Traditional.Chrome.Helpers, as: ChromeHelpers
@@ -259,33 +263,62 @@ defmodule MingaEditor.Frontend.Emit.GUI do
 
   @spec build_gui_file_tree_cmd(ctx(), Caches.t()) :: {binary() | nil, Caches.t()}
   defp build_gui_file_tree_cmd(
-         %{file_tree: %{tree: %Minga.Project.FileTree{} = tree} = file_tree} = ctx,
+         %{file_tree: %{tree: %FileTree{} = tree} = file_tree} = ctx,
          caches
        ) do
-    rows =
-      Rows.from_tree(tree,
-        active_path: active_buffer_path(ctx),
-        dirty_paths: dirty_paths(ctx.buffers),
-        editing: Map.get(file_tree, :editing),
-        focused: file_tree_focused?(file_tree),
-        git_status: tree.git_status,
-        selected_index: tree.cursor
-      )
-
+    tree = FileTree.ensure_entries(tree)
     tree_status = FileTreeState.status(file_tree)
-    rows = if tree_status == :ready, do: rows, else: []
-    fp = :erlang.phash2({tree.root, tree.width, file_tree_focused?(file_tree), tree_status, rows})
 
-    if fp != caches.last_gui_file_tree_fp do
-      {ProtocolGUI.encode_gui_file_tree(
-         tree.root,
-         tree.width,
-         tree_status,
-         file_tree_focused?(file_tree),
-         rows
-       ), %{caches | last_gui_file_tree_fp: fp}}
-    else
-      {nil, caches}
+    case tree_status do
+      :ready ->
+        active_path = active_buffer_path(ctx)
+        dirty_paths = dirty_paths(ctx.buffers)
+        diagnostics = file_tree_diagnostics(tree.root)
+
+        structural_fp =
+          file_tree_ready_structural_fingerprint(
+            tree,
+            file_tree,
+            active_path,
+            dirty_paths,
+            diagnostics
+          )
+
+        selection_fp = file_tree_selection_fingerprint(tree, file_tree)
+
+        case caches.last_gui_file_tree_fp do
+          {:ready, ^structural_fp, ^selection_fp} ->
+            {nil, caches}
+
+          {:ready, ^structural_fp, _previous_selection_fp} ->
+            {ProtocolGUI.encode_gui_file_tree_selection(
+               selected_row_id(tree),
+               file_tree_focused?(file_tree)
+             ), %{caches | last_gui_file_tree_fp: {:ready, structural_fp, selection_fp}}}
+
+          _previous_fp ->
+            rows =
+              Rows.from_tree(tree,
+                active_path: active_path,
+                dirty_paths: dirty_paths,
+                editing: Map.get(file_tree, :editing),
+                focused: file_tree_focused?(file_tree),
+                git_status: tree.git_status,
+                diagnostics: diagnostics,
+                selected_index: tree.cursor
+              )
+
+            {ProtocolGUI.encode_gui_file_tree(
+               tree.root,
+               tree.width,
+               tree_status,
+               file_tree_focused?(file_tree),
+               rows
+             ), %{caches | last_gui_file_tree_fp: {:ready, structural_fp, selection_fp}}}
+        end
+
+      status ->
+        build_gui_file_tree_state_cmd(file_tree, status, caches)
     end
   end
 
@@ -327,6 +360,61 @@ defmodule MingaEditor.Frontend.Emit.GUI do
       {ProtocolGUI.encode_hidden_gui_file_tree(root_path), %{caches | last_gui_file_tree_fp: fp}}
     else
       {nil, caches}
+    end
+  end
+
+  @spec file_tree_ready_structural_fingerprint(
+          FileTree.t(),
+          FileTreeState.t(),
+          String.t() | nil,
+          MapSet.t(String.t()),
+          %{String.t() => FileTreeDiagnostics.t()}
+        ) :: non_neg_integer()
+  defp file_tree_ready_structural_fingerprint(
+         tree,
+         file_tree,
+         active_path,
+         dirty_paths,
+         diagnostics
+       ) do
+    :erlang.phash2({
+      tree.root,
+      tree.width,
+      tree.show_hidden,
+      tree.expanded,
+      tree.entries,
+      tree.git_status,
+      Map.get(file_tree, :editing),
+      active_path,
+      dirty_paths,
+      diagnostics
+    })
+  end
+
+  @spec file_tree_diagnostics(String.t()) :: %{String.t() => FileTreeDiagnostics.t()}
+  defp file_tree_diagnostics(root) when is_binary(root) do
+    root
+    |> SyncServer.path_to_uri()
+    |> DiagnosticStore.count_tuples_by_uri_prefix()
+    |> Map.new(fn {uri, counts} ->
+      {SyncServer.uri_to_path(uri), FileTreeDiagnostics.new(counts)}
+    end)
+  rescue
+    ArgumentError -> %{}
+  catch
+    :exit, _ -> %{}
+  end
+
+  @spec file_tree_selection_fingerprint(FileTree.t(), map()) :: non_neg_integer()
+  defp file_tree_selection_fingerprint(tree, file_tree) do
+    :erlang.phash2({selected_row_id(tree), file_tree_focused?(file_tree)})
+  end
+
+  @spec selected_row_id(FileTree.t()) :: String.t()
+  defp selected_row_id(%FileTree{entries: entries, cursor: cursor}) when is_list(entries) do
+    case Enum.at(entries, cursor) do
+      nil -> ""
+      entry -> MingaEditor.FileTree.Row.id_for(entry)
     end
   end
 

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -14,6 +14,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   | Opcode | Name            | Description                    |
   |--------|-----------------|--------------------------------|
   | 0x93   | gui_file_tree   | Semantic file tree state       |
+  | 0x94   | gui_file_tree_selection | File tree selection-only update |
   | 0x71   | gui_tab_bar     | Tab bar with tab entries       |
   | 0x72   | gui_which_key   | Which-key popup bindings       |
   | 0x73   | gui_completion  | Completion popup items         |
@@ -107,6 +108,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   # GUI chrome opcodes start at 0x70. Opcodes >= 0x90 include a 2-byte length prefix.
 
   @op_gui_file_tree 0x93
+  @op_gui_file_tree_selection 0x94
   @op_gui_tab_bar 0x71
   @op_gui_which_key 0x72
   @op_gui_completion 0x73
@@ -1058,6 +1060,21 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   @spec encode_hidden_gui_file_tree(String.t() | nil) :: binary()
   def encode_hidden_gui_file_tree(root_path),
     do: encode_gui_file_tree(root_path, 0, :hidden, false, [])
+
+  @doc "Encodes a lightweight file-tree selection update."
+  @spec encode_gui_file_tree_selection(String.t(), boolean()) :: binary()
+  def encode_gui_file_tree_selection(selected_id, focused?) when is_binary(selected_id) do
+    payload =
+      IO.iodata_to_binary([
+        <<file_tree_selection_flags(focused?)::8>>,
+        encode_string16(selected_id)
+      ])
+
+    <<@op_gui_file_tree_selection, byte_size(payload)::16, payload::binary>>
+  end
+
+  @spec file_tree_selection_flags(boolean()) :: non_neg_integer()
+  defp file_tree_selection_flags(focused?), do: maybe_flag(0, focused?, 0)
 
   @spec encode_file_tree_row(Row.t(), String.t()) :: iodata()
   defp encode_file_tree_row(%Row{} = row, root) do

--- a/lib/minga_editor/renderer/caches.ex
+++ b/lib/minga_editor/renderer/caches.ex
@@ -75,7 +75,12 @@ defmodule MingaEditor.Renderer.Caches do
           last_gui_theme: integer() | nil,
           last_gui_tab_bar_fp: integer() | nil,
           last_gui_agent_groups_fp: integer() | nil,
-          last_gui_file_tree_fp: integer() | {:no_tree, String.t()} | nil,
+          last_gui_file_tree_fp:
+            integer()
+            | {:ready, non_neg_integer(), non_neg_integer()}
+            | {:file_tree_state, String.t(), non_neg_integer(), term()}
+            | {:no_tree, String.t()}
+            | nil,
           last_gui_git_status_fp: integer() | {:no_git, boolean()} | nil,
           last_gui_which_key_fp: integer() | nil,
           last_gui_completion_fp: integer() | nil,

--- a/lib/minga_editor/shell/traditional/tree_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tree_renderer.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   stays scannable without connector-heavy branch art.
   """
 
+  alias Minga.Buffer
   alias Minga.Core.Face
   alias Minga.Core.Unicode
   alias Minga.Language
@@ -81,17 +82,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   """
   @spec render(RenderInput.t()) :: [DisplayList.draw()]
   def render(%RenderInput{} = input) do
-    rows =
-      input.rows ||
-        Rows.from_tree(input.tree,
-          active_path: input.active_path,
-          dirty_paths: input.dirty_paths,
-          editing: input.editing,
-          focused: input.focused,
-          git_status: input.git_status
-        )
-
-    do_render(input.tree, input.rect, input.theme, effective_status(input.status, rows), rows)
+    do_render(input)
   end
 
   @spec render(EditorState.t() | map()) :: [DisplayList.draw()]
@@ -121,22 +112,24 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
       rect: rect,
       focused: focused,
       theme: state.theme,
-      active_path: nil,
-      rows: Rows.from_state(state),
+      active_path: active_buffer_path(state),
+      dirty_paths: dirty_paths(state),
+      editing: Map.get(file_tree, :editing),
+      git_status: tree.git_status,
       status: status_from_file_tree(file_tree)
     }
 
     render(input)
   end
 
-  @spec do_render(FileTree.t(), WindowTree.rect(), Theme.t(), FileTreeState.tree_status(), [
-          Row.t()
-        ]) :: [DisplayList.draw()]
-  defp do_render(_tree, {_row_off, _col_off, width, height}, _theme, _status, _rows)
+  @spec do_render(RenderInput.t()) :: [DisplayList.draw()]
+  defp do_render(%RenderInput{rect: {_row_off, _col_off, width, height}})
        when width <= 0 or height <= 0,
        do: []
 
-  defp do_render(tree, {row_off, col_off, width, height}, theme, status, rows) do
+  defp do_render(
+         %RenderInput{tree: tree, rect: {row_off, col_off, width, height}, theme: theme} = input
+       ) do
     # Header: project directory name with folder icon
     project_name = Path.basename(tree.root)
     header_text = " #{@folder_open} #{project_name}/"
@@ -153,7 +146,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
 
     # Entry rows (starting from row 1, leaving row 0 for header)
     content_rows = max(height - 1, 0)
-    scroll_offset = scroll_offset(selected_index(rows), content_rows)
+    {status, rows, visible_count} = visible_rows_for_input(input, content_rows)
 
     render_opts = %{
       col_off: col_off,
@@ -162,11 +155,9 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     }
 
     entry_commands =
-      render_content_rows(status, rows, scroll_offset, content_rows, row_off + 1, render_opts)
+      render_content_rows(status, rows, content_rows, row_off + 1, render_opts)
 
     # Fill remaining rows with blanks
-    visible_count = visible_content_count(status, rows, scroll_offset, content_rows)
-
     blank_commands =
       render_blanks(visible_count, content_rows, row_off + 1, col_off, width, theme)
 
@@ -181,22 +172,142 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
   defp status_from_file_tree(%FileTreeState{} = file_tree), do: FileTreeState.status(file_tree)
   defp status_from_file_tree(_file_tree), do: :ready
 
-  @spec effective_status(FileTreeState.tree_status(), [Row.t()]) :: FileTreeState.tree_status()
+  @spec active_buffer_path(EditorState.t() | map()) :: String.t() | nil
+  defp active_buffer_path(%{workspace: %{buffers: %{active: nil}}}), do: nil
+
+  defp active_buffer_path(%{workspace: %{buffers: %{active: buf}}}) do
+    case Buffer.file_path(buf) do
+      nil -> nil
+      path -> Path.expand(path)
+    end
+  catch
+    :exit, _ -> nil
+  end
+
+  defp active_buffer_path(_state), do: nil
+
+  defp dirty_paths(%{workspace: %{buffers: %{list: buffer_list}}}) do
+    buffer_list
+    |> Enum.flat_map(&dirty_buffer_path/1)
+    |> Enum.map(&Path.expand/1)
+    |> MapSet.new()
+  end
+
+  defp dirty_paths(_state), do: MapSet.new()
+
+  @spec dirty_buffer_path(pid()) :: [String.t()]
+  defp dirty_buffer_path(pid) when is_pid(pid) do
+    if Buffer.dirty?(pid), do: present_path(Buffer.file_path(pid)), else: []
+  catch
+    :exit, _ -> []
+  end
+
+  @spec present_path(String.t() | nil) :: [String.t()]
+  defp present_path(nil), do: []
+  defp present_path(path), do: [path]
+
+  @spec effective_status(FileTreeState.tree_status(), list()) :: FileTreeState.tree_status()
   defp effective_status(:ready, []), do: :empty
   defp effective_status(status, _rows), do: status
+
+  @spec visible_rows_for_input(RenderInput.t(), non_neg_integer()) ::
+          {FileTreeState.tree_status(), [Row.t()], non_neg_integer()}
+  defp visible_rows_for_input(%RenderInput{rows: rows, status: status}, content_rows)
+       when is_list(rows) do
+    status = effective_status(status, rows)
+    visible_rows = visible_rows(status, rows, content_rows)
+    {status, visible_rows, length(visible_rows)}
+  end
+
+  defp visible_rows_for_input(%RenderInput{} = input, content_rows) do
+    entries = FileTree.visible_entries(input.tree)
+    status = effective_status(input.status, entries)
+    visible_entries = visible_entries(status, entries, input.tree.cursor, content_rows)
+
+    rows =
+      Rows.from_entries(visible_entries, input.tree,
+        active_path: input.active_path,
+        dirty_paths: input.dirty_paths,
+        editing: input.editing,
+        focused: input.focused,
+        git_status: input.git_status,
+        selected_index: input.tree.cursor
+      )
+
+    {status, rows, visible_count(status, rows, content_rows)}
+  end
+
+  @spec visible_count(FileTreeState.tree_status(), [Row.t()], non_neg_integer()) ::
+          non_neg_integer()
+  defp visible_count(:ready, rows, _content_rows), do: length(rows)
+
+  defp visible_count(status, _rows, content_rows) do
+    status |> state_lines() |> Enum.take(content_rows) |> length()
+  end
+
+  @spec visible_rows(FileTreeState.tree_status(), [Row.t()], non_neg_integer()) :: [Row.t()]
+  defp visible_rows(:ready, _rows, 0), do: []
+
+  defp visible_rows(:ready, rows, content_rows) do
+    rows
+    |> selected_index()
+    |> visible_range(content_rows)
+    |> then(&Enum.slice(rows, &1))
+  end
+
+  defp visible_rows(status, _rows, content_rows) do
+    status
+    |> state_lines()
+    |> Enum.take(content_rows)
+    |> Enum.with_index()
+    |> Enum.map(fn {line, index} ->
+      Row.new(
+        id: "state:#{index}",
+        path: "",
+        name: line,
+        directory?: false,
+        expanded?: false,
+        depth: 0,
+        guides: [],
+        last_child?: true
+      )
+    end)
+  end
+
+  @spec visible_entries(
+          FileTreeState.tree_status(),
+          [FileTree.entry()],
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          [Rows.indexed_entry()]
+  defp visible_entries(:ready, _entries, _cursor, 0), do: []
+
+  defp visible_entries(:ready, entries, cursor, content_rows) do
+    range = visible_range(cursor, content_rows)
+
+    entries
+    |> Enum.slice(range)
+    |> Enum.with_index(range.first)
+  end
+
+  defp visible_entries(_status, _entries, _cursor, _content_rows), do: []
+
+  @spec visible_range(non_neg_integer(), non_neg_integer()) :: Range.t()
+  defp visible_range(cursor, content_rows) do
+    offset = scroll_offset(cursor, content_rows)
+    offset..(offset + content_rows - 1)//1
+  end
 
   @spec render_content_rows(
           FileTreeState.tree_status(),
           [Row.t()],
           non_neg_integer(),
           non_neg_integer(),
-          non_neg_integer(),
           map()
         ) :: [DisplayList.draw()]
-  defp render_content_rows(:ready, rows, scroll_offset, content_rows, first_row, opts) do
+  defp render_content_rows(:ready, rows, _content_rows, first_row, opts) do
     rows
-    |> Enum.drop(scroll_offset)
-    |> Enum.take(content_rows)
     |> Enum.with_index()
     |> Enum.flat_map(fn {tree_row, screen_row} ->
       row = first_row + screen_row
@@ -209,7 +320,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     end)
   end
 
-  defp render_content_rows(status, _rows, _scroll_offset, content_rows, first_row, opts) do
+  defp render_content_rows(status, _rows, content_rows, first_row, opts) do
     status
     |> state_lines()
     |> Enum.take(content_rows)
@@ -217,20 +328,6 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     |> Enum.map(fn {line, screen_row} ->
       render_state_line(line, first_row + screen_row, opts)
     end)
-  end
-
-  @spec visible_content_count(
-          FileTreeState.tree_status(),
-          [Row.t()],
-          non_neg_integer(),
-          non_neg_integer()
-        ) :: non_neg_integer()
-  defp visible_content_count(:ready, rows, scroll_offset, content_rows) do
-    rows |> Enum.drop(scroll_offset) |> Enum.take(content_rows) |> length()
-  end
-
-  defp visible_content_count(status, _rows, _scroll_offset, content_rows) do
-    status |> state_lines() |> Enum.take(content_rows) |> length()
   end
 
   @spec state_lines(FileTreeState.tree_status()) :: [String.t()]

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -70,9 +70,14 @@ defmodule MingaEditor.State.FileTree do
   def status(%__MODULE__{tree: nil, tree_status: status}) when status in [:loading], do: status
   def status(%__MODULE__{tree: nil, tree_status: {:error, _reason} = status}), do: status
   def status(%__MODULE__{tree: nil}), do: :hidden
-  def status(%__MODULE__{tree_status: :loading}), do: :loading
-  def status(%__MODULE__{tree_status: {:error, _reason} = status}), do: status
-  def status(%__MODULE__{tree: %FileTree{} = tree}), do: classify_tree(tree)
+
+  def status(%__MODULE__{tree: %FileTree{}, tree_status: :hidden} = ft),
+    do: classify_tree(ft.tree)
+
+  def status(%__MODULE__{tree: %FileTree{}, tree_status: status})
+      when status in [:loading, :empty, :ready], do: status
+
+  def status(%__MODULE__{tree: %FileTree{}, tree_status: {:error, _reason} = status}), do: status
 
   @doc "Returns true when the explicit tree status should occupy the sidebar."
   @spec visible_status?(tree_status()) :: boolean()
@@ -95,6 +100,8 @@ defmodule MingaEditor.State.FileTree do
   @doc "Opens the tree with the given data, buffer, and focused state."
   @spec open(t(), FileTree.t(), pid() | nil) :: t()
   def open(%__MODULE__{} = ft, tree, buffer) do
+    tree = ensure_tree_entries(tree)
+
     %{
       ft
       | tree: tree,
@@ -109,6 +116,7 @@ defmodule MingaEditor.State.FileTree do
   @doc "Replaces the backing tree and refreshes the presentation status."
   @spec replace_tree(t(), FileTree.t()) :: t()
   def replace_tree(%__MODULE__{} = ft, %FileTree{} = tree) do
+    tree = ensure_tree_entries(tree)
     %{ft | tree: tree, tree_status: classify_tree(tree), tree_width: tree.width}
   end
 
@@ -181,6 +189,9 @@ defmodule MingaEditor.State.FileTree do
   def cancel_editing(%__MODULE__{} = ft) do
     %{ft | editing: nil}
   end
+
+  @spec ensure_tree_entries(FileTree.t()) :: FileTree.t()
+  defp ensure_tree_entries(%FileTree{} = tree), do: FileTree.ensure_entries(tree)
 
   @spec classify_tree(FileTree.t()) :: tree_status()
   defp classify_tree(%FileTree{} = tree) do

--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -29,6 +29,7 @@ let OP_DRAW_STYLED_TEXT: UInt8 = 0x1C
 // MARK: - GUI chrome opcodes (BEAM → frontend)
 
 let OP_GUI_FILE_TREE: UInt8 = 0x93
+let OP_GUI_FILE_TREE_SELECTION: UInt8 = 0x94
 let OP_GUI_TAB_BAR: UInt8 = 0x71
 let OP_GUI_WHICH_KEY: UInt8 = 0x72
 let OP_GUI_COMPLETION: UInt8 = 0x73

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -33,6 +33,7 @@ enum RenderCommand: Sendable {
     case guiTheme(slots: [(slotId: UInt8, r: UInt8, g: UInt8, b: UInt8)])
     case guiTabBar(activeIndex: UInt8, tabs: [Wire.TabEntry])
     case guiFileTree(version: UInt8, treeFlags: UInt8, treeState: UInt8, selectedId: String, treeWidth: UInt16, rootPath: String, errorReason: String, entries: [Wire.FileTreeEntry])
+    case guiFileTreeSelection(selectedId: String, focused: Bool)
     case guiCompletion(visible: Bool, anchorRow: UInt16, anchorCol: UInt16, selectedIndex: UInt16, items: [Wire.CompletionItem])
     case guiWhichKey(visible: Bool, prefix: String, page: UInt8, pageCount: UInt8, bindings: [Wire.WhichKeyBinding])
     case guiBreadcrumb(segments: [String])
@@ -405,6 +406,19 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
 
         guard pos == payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
         return (.guiFileTree(version: version, treeFlags: treeFlags, treeState: treeState, selectedId: selectedId, treeWidth: treeWidth, rootPath: rootPath, errorReason: errorReason, entries: entries), 5 + payloadLen)
+
+    case OP_GUI_FILE_TREE_SELECTION:
+        guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
+        let payloadLen = Int(readU16(data, rest))
+        let payloadStart = rest + 2
+        guard data.count >= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+        guard payloadLen >= 3 else { throw ProtocolDecodeError.malformed }
+        let flags = data[payloadStart]
+        var pos = payloadStart + 1
+        let selectedIdLen = Int(readU16(data, pos)); pos += 2
+        guard pos + selectedIdLen == payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+        let selectedId = String(data: data[pos..<(pos + selectedIdLen)], encoding: .utf8) ?? ""
+        return (.guiFileTreeSelection(selectedId: selectedId, focused: flags & 0x01 != 0), 3 + payloadLen)
 
     case OP_GUI_TAB_BAR:
         // active_index:1, tab_count:1, then per tab: flags:1, id:4, group_id:2, icon_len:1, icon, label_len:2, label

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -212,6 +212,9 @@ final class CommandDispatcher {
                 guiState.fileTreeState.hide(rootPath: rootPath)
             }
 
+        case .guiFileTreeSelection(let selectedId, let focused):
+            guiState.fileTreeState.updateSelection(selectedId: selectedId, focused: focused)
+
         case .guiCompletion(let visible, let anchorRow, let anchorCol, let selectedIndex, let items):
             if visible {
                 guiState.completionState.update(visible: true, anchorRow: anchorRow, anchorCol: anchorCol, selectedIndex: selectedIndex, rawItems: items)

--- a/macos/Sources/Views/FileTreeRowView.swift
+++ b/macos/Sources/Views/FileTreeRowView.swift
@@ -18,6 +18,11 @@ struct FileTreeRowView: View {
     let onEditCancel: () -> Void
 
     @Environment(\.displayScale) private var displayScale
+    @State private var isLocallyHovered = false
+
+    private var effectiveHovered: Bool {
+        isHovered || isLocallyHovered
+    }
 
     var body: some View {
         rowContent
@@ -32,8 +37,13 @@ struct FileTreeRowView: View {
             .overlay(alignment: .leading) {
                 indentGuides
             }
+            .onHover { isHovered in
+                isLocallyHovered = isHovered
+            }
             .accessibilityLabel(accessibilityLabelText)
+            .accessibilityValue(accessibilityValueText)
             .accessibilityHint(accessibilityHintText)
+            .accessibilityAddTraits(accessibilityTraits)
     }
 
     @ViewBuilder
@@ -194,9 +204,9 @@ struct FileTreeRowView: View {
             rowFill(theme.treeSelectionBg.opacity(0.55))
         } else if entry.isSelected {
             rowFill(theme.treeSelectionBg.opacity(entry.isFocused ? 1.0 : 0.42))
-        } else if isHovered {
+        } else if effectiveHovered {
             rowFill(theme.treeFg.opacity(0.06))
-                .animation(.easeInOut(duration: animDuration), value: isHovered)
+                .animation(.easeInOut(duration: animDuration), value: effectiveHovered)
         }
     }
 
@@ -319,6 +329,28 @@ struct FileTreeRowView: View {
         case .info: return "info diagnostics"
         case .hint: return "hints"
         }
+    }
+
+    var accessibilityValueText: String {
+        accessibilityValueParts.joined(separator: ", ")
+    }
+
+    private var accessibilityValueParts: [String] {
+        var parts: [String] = []
+
+        if entry.isSelected { parts.append("selected") }
+        if entry.isActive { parts.append("current file") }
+        if entry.isFocused { parts.append("keyboard focus") }
+        if entry.isDir { parts.append(entry.isExpanded ? "expanded" : "collapsed") }
+        if entry.isEditing { parts.append("editing name") }
+
+        return parts
+    }
+
+    var accessibilityTraits: AccessibilityTraits {
+        var traits: AccessibilityTraits = .isButton
+        if entry.isSelected { traits.insert(.isSelected) }
+        return traits
     }
 
     var accessibilityHintText: String {

--- a/macos/Sources/Views/FileTreeRowView.swift
+++ b/macos/Sources/Views/FileTreeRowView.swift
@@ -14,6 +14,7 @@ struct FileTreeRowView: View {
     let isHovered: Bool
     let isDropTarget: Bool
     let animDuration: Double
+    let onActivate: () -> Void
     let onEditCommit: (String) -> Void
     let onEditCancel: () -> Void
 
@@ -25,7 +26,7 @@ struct FileTreeRowView: View {
     }
 
     var body: some View {
-        rowContent
+        let row = rowContent
             .padding(.leading, leadingPadding)
             .padding(.trailing, 8)
             .frame(height: rowHeight)
@@ -40,21 +41,32 @@ struct FileTreeRowView: View {
             .onHover { isHovered in
                 isLocallyHovered = isHovered
             }
+            .accessibilityElement(children: entry.isEditing ? .contain : .ignore)
             .accessibilityLabel(accessibilityLabelText)
             .accessibilityValue(accessibilityValueText)
             .accessibilityHint(accessibilityHintText)
             .accessibilityAddTraits(accessibilityTraits)
+
+        if entry.isEditing {
+            row
+        } else {
+            row.accessibilityAction {
+                onActivate()
+            }
+        }
     }
 
     @ViewBuilder
     private var rowContent: some View {
         HStack(spacing: 0) {
             disclosureChevron
+                .accessibilityHidden(entry.isEditing)
 
             Text(entry.icon)
                 .font(.custom("Symbols Nerd Font Mono", size: 12))
                 .foregroundStyle(iconColor)
                 .frame(width: 16, alignment: .center)
+                .accessibilityHidden(entry.isEditing)
 
             Spacer().frame(width: 4)
 
@@ -348,7 +360,8 @@ struct FileTreeRowView: View {
     }
 
     var accessibilityTraits: AccessibilityTraits {
-        var traits: AccessibilityTraits = .isButton
+        var traits: AccessibilityTraits = []
+        if !entry.isEditing { traits.insert(.isButton) }
         if entry.isSelected { traits.insert(.isSelected) }
         return traits
     }

--- a/macos/Sources/Views/FileTreeState.swift
+++ b/macos/Sources/Views/FileTreeState.swift
@@ -37,6 +37,35 @@ struct FileTreeEntry: Identifiable {
     let editingType: UInt8
     /// Pre-filled text for the editing field. Only meaningful when isEditing is true.
     let editingText: String
+
+    func withSelection(isSelected: Bool, isFocused: Bool) -> FileTreeEntry {
+        FileTreeEntry(
+            id: id,
+            pathHash: pathHash,
+            index: index,
+            isDir: isDir,
+            isExpanded: isExpanded,
+            isSelected: isSelected,
+            isFocused: isFocused,
+            isActive: isActive,
+            isDirty: isDirty,
+            isEditing: isEditing,
+            isLastChild: isLastChild,
+            depth: depth,
+            gitStatus: gitStatus,
+            diagnosticErrorCount: diagnosticErrorCount,
+            diagnosticWarningCount: diagnosticWarningCount,
+            diagnosticInfoCount: diagnosticInfoCount,
+            diagnosticHintCount: diagnosticHintCount,
+            guides: guides,
+            icon: icon,
+            name: name,
+            relPath: relPath,
+            path: path,
+            editingType: editingType,
+            editingText: editingText
+        )
+    }
 }
 
 enum FileTreeGitStatus: UInt8 {
@@ -174,11 +203,34 @@ final class FileTreeState {
         self.editingIndex = rawEntries.firstIndex(where: { $0.isEditing })
     }
 
+    /// Updates selection and focus without replacing the full tree payload.
+    func updateSelection(selectedId: String, focused: Bool) {
+        guard let selectedIndex = entries.firstIndex(where: { $0.id == selectedId }) else {
+            self.focused = focused
+            self.entries = entries.map { entry in
+                entry.withSelection(isSelected: entry.isSelected, isFocused: focused)
+            }
+            return
+        }
+
+        self.selectedId = selectedId
+        self.selectedIndex = selectedIndex
+        self.focused = focused
+        self.entries = entries.map { entry in
+            entry.withSelection(isSelected: entry.id == selectedId, isFocused: focused)
+        }
+    }
+
     /// Computes the full absolute path for an entry.
     func fullPath(for entry: FileTreeEntry) -> String {
         if !entry.path.isEmpty { return entry.path }
         guard !projectRoot.isEmpty, !entry.relPath.isEmpty else { return entry.relPath }
         return (projectRoot as NSString).appendingPathComponent(entry.relPath)
+    }
+
+    /// Resolves the current entry for a stable row identifier.
+    func entry(withID id: String) -> FileTreeEntry? {
+        entries.first { $0.id == id }
     }
 
     /// Hide the file tree (BEAM toggled it off) and keep the shared window chrome in sync with the latest project root.

--- a/macos/Sources/Views/FileTreeView.swift
+++ b/macos/Sources/Views/FileTreeView.swift
@@ -22,7 +22,6 @@ struct FileTreeView: View {
         NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : 0.15
     }
 
-    @State private var hoveredEntryId: String? = nil
     @State private var scrollOffset: CGFloat = 0
     @State private var dropTargetEntryId: String? = nil
     @State private var lastClickEntryId: String? = nil
@@ -217,12 +216,10 @@ struct FileTreeView: View {
             fileTreeRow(entry)
                 .id(entry.id)
                 .contentShape(Rectangle())
-                .onHover { isHovered in
-                    hoveredEntryId = isHovered ? entry.id : nil
-                }
                 .onTapGesture {
                     handleEntryTap(entry)
                 }
+                .modifier(FileTreeEntryAccessibilityActions(entry: entry, encoder: encoder))
                 .contextMenu { entryContextMenu(entry) }
                 .draggable(URL(fileURLWithPath: fileTreeState.fullPath(for: entry))) {
                     HStack(spacing: 4) {
@@ -250,7 +247,7 @@ struct FileTreeView: View {
             rowHeight: rowHeight,
             indentWidth: indentWidth,
             chevronWidth: chevronWidth,
-            isHovered: hoveredEntryId == entry.id,
+            isHovered: false,
             isDropTarget: dropTargetEntryId == entry.id,
             animDuration: animDuration,
             onEditCommit: { text in
@@ -419,6 +416,47 @@ struct FileTreeView: View {
         return mods
     }
 
+}
+
+private struct FileTreeEntryAccessibilityActions: ViewModifier {
+    let entry: FileTreeEntry
+    let encoder: InputEncoder?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if entry.isDir {
+            content
+                .accessibilityAction(named: Text("Toggle Folder")) {
+                    encoder?.sendFileTreeToggle(index: UInt16(entry.index))
+                }
+                .accessibilityAction(named: Text("New File…")) {
+                    encoder?.sendFileTreeNewFile(parentIndex: UInt16(entry.index))
+                }
+                .accessibilityAction(named: Text("New Folder…")) {
+                    encoder?.sendFileTreeNewFolder(parentIndex: UInt16(entry.index))
+                }
+                .accessibilityAction(named: Text("Rename")) {
+                    encoder?.sendFileTreeRename(index: UInt16(entry.index))
+                }
+                .accessibilityAction(named: Text("Move to Trash")) {
+                    encoder?.sendFileTreeDelete(index: UInt16(entry.index))
+                }
+        } else {
+            content
+                .accessibilityAction(named: Text("Open")) {
+                    encoder?.sendFileTreeClick(index: UInt16(entry.index))
+                }
+                .accessibilityAction(named: Text("Open in Split")) {
+                    encoder?.sendFileTreeOpenInSplit(index: UInt16(entry.index))
+                }
+                .accessibilityAction(named: Text("Rename")) {
+                    encoder?.sendFileTreeRename(index: UInt16(entry.index))
+                }
+                .accessibilityAction(named: Text("Move to Trash")) {
+                    encoder?.sendFileTreeDelete(index: UInt16(entry.index))
+                }
+        }
+    }
 }
 
 /// Preference key for tracking scroll offset within the file tree.

--- a/macos/Sources/Views/FileTreeView.swift
+++ b/macos/Sources/Views/FileTreeView.swift
@@ -210,16 +210,22 @@ struct FileTreeView: View {
     @ViewBuilder
     private func entryRow(_ entry: FileTreeEntry) -> some View {
         if entry.isEditing {
-            fileTreeRow(entry)
+            fileTreeRow(entry, onActivate: {})
                 .id(entry.id)
         } else {
-            fileTreeRow(entry)
+            fileTreeRow(entry, onActivate: { activateEntry(id: entry.id) })
                 .id(entry.id)
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    handleEntryTap(entry)
+                    activateEntry(id: entry.id)
                 }
-                .modifier(FileTreeEntryAccessibilityActions(entry: entry, encoder: encoder))
+                .modifier(
+                    FileTreeEntryAccessibilityActions(
+                        entry: entry,
+                        encoder: encoder,
+                        resolveEntry: { fileTreeState.entry(withID: $0) }
+                    )
+                )
                 .contextMenu { entryContextMenu(entry) }
                 .draggable(URL(fileURLWithPath: fileTreeState.fullPath(for: entry))) {
                     HStack(spacing: 4) {
@@ -240,7 +246,7 @@ struct FileTreeView: View {
         }
     }
 
-    private func fileTreeRow(_ entry: FileTreeEntry) -> FileTreeRowView {
+    private func fileTreeRow(_ entry: FileTreeEntry, onActivate: @escaping () -> Void) -> FileTreeRowView {
         FileTreeRowView(
             entry: entry,
             theme: theme,
@@ -250,6 +256,7 @@ struct FileTreeView: View {
             isHovered: false,
             isDropTarget: dropTargetEntryId == entry.id,
             animDuration: animDuration,
+            onActivate: onActivate,
             onEditCommit: { text in
                 encoder?.sendFileTreeEditConfirm(text: text)
             },
@@ -263,66 +270,95 @@ struct FileTreeView: View {
 
     @ViewBuilder
     private func entryContextMenu(_ entry: FileTreeEntry) -> some View {
+        let entryId = entry.id
+
         if !entry.isDir {
             Button("Open") {
-                encoder?.sendFileTreeClick(index: UInt16(entry.index))
+                withCurrentEntry(entryId) { entry in
+                    encoder?.sendFileTreeClick(index: UInt16(entry.index))
+                }
             }
             Button("Open in Split") {
-                encoder?.sendFileTreeOpenInSplit(index: UInt16(entry.index))
+                withCurrentEntry(entryId) { entry in
+                    encoder?.sendFileTreeOpenInSplit(index: UInt16(entry.index))
+                }
             }
             Divider()
         }
 
         if entry.isDir {
             Button("New File…") {
-                encoder?.sendFileTreeNewFile(parentIndex: UInt16(entry.index))
+                withCurrentEntry(entryId) { entry in
+                    encoder?.sendFileTreeNewFile(parentIndex: UInt16(entry.index))
+                }
             }
             Button("New Folder…") {
-                encoder?.sendFileTreeNewFolder(parentIndex: UInt16(entry.index))
+                withCurrentEntry(entryId) { entry in
+                    encoder?.sendFileTreeNewFolder(parentIndex: UInt16(entry.index))
+                }
             }
             Divider()
         }
 
         Button("Rename") {
-            encoder?.sendFileTreeRename(index: UInt16(entry.index))
+            withCurrentEntry(entryId) { entry in
+                encoder?.sendFileTreeRename(index: UInt16(entry.index))
+            }
         }
         Button("Duplicate") {
-            encoder?.sendFileTreeDuplicate(index: UInt16(entry.index))
+            withCurrentEntry(entryId) { entry in
+                encoder?.sendFileTreeDuplicate(index: UInt16(entry.index))
+            }
         }
 
         Divider()
 
         Button("Copy Path") {
-            copyToClipboard(fileTreeState.fullPath(for: entry))
+            withCurrentEntry(entryId) { entry in
+                copyToClipboard(fileTreeState.fullPath(for: entry))
+            }
         }
         Button("Copy Relative Path") {
-            copyToClipboard(entry.relPath)
+            withCurrentEntry(entryId) { entry in
+                copyToClipboard(entry.relPath)
+            }
         }
 
         Divider()
 
         Button("Reveal in Finder") {
-            let path = fileTreeState.fullPath(for: entry)
-            NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+            withCurrentEntry(entryId) { entry in
+                let path = fileTreeState.fullPath(for: entry)
+                NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+            }
         }
         Button("Open in Terminal") {
-            let path = fileTreeState.fullPath(for: entry)
-            let dirPath = entry.isDir ? path : (path as NSString).deletingLastPathComponent
-            let dirURL = URL(fileURLWithPath: dirPath)
-            NSWorkspace.shared.open(
-                [dirURL],
-                withApplicationAt: URL(fileURLWithPath: "/System/Applications/Utilities/Terminal.app"),
-                configuration: NSWorkspace.OpenConfiguration()
-            )
+            withCurrentEntry(entryId) { entry in
+                let path = fileTreeState.fullPath(for: entry)
+                let dirPath = entry.isDir ? path : (path as NSString).deletingLastPathComponent
+                let dirURL = URL(fileURLWithPath: dirPath)
+                NSWorkspace.shared.open(
+                    [dirURL],
+                    withApplicationAt: URL(fileURLWithPath: "/System/Applications/Utilities/Terminal.app"),
+                    configuration: NSWorkspace.OpenConfiguration()
+                )
+            }
         }
 
         Divider()
 
         Button(role: .destructive) {
-            encoder?.sendFileTreeDelete(index: UInt16(entry.index))
+            withCurrentEntry(entryId) { entry in
+                encoder?.sendFileTreeDelete(index: UInt16(entry.index))
+            }
         } label: {
             Text("Move to Trash")
         }
+    }
+
+    private func withCurrentEntry(_ id: String, perform: (FileTreeEntry) -> Void) {
+        guard let entry = fileTreeState.entry(withID: id) else { return }
+        perform(entry)
     }
 
     private func copyToClipboard(_ string: String) {
@@ -354,6 +390,11 @@ struct FileTreeView: View {
             lastClickEntryId = entry.id
             lastClickTime = now
         }
+    }
+
+    private func activateEntry(id: String) {
+        guard let entry = fileTreeState.entry(withID: id) else { return }
+        handleEntryTap(entry)
     }
 
     // MARK: - Drop handling
@@ -421,38 +462,48 @@ struct FileTreeView: View {
 private struct FileTreeEntryAccessibilityActions: ViewModifier {
     let entry: FileTreeEntry
     let encoder: InputEncoder?
+    let resolveEntry: (String) -> FileTreeEntry?
 
     @ViewBuilder
     func body(content: Content) -> some View {
         if entry.isDir {
             content
                 .accessibilityAction(named: Text("Toggle Folder")) {
+                    guard let entry = resolveEntry(entry.id) else { return }
                     encoder?.sendFileTreeToggle(index: UInt16(entry.index))
                 }
                 .accessibilityAction(named: Text("New File…")) {
+                    guard let entry = resolveEntry(entry.id) else { return }
                     encoder?.sendFileTreeNewFile(parentIndex: UInt16(entry.index))
                 }
                 .accessibilityAction(named: Text("New Folder…")) {
+                    guard let entry = resolveEntry(entry.id) else { return }
                     encoder?.sendFileTreeNewFolder(parentIndex: UInt16(entry.index))
                 }
                 .accessibilityAction(named: Text("Rename")) {
+                    guard let entry = resolveEntry(entry.id) else { return }
                     encoder?.sendFileTreeRename(index: UInt16(entry.index))
                 }
                 .accessibilityAction(named: Text("Move to Trash")) {
+                    guard let entry = resolveEntry(entry.id) else { return }
                     encoder?.sendFileTreeDelete(index: UInt16(entry.index))
                 }
         } else {
             content
                 .accessibilityAction(named: Text("Open")) {
+                    guard let entry = resolveEntry(entry.id) else { return }
                     encoder?.sendFileTreeClick(index: UInt16(entry.index))
                 }
                 .accessibilityAction(named: Text("Open in Split")) {
+                    guard let entry = resolveEntry(entry.id) else { return }
                     encoder?.sendFileTreeOpenInSplit(index: UInt16(entry.index))
                 }
                 .accessibilityAction(named: Text("Rename")) {
+                    guard let entry = resolveEntry(entry.id) else { return }
                     encoder?.sendFileTreeRename(index: UInt16(entry.index))
                 }
                 .accessibilityAction(named: Text("Move to Trash")) {
+                    guard let entry = resolveEntry(entry.id) else { return }
                     encoder?.sendFileTreeDelete(index: UInt16(entry.index))
                 }
         }

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -106,6 +106,47 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.fileTreeState.projectRoot == "/project")
     }
 
+    @Test("guiFileTreeSelection updates selection and focus without replacing entries")
+    @MainActor func guiFileTreeSelectionRouting() {
+        let (dispatcher, gui) = makeDispatcher()
+        let entries = [
+            wireFileTreeEntry(pathHash: 1, isSelected: true, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a"),
+            wireFileTreeEntry(pathHash: 2, id: "/project/b", path: "/project/b", name: "b", relPath: "b")
+        ]
+        dispatcher.dispatch(.guiFileTree(version: 2, treeFlags: 0x03, treeState: 3, selectedId: "/project/a", treeWidth: 30,
+                                          rootPath: "/project", errorReason: "", entries: entries))
+
+        dispatcher.dispatch(.guiFileTreeSelection(selectedId: "/project/b", focused: false))
+
+        #expect(gui.fileTreeState.entries.count == 2)
+        #expect(gui.fileTreeState.entries[0].id == "/project/a")
+        #expect(gui.fileTreeState.entries[1].id == "/project/b")
+        #expect(gui.fileTreeState.selectedId == "/project/b")
+        #expect(gui.fileTreeState.selectedIndex == 1)
+        #expect(gui.fileTreeState.focused == false)
+        #expect(gui.fileTreeState.entries[0].isSelected == false)
+        #expect(gui.fileTreeState.entries[1].isSelected == true)
+        #expect(gui.fileTreeState.entries.allSatisfy { $0.isFocused == false })
+    }
+
+    @Test("guiFileTreeSelection ignores unknown selected id without clearing selection")
+    @MainActor func guiFileTreeSelectionIgnoresUnknownId() {
+        let (dispatcher, gui) = makeDispatcher()
+        let entries = [
+            wireFileTreeEntry(pathHash: 1, isSelected: true, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a")
+        ]
+        dispatcher.dispatch(.guiFileTree(version: 2, treeFlags: 0x03, treeState: 3, selectedId: "/project/a", treeWidth: 30,
+                                          rootPath: "/project", errorReason: "", entries: entries))
+
+        dispatcher.dispatch(.guiFileTreeSelection(selectedId: "/project/missing", focused: false))
+
+        #expect(gui.fileTreeState.selectedId == "/project/a")
+        #expect(gui.fileTreeState.selectedIndex == 0)
+        #expect(gui.fileTreeState.focused == false)
+        #expect(gui.fileTreeState.entries[0].isSelected == true)
+        #expect(gui.fileTreeState.entries[0].isFocused == false)
+    }
+
     @Test("guiFileTree hides when explicit tree state is hidden")
     @MainActor func guiFileTreeHidesOnHiddenState() {
         let (dispatcher, gui) = makeDispatcher()

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -743,6 +743,28 @@ struct GUIFileTreeDecoderTests {
         #expect(entries[1].relPath == "lib/editor.ex")
     }
 
+    @Test("Decode lightweight gui_file_tree_selection")
+    func decodeSelectionUpdate() throws {
+        var payload = Data()
+        payload.append(0x01)
+        appendString16(&payload, "/home/user/project/lib/editor.ex")
+
+        var data = Data()
+        data.append(OP_GUI_FILE_TREE_SELECTION)
+        appendU16(&data, UInt16(payload.count))
+        data.append(payload)
+
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+
+        guard case .guiFileTreeSelection(let selectedId, let focused) = cmd else {
+            Issue.record("Expected .guiFileTreeSelection"); return
+        }
+
+        #expect(selectedId == "/home/user/project/lib/editor.ex")
+        #expect(focused == true)
+    }
+
     @Test("Decode semantic gui_file_tree hidden")
     func decodeHidden() throws {
         var payload = Data()

--- a/macos/Tests/MingaTests/ProtocolSchemaTests.swift
+++ b/macos/Tests/MingaTests/ProtocolSchemaTests.swift
@@ -77,6 +77,7 @@ struct ProtocolSchemaSwiftTests {
               let chrome = opcodes["gui_chrome"] as? [String: Any] else { return }
 
         #expect(try schemaHex(chrome, "gui_file_tree") == OP_GUI_FILE_TREE)
+        #expect(try schemaHex(chrome, "gui_file_tree_selection") == OP_GUI_FILE_TREE_SELECTION)
         #expect(try schemaHex(chrome, "gui_tab_bar") == OP_GUI_TAB_BAR)
         #expect(try schemaHex(chrome, "gui_which_key") == OP_GUI_WHICH_KEY)
         #expect(try schemaHex(chrome, "gui_completion") == OP_GUI_COMPLETION)

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -374,6 +374,16 @@ struct FileTreeRowViewTests {
         #expect(row.accessibilityLabelText == "File: editor.ex, 1 warning, unsaved changes, git conflict")
     }
 
+    @Test("Accessibility values expose selected current expanded and focused state")
+    @MainActor func accessibilityValuesExposeSelectionAndTreeState() throws {
+        let currentFile = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, isSelected: true, isFocused: true, isActive: true, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        #expect(currentFile.accessibilityValueText == "selected, current file, keyboard focus")
+        #expect(currentFile.accessibilityTraits.contains(.isSelected))
+
+        let folder = fileTreeRowView(entry: sidebarFileTreeEntry(id: 2, index: 1, isDir: true, isExpanded: true, icon: "\u{F0256}", name: "lib", relPath: "lib"))
+        #expect(folder.accessibilityValueText == "expanded")
+    }
+
     @Test("Diagnostic info and hint severities render distinct markers")
     @MainActor func diagnosticInfoAndHintSeveritiesRenderDistinctMarkers() throws {
         let info = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, diagnosticInfoCount: 1, icon: "\u{E62D}", name: "info.ex", relPath: "info.ex"))

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -379,9 +379,36 @@ struct FileTreeRowViewTests {
         let currentFile = fileTreeRowView(entry: sidebarFileTreeEntry(id: 1, index: 0, isSelected: true, isFocused: true, isActive: true, icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
         #expect(currentFile.accessibilityValueText == "selected, current file, keyboard focus")
         #expect(currentFile.accessibilityTraits.contains(.isSelected))
+        #expect(currentFile.accessibilityTraits.contains(.isButton))
 
         let folder = fileTreeRowView(entry: sidebarFileTreeEntry(id: 2, index: 1, isDir: true, isExpanded: true, icon: "\u{F0256}", name: "lib", relPath: "lib"))
         #expect(folder.accessibilityValueText == "expanded")
+
+        let editing = fileTreeRowView(entry: sidebarFileTreeEntry(id: 3, index: 2, isEditing: true, editingType: 2, editingText: "renamed.ex", icon: "\u{E62D}", name: "editor.ex", relPath: "lib/editor.ex"))
+        #expect(editing.accessibilityLabelText == "Editing: editor.ex")
+        #expect(editing.accessibilityValueText == "editing name")
+        #expect(editing.accessibilityTraits.contains(.isButton) == false)
+    }
+
+    @Test("Stable row ids resolve the current entry even after the row list changes")
+    @MainActor func stableRowIdsResolveTheCurrentEntry() throws {
+        let state = FileTreeState()
+        state.entries = [
+            sidebarFileTreeEntry(id: 1, index: 8, icon: "\u{E62D}", name: "alpha.ex", relPath: "/project/alpha.ex", path: "/project/alpha.ex"),
+            sidebarFileTreeEntry(id: 2, index: 3, icon: "\u{E62D}", name: "beta.ex", relPath: "/project/beta.ex", path: "/project/beta.ex"),
+        ]
+
+        #expect(state.entry(withID: "/project/alpha.ex")?.index == 8)
+        #expect(state.entry(withID: "/project/beta.ex")?.index == 3)
+        #expect(state.entry(withID: "/project/missing.ex") == nil)
+
+        state.entries = [
+            sidebarFileTreeEntry(id: 2, index: 1, icon: "\u{E62D}", name: "beta.ex", relPath: "/project/beta.ex", path: "/project/beta.ex"),
+            sidebarFileTreeEntry(id: 1, index: 0, icon: "\u{E62D}", name: "alpha.ex", relPath: "/project/alpha.ex", path: "/project/alpha.ex"),
+        ]
+
+        #expect(state.entry(withID: "/project/alpha.ex")?.index == 0)
+        #expect(state.entry(withID: "/project/beta.ex")?.index == 1)
     }
 
     @Test("Diagnostic info and hint severities render distinct markers")
@@ -506,6 +533,7 @@ private func fileTreeRowView(entry: FileTreeEntry, isHovered: Bool = false, isDr
         isHovered: isHovered,
         isDropTarget: isDropTarget,
         animDuration: 0,
+        onActivate: {},
         onEditCommit: { _ in },
         onEditCancel: {}
     )

--- a/test/minga/git/tracker_registry_test.exs
+++ b/test/minga/git/tracker_registry_test.exs
@@ -41,11 +41,10 @@ defmodule Minga.Git.TrackerRegistryTest do
     table = :"tracker_registry_#{System.unique_integer([:positive])}"
     tracker_name = :"tracker_#{System.unique_integer([:positive])}"
 
-    tracker =
-      start_supervised!(
-        {Tracker, name: tracker_name, events_registry: registry_a, registry_table: table},
-        id: table
-      )
+    start_supervised!(
+      {Tracker, name: tracker_name, events_registry: registry_a, registry_table: table},
+      id: table
+    )
 
     path = Path.join(dir, "tracker_registry_test.ex")
     File.write!(path, "x = 1\n")
@@ -53,7 +52,6 @@ defmodule Minga.Git.TrackerRegistryTest do
     {:ok, buf} = BufferProcess.start_link(content: "x = 1\n", file_path: path)
 
     Events.broadcast(:buffer_opened, %Events.BufferEvent{buffer: buf, path: path}, registry_b)
-    _ = :sys.get_state(tracker)
     refute Tracker.tracked?(buf, table)
 
     Events.broadcast(:buffer_opened, %Events.BufferEvent{buffer: buf, path: path}, registry_a)

--- a/test/minga_editor/file_tree/rows_test.exs
+++ b/test/minga_editor/file_tree/rows_test.exs
@@ -196,6 +196,32 @@ defmodule MingaEditor.FileTree.RowsTest do
     end
   end
 
+  describe "from_entries/3" do
+    test "builds only the requested indexed rows for large visible lists", %{tmp_dir: tmp_dir} do
+      for index <- 1..300 do
+        File.write!(Path.join(tmp_dir, "file_#{index}.ex"), "")
+      end
+
+      tree = FileTree.new(tmp_dir) |> FileTree.select(249)
+
+      indexed_entries =
+        tree
+        |> FileTree.visible_entries()
+        |> Enum.slice(245, 10)
+        |> Enum.with_index(245)
+
+      rows = Rows.from_entries(indexed_entries, tree, selected_index: tree.cursor)
+
+      assert length(rows) == 10
+
+      assert Enum.map(rows, & &1.name) ==
+               Enum.map(indexed_entries, fn {entry, _index} -> entry.name end)
+
+      assert Enum.count(rows, & &1.selected?) == 1
+      assert Enum.find(rows, & &1.selected?).name == Enum.at(rows, 4).name
+    end
+  end
+
   describe "from_state/1" do
     test "active row follows buffer switches without reopening the tree", %{tmp_dir: tmp_dir} do
       alpha_path = Path.join(tmp_dir, "alpha.ex")

--- a/test/minga_editor/file_tree/rows_test.exs
+++ b/test/minga_editor/file_tree/rows_test.exs
@@ -283,6 +283,22 @@ defmodule MingaEditor.FileTree.RowsTest do
       assert FileTreeState.status(errored) == :ready
     end
 
+    test "open and replace_tree keep cached visible entries on the stored tree", %{
+      tmp_dir: tmp_dir
+    } do
+      tree = flat_tree(tmp_dir)
+      file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
+
+      assert is_list(file_tree.tree.entries)
+      assert length(file_tree.tree.entries) == 2
+
+      replaced_tree = FileTree.toggle_hidden(file_tree.tree)
+      replaced = FileTreeState.replace_tree(file_tree, replaced_tree)
+
+      assert is_list(replaced.tree.entries)
+      assert replaced.tree.entries != []
+    end
+
     test "width preserves the last sidebar width for state-only payloads", %{tmp_dir: tmp_dir} do
       tree = FileTree.new(tmp_dir, width: 42)
       file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)

--- a/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
+++ b/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
@@ -9,7 +9,12 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Diagnostics
+  alias Minga.Diagnostics.Diagnostic
+  alias Minga.LSP.SyncServer
+  alias Minga.Project.FileTree
   alias MingaEditor.Renderer.Caches
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.Tab
@@ -237,6 +242,148 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
                _ ->
                  false
              end)
+    end
+
+    test "ready large file trees reuse cached rows on the second frame" do
+      root =
+        Path.join(System.tmp_dir!(), "minga-gui-file-tree-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(root)
+
+      for index <- 1..300 do
+        filename = "file_#{String.pad_leading(Integer.to_string(index), 3, "0")}.ex"
+        File.write!(Path.join(root, filename), "")
+      end
+
+      file_tree = FileTreeState.open(%FileTreeState{}, FileTree.new(root, width: 32), nil)
+
+      state = gui_state()
+      state = put_in(state.workspace.file_tree, file_tree)
+
+      {_ctx, caches} =
+        EmitGUI.sync_swiftui_chrome(
+          Context.from_editor_state(state),
+          StatusBarData.from_state(state),
+          nil,
+          %Caches{}
+        )
+
+      first_cmds = collect_port_casts() |> List.flatten()
+      assert Enum.any?(first_cmds, &match?(<<0x93, _::binary>>, &1))
+
+      {_ctx, caches2} =
+        EmitGUI.sync_swiftui_chrome(
+          Context.from_editor_state(state),
+          StatusBarData.from_state(state),
+          nil,
+          caches
+        )
+
+      second_cmds = collect_port_casts() |> List.flatten()
+
+      assert caches2.last_gui_file_tree_fp == caches.last_gui_file_tree_fp
+      refute Enum.any?(second_cmds, &match?(<<0x93, _::binary>>, &1))
+    end
+
+    test "ready file trees resend full GUI rows when diagnostics change" do
+      root =
+        Path.join(
+          System.tmp_dir!(),
+          "minga-gui-file-tree-diagnostics-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(root)
+      file_path = Path.join(root, "alpha.ex")
+      File.write!(file_path, "")
+
+      uri = SyncServer.path_to_uri(file_path)
+
+      on_exit(fn ->
+        Diagnostics.clear(:gui_file_tree_cache_test, uri)
+      end)
+
+      file_tree = FileTreeState.open(%FileTreeState{}, FileTree.new(root, width: 32), nil)
+
+      state = gui_state()
+      state = put_in(state.workspace.file_tree, file_tree)
+
+      {_ctx, caches} =
+        EmitGUI.sync_swiftui_chrome(
+          Context.from_editor_state(state),
+          StatusBarData.from_state(state),
+          nil,
+          %Caches{}
+        )
+
+      flush_port_casts()
+
+      :ok =
+        Diagnostics.publish(:gui_file_tree_cache_test, uri, [
+          %Diagnostic{
+            range: %{start_line: 0, start_col: 0, end_line: 0, end_col: 1},
+            severity: :error,
+            message: "boom"
+          }
+        ])
+
+      {_ctx, _caches2} =
+        EmitGUI.sync_swiftui_chrome(
+          Context.from_editor_state(state),
+          StatusBarData.from_state(state),
+          nil,
+          caches
+        )
+
+      cmds = collect_port_casts() |> List.flatten()
+
+      assert Enum.any?(cmds, &match?(<<0x93, _::binary>>, &1))
+      refute Enum.any?(cmds, &match?(<<0x94, _::binary>>, &1))
+    end
+
+    test "ready large file tree selection changes emit selection update without resending rows" do
+      root =
+        Path.join(
+          System.tmp_dir!(),
+          "minga-gui-file-tree-selection-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(root)
+
+      for index <- 1..300 do
+        filename = "file_#{String.pad_leading(Integer.to_string(index), 3, "0")}.ex"
+        File.write!(Path.join(root, filename), "")
+      end
+
+      file_tree = FileTreeState.open(%FileTreeState{}, FileTree.new(root, width: 32), nil)
+
+      state = gui_state()
+      state = put_in(state.workspace.file_tree, file_tree)
+
+      {_ctx, caches} =
+        EmitGUI.sync_swiftui_chrome(
+          Context.from_editor_state(state),
+          StatusBarData.from_state(state),
+          nil,
+          %Caches{}
+        )
+
+      flush_port_casts()
+
+      moved_tree = FileTreeState.replace_tree(file_tree, FileTree.select(file_tree.tree, 42))
+      moved_state = put_in(state.workspace.file_tree, moved_tree)
+
+      {_ctx, _caches2} =
+        EmitGUI.sync_swiftui_chrome(
+          Context.from_editor_state(moved_state),
+          StatusBarData.from_state(moved_state),
+          nil,
+          caches
+        )
+
+      second_cmds = collect_port_casts() |> List.flatten()
+
+      refute Enum.any?(second_cmds, &match?(<<0x93, _::binary>>, &1))
+      assert [<<0x94, _::binary>>] = Enum.filter(second_cmds, &match?(<<0x94, _::binary>>, &1))
     end
 
     test "git syncing and toast changes re-send hidden git status command" do

--- a/test/minga_editor/frontend/protocol_schema_test.exs
+++ b/test/minga_editor/frontend/protocol_schema_test.exs
@@ -38,6 +38,7 @@ defmodule MingaEditor.Frontend.ProtocolSchemaTest do
       expected = schema["opcodes"]["gui_chrome"]
 
       assert_opcode(expected, "gui_file_tree", 0x93)
+      assert_opcode(expected, "gui_file_tree_selection", 0x94)
       assert_opcode(expected, "gui_tab_bar", 0x71)
       assert_opcode(expected, "gui_which_key", 0x72)
       assert_opcode(expected, "gui_completion", 0x73)

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -1256,6 +1256,14 @@ defmodule MingaEditor.Frontend.ProtocolTest do
       assert payload_len > 65_535
     end
 
+    test "encodes lightweight gui_file_tree_selection update" do
+      encoded = ProtocolGUI.encode_gui_file_tree_selection("/project/lib/hello.ex", true)
+
+      assert <<0x94, payload_len::16, payload::binary-size(payload_len)>> = encoded
+      assert <<1::8, selected_len::16, selected::binary-size(selected_len)>> = payload
+      assert selected == "/project/lib/hello.ex"
+    end
+
     test "encodes hidden semantic gui_file_tree with explicit hidden state" do
       encoded = ProtocolGUI.encode_hidden_gui_file_tree("/tmp/minga-project")
 

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -3,13 +3,18 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Core.Unicode
   alias Minga.Project.FileTree
   alias MingaEditor.FileTree.Diagnostics, as: RowDiagnostics
   alias MingaEditor.FileTree.Row
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.Shell.Traditional.TreeRenderer
   alias MingaEditor.Shell.Traditional.TreeRenderer.RenderInput
   alias MingaEditor.UI.Theme
+
+  import MingaEditor.RenderPipeline.TestHelpers, only: [gui_state: 1]
 
   @moduletag :tmp_dir
 
@@ -108,6 +113,78 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
 
       assert [{0, 20, "│", _style}] = sep_draws
       refute Enum.any?(draws, fn {row, col, _text, _style} -> row > 0 and col < 20 end)
+    end
+
+    test "production state render shows active and dirty row states", %{tmp_dir: tmp_dir} do
+      active_path = Path.join(tmp_dir, "active.ex")
+      dirty_path = Path.join(tmp_dir, "dirty.ex")
+      File.write!(active_path, "active")
+      File.write!(dirty_path, "dirty")
+
+      {:ok, active_buf} = BufferProcess.start_link(file_path: active_path)
+      {:ok, dirty_buf} = BufferProcess.start_link(file_path: dirty_path)
+      :ok = BufferProcess.insert_text(dirty_buf, "!")
+
+      tree = FileTree.new(tmp_dir, width: 32)
+      file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
+
+      state = gui_state(rows: 10, cols: 80)
+      state = put_in(state.workspace.file_tree, file_tree)
+
+      state =
+        put_in(state.workspace.buffers, %Buffers{
+          active: active_buf,
+          list: [active_buf, dirty_buf],
+          active_index: 0
+        })
+
+      draws = TreeRenderer.render(state)
+      all_text = draw_texts(draws)
+
+      assert String.contains?(all_text, "active.ex")
+      assert String.contains?(all_text, "dirty.ex")
+      assert String.contains?(all_text, "●")
+
+      {_row, _col, _text, active_style} = draw_containing(draws, "active.ex")
+      assert active_style.fg == Theme.get!(:doom_one).tree.active_fg
+      assert active_style.bold == true
+
+      {_row, _col, _text, dirty_style} = draw_matching(draws, "●")
+      assert dirty_style.fg == Theme.get!(:doom_one).tree.modified_fg
+    end
+
+    test "production state render shows loading and error messages", %{tmp_dir: tmp_dir} do
+      tree = FileTree.new(tmp_dir, width: 24)
+      file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
+      theme = Theme.get!(:doom_one)
+
+      loading_draws =
+        TreeRenderer.render(%{
+          workspace: %{
+            file_tree: FileTreeState.loading(file_tree),
+            viewport: %{rows: 5, cols: 80},
+            buffers: %{active: nil, list: [], active_index: 0}
+          },
+          theme: theme
+        })
+
+      error_draws =
+        TreeRenderer.render(%{
+          workspace: %{
+            file_tree: FileTreeState.error(file_tree, :eacces),
+            viewport: %{rows: 5, cols: 80},
+            buffers: %{active: nil, list: [], active_index: 0}
+          },
+          theme: theme
+        })
+
+      assert draw_texts(loading_draws) =~ "Loading files"
+      assert draw_texts(error_draws) =~ "File tree error"
+      assert draw_texts(error_draws) =~ "permission denied"
+
+      for draws <- [loading_draws, error_draws] do
+        assert Enum.any?(draws, fn {_row, col, text, _style} -> col == 24 and text == "│" end)
+      end
     end
 
     test "renders empty loading and error rows without layout drift", %{tmp_dir: tmp_dir} do
@@ -218,37 +295,52 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       assert String.starts_with?(name, "lib/")
     end
 
-    test "renders production state for large trees through the visible row window", %{
-      tmp_dir: tmp_dir
-    } do
+    test "renders production state for large trees around the selected row", %{tmp_dir: tmp_dir} do
       for index <- 1..600 do
-        File.write!(Path.join(tmp_dir, "file_#{index}.ex"), "")
+        File.write!(
+          Path.join(tmp_dir, "file_#{String.pad_leading(Integer.to_string(index), 3, "0")}.ex"),
+          ""
+        )
       end
 
       tree = FileTree.new(tmp_dir, width: 32) |> FileTree.select(599)
+      file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
 
       draws =
         TreeRenderer.render(%{
           workspace: %{
-            file_tree: %{tree: tree, focused: true},
-            viewport: %{rows: 10, cols: 80}
+            file_tree: %{file_tree | focused: true},
+            viewport: %{rows: 10, cols: 80},
+            buffers: %{active: nil, list: [], active_index: 0}
           },
           theme: Theme.get!(:doom_one)
         })
 
-      content_draw_rows =
-        draws
-        |> Enum.filter(fn {row, col, _text, _style} -> row > 1 and col < 32 end)
-        |> Enum.map(fn {row, _col, _text, _style} -> row end)
-        |> Enum.uniq()
+      all_text = draw_texts(draws)
 
-      assert content_draw_rows == Enum.to_list(2..8)
-      assert draw_texts(draws) =~ ".ex"
+      for name <- [
+            "file_594.ex",
+            "file_595.ex",
+            "file_596.ex",
+            "file_597.ex",
+            "file_598.ex",
+            "file_599.ex",
+            "file_600.ex"
+          ] do
+        assert String.contains?(all_text, name)
+      end
+
+      refute String.contains?(all_text, "file_593.ex")
+      refute String.contains?(all_text, "file_001.ex")
+      assert String.contains?(all_text, "file_600.ex")
     end
 
-    test "renders large RenderInput trees from only the visible row window", %{tmp_dir: tmp_dir} do
+    test "renders large RenderInput trees around the selected row", %{tmp_dir: tmp_dir} do
       for index <- 1..600 do
-        File.write!(Path.join(tmp_dir, "file_#{index}.ex"), "")
+        File.write!(
+          Path.join(tmp_dir, "file_#{String.pad_leading(Integer.to_string(index), 3, "0")}.ex"),
+          ""
+        )
       end
 
       tree = FileTree.new(tmp_dir, width: 32) |> FileTree.select(599)
@@ -262,14 +354,22 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
           active_path: nil
         })
 
-      content_draw_rows =
-        draws
-        |> Enum.filter(fn {row, col, _text, _style} -> row > 0 and col < 32 end)
-        |> Enum.map(fn {row, _col, _text, _style} -> row end)
-        |> Enum.uniq()
+      all_text = draw_texts(draws)
 
-      assert content_draw_rows == Enum.to_list(1..7)
-      assert draw_texts(draws) =~ ".ex"
+      for name <- [
+            "file_594.ex",
+            "file_595.ex",
+            "file_596.ex",
+            "file_597.ex",
+            "file_598.ex",
+            "file_599.ex",
+            "file_600.ex"
+          ] do
+        assert String.contains?(all_text, name)
+      end
+
+      refute String.contains?(all_text, "file_593.ex")
+      refute String.contains?(all_text, "file_001.ex")
     end
 
     test "renders supplied semantic rows", %{tmp_dir: tmp_dir} do

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -218,6 +218,60 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       assert String.starts_with?(name, "lib/")
     end
 
+    test "renders production state for large trees through the visible row window", %{
+      tmp_dir: tmp_dir
+    } do
+      for index <- 1..600 do
+        File.write!(Path.join(tmp_dir, "file_#{index}.ex"), "")
+      end
+
+      tree = FileTree.new(tmp_dir, width: 32) |> FileTree.select(599)
+
+      draws =
+        TreeRenderer.render(%{
+          workspace: %{
+            file_tree: %{tree: tree, focused: true},
+            viewport: %{rows: 10, cols: 80}
+          },
+          theme: Theme.get!(:doom_one)
+        })
+
+      content_draw_rows =
+        draws
+        |> Enum.filter(fn {row, col, _text, _style} -> row > 1 and col < 32 end)
+        |> Enum.map(fn {row, _col, _text, _style} -> row end)
+        |> Enum.uniq()
+
+      assert content_draw_rows == Enum.to_list(2..8)
+      assert draw_texts(draws) =~ ".ex"
+    end
+
+    test "renders large RenderInput trees from only the visible row window", %{tmp_dir: tmp_dir} do
+      for index <- 1..600 do
+        File.write!(Path.join(tmp_dir, "file_#{index}.ex"), "")
+      end
+
+      tree = FileTree.new(tmp_dir, width: 32) |> FileTree.select(599)
+
+      draws =
+        TreeRenderer.render(%RenderInput{
+          tree: tree,
+          rect: {0, 0, 32, 8},
+          focused: true,
+          theme: Theme.get!(:doom_one),
+          active_path: nil
+        })
+
+      content_draw_rows =
+        draws
+        |> Enum.filter(fn {row, col, _text, _style} -> row > 0 and col < 32 end)
+        |> Enum.map(fn {row, _col, _text, _style} -> row end)
+        |> Enum.uniq()
+
+      assert content_draw_rows == Enum.to_list(1..7)
+      assert draw_texts(draws) =~ ".ex"
+    end
+
     test "renders supplied semantic rows", %{tmp_dir: tmp_dir} do
       file_path = Path.join(tmp_dir, "main.ex")
       File.write!(file_path, "defmodule Main do\nend\n")


### PR DESCRIPTION
# TL;DR
The file tree now keeps rendering and protocol updates bounded for large projects, while preserving readable TUI status markers and richer macOS accessibility semantics. TUI rendering builds semantic rows only for the visible window, the macOS GUI can receive lightweight selection-only updates, and row actions re-resolve by stable IDs before sending index-based commands.

Closes #1650

## Context
This closes the large-project smoothness and accessibility slice from the file-tree epic. The goal is to keep normal cursor movement, redraws, hover changes, sidebar updates, and screen-reader actions cheap even when the project tree contains thousands of visible entries.

## Changes
- Added `Rows.from_entries/3` so callers that already know the visible entry window can build only those semantic rows while preserving original row indexes for selection and inline editing.
- Updated the TUI `TreeRenderer.render(state)` path to slice visible entries before semantic row construction, instead of eagerly building every row from editor state on normal redraws.
- Cached file-tree entries on open/replace so repeated row-window access does not keep walking the filesystem.
- Added GUI file-tree cache splitting plus `gui_file_tree_selection` (`0x94`) so selection and focus changes can update Swift without resending the full row payload.
- Kept GUI diagnostic changes on the full `gui_file_tree` path so diagnostic badges do not go stale after cache splitting.
- Moved macOS row hover state into `FileTreeRowView`, so hover changes no longer mutate parent list state for every row.
- Re-resolved Swift accessibility and context-menu actions by stable row ID before sending index-based file-tree actions.
- Added macOS accessibility values, selected traits, and practical custom row actions for file/folder operations.
- Documented a generated large-tree validation fixture and the macOS/TUI interactions reviewers should smoke-test.

## Verification
- `git diff --check`
- `make lint`
- `mix test.llm` (52 doctests, 97 properties, 8637 tests, 0 failures, 5 skipped, 118 excluded)
- `mix swift.build`
- `xcodebuild test -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS' -only-testing:MingaTests/GUIFileTreeDecoderTests -only-testing:MingaTests/CommandDispatcherRoutingTests -only-testing:MingaTests/ProtocolSchemaTests -only-testing:MingaTests/SidebarViewTests`
- Manual macOS/TUI/VoiceOver large-tree smoke validation: user confirmed all good
- Review loop: round 3 code/test/Swift re-checks passed, final reviewer passed

## Acceptance Criteria Addressed
- Large-tree interactions remain responsive with a repeatable manual validation recipe ✅
- TUI rendering avoids repeated full semantic row construction during normal redraws ✅
- macOS row hover/selection changes avoid full-tree invalidation when row-level updates are enough ✅
- Per-row Swift drawing stays bounded through compact guides and simple status markers ✅
- macOS rows expose VoiceOver labels, selected/current state, expanded/collapsed state, dirty/git/diagnostic status, and practical actions ✅
- TUI rows preserve readable text markers instead of relying only on color ✅
- Targeted row/render/protocol/accessibility tests and the large-tree recipe are included ✅
