### PR TITLE
test(render): collapse semantic window cases

### DIFF
--- a/test/minga_editor/semantic_window_test.exs
+++ b/test/minga_editor/semantic_window_test.exs
@@ -53,6 +53,22 @@ defmodule MingaEditor.SemanticWindowTest do
     end)
   end
 
+  defp gui_frame(content) do
+    state = gui_state(content: content)
+    {[wf], cursor, state} = build_content(state)
+    {wf, cursor, state}
+  end
+
+  defp semantic_row_texts(wf), do: Enum.map(wf.semantic.rows, & &1.text)
+
+  defp diagnostic(line, severity \\ :error) do
+    %Minga.Diagnostics.Diagnostic{
+      range: %{start_line: line, start_col: 0, end_line: line, end_col: 5},
+      severity: severity,
+      message: "msg"
+    }
+  end
+
   # ── Font registry ─────────────────────────────────────────────────────
 
   describe "font registry" do
@@ -75,24 +91,15 @@ defmodule MingaEditor.SemanticWindowTest do
   # ── GUI vs TUI gating ─────────────────────────────────────────────────
 
   describe "GUI/TUI gating" do
-    test "WindowFrame.semantic is nil for TUI frontends" do
-      state = base_state(content: "hello\nworld")
-      {[wf], _cursor, _state} = build_content(state)
+    test "semantic window follows frontend capability and records the active window id" do
+      tui_state = base_state(content: "hello\nworld")
+      {[tui_frame], _cursor, _state} = build_content(tui_state)
+      assert tui_frame.semantic == nil
 
-      assert wf.semantic == nil
-    end
-
-    test "WindowFrame.semantic is populated for GUI frontends" do
       state = gui_state(content: "hello\nworld")
       {[wf], _cursor, _state} = build_content(state)
 
       assert %SemanticWindow{} = wf.semantic
-    end
-
-    test "semantic window has correct window_id" do
-      state = gui_state(content: "hello")
-      {[wf], _cursor, _state} = build_content(state)
-
       assert wf.semantic.window_id == state.workspace.windows.active
     end
   end
@@ -100,25 +107,16 @@ defmodule MingaEditor.SemanticWindowTest do
   # ── Core: semantic text matches draw text ──────────────────────────────
 
   describe "semantic text matches draw text" do
-    test "semantic row text matches draw text for plain content" do
-      content = "line one\nline two\nline three"
-      state = gui_state(content: content)
-      {[wf], _cursor, _state} = build_content(state)
+    test "semantic row text matches draw text for plain content shapes" do
+      for content <- [
+            "hello world",
+            "line one\nline two\nline three",
+            "alpha\nbeta\ngamma\ndelta\nepsilon"
+          ] do
+        {wf, _cursor, _state} = gui_frame(content)
 
-      semantic_texts = Enum.map(wf.semantic.rows, & &1.text)
-      draw_texts = extract_draw_texts(wf.lines)
-
-      assert semantic_texts == draw_texts
-    end
-
-    test "semantic row text matches for single-line buffer" do
-      state = gui_state(content: "hello world")
-      {[wf], _cursor, _state} = build_content(state)
-
-      [row] = wf.semantic.rows
-      [draw_text] = extract_draw_texts(wf.lines)
-
-      assert row.text == draw_text
+        assert semantic_row_texts(wf) == extract_draw_texts(wf.lines)
+      end
     end
 
     test "semantic spans include TODO keyword faces" do
@@ -215,15 +213,6 @@ defmodule MingaEditor.SemanticWindowTest do
              end)
     end
 
-    test "semantic row text matches for multiline content" do
-      content = "alpha\nbeta\ngamma\ndelta\nepsilon"
-      state = gui_state(content: content)
-      {[wf], _cursor, _state} = build_content(state)
-
-      semantic_texts = Enum.map(wf.semantic.rows, & &1.text)
-      assert semantic_texts == ["alpha", "beta", "gamma", "delta", "epsilon"]
-    end
-
     test "semantic row text includes invisible markers when enabled" do
       state = gui_state(content: "\thello   ")
 
@@ -240,11 +229,9 @@ defmodule MingaEditor.SemanticWindowTest do
     end
 
     test "empty buffer produces valid semantic window" do
