### PR TITLE
test: remove remaining sleep-based sync

### DIFF
--- a/test/minga/language/tree_sitter_test.exs
+++ b/test/minga/language/tree_sitter_test.exs
@@ -1,4 +1,5 @@
 defmodule Minga.Language.TreeSitterTest do
+  # Serial because grammar compilation shells out to cc and writes fixed shared-library cache paths.
   use ExUnit.Case, async: false
 
   alias Minga.Language.TreeSitter

--- a/test/minga/language/tree_sitter_test.exs
+++ b/test/minga/language/tree_sitter_test.exs
@@ -51,7 +51,7 @@ defmodule Minga.Language.TreeSitterTest do
       assert {:ok, lib_path} = TreeSitter.compile_grammar("test_cache", source_dir)
 
       # Record the library's mtime, then backdate source files so the cache
-      # looks newer than the sources (avoids Process.sleep for mtime gap).
+      # looks newer than the sources without waiting for an mtime gap.
       {:ok, lib_stat} = File.stat(lib_path, time: :posix)
 
       for src <- Path.wildcard(Path.join(source_dir, "*.c")) do

--- a/test/minga/tool/manager_test.exs
+++ b/test/minga/tool/manager_test.exs
@@ -6,7 +6,7 @@ defmodule Minga.Tool.ManagerTest do
   alias Minga.Tool.Installer.Stub
 
   @moduletag timeout: 10_000
-  # Sleep-based synchronization in installer stub (~500ms).
+  # Exercises the singleton Manager and async install tasks.
   # Excluded from test.llm; runs in test.heavy and full suite.
   @moduletag :heavy
 
@@ -82,9 +82,13 @@ defmodule Minga.Tool.ManagerTest do
     end
 
     test "returns error when already installing" do
-      Stub.set_install_delay(500)
+      gate_ref = Stub.block_next_install()
       assert :ok = Manager.install(:black)
+      assert_receive {:install_blocked, ^gate_ref, install_pid, :black}, 1_000
+
       assert {:error, :already_installing} = Manager.install(:black)
+
+      Stub.release_install(install_pid, gate_ref)
       await_install(:black)
     end
 

--- a/test/minga_agent/hooks/module_runner_test.exs
+++ b/test/minga_agent/hooks/module_runner_test.exs
@@ -18,8 +18,9 @@ defmodule MingaAgent.Hooks.ModuleRunnerTest do
   defmodule SlowPolicy do
     @spec check(map()) :: :allow
     def check(_payload) do
-      Process.sleep(5_000)
-      :allow
+      receive do
+        :allow -> :allow
+      end
     end
   end
 

--- a/test/minga_agent/tools/subagent_test.exs
+++ b/test/minga_agent/tools/subagent_test.exs
@@ -497,8 +497,9 @@ defmodule MingaAgent.Tools.SubagentTest do
     test "falls back to default context when parent session is already dead", %{tmp_dir: dir} do
       ref = make_ref()
       parent = start_parent_session(dir, ref)
