### PR TITLE
test: collapse high-duplication boundary suites

### DIFF
--- a/test/minga/buffer/conceal_range_test.exs
+++ b/test/minga/buffer/conceal_range_test.exs
@@ -4,441 +4,177 @@ defmodule Minga.Buffer.ConcealRangeTest do
 
   alias Minga.Core.Decorations
   alias Minga.Core.Decorations.ConcealRange
+  alias Minga.Core.Face
 
-  # ── ConcealRange struct ─────────────────────────────────────────────────
+  describe "ConcealRange" do
+    test "stores defaults, replacements, line span, containment, and display width" do
+      default = conceal({2, 0}, {5, 3})
 
-  describe "ConcealRange struct" do
-    test "creates a conceal range with required fields" do
-      range = %ConcealRange{
-        id: make_ref(),
-        start_pos: {0, 0},
-        end_pos: {0, 2}
-      }
+      replacement =
+        conceal({0, 0}, {0, 5}, replacement: "·", replacement_style: Face.new(fg: 0x555555))
 
-      assert range.replacement == nil
-      assert %Minga.Core.Face{name: "_"} = range.replacement_style
-      assert range.priority == 0
-      assert range.group == nil
-    end
+      assert default.replacement == nil
+      assert %Face{name: "_"} = default.replacement_style
+      assert default.priority == 0
+      assert default.group == nil
+      assert ConcealRange.display_width(default) == 0
+      assert ConcealRange.display_width(replacement) == 1
+      assert replacement.replacement == "·"
+      assert replacement.replacement_style.fg == 0x555555
 
-    test "creates a conceal range with replacement" do
-      range = %ConcealRange{
-        id: make_ref(),
-        start_pos: {0, 0},
-        end_pos: {0, 5},
-        replacement: "·",
-        replacement_style: Minga.Core.Face.new(fg: 0x555555)
-      }
+      for line <- 2..5, do: assert(ConcealRange.spans_line?(default, line))
+      for line <- [1, 6], do: refute(ConcealRange.spans_line?(default, line))
 
-      assert range.replacement == "·"
-      assert range.replacement_style.fg == 0x555555
+      single_line = conceal({0, 2}, {0, 5})
+      for col <- 2..4, do: assert(ConcealRange.contains?(single_line, {0, col}))
+      for col <- [1, 5, 6], do: refute(ConcealRange.contains?(single_line, {0, col}))
     end
   end
 
-  describe "display_width/1" do
-    test "returns 0 when no replacement" do
-      range = %ConcealRange{id: make_ref(), start_pos: {0, 0}, end_pos: {0, 5}}
-      assert ConcealRange.display_width(range) == 0
-    end
-
-    test "returns 1 when replacement is set" do
-      range = %ConcealRange{
-        id: make_ref(),
-        start_pos: {0, 0},
-        end_pos: {0, 5},
-        replacement: "·"
-      }
-
-      assert ConcealRange.display_width(range) == 1
-    end
-  end
-
-  describe "spans_line?/2" do
-    test "returns true for lines within the range" do
-      range = %ConcealRange{id: make_ref(), start_pos: {2, 0}, end_pos: {5, 3}}
-      assert ConcealRange.spans_line?(range, 2)
-      assert ConcealRange.spans_line?(range, 3)
-      assert ConcealRange.spans_line?(range, 5)
-    end
-
-    test "returns false for lines outside the range" do
-      range = %ConcealRange{id: make_ref(), start_pos: {2, 0}, end_pos: {5, 3}}
-      refute ConcealRange.spans_line?(range, 1)
-      refute ConcealRange.spans_line?(range, 6)
-    end
-  end
-
-  describe "contains?/2" do
-    test "returns true for positions inside the range" do
-      range = %ConcealRange{id: make_ref(), start_pos: {0, 2}, end_pos: {0, 5}}
-      assert ConcealRange.contains?(range, {0, 2})
-      assert ConcealRange.contains?(range, {0, 3})
-      assert ConcealRange.contains?(range, {0, 4})
-    end
-
-    test "returns false for end position (exclusive)" do
-      range = %ConcealRange{id: make_ref(), start_pos: {0, 2}, end_pos: {0, 5}}
-      refute ConcealRange.contains?(range, {0, 5})
-    end
-
-    test "returns false for positions outside" do
-      range = %ConcealRange{id: make_ref(), start_pos: {0, 2}, end_pos: {0, 5}}
-      refute ConcealRange.contains?(range, {0, 1})
-      refute ConcealRange.contains?(range, {0, 6})
-    end
-  end
-
-  # ── Decorations API ────────────────────────────────────────────────────
-
-  describe "add_conceal/4" do
-    test "adds a conceal range and returns id" do
+  describe "Decorations conceal API" do
+    test "adds conceal ranges with options and versions each mutation", %{test: test_name} do
       decs = Decorations.new()
-      {id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+      {first_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
 
-      assert is_reference(id)
-      assert length(decs.conceal_ranges) == 1
+      assert is_reference(first_id)
+      assert Decorations.has_conceal_ranges?(decs)
+      refute Decorations.empty?(decs)
       assert decs.version == 1
-    end
 
-    test "adds a conceal range with replacement" do
-      decs = Decorations.new()
-
-      {_id, decs} =
-        Decorations.add_conceal(decs, {0, 0}, {0, 2},
+      {_second_id, decs} =
+        Decorations.add_conceal(decs, {0, 5}, {0, 7},
           replacement: "·",
-          replacement_style: Minga.Core.Face.new(fg: 0x555555),
-          group: :markdown
+          replacement_style: Face.new(fg: 0x555555),
+          group: test_name
         )
 
-      [range] = decs.conceal_ranges
-      assert range.replacement == "·"
-      assert range.replacement_style.fg == 0x555555
-      assert range.group == :markdown
-    end
-
-    test "adds multiple conceal ranges" do
-      decs = Decorations.new()
-      {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
-      {_id2, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 7})
-
+      assert decs.version == 2
       assert length(decs.conceal_ranges) == 2
-      assert decs.version == 2
-    end
-  end
 
-  describe "remove_conceal/2" do
-    test "removes a conceal range by id" do
-      decs = Decorations.new()
-      {id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
-      decs = Decorations.remove_conceal(decs, id)
-
-      assert decs.conceal_ranges == []
-      assert decs.version == 2
+      assert Enum.any?(
+               decs.conceal_ranges,
+               &(&1.replacement == "·" and &1.replacement_style.fg == 0x555555 and
+                   &1.group == test_name)
+             )
     end
 
-    test "no-op when id doesn't exist" do
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
-      old_version = decs.version
-      decs = Decorations.remove_conceal(decs, make_ref())
+    test "removes by id, removes by group, and leaves missing ids unchanged" do
+      {first_id, decs} =
+        Decorations.add_conceal(Decorations.new(), {0, 0}, {0, 2}, group: :markdown)
 
-      assert length(decs.conceal_ranges) == 1
-      assert decs.version == old_version
-    end
-  end
+      {_second_id, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 7}, group: :markdown)
+      {_third_id, decs} = Decorations.add_conceal(decs, {1, 0}, {1, 3}, group: :other)
 
-  describe "remove_conceal_group/2" do
-    test "removes all conceals in a group" do
-      decs = Decorations.new()
-      {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, group: :markdown)
-      {_id2, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 7}, group: :markdown)
-      {_id3, decs} = Decorations.add_conceal(decs, {1, 0}, {1, 3}, group: :other)
+      decs = Decorations.remove_conceal(decs, first_id)
+      assert decs.version == 4
+      assert length(decs.conceal_ranges) == 2
 
-      decs = Decorations.remove_conceal_group(decs, :markdown)
-      assert length(decs.conceal_ranges) == 1
-      assert hd(decs.conceal_ranges).group == :other
-    end
-  end
+      unchanged = Decorations.remove_conceal(decs, make_ref())
+      assert unchanged == decs
 
-  describe "conceals_for_line/2" do
-    test "returns conceals for the given line sorted by start col" do
-      decs = Decorations.new()
-      {_id1, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 7})
-      {_id2, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
-      {_id3, decs} = Decorations.add_conceal(decs, {1, 0}, {1, 3})
-
-      line_conceals = Decorations.conceals_for_line(decs, 0)
-      assert length(line_conceals) == 2
-      [first, second] = line_conceals
-      assert elem(first.start_pos, 1) <= elem(second.start_pos, 1)
+      only_other = Decorations.remove_conceal_group(decs, :markdown)
+      assert Enum.map(only_other.conceal_ranges, & &1.group) == [:other]
+      assert only_other.version == 5
     end
 
-    test "returns empty list when no conceals exist" do
-      decs = Decorations.new()
-      assert Decorations.conceals_for_line(decs, 0) == []
+    test "queries conceals by line sorted by start column" do
+      decs = build_decs([{0, 5, 7}, {0, 0, 2}, {1, 0, 3}])
+
+      assert ranges_only(decs, 0) == [{0, 2}, {5, 7}]
+      assert ranges_only(decs, 1) == [{0, 3}]
+      assert ranges_only(decs, 2) == []
+      assert Decorations.conceals_for_line(Decorations.new(), 0) == []
     end
 
-    test "returns empty list for line with no conceals" do
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
-      assert Decorations.conceals_for_line(decs, 1) == []
-    end
-  end
-
-  describe "has_conceal_ranges?/1" do
-    test "returns false for empty" do
-      refute Decorations.has_conceal_ranges?(Decorations.new())
-    end
-
-    test "returns true when conceals exist" do
+    test "clear removes conceals and empty?/1 returns true again" do
       {_id, decs} = Decorations.add_conceal(Decorations.new(), {0, 0}, {0, 2})
-      assert Decorations.has_conceal_ranges?(decs)
+
+      refute Decorations.empty?(decs)
+      refute decs |> Decorations.clear() |> Decorations.has_conceal_ranges?()
+      assert decs |> Decorations.clear() |> Decorations.empty?()
     end
   end
 
-  # ── Overlap merging ────────────────────────────────────────────────────────
+  describe "conceal overlap merging" do
+    test "merges only truly overlapping ranges" do
+      cases = [
+        {[{0, 0, 3}, {0, 5, 8}, {0, 10, 12}], [{0, 3}, {5, 8}, {10, 12}]},
+        {[{0, 0, 5}, {0, 5, 10}], [{0, 5}, {5, 10}]},
+        {[{0, 2, 7}, {0, 5, 10}], [{2, 10}]},
+        {[{0, 0, 10}, {0, 3, 6}], [{0, 10}]},
+        {[{0, 0, 4}, {0, 3, 7}, {0, 6, 10}], [{0, 10}]},
+        {[{0, 3, 7}, {0, 3, 10}], [{3, 10}]},
+        {[{0, 4, 5}, {0, 4, 5}], [{4, 5}]}
+      ]
 
-  describe "conceals_for_line overlap merging" do
-    test "non-overlapping ranges preserved in order" do
-      decs = Decorations.new()
-      {_, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 3})
-      {_, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 8})
-      {_, decs} = Decorations.add_conceal(decs, {0, 10}, {0, 12})
-      conceals = Decorations.conceals_for_line(decs, 0)
-      assert length(conceals) == 3
-
-      assert [{0, 3}, {5, 8}, {10, 12}] ==
-               Enum.map(conceals, fn c -> {elem(c.start_pos, 1), elem(c.end_pos, 1)} end)
-    end
-
-    test "adjacent ranges are not merged" do
-      decs = Decorations.new()
-      {_, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 5})
-      {_, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 10})
-      conceals = Decorations.conceals_for_line(decs, 0)
-      assert length(conceals) == 2
-    end
-
-    test "overlapping ranges merge to union" do
-      decs = Decorations.new()
-      {_, decs} = Decorations.add_conceal(decs, {0, 2}, {0, 7})
-      {_, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 10})
-      conceals = Decorations.conceals_for_line(decs, 0)
-      assert length(conceals) == 1
-      [c] = conceals
-      assert elem(c.start_pos, 1) == 2
-      assert elem(c.end_pos, 1) == 10
-    end
-
-    test "fully nested range absorbed by outer" do
-      decs = Decorations.new()
-      {_, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 10})
-      {_, decs} = Decorations.add_conceal(decs, {0, 3}, {0, 6})
-      conceals = Decorations.conceals_for_line(decs, 0)
-      assert length(conceals) == 1
-      [c] = conceals
-      assert elem(c.start_pos, 1) == 0
-      assert elem(c.end_pos, 1) == 10
-    end
-
-    test "chain of overlapping ranges collapses to one" do
-      decs = Decorations.new()
-      {_, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 4})
-      {_, decs} = Decorations.add_conceal(decs, {0, 3}, {0, 7})
-      {_, decs} = Decorations.add_conceal(decs, {0, 6}, {0, 10})
-      conceals = Decorations.conceals_for_line(decs, 0)
-      assert length(conceals) == 1
-      [c] = conceals
-      assert elem(c.start_pos, 1) == 0
-      assert elem(c.end_pos, 1) == 10
+      for {specs, expected} <- cases do
+        assert ranges_only(build_decs(specs), 0) == expected
+      end
     end
 
     test "higher priority replacement wins on overlap" do
-      decs = Decorations.new()
-      {_, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 5}, replacement: "·", priority: 0)
-      {_, decs} = Decorations.add_conceal(decs, {0, 3}, {0, 8}, replacement: "→", priority: 5)
-      conceals = Decorations.conceals_for_line(decs, 0)
-      assert length(conceals) == 1
-      [c] = conceals
-      assert c.replacement == "→"
-    end
+      decs =
+        build_decs([
+          {0, 0, 5, replacement: "·", priority: 0},
+          {0, 3, 8, replacement: "→", priority: 5}
+        ])
 
-    test "same start, different end merges to longer" do
-      decs = Decorations.new()
-      {_, decs} = Decorations.add_conceal(decs, {0, 3}, {0, 7})
-      {_, decs} = Decorations.add_conceal(decs, {0, 3}, {0, 10})
-      conceals = Decorations.conceals_for_line(decs, 0)
-      assert length(conceals) == 1
-      [c] = conceals
-      assert elem(c.start_pos, 1) == 3
-      assert elem(c.end_pos, 1) == 10
-    end
-
-    test "duplicate ranges merge to one" do
-      decs = Decorations.new()
-      {_, decs} = Decorations.add_conceal(decs, {0, 4}, {0, 5})
-      {_, decs} = Decorations.add_conceal(decs, {0, 4}, {0, 5})
-      conceals = Decorations.conceals_for_line(decs, 0)
-      assert length(conceals) == 1
+      assert [{0, 8, "→"}] = ranges_with_replacements(decs, 0)
     end
   end
 
-  # ── Column mapping ────────────────────────────────────────────────────────
+  describe "column mapping" do
+    test "buffer columns map to display columns across conceal variants" do
+      cases = [
+        {Decorations.new(), [{5, 5}]},
+        {build_decs([{0, 0, 2}]), [{0, 0}, {2, 0}, {6, 4}]},
+        {build_decs([{0, 0, 2, replacement: "·"}]), [{2, 1}, {6, 5}]},
+        {build_decs([{0, 0, 2}, {0, 6, 8}]), [{2, 0}, {6, 4}, {8, 4}, {10, 6}]},
+        {build_decs([{1, 0, 2}]), [{5, 5}]}
+      ]
 
-  describe "buf_col_to_display_col with conceals" do
-    test "no conceals: identity mapping" do
-      decs = Decorations.new()
-      assert Decorations.buf_col_to_display_col(decs, 0, 5) == 5
+      for {decs, assertions} <- cases do
+        for {buf_col, display_col} <- assertions do
+          assert Decorations.buf_col_to_display_col(decs, 0, buf_col) == display_col
+        end
+      end
     end
 
