### PR TITLE
test(editor): clean sync boundary helpers

### DIFF
--- a/test/minga_editor/commands/buffer_management_shutdown_test.exs
+++ b/test/minga_editor/commands/buffer_management_shutdown_test.exs
@@ -6,8 +6,6 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
   alias Minga.Config.Options
   alias MingaEditor
 
-  @sync_timeout 30_000
-
   setup do
     previous_shutdown_fn = Application.fetch_env(:minga, :shutdown_fn)
     test_pid = self()
@@ -22,6 +20,47 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
         :error -> Application.delete_env(:minga, :shutdown_fn)
       end
     end)
+  end
+
+  describe "shutdown-path editor integration" do
+    test "quit all with a clean buffer exits without confirmation" do
+      {editor, _buffer, _options} = start_editor("hello")
+
+      type_string(editor, ":qa\r")
+
+      assert_receive {:shutdown_called, 0}
+    end
+
+    test "force quit all bypasses dirty-buffer confirmation" do
+      {editor, buffer, _options} = start_editor("hello")
+      BufferProcess.insert_char(buffer, "X")
+      assert BufferProcess.dirty?(buffer)
+
+      type_string(editor, ":qa!\r")
+
+      assert_receive {:shutdown_called, 0}
+    end
+
+    test "confirm_quit false disables the dirty-buffer quit-all prompt" do
+      {editor, buffer, options} = start_editor("hello")
+      BufferProcess.insert_char(buffer, "X")
+      assert BufferProcess.dirty?(buffer)
+      assert {:ok, false} = Options.set(options, :confirm_quit, false)
+
+      type_string(editor, ":qa\r")
+
+      assert_receive {:shutdown_called, 0}
+    end
+
+    test ":cq and :cq! exit with non-zero status" do
+      {editor, _buffer, _options} = start_editor("hello")
+      type_string(editor, ":cq\r")
+      assert_receive {:shutdown_called, 1}
+
+      {editor, _buffer, _options} = start_editor("hello")
+      type_string(editor, ":cq!\r")
+      assert_receive {:shutdown_called, 1}
+    end
   end
 
   defp start_editor(content) do
@@ -39,12 +78,7 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
         editing_model: :vim
       )
 
-    {editor, buffer}
-  end
-
-  defp send_key(editor, codepoint, mods \\ 0) do
-    send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = :sys.get_state(editor, @sync_timeout)
+    {editor, buffer, options}
   end
 
   defp type_string(editor, text) do
@@ -53,60 +87,8 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
     |> Enum.each(fn char -> send_key(editor, char) end)
   end
 
-  describe "shutdown-path editor integration" do
-    @describetag layer: :editor_integration
-
-    test "quit all with clean buffer exits without confirmation" do
-      {editor, _buffer} = start_editor("hello")
-
-      type_string(editor, ":qa\r")
-
-      assert_receive {:shutdown_called, 0}
-      state = :sys.get_state(editor, @sync_timeout)
-      refute state.pending_quit
-    end
-
-    test "force quit all bypasses confirmation even with dirty buffer" do
-      {editor, buffer} = start_editor("hello")
-      BufferProcess.insert_char(buffer, "X")
-      assert BufferProcess.dirty?(buffer)
-
-      type_string(editor, ":qa!\r")
-
-      assert_receive {:shutdown_called, 0}
-      state = :sys.get_state(editor, @sync_timeout)
-      refute state.pending_quit
-    end
-
-    test "confirm_quit false disables dirty-buffer quit-all prompt" do
-      {editor, buffer} = start_editor("hello")
-      BufferProcess.insert_char(buffer, "X")
-      assert BufferProcess.dirty?(buffer)
-
-      state = :sys.get_state(editor, @sync_timeout)
-      Options.set(state.options_server, :confirm_quit, false)
-
-      type_string(editor, ":qa\r")
-
-      assert_receive {:shutdown_called, 0}
-      state = :sys.get_state(editor, @sync_timeout)
-      refute state.pending_quit
-    end
-
-    test ":cq exits with non-zero exit code" do
-      {editor, _buffer} = start_editor("hello")
-
-      type_string(editor, ":cq\r")
-
-      assert_receive {:shutdown_called, 1}
-    end
-
-    test ":cq! exits with non-zero exit code" do
-      {editor, _buffer} = start_editor("hello")
-
-      type_string(editor, ":cq!\r")
-
-      assert_receive {:shutdown_called, 1}
-    end
+  defp send_key(editor, codepoint, mods \\ 0) do
+    send(editor, {:minga_input, {:key_press, codepoint, mods}})
+    GenServer.call(editor, :api_mode)
   end
 end

