### PR TITLE
refactor(editor): extract gutter sign context

### DIFF
--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -23,6 +23,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
   alias MingaEditor.Renderer.BufferLine
   alias MingaEditor.Renderer.Context
   alias MingaEditor.Renderer.Gutter
+  alias MingaEditor.Renderer.Gutter.SignContext
   alias MingaEditor.Renderer.SearchHighlight
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.Window
@@ -208,6 +209,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
     } = opts
 
     sign_w = Gutter.sign_column_width()
+    sign_ctx = SignContext.from_render_context(ctx)
     max_rows = length(lines)
     dirty_rows = dirty_screen_rows(lines, first_line, window)
     fold_start_lines = fold_start_lines(window.fold_ranges)
@@ -242,6 +244,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
                 byte_offset: byte_off,
                 screen_row: screen_row,
                 ctx: ctx,
+                sign_ctx: sign_ctx,
                 ln_style: ln_style,
                 gutter_w: gutter_w,
                 sign_w: sign_w,
@@ -315,6 +318,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
     } = opts
 
     sign_w = Gutter.sign_column_width()
+    sign_ctx = SignContext.from_render_context(ctx)
     max_rows = length(lines)
     fold_start_lines = fold_start_lines(window.fold_ranges)
 
@@ -346,6 +350,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
                 byte_offset: byte_off,
                 screen_row: screen_row,
                 ctx: ctx,
+                sign_ctx: sign_ctx,
                 ln_style: ln_style,
                 gutter_w: gutter_w,
                 sign_w: sign_w,
@@ -399,6 +404,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
     } = opts
 
     sign_w = Gutter.sign_column_width()
+    sign_ctx = SignContext.from_render_context(ctx)
     wrap_on = Map.get(opts, :wrap_on, false)
 
     # Pre-compute wrap map for all visible buffer lines in one batch call
