### PR TITLE
fix(lsp): guard automatic LSP requests with server capability checks

### DIFF
--- a/lib/minga_editor/lsp_actions.ex
+++ b/lib/minga_editor/lsp_actions.ex
@@ -174,13 +174,6 @@ defmodule MingaEditor.LspActions do
     end
   end
 
-  @spec supports_capability?(pid(), String.t()) :: boolean()
-  defp supports_capability?(client, key) do
-    caps = Client.capabilities(client)
-    provider = caps[key]
-    provider == true or is_map(provider)
-  end
-
   @doc """
   Schedules a debounced document highlight request.
 
@@ -1392,6 +1385,13 @@ defmodule MingaEditor.LspActions do
   def extract_hover_text(_), do: ""
 
   # ── Private ────────────────────────────────────────────────────────────────
+
+  @spec supports_capability?(GenServer.server(), String.t()) :: boolean()
+  defp supports_capability?(client, key) do
+    caps = Client.capabilities(client)
+    provider = caps[key]
+    provider == true or is_map(provider)
+  end
 
   @spec lsp_client_for(state(), pid()) :: pid() | nil
   defp lsp_client_for(_state, buffer_pid) do


### PR DESCRIPTION
## Summary

- Adds `supports_capability?/2` helper that checks LSP server capabilities before sending requests
- Guards `documentHighlight`, `codeLens`, and `inlayHint` automatic request paths so they skip servers that don't advertise the corresponding provider
- Flattens triple nesting (`case` -> `if` -> `case`) in `code_lens/1` and `inlay_hints/1` into linear `with` chains
- Moves `supports_capability?/2` to the Private section alongside `lsp_client_for` and `send_lsp_request`

Fixes the "Unhandled request: textDocument/documentHighlight" log spam seen in GUI mode when the LSP server doesn't support documentHighlight.

## Test plan

- [ ] Launch with `bin/minga-mac`, verify no "Unhandled request" log spam for documentHighlight/codeLens/inlayHint
- [ ] Open a file with LSP support, verify documentHighlight still works (symbol under cursor highlighted)
- [ ] Scroll through a file, verify inlay hints still render
- [ ] Verify code lenses still appear on supported files

🤖 Generated with [Claude Code](https://claude.com/claude-code)