### PR TITLE
feat(buffer): store undo history as patches

### DIFF
--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -50,6 +50,7 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     "Minga.Buffer.SaveState",
     "Minga.Buffer.State",
     "Minga.Buffer.UndoHistory",
+    "Minga.Buffer.UndoPatch",
     "Minga.Editing.Motion",
     "Minga.Editing.Operator",
     "Minga.Editing.TextObject",

--- a/lib/minga/buffer/document.ex
+++ b/lib/minga/buffer/document.ex
@@ -247,6 +247,31 @@ defmodule Minga.Buffer.Document do
     buf |> Selection.linewise(start_line, end_line) |> then(&Selection.delete(buf, &1))
   end
 
+  @doc false
+  @spec replace_at_byte_range(t(), non_neg_integer(), non_neg_integer(), binary(), position()) ::
+          t()
+  def replace_at_byte_range(
+        %__MODULE__{} = doc,
+        start_byte,
+        bytes_to_remove,
+        text_to_insert,
+        cursor_pos
+      )
+      when start_byte >= 0 and bytes_to_remove >= 0 and is_binary(text_to_insert) do
+    content = content(doc)
+    content_size = byte_size(content)
+    :ok = validate_byte_range(start_byte, bytes_to_remove, content_size)
+    prefix = binary_part(content, 0, start_byte)
+    suffix_start = start_byte + bytes_to_remove
+    suffix = binary_part(content, suffix_start, content_size - suffix_start)
+    new_content = prefix <> text_to_insert <> suffix
+
+    new_content
+    |> validate_reconstructed_content()
+    |> new()
+    |> move_to(cursor_pos)
+  end
+
   @doc """
   Returns the content and cursor position in a single call,
   avoiding separate content/1 + cursor/1 round-trips.
@@ -262,6 +287,25 @@ defmodule Minga.Buffer.Document do
   end
 
   # ── Private helpers ──
+
+  @spec validate_byte_range(non_neg_integer(), non_neg_integer(), non_neg_integer()) :: :ok
+  defp validate_byte_range(start_byte, bytes_to_remove, content_size)
+       when start_byte <= content_size and start_byte + bytes_to_remove <= content_size do
+    :ok
+  end
+
+  defp validate_byte_range(start_byte, bytes_to_remove, content_size) do
+    raise ArgumentError,
+          "invalid byte range: start_byte=#{start_byte}, bytes_to_remove=#{bytes_to_remove}, content_size=#{content_size}"
+  end
+
+  @spec validate_reconstructed_content(binary()) :: binary()
+  defp validate_reconstructed_content(content) do
+    case String.valid?(content) do
+      true -> content
+      false -> raise ArgumentError, "byte range replacement produced invalid UTF-8 content"
+    end
+  end
 
   # Computes new cursor position and line_count after inserting `text` at the current cursor.
   # Uses byte_size for column tracking.

--- a/lib/minga/buffer/operation.ex
+++ b/lib/minga/buffer/operation.ex
@@ -10,6 +10,7 @@ defmodule Minga.Buffer.Operation do
   alias Minga.Buffer.Position
   alias Minga.Buffer.Selection
   alias Minga.Buffer.Span
+  alias Minga.Buffer.UndoPatch
 
   @typedoc "Result of a pure edit operation."
   @type result :: :unchanged | {:edited, Document.t(), EditDelta.t()}
@@ -57,11 +58,20 @@ defmodule Minga.Buffer.Operation do
   @doc "Applies multiple range replacements from the end of the document toward the start."
   @spec replace_ranges(Document.t(), [range_edit()]) :: Document.t()
   def replace_ranges(%Document{} = doc, edits) when is_list(edits) do
+    {new_doc, _patches} = replace_ranges_with_patches(doc, edits)
+    new_doc
+  end
+
+  @doc "Applies multiple range replacements and returns undo patches in newest-first recording order."
+  @spec replace_ranges_with_patches(Document.t(), [range_edit()]) ::
+          {Document.t(), [UndoPatch.t()]}
+  def replace_ranges_with_patches(%Document{} = doc, edits) when is_list(edits) do
     edits
     |> Enum.sort(fn {from_a, _, _}, {from_b, _, _} -> from_a >= from_b end)
-    |> Enum.reduce(doc, fn {from_pos, to_pos, replacement}, acc ->
-      {:edited, new_doc, _delta} = replace_range(acc, from_pos, to_pos, replacement)
-      new_doc
+    |> Enum.reduce({doc, []}, fn {from_pos, to_pos, replacement}, {acc_doc, patches} ->
+      {:edited, new_doc, delta} = replace_range(acc_doc, from_pos, to_pos, replacement)
+      patch = UndoPatch.from_delta(delta, acc_doc)
+      {new_doc, [patch | patches]}
     end)
   end
 
@@ -134,22 +144,77 @@ defmodule Minga.Buffer.Operation do
   @spec delete_lines(Document.t(), non_neg_integer(), non_neg_integer()) :: result()
   def delete_lines(%Document{} = doc, start_line, end_line)
       when start_line >= 0 and end_line >= 0 do
-    selection = Selection.linewise(doc, start_line, end_line)
-    %Span{start: start_byte, stop: old_end_byte} = selection.span
     new_doc = Document.delete_lines(doc, start_line, end_line)
 
     if new_doc == doc do
       :unchanged
     else
-      delta =
-        EditDelta.deletion(
-          start_byte,
-          old_end_byte,
-          Position.from_point(doc, start_byte),
-          Position.from_point(doc, old_end_byte)
-        )
-
-      {:edited, new_doc, delta}
+      {:edited, new_doc, deletion_delta_from_documents(doc, new_doc)}
     end
   end
+
+  @spec deletion_delta_from_documents(Document.t(), Document.t()) :: EditDelta.t()
+  defp deletion_delta_from_documents(%Document{} = old_doc, %Document{} = new_doc) do
+    old_content = Document.content(old_doc)
+    new_content = Document.content(new_doc)
+    start_byte = :binary.longest_common_prefix([old_content, new_content])
+    old_tail = byte_size(old_content) - start_byte
+    new_tail = byte_size(new_content) - start_byte
+    suffix_size = common_suffix_size(old_content, new_content, old_tail, new_tail)
+    old_end_byte = byte_size(old_content) - suffix_size
+
+    EditDelta.deletion(
+      start_byte,
+      old_end_byte,
+      Position.from_point(old_doc, start_byte),
+      Position.from_point(old_doc, old_end_byte)
+    )
+  end
+
+  @spec common_suffix_size(binary(), binary(), non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  defp common_suffix_size(left, right, left_tail, right_tail) do
+    left_suffix = binary_part(left, byte_size(left) - left_tail, left_tail)
+    right_suffix = binary_part(right, byte_size(right) - right_tail, right_tail)
+    do_common_suffix_size(left_suffix, right_suffix, left_tail, right_tail, 0)
+  end
+
+  @spec do_common_suffix_size(
+          binary(),
+          binary(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: non_neg_integer()
+  defp do_common_suffix_size(_left, _right, 0, _right_tail, count), do: count
+  defp do_common_suffix_size(_left, _right, _left_tail, 0, count), do: count
+
+  defp do_common_suffix_size(left, right, left_tail, right_tail, count) do
+    left_byte = :binary.at(left, left_tail - 1)
+    right_byte = :binary.at(right, right_tail - 1)
+
+    continue_common_suffix_size(
+      left,
+      right,
+      left_tail,
+      right_tail,
+      count,
+      left_byte == right_byte
+    )
+  end
+
+  @spec continue_common_suffix_size(
+          binary(),
+          binary(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean()
+        ) :: non_neg_integer()
+  defp continue_common_suffix_size(left, right, left_tail, right_tail, count, true) do
+    do_common_suffix_size(left, right, left_tail - 1, right_tail - 1, count + 1)
+  end
+
+  defp continue_common_suffix_size(_left, _right, _left_tail, _right_tail, count, false),
+    do: count
 end

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -27,7 +27,8 @@ defmodule Minga.Buffer.Process do
     Persistence,
     Position,
     Replace,
-    UndoHistory
+    UndoHistory,
+    UndoPatch
   }
 
   alias Minga.Buffer.EditDelta
@@ -902,7 +903,10 @@ defmodule Minga.Buffer.Process do
   def handle_call({:insert_text, text, source}, _from, state) do
     {:edited, new_doc, delta} = Operation.insert_at_cursor(state.document, text)
     undo_source = EditSource.to_undo_source(source)
-    state = push_undo(state, new_doc, undo_source) |> mark_dirty() |> record_edit(delta, source)
+
+    state =
+      push_undo(state, new_doc, undo_source, delta) |> mark_dirty() |> record_edit(delta, source)
+
     {:reply, :ok, state}
   end
 
@@ -921,7 +925,7 @@ defmodule Minga.Buffer.Process do
     undo_source = EditSource.to_undo_source(source)
 
     {:reply, :ok,
-     push_undo(state, new_doc, undo_source) |> mark_dirty() |> record_edit(delta, source)}
+     push_undo(state, new_doc, undo_source, delta) |> mark_dirty() |> record_edit(delta, source)}
   end
 
   def handle_call({:apply_edits, _edits, _source}, _from, %{read_only: true} = state) do
@@ -933,12 +937,12 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call({:apply_edits, edits, source}, _from, state) do
-    doc = Operation.replace_ranges(state.document, edits)
+    {doc, patches} = Operation.replace_ranges_with_patches(state.document, edits)
     undo_source = EditSource.to_undo_source(source)
 
-    # Multi-edit batches are complex to delta-track (offsets shift between
-    # edits). Clear pending edits to force a full content sync.
-    {:reply, :ok, push_undo(state, doc, undo_source) |> mark_dirty() |> clear_edits(source)}
+    # Batch edits shift offsets between replacements, so consumers need a full content sync.
+    {:reply, :ok,
+     push_undo_batch(state, doc, undo_source, patches) |> mark_dirty() |> clear_edits(source)}
   end
 
   # ── Find and Replace ──
@@ -951,7 +955,7 @@ defmodule Minga.Buffer.Process do
     case Replace.apply(state.document, old_text, new_text, boundary) do
       {:ok, new_doc, msg} ->
         {:reply, {:ok, msg},
-         push_undo_force(state, new_doc, :agent)
+         push_undo_force_full(state, new_doc, :agent)
          |> mark_dirty()
          |> clear_edits(EditSource.agent(self(), "unknown"))}
 
@@ -973,7 +977,7 @@ defmodule Minga.Buffer.Process do
 
     new_state =
       if any_applied? do
-        push_undo_force(state, final_doc, :agent)
+        push_undo_force_full(state, final_doc, :agent)
         |> mark_dirty()
         |> clear_edits(EditSource.agent(self(), "unknown"))
       else
@@ -993,7 +997,8 @@ defmodule Minga.Buffer.Process do
         {:reply, :ok, state}
 
       {:edited, new_doc, delta} ->
-        {:reply, :ok, push_undo(state, new_doc, :user) |> mark_dirty() |> record_edit(delta)}
+        {:reply, :ok,
+         push_undo(state, new_doc, :user, delta) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -1007,7 +1012,8 @@ defmodule Minga.Buffer.Process do
         {:reply, :ok, state}
 
       {:edited, new_doc, delta} ->
-        {:reply, :ok, push_undo(state, new_doc, :user) |> mark_dirty() |> record_edit(delta)}
+        {:reply, :ok,
+         push_undo(state, new_doc, :user, delta) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -1155,10 +1161,10 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call({:replace_content, new_content, source}, _from, state) do
-    new_state = push_undo_force(state, state.document, source)
     new_buf = Document.new(new_content)
+    new_state = push_undo_force_full(state, new_buf, source)
     event_source = EditSource.from_undo_source(source)
-    {:reply, :ok, mark_dirty(%{new_state | document: new_buf}) |> clear_edits(event_source)}
+    {:reply, :ok, mark_dirty(new_state) |> clear_edits(event_source)}
   end
 
   # Force replace bypasses read_only. Used by panel buffers (file tree, agent)
@@ -1169,6 +1175,7 @@ defmodule Minga.Buffer.Process do
     new_state = %{
       BufState.record_clean_change(state)
       | document: new_buf,
+        undo_history: UndoHistory.clear(state.undo_history),
         change_log: ChangeLog.clear(state.change_log),
         decorations: Decorations.new()
     }
@@ -1421,7 +1428,8 @@ defmodule Minga.Buffer.Process do
         {:reply, :ok, state}
 
       {:edited, new_doc, delta} ->
-        {:reply, :ok, push_undo(state, new_doc, :user) |> mark_dirty() |> record_edit(delta)}
+        {:reply, :ok,
+         push_undo(state, new_doc, :user, delta) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -1445,7 +1453,8 @@ defmodule Minga.Buffer.Process do
         {:reply, :ok, state}
 
       {:edited, new_doc, delta} ->
-        {:reply, :ok, push_undo(state, new_doc, :user) |> mark_dirty() |> record_edit(delta)}
+        {:reply, :ok,
+         push_undo(state, new_doc, :user, delta) |> mark_dirty() |> record_edit(delta)}
     end
   end
 
@@ -1463,7 +1472,7 @@ defmodule Minga.Buffer.Process do
 
   def handle_call({:commit_snapshot, new_buf}, _from, state) do
     {:reply, :ok,
-     push_undo(state, new_buf, :user) |> mark_dirty() |> clear_edits(EditSource.user())}
+     push_undo_full(state, new_buf, :user) |> mark_dirty() |> clear_edits(EditSource.user())}
   end
 
   def handle_call({:clear_line, _line}, _from, %{read_only: true} = state) do
@@ -1476,7 +1485,7 @@ defmodule Minga.Buffer.Process do
     if new_buf == state.document do
       {:reply, {:ok, yanked}, state}
     else
-      {:reply, {:ok, yanked}, push_undo(state, new_buf, :user) |> mark_dirty()}
+      {:reply, {:ok, yanked}, push_undo_full(state, new_buf, :user) |> mark_dirty()}
     end
   end
 
@@ -1574,6 +1583,7 @@ defmodule Minga.Buffer.Process do
     new_state = %{
       BufState.record_clean_change(state)
       | document: new_doc,
+        undo_history: UndoHistory.clear(state.undo_history),
         change_log: ChangeLog.clear(state.change_log),
         decorations: new_decs
     }
@@ -1821,23 +1831,40 @@ defmodule Minga.Buffer.Process do
     :exit, _ -> %{}
   end
 
-  @spec push_undo(state(), Document.t(), BufState.edit_source()) :: state()
-  defp push_undo(state, new_buf, source) do
+  @spec push_undo(state(), Document.t(), BufState.edit_source(), EditDelta.t()) :: state()
+  defp push_undo(state, new_buf, source, delta) do
+    patch = UndoPatch.from_delta(delta, state.document)
+
     undo_history =
-      UndoHistory.record_edit(state.undo_history, BufState.version(state), state.document, source)
+      UndoHistory.record_edit(state.undo_history, BufState.version(state), patch, source)
 
     %{state | document: new_buf, undo_history: undo_history}
   end
 
-  @spec push_undo_force(state(), Document.t(), BufState.edit_source()) :: state()
-  defp push_undo_force(state, new_buf, source) do
+  @spec push_undo_full(state(), Document.t(), BufState.edit_source()) :: state()
+  defp push_undo_full(state, new_buf, source) do
+    patch = UndoPatch.from_documents(state.document, new_buf)
+
     undo_history =
-      UndoHistory.record_edit_force(
-        state.undo_history,
-        BufState.version(state),
-        state.document,
-        source
-      )
+      UndoHistory.record_edit(state.undo_history, BufState.version(state), patch, source)
+
+    %{state | document: new_buf, undo_history: undo_history}
+  end
+
+  @spec push_undo_batch(state(), Document.t(), BufState.edit_source(), [UndoPatch.t()]) :: state()
+  defp push_undo_batch(state, new_buf, source, patches) do
+    undo_history =
+      UndoHistory.record_edit_batch(state.undo_history, BufState.version(state), patches, source)
+
+    %{state | document: new_buf, undo_history: undo_history}
+  end
+
+  @spec push_undo_force_full(state(), Document.t(), BufState.edit_source()) :: state()
+  defp push_undo_force_full(state, new_buf, source) do
+    patch = UndoPatch.from_documents(state.document, new_buf)
+
+    undo_history =
+      UndoHistory.record_edit_force(state.undo_history, BufState.version(state), patch, source)
 
     %{state | document: new_buf, undo_history: undo_history}
   end

--- a/lib/minga/buffer/undo_history.ex
+++ b/lib/minga/buffer/undo_history.ex
@@ -2,21 +2,23 @@ defmodule Minga.Buffer.UndoHistory do
   @moduledoc """
   Undo and redo history for a buffer document.
 
