### PR TITLE
test(commands): split command coverage by layer

### DIFF
--- a/test/minga_editor/commands/buffer_management_shutdown_test.exs
+++ b/test/minga_editor/commands/buffer_management_shutdown_test.exs
@@ -6,6 +6,8 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
   alias Minga.Config.Options
   alias MingaEditor
 
+  @sync_timeout 30_000
+
   setup do
     previous_shutdown_fn = Application.fetch_env(:minga, :shutdown_fn)
     test_pid = self()
@@ -42,7 +44,7 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
 
   defp send_key(editor, codepoint, mods \\ 0) do
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor)
+    _ = :sys.get_state(editor, @sync_timeout)
   end
 
   defp type_string(editor, text) do
@@ -51,14 +53,16 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
     |> Enum.each(fn char -> send_key(editor, char) end)
   end
 
-  describe "shutdown paths" do
+  describe "shutdown-path editor integration" do
+    @describetag layer: :editor_integration
+
     test "quit all with clean buffer exits without confirmation" do
       {editor, _buffer} = start_editor("hello")
 
       type_string(editor, ":qa\r")
 
       assert_receive {:shutdown_called, 0}
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       refute state.pending_quit
     end
 
@@ -70,7 +74,7 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
       type_string(editor, ":qa!\r")
 
       assert_receive {:shutdown_called, 0}
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       refute state.pending_quit
     end
 
@@ -79,13 +83,13 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
       BufferProcess.insert_char(buffer, "X")
       assert BufferProcess.dirty?(buffer)
 
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       Options.set(state.options_server, :confirm_quit, false)
 
       type_string(editor, ":qa\r")
 
       assert_receive {:shutdown_called, 0}
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       refute state.pending_quit
     end
 

--- a/test/minga_editor/commands/buffer_management_test.exs
+++ b/test/minga_editor/commands/buffer_management_test.exs
@@ -5,9 +5,12 @@ defmodule MingaEditor.Commands.BufferManagementTest do
   alias Minga.Config.Options
   alias MingaEditor
   alias MingaEditor.Commands.BufferManagement
+  alias MingaEditor.Startup
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
-  alias MingaEditor.State.Buffers
   alias MingaEditor.State.TabBar
+
+  @sync_timeout 30_000
 
   defp start_editor(content) do
     {:ok, buffer} = BufferProcess.start_link(content: content)
@@ -27,9 +30,26 @@ defmodule MingaEditor.Commands.BufferManagementTest do
     {editor, buffer}
   end
 
+  defp start_command_state(content) do
+    {:ok, buffer} = BufferProcess.start_link(content: content)
+    {:ok, options} = Options.start_link(name: nil)
+
+    state =
+      Startup.build_initial_state(
+        port_manager: nil,
+        options_server: options,
+        buffer: buffer,
+        width: 40,
+        height: 10,
+        editing_model: :vim
+      )
+
+    {state, buffer}
+  end
+
   defp send_key(editor, codepoint, mods \\ 0) do
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor)
+    _ = :sys.get_state(editor, @sync_timeout)
   end
 
   defp type_string(editor, text) do
@@ -38,19 +58,32 @@ defmodule MingaEditor.Commands.BufferManagementTest do
     |> Enum.each(fn char -> send_key(editor, char) end)
   end
 
-  defp tab_count(editor) do
-    state = :sys.get_state(editor)
-    TabBar.count(state.shell_state.tab_bar)
+  defp add_file_tab(state, label) do
+    {:ok, buffer} = BufferProcess.start_link(content: "#{label} content")
+    state = EditorState.add_buffer(state, buffer, context: :open)
+    state
   end
 
-  describe "command mode" do
+  defp add_file_tab_with_buffer(state), do: add_file_tab_with_buffer(state, "second.txt")
+
+  defp add_file_tab_with_buffer(state, label) do
+    {:ok, buffer} = BufferProcess.start_link(content: "#{label} content")
+    state = EditorState.add_buffer(state, buffer, context: :open)
+    {state, buffer}
+  end
+
+  defp tab_count(state), do: state |> EditorState.tab_bar() |> TabBar.count()
+
+  describe "command mode editor integration smoke" do
+    @describetag layer: :editor_integration
+
     test ": enters command mode, typing w and Enter saves" do
       tmp_dir = System.tmp_dir!()
       path = Path.join(tmp_dir, "editor_test_save_#{:erlang.unique_integer([:positive])}.txt")
       File.write!(path, "test content")
+      on_exit(fn -> File.rm(path) end)
 
       {:ok, buffer} = BufferProcess.start_link(file_path: path)
-
       {:ok, options} = Options.start_link(name: nil)
 
       {:ok, editor} =
