### PR TITLE
test: collapse another boundary cleanup batch

### DIFF
--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -127,60 +127,39 @@ defmodule MingaAgent.Providers.NativeTest do
 
   # ── Lifecycle tests ─────────────────────────────────────────────────────────
 
-  describe "init and get_state" do
-    test "starts with correct initial state", %{tmp_dir: dir} do
-      {:ok, pid} = start_provider(tmp_dir: dir)
-
-      assert {:ok, session_state} = Native.get_state(pid)
-      assert session_state.model.provider == "native"
-      assert session_state.is_streaming == false
-    end
-
-    test "get_state exposes context fields used by subagents", %{tmp_dir: dir} do
+  describe "init, context, and thinking level" do
+    test "get_state exposes initial model, project context, skills, and AGENTS instructions", %{
+      tmp_dir: dir
+    } do
       write_project_skill(dir, "plan", "PLAN SKILL 1419")
+      File.write!(Path.join(dir, "AGENTS.md"), "PROJECT RULE 1419")
 
       {:ok, pid} =
         start_provider(tmp_dir: dir, thinking_level: "high", active_skill_names: ["plan"])
 
       assert {:ok, session_state} = Native.get_state(pid)
+      assert session_state.model.provider == "native"
       assert session_state.model.id == "anthropic:claude-sonnet-4-20250514"
+      assert session_state.is_streaming == false
       assert session_state.thinking_level == "high"
       assert session_state.active_skill_names == ["plan"]
       assert session_state.project_root == dir
       assert session_state.system_prompt =~ "PLAN SKILL 1419"
-    end
-
-    test "system prompt includes project AGENTS.md instructions for the inherited project root",
-         %{tmp_dir: dir} do
-      File.write!(Path.join(dir, "AGENTS.md"), "PROJECT RULE 1419")
-      {:ok, pid} = start_provider(tmp_dir: dir)
-
-      assert {:ok, session_state} = Native.get_state(pid)
       assert session_state.system_prompt =~ "PROJECT RULE 1419"
     end
-  end
 
-  describe "thinking level" do
-    test "set_thinking_level accepts valid levels", %{tmp_dir: dir} do
+    test "thinking level accepts known values, rejects unknown values, and cycles in order", %{
+      tmp_dir: dir
+    } do
       {:ok, pid} = start_provider(tmp_dir: dir)
 
-      assert :ok = Native.set_thinking_level(pid, "low")
-      assert :ok = Native.set_thinking_level(pid, "medium")
-      assert :ok = Native.set_thinking_level(pid, "high")
-      assert :ok = Native.set_thinking_level(pid, "off")
-    end
-
-    test "set_thinking_level rejects unknown levels", %{tmp_dir: dir} do
-      {:ok, pid} = start_provider(tmp_dir: dir)
+      for level <- ["low", "medium", "high", "off"] do
+        assert :ok = Native.set_thinking_level(pid, level)
+      end
 
       assert {:error, msg} = Native.set_thinking_level(pid, "turbo")
       assert msg =~ "unknown thinking level"
-    end
 
-    test "cycle_thinking_level rotates through levels", %{tmp_dir: dir} do
-      {:ok, pid} = start_provider(tmp_dir: dir)
-
-      # Default is "off", cycling should go: off -> low -> medium -> high -> off
       assert {:ok, %{"level" => "low"}} = Native.cycle_thinking_level(pid)
       assert {:ok, %{"level" => "medium"}} = Native.cycle_thinking_level(pid)
       assert {:ok, %{"level" => "high"}} = Native.cycle_thinking_level(pid)
@@ -229,73 +208,10 @@ defmodule MingaAgent.Providers.NativeTest do
     end
   end
 
-  describe "set_model" do
-    test "updates the model without resetting context", %{tmp_dir: dir} do
-      # Track what messages the LLM client receives on each call.
-      # The client runs inside a Task, so we send to the test pid explicitly.
-      test_pid = self()
-      calls = :counters.new(1, [:atomics])
-      messages_ref = make_ref()
-
-      client = fn _model, messages, _opts ->
-        count = :counters.get(calls, 1)
-        :counters.add(calls, 1, 1)
-        send(test_pid, {messages_ref, count, messages})
-
-        chunks = [
-          ReqLLM.StreamChunk.text("Response #{count}"),
-          ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
-        ]
-
-        build_stream_response(chunks)
-      end
-
-      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client)
-
-      # First prompt builds context
-      :ok = Native.send_prompt(pid, "Hello")
-      _events = collect_events(500)
-
-      # Switch model
-      assert :ok = Native.set_model(pid, "anthropic:claude-opus-4-20250514")
-
-      # Verify model changed
-      assert {:ok, state} = Native.get_state(pid)
-      assert state.model.id == "anthropic:claude-opus-4-20250514"
-
-      # Second prompt should carry the conversation context from the first
-      :ok = Native.send_prompt(pid, "Follow up")
-      _events = collect_events(500)
-
-      # The second LLM call (count=1) should have received prior messages
-      assert_received {^messages_ref, 1, messages}
-
-      # Should have at least: system prompt, user "Hello", assistant "Response 0", user "Follow up"
-      assert length(messages) >= 4
-    end
-
-    test "returns the model in get_state after set_model", %{tmp_dir: dir} do
-      {:ok, pid} = start_provider(tmp_dir: dir)
-
-      assert :ok = Native.set_model(pid, "openai:gpt-4o")
-
-      assert {:ok, state} = Native.get_state(pid)
-      assert state.model.id == "openai:gpt-4o"
-    end
-
-    test "set_model preserves the semantic thinking level across providers", %{tmp_dir: dir} do
-      {:ok, pid} = start_provider(tmp_dir: dir, thinking_level: "medium")
-
-      assert :ok = Native.set_model(pid, "openai:o4-mini")
-
-      assert {:ok, state} = Native.get_state(pid)
-      assert state.model.id == "openai:o4-mini"
-      assert state.thinking_level == "medium"
-    end
-  end
-
-  describe "cycle_model preserves context" do
-    test "conversation history survives model cycling", %{tmp_dir: dir} do
+  describe "model changes" do
+    test "set_model updates state, preserves thinking level, and keeps conversation context", %{
+      tmp_dir: dir
+    } do
       test_pid = self()
       calls = :counters.new(1, [:atomics])
       messages_ref = make_ref()
@@ -305,38 +221,26 @@ defmodule MingaAgent.Providers.NativeTest do
         :counters.add(calls, 1, 1)
         send(test_pid, {messages_ref, count, model, messages})
 
-        chunks = [
+        build_stream_response([
           ReqLLM.StreamChunk.text("Response #{count}"),
           ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
-        ]
-
-        build_stream_response(chunks)
+        ])
       end
 
-      {:ok, pid} =
-        start_provider(
-          tmp_dir: dir,
-          llm_client: client,
-          model: "anthropic:claude-sonnet-4-20250514"
-        )
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, thinking_level: "medium")
 
-      # Build some conversation context
-      :ok = Native.send_prompt(pid, "First message")
-      _events = collect_events(500)
+      :ok = Native.send_prompt(pid, "Hello")
+      collect_events(500)
 
-      # Use set_model to switch (cycle_model requires agent_models config;
-      # set_model uses the same state update path without config lookup)
-      assert :ok = Native.set_model(pid, "anthropic:claude-opus-4-20250514")
+      assert :ok = Native.set_model(pid, "openai:o4-mini")
+      assert {:ok, state} = Native.get_state(pid)
+      assert state.model.id == "openai:o4-mini"
+      assert state.thinking_level == "medium"
 
-      # Send another prompt; context should be preserved
-      :ok = Native.send_prompt(pid, "Second message after model switch")
-      _events = collect_events(500)
+      :ok = Native.send_prompt(pid, "Follow up")
+      collect_events(500)
 
-      # Verify the second call used the new model
-      assert_received {^messages_ref, 1, model, messages}
-      assert model == "anthropic:claude-opus-4-20250514"
-
-      # Verify prior conversation was included
+      assert_received {^messages_ref, 1, "openai:o4-mini", messages}
       assert length(messages) >= 4
     end
   end
@@ -353,56 +257,35 @@ defmodule MingaAgent.Providers.NativeTest do
 
   # ── Streaming tests ─────────────────────────────────────────────────────────
 
-  describe "send_prompt with text-only response" do
-    test "emits AgentStart, TextDelta, and AgentEnd events", %{tmp_dir: dir} do
+  describe "send_prompt streaming" do
+    test "emits start, text, thinking, and end events", %{tmp_dir: dir} do
       chunks = [
+        ReqLLM.StreamChunk.thinking("Let me think..."),
         ReqLLM.StreamChunk.text("Hello "),
         ReqLLM.StreamChunk.text("world!"),
         ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
       ]
 
-      client = fake_llm_client(chunks, %{input_tokens: 10, output_tokens: 5})
-      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client)
+      {:ok, pid} =
+        start_provider(
+          tmp_dir: dir,
+          llm_client: fake_llm_client(chunks, %{input_tokens: 10, output_tokens: 5})
+        )
 
       assert :ok = Native.send_prompt(pid, "Hi")
 
       events = collect_events(500)
-
-      # Should have: AgentStart, TextDelta("Hello "), TextDelta("world!"), AgentEnd
       assert %Event.AgentStart{} = Enum.at(events, 0)
 
-      text_deltas = Enum.filter(events, &match?(%Event.TextDelta{}, &1))
-      assert length(text_deltas) == 2
-      assert Enum.at(text_deltas, 0).delta == "Hello "
-      assert Enum.at(text_deltas, 1).delta == "world!"
+      assert [%Event.ThinkingDelta{delta: "Let me think..."}] =
+               Enum.filter(events, &match?(%Event.ThinkingDelta{}, &1))
 
-      agent_end = Enum.find(events, &match?(%Event.AgentEnd{}, &1))
-      assert agent_end != nil
-    end
-  end
+      assert Enum.map(Enum.filter(events, &match?(%Event.TextDelta{}, &1)), & &1.delta) == [
+               "Hello ",
+               "world!"
+             ]
 
-  describe "send_prompt with thinking response" do
-    test "emits ThinkingDelta events", %{tmp_dir: dir} do
-      chunks = [
-        ReqLLM.StreamChunk.thinking("Let me think..."),
-        ReqLLM.StreamChunk.text("The answer is 42."),
-        ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
-      ]
-
-      client = fake_llm_client(chunks)
-      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client)
-
-      assert :ok = Native.send_prompt(pid, "What is the answer?")
-
-      events = collect_events(500)
-
-      thinking = Enum.filter(events, &match?(%Event.ThinkingDelta{}, &1))
-      assert length(thinking) == 1
-      assert hd(thinking).delta == "Let me think..."
-
-      text = Enum.filter(events, &match?(%Event.TextDelta{}, &1))
-      assert length(text) == 1
-      assert hd(text).delta == "The answer is 42."
+      assert Enum.any?(events, &match?(%Event.AgentEnd{}, &1))
     end
   end
 
@@ -828,49 +711,31 @@ defmodule MingaAgent.Providers.NativeTest do
   # ── Cost budget tests (#404) ────────────────────────────────────────────────
 
   describe "cost budget" do
-    test "get_budget returns current session cost and limits", %{tmp_dir: dir} do
-      {:ok, pid} = start_provider(tmp_dir: dir, max_cost: 5.0)
+    test "budget can be read, changed, disabled, and reset by new_session", %{tmp_dir: dir} do
+      usage = %{input_tokens: 1000, output_tokens: 500, total_cost: 0.05}
+
+      client =
+        fake_llm_client(
+          [ReqLLM.StreamChunk.text("Hello"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})],
+          usage
+        )
+
+      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client, max_cost: 5.0)
 
       assert {:ok, budget} = GenServer.call(pid, :get_budget)
       assert budget.session_cost == 0.0
       assert budget.max_cost == 5.0
       assert budget.max_turns == 100
-    end
-
-    test "set_max_cost updates the budget", %{tmp_dir: dir} do
-      {:ok, pid} = start_provider(tmp_dir: dir)
 
       assert :ok = GenServer.call(pid, {:set_max_cost, 10.0})
-      assert {:ok, budget} = GenServer.call(pid, :get_budget)
-      assert budget.max_cost == 10.0
-    end
-
-    test "set_max_cost nil disables the budget", %{tmp_dir: dir} do
-      {:ok, pid} = start_provider(tmp_dir: dir, max_cost: 5.0)
+      assert {:ok, %{max_cost: 10.0}} = GenServer.call(pid, :get_budget)
 
       assert :ok = GenServer.call(pid, {:set_max_cost, nil})
-      assert {:ok, budget} = GenServer.call(pid, :get_budget)
-      assert budget.max_cost == nil
-    end
-
-    test "session cost resets on new_session", %{tmp_dir: dir} do
-      chunks = [
-        ReqLLM.StreamChunk.text("Hello"),
-        ReqLLM.StreamChunk.meta(%{finish_reason: :stop})
-      ]
-
-      usage = %{input_tokens: 1000, output_tokens: 500, total_cost: 0.05}
-      client = fake_llm_client(chunks, usage)
-
-      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client)
+      assert {:ok, %{max_cost: nil}} = GenServer.call(pid, :get_budget)
 
       :ok = Native.send_prompt(pid, "test")
-      _events = collect_events(500)
+      collect_events(500)
 
-      # Cost should have accumulated
-      # (exact amount depends on cost calculation, but should be > 0 after a turn)
-
-      # Reset
       :ok = Native.new_session(pid)
       assert {:ok, budget} = GenServer.call(pid, :get_budget)
       assert budget.session_cost == 0.0
@@ -956,131 +821,52 @@ defmodule MingaAgent.Providers.NativeTest do
   end
 
   describe "custom API base URL" do
-    test "API base URL override injects base_url into stream opts", %{tmp_dir: dir} do
-      test_pid = self()
+    test "base_url option follows override, per-provider, global, and unset precedence", %{
+      tmp_dir: dir
+    } do
+      cases = [
+        {agent_config(api_base_url_override: "https://gateway.corp.com/v1"),
+         "https://gateway.corp.com/v1"},
+        {%AgentConfig{}, nil},
+        {agent_config(
+           api_base_url: "https://global.example.com/v1",
+           api_endpoints: %{
+             "anthropic" => "https://anthropic-gw.corp.com/v1",
+             "openai" => "https://openai-gw.corp.com/v1"
+           }
+         ), "https://anthropic-gw.corp.com/v1"},
+        {agent_config(
+           api_base_url: "https://global.example.com/v1",
+           api_endpoints: %{"openai" => "https://openai-only.com/v1"}
+         ), "https://global.example.com/v1"},
+        {agent_config(
+           api_base_url_override: "https://env-override.com/v1",
+           api_endpoints: %{"anthropic" => "https://should-lose.com"}
+         ), "https://env-override.com/v1"}
+      ]
 
