### PR TITLE
feat(macos): animate GUI cursor movement

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -47,6 +47,7 @@ That's it. Save the file and restart Minga. Your options take effect immediately
 | `:font_size` | positive integer | `13` | Font size in points (see [Fonts](#fonts) below) |
 | `:font_weight` | weight atom | `:regular` | Font weight (see [Fonts](#fonts) below) |
 | `:font_ligatures` | boolean | `true` | Enable programming ligatures (see [Fonts](#fonts) below) |
+| `:cursor_animate` | boolean | `true` | Smoothly animate cursor movement in GUI frontends |
 | `:log_level` | `:debug`, `:info`, `:warning`, `:error`, `:none` | `:info` | Global minimum log level (see [Logging](#logging) below) |
 | `:log_level_render` | log level or `:default` | `:default` | Log level for the render pipeline |
 | `:log_level_lsp` | log level or `:default` | `:default` | Log level for LSP client communication |
@@ -63,6 +64,7 @@ set :font_family, "JetBrains Mono"
 set :font_size, 14
 set :font_weight, :regular
 set :font_ligatures, true
+set :cursor_animate, false
 ```
 
 Invalid values show a clear error. Setting `:tab_width` to `-1` tells you it must be a positive integer.

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -58,6 +58,7 @@ The BEAM-side encoder must use a documented length-prefixed envelope for all new
 | 0x92 | gui_line_spacing | Line spacing multiplier for the renderer |
 | 0x93 | gui_file_tree | Semantic file tree rows for the native sidebar view. Uses a 32-bit payload length because expanded project trees can exceed 64KB. |
 | 0x94 | gui_file_tree_selection | Lightweight file tree selection and focus update. |
+| 0x95 | gui_cursor_animation | Cursor movement animation preference for GUI renderers. |
 | 0x96 | gui_hover_action | Optional action metadata for the hover popup |
 
 ### 0x93 — gui_file_tree
@@ -972,7 +973,19 @@ This convention is enforced on the BEAM side: all new opcodes >= 0x90 must use a
 - `OP_GUI_INDENT_GUIDES (0x91)` — indent guide positions per window (16-bit length-prefixed)
 - `OP_GUI_LINE_SPACING (0x92)` — renderer line spacing multiplier (16-bit length-prefixed)
 - `OP_GUI_FILE_TREE (0x93)` — semantic file tree rows (32-bit length-prefixed)
+- `OP_GUI_CURSOR_ANIMATION (0x95)` — cursor movement animation preference (16-bit length-prefixed)
 - `OP_GUI_HOVER_ACTION (0x96)` — optional hover popup action metadata (16-bit length-prefixed)
+
+### 0x95 — gui_cursor_animation
+
+Sends whether GUI renderers should animate cursor movement. The frontend must still disable animation when the platform Reduce Motion accessibility setting is active.
+
+```
+opcode(1=0x95) + payload_length(2=0x0001) + enabled(1)
+```
+
+Fields:
+- `enabled`: `1` enables smooth cursor movement, `0` snaps the cursor directly to the BEAM-reported position.
 
 ### 0x96 — gui_hover_action
 

--- a/lib/minga/config/options.ex
+++ b/lib/minga/config/options.ex
@@ -110,6 +110,7 @@ defmodule Minga.Config.Options do
           | :log_level_agent
           | :log_level_editor
           | :cursorline
+          | :cursor_animate
           | :nav_flash
           | :nav_flash_threshold
           | :log_level_config
@@ -164,6 +165,13 @@ defmodule Minga.Config.Options do
 
   @typedoc "Reference to a Config.Options GenServer (registered name or pid)."
   @type server :: GenServer.server()
+
+  @typedoc "Options server state."
+  @type state :: %{
+          table: :ets.table(),
+          source: server(),
+          events_registry: Minga.Events.registry()
+        }
 
   # Single source of truth for the default registered Options server. Other
   # modules call `default_server/0` rather than referencing `__MODULE__`
@@ -290,6 +298,8 @@ defmodule Minga.Config.Options do
     {:confirm_quit, :boolean, true,
      "Whether quitting with unsaved changes asks for confirmation."},
     {:cursorline, :boolean, true, "Whether the current cursor line is highlighted."},
+    {:cursor_animate, :boolean, true,
+     "Whether cursor movement is smoothly animated in GUI frontends."},
     {:nav_flash, :boolean, true, "Whether large cursor jumps briefly highlight the destination."},
     {:nav_flash_threshold, :pos_integer, 5,
      "Minimum jump distance that triggers navigation flash."},
@@ -370,28 +380,32 @@ defmodule Minga.Config.Options do
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
+    events_registry = Keyword.get(opts, :events_registry, Minga.Events.default_registry())
+
     case Keyword.fetch(opts, :name) do
-      {:ok, nil} -> GenServer.start_link(__MODULE__, :anonymous, [])
-      {:ok, name} -> GenServer.start_link(__MODULE__, name, name: name)
-      :error -> GenServer.start_link(__MODULE__, __MODULE__, name: __MODULE__)
+      {:ok, nil} -> GenServer.start_link(__MODULE__, {:anonymous, events_registry}, [])
+      {:ok, name} -> GenServer.start_link(__MODULE__, {name, events_registry}, name: name)
+      :error -> GenServer.start_link(__MODULE__, {__MODULE__, events_registry}, name: __MODULE__)
     end
   end
 
   @impl GenServer
-  def init(:anonymous) do
+  def init({:anonymous, events_registry}) do
     # The first arg to :ets.new/2 is a tag, not a table identity, when
     # :named_table is omitted. Do NOT add :named_table here — multiple
     # anonymous Options servers may run concurrently (per-test isolation),
     # and a named ETS table can only exist once per BEAM node.
     table = :ets.new(:config_options, [:set, :public, read_concurrency: true])
     seed_defaults(table)
-    {:ok, %{table: table}}
+    seed_runtime_metadata(table, self(), events_registry)
+    {:ok, %{table: table, source: self(), events_registry: events_registry}}
   end
 
-  def init(name) do
+  def init({name, events_registry}) do
     table = :ets.new(table_name(name), [:set, :public, :named_table, read_concurrency: true])
     seed_defaults(table)
-    {:ok, %{table: table}}
+    seed_runtime_metadata(table, name, events_registry)
+    {:ok, %{table: table, source: name, events_registry: events_registry}}
   end
 
   # ── Extension Option Registration ──────────────────────────────────────────
@@ -626,9 +640,22 @@ defmodule Minga.Config.Options do
   """
   @spec set(server(), option_name(), term()) :: {:ok, term()} | {:error, String.t()}
   def set(server \\ @default_server, name, value) when is_atom(name) do
+    table = table_name(server)
+
     case validate(name, value) do
       :ok ->
-        :ets.insert(table_name(server), {name, value})
+        :ets.insert(table, {name, value})
+
+        Minga.Events.broadcast(
+          :option_changed,
+          %Minga.Events.OptionChangedEvent{
+            source: option_source(table, server),
+            name: name,
+            value: value
+          },
+          option_events_registry(table)
+        )
+
         {:ok, value}
 
       {:error, _} = err ->
@@ -711,8 +738,21 @@ defmodule Minga.Config.Options do
   @spec reset(server()) :: :ok
   def reset(server \\ @default_server) do
     table = table_name(server)
+    source = option_source(table, server)
+    events_registry = option_events_registry(table)
+    previous_cursor_animate = get(server, :cursor_animate)
     :ets.delete_all_objects(table)
     seed_defaults(table)
+    seed_runtime_metadata(table, source, events_registry)
+
+    broadcast_reset_option(
+      :cursor_animate,
+      previous_cursor_animate,
+      get(server, :cursor_animate),
+      source,
+      events_registry
+    )
+
     :ok
   end
 
@@ -1032,7 +1072,7 @@ defmodule Minga.Config.Options do
     end
   end
 
-  @spec table_name(GenServer.server()) :: atom()
+  @spec table_name(GenServer.server()) :: :ets.table()
   defp table_name(name) when is_atom(name), do: :"#{name}_ets"
   defp table_name(pid) when is_pid(pid), do: GenServer.call(pid, :table_name)
 
@@ -1040,6 +1080,42 @@ defmodule Minga.Config.Options do
   defp seed_defaults(table) do
     entries = Enum.map(@defaults, fn {name, value} -> {name, value} end)
     :ets.insert(table, entries)
+  end
+
+  @spec seed_runtime_metadata(:ets.table(), server(), Minga.Events.registry()) :: true
+  defp seed_runtime_metadata(table, source, events_registry) do
+    :ets.insert(table, [
+      {{:__metadata__, :source}, source},
+      {{:__metadata__, :events_registry}, events_registry}
+    ])
+  end
+
+  @spec option_source(:ets.table(), server()) :: server()
+  defp option_source(table, fallback) do
+    case :ets.lookup(table, {:__metadata__, :source}) do
+      [{{:__metadata__, :source}, source}] -> source
+      [] -> fallback
+    end
+  end
+
+  @spec broadcast_reset_option(option_name(), term(), term(), server(), Minga.Events.registry()) ::
+          :ok
+  defp broadcast_reset_option(_name, value, value, _source, _events_registry), do: :ok
+
+  defp broadcast_reset_option(name, _previous_value, value, source, events_registry) do
+    Minga.Events.broadcast(
+      :option_changed,
+      %Minga.Events.OptionChangedEvent{source: source, name: name, value: value},
+      events_registry
+    )
+  end
+
+  @spec option_events_registry(:ets.table()) :: Minga.Events.registry()
+  defp option_events_registry(table) do
+    case :ets.lookup(table, {:__metadata__, :events_registry}) do
+      [{{:__metadata__, :events_registry}, events_registry}] -> events_registry
+      [] -> Minga.Events.default_registry()
+    end
   end
 
   @impl GenServer

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -244,6 +244,14 @@ defmodule Minga.Events do
     @type t :: %__MODULE__{}
   end
 
+  defmodule OptionChangedEvent do
+    @moduledoc "Payload for `:option_changed` events. Published when a global config option changes at runtime."
+    @enforce_keys [:source, :name, :value]
+    defstruct [:source, :name, :value]
+
+    @type t :: %__MODULE__{source: GenServer.server(), name: atom(), value: term()}
+  end
+
   # ── Types ───────────────────────────────────────────────────────────────────
 
   @typedoc "Known event topics."
@@ -276,6 +284,7 @@ defmodule Minga.Events do
           | :changeset_merged
           | :changeset_budget_exhausted
           | :load_user_themes
+          | :option_changed
           | :buffer_fork_conflict
           | :file_written
           | :extension_updates_available
@@ -298,6 +307,7 @@ defmodule Minga.Events do
           | AgentHookEvent.t()
           | FaceOverridesChangedEvent.t()
           | LoadUserThemesEvent.t()
+          | OptionChangedEvent.t()
           | MingaAgent.SessionManager.SessionStoppedEvent.t()
           | MingaAgent.Subagent.Handle.t()
           | Minga.Distribution.Events.NodeConnectedEvent.t()
@@ -415,6 +425,7 @@ defmodule Minga.Events do
   @spec broadcast(:lsp_status_changed, LspStatusEvent.t()) :: :ok
   @spec broadcast(:supervisor_restarted, SupervisorRestartedEvent.t()) :: :ok
   @spec broadcast(:log_message, LogMessageEvent.t()) :: :ok
+  @spec broadcast(:option_changed, OptionChangedEvent.t()) :: :ok
   @spec broadcast(:face_overrides_changed, FaceOverridesChangedEvent.t()) :: :ok
   @spec broadcast(:agent_session_stopped, MingaAgent.SessionManager.SessionStoppedEvent.t()) ::
           :ok

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -239,6 +239,7 @@ defmodule MingaEditor do
     Minga.Events.subscribe(:node_connected, events_registry)
     Minga.Events.subscribe(:node_disconnected, events_registry)
     Minga.Events.subscribe(:load_user_themes, events_registry)
+    Minga.Events.subscribe(:option_changed, events_registry)
     Minga.Events.subscribe(:extension_updates_available, events_registry)
 
     # Monitor all initial buffers so we get :DOWN when they die.
@@ -934,6 +935,24 @@ defmodule MingaEditor do
 
   defp dispatch_minga_event(
          state,
+         :option_changed,
+         %Minga.Events.OptionChangedEvent{
+           source: source,
+           name: :cursor_animate,
+           value: enabled
+         },
+         _msg
+       )
+       when is_boolean(enabled) do
+    if option_source_matches?(source, EditorState.options_server(state)) do
+      Startup.send_cursor_animation_config(state, enabled)
+    end
+
+    state
+  end
+
+  defp dispatch_minga_event(
+         state,
          :face_overrides_changed,
          %Minga.Events.FaceOverridesChangedEvent{buffer: buf_pid, overrides: overrides},
          _msg
@@ -1041,6 +1060,17 @@ defmodule MingaEditor do
   end
 
   defp dispatch_minga_event(state, _event, _payload, _msg), do: state
+
+  @spec option_source_matches?(GenServer.server(), GenServer.server()) :: boolean()
+  defp option_source_matches?(source, server) when source == server, do: true
+
+  defp option_source_matches?(source, server) when is_atom(source) and is_pid(server),
+    do: Process.whereis(source) == server
+
+  defp option_source_matches?(source, server) when is_pid(source) and is_atom(server),
+    do: Process.whereis(server) == source
+
+  defp option_source_matches?(_source, _server), do: false
 
   @spec handle_node_connected(EditorState.t(), Minga.Distribution.Events.NodeConnectedEvent.t()) ::
           EditorState.t()

--- a/lib/minga_editor/frontend.ex
+++ b/lib/minga_editor/frontend.ex
@@ -105,6 +105,12 @@ defmodule MingaEditor.Frontend do
     send_commands(port, [MingaEditor.Frontend.Protocol.GUI.encode_gui_line_spacing(spacing)])
   end
 
+  @doc "Sends whether GUI frontends should animate cursor movement."
+  @spec send_cursor_animation(GenServer.server(), boolean()) :: :ok
+  def send_cursor_animation(port, enabled) when is_boolean(enabled) do
+    send_commands(port, [MingaEditor.Frontend.Protocol.GUI.encode_gui_cursor_animation(enabled)])
+  end
+
   # ── Parser/Highlight commands ────────────────────────────────────────────
 
   @doc """

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -187,6 +187,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   @op_clipboard_write 0x90
   @op_gui_indent_guides 0x91
   @op_gui_line_spacing 0x92
+  @op_gui_cursor_animation 0x95
   @op_gui_hover_action 0x96
 
   # ── GUI action sub-opcodes (Frontend → BEAM) ──
@@ -1027,6 +1028,20 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   def encode_gui_line_spacing(spacing) when is_number(spacing) and spacing >= 1.0 do
     spacing_x100 = round(spacing * 100)
     <<@op_gui_line_spacing, 2::16, spacing_x100::16>>
+  end
+
+  # ── Cursor animation (forward-compatible, 0x95) ──
+
+  @doc """
+  Encodes a gui_cursor_animation command.
+
+  Sends whether the GUI renderer should animate cursor movement. Reduce Motion can still disable animation on the frontend.
+  Uses the forward-compatible 0x90+ format: opcode(1) + payload_length(2) + enabled(1).
+  """
+  @spec encode_gui_cursor_animation(boolean()) :: binary()
+  def encode_gui_cursor_animation(enabled) when is_boolean(enabled) do
+    enabled_byte = if enabled, do: 1, else: 0
+    <<@op_gui_cursor_animation, 1::16, enabled_byte::8>>
   end
 
   # ── File tree ──

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -355,23 +355,43 @@ defmodule MingaEditor.Startup do
   @doc """
   Sends font configuration to the frontend via the port protocol.
 
-  Also sends the line_spacing value so the frontend can apply the
-  spacing multiplier to row positioning.
+  Also sends GUI renderer options such as line spacing and cursor animation.
   """
   @spec send_font_config(MingaEditor.State.t()) :: :ok
   def send_font_config(%{port_manager: nil}), do: :ok
 
-  def send_font_config(%{port_manager: port}) do
-    family = Config.get(:font_family)
-    size = Config.get(:font_size)
-    ligatures = Config.get(:font_ligatures)
-    weight = Config.get(:font_weight)
-    fallback = Config.get(:font_fallback)
+  def send_font_config(%{port_manager: port} = state) do
+    options_server = EditorState.options_server(state)
+    family = Minga.Config.Options.get(options_server, :font_family)
+    size = Minga.Config.Options.get(options_server, :font_size)
+    ligatures = Minga.Config.Options.get(options_server, :font_ligatures)
+    weight = Minga.Config.Options.get(options_server, :font_weight)
+    fallback = Minga.Config.Options.get(options_server, :font_fallback)
 
     MingaEditor.Frontend.configure_font(port, family, size, ligatures, weight, fallback || [])
 
-    line_spacing = Config.get(:line_spacing) || 1.0
-    MingaEditor.Frontend.send_line_spacing(port, line_spacing)
+    if MingaEditor.Frontend.gui?(state.capabilities) do
+      line_spacing = Minga.Config.Options.get(options_server, :line_spacing) || 1.0
+      MingaEditor.Frontend.send_line_spacing(port, line_spacing)
+
+      cursor_animate = Minga.Config.Options.get(options_server, :cursor_animate)
+      MingaEditor.Frontend.send_cursor_animation(port, cursor_animate)
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
+  @doc "Sends the current cursor animation preference to GUI frontends after a runtime option change."
+  @spec send_cursor_animation_config(MingaEditor.State.t(), boolean()) :: :ok
+  def send_cursor_animation_config(%{port_manager: nil}, _enabled), do: :ok
+
+  def send_cursor_animation_config(%{port_manager: port} = state, enabled)
+      when is_boolean(enabled) do
+    if MingaEditor.Frontend.gui?(state.capabilities) do
+      MingaEditor.Frontend.send_cursor_animation(port, enabled)
+    end
+
+    :ok
   catch
     :exit, _ -> :ok
   end

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -931,6 +931,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         disp.onLineSpacingChanged = { [weak nsView] spacing in
             nsView?.lineSpacingChanged(spacing)
         }
+        disp.onCursorAnimationChanged = { [weak ctRenderer, weak nsView] enabled in
+            ctRenderer?.setCursorAnimateConfigEnabled(enabled)
+            nsView?.renderFrame()
+        }
         disp.onTitleChanged = { [weak appState] title in
             Task { @MainActor in
                 appState?.windowTitle = title

--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -69,6 +69,7 @@ let OP_GUI_HOVER_ACTION: UInt8 = 0x96
 let OP_CLIPBOARD_WRITE: UInt8 = 0x90
 let OP_GUI_INDENT_GUIDES: UInt8 = 0x91
 let OP_GUI_LINE_SPACING: UInt8 = 0x92
+let OP_GUI_CURSOR_ANIMATION: UInt8 = 0x95
 
 // MARK: - Sectioned format section IDs
 // Used by opcodes with self-describing sections (gui_status_bar, etc.).

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -57,6 +57,7 @@ enum RenderCommand: Sendable {
     case clipboardWrite(target: UInt8, text: String)
     case guiIndentGuides(data: IndentGuideData)
     case guiLineSpacing(spacing: Float)
+    case guiCursorAnimation(enabled: Bool)
     case guiSplitSeparators(borderColor: UInt32, verticals: [Wire.VerticalSeparator], horizontals: [Wire.HorizontalSeparator])
     case guiGitStatus(repoState: UInt8, syncing: Bool, ahead: UInt16, behind: UInt16, branchName: String, entries: [Wire.GitStatusEntry], toast: (message: String, level: UInt8, action: UInt8)?)
     case guiAgentGroups(activeGroupId: UInt16, agentGroups: [Wire.AgentGroupEntry])
@@ -2137,6 +2138,15 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         let spacingX100 = readU16(data, rest + 2)
         let spacing = Float(spacingX100) / 100.0
         return (.guiLineSpacing(spacing: spacing), 1 + 2 + lsPayloadLen)
+
+    case OP_GUI_CURSOR_ANIMATION:
+        // Forward-compatible format: opcode(1) + payload_length(2) + enabled(1)
+        guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
+        let caPayloadLen = Int(readU16(data, rest))
+        guard data.count >= rest + 2 + caPayloadLen, caPayloadLen >= 1 else {
+            throw ProtocolDecodeError.malformed
+        }
+        return (.guiCursorAnimation(enabled: data[rest + 2] != 0), 1 + 2 + caPayloadLen)
 
     case OP_CLIPBOARD_WRITE:
         // Forward-compatible format: opcode(1) + payload_length(2) + target(1) + text_len(2) + text

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -60,6 +60,9 @@ final class CommandDispatcher {
     /// Called when line_spacing changes, so EditorNSView can trigger a resize.
     var onLineSpacingChanged: ((Float) -> Void)?
 
+    /// Called when the BEAM changes the GUI cursor animation preference.
+    var onCursorAnimationChanged: ((Bool) -> Void)?
+
     /// Called once after the first `batch_end` is received from the BEAM.
     /// Used in bundle mode to flush pending file URLs after the BEAM is ready.
     var onFirstRender: (() -> Void)?
@@ -204,6 +207,9 @@ final class CommandDispatcher {
             if oldSpacing != frameState.lineSpacing {
                 onLineSpacingChanged?(frameState.lineSpacing)
             }
+
+        case .guiCursorAnimation(let enabled):
+            onCursorAnimationChanged?(enabled)
 
         case .clipboardWrite(let target, let text):
             handleClipboardWrite(target: target, text: text)

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -47,10 +47,18 @@ struct BgParamsGPU {
 }
 
 /// Cursor geometry in device pixels for the current render frame.
-struct RenderCursor {
+struct RenderCursor: Equatable {
     let x: Float
     let y: Float
     let shape: CursorShape
+    let windowId: UInt16?
+
+    init(x: Float, y: Float, shape: CursorShape, windowId: UInt16? = nil) {
+        self.x = x
+        self.y = y
+        self.shape = shape
+        self.windowId = windowId
+    }
 }
 
 /// Default background clear color (dark gray matching the default bg).
@@ -88,6 +96,33 @@ final class CoreTextMetalRenderer {
     /// `.bgra8Unorm_srgb` framebuffer handles the sRGB→linear conversion
     /// for blending, so passing sRGB here is correct for visual accuracy.
     private(set) var cursorColor: SIMD3<Float>
+
+    /// Whether the cursor is currently gliding toward a new renderer-side target.
+    private(set) var cursorAnimating: Bool = false
+
+    /// Incremented each time a new cursor animation starts so the view can keep blink visible during movement.
+    private(set) var cursorAnimationGeneration: UInt64 = 0
+
+    /// Effective cursor animation setting after combining user config and Reduce Motion.
+    private(set) var cursorAnimateEnabled: Bool = true
+
+    /// User-configured cursor animation preference received from the BEAM.
+    private var cursorAnimateConfigEnabled: Bool = true
+
+    /// System accessibility Reduce Motion state, which always disables cursor animation.
+    private var cursorAnimationReduceMotionDisabled: Bool = false
+
+    private var hasCursorAnimationPosition: Bool = false
+    private var currentCursorX: Float = 0
+    private var currentCursorY: Float = 0
+    private var startCursorX: Float = 0
+    private var startCursorY: Float = 0
+    private var targetCursorX: Float = 0
+    private var targetCursorY: Float = 0
+    private var targetCursorShape: CursorShape = .block
+    private var targetCursorWindowId: UInt16?
+    private var cursorAnimationStartTime: CFTimeInterval = 0
+    private let cursorAnimationDuration: CFTimeInterval = 0.08
 
     /// Scroll indicator opacity (0.0 = hidden, 1.0 = fully visible).
     /// Set by EditorNSView based on scroll activity and fade timer.
@@ -262,7 +297,8 @@ final class CoreTextMetalRenderer {
                 gutterHoverWindowId: UInt16? = nil,
                 gutterHoverRow: UInt16? = nil,
                 drawable: CAMetalDrawable, viewportSize: CGSize,
-                contentScale: Float, scrollOffset: SIMD2<Float> = .zero) {
+                contentScale: Float, scrollOffset: SIMD2<Float> = .zero,
+                scrollTargetWindowId: UInt16? = nil) {
 
         // Store theme colors reference for helper methods.
         self.currentThemeColors = themeColors
@@ -273,6 +309,7 @@ final class CoreTextMetalRenderer {
         // Display cell height includes line spacing. Use for all row Y positioning
         // and quad heights. The original cellH is used for text texture sizing only.
         let displayCellH = cellH * frameState.lineSpacing
+        let smoothScrollOffsetPx = SIMD2<Float>(scrollOffset.x * scale, scrollOffset.y * scale)
 
         // Advance semantic content renderer.
         if let wcr = windowContentRenderer {
@@ -328,7 +365,7 @@ final class CoreTextMetalRenderer {
         let gutterPaddingPt: Float = frameState.gutterCol > 0 ? round(Float(Self.gutterRightGapPt) * scale) / scale : 0
         let gutterPaddingPx = gutterPaddingPt * scale
 
-        let renderCursor = CoreTextMetalRenderer.resolveCursor(
+        let resolvedCursor = CoreTextMetalRenderer.resolveCursor(
             frameState: frameState,
             windowContents: windowContents,
             cellW: cellW,
@@ -337,6 +374,7 @@ final class CoreTextMetalRenderer {
             gutterLeftMarginPx: gutterLeftMarginPx,
             gutterPaddingPx: gutterPaddingPx
         )
+        let renderCursor = animatedCursor(for: resolvedCursor, teleportLineThresholdPx: displayCellH * scale * 50.0)
 
         // Build background quads and line texture instances.
         var bgQuads: [QuadGPU] = []
@@ -344,7 +382,11 @@ final class CoreTextMetalRenderer {
 
         // Cursorline: draw a full-width bg fill on the cursor row.
         if frameState.cursorlineRow != 0xFFFF && frameState.cursorlineBg != 0 {
-            let yPos = Float(frameState.cursorlineRow) * displayCellH * scale
+            // gui_cursorline currently carries only a global screen row, not the owning window id.
+            // In side-by-side splits, row-only matching can apply one pane's fractional trackpad offset to another pane's cursorline.
+            // Keep the cursorline snapped until the protocol exposes an owning window id.
+            let cursorlineOffsetY: Float = 0
+            let yPos = Float(frameState.cursorlineRow) * displayCellH * scale - cursorlineOffsetY
             var clQuad = QuadGPU()
             clQuad.position = SIMD2<Float>(0, yPos)
             clQuad.size = SIMD2<Float>(Float(viewportSize.width), displayCellH * scale)
@@ -367,7 +409,13 @@ final class CoreTextMetalRenderer {
                     continue
                 }
 
+                let windowScrollOffsetPx = CoreTextMetalRenderer.smoothScrollOffset(
+                    for: content.windowId,
+                    targetWindowId: scrollTargetWindowId,
+                    scrollOffsetPx: smoothScrollOffsetPx
+                )
                 let windowRowOffset = Float(gutter.contentRow) * displayCellH * scale
+                let scrollableWindowRowOffset = windowRowOffset - windowScrollOffsetPx.y
                 let gutterWidth = Float(gutter.lineNumberWidth) + Float(gutter.signColWidth)
                 let contentColOffset = (Float(gutter.contentCol) + gutterWidth) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
 
@@ -381,7 +429,7 @@ final class CoreTextMetalRenderer {
                 if let sel = content.selection {
                     appendSelectionQuads(
                         selection: sel,
-                        rowOffset: windowRowOffset,
+                        rowOffset: scrollableWindowRowOffset,
                         colOffset: contentColOffset,
                         scrollLeft: scrollLeftInt,
                         visibleRows: content.rows.count,
@@ -397,7 +445,7 @@ final class CoreTextMetalRenderer {
                 for highlight in content.documentHighlights {
                     // Document highlights are typically single-line (one identifier).
                     // Draw on startRow only; multi-row highlights are rare for this feature.
-                    let hlY = windowRowOffset + Float(highlight.startRow) * displayCellH * scale
+                    let hlY = scrollableWindowRowOffset + Float(highlight.startRow) * displayCellH * scale
                     let hlX = contentColOffset + Float(highlight.startCol) * cellW * scale - hScrollPx
                     let hlW = Float(highlight.endCol - highlight.startCol) * cellW * scale
 
@@ -415,7 +463,7 @@ final class CoreTextMetalRenderer {
 
                 // Search match overlay quads (drawn before text).
                 for match in content.searchMatches {
-                    let matchY = windowRowOffset + Float(match.row) * displayCellH * scale
+                    let matchY = scrollableWindowRowOffset + Float(match.row) * displayCellH * scale
                     let matchX = contentColOffset + Float(match.startCol) * cellW * scale - hScrollPx
                     let matchW = Float(match.endCol - match.startCol) * cellW * scale
 
@@ -445,7 +493,7 @@ final class CoreTextMetalRenderer {
                 // Render pre-clipped line textures into atlas.
                 for (rowIdx, clippedRow) in clippedRows.enumerated() {
                     if let atlas, let entry = wcr.renderRowToAtlas(displayRow: UInt16(rowIdx), row: clippedRow, atlas: atlas) {
-                        let yPos = windowRowOffset + Float(rowIdx) * displayCellH * scale
+                        let yPos = scrollableWindowRowOffset + Float(rowIdx) * displayCellH * scale
                         let textYOffset = (displayCellH - cellH) * scale * 0.5
 
                         let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
@@ -478,7 +526,7 @@ final class CoreTextMetalRenderer {
                             linePixelWidth = 0
                         }
 
-                        let rowY = windowRowOffset + Float(rowIndex) * displayCellH * scale
+                        let rowY = scrollableWindowRowOffset + Float(rowIndex) * displayCellH * scale
                         var cursorX = contentColOffset + linePixelWidth
                             + Float(wcr.annotationGap) * scale
 
@@ -516,7 +564,7 @@ final class CoreTextMetalRenderer {
                     case .hint:    SIMD3<Float>(0.33, 0.33, 0.33)  // gray
                     }
 
-                    let diagY = windowRowOffset + Float(diag.startRow) * displayCellH * scale + displayCellH * scale - 2.0 * scale
+                    let diagY = scrollableWindowRowOffset + Float(diag.startRow) * displayCellH * scale + displayCellH * scale - 2.0 * scale
                     let diagX = contentColOffset + Float(diag.startCol) * cellW * scale - hScrollPx
                     let diagW = Float(diag.endCol - diag.startCol) * cellW * scale
 
@@ -543,6 +591,11 @@ final class CoreTextMetalRenderer {
                 isMouseInGutter: isMouseInGutter,
                 gutterHoverWindowId: gutterHoverWindowId,
                 gutterHoverRow: gutterHoverRow,
+                scrollOffsetY: CoreTextMetalRenderer.smoothScrollOffset(
+                    for: windowGutter.windowId,
+                    targetWindowId: scrollTargetWindowId,
+                    scrollOffsetPx: smoothScrollOffsetPx
+                ).y,
                 bgQuads: &bgQuads,
                 lineInstances: &lineInstances
             )
@@ -558,9 +611,10 @@ final class CoreTextMetalRenderer {
         guard let cmdBuf = commandQueue.makeCommandBuffer(),
               let encoder = cmdBuf.makeRenderCommandEncoder(descriptor: renderDesc) else { return }
 
+        // Keep shader uniforms fixed. Smooth-scroll deltas are baked only into scrollable buffer content and cursor positions above, so fixed chrome such as gutters, split separators, labels, and scroll indicators does not drift during fractional scroll frames.
         var uniforms = CTUniformsGPU(
             viewportSize: SIMD2<Float>(Float(viewportSize.width), Float(viewportSize.height)),
-            scrollOffset: SIMD2<Float>(scrollOffset.x * scale, scrollOffset.y * scale)
+            scrollOffset: .zero
         )
 
         // Default fragment params: no corner radius (sharp rectangles).
@@ -584,8 +638,13 @@ final class CoreTextMetalRenderer {
             guard let gutter = frameState.windowGutters[guideData.windowId] else { continue }
             let gutterWidth = Float(gutter.lineNumberWidth) + Float(gutter.signColWidth)
             let windowContentColOffset = (Float(gutter.contentCol) + gutterWidth) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
-            let contentTopY = Float(gutter.contentRow) * cellH * scale
-            let lineCellH = cellH * scale
+            let guideScrollOffsetY = CoreTextMetalRenderer.smoothScrollOffset(
+                for: guideData.windowId,
+                targetWindowId: scrollTargetWindowId,
+                scrollOffsetPx: smoothScrollOffsetPx
+            ).y
+            let contentTopY = Float(gutter.contentRow) * displayCellH * scale - guideScrollOffsetY
+            let lineCellH = displayCellH * scale
 
             let inactiveFg = colorFromU24(frameState.gutterColors.fg, default: SIMD3<Float>(0.33, 0.33, 0.33))
             let tabW = max(UInt16(guideData.tabWidth), 1)
@@ -593,7 +652,7 @@ final class CoreTextMetalRenderer {
             var guideQuads: [QuadGPU] = []
 
             if guideData.lineIndentLevels.isEmpty {
-                let contentHeightPx = Float(gutter.contentHeight) * cellH * scale
+                let contentHeightPx = Float(gutter.contentHeight) * displayCellH * scale
                 guideQuads.reserveCapacity(guideData.guideCols.count)
                 for col in guideData.guideCols {
                     let guideX = windowContentColOffset + Float(col) * cellW * scale
@@ -656,8 +715,15 @@ final class CoreTextMetalRenderer {
         // For block cursors, draw the cursor bg here so the text pass composites over it.
         // Beam and underline cursors are drawn AFTER text (pass 5).
         if let renderCursor, cursorBlinkVisible, renderCursor.shape == .block {
+            let cursorScrollOffsetPx = CoreTextMetalRenderer.smoothScrollOffset(
+                for: renderCursor.windowId,
+                targetWindowId: scrollTargetWindowId,
+                scrollOffsetPx: smoothScrollOffsetPx
+            )
+            let cursorX = renderCursor.x - cursorScrollOffsetPx.x
+            let cursorY = renderCursor.y - cursorScrollOffsetPx.y
             var cursorQuad = QuadGPU()
-            cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(renderCursor.x), CoreTextMetalRenderer.snapToPixel(renderCursor.y))
+            cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cursorX), CoreTextMetalRenderer.snapToPixel(cursorY))
             cursorQuad.size = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cellW * scale), CoreTextMetalRenderer.snapToPixel(displayCellH * scale))
             cursorQuad.color = cursorColor
             cursorQuad.alpha = 1.0
@@ -820,6 +886,13 @@ final class CoreTextMetalRenderer {
         // Block cursor is drawn in pass 2 (before text) so text shows on top.
         // Beam and underline are drawn AFTER text so they overlay it.
         if let renderCursor, cursorBlinkVisible, renderCursor.shape != .block {
+            let cursorScrollOffsetPx = CoreTextMetalRenderer.smoothScrollOffset(
+                for: renderCursor.windowId,
+                targetWindowId: scrollTargetWindowId,
+                scrollOffsetPx: smoothScrollOffsetPx
+            )
+            let cursorX = renderCursor.x - cursorScrollOffsetPx.x
+            let cursorY = renderCursor.y - cursorScrollOffsetPx.y
             var cursorQuad = QuadGPU()
             cursorQuad.color = cursorColor
             cursorQuad.alpha = 1.0
@@ -830,13 +903,13 @@ final class CoreTextMetalRenderer {
 
             case .beam:
                 let beamWidth: Float = 2.0 * scale
-                cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(renderCursor.x), CoreTextMetalRenderer.snapToPixel(renderCursor.y))
+                cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cursorX), CoreTextMetalRenderer.snapToPixel(cursorY))
                 cursorQuad.size = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(beamWidth), CoreTextMetalRenderer.snapToPixel(displayCellH * scale))
 
             case .underline:
                 let ulHeight: Float = 2.0 * scale
-                let cellBottom = renderCursor.y + displayCellH * scale
-                cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(renderCursor.x), CoreTextMetalRenderer.snapToPixel(cellBottom - ulHeight))
+                let cellBottom = cursorY + displayCellH * scale
+                cursorQuad.position = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cursorX), CoreTextMetalRenderer.snapToPixel(cellBottom - ulHeight))
                 cursorQuad.size = SIMD2<Float>(CoreTextMetalRenderer.snapToPixel(cellW * scale), CoreTextMetalRenderer.snapToPixel(ulHeight))
             }
 
@@ -902,6 +975,7 @@ final class CoreTextMetalRenderer {
         isMouseInGutter: Bool,
         gutterHoverWindowId: UInt16?,
         gutterHoverRow: UInt16?,
+        scrollOffsetY: Float,
         bgQuads: inout [QuadGPU],
         lineInstances: inout [LineGPU]
     ) {
@@ -911,7 +985,7 @@ final class CoreTextMetalRenderer {
 
         for (rowIndex, entry) in gutter.entries.enumerated() {
             let screenRow = baseRow + UInt16(rowIndex)
-            let yPos = Float(screenRow) * cellH * scale
+            let yPos = Float(screenRow) * cellH * scale - scrollOffsetY
             let xOffset = Float(baseCol) * cellW * scale + gutterLeftMarginPx
 
             // Sign column (leftmost in gutter)
@@ -1259,6 +1333,138 @@ final class CoreTextMetalRenderer {
 
     // MARK: - Private
 
+    /// Updates the user-configured cursor animation preference.
+    func setCursorAnimateConfigEnabled(_ enabled: Bool) {
+        cursorAnimateConfigEnabled = enabled
+        refreshCursorAnimateEnabled()
+    }
+
+    /// Updates the Reduce Motion override for cursor animation.
+    func setCursorAnimationReduceMotionDisabled(_ disabled: Bool) {
+        cursorAnimationReduceMotionDisabled = disabled
+        refreshCursorAnimateEnabled()
+    }
+
+    private func refreshCursorAnimateEnabled() {
+        cursorAnimateEnabled = cursorAnimateConfigEnabled && !cursorAnimationReduceMotionDisabled
+        guard !cursorAnimateEnabled else { return }
+        snapCursorAnimationToTarget()
+    }
+
+    func animatedCursor(for resolvedCursor: RenderCursor?, teleportLineThresholdPx: Float) -> RenderCursor? {
+        guard let resolvedCursor else {
+            cursorAnimating = false
+            hasCursorAnimationPosition = false
+            return nil
+        }
+
+        guard cursorAnimateEnabled else {
+            snapCursorAnimation(to: resolvedCursor)
+            return resolvedCursor
+        }
+
+        if !hasCursorAnimationPosition {
+            snapCursorAnimation(to: resolvedCursor)
+            return resolvedCursor
+        }
+
+        if cursorTargetChanged(resolvedCursor) {
+            updateCursorAnimation()
+            startCursorAnimation(to: resolvedCursor, teleportLineThresholdPx: teleportLineThresholdPx)
+        }
+
+        return updateCursorAnimation() ?? resolvedCursor
+    }
+
+    private func cursorTargetChanged(_ cursor: RenderCursor) -> Bool {
+        abs(targetCursorX - cursor.x) > 0.001 || abs(targetCursorY - cursor.y) > 0.001 || targetCursorShape != cursor.shape || targetCursorWindowId != cursor.windowId || !hasCursorAnimationPosition
+    }
+
+    private func startCursorAnimation(to cursor: RenderCursor, teleportLineThresholdPx: Float) {
+        let distanceY = abs(cursor.y - currentCursorY)
+        guard distanceY <= teleportLineThresholdPx else {
+            snapCursorAnimation(to: cursor)
+            return
+        }
+
+        startCursorX = currentCursorX
+        startCursorY = currentCursorY
+        targetCursorX = cursor.x
+        targetCursorY = cursor.y
+        targetCursorShape = cursor.shape
+        targetCursorWindowId = cursor.windowId
+        cursorAnimationStartTime = CACurrentMediaTime()
+        cursorAnimating = true
+        cursorAnimationGeneration &+= 1
+    }
+
+    @discardableResult
+    func updateCursorAnimation(now: CFTimeInterval = CACurrentMediaTime()) -> RenderCursor? {
+        guard hasCursorAnimationPosition else { return nil }
+        guard cursorAnimating else {
+            currentCursorX = targetCursorX
+            currentCursorY = targetCursorY
+            return RenderCursor(x: currentCursorX, y: currentCursorY, shape: targetCursorShape, windowId: targetCursorWindowId)
+        }
+
+        let progress = CoreTextMetalRenderer.cursorAnimationProgress(now: now, startTime: cursorAnimationStartTime, duration: cursorAnimationDuration)
+        let eased = CoreTextMetalRenderer.easeOutCubic(progress)
+        currentCursorX = CoreTextMetalRenderer.lerp(startCursorX, targetCursorX, eased)
+        currentCursorY = CoreTextMetalRenderer.lerp(startCursorY, targetCursorY, eased)
+
+        if progress >= 1.0 {
+            cursorAnimating = false
+            currentCursorX = targetCursorX
+            currentCursorY = targetCursorY
+        }
+
+        return RenderCursor(x: currentCursorX, y: currentCursorY, shape: targetCursorShape, windowId: targetCursorWindowId)
+    }
+
+    nonisolated static func cursorAnimationProgress(now: CFTimeInterval, startTime: CFTimeInterval, duration: CFTimeInterval) -> Float {
+        guard duration > 0 else { return 1.0 }
+        return min(max(Float((now - startTime) / duration), 0.0), 1.0)
+    }
+
+    nonisolated static func easeOutCubic(_ progress: Float) -> Float {
+        let clamped = min(max(progress, 0.0), 1.0)
+        return 1.0 - powf(1.0 - clamped, 3.0)
+    }
+
+    nonisolated static func lerp(_ start: Float, _ end: Float, _ progress: Float) -> Float {
+        start + (end - start) * progress
+    }
+
+    nonisolated static func smoothScrollOffset(for windowId: UInt16?, targetWindowId: UInt16?, scrollOffsetPx: SIMD2<Float>) -> SIMD2<Float> {
+        guard let windowId, let targetWindowId, windowId == targetWindowId else { return .zero }
+        return scrollOffsetPx
+    }
+
+    nonisolated static func interpolateCursor(start: RenderCursor, target: RenderCursor, progress: Float) -> RenderCursor {
+        let eased = easeOutCubic(progress)
+        return RenderCursor(x: lerp(start.x, target.x, eased), y: lerp(start.y, target.y, eased), shape: target.shape, windowId: target.windowId)
+    }
+
+    private func snapCursorAnimationToTarget() {
+        guard hasCursorAnimationPosition else { return }
+        currentCursorX = targetCursorX
+        currentCursorY = targetCursorY
+        cursorAnimating = false
+    }
+
+    private func snapCursorAnimation(to cursor: RenderCursor) {
+        hasCursorAnimationPosition = true
+        currentCursorX = cursor.x
+        currentCursorY = cursor.y
+        startCursorX = cursor.x
+        startCursorY = cursor.y
+        targetCursorX = cursor.x
+        targetCursorY = cursor.y
+        targetCursorShape = cursor.shape
+        targetCursorWindowId = cursor.windowId
+        cursorAnimating = false
+    }
+
     /// Resolve the cursor position in the same coordinate system as the text renderer.
     /// Semantic GUI window content is preferred because it carries window-relative cursor coordinates and horizontal scroll. Legacy frameState cursor data remains the fallback for transition frames and non-semantic surfaces.
     nonisolated static func resolveCursor(
@@ -1280,7 +1486,7 @@ final class CoreTextMetalRenderer {
             let cursorCol = resolvedSemanticCursorCol(content)
             let x = contentColOffset + Float(cursorCol) * cellW * scale - hScrollPx
             let y = (Float(gutter.contentRow) + Float(content.cursorRow)) * displayCellH * scale
-            return RenderCursor(x: x, y: y, shape: content.cursorShape)
+            return RenderCursor(x: x, y: y, shape: content.cursorShape, windowId: windowId)
         }
 
         guard frameState.cursorVisible else { return nil }

--- a/macos/Sources/Views/EditorNSView.swift
+++ b/macos/Sources/Views/EditorNSView.swift
@@ -191,6 +191,7 @@ final class EditorNSView: MTKView {
         colorPixelFormat = .bgra8Unorm_srgb
         layer?.isOpaque = true
 
+        coreTextRenderer.setCursorAnimationReduceMotionDisabled(NSWorkspace.shared.accessibilityDisplayShouldReduceMotion)
     }
 
     @available(*, unavailable)
@@ -287,6 +288,7 @@ final class EditorNSView: MTKView {
         accessibilityTask = Task { @MainActor [weak self] in
             for await _ in NotificationCenter.default.notifications(named: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification) {
                 guard let self else { return }
+                self.coreTextRenderer.setCursorAnimationReduceMotionDisabled(NSWorkspace.shared.accessibilityDisplayShouldReduceMotion)
                 if SystemBlinkTiming.blinkingDisabled {
                     self.stopCursorBlink()
                 } else {
@@ -301,6 +303,10 @@ final class EditorNSView: MTKView {
     /// Sub-cell-height vertical pixel offset for smooth trackpad scrolling.
     /// Positive = content shifted up (scrolled down). Always in [0, cellHeight).
     private var scrollPixelOffset: CGFloat = 0
+
+    /// Window receiving the current fractional smooth-scroll offset.
+    /// Nil means the event location did not resolve to a scrollable editor window, so fractional offset is disabled instead of shifting every pane.
+    private var scrollTargetWindowId: UInt16?
 
     /// Schedule a render on the next vsync. Multiple calls between vsyncs
     /// are coalesced by MTKView into a single draw() call.
@@ -343,7 +349,7 @@ final class EditorNSView: MTKView {
         }
         let validGutterHoverRow = validGutterHoverWindowId == nil ? nil : gutterHoverRow
         let validMouseInGutter = isMouseInGutter && validGutterHoverWindowId != nil
-
+        let cursorAnimationGeneration = coreTextRenderer.cursorAnimationGeneration
         coreTextRenderer.render(frameState: fs, fontManager: fontManager,
                                 cursorBlinkVisible: cursorBlinkVisible,
                                 windowContents: guiState?.windowContents ?? [:],
@@ -352,7 +358,15 @@ final class EditorNSView: MTKView {
                                 gutterHoverWindowId: validGutterHoverWindowId,
                                 gutterHoverRow: validGutterHoverRow,
                                 drawable: drawable, viewportSize: drawableSize,
-                                contentScale: scale)
+                                contentScale: scale,
+                                scrollOffset: SIMD2<Float>(0, Float(scrollPixelOffset)),
+                                scrollTargetWindowId: scrollTargetWindowId)
+        if coreTextRenderer.cursorAnimationGeneration != cursorAnimationGeneration {
+            resetCursorBlink()
+        }
+        if coreTextRenderer.cursorAnimating {
+            needsDisplay = true
+        }
         dispatcher.frameState.dirty = false
     }
 
@@ -1270,6 +1284,9 @@ final class EditorNSView: MTKView {
     private func handleTrackpadScroll(event: NSEvent, row: Int16, col: Int16, mods: UInt8) {
         if event.phase == .began {
             scrollAccumulator.reset()
+            scrollTargetWindowId = smoothScrollTargetWindowId(row: row, col: col)
+        } else if scrollTargetWindowId == nil {
+            scrollTargetWindowId = smoothScrollTargetWindowId(row: row, col: col)
         }
 
         // Vertical: smooth sub-line pixel offset
@@ -1278,7 +1295,7 @@ final class EditorNSView: MTKView {
         for e in vEvents {
             sendScrollEvent(e, row: row, col: col, mods: mods)
         }
-        scrollPixelOffset = scrollAccumulator.pixelOffsetY
+        scrollPixelOffset = scrollTargetWindowId == nil ? 0 : scrollAccumulator.pixelOffsetY
 
         // Horizontal: discrete column events
         let hEvents = scrollAccumulator.accumulateHorizontal(
@@ -1289,17 +1306,43 @@ final class EditorNSView: MTKView {
 
         // Snap to zero when gesture/momentum ends
         if (event.phase == .ended || event.phase == .cancelled) && event.momentumPhase == [] {
-            scrollAccumulator.snapVertical()
-            scrollPixelOffset = 0
+            finishSmoothScrollGesture()
         }
-        if event.momentumPhase == .ended {
-            scrollAccumulator.snapVertical()
-            scrollPixelOffset = 0
+        if event.momentumPhase == .ended || event.momentumPhase == .cancelled {
+            finishSmoothScrollGesture()
         }
 
         // Tell MTKView we need a frame. The display link coalesces
         // multiple scroll events between vsyncs into one draw() call.
         needsDisplay = true
+    }
+
+    private func finishSmoothScrollGesture() {
+        scrollAccumulator.reset()
+        scrollPixelOffset = 0
+        scrollTargetWindowId = nil
+    }
+
+    private func smoothScrollTargetWindowId(row: Int16, col: Int16) -> UInt16? {
+        EditorNSView.smoothScrollTargetWindowId(row: row, col: col, windowGutters: dispatcher.frameState.windowGutters)
+    }
+
+    nonisolated static func smoothScrollTargetWindowId(row: Int16, col: Int16, windowGutters: [UInt16: Wire.WindowGutter]) -> UInt16? {
+        guard row >= 0, col >= 0 else { return nil }
+        let rowValue = Int(row)
+        let colValue = Int(col)
+        let rowMatches = windowGutters.values.filter { gutter in
+            let startRow = Int(gutter.contentRow)
+            let endRow = startRow + Int(gutter.contentHeight)
+            let startCol = Int(gutter.contentCol)
+            let endCol = startCol + Int(gutter.contentWidth)
+            return rowValue >= startRow && rowValue < endRow && colValue >= startCol && colValue < endCol
+        }
+        guard !rowMatches.isEmpty else { return nil }
+
+        return rowMatches
+            .max { lhs, rhs in lhs.contentCol < rhs.contentCol }?
+            .windowId
     }
 
     /// Discrete mouse wheel: one event per click, no accumulation.

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -2,6 +2,7 @@
 
 import Testing
 import Foundation
+import QuartzCore
 
 @Suite("CoreTextMetalRenderer cursor geometry")
 struct CoreTextMetalRendererCursorTests {
@@ -47,8 +48,61 @@ struct CoreTextMetalRendererCursorTests {
         let expectedY = Float(4 + 2) * displayCellH * scale
 
         #expect(cursor?.shape == .beam)
+        #expect(cursor?.windowId == 2)
         #expect(abs((cursor?.x ?? 0) - expectedX) < 0.001)
         #expect(abs((cursor?.y ?? 0) - expectedY) < 0.001)
+    }
+
+    @Test("smooth scroll offset applies only to its target window")
+    func smoothScrollOffsetAppliesOnlyToTargetWindow() {
+        let offset = SIMD2<Float>(0, 7)
+
+        #expect(CoreTextMetalRenderer.smoothScrollOffset(for: 2, targetWindowId: 2, scrollOffsetPx: offset) == offset)
+        #expect(CoreTextMetalRenderer.smoothScrollOffset(for: 1, targetWindowId: 2, scrollOffsetPx: offset) == .zero)
+        #expect(CoreTextMetalRenderer.smoothScrollOffset(for: 2, targetWindowId: nil, scrollOffsetPx: offset) == .zero)
+        #expect(CoreTextMetalRenderer.smoothScrollOffset(for: nil, targetWindowId: 2, scrollOffsetPx: offset) == .zero)
+    }
+
+    @Test("cursorline smooth scroll offset stays disabled without an owning window id")
+    func cursorlineSmoothScrollOffsetStaysDisabledWithoutOwningWindowId() {
+        let offset = SIMD2<Float>(0, 7)
+
+        #expect(CoreTextMetalRenderer.smoothScrollOffset(for: nil, targetWindowId: 1, scrollOffsetPx: offset) == .zero)
+    }
+
+    @Test("smooth scroll target requires content column even for one row match")
+    func smoothScrollTargetRequiresContentColumnForSingleRowMatch() {
+        let gutters: [UInt16: Wire.WindowGutter] = [
+            1: Wire.WindowGutter(
+                windowId: 1, contentRow: 0, contentCol: 10, contentHeight: 20,
+                isActive: true, contentWidth: 30, cursorLine: 3, lineNumberStyle: .hybrid,
+                lineNumberWidth: 4, signColWidth: 1, entries: []
+            )
+        ]
+
+        #expect(EditorNSView.smoothScrollTargetWindowId(row: 5, col: 9, windowGutters: gutters) == nil)
+        #expect(EditorNSView.smoothScrollTargetWindowId(row: 5, col: 10, windowGutters: gutters) == 1)
+        #expect(EditorNSView.smoothScrollTargetWindowId(row: 5, col: 40, windowGutters: gutters) == nil)
+    }
+
+    @Test("smooth scroll target chooses rightmost content hit for split panes")
+    func smoothScrollTargetChoosesRightmostContentHitForSplitPanes() {
+        let gutters: [UInt16: Wire.WindowGutter] = [
+            1: Wire.WindowGutter(
+                windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
+                isActive: false, contentWidth: 40, cursorLine: 3, lineNumberStyle: .hybrid,
+                lineNumberWidth: 4, signColWidth: 1, entries: []
+            ),
+            2: Wire.WindowGutter(
+                windowId: 2, contentRow: 0, contentCol: 40, contentHeight: 20,
+                isActive: true, contentWidth: 40, cursorLine: 3, lineNumberStyle: .hybrid,
+                lineNumberWidth: 4, signColWidth: 1, entries: []
+            )
+        ]
+
+        #expect(EditorNSView.smoothScrollTargetWindowId(row: 5, col: 39, windowGutters: gutters) == 1)
+        #expect(EditorNSView.smoothScrollTargetWindowId(row: 5, col: 40, windowGutters: gutters) == 2)
+        #expect(EditorNSView.smoothScrollTargetWindowId(row: -1, col: 40, windowGutters: gutters) == nil)
     }
 
     @Test("semantic block cursor at end of line renders over final character")
@@ -123,6 +177,106 @@ struct CoreTextMetalRendererCursorTests {
         #expect(cursor?.shape == .underline)
         #expect(abs((cursor?.x ?? 0) - expectedX) < 0.001)
         #expect(abs((cursor?.y ?? 0) - expectedY) < 0.001)
+    }
+
+    @Test("cursor animation progress clamps to timeline bounds")
+    func cursorAnimationProgressClamps() {
+        #expect(CoreTextMetalRenderer.cursorAnimationProgress(now: 0.0, startTime: 1.0, duration: 0.08) == 0.0)
+        #expect(CoreTextMetalRenderer.cursorAnimationProgress(now: 1.04, startTime: 1.0, duration: 0.08) == 0.5)
+        #expect(CoreTextMetalRenderer.cursorAnimationProgress(now: 1.2, startTime: 1.0, duration: 0.08) == 1.0)
+    }
+
+    @Test("cursor animation uses cubic ease-out interpolation")
+    func cursorAnimationUsesCubicEaseOut() {
+        let start = RenderCursor(x: 0, y: 0, shape: .block)
+        let target = RenderCursor(x: 100, y: 40, shape: .beam)
+
+        let atStart = CoreTextMetalRenderer.interpolateCursor(start: start, target: target, progress: 0)
+        let halfway = CoreTextMetalRenderer.interpolateCursor(start: start, target: target, progress: 0.5)
+        let atEnd = CoreTextMetalRenderer.interpolateCursor(start: start, target: target, progress: 1)
+
+        #expect(atStart == RenderCursor(x: 0, y: 0, shape: .beam))
+        #expect(abs(halfway.x - 87.5) < 0.001)
+        #expect(abs(halfway.y - 35.0) < 0.001)
+        #expect(atEnd == target)
+    }
+
+    @Test("first cursor render snaps without animating from origin")
+    @MainActor func firstCursorRenderSnapsWithoutAnimatingFromOrigin() {
+        guard let renderer = CoreTextMetalRenderer() else { return }
+        let first = RenderCursor(x: 120, y: 64, shape: .beam)
+
+        let rendered = renderer.animatedCursor(for: first, teleportLineThresholdPx: 1_000)
+
+        #expect(rendered == first)
+        #expect(renderer.cursorAnimating == false)
+        #expect(renderer.cursorAnimationGeneration == 0)
+    }
+
+    @Test("small cursor move starts and completes animation")
+    @MainActor func smallCursorMoveStartsAndCompletesAnimation() {
+        guard let renderer = CoreTextMetalRenderer() else { return }
+        let start = RenderCursor(x: 10, y: 10, shape: .block)
+        let target = RenderCursor(x: 20, y: 20, shape: .beam)
+
+        _ = renderer.animatedCursor(for: start, teleportLineThresholdPx: 1_000)
+        let firstAnimatedFrame = renderer.animatedCursor(for: target, teleportLineThresholdPx: 1_000)
+
+        #expect(firstAnimatedFrame?.shape == .beam)
+        #expect(renderer.cursorAnimating == true)
+        #expect(renderer.cursorAnimationGeneration == 1)
+
+        let completed = renderer.updateCursorAnimation(now: CACurrentMediaTime() + 1.0)
+
+        #expect(completed == target)
+        #expect(renderer.cursorAnimating == false)
+    }
+
+    @Test("disabled cursor animation snaps to new target")
+    @MainActor func disabledCursorAnimationSnapsToNewTarget() {
+        guard let renderer = CoreTextMetalRenderer() else { return }
+        let start = RenderCursor(x: 10, y: 10, shape: .block)
+        let target = RenderCursor(x: 20, y: 20, shape: .beam)
+
+        _ = renderer.animatedCursor(for: start, teleportLineThresholdPx: 1_000)
+        renderer.setCursorAnimateConfigEnabled(false)
+        let rendered = renderer.animatedCursor(for: target, teleportLineThresholdPx: 1_000)
+
+        #expect(rendered == target)
+        #expect(renderer.cursorAnimateEnabled == false)
+        #expect(renderer.cursorAnimating == false)
+        #expect(renderer.updateCursorAnimation() == target)
+    }
+
+    @Test("Reduce Motion override snaps even when config enables animation")
+    @MainActor func reduceMotionOverrideSnapsWhenConfigEnablesAnimation() {
+        guard let renderer = CoreTextMetalRenderer() else { return }
+        let start = RenderCursor(x: 10, y: 10, shape: .block)
+        let target = RenderCursor(x: 20, y: 20, shape: .beam)
+
+        renderer.setCursorAnimateConfigEnabled(true)
+        _ = renderer.animatedCursor(for: start, teleportLineThresholdPx: 1_000)
+        renderer.setCursorAnimationReduceMotionDisabled(true)
+        let rendered = renderer.animatedCursor(for: target, teleportLineThresholdPx: 1_000)
+
+        #expect(rendered == target)
+        #expect(renderer.cursorAnimateEnabled == false)
+        #expect(renderer.cursorAnimating == false)
+        #expect(renderer.updateCursorAnimation() == target)
+    }
+
+    @Test("large vertical cursor jumps teleport instead of animating")
+    @MainActor func largeVerticalCursorJumpsTeleport() {
+        guard let renderer = CoreTextMetalRenderer() else { return }
+        let start = RenderCursor(x: 10, y: 10, shape: .block)
+        let farTarget = RenderCursor(x: 10, y: 2_000, shape: .block)
+
+        _ = renderer.animatedCursor(for: start, teleportLineThresholdPx: 100)
+        let rendered = renderer.animatedCursor(for: farTarget, teleportLineThresholdPx: 100)
+
+        #expect(rendered == farTarget)
+        #expect(renderer.cursorAnimating == false)
+        #expect(renderer.cursorAnimationGeneration == 0)
     }
 
     @Test("hidden semantic cursor suppresses legacy fallback after dispatcher sync")

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -56,6 +56,18 @@ struct ProtocolDecoderTests {
         #expect(shape == .beam)
     }
 
+    @Test("Decode gui_cursor_animation command")
+    func decodeGuiCursorAnimation() throws {
+        let data = Data([OP_GUI_CURSOR_ANIMATION, 0x00, 0x01, 0x00])
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == 4)
+        guard case .guiCursorAnimation(let enabled) = cmd else {
+            Issue.record("Expected .guiCursorAnimation, got \(String(describing: cmd))")
+            return
+        }
+        #expect(enabled == false)
+    }
+
     @Test("Decode draw_text command")
     func decodeDrawText() throws {
         // row=1, col=2, fg=0xFF0000 (red), bg=0x00FF00 (green), attrs=0x01 (bold), text="Hi"

--- a/test/minga/config/options_test.exs
+++ b/test/minga/config/options_test.exs
@@ -108,6 +108,7 @@ defmodule Minga.Config.OptionsTest do
                log_level_agent: :default,
                log_level_editor: :default,
                cursorline: true,
+               cursor_animate: true,
                nav_flash: true,
                nav_flash_threshold: 5,
                yank_flash: true,
@@ -331,6 +332,23 @@ defmodule Minga.Config.OptionsTest do
 
       assert Options.get(s, :tab_width) == 2
       assert Options.get(s, :autopair) == true
+    end
+
+    test "publishes cursor animation default when reset re-enables it" do
+      registry = :"#{__MODULE__}.reset_events.#{System.unique_integer([:positive])}"
+      start_supervised!({Registry, keys: :duplicate, name: registry})
+      server = start_supervised!({Options, name: nil, events_registry: registry})
+      Minga.Events.subscribe(:option_changed, registry)
+
+      assert {:ok, false} = Options.set(server, :cursor_animate, false)
+      Options.reset(server)
+
+      assert_receive {:minga_event, :option_changed,
+                      %Minga.Events.OptionChangedEvent{
+                        source: ^server,
+                        name: :cursor_animate,
+                        value: true
+                      }}
     end
   end
 

--- a/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
+++ b/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
@@ -341,6 +341,16 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
     end
   end
 
+  describe "encode_gui_cursor_animation/1" do
+    test "encodes enabled cursor animation" do
+      assert <<0x95, 1::16, 1::8>> = ProtocolGUI.encode_gui_cursor_animation(true)
+    end
+
+    test "encodes disabled cursor animation" do
+      assert <<0x95, 1::16, 0::8>> = ProtocolGUI.encode_gui_cursor_animation(false)
+    end
+  end
+
   describe "encode_gui_status_bar/1 background subagents" do
     test "encodes background subagent count and label in buffer agent section" do
       binary = ProtocolGUI.encode_gui_status_bar({:buffer, status_data()})

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -5,16 +5,81 @@ defmodule MingaEditor.StartupTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Config.Options
+  alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.LayoutPreset
   alias MingaEditor.Startup
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
+  alias Minga.Test.RecordingFrontend
   alias MingaEditor.Window
   alias MingaEditor.Window.Content
   alias MingaEditor.WindowTree
   alias MingaEditor.Input
+
+  defp start_events_registry(suffix) do
+    name = :"#{__MODULE__}.#{suffix}.#{System.unique_integer([:positive])}"
+    start_supervised!({Registry, keys: :duplicate, name: name})
+    name
+  end
+
+  defp start_recording_editor(frontend_type, suffix) do
+    id = System.unique_integer([:positive])
+    events_registry = start_events_registry(suffix)
+
+    options_server =
+      start_supervised!({Options, name: nil, events_registry: events_registry},
+        id: {:options, suffix, id}
+      )
+
+    {:ok, buffer} = BufferProcess.start_link(content: "", events_registry: events_registry)
+
+    port =
+      start_supervised!(
+        {RecordingFrontend,
+         owner: self(),
+         width: 80,
+         height: 24,
+         capabilities: %Capabilities{frontend_type: frontend_type}},
+        id: {:recording_frontend, suffix, id}
+      )
+
+    editor =
+      start_supervised!(
+        {MingaEditor,
+         name: :"#{__MODULE__}.editor.#{id}",
+         backend: :headless,
+         port_manager: port,
+         buffer: buffer,
+         width: 80,
+         height: 24,
+         editing_model: :vim,
+         options_server: options_server,
+         events_registry: events_registry,
+         suppress_tool_prompts: true},
+        id: {:editor, suffix, id}
+      )
+
+    send(editor, {:minga_input, {:ready, 80, 24}})
+    :sys.get_state(editor)
+    drain_frontend_commands(port)
+
+    %{
+      editor: editor,
+      port: port,
+      options_server: options_server,
+      events_registry: events_registry
+    }
+  end
+
+  defp drain_frontend_commands(port) do
+    receive do
+      {:frontend_commands, ^port, _commands} -> drain_frontend_commands(port)
+    after
+      0 -> :ok
+    end
+  end
 
   describe "startup_view_state/1" do
     test "returns :agent scope when startup_view is :agent in TUI mode" do
@@ -148,6 +213,199 @@ defmodule MingaEditor.StartupTest do
       assert Options.get(server_a, :line_spacing) == 1.2
       assert Options.get(server_b, :line_numbers) == :hybrid
       assert Options.get(server_b, :line_spacing) == 1.0
+    end
+  end
+
+  describe "send_font_config/1" do
+    setup do
+      server = start_supervised!({Options, name: nil})
+      %{server: server}
+    end
+
+    test "does not send GUI-only renderer options to TUI frontends", %{server: server} do
+      state = %EditorState{
+        port_manager: self(),
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+        options_server: server,
+        capabilities: %Capabilities{frontend_type: :tui}
+      }
+
+      Startup.send_font_config(state)
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      refute Enum.any?(commands, &match?(<<0x92, _::binary>>, &1))
+      refute Enum.any?(commands, &match?(<<0x95, _::binary>>, &1))
+      refute_receive {:"$gen_cast", {:send_commands, _}}
+    end
+
+    test "sends cursor animation preference to GUI frontends", %{server: server} do
+      state = %EditorState{
+        port_manager: self(),
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+        options_server: server,
+        capabilities: %Capabilities{frontend_type: :native_gui}
+      }
+
+      Startup.send_font_config(state)
+
+      assert_receive {:"$gen_cast", {:send_commands, font_commands}}
+      assert_receive {:"$gen_cast", {:send_commands, [<<0x92, _::binary>>]}}
+      assert_receive {:"$gen_cast", {:send_commands, [<<0x95, 1::16, 1::8>>]}}
+      refute Enum.any?(font_commands, &match?(<<0x92, _::binary>>, &1))
+      refute Enum.any?(font_commands, &match?(<<0x95, _::binary>>, &1))
+    end
+
+    test "sends disabled cursor animation preference from the supplied options server", %{
+      server: server
+    } do
+      {:ok, false} = Options.set(server, :cursor_animate, false)
+
+      state = %EditorState{
+        port_manager: self(),
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+        options_server: server,
+        capabilities: %Capabilities{frontend_type: :native_gui}
+      }
+
+      Startup.send_font_config(state)
+
+      assert_receive {:"$gen_cast", {:send_commands, _font_commands}}
+      assert_receive {:"$gen_cast", {:send_commands, [<<0x92, _::binary>>]}}
+      assert_receive {:"$gen_cast", {:send_commands, [<<0x95, 1::16, 0::8>>]}}
+    end
+  end
+
+  describe "send_cursor_animation_config/2" do
+    test "sends runtime cursor animation changes to GUI frontends" do
+      state = %EditorState{
+        port_manager: self(),
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+        capabilities: %Capabilities{frontend_type: :native_gui}
+      }
+
+      Startup.send_cursor_animation_config(state, false)
+
+      assert_receive {:"$gen_cast", {:send_commands, [<<0x95, 1::16, 0::8>>]}}
+    end
+
+    test "does not send runtime cursor animation changes to TUI frontends" do
+      state = %EditorState{
+        port_manager: self(),
+        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+        capabilities: %Capabilities{frontend_type: :tui}
+      }
+
+      Startup.send_cursor_animation_config(state, false)
+
+      refute_receive {:"$gen_cast", {:send_commands, _}}
+    end
+  end
+
+  describe "runtime option change events" do
+    test "global cursor animation option changes are published on the server registry" do
+      events_registry = start_events_registry(:option_changed_publish)
+      server = start_supervised!({Options, name: nil, events_registry: events_registry})
+      Minga.Events.subscribe(:option_changed, events_registry)
+
+      assert {:ok, false} = Options.set(server, :cursor_animate, false)
+
+      assert_receive {:minga_event, :option_changed,
+                      %Minga.Events.OptionChangedEvent{
+                        source: ^server,
+                        name: :cursor_animate,
+                        value: false
+                      }}
+    end
+
+    test "editor forwards runtime cursor animation changes from its options server to GUI frontends" do
+      %{editor: editor, port: port, options_server: options_server} =
+        start_recording_editor(:native_gui, :runtime_gui)
+
+      RecordingFrontend.reset(port)
+      :sys.get_state(editor)
+
+      assert {:ok, false} = Options.set(options_server, :cursor_animate, false)
+
+      assert_receive {:frontend_commands, ^port, [<<0x95, 1::16, 0::8>>]}
+    end
+
+    test "editor matches runtime cursor animation changes from a named options server passed by pid" do
+      id = System.unique_integer([:positive])
+      events_registry = start_events_registry(:runtime_named_options)
+      options_name = :"#{__MODULE__}.named_options.#{id}"
+
+      options_server =
+        start_supervised!({Options, name: options_name, events_registry: events_registry},
+          id: {:named_options, id}
+        )
+
+      {:ok, buffer} = BufferProcess.start_link(content: "", events_registry: events_registry)
+
+      port =
+        start_supervised!(
+          {RecordingFrontend,
+           owner: self(),
+           width: 80,
+           height: 24,
+           capabilities: %Capabilities{frontend_type: :native_gui}},
+          id: {:named_recording_frontend, id}
+        )
+
+      editor =
+        start_supervised!(
+          {MingaEditor,
+           name: :"#{__MODULE__}.named_editor.#{id}",
+           backend: :headless,
+           port_manager: port,
+           buffer: buffer,
+           width: 80,
+           height: 24,
+           editing_model: :vim,
+           options_server: options_server,
+           events_registry: events_registry,
+           suppress_tool_prompts: true},
+          id: {:named_editor, id}
+        )
+
+      send(editor, {:minga_input, {:ready, 80, 24}})
+      :sys.get_state(editor)
+      drain_frontend_commands(port)
+
+      RecordingFrontend.reset(port)
+      :sys.get_state(editor)
+
+      assert {:ok, false} = Options.set(options_server, :cursor_animate, false)
+
+      assert_receive {:frontend_commands, ^port, [<<0x95, 1::16, 0::8>>]}
+    end
+
+    test "editor ignores runtime cursor animation changes from other options servers" do
+      %{editor: editor, port: port, events_registry: events_registry} =
+        start_recording_editor(:native_gui, :runtime_wrong_source)
+
+      other_options =
+        start_supervised!({Options, name: nil, events_registry: events_registry},
+          id: :runtime_wrong_source_options
+        )
+
+      RecordingFrontend.reset(port)
+      :sys.get_state(editor)
+
+      assert {:ok, false} = Options.set(other_options, :cursor_animate, false)
+
+      refute_receive {:frontend_commands, ^port, [<<0x95, 1::16, 0::8>>]}
+    end
+
+    test "TUI editor does not send GUI-only cursor animation opcode for runtime changes" do
+      %{editor: editor, port: port, options_server: options_server} =
+        start_recording_editor(:tui, :runtime_tui)
+
+      RecordingFrontend.reset(port)
+      :sys.get_state(editor)
+
+      assert {:ok, false} = Options.set(options_server, :cursor_animate, false)
+
+      refute_receive {:frontend_commands, ^port, [<<0x95, _::binary>>]}
     end
   end
 

--- a/test/support/recording_frontend.ex
+++ b/test/support/recording_frontend.ex
@@ -1,0 +1,116 @@
+defmodule Minga.Test.RecordingFrontend do
+  @moduledoc """
+  Minimal frontend adapter used by integration tests that need to observe raw command batches.
+  """
+
+  use GenServer
+
+  @behaviour MingaEditor.Frontend.Adapter
+
+  alias MingaEditor.Frontend.Capabilities
+
+  @type start_opt ::
+          {:owner, pid()}
+          | {:width, pos_integer()}
+          | {:height, pos_integer()}
+          | {:capabilities, Capabilities.t()}
+
+  @type state :: %{
+          owner: pid(),
+          width: pos_integer(),
+          height: pos_integer(),
+          capabilities: Capabilities.t(),
+          commands: [binary()]
+        }
+
+  @impl MingaEditor.Frontend.Adapter
+  @spec start_link([start_opt()]) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl MingaEditor.Frontend.Adapter
+  @spec send_commands(GenServer.server(), [binary()]) :: :ok
+  def send_commands(server, commands) when is_list(commands) do
+    GenServer.cast(server, {:send_commands, commands})
+  end
+
+  @impl MingaEditor.Frontend.Adapter
+  @spec subscribe(GenServer.server()) :: :ok
+  def subscribe(server) do
+    GenServer.call(server, {:subscribe, self()})
+  end
+
+  @impl MingaEditor.Frontend.Adapter
+  @spec terminal_size(GenServer.server()) :: {pos_integer(), pos_integer()}
+  def terminal_size(server) do
+    GenServer.call(server, :terminal_size)
+  end
+
+  @impl MingaEditor.Frontend.Adapter
+  @spec ready?(GenServer.server()) :: boolean()
+  def ready?(server) do
+    GenServer.call(server, :ready?)
+  end
+
+  @impl MingaEditor.Frontend.Adapter
+  @spec capabilities(GenServer.server()) :: Capabilities.t()
+  def capabilities(server) do
+    GenServer.call(server, :capabilities)
+  end
+
+  @doc "Returns all commands recorded so far in receive order."
+  @spec commands(GenServer.server()) :: [binary()]
+  def commands(server) do
+    GenServer.call(server, :commands)
+  end
+
+  @doc "Clears recorded commands."
+  @spec reset(GenServer.server()) :: :ok
+  def reset(server) do
+    GenServer.call(server, :reset)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    {:ok,
+     %{
+       owner: Keyword.get(opts, :owner, self()),
+       width: Keyword.get(opts, :width, 80),
+       height: Keyword.get(opts, :height, 24),
+       capabilities: Keyword.get(opts, :capabilities, Capabilities.default()),
+       commands: []
+     }}
+  end
+
+  @impl GenServer
+  def handle_call({:subscribe, _pid}, _from, state) do
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:terminal_size, _from, state) do
+    {:reply, {state.width, state.height}, state}
+  end
+
+  def handle_call(:ready?, _from, state) do
+    {:reply, true, state}
+  end
+
+  def handle_call(:capabilities, _from, state) do
+    {:reply, state.capabilities, state}
+  end
+
+  def handle_call(:commands, _from, state) do
+    {:reply, Enum.reverse(state.commands), state}
+  end
+
+  def handle_call(:reset, _from, state) do
+    {:reply, :ok, %{state | commands: []}}
+  end
+
+  @impl GenServer
+  def handle_cast({:send_commands, commands}, state) do
+    send(state.owner, {:frontend_commands, self(), commands})
+    {:noreply, %{state | commands: Enum.reverse(commands) ++ state.commands}}
+  end
+end


### PR DESCRIPTION
# TL;DR
Adds smooth macOS GUI cursor movement with an 80ms ease-out animation, while preserving instant jumps for long-distance moves and respecting both `cursor_animate` config and Reduce Motion.

Closes #709

## Context
Issue #709 asks for Zed-style smooth cursor movement in the native macOS frontend. The animation belongs in Swift renderer state so the BEAM still sends only the final cursor position, avoiding per-frame protocol traffic.

## Changes
- Added renderer-side cursor interpolation in `CoreTextMetalRenderer`, including ease-out timing, animation self-drive, and a large-jump teleport threshold.
- Added `cursor_animate` config with docs, startup wiring, runtime option-change propagation, and reset/reload re-enable behavior.
- Added scoped `:option_changed` events so only editors using the changed options server receive runtime cursor animation updates.
- Added a GUI-only cursor animation protocol opcode so the Swift frontend receives config changes without sending unsupported commands to TUI frontends.
- Scoped smooth-scroll fractional offset to the scrolled window so split panes do not all shift during a trackpad gesture.
- Kept cursorline fractional offset disabled until the GUI cursorline protocol has an owning window id, avoiding wrong-pane cursorline drift.
- Wired Reduce Motion changes through `EditorNSView` so cursor animation disables when macOS accessibility settings request less motion.
- Added Swift and Elixir tests for cursor animation behavior, smooth-scroll target scoping, protocol decoding, config registration, GUI protocol encoding, startup/runtime opcode gating, event scoping, and reset broadcasts.

## Verification
- `git diff --check`
- `make lint`
- `mix test.llm test/minga/config/options_test.exs test/minga_editor/startup_test.exs` (114 tests, 0 failures)
- `mix test.llm test/minga_editor/startup_test.exs test/minga/config/options_test.exs test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs` (145 tests, 0 failures, before latest focused reset/scroll updates)
- `mix swift.build`
- `cd macos && xcodebuild test -project Minga.xcodeproj -scheme Minga -destination 'platform=macOS' -only-testing:MingaTests/CoreTextMetalRendererCursorTests` (17 Swift Testing tests passed)

## Acceptance Criteria Addressed
- Cursor position animates with ease-out interpolation, defaulting to about 80ms ✅
- Animation is applied in the renderer after cursor resolution, so all movement sources share it ✅
- Large jumps over the 50-line threshold teleport instead of animating ✅
- Smooth scrolling and cursor animation compose by applying fractional scroll offset only to the scrolled window’s content and cursor positions ✅
- Users can disable cursor animation with `set :cursor_animate, false`, including at runtime ✅
- Animation is Swift renderer-side with no BEAM frame loop, and Reduce Motion disables it ✅
