### PR TITLE
refactor(editor): encapsulate windows container API

### DIFF
--- a/lib/minga_editor/agent_activation.ex
+++ b/lib/minga_editor/agent_activation.ex
@@ -104,18 +104,15 @@ defmodule MingaEditor.AgentActivation do
   @spec set_agent_chat_window_content(EditorState.t(), pid()) :: EditorState.t()
   defp set_agent_chat_window_content(state, session) do
     active_id = state.workspace.windows.active
-    active_win = Map.get(state.workspace.windows.map, active_id)
 
-    if active_win do
-      updated_win = %{active_win | content: Content.agent_chat(session)}
-      new_map = Map.put(state.workspace.windows.map, active_id, updated_win)
+    EditorState.update_workspace(state, fn ws ->
+      windows =
+        Windows.update(ws.windows, active_id, fn active_win ->
+          %{active_win | content: Content.agent_chat(session)}
+        end)
 
-      EditorState.update_workspace(state, fn ws ->
-        WorkspaceState.set_windows(ws, Windows.set_map(ws.windows, new_map))
-      end)
-    else
-      state
-    end
+      WorkspaceState.set_windows(ws, windows)
+    end)
   end
 
   @spec focus_prompt(EditorState.t()) :: EditorState.t()

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -432,36 +432,37 @@ defmodule MingaEditor.Commands.Movement do
   defp split_window(state, direction) do
     ws = state.workspace.windows
     active_id = ws.active
-    new_id = ws.next_id
+    {new_id, ws} = Windows.allocate_id(ws)
 
     case WindowTree.split(ws.tree, active_id, direction, new_id) do
-      {:ok, new_tree} -> apply_split(state, new_tree, active_id, new_id)
+      {:ok, new_tree} -> apply_split(state, ws, new_tree, active_id, new_id)
       :error -> state
     end
   end
 
-  @spec apply_split(state(), WindowTree.t(), Window.id(), Window.id()) :: state()
-  defp apply_split(state, new_tree, active_id, new_id) do
-    active_window = Map.fetch!(state.workspace.windows.map, active_id)
-    cursor = Buffer.cursor(active_window.buffer)
+  @spec apply_split(state(), Windows.t(), WindowTree.t(), Window.id(), Window.id()) :: state()
+  defp apply_split(state, ws, new_tree, active_id, new_id) do
+    case Windows.fetch(ws, active_id) do
+      {:ok, active_window} ->
+        cursor = Buffer.cursor(active_window.buffer)
 
-    # New window gets a copy of the current cursor position
-    new_window = Window.new(new_id, active_window.buffer, 24, 80, cursor)
+        # New window gets a copy of the current cursor position
+        new_window = Window.new(new_id, active_window.buffer, 24, 80, cursor)
 
-    # Also snapshot the current cursor into the active window
-    state = EditorState.update_window(state, active_id, &%{&1 | cursor: cursor})
+        # Also snapshot the current cursor into the active window
+        new_windows =
+          ws
+          |> Windows.update(active_id, &%{&1 | cursor: cursor})
+          |> Windows.set_tree(new_tree)
+          |> Windows.add_window(new_window)
 
-    ws = state.workspace.windows
+        state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, new_windows))
 
-    new_windows =
-      ws
-      |> Windows.set_tree(new_tree)
-      |> Windows.set_map(Map.put(ws.map, new_id, new_window))
-      |> Windows.set_next_id(new_id + 1)
+        resize_windows_to_layout(state)
 
-    state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, new_windows))
-
-    resize_windows_to_layout(state)
+      :error ->
+        state
+    end
   end
 
   @spec resize_windows_to_layout(state()) :: state()
@@ -523,34 +524,42 @@ defmodule MingaEditor.Commands.Movement do
   defp close_window(state) do
     ws = state.workspace.windows
 