@@ -67,15 +100,12 @@ defmodule MingaEditor.Commands.BufferManagementTest do
       send_key(editor, ?:)
       send_key(editor, ?w)
       send_key(editor, 13)
-      _ = :sys.get_state(editor)
+      _ = :sys.get_state(editor, @sync_timeout)
 
-      assert File.exists?(path)
       assert File.read!(path) == "test content"
-
-      File.rm(path)
     end
 
-    test ":e command doesn't crash" do
+    test ":e command keeps the editor process alive when opening an arbitrary path" do
       {editor, _buffer} = start_editor("hello")
       send_key(editor, ?:)
       type_string(editor, "e test.txt")
@@ -84,35 +114,40 @@ defmodule MingaEditor.Commands.BufferManagementTest do
       assert Process.alive?(editor)
     end
 
-    test "goto line via :N command" do
+    test "goto line via :N command moves the buffer cursor" do
       {editor, buffer} = start_editor("line1\nline2\nline3\nline4")
       send_key(editor, ?:)
       send_key(editor, ?3)
       send_key(editor, 13)
-      _ = :sys.get_state(editor)
+      _ = :sys.get_state(editor, @sync_timeout)
 
       {line, _col} = BufferProcess.cursor(buffer)
       assert line == 2
     end
 
-    test "unknown ex command doesn't crash" do
-      {editor, _buffer} = start_editor("hello")
+    test "unknown ex command is a no-op at the editor layer" do
+      {editor, buffer} = start_editor("hello")
+      before = BufferProcess.content(buffer)
+
       send_key(editor, ?:)
       type_string(editor, "nonexistent")
       send_key(editor, 13)
 
+      assert BufferProcess.content(buffer) == before
       assert Process.alive?(editor)
     end
   end
 
-  describe "global keybindings" do
+  describe "global keybinding editor integration smoke" do
+    @describetag layer: :editor_integration
+
     test "Ctrl+S saves the buffer" do
       tmp_dir = System.tmp_dir!()
       path = Path.join(tmp_dir, "editor_ctrl_s_#{:erlang.unique_integer([:positive])}.txt")
       File.write!(path, "ctrl-s test")
+      on_exit(fn -> File.rm(path) end)
 
       {:ok, buffer} = BufferProcess.start_link(file_path: path)
-
       {:ok, options} = Options.start_link(name: nil)
 
       {:ok, editor} =
@@ -127,15 +162,12 @@ defmodule MingaEditor.Commands.BufferManagementTest do
         )
 
       send_key(editor, ?s, 0x02)
-      _ = :sys.get_state(editor)
+      _ = :sys.get_state(editor, @sync_timeout)
 
-      assert File.exists?(path)
       assert File.read!(path) == "ctrl-s test"
-
-      File.rm(path)
     end
 
