### PR TITLE
Fix agent view return context

### DIFF
--- a/docs/AGENTIC-KEYMAP.md
+++ b/docs/AGENTIC-KEYMAP.md
@@ -17,7 +17,7 @@ See `Minga.Keymap.Scope` for the behaviour contract, `Minga.Input.Scoped` for th
 ## Design Principles
 
 1. **Sacred vim motions stay.** j/k, gg/G, Ctrl-d/u, /, n/N work exactly as a vim user expects.
-2. **Editing keys are repurposed.** i/a focus the input (semantic parallel to "enter insert mode"). o toggles collapse (magit precedent). y copies (yank = copy). q closes (Doom special buffer convention).
+2. **Editing keys are repurposed.** i/a focus the input (semantic parallel to "enter insert mode"). o toggles collapse (magit precedent). y copies (yank = copy). q/Esc returns to the editor context for the same workspace.
 3. **Standard prefixes for multi-key sequences.** `z` for folds, `]`/`[` for next/prev navigation, `g` for go-to actions.
 4. **SPC leader always works.** In navigation mode, SPC delegates to the mode FSM so leader sequences and which-key popups function normally.
 
@@ -115,8 +115,8 @@ See [Agent tool approval](CONFIGURATION.md#agent-tool-approval) for how to confi
 
 | Key | Action |
 |-----|--------|
-| `q` | Return to editor |
-| `Esc` | Return to editor (after dismissing transient UI) |
+| `q` | Return to the recorded editor context for this workspace |
+| `Esc` | Dismiss transient UI, then return to the recorded editor context |
 | `?` | Show help overlay |
 
 ### Search
@@ -135,7 +135,7 @@ See [Agent tool approval](CONFIGURATION.md#agent-tool-approval) for how to confi
 | `SPC a s` | Stop / abort agent |
 | `SPC a m` | Pick agent model |
 | `SPC a T` | Cycle thinking level |
-| `SPC a t` | Toggle agentic view (return to editor) |
+| `SPC a t` | Toggle agentic view (return to editor context) |
 
 ## Chat Input Mode
 
@@ -161,7 +161,7 @@ Active when the file viewer panel has focus (after pressing `Tab`).
 | `Ctrl-d` / `Ctrl-u` | Scroll half page |
 | `gg` / `G` | Top / bottom |
 | `Tab` | Switch focus back to chat |
-| `q` / `Esc` | Return to editor |
+| `q` / `Esc` | Return to editor context |
 | `}` / `{` | Grow / shrink chat panel |
 | `=` | Reset panel split |
 

--- a/lib/minga/keymap/scope/agent.ex
+++ b/lib/minga/keymap/scope/agent.ex
@@ -250,7 +250,7 @@ defmodule Minga.Keymap.Scope.Agent do
        ]},
       {"View",
        [
-         {"q", "Return to editor"},
+         {"q / Esc", "Return to editor"},
          {"?", "This help overlay"}
        ]}
     ]
@@ -277,7 +277,7 @@ defmodule Minga.Keymap.Scope.Agent do
        ]},
       {"View",
        [
-         {"q", "Return to editor"},
+         {"q / Esc", "Return to editor"},
          {"?", "This help overlay"}
        ]}
     ]

--- a/lib/minga_editor/agent/ui_state.ex
+++ b/lib/minga_editor/agent/ui_state.ex
@@ -149,6 +149,12 @@ defmodule MingaEditor.Agent.UIState do
     %{state | panel: %{panel | visible: !panel.visible}}
   end
 
+  @doc "Clears the active file mention completion."
+  @spec clear_mention_completion(t()) :: t()
+  def clear_mention_completion(%__MODULE__{panel: panel} = state) do
+    %{state | panel: Panel.clear_mention_completion(panel)}
+  end
+
   @doc "Advances the spinner animation frame."
   @spec tick_spinner(t()) :: t()
   def tick_spinner(%__MODULE__{panel: panel} = state) do
@@ -488,10 +494,55 @@ defmodule MingaEditor.Agent.UIState do
   # View functions (delegate to View sub-struct)
   # ══════════════════════════════════════════════════════════════════════════
 
+  @doc "Builds a return target from the current editor context."
+  @spec return_target(
+          pos_integer() | nil,
+          pid() | nil,
+          Windows.t(),
+          FileTreeState.t(),
+          Minga.Keymap.Scope.scope_name(),
+          boolean()
+        ) :: View.return_target()
+  def return_target(
+        active_tab_id,
+        active_buffer,
+        windows,
+        file_tree,
+        keymap_scope,
+        prompt_focused
+      ) do
+    View.return_target(
+      active_tab_id,
+      active_buffer,
+      windows,
+      file_tree,
+      keymap_scope,
+      prompt_focused
+    )
+  end
+
   @doc "Activates the view, saving the current window layout."
   @spec activate(t(), Windows.t(), FileTreeState.t()) :: t()
   def activate(%__MODULE__{view: view} = state, windows, file_tree) do
     %{state | view: View.activate(view, windows, file_tree)}
+  end
+
+  @doc "Activates the view with a recorded editor return target."
+  @spec activate(t(), Windows.t(), FileTreeState.t(), View.return_target() | nil) :: t()
+  def activate(%__MODULE__{view: view} = state, windows, file_tree, return_target) do
+    %{state | view: View.activate(view, windows, file_tree, return_target)}
+  end
+
+  @doc "Sets the editor return target."
+  @spec set_return_target(t(), View.return_target() | nil) :: t()
+  def set_return_target(%__MODULE__{view: view} = state, return_target) do
+    %{state | view: View.set_return_target(view, return_target)}
+  end
+
+  @doc "Clears the editor return target."
+  @spec clear_return_target(t()) :: t()
+  def clear_return_target(%__MODULE__{view: view} = state) do
+    %{state | view: View.clear_return_target(view)}
   end
 
   @doc "Deactivates the view and returns the restored window layout."

--- a/lib/minga_editor/agent/ui_state/panel.ex
+++ b/lib/minga_editor/agent/ui_state/panel.ex
@@ -60,6 +60,12 @@ defmodule MingaEditor.Agent.UIState.Panel do
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
+  @doc "Clears the active file mention completion."
+  @spec clear_mention_completion(t()) :: t()
+  def clear_mention_completion(%__MODULE__{} = panel) do
+    %{panel | mention_completion: nil}
+  end
+
   # ── Buffer readers ──────────────────────────────────────────────────────
 
   @doc "Returns the input lines as a list of strings."

--- a/lib/minga_editor/agent/ui_state/return_target.ex
+++ b/lib/minga_editor/agent/ui_state/return_target.ex
@@ -1,0 +1,49 @@
+defmodule MingaEditor.Agent.UIState.ReturnTarget do
+  @moduledoc """
+  Editor context to restore when leaving the agent view.
+
+  The agent view is a zoom surface inside a workspace. This struct records the editor context that was active before zooming in so `q` and `Esc` can return to the same workspace instead of guessing from tab order alone.
+  """
+
+  alias Minga.Keymap.Scope
+  alias MingaEditor.State.FileTree, as: FileTreeState
+  alias MingaEditor.State.Windows
+
+  @type t :: %__MODULE__{
+          active_tab_id: pos_integer() | nil,
+          active_buffer: pid() | nil,
+          windows: Windows.t(),
+          file_tree: FileTreeState.t(),
+          keymap_scope: Scope.scope_name(),
+          prompt_focused: boolean()
+        }
+
+  @enforce_keys [:windows, :file_tree, :keymap_scope, :prompt_focused]
+  defstruct active_tab_id: nil,
+            active_buffer: nil,
+            windows: nil,
+            file_tree: nil,
+            keymap_scope: :editor,
+            prompt_focused: false
+
+  @doc "Builds a return target from the current editor context."
+  @spec new(
+          pos_integer() | nil,
+          pid() | nil,
+          Windows.t(),
+          FileTreeState.t(),
+          Scope.scope_name(),
+          boolean()
+        ) :: t()
+  def new(active_tab_id, active_buffer, windows, file_tree, keymap_scope, prompt_focused)
+      when (is_integer(active_tab_id) and active_tab_id > 0) or is_nil(active_tab_id) do
+    %__MODULE__{
+      active_tab_id: active_tab_id,
+      active_buffer: active_buffer,
+      windows: windows,
+      file_tree: file_tree,
+      keymap_scope: keymap_scope,
+      prompt_focused: prompt_focused
+    }
+  end
+end

