### PR TITLE
refactor(buffer): extract save state

### DIFF
--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -47,6 +47,7 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     "Minga.Buffer.EditDelta",
     "Minga.Buffer.EditSource",
     "Minga.Buffer.RenderSnapshot",
+    "Minga.Buffer.SaveState",
     "Minga.Buffer.State",
     "Minga.Buffer.UndoHistory",
     "Minga.Editing.Motion",

--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -216,6 +216,10 @@ defmodule Minga.Buffer do
   @spec accept_saved_content(t(), String.t()) :: :ok
   defdelegate accept_saved_content(server, new_content), to: BufferProcess
 
+  @doc "Acknowledge the current disk metadata after keeping local edits during a file-change conflict."
+  @spec acknowledge_disk_change(t()) :: :ok
+  defdelegate acknowledge_disk_change(server), to: BufferProcess
+
   @doc "Find and replace the first occurrence of `old_text` with `new_text`."
   @spec find_and_replace(t(), String.t(), String.t(), boundary()) ::
           {:ok, String.t()} | {:error, String.t()}

--- a/lib/minga/buffer/persistence.ex
+++ b/lib/minga/buffer/persistence.ex
@@ -5,12 +5,13 @@ defmodule Minga.Buffer.Persistence do
   `Minga.Buffer.Process` owns the process transaction: undo state, dirty state, events, timers, and registry updates. This module owns the file-system and remote-storage details that make those transactions possible: reading content, writing content, collecting file metadata, fingerprinting saved content, and deciding whether the backing file changed since the buffer last saved or loaded it.
   """
 
+  alias Minga.Buffer.SaveState
   alias Minga.Buffer.State, as: BufState
 
   @type storage :: BufState.storage()
   @type metadata :: {mtime :: integer() | nil, size :: non_neg_integer() | nil}
   @type state_or_storage :: BufState.t() | storage()
-  @type saved_content_status :: :same | :changed | :unknown
+  @type saved_content_status :: SaveState.saved_content_status()
 
   @doc "Loads initial buffer content from storage or returns the supplied scratch content when no path is set."
   @spec load_content(storage(), String.t() | nil, String.t()) ::
@@ -87,43 +88,41 @@ defmodule Minga.Buffer.Persistence do
 
   @doc "Returns true when the backing file differs from the buffer's saved baseline."
   @spec changed_since_saved?(BufState.t(), integer() | nil, non_neg_integer() | nil) :: boolean()
-  def changed_since_saved?(%BufState{mtime: nil}, nil, _disk_size), do: false
-  def changed_since_saved?(%BufState{mtime: nil}, _disk_mtime, _disk_size), do: true
-  def changed_since_saved?(_state, nil, _disk_size), do: false
-
   def changed_since_saved?(%BufState{} = state, disk_mtime, disk_size) do
-    metadata_changed? = disk_mtime != state.mtime or disk_size != state.file_size
-
-    case saved_content_status(state) do
-      :same -> false
-      :changed -> true
-      :unknown -> metadata_changed?
-    end
+    BufState.changed_since_saved?(state, disk_mtime, disk_size, saved_content_status(state))
   end
 
   @doc "Fingerprints content with the algorithm used to track saved file baselines."
   @spec content_fingerprint(String.t()) :: binary()
-  def content_fingerprint(content), do: :crypto.hash(:sha256, content)
+  def content_fingerprint(content), do: SaveState.content_fingerprint(content)
 
   @doc "Returns a saved-content fingerprint only when a path and concrete mtime make the baseline meaningful."
   @spec saved_content_fingerprint(String.t() | nil, integer() | nil, String.t()) :: binary() | nil
-  def saved_content_fingerprint(path, mtime, content)
-      when is_binary(path) and is_integer(mtime) do
-    content_fingerprint(content)
+  def saved_content_fingerprint(path, mtime, content) do
+    SaveState.saved_content_fingerprint(path, mtime, content)
   end
 
-  def saved_content_fingerprint(_path, _mtime, _content), do: nil
-
   @spec saved_content_status(BufState.t()) :: saved_content_status()
-  defp saved_content_status(%BufState{file_path: path, file_hash: hash} = state)
-       when is_binary(path) and is_binary(hash) do
+  defp saved_content_status(%BufState{file_path: path} = state) when is_binary(path) do
+    hash = BufState.file_hash(state)
+
+    if is_binary(hash) do
+      saved_content_status_for_hash(state, path, hash)
+    else
+      :unknown
+    end
+  end
+
+  defp saved_content_status(_state), do: :unknown
+
+  @spec saved_content_status_for_hash(BufState.t(), String.t(), binary()) ::
+          saved_content_status()
+  defp saved_content_status_for_hash(state, path, hash) do
     case read_content(state, path) do
       {:ok, content} -> if content_fingerprint(content) == hash, do: :same, else: :changed
       {:error, _reason} -> :changed
     end
   end
-
-  defp saved_content_status(_state), do: :unknown
 
   @spec remote_unavailable(term()) :: {:error, {:remote_unavailable, term()}}
   defp remote_unavailable(reason), do: {:error, {:remote_unavailable, reason}}

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -278,6 +278,12 @@ defmodule Minga.Buffer.Process do
     GenServer.call(server, {:accept_saved_content, new_content}, @file_io_call_timeout)
   end
 
+  @doc "Acknowledges the current disk metadata after the user chooses to keep local edits."
+  @spec acknowledge_disk_change(GenServer.server()) :: :ok
+  def acknowledge_disk_change(server) do
+    GenServer.call(server, :acknowledge_disk_change, @file_io_call_timeout)
+  end
+
   @doc "Returns the full text content of the buffer."
   @spec content(GenServer.server()) :: String.t()
   def content(server) do
@@ -836,9 +842,7 @@ defmodule Minga.Buffer.Process do
           filetype: filetype,
           storage: storage,
           buffer_type: buffer_type,
-          mtime: mtime,
-          file_size: size,
-          file_hash: Persistence.saved_content_fingerprint(path, mtime, text),
+          save_state: BufState.loaded_save_state(path, {mtime, size}, text),
           name: Keyword.get(opts, :buffer_name),
           read_only: read_only,
           unlisted: Keyword.get(opts, :unlisted, false),
@@ -868,14 +872,10 @@ defmodule Minga.Buffer.Process do
         {mtime, size} = Persistence.file_metadata(state, file_path)
 
         new_state = %{
-          state
+          BufState.load_saved_content(state, file_path, {mtime, size}, text)
           | document: Document.new(text),
             file_path: file_path,
             filetype: filetype,
-            dirty: false,
-            mtime: mtime,
-            file_size: size,
-            file_hash: Persistence.content_fingerprint(text),
             decorations: Decorations.new(),
             undo_history: UndoHistory.clear(state.undo_history)
         }
@@ -1035,13 +1035,7 @@ defmodule Minga.Buffer.Process do
         :ok ->
           {new_mtime, new_size} = Persistence.file_metadata(state, state.file_path)
 
-          {:reply, :ok,
-           mark_saved(%{
-             state
-             | mtime: new_mtime,
-               file_size: new_size,
-               file_hash: Persistence.content_fingerprint(content)
-           })}
+          {:reply, :ok, mark_saved(state, {new_mtime, new_size}, content)}
 
         {:error, reason} ->
           {:reply, {:error, reason}, state}
@@ -1065,13 +1059,7 @@ defmodule Minga.Buffer.Process do
       :ok ->
         {new_mtime, new_size} = Persistence.file_metadata(state, state.file_path)
 
-        {:reply, :ok,
-         mark_saved(%{
-           state
-           | mtime: new_mtime,
-             file_size: new_size,
-             file_hash: Persistence.content_fingerprint(content)
-         })}
+        {:reply, :ok, mark_saved(state, {new_mtime, new_size}, content)}
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}
@@ -1107,13 +1095,9 @@ defmodule Minga.Buffer.Process do
         {new_mtime, new_size} = Persistence.file_metadata(state, state.file_path)
 
         new_state = %{
-          state
+          BufState.load_saved_content(state, state.file_path, {new_mtime, new_size}, text)
           | document: new_buf,
             filetype: filetype,
-            dirty: false,
-            mtime: new_mtime,
-            file_size: new_size,
-            file_hash: Persistence.content_fingerprint(text),
             undo_history: UndoHistory.clear(state.undo_history),
             decorations: Decorations.new()
         }
@@ -1135,14 +1119,7 @@ defmodule Minga.Buffer.Process do
         unregister_path(state.file_path)
         register_path(file_path)
 
-        {:reply, :ok,
-         mark_saved(%{
-           state
-           | file_path: file_path,
-             mtime: new_mtime,
-             file_size: new_size,
-             file_hash: Persistence.content_fingerprint(content)
-         })}
+        {:reply, :ok, mark_saved(%{state | file_path: file_path}, {new_mtime, new_size}, content)}
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}
@@ -1166,9 +1143,8 @@ defmodule Minga.Buffer.Process do
     new_buf = Document.new(new_content)
 
     new_state = %{
-      state
+      BufState.record_clean_change(state)
       | document: new_buf,
-        version: state.version + 1,
         change_log: ChangeLog.clear(state.change_log),
         decorations: Decorations.new()
     }
@@ -1182,14 +1158,8 @@ defmodule Minga.Buffer.Process do
     {mtime, size} = Persistence.file_metadata(state, state.file_path)
 
     new_state = %{
-      state
+      BufState.accept_saved_content(state, {mtime, size}, new_content)
       | document: new_buf,
-        dirty: false,
-        version: state.version + 1,
-        saved_version: state.version + 1,
-        mtime: mtime,
-        file_size: size,
-        file_hash: Persistence.content_fingerprint(new_content),
         undo_history: UndoHistory.clear(state.undo_history),
         change_log: ChangeLog.clear(state.change_log),
         decorations: Decorations.new()
@@ -1197,6 +1167,20 @@ defmodule Minga.Buffer.Process do
 
     defer_content_replaced(new_state)
     {:reply, :ok, new_state}
+  end
+
+  def handle_call(:acknowledge_disk_change, _from, %{file_path: nil} = state) do
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:acknowledge_disk_change, _from, state) do
+    case Persistence.file_info(state, state.file_path) do
+      {:ok, %{mtime: mtime, size: size}} ->
+        {:reply, :ok, BufState.acknowledge_disk_metadata(state, {mtime, size})}
+
+      {:error, _reason} ->
+        {:reply, :ok, state}
+    end
   end
 
   def handle_call(:content, _from, state) do
@@ -1241,7 +1225,7 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call(:dirty?, _from, state) do
-    {:reply, state.dirty, state}
+    {:reply, BufState.dirty?(state), state}
   end
 
   def handle_call(:consume_edit_deltas, _from, state) do
@@ -1255,7 +1239,7 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call(:version, _from, state) do
-    {:reply, state.version, state}
+    {:reply, BufState.version(state), state}
   end
 
   def handle_call(:file_path, _from, state) do
@@ -1393,11 +1377,11 @@ defmodule Minga.Buffer.Process do
       file_path: state.file_path,
       filetype: state.filetype,
       buffer_type: state.buffer_type,
-      dirty: state.dirty,
+      dirty: BufState.dirty?(state),
       name: state.name,
       read_only: state.read_only,
       first_line_byte_offset: first_line_byte_offset,
-      version: state.version
+      version: BufState.version(state)
     }
 
     {:reply, snapshot, state}
@@ -1473,7 +1457,7 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call(:undo, _from, state) do
-    case UndoHistory.undo(state.undo_history, state.version, state.document) do
+    case UndoHistory.undo(state.undo_history, BufState.version(state), state.document) do
       :empty ->
         {:reply, :ok, state}
 
@@ -1482,9 +1466,8 @@ defmodule Minga.Buffer.Process do
 
         new_state =
           %{
-            state
+            BufState.restore_version(state, restore.version)
             | document: restore.document,
-              version: restore.version,
               undo_history: undo_history
           }
           |> sync_dirty()
@@ -1496,7 +1479,7 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call(:redo, _from, state) do
-    case UndoHistory.redo(state.undo_history, state.version, state.document) do
+    case UndoHistory.redo(state.undo_history, BufState.version(state), state.document) do
       :empty ->
         {:reply, :ok, state}
 
@@ -1505,9 +1488,8 @@ defmodule Minga.Buffer.Process do
 
         new_state =
           %{
-            state
+            BufState.restore_version(state, restore.version)
             | document: restore.document,
-              version: restore.version,
               undo_history: undo_history
           }
           |> sync_dirty()
@@ -1566,9 +1548,8 @@ defmodule Minga.Buffer.Process do
     new_decs = decoration_fn.(Decorations.new())
 
     new_state = %{
-      state
+      BufState.record_clean_change(state)
       | document: new_doc,
-        version: state.version + 1,
         change_log: ChangeLog.clear(state.change_log),
         decorations: new_decs
     }
@@ -1616,24 +1597,12 @@ defmodule Minga.Buffer.Process do
   @impl true
   def handle_info(
         :write_swap,
-        %{buffer_type: :file, file_path: path, dirty: true, swap_dir: dir} = state
+        %{buffer_type: :file, file_path: path, swap_dir: dir} = state
       )
       when is_binary(path) and is_binary(dir) do
-    content = Document.content(state.document)
-    swap_opts = [swap_dir: dir]
-
-    Task.start(fn ->
-      case Minga.Session.write_swap(path, content, swap_opts) do
-        :ok ->
-          :ok
-
-        {:error, reason} ->
-          Minga.Log.warning(
-            :editor,
-            "Failed to write swap file for #{Path.basename(path)}: #{inspect(reason)}"
-          )
-      end
-    end)
+    if BufState.dirty?(state) do
+      start_swap_write_task(state, path, dir)
+    end
 
     {:noreply, %{state | swap_timer: nil}}
   end
@@ -1644,10 +1613,10 @@ defmodule Minga.Buffer.Process do
 
   def handle_info(
         {:auto_save, token},
-        %{buffer_type: :file, file_path: path, dirty: true, auto_save_token: token} = state
+        %{buffer_type: :file, file_path: path, auto_save_token: token} = state
       )
       when is_binary(path) do
-    if auto_save_enabled?(state) do
+    if BufState.dirty?(state) and auto_save_enabled?(state) do
       auto_save_file(state, path)
     else
       {:noreply, clear_auto_save_timer(state)}
@@ -1698,6 +1667,32 @@ defmodule Minga.Buffer.Process do
 
   # ── Private ──
 
+  @spec start_swap_write_task(state(), String.t(), String.t()) :: :ok
+  defp start_swap_write_task(state, path, dir) do
+    content = Document.content(state.document)
+    swap_opts = [swap_dir: dir]
+
+    Task.start(fn ->
+      write_swap_file(path, content, swap_opts)
+    end)
+
+    :ok
+  end
+
+  @spec write_swap_file(String.t(), String.t(), keyword()) :: :ok
+  defp write_swap_file(path, content, swap_opts) do
+    case Minga.Session.write_swap(path, content, swap_opts) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Minga.Log.warning(
+          :editor,
+          "Failed to write swap file for #{Path.basename(path)}: #{inspect(reason)}"
+        )
+    end
+  end
+
   # Defers a :content_replaced broadcast to a subsequent handle_info turn.
   # Broadcasting inside handle_call would deadlock if any subscriber calls
   # back into this GenServer. The self-send pattern unblocks the caller
@@ -1736,7 +1731,7 @@ defmodule Minga.Buffer.Process do
          buffer: self(),
          delta: delta,
          source: source,
-         version: state.version
+         version: BufState.version(state)
        }}
     )
 
@@ -1805,7 +1800,7 @@ defmodule Minga.Buffer.Process do
   @spec push_undo(state(), Document.t(), BufState.edit_source()) :: state()
   defp push_undo(state, new_buf, source) do
     undo_history =
-      UndoHistory.record_edit(state.undo_history, state.version, state.document, source)
+      UndoHistory.record_edit(state.undo_history, BufState.version(state), state.document, source)
 
     %{state | document: new_buf, undo_history: undo_history}
   end
@@ -1813,7 +1808,12 @@ defmodule Minga.Buffer.Process do
   @spec push_undo_force(state(), Document.t(), BufState.edit_source()) :: state()
   defp push_undo_force(state, new_buf, source) do
     undo_history =
-      UndoHistory.record_edit_force(state.undo_history, state.version, state.document, source)
+      UndoHistory.record_edit_force(
+        state.undo_history,
+        BufState.version(state),
+        state.document,
+        source
+      )
 
     %{state | document: new_buf, undo_history: undo_history}
   end
@@ -1843,16 +1843,16 @@ defmodule Minga.Buffer.Process do
   defp sync_dirty(state) do
     state = BufState.sync_dirty(state)
 
-    if state.dirty do
+    if BufState.dirty?(state) do
       schedule_auto_save(state)
     else
       cancel_auto_save_timer(state)
     end
   end
 
-  @spec mark_saved(state()) :: state()
-  defp mark_saved(state) do
-    state = BufState.mark_saved(state)
+  @spec mark_saved(state(), Minga.Buffer.SaveState.metadata(), String.t()) :: state()
+  defp mark_saved(state, metadata, content) do
+    state = BufState.mark_saved(state, metadata, content)
     :ok = delete_swap_file(state)
     state = cancel_swap_timer(state)
     cancel_auto_save_timer(state)
@@ -1879,10 +1879,10 @@ defmodule Minga.Buffer.Process do
   end
 
   @spec apply_option_change(state(), atom()) :: state()
-  defp apply_option_change(%{dirty: true} = state, :auto_save_delay_ms),
-    do: schedule_auto_save(state)
+  defp apply_option_change(state, :auto_save_delay_ms) do
+    if BufState.dirty?(state), do: schedule_auto_save(state), else: cancel_auto_save_timer(state)
+  end
 
-  defp apply_option_change(state, :auto_save_delay_ms), do: cancel_auto_save_timer(state)
   defp apply_option_change(state, _name), do: state
 
   @spec auto_save_file(state(), String.t()) :: {:noreply, state()}
@@ -1891,11 +1891,12 @@ defmodule Minga.Buffer.Process do
       {:ok, %{mtime: disk_mtime, size: disk_size}} ->
         maybe_write_auto_save_file(state, path, disk_mtime, disk_size)
 
-      {:error, :enoent} when is_nil(state.mtime) ->
-        write_auto_save_file(state, path)
-
       {:error, :enoent} ->
-        skip_auto_save(state, path, "file was deleted on disk")
+        if is_nil(BufState.mtime(state)) do
+          write_auto_save_file(state, path)
+        else
+          skip_auto_save(state, path, "file was deleted on disk")
+        end
 
       {:error, reason} ->
         skip_auto_save(state, path, "could not stat file: #{inspect(reason)}")
@@ -1931,13 +1932,7 @@ defmodule Minga.Buffer.Process do
       :ok ->
         {new_mtime, new_size} = Persistence.file_metadata(state, path)
 
-        new_state =
-          mark_saved(%{
-            state
-            | mtime: new_mtime,
-              file_size: new_size,
-              file_hash: Persistence.content_fingerprint(content)
-          })
+        new_state = mark_saved(state, {new_mtime, new_size}, content)
 
         log_to_messages(new_state, "Auto-saved: #{display_path(path)}", :info)
         broadcast_buffer_saved(new_state, path)

--- a/lib/minga/buffer/save_state.ex
+++ b/lib/minga/buffer/save_state.ex
@@ -1,0 +1,158 @@
+defmodule Minga.Buffer.SaveState do
+  @moduledoc """
+  Tracks whether a buffer has diverged from its last saved baseline.
+
+  This module owns the pure save-point model: mutation versions, the saved version, dirty calculation, and the saved file fingerprint used by persistence conflict checks. It does not read or write files; `Minga.Buffer.Persistence` still owns storage I/O.
+  """
+
+  @type metadata :: {mtime :: integer() | nil, size :: non_neg_integer() | nil}
+  @type saved_content_status :: :same | :changed | :unknown
+
+  @opaque t :: %__MODULE__{
+            dirty: boolean(),
+            version: non_neg_integer(),
+            saved_version: non_neg_integer(),
+            mtime: integer() | nil,
+            file_size: non_neg_integer() | nil,
+            file_hash: binary() | nil
+          }
+
+  defstruct dirty: false,
+            version: 0,
+            saved_version: 0,
+            mtime: nil,
+            file_size: nil,
+            file_hash: nil
+
+  @doc "Returns a clean save state for a new buffer with no saved file baseline."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Returns a clean save state for content loaded from storage."
+  @spec loaded(String.t() | nil, metadata(), String.t()) :: t()
+  def loaded(path, {mtime, file_size}, content) do
+    %__MODULE__{
+      mtime: mtime,
+      file_size: file_size,
+      file_hash: saved_content_fingerprint(path, mtime, content)
+    }
+  end
+
+  @doc "Marks the buffer as changed and advances the mutation version."
+  @spec mark_changed(t()) :: t()
+  def mark_changed(%__MODULE__{} = save_state) do
+    new_version = save_state.version + 1
+    %{save_state | dirty: new_version != save_state.saved_version, version: new_version}
+  end
+
+  @doc "Records a content change that should not by itself make a clean buffer dirty."
+  @spec record_clean_change(t()) :: t()
+  def record_clean_change(%__MODULE__{dirty: true} = save_state) do
+    %{save_state | version: save_state.version + 1}
+  end
+
+  def record_clean_change(%__MODULE__{} = save_state) do
+    new_version = save_state.version + 1
+    %{save_state | version: new_version, saved_version: new_version}
+  end
+
+  @doc "Restores the mutation version and recalculates dirty state from the saved version."
+  @spec restore_version(t(), non_neg_integer()) :: t()
+  def restore_version(%__MODULE__{} = save_state, version)
+      when is_integer(version) and version >= 0 do
+    %{save_state | version: version, dirty: version != save_state.saved_version}
+  end
+
+  @doc "Acknowledges the latest disk metadata while preserving the saved content fingerprint."
+  @spec acknowledge_disk_metadata(t(), metadata()) :: t()
+  def acknowledge_disk_metadata(%__MODULE__{} = save_state, {mtime, file_size}) do
+    %{save_state | mtime: mtime, file_size: file_size}
+  end
+
+  @doc "Records the current version as the saved baseline."
+  @spec mark_saved(t(), metadata(), String.t()) :: t()
+  def mark_saved(%__MODULE__{} = save_state, {mtime, file_size}, content) do
+    %{
+      save_state
+      | dirty: false,
+        saved_version: save_state.version,
+        mtime: mtime,
+        file_size: file_size,
+        file_hash: content_fingerprint(content)
+    }
+  end
+
+  @doc "Accepts replacement content as a new saved baseline and advances the mutation version once."
+  @spec accept_saved_content(t(), metadata(), String.t()) :: t()
+  def accept_saved_content(%__MODULE__{} = save_state, {mtime, file_size}, content) do
+    new_version = save_state.version + 1
+
+    %{
+      save_state
+      | dirty: false,
+        version: new_version,
+        saved_version: new_version,
+        mtime: mtime,
+        file_size: file_size,
+        file_hash: content_fingerprint(content)
+    }
+  end
+
+  @doc "Returns true when the backing file differs from the saved baseline."
+  @spec changed_since_saved?(
+          t(),
+          integer() | nil,
+          non_neg_integer() | nil,
+          saved_content_status()
+        ) :: boolean()
+  def changed_since_saved?(%__MODULE__{mtime: nil}, nil, _disk_size, _status), do: false
+  def changed_since_saved?(%__MODULE__{mtime: nil}, _disk_mtime, _disk_size, _status), do: true
+  def changed_since_saved?(_save_state, nil, _disk_size, _status), do: false
+
+  def changed_since_saved?(%__MODULE__{} = save_state, disk_mtime, disk_size, status) do
+    metadata_changed? = disk_mtime != save_state.mtime or disk_size != save_state.file_size
+
+    case status do
+      :same -> false
+      :changed -> true
+      :unknown -> metadata_changed?
+    end
+  end
+
+  @doc "Returns whether the buffer differs from its saved version."
+  @spec dirty?(t()) :: boolean()
+  def dirty?(%__MODULE__{} = save_state), do: save_state.dirty
+
+  @doc "Returns the current mutation version."
+  @spec version(t()) :: non_neg_integer()
+  def version(%__MODULE__{} = save_state), do: save_state.version
+
+  @doc "Returns the saved baseline version."
+  @spec saved_version(t()) :: non_neg_integer()
+  def saved_version(%__MODULE__{} = save_state), do: save_state.saved_version
+
+  @doc "Returns the saved file mtime."
+  @spec mtime(t()) :: integer() | nil
+  def mtime(%__MODULE__{} = save_state), do: save_state.mtime
+
+  @doc "Returns the saved file size."
+  @spec file_size(t()) :: non_neg_integer() | nil
+  def file_size(%__MODULE__{} = save_state), do: save_state.file_size
+
+  @doc "Returns the saved content fingerprint, if one is known."
+  @spec file_hash(t()) :: binary() | nil
+  def file_hash(%__MODULE__{} = save_state), do: save_state.file_hash
+
+  @doc "Fingerprints content with the algorithm used to track saved file baselines."
+  @spec content_fingerprint(String.t()) :: binary()
+  def content_fingerprint(content), do: :crypto.hash(:sha256, content)
+
+  @doc "Returns a saved-content fingerprint only when a path and concrete mtime make the baseline meaningful."
+  @spec saved_content_fingerprint(String.t() | nil, integer() | nil, String.t()) :: binary() | nil
+  def saved_content_fingerprint(path, mtime, content)
+      when is_binary(path) and is_integer(mtime) do
+    content_fingerprint(content)
+  end
+
+  def saved_content_fingerprint(_path, _mtime, _content), do: nil
+end

--- a/lib/minga/buffer/state.ex
+++ b/lib/minga/buffer/state.ex
@@ -8,10 +8,12 @@ defmodule Minga.Buffer.State do
   alias Minga.Buffer.ChangeLog
   alias Minga.Buffer.Document
   alias Minga.Buffer.EditSource
+  alias Minga.Buffer.SaveState
   alias Minga.Buffer.UndoHistory
   alias Minga.Core.Decorations
 
   @default_change_log ChangeLog.new()
+  @default_save_state SaveState.new()
   @default_undo_history UndoHistory.new()
 
   @typedoc """
