### PR TITLE
refactor(editor): route workspace state updates through owners

### DIFF
--- a/credo/checks/no_direct_state_machine_write_check.exs
+++ b/credo/checks/no_direct_state_machine_write_check.exs
@@ -77,10 +77,13 @@ defmodule Minga.Credo.NoDirectStateMachineWriteCheck do
       []
     else
       gated_fields = Params.get(params, :gated_fields, __MODULE__)
+      guarded_struct_fields = Params.get(params, :guarded_struct_fields, __MODULE__)
       issue_meta = IssueMeta.for(source_file, params)
 
       source_file
-      |> Credo.Code.prewalk(&find_direct_writes(&1, &2, issue_meta, gated_fields))
+      |> Credo.Code.prewalk(
+        &find_direct_writes(&1, &2, issue_meta, gated_fields, guarded_struct_fields)
+      )
       |> List.flatten()
     end
   end
@@ -90,41 +93,122 @@ defmodule Minga.Credo.NoDirectStateMachineWriteCheck do
   #   {:%{}, meta, [{:|, _, [map, [key: val]]}]}
   # We look for gated field names in the keyword list after the pipe.
   defp find_direct_writes(
-         {:%{}, _meta, [{:|, _, [_map, updates]}]} = ast,
+         {:%{}, _meta, [{:|, _, [map, updates]}]} = ast,
          issues,
          issue_meta,
-         gated_fields
+         gated_fields,
+         guarded_struct_fields
        )
        when is_list(updates) do
     new_issues =
-      updates
-      |> Enum.filter(fn
-        {field, _value} when is_atom(field) -> field in gated_fields
-        _ -> false
-      end)
-      |> Enum.map(fn {field, value} ->
-        line_no = extract_line(value) || extract_line(ast)
-
-        format_issue(issue_meta,
-          message:
-            "Direct write to `#{field}:` bypasses the state machine gate function. " <>
-              "Use EditorState.transition_mode/3 or VimState.transition/3 instead.",
-          trigger: "#{field}:",
-          line_no: line_no
-        )
-      end)
-      |> Enum.reject(&is_nil/1)
+      direct_gated_field_issues(ast, updates, issue_meta, gated_fields) ++
+        guarded_map_update_issues(ast, map, updates, issue_meta, guarded_struct_fields)
 
     {ast, new_issues ++ issues}
   end
 
-  # Also catch nested map updates where the value itself is a map update
-  # containing the gated field. E.g.:
-  #   %{state | vim: %{state.vim | mode: :normal}}
-  # The outer update has `vim:` whose value is another map update with `mode:`.
-  defp find_direct_writes(ast, issues, _issue_meta, _gated_fields) do
+  defp find_direct_writes(
+         {:put_in, meta, [path_ast, _value]} = ast,
+         issues,
+         issue_meta,
+         _gated_fields,
+         guarded_struct_fields
+       ) do
+    new_issues =
+      case guarded_path_match(extract_dot_path(path_ast), guarded_struct_fields) do
+        nil ->
+          []
+
+        {parent, child} ->
+          [
+            format_issue(issue_meta,
+              message:
+                "Direct put_in through `#{parent}.#{child}` bypasses the owning state module. " <>
+                  "Use the appropriate WorkspaceState and sub-state setter instead.",
+              trigger: "put_in",
+              line_no: meta[:line] || extract_line(ast)
+            )
+          ]
+      end
+
+    {ast, new_issues ++ issues}
+  end
+
+  defp find_direct_writes(ast, issues, _issue_meta, _gated_fields, _guarded_struct_fields) do
     {ast, issues}
   end
+
+  @spec direct_gated_field_issues(term(), keyword(), IssueMeta.t(), [atom()]) :: [Credo.Issue.t()]
+  defp direct_gated_field_issues(ast, updates, issue_meta, gated_fields) do
+    updates
+    |> Enum.filter(fn
+      {field, _value} when is_atom(field) -> field in gated_fields
+      _ -> false
+    end)
+    |> Enum.map(fn {field, value} ->
+      line_no = extract_line(value) || extract_line(ast)
+
+      format_issue(issue_meta,
+        message:
+          "Direct write to `#{field}:` bypasses the state machine gate function. " <>
+            "Use EditorState.transition_mode/3 or VimState.transition/3 instead.",
+        trigger: "#{field}:",
+        line_no: line_no
+      )
+    end)
+  end
+
+  @spec guarded_map_update_issues(term(), term(), keyword(), IssueMeta.t(), keyword([atom()])) :: [Credo.Issue.t()]
+  defp guarded_map_update_issues(ast, map, updates, issue_meta, guarded_struct_fields) do
+    map_path = extract_dot_path(map)
+    map_match = guarded_path_match(map_path, guarded_struct_fields)
+
+    updates
+    |> Enum.flat_map(fn
+      {field, value} when is_atom(field) ->
+        update_match = guarded_path_match(map_path ++ [field], guarded_struct_fields)
+        guarded_issue(ast, value, issue_meta, map_match || update_match, field)
+
+      _ ->
+        []
+    end)
+  end
+
+  @spec guarded_issue(term(), term(), IssueMeta.t(), {atom(), atom()} | nil, atom()) :: [Credo.Issue.t()]
+  defp guarded_issue(_ast, _value, _issue_meta, nil, _field), do: []
+
+  defp guarded_issue(ast, value, issue_meta, {parent, child}, field) do
+    [
+      format_issue(issue_meta,
+        message:
+          "Direct write through `#{parent}.#{child}` bypasses the owning state module. " <>
+            "Use the appropriate WorkspaceState and sub-state setter instead.",
+        trigger: "#{field}:",
+        line_no: extract_line(value) || extract_line(ast)
+      )
+    ]
+  end
+
+  defp guarded_path_match(path, guarded_struct_fields) when is_list(path) do
+    guarded_struct_fields
+    |> Enum.find_value(fn {parent, children} ->
+      path
+      |> Enum.chunk_every(2, 1, :discard)
+      |> Enum.find_value(fn
+        [^parent, child] -> if child in children, do: {parent, child}
+        _ -> nil
+      end)
+    end)
+  end
+
+  defp guarded_path_match(_path, _guarded_struct_fields), do: nil
+
+  defp extract_dot_path({{:., _, [left, field]}, _, []}) when is_atom(field) do
+    extract_dot_path(left) ++ [field]
+  end
+
+  defp extract_dot_path({name, _, context}) when is_atom(name) and is_atom(context), do: [name]
+  defp extract_dot_path(_ast), do: []
 
   # Extracts line number from various AST shapes.
   defp extract_line({_, meta, _}) when is_list(meta), do: meta[:line]

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -94,6 +94,9 @@ defmodule MingaEditor do
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.FileTree, as: FileTreeState
+  alias MingaEditor.State.Search, as: SearchData
+  alias MingaEditor.State.Windows
   alias MingaEditor.State.Tab.Context, as: TabContext
 
   alias MingaEditor.MinibufferData
@@ -593,27 +596,27 @@ defmodule MingaEditor do
   def handle_info({:lsp_response, ref, result}, state) do
     case Map.pop(state.workspace.lsp_pending, ref) do
       {:completion_resolve, pending} ->
-        new_state = put_in(state.workspace.lsp_pending, pending)
+        new_state = set_lsp_pending(state, pending)
         new_state = CompletionHandling.handle_resolve_response(new_state, result)
         {:noreply, Renderer.render_or_async(new_state)}
 
       {:signature_help, pending} ->
-        new_state = put_in(state.workspace.lsp_pending, pending)
+        new_state = set_lsp_pending(state, pending)
         new_state = CompletionHandling.handle_signature_help_response(new_state, result)
         {:noreply, Renderer.render_or_async(new_state)}
 
       {{:semantic_tokens, buf_pid}, pending} ->
-        new_state = put_in(state.workspace.lsp_pending, pending)
+        new_state = set_lsp_pending(state, pending)
         new_state = SemanticTokenSync.handle_response(new_state, buf_pid, result)
         {:noreply, Renderer.render_or_async(new_state)}
 
       {kind, pending} when is_atom(kind) ->
-        new_state = put_in(state.workspace.lsp_pending, pending)
+        new_state = set_lsp_pending(state, pending)
         new_state = dispatch_lsp_response(kind, new_state, result)
         {:noreply, Renderer.render_or_async(new_state)}
 
       {kind, pending} when is_tuple(kind) ->
-        new_state = put_in(state.workspace.lsp_pending, pending)
+        new_state = set_lsp_pending(state, pending)
         new_state = dispatch_lsp_response(kind, new_state, result)
         {:noreply, Renderer.render_or_async(new_state)}
 
@@ -1234,6 +1237,11 @@ defmodule MingaEditor do
 
   # ── LSP response dispatch ──────────────────────────────────────────────────
 
+  @spec set_lsp_pending(state(), %{reference() => atom() | tuple()}) :: state()
+  defp set_lsp_pending(state, pending) do
+    EditorState.update_workspace(state, &WorkspaceState.set_lsp_pending(&1, pending))
+  end
+
   # Dispatches an LSP response to the appropriate handler based on the kind atom.
   @spec dispatch_lsp_response(term(), EditorState.t(), term()) :: EditorState.t()
   defp dispatch_lsp_response(:definition, state, result),
@@ -1846,7 +1854,13 @@ defmodule MingaEditor do
   @spec do_file_tree_open(state(), pid(), String.t(), FileTree.t()) :: state()
   def do_file_tree_open(state, pid, path, tree) do
     new_state = register_buffer(state, pid, path)
-    put_in(new_state.workspace.file_tree.tree, FileTree.reveal(tree, path))
+
+    EditorState.update_workspace(new_state, fn ws ->
+      WorkspaceState.set_file_tree(
+        ws,
+        FileTreeState.set_tree(ws.file_tree, FileTree.reveal(tree, path))
+      )
+    end)
   end
 
   @spec recover_swap_entries(state(), [Minga.Session.swap_entry()]) :: state()
@@ -1984,13 +1998,10 @@ defmodule MingaEditor do
   # the user explicitly opens the buffer.
   @spec register_buffer_background(state(), pid(), String.t()) :: state()
   defp register_buffer_background(state, buffer_pid, file_path) do
