### PR TITLE
fix(ui): align Catppuccin theme semantics

### DIFF
--- a/lib/minga_editor/renderer/gutter.ex
+++ b/lib/minga_editor/renderer/gutter.ex
@@ -225,8 +225,12 @@ defmodule MingaEditor.Renderer.Gutter do
 
   @spec number_and_color(non_neg_integer(), non_neg_integer(), line_number_style(), colors()) ::
           {non_neg_integer(), non_neg_integer()}
-  defp number_and_color(buf_line, _cursor_line, :absolute, colors) do
+  defp number_and_color(buf_line, cursor_line, :absolute, colors) when buf_line == cursor_line do
     {buf_line + 1, colors.current_fg}
+  end
+
+  defp number_and_color(buf_line, _cursor_line, :absolute, colors) do
+    {buf_line + 1, colors.fg}
   end
 
   defp number_and_color(buf_line, cursor_line, :relative, colors) do

--- a/lib/minga_editor/ui/theme/catppuccin.ex
+++ b/lib/minga_editor/ui/theme/catppuccin.ex
@@ -5,9 +5,10 @@ defmodule MingaEditor.UI.Theme.Catppuccin do
   Catppuccin is a community-driven pastel theme with four flavors:
   Latte (light), Frappe, Macchiato, and Mocha (darkest).
   Palette values sourced from https://github.com/catppuccin/catppuccin.