-    test "Ctrl+S with no buffer doesn't crash" do
+    test "Ctrl+S with startup-created fallback buffer keeps the editor alive" do
       {:ok, editor} =
         MingaEditor.start_link(
           name: :"editor_#{:erlang.unique_integer([:positive])}",
@@ -151,96 +183,77 @@ defmodule MingaEditor.Commands.BufferManagementTest do
     end
   end
 
-  describe "tab-aware :q" do
-    test ":q with multiple tabs closes the current tab without exiting" do
-      {editor, _buffer} = start_editor("first file")
-      assert tab_count(editor) == 1
+  describe "tab-aware quit command state" do
+    @describetag layer: :command_state
 
-      # Opening a second file on a file tab adds to the same tab's buffer
-      # list (no new tab). To get 2 tabs, inject a second tab directly.
-      add_second_tab(editor)
-      assert tab_count(editor) == 2
+    test ":q with multiple tabs closes the current tab without requesting process shutdown" do
+      {state, _buffer} = start_command_state("first file")
+      {state, closed_tab_buffer} = add_file_tab_with_buffer(state)
+      closed_tab_id = EditorState.tab_bar(state).active_id
+      assert tab_count(state) == 2
 
-      # Type :q<Enter>
-      send_key(editor, ?:)
-      type_string(editor, "q")
-      send_key(editor, 13)
+      result = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
 
-      assert Process.alive?(editor), "Editor should stay alive when closing one of multiple tabs"
-      assert tab_count(editor) == 1
+      remaining_tab_ids =
+        result |> EditorState.tab_bar() |> Map.fetch!(:tabs) |> Enum.map(& &1.id)
+
+      assert tab_count(result) == 1
+      refute closed_tab_id in remaining_tab_ids
+      assert Process.alive?(closed_tab_buffer)
     end
 
-    test ":q with a single tab leaves an empty editor open" do
-      {editor, _buffer} = start_editor("first file")
+    test ":q with a single tab leaves an empty editor buffer open" do
+      {state, _buffer} = start_command_state("first file")
 
-      type_string(editor, ":q\r")
+      result = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
 
-      state = :sys.get_state(editor)
-      assert Process.alive?(editor)
-      assert tab_count(editor) == 1
-      assert BufferProcess.content(state.workspace.buffers.active) == ""
+      assert tab_count(result) == 1
+      assert BufferProcess.content(result.workspace.buffers.active) == ""
     end
 
-    test ":q does not kill the buffer (matches Neovim)" do
-      {editor, first_buffer} = start_editor("first file")
-      add_second_tab(editor)
-      assert tab_count(editor) == 2
+    test ":q does not kill the closed tab buffer" do
+      {state, _first_buffer} = start_command_state("first file")
+      {state, closed_tab_buffer} = add_file_tab_with_buffer(state)
 
-      # Type :q<Enter> to close the current tab
-      send_key(editor, ?:)
-      type_string(editor, "q")
-      send_key(editor, 13)
+      result = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
 
-      # The first buffer should still be alive (not killed)
-      assert Process.alive?(first_buffer),
-             "Buffer should stay alive after :q closes its tab"
+      assert tab_count(result) == 1
+      assert Process.alive?(closed_tab_buffer)
     end
   end
 
-  # Injects a second file tab into the editor's tab bar by manipulating
-  # state directly. This avoids needing to go through the full open_file
-  # path which adds buffers to the existing tab rather than creating new ones.
-  defp add_second_tab(editor) do
-    :sys.replace_state(editor, fn state ->
-      {:ok, buffer2} = BufferProcess.start_link(content: "second tab content")
-      {new_tb, _tab} = TabBar.add(state.shell_state.tab_bar, :file, "second.txt")
-      new_buffers = Buffers.add(state.workspace.buffers, buffer2)
+  describe "close_other_tabs command state" do
+    @describetag layer: :command_state
 
-      MingaEditor.State.set_tab_bar(
-        %{state | workspace: %{state.workspace | buffers: new_buffers}},
-        new_tb
-      )
-    end)
-  end
-
-  describe "close_other_tabs" do
     test "closes all tabs except the active tab" do
-      {editor, _buffer} = start_editor("first file")
-      add_second_tab(editor)
-      add_second_tab(editor)
-      assert tab_count(editor) == 3
+      {state, _buffer} = start_command_state("first file")
+      original_tab_id = EditorState.tab_bar(state).active_id
 
-      :sys.replace_state(editor, fn state ->
-        BufferManagement.execute(state, :close_other_tabs)
-      end)
+      state =
+        state
+        |> add_file_tab("second.txt")
+        |> add_file_tab("third.txt")
 
-      state = :sys.get_state(editor)
-      assert TabBar.count(state.shell_state.tab_bar) == 1
-      assert TabBar.active(state.shell_state.tab_bar).label == "second.txt"
+      active_tab_id = EditorState.tab_bar(state).active_id
+      assert tab_count(state) == 3
+
+      result = BufferManagement.execute(state, :close_other_tabs)
+
+      remaining_tab_ids =
+        result |> EditorState.tab_bar() |> Map.fetch!(:tabs) |> Enum.map(& &1.id)
+
+      assert tab_count(result) == 1
+      assert EditorState.tab_bar(result).active_id == active_tab_id
+      refute original_tab_id in remaining_tab_ids
     end
 
     test "ignores stopped-session events for tabs that were already removed" do
-      {editor, _buffer} = start_editor("first file")
+      {state, _buffer} = start_command_state("first file")
 
-      state = :sys.get_state(editor)
-
-      state = %{
-        state
-        | shell_state: %{
-            state.shell_state
-            | agent: AgentState.set_error(%AgentState{}, "active agent")
-          }
-      }
+      state =
+        EditorState.update_shell_state(state, fn shell_state ->
+          %{shell_state | agent: AgentState.set_error(%AgentState{}, "active agent")}
+        end)
 
       result = BufferManagement.handle_agent_session_down(state, self(), :normal)
 
@@ -249,46 +262,47 @@ defmodule MingaEditor.Commands.BufferManagementTest do
     end
   end
 
-  describe "quit confirmation (#128)" do
-    test "quit with dirty buffer shows confirmation prompt" do
-      {editor, buffer} = start_editor("hello")
+  describe "dirty quit confirmation command state" do
+    @describetag layer: :command_state
 
-      # Make buffer dirty
+    test "quit with dirty buffer sets a confirmation prompt" do
+      {state, buffer} = start_command_state("hello")
       BufferProcess.insert_char(buffer, "X")
       assert BufferProcess.dirty?(buffer)
 
-      # Send :q via command mode
-      type_string(editor, ":q\r")
-      state = :sys.get_state(editor)
+      result = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
 
-      assert state.pending_quit == :quit
-      assert state.shell_state.status_msg =~ "Modified buffers"
+      assert result.pending_quit == :quit
+      assert result.shell_state.status_msg =~ "Modified buffers"
     end
 
     test "n at confirmation prompt cancels quit" do
-      {editor, buffer} = start_editor("hello")
+      {state, buffer} = start_command_state("hello")
       BufferProcess.insert_char(buffer, "X")
 
-      type_string(editor, ":q\r")
-      state = :sys.get_state(editor)
+      state = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
       assert state.pending_quit == :quit
 
-      send_key(editor, ?n)
-      state = :sys.get_state(editor)
-      assert state.pending_quit == nil
-      assert state.shell_state.status_msg == nil
-    end
+      result = BufferManagement.execute(state, :confirm_quit_no)
 
-    test "Escape at confirmation prompt cancels quit" do
+      assert result.pending_quit == nil
+      assert result.shell_state.status_msg == nil
+    end
+  end
+
+  describe "dirty quit confirmation editor integration smoke" do
+    @describetag layer: :editor_integration
+
+    test "Escape at confirmation prompt cancels quit through the input router" do
       {editor, buffer} = start_editor("hello")
       BufferProcess.insert_char(buffer, "X")
 
       type_string(editor, ":q\r")
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       assert state.pending_quit == :quit
 
       send_key(editor, 27)
-      state = :sys.get_state(editor)
+      state = :sys.get_state(editor, @sync_timeout)
       assert state.pending_quit == nil
     end
   end

--- a/test/minga_editor/commands/minibuffer_test.exs
+++ b/test/minga_editor/commands/minibuffer_test.exs
@@ -2,15 +2,20 @@ defmodule MingaEditor.Commands.MinibufferTest do
   @moduledoc """
   Tests for the :accept_command_candidate command handler.
 
-  Verifies that Tab acceptance in command mode replaces the input with
-  the selected candidate, handles edge cases (no match, wrong mode),
-  and resets the candidate_index after acceptance.
+  Most coverage exercises command-mode state transitions directly. One editor-level smoke test remains to verify that Tab is routed to the command handler from command mode.
   """
 
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Config.Options
   alias MingaEditor
+  alias MingaEditor.Commands
+  alias MingaEditor.Editing
+  alias MingaEditor.Startup
+  alias MingaEditor.State, as: EditorState
+
+  @sync_timeout 30_000
 
   defp start_editor(content \\ "hello") do
     {:ok, buffer} = BufferProcess.start_link(content: content)
@@ -28,77 +33,93 @@ defmodule MingaEditor.Commands.MinibufferTest do
     {editor, buffer}
   end
 
+  defp start_command_state(input, candidate_index \\ 0) do
+    {:ok, buffer} = BufferProcess.start_link(content: "hello")
+    {:ok, options} = Options.start_link(name: nil)
+
+    state =
+      Startup.build_initial_state(
+        port_manager: nil,
+        options_server: options,
+        buffer: buffer,
+        width: 80,
+        height: 24,
+        editing_model: :vim
+      )
+      |> EditorState.transition_mode(:command)
+      |> Editing.update_mode_state(%{input: input, candidate_index: candidate_index})
+
+    {state, buffer}
+  end
+
   defp send_key(editor, codepoint, mods \\ 0) do
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor)
+    :sys.get_state(editor, @sync_timeout)
   end
 
