### PR TITLE
Fix mouse drag selection past viewport edges

### DIFF
--- a/lib/minga_editor/input/router.ex
+++ b/lib/minga_editor/input/router.ex
@@ -320,6 +320,19 @@ defmodule MingaEditor.Input.Router do
           atom(),
           pos_integer()
         ) :: EditorState.t()
+  def dispatch_mouse(
+        %{workspace: %{mouse: %{dragging: true}}} = state,
+        row,
+        col,
+        :left,
+        mods,
+        event_type,
+        click_count
+      )
+      when event_type in [:drag, :release] do
+    MingaEditor.Mouse.handle(state, row, col, :left, mods, event_type, click_count)
+  end
+
   def dispatch_mouse(state, row, col, _button, _mods, _event_type, _click_count)
       when row < 0 or col < 0 do
     state

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -67,6 +67,8 @@ defmodule MingaEditor.Mouse do
            {:window_fold, Window.id(), non_neg_integer()} | {:decoration_fold, pid(), reference()}
 
   @typep fold_row_target :: {:window_fold, non_neg_integer()} | {:decoration_fold, reference()}
+  @typep drag_window_context ::
+           {Window.id(), Window.t(), pid(), integer(), integer(), pos_integer(), pos_integer()}
 
   @doc "Dispatches a mouse event routed to a focus-tree node."
   @spec handle_at_node(
@@ -121,7 +123,54 @@ defmodule MingaEditor.Mouse do
       ),
       do: state
 
-  # Ignore negative coordinates.
+  def handle(
+        %{workspace: %{mouse: %MouseState{dragging: true, anchor: anchor, drag_click_count: dcc}}} =
+          state,
+        row,
+        col,
+        :left,
+        _mods,
+        :drag,
+        _cc
+      ) do
+    handle_left_drag(state, row, col, anchor, dcc)
+  end
+
+  def handle(
+        %{workspace: %{mouse: %MouseState{dragging: true}, editing: %{mode: :visual}}} = state,
+        _r,
+        _c,
+        :left,
+        _m,
+        :release,
+        _cc
+      ) do
+    state =
+      EditorState.update_workspace(
+        state,
+        &WorkspaceState.set_mouse(&1, MouseState.stop_drag(&1.mouse))
+      )
+
+    # TUI keeps legacy selection auto-copy. Native GUI selection stays separate from the clipboard.
+    auto_copy_selection(state)
+  end
+
+  def handle(
+        %{workspace: %{mouse: %MouseState{dragging: true}}} = state,
+        _r,
+        _c,
+        :left,
+        _m,
+        :release,
+        _cc
+      ) do
+    EditorState.update_workspace(
+      state,
+      &WorkspaceState.set_mouse(&1, MouseState.stop_drag(&1.mouse))
+    )
+  end
+
+  # Ignore negative coordinates except active drags, which clamp to the originating window edge.
   def handle(state, row, _col, _button, _mods, _type, _cc) when row < 0, do: state
   def handle(state, _row, col, _button, _mods, _type, _cc) when col < 0, do: state
 
@@ -234,19 +283,6 @@ defmodule MingaEditor.Mouse do
     handle_separator_drag(state, :horizontal, sep_pos, row)
   end
 
-  def handle(
-        %{workspace: %{mouse: %MouseState{dragging: true, anchor: anchor, drag_click_count: dcc}}} =
-          state,
-        row,
-        col,
-        :left,
-        _mods,
-        :drag,
-        _cc
-      ) do
-    handle_left_drag(state, row, col, anchor, dcc)
-  end
-
   # ── Left release ──
 
   def handle(
@@ -261,40 +297,6 @@ defmodule MingaEditor.Mouse do
     EditorState.update_workspace(
       state,
       &WorkspaceState.set_mouse(&1, MouseState.stop_resize(&1.mouse))
-    )
-  end
-
-  def handle(
-        %{workspace: %{mouse: %MouseState{dragging: true}, editing: %{mode: :visual}}} = state,
-        _r,
-        _c,
-        :left,
-        _m,
-        :release,
-        _cc
-      ) do
-    state =
-      EditorState.update_workspace(
-        state,
-        &WorkspaceState.set_mouse(&1, MouseState.stop_drag(&1.mouse))
-      )
-
-    # TUI keeps legacy selection auto-copy. Native GUI selection stays separate from the clipboard.
-    auto_copy_selection(state)
-  end
-
-  def handle(
-        %{workspace: %{mouse: %MouseState{dragging: true}}} = state,
-        _r,
-        _c,
-        :left,
-        _m,
-        :release,
-        _cc
-      ) do
-    EditorState.update_workspace(
-      state,
-      &WorkspaceState.set_mouse(&1, MouseState.stop_drag(&1.mouse))
     )
   end
 
@@ -335,9 +337,12 @@ defmodule MingaEditor.Mouse do
   end
 
   defp handle_left_drag(state, row, col, anchor, dcc) do
-    case mouse_to_buffer_pos(state, row, col) do
+    state = maybe_auto_scroll(state, row, col)
+
+    case drag_mouse_to_buffer_pos(state, row, col) do
+      nil -> state
       ^anchor -> state
-      _target -> drag_to_mouse_pos(state, row, col, anchor, dcc)
+      _target -> drag_to_mouse_pos_after_scroll(state, row, col, anchor, dcc)
     end
   end
 
@@ -350,9 +355,26 @@ defmodule MingaEditor.Mouse do
         ) :: state()
   defp drag_to_mouse_pos(state, row, col, anchor, dcc) do
     state
-    |> maybe_auto_scroll(row)
-    |> move_to_mouse_pos(row, col)
-    |> update_drag_selection(anchor, dcc)
+    |> maybe_auto_scroll(row, col)
+    |> drag_to_mouse_pos_after_scroll(row, col, anchor, dcc)
+  end
+
+  @spec drag_to_mouse_pos_after_scroll(
+          state(),
+          integer(),
+          integer(),
+          {non_neg_integer(), non_neg_integer()},
+          pos_integer()
+        ) :: state()
+  defp drag_to_mouse_pos_after_scroll(state, row, col, anchor, dcc) do
+    case drag_mouse_to_buffer_pos(state, row, col) do
+      nil ->
+        state
+
+      {line, c} ->
+        move_drag_cursor(state, {line, c})
+        update_drag_selection(state, anchor, dcc)
+    end
   end
 
   @spec update_drag_selection(state(), {non_neg_integer(), non_neg_integer()}, pos_integer()) ::
@@ -507,6 +529,9 @@ defmodule MingaEditor.Mouse do
 
   @spec handle_double_click(state(), integer(), integer()) :: state()
   defp handle_double_click(state, row, col) do
+    state = maybe_focus_window_at(state, row, col)
+    origin_window = origin_window_id_at(state, row, col)
+
     case mouse_to_buffer_pos(state, row, col) do
       nil ->
         state
@@ -525,7 +550,7 @@ defmodule MingaEditor.Mouse do
 
             state = EditorState.transition_mode(state, :visual, visual_state)
 