--- a/test/minga_editor/highlight_sync_eviction_test.exs
+++ b/test/minga_editor/highlight_sync_eviction_test.exs
@@ -1,7 +1,8 @@
 defmodule MingaEditor.HighlightSyncEvictionTest do
   @moduledoc """
-  Tests for LRU eviction of inactive parser buffer trees.
+  Tests for parser-buffer highlight tracking and eviction.
   """
+
   use ExUnit.Case, async: true
 
   alias MingaEditor.HighlightSync
@@ -9,7 +10,124 @@ defmodule MingaEditor.HighlightSyncEvictionTest do
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
 
-  # Build a minimal state with buffer_ids and last_active_at set up.
+  describe "evict_inactive/2" do
+    test "evicts stale buffers while keeping recently active buffers" do
+      fresh = tracked_pid()
+      stale = tracked_pid()
+
+      state =
+        base_state()
+        |> with_buffer_tracking(fresh, 1, 1_000)
+        |> with_buffer_tracking(stale, 2, 10 * 60 * 1_000)
+
+      new_state = HighlightSync.evict_inactive(state)
+
+      assert tracked?(new_state, fresh, 1)
+      refute tracked?(new_state, stale, 2)
+    end
+
+    test "keeps active and explicitly protected stale buffers" do
+      active = tracked_pid()
+      protected = tracked_pid()
+
+      state =
+        base_state()
+        |> with_buffer_tracking(active, 1, 10 * 60 * 1_000)
+        |> with_buffer_tracking(protected, 2, 10 * 60 * 1_000)
+        |> put_active(active)
+
+      new_state = HighlightSync.evict_inactive(state, protected_pids: [protected])
+
+      assert tracked?(new_state, active, 1)
+      assert tracked?(new_state, protected, 2)
+    end
+
+    test "returns state unchanged when no buffers are tracked" do
+      state = base_state()
+
+      assert HighlightSync.evict_inactive(state) == state
+    end
+
+    test "clears highlight cache for evicted buffers" do
+      stale = tracked_pid()
+
+      state =
+        base_state()
+        |> with_buffer_tracking(stale, 1, 10 * 60 * 1_000)
+        |> put_highlight_cache(stale)
+
+      new_state = HighlightSync.evict_inactive(state)
+
+      refute Map.has_key?(new_state.workspace.highlight.highlights, stale)
+    end
+  end
+
+  describe "touch_active/1" do
+    test "sets last_active_at for the active buffer" do
+      active = tracked_pid()
+      state = base_state() |> put_active(active)
+
+      new_state = HighlightSync.touch_active(state)
+
+      assert Map.has_key?(new_state.workspace.highlight.last_active_at, active)
+      ts = new_state.workspace.highlight.last_active_at[active]
+      now = System.monotonic_time(:millisecond)
+      assert abs(now - ts) < 100
+    end
+
+    test "returns state unchanged when no active buffer" do
+      state = base_state()
+
+      assert HighlightSync.touch_active(state) == state
+    end
+  end
+
+  describe "ensure_buffer_id/1" do
+    test "assigns and reuses buffer IDs" do
+      active = tracked_pid()
+      state = base_state() |> put_active(active)
+
+      {id1, state} = HighlightSync.ensure_buffer_id(state)
+      {id2, state} = HighlightSync.ensure_buffer_id(state)
+
+      assert id1 == 1
+      assert id2 == id1
+      assert state.workspace.highlight.buffer_ids[active] == 1
+      assert state.workspace.highlight.next_buffer_id == 2
+    end
+
+    test "assigns monotonically incrementing IDs for different buffers" do
+      first = tracked_pid()
+      second = tracked_pid()
+      state = base_state() |> put_active(first)
+
+      {id1, state} = HighlightSync.ensure_buffer_id(state)
+      {id2, _state} = state |> put_active(second) |> HighlightSync.ensure_buffer_id()
+
+      assert id2 == id1 + 1
+    end
+  end
+
+  describe "close_buffer/2" do
+    test "removes buffer ID mapping and cache" do
+      pid = tracked_pid()
+
+      state =
+        base_state()
+        |> with_buffer_tracking(pid, 1, 1_000)
+        |> put_highlight_cache(pid)
+
+      new_state = HighlightSync.close_buffer(state, pid)
+
+      refute Map.has_key?(new_state.workspace.highlight.buffer_ids, pid)
+      refute Map.has_key?(new_state.workspace.highlight.highlights, pid)
+    end
+
+    test "is a no-op for unknown buffer PIDs" do
+      assert HighlightSync.close_buffer(base_state(), tracked_pid()) == base_state()
+    end
+  end
+
   defp base_state do
     %EditorState{
       port_manager: nil,
@@ -20,222 +138,45 @@ defmodule MingaEditor.HighlightSyncEvictionTest do
     }
   end
 
