### PR TITLE
feat(editing): add paragraph and sentence text objects

### DIFF
--- a/lib/minga/editing.ex
+++ b/lib/minga/editing.ex
@@ -77,6 +77,38 @@ defmodule Minga.Editing do
     to: Minga.Editing.TextObject,
     as: :a_parens
 
+  @spec select_inner_paragraph(
+          Minga.Editing.Text.Readable.t(),
+          Minga.Editing.TextObject.position()
+        ) :: Minga.Editing.TextObject.range()
+  defdelegate select_inner_paragraph(readable, pos),
+    to: Minga.Editing.TextObject,
+    as: :inner_paragraph
+
+  @spec select_around_paragraph(
+          Minga.Editing.Text.Readable.t(),
+          Minga.Editing.TextObject.position()
+        ) :: Minga.Editing.TextObject.range()
+  defdelegate select_around_paragraph(readable, pos),
+    to: Minga.Editing.TextObject,
+    as: :a_paragraph
+
+  @spec select_inner_sentence(
+          Minga.Editing.Text.Readable.t(),
+          Minga.Editing.TextObject.position()
+        ) :: Minga.Editing.TextObject.range()
+  defdelegate select_inner_sentence(readable, pos),
+    to: Minga.Editing.TextObject,
+    as: :inner_sentence
+
+  @spec select_around_sentence(
+          Minga.Editing.Text.Readable.t(),
+          Minga.Editing.TextObject.position()
+        ) :: Minga.Editing.TextObject.range()
+  defdelegate select_around_sentence(readable, pos),
+    to: Minga.Editing.TextObject,
+    as: :a_sentence
+
   defdelegate select_structural_inner(tree_data),
     to: Minga.Editing.TextObject,
     as: :structural_inner

--- a/lib/minga/editing/text_object.ex
+++ b/lib/minga/editing/text_object.ex
@@ -15,6 +15,18 @@ defmodule Minga.Editing.TextObject do
   * `a_word/2` (`aw`) — the word plus one surrounding whitespace run
     (trailing preferred; leading used when at end of line).
 
+  ## Paragraph text objects
+
+  * `inner_paragraph/2` (`ip`) — contiguous non-blank lines around the cursor,
+    or the current blank-line run when the cursor is on a blank line.
+  * `a_paragraph/2` (`ap`) — the paragraph plus one surrounding blank line,
+    preferring a trailing blank line and using a leading blank at end of file.
+
+  ## Sentence text objects
+
+  * `inner_sentence/2` (`is`) — the current sentence without trailing whitespace.
+  * `a_sentence/2` (`as`) — the current sentence including trailing whitespace.
+
   ## Quote text objects
 
   * `inner_quotes/3` (`i"`, `i'`) — the content between the nearest enclosing
@@ -40,6 +52,9 @@ defmodule Minga.Editing.TextObject do
 
   @typedoc "An inclusive `{start_pos, end_pos}` range, or `nil` when not found."
   @type range :: {position(), position()} | nil
+
+  @typep sentence_tokens :: tuple()
+  @typep sentence_span :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}
 
   # ── Word text objects ────────────────────────────────────────────────────────
 
@@ -118,6 +133,74 @@ defmodule Minga.Editing.TextObject do
       {{line, start_byte}, {line, end_byte}}
     end
   end
+
+  # ── Paragraph text objects ────────────────────────────────────────────────────
+
+  @doc """
+  Returns the current paragraph range without surrounding blank lines.
+
+  A paragraph is a contiguous run of non-blank lines. When the cursor is on a
+  blank line, the current blank-line run is returned so operators still have a
+  stable linewise target.
+
+  Corresponds to Vim's `ip` text object.
+  """
+  @spec inner_paragraph(Readable.t(), position()) :: range()
+  def inner_paragraph(buffer, position) do
+    case paragraph_bounds(buffer, position) do
+      nil -> nil
+      {first_line, last_line} -> line_range(buffer, first_line, last_line)
+    end
+  end
+
+  @doc """
+  Returns the current paragraph plus one surrounding blank line.
+
+  A trailing blank line is preferred. If the paragraph reaches end of file and
+  has a leading blank line, that leading blank is included instead.
+
+  Corresponds to Vim's `ap` text object.
+  """
+  @spec a_paragraph(Readable.t(), position()) :: range()
+  def a_paragraph(buffer, {line, _col} = position) do
+    case paragraph_bounds(buffer, position) do
+      nil ->
+        nil
+
+      {first_line, last_line} ->
+        line_text = Readable.line_at(buffer, line) || ""
+
+        if blank_line?(line_text) do
+          around_blank_paragraph_range(buffer, first_line, last_line)
+        else
+          around_paragraph_range(buffer, first_line, last_line)
+        end
+    end
+  end
+
+  # ── Sentence text objects ─────────────────────────────────────────────────────
+
+  @doc """
+  Returns the current sentence without trailing whitespace.
+
+  Sentences end at `.`, `!`, or `?`, may include closing delimiters after the
+  punctuation, and stop at paragraph boundaries.
+
+  Corresponds to Vim's `is` text object.
+  """
+  @spec inner_sentence(Readable.t(), position()) :: range()
+  def inner_sentence(buffer, position), do: sentence_range(buffer, position, :inner)
+
+  @doc """
+  Returns the current sentence including trailing whitespace.
+
+  When the cursor is on whitespace between two sentences, this follows Vim's
+  around-sentence behavior and selects the following sentence.
+
+  Corresponds to Vim's `as` text object.
+  """
+  @spec a_sentence(Readable.t(), position()) :: range()
+  def a_sentence(buffer, position), do: sentence_range(buffer, position, :around)
 
   # ── Quote text objects ────────────────────────────────────────────────────────
 
@@ -278,6 +361,529 @@ defmodule Minga.Editing.TextObject do
   defp adjust_end_position(row, 0) when row > 0, do: {row - 1, 0}
   defp adjust_end_position(row, col) when col > 0, do: {row, col - 1}
   defp adjust_end_position(row, col), do: {row, col}
