### PR TITLE
test: collapse aggressive boundary batch 3

### DIFF
--- a/test/minga/mode/normal_test.exs
+++ b/test/minga/mode/normal_test.exs
@@ -5,9 +5,6 @@ defmodule Minga.Mode.NormalTest do
   alias Minga.Mode
   alias Minga.Mode.Normal
 
-  # Shorthand: call Normal.handle_key directly with a fresh state.
-  # Populates leader_trie and normal_bindings so the FSM can resolve
-  # leader sequences and normal bindings without calling the Keymap GenServer.
   defp fresh_state do
     %{
       Mode.initial_state()
@@ -16,549 +13,228 @@ defmodule Minga.Mode.NormalTest do
     }
   end
 
+  defp handle(key, state \\ fresh_state()), do: Normal.handle_key(key, state)
+
   describe "mode transitions" do
-    test "i produces {:transition, :insert, state}" do
-      assert {:transition, :insert, _} = Normal.handle_key({?i, 0}, fresh_state())
-    end
+    test "insert, command, eval, visual, and replace transitions" do
+      transition_cases = [
+        {{?i, 0}, :insert},
+        {{?:, 0}, :command},
+        {{?:, 0x04}, :eval},
+        {{?R, 0}, :replace}
+      ]
 
-    test "a produces {:execute_then_transition, [:move_right], :insert, state}" do
-      assert {:execute_then_transition, [:move_right], :insert, _} =
-               Normal.handle_key({?a, 0}, fresh_state())
-    end
+      for {key, mode} <- transition_cases do
+        assert {:transition, ^mode, _state} = handle(key)
+      end
 
-    test "A produces {:execute_then_transition, [:move_to_line_end, :move_right], :insert, state}" do
-      assert {:execute_then_transition, [:move_to_line_end, :move_right], :insert, _} =
-               Normal.handle_key({?A, 0}, fresh_state())
-    end
+      execute_transition_cases = [
+        {{?a, 0}, [:move_right], :insert},
+        {{?A, 0}, [:move_to_line_end, :move_right], :insert},
+        {{?I, 0}, [:move_to_line_start], :insert},
+        {{?o, 0}, [:insert_line_below], :insert},
+        {{?O, 0}, [:insert_line_above], :insert},
+        {{?s, 0}, [{:delete_chars_at, 1}], :insert},
+        {{?S, 0}, [:change_line], :insert},
+        {{?C, 0}, [{:delete_motion, :line_end}], :insert}
+      ]
 
-    test "I produces {:execute_then_transition, [:move_to_line_start], :insert, state}" do
-      assert {:execute_then_transition, [:move_to_line_start], :insert, _} =
-               Normal.handle_key({?I, 0}, fresh_state())
-    end
+      for {key, commands, mode} <- execute_transition_cases do
+        assert {:execute_then_transition, ^commands, ^mode, _state} = handle(key)
+      end
 
-    test "o produces {:execute_then_transition, [:insert_line_below], :insert, state}" do
-      assert {:execute_then_transition, [:insert_line_below], :insert, _} =
-               Normal.handle_key({?o, 0}, fresh_state())
-    end
+      assert {:transition, :visual, %{visual_type: :char}} = handle({?v, 0})
+      assert {:transition, :visual, %{visual_type: :line}} = handle({?V, 0})
 
-    test "O produces {:execute_then_transition, [:insert_line_above], :insert, state}" do
-      assert {:execute_then_transition, [:insert_line_above], :insert, _} =
-               Normal.handle_key({?O, 0}, fresh_state())
-    end
-
-    test ": enters command mode" do
-      assert {:transition, :command, _} = Normal.handle_key({?:, 0}, fresh_state())
-    end
-
-    test "Alt+: enters eval mode" do
-      # Alt modifier = 0x04
-      assert {:transition, :eval, _} = Normal.handle_key({?:, 0x04}, fresh_state())
-    end
-
-    test "v enters characterwise visual mode" do
-      {:transition, :visual, state} = Normal.handle_key({?v, 0}, fresh_state())
-      assert state.visual_type == :char
-    end
-
-    test "V enters linewise visual mode" do
-      {:transition, :visual, state} = Normal.handle_key({?V, 0}, fresh_state())
-      assert state.visual_type == :line
+      assert {:transition, :replace, %Minga.Mode.ReplaceState{original_chars: []}} =
+               handle({?R, 0})
     end
   end
 
-  describe "movement keys" do
-    test "h produces {:execute, :move_left, state}" do
-      assert {:execute, :move_left, _} = Normal.handle_key({?h, 0}, fresh_state())
-    end
+  describe "normal commands" do
+    test "movement, paste, scrolling, undo, redo, and dot-repeat keys execute commands" do
+      cases = [
+        {{?h, 0}, :move_left},
+        {{?j, 0}, :move_down},
+        {{?k, 0}, :move_up},
+        {{?l, 0}, :move_right},
+        {{?h, 0x04}, :nav_parent},
+        {{?l, 0x04}, :nav_first_child},
+        {{?j, 0x04}, :nav_next_sibling},
+        {{?k, 0x04}, :nav_prev_sibling},
+        {{?0, 0}, :move_to_line_start},
+        {{?w, 0}, :word_forward},
+        {{?b, 0}, :word_backward},
+        {{?e, 0}, :word_end},
+        {{?$, 0}, :move_to_line_end},
+        {{?^, 0}, :move_to_first_non_blank},
+        {{?G, 0}, :move_to_document_end},
+        {{57_352, 0}, :move_up},
+        {{57_353, 0}, :move_down},
+        {{57_350, 0}, :move_left},
+        {{57_351, 0}, :move_right},
+        {{57_352, 0x02}, :move_up},
+        {{57_353, 0x01}, :move_down},
+        {{?p, 0}, :paste_after},
+        {{?P, 0}, :paste_before},
+        {{?d, 0x02}, :half_page_down},
+        {{?u, 0x02}, :half_page_up},
+        {{?f, 0x02}, :page_down},
+        {{?b, 0x02}, :page_up},
+        {{?u, 0}, :undo},
+        {{?r, 0x02}, :redo},
+        {{?D, 0}, {:delete_motion, :line_end}},
+        {{?., 0}, {:dot_repeat, nil}}
+      ]
 
-    test "j produces {:execute, :move_down, state}" do
-      assert {:execute, :move_down, _} = Normal.handle_key({?j, 0}, fresh_state())
-    end
-
-    test "k produces {:execute, :move_up, state}" do
-      assert {:execute, :move_up, _} = Normal.handle_key({?k, 0}, fresh_state())
-    end
-
-    test "l produces {:execute, :move_right, state}" do
-      assert {:execute, :move_right, _} = Normal.handle_key({?l, 0}, fresh_state())
-    end
-
-    test "Alt+h produces structural parent navigation" do
-      assert {:execute, :nav_parent, _} = Normal.handle_key({?h, 0x04}, fresh_state())
-    end
-
-    test "Alt+l produces structural first child navigation" do
-      assert {:execute, :nav_first_child, _} = Normal.handle_key({?l, 0x04}, fresh_state())
-    end
-
-    test "Alt+j produces structural next sibling navigation" do
-      assert {:execute, :nav_next_sibling, _} = Normal.handle_key({?j, 0x04}, fresh_state())
-    end
-
-    test "Alt+k produces structural previous sibling navigation" do
-      assert {:execute, :nav_prev_sibling, _} = Normal.handle_key({?k, 0x04}, fresh_state())
-    end
-
-    test "0 with no count produces {:execute, :move_to_line_start, state}" do
-      assert {:execute, :move_to_line_start, _} =
-               Normal.handle_key({?0, 0}, fresh_state())
-    end
-
-    test "w produces word_forward" do
-      assert {:execute, :word_forward, _} = Normal.handle_key({?w, 0}, fresh_state())
-    end
-
-    test "b produces word_backward" do
-      assert {:execute, :word_backward, _} = Normal.handle_key({?b, 0}, fresh_state())
-    end
-
-    test "e produces word_end" do
-      assert {:execute, :word_end, _} = Normal.handle_key({?e, 0}, fresh_state())
-    end
-
-    test "$ produces move_to_line_end" do
-      assert {:execute, :move_to_line_end, _} = Normal.handle_key({?$, 0}, fresh_state())
-    end
-
-    test "^ produces move_to_first_non_blank" do
-      assert {:execute, :move_to_first_non_blank, _} =
-               Normal.handle_key({?^, 0}, fresh_state())
-    end
-
-    test "G produces move_to_document_end" do
-      assert {:execute, :move_to_document_end, _} =
-               Normal.handle_key({?G, 0}, fresh_state())
-    end
-  end
-
-  describe "arrow keys" do
-    test "up arrow (57_352) produces :move_up" do
-      assert {:execute, :move_up, _} = Normal.handle_key({57_352, 0}, fresh_state())
-    end
-
-    test "down arrow (57_353) produces :move_down" do
-      assert {:execute, :move_down, _} = Normal.handle_key({57_353, 0}, fresh_state())
-    end
-
-    test "left arrow (57_350) produces :move_left" do
-      assert {:execute, :move_left, _} = Normal.handle_key({57_350, 0}, fresh_state())
-    end
-
-    test "right arrow (57_351) produces :move_right" do
-      assert {:execute, :move_right, _} = Normal.handle_key({57_351, 0}, fresh_state())
-    end
-
-    test "arrow keys work with modifiers" do
-      assert {:execute, :move_up, _} = Normal.handle_key({57_352, 0x02}, fresh_state())
-      assert {:execute, :move_down, _} = Normal.handle_key({57_353, 0x01}, fresh_state())
-    end
-  end
-
-  describe "operator entry" do
-    test "d enters operator_pending with :delete operator" do
-      {:transition, :operator_pending, state} = Normal.handle_key({?d, 0}, fresh_state())
-      assert state.operator == :delete
-      assert state.op_count == 1
-    end
-
-    test "c enters operator_pending with :change operator" do
-      {:transition, :operator_pending, state} = Normal.handle_key({?c, 0}, fresh_state())
-      assert state.operator == :change
-      assert state.op_count == 1
-    end
-
-    test "y enters operator_pending with :yank operator" do
-      {:transition, :operator_pending, state} = Normal.handle_key({?y, 0}, fresh_state())
-      assert state.operator == :yank
-      assert state.op_count == 1
-    end
-
-    test "count prefix is passed as op_count to operator_pending" do
-      {:continue, s1} = Normal.handle_key({?3, 0}, fresh_state())
-      {:transition, :operator_pending, state} = Normal.handle_key({?d, 0}, s1)
-      assert state.operator == :delete
-      assert state.op_count == 3
-    end
-  end
-
-  describe "paste" do
-    test "p produces :paste_after" do
-      assert {:execute, :paste_after, _} = Normal.handle_key({?p, 0}, fresh_state())
-    end
-
-    test "P produces :paste_before" do
-      assert {:execute, :paste_before, _} = Normal.handle_key({?P, 0}, fresh_state())
-    end
-  end
-
-  describe "page / half-page scrolling" do
-    test "Ctrl+d produces :half_page_down" do
-      assert {:execute, :half_page_down, _} = Normal.handle_key({?d, 0x02}, fresh_state())
-    end
-
-    test "Ctrl+u produces :half_page_up" do
-      assert {:execute, :half_page_up, _} = Normal.handle_key({?u, 0x02}, fresh_state())
-    end
-
-    test "Ctrl+f produces :page_down" do
-      assert {:execute, :page_down, _} = Normal.handle_key({?f, 0x02}, fresh_state())
-    end
-
-    test "Ctrl+b produces :page_up" do
-      assert {:execute, :page_up, _} = Normal.handle_key({?b, 0x02}, fresh_state())
-    end
-  end
-
-  describe "undo / redo" do
-    test "u produces :undo" do
-      assert {:execute, :undo, _} = Normal.handle_key({?u, 0}, fresh_state())
-    end
-
-    test "Ctrl+r produces :redo" do
-      assert {:execute, :redo, _} = Normal.handle_key({?r, 0x02}, fresh_state())
-    end
-  end
-
-  describe "count prefix accumulation" do
-    test "digit 3 sets count to 3 and continues" do
-      {:continue, new_state} = Normal.handle_key({?3, 0}, fresh_state())
-      assert new_state.count == 3
-    end
-
-    test "digits 1 then 2 accumulate to 12" do
-      {:continue, s1} = Normal.handle_key({?1, 0}, fresh_state())
-      {:continue, s2} = Normal.handle_key({?2, 0}, s1)
-      assert s2.count == 12
-    end
-
-    test "0 after digit continues count (e.g. 10)" do
-      {:continue, s1} = Normal.handle_key({?1, 0}, fresh_state())
-      {:continue, s2} = Normal.handle_key({?0, 0}, s1)
-      assert s2.count == 10
-    end
-
-    test "0 with no prior count is :move_to_line_start (not a count digit)" do
-      assert {:execute, :move_to_line_start, _} =
-               Normal.handle_key({?0, 0}, fresh_state())
-    end
-
-    test "count is preserved in state after digit key" do
-      {:continue, state_with_count} = Normal.handle_key({?5, 0}, fresh_state())
-      {:execute, :move_down, state_after} = Normal.handle_key({?j, 0}, state_with_count)
-      assert state_after.count == 5
-    end
-
-    test "all digits 1-9 start a count" do
-      for digit <- ?1..?9 do
-        {:continue, state} = Normal.handle_key({digit, 0}, fresh_state())
-        assert state.count == digit - ?0
+      for {key, command} <- cases do
+        assert {:execute, ^command, _state} = handle(key)
       end
     end
 
-    test "multi-digit count like 123" do
-      {:continue, s1} = Normal.handle_key({?1, 0}, fresh_state())
-      {:continue, s2} = Normal.handle_key({?2, 0}, s1)
-      {:continue, s3} = Normal.handle_key({?3, 0}, s2)
+    test "count prefix accumulates and is passed to operators and dot repeat" do
+      {:continue, s1} = handle({?1, 0})
+      {:continue, s2} = handle({?2, 0}, s1)
+      {:continue, s3} = handle({?3, 0}, s2)
       assert s3.count == 123