-      capturing_client = fn _model, _messages, opts ->
-        send(test_pid, {:captured_opts, opts})
-        build_stream_response([{:text, "ok"}])
+      for {config, expected_base_url} <- cases do
+        ref = make_ref()
+        test_pid = self()
+
+        capturing_client = fn _model, _messages, opts ->
+          send(test_pid, {ref, opts})
+          build_stream_response([{:text, "ok"}])
+        end
+
+        {:ok, pid} = start_provider(tmp_dir: dir, llm_client: capturing_client, config: config)
+        :ok = Native.send_prompt(pid, "test")
+
+        assert_receive {^ref, opts}, 2_000
+
+        if expected_base_url do
+          assert Keyword.get(opts, :base_url) == expected_base_url
+        else
+          refute Keyword.has_key?(opts, :base_url)
+        end
+
+        collect_events(500)
       end
-
-      {:ok, pid} =
-        start_provider(
-          tmp_dir: dir,
-          llm_client: capturing_client,
-          config: agent_config(api_base_url_override: "https://gateway.corp.com/v1")
-        )
-
-      :ok = Native.send_prompt(pid, "test")
-
-      assert_receive {:captured_opts, opts}, 2_000
-      assert Keyword.get(opts, :base_url) == "https://gateway.corp.com/v1"
-
-      # Collect remaining events so the process winds down
-      collect_events(500)
-    end
-
-    test "no base_url when no base URL config is set", %{tmp_dir: dir} do
-      test_pid = self()
-
-      capturing_client = fn _model, _messages, opts ->
-        send(test_pid, {:captured_opts, opts})
-        build_stream_response([{:text, "ok"}])
-      end
-
-      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: capturing_client)
-      :ok = Native.send_prompt(pid, "test")
-
-      assert_receive {:captured_opts, opts}, 2_000
-      refute Keyword.has_key?(opts, :base_url)
-
-      collect_events(500)
-    end
-
-    test "per-provider endpoint from config takes precedence over global", %{tmp_dir: dir} do
-      test_pid = self()
-
-      capturing_client = fn _model, _messages, opts ->
-        send(test_pid, {:captured_opts, opts})
-        build_stream_response([{:text, "ok"}])
-      end
-
-      config =
-        agent_config(
-          api_base_url: "https://global.example.com/v1",
-          api_endpoints: %{
-            "anthropic" => "https://anthropic-gw.corp.com/v1",
-            "openai" => "https://openai-gw.corp.com/v1"
-          }
-        )
-
-      {:ok, pid} =
-        start_provider(
-          tmp_dir: dir,
-          llm_client: capturing_client,
-          model: "anthropic:claude-sonnet-4-20250514",
-          config: config
-        )
-
-      :ok = Native.send_prompt(pid, "test")
-
-      assert_receive {:captured_opts, opts}, 2_000
-      assert Keyword.get(opts, :base_url) == "https://anthropic-gw.corp.com/v1"
-
-      collect_events(500)
-    end
-
-    test "global base_url is used when no per-provider match", %{tmp_dir: dir} do
-      test_pid = self()
-
-      capturing_client = fn _model, _messages, opts ->
-        send(test_pid, {:captured_opts, opts})
-        build_stream_response([{:text, "ok"}])
-      end
-
-      config =
-        agent_config(
-          api_base_url: "https://global.example.com/v1",
-          api_endpoints: %{"openai" => "https://openai-only.com/v1"}
-        )
-
-      {:ok, pid} =
-        start_provider(
-          tmp_dir: dir,
-          llm_client: capturing_client,
-          model: "anthropic:claude-sonnet-4-20250514",
-          config: config
-        )
-
-      :ok = Native.send_prompt(pid, "test")
-
-      assert_receive {:captured_opts, opts}, 2_000
-      assert Keyword.get(opts, :base_url) == "https://global.example.com/v1"
-
-      collect_events(500)
-    end
-
-    test "base URL override takes precedence over per-provider endpoint", %{tmp_dir: dir} do
-      test_pid = self()
-
-      capturing_client = fn _model, _messages, opts ->
-        send(test_pid, {:captured_opts, opts})
-        build_stream_response([{:text, "ok"}])
-      end
-
-      config =
-        agent_config(
-          api_base_url_override: "https://env-override.com/v1",
-          api_endpoints: %{"anthropic" => "https://should-lose.com"}
-        )
-
-      {:ok, pid} = start_provider(tmp_dir: dir, llm_client: capturing_client, config: config)
-      :ok = Native.send_prompt(pid, "test")
-
-      assert_receive {:captured_opts, opts}, 2_000
-      assert Keyword.get(opts, :base_url) == "https://env-override.com/v1"
-
-      collect_events(500)
     end
   end
 

--- a/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
+++ b/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
@@ -1,11 +1,5 @@
 defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
-  @moduledoc """
-  Tests for fingerprint-based change detection in `sync_swiftui_chrome/4`.
-
-  Verifies that unchanged chrome components are skipped on subsequent
-  frames, and that changed components are re-sent. Inspects the returned
-  `Caches` struct rather than the process dictionary.
-  """
+  @moduledoc "Tests fingerprint-based change detection in `sync_swiftui_chrome/4`."
 
   use ExUnit.Case, async: true
 
@@ -13,124 +7,40 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
   alias Minga.Diagnostics.Diagnostic
   alias Minga.LSP.SyncServer
   alias Minga.Project.FileTree
+  alias MingaEditor.Frontend.Emit.Context
+  alias MingaEditor.Frontend.Emit.GUI, as: EmitGUI
+  alias MingaEditor.MinibufferData
   alias MingaEditor.Renderer.Caches
+  alias MingaEditor.Shell.Board.State, as: BoardState
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Windows
   alias MingaEditor.StatusBar.Data, as: StatusBarData
-  alias MingaEditor.MinibufferData
-  alias MingaEditor.Frontend.Emit.Context
-  alias MingaEditor.Frontend.Emit.GUI, as: EmitGUI
-  alias MingaEditor.Shell.Board.State, as: BoardState
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
-  alias MingaEditor.State.Windows
 
   import MingaEditor.RenderPipeline.TestHelpers
 
-  defp flush_port_casts do
-    receive do
-      {:"$gen_cast", {:send_commands, _}} -> flush_port_casts()
-    after
-      0 -> :ok
-    end
-  end
-
-  defp collect_port_casts do
-    collect_port_casts([])
-  end
-
-  defp collect_port_casts(acc) do
-    receive do
-      {:"$gen_cast", {:send_commands, cmds}} -> collect_port_casts([cmds | acc])
-    after
-      0 -> Enum.reverse(acc)
-    end
-  end
+  @moduletag :tmp_dir
 
   describe "sync_swiftui_chrome/4 fingerprint caching" do
-    test "sends chrome commands on first call" do
+    test "first frame sends chrome commands, then unchanged frames send only status bar" do
       state = gui_state()
-      sb_data = StatusBarData.from_state(state)
 
-      EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
+      {_ctx, caches, first_cmds} = sync_chrome(state)
+      assert first_cmds != []
 
-      casts = collect_port_casts()
-      assert casts != [], "expected at least one port cast on first call"
-
-      all_cmds = List.flatten(casts)
-      assert all_cmds != []
+      {_ctx, _caches, second_cmds} = sync_chrome(state, caches)
+      assert opcode_count(second_cmds, 0x76) == 1
+      assert length(second_cmds) == 1
     end
 
-    test "skips unchanged chrome on second call with identical state" do
+    test "theme fingerprint includes color content, not only theme name" do
       state = gui_state()
-      sb_data = StatusBarData.from_state(state)
-
-      # First call: populates caches.
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      flush_port_casts()
-
-      # Second call with the same state and populated caches: only status bar should be sent.
-      EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, caches)
-      casts = collect_port_casts()
-
-      assert length(casts) == 1, "expected exactly one port cast (status bar always sent)"
-
-      all_cmds = List.flatten(casts)
-
-      status_bar_cmds =
-        Enum.filter(all_cmds, fn
-          <<0x76, _::binary>> -> true
-          _ -> false
-        end)
-
-      assert length(status_bar_cmds) == 1,
-             "expected exactly one status bar command on unchanged second call"
-
-      assert length(all_cmds) == 1,
-             "expected only status bar command on second call, got #{length(all_cmds)} commands"
-    end
-
-    test "re-sends chrome when state changes between calls" do
-      state = gui_state(content: long_content(50))
-      sb_data = StatusBarData.from_state(state)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      flush_port_casts()
-
-      changed_state = %{state | theme: MingaEditor.UI.Theme.get!(:one_dark)}
-      sb_data2 = StatusBarData.from_state(changed_state)
-
-      EmitGUI.sync_swiftui_chrome(Context.from_editor_state(changed_state), sb_data2, nil, caches)
-      casts = collect_port_casts()
-
-      all_cmds = List.flatten(casts)
-
-      theme_cmds =
-        Enum.filter(all_cmds, fn
-          <<0x74, _::binary>> -> true
-          _ -> false
-        end)
-
-      assert length(theme_cmds) == 1, "expected theme command after theme change"
-      assert length(all_cmds) > 1, "expected more than just status bar after theme change"
-    end
-
-    test "theme cache changes when same-name theme colors change" do
-      state = gui_state()
-      sb_data = StatusBarData.from_state(state)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      flush_port_casts()
-
+      {_ctx, caches, _cmds} = sync_chrome(state)
       theme = state.theme
 
       changed_theme = %{
@@ -140,182 +50,64 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
 
       changed_state = %{state | theme: changed_theme}
 
-      {_ctx, caches2} =
-        EmitGUI.sync_swiftui_chrome(
-          Context.from_editor_state(changed_state),
-          StatusBarData.from_state(changed_state),
-          nil,
-          caches
-        )
+      {_ctx, caches2, cmds} = sync_chrome(changed_state, caches)
 
-      casts = collect_port_casts()
-      all_cmds = List.flatten(casts)
-
-      assert Enum.any?(all_cmds, &match?(<<0x74, _::binary>>, &1)),
-             "expected gui_theme command when same-name colors change"
-
+      assert opcode_count(cmds, 0x74) == 1
+      assert length(cmds) > 1
       refute caches2.last_gui_theme == caches.last_gui_theme
     end
 
-    test "file tree cache key is populated after first call" do
-      state = gui_state()
-      sb_data = StatusBarData.from_state(state)
-
-      caches0 = %Caches{}
-      assert caches0.last_gui_file_tree_fp == nil
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, caches0)
-
-      flush_port_casts()
-
-      assert caches.last_gui_file_tree_fp == {:no_tree, ""}
-    end
-
-    test "hidden file tree command carries project root for shared GUI chrome" do
-      root = "/tmp/minga-project"
-      state = gui_state()
-      state = put_in(state.workspace.file_tree.project_root, root)
-      sb_data = StatusBarData.from_state(state)
-
-      EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      all_cmds = collect_port_casts() |> List.flatten()
-      root_len = byte_size(root)
-
-      assert Enum.any?(all_cmds, fn
-               <<0x93, payload_len::32, payload::binary-size(payload_len)>> ->
-                 match?(
-                   <<2::8, tree_flags::8, 0::8, 0::16, ^root_len::16,
-                     ^root::binary-size(root_len), 0::16, 0::16, 0::16>>
-                   when Bitwise.band(tree_flags, 0x01) == 0,
-                   payload
-                 )
-
-               _ ->
-                 false
-             end)
-    end
-
-    test "hidden file tree cache resends when project root changes" do
+    test "hidden file tree cache includes project root and resends when it changes" do
       first_root = "/tmp/first-project"
       second_root = "/tmp/second-project"
 