+  defp tracked_pid do
+    pid = spawn(fn -> receive do: (:stop -> :ok) end)
+    ExUnit.Callbacks.on_exit(fn -> if Process.alive?(pid), do: send(pid, :stop) end)
+    pid
+  end
+
   defp with_buffer_tracking(state, pid, buffer_id, last_active_ms_ago) do
     hl = state.workspace.highlight
     now = System.monotonic_time(:millisecond)
 
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | highlight: %{
-              hl
-              | buffer_ids: Map.put(hl.buffer_ids, pid, buffer_id),
-                reverse_buffer_ids: Map.put(hl.reverse_buffer_ids, buffer_id, pid),
-                last_active_at: Map.put(hl.last_active_at, pid, now - last_active_ms_ago),
-                next_buffer_id: max(hl.next_buffer_id, buffer_id + 1)
-            }
-        }
-    }
+    put_highlight(state, %{
+      hl
+      | buffer_ids: Map.put(hl.buffer_ids, pid, buffer_id),
+        reverse_buffer_ids: Map.put(hl.reverse_buffer_ids, buffer_id, pid),
+        last_active_at: Map.put(hl.last_active_at, pid, now - last_active_ms_ago),
+        next_buffer_id: max(hl.next_buffer_id, buffer_id + 1)
+    })
   end
 
