### PR TITLE
fix(editor): preserve visual selection on context click

### DIFF
--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -877,20 +877,123 @@ defmodule MingaEditor.Mouse do
   @spec handle_context_click(state(), non_neg_integer(), non_neg_integer()) :: state()
   defp handle_context_click(state, row, col) do
     state = maybe_unfocus_file_tree_for_content_click(state)
+    target = mouse_to_buffer_pos(state, row, col)
+    preserve_selection? = context_click_preserves_visual_selection?(state, row, col, target)
     state = maybe_focus_window_at(state, row, col)
 
-    case mouse_to_buffer_pos(state, row, col) do
+    case target do
       nil ->
         state
 
       {target_line, target_col} ->
-        Buffer.move_to(state.workspace.buffers.active, {target_line, target_col})
-
-        state
-        |> cancel_mode_for_mouse()
-        |> EditorState.transition_mode(:normal)
+        handle_context_click_at_buffer_pos(state, target_line, target_col, preserve_selection?)
     end
   end
+
+  @spec context_click_preserves_visual_selection?(
+          state(),
+          non_neg_integer(),
+          non_neg_integer(),
+          {non_neg_integer(), non_neg_integer()} | nil
+        ) ::
+          boolean()
+  defp context_click_preserves_visual_selection?(_state, _row, _col, nil), do: false
+
+  defp context_click_preserves_visual_selection?(state, row, col, {target_line, target_col}) do
+    context_click_targets_active_buffer?(state, row, col) and
+      click_inside_visual_selection?(state, target_line, target_col)
+  end
+
+  @spec handle_context_click_at_buffer_pos(
+          state(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean()
+        ) :: state()
+  defp handle_context_click_at_buffer_pos(state, _target_line, _target_col, true), do: state
+
+  defp handle_context_click_at_buffer_pos(state, target_line, target_col, false) do
+    Buffer.move_to(state.workspace.buffers.active, {target_line, target_col})
+
+    state
+    |> cancel_mode_for_mouse()
+    |> EditorState.transition_mode(:normal)
+  end
+
+  @spec context_click_targets_active_buffer?(state(), non_neg_integer(), non_neg_integer()) ::
+          boolean()
+  defp context_click_targets_active_buffer?(%{workspace: %{windows: %{tree: nil}}}, _row, _col),
+    do: true
+
+  defp context_click_targets_active_buffer?(
+         %{workspace: %{buffers: %{active: active}}} = state,
+         row,
+         col
+       ) do
+    screen = Layout.get(state).editor_area
+
+    case WindowTree.window_at(state.workspace.windows.tree, screen, row, col) do
+      {:ok, id, _rect} ->
+        case Map.fetch(state.workspace.windows.map, id) do
+          {:ok, %Window{buffer: ^active}} -> true
+          _ -> false
+        end
+
+      :error ->
+        false
+    end
+  end
+
+  @spec click_inside_visual_selection?(state(), non_neg_integer(), non_neg_integer()) :: boolean()
+  defp click_inside_visual_selection?(
+         %{
+           workspace: %{
+             editing: %{mode: :visual, mode_state: %VisualState{visual_type: :char} = mode_state},
+             buffers: %{active: buf}
+           }
+         },
+         target_line,
+         target_col
+       )
+       when is_pid(buf) do
+    {cursor_line, cursor_col} = Buffer.cursor(buf)
+    {anchor_line, anchor_col} = mode_state.visual_anchor
+
+    {start_pos, end_pos} =
+      normalize_position_range({anchor_line, anchor_col}, {cursor_line, cursor_col})
+
+    target_pos = {target_line, target_col}
+
+    target_pos >= start_pos and target_pos <= end_pos
+  end
+
+  defp click_inside_visual_selection?(
+         %{
+           workspace: %{
+             editing: %{mode: :visual, mode_state: %VisualState{visual_type: :line} = mode_state},
+             buffers: %{active: buf}
+           }
+         },
+         target_line,
+         _target_col
+       )
+       when is_pid(buf) do
+    {cursor_line, _cursor_col} = Buffer.cursor(buf)
+    {anchor_line, _anchor_col} = mode_state.visual_anchor
+    min_line = min(anchor_line, cursor_line)
+    max_line = max(anchor_line, cursor_line)
+
+    target_line >= min_line and target_line <= max_line
+  end
+
+  defp click_inside_visual_selection?(_state, _target_line, _target_col), do: false
+
+  @spec normalize_position_range(
+          {non_neg_integer(), non_neg_integer()},
+          {non_neg_integer(), non_neg_integer()}
+        ) :: {{non_neg_integer(), non_neg_integer()}, {non_neg_integer(), non_neg_integer()}}
+  defp normalize_position_range(first, second) when first <= second, do: {first, second}
+  defp normalize_position_range(first, second), do: {second, first}
 
   @spec handle_buffer_content_click(state(), non_neg_integer(), non_neg_integer()) :: state()
   defp handle_buffer_content_click(state, row, col) do

--- a/test/minga_editor/commands/cmd_copy_cut_test.exs
+++ b/test/minga_editor/commands/cmd_copy_cut_test.exs
@@ -118,6 +118,18 @@ defmodule MingaEditor.Commands.CmdCopyCutTest do
       assert BufferProcess.content(buf) == "hello world"
     end
 
+    test "cmd_copy from preserved visual selection copies selection text" do
+      buf = start_buffer("selected text\nsecond line")
+      BufferProcess.move_to(buf, {0, 7})
+      state = build_state(buf) |> with_visual_mode(buf, {0, 0}, :char)
+
+      new_state = Editing.execute(state, :cmd_copy)
+
+      assert register_entry(new_state) == {"selected", :charwise}
+      assert BufferProcess.content(buf) == "selected text\nsecond line"
+      assert_receive {:clipboard_written, "selected"}, 200
+    end
+
     test "copies linewise selection with cursor above anchor" do
       buf = start_buffer("aaa\nbbb\nccc")
       BufferProcess.move_to(buf, {0, 0})

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -11,6 +11,7 @@ defmodule MingaEditor.MouseTest do
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Windows
+  alias Minga.Mode.VisualState
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
   alias MingaEditor.Workspace.State, as: WorkspaceState
@@ -94,6 +95,19 @@ defmodule MingaEditor.MouseTest do
       editor,
       {:minga_input, {:capabilities_updated, %Capabilities{frontend_type: :native_gui}}}
     )