@@ -37,12 +39,7 @@ defmodule Minga.Buffer.State do
             filetype: :text,
             storage: :local,
             buffer_type: :file,
-            dirty: false,
-            version: 0,
-            saved_version: 0,
-            mtime: nil,
-            file_size: nil,
-            file_hash: nil,
+            save_state: @default_save_state,
             undo_history: @default_undo_history,
             name: nil,
             read_only: false,
@@ -65,12 +62,7 @@ defmodule Minga.Buffer.State do
           filetype: atom(),
           storage: storage(),
           buffer_type: buffer_type(),
-          dirty: boolean(),
-          version: non_neg_integer(),
-          saved_version: non_neg_integer(),
-          mtime: integer() | nil,
-          file_size: non_neg_integer() | nil,
-          file_hash: binary() | nil,
+          save_state: SaveState.t(),
           undo_history: UndoHistory.t(),
           name: String.t() | nil,
           read_only: boolean(),
@@ -88,26 +80,88 @@ defmodule Minga.Buffer.State do
           events_registry: Minga.Events.registry()
         }
 
-  @doc "Marks the buffer as having unsaved changes (bumps version)."
+  @doc "Marks the buffer as having unsaved changes and advances the mutation version."
   @spec mark_dirty(t()) :: t()
   def mark_dirty(%__MODULE__{} = state) do