@@ -416,6 +422,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
     render_opts = %{
       cursor_line: cursor_line,
       ctx: ctx,
+      sign_ctx: sign_ctx,
       ln_style: ln_style,
       gutter_w: gutter_w,
       sign_w: sign_w,
@@ -708,6 +715,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
           byte_offset: 0,
           screen_row: screen_row,
           ctx: render_opts.ctx,
+          sign_ctx: render_opts.sign_ctx,
           ln_style: render_opts.ln_style,
           gutter_w: render_opts.gutter_w,
           sign_w: render_opts.sign_w,
@@ -748,6 +756,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
       WrapMap.compute(lines, ctx.content_w, breakindent: breakindent, linebreak: linebreak)
 
     sign_w = Gutter.sign_column_width()
+    sign_ctx = SignContext.from_render_context(ctx)
     fold_start_lines = fold_start_lines(opts.window.fold_ranges)
 
     {gutters, contents, screen_row, _byte_off} =
@@ -767,6 +776,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
               byte_offset: byte_off,
               screen_row: sr,
               ctx: ctx,
+              sign_ctx: sign_ctx,
               ln_style: ln_style,
               gutter_w: gutter_w,
               sign_w: sign_w,

--- a/lib/minga_editor/renderer/buffer_line.ex
+++ b/lib/minga_editor/renderer/buffer_line.ex
@@ -25,6 +25,7 @@ defmodule MingaEditor.Renderer.BufferLine do
   alias MingaEditor.NavFlash
   alias MingaEditor.Renderer.Context
   alias MingaEditor.Renderer.Gutter
+  alias MingaEditor.Renderer.Gutter.SignContext
   alias MingaEditor.Renderer.Line, as: LineRenderer
   alias Minga.Core.WrapMap
   alias MingaEditor.UI.Highlight
@@ -40,6 +41,7 @@ defmodule MingaEditor.Renderer.BufferLine do
   - `byte_offset`   — absolute byte offset of this line in the buffer
   - `screen_row`    — first screen row to draw on
   - `ctx`           — per-frame render context (viewport, highlights, etc.)
+  - `sign_ctx`      — per-window sign rendering context
   - `ln_style`      — line number display style
   - `gutter_w`      — total gutter width (sign column + line numbers)
   - `sign_w`        — sign column width (0 when no diagnostics)
@@ -55,6 +57,7 @@ defmodule MingaEditor.Renderer.BufferLine do
           required(:byte_offset) => non_neg_integer(),
           required(:screen_row) => non_neg_integer(),
           required(:ctx) => Context.t(),
+          required(:sign_ctx) => SignContext.t(),
           required(:ln_style) => Gutter.line_number_style(),
           required(:gutter_w) => non_neg_integer(),
           required(:sign_w) => non_neg_integer(),
@@ -531,17 +534,8 @@ defmodule MingaEditor.Renderer.BufferLine do
   # ── Gutter primitives ───────────────────────────────────────────────────
 
   @spec render_sign(line_params(), non_neg_integer()) :: DisplayList.draw() | []
-  defp render_sign(%{ctx: ctx, buf_line: buf_line}, sr) do
-    Gutter.render_sign(
-      sr,
-      0,
-      buf_line,
-      ctx.diagnostic_signs,
-      ctx.git_signs,
-      ctx.gutter_colors,
-      ctx.git_colors,
-      ctx.decorations
-    )
+  defp render_sign(%{buf_line: buf_line, sign_ctx: sign_ctx}, sr) do
+    Gutter.render_sign(sr, 0, buf_line, sign_ctx)
   end
 
   @spec render_number(line_params(), non_neg_integer()) :: DisplayList.draw() | []

--- a/lib/minga_editor/renderer/gutter.ex
+++ b/lib/minga_editor/renderer/gutter.ex
@@ -15,6 +15,7 @@ defmodule MingaEditor.Renderer.Gutter do
   alias Minga.Core.Face
   alias Minga.Diagnostics.Diagnostic
   alias MingaEditor.DisplayList
+  alias MingaEditor.Renderer.Gutter.SignContext
 
   @sign_col_width 2
   @fold_col_width 1
@@ -63,24 +64,11 @@ defmodule MingaEditor.Renderer.Gutter do
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
-          %{non_neg_integer() => Diagnostic.severity()},
-          %{non_neg_integer() => atom()},
-          colors(),
-          git_colors(),
-          Minga.Core.Decorations.t()
+          SignContext.t()
         ) :: DisplayList.draw() | []
-  def render_sign(
-        screen_row,
-        col_offset,
-        buf_line,
-        diag_signs,
-        git_signs,
-        colors,
-        git_colors,
-        decorations \\ %Minga.Core.Decorations{}
-      ) do
-    diag = Map.get(diag_signs, buf_line)
-    git = Map.get(git_signs, buf_line)
+  def render_sign(screen_row, col_offset, buf_line, %SignContext{} = sign_ctx) do
+    diag = Map.get(sign_ctx.diagnostic_signs, buf_line)
+    git = Map.get(sign_ctx.git_signs, buf_line)
 
     render_sign_for_line(
       screen_row,
@@ -88,9 +76,9 @@ defmodule MingaEditor.Renderer.Gutter do
       buf_line,
       diag,
       git,
-      colors,
-      git_colors,
-      decorations
+      sign_ctx.colors,
+      sign_ctx.git_colors,
+      sign_ctx.decorations
     )
   end
 