+
+    _ = :sys.get_state(editor, @sync_timeout)
+  end
+
+  defp set_visual_selection(editor, buffer, anchor, cursor, visual_type) do
+    BufferProcess.move_to(buffer, cursor)
+
+    :sys.replace_state(editor, fn state ->
+      EditorState.transition_mode(state, :visual, %VisualState{
+        visual_anchor: anchor,
+        visual_type: visual_type
+      })
+    end)
 
     _ = :sys.get_state(editor, @sync_timeout)
   end
@@ -336,6 +350,67 @@ defmodule MingaEditor.MouseTest do
       assert line == 1
       assert col == 2
       assert state(editor).workspace.editing.mode == :normal
+    end
+
+    test "right click inside visual char selection preserves selection" do
+      {editor, buffer} = start_editor("hello world\nsecond line")
+      set_visual_selection(editor, buffer, {0, 0}, {0, 4}, :char)
+
+      send_mouse(editor, @content_row, @gutter + 2, :right, :press)
+
+      s = state(editor)
+      assert s.workspace.editing.mode == :visual
+      assert s.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert s.workspace.editing.mode_state.visual_type == :char
+      assert BufferProcess.cursor(buffer) == {0, 4}
+    end
+
+    test "right click inside visual line selection preserves selection" do
+      {editor, buffer} = start_editor("one\ntwo\nthree\nfour")
+      set_visual_selection(editor, buffer, {0, 0}, {2, 0}, :line)
+
+      send_mouse(editor, @content_row + 1, @gutter + 2, :right, :press)
+
+      s = state(editor)
+      assert s.workspace.editing.mode == :visual
+      assert s.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert s.workspace.editing.mode_state.visual_type == :line
+      assert BufferProcess.cursor(buffer) == {2, 0}
+    end
+
+    test "right click outside visual char selection clears selection" do
+      {editor, buffer} = start_editor("hello world\nsecond line")
+      set_visual_selection(editor, buffer, {0, 0}, {0, 4}, :char)
+
+      send_mouse(editor, @content_row + 1, @gutter + 2, :right, :press)
+
+      assert state(editor).workspace.editing.mode == :normal
+      assert BufferProcess.cursor(buffer) == {1, 2}
+    end
+
+    test "native GUI Ctrl-left click inside selection preserves it" do
+      {editor, buffer} = start_editor("hello world\nsecond line")
+      set_gui_capabilities(editor)
+      set_visual_selection(editor, buffer, {0, 0}, {0, 4}, :char)
+
+      send_mouse(editor, 0, @gutter + 2, :left, :press, 0x02)
+
+      s = state(editor)
+      assert s.workspace.editing.mode == :visual
+      assert s.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert s.workspace.editing.mode_state.visual_type == :char
+      assert BufferProcess.cursor(buffer) == {0, 4}
+    end
+
+    test "native GUI Ctrl-left click outside selection clears it" do
+      {editor, buffer} = start_editor("hello world\nsecond line")
+      set_gui_capabilities(editor)
+      set_visual_selection(editor, buffer, {0, 0}, {0, 4}, :char)
+
+      send_mouse(editor, 1, @gutter + 2, :left, :press, 0x02)
+
+      assert state(editor).workspace.editing.mode == :normal
+      assert BufferProcess.cursor(buffer) == {1, 2}
     end
 
     test "left click in command mode cancels command, returns to normal" do