-  describe "evict_inactive/2" do
-    test "does not evict recently active buffers" do
-      pid1 = spawn(fn -> Process.sleep(:infinity) end)
-      state = base_state() |> with_buffer_tracking(pid1, 1, 1_000)
-
-      new_state = HighlightSync.evict_inactive(state)
-
-      assert Map.has_key?(new_state.workspace.highlight.buffer_ids, pid1)
-      assert Map.has_key?(new_state.workspace.highlight.reverse_buffer_ids, 1)
-      assert Map.has_key?(new_state.workspace.highlight.last_active_at, pid1)
-    end
-
-    test "evicts buffers inactive longer than TTL" do
-      pid1 = spawn(fn -> Process.sleep(:infinity) end)
-      # 10 minutes ago (well past the 5-minute default TTL)
-      state = base_state() |> with_buffer_tracking(pid1, 1, 10 * 60 * 1_000)
-
-      new_state = HighlightSync.evict_inactive(state)
-
-      refute Map.has_key?(new_state.workspace.highlight.buffer_ids, pid1)
-      refute Map.has_key?(new_state.workspace.highlight.reverse_buffer_ids, 1)
-      refute Map.has_key?(new_state.workspace.highlight.last_active_at, pid1)
-    end
-
-    test "does not evict the active buffer even if stale" do
-      pid1 = spawn(fn -> Process.sleep(:infinity) end)
-
-      state =
-        base_state()
-        |> with_buffer_tracking(pid1, 1, 10 * 60 * 1_000)
-        |> then(fn s -> put_in(s.workspace.buffers.active, pid1) end)
-
-      new_state = HighlightSync.evict_inactive(state)
-
-      # Active buffer is protected
-      assert Map.has_key?(new_state.workspace.highlight.buffer_ids, pid1)
-    end
-
-    test "does not evict protected PIDs" do
-      pid1 = spawn(fn -> Process.sleep(:infinity) end)
-      state = base_state() |> with_buffer_tracking(pid1, 1, 10 * 60 * 1_000)
-
-      new_state = HighlightSync.evict_inactive(state, protected_pids: [pid1])
-
-      assert Map.has_key?(new_state.workspace.highlight.buffer_ids, pid1)
-    end
-
-    test "evicts only stale buffers, keeps fresh ones" do
-      pid_fresh = spawn(fn -> Process.sleep(:infinity) end)
-      pid_stale = spawn(fn -> Process.sleep(:infinity) end)
-
-      state =
-        base_state()
-        |> with_buffer_tracking(pid_fresh, 1, 1_000)
-        |> with_buffer_tracking(pid_stale, 2, 10 * 60 * 1_000)
-
-      new_state = HighlightSync.evict_inactive(state)
-
-      assert Map.has_key?(new_state.workspace.highlight.buffer_ids, pid_fresh)
-      refute Map.has_key?(new_state.workspace.highlight.buffer_ids, pid_stale)
-    end
-
-    test "returns state unchanged when no buffers are tracked" do
-      state = base_state()
-      assert HighlightSync.evict_inactive(state) == state
-    end
-
-    test "clears highlight cache for evicted buffers" do
-      pid1 = spawn(fn -> Process.sleep(:infinity) end)
-
-      state =
-        base_state()
-        |> with_buffer_tracking(pid1, 1, 10 * 60 * 1_000)
-
-      hl = state.workspace.highlight
-
-      state = %{
-        state
-        | workspace: %{
-            state.workspace
-            | highlight: %{
-                hl
-                | highlights: Map.put(hl.highlights, pid1, MingaEditor.UI.Highlight.new())
-              }
-          }
-      }
-
-      new_state = HighlightSync.evict_inactive(state)
-
-      refute Map.has_key?(new_state.workspace.highlight.highlights, pid1)
-    end
+  defp put_active(state, pid) do
+    put_in(state.workspace.buffers.active, pid)
   end
 
-  describe "touch_active/1" do
-    test "sets last_active_at for the active buffer" do
-      pid1 = spawn(fn -> Process.sleep(:infinity) end)
+  defp put_highlight_cache(state, pid) do
+    hl = state.workspace.highlight
 
-      state =
-        base_state()
-        |> then(fn s -> put_in(s.workspace.buffers.active, pid1) end)
-
-      new_state = HighlightSync.touch_active(state)
-
-      assert Map.has_key?(new_state.workspace.highlight.last_active_at, pid1)
-      ts = new_state.workspace.highlight.last_active_at[pid1]
-      now = System.monotonic_time(:millisecond)
-      assert abs(now - ts) < 100
-    end
-
-    test "returns state unchanged when no active buffer" do
-      state = base_state()
-      assert HighlightSync.touch_active(state) == state
-    end
+    put_highlight(state, %{
+      hl
+      | highlights: Map.put(hl.highlights, pid, MingaEditor.UI.Highlight.new())
+    })
   end
 
-  describe "ensure_buffer_id/1" do
-    test "assigns a new buffer_id on first call" do
-      pid1 = spawn(fn -> Process.sleep(:infinity) end)
-
-      state =
-        base_state()
-        |> then(fn s -> put_in(s.workspace.buffers.active, pid1) end)
-
-      {id, new_state} = HighlightSync.ensure_buffer_id(state)
-
-      assert id == 1
-      assert new_state.workspace.highlight.buffer_ids[pid1] == 1
-      assert new_state.workspace.highlight.next_buffer_id == 2
-    end
-
-    test "returns existing buffer_id on subsequent calls" do
-      pid1 = spawn(fn -> Process.sleep(:infinity) end)
-
-      state =
-        base_state()
-        |> then(fn s -> put_in(s.workspace.buffers.active, pid1) end)
-
-      {id1, state} = HighlightSync.ensure_buffer_id(state)
-      {id2, _state} = HighlightSync.ensure_buffer_id(state)
-
-      assert id1 == id2
-    end
-
-    test "assigns monotonically incrementing IDs for different buffers" do
-      pid1 = spawn(fn -> Process.sleep(:infinity) end)
-      pid2 = spawn(fn -> Process.sleep(:infinity) end)
-
-      state =
-        base_state()
-        |> then(fn s -> put_in(s.workspace.buffers.active, pid1) end)
-
-      {id1, state} = HighlightSync.ensure_buffer_id(state)
-
-      state = %{
-        state
-        | workspace: %{state.workspace | buffers: %{state.workspace.buffers | active: pid2}}
-      }
-
-      {id2, _state} = HighlightSync.ensure_buffer_id(state)
-
-      assert id2 == id1 + 1
-    end
+  defp put_highlight(state, highlight) do
+    put_in(state.workspace.highlight, highlight)
   end
 
