### PR TITLE
refactor(command): add provider declaration DSL

### DIFF
--- a/lib/minga_editor/commands/agent_group.ex
+++ b/lib/minga_editor/commands/agent_group.ex
@@ -7,7 +7,7 @@ defmodule MingaEditor.Commands.AgentGroup do
   context is restored. Never mutate `tab_bar.active_id` directly.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.TabBar
@@ -118,42 +118,21 @@ defmodule MingaEditor.Commands.AgentGroup do
     end
   end
 
-  @workspace_command_specs [
-    {:agent_group_next, "Next workspace", :agent_group_next},
-    {:agent_group_prev, "Previous workspace", :agent_group_prev},
-    # Kept as a command alias for the existing SPC TAB A default binding.
-    {:agent_group_next_agent, "Next agent workspace", :agent_group_next},
-    {:ungrouped_tabs, "Switch to my tabs", :switch_to_ungrouped},
-    {:agent_group_toggle, "Toggle last workspace", :agent_group_toggle},
-    {:agent_group_close, "Close workspace", :agent_group_close},
-    {:agent_group_list, "List agent groups", :agent_group_list},
-    {:agent_group_rename, "Rename workspace", :agent_group_rename},
-    {:agent_group_set_icon, "Set workspace icon", :agent_group_set_icon}
-  ]
+  command(:agent_group_next, "Next workspace", execute: &agent_group_next/1)
+  command(:agent_group_prev, "Previous workspace", execute: &agent_group_prev/1)
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    dispatched =
-      Enum.map(@workspace_command_specs, fn {cmd_name, desc, fun_name} ->
-        %Minga.Command{
-          name: cmd_name,
-          description: desc,
-          requires_buffer: false,
-          execute: fn state -> apply(__MODULE__, fun_name, [state]) end
-        }
-      end)
+  # Kept as a command alias for the existing SPC TAB A default binding.
+  command(:agent_group_next_agent, "Next agent workspace", execute: &agent_group_next/1)
 
-    # Numbered workspace jumps (SPC TAB 1..9)
-    numbered =
-      for n <- 1..9 do
-        %Minga.Command{
-          name: :"workspace_goto_#{n}",
-          description: "Workspace #{n}",
-          requires_buffer: false,
-          execute: fn state -> workspace_goto(state, n) end
-        }
-      end
+  command(:ungrouped_tabs, "Switch to my tabs", execute: &switch_to_ungrouped/1)
+  command(:agent_group_toggle, "Toggle last workspace", execute: &agent_group_toggle/1)
+  command(:agent_group_close, "Close workspace", execute: &agent_group_close/1)
+  command(:agent_group_list, "List agent groups", execute: &agent_group_list/1)
+  command(:agent_group_rename, "Rename workspace", execute: &agent_group_rename/1)
+  command(:agent_group_set_icon, "Set workspace icon", execute: &agent_group_set_icon/1)
 
-    dispatched ++ numbered
-  end
+  numbered_commands(:workspace_goto, 1..9, "Workspace",
+    argument: :number,
+    execute: &workspace_goto/2
+  )
 end

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -4,7 +4,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   ex-command dispatch, and line number style cycling.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias MingaAgent.Session
   alias Minga.Buffer
@@ -1694,200 +1694,61 @@ defmodule MingaEditor.Commands.BufferManagement do
     end
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    standard = [
-      %Minga.Command{
-        name: :save,
-        description: "Save the current file",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :save) end
-      },
-      %Minga.Command{
-        name: :force_save,
-        description: "Force save the current file",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :force_save) end
-      },
-      %Minga.Command{
-        name: :reload,
-        description: "Reload file from disk",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :reload) end
-      },
-      %Minga.Command{
-        name: :quit,
-        description: "Close tab or quit",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :quit) end
-      },
-      %Minga.Command{
-        name: :force_quit,
-        description: "Force close tab or quit",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :force_quit) end
-      },
-      %Minga.Command{
-        name: :close_other_tabs,
-        description: "Close all tabs except the active tab",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :close_other_tabs) end
-      },
-      %Minga.Command{
-        name: :quit_all,
-        description: "Quit the editor (all tabs)",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :quit_all) end
-      },
-      %Minga.Command{
-        name: :force_quit_all,
-        description: "Force quit the editor (all tabs)",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :force_quit_all) end
-      },
-      %Minga.Command{
-        name: :abort_quit,
-        description: "Abort and quit with error exit code",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :abort_quit) end
-      },
-      %Minga.Command{
-        name: :confirm_quit_yes,
-        description: "Confirm quit (yes)",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :confirm_quit_yes) end
-      },
-      %Minga.Command{
-        name: :confirm_quit_no,
-        description: "Confirm quit (no)",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :confirm_quit_no) end
-      },
-      %Minga.Command{
-        name: :buffer_list,
-        description: "Switch buffer",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :buffer_list) end
-      },
-      %Minga.Command{
-        name: :buffer_list_all,
-        description: "Switch buffer (all)",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :buffer_list_all) end
-      },
-      %Minga.Command{
-        name: :buffer_next,
-        description: "Next buffer",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :buffer_next) end
-      },
-      %Minga.Command{
-        name: :buffer_prev,
-        description: "Previous buffer",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :buffer_prev) end
-      },
-      %Minga.Command{
-        name: :kill_buffer,
-        description: "Kill current buffer",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :kill_buffer) end
-      },
-      %Minga.Command{
-        name: :view_messages,
-        description: "Show messages in bottom panel",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :view_messages) end
-      },
-      %Minga.Command{
-        name: :view_warnings,
-        description: "Show warnings in bottom panel",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :view_warnings) end
-      },
-      %Minga.Command{
-        name: :open_config,
-        description: "Open config file",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :open_config) end
-      },
-      %Minga.Command{
-        name: :tab_next,
-        description: "Next tab",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :tab_next) end
-      },
-      %Minga.Command{
-        name: :tab_prev,
-        description: "Previous tab",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :tab_prev) end
-      },
-      %Minga.Command{
-        name: :new_buffer,
-        description: "Create new empty buffer",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :new_buffer) end
-      },
-      %Minga.Command{
-        name: :reload_config,
-        description: "Reload config",
-        requires_buffer: true,
-        execute: &reload_config/1
-      },
-      %Minga.Command{
-        name: :alternate_file,
-        description: "Switch to alternate file",
-        requires_buffer: true,
-        execute: &alternate_file/1
-      }
-    ]
+  command(:save, "Save the current file", requires_buffer: true)
+  command(:force_save, "Force save the current file", requires_buffer: true)
+  command(:reload, "Reload file from disk", requires_buffer: true)
+  command(:quit, "Close tab or quit", requires_buffer: true)
+  command(:force_quit, "Force close tab or quit", requires_buffer: true)
+  command(:close_other_tabs, "Close all tabs except the active tab", requires_buffer: true)
+  command(:quit_all, "Quit the editor (all tabs)", requires_buffer: true)
+  command(:force_quit_all, "Force quit the editor (all tabs)", requires_buffer: true)
+  command(:abort_quit, "Abort and quit with error exit code", requires_buffer: false)
+  command(:confirm_quit_yes, "Confirm quit (yes)", requires_buffer: true)
+  command(:confirm_quit_no, "Confirm quit (no)", requires_buffer: true)
+  command(:buffer_list, "Switch buffer", requires_buffer: true)
+  command(:buffer_list_all, "Switch buffer (all)", requires_buffer: true)
+  command(:buffer_next, "Next buffer", requires_buffer: true)
+  command(:buffer_prev, "Previous buffer", requires_buffer: true)
+  command(:kill_buffer, "Kill current buffer", requires_buffer: true)
+  command(:view_messages, "Show messages in bottom panel", requires_buffer: false)
+  command(:view_warnings, "Show warnings in bottom panel", requires_buffer: false)
+  command(:open_config, "Open config file", requires_buffer: true)
+  command(:tab_next, "Next tab", requires_buffer: true)
+  command(:tab_prev, "Previous tab", requires_buffer: true)
+  command(:new_buffer, "Create new empty buffer", requires_buffer: false)
+  command(:reload_config, "Reload config", requires_buffer: true, execute: &reload_config/1)
 
-    tabs =
-      for n <- 1..9 do
-        cmd = String.to_atom("tab_goto_#{n}")
+  command(:alternate_file, "Switch to alternate file",
+    requires_buffer: true,
+    execute: &alternate_file/1
+  )
 
-        %Minga.Command{
-          name: cmd,
-          description: "Switch to tab #{n}",
-          requires_buffer: true,
-          execute: fn state -> tab_goto(state, cmd) end
-        }
-      end
+  numbered_commands(:tab_goto, 1..9, "Switch to tab",
+    requires_buffer: true,
+    execute: &tab_goto/2
+  )
 
-    scoped = [
-      %Minga.Command{
-        name: :cycle_line_numbers,
-        description: "Cycle line number style (hybrid → absolute → relative → none)",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :cycle_line_numbers) end,
-        option_toggle:
-          {:line_numbers,
-           fn
-             :hybrid -> :absolute
-             :absolute -> :relative
-             :relative -> :none
-             :none -> :hybrid
-           end}
-      },
-      %Minga.Command{
-        name: :toggle_wrap,
-        description: "Toggle word wrap",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :toggle_wrap) end,
-        option_toggle: :wrap
-      },
-      %Minga.Command{
-        name: :toggle_invisible,
-        description: "Toggle invisible characters",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :toggle_invisible) end,
-        option_toggle: :show_invisible
-      }
-    ]
+  command(:cycle_line_numbers, "Cycle line number style (hybrid → absolute → relative → none)",
+    requires_buffer: true,
+    option_toggle:
+      {:line_numbers,
+       fn
+         :hybrid -> :absolute
+         :absolute -> :relative
+         :relative -> :none
+         :none -> :hybrid
+       end}
+  )
 
-    standard ++ tabs ++ scoped
-  end
+  command(:toggle_wrap, "Toggle word wrap",
+    requires_buffer: true,
+    option_toggle: :wrap
+  )
+
+  command(:toggle_invisible, "Toggle invisible characters",
+    requires_buffer: true,
+    option_toggle: :show_invisible
+  )
 
   # ── Frontend dispatch ─────────────────────────────────────────────────────
 

