### PR TITLE
Fix quit behavior across file tabs and agent view

### DIFF
--- a/docs/AGENTIC-KEYMAP.md
+++ b/docs/AGENTIC-KEYMAP.md
@@ -115,8 +115,8 @@ See [Agent tool approval](CONFIGURATION.md#agent-tool-approval) for how to confi
 
 | Key | Action |
 |-----|--------|
-| `q` | Close agentic view |
-| `Esc` | Close agentic view |
+| `q` | Return to editor |
+| `Esc` | Return to editor (after dismissing transient UI) |
 | `?` | Show help overlay |
 
 ### Search
@@ -135,7 +135,7 @@ See [Agent tool approval](CONFIGURATION.md#agent-tool-approval) for how to confi
 | `SPC a s` | Stop / abort agent |
 | `SPC a m` | Pick agent model |
 | `SPC a T` | Cycle thinking level |
-| `SPC a t` | Toggle agentic view (close) |
+| `SPC a t` | Toggle agentic view (return to editor) |
 
 ## Chat Input Mode
 
@@ -161,7 +161,7 @@ Active when the file viewer panel has focus (after pressing `Tab`).
 | `Ctrl-d` / `Ctrl-u` | Scroll half page |
 | `gg` / `G` | Top / bottom |
 | `Tab` | Switch focus back to chat |
-| `q` / `Esc` | Close agentic view |
+| `q` / `Esc` | Return to editor |
 | `}` / `{` | Grow / shrink chat panel |
 | `=` | Reset panel split |
 

--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -130,8 +130,8 @@ defmodule Minga.Keymap.Scope.Agent do
     |> Bindings.bind([{?s, 0}], :agent_session_switcher, "Session switcher")
     # Help
     |> Bindings.bind([{??, 0}], :agent_toggle_help, "Toggle help overlay")
-    # Close
-    |> Bindings.bind([{?q, 0}], :agent_close, "Close agent split")
+    # Return to editor
+    |> Bindings.bind([{?q, 0}], :agent_close, "Return to editor")
     |> Bindings.bind([{@escape, 0}], :agent_dismiss_or_noop, "Dismiss/cancel")
     # Clear
     |> Bindings.bind([{?l, @ctrl}], :agent_clear_chat, "Clear chat display")
@@ -250,7 +250,7 @@ defmodule Minga.Keymap.Scope.Agent do
        ]},
       {"View",
        [
-         {"q", "Close agent split"},
+         {"q", "Return to editor"},
          {"?", "This help overlay"}
        ]}
     ]
@@ -271,13 +271,13 @@ defmodule Minga.Keymap.Scope.Agent do
        ]},
       {"Panel",
        [
-         {"Tab / Escape", "Switch focus to chat"},
+         {"Tab", "Switch focus to chat"},
          {"{ / }", "Shrink / grow chat panel"},
          {"=", "Reset panel split"}
        ]},
       {"View",
        [
-         {"q", "Close agent split"},
+         {"q", "Return to editor"},
          {"?", "This help overlay"}
        ]}
     ]

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -900,17 +900,17 @@ defmodule MingaEditor.Commands.Agent do
 
   # ── Close / dismiss ────────────────────────────────────────────────────────
 
-  @doc "Closes the agent split pane."
+  @doc "Returns from the agent view to the most recent file tab."
   @spec scope_close(state()) :: state()
   def scope_close(state), do: toggle_agent_split(state)
 
-  @doc "Dismisses active overlays or does nothing (ESC behavior)."
+  @doc "Dismisses active overlays or returns to the editor (ESC behavior)."
   @spec scope_dismiss_or_noop(state()) :: state()
   def scope_dismiss_or_noop(state) do
     if AgentAccess.view(state).help_visible do
       update_agent_ui(state, &UIState.dismiss_help/1)
     else
-      state
+      toggle_agent_split(state)
     end
   end
 