-  The buffer process owns the live document and version counter. This struct remembers the snapshots needed to move backward and forward through document history, including the source of each edit for diagnostics and attribution.
+  The buffer process owns the live document and version counter. This struct remembers the patches needed to move backward and forward through document history, including the source of each edit for diagnostics and attribution.
 
-  This module is pure state. It does not mark buffers dirty, broadcast events, or mutate documents.
+  This module is pure state. It does not mark buffers dirty, broadcast events, or mutate documents outside applying returned patches to produce a restore document.
   """
 
   alias Minga.Buffer.Document
   alias Minga.Buffer.EditSource
   alias Minga.Buffer.UndoHistory.Restore
+  alias Minga.Buffer.UndoPatch
 
   @max_entries 1000
   @coalesce_ms 300
 
   @type edit_source :: EditSource.undo_source()
   @type version :: non_neg_integer()
-  @type entry :: {version(), Document.t(), edit_source()}
+  @type patches :: nonempty_list(UndoPatch.t())
+  @type entry :: {version(), patches(), edit_source()}
 
   defstruct undo_entries: [],
             redo_entries: [],
@@ -36,22 +38,22 @@ defmodule Minga.Buffer.UndoHistory do
   @spec coalesce_ms() :: pos_integer()
   def coalesce_ms, do: @coalesce_ms
 
-  @doc "Records an undo snapshot, coalescing rapid edits into one history entry."
-  @spec record_edit(t(), version(), Document.t(), edit_source()) :: t()
-  def record_edit(%__MODULE__{} = history, version, %Document{} = document, source)
+  @doc "Records an undo patch, coalescing rapid edits into one history entry."
+  @spec record_edit(t(), version(), UndoPatch.t(), edit_source()) :: t()
+  def record_edit(%__MODULE__{} = history, version, patch, source)
       when source in [:user, :agent, :lsp, :recovery] do
     now = System.monotonic_time(:millisecond)
     elapsed = now - history.last_recorded_at
 
-    do_record_edit(history, version, document, source, now, elapsed)
+    do_record_edit(history, version, patch, source, now, elapsed)
   end
 
-  @doc "Records an undo snapshot without time-based coalescing."
-  @spec record_edit_force(t(), version(), Document.t(), edit_source()) :: t()
-  def record_edit_force(%__MODULE__{} = history, version, %Document{} = document, source)
+  @doc "Records one undo entry containing all patches in the batch."
+  @spec record_edit_batch(t(), version(), patches(), edit_source()) :: t()
+  def record_edit_batch(%__MODULE__{} = history, version, [_patch | _rest] = patches, source)
       when source in [:user, :agent, :lsp, :recovery] do
     now = System.monotonic_time(:millisecond)
-    entry = {version, document, source}
+    entry = {version, patches, source}
 
     %{
       history
@@ -61,13 +63,21 @@ defmodule Minga.Buffer.UndoHistory do
     }
   end
 
+  @doc "Records an undo patch without time-based coalescing."
+  @spec record_edit_force(t(), version(), UndoPatch.t(), edit_source()) :: t()
+  def record_edit_force(%__MODULE__{} = history, version, patch, source)
+      when source in [:user, :agent, :lsp, :recovery] do
+    record_edit_batch(history, version, [patch], source)
+  end
+
   @doc "Returns the previous document/version and updates history, or `:empty` when undo is unavailable."
   @spec undo(t(), version(), Document.t()) :: {:ok, Restore.t(), t()} | :empty
   def undo(%__MODULE__{undo_entries: []}, _current_version, %Document{}), do: :empty
 
   def undo(%__MODULE__{} = history, current_version, %Document{} = current_document) do
-    [{previous_version, previous_document, source} | remaining_undo] = history.undo_entries
-    redo_entry = {current_version, current_document, source}
+    [{previous_version, patches, source} | remaining_undo] = history.undo_entries
+    {previous_document, redo_patches} = apply_patches(current_document, patches)
+    redo_entry = {current_version, redo_patches, source}
 
     new_history = %{
       history
@@ -83,8 +93,9 @@ defmodule Minga.Buffer.UndoHistory do
   def redo(%__MODULE__{redo_entries: []}, _current_version, %Document{}), do: :empty
 
   def redo(%__MODULE__{} = history, current_version, %Document{} = current_document) do
-    [{next_version, next_document, source} | remaining_redo] = history.redo_entries
-    undo_entry = {current_version, current_document, source}
+    [{next_version, patches, source} | remaining_redo] = history.redo_entries
+    {next_document, undo_patches} = apply_patches(current_document, patches)
+    undo_entry = {current_version, undo_patches, source}
 
     new_history = %{
       history
@@ -110,12 +121,12 @@ defmodule Minga.Buffer.UndoHistory do
   @doc "Returns the source of the most recent undo entry, or `nil` if undo is unavailable."
   @spec last_undo_source(t()) :: edit_source() | nil
   def last_undo_source(%__MODULE__{undo_entries: []}), do: nil
-  def last_undo_source(%__MODULE__{undo_entries: [{_version, _document, source} | _]}), do: source
+  def last_undo_source(%__MODULE__{undo_entries: [{_version, _patches, source} | _]}), do: source
 
   @doc "Returns the source of the most recent redo entry, or `nil` if redo is unavailable."
   @spec last_redo_source(t()) :: edit_source() | nil
   def last_redo_source(%__MODULE__{redo_entries: []}), do: nil
-  def last_redo_source(%__MODULE__{redo_entries: [{_version, _document, source} | _]}), do: source
+  def last_redo_source(%__MODULE__{redo_entries: [{_version, _patches, source} | _]}), do: source
 
   @doc false
   @spec undo_count(t()) :: non_neg_integer()
@@ -125,10 +136,10 @@ defmodule Minga.Buffer.UndoHistory do
   @spec redo_count(t()) :: non_neg_integer()
   def redo_count(%__MODULE__{} = history), do: length(history.redo_entries)
 
-  @spec do_record_edit(t(), version(), Document.t(), edit_source(), integer(), integer()) :: t()
-  defp do_record_edit(%__MODULE__{} = history, version, document, source, now, elapsed)
+  @spec do_record_edit(t(), version(), UndoPatch.t(), edit_source(), integer(), integer()) :: t()
+  defp do_record_edit(%__MODULE__{} = history, version, patch, source, now, elapsed)
        when history.last_recorded_at == 0 or elapsed >= @coalesce_ms do
-    entry = {version, document, source}
+    entry = {version, [patch], source}
 
     %{
       history
@@ -138,8 +149,40 @@ defmodule Minga.Buffer.UndoHistory do
     }
   end
 
-  defp do_record_edit(%__MODULE__{} = history, _version, _document, _source, now, _elapsed) do
-    %{history | redo_entries: [], last_recorded_at: now}
+  defp do_record_edit(
+         %__MODULE__{undo_entries: [{entry_version, patches, source} | rest]} = history,
+         _version,
+         patch,
+         source,
+         now,
+         _elapsed
+       ) do
+    %{
+      history
+      | undo_entries: [{entry_version, [patch | patches], source} | rest],
+        redo_entries: [],
+        last_recorded_at: now
+    }
+  end
+
+  defp do_record_edit(%__MODULE__{} = history, version, patch, source, now, _elapsed) do
+    entry = {version, [patch], source}
+
+    %{
+      history
+      | undo_entries: cap_entries([entry | history.undo_entries]),
+        redo_entries: [],
+        last_recorded_at: now
+    }
+  end
+
+  @spec apply_patches(Document.t(), patches()) :: {Document.t(), patches()}
+  defp apply_patches(%Document{} = document, patches) do
+    Enum.reduce(patches, {document, []}, fn patch, {current_document, inverse_patches} ->
+      inverse = UndoPatch.invert(patch, current_document)
+      next_document = UndoPatch.apply(patch, current_document)
+      {next_document, [inverse | inverse_patches]}
+    end)
   end
 
   @spec cap_entries([entry()]) :: [entry()]

--- a/lib/minga/buffer/undo_patch.ex
+++ b/lib/minga/buffer/undo_patch.ex
@@ -1,0 +1,132 @@
+defmodule Minga.Buffer.UndoPatch do
+  @moduledoc """
+  Reversible byte-range edit for undo and redo history.
+
+  A patch records the bytes removed and inserted by one atomic edit, plus the cursor position to restore when that patch is applied. Undo history stores patches instead of full document snapshots so memory usage follows edit size rather than file size.
+  """
+
+  alias Minga.Buffer.Document
+  alias Minga.Buffer.EditDelta
+
+  @enforce_keys [:start_byte, :old_text, :new_text, :cursor]
+  defstruct [:start_byte, :old_text, :new_text, :cursor]
+
+  @typedoc "A byte fragment captured from a document diff. It may not be valid standalone UTF-8."
+  @type byte_fragment :: binary()
+
+  @opaque t :: %__MODULE__{
+            start_byte: non_neg_integer(),
+            old_text: byte_fragment(),
+            new_text: byte_fragment(),
+            cursor: Document.position()
+          }
+
+  @doc "Builds an undo patch from an edit delta and the document before the edit."
+  @spec from_delta(EditDelta.t(), Document.t()) :: t()
+  def from_delta(%EditDelta{} = delta, %Document{} = old_document) do
+    old_text =
+      old_document
+      |> Document.content()
+      |> binary_part(delta.start_byte, delta.old_end_byte - delta.start_byte)
+
+    %__MODULE__{
+      start_byte: delta.start_byte,
+      old_text: old_text,
+      new_text: delta.inserted_text,
+      cursor: Document.cursor(old_document)
+    }
+  end
+
+  @doc "Builds a minimal byte-range patch from two document versions."
+  @spec from_documents(Document.t(), Document.t()) :: t()
+  def from_documents(%Document{} = old_document, %Document{} = new_document) do
+    old_text = Document.content(old_document)
+    new_text = Document.content(new_document)
+    start_byte = common_prefix_size(old_text, new_text)
+    old_tail = byte_size(old_text) - start_byte
+    new_tail = byte_size(new_text) - start_byte
+    suffix_size = common_suffix_size(old_text, new_text, old_tail, new_tail)
+
+    %__MODULE__{
+      start_byte: start_byte,
+      old_text: binary_part(old_text, start_byte, old_tail - suffix_size),
+      new_text: binary_part(new_text, start_byte, new_tail - suffix_size),
+      cursor: Document.cursor(old_document)
+    }
+  end
+
+  @doc "Returns the inverse patch for the current document state."
+  @spec invert(t(), Document.t()) :: t()
+  def invert(%__MODULE__{} = patch, %Document{} = current_document) do
+    %__MODULE__{
+      start_byte: patch.start_byte,
+      old_text: patch.new_text,
+      new_text: patch.old_text,
+      cursor: Document.cursor(current_document)
+    }
+  end
+
+  @doc "Applies the patch to a document, returning the previous document state for undo or the next state for redo."
+  @spec apply(t(), Document.t()) :: Document.t()
+  def apply(%__MODULE__{} = patch, %Document{} = document) do
+    Document.replace_at_byte_range(
+      document,
+      patch.start_byte,
+      byte_size(patch.new_text),
+      patch.old_text,
+      patch.cursor
+    )
+  end
+
+  @spec common_prefix_size(binary(), binary()) :: non_neg_integer()
+  defp common_prefix_size(left, right) do
+    :binary.longest_common_prefix([left, right])
+  end
+
+  @spec common_suffix_size(binary(), binary(), non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  defp common_suffix_size(left, right, left_tail, right_tail) do
+    left_suffix = binary_part(left, byte_size(left) - left_tail, left_tail)
+    right_suffix = binary_part(right, byte_size(right) - right_tail, right_tail)
+    do_common_suffix_size(left_suffix, right_suffix, left_tail, right_tail, 0)
+  end
+
+  @spec do_common_suffix_size(
+          binary(),
+          binary(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: non_neg_integer()
+  defp do_common_suffix_size(_left, _right, 0, _right_tail, count), do: count
+  defp do_common_suffix_size(_left, _right, _left_tail, 0, count), do: count
+
+  defp do_common_suffix_size(left, right, left_tail, right_tail, count) do
+    left_byte = :binary.at(left, left_tail - 1)
+    right_byte = :binary.at(right, right_tail - 1)
+
+    continue_common_suffix_size(
+      left,
+      right,
+      left_tail,
+      right_tail,
+      count,
+      left_byte == right_byte
+    )
+  end
+
+  @spec continue_common_suffix_size(
+          binary(),
+          binary(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean()
+        ) :: non_neg_integer()
+  defp continue_common_suffix_size(left, right, left_tail, right_tail, count, true) do
+    do_common_suffix_size(left, right, left_tail - 1, right_tail - 1, count + 1)
+  end
+
+  defp continue_common_suffix_size(_left, _right, _left_tail, _right_tail, count, false),
+    do: count
+end

--- a/test/minga/buffer/document_test.exs
+++ b/test/minga/buffer/document_test.exs
@@ -204,6 +204,28 @@ defmodule Minga.Buffer.DocumentTest do
     end
   end
 
+  describe "replace_at_byte_range/5" do
+    test "replaces bytes and restores cursor" do
+      buf = Document.new("hello world") |> Document.move_to({0, 5})
+      buf = Document.replace_at_byte_range(buf, 6, 5, "there", {0, 2})
+
+      assert Document.content(buf) == "hello there"
+      assert Document.cursor(buf) == {0, 2}
+    end
+
+    test "rejects byte ranges beyond document content" do
+      assert_raise ArgumentError, ~r/invalid byte range/, fn ->
+        Document.replace_at_byte_range(Document.new("hello"), 4, 2, "x", {0, 0})
+      end
+    end
+
+    test "rejects replacements that produce invalid UTF-8 content" do
+      assert_raise ArgumentError, ~r/invalid UTF-8/, fn ->
+        Document.replace_at_byte_range(Document.new("é"), 1, 0, <<0xFF>>, {0, 0})
+      end
+    end
+  end
+
   # ── Round-trip integrity ──
 
   describe "content integrity" do

--- a/test/minga/buffer/operation_test.exs
+++ b/test/minga/buffer/operation_test.exs
@@ -53,4 +53,20 @@ defmodule Minga.Buffer.OperationTest do
       assert delta.inserted_text == ""
     end
   end
+
+  describe "delete_lines/3" do
+    test "returns a delta for the actual bytes removed when deleting the final line" do
+      doc = Document.new("alpha\nbeta")
+
+      assert {:edited, new_doc, delta} = Operation.delete_lines(doc, 1, 1)
+      assert Document.content(new_doc) == "alpha"
+      assert delta.start_byte == 5
+      assert delta.old_end_byte == 10
+      assert delta.new_end_byte == 5
+      assert delta.start_position == {0, 5}
+      assert delta.old_end_position == {1, 4}
+      assert delta.new_end_position == {0, 5}
+      assert delta.inserted_text == ""
+    end
+  end
 end

--- a/test/minga/buffer/process_test.exs
+++ b/test/minga/buffer/process_test.exs
@@ -572,6 +572,24 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.apply_edits(pid, edits)
       assert BufferProcess.content(pid) == "AAA\nbbb\nCCC"
     end
+
+    test "replays unsorted variable-length edits on the same line through undo and redo" do
+      {:ok, pid} = BufferProcess.start_link(content: "abcdefghij")
+
+      edits = [
+        {{0, 1}, {0, 2}, "LMNOP"},
+        {{0, 6}, {0, 8}, "W"}
+      ]
+
+      assert :ok = BufferProcess.apply_edits(pid, edits)
+      assert BufferProcess.content(pid) == "aLMNOPdefWj"
+
+      BufferProcess.undo(pid)
+      assert BufferProcess.content(pid) == "abcdefghij"
+
+      BufferProcess.redo(pid)
+      assert BufferProcess.content(pid) == "aLMNOPdefWj"
+    end
   end
 
   describe "buffer_type" do
@@ -821,6 +839,36 @@ defmodule Minga.Buffer.ProcessTest do
       BufferProcess.replace_content(pid, "goodbye")
 
       assert BufferProcess.last_undo_source(pid) == :user
+    end
+
+    test "replace_generated_content clears stale undo history" do
+      pid = start_supervised!({BufferProcess, content: "hello"})
+      BufferProcess.insert_char(pid, "X")
+      assert BufferProcess.content(pid) == "Xhello"
+
+      BufferProcess.replace_generated_content(pid, "generated")
+
+      assert BufferProcess.content(pid) == "generated"
+      assert BufferProcess.last_undo_source(pid) == nil
+      assert BufferProcess.last_redo_source(pid) == nil
+
+      BufferProcess.undo(pid)
+      assert BufferProcess.content(pid) == "generated"
+    end
+
+    test "replace_content_with_decorations clears stale undo history" do
+      pid = start_supervised!({BufferProcess, content: "hello"})
+      BufferProcess.insert_char(pid, "X")
+      assert BufferProcess.content(pid) == "Xhello"
+
+      BufferProcess.replace_content_with_decorations(pid, "decorated", fn decs -> decs end)
+
+      assert BufferProcess.content(pid) == "decorated"
+      assert BufferProcess.last_undo_source(pid) == nil
+      assert BufferProcess.last_redo_source(pid) == nil
+
+      BufferProcess.undo(pid)
+      assert BufferProcess.content(pid) == "decorated"
     end
 
     test "interleaved user and agent edits preserve correct sources" do

--- a/test/minga/buffer/undo_history_test.exs
+++ b/test/minga/buffer/undo_history_test.exs
@@ -3,55 +3,85 @@ defmodule Minga.Buffer.UndoHistoryTest do
 
   alias Minga.Buffer.Document
   alias Minga.Buffer.UndoHistory
+  alias Minga.Buffer.UndoPatch
 
   defp doc(text), do: Document.new(text)
 
+  defp patch(before_text, after_text),
+    do: UndoPatch.from_documents(doc(before_text), doc(after_text))
+
   describe "record_edit/4" do
-    test "records an undo snapshot with source attribution" do
-      history = UndoHistory.record_edit(UndoHistory.new(), 0, doc("before"), :agent)
+    test "records an undo patch with source attribution" do
+      history = UndoHistory.record_edit(UndoHistory.new(), 0, patch("before", "after"), :agent)
 
       assert UndoHistory.undo_count(history) == 1
       assert UndoHistory.redo_count(history) == 0
       assert UndoHistory.last_undo_source(history) == :agent
     end
 
-    test "coalesces rapid edits into one undo entry" do
+    test "coalesces rapid edits into one undo entry with multiple patches" do
       history =
         UndoHistory.new()
-        |> UndoHistory.record_edit(0, doc("a"), :user)
-        |> UndoHistory.record_edit(1, doc("ab"), :user)
+        |> UndoHistory.record_edit(0, patch("", "a"), :user)
+        |> UndoHistory.record_edit(1, patch("a", "ab"), :user)
 
       assert UndoHistory.undo_count(history) == 1
+      assert {:ok, restore, _history} = UndoHistory.undo(history, 2, doc("ab"))
+      assert Document.content(restore.document) == ""
     end
 
     test "break_coalescing makes the next edit create a new entry" do
       history =
         UndoHistory.new()
-        |> UndoHistory.record_edit(0, doc("a"), :user)
+        |> UndoHistory.record_edit(0, patch("", "a"), :user)
         |> UndoHistory.break_coalescing()
-        |> UndoHistory.record_edit(1, doc("ab"), :user)
+        |> UndoHistory.record_edit(1, patch("a", "ab"), :user)
 
       assert UndoHistory.undo_count(history) == 2
     end
 
+    test "different sources do not coalesce into one entry" do
+      history =
+        UndoHistory.new()
+        |> UndoHistory.record_edit(0, patch("", "a"), :user)
+        |> UndoHistory.record_edit(1, patch("a", "ab"), :agent)
+
+      assert UndoHistory.undo_count(history) == 2
+      assert UndoHistory.last_undo_source(history) == :agent
+    end
+
     test "force recording bypasses coalescing and clears redo entries" do
-      history = UndoHistory.record_edit_force(UndoHistory.new(), 0, doc("before"), :agent)
+      history =
+        UndoHistory.record_edit_force(UndoHistory.new(), 0, patch("before", "after"), :agent)
 
       assert {:ok, restore, history} = UndoHistory.undo(history, 1, doc("after"))
       assert restore.source == :agent
       assert UndoHistory.redo_count(history) == 1
 
-      history = UndoHistory.record_edit_force(history, 1, doc("new"), :user)
+      history = UndoHistory.record_edit_force(history, 1, patch("before", "new"), :user)
 
       assert UndoHistory.undo_count(history) == 1
       assert UndoHistory.redo_count(history) == 0
       assert UndoHistory.last_undo_source(history) == :user
     end
 
+    test "batch recording stores one undo entry" do
+      patches = [patch("aXc", "abc"), patch("abc", "aXc")]
+      history = UndoHistory.record_edit_batch(UndoHistory.new(), 0, patches, :lsp)
+
+      assert UndoHistory.undo_count(history) == 1
+      assert UndoHistory.last_undo_source(history) == :lsp
+    end
+
     test "caps undo entries" do
       history =
         Enum.reduce(1..1100, UndoHistory.new(), fn version, history ->
-          UndoHistory.record_edit_force(history, version, doc(Integer.to_string(version)), :user)
+          UndoHistory.record_edit_force(
+            history,
+            version,
+            patch(Integer.to_string(version), Integer.to_string(version + 1)),
+            :user
+          )
         end)
 
       assert UndoHistory.undo_count(history) == 1000
@@ -59,8 +89,9 @@ defmodule Minga.Buffer.UndoHistoryTest do
   end
 
   describe "undo/3 and redo/3" do
-    test "undo returns the previous snapshot and creates a redo entry" do
-      history = UndoHistory.record_edit_force(UndoHistory.new(), 0, doc("before"), :lsp)
+    test "undo returns the previous document and creates a redo entry" do
+      history =
+        UndoHistory.record_edit_force(UndoHistory.new(), 0, patch("before", "after"), :lsp)
 
       assert {:ok, restore, history} = UndoHistory.undo(history, 1, doc("after"))
       assert restore.version == 0
@@ -71,8 +102,9 @@ defmodule Minga.Buffer.UndoHistoryTest do
       assert UndoHistory.last_redo_source(history) == :lsp
     end
 
-    test "redo returns the next snapshot and restores undo history" do
-      history = UndoHistory.record_edit_force(UndoHistory.new(), 0, doc("before"), :recovery)
+    test "redo returns the next document and restores undo history" do
+      history =
+        UndoHistory.record_edit_force(UndoHistory.new(), 0, patch("before", "after"), :recovery)
 
       assert {:ok, restore, history} = UndoHistory.undo(history, 1, doc("after"))
       assert restore.source == :recovery
@@ -96,7 +128,8 @@ defmodule Minga.Buffer.UndoHistoryTest do
 
   describe "clear/1" do
     test "removes undo and redo entries" do
-      history = UndoHistory.record_edit_force(UndoHistory.new(), 0, doc("before"), :user)
+      history =
+        UndoHistory.record_edit_force(UndoHistory.new(), 0, patch("before", "after"), :user)
 
       assert {:ok, restore, history} = UndoHistory.undo(history, 1, doc("after"))
       assert restore.source == :user

--- a/test/minga/buffer/undo_patch_test.exs
+++ b/test/minga/buffer/undo_patch_test.exs
@@ -1,0 +1,93 @@
+defmodule Minga.Buffer.UndoPatchTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Document
+  alias Minga.Buffer.Operation
+  alias Minga.Buffer.UndoPatch
+
+  defp doc(text), do: Document.new(text)
+
+  describe "from_delta/2" do
+    test "captures insertion patches" do
+      old_doc = doc("hello")
+      {:edited, new_doc, delta} = Operation.insert_at_cursor(old_doc, "X")
+
+      patch = UndoPatch.from_delta(delta, old_doc)
+
+      assert patch.start_byte == 0
+      assert patch.old_text == ""
+      assert patch.new_text == "X"
+      assert UndoPatch.apply(patch, new_doc) |> Document.content() == "hello"
+    end
+
+    test "captures deletion patches" do
+      old_doc = doc("héllo") |> Document.move_to({0, 3})
+      {:edited, new_doc, delta} = Operation.backspace(old_doc)
+
+      patch = UndoPatch.from_delta(delta, old_doc)
+
+      assert patch.old_text == "é"
+      assert patch.new_text == ""
+      assert UndoPatch.apply(patch, new_doc) |> Document.content() == "héllo"
+    end
+
+    test "captures replacement patches" do
+      old_doc = doc("one two three")
+      {:edited, new_doc, delta} = Operation.replace_range(old_doc, {0, 4}, {0, 6}, "TWO")
+
+      patch = UndoPatch.from_delta(delta, old_doc)
+
+      assert patch.old_text == "two"
+      assert patch.new_text == "TWO"
+      assert UndoPatch.apply(patch, new_doc) |> Document.content() == "one two three"
+    end
+  end
+
+  describe "invert/2" do
+    test "inverted patch reapplies the original edit" do
+      old_doc = doc("hello")
+      {:edited, new_doc, delta} = Operation.insert_at_cursor(old_doc, "X")
+      patch = UndoPatch.from_delta(delta, old_doc)
+      inverse = UndoPatch.invert(patch, new_doc)
+
+      restored = UndoPatch.apply(patch, new_doc)
+      redone = UndoPatch.apply(inverse, restored)
+
+      assert Document.content(redone) == "Xhello"
+      assert Document.cursor(redone) == Document.cursor(new_doc)
+    end
+  end
+
+  describe "from_documents/2" do
+    test "stores only the changed byte range" do
+      patch = UndoPatch.from_documents(doc("prefix old suffix"), doc("prefix new suffix"))
+
+      assert patch.start_byte == byte_size("prefix ")
+      assert patch.old_text == "old"
+      assert patch.new_text == "new"
+    end
+
+    test "stores byte fragments for multi-byte replacements" do
+      patch = UndoPatch.from_documents(doc("é"), doc("è"))
+
+      assert patch.old_text == <<0xA9>>
+      assert patch.new_text == <<0xA8>>
+      refute String.valid?(patch.old_text)
+      refute String.valid?(patch.new_text)
+      assert Document.content(UndoPatch.apply(patch, doc("è"))) == "é"
+    end
+
+    test "large document patch size stays proportional to the changed slice" do
+      prefix = String.duplicate("a", 100_000)
+      suffix = String.duplicate("z", 100_000)
+
+      patch =
+        UndoPatch.from_documents(doc(prefix <> "old" <> suffix), doc(prefix <> "new" <> suffix))
+
+      assert patch.start_byte == byte_size(prefix)
+      assert patch.old_text == "old"
+      assert patch.new_text == "new"
+      assert byte_size(patch.old_text) + byte_size(patch.new_text) == 6
+    end
+  end
+end

--- a/test/minga/buffer/undo_test.exs
+++ b/test/minga/buffer/undo_test.exs
@@ -5,11 +5,51 @@ defmodule Minga.Buffer.UndoTest do
   """
 
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
+  alias Minga.Buffer.Document
   alias Minga.Buffer.Process, as: BufferProcess
 
   defp start_buffer(content) do