--- a/lib/minga_editor/commands/diagnostics.ex
+++ b/lib/minga_editor/commands/diagnostics.ex
@@ -6,7 +6,7 @@ defmodule MingaEditor.Commands.Diagnostics do
   Both wrap around at buffer boundaries.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias Minga.Diagnostics
@@ -95,15 +95,5 @@ defmodule MingaEditor.Commands.Diagnostics do
     end
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    Enum.map(@command_specs, fn {name, desc, requires_buffer} ->
-      %Minga.Command{
-        name: name,
-        description: desc,
-        requires_buffer: requires_buffer,
-        execute: fn state -> execute(state, name) end
-      }
-    end)
-  end
+  commands(@command_specs)
 end

--- a/lib/minga_editor/commands/dired.ex
+++ b/lib/minga_editor/commands/dired.ex
@@ -8,10 +8,9 @@ defmodule MingaEditor.Commands.Dired do
   directories.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
-  alias Minga.Command
   alias Minga.Dired
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
@@ -20,84 +19,18 @@ defmodule MingaEditor.Commands.Dired do
 
   @type state :: EditorState.t()
 
-  @impl Minga.Command.Provider
-  @spec __commands__() :: [Command.t()]
-  def __commands__ do
-    [
-      %Command{
-        name: :dired_open,
-        description: "Open directory (Dired)",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_open) end
-      },
-      %Command{
-        name: :dired_open_entry,
-        description: "Open file / enter directory",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_open_entry) end
-      },
-      %Command{
-        name: :dired_parent,
-        description: "Go to parent directory",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_parent) end
-      },
-      %Command{
-        name: :dired_close,
-        description: "Close directory buffer",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_close) end
-      },
-      %Command{
-        name: :dired_toggle_hidden,
-        description: "Toggle hidden files",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_toggle_hidden) end
-      },
-      %Command{
-        name: :dired_cycle_sort,
-        description: "Cycle sort order",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_cycle_sort) end
-      },
-      %Command{
-        name: :dired_toggle_details,
-        description: "Toggle detail columns",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_toggle_details) end
-      },
-      %Command{
-        name: :dired_open_external,
-        description: "Open with system application",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_open_external) end
-      },
-      %Command{
-        name: :dired_refresh,
-        description: "Refresh directory listing",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_refresh) end
-      },
-      %Command{
-        name: :dired_apply_changes,
-        description: "Apply directory changes",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_apply_changes) end
-      },
-      %Command{
-        name: :dired_confirm_apply,
-        description: "Confirm and apply changes",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_confirm_apply) end
-      },
-      %Command{
-        name: :dired_cancel_apply,
-        description: "Cancel pending changes",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :dired_cancel_apply) end
-      }
-    ]
-  end
+  command(:dired_open, "Open directory (Dired)", requires_buffer: false)
+  command(:dired_open_entry, "Open file / enter directory", requires_buffer: false)
+  command(:dired_parent, "Go to parent directory", requires_buffer: false)
+  command(:dired_close, "Close directory buffer", requires_buffer: false)
+  command(:dired_toggle_hidden, "Toggle hidden files", requires_buffer: false)
+  command(:dired_cycle_sort, "Cycle sort order", requires_buffer: false)
+  command(:dired_toggle_details, "Toggle detail columns", requires_buffer: false)
+  command(:dired_open_external, "Open with system application", requires_buffer: false)
+  command(:dired_refresh, "Refresh directory listing", requires_buffer: false)
+  command(:dired_apply_changes, "Apply directory changes", requires_buffer: false)
+  command(:dired_confirm_apply, "Confirm and apply changes", requires_buffer: false)
+  command(:dired_cancel_apply, "Cancel pending changes", requires_buffer: false)
 
   # ── Command dispatch ─────────────────────────────────────────────────────
 

--- a/lib/minga_editor/commands/editing.ex
+++ b/lib/minga_editor/commands/editing.ex
@@ -4,7 +4,7 @@ defmodule MingaEditor.Commands.Editing do
   case toggle, indent/dedent, undo/redo, and paste.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias Minga.Buffer.Document
@@ -1041,45 +1041,25 @@ defmodule MingaEditor.Commands.Editing do
     end
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    standard =
-      Enum.map(@command_specs, fn {name, desc, requires_buffer} ->
-        %Minga.Command{
-          name: name,
-          description: desc,
-          requires_buffer: requires_buffer,
-          execute: fn state -> execute(state, name) end
-        }
-      end)
+  commands(@command_specs)
 
-    aliases = [
-      %Minga.Command{
-        name: :toggle_comment_line,
-        description: "Toggle comment on line",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :comment_line) end
-      },
-      %Minga.Command{
-        name: :toggle_comment_selection,
-        description: "Toggle comment on selection",
-        requires_buffer: true,
-        execute: fn state -> execute(state, :comment_visual_selection) end
-      },
-      %Minga.Command{
-        name: :delete_chars_at,
-        description: "Delete character(s) at cursor and yank (x)",
-        requires_buffer: true,
-        execute: fn state -> execute(state, {:delete_chars_at, 1}) end
-      },
-      %Minga.Command{
-        name: :delete_chars_before,
-        description: "Delete character(s) before cursor and yank (X)",
-        requires_buffer: true,
-        execute: fn state -> execute(state, {:delete_chars_before, 1}) end
-      }
-    ]
+  command(:toggle_comment_line, "Toggle comment on line",
+    requires_buffer: true,
+    execute: fn state -> execute(state, :comment_line) end
+  )
 
-    standard ++ aliases
-  end
+  command(:toggle_comment_selection, "Toggle comment on selection",
+    requires_buffer: true,
+    execute: fn state -> execute(state, :comment_visual_selection) end
+  )
+
+  command(:delete_chars_at, "Delete character(s) at cursor and yank (x)",
+    requires_buffer: true,
+    execute: fn state -> execute(state, {:delete_chars_at, 1}) end
+  )
+
+  command(:delete_chars_before, "Delete character(s) before cursor and yank (X)",
+    requires_buffer: true,
+    execute: fn state -> execute(state, {:delete_chars_before, 1}) end
+  )
 end

--- a/lib/minga_editor/commands/extensions.ex
+++ b/lib/minga_editor/commands/extensions.ex
@@ -3,7 +3,7 @@ defmodule MingaEditor.Commands.Extensions do
   Extension management commands: list, update, and inspect extensions.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
@@ -85,39 +85,22 @@ defmodule MingaEditor.Commands.Extensions do
     end
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    [
-      %Minga.Command{
-        name: :extension_list,
-        description: "List extensions",
-        requires_buffer: true,
-        execute: &list/1
-      },
-      %Minga.Command{
-        name: :extension_update_all,
-        description: "Check all extension updates",
-        requires_buffer: true,
-        execute: &update_all/1
-      },
-      %Minga.Command{
-        name: :extension_update,
-        description: "Update extension",
-        requires_buffer: true,
-        execute: &update/1
-      },
-      %Minga.Command{
-        name: :apply_extension_updates,
-        description: "Apply extension updates",
-        requires_buffer: true,
-        execute: &apply_updates/1
-      },
-      %Minga.Command{
-        name: :extension_confirm_details,
-        description: "Extension update details",
-        requires_buffer: true,
-        execute: &confirm_details/1
-      }
-    ]
-  end
+  command(:extension_list, "List extensions", requires_buffer: true, execute: &list/1)
+
+  command(:extension_update_all, "Check all extension updates",
+    requires_buffer: true,
+    execute: &update_all/1
+  )
+
+  command(:extension_update, "Update extension", requires_buffer: true, execute: &update/1)
+
+  command(:apply_extension_updates, "Apply extension updates",
+    requires_buffer: true,
+    execute: &apply_updates/1
+  )
+
+  command(:extension_confirm_details, "Extension update details",
+    requires_buffer: true,
+    execute: &confirm_details/1
+  )
 end

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -4,7 +4,7 @@ defmodule MingaEditor.Commands.FileTree do
   expanding/collapsing directories, and opening files from the tree.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias MingaEditor.Commands