-      state = gui_state(content: "")
-      {[wf], _cursor, _state} = build_content(state)
+      {wf, _cursor, _state} = gui_frame("")
 
       assert %SemanticWindow{} = wf.semantic
-      # Empty buffer still has one line (the empty line)
       assert is_list(wf.semantic.rows)
       assert wf.semantic.cursor_row >= 0
       assert wf.semantic.cursor_col >= 0
@@ -254,80 +241,38 @@ defmodule MingaEditor.SemanticWindowTest do
   # ── Visual rows ────────────────────────────────────────────────────────
 
   describe "visual rows" do
-    test "each row has row_type :normal for regular lines" do
-      state = gui_state(content: "a\nb\nc")
-      {[wf], _cursor, _state} = build_content(state)
+    test "rows carry normal type, buffer line, and draw row count" do
+      {wf, _cursor, _state} = gui_frame("a\nb\nc\nd")
 
-      types = Enum.map(wf.semantic.rows, & &1.row_type)
-      assert types == [:normal, :normal, :normal]
+      assert Enum.map(wf.semantic.rows, & &1.row_type) == [:normal, :normal, :normal, :normal]
+      assert Enum.map(wf.semantic.rows, & &1.buf_line) == [0, 1, 2, 3]
+      assert length(wf.semantic.rows) == map_size(wf.lines)
     end
 
-    test "buf_line is correctly assigned" do
-      state = gui_state(content: "a\nb\nc\nd")
-      {[wf], _cursor, _state} = build_content(state)
-
-      buf_lines = Enum.map(wf.semantic.rows, & &1.buf_line)
-      assert buf_lines == [0, 1, 2, 3]
-    end
-
-    test "content_hash is non-zero for non-empty lines" do
-      state = gui_state(content: "hello world")
-      {[wf], _cursor, _state} = build_content(state)
-
+    test "content hashes reflect row content" do
+      {wf, _cursor, _state} = gui_frame("hello world")
       [row] = wf.semantic.rows
       assert row.content_hash != 0
-    end
 
-    test "different lines produce different hashes" do
-      state = gui_state(content: "hello\nworld")
-      {[wf], _cursor, _state} = build_content(state)
-
+      {wf, _cursor, _state} = gui_frame("hello\nworld")
       [row1, row2] = wf.semantic.rows
       assert row1.content_hash != row2.content_hash
-    end
 
-    test "identical lines produce identical hashes" do
-      state = gui_state(content: "same\nsame")
-      {[wf], _cursor, _state} = build_content(state)
-
+      {wf, _cursor, _state} = gui_frame("same\nsame")
       [row1, row2] = wf.semantic.rows
       assert row1.content_hash == row2.content_hash
-    end
-
-    test "semantic row count matches draw line count" do
-      content = "one\ntwo\nthree\nfour\nfive"
-      state = gui_state(content: content)
-      {[wf], _cursor, _state} = build_content(state)
-
-      assert length(wf.semantic.rows) == map_size(wf.lines)
     end
   end
 
   # ── Cursor ─────────────────────────────────────────────────────────────
 
   describe "cursor" do
-    test "cursor at row 0, col 0 for new buffer" do
-      state = gui_state(content: "hello")
-      {[wf], _cursor, _state} = build_content(state)
+    test "new buffer cursor metadata matches normal-mode draw cursor" do
+      {wf, %Cursor{} = cursor, _state} = gui_frame("hello\nworld")
 
       assert wf.semantic.cursor_row == 0
       assert wf.semantic.cursor_col == 0
-    end
-
-    test "cursor shape is :block in normal mode" do
-      state = gui_state(content: "hello")
-      {[wf], _cursor, _state} = build_content(state)
-
       assert wf.semantic.cursor_shape == :block
-    end
-
-    test "semantic cursor row is consistent with draw cursor" do
-      content = "hello\nworld"
-      state = gui_state(content: content)
-      {[wf], %Cursor{} = cursor, _state} = build_content(state)
-
-      # Both should be on the first line (row 0 in window-relative coords)
-      assert wf.semantic.cursor_row == 0
       assert is_integer(cursor.row)
     end
 
@@ -346,233 +291,140 @@ defmodule MingaEditor.SemanticWindowTest do
   # ── Span.from_face/3 ──────────────────────────────────────────────────
 
   describe "Span.from_face/3" do