--- a/lib/minga_editor/renderer/gutter/sign_context.ex
+++ b/lib/minga_editor/renderer/gutter/sign_context.ex
@@ -1,0 +1,45 @@
+defmodule MingaEditor.Renderer.Gutter.SignContext do
+  @moduledoc """
+  Per-window data needed to render gutter signs.
+
+  Sign rendering uses the same diagnostic, git, theme, and decoration data for every line in a window render pass. This struct keeps that data together so `Gutter.render_sign/4` receives one focused context instead of a long positional argument list.
+  """
+
+  alias Minga.Core.Decorations
+  alias Minga.Diagnostics.Diagnostic
+  alias MingaEditor.Renderer.Context
+
+  @enforce_keys [:colors, :git_colors]
+  defstruct diagnostic_signs: %{},
+            git_signs: %{},
+            colors: nil,
+            git_colors: nil,
+            decorations: %Decorations{}
+
+  @typedoc "Per-window gutter sign rendering context."
+  @type t :: %__MODULE__{
+          diagnostic_signs: %{non_neg_integer() => Diagnostic.severity()},
+          git_signs: %{non_neg_integer() => atom()},
+          colors: MingaEditor.UI.Theme.Gutter.t(),
+          git_colors: MingaEditor.UI.Theme.Git.t(),
+          decorations: Decorations.t()
+        }
+
+  @doc "Builds a sign context from a renderer context."
+  @spec from_render_context(Context.t()) :: t()
+  def from_render_context(%Context{
+        diagnostic_signs: diagnostic_signs,
+        git_signs: git_signs,
+        gutter_colors: colors,
+        git_colors: git_colors,
+        decorations: decorations
+      }) do
+    %__MODULE__{
+      diagnostic_signs: diagnostic_signs,
+      git_signs: git_signs,
+      colors: colors,
+      git_colors: git_colors,
+      decorations: decorations
+    }
+  end
+end

--- a/test/minga_editor/renderer/buffer_line_test.exs
+++ b/test/minga_editor/renderer/buffer_line_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.Renderer.BufferLineTest do
 
   alias MingaEditor.Renderer.BufferLine
   alias MingaEditor.Renderer.Context
+  alias MingaEditor.Renderer.Gutter
   alias MingaEditor.Viewport
 
   # ── Test helpers ──────────────────────────────────────────────────────────
@@ -53,7 +54,8 @@ defmodule MingaEditor.Renderer.BufferLineTest do
       col_offset: 0
     }
 
-    Map.merge(defaults, overrides)
+    params = Map.merge(defaults, overrides)
+    Map.put_new(params, :sign_ctx, Gutter.SignContext.from_render_context(params.ctx))
   end
 
   defp make_ctx(overrides) do
@@ -115,9 +117,9 @@ defmodule MingaEditor.Renderer.BufferLineTest do
         BufferLine.render(make_params(%{ctx: ctx, sign_w: 2, gutter_w: 6, buf_line: 0}))
 
       decoded = decode_all(gutters)
-      sign_cmd = Enum.find(decoded, fn cmd -> cmd.col == 0 end)
+      sign_cmd = Enum.find(decoded, fn cmd -> cmd.text == "E " end)
       assert sign_cmd != nil
-      assert String.contains?(sign_cmd.text, "E")
+      assert sign_cmd.fg == ctx.gutter_colors.error_fg
     end
 
     test "git sign appears when buffer line has a git change" do
@@ -127,8 +129,9 @@ defmodule MingaEditor.Renderer.BufferLineTest do
         BufferLine.render(make_params(%{ctx: ctx, sign_w: 2, gutter_w: 6, buf_line: 0}))
 
       decoded = decode_all(gutters)
-      sign_cmd = Enum.find(decoded, fn cmd -> cmd.col == 0 end)
+      sign_cmd = Enum.find(decoded, fn cmd -> cmd.text == "▎ " end)
       assert sign_cmd != nil
+      assert sign_cmd.fg == ctx.git_colors.added_fg
     end
 
     test "content text matches the line_text" do

--- a/test/minga_editor/renderer/gutter_test.exs
+++ b/test/minga_editor/renderer/gutter_test.exs
@@ -1,7 +1,11 @@
 defmodule MingaEditor.Renderer.GutterTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Core.Decorations
+  alias Minga.Core.Decorations.LineAnnotation
+  alias MingaEditor.Renderer.Context
   alias MingaEditor.Renderer.Gutter
+  alias MingaEditor.Viewport
 
   @colors %MingaEditor.UI.Theme.Gutter{
     fg: 0x555555,
@@ -18,6 +22,28 @@ defmodule MingaEditor.Renderer.GutterTest do
     modified_fg: 0x51AFEF,
     deleted_fg: 0xFF6C6B
   }
