### PR TITLE
fix(editor): resolve compile warnings

### DIFF
--- a/lib/minga/parser/manager.ex
+++ b/lib/minga/parser/manager.ex
@@ -805,8 +805,6 @@ defmodule Minga.Parser.Manager do
   end
 
   @spec resync_all_buffers(State.t()) :: State.t()
-  defp resync_all_buffers(%{port: nil} = state), do: state
-
   defp resync_all_buffers(state) do
     buffer_count = map_size(state.buffer_registry)
 

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -1613,7 +1613,7 @@ defmodule MingaAgent.Providers.Native do
     :exit, _ -> false
   end
 
-  @spec emit_plan_mode_refusal(pid() | nil, String.t()) :: :ok
+  @spec emit_plan_mode_refusal(pid(), String.t()) :: :ok
   defp emit_plan_mode_refusal(session_pid, message) when is_pid(session_pid) do
     send(
       session_pid,
@@ -1622,8 +1622,6 @@ defmodule MingaAgent.Providers.Native do
 
     :ok
   end
-
-  defp emit_plan_mode_refusal(_session_pid, _message), do: :ok
 
   @spec execute_found_tool(ReqLLM.Tool.t(), map(), pid() | nil) :: {String.t(), boolean()}
   defp execute_found_tool(_tool, %{name: "shell"} = tool_call, provider_pid)

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -595,33 +595,33 @@ defmodule MingaEditor do
 
   # LSP async response — route to the appropriate handler based on lsp.pending
   def handle_info({:lsp_response, ref, result}, state) do
-    case Map.pop(state.workspace.lsp_pending, ref) do
-      {:completion_resolve, pending} ->
-        new_state = set_lsp_pending(state, pending)
+    case Map.fetch(state.workspace.lsp_pending, ref) do
+      {:ok, :completion_resolve} ->
+        new_state = delete_lsp_pending(state, ref)
         new_state = CompletionHandling.handle_resolve_response(new_state, result)
         {:noreply, Renderer.render_or_async(new_state)}
 
-      {:signature_help, pending} ->
-        new_state = set_lsp_pending(state, pending)
+      {:ok, :signature_help} ->
+        new_state = delete_lsp_pending(state, ref)
         new_state = CompletionHandling.handle_signature_help_response(new_state, result)
         {:noreply, Renderer.render_or_async(new_state)}
 
-      {{:semantic_tokens, buf_pid}, pending} ->
-        new_state = set_lsp_pending(state, pending)
+      {:ok, {:semantic_tokens, buf_pid}} ->
+        new_state = delete_lsp_pending(state, ref)
         new_state = SemanticTokenSync.handle_response(new_state, buf_pid, result)
         {:noreply, Renderer.render_or_async(new_state)}
 
-      {kind, pending} when is_atom(kind) ->
-        new_state = set_lsp_pending(state, pending)
+      {:ok, kind} when is_atom(kind) ->
+        new_state = delete_lsp_pending(state, ref)
         new_state = dispatch_lsp_response(kind, new_state, result)
         {:noreply, Renderer.render_or_async(new_state)}
 
-      {kind, pending} when is_tuple(kind) ->
-        new_state = set_lsp_pending(state, pending)
+      {:ok, kind} when is_tuple(kind) ->
+        new_state = delete_lsp_pending(state, ref)
         new_state = dispatch_lsp_response(kind, new_state, result)
         {:noreply, Renderer.render_or_async(new_state)}
 
-      {nil, _} ->
+      :error ->
         # Not a tracked request — try completion handler
         handle_lsp_completion_response(ref, result, state)
     end
@@ -1270,6 +1270,11 @@ defmodule MingaEditor do
   @spec set_lsp_pending(state(), %{reference() => atom() | tuple()}) :: state()
   defp set_lsp_pending(state, pending) do
     EditorState.update_workspace(state, &WorkspaceState.set_lsp_pending(&1, pending))
+  end
+
+  @spec delete_lsp_pending(state(), reference()) :: state()
+  defp delete_lsp_pending(state, ref) do
+    set_lsp_pending(state, Map.delete(state.workspace.lsp_pending, ref))
   end
 
   # Dispatches an LSP response to the appropriate handler based on the kind atom.

--- a/lib/minga_editor/frontend/emit/gui.ex
+++ b/lib/minga_editor/frontend/emit/gui.ex
@@ -421,9 +421,7 @@ defmodule MingaEditor.Frontend.Emit.GUI do
   @spec file_tree_focused?(map()) :: boolean()
   defp file_tree_focused?(file_tree), do: Map.get(file_tree, :focused, false)
 
-  @spec dirty_paths(MingaEditor.State.Buffers.t() | nil) :: MapSet.t(String.t())
-  defp dirty_paths(nil), do: MapSet.new()
-
+  @spec dirty_paths(MingaEditor.State.Buffers.t()) :: MapSet.t(String.t())
   defp dirty_paths(%{list: buffer_list}) do
     buffer_list
     |> Enum.flat_map(&dirty_buffer_path/1)

--- a/lib/minga_editor/frontend/emit/tui.ex
+++ b/lib/minga_editor/frontend/emit/tui.ex
@@ -90,10 +90,13 @@ defmodule MingaEditor.Frontend.Emit.TUI do
     end
   end
 
-  # Kill switch for the scroll region optimization. Set to true to re-enable
-  # once the libvaxis buffer sync issue is resolved.
+  # Kill switch for the scroll region optimization. Set
+  # `config :minga, :tui_scroll_optimization, true` to re-enable once the
+  # libvaxis buffer sync issue is resolved.
   @spec scroll_optimization_enabled?() :: boolean()
-  defp scroll_optimization_enabled?, do: false
+  defp scroll_optimization_enabled? do
+    Application.get_env(:minga, :tui_scroll_optimization, false) == true
+  end
 
   @spec detect_scroll_regions_impl(ctx(), Caches.t()) :: [scroll_delta()] | nil
   defp detect_scroll_regions_impl(ctx, caches) do


### PR DESCRIPTION
# TL;DR
Fixes the new compile-time reachability warnings by removing impossible fallback clauses and preserving the untracked LSP response path with an explicit fetch/delete flow.

## Context
Elixir's newer type warnings flagged several clauses that could never match in editor, frontend emit, agent provider, and parser manager code. This PR narrows the affected helper specs and control flow so `mix compile --warnings-as-errors` stays clean.

## Changes
- Switched LSP response handling from `Map.pop/2` pattern matching to `Map.fetch/2` plus explicit pending-request deletion, keeping unknown responses routed to the completion fallback.
- Removed unreachable fallback clauses where callers already guarantee non-nil or pid values.
- Converted the TUI scroll optimization kill switch from a literal `false` to an app env flag, so the disabled branch remains intentional without producing unreachable-code warnings.

## Verification
- `mix compile --warnings-as-errors`
- `mix format --check-formatted lib/minga_editor.ex lib/minga_editor/frontend/emit/gui.ex lib/minga_editor/frontend/emit/tui.ex lib/minga_agent/providers/native.ex lib/minga/parser/manager.ex`
- Final reviewer gate: PASS