-    case WindowTree.close(ws.tree, ws.active) do
-      {:ok, new_tree} ->
-        old_id = ws.active
-        remaining = WindowTree.leaves(new_tree)
-        new_active = hd(remaining)
-        new_active_window = Map.fetch!(ws.map, new_active)
-
-        # Restore the surviving window's cursor into the buffer
-        Buffer.move_to(new_active_window.buffer, new_active_window.cursor)
-
-        new_windows =
-          ws
-          |> Windows.set_tree(new_tree)
-          |> Windows.set_map(Map.delete(ws.map, old_id))
-          |> Windows.set_active(new_active)
-
-        new_buffers =
-          Buffers.set_active_override(state.workspace.buffers, new_active_window.buffer)
-
-        EditorState.update_workspace(state, fn workspace ->
-          workspace
-          |> WorkspaceState.set_windows(new_windows)
-          |> WorkspaceState.set_buffers(new_buffers)
-        end)
+    case Windows.remove_window(ws, ws.active) do
+      {:ok, removed_windows} ->
+        focus_remaining_window(state, removed_windows)
 
       :error ->
         EditorState.set_status(state, "Cannot close the last window")
     end
+  end
+
+  @spec focus_remaining_window(state(), Windows.t()) :: state()
+  defp focus_remaining_window(state, removed_windows) do
+    remaining = WindowTree.leaves(removed_windows.tree)
+    new_active = hd(remaining)
+
+    case Windows.fetch(removed_windows, new_active) do
+      {:ok, new_active_window} ->
+        apply_remaining_window_focus(state, removed_windows, new_active, new_active_window)
+
+      :error ->
+        state
+    end
+  end
+
+  @spec apply_remaining_window_focus(state(), Windows.t(), Window.id(), Window.t()) :: state()
+  defp apply_remaining_window_focus(state, removed_windows, new_active, new_active_window) do
+    # Restore the surviving window's cursor into the buffer
+    Buffer.move_to(new_active_window.buffer, new_active_window.cursor)
+
+    new_windows = Windows.set_active(removed_windows, new_active)
+    new_buffers = Buffers.set_active_override(state.workspace.buffers, new_active_window.buffer)
+
+    EditorState.update_workspace(state, fn workspace ->
+      workspace
+      |> WorkspaceState.set_windows(new_windows)
+      |> WorkspaceState.set_buffers(new_buffers)
+    end)
   end
 
   # ── Private helpers ──────────────────────────────────────────────────────

--- a/lib/minga_editor/layout_preset.ex
+++ b/lib/minga_editor/layout_preset.ex
@@ -70,15 +70,8 @@ defmodule MingaEditor.LayoutPreset do
   defp remove_agent_window(state, agent_win_id) do
     state = maybe_switch_focus_away(state, agent_win_id)
 
-    case WindowTree.close(state.workspace.windows.tree, agent_win_id) do
-      {:ok, new_tree} ->
-        map = Map.delete(state.workspace.windows.map, agent_win_id)
-
-        windows =
-          state.workspace.windows
-          |> Windows.set_tree(new_tree)
-          |> Windows.set_map(map)
-
+    case Windows.remove_window(state.workspace.windows, agent_win_id) do
+      {:ok, windows} ->
         state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, windows))
 
         # If we were in agent scope, return to editor scope since the
@@ -101,14 +94,8 @@ defmodule MingaEditor.LayoutPreset do
 
   defp maybe_switch_focus_away(state, _closing_id) do
     case find_non_agent_window(state) do
-      {buf_win_id, window} ->
-        scope = EditorState.scope_for_content(window.content, state.workspace.keymap_scope)
-
-        EditorState.update_workspace(state, fn ws ->
-          ws
-          |> WorkspaceState.set_windows(Windows.set_active(ws.windows, buf_win_id))
-          |> WorkspaceState.set_keymap_scope(scope)
-        end)
+      {buf_win_id, _window} ->
+        EditorState.focus_window(state, buf_win_id)
 
       nil ->
         state
@@ -132,23 +119,20 @@ defmodule MingaEditor.LayoutPreset do
       state
     else
       # Create a new agent chat window
-      next_id = state.workspace.windows.next_id
+      {next_id, windows} = Windows.allocate_id(state.workspace.windows)
       rows = state.terminal_viewport.rows
       cols = state.terminal_viewport.cols
       agent_window = Window.new_agent_chat(next_id, agent_buffer, rows, cols)
 
       # Split the active window to add the agent pane
-      active_id = state.workspace.windows.active
+      active_id = windows.active
 
-      case WindowTree.split(state.workspace.windows.tree, active_id, direction, next_id) do
+      case WindowTree.split(windows.tree, active_id, direction, next_id) do
         {:ok, new_tree} ->