+
+      {:continue, ten} = handle({?0, 0}, s1)
+      assert ten.count == 10
+
+      {:execute, :move_down, after_move} = handle({?j, 0}, s3)
+      assert after_move.count == 123
+
+      for digit <- ?1..?9 do
+        {:continue, state} = handle({digit, 0})
+        assert state.count == digit - ?0
+      end
+
+      {:transition, :operator_pending, %{operator: :delete, op_count: 3}} =
+        handle({?d, 0}, handle_count(3))
+
+      {:transition, :operator_pending, %{operator: :indent, op_count: 3}} =
+        handle({?>, 0}, handle_count(3))
+
+      {:transition, :operator_pending, %{operator: :dedent, op_count: 3}} =
+        handle({?<, 0}, handle_count(3))
+
+      {:execute, {:dot_repeat, 15}, %{count: nil}} = handle({?., 0}, handle_count(15))
     end
-  end
 
-  describe "Escape key" do
-    test "Escape clears any accumulated count" do
-      {:continue, s1} = Normal.handle_key({?5, 0}, fresh_state())
-      {:continue, s2} = Normal.handle_key({27, 0}, s1)
-      assert s2.count == nil
+    test "operator entry records operator and default count" do
+      for {key, operator} <- [
+            {?d, :delete},
+            {?c, :change},
+            {?y, :yank},
+            {?>, :indent},
+            {?<, :dedent}
+          ] do
+        {:transition, :operator_pending, state} = handle({key, 0})
+        assert state.operator == operator
+        assert state.op_count == 1
+      end
+
+      refute Map.has_key?(fresh_state(), :pending_shift)
     end
 
-    test "Escape with no count is a no-op continue" do
-      assert {:continue, _} = Normal.handle_key({27, 0}, fresh_state())
-    end
+    test "escape and unknown keys clear or preserve the right state" do
+      {:continue, counted} = handle({?5, 0})
+      {:continue, cleared} = handle({27, 0}, counted)
+      assert cleared.count == nil
+      assert {:continue, _} = handle({27, 0})
 
-    test "Escape cancels leader mode" do
-      # Simulate being in leader mode
-      leader_trie = Defaults.leader_trie()
+      assert {:continue, state} = handle({?z, 0})
+      assert state.count == nil
 
-      state =
-        fresh_state()
-        |> Map.put(:leader_node, leader_trie)
-        |> Map.put(:leader_keys, ["SPC"])
-
-      {:execute, :leader_cancel, new_state} = Normal.handle_key({27, 0}, state)
-      assert new_state.leader_node == nil
-      assert new_state.leader_keys == []
-      assert new_state.count == nil
+      custom = %{count: 3}
+      assert {:continue, ^custom} = handle({?z, 0}, custom)
     end
   end
 
   describe "leader key sequences" do
-    test "SPC starts leader mode" do
-      {:execute, {:leader_start, node}, state} = Normal.handle_key({32, 0}, fresh_state())
-      assert state.leader_node == node
-      assert state.leader_keys == ["SPC"]
+    test "space starts leader mode, progress advances, repeated space restarts, and invalid keys cancel" do
+      {:execute, {:leader_start, node}, leader_state} = handle({32, 0})
+      assert leader_state.leader_node == node
+      assert leader_state.leader_keys == ["SPC"]
+
+      {:execute, repeated_commands, repeated_state} = handle({32, 0}, leader_state)
+      assert is_list(repeated_commands)
+      assert :leader_cancel in repeated_commands
+      assert repeated_state.leader_keys == ["SPC"]
+
+      case handle({?f, 0}, leader_state) do
+        {:execute, {:leader_progress, sub_node}, progressed} ->
+          assert progressed.leader_node == sub_node
+          assert "f" in progressed.leader_keys
+
+        {:execute, [_command, :leader_cancel], progressed} ->
+          assert progressed.leader_node == nil
+      end
+
+      for {key, count, pending} <- [
+            {{?z, 0}, nil, nil},
+            {{?Z, 0}, 5, nil},
+            {{27, 0}, 3, nil},
+            {{27, 0}, nil, :replace}
+          ] do
+        state = leader_state |> Map.put(:count, count) |> Map.put(:pending, pending)
+        {:execute, :leader_cancel, cancelled} = handle(key, state)
+        assert cancelled.leader_node == nil
+        assert cancelled.leader_keys == []
+        assert cancelled.count == nil
+      end
     end
 
-    test "SPC while already in leader mode cancels and restarts" do
-      # First SPC to enter leader mode
-      {:execute, {:leader_start, _node}, state} = Normal.handle_key({32, 0}, fresh_state())
-
-      # Second SPC should cancel and restart
-      {:execute, commands, new_state} = Normal.handle_key({32, 0}, state)
-      assert is_list(commands)
-      assert :leader_cancel in commands
-      assert new_state.leader_keys == ["SPC"]
-    end
-
-    test "unknown key during leader mode cancels leader" do
+    test "which-key pagination keeps leader state" do
       leader_trie = Defaults.leader_trie()
 
       state =
-        fresh_state()
-        |> Map.put(:leader_node, leader_trie)
-        |> Map.put(:leader_keys, ["SPC"])
+        fresh_state() |> Map.put(:leader_node, leader_trie) |> Map.put(:leader_keys, ["SPC"])
 
-      # Press a key that's not in the leader trie (e.g., 'z')
-      {:execute, :leader_cancel, new_state} = Normal.handle_key({?z, 0}, state)
-      assert new_state.leader_node == nil
-      assert new_state.leader_keys == []
-    end
-
-    test "escape during leader mode clears count" do
-      state =
-        fresh_state()
-        |> Map.put(:count, 3)
-        |> Map.put(:leader_node, Defaults.leader_trie())
-        |> Map.put(:leader_keys, ["SPC"])
-
-      {:execute, :leader_cancel, new_state} = Normal.handle_key({27, 0}, state)
-      assert new_state.count == nil
-      assert new_state.leader_node == nil
-    end
-
-    test "escape during leader mode clears pending" do
-      state =
-        fresh_state()
-        |> Map.put(:pending, :replace)
-        |> Map.put(:leader_node, Defaults.leader_trie())
-        |> Map.put(:leader_keys, ["SPC"])
-
-      {:execute, :leader_cancel, new_state} = Normal.handle_key({27, 0}, state)
-      assert new_state.pending == nil
-      assert new_state.leader_node == nil
-    end
-
-    test "unbound key during leader mode clears count" do
-      state =
-        fresh_state()
-        |> Map.put(:count, 5)
-        |> Map.put(:leader_node, Defaults.leader_trie())
-        |> Map.put(:leader_keys, ["SPC"])
-
-      # Press an unbound key (unlikely to be in leader trie)
-      {:execute, :leader_cancel, new_state} = Normal.handle_key({?Z, 0}, state)
-      assert new_state.count == nil
-    end
-
-    test "valid leader prefix key advances trie" do
-      # SPC f should be a prefix (file commands)
-      {:execute, {:leader_start, _node}, state} = Normal.handle_key({32, 0}, fresh_state())
-      result = Normal.handle_key({?f, 0}, state)
-
-      case result do
-        {:execute, {:leader_progress, sub_node}, new_state} ->
-          assert new_state.leader_node == sub_node
-          assert "f" in new_state.leader_keys
-
-        {:execute, [_cmd, :leader_cancel], new_state} ->
-          # If 'f' is a direct command rather than prefix, that's also valid
-          assert new_state.leader_node == nil
+      for {key, command} <- [{{?d, 0x02}, :whichkey_next_page}, {{?u, 0x02}, :whichkey_prev_page}] do
+        {:execute, ^command, new_state} = handle(key, state)
+        assert new_state.leader_node == leader_trie
+        assert new_state.leader_keys == ["SPC"]
       end
     end
   end
 
-  describe "which-key pagination during leader mode" do
-    test "Ctrl+D emits :whichkey_next_page without cancelling leader" do
-      leader_trie = Defaults.leader_trie()
-
-      state =
-        fresh_state()
-        |> Map.put(:leader_node, leader_trie)
-        |> Map.put(:leader_keys, ["SPC"])
-
-      {:execute, :whichkey_next_page, new_state} = Normal.handle_key({?d, 0x02}, state)
-      assert new_state.leader_node == leader_trie
-      assert new_state.leader_keys == ["SPC"]
-    end
-
-    test "Ctrl+U emits :whichkey_prev_page without cancelling leader" do
-      leader_trie = Defaults.leader_trie()
-
-      state =
-        fresh_state()
-        |> Map.put(:leader_node, leader_trie)
-        |> Map.put(:leader_keys, ["SPC"])
-
-      {:execute, :whichkey_prev_page, new_state} = Normal.handle_key({?u, 0x02}, state)
-      assert new_state.leader_node == leader_trie
-      assert new_state.leader_keys == ["SPC"]
-    end
-  end
-
-  describe "unknown keys" do
-    test "unknown key produces {:continue, state}" do
-      assert {:continue, state} = Normal.handle_key({?z, 0}, fresh_state())
-      assert state.count == nil
-    end
-
-    test "unknown key does not change state" do
-      s = %{count: 3}
-      {:continue, s2} = Normal.handle_key({?z, 0}, s)
-      assert s2 == s
-    end
-  end
-
-  describe "s/S/C/D shortcuts (#51)" do
-    test "s emits [{:delete_chars_at, 1}] and transitions to :insert" do
-      assert {:execute_then_transition, [{:delete_chars_at, 1}], :insert, _} =
-               Normal.handle_key({?s, 0}, fresh_state())
-    end
-
-    test "S emits [:change_line] and transitions to :insert" do
-      assert {:execute_then_transition, [:change_line], :insert, _} =
-               Normal.handle_key({?S, 0}, fresh_state())
-    end
-
-    test "C emits [{:delete_motion, :line_end}] and transitions to :insert" do
-      assert {:execute_then_transition, [{:delete_motion, :line_end}], :insert, _} =
-               Normal.handle_key({?C, 0}, fresh_state())
-    end
-
-    test "D emits {:delete_motion, :line_end} and stays in normal mode" do
-      assert {:execute, {:delete_motion, :line_end}, _} =
-               Normal.handle_key({?D, 0}, fresh_state())
-    end
-  end
-
-  describe "R enters replace mode (#52)" do
-    test "R transitions to :replace mode" do
-      assert {:transition, :replace, state} = Normal.handle_key({?R, 0}, fresh_state())
-      assert %Minga.Mode.ReplaceState{} = state
-    end
-
-    test "R mode state has empty original_chars stack" do
-      {:transition, :replace, state} = Normal.handle_key({?R, 0}, fresh_state())
-      assert state.original_chars == []
-    end
-  end
-
-  describe "> and < as indent/dedent operators (#57)" do
-    test "> transitions to :operator_pending with :indent operator" do
-      {:transition, :operator_pending, state} = Normal.handle_key({?>, 0}, fresh_state())
-      assert state.operator == :indent
-      assert state.op_count == 1
-    end
-
-    test "< transitions to :operator_pending with :dedent operator" do
-      {:transition, :operator_pending, state} = Normal.handle_key({?<, 0}, fresh_state())
-      assert state.operator == :dedent
-      assert state.op_count == 1
-    end
-
-    test "3> transitions to :operator_pending with :indent and op_count 3" do
-      {:continue, s1} = Normal.handle_key({?3, 0}, fresh_state())
-      {:transition, :operator_pending, state} = Normal.handle_key({?>, 0}, s1)
-      assert state.operator == :indent
-      assert state.op_count == 3
-    end
-
-    test "3< transitions to :operator_pending with :dedent and op_count 3" do
-      {:continue, s1} = Normal.handle_key({?3, 0}, fresh_state())
-      {:transition, :operator_pending, state} = Normal.handle_key({?<, 0}, s1)
-      assert state.operator == :dedent
-      assert state.op_count == 3
-    end
-
-    test "pending_shift field no longer exists on Mode.State" do
-      state = fresh_state()
-      refute Map.has_key?(state, :pending_shift)
-    end
-  end
-
-  describe "describe-key (SPC h k)" do
-    test "describe_key captures a normal key and emits describe_key_result" do
-      state = %{fresh_state() | describe_key: %Minga.Mode.DescribeKey{}}
-      result = Normal.handle_key({?j, 0}, state)
-
-      assert {:execute, {:describe_key_result, "j", :move_down, "Move cursor down"}, new_state} =
-               result
-
-      assert new_state.describe_key == nil
-    end
-
-    test "describe_key on unbound key emits describe_key_not_found" do
-      state = %{fresh_state() | describe_key: %Minga.Mode.DescribeKey{}}
-      # Use a key that has no normal binding
-      result = Normal.handle_key({?Z, 0}, state)
-
-      assert {:execute, {:describe_key_not_found, "Z"}, new_state} = result
-      assert new_state.describe_key == nil
-    end
-
-    test "Escape cancels describe-key" do
-      state = %{fresh_state() | describe_key: %Minga.Mode.DescribeKey{}}
-      assert {:continue, new_state} = Normal.handle_key({27, 0}, state)
-      assert new_state.describe_key == nil
-    end
-
-    test "SPC in describe-key starts leader trie walk" do
-      state = %{fresh_state() | describe_key: %Minga.Mode.DescribeKey{}}
-      assert {:continue, new_state} = Normal.handle_key({32, 0}, state)
-      assert new_state.describe_key.leader_node != nil
-      assert new_state.describe_key.keys == ["SPC"]
-    end
-
-    test "SPC f f in describe-key resolves to find_file" do
+  describe "describe-key" do
+    test "normal, unbound, escape, and leader describe-key paths" do
       state = %{fresh_state() | describe_key: %Minga.Mode.DescribeKey{}}
 
-      # SPC → start leader walk
-      {:continue, s1} = Normal.handle_key({32, 0}, state)
-      # f → prefix (stored reversed)
-      {:continue, s2} = Normal.handle_key({?f, 0}, s1)
+      assert {:execute, {:describe_key_result, "j", :move_down, "Move cursor down"},
+              %{describe_key: nil}} = handle({?j, 0}, state)
+
+      assert {:execute, {:describe_key_not_found, "Z"}, %{describe_key: nil}} =
+               handle({?Z, 0}, state)
+
+      assert {:continue, %{describe_key: nil}} = handle({27, 0}, state)
+
+      {:continue, s1} = handle({32, 0}, state)
+      assert s1.describe_key.leader_node != nil
+      assert s1.describe_key.keys == ["SPC"]
+
+      {:continue, s2} = handle({?f, 0}, s1)
       assert s2.describe_key.keys == ["f", "SPC"]
-      # f → command
-      {:execute, {:describe_key_result, "SPC f f", :find_file, "Find file"}, s3} =
-        Normal.handle_key({?f, 0}, s2)
 
-      assert s3.describe_key == nil
-    end
+      assert {:execute, {:describe_key_result, "SPC f f", :find_file, "Find file"},
+              %{describe_key: nil}} = handle({?f, 0}, s2)
 