-    start_supervised!({BufferProcess, content: content})
+    start_supervised!({BufferProcess, content: content}, id: {BufferProcess, make_ref()})
+  end
+
+  defp position_for(content, offset) do
+    content |> Document.new() |> Document.offset_to_position(offset)
+  end
+
+  defp apply_random_op(pid, {:insert, seed, text}) do
+    content = BufferProcess.content(pid)
+    offset = rem(seed, byte_size(content) + 1)
+    BufferProcess.move_to(pid, position_for(content, offset))
+    BufferProcess.insert_text(pid, text)
+    BufferProcess.break_undo_coalescing(pid)
+  end
+
+  defp apply_random_op(pid, {:delete, seed}) do
+    content = BufferProcess.content(pid)
+    delete_at_offset(pid, content, byte_size(content), seed)
+  end
+
+  defp delete_at_offset(_pid, _content, 0, _seed), do: :ok
+
+  defp delete_at_offset(pid, content, content_size, seed) do
+    position = position_for(content, rem(seed, content_size))
+    BufferProcess.move_to(pid, position)
+    BufferProcess.delete_at(pid)
+    BufferProcess.break_undo_coalescing(pid)
+  end
+
+  defp random_op_generator do
+    StreamData.frequency([
+      {3,
+       StreamData.tuple({
+         StreamData.constant(:insert),
+         StreamData.positive_integer(),
+         StreamData.string(:alphanumeric, min_length: 1, max_length: 5)
+       })},
+      {2, StreamData.tuple({StreamData.constant(:delete), StreamData.positive_integer()})}
+    ])
   end
 
   describe "undo after insert" do