-    new_version = state.version + 1
-    %{state | dirty: new_version != state.saved_version, version: new_version}
+    %{state | save_state: SaveState.mark_changed(state.save_state)}
   end
 
-  @doc """
-  Sets the dirty flag based on whether the given version matches the saved
-  version. Used by undo/redo which restore a version from history rather
-  than incrementing.
-  """
+  @doc "Records a content change that should not by itself make a clean buffer dirty."
+  @spec record_clean_change(t()) :: t()
+  def record_clean_change(%__MODULE__{} = state) do
+    %{state | save_state: SaveState.record_clean_change(state.save_state)}
+  end
+
+  @doc "Restores the mutation version and recalculates dirty state from the saved version."
+  @spec restore_version(t(), non_neg_integer()) :: t()
+  def restore_version(%__MODULE__{} = state, version) do
+    %{state | save_state: SaveState.restore_version(state.save_state, version)}
+  end
+
+  @doc "Recalculates dirty state from the current mutation version and saved version."
   @spec sync_dirty(t()) :: t()
   def sync_dirty(%__MODULE__{} = state) do
-    %{state | dirty: state.version != state.saved_version}
+    restore_version(state, version(state))
+  end
+
+  @doc "Returns save state for content loaded from storage."
+  @spec loaded_save_state(String.t() | nil, SaveState.metadata(), String.t()) :: SaveState.t()
+  def loaded_save_state(path, metadata, content) do
+    SaveState.loaded(path, metadata, content)
+  end
+
+  @doc "Replaces save tracking with a clean baseline for loaded content."
+  @spec load_saved_content(t(), String.t() | nil, SaveState.metadata(), String.t()) :: t()
+  def load_saved_content(%__MODULE__{} = state, path, metadata, content) do
+    %{state | save_state: SaveState.loaded(path, metadata, content)}
+  end
+
+  @doc "Acknowledges disk metadata without changing dirty, version, or the saved content fingerprint."
+  @spec acknowledge_disk_metadata(t(), SaveState.metadata()) :: t()
+  def acknowledge_disk_metadata(%__MODULE__{} = state, metadata) do
+    %{state | save_state: SaveState.acknowledge_disk_metadata(state.save_state, metadata)}
+  end
+
+  @doc "Returns true when the backing file differs from the saved baseline."
+  @spec changed_since_saved?(
+          t(),
+          integer() | nil,
+          non_neg_integer() | nil,
+          SaveState.saved_content_status()
+        ) :: boolean()
+  def changed_since_saved?(%__MODULE__{} = state, disk_mtime, disk_size, status) do
+    SaveState.changed_since_saved?(state.save_state, disk_mtime, disk_size, status)
   end
 
   @doc "Records the current version as the save point for dirty tracking."