-    test "conceal before position shifts display left" do
-      # Line: "**bold**" concealing first **
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+    test "display columns map back to buffer columns across conceal variants" do
+      cases = [
+        {Decorations.new(), [{5, 5}]},
+        {build_decs([{0, 0, 2}]), [{0, 2}, {4, 6}]},
+        {build_decs([{0, 0, 2, replacement: "·"}]), [{1, 2}]}
+      ]
 
-      # buf_col 0 is at the start of the conceal, display_col is 0
-      assert Decorations.buf_col_to_display_col(decs, 0, 0) == 0
-      # buf_col 2 (after "**") maps to display_col 0 (conceal width 2, replacement 0)
-      assert Decorations.buf_col_to_display_col(decs, 0, 2) == 0
-      # buf_col 6 ("bold" ends at 6) maps to display_col 4
-      assert Decorations.buf_col_to_display_col(decs, 0, 6) == 4
-    end
-
-    test "conceal with replacement: shifts by (concealed_width - 1)" do
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, replacement: "·")
-
-      # buf_col 2 maps to display_col 1 (concealed 2 chars, replaced by 1)
-      assert Decorations.buf_col_to_display_col(decs, 0, 2) == 1
-      # buf_col 6 maps to display_col 5
-      assert Decorations.buf_col_to_display_col(decs, 0, 6) == 5
-    end
-
-    test "multiple conceals accumulate offsets" do
-      # "**bold** and **more**"
-      # Conceal ** at 0..2 and ** at 6..8
-      decs = Decorations.new()
-      {_id1, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
-      {_id2, decs} = Decorations.add_conceal(decs, {0, 6}, {0, 8})
-
-      # After first **: buf_col 2 -> display 0
-      assert Decorations.buf_col_to_display_col(decs, 0, 2) == 0
-      # "bold" starts at buf_col 2, ends at 6: display 0..4
-      assert Decorations.buf_col_to_display_col(decs, 0, 6) == 4
-      # After second **: buf_col 8 -> display 4 (both conceals removed 4 total)
-      assert Decorations.buf_col_to_display_col(decs, 0, 8) == 4
-      # buf_col 10 -> display 6
-      assert Decorations.buf_col_to_display_col(decs, 0, 10) == 6
-    end
-
-    test "conceal on different line doesn't affect mapping" do
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_conceal(decs, {1, 0}, {1, 2})
-
-      assert Decorations.buf_col_to_display_col(decs, 0, 5) == 5
+      for {decs, assertions} <- cases do
+        for {display_col, buf_col} <- assertions do
+          assert Decorations.display_col_to_buf_col(decs, 0, display_col) == buf_col
+        end
+      end
     end
   end
 
-  describe "display_col_to_buf_col with conceals" do
-    test "no conceals: identity mapping" do
-      decs = Decorations.new()
-      assert Decorations.display_col_to_buf_col(decs, 0, 5) == 5
-    end
+  describe "edit adjustment" do
+    test "adjust_for_edit shifts, shrinks, preserves, or removes affected conceals" do
+      cases = [
+        {[{0, 5, 7}], {{0, 0}, {0, 0}, {0, 2}}, [{7, 9}]},
+        {[{0, 0, 2}], {{0, 5}, {0, 5}, {0, 8}}, [{0, 2}]},
+        {[{0, 2, 5}], {{0, 0}, {0, 6}, {0, 0}}, []},
+        {[{0, 2, 8}], {{0, 4}, {0, 6}, {0, 4}}, [{2, 6}]}
+      ]
 
-    test "conceal before position shifts buffer right" do
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
+      for {specs, {edit_start, edit_end, new_end}, expected} <- cases do
+        adjusted =
+          specs |> build_decs() |> Decorations.adjust_for_edit(edit_start, edit_end, new_end)
 
-      # display_col 0 maps to buf_col 2 (the "b" in "bold" after hidden "**")
-      assert Decorations.display_col_to_buf_col(decs, 0, 0) == 2
-      # display_col 4 maps to buf_col 6
-      assert Decorations.display_col_to_buf_col(decs, 0, 4) == 6
-    end
-
-    test "conceal with replacement" do
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2}, replacement: "·")
-
-      # display_col 0 is the replacement char, maps to buf_col 0
-      # display_col 1 maps to buf_col 2 (after the concealed range)
-      assert Decorations.display_col_to_buf_col(decs, 0, 1) == 2
+        assert raw_ranges(adjusted) == expected
+      end
     end
   end
-
-  # ── Anchor adjustment ────────────────────────────────────────────────────
-
-  describe "adjust_for_edit with conceals" do
-    test "insertion before conceal shifts it right" do
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_conceal(decs, {0, 5}, {0, 7})
-
-      # Insert 2 chars at col 0
-      decs = Decorations.adjust_for_edit(decs, {0, 0}, {0, 0}, {0, 2})
-
-      [conceal] = decs.conceal_ranges
-      assert conceal.start_pos == {0, 7}
-      assert conceal.end_pos == {0, 9}
-    end
-
-    test "insertion after conceal doesn't move it" do
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 2})
-
-      decs = Decorations.adjust_for_edit(decs, {0, 5}, {0, 5}, {0, 8})
-
-      [conceal] = decs.conceal_ranges
-      assert conceal.start_pos == {0, 0}
-      assert conceal.end_pos == {0, 2}
-    end
-
-    test "deletion spanning conceal removes it" do
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_conceal(decs, {0, 2}, {0, 5})
-
-      # Delete from col 0 to col 6 (spans the conceal)
-      decs = Decorations.adjust_for_edit(decs, {0, 0}, {0, 6}, {0, 0})
-
-      assert decs.conceal_ranges == []
-    end
-
-    test "deletion within conceal shrinks it" do
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_conceal(decs, {0, 2}, {0, 8})
-
-      # Delete 2 chars inside the conceal (col 4 to 6)
-      decs = Decorations.adjust_for_edit(decs, {0, 4}, {0, 6}, {0, 4})
-
-      [conceal] = decs.conceal_ranges
-      assert conceal.start_pos == {0, 2}
-      assert conceal.end_pos == {0, 6}
-    end
-  end
-
-  # ── empty?/1 with conceals ──────────────────────────────────────────────
-
-  describe "empty?/1" do
-    test "returns false when conceals exist" do
-      {_id, decs} = Decorations.add_conceal(Decorations.new(), {0, 0}, {0, 2})
-      refute Decorations.empty?(decs)
-    end
-  end
-
-  # ── clear/1 with conceals ──────────────────────────────────────────────
-
-  describe "clear/1" do
-    test "clears conceal ranges" do
-      {_id, decs} = Decorations.add_conceal(Decorations.new(), {0, 0}, {0, 2})
-      decs = Decorations.clear(decs)
-      assert decs.conceal_ranges == []
-    end
-  end
-
-  # ── Property tests ──────────────────────────────────────────────────────
 
   describe "column mapping roundtrip" do
     property "buf_col outside conceals roundtrips through display_col" do
-      # For buffer positions NOT inside concealed ranges, the roundtrip
-      # buf_col -> display_col -> buf_col should be exact.
       check all(
               line_len <- integer(5..50),
               conceal_count <- integer(0..3),
@@ -446,14 +182,12 @@ defmodule Minga.Buffer.ConcealRangeTest do
             ) do
         decs = build_decs_with_conceals(conceals)
 
-        # Test every buf_col that's not inside a concealed range
         for buf_col <- 0..line_len, not inside_any_conceal?(buf_col, conceals) do
           display_col = Decorations.buf_col_to_display_col(decs, 0, buf_col)
           roundtrip = Decorations.display_col_to_buf_col(decs, 0, display_col)
 
           assert roundtrip == buf_col,
-                 "Roundtrip failed: buf_col=#{buf_col} -> display_col=#{display_col} -> #{roundtrip}, " <>
-                   "conceals=#{inspect(conceals)}"
+                 "Roundtrip failed: buf_col=#{buf_col} -> display_col=#{display_col} -> #{roundtrip}, conceals=#{inspect(conceals)}"
         end
       end
     end
@@ -465,10 +199,8 @@ defmodule Minga.Buffer.ConcealRangeTest do
               conceals <- conceal_ranges_gen(line_len, conceal_count)
             ) do
         decs = build_decs_with_conceals(conceals)
-
         display_cols = for b <- 0..line_len, do: Decorations.buf_col_to_display_col(decs, 0, b)
 