@@ -33,6 +73,16 @@ defmodule Minga.Buffer.UndoTest do
 
       BufferProcess.undo(pid)
       assert String.contains?(BufferProcess.content(pid), "hello")
+    end
+
+    test "reverts a coalesced final-line delete and linewise paste" do
+      pid = start_buffer("alpha\nbeta")
+      BufferProcess.delete_lines(pid, 1, 1)
+      BufferProcess.insert_text(pid, "beta\n")
+      assert BufferProcess.content(pid) == "beta\nalpha"
+
+      BufferProcess.undo(pid)
+      assert BufferProcess.content(pid) == "alpha\nbeta"
     end
   end
 
@@ -65,6 +115,96 @@ defmodule Minga.Buffer.UndoTest do
 
       BufferProcess.undo(pid)
       assert BufferProcess.content(pid) == "aaa\nbbb\nccc"
+    end
+  end
+
+  describe "cursor restoration" do
+    test "undo and redo restore cursor positions for multi-byte multiline edits" do
+      pid = start_buffer("héllo\nworld")
+      BufferProcess.move_to(pid, {0, 3})
+      BufferProcess.insert_text(pid, "\nΩ")
+      edited_cursor = BufferProcess.cursor(pid)
+
+      BufferProcess.undo(pid)
+      assert BufferProcess.content(pid) == "héllo\nworld"
+      assert BufferProcess.cursor(pid) == {0, 3}
+
+      BufferProcess.redo(pid)
+      assert BufferProcess.content(pid) == "hé\nΩllo\nworld"
+      assert BufferProcess.cursor(pid) == edited_cursor
+    end
+  end
+
+  describe "batch edits" do
+    test "one undo reverts the full batch and one redo reapplies it" do
+      pid = start_buffer("aaa\nbbb\nccc")
+
+      edits = [
+        {{0, 0}, {0, 2}, "AAA"},
+        {{2, 0}, {2, 2}, "CCC"}
+      ]
+
+      BufferProcess.apply_edits(pid, edits)
+      assert BufferProcess.content(pid) == "AAA\nbbb\nCCC"
+
+      BufferProcess.undo(pid)
+      assert BufferProcess.content(pid) == "aaa\nbbb\nccc"
+
+      BufferProcess.redo(pid)
+      assert BufferProcess.content(pid) == "AAA\nbbb\nCCC"
+    end
+
+    test "undo and redo restore the cursor after a batch edit" do
+      pid = start_buffer("aaa\nbbb\nccc")
+      BufferProcess.move_to(pid, {1, 1})
+
+      edits = [
+        {{0, 0}, {0, 2}, "AAA"},
+        {{2, 0}, {2, 2}, "CCC"}
+      ]
+
+      BufferProcess.apply_edits(pid, edits)
+      edited_cursor = BufferProcess.cursor(pid)
+
+      BufferProcess.undo(pid)
+      assert BufferProcess.cursor(pid) == {1, 1}
+
+      BufferProcess.redo(pid)
+      assert BufferProcess.cursor(pid) == edited_cursor
+    end
+  end
+
+  describe "property-based undo round trips" do
+    property "undoing random insert and delete edits restores the original content" do
+      check all(
+              original <- StreamData.string(:alphanumeric, min_length: 0, max_length: 40),
+              ops <- StreamData.list_of(random_op_generator(), min_length: 50, max_length: 100),
+              max_runs: 50
+            ) do
+        pid = start_buffer(original)
+
+        Enum.each(ops, &apply_random_op(pid, &1))
+        Enum.each(ops, fn _ -> BufferProcess.undo(pid) end)
+
+        assert BufferProcess.content(pid) == original
+      end
+    end
+
+    property "undo then redo returns to the edited content" do
+      check all(
+              original <- StreamData.string(:alphanumeric, min_length: 0, max_length: 40),
+              ops <- StreamData.list_of(random_op_generator(), min_length: 50, max_length: 100),
+              max_runs: 50
+            ) do
+        pid = start_buffer(original)
+
+        Enum.each(ops, &apply_random_op(pid, &1))
+        edited = BufferProcess.content(pid)
+        Enum.each(ops, fn _ -> BufferProcess.undo(pid) end)
+        Enum.each(ops, fn _ -> BufferProcess.redo(pid) end)
+
+        assert BufferProcess.content(pid) == edited
+      end
     end
   end
 end


