### PR TITLE
test(commands): split editing coverage by layer

### DIFF
--- a/test/minga_editor/commands/cmd_copy_cut_test.exs
+++ b/test/minga_editor/commands/cmd_copy_cut_test.exs
@@ -1,9 +1,8 @@
 defmodule MingaEditor.Commands.CmdCopyCutTest do
   @moduledoc """
-  Tests for :cmd_copy and :cmd_cut commands (macOS Cmd+C / Cmd+X menu actions).
+  Layer 0/1 command-state tests for :cmd_copy and :cmd_cut commands (macOS Cmd+C / Cmd+X menu actions).
 
-  Verifies mode-aware behavior: visual selection when active, current line when not.
-  Tests register writes and forced clipboard sync.
+  Verifies mode-aware behavior: visual selection when active, current line when not. Tests register writes and forced clipboard sync without a live Editor GenServer.
   """
   use ExUnit.Case, async: true
 

--- a/test/minga_editor/commands/editing_reindent_test.exs
+++ b/test/minga_editor/commands/editing_reindent_test.exs
@@ -1,17 +1,144 @@
 defmodule MingaEditor.Commands.EditingReindentTest do
   @moduledoc """
-  Tests for the = operator (reindent) mode transitions and dispatch.
+  Split reindent coverage by layer.
 
-  Verifies that ==, =<motion>, and visual = correctly route through
-  operator-pending mode and return to normal mode. Content-level indent
-  correctness is tested in `test/minga/editor/indent_test.exs`.
+  Mode FSM tests assert `=` dispatch. Command-state tests assert indentation effects without a live Editor GenServer. One editor smoke test keeps the event-bus prompt regression covered.
   """
+
   use ExUnit.Case, async: true
 
+  import MingaEditor.CommandStateHelpers
+
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Mode
+  alias Minga.Mode.OperatorPending
+  alias Minga.Mode.OperatorPendingState
   alias MingaEditor
+  alias MingaEditor.Commands.Editing
 
   @sync_timeout 15_000
+
+  describe "Layer 0 Mode FSM: = operator dispatch" do
+    test "first = enters operator-pending with :reindent" do
+      {mode, commands, mode_state} = Mode.process(:normal, {?=, 0}, Mode.initial_state())
+
+      assert mode == :operator_pending
+      assert commands == []
+      assert mode_state.operator == :reindent
+    end
+
+    test "== emits current-line reindent and returns to normal" do
+      state = %OperatorPendingState{operator: :reindent, op_count: 1}
+
+      assert {:execute_then_transition, [{:reindent_lines, 1}], :normal, _} =
+               OperatorPending.handle_key({?=, 0}, state)
+    end
+
+    test "=w, =G, and =gg emit motion reindent and return to normal" do
+      state = %OperatorPendingState{operator: :reindent, op_count: 1}
+
+      assert {:execute_then_transition, [{:reindent_motion, :word_forward}], :normal, _} =
+               OperatorPending.handle_key({?w, 0}, state)
+
+      assert {:execute_then_transition, [{:reindent_motion, :document_end}], :normal, _} =
+               OperatorPending.handle_key({?G, 0}, state)
+
+      pending_g = %OperatorPendingState{operator: :reindent, op_count: 1, pending_g: true}
+
+      assert {:execute_then_transition, [{:reindent_motion, :document_start}], :normal, _} =
+               OperatorPending.handle_key({?g, 0}, pending_g)
+    end
+
+    test "visual = emits visual reindent and returns to normal" do
+      {_mode, _commands, mode_state} = Mode.process(:normal, {?V, 0}, Mode.initial_state())
+
+      assert {:normal, [:reindent_visual_selection], _} =
+               Mode.process(:visual, {?=, 0}, mode_state)
+    end
+
+    test "=iw emits text-object reindent and returns to normal" do
+      state = %OperatorPendingState{
+        operator: :reindent,
+        op_count: 1,
+        text_object_modifier: :inner
+      }
+
+      assert {:execute_then_transition, [{:reindent_text_object, :inner, :word}], :normal, _} =
+               OperatorPending.handle_key({?w, 0}, state)
+    end
+  end
+
+  describe "Layer 0/1 command state: reindent content behavior" do
+    test "reindent_lines applies exact copy-indent fallback to the current line" do
+      buffer = start_buffer("  parent\nchild")
+      BufferProcess.move_to(buffer, {1, 0})
+      state = command_state(buffer)
+
+      _state = Editing.execute(state, {:reindent_lines, 1})
+
+      assert BufferProcess.content(buffer) == "  parent\n  child"
+    end
+
+    test "reindent_lines preserves exact content when no indentation is needed" do
+      buffer = start_buffer("hello\nworld\nfoo")
+      state = command_state(buffer)
+
+      _state = Editing.execute(state, {:reindent_lines, 1})
+
+      assert BufferProcess.content(buffer) == "hello\nworld\nfoo"
+    end
+
+    test "reindent_motion handles multi-line range with exact output" do
+      buffer = start_buffer("  parent\nchild\nleaf")
+      state = command_state(buffer)
+
+      _state = Editing.execute(state, {:reindent_motion, :document_end})
+
+      assert BufferProcess.content(buffer) == "parent\nchild\nleaf"
+    end
+
+    test "reindent_visual_selection handles selected line ranges with exact output" do
+      buffer = start_buffer("  parent\nchild\nleaf")
+      BufferProcess.move_to(buffer, {1, 0})
+      state = command_state(buffer) |> with_visual_selection({0, 0}, :line)
+
+      _state = Editing.execute(state, :reindent_visual_selection)
+
+      assert BufferProcess.content(buffer) == "parent\nchild\nleaf"
+    end
+  end
+
+  describe "Editor GenServer smoke: reindent event routing" do
+    test "== routes through a live editor and applies reindent" do
+      {editor, buffer} = start_editor("  parent\nchild")
+      BufferProcess.move_to(buffer, {1, 0})
+
+      send_key(editor, ?=)
+      send_key(editor, ?=)
+
+      assert BufferProcess.content(buffer) == "  parent\n  child"
+      assert :sys.get_state(editor, @sync_timeout).workspace.editing.mode == :normal
+    end
+
+    test "default bus tool prompts cannot interrupt reindent dispatch" do
+      {editor, _buffer} = start_editor("hello world")
+      state = :sys.get_state(editor, @sync_timeout)
+
+      refute editor in Minga.Events.subscribers(:tool_missing)
+      assert editor in Minga.Events.subscribers(:tool_missing, state.events_registry)
+
+      Minga.Events.broadcast(:tool_missing, %Minga.Events.ToolMissingEvent{command: "rg"})
+      state = :sys.get_state(editor, @sync_timeout)
+
+      assert state.workspace.editing.mode == :normal
+      assert state.shell_state.tool_prompt_queue == []
+    end
+  end
+
+  defp send_key(editor, codepoint, mods \\ 0) do
+    send(editor, {:minga_input, {:key_press, codepoint, mods}})
+    _ = :sys.get_state(editor, @sync_timeout)
+  end
 
   defp start_editor(content) do
     id = :erlang.unique_integer([:positive])
@@ -33,157 +160,5 @@ defmodule MingaEditor.Commands.EditingReindentTest do
       )
 
     {editor, buffer}