-    test "SPC z in describe-key reports not found" do
-      state = %{fresh_state() | describe_key: %Minga.Mode.DescribeKey{}}
+      {:continue, leader} = handle({32, 0}, state)
 
-      {:continue, s1} = Normal.handle_key({32, 0}, state)
-
-      {:execute, {:describe_key_not_found, "SPC z"}, s2} =
-        Normal.handle_key({?z, 0}, s1)
-
-      assert s2.describe_key == nil
+      assert {:execute, {:describe_key_not_found, "SPC z"}, %{describe_key: nil}} =
+               handle({?z, 0}, leader)
     end
   end
 
-  describe "dot repeat (#49)" do
-    test ". emits {:dot_repeat, nil} with no count" do
-      assert {:execute, {:dot_repeat, nil}, _} = Normal.handle_key({?., 0}, fresh_state())
-    end
-
-    test ". emits {:dot_repeat, 3} with count prefix 3" do
-      {:continue, s1} = Normal.handle_key({?3, 0}, fresh_state())
-      assert {:execute, {:dot_repeat, 3}, state} = Normal.handle_key({?., 0}, s1)
-      # Count is consumed — reset to nil
-      assert state.count == nil
-    end
-
-    test ". emits {:dot_repeat, 15} with count prefix 15" do
-      {:continue, s1} = Normal.handle_key({?1, 0}, fresh_state())
-      {:continue, s2} = Normal.handle_key({?5, 0}, s1)
-      assert {:execute, {:dot_repeat, 15}, _} = Normal.handle_key({?., 0}, s2)
-    end
+  defp handle_count(count) do
+    count
+    |> Integer.to_string()
+    |> String.to_charlist()
+    |> Enum.reduce(fresh_state(), fn digit, state ->
+      {:continue, next_state} = handle({digit, 0}, state)
+      next_state
+    end)
   end
 end

--- a/test/minga_editor/agent/ui_state_test.exs
+++ b/test/minga_editor/agent/ui_state_test.exs
@@ -1,517 +1,255 @@
 defmodule MingaEditor.Agent.UIStateTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer.Process, as: BufferProcess
   alias MingaAgent.Config, as: AgentConfig
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.Panel
-  alias Minga.Buffer.Process, as: BufferProcess
 
-  # Creates a UIState with a running prompt buffer containing the given text.
-  defp ui_with_input(lines, cursor \\ nil) do
-    text = Enum.join(lines, "\n")
-    cursor = cursor || {0, 0}
-    ui = UIState.new()
-    ui = UIState.ensure_prompt_buffer(ui)
-    BufferProcess.replace_content(ui.panel.prompt_buffer, text)
+  defp ui_with_input(lines, cursor \\ {0, 0}) do
+    ui = UIState.new() |> UIState.ensure_prompt_buffer()
+    BufferProcess.replace_content(ui.panel.prompt_buffer, Enum.join(lines, "\n"))
     BufferProcess.move_to(ui.panel.prompt_buffer, cursor)
     ui
   end
 
-  # Moves the cursor in the prompt buffer.
-  defp set_input_cursor(ui, cursor) do
-    BufferProcess.move_to(ui.panel.prompt_buffer, cursor)
+  defp put_history(ui, history, index \\ -1) do
     ui
+    |> put_in([Access.key(:panel), Access.key(:prompt_history)], history)
+    |> put_in([Access.key(:panel), Access.key(:history_index)], index)
   end
 
-  describe "new/0" do
-    test "starts not visible" do
+  describe "new/0 and basic state" do
+    test "starts hidden, unfocused, empty, and configured with the default model" do
       ui = UIState.new()
+
       refute ui.panel.visible
-    end
-
-    test "starts with empty input" do
-      ui = UIState.new()
-      assert UIState.input_text(ui) == ""
-    end
-
-    test "starts not focused" do
-      ui = UIState.new()
       refute ui.panel.input_focused
-    end
-
-    test "starts with empty prompt history" do
-      ui = UIState.new()
       assert ui.panel.prompt_history == []
       assert ui.panel.history_index == -1
-    end
-
-    test "default model_name includes provider prefix" do
-      ui = UIState.new()
-      assert String.contains?(ui.panel.model_name, ":")
-      assert ui.panel.model_name == AgentConfig.default_model()
-    end
-  end
-
-  describe "toggle/1" do
-    test "toggles visibility" do
-      ui = UIState.new()
-      assert UIState.toggle(ui).panel.visible
-      refute ui |> UIState.toggle() |> UIState.toggle() |> then(& &1.panel.visible)
-    end
-  end
-
-  describe "insert_char/2" do
-    test "inserts a character" do
-      ui = ui_with_input([""])
-      ui = UIState.insert_char(ui, "h")
-      assert UIState.input_lines(ui) == ["h"]
-    end
-
-    test "appends characters at cursor" do
-      ui = ui_with_input([""])
-      ui = UIState.insert_char(ui, "h")
-      ui = UIState.insert_char(ui, "i")
-      assert UIState.input_lines(ui) == ["hi"]
-    end
-
-    test "resets history index" do
-      ui = ui_with_input([""])
-      ui = put_in(ui.panel.history_index, 2)
-      ui = UIState.insert_char(ui, "x")
-      assert ui.panel.history_index == -1
-    end
-  end
-
-  describe "insert_newline/1" do
-    test "splits line at cursor" do
-      ui = ui_with_input(["hello"], {0, 2})
-      ui = UIState.insert_newline(ui)
-      assert UIState.input_lines(ui) == ["he", "llo"]
-    end
-
-    test "inserts at end of line" do
-      ui = ui_with_input(["hi"], {0, 2})
-      ui = UIState.insert_newline(ui)
-      assert UIState.input_lines(ui) == ["hi", ""]
-    end
-  end
-
-  describe "delete_char/1" do
-    test "deletes character before cursor" do
-      ui = ui_with_input(["hi"], {0, 2})
-      ui = UIState.delete_char(ui)
-      assert UIState.input_lines(ui) == ["h"]
-    end
-
-    test "no-op at start of buffer" do
-      ui = ui_with_input(["hi"], {0, 0})
-      ui = UIState.delete_char(ui)
-      assert UIState.input_lines(ui) == ["hi"]
-    end
-
-    test "joins lines at start of non-first line" do
-      ui = ui_with_input(["ab", "cd"], {1, 0})
-      ui = UIState.delete_char(ui)
-      assert UIState.input_lines(ui) == ["abcd"]
-    end
-  end
-
-  describe "move_cursor_up/1" do
-    test "returns :at_top on first line" do
-      ui = ui_with_input(["hello"], {0, 0})
-      assert UIState.move_cursor_up(ui) == :at_top
-    end
-
-    test "moves cursor up" do
-      ui = ui_with_input(["ab", "cd"], {1, 0})
-      result = UIState.move_cursor_up(ui)
-      refute result == :at_top
-    end
-  end
-
-  describe "move_cursor_down/1" do
-    test "returns :at_bottom on last line" do
-      ui = ui_with_input(["hello"], {0, 0})
-      assert UIState.move_cursor_down(ui) == :at_bottom
-    end
-
-    test "moves cursor down" do
-      ui = ui_with_input(["ab", "cd"], {0, 0})
-      result = UIState.move_cursor_down(ui)
-      refute result == :at_bottom
-    end
-  end
-
-  describe "clear_input/1" do
-    test "clears to empty" do
-      ui = ui_with_input(["hello", "world"])
-      ui = UIState.clear_input(ui)
-      assert UIState.input_lines(ui) == [""]
       assert UIState.input_text(ui) == ""
-    end
-
-    test "saves non-empty text to history" do
-      ui = ui_with_input(["hello"])
-      ui = UIState.clear_input(ui)
-      assert ui.panel.prompt_history == ["hello"]
-    end
-
-    test "resets history index" do
-      ui = ui_with_input(["hello"])
-      ui = put_in(ui.panel.history_index, 1)
-      ui = UIState.clear_input(ui)
-      assert ui.panel.history_index == -1
-    end
-
-    test "clears pasted_blocks" do
-      ui = ui_with_input(["hello"])
-      ui = put_in(ui.panel.pasted_blocks, [%{text: "paste", expanded: false}])
-      ui = UIState.clear_input(ui)
-      assert ui.panel.pasted_blocks == []
-    end
-  end
-
-  describe "input_text/1" do
-    test "returns raw buffer content" do
-      ui = ui_with_input(["hello", "world"])
-      assert UIState.input_text(ui) == "hello\nworld"
-    end
-
-    test "returns empty string when no buffer" do
-      ui = UIState.new()
-      assert UIState.input_text(ui) == ""
-    end
-  end
-
-  describe "prompt_text/1" do
-    test "returns text with placeholders substituted" do
-      ui = ui_with_input(["before", "\0PASTE:0", "after"])
-      ui = put_in(ui.panel.pasted_blocks, [%{text: "line1\nline2\nline3", expanded: false}])
-      assert UIState.prompt_text(ui) == "before\nline1\nline2\nline3\nafter"
-    end
-
-    test "returns raw text when no placeholders" do
-      ui = ui_with_input(["hello"])
-      assert UIState.prompt_text(ui) == "hello"
-    end
-  end
-
-  describe "input_lines/1" do
-    test "returns lines from buffer" do
-      ui = ui_with_input(["ab", "cd"])
-      assert UIState.input_lines(ui) == ["ab", "cd"]
-    end
-
-    test "returns empty line when no buffer" do
-      ui = UIState.new()
       assert UIState.input_lines(ui) == [""]
-    end
-  end
-
-  describe "input_cursor/1" do
-    test "returns cursor from buffer" do
-      ui = ui_with_input(["hello"], {0, 3})
-      assert UIState.input_cursor(ui) == {0, 3}
-    end
-
-    test "returns {0, 0} when no buffer" do
-      ui = UIState.new()
       assert UIState.input_cursor(ui) == {0, 0}
-    end
-  end
-
-  describe "input_line_count/1" do
-    test "returns line count from buffer" do
-      ui = ui_with_input(["a", "b", "c"])
-      assert UIState.input_line_count(ui) == 3
-    end
-
-    test "returns 1 when no buffer" do
-      ui = UIState.new()
       assert UIState.input_line_count(ui) == 1
+      assert UIState.input_empty?(ui)
+      assert ui.panel.model_name == AgentConfig.default_model()
+      assert String.contains?(ui.panel.model_name, ":")
+    end
+
+    test "toggle flips panel visibility" do
+      assert UIState.toggle(UIState.new()).panel.visible
+      refute UIState.new() |> UIState.toggle() |> UIState.toggle() |> then(& &1.panel.visible)
     end
   end
 
-  describe "input_empty?/1" do
-    test "true when buffer is empty" do
+  describe "prompt editing" do
+    test "inserts characters, newlines, and deletes across line boundaries" do
       ui = ui_with_input([""])
-      assert UIState.input_empty?(ui)
+      ui = ui |> UIState.insert_char("h") |> UIState.insert_char("i")
+      assert UIState.input_lines(ui) == ["hi"]
+
+      BufferProcess.move_to(ui.panel.prompt_buffer, {0, 1})
+      ui = UIState.insert_newline(ui)
+      assert UIState.input_lines(ui) == ["h", "i"]
+
+      ui = ui_with_input(["ab", "cd"], {1, 0}) |> UIState.delete_char()
+      assert UIState.input_lines(ui) == ["abcd"]
+
+      ui = ui_with_input(["hi"], {0, 0}) |> UIState.delete_char()
+      assert UIState.input_lines(ui) == ["hi"]
     end
 
-    test "false when buffer has content" do
-      ui = ui_with_input(["hello"])
-      refute UIState.input_empty?(ui)
+    test "edit operations reset history index" do
+      for operation <- [
+            &UIState.insert_char(&1, "x"),
+            &UIState.insert_newline/1,
+            &UIState.delete_char/1
+          ] do
+        ui =
+          ui_with_input(["abc"], {0, 1})
+          |> put_in([Access.key(:panel), Access.key(:history_index)], 2)
+
+        assert operation.(ui).panel.history_index == -1
+      end
     end
 
-    test "true when no buffer" do
-      ui = UIState.new()
-      assert UIState.input_empty?(ui)
+    test "cursor movement reports boundaries and moves within multiline input" do
+      assert UIState.move_cursor_up(ui_with_input(["hello"], {0, 0})) == :at_top
+      assert UIState.move_cursor_down(ui_with_input(["hello"], {0, 0})) == :at_bottom
+      refute UIState.move_cursor_up(ui_with_input(["ab", "cd"], {1, 0})) == :at_top
+      refute UIState.move_cursor_down(ui_with_input(["ab", "cd"], {0, 0})) == :at_bottom
     end
-  end
 
-  describe "set_input_focused/2" do
-    test "focusing starts prompt buffer" do
-      ui = UIState.new()
-      ui = UIState.set_input_focused(ui, true)
+    test "focus starts the prompt buffer and unfocus preserves content" do
+      ui = UIState.new() |> UIState.set_input_focused(true)
       assert ui.panel.input_focused
       assert is_pid(ui.panel.prompt_buffer)
-    end
 
-    test "unfocusing preserves state" do
-      ui = ui_with_input(["hello"])
-      ui = UIState.set_input_focused(ui, true)
-      ui = UIState.set_input_focused(ui, false)
+      ui =
+        ui_with_input(["hello"])
+        |> UIState.set_input_focused(true)
+        |> UIState.set_input_focused(false)
+
       refute ui.panel.input_focused
-      # Buffer and content preserved
       assert UIState.input_lines(ui) == ["hello"]
     end
   end
 
-  describe "history_prev/1" do
-    test "no-op with empty history" do
-      ui = ui_with_input(["current"])
-      assert UIState.history_prev(ui) == ui
-    end
+  describe "input clearing, text access, and history" do
+    test "clear_input saves non-empty prompts, resets editing state, and clears paste blocks" do
+      ui =
+        ui_with_input(["hello", "world"])
+        |> put_in([Access.key(:panel), Access.key(:history_index)], 1)
+        |> put_in([Access.key(:panel), Access.key(:pasted_blocks)], [
+          %{text: "paste", expanded: false}
+        ])
+        |> UIState.clear_input()
 