-    state = %{
-      state
-      | workspace: %{
-          state.workspace
-          | buffers: Buffers.add_background(state.workspace.buffers, buffer_pid)
-        }
-    }
+    state =
+      EditorState.update_workspace(state, fn ws ->
+        WorkspaceState.set_buffers(ws, Buffers.add_background(ws.buffers, buffer_pid))
+      end)
 
     state = EditorState.monitor_buffer(state, buffer_pid)
     log_message(state, "Opened (agent): #{file_path}")
@@ -2110,8 +2121,11 @@ defmodule MingaEditor do
         state
 
       %{} ->
-        ft = MingaEditor.State.FileTree.update_editing_text(state.workspace.file_tree, text)
-        state = put_in(state.workspace.file_tree, ft)
+        ft = FileTreeState.update_editing_text(state.workspace.file_tree, text)
+
+        state =
+          EditorState.update_workspace(state, &WorkspaceState.set_file_tree(&1, ft))
+
         Commands.FileTree.confirm_editing(state)
     end
   end
@@ -2404,13 +2418,10 @@ defmodule MingaEditor do
        )
        when is_pid(buf) do
     # Set the search pattern and execute search_next/search_prev
-    state = %{
-      state
-      | workspace: %{
-          state.workspace
-          | search: %{state.workspace.search | last_pattern: text, last_direction: :forward}
-        }
-    }
+    state =
+      EditorState.update_workspace(state, fn ws ->
+        WorkspaceState.set_search(ws, SearchData.record(ws.search, text, :forward))
+      end)
 
     cmd = if direction == 1, do: :search_prev, else: :search_next
     MingaEditor.Commands.execute(state, cmd)
@@ -2428,9 +2439,14 @@ defmodule MingaEditor do
       window ->
         vp = window.viewport
         new_vp = %{vp | top: max(line, 0)}
-        new_win = %{window | viewport: new_vp}
+        new_win = MingaEditor.Window.set_viewport(window, new_vp)
         new_map = Map.put(win_map, active_win_id, new_win)
-        new_state = put_in(state.workspace.windows.map, new_map)
+
+        new_state =
+          EditorState.update_workspace(state, fn ws ->
+            WorkspaceState.set_windows(ws, Windows.set_map(ws.windows, new_map))
+          end)
+
         Renderer.render_or_async(new_state)
     end
   end
@@ -2492,7 +2508,10 @@ defmodule MingaEditor do
   defp move_tree_cursor(%{workspace: %{file_tree: %{tree: nil}}} = state, _index), do: state
 
   defp move_tree_cursor(state, index) do
-    put_in(state.workspace.file_tree.tree.cursor, index)
+    EditorState.update_workspace(state, fn ws ->
+      tree = FileTree.select(ws.file_tree.tree, index)
+      WorkspaceState.set_file_tree(ws, FileTreeState.set_tree(ws.file_tree, tree))
+    end)
   end
 
   @spec git_action(state(), (String.t() -> :ok | {:error, String.t()}), String.t()) :: state()
@@ -2770,8 +2789,7 @@ defmodule MingaEditor do
     do: state
 
   defp gui_tree_action(state, index, action) do
-    tree = %{state.workspace.file_tree.tree | cursor: index}
-    state = put_in(state.workspace.file_tree.tree, tree)
+    state = move_tree_cursor(state, index)
 
     case action do
       :click -> Commands.FileTree.open_or_toggle(state)

--- a/lib/minga_editor/agent_activation.ex
+++ b/lib/minga_editor/agent_activation.ex
@@ -16,6 +16,8 @@ defmodule MingaEditor.AgentActivation do
   alias MingaAgent.Session, as: AgentSession
   alias MingaEditor.Agent.UIState
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Windows
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.Window.Content
@@ -96,7 +98,7 @@ defmodule MingaEditor.AgentActivation do
 
   @spec set_agent_scope(EditorState.t()) :: EditorState.t()
   defp set_agent_scope(state) do
-    put_in(state.workspace.keymap_scope, :agent)
+    EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :agent))
   end
 
   @spec set_agent_chat_window_content(EditorState.t(), pid()) :: EditorState.t()
@@ -107,7 +109,10 @@ defmodule MingaEditor.AgentActivation do
     if active_win do
       updated_win = %{active_win | content: Content.agent_chat(session)}
       new_map = Map.put(state.workspace.windows.map, active_id, updated_win)
-      put_in(state.workspace.windows.map, new_map)
+
+      EditorState.update_workspace(state, fn ws ->
+        WorkspaceState.set_windows(ws, Windows.set_map(ws.windows, new_map))
+      end)
     else
       state
     end
@@ -129,7 +134,7 @@ defmodule MingaEditor.AgentActivation do
 
   @spec reset_scope(EditorState.t()) :: EditorState.t()
   defp reset_scope(state) do
-    put_in(state.workspace.keymap_scope, :editor)
+    EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor))
   end
 
   @spec unfocus_prompt(EditorState.t()) :: EditorState.t()

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -22,6 +22,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Windows
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
@@ -30,6 +31,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   alias Minga.Mode.ToolConfirmState
   alias Minga.Tool.Recipe.Registry, as: RecipeRegistry
   alias MingaEditor.UI.Popup.Lifecycle, as: PopupLifecycle
+  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   @type state :: EditorState.t()
 
@@ -885,14 +887,10 @@ defmodule MingaEditor.Commands.BufferManagement do
 
         _ ->
           new_idx = min(idx, Enum.count(new_buffers) - 1)
-          new_active = Enum.at(new_buffers, new_idx)
+          new_bs = Buffers.replace_list(bs, new_buffers, new_idx)
 
-          put_in(state.workspace.buffers, %{
-            bs
-            | list: new_buffers,
-              active_index: new_idx,
-              active: new_active
-          })
+          state
+          |> EditorState.update_workspace(&WorkspaceState.set_buffers(&1, new_bs))
           |> EditorState.sync_active_window_buffer()
       end
     end
@@ -1117,7 +1115,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp close_agent_tab(%{shell_state: %{tab_bar: %TabBar{}}} = state) do
     state
     |> cleanup_agent_session()
-    |> then(fn s -> put_in(s.workspace.keymap_scope, :editor) end)
+    |> EditorState.update_workspace(&WorkspaceState.set_keymap_scope(&1, :editor))
     |> remove_current_tab()
     |> restore_active_tab_context()
   end
@@ -1640,13 +1638,9 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp focus_popup_window(state, buffer_pid) do
     case find_popup_for_buffer(state, buffer_pid) do
       {:ok, popup_window_id} ->
-        %{
-          state
-          | workspace: %{
-              state.workspace
-              | windows: %{state.workspace.windows | active: popup_window_id}
-            }
-        }
+        EditorState.update_workspace(state, fn ws ->
+          WorkspaceState.set_windows(ws, Windows.set_active(ws.windows, popup_window_id))
+        end)
 
       :none ->
         state
@@ -1686,23 +1680,17 @@ defmodule MingaEditor.Commands.BufferManagement do
            {Minga.Buffer, content: "", buffer_name: "[new 1]"}
          ) do
       {:ok, new_buf} ->
-        %{
-          state
-          | workspace: %{
-              state.workspace
-              | buffers: %{bs | list: [new_buf], active_index: 0, active: new_buf}
-            }
-        }
+        state
+        |> EditorState.update_workspace(
+          &WorkspaceState.set_buffers(&1, Buffers.replace_list(bs, [new_buf], 0))
+        )
         |> EditorState.sync_active_window_buffer()
 
       {:error, _} ->
-        %{
-          state
-          | workspace: %{
-              state.workspace
-              | buffers: %{bs | list: [], active_index: 0, active: nil}
-            }
-        }
+        EditorState.update_workspace(
+          state,
+          &WorkspaceState.set_buffers(&1, Buffers.replace_list(bs, [], 0))
+        )
     end
   end
 
@@ -2164,7 +2152,7 @@ defmodule MingaEditor.Commands.BufferManagement do
         {updated_vim, updated_state}
       end)
 
-    put_in(final_state.workspace.editing, final_vim)
+    EditorState.update_workspace(final_state, &WorkspaceState.set_editing(&1, final_vim))
   end
 
   @spec string_to_key_tuple(String.t()) :: Minga.Mode.key()

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -32,7 +32,7 @@ defmodule MingaEditor.Commands.FileTree do
 
     EditorState.update_workspace(state, fn ws ->
       ws
-      |> Map.put(:file_tree, FileTreeState.close(ws.file_tree))
+      |> WorkspaceState.set_file_tree(FileTreeState.close(ws.file_tree))
       |> WorkspaceState.set_keymap_scope(scope)
     end)
     |> Layout.invalidate()
@@ -45,7 +45,7 @@ defmodule MingaEditor.Commands.FileTree do
 
     EditorState.update_workspace(state, fn ws ->
       ws
-      |> Map.put(:file_tree, FileTreeState.close(ws.file_tree))
+      |> WorkspaceState.set_file_tree(FileTreeState.close(ws.file_tree))
       |> WorkspaceState.set_keymap_scope(scope)
     end)
     |> Layout.invalidate()
@@ -57,7 +57,7 @@ defmodule MingaEditor.Commands.FileTree do
 
     EditorState.update_workspace(state, fn ws ->
       ws
-      |> Map.put(:file_tree, FileTreeState.close(ws.file_tree))
+      |> WorkspaceState.set_file_tree(FileTreeState.close(ws.file_tree))
       |> WorkspaceState.set_keymap_scope(scope)
     end)
     |> Layout.invalidate()
@@ -66,6 +66,18 @@ defmodule MingaEditor.Commands.FileTree do
 
   @spec restore_scope(state()) :: atom()
   defp restore_scope(state), do: EditorState.scope_for_active_window(state)
+
+  @spec set_file_tree(state(), FileTreeState.t()) :: state()
+  defp set_file_tree(state, file_tree) do
+    EditorState.update_workspace(state, &WorkspaceState.set_file_tree(&1, file_tree))
+  end
+
+  @spec update_file_tree(state(), (FileTreeState.t() -> FileTreeState.t())) :: state()
+  defp update_file_tree(state, fun) when is_function(fun, 1) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.set_file_tree(ws, fun.(ws.file_tree))
+    end)
+  end
 
   @spec open_or_toggle(state()) :: state()
   def open_or_toggle(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
@@ -77,7 +89,7 @@ defmodule MingaEditor.Commands.FileTree do
         sync_and_update(state, new_tree)
 
       %{dir?: false, path: path} ->
-        state = put_in(state.workspace.file_tree.focused, false)
+        state = update_file_tree(state, &FileTreeState.unfocus/1)
         # Opening a file buffer always uses :editor scope (not restore_scope)
         # because the new buffer becomes the active window content.
         state = EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor))
