### PR TITLE
test(commands): extract file-tree and dired seams

### DIFF
--- a/test/minga_editor/commands/dired_test.exs
+++ b/test/minga_editor/commands/dired_test.exs
@@ -2,6 +2,8 @@ defmodule MingaEditor.Commands.DiredTest do
   @moduledoc """
   Integration tests for the dired (Oil.nvim-style) directory buffer.
 
+  Classification: these tests intentionally remain EditorCase integration coverage because they verify save interception, confirmation flow, real file creation/deletion/rename, navigation, and visible listing updates through the dired buffer.
+
   Tests the full keystroke-to-filesystem pipeline: opening dired via
   ex commands, navigating directories, editing filenames, and confirming
   file operations. Uses EditorCase for headless editor state.
@@ -11,7 +13,7 @@ defmodule MingaEditor.Commands.DiredTest do
 
   @moduletag :tmp_dir
 
-  describe ":dired — open directory buffer" do
+  describe "[EditorCase integration] :dired — open directory buffer" do
     test "opens directory by path", %{tmp_dir: dir} do
       File.write!(Path.join(dir, "hello.txt"), "")
       File.write!(Path.join(dir, "other.txt"), "")
@@ -52,7 +54,7 @@ defmodule MingaEditor.Commands.DiredTest do
     end
   end
 
-  describe "save interception" do
+  describe "[EditorCase integration] save interception" do
     test ":w on dired buffer does not write to disk", %{tmp_dir: dir} do
       file = Path.join(dir, "file.txt")
       File.write!(file, "original")
@@ -92,7 +94,7 @@ defmodule MingaEditor.Commands.DiredTest do
     end
   end
 
-  describe "confirm-then-apply" do
+  describe "[EditorCase integration] confirm-then-apply" do
     test "y confirms and applies rename", %{tmp_dir: dir} do
       File.write!(Path.join(dir, "old.txt"), "content")
 
@@ -193,7 +195,7 @@ defmodule MingaEditor.Commands.DiredTest do
     end
   end
 
-  describe "navigation" do
+  describe "[EditorCase integration] navigation" do
     test "Enter on a directory navigates into it", %{tmp_dir: dir} do
       subdir = Path.join(dir, "sub")
       File.mkdir_p!(subdir)
@@ -238,7 +240,7 @@ defmodule MingaEditor.Commands.DiredTest do
     end
   end
 
-  describe "display toggles" do
+  describe "[EditorCase integration] display toggles" do
     test "g. toggles hidden files", %{tmp_dir: dir} do
       File.write!(Path.join(dir, ".hidden"), "")
       File.write!(Path.join(dir, "visible.txt"), "")

--- a/test/minga_editor/commands/file_tree_drop_test.exs
+++ b/test/minga_editor/commands/file_tree_drop_test.exs
@@ -1,57 +1,138 @@
 defmodule MingaEditor.Commands.FileTreeDropTest do
-  @moduledoc "Tests BEAM-owned file-tree drop handling from native GUI intents."
+  @moduledoc """
+  Command-state tests for BEAM-owned file-tree drop handling from native GUI intents.
 