-      first_state = gui_state()
-      first_state = put_in(first_state.workspace.file_tree.project_root, first_root)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(
-          Context.from_editor_state(first_state),
-          StatusBarData.from_state(first_state),
-          nil,
-          %Caches{}
+      first_state =
+        gui_state()
+        |> put_in(
+          [Access.key(:workspace), Access.key(:file_tree), Access.key(:project_root)],
+          first_root
         )
 
-      flush_port_casts()
+      {_ctx, caches, first_cmds} = sync_chrome(first_state)
+      assert Enum.any?(first_cmds, &hidden_tree_cmd_for_root?(&1, first_root))
+      assert caches.last_gui_file_tree_fp == {:no_tree, first_root}
 
-      second_state = gui_state()
-      second_state = put_in(second_state.workspace.file_tree.project_root, second_root)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(
-          Context.from_editor_state(second_state),
-          StatusBarData.from_state(second_state),
-          nil,
-          caches
+      second_state =
+        gui_state()
+        |> put_in(
+          [Access.key(:workspace), Access.key(:file_tree), Access.key(:project_root)],
+          second_root
         )
 
-      all_cmds = collect_port_casts() |> List.flatten()
-      root_len = byte_size(second_root)
+      {_ctx, caches2, second_cmds} = sync_chrome(second_state, caches)
 
-      assert caches.last_gui_file_tree_fp == {:no_tree, second_root}
-
-      assert Enum.any?(all_cmds, fn
-               <<0x93, payload_len::32, payload::binary-size(payload_len)>> ->
-                 match?(
-                   <<2::8, tree_flags::8, 0::8, 0::16, ^root_len::16,
-                     ^second_root::binary-size(root_len), 0::16, 0::16, 0::16>>
-                   when Bitwise.band(tree_flags, 0x01) == 0,
-                   payload
-                 )
-
-               _ ->
-                 false
-             end)
+      assert Enum.any?(second_cmds, &hidden_tree_cmd_for_root?(&1, second_root))
+      assert caches2.last_gui_file_tree_fp == {:no_tree, second_root}
     end
 
-    test "ready large file trees reuse cached rows on the second frame" do
-      root =
-        Path.join(System.tmp_dir!(), "minga-gui-file-tree-#{System.unique_integer([:positive])}")
+    test "ready file tree rows are cached, but diagnostics and selection changes emit targeted updates",
+         %{tmp_dir: tmp_dir} do
+      {state, file_tree, file_path} = ready_file_tree_state(tmp_dir, count: 300)
 
-      File.mkdir_p!(root)
+      {_ctx, caches, first_cmds} = sync_chrome(state)
+      assert has_opcode?(first_cmds, 0x93)
 
-      for index <- 1..300 do
-        filename = "file_#{String.pad_leading(Integer.to_string(index), 3, "0")}.ex"
-        File.write!(Path.join(root, filename), "")
-      end
-
-      file_tree = FileTreeState.open(%FileTreeState{}, FileTree.new(root, width: 32), nil)
-
-      state = gui_state()
-      state = put_in(state.workspace.file_tree, file_tree)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(
-          Context.from_editor_state(state),
-          StatusBarData.from_state(state),
-          nil,
-          %Caches{}
-        )
-
-      first_cmds = collect_port_casts() |> List.flatten()
-      assert Enum.any?(first_cmds, &match?(<<0x93, _::binary>>, &1))
-
-      {_ctx, caches2} =
-        EmitGUI.sync_swiftui_chrome(
-          Context.from_editor_state(state),
-          StatusBarData.from_state(state),
-          nil,
-          caches
-        )
-
-      second_cmds = collect_port_casts() |> List.flatten()
-
+      {_ctx, caches2, cached_cmds} = sync_chrome(state, caches)
       assert caches2.last_gui_file_tree_fp == caches.last_gui_file_tree_fp
-      refute Enum.any?(second_cmds, &match?(<<0x93, _::binary>>, &1))
-    end
+      refute has_opcode?(cached_cmds, 0x93)
 
-    test "ready file trees resend full GUI rows when diagnostics change" do
-      root =
-        Path.join(
-          System.tmp_dir!(),
-          "minga-gui-file-tree-diagnostics-#{System.unique_integer([:positive])}"
+      moved_state =
+        put_in(
+          state.workspace.file_tree,
+          FileTreeState.replace_tree(file_tree, FileTree.select(file_tree.tree, 42))
         )
 
-      File.mkdir_p!(root)
-      file_path = Path.join(root, "alpha.ex")
-      File.write!(file_path, "")
+      {_ctx, _caches3, moved_cmds} = sync_chrome(moved_state, caches)
+      refute has_opcode?(moved_cmds, 0x93)
+      assert opcode_count(moved_cmds, 0x94) == 1
 
       uri = SyncServer.path_to_uri(file_path)
-
-      on_exit(fn ->
-        Diagnostics.clear(:gui_file_tree_cache_test, uri)
-      end)
-
-      file_tree = FileTreeState.open(%FileTreeState{}, FileTree.new(root, width: 32), nil)
-
-      state = gui_state()
-      state = put_in(state.workspace.file_tree, file_tree)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(
-          Context.from_editor_state(state),
-          StatusBarData.from_state(state),
-          nil,
-          %Caches{}
-        )
-
-      flush_port_casts()
+      on_exit(fn -> Diagnostics.clear(:gui_file_tree_cache_test, uri) end)
 
       :ok =
         Diagnostics.publish(:gui_file_tree_cache_test, uri, [
@@ -326,194 +118,65 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
           }
         ])
 
-      {_ctx, _caches2} =
-        EmitGUI.sync_swiftui_chrome(
-          Context.from_editor_state(state),
-          StatusBarData.from_state(state),
-          nil,
-          caches
-        )
-
-      cmds = collect_port_casts() |> List.flatten()
-
-      assert Enum.any?(cmds, &match?(<<0x93, _::binary>>, &1))
-      refute Enum.any?(cmds, &match?(<<0x94, _::binary>>, &1))
-    end
-
-    test "ready large file tree selection changes emit selection update without resending rows" do
-      root =
-        Path.join(
-          System.tmp_dir!(),
-          "minga-gui-file-tree-selection-#{System.unique_integer([:positive])}"
-        )
-
-      File.mkdir_p!(root)
-
-      for index <- 1..300 do
-        filename = "file_#{String.pad_leading(Integer.to_string(index), 3, "0")}.ex"
-        File.write!(Path.join(root, filename), "")
-      end
-
-      file_tree = FileTreeState.open(%FileTreeState{}, FileTree.new(root, width: 32), nil)
-
-      state = gui_state()
-      state = put_in(state.workspace.file_tree, file_tree)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(
-          Context.from_editor_state(state),
-          StatusBarData.from_state(state),
-          nil,
-          %Caches{}
-        )
-
-      flush_port_casts()
-
-      moved_tree = FileTreeState.replace_tree(file_tree, FileTree.select(file_tree.tree, 42))
-      moved_state = put_in(state.workspace.file_tree, moved_tree)
-
-      {_ctx, _caches2} =
-        EmitGUI.sync_swiftui_chrome(
-          Context.from_editor_state(moved_state),
-          StatusBarData.from_state(moved_state),
-          nil,
-          caches
-        )
-
-      second_cmds = collect_port_casts() |> List.flatten()
-
-      refute Enum.any?(second_cmds, &match?(<<0x93, _::binary>>, &1))
-      assert [<<0x94, _::binary>>] = Enum.filter(second_cmds, &match?(<<0x94, _::binary>>, &1))
+      {_ctx, _caches4, diagnostic_cmds} = sync_chrome(state, caches)
+      assert has_opcode?(diagnostic_cmds, 0x93)
+      refute has_opcode?(diagnostic_cmds, 0x94)
     end
 
     test "git syncing and toast changes re-send hidden git status command" do
       state = gui_state()
-      sb_data = StatusBarData.from_state(state)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      flush_port_casts()
+      {_ctx, caches, _cmds} = sync_chrome(state)
 
       syncing_state =
-        MingaEditor.State.set_git_toast(state, %{
+        state
+        |> MingaEditor.State.set_git_toast(%{
           message: "Push failed: fetch first",
           level: :error,
           action: :pull_and_retry,
           dismiss_ref: make_ref()
         })
-
-      syncing_state = %{
-        syncing_state
-        | git_remote_op: {make_ref(), make_ref(), {"/tmp/repo", "Pushed", "Push failed"}}
-      }
-
-      {_ctx, caches2} =
-        EmitGUI.sync_swiftui_chrome(
-          Context.from_editor_state(syncing_state),
-          sb_data,
-          nil,
-          caches
+        |> Map.put(
+          :git_remote_op,
+          {make_ref(), make_ref(), {"/tmp/repo", "Pushed", "Push failed"}}
         )
 
-      git_status_cmds =
-        for <<0x85, _::binary>> = cmd <- List.flatten(collect_port_casts()), do: cmd
+      {_ctx, caches2, syncing_cmds} = sync_chrome(syncing_state, caches)
 
       assert [
                <<0x85, _repo_state::8, 1::8, _ahead::16, _behind::16, 0::16, 0::16, 1::8,
                  _level::8, 1::8, _msg_len::16, _msg::binary>>
-             ] = git_status_cmds
+             ] = opcode_cmds(syncing_cmds, 0x85)
 
       refute caches2.last_gui_git_status_fp == caches.last_gui_git_status_fp
-      flush_port_casts()
 
-      {_ctx, caches3} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, caches2)
-
-      stopped_cmds =
-        for <<0x85, _::binary>> = cmd <- List.flatten(collect_port_casts()), do: cmd
-
-      assert [<<0x85, _repo_state::8, 0::8, _rest::binary>>] = stopped_cmds
+      {_ctx, caches3, stopped_cmds} = sync_chrome(state, caches2)
+      assert [<<0x85, _repo_state::8, 0::8, _rest::binary>>] = opcode_cmds(stopped_cmds, 0x85)
       refute caches3.last_gui_git_status_fp == caches2.last_gui_git_status_fp
     end
 
-    test "picker cache tracks closed state" do
-      state = gui_state()
-      sb_data = StatusBarData.from_state(state)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      flush_port_casts()
+    test "closed chrome surfaces cache their not-visible state and return updated context" do
+      {ctx, caches, _cmds} = sync_chrome(gui_state())
 
       assert caches.last_gui_picker_fp == :closed
-    end
-
-    test "agent chat cache tracks not-visible state" do
-      state = gui_state()
-      sb_data = StatusBarData.from_state(state)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      flush_port_casts()
-
       assert caches.last_gui_agent_chat_fp == :not_visible
-    end
-
-    test "bottom panel returns updated context" do
-      state = gui_state()
-      sb_data = StatusBarData.from_state(state)
-
-      {ctx, _caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      flush_port_casts()
-
       assert is_map(ctx)
       assert Map.has_key?(ctx, :message_store)
     end
 
-    test "picker cache fingerprints an open picker without crashing" do
-      item = %MingaEditor.UI.Picker.Item{id: "a", label: "a.txt"}
-      picker = MingaEditor.UI.Picker.new([item], title: "Test")
+    test "picker cache fingerprints open picker content" do
       state = gui_state()
-
-      picker_state = %MingaEditor.State.Picker{picker: picker, source: nil, action_menu: nil}
-      state = ModalOverlay.open(state, :picker, PickerPayload.new(picker_state))
-      sb_data = StatusBarData.from_state(state)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      flush_port_casts()
-
-      refute caches.last_gui_picker_fp in [:closed, nil]
-    end
-
-    test "picker cache changes when visible item content changes" do
-      state = gui_state()
-      sb_data = StatusBarData.from_state(state)
       state_a = open_test_picker(state, "a.txt")
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state_a), sb_data, nil, %Caches{})
-
-      flush_port_casts()
-
       state_b = open_test_picker(state, "b.txt")
 
-      {_ctx, caches2} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state_b), sb_data, nil, caches)
+      {_ctx, caches, _cmds} = sync_chrome(state_a)
+      refute caches.last_gui_picker_fp in [:closed, nil]
 
-      flush_port_casts()
-
+      {_ctx, caches2, _cmds} = sync_chrome(state_b, caches)
       refute caches2.last_gui_picker_fp == caches.last_gui_picker_fp
     end
 
     test "minibuffer cache changes when encoded candidate metadata changes" do
       state = gui_state()
-      sb_data = StatusBarData.from_state(state)
 
       data_a =
         minibuffer_data([
@@ -526,10 +189,7 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
           }
         ])
 
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, data_a, %Caches{})
-
-      flush_port_casts()
+      {_ctx, caches, _cmds} = sync_chrome(state, %Caches{}, data_a)
 
       data_b =
         minibuffer_data([
@@ -543,85 +203,42 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
           }
         ])
 
-      {_ctx, caches2} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, data_b, caches)
+      {_ctx, caches2, cmds} = sync_chrome(state, caches, data_b)
 
-      casts = collect_port_casts()
-      all_cmds = List.flatten(casts)
-
-      assert Enum.any?(all_cmds, &match?(<<0x7F, _::binary>>, &1)),
-             "expected gui_minibuffer command when encoded candidate metadata changes"
-
+      assert has_opcode?(cmds, 0x7F)
       refute caches2.last_gui_minibuffer == caches.last_gui_minibuffer
     end
 
-    test "agent group cache changes when active group changes" do
+    test "agent group, agent chat, and board fingerprints include encoded content" do
       state = gui_state()
-      tb = tab_bar_with_two_agent_groups()
-      state_a = put_in(state.shell_state.tab_bar, tb)
-      sb_data = StatusBarData.from_state(state_a)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state_a), sb_data, nil, %Caches{})
-
-      flush_port_casts()
-
-      [_, tab_b] = tb.tabs
-      state_b = put_in(state.shell_state.tab_bar, %{tb | active_id: tab_b.id})
-
-      {_ctx, caches2} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state_b), sb_data, nil, caches)
-
-      flush_port_casts()
-
+      tab_bar = tab_bar_with_two_agent_groups()
+      state_a = put_in(state.shell_state.tab_bar, tab_bar)
+      {_ctx, caches, _cmds} = sync_chrome(state_a)
+      [_, tab_b] = tab_bar.tabs
+      state_b = put_in(state.shell_state.tab_bar, %{tab_bar | active_id: tab_b.id})
+      {_ctx, caches2, _cmds} = sync_chrome(state_b, caches)
       refute caches2.last_gui_agent_groups_fp == caches.last_gui_agent_groups_fp
-    end
 
-    test "agent chat cache changes when prompt cursor moves without text changes" do
-      state = agent_chat_state()
-      sb_data = StatusBarData.from_state(state)
+      chat_state = agent_chat_state()
+      {_ctx, chat_caches, _cmds} = sync_chrome(chat_state)
+      Minga.Buffer.move_to(chat_state.workspace.agent_ui.panel.prompt_buffer, {0, 1})
+      {_ctx, chat_caches2, _cmds} = sync_chrome(chat_state, chat_caches)
+      refute chat_caches2.last_gui_agent_chat_fp == chat_caches.last_gui_agent_chat_fp
 
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      flush_port_casts()
-
-      prompt = state.workspace.agent_ui.panel.prompt_buffer
-      Minga.Buffer.move_to(prompt, {0, 1})
-
-      {_ctx, caches2} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, caches)
-
-      flush_port_casts()
-
-      refute caches2.last_gui_agent_chat_fp == caches.last_gui_agent_chat_fp
-    end
-
-    test "board cache changes when encoded card content changes without status changes" do
       board = BoardState.new()
       {board_a, card} = BoardState.create_card(board, task: "Original task", status: :idle)
-      state = %{gui_state() | shell: MingaEditor.Shell.Board, shell_state: board_a}
-      sb_data = StatusBarData.from_state(state)
-
-      {_ctx, caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      flush_port_casts()
-
+      board_state = %{gui_state() | shell: MingaEditor.Shell.Board, shell_state: board_a}
+      {_ctx, board_caches, _cmds} = sync_chrome(board_state)
       board_b = BoardState.update_card(board_a, card.id, &%{&1 | task: "Updated task"})
-      state_b = %{state | shell_state: board_b}
 
-      {_ctx, caches2} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state_b), sb_data, nil, caches)
+      {_ctx, board_caches2, _cmds} =
+        sync_chrome(%{board_state | shell_state: board_b}, board_caches)
 
-      flush_port_casts()
-
-      refute caches2.last_gui_board_fp == caches.last_gui_board_fp
+      refute board_caches2.last_gui_board_fp == board_caches.last_gui_board_fp
     end
 
     test "agent chat survives dead prompt buffer process" do
       state = gui_state()
-
       {:ok, dead_pid} = Agent.start(fn -> nil end)
       Agent.stop(dead_pid)
 
@@ -632,15 +249,69 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
         | workspace: %{state.workspace | agent_ui: %{state.workspace.agent_ui | panel: panel}}
       }
 
-      sb_data = StatusBarData.from_state(state)
-
-      {ctx, _caches} =
-        EmitGUI.sync_swiftui_chrome(Context.from_editor_state(state), sb_data, nil, %Caches{})
-
-      flush_port_casts()
-
+      {ctx, _caches, _cmds} = sync_chrome(state)
       assert is_map(ctx)
     end