-    test "recalls previous entry" do
-      ui = ui_with_input([""])
-      ui = put_in(ui.panel.prompt_history, ["first", "second"])
-      ui = UIState.history_prev(ui)
-      assert UIState.input_text(ui) == "first"
-      assert ui.panel.history_index == 0
-    end
-
-    test "walks through history" do
-      ui = ui_with_input([""])
-      ui = put_in(ui.panel.prompt_history, ["first", "second"])
-      ui = UIState.history_prev(ui)
-      ui = UIState.history_prev(ui)
-      assert UIState.input_text(ui) == "second"
-      assert ui.panel.history_index == 1
-    end
-
-    test "clamps at oldest entry" do
-      ui = ui_with_input([""])
-      ui = put_in(ui.panel.prompt_history, ["only"])
-      ui = UIState.history_prev(ui)
-      ui = UIState.history_prev(ui)
-      assert UIState.input_text(ui) == "only"
-      assert ui.panel.history_index == 0
-    end
-  end
-
-  describe "history_next/1" do
-    test "no-op at index -1" do
-      ui = ui_with_input([""])
-      ui = UIState.history_next(ui)
+      assert UIState.input_lines(ui) == [""]
       assert UIState.input_text(ui) == ""
-    end
-
-    test "clears input at index 0" do
-      ui = ui_with_input([""])
-      ui = put_in(ui.panel.prompt_history, ["entry"])
-      ui = put_in(ui.panel.history_index, 0)
-      BufferProcess.replace_content(ui.panel.prompt_buffer, "entry")
-      ui = UIState.history_next(ui)
-      assert UIState.input_text(ui) == ""
+      assert ui.panel.prompt_history == ["hello\nworld"]
       assert ui.panel.history_index == -1
+      assert ui.panel.pasted_blocks == []
     end
 
-    test "recalls more recent entry" do
-      ui = ui_with_input([""])
-      ui = put_in(ui.panel.prompt_history, ["first", "second"])
-      ui = put_in(ui.panel.history_index, 1)
-      ui = UIState.history_next(ui)
-      assert UIState.input_text(ui) == "first"
-      assert ui.panel.history_index == 0
+    test "prompt_text substitutes paste placeholders while input_text stays raw" do
+      placeholder = <<0>> <> "PASTE:0"
+
+      ui =
+        ui_with_input(["before", placeholder, "after"])
+        |> put_in([Access.key(:panel), Access.key(:pasted_blocks)], [
+          %{text: "line1\nline2\nline3", expanded: false}
+        ])
+
+      assert UIState.input_text(ui) == "before\n#{placeholder}\nafter"
+      assert UIState.prompt_text(ui) == "before\nline1\nline2\nline3\nafter"
+    end
+
+    test "history navigation walks older and newer prompts with clamping" do
+      ui = ui_with_input([""]) |> put_history(["first", "second"])
+
+      first = UIState.history_prev(ui)
+      assert UIState.input_text(first) == "first"
+      assert first.panel.history_index == 0
+
+      second = UIState.history_prev(first)
+      assert UIState.input_text(second) == "second"
+      assert second.panel.history_index == 1
+
+      assert UIState.history_prev(second).panel.history_index == 1
+
+      newer = UIState.history_next(second)
+      assert UIState.input_text(newer) == "first"
+      assert newer.panel.history_index == 0
+
+      current = UIState.history_next(newer)
+      assert UIState.input_text(current) == ""
+      assert current.panel.history_index == -1
+    end
+
+    test "save_to_history skips blank input" do
+      for text <- ["", "   "] do
+        assert text
+               |> List.wrap()
+               |> ui_with_input()
+               |> UIState.save_to_history()
+               |> then(& &1.panel.prompt_history) == []
+      end
+
+      assert ui_with_input(["hello"])
+             |> UIState.save_to_history()
+             |> then(& &1.panel.prompt_history) == ["hello"]
     end
   end
 
-  describe "save_to_history/1" do
-    test "saves non-empty text" do
-      ui = ui_with_input(["hello"])
-      ui = UIState.save_to_history(ui)
-      assert ui.panel.prompt_history == ["hello"]
-    end
-
-    test "skips empty text" do
-      ui = ui_with_input([""])
-      ui = UIState.save_to_history(ui)
-      assert ui.panel.prompt_history == []
-    end
-
-    test "skips whitespace-only text" do
-      ui = ui_with_input(["   "])
-      ui = UIState.save_to_history(ui)
-      assert ui.panel.prompt_history == []
-    end
-  end
-
-  describe "insert_paste/2" do
-    test "no-op for empty text" do
+  describe "paste handling" do
+    test "insert_paste handles empty, direct, collapsed, sanitized, and multiple pastes" do
       ui = ui_with_input([""])
       assert UIState.insert_paste(ui, "") == ui
+
+      assert ui_with_input([""]) |> UIState.insert_paste("hello") |> UIState.input_text() ==
+               "hello"
+
+      assert ui_with_input([""]) |> UIState.insert_paste("line1\nline2") |> UIState.input_text() ==
+               "line1\nline2"
+
+      assert ui_with_input([""])
+             |> UIState.insert_paste("hello" <> <<0>> <> "world")
+             |> UIState.input_text() ==
+               "helloworld"
+
+      collapsed = ui_with_input([""]) |> UIState.insert_paste("a\nb\nc")
+      assert length(collapsed.panel.pasted_blocks) == 1
+      assert hd(collapsed.panel.pasted_blocks).text == "a\nb\nc"
+      assert UIState.prompt_text(collapsed) == "a\nb\nc"
+
+      multi = collapsed |> UIState.insert_paste("d\ne\nf")
+      assert length(multi.panel.pasted_blocks) == 2
     end
 
-    test "inserts short paste directly" do
-      ui = ui_with_input([""])
-      ui = UIState.insert_paste(ui, "hello")
-      assert UIState.input_text(ui) == "hello"
+    test "toggle_paste_expand expands, collapses, and no-ops outside paste blocks" do
+      ui =
+        ui_with_input([""])
+        |> UIState.insert_paste("line1\nline2\nline3")
+        |> move_to_placeholder()
+
+      expanded = UIState.toggle_paste_expand(ui)
+      assert hd(expanded.panel.pasted_blocks).expanded
+      assert UIState.input_line_count(expanded) >= 3
+
+      collapsed = expanded |> move_cursor_to_placeholder_line() |> UIState.toggle_paste_expand()
+      refute hd(collapsed.panel.pasted_blocks).expanded
+
+      plain = ui_with_input(["hello"])
+
+      assert UIState.toggle_paste_expand(plain) |> UIState.input_lines() ==
+               UIState.input_lines(plain)
     end
 
-    test "inserts two-line paste directly" do
-      ui = ui_with_input([""])
-      ui = UIState.insert_paste(ui, "line1\nline2")
-      assert UIState.input_text(ui) == "line1\nline2"
-    end
+    test "placeholder helpers parse only paste placeholders" do
+      placeholder0 = <<0>> <> "PASTE:0"
+      placeholder5 = <<0>> <> "PASTE:5"
 
-    test "collapses paste with 3+ lines" do
-      ui = ui_with_input([""])
-      ui = UIState.insert_paste(ui, "a\nb\nc")
-      assert length(ui.panel.pasted_blocks) == 1
-      assert hd(ui.panel.pasted_blocks).text == "a\nb\nc"
-      # prompt_text expands placeholders
-      assert UIState.prompt_text(ui) == "a\nb\nc"
-    end
-
-    test "strips NUL bytes from paste" do
-      ui = ui_with_input([""])
-      ui = UIState.insert_paste(ui, "hello\0world")
-      assert UIState.input_text(ui) == "helloworld"
-    end
-
-    test "multiple collapsed pastes" do
-      ui = ui_with_input([""])
-      ui = UIState.insert_paste(ui, "a\nb\nc")
-      ui = UIState.insert_paste(ui, "d\ne\nf")
-      assert length(ui.panel.pasted_blocks) == 2
-    end
-  end
-
-  describe "toggle_paste_expand/1" do
-    test "expands a collapsed block" do
-      ui = ui_with_input([""])
-      ui = UIState.insert_paste(ui, "line1\nline2\nline3")
-      # Move cursor to the placeholder line
-      lines = UIState.input_lines(ui)
-
-      placeholder_idx =
-        Enum.find_index(lines, &UIState.paste_placeholder?/1)
-
-      ui = set_input_cursor(ui, {placeholder_idx, 0})
-      ui = UIState.toggle_paste_expand(ui)
-
-      block = hd(ui.panel.pasted_blocks)
-      assert block.expanded
-      assert UIState.input_line_count(ui) >= 3
-    end
-
-    test "collapses an expanded block" do
-      ui = ui_with_input([""])
-      ui = UIState.insert_paste(ui, "line1\nline2\nline3")
-      lines = UIState.input_lines(ui)
-
-      placeholder_idx =
-        Enum.find_index(lines, &UIState.paste_placeholder?/1)
-
-      ui = set_input_cursor(ui, {placeholder_idx, 0})
-      # Expand
-      ui = UIState.toggle_paste_expand(ui)
-      assert hd(ui.panel.pasted_blocks).expanded
-
-      # Set cursor within expanded text
-      ui = set_input_cursor(ui, {placeholder_idx, 0})
-      # Collapse
-      ui = UIState.toggle_paste_expand(ui)
-      refute hd(ui.panel.pasted_blocks).expanded
-    end
-
-    test "no-op when cursor not on paste" do
-      ui = ui_with_input(["hello"])
-      ui2 = UIState.toggle_paste_expand(ui)
-      assert UIState.input_lines(ui2) == UIState.input_lines(ui)
-    end
-  end
-
-  describe "paste_placeholder?/1" do
-    test "true for placeholder" do
-      assert UIState.paste_placeholder?("\0PASTE:0")
-    end
-
-    test "false for regular text" do
+      assert UIState.paste_placeholder?(placeholder0)
       refute UIState.paste_placeholder?("hello")
-    end
-  end
-
-  describe "paste_block_index/1" do
-    test "returns index for placeholder" do
-      assert UIState.paste_block_index("\0PASTE:0") == 0
-      assert UIState.paste_block_index("\0PASTE:5") == 5
-    end
-
-    test "returns nil for non-placeholder" do
+      assert UIState.paste_block_index(placeholder0) == 0
+      assert UIState.paste_block_index(placeholder5) == 5
       assert UIState.paste_block_index("hello") == nil
     end
   end
 
-  describe "scrolling" do
-    test "scroll_up unpins from bottom" do
-      ui = UIState.new()
-      ui = UIState.scroll_up(ui, 5)
+  describe "scrolling and display" do
+    test "scrolling updates offset and clear_display resets visible start and scroll" do
+      ui = UIState.new() |> UIState.scroll_up(5)
       refute ui.panel.scroll.pinned
-    end
 
-    test "scroll_down unpins from bottom" do
-      ui = UIState.new()
-      # First unpin by scrolling up, then scroll down
-      ui = put_in(ui.panel.scroll, %{ui.panel.scroll | offset: 10, pinned: false})
-      ui = UIState.scroll_down(ui, 3)
+      ui =
+        put_in(ui.panel.scroll, %{ui.panel.scroll | offset: 10, pinned: false})
+        |> UIState.scroll_down(3)
+
       assert ui.panel.scroll.offset == 13
+
+      cleared = ui |> UIState.scroll_up(10) |> UIState.clear_display(5)
+      assert cleared.panel.display_start_index == 5
+      assert cleared.panel.scroll.offset == 0
     end
   end
 
-  describe "clear_display/2" do
-    test "sets display_start_index and resets scroll" do
-      ui = UIState.new()
-      ui = UIState.scroll_up(ui, 10)
-      ui = UIState.clear_display(ui, 5)
-      assert ui.panel.display_start_index == 5
-      assert ui.panel.scroll.offset == 0
-    end
-  end
+  describe "prompt buffer lifecycle" do
+    test "ensure_prompt_buffer starts, reuses, and restarts the prompt buffer" do
+      ui = UIState.new() |> UIState.ensure_prompt_buffer()
+      first_pid = ui.panel.prompt_buffer
+      assert is_pid(first_pid)
 
-  describe "ensure_prompt_buffer/1" do
-    test "starts buffer when nil" do
-      ui = UIState.new()
-      ui = UIState.ensure_prompt_buffer(ui)
-      assert is_pid(ui.panel.prompt_buffer)
-      assert Process.alive?(ui.panel.prompt_buffer)
-    end
+      assert UIState.ensure_prompt_buffer(ui).panel.prompt_buffer == first_pid
 
-    test "idempotent when alive" do
-      ui = UIState.new()
-      ui = UIState.ensure_prompt_buffer(ui)
-      pid = ui.panel.prompt_buffer
-      ui = UIState.ensure_prompt_buffer(ui)
-      assert ui.panel.prompt_buffer == pid
-    end
+      ref = Process.monitor(first_pid)
+      GenServer.stop(first_pid)
+      assert_receive {:DOWN, ^ref, :process, ^first_pid, _reason}
 
-    test "restarts when dead" do
-      Process.flag(:trap_exit, true)
-      ui = UIState.new()
-      ui = UIState.ensure_prompt_buffer(ui)
-      old_pid = ui.panel.prompt_buffer
-      Process.exit(old_pid, :kill)
-
-      receive do
-        {:EXIT, ^old_pid, :killed} -> :ok
-      after
-        100 -> flunk("expected EXIT")
-      end
-
-      ui = UIState.ensure_prompt_buffer(ui)
-      assert is_pid(ui.panel.prompt_buffer)
-      assert ui.panel.prompt_buffer != old_pid
+      restarted = UIState.ensure_prompt_buffer(ui)
+      assert is_pid(restarted.panel.prompt_buffer)
+      refute restarted.panel.prompt_buffer == first_pid
     end
   end
 
@@ -520,11 +258,25 @@ defmodule MingaEditor.Agent.UIStateTest do
       panel = Panel.new()
       assert panel.message_version == 0
 
-      panel = Panel.bump_message_version(panel)
-      assert panel.message_version == 1
-
-      panel = Panel.bump_message_version(panel)
-      assert panel.message_version == 2
+      assert panel
+             |> Panel.bump_message_version()
+             |> Panel.bump_message_version()
+             |> then(& &1.message_version) == 2
     end
+  end
+
+  defp move_to_placeholder(ui) do
+    line = Enum.find_index(UIState.input_lines(ui), &UIState.paste_placeholder?/1)
+    BufferProcess.move_to(ui.panel.prompt_buffer, {line, 0})
+    ui
+  end
+
+  defp move_cursor_to_placeholder_line(ui) do
+    line =
+      UIState.input_lines(ui)
+      |> Enum.find_index(&(String.contains?(&1, "line1") or UIState.paste_placeholder?(&1)))
+
+    BufferProcess.move_to(ui.panel.prompt_buffer, {line || 0, 0})
+    ui
   end
 end