+
+  # ── Private — paragraph helpers ───────────────────────────────────────────────
+
+  @spec paragraph_bounds(Readable.t(), position()) :: {non_neg_integer(), non_neg_integer()} | nil
+  defp paragraph_bounds(buffer, {line, _col}) do
+    if empty_buffer?(buffer) do
+      nil
+    else
+      paragraph_bounds_for_line(buffer, line, Readable.line_at(buffer, line))
+    end
+  end
+
+  @spec paragraph_bounds_for_line(Readable.t(), non_neg_integer(), String.t() | nil) ::
+          {non_neg_integer(), non_neg_integer()} | nil
+  defp paragraph_bounds_for_line(_buffer, _line, nil), do: nil
+
+  defp paragraph_bounds_for_line(buffer, line, text) do
+    if blank_line?(text) do
+      {blank_run_start(buffer, line), blank_run_end(buffer, line)}
+    else
+      {paragraph_start(buffer, line), paragraph_end(buffer, line)}
+    end
+  end
+
+  @spec empty_buffer?(Readable.t()) :: boolean()
+  defp empty_buffer?(buffer) do
+    Readable.line_count(buffer) == 1 and (Readable.line_at(buffer, 0) || "") == ""
+  end
+
+  @spec paragraph_start(Readable.t(), non_neg_integer()) :: non_neg_integer()
+  defp paragraph_start(_buffer, 0), do: 0
+
+  defp paragraph_start(buffer, line) do
+    prev_line = line - 1
+
+    if blank_line?(Readable.line_at(buffer, prev_line) || "") do
+      line
+    else
+      paragraph_start(buffer, prev_line)
+    end
+  end
+
+  @spec paragraph_end(Readable.t(), non_neg_integer()) :: non_neg_integer()
+  defp paragraph_end(buffer, line) do
+    next_line = line + 1
+
+    case Readable.line_at(buffer, next_line) do
+      nil ->
+        line
+
+      text ->
+        if blank_line?(text), do: line, else: paragraph_end(buffer, next_line)
+    end
+  end
+
+  @spec blank_run_start(Readable.t(), non_neg_integer()) :: non_neg_integer()
+  defp blank_run_start(_buffer, 0), do: 0
+
+  defp blank_run_start(buffer, line) do
+    prev_line = line - 1
+
+    if blank_line?(Readable.line_at(buffer, prev_line) || "") do
+      blank_run_start(buffer, prev_line)
+    else
+      line
+    end
+  end
+
+  @spec blank_run_end(Readable.t(), non_neg_integer()) :: non_neg_integer()
+  defp blank_run_end(buffer, line) do
+    next_line = line + 1
+
+    case Readable.line_at(buffer, next_line) do
+      nil ->
+        line
+
+      text ->
+        if blank_line?(text), do: blank_run_end(buffer, next_line), else: line
+    end
+  end
+
+  @spec around_paragraph_range(Readable.t(), non_neg_integer(), non_neg_integer()) :: range()
+  defp around_paragraph_range(buffer, first_line, last_line) do
+    line_count = Readable.line_count(buffer)
+
+    extended =
+      case paragraph_extension(buffer, first_line, last_line, line_count) do
+        :trailing -> {first_line, last_line + 1}
+        :leading -> {first_line - 1, last_line}
+        :none -> {first_line, last_line}
+      end
+
+    {range_first, range_last} = extended
+    line_range(buffer, range_first, range_last)
+  end
+
+  @spec around_blank_paragraph_range(Readable.t(), non_neg_integer(), non_neg_integer()) ::
+          range()
+  defp around_blank_paragraph_range(buffer, first_blank_line, last_blank_line) do
+    case next_non_blank_line(buffer, last_blank_line + 1) do
+      nil ->
+        case previous_non_blank_line(buffer, first_blank_line - 1) do
+          nil ->
+            line_range(buffer, first_blank_line, last_blank_line)
+
+          prev_line ->
+            line_range(buffer, paragraph_start(buffer, prev_line), last_blank_line)
+        end
+
+      next_line ->
+        around_paragraph_range(buffer, next_line, paragraph_end(buffer, next_line))
+    end
+  end
+
+  @spec paragraph_extension(
+          Readable.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          pos_integer()
+        ) :: :trailing | :leading | :none
+  defp paragraph_extension(buffer, _first_line, last_line, line_count)
+       when last_line + 1 < line_count do
+    if blank_line?(Readable.line_at(buffer, last_line + 1) || ""), do: :trailing, else: :none
+  end
+
+  defp paragraph_extension(buffer, first_line, _last_line, _line_count) when first_line > 0 do
+    if blank_line?(Readable.line_at(buffer, first_line - 1) || ""), do: :leading, else: :none
+  end
+
+  defp paragraph_extension(_buffer, _first_line, _last_line, _line_count), do: :none
+
+  @spec line_range(Readable.t(), non_neg_integer(), non_neg_integer()) :: range()
+  defp line_range(buffer, first_line, last_line) do
+    {{first_line, 0}, {last_line, last_line_col(buffer, last_line)}}
+  end
+
+  @spec last_line_col(Readable.t(), non_neg_integer()) :: non_neg_integer()
+  defp last_line_col(buffer, line) do
+    case Readable.line_at(buffer, line) do
+      nil -> 0
+      "" -> 0
+      text -> Unicode.last_grapheme_byte_offset(text)
+    end
+  end
+
+  @spec next_non_blank_line(Readable.t(), integer()) :: non_neg_integer() | nil
+  defp next_non_blank_line(_buffer, line) when line < 0, do: nil
+
+  defp next_non_blank_line(buffer, line) do
+    case Readable.line_at(buffer, line) do
+      nil ->
+        nil
+
+      text ->
+        if blank_line?(text), do: next_non_blank_line(buffer, line + 1), else: line
+    end
+  end
+
+  @spec previous_non_blank_line(Readable.t(), integer()) :: non_neg_integer() | nil
+  defp previous_non_blank_line(_buffer, line) when line < 0, do: nil
+
+  defp previous_non_blank_line(buffer, line) do
+    case Readable.line_at(buffer, line) do
+      nil ->
+        previous_non_blank_line(buffer, line - 1)
+
+      text ->
+        if blank_line?(text), do: previous_non_blank_line(buffer, line - 1), else: line
+    end
+  end
+
+  @spec blank_line?(String.t()) :: boolean()
+  defp blank_line?(text), do: String.trim(text) == ""
+
+  # ── Private — sentence helpers ────────────────────────────────────────────────
+
+  @spec sentence_range(Readable.t(), position(), :inner | :around) :: range()
+  defp sentence_range(buffer, position, kind) do
+    case sentence_context(buffer, position) do
+      nil ->
+        nil
+
+      {tokens, cursor_idx} ->
+        spans = sentence_spans(tokens)
+
+        case elem(tokens, cursor_idx) do
+          {char, _pos} ->
+            if sentence_whitespace?(char) do
+              sentence_gap_range(tokens, spans, cursor_idx, kind)
+            else
+              sentence_span_for(spans, tokens, cursor_idx, kind)
+            end
+        end
+    end
+  end
+
+  @spec sentence_context(Readable.t(), position()) :: {sentence_tokens(), non_neg_integer()} | nil
+  defp sentence_context(buffer, position) do
+    case paragraph_bounds(buffer, position) do
+      nil -> nil
+      bounds -> sentence_context_in_bounds(buffer, position, bounds)
+    end
+  end
+
+  @spec sentence_context_in_bounds(
+          Readable.t(),
+          position(),
+          {non_neg_integer(), non_neg_integer()}
+        ) :: {sentence_tokens(), non_neg_integer()} | nil
+  defp sentence_context_in_bounds(buffer, {line, _col} = position, {first_line, last_line}) do
+    line_text = Readable.line_at(buffer, line) || ""
+
+    if blank_line?(line_text) do
+      nil
+    else
+      tokens = sentence_tokens(buffer, first_line, last_line)
+      cursor_idx = sentence_cursor_index(tokens, position)
+      if cursor_idx == nil, do: nil, else: {tokens, cursor_idx}
+    end
+  end
+
+  @spec sentence_tokens(Readable.t(), non_neg_integer(), non_neg_integer()) :: sentence_tokens()
+  defp sentence_tokens(buffer, first_line, last_line) do
+    first_line..last_line
+    |> Enum.flat_map(&sentence_tokens_for_line(buffer, &1, last_line))
+    |> List.to_tuple()
+  end
+
+  @spec sentence_tokens_for_line(Readable.t(), non_neg_integer(), non_neg_integer()) :: [
+          {String.t(), position()}
+        ]
+  defp sentence_tokens_for_line(buffer, line, last_line) do
+    text = Readable.line_at(buffer, line) || ""
+    tokens = graphemes_with_byte_cols(text, line)
+
+    if line < last_line do
+      tokens ++ [{"\n", {line, byte_size(text)}}]
+    else
+      tokens
+    end
+  end
+
+  @spec sentence_cursor_index(sentence_tokens(), position()) :: non_neg_integer() | nil
+  defp sentence_cursor_index(tokens, position) do
+    list = Tuple.to_list(tokens)
+    exact = Enum.find_index(list, fn {_g, token_pos} -> token_pos == position end)
+
+    case exact do
+      nil -> nearest_sentence_cursor_index(list, position)
+      idx -> idx
+    end
+  end
+
+  @spec nearest_sentence_cursor_index([{String.t(), position()}], position()) ::
+          non_neg_integer() | nil
+  defp nearest_sentence_cursor_index(tokens, position) do
+    after_idx =
+      Enum.find_index(tokens, fn {_g, token_pos} ->
+        compare_position(token_pos, position) == :gt
+      end)
+
+    case after_idx do
+      nil -> index_before_position(tokens, position)
+      idx -> idx
+    end
+  end
+
+  @spec index_before_position([{String.t(), position()}], position()) :: non_neg_integer() | nil
+  defp index_before_position(tokens, position) do
+    tokens
+    |> Enum.with_index()
+    |> Enum.filter(fn {{_g, token_pos}, _idx} -> compare_position(token_pos, position) == :lt end)
+    |> List.last()
+    |> index_from_position_result()
+  end
+
+  @spec index_from_position_result({{String.t(), position()}, non_neg_integer()} | nil) ::
+          non_neg_integer() | nil
+  defp index_from_position_result(nil), do: nil
+  defp index_from_position_result({_token, idx}), do: idx
+
+  @spec sentence_spans(sentence_tokens()) :: [sentence_span()]
+  defp sentence_spans(tokens) do
+    case next_non_whitespace_index(tokens, 0) do
+      nil -> []
+      start_idx -> build_sentence_spans(tokens, start_idx, [])
+    end
+  end
+
+  @spec build_sentence_spans(sentence_tokens(), non_neg_integer(), [sentence_span()]) :: [
+          sentence_span()
+        ]
+  defp build_sentence_spans(tokens, start_idx, acc) do
+    end_idx = sentence_end_or_paragraph_end(tokens, start_idx)
+    trailing_end_idx = trailing_whitespace_end(tokens, end_idx + 1)
+    span = {start_idx, end_idx, trailing_end_idx}
+
+    case next_non_whitespace_index(tokens, trailing_end_idx + 1) do
+      nil -> Enum.reverse([span | acc])
+      next_start_idx -> build_sentence_spans(tokens, next_start_idx, [span | acc])
+    end
+  end
+
+  @spec sentence_end_or_paragraph_end(sentence_tokens(), non_neg_integer()) :: non_neg_integer()
+  defp sentence_end_or_paragraph_end(tokens, start_idx) do
+    case find_sentence_end(tokens, start_idx) do
+      nil -> last_non_whitespace_index(tokens, tuple_size(tokens) - 1)
+      end_idx -> end_idx
+    end
+  end
+
+  @spec find_sentence_end(sentence_tokens(), non_neg_integer()) :: non_neg_integer() | nil
+  defp find_sentence_end(tokens, idx) when idx >= tuple_size(tokens), do: nil
+
+  defp find_sentence_end(tokens, idx) do
+    {char, _pos} = elem(tokens, idx)
+
+    if sentence_terminal?(char) do
+      sentence_end_after_terminal(tokens, idx)
+    else
+      find_sentence_end(tokens, idx + 1)
+    end
+  end
+
+  @spec sentence_end_after_terminal(sentence_tokens(), non_neg_integer()) ::
+          non_neg_integer() | nil
+  defp sentence_end_after_terminal(tokens, idx) do
+    close_idx = closing_delimiter_end(tokens, idx + 1)
+
+    if sentence_boundary_after?(tokens, close_idx + 1) do
+      close_idx
+    else
+      find_sentence_end(tokens, idx + 1)
+    end
+  end
+
+  @spec closing_delimiter_end(sentence_tokens(), non_neg_integer()) :: non_neg_integer()
+  defp closing_delimiter_end(tokens, idx) when idx >= tuple_size(tokens), do: idx - 1
+
+  defp closing_delimiter_end(tokens, idx) do
+    {char, _pos} = elem(tokens, idx)
+
+    if closing_sentence_delimiter?(char) do
+      closing_delimiter_end(tokens, idx + 1)
+    else
+      idx - 1
+    end
+  end
+
+  @spec sentence_boundary_after?(sentence_tokens(), non_neg_integer()) :: boolean()
+  defp sentence_boundary_after?(tokens, idx) when idx >= tuple_size(tokens), do: true
+
+  defp sentence_boundary_after?(tokens, idx) do
+    {char, _pos} = elem(tokens, idx)
+    sentence_whitespace?(char)
+  end
+
+  @spec trailing_whitespace_end(sentence_tokens(), non_neg_integer()) :: non_neg_integer()
+  defp trailing_whitespace_end(tokens, idx) when idx >= tuple_size(tokens),
+    do: tuple_size(tokens) - 1
+
+  defp trailing_whitespace_end(tokens, idx) do
+    {char, _pos} = elem(tokens, idx)
+
+    if sentence_whitespace?(char) do
+      trailing_whitespace_end(tokens, idx + 1)
+    else
+      idx - 1
+    end
+  end
+
+  @spec next_non_whitespace_index(sentence_tokens(), non_neg_integer()) :: non_neg_integer() | nil
+  defp next_non_whitespace_index(tokens, idx) when idx >= tuple_size(tokens), do: nil
+
+  defp next_non_whitespace_index(tokens, idx) do
+    {char, _pos} = elem(tokens, idx)
+
+    if sentence_whitespace?(char) do
+      next_non_whitespace_index(tokens, idx + 1)
+    else
+      idx
+    end
+  end
+
+  @spec last_non_whitespace_index(sentence_tokens(), integer()) :: non_neg_integer()
+  defp last_non_whitespace_index(tokens, idx) do
+    {char, _pos} = elem(tokens, idx)
+
+    if sentence_whitespace?(char) do
+      last_non_whitespace_index(tokens, idx - 1)
+    else
+      idx
+    end
+  end
+
+  @spec sentence_gap_range(
+          sentence_tokens(),
+          [sentence_span()],
+          non_neg_integer(),
+          :inner | :around
+        ) :: range()
+  defp sentence_gap_range(tokens, spans, cursor_idx, kind) do
+    case elem(tokens, cursor_idx) do
+      {char, _pos} ->
+        if sentence_whitespace?(char) and spans != [] do
+          {gap_start_idx, gap_end_idx} = whitespace_run_indices(tokens, cursor_idx)
+          prev_span = previous_sentence_span(spans, cursor_idx)
+          next_span = next_sentence_span(spans, cursor_idx)
+
+          case {kind, prev_span, next_span} do
+            {:inner, nil, nil} ->
+              nil
+
+            {:inner, nil, {_next_start_idx, next_end_idx, _next_trailing_end_idx}} ->
+              range_from_token_indices(tokens, gap_start_idx, next_end_idx)
+
+            {:inner, _prev_span, nil} ->
+              range_from_token_indices(tokens, gap_start_idx, gap_end_idx)
+
+            {:inner, _prev_span, _next_span} ->
+              range_from_token_indices(tokens, gap_start_idx, gap_end_idx)
+
+            {:around, _, nil} ->
+              nil
+
+            {:around, _prev_span, {_next_start_idx, _next_end_idx, next_trailing_end_idx}} ->
+              {_gap_char, gap_start_pos} = elem(tokens, gap_start_idx)
+              {_next_char, next_end_pos} = elem(tokens, next_trailing_end_idx)
+              {gap_start_pos, next_end_pos}
+          end
+        else
+          nil
+        end
+    end
+  end
+
+  @spec next_sentence_span([sentence_span()], non_neg_integer()) :: sentence_span() | nil
+  defp next_sentence_span(spans, cursor_idx) do
+    Enum.find(spans, fn {start_idx, _end_idx, _trailing_end_idx} -> cursor_idx < start_idx end)
+  end
+
+  @spec previous_sentence_span([sentence_span()], non_neg_integer()) :: sentence_span() | nil
+  defp previous_sentence_span(spans, cursor_idx) do
+    spans
+    |> Enum.reverse()
+    |> Enum.find(fn {start_idx, _end_idx, _trailing_end_idx} -> cursor_idx >= start_idx end)
+  end
+
+  @spec whitespace_run_indices(sentence_tokens(), non_neg_integer()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp whitespace_run_indices(tokens, idx) do
+    start_idx = scan_left_tuple(tokens, idx, &sentence_whitespace_token?/1)
+    end_idx = scan_right_tuple(tokens, idx, &sentence_whitespace_token?/1)
+    {start_idx, end_idx}
+  end
+
+  @spec sentence_whitespace_token?({String.t(), position()}) :: boolean()
+  defp sentence_whitespace_token?({char, _pos}), do: sentence_whitespace?(char)
+
+  @spec sentence_span_for(
+          [sentence_span()],
+          sentence_tokens(),
+          non_neg_integer(),
+          :inner | :around
+        ) ::
+          range()
+  defp sentence_span_for(spans, tokens, cursor_idx, :inner) do
+    span =
+      Enum.find(spans, fn {start_idx, _end_idx, trailing_end_idx} ->
+        cursor_idx >= start_idx and cursor_idx <= trailing_end_idx
+      end) ||
+        Enum.find(spans, fn {start_idx, _end_idx, _trailing_end_idx} -> cursor_idx < start_idx end)
+
+    sentence_span_to_range(span, tokens, :inner)
+  end
+
+  defp sentence_span_for(spans, tokens, cursor_idx, :around) do
+    span =
+      Enum.find(spans, fn {start_idx, end_idx, _trailing_end_idx} ->
+        cursor_idx >= start_idx and cursor_idx <= end_idx
+      end) ||
+        Enum.find(spans, fn {start_idx, _end_idx, _trailing_end_idx} -> cursor_idx < start_idx end) ||
+        List.last(spans)
+
+    sentence_span_to_range(span, tokens, :around)
+  end
+
+  @spec sentence_span_to_range(sentence_span() | nil, sentence_tokens(), :inner | :around) ::
+          range()
+  defp sentence_span_to_range(nil, _tokens, _kind), do: nil
+
+  defp sentence_span_to_range({start_idx, end_idx, _trailing_end_idx}, tokens, :inner) do
+    range_from_token_indices(tokens, start_idx, end_idx)
+  end
+
+  defp sentence_span_to_range({start_idx, _end_idx, trailing_end_idx}, tokens, :around) do
+    range_from_token_indices(tokens, start_idx, trailing_end_idx)
+  end
+
+  @spec range_from_token_indices(sentence_tokens(), non_neg_integer(), non_neg_integer()) ::
+          range()
+  defp range_from_token_indices(tokens, start_idx, end_idx) when end_idx >= start_idx do
+    {_start_char, start_pos} = elem(tokens, start_idx)
+    {_end_char, end_pos} = elem(tokens, end_idx)
+    {start_pos, end_pos}
+  end
+
+  defp range_from_token_indices(_tokens, _start_idx, _end_idx), do: nil
+  @spec compare_position(position(), position()) :: :lt | :eq | :gt
+  defp compare_position(pos, pos), do: :eq
+  defp compare_position({line_a, _col_a}, {line_b, _col_b}) when line_a < line_b, do: :lt
+  defp compare_position({line_a, _col_a}, {line_b, _col_b}) when line_a > line_b, do: :gt
+  defp compare_position({line, col_a}, {line, col_b}) when col_a < col_b, do: :lt
+  defp compare_position(_pos_a, _pos_b), do: :gt
+
+  @spec sentence_terminal?(String.t()) :: boolean()
+  defp sentence_terminal?(char), do: char in [".", "!", "?"]
+
+  @spec closing_sentence_delimiter?(String.t()) :: boolean()
+  defp closing_sentence_delimiter?(char), do: char in [")", "]", "}", "\"", "'"]
+
+  @spec sentence_whitespace?(String.t()) :: boolean()
+  defp sentence_whitespace?(char), do: char in [" ", "\t", "\n"]
 
   # ── Private — word helpers ────────────────────────────────────────────────────
 

--- a/lib/minga/editing/text_object.ex
+++ b/lib/minga/editing/text_object.ex
@@ -507,8 +507,6 @@ defmodule Minga.Editing.TextObject do
   end
 
   @spec next_non_blank_line(Readable.t(), integer()) :: non_neg_integer() | nil
-  defp next_non_blank_line(_buffer, line) when line < 0, do: nil
-
   defp next_non_blank_line(buffer, line) do
     case Readable.line_at(buffer, line) do
       nil ->
@@ -545,16 +543,44 @@ defmodule Minga.Editing.TextObject do
 
       {tokens, cursor_idx} ->
         spans = sentence_spans(tokens)
-
-        case elem(tokens, cursor_idx) do
-          {char, _pos} ->
-            if sentence_whitespace?(char) do
-              sentence_gap_range(tokens, spans, cursor_idx, kind)
-            else
-              sentence_span_for(spans, tokens, cursor_idx, kind)
-            end
-        end
+        sentence_range_for_tokens(tokens, spans, cursor_idx, kind)
     end
+  end
+
+  @spec sentence_range_for_tokens(
+          sentence_tokens(),
+          [sentence_span()],
+          non_neg_integer(),
+          :inner | :around
+        ) :: range()
+  defp sentence_range_for_tokens(tokens, spans, cursor_idx, kind) do
+    case elem(tokens, cursor_idx) do
+      {" ", _pos} -> sentence_range_for_whitespace(tokens, spans, cursor_idx, kind)
+      {"\t", _pos} -> sentence_range_for_whitespace(tokens, spans, cursor_idx, kind)
+      {"\n", _pos} -> sentence_range_for_whitespace(tokens, spans, cursor_idx, kind)
+      {_char, _pos} -> sentence_span_for(spans, tokens, cursor_idx, kind)
+    end
+  end
+
+  @spec sentence_range_for_whitespace(
+          sentence_tokens(),
+          [sentence_span()],
+          non_neg_integer(),
+          :inner | :around
+        ) :: range()
+  defp sentence_range_for_whitespace(tokens, spans, cursor_idx, kind) do
+    if cursor_idx_within_sentence_inner?(spans, cursor_idx) do
+      sentence_span_for(spans, tokens, cursor_idx, kind)
+    else
+      sentence_gap_range(tokens, spans, cursor_idx, kind)
+    end
+  end
+
+  @spec cursor_idx_within_sentence_inner?([sentence_span()], non_neg_integer()) :: boolean()
+  defp cursor_idx_within_sentence_inner?(spans, cursor_idx) do
+    Enum.any?(spans, fn {start_idx, end_idx, _trailing_end_idx} ->
+      cursor_idx >= start_idx and cursor_idx <= end_idx
+    end)
   end
 
   @spec sentence_context(Readable.t(), position()) :: {sentence_tokens(), non_neg_integer()} | nil
@@ -762,38 +788,32 @@ defmodule Minga.Editing.TextObject do
           non_neg_integer(),
           :inner | :around
         ) :: range()