--- a/lib/minga_editor/agent/ui_state/view.ex
+++ b/lib/minga_editor/agent/ui_state/view.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.Agent.UIState.View do
   this struct directly.
   """
 
+  alias MingaEditor.Agent.UIState.ReturnTarget
   alias MingaEditor.Agent.View.Preview
   alias Minga.Config
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -39,6 +40,9 @@ defmodule MingaEditor.Agent.UIState.View do
   @typedoc "A notification toast."
   @type toast :: %{message: String.t(), icon: String.t(), level: :info | :warning | :error}
 
+  @typedoc "Editor context to restore when leaving the agent view."
+  @type return_target :: ReturnTarget.t()
+
   @typedoc "Layout, search, preview, and toast state."
   @type t :: %__MODULE__{
           active: boolean(),
@@ -48,6 +52,7 @@ defmodule MingaEditor.Agent.UIState.View do
           pending_prefix: prefix(),
           chat_width_pct: non_neg_integer(),
           saved_file_tree: FileTreeState.t() | nil,
+          return_target: return_target() | nil,
           help_visible: boolean(),
           search: search_state() | nil,
           toast: toast() | nil,
@@ -67,6 +72,7 @@ defmodule MingaEditor.Agent.UIState.View do
             pending_prefix: nil,
             chat_width_pct: 65,
             saved_file_tree: nil,
+            return_target: nil,
             help_visible: false,
             search: nil,
             toast: nil,
@@ -80,18 +86,62 @@ defmodule MingaEditor.Agent.UIState.View do
 
   # ── Layout ──────────────────────────────────────────────────────────────────
 
+  @doc "Builds a return target from the current editor context."
+  @spec return_target(
+          pos_integer() | nil,
+          pid() | nil,
+          Windows.t(),
+          FileTreeState.t(),
+          Minga.Keymap.Scope.scope_name(),
+          boolean()
+        ) :: return_target()
+  def return_target(
+        active_tab_id,
+        active_buffer,
+        windows,
+        file_tree,
+        keymap_scope,
+        prompt_focused
+      ) do
+    ReturnTarget.new(
+      active_tab_id,
+      active_buffer,
+      windows,
+      file_tree,
+      keymap_scope,
+      prompt_focused
+    )
+  end
+
   @doc "Activates the view, saving the current window layout."
   @spec activate(t(), Windows.t(), FileTreeState.t()) :: t()
   def activate(%__MODULE__{} = view, windows, file_tree) do
+    activate(view, windows, file_tree, nil)
+  end
+
+  @doc "Activates the view with a recorded editor return target."
+  @spec activate(t(), Windows.t(), FileTreeState.t(), return_target() | nil) :: t()
+  def activate(%__MODULE__{} = view, windows, file_tree, return_target) do
     %{
       view
       | active: true,
         focus: :chat,
         saved_windows: windows,
         saved_file_tree: file_tree,
+        return_target: return_target,
         pending_prefix: nil
     }
   end
+
+  @doc "Sets the editor return target."
+  @spec set_return_target(t(), return_target() | nil) :: t()
+  def set_return_target(%__MODULE__{} = view, return_target) do
+    %{view | return_target: return_target}
+  end
+
+  @doc "Clears the editor return target."
+  @spec clear_return_target(t()) :: t()
+  def clear_return_target(%__MODULE__{} = view), do: %{view | return_target: nil}
 
   @doc "Deactivates the view and returns the restored window layout."
   @spec deactivate(t()) :: {t(), Windows.t() | nil, FileTreeState.t() | nil}
@@ -104,6 +154,7 @@ defmodule MingaEditor.Agent.UIState.View do
          focus: :chat,
          saved_windows: nil,
          saved_file_tree: nil,
+         return_target: nil,
          pending_prefix: nil
      }, saved_windows, saved_file_tree}
   end

--- a/lib/minga_editor/agent_activation.ex
+++ b/lib/minga_editor/agent_activation.ex
@@ -19,6 +19,8 @@ defmodule MingaEditor.AgentActivation do
   alias MingaEditor.State.Windows
   alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Tab
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.Window.Content
   alias MingaEditor.Shell.Board.Card
@@ -39,8 +41,11 @@ defmodule MingaEditor.AgentActivation do
     if Card.you_card?(card) or card.session == nil do
       state
     else
+      return_target = build_return_target(state)
+
       state
       |> refresh_agent_cache(card.session)
+      |> activate_agent_view(return_target)
       |> set_agent_scope()
       |> set_agent_chat_window_content(card.session)
       |> focus_prompt()
@@ -50,23 +55,51 @@ defmodule MingaEditor.AgentActivation do
   @doc """
   Deactivates the agent view, reversing the activation steps.
 