+  end
+
+  defp sync_chrome(state, caches \\ %Caches{}, minibuffer_data \\ nil) do
+    {ctx, caches} =
+      EmitGUI.sync_swiftui_chrome(
+        Context.from_editor_state(state),
+        StatusBarData.from_state(state),
+        minibuffer_data,
+        caches
+      )
+
+    {ctx, caches, collect_port_casts() |> List.flatten()}
+  end
+
+  defp collect_port_casts, do: collect_port_casts([])
+
+  defp collect_port_casts(acc) do
+    receive do
+      {:"$gen_cast", {:send_commands, cmds}} -> collect_port_casts([cmds | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  defp has_opcode?(cmds, opcode), do: Enum.any?(cmds, &opcode?(&1, opcode))
+  defp opcode_count(cmds, opcode), do: cmds |> opcode_cmds(opcode) |> length()
+  defp opcode_cmds(cmds, opcode), do: Enum.filter(cmds, &opcode?(&1, opcode))
+  defp opcode?(<<opcode, _::binary>>, opcode), do: true
+  defp opcode?(_, _opcode), do: false
+
+  defp hidden_tree_cmd_for_root?(
+         <<0x93, payload_len::32, payload::binary-size(payload_len)>>,
+         root
+       ) do
+    root_len = byte_size(root)
+
+    match?(
+      <<2::8, tree_flags::8, 0::8, 0::16, ^root_len::16, ^root::binary-size(root_len), 0::16,
+        0::16, 0::16>>
+      when Bitwise.band(tree_flags, 0x01) == 0,
+      payload
+    )
+  end
+
+  defp hidden_tree_cmd_for_root?(_cmd, _root), do: false
+
+  defp ready_file_tree_state(tmp_dir, opts) do
+    count = Keyword.fetch!(opts, :count)
+    root = Path.join(tmp_dir, "gui-file-tree")
+    File.mkdir_p!(root)
+
+    for index <- 1..count do
+      filename = "file_#{String.pad_leading(Integer.to_string(index), 3, "0")}.ex"
+      File.write!(Path.join(root, filename), "")
+    end
+
+    file_path = Path.join(root, "file_001.ex")
+    file_tree = FileTreeState.open(%FileTreeState{}, FileTree.new(root, width: 32), nil)
+    state = gui_state() |> put_in([Access.key(:workspace), Access.key(:file_tree)], file_tree)
+    {state, file_tree, file_path}
   end
 
   defp open_test_picker(state, label) do
@@ -665,12 +336,12 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
   end
 
   defp tab_bar_with_two_agent_groups do
-    tb = TabBar.new(Tab.new_file(1, "a.ex"))
-    {tb, group_a} = TabBar.add_agent_group(tb, "A")
-    {tb, group_b} = TabBar.add_agent_group(tb, "B")
-    {tb, tab_b} = TabBar.insert(tb, :file, "b.ex")
+    tab_bar = TabBar.new(Tab.new_file(1, "a.ex"))
+    {tab_bar, group_a} = TabBar.add_agent_group(tab_bar, "A")
+    {tab_bar, group_b} = TabBar.add_agent_group(tab_bar, "B")
+    {tab_bar, tab_b} = TabBar.insert(tab_bar, :file, "b.ex")
 
-    tb
+    tab_bar
     |> TabBar.move_tab_to_group(1, group_a.id)
     |> TabBar.move_tab_to_group(tab_b.id, group_b.id)
   end
@@ -694,10 +365,10 @@ defmodule MingaEditor.Frontend.Emit.GUI.ChromeCacheTest do
     }
 
     tab = Tab.new_agent(1, "Agent") |> Tab.set_session(session)
-    tb = TabBar.new(tab)
+    tab_bar = TabBar.new(tab)
 
     state
     |> Map.put(:workspace, workspace)
-    |> put_in([Access.key(:shell_state), Access.key(:tab_bar)], tb)
+    |> put_in([Access.key(:shell_state), Access.key(:tab_bar)], tab_bar)
   end
 end

--- a/test/minga_editor/lsp_actions_test.exs
+++ b/test/minga_editor/lsp_actions_test.exs
@@ -1,5 +1,5 @@
 defmodule MingaEditor.LspActionsTest do
-  @moduledoc "Tests for LspActions: definition and hover response parsing and navigation."
+  @moduledoc "Tests for public LspActions parsing, response handling, and picker source behavior."
 
   use ExUnit.Case, async: true
 
@@ -9,660 +9,396 @@ defmodule MingaEditor.LspActionsTest do
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Highlighting
-  alias MingaEditor.VimState
-  alias MingaEditor.Viewport
   alias MingaEditor.UI.Picker.CodeActionSource
   alias MingaEditor.UI.Picker.Context, as: PickerContext
+  alias MingaEditor.VimState
+  alias MingaEditor.Viewport
   alias MingaEditor.Workspace.State, as: WorkspaceState
 
-  # ── parse_location/1 ──────────────────────────────────────────────────────
-
   describe "parse_location/1" do
-    test "parses a single Location" do
-      location = %{
-        "uri" => "file:///tmp/foo.ex",
-        "range" => %{
-          "start" => %{"line" => 10, "character" => 5},
-          "end" => %{"line" => 10, "character" => 15}
-        }
-      }
-
-      assert {"file:///tmp/foo.ex", 10, 5} = LspActions.parse_location(location)
-    end
-
-    test "parses an array of Locations (picks first)" do
-      locations = [
-        %{
-          "uri" => "file:///tmp/first.ex",
-          "range" => %{
-            "start" => %{"line" => 1, "character" => 0},
-            "end" => %{"line" => 1, "character" => 10}
-          }
-        },
-        %{
-          "uri" => "file:///tmp/second.ex",
-          "range" => %{
-            "start" => %{"line" => 20, "character" => 3},
-            "end" => %{"line" => 20, "character" => 8}
-          }
-        }
+    test "extracts the first target URI and start position from supported LSP shapes" do
+      cases = [
+        {location("file:///tmp/foo.ex", 10, 5), {"file:///tmp/foo.ex", 10, 5}},
+        {[location("file:///tmp/first.ex", 1, 0), location("file:///tmp/second.ex", 20, 3)],
+         {"file:///tmp/first.ex", 1, 0}},
+        {%{
+           "targetUri" => "file:///tmp/target.ex",
+           "targetRange" => %{
+             "start" => %{"line" => 42, "character" => 2},
+             "end" => %{"line" => 42, "character" => 20}
+           },
+           "originSelectionRange" => %{
+             "start" => %{"line" => 5, "character" => 0},
+             "end" => %{"line" => 5, "character" => 10}
+           }
+         }, {"file:///tmp/target.ex", 42, 2}}
       ]
 
-      assert {"file:///tmp/first.ex", 1, 0} = LspActions.parse_location(locations)
+      for {input, expected} <- cases do
+        assert LspActions.parse_location(input) == expected
+      end
     end
 
-    test "parses a LocationLink" do
-      link = %{
-        "targetUri" => "file:///tmp/target.ex",
-        "targetRange" => %{
-          "start" => %{"line" => 42, "character" => 2},
-          "end" => %{"line" => 42, "character" => 20}
-        },
-        "originSelectionRange" => %{
-          "start" => %{"line" => 5, "character" => 0},
-          "end" => %{"line" => 5, "character" => 10}
-        }
-      }
-
-      assert {"file:///tmp/target.ex", 42, 2} = LspActions.parse_location(link)
-    end
-
-    test "returns nil for empty array" do
-      assert LspActions.parse_location([]) == nil
-    end
-
-    test "returns nil for nil" do
-      assert LspActions.parse_location(nil) == nil
-    end
-
-    test "returns nil for unrecognized format" do
-      assert LspActions.parse_location("garbage") == nil
+    test "returns nil for unsupported location responses" do
+      for input <- [[], nil, "garbage"] do
+        assert LspActions.parse_location(input) == nil
+      end
     end
   end
-
-  # ── extract_hover_text/1 ──────────────────────────────────────────────────
 
   describe "extract_hover_text/1" do
-    test "extracts plain text from MarkupContent" do
-      content = %{"kind" => "plaintext", "value" => "some docs"}
-      assert LspActions.extract_hover_text(content) == "some docs"
-    end
-
-    test "extracts and strips markdown from MarkupContent" do
-      content = %{
-        "kind" => "markdown",
-        "value" => "```elixir\ndef hello, do: :world\n```\n\nSome description."
-      }
-
-      result = LspActions.extract_hover_text(content)
-      assert result == "def hello, do: :world Some description."
-    end
-
-    test "handles plain string" do
-      assert LspActions.extract_hover_text("just a string") == "just a string"
-    end
-
-    test "handles MarkedString array" do
-      items = [
-        %{"language" => "elixir", "value" => "def foo()"},
-        "Some docs"
+    test "normalizes hover content from supported LSP shapes" do
+      cases = [
+        {%{"kind" => "plaintext", "value" => "some docs"}, "some docs"},
+        {%{
+           "kind" => "markdown",
+           "value" => "```elixir\ndef hello, do: :world\n```\n\nSome description."
+         }, "def hello, do: :world Some description."},
+        {"just a string", "just a string"},
+        {[%{"language" => "elixir", "value" => "def foo()"}, "Some docs"],
+         "def foo() | Some docs"},
+        {nil, ""},
+        {"", ""},
+        {"```\ncode here\n```", "code here"}
       ]
 
-      result = LspActions.extract_hover_text(items)
-      assert result == "def foo() | Some docs"
-    end
-
-    test "handles nil gracefully" do
-      assert LspActions.extract_hover_text(nil) == ""
-    end
-
-    test "handles empty string" do
-      assert LspActions.extract_hover_text("") == ""
-    end
-
-    test "strips code fences from markdown" do
-      text = "```\ncode here\n```"
-      result = LspActions.extract_hover_text(text)
-      assert result == "code here"
+      for {input, expected} <- cases do
+        assert LspActions.extract_hover_text(input) == expected
+      end
     end
   end
 
-  # ── handle_definition_response/2 ──────────────────────────────────────────
+  describe "definition and hover responses" do
+    test "definition response reports errors and empty results" do
+      cases = [
+        {{:error, %{"message" => "fail"}}, "Definition request failed"},
+        {{:ok, nil}, "No definition found"},
+        {{:ok, []}, "No definition found"}
+      ]
 
-  describe "handle_definition_response/2" do
-    test "sets status message on error" do
-      state = fake_state()
-      result = LspActions.handle_definition_response(state, {:error, %{"message" => "fail"}})
-      assert result.shell_state.status_msg == "Definition request failed"
+      for {response, expected_status} <- cases do
+        result = LspActions.handle_definition_response(fake_state(), response)
+        assert result.shell_state.status_msg == expected_status
+      end
     end
 
-    test "sets status message when result is nil" do
-      state = fake_state()
-      result = LspActions.handle_definition_response(state, {:ok, nil})
-      assert result.shell_state.status_msg == "No definition found"
-    end
-
-    test "sets status message when result is empty list" do
-      state = fake_state()
-      result = LspActions.handle_definition_response(state, {:ok, []})
-      assert result.shell_state.status_msg == "No definition found"
-    end
-  end
-
-  # ── handle_peek_definition_response/2 ──────────────────────────────────────
-
-  describe "handle_peek_definition_response/2" do
-    test "creates focused popup with source preview and open action" do
-      path = Path.join(System.tmp_dir!(), "minga_peek_#{:erlang.unique_integer([:positive])}.ex")
+    @tag :tmp_dir
+    test "peek definition opens a focused popup with source preview and open action", %{
+      tmp_dir: tmp_dir
+    } do
+      path = Path.join(tmp_dir, "peek_target.ex")
       File.write!(path, "defmodule Example do\n  def target do\n    :ok\n  end\nend\n")
 
-      location = %{
-        "uri" => "file://#{path}",
-        "range" => %{"start" => %{"line" => 1, "character" => 6}}
-      }
-
-      result = LspActions.handle_peek_definition_response(fake_state(), {:ok, location})
-
-      assert %HoverPopup{} = result.shell_state.hover_popup
-      assert result.shell_state.hover_popup.focused == true
-
-      assert result.shell_state.hover_popup.open_action ==
-               {:goto_location, "file://#{path}", 1, 6}
-
-      File.rm(path)
-    end
-  end
-
-  # ── handle_hover_response/2 ────────────────────────────────────────────────
-
-  describe "handle_hover_response/2" do
-    test "sets status message on error" do
-      state = fake_state()
-      result = LspActions.handle_hover_response(state, {:error, %{"message" => "fail"}})
-      assert result.shell_state.status_msg == "Hover request failed"
-    end
-
-    test "sets status message when result is nil" do
-      state = fake_state()
-      result = LspActions.handle_hover_response(state, {:ok, nil})
-      assert result.shell_state.status_msg == "No hover information"
-    end
-
-    test "creates hover popup for content" do
-      state = fake_state()
-      hover = %{"contents" => %{"kind" => "plaintext", "value" => "Returns :ok"}}
-      result = LspActions.handle_hover_response(state, {:ok, hover})
-      assert %HoverPopup{} = result.shell_state.hover_popup
-      assert result.shell_state.hover_popup.focused == false
-    end
-
-    test "creates hover popup for markdown content" do
-      state = fake_state()
-
-      hover = %{
-        "contents" => %{
-          "kind" => "markdown",
-          "value" => "```elixir\n@spec foo() :: :ok\n```"
-        }
-      }
-
-      result = LspActions.handle_hover_response(state, {:ok, hover})
-      assert %HoverPopup{} = result.shell_state.hover_popup
-      assert result.shell_state.hover_popup.content_lines != []
-    end
-
-    test "handles hover with no contents key" do
-      state = fake_state()
-      result = LspActions.handle_hover_response(state, {:ok, %{"range" => %{}}})
-      assert result.shell_state.status_msg == "No hover information"
-    end
-  end
-
-  # ── code_lens/1 ───────────────────────────────────────────────────────────
-
-  describe "code_lens/1" do
-    test "sets status_msg when no active buffer" do
-      state = fake_state()
-      result = LspActions.code_lens(state)
-      assert result.shell_state.status_msg == "No active buffer"
-    end
-
-    test "silently no-ops when no LSP client is registered" do
-      buf = start_supervised!({BufferProcess, content: "hello"})
-      state = fake_state_with_buffer(buf)
-      result = LspActions.code_lens(state)
-      assert result.shell_state.status_msg == nil
-    end
-  end
-
-  # ── handle_code_lens_response/2 ──────────────────────────────────────────
-
-  describe "handle_code_lens_response/2" do
-    test "stores resolved lenses with commands directly" do
-      {:ok, buf} = BufferProcess.start_link(content: "def hello do\n  :ok\nend")
-      state = fake_state_with_buffer(buf)
-
-      lens = %{
-        "range" => %{
-          "start" => %{"line" => 0, "character" => 0},
-          "end" => %{"line" => 0, "character" => 5}
-        },
-        "command" => %{"title" => "1 reference", "command" => "refs"}
-      }
-
-      result = LspActions.handle_code_lens_response(state, {:ok, [lens]})
-      assert length(result.lsp.code_lenses) == 1
-      assert hd(result.lsp.code_lenses).title == "1 reference"
-      assert hd(result.lsp.code_lenses).line == 0
-
-      GenServer.stop(buf)
-    end
-
-    test "error returns state unchanged" do
-      state = fake_state()
-      result = LspActions.handle_code_lens_response(state, {:error, "timeout"})
-      assert result == state
-    end
-
-    test "nil returns state unchanged" do
-      state = fake_state()
-      result = LspActions.handle_code_lens_response(state, {:ok, nil})
-      assert result == state
-    end
-
-    test "empty list returns state unchanged" do
-      state = fake_state()
-      result = LspActions.handle_code_lens_response(state, {:ok, []})
-      assert result == state
-    end
-  end
-
-  # ── handle_code_lens_resolve_response/2 ─────────────────────────────────
-
-  describe "handle_code_lens_resolve_response/2" do
-    test "merges resolved lens into existing lenses" do
-      {:ok, buf} = BufferProcess.start_link(content: "def hello do\n  :ok\nend")
-      state = fake_state_with_buffer(buf)
-
-      resolved = %{
-        "range" => %{
-          "start" => %{"line" => 0, "character" => 0},
-          "end" => %{"line" => 0, "character" => 5}
-        },
-        "command" => %{"title" => "2 references", "command" => "refs"}
-      }
-
-      result = LspActions.handle_code_lens_resolve_response(state, {:ok, resolved})
-      assert length(result.lsp.code_lenses) == 1
-      assert hd(result.lsp.code_lenses).title == "2 references"
-
-      GenServer.stop(buf)
-    end
-
-    test "ignores errors gracefully" do
-      state = fake_state()
-
-      state =
-        put_in(
-          state.lsp,
-          MingaEditor.State.LSP.set_code_lenses(state.lsp, [%{line: 0, title: "existing"}])
-        )
-
-      result = LspActions.handle_code_lens_resolve_response(state, {:error, "timeout"})
-      assert result.lsp.code_lenses == [%{line: 0, title: "existing"}]
-    end
-
-    test "ignores nil result" do
-      state = fake_state()
-      result = LspActions.handle_code_lens_resolve_response(state, {:ok, nil})
-      assert result == state
-    end
-  end
-
-  # ── handle_inlay_hint_response/2 ──────────────────────────────────────────
-
-  describe "handle_inlay_hint_response/2" do
-    test "stores parsed hints with correct line/col/label" do
-      {:ok, buf} = BufferProcess.start_link(content: "x = 1 + 2")
-      state = fake_state_with_buffer(buf)
-
-      hint = %{
-        "position" => %{"line" => 0, "character" => 2},
-        "label" => ": integer",
-        "kind" => 1,
-        "paddingLeft" => true,
-        "paddingRight" => false
-      }
-
-      result = LspActions.handle_inlay_hint_response(state, {:ok, [hint]})
-      assert length(result.lsp.inlay_hints) == 1
-      parsed = hd(result.lsp.inlay_hints)
-      assert parsed.line == 0
-      assert parsed.col == 2
-      assert parsed.label == ": integer"
-      assert parsed.kind == :type
-      assert parsed.padding_left == true
-      assert parsed.padding_right == false
-
-      GenServer.stop(buf)
-    end
-
-    test "handles label as array of InlayHintLabelPart" do
-      {:ok, buf} = BufferProcess.start_link(content: "x = 1")
-      state = fake_state_with_buffer(buf)
-
-      hint = %{
-        "position" => %{"line" => 0, "character" => 2},
-        "label" => [%{"value" => ": "}, %{"value" => "int"}],
-        "kind" => 1
-      }
-
-      result = LspActions.handle_inlay_hint_response(state, {:ok, [hint]})
-      assert hd(result.lsp.inlay_hints).label == ": int"
-
-      GenServer.stop(buf)
-    end
-
-    test "error is a no-op" do
-      state = fake_state()
-      state = put_in(state.lsp, MingaEditor.State.LSP.set_inlay_hints(state.lsp, [%{line: 0}]))
-      result = LspActions.handle_inlay_hint_response(state, {:error, "fail"})
-      assert result == state
-    end
-
-    test "nil is a no-op" do
-      state = fake_state()
-      state = put_in(state.lsp, MingaEditor.State.LSP.set_inlay_hints(state.lsp, [%{line: 0}]))
-      result = LspActions.handle_inlay_hint_response(state, {:ok, nil})
-      assert result == state
-    end
-
-    test "empty list is a no-op" do
-      state = fake_state()
-      state = put_in(state.lsp, MingaEditor.State.LSP.set_inlay_hints(state.lsp, [%{line: 0}]))
-      result = LspActions.handle_inlay_hint_response(state, {:ok, []})
-      assert result == state
-    end
-  end
-
-  # ── schedule_inlay_hints_on_scroll/1 ────────────────────────────────────
-
-  describe "schedule_inlay_hints_on_scroll/1" do
-    test "no-op when viewport hasn't changed" do
-      state = fake_state()
-      state = put_in(state.lsp, %{state.lsp | last_inlay_viewport_top: 0})
-
-      result = LspActions.schedule_inlay_hints_on_scroll(state)
-      assert result.lsp.inlay_hint_debounce_timer == nil
-    end
-
-    test "sets timer when viewport top changes" do
-      {:ok, buf} = BufferProcess.start_link(content: "hello")
-
-      state = %{fake_state() | backend: :zig}
-
-      ws = %{state.workspace | buffers: %{state.workspace.buffers | active: buf}}
-
-      state = %{
-        state
-        | workspace: ws,
-          terminal_viewport: %{state.terminal_viewport | top: 10}
-      }
-
-      result = LspActions.schedule_inlay_hints_on_scroll(state)
-      assert result.lsp.inlay_hint_debounce_timer != nil
-      assert result.lsp.last_inlay_viewport_top == 10
-      # Clean up timer
-      Process.cancel_timer(result.lsp.inlay_hint_debounce_timer)
-      GenServer.stop(buf)
-    end
-
-    test "skips timer in headless mode" do
-      {:ok, buf} = BufferProcess.start_link(content: "hello")
-
-      state = fake_state()
-
-      ws = %{state.workspace | buffers: %{state.workspace.buffers | active: buf}}
-
-      state = %{
-        state
-        | workspace: ws,
-          terminal_viewport: %{state.terminal_viewport | top: 10}
-      }
-
-      result = LspActions.schedule_inlay_hints_on_scroll(state)
-      assert result.lsp.inlay_hint_debounce_timer == nil
-      GenServer.stop(buf)
-    end
-
-    test "cancels previous timer and sets new one" do
-      {:ok, buf} = BufferProcess.start_link(content: "hello")
-
-      state = %{fake_state() | backend: :zig}
-
-      ws = %{state.workspace | buffers: %{state.workspace.buffers | active: buf}}
-
-      state = %{
-        state
-        | workspace: ws,
-          terminal_viewport: %{state.terminal_viewport | top: 5}
-      }
-
-      state1 = LspActions.schedule_inlay_hints_on_scroll(state)
-      timer1 = state1.lsp.inlay_hint_debounce_timer
-
-      state2 = %{state1 | terminal_viewport: %{state1.terminal_viewport | top: 15}}
-
-      state2 = LspActions.schedule_inlay_hints_on_scroll(state2)
-      timer2 = state2.lsp.inlay_hint_debounce_timer
-
-      assert timer1 != timer2
-      assert state2.lsp.last_inlay_viewport_top == 15
-      # Clean up
-      Process.cancel_timer(timer2)
-      GenServer.stop(buf)
-    end
-  end
-
-  # ── handle_prepare_rename_response/2 with Range ─────────────────────────
-
-  describe "handle_prepare_rename_response/2" do
-    test "prepareRename with placeholder uses placeholder directly" do
-      state = fake_state_with_vim()
+      uri = "file://#{path}"
 
       result =
-        LspActions.handle_prepare_rename_response(state, {:ok, %{"placeholder" => "myVar"}})
+        LspActions.handle_peek_definition_response(
+          fake_state(),
+          {:ok, location(uri, 1, 6)}
+        )
 
-      assert result.workspace.editing.mode == :command
-      assert result.workspace.editing.mode_state.input == "rename myVar"
+      assert %HoverPopup{focused: true, open_action: {:goto_location, ^uri, 1, 6}} =
+               result.shell_state.hover_popup
     end
 
-    test "prepareRename with Range + placeholder uses placeholder" do
-      state = fake_state_with_vim()
+    test "hover response reports empty results or creates an unfocused popup" do
+      empty_cases = [
+        {{:error, %{"message" => "fail"}}, "Hover request failed"},
+        {{:ok, nil}, "No hover information"},
+        {{:ok, %{"range" => %{}}}, "No hover information"}
+      ]
 
-      resp = %{
-        "range" => %{
-          "start" => %{"line" => 0, "character" => 4},
-          "end" => %{"line" => 0, "character" => 15}
-        },
-        "placeholder" => "hello_world"
-      }
+      for {response, expected_status} <- empty_cases do
+        assert LspActions.handle_hover_response(fake_state(), response).shell_state.status_msg ==
+                 expected_status
+      end
 
-      result = LspActions.handle_prepare_rename_response(state, {:ok, resp})
-      assert result.workspace.editing.mode == :command
-      assert result.workspace.editing.mode_state.input == "rename hello_world"
+      for hover <- [
+            %{"contents" => %{"kind" => "plaintext", "value" => "Returns :ok"}},
+            %{
+              "contents" => %{
+                "kind" => "markdown",
+                "value" => "```elixir\n@spec foo() :: :ok\n```"
+              }
+            }
+          ] do
+        result = LspActions.handle_hover_response(fake_state(), {:ok, hover})
+        assert %HoverPopup{focused: false} = result.shell_state.hover_popup
+        assert result.shell_state.hover_popup.content_lines != []
+      end
     end
 
-    test "prepareRename with Range only reads text from buffer" do
-      {:ok, buf} = BufferProcess.start_link(content: "def hello_world do\n  :ok\nend")
-      state = fake_state_with_buffer(buf)
-      state = %{state | workspace: %{state.workspace | editing: VimState.new()}}
+    test "mouse hover creates positioned popup for content and no-ops for empty responses" do
+      plaintext = %{"contents" => %{"kind" => "plaintext", "value" => "Returns :ok"}}
 
-      resp = %{
-        "start" => %{"line" => 0, "character" => 4},
-        "end" => %{"line" => 0, "character" => 15}
-      }
-
-      result = LspActions.handle_prepare_rename_response(state, {:ok, resp})
-      assert result.workspace.editing.mode == :command
-      assert result.workspace.editing.mode_state.input == "rename hello_world"
-
-      GenServer.stop(buf)
-    end
-
-    test "prepareRename with wrapped Range reads text from buffer" do
-      {:ok, buf} = BufferProcess.start_link(content: "def hello_world do\n  :ok\nend")
-      state = fake_state_with_buffer(buf)
-      state = %{state | workspace: %{state.workspace | editing: VimState.new()}}
-
-      resp = %{
-        "range" => %{
-          "start" => %{"line" => 0, "character" => 4},
-          "end" => %{"line" => 0, "character" => 15}
-        }
-      }
-
-      result = LspActions.handle_prepare_rename_response(state, {:ok, resp})
-      assert result.workspace.editing.mode == :command
-      assert result.workspace.editing.mode_state.input == "rename hello_world"
-
-      GenServer.stop(buf)
-    end
-
-    test "prepareRename error shows status message" do
-      state = fake_state_with_vim()
-      result = LspActions.handle_prepare_rename_response(state, {:error, "not renameable"})
-      assert result.shell_state.status_msg == "Cannot rename at this position"
-    end
-
-    test "prepareRename nil shows cannot-rename message" do
-      state = fake_state_with_vim()
-      result = LspActions.handle_prepare_rename_response(state, {:ok, nil})
-      assert result.shell_state.status_msg == "Cannot rename at this position"
-    end
-
-    test "prepareRename with Range but no buffer falls back to empty" do
-      state = fake_state_with_vim()
-
-      resp = %{
-        "start" => %{"line" => 0, "character" => 0},
-        "end" => %{"line" => 0, "character" => 5}
-      }
-
-      result = LspActions.handle_prepare_rename_response(state, {:ok, resp})
-      assert result.workspace.editing.mode == :command
-      assert result.workspace.editing.mode_state.input == "rename "
-    end
-  end
-
-  # ── handle_hover_mouse_response/4 ────────────────────────────────────────
-
-  describe "handle_hover_mouse_response/4" do
-    test "creates hover popup at mouse position for valid content" do
-      state = fake_state()
-      hover = %{"contents" => %{"kind" => "plaintext", "value" => "Returns :ok"}}
-      result = LspActions.handle_hover_mouse_response(state, {:ok, hover}, 5, 20)
-      assert %HoverPopup{} = result.shell_state.hover_popup
-    end
-
-    test "is a no-op on error" do
-      state = fake_state()
-      result = LspActions.handle_hover_mouse_response(state, {:error, "fail"}, 5, 20)
-      assert result == state
-    end
-
-    test "is a no-op when result is nil" do
-      state = fake_state()
-      result = LspActions.handle_hover_mouse_response(state, {:ok, nil}, 5, 20)
-      assert result == state
-    end
-
-    test "is a no-op for empty hover contents" do
-      state = fake_state()
-      hover = %{"contents" => %{"kind" => "plaintext", "value" => ""}}
-      result = LspActions.handle_hover_mouse_response(state, {:ok, hover}, 5, 20)
-      assert result == state
-    end
-
-    test "creates hover popup for markdown content at mouse position" do
-      state = fake_state()
-
-      hover = %{
+      markdown = %{
         "contents" => %{"kind" => "markdown", "value" => "```elixir\n@spec foo() :: :ok\n```"}
       }
 
-      result = LspActions.handle_hover_mouse_response(state, {:ok, hover}, 10, 30)
-      assert %HoverPopup{} = result.shell_state.hover_popup
-      assert result.shell_state.hover_popup.content_lines != []
+      for hover <- [plaintext, markdown] do
+        result = LspActions.handle_hover_mouse_response(fake_state(), {:ok, hover}, 5, 20)
+        assert %HoverPopup{} = result.shell_state.hover_popup
+        assert result.shell_state.hover_popup.content_lines != []
+      end
+
+      for response <- [
+            {:error, "fail"},
+            {:ok, nil},
+            {:ok, %{"contents" => %{"kind" => "plaintext", "value" => ""}}}
+          ] do
+        state = fake_state()
+        assert LspActions.handle_hover_mouse_response(state, response, 5, 20) == state
+      end
     end
   end
 
-  # ── CodeActionSource resolve logic (Item 10) ────────────────────────────
+  describe "code lens responses" do
+    test "code_lens reports missing buffers and no-ops when no client is registered" do
+      assert LspActions.code_lens(fake_state()).shell_state.status_msg == "No active buffer"
 
-  describe "CodeActionSource resolve logic" do
-    test "on_select applies edit directly when present" do
-      # CodeActionSource.on_select handles actions with edit fields by applying
-      # them via LspActions.apply_workspace_edit. We can't test the full picker
-      # path without a real LSP client, but we verify the code action source
-      # module loads and its candidates function works.
-      assert Code.ensure_loaded?(CodeActionSource)
+      state = fake_state_with_buffer(start_buffer!("hello"))
+      assert LspActions.code_lens(state).shell_state.status_msg == nil
     end
 
-    test "candidates returns items from actions context" do
+    test "stores resolved lenses with commands directly" do
+      state = fake_state_with_buffer(start_buffer!("def hello do\n  :ok\nend"))
+      result = LspActions.handle_code_lens_response(state, {:ok, [code_lens("1 reference")]})
+
+      assert [%{title: "1 reference", line: 0}] = result.lsp.code_lenses
+    end
+
+    test "code lens response leaves state unchanged for empty or failed responses" do
+      for response <- [{:error, "timeout"}, {:ok, nil}, {:ok, []}] do
+        state = fake_state()
+        assert LspActions.handle_code_lens_response(state, response) == state
+      end
+    end
+
+    test "resolve response merges commands and preserves existing lenses on ignored responses" do
+      state = fake_state_with_buffer(start_buffer!("def hello do\n  :ok\nend"))
+      resolved = code_lens("2 references")
+
+      result = LspActions.handle_code_lens_resolve_response(state, {:ok, resolved})
+      assert [%{title: "2 references"}] = result.lsp.code_lenses
+
+      existing_state = fake_state()
+
+      existing_state =
+        put_in(
+          existing_state.lsp,
+          MingaEditor.State.LSP.set_code_lenses(existing_state.lsp, [
+            %{line: 0, title: "existing"}
+          ])
+        )
+
+      assert LspActions.handle_code_lens_resolve_response(existing_state, {:error, "timeout"}).lsp.code_lenses ==
+               [%{line: 0, title: "existing"}]
+
+      state = fake_state()
+      assert LspActions.handle_code_lens_resolve_response(state, {:ok, nil}) == state
+    end
+  end
+
+  describe "inlay hints" do
+    test "stores parsed hints from string labels and label parts" do
+      state = fake_state_with_buffer(start_buffer!("x = 1 + 2"))
+
+      hints = [
+        %{
+          "position" => %{"line" => 0, "character" => 2},
+          "label" => ": integer",
+          "kind" => 1,
+          "paddingLeft" => true,
+          "paddingRight" => false
+        },
+        %{
+          "position" => %{"line" => 0, "character" => 4},
+          "label" => [%{"value" => ": "}, %{"value" => "int"}],
+          "kind" => 1
+        }
+      ]
+
+      result = LspActions.handle_inlay_hint_response(state, {:ok, hints})
+
+      assert [first, second] = result.lsp.inlay_hints
+
+      assert %{
+               line: 0,
+               col: 2,
+               label: ": integer",
+               kind: :type,
+               padding_left: true,
+               padding_right: false
+             } = first
+
+      assert second.label == ": int"
+    end
+
+    test "leaves existing hints unchanged for empty or failed responses" do
+      for response <- [{:error, "fail"}, {:ok, nil}, {:ok, []}] do
+        state = fake_state()
+        state = put_in(state.lsp, MingaEditor.State.LSP.set_inlay_hints(state.lsp, [%{line: 0}]))
+        assert LspActions.handle_inlay_hint_response(state, response) == state
+      end
+    end
+
+    test "schedules hints only when a Zig viewport changes, replacing existing timers" do
+      state = fake_state()
+      state = put_in(state.lsp, %{state.lsp | last_inlay_viewport_top: 0})
+      assert LspActions.schedule_inlay_hints_on_scroll(state).lsp.inlay_hint_debounce_timer == nil
+
+      headless_state = state_with_active_buffer(fake_state(), start_buffer!("hello"), top: 10)
+
+      assert LspActions.schedule_inlay_hints_on_scroll(headless_state).lsp.inlay_hint_debounce_timer ==
+               nil
+
+      zig_state = %{
+        state_with_active_buffer(fake_state(), start_buffer!("hello"), top: 5)
+        | backend: :zig
+      }
+
+      scheduled = LspActions.schedule_inlay_hints_on_scroll(zig_state)
+      first_timer = scheduled.lsp.inlay_hint_debounce_timer
+      assert first_timer != nil
+      assert scheduled.lsp.last_inlay_viewport_top == 5
+
+      rescheduled =
+        LspActions.schedule_inlay_hints_on_scroll(%{
+          scheduled
+          | terminal_viewport: %{scheduled.terminal_viewport | top: 15}
+        })
+
+      assert rescheduled.lsp.inlay_hint_debounce_timer != first_timer
+      assert rescheduled.lsp.last_inlay_viewport_top == 15
+      Process.cancel_timer(rescheduled.lsp.inlay_hint_debounce_timer)
+    end
+  end
+
+  describe "prepare rename response" do
+    test "opens rename command with placeholders or range text" do
+      cases = [
+        {{:ok, %{"placeholder" => "myVar"}}, nil, "rename myVar"},
+        {{:ok, %{"range" => range(0, 4, 15), "placeholder" => "hello_world"}}, nil,
+         "rename hello_world"},
+        {{:ok, flat_range(0, 4, 15)}, "def hello_world do\n  :ok\nend", "rename hello_world"},
+        {{:ok, %{"range" => range(0, 4, 15)}}, "def hello_world do\n  :ok\nend",
+         "rename hello_world"},
+        {{:ok, flat_range(0, 0, 5)}, nil, "rename "}
+      ]
+
+      for {response, buffer_content, expected_input} <- cases do
+        state =
+          if buffer_content,
+            do: fake_state_with_buffer(start_buffer!(buffer_content)),
+            else: fake_state_with_vim()
+
+        state = %{state | workspace: %{state.workspace | editing: VimState.new()}}
+        result = LspActions.handle_prepare_rename_response(state, response)
+
+        assert result.workspace.editing.mode == :command
+        assert result.workspace.editing.mode_state.input == expected_input
+      end
+    end
+
+    test "reports cannot-rename for failed responses" do
+      for response <- [{:error, "not renameable"}, {:ok, nil}] do
+        result = LspActions.handle_prepare_rename_response(fake_state_with_vim(), response)
+        assert result.shell_state.status_msg == "Cannot rename at this position"
+      end
+    end
+  end
+
+  describe "CodeActionSource" do
+    test "candidates expose quickfix labels, preferred marker, and empty context behavior" do
       actions = [
         %{"title" => "Fix import", "kind" => "quickfix"},
         %{"title" => "Extract variable", "kind" => "refactor.extract", "isPreferred" => true}
       ]
 
-      tab = MingaEditor.State.Tab.new_file(1, "test")
-
-      ctx = %PickerContext{
-        buffers: %Buffers{},
-        editing: VimState.new(),
-        search: %MingaEditor.State.Search{},
-        viewport: Viewport.new(24, 80),
-        tab_bar: MingaEditor.State.TabBar.new(tab),
-        picker_ui: %{context: %{actions: actions}},
-        capabilities: %{},
-        theme: MingaEditor.UI.Theme.get!(:doom_one)
-      }
-
-      items = CodeActionSource.candidates(ctx)
+      items = CodeActionSource.candidates(picker_context(actions))
 
       assert length(items) == 2
       assert Enum.any?(items, fn item -> String.contains?(item.label, "Fix import") end)
       assert Enum.any?(items, fn item -> String.contains?(item.label, "★") end)
-    end
-
-    test "candidates returns empty list when no actions" do
-      assert [] == CodeActionSource.candidates(%{})
+      assert CodeActionSource.candidates(%{}) == []
     end
   end
 
-  # ── Helpers ────────────────────────────────────────────────────────────────
+  defp location(uri, line, character) do
+    %{
+      "uri" => uri,
+      "range" => %{
+        "start" => %{"line" => line, "character" => character},
+        "end" => %{"line" => line, "character" => character + 10}
+      }
+    }
+  end
+
+  defp range(line, start_col, end_col) do
+    %{
+      "start" => %{"line" => line, "character" => start_col},
+      "end" => %{"line" => line, "character" => end_col}
+    }
+  end
+
+  defp flat_range(line, start_col, end_col) do
+    %{
+      "start" => %{"line" => line, "character" => start_col},
+      "end" => %{"line" => line, "character" => end_col}
+    }
+  end
+
+  defp code_lens(title) do
+    %{
+      "range" => range(0, 0, 5),
+      "command" => %{"title" => title, "command" => "refs"}
+    }
+  end
+
+  defp start_buffer!(content) do
+    {:ok, pid} = BufferProcess.start_link(content: content)
+    on_exit(fn -> Process.exit(pid, :normal) end)
+    pid
+  end
+
+  defp state_with_active_buffer(state, buf, opts) do
+    top = Keyword.fetch!(opts, :top)
+    state = %{state | workspace: %{state.workspace | buffers: %Buffers{active: buf, list: [buf]}}}
+    %{state | terminal_viewport: %{state.terminal_viewport | top: top}}
+  end
+
+  defp picker_context(actions) do
+    tab = MingaEditor.State.Tab.new_file(1, "test")
+
+    %PickerContext{
+      buffers: %Buffers{},
+      editing: VimState.new(),
+      search: %MingaEditor.State.Search{},
+      viewport: Viewport.new(24, 80),
+      tab_bar: MingaEditor.State.TabBar.new(tab),
+      picker_ui: %{context: %{actions: actions}},
+      capabilities: %{},
+      theme: MingaEditor.UI.Theme.get!(:doom_one)
+    }
+  end
 
   defp fake_state do
-    vp = Viewport.new(24, 80)
+    viewport = Viewport.new(24, 80)
 
     %EditorState{
       port_manager: nil,
-      terminal_viewport: vp,
-      workspace: %WorkspaceState{
-        viewport: vp,
-        highlight: %Highlighting{}
-      }
+      terminal_viewport: viewport,
+      workspace: %WorkspaceState{viewport: viewport, highlight: %Highlighting{}}
     }
   end
 
   defp fake_state_with_buffer(buf) do
     state = fake_state()
-    ws = %{state.workspace | buffers: %Buffers{active: buf, list: [buf]}}
-    %{state | workspace: ws}
+    %{state | workspace: %{state.workspace | buffers: %Buffers{active: buf, list: [buf]}}}
   end
 
   defp fake_state_with_vim do
     state = fake_state()
-    ws = %{state.workspace | editing: VimState.new()}
-    %{state | workspace: ws}
+    %{state | workspace: %{state.workspace | editing: VimState.new()}}
   end
 end

--- a/test/minga_editor/window_tree_test.exs
+++ b/test/minga_editor/window_tree_test.exs
@@ -3,168 +3,86 @@ defmodule MingaEditor.WindowTreeTest do
 
   alias MingaEditor.WindowTree
 
-  describe "new/1" do
-    test "creates a single-leaf tree" do
-      tree = WindowTree.new(1)
-      assert tree == {:leaf, 1}
-    end
-  end
+  @screen {0, 0, 80, 24}
 
-  describe "leaves/1" do
-    test "single leaf returns one id" do
+  describe "basic tree queries" do
+    test "new tree starts as one leaf" do
+      assert WindowTree.new(1) == {:leaf, 1}
       assert WindowTree.leaves(WindowTree.new(1)) == [1]
-    end
-
-    test "split tree returns ids in order" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert WindowTree.leaves(tree) == [1, 2]
-    end
-  end
-
-  describe "count/1" do
-    test "single leaf" do
       assert WindowTree.count(WindowTree.new(1)) == 1
-    end
-
-    test "after one split" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert WindowTree.count(tree) == 2
-    end
-
-    test "after nested splits" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
-      assert WindowTree.count(tree) == 3
-    end
-  end
-
-  describe "member?/2" do
-    test "finds existing id" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert WindowTree.member?(tree, 1)
-      assert WindowTree.member?(tree, 2)
-    end
-
-    test "returns false for missing id" do
+      assert WindowTree.member?(WindowTree.new(1), 1)
       refute WindowTree.member?(WindowTree.new(1), 99)
+    end
+
+    test "nested split preserves ordered leaves, count, and membership" do
+      tree = nested_tree()
+
+      assert WindowTree.leaves(tree) == [1, 2, 3]
+      assert WindowTree.count(tree) == 3
+      for id <- [1, 2, 3], do: assert(WindowTree.member?(tree, id))
+      refute WindowTree.member?(tree, 99)
     end
   end
 
   describe "split/4" do
-    test "vertical split" do
-      tree = WindowTree.new(1)
-
+    test "splits leaves by direction and reports missing targets" do
       assert {:ok, {:split, :vertical, {:leaf, 1}, {:leaf, 2}, 0}} =
-               WindowTree.split(tree, 1, :vertical, 2)
-    end
-
-    test "horizontal split" do
-      tree = WindowTree.new(1)
+               WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
 
       assert {:ok, {:split, :horizontal, {:leaf, 1}, {:leaf, 2}, 0}} =
-               WindowTree.split(tree, 1, :horizontal, 2)
-    end
+               WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
 
-    test "split non-existent window returns error" do
       assert :error = WindowTree.split(WindowTree.new(1), 99, :vertical, 2)
     end
 
-    test "nested split on right child" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
+    test "splits nested leaves without reordering siblings" do
+      {:ok, right_nested} = WindowTree.split(two_pane_tree(), 2, :horizontal, 3)
+      {:ok, left_nested} = WindowTree.split(two_pane_tree(), 1, :horizontal, 3)
 
-      assert {:split, :vertical, {:leaf, 1}, {:split, :horizontal, {:leaf, 2}, {:leaf, 3}, 0}, 0} =
-               tree
-    end
+      assert right_nested ==
+               {:split, :vertical, {:leaf, 1}, {:split, :horizontal, {:leaf, 2}, {:leaf, 3}, 0},
+                0}
 
-    test "nested split on left child" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 1, :horizontal, 3)
-
-      assert {:split, :vertical, {:split, :horizontal, {:leaf, 1}, {:leaf, 3}, 0}, {:leaf, 2}, 0} =
-               tree
+      assert left_nested ==
+               {:split, :vertical, {:split, :horizontal, {:leaf, 1}, {:leaf, 3}, 0}, {:leaf, 2},
+                0}
     end
   end
 
   describe "close/2" do
-    test "cannot close the last window" do
+    test "closes leaves by promoting the sibling, but not the last window" do
       assert :error = WindowTree.close(WindowTree.new(1), 1)
+      assert {:ok, {:leaf, 2}} = WindowTree.close(two_pane_tree(), 1)
+      assert {:ok, {:leaf, 1}} = WindowTree.close(two_pane_tree(), 2)
+      assert :error = WindowTree.close(two_pane_tree(), 99)
     end
 
-    test "closing left child promotes right" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert {:ok, {:leaf, 2}} = WindowTree.close(tree, 1)
-    end
-
-    test "closing right child promotes left" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert {:ok, {:leaf, 1}} = WindowTree.close(tree, 2)
-    end
-
-    test "closing non-existent window returns error" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert :error = WindowTree.close(tree, 99)
-    end
-
-    test "closing in nested tree preserves structure" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
-
-      # Close window 2, window 3 should take its place
+    test "closes nested leaves while preserving surviving layout" do
       assert {:ok, {:split, :vertical, {:leaf, 1}, {:leaf, 3}, 0}} =
-               WindowTree.close(tree, 2)
-    end
+               WindowTree.close(nested_tree(), 2)
 
-    test "closing in deeply nested tree" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
-      {:ok, tree} = WindowTree.split(tree, 3, :vertical, 4)
-
-      # Close window 3, window 4 takes its place
-      {:ok, tree} = WindowTree.close(tree, 3)
+      tree = nested_tree() |> split!(3, :vertical, 4) |> close!(3)
       assert WindowTree.leaves(tree) == [1, 2, 4]
     end
   end
 
   describe "layout/2" do
-    @screen {0, 0, 80, 24}
+    test "computes single, vertical, horizontal, and nested rects" do
+      assert WindowTree.layout(WindowTree.new(1), @screen) == [{1, {0, 0, 80, 24}}]
 
-    test "single window gets full screen" do
-      tree = WindowTree.new(1)
-      assert [{1, {0, 0, 80, 24}}] = WindowTree.layout(tree, @screen)
-    end
+      assert WindowTree.layout(two_pane_tree(), @screen) == [
+               {1, {0, 0, 39, 24}},
+               {2, {0, 40, 40, 24}}
+             ]
 
-    test "vertical split divides width with separator" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      layouts = WindowTree.layout(tree, @screen)
+      assert WindowTree.layout(split!(WindowTree.new(1), 1, :horizontal, 2), @screen) == [
+               {1, {0, 0, 80, 12}},
+               {2, {12, 0, 80, 12}}
+             ]
 
-      assert [{1, {0, 0, left_w, 24}}, {2, {0, right_col, right_w, 24}}] = layouts
-
-      # Left gets floor((80-1)/2) = 39, separator at 39, right starts at 40
-      assert left_w == 39
-      assert right_col == 40
-      assert right_w == 40
-      # Total: 39 + 1 (sep) + 40 = 80
-      assert left_w + 1 + right_w == 80
-    end
-
-    test "horizontal split divides height" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
-      layouts = WindowTree.layout(tree, @screen)
-
-      assert [{1, {0, 0, 80, 12}}, {2, {12, 0, 80, 12}}] = layouts
-    end
-
-    test "nested splits produce correct rects" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
-      layouts = WindowTree.layout(tree, @screen)
-
+      layouts = WindowTree.layout(nested_tree(), @screen)
       assert length(layouts) == 3
-
       [{1, {_, _, w1, _}}, {2, {r2, _, w2, h2}}, {3, {r3, _, w3, h3}}] = layouts
-
-      # Window 1 is left half, windows 2 and 3 share right half vertically
       assert w1 == 39
       assert w2 == w3
       assert r3 == r2 + h2
@@ -173,436 +91,215 @@ defmodule MingaEditor.WindowTreeTest do
   end
 
   describe "focus_neighbor/4" do
-    @screen {0, 0, 80, 24}
+    test "finds cardinal neighbors and reports missing neighbors" do
+      vertical = two_pane_tree()
+      horizontal = split!(WindowTree.new(1), 1, :horizontal, 2)
 
-    test "navigating right from left pane" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert {:ok, 2} = WindowTree.focus_neighbor(tree, 1, :right, @screen)
+      assert {:ok, 2} = WindowTree.focus_neighbor(vertical, 1, :right, @screen)
+      assert {:ok, 1} = WindowTree.focus_neighbor(vertical, 2, :left, @screen)
+      assert {:ok, 2} = WindowTree.focus_neighbor(horizontal, 1, :down, @screen)
+      assert {:ok, 1} = WindowTree.focus_neighbor(horizontal, 2, :up, @screen)
+      assert :error = WindowTree.focus_neighbor(vertical, 1, :left, @screen)
+      assert :error = WindowTree.focus_neighbor(vertical, 2, :right, @screen)
+      assert :error = WindowTree.focus_neighbor(WindowTree.new(1), 1, :right, @screen)
     end
 
-    test "navigating left from right pane" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert {:ok, 1} = WindowTree.focus_neighbor(tree, 2, :left, @screen)
-    end
+    test "navigates nested layouts by nearest visible neighbor" do
+      tree = nested_tree()
 
-    test "navigating down from top pane" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
-      assert {:ok, 2} = WindowTree.focus_neighbor(tree, 1, :down, @screen)
-    end
-
-    test "navigating up from bottom pane" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
-      assert {:ok, 1} = WindowTree.focus_neighbor(tree, 2, :up, @screen)
-    end
-
-    test "no neighbor returns error" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert :error = WindowTree.focus_neighbor(tree, 1, :left, @screen)
-      assert :error = WindowTree.focus_neighbor(tree, 2, :right, @screen)
-    end
-
-    test "no neighbor in single window" do
-      tree = WindowTree.new(1)
-      assert :error = WindowTree.focus_neighbor(tree, 1, :right, @screen)
-    end
-
-    test "navigating in nested layout" do
-      # [1] | [2]
-      #     | [3]
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
-
-      # Window 1 is tall (full height), so its center is between windows 2 and 3.
-      # The nearest right neighbor depends on center-to-center distance.
-      {:ok, right_neighbor} = WindowTree.focus_neighbor(tree, 1, :right, @screen)
+      assert {:ok, right_neighbor} = WindowTree.focus_neighbor(tree, 1, :right, @screen)
       assert right_neighbor in [2, 3]
-
       assert {:ok, 3} = WindowTree.focus_neighbor(tree, 2, :down, @screen)
-
       assert {:ok, 1} = WindowTree.focus_neighbor(tree, 3, :left, @screen)
     end
   end
 
-  # ── resize_at/5 ──────────────────────────────────────────────────────────────
-
   describe "resize_at/5" do
-    @screen {0, 0, 80, 24}
+    test "resizes vertical and horizontal separators within bounds" do
+      cases = [
+        {:vertical, 39, 50, [{1, {0, 0, 50, 24}}, {2, {0, 51, 29, 24}}]},
+        {:vertical, 39, 20, [{1, {0, 0, 20, 24}}, {2, {0, 21, 59, 24}}]},
+        {:horizontal, 11, 16, [{1, {0, 0, 80, 17}}, {2, {17, 0, 80, 7}}]},
+        {:horizontal, 11, 4, [{1, {0, 0, 80, 5}}, {2, {5, 0, 80, 19}}]}
+      ]
 
-    test "vertical resize moves separator right" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      # Default split: size=0, usable=79, left_width=39, separator at col 39
-      layouts_before = WindowTree.layout(tree, @screen)
-      [{1, {_, _, left_w_before, _}}, _] = layouts_before
-      assert left_w_before == 39
+      for {direction, old_pos, new_pos, expected_layout} <- cases do
+        tree =
+          if direction == :vertical,
+            do: two_pane_tree(),
+            else: split!(WindowTree.new(1), 1, :horizontal, 2)
 
-      # Move separator from col 39 to col 50
-      {:ok, resized} = WindowTree.resize_at(tree, @screen, :vertical, 39, 50)
-      layouts_after = WindowTree.layout(resized, @screen)
-      [{1, {_, _, left_w_after, _}}, {2, {_, _, right_w_after, _}}] = layouts_after
-
-      assert left_w_after == 50
-      assert right_w_after == 29
-      assert left_w_after + 1 + right_w_after == 80
+        assert {:ok, resized} = WindowTree.resize_at(tree, @screen, direction, old_pos, new_pos)
+        assert WindowTree.layout(resized, @screen) == expected_layout
+      end
     end
 
-    test "vertical resize moves separator left" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      # Separator at col 39, move to col 20
-      {:ok, resized} = WindowTree.resize_at(tree, @screen, :vertical, 39, 20)
-      [{1, {_, _, left_w, _}}, {2, {_, _, right_w, _}}] = WindowTree.layout(resized, @screen)
+    test "clamps vertical resize to non-empty panes" do
+      for new_pos <- [0, 79] do
+        assert {:ok, resized} =
+                 WindowTree.resize_at(two_pane_tree(), @screen, :vertical, 39, new_pos)
 
-      assert left_w == 20
-      assert right_w == 59
-      assert left_w + 1 + right_w == 80
+        [{1, {_, _, left_w, _}}, {2, {_, _, right_w, _}}] = WindowTree.layout(resized, @screen)
+        assert left_w >= 1
+        assert right_w >= 1
+        assert left_w + 1 + right_w == 80
+      end
     end
 
-    test "vertical resize clamps to minimum of 1 column" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      # Try to move separator to col 0 (past left boundary)
-      {:ok, resized} = WindowTree.resize_at(tree, @screen, :vertical, 39, 0)
-      [{1, {_, _, left_w, _}}, _] = WindowTree.layout(resized, @screen)
+    test "reports missing separators and only resizes the matching nested separator" do
+      assert :error = WindowTree.resize_at(two_pane_tree(), @screen, :vertical, 99, 50)
+      assert :error = WindowTree.resize_at(WindowTree.new(1), @screen, :vertical, 39, 50)
+      assert :error = WindowTree.resize_at(two_pane_tree(), @screen, :horizontal, 11, 5)
 
-      assert left_w >= 1
-    end
-
-    test "vertical resize clamps to maximum (usable - 1)" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      # Try to move separator to col 79 (past right boundary)
-      {:ok, resized} = WindowTree.resize_at(tree, @screen, :vertical, 39, 79)
-      [{1, {_, _, left_w, _}}, {2, {_, _, right_w, _}}] = WindowTree.layout(resized, @screen)
-
-      assert right_w >= 1
-      assert left_w + 1 + right_w == 80
-    end
-
-    test "horizontal resize moves separator down" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
-      # Default: size=0, top_height=12, modeline_row=11
-      {:ok, resized} = WindowTree.resize_at(tree, @screen, :horizontal, 11, 16)
-
-      [{1, {_, _, _, top_h}}, {2, {bottom_row, _, _, bottom_h}}] =
-        WindowTree.layout(resized, @screen)
-
-      # new_top_height = max(min(16 - 0 + 1, 24 - 1), 1) = 17
-      assert top_h == 17
-      assert bottom_row == 17
-      assert top_h + bottom_h == 24
-    end
-
-    test "horizontal resize moves separator up" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
-      # Default modeline_row=11. Move up to row 4.
-      {:ok, resized} = WindowTree.resize_at(tree, @screen, :horizontal, 11, 4)
-      [{1, {_, _, _, top_h}}, {2, {_, _, _, bottom_h}}] = WindowTree.layout(resized, @screen)
-
-      # new_top_height = max(min(4 - 0 + 1, 23), 1) = 5
-      assert top_h == 5
-      assert top_h + bottom_h == 24
-    end
-
-    test "returns error for nonexistent separator position" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert :error = WindowTree.resize_at(tree, @screen, :vertical, 99, 50)
-    end
-
-    test "returns error for leaf tree" do
-      tree = WindowTree.new(1)
-      assert :error = WindowTree.resize_at(tree, @screen, :vertical, 39, 50)
-    end
-
-    test "nested: resize inner vertical split, outer unaffected" do
-      # [1] | [2]
-      #     | [3]
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
-
-      # The outer vertical separator is at col 39.
-      # Inner horizontal split: right side gets cols 40..79 (width 40),
-      # top_height = div(24, 2) = 12, modeline_row = 40_col_start? No — it's a row.
-      # Right subtree rect: {0, 40, 40, 24}. top_height = 12, modeline_row = 0 + 12 - 1 = 11.
-      # Resize the inner horizontal separator (at row 11) to row 15.
-      {:ok, resized} = WindowTree.resize_at(tree, @screen, :horizontal, 11, 15)
-
-      layouts = WindowTree.layout(resized, @screen)
-
-      # Window 1 should be unchanged (full left side)
-      [{1, {_, _, w1, h1}} | _] = layouts
+      assert {:ok, resized} = WindowTree.resize_at(nested_tree(), @screen, :horizontal, 11, 15)
+      [{1, {_, _, w1, h1}} | _] = WindowTree.layout(resized, @screen)
       assert w1 == 39
       assert h1 == 24
     end
-
-    test "resize with mismatched direction returns error when no matching separator" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      # Pure vertical split has no horizontal separator; any row position returns error
-      assert :error = WindowTree.resize_at(tree, @screen, :horizontal, 11, 5)
-    end
   end
 
-  # ── reset_split_at/4 ─────────────────────────────────────────────────────────
-
   describe "reset_split_at/4" do
-    @screen {0, 0, 80, 24}
+    test "resets vertical, horizontal, and nested matching separators" do
+      vertical = two_pane_tree() |> resize!(:vertical, 39, 30)
+      assert {:ok, reset} = WindowTree.reset_split_at(vertical, @screen, :vertical, 30)
+      assert WindowTree.layout(reset, @screen) == [{1, {0, 0, 39, 24}}, {2, {0, 40, 40, 24}}]
 
-    test "vertical reset stores equal split size" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, resized} = WindowTree.resize_at(tree, @screen, :vertical, 39, 30)
+      horizontal = WindowTree.new(1) |> split!(1, :horizontal, 2) |> resize!(:horizontal, 11, 16)
+      assert {:ok, reset} = WindowTree.reset_split_at(horizontal, @screen, :horizontal, 16)
+      assert WindowTree.layout(reset, @screen) == [{1, {0, 0, 80, 12}}, {2, {12, 0, 80, 12}}]
 
-      assert {:ok, {:split, :vertical, {:leaf, 1}, {:leaf, 2}, 0} = reset} =
-               WindowTree.reset_split_at(resized, @screen, :vertical, 30)
-
-      [{1, {_, _, left_w, _}}, {2, {_, _, right_w, _}}] = WindowTree.layout(reset, @screen)
-      assert left_w == 39
-      assert right_w == 40
-    end
-
-    test "horizontal reset stores equal split size" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
-      {:ok, resized} = WindowTree.resize_at(tree, @screen, :horizontal, 11, 16)
-
-      assert {:ok, {:split, :horizontal, {:leaf, 1}, {:leaf, 2}, 0} = reset} =
-               WindowTree.reset_split_at(resized, @screen, :horizontal, 16)
-
-      [{1, {_, _, _, top_h}}, {2, {bottom_row, _, _, bottom_h}}] =
-        WindowTree.layout(reset, @screen)
-
-      assert top_h == 12
-      assert bottom_row == 12
-      assert bottom_h == 12
-    end
-
-    test "nested reset only resets matching separator" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
-      {:ok, resized} = WindowTree.resize_at(tree, @screen, :horizontal, 11, 16)
+      nested = resize!(nested_tree(), :horizontal, 11, 16)
 
       assert {:ok,
               {:split, :vertical, {:leaf, 1}, {:split, :horizontal, {:leaf, 2}, {:leaf, 3}, 0}, 0}} =
-               WindowTree.reset_split_at(resized, @screen, :horizontal, 16)
+               WindowTree.reset_split_at(nested, @screen, :horizontal, 16)
     end
 
-    test "returns error for missing separator" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert :error = WindowTree.reset_split_at(tree, @screen, :vertical, 99)
-    end
+    test "reports missing or ambiguous separators unless an exact coordinate is provided" do
+      ambiguous =
+        {:split, :horizontal, {:split, :vertical, {:leaf, 1}, {:leaf, 2}, 39},
+         {:split, :vertical, {:leaf, 3}, {:leaf, 4}, 39}, 0}
 
-    test "returns error instead of guessing when separator position is ambiguous" do
-      tree = {
-        :split,
-        :horizontal,
-        {:split, :vertical, {:leaf, 1}, {:leaf, 2}, 39},
-        {:split, :vertical, {:leaf, 3}, {:leaf, 4}, 39},
-        0
-      }
-
-      assert :error = WindowTree.reset_split_at(tree, @screen, :vertical, 39)
-    end
-  end
-
-  describe "reset_split_at_coordinate/4" do
-    @screen {0, 0, 80, 24}
-
-    test "resets the exact separator under the clicked coordinate" do
-      tree = {
-        :split,
-        :horizontal,
-        {:split, :vertical, {:leaf, 1}, {:leaf, 2}, 39},
-        {:split, :vertical, {:leaf, 3}, {:leaf, 4}, 39},
-        0
-      }
+      assert :error = WindowTree.reset_split_at(two_pane_tree(), @screen, :vertical, 99)
+      assert :error = WindowTree.reset_split_at(ambiguous, @screen, :vertical, 39)
 
       assert {:ok,
               {:split, :horizontal, {:split, :vertical, {:leaf, 1}, {:leaf, 2}, 39},
                {:split, :vertical, {:leaf, 3}, {:leaf, 4}, 0}, 0}} =
-               WindowTree.reset_split_at_coordinate(tree, @screen, 18, 39)
+               WindowTree.reset_split_at_coordinate(ambiguous, @screen, 18, 39)
     end
   end
-
-  # ── window_at/4 ──────────────────────────────────────────────────────────────
 
   describe "window_at/4" do
-    @screen {0, 0, 80, 24}
+    test "maps coordinates to windows and rejects separators or out-of-bounds points" do
+      assert {:ok, 1, {0, 0, 80, 24}} = WindowTree.window_at(WindowTree.new(1), @screen, 12, 40)
+      assert :error = WindowTree.window_at(WindowTree.new(1), @screen, 24, 0)
+      assert :error = WindowTree.window_at(WindowTree.new(1), @screen, 0, 80)
 
-    test "single window: any coordinate returns that window" do
-      tree = WindowTree.new(1)
-      assert {:ok, 1, {0, 0, 80, 24}} = WindowTree.window_at(tree, @screen, 0, 0)
-      assert {:ok, 1, {0, 0, 80, 24}} = WindowTree.window_at(tree, @screen, 12, 40)
-      assert {:ok, 1, {0, 0, 80, 24}} = WindowTree.window_at(tree, @screen, 23, 79)
+      vertical = two_pane_tree()
+      assert_window_at(vertical, @screen, 12, 0, 1)
+      assert_window_at(vertical, @screen, 12, 38, 1)
+      assert :error = WindowTree.window_at(vertical, @screen, 12, 39)
+      assert_window_at(vertical, @screen, 12, 40, 2)
+      assert_window_at(vertical, @screen, 12, 79, 2)
+
+      horizontal = split!(WindowTree.new(1), 1, :horizontal, 2)
+      assert_window_at(horizontal, @screen, 0, 40, 1)
+      assert_window_at(horizontal, @screen, 11, 40, 1)
+      assert_window_at(horizontal, @screen, 12, 40, 2)
+      assert_window_at(horizontal, @screen, 23, 40, 2)
     end
 
-    test "single window: outside bounds returns error" do
-      tree = WindowTree.new(1)
-      assert :error = WindowTree.window_at(tree, @screen, 24, 0)
-      assert :error = WindowTree.window_at(tree, @screen, 0, 80)
-    end
+    test "maps nested and offset coordinates" do
+      tree = nested_tree()
+      assert_window_at(tree, @screen, 12, 10, 1)
+      assert_window_at(tree, @screen, 5, 50, 2)
+      assert_window_at(tree, @screen, 15, 50, 3)
 
-    test "vertical split: left side" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      # Left: {0, 0, 39, 24}, separator at col 39, right: {0, 40, 40, 24}
-      {:ok, id, _rect} = WindowTree.window_at(tree, @screen, 12, 0)
-      assert id == 1
-
-      {:ok, id, _rect} = WindowTree.window_at(tree, @screen, 12, 38)
-      assert id == 1
-    end
-
-    test "vertical split: right side" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, id, _rect} = WindowTree.window_at(tree, @screen, 12, 40)
-      assert id == 2
-
-      {:ok, id, _rect} = WindowTree.window_at(tree, @screen, 12, 79)
-      assert id == 2
-    end
-
-    test "vertical split: separator column returns error" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      # Separator is at col 39
-      assert :error = WindowTree.window_at(tree, @screen, 12, 39)
-    end
-
-    test "horizontal split: top side" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
-      # Top: {0, 0, 80, 12}, bottom: {12, 0, 80, 12}
-      {:ok, id, _rect} = WindowTree.window_at(tree, @screen, 0, 40)
-      assert id == 1
-
-      {:ok, id, _rect} = WindowTree.window_at(tree, @screen, 11, 40)
-      assert id == 1
-    end
-
-    test "horizontal split: bottom side" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
-      {:ok, id, _rect} = WindowTree.window_at(tree, @screen, 12, 40)
-      assert id == 2
-
-      {:ok, id, _rect} = WindowTree.window_at(tree, @screen, 23, 40)
-      assert id == 2
-    end
-
-    test "nested splits: correct window at various coordinates" do
-      # [1] | [2]
-      #     | [3]
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
-
-      # Window 1: left side, full height {0, 0, 39, 24}
-      {:ok, id, _rect} = WindowTree.window_at(tree, @screen, 12, 10)
-      assert id == 1
-
-      # Window 2: top-right {0, 40, 40, 12}
-      {:ok, id, _rect} = WindowTree.window_at(tree, @screen, 5, 50)
-      assert id == 2
-
-      # Window 3: bottom-right {12, 40, 40, 12}
-      {:ok, id, _rect} = WindowTree.window_at(tree, @screen, 15, 50)
-      assert id == 3
-    end
-
-    test "nested splits with offset screen rect" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
       screen = {5, 10, 80, 24}
-
-      {:ok, id, _rect} = WindowTree.window_at(tree, screen, 10, 15)
-      assert id == 1
-
-      {:ok, id, _rect} = WindowTree.window_at(tree, screen, 10, 55)
-      assert id == 2
+      assert_window_at(two_pane_tree(), screen, 10, 15, 1)
+      assert_window_at(two_pane_tree(), screen, 10, 55, 2)
     end
   end
-
-  # ── separator_at/4 ──────────────────────────────────────────────────────────
 
   describe "separator_at/4" do
-    @screen {0, 0, 80, 24}
+    test "detects vertical, horizontal, nested, and offset separators" do
+      vertical = two_pane_tree()
 
-    test "vertical split: separator detected at correct column" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      # Separator at col 39, any row within bounds
-      assert {:ok, {:vertical, 39}} = WindowTree.separator_at(tree, @screen, 0, 39)
-      assert {:ok, {:vertical, 39}} = WindowTree.separator_at(tree, @screen, 12, 39)
-      assert {:ok, {:vertical, 39}} = WindowTree.separator_at(tree, @screen, 23, 39)
-    end
+      for row <- [0, 12, 23],
+          do: assert({:ok, {:vertical, 39}} = WindowTree.separator_at(vertical, @screen, row, 39))
 
-    test "vertical split: non-separator column returns error" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      assert :error = WindowTree.separator_at(tree, @screen, 12, 38)
-      assert :error = WindowTree.separator_at(tree, @screen, 12, 40)
-      assert :error = WindowTree.separator_at(tree, @screen, 12, 0)
-    end
+      for col <- [0, 38, 40],
+          do: assert(:error = WindowTree.separator_at(vertical, @screen, 12, col))
 
-    test "horizontal split: separator detected at modeline row" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
-      # top_height = 12, modeline_row = 11
-      assert {:ok, {:horizontal, 11}} = WindowTree.separator_at(tree, @screen, 11, 0)
-      assert {:ok, {:horizontal, 11}} = WindowTree.separator_at(tree, @screen, 11, 40)
-      assert {:ok, {:horizontal, 11}} = WindowTree.separator_at(tree, @screen, 11, 79)
-    end
+      assert :error = WindowTree.separator_at(vertical, @screen, 24, 39)
 
-    test "horizontal split: non-separator row returns error" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :horizontal, 2)
-      assert :error = WindowTree.separator_at(tree, @screen, 10, 40)
-      assert :error = WindowTree.separator_at(tree, @screen, 12, 40)
-    end
+      horizontal = split!(WindowTree.new(1), 1, :horizontal, 2)
 