--- a/test/minga_editor/commands/help_test.exs
+++ b/test/minga_editor/commands/help_test.exs
@@ -6,18 +6,17 @@ defmodule MingaEditor.Commands.HelpTest do
   alias Minga.Config.Options
   alias Minga.Keymap.Active, as: ActiveKeymap
   alias MingaEditor.Commands.Help
+  alias MingaEditor.KeystrokeHistory
+  alias MingaEditor.KeystrokeHistory.Entry
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
   alias MingaEditor.UI.Picker.CommandHelpSource
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Picker.OptionSource
-  alias MingaEditor.State.Buffers
   alias MingaEditor.Viewport
 
-  # ── Test helpers ──────────────────────────────────────────────────────────────
-
   defp build_state do
-    # Start a minimal buffer so add_buffer works
     {:ok, buf} =
       DynamicSupervisor.start_child(
         Minga.Buffer.Supervisor,
@@ -25,7 +24,7 @@ defmodule MingaEditor.Commands.HelpTest do
       )
 
     {:ok, keymap} = ActiveKeymap.start_link(name: nil)
-    {:ok, options} = Minga.Config.Options.start_link(name: nil)
+    {:ok, options} = Options.start_link(name: nil)
 
     %EditorState{
       port_manager: nil,
@@ -38,90 +37,46 @@ defmodule MingaEditor.Commands.HelpTest do
     }
   end
 
-  # ── Tests ─────────────────────────────────────────────────────────────────────
-
-  describe "describe_key_result" do
-    test "creates *Help* buffer with key description" do
-      state = build_state()
+  describe "describe-key help" do
+    test "describe_key_result opens or reuses read-only *Help* and clears status" do
+      state = MingaEditor.State.set_status(build_state(), "Press key to describe:")
 
       assert {:ok, false} =
                Options.set_for_filetype(state.options_server, :text, :autopair_block, false)
 
       result = Help.execute(state, {:describe_key_result, "j", :move_down, "Move cursor down"})
+      help = result.workspace.buffers.help
 
-      assert result.workspace.buffers.help != nil
-      assert Process.alive?(result.workspace.buffers.help)
-      assert BufferProcess.get_option(result.workspace.buffers.help, :autopair_block) == false
+      assert is_pid(help)
+      assert result.workspace.buffers.active == help
+      assert result.shell_state.status_msg == nil
+      assert BufferProcess.read_only?(help)
+      assert BufferProcess.get_option(help, :autopair_block) == false
 
-      content = BufferProcess.content(result.workspace.buffers.help)
+      content = BufferProcess.content(help)
       assert content =~ "Key:         j"
       assert content =~ "Command:     move_down"
       assert content =~ "Description: Move cursor down"
+
+      version = BufferProcess.version(help)
+      reused = Help.execute(result, {:describe_key_result, "k", :move_up, "Move cursor up"})
+
+      assert reused.workspace.buffers.help == help
+      assert BufferProcess.version(help) > version
+      assert BufferProcess.content(help) =~ "Command:     move_up"
+      refute BufferProcess.content(help) =~ "Command:     move_down"
     end
 
-    test "switches to *Help* buffer after describing" do
-      state = build_state()
-      result = Help.execute(state, {:describe_key_result, "SPC f f", :find_file, "Find file"})
-
-      assert result.workspace.buffers.active == result.workspace.buffers.help
-    end
-
-    test "reuses existing *Help* buffer on subsequent calls" do
-      state = build_state()
-      result1 = Help.execute(state, {:describe_key_result, "j", :move_down, "Move cursor down"})
-      help_pid = result1.workspace.buffers.help
-      version = BufferProcess.version(help_pid)
-
-      result2 =
-        Help.execute(result1, {:describe_key_result, "k", :move_up, "Move cursor up"})
-
-      assert result2.workspace.buffers.help == help_pid
-      assert BufferProcess.version(help_pid) > version
-
-      content = BufferProcess.content(help_pid)
-      assert content =~ "Command:     move_up"
-      refute content =~ "Command:     move_down"
-    end
-
-    test "clears status message" do
-      state = MingaEditor.State.set_status(build_state(), "Press key to describe:")
-      result = Help.execute(state, {:describe_key_result, "j", :move_down, "Move cursor down"})
-
-      assert result.shell_state.status_msg == nil
+    test "describe_key_not_found shows the unbound key" do
+      result = Help.execute(build_state(), {:describe_key_not_found, "z"})
+      assert BufferProcess.content(result.workspace.buffers.help) =~ "Key not bound: z"
     end
   end
 
-  describe "describe_key_not_found" do
-    test "shows 'Key not bound' in *Help* buffer" do
-      state = build_state()
-      result = Help.execute(state, {:describe_key_not_found, "z"})
-
-      content = BufferProcess.content(result.workspace.buffers.help)
-      assert content =~ "Key not bound: z"
-    end
-  end
-
-  describe "describe_bindings" do
-    test "formats leader, normal, text object, and filetype bindings" do
+  describe "bindings help" do
+    test "bindings content includes built-in, text-object, filetype, and user bindings" do
       state = build_state()
       BufferProcess.set_filetype(state.workspace.buffers.active, :elixir)