-        # Each display_col should be >= the previous one
         display_cols
         |> Enum.chunk_every(2, 1, :discard)
         |> Enum.each(fn [prev, curr] ->
@@ -492,102 +224,6 @@ defmodule Minga.Buffer.ConcealRangeTest do
       end
     end
   end
-
-  # ── Generators ─────────────────────────────────────────────────────────
-
-  defp conceal_ranges_gen(line_len, count, with_replacement \\ true) do
-    if count == 0 do
-      constant([])
-    else
-      bind(non_overlapping_ranges(line_len, count), fn ranges ->
-        constant(add_replacements(ranges, with_replacement))
-      end)
-    end
-  end
-
-  defp add_replacements(ranges, with_replacement) do
-    Enum.map(ranges, fn {s, e} ->
-      replacement = if with_replacement and :rand.uniform(2) == 1, do: "·", else: nil
-      {s, e, replacement}
-    end)
-  end
-
-  defp non_overlapping_ranges(line_len, count) do
-    bind(list_of(integer(1..max(line_len - 1, 2)), length: count), fn widths ->
-      constant(build_ranges(widths, line_len, count))
-    end)
-  end
-
-  defp build_ranges(widths, line_len, _count) do
-    widths = Enum.map(widths, &min(&1, 3))
-
-    # Walk left to right. Each range starts at least 1 col after the previous end.
-    # Skip any range that doesn't fit within line_len.
-    {ranges, _cursor} =
-      Enum.reduce(widths, {[], 0}, fn w, {acc, cursor} ->
-        start_col = cursor + 1
-        end_col = start_col + w
-
-        if end_col <= line_len do
-          {[{start_col, end_col} | acc], end_col}
-        else
-          # No room; skip this range
-          {acc, cursor}
-        end
-      end)
-
-    Enum.reverse(ranges)
-  end
-
-  defp build_decs_with_conceals(conceals) do
-    Enum.reduce(conceals, Decorations.new(), fn {s, e, replacement}, decs ->
-      opts = if replacement, do: [replacement: replacement], else: []
-      {_id, decs} = Decorations.add_conceal(decs, {0, s}, {0, e}, opts)
-      decs
-    end)
-  end
-
-  defp inside_any_conceal?(buf_col, conceals) do
-    Enum.any?(conceals, fn {s, e, _} -> buf_col >= s and buf_col < e end)
-  end
-
-  # ── Overlapping conceal generators ─────────────────────────────────────
-
-  defp overlapping_conceals_gen(line_len) do
-    bind(integer(2..5), fn count ->
-      list_of(single_conceal_gen(line_len), length: count)
-    end)
-  end
-
-  defp single_conceal_gen(line_len) do
-    bind(
-      {integer(0..max(line_len - 2, 0)), integer(1..min(line_len, 5)), member_of([nil, "·", "→"]),
-       integer(0..3)},
-      fn {start, width, replacement, priority} ->
-        end_col = min(start + width, line_len)
-        constant({start, end_col, replacement, priority})
-      end
-    )
-  end
-
-  defp build_decs_with_priority_conceals(conceals) do
-    Enum.reduce(conceals, Decorations.new(), fn {s, e, replacement, priority}, decs ->
-      opts = [priority: priority]
-      opts = if replacement, do: [{:replacement, replacement} | opts], else: opts
-      {_id, decs} = Decorations.add_conceal(decs, {0, s}, {0, e}, opts)
-      decs
-    end)
-  end
-
-  defp inside_any_merged_conceal?(buf_col, merged_conceals) do
-    Enum.any?(merged_conceals, fn c ->
-      {_, sc} = c.start_pos
-      {_, ec} = c.end_pos
-      buf_col >= sc and buf_col < ec
-    end)
-  end
-
-  # ── Overlap property tests ────────────────────────────────────────────
 
   describe "column mapping with overlapping conceals" do
     property "conceals_for_line returns non-overlapping ranges" do
@@ -635,14 +271,12 @@ defmodule Minga.Buffer.ConcealRangeTest do
         decs = build_decs_with_priority_conceals(raw_conceals)
         merged = Decorations.conceals_for_line(decs, 0)
 
-        for buf_col <- 0..line_len,
-            not inside_any_merged_conceal?(buf_col, merged) do
+        for buf_col <- 0..line_len, not inside_any_merged_conceal?(buf_col, merged) do
           display_col = Decorations.buf_col_to_display_col(decs, 0, buf_col)
           roundtrip = Decorations.display_col_to_buf_col(decs, 0, display_col)
 
           assert roundtrip == buf_col,
-                 "Roundtrip failed: buf_col=#{buf_col} -> display_col=#{display_col} -> #{roundtrip}, " <>
-                   "conceals=#{inspect(raw_conceals)}"
+                 "Roundtrip failed: buf_col=#{buf_col} -> display_col=#{display_col} -> #{roundtrip}, conceals=#{inspect(raw_conceals)}"
         end
       end
     end
@@ -664,18 +298,13 @@ defmodule Minga.Buffer.ConcealRangeTest do
 
           if overlapping_inputs != [] do
             max_priority = overlapping_inputs |> Enum.map(fn {_, _, _, p} -> p end) |> Enum.max()
-
-            top_tier =
-              Enum.filter(overlapping_inputs, fn {_, _, _, p} -> p == max_priority end)
-
-            # Only assert when there's a single unique max-priority replacement
+            top_tier = Enum.filter(overlapping_inputs, fn {_, _, _, p} -> p == max_priority end)
             replacements = top_tier |> Enum.map(fn {_, _, r, _} -> r end) |> Enum.uniq()
 
             if length(replacements) == 1 do
               assert m.replacement == hd(replacements),
                      "Expected replacement #{inspect(hd(replacements))}, got #{inspect(m.replacement)}"
             else
-              # Tie: just verify the replacement came from one of the top-tier inputs
               assert m.replacement in replacements,
                      "Replacement #{inspect(m.replacement)} not in top-tier #{inspect(replacements)}"
             end
@@ -683,5 +312,133 @@ defmodule Minga.Buffer.ConcealRangeTest do
         end
       end
     end
+  end
+
+  defp conceal(start_pos, end_pos, opts \\ []) do
+    struct!(
+      ConcealRange,
+      Keyword.merge([id: make_ref(), start_pos: start_pos, end_pos: end_pos], opts)
+    )
+  end
+
+  defp build_decs(specs) do
+    Enum.reduce(specs, Decorations.new(), fn spec, decs ->
+      {line, start_col, end_col, opts} = normalize_spec(spec)
+      {_id, decs} = Decorations.add_conceal(decs, {line, start_col}, {line, end_col}, opts)
+      decs
+    end)
+  end
+
+  defp normalize_spec({line, start_col, end_col}), do: {line, start_col, end_col, []}
+  defp normalize_spec({line, start_col, end_col, opts}), do: {line, start_col, end_col, opts}
+
+  defp ranges_only(decs, line) do
+    decs
+    |> Decorations.conceals_for_line(line)
+    |> Enum.map(fn conceal -> {col(conceal.start_pos), col(conceal.end_pos)} end)
+  end
+
+  defp ranges_with_replacements(decs, line) do
+    decs
+    |> Decorations.conceals_for_line(line)
+    |> Enum.map(fn conceal ->
+      {col(conceal.start_pos), col(conceal.end_pos), conceal.replacement}
+    end)
+  end
+
+  defp raw_ranges(decs) do
+    decs.conceal_ranges
+    |> Enum.map(fn conceal -> {col(conceal.start_pos), col(conceal.end_pos)} end)
+    |> Enum.sort()
+  end
+
+  defp col({_line, col}), do: col
+
+  defp conceal_ranges_gen(line_len, count, with_replacement \\ true) do
+    if count == 0 do
+      constant([])
+    else
+      bind(non_overlapping_ranges(line_len, count), fn ranges ->
+        constant(add_replacements(ranges, with_replacement))
+      end)
+    end
+  end
+
+  defp add_replacements(ranges, with_replacement) do
+    Enum.map(ranges, fn {s, e} ->
+      replacement = if with_replacement and :rand.uniform(2) == 1, do: "·", else: nil
+      {s, e, replacement}
+    end)
+  end
+
+  defp non_overlapping_ranges(line_len, count) do
+    bind(list_of(integer(1..max(line_len - 1, 2)), length: count), fn widths ->
+      constant(build_ranges(widths, line_len))
+    end)
+  end
+
+  defp build_ranges(widths, line_len) do
+    widths = Enum.map(widths, &min(&1, 3))
+
+    {ranges, _cursor} =
+      Enum.reduce(widths, {[], 0}, fn width, {acc, cursor} ->
+        start_col = cursor + 1
+        end_col = start_col + width
+
+        if end_col <= line_len do
+          {[{start_col, end_col} | acc], end_col}
+        else
+          {acc, cursor}
+        end
+      end)
+
+    Enum.reverse(ranges)
+  end
+
+  defp build_decs_with_conceals(conceals) do
+    Enum.reduce(conceals, Decorations.new(), fn {start_col, end_col, replacement}, decs ->
+      opts = if replacement, do: [replacement: replacement], else: []
+      {_id, decs} = Decorations.add_conceal(decs, {0, start_col}, {0, end_col}, opts)
+      decs
+    end)
+  end
+
+  defp inside_any_conceal?(buf_col, conceals) do
+    Enum.any?(conceals, fn {start_col, end_col, _} ->
+      buf_col >= start_col and buf_col < end_col
+    end)
+  end
+
+  defp overlapping_conceals_gen(line_len) do
+    bind(integer(2..5), fn count ->
+      list_of(single_conceal_gen(line_len), length: count)
+    end)
+  end
+
+  defp single_conceal_gen(line_len) do
+    bind(
+      {integer(0..max(line_len - 2, 0)), integer(1..min(line_len, 5)), member_of([nil, "·", "→"]),
+       integer(0..3)},
+      fn {start, width, replacement, priority} ->
+        end_col = min(start + width, line_len)
+        constant({start, end_col, replacement, priority})
+      end
+    )
+  end
+
+  defp build_decs_with_priority_conceals(conceals) do
+    Enum.reduce(conceals, Decorations.new(), fn {start_col, end_col, replacement, priority},
+                                                decs ->
+      opts = [priority: priority]
+      opts = if replacement, do: [{:replacement, replacement} | opts], else: opts
+      {_id, decs} = Decorations.add_conceal(decs, {0, start_col}, {0, end_col}, opts)
+      decs
+    end)
+  end
+
+  defp inside_any_merged_conceal?(buf_col, merged_conceals) do
+    Enum.any?(merged_conceals, fn conceal ->
+      buf_col >= col(conceal.start_pos) and buf_col < col(conceal.end_pos)
+    end)
   end
 end

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -193,62 +193,41 @@ defmodule Minga.Config.LoaderTest do
     end
   end
 
-  describe "loading config with syntax error" do
-    test "captures syntax error and stores it" do
-      {_dir, cleanup} =
-        make_config_dir("""
-        this is not valid elixir %%%
-        """)
+  describe "loading invalid config" do
+    test "captures syntax, option validation, and migration errors" do
+      cases = [
+        {"syntax",
+         """
+         this is not valid elixir %%%
+         """, {:any, ["syntax", "error", "Error"]}},
+        {"runtime",
+         """
+         use Minga.Config
 
-      on_exit(cleanup)
+         set :tab_width, -1
+         """, {:any, ["positive integer", "error", "Error"]}},
+        {"legacy_provider",
+         """
+         use Minga.Config
 
-      name = :"loader_syntax_#{System.unique_integer([:positive])}"
-      {:ok, pid} = Loader.start_link(name: name)
+         set :agent_provider, :pi_rpc
+         """, {:all, ["agent_provider no longer supports :pi_rpc", "Use :native instead"]}}
+      ]
 
-      error = Loader.load_error(pid)
-      assert is_binary(error)
-      assert error =~ "syntax" or error =~ "error" or error =~ "Error"
-    end
-  end
+      for {label, config, expected_fragments} <- cases do
+        {_dir, cleanup} = make_config_dir(config)
 
-  describe "loading config with runtime error" do
-    test "captures runtime error from invalid option value" do
-      {_dir, cleanup} =
-        make_config_dir("""
-        use Minga.Config
+        try do
+          name = :"loader_#{label}_#{System.unique_integer([:positive])}"
+          {:ok, pid} = Loader.start_link(name: name)
 
-        set :tab_width, -1
-        """)
-
-      on_exit(cleanup)
-
-      name = :"loader_runtime_#{System.unique_integer([:positive])}"
-      {:ok, pid} = Loader.start_link(name: name)
-
-      error = Loader.load_error(pid)
-      assert is_binary(error)
-      assert error =~ "positive integer" or error =~ "error" or error =~ "Error"
-    end
-  end
-
-  describe "loading config with a removed agent provider" do
-    test "fails with a native-provider migration hint" do
-      {_dir, cleanup} =
-        make_config_dir("""
-        use Minga.Config
-
-        set :agent_provider, :pi_rpc
-        """)
-
-      on_exit(cleanup)
-
-      name = :"loader_legacy_provider_#{System.unique_integer([:positive])}"
-      {:ok, pid} = Loader.start_link(name: name)
-
-      error = Loader.load_error(pid)
-      assert is_binary(error)
-      assert error =~ "agent_provider no longer supports :pi_rpc"
-      assert error =~ "Use :native instead"
+          error = Loader.load_error(pid)
+          assert is_binary(error)
+          assert_error_fragments(error, expected_fragments)
+        after
+          cleanup.()
+        end
+      end
     end
   end
 
@@ -1130,6 +1109,14 @@ defmodule Minga.Config.LoaderTest do
   end
 
   # ── Helpers ─────────────────────────────────────────────────────────────────
+
+  defp assert_error_fragments(error, {:any, fragments}) do
+    assert Enum.any?(fragments, &String.contains?(error, &1))
+  end
+
+  defp assert_error_fragments(error, {:all, fragments}) do
+    for fragment <- fragments, do: assert(error =~ fragment)
+  end
 
   # Creates a temporary directory structure that mimics XDG_CONFIG_HOME with
   # a minga/config.exs file. Returns `{minga_dir, cleanup_fn}`.

--- a/test/minga/project/file_tree_test.exs
+++ b/test/minga/project/file_tree_test.exs
@@ -3,628 +3,280 @@ defmodule Minga.Project.FileTreeTest do
 
   alias Minga.Project.FileTree
 
-  @tag :tmp_dir
-  test "new/1 creates tree with root expanded", %{tmp_dir: tmp_dir} do
-    tree = FileTree.new(tmp_dir)
-    assert tree.root == Path.expand(tmp_dir)
-    assert MapSet.member?(tree.expanded, tree.root)
-    assert tree.cursor == 0
-    assert tree.show_hidden == false
+  defp touch(path), do: File.write!(path, "")
+  defp mkdir(path), do: File.mkdir_p!(path)
+  defp names(tree), do: tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
+  defp paths(tree), do: tree |> FileTree.visible_entries() |> Enum.map(& &1.path)
+  defp selected_name(tree), do: tree |> FileTree.selected_entry() |> Map.get(:name)
+
+  defp expand_path(tree, parts) when is_list(parts) do
+    FileTree.expand_path(tree, Path.join([tree.root | parts]))
   end
 
-  describe "visible_entries/1" do
+  describe "construction and visible entries" do
     @tag :tmp_dir
-    test "lists files and directories sorted (dirs first, then alpha)", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "zebra.txt"), "")
-      File.write!(Path.join(tmp_dir, "alpha.txt"), "")
-      File.mkdir_p!(Path.join(tmp_dir, "lib"))
-      File.mkdir_p!(Path.join(tmp_dir, "app"))
-
+    test "starts at the expanded root with default display options", %{tmp_dir: tmp_dir} do
       tree = FileTree.new(tmp_dir)
-      entries = FileTree.visible_entries(tree)
-      names = Enum.map(entries, & &1.name)
 
-      assert names == ["app", "lib", "alpha.txt", "zebra.txt"]
+      assert tree.root == Path.expand(tmp_dir)
+      assert MapSet.member?(tree.expanded, tree.root)
+      assert tree.cursor == 0
+      assert tree.show_hidden == false
+      assert tree.width == 30
     end
 
     @tag :tmp_dir
-    test "hides dotfiles by default", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, ".hidden"), "")
-      File.write!(Path.join(tmp_dir, "visible.txt"), "")
+    test "lists directories before files, sorted alphabetically", %{tmp_dir: tmp_dir} do
+      touch(Path.join(tmp_dir, "zebra.txt"))
+      touch(Path.join(tmp_dir, "alpha.txt"))
+      mkdir(Path.join(tmp_dir, "lib"))
+      mkdir(Path.join(tmp_dir, "app"))
 
-      tree = FileTree.new(tmp_dir)
-      names = Enum.map(FileTree.visible_entries(tree), & &1.name)
-
-      assert names == ["visible.txt"]
+      assert tmp_dir |> FileTree.new() |> names() == ["app", "lib", "alpha.txt", "zebra.txt"]
     end
 
     @tag :tmp_dir
-    test "shows dotfiles when show_hidden is true", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, ".hidden"), "")
-      File.write!(Path.join(tmp_dir, "visible.txt"), "")
+    test "filters hidden files and ignored directories independently", %{tmp_dir: tmp_dir} do
+      touch(Path.join(tmp_dir, ".hidden"))
+      touch(Path.join(tmp_dir, "visible.txt"))
+      mkdir(Path.join(tmp_dir, ".git"))
+      mkdir(Path.join(tmp_dir, "node_modules"))
+      mkdir(Path.join(tmp_dir, "_build"))
+      mkdir(Path.join(tmp_dir, "src"))
 
-      tree = FileTree.new(tmp_dir) |> FileTree.toggle_hidden()
-      names = Enum.map(FileTree.visible_entries(tree), & &1.name)
+      hidden_names = tmp_dir |> FileTree.new() |> names()
+      shown_names = tmp_dir |> FileTree.new() |> FileTree.toggle_hidden() |> names()
 
-      assert ".hidden" in names
-      assert "visible.txt" in names
+      assert hidden_names == ["src", "visible.txt"]
+      assert ".hidden" in shown_names
+      assert "visible.txt" in shown_names
+      assert "src" in shown_names
+      refute ".git" in shown_names
+      refute "node_modules" in shown_names
+      refute "_build" in shown_names
     end
 
     @tag :tmp_dir
-    test "ignores default ignored directories", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, ".git"))
-      File.mkdir_p!(Path.join(tmp_dir, "node_modules"))
-      File.mkdir_p!(Path.join(tmp_dir, "_build"))
-      File.mkdir_p!(Path.join(tmp_dir, "src"))
+    test "only expanded directories expose children and child depth", %{tmp_dir: tmp_dir} do
+      mkdir(Path.join(tmp_dir, "lib"))
+      touch(Path.join([tmp_dir, "lib", "app.ex"]))
+      touch(Path.join(tmp_dir, "mix.exs"))
 
-      tree = FileTree.new(tmp_dir) |> FileTree.toggle_hidden()
-      names = Enum.map(FileTree.visible_entries(tree), & &1.name)
+      collapsed = FileTree.new(tmp_dir)
+      expanded = expand_path(collapsed, ["lib"])
 
-      assert "src" in names
-      refute ".git" in names
-      refute "node_modules" in names
-      refute "_build" in names
-    end
+      assert names(collapsed) == ["lib", "mix.exs"]
 
-    @tag :tmp_dir
-    test "unexpanded directories do not show children", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "lib"))
-      File.write!(Path.join([tmp_dir, "lib", "app.ex"]), "")
-
-      tree = FileTree.new(tmp_dir)
-      entries = FileTree.visible_entries(tree)
-
-      assert length(entries) == 1
-      assert hd(entries).name == "lib"
-      assert hd(entries).dir? == true
-    end
-
-    @tag :tmp_dir
-    test "expanded directories show children with increased depth", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "lib"))
-      File.write!(Path.join([tmp_dir, "lib", "app.ex"]), "")
-      File.write!(Path.join(tmp_dir, "mix.exs"), "")
-
-      tree = FileTree.new(tmp_dir)
-      # Expand lib
-      tree = %{tree | expanded: MapSet.put(tree.expanded, Path.join(tmp_dir, "lib"))}
-
-      entries = FileTree.visible_entries(tree)
-      names = Enum.map(entries, & &1.name)
-
-      assert names == ["lib", "app.ex", "mix.exs"]
-      assert Enum.at(entries, 0).depth == 0
-      assert Enum.at(entries, 1).depth == 1
+      entries = FileTree.visible_entries(expanded)
+      assert Enum.map(entries, & &1.name) == ["lib", "app.ex", "mix.exs"]
+      assert Enum.map(entries, & &1.depth) == [0, 1, 0]
     end
   end
 
   describe "navigation" do
     @tag :tmp_dir
-    test "move_down increments cursor", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "a.txt"), "")
-      File.write!(Path.join(tmp_dir, "b.txt"), "")
+    test "move_up, move_down, and select clamp to visible entries", %{tmp_dir: tmp_dir} do
+      touch(Path.join(tmp_dir, "a.txt"))
+      touch(Path.join(tmp_dir, "b.txt"))
 
-      tree = FileTree.new(tmp_dir) |> FileTree.move_down()
-      assert tree.cursor == 1
+      tree = FileTree.new(tmp_dir)
+
+      assert selected_name(FileTree.move_up(tree)) == "a.txt"
+      assert selected_name(FileTree.move_down(tree)) == "b.txt"
+      assert selected_name(tree |> FileTree.move_down() |> FileTree.move_down()) == "b.txt"
+      assert selected_name(FileTree.select(tree, -10)) == "a.txt"
+      assert selected_name(FileTree.select(tree, 99)) == "b.txt"
     end
 
     @tag :tmp_dir
-    test "move_down clamps to last entry", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "only.txt"), "")
-
-      tree = FileTree.new(tmp_dir) |> FileTree.move_down() |> FileTree.move_down()
-      assert tree.cursor == 0
-    end
-
-    @tag :tmp_dir
-    test "move_up decrements cursor", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "a.txt"), "")
-      File.write!(Path.join(tmp_dir, "b.txt"), "")
-
-      tree = FileTree.new(tmp_dir) |> FileTree.move_down() |> FileTree.move_up()
-      assert tree.cursor == 0
-    end
-
-    @tag :tmp_dir
-    test "move_up clamps to zero", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "a.txt"), "")
-
-      tree = FileTree.new(tmp_dir) |> FileTree.move_up()
-      assert tree.cursor == 0
+    test "selected_entry returns nil when no entries are visible", %{tmp_dir: tmp_dir} do
+      assert FileTree.selected_entry(FileTree.new(tmp_dir)) == nil
     end
   end
 
