### PR TITLE
File tree: add remaining neo-tree keybindings

### DIFF
--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -305,6 +305,10 @@ defmodule Minga.Buffer do
   @spec save_as(t(), String.t()) :: :ok | {:error, term()}
   defdelegate save_as(server, file_path), to: BufferProcess
 
+  @doc "Retargets the buffer to a new file path without writing content."
+  @spec retarget_path(t(), String.t()) :: :ok | {:error, term()}
+  defdelegate retarget_path(server, file_path), to: BufferProcess
+
   # ── Identity and metadata ──────────────────────────────────────────
 
   @doc "File path of the buffer, or nil for scratch buffers."

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -258,6 +258,12 @@ defmodule Minga.Buffer.Process do
     GenServer.call(server, {:save_as, file_path}, @file_io_call_timeout)
   end
 
+  @doc "Retargets the buffer to a new file path without writing content."
+  @spec retarget_path(GenServer.server(), String.t()) :: :ok | {:error, term()}
+  def retarget_path(server, file_path) do
+    GenServer.call(server, {:retarget_path, file_path}, @file_io_call_timeout)
+  end
+
   @doc "Replaces the entire buffer content, pushing the old content onto the undo stack."
   @spec replace_content(GenServer.server(), String.t(), BufState.edit_source()) ::
           :ok | {:error, :read_only}
@@ -1119,10 +1125,28 @@ defmodule Minga.Buffer.Process do
         unregister_path(state.file_path)
         register_path(file_path)
 
-        {:reply, :ok, mark_saved(%{state | file_path: file_path}, {new_mtime, new_size}, content)}
+        new_state = BufState.retarget_path(state, file_path)
+        {:reply, :ok, mark_saved(new_state, {new_mtime, new_size}, content)}
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call({:retarget_path, _file_path}, _from, %{file_path: nil} = state) do
+    {:reply, {:error, :no_file_path}, state}
+  end
+
+  def handle_call({:retarget_path, file_path}, _from, state) do
+    new_path = Path.expand(file_path)
+    old_path = state.file_path && Path.expand(state.file_path)
+
+    if old_path == new_path do
+      {:reply, :ok, state}
+    else
+      unregister_path(state.file_path)
+      register_path(new_path)
+      {:reply, :ok, BufState.retarget_path(state, new_path)}
     end
   end
 

--- a/lib/minga/buffer/state.ex
+++ b/lib/minga/buffer/state.ex
@@ -104,6 +104,12 @@ defmodule Minga.Buffer.State do
     restore_version(state, version(state))
   end
 
+  @doc "Retargets the buffer to a new file path without changing content or dirty state."
+  @spec retarget_path(t(), String.t()) :: t()
+  def retarget_path(%__MODULE__{} = state, file_path) when is_binary(file_path) do
+    %{state | file_path: file_path}
+  end
+
   @doc "Returns save state for content loaded from storage."
   @spec loaded_save_state(String.t() | nil, SaveState.metadata(), String.t()) :: SaveState.t()
   def loaded_save_state(path, metadata, content) do

--- a/lib/minga/keymap/scope/file_tree.ex
+++ b/lib/minga/keymap/scope/file_tree.ex
@@ -58,17 +58,23 @@ defmodule Minga.Keymap.Scope.FileTree do
          {"Tab", "Toggle directory expand"},
          {"l / h", "Expand / collapse directory"},
          {"H", "Toggle hidden files"},
-         {"r", "Refresh tree"}
+         {"r", "Refresh tree"},
+         {"- / . / ~", "Parent root / selected root / project root"}
        ]},
       {"File Operations",
        [
          {"a", "New file"},
          {"A", "New folder"},
          {"R", "Rename"},
-         {"d", "Delete"}
+         {"d", "Delete"},
+         {"y", "Copy path"},
+         {"c / m", "Mark copy / move"},
+         {"p", "Paste marked entry"}
        ]},
       {"View",
        [
+         {"/", "Filter tree"},
+         {"?", "Toggle help"},
          {"q / Esc", "Close file tree"}
        ]}
     ]
@@ -85,12 +91,21 @@ defmodule Minga.Keymap.Scope.FileTree do
     |> Bindings.bind([{?h, 0}], :tree_collapse, "Collapse directory")
     |> Bindings.bind([{?H, 0}], :tree_toggle_hidden, "Toggle hidden files")
     |> Bindings.bind([{?r, 0}], :tree_refresh, "Refresh file tree")
+    |> Bindings.bind([{?-, 0}], :tree_root_parent, "Root tree at parent")
+    |> Bindings.bind([{?., 0}], :tree_root_selected, "Root tree at selected directory")
+    |> Bindings.bind([{?~, 0}], :tree_root_original, "Root tree at project")
+    |> Bindings.bind([{?/, 0}], :tree_filter, "Filter file tree")
+    |> Bindings.bind([{??, 0}], :tree_toggle_help, "Toggle help overlay")
     |> Bindings.bind([{?q, 0}], :tree_close, "Close file tree")
     |> Bindings.bind([{@escape, 0}], :tree_close, "Close file tree")
     |> Bindings.bind([{?a, 0}], :tree_new_file, "New file")
     |> Bindings.bind([{?A, 0}], :tree_new_folder, "New folder")
     |> Bindings.bind([{?R, 0}], :tree_rename, "Rename")
     |> Bindings.bind([{?d, 0}], :tree_delete, "Delete")
+    |> Bindings.bind([{?y, 0}], :tree_copy_path, "Copy path")
+    |> Bindings.bind([{?c, 0}], :tree_mark_copy, "Mark for copy")
+    |> Bindings.bind([{?m, 0}], :tree_mark_move, "Mark for move")
+    |> Bindings.bind([{?p, 0}], :tree_paste, "Paste marked entry")
   end
 
   # ── CUA mode bindings ─────────────────────────────────────────────────────

--- a/lib/minga/project/file_tree.ex
+++ b/lib/minga/project/file_tree.ex
@@ -37,7 +37,8 @@ defmodule Minga.Project.FileTree do
           show_hidden: boolean(),
           width: pos_integer(),
           git_status: GitStatus.status_map(),
-          entries: [entry()] | nil
+          entries: [entry()] | nil,
+          filter: String.t() | nil
         }
 
   @enforce_keys [:root]
@@ -47,7 +48,8 @@ defmodule Minga.Project.FileTree do
             show_hidden: false,
             width: 30,
             git_status: %{},
-            entries: nil
+            entries: nil,
+            filter: nil
 
   @default_ignore ~w(.git _build deps node_modules .elixir_ls)
 
@@ -234,7 +236,7 @@ defmodule Minga.Project.FileTree do
   def ensure_entries(%__MODULE__{entries: entries} = tree) when is_list(entries), do: tree
 
   def ensure_entries(%__MODULE__{} = tree) do
-    %{tree | entries: walk(tree.root, 0, tree, [])}
+    %{tree | entries: tree.root |> walk(0, tree, []) |> filter_entries(tree)}
   end
 
   @doc "Refreshes the tree by rescanning the filesystem (clamps cursor)."
@@ -243,6 +245,32 @@ defmodule Minga.Project.FileTree do
     tree = invalidate_entries(tree) |> ensure_entries()
     max_idx = max(length(tree.entries) - 1, 0)
     %{tree | cursor: min(tree.cursor, max_idx)}
+  end
+
+  @doc "Re-roots the tree while preserving display options."
+  @spec reroot(t(), String.t()) :: t()
+  def reroot(%__MODULE__{} = tree, root) when is_binary(root) do
+    %__MODULE__{
+      root: Path.expand(root),
+      expanded: MapSet.new([Path.expand(root)]),
+      cursor: 0,
+      show_hidden: tree.show_hidden,
+      width: tree.width,
+      git_status: %{},
+      filter: tree.filter
+    }
+  end
+
+  @doc "Sets the active substring filter and resets selection to the first match."
+  @spec set_filter(t(), String.t()) :: t()
+  def set_filter(%__MODULE__{} = tree, filter) when is_binary(filter) do
+    invalidate_entries(%{tree | filter: filter, cursor: 0})
+  end
+
+  @doc "Clears the active substring filter and resets selection to the first visible entry."
+  @spec clear_filter(t()) :: t()
+  def clear_filter(%__MODULE__{} = tree) do
+    invalidate_entries(%{tree | filter: nil, cursor: 0})
   end
 
   @doc "Refreshes git status for the tree root. Returns the updated tree."
@@ -323,7 +351,7 @@ defmodule Minga.Project.FileTree do
       guides: parent_guides
     }
 
-    if is_dir and MapSet.member?(tree.expanded, full) do
+    if is_dir and descend_into_directory?(tree, full) do
       # Children need to know: at this entry's depth, are there more siblings?
       # If this entry is NOT the last child, its depth column should draw │.
       child_guides = parent_guides ++ [not is_last]
@@ -332,6 +360,32 @@ defmodule Minga.Project.FileTree do
       [entry]
     end
   end
+
+  @spec descend_into_directory?(t(), String.t()) :: boolean()
+  defp descend_into_directory?(%__MODULE__{} = tree, path) do
+    MapSet.member?(tree.expanded, path) or active_filter?(tree)
+  end
+
+  @spec filter_entries([entry()], t()) :: [entry()]
+  defp filter_entries(entries, %__MODULE__{filter: nil}), do: entries
+  defp filter_entries(entries, %__MODULE__{filter: ""}), do: entries
+
+  defp filter_entries(entries, %__MODULE__{filter: filter, root: root}) do
+    needle = String.downcase(filter)
+    Enum.filter(entries, &filter_match?(&1, needle, root))
+  end
+
+  @spec filter_match?(entry(), String.t(), String.t()) :: boolean()
+  defp filter_match?(entry, needle, root) do
+    relative_path = Path.relative_to(entry.path, root)
+
+    entry.name |> String.downcase() |> String.contains?(needle) or
+      relative_path |> String.downcase() |> String.contains?(needle)
+  end
+
+  @spec active_filter?(t()) :: boolean()
+  defp active_filter?(%__MODULE__{filter: filter}) when is_binary(filter), do: filter != ""
+  defp active_filter?(%__MODULE__{}), do: false
 
   @spec ignored?(String.t()) :: boolean()
   defp ignored?(name), do: name in @default_ignore

--- a/lib/minga/project/file_tree.ex
+++ b/lib/minga/project/file_tree.ex
@@ -351,7 +351,7 @@ defmodule Minga.Project.FileTree do
       guides: parent_guides
     }
 
-    if is_dir and descend_into_directory?(tree, full) do
+    if is_dir and descend_into_directory?(tree, full) and not symlinked_directory?(full) do
       # Children need to know: at this entry's depth, are there more siblings?
       # If this entry is NOT the last child, its depth column should draw │.
       child_guides = parent_guides ++ [not is_last]
@@ -381,6 +381,14 @@ defmodule Minga.Project.FileTree do
 
     entry.name |> String.downcase() |> String.contains?(needle) or
       relative_path |> String.downcase() |> String.contains?(needle)
+  end
+
+  @spec symlinked_directory?(String.t()) :: boolean()
+  defp symlinked_directory?(path) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :symlink}} -> true
+      _ -> false
+    end
   end
 
   @spec active_filter?(t()) :: boolean()

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.Commands.FileTree do
 
   alias Minga.Buffer
   alias MingaEditor.Commands
+  alias MingaEditor.Commands.Helpers
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -138,6 +139,103 @@ defmodule MingaEditor.Commands.FileTree do
   def refresh(%{workspace: %{file_tree: %{tree: tree}}} = state) do
     tree = tree |> FileTree.refresh() |> FileTree.refresh_git_status()
     sync_and_update(state, tree)
