### PR TITLE
test(agent): replace board sleeper session fakes

### DIFF
--- a/test/minga_editor/agent/agent_group_association_test.exs
+++ b/test/minga_editor/agent/agent_group_association_test.exs
@@ -11,8 +11,20 @@ defmodule MingaEditor.Agent.AgentGroupAssociationTest do
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
 
+  defp fake_session_pid do
+    pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn -> if Process.alive?(pid), do: send(pid, :stop) end)
+    pid
+  end
+
   defp build_agent_scenario do
-    fake_session = spawn(fn -> Process.sleep(:infinity) end)
+    fake_session = fake_session_pid()
 
     tab1 = %Tab{id: 1, kind: :file, label: "editor.ex", group_id: 0}
     tab2 = %Tab{id: 2, kind: :file, label: "main.ex", group_id: 0}
@@ -59,7 +71,7 @@ defmodule MingaEditor.Agent.AgentGroupAssociationTest do
   describe "workspace lifecycle" do
     test "creating agent workspace assigns session" do
       tb = TabBar.new(Tab.new_file(1, "a.ex"))
-      fake_session = spawn(fn -> Process.sleep(:infinity) end)
+      fake_session = fake_session_pid()
 
       {tb, ws} = TabBar.add_agent_group(tb, "Research", fake_session)
       assert ws.session == fake_session

--- a/test/minga_editor/agent/event_routing_test.exs
+++ b/test/minga_editor/agent/event_routing_test.exs
@@ -28,6 +28,18 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
   defp workspace, do: %WorkspaceState{viewport: Viewport.new(24, 80), editing: VimState.new()}
 
+  defp fake_session_pid do
+    pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn -> if Process.alive?(pid), do: send(pid, :stop) end)
+    pid
+  end
+
   defp tab(%TabBar{tabs: tabs}, id), do: Enum.find(tabs, &(&1.id == id))
 
   defp tab_bar(tabs, active_id) do
@@ -46,8 +58,8 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
   describe "Traditional.on_agent_event/4" do
     setup do
-      session_a = spawn_link(fn -> Process.sleep(:infinity) end)
-      session_b = spawn_link(fn -> Process.sleep(:infinity) end)
+      session_a = fake_session_pid()
+      session_b = fake_session_pid()
 
       tabs = [
         Tab.new_agent(1, "A") |> Tab.set_session(session_a),
@@ -146,8 +158,8 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
   describe "Board.on_agent_event/4" do
     setup do
-      session_a = spawn_link(fn -> Process.sleep(:infinity) end)
-      session_b = spawn_link(fn -> Process.sleep(:infinity) end)
+      session_a = fake_session_pid()
+      session_b = fake_session_pid()
 
       board = BoardState.new()
       {board, _card_a} = BoardState.create_card(board, task: "A", session: session_a)

--- a/test/minga_editor/shell/board/input_test.exs
+++ b/test/minga_editor/shell/board/input_test.exs
@@ -65,6 +65,18 @@ defmodule MingaEditor.Shell.Board.InputTest do
 
   defp stop_session(_pid), do: :ok
 
+  defp fake_session_pid do
+    pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn -> if Process.alive?(pid), do: send(pid, :stop) end)
+    pid
+  end
+
   # ── Grid navigation ────────────────────────────────────────────────────
 
   describe "grid navigation" do
@@ -147,7 +159,7 @@ defmodule MingaEditor.Shell.Board.InputTest do
       # Set up a board with one agent card that has a session but no workspace.
       # The shell carries the agent buffer pid that the bootstrap helper uses
       # to construct the agent-chat window.
-      fake_session = spawn(fn -> Process.sleep(:infinity) end)
+      fake_session = fake_session_pid()
       {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
 
       board =
@@ -188,7 +200,7 @@ defmodule MingaEditor.Shell.Board.InputTest do
     test "first-time zoom matches re-zoom shape (modulo prompt content)" do
       # The acceptance criterion: first-zoom and re-zoom land in the same
       # workspace shape — agent scope, agent-chat window, fresh agent_ui.
-      fake_session = spawn(fn -> Process.sleep(:infinity) end)
+      fake_session = fake_session_pid()
       {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
 
       board =
@@ -295,7 +307,7 @@ defmodule MingaEditor.Shell.Board.InputTest do
 
     test "does not double-start when card already has a session" do
       {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
-      fake_session = spawn(fn -> Process.sleep(:infinity) end)
+      fake_session = fake_session_pid()
 
       board =
         BoardState.new()
@@ -347,7 +359,7 @@ defmodule MingaEditor.Shell.Board.InputTest do
       # (zoomed_into == nil), so active_session/1 reports nil. The session
       # itself is not killed; the card retains its pid for the next zoom-in.
       state = editor_zoomed_into(3, 1)
-      fake_pid = spawn(fn -> Process.sleep(:infinity) end)
+      fake_pid = fake_session_pid()
 
       board =
         BoardState.update_card(state.shell_state, 1, fn card ->
@@ -401,8 +413,8 @@ defmodule MingaEditor.Shell.Board.InputTest do
     test "zoom A → out → zoom B does not leak A's session into B's rendering cache" do
       # Two cards with distinct sessions. After zooming through A and into
       # B, the active session must report as B's pid (no leak from A).
-      session_a = spawn(fn -> Process.sleep(:infinity) end)
-      session_b = spawn(fn -> Process.sleep(:infinity) end)
+      session_a = fake_session_pid()
+      session_b = fake_session_pid()
       {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
 
       board =


### PR DESCRIPTION
# TL;DR
This PR removes the remaining Board and agent event `Process.sleep(:infinity)` test fakes and replaces them with stoppable helper session pids.

## Context
This continues the test-boundary cleanup from the recent PRs. These tests did not need real sleeper processes. They only needed stable pids to stand in for agent sessions. The old helpers leaked processes until test shutdown and counted as production-style sleep usage in the suite.

## Changes
- Added small `fake_session_pid/0` helpers that wait for a `:stop` message and are cleaned up with `on_exit`.
- Updated Board input tests to use stoppable fake session pids for zoom and session-cache behavior.
- Updated agent event routing tests to use stoppable fake session pids for Traditional and Board routing assertions.
- Updated agent group association tests to use stoppable fake session pids for TabBar workspace association.

## Verification
- `mix test.llm test/minga_editor/shell/board/input_test.exs test/minga_editor/agent/event_routing_test.exs test/minga_editor/agent/agent_group_association_test.exs`
- Result: `PASS: 45 tests, 0 failures`

## Notes for reviewers
- Net change across touched files: 923 lines to 959 lines, 45 tests unchanged, and `Process.sleep` usage from 12 to 0.
- No production code changed.