@@ -1333,7 +1333,7 @@ defmodule MingaEditor.Commands.Agent do
     {:agent_prev_search_match, "Previous agent search match", :scope_prev_search_match},
     {:agent_session_switcher, "Agent session switcher", :scope_session_switcher},
     {:agent_toggle_help, "Toggle agent help", :scope_toggle_help},
-    {:agent_close, "Close agent panel", :scope_close},
+    {:agent_close, "Return to editor", :scope_close},
     {:agent_dismiss_or_noop, "Dismiss agent or no-op", :scope_dismiss_or_noop},
     {:agent_accept_hunk, "Accept agent hunk", :scope_accept_hunk},
     {:agent_reject_hunk, "Reject agent hunk", :scope_reject_hunk},

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -1130,22 +1130,40 @@ defmodule MingaEditor.Commands.BufferManagement do
   # For file tabs, this closes the tab without killing the buffer (matching
   # Neovim where `:q` closes the window but the buffer stays in memory).
   # For agent tabs, session cleanup is needed so we delegate to close_agent_tab.
-  # Checks whether a quit should be confirmed (dirty buffers + confirm_quit enabled).
-  # If confirmation is needed, sets `pending_quit` and a status message.
-  # Otherwise, proceeds with the quit immediately.
+  # Checks whether a quit should be confirmed. Dirty buffers use the existing
+  # confirm_quit option; last-file `:q` always asks before exiting so Vim-style
+  # close semantics do not surprise users by terminating the app.
   @spec maybe_confirm_quit(state(), :quit | :quit_all) :: state()
-  defp maybe_confirm_quit(state, kind) do
-    if confirm_quit_enabled?(state) and any_buffer_dirty?(state) do
+  defp maybe_confirm_quit(state, :quit) do
+    dirty? = dirty_quit_confirmation_needed?(state)
+
+    if dirty? or quit_would_exit_editor?(state) do
       state
-      |> EditorState.set_pending_quit(kind)
-      |> EditorState.set_status("Modified buffers exist. Really quit? (y/n)")
+      |> EditorState.set_pending_quit(:quit)
+      |> EditorState.set_status(quit_confirmation_message(dirty?))
     else
-      case kind do
-        :quit -> close_tab_or_quit(state)
-        :quit_all -> shutdown_editor(state)
-      end
+      close_tab_or_quit(state)
     end
   end
+
+  defp maybe_confirm_quit(state, :quit_all) do
+    if dirty_quit_confirmation_needed?(state) do
+      state
+      |> EditorState.set_pending_quit(:quit_all)
+      |> EditorState.set_status("Modified buffers exist. Really quit? (y/n)")
+    else
+      shutdown_editor(state)
+    end
+  end
+
+  @spec dirty_quit_confirmation_needed?(state()) :: boolean()
+  defp dirty_quit_confirmation_needed?(state) do
+    confirm_quit_enabled?(state) and any_buffer_dirty?(state)
+  end
+
+  @spec quit_confirmation_message(boolean()) :: String.t()
+  defp quit_confirmation_message(true), do: "Modified buffers exist. Quit Minga? (y/n)"
+  defp quit_confirmation_message(false), do: "Quit Minga? (y/n)"
 
   @spec any_buffer_dirty?(state()) :: boolean()
   defp any_buffer_dirty?(state) do
@@ -1178,44 +1196,51 @@ defmodule MingaEditor.Commands.BufferManagement do
   end
 
   @spec close_tab_or_quit(state()) :: state()