-  describe "close_buffer/2" do
-    test "removes buffer_id mapping and cache" do
-      pid1 = spawn(fn -> Process.sleep(:infinity) end)
-
-      state =
-        base_state()
-        |> with_buffer_tracking(pid1, 1, 1_000)
-
-      hl = state.workspace.highlight
-
-      state = %{
-        state
-        | workspace: %{
-            state.workspace
-            | highlight: %{
-                hl
-                | highlights: Map.put(hl.highlights, pid1, MingaEditor.UI.Highlight.new())
-              }
-          }
-      }
-
-      new_state = HighlightSync.close_buffer(state, pid1)
-
-      refute Map.has_key?(new_state.workspace.highlight.buffer_ids, pid1)
-      refute Map.has_key?(new_state.workspace.highlight.highlights, pid1)
-    end
-
-    test "no-op for unknown buffer PID" do
-      pid1 = spawn(fn -> Process.sleep(:infinity) end)
-      state = base_state()
-
-      new_state = HighlightSync.close_buffer(state, pid1)
-      assert new_state == state
-    end
+  defp tracked?(state, pid, buffer_id) do
+    Map.has_key?(state.workspace.highlight.buffer_ids, pid) and
+      Map.has_key?(state.workspace.highlight.reverse_buffer_ids, buffer_id) and
+      Map.has_key?(state.workspace.highlight.last_active_at, pid)
   end
 end

--- a/test/minga_editor/integration/gui_settings_action_test.exs
+++ b/test/minga_editor/integration/gui_settings_action_test.exs
@@ -8,7 +8,6 @@ defmodule Minga.Integration.GUISettingsActionTest do
   alias MingaEditor
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
-  alias MingaEditor.State, as: EditorState
 
   setup do
     gui_settings_path = Minga.Config.Loader.gui_settings_path()
@@ -22,10 +21,53 @@ defmodule Minga.Integration.GUISettingsActionTest do
     :ok
   end
 
-  defp start_events_registry(suffix) do
-    name = :"#{__MODULE__}.#{suffix}.#{System.unique_integer([:positive])}"
-    start_supervised!({Registry, keys: :duplicate, name: name})
-    name
+  test "config_query emits full config state" do
+    ctx = start_recording_editor(:gui_settings_query)
+    RecordingFrontend.reset(ctx.port)
+
+    send(ctx.editor, {:minga_input, {:gui_action, :config_query}})
+    sync_editor(ctx.editor)
+
+    expected = ProtocolGUI.config_state(ctx.options_server, Minga.Keymap.default_server())
+
+    assert ProtocolGUI.encode_gui_config_state(expected) in RecordingFrontend.commands(ctx.port)
+  end
+
+  test "config_update applies live changes and emits the changed entry" do
+    ctx = start_recording_editor(:gui_settings_update)
+    RecordingFrontend.reset(ctx.port)
+
+    send(ctx.editor, {:minga_input, {:gui_action, {:config_update, :wrap, true}}})
+    sync_editor(ctx.editor)
+
+    assert Options.get(ctx.options_server, :wrap) == true
+    assert BufferProcess.get_option(ctx.buffer, :wrap) == true
+
+    expected = ProtocolGUI.encode_gui_config_state(ProtocolGUI.config_state_entry(:wrap, true))
+    assert expected in RecordingFrontend.commands(ctx.port)
+  end
+
+  test "config_update persists settings and keeps explicit GUI defaults" do
+    ctx = start_recording_editor(:gui_settings_persist)
+
+    send(ctx.editor, {:minga_input, {:gui_action, {:config_update, :wrap, false}}})
+    sync_editor(ctx.editor)
+    Minga.Config.Writer.flush()
+
+    assert Options.get(ctx.options_server, :wrap) == false
+    assert BufferProcess.get_option(ctx.buffer, :wrap) == false
+    assert File.read!(Minga.Config.Loader.gui_settings_path()) =~ "set :wrap, false"
+
+    send(ctx.editor, {:minga_input, {:gui_action, {:config_update, :line_numbers, :hybrid}}})
+    sync_editor(ctx.editor)
+
+    assert Options.get(ctx.options_server, :line_numbers) == :hybrid
+    assert Options.explicitly_set?(ctx.options_server, :line_numbers)
+
+    send(ctx.editor, {:minga_input, {:ready, 80, 24}})
+    sync_editor(ctx.editor)
+
+    assert Options.get(ctx.options_server, :line_numbers) == :hybrid
   end
 
   defp start_recording_editor(suffix) do