-    test "encodes bold flag in bit 0" do
-      face = Face.new(bold: true)
-      span = Span.from_face(face, 0, 10)
+    test "encodes face attributes into protocol bits" do
+      cases = [
+        {Face.new(bold: true), 0},
+        {Face.new(italic: true), 1},
+        {Face.new(underline: true), 2},
+        {Face.new(strikethrough: true), 3},
+        {Face.new(underline: true, underline_style: :curl), 4}
+      ]
 
-      import Bitwise
-      assert (span.attrs &&& 1) == 1
+      for {face, bit} <- cases do
+        span = Span.from_face(face, 0, 10)
+        assert Bitwise.band(Bitwise.bsr(span.attrs, bit), 1) == 1
+      end
+
+      packed =
+        Span.from_face(
+          Face.new(bold: true, italic: true, underline: true, strikethrough: true),
+          0,
+          10
+        )
+
+      assert Bitwise.band(packed.attrs, 0x0F) == 0x0F
     end
 
-    test "encodes italic flag in bit 1" do
-      face = Face.new(italic: true)
-      span = Span.from_face(face, 0, 10)
-
-      import Bitwise
-      assert (span.attrs >>> 1 &&& 1) == 1
-    end
-
-    test "encodes underline flag in bit 2" do
-      face = Face.new(underline: true)
-      span = Span.from_face(face, 0, 10)
-
-      import Bitwise
-      assert (span.attrs >>> 2 &&& 1) == 1
-    end
-
-    test "encodes strikethrough flag in bit 3" do
-      face = Face.new(strikethrough: true)
-      span = Span.from_face(face, 0, 10)
-
-      import Bitwise
-      assert (span.attrs >>> 3 &&& 1) == 1
-    end
-
-    test "encodes curl underline in bit 4" do
-      face = Face.new(underline: true, underline_style: :curl)
-      span = Span.from_face(face, 0, 5)
-
-      import Bitwise
-      assert (span.attrs >>> 4 &&& 1) == 1
-    end
-
-    test "packs all attrs into one byte correctly" do
-      face = Face.new(bold: true, italic: true, underline: true, strikethrough: true)
-      span = Span.from_face(face, 0, 10)
-
-      import Bitwise
-      assert (span.attrs &&& 0x0F) == 0x0F
-    end
-
-    test "preserves fg and bg colors" do
-      face = Face.new(fg: 0xFF6C6B, bg: 0x282C34)
-      span = Span.from_face(face, 0, 10)
+    test "preserves colors and column range with nil color defaults" do
+      span = Span.from_face(Face.new(fg: 0xFF6C6B, bg: 0x282C34), 3, 17)
 
       assert span.fg == 0xFF6C6B
       assert span.bg == 0x282C34
-    end
-
-    test "nil colors default to 0" do
-      face = Face.new()
-      span = Span.from_face(face, 0, 1)
-
-      assert span.fg == 0
-      assert span.bg == 0
-    end
-
-    test "preserves column range" do
-      face = Face.new(fg: 0xABCDEF)
-      span = Span.from_face(face, 3, 17)
-
       assert span.start_col == 3
       assert span.end_col == 17
+
+      default_span = Span.from_face(Face.new(), 0, 1)
+      assert default_span.fg == 0
+      assert default_span.bg == 0
     end
 
-    test "encodes font weight using the shared frontend protocol values" do
-      assert Span.from_face(Face.new(font_weight: :thin), 0, 10).font_weight == 0
-      assert Span.from_face(Face.new(font_weight: :light), 0, 10).font_weight == 1
-      assert Span.from_face(Face.new(font_weight: :regular), 0, 10).font_weight == 2
-      assert Span.from_face(Face.new(font_weight: :medium), 0, 10).font_weight == 3
-      assert Span.from_face(Face.new(font_weight: :semibold), 0, 10).font_weight == 4
-      assert Span.from_face(Face.new(font_weight: :bold), 0, 10).font_weight == 5
-      assert Span.from_face(Face.new(font_weight: :heavy), 0, 10).font_weight == 6
-      assert Span.from_face(Face.new(font_weight: :black), 0, 10).font_weight == 7
-    end
+    test "encodes font weight using shared frontend protocol values" do
+      cases = [
+        thin: 0,
+        light: 1,
+        regular: 2,
+        medium: 3,
+        semibold: 4,
+        bold: 5,
+        heavy: 6,
+        black: 7
+      ]
 