-  defp sentence_gap_range(tokens, spans, cursor_idx, kind) do
-    case elem(tokens, cursor_idx) do
-      {char, _pos} ->
-        if sentence_whitespace?(char) and spans != [] do
-          {gap_start_idx, gap_end_idx} = whitespace_run_indices(tokens, cursor_idx)
-          prev_span = previous_sentence_span(spans, cursor_idx)
-          next_span = next_sentence_span(spans, cursor_idx)
+  defp sentence_gap_range(tokens, spans, cursor_idx, :inner) do
+    {gap_start_idx, gap_end_idx} = whitespace_run_indices(tokens, cursor_idx)
 
-          case {kind, prev_span, next_span} do
-            {:inner, nil, nil} ->
-              nil
+    case {previous_sentence_span(spans, cursor_idx), next_sentence_span(spans, cursor_idx)} do
+      {nil, nil} ->
+        nil
 
-            {:inner, nil, {_next_start_idx, next_end_idx, _next_trailing_end_idx}} ->
-              range_from_token_indices(tokens, gap_start_idx, next_end_idx)
+      {nil, {_next_start_idx, next_end_idx, _next_trailing_end_idx}} ->
+        range_from_token_indices(tokens, gap_start_idx, next_end_idx)
 
-            {:inner, _prev_span, nil} ->
-              range_from_token_indices(tokens, gap_start_idx, gap_end_idx)
+      {_prev_span, _next_span} ->
+        range_from_token_indices(tokens, gap_start_idx, gap_end_idx)
+    end
+  end
 