-  use Minga.Test.EditorCase, async: true
+  Classification: these tests call `Commands.FileTree.drop/2` directly on constructed editor state. They still verify filesystem-visible behavior, stale-target rejection, overwrite protection, and open-buffer retargeting without booting the full EditorCase input/render stack.
+  """
 
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer
+  alias Minga.Events
   alias Minga.Project.FileTree
   alias MingaEditor.Commands
   alias MingaEditor.FileTree.DropIntent
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.FileTree, as: FileTreeState
+  alias MingaEditor.Viewport
+  alias MingaEditor.Workspace.State, as: WorkspaceState
 
   @moduletag :tmp_dir
 
-  describe "drop/2" do
-    test "copies an external file into a directory target", %{tmp_dir: dir} do
-      active_file = Path.join(dir, "main.ex")
+  setup context do
+    events_registry = private_events_registry(context)
+    start_supervised!({Events, name: events_registry})
+    {:ok, events_registry: events_registry}
+  end
+
+  describe "[command-state] drop/2 filesystem effects" do
+    test "copies an external file into a directory target", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
       target_dir = Path.join(dir, "target")
-      File.write!(active_file, "main")
       File.mkdir_p!(target_dir)
       {external_root, external_file} = external_file_fixture(dir, "external.txt")
       on_exit(fn -> File.rm_rf(external_root) end)
 
-      state = open_file_tree(dir, active_file)
+      state = open_file_tree(dir, events_registry)
       intent = drop_intent(state.workspace.file_tree.tree, target_dir, [external_file])
 
       state = Commands.FileTree.drop(state, intent)
 
-      assert File.exists?(Path.join(target_dir, "external.txt"))
+      assert File.read!(Path.join(target_dir, "external.txt")) == "external"
       assert state.workspace.file_tree.tree != nil
     end
 
     test "copies an external file to the parent directory when dropped onto a file", %{
-      tmp_dir: dir
+      tmp_dir: dir,
+      events_registry: events_registry
     } do
       target_file = Path.join(dir, "main.ex")
       File.write!(target_file, "main")
       {external_root, external_file} = external_file_fixture(dir, "onto-file.txt")
       on_exit(fn -> File.rm_rf(external_root) end)
 
-      state = open_file_tree(dir, target_file)
+      state = open_file_tree(dir, events_registry)
       intent = drop_intent(state.workspace.file_tree.tree, target_file, [external_file])
 
       _state = Commands.FileTree.drop(state, intent)
 
-      assert File.exists?(Path.join(dir, "onto-file.txt"))
+      assert File.read!(Path.join(dir, "onto-file.txt")) == "external"
     end
 
-    test "rejects stale target identity without copying", %{tmp_dir: dir} do
-      active_file = Path.join(dir, "main.ex")
+    test "moves an internal visible source into a directory target", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
+      source_file = Path.join(dir, "source.txt")
       target_dir = Path.join(dir, "target")
-      File.write!(active_file, "main")
+      File.write!(source_file, "source")
+      File.mkdir_p!(target_dir)
+
+      state = open_file_tree(dir, events_registry)
+      intent = drop_intent(state.workspace.file_tree.tree, target_dir, [source_file])
+
+      _state = Commands.FileTree.drop(state, intent)
+
+      refute File.exists?(source_file)
+      assert File.read!(Path.join(target_dir, "source.txt")) == "source"
+    end
+
+    test "moves an internal symlink entry instead of copying its external target", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
+      target_dir = Path.join(dir, "target")
+      symlink_path = Path.join(dir, "linked.txt")
+      {external_root, external_file} = external_file_fixture(dir, "linked-target.txt")
+      on_exit(fn -> File.rm_rf(external_root) end)
+      File.mkdir_p!(target_dir)
+      File.ln_s!(external_file, symlink_path)
+
+      state = open_file_tree(dir, events_registry)
+      intent = drop_intent(state.workspace.file_tree.tree, target_dir, [symlink_path])
+
+      _state = Commands.FileTree.drop(state, intent)
+
+      assert {:error, :enoent} = File.lstat(symlink_path)
+      assert {:ok, %File.Stat{type: :symlink}} = File.lstat(Path.join(target_dir, "linked.txt"))
+      assert File.read!(external_file) == "external"
+    end
+
+    test "moves an internal visible source to the parent directory when dropped onto a file", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
+      source_file = Path.join(dir, "source.txt")
+      nested_dir = Path.join(dir, "nested")
+      target_file = Path.join(nested_dir, "main.ex")
+      File.write!(source_file, "source")
+      File.mkdir_p!(nested_dir)
+      File.write!(target_file, "main")
+
+      state = open_file_tree(dir, events_registry, target_file)
+      intent = drop_intent(state.workspace.file_tree.tree, target_file, [source_file])
+
+      _state = Commands.FileTree.drop(state, intent)
+
+      refute File.exists?(source_file)
+      assert File.read!(Path.join(nested_dir, "source.txt")) == "source"
+    end
+  end
+
+  describe "[command-state] drop/2 rejection and retargeting" do
+    test "rejects stale target identity without copying", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
+      target_dir = Path.join(dir, "target")
       File.mkdir_p!(target_dir)
       {external_root, external_file} = external_file_fixture(dir, "stale.txt")
       on_exit(fn -> File.rm_rf(external_root) end)
 
-      state = open_file_tree(dir, active_file)
+      state = open_file_tree(dir, events_registry)
 
       intent =
         state.workspace.file_tree.tree
@@ -63,73 +144,18 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       refute File.exists?(Path.join(target_dir, "stale.txt"))
     end
 
-    test "moves an internal visible source into a directory target", %{tmp_dir: dir} do
-      active_file = Path.join(dir, "main.ex")
-      source_file = Path.join(dir, "source.txt")
-      target_dir = Path.join(dir, "target")
-      File.write!(active_file, "main")
-      File.write!(source_file, "source")
-      File.mkdir_p!(target_dir)
-
-      state = open_file_tree(dir, active_file)
-      intent = drop_intent(state.workspace.file_tree.tree, target_dir, [source_file])
-
-      _state = Commands.FileTree.drop(state, intent)
-
-      refute File.exists?(source_file)
-      assert File.exists?(Path.join(target_dir, "source.txt"))
-    end
-
-    test "moves an internal symlink entry instead of copying its external target", %{tmp_dir: dir} do
-      active_file = Path.join(dir, "main.ex")
-      target_dir = Path.join(dir, "target")
-      symlink_path = Path.join(dir, "linked.txt")
-      {external_root, external_file} = external_file_fixture(dir, "linked-target.txt")
-      on_exit(fn -> File.rm_rf(external_root) end)
-      File.write!(active_file, "main")
-      File.mkdir_p!(target_dir)
-      File.ln_s!(external_file, symlink_path)
-
-      state = open_file_tree(dir, active_file)
-      intent = drop_intent(state.workspace.file_tree.tree, target_dir, [symlink_path])
-
-      _state = Commands.FileTree.drop(state, intent)
-
-      assert {:error, :enoent} = File.lstat(symlink_path)
-      assert {:ok, %File.Stat{type: :symlink}} = File.lstat(Path.join(target_dir, "linked.txt"))
-      assert File.read!(external_file) == "external"
-    end
-
-    test "moves an internal visible source to the parent directory when dropped onto a file", %{
-      tmp_dir: dir
+    test "does not overwrite an existing destination for an internal source", %{
+      tmp_dir: dir,
+      events_registry: events_registry
     } do
-      source_file = Path.join(dir, "source.txt")
-      nested_dir = Path.join(dir, "nested")
-      target_file = Path.join(nested_dir, "main.ex")
-      File.write!(source_file, "source")
-      File.mkdir_p!(nested_dir)
-      File.write!(target_file, "main")
-
-      state = open_file_tree(dir, target_file)
-      intent = drop_intent(state.workspace.file_tree.tree, target_file, [source_file])
-
-      _state = Commands.FileTree.drop(state, intent)
-
-      refute File.exists?(source_file)
-      assert File.exists?(Path.join(nested_dir, "source.txt"))
-    end
-
-    test "does not overwrite an existing destination for an internal source", %{tmp_dir: dir} do
-      active_file = Path.join(dir, "main.ex")
       source_file = Path.join(dir, "source.txt")
       target_dir = Path.join(dir, "target")
       existing_dest = Path.join(target_dir, "source.txt")
-      File.write!(active_file, "main")
       File.write!(source_file, "source")
       File.mkdir_p!(target_dir)
       File.write!(existing_dest, "existing")
 
-      state = open_file_tree(dir, active_file)
+      state = open_file_tree(dir, events_registry)
       intent = drop_intent(state.workspace.file_tree.tree, target_dir, [source_file])
 
       _state = Commands.FileTree.drop(state, intent)
@@ -139,18 +165,17 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
     end
 
     test "does not overwrite a dangling symlink destination for an internal source", %{
-      tmp_dir: dir
+      tmp_dir: dir,
+      events_registry: events_registry
     } do
-      active_file = Path.join(dir, "main.ex")
       source_file = Path.join(dir, "source.txt")
       target_dir = Path.join(dir, "target")
       dangling_dest = Path.join(target_dir, "source.txt")
-      File.write!(active_file, "main")
       File.write!(source_file, "source")
       File.mkdir_p!(target_dir)
       File.ln_s!("missing.txt", dangling_dest)
 
-      state = open_file_tree(dir, active_file)
+      state = open_file_tree(dir, events_registry)
       intent = drop_intent(state.workspace.file_tree.tree, target_dir, [source_file])
 
       _state = Commands.FileTree.drop(state, intent)
@@ -161,18 +186,17 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
     end
 
     test "does not copy through a dangling symlink destination for an external source", %{
-      tmp_dir: dir
+      tmp_dir: dir,
+      events_registry: events_registry
     } do
-      active_file = Path.join(dir, "main.ex")
       target_dir = Path.join(dir, "target")
       dangling_dest = Path.join(target_dir, "external.txt")
-      File.write!(active_file, "main")
       File.mkdir_p!(target_dir)
       File.ln_s!("missing.txt", dangling_dest)
       {external_root, external_file} = external_file_fixture(dir, "external.txt")
       on_exit(fn -> File.rm_rf(external_root) end)
 
-      state = open_file_tree(dir, active_file)
+      state = open_file_tree(dir, events_registry)
       intent = drop_intent(state.workspace.file_tree.tree, target_dir, [external_file])
 
       _state = Commands.FileTree.drop(state, intent)
@@ -181,7 +205,10 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       refute File.exists?(Path.join(target_dir, "missing.txt"))
     end
 
-    test "retargets open buffers under an internally moved directory", %{tmp_dir: dir} do
+    test "retargets open buffers under an internally moved directory", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
       source_dir = Path.join(dir, "source")
       target_dir = Path.join(dir, "target")
       active_file = Path.join(source_dir, "main.ex")
@@ -190,20 +217,45 @@ defmodule MingaEditor.Commands.FileTreeDropTest do
       File.mkdir_p!(target_dir)
       File.write!(active_file, "main")
 
-      state = open_file_tree(dir, active_file)
+      state = open_file_tree(dir, events_registry, active_file)
       intent = drop_intent(state.workspace.file_tree.tree, target_dir, [source_dir])
 
       _state = Commands.FileTree.drop(state, intent)
 
       refute File.exists?(active_file)
       assert File.exists?(moved_file)
-      assert Minga.Buffer.file_path(state.workspace.buffers.active) == moved_file
+      assert Buffer.file_path(state.workspace.buffers.active) == moved_file
     end
   end
 
-  defp open_file_tree(dir, active_file) do
-    ctx = start_editor("main", file_path: active_file, project_root: dir)
-    send_keys_sync(ctx, "<SPC>op")
+  defp open_file_tree(dir, events_registry, active_file \\ nil) do
+    tree = reveal_active_file(FileTree.new(dir), active_file)
+    buffers = buffers_for_active_file(active_file, events_registry)
+
+    %EditorState{
+      port_manager: self(),
+      events_registry: events_registry,
+      workspace: %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: buffers,
+        file_tree: FileTreeState.open(%FileTreeState{}, tree, nil),
+        keymap_scope: :file_tree
+      }
+    }
+  end
+
+  defp private_events_registry(%{module: module, test: test}) do
+    Module.concat([module, test, Events])
+  end
+
+  defp reveal_active_file(tree, nil), do: tree
+  defp reveal_active_file(tree, active_file), do: FileTree.reveal(tree, active_file)
+
+  defp buffers_for_active_file(nil, _events_registry), do: %Buffers{}
+
+  defp buffers_for_active_file(active_file, events_registry) do
+    buffer = start_supervised!({Buffer, file_path: active_file, events_registry: events_registry})
+    Buffers.add(%Buffers{}, buffer)
   end
 
   defp external_file_fixture(dir, name) do

--- a/test/minga_editor/commands/file_tree_editing_integration_test.exs
+++ b/test/minga_editor/commands/file_tree_editing_integration_test.exs
@@ -1,0 +1,66 @@
+defmodule MingaEditor.Commands.FileTreeEditingIntegrationTest do
+  @moduledoc """
+  EditorCase smoke tests for file tree inline editing key routing.
+
+  Classification: deterministic editing state transitions live in `FileTreeEditingTest`; these tests stay full-editor because they prove user-facing key routing still creates and renames real filesystem entries through the visible file tree.
+  """
+
+  use Minga.Test.EditorCase, async: true
+
+  @moduletag :tmp_dir
+
+  describe "[EditorCase integration] file tree editing key routing" do
+    test "a creates a file on disk after typing a name and pressing Enter", %{tmp_dir: dir} do
+      file = Path.join(dir, "test.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file, project_root: dir)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      _state = send_keys_sync(ctx, "a")
+      state = send_keys_sync(ctx, "newfile.txt<Enter>")
+
+      assert state.workspace.file_tree.editing == nil
+
+      expected = Path.join(dir, "newfile.txt")
+      assert File.exists?(expected), "Expected newfile.txt to exist at #{expected}"
+    end
+
+    test "A creates a folder on disk after typing a name and pressing Enter", %{tmp_dir: dir} do
+      file = Path.join(dir, "test.txt")
+      File.write!(file, "hello")
+
+      ctx = start_editor("hello", file_path: file, project_root: dir)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      state = send_keys_sync(ctx, "A")
+
+      assert state.workspace.file_tree.editing.type == :new_folder
+
+      state = send_keys_sync(ctx, "newfolder<Enter>")
+
+      assert state.workspace.file_tree.editing == nil
+
+      expected = Path.join(dir, "newfolder")
+      assert File.dir?(expected), "Expected newfolder to exist at #{expected}"
+    end
+
+    test "R renames a file on disk after replacing the inline name", %{tmp_dir: dir} do
+      file = Path.join(dir, "target.txt")
+      File.write!(file, "content")
+
+      ctx = start_editor("content", file_path: file, project_root: dir)
+
+      _state = send_keys_sync(ctx, "<SPC>op")
+      state = send_keys_sync(ctx, "R")
+      backspaces = String.duplicate("<BS>", String.length(state.workspace.file_tree.editing.text))
+      state = send_keys_sync(ctx, "#{backspaces}renamed.txt<Enter>")
+
+      assert state.workspace.file_tree.editing == nil
+
+      new_path = Path.join(dir, "renamed.txt")
+      assert File.exists?(new_path), "Expected renamed.txt to exist"
+      refute File.exists?(file), "Expected target.txt to no longer exist"
+    end
+  end
+end

--- a/test/minga_editor/commands/file_tree_editing_test.exs
+++ b/test/minga_editor/commands/file_tree_editing_test.exs
@@ -1,71 +1,86 @@
 defmodule MingaEditor.Commands.FileTreeEditingTest do
   @moduledoc """
