### PR TITLE
feat(parser): add structural AST navigation

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -65,6 +65,7 @@ The frontend runs as a child process of the BEAM. Communication uses stdin (BEAM
 | `0x2C` | request_textobject | variable | Request a text object range |
 | `0x2D` | close_buffer | 5 | Free parser state for a buffer |
 | `0x2E` | request_match_item | 17 | Request structural delimiter, keyword, quote, or tag match |
+| `0x2F` | request_structural_nav | 18 | Request parent, child, or sibling AST navigation |
 
 ### Frontend → BEAM (Input Events)
 
@@ -93,6 +94,7 @@ The frontend runs as a child process of the BEAM. Communication uses stdin (BEAM
 | `0x3A` | conceal_spans | variable | Conceal byte ranges and replacement text |
 | `0x3B` | request_reparse | 5 | Parser requests full reparse after stale edit deltas |
 | `0x3C` | match_item_result | 6 or 14 | Structural match position result (or nil) |
+| `0x3D` | node_info | 6 or 24 + type_len | Structural navigation target range and node type |
 
 ### Frontend → BEAM (Diagnostics)
 
@@ -591,6 +593,23 @@ Total size: 9 + count × 9 bytes.
 
 **Behavior:** The Zig parser runs the `textobjects.scm` query against the parse tree and collects the start positions of all `.around` captures (e.g., `@function.around`, `@class.around`). Entries are sorted by (row, col) before sending. The BEAM decodes them into a `%{atom => [{row, col}]}` map and stores them on the active window struct. Navigation commands (`]f`, `[f`, etc.) scan this cached data with no further IPC to Zig.
 
+### `0x2F` request_structural_nav
+
+Request Helix-style structural AST navigation from the parser. The parser starts from the deepest named tree-sitter node at the cursor and returns the requested named relative.
+
+```
+opcode:     u8  = 0x2F
+buffer_id:  u32           parser buffer id
+request_id: u32           caller-chosen correlation id
+row:        u32           0-indexed line number
+col:        u32           0-indexed byte column
+action:     u8            0=parent, 1=first child, 2=next sibling, 3=previous sibling
+```
+
+Total size: 18 bytes.
+
+**Behavior:** Anonymous and punctuation nodes are skipped by starting with `ts_node_named_descendant_for_point_range` and moving through named parents, children, or siblings. If the parser has no buffer, no grammar, or no target node, it responds with `node_info` and `found = 0`. Invalid action bytes are malformed protocol commands.
+
 ### `0x3C` match_item_result
 
 Response to `request_match_item`. The parser returns one cursor position for the matching structural item, or `found = 0` when the cursor is not on a matchable item or the buffer has no grammar.
@@ -606,6 +625,26 @@ col:        u32           present only when found = 1
 Total size: 6 bytes when not found, 14 bytes when found.
 
 **Behavior:** Used by `%` in normal, visual, and operator-pending modes. The Zig parser walks the tree-sitter AST to match structural brackets, block keywords such as `def`/`end`, string delimiters, and HTML/XML tags without falling back to text scanning.
+
+### `0x3D` node_info
+
+Response to `request_structural_nav`. The parser returns the target node range and tree-sitter node type, or `found = 0` when no target exists.
+
+```
+opcode:     u8  = 0x3D
+request_id: u32           correlation ID from the request
+found:      u8            1 if a node was found, 0 otherwise
+start_row:  u32           present only when found = 1
+start_col:  u32           present only when found = 1
+end_row:    u32           present only when found = 1
+end_col:    u32           present only when found = 1
+type_len:   u16           present only when found = 1, capped at 255 bytes by the Zig encoder
+type:       [type_len]u8  UTF-8 tree-sitter node type name
+```
+
+Total size: 6 bytes when not found, 24 + type_len bytes when found.
+
+**Behavior:** The BEAM moves the cursor to `(start_row, start_col)` and can display `type` to help users learn the file's AST structure. The Zig encoder uses a fixed 280-byte stack buffer and truncates type names to 255 bytes. Current tree-sitter node type names are far shorter than this cap, but frontend and parser implementations should treat the cap as part of the wire contract.
 
 ### `0x3B` request_reparse
 
@@ -666,7 +705,7 @@ Total size: 4 + msg_len bytes.
 
 ### Current design
 
-Tree-sitter parsing runs in a dedicated `minga-parser` Zig process, separate from the rendering frontend. The renderer process handles only render commands (`0x10`-`0x1B` plus GUI chrome `0x70+`). The parser process handles highlight commands (`0x20`-`0x2E`) and sends highlight responses (`0x30`-`0x3C`). Both use the same `{:packet, 4}` framing on their respective stdin/stdout pipes. The BEAM manages both Port processes, routing commands to the appropriate one.
+Tree-sitter parsing runs in a dedicated `minga-parser` Zig process, separate from the rendering frontend. The renderer process handles only render commands (`0x10`-`0x1B` plus GUI chrome `0x70+`). The parser process handles highlight commands (`0x20`-`0x2F`) and sends highlight responses (`0x30`-`0x3D`). Both use the same `{:packet, 4}` framing on their respective stdin/stdout pipes. The BEAM manages both Port processes, routing commands to the appropriate one.
 
 This separation means rendering frontends (Swift/Metal, GTK4, Zig/libvaxis) only need to implement render commands. Tree-sitter parsing is handled by the shared parser process regardless of which frontend is active.
 

--- a/lib/minga/keymap/defaults.ex
+++ b/lib/minga/keymap/defaults.ex
@@ -28,6 +28,7 @@ defmodule Minga.Keymap.Defaults do
   alias Minga.Keymap.Bindings
 
   @none 0x00
+  @alt 0x04
 
   # ---------------------------------------------------------------------------
   # Leaf bindings: {key_sequence, command_atom, description}
@@ -270,6 +271,10 @@ defmodule Minga.Keymap.Defaults do
       {?j, 0} => {:move_down, "Move cursor down"},
       {?k, 0} => {:move_up, "Move cursor up"},
       {?l, 0} => {:move_right, "Move cursor right"},
+      {?h, @alt} => {:nav_parent, "Move to parent AST node"},
+      {?l, @alt} => {:nav_first_child, "Move to first child AST node"},
+      {?j, @alt} => {:nav_next_sibling, "Move to next sibling AST node"},
+      {?k, @alt} => {:nav_prev_sibling, "Move to previous sibling AST node"},
       {?0, 0} => {:move_to_line_start, "Move to line start"},
       {?$, 0} => {:move_to_line_end, "Move to line end"},
       {?^, 0} => {:move_to_first_non_blank, "First non-blank character"},

--- a/lib/minga/mode/normal.ex
+++ b/lib/minga/mode/normal.ex
@@ -393,6 +393,22 @@ defmodule Minga.Mode.Normal do
     {:execute, :move_right, state}
   end
 
+  def handle_key({?h, mods}, state) when band(mods, @alt) != 0 do
+    {:execute, :nav_parent, state}
+  end
+
+  def handle_key({?l, mods}, state) when band(mods, @alt) != 0 do
+    {:execute, :nav_first_child, state}
+  end
+
+  def handle_key({?j, mods}, state) when band(mods, @alt) != 0 do
+    {:execute, :nav_next_sibling, state}
+  end
+
+  def handle_key({?k, mods}, state) when band(mods, @alt) != 0 do
+    {:execute, :nav_prev_sibling, state}
+  end
+
   # Arrow keys
   def handle_key({@arrow_up, _mods}, state) do
     {:execute, :move_up, state}

--- a/lib/minga/mode/visual.ex
+++ b/lib/minga/mode/visual.ex
@@ -61,6 +61,7 @@ defmodule Minga.Mode.Visual do
 
   # Modifier flags (mirrors MingaEditor.Frontend.Protocol)
   @ctrl 0x02
+  @alt 0x04
   @super 0x08
 
   # Arrow key codepoints sent by libvaxis
@@ -93,6 +94,22 @@ defmodule Minga.Mode.Visual do
 
   def handle_key({?l, 0}, state) do
     {:execute, :move_right, state}
+  end
+
+  def handle_key({?h, mods}, state) when band(mods, @alt) != 0 do
+    {:execute, :nav_parent, state}
+  end
+
+  def handle_key({?l, mods}, state) when band(mods, @alt) != 0 do
+    {:execute, :nav_first_child, state}
+  end
+
+  def handle_key({?j, mods}, state) when band(mods, @alt) != 0 do
+    {:execute, :nav_next_sibling, state}
+  end
+
+  def handle_key({?k, mods}, state) when band(mods, @alt) != 0 do
+    {:execute, :nav_prev_sibling, state}
   end
 
   def handle_key({?w, 0}, %VisualState{text_object_modifier: nil} = state) do

--- a/lib/minga/parser/manager.ex
+++ b/lib/minga/parser/manager.ex
@@ -38,6 +38,7 @@ defmodule Minga.Parser.Manager do
   alias Minga.Language.Grammar
   alias Minga.Language.Highlight.Span
   alias Minga.Parser.Protocol
+  alias Minga.Parser.StructuralNavResult
 
   # ── Restart constants ──
 
@@ -50,6 +51,7 @@ defmodule Minga.Parser.Manager do
   @default_indent_request_timeout_ms 2_000
   @default_textobject_request_timeout_ms 2_000
   @default_match_item_request_timeout_ms 2_000
+  @default_structural_nav_request_timeout_ms 2_000
   @request_client_timeout_slack_ms 50
 
   @typedoc "Options for starting the parser manager."
@@ -71,6 +73,9 @@ defmodule Minga.Parser.Manager do
           spans: [Span.t()] | nil,
           timer_ref: reference()
         }
+
+  @typedoc "Structural navigation result returned by the parser."
+  @type structural_nav_result :: StructuralNavResult.t()
 
   @typedoc "Tracked buffer metadata for re-sync after parser restart."
   @type buffer_meta :: %{
@@ -227,6 +232,33 @@ defmodule Minga.Parser.Manager do
       server,
       {:request_match_item, buffer_id, row, col, @default_match_item_request_timeout_ms},
       @default_match_item_request_timeout_ms + @request_client_timeout_slack_ms
+    )
+  catch
+    :exit, _ -> nil
+  end
+
+  @doc """
+  Requests structural AST navigation synchronously.
+
+  Action values are `0` for parent, `1` for first child, `2` for next sibling, and `3` for previous sibling.
+
+  Returns `%Minga.Parser.StructuralNavResult{}` for the target node, or `nil` if no target exists or the parser is unavailable.
+  """
+  @spec request_structural_nav(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          0..3,
+          GenServer.server()
+        ) :: structural_nav_result() | nil
+  def request_structural_nav(buffer_id, row, col, action, server \\ __MODULE__)
+      when is_integer(buffer_id) and is_integer(row) and is_integer(col) and
+             is_integer(action) and action >= 0 and action <= 3 do
+    GenServer.call(
+      server,
+      {:request_structural_nav, buffer_id, row, col, action,
+       @default_structural_nav_request_timeout_ms},
+      @default_structural_nav_request_timeout_ms + @request_client_timeout_slack_ms
     )
   catch
     :exit, _ -> nil
@@ -423,6 +455,20 @@ defmodule Minga.Parser.Manager do
     enqueue_pending_request(state, from, request_id, cmd, timeout_ms)
   end
 
+  def handle_call(
+        {:request_structural_nav, _buffer_id, _row, _col, _action, _timeout_ms},
+        _from,
+        %{port: nil} = state
+      ) do
+    {:reply, nil, state}
+  end
+
+  def handle_call({:request_structural_nav, buffer_id, row, col, action, timeout_ms}, from, state) do
+    request_id = state.next_request_id
+    cmd = Protocol.encode_request_structural_nav(buffer_id, request_id, row, col, action)
+    enqueue_pending_request(state, from, request_id, cmd, timeout_ms)
+  end
+
   def handle_call({:highlight_source, _language, _source, _timeout}, _from, %{port: nil} = state) do
     {:reply, :unavailable, state}
   end
@@ -496,6 +542,9 @@ defmodule Minga.Parser.Manager do
         reply_to_pending_request(state, request_id, result)
 
       {:ok, {:match_item_result, request_id, result}} ->
+        reply_to_pending_request(state, request_id, result)
+
+      {:ok, {:node_info, request_id, result}} ->
         reply_to_pending_request(state, request_id, result)
 
       {:ok, {:highlight_names, _buffer_id, _names} = event} ->

--- a/lib/minga/parser/protocol.ex
+++ b/lib/minga/parser/protocol.ex
@@ -13,6 +13,7 @@ defmodule Minga.Parser.Protocol do
 
   alias Minga.Language.Highlight.InjectionRange
   alias Minga.Language.Highlight.Span
+  alias Minga.Parser.StructuralNavResult
 
   # ── Opcodes: commands (BEAM → Zig parser) ──
 
@@ -30,6 +31,7 @@ defmodule Minga.Parser.Protocol do
   @op_request_textobject 0x2C
   @op_close_buffer 0x2D
   @op_request_match_item 0x2E
+  @op_request_structural_nav 0x2F
 
   # ── Opcodes: responses (Zig parser → BEAM) ──
 
@@ -45,6 +47,7 @@ defmodule Minga.Parser.Protocol do
   @op_conceal_spans 0x3A
   @op_request_reparse 0x3B
   @op_match_item_result 0x3C
+  @op_node_info 0x3D
 
   # Log messages (Zig → BEAM)
   @op_log_message 0x60
@@ -186,6 +189,21 @@ defmodule Minga.Parser.Protocol do
     <<@op_request_match_item, buffer_id::32, request_id::32, row::32, col::32>>
   end
 
+  @doc "Encodes a request_structural_nav command: buffer_id(4) + request_id(4) + row(4) + col(4) + action(1)."
+  @spec encode_request_structural_nav(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          0..3
+        ) :: binary()
+  def encode_request_structural_nav(buffer_id, request_id, row, col, action)
+      when is_integer(buffer_id) and buffer_id >= 0 and
+             is_integer(request_id) and is_integer(row) and is_integer(col) and
+             is_integer(action) and action >= 0 and action <= 3 do
+    <<@op_request_structural_nav, buffer_id::32, request_id::32, row::32, col::32, action::8>>
+  end
+
   @doc "Encodes a load_grammar command."
   @spec encode_load_grammar(String.t(), String.t()) :: binary()
   def encode_load_grammar(name, path) when is_binary(name) and is_binary(path) do
@@ -276,6 +294,18 @@ defmodule Minga.Parser.Protocol do
 
   def decode_event(<<@op_match_item_result, request_id::32, 0>>) do
     {:ok, {:match_item_result, request_id, nil}}
+  end
+
+  def decode_event(
+        <<@op_node_info, request_id::32, 1, start_row::32, start_col::32, end_row::32,
+          end_col::32, type_len::16, type_name::binary-size(type_len)>>
+      ) do
+    result = StructuralNavResult.new(start_row, start_col, end_row, end_col, type_name)
+    {:ok, {:node_info, request_id, result}}
+  end
+
+  def decode_event(<<@op_node_info, request_id::32, 0>>) do
+    {:ok, {:node_info, request_id, nil}}
   end
 
   def decode_event(

--- a/lib/minga/parser/structural_nav_result.ex
+++ b/lib/minga/parser/structural_nav_result.ex
@@ -1,0 +1,43 @@
+defmodule Minga.Parser.StructuralNavResult do
+  @moduledoc """
+  Result returned by tree-sitter structural navigation.
+
+  Positions are zero-indexed tree-sitter points. Columns are byte offsets within the line, matching the rest of the parser protocol.
+  """
+
+  @enforce_keys [:start_row, :start_col, :end_row, :end_col, :type_name]
+  defstruct [:start_row, :start_col, :end_row, :end_col, :type_name]
+
+  @type t :: %__MODULE__{
+          start_row: non_neg_integer(),
+          start_col: non_neg_integer(),
+          end_row: non_neg_integer(),
+          end_col: non_neg_integer(),
+          type_name: String.t()
+        }
+
+  @doc "Builds a structural navigation result."
+  @spec new(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          String.t()
+        ) :: t()
+  def new(start_row, start_col, end_row, end_col, type_name)
+      when is_integer(start_row) and start_row >= 0 and is_integer(start_col) and start_col >= 0 and
+             is_integer(end_row) and end_row >= 0 and is_integer(end_col) and end_col >= 0 and
+             is_binary(type_name) do
+    %__MODULE__{
+      start_row: start_row,
+      start_col: start_col,
+      end_row: end_row,
+      end_col: end_col,
+      type_name: type_name
+    }
+  end
+
+  @doc "Returns the cursor position for the start of the node."
+  @spec start_position(t()) :: {non_neg_integer(), non_neg_integer()}
+  def start_position(%__MODULE__{start_row: row, start_col: col}), do: {row, col}
+end

--- a/lib/minga_editor/commands/helpers.ex
+++ b/lib/minga_editor/commands/helpers.ex
@@ -379,16 +379,11 @@ defmodule MingaEditor.Commands.Helpers do
 
   @doc "Sets up parser state only for motions that need tree-sitter."
   @spec setup_for_motion(state(), atom()) :: state()
-  def setup_for_motion(%{workspace: %{buffers: %{active: buf}}} = state, :match_bracket)
-      when is_pid(buf) do
-    if HighlightSync.buffer_id_for(state, buf) == 0 do
-      HighlightSync.setup_for_buffer(state)
-    else
-      state
-    end
-  end
-
-  def setup_for_motion(state, :match_bracket), do: state
+  def setup_for_motion(state, :match_bracket), do: setup_for_tree_sitter_motion(state)
+  def setup_for_motion(state, :nav_parent), do: setup_for_tree_sitter_motion(state)
+  def setup_for_motion(state, :nav_first_child), do: setup_for_tree_sitter_motion(state)
+  def setup_for_motion(state, :nav_next_sibling), do: setup_for_tree_sitter_motion(state)
+  def setup_for_motion(state, :nav_prev_sibling), do: setup_for_tree_sitter_motion(state)
   def setup_for_motion(state, _motion), do: state
 
   @doc "Returns the parser buffer id only for motions that need tree-sitter."
@@ -396,7 +391,30 @@ defmodule MingaEditor.Commands.Helpers do
   def buffer_id_for_motion(state, buf, :match_bracket),
     do: HighlightSync.buffer_id_for(state, buf)
 
+  def buffer_id_for_motion(state, buf, :nav_parent), do: HighlightSync.buffer_id_for(state, buf)
+
+  def buffer_id_for_motion(state, buf, :nav_first_child),
+    do: HighlightSync.buffer_id_for(state, buf)
+
+  def buffer_id_for_motion(state, buf, :nav_next_sibling),
+    do: HighlightSync.buffer_id_for(state, buf)
+
+  def buffer_id_for_motion(state, buf, :nav_prev_sibling),
+    do: HighlightSync.buffer_id_for(state, buf)
+
   def buffer_id_for_motion(_state, _buf, _motion), do: 0
+
+  @spec setup_for_tree_sitter_motion(state()) :: state()
+  defp setup_for_tree_sitter_motion(%{workspace: %{buffers: %{active: buf}}} = state)
+       when is_pid(buf) do
+    if HighlightSync.buffer_id_for(state, buf) == 0 do
+      HighlightSync.setup_for_buffer(state)
+    else
+      state
+    end
+  end
+
+  defp setup_for_tree_sitter_motion(state), do: state
 
   @doc "Resolves a motion atom to a new position in the buffer."
   @spec resolve_motion(

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -9,6 +9,8 @@ defmodule MingaEditor.Commands.Movement do
   alias Minga.Buffer
   alias Minga.Buffer.Document
   alias Minga.Core.Unicode
+  alias Minga.Parser.Manager, as: ParserManager
+  alias Minga.Parser.StructuralNavResult
 
   alias MingaEditor.Commands.Helpers
   alias MingaEditor.FoldMap
@@ -25,6 +27,7 @@ defmodule MingaEditor.Commands.Movement do
   alias Minga.Mode
 
   @type state :: EditorState.t()
+  @type structural_nav_action :: :parent | :first_child | :next_sibling | :prev_sibling
 
   @command_specs [
     {:move_left, "Move cursor left", true},
@@ -51,6 +54,10 @@ defmodule MingaEditor.Commands.Movement do
     {:repeat_find_char, "Repeat last find-char", true},
     {:repeat_find_char_reverse, "Repeat last find-char (reverse)", true},
     {:match_bracket, "Jump to matching bracket", true},
+    {:nav_parent, "Move to parent AST node", true},
+    {:nav_first_child, "Move to first child AST node", true},
+    {:nav_next_sibling, "Move to next sibling AST node", true},
+    {:nav_prev_sibling, "Move to previous sibling AST node", true},
     {:paragraph_forward, "Move to next paragraph", true},
     {:paragraph_backward, "Move to previous paragraph", true},
     {:half_page_down, "Scroll half page down", true},
@@ -286,6 +293,13 @@ defmodule MingaEditor.Commands.Movement do
 
     state
   end
+
+  # ── Structural AST navigation ─────────────────────────────────────────────
+
+  def execute(state, :nav_parent), do: structural_nav(state, :parent)
+  def execute(state, :nav_first_child), do: structural_nav(state, :first_child)
+  def execute(state, :nav_next_sibling), do: structural_nav(state, :next_sibling)
+  def execute(state, :nav_prev_sibling), do: structural_nav(state, :prev_sibling)
 
   # ── Paragraph motions ─────────────────────────────────────────────────────
 
@@ -563,6 +577,43 @@ defmodule MingaEditor.Commands.Movement do
   end
 
   # ── Private helpers ──────────────────────────────────────────────────────
+
+  @spec structural_nav(state(), structural_nav_action()) :: state()
+  defp structural_nav(%{workspace: %{buffers: %{active: buf}}} = state, action)
+       when is_pid(buf) do
+    command = structural_nav_command(action)
+    state = Helpers.setup_for_motion(state, command)
+    buffer_id = Helpers.buffer_id_for_motion(state, buf, command)
+    {row, col} = Buffer.cursor(buf)
+
+    case ParserManager.request_structural_nav(
+           buffer_id,
+           row,
+           col,
+           structural_nav_action_code(action)
+         ) do
+      %StructuralNavResult{type_name: type_name} = result ->
+        Buffer.move_to(buf, StructuralNavResult.start_position(result))
+        EditorState.set_status(state, "→ #{type_name}")
+
+      nil ->
+        state
+    end
+  end
+
+  defp structural_nav(state, _action), do: state
+
+  @spec structural_nav_command(structural_nav_action()) :: atom()
+  defp structural_nav_command(:parent), do: :nav_parent
+  defp structural_nav_command(:first_child), do: :nav_first_child
+  defp structural_nav_command(:next_sibling), do: :nav_next_sibling
+  defp structural_nav_command(:prev_sibling), do: :nav_prev_sibling
+
+  @spec structural_nav_action_code(structural_nav_action()) :: 0..3
+  defp structural_nav_action_code(:parent), do: 0
+  defp structural_nav_action_code(:first_child), do: 1
+  defp structural_nav_action_code(:next_sibling), do: 2
+  defp structural_nav_action_code(:prev_sibling), do: 3
 
   @spec update_file_tree(state(), (FileTreeState.t() -> FileTreeState.t())) :: state()
   defp update_file_tree(state, fun) when is_function(fun, 1) do

--- a/lib/minga_editor/frontend/protocol.ex
+++ b/lib/minga_editor/frontend/protocol.ex
@@ -49,6 +49,7 @@ defmodule MingaEditor.Frontend.Protocol do
   @op_gui_action 0x07
 
   alias Minga.Core.Face
+  alias Minga.Parser.StructuralNavResult
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
 
@@ -171,6 +172,7 @@ defmodule MingaEditor.Frontend.Protocol do
              result ::
                {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()}
                | nil}
+          | {:node_info, request_id :: non_neg_integer(), StructuralNavResult.t() | nil}
           | {:match_item_result, request_id :: non_neg_integer(),
              result :: {non_neg_integer(), non_neg_integer()} | nil}
           | {:textobject_positions, buffer_id :: non_neg_integer(), version :: non_neg_integer(),
@@ -503,6 +505,16 @@ defmodule MingaEditor.Frontend.Protocol do
   defdelegate encode_request_match_item(buffer_id, request_id, row, col),
     to: Minga.Parser.Protocol
 
+  @spec encode_request_structural_nav(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          0..3
+        ) :: binary()
+  defdelegate encode_request_structural_nav(buffer_id, request_id, row, col, action),
+    to: Minga.Parser.Protocol
+
   defdelegate encode_load_grammar(name, path), to: Minga.Parser.Protocol
 
   defdelegate encode_query_language_at(buffer_id, request_id, byte_offset),
@@ -580,7 +592,7 @@ defmodule MingaEditor.Frontend.Protocol do
   # Parser events are decoded by Minga.Parser.Protocol. Try it first,
   # then fall through to input event decoders.
   def decode_event(<<opcode::8, _rest::binary>> = data)
-      when opcode in 0x30..0x3C or opcode == 0x60 do
+      when opcode in 0x30..0x3D or opcode == 0x60 do
     case Minga.Parser.Protocol.decode_event(data) do
       {:ok, _} = result -> result
       :unknown -> {:error, :unknown_opcode}

--- a/test/minga/keymap/defaults_test.exs
+++ b/test/minga/keymap/defaults_test.exs
@@ -238,6 +238,14 @@ defmodule Minga.Keymap.DefaultsTest do
       assert {_, _} = bindings[{?u, 0x02}]
     end
 
+    test "contains structural navigation Alt+ bindings" do
+      bindings = Defaults.normal_bindings()
+      assert {:nav_parent, _} = bindings[{?h, 0x04}]
+      assert {:nav_first_child, _} = bindings[{?l, 0x04}]
+      assert {:nav_next_sibling, _} = bindings[{?j, 0x04}]
+      assert {:nav_prev_sibling, _} = bindings[{?k, 0x04}]
+    end
+
     test "contains operator keys" do
       bindings = Defaults.normal_bindings()
       assert {_, _} = bindings[{?d, 0}]

--- a/test/minga/mode/normal_test.exs
+++ b/test/minga/mode/normal_test.exs
@@ -83,6 +83,22 @@ defmodule Minga.Mode.NormalTest do
       assert {:execute, :move_right, _} = Normal.handle_key({?l, 0}, fresh_state())
     end
 
+    test "Alt+h produces structural parent navigation" do
+      assert {:execute, :nav_parent, _} = Normal.handle_key({?h, 0x04}, fresh_state())
+    end
+
+    test "Alt+l produces structural first child navigation" do
+      assert {:execute, :nav_first_child, _} = Normal.handle_key({?l, 0x04}, fresh_state())
+    end
+
+    test "Alt+j produces structural next sibling navigation" do
+      assert {:execute, :nav_next_sibling, _} = Normal.handle_key({?j, 0x04}, fresh_state())
+    end
+
+    test "Alt+k produces structural previous sibling navigation" do
+      assert {:execute, :nav_prev_sibling, _} = Normal.handle_key({?k, 0x04}, fresh_state())
+    end
+
     test "0 with no count produces {:execute, :move_to_line_start, state}" do
       assert {:execute, :move_to_line_start, _} =
                Normal.handle_key({?0, 0}, fresh_state())

--- a/test/minga/mode/visual_test.exs
+++ b/test/minga/mode/visual_test.exs
@@ -97,6 +97,26 @@ defmodule Minga.Mode.VisualTest do
       assert {:execute, :move_right, _} = Visual.handle_key({?l, 0}, state)
     end
 
+    test "Alt+h emits structural parent navigation" do
+      state = visual_state()
+      assert {:execute, :nav_parent, _} = Visual.handle_key({?h, 0x04}, state)
+    end
+
+    test "Alt+l emits structural first child navigation" do
+      state = visual_state()
+      assert {:execute, :nav_first_child, _} = Visual.handle_key({?l, 0x04}, state)
+    end
+
+    test "Alt+j emits structural next sibling navigation" do
+      state = visual_state()
+      assert {:execute, :nav_next_sibling, _} = Visual.handle_key({?j, 0x04}, state)
+    end
+
+    test "Alt+k emits structural previous sibling navigation" do
+      state = visual_state()
+      assert {:execute, :nav_prev_sibling, _} = Visual.handle_key({?k, 0x04}, state)
+    end
+
     test "w emits :word_forward" do
       state = visual_state()
       assert {:execute, :word_forward, _} = Visual.handle_key({?w, 0}, state)

--- a/test/minga/parser/manager_test.exs
+++ b/test/minga/parser/manager_test.exs
@@ -20,7 +20,7 @@ defmodule Minga.Parser.ManagerTest do
       content = "def foo do\nif bar do\nbaz\nend\nend"
       buffer_id = 1
 
-      setup_buffer(server, buffer_id, content)
+      setup_buffer(server, buffer_id, "elixir", content)
 
       assert Manager.request_indent(buffer_id, 2, server) == 2
       assert Manager.request_indent(buffer_id, 3, server) == 1
@@ -31,19 +31,50 @@ defmodule Minga.Parser.ManagerTest do
       content = "def foo do\n\nend"
       buffer_id = 1
 
-      setup_buffer(server, buffer_id, content)
+      setup_buffer(server, buffer_id, "elixir", content)
 
       assert Manager.request_indent(buffer_id, 1, server) == 1
     end
   end
 
-  defp setup_buffer(server, buffer_id, content) do
+  describe "request_structural_nav/5" do
+    test "returns nil without waiting when the parser port is unavailable" do
+      server = start_parser_manager(parser_path: "/missing/minga-parser")
+
+      assert Manager.request_structural_nav(1, 0, 0, 0, server) == nil
+    end
+
+    test "returns target node ranges and type names from the parser" do
+      server = start_parser_manager()
+      content = "function add(a, b) {\n  return a + b;\n}\n"
+      buffer_id = 2
+
+      setup_buffer(server, buffer_id, "javascript", content)
+
+      parent = Manager.request_structural_nav(buffer_id, 0, 20, 0, server)
+      first_child = Manager.request_structural_nav(buffer_id, 0, 0, 1, server)
+      next_sibling = Manager.request_structural_nav(buffer_id, 0, 13, 2, server)
+      prev_sibling = Manager.request_structural_nav(buffer_id, 0, 16, 3, server)
+
+      assert parent.start_row == 0
+      assert parent.start_col == 0
+      assert parent.type_name == "function_declaration"
+      assert first_child.start_col == 9
+      assert first_child.type_name == "identifier"
+      assert next_sibling.start_col == 16
+      assert next_sibling.type_name == "identifier"
+      assert prev_sibling.start_col == 13
+      assert prev_sibling.type_name == "identifier"
+    end
+  end
+
+  defp setup_buffer(server, buffer_id, language, content) do
     Manager.send_commands(server, [
-      Protocol.encode_set_language(buffer_id, "elixir"),
+      Protocol.encode_set_language(buffer_id, language),
       Protocol.encode_parse_buffer(buffer_id, 0, content)
     ])
 
-    Manager.register_buffer(buffer_id, "elixir", fn -> content end, server: server)
+    Manager.register_buffer(buffer_id, language, fn -> content end, server: server)
   end
 
   defp start_parser_manager(opts \\ []) do

--- a/test/minga/parser/protocol_structural_nav_test.exs
+++ b/test/minga/parser/protocol_structural_nav_test.exs
@@ -1,0 +1,34 @@
+defmodule Minga.Parser.ProtocolStructuralNavTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Parser.Protocol
+  alias Minga.Parser.StructuralNavResult
+
+  @op_request_structural_nav 0x2F
+  @op_node_info 0x3D
+
+  describe "request_structural_nav" do
+    test "encodes buffer id, request id, row, column, and action" do
+      assert <<@op_request_structural_nav, 7::32, 42::32, 3::32, 11::32, 2>> =
+               Protocol.encode_request_structural_nav(7, 42, 3, 11, 2)
+    end
+
+    test "decodes a found node_info response" do
+      payload =
+        <<@op_node_info, 42::32, 1, 1::32, 2::32, 3::32, 4::32, 15::16, "call_expression">>
+
+      assert {:ok, {:node_info, 42, result}} = Protocol.decode_event(payload)
+      assert %StructuralNavResult{} = result
+      assert result.start_row == 1
+      assert result.start_col == 2
+      assert result.end_row == 3
+      assert result.end_col == 4
+      assert result.type_name == "call_expression"
+    end
+
+    test "decodes an empty node_info response" do
+      payload = <<@op_node_info, 42::32, 0>>
+      assert {:ok, {:node_info, 42, nil}} = Protocol.decode_event(payload)
+    end
+  end
+end

--- a/test/minga_editor/commands/structural_navigation_test.exs
+++ b/test/minga_editor/commands/structural_navigation_test.exs
@@ -1,0 +1,135 @@
+defmodule MingaEditor.Commands.StructuralNavigationTest do
+  # Starts the real parser Port under its global production name, so these tests must not run concurrently.
+  use ExUnit.Case, async: false
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Parser.Manager, as: ParserManager
+  alias MingaEditor
+  alias MingaEditor.State, as: EditorState
+
+  @moduletag timeout: 15_000
+  @sync_timeout 15_000
+
+  setup do
+    start_supervised!({ParserManager, name: ParserManager, parser_path: parser_path()})
+    :ok
+  end
+
+  test "Alt+h moves to parent AST node and shows node type" do
+    {editor, buffer} = start_editor("function add(a, b) {\n  return a + b;\n}\n")
+    BufferProcess.move_to(buffer, {0, 20})
+
+    send_key(editor, ?h, 0x04)
+
+    assert BufferProcess.cursor(buffer) == {0, 0}
+
+    assert EditorState.status_msg(:sys.get_state(editor, @sync_timeout)) ==
+             "→ function_declaration"
+  end
+
+  test "Alt+h is a no-op when no structural parent exists" do
+    {editor, buffer} = start_editor("function add(a, b) { return a + b; }")
+    BufferProcess.move_to(buffer, {0, 0})
+    before_status = EditorState.status_msg(:sys.get_state(editor, @sync_timeout))
+
+    send_key(editor, ?h, 0x04)
+
+    assert BufferProcess.cursor(buffer) == {0, 0}
+    assert EditorState.status_msg(:sys.get_state(editor, @sync_timeout)) == before_status
+  end
+
+  test "Alt+l moves to the first child AST node" do
+    {editor, buffer} = start_editor("function add(a, b) { return a + b; }\n")
+    BufferProcess.move_to(buffer, {0, 0})
+
+    send_key(editor, ?l, 0x04)
+
+    assert BufferProcess.cursor(buffer) == {0, 9}
+
+    assert EditorState.status_msg(:sys.get_state(editor, @sync_timeout)) ==
+             "→ identifier"
+  end
+
+  test "Alt+j moves to the next sibling AST node" do
+    {editor, buffer} = start_editor("f(a, b, c);")
+    BufferProcess.move_to(buffer, {0, 2})
+
+    send_key(editor, ?j, 0x04)
+
+    assert BufferProcess.cursor(buffer) == {0, 5}
+
+    assert EditorState.status_msg(:sys.get_state(editor, @sync_timeout)) ==
+             "→ identifier"
+  end
+
+  test "Alt+k moves to the previous sibling AST node" do
+    {editor, buffer} = start_editor("f(a, b, c);")
+    BufferProcess.move_to(buffer, {0, 8})
+
+    send_key(editor, ?k, 0x04)
+
+    assert BufferProcess.cursor(buffer) == {0, 5}
+
+    assert EditorState.status_msg(:sys.get_state(editor, @sync_timeout)) ==
+             "→ identifier"
+  end
+
+  test "Alt+l in visual mode keeps the selection active" do
+    {editor, buffer} = start_editor("function add(a, b) { return a + b; }\n")
+    BufferProcess.move_to(buffer, {0, 0})
+
+    send_key(editor, ?v)
+    send_key(editor, ?l, 0x04)
+
+    state = :sys.get_state(editor, @sync_timeout)
+
+    assert BufferProcess.cursor(buffer) == {0, 9}
+    assert Minga.Editing.mode(state) == :visual
+    assert MingaEditor.Editing.visual_anchor(state) == {0, 0}
+    assert EditorState.status_msg(state) == "→ identifier"
+  end
+
+  defp start_editor(content) do
+    id = :erlang.unique_integer([:positive])
+    events_registry = :"structural_nav_events_#{id}"
+    project_root = isolated_project_root(id)
+    start_supervised!({Minga.Events, name: events_registry})
+
+    {:ok, buffer} =
+      BufferProcess.start_link(
+        content: content,
+        events_registry: events_registry,
+        filetype: :javascript
+      )
+
+    {:ok, editor} =
+      MingaEditor.start_link(
+        name: :"structural_nav_editor_#{id}",
+        port_manager: nil,
+        buffer: buffer,
+        width: 40,
+        height: 10,
+        editing_model: :vim,
+        events_registry: events_registry,
+        project_root: project_root,
+        suppress_tool_prompts: true
+      )
+
+    {editor, buffer}
+  end
+
+  defp isolated_project_root(id) do
+    root = Path.join(System.tmp_dir!(), "minga-structural-nav-#{id}")
+    File.mkdir_p!(root)
+    root
+  end
+
+  defp send_key(editor, codepoint, mods \\ 0) do
+    send(editor, {:minga_input, {:key_press, codepoint, mods}})
+    _ = :sys.get_state(editor, @sync_timeout)
+  end
+
+  defp parser_path do
+    Application.app_dir(:minga, "priv/minga-parser")
+  end
+end

--- a/test/minga_editor/frontend/protocol_structural_nav_test.exs
+++ b/test/minga_editor/frontend/protocol_structural_nav_test.exs
@@ -1,0 +1,32 @@
+defmodule MingaEditor.Frontend.ProtocolStructuralNavTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Parser.StructuralNavResult
+  alias MingaEditor.Frontend.Protocol
+
+  test "decode_event accepts found node_info responses" do
+    payload = <<0x3D, 42::32, 1, 1::32, 2::32, 3::32, 4::32, 15::16, "call_expression">>
+
+    assert {:ok, {:node_info, 42, %StructuralNavResult{} = result}} =
+             Protocol.decode_event(payload)
+
+    assert result == %StructuralNavResult{
+             start_row: 1,
+             start_col: 2,
+             end_row: 3,
+             end_col: 4,
+             type_name: "call_expression"
+           }
+  end
+
+  test "decode_event accepts empty node_info responses" do
+    payload = <<0x3D, 42::32, 0>>
+
+    assert {:ok, {:node_info, 42, nil}} = Protocol.decode_event(payload)
+  end
+
+  test "encode_request_structural_nav encodes the structural nav request payload" do
+    assert Protocol.encode_request_structural_nav(7, 42, 3, 11, 2) ==
+             <<0x2F, 7::32, 42::32, 3::32, 11::32, 2::8>>
+  end
+end

--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -779,6 +779,29 @@ pub const Highlighter = struct {
         return null;
     }
 
+    /// Alias for the shared StructuralNavResult type.
+    pub const StructuralNavResult = protocol.StructuralNavResult;
+
+    /// Navigate from the deepest named node at `row, col` to a structural relative.
+    pub fn structuralNav(self: *Highlighter, row: u32, col: u32, action: protocol.StructuralNavAction) ?StructuralNavResult {
+        const tree = self.tree orelse return null;
+        const root = c.ts_tree_root_node(tree);
+        const node = namedNodeAtPoint(root, row, col);
+        if (isNullNode(node)) return null;
+
+        const target = structuralNavTarget(node, action) orelse return null;
+        const start = c.ts_node_start_point(target);
+        const end = c.ts_node_end_point(target);
+
+        return .{
+            .start_row = start.row,
+            .start_col = start.column,
+            .end_row = end.row,
+            .end_col = end.column,
+            .type_name = nodeType(target),
+        };
+    }
+
     /// Alias for the shared TextobjectEntry type (defined in protocol to avoid circular imports).
     pub const TextobjectEntry = protocol.TextobjectEntry;
 
@@ -1583,6 +1606,39 @@ fn nodeAtPoint(root: c.TSNode, row: u32, col: u32) c.TSNode {
     const start = c.TSPoint{ .row = row, .column = col };
     const end = c.TSPoint{ .row = row, .column = col + 1 };
     return c.ts_node_descendant_for_point_range(root, start, end);
+}
+
+fn namedNodeAtPoint(root: c.TSNode, row: u32, col: u32) c.TSNode {
+    const start = c.TSPoint{ .row = row, .column = col };
+    const end = c.TSPoint{ .row = row, .column = col + 1 };
+    return c.ts_node_named_descendant_for_point_range(root, start, end);
+}
+
+fn structuralNavTarget(node: c.TSNode, action: protocol.StructuralNavAction) ?c.TSNode {
+    return switch (action) {
+        .parent => firstMeaningfulNamedParent(node),
+        .first_child => nullIfNull(c.ts_node_named_child(node, 0)),
+        .next_sibling => nullIfNull(c.ts_node_next_named_sibling(node)),
+        .prev_sibling => nullIfNull(c.ts_node_prev_named_sibling(node)),
+    };
+}
+
+fn firstMeaningfulNamedParent(node: c.TSNode) ?c.TSNode {
+    var parent = c.ts_node_parent(node);
+    while (!isNullNode(parent)) : (parent = c.ts_node_parent(parent)) {
+        if (isRootNode(parent)) return null;
+        if (c.ts_node_is_named(parent)) return parent;
+    }
+    return null;
+}
+
+fn nullIfNull(node: c.TSNode) ?c.TSNode {
+    if (isNullNode(node)) return null;
+    return node;
+}
+
+fn isRootNode(node: c.TSNode) bool {
+    return isNullNode(c.ts_node_parent(node));
 }
 
 fn isNullNode(node: c.TSNode) bool {
@@ -2447,6 +2503,61 @@ test "highlighter: Perl shebang predicate does not tag ordinary first comments a
         }
     }
     try std.testing.expect(found_shebang);
+}
+
+test "highlighter: structural nav parent moves from function body to function declaration" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("javascript"));
+    try hl.parse("function add(a, b) {\n  return a + b;\n}\n");
+
+    const result = hl.structuralNav(0, 20, .parent) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 0), result.start_row);
+    try std.testing.expectEqual(@as(u32, 0), result.start_col);
+    try std.testing.expectEqualStrings("function_declaration", result.type_name);
+}
+
+test "highlighter: structural nav first child moves from function to name" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("javascript"));
+    try hl.parse("function add(a, b) { return a + b; }");
+
+    const result = hl.structuralNav(0, 0, .first_child) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 0), result.start_row);
+    try std.testing.expectEqual(@as(u32, 9), result.start_col);
+    try std.testing.expectEqualStrings("identifier", result.type_name);
+}
+
+test "highlighter: structural nav next and previous siblings move between arguments" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("javascript"));
+    try hl.parse("f(a, b, c);");
+
+    const next = hl.structuralNav(0, 2, .next_sibling) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 0), next.start_row);
+    try std.testing.expectEqual(@as(u32, 5), next.start_col);
+    try std.testing.expectEqualStrings("identifier", next.type_name);
+
+    const prev = hl.structuralNav(0, 8, .prev_sibling) orelse return error.NoMatch;
+    try std.testing.expectEqual(@as(u32, 0), prev.start_row);
+    try std.testing.expectEqual(@as(u32, 5), prev.start_col);
+    try std.testing.expectEqualStrings("identifier", prev.type_name);
+}
+
+test "highlighter: structural nav returns null when no target exists" {
+    var hl = try Highlighter.init(std.testing.allocator);
+    defer hl.deinit();
+
+    try std.testing.expect(hl.setLanguage("javascript"));
+    try hl.parse("function add(a, b) { return a + b; }");
+
+    try std.testing.expect(hl.structuralNav(0, 0, .parent) == null);
+    try std.testing.expect(hl.structuralNav(0, 9, .prev_sibling) == null);
 }
 
 test "highlighter: match item finds structural brackets" {

--- a/zig/src/parser_main.zig
+++ b/zig/src/parser_main.zig
@@ -359,6 +359,19 @@ fn handleCommand(
             saveTreeToBuffer(hl, bs);
             try sendMatchItemResult(stdout, req.request_id, result);
         },
+        .request_structural_nav => |req| {
+            const bs = buffers.getPtr(req.buffer_id) orelse {
+                try sendStructuralNavResult(stdout, req.request_id, null);
+                return;
+            };
+            if (!activateBuffer(hl, bs)) {
+                try sendStructuralNavResult(stdout, req.request_id, null);
+                return;
+            }
+            const result = hl.structuralNav(req.row, req.col, req.action);
+            saveTreeToBuffer(hl, bs);
+            try sendStructuralNavResult(stdout, req.request_id, result);
+        },
         .load_grammar => |lg| {
             hl.loadGrammar(lg.name, lg.path) catch {
                 var rbuf: [260]u8 = undefined;
@@ -491,6 +504,13 @@ fn sendTextobjectResult(stdout: *std.Io.Writer, request_id: u32, result: ?protoc
 fn sendMatchItemResult(stdout: *std.Io.Writer, request_id: u32, result: ?protocol.MatchItemResult) !void {
     var rbuf: [14]u8 = undefined;
     const rlen = protocol.encodeMatchItemResult(&rbuf, request_id, result);
+    try protocol.writeMessage(stdout, rbuf[0..rlen]);
+    try stdout.flush();
+}
+
+fn sendStructuralNavResult(stdout: *std.Io.Writer, request_id: u32, result: ?protocol.StructuralNavResult) !void {
+    var rbuf: [280]u8 = undefined;
+    const rlen = protocol.encodeNodeInfo(&rbuf, request_id, result);
     try protocol.writeMessage(stdout, rbuf[0..rlen]);
     try stdout.flush();
 }

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -67,6 +67,7 @@ pub const OP_SET_TEXTOBJECT_QUERY: u8 = 0x2B;
 pub const OP_REQUEST_TEXTOBJECT: u8 = 0x2C;
 pub const OP_CLOSE_BUFFER: u8 = 0x2D;
 pub const OP_REQUEST_MATCH_ITEM: u8 = 0x2E;
+pub const OP_REQUEST_STRUCTURAL_NAV: u8 = 0x2F;
 
 // Highlight responses (Zig → BEAM)
 pub const OP_HIGHLIGHT_SPANS: u8 = 0x30;
@@ -94,6 +95,7 @@ pub const OP_CONCEAL_SPANS: u8 = 0x3A;
 /// the stored source), typically after system sleep/wake.
 pub const OP_REQUEST_REPARSE: u8 = 0x3B;
 pub const OP_MATCH_ITEM_RESULT: u8 = 0x3C;
+pub const OP_NODE_INFO: u8 = 0x3D;
 
 // Log messages (Zig → BEAM)
 pub const OP_LOG_MESSAGE: u8 = 0x60;
@@ -269,6 +271,7 @@ pub const RenderCommand = union(enum) {
     set_textobject_query: SetTextobjectQuery,
     request_textobject: RequestTextobject,
     request_match_item: RequestMatchItem,
+    request_structural_nav: RequestStructuralNav,
     load_grammar: LoadGrammar,
     query_language_at: QueryLanguageAt,
     close_buffer: u32, // buffer_id
@@ -361,6 +364,21 @@ pub const RequestMatchItem = struct {
     request_id: u32,
     row: u32,
     col: u32,
+};
+
+pub const StructuralNavAction = enum(u8) {
+    parent = 0,
+    first_child = 1,
+    next_sibling = 2,
+    prev_sibling = 3,
+};
+
+pub const RequestStructuralNav = struct {
+    buffer_id: u32 = 0,
+    request_id: u32,
+    row: u32,
+    col: u32,
+    action: StructuralNavAction,
 };
 
 pub const LoadGrammar = struct {
@@ -838,6 +856,17 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
                 .col = std.mem.readInt(u32, rest[12..16], .big),
             } };
         },
+        OP_REQUEST_STRUCTURAL_NAV => {
+            // buffer_id:4, request_id:4, row:4, col:4, action:1
+            if (rest.len < 17) return error.Malformed;
+            return .{ .request_structural_nav = .{
+                .buffer_id = std.mem.readInt(u32, rest[0..4], .big),
+                .request_id = std.mem.readInt(u32, rest[4..8], .big),
+                .row = std.mem.readInt(u32, rest[8..12], .big),
+                .col = std.mem.readInt(u32, rest[12..16], .big),
+                .action = try decodeStructuralNavAction(rest[16]),
+            } };
+        },
         OP_LOAD_GRAMMAR => {
             // name_len:2, name, path_len:2, path
             if (rest.len < 2) return error.Malformed;
@@ -957,6 +986,16 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
     }
 }
 
+fn decodeStructuralNavAction(action: u8) !StructuralNavAction {
+    return switch (action) {
+        0 => .parent,
+        1 => .first_child,
+        2 => .next_sibling,
+        3 => .prev_sibling,
+        else => error.Malformed,
+    };
+}
+
 /// Returns the byte size of the first command in `payload`.
 ///
 /// Used when iterating a batch message containing multiple concatenated
@@ -1022,6 +1061,7 @@ pub fn commandSize(payload: []const u8) usize {
             break :blk 19 + nl;
         },
         OP_REQUEST_MATCH_ITEM => 17, // opcode(1) + buffer_id(4) + request_id(4) + row(4) + col(4)
+        OP_REQUEST_STRUCTURAL_NAV => 18, // opcode(1) + buffer_id(4) + request_id(4) + row(4) + col(4) + action(1)
         OP_CLOSE_BUFFER => 5, // opcode(1) + buffer_id(4)
         OP_EDIT_BUFFER => blk: {
             // opcode(1) + buffer_id(4) + version(4) + edit_count(2) + variable per edit
@@ -1229,6 +1269,35 @@ pub fn encodeMatchItemResult(buf: *[14]u8, request_id: u32, result: ?MatchItemRe
         std.mem.writeInt(u32, buf[6..10], r.row, .big);
         std.mem.writeInt(u32, buf[10..14], r.col, .big);
         return 14;
+    } else {
+        buf[5] = 0;
+        return 6;
+    }
+}
+
+/// Structural navigation result (shared between protocol and highlighter).
+pub const StructuralNavResult = struct {
+    start_row: u32,
+    start_col: u32,
+    end_row: u32,
+    end_col: u32,
+    type_name: []const u8,
+};
+
+/// Encodes node_info: opcode(1) + request_id(4) + found(1) + start_row(4) + start_col(4) + end_row(4) + end_col(4) + type_len(2) + type
+pub fn encodeNodeInfo(buf: *[280]u8, request_id: u32, result: ?StructuralNavResult) usize {
+    buf[0] = OP_NODE_INFO;
+    std.mem.writeInt(u32, buf[1..5], request_id, .big);
+    if (result) |r| {
+        const type_len = @min(r.type_name.len, 255);
+        buf[5] = 1;
+        std.mem.writeInt(u32, buf[6..10], r.start_row, .big);
+        std.mem.writeInt(u32, buf[10..14], r.start_col, .big);
+        std.mem.writeInt(u32, buf[14..18], r.end_row, .big);
+        std.mem.writeInt(u32, buf[18..22], r.end_col, .big);
+        std.mem.writeInt(u16, buf[22..24], @intCast(type_len), .big);
+        @memcpy(buf[24 .. 24 + type_len], r.type_name[0..type_len]);
+        return 24 + type_len;
     } else {
         buf[5] = 0;
         return 6;
@@ -2102,6 +2171,68 @@ test "encode match_item_result" {
     const empty_len = encodeMatchItemResult(&empty_buf, 43, null);
     try std.testing.expectEqual(@as(usize, 6), empty_len);
     try std.testing.expectEqual(@as(u8, OP_MATCH_ITEM_RESULT), empty_buf[0]);
+    try std.testing.expectEqual(@as(u32, 43), std.mem.readInt(u32, empty_buf[1..5], .big));
+    try std.testing.expectEqual(@as(u8, 0), empty_buf[5]);
+}
+
+test "decode request_structural_nav" {
+    var data: [18]u8 = undefined;
+    data[0] = OP_REQUEST_STRUCTURAL_NAV;
+    std.mem.writeInt(u32, data[1..5], 7, .big);
+    std.mem.writeInt(u32, data[5..9], 42, .big);
+    std.mem.writeInt(u32, data[9..13], 3, .big);
+    std.mem.writeInt(u32, data[13..17], 11, .big);
+    data[17] = 2;
+
+    const cmd = try decodeCommand(&data);
+    switch (cmd) {
+        .request_structural_nav => |req| {
+            try std.testing.expectEqual(@as(u32, 7), req.buffer_id);
+            try std.testing.expectEqual(@as(u32, 42), req.request_id);
+            try std.testing.expectEqual(@as(u32, 3), req.row);
+            try std.testing.expectEqual(@as(u32, 11), req.col);
+            try std.testing.expectEqual(StructuralNavAction.next_sibling, req.action);
+        },
+        else => return error.Malformed,
+    }
+}
+
+test "decode request_structural_nav rejects invalid actions" {
+    var data: [18]u8 = undefined;
+    data[0] = OP_REQUEST_STRUCTURAL_NAV;
+    std.mem.writeInt(u32, data[1..5], 7, .big);
+    std.mem.writeInt(u32, data[5..9], 42, .big);
+    std.mem.writeInt(u32, data[9..13], 3, .big);
+    std.mem.writeInt(u32, data[13..17], 11, .big);
+    data[17] = 4;
+
+    try std.testing.expectError(error.Malformed, decodeCommand(&data));
+}
+
+test "encode node_info" {
+    var found_buf: [280]u8 = undefined;
+    const found_len = encodeNodeInfo(&found_buf, 42, .{
+        .start_row = 1,
+        .start_col = 2,
+        .end_row = 3,
+        .end_col = 4,
+        .type_name = "call_expression",
+    });
+    try std.testing.expectEqual(@as(usize, 39), found_len);
+    try std.testing.expectEqual(@as(u8, OP_NODE_INFO), found_buf[0]);
+    try std.testing.expectEqual(@as(u32, 42), std.mem.readInt(u32, found_buf[1..5], .big));
+    try std.testing.expectEqual(@as(u8, 1), found_buf[5]);
+    try std.testing.expectEqual(@as(u32, 1), std.mem.readInt(u32, found_buf[6..10], .big));
+    try std.testing.expectEqual(@as(u32, 2), std.mem.readInt(u32, found_buf[10..14], .big));
+    try std.testing.expectEqual(@as(u32, 3), std.mem.readInt(u32, found_buf[14..18], .big));
+    try std.testing.expectEqual(@as(u32, 4), std.mem.readInt(u32, found_buf[18..22], .big));
+    try std.testing.expectEqual(@as(u16, 15), std.mem.readInt(u16, found_buf[22..24], .big));
+    try std.testing.expectEqualStrings("call_expression", found_buf[24..39]);
+
+    var empty_buf: [280]u8 = undefined;
+    const empty_len = encodeNodeInfo(&empty_buf, 43, null);
+    try std.testing.expectEqual(@as(usize, 6), empty_len);
+    try std.testing.expectEqual(@as(u8, OP_NODE_INFO), empty_buf[0]);
     try std.testing.expectEqual(@as(u32, 43), std.mem.readInt(u32, empty_buf[1..5], .big));
     try std.testing.expectEqual(@as(u8, 0), empty_buf[5]);
 }

--- a/zig/src/renderer.zig
+++ b/zig/src/renderer.zig
@@ -223,7 +223,7 @@ pub fn Renderer(comptime SurfaceT: type) type {
                 },
 
                 // edit_buffer, measure_text and highlight commands are handled by the event loop, not the renderer.
-                .noop, .edit_buffer, .measure_text, .set_language, .parse_buffer, .set_highlight_query, .set_injection_query, .set_fold_query, .set_indent_query, .request_indent, .set_textobject_query, .request_textobject, .request_match_item, .load_grammar, .query_language_at, .close_buffer => {},
+                .noop, .edit_buffer, .measure_text, .set_language, .parse_buffer, .set_highlight_query, .set_injection_query, .set_fold_query, .set_indent_query, .request_indent, .set_textobject_query, .request_textobject, .request_match_item, .request_structural_nav, .load_grammar, .query_language_at, .close_buffer => {},
             }
         }
 


### PR DESCRIPTION
# TL;DR
Adds Helix-style structural AST navigation backed by tree-sitter, so Alt+h/l/j/k can move to parent, first child, next sibling, and previous sibling nodes in normal and visual mode.

Closes #669

## Context
Word and line motions do not understand code structure. This PR adds a single parser request path for structural navigation, using named tree-sitter nodes so punctuation and anonymous nodes are skipped.

## Changes
- Added `request_structural_nav` (`0x2F`) and `node_info` (`0x3D`) to the parser protocol, Zig decoder/encoder, Elixir protocol decoder, parser manager, frontend protocol facade, and protocol docs.
- Added `Minga.Parser.StructuralNavResult` so parser callers get a named result shape instead of a positional tuple.
- Implemented structural navigation in `zig/src/highlighter.zig` using `ts_node_named_descendant_for_point_range` plus named parent, child, and sibling traversal.
- Wired commands and keybindings for Alt+h parent, Alt+l first child, Alt+j next sibling, and Alt+k previous sibling in normal and visual mode.
- Added no-op behavior when the parser is unavailable or no structural target exists.

## Verification
- `cd zig && zig build test` passed.
- `mix zig.lint` passed.
- `make lint` passed.
- `mix compile --warnings-as-errors` passed after review-loop fixes.
- `mix test.llm test/minga_editor/frontend/protocol_structural_nav_test.exs test/minga_editor/commands/structural_navigation_test.exs test/minga/parser/protocol_structural_nav_test.exs` passed.
- `mix test.llm test/minga/parser/protocol_structural_nav_test.exs test/minga/parser/protocol_match_item_test.exs test/minga/mode/normal_test.exs test/minga/mode/visual_test.exs test/minga/keymap/defaults_test.exs test/minga_editor/commands/structural_navigation_test.exs` passed.
- `mix test.llm test/minga/parser/manager_test.exs test/minga_editor/commands/movement_test.exs test/minga_editor/commands/structural_navigation_test.exs --include heavy` passed.
- Full-suite runs were exercised locally. Load-sensitive unrelated failures were rerun focused and passed.

## Acceptance Criteria Addressed
- Keybindings for four structural navigation directions: parent, first child, next sibling, previous sibling ✅
- Cursor moves to the start of the target AST node ✅
- Navigation skips anonymous/punctuation nodes by using named tree-sitter traversal ✅
- Works in normal mode and visual mode ✅
- Works across languages with tree-sitter grammars through the generic parser/highlighter path ✅
- No target leaves the cursor in place without error ✅
- Uses one parser roundtrip per keypress through `request_structural_nav` ✅
- Parser unavailable fallback is a no-op ✅

---
**Updated after review:** Synced the frontend protocol facade with `0x3D node_info`, added facade regression tests, and added editor-level coverage for Alt+l, Alt+j, Alt+k, and visual-mode structural navigation.