-            update_mouse(state, &MouseState.start_drag(&1, {line, word_start}))
+            update_mouse(state, &MouseState.start_drag(&1, {line, word_start}, origin_window))
 
           nil ->
             state
@@ -536,7 +561,10 @@ defmodule MingaEditor.Mouse do
   # ── Triple-click: line selection ───────────────────────────────────────────
 
   @spec handle_triple_click(state(), integer(), integer()) :: state()
-  defp handle_triple_click(state, row, _col) do
+  defp handle_triple_click(state, row, col) do
+    state = maybe_focus_window_at(state, row, col)
+    origin_window = origin_window_id_at(state, row, col)
+
     case mouse_to_buffer_line(state, row) do
       nil ->
         state
@@ -560,7 +588,7 @@ defmodule MingaEditor.Mouse do
 
         state = EditorState.transition_mode(state, :visual, visual_state)
 
-        update_mouse(state, &MouseState.start_drag(&1, {line, 0}))
+        update_mouse(state, &MouseState.start_drag(&1, {line, 0}, origin_window))
     end
   end
 
@@ -1007,7 +1035,8 @@ defmodule MingaEditor.Mouse do
         state = cancel_mode_for_mouse(state)
         state = EditorState.transition_mode(state, :normal)
 
-        update_mouse(state, &MouseState.start_drag(&1, {target_line, target_col}))
+        origin_window = state.workspace.windows.active
+        update_mouse(state, &MouseState.start_drag(&1, {target_line, target_col}, origin_window))
     end
   end
 
@@ -1190,6 +1219,19 @@ defmodule MingaEditor.Mouse do
     end
   end
 
+  @spec origin_window_id_at(state(), integer(), integer()) :: Window.id() | nil
+  defp origin_window_id_at(%{workspace: %{windows: %{tree: nil, active: active}}}, _row, _col),
+    do: active
+
+  defp origin_window_id_at(state, row, col) do
+    screen = Layout.get(state).editor_area
+
+    case WindowTree.window_at(state.workspace.windows.tree, screen, row, col) do
+      {:ok, id, _rect} -> id
+      :error -> state.workspace.windows.active
+    end
+  end
+
   @spec gutter_width(state(), non_neg_integer()) :: non_neg_integer()
   defp gutter_width(%{workspace: %{buffers: %{active: buf}}}, total_lines) do
     buffer_gutter_width(buf, total_lines)
@@ -1312,6 +1354,106 @@ defmodule MingaEditor.Mouse do
       :error ->
         nil
     end