-  describe "toggle_expand/1" do
+  describe "expansion and collapse" do
     @tag :tmp_dir
-    test "expands a collapsed directory at cursor", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "src"))
-      File.write!(Path.join([tmp_dir, "src", "main.ex"]), "")
+    test "toggle_expand expands and collapses the directory at the cursor", %{tmp_dir: tmp_dir} do
+      mkdir(Path.join(tmp_dir, "src"))
+      touch(Path.join([tmp_dir, "src", "main.ex"]))
 
       tree = FileTree.new(tmp_dir)
-      # Cursor at 0 = "src" directory (collapsed)
-      assert tree.cursor == 0
-      refute MapSet.member?(tree.expanded, Path.join(tmp_dir, "src"))
 
-      tree = FileTree.toggle_expand(tree)
-      assert MapSet.member?(tree.expanded, Path.join(tmp_dir, "src"))
-
-      entries = FileTree.visible_entries(tree)
-      names = Enum.map(entries, & &1.name)
-      assert names == ["src", "main.ex"]
+      assert names(tree) == ["src"]
+      assert tree |> FileTree.toggle_expand() |> names() == ["src", "main.ex"]
+      assert tree |> FileTree.toggle_expand() |> FileTree.toggle_expand() |> names() == ["src"]
     end
 
     @tag :tmp_dir
-    test "collapses an expanded directory at cursor", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "src"))
-      File.write!(Path.join([tmp_dir, "src", "main.ex"]), "")
+    test "toggle_expand is a no-op on files", %{tmp_dir: tmp_dir} do
+      touch(Path.join(tmp_dir, "readme.md"))
+
+      tree = FileTree.new(tmp_dir)
+      toggled = FileTree.toggle_expand(tree)
+
+      assert names(toggled) == ["readme.md"]
+      assert toggled.cursor == tree.cursor
+      assert toggled.root == tree.root
+    end
+
+    @tag :tmp_dir
+    test "collapse and expand move between a directory and its children", %{tmp_dir: tmp_dir} do
+      mkdir(Path.join(tmp_dir, "lib"))
+      touch(Path.join([tmp_dir, "lib", "a.ex"]))
+
+      tree = FileTree.new(tmp_dir)
+
+      assert tree |> FileTree.expand() |> names() == ["lib", "a.ex"]
+      assert tree |> FileTree.expand() |> FileTree.expand() |> selected_name() == "a.ex"
+
+      assert tree
+             |> FileTree.expand()
+             |> FileTree.expand()
+             |> FileTree.collapse()
+             |> selected_name() == "lib"
+
+      assert tree |> FileTree.expand() |> FileTree.collapse() |> names() == ["lib"]
+    end
+
+    @tag :tmp_dir
+    test "collapse_all keeps only the root expanded and resets selection", %{tmp_dir: tmp_dir} do
+      mkdir(Path.join([tmp_dir, "lib", "minga"]))
+      touch(Path.join([tmp_dir, "lib", "minga", "editor.ex"]))
+      touch(Path.join(tmp_dir, "mix.exs"))
 
       tree =
         FileTree.new(tmp_dir)
-        |> FileTree.toggle_expand()
-        |> FileTree.toggle_expand()
+        |> expand_path(["lib"])
+        |> expand_path(["lib", "minga"])
+        |> FileTree.select(3)
 
-      refute MapSet.member?(tree.expanded, Path.join(tmp_dir, "src"))
-      entries = FileTree.visible_entries(tree)
-      assert length(entries) == 1
-    end
+      collapsed = FileTree.collapse_all(tree)
 
-    @tag :tmp_dir
-    test "is a no-op on files", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "readme.md"), "")
-
-      tree = FileTree.new(tmp_dir)
-      tree2 = FileTree.toggle_expand(tree)
-      # Structural state unchanged (expanded set, cursor, root)
-      assert tree2.expanded == tree.expanded
-      assert tree2.cursor == tree.cursor
-      assert tree2.root == tree.root
-      # Cache is populated as a side effect of checking the entry
-      assert is_list(tree2.entries)
+      assert names(collapsed) == ["lib", "mix.exs"]
+      assert selected_name(collapsed) == "lib"
+      assert MapSet.equal?(collapsed.expanded, MapSet.new([collapsed.root]))
     end
   end
 
-  describe "collapse/1 and expand/1" do
+  describe "hidden files" do
     @tag :tmp_dir
-    test "collapse on expanded dir collapses it", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "lib"))
-      File.write!(Path.join([tmp_dir, "lib", "a.ex"]), "")
-
-      tree = FileTree.new(tmp_dir) |> FileTree.toggle_expand()
-      assert MapSet.member?(tree.expanded, Path.join(tmp_dir, "lib"))
-
-      tree = FileTree.collapse(tree)
-      refute MapSet.member?(tree.expanded, Path.join(tmp_dir, "lib"))
-    end
-
-    @tag :tmp_dir
-    test "collapse on file jumps to parent directory", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "lib"))
-      File.write!(Path.join([tmp_dir, "lib", "a.ex"]), "")
-
-      tree = FileTree.new(tmp_dir) |> FileTree.toggle_expand() |> FileTree.move_down()
-      assert FileTree.selected_entry(tree).name == "a.ex"
-
-      tree = FileTree.collapse(tree)
-      assert tree.cursor == 0
-      assert FileTree.selected_entry(tree).name == "lib"
-    end
-
-    @tag :tmp_dir
-    test "expand on collapsed dir expands it", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "lib"))
-      File.write!(Path.join([tmp_dir, "lib", "a.ex"]), "")
-
-      tree = FileTree.new(tmp_dir)
-      refute MapSet.member?(tree.expanded, Path.join(tmp_dir, "lib"))
-
-      tree = FileTree.expand(tree)
-      assert MapSet.member?(tree.expanded, Path.join(tmp_dir, "lib"))
-    end
-
-    @tag :tmp_dir
-    test "expand on already-expanded dir moves to first child", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "lib"))
-      File.write!(Path.join([tmp_dir, "lib", "a.ex"]), "")
-
-      tree = FileTree.new(tmp_dir) |> FileTree.toggle_expand()
-      assert tree.cursor == 0
-
-      tree = FileTree.expand(tree)
-      assert tree.cursor == 1
-      assert FileTree.selected_entry(tree).name == "a.ex"
-    end
-  end
-
-  describe "toggle_hidden/1" do
-    @tag :tmp_dir
-    test "reveals hidden files", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, ".env"), "")
-      File.write!(Path.join(tmp_dir, "app.ex"), "")
-
-      tree = FileTree.new(tmp_dir)
-      assert length(FileTree.visible_entries(tree)) == 1
-
-      tree = FileTree.toggle_hidden(tree)
-      assert length(FileTree.visible_entries(tree)) == 2
-    end
-
-    @tag :tmp_dir
-    test "clamps cursor when toggling hides entries", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, ".a"), "")
-      File.write!(Path.join(tmp_dir, ".b"), "")
-      File.write!(Path.join(tmp_dir, "c.txt"), "")
-
-      tree =
-        FileTree.new(tmp_dir)
-        |> FileTree.toggle_hidden()
-        |> Map.put(:cursor, 2)
-
-      # cursor at 2 = ".b" (hidden). Toggling back hides it, clamp to 0
-      tree = FileTree.toggle_hidden(tree)
-      assert tree.cursor == 0
-    end
-  end
-
-  describe "selected_entry/1" do
-    @tag :tmp_dir
-    test "returns entry at cursor", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "hello.txt"), "")
-
-      tree = FileTree.new(tmp_dir)
-      entry = FileTree.selected_entry(tree)
-      assert entry.name == "hello.txt"
-      assert entry.dir? == false
-      assert entry.depth == 0
-    end
-
-    @tag :tmp_dir
-    test "returns nil for empty directory", %{tmp_dir: tmp_dir} do
-      tree = FileTree.new(tmp_dir)
-      assert FileTree.selected_entry(tree) == nil
-    end
-  end
-
-  describe "reveal/2" do
-    @tag :tmp_dir
-    test "expands ancestors and moves cursor to target file", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join([tmp_dir, "lib", "minga"]))
-      File.write!(Path.join([tmp_dir, "lib", "minga", "editor.ex"]), "")
-
-      tree = FileTree.new(tmp_dir)
-      tree = FileTree.reveal(tree, Path.join([tmp_dir, "lib", "minga", "editor.ex"]))
-
-      assert MapSet.member?(tree.expanded, Path.join(tmp_dir, "lib"))
-      assert MapSet.member?(tree.expanded, Path.join([tmp_dir, "lib", "minga"]))
-
-      entry = FileTree.selected_entry(tree)
-      assert entry.name == "editor.ex"
-    end
-  end
-
-  describe "entry guide metadata" do
-    @tag :tmp_dir
-    test "entries include last_child? and guides fields", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "a.txt"), "")
-      File.write!(Path.join(tmp_dir, "b.txt"), "")
-
-      tree = FileTree.new(tmp_dir)
-      entries = FileTree.visible_entries(tree)
-
-      # All depth-0 entries have empty guides list
-      assert Enum.all?(entries, fn e -> e.guides == [] end)
-
-      # First file is not last child, second is
-      first = Enum.at(entries, 0)
-      last = Enum.at(entries, 1)
-      assert first.last_child? == false
-      assert last.last_child? == true
-    end
-
-    @tag :tmp_dir
-    test "single entry is marked as last child", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "only.txt"), "")
-
-      tree = FileTree.new(tmp_dir)
-      [entry] = FileTree.visible_entries(tree)
-
-      assert entry.last_child? == true
-      assert entry.guides == []
-    end
-
-    @tag :tmp_dir
-    test "nested entries have correct guide flags for ancestor columns", %{tmp_dir: tmp_dir} do
-      # Create: lib/ (not last) -> app.ex (last child of lib)
-      #         mix.exs (last sibling at depth 0)
-      File.mkdir_p!(Path.join(tmp_dir, "lib"))
-      File.write!(Path.join([tmp_dir, "lib", "app.ex"]), "")
-      File.write!(Path.join(tmp_dir, "mix.exs"), "")
-
-      tree = FileTree.new(tmp_dir)
-      tree = %{tree | expanded: MapSet.put(tree.expanded, Path.join(tmp_dir, "lib"))}
-
-      entries = FileTree.visible_entries(tree)
-      # Expected: lib (depth 0, not last), app.ex (depth 1, last), mix.exs (depth 0, last)
-      [lib_entry, app_entry, mix_entry] = entries
-
-      assert lib_entry.last_child? == false
-      assert lib_entry.guides == []
-
-      # app.ex is the only child of lib, so it's last_child?
-      # Its guides list has one entry: true (because lib is NOT the last sibling,
-      # so the depth-0 column should still draw │)
-      assert app_entry.last_child? == true
-      assert app_entry.guides == [true]
-
-      assert mix_entry.last_child? == true
-      assert mix_entry.guides == []
-    end
-
-    @tag :tmp_dir
-    test "deeply nested entries accumulate guide flags", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join([tmp_dir, "a", "b", "c"]))
-      File.write!(Path.join([tmp_dir, "a", "b", "c", "deep.txt"]), "")
-
-      tree = FileTree.new(tmp_dir)
-
-      tree = %{
-        tree
-        | expanded:
-            tree.expanded
-            |> MapSet.put(Path.join(tmp_dir, "a"))
-            |> MapSet.put(Path.join([tmp_dir, "a", "b"]))
-            |> MapSet.put(Path.join([tmp_dir, "a", "b", "c"]))
-      }
-
-      entries = FileTree.visible_entries(tree)
-      deep = List.last(entries)
-
-      assert deep.name == "deep.txt"
-      assert deep.depth == 3
-      # All ancestors are last children (only child at each level),
-      # so all guide flags should be false (no more siblings = no │)
-      assert deep.guides == [false, false, false]
-      assert deep.last_child? == true
-    end
-  end
-
-  describe "collapse_all/1" do
-    @tag :tmp_dir
-    test "collapses everything except root", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join([tmp_dir, "lib", "minga"]))
-      File.write!(Path.join([tmp_dir, "lib", "minga", "editor.ex"]), "")
-
-      tree =
-        FileTree.new(tmp_dir)
-        |> Map.update!(:expanded, fn exp ->
-          exp
-          |> MapSet.put(Path.join(tmp_dir, "lib"))
-          |> MapSet.put(Path.join([tmp_dir, "lib", "minga"]))
-        end)
-
-      assert MapSet.size(tree.expanded) == 3
-
-      tree = FileTree.collapse_all(tree)
-      assert MapSet.size(tree.expanded) == 1
-      assert MapSet.member?(tree.expanded, tree.root)
-    end
-
-    @tag :tmp_dir
-    test "clamps cursor to valid range", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "lib"))
-      File.write!(Path.join([tmp_dir, "lib", "a.ex"]), "")
-      File.write!(Path.join([tmp_dir, "lib", "b.ex"]), "")
-      File.write!(Path.join(tmp_dir, "mix.exs"), "")
-
-      tree =
-        FileTree.new(tmp_dir)
-        |> Map.update!(:expanded, &MapSet.put(&1, Path.join(tmp_dir, "lib")))
-        |> Map.put(:cursor, 3)
-
-      # cursor 3 = "mix.exs" with lib expanded. After collapse_all,
-      # only root-level entries are visible (lib, mix.exs), cursor clamps to 0.
-      tree = FileTree.collapse_all(tree)
-      assert tree.cursor == 0
-    end
-
-    @tag :tmp_dir
-    test "is a no-op on an already-collapsed tree", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "a.txt"), "")
-
-      tree = FileTree.new(tmp_dir)
-      tree2 = FileTree.collapse_all(tree)
-
-      assert tree2.expanded == tree.expanded
-      assert tree2.cursor == 0
-    end
-  end
-
-  describe "refresh/1" do
-    @tag :tmp_dir
-    test "clamps cursor after files are deleted", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "a.txt"), "")
-      File.write!(Path.join(tmp_dir, "b.txt"), "")
-
-      tree = FileTree.new(tmp_dir) |> FileTree.move_down()
-      assert tree.cursor == 1
-
-      File.rm!(Path.join(tmp_dir, "b.txt"))
-      tree = FileTree.refresh(tree)
-      assert tree.cursor == 0
-    end
-  end
-
-  describe "entry caching" do
-    @tag :tmp_dir
-    test "visible_entries returns cached results when filesystem changes", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "a.txt"), "")
-
-      # Use ensure_entries to populate the cache in the struct
-      tree = FileTree.new(tmp_dir) |> FileTree.ensure_entries()
-      entries1 = FileTree.visible_entries(tree)
-      assert length(entries1) == 1
-
-      # Create a new file after the cache is populated
-      File.write!(Path.join(tmp_dir, "b.txt"), "")
-
-      # Second call on the SAME struct should return the cached list,
-      # not seeing the new file
-      entries2 = FileTree.visible_entries(tree)
-      assert entries2 == entries1
-      assert length(entries2) == 1
-    end
-
-    @tag :tmp_dir
-    test "ensure_entries populates cache and subsequent visible_entries uses it", %{
+    test "toggle_hidden reveals hidden files and clamps selection when they disappear", %{
       tmp_dir: tmp_dir
     } do
-      File.write!(Path.join(tmp_dir, "a.txt"), "")
+      touch(Path.join(tmp_dir, ".a"))
+      touch(Path.join(tmp_dir, ".b"))
+      touch(Path.join(tmp_dir, "c.txt"))
 
-      tree = FileTree.new(tmp_dir)
-      assert tree.entries == nil
+      shown = tmp_dir |> FileTree.new() |> FileTree.toggle_hidden() |> FileTree.select(2)
 
-      tree = FileTree.ensure_entries(tree)
-      assert is_list(tree.entries)
-      assert length(tree.entries) == 1
+      assert names(shown) == [".a", ".b", "c.txt"]
+      assert selected_name(shown) == "c.txt"
 
-      # Create a new file; cached entries should still show only "a.txt"
-      File.write!(Path.join(tmp_dir, "b.txt"), "")
-      assert FileTree.visible_entries(tree) == tree.entries
-      assert length(FileTree.visible_entries(tree)) == 1
+      hidden = FileTree.toggle_hidden(shown)
+      assert names(hidden) == ["c.txt"]
+      assert selected_name(hidden) == "c.txt"
     end
+  end
 
+  describe "reveal and guide metadata" do
     @tag :tmp_dir
-    test "toggle_expand invalidates cache so new entries are computed", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "src"))
-      File.write!(Path.join([tmp_dir, "src", "main.ex"]), "")
-
-      tree = FileTree.new(tmp_dir)
-      # Populate cache: just "src" (collapsed)
-      entries_before = FileTree.visible_entries(tree)
-      assert length(entries_before) == 1
-
-      # Expand "src"; this should invalidate the cache
-      tree = FileTree.toggle_expand(tree)
-      entries_after = FileTree.visible_entries(tree)
-
-      # Now we see both "src" and "main.ex"
-      assert length(entries_after) == 2
-      names = Enum.map(entries_after, & &1.name)
-      assert names == ["src", "main.ex"]
-    end
-
-    @tag :tmp_dir
-    test "refresh invalidates cache and picks up filesystem changes", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "a.txt"), "")
-
-      tree = FileTree.new(tmp_dir) |> FileTree.ensure_entries()
-      assert length(FileTree.visible_entries(tree)) == 1
-
-      # Create a new file
-      File.write!(Path.join(tmp_dir, "b.txt"), "")
-
-      # Stale cache: still 1 entry
-      assert length(FileTree.visible_entries(tree)) == 1
-
-      # Refresh should rescan and see both files
-      tree = FileTree.refresh(tree)
-      assert length(FileTree.visible_entries(tree)) == 2
-    end
-
-    @tag :tmp_dir
-    test "cursor-only operations preserve the entry cache", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "a.txt"), "")
-      File.write!(Path.join(tmp_dir, "b.txt"), "")
-
-      tree = FileTree.new(tmp_dir) |> FileTree.ensure_entries()
-      original_entries = tree.entries
-
-      # move_down preserves cache
-      tree = FileTree.move_down(tree)
-      assert tree.entries == original_entries
-      assert tree.cursor == 1
-
-      # move_up preserves cache
-      tree = FileTree.move_up(tree)
-      assert tree.entries == original_entries
-      assert tree.cursor == 0
-    end
-
-    @tag :tmp_dir
-    test "toggle_hidden invalidates and recomputes cache", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, ".hidden"), "")
-      File.write!(Path.join(tmp_dir, "visible.txt"), "")
-
-      tree = FileTree.new(tmp_dir) |> FileTree.ensure_entries()
-      assert length(tree.entries) == 1
-
-      tree = FileTree.toggle_hidden(tree)
-      assert length(tree.entries) == 2
-      names = Enum.map(tree.entries, & &1.name)
-      assert ".hidden" in names
-      assert "visible.txt" in names
-    end
-
-    @tag :tmp_dir
-    test "collapse_all invalidates cache", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "lib"))
-      File.write!(Path.join([tmp_dir, "lib", "a.ex"]), "")
-
-      tree = FileTree.new(tmp_dir) |> FileTree.toggle_expand() |> FileTree.ensure_entries()
-      assert length(tree.entries) == 2
-
-      tree = FileTree.collapse_all(tree)
-      # Cache invalidated; new entries should show only collapsed "lib"
-      assert length(FileTree.visible_entries(tree)) == 1
-    end
-
-    @tag :tmp_dir
-    test "reveal invalidates cache and sees newly expanded paths", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join([tmp_dir, "lib", "minga"]))
+    test "reveal expands ancestors and selects the target file", %{tmp_dir: tmp_dir} do
+      mkdir(Path.join([tmp_dir, "lib", "minga"]))
       target = Path.join([tmp_dir, "lib", "minga", "editor.ex"])