-  Tests for file tree inline editing commands: new file, new folder,
-  rename, confirm, and cancel.
+  Command-state tests for file tree inline editing commands: new file, new folder, rename, confirm, and cancel.
 
-  Uses EditorCase with tmp_dir for real filesystem operations.
+  Classification: these tests call file-tree command and input-handler seams directly on constructed editor state. They verify deterministic editing mode transitions, filesystem-visible mutations, overwrite protection, and open-buffer retargeting without booting the full EditorCase input/render stack.
   """
-  use Minga.Test.EditorCase, async: true
+
+  use ExUnit.Case, async: true
 
   alias Minga.Buffer
+  alias Minga.Events
+  alias Minga.Project.FileTree
+  alias MingaEditor.Commands
+  alias MingaEditor.Input.FileTreeHandler
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.FileTree, as: FileTreeState
+  alias MingaEditor.Viewport
+  alias MingaEditor.Workspace.State, as: WorkspaceState
+
+  @backspace 127
 
   @moduletag :tmp_dir
 
-  describe "new file (a)" do
-    test "enters new-file editing mode", %{tmp_dir: dir} do
-      file = Path.join(dir, "test.txt")
-      File.write!(file, "hello")
+  setup context do
+    events_registry = private_events_registry(context)
+    start_supervised!({Events, name: events_registry})
+    {:ok, events_registry: events_registry}
+  end
 
-      ctx = start_editor("hello", file_path: file, project_root: dir)
+  describe "[command-state] new file (a)" do
+    test "enters new-file editing mode", %{tmp_dir: dir, events_registry: events_registry} do
+      state = make_state(dir, events_registry)
 
-      _state = send_keys_sync(ctx, "<SPC>op")
-      state = send_keys_sync(ctx, "a")
+      state = Commands.FileTree.new_file(state)
 
       assert state.workspace.file_tree.editing != nil
       assert state.workspace.file_tree.editing.type == :new_file
       assert state.workspace.file_tree.editing.text == ""
     end
 
-    test "creates file on disk after typing name and pressing Enter", %{tmp_dir: dir} do
-      file = Path.join(dir, "test.txt")
-      File.write!(file, "hello")
+    test "creates file on disk after confirming a typed name", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
+      expected = Path.join(dir, "newfile.txt")
+      _buffer = start_supervised!({Buffer, file_path: expected, events_registry: events_registry})
 
-      ctx = start_editor("hello", file_path: file, project_root: dir)
+      state =
+        dir
+        |> make_state(events_registry)
+        |> Commands.FileTree.new_file()
+        |> replace_editing_text("newfile.txt")
 
-      _state = send_keys_sync(ctx, "<SPC>op")
-      _state = send_keys_sync(ctx, "a")
-      state = send_keys_sync(ctx, "newfile.txt<Enter>")
+      state = Commands.FileTree.confirm_editing(state)
 
       assert state.workspace.file_tree.editing == nil
 
-      expected = Path.join(dir, "newfile.txt")
       assert File.exists?(expected), "Expected newfile.txt to exist at #{expected}"
     end
   end
 
-  describe "new folder (A)" do
-    test "enters new-folder editing mode", %{tmp_dir: dir} do
-      file = Path.join(dir, "test.txt")
-      File.write!(file, "hello")
+  describe "[command-state] new folder (A)" do
+    test "enters new-folder editing mode", %{tmp_dir: dir, events_registry: events_registry} do
+      state = make_state(dir, events_registry)
 
-      ctx = start_editor("hello", file_path: file, project_root: dir)
-
-      _state = send_keys_sync(ctx, "<SPC>op")
-      state = send_keys_sync(ctx, "A")
+      state = Commands.FileTree.new_folder(state)
 
       assert state.workspace.file_tree.editing != nil
       assert state.workspace.file_tree.editing.type == :new_folder
     end
 
-    test "creates directory on disk after typing name and pressing Enter", %{tmp_dir: dir} do
-      file = Path.join(dir, "test.txt")
-      File.write!(file, "hello")
+    test "creates directory on disk after confirming a typed name", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
+      state =
+        dir
+        |> make_state(events_registry)
+        |> Commands.FileTree.new_folder()
+        |> replace_editing_text("newfolder")
 
-      ctx = start_editor("hello", file_path: file, project_root: dir)
-
-      _state = send_keys_sync(ctx, "<SPC>op")
-      _state = send_keys_sync(ctx, "A")
-      state = send_keys_sync(ctx, "newfolder<Enter>")
+      state = Commands.FileTree.confirm_editing(state)
 
       assert state.workspace.file_tree.editing == nil
 
@@ -74,35 +89,39 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
     end
   end
 
-  describe "rename (R)" do
-    test "enters rename editing mode with current name pre-filled", %{tmp_dir: dir} do
+  describe "[command-state] rename (R)" do
+    test "enters rename editing mode with current name pre-filled", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
       file = Path.join(dir, "target.txt")
       File.write!(file, "content")
 
-      ctx = start_editor("content", file_path: file, project_root: dir)
+      state = dir |> make_state(events_registry) |> select_entry("target.txt")
 
-      _state = send_keys_sync(ctx, "<SPC>op")
-      state = send_keys_sync(ctx, "R")
+      state = Commands.FileTree.rename(state)
 
       assert state.workspace.file_tree.editing != nil
       assert state.workspace.file_tree.editing.type == :rename
-      assert state.workspace.file_tree.editing.original_name != nil
+      assert state.workspace.file_tree.editing.text == "target.txt"
+      assert state.workspace.file_tree.editing.original_name == "target.txt"
     end
 
-    test "renames file on disk after changing name", %{tmp_dir: dir} do
+    test "renames file on disk after changing name", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
       file = Path.join(dir, "target.txt")
       File.write!(file, "content")
 
-      ctx = start_editor("content", file_path: file, project_root: dir)
+      state =
+        dir
+        |> make_state(events_registry)
+        |> select_entry("target.txt")
+        |> Commands.FileTree.rename()
+        |> replace_editing_text("renamed.txt")
 
-      # Open tree (reveals active file automatically), press R
-      _state = send_keys_sync(ctx, "<SPC>op")
-      state = send_keys_sync(ctx, "R")
-      name = state.workspace.file_tree.editing.text
-
-      # Clear pre-filled text with backspaces, then type new name
-      backspaces = String.duplicate("<BS>", String.length(name))
-      state = send_keys_sync(ctx, "#{backspaces}renamed.txt<Enter>")
+      state = Commands.FileTree.confirm_editing(state)
 
       assert state.workspace.file_tree.editing == nil
 
@@ -111,18 +130,23 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
       refute File.exists?(file), "Expected target.txt to no longer exist"
     end
 
-    test "rename does not overwrite an existing sibling", %{tmp_dir: dir} do
+    test "rename does not overwrite an existing sibling", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
       file = Path.join(dir, "target.txt")
       existing = Path.join(dir, "existing.txt")
       File.write!(file, "content")
       File.write!(existing, "existing")
 
-      ctx = start_editor("content", file_path: file, project_root: dir)
+      state =
+        dir
+        |> make_state(events_registry)
+        |> select_entry("target.txt")
+        |> Commands.FileTree.rename()
+        |> replace_editing_text("existing.txt")
 
-      _state = send_keys_sync(ctx, "<SPC>op")
-      state = send_keys_sync(ctx, "R")
-      backspaces = String.duplicate("<BS>", String.length(state.workspace.file_tree.editing.text))
-      state = send_keys_sync(ctx, "#{backspaces}existing.txt<Enter>")
+      state = Commands.FileTree.confirm_editing(state)
 
       assert state.workspace.file_tree.editing == nil
       assert File.read!(file) == "content"
@@ -130,23 +154,27 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
     end
   end
 
-  describe "rename retargets open buffers" do
-    test "rename retargets a dirty open file buffer without writing its contents", %{tmp_dir: dir} do
+  describe "[command-state] rename retargets open buffers" do
+    test "rename retargets a dirty open file buffer without writing its contents", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
       file = Path.join(dir, "target.txt")
       renamed = Path.join(dir, "renamed.txt")
       File.write!(file, "content")
+      buffer = start_supervised!({Buffer, file_path: file, events_registry: events_registry})
 
-      ctx = start_editor("content", file_path: file, project_root: dir)
-      buffer = active_buffer(ctx)
-
-      assert is_pid(buffer)
       :ok = Buffer.insert_char(buffer, "!")
       assert Buffer.dirty?(buffer)
 
-      _state = send_keys_sync(ctx, "<SPC>op")
-      state = send_keys_sync(ctx, "R")
-      backspaces = String.duplicate("<BS>", String.length(state.workspace.file_tree.editing.text))
-      state = send_keys_sync(ctx, "#{backspaces}renamed.txt<Enter>")
+      state =
+        dir
+        |> make_state(events_registry, buffer)
+        |> select_entry("target.txt")
+        |> Commands.FileTree.rename()
+        |> replace_editing_text("renamed.txt")
+
+      state = Commands.FileTree.confirm_editing(state)
 
       assert state.workspace.file_tree.editing == nil
       assert Buffer.file_path(buffer) == renamed
@@ -159,23 +187,26 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
     end
 
     test "rename leaves a dirty open buffer on the original path when destination exists", %{
-      tmp_dir: dir
+      tmp_dir: dir,
+      events_registry: events_registry
     } do
       file = Path.join(dir, "target.txt")
       existing = Path.join(dir, "existing.txt")
       File.write!(file, "content")
       File.write!(existing, "existing")
-
-      ctx = start_editor("content", file_path: file, project_root: dir)
-      buffer = active_buffer(ctx)
+      buffer = start_supervised!({Buffer, file_path: file, events_registry: events_registry})
 
       :ok = Buffer.insert_char(buffer, "!")
       assert Buffer.dirty?(buffer)
 
-      _state = send_keys_sync(ctx, "<SPC>op")
-      state = send_keys_sync(ctx, "R")
-      backspaces = String.duplicate("<BS>", String.length(state.workspace.file_tree.editing.text))
-      state = send_keys_sync(ctx, "#{backspaces}existing.txt<Enter>")
+      state =
+        dir
+        |> make_state(events_registry, buffer)
+        |> select_entry("target.txt")
+        |> Commands.FileTree.rename()
+        |> replace_editing_text("existing.txt")
+
+      state = Commands.FileTree.confirm_editing(state)
 
       assert state.workspace.file_tree.editing == nil
       assert Buffer.file_path(buffer) == file
@@ -185,17 +216,18 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
     end
   end
 
-  describe "cancel editing" do
-    test "Escape cancels without filesystem changes", %{tmp_dir: dir} do
-      file = Path.join(dir, "test.txt")
-      File.write!(file, "hello")
+  describe "[command-state] cancel editing" do
+    test "Escape-equivalent command cancels without filesystem changes", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
+      state =
+        dir
+        |> make_state(events_registry)
+        |> Commands.FileTree.new_file()
+        |> replace_editing_text("partial")
 
-      ctx = start_editor("hello", file_path: file, project_root: dir)
-
-      _state = send_keys_sync(ctx, "<SPC>op")
-      _state = send_keys_sync(ctx, "a")
-      _state = send_keys_sync(ctx, "partial")
-      state = send_keys_sync(ctx, "<Esc>")
+      state = Commands.FileTree.cancel_editing(state)
 
       assert state.workspace.file_tree.editing == nil
 
@@ -203,46 +235,86 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
              "No file should be created when editing is cancelled"
     end
 
-    test "confirm with empty text cancels", %{tmp_dir: dir} do
-      file = Path.join(dir, "test.txt")
-      File.write!(file, "hello")
+    test "confirm with empty text cancels", %{tmp_dir: dir, events_registry: events_registry} do
+      state = dir |> make_state(events_registry) |> Commands.FileTree.new_file()
 
-      ctx = start_editor("hello", file_path: file, project_root: dir)
-
-      _state = send_keys_sync(ctx, "<SPC>op")
-      _state = send_keys_sync(ctx, "a")
-      state = send_keys_sync(ctx, "<Enter>")
+      state = Commands.FileTree.confirm_editing(state)
 
       assert state.workspace.file_tree.editing == nil
     end
 
-    test "Backspace on empty text cancels editing", %{tmp_dir: dir} do
-      file = Path.join(dir, "test.txt")
-      File.write!(file, "hello")
+    test "Backspace on empty text cancels editing through the file-tree input handler", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
+      state = dir |> make_state(events_registry) |> Commands.FileTree.new_file()
 
-      ctx = start_editor("hello", file_path: file, project_root: dir)
-
-      _state = send_keys_sync(ctx, "<SPC>op")
-      _state = send_keys_sync(ctx, "a")
-      state = send_keys_sync(ctx, "<BS>")
+      {:handled, state} = FileTreeHandler.handle_key(state, @backspace, 0)
 
       assert state.workspace.file_tree.editing == nil
     end
   end
 
-  describe "rename to same name cancels" do
-    test "no filesystem operation when name unchanged", %{tmp_dir: dir} do
+  describe "[command-state] rename to same name cancels" do
+    test "no filesystem operation when name unchanged", %{
+      tmp_dir: dir,
+      events_registry: events_registry
+    } do
       file = Path.join(dir, "same.txt")
       File.write!(file, "content")
 
-      ctx = start_editor("content", file_path: file, project_root: dir)
+      state =
+        dir
+        |> make_state(events_registry)
+        |> select_entry("same.txt")
+        |> Commands.FileTree.rename()
 
-      _state = send_keys_sync(ctx, "<SPC>op")
-      _state = send_keys_sync(ctx, "R")
-      state = send_keys_sync(ctx, "<Enter>")
+      state = Commands.FileTree.confirm_editing(state)
 
       assert state.workspace.file_tree.editing == nil
       assert File.exists?(file), "File should still exist unchanged"
     end
+  end
+
+  defp make_state(dir, events_registry, active_buffer \\ nil) do
+    tree = FileTree.new(dir)
+
+    %EditorState{
+      port_manager: self(),
+      events_registry: events_registry,
+      workspace: %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        buffers: buffers_for_active_buffer(active_buffer),
+        file_tree: FileTreeState.open(%FileTreeState{}, tree, nil),
+        keymap_scope: :file_tree
+      },
+      focus_stack: [MingaEditor.Input.Scoped, MingaEditor.Input.ModeFSM]
+    }
+  end
+
+  defp private_events_registry(%{module: module, test: test}) do
+    Module.concat([module, test, Events])
+  end
+
+  defp buffers_for_active_buffer(nil), do: %Buffers{}
+  defp buffers_for_active_buffer(buffer) when is_pid(buffer), do: Buffers.add(%Buffers{}, buffer)
+
+  defp replace_editing_text(%EditorState{} = state, text) when is_binary(text) do
+    ft = FileTreeState.update_editing_text(state.workspace.file_tree, text)
+    EditorState.update_workspace(state, &WorkspaceState.set_file_tree(&1, ft))
+  end
+
+  defp select_entry(%EditorState{} = state, name) when is_binary(name) do
+    tree = state.workspace.file_tree.tree
+    entries = FileTree.visible_entries(tree)
+    index = Enum.find_index(entries, &(&1.name == name))
+    assert index != nil, "Expected #{name} to be visible in the file tree"
+
+    replace_tree(state, FileTree.select(tree, index))
+  end
+
+  defp replace_tree(%EditorState{} = state, %FileTree{} = tree) do
+    ft = FileTreeState.replace_tree(state.workspace.file_tree, tree)
+    EditorState.update_workspace(state, &WorkspaceState.set_file_tree(&1, ft))
   end
 end

--- a/test/minga_editor/commands/file_tree_reveal_test.exs
+++ b/test/minga_editor/commands/file_tree_reveal_test.exs
@@ -2,6 +2,8 @@ defmodule MingaEditor.Commands.FileTreeRevealTest do
   @moduledoc """
   Tests for the reveal_active_file command (SPC o r).
 