-            {:inner, _prev_span, _next_span} ->
-              range_from_token_indices(tokens, gap_start_idx, gap_end_idx)
+  defp sentence_gap_range(tokens, spans, cursor_idx, :around) do
+    {gap_start_idx, _gap_end_idx} = whitespace_run_indices(tokens, cursor_idx)
 
-            {:around, _, nil} ->
-              nil
+    case next_sentence_span(spans, cursor_idx) do
+      nil ->
+        nil
 
-            {:around, _prev_span, {_next_start_idx, _next_end_idx, next_trailing_end_idx}} ->
-              {_gap_char, gap_start_pos} = elem(tokens, gap_start_idx)
-              {_next_char, next_end_pos} = elem(tokens, next_trailing_end_idx)
-              {gap_start_pos, next_end_pos}
-          end
-        else
-          nil
-        end
+      {_next_start_idx, _next_end_idx, next_trailing_end_idx} ->
+        {_gap_char, gap_start_pos} = elem(tokens, gap_start_idx)
+        {_next_char, next_end_pos} = elem(tokens, next_trailing_end_idx)
+        {gap_start_pos, next_end_pos}
     end
   end
 

--- a/lib/minga/mode/operator_pending.ex
+++ b/lib/minga/mode/operator_pending.ex
@@ -57,6 +57,8 @@ defmodule Minga.Mode.OperatorPending do
   | Key | Object                              |
   |-----|-------------------------------------|
   | `w` | word (`iw` / `aw`)                  |