-      File.write!(target, "")
+      touch(target)
 
-      tree = FileTree.new(tmp_dir) |> FileTree.ensure_entries()
-      # Only "lib" visible (collapsed)
-      assert length(tree.entries) == 1
+      tree = FileTree.new(tmp_dir) |> FileTree.reveal(target)
 
-      tree = FileTree.reveal(tree, target)
-      # Now lib, minga, and editor.ex are visible
-      assert length(tree.entries) == 3
-      assert FileTree.selected_entry(tree).name == "editor.ex"
+      assert names(tree) == ["lib", "minga", "editor.ex"]
+      assert selected_name(tree) == "editor.ex"
     end
 
     @tag :tmp_dir
-    test "selected_entry uses cached entries for cursor stability", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "a.txt"), "")
-      File.write!(Path.join(tmp_dir, "b.txt"), "")
+    test "visible entries expose renderer guide metadata", %{tmp_dir: tmp_dir} do
+      mkdir(Path.join([tmp_dir, "lib", "nested"]))
+      touch(Path.join([tmp_dir, "lib", "app.ex"]))
+      touch(Path.join([tmp_dir, "lib", "nested", "deep.ex"]))
+      touch(Path.join(tmp_dir, "mix.exs"))
 
-      # move_down calls ensure_entries internally, so cache is populated
+      entries =
+        tmp_dir
+        |> FileTree.new()
+        |> expand_path(["lib"])
+        |> expand_path(["lib", "nested"])
+        |> FileTree.visible_entries()
+
+      assert Enum.map(entries, &{&1.name, &1.depth, &1.last_child?, &1.guides}) == [
+               {"lib", 0, false, []},
+               {"nested", 1, false, [true]},
+               {"deep.ex", 2, true, [true, true]},
+               {"app.ex", 1, true, [true]},
+               {"mix.exs", 0, true, []}
+             ]
+    end
+  end
+
+  describe "cache and refresh" do
+    @tag :tmp_dir
+    test "ensure_entries caches visible entries until refresh", %{tmp_dir: tmp_dir} do
+      touch(Path.join(tmp_dir, "a.txt"))
+
+      tree = FileTree.new(tmp_dir) |> FileTree.ensure_entries()
+      touch(Path.join(tmp_dir, "b.txt"))
+
+      assert names(tree) == ["a.txt"]
+      assert tree |> FileTree.refresh() |> names() == ["a.txt", "b.txt"]
+    end
+
+    @tag :tmp_dir
+    test "structural operations recompute visible entries", %{tmp_dir: tmp_dir} do
+      mkdir(Path.join(tmp_dir, "src"))
+      touch(Path.join([tmp_dir, "src", "main.ex"]))
+      touch(Path.join(tmp_dir, ".env"))
+
+      tree = FileTree.new(tmp_dir) |> FileTree.ensure_entries()
+
+      assert names(FileTree.toggle_expand(tree)) == ["src", "main.ex"]
+      assert names(FileTree.toggle_hidden(tree)) == ["src", ".env"]
+    end
+
+    @tag :tmp_dir
+    test "refresh clamps selection after entries are removed", %{tmp_dir: tmp_dir} do
+      touch(Path.join(tmp_dir, "a.txt"))
+      touch(Path.join(tmp_dir, "b.txt"))
+
       tree = FileTree.new(tmp_dir) |> FileTree.move_down()
-      assert tree.entries != nil
-      entry = FileTree.selected_entry(tree)
-      assert entry.name == "b.txt"
+      File.rm!(Path.join(tmp_dir, "b.txt"))
 
-      # Even if a file is added that would sort before "b.txt",
-      # selected_entry on the same struct returns the same entry
-      File.write!(Path.join(tmp_dir, "aaa.txt"), "")
-      entry2 = FileTree.selected_entry(tree)
-      assert entry2.name == "b.txt"
+      assert tree |> FileTree.refresh() |> selected_name() == "a.txt"
     end
   end
 
   describe "filtering and re-rooting" do
     @tag :tmp_dir
-    test "set_filter narrows entries and descends into collapsed directories", %{tmp_dir: tmp_dir} do
-      File.mkdir_p!(Path.join(tmp_dir, "lib"))
-      File.write!(Path.join([tmp_dir, "lib", "target.ex"]), "")
-      File.write!(Path.join(tmp_dir, "other.txt"), "")
+    test "set_filter matches descendants without requiring expansion", %{tmp_dir: tmp_dir} do
+      mkdir(Path.join(tmp_dir, "lib"))
+      touch(Path.join([tmp_dir, "lib", "target.ex"]))
+      touch(Path.join(tmp_dir, "other.txt"))
 
       tree = FileTree.new(tmp_dir) |> FileTree.set_filter("target")
-      entries = FileTree.visible_entries(tree)
 
-      assert Enum.map(entries, & &1.name) == ["target.ex"]
-      assert hd(entries).depth == 1
-      assert FileTree.selected_entry(tree).name == "target.ex"
+      assert names(tree) == ["target.ex"]
+      assert FileTree.selected_entry(tree).depth == 1
+    end
+
+    @tag :tmp_dir
+    test "set_filter does not match every entry just because the root path matches", %{
+      tmp_dir: tmp_dir
+    } do
+      matching_root = Path.join(tmp_dir, "rootneedle")
+      mkdir(matching_root)
+      touch(Path.join(matching_root, "alpha.txt"))
+      touch(Path.join(matching_root, "beta.txt"))
+
+      assert matching_root
+             |> FileTree.new()
+             |> FileTree.set_filter("rootneedle")
+             |> FileTree.visible_entries() == []
     end
 
     @tag :tmp_dir
@@ -632,51 +284,39 @@ defmodule Minga.Project.FileTreeTest do
       root = Path.join(tmp_dir, "root")
       nested = Path.join(root, "nested")
       link = Path.join(root, "link")
-      File.mkdir_p!(nested)
-      File.write!(Path.join(nested, "target.ex"), "")
+      mkdir(nested)
+      touch(Path.join(nested, "target.ex"))
 
       case File.ln_s(nested, link) do
         :ok -> :ok
         {:error, reason} -> flunk("symlink creation failed: #{inspect(reason)}")
       end
 
-      tree = FileTree.new(root) |> FileTree.set_filter("target")
-      entries = FileTree.visible_entries(tree)
-
-      assert Enum.map(entries, & &1.path) == [Path.join(nested, "target.ex")]
+      assert root |> FileTree.new() |> FileTree.set_filter("target") |> paths() == [
+               Path.join(nested, "target.ex")
+             ]
     end
 
     @tag :tmp_dir
-    test "filter does not match every entry just because the root path matches", %{
-      tmp_dir: tmp_dir
-    } do
-      matching_root = Path.join(tmp_dir, "rootneedle")
-      File.mkdir_p!(matching_root)
-      File.write!(Path.join(matching_root, "alpha.txt"), "")
-      File.write!(Path.join(matching_root, "beta.txt"), "")
-
-      tree = FileTree.new(matching_root) |> FileTree.set_filter("rootneedle")
-
-      assert FileTree.visible_entries(tree) == []
-    end
-
-    @tag :tmp_dir
-    test "clear_filter restores the unfiltered visible entries", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "alpha.txt"), "")
-      File.write!(Path.join(tmp_dir, "beta.txt"), "")
+    test "clear_filter restores unfiltered entries", %{tmp_dir: tmp_dir} do
+      touch(Path.join(tmp_dir, "alpha.txt"))
+      touch(Path.join(tmp_dir, "beta.txt"))
 
       tree = tmp_dir |> FileTree.new() |> FileTree.set_filter("alpha") |> FileTree.clear_filter()
 
-      assert Enum.map(FileTree.visible_entries(tree), & &1.name) == ["alpha.txt", "beta.txt"]
+      assert names(tree) == ["alpha.txt", "beta.txt"]
     end
 
     @tag :tmp_dir
-    test "reroot preserves width, hidden setting, and filter", %{tmp_dir: tmp_dir} do
+    test "reroot preserves display settings and opens the new root", %{tmp_dir: tmp_dir} do
       next_root = Path.join(tmp_dir, "child")
-      File.mkdir_p!(next_root)
+      mkdir(next_root)
 
       tree =
-        FileTree.new(tmp_dir, width: 42) |> FileTree.toggle_hidden() |> FileTree.set_filter("ex")
+        tmp_dir
+        |> FileTree.new(width: 42)
+        |> FileTree.toggle_hidden()
+        |> FileTree.set_filter("ex")
 
       rerooted = FileTree.reroot(tree, next_root)
 

--- a/test/minga_editor/shell/traditional/tree_renderer_test.exs
+++ b/test/minga_editor/shell/traditional/tree_renderer_test.exs
@@ -1,5 +1,5 @@
 defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
-  @moduledoc "Tests TreeRenderer with focused RenderInput (no EditorState needed)."
+  @moduledoc "Tests TreeRenderer with focused RenderInput, keeping production-state extraction smoke coverage thin."
 
   use ExUnit.Case, async: true
 
@@ -18,143 +18,122 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
 
   @moduletag :tmp_dir
 
-  defp sample_tree(tmp_dir) do
-    # Create real files so FileTree.visible_entries works
-    File.mkdir_p!(Path.join(tmp_dir, "lib"))
-    File.write!(Path.join(tmp_dir, "lib/main.ex"), "defmodule Main do\nend\n")
-    File.mkdir_p!(Path.join(tmp_dir, "test"))
-    File.write!(Path.join(tmp_dir, "test/main_test.exs"), "defmodule MainTest do\nend\n")
+  describe "RenderInput rendering" do
+    test "renders header, entry draw tuples, and separator", %{tmp_dir: tmp_dir} do
+      root = Path.join(tmp_dir, "minga")
+      draws = render_input(root, width: 20, height: 10, focused: false)
 
-    tree = FileTree.new(tmp_dir, width: 20)
-    FileTree.expand_path(tree, Path.join(tmp_dir, "lib"))
-  end
-
-  describe "render/1 with RenderInput" do
-    test "renders tree entries as draw tuples", %{tmp_dir: tmp_dir} do
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 20, 10},
-        focused: true,
-        theme: Theme.get!(:doom_one),
-        active_path: nil
-      }
-
-      draws = TreeRenderer.render(input)
       assert [_ | _] = draws
       assert Enum.all?(draws, &(tuple_size(&1) == 4))
+
+      {0, 0, header, header_style} = draw_at(draws, 0, 0)
+      assert header =~ "\u{F0256}"
+      assert header =~ "minga"
+      assert header_style.bold == true
+
+      assert Enum.any?(draws, fn {_row, col, text, _style} -> col == 20 and text == "│" end)
     end
 
-    test "includes a header row with project name and folder icon", %{tmp_dir: tmp_dir} do
-      root = Path.join(tmp_dir, "minga")
+    test "renders filter and help overlay text", %{tmp_dir: tmp_dir} do
+      filter_text =
+        tmp_dir
+        |> render_input(width: 24, height: 6, filtering?: true, filter_text: "main")
+        |> draw_texts()
 
-      input = %RenderInput{
-        tree: sample_tree(root),
-        rect: {0, 0, 20, 10},
-        focused: false,
-        theme: Theme.get!(:doom_one),
-        active_path: nil
-      }
+      help_text =
+        tmp_dir
+        |> render_input(width: 72, height: 30, help_visible?: true)
+        |> draw_texts()
 