-    test "single window: always returns error" do
-      tree = WindowTree.new(1)
-      assert :error = WindowTree.separator_at(tree, @screen, 12, 39)
-      assert :error = WindowTree.separator_at(tree, @screen, 0, 0)
-    end
+      for col <- [0, 40, 79],
+          do:
+            assert(
+              {:ok, {:horizontal, 11}} = WindowTree.separator_at(horizontal, @screen, 11, col)
+            )
 
-    test "nested splits: detects outer vertical separator" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
+      for row <- [10, 12],
+          do: assert(:error = WindowTree.separator_at(horizontal, @screen, row, 40))
 
-      # Outer vertical separator at col 39
-      assert {:ok, {:vertical, 39}} = WindowTree.separator_at(tree, @screen, 12, 39)
-    end
+      assert :error = WindowTree.separator_at(WindowTree.new(1), @screen, 12, 39)
 
-    test "nested splits: detects inner horizontal separator" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      {:ok, tree} = WindowTree.split(tree, 2, :horizontal, 3)
+      nested = nested_tree()
+      assert {:ok, {:vertical, 39}} = WindowTree.separator_at(nested, @screen, 12, 39)
+      assert {:ok, {:horizontal, 11}} = WindowTree.separator_at(nested, @screen, 11, 50)
 