@@ -1334,165 +1334,104 @@ defmodule MingaEditor.Commands.FileTree do
     end
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    [
-      %Minga.Command{
-        name: :toggle_file_tree,
-        description: "Toggle file tree",
-        requires_buffer: false,
-        execute: &toggle/1
-      },
-      %Minga.Command{
-        name: :tree_open_or_toggle,
-        description: "Open file or toggle directory",
-        requires_buffer: false,
-        execute: &open_or_toggle/1
-      },
-      %Minga.Command{
-        name: :tree_toggle_directory,
-        description: "Toggle directory in tree",
-        requires_buffer: false,
-        execute: &toggle_directory/1
-      },
-      %Minga.Command{
-        name: :tree_expand,
-        description: "Expand tree node",
-        requires_buffer: false,
-        execute: &expand/1
-      },
-      %Minga.Command{
-        name: :tree_collapse,
-        description: "Collapse tree node",
-        requires_buffer: false,
-        execute: &collapse/1
-      },
-      %Minga.Command{
-        name: :tree_toggle_hidden,
-        description: "Toggle hidden files in tree",
-        requires_buffer: false,
-        execute: &toggle_hidden/1
-      },
-      %Minga.Command{
-        name: :tree_refresh,
-        description: "Refresh file tree",
-        requires_buffer: false,
-        execute: &refresh/1
-      },
-      %Minga.Command{
-        name: :tree_copy_path,
-        description: "Copy file tree path",
-        requires_buffer: false,
-        execute: &copy_path/1
-      },
-      %Minga.Command{
-        name: :tree_mark_copy,
-        description: "Mark file tree entry for copy",
-        requires_buffer: false,
-        execute: &mark_copy/1
-      },
-      %Minga.Command{
-        name: :tree_mark_move,
-        description: "Mark file tree entry for move",
-        requires_buffer: false,
-        execute: &mark_move/1
-      },
-      %Minga.Command{
-        name: :tree_paste,
-        description: "Paste marked file tree entry",
-        requires_buffer: false,
-        execute: &paste/1
-      },
-      %Minga.Command{
-        name: :tree_root_parent,
-        description: "Root file tree at parent directory",
-        requires_buffer: false,
-        execute: &root_parent/1
-      },
-      %Minga.Command{
-        name: :tree_root_selected,
-        description: "Root file tree at selected directory",
-        requires_buffer: false,
-        execute: &root_selected/1
-      },
-      %Minga.Command{
-        name: :tree_root_original,
-        description: "Restore file tree project root",
-        requires_buffer: false,
-        execute: &root_original/1
-      },
-      %Minga.Command{
-        name: :tree_filter,
-        description: "Filter file tree",
-        requires_buffer: false,
-        execute: &filter/1
-      },
-      %Minga.Command{
-        name: :tree_toggle_help,
-        description: "Toggle file tree help",
-        requires_buffer: false,
-        execute: &toggle_help/1
-      },
-      %Minga.Command{
-        name: :tree_close,
-        description: "Close file tree",
-        requires_buffer: false,
-        execute: &close/1
-      },
-      %Minga.Command{
-        name: :tree_collapse_all,
-        description: "Collapse all directories in tree",
-        requires_buffer: false,
-        execute: &collapse_all/1
-      },
-      %Minga.Command{
-        name: :tree_new_file,
-        description: "Create new file in tree",
-        requires_buffer: false,
-        execute: &new_file/1
-      },
-      %Minga.Command{
-        name: :tree_new_folder,
-        description: "Create new folder in tree",
-        requires_buffer: false,
-        execute: &new_folder/1
-      },
-      %Minga.Command{
-        name: :tree_rename,
-        description: "Rename file or folder in tree",
-        requires_buffer: false,
-        execute: &rename/1
-      },
-      %Minga.Command{
-        name: :tree_confirm_editing,
-        description: "Confirm file tree inline edit",
-        requires_buffer: false,
-        execute: &confirm_editing/1
-      },
-      %Minga.Command{
-        name: :tree_cancel_editing,
-        description: "Cancel file tree inline edit",
-        requires_buffer: false,
-        execute: &cancel_editing/1
-      },
-      %Minga.Command{
-        name: :tree_reveal_active,
-        description: "Reveal active file in tree",
-        requires_buffer: false,
-        execute: &reveal_active_file/1
-      },
-      %Minga.Command{
-        name: :tree_delete,
-        description: "Delete file or folder in tree",
-        requires_buffer: false,
-        execute: &delete/1
-      },
-      %Minga.Command{
-        name: :tree_duplicate,
-        description: "Duplicate file or folder in tree",
-        requires_buffer: false,
-        execute: &duplicate/1
-      }
-    ]
-  end
+  command(:toggle_file_tree, "Toggle file tree", requires_buffer: false, execute: &toggle/1)
+
+  command(:tree_open_or_toggle, "Open file or toggle directory",
+    requires_buffer: false,
+    execute: &open_or_toggle/1
+  )
+
+  command(:tree_toggle_directory, "Toggle directory in tree",
+    requires_buffer: false,
+    execute: &toggle_directory/1
+  )
+
+  command(:tree_expand, "Expand tree node", requires_buffer: false, execute: &expand/1)
+  command(:tree_collapse, "Collapse tree node", requires_buffer: false, execute: &collapse/1)
+
+  command(:tree_toggle_hidden, "Toggle hidden files in tree",
+    requires_buffer: false,
+    execute: &toggle_hidden/1
+  )
+
+  command(:tree_refresh, "Refresh file tree", requires_buffer: false, execute: &refresh/1)
+  command(:tree_copy_path, "Copy file tree path", requires_buffer: false, execute: &copy_path/1)
+
+  command(:tree_mark_copy, "Mark file tree entry for copy",
+    requires_buffer: false,
+    execute: &mark_copy/1
+  )
+
+  command(:tree_mark_move, "Mark file tree entry for move",
+    requires_buffer: false,
+    execute: &mark_move/1
+  )
+
+  command(:tree_paste, "Paste marked file tree entry", requires_buffer: false, execute: &paste/1)
+
+  command(:tree_root_parent, "Root file tree at parent directory",
+    requires_buffer: false,
+    execute: &root_parent/1
+  )
+
+  command(:tree_root_selected, "Root file tree at selected directory",
+    requires_buffer: false,
+    execute: &root_selected/1
+  )
+
+  command(:tree_root_original, "Restore file tree project root",
+    requires_buffer: false,
+    execute: &root_original/1
+  )
+
+  command(:tree_filter, "Filter file tree", requires_buffer: false, execute: &filter/1)
+
+  command(:tree_toggle_help, "Toggle file tree help",
+    requires_buffer: false,
+    execute: &toggle_help/1
+  )
+
+  command(:tree_close, "Close file tree", requires_buffer: false, execute: &close/1)
+
+  command(:tree_collapse_all, "Collapse all directories in tree",
+    requires_buffer: false,
+    execute: &collapse_all/1
+  )
+
+  command(:tree_new_file, "Create new file in tree", requires_buffer: false, execute: &new_file/1)
+
+  command(:tree_new_folder, "Create new folder in tree",
+    requires_buffer: false,
+    execute: &new_folder/1
+  )
+
+  command(:tree_rename, "Rename file or folder in tree",
+    requires_buffer: false,
+    execute: &rename/1
+  )
+
+  command(:tree_confirm_editing, "Confirm file tree inline edit",
+    requires_buffer: false,
+    execute: &confirm_editing/1
+  )
+
+  command(:tree_cancel_editing, "Cancel file tree inline edit",
+    requires_buffer: false,
+    execute: &cancel_editing/1
+  )
+
+  command(:tree_reveal_active, "Reveal active file in tree",
+    requires_buffer: false,
+    execute: &reveal_active_file/1
+  )
+
+  command(:tree_delete, "Delete file or folder in tree",
+    requires_buffer: false,
+    execute: &delete/1
+  )
+
+  command(:tree_duplicate, "Duplicate file or folder in tree",
+    requires_buffer: false,
+    execute: &duplicate/1
+  )
 end

--- a/lib/minga_editor/commands/folding.ex
+++ b/lib/minga_editor/commands/folding.ex
@@ -7,7 +7,7 @@ defmodule MingaEditor.Commands.Folding do
   take precedence when both types exist at the cursor line.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias Minga.Core.Decorations
@@ -257,15 +257,5 @@ defmodule MingaEditor.Commands.Folding do
     if fold.closed, do: Decorations.toggle_fold_region(decs, fold.id), else: decs
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    Enum.map(@command_specs, fn {name, desc, requires_buffer} ->
-      %Minga.Command{
-        name: name,
-        description: desc,
-        requires_buffer: requires_buffer,
-        execute: fn state -> execute(state, name) end
-      }
-    end)
-  end
+  commands(@command_specs)
 end

--- a/lib/minga_editor/commands/formatting.ex
+++ b/lib/minga_editor/commands/formatting.ex
@@ -7,7 +7,7 @@ defmodule MingaEditor.Commands.Formatting do
   Falls back to configured external formatters if LSP is unavailable.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias MingaEditor.State, as: EditorState
@@ -224,15 +224,5 @@ defmodule MingaEditor.Commands.Formatting do
     )
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    [
-      %Minga.Command{
-        name: :format_buffer,
-        description: "Format buffer",
-        requires_buffer: true,
-        execute: &format_buffer/1
-      }
-    ]
-  end
+  command(:format_buffer, "Format buffer", requires_buffer: true, execute: &format_buffer/1)
 end

--- a/lib/minga_editor/commands/git.ex
+++ b/lib/minga_editor/commands/git.ex
@@ -4,7 +4,7 @@ defmodule MingaEditor.Commands.Git do
   branch picker, hunk navigation, stage, revert, preview, and blame.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias Minga.Core.Diff
@@ -1313,15 +1313,5 @@ defmodule MingaEditor.Commands.Git do
     end
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    Enum.map(@command_specs, fn {name, desc, requires_buffer} ->
-      %Minga.Command{
-        name: name,
-        description: desc,
-        requires_buffer: requires_buffer,
-        execute: fn state -> execute(state, name) end
-      }
-    end)
-  end
+  commands(@command_specs)
 end

--- a/lib/minga_editor/commands/help.ex
+++ b/lib/minga_editor/commands/help.ex
@@ -5,7 +5,7 @@ defmodule MingaEditor.Commands.Help do
   Help content is created lazily, reused across invocations, and always shown in read-only special buffers.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias Minga.Command
@@ -31,48 +31,12 @@ defmodule MingaEditor.Commands.Help do
           optional(:display_key) => String.t()
         }
 
-  @impl Minga.Command.Provider
-  @spec __commands__() :: [Command.t()]
-  def __commands__ do
-    [
-      %Command{
-        name: :describe_bindings,
-        description: "Describe bindings",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :describe_bindings) end
-      },
-      %Command{
-        name: :describe_command,
-        description: "Describe command",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :describe_command) end
-      },
-      %Command{
-        name: :describe_option,
-        description: "Describe option",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :describe_option) end
-      },
-      %Command{
-        name: :indent_picker,
-        description: "Open indent settings picker",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :indent_picker) end
-      },
-      %Command{
-        name: :describe_lossage,
-        description: "Show keystroke history",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :describe_lossage) end
-      },
-      %Command{
-        name: :describe_function,
-        description: "Describe function",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :describe_function) end
-      }
-    ]
-  end
+  command(:describe_bindings, "Describe bindings", requires_buffer: false)
+  command(:describe_command, "Describe command", requires_buffer: false)
+  command(:describe_option, "Describe option", requires_buffer: false)
+  command(:indent_picker, "Open indent settings picker", requires_buffer: false)
+  command(:describe_lossage, "Show keystroke history", requires_buffer: false)
+  command(:describe_function, "Describe function", requires_buffer: false)
 
   @spec execute(state(), Mode.command()) :: state()
   def execute(state, {:describe_key_result, key_str, command, description}) do