-      draws = TreeRenderer.render(input)
-      # Header is the draw at row 0, col 0 with bold style
-      header = Enum.find(draws, fn {r, c, _t, _s} -> r == 0 and c == 0 end)
-      assert header != nil
-      {_r, _c, text, style} = header
-      # Contains the folder open icon (nf-md-folder-open U+F0256) and project/root context.
-      assert String.contains?(text, "\u{F0256}")
-      assert String.contains?(text, "minga")
-      assert style.bold == true
+      assert filter_text =~ " / main▏"
+
+      for expected <- [
+            "Keyboard Shortcuts",
+            "Navigation",
+            "File Operations",
+            "Copy path",
+            "Mark copy / move",
+            "Paste",
+            "Parent root / selected root / project root",
+            "Filter tree",
+            "Toggle help"
+          ] do
+        assert help_text =~ expected
+      end
     end
 
-    test "renders filter prompt header while filtering", %{tmp_dir: tmp_dir} do
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 24, 6},
-        focused: true,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        filtering?: true,
-        filter_text: "main"
-      }
+    test "clips zero-height and height-one panels to the rect", %{tmp_dir: tmp_dir} do
+      assert render_input(tmp_dir, width: 20, height: 0) == []
 
-      draws = TreeRenderer.render(input)
-      assert draw_texts(draws) =~ " / main▏"
-    end
-
-    test "renders file tree help overlay contents", %{tmp_dir: tmp_dir} do
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 72, 30},
-        focused: true,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        help_visible?: true
-      }
-
-      draws = TreeRenderer.render(input)
-      text = draw_texts(draws)
-
-      assert text =~ "Keyboard Shortcuts"
-      assert text =~ "Navigation"
-      assert text =~ "File Operations"
-      assert text =~ "Copy path"
-      assert text =~ "Mark copy / move"
-      assert text =~ "Paste"
-      assert text =~ "Parent root / selected root / project root"
-      assert text =~ "Filter tree"
-      assert text =~ "Toggle help"
-    end
-
-    test "renders separator column", %{tmp_dir: tmp_dir} do
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 20, 10},
-        focused: false,
-        theme: Theme.get!(:doom_one),
-        active_path: nil
-      }
-
-      draws = TreeRenderer.render(input)
-      # Separator is at col 20 (width of tree rect)
-      sep_draws = Enum.filter(draws, fn {_r, c, text, _s} -> c == 20 and text == "│" end)
-      assert sep_draws != []
-    end
-
-    test "renders no off-rect rows for zero-height panels", %{tmp_dir: tmp_dir} do
-      draws =
-        TreeRenderer.render(%RenderInput{
-          tree: sample_tree(tmp_dir),
-          rect: {0, 0, 20, 0},
-          focused: false,
-          theme: Theme.get!(:doom_one),
-          active_path: nil
-        })
-
-      assert draws == []
-    end
-
-    test "height-one panels render only the header and one separator cell", %{tmp_dir: tmp_dir} do
-      draws =
-        TreeRenderer.render(%RenderInput{
-          tree: sample_tree(tmp_dir),
-          rect: {0, 0, 20, 1},
-          focused: false,
-          theme: Theme.get!(:doom_one),
-          active_path: nil
-        })
+      draws = render_input(tmp_dir, width: 20, height: 1)
 
       assert Enum.any?(draws, fn {row, col, text, _style} ->
                row == 0 and col == 0 and String.contains?(text, "\u{F0256}")
              end)
 
-      sep_draws =
-        Enum.filter(draws, fn {_row, col, text, _style} -> col == 20 and text == "│" end)
+      assert [{0, 20, "│", _style}] =
+               Enum.filter(draws, fn {_row, col, text, _style} -> col == 20 and text == "│" end)
 
-      assert [{0, 20, "│", _style}] = sep_draws
       refute Enum.any?(draws, fn {row, col, _text, _style} -> row > 0 and col < 20 end)
     end
 
-    test "production state render shows active and dirty row states", %{tmp_dir: tmp_dir} do
+    test "renders empty, loading, and error status rows without layout drift", %{tmp_dir: tmp_dir} do
+      cases = [
+        {:ready, "No files yet"},
+        {:loading, "Loading files"},
+        {{:error, "permission denied"}, "File tree error"}
+      ]
+
+      for {status, expected} <- cases do
+        draws = render_input(tmp_dir, width: 24, height: 5, rows: [], status: status)
+        text = draw_texts(draws)
+
+        assert text =~ expected
+        if match?({:error, _}, status), do: assert(text =~ "permission denied")
+        assert Enum.any?(draws, fn {_row, col, text, _style} -> col == 24 and text == "│" end)
+        refute Enum.any?(draws, fn {row, col, _text, _style} -> row < 0 or col < 0 end)
+      end
+    end
+
+    test "renders disclosure, guide, icon, and stable name columns", %{tmp_dir: tmp_dir} do
+      draws = render_input(tmp_dir, width: 30, height: 10, focused: false)
+      all_text = draw_texts(draws)
+
+      assert all_text =~ "▾ "
+      assert all_text =~ "▸ "
+      assert all_text =~ "│ "
+      refute all_text =~ "├─"
+      refute all_text =~ "└─"
+      assert all_text =~ "lib/"
+      assert all_text =~ "test/"
+      assert all_text =~ "\u{E62D}"
+
+      assert {1, 0, "▾ ", _style} = draw_matching(draws, "▾ ")
+      assert {1, 2, "\u{F0256} ", _style} = draw_matching(draws, "\u{F0256} ")
+      assert {1, 4, name, _style} = draw_containing(draws, "lib/")
+      assert String.starts_with?(name, "lib/")
+      assert length(row_draws(draws, 1)) >= 3
+    end
+
+    @tag timeout: 180_000
+    test "renders large trees around the selected row", %{tmp_dir: tmp_dir} do
+      tree = large_tree(tmp_dir, 600, width: 32) |> FileTree.select(599)
+      draws = render_input(tmp_dir, tree: tree, width: 32, height: 8, focused: true)
+      text = draw_texts(draws)
+
+      for name <-
+            Enum.map(594..600, &"file_#{String.pad_leading(Integer.to_string(&1), 3, "0")}.ex") do
+        assert text =~ name
+      end
+
+      refute text =~ "file_593.ex"
+      refute text =~ "file_001.ex"
+    end
+  end
+
+  describe "production state extraction" do
+    test "renders active and dirty row state from editor state", %{tmp_dir: tmp_dir} do
+      theme = Theme.get!(:doom_one)
       active_path = Path.join(tmp_dir, "active.ex")
       dirty_path = Path.join(tmp_dir, "dirty.ex")
       File.write!(active_path, "active")
@@ -164,474 +143,79 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       {:ok, dirty_buf} = BufferProcess.start_link(file_path: dirty_path)
       :ok = BufferProcess.insert_text(dirty_buf, "!")
 
-      tree = FileTree.new(tmp_dir, width: 32)
-      file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
-
-      state = gui_state(rows: 10, cols: 80)
-      state = put_in(state.workspace.file_tree, file_tree)
-
       state =
-        put_in(state.workspace.buffers, %Buffers{
+        gui_state(rows: 10, cols: 80)
+        |> put_in(
+          [Access.key(:workspace), Access.key(:file_tree)],
+          FileTreeState.open(%FileTreeState{}, FileTree.new(tmp_dir, width: 32), nil)
+        )
+        |> put_in([Access.key(:workspace), Access.key(:buffers)], %Buffers{
           active: active_buf,
           list: [active_buf, dirty_buf],
           active_index: 0
         })
 
       draws = TreeRenderer.render(state)
-      all_text = draw_texts(draws)
+      text = draw_texts(draws)
 
-      assert String.contains?(all_text, "active.ex")
-      assert String.contains?(all_text, "dirty.ex")
-      assert String.contains?(all_text, "●")
+      assert text =~ "active.ex"
+      assert text =~ "dirty.ex"
+      assert text =~ "●"
 
       {_row, _col, _text, active_style} = draw_containing(draws, "active.ex")
-      assert active_style.fg == Theme.get!(:doom_one).tree.active_fg
-      assert active_style.bold == true
-
       {_row, _col, _text, dirty_style} = draw_matching(draws, "●")
-      assert dirty_style.fg == Theme.get!(:doom_one).tree.modified_fg
-    end
-
-    test "production state render shows loading and error messages", %{tmp_dir: tmp_dir} do
-      tree = FileTree.new(tmp_dir, width: 24)
-      file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
-      theme = Theme.get!(:doom_one)
-
-      loading_draws =
-        TreeRenderer.render(%{
-          workspace: %{
-            file_tree: FileTreeState.loading(file_tree),
-            viewport: %{rows: 5, cols: 80},
-            buffers: %{active: nil, list: [], active_index: 0}
-          },
-          theme: theme
-        })
-
-      error_draws =
-        TreeRenderer.render(%{
-          workspace: %{
-            file_tree: FileTreeState.error(file_tree, :eacces),
-            viewport: %{rows: 5, cols: 80},
-            buffers: %{active: nil, list: [], active_index: 0}
-          },
-          theme: theme
-        })
-
-      assert draw_texts(loading_draws) =~ "Loading files"
-      assert draw_texts(error_draws) =~ "File tree error"
-      assert draw_texts(error_draws) =~ "permission denied"
-
-      for draws <- [loading_draws, error_draws] do
-        assert Enum.any?(draws, fn {_row, col, text, _style} -> col == 24 and text == "│" end)
-      end
-    end
-
-    test "renders empty loading and error rows without layout drift", %{tmp_dir: tmp_dir} do
-      tree = FileTree.new(tmp_dir, width: 24)
-      theme = Theme.get!(:doom_one)
-
-      empty_draws =
-        TreeRenderer.render(%RenderInput{
-          tree: tree,
-          rect: {0, 0, 24, 5},
-          focused: false,
-          theme: theme,
-          active_path: nil,
-          rows: []
-        })
-
-      loading_draws =
-        TreeRenderer.render(%RenderInput{
-          tree: tree,
-          rect: {0, 0, 24, 5},
-          focused: false,
-          theme: theme,
-          active_path: nil,
-          rows: [],
-          status: :loading
-        })
-
-      error_draws =
-        TreeRenderer.render(%RenderInput{
-          tree: tree,
-          rect: {0, 0, 24, 5},
-          focused: false,
-          theme: theme,
-          active_path: nil,
-          rows: [],
-          status: {:error, "permission denied"}
-        })
-
-      assert draw_texts(empty_draws) =~ "No files yet"
-      assert draw_texts(loading_draws) =~ "Loading files"
-      assert draw_texts(error_draws) =~ "File tree error"
-      assert draw_texts(error_draws) =~ "permission denied"
-
-      for draws <- [empty_draws, loading_draws, error_draws] do
-        assert Enum.any?(draws, fn {_row, col, text, _style} -> col == 24 and text == "│" end)
-        refute Enum.any?(draws, fn {row, col, _text, _style} -> row < 0 or col < 0 end)
-      end
-    end
-
-    test "renders indent guides and file icons", %{tmp_dir: tmp_dir} do
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 30, 10},
-        focused: false,
-        theme: Theme.get!(:doom_one),
-        active_path: nil
-      }
-
-      draws = TreeRenderer.render(input)
-      texts = Enum.map(draws, fn {_r, _c, text, _s} -> text end)
-      all_text = Enum.join(texts)
-
-      # Disclosure symbols replace heavy connector branch art.
-      assert String.contains?(all_text, "▾ ")
-      assert String.contains?(all_text, "▸ ")
-      refute String.contains?(all_text, "├─")
-      refute String.contains?(all_text, "└─")
-      # Expanded lib/ should still produce a quiet ancestor guide for its children.
-      assert String.contains?(all_text, "│ ")
-
-      # Directory names should have trailing slashes
-      assert String.contains?(all_text, "lib/")
-      assert String.contains?(all_text, "test/")
-
-      # File entries should have Elixir icon (U+E62D)
-      assert String.contains?(all_text, "\u{E62D}")
-    end
-
-    test "renders multiple draw commands per entry row for icon coloring", %{tmp_dir: tmp_dir} do
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 30, 10},
-        focused: false,
-        theme: Theme.get!(:doom_one),
-        active_path: nil
-      }
-
-      draws = TreeRenderer.render(input)
-      # Row 1 is the first entry (lib/ directory). It should have multiple draws:
-      # structure segment, icon segment, name segment
-      row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
-      assert length(row1_draws) >= 3
-    end
-
-    test "uses stable disclosure icon and name columns", %{tmp_dir: tmp_dir} do
-      draws =
-        TreeRenderer.render(%RenderInput{
-          tree: sample_tree(tmp_dir),
-          rect: {0, 0, 30, 10},
-          focused: false,
-          theme: Theme.get!(:doom_one),
-          active_path: nil
-        })
-
-      assert {1, 0, "▾ ", _style} = draw_matching(draws, "▾ ")
-      assert {1, 2, "\u{F0256} ", _style} = draw_matching(draws, "\u{F0256} ")
-      assert {1, 4, name, _style} = draw_containing(draws, "lib/")
-      assert String.starts_with?(name, "lib/")
-    end
-
-    @tag timeout: 180_000
-    test "renders production state for large trees around the selected row", %{tmp_dir: tmp_dir} do
-      for index <- 1..600 do
-        File.write!(
-          Path.join(tmp_dir, "file_#{String.pad_leading(Integer.to_string(index), 3, "0")}.ex"),
-          ""
-        )
-      end
-
-      tree = FileTree.new(tmp_dir, width: 32) |> FileTree.select(599)
-      file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
-
-      draws =
-        TreeRenderer.render(%{
-          workspace: %{
-            file_tree: %{file_tree | focused: true},
-            viewport: %{rows: 10, cols: 80},
-            buffers: %{active: nil, list: [], active_index: 0}
-          },
-          theme: Theme.get!(:doom_one)
-        })
-
-      all_text = draw_texts(draws)
-
-      for name <- [
-            "file_594.ex",
-            "file_595.ex",
-            "file_596.ex",
-            "file_597.ex",
-            "file_598.ex",
-            "file_599.ex",
-            "file_600.ex"
-          ] do
-        assert String.contains?(all_text, name)
-      end
-
-      refute String.contains?(all_text, "file_593.ex")
-      refute String.contains?(all_text, "file_001.ex")
-      assert String.contains?(all_text, "file_600.ex")
-    end
-
-    @tag timeout: 180_000
-    test "renders large RenderInput trees around the selected row", %{tmp_dir: tmp_dir} do
-      for index <- 1..600 do
-        File.write!(
-          Path.join(tmp_dir, "file_#{String.pad_leading(Integer.to_string(index), 3, "0")}.ex"),
-          ""
-        )
-      end
-
-      tree = FileTree.new(tmp_dir, width: 32) |> FileTree.select(599)
-
-      draws =
-        TreeRenderer.render(%RenderInput{
-          tree: tree,
-          rect: {0, 0, 32, 8},
-          focused: true,
-          theme: Theme.get!(:doom_one),
-          active_path: nil
-        })
-
-      all_text = draw_texts(draws)
-
-      for name <- [
-            "file_594.ex",
-            "file_595.ex",
-            "file_596.ex",
-            "file_597.ex",
-            "file_598.ex",
-            "file_599.ex",
-            "file_600.ex"
-          ] do
-        assert String.contains?(all_text, name)
-      end
-
-      refute String.contains?(all_text, "file_593.ex")
-      refute String.contains?(all_text, "file_001.ex")
-    end
-
-    test "renders supplied semantic rows", %{tmp_dir: tmp_dir} do
-      file_path = Path.join(tmp_dir, "main.ex")
-      File.write!(file_path, "defmodule Main do\nend\n")
-      tree = FileTree.new(tmp_dir, width: 30)
-
-      rows = [
-        Row.new(
-          id: file_path,
-          path: file_path,
-          relative_path: "main.ex",
-          name: "main.ex",
-          directory?: false,
-          expanded?: false,
-          selected?: true,
-          focused?: true,
-          active?: true,
-          dirty?: true,
-          git_status: :modified,
-          depth: 0,
-          guides: [],
-          last_child?: true
-        )
-      ]
-
-      input = %RenderInput{
-        tree: tree,
-        rect: {0, 0, 30, 5},
-        focused: false,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        rows: rows
-      }
-
-      draws = TreeRenderer.render(input)
-      all_text = Enum.map_join(draws, fn {_r, _c, text, _s} -> text end)
-
-      assert String.contains?(all_text, "main.ex")
-      assert String.contains?(all_text, "●")
-    end
-
-    test "renders git status indicators right-aligned", %{tmp_dir: tmp_dir} do
-      tree = sample_tree(tmp_dir)
-      main_path = Path.join(tmp_dir, "lib/main.ex")
-
-      input = %RenderInput{
-        tree: tree,
-        rect: {0, 0, 30, 10},
-        focused: false,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        git_status: %{main_path => :modified}
-      }
-
-      draws = TreeRenderer.render(input)
-      texts = Enum.map(draws, fn {_r, _c, text, _s} -> text end)
-      all_text = Enum.join(texts)
-
-      # The modified indicator symbol should appear
-      assert String.contains?(all_text, "●")
-    end
-
-    test "git status indicator has correct theme color", %{tmp_dir: tmp_dir} do
-      tree = sample_tree(tmp_dir)
-      main_path = Path.join(tmp_dir, "lib/main.ex")
-      theme = Theme.get!(:doom_one)
-
-      input = %RenderInput{
-        tree: tree,
-        rect: {0, 0, 30, 10},
-        focused: false,
-        theme: theme,
-        active_path: nil,
-        git_status: %{main_path => :staged}
-      }
-
-      draws = TreeRenderer.render(input)
-      # Find the draw that contains the staged symbol
-      staged_draw = Enum.find(draws, fn {_r, _c, text, _s} -> String.contains?(text, "✚") end)
-      assert staged_draw != nil
-      {_r, _c, _text, style} = staged_draw
-      assert style.fg == theme.tree.git_staged_fg
-    end
-
-    test "renders modified buffer dot for dirty files", %{tmp_dir: tmp_dir} do
-      tree = sample_tree(tmp_dir)
-      main_path = Path.join(tmp_dir, "lib/main.ex")
-
-      input = %RenderInput{
-        tree: tree,
-        rect: {0, 0, 30, 10},
-        focused: false,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        dirty_paths: MapSet.new([main_path])
-      }
-
-      draws = TreeRenderer.render(input)
-
-      # Find draws for the row containing main.ex (should have the dirty dot)
-      # The dirty dot is ● with the modified_fg color
-      dirty_draws =
-        Enum.filter(draws, fn {_r, _c, text, _s} ->
-          text == "●"
-        end)
-
-      assert dirty_draws != []
-
-      {_r, _c, _text, style} = hd(dirty_draws)
-      theme = Theme.get!(:doom_one)
-      assert style.fg == theme.tree.modified_fg
-    end
-
-    test "dirty dot and git status coexist on same row", %{tmp_dir: tmp_dir} do
-      tree = sample_tree(tmp_dir)
-      main_path = Path.join(tmp_dir, "lib/main.ex")
-
-      input = %RenderInput{
-        tree: tree,
-        rect: {0, 0, 30, 10},
-        focused: false,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        git_status: %{main_path => :modified},
-        dirty_paths: MapSet.new([main_path])
-      }
-
-      draws = TreeRenderer.render(input)
-      texts = Enum.map(draws, fn {_r, _c, text, _s} -> text end)
-      all_text = Enum.join(texts)
-
-      # Both the dirty dot (●) and git modified indicator (●) should appear
-      # The dirty dot is bare "●", the git one is " ●"
-      assert String.contains?(all_text, "●")
-    end
-
-    test "no dirty dot for directories", %{tmp_dir: tmp_dir} do
-      tree = sample_tree(tmp_dir)
-      lib_path = Path.join(tmp_dir, "lib")
-
-      input = %RenderInput{
-        tree: tree,
-        rect: {0, 0, 30, 10},
-        focused: false,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        dirty_paths: MapSet.new([lib_path])
-      }
-
-      draws = TreeRenderer.render(input)
-      # The lib/ row should NOT have a dirty dot (dirs excluded)
-      # Find the lib/ entry row draws
-      # Only file entries get the dot, not directories
-      # lib/ shouldn't have a bare "●" (only guide/icon/name draws)
-      lib_row_draws =
-        Enum.filter(draws, fn {r, _c, text, _s} ->
-          r == 1 and text == "●"
-        end)
-
-      assert lib_row_draws == []
-    end
-
-    test "active plus selected keeps selection background and active name accent", %{
-      tmp_dir: tmp_dir
-    } do
-      theme = Theme.get!(:doom_one)
-      row = semantic_file_row(tmp_dir, selected?: true, focused?: true, active?: true)
-
-      draws = render_semantic_rows(tmp_dir, [row], theme)
-      {_r, _c, _text, style} = draw_containing(draws, "main.ex")
-
-      assert style.fg == theme.tree.active_fg
-      assert style.bg == theme.tree.cursor_bg
-      assert style.bold == true
-    end
-
-    test "active plus git modified preserves independent git marker", %{tmp_dir: tmp_dir} do
-      theme = Theme.get!(:doom_one)
-      row = semantic_file_row(tmp_dir, active?: true, git_status: :modified)
-
-      draws = render_semantic_rows(tmp_dir, [row], theme)
-      {_r, _c, _text, name_style} = draw_containing(draws, "main.ex")
-      {_r, _c, _text, git_style} = draw_matching(draws, " ●")
-
-      assert name_style.fg == theme.tree.active_fg
-      assert git_style.fg == theme.tree.git_modified_fg
-      assert git_style.bg == theme.tree.bg
-    end
-
-    test "selected plus dirty keeps dirty marker visible on selection background", %{
-      tmp_dir: tmp_dir
-    } do
-      theme = Theme.get!(:doom_one)
-      row = semantic_file_row(tmp_dir, selected?: true, focused?: true, dirty?: true)
-
-      draws = render_semantic_rows(tmp_dir, [row], theme)
-      {_r, _c, _text, dirty_style} = draw_matching(draws, "●")
-
+      assert active_style.fg == theme.tree.active_fg
+      assert active_style.bold == true
       assert dirty_style.fg == theme.tree.modified_fg
