### PR TITLE
fix(macos): render configurable modeline natively

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -73,7 +73,7 @@ Invalid values show a clear error. Setting `:tab_width` to `-1` tells you it mus
 
 ## Modeline
 
-The modeline is the status line at the bottom of each editor window. It is built from named segments, so you can hide noisy information, move the important parts closer to the edge, or add your own project-specific status. The same segment configuration drives the TUI modeline and the native GUI status bar.
+The modeline is the status line at the bottom of each editor window. It is built from named segments, so you can hide noisy information, move the important parts closer to the edge, or add your own project-specific status. The same segment configuration drives the TUI modeline and the native GUI status bar; the GUI renders known built-ins with compact SwiftUI controls and renders custom segments as native chips instead of terminal-style color blocks.
 
 ### Built-in segments
 

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -269,6 +269,8 @@ Macro recording: 0=not recording, 1-26=recording register a-z
 
 `ModelineSegments` is the named GUI projection of the configurable modeline. The BEAM resolves built-in and custom segment names, side placement, explicit ordering, and click targets, then sends named styled segments to the frontend. Native frontends should use `name` to render known built-ins with platform-native controls (`mode` as a badge, `position` as compact text, `filetype` with the devicon, and so on) instead of drawing terminal-style full-height color blocks. Unknown or custom names can use `text`, `fg`, `bg`, and `attrs` as a native chip fallback. `attrs` uses the same low bits as `draw_text`: bit 0 bold, bit 1 underline, bit 2 italic. `command` is empty for non-clickable segments; otherwise it is a command name to send through the existing `execute_command` GUI action.
 
+Section `0x0B` is omitted when the BEAM has no GUI modeline data for this frame. A present section with zero left and right segments is explicit and tells the frontend not to synthesize fallback built-ins.
+
 ### 0x77 — gui_picker (sectioned format)
 
 Fuzzy finder / command palette state. Uses sectioned envelope: `opcode(1) + section_count(1) + sections...`. Hidden picker: section_count=0.

--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -244,7 +244,7 @@ opcode(1) + section_count(1) + [section_id(1) + section_len(2) + payload(section
 | 0x08 | Recording | macro_recording(1) |
 | 0x09 | Agent | buffer variant: agent_status(1) + background_count(2) + background_label_len(2) + background_label. Agent variant: model_name_len(1) + model_name + message_count(4) + session_status(1) + agent_status(1) + background_count(2) + background_label_len(2) + background_label |
 | 0x0A | Indent | indent_type(1: 0=spaces, 1=tabs) + indent_size(1) |
-| 0x0B | ModelineSegments | version(1) + left_count(2) + right_count(2) + left segments + right segments. Each segment is fg(3) + bg(3) + attrs(1) + text_len(2) + text + command_len(2) + command |
+| 0x0B | ModelineSegments | version(1, currently 2) + left_count(2) + right_count(2) + left segments + right segments. Each v2 segment is name_len(1) + name + fg(3) + bg(3) + attrs(1) + text_len(2) + text + command_len(2) + command. |
 | 0x0C | Selection | selection_mode(1: 0=none, 1=chars, 2=lines) + selection_size(4) |
 
 `content_kind`: 0 = buffer window, 1 = agent chat window. When `content_kind == 1`, the standard sections (cursor, git, diagnostics, etc.) contain background buffer data and section 0x09 includes agent-specific fields. `background_count` is the number of currently running background sub-agents. `background_label` is the active background child label when focused, otherwise the first running child label.
@@ -267,7 +267,7 @@ Macro recording: 0=not recording, 1-26=recording register a-z
 
 `icon` is a UTF-8 encoded Nerd Font glyph for the filetype (e.g., "" for Elixir). `icon_color` is 24-bit RGB split into 3 bytes. `filename` is the display name of the active buffer (for accessibility/tooltip use). `git_added`, `git_modified`, `git_deleted` are line counts from the buffer's diff against HEAD.
 
-`ModelineSegments` is the native GUI projection of the configurable modeline. The BEAM resolves built-in and custom segment names, default side placement, explicit side overrides, separator style, and click targets, then sends styled text segments to the frontend. Native frontends render these segments in the status bar alongside frontend-owned controls such as panel toggles. `attrs` uses the same low bits as `draw_text`: bit 0 bold, bit 1 underline, bit 2 italic. `command` is empty for non-clickable segments; otherwise it is a command name to send through the existing `execute_command` GUI action.
+`ModelineSegments` is the named GUI projection of the configurable modeline. The BEAM resolves built-in and custom segment names, side placement, explicit ordering, and click targets, then sends named styled segments to the frontend. Native frontends should use `name` to render known built-ins with platform-native controls (`mode` as a badge, `position` as compact text, `filetype` with the devicon, and so on) instead of drawing terminal-style full-height color blocks. Unknown or custom names can use `text`, `fg`, `bg`, and `attrs` as a native chip fallback. `attrs` uses the same low bits as `draw_text`: bit 0 bold, bit 1 underline, bit 2 italic. `command` is empty for non-clickable segments; otherwise it is a command name to send through the existing `execute_command` GUI action.
 
 ### 0x77 — gui_picker (sectioned format)
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -925,9 +925,9 @@ Total size: 7 + (40 + text_len) per edit.
 
 ## GUI Chrome Protocol
 
-Native GUI frontends (SwiftUI, GTK4) receive additional structured data opcodes for chrome elements like tab bars, file trees, status bars, and popups. These opcodes start at 0x70 and are sent only when the frontend reports `frontend_type = native_gui` in its capabilities. The GUI status bar opcode carries the same configured modeline segment surface as the TUI modeline, encoded as structured styled segments inside the `gui_status_bar` sectioned payload.
+Native GUI frontends (SwiftUI, GTK4) receive additional structured data opcodes for chrome elements like tab bars, file trees, status bars, and popups. These opcodes start at 0x70 and are sent only when the frontend reports `frontend_type = native_gui` in its capabilities. The GUI status bar opcode carries structured status fields plus named configured modeline segments so native frontends can keep platform styling while honoring modeline order and visibility.
 
-See [GUI_PROTOCOL.md](GUI_PROTOCOL.md) for the complete specification of GUI chrome opcodes, gui_action input events, theme color slots, and the behavioral contract for GUI frontends. The sectioned `gui_status_bar` opcode (`0x76`) is specified there, including the indent section (`0x0A`), reserved encoding section (`0x0B`), and selection section (`0x0C`).
+See [GUI_PROTOCOL.md](GUI_PROTOCOL.md) for the complete specification of GUI chrome opcodes, gui_action input events, theme color slots, and the behavioral contract for GUI frontends. The sectioned `gui_status_bar` opcode (`0x76`) is specified there, including the indent section (`0x0A`), named modeline segment section (`0x0B`), and selection section (`0x0C`).
 
 ---
 

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -1767,13 +1767,13 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
       ),
       encode_section(@section_message, <<byte_size(message)::16, message::binary>>),
       encode_section(@section_recording, <<macro_byte::8>>),
-      encode_section(@section_indent, <<indent_type_byte::8, indent_size::8>>),
-      encode_section(
-        @section_modeline_segments,
-        encode_modeline_segments(Map.get(d, :modeline_segments))
-      ),
-      encode_section(@section_selection, <<selection_mode::8, selection_size::32>>)
+      encode_section(@section_indent, <<indent_type_byte::8, indent_size::8>>)
     ]
+
+    sections = sections ++ modeline_segment_sections(Map.get(d, :modeline_segments))
+
+    sections =
+      sections ++ [encode_section(@section_selection, <<selection_mode::8, selection_size::32>>)]
 
     # Agent section (only when content_kind == 1)
     if content_kind == 1 do
@@ -1801,9 +1801,14 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     end
   end
 
-  @spec encode_modeline_segments(%{left: [tuple()], right: [tuple()]} | nil) :: binary()
-  defp encode_modeline_segments(nil), do: <<2::8, 0::16, 0::16>>
+  @spec modeline_segment_sections(%{left: [tuple()], right: [tuple()]} | nil) :: [binary()]
+  defp modeline_segment_sections(nil), do: []
 
+  defp modeline_segment_sections(modeline_segments) do
+    [encode_section(@section_modeline_segments, encode_modeline_segments(modeline_segments))]
+  end
+
+  @spec encode_modeline_segments(%{left: [tuple()], right: [tuple()]}) :: binary()
   defp encode_modeline_segments(%{left: left, right: right}) do
     {left, right} = capped_modeline_segments(left, right)
     {encoded_left, left_count, remaining} = bounded_modeline_side(left, @max_u16 - 5)

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -1697,7 +1697,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     0x08 - Recording: macro_recording
     0x09 - Agent: model_name, message_count, session_status, agent_status
     0x0A - Indent: indent_type, indent_size
