### PR TITLE
test(mouse): slim gesture boundary coverage

### DIFF
--- a/test/minga/lsp/client_test.exs
+++ b/test/minga/lsp/client_test.exs
@@ -1,10 +1,7 @@
 defmodule Minga.LSP.ClientTest do
-  # async: false because mock LSP server spawns OS processes that may not
-  # start in time under heavy parallel test load
+  # async: false because MockLSPServer spawns OS processes that can race under heavy parallel load.
   use ExUnit.Case, async: false
 
-  # OS process startup (MockLSPServer) makes these inherently slow (~250ms each).
-  # Excluded from test.llm; runs in test.heavy and full suite.
   @moduletag :heavy
 
   alias Minga.Diagnostics
@@ -12,6 +9,8 @@ defmodule Minga.LSP.ClientTest do
   alias Minga.Test.MockLSPServer
 
   @ready_timeout 10_000
+  @event_timeout 5_000
+  @uri "file:///tmp/test.ex"
 
   setup context do
     diag_server = start_supervised!({Diagnostics, name: :"diag_#{System.unique_integer()}"})
@@ -29,7 +28,6 @@ defmodule Minga.LSP.ClientTest do
       Minga.Events.subscribe(:diagnostics_updated)
     end
 
-    # Subscribe to LSP status events and wait for the client to be ready.
     Minga.Events.subscribe(:lsp_status_changed)
 
     client =
@@ -38,58 +36,37 @@ defmodule Minga.LSP.ClientTest do
          server_config: server_config, root_path: System.tmp_dir!(), diagnostics: diag_server}
       )
 
-    case Client.status(client) do
-      :ready ->
-        :ok
-
-      _ ->
-        assert_receive {:minga_event, :lsp_status_changed,
-                        %Minga.Events.LspStatusEvent{name: :mock_lsp, status: :ready}},
-                       @ready_timeout
-    end
+    wait_until_ready(client)
 
     %{client: client, diag_server: diag_server}
   end
 
   describe "initialize handshake" do
-    test "client reaches ready status", %{client: client} do
-      assert Client.status(client) == :ready
-    end
-
-    test "parses server capabilities", %{client: client} do
+    test "client exposes negotiated server metadata", %{client: client} do
       caps = Client.capabilities(client)
+
+      assert Client.status(client) == :ready
       assert is_map(caps)
       assert caps["textDocumentSync"]["openClose"] == true
-    end
-
-    test "negotiates position encoding", %{client: client} do
-      # Mock server advertises utf-8
       assert Client.encoding(client) == :utf8
-    end
-
-    test "reports server name", %{client: client} do
       assert Client.server_name(client) == :mock_lsp
     end
   end
 
   describe "document sync" do
-    @uri "file:///tmp/test.ex"
-
-    test "didOpen sends notification and receives diagnostics", %{
+    test "didOpen sends notification and stores diagnostics", %{
       client: client,
       diag_server: diag_server
     } do
       Minga.Events.subscribe(:diagnostics_updated)
+
       Client.did_open(client, @uri, "elixir", "defmodule Test do\nend\n")
 
       assert_receive {:minga_event, :diagnostics_updated,
                       %Minga.Events.DiagnosticsUpdatedEvent{uri: @uri}},
-                     5_000
+                     @event_timeout
 
-      diags = Diagnostics.for_uri(diag_server, @uri)
-      assert length(diags) == 1
-
-      [diag] = diags
+      assert [diag] = Diagnostics.for_uri(diag_server, @uri)
       assert diag.severity == :warning
       assert diag.message == "mock warning on line 1"
       assert diag.source == "mock_lsp"
@@ -98,7 +75,7 @@ defmodule Minga.LSP.ClientTest do
       assert diag.range.start_col == 0
     end
 
-    test "didOpen before initialization is sent once the client becomes ready", %{
+    test "didOpen during startup is sent once the client becomes ready", %{
       diag_server: diag_server
     } do
       uri = "file:///tmp/queued_open.ex"
@@ -123,37 +100,26 @@ defmodule Minga.LSP.ClientTest do
 
       Client.did_open(client, uri, "elixir", "defmodule QueuedOpen do\nend\n")
 
-      assert_receive {:minga_event, :lsp_status_changed,
-                      %Minga.Events.LspStatusEvent{name: :mock_lsp, status: :ready}},
-                     5_000
+      wait_until_ready(client)
 
       assert_receive {:minga_event, :diagnostics_updated,
                       %Minga.Events.DiagnosticsUpdatedEvent{uri: ^uri}},
-                     5_000
+                     @event_timeout
 
-      state = :sys.get_state(client)
-      assert Map.has_key?(state.open_documents, uri)
-      assert state.pending_document_opens == %{}
+      assert [_diag] = Diagnostics.for_uri(diag_server, uri)
     end
 
-    test "didChange does not crash", %{client: client} do
+    test "didChange, didSave, and unknown-uri didChange are safe no-ops", %{client: client} do
       Client.did_open(client, @uri, "elixir", "original")
-      :sys.get_state(client)
+      assert Client.status(client) == :ready
 
       Client.did_change(client, @uri, "modified")
-      :sys.get_state(client)
-
-      # Still alive and ready
       assert Client.status(client) == :ready
-    end
-
-    test "didSave does not crash", %{client: client} do
-      Client.did_open(client, @uri, "elixir", "content")
-      :sys.get_state(client)
 
       Client.did_save(client, @uri)
-      :sys.get_state(client)
+      assert Client.status(client) == :ready
 
+      Client.did_change(client, "file:///unknown", "text")
       assert Client.status(client) == :ready
     end
 
@@ -164,7 +130,7 @@ defmodule Minga.LSP.ClientTest do
 
       assert_receive {:minga_event, :diagnostics_updated,
                       %Minga.Events.DiagnosticsUpdatedEvent{uri: @uri}},
-                     5_000
+                     @event_timeout
 
       assert Diagnostics.for_uri(diag_server, @uri) != []
 
@@ -172,26 +138,15 @@ defmodule Minga.LSP.ClientTest do
 
       assert_receive {:minga_event, :diagnostics_updated,
                       %Minga.Events.DiagnosticsUpdatedEvent{uri: @uri}},
-                     5_000
+                     @event_timeout
 
       assert Diagnostics.for_uri(diag_server, @uri) == []
-    end
-
-    test "didChange on unknown URI is a no-op", %{client: client} do
-      Client.did_change(client, "file:///unknown", "text")
-      :sys.get_state(client)
-      assert Client.status(client) == :ready
     end
   end
 
   describe "workspace/configuration" do
     @tag request_configuration: true,
-         server_settings: %{
-           "mock_lsp" => %{
-             "nested" => %{"enabled" => true},
-             "value" => 1
-           }
-         }
+         server_settings: %{"mock_lsp" => %{"nested" => %{"enabled" => true}, "value" => 1}}
     test "responds to server configuration requests with section results", %{
       diag_server: diag_server
     } do
@@ -199,7 +154,7 @@ defmodule Minga.LSP.ClientTest do
                       %Minga.Events.DiagnosticsUpdatedEvent{
                         uri: "file:///tmp/configuration-test.ex"
                       }},
-                     5_000
+                     @event_timeout
 
       [diag] = Diagnostics.for_uri(diag_server, "file:///tmp/configuration-test.ex")
 
@@ -218,7 +173,7 @@ defmodule Minga.LSP.ClientTest do
                       %Minga.Events.DiagnosticsUpdatedEvent{
                         uri: "file:///tmp/unknown-request-test.ex"
                       }},
-                     5_000
+                     @event_timeout
 
       [diag] = Diagnostics.for_uri(diag_server, "file:///tmp/unknown-request-test.ex")
 
@@ -228,16 +183,15 @@ defmodule Minga.LSP.ClientTest do
   end
 
   describe "status events" do
-    test "client broadcasts :lsp_status_changed with :stopped on shutdown", %{client: client} do
-      # Setup already proved :ready fires (via assert_receive). Test :stopped.
+    test "client broadcasts stopped without a spurious crash event on shutdown", %{client: client} do
       Minga.Events.subscribe(:lsp_status_changed)
+
       Client.shutdown(client)
 
       assert_receive {:minga_event, :lsp_status_changed,
                       %Minga.Events.LspStatusEvent{name: :mock_lsp, status: :stopped}},
-                     5_000
+                     @event_timeout
 
-      # Clean shutdown must not produce a spurious :crashed event.
       refute_receive {:minga_event, :lsp_status_changed,
                       %Minga.Events.LspStatusEvent{status: :crashed}},
                      200
@@ -245,26 +199,31 @@ defmodule Minga.LSP.ClientTest do
   end
 
   describe "async request/response" do
-    test "request/3 returns a reference", %{client: client} do
-      ref =
+    test "request/3 returns unique references while the client stays ready", %{client: client} do
+      ref1 =
         Client.request(client, "textDocument/completion", %{
-          "textDocument" => %{"uri" => "file:///tmp/test.ex"},
+          "textDocument" => %{"uri" => @uri},
           "position" => %{"line" => 0, "character" => 0}
         })
 
-      assert is_reference(ref)
-
-      # This test only verifies the async request can be sent without crashing.
-      assert Client.status(client) == :ready
-    end
-
-    test "multiple requests return unique references", %{client: client} do
-      ref1 = Client.request(client, "textDocument/hover", %{})
       ref2 = Client.request(client, "textDocument/hover", %{})
 
       assert is_reference(ref1)
       assert is_reference(ref2)
       assert ref1 != ref2
+      assert Client.status(client) == :ready
+    end
+  end
+
+  defp wait_until_ready(client) do
+    case Client.status(client) do
+      :ready ->
+        :ok
+
+      _ ->
+        assert_receive {:minga_event, :lsp_status_changed,
+                        %Minga.Events.LspStatusEvent{name: :mock_lsp, status: :ready}},
+                       @ready_timeout
     end
   end
 end

--- a/test/minga_agent/session_test.exs
+++ b/test/minga_agent/session_test.exs
@@ -247,7 +247,8 @@ defmodule MingaAgent.SessionTest do
 
   defp send_provider_event(session, event) do
     send(session, {:agent_provider_event, event})
-    :sys.get_state(session)
+    Session.status(session)
+    :ok
   end
 
   defp mcp_session_builtin_tool do
@@ -290,17 +291,11 @@ defmodule MingaAgent.SessionTest do
   end
 
   describe "initial state" do
-    test "starts with idle status", %{session: session} do
+    test "starts idle with a system message and zero usage", %{session: session} do
       assert Session.status(session) == :idle
-    end
-
-    test "starts with a session-started system message", %{session: session} do
-      messages = Session.messages(session)
-      assert [{:system, text, :info}] = messages
+      assert [{:system, text, :info}] = Session.messages(session)
       assert String.starts_with?(text, "Session started")
-    end
 
-    test "starts with zero usage", %{session: session} do
       usage = Session.usage(session)
       assert usage.input == 0
       assert usage.output == 0
@@ -412,58 +407,24 @@ defmodule MingaAgent.SessionTest do
   end
 
   describe "send_prompt/2" do
-    test "adds user message and streams response", %{session: session} do
+    test "adds messages, broadcasts stream events, and records usage", %{session: session} do
       :ok = Session.send_prompt(session, "Hello!")
-      await_turn_complete()
+
+      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
+      assert_receive {:agent_event, _, {:text_delta, "Hello "}}, @event_timeout
+      assert_receive {:agent_event, _, {:text_delta, "world!"}}, @event_timeout
+      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
 
       messages = Session.messages(session)
-
-      # Should have system message + user message + assistant message + usage
-      assert length(messages) >= 3
       assert {:system, _, :info} = Enum.at(messages, 0)
       assert {:user, "Hello!"} = Enum.at(messages, 1)
       assert {:assistant, "Hello world!"} = Enum.at(messages, 2)
-    end
-
-    test "accumulates token usage", %{session: session} do
-      :ok = Session.send_prompt(session, "Test")
-      await_turn_complete()
+      assert Enum.any?(messages, &match?({:usage, %{input: 100, output: 50, cost: 0.01}}, &1))
 
       usage = Session.usage(session)
       assert usage.input == 100
       assert usage.output == 50
       assert usage.cost == 0.01
-    end
-
-    test "broadcasts status changes", %{session: session} do
-      :ok = Session.send_prompt(session, "Test")
-
-      assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
-      assert_receive {:agent_event, _, {:status_changed, :idle}}, @event_timeout
-    end
-
-    test "broadcasts text deltas", %{session: session} do
-      :ok = Session.send_prompt(session, "Test")
-
-      assert_receive {:agent_event, _, {:text_delta, "Hello "}}, @event_timeout
-      assert_receive {:agent_event, _, {:text_delta, "world!"}}, @event_timeout
-    end
-  end
-
-  describe "per-turn usage" do
-    test "appends usage message after AgentEnd", %{session: session} do
-      :ok = Session.send_prompt(session, "Test")
-      await_turn_complete()
-
-      messages = Session.messages(session)
-
-      usage_msg =
-        Enum.find(messages, fn
-          {:usage, _} -> true
-          _ -> false
-        end)
-
-      assert {:usage, %{input: 100, output: 50, cost: 0.01}} = usage_msg
     end
   end
 
@@ -512,25 +473,16 @@ defmodule MingaAgent.SessionTest do
   end
 
   describe "new_session/1" do
-    test "clears messages and resets status", %{session: session} do
+    test "clears messages, resets status, and resets usage", %{session: session} do
       :ok = Session.send_prompt(session, "First")
       await_turn_complete()
-
       assert length(Session.messages(session)) > 1
 
       :ok = Session.new_session(session)
 
-      messages = Session.messages(session)
-      assert [{:system, text, :info}] = messages
+      assert [{:system, text, :info}] = Session.messages(session)
       assert String.starts_with?(text, "Session cleared")
       assert Session.status(session) == :idle
-    end
-
-    test "resets usage counters", %{session: session} do
-      :ok = Session.send_prompt(session, "Test")
-      await_turn_complete()
-
-      :ok = Session.new_session(session)
 
       usage = Session.usage(session)
       assert usage.input == 0
@@ -808,7 +760,7 @@ defmodule MingaAgent.SessionTest do
 
       current_id = Session.session_id(session)
       Session.add_system_message(session, "unsaved local note")