-      assert dirty_style.bg == theme.tree.cursor_bg
-      assert dirty_style.bold == true
     end
 
-    test "diagnostic dirty and git markers remain separate on selected rows", %{tmp_dir: tmp_dir} do
+    test "renders loading and error status from file tree state", %{tmp_dir: tmp_dir} do
+      tree = FileTree.new(tmp_dir, width: 24)
+      file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
+
+      for {file_tree, expected} <- [
+            {FileTreeState.loading(file_tree), "Loading files"},
+            {FileTreeState.error(file_tree, :eacces), "permission denied"}
+          ] do
+        draws = TreeRenderer.render(production_state(file_tree, rows: 5, cols: 80))
+        assert draw_texts(draws) =~ expected
+        assert Enum.any?(draws, fn {_row, col, text, _style} -> col == 24 and text == "│" end)
+      end
+    end
+  end
+
+  describe "semantic row rendering" do
+    test "renders supplied semantic rows and independent status marker styles", %{
+      tmp_dir: tmp_dir
+    } do
       theme = Theme.get!(:doom_one)
 
       row =
         semantic_file_row(tmp_dir,
           selected?: true,
           focused?: true,
+          active?: true,
           dirty?: true,
           git_status: :conflict,
           diagnostics: RowDiagnostics.new({2, 0, 0, 0})
         )
 
       draws = render_semantic_rows(tmp_dir, [row], theme)
-      {_r, _c, _text, diagnostic_style} = draw_matching(draws, "✖2")
-      {_r, _c, _text, dirty_style} = draw_matching(draws, "●")
-      {_r, _c, _text, git_style} = draw_matching(draws, " !")
+      text = draw_texts(draws)
 
+      assert text =~ "main.ex"
+      assert text =~ "✖2"
+      assert text =~ "●"
+      assert text =~ " !"
+
+      {_row, _col, _text, name_style} = draw_containing(draws, "main.ex")
+      {_row, _col, _text, diagnostic_style} = draw_matching(draws, "✖2")
+      {_row, _col, _text, dirty_style} = draw_matching(draws, "●")
+      {_row, _col, _text, git_style} = draw_matching(draws, " !")
+
+      assert name_style.fg == theme.tree.active_fg
+      assert name_style.bg == theme.tree.cursor_bg
+      assert name_style.bold == true
       assert diagnostic_style.fg == theme.gutter.error_fg
       assert diagnostic_style.bg == theme.tree.cursor_bg
       assert dirty_style.fg == theme.tree.modified_fg
@@ -648,22 +232,8 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
           diagnostics: RowDiagnostics.new({0, 1, 0, 0})
         )
 
-      draws =
-        TreeRenderer.render(%RenderInput{
-          tree: FileTree.new(tmp_dir, width: 12),
-          rect: {0, 0, 12, 5},
-          focused: false,
-          theme: Theme.get!(:doom_one),
-          active_path: nil,
-          rows: [row]
-        })
-
-      row_text =
-        draws
-        |> Enum.filter(fn {r, c, _t, _s} -> r == 1 and c < 12 end)
-        |> Enum.sort_by(fn {_r, c, _t, _s} -> c end)
-        |> Enum.map_join(fn {_r, _c, text, _s} -> text end)
-
+      draws = render_semantic_rows(tmp_dir, [row], Theme.get!(:doom_one), width: 12)
+      row_text = rendered_row_text(draws, 1, 12)
       diagnostic_draw = draw_matching(draws, "⚠")
       dirty_draw = draw_matching(draws, "●")
       git_draw = draw_matching(draws, " ●")
@@ -676,70 +246,48 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
       assert draw_col(dirty_draw) < draw_col(git_draw)
     end
 
-    test "deep nested unicode rows preserve basename tail and status within display width", %{
-      tmp_dir: tmp_dir
-    } do
+    test "unicode basename tails and statuses fit in narrow rows", %{tmp_dir: tmp_dir} do
       path = Path.join(tmp_dir, "lib/minga_editor/shell/traditional/非常に長い_component_view.ex")
 
       row =
-        Row.new(
-          id: path,
+        semantic_file_row(tmp_dir,
           path: path,
-          relative_path: "lib/minga_editor/shell/traditional/非常に長い_component_view.ex",
           name: "非常に長い_component_view.ex",
-          directory?: false,
-          expanded?: false,
-          selected?: true,
-          focused?: true,
-          active?: false,
-          dirty?: true,
-          git_status: :modified,
-          diagnostics: RowDiagnostics.new({0, 1, 0, 0}),
           depth: 8,
           guides: [true, true, false, true, false, true, true, false],
-          last_child?: true
+          dirty?: true,
+          git_status: :modified,
+          diagnostics: RowDiagnostics.new({0, 1, 0, 0})
         )
 
       draws =
-        TreeRenderer.render(%RenderInput{
-          tree: FileTree.new(tmp_dir, width: 18),
-          rect: {0, 0, 18, 5},
-          focused: true,
-          theme: Theme.get!(:doom_one),
-          active_path: nil,
-          rows: [row]
-        })
+        render_semantic_rows(tmp_dir, [row], Theme.get!(:doom_one), width: 18, focused: true)
 
       row_text = rendered_row_text(draws, 1, 18)
 
       assert Unicode.display_width(row_text) <= 18
-      assert String.contains?(row_text, "…")
-      assert String.contains?(row_text, ".ex")
+      assert row_text =~ "…"
+      assert row_text =~ ".ex"
       assert draw_matching(draws, "⚠") != nil
       assert draw_matching(draws, "●") != nil
       assert draw_matching(draws, " ●") != nil
     end
 
-    test "deep nested fixture renders long unicode children within narrow tree width", %{
-      tmp_dir: tmp_dir
-    } do
-      tree = nested_fixture_tree(tmp_dir, width: 18)
-
+    test "actual nested unicode file tree rows fit within narrow tree width", %{tmp_dir: tmp_dir} do
       target_path =
         Path.join(tmp_dir, "lib/minga_editor/shell/traditional/非常に長い_component_view.ex")
 
       draws =
-        TreeRenderer.render(%RenderInput{
-          tree: tree,
-          rect: {0, 0, 18, 12},
-          focused: false,
-          theme: Theme.get!(:doom_one),
-          active_path: nil,
+        render_input(tmp_dir,
+          tree: nested_fixture_tree(tmp_dir, width: 18),
+          width: 18,
+          height: 12,
           git_status: %{target_path => :modified},
           dirty_paths: MapSet.new([target_path])
-        })
+        )
 
-      row_draws = Enum.filter(draws, fn {_r, _c, text, _s} -> String.contains?(text, ".ex") end)
+      row_draws =
+        Enum.filter(draws, fn {_row, _col, text, _style} -> String.contains?(text, ".ex") end)
 
       assert row_draws != []
 
@@ -756,36 +304,113 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
           diagnostics: RowDiagnostics.new({120, 0, 0, 0})
         )
 
-      draws =
-        TreeRenderer.render(%RenderInput{
-          tree: FileTree.new(tmp_dir, width: 10),
-          rect: {0, 0, 10, 5},
-          focused: false,
-          theme: Theme.get!(:doom_one),
-          active_path: nil,
-          rows: [row]
-        })
-
-      row_text =
-        draws
-        |> Enum.filter(fn {r, c, _t, _s} -> r == 1 and c < 10 end)
-        |> Enum.sort_by(fn {_r, c, _t, _s} -> c end)
-        |> Enum.map_join(fn {_r, _c, text, _s} -> text end)
+      draws = render_semantic_rows(tmp_dir, [row], Theme.get!(:doom_one), width: 10)
+      row_text = rendered_row_text(draws, 1, 10)
 
       assert Unicode.display_width(row_text) <= 10
-      assert String.contains?(row_text, "✖9+")
+      assert row_text =~ "✖9+"
     end
 
-    test "unfocused selected row uses subdued selection background", %{tmp_dir: tmp_dir} do
+    test "unfocused selected rows use subdued selection background", %{tmp_dir: tmp_dir} do
       theme = Theme.get!(:doom_one)
       row = semantic_file_row(tmp_dir, selected?: true, focused?: false)
-
       draws = render_semantic_rows(tmp_dir, [row], theme)
-      {_r, _c, _text, style} = draw_containing(draws, "main.ex")
+      {_row, _col, _text, style} = draw_containing(draws, "main.ex")
 
       assert style.bg == theme.tree.separator_fg
       refute style.bg == theme.tree.cursor_bg
     end