@@ -66,11 +108,19 @@ defmodule Minga.Integration.GUISettingsActionTest do
       )
 
     send(editor, {:minga_input, {:ready, 80, 24}})
-    :sys.get_state(editor)
+    sync_editor(editor)
     drain_frontend_commands(port)
 
     %{editor: editor, port: port, buffer: buffer, options_server: options_server}
   end
+
+  defp start_events_registry(suffix) do
+    name = :"#{__MODULE__}.#{suffix}.#{System.unique_integer([:positive])}"
+    start_supervised!({Registry, keys: :duplicate, name: name})
+    name
+  end
+
+  defp sync_editor(editor), do: GenServer.call(editor, :api_mode)
 
   defp drain_frontend_commands(port) do
     receive do
@@ -78,53 +128,5 @@ defmodule Minga.Integration.GUISettingsActionTest do
     after
       0 -> :ok
     end
-  end
-
-  test "config_query emits full config state and config_update applies live changes" do
-    ctx = start_recording_editor(:gui_settings_action)
-    RecordingFrontend.reset(ctx.port)
-
-    send(ctx.editor, {:minga_input, {:gui_action, :config_query}})
-    state = :sys.get_state(ctx.editor)
-
-    expected_full_state =
-      ProtocolGUI.config_state(state.options_server, EditorState.keymap_server(state))
-
-    assert ProtocolGUI.encode_gui_config_state(expected_full_state) in RecordingFrontend.commands(
-             ctx.port
-           )
-
-    RecordingFrontend.reset(ctx.port)
-    send(ctx.editor, {:minga_input, {:gui_action, {:config_update, :wrap, true}}})
-    :sys.get_state(ctx.editor)
-
-    assert Options.get(ctx.options_server, :wrap) == true
-    assert BufferProcess.get_option(ctx.buffer, :wrap) == true
-
-    expected_update =
-      ProtocolGUI.encode_gui_config_state(ProtocolGUI.config_state_entry(:wrap, true))
-
-    assert expected_update in RecordingFrontend.commands(ctx.port)
-
-    RecordingFrontend.reset(ctx.port)
-    send(ctx.editor, {:minga_input, {:gui_action, {:config_update, :wrap, false}}})
-    :sys.get_state(ctx.editor)
-    Minga.Config.Writer.flush()
-
-    assert Options.get(ctx.options_server, :wrap) == false
-    assert BufferProcess.get_option(ctx.buffer, :wrap) == false
-    assert File.read!(Minga.Config.Loader.gui_settings_path()) =~ "set :wrap, false"
-
-    RecordingFrontend.reset(ctx.port)
-    send(ctx.editor, {:minga_input, {:gui_action, {:config_update, :line_numbers, :hybrid}}})
-    :sys.get_state(ctx.editor)
-
-    assert Options.get(ctx.options_server, :line_numbers) == :hybrid
-    assert Options.explicitly_set?(ctx.options_server, :line_numbers)
-
-    send(ctx.editor, {:minga_input, {:ready, 80, 24}})
-    :sys.get_state(ctx.editor)
-
-    assert Options.get(ctx.options_server, :line_numbers) == :hybrid
   end
 end

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -118,7 +118,7 @@ defmodule Minga.Test.EditorCase do
     # :setup_highlight, :debounced_render). Without this, a background
     # render can produce a spurious batch_end that satisfies the next
     # send_key's frame waiter before the key press is actually processed.