+  | `p` | paragraph (`ip` / `ap`)             |
+  | `s` | sentence (`is` / `as`)              |
   | `"` | double-quoted string (`i"` / `a"`)  |
   | `'` | single-quoted string (`i'` / `a'`)  |
   | `(` or `)` | parentheses (`i(` / `a(`) |
@@ -106,6 +108,18 @@ defmodule Minga.Mode.OperatorPending do
   def handle_key({?w, 0}, %OPState{text_object_modifier: modifier} = state)
       when modifier in [:inner, :around] do
     execute_text_object(state, modifier, :word)
+  end
+
+  # `p` — paragraph text object.
+  def handle_key({?p, 0}, %OPState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] do
+    execute_text_object(state, modifier, :paragraph)
+  end
+
+  # `s` — sentence text object.
+  def handle_key({?s, 0}, %OPState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] do
+    execute_text_object(state, modifier, :sentence)
   end
 
   # `"` — double-quoted string.

--- a/lib/minga/mode/visual.ex
+++ b/lib/minga/mode/visual.ex
@@ -262,6 +262,19 @@ defmodule Minga.Mode.Visual do
     {:execute, [{:visual_text_object, modifier, :word}], %{state | text_object_modifier: nil}}
   end
 
+  # Paragraph text object
+  def handle_key({?p, 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] do
+    {:execute, [{:visual_text_object, modifier, :paragraph}],
+     %{state | text_object_modifier: nil}}
+  end
+
+  # Sentence text object
+  def handle_key({?s, 0}, %VisualState{text_object_modifier: modifier} = state)
+      when modifier in [:inner, :around] do
+    {:execute, [{:visual_text_object, modifier, :sentence}], %{state | text_object_modifier: nil}}
+  end
+
   # Quote text objects
   def handle_key({?", 0}, %VisualState{text_object_modifier: modifier} = state)
       when modifier in [:inner, :around] do

--- a/lib/minga_editor/commands/helpers.ex
+++ b/lib/minga_editor/commands/helpers.ex
@@ -26,7 +26,7 @@ defmodule MingaEditor.Commands.Helpers do
   @type operator_action :: :delete | :yank
 
   @typedoc "Text object action kind."
-  @type text_object_action :: :delete | :yank
+  @type text_object_action :: :delete | :yank | :change
 
   @typedoc "Clipboard sync mode controlling automatic system clipboard integration."
   @type clipboard_mode :: :unnamedplus | :unnamed | :none
@@ -570,21 +570,69 @@ defmodule MingaEditor.Commands.Helpers do
     buffer_id = HighlightSync.buffer_id_for(state, buf)
     range = compute_text_object_range(gb, cursor, modifier, spec, buffer_id)
 
-    case {action, range} do
-      {_, nil} ->
+    case {linewise_spec?(spec), action, range} do
+      {_, _, nil} ->
         state
 
-      {:delete, {start_pos, end_pos}} ->
+      {true, :delete, {start_pos, end_pos}} ->
+        apply_linewise_text_object(buf, state, start_pos, end_pos, :delete)
+
+      {true, :change, {start_pos, end_pos}} ->
+        apply_linewise_text_object(buf, state, start_pos, end_pos, :change)
+
+      {true, :yank, {start_pos, end_pos}} ->
+        apply_linewise_text_object(buf, state, start_pos, end_pos, :yank)
+
+      {false, :delete, {start_pos, end_pos}} ->
         text = Document.content_between_inclusive(gb, start_pos, end_pos)
         Buffer.delete_range(buf, start_pos, end_pos)
         put_register(state, text, :delete)
 
-      {:yank, {start_pos, end_pos}} ->
+      {false, :change, {start_pos, end_pos}} ->
+        text = Document.content_between_inclusive(gb, start_pos, end_pos)
+        Buffer.delete_range(buf, start_pos, end_pos)
+        put_register(state, text, :delete)
+
+      {false, :yank, {start_pos, end_pos}} ->
         text = Document.content_between_inclusive(gb, start_pos, end_pos)
         state = put_register(state, text, :yank)
         maybe_start_yank_flash(state, buf, start_pos, end_pos, :charwise)
     end
   end
+
+  defp apply_linewise_text_object(
+         buf,
+         state,
+         {start_line, _start_col},
+         {end_line, _end_col},
+         action
+       ) do
+    first_line = min(start_line, end_line)
+    last_line = max(start_line, end_line)
+    text = Buffer.content_on_lines(buf, first_line, last_line) <> "\n"
+
+    case action do
+      :delete ->
+        Buffer.delete_lines(buf, first_line, last_line)
+        put_register(state, text, :delete, :linewise)
+
+      :change ->
+        if first_line < last_line do
+          Buffer.delete_lines(buf, first_line + 1, last_line)
+        end
+
+        {:ok, _} = Buffer.clear_line(buf, first_line)
+        put_register(state, text, :delete, :linewise)
+
+      :yank ->
+        state = put_register(state, text, :yank, :linewise)
+        maybe_start_yank_flash(state, buf, {first_line, 0}, {last_line, 0}, :linewise)
+    end
+  end
+
+  @spec linewise_spec?(term()) :: boolean()
+  defp linewise_spec?(:paragraph), do: true
+  defp linewise_spec?(_spec), do: false
 
   @doc "Computes the range for a text object modifier + spec pair."
   @spec compute_text_object_range(
@@ -612,6 +660,18 @@ defmodule MingaEditor.Commands.Helpers do
 
   def compute_text_object_range(buf, pos, :around, {:paren, open, close}, _bid),
     do: Minga.Editing.select_around_parens(buf, pos, open, close)
+
+  def compute_text_object_range(buf, pos, :inner, :paragraph, _bid),
+    do: Minga.Editing.select_inner_paragraph(buf, pos)
+
+  def compute_text_object_range(buf, pos, :around, :paragraph, _bid),
+    do: Minga.Editing.select_around_paragraph(buf, pos)
+
+  def compute_text_object_range(buf, pos, :inner, :sentence, _bid),
+    do: Minga.Editing.select_inner_sentence(buf, pos)
+
+  def compute_text_object_range(buf, pos, :around, :sentence, _bid),
+    do: Minga.Editing.select_around_sentence(buf, pos)
 
   def compute_text_object_range(_buf, {line, col}, :inner, {:structural, type}, bid) do
     capture = Atom.to_string(type) <> ".inside"

--- a/lib/minga_editor/commands/operators.ex
+++ b/lib/minga_editor/commands/operators.ex
@@ -115,7 +115,7 @@ defmodule MingaEditor.Commands.Operators do
       when is_pid(buf) do
     if read_only?(buf),
       do: read_only_msg(state),
-      else: Helpers.apply_text_object(state, modifier, spec, :delete)
+      else: Helpers.apply_text_object(state, modifier, spec, :change)
   end
 
   def execute(

--- a/lib/minga_editor/commands/visual.ex
+++ b/lib/minga_editor/commands/visual.ex
@@ -136,7 +136,7 @@ defmodule MingaEditor.Commands.Visual do
 
       {start_pos, end_pos} ->
         # Update visual anchor to start of text object, move cursor to end
-        new_ms = %{ms | visual_anchor: start_pos}
+        new_ms = %{ms | visual_anchor: start_pos, visual_type: visual_type_for_text_object(spec)}
         Buffer.move_to(buf, end_pos)
 
         EditorState.update_workspace(
@@ -168,6 +168,10 @@ defmodule MingaEditor.Commands.Visual do
 
     EditorState.transition_mode(state, :visual, visual_state)
   end
+
+  @spec visual_type_for_text_object(term()) :: :char | :line
+  defp visual_type_for_text_object(:paragraph), do: :line
+  defp visual_type_for_text_object(_spec), do: :char
 
   @impl Minga.Command.Provider
   def __commands__ do

--- a/test/minga/editing/text_object_test.exs
+++ b/test/minga/editing/text_object_test.exs
@@ -313,6 +313,16 @@ defmodule Minga.Editing.TextObjectTest do
       assert {{0, 0}, {0, 5}} = TextObject.inner_sentence(b, {0, 5})
     end
 
+    test "cursor on whitespace inside a sentence selects the sentence" do
+      b = buf("One continues.")
+      assert {{0, 0}, {0, 13}} = TextObject.inner_sentence(b, {0, 3})
+    end
+
+    test "cursor on embedded newline inside a sentence selects the sentence" do
+      b = buf("One continues\nacross lines.")
+      assert {{0, 0}, {1, 12}} = TextObject.inner_sentence(b, {0, 13})
+    end
+
     test "cursor on leading whitespace selects the first sentence" do
       b = buf("  Hello. Bye.")
       assert {{0, 0}, {0, 7}} = TextObject.inner_sentence(b, {0, 0})
@@ -345,6 +355,16 @@ defmodule Minga.Editing.TextObjectTest do
     test "includes trailing whitespace" do
       b = buf("Hello.   Bye.")
       assert {{0, 0}, {0, 8}} = TextObject.a_sentence(b, {0, 1})
+    end
+
+    test "cursor on whitespace inside a single sentence selects that sentence" do
+      b = buf("One continues.")
+      assert {{0, 0}, {0, 13}} = TextObject.a_sentence(b, {0, 3})
+    end
+
+    test "cursor on whitespace inside a sentence selects the sentence" do
+      b = buf("One continues. Two.")
+      assert {{0, 0}, {0, 14}} = TextObject.a_sentence(b, {0, 3})
     end
 
     test "cursor on whitespace between sentences selects whitespace plus following sentence" do

--- a/test/minga/editing/text_object_test.exs
+++ b/test/minga/editing/text_object_test.exs
@@ -232,4 +232,143 @@ defmodule Minga.Editing.TextObjectTest do
       assert {{0, 3}, {0, 5}} = result
     end
   end
+
+  # ── inner_paragraph/2 ─────────────────────────────────────────────────────────
+
+  describe "inner_paragraph/2 (ip)" do
+    test "selects contiguous non-blank lines around the cursor" do
+      b = buf("one\ntwo\n\nthree")
+      assert {{0, 0}, {1, 2}} = TextObject.inner_paragraph(b, {1, 1})
+    end
+
+    test "selects the blank-line run when cursor is on a blank line" do
+      b = buf("one\n\n  \ntwo")
+      assert {{1, 0}, {2, 1}} = TextObject.inner_paragraph(b, {1, 0})
+    end
+
+    test "selects a single-line buffer" do
+      b = buf("only line")
+      assert {{0, 0}, {0, 8}} = TextObject.inner_paragraph(b, {0, 4})
+    end
+
+    test "returns nil for an empty buffer" do
+      assert nil == TextObject.inner_paragraph(buf(""), {0, 0})
+    end
+
+    test "handles document boundaries" do
+      b = buf("first\n\nlast")
+      assert {{0, 0}, {0, 4}} = TextObject.inner_paragraph(b, {0, 0})
+      assert {{2, 0}, {2, 3}} = TextObject.inner_paragraph(b, {2, 3})
+    end
+  end
+
+  # ── a_paragraph/2 ─────────────────────────────────────────────────────────────
+
+  describe "a_paragraph/2 (ap)" do
+    test "includes one trailing blank line when available" do
+      b = buf("one\ntwo\n\nthree")
+      assert {{0, 0}, {2, 0}} = TextObject.a_paragraph(b, {0, 1})
+    end
+
+    test "includes one leading blank line when paragraph is at end of file" do
+      b = buf("one\n\ntwo\nthree")
+      assert {{1, 0}, {3, 4}} = TextObject.a_paragraph(b, {2, 1})
+    end
+
+    test "keeps a single paragraph without surrounding blank lines unchanged" do
+      b = buf("one\ntwo")
+      assert {{0, 0}, {1, 2}} = TextObject.a_paragraph(b, {1, 0})
+    end
+
+    test "handles cursor on a blank separator line by selecting the following paragraph" do
+      b = buf("one\n\nthree\n\nfour")
+      assert {{2, 0}, {3, 0}} = TextObject.a_paragraph(b, {1, 0})
+    end
+
+    test "returns nil for an empty buffer" do
+      assert nil == TextObject.a_paragraph(buf(""), {0, 0})
+    end
+  end
+
+  # ── inner_sentence/2 ──────────────────────────────────────────────────────────
+
+  describe "inner_sentence/2 (is)" do
+    test "selects the current sentence on a multi-sentence line" do
+      b = buf("First sentence. Second sentence!")
+      assert {{0, 16}, {0, 31}} = TextObject.inner_sentence(b, {0, 20})
+    end
+
+    test "selects a sentence spanning multiple lines" do
+      b = buf("First sentence spans\ntwo lines. Next one.")
+      assert {{0, 0}, {1, 9}} = TextObject.inner_sentence(b, {1, 4})
+    end
+
+    test "includes closing delimiters after terminal punctuation" do
+      b = buf(~s(He said "stop." Then left.))
+      assert {{0, 0}, {0, 14}} = TextObject.inner_sentence(b, {0, 10})
+    end
+
+    test "cursor on punctuation selects that sentence" do
+      b = buf("Hello. Bye.")
+      assert {{0, 0}, {0, 5}} = TextObject.inner_sentence(b, {0, 5})
+    end
+
+    test "cursor on leading whitespace selects the first sentence" do
+      b = buf("  Hello. Bye.")
+      assert {{0, 0}, {0, 7}} = TextObject.inner_sentence(b, {0, 0})
+    end
+
+    test "cursor on whitespace between sentences selects the whitespace run" do
+      b = buf("Hello.   Bye.")
+      assert {{0, 6}, {0, 8}} = TextObject.inner_sentence(b, {0, 7})
+    end
+
+    test "cursor on trailing whitespace selects the trailing spaces only" do
+      b = buf("Hello.   ")
+      assert {{0, 6}, {0, 8}} = TextObject.inner_sentence(b, {0, 7})
+    end
+
+    test "returns nil for empty buffer and blank lines" do
+      assert nil == TextObject.inner_sentence(buf(""), {0, 0})
+      assert nil == TextObject.inner_sentence(buf("Hello.\n\nBye."), {1, 0})
+    end
+
+    test "treats an unterminated single line as a sentence" do
+      b = buf("No punctuation")
+      assert {{0, 0}, {0, 13}} = TextObject.inner_sentence(b, {0, 3})
+    end
+  end
+
+  # ── a_sentence/2 ──────────────────────────────────────────────────────────────
+
+  describe "a_sentence/2 (as)" do
+    test "includes trailing whitespace" do
+      b = buf("Hello.   Bye.")
+      assert {{0, 0}, {0, 8}} = TextObject.a_sentence(b, {0, 1})
+    end
+
+    test "cursor on whitespace between sentences selects whitespace plus following sentence" do
+      b = buf("Hello.   Bye.")
+      assert {{0, 6}, {0, 12}} = TextObject.a_sentence(b, {0, 7})
+    end
+
+    test "includes newline whitespace before the next sentence" do
+      b = buf("Hello.\nBye.")
+      assert {{0, 0}, {0, 6}} = TextObject.a_sentence(b, {0, 1})
+    end
+
+    test "handles sentence at document end" do
+      b = buf("Hello. Bye.")
+      assert {{0, 7}, {0, 10}} = TextObject.a_sentence(b, {0, 8})
+    end
+
+    test "returns nil for trailing whitespace after the final sentence" do
+      assert nil == TextObject.a_sentence(buf("Hello.   "), {0, 7})
+    end
+
+    test "returns nil for empty buffer and blank lines" do
+      assert nil == TextObject.a_sentence(buf(""), {0, 0})
+      assert nil == TextObject.a_sentence(buf("Hello.\n\nBye."), {1, 0})
+    end
+  end
 end

--- a/test/minga/mode/operator_pending_structural_test.exs
+++ b/test/minga/mode/operator_pending_structural_test.exs
@@ -100,5 +100,33 @@ defmodule Minga.Mode.OperatorPendingStructuralTest do
       assert {:execute_then_transition, [{:delete_text_object, :inner, {:paren, "(", ")"}}],
               :normal, _} = OperatorPending.handle_key({?(, 0}, state)
     end
+
+    test "dip emits paragraph text object without affecting unmodified p" do
+      state = %OPState{operator: :delete, text_object_modifier: :inner}
+
+      assert {:execute_then_transition, [{:delete_text_object, :inner, :paragraph}], :normal, _} =
+               OperatorPending.handle_key({?p, 0}, state)
+    end
+
+    test "yap emits around paragraph text object" do
+      state = %OPState{operator: :yank, text_object_modifier: :around}
+
+      assert {:execute_then_transition, [{:yank_text_object, :around, :paragraph}], :normal, _} =
+               OperatorPending.handle_key({?p, 0}, state)
+    end
+
+    test "cis emits inner sentence text object and transitions to insert" do
+      state = %OPState{operator: :change, text_object_modifier: :inner}
+
+      assert {:execute_then_transition, [{:change_text_object, :inner, :sentence}], :insert, _} =
+               OperatorPending.handle_key({?s, 0}, state)
+    end
+
+    test "das emits around sentence text object" do
+      state = %OPState{operator: :delete, text_object_modifier: :around}
+
+      assert {:execute_then_transition, [{:delete_text_object, :around, :sentence}], :normal, _} =
+               OperatorPending.handle_key({?s, 0}, state)
+    end
   end
 end

--- a/test/minga/mode/visual_text_object_test.exs
+++ b/test/minga/mode/visual_text_object_test.exs
@@ -72,6 +72,34 @@ defmodule Minga.Mode.VisualTextObjectTest do
                Visual.handle_key({?w, 0}, state)
     end
 
+    test "vip selects inner paragraph" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, :paragraph}], %VisualState{}} =
+               Visual.handle_key({?p, 0}, state)
+    end
+
+    test "vap selects around paragraph" do
+      state = visual_state(modifier: :around)
+
+      assert {:execute, [{:visual_text_object, :around, :paragraph}], %VisualState{}} =
+               Visual.handle_key({?p, 0}, state)
+    end
+
+    test "vis selects inner sentence" do
+      state = visual_state(modifier: :inner)
+
+      assert {:execute, [{:visual_text_object, :inner, :sentence}], %VisualState{}} =
+               Visual.handle_key({?s, 0}, state)
+    end
+
+    test "vas selects around sentence" do
+      state = visual_state(modifier: :around)
+
+      assert {:execute, [{:visual_text_object, :around, :sentence}], %VisualState{}} =
+               Visual.handle_key({?s, 0}, state)
+    end
+
     test "vi\" selects inner double-quoted string" do
       state = visual_state(modifier: :inner)
 

--- a/test/minga_editor/commands/operators_test.exs
+++ b/test/minga_editor/commands/operators_test.exs
@@ -191,4 +191,112 @@ defmodule MingaEditor.Commands.OperatorsTest do
       assert register_entry(new_state) == {"aaa\nbbb\n", :linewise}
     end
   end
+
+  # ── paragraph text object operators ─────────────────────────────────────────
+
+  describe "paragraph text object operators" do
+    test "dip deletes the current paragraph linewise" do
+      buf = start_buffer("one\ntwo\n\nthree")
+      BufferProcess.move_to(buf, {1, 0})
+      state = build_state(buf)
+
+      new_state = Operators.execute(state, {:delete_text_object, :inner, :paragraph})
+
+      assert BufferProcess.content(buf) == "\nthree"
+      assert register_entry(new_state) == {"one\ntwo\n", :linewise}
+    end
+
+    test "yap yanks paragraph plus trailing blank line as linewise" do
+      buf = start_buffer("one\ntwo\n\nthree")
+      BufferProcess.move_to(buf, {0, 0})
+      state = build_state(buf)
+
+      new_state = Operators.execute(state, {:yank_text_object, :around, :paragraph})
+
+      assert BufferProcess.content(buf) == "one\ntwo\n\nthree"
+      assert register_entry(new_state) == {"one\ntwo\n\n", :linewise}
+      assert register_entry(new_state, "0") == {"one\ntwo\n\n", :linewise}
+    end
+
+    test "cip clears the current line instead of deleting all selected lines" do
+      buf = start_buffer("one\ntwo\n\nthree")
+      BufferProcess.move_to(buf, {1, 0})
+      state = build_state(buf)
+
+      new_state = Operators.execute(state, {:change_text_object, :inner, :paragraph})
+
+      assert BufferProcess.content(buf) == "\n\nthree"
+      assert register_entry(new_state) == {"one\ntwo\n", :linewise}
+    end
+
+    test "cap on a blank separator line prefers the following paragraph" do
+      buf = start_buffer("one\n\nthree\n\nfour")
+      BufferProcess.move_to(buf, {1, 0})
+      state = build_state(buf)
+
+      new_state = Operators.execute(state, {:change_text_object, :around, :paragraph})
+
+      assert BufferProcess.content(buf) == "one\n\n\nfour"
+      assert register_entry(new_state) == {"three\n\n", :linewise}
+    end
+
+    test "dap on a blank separator line deletes the following paragraph linewise" do
+      buf = start_buffer("one\n\nthree\n\nfour")
+      BufferProcess.move_to(buf, {1, 0})
+      state = build_state(buf)
+
+      new_state = Operators.execute(state, {:delete_text_object, :around, :paragraph})
+
+      assert BufferProcess.content(buf) == "one\n\nfour"
+      assert register_entry(new_state) == {"three\n\n", :linewise}
+    end
+  end
+
+  # ── sentence text object operators ───────────────────────────────────────────
+
+  describe "sentence text object operators" do
+    test "dis on leading whitespace selects the whole sentence" do
+      buf = start_buffer("  Hello. Bye.")
+      BufferProcess.move_to(buf, {0, 0})
+      state = build_state(buf)
+
+      new_state = Operators.execute(state, {:delete_text_object, :inner, :sentence})
+
+      assert BufferProcess.content(buf) == " Bye."
+      assert register_entry(new_state) == {"  Hello.", :charwise}
+    end
+
+    test "cis on leading whitespace selects the whole sentence and enters insert" do
+      buf = start_buffer("  Hello. Bye.")
+      BufferProcess.move_to(buf, {0, 0})
+      state = build_state(buf)
+
+      new_state = Operators.execute(state, {:change_text_object, :inner, :sentence})
+
+      assert BufferProcess.content(buf) == " Bye."
+      assert register_entry(new_state) == {"  Hello.", :charwise}
+    end
+
+    test "das on trailing whitespace is a no-op" do
+      buf = start_buffer("Hello.   ")
+      BufferProcess.move_to(buf, {0, 7})
+      state = build_state(buf)
+
+      new_state = Operators.execute(state, {:delete_text_object, :around, :sentence})
+
+      assert BufferProcess.content(buf) == "Hello.   "
+      assert register_entry(new_state) == nil
+    end
+
+    test "yas on trailing whitespace is a no-op" do
+      buf = start_buffer("Hello.   ")
+      BufferProcess.move_to(buf, {0, 7})
+      state = build_state(buf)
+
+      new_state = Operators.execute(state, {:yank_text_object, :around, :sentence})
+
+      assert BufferProcess.content(buf) == "Hello.   "
+      assert register_entry(new_state) == nil
+    end
+  end
 end

--- a/test/minga_editor/commands/visual_text_object_test.exs
+++ b/test/minga_editor/commands/visual_text_object_test.exs
@@ -1,0 +1,102 @@
+defmodule MingaEditor.Commands.VisualTextObjectTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Mode.VisualState
+  alias MingaEditor.Commands.Visual
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  defp start_buffer(content) do
+    start_supervised!({BufferProcess, content: content})
+  end
+
+  defp build_state(buf, anchor \\ {0, 0}) do
+    state = %EditorState{
+      port_manager: nil,
+      workspace: %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: %MingaEditor.State.Buffers{active: buf, list: [buf]}
+      }
+    }
+
+    EditorState.transition_mode(state, :visual, %VisualState{
+      visual_anchor: anchor,
+      visual_type: :char
+    })
+  end
+
+  describe "visual paragraph and sentence text objects" do
+    test "vip selects the current paragraph range as linewise" do
+      buf = start_buffer("one\ntwo\n\nthree")
+      BufferProcess.move_to(buf, {1, 1})
+      state = build_state(buf)
+
+      new_state = Visual.execute(state, {:visual_text_object, :inner, :paragraph})
+
+      assert new_state.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert new_state.workspace.editing.mode_state.visual_type == :line
+      assert BufferProcess.cursor(buf) == {1, 2}
+    end
+
+    test "vap selects the paragraph plus trailing blank line" do
+      buf = start_buffer("one\ntwo\n\nthree")
+      BufferProcess.move_to(buf, {0, 1})
+      state = build_state(buf)
+
+      new_state = Visual.execute(state, {:visual_text_object, :around, :paragraph})
+
+      assert new_state.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert new_state.workspace.editing.mode_state.visual_type == :line
+      assert BufferProcess.cursor(buf) == {2, 0}
+    end
+
+    test "vis selects the current sentence range" do
+      buf = start_buffer("First. Second sentence!")
+      BufferProcess.move_to(buf, {0, 10})
+      state = build_state(buf)
+
+      new_state = Visual.execute(state, {:visual_text_object, :inner, :sentence})
+
+      assert new_state.workspace.editing.mode_state.visual_anchor == {0, 7}
+      assert BufferProcess.cursor(buf) == {0, 22}
+    end
+
+    test "vas selects the sentence plus trailing whitespace" do
+      buf = start_buffer("Hello.   Bye.")
+      BufferProcess.move_to(buf, {0, 1})
+      state = build_state(buf)
+
+      new_state = Visual.execute(state, {:visual_text_object, :around, :sentence})
+
+      assert new_state.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert BufferProcess.cursor(buf) == {0, 8}
+    end
+
+    test "vas on whitespace selects the following sentence" do
+      buf = start_buffer("Hello.   Bye.")
+      BufferProcess.move_to(buf, {0, 7})
+      state = build_state(buf)
+
+      new_state = Visual.execute(state, {:visual_text_object, :around, :sentence})
+
+      assert new_state.workspace.editing.mode_state.visual_anchor == {0, 6}
+      assert BufferProcess.cursor(buf) == {0, 12}
+    end
+
+    test "vip then delete removes whole lines linewise" do
+      buf = start_buffer("one\ntwo\n\nthree")
+      BufferProcess.move_to(buf, {1, 1})
+      state = build_state(buf)
+
+      selected = Visual.execute(state, {:visual_text_object, :inner, :paragraph})
+      new_state = Visual.execute(selected, :delete_visual_selection)
+
+      assert BufferProcess.content(buf) == "\nthree"
+
+      assert MingaEditor.State.Registers.get(new_state.workspace.editing.reg, "") ==
+               {"one\ntwo\n", :linewise}
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR
Adds Vim paragraph and sentence text objects so `ip`, `ap`, `is`, and `as` work in operator-pending and visual modes.

Closes #637

## Context
Minga already had paragraph motions, but the matching Vim text objects were missing. This PR fills that grammar gap for prose and code separated by blank lines.

## Changes
- Added pure paragraph text object ranges for `ip` and `ap`, including blank-line cursor behavior and EOF leading-blank handling.
- Added sentence text object ranges for `is` and `as`, including punctuation delimiters, closing delimiters, multiline sentences, and trailing whitespace.
- Routed paragraph text objects through the linewise operator path so delete/change/yank register behavior matches Vim linewise semantics.
- Registered paragraph and sentence objects in operator-pending and visual modes.
- Added pure, dispatch, operator-command, and visual-command tests for the new behavior, including Vim-parity regressions for sentence whitespace and blank-line paragraph cases.

## Verification
- `mix test.llm test/minga/editing/text_object_test.exs test/minga/mode/operator_pending_structural_test.exs test/minga/mode/visual_text_object_test.exs test/minga_editor/commands/operators_test.exs test/minga_editor/commands/visual_text_object_test.exs` passed: 142 tests, 0 failures.
- `make lint` passed. Credo reports existing struct-size warnings, then compile and Dialyzer pass.
- `git diff --cached --check` passed before commit.
- Test-advisor re-check passed after adding the requested extra edge coverage. Parent-orchestrated review loop then found and fixed Vim-parity edge cases for sentence whitespace, paragraph change/delete, visual linewise paragraph behavior, and blank separator `ap`.
- Full `mix test.llm` runs exposed rotating unrelated timeout/frecency/editor-start failures outside this diff. Each reported failure location was rerun directly and passed in isolation.

## Acceptance Criteria Addressed
- `ip` selects the current paragraph without surrounding blank lines ✅
- `ap` selects the current paragraph including one trailing blank line, or leading blank at EOF ✅
- `is` selects the current sentence ✅
- `as` selects the current sentence including trailing whitespace ✅
- All four work in operator-pending mode (`dip`, `yap`, `cis`, `das`) ✅
- All four work in visual mode (`vip`, `vap`, `vis`, `vas`) ✅
- Edge cases tested: empty buffer, single line, blank-line cursor, document boundaries, trailing whitespace, and closing sentence delimiters ✅