+  end
+
+  describe "editing entry rendering" do
+    test "editing row renders inverse bold text, cursor, folder icon, and depth guides", %{
+      tmp_dir: tmp_dir
+    } do
+      theme = Theme.get!(:doom_one)
+
+      file_draws =
+        render_input(tmp_dir,
+          width: 30,
+          height: 10,
+          focused: true,
+          editing: %{index: 0, text: "new_file.ex", type: :new_file, original_name: nil}
+        )
+
+      folder_draws =
+        render_input(tmp_dir,
+          width: 30,
+          height: 10,
+          focused: true,
+          editing: %{index: 0, text: "new_dir", type: :new_folder, original_name: nil}
+        )
+
+      nested_draws =
+        render_input(tmp_dir,
+          width: 30,
+          height: 10,
+          focused: true,
+          editing: %{index: 1, text: "renamed.ex", type: :rename, original_name: "main.ex"}
+        )
+
+      {_row, _col, _text, file_style} = draw_containing(row_draws(file_draws, 1), "new_file.ex▏")
+      folder_text = row_text(folder_draws, 1)
+      nested_text = row_text(nested_draws, 2)
+
+      assert file_style.fg == theme.tree.bg
+      assert file_style.bg == theme.tree.dir_fg
+      assert file_style.bold == true
+      assert folder_text =~ "\u{F0256}"
+      assert folder_text =~ "new_dir▏"
+      assert nested_text =~ "renamed.ex▏"
+      assert nested_text =~ "│ " or nested_text =~ "  "
+      refute nested_text =~ "└─"
+      refute nested_text =~ "├─"
+    end
+
+    test "empty editing text still renders a cursor and non-edited rows keep normal styling", %{
+      tmp_dir: tmp_dir
+    } do
+      theme = Theme.get!(:doom_one)
+
+      draws =
+        render_input(tmp_dir,
+          width: 30,
+          height: 10,
+          focused: true,
+          editing: %{index: 0, text: "", type: :new_file, original_name: nil}
+        )
+
+      assert row_text(draws, 1) =~ "▏"
+
+      assert Enum.any?(row_draws(draws, 2), fn {_row, _col, _text, style} ->
+               style.bg == theme.tree.bg
+             end)
+    end
+  end
+
+  defp sample_tree(tmp_dir, opts) do
+    width = Keyword.get(opts, :width, 20)
+    File.mkdir_p!(Path.join(tmp_dir, "lib"))
+    File.write!(Path.join(tmp_dir, "lib/main.ex"), "defmodule Main do\nend\n")
+    File.mkdir_p!(Path.join(tmp_dir, "test"))
+    File.write!(Path.join(tmp_dir, "test/main_test.exs"), "defmodule MainTest do\nend\n")
+
+    tmp_dir
+    |> FileTree.new(width: width)
+    |> FileTree.expand_path(Path.join(tmp_dir, "lib"))
+  end
+
+  defp large_tree(tmp_dir, count, opts) do
+    width = Keyword.fetch!(opts, :width)
+
+    for index <- 1..count do
+      File.write!(
+        Path.join(tmp_dir, "file_#{String.pad_leading(Integer.to_string(index), 3, "0")}.ex"),
+        ""
+      )
+    end
+
+    FileTree.new(tmp_dir, width: width)
   end
 
   defp nested_fixture_tree(tmp_dir, opts) do
@@ -803,30 +428,73 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
 
     File.write!(Path.join(sibling_dir, "card.ex"), "defmodule Card do\nend\n")
 
-    FileTree.new(tmp_dir, width: width)
+    tmp_dir
+    |> FileTree.new(width: width)
     |> FileTree.expand_path(Path.join(tmp_dir, "lib"))
     |> FileTree.expand_path(Path.join(tmp_dir, "lib/minga_editor"))
     |> FileTree.expand_path(Path.join(tmp_dir, "lib/minga_editor/shell"))
     |> FileTree.expand_path(deep_dir)
   end
 
-  defp rendered_row_text(draws, row, width) do
-    draws
-    |> Enum.filter(fn {draw_row, col, _t, _s} -> draw_row == row and col < width end)
-    |> Enum.sort_by(fn {_r, col, _t, _s} -> col end)
-    |> Enum.map_join(fn {_r, _c, text, _s} -> text end)
+  defp render_input(tmp_dir, opts) do
+    width = Keyword.get(opts, :width, 30)
+    height = Keyword.get(opts, :height, 10)
+    tree = Keyword.get_lazy(opts, :tree, fn -> sample_tree(tmp_dir, width: width) end)
+
+    TreeRenderer.render(%RenderInput{
+      tree: tree,
+      rect: {0, 0, width, height},
+      focused: Keyword.get(opts, :focused, false),
+      theme: Keyword.get_lazy(opts, :theme, fn -> Theme.get!(:doom_one) end),
+      active_path: Keyword.get(opts, :active_path),
+      editing: Keyword.get(opts, :editing),
+      git_status: Keyword.get(opts, :git_status, %{}),
+      dirty_paths: Keyword.get(opts, :dirty_paths, MapSet.new()),
+      rows: Keyword.get(opts, :rows),
+      status: Keyword.get(opts, :status, :ready),
+      filter_text: Keyword.get(opts, :filter_text),
+      filtering?: Keyword.get(opts, :filtering?, false),
+      help_visible?: Keyword.get(opts, :help_visible?, false)
+    })
+  end
+
+  defp production_state(file_tree, opts) do
+    rows = Keyword.fetch!(opts, :rows)
+    cols = Keyword.fetch!(opts, :cols)
+
+    %{
+      workspace: %{
+        file_tree: file_tree,
+        viewport: %{rows: rows, cols: cols},
+        buffers: %{active: nil, list: [], active_index: 0}
+      },
+      theme: Theme.get!(:doom_one)
+    }
+  end
+
+  defp render_semantic_rows(tmp_dir, rows, theme, opts \\ []) do
+    width = Keyword.get(opts, :width, 30)
+
+    TreeRenderer.render(%RenderInput{
+      tree: FileTree.new(tmp_dir, width: width),
+      rect: {0, 0, width, 5},
+      focused: Keyword.get(opts, :focused, false),
+      theme: theme,
+      active_path: nil,
+      rows: rows
+    })
   end
 
   defp semantic_file_row(tmp_dir, attrs) do
-    file_path = Path.join(tmp_dir, "main.ex")
+    file_path = Keyword.get(attrs, :path, Path.join(tmp_dir, "main.ex"))
 
     Row.new(
       Keyword.merge(
         [
           id: file_path,
           path: file_path,
-          relative_path: "main.ex",
-          name: "main.ex",
+          relative_path: Path.relative_to(file_path, tmp_dir),
+          name: Path.basename(file_path),
           directory?: false,
           expanded?: false,
           selected?: false,
@@ -843,183 +511,33 @@ defmodule MingaEditor.Shell.Traditional.TreeRendererTest do
     )
   end
 
-  defp render_semantic_rows(tmp_dir, rows, theme) do
-    TreeRenderer.render(%RenderInput{
-      tree: FileTree.new(tmp_dir, width: 30),
-      rect: {0, 0, 30, 5},
-      focused: false,
-      theme: theme,
-      active_path: nil,
-      rows: rows
-    })
-  end
+  defp draw_texts(draws), do: Enum.map_join(draws, fn {_row, _col, text, _style} -> text end)
 
-  defp draw_texts(draws) do
-    Enum.map_join(draws, fn {_r, _c, text, _style} -> text end)
-  end
+  defp draw_at(draws, row, col),
+    do:
+      Enum.find(draws, fn {draw_row, draw_col, _text, _style} ->
+        draw_row == row and draw_col == col
+      end)
 
-  defp draw_containing(draws, text) do
-    Enum.find(draws, fn {_r, _c, draw_text, _style} -> String.contains?(draw_text, text) end)
-  end
+  defp draw_containing(draws, text),
+    do:
+      Enum.find(draws, fn {_row, _col, draw_text, _style} -> String.contains?(draw_text, text) end)
 
-  defp draw_matching(draws, text) do
-    Enum.find(draws, fn {_r, _c, draw_text, _style} -> draw_text == text end)
-  end
+  defp draw_matching(draws, text),
+    do: Enum.find(draws, fn {_row, _col, draw_text, _style} -> draw_text == text end)
 
-  defp draw_col({_r, col, _text, _style}), do: col
+  defp draw_col({_row, col, _text, _style}), do: col
 
-  describe "editing entry rendering" do
-    test "editing entry renders with inverse video styling", %{tmp_dir: tmp_dir} do
-      theme = Theme.get!(:doom_one)
+  defp row_draws(draws, row),
+    do: Enum.filter(draws, fn {draw_row, _col, _text, _style} -> draw_row == row end)
 
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 30, 10},
-        focused: true,
-        theme: theme,
-        active_path: nil,
-        editing: %{index: 0, text: "new_file.ex", type: :new_file, original_name: nil}
-      }
+  defp row_text(draws, row),
+    do: draws |> row_draws(row) |> Enum.map_join(fn {_row, _col, text, _style} -> text end)
 
-      draws = TreeRenderer.render(input)
-
-      # Row 1 is the first entry (header is row 0). Find the text segment.
-      row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
-      assert row1_draws != []
-
-      # The text segment should have inverse video: fg = tree.bg, bg = tree.dir_fg
-      text_draw =
-        Enum.find(row1_draws, fn {_r, _c, text, _s} -> String.contains?(text, "new_file.ex") end)
-
-      assert text_draw != nil
-      {_r, _c, _text, style} = text_draw
-      assert style.fg == theme.tree.bg
-      assert style.bg == theme.tree.dir_fg
-    end
-
-    test "editing entry shows cursor indicator at end of text", %{tmp_dir: tmp_dir} do
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 30, 10},
-        focused: true,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        editing: %{index: 0, text: "hello", type: :new_file, original_name: nil}
-      }
-
-      draws = TreeRenderer.render(input)
-      row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
-      texts = Enum.map(row1_draws, fn {_r, _c, text, _s} -> text end)
-      all_text = Enum.join(texts)
-
-      # Should contain the text followed by the cursor indicator
-      assert String.contains?(all_text, "hello▏")
-    end
-
-    test "editing entry with empty text shows only cursor indicator", %{tmp_dir: tmp_dir} do
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 30, 10},
-        focused: true,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        editing: %{index: 0, text: "", type: :new_file, original_name: nil}
-      }
-
-      draws = TreeRenderer.render(input)
-      row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
-      texts = Enum.map(row1_draws, fn {_r, _c, text, _s} -> text end)
-      all_text = Enum.join(texts)
-
-      assert String.contains?(all_text, "▏")
-    end
-
-    test "editing entry shows correct indent guides at depth", %{tmp_dir: tmp_dir} do
-      # main.ex is inside expanded lib/, so it has depth > 0 and should have guides.
-      # Index 1 in sample_tree is lib/main.ex (inside expanded lib/).
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 30, 10},
-        focused: true,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        editing: %{index: 1, text: "renamed.ex", type: :rename, original_name: "main.ex"}
-      }
-
-      draws = TreeRenderer.render(input)
-      row2_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 2 end)
-      texts = Enum.map(row2_draws, fn {_r, _c, text, _s} -> text end)
-      all_text = Enum.join(texts)
-
-      # The entry at depth 1 should keep a quiet structure column without heavy branch art.
-      assert String.contains?(all_text, "│ ") or String.contains?(all_text, "  ")
-      refute String.contains?(all_text, "└─")
-      refute String.contains?(all_text, "├─")
-    end
-
-    test "non-editing entries render normally when editing is active", %{tmp_dir: tmp_dir} do
-      theme = Theme.get!(:doom_one)
-
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 30, 10},
-        focused: false,
-        theme: theme,
-        active_path: nil,
-        editing: %{index: 0, text: "new.txt", type: :new_file, original_name: nil}
-      }
-
-      draws = TreeRenderer.render(input)
-
-      # Row 2 is the second entry (not being edited). It should have normal styling.
-      row2_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 2 end)
-      assert row2_draws != []
-
-      # Non-editing, non-cursor entries should have the normal tree bg
-      name_draw =
-        Enum.find(row2_draws, fn {_r, _c, _text, style} -> style.bg == theme.tree.bg end)
-
-      assert name_draw != nil
-    end
-
-    test "editing type :new_folder shows folder icon", %{tmp_dir: tmp_dir} do
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 30, 10},
-        focused: true,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        editing: %{index: 0, text: "new_dir", type: :new_folder, original_name: nil}
-      }
-
-      draws = TreeRenderer.render(input)
-      row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
-      texts = Enum.map(row1_draws, fn {_r, _c, text, _s} -> text end)
-      all_text = Enum.join(texts)
-
-      # Should contain the folder-open icon (U+F0256)
-      assert String.contains?(all_text, "\u{F0256}")
-    end
-
-    test "editing text style is bold", %{tmp_dir: tmp_dir} do
-      input = %RenderInput{
-        tree: sample_tree(tmp_dir),
-        rect: {0, 0, 30, 10},
-        focused: true,
-        theme: Theme.get!(:doom_one),
-        active_path: nil,
-        editing: %{index: 0, text: "test.txt", type: :new_file, original_name: nil}
-      }
-
-      draws = TreeRenderer.render(input)
-      row1_draws = Enum.filter(draws, fn {r, _c, _t, _s} -> r == 1 end)
-
-      text_draw =
-        Enum.find(row1_draws, fn {_r, _c, text, _s} -> String.contains?(text, "test.txt") end)
-
-      assert text_draw != nil
-      {_r, _c, _text, style} = text_draw
-      assert style.bold == true
-    end
+  defp rendered_row_text(draws, row, width) do
+    draws
+    |> Enum.filter(fn {draw_row, col, _text, _style} -> draw_row == row and col < width end)
+    |> Enum.sort_by(fn {_row, col, _text, _style} -> col end)
+    |> Enum.map_join(fn {_row, _col, text, _style} -> text end)
   end
 end


### PR DESCRIPTION
# TL;DR
This PR does an aggressive test-only cleanup pass across four suites, reducing repeated one-case-per-variant coverage while keeping the public behavior contracts covered.

## Context
This continues the Sandi Metz-style test boundary cleanup: test public behavior at the cheapest useful layer, keep integration smoke checks thin, and avoid preserving brittle structure assertions just because they existed.

## Changes
- Collapses `FileTree` tests around visible behavior: sorting, hidden/ignored filtering, expansion, navigation, reveal, guides, cache/refresh, filtering, and rerooting.
- Collapses conceal range examples while preserving all 7 property tests for column mapping and overlap invariants.
- Collapses tree renderer tests around focused `RenderInput` behavior, semantic row rendering, production-state extraction smoke checks, status fitting, unicode width behavior, and editing row rendering.
- Consolidates loader invalid-config cases into one table-driven test while leaving the broader filesystem/env-sensitive loader suite intact.

## Verification
- `mix test.debug test/minga/project/file_tree_test.exs` → `21 tests, 0 failures`
- `mix test.debug test/minga/buffer/conceal_range_test.exs` → `7 properties, 10 tests, 0 failures`
- `mix test.debug test/minga_editor/shell/traditional/tree_renderer_test.exs` → `16 tests, 0 failures`
- `mix test.debug test/minga/config/loader_test.exs` → `36 tests, 0 failures`
- `mix test.llm test/minga/project/file_tree_test.exs test/minga/buffer/conceal_range_test.exs test/minga_editor/shell/traditional/tree_renderer_test.exs test/minga/config/loader_test.exs` → `PASS: 7 properties, 83 tests, 0 failures`
- Final reviewer gate: PASS

## Stats
- `test/minga/project/file_tree_test.exs`: 690 → 330 lines, 45 → 21 tests
- `test/minga/buffer/conceal_range_test.exs`: 687 → 444 lines, 42 → 10 example tests, 7 properties preserved
- `test/minga_editor/shell/traditional/tree_renderer_test.exs`: 1025 → 543 lines, 37 → 16 tests
- `test/minga/config/loader_test.exs`: 1165 → 1152 lines, 38 → 36 tests
- Total diff: 4 files changed, 799 insertions, 1897 deletions

## Notes for reviewers
No production code changed. The loader cleanup is intentionally small because the suite is filesystem/env/cwd-sensitive and already serial for good reasons.