@@ -146,7 +158,7 @@ defmodule MingaEditor.Commands.FileTree do
       |> FileTreeState.start_editing(index, :new_file)
       |> FileTreeState.replace_tree(tree)
 
-    state = put_in(state.workspace.file_tree, ft)
+    state = set_file_tree(state, ft)
     sync_buffer(state)
   end
 
@@ -166,7 +178,7 @@ defmodule MingaEditor.Commands.FileTree do
       |> FileTreeState.start_editing(index, :new_folder)
       |> FileTreeState.replace_tree(tree)
 
-    state = put_in(state.workspace.file_tree, ft)
+    state = set_file_tree(state, ft)
     sync_buffer(state)
   end
 
@@ -192,7 +204,7 @@ defmodule MingaEditor.Commands.FileTree do
             entry.name
           )
 
-        put_in(state.workspace.file_tree, ft)
+        set_file_tree(state, ft)
     end
   end
 
@@ -387,7 +399,7 @@ defmodule MingaEditor.Commands.FileTree do
 
   def cancel_editing(state) do
     ft = FileTreeState.cancel_editing(state.workspace.file_tree)
-    put_in(state.workspace.file_tree, ft)
+    set_file_tree(state, ft)
   end
 
   @doc """
@@ -410,7 +422,7 @@ defmodule MingaEditor.Commands.FileTree do
         state = ensure_tree_open(state)
         tree = FileTree.reveal(state.workspace.file_tree.tree, path)
         state = sync_and_update(state, tree)
-        state = put_in(state.workspace.file_tree.focused, true)
+        state = update_file_tree(state, &FileTreeState.focus/1)
 
         EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :file_tree))
         |> Layout.invalidate()
@@ -434,7 +446,7 @@ defmodule MingaEditor.Commands.FileTree do
 
     EditorState.update_workspace(state, fn ws ->
       ws
-      |> Map.put(:file_tree, FileTreeState.close(ws.file_tree))
+      |> WorkspaceState.set_file_tree(FileTreeState.close(ws.file_tree))
       |> WorkspaceState.set_keymap_scope(scope)
     end)
   end
@@ -444,7 +456,7 @@ defmodule MingaEditor.Commands.FileTree do
 
     EditorState.update_workspace(state, fn ws ->
       ws
-      |> Map.put(:file_tree, FileTreeState.close(ws.file_tree))
+      |> WorkspaceState.set_file_tree(FileTreeState.close(ws.file_tree))
       |> WorkspaceState.set_keymap_scope(scope)
     end)
   end
@@ -490,10 +502,7 @@ defmodule MingaEditor.Commands.FileTree do
             EditorState.switch_buffer(state, idx)
           end
 
-        put_in(
-          state.workspace.file_tree,
-          FileTreeState.replace_tree(state.workspace.file_tree, FileTree.reveal(tree, path))
-        )
+        update_file_tree(state, &FileTreeState.set_tree(&1, FileTree.reveal(tree, path)))
     end
   end
 
@@ -516,7 +525,7 @@ defmodule MingaEditor.Commands.FileTree do
 
     EditorState.update_workspace(state, fn ws ->
       ws
-      |> Map.put(:file_tree, FileTreeState.open(ws.file_tree, tree, buf))
+      |> WorkspaceState.set_file_tree(FileTreeState.open(ws.file_tree, tree, buf))
       |> WorkspaceState.set_keymap_scope(:file_tree)
     end)
     |> Layout.invalidate()
@@ -539,19 +548,13 @@ defmodule MingaEditor.Commands.FileTree do
     FileTreeFreshness.watch_expanded_dirs(new_tree)
     BufferSync.sync(buf, new_tree)
 
-    put_in(
-      state.workspace.file_tree,
-      FileTreeState.replace_tree(state.workspace.file_tree, new_tree)
-    )
+    update_file_tree(state, &FileTreeState.set_tree(&1, new_tree))
   end
 
   defp sync_and_update(state, new_tree) do
     FileTreeFreshness.watch_expanded_dirs(new_tree)
 
-    put_in(
-      state.workspace.file_tree,
-      FileTreeState.replace_tree(state.workspace.file_tree, new_tree)
-    )
+    update_file_tree(state, &FileTreeState.set_tree(&1, new_tree))
   end
 
   # Computes the insertion index for a new file/folder.
@@ -832,7 +835,7 @@ defmodule MingaEditor.Commands.FileTree do
   @spec clear_editing_and_refresh(state()) :: state()
   defp clear_editing_and_refresh(state) do
     ft = FileTreeState.cancel_editing(state.workspace.file_tree)
-    state = put_in(state.workspace.file_tree, ft)
+    state = set_file_tree(state, ft)
     refresh(state)
   end
 

--- a/lib/minga_editor/commands/help.ex
+++ b/lib/minga_editor/commands/help.ex
@@ -18,6 +18,8 @@ defmodule MingaEditor.Commands.Help do
   alias MingaEditor.KeystrokeHistory
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias Minga.Mode
 
   @type state :: EditorState.t()
@@ -905,7 +907,13 @@ defmodule MingaEditor.Commands.Help do
   @spec start_help_buffer(state()) :: {state(), pid()}
   defp start_help_buffer(state) do
     {:ok, pid} = start_special_buffer("*Help*")
-    {put_in(state.workspace.buffers.help, pid), pid}
+
+    state =
+      EditorState.update_workspace(state, fn ws ->
+        WorkspaceState.set_buffers(ws, Buffers.set_help(ws.buffers, pid))
+      end)
+
+    {state, pid}
   end
 
   @spec start_named_buffer(state(), String.t()) :: {state(), pid()}

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -14,6 +14,9 @@ defmodule MingaEditor.Commands.Movement do
   alias MingaEditor.FoldMap
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.FileTree, as: FileTreeState
+  alias MingaEditor.State.Windows
   alias MingaEditor.VimState
   alias MingaEditor.Viewport
   alias MingaEditor.Workspace.State, as: WorkspaceState
@@ -450,13 +453,13 @@ defmodule MingaEditor.Commands.Movement do
 
     ws = state.workspace.windows
 
-    state =
-      put_in(state.workspace.windows, %{
-        ws
-        | tree: new_tree,
-          map: Map.put(ws.map, new_id, new_window),
-          next_id: new_id + 1
-      })
+    new_windows =
+      ws
+      |> Windows.set_tree(new_tree)
+      |> Windows.set_map(Map.put(ws.map, new_id, new_window))
+      |> Windows.set_next_id(new_id + 1)
+
+    state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, new_windows))
 
     resize_windows_to_layout(state)
   end
@@ -480,7 +483,7 @@ defmodule MingaEditor.Commands.Movement do
   # When file tree is focused, navigating right unfocuses the tree
   # and restores the scope based on the active window's content type.
   defp navigate_window(%{workspace: %{file_tree: %{focused: true}}} = state, :right) do
-    state = put_in(state.workspace.file_tree.focused, false)
+    state = update_file_tree(state, &FileTreeState.unfocus/1)
     scope = EditorState.scope_for_active_window(state)
     EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, scope))
   end
@@ -508,7 +511,7 @@ defmodule MingaEditor.Commands.Movement do
          %{workspace: %{file_tree: %{tree: %Minga.Project.FileTree{}}}} = state,
          :left
        ) do
-    state = put_in(state.workspace.file_tree.focused, true)
+    state = update_file_tree(state, &FileTreeState.focus/1)
     EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :file_tree))
   end
 
@@ -530,19 +533,20 @@ defmodule MingaEditor.Commands.Movement do
         # Restore the surviving window's cursor into the buffer
         Buffer.move_to(new_active_window.buffer, new_active_window.cursor)
 
-        %{
-          state
-          | workspace: %{
-              state.workspace
-              | windows: %{
-                  ws
-                  | tree: new_tree,
-                    map: Map.delete(ws.map, old_id),
-                    active: new_active
-                },
-                buffers: %{state.workspace.buffers | active: new_active_window.buffer}
-            }
-        }
+        new_windows =
+          ws
+          |> Windows.set_tree(new_tree)
+          |> Windows.set_map(Map.delete(ws.map, old_id))
+          |> Windows.set_active(new_active)
+
+        new_buffers =
+          Buffers.set_active_override(state.workspace.buffers, new_active_window.buffer)
+
+        EditorState.update_workspace(state, fn workspace ->
+          workspace
+          |> WorkspaceState.set_windows(new_windows)
+          |> WorkspaceState.set_buffers(new_buffers)
+        end)
 
       :error ->
         EditorState.set_status(state, "Cannot close the last window")
@@ -550,6 +554,13 @@ defmodule MingaEditor.Commands.Movement do
   end
 
   # ── Private helpers ──────────────────────────────────────────────────────
+
+  @spec update_file_tree(state(), (FileTreeState.t() -> FileTreeState.t())) :: state()
+  defp update_file_tree(state, fun) when is_function(fun, 1) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.set_file_tree(ws, fun.(ws.file_tree))
+    end)
+  end
 
   @spec visual_line_move(GenServer.server(), state(), :up | :down) :: state()
   defp visual_line_move(buf, state, direction) do

--- a/lib/minga_editor/commands/search.ex
+++ b/lib/minga_editor/commands/search.ex
@@ -12,6 +12,7 @@ defmodule MingaEditor.Commands.Search do
   alias Minga.Core.Unicode
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Search, as: SearchData
   alias MingaEditor.Window
   alias MingaEditor.Workspace.State, as: WorkspaceState
   alias Minga.Mode
@@ -218,7 +219,11 @@ defmodule MingaEditor.Commands.Search do
       {:ok, matches, truncated?} ->
         msg = if truncated?, do: "Results truncated to 10,000", else: nil
 
-        state = put_in(state.workspace.search.project_results, matches)
+        state =
+          EditorState.update_workspace(state, fn ws ->
+            WorkspaceState.update_search(ws, &SearchData.set_project_results(&1, matches))
+          end)
+
         state = PickerUI.open(state, MingaEditor.UI.Picker.ProjectSearchSource)
         if msg, do: EditorState.set_status(state, msg), else: state
 
@@ -313,13 +318,10 @@ defmodule MingaEditor.Commands.Search do
     text = word_at_cursor(gb, cursor)
 
     if text != "" do
-      state = %{
-        state
-        | workspace: %{
-            state.workspace
-            | search: %{state.workspace.search | last_pattern: text, last_direction: :forward}
-          }
-      }
+      state =
+        EditorState.update_workspace(state, fn ws ->
+          WorkspaceState.set_search(ws, SearchData.record(ws.search, text, :forward))
+        end)
 
       if state.backend in [:gui, :native_gui] and state.port_manager do
         MingaEditor.Frontend.clipboard_write(state.port_manager, text, :find)
@@ -408,18 +410,14 @@ defmodule MingaEditor.Commands.Search do
 
   @spec put_in_search(state(), atom(), term()) :: state()
   defp put_in_search(state, :last_pattern, value) do
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | search: MingaEditor.State.Search.record_pattern(state.workspace.search, value)
-        }
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_search(ws, &SearchData.record_pattern(&1, value))
+    end)
   end
 
   defp put_in_search(state, :last_direction, value) do
     EditorState.update_workspace(state, fn ws ->
-      WorkspaceState.update_search(ws, fn s -> %{s | last_direction: value} end)
+      WorkspaceState.update_search(ws, &SearchData.set_last_direction(&1, value))
     end)
   end
 

--- a/lib/minga_editor/commands/tutor.ex
+++ b/lib/minga_editor/commands/tutor.ex
@@ -11,6 +11,8 @@ defmodule MingaEditor.Commands.Tutor do
   alias Minga.Command
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   @type state :: EditorState.t()
 
@@ -93,8 +95,9 @@ defmodule MingaEditor.Commands.Tutor do
 
     state =
       if idx do
-        put_in(state.workspace.buffers.active_index, idx)
-        |> then(fn s -> put_in(s.workspace.buffers.active, buffer) end)
+        EditorState.update_workspace(state, fn ws ->
+          WorkspaceState.set_buffers(ws, Buffers.switch_to(ws.buffers, idx))
+        end)
       else
         Commands.add_buffer(state, buffer)
       end

--- a/lib/minga_editor/completion_handling.ex
+++ b/lib/minga_editor/completion_handling.ex
@@ -14,6 +14,7 @@ defmodule MingaEditor.CompletionHandling do
   alias MingaEditor.CompletionTrigger
   alias MingaEditor.SignatureHelp
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.State.ModalOverlay
   alias Minga.LSP.Client
   alias Minga.LSP.SyncServer
@@ -89,10 +90,7 @@ defmodule MingaEditor.CompletionHandling do
         client ->
           ref = Client.request(client, "completionItem/resolve", item.raw)
 
-          put_in(
-            state.workspace.lsp_pending,
-            Map.put(state.workspace.lsp_pending, ref, :completion_resolve)
-          )
+          put_lsp_pending(state, ref, :completion_resolve)
       end
     end
   end
@@ -190,6 +188,13 @@ defmodule MingaEditor.CompletionHandling do
   end
 
   # ── Private helpers ────────────────────────────────────────────────────────
+
+  @spec put_lsp_pending(EditorState.t(), reference(), atom() | tuple()) :: EditorState.t()
+  defp put_lsp_pending(state, ref, kind) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.set_lsp_pending(ws, Map.put(ws.lsp_pending, ref, kind))
+    end)
+  end
 
   @spec accept_text(EditorState.t(), Completion.t(), String.t()) :: EditorState.t()
   defp accept_text(%{workspace: %{buffers: %{active: buf}}} = state, completion, text)
@@ -676,10 +681,7 @@ defmodule MingaEditor.CompletionHandling do
 
           ref = Client.request(client, "textDocument/signatureHelp", params)
 
-          put_in(
-            state.workspace.lsp_pending,
-            Map.put(state.workspace.lsp_pending, ref, :signature_help)
-          )
+          put_lsp_pending(state, ref, :signature_help)
         else
           state
         end

--- a/lib/minga_editor/editing.ex
+++ b/lib/minga_editor/editing.ex
@@ -59,29 +59,42 @@ defmodule MingaEditor.Editing do
   @doc "Sets the active register to `name`."
   @spec set_active_register(EditorState.t(), String.t()) :: EditorState.t()
   def set_active_register(%EditorState{} = state, name) do
-    put_in(state.workspace.editing.reg.active, name)
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, fn vim ->
+        VimState.set_registers(vim, Registers.set_active(vim.reg, name))
+      end)
+    end)
   end
 
   @doc "Stores `text` in register `name` with the given type."
   @spec put_register(EditorState.t(), String.t(), String.t(), Registers.reg_type()) ::
           EditorState.t()
   def put_register(%EditorState{} = state, name, text, reg_type \\ :charwise) do
-    put_in(
-      state.workspace.editing.reg,
-      Registers.put(state.workspace.editing.reg, name, text, reg_type)
-    )
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, fn vim ->
+        VimState.set_registers(vim, Registers.put(vim.reg, name, text, reg_type))
+      end)
+    end)
   end
 
   @doc "Resets the active register back to unnamed."
   @spec reset_active_register(EditorState.t()) :: EditorState.t()
   def reset_active_register(%EditorState{} = state) do
-    put_in(state.workspace.editing.reg, Registers.reset_active(state.workspace.editing.reg))
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, fn vim ->
+        VimState.set_registers(vim, Registers.reset_active(vim.reg))
+      end)
+    end)
   end
 
   @doc "Sets the leader_node on mode_state."
   @spec set_leader_node(EditorState.t(), term()) :: EditorState.t()
   def set_leader_node(%EditorState{} = state, node) do
-    put_in(state.workspace.editing.mode_state.leader_node, node)
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, fn vim ->
+        VimState.set_mode_state(vim, %{vim.mode_state | leader_node: node})
+      end)
+    end)
   end
 
   @doc """