-      :sys.get_state(session)
+      assert {:system, "unsaved local note", :info} in Session.messages(session)
 
       SessionStore.save(
         %{
@@ -1004,7 +956,7 @@ defmodule MingaAgent.SessionTest do
   end
 
   describe "metadata/1" do
-    test "returns session metadata with id, model, and created_at", %{session: session} do
+    test "returns idle session metadata before any user prompt", %{session: session} do
       meta = Session.metadata(session)
 
       assert is_binary(meta.id)
@@ -1012,61 +964,43 @@ defmodule MingaAgent.SessionTest do
       assert meta.message_count >= 1
       assert meta.cost == 0.0
       assert meta.status == :idle
-    end
-
-    test "first_prompt is nil when no user messages", %{session: session} do
-      meta = Session.metadata(session)
       assert meta.first_prompt == nil
     end
 
     test "first_prompt returns first user message text", %{session: session} do
       Session.send_prompt(session, "Hello there")
-      # Wait for prompt to be added to messages
       assert_receive {:agent_event, _, :messages_changed}, @event_timeout
 
-      meta = Session.metadata(session)
-      assert meta.first_prompt == "Hello there"
+      assert Session.metadata(session).first_prompt == "Hello there"
     end
   end
 
   # ── Queue API ──────────────────────────────────────────────────────────────
 
   describe "combine_queue_entries_to_text/1" do
-    test "returns empty string for empty list" do
+    test "handles empty, single, and multiple string queues" do
       assert Session.combine_queue_entries_to_text([]) == ""
-    end
-
-    test "returns a single string unchanged" do
       assert Session.combine_queue_entries_to_text(["hello"]) == "hello"
+
+      assert Session.combine_queue_entries_to_text(["first", "second", "third"]) ==
+               "first\n\nsecond\n\nthird"
     end
 
-    test "joins multiple strings with double newlines" do
-      result = Session.combine_queue_entries_to_text(["first", "second", "third"])
-      assert result == "first\n\nsecond\n\nthird"
-    end
-
-    test "extracts text from ContentPart lists" do
+    test "extracts text content parts and skips non-text parts" do
       parts = [
         %ReqLLM.Message.ContentPart{type: :text, text: "hello "},
+        %ReqLLM.Message.ContentPart{type: :image, text: nil},
         %ReqLLM.Message.ContentPart{type: :text, text: "world"}
       ]
 
       assert Session.combine_queue_entries_to_text([parts]) == "hello world"
     end
 
-    test "skips image ContentParts when extracting text" do
-      parts = [
-        %ReqLLM.Message.ContentPart{type: :text, text: "describe this"},
-        %ReqLLM.Message.ContentPart{type: :image, text: nil}
-      ]
-
-      assert Session.combine_queue_entries_to_text([parts]) == "describe this"
-    end
-
     test "mixes strings and ContentPart lists" do
       parts = [%ReqLLM.Message.ContentPart{type: :text, text: "part text"}]
-      result = Session.combine_queue_entries_to_text(["string entry", parts])
-      assert result == "string entry\n\npart text"
+
+      assert Session.combine_queue_entries_to_text(["string entry", parts]) ==
+               "string entry\n\npart text"
     end
   end
 
@@ -1080,8 +1014,7 @@ defmodule MingaAgent.SessionTest do
 
       Session.subscribe(slow_session)
 
-      # Wait for provider to start
-      :sys.get_state(slow_session)
+      assert is_pid(Session.get_provider(slow_session))
 
       %{slow_session: slow_session}
     end
@@ -1278,7 +1211,7 @@ defmodule MingaAgent.SessionTest do
         )
 
       Session.subscribe(slow_session)
-      :sys.get_state(slow_session)
+      assert is_pid(Session.get_provider(slow_session))
 
       %{slow_session: slow_session}
     end
@@ -1426,7 +1359,7 @@ defmodule MingaAgent.SessionTest do
         Session.start_link(provider: SlowMockProvider, provider_opts: [])
 
       Session.subscribe(slow_session)
-      :sys.get_state(slow_session)
+      assert is_pid(Session.get_provider(slow_session))
 
       :ok = Session.send_prompt(slow_session, "hello")
       assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
@@ -1640,7 +1573,7 @@ defmodule MingaAgent.SessionTest do
         Session.start_link(provider: SlowMockProvider, provider_opts: [])
 
       Session.subscribe(slow_session)
-      :sys.get_state(slow_session)
+      assert is_pid(Session.get_provider(slow_session))
 
       :ok = Session.send_prompt(slow_session, "first")
       assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout

--- a/test/minga_editor/integration/lsp_wiring_test.exs
+++ b/test/minga_editor/integration/lsp_wiring_test.exs
@@ -1,154 +1,101 @@
 defmodule Minga.Integration.LspWiringTest do
   @moduledoc """
-  Integration tests for LSP feature wiring in the Editor GenServer.
-
-  These tests verify that trigger messages (timer, save event, scroll)
-  route correctly through the Editor without crashing, and that LSP
-  responses with complex keys (tuple dispatch) are handled properly.
-
-  None of these tests require a real or mock LSP server. They test at
-  the GenServer message boundary: send a trigger, sync with
-  `:sys.get_state/1`, assert the editor is alive and state changed.
+  Thin Editor GenServer smoke tests for LSP trigger and response routing.
   """
+
   use Minga.Test.EditorCase, async: true
 
   alias Minga.Events
+  alias MingaEditor.State.LSP
 
-  # 50-line buffer for scroll tests
-  @scroll_content Enum.map_join(1..50, "\n", &"line #{&1}")
-
-  # ── Code lens / inlay hints on open ────────────────────────────────────────
-
-  describe "code lens and inlay hints on buffer open" do
-    test "timer message is handled without crash when no LSP client" do
+  describe "LSP no-op triggers" do
+    test "deferred and save triggers are safe without an LSP client" do
       ctx = start_editor("defmodule Foo do\n  def bar, do: :ok\nend")
 
-      # Simulate the deferred timer firing (normally 800ms after open).
-      # With no LSP client registered, code_lens/inlay_hints no-op gracefully.
       send(ctx.editor, :request_code_lens_and_inlay_hints)
+      assert sync_editor(ctx) == :normal
 
-      # Sync: if the handler crashed, get_state would raise.
-      state = :sys.get_state(ctx.editor)
-      assert state.workspace.editing.mode == :normal
+      save_event = %Events.BufferEvent{buffer: ctx.buffer, path: "/tmp/test.ex"}
+      send(ctx.editor, {:minga_event, :buffer_saved, save_event})
+      assert sync_editor(ctx) == :normal
     end
 
-    test "timer message with no active buffer is gracefully handled" do
+    test "deferred trigger is safe without an active buffer" do
       ctx = start_editor("hello")
 
-      # Remove the active buffer to simulate the edge case
       :sys.replace_state(ctx.editor, fn state ->
         put_in(state.workspace.buffers.active, nil)
       end)
 
-      # Should not crash even with no active buffer
       send(ctx.editor, :request_code_lens_and_inlay_hints)
-      state = :sys.get_state(ctx.editor)
-      assert is_map(state)
+
+      assert sync_editor(ctx) == :normal
     end
   end
-
-  # ── Code lens / inlay hints on save ────────────────────────────────────────
-
-  describe "code lens and inlay hints on save" do
-    test "save event triggers lens and hint requests without crash" do
-      ctx = start_editor("hello world")
-
-      # Send a buffer_saved event (the Editor subscribes to this in init)
-      save_event = %Events.BufferEvent{buffer: ctx.buffer, path: "/tmp/test.ex"}
-      send(ctx.editor, {:minga_event, :buffer_saved, save_event})
-
-      # Sync and verify the editor is still alive
-      state = :sys.get_state(ctx.editor)
-      assert state.workspace.editing.mode == :normal
-    end
-  end
-
-  # ── Inlay hints on scroll ──────────────────────────────────────────────────
-
-  describe "inlay hints on scroll" do
-    test "scroll wheel skips inlay hint timer in headless mode" do
-      ctx = start_editor(@scroll_content)
-
-      # Scroll down with the mouse wheel
-      send_mouse(ctx, 10, 10, :wheel_down)
-
-      # In headless mode, the inlay hint debounce timer is quarantined
-      # (skipped) to avoid non-deterministic timer messages in tests.
-      state = :sys.get_state(ctx.editor)
-
-      assert state.lsp.inlay_hint_debounce_timer == nil,
-             "inlay hint debounce timer should be skipped in headless mode"
-    end
-  end
-
-  # ── Mouse hover LSP response routing ───────────────────────────────────────
 
   describe "mouse hover LSP response routing" do
-    test "response with {:hover_mouse, row, col} creates popup at mouse position" do
+    test "tuple-keyed hover response creates a popup at the mouse position" do
       ctx = start_editor("defmodule Foo do\n  def bar, do: :ok\nend")
-
-      # Inject a fake pending LSP request with a {:hover_mouse, row, col} key
       ref = make_ref()
 
       :sys.replace_state(ctx.editor, fn state ->
-        %{
-          state
-          | workspace: %{
-              state.workspace
-              | lsp_pending: Map.put(state.workspace.lsp_pending, ref, {:hover_mouse, 5, 20})
-            }
-        }
+        put_in(state.workspace.lsp_pending[ref], {:hover_mouse, 5, 20})
       end)
 
-      # Send an LSP response for that ref
       hover_result =
         {:ok, %{"contents" => %{"kind" => "plaintext", "value" => "fn bar() :: :ok"}}}
 
       send(ctx.editor, {:lsp_response, ref, hover_result})
 
-      # Wait for the response to be processed and render to complete
       state =
-        wait_until(ctx, fn s -> s.shell_state.hover_popup != nil end,
+        wait_until(ctx, fn state -> state.shell_state.hover_popup != nil end,
           max_attempts: 10,
           interval_ms: 10,
           message: "hover popup should be created from {:hover_mouse, ...} response"
         )
 
-      assert state.shell_state.hover_popup != nil
       assert state.shell_state.hover_popup.anchor_row == 5
       assert state.shell_state.hover_popup.anchor_col == 20
     end
   end
 
-  # ── Selection range cleanup on mode exit ───────────────────────────────────
-
   describe "selection range cleanup on visual mode exit" do
     test "leaving visual mode clears selection range state" do
       ctx = start_editor("hello world\nsecond line")
 
-      # Inject fake selection range state
       :sys.replace_state(ctx.editor, fn state ->
         %{
           state
           | lsp:
-              MingaEditor.State.LSP.set_selection_ranges(state.lsp, [
-                %{"range" => %{"start" => %{"line" => 0}, "end" => %{"line" => 1}}}
-              ])
-              |> Map.put(:selection_range_index, 1)
+              state.lsp |> LSP.set_selection_ranges([selection_range()]) |> LSP.expand_selection()
         }
       end)
 
-      # Enter visual mode then exit
       send_keys_sync(ctx, "v")
       assert editor_mode(ctx) == :visual
 
       send_keys_sync(ctx, "<Esc>")
       assert editor_mode(ctx) == :normal
 
-      # Selection range state should be cleared
-      state = :sys.get_state(ctx.editor)
+      state =
+        wait_until(
+          ctx,
+          fn state ->
+            state.lsp.selection_ranges == nil and state.lsp.selection_range_index == 0
+          end,
+          max_attempts: 5,
+          interval_ms: 10,
+          message: "selection range state should be cleared after visual mode exit"
+        )
+
       assert state.lsp.selection_ranges == nil
       assert state.lsp.selection_range_index == 0
     end
+  end
+
+  defp sync_editor(ctx), do: GenServer.call(ctx.editor, :api_mode)
+
+  defp selection_range do
+    %{"range" => %{"start" => %{"line" => 0}, "end" => %{"line" => 1}}}
   end
 end

--- a/test/minga_editor/mouse_multi_click_test.exs
+++ b/test/minga_editor/mouse_multi_click_test.exs
@@ -1,16 +1,21 @@
 defmodule MingaEditor.MouseMultiClickTest do
-  @moduledoc "Tests for multi-click selection, modifier clicks, and new mouse features."
-  # Uses live editor startup and shared mouse/input state, so this file runs serially.
+  @moduledoc """
+  Focused mouse gesture tests at the Mouse.handle/7 boundary.
+  """
+
+  # async: false because this file stubs the global clipboard mock for middle-click paste.
   use ExUnit.Case, async: false
 
   import Hammox
 
   alias Minga.Buffer.Process, as: BufferProcess
-  alias MingaEditor
+  alias MingaEditor.Mouse
+  alias MingaEditor.Startup
+  alias MingaEditor.State, as: EditorState
 
   @gutter 6
-  # Content starts at row 1 because the tab bar occupies row 0.
   @content_row 1
+  @shift 0x01
 
   setup :verify_on_exit!
 
@@ -19,9 +24,87 @@ defmodule MingaEditor.MouseMultiClickTest do
     :ok
   end
 
-  defp start_editor(content) do
+  describe "multi-click selection" do
+    test "double-click selects the word under the cursor" do
+      {state, buffer} = start_mouse_state("hello world foo")
+
+      state = mouse(state, @content_row, @gutter + 6, :left, :press, 0, 2)
+
+      assert editing_mode(state) == :visual
+      assert state.workspace.editing.mode_state.visual_type == :char
+      assert state.workspace.editing.mode_state.visual_anchor == {0, 6}
+      assert BufferProcess.cursor(buffer) == {0, 10}
+    end
+
+    test "triple-click selects the clicked line" do
+      {state, _buffer} = start_mouse_state("hello\nworld\nfoo")
+
+      state = mouse(state, @content_row + 1, @gutter + 2, :left, :press, 0, 3)
+
+      assert editing_mode(state) == :visual
+      assert state.workspace.editing.mode_state.visual_type == :line
+      assert state.workspace.editing.mode_state.visual_anchor == {1, 0}
+    end
+  end
+
+  describe "modifier click selection" do
+    test "shift-click from normal mode starts a visual selection from the existing cursor" do
+      {state, buffer} = start_mouse_state("hello world foo bar")
+      state = mouse(state, @content_row, @gutter, :left, :press)
+      state = mouse(state, @content_row, @gutter, :left, :release)
+
+      state = mouse(state, @content_row, @gutter + 10, :left, :press, @shift)
+
+      assert editing_mode(state) == :visual
+      assert state.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert BufferProcess.cursor(buffer) == {0, 10}
+    end
+  end
+
+  describe "scrolling" do
+    test "horizontal wheel events adjust the active viewport" do
+      {state, _buffer} =
+        start_mouse_state(
+          "a very long line that extends beyond the viewport width for testing horizontal scroll"
+        )
+
+      state = mouse(state, @content_row, @gutter, :wheel_right, :press)
+      assert active_viewport(state).left == 6
+
+      state = mouse(state, @content_row, @gutter, :wheel_left, :press)
+      assert active_viewport(state).left == 0
+    end
+  end
+
+  describe "middle click" do
+    test "middle-click moves the cursor to the clicked position" do
+      {state, buffer} = start_mouse_state("hello world")
+
+      mouse(state, @content_row, @gutter + 5, :middle, :press)
+
+      assert BufferProcess.cursor(buffer) == {0, 5}
+    end
+  end
+
+  describe "invalid coordinates" do
+    test "negative coordinates are ignored" do
+      {state, buffer} = start_mouse_state("hello")
+      original = BufferProcess.cursor(buffer)
+
+      state = mouse(state, -1, 5, :left, :press)
+      assert BufferProcess.cursor(buffer) == original
+
+      mouse(state, @content_row, -3, :left, :press)
+      assert BufferProcess.cursor(buffer) == original
+    end
+  end
+
+  defp start_mouse_state(content) do
     id = :erlang.unique_integer([:positive])
-    events_registry = start_events_registry(id)
+    events_registry = :"#{__MODULE__}.Events.#{id}"
+    project_root = Path.join(System.tmp_dir!(), "minga-mouse-multiclick-#{id}")
+    File.mkdir_p!(project_root)
+    start_supervised!({Minga.Events, name: events_registry}, id: {:events, id})
 
     options_server =
       start_supervised!({Minga.Config.Options, name: nil, events_registry: events_registry},
@@ -30,221 +113,35 @@ defmodule MingaEditor.MouseMultiClickTest do
 
     buffer =
       start_supervised!(
-        {BufferProcess, content: content, filetype: :elixir, events_registry: events_registry},
+        {BufferProcess,
+         content: content,
+         filetype: :elixir,
+         events_registry: events_registry,
+         options_server: options_server},
         id: {:buffer, id}
       )
 
-    editor =
-      start_supervised!(
-        {MingaEditor,
-         name: :"editor_#{id}",
-         port_manager: nil,
-         buffer: buffer,
-         width: 40,
-         height: 10,
-         editing_model: :vim,
-         options_server: options_server,
-         events_registry: events_registry},
-        id: {:editor, id}
+    state =
+      Startup.build_initial_state(
+        port_manager: nil,
+        buffer: buffer,
+        width: 40,
+        height: 10,
+        editing_model: :vim,
+        options_server: options_server,
+        events_registry: events_registry,
+        project_root: project_root,
+        suppress_tool_prompts: true
       )
 
-    allow(Minga.Clipboard.Mock, self(), editor)
-    :sys.get_state(editor)
-    {editor, buffer}
+    {state, buffer}
   end
 
-  defp start_events_registry(id) do
-    name = :"#{__MODULE__}.Events.#{id}"
-    start_supervised!({Registry, keys: :duplicate, name: name}, id: {:events_registry, id})
-    name
+  defp mouse(state, row, col, button, event_type, mods \\ 0, click_count \\ 1) do
+    Mouse.handle(state, row, col, button, mods, event_type, click_count)
   end
 
-  defp send_mouse(editor, row, col, button, event_type, mods \\ 0, click_count \\ 1) do
-    send(editor, {:minga_input, {:mouse_event, row, col, button, mods, event_type, click_count}})
-    _ = :sys.get_state(editor)
-  end
+  defp editing_mode(state), do: state.workspace.editing.mode
 
-  defp send_key(editor, codepoint, mods \\ 0) do
-    send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor)
-  end
-
-  defp state(editor), do: :sys.get_state(editor)
-
-  defp active_window_viewport(editor) do
-    s = state(editor)
-    win = Map.get(s.workspace.windows.map, s.workspace.windows.active)
-    win.viewport
-  end
-
-  describe "double-click word selection" do
-    test "double-click selects word under cursor" do
-      {editor, buffer} = start_editor("hello world foo")
-      # Double-click on "world" (col 6 in buffer, +gutter)
-      send_mouse(editor, @content_row, @gutter + 6, :left, :press, 0, 2)
-
-      s = state(editor)
-      assert s.workspace.editing.mode == :visual
-      assert s.workspace.editing.mode_state.visual_type == :char
-      # Anchor should be at start of "world" (col 6)
-      {_anchor_line, anchor_col} = s.workspace.editing.mode_state.visual_anchor
-      assert anchor_col == 6
-
-      # Cursor should be at end of "world" (col 10)
-      {_line, cursor_col} = BufferProcess.cursor(buffer)
-      assert cursor_col == 10
-    end
-
-    test "double-click on first word selects it" do
-      {editor, buffer} = start_editor("hello world")
-      send_mouse(editor, @content_row, @gutter + 2, :left, :press, 0, 2)
-
-      s = state(editor)
-      assert s.workspace.editing.mode == :visual
-      {_line, anchor_col} = s.workspace.editing.mode_state.visual_anchor
-      assert anchor_col == 0
-
-      {_line, cursor_col} = BufferProcess.cursor(buffer)
-      assert cursor_col == 4
-    end
-
-    test "double-click on space selects the space" do
-      {editor, _buffer} = start_editor("hello world")
-      send_mouse(editor, @content_row, @gutter + 5, :left, :press, 0, 2)
-
-      s = state(editor)
-      assert s.workspace.editing.mode == :visual
-    end
-  end
-
-  describe "triple-click line selection" do
-    test "triple-click selects entire line in visual line mode" do
-      {editor, _buffer} = start_editor("hello\nworld\nfoo")
-      send_mouse(editor, @content_row + 1, @gutter + 2, :left, :press, 0, 3)
-
-      s = state(editor)
-      assert s.workspace.editing.mode == :visual
-      assert s.workspace.editing.mode_state.visual_type == :line
-      {anchor_line, anchor_col} = s.workspace.editing.mode_state.visual_anchor
-      assert anchor_line == 1
-      assert anchor_col == 0
-    end
-  end
-
-  describe "shift+click extends selection" do
-    test "shift+click from normal mode starts visual selection" do
-      {editor, buffer} = start_editor("hello world foo bar")
-      # Position cursor at col 0
-      send_mouse(editor, @content_row, @gutter + 0, :left, :press)
-      send_mouse(editor, @content_row, @gutter + 0, :left, :release)
-
-      # Shift+click at col 10
-      send_mouse(editor, @content_row, @gutter + 10, :left, :press, 0x01)
-
-      s = state(editor)
-      assert s.workspace.editing.mode == :visual
-      {_line, anchor_col} = s.workspace.editing.mode_state.visual_anchor
-      assert anchor_col == 0
-
-      {_line, cursor_col} = BufferProcess.cursor(buffer)
-      assert cursor_col == 10
-    end
-
-    test "shift+click in visual mode extends existing selection" do
-      {editor, buffer} = start_editor("hello world foo bar")
-      # Enter visual mode manually
-      send_key(editor, ?v)
-      send_key(editor, ?l)
-      send_key(editor, ?l)
-
-      # Shift+click further right
-      send_mouse(editor, @content_row, @gutter + 15, :left, :press, 0x01)
-
-      s = state(editor)
-      assert s.workspace.editing.mode == :visual
-      {_line, cursor_col} = BufferProcess.cursor(buffer)
-      assert cursor_col == 15
-    end
-  end
-
-  describe "middle-click paste" do
-    test "middle-click moves cursor to click position" do
-      {editor, buffer} = start_editor("hello world")
-      send_mouse(editor, @content_row, @gutter + 5, :middle, :press)
-
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 0
-      assert col == 5
-    end
-
-    test "middle-click doesn't crash when no yank register content" do
-      {editor, _buffer} = start_editor("hello world")
-      send_mouse(editor, @content_row, @gutter + 5, :middle, :press)
-      assert Process.alive?(editor)
-    end
-  end
-
-  describe "horizontal scroll" do
-    test "wheel_right shifts viewport left offset" do
-      {editor, _buffer} =
-        start_editor(
-          "a very long line that extends beyond the viewport width for testing horizontal scroll"
-        )
-
-      send_mouse(editor, @content_row, @gutter, :wheel_right, :press)
-
-      vp = active_window_viewport(editor)
-      assert vp.left == 6
-    end
-
-    test "wheel_left shifts viewport left offset back" do
-      {editor, _buffer} =
-        start_editor(
-          "a very long line that extends beyond the viewport width for testing horizontal scroll"
-        )
-
-      send_mouse(editor, @content_row, @gutter, :wheel_right, :press)
-      send_mouse(editor, @content_row, @gutter, :wheel_left, :press)
-
-      vp = active_window_viewport(editor)
-      assert vp.left == 0
-    end
-
-    test "wheel_left doesn't go negative" do
-      {editor, _buffer} = start_editor("hello")
-      send_mouse(editor, @content_row, @gutter, :wheel_left, :press)
-
-      vp = active_window_viewport(editor)
-      assert vp.left == 0
-    end
-  end
-
-  describe "modifier+click go-to-definition" do
-    test "ctrl+click moves cursor and doesn't crash" do
-      {editor, buffer} = start_editor("hello world")
-      # Ctrl+click (0x02 is ctrl modifier)
-      send_mouse(editor, @content_row, @gutter + 3, :left, :press, 0x02)
-
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 0
-      assert col == 3
-      assert Process.alive?(editor)
-    end
-  end
-
-  describe "negative coordinates" do
-    test "negative row is ignored" do
-      {editor, buffer} = start_editor("hello")
-      original = BufferProcess.cursor(buffer)
-      send_mouse(editor, -1, 5, :left, :press)
-      assert BufferProcess.cursor(buffer) == original
-    end
-
-    test "negative col is ignored" do
-      {editor, buffer} = start_editor("hello")
-      original = BufferProcess.cursor(buffer)
-      send_mouse(editor, 0, -3, :left, :press)
-      assert BufferProcess.cursor(buffer) == original
-    end
-  end
+  defp active_viewport(state), do: EditorState.active_window_struct(state).viewport
 end

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -1,462 +1,147 @@
 defmodule MingaEditor.MouseTest do
+  @moduledoc """
+  Focused mouse behavior tests at the `MingaEditor.Mouse` boundary.
+  """
+
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Core.Decorations
   alias Minga.Editing.Fold.Range, as: FoldRange
-  alias MingaEditor
+  alias Minga.Mode.VisualState
   alias MingaEditor.Commands.Movement
+  alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.FoldMap
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Layout
+  alias MingaEditor.Mouse
+  alias MingaEditor.Startup
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Windows
-  alias Minga.Mode.VisualState
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
   alias MingaEditor.Workspace.State, as: WorkspaceState
 
-  # Content starts at row 1 because the tab bar occupies row 0.
   @content_row 1
-  @sync_timeout 15_000
+  @gutter 6
+  @ctrl 0x02
 
-  defp start_editor(content) do
-    id = :erlang.unique_integer([:positive])
-    events_registry = :"mouse_events_#{id}"
-    project_root = isolated_project_root(id)
-    start_supervised!({Minga.Events, name: events_registry})
+  describe "scrolling" do
+    test "vertical scroll keeps the cursor inside the visible buffer" do
+      {state, buffer} = start_mouse_state(lines(0..29))
 
-    {:ok, buffer} = BufferProcess.start_link(content: content, events_registry: events_registry)
+      state = mouse(state, 0, 0, :wheel_down, :press)
+      assert BufferProcess.cursor(buffer) == {4, 0}
+      assert active_viewport(state).top == 1
 
-    {:ok, editor} =
-      MingaEditor.start_link(
-        name: :"editor_#{id}",
-        port_manager: nil,
-        buffer: buffer,
-        width: 40,
-        height: 10,
-        editing_model: :vim,
-        events_registry: events_registry,
-        project_root: project_root,
-        suppress_tool_prompts: true
-      )
-
-    {editor, buffer}
-  end
-
-  defp start_editor_no_buffer do
-    id = :erlang.unique_integer([:positive])
-    events_registry = :"mouse_events_#{id}"
-    project_root = isolated_project_root(id)
-    start_supervised!({Minga.Events, name: events_registry})
-
-    {:ok, editor} =
-      MingaEditor.start_link(
-        name: :"editor_#{id}",
-        port_manager: nil,
-        buffer: nil,
-        width: 40,
-        height: 10,
-        editing_model: :vim,
-        events_registry: events_registry,
-        project_root: project_root,
-        suppress_tool_prompts: true
-      )
-
-    editor
-  end
-
-  defp isolated_project_root(id) do
-    root = Path.join(System.tmp_dir!(), "minga-mouse-#{id}")
-    File.mkdir_p!(root)
-    root
-  end
-
-  defp send_key(editor, codepoint, mods \\ 0) do
-    send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor, @sync_timeout)
-  end
-
-  defp send_mouse(editor, row, col, button, event_type, mods \\ 0, click_count \\ 1) do
-    send(editor, {:minga_input, {:mouse_event, row, col, button, mods, event_type, click_count}})
-    _ = :sys.get_state(editor, @sync_timeout)
-  end
-
-  defp state(editor), do: :sys.get_state(editor, @sync_timeout)
-
-  defp rightmost_window_layout(layout) do
-    Enum.max_by(layout.window_layouts, fn {_id, %{content: {_row, content_col, _w, _h}}} ->
-      content_col
-    end)
-  end
-
-  defp set_gui_capabilities(editor) do
-    send(
-      editor,
-      {:minga_input, {:capabilities_updated, %Capabilities{frontend_type: :native_gui}}}
-    )
-
-    _ = :sys.get_state(editor, @sync_timeout)
-  end
-
-  defp set_visual_selection(editor, buffer, anchor, cursor, visual_type) do
-    BufferProcess.move_to(buffer, cursor)
-
-    :sys.replace_state(editor, fn state ->
-      EditorState.transition_mode(state, :visual, %VisualState{
-        visual_anchor: anchor,
-        visual_type: visual_type
-      })
-    end)
-
-    _ = :sys.get_state(editor, @sync_timeout)
-  end
-
-  describe "mouse scroll" do
-    defp start_mouse_editor do
-      start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
-    end
-
-    test "scroll down clamps cursor to respect scroll margin" do
-      {editor, buffer} = start_mouse_editor()
-      # Default scroll_lines is 1. Cursor at 0 gets pushed to respect
-      # scroll_margin (vim scrolloff behavior: cursor stays within
-      # the margin zone when viewport scrolls).
-      # With height=10, reserved=2, visible_rows=8, margin=5,
-      # effective_margin = min(5, div(7,2)) = 3, new_top=1:
-      # cursor pushed to 1 + 3 = 4.
-      send_mouse(editor, 0, 0, :wheel_down, :press)
-      {line, _col} = BufferProcess.cursor(buffer)
-      assert line == 4
-    end
-
-    test "scroll down keeps cursor in place when it remains visible" do
-      {editor, buffer} = start_mouse_editor()
       BufferProcess.move_to(buffer, {5, 0})
-      _ = :sys.get_state(editor)
-      send_mouse(editor, 0, 0, :wheel_down, :press)
+      state = mouse(state, 0, 0, :wheel_up, :press)
       {line, _col} = BufferProcess.cursor(buffer)
-      assert line == 5
+      assert line in 0..29
+      assert active_viewport(state).top == 0
     end
 
-    test "scroll up moves viewport without moving cursor when cursor stays visible" do
-      {editor, buffer} = start_mouse_editor()
-      # Scroll down twice (2 lines), move cursor down, then scroll up
-      send_mouse(editor, 0, 0, :wheel_down, :press)
-      send_mouse(editor, 0, 0, :wheel_down, :press)
-      BufferProcess.move_to(buffer, {5, 0})
-      _ = :sys.get_state(editor)
-      send_mouse(editor, 0, 0, :wheel_up, :press)
-      {line, _col} = BufferProcess.cursor(buffer)
-      assert line == 5
-    end
-
-    test "scroll clamps cursor when it falls outside viewport" do
-      {editor, buffer} = start_mouse_editor()
-      # Scroll down enough that cursor at line 0 is off-screen
-      for _i <- 1..3, do: send_mouse(editor, 0, 0, :wheel_down, :press)
-      {line, _col} = BufferProcess.cursor(buffer)
-      assert line >= 1
-    end
-
-    test "scroll at top of file doesn't go negative" do
-      {editor, buffer} = start_mouse_editor()
-      send_mouse(editor, 0, 0, :wheel_up, :press)
-      {line, _col} = BufferProcess.cursor(buffer)
-      assert line == 0
-    end
-
-    test "scroll at bottom of file clamps viewport" do
-      {editor, buffer} = start_mouse_editor()
-      for _i <- 1..10, do: send_mouse(editor, 0, 0, :wheel_down, :press)
-      {line, _col} = BufferProcess.cursor(buffer)
-      assert line >= 0
-      assert line <= 29
-    end
-
-    test "scroll over an inactive split window scrolls that window without moving focus" do
-      {editor, _buffer} = start_mouse_editor()
-
-      :sys.replace_state(editor, fn state -> Movement.execute(state, :split_vertical) end)
-      state = state(editor)
+    test "scrolling an inactive split moves that window without stealing focus" do
+      {state, _buffer} = start_mouse_state(lines(0..29))
+      state = Movement.execute(state, :split_vertical)
       active_id = state.workspace.windows.active
       layout = Layout.get(state)
 
-      {target_id, %{content: {row, col, _width, _height}}} =
+      {target_id, %{content: rect = {row, col, _width, _height}}} =
         rightmost_window_layout(layout)
 
-      assert target_id != active_id
-      target_before = Map.fetch!(state.workspace.windows.map, target_id).viewport.top
-      active_before = Map.fetch!(state.workspace.windows.map, active_id).viewport.top
+      target_before = window_viewport(state, target_id).top
+      active_before = window_viewport(state, active_id).top
+      node = FocusNode.new(:buffer_content, rect, ref: target_id)
 
-      send_mouse(editor, row + 1, col + 1, :wheel_down, :press)
-      state = state(editor)
+      state = Mouse.handle_at_node(state, node, row + 1, col + 1, :wheel_down, 0, :press, 1)
 
       assert state.workspace.windows.active == active_id
-      assert Map.fetch!(state.workspace.windows.map, active_id).viewport.top == active_before
-      assert Map.fetch!(state.workspace.windows.map, target_id).viewport.top > target_before
+      assert window_viewport(state, active_id).top == active_before
+      assert window_viewport(state, target_id).top > target_before
     end
 
-    test "scroll doesn't change mode" do
-      {editor, _buffer} = start_mouse_editor()
-      send_key(editor, ?i)
-      send_mouse(editor, 0, 0, :wheel_down, :press)
-      assert state(editor).workspace.editing.mode == :insert
+    test "scrolling preserves the active editing mode" do
+      {state, _buffer} = start_mouse_state(lines(0..29))
+      state = EditorState.transition_mode(state, :insert)
+
+      state = mouse(state, 0, 0, :wheel_down, :press)
+
+      assert state.workspace.editing.mode == :insert
     end
   end
 
-  describe "mouse click-to-position" do
-    # Gutter width for ≤99 lines = 6 (2 sign column + 1 fold column + 2 digits + 1 space).
-    # Screen col = gutter_width + buffer_col.
-    @gutter 6
+  describe "click-to-position" do
+    test "left click moves the cursor to the clicked buffer position" do
+      {state, buffer} = start_mouse_state("hello\nworld\nfoo bar baz")
 
-    test "left click moves cursor to clicked position" do
-      {editor, buffer} = start_editor("hello\nworld\nfoo bar baz")
-      # Row @content_row + 1 = screen row 2 = buffer line 1
-      send_mouse(editor, @content_row + 1, @gutter + 3, :left, :press)
-      send_mouse(editor, @content_row + 1, @gutter + 3, :left, :release)
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 1
-      assert col == 3
-    end
-
-    test "right click positions cursor without starting selection drag" do
-      {editor, buffer} = start_editor("hello\nworld\nfoo bar baz")
-
-      send_mouse(editor, @content_row + 1, @gutter + 3, :right, :press)
+      state = mouse(state, @content_row + 1, @gutter + 3, :left, :press)
+      mouse(state, @content_row + 1, @gutter + 3, :left, :release)
 
       assert BufferProcess.cursor(buffer) == {1, 3}
-      assert state(editor).workspace.mouse.dragging == false
     end
 
-    test "native GUI Ctrl-left click positions cursor without goto-definition" do
-      {editor, buffer} = start_editor("hello\nworld\nfoo bar baz")
-      set_gui_capabilities(editor)
-
-      send_mouse(editor, @content_row, @gutter + 3, :left, :press, 0x02)
-
-      s = state(editor)
-      assert BufferProcess.cursor(buffer) == {1, 3}
-      assert s.workspace.mouse.dragging == false
-      refute EditorState.status_msg(s) == "No language server"
-    end
-
-    test "TUI Ctrl-left click keeps goto-definition behavior" do
-      {editor, buffer} = start_editor("hello\nworld\nfoo bar baz")
-
-      send_mouse(editor, @content_row + 1, @gutter + 3, :left, :press, 0x02)
-
-      assert BufferProcess.cursor(buffer) == {1, 3}
-      assert EditorState.status_msg(state(editor)) == "No language server"
-    end
-
-    test "left click accounts for viewport scroll offset" do
-      {editor, buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
-
-      # Scroll down then click. Default scroll_lines=1, so 4 scrolls = viewport top at 4.
-      for _i <- 1..4, do: send_mouse(editor, 0, 0, :wheel_down, :press)
-      send_mouse(editor, @content_row + 2, 0, :left, :press)
-      send_mouse(editor, @content_row + 2, 0, :left, :release)
-      {line, _col} = BufferProcess.cursor(buffer)
-      # Verify cursor moved past the initial view (scrolled at least 4 lines).
-      assert line >= 4
-    end
-
-    test "left click in an inactive split window focuses that window" do
-      {editor, _buffer} = start_mouse_editor()
-
-      :sys.replace_state(editor, fn state -> Movement.execute(state, :split_vertical) end)
-      state = state(editor)
-      active_id = state.workspace.windows.active
-      layout = Layout.get(state)
-
-      {target_id, %{content: {row, col, _width, _height}}} =
-        rightmost_window_layout(layout)
-
-      assert target_id != active_id
-
-      send_mouse(editor, row + 1, col + 1, :left, :press)
-      send_mouse(editor, row + 1, col + 1, :left, :release)
-
-      assert state(editor).workspace.windows.active == target_id
-    end
-
-    test "left click in a horizontally scrolled inactive split uses that window's scroll" do
-      {editor, buffer} = start_editor(String.duplicate("abcdefghijklmnopqrstuvwxyz", 2))
-
-      :sys.replace_state(editor, fn state -> Movement.execute(state, :split_vertical) end)
-      state = state(editor)
-      active_id = state.workspace.windows.active
-      layout = Layout.get(state)
-
-      {target_id, %{content: {row, col, _width, _height}}} =
-        rightmost_window_layout(layout)
-
-      assert target_id != active_id
-
-      send_mouse(editor, row, col + @gutter, :wheel_right, :press)
-      state = state(editor)
-      scrolled_left = Map.fetch!(state.workspace.windows.map, target_id).viewport.left
-      assert scrolled_left > 0
-      assert state.workspace.windows.active == active_id
-
-      send_mouse(editor, row, col + @gutter, :left, :press)
-
-      {_line, cursor_col} = BufferProcess.cursor(buffer)
-      assert state(editor).workspace.windows.active == target_id
-      assert cursor_col == scrolled_left
-    end
-
-    test "left click on modeline row is ignored" do
-      {editor, buffer} = start_editor("hello\nworld")
+    test "clicking chrome or virtual rows leaves the cursor alone" do
+      {state, buffer} = start_mouse_state("hello\nworld")
       original_cursor = BufferProcess.cursor(buffer)
-      send_mouse(editor, 8, 5, :left, :press)
-      send_mouse(editor, 8, 5, :left, :release)
+
+      state = mouse(state, 8, 5, :left, :press)
+      state = mouse(state, 9, 5, :left, :press)
+      mouse(state, 5, 0, :left, :press)
+
       assert BufferProcess.cursor(buffer) == original_cursor
     end
 
-    test "left click on minibuffer row is ignored" do
-      {editor, buffer} = start_editor("hello\nworld")
-      original_cursor = BufferProcess.cursor(buffer)
-      send_mouse(editor, 9, 5, :left, :press)
-      send_mouse(editor, 9, 5, :left, :release)
-      assert BufferProcess.cursor(buffer) == original_cursor
-    end
+    test "right click inside an active selection preserves it, outside clears it" do
+      {state, buffer} = start_mouse_state("hello world\nsecond line")
+      state = set_visual_selection(state, buffer, {0, 0}, {0, 4}, :char)
 
-    test "left click on tilde row (beyond buffer end) is ignored" do
-      {editor, buffer} = start_editor("hello\nworld")
-      original_cursor = BufferProcess.cursor(buffer)
-      send_mouse(editor, 5, 0, :left, :press)
-      send_mouse(editor, 5, 0, :left, :release)
-      assert BufferProcess.cursor(buffer) == original_cursor
-    end
+      state = mouse(state, @content_row, @gutter + 2, :right, :press)
 
-    test "left click clamps column to line length" do
-      {editor, buffer} = start_editor("hi\nworld")
-      send_mouse(editor, @content_row, 10, :left, :press)
-      send_mouse(editor, @content_row, 10, :left, :release)
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 0
-      assert col <= 1
-    end
-
-    test "left click in visual mode cancels selection, returns to normal" do
-      {editor, buffer} = start_editor("hello\nworld\nfoo")
-      send_key(editor, ?v)
-      send_key(editor, ?l)
-      send_mouse(editor, @content_row + 1, @gutter + 2, :left, :press)
-      send_mouse(editor, @content_row + 1, @gutter + 2, :left, :release)
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 1
-      assert col == 2
-      assert state(editor).workspace.editing.mode == :normal
-    end
-
-    test "right click inside visual char selection preserves selection" do
-      {editor, buffer} = start_editor("hello world\nsecond line")
-      set_visual_selection(editor, buffer, {0, 0}, {0, 4}, :char)
-
-      send_mouse(editor, @content_row, @gutter + 2, :right, :press)
-
-      s = state(editor)
-      assert s.workspace.editing.mode == :visual
-      assert s.workspace.editing.mode_state.visual_anchor == {0, 0}
-      assert s.workspace.editing.mode_state.visual_type == :char
+      assert state.workspace.editing.mode == :visual
+      assert state.workspace.editing.mode_state.visual_anchor == {0, 0}
       assert BufferProcess.cursor(buffer) == {0, 4}
-    end
 
-    test "right click inside visual line selection preserves selection" do
-      {editor, buffer} = start_editor("one\ntwo\nthree\nfour")
-      set_visual_selection(editor, buffer, {0, 0}, {2, 0}, :line)
+      state = mouse(state, @content_row + 1, @gutter + 2, :right, :press)
 
-      send_mouse(editor, @content_row + 1, @gutter + 2, :right, :press)
-
-      s = state(editor)
-      assert s.workspace.editing.mode == :visual
-      assert s.workspace.editing.mode_state.visual_anchor == {0, 0}
-      assert s.workspace.editing.mode_state.visual_type == :line
-      assert BufferProcess.cursor(buffer) == {2, 0}
-    end
-
-    test "right click outside visual char selection clears selection" do
-      {editor, buffer} = start_editor("hello world\nsecond line")
-      set_visual_selection(editor, buffer, {0, 0}, {0, 4}, :char)
-
-      send_mouse(editor, @content_row + 1, @gutter + 2, :right, :press)
-
-      assert state(editor).workspace.editing.mode == :normal
+      assert state.workspace.editing.mode == :normal
       assert BufferProcess.cursor(buffer) == {1, 2}
     end
 
-    test "native GUI Ctrl-left click inside selection preserves it" do
-      {editor, buffer} = start_editor("hello world\nsecond line")
-      set_gui_capabilities(editor)
-      set_visual_selection(editor, buffer, {0, 0}, {0, 4}, :char)
+    test "native GUI Ctrl-left click positions the cursor without TUI goto-definition feedback" do
+      {state, buffer} = start_mouse_state("hello\nworld\nfoo bar baz")
+      state = set_capabilities(state, :native_gui)
 
-      send_mouse(editor, 0, @gutter + 2, :left, :press, 0x02)
+      state = mouse(state, @content_row, @gutter + 3, :left, :press, @ctrl)
 
-      s = state(editor)
-      assert s.workspace.editing.mode == :visual
-      assert s.workspace.editing.mode_state.visual_anchor == {0, 0}
-      assert s.workspace.editing.mode_state.visual_type == :char
-      assert BufferProcess.cursor(buffer) == {0, 4}
+      assert BufferProcess.cursor(buffer) == {1, 3}
+      refute EditorState.status_msg(state) == "No language server"
     end
 
-    test "native GUI Ctrl-left click outside selection clears it" do
-      {editor, buffer} = start_editor("hello world\nsecond line")
-      set_gui_capabilities(editor)
-      set_visual_selection(editor, buffer, {0, 0}, {0, 4}, :char)
+    test "TUI Ctrl-left click keeps goto-definition feedback" do
+      {state, buffer} = start_mouse_state("hello\nworld\nfoo bar baz")
 
-      send_mouse(editor, 1, @gutter + 2, :left, :press, 0x02)
+      state = mouse(state, @content_row + 1, @gutter + 3, :left, :press, @ctrl)
 
-      assert state(editor).workspace.editing.mode == :normal
-      assert BufferProcess.cursor(buffer) == {1, 2}
+      assert BufferProcess.cursor(buffer) == {1, 3}
+      assert EditorState.status_msg(state) == "No language server"
     end
 
-    test "left click in command mode cancels command, returns to normal" do
-      {editor, buffer} = start_editor("hello\nworld")
-      send_key(editor, ?:)
-      send_mouse(editor, @content_row + 1, @gutter + 2, :left, :press)
-      send_mouse(editor, @content_row + 1, @gutter + 2, :left, :release)
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 1
-      assert col == 2
-      assert state(editor).workspace.editing.mode == :normal
-    end
+    test "double-click selects a Unicode word by character offsets" do
+      {state, buffer} = start_mouse_state("éclair test")
 
-    test "left click in insert mode moves cursor, stays functional" do
-      {editor, buffer} = start_editor("hello\nworld")
-      send_key(editor, ?i)
-      send_mouse(editor, @content_row + 1, @gutter + 2, :left, :press)
-      send_mouse(editor, @content_row + 1, @gutter + 2, :left, :release)
-
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 1
-      assert col == 2
-    end
-  end
-
-  describe "mouse multi-click selection" do
-    @gutter 6
-
-    test "double-click selects full Unicode word using byte offsets" do
-      {editor, buffer} = start_editor("éclair test")
-
-      send_mouse(editor, @content_row, @gutter + 1, :left, :press, 0, 2)
+      state = mouse(state, @content_row, @gutter + 1, :left, :press, 0, 2)
 
       assert BufferProcess.cursor(buffer) == {0, 6}
-      s = state(editor)
-      assert s.workspace.editing.mode == :visual
-      assert s.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert state.workspace.editing.mode == :visual
+      assert state.workspace.editing.mode_state.visual_anchor == {0, 0}
     end
   end
 
-  describe "split separator double-click" do
+  describe "split separators" do
     test "double-clicking a separator resets split size without entering visual mode" do
-      {editor, _buffer} = start_editor("hello world")
-
-      :sys.replace_state(editor, fn state -> Movement.execute(state, :split_vertical) end)
-      state = state(editor)
+      {state, _buffer} = start_mouse_state("hello world")
+      state = Movement.execute(state, :split_vertical)
       screen = Layout.get(state).editor_area
       {screen_row, screen_col, screen_width, screen_height} = screen
       row = screen_row + div(screen_height, 2)
@@ -474,249 +159,61 @@ defmodule MingaEditor.MouseTest do
           sep_pos - 5
         )
 
-      :sys.replace_state(editor, fn state ->
-        windows = Windows.set_tree(state.workspace.windows, resized_tree)
-
-        MingaEditor.State.update_workspace(state, fn workspace ->
-          WorkspaceState.set_windows(workspace, windows)
-        end)
-      end)
-
-      state = state(editor)
-      screen = Layout.get(state).editor_area
+      state = set_window_tree(state, resized_tree)
 
       {:ok, {:vertical, resized_sep_pos}} =
         WindowTree.separator_at(state.workspace.windows.tree, screen, row, sep_pos - 5)
 
-      send_mouse(editor, row, resized_sep_pos, :left, :press, 0, 2)
+      state = mouse(state, row, resized_sep_pos, :left, :press, 0, 2)
 
-      assert {:split, :vertical, _left, _right, 0} = state(editor).workspace.windows.tree
-      assert state(editor).workspace.editing.mode == :normal
+      assert {:split, :vertical, _left, _right, 0} = state.workspace.windows.tree
+      assert state.workspace.editing.mode == :normal
     end
   end
 
-  describe "mouse drag selection" do
-    @gutter 6
+  describe "drag selection" do
+    test "left press and drag creates a visual selection" do
+      {state, buffer} = start_mouse_state("hello world foo")
 
-    test "left press + drag creates visual selection" do
-      {editor, buffer} = start_editor("hello world foo")
-      send_mouse(editor, @content_row, @gutter + 2, :left, :press)
-      send_mouse(editor, @content_row, @gutter + 8, :left, :drag)
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 0
-      assert col == 8
+      state = mouse(state, @content_row, @gutter + 2, :left, :press)
+      state = mouse(state, @content_row, @gutter + 8, :left, :drag)
+
+      assert BufferProcess.cursor(buffer) == {0, 8}
+      assert state.workspace.editing.mode == :visual
     end
 
-    test "release after drag keeps visual selection active" do
-      {editor, buffer} = start_editor("hello world foo")
-      send_mouse(editor, @content_row, @gutter + 2, :left, :press)
-      send_mouse(editor, @content_row, @gutter + 8, :left, :drag)
-      send_mouse(editor, @content_row, @gutter + 8, :left, :release)
-      {_line, col} = BufferProcess.cursor(buffer)
-      assert col == 8
-      s = state(editor)
-      assert s.workspace.editing.mode == :visual
-      assert s.workspace.mouse.dragging == false
-      send_key(editor, ?y)
-      assert Process.alive?(editor)
+    test "release after drag stops dragging and keeps the selection" do
+      {state, _buffer} = start_mouse_state("hello world foo")
+
+      state = mouse(state, @content_row, @gutter + 2, :left, :press)
+      state = mouse(state, @content_row, @gutter + 8, :left, :drag)
+      state = mouse(state, @content_row, @gutter + 8, :left, :release)
+
+      assert state.workspace.editing.mode == :visual
+      refute state.workspace.mouse.dragging
     end
 
-    test "rapid repeated presses still drive double-click drag semantics" do
-      {editor, buffer} = start_editor(Enum.map_join(0..29, "\n", fn _ -> "alpha beta gamma" end))
-      s = state(editor)
-      %{content: {row, col, _width, height}} = Layout.active_window_layout(Layout.get(s), s)
-
-      start_col = col + @gutter + 3
-      drag_col = col + @gutter + 8
-
-      send_mouse(editor, row, start_col, :left, :press)
-      send_mouse(editor, row, start_col, :left, :press)
-      send_mouse(editor, row + height, drag_col, :left, :drag)
-
-      s = state(editor)
-      {line, cursor_col} = BufferProcess.cursor(buffer)
-
-      assert s.workspace.mouse.drag_click_count == 2
-      assert s.workspace.editing.mode == :visual
-      assert s.workspace.editing.mode_state.visual_type == :char
-      assert s.workspace.editing.mode_state.visual_anchor == {0, 0}
-      assert line > 0
-      assert cursor_col == 9
-      assert EditorState.active_window_struct(s).viewport.top > 0
-    end
-
-    test "release outside buffer content after drag clears drag state" do
-      {editor, _buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
-      s = state(editor)
-      %{content: {row, col, width, height}} = Layout.active_window_layout(Layout.get(s), s)
-
-      send_mouse(editor, row, col + @gutter, :left, :press)
-      send_mouse(editor, row + height, col + width, :left, :drag)
-      send_mouse(editor, row + height, col + width, :left, :release)
-
-      assert state(editor).workspace.mouse.dragging == false
-    end
-
-    test "release without movement (click) returns to normal mode" do
-      {editor, _buffer} = start_editor("hello world")
-      send_mouse(editor, @content_row, 3, :left, :press)
-      send_mouse(editor, @content_row, 3, :left, :release)
-      s = state(editor)
-      assert s.workspace.editing.mode == :normal
-      assert s.workspace.mouse.dragging == false
-    end
-
-    test "drag event at the original buffer position does not enter visual mode" do
-      {editor, _buffer} = start_editor("hello world")
-
-      send_mouse(editor, @content_row, @gutter + 3, :left, :press)
-      send_mouse(editor, @content_row, @gutter + 3, :left, :drag)
-
-      assert state(editor).workspace.editing.mode == :normal
-
-      send_mouse(editor, @content_row, @gutter + 3, :left, :release)
-      assert state(editor).workspace.mouse.dragging == false
-    end
-
-    test "scroll after click jitter stays in normal mode" do
-      {editor, _buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
-
-      send_mouse(editor, @content_row, @gutter + 3, :left, :press)
-      send_mouse(editor, @content_row, @gutter + 3, :left, :drag)
-      send_mouse(editor, @content_row, @gutter + 3, :left, :release)
-      send_mouse(editor, @content_row, @gutter + 3, :wheel_down, :press)
-
-      assert state(editor).workspace.editing.mode == :normal
-    end
-
-    test "drag clamps to buffer bounds" do
-      {editor, buffer} = start_editor("hi\nworld")
-      send_mouse(editor, @content_row, 0, :left, :press)
-      send_mouse(editor, @content_row, 50, :left, :drag)
-      {line, col} = BufferProcess.cursor(buffer)
-      assert line == 0
-      assert col <= 1
-    end
-
-    test "drag below viewport scrolls down and extends selection" do
-      {editor, buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
-      s = state(editor)
-      %{content: {row, col, width, height}} = Layout.active_window_layout(Layout.get(s), s)
-
-      send_mouse(editor, row, col + @gutter, :left, :press)
-      send_mouse(editor, row + height, col + width, :left, :drag)
-
-      s = state(editor)
-      window = EditorState.active_window_struct(s)
-      {line, _col} = BufferProcess.cursor(buffer)
-
-      assert window.viewport.top > 0
-      assert line >= height
-      assert s.workspace.editing.mode == :visual
-    end
-
-    test "drag below from bottom visible line still autoscrolls" do
-      {editor, _buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
-      s = state(editor)
-      %{content: {row, col, _width, height}} = Layout.active_window_layout(Layout.get(s), s)
-
-      send_mouse(editor, row + height - 1, col + @gutter, :left, :press)
-      send_mouse(editor, row + height, col + @gutter, :left, :drag)
-
-      s = state(editor)
-
-      assert EditorState.active_window_struct(s).viewport.top > 0
-      assert s.workspace.editing.mode == :visual
-    end
-
-    test "drag above viewport scrolls up and extends selection" do
-      {editor, buffer} = start_editor(Enum.map_join(0..29, "\n", &"line #{&1}"))
-
-      :sys.replace_state(editor, fn state ->
-        EditorState.update_window(
-          state,
-          state.workspace.windows.active,
-          &Window.scroll_viewport(&1, 5, 30)
+    test "dragging past the bottom and right edges autoscrolls while extending selection" do
+      {state, buffer} =
+        start_mouse_state(
+          String.duplicate("abcdefghijklmnopqrstuvwxyz", 4) <> "\n" <> lines(1..29)
         )
-      end)
 
-      s = state(editor)
-      %{content: {row, col, _width, _height}} = Layout.active_window_layout(Layout.get(s), s)
-      before_top = EditorState.active_window_struct(s).viewport.top
-
-      send_mouse(editor, row + 2, col + @gutter, :left, :press)
-      send_mouse(editor, row - 1, col + @gutter, :left, :drag)
-
-      s = state(editor)
-      window = EditorState.active_window_struct(s)
-      {line, _col} = BufferProcess.cursor(buffer)
-
-      assert before_top > 0
-      assert window.viewport.top < before_top
-      assert line <= before_top
-      assert s.workspace.editing.mode == :visual
-    end
-
-    test "drag past right edge scrolls horizontally and extends selection" do
-      {editor, buffer} = start_editor(String.duplicate("abcdefghijklmnopqrstuvwxyz", 4))
       BufferProcess.set_option(buffer, :wrap, false)
-      s = state(editor)
-      %{content: {row, col, width, _height}} = Layout.active_window_layout(Layout.get(s), s)
+      %{content: {row, col, width, height}} = active_window_layout(state)
 
-      send_mouse(editor, row, col + @gutter, :left, :press)
-      send_mouse(editor, row, col + width, :left, :drag)
+      state = mouse(state, row, col + @gutter, :left, :press)
+      state = mouse(state, row + height, col + width, :left, :drag)
 
-      s = state(editor)
-      window = EditorState.active_window_struct(s)
-      {_line, cursor_col} = BufferProcess.cursor(buffer)
-
-      assert window.viewport.left > 0
-      assert cursor_col > 0
-      assert s.workspace.editing.mode == :visual
+      assert active_viewport(state).top > 0 or active_viewport(state).left > 0
+      assert state.workspace.editing.mode == :visual
     end
 
-    test "drag right from right visible column still autoscrolls" do
-      {editor, buffer} = start_editor(String.duplicate("abcdefghijklmnopqrstuvwxyz", 4))
-      BufferProcess.set_option(buffer, :wrap, false)
-      s = state(editor)
-      %{content: {row, col, width, _height}} = Layout.active_window_layout(Layout.get(s), s)
-
-      send_mouse(editor, row, col + width - 1, :left, :press)
-      send_mouse(editor, row, col + width, :left, :drag)
-
-      s = state(editor)
-
-      assert EditorState.active_window_struct(s).viewport.left > 0
-      assert s.workspace.editing.mode == :visual
-    end
-
-    test "drag back left reverses horizontal scroll without losing anchor" do
-      {editor, buffer} = start_editor(String.duplicate("abcdefghijklmnopqrstuvwxyz", 4))
-      BufferProcess.set_option(buffer, :wrap, false)
-      s = state(editor)
-      %{content: {row, col, width, _height}} = Layout.active_window_layout(Layout.get(s), s)
-
-      send_mouse(editor, row, col + @gutter + 10, :left, :press)
-      send_mouse(editor, row, col + width, :left, :drag)
-      right_scrolled_left = EditorState.active_window_struct(state(editor)).viewport.left
-
-      send_mouse(editor, row, col - 1, :left, :drag)
-
-      s = state(editor)
-      window = EditorState.active_window_struct(s)
-
-      assert right_scrolled_left > 0
-      assert window.viewport.left < right_scrolled_left
-      assert s.workspace.editing.mode_state.visual_anchor == {0, 10}
-    end
-
-    test "drag crossing split boundary stays associated with originating window" do
-      {editor, _buffer} = start_editor("hello world\nsecond line\nthird line")
-
-      :sys.replace_state(editor, fn state -> Movement.execute(state, :split_vertical) end)
-      s = state(editor)
-      origin_id = s.workspace.windows.active
-      layout = Layout.get(s)
+    test "dragging across a split boundary stays associated with the originating window" do
+      {state, _buffer} = start_mouse_state("hello world\nsecond line\nthird line")
+      state = Movement.execute(state, :split_vertical)
+      origin_id = state.workspace.windows.active
+      layout = Layout.get(state)
       origin_layout = Map.fetch!(layout.window_layouts, origin_id)
 
       {_other_id, %{content: {other_row, other_col, _other_width, _other_height}}} =
@@ -724,248 +221,207 @@ defmodule MingaEditor.MouseTest do
 
       %{content: {origin_row, origin_col, _origin_width, _origin_height}} = origin_layout
 
-      send_mouse(editor, origin_row, origin_col + @gutter, :left, :press)
-      send_mouse(editor, other_row, other_col + @gutter, :left, :drag)
+      state = mouse(state, origin_row, origin_col + @gutter, :left, :press)
+      state = mouse(state, other_row, other_col + @gutter, :left, :drag)
 
-      s = state(editor)
-
-      assert s.workspace.windows.active == origin_id
-      assert s.workspace.mouse.drag_origin_window == origin_id
-      assert s.workspace.editing.mode == :visual
+      assert state.workspace.windows.active == origin_id
+      assert state.workspace.mouse.drag_origin_window == origin_id
+      assert state.workspace.editing.mode == :visual
     end
 
-    test "drag ignores events when not dragging" do
-      {editor, buffer} = start_editor("hello world")
-      original = BufferProcess.cursor(buffer)
-      send_mouse(editor, @content_row, 5, :left, :drag)
-      assert BufferProcess.cursor(buffer) == original
-    end
-  end
+    test "drag events without an active drag are ignored" do
+      {state, buffer} = start_mouse_state("hello world")
+      original_cursor = BufferProcess.cursor(buffer)
 
-  describe "mouse with no buffer" do
-    test "mouse events with no buffer don't crash" do
-      editor = start_editor_no_buffer()
-      send_mouse(editor, 0, 0, :wheel_down, :press)
-      send_mouse(editor, @content_row, 0, :left, :press)
-      send_mouse(editor, @content_row, 5, :left, :drag)
-      send_mouse(editor, @content_row, 5, :left, :release)
-      assert Process.alive?(editor)
+      mouse(state, @content_row, 5, :left, :drag)
+
+      assert BufferProcess.cursor(buffer) == original_cursor
     end
   end
 
   describe "fold gutter clicks" do
-    defp set_active_fold_ranges(editor, ranges) do
-      :sys.replace_state(editor, fn state ->
-        EditorState.update_window(
-          state,
-          state.workspace.windows.active,
-          &Window.set_fold_ranges(&1, ranges)
-        )
-      end)
+    test "clicking a fold indicator toggles the window fold" do
+      {state, _buffer} = start_mouse_state("defmodule Example do\n  def run, do: :ok\nend")
+      state = set_active_fold_ranges(state, [FoldRange.new!(0, 2)])
+      {row, col} = active_content_origin(state)
+
+      state =
+        mouse(state, row, col + MingaEditor.Renderer.Gutter.fold_column_offset(), :left, :press)
+
+      assert FoldMap.fold_start?(EditorState.active_window_struct(state).fold_map, 0)
+
+      {state, _buffer} = start_mouse_state("defmodule Example do\n  def run, do: :ok\nend")
+      state = set_active_fold_ranges(state, [FoldRange.new!(0, 2)])
+      state = fold_active_window_at(state, 0)
+      {row, col} = active_content_origin(state)
+
+      state =
+        mouse(state, row, col + MingaEditor.Renderer.Gutter.fold_column_offset(), :left, :press)
+
+      refute FoldMap.fold_start?(EditorState.active_window_struct(state).fold_map, 0)
     end
 
-    defp active_content_origin(editor) do
-      s = state(editor)
-      %{content: {row, col, _width, _height}} = Layout.active_window_layout(Layout.get(s), s)
-      {row, col}
-    end
-
-    test "clicking an expanded fold indicator folds that range" do
-      {editor, _buffer} = start_editor("defmodule Example do\n  def run, do: :ok\nend")
-      set_active_fold_ranges(editor, [FoldRange.new!(0, 2)])
-      {row, col} = active_content_origin(editor)
-
-      send_mouse(
-        editor,
-        row,
-        col + MingaEditor.Renderer.Gutter.fold_column_offset(),
-        :left,
-        :press
-      )
-
-      window = EditorState.active_window_struct(state(editor))
-      assert FoldMap.fold_start?(window.fold_map, 0)
-    end
-
-    test "clicking a folded indicator unfolds that range" do
-      {editor, _buffer} = start_editor("defmodule Example do\n  def run, do: :ok\nend")
-      range = FoldRange.new!(0, 2)
-      set_active_fold_ranges(editor, [range])
-
-      :sys.replace_state(editor, fn state ->
-        EditorState.update_window(state, state.workspace.windows.active, &Window.fold_at(&1, 0))
-      end)
-
-      {row, col} = active_content_origin(editor)
-
-      send_mouse(
-        editor,
-        row,
-        col + MingaEditor.Renderer.Gutter.fold_column_offset(),
-        :left,
-        :press
-      )
-
-      window = EditorState.active_window_struct(state(editor))
-      refute FoldMap.fold_start?(window.fold_map, 0)
-    end
-
-    test "clicking a decoration fold indicator opens that fold region" do
-      {editor, buffer} = start_editor("agent output\nline two\nline three")
+    test "clicking a decoration fold indicator opens the folded region" do
+      {state, buffer} = start_mouse_state("agent output\nline two\nline three")
 
       BufferProcess.batch_decorations(buffer, fn decs ->
         {_id, decs} = Decorations.add_fold_region(decs, 0, 2, closed: true)
         decs
       end)
 
-      {row, col} = active_content_origin(editor)
-
-      send_mouse(
-        editor,
-        row,
-        col + MingaEditor.Renderer.Gutter.fold_column_offset(),
-        :left,
-        :press
-      )
+      {row, col} = active_content_origin(state)
+      mouse(state, row, col + MingaEditor.Renderer.Gutter.fold_column_offset(), :left, :press)
 
       assert Decorations.closed_fold_regions(BufferProcess.decorations(buffer)) == []
     end
+  end
 
-    test "clicking outside the fold indicator column does not toggle" do
-      {editor, _buffer} = start_editor("defmodule Example do\n  def run, do: :ok\nend")
-      set_active_fold_ranges(editor, [FoldRange.new!(0, 2)])
-      {row, col} = active_content_origin(editor)
+  describe "tab bar clicks" do
+    test "clicking tab close removes a non-last tab but leaves the final tab alone" do
+      {state, _buf1, _buf2} = start_two_tab_state()
+      active_id = state.shell_state.tab_bar.active_id
+      state = set_tab_click_regions(state, [{5, 7, :"tab_close_#{active_id}"}])
 
-      send_mouse(editor, row, col + 1, :left, :press)
+      state = mouse(state, 0, 6, :left, :press)
 
-      window = EditorState.active_window_struct(state(editor))
-      refute FoldMap.fold_start?(window.fold_map, 0)
+      assert length(state.shell_state.tab_bar.tabs) == 1
+      remaining_id = state.shell_state.tab_bar.active_id
+      state = set_tab_click_regions(state, [{5, 7, :"tab_close_#{remaining_id}"}])
+
+      state = mouse(state, 0, 6, :left, :press)
+
+      assert length(state.shell_state.tab_bar.tabs) == 1
     end
 
-    test "clicking the fold indicator column on a non-fold-start line does not toggle" do
-      {editor, _buffer} = start_editor("defmodule Example do\n  def run, do: :ok\nend")
-      set_active_fold_ranges(editor, [FoldRange.new!(0, 2)])
-      {row, col} = active_content_origin(editor)
+    test "clicking tab goto switches tabs without closing" do
+      {state, _buf1, _buf2} = start_two_tab_state()
+      active_id = state.shell_state.tab_bar.active_id
+      other_id = Enum.find(state.shell_state.tab_bar.tabs, &(&1.id != active_id)).id
 
-      send_mouse(
-        editor,
-        row + 1,
-        col + MingaEditor.Renderer.Gutter.fold_column_offset(),
-        :left,
-        :press
+      state =
+        set_tab_click_regions(state, [
+          {0, 4, :"tab_goto_#{other_id}"},
+          {5, 7, :"tab_close_#{other_id}"}
+        ])
+
+      state = mouse(state, 0, 2, :left, :press)
+
+      assert length(state.shell_state.tab_bar.tabs) == 2
+      assert state.shell_state.tab_bar.active_id == other_id
+    end
+  end
+
+  describe "invalid coordinates" do
+    test "negative coordinates are ignored" do
+      {state, buffer} = start_mouse_state("hello")
+      original_cursor = BufferProcess.cursor(buffer)
+
+      state = mouse(state, -1, 5, :left, :press)
+      mouse(state, @content_row, -3, :left, :press)
+
+      assert BufferProcess.cursor(buffer) == original_cursor
+    end
+  end
+
+  defp start_mouse_state(content, opts \\ []) do
+    id = :erlang.unique_integer([:positive])
+    events_registry = :"#{__MODULE__}.Events.#{id}"
+    project_root = Path.join(System.tmp_dir!(), "minga-mouse-#{id}")
+    File.mkdir_p!(project_root)
+    start_supervised!({Minga.Events, name: events_registry}, id: {:events, id})
+
+    options_server =
+      start_supervised!({Minga.Config.Options, name: nil, events_registry: events_registry},
+        id: {:options, id}
       )
 
-      window = EditorState.active_window_struct(state(editor))
-      refute FoldMap.fold_start?(window.fold_map, 0)
-    end
+    buffer =
+      start_supervised!(
+        {BufferProcess,
+         content: content, events_registry: events_registry, options_server: options_server},
+        id: {:buffer, id}
+      )
+
+    BufferProcess.set_option(buffer, :clipboard, :none)
+
+    state =
+      Startup.build_initial_state(
+        port_manager: nil,
+        buffer: buffer,
+        width: Keyword.get(opts, :width, 40),
+        height: Keyword.get(opts, :height, 10),
+        editing_model: :vim,
+        options_server: options_server,
+        events_registry: events_registry,
+        project_root: project_root,
+        suppress_tool_prompts: true
+      )
+
+    {state, buffer}
   end
 
-  describe "mouse with negative coordinates" do
-    test "negative row is ignored" do
-      {editor, buffer} = start_editor("hello")
-      original = BufferProcess.cursor(buffer)
-      send_mouse(editor, -1, 5, :left, :press)
-      assert BufferProcess.cursor(buffer) == original
-    end
-
-    test "negative col is ignored" do
-      {editor, buffer} = start_editor("hello")
-      original = BufferProcess.cursor(buffer)
-      send_mouse(editor, @content_row, -3, :left, :press)
-      assert BufferProcess.cursor(buffer) == original
-    end
+  defp start_two_tab_state do
+    {state, buf1} = start_mouse_state("hello", width: 80)
+    {:ok, buf2} = BufferProcess.start_link(content: "world")
+    state = EditorState.add_buffer(state, buf2, context: :open)
+    {state, buf1, buf2}
   end
 
-  describe "tab close button click" do
-    alias MingaEditor.State.TabBar
+  defp mouse(state, row, col, button, event_type, mods \\ 0, click_count \\ 1) do
+    Mouse.handle(state, row, col, button, mods, event_type, click_count)
+  end
 
-    defp start_two_tab_editor do
-      id = :erlang.unique_integer([:positive])
-      events_registry = :"mouse_tab_events_#{id}"
-      project_root = isolated_project_root(id)
-      start_supervised!({Minga.Events, name: events_registry})
+  defp lines(range), do: Enum.map_join(range, "\n", &"line #{&1}")
 
-      {:ok, buf1} = BufferProcess.start_link(content: "hello", events_registry: events_registry)
-      {:ok, buf2} = BufferProcess.start_link(content: "world", events_registry: events_registry)
+  defp rightmost_window_layout(layout) do
+    Enum.max_by(layout.window_layouts, fn {_id, %{content: {_row, content_col, _w, _h}}} ->
+      content_col
+    end)
+  end
 
-      {:ok, editor} =
-        MingaEditor.start_link(
-          name: :"editor_#{id}",
-          port_manager: nil,
-          buffer: buf1,
-          width: 80,
-          height: 10,
-          editing_model: :vim,
-          events_registry: events_registry,
-          project_root: project_root,
-          suppress_tool_prompts: true
-        )
+  defp window_viewport(state, window_id),
+    do: Map.fetch!(state.workspace.windows.map, window_id).viewport
 
-      # Inject a second tab directly via state manipulation
-      :sys.replace_state(editor, fn s ->
-        {tb, _tab} = TabBar.add(s.shell_state.tab_bar, :file, "world.ex")
-        buffers = %{s.workspace.buffers | list: [buf1, buf2]}
-        MingaEditor.State.set_tab_bar(%{s | workspace: %{s.workspace | buffers: buffers}}, tb)
-      end)
+  defp active_viewport(state), do: EditorState.active_window_struct(state).viewport
 
-      {editor, buf1, buf2}
-    end
+  defp active_window_layout(state), do: Layout.active_window_layout(Layout.get(state), state)
 
-    defp inject_click_regions(editor, regions) do
-      :sys.replace_state(editor, fn state ->
-        MingaEditor.State.update_shell_state(state, &%{&1 | tab_bar_click_regions: regions})
-      end)
-    end
+  defp active_content_origin(state) do
+    %{content: {row, col, _width, _height}} = active_window_layout(state)
+    {row, col}
+  end
 
-    test "clicking tab_close region closes the tab" do
-      {editor, _buf1, _buf2} = start_two_tab_editor()
+  defp set_visual_selection(state, buffer, anchor, cursor, visual_type) do
+    BufferProcess.move_to(buffer, cursor)
 
-      s = state(editor)
-      assert length(s.shell_state.tab_bar.tabs) == 2
+    EditorState.transition_mode(state, :visual, %VisualState{
+      visual_anchor: anchor,
+      visual_type: visual_type
+    })
+  end
 
-      # The active tab is tab 2 (we just added it). Inject a close region for it.
-      active_id = s.shell_state.tab_bar.active_id
-      inject_click_regions(editor, [{5, 7, :"tab_close_#{active_id}"}])
+  defp set_capabilities(state, frontend_type) do
+    %{state | capabilities: %Capabilities{frontend_type: frontend_type}}
+  end
 
-      # Click the close region on the tab bar row (row 0)
-      send_mouse(editor, 0, 6, :left, :press)
+  defp set_window_tree(state, tree) do
+    windows = Windows.set_tree(state.workspace.windows, tree)
+    EditorState.update_workspace(state, &WorkspaceState.set_windows(&1, windows))
+  end
 
-      s = state(editor)
-      assert length(s.shell_state.tab_bar.tabs) == 1
-    end
+  defp set_active_fold_ranges(state, ranges) do
+    EditorState.update_window(
+      state,
+      state.workspace.windows.active,
+      &Window.set_fold_ranges(&1, ranges)
+    )
+  end
 
-    test "clicking tab_close on the last remaining tab does nothing" do
-      {editor, _buffer} = start_editor("hello")
+  defp fold_active_window_at(state, line) do
+    EditorState.update_window(state, state.workspace.windows.active, &Window.fold_at(&1, line))
+  end
 
-      s = state(editor)
-      assert length(s.shell_state.tab_bar.tabs) == 1
-      active_id = s.shell_state.tab_bar.active_id
-
-      inject_click_regions(editor, [{5, 7, :"tab_close_#{active_id}"}])
-      send_mouse(editor, 0, 6, :left, :press)
-
-      s = state(editor)
-      assert length(s.shell_state.tab_bar.tabs) == 1
-    end
-
-    test "clicking tab_goto region switches tab without closing" do
-      {editor, _buf1, _buf2} = start_two_tab_editor()
-
-      s = state(editor)
-      active_id = s.shell_state.tab_bar.active_id
-      other_id = Enum.find(s.shell_state.tab_bar.tabs, &(&1.id != active_id)).id
-
-      inject_click_regions(editor, [
-        {0, 4, :"tab_goto_#{other_id}"},
-        {5, 7, :"tab_close_#{other_id}"}
-      ])
-
-      # Click the goto region (not the close region)
-      send_mouse(editor, 0, 2, :left, :press)
-
-      s = state(editor)
-      assert length(s.shell_state.tab_bar.tabs) == 2
-      assert s.shell_state.tab_bar.active_id == other_id
-    end
+  defp set_tab_click_regions(state, regions) do
+    EditorState.update_shell_state(state, &%{&1 | tab_bar_click_regions: regions})
   end
 end

--- a/test/minga_editor/startup_test.exs
+++ b/test/minga_editor/startup_test.exs
@@ -1,27 +1,253 @@
 defmodule MingaEditor.StartupTest do
-  # async: false because the CLI startup flag tests mutate Application env,
-  # which races with the first test when run concurrently.
+  # async: false because startup_view_state/1 reads global CLI startup flags from Application env.
   use ExUnit.Case, async: false
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Config.Options
+  alias Minga.Test.RecordingFrontend
   alias MingaEditor.Frontend.Capabilities
+  alias MingaEditor.Input
   alias MingaEditor.LayoutPreset
   alias MingaEditor.Startup
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
-  alias Minga.Test.RecordingFrontend
   alias MingaEditor.Window
   alias MingaEditor.Window.Content
   alias MingaEditor.WindowTree
-  alias MingaEditor.Input
 
-  defp start_events_registry(suffix) do
-    name = :"#{__MODULE__}.#{suffix}.#{System.unique_integer([:positive])}"
-    start_supervised!({Registry, keys: :duplicate, name: name})
-    name
+  describe "startup_view_state/1" do
+    test "defaults to agent view for TUI startup" do
+      {scope, agentic} = Startup.startup_view_state(:tui)
+
+      assert scope == :agent
+      assert agentic.view.active == true
+      assert agentic.view.focus == :chat
+    end
+
+    test "CLI startup flags select editor, agentic, and native GUI auto modes" do
+      assert_startup_scope(:tui, :editor, :editor, false)
+      assert_startup_scope(:native_gui, :agentic, :agent, true)
+      assert_startup_scope(:native_gui, :auto, :editor, false)
+    end
+  end
+
+  describe "apply_gui_defaults/2" do
+    setup do
+      %{server: start_supervised!({Options, name: nil})}
+    end
+
+    test "GUI frontends get GUI defaults while TUI frontends keep shared defaults", %{
+      server: server
+    } do
+      Startup.apply_gui_defaults(%Capabilities{frontend_type: :native_gui}, server)
+
+      assert Options.get(server, :line_spacing) == 1.2
+      assert Options.get(server, :line_numbers) == :absolute
+
+      tui_server = start_supervised!({Options, name: nil}, id: :tui_gui_defaults)
+      Startup.apply_gui_defaults(%Capabilities{frontend_type: :tui}, tui_server)
+
+      assert Options.get(tui_server, :line_spacing) == 1.0
+      assert Options.get(tui_server, :line_numbers) == :hybrid
+    end
+
+    test "explicit user overrides win over GUI defaults", %{server: server} do
+      {:ok, _} = Options.set(server, :line_spacing, 1.5)
+      {:ok, _} = Options.set(server, :line_numbers, :relative)
+
+      Startup.apply_gui_defaults(%Capabilities{frontend_type: :native_gui}, server)
+
+      assert Options.get(server, :line_spacing) == 1.5
+      assert Options.get(server, :line_numbers) == :relative
+    end
+
+    test "writes land on the supplied options server only" do
+      server_a = start_supervised!({Options, name: nil}, id: :gui_defaults_a)
+      server_b = start_supervised!({Options, name: nil}, id: :gui_defaults_b)
+
+      Startup.apply_gui_defaults(%Capabilities{frontend_type: :native_gui}, server_a)
+
+      assert Options.get(server_a, :line_numbers) == :absolute
+      assert Options.get(server_a, :line_spacing) == 1.2
+      assert Options.get(server_b, :line_numbers) == :hybrid
+      assert Options.get(server_b, :line_spacing) == 1.0
+    end
+  end
+
+  describe "send_font_config/1" do
+    setup do
+      %{server: start_supervised!({Options, name: nil})}
+    end
+
+    test "TUI font config excludes GUI-only opcodes", %{server: server} do
+      Startup.send_font_config(state_for_frontend(:tui, server))
+
+      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      refute Enum.any?(commands, &cursor_animation_opcode?/1)
+      refute Enum.any?(commands, &gui_font_option_opcode?/1)
+      refute_receive {:"$gen_cast", {:send_commands, _}}
+    end
+
+    test "GUI font config includes cursor animation from the supplied options server", %{
+      server: server
+    } do
+      Startup.send_font_config(state_for_frontend(:native_gui, server))
+
+      assert_receive {:"$gen_cast", {:send_commands, font_commands}}
+      assert_receive {:"$gen_cast", {:send_commands, [<<0x92, _::binary>>]}}
+      assert_receive {:"$gen_cast", {:send_commands, [<<0x95, 1::16, 1::8>>]}}
+      refute Enum.any?(font_commands, &cursor_animation_opcode?/1)
+      refute Enum.any?(font_commands, &gui_font_option_opcode?/1)
+
+      {:ok, false} = Options.set(server, :cursor_animate, false)
+      Startup.send_font_config(state_for_frontend(:native_gui, server))
+
+      assert_receive {:"$gen_cast", {:send_commands, _font_commands}}
+      assert_receive {:"$gen_cast", {:send_commands, [<<0x92, _::binary>>]}}
+      assert_receive {:"$gen_cast", {:send_commands, [<<0x95, 1::16, 0::8>>]}}
+    end
+  end
+
+  describe "send_cursor_animation_config/2" do
+    test "runtime cursor animation changes are GUI-only" do
+      Startup.send_cursor_animation_config(state_for_frontend(:native_gui), false)
+      assert_receive {:"$gen_cast", {:send_commands, [<<0x95, 1::16, 0::8>>]}}
+
+      Startup.send_cursor_animation_config(state_for_frontend(:tui), false)
+      refute_receive {:"$gen_cast", {:send_commands, _}}
+    end
+  end
+
+  describe "runtime option change events" do
+    test "editor forwards cursor animation changes from its own options server and ignores others" do
+      %{
+        editor: editor,
+        port: port,
+        options_server: options_server,
+        events_registry: events_registry
+      } =
+        start_recording_editor(:native_gui, :runtime_gui)
+
+      RecordingFrontend.reset(port)
+      sync_editor(editor)
+
+      assert {:ok, false} = Options.set(options_server, :cursor_animate, false)
+      assert_receive {:frontend_commands, ^port, [<<0x95, 1::16, 0::8>>]}
+
+      other_options =
+        start_supervised!({Options, name: nil, events_registry: events_registry},
+          id: :runtime_wrong_source_options
+        )
+
+      RecordingFrontend.reset(port)
+      sync_editor(editor)
+
+      assert {:ok, false} = Options.set(other_options, :cursor_animate, false)
+      refute_receive {:frontend_commands, ^port, [<<0x95, 1::16, 0::8>>]}
+    end
+
+    test "TUI editor ignores GUI-only cursor animation runtime changes" do
+      %{editor: editor, port: port, options_server: options_server} =
+        start_recording_editor(:tui, :runtime_tui)
+
+      RecordingFrontend.reset(port)
+      sync_editor(editor)
+
+      assert {:ok, false} = Options.set(options_server, :cursor_animate, false)
+      refute_receive {:frontend_commands, ^port, [<<0x95, _::binary>>]}
+    end
+  end
+
+  describe "build_initial_state/1" do
+    test "normalizes nil and supplied options servers" do
+      default_state =
+        Startup.build_initial_state(
+          backend: :headless,
+          port_manager: nil,
+          parser_manager: nil,
+          options_server: nil,
+          width: 80,
+          height: 24
+        )
+
+      assert default_state.options_server == Options.default_server()
+
+      options_server = start_supervised!({Options, name: __MODULE__})
+
+      assert {:ok, false} =
+               Options.set_for_filetype(options_server, :text, :autopair_block, false)
+
+      custom_state =
+        Startup.build_initial_state(
+          backend: :headless,
+          port_manager: nil,
+          parser_manager: nil,
+          options_server: options_server,
+          width: 80,
+          height: 24
+        )
+
+      assert custom_state.options_server == options_server
+
+      assert BufferProcess.get_option(custom_state.workspace.buffers.active, :autopair_block) ==
+               false
+    end
+  end
+
+  describe "build_initial_window/5" do
+    test "agent startup creates an agent chat window and editor startup creates a buffer window" do
+      {agent_window, {:agent_buffer, agent_buf}} =
+        Startup.build_initial_window(:agent, 1, self(), 24, 80)
+
+      assert %Window{} = agent_window
+      assert Content.agent_chat?(agent_window.content)
+      refute Content.buffer?(agent_window.content)
+      assert is_pid(agent_buf)
+      assert Process.alive?(agent_buf)
+
+      {:ok, buf} = BufferProcess.start_link(content: "hello")
+      {editor_window, :noop} = Startup.build_initial_window(:editor, 1, buf, 24, 80)
+
+      assert %Window{} = editor_window
+      assert Content.buffer?(editor_window.content)
+      assert editor_window.buffer == buf
+    end
+
+    test "editor startup with nil buffer returns no window" do
+      assert {nil, :noop} = Startup.build_initial_window(:editor, 1, nil, 24, 80)
+    end
+  end
+
+  describe "startup window shape" do
+    test "initial windows match LayoutPreset agent-chat detection" do
+      {:ok, buf} = BufferProcess.start_link(content: "scratch")
+
+      {agent_window, {:agent_buffer, _agent_buf}} =
+        Startup.build_initial_window(:agent, 1, buf, 24, 80)
+
+      {editor_window, :noop} = Startup.build_initial_window(:editor, 1, buf, 24, 80)
+
+      agent_state = window_state(:agent, agent_window)
+      editor_state = window_state(:editor, editor_window)
+
+      assert LayoutPreset.has_agent_chat?(agent_state)
+      refute LayoutPreset.has_agent_chat?(editor_state)
+      assert {:leaf, 1} = agent_state.workspace.windows.tree
+      assert map_size(agent_state.workspace.windows.map) == 1
+    end
+  end
+
+  defp assert_startup_scope(backend, view_mode, expected_scope, expected_active?) do
+    Application.put_env(:minga, :cli_startup_flags, %{view_mode: view_mode, no_context: false})
+
+    {scope, agentic} = Startup.startup_view_state(backend)
+
+    assert scope == expected_scope
+    assert agentic.view.active == expected_active?
+  after
+    Application.delete_env(:minga, :cli_startup_flags)
   end
 
   defp start_recording_editor(frontend_type, suffix) do
@@ -62,7 +288,7 @@ defmodule MingaEditor.StartupTest do
       )
 
     send(editor, {:minga_input, {:ready, 80, 24}})
-    :sys.get_state(editor)
+    sync_editor(editor)
     drain_frontend_commands(port)
 
     %{
@@ -73,6 +299,14 @@ defmodule MingaEditor.StartupTest do
     }
   end
 
+  defp start_events_registry(suffix) do
+    name = :"#{__MODULE__}.#{suffix}.#{System.unique_integer([:positive])}"
+    start_supervised!({Registry, keys: :duplicate, name: name})
+    name
+  end
+
+  defp sync_editor(editor), do: GenServer.call(editor, :api_mode)
+
   defp drain_frontend_commands(port) do
     receive do
       {:frontend_commands, ^port, _commands} -> drain_frontend_commands(port)
@@ -81,466 +315,31 @@ defmodule MingaEditor.StartupTest do
     end
   end
 
-  describe "startup_view_state/1" do
-    test "returns :agent scope when startup_view is :agent in TUI mode" do
-      {scope, agentic} = Startup.startup_view_state(:tui)
-
-      assert scope == :agent
-      assert agentic.view.active == true
-      assert agentic.view.focus == :chat
-    end
-
-    test "returns :editor scope when editor view mode is set" do
-      Application.put_env(:minga, :cli_startup_flags, %{view_mode: :editor, no_context: false})
-
-      {scope, agentic} = Startup.startup_view_state(:tui)
-
-      assert scope == :editor
-      assert agentic.view.active == false
-    after
-      Application.delete_env(:minga, :cli_startup_flags)
-    end
-
-    test "returns :agent scope when agentic view mode is set" do
-      Application.put_env(:minga, :cli_startup_flags, %{view_mode: :agentic, no_context: false})
-
-      {scope, agentic} = Startup.startup_view_state(:native_gui)
-
-      assert scope == :agent
-      assert agentic.view.active == true
-      assert agentic.view.focus == :chat
-    after
-      Application.delete_env(:minga, :cli_startup_flags)
-    end
-
-    test "returns :editor scope for native GUI backend in auto mode" do
-      Application.put_env(:minga, :cli_startup_flags, %{view_mode: :auto, no_context: false})
-
-      {scope, _agentic} = Startup.startup_view_state(:native_gui)
-
-      assert scope == :editor
-    after
-      Application.delete_env(:minga, :cli_startup_flags)
-    end
+  defp state_for_frontend(frontend_type, server \\ nil) do
+    %EditorState{
+      port_manager: self(),
+      workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+      options_server: server || Options.default_server(),
+      capabilities: %Capabilities{frontend_type: frontend_type}
+    }
   end
 
-  describe "apply_gui_defaults/2" do
-    setup do
-      # Per-test isolated Options server keeps these cases from racing on the
-      # global singleton and lets us assert exactly which server received the
-      # writes (proving the threading argument is honored).
-      server = start_supervised!({Options, name: nil})
-      %{server: server}
-    end
-
-    test "sets line_spacing to 1.2 for GUI frontend", %{server: server} do
-      gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
-
-      Startup.apply_gui_defaults(gui_caps, server)
-
-      assert Options.get(server, :line_spacing) == 1.2
-    end
-
-    test "does not change line_spacing for TUI frontend", %{server: server} do
-      tui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :tui}
-
-      Startup.apply_gui_defaults(tui_caps, server)
-
-      assert Options.get(server, :line_spacing) == 1.0
-    end
-
-    test "respects explicit user override to custom line_spacing in GUI mode",
-         %{server: server} do
-      gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
-      {:ok, _} = Options.set(server, :line_spacing, 1.5)
-
-      Startup.apply_gui_defaults(gui_caps, server)
-
-      assert Options.get(server, :line_spacing) == 1.5
-    end
-
-    test "respects explicit user override to default line_spacing in GUI mode",
-         %{server: server} do
-      gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
-      {:ok, _} = Options.set(server, :line_spacing, 1.0)
-      :ok = Options.mark_explicit(server, :line_spacing)
-
-      Startup.apply_gui_defaults(gui_caps, server)
-
-      assert Options.get(server, :line_spacing) == 1.0
-    end
-
-    test "sets line_numbers to :absolute for GUI frontend", %{server: server} do
-      gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
-
-      # Ensure the default is :hybrid before applying
-      assert Options.get(server, :line_numbers) == :hybrid
-
-      Startup.apply_gui_defaults(gui_caps, server)
-
-      assert Options.get(server, :line_numbers) == :absolute
-    end
-
-    test "does not change line_numbers for TUI frontend", %{server: server} do
-      tui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :tui}
-
-      Startup.apply_gui_defaults(tui_caps, server)
-
-      assert Options.get(server, :line_numbers) == :hybrid
-    end
-
-    test "respects explicit user override to :relative in GUI mode", %{server: server} do
-      gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
-      {:ok, _} = Options.set(server, :line_numbers, :relative)
-
-      Startup.apply_gui_defaults(gui_caps, server)
-
-      assert Options.get(server, :line_numbers) == :relative
-    end
-
-    test "respects explicit user override to :hybrid in GUI mode", %{server: server} do
-      gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
-      {:ok, _} = Options.set(server, :line_numbers, :hybrid)
-      :ok = Options.mark_explicit(server, :line_numbers)
-
-      Startup.apply_gui_defaults(gui_caps, server)
-
-      assert Options.get(server, :line_numbers) == :hybrid
-    end
-
-    test "writes land on the supplied server, not the default singleton" do
-      # End-to-end proof of the threading: two isolated servers, only the
-      # one passed to apply_gui_defaults/2 is mutated.
-      server_a = start_supervised!({Options, name: nil}, id: :gui_defaults_a)
-      server_b = start_supervised!({Options, name: nil}, id: :gui_defaults_b)
-      gui_caps = %MingaEditor.Frontend.Capabilities{frontend_type: :native_gui}
-
-      Startup.apply_gui_defaults(gui_caps, server_a)
-
-      assert Options.get(server_a, :line_numbers) == :absolute
-      assert Options.get(server_a, :line_spacing) == 1.2
-      assert Options.get(server_b, :line_numbers) == :hybrid
-      assert Options.get(server_b, :line_spacing) == 1.0
-    end
+  defp window_state(scope, window) do
+    %EditorState{
+      port_manager: self(),
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: VimState.new(),
+        keymap_scope: scope,
+        windows: %Windows{tree: WindowTree.new(1), map: %{1 => window}, active: 1, next_id: 2}
+      },
+      focus_stack: Input.default_stack()
+    }
   end
 
-  describe "send_font_config/1" do
-    setup do
-      server = start_supervised!({Options, name: nil})
-      %{server: server}
-    end
+  defp cursor_animation_opcode?(<<0x95, _::binary>>), do: true
+  defp cursor_animation_opcode?(_), do: false
 
-    test "does not send GUI-only renderer options to TUI frontends", %{server: server} do
-      state = %EditorState{
-        port_manager: self(),
-        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
-        options_server: server,
-        capabilities: %Capabilities{frontend_type: :tui}
-      }
-
-      Startup.send_font_config(state)
-
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
-      refute Enum.any?(commands, &match?(<<0x92, _::binary>>, &1))
-      refute Enum.any?(commands, &match?(<<0x95, _::binary>>, &1))
-      refute_receive {:"$gen_cast", {:send_commands, _}}
-    end
-
-    test "sends cursor animation preference to GUI frontends", %{server: server} do
-      state = %EditorState{
-        port_manager: self(),
-        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
-        options_server: server,
-        capabilities: %Capabilities{frontend_type: :native_gui}
-      }
-
-      Startup.send_font_config(state)
-
-      assert_receive {:"$gen_cast", {:send_commands, font_commands}}
-      assert_receive {:"$gen_cast", {:send_commands, [<<0x92, _::binary>>]}}
-      assert_receive {:"$gen_cast", {:send_commands, [<<0x95, 1::16, 1::8>>]}}
-      refute Enum.any?(font_commands, &match?(<<0x92, _::binary>>, &1))
-      refute Enum.any?(font_commands, &match?(<<0x95, _::binary>>, &1))
-    end
-
-    test "sends disabled cursor animation preference from the supplied options server", %{
-      server: server
-    } do
-      {:ok, false} = Options.set(server, :cursor_animate, false)
-
-      state = %EditorState{
-        port_manager: self(),
-        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
-        options_server: server,
-        capabilities: %Capabilities{frontend_type: :native_gui}
-      }
-
-      Startup.send_font_config(state)
-
-      assert_receive {:"$gen_cast", {:send_commands, _font_commands}}
-      assert_receive {:"$gen_cast", {:send_commands, [<<0x92, _::binary>>]}}
-      assert_receive {:"$gen_cast", {:send_commands, [<<0x95, 1::16, 0::8>>]}}
-    end
-  end
-
-  describe "send_cursor_animation_config/2" do
-    test "sends runtime cursor animation changes to GUI frontends" do
-      state = %EditorState{
-        port_manager: self(),
-        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
-        capabilities: %Capabilities{frontend_type: :native_gui}
-      }
-
-      Startup.send_cursor_animation_config(state, false)
-
-      assert_receive {:"$gen_cast", {:send_commands, [<<0x95, 1::16, 0::8>>]}}
-    end
-
-    test "does not send runtime cursor animation changes to TUI frontends" do
-      state = %EditorState{
-        port_manager: self(),
-        workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
-        capabilities: %Capabilities{frontend_type: :tui}
-      }
-
-      Startup.send_cursor_animation_config(state, false)
-
-      refute_receive {:"$gen_cast", {:send_commands, _}}
-    end
-  end
-
-  describe "runtime option change events" do
-    test "global cursor animation option changes are published on the server registry" do
-      events_registry = start_events_registry(:option_changed_publish)
-      server = start_supervised!({Options, name: nil, events_registry: events_registry})
-      Minga.Events.subscribe(:option_changed, events_registry)
-
-      assert {:ok, false} = Options.set(server, :cursor_animate, false)
-
-      assert_receive {:minga_event, :option_changed,
-                      %Minga.Events.OptionChangedEvent{
-                        source: ^server,
-                        name: :cursor_animate,
-                        value: false
-                      }}
-    end
-
-    test "editor forwards runtime cursor animation changes from its options server to GUI frontends" do
-      %{editor: editor, port: port, options_server: options_server} =
-        start_recording_editor(:native_gui, :runtime_gui)
-
-      RecordingFrontend.reset(port)
-      :sys.get_state(editor)
-
-      assert {:ok, false} = Options.set(options_server, :cursor_animate, false)
-
-      assert_receive {:frontend_commands, ^port, [<<0x95, 1::16, 0::8>>]}
-    end
-
-    test "editor matches runtime cursor animation changes from a named options server passed by pid" do
-      id = System.unique_integer([:positive])
-      events_registry = start_events_registry(:runtime_named_options)
-      options_name = :"#{__MODULE__}.named_options.#{id}"
-
-      options_server =
-        start_supervised!({Options, name: options_name, events_registry: events_registry},
-          id: {:named_options, id}
-        )
-
-      {:ok, buffer} = BufferProcess.start_link(content: "", events_registry: events_registry)
-
-      port =
-        start_supervised!(
-          {RecordingFrontend,
-           owner: self(),
-           width: 80,
-           height: 24,
-           capabilities: %Capabilities{frontend_type: :native_gui}},
-          id: {:named_recording_frontend, id}
-        )
-
-      editor =
-        start_supervised!(
-          {MingaEditor,
-           name: :"#{__MODULE__}.named_editor.#{id}",
-           backend: :headless,
-           port_manager: port,
-           buffer: buffer,
-           width: 80,
-           height: 24,
-           editing_model: :vim,
-           options_server: options_server,
-           events_registry: events_registry,
-           suppress_tool_prompts: true},
-          id: {:named_editor, id}
-        )
-
-      send(editor, {:minga_input, {:ready, 80, 24}})
-      :sys.get_state(editor)
-      drain_frontend_commands(port)
-
-      RecordingFrontend.reset(port)
-      :sys.get_state(editor)
-
-      assert {:ok, false} = Options.set(options_server, :cursor_animate, false)
-
-      assert_receive {:frontend_commands, ^port, [<<0x95, 1::16, 0::8>>]}
-    end
-
-    test "editor ignores runtime cursor animation changes from other options servers" do
-      %{editor: editor, port: port, events_registry: events_registry} =
-        start_recording_editor(:native_gui, :runtime_wrong_source)
-
-      other_options =
-        start_supervised!({Options, name: nil, events_registry: events_registry},
-          id: :runtime_wrong_source_options
-        )
-
-      RecordingFrontend.reset(port)
-      :sys.get_state(editor)
-
-      assert {:ok, false} = Options.set(other_options, :cursor_animate, false)
-
-      refute_receive {:frontend_commands, ^port, [<<0x95, 1::16, 0::8>>]}
-    end
-
-    test "TUI editor does not send GUI-only cursor animation opcode for runtime changes" do
-      %{editor: editor, port: port, options_server: options_server} =
-        start_recording_editor(:tui, :runtime_tui)
-
-      RecordingFrontend.reset(port)
-      :sys.get_state(editor)
-
-      assert {:ok, false} = Options.set(options_server, :cursor_animate, false)
-
-      refute_receive {:frontend_commands, ^port, [<<0x95, _::binary>>]}
-    end
-  end
-
-  describe "build_initial_state/1" do
-    test "treats nil options_server as the default server" do
-      state =
-        Startup.build_initial_state(
-          backend: :headless,
-          port_manager: nil,
-          parser_manager: nil,
-          options_server: nil,
-          width: 80,
-          height: 24
-        )
-
-      assert state.options_server == Options.default_server()
-    end
-
-    test "threads the supplied options server into the initial buffer" do
-      options_server = start_supervised!({Options, name: __MODULE__})
-
-      assert {:ok, false} =
-               Options.set_for_filetype(options_server, :text, :autopair_block, false)
-
-      state =
-        Startup.build_initial_state(
-          backend: :headless,
-          port_manager: nil,
-          parser_manager: nil,
-          options_server: options_server,
-          width: 80,
-          height: 24
-        )
-
-      assert state.options_server == options_server
-      assert BufferProcess.get_option(state.workspace.buffers.active, :autopair_block) == false
-    end
-  end
-
-  describe "build_initial_window/5" do
-    test "agent mode creates a full-screen agent_chat window" do
-      {window, update} = Startup.build_initial_window(:agent, 1, self(), 24, 80)
-
-      assert %Window{} = window
-      assert Content.agent_chat?(window.content)
-      refute Content.buffer?(window.content)
-      assert {:agent_buffer, pid} = update
-      assert is_pid(pid)
-      assert Process.alive?(pid)
-    end
-
-    test "editor mode creates a buffer window" do
-      {:ok, buf} = BufferProcess.start_link(content: "hello")
-
-      {window, update} = Startup.build_initial_window(:editor, 1, buf, 24, 80)
-
-      assert %Window{} = window
-      assert Content.buffer?(window.content)
-      refute Content.agent_chat?(window.content)
-      assert window.buffer == buf
-      assert update == :noop
-    end
-
-    test "editor mode with nil buffer returns nil window" do
-      {window, update} = Startup.build_initial_window(:editor, 1, nil, 24, 80)
-
-      assert window == nil
-      assert update == :noop
-    end
-  end
-
-  describe "startup creates correct window type (integration)" do
-    test "agent mode produces has_agent_chat? == true with single-leaf tree" do
-      # This is the regression guard. If this test fails, the agent
-      # session won't start because AgentLifecycle.maybe_start_session
-      # checks LayoutPreset.has_agent_chat? before starting.
-      {:ok, buf} = BufferProcess.start_link(content: "scratch")
-
-      {window, {:agent_buffer, _agent_buf}} =
-        Startup.build_initial_window(:agent, 1, buf, 24, 80)
-
-      # Simulate what build_initial_state does with the window
-      state = %EditorState{
-        port_manager: self(),
-        workspace: %MingaEditor.Workspace.State{
-          viewport: Viewport.new(24, 80),
-          editing: VimState.new(),
-          keymap_scope: :agent,
-          windows: %Windows{
-            tree: WindowTree.new(1),
-            map: %{1 => window},
-            active: 1,
-            next_id: 2
-          }
-        },
-        focus_stack: Input.default_stack()
-      }
-
-      assert LayoutPreset.has_agent_chat?(state),
-             "agent startup must produce a state where has_agent_chat? is true"
-
-      assert {:leaf, 1} = state.workspace.windows.tree
-      assert map_size(state.workspace.windows.map) == 1
-    end
-
-    test "editor mode produces has_agent_chat? == false" do
-      {:ok, buf} = BufferProcess.start_link(content: "scratch")
-      {window, :noop} = Startup.build_initial_window(:editor, 1, buf, 24, 80)
-
-      state = %EditorState{
-        port_manager: self(),
-        workspace: %MingaEditor.Workspace.State{
-          viewport: Viewport.new(24, 80),
-          editing: VimState.new(),
-          keymap_scope: :editor,
-          windows: %Windows{
-            tree: WindowTree.new(1),
-            map: %{1 => window},
-            active: 1,
-            next_id: 2
-          }
-        },
-        focus_stack: Input.default_stack()
-      }
-
-      refute LayoutPreset.has_agent_chat?(state)
-      assert Content.buffer?(state.workspace.windows.map[1].content)
-    end
-  end
+  defp gui_font_option_opcode?(<<0x92, _::binary>>), do: true
+  defp gui_font_option_opcode?(_), do: false
 end


### PR DESCRIPTION
# TL;DR
This PR cleans up mouse, startup, LSP, and agent session tests by moving assertions to the cheapest useful behavior boundary and removing direct GenServer state synchronization from the touched files.

## Context
This follows the same testing direction as #1751: keep broad editor integration coverage thin, and verify behavior at the cheapest useful layer. The old tests mixed public behavior checks with internal GenServer state assertions, timer checks, and duplicated full-stack cases. This PR keeps representative behavior coverage while removing brittle internal coupling.

## Changes
- Rewrote `MingaEditor.MouseTest` and `MingaEditor.MouseMultiClickTest` around direct `MingaEditor.Mouse` behavior calls.
- Slimmed startup tests around GUI defaults, runtime option forwarding, initial window construction, and startup mode selection.
- Thinned editor LSP wiring tests to no-op trigger safety, tuple-keyed hover response routing, and selection-range cleanup on visual exit.
- Collapsed LSP client lifecycle tests around public client behavior: handshake metadata, document sync notifications, diagnostics, status events, server requests, and request refs.
- Reduced agent session tests by combining duplicated initial state, send prompt, new session, metadata, queue text, and direct event sync cases.
- Removed all direct `:sys.get_state` usage from the six touched files.

## Verification
- `mix test.llm test/minga_editor/mouse_test.exs test/minga_editor/mouse_multi_click_test.exs test/minga_editor/startup_test.exs test/minga_editor/integration/lsp_wiring_test.exs test/minga_agent/session_test.exs`
- Result: `PASS: 112 tests, 0 failures`
- `mix test.debug test/minga/lsp/client_test.exs`
- Result: `9 tests, 0 failures`

## Notes for reviewers
- Net change across touched files: 3943 lines to 2934 lines, 200 tests to 121 tests, and direct `:sys.get_state` usage from 35 to 0.
- No production code changed.