-  end
-
-  defp send_key(editor, codepoint, mods \\ 0) do
-    send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor, @sync_timeout)
-  end
-
-  # ── == mode transitions ────────────────────────────────────────────────────
-
-  describe "== mode transitions" do
-    test "first = enters operator-pending with :reindent" do
-      {editor, _buffer} = start_editor("line 1\nline 2")
-      send_key(editor, ?=)
-
-      state = :sys.get_state(editor, @sync_timeout)
-      assert state.workspace.editing.mode == :operator_pending
-      assert state.workspace.editing.mode_state.operator == :reindent
-    end
-
-    test "== returns to normal mode" do
-      {editor, _buffer} = start_editor("line 1\nline 2")
-      send_key(editor, ?=)
-      send_key(editor, ?=)
-
-      state = :sys.get_state(editor, @sync_timeout)
-      assert state.workspace.editing.mode == :normal
-    end
-
-    test "=w returns to normal mode (word motion)" do
-      {editor, _buffer} = start_editor("line 1\nline 2\nline 3")
-      send_key(editor, ?=)
-      send_key(editor, ?w)
-
-      state = :sys.get_state(editor, @sync_timeout)
-      assert state.workspace.editing.mode == :normal
-    end
-
-    test "=G returns to normal mode" do
-      {editor, _buffer} = start_editor("line 1\nline 2\nline 3")
-      send_key(editor, ?=)
-      send_key(editor, ?G)
-
-      state = :sys.get_state(editor, @sync_timeout)
-      assert state.workspace.editing.mode == :normal
-    end
-
-    test "=gg returns to normal mode" do
-      {editor, _buffer} = start_editor("line 1\nline 2\nline 3")
-      send_key(editor, ?j)
-      send_key(editor, ?=)
-      send_key(editor, ?g)
-      send_key(editor, ?g)
-
-      state = :sys.get_state(editor, @sync_timeout)
-      assert state.workspace.editing.mode == :normal
-    end
-  end
-
-  # ── Visual = mode transitions ──────────────────────────────────────────────
-
-  describe "visual = mode transitions" do
-    test "V j = reindents visual selection and returns to normal" do
-      {editor, _buffer} = start_editor("line 1\nline 2\nline 3")
-      send_key(editor, ?V)
-      send_key(editor, ?j)
-      send_key(editor, ?=)
-
-      state = :sys.get_state(editor, @sync_timeout)
-      assert state.workspace.editing.mode == :normal
-    end
-
-    test "v l = returns to normal after characterwise reindent" do
-      {editor, _buffer} = start_editor("line 1\nline 2")
-      send_key(editor, ?v)
-      send_key(editor, ?j)
-      send_key(editor, ?=)
-
-      state = :sys.get_state(editor, @sync_timeout)
-      assert state.workspace.editing.mode == :normal
-    end
-  end
-
-  # ── = with text objects ────────────────────────────────────────────────────
-
-  describe "= with text objects" do
-    test "=iw enters operator-pending then dispatches and returns to normal" do
-      {editor, _buffer} = start_editor("hello world")
-      send_key(editor, ?=)
-
-      state = :sys.get_state(editor, @sync_timeout)
-      assert state.workspace.editing.mode == :operator_pending
-
-      send_key(editor, ?i)
-      send_key(editor, ?w)
-
-      state = :sys.get_state(editor, @sync_timeout)
-      assert state.workspace.editing.mode == :normal
-    end
-
-    test "default bus tool prompts cannot interrupt reindent dispatch" do
-      {editor, _buffer} = start_editor("hello world")
-      state = :sys.get_state(editor, @sync_timeout)
-
-      refute editor in Minga.Events.subscribers(:tool_missing)
-      assert editor in Minga.Events.subscribers(:tool_missing, state.events_registry)
-
-      Minga.Events.broadcast(:tool_missing, %Minga.Events.ToolMissingEvent{command: "rg"})
-      state = :sys.get_state(editor, @sync_timeout)
-
-      assert state.workspace.editing.mode == :normal
-      assert state.shell_state.tool_prompt_queue == []
-    end
-  end
-
-  # ── Content verification (simple cases) ────────────────────────────────────
-
-  describe "content verification" do
-    test "== applies exact copy-indent fallback to the current line" do
-      content = "  parent\nchild"
-      {editor, buffer} = start_editor(content)
-      send_key(editor, ?j)
-      send_key(editor, ?=)
-      send_key(editor, ?=)
-
-      assert BufferProcess.content(buffer) == "  parent\n  child"
-    end
-
-    test "== does not corrupt buffer content" do
-      content = "hello\nworld\nfoo"
-      {editor, buffer} = start_editor(content)
-      send_key(editor, ?=)
-      send_key(editor, ?=)
-
-      result = BufferProcess.content(buffer)
-      # Content should not lose characters. The line may gain/lose whitespace
-      # but the non-whitespace content should be preserved.
-      assert String.contains?(result, "hello")
-    end
-
-    test "=G does not crash on multi-line buffer" do
-      {editor, buffer} = start_editor("a\nb\nc\nd\ne")
-      send_key(editor, ?=)
-      send_key(editor, ?G)
-
-      result = BufferProcess.content(buffer)
-      assert is_binary(result)
-      # All original non-whitespace content should be preserved
-      for char <- ["a", "b", "c", "d", "e"] do
-        assert String.contains?(result, char),
-               "Expected '#{char}' to be preserved after =G, content: #{inspect(result)}"
-      end
-    end
   end
 end

--- a/test/minga_editor/commands/editing_test.exs
+++ b/test/minga_editor/commands/editing_test.exs
@@ -1,10 +1,427 @@
 defmodule MingaEditor.Commands.EditingTest do
+  @moduledoc """
+  Split editing command coverage by layer.
+
+  Mode FSM tests assert key-to-command emission. Command-state tests assert buffer/register behavior by calling command modules directly. The final describe block keeps a small Editor GenServer smoke layer for end-to-end key routing.
+  """
+
   use ExUnit.Case, async: true
+
+  import MingaEditor.CommandStateHelpers
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Config.Options
   alias Minga.Keymap.Active, as: KeymapActive
+  alias Minga.Mode
   alias MingaEditor