+
+  Catppuccin recommends overlay2 at 20% to 30% opacity for selection backgrounds. Minga theme colors are opaque RGB values, so this builder uses surface2 as the solid selection approximation.
   """
 
-  alias Minga.Core.Face
   alias MingaEditor.UI.Theme.Builder
   alias MingaEditor.UI.Theme.Palette
 
@@ -25,20 +26,20 @@ defmodule MingaEditor.UI.Theme.Catppuccin do
       fg: p.text,
       surface: p.surface0,
       overlay: p.mantle,
-      muted: p.overlay0,
+      muted: p.overlay1,
       subtle: p.surface1,
       accent: p.blue,
       highlight: p.blue,
       selection_bg: p.surface2,
       error: p.red,
       warning: p.yellow,
-      info: p.blue,
+      info: p.teal,
       success: p.green,
-      match: p.yellow,
-      link: p.rosewater,
+      match: p.teal,
+      link: p.blue,
       border: p.overlay1,
       contrast_fg: p.base,
-      builtin: p.teal,
+      builtin: p.red,
       functions: p.blue,
       keywords: p.mauve,
       methods: p.blue,
@@ -48,7 +49,7 @@ defmodule MingaEditor.UI.Theme.Catppuccin do
       numbers: p.peach,
       type: p.yellow,
       variables: p.text,
-      comments: p.overlay0
+      comments: p.overlay2
     })
   end
 
@@ -60,297 +61,26 @@ defmodule MingaEditor.UI.Theme.Catppuccin do
   defp overrides(p) do
     %{
       syntax: syntax(p),
-      hl_todo: %{
-        todo: Face.new(fg: p.yellow, bold: true),
-        fixme: Face.new(fg: p.red, bold: true),
-        note: Face.new(fg: p.blue, bold: true),
-        hack: Face.new(fg: p.peach, bold: true),
-        review: Face.new(fg: p.mauve, bold: true),
-        deprecated: Face.new(fg: p.overlay0, strikethrough: true)
-      },
-      editor: %{
-        bg: p.base,
-        fg: p.text,
-        tilde_fg: p.surface1,
-        split_border_fg: p.surface1,
-        cursorline_bg: p.surface0,
-        nav_flash_bg: p.surface1,
-        yank_flash_bg: p.surface1,
-        highlight_read_bg: p.surface1,
-        highlight_write_bg: p.surface2,
-        selection_bg: p.surface2,
-        whitespace_fg: p.overlay0,
-        indent_guide_fg: p.surface1,
-        indent_guide_active_fg: p.overlay0
-      },
-      gutter: %{
-        fg: p.overlay0,
-        current_fg: p.text,
-        error_fg: p.red,
-        warning_fg: p.yellow,
-        info_fg: p.blue,
-        hint_fg: p.overlay0,
-        fold_fg: p.overlay0,
-        separator_fg: p.overlay0
-      },
-      git: %{added_fg: p.green, modified_fg: p.blue, deleted_fg: p.red},
-      modeline: %{
-        bar_fg: p.text,
-        bar_bg: p.mantle,
-        info_fg: p.text,
-        info_bg: p.surface0,
-        filetype_fg: p.green,
-        mode_colors: %{
-          normal: {p.base, p.blue},
-          insert: {p.base, p.green},
-          visual: {p.base, p.mauve},
-          operator_pending: {p.base, p.peach},
-          command: {p.base, p.yellow},
-          replace: {p.base, p.red},
-          search: {p.base, p.sky}
-        },
-        lsp_ready: p.green,
-        lsp_initializing: p.yellow,
-        lsp_starting: p.overlay0,
-        lsp_error: p.red
-      },
-      picker: %{
-        bg: p.mantle,
-        sel_bg: p.surface1,
-        prompt_bg: p.mantle,
-        dim_fg: p.overlay0,
-        text_fg: p.text,
-        highlight_fg: p.lavender,
-        match_fg: p.yellow,
-        border_fg: p.blue,
-        menu_bg: p.base,
-        menu_fg: p.text,
-        menu_sel_bg: p.surface1,
-        menu_sel_fg: p.lavender
-      },
-      minibuffer: %{fg: p.text, bg: p.crust, warning_fg: p.yellow, dim_fg: p.overlay0},
-      search: %{highlight_fg: p.base, highlight_bg: p.yellow, current_bg: p.red},
-      popup: %{
-        fg: p.text,
-        bg: p.surface0,
-        border_fg: p.overlay1,
-        sel_fg: p.base,
-        sel_bg: p.blue,
-        title_fg: p.blue,
-        key_fg: p.teal,
-        separator_fg: p.overlay0,
-        group_fg: p.blue
-      },
-      tree: %{
-        bg: p.mantle,
-        fg: p.text,
-        dir_fg: p.blue,
-        active_fg: p.green,
-        cursor_bg: p.surface0,
-        header_fg: p.blue,
-        header_bg: p.mantle,
-        separator_fg: p.surface1,
-        modified_fg: p.peach,
-        git_modified_fg: p.peach,
-        git_staged_fg: p.green,
-        git_untracked_fg: p.overlay0,
-        git_conflict_fg: p.red
-      },
-      agent: %{
-        panel_bg: p.base,
-        panel_border: p.surface1,
-        header_fg: p.blue,
-        header_bg: p.mantle,
-        user_border: p.blue,
-        user_label: p.blue,
-        assistant_border: p.green,
-        assistant_label: p.green,
-        tool_border: p.yellow,
-        tool_header: p.yellow,
-        code_bg: p.mantle,
-        code_border: p.surface1,
-        input_border: p.blue,
-        input_bg: p.base,
-        input_placeholder: p.overlay0,
-        thinking_fg: p.yellow,
-        status_thinking: p.yellow,
-        status_tool: p.sky,
-        status_error: p.red,
-        status_idle: p.overlay0,
-        text_fg: p.text,
-        context_low: p.green,
-        context_mid: p.yellow,
-        context_high: p.red,
-        usage_fg: p.overlay0,
-        toast_bg: p.surface0,
-        toast_fg: p.text,
-        toast_border: p.overlay1,
-        system_fg: p.overlay1,
-        search_match_bg: p.yellow,
-        search_current_bg: p.red,
-        hint_fg: p.overlay0,
-        heading1_fg: p.mauve,
-        heading2_fg: p.blue,
-        heading3_fg: p.green,
-        dashboard_label: p.blue,
-        delimiter_dim: p.surface0,
-        link_fg: p.blue
-      },
-      dashboard: %{
-        bg: p.base,
-        logo_fg: p.yellow,
-        heading_fg: p.blue,
-        item_fg: p.text,
-        item_active_bg: p.surface0,
-        shortcut_fg: p.green,
-        muted_fg: p.overlay0
-      },
-      tab_bar: %{
-        active_fg: p.text,
-        active_bg: p.base,
-        inactive_fg: p.overlay0,
-        inactive_bg: p.mantle,
-        separator_fg: p.surface0,
-        modified_fg: p.peach,
-        attention_fg: p.red,
-        close_hover_fg: p.red,
-        bg: p.mantle
-      }
+      gutter: %{current_fg: p.lavender}
     }
   end
 
   @spec syntax(map()) :: MingaEditor.UI.Theme.syntax()
   defp syntax(p) do
     %{
-      # ── Keywords ────────────────────────────────────────────────────────
-      "keyword" => [fg: p.mauve, bold: true],
-      "keyword.function" => [fg: p.mauve, bold: true],
-      "keyword.operator" => [fg: p.mauve],
-      "keyword.return" => [fg: p.mauve, bold: true],
-      "keyword.conditional" => [fg: p.mauve, bold: true],
-      "keyword.coroutine" => [fg: p.mauve, bold: true],
-      "keyword.directive" => [fg: p.mauve],
-      "keyword.exception" => [fg: p.mauve],
-      "keyword.import" => [fg: p.mauve],
-      "keyword.modifier" => [fg: p.mauve, bold: true],
-      "keyword.repeat" => [fg: p.mauve, bold: true],
-      "keyword.type" => [fg: p.mauve, bold: true],
-      "conditional" => [fg: p.mauve, bold: true],
-      "exception" => [fg: p.mauve],
-      "include" => [fg: p.mauve],
-      "import" => [fg: p.mauve],
-      "repeat" => [fg: p.mauve, bold: true],
-
-      # ── Strings ─────────────────────────────────────────────────────────
-      "string" => [fg: p.green],
-      "string.special" => [fg: p.peach],
-      "string.special.symbol" => [fg: p.flamingo],
-      "string.special.key" => [fg: p.blue],
-      "string.special.regex" => [fg: p.peach],
+      "string.special.regex" => [fg: p.pink],
       "string.escape" => [fg: p.pink],
-      "string.regex" => [fg: p.peach],
-      "character" => [fg: p.teal],
-
-      # ── Comments ────────────────────────────────────────────────────────
-      "comment" => [fg: p.overlay0, italic: true],
-      "comment.doc" => [fg: p.overlay1, italic: true],
-      "comment.documentation" => [fg: p.overlay1, italic: true],
-      "comment.unused" => [fg: p.overlay0, italic: true],
-      "comment.discard" => [fg: p.overlay0, italic: true],
-
-      # ── Functions ───────────────────────────────────────────────────────
-      "function" => [fg: p.blue],
-      "function.call" => [fg: p.blue],
-      "function.builtin" => [fg: p.teal],
-      "function.macro" => [fg: p.mauve, bold: true],
-      "function.method" => [fg: p.blue],
-      "function.method.builtin" => [fg: p.teal],
-      "function.special" => [fg: p.mauve],
-      "method" => [fg: p.blue],
-      "method.call" => [fg: p.blue],
-
-      # ── Types ───────────────────────────────────────────────────────────
-      "type" => [fg: p.yellow],
-      "type.builtin" => [fg: p.yellow, bold: true],
-
-      # ── Variables ───────────────────────────────────────────────────────
-      "variable" => [fg: p.text],
-      "variable.builtin" => [fg: p.red],
+      "string.regex" => [fg: p.pink],
+      "character" => [fg: p.red],
       "variable.parameter" => [fg: p.maroon],
-      "variable.member" => [fg: p.teal],
+      "variable.member" => [fg: p.blue],
       "parameter" => [fg: p.maroon],
-      "field" => [fg: p.teal],
-
-      # ── Constants & numbers ─────────────────────────────────────────────
-      "constant" => [fg: p.peach],
-      "constant.builtin" => [fg: p.peach, bold: true],
-      "boolean" => [fg: p.peach, bold: true],
-      "number" => [fg: p.peach],
-      "number.float" => [fg: p.peach],
-      "float" => [fg: p.peach],
-
-      # ── Operators & punctuation ─────────────────────────────────────────
-      "operator" => [fg: p.sky],
-      "punctuation" => [fg: p.overlay2],
-      "punctuation.bracket" => [fg: p.overlay2],
-      "punctuation.delimiter" => [fg: p.overlay2],
-      "punctuation.special" => [fg: p.sky],
-      "delimiter" => [fg: p.overlay2],
-
-      # ── Modules & namespaces ────────────────────────────────────────────
-      "module" => [fg: p.yellow],
-      "namespace" => [fg: p.yellow],
-
-      # ── Attributes & properties ─────────────────────────────────────────
-      "attribute" => [fg: p.teal],
-      "property" => [fg: p.teal],
-      "label" => [fg: p.sapphire],
-
-      # ── Tags (HTML/XML) ────────────────────────────────────────────────
-      "tag" => [fg: p.mauve],
+      "field" => [fg: p.blue],
+      "attribute" => [fg: p.yellow],
+      "property" => [fg: p.blue],
       "tag.attribute" => [fg: p.yellow],
-      "tag.error" => [fg: p.red, bold: true],
-
-      # ── Preprocessor ───────────────────────────────────────────────────
-      "preproc" => [fg: p.pink, bold: true],
-
-      # ── Markup (nvim-treesitter / tree-sitter standard) ────────────────
-      "markup.heading" => [fg: p.red, bold: true],
-      "markup.heading.1" => [fg: p.red, bold: true],
-      "markup.heading.2" => [fg: p.peach, bold: true],
-      "markup.heading.3" => [fg: p.yellow, bold: true],
-      "markup.heading.4" => [fg: p.green, bold: true],
-      "markup.heading.5" => [fg: p.blue, bold: true],
-      "markup.heading.6" => [fg: p.mauve, bold: true],
-      "markup.bold" => [fg: p.peach, bold: true],
-      "markup.strong" => [fg: p.peach, bold: true],
-      "markup.italic" => [fg: p.maroon, italic: true],
-      "markup.strikethrough" => [fg: p.overlay0, strikethrough: true],
-      "markup.raw" => [fg: p.green],
-      "markup.raw.block" => [fg: p.green],
-      "markup.raw.inline" => [fg: p.green],
-      "markup.link" => [fg: p.rosewater],
-      "markup.link.url" => [fg: p.rosewater, underline: true],
-      "markup.link.label" => [fg: p.blue],
-      "markup.list" => [fg: p.red],
-      "markup.list.numbered" => [fg: p.red],
-      "markup.list.unnumbered" => [fg: p.red],
-      "markup.list.checked" => [fg: p.green],
-      "markup.list.unchecked" => [fg: p.overlay0],
-      "markup.quote" => [fg: p.overlay1, italic: true],
-
-      # ── CSS-specific ───────────────────────────────────────────────────
-      "charset" => [fg: p.mauve, bold: true],
-      "keyframes" => [fg: p.mauve, bold: true],
-      "media" => [fg: p.mauve, bold: true],
-      "supports" => [fg: p.mauve, bold: true],
-
-      # ── Misc ───────────────────────────────────────────────────────────
       "escape" => [fg: p.pink],
-      "embedded" => [fg: p.text],
-      "constructor" => [fg: p.sapphire, bold: true],
-      "error" => [fg: p.red, bold: true],
-      "warning" => [fg: p.yellow, bold: true]
+      "constructor" => [fg: p.sapphire, bold: true]
     }
   end
 end

--- a/test/minga_editor/renderer/gutter_test.exs
+++ b/test/minga_editor/renderer/gutter_test.exs
@@ -138,6 +138,28 @@ defmodule MingaEditor.Renderer.GutterTest do
       assert is_tuple(result)
     end
 
+    test "absolute line numbers use the active color only on the cursor line" do
+      current = Gutter.render_number(0, 0, 5, 5, 4, :absolute, @colors)
+      other = Gutter.render_number(1, 0, 4, 5, 4, :absolute, @colors)
+
+      current_fg = @colors.current_fg
+      regular_fg = @colors.fg
+
+      assert %{text: "  6", fg: ^current_fg} = decode_draw(current)
+      assert %{text: "  5", fg: ^regular_fg} = decode_draw(other)
+    end
+
+    test "hybrid line numbers keep relative lines dim and cursor line active" do
+      current = Gutter.render_number(0, 0, 5, 5, 4, :hybrid, @colors)
+      other = Gutter.render_number(1, 0, 4, 5, 4, :hybrid, @colors)
+
+      current_fg = @colors.current_fg
+      regular_fg = @colors.fg
+
+      assert %{text: "  6", fg: ^current_fg} = decode_draw(current)
+      assert %{text: "  1", fg: ^regular_fg} = decode_draw(other)
+    end
+
     test "returns empty for :none style with zero width" do
       assert Gutter.render_number(0, 0, 5, 5, 0, :none, @colors) == []
     end

--- a/test/minga_editor/ui/theme/builder_test.exs
+++ b/test/minga_editor/ui/theme/builder_test.exs
@@ -79,24 +79,6 @@ defmodule MingaEditor.UI.Theme.BuilderTest do
     end
   end
 
-  describe "Catppuccin migration" do
-    for theme_name <- [
-          :catppuccin_mocha,
-          :catppuccin_latte,
-          :catppuccin_frappe,
-          :catppuccin_macchiato
-        ] do
-      test "#{theme_name} matches the legacy hand-wired theme byte-for-byte" do
-        legacy =
-          "test/fixtures/theme/#{unquote(theme_name)}.term"
-          |> File.read!()
-          |> :erlang.binary_to_term()
-
-        assert Theme.get!(unquote(theme_name)) == legacy
-      end
-    end
-  end
-
   @spec sample_palette() :: Palette.t()
   defp sample_palette do
     Palette.new(%{

--- a/test/minga_editor/ui/theme/catppuccin_test.exs
+++ b/test/minga_editor/ui/theme/catppuccin_test.exs
@@ -1,0 +1,180 @@
+defmodule MingaEditor.UI.Theme.CatppuccinTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.UI.Theme
+
+  @official_palettes %{
+    catppuccin_latte: %{
+      source: "lib/minga_editor/ui/theme/catppuccin_latte.ex",
+      values: %{
+        rosewater: 0xDC8A78,
+        flamingo: 0xDD7878,
+        pink: 0xEA76CB,
+        mauve: 0x8839EF,
+        red: 0xD20F39,
+        maroon: 0xE64553,
+        peach: 0xFE640B,
+        yellow: 0xDF8E1D,
+        green: 0x40A02B,
+        teal: 0x179299,
+        sky: 0x04A5E5,
+        sapphire: 0x209FB5,
+        blue: 0x1E66F5,
+        lavender: 0x7287FD,
+        text: 0x4C4F69,
+        subtext1: 0x5C5F77,
+        subtext0: 0x6C6F85,
+        overlay2: 0x7C7F93,
+        overlay1: 0x8C8FA1,
+        overlay0: 0x9CA0B0,
+        surface2: 0xACB0BE,
+        surface1: 0xBCC0CC,
+        surface0: 0xCCD0DA,
+        base: 0xEFF1F5,
+        mantle: 0xE6E9EF,
+        crust: 0xDCE0E8
+      }
+    },
+    catppuccin_frappe: %{
+      source: "lib/minga_editor/ui/theme/catppuccin_frappe.ex",
+      values: %{
+        rosewater: 0xF2D5CF,
+        flamingo: 0xEEBEBE,
+        pink: 0xF4B8E4,
+        mauve: 0xCA9EE6,
+        red: 0xE78284,
+        maroon: 0xEA999C,
+        peach: 0xEF9F76,
+        yellow: 0xE5C890,
+        green: 0xA6D189,
+        teal: 0x81C8BE,
+        sky: 0x99D1DB,
+        sapphire: 0x85C1DC,
+        blue: 0x8CAAEE,
+        lavender: 0xBABBF1,
+        text: 0xC6D0F5,
+        subtext1: 0xB5BFE2,
+        subtext0: 0xA5ADCE,
+        overlay2: 0x949CBB,
+        overlay1: 0x838BA7,
+        overlay0: 0x737994,
+        surface2: 0x626880,
+        surface1: 0x51576D,
+        surface0: 0x414559,
+        base: 0x303446,
+        mantle: 0x292C3C,
+        crust: 0x232634
+      }
+    },
+    catppuccin_macchiato: %{
+      source: "lib/minga_editor/ui/theme/catppuccin_macchiato.ex",
+      values: %{
+        rosewater: 0xF4DBD6,
+        flamingo: 0xF0C6C6,
+        pink: 0xF5BDE6,
+        mauve: 0xC6A0F6,
+        red: 0xED8796,
+        maroon: 0xEE99A0,
+        peach: 0xF5A97F,
+        yellow: 0xEED49F,
+        green: 0xA6DA95,
+        teal: 0x8BD5CA,
+        sky: 0x91D7E3,
+        sapphire: 0x7DC4E4,
+        blue: 0x8AADF4,
+        lavender: 0xB7BDF8,
+        text: 0xCAD3F5,
+        subtext1: 0xB8C0E0,
+        subtext0: 0xA5ADCB,
+        overlay2: 0x939AB7,
+        overlay1: 0x8087A2,
+        overlay0: 0x6E738D,
+        surface2: 0x5B6078,
+        surface1: 0x494D64,
+        surface0: 0x363A4F,
+        base: 0x24273A,
+        mantle: 0x1E2030,
+        crust: 0x181926
+      }
+    },
+    catppuccin_mocha: %{
+      source: "lib/minga_editor/ui/theme/catppuccin_mocha.ex",
+      values: %{
+        rosewater: 0xF5E0DC,
+        flamingo: 0xF2CDCD,
+        pink: 0xF5C2E7,
+        mauve: 0xCBA6F7,
+        red: 0xF38BA8,
+        maroon: 0xEBA0AC,
+        peach: 0xFAB387,
+        yellow: 0xF9E2AF,
+        green: 0xA6E3A1,
+        teal: 0x94E2D5,
+        sky: 0x89DCEB,
+        sapphire: 0x74C7EC,
+        blue: 0x89B4FA,
+        lavender: 0xB4BEFE,
+        text: 0xCDD6F4,
+        subtext1: 0xBAC2DE,
+        subtext0: 0xA6ADC8,
+        overlay2: 0x9399B2,
+        overlay1: 0x7F849C,
+        overlay0: 0x6C7086,
+        surface2: 0x585B70,
+        surface1: 0x45475A,
+        surface0: 0x313244,
+        base: 0x1E1E2E,
+        mantle: 0x181825,
+        crust: 0x11111B
+      }
+    }
+  }
+
+  describe "official palette values" do
+    for {theme_name, %{source: source, values: values}} <- @official_palettes do
+      test "#{theme_name} palette constants match Catppuccin palette JSON" do
+        assert source_palette(unquote(source)) == unquote(Macro.escape(values))
+      end
+    end
+  end
+
+  describe "style guide semantics" do
+    for {theme_name, %{values: values}} <- @official_palettes do
+      test "#{theme_name} maps syntax and UI colors through Catppuccin semantics" do
+        theme = Theme.get!(unquote(theme_name))
+        p = unquote(Macro.escape(values))
+
+        assert theme.editor.bg == p.base
+        assert theme.editor.fg == p.text
+        assert theme.editor.selection_bg == p.surface2
+        assert theme.gutter.fg == p.overlay1
+        assert theme.gutter.current_fg == p.lavender
+        assert theme.gutter.info_fg == p.teal
+        assert theme.search.highlight_bg == p.teal
+        assert theme.search.current_bg == p.red
+        assert theme.popup.sel_bg == p.surface2
+        assert theme.popup.title_fg == p.blue
+        assert theme.agent.link_fg == p.blue
+        assert theme.syntax["markup.link"] == [fg: p.blue]
+        assert theme.syntax["function.builtin"] == [fg: p.red]
+        assert theme.syntax["comment"] == [fg: p.overlay2, italic: true]
+        assert theme.syntax["string.regex"] == [fg: p.pink]
+        assert theme.syntax["string.escape"] == [fg: p.pink]
+        assert theme.syntax["string.special.symbol"] == [fg: p.red]
+        assert theme.syntax["character"] == [fg: p.red]
+        assert theme.syntax["variable.parameter"] == [fg: p.maroon]
+        assert theme.syntax["property"] == [fg: p.blue]
+        assert theme.syntax["attribute"] == [fg: p.yellow]
+      end
+    end
+  end
+
+  defp source_palette(path) do
+    path
+    |> File.read!()
+    |> then(&Regex.scan(~r/(\w+): 0x([0-9A-F]{6})/, &1))
+    |> Map.new(fn [_match, key, value] ->
+      {String.to_existing_atom(key), String.to_integer(value, 16)}
+    end)
+  end
+end


### PR DESCRIPTION
# TL;DR

Catppuccin themes now keep the official palette values while deriving their UI and syntax colors from the semantic theme layer. The shared builder aligns links, builtins, comments, info, search, gutter line numbers, regex, symbols, parameters, properties, and attributes with the Catppuccin style guide.

Closes #1737

## Context

#1737 follows the upstream theme audit in #1727. The palette values were already correct, so this PR focuses on semantic assignments and removes the old hand-wired Catppuccin UI override map.

## Changes

- Reworked the shared Catppuccin builder to rely on `Theme.Builder.from_palette/3` cascade defaults, with only necessary syntax and active-line-number overrides.
- Updated Catppuccin semantic slots to match the style guide: blue links, red builtins, overlay2 comments, teal info/search, pink regex/escapes, red symbols, maroon parameters, blue properties, and yellow XML attributes.
- Documented the selection-background deviation: Catppuccin recommends overlay2 with alpha, but Minga theme fields are opaque RGB, so the builder uses surface2 as the solid approximation.
- Fixed absolute gutter line-number rendering so only the cursor line uses `current_fg`; non-cursor absolute line numbers use regular gutter `fg`.
- Replaced the old byte-for-byte Catppuccin migration test with palette exactness and representative semantic mapping tests.

## Verification

- `mix test.debug test/minga_editor/renderer/gutter_test.exs test/minga_editor/ui/theme/catppuccin_test.exs test/minga_editor/ui/theme/builder_test.exs` ✅
- `mix test.llm test/minga_editor/ui/theme test/minga_editor/renderer/gutter_test.exs` ✅
- `make lint` ✅
- `mix test.llm` ✅, 9010 tests, 52 doctests, 99 properties, 0 failures
- Final reviewer gate passed after a targeted re-review of the test-advisor process blocker.

## Acceptance Criteria Addressed

- Catppuccin Latte, Frappé, Macchiato, and Mocha keep exact official palette values ✅
- The shared Catppuccin builder uses the semantic theme layer for cascade defaults, with only necessary overrides ✅
- Semantic assignments follow the Catppuccin style guide ✅
- Minga-specific selection-background deviation is documented ✅