+  Classification: the FileTree.reveal/2 ancestor expansion seam is tested directly, while EditorCase tests remain for user-facing command routing, tree opening, focus, and visible sidebar behavior.
+
   Verifies that revealing the active buffer's file in the tree opens the
   tree if needed, expands parents, moves the cursor, and focuses the tree.
 
@@ -34,7 +36,23 @@ defmodule MingaEditor.Commands.FileTreeRevealTest do
     assert file_entry != nil, "#{Path.basename(file_path)} should be visible in the tree"
   end
 
-  describe "reveal active file (SPC o r)" do
+  describe "[command-state] FileTree.reveal/2" do
+    test "expands ancestors and selects the target file directly", %{tmp_dir: dir} do
+      nested = Path.join([dir, "lib", "minga"])
+      File.mkdir_p!(nested)
+      file = Path.join(nested, "editor.ex")
+      File.write!(file, "hello")
+
+      tree = dir |> FileTree.new() |> FileTree.collapse_all() |> FileTree.reveal(file)
+      entries = FileTree.visible_entries(tree)
+
+      assert Enum.any?(entries, &(&1.path == Path.expand(file)))
+      assert %{path: selected_path} = FileTree.selected_entry(tree)
+      assert selected_path == Path.expand(file)
+    end
+  end
+
+  describe "[EditorCase integration] reveal active file (SPC o r)" do
     test "opens tree and reveals file when tree is closed", %{tmp_dir: dir} do
       file = Path.join(dir, "reveal_test.txt")
       File.write!(file, "hello")