-  defp close_tab_or_quit(%{shell_state: %{tab_bar: %TabBar{tabs: [_, _ | _]}}} = state) do
-    case EditorState.active_tab_kind(state) do
-      :agent -> close_agent_tab(state)
-      _ -> close_file_tab(state)
-    end
-  end
-
-  # Last tab: replace with an empty buffer instead of quitting.
-  # Matches VS Code/Zed behavior where closing the last tab leaves
-  # an empty editor, not an exited process.
-  defp close_tab_or_quit(%{shell_state: %{tab_bar: %TabBar{tabs: [only]}}} = state) do
-    # For agent tabs, clean up the session first (no tab navigation;
-    # cleanup_agent_session is pure resource teardown).
-    state = if only.kind == :agent, do: cleanup_agent_session(state), else: state
-
-    {:ok, buf} =
-      DynamicSupervisor.start_child(
-        Minga.Buffer.Supervisor,
-        {Minga.Buffer,
-         content: "", buffer_name: "[new]", options_server: EditorState.options_server(state)}
-      )
-
-    # add_buffer creates a new file tab (for agent tabs, via
-    # add_buffer_as_new_tab which resets keymap_scope to :editor
-    # and resets the agent UI). For file tabs it replaces in place.
-    state = EditorState.add_buffer(state, buf)
-
-    # Now we have 2 tabs; remove the old one. add_buffer may have reused
-    # the existing tab (replaced in-place), leaving only one tab, so
-    # TabBar.remove returns :last_tab. That's fine: the buffer was
-    # already swapped.
-    case TabBar.remove(state.shell_state.tab_bar, only.id) do
-      {:ok, tb} -> EditorState.set_tab_bar(state, tb)
-      :last_tab -> state
+  defp close_tab_or_quit(%{shell_state: %{tab_bar: %TabBar{}}} = state) do
+    case EditorState.active_tab(state) do
+      %Tab{kind: :agent} -> close_agent_tab_or_quit(state)
+      %Tab{kind: :file, id: active_id} -> close_file_tab_or_quit(state, active_id)
+      _ -> shutdown_editor(state)
     end
   end
 
   defp close_tab_or_quit(state), do: shutdown_editor(state)