-          new_map = Map.put(state.workspace.windows.map, next_id, agent_window)
-
           windows =
-            state.workspace.windows
+            windows
             |> Windows.set_tree(new_tree)
-            |> Windows.set_map(new_map)
-            |> Windows.set_next_id(next_id + 1)
+            |> Windows.add_window(agent_window)
 
           EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, windows))
 
@@ -160,14 +144,14 @@ defmodule MingaEditor.LayoutPreset do
 
   @spec find_agent_chat_window(EditorState.t()) :: {Window.id(), Window.t()} | nil
   defp find_agent_chat_window(state) do
-    Enum.find(state.workspace.windows.map, fn {_id, window} ->
+    Windows.find_by_content(state.workspace.windows, fn window ->
       Content.agent_chat?(window.content)
     end)
   end
 
   @spec find_non_agent_window(EditorState.t()) :: {Window.id(), Window.t()} | nil
   defp find_non_agent_window(state) do
-    Enum.find(state.workspace.windows.map, fn {_id, window} ->
+    Windows.find_by_content(state.workspace.windows, fn window ->
       Content.buffer?(window.content)
     end)
   end

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -577,26 +577,26 @@ defmodule MingaEditor.Shell.Traditional do
   # Resets the active window's content type from agent_chat back to buffer.
   @spec reset_active_window_to_buffer(WorkspaceState.t()) :: WorkspaceState.t()
   defp reset_active_window_to_buffer(workspace) do
-    %{windows: %{map: map, active: id}, buffers: buffers} = workspace
-    window = Map.get(map, id)
+    %{windows: windows, buffers: buffers} = workspace
+    id = windows.active
 
-    case window do
-      %Window{content: {:buffer, _}} ->
+    case Windows.fetch(windows, id) do
+      {:ok, %Window{content: {:buffer, _}}} ->
         workspace
 
-      %Window{} ->
-        updated = %{
-          Window.invalidate(window)
-          | buffer: buffers.active,
-            content: Content.buffer(buffers.active)
-        }
+      {:ok, %Window{}} ->
+        windows =
+          Windows.update(windows, id, fn window ->
+            %{
+              Window.invalidate(window)
+              | buffer: buffers.active,
+                content: Content.buffer(buffers.active)
+            }
+          end)
 
-        WorkspaceState.set_windows(
-          workspace,
-          Windows.set_map(workspace.windows, Map.put(map, id, updated))
-        )
+        WorkspaceState.set_windows(workspace, windows)
 
-      nil ->
+      :error ->
         workspace
     end
   end

--- a/lib/minga_editor/state/windows.ex
+++ b/lib/minga_editor/state/windows.ex
@@ -51,6 +51,51 @@ defmodule MingaEditor.State.Windows do
   @spec set_next_id(t(), Window.id()) :: t()
   def set_next_id(%__MODULE__{} = windows, id), do: %{windows | next_id: id}
 
+  @doc "Allocates the next window id and advances the allocator."
+  @spec allocate_id(t()) :: {Window.id(), t()}
+  def allocate_id(%__MODULE__{next_id: id} = windows) do
+    {id, set_next_id(windows, id + 1)}
+  end
+
+  @doc "Adds a window to the container using the window's id."
+  @spec add_window(t(), Window.t()) :: t()
+  def add_window(%__MODULE__{map: map} = windows, %Window{id: id} = window) do
+    set_map(windows, Map.put(map, id, window))
+  end
+
+  @doc "Removes a tree-managed window from the container."
+  @spec remove_window(t(), Window.id()) :: {:ok, t()} | :error
+  def remove_window(%__MODULE__{tree: nil}, _id), do: :error
+
+  def remove_window(%__MODULE__{tree: tree} = windows, id) do
+    case WindowTree.close(tree, id) do
+      {:ok, new_tree} ->
+        {:ok,
+         windows
+         |> set_tree(new_tree)
+         |> delete_window(id)}
+
+      :error ->
+        :error
+    end
+  end
+
+  @doc "Deletes a window from the map without touching the window tree."
+  @spec delete_window(t(), Window.id()) :: t()
+  def delete_window(%__MODULE__{map: map} = windows, id) do
+    set_map(windows, Map.delete(map, id))
+  end
+
+  @doc "Fetches a window by id."
+  @spec fetch(t(), Window.id()) :: {:ok, Window.t()} | :error
+  def fetch(%__MODULE__{map: map}, id), do: Map.fetch(map, id)
+
+  @doc "Finds the first window matching the given predicate."
+  @spec find_by_content(t(), (Window.t() -> boolean())) :: {Window.id(), Window.t()} | nil
+  def find_by_content(%__MODULE__{map: map}, predicate) when is_function(predicate, 1) do
+    Enum.find(map, fn {_id, window} -> predicate.(window) end)
+  end
+
   @doc """
   Updates the window struct for the given window id.
 

--- a/lib/minga_editor/ui/popup/lifecycle.ex
+++ b/lib/minga_editor/ui/popup/lifecycle.ex
@@ -35,6 +35,7 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   alias MingaEditor.FloatingWindow
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
@@ -82,7 +83,7 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   """
   @spec close_popup(state(), Window.id()) :: state()
   def close_popup(state, window_id) when is_integer(window_id) do
-    case Map.fetch(state.workspace.windows.map, window_id) do
+    case Windows.fetch(state.workspace.windows, window_id) do
       {:ok, %Window{popup_meta: %PopupActive{} = meta}} ->
         do_close(state, window_id, meta)
 
@@ -111,8 +112,8 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   @spec close_all_popups(state()) :: state()
   def close_all_popups(state) do
     popup_ids =
-      state.workspace.windows.map
-      |> Enum.filter(fn {_id, w} -> Window.popup?(w) end)
+      state.workspace.windows
+      |> Windows.popup_windows()
       |> Enum.sort_by(fn {id, _w} -> id end, :desc)
       |> Enum.map(fn {id, _w} -> id end)
 
@@ -124,9 +125,9 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   """
   @spec active_is_popup?(state()) :: boolean()
   def active_is_popup?(state) do
-    case Map.fetch(state.workspace.windows.map, state.workspace.windows.active) do
-      {:ok, window} -> Window.popup?(window)
-      :error -> false
+    case Windows.active_struct(state.workspace.windows) do
+      %Window{} = window -> Window.popup?(window)
+      nil -> false
     end
   end
 
@@ -139,7 +140,8 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   """
   @spec render_float_overlays(state()) :: [DisplayList.Overlay.t()]
   def render_float_overlays(state) do
-    state.workspace.windows.map
+    state.workspace.windows
+    |> Windows.popup_windows()
     |> Enum.filter(fn {_id, w} -> float_popup?(w) end)
     |> Enum.map(fn {_id, window} -> render_float_overlay(state, window) end)
   end
@@ -151,7 +153,8 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   """
   @spec click_inside_float?(state(), integer(), integer()) :: boolean()
   def click_inside_float?(state, row, col) do
-    state.workspace.windows.map
+    state.workspace.windows
+    |> Windows.popup_windows()
     |> Enum.any?(fn {_id, w} ->
       float_popup?(w) and inside_float_box?(state, w, row, col)
     end)
@@ -269,7 +272,7 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
     previous_active = ws.active
 
     # Create the popup window
-    next_id = ws.next_id
+    {next_id, ws} = Windows.allocate_id(ws)
     {rows, cols} = viewport_size(state)
     popup_window = Window.new(next_id, buffer_pid, rows, cols)
 
@@ -295,11 +298,12 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
         popup_window = %{popup_window | popup_meta: active}
 
         # Update state
-        new_map = Map.put(ws.map, next_id, popup_window)
-        new_windows = %{ws | tree: new_tree, map: new_map, next_id: next_id + 1}
+        windows =
+          ws
+          |> Windows.set_tree(new_tree)
+          |> Windows.add_window(popup_window)
 
-        windows = if rule.focus, do: %{new_windows | active: next_id}, else: new_windows
-        state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, windows))
+        state = update_popup_windows(state, windows, next_id, rule.focus)
 
         Layout.invalidate(state)
 
@@ -312,7 +316,7 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
     previous_active = ws.active
 
     # Create the popup window (not added to the tree, only the map)
-    next_id = ws.next_id
+    {next_id, ws} = Windows.allocate_id(ws)
     {rows, cols} = viewport_size(state)
     popup_window = Window.new(next_id, buffer_pid, rows, cols)
 
@@ -321,21 +325,21 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
     popup_window = %{popup_window | popup_meta: active}
 
     # Add window to map but NOT to the tree (floats overlay the layout)
-    new_map = Map.put(ws.map, next_id, popup_window)
-    new_windows = %{ws | map: new_map, next_id: next_id + 1}
-    state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, new_windows))
-
-    # Optionally switch focus to the popup
-    state =
-      if rule.focus do
-        EditorState.update_workspace(state, fn wspace ->
-          WorkspaceState.set_windows(wspace, %{wspace.windows | active: next_id})
-        end)
-      else
-        state
-      end
+    windows = Windows.add_window(ws, popup_window)
+    state = update_popup_windows(state, windows, next_id, rule.focus)
 
     Layout.invalidate(state)
+  end
+
+  @spec update_popup_windows(state(), Windows.t(), Window.id(), boolean()) :: state()
+  defp update_popup_windows(state, windows, next_id, true) do
+    state
+    |> EditorState.update_workspace(&WorkspaceState.set_windows(&1, windows))
+    |> EditorState.focus_window(next_id)
+  end
+
+  defp update_popup_windows(state, windows, _next_id, false) do
+    EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, windows))
   end
 
   @spec do_close(state(), Window.id(), PopupActive.t()) :: state()
@@ -347,15 +351,12 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
       if ws.active == window_id do
         # Restore focus to the previous active window, or find any non-popup window
         restore_id =
-          if Map.has_key?(ws.map, meta.previous_active) do
-            meta.previous_active
-          else
-            find_non_popup_window(ws.map, window_id)
+          case Windows.fetch(ws, meta.previous_active) do
+            {:ok, _window} -> meta.previous_active
+            :error -> find_non_popup_window(ws, window_id)
           end
 
-        EditorState.update_workspace(state, fn wspace ->
-          WorkspaceState.set_windows(wspace, %{wspace.windows | active: restore_id})
-        end)
+        EditorState.focus_window(state, restore_id)
       else
         state
       end
@@ -365,15 +366,7 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
     # Remove just this popup's window from the current tree (like
     # delete-window in Emacs). We used to restore a full tree snapshot,
     # but that clobbers any other popups that were opened after this one.
-    new_tree =
-      case WindowTree.close(ws.tree, window_id) do
-        {:ok, tree} -> tree
-        :error -> ws.tree
-      end
-
-    # Remove the popup window from the map
-    new_map = Map.delete(ws.map, window_id)
-    new_windows = %{ws | tree: new_tree, map: new_map}
+    new_windows = remove_popup_window(ws, window_id, meta)
     state = EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, new_windows))
 
     Layout.invalidate(state)
@@ -431,9 +424,23 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   defp viewport_size(%{viewport: %Viewport{rows: r, cols: c}}), do: {r, c}
   defp viewport_size(_state), do: {24, 80}
 
-  @spec find_non_popup_window(%{Window.id() => Window.t()}, Window.id()) :: Window.id()
-  defp find_non_popup_window(window_map, exclude_id) do
-    case Enum.find(window_map, fn {id, w} -> id != exclude_id and not Window.popup?(w) end) do
+  @spec remove_popup_window(Windows.t(), Window.id(), PopupActive.t()) :: Windows.t()
+  defp remove_popup_window(ws, window_id, %PopupActive{rule: %Rule{display: :float}}) do
+    Windows.delete_window(ws, window_id)
+  end
+
+  defp remove_popup_window(ws, window_id, %PopupActive{}) do
+    case Windows.remove_window(ws, window_id) do
+      {:ok, windows} -> windows
+      :error -> Windows.delete_window(ws, window_id)
+    end
+  end
+
+  @spec find_non_popup_window(Windows.t(), Window.id()) :: Window.id()
+  defp find_non_popup_window(windows, exclude_id) do
+    case Windows.find_by_content(windows, fn window ->
+           window.id != exclude_id and not Window.popup?(window)
+         end) do
       {id, _window} -> id
       nil -> exclude_id
     end

--- a/lib/minga_editor/workspace/state.ex
+++ b/lib/minga_editor/workspace/state.ex
@@ -118,10 +118,12 @@ defmodule MingaEditor.Workspace.State do
   """
   @spec invalidate_all_windows(t()) :: t()
   def invalidate_all_windows(%__MODULE__{windows: ws} = wspace) do
-    new_map =
-      Map.new(ws.map, fn {id, window} -> {id, Window.invalidate(window)} end)
+    windows =
+      Enum.reduce(ws.map, ws, fn {id, _window}, acc ->
+        Windows.update(acc, id, &Window.invalidate/1)
+      end)
 
-    %{wspace | windows: %{ws | map: new_map}}
+    %{wspace | windows: windows}
   end
 
   @doc """
@@ -144,19 +146,21 @@ defmodule MingaEditor.Workspace.State do
   @spec sync_active_window_buffer(t()) :: t()
   def sync_active_window_buffer(%__MODULE__{buffers: %{active: nil}} = wspace), do: wspace
 
-  def sync_active_window_buffer(
-        %__MODULE__{windows: %{map: windows, active: id} = ws, buffers: buffers} = wspace
-      ) do
-    case Map.fetch(windows, id) do
-      {:ok, %Window{buffer: existing, content: {:buffer, _}} = window}
-      when existing != buffers.active ->
-        window = %{
-          Window.invalidate(window)
-          | buffer: buffers.active,
-            content: Content.buffer(buffers.active)
-        }
+  def sync_active_window_buffer(%__MODULE__{windows: ws, buffers: buffers} = wspace) do
+    id = ws.active
 
-        %{wspace | windows: %{ws | map: Map.put(windows, id, window)}}
+    case Windows.fetch(ws, id) do
+      {:ok, %Window{buffer: existing, content: {:buffer, _}}} when existing != buffers.active ->
+        windows =
+          Windows.update(ws, id, fn window ->
+            %{
+              Window.invalidate(window)
+              | buffer: buffers.active,
+                content: Content.buffer(buffers.active)
+            }
+          end)
+
+        %{wspace | windows: windows}
 
       _ ->
         wspace

--- a/test/minga_editor/commands/window_test.exs
+++ b/test/minga_editor/commands/window_test.exs
@@ -209,6 +209,29 @@ defmodule MingaEditor.Commands.WindowTest do
       assert state.workspace.buffers.active == buffer
       refute EditorState.split?(state)
     end
+
+    test "closing a split restores the surviving window cursor into the buffer" do
+      {editor, buffer} = start_editor("hello\nworld")
+      split_vertical(editor)
+
+      # Move to the right split and move the cursor so the active window
+      # cursor differs from the surviving window's saved cursor.
+      send_keys(editor, [?\s, ?w, ?l])
+      send_key(editor, ?l)
+      send_key(editor, ?l)
+
+      state = get_state(editor)
+      assert state.workspace.windows.active == 2
+      assert state.workspace.windows.map[2].cursor == {0, 2}
+
+      close_window(editor)
+      state = get_state(editor)
+
+      assert BufferProcess.cursor(buffer) == {0, 0}
+      assert state.workspace.windows.active == 1
+      assert state.workspace.windows.map[1].cursor == {0, 0}
+      refute EditorState.split?(state)
+    end
   end
 
   describe "editing in split windows" do

--- a/test/minga_editor/input/popup_test.exs
+++ b/test/minga_editor/input/popup_test.exs
@@ -13,7 +13,22 @@ defmodule MingaEditor.Input.PopupTest do
   alias Minga.Popup.Rule
 
   defp fake_pid do
-    spawn(fn -> Process.sleep(:infinity) end)
+    spawn(fn -> fake_pid_loop() end)
+  end
+
+  defp fake_pid_loop do
+    receive do
+      {:"$gen_call", from, :cursor} ->
+        GenServer.reply(from, {0, 0})
+        fake_pid_loop()
+
+      {:"$gen_call", from, {:move_to, _pos}} ->
+        GenServer.reply(from, :ok)
+        fake_pid_loop()
+
+      _ ->
+        fake_pid_loop()
+    end
   end
 
   defp build_state_with_popup(opts \\ []) do
@@ -32,7 +47,7 @@ defmodule MingaEditor.Input.PopupTest do
 
     vim = %VimState{VimState.new() | mode: mode}
 
-    %EditorState{
+    state = %EditorState{
       port_manager: nil,
       workspace: %MingaEditor.Workspace.State{
         viewport: Viewport.new(24, 80),
@@ -41,11 +56,17 @@ defmodule MingaEditor.Input.PopupTest do
         windows: %Windows{
           tree: {:split, :horizontal, {:leaf, 1}, {:leaf, 2}, 16},
           map: %{1 => main_window, 2 => popup_window},
-          active: if(focus_popup, do: 2, else: 1),
+          active: 1,
           next_id: 3
         }
       }
     }
+
+    if focus_popup do
+      EditorState.focus_window(state, 2)
+    else
+      state
+    end
   end
 
   defp build_state_no_popup do

--- a/test/minga_editor/layout_preset_test.exs
+++ b/test/minga_editor/layout_preset_test.exs
@@ -104,20 +104,24 @@ defmodule MingaEditor.LayoutPresetTest do
   describe "restore_default/1" do
     test "switches active window away from agent before removing" do
       state = make_state()
+      file_buffer = state.workspace.buffers.active
       buf = agent_buffer()
 
-      state = LayoutPreset.apply(state, :agent_right, buf)
-
-      # Set agent window as active
-      state = %{
+      state =
         state
-        | workspace: %{state.workspace | windows: %{state.workspace.windows | active: 2}}
-      }
+        |> LayoutPreset.apply(:agent_right, buf)
+        |> EditorState.focus_window(2)
+
+      assert state.workspace.windows.active == 2
+      assert state.workspace.buffers.active == buf
+      assert state.workspace.keymap_scope == :agent
 
       state = LayoutPreset.restore_default(state)
 
       # Active should be the file buffer window (1), not the deleted agent window (2)
       assert state.workspace.windows.active == 1
+      assert state.workspace.buffers.active == file_buffer
+      assert state.workspace.keymap_scope == :editor
       refute Map.has_key?(state.workspace.windows.map, 2)
     end
   end

--- a/test/minga_editor/state/windows_test.exs
+++ b/test/minga_editor/state/windows_test.exs
@@ -65,6 +65,67 @@ defmodule MingaEditor.State.WindowsTest do
     end
   end
 
+  # ── container API ─────────────────────────────────────────────────────────────
+
+  describe "allocate_id/1" do
+    test "returns the next id and bumps the allocator" do
+      ws = new_windows()
+
+      assert {2, updated} = Windows.allocate_id(ws)
+      assert updated.next_id == 3
+    end
+  end
+
+  describe "add_window/2" do
+    test "inserts the window by id" do
+      ws = new_windows()
+      window = Window.new(2, self(), 24, 80)
+
+      updated = Windows.add_window(ws, window)
+
+      assert Windows.fetch(updated, 2) == {:ok, window}
+    end
+  end
+
+  describe "remove_window/2" do
+    test "removes the window from the map and tree" do
+      ws = split_windows()
+
+      assert {:ok, updated} = Windows.remove_window(ws, 2)
+      assert Windows.fetch(updated, 2) == :error
+      assert updated.tree == {:leaf, 1}
+    end
+
+    test "returns error when closing the last window" do
+      assert Windows.remove_window(new_windows(), 1) == :error
+    end
+  end
+
+  describe "delete_window/2" do
+    test "removes a window from the map without changing the tree" do
+      ws = split_windows()
+
+      updated = Windows.delete_window(ws, 2)
+
+      assert Windows.fetch(updated, 2) == :error
+      assert updated.tree == ws.tree
+    end
+  end
+
+  describe "find_by_content/2" do
+    test "returns the first matching window" do
+      ws = split_windows()
+
+      assert {2, %Window{id: 2}} = Windows.find_by_content(ws, fn window -> window.id == 2 end)
+    end
+
+    test "returns nil when no window matches" do
+      ws = split_windows()
+
+      assert Windows.find_by_content(ws, fn window -> window.id == 99 end) == nil
+    end
+  end
+
   # ── update/3 ─────────────────────────────────────────────────────────────────
 
   describe "update/3" do

--- a/test/minga_editor/ui/popup/lifecycle_test.exs
+++ b/test/minga_editor/ui/popup/lifecycle_test.exs
@@ -6,6 +6,7 @@ defmodule MingaEditor.UI.Popup.LifecycleTest do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Windows
+  alias MingaEditor.UI.Popup.Active, as: PopupActive
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
   alias MingaEditor.Window
@@ -24,6 +25,14 @@ defmodule MingaEditor.UI.Popup.LifecycleTest do
     receive do
       {:"$gen_call", from, :display_name} ->
         GenServer.reply(from, "[test]")
+        fake_pid_loop()
+
+      {:"$gen_call", from, :cursor} ->
+        GenServer.reply(from, {0, 0})
+        fake_pid_loop()
+
+      {:"$gen_call", from, {:move_to, _pos}} ->
+        GenServer.reply(from, :ok)
         fake_pid_loop()
 
       _ ->
@@ -165,10 +174,37 @@ defmodule MingaEditor.UI.Popup.LifecycleTest do
 
       # Focus is on the popup
       assert with_popup.workspace.windows.active == 2
+      assert with_popup.workspace.buffers.active == popup_buf
 
       # Close restores focus to window 1
       restored = Lifecycle.close_popup(with_popup, 2)
       assert restored.workspace.windows.active == 1
+      assert restored.workspace.buffers.active == state.workspace.buffers.active
+    end
+
+    test "falls back to a remaining editor window when previous_active is gone", %{
+      state: state,
+      popup_buf: popup_buf
+    } do
+      rule = Rule.new("*Warnings*", focus: true)
+      popup_window = Window.new(3, popup_buf, 24, 80)
+      popup_window = %{popup_window | popup_meta: PopupActive.new(rule, 3, 2)}
+
+      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 3)
+
+      state =
+        put_in(state.workspace.windows, %Windows{
+          tree: tree,
+          map: %{1 => state.workspace.windows.map[1], 3 => popup_window},
+          active: 3,
+          next_id: 4
+        })
+
+      restored = Lifecycle.close_popup(state, 3)
+
+      assert restored.workspace.windows.active == 1
+      assert restored.workspace.buffers.active == state.workspace.buffers.active
+      refute Map.has_key?(restored.workspace.windows.map, 3)
     end
 
     test "is a no-op for non-popup windows", %{state: state, table: _t} do


### PR DESCRIPTION
# TL;DR
Windows container mutations now flow through `MingaEditor.State.Windows` APIs instead of each caller manually allocating ids and editing the window map. Focus-changing popup and layout paths now use `EditorState.focus_window/2`, so `windows.active`, `buffers.active`, cursor restoration, and keymap scope stay aligned.

Closes #1160

## Context
Issue #1160 called out write-path callers that reached into `Windows.t()` fields directly, especially layout presets and popup lifecycle code. This PR completes that encapsulation pass while leaving render and read-only display paths free to read the struct directly.

## Changes
- Added `Windows.allocate_id/1`, `add_window/2`, `remove_window/2`, `delete_window/2`, `fetch/2`, and `find_by_content/2`.
- Migrated layout preset split and restore logic to allocate, insert, remove, query, and focus through owning APIs.
- Migrated popup open, close, close-all, active-popup, float overlay, and hit-test paths to use the `Windows` API.
- Routed focused popup open/close and agent-pane removal through `EditorState.focus_window/2` instead of direct `windows.active` writes.
- Migrated adjacent window write paths in agent activation, movement commands, traditional shell reset, and workspace helpers to avoid manual map replacement where the owning API now exists.
- Added focused tests for the container API, cursor restoration, popup fallback focus restoration, `buffers.active` restoration, and keymap scope restoration.

## Verification
- `mix test.llm test/minga_editor/commands/window_test.exs test/minga_editor/input/popup_test.exs test/minga_editor/layout_preset_test.exs test/minga_editor/state/windows_test.exs test/minga_editor/ui/popup/lifecycle_test.exs` passed: 81 tests, 0 failures.
- `make lint` passed.
- `git diff --check` passed.
- `mix test.llm` was attempted after the final focus fixes. Touched window/popup tests passed, but the full suite hit unrelated failures/timeouts. The persistent `test/minga/buffer/auto_save_test.exs:16` failure reproduces on `main` in the primary checkout.

## Acceptance Criteria Addressed
- `Windows` module exposes `allocate_id/1`, `add_window/2`, `remove_window/2`, and `find_by_content/2` functions ✅
- `layout_preset.ex` uses `Windows` API instead of reaching into `.tree`, `.map`, `.next_id` write paths ✅
- `popup/lifecycle.ex` uses `Windows` API instead of raw map manipulation ✅
- Direct `windows.map` write-path access was migrated from the scoped callers; remaining direct reads are owner, render, or read-only paths ✅
- Existing focused window-related tests pass ✅