+  end
+
+  @doc "Copies the selected entry's absolute path to the system clipboard."
+  @spec copy_path(state()) :: state()
+  def copy_path(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+
+  def copy_path(%{workspace: %{file_tree: %{tree: tree}}} = state) do
+    case FileTree.selected_entry(tree) do
+      nil ->
+        state
+
+      %{path: path} ->
+        state
+        |> Helpers.force_clipboard_sync(Path.expand(path))
+        |> EditorState.set_status("Copied #{Path.expand(path)}")
+    end
+  end
+
+  @doc "Marks the selected entry for a later copy operation."
+  @spec mark_copy(state()) :: state()
+  def mark_copy(state), do: mark_for_paste(state, :copy)
+
+  @doc "Marks the selected entry for a later move operation."
+  @spec mark_move(state()) :: state()
+  def mark_move(state), do: mark_for_paste(state, :move)
+
+  @doc "Pastes the marked copy or move entry into the selected directory or file parent."
+  @spec paste(state()) :: state()
+  def paste(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+
+  def paste(%{workspace: %{file_tree: %{clipboard_mark: nil}}} = state),
+    do: EditorState.set_status(state, "No file tree copy or move is pending")
+
+  def paste(%{workspace: %{file_tree: %{clipboard_mark: mark, tree: tree}}} = state) do
+    target_dir = selected_target_dir(tree)
+    destination = Path.join(target_dir, mark.name)
+    paste_marked_entry(state, mark, destination)
+  end
+
+  @doc "Changes the tree root to the parent directory of the current root."
+  @spec root_parent(state()) :: state()
+  def root_parent(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+
+  def root_parent(%{workspace: %{file_tree: %{tree: %FileTree{root: root}}}} = state) do
+    parent = Path.dirname(root)
+
+    if parent == root do
+      state
+    else
+      reroot(state, parent)
+    end
+  end
+
+  @doc "Changes the tree root to the selected directory."
+  @spec root_selected(state()) :: state()
+  def root_selected(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+
+  def root_selected(%{workspace: %{file_tree: %{tree: tree}}} = state) do
+    case FileTree.selected_entry(tree) do
+      %{dir?: true, path: path} -> reroot(state, path)
+      %{dir?: false} -> state
+      nil -> state
+    end
+  end
+
+  @doc "Restores the tree root to the original project directory."
+  @spec root_original(state()) :: state()
+  def root_original(%{workspace: %{file_tree: %{tree: nil}}} = state), do: state
+
+  def root_original(%{workspace: %{file_tree: %{original_root: root}}} = state)
+      when is_binary(root) do
+    reroot(state, root)
+  end
+
+  def root_original(%{workspace: %{file_tree: %{project_root: root}}} = state)
+      when is_binary(root) do
+    reroot(state, root)
+  end
+
+  def root_original(state), do: state
+
+  @doc "Starts inline file tree filtering."
+  @spec filter(state()) :: state()
+  def filter(state) do
+    update_file_tree(state, &FileTreeState.start_filtering/1)
+  end
+
+  @doc "Toggles the file tree help overlay."
+  @spec toggle_help(state()) :: state()
+  def toggle_help(state) do
+    update_file_tree(state, &FileTreeState.toggle_help/1)
+  end
+
+  @doc "Hides the file tree help overlay."
+  @spec hide_help(state()) :: state()
+  def hide_help(state) do
+    update_file_tree(state, &FileTreeState.hide_help/1)
   end
 
   @doc """
@@ -462,6 +560,192 @@ defmodule MingaEditor.Commands.FileTree do
   end
 
   # ── Private helpers ───────────────────────────────────────────────────────
+
+  @spec mark_for_paste(state(), FileTreeState.clipboard_operation()) :: state()
+  defp mark_for_paste(%{workspace: %{file_tree: %{tree: nil}}} = state, _operation), do: state
+
+  defp mark_for_paste(%{workspace: %{file_tree: %{tree: tree}}} = state, operation) do
+    case FileTree.selected_entry(tree) do
+      nil -> state
+      entry -> store_clipboard_mark(state, entry, operation)
+    end
+  end
+
+  @spec store_clipboard_mark(state(), FileTree.entry(), FileTreeState.clipboard_operation()) ::
+          state()
+  defp store_clipboard_mark(state, entry, operation) do
+    label = if operation == :copy, do: "copy", else: "move"
+
+    state =
+      update_file_tree(
+        state,
+        &FileTreeState.mark_clipboard(
+          &1,
+          Path.expand(entry.path),
+          entry.name,
+          entry.dir?,
+          operation
+        )
+      )
+
+    EditorState.set_status(state, "Marked #{entry.name} for #{label}")
+  end
+
+  @spec selected_target_dir(FileTree.t()) :: String.t()
+  defp selected_target_dir(%FileTree{} = tree) do
+    case FileTree.selected_entry(tree) do
+      %{dir?: true, path: path} -> path
+      %{dir?: false, path: path} -> Path.dirname(path)
+      nil -> tree.root
+    end
+  end
+
+  @spec paste_marked_entry(state(), FileTreeState.clipboard_mark(), String.t()) :: state()
+  defp paste_marked_entry(state, %{operation: :copy} = mark, destination) do
+    execute_copy(state, mark, destination)
+  end
+
+  defp paste_marked_entry(state, %{operation: :move} = mark, destination) do
+    if same_path?(mark.path, destination) do
+      state
+    else
+      execute_marked_move(state, mark, destination)
+    end
+  end
+
+  @spec execute_marked_move(state(), FileTreeState.clipboard_mark(), String.t()) :: state()
+  defp execute_marked_move(state, mark, destination) do
+    case guarded_rename(mark.path, destination) do
+      :ok -> marked_move_succeeded(state, mark, destination)
+      {:error, reason} -> marked_move_failed(state, mark.path, destination, reason)
+    end
+  end
+
+  @spec marked_move_succeeded(state(), FileTreeState.clipboard_mark(), String.t()) :: state()
+  defp marked_move_succeeded(state, mark, destination) do
+    state = sync_moved_buffer_path(state, mark.path, destination, "Move")
+    MingaEditor.log_to_messages("[file-tree] Moved: #{mark.name} → #{Path.dirname(destination)}")
+
+    state
+    |> refresh()
+    |> update_file_tree(&FileTreeState.clear_clipboard/1)
+  end
+
+  @spec marked_move_failed(state(), String.t(), String.t(), term()) :: state()
+  defp marked_move_failed(state, source, destination, reason) do
+    MingaEditor.log_to_messages(
+      "[file-tree] Move failed: #{source} → #{destination}: #{inspect(reason)}"
+    )
+
+    state
+  end
+
+  @spec execute_copy(state(), FileTreeState.clipboard_mark(), String.t()) :: state()
+  defp execute_copy(state, mark, destination) do
+    execute_copy_with_destination_check(
+      state,
+      mark,
+      destination,
+      copy_destination_status(mark, destination)
+    )
+  end
+
+  @spec copy_destination_status(FileTreeState.clipboard_mark(), String.t()) ::
+          :ok | {:error, term()}
+  defp copy_destination_status(%{dir?: true, path: source}, destination) do
+    expanded_source = Path.expand(source)
+    expanded_destination = Path.expand(destination)
+
+    if path_under_root?(expanded_destination, expanded_source) do
+      {:error, {:destination_inside_source, destination}}
+    else
+      copy_destination_exists_status(destination)
+    end
+  end
+
+  defp copy_destination_status(_mark, destination),
+    do: copy_destination_exists_status(destination)
+
+  @spec copy_destination_exists_status(String.t()) :: :ok | {:error, term()}
+  defp copy_destination_exists_status(destination) do
+    if path_entry_exists?(destination),
+      do: {:error, {:destination_exists, destination}},
+      else: :ok
+  end
+
+  @spec execute_copy_with_destination_check(
+          state(),
+          FileTreeState.clipboard_mark(),
+          String.t(),
+          :ok | {:error, term()}
+        ) :: state()
+  defp execute_copy_with_destination_check(state, mark, destination, :ok) do
+    do_copy_marked_entry(state, mark, destination)
+  end
+
+  defp execute_copy_with_destination_check(state, _mark, _destination, {:error, reason}) do
+    MingaEditor.log_to_messages("[file-tree] Copy failed: #{inspect(reason)}")
+    state
+  end
+
+  @spec do_copy_marked_entry(state(), FileTreeState.clipboard_mark(), String.t()) :: state()
+  defp do_copy_marked_entry(state, mark, destination) do
+    result =
+      if mark.dir?, do: File.cp_r(mark.path, destination), else: File.cp(mark.path, destination)
+
+    case result do
+      :ok ->
+        copy_succeeded(state, mark, destination)
+
+      {:ok, _files} ->
+        copy_succeeded(state, mark, destination)
+
+      {:error, reason, file} ->
+        copy_failed_with_cleanup(state, mark.path, destination, reason, file)
+
+      {:error, reason} ->
+        copy_failed(state, mark.path, destination, reason)
+    end
+  end
+
+  @spec copy_succeeded(state(), FileTreeState.clipboard_mark(), String.t()) :: state()
+  defp copy_succeeded(state, mark, destination) do
+    MingaEditor.log_to_messages("[file-tree] Copied: #{mark.name} → #{Path.dirname(destination)}")
+    refresh(state)
+  end
+
+  @spec copy_failed_with_cleanup(state(), String.t(), String.t(), term(), String.t()) :: state()
+  defp copy_failed_with_cleanup(state, source, destination, reason, file) do
+    cleanup_result = cleanup_partial_copy(destination)
+
+    MingaEditor.log_to_messages(
+      "[file-tree] Copy failed: #{source} → #{destination} at #{file}: #{inspect(reason)}. #{cleanup_result}"
+    )
+
+    state
+  end
+
+  @spec copy_failed(state(), String.t(), String.t(), term()) :: state()
+  defp copy_failed(state, source, destination, reason) do
+    MingaEditor.log_to_messages(
+      "[file-tree] Copy failed: #{source} → #{destination}: #{inspect(reason)}"
+    )
+
+    state
+  end
+
+  @spec reroot(state(), String.t()) :: state()
+  defp reroot(%{workspace: %{file_tree: %{tree: %FileTree{} = tree}}} = state, root) do
+    FileTreeFreshness.unwatch_expanded_dirs(tree)
+
+    new_tree =
+      tree
+      |> FileTree.reroot(root)
+      |> FileTree.refresh_git_status()
+
+    FileTreeFreshness.watch_expanded_dirs(new_tree)
+    sync_and_update(state, new_tree)
+  end
 
   # Mutual exclusivity: close git status panel when opening file tree.
   # Explicitly resets keymap_scope to :editor so we don't leave orphaned
@@ -1072,6 +1356,60 @@ defmodule MingaEditor.Commands.FileTree do
         description: "Refresh file tree",
         requires_buffer: false,
         execute: &refresh/1
+      },
+      %Minga.Command{
+        name: :tree_copy_path,
+        description: "Copy file tree path",
+        requires_buffer: false,
+        execute: &copy_path/1
+      },
+      %Minga.Command{
+        name: :tree_mark_copy,
+        description: "Mark file tree entry for copy",
+        requires_buffer: false,
+        execute: &mark_copy/1
+      },
+      %Minga.Command{
+        name: :tree_mark_move,
+        description: "Mark file tree entry for move",
+        requires_buffer: false,
+        execute: &mark_move/1
+      },
+      %Minga.Command{
+        name: :tree_paste,
+        description: "Paste marked file tree entry",
+        requires_buffer: false,
+        execute: &paste/1
+      },
+      %Minga.Command{
+        name: :tree_root_parent,
+        description: "Root file tree at parent directory",
+        requires_buffer: false,
+        execute: &root_parent/1
+      },
+      %Minga.Command{
+        name: :tree_root_selected,
+        description: "Root file tree at selected directory",
+        requires_buffer: false,
+        execute: &root_selected/1
+      },
+      %Minga.Command{
+        name: :tree_root_original,
+        description: "Restore file tree project root",
+        requires_buffer: false,
+        execute: &root_original/1
+      },
+      %Minga.Command{
+        name: :tree_filter,
+        description: "Filter file tree",
+        requires_buffer: false,
+        execute: &filter/1
+      },
+      %Minga.Command{
+        name: :tree_toggle_help,
+        description: "Toggle file tree help",
+        requires_buffer: false,
+        execute: &toggle_help/1
       },
       %Minga.Command{
         name: :tree_close,

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -615,9 +615,15 @@ defmodule MingaEditor.Commands.FileTree do
 
   @spec execute_marked_move(state(), FileTreeState.clipboard_mark(), String.t()) :: state()
   defp execute_marked_move(state, mark, destination) do
-    case guarded_rename(mark.path, destination) do
-      :ok -> marked_move_succeeded(state, mark, destination)
-      {:error, reason} -> marked_move_failed(state, mark.path, destination, reason)
+    case move_destination_status(mark, destination) do
+      :ok ->
+        case guarded_rename(mark.path, destination) do
+          :ok -> marked_move_succeeded(state, mark, destination)
+          {:error, reason} -> marked_move_failed(state, mark.path, destination, reason)
+        end
+
+      {:error, reason} ->
+        marked_move_failed(state, mark.path, destination, reason)
     end
   end
 
@@ -672,6 +678,22 @@ defmodule MingaEditor.Commands.FileTree do
       do: {:error, {:destination_exists, destination}},
       else: :ok
   end
+
+  @spec move_destination_status(FileTreeState.clipboard_mark(), String.t()) ::
+          :ok | {:error, term()}
+  defp move_destination_status(%{dir?: true, path: source}, destination) do
+    expanded_source = Path.expand(source)
+    expanded_destination = Path.expand(destination)
+
+    if path_under_root?(expanded_destination, expanded_source) do
+      {:error, {:destination_inside_source, destination}}
+    else
+      copy_destination_exists_status(destination)
+    end
+  end
+
+  defp move_destination_status(_mark, destination),
+    do: copy_destination_exists_status(destination)
 
   @spec execute_copy_with_destination_check(
           state(),
@@ -1226,7 +1248,7 @@ defmodule MingaEditor.Commands.FileTree do
         errors
 
       path ->
-        save_moved_buffer_path(pid, path, moved_buffer_path(path, old_path, new_path), errors)
+        retarget_moved_buffer_path(pid, path, moved_buffer_path(path, old_path, new_path), errors)
     end
   end
 
@@ -1237,12 +1259,12 @@ defmodule MingaEditor.Commands.FileTree do
     :exit, _ -> nil
   end
 
-  @spec save_moved_buffer_path(pid(), String.t(), String.t() | nil, [{String.t(), term()}]) ::
+  @spec retarget_moved_buffer_path(pid(), String.t(), String.t() | nil, [{String.t(), term()}]) ::
           [{String.t(), term()}]
-  defp save_moved_buffer_path(_pid, _path, nil, errors), do: errors
+  defp retarget_moved_buffer_path(_pid, _path, nil, errors), do: errors
 
-  defp save_moved_buffer_path(pid, path, moved_path, errors) do
-    case Buffer.save_as(pid, moved_path) do
+  defp retarget_moved_buffer_path(pid, path, moved_path, errors) do
+    case Buffer.retarget_path(pid, moved_path) do
       :ok -> errors
       {:error, reason} -> [{path, reason} | errors]
     end

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -22,10 +22,20 @@ defmodule MingaEditor.Input.FileTreeHandler do
   alias MingaEditor.Input
   alias Minga.Keymap
   alias Minga.Project.FileTree
+  alias Minga.Project.FileTree.BufferSync
   alias MingaEditor.Workspace.State, as: WorkspaceState
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
+
+  # Help overlay active: capture keys so Escape closes help instead of closing the tree.
+  def handle_key(
+        %{workspace: %{keymap_scope: :file_tree, file_tree: %{help_visible: true}}} = state,
+        cp,
+        mods
+      ) do
+    {:handled, handle_help_key(state, cp, mods)}
+  end
 
   # Inline editing active: capture all keys before they reach the mode FSM or scope trie
   def handle_key(
@@ -34,6 +44,15 @@ defmodule MingaEditor.Input.FileTreeHandler do
         mods
       ) do
     {:handled, handle_inline_edit_key(state, cp, mods)}
+  end
+
+  # Filter input active: capture text before it reaches vim search.
+  def handle_key(
+        %{workspace: %{keymap_scope: :file_tree, file_tree: %{filtering: true}}} = state,
+        cp,
+        mods
+      ) do
+    {:handled, handle_filter_key(state, cp, mods)}
   end
 
   # File tree scope with tree focused
@@ -306,6 +325,47 @@ defmodule MingaEditor.Input.FileTreeHandler do
   # All other keys (with modifiers, control chars): swallow them
   defp handle_inline_edit_key(state, _cp, _mods), do: state
 
+  # ── Help and filter key handlers ────────────────────────────────────────
+
+  @spec handle_help_key(EditorState.t(), non_neg_integer(), non_neg_integer()) :: EditorState.t()
+  defp handle_help_key(state, @escape, 0), do: Commands.FileTree.hide_help(state)
+  defp handle_help_key(state, ??, 0), do: Commands.FileTree.toggle_help(state)
+  defp handle_help_key(state, _cp, _mods), do: state
+
+  @spec handle_filter_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          EditorState.t()
+  defp handle_filter_key(state, @enter, 0) do
+    set_file_tree(state, FileTreeState.accept_filter(state.workspace.file_tree))
+  end
+
+  defp handle_filter_key(state, @escape, 0) do
+    set_file_tree(state, FileTreeState.clear_filter(state.workspace.file_tree))
+  end
+
+  defp handle_filter_key(state, @backspace, 0) do
+    text = current_filter_text(state)
+
+    if text == "" do
+      set_file_tree(state, FileTreeState.clear_filter(state.workspace.file_tree))
+    else
+      new_text = String.slice(text, 0, max(String.length(text) - 1, 0))
+      set_file_tree(state, FileTreeState.update_filter(state.workspace.file_tree, new_text))
+    end
+  end
+
+  defp handle_filter_key(state, cp, 0) when cp >= 32 do
+    new_text = current_filter_text(state) <> <<cp::utf8>>
+    set_file_tree(state, FileTreeState.update_filter(state.workspace.file_tree, new_text))
+  end
+
+  defp handle_filter_key(state, _cp, _mods), do: state
+
+  @spec current_filter_text(EditorState.t()) :: String.t()
+  defp current_filter_text(%{workspace: %{file_tree: %{tree: %FileTree{filter: filter}}}})
+       when is_binary(filter), do: filter
+
+  defp current_filter_text(_state), do: ""
+
   # ── Shared helpers ──────────────────────────────────────────────────────
 
   @spec set_active_buffer_override(EditorState.t(), pid() | nil) :: EditorState.t()
@@ -317,8 +377,19 @@ defmodule MingaEditor.Input.FileTreeHandler do
 
   @spec set_file_tree(EditorState.t(), FileTreeState.t()) :: EditorState.t()
   defp set_file_tree(state, file_tree) do
+    sync_buffer(file_tree)
     EditorState.update_workspace(state, &WorkspaceState.set_file_tree(&1, file_tree))
   end
+
+  @spec sync_buffer(FileTreeState.t()) :: :ok
+  defp sync_buffer(%FileTreeState{buffer: buffer, tree: %FileTree{} = tree})
+       when is_pid(buffer) do
+    BufferSync.sync(buffer, tree)
+  catch
+    :exit, _reason -> :ok
+  end
+
+  defp sync_buffer(%FileTreeState{}), do: :ok
 
   @spec update_file_tree(EditorState.t(), (FileTreeState.t() -> FileTreeState.t())) ::
           EditorState.t()

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -288,6 +288,11 @@ defmodule MingaEditor.Input.FileTreeHandler do
   @enter 13
   @escape 27
   @backspace 127
+  defguardp special_text_key?(cp)
+            when cp in 57_348..57_376 or cp in 0xF700..0xF728
+
+  defguardp printable_text_key?(cp, mods)
+            when mods == 0 and cp >= 32 and not special_text_key?(cp)
 
   @spec handle_inline_edit_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           EditorState.t()
@@ -314,7 +319,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
   end
 
   # Printable characters: append to editing text
-  defp handle_inline_edit_key(state, cp, 0) when cp >= 32 do
+  defp handle_inline_edit_key(state, cp, mods) when printable_text_key?(cp, mods) do
     char = <<cp::utf8>>
     editing = state.workspace.file_tree.editing
     new_text = editing.text <> char
@@ -329,6 +334,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
 
   @spec handle_help_key(EditorState.t(), non_neg_integer(), non_neg_integer()) :: EditorState.t()
   defp handle_help_key(state, @escape, 0), do: Commands.FileTree.hide_help(state)
+  defp handle_help_key(state, ?/, 0), do: Commands.FileTree.filter(state)
   defp handle_help_key(state, ??, 0), do: Commands.FileTree.toggle_help(state)
   defp handle_help_key(state, _cp, _mods), do: state
 
@@ -342,6 +348,8 @@ defmodule MingaEditor.Input.FileTreeHandler do
     set_file_tree(state, FileTreeState.clear_filter(state.workspace.file_tree))
   end
 
+  defp handle_filter_key(state, ??, 0), do: Commands.FileTree.toggle_help(state)
+
   defp handle_filter_key(state, @backspace, 0) do
     text = current_filter_text(state)
 
@@ -353,7 +361,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
     end
   end
 
-  defp handle_filter_key(state, cp, 0) when cp >= 32 do
+  defp handle_filter_key(state, cp, mods) when printable_text_key?(cp, mods) do
     new_text = current_filter_text(state) <> <<cp::utf8>>
     set_file_tree(state, FileTreeState.update_filter(state.workspace.file_tree, new_text))
   end

--- a/lib/minga_editor/shell/traditional/tree_renderer.ex
+++ b/lib/minga_editor/shell/traditional/tree_renderer.ex
@@ -54,7 +54,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
       git_status: %{},
       dirty_paths: MapSet.new(),
       rows: nil,
-      status: :ready
+      status: :ready,
+      filter_text: nil,
+      filtering?: false,
+      help_visible?: false
     ]
 
     @type t :: %__MODULE__{
@@ -67,7 +70,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
             git_status: Minga.Project.FileTree.GitStatus.status_map(),
             dirty_paths: MapSet.t(String.t()),
             rows: [Row.t()] | nil,
-            status: FileTreeState.tree_status()
+            status: FileTreeState.tree_status(),
+            filter_text: String.t() | nil,
+            filtering?: boolean(),
+            help_visible?: boolean()
           }
   end
 
@@ -115,7 +121,10 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
       active_path: active_buffer_path(state),
       dirty_paths: dirty_paths(state),
       editing: Map.get(file_tree, :editing),
+      filter_text: Map.get(tree, :filter),
+      filtering?: Map.get(file_tree, :filtering, false),
       git_status: tree.git_status,
+      help_visible?: Map.get(file_tree, :help_visible, false),
       status: status_from_file_tree(file_tree)
     }
 
@@ -127,12 +136,12 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
        when width <= 0 or height <= 0,
        do: []
 
+  defp do_render(%RenderInput{help_visible?: true} = input), do: render_help_panel(input)
+
   defp do_render(
          %RenderInput{tree: tree, rect: {row_off, col_off, width, height}, theme: theme} = input
        ) do
-    # Header: project directory name with folder icon
-    project_name = Path.basename(tree.root)
-    header_text = " #{@folder_open} #{project_name}/"
+    header_text = header_text(input, tree)
     header_display = Unicode.pad_display_trailing(header_text, width)
 
     header = [
@@ -166,6 +175,178 @@ defmodule MingaEditor.Shell.Traditional.TreeRenderer do
     sep_commands = render_separator(sep_col, row_off, height, theme)
 
     header ++ entry_commands ++ blank_commands ++ sep_commands
+  end
+
+  @spec render_help_panel(RenderInput.t()) :: [DisplayList.draw()]
+  defp render_help_panel(%RenderInput{rect: {row_off, col_off, width, height}, theme: theme}) do
+    blank = String.duplicate(" ", width)
+    bg_face = Face.new(fg: theme.tree.fg, bg: theme.tree.bg)
+
+    background =
+      for row <- 0..(height - 1) do
+        DisplayList.draw(row_off + row, col_off, blank, bg_face)
+      end
+
+    title_face = Face.new(fg: theme.tree.header_fg, bg: theme.tree.header_bg, bold: true)
+    label_face = Face.new(fg: theme.tree.dir_fg, bg: theme.tree.bg, bold: true)
+    key_face = Face.new(fg: theme.tree.fg, bg: theme.tree.bg, bold: true)
+    desc_face = Face.new(fg: theme.tree.separator_fg, bg: theme.tree.bg)
+
+    header = [
+      DisplayList.draw(
+        row_off,
+        col_off,
+        Unicode.pad_display_trailing(" Keyboard Shortcuts", width),
+        title_face
+      )
+    ]
+
+    help_draws =
+      render_help_groups(
+        Minga.Keymap.Scope.FileTree.help_groups(:default),
+        row_off + 2,
+        col_off,
+        width,
+        max(height - 2, 0),
+        label_face,
+        key_face,
+        desc_face
+      )
+
+    separator = render_separator(col_off + width, row_off, height, theme)
+    background ++ header ++ help_draws ++ separator
+  end
+
+  @spec render_help_groups(
+          [{String.t(), [{String.t(), String.t()}]}],
+          non_neg_integer(),
+          non_neg_integer(),
+          pos_integer(),
+          non_neg_integer(),
+          Face.t(),
+          Face.t(),
+          Face.t()
+        ) :: [DisplayList.draw()]
+  defp render_help_groups(groups, row, col, width, rows_left, label_face, key_face, desc_face) do
+    {draws, _row, _remaining} =
+      Enum.reduce(groups, {[], row, rows_left}, fn group, acc ->
+        render_help_group_block(group, acc, col, width, label_face, key_face, desc_face)
+      end)
+
+    Enum.reverse(draws)
+  end
+
+  @spec render_help_group_block(
+          {String.t(), [{String.t(), String.t()}]},
+          {[DisplayList.draw()], non_neg_integer(), non_neg_integer()},
+          non_neg_integer(),
+          pos_integer(),
+          Face.t(),
+          Face.t(),
+          Face.t()
+        ) :: {[DisplayList.draw()], non_neg_integer(), non_neg_integer()}
+  defp render_help_group_block(
+         _group,
+         {draws, row, remaining},
+         _col,
+         _width,
+         _label_face,
+         _key_face,
+         _desc_face
+       )
+       when remaining <= 0,
+       do: {draws, row, 0}
+
+  defp render_help_group_block(
+         {title, bindings},
+         {draws, row, remaining},
+         col,
+         width,
+         label_face,
+         key_face,
+         desc_face
+       ) do
+    title_draw =
+      DisplayList.draw(
+        row,
+        col + 2,
+        Unicode.truncate_display_width(title, max(width - 4, 0)),
+        label_face
+      )
+
+    {binding_draws, row, remaining} =
+      render_help_bindings(bindings, row + 1, remaining - 1, col, width, key_face, desc_face)
+
+    {[title_draw | binding_draws] ++ draws, row + 1, remaining - 1}
+  end
+
+  @spec render_help_bindings(
+          [{String.t(), String.t()}],
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pos_integer(),
+          Face.t(),
+          Face.t()
+        ) :: {[DisplayList.draw()], non_neg_integer(), non_neg_integer()}
+  defp render_help_bindings(bindings, row, remaining, col, width, key_face, desc_face) do
+    Enum.reduce(bindings, {[], row, remaining}, fn binding, acc ->
+      render_help_binding_row(binding, acc, col, width, key_face, desc_face)
+    end)
+  end
+
+  @spec render_help_binding_row(
+          {String.t(), String.t()},
+          {[DisplayList.draw()], non_neg_integer(), non_neg_integer()},
+          non_neg_integer(),
+          pos_integer(),
+          Face.t(),
+          Face.t()
+        ) :: {[DisplayList.draw()], non_neg_integer(), non_neg_integer()}
+  defp render_help_binding_row(
+         _binding,
+         {draws, row, remaining},
+         _col,
+         _width,
+         _key_face,
+         _desc_face
+       )
+       when remaining <= 0,
+       do: {draws, row, 0}
+
+  defp render_help_binding_row(
+         {key, desc},
+         {draws, row, remaining},
+         col,
+         width,
+         key_face,
+         desc_face
+       ) do
+    key_width = min(div(width, 3), 12)
+    key_text = key |> String.pad_trailing(key_width) |> Unicode.truncate_display_width(key_width)
+    desc_text = Unicode.truncate_display_width(desc, max(width - key_width - 6, 0))
+
+    row_draws = [
+      DisplayList.draw(row, col + 4, key_text, key_face),
+      DisplayList.draw(row, col + 4 + key_width, desc_text, desc_face)
+    ]
+
+    {row_draws ++ draws, row + 1, remaining - 1}
+  end
+
+  @spec header_text(RenderInput.t(), FileTree.t()) :: String.t()
+  defp header_text(%RenderInput{filtering?: true, filter_text: filter}, _tree) do
+    " / " <> (filter || "") <> "▏"
+  end
+
+  defp header_text(%RenderInput{filter_text: filter}, _tree)
+       when is_binary(filter) and filter != "" do
+    " / " <> filter
+  end
+
+  defp header_text(%RenderInput{}, tree) do
+    project_name = Path.basename(tree.root)
+    " #{@folder_open} #{project_name}/"
   end
 
   @spec status_from_file_tree(FileTreeState.t() | map()) :: FileTreeState.tree_status()

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.State.FileTree do
   """
 
   alias Minga.Project.FileTree
+  alias MingaEditor.State.FileTree.ClipboardMark
 
   @typedoc """
   Inline editing state for creating files/folders or renaming entries.
@@ -26,6 +27,9 @@ defmodule MingaEditor.State.FileTree do
           original_name: String.t() | nil
         }
 
+  @type clipboard_operation :: ClipboardMark.operation()
+  @type clipboard_mark :: ClipboardMark.t()
+
   @typedoc "Explicit presentation state for the file tree sidebar."
   @type tree_status :: :hidden | :loading | :empty | :ready | {:error, String.t()}
 
@@ -36,9 +40,13 @@ defmodule MingaEditor.State.FileTree do
           buffer: pid() | nil,
           editing: editing() | nil,
           project_root: String.t() | nil,
+          original_root: String.t() | nil,
           tree_status: tree_status(),
           tree_width: pos_integer(),
-          refresh_timer: reference() | nil
+          refresh_timer: reference() | nil,
+          clipboard_mark: clipboard_mark() | nil,
+          filtering: boolean(),
+          help_visible: boolean()
         }
 
   defstruct tree: nil,
@@ -46,9 +54,13 @@ defmodule MingaEditor.State.FileTree do
             buffer: nil,
             editing: nil,
             project_root: nil,
+            original_root: nil,
             tree_status: :hidden,
             tree_width: 30,
-            refresh_timer: nil
+            refresh_timer: nil,
+            clipboard_mark: nil,
+            filtering: false,
+            help_visible: false
 
   @doc "Returns true when the file tree is open."
   @spec open?(t()) :: boolean()
@@ -108,6 +120,7 @@ defmodule MingaEditor.State.FileTree do
         focused: true,
         buffer: buffer,
         project_root: tree.root,
+        original_root: ft.original_root || tree.root,
         tree_status: classify_tree(tree),
         tree_width: tree.width
     }
@@ -117,21 +130,36 @@ defmodule MingaEditor.State.FileTree do
   @spec replace_tree(t(), FileTree.t()) :: t()
   def replace_tree(%__MODULE__{} = ft, %FileTree{} = tree) do
     tree = ensure_tree_entries(tree)
-    %{ft | tree: tree, tree_status: classify_tree(tree), tree_width: tree.width}
+
+    %{
+      ft
+      | tree: tree,
+        project_root: tree.root,
+        tree_status: classify_tree(tree),
+        tree_width: tree.width
+    }
   end
 
   @doc "Marks the sidebar as loading."
   @spec loading(t()) :: t()
   def loading(%__MODULE__{} = ft) do
-    %{ft | focused: false, editing: nil, tree_status: :loading}
+    %{
+      ft
+      | focused: false,
+        editing: nil,
+        filtering: false,
+        help_visible: false,
+        tree_status: :loading
+    }
   end
 
   @doc "Updates the project root associated with the file tree."
   @spec set_project_root(t(), String.t() | nil) :: t()
-  def set_project_root(%__MODULE__{} = ft, nil), do: %{ft | project_root: nil}
+  def set_project_root(%__MODULE__{} = ft, nil), do: %{ft | project_root: nil, original_root: nil}
 
   def set_project_root(%__MODULE__{} = ft, root) when is_binary(root) do
-    %{ft | project_root: Path.expand(root)}
+    expanded = Path.expand(root)
+    %{ft | project_root: expanded, original_root: expanded}
   end
 
   @doc "Returns true when a filesystem refresh timer is pending."
@@ -158,7 +186,17 @@ defmodule MingaEditor.State.FileTree do
   @doc "Closes the tree and clears the buffer."
   @spec close(t()) :: t()
   def close(%__MODULE__{} = ft) do
-    %{ft | tree: nil, focused: false, buffer: nil, editing: nil, tree_status: :hidden}
+    %{
+      ft
+      | tree: nil,
+        focused: false,
+        buffer: nil,
+        editing: nil,
+        tree_status: :hidden,
+        clipboard_mark: nil,
+        filtering: false,
+        help_visible: false
+    }
   end
 
   @doc """
@@ -172,7 +210,12 @@ defmodule MingaEditor.State.FileTree do
       when type in [:new_file, :new_folder, :rename] and is_integer(index) and index >= 0 do
     original = if type == :rename, do: initial_text, else: nil
 
-    %{ft | editing: %{index: index, text: initial_text, type: type, original_name: original}}
+    %{
+      ft
+      | editing: %{index: index, text: initial_text, type: type, original_name: original},
+        filtering: false,
+        help_visible: false
+    }
   end
 
   @doc "Updates the text being typed in the inline editor."
@@ -183,6 +226,65 @@ defmodule MingaEditor.State.FileTree do
   end
 
   def update_editing_text(%__MODULE__{editing: nil} = ft, _new_text), do: ft
+
+  @doc "Stores a pending file tree clipboard operation."
+  @spec mark_clipboard(t(), String.t(), String.t(), boolean(), clipboard_operation()) :: t()
+  def mark_clipboard(%__MODULE__{} = ft, path, name, dir?, operation)
+      when is_binary(path) and is_binary(name) and is_boolean(dir?) and
+             operation in [:copy, :move] do
+    %{ft | clipboard_mark: ClipboardMark.new(path, name, dir?, operation)}
+  end
+
+  @doc "Clears a pending file tree clipboard operation."
+  @spec clear_clipboard(t()) :: t()
+  def clear_clipboard(%__MODULE__{} = ft), do: %{ft | clipboard_mark: nil}
+
+  @doc "Starts inline file tree filtering."
+  @spec start_filtering(t()) :: t()
+  def start_filtering(%__MODULE__{tree: %FileTree{} = tree} = ft) do
+    filter = tree.filter || ""
+
+    %{
+      ft
+      | tree: FileTree.set_filter(tree, filter),
+        filtering: true,
+        editing: nil,
+        help_visible: false
+    }
+  end
+
+  def start_filtering(%__MODULE__{} = ft), do: ft
+
+  @doc "Updates the active file tree filter."
+  @spec update_filter(t(), String.t()) :: t()
+  def update_filter(%__MODULE__{tree: %FileTree{} = tree} = ft, filter) when is_binary(filter) do
+    tree = FileTree.set_filter(tree, filter)
+    %{ft | tree: tree, tree_status: classify_tree(tree)}
+  end
+
+  def update_filter(%__MODULE__{} = ft, _filter), do: ft
+
+  @doc "Accepts the current filter and leaves the narrowed tree visible."
+  @spec accept_filter(t()) :: t()
+  def accept_filter(%__MODULE__{} = ft), do: %{ft | filtering: false}
+
+  @doc "Clears the active filter and exits filtering mode."
+  @spec clear_filter(t()) :: t()
+  def clear_filter(%__MODULE__{tree: %FileTree{} = tree} = ft) do
+    tree = FileTree.clear_filter(tree)
+    %{ft | tree: tree, filtering: false, tree_status: classify_tree(tree)}
+  end
+
+  def clear_filter(%__MODULE__{} = ft), do: %{ft | filtering: false}
+
+  @doc "Toggles the file tree help overlay."
+  @spec toggle_help(t()) :: t()
+  def toggle_help(%__MODULE__{} = ft),
+    do: %{ft | help_visible: not ft.help_visible, filtering: false}
+
+  @doc "Hides the file tree help overlay."
+  @spec hide_help(t()) :: t()
+  def hide_help(%__MODULE__{} = ft), do: %{ft | help_visible: false}
 
   @doc "Cancels inline editing, clearing the editing state back to nil."
   @spec cancel_editing(t()) :: t()

--- a/lib/minga_editor/state/file_tree/clipboard_mark.ex
+++ b/lib/minga_editor/state/file_tree/clipboard_mark.ex
@@ -1,0 +1,27 @@
+defmodule MingaEditor.State.FileTree.ClipboardMark do
+  @moduledoc """
+  Pending file tree copy or move operation.
+
+  The mark stores the selected source entry until the user chooses a paste destination.
+  """
+
+  @type operation :: :copy | :move
+
+  @type t :: %__MODULE__{
+          path: String.t(),
+          name: String.t(),
+          dir?: boolean(),
+          operation: operation()
+        }
+
+  @enforce_keys [:path, :name, :dir?, :operation]
+  defstruct [:path, :name, :dir?, :operation]
+
+  @doc "Builds a clipboard mark for a file tree entry."
+  @spec new(String.t(), String.t(), boolean(), operation()) :: t()
+  def new(path, name, dir?, operation)
+      when is_binary(path) and is_binary(name) and is_boolean(dir?) and
+             operation in [:copy, :move] do
+    %__MODULE__{path: path, name: name, dir?: dir?, operation: operation}
+  end
+end

--- a/test/minga/buffer/process_test.exs
+++ b/test/minga/buffer/process_test.exs
@@ -1,6 +1,7 @@
 defmodule Minga.Buffer.ProcessTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer
   alias Minga.Buffer.Document
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Config.Options
@@ -295,6 +296,65 @@ defmodule Minga.Buffer.ProcessTest do
       assert BufferProcess.file_path(pid) == path
       refute BufferProcess.dirty?(pid)
       assert File.read!(path) == "Xcontent"
+    end
+  end
+
+  describe "retarget_path/2" do
+    test "retargets a clean buffer without writing content", %{tmp_dir: tmp_dir} do
+      source = Path.join(tmp_dir, "source.txt")
+      target = Path.join(tmp_dir, "target.txt")
+      File.write!(source, "alpha")
+
+      {:ok, pid} = BufferProcess.start_link(file_path: source)
+
+      assert :ok = BufferProcess.retarget_path(pid, target)
+      assert BufferProcess.file_path(pid) == target
+      refute BufferProcess.dirty?(pid)
+      assert File.exists?(source)
+      refute File.exists?(target)
+      assert :not_found = BufferProcess.pid_for_path(source)
+      assert {:ok, ^pid} = BufferProcess.pid_for_path(target)
+    end
+
+    test "retargets a dirty buffer and preserves dirty state until explicit save", %{
+      tmp_dir: tmp_dir
+    } do
+      source = Path.join(tmp_dir, "source.txt")
+      target = Path.join(tmp_dir, "target.txt")
+      File.write!(source, "alpha")
+
+      {:ok, pid} = BufferProcess.start_link(file_path: source)
+      BufferProcess.replace_content(pid, "dirty", :user)
+      assert BufferProcess.dirty?(pid)
+
+      assert :ok = BufferProcess.retarget_path(pid, target)
+      assert BufferProcess.file_path(pid) == target
+      assert BufferProcess.dirty?(pid)
+      assert File.read!(source) == "alpha"
+      refute File.exists?(target)
+
+      assert :ok = BufferProcess.save(pid)
+      assert File.read!(target) == "dirty"
+      assert File.exists?(source)
+    end
+
+    test "retarget_path/2 updates registry for nowrite buffers and still blocks save", %{
+      tmp_dir: tmp_dir
+    } do
+      source = Path.join(tmp_dir, "source.txt")
+      target = Path.join(tmp_dir, "target.txt")
+      File.write!(source, "display only")
+
+      {:ok, pid} = BufferProcess.start_link(file_path: source, buffer_type: :nowrite)
+      assert BufferProcess.buffer_type(pid) == :nowrite
+      assert {:ok, ^pid} = Buffer.pid_for_path(source)
+
+      assert :ok = Buffer.retarget_path(pid, target)
+      assert BufferProcess.file_path(pid) == target
+      assert BufferProcess.buffer_type(pid) == :nowrite
+      assert :not_found = Buffer.pid_for_path(source)
+      assert {:ok, ^pid} = Buffer.pid_for_path(target)
+      assert Buffer.save(pid) == {:error, :buffer_not_saveable}
     end
   end
 

--- a/test/minga/keymap/scope/file_tree_scope_test.exs
+++ b/test/minga/keymap/scope/file_tree_scope_test.exs
@@ -29,6 +29,13 @@ defmodule Minga.Keymap.Scope.FileTreeScopeTest do
     test "d resolves to tree_delete" do
       assert {:command, :tree_delete} = Scope.resolve_key(:file_tree, :normal, {?d, 0})
     end
+
+    test "copy and paste operations resolve" do
+      assert {:command, :tree_copy_path} = Scope.resolve_key(:file_tree, :normal, {?y, 0})
+      assert {:command, :tree_mark_copy} = Scope.resolve_key(:file_tree, :normal, {?c, 0})
+      assert {:command, :tree_mark_move} = Scope.resolve_key(:file_tree, :normal, {?m, 0})
+      assert {:command, :tree_paste} = Scope.resolve_key(:file_tree, :normal, {?p, 0})
+    end
   end
 
   describe "CUA mode: file operation bindings not present" do
@@ -83,6 +90,14 @@ defmodule Minga.Keymap.Scope.FileTreeScopeTest do
     test "r refreshes tree" do
       assert {:command, :tree_refresh} = Scope.resolve_key(:file_tree, :normal, {?r, 0})
     end
+
+    test "re-root, filter, and help bindings resolve" do
+      assert {:command, :tree_root_parent} = Scope.resolve_key(:file_tree, :normal, {?-, 0})
+      assert {:command, :tree_root_selected} = Scope.resolve_key(:file_tree, :normal, {?., 0})
+      assert {:command, :tree_root_original} = Scope.resolve_key(:file_tree, :normal, {?~, 0})
+      assert {:command, :tree_filter} = Scope.resolve_key(:file_tree, :normal, {?/, 0})
+      assert {:command, :tree_toggle_help} = Scope.resolve_key(:file_tree, :normal, {??, 0})
+    end
   end
 
   describe "help_groups includes File Operations" do
@@ -96,6 +111,9 @@ defmodule Minga.Keymap.Scope.FileTreeScopeTest do
       assert Enum.any?(bindings, fn {key, _desc} -> key == "A" end)
       assert Enum.any?(bindings, fn {key, _desc} -> key == "R" end)
       assert Enum.any?(bindings, fn {key, _desc} -> key == "d" end)
+      assert Enum.any?(bindings, fn {key, _desc} -> key == "y" end)
+      assert Enum.any?(bindings, fn {key, _desc} -> key == "c / m" end)
+      assert Enum.any?(bindings, fn {key, _desc} -> key == "p" end)
     end
   end
 end

--- a/test/minga/project/file_tree_test.exs
+++ b/test/minga/project/file_tree_test.exs
@@ -628,6 +628,25 @@ defmodule Minga.Project.FileTreeTest do
     end
 
     @tag :tmp_dir
+    test "set_filter skips symlinked directories while descending", %{tmp_dir: tmp_dir} do
+      root = Path.join(tmp_dir, "root")
+      nested = Path.join(root, "nested")
+      link = Path.join(root, "link")
+      File.mkdir_p!(nested)
+      File.write!(Path.join(nested, "target.ex"), "")
+
+      case File.ln_s(nested, link) do
+        :ok -> :ok
+        {:error, reason} -> flunk("symlink creation failed: #{inspect(reason)}")
+      end
+
+      tree = FileTree.new(root) |> FileTree.set_filter("target")
+      entries = FileTree.visible_entries(tree)
+
+      assert Enum.map(entries, & &1.path) == [Path.join(nested, "target.ex")]
+    end
+
+    @tag :tmp_dir
     test "filter does not match every entry just because the root path matches", %{
       tmp_dir: tmp_dir
     } do

--- a/test/minga/project/file_tree_test.exs
+++ b/test/minga/project/file_tree_test.exs
@@ -611,4 +611,61 @@ defmodule Minga.Project.FileTreeTest do
       assert entry2.name == "b.txt"
     end
   end
+
+  describe "filtering and re-rooting" do
+    @tag :tmp_dir
+    test "set_filter narrows entries and descends into collapsed directories", %{tmp_dir: tmp_dir} do
+      File.mkdir_p!(Path.join(tmp_dir, "lib"))
+      File.write!(Path.join([tmp_dir, "lib", "target.ex"]), "")
+      File.write!(Path.join(tmp_dir, "other.txt"), "")
+
+      tree = FileTree.new(tmp_dir) |> FileTree.set_filter("target")
+      entries = FileTree.visible_entries(tree)
+
+      assert Enum.map(entries, & &1.name) == ["target.ex"]
+      assert hd(entries).depth == 1
+      assert FileTree.selected_entry(tree).name == "target.ex"
+    end
+
+    @tag :tmp_dir
+    test "filter does not match every entry just because the root path matches", %{
+      tmp_dir: tmp_dir
+    } do
+      matching_root = Path.join(tmp_dir, "rootneedle")
+      File.mkdir_p!(matching_root)
+      File.write!(Path.join(matching_root, "alpha.txt"), "")
+      File.write!(Path.join(matching_root, "beta.txt"), "")
+
+      tree = FileTree.new(matching_root) |> FileTree.set_filter("rootneedle")
+
+      assert FileTree.visible_entries(tree) == []
+    end
+
+    @tag :tmp_dir
+    test "clear_filter restores the unfiltered visible entries", %{tmp_dir: tmp_dir} do
+      File.write!(Path.join(tmp_dir, "alpha.txt"), "")
+      File.write!(Path.join(tmp_dir, "beta.txt"), "")
+
+      tree = tmp_dir |> FileTree.new() |> FileTree.set_filter("alpha") |> FileTree.clear_filter()
+
+      assert Enum.map(FileTree.visible_entries(tree), & &1.name) == ["alpha.txt", "beta.txt"]
+    end
+
+    @tag :tmp_dir
+    test "reroot preserves width, hidden setting, and filter", %{tmp_dir: tmp_dir} do
+      next_root = Path.join(tmp_dir, "child")
+      File.mkdir_p!(next_root)
+
+      tree =
+        FileTree.new(tmp_dir, width: 42) |> FileTree.toggle_hidden() |> FileTree.set_filter("ex")
+
+      rerooted = FileTree.reroot(tree, next_root)
+
+      assert rerooted.root == Path.expand(next_root)
+      assert rerooted.width == 42
+      assert rerooted.show_hidden == true
+      assert rerooted.filter == "ex"
+      assert MapSet.member?(rerooted.expanded, Path.expand(next_root))
+    end
+  end
 end

--- a/test/minga_editor/commands/file_tree_editing_test.exs
+++ b/test/minga_editor/commands/file_tree_editing_test.exs
@@ -7,6 +7,8 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
   """
   use Minga.Test.EditorCase, async: true
 
+  alias Minga.Buffer
+
   @moduletag :tmp_dir
 
   describe "new file (a)" do
@@ -123,6 +125,61 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
       state = send_keys_sync(ctx, "#{backspaces}existing.txt<Enter>")
 
       assert state.workspace.file_tree.editing == nil
+      assert File.read!(file) == "content"
+      assert File.read!(existing) == "existing"
+    end
+  end
+
+  describe "rename retargets open buffers" do
+    test "rename retargets a dirty open file buffer without writing its contents", %{tmp_dir: dir} do
+      file = Path.join(dir, "target.txt")
+      renamed = Path.join(dir, "renamed.txt")
+      File.write!(file, "content")
+
+      ctx = start_editor("content", file_path: file, project_root: dir)
+      buffer = active_buffer(ctx)
+
+      assert is_pid(buffer)
+      :ok = Buffer.insert_char(buffer, "!")
+      assert Buffer.dirty?(buffer)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      state = send_keys_sync(ctx, "R")
+      backspaces = String.duplicate("<BS>", String.length(state.workspace.file_tree.editing.text))
+      state = send_keys_sync(ctx, "#{backspaces}renamed.txt<Enter>")
+
+      assert state.workspace.file_tree.editing == nil
+      assert Buffer.file_path(buffer) == renamed
+      assert Buffer.dirty?(buffer)
+      assert File.read!(renamed) == "content"
+      refute File.exists?(file)
+
+      assert :ok = Buffer.save(buffer)
+      assert File.read!(renamed) == "!content"
+    end
+
+    test "rename leaves a dirty open buffer on the original path when destination exists", %{
+      tmp_dir: dir
+    } do
+      file = Path.join(dir, "target.txt")
+      existing = Path.join(dir, "existing.txt")
+      File.write!(file, "content")
+      File.write!(existing, "existing")
+
+      ctx = start_editor("content", file_path: file, project_root: dir)
+      buffer = active_buffer(ctx)
+
+      :ok = Buffer.insert_char(buffer, "!")
+      assert Buffer.dirty?(buffer)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      state = send_keys_sync(ctx, "R")
+      backspaces = String.duplicate("<BS>", String.length(state.workspace.file_tree.editing.text))
+      state = send_keys_sync(ctx, "#{backspaces}existing.txt<Enter>")
+
+      assert state.workspace.file_tree.editing == nil
+      assert Buffer.file_path(buffer) == file
+      assert Buffer.dirty?(buffer)
       assert File.read!(file) == "content"
       assert File.read!(existing) == "existing"
     end

--- a/test/minga_editor/commands/file_tree_neo_bindings_test.exs
+++ b/test/minga_editor/commands/file_tree_neo_bindings_test.exs
@@ -1,0 +1,232 @@
+defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
+  @moduledoc """
+  Regression tests for neo-tree-style file tree commands.
+  """
+  use ExUnit.Case, async: true
+
+  import Hammox
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.Commands.FileTree, as: FileTreeCommands
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
+  alias MingaEditor.Viewport
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  setup :verify_on_exit!
+
+  setup do
+    test_pid = self()
+
+    stub(Minga.Clipboard.Mock, :write, fn text ->
+      send(test_pid, {:clipboard_written, text})
+      :ok
+    end)
+
+    stub(Minga.Clipboard.Mock, :read, fn -> nil end)
+
+    :ok
+  end
+
+  describe "copy path" do
+    @tag :tmp_dir
+    test "copies selected entry absolute path to the system clipboard", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "alpha.txt")
+      File.write!(path, "alpha")
+
+      state = build_state(tmp_dir)
+
+      FileTreeCommands.copy_path(state)
+
+      assert_receive {:clipboard_written, ^path}, 200
+    end
+  end
+
+  describe "copy, move, and paste" do
+    @tag :tmp_dir
+    test "copies marked file into selected directory", %{tmp_dir: tmp_dir} do
+      source = Path.join(tmp_dir, "alpha.txt")
+      target_dir = Path.join(tmp_dir, "dest")
+      File.write!(source, "alpha")
+      File.mkdir_p!(target_dir)
+
+      state =
+        tmp_dir |> build_state() |> select_entry("alpha.txt") |> FileTreeCommands.mark_copy()
+
+      state = state |> select_entry("dest") |> FileTreeCommands.paste()
+
+      assert File.read!(Path.join(target_dir, "alpha.txt")) == "alpha"
+      assert state.workspace.file_tree.clipboard_mark.operation == :copy
+    end
+
+    @tag :tmp_dir
+    test "moves marked file into selected directory and clears move mark", %{tmp_dir: tmp_dir} do
+      source = Path.join(tmp_dir, "alpha.txt")
+      target_dir = Path.join(tmp_dir, "dest")
+      File.write!(source, "alpha")
+      File.mkdir_p!(target_dir)
+
+      state =
+        tmp_dir |> build_state() |> select_entry("alpha.txt") |> FileTreeCommands.mark_move()
+
+      state = state |> select_entry("dest") |> FileTreeCommands.paste()
+
+      refute File.exists?(source)
+      assert File.read!(Path.join(target_dir, "alpha.txt")) == "alpha"
+      assert state.workspace.file_tree.clipboard_mark == nil
+    end
+
+    @tag :tmp_dir
+    test "copy paste rejects directory destinations inside the source", %{tmp_dir: tmp_dir} do
+      source_dir = Path.join(tmp_dir, "src")
+      child_dir = Path.join(source_dir, "child")
+      File.mkdir_p!(child_dir)
+      File.write!(Path.join(source_dir, "file.txt"), "content")
+
+      state =
+        tmp_dir
+        |> build_state()
+        |> expand_path(source_dir)
+        |> select_entry("src")
+        |> FileTreeCommands.mark_copy()
+
+      state = state |> select_entry("child") |> FileTreeCommands.paste()
+
+      refute File.exists?(Path.join(child_dir, "src"))
+      assert state.workspace.file_tree.clipboard_mark.operation == :copy
+    end
+
+    @tag :tmp_dir
+    test "copy paste into selected file uses the file parent directory", %{tmp_dir: tmp_dir} do
+      source_dir = Path.join(tmp_dir, "src")
+      source = Path.join(source_dir, "alpha.txt")
+      File.mkdir_p!(source_dir)
+      File.write!(source, "alpha")
+      File.write!(Path.join(tmp_dir, "target.txt"), "target")
+
+      state =
+        tmp_dir
+        |> build_state()
+        |> expand_path(source_dir)
+        |> select_entry("alpha.txt")
+        |> FileTreeCommands.mark_copy()
+
+      state |> select_entry("target.txt") |> FileTreeCommands.paste()
+
+      assert File.read!(Path.join(tmp_dir, "alpha.txt")) == "alpha"
+    end
+
+    @tag :tmp_dir
+    test "copy paste does not overwrite an existing destination", %{tmp_dir: tmp_dir} do
+      File.write!(Path.join(tmp_dir, "alpha.txt"), "source")
+      target_dir = Path.join(tmp_dir, "dest")
+      File.mkdir_p!(target_dir)
+      File.write!(Path.join(target_dir, "alpha.txt"), "existing")
+
+      state =
+        tmp_dir |> build_state() |> select_entry("alpha.txt") |> FileTreeCommands.mark_copy()
+
+      state |> select_entry("dest") |> FileTreeCommands.paste()
+
+      assert File.read!(Path.join(target_dir, "alpha.txt")) == "existing"
+    end
+
+    @tag :tmp_dir
+    test "copy paste recursively copies directories", %{tmp_dir: tmp_dir} do
+      source_dir = Path.join(tmp_dir, "src")
+      File.mkdir_p!(Path.join(source_dir, "nested"))
+      File.write!(Path.join([source_dir, "nested", "file.txt"]), "content")
+      target_dir = Path.join(tmp_dir, "dest")
+      File.mkdir_p!(target_dir)
+
+      state = tmp_dir |> build_state() |> select_entry("src") |> FileTreeCommands.mark_copy()
+      state |> select_entry("dest") |> FileTreeCommands.paste()
+
+      assert File.read!(Path.join([target_dir, "src", "nested", "file.txt"])) == "content"
+    end
+  end
+
+  describe "re-rooting" do
+    @tag :tmp_dir
+    test "root_parent changes root to parent directory", %{tmp_dir: tmp_dir} do
+      child = Path.join(tmp_dir, "child")
+      File.mkdir_p!(child)
+      state = build_state(child)
+
+      state = FileTreeCommands.root_parent(state)
+
+      assert state.workspace.file_tree.tree.root == Path.expand(tmp_dir)
+      assert state.workspace.file_tree.original_root == Path.expand(child)
+    end
+
+    @tag :tmp_dir
+    test "root_selected changes root to selected directory and root_original resets it", %{
+      tmp_dir: tmp_dir
+    } do
+      child = Path.join(tmp_dir, "child")
+      File.mkdir_p!(child)
+      File.write!(Path.join(tmp_dir, "alpha.txt"), "alpha")
+
+      state =
+        tmp_dir |> build_state() |> select_entry("child") |> FileTreeCommands.root_selected()
+
+      assert state.workspace.file_tree.tree.root == Path.expand(child)
+
+      state = FileTreeCommands.root_original(state)
+      assert state.workspace.file_tree.tree.root == Path.expand(tmp_dir)
+    end
+  end
+
+  describe "filter and help state" do
+    @tag :tmp_dir
+    test "filter starts filtering and narrows visible entries", %{tmp_dir: tmp_dir} do
+      File.write!(Path.join(tmp_dir, "alpha.txt"), "alpha")
+      File.write!(Path.join(tmp_dir, "beta.txt"), "beta")
+
+      state = tmp_dir |> build_state() |> FileTreeCommands.filter()
+      file_tree = FileTreeState.update_filter(state.workspace.file_tree, "alpha")
+
+      assert file_tree.filtering == true
+      assert Enum.map(FileTree.visible_entries(file_tree.tree), & &1.name) == ["alpha.txt"]
+    end
+
+    @tag :tmp_dir
+    test "toggle_help flips help overlay visibility", %{tmp_dir: tmp_dir} do
+      state = build_state(tmp_dir)
+
+      state = FileTreeCommands.toggle_help(state)
+      assert state.workspace.file_tree.help_visible == true
+
+      state = FileTreeCommands.toggle_help(state)
+      assert state.workspace.file_tree.help_visible == false
+    end
+  end
+
+  defp build_state(root) do
+    tree = root |> FileTree.new() |> FileTree.refresh()
+
+    %EditorState{
+      port_manager: nil,
+      workspace: %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        file_tree: FileTreeState.open(%FileTreeState{}, tree, nil)
+      }
+    }
+  end
+
+  defp expand_path(state, path) do
+    tree = FileTree.expand_path(state.workspace.file_tree.tree, path)
+    file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
+    EditorState.update_workspace(state, &WorkspaceState.set_file_tree(&1, file_tree))
+  end
+
+  defp select_entry(state, name) do
+    entries = FileTree.visible_entries(state.workspace.file_tree.tree)
+    index = Enum.find_index(entries, &(&1.name == name))
+    refute index == nil
+
+    tree = FileTree.select(state.workspace.file_tree.tree, index)
+    file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
+    EditorState.update_workspace(state, &WorkspaceState.set_file_tree(&1, file_tree))
+  end
+end

--- a/test/minga_editor/commands/file_tree_neo_bindings_test.exs
+++ b/test/minga_editor/commands/file_tree_neo_bindings_test.exs
@@ -6,9 +6,11 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
   import Hammox
 
+  alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Project.FileTree
   alias MingaEditor.Commands.FileTree, as: FileTreeCommands
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.Viewport
   alias MingaEditor.Workspace.State, as: WorkspaceState
@@ -77,6 +79,126 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
     end
 
     @tag :tmp_dir
+    test "moves a dirty open file buffer without saving it during retarget", %{tmp_dir: tmp_dir} do
+      source = Path.join(tmp_dir, "alpha.txt")
+      target_dir = Path.join(tmp_dir, "dest")
+      target = Path.join(target_dir, "alpha.txt")
+      File.write!(source, "alpha")
+      File.mkdir_p!(target_dir)
+
+      buffer = start_supervised!({BufferProcess, file_path: source})
+      BufferProcess.replace_content(buffer, "dirty", :user)
+      assert BufferProcess.dirty?(buffer)
+
+      state =
+        tmp_dir
+        |> build_state(Buffers.add(%Buffers{}, buffer))
+        |> select_entry("alpha.txt")
+        |> FileTreeCommands.mark_move()
+
+      state = state |> select_entry("dest") |> FileTreeCommands.paste()
+
+      assert BufferProcess.file_path(buffer) == target
+      assert BufferProcess.dirty?(buffer)
+      assert :not_found = BufferProcess.pid_for_path(source)
+      assert {:ok, ^buffer} = BufferProcess.pid_for_path(target)
+      assert File.read!(target) == "alpha"
+      refute File.exists?(source)
+
+      assert :ok = BufferProcess.save(buffer)
+      assert File.read!(target) == "dirty"
+      assert state.workspace.file_tree.clipboard_mark == nil
+    end
+
+    @tag :tmp_dir
+    test "move failure on existing destination leaves source, target, and mark intact", %{
+      tmp_dir: tmp_dir
+    } do
+      source = Path.join(tmp_dir, "alpha.txt")
+      target_dir = Path.join(tmp_dir, "dest")
+      target = Path.join(target_dir, "alpha.txt")
+      File.write!(source, "source")
+      File.mkdir_p!(target_dir)
+      File.write!(target, "existing")
+
+      state =
+        tmp_dir |> build_state() |> select_entry("alpha.txt") |> FileTreeCommands.mark_move()
+
+      state = state |> select_entry("dest") |> FileTreeCommands.paste()
+
+      assert File.read!(source) == "source"
+      assert File.read!(target) == "existing"
+      assert state.workspace.file_tree.clipboard_mark.operation == :move
+    end
+
+    @tag :tmp_dir
+    test "move failure into a descendant keeps the directory and mark intact", %{tmp_dir: tmp_dir} do
+      source_dir = Path.join(tmp_dir, "src")
+      child_dir = Path.join(source_dir, "child")
+      File.mkdir_p!(child_dir)
+      File.write!(Path.join(source_dir, "file.txt"), "content")
+
+      state =
+        tmp_dir
+        |> build_state()
+        |> expand_path(source_dir)
+        |> select_entry("src")
+        |> FileTreeCommands.mark_move()
+
+      state = state |> select_entry("child") |> FileTreeCommands.paste()
+
+      refute File.exists?(Path.join(child_dir, "src"))
+      assert File.exists?(source_dir)
+      assert state.workspace.file_tree.clipboard_mark.operation == :move
+    end
+
+    @tag :tmp_dir
+    test "successful move retargets an open buffer path and saves to the new path", %{
+      tmp_dir: tmp_dir
+    } do
+      source = Path.join(tmp_dir, "alpha.txt")
+      target_dir = Path.join(tmp_dir, "dest")
+      target = Path.join(target_dir, "alpha.txt")
+      File.write!(source, "source")
+      File.mkdir_p!(target_dir)
+
+      buffer = start_supervised!({BufferProcess, file_path: source})
+
+      state =
+        tmp_dir
+        |> build_state(Buffers.add(%Buffers{}, buffer))
+        |> select_entry("alpha.txt")
+        |> FileTreeCommands.mark_move()
+
+      _state = state |> select_entry("dest") |> FileTreeCommands.paste()
+
+      assert BufferProcess.file_path(buffer) == target
+      assert File.read!(target) == "source"
+
+      BufferProcess.replace_content(buffer, "updated", :user)
+      assert :ok = BufferProcess.save(buffer)
+
+      assert File.read!(target) == "updated"
+      refute File.exists?(source)
+    end
+
+    @tag :tmp_dir
+    test "failed move keeps the clipboard mark for retry", %{tmp_dir: tmp_dir} do
+      source = Path.join(tmp_dir, "retry.txt")
+      target_dir = Path.join(tmp_dir, "dest")
+      File.write!(source, "retry")
+      File.mkdir_p!(target_dir)
+      File.write!(Path.join(target_dir, "retry.txt"), "existing")
+
+      state =
+        tmp_dir |> build_state() |> select_entry("retry.txt") |> FileTreeCommands.mark_move()
+
+      state = state |> select_entry("dest") |> FileTreeCommands.paste()
+
+      assert state.workspace.file_tree.clipboard_mark.operation == :move
+    end
+
+    @tag :tmp_dir
     test "copy paste rejects directory destinations inside the source", %{tmp_dir: tmp_dir} do
       source_dir = Path.join(tmp_dir, "src")
       child_dir = Path.join(source_dir, "child")
@@ -114,6 +236,42 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
       state |> select_entry("target.txt") |> FileTreeCommands.paste()
 
       assert File.read!(Path.join(tmp_dir, "alpha.txt")) == "alpha"
+    end
+
+    @tag :tmp_dir
+    test "moves a dirty open descendant buffer when renaming a directory", %{tmp_dir: tmp_dir} do
+      source_dir = Path.join(tmp_dir, "src")
+      source_file = Path.join([source_dir, "nested", "alpha.txt"])
+      target_dir = Path.join(tmp_dir, "dest")
+      target_file = Path.join([target_dir, "src", "nested", "alpha.txt"])
+      File.mkdir_p!(Path.dirname(source_file))
+      File.write!(source_file, "alpha")
+      File.mkdir_p!(target_dir)
+
+      buffer = start_supervised!({BufferProcess, file_path: source_file})
+      BufferProcess.replace_content(buffer, "dirty", :user)
+      assert BufferProcess.dirty?(buffer)
+
+      state =
+        tmp_dir
+        |> build_state(Buffers.add(%Buffers{}, buffer))
+        |> expand_path(source_dir)
+        |> select_entry("src")
+        |> FileTreeCommands.mark_move()
+
+      state = state |> select_entry("dest") |> FileTreeCommands.paste()
+
+      assert BufferProcess.file_path(buffer) == target_file
+      assert BufferProcess.dirty?(buffer)
+      assert File.read!(target_file) == "alpha"
+      refute File.exists?(source_file)
+      refute File.exists?(source_dir)
+      assert {:ok, ^buffer} = BufferProcess.pid_for_path(target_file)
+      assert :not_found = BufferProcess.pid_for_path(source_file)
+
+      assert :ok = BufferProcess.save(buffer)
+      assert File.read!(target_file) == "dirty"
+      assert state.workspace.file_tree.clipboard_mark == nil
     end
 
     @tag :tmp_dir
@@ -202,12 +360,13 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
     end
   end
 
-  defp build_state(root) do
+  defp build_state(root, buffers \\ %Buffers{}) do
     tree = root |> FileTree.new() |> FileTree.refresh()
 
     %EditorState{
       port_manager: nil,
       workspace: %WorkspaceState{
+        buffers: buffers,
         viewport: Viewport.new(24, 80),
         file_tree: FileTreeState.open(%FileTreeState{}, tree, nil)
       }

--- a/test/minga_editor/input/file_tree_editing_input_test.exs
+++ b/test/minga_editor/input/file_tree_editing_input_test.exs
@@ -13,6 +13,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
 
   @moduletag :tmp_dir
 
+  alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.Viewport
@@ -161,6 +162,8 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       {:handled, state} = FileTreeHandler.handle_key(state, ?a, 0)
       {:handled, state} = FileTreeHandler.handle_key(state, ?l, 0)
       assert state.workspace.file_tree.tree.filter == "al"
+      assert BufferProcess.content(state.workspace.file_tree.buffer) =~ "alpha.txt"
+      refute BufferProcess.content(state.workspace.file_tree.buffer) =~ "beta.txt"
 
       assert Enum.map(FileTree.visible_entries(state.workspace.file_tree.tree), & &1.name) == [
                "alpha.txt"
@@ -184,6 +187,28 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       {:handled, state} = FileTreeHandler.handle_key(state, @escape, 0)
       assert state.workspace.file_tree.filtering == false
       assert state.workspace.file_tree.tree.filter == nil
+    end
+
+    test "/ while help is open starts filtering and hides help", %{tmp_dir: dir} do
+      state = make_state(dir)
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ??, 0)
+      assert state.workspace.file_tree.help_visible == true
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?/, 0)
+      assert state.workspace.file_tree.help_visible == false
+      assert state.workspace.file_tree.filtering == true
+    end
+
+    test "question mark while filtering shows help and exits filtering", %{tmp_dir: dir} do
+      state = make_state(dir)
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?/, 0)
+      assert state.workspace.file_tree.filtering == true
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ??, 0)
+      assert state.workspace.file_tree.help_visible == true
+      refute state.workspace.file_tree.filtering
     end
   end
 
@@ -223,6 +248,57 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       assert state.workspace.file_tree.editing.text == "test"
     end
 
+    test "protocol special keys are swallowed during inline editing", %{tmp_dir: dir} do
+      state = make_editing_state(dir, text: "test")
+
+      for code <- [
+            57_348,
+            57_360,
+            57_361,
+            57_362,
+            57_363,
+            57_364,
+            57_376,
+            0xF700,
+            0xF701,
+            0xF702,
+            0xF703,
+            0xF704,
+            0xF728
+          ] do
+        {:handled, state} = FileTreeHandler.handle_key(state, code, 0)
+        assert state.workspace.file_tree.editing.text == "test"
+        assert state.workspace.file_tree.editing.type == :new_file
+      end
+    end
+
+    test "protocol special keys are swallowed during filtering", %{tmp_dir: dir} do
+      state = make_state(dir)
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?/, 0)
+      assert state.workspace.file_tree.filtering == true
+
+      for code <- [
+            57_348,
+            57_360,
+            57_361,
+            57_362,
+            57_363,
+            57_364,
+            57_376,
+            0xF700,
+            0xF701,
+            0xF702,
+            0xF703,
+            0xF704,
+            0xF728
+          ] do
+        {:handled, state} = FileTreeHandler.handle_key(state, code, 0)
+        assert state.workspace.file_tree.tree.filter == ""
+        assert state.workspace.file_tree.filtering == true
+      end
+    end
+
     test "Tab is swallowed during editing", %{tmp_dir: dir} do
       state = make_editing_state(dir, text: "test")
 
@@ -241,6 +317,21 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?d, 0)
       assert state.workspace.file_tree.editing.text == "jkd"
+    end
+
+    test "help-visible navigation keys are swallowed without moving the buffer cursor", %{
+      tmp_dir: dir
+    } do
+      state = make_state(dir)
+      buffer = state.workspace.file_tree.buffer
+      before = BufferProcess.cursor(buffer)
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ??, 0)
+      {:handled, state} = FileTreeHandler.handle_key(state, ?j, 0)
+
+      assert state.workspace.file_tree.help_visible == true
+      assert BufferProcess.cursor(buffer) == before
+      assert state.workspace.file_tree.tree.cursor == 0
     end
 
     test "q appends to text instead of closing tree", %{tmp_dir: dir} do

--- a/test/minga_editor/input/file_tree_editing_input_test.exs
+++ b/test/minga_editor/input/file_tree_editing_input_test.exs
@@ -35,7 +35,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       port_manager: self(),
       workspace: %MingaEditor.Workspace.State{
         viewport: Viewport.new(24, 80),
-        file_tree: %FileTreeState{tree: tree, focused: true, buffer: buf},
+        file_tree: %FileTreeState{} |> FileTreeState.open(tree, buf),
         keymap_scope: :file_tree
       },
       focus_stack: [MingaEditor.Input.Scoped, MingaEditor.Input.ModeFSM]
@@ -113,6 +113,106 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       {:handled, state} = FileTreeHandler.handle_key(state, @backspace, 0)
       assert state.workspace.file_tree.editing.text == "caf"
     end
+  end
+
+  describe "file operation and re-root dispatch" do
+    test "c then p copies the selected entry into the selected directory", %{tmp_dir: dir} do
+      state = make_state(dir) |> select_entry("existing.txt")
+      selected_path = Path.join(dir, "existing.txt")
+      destination = Path.join([dir, "subdir", "existing.txt"])
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?c, 0)
+      state = select_entry(state, "subdir")
+      {:handled, _state} = FileTreeHandler.handle_key(state, ?p, 0)
+
+      assert File.read!(destination) == File.read!(selected_path)
+    end
+
+    test ". re-roots to selected directory and ~ returns to original root", %{tmp_dir: dir} do
+      state = make_state(dir) |> select_entry("subdir")
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?., 0)
+      assert state.workspace.file_tree.tree.root == Path.join(dir, "subdir")
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?~, 0)
+      assert state.workspace.file_tree.tree.root == Path.expand(dir)
+    end
+  end
+
+  describe "filter input" do
+    test "/ enters filtering, printable keys narrow, Enter accepts, and Escape clears", %{
+      tmp_dir: dir
+    } do
+      state = make_state(dir)
+      File.write!(Path.join(dir, "alpha.txt"), "alpha")
+      File.write!(Path.join(dir, "beta.txt"), "beta")
+      tree = FileTree.refresh(state.workspace.file_tree.tree)
+      file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
+
+      state =
+        EditorState.update_workspace(
+          state,
+          &MingaEditor.Workspace.State.set_file_tree(&1, file_tree)
+        )
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?/, 0)
+      assert state.workspace.file_tree.filtering == true
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?a, 0)
+      {:handled, state} = FileTreeHandler.handle_key(state, ?l, 0)
+      assert state.workspace.file_tree.tree.filter == "al"
+
+      assert Enum.map(FileTree.visible_entries(state.workspace.file_tree.tree), & &1.name) == [
+               "alpha.txt"
+             ]
+
+      {:handled, state} = FileTreeHandler.handle_key(state, @backspace, 0)
+      assert state.workspace.file_tree.tree.filter == "a"
+
+      {:handled, state} = FileTreeHandler.handle_key(state, @enter, 0)
+      assert state.workspace.file_tree.filtering == false
+      assert state.workspace.file_tree.tree.filter == "a"
+
+      file_tree = FileTreeState.start_filtering(state.workspace.file_tree)
+
+      state =
+        EditorState.update_workspace(
+          state,
+          &MingaEditor.Workspace.State.set_file_tree(&1, file_tree)
+        )
+
+      {:handled, state} = FileTreeHandler.handle_key(state, @escape, 0)
+      assert state.workspace.file_tree.filtering == false
+      assert state.workspace.file_tree.tree.filter == nil
+    end
+  end
+
+  describe "help overlay input" do
+    test "? toggles help and Escape dismisses it without closing the tree", %{tmp_dir: dir} do
+      state = make_state(dir)
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ??, 0)
+      assert state.workspace.file_tree.help_visible == true
+
+      {:handled, state} = FileTreeHandler.handle_key(state, @escape, 0)
+      assert state.workspace.file_tree.help_visible == false
+      assert state.workspace.file_tree.tree != nil
+    end
+  end
+
+  @spec select_entry(EditorState.t(), String.t()) :: EditorState.t()
+  defp select_entry(state, name) do
+    entries = FileTree.visible_entries(state.workspace.file_tree.tree)
+    index = Enum.find_index(entries, &(&1.name == name))
+    refute index == nil
+
+    tree = FileTree.select(state.workspace.file_tree.tree, index)
+    file_tree = FileTreeState.replace_tree(state.workspace.file_tree, tree)
+
+    EditorState.update_workspace(
+      state,
+      &MingaEditor.Workspace.State.set_file_tree(&1, file_tree)
+    )
   end
 
   describe "key swallowing (no leaking to mode FSM)" do

--- a/test/minga_editor/input/vim_nav_integration_test.exs
+++ b/test/minga_editor/input/vim_nav_integration_test.exs
@@ -4,11 +4,13 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
   buffers (file tree and agent panel) via mode FSM delegation through
   the keymap scope system.
 
-  Tests cover motions (j, k, gg, G), count prefix, yank, insert mode
+  Tests cover motions (j, k, gg, G), count prefix, path copy, insert mode
   blocking, and tree-specific keys to confirm these buffers inherit the
   full vim vocabulary while scope-specific bindings take priority.
   """
   use ExUnit.Case, async: true
+
+  import Hammox
 
   @moduletag :tmp_dir
 
@@ -18,6 +20,21 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
   alias MingaEditor.Viewport
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.BufferSync
+
+  setup :verify_on_exit!
+
+  setup do
+    test_pid = self()
+
+    stub(Minga.Clipboard.Mock, :write, fn text ->
+      send(test_pid, {:clipboard_written, text})
+      :ok
+    end)
+
+    stub(Minga.Clipboard.Mock, :read, fn -> nil end)
+
+    :ok
+  end
 
   defp walk_surface_handlers(state, cp, mods) do
     Enum.reduce_while(MingaEditor.Input.surface_handlers(), {:passthrough, state}, fn handler,
@@ -89,17 +106,19 @@ defmodule MingaEditor.Input.VimNavIntegrationTest do
     end
   end
 
-  describe "file tree: yank in read-only buffer" do
-    test "yy yanks the current line without modifying buffer", %{tmp_dir: tmp_dir} do
+  describe "file tree: copy path" do
+    test "y copies the selected path without modifying the read-only tree buffer", %{
+      tmp_dir: tmp_dir
+    } do
       state = make_tree_state(tmp_dir)
       buf = state.workspace.file_tree.buffer
       content_before = BufferProcess.content(buf)
+      selected_path = FileTree.selected_entry(state.workspace.file_tree.tree).path
 
-      # yy should yank without error
-      {:handled, state} = walk_surface_handlers(state, ?y, 0)
       {:handled, _state} = walk_surface_handlers(state, ?y, 0)
 
       assert BufferProcess.content(buf) == content_before
+      assert_receive {:clipboard_written, ^selected_path}, 200
     end
   end
 

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -66,6 +66,45 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       assert style.bold == true
     end
 
+    test "renders filter prompt header while filtering", %{tmp_dir: tmp_dir} do
+      input = %RenderInput{
+        tree: sample_tree(tmp_dir),
+        rect: {0, 0, 24, 6},
+        focused: true,
+        theme: Theme.get!(:doom_one),
+        active_path: nil,
+        filtering?: true,
+        filter_text: "main"
+      }
+
+      draws = TreeRenderer.render(input)
+      assert draw_texts(draws) =~ " / main▏"
+    end
+
+    test "renders file tree help overlay contents", %{tmp_dir: tmp_dir} do
+      input = %RenderInput{
+        tree: sample_tree(tmp_dir),
+        rect: {0, 0, 72, 30},
+        focused: true,
+        theme: Theme.get!(:doom_one),
+        active_path: nil,
+        help_visible?: true
+      }
+
+      draws = TreeRenderer.render(input)
+      text = draw_texts(draws)
+
+      assert text =~ "Keyboard Shortcuts"
+      assert text =~ "Navigation"
+      assert text =~ "File Operations"
+      assert text =~ "Copy path"
+      assert text =~ "Mark copy / move"
+      assert text =~ "Paste"
+      assert text =~ "Parent root / selected root / project root"
+      assert text =~ "Filter tree"
+      assert text =~ "Toggle help"
+    end
+
     test "renders separator column", %{tmp_dir: tmp_dir} do
       input = %RenderInput{
         tree: sample_tree(tmp_dir),


### PR DESCRIPTION
# TL;DR
Adds the remaining neo-tree-style file tree bindings for copy/move/paste, re-rooting, filtering, and help. This completes the file tree keyboard surface from issue #1143.

Closes #1143

## Context
The file tree already supported navigation, open/toggle, file creation, rename, delete, hidden toggle, refresh, and close. This PR fills in the remaining neo-tree-style bindings so the tree can be operated without falling back to external file management.

## Changes
- Added file tree bindings for `y`, `c`, `m`, `p`, `-`, `.`, `~`, `/`, and `?`.
- Added copy path, copy mark, move mark, paste, re-root, filter, and help commands.
- Added `MingaEditor.State.FileTree.ClipboardMark` so pending copy/move payloads are typed instead of raw maps.
- Added filter and help state to file tree state, with input handling for filter text, Enter, Backspace, and Escape.
- Added tree filter and re-root helpers, including root-relative filtering so temp/project prefixes do not match every row.
- Added help overlay rendering inside the tree panel.
- Added copy/move safety checks for destination conflicts, self-copy, and partial recursive copy cleanup.

## Verification
- `mix test.llm test/minga/keymap/scope/file_tree_scope_test.exs test/minga/project/file_tree_test.exs test/minga_editor/commands/file_tree_neo_bindings_test.exs test/minga_editor/input/file_tree_editing_input_test.exs test/minga_editor/input/vim_nav_integration_test.exs test/minga_editor/shell/traditional/tree_renderer_test.exs` => 137 tests, 0 failures
- `mix test.debug test/minga_editor/commands/scroll_commands_test.exs:90` => 1 test, 0 failures
- `make lint` => pass, existing struct-size warnings only
- Final reviewer gate => PASS, including reported full `mix test.llm` pass

## Acceptance Criteria Addressed
- `y` copies the absolute path of the selected entry to the system clipboard ✅
- `c` marks the selected entry for copy ✅
- `m` marks the selected entry for move (cut) ✅
- `p` pastes a previously copied/cut entry into the selected directory, or parent directory of the selected file ✅
- `-` changes the tree root to the parent of the current root directory ✅
- `.` sets the tree root to the selected directory ✅
- `~` resets the tree root to the original project directory ✅
- `/` opens a filter/search input and narrows visible entries while typing ✅
- `?` toggles the which-key style help overlay ✅