-  @spec mark_saved(t()) :: t()
-  def mark_saved(%__MODULE__{} = state) do
-    %{state | dirty: false, saved_version: state.version}
+  @spec mark_saved(t(), SaveState.metadata(), String.t()) :: t()
+  def mark_saved(%__MODULE__{} = state, metadata, content) do
+    %{state | save_state: SaveState.mark_saved(state.save_state, metadata, content)}
   end
+
+  @doc "Accepts replacement content as a new saved baseline and advances the mutation version once."
+  @spec accept_saved_content(t(), SaveState.metadata(), String.t()) :: t()
+  def accept_saved_content(%__MODULE__{} = state, metadata, content) do
+    %{state | save_state: SaveState.accept_saved_content(state.save_state, metadata, content)}
+  end
+
+  @doc "Returns whether the buffer differs from its saved version."
+  @spec dirty?(t()) :: boolean()
+  def dirty?(%__MODULE__{} = state), do: SaveState.dirty?(state.save_state)
+
+  @doc "Returns the current mutation version."
+  @spec version(t()) :: non_neg_integer()
+  def version(%__MODULE__{} = state), do: SaveState.version(state.save_state)
+
+  @doc "Returns the saved file mtime."
+  @spec mtime(t()) :: integer() | nil
+  def mtime(%__MODULE__{} = state), do: SaveState.mtime(state.save_state)
+
+  @doc "Returns the saved file size."
+  @spec file_size(t()) :: non_neg_integer() | nil
+  def file_size(%__MODULE__{} = state), do: SaveState.file_size(state.save_state)
+
+  @doc "Returns the saved content fingerprint, if one is known."
+  @spec file_hash(t()) :: binary() | nil
+  def file_hash(%__MODULE__{} = state), do: SaveState.file_hash(state.save_state)
 end

