### PR TITLE
test(editor): quiet noisy test output

### DIFF
--- a/lib/minga/file_watcher.ex
+++ b/lib/minga/file_watcher.ex
@@ -311,16 +311,28 @@ defmodule Minga.FileWatcher do
   end
 
   defp ensure_watcher(existing_watcher, dirs) do
-    if existing_watcher do
-      try do
-        GenServer.stop(existing_watcher)
-      catch
-        :exit, _ -> :ok
-      end
+    stop_watcher(existing_watcher)
+
+    dir_list = dirs |> Map.keys() |> Enum.filter(&File.dir?/1)
+
+    if dir_list == [] do
+      nil
+    else
+      start_watcher(dir_list)
     end
+  end
 
-    dir_list = Map.keys(dirs)
+  @spec stop_watcher(pid() | nil) :: :ok
+  defp stop_watcher(nil), do: :ok
 
+  defp stop_watcher(pid) do
+    GenServer.stop(pid)
+  catch
+    :exit, _ -> :ok
+  end
+
+  @spec start_watcher([String.t()]) :: pid() | nil
+  defp start_watcher(dir_list) do
     case FileSystem.start_link(dirs: dir_list) do
       {:ok, pid} ->
         FileSystem.subscribe(pid)

--- a/lib/minga/git/repo.ex
+++ b/lib/minga/git/repo.ex
@@ -389,6 +389,15 @@ defmodule Minga.Git.Repo do
   defp start_git_watcher(state) do
     git_dir = Path.join(state.git_root, ".git")
 
+    if File.dir?(git_dir) do
+      do_start_git_watcher(state, git_dir)
+    else
+      state
+    end
+  end
+
+  @spec do_start_git_watcher(t(), String.t()) :: t()
+  defp do_start_git_watcher(state, git_dir) do
     case FileSystem.start_link(dirs: [git_dir]) do
       {:ok, pid} ->
         FileSystem.subscribe(pid)