@@ -94,25 +107,35 @@ defmodule MingaEditor.Editing do
   @spec update_mode_state(EditorState.t(), (Mode.state() -> Mode.state()) | map()) ::
           EditorState.t()
   def update_mode_state(%EditorState{} = state, fun) when is_function(fun, 1) do
-    new_ms = fun.(state.workspace.editing.mode_state)
-    put_in(state.workspace.editing.mode_state, new_ms)
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, fn vim ->
+        VimState.set_mode_state(vim, fun.(vim.mode_state))
+      end)
+    end)
   end
 
   def update_mode_state(%EditorState{} = state, updates) when is_map(updates) do
-    new_ms = Map.merge(state.workspace.editing.mode_state, updates)
-    put_in(state.workspace.editing.mode_state, new_ms)
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, fn vim ->
+        VimState.set_mode_state(vim, Map.merge(vim.mode_state, updates))
+      end)
+    end)
   end
 
   @doc "Replaces the macro recorder."
   @spec set_macro_recorder(EditorState.t(), MacroRecorder.t()) :: EditorState.t()
   def set_macro_recorder(%EditorState{} = state, rec) do
-    put_in(state.workspace.editing.macro_recorder, rec)
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_macro_recorder(&1, rec))
+    end)
   end
 
   @doc "Replaces the change recorder."
   @spec set_change_recorder(EditorState.t(), term()) :: EditorState.t()
   def set_change_recorder(%EditorState{} = state, rec) do
-    put_in(state.workspace.editing.change_recorder, rec)
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_editing(ws, &VimState.set_change_recorder(&1, rec))
+    end)
   end
 
   @doc "Saves the jump position when the cursor crosses a line boundary."

--- a/lib/minga_editor/handlers/highlight_handler.ex
+++ b/lib/minga_editor/handlers/highlight_handler.ex
@@ -16,8 +16,10 @@ defmodule MingaEditor.Handlers.HighlightHandler do
   alias MingaEditor.HighlightEvents
   alias MingaEditor.HighlightSync
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Highlighting
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.Window
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias Minga.Editing.Fold.Range, as: FoldRange
 
   @typedoc "Effects that the highlight handler may return."
@@ -204,13 +206,10 @@ defmodule MingaEditor.Handlers.HighlightHandler do
   end
 
   defp handle_injection_ranges(state, pid, _buffer_id, ranges) do
-    new_state = %{
-      state
-      | workspace: %{
-          state.workspace
-          | injection_ranges: Map.put(state.workspace.injection_ranges, pid, ranges)
-        }
-    }
+    new_state =
+      EditorState.update_workspace(state, fn ws ->
+        WorkspaceState.set_injection_ranges(ws, Map.put(ws.injection_ranges, pid, ranges))
+      end)
 
     {new_state, []}
   end
@@ -388,14 +387,16 @@ defmodule MingaEditor.Handlers.HighlightHandler do
         {pid, %{buf_hl | version: 0}}
       end)
 
-    new_state = %{
+    new_state =
       state
-      | workspace: %{
-          state.workspace
-          | highlight: %{hl | version: 0, highlights: reset_highlights}
-        },
-        parser_status: :available
-    }
+      |> EditorState.update_workspace(fn ws ->
+        WorkspaceState.update_highlight(ws, fn highlight ->
+          highlight
+          |> Highlighting.set_version(0)
+          |> Highlighting.set_highlights(reset_highlights)
+        end)
+      end)
+      |> Map.put(:parser_status, :available)
 
     {new_state, [{:log_message, "Parser restarted, syntax highlighting recovered"}]}
   end

--- a/lib/minga_editor/highlight_sync.ex
+++ b/lib/minga_editor/highlight_sync.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.HighlightSync do
 
   alias Minga.Buffer
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Highlighting
   alias MingaEditor.Frontend.Protocol
   alias MingaEditor.Workspace.State, as: WorkspaceState
   alias Minga.Parser.Manager, as: ParserManager
@@ -179,17 +180,14 @@ defmodule MingaEditor.HighlightSync do
         hl2.syntax_overrides
       end
 