-  defp get_mode_state(editor) do
-    state = :sys.get_state(editor)
-    {state.workspace.editing.mode, state.workspace.editing.mode_state}
+  describe "accept_command_candidate command state" do
+    @describetag layer: :command_state
+
+    test "replaces input with selected candidate" do
+      {state, _buffer} = start_command_state("sav")
+
+      result = Commands.execute(state, {:accept_command_candidate})
+      mode_state = Editing.mode_state(result)
+
+      assert Minga.Editing.mode(result) == :command
+      assert mode_state.input == "save"
+      assert mode_state.candidate_index == 0
+    end
+
+    test "with no matching candidates is a no-op" do
+      {state, _buffer} = start_command_state("zzzzz")
+
+      result = Commands.execute(state, {:accept_command_candidate})
+      mode_state = Editing.mode_state(result)
+
+      assert Minga.Editing.mode(result) == :command
+      assert mode_state.input == "zzzzz"
+      assert mode_state.candidate_index == 0
+    end
+
+    test "accepts the selected non-first candidate" do
+      {state, _buffer} = start_command_state("qui", 1)
+
+      result = Commands.execute(state, {:accept_command_candidate})
+      mode_state = Editing.mode_state(result)
+
+      assert mode_state.input == "quit_all"
+      assert mode_state.candidate_index == 0
+    end
+
+    test "does nothing outside command mode" do
+      {state, _buffer} = start_command_state("sav")
+      state = EditorState.transition_mode(state, :normal)
+
+      result = Commands.execute(state, {:accept_command_candidate})
+
+      assert Minga.Editing.mode(result) == :normal
+    end
   end
 