@@ -42,7 +60,7 @@ defmodule MingaEditor.Commands.FileTreeRevealTest do
       ctx = start_editor("hello", file_path: file, project_root: dir)
 
       # Tree starts closed
-      state = :sys.get_state(ctx.editor)
+      state = editor_state(ctx)
       assert state.workspace.file_tree.tree == nil
 
       # Reveal active file
@@ -108,7 +126,7 @@ defmodule MingaEditor.Commands.FileTreeRevealTest do
 
       # Reveal should be a no-op (tree stays closed)
       _state = send_keys_sync(ctx, "<SPC>or")
-      state = :sys.get_state(ctx.editor)
+      state = editor_state(ctx)
 
       # Tree should not have opened
       assert state.workspace.file_tree.tree == nil


### PR DESCRIPTION
# TL;DR
Extracts file-tree and dired command tests to lighter seams where possible, while keeping full EditorCase coverage for user-facing routing and filesystem workflows.

Closes #1691

## Context
Issue #1691 called for a test extraction pass, not behavior changes. The goal was to reduce unnecessary full-editor setup for deterministic file-tree command logic while preserving integration coverage for workflows that need real key routing, visible tree/dired state, and filesystem effects.

## Changes
- Reclassified dired coverage as intentional EditorCase integration because it verifies save interception, confirmation flow, real create/delete/rename behavior, navigation, and visible listing updates.
- Moved file-tree drop coverage to direct command-state tests around `Commands.FileTree.drop/2`, including stale target rejection, overwrite protection, filesystem-visible copy/move behavior, symlink handling, and open-buffer retargeting.
- Moved file-tree editing mode transitions and deterministic command behavior to direct state/command tests with private `Minga.Events` registries so async tests do not leak global event-bus messages.
- Added a small EditorCase smoke file for `a`, `A`, and `R` key routing through the visible file tree to real filesystem mutations.
- Added direct `FileTree.reveal/2` coverage for ancestor expansion and target selection, while keeping EditorCase reveal tests for tree opening, focus, scope, and no-op behavior.