-    state = %{
-      state
-      | workspace: %{
-          state.workspace
-          | highlight: %{
-              hl2
-              | version: version,
-                syntax_overrides: syntax_overrides
-            }
-        }
-    }
+    state =
+      EditorState.update_workspace(state, fn ws ->
+        WorkspaceState.update_highlight(ws, fn highlight ->
+          highlight
+          |> Highlighting.set_version(version)
+          |> Highlighting.set_syntax_overrides(syntax_overrides)
+        end)
+      end)
 
     touch_buffer(state, buf_pid)
   end
@@ -271,18 +269,11 @@ defmodule MingaEditor.HighlightSync do
     )
 
     state = put_active_highlight(state, Highlight.from_theme(state.theme))
-    hl2 = state.workspace.highlight
 
-    state = %{
-      state
-      | workspace: %{
-          state.workspace
-          | highlight: %{
-              hl2
-              | version: version
-            }
-        }
-    }
+    state =
+      EditorState.update_workspace(state, fn ws ->
+        WorkspaceState.update_highlight(ws, &Highlighting.set_version(&1, version))
+      end)
 
     touch_active(state)
   end
@@ -338,14 +329,12 @@ defmodule MingaEditor.HighlightSync do
         ParserManager.close_buffer(buffer_id)
         ParserManager.unregister_buffer(buffer_id)
 
-        put_in(state.workspace.highlight, %{
-          hl
-          | buffer_ids: remaining_ids,
-            reverse_buffer_ids: Map.delete(hl.reverse_buffer_ids, buffer_id),
-            highlights: Map.delete(hl.highlights, buffer_pid),
-            last_active_at: Map.delete(hl.last_active_at, buffer_pid),
-            syntax_overrides: Map.delete(hl.syntax_overrides, buffer_pid)
-        })
+        EditorState.update_workspace(state, fn ws ->
+          WorkspaceState.update_highlight(
+            ws,
+            &Highlighting.remove_buffer(&1, buffer_pid, buffer_id, remaining_ids)
+          )
+        end)
     end
   end
 
@@ -685,28 +674,20 @@ defmodule MingaEditor.HighlightSync do
     do: state
 
   def put_active_highlight(
-        %EditorState{workspace: %{highlight: hl, buffers: %{active: buf}}} = state,
+        %EditorState{workspace: %{buffers: %{active: buf}}} = state,
         hl_data
       ) do
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | highlight: %{hl | highlights: Map.put(hl.highlights, buf, hl_data)}
-        }
-    }
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_highlight(ws, &Highlighting.put_highlight(&1, buf, hl_data))
+    end)
   end
 
   @doc "Stores highlight data for a specific buffer PID."
   @spec put_highlight(EditorState.t(), pid(), Highlight.t()) :: EditorState.t()
-  def put_highlight(%EditorState{workspace: %{highlight: hl}} = state, buf_pid, hl_data) do
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | highlight: %{hl | highlights: Map.put(hl.highlights, buf_pid, hl_data)}
-        }
-    }
+  def put_highlight(%EditorState{} = state, buf_pid, hl_data) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.update_highlight(ws, &Highlighting.put_highlight(&1, buf_pid, hl_data))
+    end)
   end
 
   # Updates the active buffer's highlight via a function.

--- a/lib/minga_editor/input/agent_nav.ex
+++ b/lib/minga_editor/input/agent_nav.ex
@@ -34,6 +34,8 @@ defmodule MingaEditor.Input.AgentNav do
   alias MingaEditor.Agent.UIState
   alias Minga.Buffer
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.Window
 
@@ -122,7 +124,7 @@ defmodule MingaEditor.Input.AgentNav do
         ) :: EditorState.t()
   def delegate_to_mode_fsm(state, chat_buffer, cp, mods) do
     real_active = state.workspace.buffers.active
-    state = put_in(state.workspace.buffers.active, chat_buffer)
+    state = set_active_buffer_override(state, chat_buffer)
 
     state = MingaEditor.do_handle_key(state, cp, mods)
 
@@ -145,10 +147,17 @@ defmodule MingaEditor.Input.AgentNav do
     # Only restore the original active buffer if a command didn't
     # legitimately change it (e.g., leader commands like :new_buffer).
     if state.workspace.buffers.active == chat_buffer do
-      put_in(state.workspace.buffers.active, real_active)
+      set_active_buffer_override(state, real_active)
     else
       state
     end
+  end
+
+  @spec set_active_buffer_override(EditorState.t(), pid() | nil) :: EditorState.t()
+  defp set_active_buffer_override(state, pid) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.set_buffers(ws, Buffers.set_active_override(ws.buffers, pid))
+    end)
   end
 
   # ── Private helpers ─────────────────────────────────────────────────────

--- a/lib/minga_editor/input/agent_panel.ex
+++ b/lib/minga_editor/input/agent_panel.ex
@@ -24,6 +24,8 @@ defmodule MingaEditor.Input.AgentPanel do
   alias MingaEditor.Commands.Agent, as: AgentCommands
   alias MingaEditor.LayoutPreset
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.Input
   alias MingaEditor.Input.AgentNav
@@ -146,6 +148,13 @@ defmodule MingaEditor.Input.AgentPanel do
   # bindings. Printable chars and @-mention fall through to
   # handle_panel_self_insert above.
 
+  @spec set_active_buffer_override(EditorState.t(), pid() | nil) :: EditorState.t()
+  defp set_active_buffer_override(state, pid) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.set_buffers(ws, Buffers.set_active_override(ws.buffers, pid))
+    end)
+  end
+
   # ── Panel navigation mode ──────────────────────────────────────────────
 
   @spec handle_panel_nav(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
@@ -217,13 +226,13 @@ defmodule MingaEditor.Input.AgentPanel do
     if is_pid(prompt_pid) do
       try do
         real_active = state.workspace.buffers.active
-        state = put_in(state.workspace.buffers.active, prompt_pid)
+        state = set_active_buffer_override(state, prompt_pid)
         state = MingaEditor.do_handle_key(state, cp, mods)
 
         # Only restore if a command didn't legitimately change buffers.active.
         # Same guard as AgentNav.delegate_to_mode_fsm/4.
         if state.workspace.buffers.active == prompt_pid do
-          put_in(state.workspace.buffers.active, real_active)
+          set_active_buffer_override(state, real_active)
         else
           state
         end

--- a/lib/minga_editor/input/cua/tui_space_leader.ex
+++ b/lib/minga_editor/input/cua/tui_space_leader.ex
@@ -30,6 +30,7 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
   alias Minga.Buffer
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias Minga.Keymap
   alias Minga.Keymap.Bindings
 
@@ -130,12 +131,12 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
 
   @spec put_space_leader_pending(EditorState.t(), boolean()) :: EditorState.t()
   defp put_space_leader_pending(state, value) do
-    %{state | shell_state: %{state.shell_state | space_leader_pending: value}}
+    EditorState.update_shell_state(state, &ShellState.set_space_leader_pending(&1, value))
   end
 
   @spec put_space_leader_timer(EditorState.t(), reference() | nil) :: EditorState.t()
   defp put_space_leader_timer(state, timer) do
-    %{state | shell_state: %{state.shell_state | space_leader_timer: timer}}
+    EditorState.update_shell_state(state, &ShellState.set_space_leader_timer(&1, timer))
   end
 
   @spec cancel_timer(EditorState.t()) :: EditorState.t()
@@ -143,7 +144,7 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
 
   defp cancel_timer(%{shell_state: %{space_leader_timer: timer}} = state) do
     Process.cancel_timer(timer)
-    %{state | shell_state: %{state.shell_state | space_leader_timer: nil}}
+    put_space_leader_timer(state, nil)
   end
 
   @spec retract_space(EditorState.t()) :: EditorState.t()

--- a/lib/minga_editor/input/dired.ex
+++ b/lib/minga_editor/input/dired.ex
@@ -17,6 +17,8 @@ defmodule MingaEditor.Input.Dired do
 
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Dired, as: DiredState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias Minga.Keymap
   alias Minga.Keymap.Scope
 
@@ -127,11 +129,18 @@ defmodule MingaEditor.Input.Dired do
 
   @spec put_pending_prefix(state(), Minga.Keymap.Bindings.node_t()) :: state()
   defp put_pending_prefix(state, node) do
-    put_in(state.workspace.dired.pending_prefix, node)
+    update_pending_prefix(state, node)
   end
 
   @spec clear_pending_prefix(state()) :: state()
   defp clear_pending_prefix(state) do
-    put_in(state.workspace.dired.pending_prefix, nil)
+    update_pending_prefix(state, nil)
+  end
+
+  @spec update_pending_prefix(state(), Minga.Keymap.Bindings.node_t() | nil) :: state()
+  defp update_pending_prefix(state, prefix) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.set_dired(ws, DiredState.set_pending_prefix(ws.dired, prefix))
+    end)
   end
 end

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -17,6 +17,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
   alias MingaEditor.FocusTree
   alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.Input
   alias Minga.Keymap
@@ -173,7 +174,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
        )
        when is_pid(buf) do
     real_active = state.workspace.buffers.active
-    state = put_in(state.workspace.buffers.active, buf)
+    state = set_active_buffer_override(state, buf)
     state = MingaEditor.do_handle_key(state, cp, mods)
 
     state =
@@ -183,7 +184,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
         state
       end
 
-    state = put_in(state.workspace.buffers.active, real_active)
+    state = set_active_buffer_override(state, real_active)
 
     if state.workspace.file_tree.tree == nil do
       state
@@ -198,10 +199,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
   defp sync_tree_cursor_from_buffer(%{workspace: %{file_tree: %{tree: tree}}} = state, buf) do
     {cursor_line, _col} = Buffer.cursor(buf)
 
-    put_in(
-      state.workspace.file_tree,
-      FileTreeState.replace_tree(state.workspace.file_tree, FileTree.select(tree, cursor_line))
-    )
+    update_file_tree(state, &FileTreeState.set_tree(&1, FileTree.select(tree, cursor_line)))
   end
 
   # ── File tree mouse helpers ────────────────────────────────────────────
@@ -219,12 +217,9 @@ defmodule MingaEditor.Input.FileTreeHandler do
        when button in [:wheel_up, :wheel_down] do
     delta = if button == :wheel_down, do: 3, else: -3
 