-
-      content = Help.bindings_content(state)
-
-      assert content =~ "+file"
-      assert content =~ "SPC f s"
-      assert content =~ "save"
-      assert content =~ "Movement"
-      assert content =~ "w"
-      assert content =~ "word_forward"
-      assert content =~ "Text objects"
-      assert content =~ "iw"
-      assert content =~ "+filetype :elixir"
-      assert content =~ "SPC m t t"
-    end
-
-    test "marks user-defined bindings" do
-      state = build_state()
 
       ActiveKeymap.bind(
         state.keymap_server,
@@ -133,14 +88,27 @@ defmodule MingaEditor.Commands.HelpTest do
 
       content = Help.bindings_content(state)
 
-      assert content =~ "SPC x y"
-      assert content =~ "custom_command"
-      assert content =~ "*user*"
+      for expected <- [
+            "+file",
+            "SPC f s",
+            "save",
+            "Movement",
+            "w",
+            "word_forward",
+            "Text objects",
+            "iw",
+            "+filetype :elixir",
+            "SPC m t t",
+            "SPC x y",
+            "custom_command",
+            "*user*"
+          ] do
+        assert content =~ expected
+      end
     end
 
-    test "opens a read-only *Bindings* buffer" do
-      state = build_state()
-      result = Help.execute(state, :describe_bindings)
+    test "describe_bindings opens a read-only *Bindings* buffer" do
+      result = Help.execute(build_state(), :describe_bindings)
       buffer = result.workspace.buffers.active
 
       assert BufferProcess.buffer_name(buffer) == "*Bindings*"
@@ -149,433 +117,265 @@ defmodule MingaEditor.Commands.HelpTest do
     end
   end
 
-  describe "describe_option" do
-    test "shows option metadata in *Help*" do
+  describe "option help" do
+    test "describes default, configured, filetype, buffer-local, and extension options" do
       state = build_state()
-      result = Help.describe_option(state, :tab_width)
 
-      content = BufferProcess.content(result.workspace.buffers.help)
-      assert content =~ "# Option: tab_width"
-      assert content =~ "Current value: 2"
-      assert content =~ "Default: 2"
-      assert content =~ "Type: positive integer"
-      assert content =~ "Set by: default"
-      assert content =~ "Description:"
-    end
+      default = Help.describe_option(state, :tab_width) |> help_content()
+      assert default =~ "# Option: tab_width"
+      assert default =~ "Current value: 2"
+      assert default =~ "Default: 2"
+      assert default =~ "Type: positive integer"
+      assert default =~ "Set by: default"
+      assert default =~ "Description:"
 
-    test "uses the editor options server for non-buffer-local option values" do
-      state = build_state()
-      Minga.Config.Options.set(state.options_server, :agent_model, "test-model")
+      Options.set(state.options_server, :agent_model, "test-model")
+      configured = Help.describe_option(state, :agent_model) |> help_content()
+      assert configured =~ "Current value: \"test-model\""
+      assert configured =~ "Set by: default → config.exs"
 
-      result = Help.describe_option(state, :agent_model)
-      content = BufferProcess.content(result.workspace.buffers.help)
+      filetype_state = build_state()
+      BufferProcess.set_filetype(filetype_state.workspace.buffers.active, :go)
+      Options.set_for_filetype(filetype_state.options_server, :go, :agent_model, "go-model")
+      filetype = Help.describe_option(filetype_state, :agent_model) |> help_content()
+      assert filetype =~ "Current value: \"go-model\""
+      assert filetype =~ "Set by: default → filetype :go"
 
-      assert content =~ "Current value: \"test-model\""
-      assert content =~ "Set by: default → config.exs"
-    end
-
-    test "uses filetype-scoped values from the editor options server" do
-      state = build_state()
-      BufferProcess.set_filetype(state.workspace.buffers.active, :go)
-      Minga.Config.Options.set_for_filetype(state.options_server, :go, :agent_model, "go-model")
-
-      result = Help.describe_option(state, :agent_model)
-      content = BufferProcess.content(result.workspace.buffers.help)
-
-      assert content =~ "Current value: \"go-model\""
-      assert content =~ "Set by: default → filetype :go"
-    end
-
-    test "includes buffer-local provenance in option help" do
-      state = build_state()
       BufferProcess.set_option(state.workspace.buffers.active, :tab_width, 6)
+      local = Help.describe_option(state, :tab_width) |> help_content()
+      assert local =~ "Current value: 6"
+      assert local =~ "Set by: default → buffer-local"
 
-      result = Help.describe_option(state, :tab_width)
-      content = BufferProcess.content(result.workspace.buffers.help)
-
-      assert content =~ "Current value: 6"
-      assert content =~ "Set by: default → buffer-local"
-    end
-
-    test "option picker uses the editor options server for non-buffer-local values" do
-      state = build_state()
-      Minga.Config.Options.set(state.options_server, :agent_model, "test-model")
-      context = Context.from_editor_state(state)
-
-      item = Enum.find(OptionSource.candidates(context), &(&1.id == :agent_model))
-
-      assert item.description =~ "\"test-model\""
-      assert item.annotation == "modified"
-    end
-
-    test "option picker falls back to the editor options server if the active buffer died" do
-      state = build_state()
-      Minga.Config.Options.set(state.options_server, :agent_model, "test-model")
-      buffer = state.workspace.buffers.active
-      monitor = Process.monitor(buffer)
-
-      GenServer.stop(buffer)
-      assert_receive {:DOWN, ^monitor, :process, ^buffer, _reason}
-
-      context = Context.from_editor_state(state)
-      item = Enum.find(OptionSource.candidates(context), &(&1.id == :agent_model))
-
-      assert item.description =~ "\"test-model\""
-    end
-
-    test "shows extension option metadata" do
-      state = build_state()
-
-      Minga.Config.Options.register_extension_schema(
+      Options.register_extension_schema(
         state.options_server,
         :minga_org,
         [{:conceal, :boolean, true, "Hide markup syntax."}],
         conceal: false
       )
 
-      result = Help.describe_extension_option(state, :minga_org, :conceal)
-      content = BufferProcess.content(result.workspace.buffers.help)
+      extension = Help.describe_extension_option(state, :minga_org, :conceal) |> help_content()
+      assert extension =~ "# Option: minga_org.conceal"
+      assert extension =~ "Current value: false"
+      assert extension =~ "Set by: default → config.exs"
+      assert extension =~ "Hide markup syntax."
+    end
 
-      assert content =~ "# Option: minga_org.conceal"
-      assert content =~ "Current value: false"
-      assert content =~ "Set by: default → config.exs"
-      assert content =~ "Hide markup syntax."
+    test "option picker uses editor options even when the active buffer is dead" do
+      state = build_state()
+      Options.set(state.options_server, :agent_model, "test-model")
+
+      item = option_item(state, :agent_model)
+      assert item.description =~ "\"test-model\""
+      assert item.annotation == "modified"
+
+      buffer = state.workspace.buffers.active
+      monitor = Process.monitor(buffer)
+      GenServer.stop(buffer)
+      assert_receive {:DOWN, ^monitor, :process, ^buffer, _reason}
+
+      assert option_item(state, :agent_model).description =~ "\"test-model\""
     end
   end
 
-  describe "build_reverse_keybind_map" do
-    test "includes leader bindings with SPC prefix" do
+  describe "command help" do
+    test "reverse keybinding map includes leader, normal, filetype, missing, and multi-bound commands" do
       map = Help.build_reverse_keybind_map()
+
       assert "SPC f s" in Map.get(map, :save, [])
-    end
-
-    test "includes normal mode bindings" do
-      map = Help.build_reverse_keybind_map()
       assert "j" in Map.get(map, :move_down, [])
-    end
-
-    test "includes filetype bindings with SPC m prefix" do
-      map = Help.build_reverse_keybind_map()
       assert "SPC m a" in Map.get(map, :alternate_file, [])
-    end
-
-    test "commands with no binding return empty list" do
-      map = Help.build_reverse_keybind_map()
       assert Map.get(map, :nonexistent_command_xyz, []) == []
+      assert "SPC s p" in Map.get(map, :search_project, [])
+      assert "SPC /" in Map.get(map, :search_project, [])
     end
 
-    test "commands with multiple bindings collect all of them" do
-      map = Help.build_reverse_keybind_map()
-      bindings = Map.get(map, :search_project, [])
-      assert "SPC s p" in bindings
-      assert "SPC /" in bindings
+    test "format_describe_command handles keybindings, no binding, multiple bindings, and scopes" do
+      cases = [
+        {%Minga.Command{
+           name: :save,
+           description: "Save the current file",
+           execute: fn state -> state end
+         }, %{save: ["SPC f s"]},
+         [
+           "# Command: save",
+           "Description: Save the current file",
+           "Keybinding:  SPC f s",
+           "Scope:       any"
+         ]},
+        {%Minga.Command{
+           name: :some_command,
+           description: "A command",
+           execute: fn state -> state end
+         }, %{}, ["Keybinding:  none"]},
+        {%Minga.Command{
+           name: :search_project,
+           description: "Search project",
+           execute: fn state -> state end
+         }, %{search_project: ["SPC s p", "SPC /"]}, ["Keybinding:  SPC s p", "SPC /"]},
+        {%Minga.Command{
+           name: :agent_abort,
+           description: "Stop agent",
+           execute: fn state -> state end,
+           scope: :agent
+         }, %{}, ["Scope:       :agent"]}
+      ]
+
+      for {command, keybind_map, expected_fragments} <- cases do
+        content = Help.format_describe_command(command, keybind_map)
+        for fragment <- expected_fragments, do: assert(content =~ fragment)
+      end
+    end
+
+    test "describe_command handles registered, unknown, colon-prefixed, and picker-selected commands" do
+      state = build_state()
+
+      described =
+        Help.execute(state, {:describe_command_named, "describe_bindings"}) |> help_content()
+
+      assert described =~ "# Command: describe_bindings"
+      assert described =~ "Description: Describe bindings"
+      assert described =~ "Keybinding:  SPC h b"
+
+      colon =
+        Help.execute(state, {:describe_command_named, ":describe_bindings"}) |> help_content()
+
+      assert colon =~ "# Command: describe_bindings"
+
+      unknown =
+        Help.execute(state, {:describe_command_named, "not_a_real_command_xyz"}) |> help_content()
+
+      assert unknown =~ "Unknown command: not_a_real_command_xyz"
+
+      atom_not_command = Help.execute(state, {:describe_command_named, "true"}) |> help_content()
+      assert atom_not_command =~ "Unknown command: true"
+
+      normalized_unknown =
+        Help.execute(state, {:describe_command_named, ":not_a_real_command"}) |> help_content()
+
+      assert normalized_unknown =~ "Unknown command: not_a_real_command"
+      refute normalized_unknown =~ "Unknown command: :not_a_real_command"
+
+      selected =
+        CommandHelpSource.on_select(%Item{id: :describe_bindings, label: ""}, state)
+        |> help_content()
+
+      assert selected =~ "# Command: describe_bindings"
+      assert selected =~ "Keybinding:  SPC h b"
     end
   end
 
-  describe "format_describe_command" do
-    test "formats command with keybinding" do
-      cmd = %Minga.Command{
-        name: :save,
-        description: "Save the current file",
-        execute: fn s -> s end
-      }
-
-      keybind_map = %{save: ["SPC f s"]}
-      content = Help.format_describe_command(cmd, keybind_map)
-
-      assert content =~ "# Command: save"
-      assert content =~ "Command:     save"
-      assert content =~ "Description: Save the current file"
-      assert content =~ "Keybinding:  SPC f s"
-      assert content =~ "Scope:       any"
-    end
-
-    test "formats command with no keybinding" do
-      cmd = %Minga.Command{
-        name: :some_command,
-        description: "A command",
-        execute: fn s -> s end
-      }
-
-      content = Help.format_describe_command(cmd, %{})
-      assert content =~ "Keybinding:  none"
-    end
-
-    test "formats command with multiple keybindings" do
-      cmd = %Minga.Command{
-        name: :search_project,
-        description: "Search project",
-        execute: fn s -> s end
-      }
-
-      keybind_map = %{search_project: ["SPC s p", "SPC /"]}
-      content = Help.format_describe_command(cmd, keybind_map)
-
-      assert content =~ "Keybinding:  SPC s p"
-      assert content =~ "SPC /"
-    end
-
-    test "formats scoped command" do
-      cmd = %Minga.Command{
-        name: :agent_abort,
-        description: "Stop agent",
-        execute: fn s -> s end,
-        scope: :agent
-      }
-
-      content = Help.format_describe_command(cmd, %{})
-      assert content =~ "Scope:       :agent"
-    end
-  end
-
-  describe "describe_command" do
-    test "opens *Help* buffer with command description" do
+  describe "help buffer properties" do
+    test "help buffer filetype is explicit and resettable" do
       state = build_state()
-      result = Help.execute(state, {:describe_command_named, "describe_bindings"})
+      markdown = Help.show_in_help_buffer(state, "# Help\n", filetype: :markdown)
+      assert BufferProcess.filetype(markdown.workspace.buffers.help) == :markdown
+      assert BufferProcess.read_only?(markdown.workspace.buffers.help)
 
-      content = BufferProcess.content(result.workspace.buffers.help)
-      assert content =~ "# Command: describe_bindings"
-      assert content =~ "Description: Describe bindings"
-      assert content =~ "Keybinding:  SPC h b"
-    end
+      reset_by_command =
+        Help.execute(markdown, {:describe_key_result, "j", :move_down, "Move cursor down"})
 
-    test "shows unknown command message for invalid name" do
-      state = build_state()
-      result = Help.execute(state, {:describe_command_named, "not_a_real_command_xyz"})
+      assert BufferProcess.filetype(reset_by_command.workspace.buffers.help) == :text
 
-      content = BufferProcess.content(result.workspace.buffers.help)
-      assert content =~ "Unknown command: not_a_real_command_xyz"
-    end
-
-    test "shows unknown command for valid atom that is not a registered command" do
-      state = build_state()
-      result = Help.execute(state, {:describe_command_named, "true"})
-
-      content = BufferProcess.content(result.workspace.buffers.help)
-      assert content =~ "Unknown command: true"
-    end
-
-    test "strips leading colon from command name" do
-      state = build_state()
-      result = Help.execute(state, {:describe_command_named, ":describe_bindings"})
-
-      content = BufferProcess.content(result.workspace.buffers.help)
-      assert content =~ "# Command: describe_bindings"
-    end
-
-    test "error message uses normalized name without colon" do
-      state = build_state()
-      result = Help.execute(state, {:describe_command_named, ":not_a_real_command"})
-
-      content = BufferProcess.content(result.workspace.buffers.help)
-      assert content =~ "Unknown command: not_a_real_command"
-      refute content =~ "Unknown command: :not_a_real_command"
-    end
-
-    test "CommandHelpSource.on_select opens help buffer for command" do
-      state = build_state()
-      result = CommandHelpSource.on_select(%Item{id: :describe_bindings, label: ""}, state)
-
-      content = BufferProcess.content(result.workspace.buffers.help)
-      assert content =~ "# Command: describe_bindings"
-      assert content =~ "Keybinding:  SPC h b"
-    end
-  end
-
-  describe "*Help* buffer properties" do
-    test "help buffer is read-only" do
-      state = build_state()
-      result = Help.execute(state, {:describe_key_result, "j", :move_down, "Move cursor down"})
-
-      assert BufferProcess.read_only?(result.workspace.buffers.help)
-    end
-
-    test "help buffer can be shown as markdown" do
-      state = build_state()
-      result = Help.show_in_help_buffer(state, "# Help\n", filetype: :markdown)
-
-      assert BufferProcess.filetype(result.workspace.buffers.help) == :markdown
-    end
-
-    test "help commands without an explicit filetype reset the help buffer to text" do
-      state = build_state()
-      result = Help.show_in_help_buffer(state, "# Help\n", filetype: :markdown)
-
-      result = Help.execute(result, {:describe_key_result, "j", :move_down, "Move cursor down"})
-
-      assert BufferProcess.filetype(result.workspace.buffers.help) == :text
-    end
-
-    test "nil help buffer filetype resets to text" do
-      state = build_state()
-      result = Help.show_in_help_buffer(state, "# Help\n", filetype: :markdown)
-
-      result = Help.show_in_help_buffer(result, "Plain help\n", filetype: nil)
-
-      assert BufferProcess.filetype(result.workspace.buffers.help) == :text
+      reset_by_nil = Help.show_in_help_buffer(markdown, "Plain help\n", filetype: nil)
+      assert BufferProcess.filetype(reset_by_nil.workspace.buffers.help) == :text
     end
   end
 
   describe "describe_lossage" do
-    alias MingaEditor.KeystrokeHistory
-    alias MingaEditor.KeystrokeHistory.Entry
+    test "opens a read-only *Keystrokes* buffer and reports empty history" do
+      result = Help.execute(build_state(), :describe_lossage)
+      buffer = result.workspace.buffers.active
+      content = BufferProcess.content(buffer)
 
-    defp make_lossage_entry(opts) do
-      %Entry{
-        key: Keyword.get(opts, :key, {?j, 0}),
-        mode_before: Keyword.get(opts, :mode_before, :normal),
-        mode_after: Keyword.get(opts, :mode_after, :normal),
-        timestamp: Keyword.get(opts, :timestamp, 1_715_500_800_000)
-      }
-    end
-
-    test "creates *Keystrokes* buffer with empty history message" do
-      state = build_state()
-      result = Help.execute(state, :describe_lossage)
-
-      buf = result.workspace.buffers.active
-      assert Process.alive?(buf)
-      assert BufferProcess.buffer_name(buf) == "*Keystrokes*"
-
-      content = BufferProcess.content(buf)
+      assert BufferProcess.buffer_name(buffer) == "*Keystrokes*"
+      assert BufferProcess.read_only?(buffer)
       assert content =~ "Keystroke History"
       assert content =~ "No keystrokes recorded yet."
     end
 
-    test "*Keystrokes* buffer is read-only" do
-      state = build_state()
-      result = Help.execute(state, :describe_lossage)
+    test "formats keystrokes, mode changes, operator groups, and insert runs" do
+      cases = [
+        {[
+           lossage(key: {?j, 0}, timestamp: 1_715_500_800_000),
+           lossage(key: {?k, 0}, timestamp: 1_715_500_801_000)
+         ], ["Keystroke History (last 2 keys)", "j", "k"], []},
+        {[
+           lossage(key: {?j, 0}, timestamp: 1_715_500_800_000),
+           lossage(
+             key: {?h, 0},
+             mode_before: :insert,
+             mode_after: :insert,
+             timestamp: 1_715_500_802_000
+           )
+         ], ["── mode: insert ──"], []},
+        {[lossage(key: {?i, 0}, mode_before: :normal, mode_after: :insert)], ["→ insert"], []},
+        {[
+           lossage(
+             key: {?d, 0},
+             mode_before: :normal,
+             mode_after: :operator_pending,
+             timestamp: 1_715_500_800_000
+           ),
+           lossage(
+             key: {?w, 0},
+             mode_before: :operator_pending,
+             mode_after: :normal,
+             timestamp: 1_715_500_800_100
+           )
+         ], ["d w"], []},
+        {Enum.map(
+           ?a..?c,
+           &lossage(
+             key: {&1, 0},
+             mode_before: :insert,
+             mode_after: :insert,
+             timestamp: 1_715_500_800_000 + &1
+           )
+         ), [], ["chars"]},
+        {Enum.map(
+           ?a..?h,
+           &lossage(
+             key: {&1, 0},
+             mode_before: :insert,
+             mode_after: :insert,
+             timestamp: 1_715_500_800_000 + &1
+           )
+         ), ["(8 chars)"], []}
+      ]
 
-      buf = result.workspace.buffers.active
-      assert BufferProcess.read_only?(buf)
+      for {entries, expected, rejected} <- cases do
+        content =
+          entries
+          |> history_state()
+          |> Help.execute(:describe_lossage)
+          |> then(&BufferProcess.content(&1.workspace.buffers.active))
+
+        for fragment <- expected, do: assert(content =~ fragment)
+        for fragment <- rejected, do: refute(content =~ fragment)
+      end
     end
+  end
 
-    test "shows formatted keystrokes when history has entries" do
-      state = build_state()
+  defp help_content(state), do: BufferProcess.content(state.workspace.buffers.help)
 
-      history =
-        KeystrokeHistory.new()
-        |> KeystrokeHistory.record(make_lossage_entry(key: {?j, 0}, timestamp: 1_715_500_800_000))
-        |> KeystrokeHistory.record(make_lossage_entry(key: {?k, 0}, timestamp: 1_715_500_801_000))
+  defp option_item(state, option_name) do
+    state
+    |> Context.from_editor_state()
+    |> OptionSource.candidates()
+    |> Enum.find(&(&1.id == option_name))
+  end
 
-      state = %{state | keystroke_history: history}
-      result = Help.execute(state, :describe_lossage)
+  defp lossage(opts) do
+    %Entry{
+      key: Keyword.get(opts, :key, {?j, 0}),
+      mode_before: Keyword.get(opts, :mode_before, :normal),
+      mode_after: Keyword.get(opts, :mode_after, :normal),
+      timestamp: Keyword.get(opts, :timestamp, 1_715_500_800_000)
+    }
+  end
 
-      content = BufferProcess.content(result.workspace.buffers.active)
-      assert content =~ "Keystroke History (last 2 keys)"
-      assert content =~ "j"
-      assert content =~ "k"
-    end
-
-    test "annotates mode transitions between groups" do
-      state = build_state()
-
-      history =
-        KeystrokeHistory.new()
-        |> KeystrokeHistory.record(make_lossage_entry(key: {?j, 0}, timestamp: 1_715_500_800_000))
-        |> KeystrokeHistory.record(
-          make_lossage_entry(
-            key: {?h, 0},
-            mode_before: :insert,
-            mode_after: :insert,
-            timestamp: 1_715_500_802_000
-          )
-        )
-
-      state = %{state | keystroke_history: history}
-      result = Help.execute(state, :describe_lossage)
-
-      content = BufferProcess.content(result.workspace.buffers.active)
-      assert content =~ "── mode: insert ──"
-    end
-
-    test "shows mode change arrow on single entry" do
-      state = build_state()
-
-      history =
-        KeystrokeHistory.new()
-        |> KeystrokeHistory.record(
-          make_lossage_entry(key: {?i, 0}, mode_before: :normal, mode_after: :insert)
-        )
-
-      state = %{state | keystroke_history: history}
-      result = Help.execute(state, :describe_lossage)
-
-      content = BufferProcess.content(result.workspace.buffers.active)
-      assert content =~ "→ insert"
-    end
-
-    test "groups operator-pending sequences" do
-      state = build_state()
-
-      history =
-        KeystrokeHistory.new()
-        |> KeystrokeHistory.record(
-          make_lossage_entry(
-            key: {?d, 0},
-            mode_before: :normal,
-            mode_after: :operator_pending,
-            timestamp: 1_715_500_800_000
-          )
-        )
-        |> KeystrokeHistory.record(
-          make_lossage_entry(
-            key: {?w, 0},
-            mode_before: :operator_pending,
-            mode_after: :normal,
-            timestamp: 1_715_500_800_100
-          )
-        )
-
-      state = %{state | keystroke_history: history}
-      result = Help.execute(state, :describe_lossage)
-
-      content = BufferProcess.content(result.workspace.buffers.active)
-      assert content =~ "d w"
-    end
-
-    test "3 insert chars are shown individually, not collapsed" do
-      state = build_state()
-
-      entries =
-        Enum.map(?a..?c, fn cp ->
-          make_lossage_entry(
-            key: {cp, 0},
-            mode_before: :insert,
-            mode_after: :insert,
-            timestamp: 1_715_500_800_000 + cp
-          )
-        end)
-
-      history = Enum.reduce(entries, KeystrokeHistory.new(), &KeystrokeHistory.record(&2, &1))
-
-      state = %{state | keystroke_history: history}
-      result = Help.execute(state, :describe_lossage)
-
-      content = BufferProcess.content(result.workspace.buffers.active)
-      refute content =~ "chars"
-    end
-
-    test "4+ insert chars are collapsed into compact display" do
-      state = build_state()
-
-      entries =
-        Enum.map(?a..?h, fn cp ->
-          make_lossage_entry(
-            key: {cp, 0},
-            mode_before: :insert,
-            mode_after: :insert,
-            timestamp: 1_715_500_800_000 + cp
-          )
-        end)
-
-      history = Enum.reduce(entries, KeystrokeHistory.new(), &KeystrokeHistory.record(&2, &1))
-
-      state = %{state | keystroke_history: history}
-      result = Help.execute(state, :describe_lossage)
-
-      content = BufferProcess.content(result.workspace.buffers.active)
-      assert content =~ "(8 chars)"
-    end
+  defp history_state(entries) do
+    history = Enum.reduce(entries, KeystrokeHistory.new(), &KeystrokeHistory.record(&2, &1))
+    %{build_state() | keystroke_history: history}
   end
 end

--- a/test/minga_editor/handlers/highlight_handler_test.exs
+++ b/test/minga_editor/handlers/highlight_handler_test.exs
@@ -1,23 +1,18 @@
 defmodule MingaEditor.Handlers.HighlightHandlerTest do
   @moduledoc """
   Pure-function tests for `MingaEditor.Handlers.HighlightHandler`.
-
-  Uses `RenderPipeline.TestHelpers.base_state/1` to construct state
-  without starting a GenServer. Each test calls `handle/2` directly
-  and asserts on the returned `{state, effects}` tuple.
   """
 
   use ExUnit.Case, async: true
 
   alias MingaEditor.Handlers.HighlightHandler
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.UI.Highlight
   alias MingaEditor.Window
   alias MingaEditor.Workspace.State, as: WorkspaceState
-  alias MingaEditor.UI.Highlight
 
   import MingaEditor.RenderPipeline.TestHelpers
 
-  # Helper to register a buffer_id mapping in the highlight state.
   @spec with_buffer_id(EditorState.t(), pid(), non_neg_integer()) :: EditorState.t()
   defp with_buffer_id(state, pid, buffer_id) do
     hl = state.workspace.highlight
@@ -32,18 +27,16 @@ defmodule MingaEditor.Handlers.HighlightHandlerTest do
     %{state | workspace: %{state.workspace | highlight: updated_hl}}
   end
 
-  # Helper to put a highlight entry for a buffer.
   @spec with_highlight(EditorState.t(), pid()) :: EditorState.t()
   defp with_highlight(state, pid) do
     hl = state.workspace.highlight
     theme = state.theme
-    syntax = theme.syntax
 
     buf_hl = %Highlight{
       version: 0,
       spans: {},
       capture_names: {},
-      theme: syntax,
+      theme: theme.syntax,
       face_registry: MingaEditor.UI.Face.Registry.from_theme(theme)
     }
 
@@ -51,467 +44,308 @@ defmodule MingaEditor.Handlers.HighlightHandlerTest do
     %{state | workspace: %{state.workspace | highlight: updated_hl}}
   end
 
-  describe "setup_highlight" do
-    test "returns request_semantic_tokens effect" do
-      state = base_state()
-      {_state, effects} = HighlightHandler.handle(state, :setup_highlight)
-      assert {:request_semantic_tokens} in effects
-    end
-  end
+  describe "setup and parser lifecycle" do
+    test "setup, parser status, eviction, and catch-all messages return the expected effects" do
+      {_, setup_effects} = HighlightHandler.handle(base_state(), :setup_highlight)
+      assert {:request_semantic_tokens} in setup_effects
 
-  describe "highlight_names" do
-    test "unknown buffer_id returns log warning effect" do
-      state = base_state()
+      {crashed, effects} =
+        HighlightHandler.handle(base_state(), {:minga_highlight, :parser_crashed})
 
-      {new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:highlight_names, 999, ["keyword"]}})
-
-      assert new_state == state
-
-      assert Enum.any?(effects, fn
-               {:log, :editor, :warning, msg} -> String.contains?(msg, "999")
-               _ -> false
-             end)
-    end
-
-    test "active buffer delegates to HighlightEvents" do
-      state = base_state()
-      buf = state.workspace.buffers.active
-      state = with_buffer_id(state, buf, 1)
-      state = with_highlight(state, buf)
-
-      {_new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:highlight_names, 1, ["keyword"]}})
-
-      # Should succeed without errors; no render effect for names
+      assert crashed.parser_status == :restarting
       assert effects == []