### PR DESCRIPTION
# TL;DR
Diff-based undo now stores reversible byte-range patches instead of full `Document` snapshots, so undo memory grows with edit size rather than file size while preserving existing undo/redo behavior.

Closes #638

## Context
Issue #638 calls out the memory cost of snapshot-based undo for large files. This PR replaces snapshot entries with patch-list entries while keeping `UndoHistory` pure and leaving the existing restore interface intact for `Buffer.Process`.

## Changes
- Added `Minga.Buffer.UndoPatch`, a Layer 0 patch struct that captures `start_byte`, old/new byte fragments, and cursor restoration data.
- Added `Document.replace_at_byte_range/5` as the trusted byte-level mutation API used by undo/redo, with explicit byte-range and reconstructed UTF-8 validation.
- Changed `UndoHistory` entries from full `Document.t()` snapshots to non-empty patch lists, including source-aware coalescing so mixed edit sources do not collapse into one entry.
- Updated buffer mutation paths to record patches from existing `EditDelta` values, with fallback document-diff patches for full-content replacements and snapshot commits.
- Updated batch `apply_edits` handling to record one undo entry containing every patch in the batch.
- Added `UndoPatch` to the custom Credo dependency-direction Layer 0 list.

## Verification
- `make lint` passed.
- `git diff --check` passed.
- `mix test.llm test/minga/buffer/` passed, 25 properties, 747 tests.
- Focused tests passed:
  - `mix test.llm test/minga/buffer/process_test.exs test/minga/buffer/undo_patch_test.exs test/minga/buffer/undo_history_test.exs test/minga/buffer/undo_test.exs`
  - `mix test.llm test/minga/buffer/document_test.exs test/minga/buffer/process_test.exs test/minga/buffer/undo_patch_test.exs test/minga/buffer/undo_history_test.exs test/minga/buffer/undo_test.exs`

Note: full `mix test.llm` currently has unrelated pre-existing local failures/timeouts in editor/project tests. The relevant buffer suite passes, and the exact reported non-buffer failures were checked separately against main or directly where applicable.

## Acceptance Criteria Addressed
- Undo entries store reverse patches instead of full document snapshots ✅
- Undo/redo preserve document content and cursor position ✅
- Undo history memory scales with cumulative edit size, not file size ✅
- Undo coalescing and `break_coalescing/1` continue to work, including multi-patch entries ✅
- Batch edits produce a single undo entry covering the full batch ✅
- Property-based round-trip tests verify random edit undo/redo correctness ✅
