### PR TITLE
Rank command palette recents

### DIFF
--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -13,6 +13,7 @@ defmodule Minga.Project do
   * `cached_files` — the file list for the current project (populated by a background Task)
   * `known_projects` — list of all project roots the user has visited, persisted to disk
   * `recent_files` — per-project list of recently opened files, most recent first, persisted to disk
+  * `command_frecency` — command execution timestamps used to rank the empty command palette
   * `rebuilding?` — true while a background Task is rebuilding the file cache
 
   ## File cache
@@ -26,6 +27,7 @@ defmodule Minga.Project do
 
   use GenServer
 
+  alias Minga.Command
   alias Minga.Config
   alias Minga.Project.Detector
 
@@ -35,6 +37,7 @@ defmodule Minga.Project do
             known_projects: [],
             recent_files: %{},
             frecency_events: %{},
+            command_frecency: %{},
             rebuilding?: false,
             rebuild_ref: nil,
             events_registry: Minga.Events.default_registry()
@@ -48,6 +51,9 @@ defmodule Minga.Project do
   @typedoc "Per-project frecency map: project root => %{relative_path => access_timestamps}."
   @type frecency_events_map :: %{String.t() => file_accesses_map()}
 
+  @typedoc "Per-command execution event history (most recent first, unix seconds)."
+  @type command_frecency_map :: %{atom() => [non_neg_integer()]}
+
   @typedoc "Project GenServer state."
   @type t :: %__MODULE__{
           current_root: String.t() | nil,
@@ -56,6 +62,7 @@ defmodule Minga.Project do
           known_projects: [String.t()],
           recent_files: recent_files_map(),
           frecency_events: frecency_events_map(),
+          command_frecency: command_frecency_map(),
           rebuilding?: boolean(),
           rebuild_ref: reference() | nil,
           events_registry: Minga.Events.registry()
@@ -64,7 +71,9 @@ defmodule Minga.Project do
   @known_projects_file "known-projects"
   @recent_files_file "recent-files"
   @frecency_file "frecency"
+  @command_frecency_file "command-frecency"
   @frecency_events_per_file_limit 10
+  @command_frecency_events_limit 20
 
   # ── Client API ──────────────────────────────────────────────────────────────
 
@@ -169,6 +178,35 @@ defmodule Minga.Project do
     GenServer.call(server, :frecency_scores)
   end
 
+  @doc "Records a command execution for command palette frecency ranking."
+  @spec record_command(GenServer.server(), atom()) :: :ok
+  def record_command(server \\ __MODULE__, command_name)
+
+  def record_command(__MODULE__, command_name) when is_atom(command_name) do
+    case Process.whereis(__MODULE__) do
+      nil ->
+        Minga.Log.warning(
+          :editor,
+          "Command frecency not recorded, Project unavailable: #{command_name}"
+        )
+
+        :ok
+
+      _pid ->
+        GenServer.cast(__MODULE__, {:record_command, command_name})
+    end
+  end
+
+  def record_command(server, command_name) when is_atom(command_name) do
+    GenServer.cast(server, {:record_command, command_name})
+  end
+
+  @doc "Returns frecency scores for command palette commands (command name => score)."
+  @spec command_frecency_scores(GenServer.server()) :: %{atom() => non_neg_integer()}
+  def command_frecency_scores(server \\ __MODULE__) do
+    GenServer.call(server, :command_frecency_scores)
+  end
+
   @doc "Scores a file's access timestamps using frecency decay buckets."
   @spec score_accesses([non_neg_integer()], non_neg_integer()) :: non_neg_integer()
   def score_accesses(timestamps, now_unix) when is_list(timestamps) and is_integer(now_unix) do
@@ -192,12 +230,14 @@ defmodule Minga.Project do
     known = if persist_known_projects?(), do: load_known_projects(), else: []
     recent = if persist_recent_files?(), do: load_recent_files(), else: %{}
     frecency = if persist_recent_files?(), do: load_frecency_events(), else: %{}
+    command_frecency = load_command_frecency()
 
     {:ok,
      %__MODULE__{
        known_projects: known,
        recent_files: recent,
        frecency_events: frecency,
+       command_frecency: command_frecency,
        events_registry: events_registry
      }}
   end
@@ -238,6 +278,17 @@ defmodule Minga.Project do
       |> Map.get(root, %{})
       |> Map.new(fn {rel_path, timestamps} ->
         {rel_path, score_accesses(timestamps, now_unix)}
+      end)
+
+    {:reply, scores, state}
+  end
+
+  def handle_call(:command_frecency_scores, _from, state) do
+    now_unix = System.system_time(:second)
+
+    scores =
+      Map.new(state.command_frecency, fn {command_name, timestamps} ->
+        {command_name, score_accesses(timestamps, now_unix)}
       end)
 
     {:reply, scores, state}
@@ -289,6 +340,10 @@ defmodule Minga.Project do
 
   def handle_cast({:record_file, file_path}, state) do
     {:noreply, do_record_file(state, file_path)}
+  end
+
+  def handle_cast({:record_command, command_name}, state) do
+    {:noreply, do_record_command(state, command_name)}
   end
 
   def handle_cast({:remove, root_path}, state) do
@@ -394,6 +449,20 @@ defmodule Minga.Project do
 
         state
     end
+  end
+
+  @spec do_record_command(t(), atom()) :: t()
+  defp do_record_command(state, command_name) when is_atom(command_name) do
+    now_unix = System.system_time(:second)
+
+    command_frecency =
+      Map.update(state.command_frecency, command_name, [now_unix], fn timestamps ->
+        [now_unix | timestamps] |> Enum.take(@command_frecency_events_limit)
+      end)
+
+    state = %{state | command_frecency: command_frecency}
+    persist_command_frecency(command_frecency)
+    state
   end
 
   @spec set_project(t(), String.t(), Detector.project_type() | nil) :: t()
@@ -638,6 +707,144 @@ defmodule Minga.Project do
   defp file_accesses_to_lines(root, file_accesses) do
     Enum.flat_map(file_accesses, fn {rel_path, timestamps} ->
       Enum.map(timestamps, fn ts -> "#{root}\t#{rel_path}\t#{ts}" end)
+    end)
+  end
+
+  # ── Command frecency persistence ───────────────────────────────────────────
+
+  @spec command_frecency_path() :: String.t()
+  defp command_frecency_path do
+    config_dir = System.get_env("XDG_CONFIG_HOME") || Path.expand("~/.config")
+    Path.join([config_dir, "minga", @command_frecency_file])
+  end
+
+  @spec load_command_frecency() :: command_frecency_map()
+  defp load_command_frecency do
+    path = command_frecency_path()
+
+    case read_persisted_file(path, "command frecency") do
+      {:ok, content} -> parse_command_frecency(content)
+      :missing -> %{}
+      {:error, _reason} -> %{}
+    end
+  end
+
+  @spec read_persisted_file(String.t(), String.t()) ::
+          {:ok, String.t()} | :missing | {:error, term()}
+  defp read_persisted_file(path, label) do
+    case File.read(path) do
+      {:ok, content} ->
+        {:ok, content}
+
+      {:error, :enoent} ->
+        :missing
+
+      {:error, reason} ->
+        Minga.Log.warning(:editor, "Failed to read #{label} from #{path}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @spec parse_command_frecency(String.t()) :: command_frecency_map()
+  defp parse_command_frecency(content) do
+    content
+    |> String.split("\n", trim: true)
+    |> Enum.with_index(1)
+    |> Enum.reduce(%{}, fn {line, line_number}, acc ->
+      case parse_command_frecency_line(line) do
+        {:ok, command_name, timestamp} ->
+          update_command_frecency(acc, command_name, timestamp)
+
+        {:error, reason} ->
+          Minga.Log.warning(
+            :editor,
+            "Skipping invalid command frecency line #{line_number}: #{line} (#{reason})"
+          )
+
+          acc
+      end
+    end)
+  end
+
+  @spec parse_command_frecency_line(String.t()) ::
+          {:ok, atom(), non_neg_integer()} | {:error, atom()}
+  defp parse_command_frecency_line(line) do
+    case String.split(line, "\t", parts: 2) do
+      [command_name, ts] ->
+        with {:ok, command_atom} <- parse_command_frecency_command_name(command_name),
+             {:ok, timestamp} <- parse_command_frecency_timestamp(ts),
+             :ok <- validate_command_frecency_command(command_atom) do
+          {:ok, command_atom, timestamp}
+        end
+
+      _ ->
+        {:error, :invalid_format}
+    end
+  end
+
+  @spec parse_command_frecency_command_name(String.t()) :: {:ok, atom()} | {:error, atom()}
+  defp parse_command_frecency_command_name(command_name) do
+    {:ok, String.to_existing_atom(command_name)}
+  rescue
+    ArgumentError -> {:error, :unknown_command_name}
+  end
+
+  @spec parse_command_frecency_timestamp(String.t()) ::
+          {:ok, non_neg_integer()} | {:error, atom()}
+  defp parse_command_frecency_timestamp(ts) do
+    case Integer.parse(ts) do
+      {timestamp, ""} when timestamp >= 0 -> {:ok, timestamp}
+      _ -> {:error, :invalid_timestamp}
+    end
+  end
+
+  @spec validate_command_frecency_command(atom()) :: :ok | {:error, atom()}
+  defp validate_command_frecency_command(command_name) do
+    case Process.whereis(Minga.Command.Registry) do
+      nil ->
+        {:error, :command_registry_unavailable}
+
+      _pid ->
+        case Command.lookup(command_name) do
+          {:ok, _cmd} -> :ok
+          :error -> {:error, :stale_command}
+        end
+    end
+  catch
+    :exit, _ -> {:error, :command_registry_unavailable}
+  end
+
+  @spec update_command_frecency(command_frecency_map(), atom(), non_neg_integer()) ::
+          command_frecency_map()
+  defp update_command_frecency(events, command_name, timestamp) do
+    Map.update(events, command_name, [timestamp], fn timestamps ->
+      (timestamps ++ [timestamp]) |> Enum.take(@command_frecency_events_limit)
+    end)
+  end
+
+  @spec persist_command_frecency(command_frecency_map()) :: :ok
+  defp persist_command_frecency(command_frecency) do
+    path = command_frecency_path()
+    dir = Path.dirname(path)
+    File.mkdir_p!(dir)
+
+    content = command_frecency_lines(command_frecency) |> Enum.join("\n") |> Kernel.<>("\n")
+    File.write!(path, content)
+    :ok
+  rescue
+    e ->
+      Minga.Log.warning(
+        :editor,
+        "Failed to persist command frecency data: #{Exception.message(e)}"
+      )
+
+      :ok
+  end
+
+  @spec command_frecency_lines(command_frecency_map()) :: [String.t()]
+  defp command_frecency_lines(command_frecency) do
+    Enum.flat_map(command_frecency, fn {command_name, timestamps} ->
+      Enum.map(timestamps, fn ts -> "#{command_name}\t#{ts}" end)
     end)
   end
 

--- a/lib/minga_editor/input/picker.ex
+++ b/lib/minga_editor/input/picker.ex
@@ -170,11 +170,25 @@ defmodule MingaEditor.Input.Picker do
         new_state = source.on_select(item, new_state)
 
         case Map.get(new_state, :pending_command) do
-          nil -> new_state
-          cmd -> MingaEditor.dispatch_command(Map.delete(new_state, :pending_command), cmd)
+          nil ->
+            new_state
+
+          cmd ->
+            record_command_execution(source, cmd)
+            MingaEditor.dispatch_command(Map.delete(new_state, :pending_command), cmd)
         end
     end
   end
+
+  @spec record_command_execution(module(), term()) :: :ok
+  defp record_command_execution(MingaEditor.UI.Picker.CommandSource, command_name)
+       when is_atom(command_name) do
+    Minga.Project.record_command(command_name)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp record_command_execution(_source, _command_name), do: :ok
 
   # Bottom-anchored: items grow upward from the prompt at viewport bottom.
   @spec bottom_click_index(EditorState.t(), PickerData.t(), integer()) :: integer()

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -445,10 +445,24 @@ defmodule MingaEditor.PickerUI do
     new_state = source.on_select(item, new_state)
 
     case Map.get(new_state, :pending_command) do
-      nil -> new_state
-      cmd -> {Map.delete(new_state, :pending_command), {:execute_command, cmd}}
+      nil ->
+        new_state
+
+      cmd ->
+        record_command_execution(source, cmd)
+        {Map.delete(new_state, :pending_command), {:execute_command, cmd}}
     end
   end
+
+  @spec record_command_execution(module(), term()) :: :ok
+  defp record_command_execution(MingaEditor.UI.Picker.CommandSource, command_name)
+       when is_atom(command_name) do
+    Minga.Project.record_command(command_name)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp record_command_execution(_source, _command_name), do: :ok
 
   @doc """
   Renders the picker overlay. Returns `{draws, cursor_pos | nil}`.

--- a/lib/minga_editor/ui/picker/command_source.ex
+++ b/lib/minga_editor/ui/picker/command_source.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.UI.Picker.CommandSource do
   @behaviour MingaEditor.UI.Picker.Source
 
   alias Minga.Keymap
+  alias Minga.Project
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.Item
 
@@ -27,6 +28,7 @@ defmodule MingaEditor.UI.Picker.CommandSource do
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(_ctx) do
     keybind_map = build_keybind_map()
+    frecency_scores = fetch_command_frecency()
 
     try do
       Command.all_commands()
@@ -40,7 +42,7 @@ defmodule MingaEditor.UI.Picker.CommandSource do
           annotation: annotation
         }
       end)
-      |> Enum.sort_by(& &1.label)
+      |> sort_by_frecency(frecency_scores)
     catch
       :exit, _ ->
         Minga.Log.warning(:editor, "Command registry not available")
@@ -101,6 +103,20 @@ defmodule MingaEditor.UI.Picker.CommandSource do
     }
 
     PickerUI.open(state, OptionScopeSource, context)
+  end
+
+  @spec fetch_command_frecency() :: %{atom() => non_neg_integer()}
+  defp fetch_command_frecency do
+    Project.command_frecency_scores()
+  catch
+    :exit, _ -> %{}
+  end
+
+  @spec sort_by_frecency([Item.t()], %{atom() => non_neg_integer()}) :: [Item.t()]
+  defp sort_by_frecency(items, scores) do
+    Enum.sort_by(items, fn %Item{id: command_name, label: label} ->
+      {-Map.get(scores, command_name, 0), label}
+    end)
   end
 
   @spec build_keybind_map() :: %{atom() => String.t()}

--- a/lib/minga_editor/ui/picker/option_scope_source.ex
+++ b/lib/minga_editor/ui/picker/option_scope_source.ex
@@ -48,6 +48,7 @@ defmodule MingaEditor.UI.Picker.OptionScopeSource do
   @impl true
   @spec on_select(Item.t(), term()) :: term()
   def on_select(%Item{id: {scope, ctx}}, state) when scope in [:buffer, :global] do
+    record_command_execution(ctx)
     apply_scoped(scope, ctx.option_name, ctx.new_value, state)
   end
 
@@ -58,6 +59,15 @@ defmodule MingaEditor.UI.Picker.OptionScopeSource do
   def on_cancel(state), do: state
 
   # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec record_command_execution(map()) :: :ok
+  defp record_command_execution(%{command_name: command_name}) when is_atom(command_name) do
+    Minga.Project.record_command(command_name)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp record_command_execution(_ctx), do: :ok
 
   @spec apply_scoped(:buffer | :global, atom(), term(), term()) :: term()
   defp apply_scoped(:buffer, name, value, state) do

--- a/test/minga/project_test.exs
+++ b/test/minga/project_test.exs
@@ -378,6 +378,35 @@ defmodule Minga.ProjectTest do
     end
   end
 
+  describe "command frecency" do
+    test "record_command/2 scores repeated command executions higher" do
+      {_pid, name} = start_project!()
+
+      Enum.each(1..3, fn _ ->
+        Project.record_command(name, :save)
+        flush(name)
+      end)
+
+      Project.record_command(name, :quit)
+      flush(name)
+
+      scores = Project.command_frecency_scores(name)
+      assert scores.save > scores.quit
+    end
+
+    test "record_command/2 keeps the newest command events within the limit" do
+      {_pid, name} = start_project!()
+
+      Enum.each(1..25, fn _ ->
+        Project.record_command(name, :save)
+        flush(name)
+      end)
+
+      state = flush(name)
+      assert length(state.command_frecency.save) == 20
+    end
+  end
+
   describe "frecency" do
     test "score_accesses/2 applies Mozilla-style decay buckets" do
       now = 1_700_000_000

--- a/test/minga_editor/ui/picker/command_source_frecency_test.exs
+++ b/test/minga_editor/ui/picker/command_source_frecency_test.exs
@@ -1,0 +1,244 @@
+defmodule MingaEditor.UI.Picker.CommandSourceFrecencyTest do
+  @moduledoc "Tests command palette frecency ordering, persistence, and mouse recording."
+
+  # Mutates process-global XDG_CONFIG_HOME and the global Minga.Project singleton.
+  use ExUnit.Case, async: false
+
+  @moduletag :tmp_dir
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Project
+  alias MingaEditor.Input.Picker, as: PickerInput
+  alias MingaEditor.PickerUI
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+  alias MingaEditor.State.Picker, as: PickerState
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
+  alias MingaEditor.UI.Picker
+  alias MingaEditor.UI.Picker.CommandSource
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.OptionScopeSource
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  setup %{tmp_dir: tmp_dir} do
+    previous_config_home = System.get_env("XDG_CONFIG_HOME")
+    config_home = Path.join(tmp_dir, "config")
+    File.mkdir_p!(Path.join(config_home, "minga"))
+    System.put_env("XDG_CONFIG_HOME", config_home)
+
+    previous_state = :sys.get_state(Project)
+    :sys.replace_state(Project, fn state -> %{state | command_frecency: %{}} end)
+
+    on_exit(fn ->
+      restore_xdg_config_home(previous_config_home)
+
+      :sys.replace_state(Project, fn state ->
+        %{state | command_frecency: previous_state.command_frecency}
+      end)
+    end)
+
+    :ok
+  end
+
+  test "recently executed commands are ranked before alphabetical commands" do
+    Enum.each(1..5, fn _ ->
+      Project.record_command(:quit)
+      :sys.get_state(Project)
+    end)
+
+    items = CommandSource.candidates(nil)
+    quit_index = Enum.find_index(items, &(&1.id == :quit))
+    save_index = Enum.find_index(items, &(&1.id == :save))
+
+    assert is_integer(quit_index)
+    assert is_integer(save_index)
+    assert quit_index < save_index
+  end
+
+  test "typed queries still re-rank by fuzzy match after frecency pre-ordering" do
+    Enum.each(1..5, fn _ ->
+      Project.record_command(:quit_all)
+      :sys.get_state(Project)
+    end)
+
+    Project.record_command(:quit)
+    :sys.get_state(Project)
+
+    candidates = CommandSource.candidates(nil)
+    quit_index = Enum.find_index(candidates, &(&1.id == :quit))
+    quit_all_index = Enum.find_index(candidates, &(&1.id == :quit_all))
+
+    assert is_integer(quit_index)
+    assert is_integer(quit_all_index)
+    assert quit_all_index < quit_index
+
+    picker = Picker.new(candidates, title: CommandSource.title())
+    filtered = Picker.filter(picker, "q")
+
+    assert Picker.selected_id(filtered) == :quit
+  end
+
+  test "persisted command frecency reloads from the XDG config path" do
+    project_name = :command_frecency_roundtrip
+    command_frecency_file = command_frecency_path()
+    File.rm(command_frecency_file)
+
+    {pid, name} = start_project!(name: project_name)
+    Project.record_command(name, :save)
+    :sys.get_state(name)
+
+    assert File.exists?(command_frecency_file)
+    assert File.read!(command_frecency_file) =~ "save"
+
+    GenServer.stop(pid)
+    {reloaded_pid, reloaded_name} = start_project!(name: project_name)
+
+    assert Project.command_frecency_scores(reloaded_name).save > 0
+
+    GenServer.stop(reloaded_pid)
+  end
+
+  test "persisted command frecency reload keeps the newest events within the limit" do
+    command_frecency_file = command_frecency_path()
+    newest_first = Enum.to_list(1_000..976//-1)
+
+    content = Enum.map_join(newest_first, "\n", fn timestamp -> "save\t#{timestamp}" end)
+
+    File.write!(command_frecency_file, content <> "\n")
+
+    {pid, name} = start_project!(name: :command_frecency_limit_reload)
+    state = :sys.get_state(name)
+
+    assert state.command_frecency.save == Enum.take(newest_first, 20)
+
+    GenServer.stop(pid)
+  end
+
+  test "stale and malformed persisted lines are skipped on load" do
+    command_frecency_file = command_frecency_path()
+
+    File.write!(
+      command_frecency_file,
+      "save\t100\nElixir.MingaEditor.UI.Picker.CommandSource\t200\nnot-a-line\n"
+    )
+
+    {pid, name} = start_project!(name: :command_frecency_validation)
+    scores = Project.command_frecency_scores(name)
+
+    assert scores.save > 0
+    refute Map.has_key?(scores, MingaEditor.UI.Picker.CommandSource)
+
+    GenServer.stop(pid)
+  end
+
+  test "command palette keyboard selection records command frecency" do
+    state = picker_state(CommandSource, [%Item{id: :save, label: "󰘳 save: Save file"}], nil)
+
+    assert {_state, {:execute_command, :save}} = PickerUI.handle_key(state, 13, 0)
+    assert Project.command_frecency_scores().save > 0
+  end
+
+  test "scopeable command palette selections record after scope choice" do
+    {:ok, buf} = BufferProcess.start_link(content: "hello")
+
+    ctx = %{option_name: :wrap, new_value: true, command_name: :toggle_wrap}
+
+    state = %{
+      workspace: %{buffers: %{active: buf}},
+      shell_state: %ShellState{status_msg: nil}
+    }
+
+    assert %{shell_state: %{status_msg: status}} =
+             OptionScopeSource.on_select(
+               %Item{id: {:buffer, ctx}, label: "This Buffer", description: ""},
+               state
+             )
+
+    assert status =~ "this buffer"
+    assert Project.command_frecency_scores().toggle_wrap > 0
+  end
+
+  test "command palette mouse selection records command frecency" do
+    {buffer, _path} = save_buffer()
+    state = picker_state(CommandSource, [%Item{id: :save, label: "󰘳 save: Save file"}], buffer)
+
+    {:handled, _state} = PickerInput.handle_mouse(state, 28, 10, :left, 0, :press, 1)
+    :sys.get_state(Project)
+
+    assert Project.command_frecency_scores().save > 0
+  end
+
+  test "non-command picker mouse selection does not pollute command frecency" do
+    {buffer, _path} = save_buffer()
+
+    state =
+      picker_state(
+        Minga.Test.PendingCommandPickerSource,
+        [%Item{id: :pick, label: "Pick"}],
+        buffer
+      )
+
+    {:handled, _state} = PickerInput.handle_mouse(state, 28, 10, :left, 0, :press, 1)
+    :sys.get_state(Project)
+
+    refute Map.has_key?(Project.command_frecency_scores(), :save)
+  end
+
+  defp start_project!(opts) do
+    name = Keyword.get(opts, :name, :"command_frecency_#{System.unique_integer([:positive])}")
+
+    start_opts =
+      opts
+      |> Keyword.drop([:name])
+      |> Keyword.put(:name, name)
+      |> Keyword.put_new(:subscribe, false)
+
+    {:ok, pid} = Project.start_link(start_opts)
+    {pid, name}
+  end
+
+  defp command_frecency_path do
+    Path.join([System.fetch_env!("XDG_CONFIG_HOME"), "minga", "command-frecency"])
+  end
+
+  defp restore_xdg_config_home(nil), do: System.delete_env("XDG_CONFIG_HOME")
+  defp restore_xdg_config_home(value), do: System.put_env("XDG_CONFIG_HOME", value)
+
+  defp save_buffer do
+    path =
+      Path.join(System.tmp_dir!(), "command-frecency-#{System.unique_integer([:positive])}.txt")
+
+    File.write!(path, "hello")
+    {start_supervised!({BufferProcess, file_path: path}), path}
+  end
+
+  defp picker_state(source, items, buffer_pid) do
+    viewport = Viewport.new(30, 80)
+    picker = Picker.new(items, title: source.title())
+
+    picker_state = %PickerState{
+      picker: picker,
+      source: source,
+      restore: 0
+    }
+
+    %EditorState{
+      port_manager: nil,
+      terminal_viewport: viewport,
+      workspace: %WorkspaceState{
+        viewport: viewport,
+        editing: VimState.new(),
+        buffers: %Buffers{active: buffer_pid, list: maybe_list(buffer_pid), active_index: 0}
+      },
+      shell_state: %ShellState{
+        modal: {:picker, PickerPayload.new(picker_state)}
+      }
+    }
+  end
+
+  defp maybe_list(nil), do: []
+  defp maybe_list(pid), do: [pid]
+end

--- a/test/support/pending_command_picker_source.ex
+++ b/test/support/pending_command_picker_source.ex
@@ -1,0 +1,23 @@
+defmodule Minga.Test.PendingCommandPickerSource do
+  @moduledoc "Test picker source that sets a pending command without being the command palette."
+
+  @behaviour MingaEditor.UI.Picker.Source
+
+  alias MingaEditor.UI.Picker.Item
+
+  @impl true
+  @spec title() :: String.t()
+  def title, do: "Pending Command Test"
+
+  @impl true
+  @spec candidates(term()) :: [Item.t()]
+  def candidates(_ctx), do: [%Item{id: :pick, label: "Pick"}]
+
+  @impl true
+  @spec on_select(Item.t(), term()) :: term()
+  def on_select(%Item{}, state), do: Map.put(state, :pending_command, :save)
+
+  @impl true
+  @spec on_cancel(term()) :: term()
+  def on_cancel(state), do: state
+end


### PR DESCRIPTION
# TL;DR
Command palette selections now build BEAM-side recency data and use it to rank the empty command palette, so frequently used commands rise to the top across editor restarts.

Closes #720

## Context
Issue #720 asked for the remaining command palette recents work after keybinding hints, annotation data, and fuzzy match highlighting were already present. This PR follows the existing project file frecency pattern and stores command execution timestamps in `Minga.Project`.

## Changes
- Added command frecency state, scoring APIs, and persistence to `command-frecency` under `XDG_CONFIG_HOME/minga` with the normal `~/.config/minga` fallback.
- Records command palette executions from keyboard and mouse picker confirmation paths.
- Keeps recording source-aware so other picker flows that use `:pending_command` do not pollute command recents.
- Records scopeable command palette choices after the user selects the option scope.
- Sorts command palette candidates by `{-score, label}` when opened with an empty query while leaving fuzzy query scoring in the picker core unchanged.
- Added regression coverage for scoring, persistence reload, over-limit event retention, command palette ordering, source-aware recording, mouse selection, typed-query ordering, invalid persisted lines, and scopeable commands.

## Verification
- `make lint` ✅
- `mix test.llm test/minga/project_test.exs test/minga_editor/ui/picker/command_source_test.exs test/minga_editor/ui/picker/command_source_frecency_test.exs test/minga_editor/ui/picker/option_scope_source_test.exs test/minga_editor/input/picker_mouse_test.exs` ✅
- Parent-orchestrated review loop: 3 review rounds. Round 1 found persistence/test hardening; round 2 found reload ordering and path scoping issues; round 3 passed with no blockers ✅
- Local full `mix test.llm` note: the full suite still fails locally on unrelated baseline/load-sensitive tests. The failed tests pass in isolation, and a clean `origin/main` validation worktree also fails full `mix test.llm` with the same class of unrelated failures.

## Acceptance Criteria Addressed
- Each command in the palette shows its keybinding (right-aligned, dimmed color) ✅ already present on base
- Recently used commands appear at the top of the list when the query is empty (frecency-scored) ✅
- Fuzzy match characters are highlighted in the result labels (bold or colored) ✅ already present on base
- Keybinding data comes from the BEAM keymap (via annotation field on picker items) ✅ already present on base
- Recents are tracked on the BEAM side with frecency scoring (persisted to `~/.config/minga/command-frecency`, or `XDG_CONFIG_HOME/minga/command-frecency` when set) ✅