+
+  defp sign_ctx(overrides) do
+    %Context{
+      viewport: Viewport.new(24, 80),
+      gutter_w: 4,
+      content_w: 76,
+      diagnostic_signs: Map.get(overrides, :diagnostic_signs, %{}),
+      git_signs: Map.get(overrides, :git_signs, %{}),
+      gutter_colors: @colors,
+      git_colors: @git_colors,
+      decorations: Map.get(overrides, :decorations, %Decorations{})
+    }
+    |> Gutter.SignContext.from_render_context()
+  end
+
+  defp decode_draw({row, col, text, style}) do
+    %{row: row, col: col, text: text, fg: style.fg, bg: style.bg}
+  end
+
+  defp assert_sign(draw, expected_text, expected_fg) do
+    assert %{text: ^expected_text, fg: ^expected_fg} = decode_draw(draw)
+  end
 
   describe "total_width/1" do
     test "always includes sign and fold column width" do
@@ -41,61 +67,68 @@ defmodule MingaEditor.Renderer.GutterTest do
     end
   end
 
-  describe "render_sign/7" do
+  describe "render_sign/4" do
     test "renders error sign (diagnostic takes priority)" do
-      diag_signs = %{5 => :error}
-      result = Gutter.render_sign(0, 0, 5, diag_signs, %{}, @colors, @git_colors)
-      assert is_tuple(result)
+      result = Gutter.render_sign(0, 0, 5, sign_ctx(%{diagnostic_signs: %{5 => :error}}))
+      assert_sign(result, "E ", @colors.error_fg)
     end
 
     test "renders warning sign" do
-      diag_signs = %{3 => :warning}
-      result = Gutter.render_sign(0, 0, 3, diag_signs, %{}, @colors, @git_colors)
-      assert is_tuple(result)
+      result = Gutter.render_sign(0, 0, 3, sign_ctx(%{diagnostic_signs: %{3 => :warning}}))
+      assert_sign(result, "W ", @colors.warning_fg)
     end
 
     test "renders info sign" do
-      diag_signs = %{1 => :info}
-      result = Gutter.render_sign(0, 0, 1, diag_signs, %{}, @colors, @git_colors)
-      assert is_tuple(result)
+      result = Gutter.render_sign(0, 0, 1, sign_ctx(%{diagnostic_signs: %{1 => :info}}))
+      assert_sign(result, "I ", @colors.info_fg)
     end
 
     test "renders hint sign" do
-      diag_signs = %{0 => :hint}
-      result = Gutter.render_sign(0, 0, 0, diag_signs, %{}, @colors, @git_colors)
-      assert is_tuple(result)
+      result = Gutter.render_sign(0, 0, 0, sign_ctx(%{diagnostic_signs: %{0 => :hint}}))
+      assert_sign(result, "H ", @colors.hint_fg)
     end
 
     test "renders git added sign when no diagnostic" do
-      git_signs = %{5 => :added}
-      result = Gutter.render_sign(0, 0, 5, %{}, git_signs, @colors, @git_colors)
-      assert is_tuple(result)
+      result = Gutter.render_sign(0, 0, 5, sign_ctx(%{git_signs: %{5 => :added}}))
+      assert_sign(result, "▎ ", @git_colors.added_fg)
     end
 
     test "renders git modified sign when no diagnostic" do
-      git_signs = %{5 => :modified}
-      result = Gutter.render_sign(0, 0, 5, %{}, git_signs, @colors, @git_colors)
-      assert is_tuple(result)
+      result = Gutter.render_sign(0, 0, 5, sign_ctx(%{git_signs: %{5 => :modified}}))
+      assert_sign(result, "▎ ", @git_colors.modified_fg)
     end
 
     test "renders git deleted sign when no diagnostic" do