+  alias MingaEditor.Commands.Editing
+  alias MingaEditor.Commands.Operators
+  alias MingaEditor.Commands.Visual
+
+  @sync_timeout 15_000
+
+  describe "Layer 0 Mode FSM: normal command emission" do
+    test "insert entry keys emit commands without a live editor" do
+      assert_mode({?i, 0}, :insert, [])
+      assert_mode({?a, 0}, :insert, [:move_right])
+      assert_mode({?A, 0}, :insert, [:move_to_line_end, :move_right])
+      assert_mode({?I, 0}, :insert, [:move_to_line_start])
+      assert_mode({?o, 0}, :insert, [:insert_line_below])
+      assert_mode({?O, 0}, :insert, [:insert_line_above])
+    end
+
+    test "paste and counted delete keys emit normal-mode commands" do
+      assert_mode({?p, 0}, :normal, [:paste_after])
+      assert_mode({?P, 0}, :normal, [:paste_before])
+
+      {_mode, _commands, counted} = Mode.process(:normal, {?3, 0}, Mode.initial_state())
+      {mode, commands, _state} = Mode.process(:normal, {?x, 0}, counted)
+
+      assert mode == :normal
+      assert commands == [{:delete_chars_at, 3}]
+    end
+
+    test "yy and dd emit operator-pending commands through the FSM" do
+      {mode, _commands, pending_yank} = Mode.process(:normal, {?y, 0}, Mode.initial_state())
+      assert mode == :operator_pending
+      assert pending_yank.operator == :yank
+
+      assert {:normal, [{:yank_lines_counted, 1}], _} =
+               Mode.process(:operator_pending, {?y, 0}, pending_yank)
+
+      {mode, _commands, pending_delete} = Mode.process(:normal, {?d, 0}, Mode.initial_state())
+      assert mode == :operator_pending
+      assert pending_delete.operator == :delete
+
+      assert {:normal, [{:delete_lines_counted, 1}], _} =
+               Mode.process(:operator_pending, {?d, 0}, pending_delete)
+    end
+
+    test "visual v and V enter visual mode through the FSM" do
+      {mode, commands, mode_state} = Mode.process(:normal, {?v, 0}, Mode.initial_state())
+      assert mode == :visual
+      assert commands == []
+      assert mode_state.visual_type == :char
+
+      {mode, commands, mode_state} = Mode.process(:normal, {?V, 0}, Mode.initial_state())
+      assert mode == :visual
+      assert commands == []
+      assert mode_state.visual_type == :line
+    end
+
+    test "s emits delete-char and transitions to insert" do
+      {mode, commands, _state} = Mode.process(:normal, {?s, 0}, Mode.initial_state())
+
+      assert mode == :insert
+      assert commands == [{:delete_chars_at, 1}]
+    end
+  end
+
+  describe "Layer 0/1 command state: insertion and open-line commands" do
+    test "insert_char updates buffer content" do
+      buffer = start_buffer("hello")
+      state = command_state(buffer)
+
+      _state = Editing.execute(state, {:insert_char, "x"})
+
+      assert BufferProcess.content(buffer) == "xhello"
+    end
+
+    test "delete_before and insert_newline mutate content without touching registers" do
+      buffer = start_buffer("abc")
+      BufferProcess.move_to(buffer, {0, 2})
+      state = command_state(buffer)
+
+      state = Editing.execute(state, :delete_before)
+      state = Editing.execute(state, :insert_newline)
+
+      assert BufferProcess.content(buffer) == "a\nc"
+      assert register_entry(state) == nil
+    end
+
+    test "insert_line_below inserts an indented line below" do
+      buffer = start_buffer("  hello")
+      state = command_state(buffer)
+
+      _state = Editing.execute(state, :insert_line_below)
+
+      assert BufferProcess.content(buffer) == "  hello\n  "
+    end
+
+    test "insert_line_above preserves fallback indentation above the first line" do
+      buffer = start_buffer("  hello")
+      state = command_state(buffer)
+
+      _state = Editing.execute(state, :insert_line_above)
+      Editing.execute(state, {:insert_char, "w"})
+
+      assert BufferProcess.content(buffer) == "  w\n  hello"
+    end
+
+    test "autopair insert and delete work when command executor is called directly" do
+      buffer = start_buffer("")
+      BufferProcess.set_option(buffer, :autopair, true)
+      state = command_state(buffer)
+
+      _state = Editing.execute(state, {:insert_char, "("})
+      assert BufferProcess.content(buffer) == "()"
+
+      _state = Editing.execute(state, :delete_before)
+      assert BufferProcess.content(buffer) == ""
+    end
+  end
+
+  describe "Layer 0/1 command state: undo, redo, and indent" do
+    test "undo and redo operate through direct command execution" do
+      buffer = start_buffer("hello")
+      state = command_state(buffer)
+
+      state = Editing.execute(state, {:insert_char, "x"})
+      assert BufferProcess.content(buffer) == "xhello"
+
+      state = Editing.execute(state, :undo)
+      assert BufferProcess.content(buffer) == "hello"
+
+      _state = Editing.execute(state, :redo)
+      assert BufferProcess.content(buffer) == "xhello"
+    end
+
+    test "indent_line respects tab indentation" do
+      buffer = start_buffer("hello")
+      BufferProcess.set_option(buffer, :indent_with, :tabs)
+      state = command_state(buffer)
+
+      _state = Editing.execute(state, :indent_line)
+
+      assert BufferProcess.content(buffer) == "\thello"
+      assert BufferProcess.cursor(buffer) == {0, 1}
+    end
+  end
+
+  describe "Layer 0/1 command state: linewise paste" do
+    test "paste_after and paste_before insert linewise registers as full lines" do
+      buffer = start_buffer("aaa\nbbb\nccc")
+      state = command_state(buffer) |> with_register("", "aaa\n", :linewise)
+
+      BufferProcess.move_to(buffer, {1, 2})
+      _state = Editing.execute(state, :paste_after)
+      assert BufferProcess.content(buffer) == "aaa\nbbb\naaa\nccc"
+
+      buffer = start_buffer("aaa\nbbb")
+      state = command_state(buffer) |> with_register("", "bbb\n", :linewise)
+
+      BufferProcess.move_to(buffer, {0, 0})
+      _state = Editing.execute(state, :paste_before)
+      assert BufferProcess.content(buffer) == "bbb\naaa\nbbb"
+    end
+
+    test "linewise paste places cursor on first non-blank of pasted line" do
+      buffer = start_buffer("  indented\nplain")
+      state = command_state(buffer) |> with_register("", "  indented\n", :linewise)
+
+      BufferProcess.move_to(buffer, {1, 0})
+      _state = Editing.execute(state, :paste_after)
+
+      assert BufferProcess.cursor(buffer) == {2, 2}
+    end
+
+    test "empty registers leave paste commands as no-ops" do
+      buffer = start_buffer("hello")
+      original = BufferProcess.content(buffer)
+      state = command_state(buffer)
+
+      state = Editing.execute(state, :paste_after)
+      _state = Editing.execute(state, :paste_before)
+
+      assert BufferProcess.content(buffer) == original
+    end
+  end
+
+  describe "Layer 0/1 command state: charwise delete and paste" do
+    test "delete_chars_at stores deleted chars and paste_after inserts them inline" do
+      buffer = start_buffer("abcdef")
+      state = command_state(buffer)
+
+      state = Editing.execute(state, {:delete_chars_at, 3})
+      assert BufferProcess.content(buffer) == "def"
+      assert register_entry(state) == {"abc", :charwise}
+
+      BufferProcess.move_to(buffer, {0, 2})
+      _state = Editing.execute(state, :paste_after)
+
+      assert BufferProcess.content(buffer) == "defabc"
+    end
+
+    test "delete_chars_at clamps to available characters" do
+      buffer = start_buffer("ab")
+      state = command_state(buffer)
+
+      state = Editing.execute(state, {:delete_chars_at, 5})
+
+      assert BufferProcess.content(buffer) == ""
+      assert register_entry(state) == {"ab", :charwise}
+    end
+
+    test "delete_chars_before stores deleted chars in reading order" do
+      buffer = start_buffer("abcdef")
+      BufferProcess.move_to(buffer, {0, 4})
+      state = command_state(buffer)
+
+      state = Editing.execute(state, {:delete_chars_before, 3})
+
+      assert BufferProcess.content(buffer) == "aef"
+      assert register_entry(state) == {"bcd", :charwise}
+    end
+
+    test "x on empty line and X at column zero are no-ops" do
+      buffer = start_buffer("")
+      state = command_state(buffer)
+
+      state = Editing.execute(state, {:delete_chars_at, 1})
+      assert BufferProcess.content(buffer) == ""
+      assert register_entry(state) == nil
+
+      buffer = start_buffer("abc")
+      state = command_state(buffer)
+
+      state = Editing.execute(state, {:delete_chars_before, 1})
+      assert BufferProcess.content(buffer) == "abc"
+      assert register_entry(state) == nil
+    end
+
+    test "named and black-hole registers affect delete behavior" do
+      buffer = start_buffer("abc")
+      state = command_state(buffer) |> with_active_register("a")
+
+      state = Editing.execute(state, {:delete_chars_at, 1})
+      assert BufferProcess.content(buffer) == "bc"
+      assert register_entry(state, "a") == {"a", :charwise}
+
+      buffer = start_buffer("abc")
+
+      state =
+        command_state(buffer)
+        |> with_register("", "seed", :charwise)
+        |> with_active_register("_")
+
+      state = Editing.execute(state, {:delete_chars_at, 1})
+      assert BufferProcess.content(buffer) == "bc"
+      assert register_entry(state) == {"seed", :charwise}
+    end
+  end
+
+  describe "Layer 0/1 command state: operators, registers, and paste" do
+    test "yy then paste_after pastes a yanked line below the target line" do
+      buffer = start_buffer("aaa\nbbb\nccc")
+      state = command_state(buffer)
+
+      state = Operators.execute(state, {:yank_lines_counted, 1})
+      BufferProcess.move_to(buffer, {1, 0})
+      _state = Editing.execute(state, :paste_after)
+
+      assert BufferProcess.content(buffer) == "aaa\nbbb\naaa\nccc"
+      assert register_entry(state) == {"aaa\n", :linewise}
+      assert register_entry(state, "0") == {"aaa\n", :linewise}
+    end
+
+    test "dd then paste_before restores the deleted line above the cursor" do
+      buffer = start_buffer("aaa\nbbb\nccc")
+      BufferProcess.move_to(buffer, {1, 0})
+      state = command_state(buffer)
+
+      state = Operators.execute(state, {:delete_lines_counted, 1})
+      _state = Editing.execute(state, :paste_before)
+
+      assert BufferProcess.content(buffer) == "aaa\nbbb\nccc"
+      assert register_entry(state) == {"bbb\n", :linewise}
+      assert register_entry(state, "0") == nil
+    end
+
+    test "cc stores linewise register type before clearing" do
+      buffer = start_buffer("hello\nworld")
+      state = command_state(buffer)
+
+      state = Operators.execute(state, {:change_lines_counted, 1})
+
+      refute String.contains?(BufferProcess.content(buffer), "hello")
+      assert register_entry(state) == {"hello\n", :linewise}
+    end
+
+    test "named register preserves linewise type through later unnamed operations" do
+      buffer = start_buffer("alpha\nbeta\ngamma")
+
+      state =
+        command_state(buffer)
+        |> with_active_register("a")
+        |> Operators.execute({:yank_lines_counted, 1})
+
+      BufferProcess.move_to(buffer, {1, 0})
+      state = Operators.execute(state, {:delete_lines_counted, 1})
+      state = with_active_register(state, "a")
+      _state = Editing.execute(state, :paste_after)
+
+      assert BufferProcess.content(buffer) == "alpha\ngamma\nalpha"
+    end
+  end
+
+  describe "Layer 0/1 command state: visual paste contracts" do
+    test "visual line yank then paste_after duplicates selected lines" do
+      buffer = start_buffer("aaa\nbbb\nccc\nddd")
+      BufferProcess.move_to(buffer, {1, 0})
+      state = command_state(buffer) |> with_visual_selection({0, 0}, :line)
+
+      state = Visual.execute(state, :yank_visual_selection)
+      _state = Editing.execute(state, :paste_after)
+
+      assert BufferProcess.content(buffer) == "aaa\nbbb\naaa\nbbb\nccc\nddd"
+    end
+
+    test "visual line delete then paste_after restores deleted lines as linewise" do
+      buffer = start_buffer("aaa\nbbb\nccc")
+      BufferProcess.move_to(buffer, {1, 0})
+      state = command_state(buffer) |> with_visual_selection({0, 0}, :line)
+
+      state = Visual.execute(state, :delete_visual_selection)
+      _state = Editing.execute(state, :paste_after)
+
+      assert BufferProcess.content(buffer) == "ccc\naaa\nbbb"
+    end
+
+    test "visual char yank then paste_after stays inline" do
+      buffer = start_buffer("abcdefgh")
+      BufferProcess.move_to(buffer, {0, 3})
+      state = command_state(buffer) |> with_visual_selection({0, 0}, :char)
+
+      state = Visual.execute(state, :yank_visual_selection)
+      BufferProcess.move_to(buffer, {0, 7})
+      _state = Editing.execute(state, :paste_after)
+
+      assert BufferProcess.content(buffer) == "abcdefghabcd"
+    end
+  end
+
+  describe "Editor GenServer smoke: key routing" do
+    test "normal and insert routing inserts text and Escape returns to normal semantics" do
+      {editor, buffer} = start_editor("")
+
+      send_key(editor, ?i)
+      Enum.each(~c"abc!", &send_key(editor, &1))
+      send_key(editor, 27)
+      send_key(editor, ?l)
+
+      assert BufferProcess.content(buffer) == "abc!"
+      assert BufferProcess.cursor(buffer) == {0, 3}
+    end
+
+    test "operator-pending yy then p routes through the editor" do
+      {editor, buffer} = start_editor("aaa\nbbb\nccc")
+      send_key(editor, ?y)
+      send_key(editor, ?y)
+      send_key(editor, ?j)
+      send_key(editor, ?p)
+
+      assert BufferProcess.content(buffer) == "aaa\nbbb\naaa\nccc"
+    end
+
+    test "visual v d routes through the editor" do
+      {editor, buffer} = start_editor("hello world")
+      send_key(editor, ?v)
+      send_key(editor, ?l)
+      send_key(editor, ?l)
+      send_key(editor, ?d)
+
+      assert BufferProcess.content(buffer) == "lo world"
+    end
+
+    test "command mode key routing enters command mode" do
+      {editor, _buffer} = start_editor("hello")
+      send_key(editor, ?:)
+
+      state = :sys.get_state(editor)
+      assert state.workspace.editing.mode == :command
+    end
+
+    test "paste events route in normal and insert modes" do
+      {editor, buffer} = start_editor("start")
+
+      send(editor, {:minga_input, {:paste_event, " normal"}})
+      _ = :sys.get_state(editor)
+      send_key(editor, ?i)
+      send(editor, {:minga_input, {:paste_event, " insert"}})
+      _ = :sys.get_state(editor)
+
+      content = BufferProcess.content(buffer)
+      assert String.contains?(content, "normal")
+      assert String.contains?(content, "insert")
+    end
+  end
+
+  defp assert_mode(key, expected_mode, expected_commands) do
+    {mode, commands, _state} = Mode.process(:normal, key, Mode.initial_state())
+
+    assert mode == expected_mode
+    assert commands == expected_commands
+  end
 
   defp start_editor(content) do
     id = :erlang.unique_integer([:positive])