-    put_in(
-      state.workspace.file_tree,
-      FileTreeState.replace_tree(
-        state.workspace.file_tree,
-        FileTree.select(tree, tree.cursor + delta)
-      )
+    update_file_tree(
+      state,
+      &FileTreeState.set_tree(&1, FileTree.select(tree, tree.cursor + delta))
     )
   end
 
@@ -245,13 +240,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
 
         entry ->
           state =
-            put_in(
-              state.workspace.file_tree,
-              FileTreeState.replace_tree(
-                state.workspace.file_tree,
-                FileTree.select(tree, entry_idx)
-              )
-            )
+            update_file_tree(state, &FileTreeState.set_tree(&1, FileTree.select(tree, entry_idx)))
 
           handle_tree_entry_click(state, entry, click_count)
       end
@@ -301,7 +290,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
       # Use String.slice/3 (start, length) to avoid negative index issues.
       new_text = String.slice(editing.text, 0, max(String.length(editing.text) - 1, 0))
       ft = FileTreeState.update_editing_text(state.workspace.file_tree, new_text)
-      put_in(state.workspace.file_tree, ft)
+      set_file_tree(state, ft)
     end
   end
 
@@ -311,11 +300,31 @@ defmodule MingaEditor.Input.FileTreeHandler do
     editing = state.workspace.file_tree.editing
     new_text = editing.text <> char
     ft = FileTreeState.update_editing_text(state.workspace.file_tree, new_text)
-    put_in(state.workspace.file_tree, ft)
+    set_file_tree(state, ft)
   end
 
   # All other keys (with modifiers, control chars): swallow them
   defp handle_inline_edit_key(state, _cp, _mods), do: state
 
   # ── Shared helpers ──────────────────────────────────────────────────────
+
+  @spec set_active_buffer_override(EditorState.t(), pid() | nil) :: EditorState.t()
+  defp set_active_buffer_override(state, pid) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.set_buffers(ws, Buffers.set_active_override(ws.buffers, pid))
+    end)
+  end
+
+  @spec set_file_tree(EditorState.t(), FileTreeState.t()) :: EditorState.t()
+  defp set_file_tree(state, file_tree) do
+    EditorState.update_workspace(state, &WorkspaceState.set_file_tree(&1, file_tree))
+  end
+
+  @spec update_file_tree(EditorState.t(), (FileTreeState.t() -> FileTreeState.t())) ::
+          EditorState.t()
+  defp update_file_tree(state, fun) when is_function(fun, 1) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.set_file_tree(ws, fun.(ws.file_tree))
+    end)
+  end
 end