-    _ = get_editor_state(editor)
+    _ = sync_editor(editor)
     _ = sync_port(port)
 
     Map.merge(ctx, %{
@@ -180,7 +180,7 @@ defmodule Minga.Test.EditorCase do
     Process.put({:last_frame_snapshot, port}, snapshot)
 
     # Drain deferred messages from :ready (see start_editor/2 comment).
-    _ = get_editor_state(editor)
+    _ = sync_editor(editor)
     _ = sync_port(port)
 
     %{
@@ -203,7 +203,7 @@ defmodule Minga.Test.EditorCase do
   @spec inject_highlights(editor_ctx(), [String.t()], non_neg_integer(), [map()]) :: editor_ctx()
   def inject_highlights(ctx, capture_names, version \\ 1, spans) do
     # Flush pending messages (e.g. :setup_highlight from :ready)
-    _ = get_editor_state(ctx.editor)
+    _ = sync_editor(ctx.editor)
 
     # Ensure the active buffer has a registered parser buffer_id so the
     # highlight event handlers can route the message correctly. Previously
@@ -219,7 +219,7 @@ defmodule Minga.Test.EditorCase do
     send(ctx.editor, {:minga_input, {:highlight_names, buffer_id, capture_names}})
     send(ctx.editor, {:minga_input, {:highlight_spans, buffer_id, version, spans}})
     # Sync: ensure both messages have been processed before returning
-    _ = get_editor_state(ctx.editor)
+    _ = sync_editor(ctx.editor)
     ctx
   end
 
@@ -271,7 +271,7 @@ defmodule Minga.Test.EditorCase do
     # Drain any pending async messages (timers, highlight events, etc.)
     # before registering the frame waiter. This prevents a pending render
     # from satisfying our waiter instead of the intended key's render.
-    _ = get_editor_state(editor)
+    _ = sync_editor(editor)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
     {:ok, snapshot} = HeadlessPort.collect_frame(ref, @sync_timeout)
@@ -282,12 +282,12 @@ defmodule Minga.Test.EditorCase do
 
   @doc """
   Sends a key and waits for the editor GenServer to process it.
-  Uses `:sys.get_state` as a synchronization barrier instead of waiting
+  Uses a public GenServer call as a synchronization barrier instead of waiting
   for a render frame. Safe for both editor/buffer state reads AND
   port/screen state reads: because the editor sends the render cast to
-  the port before processing the `:sys.get_state` message, BEAM message
-  ordering guarantees the render reaches the port's mailbox ahead of any
-  subsequent `screen_cursor` or `modeline` call from the test process.
+  the port before processing the barrier call, BEAM message ordering guarantees
+  the render reaches the port's mailbox ahead of any subsequent `screen_cursor`
+  or `modeline` call from the test process.
 
   This is the preferred sync primitive for navigation tests. Use
   `send_key/3` only when you need the captured frame snapshot for
@@ -304,7 +304,7 @@ defmodule Minga.Test.EditorCase do
 
   @doc """
   Sends a vim-style key sequence and returns the editor state after
-  all keys are processed. Uses `:sys.get_state` as a barrier after
+  all keys are processed. Uses a public GenServer call as a barrier after
   each key to ensure re-sent messages (like passthrough from file tree
   or which-key timeouts) are fully processed before the next key.
   """
@@ -313,7 +313,7 @@ defmodule Minga.Test.EditorCase do
     parse_key_sequence(sequence)
     |> Enum.each(fn {cp, mods} ->
       send(editor, {:minga_input, {:key_press, cp, mods}})
-      get_editor_state(editor)
+      sync_editor(editor)
     end)
 
     # Clear any stale frame snapshot so assert_screen_snapshot falls back
@@ -327,8 +327,8 @@ defmodule Minga.Test.EditorCase do
 
   After `send_keys_sync` returns, the editor has finished processing all
   keys and sent the render cast to the port. But the port processes that
-  cast asynchronously. This function uses `:sys.get_state` on the port as
-  a barrier, ensuring the port has processed all pending render commands
+  cast asynchronously. This function reads a port snapshot as a barrier,
+  ensuring the port has processed all pending render commands
   before the test reads the screen.
 
   Call this before `assert_screen_snapshot` when using `send_keys_sync`.
@@ -443,8 +443,11 @@ defmodule Minga.Test.EditorCase do
   @spec get_editor_state(pid()) :: MingaEditor.State.t()
   defp get_editor_state(editor), do: :sys.get_state(editor, @sync_timeout)
 
-  @spec sync_port(pid()) :: map()
-  defp sync_port(port), do: :sys.get_state(port, @sync_timeout)
+  @spec sync_editor(pid()) :: atom()
+  defp sync_editor(editor), do: GenServer.call(editor, :api_mode, @sync_timeout)
+
+  @spec sync_port(pid()) :: HeadlessPort.screen()
+  defp sync_port(port), do: HeadlessPort.get_screen(port)
 
   @doc "Returns the current editor mode."
   @spec editor_mode(editor_ctx()) :: atom()
@@ -458,7 +461,7 @@ defmodule Minga.Test.EditorCase do
     BufferProcess.cursor(buffer)
   end
 
-  @doc "Returns the full editor state (via :sys.get_state). Race-free."
+  @doc "Returns the full editor state after synchronizing with the editor process. Prefer narrower helpers when possible."
   @spec editor_state(editor_ctx()) :: MingaEditor.State.t()
   def editor_state(%{editor: editor}) do
     get_editor_state(editor)
@@ -744,7 +747,7 @@ defmodule Minga.Test.EditorCase do
   end
 
   defp do_wait_screen(editor, port, condition, remaining, interval, message) when remaining > 0 do
-    get_editor_state(editor)
+    sync_editor(editor)
     sync_port(port)
 
     if condition.() do
@@ -792,7 +795,7 @@ defmodule Minga.Test.EditorCase do
         event_type \\ :press,
         click_count \\ 1
       ) do
-    _ = get_editor_state(editor)
+    _ = sync_editor(editor)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:mouse_event, row, col, button, mods, event_type, click_count}})
     {:ok, snapshot} = HeadlessPort.collect_frame(ref, @sync_timeout)
@@ -806,7 +809,7 @@ defmodule Minga.Test.EditorCase do
   """
   @spec send_resize(editor_ctx(), pos_integer(), pos_integer()) :: editor_ctx()
   def send_resize(%{editor: editor, port: port} = ctx, new_width, new_height) do
-    _ = get_editor_state(editor)
+    _ = sync_editor(editor)
     HeadlessPort.resize(port, new_width, new_height)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:resize, new_width, new_height}})