+  end
+
+  @spec drag_mouse_to_buffer_pos(state(), integer(), integer()) ::
+          {non_neg_integer(), non_neg_integer()} | nil
+  defp drag_mouse_to_buffer_pos(state, row, col) do
+    case drag_window_context(state) do
+      nil -> mouse_to_buffer_pos_for_drag_fallback(state, row, col)
+      context -> drag_mouse_to_buffer_pos(state, context, row, col)
+    end
+  end
+
+  @spec mouse_to_buffer_pos_for_drag_fallback(state(), integer(), integer()) ::
+          {non_neg_integer(), non_neg_integer()} | nil
+  defp mouse_to_buffer_pos_for_drag_fallback(_state, row, _col) when row < 0, do: nil
+  defp mouse_to_buffer_pos_for_drag_fallback(_state, _row, col) when col < 0, do: nil
+
+  defp mouse_to_buffer_pos_for_drag_fallback(state, row, col),
+    do: mouse_to_buffer_pos(state, row, col)
+
+  @spec drag_window_context(state()) :: drag_window_context() | nil
+  defp drag_window_context(state) do
+    layout = Layout.get(state)
+    win_id = state.workspace.mouse.drag_origin_window || state.workspace.windows.active
+
+    with id when is_integer(id) <- win_id,
+         %Window{} = window <- Map.get(state.workspace.windows.map, id),
+         %{content: {content_row, content_col, content_w, content_h}} <-
+           Map.get(layout.window_layouts, id),
+         buf when is_pid(buf) <- window.buffer do
+      {id, window, buf, content_row, content_col, content_w, max(content_h, 1)}
+    else
+      _ -> nil
+    end
+  end
+
+  @spec drag_mouse_to_buffer_pos(state(), drag_window_context(), integer(), integer()) ::
+          {non_neg_integer(), non_neg_integer()} | nil
+  defp drag_mouse_to_buffer_pos(
+         _state,
+         {_id, window, buf, content_row, content_col, content_w, content_h},
+         row,
+         col
+       ) do
+    total_lines = Buffer.line_count(buf)
+    gutter_w = buffer_gutter_width(buf, total_lines)
+    {cursor_line, _} = window.cursor
+    scroll_top = window_scroll_top(window, content_h, content_w, cursor_line, buf)
+    local_row = row - content_row
+    local_col = max(col - content_col - gutter_w, 0) + window.viewport.left
+
+    if local_row < 0 or local_row >= content_h do
+      resolve_drag_buffer_pos(buf, local_row, local_col, scroll_top, content_h, total_lines)
+    else
+      case resolve_with_display_map(
+             buf,
+             window,
+             local_row,
+             local_col,
+             scroll_top,
+             content_h,
+             content_w,
+             total_lines
+           ) do
+        nil ->
+          resolve_drag_buffer_pos(buf, local_row, local_col, scroll_top, content_h, total_lines)
+
+        pos ->
+          pos
+      end
+    end
+  catch
+    :exit, _ -> nil
+  end
+
+  @spec resolve_drag_buffer_pos(
+          pid(),
+          integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pos_integer(),
+          pos_integer()
+        ) :: {non_neg_integer(), non_neg_integer()}
+  defp resolve_drag_buffer_pos(buf, local_row, local_col, scroll_top, content_h, total_lines) do
+    line = drag_target_line(local_row, scroll_top, content_h, total_lines)
+    {line, clamp_col_to_line(buf, line, local_col)}
+  end
+
+  @spec drag_target_line(integer(), non_neg_integer(), pos_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  defp drag_target_line(local_row, scroll_top, _content_h, total_lines) when local_row < 0 do
+    min(scroll_top, total_lines - 1)
+  end
+
+  defp drag_target_line(local_row, scroll_top, content_h, total_lines)
+       when local_row >= content_h do
+    min(scroll_top + content_h - 1, total_lines - 1)
+  end
+
+  defp drag_target_line(local_row, scroll_top, _content_h, total_lines) do
+    (scroll_top + local_row) |> max(0) |> min(total_lines - 1)
   end
 
   # Resolves a click position using the DisplayMap to correctly handle
@@ -1627,36 +1769,69 @@ defmodule MingaEditor.Mouse do
     :exit, _ -> 5
   end
 
-  @spec maybe_auto_scroll(state(), integer()) :: state()
-  defp maybe_auto_scroll(%{workspace: %{buffers: %{active: buf}}} = state, row) when row <= 0 do
-    vp = current_viewport(state)
-    page_move(buf, vp, -1)
-    state
-  end
-
-  defp maybe_auto_scroll(%{workspace: %{buffers: %{active: buf}}} = state, row) do
-    vp = current_viewport(state)
-    scroll_threshold = Viewport.content_rows(vp) - 1
-    maybe_scroll_down(state, buf, vp, row, scroll_threshold)
-  end
-
-  defp maybe_scroll_down(state, buf, vp, row, threshold) when row >= threshold do
-    page_move(buf, vp, 1)
-    state
-  end
-
-  defp maybe_scroll_down(state, _buf, _vp, _row, _threshold), do: state
-
-  @spec move_to_mouse_pos(state(), non_neg_integer(), non_neg_integer()) :: state()
-  defp move_to_mouse_pos(state, row, col) do
-    case mouse_to_buffer_pos(state, row, col) do
+  @spec maybe_auto_scroll(state(), integer(), integer()) :: state()
+  defp maybe_auto_scroll(state, row, col) do
+    case drag_window_context(state) do
       nil ->
         state
 
-      {line, c} ->
-        Buffer.move_to(state.workspace.buffers.active, {line, c})
+      context ->
         state
+        |> maybe_auto_scroll_vertical(context, row)
+        |> maybe_auto_scroll_horizontal(context, col)
     end
+  end
+
+  @spec maybe_auto_scroll_vertical(state(), drag_window_context(), integer()) :: state()
+  defp maybe_auto_scroll_vertical(
+         state,
+         {win_id, _window, _buf, content_row, _content_col, _w, _h},
+         row
+       )
+       when row < content_row do
+    scroll_window_vertical(state, win_id, -1)
+  end
+
+  defp maybe_auto_scroll_vertical(
+         state,
+         {win_id, _window, _buf, content_row, _content_col, _w, content_h},
+         row
+       )
+       when row >= content_row + content_h do
+    scroll_window_vertical(state, win_id, 1)
+  end
+
+  defp maybe_auto_scroll_vertical(state, _context, _row), do: state
+
+  @spec maybe_auto_scroll_horizontal(state(), drag_window_context(), integer()) :: state()
+  defp maybe_auto_scroll_horizontal(
+         state,
+         {win_id, _window, _buf, _row, content_col, _w, _h},
+         col
+       )
+       when col < content_col do
+    scroll_window_horizontal(state, win_id, -@scroll_cols)
+  end
+
+  defp maybe_auto_scroll_horizontal(
+         state,
+         {win_id, _window, _buf, _row, content_col, content_w, _h},
+         col
+       )
+       when col >= content_col + content_w do
+    scroll_window_horizontal(state, win_id, @scroll_cols)
+  end
+
+  defp maybe_auto_scroll_horizontal(state, _context, _col), do: state
+
+  @spec move_drag_cursor(state(), {non_neg_integer(), non_neg_integer()}) :: state()
+  defp move_drag_cursor(state, {line, c}) do
+    case drag_window_context(state) do
+      {_win_id, _window, buf, _row, _col, _w, _h} -> Buffer.move_to(buf, {line, c})
+      nil -> Buffer.move_to(state.workspace.buffers.active, {line, c})
+    end
+
+    state
   end
 
   @spec enter_visual_if_needed(state(), {non_neg_integer(), non_neg_integer()}) :: state()
@@ -1685,25 +1860,6 @@ defmodule MingaEditor.Mouse do
   end
 
   defp cancel_mode_for_mouse(state), do: state
-
-  @spec page_move(pid(), Viewport.t(), integer()) :: :ok
-  defp page_move(buf, _vp, delta) do
-    {line, col} = Buffer.cursor(buf)
-    total_lines = Buffer.line_count(buf)
-    target_line = line + delta
-    target_line = max(0, min(target_line, total_lines - 1))
-
-    target_col =
-      case Buffer.lines(buf, target_line, 1) do
-        [text] when byte_size(text) > 0 ->
-          min(col, Unicode.last_grapheme_byte_offset(text))
-
-        _ ->
-          0
-      end
-
-    Buffer.move_to(buf, {target_line, target_col})
-  end
 
   # ── Tab bar close (middle-click) ─────────────────────────────────────────
 

--- a/lib/minga_editor/state/mouse.ex
+++ b/lib/minga_editor/state/mouse.ex
@@ -24,6 +24,7 @@ defmodule MingaEditor.State.Mouse do
 
   defstruct dragging: false,
             anchor: nil,
+            drag_origin_window: nil,
             resize_dragging: nil,
             last_press_time: nil,
             last_press_pos: nil,
@@ -35,6 +36,7 @@ defmodule MingaEditor.State.Mouse do
   @type t :: %__MODULE__{
           dragging: boolean(),
           anchor: {non_neg_integer(), non_neg_integer()} | nil,
+          drag_origin_window: MingaEditor.Window.id() | nil,
           resize_dragging: {WindowTree.direction() | :agent_separator, non_neg_integer()} | nil,
           last_press_time: integer() | nil,
           last_press_pos: {integer(), integer()} | nil,
@@ -47,13 +49,26 @@ defmodule MingaEditor.State.Mouse do
   @doc "Begins a content drag from the given buffer position."
   @spec start_drag(t(), {non_neg_integer(), non_neg_integer()}) :: t()
   def start_drag(%__MODULE__{} = mouse, anchor) do
-    %{mouse | dragging: true, anchor: anchor, drag_click_count: max(mouse.click_count, 1)}
+    start_drag(mouse, anchor, nil)
+  end
+
+  @doc "Begins a content drag from the given buffer position and originating window."
+  @spec start_drag(t(), {non_neg_integer(), non_neg_integer()}, MingaEditor.Window.id() | nil) ::
+          t()
+  def start_drag(%__MODULE__{} = mouse, anchor, origin_window) do
+    %{
+      mouse
+      | dragging: true,
+        anchor: anchor,
+        drag_origin_window: origin_window,
+        drag_click_count: max(mouse.click_count, 1)
+    }
   end
 
   @doc "Ends an active drag, clearing the anchor."
   @spec stop_drag(t()) :: t()
   def stop_drag(%__MODULE__{} = mouse) do
-    %{mouse | dragging: false, anchor: nil}
+    %{mouse | dragging: false, anchor: nil, drag_origin_window: nil}
   end
 
   @doc "Begins a separator resize drag in the given direction at the given position."

--- a/test/minga/buffer/auto_save_test.exs
+++ b/test/minga/buffer/auto_save_test.exs
@@ -12,6 +12,7 @@ defmodule Minga.Buffer.AutoSaveTest do
 
   @moduletag :tmp_dir
   @delay_ms 5_000
+  @event_timeout 5_000
 
   test "dirty file-backed buffer auto-saves when the debounce timer fires", %{tmp_dir: dir} do
     path = Path.join(dir, "auto-save.txt")
@@ -272,7 +273,7 @@ defmodule Minga.Buffer.AutoSaveTest do
           assert_log_contains(text)
         end
     after
-      500 -> flunk("expected log message containing #{inspect(text)}")
+      @event_timeout -> flunk("expected log message containing #{inspect(text)}")
     end
   end
 
@@ -282,7 +283,7 @@ defmodule Minga.Buffer.AutoSaveTest do
       when is_pid(buffer) ->
         :ok
     after
-      500 -> flunk("expected buffer_saved event for #{inspect(path)}")
+      @event_timeout -> flunk("expected buffer_saved event for #{inspect(path)}")
     end
   end
 end

--- a/test/minga/buffer/buftype_integration_test.exs
+++ b/test/minga/buffer/buftype_integration_test.exs
@@ -100,6 +100,7 @@ defmodule Minga.Buffer.BuftypeIntegrationTest do
 
       ctx = start_editor("hello", file_path: path)
       buf = ctx.buffer
+      assert {:ok, 0} = BufferProcess.set_option(buf, :auto_save_delay_ms, 0)
 
       refute BufferProcess.dirty?(buf)
 

--- a/test/minga/buffer/dirty_flag_verification_test.exs
+++ b/test/minga/buffer/dirty_flag_verification_test.exs
@@ -149,6 +149,7 @@ defmodule Minga.Buffer.DirtyFlagVerificationTest do
   end
 
   @tag :tmp_dir
+  @tag timeout: 180_000
   property "dirty flag is consistent after random insert/undo sequences", %{tmp_dir: dir} do
     check all(
             ops <-

--- a/test/minga/buffer/save_all_dirty_test.exs
+++ b/test/minga/buffer/save_all_dirty_test.exs
@@ -1,5 +1,6 @@
 defmodule Minga.Buffer.SaveAllDirtyTest do
-  use ExUnit.Case, async: true
+  # Uses global Minga.Buffer.Registry; save_all_dirty/0 can save buffers owned by concurrent tests.
+  use ExUnit.Case, async: false
 
   alias Minga.Buffer
   alias Minga.Buffer.Process, as: BufferProcess

--- a/test/minga/clipboard/system_test.exs
+++ b/test/minga/clipboard/system_test.exs
@@ -27,9 +27,9 @@ defmodule Minga.Clipboard.SystemTest do
 
       assert result == :ok
       # The old code always hit a 500ms timeout in await_port_exit.
-      # New code uses Port.close and should complete well under 100ms.
-      assert time_μs < 100_000,
-             "write took #{time_μs}µs (#{div(time_μs, 1000)}ms), expected < 100ms. " <>
+      # New code uses Port.close and should complete well under 250ms even on a loaded machine.
+      assert time_μs < 250_000,
+             "write took #{time_μs}µs (#{div(time_μs, 1000)}ms), expected < 250ms. " <>
                "This suggests the 500ms await_port_exit timeout bug has regressed."
     end
 

--- a/test/minga/file_watcher_test.exs
+++ b/test/minga/file_watcher_test.exs
@@ -4,9 +4,12 @@ defmodule Minga.FileWatcherTest do
   subscriber notifications.
   """
 
-  use ExUnit.Case, async: true
+  # Uses file-system watcher resources that can block under concurrent full-suite load, so keep this file serialized.
+  use ExUnit.Case, async: false
 
   alias Minga.FileWatcher
+
+  @sync_timeout 15_000
 
   defp start_watcher(opts \\ []) do
     opts =
@@ -50,7 +53,7 @@ defmodule Minga.FileWatcherTest do
     FileWatcher.check_all(watcher)
 
     # check_all is a cast; barrier ensures it's processed before asserting
-    :sys.get_state(watcher)
+    :sys.get_state(watcher, @sync_timeout)
 
     assert_receive {:file_changed_on_disk, "/tmp/a.txt"}, 50
     assert_receive {:file_changed_on_disk, "/tmp/b.txt"}, 50
@@ -69,7 +72,7 @@ defmodule Minga.FileWatcherTest do
 
     # Ensure the watcher has processed all 5 events and rescheduled
     # the debounce timer before we start waiting for the result.
-    :sys.get_state(watcher)
+    :sys.get_state(watcher, @sync_timeout)
 
     # Should receive only one notification after debounce
     assert_receive {:file_changed_on_disk, ^path}, 500
@@ -83,7 +86,7 @@ defmodule Minga.FileWatcherTest do
     send(watcher, {:file_event, nil, {"/tmp/other.txt", [:modified]}})
 
     # Flush the watcher's mailbox so the event is processed
-    :sys.get_state(watcher)
+    :sys.get_state(watcher, @sync_timeout)
     refute_receive {:file_changed_on_disk, _}, 50
   end
 
@@ -94,7 +97,7 @@ defmodule Minga.FileWatcherTest do
 
     FileWatcher.watch_directory(watcher, root)
     send(watcher, {:file_event, nil, {path, [:created]}})
-    :sys.get_state(watcher)
+    :sys.get_state(watcher, @sync_timeout)
 
     assert_receive {:file_changed_on_disk, ^path}, 500
   end
@@ -107,7 +110,7 @@ defmodule Minga.FileWatcherTest do
     FileWatcher.watch_directory(watcher, root)
     FileWatcher.unwatch_directory(watcher, root)
     send(watcher, {:file_event, nil, {path, [:created]}})
-    :sys.get_state(watcher)
+    :sys.get_state(watcher, @sync_timeout)
 
     refute_receive {:file_changed_on_disk, ^path}, 50
   end
@@ -117,9 +120,9 @@ defmodule Minga.FileWatcherTest do
     root = "/tmp/project-tree-idempotent"
 
     FileWatcher.watch_directory(watcher, root)
-    first_state = :sys.get_state(watcher)
+    first_state = :sys.get_state(watcher, @sync_timeout)
     FileWatcher.watch_directory(watcher, root)
-    second_state = :sys.get_state(watcher)
+    second_state = :sys.get_state(watcher, @sync_timeout)
 
     assert first_state.watched_dirs == second_state.watched_dirs
     assert first_state.watcher == second_state.watcher
@@ -131,7 +134,7 @@ defmodule Minga.FileWatcherTest do
 
     FileWatcher.watch_directory(watcher, root)
     FileWatcher.check_all(watcher)
-    :sys.get_state(watcher)
+    :sys.get_state(watcher, @sync_timeout)
 
     assert_receive {:file_changed_on_disk, ^root}, 50
   end
@@ -146,7 +149,7 @@ defmodule Minga.FileWatcherTest do
     FileWatcher.watch_directory(watcher, nested)
     FileWatcher.unwatch_directory_tree(watcher, root)
     send(watcher, {:file_event, nil, {path, [:created]}})
-    state = :sys.get_state(watcher)
+    state = :sys.get_state(watcher, @sync_timeout)
 
     assert state.watched_project_dirs == MapSet.new()
     refute_receive {:file_changed_on_disk, ^path}, 50
@@ -160,12 +163,12 @@ defmodule Minga.FileWatcherTest do
     FileWatcher.subscribe(watcher, task.pid)
 
     # Barrier: ensure :DOWN is processed
-    :sys.get_state(watcher)
+    :sys.get_state(watcher, @sync_timeout)
 
     # check_all should not crash, and we should not receive anything
     FileWatcher.watch_path(watcher, "/tmp/a.txt")
     FileWatcher.check_all(watcher)
-    :sys.get_state(watcher)
+    :sys.get_state(watcher, @sync_timeout)
     refute_receive {:file_changed_on_disk, _}, 50
   end
 
@@ -181,7 +184,7 @@ defmodule Minga.FileWatcherTest do
 
     FileWatcher.watch_path(watcher, "/tmp/resub.txt")
     FileWatcher.check_all(watcher)
-    :sys.get_state(watcher)
+    :sys.get_state(watcher, @sync_timeout)
 
     # New subscriber (self) gets the notification
     assert_receive {:file_changed_on_disk, "/tmp/resub.txt"}, 50

--- a/test/minga/git/tracker_test.exs
+++ b/test/minga/git/tracker_test.exs
@@ -1,5 +1,6 @@
 defmodule Minga.Git.TrackerTest do
-  use ExUnit.Case, async: true
+  # Uses the global Minga.Git.Repo.Supervisor and Git.Stub registry, so keep this file serialized.
+  use ExUnit.Case, async: false
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Events
@@ -8,6 +9,7 @@ defmodule Minga.Git.TrackerTest do
   alias Minga.Git.Tracker
 
   @moduletag :tmp_dir
+  @sync_timeout 15_000
 
   setup %{tmp_dir: dir} do
     id = System.unique_integer([:positive])
@@ -44,7 +46,7 @@ defmodule Minga.Git.TrackerTest do
 
   # Flushes the Tracker's mailbox so any pending events (:buffer_opened,
   # :DOWN, etc.) are processed before we check state.
-  defp flush_tracker(tracker), do: :sys.get_state(tracker)
+  defp flush_tracker(tracker), do: :sys.get_state(tracker, @sync_timeout)
 
   describe "lookup/1" do
     test "returns nil for untracked buffer", %{

--- a/test/minga_agent/providers/native_mcp_test.exs
+++ b/test/minga_agent/providers/native_mcp_test.exs
@@ -9,6 +9,7 @@ defmodule MingaAgent.Providers.NativeMCPTest do
   alias ReqLLM.StreamResponse.MetadataHandle
 
   @moduletag :tmp_dir
+  @receive_timeout 5_000
 
   defp server_config(name \\ "Local Tools") do
     %ServerConfig{name: name, command: "ignored"}
@@ -102,7 +103,7 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     assert :ok = Native.send_prompt(provider, "hello")
     _events = collect_until_end()
 
-    assert_receive {:llm_tools, tool_names}
+    assert_receive {:llm_tools, tool_names}, @receive_timeout
     assert "builtin_echo" in tool_names
     assert "mcp_local_tools__echo_text" in tool_names
     assert "todo_write" in tool_names
@@ -135,7 +136,7 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     assert :ok = Native.send_prompt(provider, "hello")
     _events = collect_until_end()
 
-    assert_receive {:llm_tools_two_servers, tool_names}
+    assert_receive {:llm_tools_two_servers, tool_names}, @receive_timeout
     assert "builtin_echo" in tool_names
     assert "mcp_alpha__echo_text" in tool_names
     assert "mcp_beta__search_code" in tool_names
@@ -170,7 +171,7 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     assert :ok = Native.send_prompt(provider, "hello")
     _events = collect_until_end()
 
-    assert_receive {:llm_tools_with_reserved_collision, tool_names}
+    assert_receive {:llm_tools_with_reserved_collision, tool_names}, @receive_timeout
     assert "mcp_local_tools__echo_text" in tool_names
     assert "mcp_local_tools__echo_text_2" in tool_names
     assert length(tool_names) == length(Enum.uniq(tool_names))
@@ -193,14 +194,14 @@ defmodule MingaAgent.Providers.NativeMCPTest do
         config: %AgentConfig{mcp_servers: [%{name: "Local Tools"}], tool_approval: :none}
       )
 
-    assert_receive {:agent_provider_event, %Event.Error{message: message}}
+    assert_receive {:agent_provider_event, %Event.Error{message: message}}, @receive_timeout
     assert message =~ "MCP config error"
     assert message =~ "command is required"
 
     assert :ok = Native.send_prompt(provider, "hello")
     _events = collect_until_end()
 
-    assert_receive {:llm_tools_with_invalid_mcp, tool_names}
+    assert_receive {:llm_tools_with_invalid_mcp, tool_names}, @receive_timeout
     assert "builtin_echo" in tool_names
     refute "mcp_local_tools__echo_text" in tool_names
     assert "todo_write" in tool_names
@@ -228,13 +229,13 @@ defmodule MingaAgent.Providers.NativeMCPTest do
         ]
       )
 
-    assert_receive {:agent_provider_event, %Event.Error{message: message}}
+    assert_receive {:agent_provider_event, %Event.Error{message: message}}, @receive_timeout
     assert message =~ "MCP server Broken failed to start"
 
     assert :ok = Native.send_prompt(provider, "hello")
     _events = collect_until_end()
 
-    assert_receive {:llm_tools_with_failed_server, tool_names}
+    assert_receive {:llm_tools_with_failed_server, tool_names}, @receive_timeout
     assert "builtin_echo" in tool_names
     assert "mcp_healthy__echo_text" in tool_names
     refute "mcp_broken__echo_text" in tool_names
@@ -268,7 +269,7 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     assert :ok = Native.send_prompt(provider, "use mcp")
     events = collect_until_end()
 
-    assert_receive {:mcp_tool_call, "echo-text", %{"text" => "hi"}}
+    assert_receive {:mcp_tool_call, "echo-text", %{"text" => "hi"}}, @receive_timeout
 
     assert Enum.any?(
              events,
@@ -299,17 +300,17 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     end
 
     {:ok, provider} = start_provider(tmp_dir: dir, llm_client: client)
-    assert_receive {:mcp_transport_started, "Local Tools", transport}
+    assert_receive {:mcp_transport_started, "Local Tools", transport}, @receive_timeout
     FakeTransport.crash(transport)
 
-    assert_receive {:agent_provider_event, %Event.Error{message: message}}
+    assert_receive {:agent_provider_event, %Event.Error{message: message}}, @receive_timeout
     assert message =~ "MCP server Local Tools stopped"
 
     :sys.get_state(provider)
     assert :ok = Native.send_prompt(provider, "still works")
     events = collect_until_end()
 
-    assert_receive {:llm_tools_after_crash, tool_names}
+    assert_receive {:llm_tools_after_crash, tool_names}, @receive_timeout
     assert "builtin_echo" in tool_names
     refute "mcp_local_tools__echo_text" in tool_names
     assert Enum.any?(events, &match?(%Event.ToolEnd{name: "builtin_echo", is_error: false}, &1))
@@ -329,15 +330,15 @@ defmodule MingaAgent.Providers.NativeMCPTest do
         ]
       )
 
-    assert_receive {:mcp_transport_started, "Alpha", alpha_transport}
-    assert_receive {:mcp_transport_started, "Beta", beta_transport}
+    assert_receive {:mcp_transport_started, "Alpha", alpha_transport}, @receive_timeout
+    assert_receive {:mcp_transport_started, "Beta", beta_transport}, @receive_timeout
 
     provider_ref = Process.monitor(provider)
     GenServer.stop(provider)
 
-    assert_receive {:DOWN, ^provider_ref, :process, ^provider, :normal}
-    assert_receive {:mcp_transport_stopped, "Alpha", ^alpha_transport}
-    assert_receive {:mcp_transport_stopped, "Beta", ^beta_transport}
+    assert_receive {:DOWN, ^provider_ref, :process, ^provider, :normal}, @receive_timeout
+    assert_receive {:mcp_transport_stopped, "Alpha", ^alpha_transport}, @receive_timeout
+    assert_receive {:mcp_transport_stopped, "Beta", ^beta_transport}, @receive_timeout
   end
 
   test "MCP tool failure during a call reports an error and keeps provider usable", %{
@@ -408,7 +409,7 @@ defmodule MingaAgent.Providers.NativeMCPTest do
     assert :ok = Native.send_prompt(provider, "still works")
     events = collect_until_end()
 
-    assert_receive {:llm_tools_after_call_failure, tool_names}
+    assert_receive {:llm_tools_after_call_failure, tool_names}, @receive_timeout
     assert "builtin_echo" in tool_names
     refute "mcp_local_tools__echo_text" in tool_names
     assert Enum.any?(events, &match?(%Event.AgentEnd{}, &1))
@@ -453,21 +454,21 @@ defmodule MingaAgent.Providers.NativeMCPTest do
         ]
       )
 
-    assert_receive {:mcp_transport_started, "Alpha", alpha_transport}
+    assert_receive {:mcp_transport_started, "Alpha", alpha_transport}, @receive_timeout
     FakeTransport.crash(alpha_transport)
 
-    assert_receive {:agent_provider_event, %Event.Error{message: message}}
+    assert_receive {:agent_provider_event, %Event.Error{message: message}}, @receive_timeout
     assert message =~ "MCP server Alpha stopped"
 
     :sys.get_state(provider)
     assert :ok = Native.send_prompt(provider, "still works")
     events = collect_until_end()
 
-    assert_receive {:llm_tools_after_one_server_crash, tool_names}
+    assert_receive {:llm_tools_after_one_server_crash, tool_names}, @receive_timeout
     assert "builtin_echo" in tool_names
     refute "mcp_alpha__echo_text" in tool_names
     assert "mcp_beta__search_code" in tool_names
-    assert_receive {:mcp_tool_call, "Beta", "search-code", %{"text" => "hi"}}
+    assert_receive {:mcp_tool_call, "Beta", "search-code", %{"text" => "hi"}}, @receive_timeout
 
     assert Enum.any?(
              events,

--- a/test/minga_editor/commands/editing_reindent_test.exs
+++ b/test/minga_editor/commands/editing_reindent_test.exs
@@ -11,6 +11,8 @@ defmodule MingaEditor.Commands.EditingReindentTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor
 
+  @sync_timeout 15_000
+
   defp start_editor(content) do
     id = :erlang.unique_integer([:positive])
     events_registry = :"reindent_events_#{id}"
@@ -35,7 +37,7 @@ defmodule MingaEditor.Commands.EditingReindentTest do
 
   defp send_key(editor, codepoint, mods \\ 0) do
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor)
+    _ = :sys.get_state(editor, @sync_timeout)
   end
 
   # ── == mode transitions ────────────────────────────────────────────────────
@@ -45,7 +47,7 @@ defmodule MingaEditor.Commands.EditingReindentTest do
       {editor, _buffer} = start_editor("line 1\nline 2")
       send_key(editor, ?=)
 
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       assert state.workspace.editing.mode == :operator_pending
       assert state.workspace.editing.mode_state.operator == :reindent
     end
@@ -55,7 +57,7 @@ defmodule MingaEditor.Commands.EditingReindentTest do
       send_key(editor, ?=)
       send_key(editor, ?=)
 
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       assert state.workspace.editing.mode == :normal
     end
 
@@ -64,7 +66,7 @@ defmodule MingaEditor.Commands.EditingReindentTest do
       send_key(editor, ?=)
       send_key(editor, ?w)
 
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       assert state.workspace.editing.mode == :normal
     end
 
@@ -73,7 +75,7 @@ defmodule MingaEditor.Commands.EditingReindentTest do
       send_key(editor, ?=)
       send_key(editor, ?G)
 
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       assert state.workspace.editing.mode == :normal
     end
 
@@ -84,7 +86,7 @@ defmodule MingaEditor.Commands.EditingReindentTest do
       send_key(editor, ?g)
       send_key(editor, ?g)
 
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       assert state.workspace.editing.mode == :normal
     end
   end
@@ -98,7 +100,7 @@ defmodule MingaEditor.Commands.EditingReindentTest do
       send_key(editor, ?j)
       send_key(editor, ?=)
 
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       assert state.workspace.editing.mode == :normal
     end
 
@@ -108,7 +110,7 @@ defmodule MingaEditor.Commands.EditingReindentTest do
       send_key(editor, ?j)
       send_key(editor, ?=)
 
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       assert state.workspace.editing.mode == :normal
     end
   end
@@ -120,25 +122,25 @@ defmodule MingaEditor.Commands.EditingReindentTest do
       {editor, _buffer} = start_editor("hello world")
       send_key(editor, ?=)
 
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       assert state.workspace.editing.mode == :operator_pending
 
       send_key(editor, ?i)
       send_key(editor, ?w)
 
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       assert state.workspace.editing.mode == :normal
     end
 
     test "default bus tool prompts cannot interrupt reindent dispatch" do
       {editor, _buffer} = start_editor("hello world")
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
 
       refute editor in Minga.Events.subscribers(:tool_missing)
       assert editor in Minga.Events.subscribers(:tool_missing, state.events_registry)
 
       Minga.Events.broadcast(:tool_missing, %Minga.Events.ToolMissingEvent{command: "rg"})
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
 
       assert state.workspace.editing.mode == :normal
       assert state.shell_state.tool_prompt_queue == []

--- a/test/minga_editor/integration/file_open_from_agent_tab_test.exs
+++ b/test/minga_editor/integration/file_open_from_agent_tab_test.exs
@@ -98,7 +98,7 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
     # Trigger a render so the agent view is visible
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:ready, width, height}})
-    {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+    {:ok, _snapshot} = HeadlessPort.collect_frame(ref, 15_000)
 
     %{
       editor: editor,
@@ -133,7 +133,7 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
 
       ref = HeadlessPort.prepare_await(ctx.port)
       :ok = MingaEditor.open_file(ctx.editor, file_path)
-      {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+      {:ok, _snapshot} = HeadlessPort.collect_frame(ref, 15_000)
 
       # After opening a file, the window content MUST be {:buffer, _}
       state = :sys.get_state(ctx.editor)
@@ -166,7 +166,7 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
 
       ref = HeadlessPort.prepare_await(ctx.port)
       :ok = MingaEditor.open_file(ctx.editor, file_path)
-      {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+      {:ok, _snapshot} = HeadlessPort.collect_frame(ref, 15_000)
 
       # Tab bar should show the file
       tab_row = screen_row(ctx, 0)
@@ -197,7 +197,7 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
 
       ref = HeadlessPort.prepare_await(ctx.port)
       :ok = MingaEditor.open_file(ctx.editor, file_path)
-      {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+      {:ok, _snapshot} = HeadlessPort.collect_frame(ref, 15_000)
 
       ml = modeline(ctx)
 
@@ -221,7 +221,7 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
 
       ref = HeadlessPort.prepare_await(ctx.port)
       :ok = MingaEditor.open_file(ctx.editor, file_path)
-      {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
+      {:ok, _snapshot} = HeadlessPort.collect_frame(ref, 15_000)
 
       state = :sys.get_state(ctx.editor)
 

--- a/test/minga_editor/integration/mouse_test.exs
+++ b/test/minga_editor/integration/mouse_test.exs
@@ -8,6 +8,7 @@ defmodule Minga.Integration.MouseTest do
   use Minga.Test.EditorCase, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree
   alias Minga.Test.HeadlessPort
@@ -201,6 +202,50 @@ defmodule Minga.Integration.MouseTest do
       send_mouse(ctx, 1, 15, :left, 0, :release, 1)
 
       assert editor_mode(ctx) == :visual
+    end
+
+    test "double-click-drag past viewport extends by word with autoscroll" do
+      ctx = start_editor(Enum.map_join(0..29, "\n", fn _ -> "alpha beta gamma" end))
+      state = editor_state(ctx)
+
+      %{content: {row, col, _width, height}} =
+        Layout.active_window_layout(Layout.get(state), state)
+
+      send_mouse(ctx, row, col + 3, :left, 0, :press, 2)
+      send_mouse(ctx, row + height, col + 8, :left, 0, :drag, 1)
+
+      state = editor_state(ctx)
+      {line, cursor_col} = buffer_cursor(ctx)
+
+      assert editor_mode(ctx) == :visual
+      assert state.workspace.editing.mode_state.visual_type == :char
+      assert state.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert state.workspace.mouse.drag_click_count == 2
+      assert line > 0
+      assert cursor_col == 4
+      assert EditorState.active_window_struct(state).viewport.top > 0
+    end
+
+    test "triple-click-drag past viewport extends by line with autoscroll" do
+      ctx = start_editor(Enum.map_join(0..29, "\n", fn _ -> "alpha beta gamma" end))
+      state = editor_state(ctx)
+
+      %{content: {row, col, _width, height}} =
+        Layout.active_window_layout(Layout.get(state), state)
+
+      send_mouse(ctx, row, col + 3, :left, 0, :press, 3)
+      send_mouse(ctx, row + height, col + 8, :left, 0, :drag, 1)
+
+      state = editor_state(ctx)
+      {line, cursor_col} = buffer_cursor(ctx)
+
+      assert editor_mode(ctx) == :visual
+      assert state.workspace.editing.mode_state.visual_type == :line
+      assert state.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert state.workspace.mouse.drag_click_count == 3
+      assert line > 0
+      assert cursor_col == 15
+      assert EditorState.active_window_struct(state).viewport.top > 0
     end
   end
 

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -521,6 +521,42 @@ defmodule MingaEditor.MouseTest do
       assert Process.alive?(editor)
     end
 
+    test "rapid repeated presses still drive double-click drag semantics" do
+      {editor, buffer} = start_editor(Enum.map_join(0..29, "\n", fn _ -> "alpha beta gamma" end))
+      s = state(editor)
+      %{content: {row, col, _width, height}} = Layout.active_window_layout(Layout.get(s), s)
+
+      start_col = col + @gutter + 3
+      drag_col = col + @gutter + 8
+
+      send_mouse(editor, row, start_col, :left, :press)
+      send_mouse(editor, row, start_col, :left, :press)
+      send_mouse(editor, row + height, drag_col, :left, :drag)
+
+      s = state(editor)
+      {line, cursor_col} = BufferProcess.cursor(buffer)
+
+      assert s.workspace.mouse.drag_click_count == 2
+      assert s.workspace.editing.mode == :visual
+      assert s.workspace.editing.mode_state.visual_type == :char
+      assert s.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert line > 0
+      assert cursor_col == 9
+      assert EditorState.active_window_struct(s).viewport.top > 0
+    end
+
+    test "release outside buffer content after drag clears drag state" do
+      {editor, _buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
+      s = state(editor)
+      %{content: {row, col, width, height}} = Layout.active_window_layout(Layout.get(s), s)
+
+      send_mouse(editor, row, col + @gutter, :left, :press)
+      send_mouse(editor, row + height, col + width, :left, :drag)
+      send_mouse(editor, row + height, col + width, :left, :release)
+
+      assert state(editor).workspace.mouse.dragging == false
+    end
+
     test "release without movement (click) returns to normal mode" do
       {editor, _buffer} = start_editor("hello world")
       send_mouse(editor, @content_row, 3, :left, :press)
@@ -560,6 +596,139 @@ defmodule MingaEditor.MouseTest do
       {line, col} = BufferProcess.cursor(buffer)
       assert line == 0
       assert col <= 1
+    end
+
+    test "drag below viewport scrolls down and extends selection" do
+      {editor, buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
+      s = state(editor)
+      %{content: {row, col, width, height}} = Layout.active_window_layout(Layout.get(s), s)
+
+      send_mouse(editor, row, col + @gutter, :left, :press)
+      send_mouse(editor, row + height, col + width, :left, :drag)
+
+      s = state(editor)
+      window = EditorState.active_window_struct(s)
+      {line, _col} = BufferProcess.cursor(buffer)
+
+      assert window.viewport.top > 0
+      assert line >= height
+      assert s.workspace.editing.mode == :visual
+    end
+
+    test "drag below from bottom visible line still autoscrolls" do
+      {editor, _buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
+      s = state(editor)
+      %{content: {row, col, _width, height}} = Layout.active_window_layout(Layout.get(s), s)
+
+      send_mouse(editor, row + height - 1, col + @gutter, :left, :press)
+      send_mouse(editor, row + height, col + @gutter, :left, :drag)
+
+      s = state(editor)
+
+      assert EditorState.active_window_struct(s).viewport.top > 0
+      assert s.workspace.editing.mode == :visual
+    end
+
+    test "drag above viewport scrolls up and extends selection" do
+      {editor, buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
+
+      :sys.replace_state(editor, fn state ->
+        EditorState.update_window(
+          state,
+          state.workspace.windows.active,
+          &Window.scroll_viewport(&1, 5, 30)
+        )
+      end)
+
+      s = state(editor)
+      %{content: {row, col, _width, _height}} = Layout.active_window_layout(Layout.get(s), s)
+      before_top = EditorState.active_window_struct(s).viewport.top
+
+      send_mouse(editor, row + 2, col + @gutter, :left, :press)
+      send_mouse(editor, row - 1, col + @gutter, :left, :drag)
+
+      s = state(editor)
+      window = EditorState.active_window_struct(s)
+      {line, _col} = BufferProcess.cursor(buffer)
+
+      assert before_top > 0
+      assert window.viewport.top < before_top
+      assert line <= before_top
+      assert s.workspace.editing.mode == :visual
+    end
+
+    test "drag past right edge scrolls horizontally and extends selection" do
+      {editor, buffer} = start_editor(String.duplicate("abcdefghijklmnopqrstuvwxyz", 4))
+      s = state(editor)
+      %{content: {row, col, width, _height}} = Layout.active_window_layout(Layout.get(s), s)
+
+      send_mouse(editor, row, col + @gutter, :left, :press)
+      send_mouse(editor, row, col + width, :left, :drag)
+
+      s = state(editor)
+      window = EditorState.active_window_struct(s)
+      {_line, cursor_col} = BufferProcess.cursor(buffer)
+
+      assert window.viewport.left > 0
+      assert cursor_col > 0
+      assert s.workspace.editing.mode == :visual
+    end
+
+    test "drag right from right visible column still autoscrolls" do
+      {editor, _buffer} = start_editor(String.duplicate("abcdefghijklmnopqrstuvwxyz", 4))
+      s = state(editor)
+      %{content: {row, col, width, _height}} = Layout.active_window_layout(Layout.get(s), s)
+
+      send_mouse(editor, row, col + width - 1, :left, :press)
+      send_mouse(editor, row, col + width, :left, :drag)
+
+      s = state(editor)
+
+      assert EditorState.active_window_struct(s).viewport.left > 0
+      assert s.workspace.editing.mode == :visual
+    end
+
+    test "drag back left reverses horizontal scroll without losing anchor" do
+      {editor, _buffer} = start_editor(String.duplicate("abcdefghijklmnopqrstuvwxyz", 4))
+      s = state(editor)
+      %{content: {row, col, width, _height}} = Layout.active_window_layout(Layout.get(s), s)
+
+      send_mouse(editor, row, col + @gutter + 10, :left, :press)
+      send_mouse(editor, row, col + width, :left, :drag)
+      right_scrolled_left = EditorState.active_window_struct(state(editor)).viewport.left
+
+      send_mouse(editor, row, col - 1, :left, :drag)
+
+      s = state(editor)
+      window = EditorState.active_window_struct(s)
+
+      assert right_scrolled_left > 0
+      assert window.viewport.left < right_scrolled_left
+      assert s.workspace.editing.mode_state.visual_anchor == {0, 10}
+    end
+
+    test "drag crossing split boundary stays associated with originating window" do
+      {editor, _buffer} = start_editor("hello world\nsecond line\nthird line")
+
+      :sys.replace_state(editor, fn state -> Movement.execute(state, :split_vertical) end)
+      s = state(editor)
+      origin_id = s.workspace.windows.active
+      layout = Layout.get(s)
+      origin_layout = Map.fetch!(layout.window_layouts, origin_id)
+
+      {_other_id, %{content: {other_row, other_col, _other_width, _other_height}}} =
+        Enum.find(layout.window_layouts, fn {id, _layout} -> id != origin_id end)
+
+      %{content: {origin_row, origin_col, _origin_width, _origin_height}} = origin_layout
+
+      send_mouse(editor, origin_row, origin_col + @gutter, :left, :press)
+      send_mouse(editor, other_row, other_col + @gutter, :left, :drag)
+
+      s = state(editor)
+
+      assert s.workspace.windows.active == origin_id
+      assert s.workspace.mouse.drag_origin_window == origin_id
+      assert s.workspace.editing.mode == :visual
     end
 
     test "drag ignores events when not dragging" do

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -295,6 +295,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       assert String.starts_with?(name, "lib/")
     end
 
+    @tag timeout: 180_000
     test "renders production state for large trees around the selected row", %{tmp_dir: tmp_dir} do
       for index <- 1..600 do
         File.write!(
@@ -335,6 +336,7 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       assert String.contains?(all_text, "file_600.ex")
     end
 
+    @tag timeout: 180_000
     test "renders large RenderInput trees around the selected row", %{tmp_dir: tmp_dir} do
       for index <- 1..600 do
         File.write!(

--- a/test/minga_editor/ui/picker/agent_session_source_test.exs
+++ b/test/minga_editor/ui/picker/agent_session_source_test.exs
@@ -1,5 +1,6 @@
 defmodule MingaEditor.UI.Picker.AgentSessionSourceTest do
-  use ExUnit.Case, async: true
+  # Uses real agent sessions through the global MingaAgent.Supervisor, so keep this file serialized.
+  use ExUnit.Case, async: false
 
   alias MingaEditor.UI.Picker
   alias MingaEditor.UI.Picker.Context


### PR DESCRIPTION
# TL;DR
Mouse drag selection now keeps extending when the pointer leaves the visible buffer edge. Edge drags autoscroll vertically and horizontally, stay tied to the originating split, and preserve double/triple-click selection semantics.

Closes #1635

## Context
Issue #1635 covers the missing GUI-style drag selection behavior where long selections should continue past the current viewport, like Doom Emacs and Neovim. The backend drag pipeline previously stopped extending when out-of-bounds mouse coordinates produced no buffer position.

## Changes
- Track the originating window for an active mouse drag, and clear it when the drag ends.
- Route active left-button drag and release events directly through the mouse handler so leaving normal content or focus regions does not strand drag state.
- Add edge-aware drag coordinate handling that clamps to content boundaries while triggering vertical and horizontal autoscroll.
- Preserve selection anchors while reversing horizontal scroll and while crossing split-window boundaries.
- Keep double-click-drag word selection and triple-click-drag line selection working during autoscroll, including a repeated-press fallback regression for TUI-style multi-click detection.
- Stabilize load-sensitive tests that were exposed while proving the full suite green.

## Verification
- `make lint` ✅
- `mix test.llm` ✅, `PASS: 52 doctests, 97 properties, 8701 tests, 0 failures, 5 skipped, 118 excluded`
- Parent-orchestrated review loop ✅
- Final reviewer ✅
- Test-advisor reviewed the viewport/mouse test strategy and the auto-save/save-all dirty flake root cause.

## Acceptance Criteria Addressed
- Dragging below the visible buffer content scrolls downward and continues extending the active selection. ✅
- Dragging above the visible buffer content scrolls upward and continues extending the active selection. ✅
- Dragging past the right side of a horizontally scrollable line advances horizontal scroll and extends the selection to newly visible text. ✅
- Dragging back toward the left side reverses horizontal scroll without losing the selection anchor. ✅
- Dragging near split-window edges keeps the selection associated with the originating window unless the user begins a new click in another window. ✅
- Double-click-drag keeps extending by word boundaries while autoscrolling, and triple-click-drag keeps extending by line boundaries while autoscrolling. ✅
- Tiny same-cell drag jitter after a click still does not enter visual mode. ✅
