### PR TITLE
fix(docs): remove stale Pi guide from ExDoc extras

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,6 @@ defmodule Minga.MixProject do
           # Coming From...
           "docs/FOR-NEOVIM-USERS.md",
           "docs/FOR-EMACS-USERS.md",
-          "docs/FOR-PI-USERS.md",
           "docs/FOR-AI-CODERS.md",
           # Extending Minga
           "docs/EXTENSIBILITY.md",
@@ -65,7 +64,6 @@ defmodule Minga.MixProject do
           "Coming From...": [
             "docs/FOR-NEOVIM-USERS.md",
             "docs/FOR-EMACS-USERS.md",
-            "docs/FOR-PI-USERS.md",
             "docs/FOR-AI-CODERS.md"
           ],
           "Extending Minga": [


### PR DESCRIPTION
# TL;DR
Remove the deleted Pi guide from the ExDoc sidebar config so the Deploy Docs workflow can generate the docs site again.

## Context
The docs job on `main` fails because `mix docs` still tries to read `docs/FOR-PI-USERS.md`, which was deleted when the Pi RPC provider was removed. ExDoc treats missing extras as a hard error, so the Pages deployment stops before upload.

## Changes
- Removed `docs/FOR-PI-USERS.md` from `docs[:extras]` in `mix.exs`.
- Removed the same stale file from the `Coming From...` extras group.

## Verification
- `rg -n "FOR-PI-USERS" mix.exs docs .github/workflows || true` returned 0 matches.
- `MIX_ENV=dev mix docs` generated docs successfully. Existing documentation warnings remain, but the missing-file failure is gone.
- `mix format --check-formatted mix.exs` passed.
- Reviewer gate: PASS.