--- a/lib/minga_editor/commands/lsp.ex
+++ b/lib/minga_editor/commands/lsp.ex
@@ -6,7 +6,7 @@ defmodule MingaEditor.Commands.Lsp do
   language server instances attached to the current buffer.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias MingaEditor.HoverPopup
@@ -270,107 +270,69 @@ defmodule MingaEditor.Commands.Lsp do
   defp format_elapsed(s) when s < 3600, do: "#{div(s, 60)}m #{rem(s, 60)}s"
   defp format_elapsed(s), do: "#{div(s, 3600)}h #{div(rem(s, 3600), 60)}m"
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    standard =
-      Enum.map(@command_specs, fn {name, desc, requires_buffer} ->
-        %Minga.Command{
-          name: name,
-          description: desc,
-          requires_buffer: requires_buffer,
-          execute: fn state -> execute(state, name) end
-        }
-      end)
+  commands(@command_specs)
 
-    lsp_actions = [
-      %Minga.Command{
-        name: :goto_definition,
-        description: "Go to definition",
-        requires_buffer: true,
-        execute: &LspActions.goto_definition/1
-      },
-      %Minga.Command{
-        name: :hover,
-        description: "Hover documentation",
-        requires_buffer: true,
-        execute: &LspActions.hover/1
-      },
-      %Minga.Command{
-        name: :peek_definition,
-        description: "Peek definition",
-        requires_buffer: true,
-        execute: &LspActions.peek_definition/1
-      },
-      %Minga.Command{
-        name: :find_references,
-        description: "Find all references",
-        requires_buffer: true,
-        execute: &LspActions.find_references/1
-      },
-      %Minga.Command{
-        name: :code_action,
-        description: "Code actions",
-        requires_buffer: true,
-        execute: &LspActions.code_action/1
-      },
-      %Minga.Command{
-        name: :rename_symbol,
-        description: "Rename symbol",
-        requires_buffer: true,
-        execute: &LspActions.prepare_rename/1
-      },
-      %Minga.Command{
-        name: :goto_type_definition,
-        description: "Go to type definition",
-        requires_buffer: true,
-        execute: &LspActions.goto_type_definition/1
-      },
-      %Minga.Command{
-        name: :goto_implementation,
-        description: "Go to implementation",
-        requires_buffer: true,
-        execute: &LspActions.goto_implementation/1
-      },
-      %Minga.Command{
-        name: :document_symbols,
-        description: "Document symbols",
-        requires_buffer: true,
-        execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.SymbolSource) end
-      },
-      %Minga.Command{
-        name: :selection_expand,
-        description: "Smart selection expand",
-        requires_buffer: true,
-        execute: &LspActions.selection_expand/1
-      },
-      %Minga.Command{
-        name: :selection_shrink,
-        description: "Smart selection shrink",
-        requires_buffer: true,
-        execute: &LspActions.selection_shrink/1
-      },
-      %Minga.Command{
-        name: :call_hierarchy,
-        description: "Call hierarchy (incoming)",
-        requires_buffer: true,
-        execute: &LspActions.prepare_call_hierarchy/1
-      },
-      %Minga.Command{
-        name: :call_hierarchy_outgoing,
-        description: "Call hierarchy (outgoing)",
-        requires_buffer: true,
-        execute: &LspActions.prepare_outgoing_call_hierarchy/1
-      },
-      %Minga.Command{
-        name: :workspace_symbols,
-        description: "Search workspace symbols",
-        requires_buffer: true,
-        execute: fn state ->
-          PickerUI.open(state, WorkspaceSymbolSource)
-        end
-      }
-    ]
+  command(:goto_definition, "Go to definition",
+    requires_buffer: true,
+    execute: &LspActions.goto_definition/1
+  )
 
-    standard ++ lsp_actions
-  end
+  command(:hover, "Hover documentation", requires_buffer: true, execute: &LspActions.hover/1)
+
+  command(:peek_definition, "Peek definition",
+    requires_buffer: true,
+    execute: &LspActions.peek_definition/1
+  )
+
+  command(:find_references, "Find all references",
+    requires_buffer: true,
+    execute: &LspActions.find_references/1
+  )
+
+  command(:code_action, "Code actions", requires_buffer: true, execute: &LspActions.code_action/1)
+
+  command(:rename_symbol, "Rename symbol",
+    requires_buffer: true,
+    execute: &LspActions.prepare_rename/1
+  )
+
+  command(:goto_type_definition, "Go to type definition",
+    requires_buffer: true,
+    execute: &LspActions.goto_type_definition/1
+  )
+
+  command(:goto_implementation, "Go to implementation",
+    requires_buffer: true,
+    execute: &LspActions.goto_implementation/1
+  )
+
+  command(:document_symbols, "Document symbols",
+    requires_buffer: true,
+    execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.SymbolSource) end
+  )
+
+  command(:selection_expand, "Smart selection expand",
+    requires_buffer: true,
+    execute: &LspActions.selection_expand/1
+  )
+
+  command(:selection_shrink, "Smart selection shrink",
+    requires_buffer: true,
+    execute: &LspActions.selection_shrink/1
+  )
+
+  command(:call_hierarchy, "Call hierarchy (incoming)",
+    requires_buffer: true,
+    execute: &LspActions.prepare_call_hierarchy/1
+  )
+
+  command(:call_hierarchy_outgoing, "Call hierarchy (outgoing)",
+    requires_buffer: true,
+    execute: &LspActions.prepare_outgoing_call_hierarchy/1
+  )
+
+  command(:workspace_symbols, "Search workspace symbols",
+    requires_buffer: true,
+    execute: fn state -> PickerUI.open(state, WorkspaceSymbolSource) end
+  )
 end

--- a/lib/minga_editor/commands/macros.ex
+++ b/lib/minga_editor/commands/macros.ex
@@ -3,7 +3,7 @@ defmodule MingaEditor.Commands.Macros do
   Macro recording and replay commands.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias MingaEditor.Editing
   alias MingaEditor.MacroRecorder
@@ -41,21 +41,13 @@ defmodule MingaEditor.Commands.Macros do
     end
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    [
-      %Minga.Command{
-        name: :toggle_macro_recording,
-        description: "Toggle macro recording",
-        requires_buffer: true,
-        execute: &toggle_recording/1
-      },
-      %Minga.Command{
-        name: :replay_last_macro,
-        description: "Replay last macro",
-        requires_buffer: true,
-        execute: &replay_last/1
-      }
-    ]
-  end
+  command(:toggle_macro_recording, "Toggle macro recording",
+    requires_buffer: true,
+    execute: &toggle_recording/1
+  )
+
+  command(:replay_last_macro, "Replay last macro",
+    requires_buffer: true,
+    execute: &replay_last/1
+  )
 end

--- a/lib/minga_editor/commands/marks.ex
+++ b/lib/minga_editor/commands/marks.ex
@@ -4,7 +4,7 @@ defmodule MingaEditor.Commands.Marks do
   last cursor position.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias Minga.Buffer.Document
@@ -110,15 +110,5 @@ defmodule MingaEditor.Commands.Marks do
 
   def execute(state, :jump_to_last_pos_exact), do: state
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    Enum.map(@command_specs, fn {name, desc, requires_buffer} ->
-      %Minga.Command{
-        name: name,
-        description: desc,
-        requires_buffer: requires_buffer,
-        execute: fn state -> execute(state, name) end
-      }
-    end)
-  end
+  commands(@command_specs)
 end

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -4,7 +4,7 @@ defmodule MingaEditor.Commands.Movement do
   matching, paragraph jumps, page scroll, and screen-relative positioning.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias Minga.Buffer.Document
@@ -764,15 +764,5 @@ defmodule MingaEditor.Commands.Movement do
     end
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    Enum.map(@command_specs, fn {name, desc, requires_buffer} ->
-      %Minga.Command{
-        name: name,
-        description: desc,
-        requires_buffer: requires_buffer,
-        execute: fn state -> execute(state, name) end
-      }
-    end)
-  end
+  commands(@command_specs)
 end

--- a/lib/minga_editor/commands/operators.ex
+++ b/lib/minga_editor/commands/operators.ex
@@ -4,7 +4,7 @@ defmodule MingaEditor.Commands.Operators do
   line-wise variants (dd/yy/cc/S).
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias MingaEditor.Commands.Helpers
@@ -142,15 +142,5 @@ defmodule MingaEditor.Commands.Operators do
   @spec read_only_msg(state()) :: state()
   defp read_only_msg(state), do: EditorState.set_status(state, "Buffer is read-only")
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    Enum.map(@command_specs, fn {name, desc, requires_buffer} ->
-      %Minga.Command{
-        name: name,
-        description: desc,
-        requires_buffer: requires_buffer,
-        execute: fn state -> execute(state, name) end
-      }
-    end)
-  end
+  commands(@command_specs)
 end

--- a/lib/minga_editor/commands/project.ex
+++ b/lib/minga_editor/commands/project.ex
@@ -4,7 +4,7 @@ defmodule MingaEditor.Commands.Project do
   add/remove known projects.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
@@ -80,15 +80,5 @@ defmodule MingaEditor.Commands.Project do
     :exit, _ -> nil
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    Enum.map(@command_specs, fn {name, desc, requires_buffer} ->
-      %Minga.Command{
-        name: name,
-        description: desc,
-        requires_buffer: requires_buffer,
-        execute: fn state -> execute(state, name) end
-      }
-    end)
-  end
+  commands(@command_specs)
 end