-      MingaAgent.Supervisor.stop_session(parent)
-      Process.sleep(50)
+      monitor_ref = Process.monitor(parent)
+      assert :ok = MingaAgent.Supervisor.stop_session(parent)
+      assert_receive {:DOWN, ^monitor_ref, :process, ^parent, _reason}, 1_000
 
       assert {:ok, "child response"} =
                Subagent.execute("do child task",

--- a/test/minga_editor/agent_activation_test.exs
+++ b/test/minga_editor/agent_activation_test.exs
@@ -32,7 +32,7 @@ defmodule MingaEditor.AgentActivationTest do
 
   defp activated_state do
     # Simulate an activated agent: session attached to active tab, scope is :agent, prompt focused
-    fake_pid = spawn(fn -> Process.sleep(:infinity) end)
+    fake_pid = self()
 
     state = base_state()
 

--- a/test/minga_editor/frontend/protocol_gui_board_test.exs
+++ b/test/minga_editor/frontend/protocol_gui_board_test.exs
@@ -94,7 +94,7 @@ defmodule MingaEditor.Frontend.Protocol.GUIBoardTest do
 
     test "does not set you-card flag for agent card" do
       state = State.new()
-      fake_pid = spawn(fn -> Process.sleep(:infinity) end)
+      fake_pid = self()
       {state, card} = State.create_card(state, task: "agent task")
       state = State.update_card(state, card.id, &Card.attach_session(&1, fake_pid))
 

--- a/test/minga_editor/highlight_sync_test.exs
+++ b/test/minga_editor/highlight_sync_test.exs
@@ -12,7 +12,7 @@ defmodule MingaEditor.HighlightSyncTest do
 
   # Minimal state for testing with a fake active buffer PID.
   defp base_state do
-    pid = spawn(fn -> Process.sleep(:infinity) end)
+    pid = self()
 
     %EditorState{
       port_manager: nil,

--- a/test/minga_editor/shell/board/session_lifecycle_test.exs
+++ b/test/minga_editor/shell/board/session_lifecycle_test.exs
@@ -44,7 +44,7 @@ defmodule MingaEditor.Shell.Board.SessionLifecycleTest do
     end
 
     test "no-ops when card already has a session" do
-      fake_pid = spawn(fn -> Process.sleep(:infinity) end)
+      fake_pid = self()
       board = BoardState.new()
       {board, card} = BoardState.create_card(board, task: "Agent", session: fake_pid)
       state = make_state(board)

--- a/test/minga_editor/shell/board/session_lifecycle_test.exs
+++ b/test/minga_editor/shell/board/session_lifecycle_test.exs
@@ -1,4 +1,5 @@
 defmodule MingaEditor.Shell.Board.SessionLifecycleTest do
+  # Serial because one test temporarily unregisters the global MingaAgent.SessionManager.
   use ExUnit.Case, async: false
 
   alias MingaAgent.SessionManager

--- a/test/minga_editor/state/agent_test.exs
+++ b/test/minga_editor/state/agent_test.exs
@@ -37,7 +37,7 @@ defmodule MingaEditor.State.AgentTest do
     end
 
     test "reset_cache preserves buffer pid (rendering stays on the same buffer)" do
-      buf = spawn(fn -> Process.sleep(:infinity) end)
+      buf = self()
       agent = new_agent() |> AgentState.set_buffer(buf) |> AgentState.reset_cache()
       assert agent.buffer == buf
     end

--- a/test/minga_editor/workspace/state_test.exs
+++ b/test/minga_editor/workspace/state_test.exs
@@ -51,7 +51,7 @@ defmodule MingaEditor.Workspace.StateTest do
       win_id = ws.windows.active
 
       # Set the window's content to agent_chat
-      agent_pid = spawn(fn -> Process.sleep(:infinity) end)
+      agent_pid = self()
       window = Map.get(ws.windows.map, win_id)
       agent_window = %{window | content: Content.agent_chat(agent_pid)}
       ws = %{ws | windows: %{ws.windows | map: Map.put(ws.windows.map, win_id, agent_window)}}

--- a/test/support/minga/tool/installer/stub.ex
+++ b/test/support/minga/tool/installer/stub.ex
@@ -49,7 +49,7 @@ defmodule Minga.Tool.Installer.Stub do
     :ets.insert(@table, {:uninstall_result, :ok})
     :ets.insert(@table, {:installed_version, {:ok, "1.0.0-stub"}})
     :ets.insert(@table, {:latest_version, {:ok, "2.0.0-stub"}})
-    :ets.insert(@table, {:install_delay_ms, 0})
+    :ets.insert(@table, {:install_gate, nil})
     :ets.insert(@table, {:installs, []})
     :ets.insert(@table, {:uninstalls, []})
     :ok
@@ -83,10 +83,18 @@ defmodule Minga.Tool.Installer.Stub do
     :ok
   end
 
-  @doc "Sets a delay in milliseconds before install completes."
-  @spec set_install_delay(non_neg_integer()) :: :ok
-  def set_install_delay(ms) when is_integer(ms) and ms >= 0 do
-    :ets.insert(@table, {:install_delay_ms, ms})
+  @doc "Blocks the next install until the test releases it."
+  @spec block_next_install(pid()) :: reference()
+  def block_next_install(test_pid \\ self()) when is_pid(test_pid) do
+    ref = make_ref()
+    :ets.insert(@table, {:install_gate, {test_pid, ref}})
+    ref
+  end
+
+  @doc "Releases a blocked install task."
+  @spec release_install(pid(), reference()) :: :ok
+  def release_install(installer_pid, ref) when is_pid(installer_pid) and is_reference(ref) do
+    send(installer_pid, {ref, :continue})
     :ok
   end
 
@@ -124,10 +132,7 @@ defmodule Minga.Tool.Installer.Stub do
 
     progress.(:installing, "Stub installing #{name}...")
 
-    # Simulate delay if configured (test stub only, not production code)
-    delay = get_value(:install_delay_ms, 0)
-    # credo:disable-for-next-line Minga.Credo.NoProcessSleepCheck
-    if delay > 0, do: Process.sleep(delay)
+    maybe_gate_install(name)
 
     progress.(:verifying, "Stub verifying #{name}...")
 
@@ -156,6 +161,28 @@ defmodule Minga.Tool.Installer.Stub do
   end
 
   # ── Private ─────────────────────────────────────────────────────────────────
+
+  @spec maybe_gate_install(atom()) :: :ok
+  defp maybe_gate_install(name) do
+    case get_value(:install_gate, nil) do
+      {test_pid, ref} when is_pid(test_pid) and is_reference(ref) ->
+        :ets.insert(@table, {:install_gate, nil})
+        monitor_ref = Process.monitor(test_pid)
+        send(test_pid, {:install_blocked, ref, self(), name})
+
+        receive do
+          {^ref, :continue} ->
+            Process.demonitor(monitor_ref, [:flush])
+            :ok
+
+          {:DOWN, ^monitor_ref, :process, ^test_pid, _reason} ->
+            :ok
+        end
+
+      _ ->
+        :ok
+    end
+  end
 
   @spec get_value(atom(), term()) :: term()
   defp get_value(key, default) do


### PR DESCRIPTION
# TL;DR
This PR removes the remaining `Process.sleep` usage from the test tree. Tests now use monitor messages, deterministic gates, or stable existing pids instead of sleeping to make async behavior observable.

## Context
This continues the test-boundary cleanup work by removing isolated sleep-based synchronization cases. The goal is to keep tests deterministic and avoid hidden timing assumptions, especially around agent/session lifecycle and async tool installation.

## Changes
- Replaced the module hook timeout sleep with a blocking `receive`, letting the runner timeout drive the assertion.
- Replaced the dead parent session wait in subagent tests with `Process.monitor/1` and an asserted `:DOWN` message.
- Replaced fake sleeper pids with `self()` where tests only need a stable pid identity.
- Replaced the installer stub's configurable delay with an explicit install gate that tells the test when the async install task is blocked and can be released.
- Added required comments for two serial test modules, documenting the concrete global resources that force `async: false`.

## Verification
- `rg -n "Process\\.sleep" test` → `0 matches`
- `mix test.llm test/minga_agent/hooks/module_runner_test.exs test/minga_agent/tools/subagent_test.exs test/minga_editor/agent_activation_test.exs test/minga_editor/frontend/protocol_gui_board_test.exs test/minga_editor/highlight_sync_test.exs test/minga_editor/shell/board/session_lifecycle_test.exs test/minga_editor/state/agent_test.exs test/minga_editor/workspace/state_test.exs test/minga/language/tree_sitter_test.exs test/minga/tool/manager_test.exs` → `PASS: 91 tests, 0 failures, 12 excluded`
- `mix test.debug test/minga/tool/manager_test.exs` → `12 tests, 0 failures`
- Final reviewer gate: PASS after targeted re-review

## Notes for reviewers
- Changed files: 11
- Test-tree `Process.sleep` mentions in changed files: 10 to 0
- No production code changed.