### PR DESCRIPTION
# TL;DR
This PR removes the next batch of brittle test synchronization patterns: shared `EditorCase` now uses public sync barriers for synchronization-only paths, GUI settings and shutdown tests assert outcomes without reading editor internals, and highlight eviction tests no longer spawn sleeper processes.

## Context
This continues the test-boundary cleanup from #1751 and #1753. The goal is to keep internal state access isolated to explicit helper APIs, avoid synchronizing tests by reading private GenServer state, and remove fake test processes that only exist because they sleep forever.

## Changes
- Updated `test/support/editor_case.ex` so synchronization-only helpers use public GenServer calls and HeadlessPort snapshots instead of direct state reads. The one remaining direct state read backs the intentionally explicit `editor_state/1` helper.
- Split the GUI settings action integration test into query, live update, and persistence/default-retention outcomes.
- Reworked buffer-management shutdown tests to assert shutdown status outcomes through the configured shutdown callback instead of inspecting `pending_quit`.
- Rewrote highlight eviction tests to use stoppable helper processes instead of `Process.sleep(:infinity)` and collapsed redundant cases.

## Verification
- `mix test.llm test/minga_editor/integration/lsp_wiring_test.exs test/minga_editor/startup_test.exs test/minga_editor/integration/gui_settings_action_test.exs test/minga_editor/commands/buffer_management_shutdown_test.exs test/minga_editor/highlight_sync_eviction_test.exs`
- Result: `PASS: 35 tests, 0 failures`

## Notes for reviewers
- Net change across touched files: 1342 lines to 1270 lines, 20 tests to 17 tests, direct `:sys.get_state` usage from 18 to 1, and `Process.sleep` usage from 14 to 0.
- No production code changed.