-    end
 
-    test "non-active buffer stores names in highlights map" do
-      state = base_state()
-      # Create a secondary buffer
-      {:ok, other_buf} = Minga.Buffer.Process.start_link(content: "other")
-      state = with_buffer_id(state, other_buf, 2)
-      state = with_highlight(state, other_buf)
+      restart_base = base_state()
 
-      {new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:highlight_names, 2, ["string"]}})
+      restarted_state =
+        restart_base |> with_highlight(active_buffer(restart_base)) |> mark_parser_restarting()
 
-      assert effects == []
-      # Verify names were stored
-      other_hl = new_state.workspace.highlight.highlights[other_buf]
-      assert other_hl != nil
-    end
+      {restarted, effects} =
+        HighlightHandler.handle(restarted_state, {:minga_highlight, :parser_restarted})
 
-    test "works with :minga_input tag" do
-      state = base_state()
-      buf = state.workspace.buffers.active
-      state = with_buffer_id(state, buf, 1)
-      state = with_highlight(state, buf)
+      assert restarted.parser_status == :available
+      assert restarted.workspace.highlight.version == 0
 
-      {_state, _effects} =
-        HighlightHandler.handle(state, {:minga_input, {:highlight_names, 1, ["keyword"]}})
-    end
-  end
+      assert Enum.all?(restarted.workspace.highlight.highlights, fn {_pid, hl} ->
+               hl.version == 0
+             end)
 
-  describe "injection_ranges" do
-    test "unknown buffer_id returns log warning" do
-      state = base_state()
+      assert {:log_message, "Parser restarted, syntax highlighting recovered"} in effects
 
-      {new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:injection_ranges, 999, []}})
+      {unavailable, effects} =
+        HighlightHandler.handle(base_state(), {:minga_highlight, :parser_gave_up})
 
-      assert new_state == state
+      assert unavailable.parser_status == :unavailable
 
       assert Enum.any?(effects, fn
-               {:log, :editor, :warning, _} -> true
+               {:log_message, msg} -> String.contains?(msg, "syntax highlighting disabled")
                _ -> false
              end)
+
+      {_, headless_effects} = HighlightHandler.handle(base_state(), :evict_parser_trees)
+      refute {:evict_parser_trees_timer} in headless_effects
+
+      tui_state = %{base_state() | backend: :tui}
+      {_, tui_effects} = HighlightHandler.handle(tui_state, :evict_parser_trees)
+      assert {:evict_parser_trees_timer} in tui_effects
+
+      catch_all_state = base_state()
+
+      assert {^catch_all_state, []} =
+               HighlightHandler.handle(catch_all_state, {:minga_highlight, :unknown_event})
     end
 
-    test "valid buffer stores ranges" do
-      state = base_state()
-      buf = state.workspace.buffers.active
-      state = with_buffer_id(state, buf, 1)
-      ranges = [%{start: 0, end: 10, language: "elixir"}]
+    test "grammar and port log messages are translated to log effects" do
+      success_state = base_state()
 
-      {new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:injection_ranges, 1, ranges}})
+      assert {^success_state, [{:log, :editor, :info, "Grammar loaded: elixir"}]} =
+               HighlightHandler.handle(
+                 success_state,
+                 {:minga_highlight, {:grammar_loaded, true, "elixir"}}
+               )
 
-      assert effects == []
-      assert new_state.workspace.injection_ranges[buf] == ranges
-    end
-  end
+      failure_state = base_state()
 
-  describe "language_at_response" do
-    test "is a no-op" do
-      state = base_state()
+      assert {^failure_state, [{:log, :editor, :warning, "Grammar failed to load: unknown"}]} =
+               HighlightHandler.handle(
+                 failure_state,
+                 {:minga_highlight, {:grammar_loaded, false, "unknown"}}
+               )
 
-      {new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:language_at_response, 1, "elixir"}})
-
-      assert new_state == state
-      assert effects == []
-    end
-  end
-
-  describe "highlight_spans" do
-    test "unknown buffer_id returns log warning" do
-      state = base_state()
-
-      {new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:highlight_spans, 999, 1, []}})
-
-      assert new_state == state
-
-      assert Enum.any?(effects, fn
-               {:log, :editor, :warning, _} -> true
-               _ -> false
-             end)
-    end
-
-    test "active buffer returns render and prettify effects" do
-      state = base_state()
-      buf = state.workspace.buffers.active
-      state = with_buffer_id(state, buf, 1)
-      state = with_highlight(state, buf)
-
-      {_new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:highlight_spans, 1, 1, []}})
-
-      assert :render in effects
-
-      assert Enum.any?(effects, fn
-               {:prettify_symbols, _} -> true
-               _ -> false
-             end)
-    end
-
-    test "non-active buffer stores spans" do
-      state = base_state()
-      {:ok, other_buf} = Minga.Buffer.Process.start_link(content: "other")
-      state = with_buffer_id(state, other_buf, 2)
-      state = with_highlight(state, other_buf)
-
-      {_new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:highlight_spans, 2, 1, []}})
-
-      # Not visible in any window, so no render
-      assert effects == []
-    end
-  end
-
-  describe "conceal_spans" do
-    test "unknown buffer_id returns log warning" do
-      state = base_state()
-
-      {_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:conceal_spans, 999, 1, []}})
-
-      assert Enum.any?(effects, fn
-               {:log, :editor, :warning, _} -> true
-               _ -> false
-             end)
-    end
-
-    test "valid buffer returns conceal_spans effect" do
-      state = base_state()
-      buf = state.workspace.buffers.active
-      state = with_buffer_id(state, buf, 1)
-      spans = [%{start_byte: 0, end_byte: 5, replacement: ""}]
-
-      {_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:conceal_spans, 1, 1, spans}})
-
-      assert {:conceal_spans, ^buf, ^spans} =
-               Enum.find(effects, &match?({:conceal_spans, _, _}, &1))
-    end
-  end
-
-  describe "fold_ranges" do
-    test "unknown buffer_id returns log warning" do
-      state = base_state()
-
-      {_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:fold_ranges, 999, 1, []}})
-
-      assert Enum.any?(effects, fn
-               {:log, :editor, :warning, _} -> true
-               _ -> false
-             end)
-    end
-
-    test "active buffer sets fold ranges on the window" do
-      state = base_state()
-      buf = state.workspace.buffers.active
-      state = with_buffer_id(state, buf, 1)
-
-      ranges = [{0, 5}, {10, 15}]
-
-      {new_state, _effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:fold_ranges, 1, 1, ranges}})
-
-      win_id = new_state.workspace.windows.active
-      window = Map.get(new_state.workspace.windows.map, win_id)
-      assert length(window.fold_ranges) == 2
-    end
-
-    test "non-active buffer is a no-op" do
-      state = base_state()
-      {:ok, other_buf} = Minga.Buffer.Process.start_link(content: "other")
-      state = with_buffer_id(state, other_buf, 2)
-
-      {new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:fold_ranges, 2, 1, [{0, 5}]}})
-
-      assert new_state == state
-      assert effects == []
-    end
-  end
-
-  describe "textobject_positions" do
-    test "unknown buffer_id returns log warning" do
-      state = base_state()
-
-      {_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:textobject_positions, 999, 1, %{}}})
-
-      assert Enum.any?(effects, fn
-               {:log, :editor, :warning, _} -> true
-               _ -> false
-             end)
-    end
-
-    test "active buffer sets positions on the window" do
-      state = base_state()
-      buf = state.workspace.buffers.active
-      state = with_buffer_id(state, buf, 1)
-
-      positions = %{function: [{0, 5}]}
-
-      {new_state, effects} =
+      {_, parser_effects} =
         HighlightHandler.handle(
-          state,
-          {:minga_highlight, {:textobject_positions, 1, 1, positions}}
+          base_state(),
+          {:minga_highlight, {:log_message, :info, "test msg"}}
         )
 
-      assert effects == []
-      win_id = new_state.workspace.windows.active
-      window = Map.get(new_state.workspace.windows.map, win_id)
-      assert window.textobject_positions == positions
-    end
+      assert {:log_message, "[PARSER/info] test msg"} in parser_effects
 
-    test "non-active buffer is a no-op" do
-      state = base_state()
-      {:ok, other_buf} = Minga.Buffer.Process.start_link(content: "other")
-      state = with_buffer_id(state, other_buf, 2)
+      {_, input_effects} =
+        HighlightHandler.handle(base_state(), {:minga_input, {:log_message, :info, "test msg"}})
 