--- a/lib/minga_agent/notifier.ex
+++ b/lib/minga_agent/notifier.ex
@@ -73,12 +73,12 @@ defmodule MingaAgent.Notifier do
 
   `message` is a short summary shown in the OS notification body.
   """
-  @spec notify(trigger(), String.t()) :: :ok
-  def notify(trigger, message) do
+  @spec notify(trigger(), String.t(), keyword()) :: :ok
+  def notify(trigger, message, opts \\ []) do
     if enabled?() and trigger in active_triggers() and not debounced?() do
       record_notification()
-      send_bell()
-      send_os_notification(trigger, message)
+      maybe_send_bell(Keyword.get(opts, :bell, true))
+      send_os_notification(trigger, message, Keyword.get(opts, :os_adapter, @os_adapter))
     end
 
     :ok
@@ -130,6 +130,10 @@ defmodule MingaAgent.Notifier do
     :ok
   end
 
+  @spec maybe_send_bell(boolean()) :: :ok
+  defp maybe_send_bell(false), do: :ok
+  defp maybe_send_bell(true), do: send_bell()
+
   @spec send_bell() :: :ok
   defp send_bell do
     # Write BEL to stderr (the terminal) to trigger tab flash / dock bounce
@@ -141,10 +145,10 @@ defmodule MingaAgent.Notifier do
       :ok
   end
 
-  @spec send_os_notification(trigger(), String.t()) :: :ok
-  defp send_os_notification(trigger, message) do
+  @spec send_os_notification(trigger(), String.t(), module()) :: :ok
+  defp send_os_notification(trigger, message, os_adapter) do
     title = title_for(trigger)
-    @os_adapter.send_notification(title, message)
+    os_adapter.send_notification(title, message)
   end
 
   @spec title_for(trigger()) :: String.t()

--- a/lib/minga_editor/commands/eval.ex
+++ b/lib/minga_editor/commands/eval.ex
@@ -61,6 +61,17 @@ defmodule MingaEditor.Commands.Eval do
   @spec eval_in_sandbox(String.t(), pid()) ::
           {:ok, term()} | {:error, atom(), term(), Exception.stacktrace()}
   defp eval_in_sandbox(input, editor_pid) do
+    {result, diagnostics} =
+      Code.with_diagnostics(fn ->
+        do_eval_in_sandbox(input, editor_pid)
+      end)
+
+    enrich_compile_error(result, diagnostics)
+  end
+
+  @spec do_eval_in_sandbox(String.t(), pid()) ::
+          {:ok, term()} | {:error, atom(), term(), Exception.stacktrace()}
+  defp do_eval_in_sandbox(input, editor_pid) do
     env = %{__ENV__ | file: "eval", line: 1}
     {result, _bindings} = Code.eval_string(input, [editor: editor_pid], env)
     {:ok, result}
@@ -68,6 +79,33 @@ defmodule MingaEditor.Commands.Eval do
     e -> {:error, :error, e, __STACKTRACE__}
   catch
     kind, value -> {:error, kind, value, __STACKTRACE__}
+  end
+
+  @spec enrich_compile_error(
+          {:ok, term()} | {:error, atom(), term(), Exception.stacktrace()},
+          [map()]
+        ) :: {:ok, term()} | {:error, atom(), term(), Exception.stacktrace()}
+  defp enrich_compile_error({:error, :error, %CompileError{} = error, stacktrace}, diagnostics) do
+    case first_error_diagnostic(diagnostics) do
+      nil ->
+        {:error, :error, error, stacktrace}
+
+      diagnostic ->
+        {:error, :error,
+         %CompileError{
+           error
+           | description: diagnostic.message,
+             file: diagnostic.file || error.file,
+             line: diagnostic.position || error.line
+         }, stacktrace}
+    end
+  end
+
+  defp enrich_compile_error(result, _diagnostics), do: result
+
+  @spec first_error_diagnostic([map()]) :: map() | nil
+  defp first_error_diagnostic(diagnostics) do
+    Enum.find(diagnostics, &(&1.severity == :error))
   end
 
   @spec format_error_oneline(atom(), term()) :: String.t()

--- a/test/minga_agent/notifier_test.exs
+++ b/test/minga_agent/notifier_test.exs
@@ -2,20 +2,23 @@ defmodule MingaAgent.NotifierTest do
   use ExUnit.Case, async: true
 
   alias MingaAgent.Notifier
+  alias MingaAgent.Notifier.OSAdapter.Noop
 
-  describe "notify/2" do
+  @notify_opts [bell: false, os_adapter: Noop]
+
+  describe "notify/3" do
     test "does not crash on any trigger type" do
-      assert :ok = Notifier.notify(:approval, "Test approval")
-      assert :ok = Notifier.notify(:complete, "Test complete")
-      assert :ok = Notifier.notify(:error, "Test error")
+      assert :ok = Notifier.notify(:approval, "Test approval", @notify_opts)
+      assert :ok = Notifier.notify(:complete, "Test complete", @notify_opts)
+      assert :ok = Notifier.notify(:error, "Test error", @notify_opts)
     end
 
     test "respects debouncing" do
       # First notification should go through
-      assert :ok = Notifier.notify(:complete, "First")
+      assert :ok = Notifier.notify(:complete, "First", @notify_opts)
 
       # Second within debounce window should be suppressed (but still return :ok)
-      assert :ok = Notifier.notify(:complete, "Second")
+      assert :ok = Notifier.notify(:complete, "Second", @notify_opts)
 
       # We can't easily test that the second was suppressed without mocking,
       # but we verify no crash occurs
@@ -23,7 +26,7 @@ defmodule MingaAgent.NotifierTest do
 
     test "handles unknown trigger gracefully" do
       # Shouldn't crash even with unexpected trigger values
-      assert :ok = Notifier.notify(:unknown_trigger, "test")
+      assert :ok = Notifier.notify(:unknown_trigger, "test", @notify_opts)
     end
   end
 

--- a/test/minga_editor/commands/eval_test.exs
+++ b/test/minga_editor/commands/eval_test.exs
@@ -82,16 +82,9 @@ defmodule MingaEditor.Commands.EvalTest do
     @tag capture_log: true
     test "undefined variable returns error" do
       state = build_state()
-
-      # Note: `Code.eval_string("undefined_var")` writes a compiler diagnostic
-      # to stderr. We used to wrap this in `ExUnit.CaptureIO.capture_io(:stderr,
-      # ...)` to keep test output clean, but that races with other async tests
-      # over the global :standard_error process and crashes ExUnit.CaptureServer
-      # on CI (see PR #1442 for the failure trace). The diagnostic line is
-      # tolerable; correctness is what we care about here.
       result = Eval.execute(state, {:eval_expression, "undefined_var"})
 
-      assert result.shell_state.status_msg =~ "**"
+      assert result.shell_state.status_msg =~ "undefined variable"
     end
 
     test "throw is caught and displayed" do

--- a/test/minga_editor/integration/file_open_from_agent_tab_test.exs
+++ b/test/minga_editor/integration/file_open_from_agent_tab_test.exs
@@ -103,6 +103,10 @@ defmodule Minga.Integration.FileOpenFromAgentTabTest do
 
       open_file_and_wait(ctx, file_path)
 
+      wait_until_screen(ctx, fn -> String.contains?(screen_row(ctx, 0), ".credo.exs") end,
+        message: "Expected opened file tab to become visible"
+      )
+
       assert String.contains?(screen_row(ctx, 0), ".credo.exs")
       assert screen_contains?(ctx, "configs = [:editor]")
       assert_modeline_contains(ctx, "NORMAL")

--- a/test/scripts/protocol_generated_edits_test.exs
+++ b/test/scripts/protocol_generated_edits_test.exs
@@ -3,6 +3,14 @@ defmodule Minga.ProtocolGeneratedEditsScriptTest do
   use ExUnit.Case, async: false
 
   @script Path.expand("../../scripts/check_protocol_generated_edits", __DIR__)
+  @git_env [
+    {"GIT_CONFIG_NOSYSTEM", "1"},
+    {"GIT_CONFIG_GLOBAL", "/dev/null"},
+    {"GIT_AUTHOR_NAME", "Test User"},
+    {"GIT_AUTHOR_EMAIL", "test@example.com"},
+    {"GIT_COMMITTER_NAME", "Test User"},
+    {"GIT_COMMITTER_EMAIL", "test@example.com"}
+  ]
 
   test "passes when generated source files are only deleted" do
     with_git_repo(fn dir ->
@@ -87,6 +95,7 @@ defmodule Minga.ProtocolGeneratedEditsScriptTest do
       git!(dir, ["init", "-b", "main"])
       git!(dir, ["config", "user.email", "test@example.com"])
       git!(dir, ["config", "user.name", "Test User"])
+      git!(dir, ["config", "core.hooksPath", "/dev/null"])
       fun.(dir)
     after
       File.rm_rf!(dir)
@@ -108,7 +117,7 @@ defmodule Minga.ProtocolGeneratedEditsScriptTest do
 
   @spec git!(Path.t(), [String.t()]) :: :ok
   defp git!(dir, args) do
-    case System.cmd("git", args, cd: dir, stderr_to_stdout: true) do
+    case System.cmd("git", args, cd: dir, stderr_to_stdout: true, env: @git_env) do
       {_output, 0} -> :ok
       {output, code} -> flunk("git #{Enum.join(args, " ")} failed with #{code}: #{output}")
     end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -54,6 +54,10 @@ Minga.Config.Options.set(:auto_save_delay_ms, 0)
 # not leak real language-server clients into tests that assert no LSP is active.
 Minga.Config.Options.set(:lsp_auto_start, false)
 
+# Disable agent notifications during tests to avoid terminal bells and OS
+# notification subprocesses from ordinary session tests.
+Minga.Config.Options.set(:agent_notifications, false)
+
 # Disable persisting known projects and recent files during tests to avoid
 # polluting ~/.config/minga/known-projects with test fixture directories.
 Minga.Config.Options.set(:persist_known_projects, false)


### PR DESCRIPTION
# TL;DR
Test output is quieter and the protocol-generated edits script tests no longer fail when a developer has global git identity hooks installed. This keeps async tests async while moving noisy behavior to the right layer.

## Context
A full `mix test` run was failing in `Minga.ProtocolGeneratedEditsScriptTest` because temporary git repos inherited a global pre-commit hook. The same run also printed noisy watcher errors, eval compiler diagnostics, terminal bells, and occasional async-render timing flakes.

## Changes
- Isolated protocol-generated script test repos from global git config and hooks by setting a hermetic git env plus `core.hooksPath=/dev/null`.
- Avoided starting FileSystem watchers for missing directories, including missing `.git` directories in git repo tests.
- Wrapped eval execution in `Code.with_diagnostics/1` so undefined-variable diagnostics become structured eval errors instead of stderr noise.
- Added test-safe notification options and disabled agent notifications in the test helper to avoid BEL output and OS notification subprocesses during tests.
- Kept async tests async, and fixed the agent-tab file-open integration test to wait for the opened file surface before asserting.

## Verification
- `make lint` passed.
- `mix test.llm` passed: 52 doctests, 99 properties, 8891 tests, 0 failures, 5 skipped, 225 excluded.
- Earlier full `mix test` passed after the main noise fixes: 52 doctests, 100 properties, 9006 tests, 0 failures, 5 skipped, 109 excluded.
- Targeted reviewer re-check returned PASS.