### PR DESCRIPTION
# TL;DR
Context-menu clicks now preserve an active visual selection when the click lands inside it, so native Copy and Cut actions operate on the selected text instead of silently falling back to cursor or line behavior.

Closes #1634

## Context
Right-click and native GUI Ctrl-left-click previously reused the normal click positioning path. That cleared visual mode before the context menu action fired, so Copy and Cut could act on the wrong text.

## Changes
- Made context clicks selection-aware in `MingaEditor.Mouse`.
- Preserved visual char and visual line selections when the click target is inside the active selection.
- Kept the existing outside-selection behavior: focus the clicked window, move the cursor, cancel visual mode, and return to normal mode.
- Kept TUI Ctrl-click behavior routed to go-to-definition while native GUI Ctrl-left-click follows context-menu semantics.
- Added mouse regression tests for right-click and native GUI Ctrl-left-click inside and outside selections.
- Added a copy regression test documenting that preserved visual selection text is copied by `cmd_copy`.

## Verification
- `mix test.llm test/minga_editor/mouse_test.exs test/minga_editor/commands/cmd_copy_cut_test.exs test/minga_editor/mouse_clipboard_test.exs` passed, 63 tests.
- `make lint` passed.
- `mix test.llm --max-cases 1` passed, 52 doctests, 97 properties, 8664 tests, 0 failures.
- `git diff --check` passed.

Note: default-concurrency `mix test.llm` still shows unrelated async/resource interference locally. I verified the same default-concurrency failure pattern on a clean `origin/main` worktree. The serialized full suite is green, and the changed tests pass in focused and full runs.

## Acceptance Criteria Addressed
- Right-clicking inside an active visual char selection keeps the visual selection active. ✅
- Right-clicking inside an active visual line selection keeps the visual-line selection active. ✅
- Right-clicking outside the active selection moves the cursor to the clicked location and clears the selection. ✅
- Native GUI Ctrl-left-click follows the same inside-selection and outside-selection behavior as right-click. ✅
- The context menu Copy and Cut actions operate on the preserved selection when one exists. ✅
- TUI behavior does not regress for plain clicks, drags, or Ctrl-click goto-definition. ✅