@@ -34,758 +451,6 @@ defmodule MingaEditor.Commands.EditingTest do
 
   defp send_key(editor, codepoint, mods \\ 0) do
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor)
-  end
-
-  describe "Normal → Insert transition" do
-    test "i enters insert mode and allows character insertion" do
-      {editor, buffer} = start_editor("hello")
-      send_key(editor, ?i)
-      send_key(editor, ?x)
-
-      assert BufferProcess.content(buffer) == "xhello"
-    end
-
-    test "a moves right and enters insert mode" do
-      {editor, buffer} = start_editor("hello")
-      send_key(editor, ?a)
-      send_key(editor, ?x)
-
-      assert String.contains?(BufferProcess.content(buffer), "x")
-    end
-
-    test "A moves after line end and enters insert mode" do
-      {editor, buffer} = start_editor("hi")
-      send_key(editor, ?A)
-      send_key(editor, ?!)
-
-      assert BufferProcess.content(buffer) == "hi!"
-    end
-
-    test "I moves to line start and enters insert mode" do
-      {editor, buffer} = start_editor("hello")
-      send_key(editor, ?l)
-      send_key(editor, ?l)
-      send_key(editor, ?I)
-      send_key(editor, ?^)
-
-      assert String.starts_with?(BufferProcess.content(buffer), "^")
-    end
-
-    test "o inserts a new line below and enters insert mode" do
-      {editor, buffer} = start_editor("hello")
-      send_key(editor, ?o)
-      send_key(editor, ?w)
-
-      content = BufferProcess.content(buffer)
-      assert String.contains?(content, "\n")
-      assert String.contains?(content, "w")
-    end
-
-    test "O inserts a new line above and enters insert mode" do
-      {editor, buffer} = start_editor("hello")
-      send_key(editor, ?O)
-      send_key(editor, ?w)
-
-      content = BufferProcess.content(buffer)
-      assert String.contains?(content, "\n")
-      assert String.contains?(content, "w")
-    end
-
-    test "O above an indented first line preserves fallback indentation" do
-      {editor, buffer} = start_editor("  hello")
-      send_key(editor, ?O)
-      send_key(editor, ?w)
-
-      assert BufferProcess.content(buffer) == "  w\n  hello"
-    end
-  end
-
-  describe "Insert mode operations" do
-    test "insert character updates buffer" do
-      {editor, buffer} = start_editor("hello\nworld\nfoo")
-      send_key(editor, ?i)
-      send_key(editor, ?x)
-
-      assert BufferProcess.content(buffer) == "xhello\nworld\nfoo"
-    end
-
-    test "backspace (127) deletes character in insert mode" do
-      {editor, buffer} = start_editor("hello\nworld\nfoo")
-      send_key(editor, ?i)
-      send_key(editor, ?a)
-      _ = :sys.get_state(editor)
-      send_key(editor, 127)
-
-      assert BufferProcess.content(buffer) == "hello\nworld\nfoo"
-    end
-
-    test "enter inserts newline in insert mode" do
-      {editor, buffer} = start_editor("hello\nworld\nfoo")
-      send_key(editor, ?i)
-      send_key(editor, 13)
-
-      assert BufferProcess.content(buffer) == "\nhello\nworld\nfoo"
-    end
-  end
-
-  describe "Insert → Normal transition" do
-    test "Escape returns to Normal mode" do
-      {editor, buffer} = start_editor("hello")
-      send_key(editor, ?i)
-      send_key(editor, ?x)
-      send_key(editor, 27)
-
-      content_before = BufferProcess.content(buffer)
-      send_key(editor, ?l)
-      assert BufferProcess.content(buffer) == content_before
-    end
-
-    test "Escape from insert at end of line leaves normal cursor on the inserted character" do
-      {editor, buffer} = start_editor("")
-
-      send_key(editor, ?i)
-      Enum.each(~c"abc!", &send_key(editor, &1))
-      send_key(editor, 27)
-
-      assert BufferProcess.content(buffer) == "abc!"
-      assert BufferProcess.cursor(buffer) == {0, 3}
-    end
-
-    test "visual round trip after insert preserves normal cursor semantics for the next insert" do
-      {editor, buffer} = start_editor("")
-
-      send_key(editor, ?i)
-      Enum.each(~c"abc!", &send_key(editor, &1))
-      send_key(editor, 27)
-      send_key(editor, ?v)
-      send_key(editor, 27)
-      send_key(editor, ?i)
-      send_key(editor, ?X)
-
-      assert BufferProcess.content(buffer) == "abcX!"
-    end
-  end
-
-  describe "undo / redo" do
-    test "u undoes the last change" do
-      {editor, buffer} = start_editor("hello")
-      send_key(editor, ?i)
-      send_key(editor, ?x)
-      send_key(editor, 27)
-
-      assert BufferProcess.content(buffer) == "xhello"
-      send_key(editor, ?u)
-      assert BufferProcess.content(buffer) == "hello"
-    end
-
-    test "Ctrl+r redoes after undo" do
-      {editor, buffer} = start_editor("hello")
-      send_key(editor, ?i)
-      send_key(editor, ?x)
-      send_key(editor, 27)
-
-      send_key(editor, ?u)
-      assert BufferProcess.content(buffer) == "hello"
-
-      send_key(editor, ?r, 0x02)
-      assert BufferProcess.content(buffer) == "xhello"
-    end
-  end
-
-  describe "paste operations" do
-    test "p pastes after cursor" do
-      {editor, buffer} = start_editor("hello\nworld")
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      send_key(editor, ?j)
-      send_key(editor, ?p)
-
-      content = BufferProcess.content(buffer)
-      assert String.contains?(content, "hello")
-      lines = String.split(content, "\n")
-      assert length(lines) >= 3
-    end
-
-    test "P pastes before cursor" do
-      {editor, buffer} = start_editor("hello\nworld")
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      send_key(editor, ?j)
-      send_key(editor, ?P)
-
-      assert String.contains?(BufferProcess.content(buffer), "hello")
-    end
-
-    test "p is a no-op when register is empty" do
-      {editor, buffer} = start_editor("hello")
-      original = BufferProcess.content(buffer)
-      send_key(editor, ?p)
-      assert BufferProcess.content(buffer) == original
-    end
-
-    test "P is a no-op when register is empty" do
-      {editor, buffer} = start_editor("hello")
-      original = BufferProcess.content(buffer)
-      send_key(editor, ?P)
-      assert BufferProcess.content(buffer) == original
-    end
-  end
-
-  # ── Linewise paste ──────────────────────────────────────────────────────
-
-  describe "linewise paste (yy + p)" do
-    test "yy then p pastes yanked line below the current line" do
-      {editor, buffer} = start_editor("aaa\nbbb\nccc")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      send_key(editor, ?j)
-      send_key(editor, ?p)
-
-      assert BufferProcess.content(buffer) == "aaa\nbbb\naaa\nccc"
-    end
-
-    test "yy then P pastes yanked line above the current line" do
-      {editor, buffer} = start_editor("aaa\nbbb\nccc")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      # move to line 2, paste above
-      send_key(editor, ?j)
-      send_key(editor, ?j)
-      send_key(editor, ?P)
-
-      assert BufferProcess.content(buffer) == "aaa\nbbb\naaa\nccc"
-    end
-
-    test "p on the last line of the file appends a new line" do
-      {editor, buffer} = start_editor("aaa\nbbb")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      send_key(editor, ?j)
-      send_key(editor, ?p)
-
-      assert BufferProcess.content(buffer) == "aaa\nbbb\naaa"
-    end
-
-    test "P on the first line of the file inserts above" do
-      {editor, buffer} = start_editor("aaa\nbbb")
-      BufferProcess.move_to(buffer, {1, 0})
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?P)
-
-      assert BufferProcess.content(buffer) == "bbb\naaa\nbbb"
-    end
-
-    test "cursor column is irrelevant for linewise paste" do
-      {editor, buffer} = start_editor("aaa\nbbb\nccc")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      # move to middle of line 1
-      BufferProcess.move_to(buffer, {1, 2})
-      send_key(editor, ?p)
-
-      # Should still paste as a full new line, not splice at col 2
-      assert BufferProcess.content(buffer) == "aaa\nbbb\naaa\nccc"
-    end
-  end
-
-  describe "indent commands" do
-    test ">> respects tab indentation" do
-      {editor, buffer} = start_editor("hello")
-      BufferProcess.set_option(buffer, :indent_with, :tabs)
-
-      send_key(editor, ?>)
-      send_key(editor, ?>)
-
-      assert BufferProcess.content(buffer) == "\thello"
-      assert BufferProcess.cursor(buffer) == {0, 1}
-    end
-  end
-
-  describe "linewise paste (dd + p/P)" do
-    test "dd then p moves deleted line below current line" do
-      {editor, buffer} = start_editor("aaa\nbbb\nccc")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?d)
-      send_key(editor, ?d)
-      send_key(editor, ?p)
-
-      assert BufferProcess.content(buffer) == "bbb\naaa\nccc"
-    end
-
-    test "dd then P pastes deleted line above current line" do
-      {editor, buffer} = start_editor("aaa\nbbb\nccc")
-      BufferProcess.move_to(buffer, {1, 0})
-      send_key(editor, ?d)
-      send_key(editor, ?d)
-      # cursor is now on "ccc"
-      send_key(editor, ?P)
-
-      assert BufferProcess.content(buffer) == "aaa\nbbb\nccc"
-    end
-  end
-
-  describe "linewise paste cursor positioning" do
-    test "p lands cursor on first non-blank of pasted line" do
-      {editor, buffer} = start_editor("  indented\nplain")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      send_key(editor, ?j)
-      send_key(editor, ?p)
-
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 2
-      assert col == 2
-    end
-
-    test "P lands cursor on first non-blank of pasted line" do
-      {editor, buffer} = start_editor("plain\n    deep")
-      BufferProcess.move_to(buffer, {1, 0})
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?P)
-
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 0
-      assert col == 4
-    end
-
-    test "p with no-indent line lands cursor at col 0" do
-      {editor, buffer} = start_editor("noindent\nother")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      send_key(editor, ?j)
-      # Cross-process barrier: confirm `j` has fully landed in BufferProcess
-      # before we paste. `send_key`'s `:sys.get_state(editor)` only proves
-      # the editor process drained its mailbox, not that any async follow-up
-      # work the executor scheduled has applied to BufferProcess state.
-      _ = BufferProcess.cursor(buffer)
-      send_key(editor, ?p)
-
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 2
-      assert col == 0
-    end
-  end
-
-  describe "cc stores linewise register type" do
-    test "cc yanks the line content as linewise before clearing" do
-      {editor, _buffer} = start_editor("hello\nworld")
-      send_key(editor, ?c)
-      send_key(editor, ?c)
-
-      s = :sys.get_state(editor)
-      assert Map.get(s.workspace.editing.reg.registers, "") == {"hello\n", :linewise}
-    end
-  end
-
-  # ── Charwise paste (regression guard) ──────────────────────────────────
-
-  describe "charwise paste stays inline" do
-    test "yw then p pastes inline, no new line created" do
-      {editor, buffer} = start_editor("hello world")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?y)
-      send_key(editor, ?w)
-      send_key(editor, ?$)
-      send_key(editor, ?p)
-
-      content = BufferProcess.content(buffer)
-      refute String.contains?(content, "\n")
-    end
-
-    test "x then p pastes deleted char inline" do
-      {editor, buffer} = start_editor("abc")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?x)
-      assert BufferProcess.content(buffer) == "bc"
-
-      send_key(editor, ?p)
-      assert BufferProcess.content(buffer) == "bac"
-    end
-
-    test "dw then p pastes deleted word inline" do
-      {editor, buffer} = start_editor("one two three")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?d)
-      send_key(editor, ?w)
-      # "one " deleted, cursor at "two"
-      send_key(editor, ?$)
-      send_key(editor, ?p)
-
-      content = BufferProcess.content(buffer)
-      refute String.contains?(content, "\n")
-      assert String.contains?(content, "one ")
-    end
-  end
-
-  # ── Named register linewise round-trip ─────────────────────────────────
-
-  describe "named register linewise round-trip" do
-    test ~S["ayy then "ap pastes as a new line] do
-      {editor, buffer} = start_editor("first\nsecond\nthird")
-      BufferProcess.move_to(buffer, {0, 0})
-      # "ayy
-      send_key(editor, ?")
-      send_key(editor, ?a)
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      # move to last line, "ap
-      send_key(editor, ?j)
-      send_key(editor, ?j)
-      send_key(editor, ?")
-      send_key(editor, ?a)
-      send_key(editor, ?p)
-
-      assert BufferProcess.content(buffer) == "first\nsecond\nthird\nfirst"
-    end
-
-    test "named register preserves linewise type through multiple operations" do
-      {editor, buffer} = start_editor("alpha\nbeta\ngamma")
-      BufferProcess.move_to(buffer, {0, 0})
-      # "ayy
-      send_key(editor, ?")
-      send_key(editor, ?a)
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      # Now do an unnamed dd (overwrites unnamed register, not "a")
-      send_key(editor, ?j)
-      send_key(editor, ?d)
-      send_key(editor, ?d)
-      # "ap should still paste "alpha" as linewise from register a
-      send_key(editor, ?")
-      send_key(editor, ?a)
-      send_key(editor, ?p)
-
-      assert BufferProcess.content(buffer) == "alpha\ngamma\nalpha"
-    end
-  end
-
-  # ── Visual-line paste ──────────────────────────────────────────────────
-
-  describe "visual-line yank and paste" do
-    test "Vjy then p pastes two lines below current line" do
-      {editor, buffer} = start_editor("aaa\nbbb\nccc\nddd")
-      BufferProcess.move_to(buffer, {0, 0})
-      # V to enter visual-line, j to extend to line 1, y to yank
-      send_key(editor, ?V)
-      send_key(editor, ?j)
-      send_key(editor, ?y)
-      # Paste below wherever the cursor is after yank
-      send_key(editor, ?p)
-
-      lines = String.split(BufferProcess.content(buffer), "\n")
-      # Should have 6 lines: original 4 + 2 pasted
-      assert length(lines) == 6
-      # The pasted block should contain "aaa" and "bbb" in order
-      assert Enum.count(lines, &(&1 == "aaa")) == 2
-      assert Enum.count(lines, &(&1 == "bbb")) == 2
-    end
-
-    test "Vd then p pastes deleted lines as linewise" do
-      {editor, buffer} = start_editor("aaa\nbbb\nccc")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?V)
-      send_key(editor, ?j)
-      send_key(editor, ?d)
-      # "aaa" and "bbb" deleted, cursor on "ccc"
-      send_key(editor, ?p)
-
-      assert BufferProcess.content(buffer) == "ccc\naaa\nbbb"
-    end
-  end
-
-  # ── Visual-char paste (charwise guard) ─────────────────────────────────
-
-  # ── x / X yank into register (#482) ──────────────────────────────────────
-
-  describe "x (delete_char_at) yanks into register" do
-    test "x stores deleted char in unnamed register" do
-      {editor, buffer} = start_editor("abc")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?x)
-
-      assert BufferProcess.content(buffer) == "bc"
-      s = :sys.get_state(editor)
-      assert Map.get(s.workspace.editing.reg.registers, "") == {"a", :charwise}
-    end
-
-    test "xp transposes two characters" do
-      {editor, buffer} = start_editor("ab")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?x)
-      send_key(editor, ?p)
-
-      assert BufferProcess.content(buffer) == "ba"
-    end
-
-    test "x on empty line is a no-op" do
-      {editor, buffer} = start_editor("")
-      send_key(editor, ?x)
-
-      assert BufferProcess.content(buffer) == ""
-      s = :sys.get_state(editor)
-      refute Map.has_key?(s.workspace.editing.reg.registers, "")
-    end
-
-    test ~S["ax stores deleted char in named register a] do
-      {editor, buffer} = start_editor("abc")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?")
-      send_key(editor, ?a)
-      send_key(editor, ?x)
-
-      assert BufferProcess.content(buffer) == "bc"
-      s = :sys.get_state(editor)
-      assert Map.get(s.workspace.editing.reg.registers, "a") == {"a", :charwise}
-    end
-
-    test ~S["_x deletes without touching any register] do
-      {editor, buffer} = start_editor("abc")
-      BufferProcess.move_to(buffer, {0, 0})
-      # First yank something into unnamed so we can verify it's not overwritten
-      send_key(editor, ?y)
-      send_key(editor, ?w)
-      previous_unnamed = Map.get(:sys.get_state(editor).workspace.editing.reg.registers, "")
-
-      send_key(editor, ?")
-      send_key(editor, ?_)
-      send_key(editor, ?x)
-
-      assert BufferProcess.content(buffer) == "bc"
-      s = :sys.get_state(editor)
-      assert Map.get(s.workspace.editing.reg.registers, "") == previous_unnamed
-    end
-
-    test "multiple x's each yank the char they delete" do
-      {editor, buffer} = start_editor("abcd")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?x)
-      send_key(editor, ?x)
-
-      assert BufferProcess.content(buffer) == "cd"
-      # Last deleted char ('b') should be in unnamed
-      s = :sys.get_state(editor)
-      assert Map.get(s.workspace.editing.reg.registers, "") == {"b", :charwise}
-    end
-  end
-
-  describe "counted x (3x)" do
-    test "3x deletes three characters and yanks all three into the register" do
-      {editor, buffer} = start_editor("abcdef")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?3)
-      send_key(editor, ?x)
-
-      assert BufferProcess.content(buffer) == "def"
-      s = :sys.get_state(editor)
-      assert Map.get(s.workspace.editing.reg.registers, "") == {"abc", :charwise}
-    end
-
-    test "3x then p pastes all three deleted characters" do
-      {editor, buffer} = start_editor("abcdef")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?3)
-      send_key(editor, ?x)
-      send_key(editor, ?$)
-      send_key(editor, ?p)
-
-      content = BufferProcess.content(buffer)
-      assert String.contains?(content, "abc")
-    end
-
-    test "count larger than available chars deletes only what exists" do
-      {editor, buffer} = start_editor("ab")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?5)
-      send_key(editor, ?x)
-
-      assert BufferProcess.content(buffer) == ""
-      s = :sys.get_state(editor)
-      assert Map.get(s.workspace.editing.reg.registers, "") == {"ab", :charwise}
-    end
-
-    test "3X deletes three characters before cursor and yanks all three" do
-      {editor, buffer} = start_editor("abcdef")
-      BufferProcess.move_to(buffer, {0, 4})
-      send_key(editor, ?3)
-      send_key(editor, ?X)
-
-      assert BufferProcess.content(buffer) == "aef"
-      s = :sys.get_state(editor)
-      # Deleted chars in reading order: "bcd"
-      assert Map.get(s.workspace.editing.reg.registers, "") == {"bcd", :charwise}
-    end
-  end
-
-  describe "X (delete_char_before) yanks into register" do
-    test "X stores deleted char in unnamed register" do
-      {editor, buffer} = start_editor("abc")
-      BufferProcess.move_to(buffer, {0, 1})
-      send_key(editor, ?X)
-
-      assert BufferProcess.content(buffer) == "bc"
-      s = :sys.get_state(editor)
-      assert Map.get(s.workspace.editing.reg.registers, "") == {"a", :charwise}
-    end
-
-    test "X at col 0 is a no-op" do
-      {editor, buffer} = start_editor("abc")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?X)
-
-      assert BufferProcess.content(buffer) == "abc"
-      s = :sys.get_state(editor)
-      refute Map.has_key?(s.workspace.editing.reg.registers, "")
-    end
-
-    test ~S["aX stores deleted char in named register a] do
-      {editor, buffer} = start_editor("abc")
-      BufferProcess.move_to(buffer, {0, 2})
-      send_key(editor, ?")
-      send_key(editor, ?a)
-      send_key(editor, ?X)
-
-      assert BufferProcess.content(buffer) == "ac"
-      s = :sys.get_state(editor)
-      assert Map.get(s.workspace.editing.reg.registers, "a") == {"b", :charwise}
-    end
-  end
-
-  describe "insert-mode backspace does NOT yank" do
-    test "backspace in insert mode deletes without touching registers" do
-      {editor, buffer} = start_editor("abc")
-      BufferProcess.move_to(buffer, {0, 2})
-      # Enter insert mode
-      send_key(editor, ?i)
-      # Backspace (ASCII DEL)
-      send_key(editor, 127)
-
-      assert BufferProcess.content(buffer) == "ac"
-      s = :sys.get_state(editor)
-      # Register should be empty since insert-mode backspace doesn't yank
-      refute Map.has_key?(s.workspace.editing.reg.registers, "")
-    end
-  end
-
-  describe "s (substitute) yanks deleted char" do
-    test "s deletes char, enters insert mode, and yanks deleted char" do
-      {editor, buffer} = start_editor("abc")
-      BufferProcess.move_to(buffer, {0, 0})
-      send_key(editor, ?s)
-
-      assert BufferProcess.content(buffer) == "bc"
-      s = :sys.get_state(editor)
-      assert s.workspace.editing.mode == :insert
-      assert Map.get(s.workspace.editing.reg.registers, "") == {"a", :charwise}
-    end
-  end
-
-  describe "visual-char yank and paste" do
-    test "vllly then p pastes inline" do
-      {editor, buffer} = start_editor("abcdefgh")
-      BufferProcess.move_to(buffer, {0, 0})
-      # select "abcd"
-      send_key(editor, ?v)
-      send_key(editor, ?l)
-      send_key(editor, ?l)
-      send_key(editor, ?l)
-      send_key(editor, ?y)
-      # move to end and paste
-      send_key(editor, ?$)
-      send_key(editor, ?p)
-
-      content = BufferProcess.content(buffer)
-      refute String.contains?(content, "\n")
-    end
-  end
-
-  # ── Paste event (mode-independent) ──────────────────────────────────────
-
-  describe "paste event" do
-    test "paste inserts text in vim normal mode" do
-      {editor, buffer} = start_editor("hello")
-      # Don't enter insert mode, stay in normal
-      send(editor, {:minga_input, {:paste_event, "world"}})
-      _ = :sys.get_state(editor)
-
-      assert String.contains?(BufferProcess.content(buffer), "world")
-    end
-
-    test "paste inserts text in vim insert mode" do
-      {editor, buffer} = start_editor("hello")
-      send_key(editor, ?i)
-      send(editor, {:minga_input, {:paste_event, "xyz"}})
-      _ = :sys.get_state(editor)
-
-      assert String.contains?(BufferProcess.content(buffer), "xyz")
-    end
-
-    test "paste inserts multiline text" do
-      {editor, buffer} = start_editor("start")
-      send_key(editor, ?i)
-      send(editor, {:minga_input, {:paste_event, "line1\nline2"}})
-      _ = :sys.get_state(editor)
-
-      content = BufferProcess.content(buffer)
-      assert String.contains?(content, "line1\nline2")
-    end
-  end
-
-  # ── Autopair without mode gate ──────────────────────────────────────────
-
-  describe "autopair fires regardless of vim mode" do
-    test "insert_char autopairs opening bracket in normal mode context" do
-      # Autopair should fire for any :insert_char command, because the
-      # editing model already decided to produce the command. The executor
-      # doesn't second-guess mode.
-      {:ok, buffer} = BufferProcess.start_link(content: "")
-      BufferProcess.set_option(buffer, :autopair, true)
-
-      state = %MingaEditor.State{
-        port_manager: nil,
-        workspace: %MingaEditor.Workspace.State{
-          viewport: %MingaEditor.Viewport{top: 0, left: 0, rows: 10, cols: 40},
-          buffers: %MingaEditor.State.Buffers{active: buffer, list: [buffer]},
-          editing: MingaEditor.VimState.new()
-        }
-      }
-
-      # Execute insert_char directly (bypasses mode FSM, tests the executor)
-      MingaEditor.Commands.Editing.execute(state, {:insert_char, "("})
-
-      content = BufferProcess.content(buffer)
-      assert content == "()", "autopair should insert closing paren, got: #{inspect(content)}"
-    end
-
-    test "delete_before removes autopair in normal mode context" do
-      {:ok, buffer} = BufferProcess.start_link(content: "()")
-      BufferProcess.set_option(buffer, :autopair, true)
-      # Place cursor between the parens (line 0, col 1)
-      BufferProcess.move_to(buffer, {0, 1})
-
-      state = %MingaEditor.State{
-        port_manager: nil,
-        workspace: %MingaEditor.Workspace.State{
-          viewport: %MingaEditor.Viewport{top: 0, left: 0, rows: 10, cols: 40},
-          buffers: %MingaEditor.State.Buffers{active: buffer, list: [buffer]},
-          editing: MingaEditor.VimState.new()
-        }
-      }
-
-      MingaEditor.Commands.Editing.execute(state, :delete_before)
-
-      content = BufferProcess.content(buffer)
-      assert content == "", "autopair should delete both parens, got: #{inspect(content)}"
-    end
+    _ = :sys.get_state(editor, @sync_timeout)
   end
 end

--- a/test/minga_editor/commands/operators_test.exs
+++ b/test/minga_editor/commands/operators_test.exs
@@ -1,10 +1,8 @@
 defmodule MingaEditor.Commands.OperatorsTest do
   @moduledoc """
-  Tests for counted line operators (delete_lines_counted, change_lines_counted,
-  yank_lines_counted) in MingaEditor.Commands.Operators.
+  Layer 0/1 command-state tests for counted line operators (delete_lines_counted, change_lines_counted, yank_lines_counted) in MingaEditor.Commands.Operators.
 
-  Calls `Operators.execute/2` directly on constructed EditorState structs
-  with a real BufferProcess. No Editor GenServer needed.
+  Calls `Operators.execute/2` directly on constructed EditorState structs with a real BufferProcess. No Editor GenServer needed.
   """
   use ExUnit.Case, async: true
 

--- a/test/minga_editor/commands/search_leader_test.exs
+++ b/test/minga_editor/commands/search_leader_test.exs
@@ -1,11 +1,18 @@
 defmodule MingaEditor.Commands.SearchLeaderTest do
-  use Minga.Test.EditorCase, async: true
+  @moduledoc """
+  Layer 0/1 command-state tests for search leader commands.
 
-  describe "search_buffer" do
+  These commands only transform EditorState, so they do not need a live Editor GenServer.
+  """
+
+  use ExUnit.Case, async: true
+
+  import MingaEditor.CommandStateHelpers
+
+  describe "Layer 0/1 command state: search_buffer" do
     test "transitions to search mode with forward direction" do
-      ctx = start_editor("hello world")
+      state = start_buffer("hello world") |> command_state()
 
-      state = editor_state(ctx)
       state = MingaEditor.Commands.execute(state, :search_buffer)
 
       assert state.workspace.editing.mode == :search
@@ -13,11 +20,10 @@ defmodule MingaEditor.Commands.SearchLeaderTest do
     end
   end
 
-  describe "search_and_replace" do
+  describe "Layer 0/1 command state: search_and_replace" do
     test "transitions to command mode with %s/ prefix" do
-      ctx = start_editor("hello world")
+      state = start_buffer("hello world") |> command_state()
 
-      state = editor_state(ctx)
       state = MingaEditor.Commands.execute(state, :search_and_replace)
 
       assert state.workspace.editing.mode == :command

--- a/test/minga_editor/commands/select_all_test.exs
+++ b/test/minga_editor/commands/select_all_test.exs
@@ -1,37 +1,38 @@
 defmodule MingaEditor.Commands.SelectAllTest do
   @moduledoc """
-  Tests for the :select_all command.
+  Layer 0/1 command-state tests for the :select_all command.
+
+  The observable contract is the selected buffer range and visual state, so a live Editor GenServer is unnecessary.
   """
 
-  use Minga.Test.EditorCase, async: true
+  use ExUnit.Case, async: true
 
-  describe "select_all" do
+  import MingaEditor.CommandStateHelpers
+
+  alias Minga.Buffer.Process, as: BufferProcess
+
+  describe "Layer 0/1 command state: select_all" do
     test "enters visual line mode with full buffer selected" do
-      ctx = start_editor("aaa\nbbb\nccc")
+      buffer = start_buffer("aaa\nbbb\nccc")
+      state = command_state(buffer)
 
-      send_keys_sync(ctx, "<Space>")
-      # Cancel the leader mode (we just need normal mode for the test)
-      send_key(ctx, 27)
-
-      # Execute select_all via command registry
-      state = editor_state(ctx)
       state = MingaEditor.Commands.execute(state, :select_all)
 
-      assert Minga.Editing.mode(state) == :visual
-      ms = MingaEditor.Editing.mode_state(state)
-      assert ms.visual_anchor == {0, 0}
-      assert ms.visual_type == :line
+      assert state.workspace.editing.mode == :visual
+      assert state.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert state.workspace.editing.mode_state.visual_type == :line
+      assert BufferProcess.cursor(buffer) == {2, 2}
     end
 
     test "works with single-line buffer" do
-      ctx = start_editor("hello")
+      buffer = start_buffer("hello")
+      state = command_state(buffer)
 
-      state = editor_state(ctx)
       state = MingaEditor.Commands.execute(state, :select_all)
 
-      assert Minga.Editing.mode(state) == :visual
-      ms = MingaEditor.Editing.mode_state(state)
-      assert ms.visual_anchor == {0, 0}
+      assert state.workspace.editing.mode == :visual
+      assert state.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert BufferProcess.cursor(buffer) == {0, 4}
     end
   end
 end

--- a/test/minga_editor/commands/use_selection_for_find_test.exs
+++ b/test/minga_editor/commands/use_selection_for_find_test.exs
@@ -1,15 +1,18 @@
 defmodule MingaEditor.Commands.UseSelectionForFindTest do
   @moduledoc """
-  Tests for the :use_selection_for_find command (Cmd+E).
+  Layer 0/1 command-state tests for the :use_selection_for_find command.
+
+  The command reads the active buffer snapshot and updates search/status state directly, so it does not need a live Editor GenServer.
   """
 
-  use Minga.Test.EditorCase, async: true
+  use ExUnit.Case, async: true
 
-  describe "use_selection_for_find" do
+  import MingaEditor.CommandStateHelpers
+
+  describe "Layer 0/1 command state: use_selection_for_find" do
     test "sets search pattern to word under cursor" do
-      ctx = start_editor("hello world")
+      state = start_buffer("hello world") |> command_state()
 
-      state = editor_state(ctx)
       state = MingaEditor.Commands.execute(state, :use_selection_for_find)
 
       assert state.workspace.search.last_pattern == "hello"
@@ -17,9 +20,8 @@ defmodule MingaEditor.Commands.UseSelectionForFindTest do
     end
 
     test "sets forward search direction" do
-      ctx = start_editor("hello world")
+      state = start_buffer("hello world") |> command_state()
 
-      state = editor_state(ctx)
       state = MingaEditor.Commands.execute(state, :use_selection_for_find)
 
       assert state.workspace.search.last_direction == :forward

--- a/test/minga_editor/commands/visual_test.exs
+++ b/test/minga_editor/commands/visual_test.exs
@@ -1,63 +1,76 @@
 defmodule MingaEditor.Commands.VisualTest do
+  @moduledoc """
+  Split visual coverage by layer.
+
+  Mode FSM tests assert key emission. Command-state tests assert buffer/register behavior without a live Editor GenServer.
+  """
+
   use ExUnit.Case, async: true
 
+  import MingaEditor.CommandStateHelpers
+
   alias Minga.Buffer.Process, as: BufferProcess
-  alias MingaEditor
+  alias Minga.Mode
+  alias MingaEditor.Commands.Visual
 
-  defp start_editor(content) do
-    {:ok, buffer} = BufferProcess.start_link(content: content)
+  describe "Layer 0 Mode FSM: visual key emission" do
+    test "v enters characterwise visual mode" do
+      {mode, commands, mode_state} = Mode.process(:normal, {?v, 0}, Mode.initial_state())
 
-    {:ok, editor} =
-      MingaEditor.start_link(
-        name: :"editor_#{:erlang.unique_integer([:positive])}",
-        port_manager: nil,
-        buffer: buffer,
-        width: 40,
-        height: 10,
-        editing_model: :vim
-      )
-
-    {editor, buffer}
-  end
-
-  defp send_key(editor, codepoint, mods \\ 0) do
-    send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor)
-  end
-
-  describe "visual mode" do
-    test "v enters visual mode and d deletes selection" do
-      {editor, buffer} = start_editor("hello world")
-      send_key(editor, ?v)
-      send_key(editor, ?l)
-      send_key(editor, ?l)
-      send_key(editor, ?d)
-
-      content = BufferProcess.content(buffer)
-      refute String.starts_with?(content, "hel")
+      assert mode == :visual
+      assert commands == []
+      assert mode_state.visual_type == :char
     end
 
     test "V enters linewise visual mode" do
-      {editor, buffer} = start_editor("hello\nworld\nfoo")
-      send_key(editor, ?V)
-      send_key(editor, ?j)
-      send_key(editor, ?d)
+      {mode, commands, mode_state} = Mode.process(:normal, {?V, 0}, Mode.initial_state())
 
-      content = BufferProcess.content(buffer)
-      assert String.contains?(content, "foo")
+      assert mode == :visual
+      assert commands == []
+      assert mode_state.visual_type == :line
     end
 
-    test "v then y yanks visual selection" do
-      {editor, buffer} = start_editor("hello world")
-      send_key(editor, ?v)
-      send_key(editor, ?l)
-      send_key(editor, ?l)
-      send_key(editor, ?y)
+    test "visual d and y emit command outputs and leave visual mode" do
+      {_mode, _commands, mode_state} = Mode.process(:normal, {?v, 0}, Mode.initial_state())
+
+      assert {:normal, [:delete_visual_selection], _} = Mode.process(:visual, {?d, 0}, mode_state)
+      assert {:normal, [:yank_visual_selection], _} = Mode.process(:visual, {?y, 0}, mode_state)
+    end
+  end
+
+  describe "Layer 0/1 command state: visual selection behavior" do
+    test "delete_visual_selection deletes characterwise selection and stores unnamed register" do
+      buffer = start_buffer("hello world")
+      BufferProcess.move_to(buffer, {0, 2})
+      state = command_state(buffer) |> with_visual_selection({0, 0}, :char)
+
+      state = Visual.execute(state, :delete_visual_selection)
+
+      assert BufferProcess.content(buffer) == "lo world"
+      assert register_entry(state) == {"hel", :charwise}
+    end
+
+    test "delete_visual_selection deletes linewise selection" do
+      buffer = start_buffer("hello\nworld\nfoo")
+      BufferProcess.move_to(buffer, {1, 0})
+      state = command_state(buffer) |> with_visual_selection({0, 0}, :line)
+
+      state = Visual.execute(state, :delete_visual_selection)
+
+      assert BufferProcess.content(buffer) == "foo"
+      assert register_entry(state) == {"hello\nworld\n", :linewise}
+    end
+
+    test "yank_visual_selection leaves content unchanged and stores the selection" do
+      buffer = start_buffer("hello world")
+      BufferProcess.move_to(buffer, {0, 2})
+      state = command_state(buffer) |> with_visual_selection({0, 0}, :char)
+
+      state = Visual.execute(state, :yank_visual_selection)
 
       assert BufferProcess.content(buffer) == "hello world"
-
-      send_key(editor, ?p)
-      assert String.length(BufferProcess.content(buffer)) > String.length("hello world")
+      assert register_entry(state) == {"hel", :charwise}
+      assert register_entry(state, "0") == {"hel", :charwise}
     end
   end
 end

--- a/test/support/minga_editor/command_state_helpers.ex
+++ b/test/support/minga_editor/command_state_helpers.ex
@@ -1,0 +1,81 @@
+defmodule MingaEditor.CommandStateHelpers do
+  @moduledoc """
+  Lightweight helpers for command tests that need an EditorState-shaped value without an Editor GenServer.
+  """
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Mode
+  alias Minga.Mode.VisualState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Registers
+  alias MingaEditor.Viewport
+  alias MingaEditor.VimState
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  @type state :: EditorState.t()
+  @type register_type :: Registers.reg_type()
+
+  @spec start_buffer(String.t(), keyword()) :: pid()
+  def start_buffer(content, opts \\ []) when is_binary(content) and is_list(opts) do
+    opts = Keyword.put(opts, :content, content)
+    id = {:command_state_buffer, System.unique_integer([:positive])}
+    buffer = ExUnit.Callbacks.start_supervised!({BufferProcess, opts}, id: id)
+    BufferProcess.set_option(buffer, :clipboard, :none)
+    buffer
+  end
+
+  @spec command_state(pid(), keyword()) :: state()
+  def command_state(buffer, opts \\ []) when is_pid(buffer) and is_list(opts) do
+    mode = Keyword.get(opts, :mode, :normal)
+    mode_state = Keyword.get(opts, :mode_state, Mode.initial_state())
+    editing = VimState.transition(VimState.new(), mode, mode_state)
+    buffers = Buffers.add(%Buffers{}, buffer)
+
+    %EditorState{
+      backend: Keyword.get(opts, :backend, :headless),
+      port_manager: Keyword.get(opts, :port_manager, nil),
+      workspace: %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: buffers,
+        editing: editing
+      }
+    }
+  end
+
+  @spec with_mode(state(), Mode.mode(), Mode.state() | nil) :: state()
+  def with_mode(%EditorState{} = state, mode, mode_state \\ nil) do
+    EditorState.transition_mode(state, mode, mode_state)
+  end
+
+  @spec with_visual_selection(state(), {non_neg_integer(), non_neg_integer()}, :char | :line) ::
+          state()
+  def with_visual_selection(%EditorState{} = state, anchor, visual_type)
+      when visual_type in [:char, :line] do
+    with_mode(state, :visual, %VisualState{visual_anchor: anchor, visual_type: visual_type})
+  end
+
+  @spec with_register(state(), String.t(), String.t(), register_type()) :: state()
+  def with_register(%EditorState{} = state, name, text, type \\ :charwise) do
+    update_registers(state, &Registers.put(&1, name, text, type))
+  end
+
+  @spec with_active_register(state(), String.t()) :: state()
+  def with_active_register(%EditorState{} = state, name) do
+    update_registers(state, &Registers.set_active(&1, name))
+  end
+
+  @spec register_entry(state(), String.t()) :: Registers.entry() | nil
+  def register_entry(%EditorState{} = state, name \\ "") do
+    Registers.get(state.workspace.editing.reg, name)
+  end
+
+  @spec update_registers(state(), (Registers.t() -> Registers.t())) :: state()
+  def update_registers(%EditorState{} = state, fun) when is_function(fun, 1) do
+    EditorState.update_workspace(state, fn workspace ->
+      WorkspaceState.update_editing(workspace, fn vim ->
+        VimState.set_registers(vim, fun.(vim.reg))
+      end)
+    end)
+  end
+end