-      # Inner horizontal separator: right subtree at {0, 40, 40, 24}
-      # top_height = div(24, 2) = 12, modeline_row = 0 + 12 - 1 = 11
-      assert {:ok, {:horizontal, 11}} = WindowTree.separator_at(tree, @screen, 11, 50)
-    end
-
-    test "vertical split: separator row outside bounds returns error" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
-      # Row 24 is outside height 24 (rows 0-23)
-      assert :error = WindowTree.separator_at(tree, @screen, 24, 39)
-    end
-
-    test "offset screen rect: separator position accounts for offset" do
-      {:ok, tree} = WindowTree.split(WindowTree.new(1), 1, :vertical, 2)
       screen = {5, 10, 80, 24}
-      # Separator at col 10 + 39 = 49
-      assert {:ok, {:vertical, 49}} = WindowTree.separator_at(tree, screen, 15, 49)
-      assert :error = WindowTree.separator_at(tree, screen, 15, 39)
+      assert {:ok, {:vertical, 49}} = WindowTree.separator_at(vertical, screen, 15, 49)
+      assert :error = WindowTree.separator_at(vertical, screen, 15, 39)
     end
   end
 
-  # ── clamp_size/2 ─────────────────────────────────────────────────────────────
-
   describe "clamp_size/2" do