--- a/lib/minga_editor/commands/provider.ex
+++ b/lib/minga_editor/commands/provider.ex
@@ -1,0 +1,326 @@
+defmodule MingaEditor.Commands.Provider do
+  @moduledoc """
+  Compile-time DSL for editor command provider modules.
+
+  `use MingaEditor.Commands.Provider` keeps the existing `Minga.Command.Provider` contract while replacing repeated `%Minga.Command{}` boilerplate with concise declarations. The DSL only generates command metadata and `__commands__/0`; command behavior stays in normal Elixir functions.
+  """
+
+  @command_keys [:execute, :option_toggle, :requires_buffer, :scope]
+  @numbered_keys [:argument | @command_keys]
+
+  @spec __using__(keyword()) :: Macro.t()
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Minga.Command.Provider
+      import unquote(__MODULE__),
+        only: [command: 2, command: 3, commands: 1, numbered_commands: 3, numbered_commands: 4]
+
+      Module.register_attribute(__MODULE__, :minga_commands, accumulate: true)
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  @spec command(Macro.t(), Macro.t()) :: Macro.t()
+  @spec command(Macro.t(), Macro.t(), Macro.t()) :: Macro.t()
+  defmacro command(name_ast, description_ast, opts_ast \\ []) do
+    define(command_definition!(name_ast, description_ast, opts_ast, __CALLER__))
+  end
+
+  @spec commands(Macro.t()) :: Macro.t()
+  defmacro commands(specs_ast) do
+    quote do
+      for spec <- unquote(specs_ast) do
+        @minga_commands unquote(__MODULE__).__command_definition_from_spec__(spec, __ENV__)
+      end
+    end
+  end
+
+  @spec numbered_commands(Macro.t(), Macro.t(), Macro.t()) :: Macro.t()
+  @spec numbered_commands(Macro.t(), Macro.t(), Macro.t(), Macro.t()) :: Macro.t()
+  defmacro numbered_commands(prefix_ast, range_ast, description_ast, opts_ast \\ []) do
+    env = __CALLER__
+    prefix = atom!(prefix_ast, env, "numbered command prefix")
+    range = range!(range_ast, env)
+    description = description!(description_ast, prefix, env)
+    opts = numbered_opts!(prefix, opts_ast, env)
+
+    range
+    |> Enum.map(&numbered_definition(prefix, &1, description, opts))
+    |> Enum.map(&define/1)
+    |> then(&{:__block__, [], &1})
+  end
+
+  @doc false
+  @spec __command_definition_from_spec__(term(), Macro.Env.t()) :: {atom(), String.t(), keyword()}
+  def __command_definition_from_spec__({name, description, requires_buffer}, env) do
+    name = atom!(name, env, "command name")
+    description = description!(description, name, env)
+    bool!(requires_buffer, name, env)
+    {name, description, [requires_buffer: requires_buffer, execute: default_execute_ast(name)]}
+  end
+
+  def __command_definition_from_spec__(spec, env) do
+    fail!(
+      env,
+      "invalid command spec in #{inspect(env.module)}: expected {name, description, requires_buffer}, got #{inspect(spec)}"
+    )
+  end
+
+  @spec __before_compile__(Macro.Env.t()) :: Macro.t()
+  defmacro __before_compile__(env) do
+    definitions = env.module |> Module.get_attribute(:minga_commands) |> Enum.reverse()
+    validate_unique_names!(definitions, env)
+    commands = Enum.map(definitions, &command_ast/1)
+
+    quote do
+      @impl Minga.Command.Provider
+      @spec __commands__() :: [Minga.Command.t()]
+      def __commands__, do: [unquote_splicing(commands)]
+    end
+  end
+
+  defp define(definition) do
+    quote bind_quoted: [definition: Macro.escape(definition)] do
+      @minga_commands definition
+    end
+  end
+
+  defp command_definition!(name_ast, description_ast, opts_ast, env) do
+    name = atom!(name_ast, env, "command name")
+    description = description!(description_ast, name, env)
+    opts = command_opts!(name, opts_ast, env)
+    {name, description, opts}
+  end
+
+  defp numbered_definition(prefix, n, description, opts) do
+    name = String.to_atom("#{prefix}_#{n}")
+    argument = numbered_argument(Keyword.get(opts, :argument, :name), name, n)
+    opts = Keyword.delete(opts, :argument)
+
+    opts =
+      case Keyword.fetch(opts, :execute) do
+        {:ok, execute_ast} ->
+          Keyword.put(opts, :execute, numbered_execute_ast(execute_ast, argument))
+
+        :error ->
+          Keyword.put(opts, :execute, default_execute_ast(name))
+      end
+
+    {name, "#{description} #{n}", opts}
+  end
+
+  defp command_ast({name, description, opts}) do
+    quote do
+      %Minga.Command{
+        name: unquote(name),
+        description: unquote(description),
+        requires_buffer: unquote(Keyword.get(opts, :requires_buffer, false)),
+        execute: unquote(Keyword.fetch!(opts, :execute)),
+        option_toggle: unquote(Keyword.get(opts, :option_toggle, nil)),
+        scope: unquote(Keyword.get(opts, :scope, nil))
+      }
+    end
+  end
+
+  defp default_execute_ast(name), do: quote(do: fn state -> execute(state, unquote(name)) end)
+
+  defp numbered_execute_ast(execute_ast, argument),
+    do: quote(do: fn state -> unquote(execute_ast).(state, unquote(argument)) end)
+
+  defp numbered_argument(:name, name, _n), do: name
+  defp numbered_argument(:number, _name, n), do: n
+
+  defp atom!(value, _env, _label) when is_atom(value) and not is_nil(value), do: value
+
+  defp atom!(value, env, label),
+    do: fail!(env, "invalid #{label}: expected a non-nil atom, got #{inspect(value)}")
+
+  defp description!(value, _name, _env) when is_binary(value) and byte_size(value) > 0, do: value
+
+  defp description!(value, name, env),
+    do:
+      fail!(
+        env,
+        "invalid description for command #{inspect(name)}: expected a non-empty string, got #{inspect(value)}"
+      )
+
+  defp range!({:.., _meta, [first, last]}, _env) when is_integer(first) and is_integer(last),
+    do: first..last
+
+  defp range!({:..//, _meta, [first, last, step]}, _env)
+       when is_integer(first) and is_integer(last) and is_integer(step), do: first..last//step
+
+  defp range!(value, env),
+    do:
+      fail!(
+        env,
+        "invalid range for numbered commands: expected a literal range, got #{Macro.to_string(value)}"
+      )
+
+  defp command_opts!(name, opts, env) do
+    opts = opts!(name, opts, @command_keys, env)
+    bool!(Keyword.get(opts, :requires_buffer, false), name, env)
+    scope!(Keyword.get(opts, :scope, nil), name, env)
+    option_toggle!(Keyword.get(opts, :option_toggle, nil), name, env)
+    execute!(Keyword.get(opts, :execute, nil), name, env)
+    Keyword.put_new(opts, :execute, default_execute_ast(name))
+  end
+
+  defp numbered_opts!(prefix, opts, env) do
+    opts = opts!(prefix, opts, @numbered_keys, env)
+    bool!(Keyword.get(opts, :requires_buffer, false), prefix, env)
+    scope!(Keyword.get(opts, :scope, nil), prefix, env)
+    argument!(Keyword.get(opts, :argument, :name), prefix, env)
+    option_toggle!(Keyword.get(opts, :option_toggle, nil), prefix, env)
+    numbered_execute!(Keyword.get(opts, :execute, nil), prefix, env)
+    opts
+  end
+
+  defp opts!(name, opts, valid_keys, env) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      invalid = Keyword.keys(opts) -- valid_keys
+
+      if invalid != [],
+        do:
+          fail!(
+            env,
+            "invalid options for command #{inspect(name)}: unknown keys #{inspect(invalid)}"
+          )
+
+      opts
+    else
+      fail!(env, "invalid options for command #{inspect(name)}: expected a keyword list")
+    end
+  end
+
+  defp opts!(name, opts, _valid_keys, env),
+    do:
+      fail!(
+        env,
+        "invalid options for command #{inspect(name)}: expected a keyword list, got #{Macro.to_string(opts)}"
+      )
+
+  defp bool!(value, _name, _env) when is_boolean(value), do: :ok
+
+  defp bool!(value, name, env),
+    do:
+      fail!(
+        env,
+        "invalid requires_buffer for command #{inspect(name)}: expected true or false, got #{inspect(value)}"
+      )
+
+  defp option_toggle!(nil, _name, _env), do: :ok
+  defp option_toggle!(value, _name, _env) when is_atom(value), do: :ok
+
+  defp option_toggle!({name, fun}, command_name, env) when is_atom(name) do
+    if one_arity_function_ast?(fun) do
+      :ok
+    else
+      fail!(
+        env,
+        "invalid option_toggle for command #{inspect(command_name)}: expected nil, an atom, or {atom, one-arity function/capture}, got #{inspect({name, fun})}"
+      )
+    end
+  end
+
+  defp option_toggle!(value, name, env),
+    do:
+      fail!(
+        env,
+        "invalid option_toggle for command #{inspect(name)}: expected nil, an atom, or {atom, one-arity function/capture}, got #{inspect(value)}"
+      )
+
+  defp scope!(nil, _name, _env), do: :ok
+  defp scope!(value, _name, _env) when is_atom(value), do: :ok
+
+  defp scope!(value, name, env),
+    do:
+      fail!(
+        env,
+        "invalid scope for command #{inspect(name)}: expected an atom, got #{inspect(value)}"
+      )
+
+  defp argument!(value, _prefix, _env) when value in [:name, :number], do: :ok
+
+  defp argument!(value, prefix, env),
+    do:
+      fail!(
+        env,
+        "invalid argument for numbered command #{inspect(prefix)}: expected :name or :number, got #{inspect(value)}"
+      )
+
+  defp execute!(nil, _name, _env), do: :ok
+
+  defp execute!(execute, name, env) do
+    if one_arity_function_ast?(execute) do
+      :ok
+    else
+      invalid_execute!(name, execute, env)
+    end
+  end
+
+  defp numbered_execute!(nil, _prefix, _env), do: :ok
+  defp numbered_execute!({:&, _meta, [{:/, _slash_meta, [_call, 2]}]}, _prefix, _env), do: :ok
+
+  defp numbered_execute!(execute, prefix, env),
+    do:
+      fail!(
+        env,
+        "invalid execute callback for numbered command #{inspect(prefix)}: expected a two-arity function capture or omit execute for default execute/2 routing; got #{Macro.to_string(execute)}"
+      )
+
+  defp one_arity_function_ast?(ast) do
+    one_arity_capture?(ast) or one_arity_fn?(ast)
+  end
+
+  defp one_arity_capture?({:&, _meta, [{:/, _slash_meta, [_call, 1]}]}), do: true
+
+  defp one_arity_capture?({:&, _meta, [body]}) do
+    indexes = body |> capture_placeholder_indexes() |> Enum.uniq()
+    indexes != [] and Enum.max(indexes) == 1
+  end
+
+  defp one_arity_capture?(_), do: false
+
+  defp one_arity_fn?({:fn, _meta, clauses}) when is_list(clauses),
+    do: Enum.all?(clauses, &one_arity_clause?/1)
+
+  defp one_arity_fn?(_), do: false
+
+  defp capture_placeholder_indexes(ast) do
+    {_ast, indexes} =
+      Macro.prewalk(ast, [], fn
+        {:&, _meta, [index]} = node, indexes when is_integer(index) -> {node, [index | indexes]}
+        node, indexes -> {node, indexes}
+      end)
+
+    indexes
+  end
+
+  defp one_arity_clause?({:->, _meta, [args, _body]}) when is_list(args), do: length(args) == 1
+  defp one_arity_clause?(_clause), do: false
+
+  @spec invalid_execute!(atom(), Macro.t(), Macro.Env.t()) :: no_return()
+  defp invalid_execute!(name, execute, env),
+    do:
+      fail!(
+        env,
+        "invalid execute callback for command #{inspect(name)}: expected a one-arity function capture, one-arity fn, or omit execute for default execute/2 routing; got #{Macro.to_string(execute)}"
+      )
+
+  defp validate_unique_names!(definitions, env) do
+    names = Enum.map(definitions, fn {name, _description, _opts} -> name end)
+    duplicates = names -- Enum.uniq(names)
+
+    if duplicates != [],
+      do:
+        fail!(
+          env,
+          "duplicate command names in #{inspect(env.module)}: #{inspect(Enum.uniq(duplicates))}"
+        )
+  end
+
+  @spec fail!(Macro.Env.t(), String.t()) :: no_return()
+  defp fail!(env, description),
+    do: raise(CompileError, file: env.file, line: env.line, description: description)
+end

--- a/lib/minga_editor/commands/remote_files.ex
+++ b/lib/minga_editor/commands/remote_files.ex
@@ -5,7 +5,7 @@ defmodule MingaEditor.Commands.RemoteFiles do
   Remote files edit at local buffer speed and save through Erlang distribution. LSP features are intentionally disabled for these buffers because language servers run on the remote machine, not in the local editor workspace.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias Minga.Distribution.ConnectionManager
@@ -48,17 +48,10 @@ defmodule MingaEditor.Commands.RemoteFiles do
     end
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    [
-      %Minga.Command{
-        name: :remote_find_file,
-        description: "Find file on remote server",
-        requires_buffer: false,
-        execute: &find_remote_file/1
-      }
-    ]
-  end
+  command(:remote_find_file, "Find file on remote server",
+    requires_buffer: false,
+    execute: &find_remote_file/1
+  )
 
   @spec open_remote_file(state(), String.t(), node(), String.t()) :: state()
   defp open_remote_file(state, server_name, remote_node, remote_path) do

--- a/lib/minga_editor/commands/search.ex
+++ b/lib/minga_editor/commands/search.ex
@@ -4,7 +4,7 @@ defmodule MingaEditor.Commands.Search do
   word-under-cursor search.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias Minga.Buffer.Document
@@ -502,53 +502,31 @@ defmodule MingaEditor.Commands.Search do
     end
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    standard =
-      Enum.map(@command_specs, fn {name, desc, requires_buffer} ->
-        %Minga.Command{
-          name: name,
-          description: desc,
-          requires_buffer: requires_buffer,
-          execute: fn state -> execute(state, name) end
-        }
-      end)
+  commands(@command_specs)
 
-    extra = [
-      %Minga.Command{
-        name: :search_project,
-        description: "Search across project files",
-        requires_buffer: false,
-        execute: fn state ->
-          EditorState.transition_mode(state, :search_prompt, %Minga.Mode.SearchPromptState{})
-        end
-      },
-      %Minga.Command{
-        name: :search_todos,
-        description: "Search TODO markers",
-        requires_buffer: false,
-        execute: fn state ->
-          PickerUI.open(state, MingaEditor.UI.Picker.TodoSearchSource)
-        end
-      },
-      %Minga.Command{
-        name: :search_buffer,
-        description: "Search in buffer",
-        requires_buffer: true,
-        execute: fn state ->
-          EditorState.transition_mode(state, :search, %SearchState{direction: :forward})
-        end
-      },
-      %Minga.Command{
-        name: :search_and_replace,
-        description: "Search and replace",
-        requires_buffer: true,
-        execute: fn state ->
-          EditorState.transition_mode(state, :command, %CommandState{input: "%s/"})
-        end
-      }
-    ]
+  command(:search_project, "Search across project files",
+    requires_buffer: false,
+    execute: fn state ->
+      EditorState.transition_mode(state, :search_prompt, %Minga.Mode.SearchPromptState{})
+    end
+  )
 
-    standard ++ extra
-  end
+  command(:search_todos, "Search TODO markers",
+    requires_buffer: false,
+    execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.TodoSearchSource) end
+  )
+
+  command(:search_buffer, "Search in buffer",
+    requires_buffer: true,
+    execute: fn state ->
+      EditorState.transition_mode(state, :search, %SearchState{direction: :forward})
+    end
+  )
+
+  command(:search_and_replace, "Search and replace",
+    requires_buffer: true,
+    execute: fn state ->
+      EditorState.transition_mode(state, :command, %CommandState{input: "%s/"})
+    end
+  )
 end

--- a/lib/minga_editor/commands/testing.ex
+++ b/lib/minga_editor/commands/testing.ex
@@ -4,7 +4,7 @@ defmodule MingaEditor.Commands.Testing do
   view output.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias MingaEditor.Commands.BufferManagement
@@ -115,39 +115,9 @@ defmodule MingaEditor.Commands.Testing do
     Minga.Project.TestRunner.detect_project_filetype(Minga.Project.root() || ".")
   end
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    [
-      %Minga.Command{
-        name: :test_file,
-        description: "Run tests for current file",
-        requires_buffer: true,
-        execute: &test_file/1
-      },
-      %Minga.Command{
-        name: :test_all,
-        description: "Run all tests",
-        requires_buffer: true,
-        execute: &test_all/1
-      },
-      %Minga.Command{
-        name: :test_at_point,
-        description: "Run test at cursor",
-        requires_buffer: true,
-        execute: &test_at_point/1
-      },
-      %Minga.Command{
-        name: :test_rerun,
-        description: "Rerun last test",
-        requires_buffer: true,
-        execute: &test_rerun/1
-      },
-      %Minga.Command{
-        name: :test_output,
-        description: "Show test output",
-        requires_buffer: true,
-        execute: &test_output/1
-      }
-    ]
-  end
+  command(:test_file, "Run tests for current file", requires_buffer: true, execute: &test_file/1)
+  command(:test_all, "Run all tests", requires_buffer: true, execute: &test_all/1)
+  command(:test_at_point, "Run test at cursor", requires_buffer: true, execute: &test_at_point/1)
+  command(:test_rerun, "Rerun last test", requires_buffer: true, execute: &test_rerun/1)
+  command(:test_output, "Show test output", requires_buffer: true, execute: &test_output/1)
 end

--- a/lib/minga_editor/commands/tool.ex
+++ b/lib/minga_editor/commands/tool.ex
@@ -6,9 +6,8 @@ defmodule MingaEditor.Commands.Tool do
   and `:tool_manage` (picker UI) commands.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
-  alias Minga.Command
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
   alias Minga.Tool.Manager, as: ToolManager
@@ -18,42 +17,11 @@ defmodule MingaEditor.Commands.Tool do
 
   @type state :: EditorState.t()
 
-  @impl true
-  @spec __commands__() :: [Command.t()]
-  def __commands__ do
-    [
-      %Command{
-        name: :tool_install,
-        description: "Install a tool",
-        execute: fn state -> execute(state, :tool_install) end,
-        requires_buffer: false
-      },
-      %Command{
-        name: :tool_uninstall,
-        description: "Uninstall a tool",
-        execute: fn state -> execute(state, :tool_uninstall) end,
-        requires_buffer: false
-      },
-      %Command{
-        name: :tool_update,
-        description: "Update a tool",
-        execute: fn state -> execute(state, :tool_update) end,
-        requires_buffer: false
-      },
-      %Command{
-        name: :tool_list,
-        description: "List installed tools",
-        execute: fn state -> execute(state, :tool_list) end,
-        requires_buffer: false
-      },
-      %Command{
-        name: :tool_manage,
-        description: "Manage tools",
-        execute: fn state -> execute(state, :tool_manage) end,
-        requires_buffer: false
-      }
-    ]
-  end
+  command(:tool_install, "Install a tool", requires_buffer: false)
+  command(:tool_uninstall, "Uninstall a tool", requires_buffer: false)
+  command(:tool_update, "Update a tool", requires_buffer: false)
+  command(:tool_list, "List installed tools", requires_buffer: false)
+  command(:tool_manage, "Manage tools", requires_buffer: false)
 
   @doc "Executes a named tool action (from :ToolInstall name, etc.)."
   @spec execute_named(state(), :install | :uninstall | :update, String.t()) :: state()

--- a/lib/minga_editor/commands/tutor.ex
+++ b/lib/minga_editor/commands/tutor.ex
@@ -4,11 +4,10 @@ defmodule MingaEditor.Commands.Tutor do
   lessons that the user edits directly to practice motions and operators.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias Minga.Buffer.Document
-  alias Minga.Command
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -18,18 +17,7 @@ defmodule MingaEditor.Commands.Tutor do
 
   @tutor_buffer_name "*Tutor*"
 
-  @impl Minga.Command.Provider
-  @spec __commands__() :: [Command.t()]
-  def __commands__ do
-    [
-      %Command{
-        name: :tutor,
-        description: "Interactive Minga tutorial",
-        requires_buffer: false,
-        execute: fn state -> execute(state, :tutor) end
-      }
-    ]
-  end
+  command(:tutor, "Interactive Minga tutorial", requires_buffer: false)
 
   @spec execute(state(), :tutor) :: state()
   def execute(state, :tutor) do

--- a/lib/minga_editor/commands/ui.ex
+++ b/lib/minga_editor/commands/ui.ex
@@ -5,93 +5,75 @@ defmodule MingaEditor.Commands.UI do
   to a specific domain.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
   alias Minga.Parser.Manager, as: ParserManager
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    [
-      %Minga.Command{
-        name: :command_palette,
-        description: "Execute command",
-        requires_buffer: false,
-        execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.CommandSource) end
-      },
-      %Minga.Command{
-        name: :find_file,
-        description: "Find file in project",
-        requires_buffer: false,
-        execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.FileSource) end
-      },
-      %Minga.Command{
-        name: :find_file_other_window,
-        description: "Find file in other window",
-        requires_buffer: false,
-        execute: fn state ->
-          state
-          |> MingaEditor.Commands.Movement.execute(:split_vertical)
-          |> PickerUI.open(MingaEditor.UI.Picker.FileSource)
-        end
-      },
-      %Minga.Command{
-        name: :theme_picker,
-        description: "Pick theme",
-        requires_buffer: false,
-        execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.ThemeSource) end
-      },
-      %Minga.Command{
-        name: :set_language,
-        description: "Set buffer language",
-        requires_buffer: false,
-        execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.LanguageSource) end
-      },
-      %Minga.Command{
-        name: :diagnostics_list,
-        description: "List buffer diagnostics",
-        requires_buffer: true,
-        execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.Sources.Diagnostics) end
-      },
-      %Minga.Command{
-        name: :filetype_menu,
-        description: "Show filetype actions",
-        requires_buffer: true,
-        execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.LanguageSource) end
-      },
-      %Minga.Command{
-        name: :parser_restart,
-        description: "Restart tree-sitter parser",
-        requires_buffer: false,
-        execute: &execute_parser_restart/1
-      },
-      %Minga.Command{
-        name: :toggle_bottom_panel,
-        description: "Toggle bottom panel",
-        requires_buffer: false,
-        execute: &toggle_bottom_panel/1
-      },
-      %Minga.Command{
-        name: :bottom_panel_next_tab,
-        description: "Bottom panel: next tab",
-        requires_buffer: false,
-        execute: &bottom_panel_next_tab/1
-      },
-      %Minga.Command{
-        name: :bottom_panel_prev_tab,
-        description: "Bottom panel: previous tab",
-        requires_buffer: false,
-        execute: &bottom_panel_prev_tab/1
-      },
-      %Minga.Command{
-        name: :toggle_board,
-        description: "Toggle The Board view",
-        requires_buffer: false,
-        execute: &toggle_board/1
-      }
-    ]
-  end
+  command(:command_palette, "Execute command",
+    requires_buffer: false,
+    execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.CommandSource) end
+  )
+
+  command(:find_file, "Find file in project",
+    requires_buffer: false,
+    execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.FileSource) end
+  )
+
+  command(:find_file_other_window, "Find file in other window",
+    requires_buffer: false,
+    execute: fn state ->
+      state
+      |> MingaEditor.Commands.Movement.execute(:split_vertical)
+      |> PickerUI.open(MingaEditor.UI.Picker.FileSource)
+    end
+  )
+
+  command(:theme_picker, "Pick theme",
+    requires_buffer: false,
+    execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.ThemeSource) end
+  )
+
+  command(:set_language, "Set buffer language",
+    requires_buffer: false,
+    execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.LanguageSource) end
+  )
+
+  command(:diagnostics_list, "List buffer diagnostics",
+    requires_buffer: true,
+    execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.Sources.Diagnostics) end
+  )
+
+  command(:filetype_menu, "Show filetype actions",
+    requires_buffer: true,
+    execute: fn state -> PickerUI.open(state, MingaEditor.UI.Picker.LanguageSource) end
+  )
+
+  command(:parser_restart, "Restart tree-sitter parser",
+    requires_buffer: false,
+    execute: &execute_parser_restart/1
+  )
+
+  command(:toggle_bottom_panel, "Toggle bottom panel",
+    requires_buffer: false,
+    execute: &toggle_bottom_panel/1
+  )
+
+  command(:bottom_panel_next_tab, "Bottom panel: next tab",
+    requires_buffer: false,
+    execute: &bottom_panel_next_tab/1
+  )
+
+  command(:bottom_panel_prev_tab, "Bottom panel: previous tab",
+    requires_buffer: false,
+    execute: &bottom_panel_prev_tab/1
+  )
+
+  command(:toggle_board, "Toggle The Board view",
+    requires_buffer: false,
+    execute: &toggle_board/1
+  )
 
   @spec toggle_bottom_panel(EditorState.t()) :: EditorState.t()
   defp toggle_bottom_panel(state), do: frontend(state).toggle_bottom_panel(state)