-    test "nil font weight defaults to regular" do
-      face = Face.new()
-      span = Span.from_face(face, 0, 10)
+      for {weight, value} <- cases do
+        assert Span.from_face(Face.new(font_weight: weight), 0, 10).font_weight == value
+      end
 
-      assert span.font_weight == 2
-    end
-
-    test "bold attr without explicit font weight uses bold font weight" do
-      face = Face.new(bold: true)
-      span = Span.from_face(face, 0, 10)
-
-      assert span.font_weight == 5
+      assert Span.from_face(Face.new(), 0, 10).font_weight == 2
+      assert Span.from_face(Face.new(bold: true), 0, 10).font_weight == 5
     end
   end
 
   # ── Selection.from_visual_selection ────────────────────────────────────
 
   describe "Selection.from_visual_selection/2" do
-    test "returns nil for no selection" do
+    test "converts basic selections into display coordinates" do
       assert Selection.from_visual_selection(nil, 0) == nil
-    end
 
-    test "converts char selection to display coordinates" do
-      sel = Selection.from_visual_selection({:char, {5, 3}, {7, 10}}, 0)
+      char = Selection.from_visual_selection({:char, {5, 3}, {7, 10}}, 0)
 
-      assert sel.type == :char
-      assert sel.start_row == 5
-      assert sel.start_col == 3
-      assert sel.end_row == 7
-      assert sel.end_col == 10
-    end
+      assert {char.type, char.start_row, char.start_col, char.end_row, char.end_col} ==
+               {:char, 5, 3, 7, 10}
 
-    test "char selection adjusts for viewport scroll offset" do
-      sel = Selection.from_visual_selection({:char, {5, 3}, {7, 10}}, 2)
+      scrolled = Selection.from_visual_selection({:char, {5, 3}, {7, 10}}, 2)
+      assert {scrolled.start_row, scrolled.end_row} == {3, 5}
 
-      assert sel.start_row == 3
-      assert sel.end_row == 5
-    end
-
-    test "converts line selection to display coordinates" do
-      sel = Selection.from_visual_selection({:line, 10, 15}, 5)
-
-      assert sel.type == :line
-      assert sel.start_row == 5
-      assert sel.end_row == 10
+      line = Selection.from_visual_selection({:line, 10, 15}, 5)
+      assert {line.type, line.start_row, line.end_row} == {:line, 5, 10}
     end
   end
 
   describe "Selection.from_visual_selection/5" do
-    test "clips char selection that starts above the viewport" do
-      sel = Selection.from_visual_selection({:char, {2, 4}, {7, 10}}, 5, 4, 0, 80)
+    test "clips visible selections to the viewport" do
+      cases = [
+        {{:char, {2, 4}, {7, 10}}, 5, 4, 0, 80, {:char, 0, 0, 2, 10}},
+        {{:char, {5, 4}, {12, 10}}, 5, 4, 2, 80, {:char, 0, 4, 3, 82}},
+        {{:char, {8, 0}, {8, 5}}, 5, 4, 0, 80, {:char, 3, 0, 3, 5}},
+        {{:char, {5, 2}, {5, 20}}, 5, 4, 10, 80, {:char, 0, 10, 0, 20}},
+        {{:char, {5, 4}, {5, 200}}, 5, 4, 0, 80, {:char, 0, 4, 0, 80}},
+        {{:line, 1, 10}, 5, 4, 0, 80, {:line, 0, 0, 3, 0}}
+      ]
 
-      assert sel.type == :char
-      assert sel.start_row == 0
-      assert sel.start_col == 0
-      assert sel.end_row == 2
-      assert sel.end_col == 10
+      for {selection, first_line, row_count, viewport_left, content_w, expected} <- cases do
+        sel =
+          Selection.from_visual_selection(
+            selection,
+            first_line,
+            row_count,
+            viewport_left,
+            content_w
+          )
+
+        assert {sel.type, sel.start_row, sel.start_col, sel.end_row, sel.end_col} == expected
+      end
     end
 