### PR DESCRIPTION
# TL;DR
Split the large command editing test coverage into cheaper layer-specific tests. The PR keeps a small Editor GenServer smoke layer, while direct Mode FSM and command-state tests now carry most of the behavior coverage.

Closes #1693

## Context
Issue #1693 identified the command editing tests as the largest lighter-layer opportunity in `commands/*`. The previous suite mixed key routing, mode transitions, command execution, register behavior, and content mutation in live editor tests.

## Changes
- Added `MingaEditor.CommandStateHelpers` for constructing lightweight command-state tests with a real buffer but no Editor GenServer.
- Reworked `editing_test.exs` into Mode FSM emission tests, direct command-state mutation tests, and a small end-to-end smoke set for normal, insert, command, visual, operator-pending, and paste routing.
- Reworked reindent coverage so `=` dispatch is tested at the Mode FSM layer, content mutations are tested through `MingaEditor.Commands.Editing`, and one live `==` smoke test remains.
- Moved search leader, select-all, and use-selection-for-find coverage to direct command/state assertions.
- Kept operator, register, Cmd+C/Cmd+X, read-only, and visual behavior assertions focused on observable content, cursor, register, search, and visual state.

## Verification
- `mix test.llm test/minga_editor/commands/editing_test.exs test/minga_editor/commands/editing_reindent_test.exs test/minga_editor/commands/visual_test.exs test/minga_editor/commands/operators_test.exs test/minga_editor/commands/cmd_copy_cut_test.exs test/minga_editor/commands/search_leader_test.exs test/minga_editor/commands/select_all_test.exs test/minga_editor/commands/use_selection_for_find_test.exs` ✅ PASS, 83 tests
- `make lint` ✅ PASS
- `mix test.llm` was run, but unrelated async/performance tests failed outside this diff. The reported locations passed when rerun by line, and the persistent mouse failure reproduced on `main` with the same assertion.
- Final targeted reviewer recheck ✅ PASS

## Acceptance Criteria Addressed
- Each scoped test is classified by layer ✅
- Insert-mode entry and normal-mode command emission moved to Mode FSM or focused command tests where possible ✅
- Operator and register behavior asserted through direct command/editing functions ✅
- Reindent dispatch/content coverage split by layer with a small live smoke test ✅
- Search leader, select-all, and use-selection-for-find use direct command/state assertions ✅
- Read-only command paths keep meaningful no-mutation/no-clipboard assertions ✅
- Remaining editor-level tests are limited to a small routing smoke set ✅
- Anti-tautology rule followed with observable state/content/register assertions ✅
- Focused rewritten-file tests pass ✅