-  describe "accept_command_candidate via Tab in command mode" do
-    test "Tab replaces input with selected candidate" do
+  describe "accept_command_candidate editor integration smoke" do
+    @describetag layer: :editor_integration
+
+    test "Tab routes to quit_all candidate acceptance in command mode" do
       {editor, _buf} = start_editor()
 
-      # Enter command mode
       send_key(editor, ?:)
-      # Type "sav" to get "save" as a candidate
-      send_key(editor, ?s)
-      send_key(editor, ?a)
-      send_key(editor, ?v)
-
-      # Press Tab to accept
-      send_key(editor, 9)
-
-      {mode, ms} = get_mode_state(editor)
-      assert mode == :command
-      assert ms.input == "save"
-      assert ms.candidate_index == 0
-    end
-
-    test "Tab with no matching candidates is a no-op" do
-      {editor, _buf} = start_editor()
-
-      # Enter command mode
-      send_key(editor, ?:)
-      # Type nonsense that matches nothing
-      send_key(editor, ?z)
-      send_key(editor, ?z)
-      send_key(editor, ?z)
-      send_key(editor, ?z)
-      send_key(editor, ?z)
-
-      # Press Tab
-      send_key(editor, 9)
-
-      {mode, ms} = get_mode_state(editor)
-      assert mode == :command
-      assert ms.input == "zzzzz"
-    end
-
-    test "arrow down then Tab selects second candidate" do
-      {editor, _buf} = start_editor()
-
-      # Enter command mode
-      send_key(editor, ?:)
-      # Type "qui" to get "quit" and "quit_all" as candidates
       send_key(editor, ?q)
       send_key(editor, ?u)
       send_key(editor, ?i)
 
-      # Arrow down to select second candidate
-      send_key(editor, 57_353)
+      _ = send_key(editor, 57_353)
+      state = send_key(editor, 9)
+      mode_state = Editing.mode_state(state)
 
-      # Press Tab to accept
-      send_key(editor, 9)
-
-      {mode, ms} = get_mode_state(editor)
-      assert mode == :command
-      # Should have accepted the second candidate (quit_all)
-      assert ms.input == "quit_all"
-      assert ms.candidate_index == 0
+      assert Minga.Editing.mode(state) == :command
+      assert mode_state.input == "quit_all"
+      assert mode_state.candidate_index == 0
     end
   end
 end

--- a/test/minga_editor/commands/window_test.exs
+++ b/test/minga_editor/commands/window_test.exs
@@ -3,8 +3,14 @@ defmodule MingaEditor.Commands.WindowTest do
   use ExUnit.Case, async: false
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Config.Options
   alias MingaEditor
+  alias MingaEditor.Commands.Movement
+  alias MingaEditor.Startup
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Windows
+
+  @sync_timeout 30_000
 
   defp start_editor(content \\ "hello\nworld\nfoo") do
     {:ok, buffer} = BufferProcess.start_link(content: content)
@@ -22,231 +28,227 @@ defmodule MingaEditor.Commands.WindowTest do
     {editor, buffer}
   end
 
-  defp get_state(editor), do: :sys.get_state(editor)
+  defp start_command_state(content \\ "hello\nworld\nfoo") do
+    {:ok, buffer} = BufferProcess.start_link(content: content)
+    {:ok, options} = Options.start_link(name: nil)
+
+    state =
+      Startup.build_initial_state(
+        port_manager: nil,
+        options_server: options,
+        buffer: buffer,
+        width: 80,
+        height: 24,
+        editing_model: :vim
+      )
+
+    {state, buffer}
+  end
 
   defp send_key(editor, codepoint, mods \\ 0) do
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor)
+    :sys.get_state(editor, @sync_timeout)
   end
 
   defp send_keys(editor, keys) when is_list(keys) do
