### PR TITLE
feat(cli): add crash-safe debug log flag

### DIFF
--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -155,9 +155,19 @@ defmodule Minga.Application do
     # This only runs when the application is stopping gracefully, not on
     # Editor crashes (where the LoggerHandler stays installed so crash
     # reports flow through the ETS buffer and get replayed on restart).
+    Logger.flush()
+
     case :logger.get_handler_config(:minga_messages) do
       {:ok, _} -> Minga.LoggerHandler.uninstall()
       _ -> :ok
+    end
+
+    case Minga.DebugLog.stop() do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        IO.puts(:stderr, "Failed to stop debug log during shutdown: #{inspect(reason)}")
     end
 
     :ok

--- a/lib/minga/cli.ex
+++ b/lib/minga/cli.ex
@@ -31,6 +31,7 @@ defmodule Minga.CLI do
           view_mode: view_mode(),
           no_context: boolean(),
           config_file: String.t() | nil,
+          debug_log: String.t() | nil,
           headless: boolean(),
           minimal: boolean(),
           node_name: String.t() | nil,
@@ -45,6 +46,7 @@ defmodule Minga.CLI do
     view_mode: :auto,
     no_context: false,
     config_file: nil,
+    debug_log: nil,
     headless: false,
     minimal: false,
     node_name: nil,
@@ -64,8 +66,10 @@ defmodule Minga.CLI do
       {:open, file, flags} ->
         store_startup_flags(flags, file)
 
-        case maybe_start_distribution(flags) do
-          :ok -> launch(flags, file)
+        with :ok <- maybe_start_debug_log(flags),
+             :ok <- maybe_start_distribution(flags) do
+          launch(flags, file)
+        else
           {:error, message} -> abort_startup(message)
         end
 
@@ -227,6 +231,38 @@ defmodule Minga.CLI do
     {:error, "--config requires a path argument\n\n#{usage()}"}
   end
 
+  defp parse_args(["--debug-log", <<"--", _::binary>> | _], _file, _flags) do
+    {:error, "--debug-log requires a path argument, not a flag\n\n#{usage()}"}
+  end
+
+  defp parse_args(["--debug-log", "" | _], _file, _flags) do
+    {:error, "--debug-log requires a non-empty path argument\n\n#{usage()}"}
+  end
+
+  defp parse_args(["--debug-log", path | rest], file, flags) when is_binary(path) do
+    parse_args(rest, file, %{flags | debug_log: Path.expand(path)})
+  end
+
+  defp parse_args(["--debug-log"], _file, _flags) do
+    {:error, "--debug-log requires a path argument\n\n#{usage()}"}
+  end
+
+  defp parse_args(["-D", <<"--", _::binary>> | _], _file, _flags) do
+    {:error, "-D requires a path argument, not a flag\n\n#{usage()}"}
+  end
+
+  defp parse_args(["-D", "" | _], _file, _flags) do
+    {:error, "-D requires a non-empty path argument\n\n#{usage()}"}
+  end
+
+  defp parse_args(["-D", path | rest], file, flags) when is_binary(path) do
+    parse_args(rest, file, %{flags | debug_log: Path.expand(path)})
+  end
+
+  defp parse_args(["-D"], _file, _flags) do
+    {:error, "-D requires a path argument\n\n#{usage()}"}
+  end
+
   defp parse_args(["--minimal" | rest], file, flags) do
     parse_args(rest, file, %{flags | minimal: true})
   end
@@ -283,6 +319,47 @@ defmodule Minga.CLI do
     end
 
     :ok
+  end
+
+  @spec maybe_start_debug_log(flags()) :: :ok | {:error, String.t()}
+  defp maybe_start_debug_log(%{debug_log: nil}), do: :ok
+
+  defp maybe_start_debug_log(%{debug_log: path}) when is_binary(path) do
+    case Minga.DebugLog.start(path) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, {:debug_log_unwritable, ^path, reason}} ->
+        {:error, debug_log_error(path, reason)}
+
+      {:error, {:debug_log_init_failed, ^path, reason}} ->
+        {:error, debug_log_init_error(path, reason)}
+
+      {:error, {:debug_log_init_failed, ^path, reason, {:close_failed, close_reason}}} ->
+        {:error, debug_log_init_error(path, reason, close_reason)}
+
+      {:error, {:debug_log_already_started, existing_path, ^path}} ->
+        {:error, "Debug log is already writing to #{existing_path}, not #{path}"}
+
+      {:error, reason} ->
+        {:error, "Failed to start debug log #{path}: #{inspect(reason)}"}
+    end
+  end
+
+  @spec debug_log_error(String.t(), term()) :: String.t()
+  defp debug_log_error(path, reason) do
+    "Debug log path is not writable: #{path} (#{inspect(reason)})"
+  end
+
+  @spec debug_log_init_error(String.t(), term(), term() | nil) :: String.t()
+  defp debug_log_init_error(path, reason, close_reason \\ nil) do
+    message = "Debug log could not initialize at #{path}: #{inspect(reason)}"
+
+    if close_reason == nil do
+      message
+    else
+      "#{message} (cleanup failed: #{inspect(close_reason)})"
+    end
   end
 
   @spec maybe_start_distribution(flags()) :: :ok | {:error, String.t()}
@@ -482,9 +559,22 @@ defmodule Minga.CLI do
   @spec abort_startup(String.t()) :: no_return()
   defp abort_startup(message) do
     Minga.Log.error(:editor, message)
+    Logger.flush()
+    flush_debug_log()
     IO.puts(:stderr, message)
     System.stop(1)
     exit({:shutdown, 1})
+  end
+
+  @spec flush_debug_log() :: :ok
+  defp flush_debug_log do
+    case Minga.DebugLog.stop() do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        IO.puts(:stderr, "Failed to stop debug log before shutdown: #{inspect(reason)}")
+    end
   end
 
   @doc "Applies flag implications to a flags map."
@@ -521,7 +611,19 @@ defmodule Minga.CLI do
   defp store_startup_flags(flags, file) do
     effective = apply_flag_implications(flags, file)
     Application.put_env(:minga, :cli_startup_flags, effective)
+    store_debug_log_path(effective.debug_log)
     if effective.minimal, do: Application.put_env(:minga, :minimal_mode, true)
+    :ok
+  end
+
+  @spec store_debug_log_path(String.t() | nil) :: :ok
+  defp store_debug_log_path(nil) do
+    Application.delete_env(:minga, :debug_log_path)
+    :ok
+  end
+
+  defp store_debug_log_path(path) when is_binary(path) do
+    Application.put_env(:minga, :debug_log_path, path)
     :ok
   end
 