--- a/lib/minga_editor/layout_preset.ex
+++ b/lib/minga_editor/layout_preset.ex
@@ -27,6 +27,7 @@ defmodule MingaEditor.LayoutPreset do
   """
 
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Windows
   alias MingaEditor.Window
   alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.Window.Content
@@ -72,7 +73,12 @@ defmodule MingaEditor.LayoutPreset do
     case WindowTree.close(state.workspace.windows.tree, agent_win_id) do
       {:ok, new_tree} ->
         map = Map.delete(state.workspace.windows.map, agent_win_id)
-        windows = %{state.workspace.windows | tree: new_tree, map: map}
+
+        windows =
+          state.workspace.windows
+          |> Windows.set_tree(new_tree)
+          |> Windows.set_map(map)
+
         state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, windows))
 
         # If we were in agent scope, return to editor scope since the
@@ -89,26 +95,23 @@ defmodule MingaEditor.LayoutPreset do
   end
 
   @spec maybe_switch_focus_away(EditorState.t(), Window.id()) :: EditorState.t()
-  defp maybe_switch_focus_away(state, closing_id) do
-    if state.workspace.windows.active == closing_id do
-      case find_non_agent_window(state) do
-        {buf_win_id, window} ->
-          scope = EditorState.scope_for_content(window.content, state.workspace.keymap_scope)
+  defp maybe_switch_focus_away(%{workspace: %{windows: %{active: active}}} = state, closing_id)
+       when active != closing_id,
+       do: state
 
-          %{
-            state
-            | workspace: %{
-                state.workspace
-                | windows: %{state.workspace.windows | active: buf_win_id},
-                  keymap_scope: scope
-              }
-          }
+  defp maybe_switch_focus_away(state, _closing_id) do
+    case find_non_agent_window(state) do
+      {buf_win_id, window} ->
+        scope = EditorState.scope_for_content(window.content, state.workspace.keymap_scope)
 
-        nil ->
-          state
-      end
-    else
-      state
+        EditorState.update_workspace(state, fn ws ->
+          ws
+          |> WorkspaceState.set_windows(Windows.set_active(ws.windows, buf_win_id))
+          |> WorkspaceState.set_keymap_scope(scope)
+        end)
+
+      nil ->
+        state
     end
   end
 
@@ -141,12 +144,11 @@ defmodule MingaEditor.LayoutPreset do
         {:ok, new_tree} ->
           new_map = Map.put(state.workspace.windows.map, next_id, agent_window)
 
-          windows = %{
+          windows =
             state.workspace.windows
-            | tree: new_tree,
-              map: new_map,
-              next_id: next_id + 1
-          }
+            |> Windows.set_tree(new_tree)
+            |> Windows.set_map(new_map)
+            |> Windows.set_next_id(next_id + 1)
 
           EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, windows))
 

--- a/lib/minga_editor/lsp_actions.ex
+++ b/lib/minga_editor/lsp_actions.ex
@@ -138,10 +138,7 @@ defmodule MingaEditor.LspActions do
 
             ref = Client.request(client, "textDocument/references", params)
 
-            put_in(
-              state.workspace.lsp_pending,
-              Map.put(state.workspace.lsp_pending, ref, :references)
-            )
+            put_lsp_pending(state, ref, :references)
         end
     end
   end
@@ -212,7 +209,7 @@ defmodule MingaEditor.LspActions do
   def clear_document_highlights(state) do
     state
     |> cancel_highlight_timer()
-    |> then(fn s -> put_in(s.workspace.document_highlights, nil) end)
+    |> then(&set_document_highlights(&1, nil))
   end
 
   @spec cancel_highlight_timer(state()) :: state()
@@ -259,10 +256,7 @@ defmodule MingaEditor.LspActions do
 
             ref = Client.request(client, "textDocument/codeAction", params)
 
-            put_in(
-              state.workspace.lsp_pending,
-              Map.put(state.workspace.lsp_pending, ref, :code_action)
-            )
+            put_lsp_pending(state, ref, :code_action)
         end
     end
   end
@@ -315,10 +309,7 @@ defmodule MingaEditor.LspActions do
 
             ref = Client.request(client, "textDocument/rename", params)
 
-            put_in(
-              state.workspace.lsp_pending,
-              Map.put(state.workspace.lsp_pending, ref, :rename)
-            )
+            put_lsp_pending(state, ref, :rename)
         end
     end
   end
@@ -386,10 +377,7 @@ defmodule MingaEditor.LspActions do
 
             ref = Client.request(client, "textDocument/documentSymbol", params)
 
-            put_in(
-              state.workspace.lsp_pending,
-              Map.put(state.workspace.lsp_pending, ref, :document_symbol)
-            )
+            put_lsp_pending(state, ref, :document_symbol)
         end
     end
   end
@@ -411,10 +399,7 @@ defmodule MingaEditor.LspActions do
         params = %{"query" => query}
         ref = Client.request(client, "workspace/symbol", params)
 
-        put_in(
-          state.workspace.lsp_pending,
-          Map.put(state.workspace.lsp_pending, ref, :workspace_symbol)
-        )
+        put_lsp_pending(state, ref, :workspace_symbol)
     end
   end
 
@@ -449,10 +434,7 @@ defmodule MingaEditor.LspActions do
 
             ref = Client.request(client, "textDocument/selectionRange", params)
 
-            put_in(
-              state.workspace.lsp_pending,
-              Map.put(state.workspace.lsp_pending, ref, :selection_range)
-            )
+            put_lsp_pending(state, ref, :selection_range)
         end
     end
   end
@@ -578,10 +560,7 @@ defmodule MingaEditor.LspActions do
             params = %{"textDocument" => %{"uri" => uri}}
             ref = Client.request(client, "textDocument/codeLens", params)
 
-            put_in(
-              state.workspace.lsp_pending,
-              Map.put(state.workspace.lsp_pending, ref, :code_lens)
-            )
+            put_lsp_pending(state, ref, :code_lens)
         end
     end
   end
@@ -620,10 +599,7 @@ defmodule MingaEditor.LspActions do
 
             ref = Client.request(client, "textDocument/inlayHint", params)
 
-            put_in(
-              state.workspace.lsp_pending,
-              Map.put(state.workspace.lsp_pending, ref, :inlay_hint)
-            )
+            put_lsp_pending(state, ref, :inlay_hint)
         end
     end
   end
@@ -1406,8 +1382,23 @@ defmodule MingaEditor.LspActions do
         }
 
         ref = Client.request(client, method, params)
-        put_in(state.workspace.lsp_pending, Map.put(state.workspace.lsp_pending, ref, kind))
+
+        EditorState.update_workspace(state, fn ws ->
+          WorkspaceState.set_lsp_pending(ws, Map.put(ws.lsp_pending, ref, kind))
+        end)
     end
+  end
+
+  @spec put_lsp_pending(state(), reference(), atom() | tuple()) :: state()
+  defp put_lsp_pending(state, ref, kind) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.set_lsp_pending(ws, Map.put(ws.lsp_pending, ref, kind))
+    end)
+  end
+
+  @spec set_document_highlights(state(), [DocumentHighlight.t()] | nil) :: state()
+  defp set_document_highlights(state, highlights) do
+    EditorState.update_workspace(state, &WorkspaceState.set_document_highlights(&1, highlights))
   end
 
   @spec parse_single_location(map()) ::
@@ -1713,10 +1704,7 @@ defmodule MingaEditor.LspActions do
         Enum.reduce(unresolved, state, fn lens, st ->
           ref = Client.request(client, "codeLens/resolve", lens)
 
-          put_in(
-            st.workspace.lsp_pending,
-            Map.put(st.workspace.lsp_pending, ref, :code_lens_resolve)
-          )
+          put_lsp_pending(st, ref, :code_lens_resolve)
         end)
     end
   end
@@ -1937,10 +1925,7 @@ defmodule MingaEditor.LspActions do
         params = %{"item" => item}
         ref = Client.request(client, "callHierarchy/incomingCalls", params)
 
-        put_in(
-          state.workspace.lsp_pending,
-          Map.put(state.workspace.lsp_pending, ref, :incoming_calls)
-        )
+        put_lsp_pending(state, ref, :incoming_calls)
     end
   end
 
@@ -1956,10 +1941,7 @@ defmodule MingaEditor.LspActions do
         params = %{"item" => item}
         ref = Client.request(client, "callHierarchy/outgoingCalls", params)
 
-        put_in(
-          state.workspace.lsp_pending,
-          Map.put(state.workspace.lsp_pending, ref, :outgoing_calls)
-        )
+        put_lsp_pending(state, ref, :outgoing_calls)
     end
   end
 

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -309,18 +309,19 @@ defmodule MingaEditor.Mouse do
         state
       end
 
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | mouse: MouseState.set_hover(state.workspace.mouse, row, col, backend: state.backend)
-        }
-    }
+    update_mouse(state, &MouseState.set_hover(&1, row, col, backend: state.backend))
   end
 
   # ── Ignore all other mouse events ──
 
   def handle(state, _row, _col, _button, _mods, _type, _cc), do: state
+
+  @spec update_mouse(state(), (MouseState.t() -> MouseState.t())) :: state()
+  defp update_mouse(state, fun) when is_function(fun, 1) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.set_mouse(ws, fun.(ws.mouse))
+    end)
+  end
 
   @spec handle_left_drag(
           state(),
@@ -524,13 +525,7 @@ defmodule MingaEditor.Mouse do
 
             state = EditorState.transition_mode(state, :visual, visual_state)
 
-            %{
-              state
-              | workspace: %{
-                  state.workspace
-                  | mouse: MouseState.start_drag(state.workspace.mouse, {line, word_start})
-                }
-            }
+            update_mouse(state, &MouseState.start_drag(&1, {line, word_start}))
 
           nil ->
             state
@@ -565,13 +560,7 @@ defmodule MingaEditor.Mouse do
 
         state = EditorState.transition_mode(state, :visual, visual_state)
 
-        %{
-          state
-          | workspace: %{
-              state.workspace
-              | mouse: MouseState.start_drag(state.workspace.mouse, {line, 0})
-            }
-        }
+        update_mouse(state, &MouseState.start_drag(&1, {line, 0}))
     end
   end
 
@@ -776,13 +765,7 @@ defmodule MingaEditor.Mouse do
 
     case WindowTree.separator_at(state.workspace.windows.tree, screen, row, col) do
       {:ok, {dir, sep_pos}} ->
-        %{
-          state
-          | workspace: %{
-              state.workspace
-              | mouse: MouseState.start_resize(state.workspace.mouse, dir, sep_pos)
-            }
-        }
+        update_mouse(state, &MouseState.start_resize(&1, dir, sep_pos))
 
       :error ->
         state
@@ -921,13 +904,7 @@ defmodule MingaEditor.Mouse do
         state = cancel_mode_for_mouse(state)
         state = EditorState.transition_mode(state, :normal)
 
-        %{
-          state
-          | workspace: %{
-              state.workspace
-              | mouse: MouseState.start_drag(state.workspace.mouse, {target_line, target_col})
-            }
-        }
+        update_mouse(state, &MouseState.start_drag(&1, {target_line, target_col}))
     end
   end
 

--- a/lib/minga_editor/mouse_hover_tooltip.ex
+++ b/lib/minga_editor/mouse_hover_tooltip.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.MouseHoverTooltip do
   alias Minga.Diagnostics
   alias MingaEditor.HoverPopup
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias Minga.LSP.Client
   alias Minga.LSP.SyncServer
 
@@ -80,43 +81,31 @@ defmodule MingaEditor.MouseHoverTooltip do
           integer()
         ) :: state()
   defp send_hover_request(state, buf, buf_line, buf_col, row, col) do
-    clients = SyncServer.clients_for_buffer(buf)
+    with [client | _] <- SyncServer.clients_for_buffer(buf),
+         path when is_binary(path) <- Buffer.file_path(buf) do
+      uri = SyncServer.path_to_uri(path)
 
-    case clients do
-      [] ->
-        state
+      params = %{
+        "textDocument" => %{"uri" => uri},
+        "position" => %{"line" => buf_line, "character" => buf_col}
+      }
 
-      [client | _] ->
-        file_path = Buffer.file_path(buf)
-
-        case file_path do
-          nil ->
-            state
-
-          path ->
-            uri = SyncServer.path_to_uri(path)
-
-            params = %{
-              "textDocument" => %{"uri" => uri},
-              "position" => %{"line" => buf_line, "character" => buf_col}
-            }
-
-            ref = Client.request(client, "textDocument/hover", params)
-
-            # Store the mouse screen position for the hover popup anchor
-            state =
-              put_in(
-                state.workspace.lsp_pending,
-                Map.put(state.workspace.lsp_pending, ref, {:hover_mouse, row, col})
-              )
-
-            state
-        end
+      ref = Client.request(client, "textDocument/hover", params)
+      put_lsp_pending(state, ref, {:hover_mouse, row, col})
+    else
+      _ -> state
     end
   rescue
     _ -> state
   catch
     :exit, _ -> state
+  end
+
+  @spec put_lsp_pending(state(), reference(), atom() | tuple()) :: state()
+  defp put_lsp_pending(state, ref, kind) do
+    EditorState.update_workspace(state, fn ws ->
+      WorkspaceState.set_lsp_pending(ws, Map.put(ws.lsp_pending, ref, kind))
+    end)
   end
 
   @spec gutter_width(term()) :: non_neg_integer()

--- a/lib/minga_editor/render_pipeline/scroll.ex
+++ b/lib/minga_editor/render_pipeline/scroll.ex
@@ -20,6 +20,7 @@ defmodule MingaEditor.RenderPipeline.Scroll do
   alias MingaEditor.Renderer.Gutter
   alias MingaEditor.Renderer.SearchHighlight
   alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
   alias MingaEditor.Window
 
@@ -169,10 +170,17 @@ defmodule MingaEditor.RenderPipeline.Scroll do
 
         scroll = %{scroll | window: updated_window}
         new_map = Map.put(st.workspace.windows.map, win_id, updated_window)
-        st = %{st | workspace: %{st.workspace | windows: %{st.workspace.windows | map: new_map}}}
+
+        windows = Windows.set_map(st.workspace.windows, new_map)
+        st = %{st | workspace: put_windows(st.workspace, windows)}
+
         {Map.put(acc, win_id, scroll), st}
     end
   end
+
+  @spec put_windows(map(), Windows.t()) :: map()
+  defp put_windows(workspace, windows) when is_map(workspace),
+    do: Map.put(workspace, :windows, windows)
 
   # Wraps scroll_window with a catch for dead buffer processes. Returns
   # {:ok, scroll} on success, :skip if the buffer died mid-call.

--- a/lib/minga_editor/semantic_token_sync.ex
+++ b/lib/minga_editor/semantic_token_sync.ex
@@ -26,6 +26,7 @@ defmodule MingaEditor.SemanticTokenSync do
 
   alias Minga.Buffer
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Highlighting
   alias Minga.LSP.Client
   alias MingaEditor.Workspace.State, as: WorkspaceState
   alias Minga.LSP.SemanticTokens
@@ -127,7 +128,10 @@ defmodule MingaEditor.SemanticTokenSync do
       hl = %{hl | spans: List.to_tuple(merged)}
 
       highlights = Map.put(state.workspace.highlight.highlights, buf_pid, hl)
-      put_in(state.workspace.highlight.highlights, highlights)
+
+      EditorState.update_workspace(state, fn ws ->
+        WorkspaceState.update_highlight(ws, &Highlighting.set_highlights(&1, highlights))
+      end)
     end
   end
 

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -527,7 +527,11 @@ defmodule MingaEditor.Shell.Traditional do
     {tb, new_tab} = TabBar.add(tb, :file, label)
 
     # Leave agent UI view: reset to editor scope and window content type
-    workspace = %{workspace | agent_ui: UIState.new(), keymap_scope: :editor}
+    workspace =
+      workspace
+      |> WorkspaceState.set_agent_ui(UIState.new())
+      |> WorkspaceState.set_keymap_scope(:editor)
+
     workspace = reset_active_window_to_buffer(workspace)
     workspace = WorkspaceState.sync_active_window_buffer(workspace)
 
@@ -587,7 +591,10 @@ defmodule MingaEditor.Shell.Traditional do
             content: Content.buffer(buffers.active)
         }
 
-        %{workspace | windows: %{workspace.windows | map: Map.put(map, id, updated)}}
+        WorkspaceState.set_windows(
+          workspace,
+          Windows.set_map(workspace.windows, Map.put(map, id, updated))
+        )
 
       nil ->
         workspace

--- a/lib/minga_editor/shell/traditional/state.ex
+++ b/lib/minga_editor/shell/traditional/state.ex
@@ -288,4 +288,16 @@ defmodule MingaEditor.Shell.Traditional.State do
       MapSet.member?(ToolManager.installing(), tool_name) or
       tool_name in ss.tool_prompt_queue
   end
+
+  @doc "Sets whether a CUA space leader sequence is pending."
+  @spec set_space_leader_pending(t(), boolean()) :: t()
+  def set_space_leader_pending(%{} = ss, value) when is_boolean(value) do
+    %{ss | space_leader_pending: value}
+  end
+
+  @doc "Sets the CUA space leader timer reference."
+  @spec set_space_leader_timer(t(), reference() | nil) :: t()
+  def set_space_leader_timer(%{} = ss, timer) do
+    %{ss | space_leader_timer: timer}
+  end
 end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -902,7 +902,7 @@ defmodule MingaEditor.State do
       end
 
     prev_workspace = state.workspace
-    state = put_in(state.workspace.buffers, new_bs)
+    state = update_workspace(state, &WorkspaceState.set_buffers(&1, new_bs))
 
     # Dispatch to the active shell for presentation logic
     {shell_state, workspace, shell_effects} =

--- a/lib/minga_editor/state/buffers.ex
+++ b/lib/minga_editor/state/buffers.ex
@@ -114,4 +114,23 @@ defmodule MingaEditor.State.Buffers do
         help: help
     }
   end
+
+  @doc "Sets the help buffer pid."
+  @spec set_help(t(), pid() | nil) :: t()
+  def set_help(%__MODULE__{} = bs, pid), do: %{bs | help: pid}
+
+  @doc "Sets the messages buffer pid."
+  @spec set_messages(t(), pid() | nil) :: t()
+  def set_messages(%__MODULE__{} = bs, pid), do: %{bs | messages: pid}
+
+  @doc "Overrides the active buffer pid without updating the index. Use for temporary buffer swaps where the pid is not in the buffer list."
+  @spec set_active_override(t(), pid() | nil) :: t()
+  def set_active_override(%__MODULE__{} = bs, pid), do: %{bs | active: pid}
+
+  @doc "Replaces the buffer list and selects the buffer at the given index."
+  @spec replace_list(t(), [pid()], non_neg_integer()) :: t()
+  def replace_list(%__MODULE__{} = bs, list, idx) when is_list(list) and is_integer(idx) do
+    active = Enum.at(list, idx)
+    %{bs | list: list, active_index: idx, active: active}
+  end
 end

--- a/lib/minga_editor/state/dired.ex
+++ b/lib/minga_editor/state/dired.ex
@@ -54,4 +54,8 @@ defmodule MingaEditor.State.Dired do
   def exit_confirmation(%__MODULE__{} = state) do
     %{state | confirming?: false, pending_ops: []}
   end
+
+  @doc "Sets the pending keymap prefix node."
+  @spec set_pending_prefix(t(), Minga.Keymap.Bindings.node_t() | nil) :: t()
+  def set_pending_prefix(%__MODULE__{} = state, prefix), do: %{state | pending_prefix: prefix}
 end

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -190,6 +190,11 @@ defmodule MingaEditor.State.FileTree do
     %{ft | editing: nil}
   end
 
+  @doc "Replaces the tree data."
+  @spec set_tree(t(), FileTree.t() | nil) :: t()
+  def set_tree(%__MODULE__{} = ft, nil), do: %{ft | tree: nil, tree_status: :hidden}
+  def set_tree(%__MODULE__{} = ft, %FileTree{} = tree), do: replace_tree(ft, tree)
+
   @spec ensure_tree_entries(FileTree.t()) :: FileTree.t()
   defp ensure_tree_entries(%FileTree{} = tree), do: FileTree.ensure_entries(tree)
 

--- a/lib/minga_editor/state/highlighting.ex
+++ b/lib/minga_editor/state/highlighting.ex
@@ -31,4 +31,41 @@ defmodule MingaEditor.State.Highlighting do
             next_buffer_id: 1,
             last_active_at: %{},
             syntax_overrides: %{}
+
+  @doc "Sets the highlight state version."
+  @spec set_version(t(), non_neg_integer()) :: t()
+  def set_version(%__MODULE__{} = state, version) when is_integer(version) and version >= 0 do
+    %{state | version: version}
+  end
+
+  @doc "Replaces syntax overrides."
+  @spec set_syntax_overrides(t(), %{pid() => MingaEditor.UI.Theme.syntax()}) :: t()
+  def set_syntax_overrides(%__MODULE__{} = state, overrides) when is_map(overrides) do
+    %{state | syntax_overrides: overrides}
+  end
+
+  @doc "Stores highlight data for a buffer."
+  @spec put_highlight(t(), pid(), Highlight.t()) :: t()
+  def put_highlight(%__MODULE__{} = state, pid, highlight) do
+    %{state | highlights: Map.put(state.highlights, pid, highlight)}
+  end
+
+  @doc "Replaces the highlight map."
+  @spec set_highlights(t(), %{pid() => Highlight.t()}) :: t()
+  def set_highlights(%__MODULE__{} = state, highlights) when is_map(highlights) do
+    %{state | highlights: highlights}
+  end
+
+  @doc "Removes all highlight-related state for a buffer."
+  @spec remove_buffer(t(), pid(), non_neg_integer(), %{pid() => non_neg_integer()}) :: t()
+  def remove_buffer(%__MODULE__{} = state, buffer_pid, buffer_id, remaining_ids) do
+    %{
+      state
+      | buffer_ids: remaining_ids,
+        reverse_buffer_ids: Map.delete(state.reverse_buffer_ids, buffer_id),
+        highlights: Map.delete(state.highlights, buffer_pid),
+        last_active_at: Map.delete(state.last_active_at, buffer_pid),
+        syntax_overrides: Map.delete(state.syntax_overrides, buffer_pid)
+    }
+  end
 end

--- a/lib/minga_editor/state/search.ex
+++ b/lib/minga_editor/state/search.ex
@@ -27,4 +27,16 @@ defmodule MingaEditor.State.Search do
   def record_pattern(%__MODULE__{} = s, pattern) do
     %{s | last_pattern: pattern}
   end
+
+  @doc "Sets just the last search direction."
+  @spec set_last_direction(t(), Minga.Editing.Search.direction()) :: t()
+  def set_last_direction(%__MODULE__{} = s, direction) do
+    %{s | last_direction: direction}
+  end
+
+  @doc "Replaces the cached project search results."
+  @spec set_project_results(t(), [Minga.Project.ProjectSearch.match()]) :: t()
+  def set_project_results(%__MODULE__{} = s, results) when is_list(results) do
+    %{s | project_results: results}
+  end
 end

--- a/lib/minga_editor/state/windows.ex
+++ b/lib/minga_editor/state/windows.ex
@@ -39,6 +39,18 @@ defmodule MingaEditor.State.Windows do
     %{windows | tree: tree}
   end
 
+  @doc "Sets the active window id."
+  @spec set_active(t(), Window.id()) :: t()
+  def set_active(%__MODULE__{} = windows, id), do: %{windows | active: id}
+
+  @doc "Replaces the window map."
+  @spec set_map(t(), %{Window.id() => Window.t()}) :: t()
+  def set_map(%__MODULE__{} = windows, map) when is_map(map), do: %{windows | map: map}
+
+  @doc "Sets the next available window id."
+  @spec set_next_id(t(), Window.id()) :: t()
+  def set_next_id(%__MODULE__{} = windows, id), do: %{windows | next_id: id}
+
   @doc """
   Updates the window struct for the given window id.
 