-    Enum.each(keys, fn
-      {cp, mods} -> send_key(editor, cp, mods)
-      cp when is_integer(cp) -> send_key(editor, cp)
+    Enum.reduce(keys, nil, fn
+      {cp, mods}, _state -> send_key(editor, cp, mods)
+      cp, _state when is_integer(cp) -> send_key(editor, cp)
     end)
   end
 
-  # SPC w v = vertical split
-  defp split_vertical(editor) do
-    send_keys(editor, [?\s, ?w, ?v])
-  end
+  defp split_vertical(editor), do: send_keys(editor, [?\s, ?w, ?v])
+  defp split_horizontal(editor), do: send_keys(editor, [?\s, ?w, ?s])
+  defp close_window(editor), do: send_keys(editor, [?\s, ?w, ?d])
+  defp window_count(state), do: map_size(state.workspace.windows.map)
 
-  # SPC w s = horizontal split
-  defp split_horizontal(editor) do
-    send_keys(editor, [?\s, ?w, ?s])
-  end
+  describe "split command state" do
+    @describetag layer: :command_state
 
-  # SPC w d = close window
-  defp close_window(editor) do
-    send_keys(editor, [?\s, ?w, ?d])
-  end
+    test "vertical split creates two windows showing the same buffer" do
+      {state, buffer} = start_command_state()
 
-  describe "vertical split" do
-    test "creates two windows showing the same buffer" do
-      {editor, buffer} = start_editor()
-      split_vertical(editor)
-      state = get_state(editor)
+      result = Movement.execute(state, :split_vertical)
 
-      assert EditorState.split?(state)
-      assert map_size(state.workspace.windows.map) == 2
+      assert Windows.split?(result.workspace.windows)
+      assert window_count(result) == 2
 
-      # Both windows reference the same buffer
       window_buffers =
-        state.workspace.windows.map
-        |> Map.values()
-        |> Enum.map(& &1.buffer)
-        |> Enum.uniq()
+        result.workspace.windows.map |> Map.values() |> Enum.map(& &1.buffer) |> Enum.uniq()
 
       assert window_buffers == [buffer]
     end
 
-    test "each window has independent viewport dimensions" do
-      {editor, _buffer} = start_editor()
-      split_vertical(editor)
-      state = get_state(editor)
+    test "vertical split gives each window independent viewport dimensions" do
+      {state, _buffer} = start_command_state()
 
-      viewports =
-        state.workspace.windows.map
-        |> Map.values()
-        |> Enum.map(& &1.viewport)
+      result = Movement.execute(state, :split_vertical)
+      viewports = result.workspace.windows.map |> Map.values() |> Enum.map(& &1.viewport)
 
-      # Vertical split: each window gets roughly half the width,
-      # and rows equal the content area (total rows minus tab, status_bar, minibuffer).
-      # 24 rows - tab(1) - status_bar(1) - minibuffer(1) = 21 content rows.
-      Enum.each(viewports, fn vp ->
-        assert vp.cols < 80
-        assert vp.rows == 21
+      Enum.each(viewports, fn viewport ->
+        assert viewport.cols < 80
+        assert viewport.rows == 21
+      end)
+    end
+
+    test "horizontal split creates two windows stacked vertically" do
+      {state, _buffer} = start_command_state()
+
+      result = Movement.execute(state, :split_horizontal)
+      viewports = result.workspace.windows.map |> Map.values() |> Enum.map(& &1.viewport)
+
+      assert Windows.split?(result.workspace.windows)
+      assert window_count(result) == 2
+
+      Enum.each(viewports, fn viewport ->
+        assert viewport.cols == 80
+        assert viewport.rows < 24
       end)
     end
   end
 
-  describe "horizontal split" do
-    test "creates two windows stacked vertically" do
-      {editor, _buffer} = start_editor()
-      split_horizontal(editor)
-      state = get_state(editor)
+  describe "window navigation command state" do
+    @describetag layer: :command_state
 
-      assert EditorState.split?(state)
-      assert map_size(state.workspace.windows.map) == 2
+    test "window_right moves focus to the right window after vertical split" do
+      {state, _buffer} = start_command_state()
+      state = Movement.execute(state, :split_vertical)
+      initial_window = state.workspace.windows.active
 
-      viewports =
-        state.workspace.windows.map
-        |> Map.values()
-        |> Enum.map(& &1.viewport)
+      result = Movement.execute(state, :window_right)
 
-      # Horizontal split: each window gets roughly half the height
-      Enum.each(viewports, fn vp ->
-        assert vp.cols == 80
-        assert vp.rows < 24
-      end)
+      assert result.workspace.windows.active != initial_window
+    end
+
+    test "window_left moves focus back to the left window" do
+      {state, _buffer} = start_command_state()
+      state = Movement.execute(state, :split_vertical)
+      initial_window = state.workspace.windows.active
+
+      result = state |> Movement.execute(:window_right) |> Movement.execute(:window_left)
+
+      assert result.workspace.windows.active == initial_window
+    end
+
+    test "window_down moves focus to the bottom window after horizontal split" do
+      {state, _buffer} = start_command_state()
+      state = Movement.execute(state, :split_horizontal)
+      initial_window = state.workspace.windows.active
+
+      result = Movement.execute(state, :window_down)
+
+      assert result.workspace.windows.active != initial_window
+    end
+
+    test "navigating with no neighbor preserves the active window" do
+      {state, _buffer} = start_command_state()
+      state = Movement.execute(state, :split_vertical)
+
+      result = Movement.execute(state, :window_left)
+
+      assert result.workspace.windows.active == state.workspace.windows.active
     end
   end
 
-  describe "window navigation" do
-    test "SPC w l moves focus to the right window after vertical split" do
-      {editor, _buffer} = start_editor()
-      split_vertical(editor)
+  describe "close window command state" do
+    @describetag layer: :command_state
 
-      state_before = get_state(editor)
-      initial_window = state_before.workspace.windows.active
+    test "closing a split returns to a single window" do
+      {state, _buffer} = start_command_state()
+      state = Movement.execute(state, :split_vertical)
+      assert Windows.split?(state.workspace.windows)
 
-      # Navigate right
-      send_keys(editor, [?\s, ?w, ?l])
-      state_after = get_state(editor)
+      result = Movement.execute(state, :window_close)
 
-      assert state_after.workspace.windows.active != initial_window
-    end
-
-    test "SPC w h moves focus back to the left window" do
-      {editor, _buffer} = start_editor()
-      split_vertical(editor)
-
-      state_before = get_state(editor)
-      initial_window = state_before.workspace.windows.active
-
-      # Navigate right then left
-      send_keys(editor, [?\s, ?w, ?l])
-      send_keys(editor, [?\s, ?w, ?h])
-      state_after = get_state(editor)
-
-      assert state_after.workspace.windows.active == initial_window
-    end
-
-    test "SPC w j moves focus to the bottom window after horizontal split" do
-      {editor, _buffer} = start_editor()
-      split_horizontal(editor)
-
-      state_before = get_state(editor)
-      initial_window = state_before.workspace.windows.active
-
-      send_keys(editor, [?\s, ?w, ?j])
-      state_after = get_state(editor)
-
-      assert state_after.workspace.windows.active != initial_window
-    end
-
-    test "navigating with no neighbor does nothing" do
-      {editor, _buffer} = start_editor()
-      split_vertical(editor)
-
-      state_before = get_state(editor)
-
-      # Try to go left from leftmost window — should stay
-      send_keys(editor, [?\s, ?w, ?h])
-      state_after = get_state(editor)
-
-      assert state_after.workspace.windows.active == state_before.workspace.windows.active
-    end
-  end
-
-  describe "close window" do
-    test "closing a split returns to single window" do
-      {editor, _buffer} = start_editor()
-      split_vertical(editor)
-
-      state = get_state(editor)
-      assert EditorState.split?(state)
-
-      close_window(editor)
-      state = get_state(editor)
-
-      refute EditorState.split?(state)
-      assert map_size(state.workspace.windows.map) == 1
+      refute Windows.split?(result.workspace.windows)
+      assert window_count(result) == 1
     end
 
     test "cannot close the last window" do
-      {editor, _buffer} = start_editor()
+      {state, _buffer} = start_command_state()
 
-      close_window(editor)
-      state = get_state(editor)
+      result = Movement.execute(state, :window_close)
 
-      # Should show error message but not crash
-      assert state.shell_state.status_msg == "Cannot close the last window"
+      assert result.shell_state.status_msg == "Cannot close the last window"
+      refute Windows.split?(result.workspace.windows)
     end
 
-    test "focus moves to remaining window after close" do
-      {editor, buffer} = start_editor()
-      split_vertical(editor)
+    test "focus moves to the remaining window after close" do
+      {state, buffer} = start_command_state()
 
-      # Navigate to right window
-      send_keys(editor, [?\s, ?w, ?l])
+      result =
+        state
+        |> Movement.execute(:split_vertical)
+        |> Movement.execute(:window_right)
+        |> Movement.execute(:window_close)
 
-      # Close it
-      close_window(editor)
-      state = get_state(editor)
-
-      # Should be focused on the remaining window with the same buffer
-      assert state.workspace.buffers.active == buffer
-      refute EditorState.split?(state)
+      assert result.workspace.buffers.active == buffer
+      refute Windows.split?(result.workspace.windows)
     end
 
     test "closing a split restores the surviving window cursor into the buffer" do
-      {editor, buffer} = start_editor("hello\nworld")
-      split_vertical(editor)
+      {state, buffer} = start_command_state("hello\nworld")
 
-      # Move to the right split and move the cursor so the active window
-      # cursor differs from the surviving window's saved cursor.
-      send_keys(editor, [?\s, ?w, ?l])
-      send_key(editor, ?l)
-      send_key(editor, ?l)
+      state =
+        state
+        |> Movement.execute(:split_vertical)
+        |> Movement.execute(:window_right)
 
-      state = get_state(editor)
+      BufferProcess.move_to(buffer, {0, 2})
+      state = EditorState.sync_active_window_cursor(state)
       assert state.workspace.windows.active == 2
       assert state.workspace.windows.map[2].cursor == {0, 2}
 
-      close_window(editor)
-      state = get_state(editor)
+      result = Movement.execute(state, :window_close)
 
       assert BufferProcess.cursor(buffer) == {0, 0}
-      assert state.workspace.windows.active == 1
-      assert state.workspace.windows.map[1].cursor == {0, 0}
-      refute EditorState.split?(state)
+      assert result.workspace.windows.active == 1
+      assert result.workspace.windows.map[1].cursor == {0, 0}
+      refute Windows.split?(result.workspace.windows)
     end
   end
 
-  describe "editing in split windows" do
-    test "edits in active window are visible via buffer" do
+  describe "window key-routing editor integration smoke" do
+    @describetag layer: :editor_integration
+
+    test "SPC w v routes to vertical split" do
+      {editor, _buffer} = start_editor()
+
+      state = split_vertical(editor)
+
+      assert Windows.split?(state.workspace.windows)
+      assert window_count(state) == 2
+    end
+
+    test "SPC w l routes focus to the right window after a vertical split" do
+      {editor, _buffer} = start_editor()
+      state = split_vertical(editor)
+      initial_window = state.workspace.windows.active
+
+      state = send_keys(editor, [?\s, ?w, ?l])
+
+      assert state.workspace.windows.active != initial_window
+    end
+
+    test "SPC w d routes to window close" do
+      {editor, _buffer} = start_editor()
+      split_horizontal(editor)
+
+      state = close_window(editor)
+
+      refute Windows.split?(state.workspace.windows)
+      assert window_count(state) == 1
+    end
+
+    test "edits in an active split window are written to the shared buffer" do
       {editor, buffer} = start_editor("hello")
       split_vertical(editor)
 
-      # Type in the active window (insert mode)
       send_key(editor, ?i)
       send_key(editor, ?X)
       send_key(editor, 27)
 
-      # Buffer content should reflect the edit
-      content = BufferProcess.content(buffer)
-      assert content =~ "X"
+      assert BufferProcess.content(buffer) =~ "X"
     end
   end
 end


### PR DESCRIPTION
# TL;DR
Splits buffer, minibuffer, and window command tests by layer so command/state behavior is covered without booting a full editor for every case. Editor-level coverage remains for shutdown paths and key-routing smoke tests.

Closes #1690

## Context
Issue #1690 asked to keep real lifecycle coverage while moving state-only command behavior out of full Editor GenServer tests. This PR narrows the heavy integration surface without changing production behavior.

## Changes
- Classifies the touched command tests with `@describetag layer: :command_state` or `:editor_integration`.
- Moves tab-aware `:q`, `close_other_tabs`, dirty quit confirmation, stale agent-session cleanup, minibuffer candidate acceptance, and window split/navigation/close checks to direct command/state tests where possible.
- Keeps editor smoke coverage for command entry/save, global save routing, Escape quit-confirmation routing, minibuffer ArrowDown+Tab routing, window split/navigation/close key routing, shutdown, and `:cq` paths.
- Uses production-realistic tab setup via `EditorState.add_buffer(..., context: :open)` for tab-close command-state tests.

## Verification
- `mix test.llm test/minga_editor/commands/buffer_management_test.exs test/minga_editor/commands/buffer_management_shutdown_test.exs test/minga_editor/commands/minibuffer_test.exs test/minga_editor/commands/window_test.exs` ✅ 39 tests, 0 failures
- `make lint` ✅ passed
- Review loop ✅ 2 rounds, no remaining blockers from intent, correctness, or test-quality reviewers

Note: local full-suite runs were attempted, but this checkout repeatedly hit moving, load-sensitive failures in unrelated tests. At least one failing focused case also failed on `main`, so the PR validation relies on the focused affected test set plus lint.

## Acceptance Criteria Addressed
- Each test in the four scoped files is classified by layer ✅
- Tab-aware `:q`, close-other-tabs, dirty quit confirmation, and stale agent-session cleanup are tested through focused state/command functions where possible ✅
- Shutdown and `:cq` cases remain integration-only, with `async: false` reasons documented ✅
- Minibuffer candidate acceptance is tested through state transitions, with routing smoke kept at editor layer ✅
- Window split/navigation/close behavior is tested through command/state paths, with editor smoke for key routing ✅
- New assertions verify topology, status messages, process behavior, or command outcomes rather than set/get round trips ✅
- Focused rewritten-file tests pass ✅