@@ -536,6 +638,7 @@ defmodule Minga.CLI do
       -h, --help             Show this help message
       -v, --version          Show version
       --config <path>        Use a custom config file instead of the default
+      -D, --debug-log <path> Append *Messages* and *Warnings* entries to a crash-safe log
       --editor               Start in file editing mode (skip agentic view)
       --minimal              Minimal mode: editor-only, no services/agent (for GIT_EDITOR use)
       --no-context           Keep agentic view and don't load the file as agent context
@@ -554,6 +657,7 @@ defmodule Minga.CLI do
       minga --editor README.md           Open file in traditional editor
       MINGA_COOKIE=$(openssl rand -base64 32 | tr -d '/+=') minga --headless   Start detachable agent server
       minga --config ~/minimal.exs       Use a custom config profile
+      minga -D /tmp/minga-debug.log      Persist messages and warnings for crash forensics
     """
   end
 

--- a/lib/minga/debug_log.ex
+++ b/lib/minga/debug_log.ex
@@ -1,0 +1,576 @@
+defmodule Minga.DebugLog do
+  @moduledoc """
+  Crash-safe debug log writer for `*Messages*` and `*Warnings*` entries.
+
+  The process subscribes to `:log_message` events and appends each event to a file. Writes are buffered for a short debounce window so bursts only force one disk sync, while isolated messages still reach disk quickly.
+  """
+
+  use GenServer
+
+  alias Minga.Events
+  alias Minga.Events.LogMessageEvent
+
+  @default_flush_after 50
+  @default_registry_retry_after 50
+
+  @typedoc "Registry process name that the debug log subscribes to."
+  @type registry :: Events.registry()
+
+  @typedoc "Options for starting a debug log writer."
+  @type start_opt ::
+          {:name, atom() | nil}
+          | {:path, path()}
+          | {:registry, registry()}
+          | {:registry_retry_after, pos_integer()}
+          | {:flush_after, pos_integer()}
+
+  @type start_opts :: [start_opt()]
+  @type fd :: :file.io_device()
+  @type path :: String.t()
+  @type timer :: {reference(), reference()}
+  @type registry_ref :: reference() | nil
+  @type registry_pid :: pid() | nil
+  @type registry_retry :: timer() | nil
+  @type t :: %__MODULE__{
+          path: path(),
+          fd: fd(),
+          buffer: iodata(),
+          timer: timer() | nil,
+          flush_after: pos_integer(),
+          registry: registry(),
+          registry_pid: registry_pid(),
+          registry_ref: registry_ref(),
+          registry_retry: registry_retry(),
+          registry_retry_after: pos_integer(),
+          registry_gap_open: boolean(),
+          registry_retry_reported: boolean()
+        }
+
+  @enforce_keys [
+    :path,
+    :fd,
+    :flush_after,
+    :registry,
+    :registry_pid,
+    :registry_ref,
+    :registry_retry_after
+  ]
+  defstruct [
+    :path,
+    :fd,
+    :timer,
+    :flush_after,
+    :registry,
+    :registry_pid,
+    :registry_ref,
+    :registry_retry,
+    :registry_retry_after,
+    :registry_gap_open,
+    :registry_retry_reported,
+    buffer: []
+  ]
+
+  @doc "Starts the debug log writer without linking it to the caller."
+  @spec start(path() | start_opts()) :: GenServer.on_start() | :ignore
+  def start(path) when is_binary(path), do: start(path: path)
+
+  def start(opts) when is_list(opts) do
+    case Keyword.get(opts, :path, Application.get_env(:minga, :debug_log_path)) do
+      nil ->
+        :ignore
+
+      path when is_binary(path) ->
+        start_impl(Path.expand(path), opts, :nolink)
+    end
+  end
+
+  @doc "Returns a child-linked debug log writer for tests or narrow supervision use."
+  @spec start_link(path() | start_opts()) :: GenServer.on_start() | :ignore
+  def start_link(path) when is_binary(path), do: start_link(path: path)
+
+  def start_link(opts) when is_list(opts) do
+    case Keyword.get(opts, :path, Application.get_env(:minga, :debug_log_path)) do
+      nil ->
+        :ignore
+
+      path when is_binary(path) ->
+        start_impl(Path.expand(path), opts, :link)
+    end
+  end
+
+  @doc "Stops the named debug log writer if it is running."
+  @spec stop() :: :ok | {:error, term()}
+  def stop do
+    case Process.whereis(__MODULE__) do
+      nil ->
+        case configured_path() do
+          nil -> :ok
+          path -> {:error, {:debug_log_not_running, path}}
+        end
+
+      pid ->
+        stop(pid)
+    end
+  end
+
+  @doc "Stops a debug log writer."
+  @spec stop(GenServer.server()) :: :ok | {:error, term()}
+  def stop(server) do
+    flush_result = flush(server)
+    stop_result = stop_server(server)
+    resolve_stop_result(flush_result, stop_result)
+  end
+
+  @doc "Synchronously flushes the named debug log writer when it is running."
+  @spec flush() :: :ok | {:error, term()}
+  def flush do
+    case Process.whereis(__MODULE__) do
+      nil ->
+        case configured_path() do
+          nil -> :ok
+          path -> {:error, {:debug_log_not_running, path}}
+        end
+
+      pid ->
+        flush(pid)
+    end
+  end
+
+  @doc "Synchronously flushes a debug log writer."
+  @spec flush(GenServer.server()) :: :ok | {:error, term()}
+  def flush(server) do
+    GenServer.call(server, :flush, 5_000)
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  @doc "Returns the path used by a running debug log writer."
+  @spec path(GenServer.server()) :: path()
+  def path(server), do: GenServer.call(server, :path)
+
+  @impl true
+  @spec init({path(), keyword()}) :: {:ok, t()} | {:stop, term()}
+  def init({path, opts}) do
+    Process.flag(:trap_exit, true)
+
+    case File.open(path, [:append, :binary]) do
+      {:ok, fd} ->
+        case write_and_sync(fd, session_header()) do
+          :ok ->
+            init_registry(path, fd, opts)
+
+          {:error, reason} ->
+            stop_init(path, fd, {:debug_log_session_header_failed, path, reason})
+        end
+
+      {:error, reason} ->
+        {:stop, {:debug_log_unwritable, path, reason}}
+    end
+  end
+
+  @impl true
+  @spec handle_call(:flush | :path, GenServer.from(), t()) ::
+          {:reply, :ok | {:error, term()} | path(), t()} | {:stop, term(), {:error, term()}, t()}
+  def handle_call(:flush, _from, state) do
+    case flush_buffer(state) do
+      {:ok, state} ->
+        {:reply, :ok, state}
+
+      {{:error, reason}, state} ->
+        {:stop, {:debug_log_write_failed, state.path, reason}, {:error, reason}, state}
+    end
+  end
+
+  def handle_call(:path, _from, state), do: {:reply, state.path, state}
+
+  @impl true
+  @spec handle_info(term(), t()) :: {:noreply, t()} | {:stop, term(), t()}
+  def handle_info({:minga_event, :log_message, %LogMessageEvent{} = event}, state) do
+    state = append_event(state, event)
+    {:noreply, reset_flush_timer(state)}
+  end
+
+  def handle_info(
+        {:retry_registry_subscription, token},
+        %__MODULE__{registry_retry: {_, token}} = state
+      ) do
+    retry_registry_subscription(%{state | registry_retry: nil})
+  end
+
+  def handle_info({:retry_registry_subscription, _stale_token}, state), do: {:noreply, state}
+
+  def handle_info(
+        {:DOWN, ref, :process, pid, reason},
+        %__MODULE__{registry_ref: ref, registry_pid: pid} = state
+      ) do
+    handle_registry_down(state, reason)
+  end
+
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state), do: {:noreply, state}
+
+  def handle_info({:flush, token}, %__MODULE__{timer: {_, token}} = state) do
+    flush_state(state)
+  end
+
+  def handle_info({:flush, _stale_token}, state), do: {:noreply, state}
+  def handle_info(:flush, state), do: flush_state(state)
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  @impl true
+  @spec terminate(term(), t()) :: :ok
+  def terminate(_reason, %__MODULE__{} = state) do
+    flush_result = write_buffer(state.buffer, state.fd)
+    close_result = File.close(state.fd)
+    report_terminate_result(flush_result, close_result, state.path)
+  end
+
+  @spec start_impl(path(), keyword(), :link | :nolink) :: GenServer.on_start()
+  defp start_impl(path, opts, mode) do
+    name = Keyword.get(opts, :name, __MODULE__)
+
+    case existing_pid(name) do
+      nil ->
+        do_start(path, opts, mode, name)
+
+      pid ->
+        ensure_same_path(pid, path)
+    end
+  end
+
+  @spec existing_pid(atom() | nil) :: pid() | nil
+  defp existing_pid(nil), do: nil
+  defp existing_pid(name) when is_atom(name), do: Process.whereis(name)
+
+  @spec do_start(path(), keyword(), :link | :nolink, atom() | nil) :: GenServer.on_start()
+  defp do_start(path, opts, :link, name) do
+    GenServer.start_link(__MODULE__, {path, opts}, genserver_opts(name))
+  end
+
+  defp do_start(path, opts, :nolink, name) do
+    GenServer.start(__MODULE__, {path, opts}, genserver_opts(name))
+  end
+
+  @spec ensure_same_path(pid(), path()) :: {:ok, pid()} | {:error, term()}
+  defp ensure_same_path(pid, requested_path) do
+    ensure_same_path(pid, path(pid), requested_path)
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  @spec ensure_same_path(pid(), path(), path()) :: {:ok, pid()} | {:error, term()}
+  defp ensure_same_path(pid, path, path), do: {:ok, pid}
+
+  defp ensure_same_path(_pid, existing_path, requested_path) do
+    {:error, {:debug_log_already_started, existing_path, requested_path}}
+  end
+
+  @spec genserver_opts(atom() | nil) :: GenServer.options()
+  defp genserver_opts(nil), do: []
+  defp genserver_opts(name) when is_atom(name), do: [name: name]
+
+  @spec init_registry(path(), fd(), keyword()) :: {:ok, t()} | {:stop, term()}
+  defp init_registry(path, fd, opts) do
+    registry = Keyword.get(opts, :registry, Events.default_registry())
+    flush_after = Keyword.get(opts, :flush_after, @default_flush_after)
+    retry_after = Keyword.get(opts, :registry_retry_after, @default_registry_retry_after)
+
+    case attach_registry(registry) do
+      {:ok, registry_pid, registry_ref} ->
+        {:ok,
+         %__MODULE__{
+           path: path,
+           fd: fd,
+           flush_after: flush_after,
+           registry: registry,
+           registry_pid: registry_pid,
+           registry_ref: registry_ref,
+           registry_retry_after: retry_after,
+           registry_gap_open: false,
+           registry_retry_reported: false
+         }}
+
+      {:error, reason} ->
+        stop_init(path, fd, reason)
+    end
+  end
+
+  @spec attach_registry(registry()) :: {:ok, pid(), reference()} | {:error, term()}
+  defp attach_registry(registry) do
+    case Process.whereis(registry) do
+      nil ->
+        {:error, {:debug_log_events_registry_unavailable, registry}}
+
+      pid ->
+        subscribe_to_registry(registry, pid)
+    end
+  end
+
+  @spec subscribe_to_registry(registry(), pid()) :: {:ok, pid(), reference()} | {:error, term()}
+  defp subscribe_to_registry(registry, pid) do
+    Events.subscribe(:log_message, registry)
+
+    if subscribed_to_registry?(registry) do
+      {:ok, pid, Process.monitor(pid)}
+    else
+      {:error, {:debug_log_events_subscription_failed, registry}}
+    end
+  rescue
+    error -> {:error, {:debug_log_events_subscription_failed, registry, error}}
+  catch
+    :exit, reason -> {:error, {:debug_log_events_subscription_failed, registry, reason}}
+  end
+
+  @spec subscribed_to_registry?(registry()) :: boolean()
+  defp subscribed_to_registry?(registry) do
+    Enum.any?(Events.subscribers(:log_message, registry), &(&1 == self()))
+  end
+
+  @spec retry_registry_subscription(t()) :: {:noreply, t()} | {:stop, term(), t()}
+  defp retry_registry_subscription(%__MODULE__{} = state) do
+    case attach_registry(state.registry) do
+      {:ok, registry_pid, registry_ref} ->
+        case maybe_write_registry_status_marker(
+               state,
+               "events registry re-subscribed; missed events may exist"
+             ) do
+          {:ok, state} ->
+            {:noreply,
+             %{
+               state
+               | registry_pid: registry_pid,
+                 registry_ref: registry_ref,
+                 registry_retry: nil,
+                 registry_gap_open: false,
+                 registry_retry_reported: false
+             }}
+
+          {:error, reason} ->
+            {:stop, {:debug_log_write_failed, state.path, reason}, state}
+        end
+
+      {:error, reason} ->
+        case maybe_write_registry_retry_failure(state, reason) do
+          {:ok, state} ->
+            {:noreply, schedule_registry_retry(%{state | registry_pid: nil, registry_ref: nil})}
+
+          {:error, write_reason} ->
+            {:stop, {:debug_log_write_failed, state.path, write_reason}, state}
+        end
+    end
+  end
+
+  @spec handle_registry_down(t(), term()) :: {:noreply, t()} | {:stop, term(), t()}
+  defp handle_registry_down(%__MODULE__{} = state, reason) do
+    state =
+      %{
+        state
+        | registry_pid: nil,
+          registry_ref: nil,
+          registry_gap_open: true,
+          registry_retry_reported: false
+      }
+
+    case maybe_write_registry_status_marker(state, "events registry down: #{inspect(reason)}") do
+      {:ok, state} ->
+        {:noreply, schedule_registry_retry(state)}
+
+      {:error, write_reason} ->
+        {:stop, {:debug_log_write_failed, state.path, write_reason}, state}
+    end
+  end
+
+  @spec maybe_write_registry_retry_failure(t(), term()) :: {:ok, t()} | {:error, term()}
+  defp maybe_write_registry_retry_failure(%__MODULE__{} = state, reason) do
+    if state.registry_gap_open and not state.registry_retry_reported do
+      case maybe_write_registry_status_marker(
+             state,
+             "events registry retry failed: #{inspect(reason)}"
+           ) do
+        {:ok, state} -> {:ok, %{state | registry_retry_reported: true}}
+        {:error, write_reason} -> {:error, write_reason}
+      end
+    else
+      {:ok, state}
+    end
+  end
+
+  @spec maybe_write_registry_status_marker(t(), String.t()) :: {:ok, t()} | {:error, term()}
+  defp maybe_write_registry_status_marker(%__MODULE__{} = state, message) do
+    case flush_buffer(state) do
+      {:ok, state} ->
+        case write_registry_marker(state.fd, message) do
+          :ok -> {:ok, state}
+          {:error, reason} -> {:error, reason}
+        end
+
+      {{:error, reason}, _state} ->
+        {:error, reason}
+    end
+  end
+
+  @spec write_registry_marker(fd(), String.t()) :: :ok | {:error, term()}
+  defp write_registry_marker(fd, message) do
+    write_and_sync(fd, [registry_marker_prefix(), message, "\n"])
+  end
+
+  @spec registry_marker_prefix() :: String.t()
+  defp registry_marker_prefix, do: "[debug-log] "
+
+  @spec schedule_registry_retry(t()) :: t()
+  defp schedule_registry_retry(%__MODULE__{} = state) do
+    cancel_registry_retry(state.registry_retry)
+    token = make_ref()
+
+    timer_ref =
+      Process.send_after(
+        self(),
+        {:retry_registry_subscription, token},
+        state.registry_retry_after
+      )
+
+    %{state | registry_retry: {timer_ref, token}}
+  end
+
+  @spec cancel_registry_retry(registry_retry()) :: :ok
+  defp cancel_registry_retry(nil), do: :ok
+
+  defp cancel_registry_retry({timer_ref, _token}) when is_reference(timer_ref) do
+    Process.cancel_timer(timer_ref, async: false, info: false)
+    :ok
+  end
+
+  @spec stop_init(path(), fd(), term()) :: {:stop, term()}
+  defp stop_init(path, fd, reason) do
+    case File.close(fd) do
+      :ok ->
+        {:stop, {:debug_log_init_failed, path, reason}}
+
+      {:error, close_reason} ->
+        {:stop, {:debug_log_init_failed, path, reason, {:close_failed, close_reason}}}
+    end
+  end
+
+  @spec append_event(t(), LogMessageEvent.t()) :: t()
+  defp append_event(%__MODULE__{buffer: buffer} = state, %LogMessageEvent{} = event) do
+    %{state | buffer: [buffer, format_event(event)]}
+  end
+
+  @spec reset_flush_timer(t()) :: t()
+  defp reset_flush_timer(%__MODULE__{} = state) do
+    cancel_timer(state.timer)
+    token = make_ref()
+    timer_ref = Process.send_after(self(), {:flush, token}, state.flush_after)
+    %{state | timer: {timer_ref, token}}
+  end
+
+  @spec cancel_timer(timer() | nil) :: :ok
+  defp cancel_timer(nil), do: :ok
+
+  defp cancel_timer({timer_ref, _token}) when is_reference(timer_ref) do
+    Process.cancel_timer(timer_ref, async: false, info: false)
+    :ok
+  end
+
+  @spec flush_state(t()) :: {:noreply, t()} | {:stop, term(), t()}
+  defp flush_state(state) do
+    case flush_buffer(state) do
+      {:ok, state} -> {:noreply, state}
+      {{:error, reason}, state} -> {:stop, {:debug_log_write_failed, state.path, reason}, state}
+    end
+  end
+
+  @spec flush_buffer(t()) :: {:ok, t()} | {{:error, term()}, t()}
+  defp flush_buffer(%__MODULE__{buffer: []} = state), do: {:ok, %{state | timer: nil}}
+
+  defp flush_buffer(%__MODULE__{fd: fd, buffer: buffer} = state) do
+    case write_buffer(buffer, fd) do
+      :ok -> {:ok, %{state | buffer: [], timer: nil}}
+      {:error, reason} -> {{:error, reason}, state}
+    end
+  end
+
+  @spec write_buffer(iodata(), fd()) :: :ok | {:error, term()}
+  defp write_buffer([], _fd), do: :ok
+  defp write_buffer(buffer, fd), do: write_and_sync(fd, buffer)
+
+  @spec write_and_sync(fd(), iodata()) :: :ok | {:error, term()}
+  defp write_and_sync(fd, data) do
+    case :file.write(fd, data) do
+      :ok -> :file.datasync(fd)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @spec stop_server(GenServer.server()) :: :ok | {:error, term()}
+  defp stop_server(server) do
+    GenServer.stop(server)
+    :ok
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  @spec resolve_stop_result(:ok | {:error, term()}, :ok | {:error, term()}) ::
+          :ok | {:error, term()}
+  defp resolve_stop_result(:ok, :ok), do: :ok
+  defp resolve_stop_result(:ok, {:error, :noproc}), do: :ok
+  defp resolve_stop_result(:ok, {:error, {:noproc, _}}), do: :ok
+  defp resolve_stop_result(:ok, {:error, reason}), do: {:error, reason}
+  defp resolve_stop_result({:error, :noproc}, _stop_result), do: :ok
+  defp resolve_stop_result({:error, {:noproc, _}}, _stop_result), do: :ok
+  defp resolve_stop_result({:error, reason}, _stop_result), do: {:error, reason}
+
+  @spec configured_path() :: path() | nil
+  defp configured_path, do: Application.get_env(:minga, :debug_log_path)
+
+  @spec report_terminate_result(:ok | {:error, term()}, :ok | {:error, term()}, path()) :: :ok
+  defp report_terminate_result(:ok, :ok, _path), do: :ok
+
+  defp report_terminate_result({:error, reason}, close_result, path) do
+    IO.puts(:stderr, "Debug log final flush failed for #{path}: #{inspect(reason)}")
+    report_close_result(close_result, path)
+  end
+
+  defp report_terminate_result(:ok, close_result, path),
+    do: report_close_result(close_result, path)
+
+  @spec report_close_result(:ok | {:error, term()}, path()) :: :ok
+  defp report_close_result(:ok, _path), do: :ok
+
+  defp report_close_result({:error, reason}, path) do
+    IO.puts(:stderr, "Debug log close failed for #{path}: #{inspect(reason)}")
+    :ok
+  end
+
+  @spec format_event(LogMessageEvent.t()) :: iodata()
+  defp format_event(%LogMessageEvent{text: text, level: :warning}), do: lines(text, "[WARNING] ")
+  defp format_event(%LogMessageEvent{text: text, level: :error}), do: lines(text, "[ERROR] ")
+  defp format_event(%LogMessageEvent{text: text}), do: lines(text, "")
+
+  @spec lines(String.t(), String.t()) :: iodata()
+  defp lines(text, prefix) do
+    text
+    |> String.trim_trailing("\n")
+    |> String.split("\n")
+    |> Enum.map(fn line -> [prefix, line, "\n"] end)
+  end
+
+  @spec session_header() :: iodata()
+  defp session_header do
+    [
+      "\n--- Minga debug log session ---\n",
+      "Minga ",
+      Minga.version(),
+      " | Elixir ",
+      System.version(),
+      " | OTP ",
+      otp_release(),
+      " | ",
+      DateTime.utc_now() |> DateTime.to_iso8601(),
+      "\n"
+    ]
+  end
+
+  @spec otp_release() :: String.t()
+  defp otp_release, do: :erlang.system_info(:otp_release) |> List.to_string()
+end

--- a/lib/minga/log.ex
+++ b/lib/minga/log.ex
@@ -149,16 +149,19 @@ defmodule Minga.Log do
     msg_priority = Map.fetch!(@level_priority, level)
 
     if otp_priority > msg_priority do
-      event_level = if level in [:warning, :error], do: :warning, else: :info
-
       Minga.Events.broadcast(:log_message, %Minga.Events.LogMessageEvent{
         text: "[#{subsystem}/#{level}] " <> message,
-        level: event_level
+        level: event_level(level)
       })
     end
 
     :ok
   end
+
+  @spec event_level(level()) :: Minga.Events.LogMessageEvent.level()
+  defp event_level(:error), do: :error
+  defp event_level(:warning), do: :warning
+  defp event_level(_level), do: :info
 
   @spec safe_get_option(Minga.Config.option_name()) :: atom()
   defp safe_get_option(name) do

--- a/lib/minga/logger_handler.ex
+++ b/lib/minga/logger_handler.ex
@@ -184,16 +184,19 @@ defmodule Minga.LoggerHandler do
     # yet (Minga.Log.MessagesBuffer hasn't booted). Once the wrapper subscribes,
     # broadcasts reach it directly and the ETS buffer is drained on its init.
     if has_subscribers?() do
-      event_level = if level in [:warning, :error], do: :warning, else: :info
-
       Minga.Events.broadcast(:log_message, %Minga.Events.LogMessageEvent{
         text: text,
-        level: event_level
+        level: event_level(level)
       })
     else
       buffer_message(text, level)
     end
   end
+
+  @spec event_level(atom()) :: Minga.Events.LogMessageEvent.level()
+  defp event_level(level) when level in [:error, :critical, :alert, :emergency], do: :error
+  defp event_level(:warning), do: :warning
+  defp event_level(_level), do: :info
 
   @spec has_subscribers?() :: boolean()
   defp has_subscribers? do

--- a/test/minga/cli_test.exs
+++ b/test/minga/cli_test.exs
@@ -4,6 +4,14 @@ defmodule Minga.CLITest do
 
   alias Minga.CLI
 
+  setup do
+    if Process.whereis(Minga.EventBus) == nil do
+      start_supervised!(Minga.Events.child_spec(name: Minga.EventBus))
+    end
+
+    :ok
+  end
+
   describe "parse_args/1" do
     test "no arguments returns {:open, nil, default_flags}" do
       assert {:open, nil, %{view_mode: :auto, no_context: false, config_file: nil}} =
@@ -118,6 +126,54 @@ defmodule Minga.CLITest do
       assert message =~ "--config"
     end
 
+    test "--debug-log sets expanded debug log path" do
+      assert {:open, nil, %{debug_log: path}} =
+               CLI.parse_args(["--debug-log", "~/minga-debug.log"])
+
+      assert path == Path.expand("~/minga-debug.log")
+    end
+
+    test "-D sets expanded debug log path" do
+      assert {:open, nil, %{debug_log: path}} = CLI.parse_args(["-D", "debug.log"])
+      assert path == Path.expand("debug.log")
+    end
+
+    test "--debug-log without a following argument returns error" do
+      assert {:error, message} = CLI.parse_args(["--debug-log"])
+      assert message =~ "--debug-log requires a path argument"
+    end
+
+    test "--debug-log followed by another flag returns error" do
+      assert {:error, message} = CLI.parse_args(["--debug-log", "--editor"])
+      assert message =~ "--debug-log requires a path argument, not a flag"
+    end
+
+    test "-D followed by another flag returns error" do
+      assert {:error, message} = CLI.parse_args(["-D", "--editor"])
+      assert message =~ "-D requires a path argument, not a flag"
+    end
+
+    test "--debug-log with empty string returns error" do
+      assert {:error, message} = CLI.parse_args(["--debug-log", ""])
+      assert message =~ "--debug-log requires a non-empty path argument"
+    end
+
+    test "-D with empty string returns error" do
+      assert {:error, message} = CLI.parse_args(["-D", ""])
+      assert message =~ "-D requires a non-empty path argument"
+    end
+
+    test "-D without a following argument returns error" do
+      assert {:error, message} = CLI.parse_args(["-D"])
+      assert message =~ "-D requires a path argument"
+    end
+
+    test "--debug-log flag appears in help output" do
+      assert {:error, message} = CLI.parse_args(["--help"])
+      assert message =~ "--debug-log"
+      assert message =~ "-D"
+    end
+
     test "--headless sets headless flag" do
       assert {:open, nil, %{headless: true}} = CLI.parse_args(["--headless"])
     end
@@ -181,11 +237,12 @@ defmodule Minga.CLITest do
       assert message =~ "unknown flag: --unknown"
     end
 
-    test "usage text includes --editor, --no-context, --config, and --minimal" do
+    test "usage text includes --editor, --no-context, --config, --debug-log, and --minimal" do
       assert {:error, message} = CLI.parse_args(["--help"])
       assert message =~ "--editor"
       assert message =~ "--no-context"
       assert message =~ "--config"
+      assert message =~ "--debug-log"
       assert message =~ "--minimal"
     end
 
@@ -251,6 +308,25 @@ defmodule Minga.CLITest do
       assert %{view_mode: :auto, config_file: "/tmp/test_config.exs"} = CLI.startup_flags()
     after
       Application.delete_env(:minga, :cli_startup_flags)
+    end
+
+    test "main stores debug_log path in application env" do
+      path =
+        Path.join(System.tmp_dir!(), "minga_cli_debug_#{System.unique_integer([:positive])}.log")
+
+      Application.delete_env(:minga, :cli_startup_flags)
+
+      CLI.main(["--debug-log", path])
+
+      assert %{debug_log: ^path} = CLI.startup_flags()
+      assert Application.get_env(:minga, :debug_log_path) == path
+    after
+      if pid = Process.whereis(Minga.DebugLog) do
+        assert :ok = Minga.DebugLog.stop(pid)
+      end
+
+      Application.delete_env(:minga, :cli_startup_flags)
+      Application.delete_env(:minga, :debug_log_path)
     end
   end
 

--- a/test/minga/debug_log_test.exs
+++ b/test/minga/debug_log_test.exs
@@ -1,0 +1,344 @@
+defmodule Minga.DebugLogTest do
+  # Not async: DebugLog subscribes to the global Events registry and these tests assert on flat log files.
+  use ExUnit.Case, async: false
+
+  alias Minga.DebugLog
+  alias Minga.Events
+  alias Minga.Events.LogMessageEvent
+  require Logger
+
+  setup do
+    ensure_events_registry()
+
+    dir =
+      Path.join(System.tmp_dir!(), "minga_debug_log_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(dir)
+
+    on_exit(fn -> File.rm_rf(dir) end)
+
+    {:ok, dir: dir}
+  end
+
+  test "start_link creates a file with a session header", %{dir: dir} do
+    path = Path.join(dir, "debug.log")
+    pid = start_debug_log(path)
+
+    assert File.exists?(path)
+    assert File.read!(path) =~ "Minga #{Minga.version()} | Elixir #{System.version()} | OTP"
+
+    stop_debug_log(pid)
+  end
+
+  test "starting an existing named writer reuses the same path and rejects a different path", %{
+    dir: dir
+  } do
+    path = Path.join(dir, "debug.log")
+    other_path = Path.join(dir, "other.log")
+    pid = start_named_debug_log(path)
+
+    assert {:ok, ^pid} = DebugLog.start(path)
+    assert {:error, {:debug_log_already_started, ^path, ^other_path}} = DebugLog.start(other_path)
+
+    stop_debug_log(pid)
+  end
+
+  test "DebugLog.flush/0 writes buffered entries for the named writer", %{dir: dir} do
+    path = Path.join(dir, "debug.log")
+    pid = start_named_debug_log(path)
+    text = unique_text("debug-log-named-flush")
+
+    Events.broadcast(:log_message, %LogMessageEvent{text: text, level: :info})
+    assert :ok = DebugLog.flush()
+
+    assert File.read!(path) =~ text
+
+    stop_debug_log(pid)
+  end
+
+  test "DebugLog.flush/0 reports when a configured path has no running writer", %{dir: dir} do
+    path = Path.join(dir, "debug-log-missing.log")
+    Application.put_env(:minga, :debug_log_path, path)
+
+    assert {:error, {:debug_log_not_running, ^path}} = DebugLog.flush()
+  after
+    Application.delete_env(:minga, :debug_log_path)
+  end
+
+  test "DebugLog.stop/0 reports when a configured path has no running writer", %{dir: dir} do
+    path = Path.join(dir, "debug-log-stop-missing.log")
+    Application.put_env(:minga, :debug_log_path, path)
+
+    assert {:error, {:debug_log_not_running, ^path}} = DebugLog.stop()
+  after
+    Application.delete_env(:minga, :debug_log_path)
+  end
+
+  test "DebugLog.flush/1 writes buffered entries to disk", %{dir: dir} do
+    path = Path.join(dir, "debug.log")
+    pid = start_debug_log(path)
+    text = unique_text("debug-log-info")
+
+    Events.broadcast(:log_message, %LogMessageEvent{text: text, level: :info})
+    assert :ok = DebugLog.flush(pid)
+
+    assert File.read!(path) =~ text
+
+    stop_debug_log(pid)
+  end
+
+  test "DebugLog.stop/0 flushes buffered entries and is benign when already stopped", %{dir: dir} do
+    path = Path.join(dir, "debug.log")
+    _pid = start_named_debug_log(path, flush_after: 60_000)
+    text = unique_text("debug-log-stop-flush")
+
+    Events.broadcast(:log_message, %LogMessageEvent{text: text, level: :info})
+
+    assert :ok = DebugLog.stop()
+    assert File.read!(path) =~ text
+    assert Process.whereis(Minga.DebugLog) == nil
+    assert :ok = DebugLog.stop()
+  end
+
+  test "warning events are prefixed", %{dir: dir} do
+    path = Path.join(dir, "debug.log")
+    pid = start_debug_log(path)
+    text = unique_text("debug-log-warning")
+    second = unique_text("debug-log-warning-second")
+
+    Events.broadcast(:log_message, %LogMessageEvent{text: "#{text}\n#{second}", level: :warning})
+    flush(pid)
+
+    content = File.read!(path)
+    assert content =~ "[WARNING] #{text}"
+    assert content =~ "[WARNING] #{second}"
+
+    stop_debug_log(pid)
+  end
+
+  test "error events preserve error severity", %{dir: dir} do
+    path = Path.join(dir, "debug.log")
+    pid = start_debug_log(path)
+    text = unique_text("debug-log-error")
+
+    Events.broadcast(:log_message, %LogMessageEvent{text: text, level: :error})
+    flush(pid)
+
+    assert File.read!(path) =~ "[ERROR] #{text}"
+
+    stop_debug_log(pid)
+  end
+
+  test "logger error events preserve error severity", %{dir: dir} do
+    path = Path.join(dir, "debug.log")
+    pid = start_debug_log(path)
+    text = unique_text("debug-log-logger-error")
+
+    Logger.error(text)
+    Logger.flush()
+    flush(pid)
+
+    content = File.read!(path)
+    assert content =~ "[ERROR]"
+    assert content =~ text
+
+    stop_debug_log(pid)
+  end
+
+  test "unwritable path returns an error", %{dir: dir} do
+    path = Path.join([dir, "missing", "debug.log"])
+    trap_exit? = Process.flag(:trap_exit, true)
+
+    try do
+      assert {:error, {:debug_log_unwritable, ^path, :enoent}} =
+               DebugLog.start_link(path: path, name: nil)
+    after
+      Process.flag(:trap_exit, trap_exit?)
+    end
+  end
+
+  test "existing files are appended, not truncated", %{dir: dir} do
+    path = Path.join(dir, "debug.log")
+    File.write!(path, "existing debug context\n")
+
+    pid = start_debug_log(path)
+    content = File.read!(path)
+
+    assert content =~ "existing debug context"
+    assert content =~ "--- Minga debug log session ---"
+
+    stop_debug_log(pid)
+  end
+
+  test "rapid messages are buffered until one flush", %{dir: dir} do
+    path = Path.join(dir, "debug.log")
+    pid = start_debug_log(path, flush_after: 60_000)
+    first = unique_text("debug-log-batch-a")
+    second = unique_text("debug-log-batch-b")
+
+    Events.broadcast(:log_message, %LogMessageEvent{text: first, level: :info})
+    Events.broadcast(:log_message, %LogMessageEvent{text: second, level: :info})
+
+    %{buffer: buffer} = :sys.get_state(pid)
+    buffered = IO.iodata_to_binary(buffer)
+
+    assert buffered =~ first
+    assert buffered =~ second
+    refute File.read!(path) =~ first
+
+    flush(pid)
+
+    content = File.read!(path)
+    assert content =~ first
+    assert content =~ second
+
+    stop_debug_log(pid)
+  end
+
+  test "short flush_after writes buffered entries on the real debounce timer", %{dir: dir} do
+    path = Path.join(dir, "debug.log")
+    pid = start_debug_log(path, flush_after: 5)
+    text = unique_text("debug-log-timer-flush")
+
+    Events.broadcast(:log_message, %LogMessageEvent{text: text, level: :info})
+
+    assert eventually_file_contains?(path, text)
+
+    stop_debug_log(pid)
+  end
+
+  test "re-subscribes when the events registry restarts", %{dir: dir} do
+    registry = unique_registry_name()
+    path = Path.join(dir, "debug-retry.log")
+    trap_exit? = Process.flag(:trap_exit, true)
+
+    try do
+      {:ok, registry_pid} = Registry.start_link(keys: :duplicate, name: registry)
+
+      {:ok, pid} =
+        DebugLog.start_link(path: path, name: nil, registry: registry, registry_retry_after: 5)
+
+      first = unique_text("debug-log-registry-before-restart")
+      Events.broadcast(:log_message, %LogMessageEvent{text: first, level: :info}, registry)
+      assert eventually_file_contains?(path, first)
+
+      Process.exit(registry_pid, :kill)
+      assert_receive {:EXIT, ^registry_pid, :killed}
+      :sys.get_state(pid)
+
+      assert eventually_file_contains?(path, "[debug-log] events registry down")
+      assert eventually_file_contains?(path, "[debug-log] events registry retry failed")
+
+      {:ok, _replacement_pid} = restart_registry(registry)
+      assert eventually_subscribed?(registry, pid)
+      assert eventually_file_contains?(path, "[debug-log] events registry re-subscribed")
+
+      second = unique_text("debug-log-registry-after-restart")
+      Events.broadcast(:log_message, %LogMessageEvent{text: second, level: :info}, registry)
+      assert eventually_file_contains?(path, second)
+
+      stop_debug_log(pid)
+    after
+      Process.flag(:trap_exit, trap_exit?)
+    end
+  end
+
+  defp ensure_events_registry do
+    if Process.whereis(Minga.EventBus) == nil do
+      start_supervised!(Minga.Events.child_spec(name: Minga.EventBus))
+    end
+
+    :ok
+  end
+
+  defp start_debug_log(path, opts \\ []) do
+    {:ok, pid} = DebugLog.start_link(Keyword.merge([path: path, name: nil], opts))
+    pid
+  end
+
+  defp start_named_debug_log(path, opts \\ []) do
+    {:ok, pid} = DebugLog.start(Keyword.merge([path: path], opts))
+    pid
+  end
+
+  defp stop_debug_log(pid) do
+    assert :ok = DebugLog.stop(pid)
+  end
+
+  defp flush(pid) do
+    assert :ok = DebugLog.flush(pid)
+  end
+
+  defp eventually_file_contains?(path, text, retries \\ 50)
+
+  defp eventually_file_contains?(_path, _text, 0), do: false
+
+  defp eventually_file_contains?(path, text, retries) when retries > 0 do
+    case File.read(path) do
+      {:ok, content} ->
+        if String.contains?(content, text) do
+          true
+        else
+          receive do
+          after
+            10 -> eventually_file_contains?(path, text, retries - 1)
+          end
+        end
+
+      _ ->
+        receive do
+        after
+          10 -> eventually_file_contains?(path, text, retries - 1)
+        end
+    end
+  end
+
+  defp eventually_subscribed?(registry, pid, retries \\ 50)
+
+  defp eventually_subscribed?(_registry, _pid, 0), do: false
+
+  defp eventually_subscribed?(registry, pid, retries) when retries > 0 do
+    if Enum.any?(Events.subscribers(:log_message, registry), &(&1 == pid)) do
+      true
+    else
+      receive do
+      after
+        10 -> eventually_subscribed?(registry, pid, retries - 1)
+      end
+    end
+  end
+
+  defp restart_registry(registry, retries \\ 50)
+
+  defp restart_registry(registry, 0), do: flunk("registry #{inspect(registry)} did not restart")
+
+  defp restart_registry(registry, retries) when retries > 0 do
+    case Registry.start_link(keys: :duplicate, name: registry) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      {:error, {:already_started, _pid}} ->
+        receive do
+        after
+          10 -> restart_registry(registry, retries - 1)
+        end
+
+      {:error, {:shutdown, {:failed_to_start_child, _child, {:already_started, _pid}}}} ->
+        receive do
+        after
+          10 -> restart_registry(registry, retries - 1)
+        end
+
+      {:error, reason} ->
+        flunk("registry #{inspect(registry)} failed to restart: #{inspect(reason)}")
+    end
+  end
+
+  defp unique_registry_name do
+    String.to_atom("debug_log_registry_#{System.unique_integer([:positive])}")
+  end
+
+  defp unique_text(prefix) do
+    "#{prefix}-#{System.unique_integer([:positive])}"
+  end
+end

--- a/test/minga/log_messages_routing_test.exs
+++ b/test/minga/log_messages_routing_test.exs
@@ -9,6 +9,10 @@ defmodule Minga.LogMessagesRoutingTest do
   setup do
     {:ok, _opts} = Options.start_link(name: :"opts_#{System.unique_integer()}")
 
+    if Process.whereis(Minga.EventBus) == nil do
+      start_supervised!(Minga.Events.child_spec(name: Minga.EventBus))
+    end
+
     on_exit(fn -> Options.reset() end)
 
     :ok
@@ -36,6 +40,29 @@ defmodule Minga.LogMessagesRoutingTest do
 
       assert text =~ "Grammar org registered successfully"
       assert text =~ "[editor/info]"
+    end
+
+    test "Minga.Log.error preserves error severity when Logger suppresses it" do
+      Options.set(:log_level, :info)
+      Options.set(:log_level_editor, :default)
+
+      Events.subscribe(:log_message)
+
+      previous_level = Logger.level()
+      Logger.configure(level: :none)
+
+      on_exit(fn ->
+        Logger.configure(level: previous_level)
+        Events.unsubscribe(:log_message)
+      end)
+
+      Minga.Log.error(:editor, "startup aborted")
+
+      assert_receive {:minga_event, :log_message, %LogMessageEvent{text: text, level: :error}},
+                     500
+
+      assert text =~ "startup aborted"
+      assert text =~ "[editor/error]"
     end
   end
 end

--- a/test/minga/logger_handler_test.exs
+++ b/test/minga/logger_handler_test.exs
@@ -1,13 +1,21 @@
 defmodule Minga.LoggerHandlerTest do
+  # async: false because Logger handler tests mutate the global Logger/EventBus routing state and shared ETS buffer.
   use ExUnit.Case, async: false
 
   alias Minga.Buffer
+  alias Minga.Events
+  alias Minga.Events.LogMessageEvent
   alias Minga.LoggerHandler
 
   @buffer_table :minga_log_buffer
 
   setup do
     LoggerHandler.ensure_buffer_table()
+
+    if Process.whereis(Minga.EventBus) == nil do
+      start_supervised!(Minga.Events.child_spec(name: Minga.EventBus))
+    end
+
     :ets.delete_all_objects(@buffer_table)
     :ok
   end
@@ -53,6 +61,23 @@ defmodule Minga.LoggerHandlerTest do
       )
 
       assert_messages_buffer_contains(tag)
+    end
+
+    test "reports critical logger events as error severity" do
+      Events.subscribe(:log_message)
+
+      on_exit(fn -> Events.unsubscribe(:log_message) end)
+
+      for level <- [:critical, :alert, :emergency] do
+        tag = "logger-handler-#{level}-#{System.unique_integer([:positive])}"
+
+        LoggerHandler.log(%{level: level, msg: {:string, tag}, meta: %{}}, %{})
+
+        assert_receive {:minga_event, :log_message, %LogMessageEvent{text: text, level: :error}},
+                       500
+
+        assert text =~ tag
+      end
     end
   end
 


### PR DESCRIPTION
# TL;DR
Adds `minga --debug-log <path>` / `-D <path>` so crash-forensics logs persist `*Messages*` and warning/error events to disk with append-only session headers and synced writes.

Closes #142

## Context
When Minga crashes hard enough that in-memory buffers are gone, the existing log file does not capture everything that reaches `*Messages*` or warning/error flows. This PR adds a CLI-controlled flat debug log that survives process crashes and makes bug reports easier to diagnose.

Early pre-application-start capture is intentionally deferred. This implementation starts from CLI startup onward, matching the issue’s Developer Notes.

## Changes
- Added `Minga.DebugLog`, a GenServer that subscribes to `:log_message`, writes to an append-only file, and debounces writes with `:file.datasync/1`.
- Added `--debug-log <path>` and `-D <path>` CLI parsing, help text, startup path validation, and cleanup reporting.
- Preserved warning/error severity in the flat log, including critical/alert/emergency Logger events as `[ERROR]`.
- Added registry restart handling so DebugLog re-subscribes after `Minga.Events` restarts and writes gap/reconnect markers directly to the debug log.
- Added shutdown/abort cleanup paths that flush Logger/DebugLog and report configured-but-not-running or stop errors.
- Added focused tests for parsing, headers, append mode, unwritable paths, debounce flushes, named flush/stop behavior, registry restart markers, and severity propagation.

## Verification
- `mix test.llm test/minga/debug_log_test.exs test/minga/cli_test.exs test/minga/log_messages_routing_test.exs test/minga/logger_handler_test.exs` passed, 84 tests.
- `make lint` passed.
- `git diff --check` passed.
- Final reviewer targeted re-check passed after fixing the `async: false` test comment.

## Acceptance Criteria Addressed
- `--debug-log <path>` and `-D <path>` are accepted by `minga` ✅
- `:log_message` entries are written to the specified file with debounce flush/datasync ✅
- Warning entries are prefixed with `[WARNING]`; error/critical entries are prefixed with `[ERROR]` ✅
- Unwritable debug-log paths fail before editor launch ✅
- Debug log sessions include Minga, Elixir, OTP, and timestamp header information ✅
- `--help` documents the new flag ✅
- Existing log files are appended to with a new session separator, not truncated ✅