--- a/test/minga/credo/no_direct_state_machine_write_check_test.exs
+++ b/test/minga/credo/no_direct_state_machine_write_check_test.exs
@@ -1,0 +1,62 @@
+Code.require_file("credo/checks/no_direct_state_machine_write_check.exs")
+
+defmodule Minga.Credo.NoDirectStateMachineWriteCheckTest do
+  use Credo.Test.Case, async: true
+
+  alias Minga.Credo.NoDirectStateMachineWriteCheck
+
+  @moduletag :credo
+
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  defp check(source_code, filename) do
+    source_code
+    |> to_source_file(filename)
+    |> run_check(NoDirectStateMachineWriteCheck, [])
+  end
+
+  test "flags put_in through guarded workspace sub-structs" do
+    """
+    defmodule MingaEditor.BadPutIn do
+      def set_active(state, pid) do
+        put_in(state.workspace.buffers.active, pid)
+      end
+    end
+    """
+    |> check("lib/minga_editor/bad_put_in.ex")
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "put_in"
+      assert issue.message =~ "workspace.buffers"
+    end)
+  end
+
+  test "flags map updates on guarded workspace sub-structs" do
+    """
+    defmodule MingaEditor.BadMapUpdate do
+      def focus_window(state, id) do
+        %{state.workspace.windows | active: id}
+      end
+    end
+    """
+    |> check("lib/minga_editor/bad_map_update.ex")
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "active:"
+      assert issue.message =~ "workspace.windows"
+    end)
+  end
+
+  test "allows owning workspace state module" do
+    """
+    defmodule MingaEditor.Workspace.State do
+      def set_buffers(workspace, buffers) do
+        %{workspace | buffers: buffers}
+      end
+    end
+    """
+    |> check("lib/minga_editor/workspace/state.ex")
+    |> refute_issues()
+  end
+end


### PR DESCRIPTION
# TL;DR
Route editor workspace sub-struct mutations through their owning state modules instead of direct struct updates. This closes the state ownership violation audit and extends the custom Credo check so `put_in` regressions are caught.

Closes #1666

## Context
Issue #1666 identified direct writes into `state.workspace.*` sub-structs across editor code. Those writes bypass the owner modules, which makes future changes to window, buffer, file tree, search, highlighting, and shell state behavior grep-dependent.

## Changes
- Added missing owner APIs for buffer, window, file tree, search, dired, highlighting, and traditional shell state mutations.
- Replaced direct workspace and shell-state mutations across editor commands, input handlers, LSP/completion paths, mouse handling, layout helpers, render pipeline code, and highlight sync.
- Updated `MingaEditor.Editing` register, mode-state, and recorder mutations to flow through `EditorState.update_workspace/2`, `WorkspaceState.update_editing/2`, and `VimState`/`Registers` setters.
- Extended `NoDirectStateMachineWriteCheck` to catch guarded `put_in(...)` paths, and added regression tests for both `put_in` and guarded workspace map updates.
- Preserved temporary active-buffer override behavior for file tree and agent navigation, where the temporary buffer is intentionally not in the normal buffer list.

## Verification
- `make lint` ✅
- `mix test.llm` ✅, 52 doctests, 97 properties, 8658 tests, 0 failures, 5 skipped, 118 excluded
- `mix test.llm test/minga/credo/no_direct_state_machine_write_check_test.exs` ✅
- Focused rechecks passed for highlight sync/handler tests and render pipeline/renderer tests while iterating.
- Verification greps show no remaining `put_in(state.workspace...)` hits outside owner files and no `%{state.shell_state ...}` hits. The remaining `%{state.workspace...` grep hits are map literals in layout renderers, not struct updates.

## Acceptance Criteria Addressed
- All identified `put_in(state.workspace.*.field, ...)` and `%{state.workspace.* | field: ...}` violations outside owning modules are replaced with owning-module APIs ✅
- Missing setter functions are added to owning modules where no suitable API existed ✅
- `MingaEditor.Editing` mutations use `WorkspaceState.update_editing` plus `VimState`/`Registers` setters ✅
- No intended behavior changes, existing tests pass ✅
- `make lint` is clean ✅
- `NoDirectStateMachineWriteCheck` catches guarded `put_in()` paths and has regression coverage ✅