-      git_signs = %{5 => :deleted}
-      result = Gutter.render_sign(0, 0, 5, %{}, git_signs, @colors, @git_colors)
-      assert is_tuple(result)
+      result = Gutter.render_sign(0, 0, 5, sign_ctx(%{git_signs: %{5 => :deleted}}))
+      assert_sign(result, "▁ ", @git_colors.deleted_fg)
     end
 
     test "diagnostic takes priority over git sign on same line" do
-      diag_signs = %{5 => :error}
-      git_signs = %{5 => :added}
-      result = Gutter.render_sign(0, 0, 5, diag_signs, git_signs, @colors, @git_colors)
-      # Should render the diagnostic sign, not the git sign
-      assert is_tuple(result)
+      result =
+        Gutter.render_sign(
+          0,
+          0,
+          5,
+          sign_ctx(%{diagnostic_signs: %{5 => :error}, git_signs: %{5 => :added}})
+        )
+
+      assert_sign(result, "E ", @colors.error_fg)
     end
 
-    test "renders empty space when no diagnostic or git sign" do
-      diag_signs = %{5 => :error}
-      result = Gutter.render_sign(0, 0, 10, diag_signs, %{}, @colors, @git_colors)
-      assert is_tuple(result)
+    test "renders gutter icon annotation when no diagnostic or git sign" do
+      decorations = %Decorations{
+        annotations: [
+          %LineAnnotation{id: make_ref(), line: 10, text: "!", kind: :gutter_icon, fg: 0xAA55FF}
+        ]
+      }
+
+      result = Gutter.render_sign(0, 0, 10, sign_ctx(%{decorations: decorations}))
+      assert_sign(result, "! ", 0xAA55FF)
+    end
+
+    test "renders empty space when no diagnostic, git sign, or gutter annotation" do
+      result = Gutter.render_sign(0, 0, 10, sign_ctx(%{}))
+      assert_sign(result, "  ", nil)
     end
   end
 


### PR DESCRIPTION
# TL;DR
Extracts gutter sign rendering data into `Gutter.SignContext`, so `Gutter.render_sign/4` takes a focused context instead of five repeated per-window arguments. This keeps sign rendering behavior unchanged while making the API harder to misuse.

Closes #1137

## Context
`Gutter.render_sign` grew a long positional argument list after gutter icon annotations. Most of those arguments are invariant for a window render pass, so passing them separately through every line render call made the API noisy and easy to mix up.

## Changes
- Added `MingaEditor.Renderer.Gutter.SignContext` to group diagnostic signs, git signs, gutter colors, git colors, and decorations.
- Changed `Gutter.render_sign/4` to accept the sign context and keep the existing priority flow: diagnostics first, git signs second, annotation icons third.
- Built the sign context once in each content render path before per-line rendering, then passed it through `BufferLine.render/1` line params.
- Updated gutter and buffer line tests to construct and pass the new sign context.

## Verification
- `mix test.debug test/minga_editor/renderer/gutter_test.exs test/minga_editor/renderer/buffer_line_test.exs` passed, 57 tests, 0 failures.
- `make lint` passed.
- `mix test.llm` was run multiple times and hit unrelated, changing timeout/event failures outside this diff. The reported failures passed when isolated. One isolated failure, `test/minga/buffer/auto_save_test.exs:16`, also fails on a clean `origin/main` worktree, so it is pre-existing. A serial full-suite run reduced the failures to one unrelated editor startup timeout in `toggle_line_numbers_test.exs:34`, and that test plus its full file passed when rerun directly.

## Acceptance Criteria Addressed
- A `SignContext` struct groups diagnostic signs, git signs, gutter colors, git colors, and decorations. ✅
- `Gutter.render_sign` accepts the struct instead of five individual data-clump arguments. ✅
- The struct is built once per content render path before per-line rendering and passed to each line render call. ✅
- Existing gutter tests are updated with exact output, priority, and annotation fallback assertions, and pass. ✅
- Sign rendering priority remains diagnostics > git > annotations. ✅