-      {new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:textobject_positions, 2, 1, %{}}})
-
-      assert new_state == state
-      assert effects == []
-    end
-  end
-
-  describe "document_symbols" do
-    test "unknown buffer_id returns log warning" do
-      state = base_state()
-
-      {_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:document_symbols, 999, 1, []}})
-
-      assert Enum.any?(effects, fn
-               {:log, :editor, :warning, msg} -> String.contains?(msg, "document_symbols")
-               _ -> false
-             end)
-    end
-
-    test "active buffer sets document symbols on the window" do
-      state = base_state()
-      buf = state.workspace.buffers.active
-      state = with_buffer_id(state, buf, 1)
-      symbols = [%Minga.Language.Symbol{kind: :function, name: "run", range: {0, 0, 3, 3}}]
-
-      {new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:document_symbols, 1, 1, symbols}})
-
-      assert effects == []
-      win_id = new_state.workspace.windows.active
-      window = Map.get(new_state.workspace.windows.map, win_id)
-      assert window.document_symbols == symbols
-    end
-
-    test "updates a visible matching window even when another buffer is active" do
-      state = base_state()
-      first_buf = state.workspace.buffers.active
-      {:ok, other_buf} = Minga.Buffer.Process.start_link(content: "other")
-      stale_symbols = [%Minga.Language.Symbol{kind: :function, name: "old", range: {0, 0, 0, 3}}]
-      fresh_symbols = [%Minga.Language.Symbol{kind: :function, name: "new", range: {0, 0, 0, 3}}]
-
-      state = with_buffer_id(state, first_buf, 1)
-      win_id = state.workspace.windows.active
-
-      state =
-        EditorState.update_workspace(state, fn ws ->
-          WorkspaceState.update_window(ws, win_id, fn window ->
-            Window.set_document_symbols(window, stale_symbols)
-          end)
-        end)
-
-      second_window = Window.new(2, other_buf, 24, 80)
-
-      workspace =
-        %{state.workspace | buffers: %{state.workspace.buffers | active: other_buf}}
-        |> then(fn ws ->
-          %{
-            ws
-            | windows: %{
-                ws.windows
-                | map: Map.put(ws.windows.map, 2, second_window),
-                  active: 2,
-                  next_id: 3
-              }
-          }
-        end)
-
-      state = %{state | workspace: workspace}
-
-      {new_state, effects} =
-        HighlightHandler.handle(
-          state,
-          {:minga_highlight, {:document_symbols, 1, 1, fresh_symbols}}
-        )
-
-      assert effects == []
-      assert Map.fetch!(new_state.workspace.windows.map, 1).document_symbols == fresh_symbols
-      assert Map.fetch!(new_state.workspace.windows.map, 2).document_symbols == []
-    end
-  end
-
-  describe "grammar_loaded" do
-    test "success returns info log effect" do
-      state = base_state()
-
-      {new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:grammar_loaded, true, "elixir"}})
-
-      assert new_state == state
-      assert {:log, :editor, :info, "Grammar loaded: elixir"} in effects
-    end
-
-    test "failure returns warning log effect" do
-      state = base_state()
-
-      {new_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:grammar_loaded, false, "unknown"}})
-
-      assert new_state == state
-      assert {:log, :editor, :warning, "Grammar failed to load: unknown"} in effects
-    end
-  end
-
-  describe "log_message" do
-    test "from parser port prefixes with PARSER" do
-      state = base_state()
-
-      {_state, effects} =
-        HighlightHandler.handle(state, {:minga_highlight, {:log_message, :info, "test msg"}})
-
-      assert {:log_message, "[PARSER/info] test msg"} in effects
-    end
-
-    test "from renderer port prefixes with frontend type" do
-      state = base_state()
-
-      {_state, effects} =
-        HighlightHandler.handle(state, {:minga_input, {:log_message, :info, "test msg"}})
-
-      assert Enum.any?(effects, fn
+      assert Enum.any?(input_effects, fn
                {:log_message, msg} -> String.contains?(msg, "test msg")
                _ -> false
              end)
     end
   end
 
-  describe "parser_crashed" do
-    test "sets parser_status to :restarting" do
+  describe "unknown buffer ids" do
+    test "highlight messages for missing buffer ids log warnings without changing state" do
       state = base_state()
-      {new_state, effects} = HighlightHandler.handle(state, {:minga_highlight, :parser_crashed})
-      assert new_state.parser_status == :restarting
-      assert effects == []
+
+      messages = [
+        {:minga_highlight, {:highlight_names, 999, ["keyword"]}},
+        {:minga_highlight, {:injection_ranges, 999, []}},
+        {:minga_highlight, {:highlight_spans, 999, 1, []}},
+        {:minga_highlight, {:conceal_spans, 999, 1, []}},
+        {:minga_highlight, {:fold_ranges, 999, 1, []}},
+        {:minga_highlight, {:textobject_positions, 999, 1, %{}}},
+        {:minga_highlight, {:document_symbols, 999, 1, []}}
+      ]
+
+      for message <- messages do
+        {new_state, effects} = HighlightHandler.handle(state, message)
+        assert new_state == state
+        assert warning_effect?(effects)
+      end
     end
   end
 
-  describe "parser_restarted" do
-    test "resets highlight versions and sets parser_status to :available" do
+  describe "highlight metadata" do
+    test "highlight names support active, non-active, and input-tagged buffers" do
       state = base_state()
-      buf = state.workspace.buffers.active
-      state = with_highlight(state, buf)
+      buf = active_buffer(state)
+      state = state |> with_buffer_id(buf, 1) |> with_highlight(buf)
 
-      # Set a non-zero version
-      hl = state.workspace.highlight
-      buf_hl = Map.get(hl.highlights, buf)
+      assert {_, []} =
+               HighlightHandler.handle(
+                 state,
+                 {:minga_highlight, {:highlight_names, 1, ["keyword"]}}
+               )
 
-      updated_hl = %{
-        hl
-        | version: 5,
-          highlights: Map.put(hl.highlights, buf, %{buf_hl | version: 3})
-      }
+      assert {_, []} =
+               HighlightHandler.handle(state, {:minga_input, {:highlight_names, 1, ["keyword"]}})
 
-      state = %{
-        state
-        | workspace: %{state.workspace | highlight: updated_hl},
-          parser_status: :restarting
-      }
+      {state, other_buf} = state_with_other_buffer(base_state(), 2)
+      state = with_highlight(state, other_buf)
 
-      {new_state, effects} = HighlightHandler.handle(state, {:minga_highlight, :parser_restarted})
-      assert new_state.parser_status == :available
-      assert new_state.workspace.highlight.version == 0
-      # All per-buffer highlights should have version 0
-      Enum.each(new_state.workspace.highlight.highlights, fn {_pid, bhl} ->
-        assert bhl.version == 0
+      {new_state, []} =
+        HighlightHandler.handle(state, {:minga_highlight, {:highlight_names, 2, ["string"]}})
+
+      assert new_state.workspace.highlight.highlights[other_buf] != nil
+    end
+
+    test "injection ranges and language responses update only the public highlight state" do
+      state = base_state()
+      buf = active_buffer(state)
+      state = with_buffer_id(state, buf, 1)
+      ranges = [%{start: 0, end: 10, language: "elixir"}]
+
+      {new_state, []} =
+        HighlightHandler.handle(state, {:minga_highlight, {:injection_ranges, 1, ranges}})
+
+      assert new_state.workspace.injection_ranges[buf] == ranges
+
+      assert {^new_state, []} =
+               HighlightHandler.handle(
+                 new_state,
+                 {:minga_highlight, {:language_at_response, 1, "elixir"}}
+               )
+    end
+
+    test "highlight and conceal spans produce visible-buffer effects and skip invisible buffers" do
+      state = base_state()
+      buf = active_buffer(state)
+      state = state |> with_buffer_id(buf, 1) |> with_highlight(buf)
+
+      {_, effects} =
+        HighlightHandler.handle(state, {:minga_highlight, {:highlight_spans, 1, 1, []}})
+
+      assert :render in effects
+      assert Enum.any?(effects, &match?({:prettify_symbols, _}, &1))
+
+      spans = [%{start_byte: 0, end_byte: 5, replacement: ""}]
+
+      {_, effects} =
+        HighlightHandler.handle(state, {:minga_highlight, {:conceal_spans, 1, 1, spans}})
+
+      assert {:conceal_spans, buf, spans} in effects
+
+      {state, other_buf} = state_with_other_buffer(base_state(), 2)
+      state = with_highlight(state, other_buf)
+
+      assert {_, []} =
+               HighlightHandler.handle(state, {:minga_highlight, {:highlight_spans, 2, 1, []}})
+    end
+  end
+
+  describe "window metadata" do
+    test "fold ranges and textobject positions update the active window and ignore invisible buffers" do
+      state = base_state()
+      buf = active_buffer(state)
+      state = with_buffer_id(state, buf, 1)
+
+      {new_state, _effects} =
+        HighlightHandler.handle(
+          state,
+          {:minga_highlight, {:fold_ranges, 1, 1, [{0, 5}, {10, 15}]}}
+        )
+
+      assert length(active_window(new_state).fold_ranges) == 2
+
+      positions = %{function: [{0, 5}]}
+
+      {new_state, []} =
+        HighlightHandler.handle(
+          new_state,
+          {:minga_highlight, {:textobject_positions, 1, 1, positions}}
+        )
+
+      assert active_window(new_state).textobject_positions == positions
+
+      {other_state, _other_buf} = state_with_other_buffer(base_state(), 2)
+
+      assert {^other_state, []} =
+               HighlightHandler.handle(
+                 other_state,
+                 {:minga_highlight, {:fold_ranges, 2, 1, [{0, 5}]}}
+               )
+
+      assert {^other_state, []} =
+               HighlightHandler.handle(
+                 other_state,
+                 {:minga_highlight, {:textobject_positions, 2, 1, %{}}}
+               )
+    end
+
+    test "document symbols update active and visible matching windows" do
+      state = base_state()
+      buf = active_buffer(state)
+      state = with_buffer_id(state, buf, 1)
+      symbols = [%Minga.Language.Symbol{kind: :function, name: "run", range: {0, 0, 3, 3}}]
+
+      {new_state, []} =
+        HighlightHandler.handle(state, {:minga_highlight, {:document_symbols, 1, 1, symbols}})
+
+      assert active_window(new_state).document_symbols == symbols
+
+      visible_state = state_with_visible_inactive_buffer_symbols(state)
+      fresh_symbols = [%Minga.Language.Symbol{kind: :function, name: "new", range: {0, 0, 0, 3}}]
+
+      {updated, []} =
+        HighlightHandler.handle(
+          visible_state,
+          {:minga_highlight, {:document_symbols, 1, 1, fresh_symbols}}
+        )
+
+      assert Map.fetch!(updated.workspace.windows.map, 1).document_symbols == fresh_symbols
+      assert Map.fetch!(updated.workspace.windows.map, 2).document_symbols == []
+    end
+  end
+
+  defp active_buffer(state), do: state.workspace.buffers.active
+
+  defp active_window(state),
+    do: Map.fetch!(state.workspace.windows.map, state.workspace.windows.active)
+
+  defp state_with_other_buffer(state, buffer_id) do
+    {:ok, other_buf} = Minga.Buffer.Process.start_link(content: "other")
+    {with_buffer_id(state, other_buf, buffer_id), other_buf}
+  end
+
+  defp warning_effect?(effects) do
+    Enum.any?(effects, fn
+      {:log, :editor, :warning, _message} -> true
+      _ -> false
+    end)
+  end
+
+  defp mark_parser_restarting(state) do
+    buf = active_buffer(state)
+    hl = state.workspace.highlight
+    buf_hl = Map.fetch!(hl.highlights, buf)
+
+    updated_hl = %{
+      hl
+      | version: 5,
+        highlights: Map.put(hl.highlights, buf, %{buf_hl | version: 3})
+    }
+
+    %{state | workspace: %{state.workspace | highlight: updated_hl}, parser_status: :restarting}
+  end
+
+  defp state_with_visible_inactive_buffer_symbols(state) do
+    first_buf = active_buffer(state)
+    {:ok, other_buf} = Minga.Buffer.Process.start_link(content: "other")
+    stale_symbols = [%Minga.Language.Symbol{kind: :function, name: "old", range: {0, 0, 0, 3}}]
+
+    state = with_buffer_id(state, first_buf, 1)
+    win_id = state.workspace.windows.active
+
+    state =
+      EditorState.update_workspace(state, fn ws ->
+        WorkspaceState.update_window(ws, win_id, fn window ->
+          Window.set_document_symbols(window, stale_symbols)
+        end)
       end)
 
-      assert {:log_message, "Parser restarted, syntax highlighting recovered"} in effects
-    end
-  end
+    second_window = Window.new(2, other_buf, 24, 80)
 
-  describe "parser_gave_up" do
-    test "sets parser_status to :unavailable with log message" do
-      state = base_state()
-      {new_state, effects} = HighlightHandler.handle(state, {:minga_highlight, :parser_gave_up})
-      assert new_state.parser_status == :unavailable
+    workspace =
+      %{state.workspace | buffers: %{state.workspace.buffers | active: other_buf}}
+      |> then(fn ws ->
+        %{
+          ws
+          | windows: %{
+              ws.windows
+              | map: Map.put(ws.windows.map, 2, second_window),
+                active: 2,
+                next_id: 3
+            }
+        }
+      end)
 
-      assert Enum.any?(effects, fn
-               {:log_message, msg} -> String.contains?(msg, "syntax highlighting disabled")
-               _ -> false
-             end)
-    end
-  end
-
-  describe "evict_parser_trees" do
-    test "returns timer effect in non-headless mode" do
-      state = base_state()
-      state = %{state | backend: :tui}
-      {_new_state, effects} = HighlightHandler.handle(state, :evict_parser_trees)
-      assert {:evict_parser_trees_timer} in effects
-    end
-
-    test "returns no timer effect in headless mode" do
-      state = base_state()
-      # base_state defaults to headless
-      {_new_state, effects} = HighlightHandler.handle(state, :evict_parser_trees)
-      refute {:evict_parser_trees_timer} in effects
-    end
-  end
-
-  describe "catch-all" do
-    test "unknown messages return no-op" do
-      state = base_state()
-      {new_state, effects} = HighlightHandler.handle(state, {:minga_highlight, :unknown_event})
-      assert new_state == state
-      assert effects == []
-    end
+    %{state | workspace: workspace}
   end
 end


### PR DESCRIPTION
## Summary
- Consolidates four oversized test suites into behavior-focused scenarios at the cheapest useful layer.
- Keeps the coverage on public outcomes: agent UI state transitions, normal-mode command dispatch, help command surfaces, and highlight handler effects.
- Reduces the batch from 2,192 lines to 1,254 and from 224 tests to 44.

## Test suite reductions
| File | Lines | Tests |
| --- | ---: | ---: |
| `test/minga_editor/agent/ui_state_test.exs` | 530 → 282 | 67 → 16 |
| `test/minga/mode/normal_test.exs` | 564 → 240 | 83 → 8 |
| `test/minga_editor/commands/help_test.exs` | 581 → 381 | 42 → 12 |
| `test/minga_editor/handlers/highlight_handler_test.exs` | 517 → 351 | 32 → 8 |

## Verification
- `mix test.llm test/minga_editor/agent/ui_state_test.exs test/minga/mode/normal_test.exs test/minga_editor/commands/help_test.exs test/minga_editor/handlers/highlight_handler_test.exs` → PASS: 44 tests, 0 failures
- Final reviewer gate: PASS