+
+  @spec close_agent_tab_or_quit(state()) :: state()
+  defp close_agent_tab_or_quit(%{shell_state: %{tab_bar: %TabBar{tabs: [_single]}}} = state) do
+    state
+    |> cleanup_agent_session()
+    |> shutdown_editor()
+  end
+
+  defp close_agent_tab_or_quit(state), do: close_agent_tab(state)
+
+  @spec close_file_tab_or_quit(state(), Tab.id()) :: state()
+  defp close_file_tab_or_quit(state, active_id) do
+    tb = EditorState.tab_bar(state)
+
+    if has_other_file_tab?(tb, active_id) do
+      close_file_tab(state)
+    else
+      shutdown_editor(state)
+    end
+  end
+
+  @spec quit_would_exit_editor?(state()) :: boolean()
+  defp quit_would_exit_editor?(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+    case EditorState.active_tab(state) do
+      %Tab{kind: :file, id: active_id} -> not has_other_file_tab?(tb, active_id)
+      %Tab{kind: :agent} -> TabBar.count(tb) == 1
+      _ -> true
+    end
+  end
+
+  defp quit_would_exit_editor?(_state), do: true
+
+  @spec has_other_file_tab?(TabBar.t(), Tab.id()) :: boolean()
+  defp has_other_file_tab?(%TabBar{tabs: tabs}, active_id) do
+    Enum.any?(tabs, &(&1.kind == :file and &1.id != active_id))
+  end
 
   @spec close_other_tabs(state()) :: state()
   defp close_other_tabs(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
@@ -1290,13 +1315,14 @@ defmodule MingaEditor.Commands.BufferManagement do
   # stays in the buffer pool (matching Neovim's `:q` which closes the
   # window but leaves the buffer in the background buffer list).
   @spec close_file_tab(state()) :: state()
-  defp close_file_tab(%{shell_state: %{tab_bar: %TabBar{}}} = state) do
+  defp close_file_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
     active_tab = EditorState.active_tab(state)
     label = if active_tab, do: active_tab.label, else: "tab"
+    replacement_id = active_tab && replacement_file_tab_id(tb, active_tab.id)
     MingaEditor.log_to_messages("Closed: #{label}")
 
     state
-    |> remove_current_tab()
+    |> remove_current_tab(replacement_id)
     |> restore_active_tab_context()
   end
 
@@ -1323,15 +1349,43 @@ defmodule MingaEditor.Commands.BufferManagement do
     create_fallback_buffer(state, old_buffers)
   end
 
-  @spec remove_current_tab(state()) :: state()
-  defp remove_current_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  @spec remove_current_tab(state(), Tab.id() | nil) :: state()
+  defp remove_current_tab(state, replacement_id \\ nil)
+
+  defp remove_current_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, replacement_id) do
     case TabBar.remove(tb, tb.active_id) do
-      {:ok, new_tb} -> EditorState.set_tab_bar(state, new_tb)
-      :last_tab -> state
+      {:ok, new_tb} ->
+        EditorState.set_tab_bar(state, maybe_switch_to_replacement(new_tb, replacement_id))
+
+      :last_tab ->
+        state
     end
   end
 
-  defp remove_current_tab(state), do: state
+  defp remove_current_tab(state, _replacement_id), do: state
+
+  @spec maybe_switch_to_replacement(TabBar.t(), Tab.id() | nil) :: TabBar.t()
+  defp maybe_switch_to_replacement(tb, nil), do: tb
+  defp maybe_switch_to_replacement(tb, replacement_id), do: TabBar.switch_to(tb, replacement_id)
+
+  @spec replacement_file_tab_id(TabBar.t(), Tab.id()) :: Tab.id() | nil
+  defp replacement_file_tab_id(%TabBar{tabs: tabs}, active_id) do
+    case Enum.find_index(tabs, &(&1.id == active_id)) do
+      nil -> nil
+      idx -> replacement_file_tab_id(tabs, idx)
+    end
+  end
+
+  @spec replacement_file_tab_id([Tab.t()], non_neg_integer()) :: Tab.id() | nil
+  defp replacement_file_tab_id(tabs, idx) do
+    right = tabs |> Enum.drop(idx + 1) |> Enum.find(&(&1.kind == :file))
+    left = tabs |> Enum.take(idx) |> Enum.reverse() |> Enum.find(&(&1.kind == :file))
+
+    case right || left do
+      %Tab{id: id} -> id
+      nil -> nil
+    end
+  end
 
   # Restores the now-active tab's snapshotted context into live editor state.
   # Called after removing a tab to switch the editor to the neighbor tab's

--- a/test/minga_editor/commands/agent_split_toggle_test.exs
+++ b/test/minga_editor/commands/agent_split_toggle_test.exs
@@ -195,6 +195,30 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
 
       assert without_agent.workspace.keymap_scope == :editor
     end
+
+    test "agent scope close returns to file without stopping the session" do
+      session = fake_session()
+      state = base_state(active: true, session: session)
+
+      without_agent = AgentCommands.scope_close(state)
+
+      assert EditorState.active_tab_kind(without_agent) == :file
+      assert without_agent.workspace.keymap_scope == :editor
+      refute_process_down(session)
+      assert TabBar.find_by_session(without_agent.shell_state.tab_bar, session) != nil
+    end
+
+    test "agent ESC behavior returns to file without stopping the session" do
+      session = fake_session()
+      state = base_state(active: true, session: session)
+
+      without_agent = AgentCommands.scope_dismiss_or_noop(state)
+
+      assert EditorState.active_tab_kind(without_agent) == :file
+      assert without_agent.workspace.keymap_scope == :editor
+      refute_process_down(session)
+      assert TabBar.find_by_session(without_agent.shell_state.tab_bar, session) != nil
+    end
   end
 
   describe "kill_buffer on agent tab" do
@@ -223,6 +247,12 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
       new_state = BufferManagement.execute(state, :kill_buffer)
       assert TabBar.filter_by_kind(new_state.shell_state.tab_bar, :agent) == []
     end
+  end
+
+  defp refute_process_down(pid) do
+    ref = Process.monitor(pid)
+    refute_receive {:DOWN, ^ref, :process, ^pid, _reason}
+    Process.demonitor(ref, [:flush])
   end
 
   describe "round-trip toggle" do

--- a/test/minga_editor/commands/buffer_management_shutdown_test.exs
+++ b/test/minga_editor/commands/buffer_management_shutdown_test.exs
@@ -31,6 +31,20 @@ defmodule MingaEditor.Commands.BufferManagementShutdownTest do
       assert_receive {:shutdown_called, 0}
     end
 
+    test "last-tab :q prompts, then confirmation exits" do
+      {editor, _buffer, _options} = start_editor("hello")
+
+      type_string(editor, ":q\r")
+      state = :sys.get_state(editor)
+      assert state.pending_quit == :quit
+      assert state.shell_state.status_msg == "Quit Minga? (y/n)"
+      refute Enum.any?(state.shell_state.tab_bar.tabs, &String.starts_with?(&1.label, "[new"))
+
+      send_key(editor, ?y)
+
+      assert_receive {:shutdown_called, 0}
+    end
+
     test "force quit all bypasses dirty-buffer confirmation" do
       {editor, buffer, _options} = start_editor("hello")
       BufferProcess.insert_char(buffer, "X")

--- a/test/minga_editor/commands/buffer_management_test.exs
+++ b/test/minga_editor/commands/buffer_management_test.exs
@@ -121,7 +121,7 @@ defmodule MingaEditor.Commands.BufferManagementTest do
 
       send_key(editor, ?s, @ctrl)
 
-      assert Process.alive?(editor)
+      refute_process_down(editor)
     end
   end
 
@@ -138,16 +138,77 @@ defmodule MingaEditor.Commands.BufferManagementTest do
 
       assert tab_count(result) == 1
       refute closed_tab_id in remaining_tab_ids
-      assert Process.alive?(closed_tab_buffer)
+      refute_process_down(closed_tab_buffer)
     end
 
-    test ":q with a single tab leaves an empty editor buffer open" do
-      {state, _buffer} = start_command_state("first file")
+    test ":q with a single clean file tab prompts before exiting" do
+      {state, buffer} = start_command_state("first file")
+      initial_tab_labels = tab_labels(state)
+      initial_active_id = EditorState.tab_bar(state).active_id
 
       result = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
 
+      assert result.pending_quit == :quit
+      assert result.shell_state.status_msg == "Quit Minga? (y/n)"
       assert tab_count(result) == 1
-      assert BufferProcess.content(result.workspace.buffers.active) == ""
+      assert result.workspace.buffers.active == buffer
+      assert BufferProcess.content(result.workspace.buffers.active) == "first file"
+      assert EditorState.tab_bar(result).active_id == initial_active_id
+      assert tab_labels(result) == initial_tab_labels
+      refute Enum.any?(tab_labels(result), &String.starts_with?(&1, "[new"))
+    end
+
+    test ":q with a single clean file tab cancels without changing state" do
+      {state, buffer} = start_command_state("first file")
+      initial_tab_labels = tab_labels(state)
+      initial_active_id = EditorState.tab_bar(state).active_id
+
+      prompted = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
+
+      assert prompted.pending_quit == :quit
+      assert prompted.shell_state.status_msg == "Quit Minga? (y/n)"
+      refute Enum.any?(tab_labels(prompted), &String.starts_with?(&1, "[new"))
+
+      result = BufferManagement.execute(prompted, :confirm_quit_no)
+
+      assert result.pending_quit == nil
+      assert result.shell_state.status_msg == nil
+      assert result.workspace.buffers.active == buffer
+      assert BufferProcess.content(result.workspace.buffers.active) == "first file"
+      assert EditorState.tab_bar(result).active_id == initial_active_id
+      assert tab_labels(result) == initial_tab_labels
+      refute Enum.any?(tab_labels(result), &String.starts_with?(&1, "[new"))
+    end
+
+    test ":q with the last file tab and an agent tab prompts instead of activating the agent" do
+      {state, _buffer} = start_command_state("first file")
+      {state, _agent_tab_id} = add_agent_tab_after_active_and_return_to_file(state)
+      active_tab_id = EditorState.tab_bar(state).active_id
+
+      result = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
+
+      assert result.pending_quit == :quit
+      assert result.shell_state.status_msg == "Quit Minga? (y/n)"
+      assert tab_count(result) == 2
+      assert EditorState.tab_bar(result).active_id == active_tab_id
+      assert EditorState.active_tab_kind(result) == :file
+      refute Enum.any?(tab_labels(result), &String.starts_with?(&1, "[new"))
+    end
+
+    test ":q with a file and agent neighbor activates another file tab" do
+      {state, _buffer} = start_command_state("first file")
+      {state, closed_tab_buffer} = add_file_tab_with_buffer(state)
+      closed_tab_id = EditorState.tab_bar(state).active_id
+      {state, agent_tab_id} = add_agent_tab_after_active_and_return_to_file(state)
+
+      result = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
+
+      assert tab_count(result) == 2
+      assert EditorState.active_tab_kind(result) == :file
+      refute EditorState.tab_bar(result).active_id == agent_tab_id
+      refute EditorState.tab_bar(result).active_id == closed_tab_id
+      refute Enum.any?(tab_labels(result), &String.starts_with?(&1, "[new"))
+      refute_process_down(closed_tab_buffer)
     end
   end
 
@@ -191,10 +252,13 @@ defmodule MingaEditor.Commands.BufferManagementTest do
       state = BufferManagement.execute(state, {:execute_ex_command, {:quit, []}})
       assert state.pending_quit == :quit
       assert state.shell_state.status_msg =~ "Modified buffers"
+      refute Enum.any?(tab_labels(state), &String.starts_with?(&1, "[new"))
 
       result = BufferManagement.execute(state, :confirm_quit_no)
       assert result.pending_quit == nil
       assert result.shell_state.status_msg == nil
+      assert tab_labels(result) == tab_labels(state)
+      refute Enum.any?(tab_labels(result), &String.starts_with?(&1, "[new"))
     end
 
     test "Escape cancels dirty quit confirmation through the input router" do
@@ -203,9 +267,11 @@ defmodule MingaEditor.Commands.BufferManagementTest do
 
       state = send_keys(editor, ":q\r")
       assert state.pending_quit == :quit
+      refute Enum.any?(tab_labels(state), &String.starts_with?(&1, "[new"))
 
       state = send_key(editor, 27)
       assert state.pending_quit == nil
+      refute Enum.any?(tab_labels(state), &String.starts_with?(&1, "[new"))
     end
   end
 
@@ -272,6 +338,26 @@ defmodule MingaEditor.Commands.BufferManagementTest do
   defp add_file_tab_with_buffer(state) do
     {:ok, buffer} = BufferProcess.start_link(content: "second.txt content")
     {EditorState.add_buffer(state, buffer, context: :open), buffer}
+  end
+
+  defp add_agent_tab_after_active_and_return_to_file(state) do
+    active_file_tab_id = EditorState.tab_bar(state).active_id
+    {tb, agent_tab} = TabBar.add(EditorState.tab_bar(state), :agent, "Agent")
+    tb = TabBar.switch_to(tb, active_file_tab_id)
+    {EditorState.set_tab_bar(state, tb), agent_tab.id}
+  end
+
+  defp refute_process_down(pid) do
+    ref = Process.monitor(pid)
+    refute_receive {:DOWN, ^ref, :process, ^pid, _reason}
+    Process.demonitor(ref, [:flush])
+  end
+
+  defp tab_labels(state) do
+    state
+    |> EditorState.tab_bar()
+    |> Map.fetch!(:tabs)
+    |> Enum.map(& &1.label)
   end
 
   defp tab_count(state), do: state |> EditorState.tab_bar() |> TabBar.count()

--- a/test/minga_editor/input/scoped_test.exs
+++ b/test/minga_editor/input/scoped_test.exs
@@ -192,7 +192,7 @@ defmodule MingaEditor.Input.ScopedTest do
       end
     end
 
-    test "q switches from agent tab back to file tab", %{state: state} do
+    test "q switches from agent tab back to file tab and keeps agent tab", %{state: state} do
       # The base_state with agentic_active: true already sets up:
       # - file tab (id 1) and agent tab (id 2)
       # - agent tab is active, keymap_scope is :agent
@@ -200,6 +200,17 @@ defmodule MingaEditor.Input.ScopedTest do
 
       {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
       assert new_state.workspace.keymap_scope == :editor
+      assert TabBar.filter_by_kind(new_state.shell_state.tab_bar, :agent) != []
+    end
+
+    test "ESC switches from agent tab back to file tab when nothing transient is open", %{
+      state: state
+    } do
+      assert state.workspace.keymap_scope == :agent
+
+      {:handled, new_state} = Scoped.handle_key(state, 27, 0)
+      assert new_state.workspace.keymap_scope == :editor
+      assert TabBar.filter_by_kind(new_state.shell_state.tab_bar, :agent) != []
     end
 
     test "? toggles help", %{state: state} do


### PR DESCRIPTION
# TL;DR
This PR makes `:q` follow familiar Vim-style semantics: close the current file tab when another file tab exists, and prompt before exiting Minga when it would close the last file tab. It also makes agent-view `q` / `Esc` return to the editor without stopping the agent session.

Closes #1770

## Context
The previous quit flow mixed Vim-style `:q`, Emacs-style fallback buffers, and agent tab navigation. That made close behavior hard to predict: `:q` could create `[new]`, file tab close could land in the agent view, and `Esc` in the agent view did not return to the editor.

## Changes
- Replaced the last-tab `:q` fallback-buffer path with a quit confirmation prompt.
- Changed file-tab close selection to prefer another file tab over an agent tab when one is available.
- Kept agent view close behavior separate from editor quit: `q` / `Esc` return to the editor and keep the agent tab/session alive.
- Updated agent keymap/help copy to say “Return to editor” instead of “Close agent split/view.”
- Added regression coverage for last-tab quit prompts, dirty quit protection, file-tab close near agent tabs, and agent `q` / `Esc` session preservation.

## Verification
- `mix test.llm test/minga_editor/commands/buffer_management_test.exs test/minga_editor/commands/buffer_management_shutdown_test.exs test/minga_editor/input/scoped_test.exs test/minga_editor/commands/agent_split_toggle_test.exs` passed, 85 tests.
- `mix test.llm` was run. Wayland connection warnings appeared from GUI-related tests. `mix test --failed` reran one failed/stale test successfully, then a second `mix test --failed` reported no tests to run.
- Focused repros for reviewer-reported failures passed: diagnostic feedback, agent session, distribution connection manager, dired, and file-open-from-agent-tab tests.
- `make lint` passed. Existing Credo struct-size warnings were reported.
- `git diff --check` passed.
- Final reviewer returned PASS; parent-orchestrated review loop ran 2 rounds and found no remaining fixes worth doing now.

## Acceptance Criteria Addressed
- `:q` on a normal file tab with other file tabs open closes the current file tab and activates another file tab. ✅
- `:q` on the last file tab prompts before exiting the editor; confirm exits and cancel leaves state unchanged. ✅
- `:q` does not create a fallback `[new]` or `[new N]` buffer when it would otherwise quit. ✅
- Closing a file tab does not activate the agentic view when another file tab is available. ✅
- Agentic view close behavior is distinct from editor quit behavior; `q` / `Esc` returns to the editor and keeps the agent session alive. ✅
- Dirty-buffer protection still works. ✅
- Untitled buffers remain explicit new-buffer/startup behavior, not a `:q` side effect. ✅