--- a/lib/minga_editor/commands/visual.ex
+++ b/lib/minga_editor/commands/visual.ex
@@ -4,7 +4,7 @@ defmodule MingaEditor.Commands.Visual do
   visual selection.
   """
 
-  @behaviour Minga.Command.Provider
+  use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
   alias Minga.Buffer.Document
@@ -173,17 +173,7 @@ defmodule MingaEditor.Commands.Visual do
   defp visual_type_for_text_object(:paragraph), do: :line
   defp visual_type_for_text_object(_spec), do: :char
 
-  @impl Minga.Command.Provider
-  def __commands__ do
-    Enum.map(@command_specs, fn {name, desc, requires_buffer} ->
-      %Minga.Command{
-        name: name,
-        description: desc,
-        requires_buffer: requires_buffer,
-        execute: fn state -> execute(state, name) end
-      }
-    end)
-  end
+  commands(@command_specs)
 
   # Checks if the active window is an agent chat window by inspecting
   # the window's content field (structural check, no GenServer call).

--- a/test/minga_editor/commands/agent_group_test.exs
+++ b/test/minga_editor/commands/agent_group_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.Commands.AgentGroupTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Command
   alias MingaEditor.Commands.AgentGroup
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Tab
@@ -47,6 +48,26 @@ defmodule MingaEditor.Commands.AgentGroupTest do
       },
       shell_state: %MingaEditor.Shell.Traditional.State{tab_bar: tb}
     }
+  end
+
+  describe "__commands__/0" do
+    test "exports the agent group command contract" do
+      commands = AgentGroup.__commands__()
+
+      assert Enum.all?(commands, &match?(%Command{}, &1))
+      assert Enum.any?(commands, &(&1.name == :agent_group_next))
+      assert Enum.any?(commands, &(&1.name == :agent_group_next_agent))
+
+      for n <- 1..9 do
+        assert Enum.any?(commands, &(&1.name == String.to_atom("workspace_goto_#{n}")))
+      end
+
+      assert %{description: "Next workspace", requires_buffer: false} =
+               Enum.find(commands, &(&1.name == :agent_group_next))
+
+      assert %{description: "Workspace 1", requires_buffer: false} =
+               Enum.find(commands, &(&1.name == :workspace_goto_1))
+    end
   end
 
   describe "agent_group_next/1" do

--- a/test/minga_editor/commands/buffer_management_test.exs
+++ b/test/minga_editor/commands/buffer_management_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.Commands.BufferManagementTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Command
   alias Minga.Config.Options
   alias MingaEditor
   alias MingaEditor.Commands.BufferManagement
@@ -73,6 +74,26 @@ defmodule MingaEditor.Commands.BufferManagementTest do
   end
 
   defp tab_count(state), do: state |> EditorState.tab_bar() |> TabBar.count()
+
+  describe "__commands__/0" do
+    test "preserves line toggle and wrap metadata" do
+      commands = BufferManagement.__commands__() |> Map.new(&{&1.name, &1})
+
+      assert %Command{requires_buffer: true, option_toggle: {:line_numbers, toggle}} =
+               commands[:cycle_line_numbers]
+
+      assert is_function(toggle, 1)
+      assert toggle.(:hybrid) == :absolute
+      assert toggle.(:absolute) == :relative
+      assert toggle.(:relative) == :none
+      assert toggle.(:none) == :hybrid
+
+      assert %Command{requires_buffer: true, option_toggle: :wrap} = commands[:toggle_wrap]
+
+      assert %Command{requires_buffer: true, option_toggle: :show_invisible} =
+               commands[:toggle_invisible]
+    end
+  end
 
   describe "command mode editor integration smoke" do
     @describetag layer: :editor_integration

--- a/test/minga_editor/commands/provider_test.exs
+++ b/test/minga_editor/commands/provider_test.exs
@@ -1,0 +1,235 @@
+defmodule MingaEditor.Commands.ProviderTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Command
+
+  defp compile_provider(source) do
+    suffix = System.unique_integer([:positive])
+    module = Module.concat([__MODULE__, "Generated#{suffix}"])
+    source = String.replace(source, "__MODULE_UNDER_TEST__", inspect(module))
+    Code.compile_string(source)
+    module
+  end
+
+  test "generates command metadata with default execute/2 routing" do
+    module =
+      compile_provider("""
+      defmodule __MODULE_UNDER_TEST__ do
+        use MingaEditor.Commands.Provider
+
+        command :toggle_wrap, "Toggle word wrap",
+          requires_buffer: true,
+          scope: :editor,
+          option_toggle: :wrap
+
+        def execute(state, :toggle_wrap), do: Map.put(state, :wrapped, true)
+      end
+      """)
+
+    assert [cmd] = module.__commands__()
+    assert %Command{name: :toggle_wrap} = cmd
+    assert cmd.description == "Toggle word wrap"
+    assert cmd.requires_buffer
+    assert cmd.scope == :editor
+    assert cmd.option_toggle == :wrap
+    assert cmd.execute.(%{}) == %{wrapped: true}
+  end
+
+  test "generates numbered command metadata" do
+    module =
+      compile_provider("""
+      defmodule __MODULE_UNDER_TEST__ do
+        use MingaEditor.Commands.Provider
+
+        numbered_commands :workspace_goto, 1..3, "Workspace",
+          requires_buffer: false,
+          argument: :number,
+          execute: &workspace_goto/2
+
+        def workspace_goto(state, n), do: Map.put(state, :workspace, n)
+      end
+      """)
+
+    assert [one, two, three] = module.__commands__()
+    assert %Command{name: :workspace_goto_1, description: "Workspace 1"} = one
+    assert %Command{name: :workspace_goto_2, description: "Workspace 2"} = two
+    assert %Command{name: :workspace_goto_3, description: "Workspace 3"} = three
+    assert one.execute.(%{}) == %{workspace: 1}
+    assert two.execute.(%{}) == %{workspace: 2}
+    assert three.execute.(%{}) == %{workspace: 3}
+  end
+
+  test "generates command metadata from command spec lists" do
+    module =
+      compile_provider("""
+      defmodule __MODULE_UNDER_TEST__ do
+        use MingaEditor.Commands.Provider
+
+        @command_specs [
+          {:move_left, "Move left", true},
+          {:move_right, "Move right", true}
+        ]
+
+        commands @command_specs
+
+        def execute(state, name), do: Map.put(state, :command, name)
+      end
+      """)
+
+    assert [move_left, move_right] = module.__commands__()
+    assert %Command{name: :move_left, description: "Move left", requires_buffer: true} = move_left
+
+    assert %Command{name: :move_right, description: "Move right", requires_buffer: true} =
+             move_right
+
+    assert move_left.execute.(%{}) == %{command: :move_left}
+    assert move_right.execute.(%{}) == %{command: :move_right}
+  end
+
+  test "generates command metadata with explicit execute callbacks" do
+    module =
+      compile_provider("""
+      defmodule __MODULE_UNDER_TEST__ do
+        use MingaEditor.Commands.Provider
+
+        command :open_palette, "Open palette",
+          requires_buffer: false,
+          execute: &open_palette/1
+
+        command :annotate_state, "Annotate state",
+          requires_buffer: false,
+          execute: &Map.put(&1, :annotated, true)
+
+        command :inline_fn, "Inline fn",
+          requires_buffer: false,
+          execute: fn state -> Map.put(state, :inline, true) end
+
+        def open_palette(state), do: Map.put(state, :palette, true)
+      end
+      """)
+
+    assert [open_palette, annotate_state, inline_fn] = module.__commands__()
+    assert %Command{name: :open_palette, requires_buffer: false} = open_palette
+    assert %Command{name: :annotate_state, requires_buffer: false} = annotate_state
+    assert %Command{name: :inline_fn, requires_buffer: false} = inline_fn
+    assert open_palette.execute.(%{}) == %{palette: true}
+    assert annotate_state.execute.(%{}) == %{annotated: true}
+    assert inline_fn.execute.(%{}) == %{inline: true}
+  end
+
+  test "rejects invalid numbered commands" do
+    invalid_sources = [
+      "numbered_commands \"bad\", 1..2, \"Bad\", execute: &workspace_goto/2",
+      "numbered_commands :bad_range, [1, 2], \"Bad\", execute: &workspace_goto/2",
+      "numbered_commands :bad_description, 1..2, \"\", execute: &workspace_goto/2",
+      "numbered_commands :bad_argument, 1..2, \"Bad\", argument: :other, execute: &workspace_goto/2",
+      "numbered_commands :bad_execute, 1..2, \"Bad\", execute: &workspace_goto/1"
+    ]
+
+    for source <- invalid_sources do
+      assert_raise CompileError, fn ->
+        compile_provider("""
+        defmodule __MODULE_UNDER_TEST__ do
+          use MingaEditor.Commands.Provider
+          #{source}
+          def workspace_goto(state, _n), do: state
+          def workspace_goto(state), do: state
+        end
+        """)
+      end
+    end
+  end
+
+  test "rejects invalid option_toggle values" do
+    invalid_sources = [
+      "command :bad_toggle, \"Bad toggle\", option_toggle: 123",
+      "command :bad_toggle_tuple, \"Bad toggle\", option_toggle: {:wrap, &execute/2}",
+      "command :bad_toggle_fn, \"Bad toggle\", option_toggle: {:wrap, fn current, _extra -> current end}",
+      "numbered_commands :bad_numbered_toggle, 1..2, \"Bad\", option_toggle: 123"
+    ]
+
+    for source <- invalid_sources do
+      assert_raise CompileError, ~r/invalid option_toggle/, fn ->
+        compile_provider("""
+        defmodule __MODULE_UNDER_TEST__ do
+          use MingaEditor.Commands.Provider
+          #{source}
+          def execute(state, _name), do: state
+          def workspace_goto(state, _n), do: state
+        end
+        """)
+      end
+    end
+  end
+
+  test "rejects invalid command specs" do
+    invalid_sources = [
+      "@command_specs [{\"bad\", \"Bad command\", true}]",
+      "@command_specs [{:missing_description, \"\", true}]",
+      "@command_specs [{:bad_requires_buffer, \"Bad requires buffer\", :yes}]",
+      "@command_specs [{:bad_shape, \"Bad shape\"}]"
+    ]
+
+    for source <- invalid_sources do
+      assert_raise CompileError, fn ->
+        compile_provider("""
+        defmodule __MODULE_UNDER_TEST__ do
+          use MingaEditor.Commands.Provider
+          #{source}
+          commands @command_specs
+          def execute(state, _name), do: state
+        end
+        """)
+      end
+    end
+  end
+
+  test "rejects invalid command names" do
+    assert_raise CompileError, ~r/invalid command name/, fn ->
+      compile_provider("""
+      defmodule __MODULE_UNDER_TEST__ do
+        use MingaEditor.Commands.Provider
+        command "bad", "Bad command", execute: &execute/1
+        def execute(state), do: state
+      end
+      """)
+    end
+  end
+
+  test "rejects missing descriptions" do
+    assert_raise CompileError, ~r/invalid description for command :missing_description/, fn ->
+      compile_provider("""
+      defmodule __MODULE_UNDER_TEST__ do
+        use MingaEditor.Commands.Provider
+        command :missing_description, "", execute: &execute/1
+        def execute(state), do: state
+      end
+      """)
+    end
+  end
+
+  test "rejects invalid execute callback shape" do
+    assert_raise CompileError, ~r/invalid execute callback for command :bad_execute/, fn ->
+      compile_provider("""
+      defmodule __MODULE_UNDER_TEST__ do
+        use MingaEditor.Commands.Provider
+        command :bad_execute, "Bad execute", execute: &execute/2
+        def execute(state, _arg), do: state
+      end
+      """)
+    end
+  end
+
+  test "rejects duplicate command names within one provider" do
+    assert_raise CompileError, ~r/duplicate command names/, fn ->
+      compile_provider("""
+      defmodule __MODULE_UNDER_TEST__ do
+        use MingaEditor.Commands.Provider
+        command :same, "First"
+        command :same, "Second"
+        def execute(state, :same), do: state
+      end
+      """)
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR
Command providers can now declare command metadata with a small compile-time DSL while keeping command behavior in normal functions. This removes registry boilerplate across the command provider surface, adds a focused numbered-command helper, and keeps the existing command registry API unchanged.

Closes #1736

## Context
Issue #1736 asks for a narrow macro-backed helper that generates command metadata and `__commands__/0`, without creating a new command runtime. The goal is less repeated `%Minga.Command{}` boilerplate, clearer provider modules, and compile-time validation for bad declarations.

## Changes
- Added `MingaEditor.Commands.Provider`, a `use`-based DSL with `command/3`, `commands @command_specs`, `numbered_commands/4`, and generated `__commands__/0`.
- Supports default `fn state -> execute(state, name) end` routing, explicit one-arity captures, placeholder captures, one-arity anonymous functions, tuple command specs, and numbered command families like `tab_goto_1..9`.
- Validates command names, non-empty descriptions, option keys, `requires_buffer`, `scope`, `option_toggle`, execute callback shape, malformed command specs, numbered command ranges, numbered command arguments, and duplicate names at compile time.
- Converted high-boilerplate providers including `BufferManagement`, `FileTree`, `UI`, `Help`, `Dired`, `Testing`, `AgentGroup`, plus most tuple-spec and small command providers.
- Added provider DSL tests that compile real provider modules and assert generated metadata, callback behavior, command spec behavior, numbered command behavior, metadata preservation, and validation failures.

## LOC impact
- Total `lib/minga_editor/commands`: 15536 -> 14596 (-940) on the current branch base.

## Verification
- `mix test.llm test/minga_editor/commands/provider_test.exs test/minga/command/registry_test.exs test/minga_editor/commands/agent_group_test.exs test/minga_editor/commands/buffer_management_test.exs` ✅
- `mix compile --warnings-as-errors` ✅
- `mix test.llm` ✅
- `make lint` ✅, Credo emitted existing large-struct warnings only
- `git diff --check` ✅

## Review loop
- Round 1 reviewers found no blockers and suggested hardening `option_toggle` validation plus metadata regression tests.
- A worker added `option_toggle` validation and regression coverage for AgentGroup exports and BufferManagement toggle metadata.
- Round 2 reviewers found no blockers. One test brittleness fix was worth doing now.
- A worker loosened the AgentGroup metadata regression test to assert the command contract without hard-coding the full command list.
- The loop stopped because remaining feedback was optional or intentionally deferred.

## Acceptance Criteria Addressed
- Command provider modules can declare commands with a concise API ✅
- Generated providers still implement the existing `Minga.Command.Provider` contract ✅
- Compile-time validation catches invalid command declarations ✅
- At least three high-boilerplate command modules use the new declaration style ✅
- Converted modules and total `lib/minga_editor/commands` LOC are lower ✅
- Command behavior is unchanged, with registry and converted-provider tests passing ✅