-    test "clips char selection that ends below the viewport" do
-      sel = Selection.from_visual_selection({:char, {5, 4}, {12, 10}}, 5, 4, 2, 80)
+    test "drops selections entirely outside the viewport" do
+      cases = [
+        {:char, {1, 0}, {3, 4}},
+        {:char, {20, 0}, {25, 4}},
+        {:char, {9, 0}, {9, 5}}
+      ]
 
-      assert sel.type == :char
-      assert sel.start_row == 0
-      assert sel.start_col == 4
-      assert sel.end_row == 3
-      assert sel.end_col == 82
-    end
-
-    test "drops char selection entirely above the viewport" do
-      assert Selection.from_visual_selection({:char, {1, 0}, {3, 4}}, 5, 4, 0, 80) == nil
-    end
-
-    test "drops char selection entirely below the viewport" do
-      assert Selection.from_visual_selection({:char, {20, 0}, {25, 4}}, 5, 4, 0, 80) == nil
-    end
-
-    test "selection at exact viewport bottom boundary is included" do
-      sel = Selection.from_visual_selection({:char, {8, 0}, {8, 5}}, 5, 4, 0, 80)
-
-      assert sel.type == :char
-      assert sel.start_row == 3
-      assert sel.end_row == 3
-    end
-
-    test "selection one row past viewport bottom is dropped" do
-      assert Selection.from_visual_selection({:char, {9, 0}, {9, 5}}, 5, 4, 0, 80) == nil
-    end
-
-    test "clips start_col to viewport_left when selection starts left of viewport" do
-      sel = Selection.from_visual_selection({:char, {5, 2}, {5, 20}}, 5, 4, 10, 80)
-
-      assert sel.start_col == 10
-      assert sel.end_col == 20
-    end
-
-    test "clips end_col to viewport right edge on same-line selection" do
-      sel = Selection.from_visual_selection({:char, {5, 4}, {5, 200}}, 5, 4, 0, 80)
-
-      assert sel.start_col == 4
-      assert sel.end_col == 80
-    end
-
-    test "clips line selection to visible rows" do
-      sel = Selection.from_visual_selection({:line, 1, 10}, 5, 4, 0, 80)
-
-      assert sel.type == :line
-      assert sel.start_row == 0
-      assert sel.start_col == 0
-      assert sel.end_row == 3
-      assert sel.end_col == 0
+      for selection <- cases do
+        assert Selection.from_visual_selection(selection, 5, 4, 0, 80) == nil
+      end
     end
   end
 
   # ── SearchMatch.from_context_matches/4 ─────────────────────────────────
 
   describe "SearchMatch.from_context_matches/4" do
-    test "filters matches to visible viewport range" do
+    test "filters visible matches and converts buffer coordinates" do
       matches = [
         %SearchMatchStruct{line: 0, col: 5, length: 3},
         %SearchMatchStruct{line: 3, col: 2, length: 4},
-        %SearchMatchStruct{line: 5, col: 0, length: 2},
+        %SearchMatchStruct{line: 5, col: 10, length: 3},
         %SearchMatchStruct{line: 8, col: 1, length: 3},
         %SearchMatchStruct{line: 12, col: 0, length: 5}
       ]
 
       result = SearchMatch.from_context_matches(matches, nil, 3, 10)
 
-      lines = Enum.map(result, & &1.row)
-      # Lines 3, 5, 8 are in viewport [3, 10). Converted to display rows: 0, 2, 5
-      assert lines == [0, 2, 5]
+      assert Enum.map(result, & &1.row) == [0, 2, 5]
+      assert Enum.map(result, &{&1.start_col, &1.end_col}) == [{2, 6}, {10, 13}, {1, 4}]
     end
 