-  Resets the rendering cache (status/error/pending_approval) to idle,
-  resets keymap scope to `:editor`, and unfocuses the prompt. Does NOT
-  modify `workspace.windows` — that is handled by the workspace restore
-  in zoom_out. Does NOT clear the card's `:session` field; the session
-  keeps running in the background and the card retains its pid.
+  Resets the rendering cache (status/error/pending_approval) to idle and restores the recorded editor return target when one exists. The return target includes window layout, file tree state, keymap scope, active buffer, and prompt focus. Without a return target, deactivation falls back to editor scope with the prompt unfocused. It does NOT clear the card's `:session` field; the session keeps running in the background and the card retains its pid.
 
   Symmetric counterpart to `activate_for_card/2`.
   """
   @spec deactivate(EditorState.t()) :: EditorState.t()
   def deactivate(state) do
+    return_target = AgentAccess.view(state).return_target
+
     state
     |> reset_cache()
-    |> reset_scope()
-    |> unfocus_prompt()
+    |> deactivate_agent_view()
+    |> restore_return_target(return_target)
+    |> restore_deactivated_scope(return_target)
+    |> restore_deactivated_prompt_focus(return_target)
   end
 
   # ── Private steps ───────────────────────────────────────────────────────
+
+  @spec build_return_target(EditorState.t()) :: UIState.View.return_target()
+  defp build_return_target(state) do
+    UIState.return_target(
+      active_tab_id(state),
+      state.workspace.buffers.active,
+      state.workspace.windows,
+      state.workspace.file_tree,
+      state.workspace.keymap_scope,
+      AgentAccess.input_focused?(state)
+    )
+  end
+
+  @spec active_tab_id(EditorState.t()) :: pos_integer() | nil
+  defp active_tab_id(state) do
+    case EditorState.active_tab(state) do
+      %Tab{id: id} -> id
+      nil -> nil
+    end
+  end
+
+  @spec activate_agent_view(EditorState.t(), UIState.View.return_target()) :: EditorState.t()
+  defp activate_agent_view(state, return_target) do
+    AgentAccess.update_agent_ui(
+      state,
+      &UIState.activate(&1, return_target.windows, return_target.file_tree, return_target)
+    )
+  end
 
   # Populates the rendering cache (status, error, pending_approval) from
   # the session process. The session pid itself lives on the card, not
@@ -124,20 +157,60 @@ defmodule MingaEditor.AgentActivation do
 
   # ── Deactivation steps ─────────────────────────────────────────────────
 
+  @spec deactivate_agent_view(EditorState.t()) :: EditorState.t()
+  defp deactivate_agent_view(state) do
+    AgentAccess.update_agent_ui(state, fn ui ->
+      {ui, _windows, _file_tree} = UIState.deactivate(ui)
+      ui
+    end)
+  end
+
+  @spec restore_return_target(EditorState.t(), UIState.View.return_target() | nil) ::
+          EditorState.t()
+  defp restore_return_target(state, nil), do: state
+
+  defp restore_return_target(state, return_target) do
+    EditorState.update_workspace(state, &restore_workspace(&1, return_target))
+  end
+
+  @spec restore_workspace(WorkspaceState.t(), UIState.View.return_target()) :: WorkspaceState.t()
+  defp restore_workspace(workspace, return_target) do
+    workspace
+    |> WorkspaceState.set_keymap_scope(return_target.keymap_scope)
+    |> WorkspaceState.set_windows(return_target.windows)
+    |> WorkspaceState.set_file_tree(return_target.file_tree)
+    |> restore_active_buffer(return_target.active_buffer)
+  end
+
+  @spec restore_active_buffer(WorkspaceState.t(), pid() | nil) :: WorkspaceState.t()
+  defp restore_active_buffer(workspace, active_buffer) when is_pid(active_buffer) do
+    WorkspaceState.set_buffers(workspace, Buffers.switch_to_pid(workspace.buffers, active_buffer))
+  end
+
+  defp restore_active_buffer(workspace, _active_buffer), do: workspace
+
+  @spec restore_deactivated_prompt_focus(EditorState.t(), UIState.View.return_target() | nil) ::
+          EditorState.t()
+  defp restore_deactivated_prompt_focus(state, %{prompt_focused: true}) do
+    AgentAccess.update_agent_ui(state, &UIState.set_input_focused(&1, true))
+  end
+
+  defp restore_deactivated_prompt_focus(state, _return_target) do
+    AgentAccess.update_agent_ui(state, &UIState.set_input_focused(&1, false))
+  end
+
   @spec reset_cache(EditorState.t()) :: EditorState.t()
   defp reset_cache(state) do
     AgentAccess.update_agent(state, &AgentState.reset_cache/1)
   end
 
-  @spec reset_scope(EditorState.t()) :: EditorState.t()
-  defp reset_scope(state) do
-    EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor))
+  @spec restore_deactivated_scope(EditorState.t(), UIState.View.return_target() | nil) ::
+          EditorState.t()
+  defp restore_deactivated_scope(state, %{keymap_scope: keymap_scope}) do
+    EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, keymap_scope))
   end
 
-  @spec unfocus_prompt(EditorState.t()) :: EditorState.t()
-  defp unfocus_prompt(state) do
-    AgentAccess.update_agent_ui(state, fn ui ->
-      UIState.set_input_focused(ui, false)
-    end)
+  defp restore_deactivated_scope(state, _return_target) do
+    EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor))
   end
 end

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -31,9 +31,12 @@ defmodule MingaEditor.Commands.Agent do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Windows
+  alias MingaEditor.Workspace.State, as: WorkspaceState
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
   alias MingaEditor.Input.AgentPanel
@@ -59,15 +62,12 @@ defmodule MingaEditor.Commands.Agent do
   def toggle_agent_split(state) do
     case EditorState.active_tab_kind(state) do
       :agent ->
-        # On agent tab: switch back to most recent file tab
-        case TabBar.most_recent_of_kind(EditorState.tab_bar(state), :file) do
-          %Tab{id: file_id} -> EditorState.switch_tab(state, file_id)
-          nil -> state
-        end
+        return_to_editor(state)
 
       _ ->
-        # On file tab: ensure agent tab exists and switch to it
+        # On file tab: ensure agent tab exists, record the return target, and switch to it.
         state = ensure_agent_state(state)
+        return_target = build_return_target(state)
 
         case find_agent_tab(state) do
           %Tab{id: agent_id} ->
@@ -76,6 +76,7 @@ defmodule MingaEditor.Commands.Agent do
             # switch — otherwise it would always see nil from the file tab.
             state
             |> EditorState.switch_tab(agent_id)
+            |> activate_agent_view(return_target)
             |> maybe_start_session()
 
           nil ->
@@ -191,6 +192,130 @@ defmodule MingaEditor.Commands.Agent do
     else
       state
     end
+  end
+
+  @spec build_return_target(state()) :: UIState.View.return_target()
+  defp build_return_target(state) do
+    active_tab_id = active_tab_id(state)
+
+    UIState.return_target(
+      active_tab_id,
+      state.workspace.buffers.active,
+      state.workspace.windows,
+      state.workspace.file_tree,
+      state.workspace.keymap_scope,
+      AgentAccess.input_focused?(state)
+    )
+  end
+
+  @spec active_tab_id(state()) :: pos_integer() | nil
+  defp active_tab_id(state) do
+    case EditorState.active_tab(state) do
+      %Tab{id: id} -> id
+      nil -> nil
+    end
+  end
+
+  @spec activate_agent_view(state(), UIState.View.return_target()) :: state()
+  defp activate_agent_view(state, return_target) do
+    update_agent_ui(
+      state,
+      &UIState.activate(&1, return_target.windows, return_target.file_tree, return_target)
+    )
+  end
+
+  @doc "Returns from the agent view to the recorded editor context without stopping the session."
+  @spec return_to_editor(state()) :: state()
+  def return_to_editor(state) do
+    return_target = AgentAccess.view(state).return_target
+
+    case target_file_tab_id(EditorState.tab_bar(state), return_target) do
+      id when is_integer(id) ->
+        state
+        |> mark_agent_view_inactive()
+        |> EditorState.switch_tab(id)
+        |> restore_return_keymap_scope(return_target)
+
+      nil ->
+        restore_return_target_without_tab(state, return_target)
+    end
+  end
+
+  @spec target_file_tab_id(TabBar.t() | nil, UIState.View.return_target() | nil) ::
+          pos_integer() | nil
+  defp target_file_tab_id(%TabBar{} = tb, %{active_tab_id: id}) when is_integer(id) do
+    case TabBar.get(tb, id) do
+      %Tab{kind: :file, id: file_id} -> file_id
+      _ -> fallback_file_tab_id(tb)
+    end
+  end
+
+  defp target_file_tab_id(%TabBar{} = tb, _return_target), do: fallback_file_tab_id(tb)
+  defp target_file_tab_id(_tb, _return_target), do: nil
+
+  @spec fallback_file_tab_id(TabBar.t()) :: pos_integer() | nil
+  defp fallback_file_tab_id(%TabBar{} = tb) do
+    case TabBar.most_recent_of_kind(tb, :file) do
+      %Tab{id: id} -> id
+      nil -> nil
+    end
+  end
+
+  @spec restore_return_keymap_scope(state(), UIState.View.return_target() | nil) :: state()
+  defp restore_return_keymap_scope(state, %{keymap_scope: keymap_scope}) do
+    EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, keymap_scope))
+  end
+
+  defp restore_return_keymap_scope(state, _return_target) do
+    EditorState.update_workspace(state, &WorkspaceState.set_keymap_scope(&1, :editor))
+  end
+
+  @spec restore_return_target_without_tab(state(), UIState.View.return_target() | nil) :: state()
+  defp restore_return_target_without_tab(state, nil) do
+    state
+    |> mark_agent_view_inactive()
+    |> EditorState.update_workspace(&WorkspaceState.set_keymap_scope(&1, :editor))
+    |> EditorState.set_status("No file tabs in this workspace")
+  end
+
+  defp restore_return_target_without_tab(state, return_target) do
+    state
+    |> mark_agent_view_inactive()
+    |> EditorState.update_workspace(&restore_workspace_return_target(&1, return_target))
+    |> restore_prompt_focus(return_target.prompt_focused)
+    |> EditorState.set_status("No file tabs in this workspace")
+  end
+
+  @spec restore_workspace_return_target(WorkspaceState.t(), UIState.View.return_target()) ::
+          WorkspaceState.t()
+  defp restore_workspace_return_target(workspace, return_target) do
+    workspace
+    |> WorkspaceState.set_keymap_scope(return_target.keymap_scope)
+    |> WorkspaceState.set_windows(return_target.windows)
+    |> WorkspaceState.set_file_tree(return_target.file_tree)
+    |> restore_return_target_buffer(return_target.active_buffer)
+  end
+
+  @spec restore_return_target_buffer(WorkspaceState.t(), pid() | nil) :: WorkspaceState.t()
+  defp restore_return_target_buffer(workspace, active_buffer) when is_pid(active_buffer) do
+    WorkspaceState.set_buffers(workspace, Buffers.switch_to_pid(workspace.buffers, active_buffer))
+  end
+
+  defp restore_return_target_buffer(workspace, _active_buffer), do: workspace
+
+  @spec restore_prompt_focus(state(), boolean()) :: state()
+  defp restore_prompt_focus(state, true),
+    do: update_agent_ui(state, &UIState.set_input_focused(&1, true))
+
+  defp restore_prompt_focus(state, false),
+    do: update_agent_ui(state, &UIState.set_input_focused(&1, false))
+
+  @spec mark_agent_view_inactive(state()) :: state()
+  defp mark_agent_view_inactive(state) do
+    update_agent_ui(state, fn ui ->
+      {ui, _windows, _file_tree} = UIState.deactivate(ui)
+      UIState.set_input_focused(ui, false)
+    end)
   end
 
   @doc "Starts a local session, or opens a server picker when remotes are connected."
@@ -900,17 +1025,71 @@ defmodule MingaEditor.Commands.Agent do
 
   # ── Close / dismiss ────────────────────────────────────────────────────────
 
-  @doc "Returns from the agent view to the most recent file tab."
+  @doc "Returns from the agent view to the recorded editor context."
   @spec scope_close(state()) :: state()
-  def scope_close(state), do: toggle_agent_split(state)
+  def scope_close(state), do: return_to_editor(state)
 
   @doc "Dismisses active overlays or returns to the editor (ESC behavior)."
   @spec scope_dismiss_or_noop(state()) :: state()
-  def scope_dismiss_or_noop(state) do
-    if AgentAccess.view(state).help_visible do
-      update_agent_ui(state, &UIState.dismiss_help/1)
+  def scope_dismiss_or_noop(state), do: dismiss_agent_transient_or_return(state)
+
+  @spec dismiss_agent_transient_or_return(state()) :: state()
+  defp dismiss_agent_transient_or_return(state) do
+    view = AgentAccess.view(state)
+    panel = AgentAccess.panel(state)
+
+    dismiss_agent_transient_or_return(state, view, panel)
+  end
+
+  @spec dismiss_agent_transient_or_return(state(), UIState.View.t(), Panel.t()) :: state()
+  defp dismiss_agent_transient_or_return(state, %{help_visible: true}, _panel) do
+    update_agent_ui(state, &UIState.dismiss_help/1)
+  end
+
+  defp dismiss_agent_transient_or_return(state, view, _panel) do
+    if UIState.searching?(view) do
+      update_agent_ui(state, &UIState.cancel_search/1)
     else
-      toggle_agent_split(state)
+      dismiss_agent_prefix_or_modal(state, view)
+    end
+  end
+
+  @spec dismiss_agent_prefix_or_modal(state(), UIState.View.t()) :: state()
+  defp dismiss_agent_prefix_or_modal(state, %{pending_prefix: nil}) do
+    panel = AgentAccess.panel(state)
+    dismiss_agent_panel_or_modal(state, panel)
+  end
+
+  defp dismiss_agent_prefix_or_modal(state, _view) do
+    update_agent_ui(state, &UIState.clear_prefix/1)
+  end
+
+  @spec dismiss_agent_panel_or_modal(state(), Panel.t()) :: state()
+  defp dismiss_agent_panel_or_modal(state, %{mention_completion: nil}) do
+    dismiss_agent_modal_or_hover(state, EditorState.modal(state))
+  end
+
+  defp dismiss_agent_panel_or_modal(state, _panel) do
+    update_agent_ui(state, &UIState.clear_mention_completion/1)
+  end
+
+  @spec dismiss_agent_modal_or_hover(state(), ModalOverlay.t()) :: state()
+  defp dismiss_agent_modal_or_hover(state, :none) do
+    dismiss_agent_hover_or_input(state, EditorState.hover_popup(state))
+  end
+
+  defp dismiss_agent_modal_or_hover(state, _modal), do: ModalOverlay.dismiss(state)
+
+  @spec dismiss_agent_hover_or_input(state(), term()) :: state()
+  defp dismiss_agent_hover_or_input(state, nil), do: dismiss_agent_input_or_return(state)
+  defp dismiss_agent_hover_or_input(state, _hover), do: EditorState.dismiss_hover_popup(state)
+
+  @spec dismiss_agent_input_or_return(state()) :: state()
+  defp dismiss_agent_input_or_return(state) do
+    if AgentAccess.input_focused?(state) do
+      scope_unfocus_input(state)
+    else
+      return_to_editor(state)
     end
   end
 

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -182,9 +182,8 @@ defmodule MingaEditor.Commands.Agent do
   defp find_agent_tab(%{shell_state: %{tab_bar: nil}}), do: nil
   defp find_agent_tab(%{shell_state: %{tab_bar: tb}}), do: TabBar.find_by_kind(tb, :agent)
 
-  # Creates a new file tab for the active buffer and switches to it.
-  # Used when deactivating the agentic view and no file tab exists yet
-  # (e.g., cold boot into agent mode). The new tab starts with an empty
+  # Starts an agent session after switching into the agent tab.
+  # Called only after the tab switch so AgentAccess.session/1 sees the tab's pid.
   @spec maybe_start_session(state()) :: state()
   defp maybe_start_session(state) do
     if AgentAccess.session(state) == nil do
@@ -230,11 +229,16 @@ defmodule MingaEditor.Commands.Agent do
     return_target = AgentAccess.view(state).return_target
 
     case target_file_tab_id(EditorState.tab_bar(state), return_target) do
-      id when is_integer(id) ->
+      {:exact, id} ->
         state
         |> mark_agent_view_inactive()
         |> EditorState.switch_tab(id)
         |> restore_return_keymap_scope(return_target)
+
+      {:fallback, id} ->
+        state
+        |> mark_agent_view_inactive()
+        |> EditorState.switch_tab(id)
 
       nil ->
         restore_return_target_without_tab(state, return_target)
@@ -242,10 +246,10 @@ defmodule MingaEditor.Commands.Agent do
   end
 
   @spec target_file_tab_id(TabBar.t() | nil, UIState.View.return_target() | nil) ::
-          pos_integer() | nil
+          {:exact, pos_integer()} | {:fallback, pos_integer()} | nil
   defp target_file_tab_id(%TabBar{} = tb, %{active_tab_id: id}) when is_integer(id) do
     case TabBar.get(tb, id) do
-      %Tab{kind: :file, id: file_id} -> file_id
+      %Tab{kind: :file, id: file_id} -> {:exact, file_id}
       _ -> fallback_file_tab_id(tb)
     end
   end
@@ -253,10 +257,10 @@ defmodule MingaEditor.Commands.Agent do
   defp target_file_tab_id(%TabBar{} = tb, _return_target), do: fallback_file_tab_id(tb)
   defp target_file_tab_id(_tb, _return_target), do: nil
 
-  @spec fallback_file_tab_id(TabBar.t()) :: pos_integer() | nil
+  @spec fallback_file_tab_id(TabBar.t()) :: {:fallback, pos_integer()} | nil
   defp fallback_file_tab_id(%TabBar{} = tb) do
     case TabBar.most_recent_of_kind(tb, :file) do
-      %Tab{id: id} -> id
+      %Tab{id: id} -> {:fallback, id}
       nil -> nil
     end
   end
@@ -298,7 +302,18 @@ defmodule MingaEditor.Commands.Agent do
 
   @spec restore_return_target_buffer(WorkspaceState.t(), pid() | nil) :: WorkspaceState.t()
   defp restore_return_target_buffer(workspace, active_buffer) when is_pid(active_buffer) do
-    WorkspaceState.set_buffers(workspace, Buffers.switch_to_pid(workspace.buffers, active_buffer))
+    buffers = Buffers.switch_to_pid(workspace.buffers, active_buffer)
+
+    buffers =
+      if buffers.active == active_buffer do
+        buffers
+      else
+        Buffers.replace_list(buffers, [active_buffer | buffers.list], 0)
+      end
+
+    workspace
+    |> WorkspaceState.set_buffers(buffers)
+    |> WorkspaceState.sync_active_window_buffer()
   end
 
   defp restore_return_target_buffer(workspace, _active_buffer), do: workspace

--- a/lib/minga_editor/input/agent_panel.ex
+++ b/lib/minga_editor/input/agent_panel.ex
@@ -83,6 +83,8 @@ defmodule MingaEditor.Input.AgentPanel do
 
   @spec handle_panel_input(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           EditorState.t()
+  defp handle_panel_input(state, 27, 0), do: handle_panel_escape(state)
+
   defp handle_panel_input(state, cp, mods) do
     binding_state = Minga.Editing.binding_state(state)
 
@@ -113,6 +115,14 @@ defmodule MingaEditor.Input.AgentPanel do
       # Normal, visual, operator-pending: route through Mode FSM
       # targeting the prompt buffer
       dispatch_prompt_via_mode_fsm(state, cp, mods)
+    end
+  end
+
+  @spec handle_panel_escape(EditorState.t()) :: EditorState.t()
+  defp handle_panel_escape(state) do
+    case Minga.Editing.mode(state) do
+      :normal -> AgentCommands.scope_unfocus_input(state)
+      _ -> dispatch_prompt_via_mode_fsm(state, 27, 0)
     end
   end
 

--- a/lib/minga_editor/input/scoped.ex
+++ b/lib/minga_editor/input/scoped.ex
@@ -171,7 +171,10 @@ defmodule MingaEditor.Input.Scoped do
   @spec handle_focused_input_normal(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
   defp handle_focused_input_normal(state, 27, 0) do
-    {:handled, AgentCommands.scope_unfocus_input(state)}
+    case Minga.Editing.mode(state) do
+      :normal -> {:handled, AgentCommands.scope_unfocus_input(state)}
+      _ -> {:handled, AgentPanel.dispatch_prompt_via_mode_fsm(state, 27, 0)}
+    end
   end
 
   defp handle_focused_input_normal(state, cp, mods) do

--- a/lib/minga_editor/input/scoped.ex
+++ b/lib/minga_editor/input/scoped.ex
@@ -164,10 +164,20 @@ defmodule MingaEditor.Input.Scoped do
       # Enter, Backspace, Ctrl combos, etc.
       resolve_agent_key(state, :insert, cp, mods)
     else
-      # Normal, visual, operator-pending: route through Mode FSM
-      # targeting the prompt buffer.
-      {:handled, AgentPanel.dispatch_prompt_via_mode_fsm(state, cp, mods)}
+      handle_focused_input_normal(state, cp, mods)
     end
+  end
+
+  @spec handle_focused_input_normal(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
+          MingaEditor.Input.Handler.result()
+  defp handle_focused_input_normal(state, 27, 0) do
+    {:handled, AgentCommands.scope_unfocus_input(state)}
+  end
+
+  defp handle_focused_input_normal(state, cp, mods) do
+    # Normal, visual, operator-pending: route through Mode FSM
+    # targeting the prompt buffer.
+    {:handled, AgentPanel.dispatch_prompt_via_mode_fsm(state, cp, mods)}
   end
 
   @spec cua_active?(map()) :: boolean()

--- a/lib/minga_editor/input/tool_approval.ex
+++ b/lib/minga_editor/input/tool_approval.ex
@@ -32,5 +32,6 @@ defmodule MingaEditor.Input.ToolApproval do
   defp dispatch_approval(state, ?y), do: Commands.execute(state, :agent_approve_tool)
   defp dispatch_approval(state, ?n), do: Commands.execute(state, :agent_deny_tool)
   defp dispatch_approval(state, ?Y), do: Commands.execute(state, :agent_approve_all_tools)
+  defp dispatch_approval(state, 27), do: Commands.execute(state, :agent_dismiss_or_noop)
   defp dispatch_approval(state, _cp), do: state
 end

--- a/lib/minga_editor/shell/board/zoom_out.ex
+++ b/lib/minga_editor/shell/board/zoom_out.ex
@@ -24,32 +24,38 @@ defmodule MingaEditor.Shell.Board.ZoomOut do
   @spec handle_key(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
 
-  # Escape when zoomed: zoom out back to the grid.
-  # But when the agent panel is in insert mode, let ESC pass through
-  # so it switches to normal mode first. The user presses ESC again
-  # (in normal mode) to zoom out.
-  def handle_key(
-        %{shell: Board, shell_state: %BoardState{zoomed_into: card_id}} = state,
-        @key_escape,
-        0
-      )
-      when card_id != nil do
-    if agent_panel_in_insert_mode?(state) do
+  # Escape or q when zoomed: zoom out back to the grid.
+  # Leader sequences must keep flowing to the normal handler stack, so they
+  # always pass through before zoom-out gets a chance to run.
+  # When the agent panel is focused, let the key pass through so the prompt
+  # handler can apply its own normal/visual/operator semantics first.
+  def handle_key(%{shell: Board} = state, cp, mods) do
+    if Minga.Editing.in_leader?(state) do
+      {:passthrough, state}
+    else
+      handle_zoomed_key(state, cp, mods)
+    end
+  end
+
+  def handle_key(state, _cp, _mods), do: {:passthrough, state}
+
+  defp handle_zoomed_key(%{shell_state: %BoardState{zoomed_into: card_id}} = state, cp, 0)
+       when card_id != nil and cp in [@key_escape, ?q] do
+    if agent_panel_focused?(state) do
       {:passthrough, state}
     else
       {:handled, zoom_out(state)}
     end
   end
 
-  def handle_key(state, _cp, _mods), do: {:passthrough, state}
+  defp handle_zoomed_key(state, _cp, _mods), do: {:passthrough, state}
 
-  # Returns true when the agent panel is focused and in insert mode.
-  # In this state, ESC should toggle vim mode, not zoom out.
-  @spec agent_panel_in_insert_mode?(EditorState.t()) :: boolean()
-  defp agent_panel_in_insert_mode?(state) do
+  # Returns true when the agent panel is focused.
+  # In this state, ESC should be handled by the prompt stack, not zoom out.
+  @spec agent_panel_focused?(EditorState.t()) :: boolean()
+  defp agent_panel_focused?(state) do
     state.workspace.keymap_scope == :agent and
-      state.workspace.agent_ui.panel.input_focused and
-      Minga.Editing.mode(state) == :insert
+      state.workspace.agent_ui.panel.input_focused
   end
 
   # ── Zoom out ───────────────────────────────────────────────────────────

--- a/test/minga_editor/agent_activation_test.exs
+++ b/test/minga_editor/agent_activation_test.exs
@@ -1,11 +1,17 @@
 defmodule MingaEditor.AgentActivationTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Test.StubServer
+
   alias MingaEditor.Agent.UIState
   alias MingaEditor.AgentActivation
+  alias MingaEditor.Commands.Agent, as: AgentCommands
+  alias MingaEditor.Shell.Board.Card
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
@@ -55,6 +61,26 @@ defmodule MingaEditor.AgentActivationTest do
       end)
 
     {state, fake_pid}
+  end
+
+  defp file_active_state do
+    {:ok, buf} = BufferProcess.start_link(content: "hello")
+
+    state = base_state()
+
+    state = %{
+      state
+      | workspace: %{
+          state.workspace
+          | buffers: %Buffers{active: buf, list: [buf], active_index: 0}
+        }
+    }
+
+    {tb, file_tab} = TabBar.insert(state.shell_state.tab_bar, :file, "file.ex")
+    state = EditorState.set_tab_bar(state, tb)
+    state = EditorState.switch_tab(state, file_tab.id)
+
+    {state, buf, file_tab.id}
   end
 
   # ── deactivate/1 ─────────────────────────────────────────────────────────────
@@ -126,6 +152,37 @@ defmodule MingaEditor.AgentActivationTest do
       assert result.workspace.windows == windows
       assert result.workspace.file_tree == file_tree
       assert result.workspace.keymap_scope == :file_tree
+      assert AgentAccess.input_focused?(result) == true
+    end
+
+    test "return_to_editor keeps the fallback tab's own keymap scope" do
+      {state, _buf, file_tab_id} = file_active_state()
+      {tb, fallback_tab} = TabBar.insert(state.shell_state.tab_bar, :file, "fallback.ex")
+      state = EditorState.set_tab_bar(state, tb)
+      state = EditorState.switch_tab(state, fallback_tab.id)
+      state = put_in(state.workspace.keymap_scope, :file_tree)
+      state = EditorState.switch_tab(state, file_tab_id)
+      state = AgentCommands.toggle_agentic_view(state)
+      {:ok, tb} = TabBar.remove(state.shell_state.tab_bar, file_tab_id)
+      state = put_in(state.shell_state.tab_bar, tb)
+
+      result = AgentCommands.return_to_editor(state)
+
+      assert result.shell_state.tab_bar.active_id == fallback_tab.id
+      assert result.workspace.keymap_scope == :file_tree
+    end
+
+    test "activate_for_card records the current editor return target" do
+      {state, buf, file_tab_id} = file_active_state()
+      session = start_supervised!(StubServer)
+      card = Card.new(2, session: session, task: "Agent")
+
+      result = AgentActivation.activate_for_card(state, card)
+
+      assert AgentAccess.view(result).return_target.active_tab_id == file_tab_id
+      assert AgentAccess.view(result).return_target.active_buffer == buf
+      assert AgentAccess.view(result).return_target.prompt_focused == false
+      assert result.workspace.keymap_scope == :agent
       assert AgentAccess.input_focused?(result) == true
     end
 

--- a/test/minga_editor/agent_activation_test.exs
+++ b/test/minga_editor/agent_activation_test.exs
@@ -6,8 +6,10 @@ defmodule MingaEditor.AgentActivationTest do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
 
@@ -89,13 +91,42 @@ defmodule MingaEditor.AgentActivationTest do
       assert result.workspace.keymap_scope == :editor
     end
 
-    test "unfocuses the prompt" do
+    test "unfocuses the prompt when no return target was recorded" do
       {state, _pid} = activated_state()
       assert AgentAccess.input_focused?(state) == true
 
       result = AgentActivation.deactivate(state)
 
       assert AgentAccess.input_focused?(result) == false
+    end
+
+    test "restores the recorded workspace return target" do
+      {state, _pid} = activated_state()
+      windows = %Windows{tree: nil, map: %{}, active: 7, next_id: 8}
+      file_tree = %FileTreeState{focused: true}
+
+      return_target =
+        UIState.return_target(
+          nil,
+          state.workspace.buffers.active,
+          windows,
+          file_tree,
+          :file_tree,
+          true
+        )
+
+      state =
+        AgentAccess.update_agent_ui(
+          state,
+          &UIState.activate(&1, windows, file_tree, return_target)
+        )
+
+      result = AgentActivation.deactivate(state)
+
+      assert result.workspace.windows == windows
+      assert result.workspace.file_tree == file_tree
+      assert result.workspace.keymap_scope == :file_tree
+      assert AgentAccess.input_focused?(result) == true
     end
 
     test "is idempotent on already-deactivated state" do

--- a/test/minga_editor/input/agent_panel_nav_test.exs
+++ b/test/minga_editor/input/agent_panel_nav_test.exs
@@ -139,14 +139,19 @@ defmodule MingaEditor.Input.AgentPanelNavTest do
   end
 
   describe "agent panel input mode (via Scoped)" do
-    test "Escape switches to input normal mode" do
+    test "Escape unfocuses a normal-mode input without clearing the draft" do
       state = make_state()
 
       state =
-        AgentAccess.update_agent_ui(state, fn ui -> put_in(ui.panel.input_focused, true) end)
+        AgentAccess.update_agent_ui(state, fn ui ->
+          ui
+          |> UIState.set_input_focused(true)
+          |> UIState.set_prompt_text("draft")
+        end)
 
       {:handled, new_state} = walk_surface_handlers(state, 27, 0)
-      assert AgentAccess.input_focused?(new_state) == true
+      refute AgentAccess.input_focused?(new_state)
+      assert UIState.input_text(AgentAccess.panel(new_state)) == "draft"
       assert new_state.workspace.editing.mode == :normal
     end
 

--- a/test/minga_editor/input/scoped_test.exs
+++ b/test/minga_editor/input/scoped_test.exs
@@ -8,6 +8,7 @@ defmodule MingaEditor.Input.ScopedTest do
   alias MingaEditor.Agent.View.Preview
   alias Minga.Buffer.Process, as: BufferProcess
 
+  alias MingaEditor.Commands.Agent, as: AgentCommands
   alias MingaEditor.State, as: EditorState
   alias MingaAgent.RuntimeState
   alias MingaEditor.State.Agent, as: AgentState
@@ -71,22 +72,64 @@ defmodule MingaEditor.Input.ScopedTest do
     }
   end
 
-  defp with_return_target(state, tab_id, keymap_scope \\ :editor) do
-    return_target =
-      UIState.return_target(
-        tab_id,
-        state.workspace.buffers.active,
-        state.workspace.windows,
-        state.workspace.file_tree,
-        keymap_scope,
-        AgentAccess.input_focused?(state)
+  defp board_state(opts) do
+    {:ok, buf} = BufferProcess.start_link(content: "hello world")
+    {:ok, prompt_buf} = BufferProcess.start_link(content: "")
+
+    agent = %AgentState{
+      runtime: %RuntimeState{status: :idle},
+      buffer: Keyword.get(opts, :agent_buffer, nil)
+    }
+
+    agentic = %UIState{
+      panel: %UIState.Panel{
+        visible: Keyword.get(opts, :panel_visible, false),
+        input_focused: Keyword.get(opts, :input_focused, false),
+        prompt_buffer: prompt_buf
+      },
+      view: %UIState.View{
+        active: Keyword.get(opts, :agentic_active, false),
+        focus: Keyword.get(opts, :focus, :chat)
+      }
+    }
+
+    mode =
+      Keyword.get(
+        opts,
+        :mode,
+        if(Keyword.get(opts, :input_focused, false), do: :insert, else: :normal)
       )
 
-    AgentAccess.update_agent_ui(state, &UIState.set_return_target(&1, return_target))
+    %EditorState{
+      port_manager: self(),
+      shell: MingaEditor.Shell.Board,
+      workspace: %MingaEditor.Workspace.State{
+        viewport: Viewport.new(24, 80),
+        editing: %VimState{mode: mode, mode_state: Mode.initial_state()},
+        buffers: %Buffers{active: buf, list: [buf]},
+        keymap_scope: Keyword.get(opts, :keymap_scope, :editor),
+        agent_ui: agentic
+      },
+      shell_state: %MingaEditor.Shell.Board.State{agent: agent}
+    }
   end
 
-  defp with_active_agent_session(state, session) do
-    EditorState.set_tab_session(state, state.shell_state.tab_bar.active_id, session)
+  defp activated_agent_state do
+    state = base_state(keymap_scope: :editor, agentic_active: false)
+    file_buffer = state.workspace.buffers.active
+    state = AgentCommands.toggle_agentic_view(state)
+    session = AgentAccess.session(state)
+    agent_buffer = AgentAccess.agent(state).buffer
+
+    {state, session, file_buffer, agent_buffer}
+  end
+
+  defp focus_prompt(state, text) do
+    AgentAccess.update_agent_ui(state, fn ui ->
+      ui
+      |> UIState.set_input_focused(true)
+      |> UIState.set_prompt_text(text)
+    end)
   end
 
   # ══════════════════════════════════════════════════════════════════════════
@@ -196,12 +239,57 @@ defmodule MingaEditor.Input.ScopedTest do
   end
 
   # ══════════════════════════════════════════════════════════════════════════
+  # Board shell agent prompt input
+  # ══════════════════════════════════════════════════════════════════════════
+
+  describe "board shell — focused prompt" do
+    setup do
+      {:ok,
+       state:
+         board_state(
+           shell: MingaEditor.Shell.Board,
+           keymap_scope: :agent,
+           input_focused: true,
+           panel_visible: true,
+           mode: :normal
+         )}
+    end
+
+    test "ESC unfocuses a normal prompt without clearing the draft", %{state: state} do
+      state = focus_prompt(state, "board draft")
+
+      {:handled, new_state} = walk_surface_handlers(state, 27, 0)
+      refute AgentAccess.input_focused?(new_state)
+      assert UIState.input_text(AgentAccess.panel(new_state)) == "board draft"
+      assert new_state.workspace.editing.mode == :normal
+    end
+
+    test "ESC keeps focus while cancelling visual and operator-pending prompt modes", %{
+      state: state
+    } do
+      for {enter_key, mode} <- [{?v, :visual}, {?d, :operator_pending}] do
+        state = focus_prompt(state, "#{mode} draft")
+
+        {:handled, mode_state} = walk_surface_handlers(state, enter_key, 0)
+        assert AgentAccess.input_focused?(mode_state)
+        assert Minga.Editing.mode(mode_state) == mode
+
+        {:handled, new_state} = walk_surface_handlers(mode_state, 27, 0)
+        assert AgentAccess.input_focused?(new_state)
+        assert new_state.workspace.editing.mode == :normal
+        assert UIState.input_text(AgentAccess.panel(new_state)) == "#{mode} draft"
+      end
+    end
+  end
+
+  # ══════════════════════════════════════════════════════════════════════════
   # Agent scope (full-screen agentic view)
   # ══════════════════════════════════════════════════════════════════════════
 
   describe "agent scope — normal mode" do
     setup do
-      {:ok, state: base_state(keymap_scope: :agent, agentic_active: true)}
+      {state, session, file_buffer, agent_buffer} = activated_agent_state()
+      {:ok, state: state, session: session, file_buffer: file_buffer, agent_buffer: agent_buffer}
     end
 
     test "navigation keys pass through Scoped and are handled by AgentNav", %{state: state} do
@@ -210,15 +298,14 @@ defmodule MingaEditor.Input.ScopedTest do
       end
     end
 
-    test "q returns to the recorded file tab and keeps the agent session", %{state: state} do
-      session = self()
-
-      state =
-        state
-        |> with_return_target(1)
-        |> with_active_agent_session(session)
-
+    test "q returns to the recorded file tab and keeps the agent session", %{
+      state: state,
+      session: session,
+      file_buffer: file_buffer
+    } do
       assert state.workspace.keymap_scope == :agent
+      assert AgentAccess.view(state).return_target.active_tab_id == 1
+      assert AgentAccess.view(state).return_target.active_buffer == file_buffer
 
       {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
       assert new_state.workspace.keymap_scope == :editor
@@ -232,8 +319,8 @@ defmodule MingaEditor.Input.ScopedTest do
     end
 
     test "ESC returns to the recorded file tab when nothing transient is open", %{state: state} do
-      state = with_return_target(state, 1)
       assert state.workspace.keymap_scope == :agent
+      assert AgentAccess.view(state).return_target.active_tab_id == 1
 
       {:handled, new_state} = Scoped.handle_key(state, 27, 0)
       assert new_state.workspace.keymap_scope == :editor
@@ -244,7 +331,6 @@ defmodule MingaEditor.Input.ScopedTest do
     test "return falls back to the most recent remaining file tab when the target closed", %{
       state: state
     } do
-      state = with_return_target(state, 1)
       {tb, fallback_tab} = TabBar.insert(state.shell_state.tab_bar, :file, "fallback.ex")
       {:ok, tb} = TabBar.remove(tb, 1)
       state = put_in(state.shell_state.tab_bar, tb)
@@ -254,22 +340,20 @@ defmodule MingaEditor.Input.ScopedTest do
       assert new_state.shell_state.tab_bar.active_id == fallback_tab.id
     end
 
-    test "return restores the recorded workspace keymap scope", %{state: state} do
-      state = with_return_target(state, 1, :file_tree)
-
-      {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
-      assert new_state.workspace.keymap_scope == :file_tree
-      assert new_state.shell_state.tab_bar.active_id == 1
-    end
-
-    test "return without file tabs does not create an untitled fallback", %{state: state} do
-      state = with_return_target(state, 1)
+    test "return without file tabs does not create an untitled fallback", %{
+      state: state,
+      file_buffer: file_buffer,
+      agent_buffer: agent_buffer
+    } do
       {:ok, tb} = TabBar.remove(state.shell_state.tab_bar, 1)
       state = put_in(state.shell_state.tab_bar, tb)
 
       {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
       assert new_state.workspace.keymap_scope == :editor
       assert TabBar.filter_by_kind(new_state.shell_state.tab_bar, :file) == []
+      assert new_state.workspace.buffers.active == file_buffer
+      assert hd(new_state.workspace.buffers.list) == file_buffer
+      refute new_state.workspace.buffers.active == agent_buffer
       assert new_state.shell_state.status_msg == "No file tabs in this workspace"
     end
 
@@ -321,10 +405,7 @@ defmodule MingaEditor.Input.ScopedTest do
     end
 
     test "ESC dismisses help before returning to the editor", %{state: state} do
-      state =
-        state
-        |> with_return_target(1)
-        |> AgentAccess.update_view(fn v -> %{v | help_visible: true} end)
+      state = AgentAccess.update_view(state, fn v -> %{v | help_visible: true} end)
 
       {:handled, new_state} = Scoped.handle_key(state, 27, 0)
       refute AgentAccess.view(new_state).help_visible
@@ -333,19 +414,37 @@ defmodule MingaEditor.Input.ScopedTest do
     end
 
     test "ESC leaves prompt focus without clearing prompt text before returning", %{state: state} do
-      state =
-        state
-        |> with_return_target(1)
-        |> AgentAccess.update_agent_ui(fn ui ->
-          ui
-          |> UIState.set_input_focused(true)
-          |> UIState.set_prompt_text("keep this")
-        end)
+      state = focus_prompt(state, "keep this")
+      agent_tab_id = TabBar.find_by_kind(state.shell_state.tab_bar, :agent).id
 
-      {:handled, new_state} = Scoped.handle_key(state, 27, 0)
-      refute AgentAccess.input_focused?(new_state)
-      assert UIState.prompt_text(AgentAccess.agent_ui(new_state)) == "keep this"
-      assert new_state.workspace.keymap_scope == :agent
+      {:handled, unfocused_state} = Scoped.handle_key(state, 27, 0)
+      refute AgentAccess.input_focused?(unfocused_state)
+      assert UIState.prompt_text(AgentAccess.agent_ui(unfocused_state)) == "keep this"
+      assert unfocused_state.workspace.keymap_scope == :agent
+
+      {:handled, returned_state} = Scoped.handle_key(unfocused_state, 27, 0)
+      assert returned_state.workspace.keymap_scope == :editor
+      assert returned_state.shell_state.tab_bar.active_id == 1
+
+      reopened_state = EditorState.switch_tab(returned_state, agent_tab_id)
+      assert UIState.prompt_text(AgentAccess.agent_ui(reopened_state)) == "keep this"
+    end
+
+    test "ESC keeps prompt focus when cancelling visual and operator-pending prompt states", %{
+      state: state
+    } do
+      for {enter_key, mode} <- [{?v, :visual}, {?d, :operator_pending}] do
+        state = state |> focus_prompt("#{mode} draft")
+
+        {:handled, mode_state} = Scoped.handle_key(state, enter_key, 0)
+        assert AgentAccess.input_focused?(mode_state)
+        assert Minga.Editing.mode(mode_state) == mode
+
+        {:handled, new_state} = Scoped.handle_key(mode_state, 27, 0)
+        assert AgentAccess.input_focused?(new_state)
+        assert new_state.workspace.editing.mode == :normal
+        assert UIState.prompt_text(AgentAccess.agent_ui(new_state)) == "#{mode} draft"
+      end
     end
   end
 

--- a/test/minga_editor/input/scoped_test.exs
+++ b/test/minga_editor/input/scoped_test.exs
@@ -71,6 +71,24 @@ defmodule MingaEditor.Input.ScopedTest do
     }
   end
 
+  defp with_return_target(state, tab_id, keymap_scope \\ :editor) do
+    return_target =
+      UIState.return_target(
+        tab_id,
+        state.workspace.buffers.active,
+        state.workspace.windows,
+        state.workspace.file_tree,
+        keymap_scope,
+        AgentAccess.input_focused?(state)
+      )
+
+    AgentAccess.update_agent_ui(state, &UIState.set_return_target(&1, return_target))
+  end
+
+  defp with_active_agent_session(state, session) do
+    EditorState.set_tab_session(state, state.shell_state.tab_bar.active_id, session)
+  end
+
   # ══════════════════════════════════════════════════════════════════════════
   # Editor scope (no panel)
   # ══════════════════════════════════════════════════════════════════════════
@@ -192,25 +210,67 @@ defmodule MingaEditor.Input.ScopedTest do
       end
     end
 
-    test "q switches from agent tab back to file tab and keeps agent tab", %{state: state} do
-      # The base_state with agentic_active: true already sets up:
-      # - file tab (id 1) and agent tab (id 2)
-      # - agent tab is active, keymap_scope is :agent
+    test "q returns to the recorded file tab and keeps the agent session", %{state: state} do
+      session = self()
+
+      state =
+        state
+        |> with_return_target(1)
+        |> with_active_agent_session(session)
+
       assert state.workspace.keymap_scope == :agent
 
       {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
       assert new_state.workspace.keymap_scope == :editor
+      assert new_state.shell_state.tab_bar.active_id == 1
       assert TabBar.filter_by_kind(new_state.shell_state.tab_bar, :agent) != []
+
+      assert Enum.any?(
+               new_state.shell_state.tab_bar.tabs,
+               &(&1.kind == :agent and &1.session == session)
+             )
     end
 
-    test "ESC switches from agent tab back to file tab when nothing transient is open", %{
-      state: state
-    } do
+    test "ESC returns to the recorded file tab when nothing transient is open", %{state: state} do
+      state = with_return_target(state, 1)
       assert state.workspace.keymap_scope == :agent
 
       {:handled, new_state} = Scoped.handle_key(state, 27, 0)
       assert new_state.workspace.keymap_scope == :editor
+      assert new_state.shell_state.tab_bar.active_id == 1
       assert TabBar.filter_by_kind(new_state.shell_state.tab_bar, :agent) != []
+    end
+
+    test "return falls back to the most recent remaining file tab when the target closed", %{
+      state: state
+    } do
+      state = with_return_target(state, 1)
+      {tb, fallback_tab} = TabBar.insert(state.shell_state.tab_bar, :file, "fallback.ex")
+      {:ok, tb} = TabBar.remove(tb, 1)
+      state = put_in(state.shell_state.tab_bar, tb)
+
+      {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
+      assert new_state.workspace.keymap_scope == :editor
+      assert new_state.shell_state.tab_bar.active_id == fallback_tab.id
+    end
+
+    test "return restores the recorded workspace keymap scope", %{state: state} do
+      state = with_return_target(state, 1, :file_tree)
+
+      {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
+      assert new_state.workspace.keymap_scope == :file_tree
+      assert new_state.shell_state.tab_bar.active_id == 1
+    end
+
+    test "return without file tabs does not create an untitled fallback", %{state: state} do
+      state = with_return_target(state, 1)
+      {:ok, tb} = TabBar.remove(state.shell_state.tab_bar, 1)
+      state = put_in(state.shell_state.tab_bar, tb)
+
+      {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
+      assert new_state.workspace.keymap_scope == :editor
+      assert TabBar.filter_by_kind(new_state.shell_state.tab_bar, :file) == []
+      assert new_state.shell_state.status_msg == "No file tabs in this workspace"
     end
 
     test "? toggles help", %{state: state} do
@@ -260,12 +320,32 @@ defmodule MingaEditor.Input.ScopedTest do
                AgentAccess.view(state).chat_width_pct
     end
 
-    test "ESC dismisses help when visible", %{state: state} do
+    test "ESC dismisses help before returning to the editor", %{state: state} do
       state =
-        AgentAccess.update_view(state, fn v -> %{v | help_visible: true} end)
+        state
+        |> with_return_target(1)
+        |> AgentAccess.update_view(fn v -> %{v | help_visible: true} end)
 
       {:handled, new_state} = Scoped.handle_key(state, 27, 0)
       refute AgentAccess.view(new_state).help_visible
+      assert new_state.workspace.keymap_scope == :agent
+      assert new_state.shell_state.tab_bar.active_id == state.shell_state.tab_bar.active_id
+    end
+
+    test "ESC leaves prompt focus without clearing prompt text before returning", %{state: state} do
+      state =
+        state
+        |> with_return_target(1)
+        |> AgentAccess.update_agent_ui(fn ui ->
+          ui
+          |> UIState.set_input_focused(true)
+          |> UIState.set_prompt_text("keep this")
+        end)
+
+      {:handled, new_state} = Scoped.handle_key(state, 27, 0)
+      refute AgentAccess.input_focused?(new_state)
+      assert UIState.prompt_text(AgentAccess.agent_ui(new_state)) == "keep this"
+      assert new_state.workspace.keymap_scope == :agent
     end
   end
 

--- a/test/minga_editor/shell/board/input_test.exs
+++ b/test/minga_editor/shell/board/input_test.exs
@@ -12,6 +12,7 @@ defmodule MingaEditor.Shell.Board.InputTest do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
+  alias MingaEditor.Agent.UIState
   alias MingaEditor.Viewport
   alias MingaEditor.Window.Content
   alias MingaEditor.Shell.Board
@@ -55,6 +56,44 @@ defmodule MingaEditor.Shell.Board.InputTest do
     state = editor_with_board(card_count)
     board = BoardState.zoom_into(state.shell_state, card_id, %{fake: :workspace})
     %{state | shell_state: board}
+  end
+
+  defp zoomed_board_prompt_state(mode, prompt_text) do
+    fake_session = fake_session_pid()
+    {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
+
+    board =
+      BoardState.new()
+      |> then(fn b ->
+        {b, _card} = BoardState.create_card(b, task: "Agent 1", session: fake_session)
+        b
+      end)
+      |> Map.put(:agent, %AgentState{buffer: agent_buf})
+
+    state = %EditorState{
+      port_manager: self(),
+      shell: Board,
+      shell_state: board,
+      workspace: %MingaEditor.Workspace.State{viewport: Viewport.new(24, 80)},
+      focus_stack: [BoardInput, MingaEditor.Input.GlobalBindings]
+    }
+
+    {:handled, state} = BoardInput.handle_key(state, @enter, 0)
+
+    mode_state =
+      case mode do
+        :normal -> nil
+        :visual -> %Minga.Mode.VisualState{visual_type: :char}
+        :operator_pending -> Minga.Mode.OperatorPendingState.new(:delete)
+      end
+
+    state
+    |> EditorState.transition_mode(mode, mode_state)
+    |> AgentAccess.update_agent_ui(fn ui ->
+      ui
+      |> UIState.set_input_focused(true)
+      |> UIState.set_prompt_text(prompt_text)
+    end)
   end
 
   defp stop_session(pid) when is_pid(pid) do
@@ -199,7 +238,8 @@ defmodule MingaEditor.Shell.Board.InputTest do
 
     test "first-time zoom matches re-zoom shape (modulo prompt content)" do
       # The acceptance criterion: first-zoom and re-zoom land in the same
-      # workspace shape — agent scope, agent-chat window, fresh agent_ui.
+      # workspace shape, and the real board handler stack requires two
+      # Escape presses after zooming in when the prompt is focused.
       fake_session = fake_session_pid()
       {:ok, agent_buf} = Minga.Buffer.start_link(content: "")
 
@@ -222,8 +262,15 @@ defmodule MingaEditor.Shell.Board.InputTest do
       # First zoom: bootstrap path
       {:handled, after_first_zoom} = BoardInput.handle_key(state, @enter, 0)
 
-      # Zoom out then back in: snapshot/restore path
-      {:handled, after_zoom_out} = ZoomOut.handle_key(after_first_zoom, @escape, 0)
+      # First Escape only unfocuses the prompt on the real Board stack.
+      {:handled, after_unfocus} = walk_board_surface_handlers(after_first_zoom, @escape, 0)
+      assert after_unfocus.shell_state.zoomed_into == after_first_zoom.shell_state.zoomed_into
+      refute AgentAccess.input_focused?(after_unfocus)
+      assert UIState.prompt_text(AgentAccess.panel(after_unfocus)) == ""
+
+      # Second Escape zooms out, then re-zooming should restore the same shape.
+      {:handled, after_zoom_out} = walk_board_surface_handlers(after_unfocus, @escape, 0)
+      assert after_zoom_out.shell_state.zoomed_into == nil
       {:handled, after_second_zoom} = BoardInput.handle_key(after_zoom_out, @enter, 0)
 
       # Both zoom-ins should produce the same shape.
@@ -343,6 +390,86 @@ defmodule MingaEditor.Shell.Board.InputTest do
   # ── Zoom out ───────────────────────────────────────────────────────────
 
   describe "Escape zooms out when zoomed" do
+    test "real board handler stack keeps a focused normal prompt from zooming out on q" do
+      state = zoomed_board_prompt_state(:normal, "focused draft")
+      zoomed_card_id = state.shell_state.zoomed_into
+
+      {:handled, new_state} = walk_board_surface_handlers(state, ?q, 0)
+      assert new_state.shell_state.zoomed_into == zoomed_card_id
+      assert AgentAccess.input_focused?(new_state)
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == "focused draft"
+    end
+
+    test "real board handler stack keeps a focused normal prompt zoomed on first Escape" do
+      state = zoomed_board_prompt_state(:normal, "normal draft")
+      zoomed_card_id = state.shell_state.zoomed_into
+
+      {:handled, unfocused_state} = walk_board_surface_handlers(state, @escape, 0)
+      assert unfocused_state.shell_state.zoomed_into == zoomed_card_id
+      refute AgentAccess.input_focused?(unfocused_state)
+      assert UIState.prompt_text(AgentAccess.panel(unfocused_state)) == "normal draft"
+      assert unfocused_state.workspace.keymap_scope == :agent
+      assert unfocused_state.workspace.editing.mode == :normal
+
+      {:handled, zoomed_out_state} = walk_board_surface_handlers(unfocused_state, @escape, 0)
+      assert zoomed_out_state.shell_state.zoomed_into == nil
+    end
+
+    test "real board handler stack lets leader q continue without zooming out" do
+      state = zoomed_board_prompt_state(:normal, "leader draft")
+      zoomed_card_id = state.shell_state.zoomed_into
+
+      {:handled, unfocused_state} = walk_board_surface_handlers(state, @escape, 0)
+      assert unfocused_state.shell_state.zoomed_into == zoomed_card_id
+      refute AgentAccess.input_focused?(unfocused_state)
+      assert UIState.prompt_text(AgentAccess.panel(unfocused_state)) == "leader draft"
+
+      leader_state =
+        put_in(
+          unfocused_state.workspace.editing.mode_state.leader_node,
+          Minga.Keymap.Defaults.leader_trie()
+        )
+
+      {:handled, new_state} = walk_board_surface_handlers(leader_state, ?q, 0)
+      assert new_state.shell_state.zoomed_into == zoomed_card_id
+      assert Minga.Editing.in_leader?(new_state)
+      assert UIState.prompt_text(AgentAccess.panel(new_state)) == "leader draft"
+      assert new_state.workspace.keymap_scope == :agent
+    end
+
+    test "real board handler stack keeps q zoomed out after the prompt is unfocused" do
+      state = zoomed_board_prompt_state(:normal, "normal draft")
+      zoomed_card_id = state.shell_state.zoomed_into
+      session = state.shell_state.cards[zoomed_card_id].session
+
+      {:handled, unfocused_state} = walk_board_surface_handlers(state, @escape, 0)
+      assert unfocused_state.shell_state.zoomed_into == zoomed_card_id
+      refute AgentAccess.input_focused?(unfocused_state)
+      assert UIState.prompt_text(AgentAccess.panel(unfocused_state)) == "normal draft"
+
+      {:handled, zoomed_out_state} = walk_board_surface_handlers(unfocused_state, ?q, 0)
+      assert zoomed_out_state.shell_state.zoomed_into == nil
+      assert zoomed_out_state.shell_state.cards[zoomed_card_id].session == session
+      assert AgentAccess.session(zoomed_out_state) == nil
+    end
+
+    test "real board handler stack keeps visual and operator-pending prompts zoomed while Esc normalizes the prompt" do
+      for {mode, draft} <- [
+            {:visual, "visual draft"},
+            {:operator_pending, "operator draft"}
+          ] do
+        state = zoomed_board_prompt_state(mode, draft)
+        zoomed_card_id = state.shell_state.zoomed_into
+
+        {:handled, new_state} = walk_board_surface_handlers(state, @escape, 0)
+        assert new_state.shell_state.zoomed_into == zoomed_card_id
+        assert AgentAccess.input_focused?(new_state)
+        assert UIState.prompt_text(AgentAccess.panel(new_state)) == draft
+        assert new_state.workspace.keymap_scope == :agent
+        assert new_state.workspace.editing.mode == :normal
+      end
+    end
+
     test "clears zoomed_into and snapshots workspace" do
       state = editor_zoomed_into(3, 1)
       assert state.shell_state.zoomed_into == 1
@@ -443,8 +570,13 @@ defmodule MingaEditor.Shell.Board.InputTest do
       {:handled, state} = BoardInput.handle_key(state, @enter, 0)
       assert AgentAccess.session(state) == session_a
 
-      # Zoom out: cache reset, grid view has no active session.
-      {:handled, state} = ZoomOut.handle_key(state, @escape, 0)
+      # Zoom out now takes two Esc presses because the first one is handled
+      # by the focused prompt and only the second one reaches ZoomOut.
+      {:handled, state} = walk_board_surface_handlers(state, @escape, 0)
+      refute AgentAccess.input_focused?(state)
+      assert state.shell_state.zoomed_into == 1
+
+      {:handled, state} = walk_board_surface_handlers(state, @escape, 0)
       assert AgentAccess.session(state) == nil
 
       # Focus B, zoom in. The active session must be B, not A.
@@ -589,5 +721,20 @@ defmodule MingaEditor.Shell.Board.InputTest do
       # Board.Input should passthrough since we're zoomed
       {:passthrough, _state} = BoardInput.handle_key(state, ?j, 0)
     end
+  end
+
+  # ── Helpers ────────────────────────────────────────────────────────────
+
+  defp walk_board_surface_handlers(state, cp, mods) do
+    Enum.reduce_while(
+      MingaEditor.Shell.Board.input_handlers(state).surface,
+      {:passthrough, state},
+      fn handler, {_, acc} ->
+        case handler.handle_key(acc, cp, mods) do
+          {:handled, new_state} -> {:halt, {:handled, new_state}}
+          {:passthrough, new_state} -> {:cont, {:passthrough, new_state}}
+        end
+      end
+    )
   end
 end


### PR DESCRIPTION
# TL;DR
Agent view now records the editor context it zoomed from and returns there with `q` or `Esc`, while keeping the agent session alive. This makes agent view behave like a workspace zoom surface instead of a mysterious tab switch.

Closes #1773

## Context
This is the next workspace-foundation slice from #1772. It separates agent session lifecycle from agent view zoom state so leaving the agent view restores the same workspace editor context when possible.

## Changes
- Added `MingaEditor.Agent.UIState.ReturnTarget` to record the active tab, active buffer, windows, file tree state, keymap scope, and prompt focus before opening agent view.
- Updated agent view activation and return commands so `q` returns to the recorded file tab, falls back to the most recent remaining file tab, and never stops the agent session.
- Expanded `Esc` behavior to dismiss transient agent UI before returning, including help, search, pending prefixes, mention completion, modal overlays, hover, and prompt focus.
- Preserved prompt text when leaving prompt/input mode.
- Avoided creating `[new]` fallback buffers when no file tab remains, showing a clear status instead.
- Updated agent help text and docs to say `q/Esc: return to editor`.

## Verification
- `mix test.llm test/minga_editor/agent_activation_test.exs test/minga_editor/input/scoped_test.exs`: PASS, 60 tests, 0 failures
- `mix test.llm`: PASS, 52 doctests, 99 properties, 8510 tests, 0 failures, 5 skipped, 219 excluded
- `make lint`: PASS, exit 0
- `git diff --check`: PASS, no output

## Acceptance Criteria Addressed
- Opening the agent view records the active workspace return target, including active tab id, active buffer, active window layout, file tree state, and prompt focus where applicable ✅
- `q` in agent scope returns to the recorded editor context for the same workspace and does not stop the agent session ✅
- `Esc` in agent scope dismisses transient UI before returning to the editor context, and prompt text is preserved when leaving prompt/input mode ✅
- If the recorded file tab was closed, returning from agent view selects the most recent remaining file tab in the same workspace ✅
- If no file tab remains in the workspace, returning from agent view shows a clear status instead of creating a `[new]` buffer ✅
- Selecting a file tab while agent view is active returns to editor view for that workspace ✅
- Agent view help text says `q/Esc: return to editor` and does not say `close agent split` ✅