--- a/lib/minga_editor/file_watcher_helpers.ex
+++ b/lib/minga_editor/file_watcher_helpers.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.FileWatcherHelpers do
   """
 
   alias Minga.Buffer
+  alias Minga.Buffer.State, as: BufState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
@@ -59,20 +60,70 @@ defmodule MingaEditor.FileWatcherHelpers do
 
   # ── Private helpers ──────────────────────────────────────────────────────
 
-  @spec handle_change(state(), pid(), String.t(), map(), integer() | nil, non_neg_integer() | nil) ::
+  @spec handle_change(
+          state(),
+          pid(),
+          String.t(),
+          BufState.t(),
+          integer() | nil,
+          non_neg_integer() | nil
+        ) ::
           state()
   defp handle_change(state, _buf, _path, _buf_state, nil, _size), do: state
-  defp handle_change(state, _buf, _path, %{mtime: nil}, _mtime, _size), do: state
 
-  defp handle_change(state, _buf, _path, %{mtime: mtime, file_size: size}, mtime, size), do: state
+  defp handle_change(state, buf, path, buf_state, disk_mtime, disk_size) do
+    handle_known_change(
+      state,
+      buf,
+      path,
+      disk_mtime,
+      disk_size,
+      BufState.mtime(buf_state),
+      BufState.file_size(buf_state),
+      BufState.dirty?(buf_state)
+    )
+  end
 
-  defp handle_change(state, buf, path, %{dirty: false}, _mtime, _size) do
+  @spec handle_known_change(
+          state(),
+          pid(),
+          String.t(),
+          integer(),
+          non_neg_integer() | nil,
+          integer() | nil,
+          non_neg_integer() | nil,
+          boolean()
+        ) :: state()
+  defp handle_known_change(state, _buf, _path, _disk_mtime, _disk_size, nil, _saved_size, _dirty),
+    do: state
+
+  defp handle_known_change(state, _buf, _path, mtime, size, mtime, size, _dirty), do: state
+
+  defp handle_known_change(
+         state,
+         buf,
+         path,
+         _disk_mtime,
+         _disk_size,
+         _saved_mtime,
+         _saved_size,
+         false
+       ) do
     Buffer.reload(buf)
     name = Path.basename(path)
     EditorState.set_status(state, "#{name} reloaded (changed on disk)")
   end
 
-  defp handle_change(state, buf, path, _buf_state, _mtime, _size) do
+  defp handle_known_change(
+         state,
+         buf,
+         path,
+         _disk_mtime,
+         _disk_size,
+         _saved_mtime,
+         _saved_size,
+         true
+       ) do
     name = Path.basename(path)
 
     state = ModalOverlay.open(state, :conflict, ConflictPayload.new(buf, path))

--- a/lib/minga_editor/input/conflict_prompt.ex
+++ b/lib/minga_editor/input/conflict_prompt.ex
@@ -43,15 +43,7 @@ defmodule MingaEditor.Input.ConflictPrompt do
         _mods
       )
       when is_pid(buf) do
-    buf_state = :sys.get_state(buf)
-
-    case File.stat(buf_state.file_path, time: :posix) do
-      {:ok, %{mtime: mtime, size: size}} ->
-        :sys.replace_state(buf, fn s -> %{s | mtime: mtime, file_size: size} end)
-
-      {:error, _} ->
-        :ok
-    end
+    Buffer.acknowledge_disk_change(buf)
 
     {:handled, state |> ModalOverlay.dismiss() |> EditorState.clear_status()}
   end

--- a/test/minga/buffer/auto_save_test.exs
+++ b/test/minga/buffer/auto_save_test.exs
@@ -6,6 +6,7 @@ defmodule Minga.Buffer.AutoSaveTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Buffer.State, as: BufState
   alias Minga.Events
   alias Minga.Events.LogMessageEvent
 
@@ -195,7 +196,7 @@ defmodule Minga.Buffer.AutoSaveTest do
     {:ok, pid} = BufferProcess.start_link(file_path: path)
     assert {:ok, @delay_ms} = BufferProcess.set_option(pid, :auto_save_delay_ms, @delay_ms)
 
-    original_mtime = :sys.get_state(pid).mtime
+    original_mtime = pid |> :sys.get_state() |> BufState.mtime()
     :ok = BufferProcess.insert_text(pid, "!")
     token = :sys.get_state(pid).auto_save_token
     File.write!(path, "HELLO")

--- a/test/minga/buffer/mtime_test.exs
+++ b/test/minga/buffer/mtime_test.exs
@@ -6,6 +6,7 @@ defmodule Minga.Buffer.MtimeTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Buffer.State, as: BufState
 
   @tag :tmp_dir
   test "opening a file records its mtime", %{tmp_dir: tmp_dir} do
@@ -16,14 +17,14 @@ defmodule Minga.Buffer.MtimeTest do
     {:ok, buf} = BufferProcess.start_link(file_path: path)
     state = :sys.get_state(buf)
 
-    assert state.mtime == disk_mtime
+    assert BufState.mtime(state) == disk_mtime
   end
 
   test "scratch buffer has nil mtime" do
     {:ok, buf} = BufferProcess.start_link(content: "scratch")
     state = :sys.get_state(buf)
 
-    assert state.mtime == nil
+    assert BufState.mtime(state) == nil
   end
 
   @tag :tmp_dir
@@ -39,8 +40,8 @@ defmodule Minga.Buffer.MtimeTest do
     :ok = BufferProcess.save(buf)
 
     new_state = :sys.get_state(buf)
-    assert new_state.mtime >= old_state.mtime
-    assert new_state.dirty == false
+    assert BufState.mtime(new_state) >= BufState.mtime(old_state)
+    assert BufState.dirty?(new_state) == false
   end
 
   @tag :tmp_dir
@@ -58,7 +59,7 @@ defmodule Minga.Buffer.MtimeTest do
 
     assert result == {:error, :file_changed}
     state = :sys.get_state(buf)
-    assert state.dirty == true
+    assert BufState.dirty?(state) == true
   end
 
   @tag :tmp_dir
@@ -67,7 +68,7 @@ defmodule Minga.Buffer.MtimeTest do
     File.write!(path, "original")
 
     {:ok, buf} = BufferProcess.start_link(file_path: path)
-    original_mtime = :sys.get_state(buf).mtime
+    original_mtime = buf |> :sys.get_state() |> BufState.mtime()
     File.touch!(path, original_mtime + 10)
 
     BufferProcess.insert_char(buf, "x")
@@ -94,7 +95,7 @@ defmodule Minga.Buffer.MtimeTest do
     assert File.read!(path) == "forcedoriginal"
 
     state = :sys.get_state(buf)
-    assert state.dirty == false
+    assert BufState.dirty?(state) == false
   end
 
   @tag :tmp_dir
@@ -188,7 +189,7 @@ defmodule Minga.Buffer.MtimeTest do
     :ok = BufferProcess.save_as(buf, path)
 
     state = :sys.get_state(buf)
-    assert state.mtime != nil
+    assert BufState.mtime(state) != nil
     assert File.exists?(path)
   end
 
@@ -200,7 +201,7 @@ defmodule Minga.Buffer.MtimeTest do
     {:ok, buf} = BufferProcess.start_link(file_path: path)
     state = :sys.get_state(buf)
 
-    assert state.file_size == 5
+    assert BufState.file_size(state) == 5
   end
 
   @tag :tmp_dir
@@ -212,6 +213,6 @@ defmodule Minga.Buffer.MtimeTest do
     :ok = BufferProcess.open(buf, path)
 
     state = :sys.get_state(buf)
-    assert state.mtime != nil
+    assert BufState.mtime(state) != nil
   end
 end

--- a/test/minga/buffer/persistence_test.exs
+++ b/test/minga/buffer/persistence_test.exs
@@ -3,6 +3,7 @@ defmodule Minga.Buffer.PersistenceTest do
 
   alias Minga.Buffer.Document
   alias Minga.Buffer.Persistence
+  alias Minga.Buffer.SaveState
   alias Minga.Buffer.State, as: BufState
 
   @moduletag :tmp_dir
@@ -55,9 +56,7 @@ defmodule Minga.Buffer.PersistenceTest do
     %BufState{
       document: Document.new(content),
       file_path: path,
-      mtime: mtime,
-      file_size: size,
-      file_hash: Persistence.content_fingerprint(content)
+      save_state: SaveState.loaded(path, {mtime, size}, content)
     }
   end
 end

--- a/test/minga/buffer/save_state_test.exs
+++ b/test/minga/buffer/save_state_test.exs
@@ -1,0 +1,97 @@
+defmodule Minga.Buffer.SaveStateTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.SaveState
+
+  describe "dirty tracking" do
+    test "mark_changed advances version and marks dirty until the saved version is restored" do
+      save_state = SaveState.new()
+
+      changed = SaveState.mark_changed(save_state)
+      assert SaveState.version(changed) == 1
+      assert SaveState.dirty?(changed)
+
+      restored = SaveState.restore_version(changed, 0)
+      refute SaveState.dirty?(restored)
+    end
+
+    test "mark_saved records the current version as the clean baseline" do
+      save_state = SaveState.new() |> SaveState.mark_changed()
+
+      saved = SaveState.mark_saved(save_state, {123, 5}, "hello")
+
+      refute SaveState.dirty?(saved)
+      assert SaveState.saved_version(saved) == SaveState.version(saved)
+      assert SaveState.mtime(saved) == 123
+      assert SaveState.file_size(saved) == 5
+      assert SaveState.file_hash(saved) == SaveState.content_fingerprint("hello")
+    end
+
+    test "record_clean_change preserves clean buffers as clean while advancing version" do
+      save_state = SaveState.new()
+
+      changed = SaveState.record_clean_change(save_state)
+
+      refute SaveState.dirty?(changed)
+      assert SaveState.version(changed) == 1
+      assert SaveState.saved_version(changed) == 1
+    end
+
+    test "record_clean_change preserves an existing dirty state" do
+      save_state = SaveState.new() |> SaveState.mark_changed()
+
+      changed = SaveState.record_clean_change(save_state)
+
+      assert SaveState.dirty?(changed)
+      assert SaveState.version(changed) == 2
+      assert SaveState.saved_version(changed) == 0
+    end
+  end
+
+  describe "saved baseline tracking" do
+    test "loaded records metadata and fingerprint only for meaningful file baselines" do
+      save_state = SaveState.loaded("file.txt", {123, 5}, "hello")
+
+      assert SaveState.mtime(save_state) == 123
+      assert SaveState.file_size(save_state) == 5
+      assert SaveState.file_hash(save_state) == SaveState.content_fingerprint("hello")
+
+      scratch = SaveState.loaded(nil, {nil, nil}, "scratch")
+      assert SaveState.file_hash(scratch) == nil
+    end
+
+    test "accept_saved_content advances version and makes replacement content clean" do
+      save_state = SaveState.new() |> SaveState.mark_changed()
+
+      accepted = SaveState.accept_saved_content(save_state, {234, 7}, "content")
+
+      refute SaveState.dirty?(accepted)
+      assert SaveState.version(accepted) == 2
+      assert SaveState.saved_version(accepted) == 2
+      assert SaveState.mtime(accepted) == 234
+      assert SaveState.file_size(accepted) == 7
+      assert SaveState.file_hash(accepted) == SaveState.content_fingerprint("content")
+    end
+  end
+
+  describe "conflict detection" do
+    test "same saved content ignores metadata-only changes" do
+      save_state = SaveState.loaded("file.txt", {123, 5}, "hello")
+
+      refute SaveState.changed_since_saved?(save_state, 456, 5, :same)
+    end
+
+    test "changed saved content reports a conflict" do
+      save_state = SaveState.loaded("file.txt", {123, 5}, "hello")
+
+      assert SaveState.changed_since_saved?(save_state, 123, 5, :changed)
+    end
+
+    test "unknown saved content falls back to metadata comparison" do
+      save_state = SaveState.loaded(nil, {123, 5}, "hello")
+
+      refute SaveState.changed_since_saved?(save_state, 123, 5, :unknown)
+      assert SaveState.changed_since_saved?(save_state, 456, 5, :unknown)
+    end
+  end
+end

--- a/test/minga_editor/file_change_test.exs
+++ b/test/minga_editor/file_change_test.exs
@@ -106,6 +106,13 @@ defmodule MingaEditor.FileChangeTest do
 
     state = :sys.get_state(ctx.editor)
     refute MingaEditor.State.ModalOverlay.match(state.shell_state.modal, :conflict)
+
+    send(ctx.editor, {:file_changed_on_disk, Path.expand(path)})
+    _ = :sys.get_state(ctx.editor)
+    state = :sys.get_state(ctx.editor)
+    refute MingaEditor.State.ModalOverlay.match(state.shell_state.modal, :conflict)
+
+    assert BufferProcess.save(ctx.buffer) == {:error, :file_changed}
   end
 
   @tag :tmp_dir


### PR DESCRIPTION
# TL;DR
Extracts buffer save-point bookkeeping into `Minga.Buffer.SaveState`, a pure domain module for dirty state, mutation versions, saved versions, file metadata, saved-content fingerprints, and conflict-check decisions.

## Changes
- Added opaque `Minga.Buffer.SaveState` for dirty/version/save-baseline state and pure conflict-decision logic.
- Replaced top-level `dirty`, `version`, `saved_version`, `mtime`, `file_size`, and `file_hash` fields in `Minga.Buffer.State` with `save_state`.
- Routed buffer process save/dirty/version transitions through `Minga.Buffer.State` and `SaveState` helpers.
- Kept persistence I/O in `Minga.Buffer.Persistence`, while delegating pure saved-baseline conflict decisions to `SaveState` via `BufState`.
- Added `Buffer.acknowledge_disk_change/1` so the conflict prompt no longer mutates buffer internals with `:sys.replace_state`.
- Updated file watcher conflict handling to read saved metadata and dirty state through `BufState` accessors.
- Added direct `SaveState` tests and a keep-local regression proving repeated watcher prompts are suppressed while normal save still reports `{:error, :file_changed}`.

## Verification
- `mix compile --warnings-as-errors`
- `mix test.llm test/minga/buffer`
- `mix test.llm test/minga_editor/file_change_test.exs test/minga_editor/input/handler_test.exs`
- `make lint`
- `mix test.llm` (8645 tests, 97 properties, 52 doctests, 0 failures)
- After rebasing onto merged main: `mix compile --warnings-as-errors` and focused save/file-change tests passed.

## Review Notes
- `prtk-code-reviewer`: no issues.
- `prtk-type-design-analyzer`: initially flagged metadata acknowledgement naming and external conflict-prompt mutation; fixed with `acknowledge_disk_metadata` and `Buffer.acknowledge_disk_change/1`.
- Targeted type-design re-check: PASS.
- Final reviewer gate: PASS.