-    test "converts buffer line to display row" do
-      matches = [%SearchMatchStruct{line: 5, col: 10, length: 3}]
-
-      [match] = SearchMatch.from_context_matches(matches, nil, 3, 10)
-
-      assert match.row == 2
-      assert match.start_col == 10
-      assert match.end_col == 13
-    end
-
-    test "marks exactly one match as current" do
+    test "marks the confirmed match as current" do
       confirm = %SearchMatchStruct{line: 5, col: 2, length: 4}
 
       matches = [
@@ -583,161 +435,82 @@ defmodule MingaEditor.SemanticWindowTest do
 
       result = SearchMatch.from_context_matches(matches, confirm, 0, 10)
 
-      current_flags = Enum.map(result, & &1.is_current)
-      assert current_flags == [false, true, false]
+      assert Enum.map(result, & &1.is_current) == [false, true, false]
     end
 
-    test "empty matches produces empty result" do
-      assert SearchMatch.from_context_matches([], nil, 0, 24) == []
-    end
-
-    test "all matches outside viewport produces empty result" do
-      matches = [
+    test "returns empty when there are no visible matches" do
+      outside = [
         %SearchMatchStruct{line: 100, col: 0, length: 5},
         %SearchMatchStruct{line: 200, col: 0, length: 3}
       ]
 
-      assert SearchMatch.from_context_matches(matches, nil, 0, 24) == []
+      assert SearchMatch.from_context_matches([], nil, 0, 24) == []
+      assert SearchMatch.from_context_matches(outside, nil, 0, 24) == []
     end
   end
 
   # ── DiagnosticRange.from_diagnostics/3 ─────────────────────────────────
 
   describe "DiagnosticRange.from_diagnostics/3" do
-    test "filters diagnostics to visible line range" do
+    test "filters visible diagnostics and converts coordinates" do
       diagnostics = [
-        %Minga.Diagnostics.Diagnostic{
-          range: %{start_line: 1, start_col: 0, end_line: 1, end_col: 5},
-          severity: :error,
-          message: "err"
-        },
-        %Minga.Diagnostics.Diagnostic{
-          range: %{start_line: 5, start_col: 0, end_line: 5, end_col: 10},
-          severity: :warning,
-          message: "warn"
-        },
-        %Minga.Diagnostics.Diagnostic{
-          range: %{start_line: 30, start_col: 0, end_line: 30, end_col: 3},
-          severity: :info,
-          message: "info"
-        }
+        diagnostic(1, :error),
+        diagnostic(5, :warning),
+        diagnostic(30, :info)
       ]
 
       result = DiagnosticRange.from_diagnostics(diagnostics, 0, 10)
+      assert Enum.map(result, & &1.severity) == [:error, :warning]
 
-      # Lines 1 and 5 in viewport [0, 10), line 30 is out
-      assert length(result) == 2
+      precise = %Minga.Diagnostics.Diagnostic{
+        range: %{start_line: 5, start_col: 3, end_line: 5, end_col: 10},
+        severity: :error,
+        message: "err"
+      }
+
+      [range] = DiagnosticRange.from_diagnostics([precise], 2, 10)
+      assert {range.start_row, range.start_col, range.end_row, range.end_col} == {3, 3, 3, 10}
     end
 
-    test "converts buffer coordinates to display coordinates" do
-      diagnostics = [
-        %Minga.Diagnostics.Diagnostic{
-          range: %{start_line: 5, start_col: 3, end_line: 5, end_col: 10},
-          severity: :error,
-          message: "err"
-        }
-      ]
+    test "maps severity levels and returns empty without visible diagnostics" do
+      diagnostics = Enum.with_index([:error, :warning, :info, :hint], &diagnostic(&2, &1))
 
-      [range] = DiagnosticRange.from_diagnostics(diagnostics, 2, 10)
+      assert DiagnosticRange.from_diagnostics(diagnostics, 0, 10) |> Enum.map(& &1.severity) == [
+               :error,
+               :warning,
+               :info,
+               :hint
+             ]
 
-      assert range.start_row == 3
-      assert range.start_col == 3
-      assert range.end_row == 3
-      assert range.end_col == 10
-    end
-
-    test "maps all severity levels correctly" do
-      make_diag = fn line, severity ->
-        %Minga.Diagnostics.Diagnostic{
-          range: %{start_line: line, start_col: 0, end_line: line, end_col: 5},
-          severity: severity,
-          message: "msg"
-        }
-      end
-
-      diagnostics = [
-        make_diag.(0, :error),
-        make_diag.(1, :warning),
-        make_diag.(2, :info),
-        make_diag.(3, :hint)
-      ]
-
-      result = DiagnosticRange.from_diagnostics(diagnostics, 0, 10)
-
-      severities = Enum.map(result, & &1.severity)
-      assert severities == [:error, :warning, :info, :hint]
-    end
-
-    test "empty diagnostics produces empty result" do
       assert DiagnosticRange.from_diagnostics([], 0, 24) == []
-    end
-
-    test "all diagnostics outside viewport produces empty result" do
-      diagnostics = [
-        %Minga.Diagnostics.Diagnostic{
-          range: %{start_line: 50, start_col: 0, end_line: 50, end_col: 5},
-          severity: :error,
-          message: "err"
-        }
-      ]
-
-      assert DiagnosticRange.from_diagnostics(diagnostics, 0, 24) == []
+      assert DiagnosticRange.from_diagnostics([diagnostic(50)], 0, 24) == []
     end
   end
 
   # ── VisualRow.compute_hash/2 ───────────────────────────────────────────
 
   describe "VisualRow.compute_hash/2" do
-    test "same inputs produce same hash" do
-      h1 = VisualRow.compute_hash("hello", [])
-      h2 = VisualRow.compute_hash("hello", [])
-      assert h1 == h2
-    end
+    test "hashes are stable and reflect text or span changes" do
+      assert VisualRow.compute_hash("hello", []) == VisualRow.compute_hash("hello", [])
+      assert VisualRow.compute_hash("hello", []) != VisualRow.compute_hash("world", [])
 
-    test "different text produces different hash" do
-      h1 = VisualRow.compute_hash("hello", [])
-      h2 = VisualRow.compute_hash("world", [])
-      assert h1 != h2
-    end
-
-    test "same text with different spans produces different hash" do
       span_bold = %Span{start_col: 0, end_col: 5, fg: 0xFF0000, bg: 0, attrs: 1}
       span_italic = %Span{start_col: 0, end_col: 5, fg: 0xFF0000, bg: 0, attrs: 2}
 
-      h1 = VisualRow.compute_hash("hello", [span_bold])
-      h2 = VisualRow.compute_hash("hello", [span_italic])
-      assert h1 != h2
+      assert VisualRow.compute_hash("hello", [span_bold]) !=
+               VisualRow.compute_hash("hello", [span_italic])
     end
   end
 
   # ── Integration: semantic window in render pipeline ────────────────────
 
   describe "integration: semantic window in full pipeline" do
-    test "semantic selection is nil when not in visual mode" do
-      state = gui_state(content: "hello\nworld")
-      {[wf], _cursor, _state} = build_content(state)
+    test "initial semantic metadata is empty and marked as full refresh" do
+      {wf, _cursor, _state} = gui_frame("hello\nworld")
 
       assert wf.semantic.selection == nil
-    end
-
-    test "semantic search_matches is empty when no search" do
-      state = gui_state(content: "hello world")
-      {[wf], _cursor, _state} = build_content(state)
-
       assert wf.semantic.search_matches == []
-    end
-
-    test "semantic diagnostic_ranges is empty when no diagnostics" do
-      state = gui_state(content: "hello world")
-      {[wf], _cursor, _state} = build_content(state)
-
       assert wf.semantic.diagnostic_ranges == []
-    end
-
-    test "full_refresh is true on initial render" do
-      state = gui_state(content: "hello")
-      {[wf], _cursor, _state} = build_content(state)
-
       assert wf.semantic.full_refresh == true
     end
   end


### PR DESCRIPTION
# TL;DR
This PR collapses repeated `SemanticWindow` tests into behavior-focused cases. It keeps the semantic rendering contracts covered while removing one-test-per-small-variant duplication.

## Context
`semantic_window_test.exs` already tested the right boundaries: direct semantic helpers plus a thin render-pipeline check. The cleanup reduces repeated setup/assertion shape without changing production behavior.

## Changes
- Adds helpers for building GUI window frames, extracting semantic row text, and creating diagnostics.
- Consolidates GUI/TUI gating, semantic row text parity, visual row metadata, cursor metadata, span encoding, selection clipping, search match conversion, diagnostic range conversion, and hash behavior.
- Preserves the complex fold/TODO regression test and distinct checks for invisible markers, empty buffers, and initial pipeline metadata.

## Verification
- `mix test.debug test/minga_editor/semantic_window_test.exs` → `24 tests, 0 failures`
- `mix test.llm test/minga_editor/semantic_window_test.exs` → `PASS: 24 tests, 0 failures`
- Final reviewer gate: PASS

## Notes for reviewers
- Lines: 744 to 517.
- Tests: 63 to 24.
- No production code changed.