-    test "zero means half" do
-      assert WindowTree.clamp_size(0, 80) == 40
-      assert WindowTree.clamp_size(0, 79) == 39
-    end
+    test "returns half for zero and clamps explicit sizes to valid ranges" do
+      cases = [
+        {{0, 80}, 40},
+        {{0, 79}, 39},
+        {{50, 80}, 50},
+        {{1, 80}, 1},
+        {{79, 80}, 79},
+        {{100, 80}, 79},
+        {{0, 2}, 1},
+        {{0, 1}, 0}
+      ]
 
-    test "positive size is clamped to [1, total-1]" do
-      assert WindowTree.clamp_size(50, 80) == 50
-      assert WindowTree.clamp_size(1, 80) == 1
-      assert WindowTree.clamp_size(79, 80) == 79
+      for {{size, total}, expected} <- cases do
+        assert WindowTree.clamp_size(size, total) == expected
+      end
     end
+  end
 
-    test "size exceeding total is clamped" do
-      assert WindowTree.clamp_size(100, 80) == 79
-    end
+  defp two_pane_tree do
+    split!(WindowTree.new(1), 1, :vertical, 2)
+  end
 
-    test "size of zero with small total" do
-      assert WindowTree.clamp_size(0, 2) == 1
-      assert WindowTree.clamp_size(0, 1) == 0
-    end
+  defp nested_tree do
+    two_pane_tree() |> split!(2, :horizontal, 3)
+  end
+
+  defp split!(tree, target_id, direction, new_id) do
+    assert {:ok, tree} = WindowTree.split(tree, target_id, direction, new_id)
+    tree
+  end
+
+  defp close!(tree, id) do
+    assert {:ok, tree} = WindowTree.close(tree, id)
+    tree
+  end
+
+  defp resize!(tree, direction, old_pos, new_pos) do
+    assert {:ok, tree} = WindowTree.resize_at(tree, @screen, direction, old_pos, new_pos)
+    tree
+  end
+
+  defp assert_window_at(tree, screen, row, col, expected_id) do
+    assert {:ok, ^expected_id, _rect} = WindowTree.window_at(tree, screen, row, col)
   end
 end


