### PR TITLE
fix(zig): avoid stale predicate cache pointer

### DIFF
--- a/zig/src/highlighter.zig
+++ b/zig/src/highlighter.zig
@@ -75,8 +75,14 @@ pub const Highlighter = struct {
     indent_query_cache: std.StringHashMapUnmanaged(*c.TSQuery),
     textobject_query_cache: std.StringHashMapUnmanaged(*c.TSQuery),
     tags_query_cache: std.StringHashMapUnmanaged(*c.TSQuery),
-    /// Currently active predicate table (set during setLanguage)
-    current_predicates: ?*const predicates_mod.PredicateTable = null,
+    /// Currently active predicate table (set during setLanguage).
+    ///
+    /// This is a shallow copy of the cached table value, not a pointer into
+    /// `predicate_cache`. `StringHashMapUnmanaged` can rehash when the
+    /// background prewarm thread inserts another language, which invalidates
+    /// value pointers returned by `getPtr` while leaving the table's owned
+    /// slices stable.
+    current_predicates: ?predicates_mod.PredicateTable = null,
     /// Capture id for @conceal in the active highlight query, if present.
     current_conceal_capture_id: ?u32 = null,
     /// Last highlight result sizes, used to pre-size hot-path result buffers.
@@ -324,8 +330,8 @@ pub const Highlighter = struct {
                 }
             }
             // Restore predicate table and hot capture metadata for current language
-            if (self.predicate_cache.getPtr(name)) |cached_ptr| {
-                self.current_predicates = cached_ptr;
+            if (self.predicate_cache.get(name)) |cached| {
+                self.current_predicates = cached;
             } else {
                 self.current_predicates = null;
             }


### PR DESCRIPTION
# TL;DR
Fixes a Zig parser crash caused by holding a stale pointer into the predicate cache while the background query prewarm thread can rehash that cache.

## Context
The test suite could finish with zero ExUnit failures while still printing a Zig stack trace from `predicates.zig:127`. The crash address used Zig's debug memory poison pattern, which pointed to invalid memory rather than a logical predicate failure.

## Changes
- Store the active predicate table as a shallow copied `PredicateTable` value instead of a pointer returned by `StringHashMapUnmanaged.getPtr`.
- Keep the copied table non-owning, so cached predicate tables still own their slices and compiled regex cleanup remains centralized in the cache.
- Document why this avoids pointer invalidation when the background prewarm thread inserts more languages and the hash map rehashes.

## Verification
- `mix zig.lint` passed in `../minga-worktrees/fix-zig-predicate-crash-investigation`
- `mix test.llm` passed in the same worktree: 52 doctests, 99 properties, 8811 tests, 0 failures, 5 skipped, 193 excluded
- Grepped the full test output for `predicates.zig:127` and `address 0xaaaaaaaa`; result: `STACK_NOT_FOUND`
- Final reviewer gate passed after validation was rerun in the actual worktree