-    0x0B - ModelineSegments: configured left/right styled modeline segments
+    0x0B - ModelineSegments: named configured left/right styled modeline segments
     0x0C - Selection: selection_mode, selection_size
   """
   @spec encode_gui_status_bar(MingaEditor.StatusBar.Data.t()) :: binary()
@@ -1802,7 +1802,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   end
 
   @spec encode_modeline_segments(%{left: [tuple()], right: [tuple()]} | nil) :: binary()
-  defp encode_modeline_segments(nil), do: <<1::8, 0::16, 0::16>>
+  defp encode_modeline_segments(nil), do: <<2::8, 0::16, 0::16>>
 
   defp encode_modeline_segments(%{left: left, right: right}) do
     {left, right} = capped_modeline_segments(left, right)
@@ -1810,7 +1810,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
     {encoded_right, right_count, _remaining} = bounded_modeline_side(right, remaining)
 
     IO.iodata_to_binary([
-      <<1::8, left_count::16, right_count::16>>,
+      <<2::8, left_count::16, right_count::16>>,
       encoded_left,
       encoded_right
     ])
@@ -1836,17 +1836,37 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   end
 
   @spec encode_modeline_segment(tuple(), non_neg_integer()) :: {:ok, binary()} | :drop
-  defp encode_modeline_segment(_segment, remaining) when remaining < 11, do: :drop
+  defp encode_modeline_segment(_segment, remaining) when remaining < 12, do: :drop
+
+  defp encode_modeline_segment({name, text, fg, bg, opts, target}, remaining) do
+    name_bytes = modeline_name_bytes(name)
+    overhead = 12 + byte_size(name_bytes)
+
+    if remaining < overhead do
+      :drop
+    else
+      attrs = encode_modeline_attrs(opts)
+      target = encode_modeline_target(target)
+      payload_budget = remaining - overhead
+      {text_bytes, target_bytes} = bounded_modeline_text_and_target(text, target, payload_budget)
+
+      {:ok,
+       <<byte_size(name_bytes)::8, name_bytes::binary, fg::24, bg::24, attrs::8,
+         byte_size(text_bytes)::16, text_bytes::binary, byte_size(target_bytes)::16,
+         target_bytes::binary>>}
+    end
+  end
 
   defp encode_modeline_segment({text, fg, bg, opts, target}, remaining) do
-    attrs = encode_modeline_attrs(opts)
-    target = encode_modeline_target(target)
-    payload_budget = remaining - 11
-    {text_bytes, target_bytes} = bounded_modeline_text_and_target(text, target, payload_budget)
+    encode_modeline_segment({:custom, text, fg, bg, opts, target}, remaining)
+  end
 
-    {:ok,
-     <<fg::24, bg::24, attrs::8, byte_size(text_bytes)::16, text_bytes::binary,
-       byte_size(target_bytes)::16, target_bytes::binary>>}
+  @spec modeline_name_bytes(atom() | String.t()) :: binary()
+  defp modeline_name_bytes(name) do
+    name
+    |> to_string()
+    |> :erlang.iolist_to_binary()
+    |> utf8_prefix_bytes(255)
   end
 
   @spec bounded_modeline_text_and_target(String.t(), String.t(), non_neg_integer()) ::

--- a/lib/minga_editor/shell/traditional/modeline.ex
+++ b/lib/minga_editor/shell/traditional/modeline.ex
@@ -61,8 +61,10 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
 
   @type separator_style :: :powerline | :round | :slant | :none
   @type render_segment :: ModelineSegment.render_segment()
+  @type gui_segment ::
+          {atom(), String.t(), non_neg_integer(), non_neg_integer(), keyword(), atom() | nil}
   @type segment_group :: %{name: atom(), priority: integer(), segments: [render_segment()]}
-  @type gui_segments :: %{left: [render_segment()], right: [render_segment()]}
+  @type gui_segments :: %{left: [gui_segment()], right: [gui_segment()]}
   @type context :: %{
           data: modeline_data(),
           theme: Theme.t(),
@@ -153,14 +155,13 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
         modeline_segments_table \\ ModelineSegments
       ) do
     ctx = context(data, theme)
-    separator_style = Minga.Config.get(:modeline_separator)
     {left_names, right_names} = configured_segment_names(modeline_segments_table)
     left_groups = build_segment_groups(left_names, ctx, modeline_segments_table)
     right_groups = build_segment_groups(right_names, ctx, modeline_segments_table)
 
     %{
-      left: left_segments(left_groups, separator_style, ctx.bar_bg),
-      right: right_segments(right_groups, separator_style, ctx.bar_bg)
+      left: gui_segments_from_groups(left_groups),
+      right: gui_segments_from_groups(right_groups)
     }
   end
 
@@ -500,6 +501,13 @@ defmodule MingaEditor.Shell.Traditional.Modeline do
   @spec drop_group([segment_group()], :left | :right, atom(), :left | :right) :: [segment_group()]
   defp drop_group(groups, side, name, side), do: Enum.reject(groups, &(&1.name == name))
   defp drop_group(groups, _drop_side, _name, _own_side), do: groups
+
+  @spec gui_segments_from_groups([segment_group()]) :: [gui_segment()]
+  defp gui_segments_from_groups(groups) do
+    Enum.flat_map(groups, fn %{name: name, segments: segments} ->
+      Enum.map(segments, fn {text, fg, bg, opts, target} -> {name, text, fg, bg, opts, target} end)
+    end)
+  end
 
   @spec groups_width([segment_group()], [segment_group()], separator_style(), non_neg_integer()) ::
           non_neg_integer()

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -53,6 +53,7 @@ struct StatusBarUpdate: Sendable {
     let backgroundSubagentCount: UInt16
     let backgroundSubagentLabel: String
     let indent: IndentInfo
+    let modelineSegmentsPresent: Bool
     let modelineLeftSegments: [Wire.StatusBarSegment]
     let modelineRightSegments: [Wire.StatusBarSegment]
     let selection: SelectionInfo
@@ -90,6 +91,7 @@ struct StatusBarUpdate: Sendable {
         backgroundSubagentCount: UInt16,
         backgroundSubagentLabel: String,
         indent: IndentInfo = .init(kind: 0, size: 2),
+        modelineSegmentsPresent: Bool = false,
         modelineLeftSegments: [Wire.StatusBarSegment] = [],
         modelineRightSegments: [Wire.StatusBarSegment] = [],
         selection: SelectionInfo = .init(mode: 0, size: 0)
@@ -126,6 +128,7 @@ struct StatusBarUpdate: Sendable {
         self.backgroundSubagentCount = backgroundSubagentCount
         self.backgroundSubagentLabel = backgroundSubagentLabel
         self.indent = indent
+        self.modelineSegmentsPresent = modelineSegmentsPresent
         self.modelineLeftSegments = modelineLeftSegments
         self.modelineRightSegments = modelineRightSegments
         self.selection = selection
@@ -720,6 +723,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
         var sessionStatus: UInt8 = 0
         var agentStatus: UInt8 = 0
         var indent = StatusBarUpdate.IndentInfo(kind: 0, size: 2)
+        var modelineSegmentsPresent = false
         var modelineLeftSegments: [Wire.StatusBarSegment] = []
         var modelineRightSegments: [Wire.StatusBarSegment] = []
         var selection = StatusBarUpdate.SelectionInfo(mode: 0, size: 0)
@@ -833,13 +837,14 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             case 0x0B: // ModelineSegments: version(1) + left_count(2) + right_count(2) + segments...
                 guard sectionLen >= 5 else { throw ProtocolDecodeError.malformed }
                 let version = data[sStart]
-                guard version == 1 else { break }
+                guard version == 1 || version == 2 else { break }
+                modelineSegmentsPresent = true
                 let leftCount = Int(readU16(data, sStart + 1))
                 let rightCount = Int(readU16(data, sStart + 3))
                 var segmentPos = sStart + 5
                 let sectionEnd = sStart + sectionLen
-                modelineLeftSegments = try decodeStatusBarSegments(data: data, pos: &segmentPos, count: leftCount, end: sectionEnd)
-                modelineRightSegments = try decodeStatusBarSegments(data: data, pos: &segmentPos, count: rightCount, end: sectionEnd)
+                modelineLeftSegments = try decodeStatusBarSegments(data: data, pos: &segmentPos, count: leftCount, end: sectionEnd, version: version)
+                modelineRightSegments = try decodeStatusBarSegments(data: data, pos: &segmentPos, count: rightCount, end: sectionEnd, version: version)
                 guard segmentPos == sectionEnd else { throw ProtocolDecodeError.malformed }
 
             case 0x0C: // Selection: selection_mode(1) + selection_size(4)
@@ -868,6 +873,7 @@ func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
             backgroundSubagentCount: backgroundSubagentCount,
             backgroundSubagentLabel: backgroundSubagentLabel,
             indent: indent,
+            modelineSegmentsPresent: modelineSegmentsPresent,
             modelineLeftSegments: modelineLeftSegments,
             modelineRightSegments: modelineRightSegments,
             selection: selection
@@ -2484,11 +2490,21 @@ private func readRequiredUTF8(_ data: Data.SubSequence) throws -> String {
     return string
 }
 
-private func decodeStatusBarSegments(data: Data, pos: inout Int, count: Int, end: Int) throws -> [Wire.StatusBarSegment] {
+private func decodeStatusBarSegments(data: Data, pos: inout Int, count: Int, end: Int, version: UInt8) throws -> [Wire.StatusBarSegment] {
     var segments: [Wire.StatusBarSegment] = []
     segments.reserveCapacity(count)
 
     for index in 0..<count {
+        var kind = "custom"
+        if version >= 2 {
+            guard pos + 1 <= end else { throw ProtocolDecodeError.malformed }
+            let kindLen = Int(data[pos]); pos += 1
+            guard pos + kindLen <= end else { throw ProtocolDecodeError.malformed }
+            guard let decodedKind = String(data: data[pos..<(pos + kindLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+            kind = decodedKind
+            pos += kindLen
+        }
+
         guard pos + 9 <= end else { throw ProtocolDecodeError.malformed }
         let fg = readU24(data, pos); pos += 3
         let bg = readU24(data, pos); pos += 3
@@ -2501,7 +2517,7 @@ private func decodeStatusBarSegments(data: Data, pos: inout Int, count: Int, end
         guard pos + commandLen <= end else { throw ProtocolDecodeError.malformed }
         guard let command = String(data: data[pos..<(pos + commandLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
         pos += commandLen
-        segments.append(Wire.StatusBarSegment(id: index, text: text, fgColor: fg, bgColor: bg, attrs: attrs, command: command))
+        segments.append(Wire.StatusBarSegment(id: index, kind: kind, text: text, fgColor: fg, bgColor: bg, attrs: attrs, command: command))
     }
 
     return segments

--- a/macos/Sources/Protocol/ProtocolTypes.swift
+++ b/macos/Sources/Protocol/ProtocolTypes.swift
@@ -134,11 +134,22 @@ enum Wire {
     /// A configured modeline segment from the gui_status_bar modeline segment section.
     struct StatusBarSegment: Sendable, Equatable, Identifiable {
         let id: Int
+        let kind: String
         let text: String
         let fgColor: UInt32
         let bgColor: UInt32
         let attrs: UInt8
         let command: String
+
+        init(id: Int, kind: String = "custom", text: String, fgColor: UInt32, bgColor: UInt32, attrs: UInt8, command: String) {
+            self.id = id
+            self.kind = kind
+            self.text = text
+            self.fgColor = fgColor
+            self.bgColor = bgColor
+            self.attrs = attrs
+            self.command = command
+        }
 
         var isBold: Bool { attrs & 0x01 != 0 }
         var isUnderline: Bool { attrs & 0x02 != 0 }

--- a/macos/Sources/Views/StatusBarView.swift
+++ b/macos/Sources/Views/StatusBarView.swift
@@ -64,6 +64,7 @@ final class StatusBarState {
     var backgroundSubagentCount: UInt16 = 0
     var backgroundSubagentLabel: String = ""
     var indent: StatusBarUpdate.IndentInfo = .init(kind: 0, size: 2)
+    var modelineSegmentsPresent: Bool = false
     var modelineLeftSegments: [Wire.StatusBarSegment] = []
     var modelineRightSegments: [Wire.StatusBarSegment] = []
     var selection: StatusBarUpdate.SelectionInfo = .init(mode: 0, size: 0)
@@ -106,6 +107,8 @@ final class StatusBarState {
         if self.backgroundSubagentCount != data.backgroundSubagentCount { self.backgroundSubagentCount = data.backgroundSubagentCount }
         if self.backgroundSubagentLabel != data.backgroundSubagentLabel { self.backgroundSubagentLabel = data.backgroundSubagentLabel }
         if self.indent != data.indent { self.indent = data.indent }
+        let hasModelineSegments = data.modelineSegmentsPresent || !data.modelineLeftSegments.isEmpty || !data.modelineRightSegments.isEmpty
+        if self.modelineSegmentsPresent != hasModelineSegments { self.modelineSegmentsPresent = hasModelineSegments }
         if self.modelineLeftSegments != data.modelineLeftSegments { self.modelineLeftSegments = data.modelineLeftSegments }
         if self.modelineRightSegments != data.modelineRightSegments { self.modelineRightSegments = data.modelineRightSegments }
         if self.selection != data.selection { self.selection = data.selection }
@@ -169,6 +172,12 @@ final class StatusBarState {
     }
 }
 
+private struct StatusBarSegmentGroup: Identifiable {
+    let id: String
+    let kind: String
+    var segments: [Wire.StatusBarSegment]
+}
+
 struct StatusBarView: View {
     let state: StatusBarState
     let theme: ThemeColors
@@ -184,6 +193,8 @@ struct StatusBarView: View {
     private let leftFixedControlsWidth: CGFloat = 101
     private let rightFixedControlsWidth: CGFloat = 34
     private let maxCenterStatusWidth: CGFloat = 320
+
+    @State private var gitCopied = false
 
     var body: some View {
         GeometryReader { proxy in
@@ -211,6 +222,62 @@ struct StatusBarView: View {
         .background(theme.modelineBarBg)
         .focusable(false)
         .focusEffectDisabled()
+    }
+
+    private var leftModelineGroups: [StatusBarSegmentGroup] {
+        statusBarGroups(
+            from: state.modelineLeftSegments,
+            fallbackKinds: ["agent", "background_agent", "git", "diagnostics"],
+            side: "left"
+        )
+    }
+
+    private var rightModelineGroups: [StatusBarSegmentGroup] {
+        statusBarGroups(
+            from: state.modelineRightSegments,
+            fallbackKinds: ["parser", "lsp", "indent", "filetype", "position", "mode"],
+            side: "right"
+        )
+    }
+
+    private func statusBarGroups(from segments: [Wire.StatusBarSegment], fallbackKinds: [String], side: String) -> [StatusBarSegmentGroup] {
+        guard state.modelineSegmentsPresent else {
+            return fallbackKinds.enumerated().map { index, kind in
+                StatusBarSegmentGroup(id: "fallback-\(side)-\(index)-\(kind)", kind: kind, segments: [])
+            }
+        }
+
+        var groups: [StatusBarSegmentGroup] = []
+        for segment in segments {
+            let kind = segment.kind.isEmpty ? "custom" : segment.kind
+            if let lastIndex = groups.indices.last, groups[lastIndex].kind == kind {
+                groups[lastIndex].segments.append(segment)
+            } else {
+                groups.append(StatusBarSegmentGroup(id: "\(side)-\(groups.count)-\(kind)", kind: kind, segments: [segment]))
+            }
+        }
+        return groups
+    }
+
+    private func command(in group: StatusBarSegmentGroup) -> String? {
+        group.segments.first { !$0.command.isEmpty }?.command
+    }
+
+    @ViewBuilder
+    private func commandButton<Content: View>(command: String?, tooltip: String, @ViewBuilder content: () -> Content) -> some View {
+        if let command {
+            Button(action: { encoder?.sendExecuteCommand(name: command) }) {
+                content()
+            }
+            .buttonStyle(.plain)
+            .help(tooltip)
+            .onHover { isHovered in
+                if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+        } else {
+            content()
+                .help(tooltip)
+        }
     }
 
     func modelineLayout(totalWidth: CGFloat) -> StatusBarModelineLayout {
@@ -265,6 +332,390 @@ struct StatusBarView: View {
                 .foregroundStyle(theme.modelineBarFg.opacity(0.45))
                 .lineLimit(1)
                 .truncationMode(.tail)
+        }
+    }
+
+    // MARK: - Native configured groups
+
+    @ViewBuilder
+    private func nativeModelineGroup(_ group: StatusBarSegmentGroup) -> some View {
+        switch group.kind {
+        case "mode":
+            modeBadge
+        case "filename":
+            filenameSegment(command: command(in: group))
+        case "git":
+            if state.hasGit && !state.gitBranch.isEmpty { gitSegment }
+        case "agent":
+            agentStatusIcon
+        case "background_agent":
+            if state.hasRunningBackgroundSubagents { backgroundSubagentSegment }
+        case "diagnostics":
+            diagnosticIndicators(command: command(in: group))
+        case "parser":
+            parserStatusIcon(command: command(in: group))
+        case "lsp":
+            if state.hasLsp { lspIndicator(command: command(in: group)) }
+        case "filetype":
+            if !state.filetype.isEmpty { filetypeSegment(command: command(in: group)) }
+        case "position":
+            positionSegment
+        case "percent":
+            percentSegment
+        case "indent":
+            indentSegment(command: command(in: group))
+        default:
+            customModelineGroup(group)
+        }
+    }
+
+    @ViewBuilder
+    private var agentStatusIcon: some View {
+        switch state.agentStatus {
+        case 1:
+            ProgressView()
+                .scaleEffect(0.45)
+                .frame(width: 14, height: barHeight)
+        case 2:
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 9))
+                .foregroundStyle(theme.statusbarAccentFg)
+                .frame(width: 14, height: barHeight)
+        case 3:
+            Image(systemName: "exclamationmark.circle.fill")
+                .font(.system(size: 9))
+                .foregroundStyle(theme.gutterErrorFg)
+                .frame(width: 14, height: barHeight)
+        case 4:
+            Image(systemName: "pencil.and.outline")
+                .font(.system(size: 9))
+                .foregroundStyle(theme.agentStatusNeedsYou)
+                .frame(width: 14, height: barHeight)
+        default:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var backgroundSubagentSegment: some View {
+        Button(action: {
+            encoder?.sendExecuteCommand(name: "agent_session_switcher")
+        }) {
+            HStack(spacing: 3) {
+                Image(systemName: "person.2.wave.2.fill")
+                    .font(.system(size: 9, weight: .medium))
+                Text(backgroundSubagentText)
+                    .font(.system(size: 11))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(theme.modelineBarFg.opacity(0.65))
+        }
+        .buttonStyle(.plain)
+        .help("Background sub-agents")
+        .padding(.horizontal, 6)
+        .onHover { isHovered in
+            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+
+    private var backgroundSubagentText: String {
+        if state.backgroundSubagentLabel.isEmpty {
+            return "bg:\(state.backgroundSubagentCount)"
+        }
+
+        return "bg:\(state.backgroundSubagentCount) \(state.backgroundSubagentLabel)"
+    }
+
+    @ViewBuilder
+    private var gitSegment: some View {
+        Button(action: {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(state.gitBranch, forType: .string)
+            gitCopied = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                gitCopied = false
+            }
+        }) {
+            HStack(spacing: 3) {
+                Image(systemName: gitCopied ? "checkmark" : "arrow.triangle.branch")
+                    .font(.system(size: 9, weight: .medium))
+                Text(gitCopied ? "Copied!" : state.gitBranch)
+                    .font(.system(size: 11))
+                    .lineLimit(1)
+
+                if !gitCopied && gitSyncing {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .scaleEffect(0.45)
+                        .frame(width: 12, height: barHeight)
+                }
+
+                if !gitCopied, state.hasGitDiffStats {
+                    HStack(spacing: 4) {
+                        if state.gitAdded > 0 {
+                            Text("+\(state.gitAdded)")
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(theme.gitAddedFg)
+                        }
+                        if state.gitModified > 0 {
+                            Text("~\(state.gitModified)")
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(theme.gitModifiedFg)
+                        }
+                        if state.gitDeleted > 0 {
+                            Text("-\(state.gitDeleted)")
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(theme.gitDeletedFg)
+                        }
+                    }
+                }
+            }
+            .foregroundStyle(theme.modelineBarFg.opacity(0.6))
+        }
+        .buttonStyle(.plain)
+        .help("Click to copy branch name")
+        .padding(.horizontal, 6)
+        .onHover { isHovered in
+            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+
+    @ViewBuilder
+    private func diagnosticIndicators(command: String? = nil) -> some View {
+        let hasAny = state.errorCount > 0 || state.warningCount > 0 || state.infoCount > 0 || state.hintCount > 0
+        if hasAny {
+            Button(action: {
+                if let command {
+                    encoder?.sendExecuteCommand(name: command)
+                } else {
+                    encoder?.sendTogglePanel(panel: 1)
+                }
+            }) {
+                HStack(spacing: 6) {
+                    if state.errorCount > 0 {
+                        HStack(spacing: 2) {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 9))
+                            Text("\(state.errorCount)")
+                                .font(.system(size: 11))
+                        }
+                        .foregroundStyle(theme.gutterErrorFg)
+                    }
+                    if state.warningCount > 0 {
+                        HStack(spacing: 2) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .font(.system(size: 9))
+                            Text("\(state.warningCount)")
+                                .font(.system(size: 11))
+                        }
+                        .foregroundStyle(theme.gutterWarningFg)
+                    }
+                    if state.infoCount > 0 {
+                        HStack(spacing: 2) {
+                            Image(systemName: "info.circle.fill")
+                                .font(.system(size: 9))
+                            Text("\(state.infoCount)")
+                                .font(.system(size: 11))
+                        }
+                        .foregroundStyle(theme.gutterInfoFg)
+                    }
+                    if state.hintCount > 0 {
+                        HStack(spacing: 2) {
+                            Image(systemName: "lightbulb.fill")
+                                .font(.system(size: 9))
+                            Text("\(state.hintCount)")
+                                .font(.system(size: 11))
+                        }
+                        .foregroundStyle(theme.gutterHintFg)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+            .help("Show diagnostics (SPC c d)")
+            .padding(.horizontal, 4)
+            .onHover { isHovered in
+                if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func parserStatusIcon(command: String? = nil) -> some View {
+        switch state.parserStatus {
+        case 1:
+            commandButton(command: command, tooltip: "Tree-sitter parser unavailable") {
+                Image(systemName: "leaf.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(theme.gutterErrorFg)
+            }
+        case 2:
+            commandButton(command: command, tooltip: "Tree-sitter parser restarting") {
+                Image(systemName: "leaf.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(theme.gutterWarningFg)
+            }
+        default:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func lspIndicator(command: String? = nil) -> some View {
+        let info = lspInfo(state.lspStatus)
+        commandButton(command: command, tooltip: info.tooltip) {
+            Image(systemName: info.icon)
+                .font(.system(size: 9))
+                .foregroundStyle(info.color)
+                .padding(.horizontal, 4)
+        }
+    }
+
+    private func lspInfo(_ status: UInt8) -> (icon: String, tooltip: String, color: Color) {
+        switch status {
+        case 1:  return ("checkmark.circle.fill",         "LSP: ready",         theme.gitAddedFg)
+        case 2:  return ("arrow.triangle.2.circlepath",   "LSP: initializing…", theme.modelineBarFg.opacity(0.5))
+        case 3:  return ("arrow.triangle.2.circlepath",   "LSP: starting…",     theme.modelineBarFg.opacity(0.5))
+        case 4:  return ("exclamationmark.triangle.fill", "LSP: error",         theme.gutterErrorFg)
+        default: return ("circle",                        "LSP: inactive",      theme.modelineBarFg.opacity(0.3))
+        }
+    }
+
+    @ViewBuilder
+    private func indentSegment(command: String? = nil) -> some View {
+        Button(action: {
+            encoder?.sendExecuteCommand(name: command ?? "indent_picker")
+        }) {
+            Text("\(state.indent.label):\(state.indent.size)")
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(theme.modelineBarFg.opacity(0.65))
+        }
+        .buttonStyle(.plain)
+        .help("Indent settings")
+        .onHover { isHovered in
+            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+
+    @ViewBuilder
+    private func filetypeSegment(command: String? = nil) -> some View {
+        Button(action: {
+            encoder?.sendExecuteCommand(name: command ?? "set_language")
+        }) {
+            HStack(spacing: 3) {
+                if !state.icon.isEmpty {
+                    Text(state.icon)
+                        .font(.custom("Symbols Nerd Font Mono", size: 11))
+                        .foregroundStyle(state.iconColor)
+                }
+                Text(state.filetypeDisplay)
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.modelineBarFg.opacity(0.6))
+            }
+        }
+        .buttonStyle(.plain)
+        .help("Change language mode (SPC b l)")
+        .onHover { isHovered in
+            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+
+    @ViewBuilder
+    private func filenameSegment(command: String? = nil) -> some View {
+        if !state.filename.isEmpty {
+            Button(action: {
+                encoder?.sendExecuteCommand(name: command ?? "buffer_list")
+            }) {
+                HStack(spacing: 3) {
+                    Text(state.filename)
+                        .font(.system(size: 11))
+                        .foregroundStyle(theme.modelineBarFg.opacity(0.65))
+                        .lineLimit(1)
+                    if state.isDirty {
+                        Circle()
+                            .fill(theme.statusbarAccentFg.opacity(0.9))
+                            .frame(width: 5, height: 5)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+            .help("Buffer list")
+            .onHover { isHovered in
+                if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var positionSegment: some View {
+        if state.isAgentWindow {
+            Text("\(state.messageCount) msgs")
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(theme.modelineBarFg.opacity(0.7))
+        } else if state.selection.isActive {
+            Text(state.selection.displayText)
+                .font(.system(size: 11, design: .monospaced))
+                .monospacedDigit()
+                .contentTransition(.numericText())
+                .foregroundStyle(theme.modelineBarFg.opacity(0.7))
+                .help(state.selection.displayText)
+        } else {
+            Text("Ln \(state.cursorLine), Col \(state.cursorCol)")
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(theme.modelineBarFg.opacity(0.7))
+                .help("Line \(state.cursorLine), Column \(state.cursorCol)")
+        }
+    }
+
+    @ViewBuilder
+    private var percentSegment: some View {
+        Text(percentText)
+            .font(.system(size: 11, design: .monospaced))
+            .foregroundStyle(theme.modelineBarFg.opacity(0.55))
+            .help("Position in file")
+    }
+
+    private var percentText: String {
+        if state.lineCount <= 1 || state.cursorLine <= 1 {
+            return "Top"
+        }
+        if state.cursorLine >= state.lineCount {
+            return "Bot"
+        }
+        let numerator = max(0, Int(state.cursorLine) - 1) * 100
+        let denominator = max(1, Int(state.lineCount) - 1)
+        return "\(numerator / denominator)%"
+    }
+
+    @ViewBuilder
+    private var modeBadge: some View {
+        let (bg, fg) = modeColors(state.mode)
+        Text(state.modeName)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(fg)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(bg)
+            )
+            .help("\(state.modeName) mode")
+    }
+
+    private func modeColors(_ mode: UInt8) -> (Color, Color) {
+        switch mode {
+        case 0: return (theme.modeNormalBg, theme.modeNormalFg)
+        case 1: return (theme.modeInsertBg, theme.modeInsertFg)
+        case 2: return (theme.modeVisualBg, theme.modeVisualFg)
+        default: return (theme.modelineInfoBg, theme.modelineInfoFg)
+        }
+    }
+
+    @ViewBuilder
+    private func customModelineGroup(_ group: StatusBarSegmentGroup) -> some View {
+        HStack(spacing: 2) {
+            ForEach(group.segments) { segment in
+                StatusBarModelineSegmentView(segment: segment, encoder: encoder)
+            }
         }
     }
 
@@ -344,9 +795,8 @@ struct StatusBarView: View {
                 .clipped()
                 .contentShape(Rectangle())
 
-
-            boundedConfiguredModelineSegments(
-                state.modelineLeftSegments,
+            boundedNativeModelineGroups(
+                leftModelineGroups,
                 width: layout.leftModelineWidth,
                 alignment: .leading
             )
@@ -358,8 +808,8 @@ struct StatusBarView: View {
 
     private func rightStatusZone(_ layout: StatusBarModelineLayout) -> some View {
         HStack(spacing: sideSpacing) {
-            boundedConfiguredModelineSegments(
-                state.modelineRightSegments,
+            boundedNativeModelineGroups(
+                rightModelineGroups,
                 width: layout.rightModelineWidth,
                 alignment: .trailing
             )
@@ -374,8 +824,8 @@ struct StatusBarView: View {
         .contentShape(Rectangle())
     }
 
-    private func boundedConfiguredModelineSegments(_ segments: [Wire.StatusBarSegment], width: CGFloat, alignment: Alignment) -> some View {
-        configuredModelineSegments(segments)
+    private func boundedNativeModelineGroups(_ groups: [StatusBarSegmentGroup], width: CGFloat, alignment: Alignment) -> some View {
+        nativeModelineGroups(groups)
             .lineLimit(1)
             .truncationMode(.tail)
             .frame(width: width, height: barHeight, alignment: alignment)
@@ -383,10 +833,10 @@ struct StatusBarView: View {
             .clipped()
     }
 
-    private func configuredModelineSegments(_ segments: [Wire.StatusBarSegment]) -> some View {
-        HStack(spacing: 0) {
-            ForEach(segments) { segment in
-                StatusBarModelineSegmentView(segment: segment, encoder: encoder)
+    private func nativeModelineGroups(_ groups: [StatusBarSegmentGroup]) -> some View {
+        HStack(spacing: 8) {
+            ForEach(groups) { group in
+                nativeModelineGroup(group)
             }
         }
         .contentShape(Rectangle())
@@ -521,7 +971,8 @@ private struct StatusBarModelineSegmentView: View {
 
     @ViewBuilder
     private var segmentText: some View {
-        let text = Text(segment.text)
+        let displayText = trimmedDisplayText
+        let text = Text(displayText)
             .font(segmentFont)
             .fontWeight(segmentFontWeight)
             .foregroundStyle(color(segment.fgColor))
@@ -532,17 +983,29 @@ private struct StatusBarModelineSegmentView: View {
         if segment.isItalic {
             text
                 .italic()
-                .frame(minHeight: 24, maxHeight: 24, alignment: .center)
-                .background(color(segment.bgColor))
+                .padding(.horizontal, 6)
+                .frame(height: 18, alignment: .center)
+                .background(customBackground)
                 .contentShape(Rectangle())
                 .clipped()
         } else {
             text
-                .frame(minHeight: 24, maxHeight: 24, alignment: .center)
-                .background(color(segment.bgColor))
+                .padding(.horizontal, 6)
+                .frame(height: 18, alignment: .center)
+                .background(customBackground)
                 .contentShape(Rectangle())
                 .clipped()
         }
+    }
+
+    private var trimmedDisplayText: String {
+        let trimmed = segment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? segment.text : trimmed
+    }
+
+    private var customBackground: some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(color(segment.bgColor).opacity(0.18))
     }
 
     private var segmentFont: Font {

--- a/macos/Sources/Views/StatusBarView.swift
+++ b/macos/Sources/Views/StatusBarView.swift
@@ -195,6 +195,7 @@ struct StatusBarView: View {
     private let maxCenterStatusWidth: CGFloat = 320
 
     @State private var gitCopied = false
+    @State private var gitCopyResetTask: Task<Void, Never>?
 
     var body: some View {
         GeometryReader { proxy in
@@ -271,12 +272,13 @@ struct StatusBarView: View {
             }
             .buttonStyle(.plain)
             .help(tooltip)
-            .onHover { isHovered in
-                if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
+            .accessibilityLabel(tooltip)
+            .accessibilityHint("Runs the status bar action")
+            .statusBarPointingHand()
         } else {
             content()
                 .help(tooltip)
+                .accessibilityLabel(tooltip)
         }
     }
 
@@ -343,7 +345,7 @@ struct StatusBarView: View {
         case "mode":
             modeBadge
         case "filename":
-            filenameSegment(command: command(in: group))
+            filenameSegment(group: group, command: command(in: group))
         case "git":
             if state.hasGit && !state.gitBranch.isEmpty { gitSegment }
         case "agent":
@@ -376,21 +378,29 @@ struct StatusBarView: View {
             ProgressView()
                 .scaleEffect(0.45)
                 .frame(width: 14, height: barHeight)
+                .help("Agent thinking")
+                .accessibilityLabel("Agent thinking")
         case 2:
             Image(systemName: "bolt.fill")
                 .font(.system(size: 9))
                 .foregroundStyle(theme.statusbarAccentFg)
                 .frame(width: 14, height: barHeight)
+                .help("Agent executing tools")
+                .accessibilityLabel("Agent executing tools")
         case 3:
             Image(systemName: "exclamationmark.circle.fill")
                 .font(.system(size: 9))
                 .foregroundStyle(theme.gutterErrorFg)
                 .frame(width: 14, height: barHeight)
+                .help("Agent error")
+                .accessibilityLabel("Agent error")
         case 4:
             Image(systemName: "pencil.and.outline")
                 .font(.system(size: 9))
                 .foregroundStyle(theme.agentStatusNeedsYou)
                 .frame(width: 14, height: barHeight)
+                .help("Agent needs input")
+                .accessibilityLabel("Agent needs input")
         default:
             EmptyView()
         }
@@ -412,10 +422,10 @@ struct StatusBarView: View {
         }
         .buttonStyle(.plain)
         .help("Background sub-agents")
+        .accessibilityLabel(backgroundSubagentText)
+        .accessibilityHint("Switches to a background sub-agent session")
         .padding(.horizontal, 6)
-        .onHover { isHovered in
-            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
+        .statusBarPointingHand()
     }
 
     private var backgroundSubagentText: String {
@@ -432,8 +442,12 @@ struct StatusBarView: View {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(state.gitBranch, forType: .string)
             gitCopied = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            gitCopyResetTask?.cancel()
+            gitCopyResetTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(2))
+                guard !Task.isCancelled else { return }
                 gitCopied = false
+                gitCopyResetTask = nil
             }
         }) {
             HStack(spacing: 3) {
@@ -474,9 +488,13 @@ struct StatusBarView: View {
         }
         .buttonStyle(.plain)
         .help("Click to copy branch name")
+        .accessibilityLabel(gitCopied ? "Git branch copied" : "Git branch \(state.gitBranch)")
+        .accessibilityHint("Copies the branch name")
         .padding(.horizontal, 6)
-        .onHover { isHovered in
-            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        .statusBarPointingHand()
+        .onDisappear {
+            gitCopyResetTask?.cancel()
+            gitCopyResetTask = nil
         }
     }
 
@@ -532,11 +550,20 @@ struct StatusBarView: View {
             }
             .buttonStyle(.plain)
             .help("Show diagnostics (SPC c d)")
+            .accessibilityLabel(diagnosticsAccessibilityLabel)
+            .accessibilityHint("Shows diagnostics")
             .padding(.horizontal, 4)
-            .onHover { isHovered in
-                if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
+            .statusBarPointingHand()
         }
+    }
+
+    private var diagnosticsAccessibilityLabel: String {
+        var parts: [String] = []
+        if state.errorCount > 0 { parts.append("\(state.errorCount) errors") }
+        if state.warningCount > 0 { parts.append("\(state.warningCount) warnings") }
+        if state.infoCount > 0 { parts.append("\(state.infoCount) info") }
+        if state.hintCount > 0 { parts.append("\(state.hintCount) hints") }
+        return parts.isEmpty ? "Diagnostics" : "Diagnostics: \(parts.joined(separator: ", "))"
     }
 
     @ViewBuilder
@@ -591,9 +618,9 @@ struct StatusBarView: View {
         }
         .buttonStyle(.plain)
         .help("Indent settings")
-        .onHover { isHovered in
-            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
+        .accessibilityLabel("Indent settings: \(state.indent.label) \(state.indent.size)")
+        .accessibilityHint("Changes indentation settings")
+        .statusBarPointingHand()
     }
 
     @ViewBuilder
@@ -614,23 +641,26 @@ struct StatusBarView: View {
         }
         .buttonStyle(.plain)
         .help("Change language mode (SPC b l)")
-        .onHover { isHovered in
-            if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
+        .accessibilityLabel("Language mode \(state.filetypeDisplay)")
+        .accessibilityHint("Changes language mode")
+        .statusBarPointingHand()
     }
 
     @ViewBuilder
-    private func filenameSegment(command: String? = nil) -> some View {
-        if !state.filename.isEmpty {
+    private func filenameSegment(group: StatusBarSegmentGroup? = nil, command: String? = nil) -> some View {
+        let modelineText = group.map(filenameText(in:)) ?? ""
+        let displayText = modelineText.isEmpty ? state.filename : modelineText
+
+        if !displayText.isEmpty {
             Button(action: {
                 encoder?.sendExecuteCommand(name: command ?? "buffer_list")
             }) {
                 HStack(spacing: 3) {
-                    Text(state.filename)
+                    Text(displayText)
                         .font(.system(size: 11))
                         .foregroundStyle(theme.modelineBarFg.opacity(0.65))
                         .lineLimit(1)
-                    if state.isDirty {
+                    if modelineText.isEmpty && state.isDirty {
                         Circle()
                             .fill(theme.statusbarAccentFg.opacity(0.9))
                             .frame(width: 5, height: 5)
@@ -639,10 +669,17 @@ struct StatusBarView: View {
             }
             .buttonStyle(.plain)
             .help("Buffer list")
-            .onHover { isHovered in
-                if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
+            .accessibilityLabel("Buffer \(displayText)")
+            .accessibilityHint("Opens the buffer list")
+            .statusBarPointingHand()
         }
+    }
+
+    private func filenameText(in group: StatusBarSegmentGroup) -> String {
+        group.segments
+            .map(\.text)
+            .joined()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     @ViewBuilder
@@ -953,6 +990,7 @@ private struct StatusBarModelineSegmentView: View {
         if segment.command.isEmpty {
             segmentText
                 .contentShape(Rectangle())
+                .accessibilityLabel(trimmedDisplayText)
         } else {
             Button(action: {
                 encoder?.sendExecuteCommand(name: segment.command)
@@ -962,10 +1000,10 @@ private struct StatusBarModelineSegmentView: View {
             }
             .buttonStyle(.plain)
             .contentShape(Rectangle())
-            .help(segment.command)
-            .onHover { isHovered in
-                if isHovered { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
+            .help(accessibilityHelp)
+            .accessibilityLabel(trimmedDisplayText)
+            .accessibilityHint(accessibilityHint)
+            .statusBarPointingHand()
         }
     }
 
@@ -1008,6 +1046,17 @@ private struct StatusBarModelineSegmentView: View {
             .fill(color(segment.bgColor).opacity(0.18))
     }
 
+    private var accessibilityHelp: String {
+        if segment.command.isEmpty {
+            return trimmedDisplayText
+        }
+        return "\(trimmedDisplayText) (\(segment.command))"
+    }
+
+    private var accessibilityHint: String {
+        segment.command.isEmpty ? "Status bar segment" : "Runs \(segment.command)"
+    }
+
     private var segmentFont: Font {
         if StatusBarModelineFont.containsPrivateUseGlyph(segment.text) {
             return .custom("Symbols Nerd Font Mono", size: 11)
@@ -1026,6 +1075,35 @@ private struct StatusBarModelineSegmentView: View {
             green: Double((value >> 8) & 0xFF) / 255.0,
             blue: Double(value & 0xFF) / 255.0
         )
+    }
+}
+
+private struct StatusBarPointingHandModifier: ViewModifier {
+    @State private var didPushCursor = false
+
+    func body(content: Content) -> some View {
+        content
+            .onHover { hovering in
+                if hovering, !didPushCursor {
+                    NSCursor.pointingHand.push()
+                    didPushCursor = true
+                } else if !hovering, didPushCursor {
+                    NSCursor.pop()
+                    didPushCursor = false
+                }
+            }
+            .onDisappear {
+                if didPushCursor {
+                    NSCursor.pop()
+                    didPushCursor = false
+                }
+            }
+    }
+}
+
+private extension View {
+    func statusBarPointingHand() -> some View {
+        modifier(StatusBarPointingHandModifier())
     }
 }
 
@@ -1074,6 +1152,8 @@ private struct StatusBarIconButton: View {
         }
         .buttonStyle(.plain)
         .help(tooltip)
+        .accessibilityLabel(tooltip)
+        .accessibilityHint("Toggles this panel")
         .onHover { hovering in
             if reduceMotion {
                 isHovered = hovering
@@ -1082,8 +1162,8 @@ private struct StatusBarIconButton: View {
                     isHovered = hovering
                 }
             }
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
         }
+        .statusBarPointingHand()
     }
 }
 

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -352,7 +352,10 @@ struct GUIStatusBarDecoderTests {
         return section
     }
 
-    private func appendStatusBarSegment(_ data: inout Data, text: String, fg: UInt32, bg: UInt32, attrs: UInt8, command: String) {
+    private func appendStatusBarSegment(_ data: inout Data, kind: String? = nil, text: String, fg: UInt32, bg: UInt32, attrs: UInt8, command: String) {
+        if let kind {
+            appendString8(&data, kind)
+        }
         appendU24(&data, fg)
         appendU24(&data, bg)
         data.append(attrs)
@@ -569,11 +572,11 @@ struct GUIStatusBarDecoderTests {
         identity.append(0); identity.append(0); identity.append(0)
 
         var modelineSegments = Data()
-        modelineSegments.append(1) // version
+        modelineSegments.append(2) // version
         appendU16(&modelineSegments, 1) // left count
         appendU16(&modelineSegments, 1) // right count
-        appendStatusBarSegment(&modelineSegments, text: " NORMAL ", fg: 0xBBC2CF, bg: 0x51AFEF, attrs: 0x01, command: "")
-        appendStatusBarSegment(&modelineSegments, text: " Elixir ", fg: 0xC678DD, bg: 0x282C34, attrs: 0x00, command: "set_language")
+        appendStatusBarSegment(&modelineSegments, kind: "mode", text: " NORMAL ", fg: 0xBBC2CF, bg: 0x51AFEF, attrs: 0x01, command: "")
+        appendStatusBarSegment(&modelineSegments, kind: "filetype", text: " Elixir ", fg: 0xC678DD, bg: 0x282C34, attrs: 0x00, command: "set_language")
 
         let sections = [
             buildSection(SECTION_IDENTITY, identity),
@@ -592,12 +595,15 @@ struct GUIStatusBarDecoderTests {
             Issue.record("Expected .guiStatusBar"); return
         }
 
+        #expect(update.modelineSegmentsPresent)
         #expect(update.modelineLeftSegments.count == 1)
+        #expect(update.modelineLeftSegments[0].kind == "mode")
         #expect(update.modelineLeftSegments[0].text == " NORMAL ")
         #expect(update.modelineLeftSegments[0].fgColor == 0xBBC2CF)
         #expect(update.modelineLeftSegments[0].bgColor == 0x51AFEF)
         #expect(update.modelineLeftSegments[0].isBold)
         #expect(update.modelineRightSegments.count == 1)
+        #expect(update.modelineRightSegments[0].kind == "filetype")
         #expect(update.modelineRightSegments[0].text == " Elixir ")
         #expect(update.modelineRightSegments[0].command == "set_language")
     }
@@ -608,7 +614,7 @@ struct GUIStatusBarDecoderTests {
         identity.append(0); identity.append(0); identity.append(0)
 
         var modelineSegments = Data()
-        modelineSegments.append(2) // unsupported version
+        modelineSegments.append(3) // unsupported version
         appendU16(&modelineSegments, 1)
         appendU16(&modelineSegments, 0)
         appendStatusBarSegment(&modelineSegments, text: " HIDDEN ", fg: 0xBBC2CF, bg: 0x51AFEF, attrs: 0x00, command: "")

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -608,6 +608,45 @@ struct GUIStatusBarDecoderTests {
         #expect(update.modelineRightSegments[0].command == "set_language")
     }
 
+    @Test("Decode legacy v1 modeline segments as custom kind")
+    func decodeLegacyV1ModelineSegmentsSection() throws {
+        var identity = Data()
+        identity.append(0); identity.append(0); identity.append(0)
+
+        var modelineSegments = Data()
+        modelineSegments.append(1) // legacy version without segment names
+        appendU16(&modelineSegments, 1) // left count
+        appendU16(&modelineSegments, 1) // right count
+        appendStatusBarSegment(&modelineSegments, text: " LEGACY ", fg: 0xBBC2CF, bg: 0x51AFEF, attrs: 0x01, command: "")
+        appendStatusBarSegment(&modelineSegments, text: " Click ", fg: 0xC678DD, bg: 0x282C34, attrs: 0x00, command: "buffer_list")
+
+        let sections = [
+            buildSection(SECTION_IDENTITY, identity),
+            buildSection(SECTION_MODELINE_SEGMENTS, modelineSegments),
+        ]
+
+        var data = Data()
+        data.append(OP_GUI_STATUS_BAR)
+        data.append(UInt8(sections.count))
+        for s in sections { data.append(s) }
+
+        let (cmd, size) = try decodeCommand(data: data, offset: 0)
+        #expect(size == data.count)
+
+        guard case .guiStatusBar(let update) = cmd else {
+            Issue.record("Expected .guiStatusBar"); return
+        }
+
+        #expect(update.modelineSegmentsPresent)
+        #expect(update.modelineLeftSegments.count == 1)
+        #expect(update.modelineLeftSegments[0].kind == "custom")
+        #expect(update.modelineLeftSegments[0].text == " LEGACY ")
+        #expect(update.modelineLeftSegments[0].isBold)
+        #expect(update.modelineRightSegments.count == 1)
+        #expect(update.modelineRightSegments[0].kind == "custom")
+        #expect(update.modelineRightSegments[0].command == "buffer_list")
+    }
+
     @Test("Unsupported modeline segment section version is ignored")
     func unsupportedModelineSegmentVersionIsIgnored() throws {
         var identity = Data()

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -210,6 +210,107 @@ struct StatusBarViewViewTests {
         #expect(strings.contains("Ln 42, Col 9"))
     }
 
+    @Test("Fallback native status bar renders default built-ins without modeline segments")
+    @MainActor func fallbackNativeStatusBarRendersDefaultBuiltins() throws {
+        let state = statusBarState()
+        let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: nil)
+        let body = try sut.inspect()
+        let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("NORMAL"))
+        #expect(strings.contains("Elixir"))
+        #expect(strings.contains("Ln 42, Col 9"))
+        #expect(strings.contains("Spaces:2"))
+    }
+
+    @Test("Filename group uses BEAM modeline text for native rendering")
+    @MainActor func filenameGroupUsesModelineText() throws {
+        let state = statusBarState(leftSegments: [segment(1, " main.ex [1/2] recording @q ", kind: "filename")])
+        state.filename = "main.ex"
+        let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: nil)
+        let body = try sut.inspect()
+        let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+
+        #expect(strings.contains("main.ex [1/2] recording @q"))
+    }
+
+    @Test("Fallback built-in status bar controls emit default commands")
+    @MainActor func fallbackBuiltinControlsEmitDefaultCommands() throws {
+        let spy = SpyEncoder()
+        let state = statusBarState()
+        let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: spy)
+        let buttons = try sut.inspect().findAll(ViewType.Button.self)
+
+        for button in buttons {
+            try button.tap()
+        }
+
+        #expect(spy.guiActions.contains(.executeCommand(name: "set_language")))
+        #expect(spy.guiActions.contains(.executeCommand(name: "indent_picker")))
+    }
+
+    @Test("Configured built-in controls prefer BEAM command override")
+    @MainActor func configuredBuiltinControlsPreferBeamCommandOverride() throws {
+        let spy = SpyEncoder()
+        let state = statusBarState(rightSegments: [segment(1, " Elixir ", kind: "filetype", command: "filetype_menu")])
+        let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: spy)
+        let buttons = try sut.inspect().findAll(ViewType.Button.self)
+
+        for button in buttons {
+            try button.tap()
+        }
+
+        #expect(spy.guiActions.contains(.executeCommand(name: "filetype_menu")))
+        #expect(!spy.guiActions.contains(.executeCommand(name: "set_language")))
+    }
+
+    @Test("Filename control emits fallback buffer list command")
+    @MainActor func filenameControlEmitsFallbackBufferListCommand() throws {
+        let spy = SpyEncoder()
+        let state = statusBarState(leftSegments: [segment(1, " main.ex ", kind: "filename")])
+        let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: spy)
+        let buttons = try sut.inspect().findAll(ViewType.Button.self)
+
+        for button in buttons {
+            try button.tap()
+        }
+
+        #expect(spy.guiActions.contains(.executeCommand(name: "buffer_list")))
+    }
+
+    @Test("Filename control prefers BEAM command override")
+    @MainActor func filenameControlPrefersBeamCommandOverride() throws {
+        let spy = SpyEncoder()
+        let state = statusBarState(leftSegments: [segment(1, " main.ex ", kind: "filename", command: "custom_buffer_picker")])
+        let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: spy)
+        let buttons = try sut.inspect().findAll(ViewType.Button.self)
+
+        for button in buttons {
+            try button.tap()
+        }
+
+        #expect(spy.guiActions.contains(.executeCommand(name: "custom_buffer_picker")))
+        #expect(!spy.guiActions.contains(.executeCommand(name: "buffer_list")))
+    }
+
+    @Test("Custom unknown status bar segment remains visible and clickable")
+    @MainActor func customUnknownStatusBarSegmentVisibleAndClickable() throws {
+        let spy = SpyEncoder()
+        let state = statusBarState(leftSegments: [segment(1, " 42W ", kind: "word_count", command: "word_count")])
+        let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: spy)
+        let body = try sut.inspect()
+        let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
+        let buttons = body.findAll(ViewType.Button.self)
+
+        #expect(strings.contains("42W"))
+
+        for button in buttons {
+            try button.tap()
+        }
+
+        #expect(spy.guiActions.contains(.executeCommand(name: "word_count")))
+    }
+
     @Test("Configured modeline groups receive bounded budgets")
     @MainActor func configuredModelineGroupsReceiveBoundedBudgets() throws {
         let longLeftSegments = (0..<20).map { segment($0, " LEFT-SEGMENT-WITH-LONG-TEXT-\($0) ") }

--- a/macos/Tests/MingaTests/SwiftUIViewTests.swift
+++ b/macos/Tests/MingaTests/SwiftUIViewTests.swift
@@ -158,8 +158,8 @@ struct BreadcrumbBarViewTests {
 @Suite("StatusBarView View Structure")
 struct StatusBarViewViewTests {
 
-    private func segment(_ id: Int, _ text: String, command: String = "") -> Wire.StatusBarSegment {
-        Wire.StatusBarSegment(id: id, text: text, fgColor: 0xFFFFFF, bgColor: 0x000000, attrs: 0, command: command)
+    private func segment(_ id: Int, _ text: String, kind: String = "custom", command: String = "") -> Wire.StatusBarSegment {
+        Wire.StatusBarSegment(id: id, kind: kind, text: text, fgColor: 0xFFFFFF, bgColor: 0x000000, attrs: 0, command: command)
     }
 
     @MainActor private func statusBarState(
@@ -196,8 +196,8 @@ struct StatusBarViewViewTests {
             gitAdded: 0, gitModified: 0, gitDeleted: 0,
             icon: "", iconColorR: 0, iconColorG: 0, iconColorB: 0, filename: "", diagnosticHint: "",
             backgroundSubagentCount: 0, backgroundSubagentLabel: "",
-            modelineLeftSegments: [segment(0, " NORMAL ")],
-            modelineRightSegments: [segment(0, " Elixir "), segment(1, " 42:9 ")]
+            modelineLeftSegments: [segment(0, " NORMAL ", kind: "mode")],
+            modelineRightSegments: [segment(0, " Elixir ", kind: "filetype"), segment(1, " 42:9 ", kind: "position")]
         ))
 
         let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: nil)
@@ -205,9 +205,9 @@ struct StatusBarViewViewTests {
         let texts = body.findAll(ViewInspectorQuery.text)
         let strings = texts.compactMap { try? $0.string() }
 
-        #expect(strings.contains(" NORMAL "))
-        #expect(strings.contains(" Elixir "))
-        #expect(strings.contains(" 42:9 "))
+        #expect(strings.contains("NORMAL"))
+        #expect(strings.contains("Elixir"))
+        #expect(strings.contains("Ln 42, Col 9"))
     }
 
     @Test("Configured modeline groups receive bounded budgets")
@@ -235,7 +235,7 @@ struct StatusBarViewViewTests {
 
         let body = try sut.inspect()
         let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
-        #expect(strings.contains(" CLICKABLE-RIGHT-SEGMENT-WITH-LONG-TEXT "))
+        #expect(strings.contains("CLICKABLE-RIGHT-SEGMENT-WITH-LONG-TEXT"))
     }
 
     @Test("Layout protects center lane with huge left and tiny right groups")
@@ -389,8 +389,8 @@ struct StatusBarViewViewTests {
             gitAdded: 0, gitModified: 0, gitDeleted: 0,
             icon: "", iconColorR: 0, iconColorG: 0, iconColorB: 0, filename: "", diagnosticHint: "",
             backgroundSubagentCount: 0, backgroundSubagentLabel: "",
-            modelineLeftSegments: [segment(0, " NORMAL ")],
-            modelineRightSegments: [segment(0, " 7 msgs ")]
+            modelineLeftSegments: [segment(0, " NORMAL ", kind: "mode")],
+            modelineRightSegments: [segment(0, " 7 msgs ", kind: "position")]
         ))
 
         let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: nil)
@@ -400,8 +400,8 @@ struct StatusBarViewViewTests {
 
         // Model name no longer appears in the status bar (lives in agent chat header only)
         #expect(!strings.contains("claude-3-5-sonnet"))
-        #expect(strings.contains(" 7 msgs "))
-        #expect(strings.contains(" NORMAL "))
+        #expect(strings.contains("7 msgs"))
+        #expect(strings.contains("NORMAL"))
     }
 
     @Test("Git branch shown when flag is set")
@@ -416,7 +416,7 @@ struct StatusBarViewViewTests {
             gitAdded: 0, gitModified: 0, gitDeleted: 0,
             icon: "", iconColorR: 0, iconColorG: 0, iconColorB: 0, filename: "", diagnosticHint: "",
             backgroundSubagentCount: 0, backgroundSubagentLabel: "",
-            modelineLeftSegments: [segment(0, " main ")], modelineRightSegments: []
+            modelineLeftSegments: [segment(0, " main ", kind: "git")], modelineRightSegments: []
         ))
 
         let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: nil)
@@ -424,7 +424,7 @@ struct StatusBarViewViewTests {
         let texts = body.findAll(ViewInspectorQuery.text)
         let strings = texts.compactMap { try? $0.string() }
 
-        #expect(strings.contains(" main "))
+        #expect(strings.contains("main"))
     }
 
     @Test("Diagnostic counts shown when non-zero")
@@ -439,7 +439,7 @@ struct StatusBarViewViewTests {
             gitAdded: 0, gitModified: 0, gitDeleted: 0,
             icon: "", iconColorR: 0, iconColorG: 0, iconColorB: 0, filename: "", diagnosticHint: "",
             backgroundSubagentCount: 0, backgroundSubagentLabel: "",
-            modelineLeftSegments: [], modelineRightSegments: [segment(0, " 3 "), segment(1, " 7 ")]
+            modelineLeftSegments: [], modelineRightSegments: [segment(0, " 3 ", kind: "diagnostics"), segment(1, " 7 ", kind: "diagnostics")]
         ))
 
         let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: nil)
@@ -447,8 +447,8 @@ struct StatusBarViewViewTests {
         let texts = body.findAll(ViewInspectorQuery.text)
         let strings = texts.compactMap { try? $0.string() }
 
-        #expect(strings.contains(" 3 "))
-        #expect(strings.contains(" 7 "))
+        #expect(strings.contains("3"))
+        #expect(strings.contains("7"))
     }
 
     @Test("Background subagent segment shows count and label")
@@ -463,7 +463,7 @@ struct StatusBarViewViewTests {
             gitAdded: 0, gitModified: 0, gitDeleted: 0,
             icon: "", iconColorR: 0, iconColorG: 0, iconColorB: 0, filename: "", diagnosticHint: "",
             backgroundSubagentCount: 2, backgroundSubagentLabel: "session-2: tests",
-            modelineLeftSegments: [segment(0, " bg:2 session-2: tests")], modelineRightSegments: []
+            modelineLeftSegments: [segment(0, " bg:2 session-2: tests", kind: "background_agent")], modelineRightSegments: []
         ))
 
         let sut = StatusBarView(state: state, theme: ThemeColors(), encoder: nil)
@@ -471,7 +471,7 @@ struct StatusBarViewViewTests {
         let texts = body.findAll(ViewInspectorQuery.text)
         let strings = texts.compactMap { try? $0.string() }
 
-        #expect(strings.contains(" bg:2 session-2: tests"))
+        #expect(strings.contains("bg:2 session-2: tests"))
     }
 
     @Test("Background subagent segment is hidden when count is zero")

--- a/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
+++ b/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
@@ -364,6 +364,26 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
       assert label == "session-3: tests"
     end
 
+    test "omits modeline segment section when no GUI modeline data is attached" do
+      binary = ProtocolGUI.encode_gui_status_bar({:buffer, status_data()})
+      sections = status_sections(binary)
+
+      refute Map.has_key?(sections, 0x0B)
+    end
+
+    test "encodes explicit empty modeline segment section" do
+      data =
+        Map.put(status_data(), :modeline_segments, %{
+          left: [],
+          right: []
+        })
+
+      binary = ProtocolGUI.encode_gui_status_bar({:buffer, data})
+      sections = status_sections(binary)
+
+      assert <<2, 0::16, 0::16>> = Map.fetch!(sections, 0x0B)
+    end
+
     test "encodes configured modeline segment section" do
       data =
         Map.put(status_data(), :modeline_segments, %{

--- a/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
+++ b/test/minga_editor/frontend/protocol/gui_protocol_unit_test.exs
@@ -367,35 +367,35 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
     test "encodes configured modeline segment section" do
       data =
         Map.put(status_data(), :modeline_segments, %{
-          left: [{" NORMAL ", 0xBBC2CF, 0x51AFEF, [bold: true], nil}],
-          right: [{" Elixir ", 0xC678DD, 0x282C34, [], :set_language}]
+          left: [{:mode, " NORMAL ", 0xBBC2CF, 0x51AFEF, [bold: true], nil}],
+          right: [{:filetype, " Elixir ", 0xC678DD, 0x282C34, [], :set_language}]
         })
 
       binary = ProtocolGUI.encode_gui_status_bar({:buffer, data})
       sections = status_sections(binary)
 
-      <<1::8, 1::16, 1::16, left_fg::24, left_bg::24, left_attrs::8, left_len::16,
-        left_text::binary-size(left_len), left_target_len::16,
-        left_target::binary-size(left_target_len), right_fg::24, right_bg::24, right_attrs::8,
-        right_len::16, right_text::binary-size(right_len), right_target_len::16,
-        right_target::binary-size(right_target_len)>> = Map.fetch!(sections, 0x0B)
+      <<2::8, 1::16, 1::16, segments::binary>> = Map.fetch!(sections, 0x0B)
+      {left, rest} = take_modeline_segment(segments)
+      {right, ""} = take_modeline_segment(rest)
 
-      assert left_fg == 0xBBC2CF
-      assert left_bg == 0x51AFEF
-      assert left_attrs == 0x01
-      assert left_text == " NORMAL "
-      assert left_target == ""
-      assert right_fg == 0xC678DD
-      assert right_bg == 0x282C34
-      assert right_attrs == 0x00
-      assert right_text == " Elixir "
-      assert right_target == "set_language"
+      assert left.name == "mode"
+      assert left.fg == 0xBBC2CF
+      assert left.bg == 0x51AFEF
+      assert left.attrs == 0x01
+      assert left.text == " NORMAL "
+      assert left.target == ""
+      assert right.name == "filetype"
+      assert right.fg == 0xC678DD
+      assert right.bg == 0x282C34
+      assert right.attrs == 0x00
+      assert right.text == " Elixir "
+      assert right.target == "set_language"
     end
 
     test "bounds oversized modeline segment text to the 16-bit section limit" do
       data =
         Map.put(status_data(), :modeline_segments, %{
-          left: [{String.duplicate("x", 70_000), 0xBBC2CF, 0x51AFEF, [], nil}],
+          left: [{:custom, String.duplicate("x", 70_000), 0xBBC2CF, 0x51AFEF, [], nil}],
           right: []
         })
 
@@ -405,14 +405,14 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
 
       assert byte_size(payload) <= 65_535
 
-      <<1::8, 1::16, 0::16, _fg::24, _bg::24, _attrs::8, text_len::16, _rest::binary>> =
-        payload
+      <<2::8, 1::16, 0::16, segments::binary>> = payload
+      {segment, ""} = take_modeline_segment(segments)
 
-      assert text_len <= 65_524
+      assert byte_size(segment.text) <= 65_512
     end
 
     test "drops trailing modeline segments when the section would overflow" do
-      tiny_segment = {"x", 0xBBC2CF, 0x51AFEF, [], nil}
+      tiny_segment = {:custom, "x", 0xBBC2CF, 0x51AFEF, [], nil}
 
       data =
         Map.put(status_data(), :modeline_segments, %{
@@ -423,14 +423,14 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
       binary = ProtocolGUI.encode_gui_status_bar({:buffer, data})
       sections = status_sections(binary)
       payload = Map.fetch!(sections, 0x0B)
-      <<1::8, left_count::16, 0::16, _segments::binary>> = payload
+      <<2::8, left_count::16, 0::16, _segments::binary>> = payload
 
       assert byte_size(payload) <= 65_535
       assert left_count == 128
     end
 
     test "caps total modeline segments across both sides" do
-      tiny_segment = {"x", 0xBBC2CF, 0x51AFEF, [], nil}
+      tiny_segment = {:custom, "x", 0xBBC2CF, 0x51AFEF, [], nil}
 
       data =
         Map.put(status_data(), :modeline_segments, %{
@@ -440,15 +440,15 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
 
       binary = ProtocolGUI.encode_gui_status_bar({:buffer, data})
       payload = binary |> status_sections() |> Map.fetch!(0x0B)
-      <<1::8, left_count::16, right_count::16, _segments::binary>> = payload
+      <<2::8, left_count::16, right_count::16, _segments::binary>> = payload
 
       assert left_count == 100
       assert right_count == 28
     end
 
     test "does not truncate oversized modeline command targets" do
-      first_segment = {String.duplicate("x", 65_507), 0xBBC2CF, 0x51AFEF, [], nil}
-      clickable_segment = {"Y", 0xBBC2CF, 0x51AFEF, [], :set_language}
+      first_segment = {:custom, String.duplicate("x", 65_487), 0xBBC2CF, 0x51AFEF, [], nil}
+      clickable_segment = {:filetype, "Y", 0xBBC2CF, 0x51AFEF, [], :set_language}
 
       data =
         Map.put(status_data(), :modeline_segments, %{
@@ -458,7 +458,7 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
 
       binary = ProtocolGUI.encode_gui_status_bar({:buffer, data})
       payload = binary |> status_sections() |> Map.fetch!(0x0B)
-      <<1::8, 2::16, 0::16, segments::binary>> = payload
+      <<2::8, 2::16, 0::16, segments::binary>> = payload
       {_first, rest} = take_modeline_segment(segments)
       {second, ""} = take_modeline_segment(rest)
 
@@ -469,13 +469,13 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
     test "sanitizes invalid UTF-8 modeline text before encoding" do
       data =
         Map.put(status_data(), :modeline_segments, %{
-          left: [{<<"BAD", 0xFF>>, 0xBBC2CF, 0x51AFEF, [], nil}],
+          left: [{:custom, <<"BAD", 0xFF>>, 0xBBC2CF, 0x51AFEF, [], nil}],
           right: []
         })
 
       binary = ProtocolGUI.encode_gui_status_bar({:buffer, data})
       payload = binary |> status_sections() |> Map.fetch!(0x0B)
-      <<1::8, 1::16, 0::16, segments::binary>> = payload
+      <<2::8, 1::16, 0::16, segments::binary>> = payload
       {segment, ""} = take_modeline_segment(segments)
 
       assert segment.text == "BAD"
@@ -534,10 +534,11 @@ defmodule MingaEditor.Frontend.Protocol.GUIProtocolUnitTest do
   end
 
   defp take_modeline_segment(
-         <<fg::24, bg::24, attrs::8, text_len::16, text::binary-size(text_len), target_len::16,
-           target::binary-size(target_len), rest::binary>>
+         <<name_len::8, name::binary-size(name_len), fg::24, bg::24, attrs::8, text_len::16,
+           text::binary-size(text_len), target_len::16, target::binary-size(target_len),
+           rest::binary>>
        ) do
-    {%{fg: fg, bg: bg, attrs: attrs, text: text, target: target}, rest}
+    {%{name: name, fg: fg, bg: bg, attrs: attrs, text: text, target: target}, rest}
   end
 
   defp parse_status_sections(rest, 0, acc) do

--- a/test/minga_editor/shell/traditional/modeline_test.exs
+++ b/test/minga_editor/shell/traditional/modeline_test.exs
@@ -370,11 +370,11 @@ defmodule MingaEditor.Shell.Traditional.ModelineTest do
 
         segments = Modeline.gui_segments(@base_data)
 
-        assert Enum.any?(segments.left, fn {text, _fg, _bg, _opts, _target} ->
-                 text == " LEFTY "
+        assert Enum.any?(segments.left, fn {name, text, _fg, _bg, _opts, _target} ->
+                 name == segment_name and text == " LEFTY "
                end)
 
-        refute Enum.any?(segments.right, fn {text, _fg, _bg, _opts, _target} ->
+        refute Enum.any?(segments.right, fn {_name, text, _fg, _bg, _opts, _target} ->
                  text == " LEFTY "
                end)
       after
@@ -672,7 +672,7 @@ defmodule MingaEditor.Shell.Traditional.ModelineTest do
   end
 
   defp segment_text(segments) do
-    Enum.map_join(segments, fn {text, _fg, _bg, _opts, _target} -> text end)
+    Enum.map_join(segments, fn {_name, text, _fg, _bg, _opts, _target} -> text end)
   end
 
   describe "parser status indicator" do

--- a/test/minga_editor/status_bar/data_test.exs
+++ b/test/minga_editor/status_bar/data_test.exs
@@ -44,7 +44,7 @@ defmodule MingaEditor.StatusBar.DataTest do
     assert {:buffer, buffer_data} = Data.with_modeline_segments(data, state.theme, table)
     assert %{left: left, right: right} = buffer_data.modeline_segments
 
-    assert Enum.any?(left ++ right, fn {text, _fg, _bg, _opts, _target} ->
+    assert Enum.any?(left ++ right, fn {_name, text, _fg, _bg, _opts, _target} ->
              text == " GUI_ONLY "
            end)
   end


### PR DESCRIPTION
# TL;DR
Preserves configurable modeline segment ordering while restoring the macOS status bar to native SwiftUI rendering. Built-in segments now render as compact platform controls instead of terminal-style colored blocks, and custom segments render as subtle native chips.

## Context
The configurable modeline work made the macOS status bar render raw styled modeline segments directly. That kept configuration working, but visually regressed the native GUI bar compared to the previous compact layout.

## Changes
- Tags GUI modeline segments with their segment name, such as `mode`, `git`, `filetype`, and `position`, so Swift can tell which built-in it is rendering.
- Keeps v1 Swift decoder compatibility while adding v2 named modeline segment decoding.
- Renders known built-ins with native SwiftUI controls: mode badge, diagnostics, parser/LSP indicators, filetype, position, indent, filename, background agents, and git status.
- Preserves configured ordering and visibility from BEAM modeline config for the native GUI status bar.
- Renders unknown/custom modeline segments as compact native chips instead of full-height TUI color blocks.
- Preserves per-segment click commands for native built-ins and custom segments.
- Updates protocol and configuration docs for the named GUI modeline segment payload.

## Verification
- `mix test.llm`
- `mix swift.build`
- `xcodebuild -project macos/Minga.xcodeproj -scheme Minga test`
- `make lint`
- `git diff --check`
- `prtk-code-reviewer` targeted re-check: PASS
- `reviewer` final gate: PASS

## Acceptance Criteria Addressed
- Configurable modeline segments still control macOS status bar ordering and visibility ✅
- macOS status bar built-ins render with native SwiftUI styling instead of raw terminal-style blocks ✅
- Custom modeline segments still render in the GUI with a native fallback style ✅
- Existing status bar click behavior is preserved through BEAM-provided segment commands ✅