### PR DESCRIPTION
# TL;DR
This PR does another aggressive test-only cleanup pass across four high-duplication suites. It keeps behavior coverage at public module boundaries while removing repeated one-case-per-variant tests.

## Context
This continues the Sandi Metz-style test boundary cleanup: test public behavior at the cheapest useful layer, keep heavier paths as thin smoke coverage, and avoid preserving brittle structure assertions just because they existed.

## Changes
- Collapses GUI chrome cache tests around first-frame sends, unchanged-frame caching, theme fingerprints, hidden and ready file tree fingerprints, git status changes, picker/minibuffer/agent/board fingerprints, and dead prompt buffer safety.
- Collapses LSP action tests around parse and hover normalization tables, definition/hover response behavior, code lens and inlay hint responses, prepare-rename paths, mouse hover no-ops, and code action picker candidates.
- Collapses native provider heavy tests around initial context, thinking levels, model changes, streaming events, budget behavior, API base URL precedence, while preserving tool loop, recovery, turn limit, cost limit, abort, and concurrent prompt behavior.
- Rewrites window tree tests around public invariants for split, close, layout, focus navigation, resize, reset, hit testing, separators, and clamp behavior.

## Verification
- `mix test.debug test/minga_editor/frontend/emit/gui_chrome_cache_test.exs` → `10 tests, 0 failures`
- `mix test.debug test/minga_editor/lsp_actions_test.exs` → `17 tests, 0 failures`
- `mix test.debug test/minga_agent/providers/native_test.exs` → `24 tests, 0 failures`
- `mix test.debug test/minga_editor/window_tree_test.exs` → `18 tests, 0 failures`
- `mix test.llm test/minga_editor/frontend/emit/gui_chrome_cache_test.exs test/minga_editor/lsp_actions_test.exs test/minga_editor/window_tree_test.exs` → `PASS: 45 tests, 0 failures`
- Final reviewer gate: PASS

## Stats
- `test/minga_editor/frontend/emit/gui_chrome_cache_test.exs`: 703 → 374 lines, 21 → 10 tests
- `test/minga_editor/lsp_actions_test.exs`: 668 → 404 lines, 55 → 17 tests
- `test/minga_agent/providers/native_test.exs`: 1113 → 899 lines, 39 → 24 tests
- `test/minga_editor/window_tree_test.exs`: 608 → 305 lines, 68 → 18 tests
- Total diff: 4 files changed, 724 insertions, 1834 deletions

## Notes for reviewers
No production code changed. `native_test.exs` is tagged `:heavy`, so it was validated with `mix test.debug` instead of relying on `test.llm`.