## Verification
- `git diff --check` -> pass
- `make lint` -> pass
- `mix test.llm test/minga_editor/commands/dired_test.exs test/minga_editor/commands/file_tree_drop_test.exs test/minga_editor/commands/file_tree_editing_test.exs test/minga_editor/commands/file_tree_editing_integration_test.exs test/minga_editor/commands/file_tree_reveal_test.exs` -> pass, 50 tests
- Review loop: 2 rounds. Round 1 found event-bus isolation and missing `A` smoke coverage. Worker fixed both. Round 2 found no blockers.

Local full-suite note: full `mix test.llm` was attempted under heavy concurrent local test/lint load and hit unrelated timeout/timer failures outside this diff. Each reported failing test was rerun directly and passed.

## Acceptance Criteria Addressed
- Each test in the four target files is classified as command-state coverage or legitimate EditorCase integration ✅
- Drop target resolution, stale target rejection, overwrite protection, and open-buffer retargeting are tested at the command/helper layer while still verifying filesystem-visible behavior ✅
- Dired save interception and confirm/apply behavior keep integration coverage for real file creation, deletion, rename, and navigation ✅
- File-tree editing mode transitions moved to direct command-state tests where possible, with filesystem mutation and key-routing smoke left in EditorCase ✅
- Reveal active file keeps EditorCase coverage for visible tree behavior, with direct `FileTree.reveal/2` seam coverage for ancestor expansion and target selection ✅
- Assertions verify filesystem effects, visible entries, selected targets, buffer retargeting, or command outputs rather than tautological helper state ✅
- Focused tests for the rewritten files pass ✅
