### PR TITLE
test: collapse aggressive boundary batch 4

### DIFF
--- a/test/minga_editor/commands/editing_test.exs
+++ b/test/minga_editor/commands/editing_test.exs
@@ -1,8 +1,6 @@
 defmodule MingaEditor.Commands.EditingTest do
   @moduledoc """
-  Split editing command coverage by layer.
-
-  Mode FSM tests assert key-to-command emission. Command-state tests assert buffer/register behavior by calling command modules directly. The final describe block keeps a small Editor GenServer smoke layer for end-to-end key routing.
+  Boundary-focused coverage for editing commands.
   """
 
   use ExUnit.Case, async: true
@@ -23,388 +21,245 @@ defmodule MingaEditor.Commands.EditingTest do
 
   @sync_timeout 15_000
 
-  describe "Layer 0 Mode FSM: normal command emission" do
-    test "insert entry keys emit commands without a live editor" do
-      assert_mode({?i, 0}, :insert, [])
-      assert_mode({?a, 0}, :insert, [:move_right])
-      assert_mode({?A, 0}, :insert, [:move_to_line_end, :move_right])
-      assert_mode({?I, 0}, :insert, [:move_to_line_start])
-      assert_mode({?o, 0}, :insert, [:insert_line_below])
-      assert_mode({?O, 0}, :insert, [:insert_line_above])
-    end
+  describe "Mode FSM command emission" do
+    test "normal keys emit transitions and commands without a live editor" do
+      cases = [
+        {{?i, 0}, :insert, []},
+        {{?a, 0}, :insert, [:move_right]},
+        {{?A, 0}, :insert, [:move_to_line_end, :move_right]},
+        {{?I, 0}, :insert, [:move_to_line_start]},
+        {{?o, 0}, :insert, [:insert_line_below]},
+        {{?O, 0}, :insert, [:insert_line_above]},
+        {{?s, 0}, :insert, [{:delete_chars_at, 1}]},
+        {{?p, 0}, :normal, [:paste_after]},
+        {{?P, 0}, :normal, [:paste_before]}
+      ]
 
-    test "paste and counted delete keys emit normal-mode commands" do
-      assert_mode({?p, 0}, :normal, [:paste_after])
-      assert_mode({?P, 0}, :normal, [:paste_before])
+      for {key, expected_mode, expected_commands} <- cases do
+        assert_mode(key, expected_mode, expected_commands)
+      end
 
       {_mode, _commands, counted} = Mode.process(:normal, {?3, 0}, Mode.initial_state())
-      {mode, commands, _state} = Mode.process(:normal, {?x, 0}, counted)
-
-      assert mode == :normal
-      assert commands == [{:delete_chars_at, 3}]
+      assert {:normal, [{:delete_chars_at, 3}], _state} = Mode.process(:normal, {?x, 0}, counted)
     end
 
-    test "yy and dd emit operator-pending commands through the FSM" do
-      {mode, _commands, pending_yank} = Mode.process(:normal, {?y, 0}, Mode.initial_state())
-      assert mode == :operator_pending
-      assert pending_yank.operator == :yank
+    test "operator and visual entry keep modal contracts" do
+      for {operator_key, command_key, operator, command} <- [
+            {?y, ?y, :yank, {:yank_lines_counted, 1}},
+            {?d, ?d, :delete, {:delete_lines_counted, 1}}
+          ] do
+        {mode, _commands, pending} =
+          Mode.process(:normal, {operator_key, 0}, Mode.initial_state())
 
-      assert {:normal, [{:yank_lines_counted, 1}], _} =
-               Mode.process(:operator_pending, {?y, 0}, pending_yank)
+        assert mode == :operator_pending
+        assert pending.operator == operator
 
-      {mode, _commands, pending_delete} = Mode.process(:normal, {?d, 0}, Mode.initial_state())
-      assert mode == :operator_pending
-      assert pending_delete.operator == :delete
+        assert {:normal, [^command], _state} =
+                 Mode.process(:operator_pending, {command_key, 0}, pending)
+      end
 
-      assert {:normal, [{:delete_lines_counted, 1}], _} =
-               Mode.process(:operator_pending, {?d, 0}, pending_delete)
-    end
-
-    test "visual v and V enter visual mode through the FSM" do
-      {mode, commands, mode_state} = Mode.process(:normal, {?v, 0}, Mode.initial_state())
-      assert mode == :visual
-      assert commands == []
-      assert mode_state.visual_type == :char
-
-      {mode, commands, mode_state} = Mode.process(:normal, {?V, 0}, Mode.initial_state())
-      assert mode == :visual
-      assert commands == []
-      assert mode_state.visual_type == :line
-    end
-
-    test "s emits delete-char and transitions to insert" do
-      {mode, commands, _state} = Mode.process(:normal, {?s, 0}, Mode.initial_state())
-
-      assert mode == :insert
-      assert commands == [{:delete_chars_at, 1}]
+      for {key, type} <- [{?v, :char}, {?V, :line}] do
+        assert {:visual, [], %{visual_type: ^type}} =
+                 Mode.process(:normal, {key, 0}, Mode.initial_state())
+      end
     end
   end
 
-  describe "Layer 0/1 command state: insertion and open-line commands" do
-    test "insert_char updates buffer content" do
+  describe "direct editing commands" do
+    test "insertion, deletion, open-line, undo, redo, and indent mutate buffers through command execution" do
       buffer = start_buffer("hello")
-      state = command_state(buffer)
-
-      _state = Editing.execute(state, {:insert_char, "x"})
-
+      Editing.execute(command_state(buffer), {:insert_char, "x"})
       assert BufferProcess.content(buffer) == "xhello"
-    end
 
-    test "delete_before and insert_newline mutate content without touching registers" do
       buffer = start_buffer("abc")
       BufferProcess.move_to(buffer, {0, 2})
       state = command_state(buffer)
-
       state = Editing.execute(state, :delete_before)
-      state = Editing.execute(state, :insert_newline)
-
+      Editing.execute(state, :insert_newline)
       assert BufferProcess.content(buffer) == "a\nc"
       assert register_entry(state) == nil
-    end
 
-    test "insert_line_below inserts an indented line below" do
       buffer = start_buffer("  hello")
-      state = command_state(buffer)
-
-      _state = Editing.execute(state, :insert_line_below)
-
+      Editing.execute(command_state(buffer), :insert_line_below)
       assert BufferProcess.content(buffer) == "  hello\n  "
-    end
 
-    test "insert_line_above preserves fallback indentation above the first line" do
       buffer = start_buffer("  hello")
       state = command_state(buffer)
-
-      _state = Editing.execute(state, :insert_line_above)
+      Editing.execute(state, :insert_line_above)
       Editing.execute(state, {:insert_char, "w"})
-
       assert BufferProcess.content(buffer) == "  w\n  hello"
-    end
 
-    test "autopair insert and delete work when command executor is called directly" do
-      buffer = start_buffer("")
-      BufferProcess.set_option(buffer, :autopair, true)
-      state = command_state(buffer)
-
-      _state = Editing.execute(state, {:insert_char, "("})
-      assert BufferProcess.content(buffer) == "()"
-
-      _state = Editing.execute(state, :delete_before)
-      assert BufferProcess.content(buffer) == ""
-    end
-
-    test "insert_char does not autopair inside highlighted strings" do
-      buffer = start_buffer("\"hello\"")
-      BufferProcess.set_option(buffer, :autopair, true)
-      BufferProcess.move_to(buffer, {0, 1})
-
-      highlight =
-        Highlight.new()
-        |> Highlight.put_names(["string"])
-        |> Highlight.put_spans(1, [Span.new(0, 7, 0)])
-
-      _state =
-        Editing.execute(command_state_with_highlight(buffer, highlight), {:insert_char, "("})
-
-      assert BufferProcess.content(buffer) == "\"(hello\""
-    end
-
-    test "insert_char skips over closing delimiter inside highlighted strings" do
-      buffer = start_buffer("\"()\"")
-      BufferProcess.set_option(buffer, :autopair, true)
-      BufferProcess.move_to(buffer, {0, 2})
-
-      highlight =
-        Highlight.new()
-        |> Highlight.put_names(["string"])
-        |> Highlight.put_spans(1, [Span.new(0, 4, 0)])
-
-      _state =
-        Editing.execute(command_state_with_highlight(buffer, highlight), {:insert_char, ")"})
-
-      assert BufferProcess.content(buffer) == "\"()\""
-      assert BufferProcess.cursor(buffer) == {0, 3}
-    end
-
-    test "insert_char does not autopair opening brackets inside highlighted comments" do
-      buffer = start_buffer("# x")
-      BufferProcess.set_option(buffer, :autopair, true)
-      BufferProcess.move_to(buffer, {0, 2})
-
-      highlight =
-        Highlight.new()
-        |> Highlight.put_names(["comment"])
-        |> Highlight.put_spans(1, [Span.new(0, 3, 0)])
-
-      _state =
-        Editing.execute(command_state_with_highlight(buffer, highlight), {:insert_char, "("})
-
-      assert BufferProcess.content(buffer) == "# (x"
-    end
-
-    test "insert_char does not autopair at the end of an inline highlighted line comment" do
-      buffer = start_buffer("x # comment", filetype: :elixir)
-      BufferProcess.set_option(buffer, :autopair, true)
-      BufferProcess.move_to(buffer, {0, byte_size("x # comment")})
-
-      highlight =
-        Highlight.new()
-        |> Highlight.put_names(["comment"])
-        |> Highlight.put_spans(1, [Span.new(2, byte_size("x # comment"), 0)])
-
-      _state =
-        Editing.execute(command_state_with_highlight(buffer, highlight), {:insert_char, "("})
-
-      assert BufferProcess.content(buffer) == "x # comment("
-      assert BufferProcess.cursor(buffer) == {0, byte_size("x # comment(")}
-    end
-
-    test "insert_char does not autopair at the end of a no-space line comment" do
-      buffer = start_buffer("#x", filetype: :elixir)
-      BufferProcess.set_option(buffer, :autopair, true)
-      BufferProcess.move_to(buffer, {0, byte_size("#x")})
-
-      highlight =
-        Highlight.new()
-        |> Highlight.put_names(["comment"])
-        |> Highlight.put_spans(1, [Span.new(0, byte_size("#x"), 0)])
-
-      _state =
-        Editing.execute(command_state_with_highlight(buffer, highlight), {:insert_char, "("})
-
-      assert BufferProcess.content(buffer) == "#x("
-      assert BufferProcess.cursor(buffer) == {0, byte_size("#x(")}
-    end
-  end
-
-  describe "Layer 0/1 command state: block autopair" do
-    test "inserts Elixir end below a block opener and leaves cursor on inner line" do
-      buffer = start_buffer("def run do", filetype: :elixir)
-      BufferProcess.set_option(buffer, :autopair_block, true)
-      BufferProcess.set_option(buffer, :tab_width, 2)
-      BufferProcess.set_option(buffer, :indent_with, :spaces)
-      BufferProcess.move_to(buffer, {0, byte_size("def run do")})
-
-      _state = Editing.execute(command_state(buffer), :insert_newline)
-
-      assert BufferProcess.content(buffer) == "def run do\n  \nend"
-      assert BufferProcess.cursor(buffer) == {1, 2}
-    end
-
-    test "does not insert block closer when disabled for the buffer" do
-      buffer = start_buffer("def run do", filetype: :elixir)
-      BufferProcess.set_option(buffer, :autopair_block, false)
-      BufferProcess.move_to(buffer, {0, byte_size("def run do")})
-
-      _state = Editing.execute(command_state(buffer), :insert_newline)
-
-      assert BufferProcess.content(buffer) == "def run do\n"
-    end
-
-    test "does not insert block closer when cursor is before trailing text" do
-      buffer = start_buffer("def run do rest", filetype: :elixir)
-      BufferProcess.set_option(buffer, :autopair_block, true)
-      BufferProcess.move_to(buffer, {0, byte_size("def run do")})
-
-      _state = Editing.execute(command_state(buffer), :insert_newline)
-
-      assert BufferProcess.content(buffer) == "def run do\n rest"
-    end
-
-    test "insert_newline does not add a block closer at the end of a highlighted line comment" do
-      buffer = start_buffer("# def run do", filetype: :elixir)
-      BufferProcess.set_option(buffer, :autopair_block, true)
-      BufferProcess.move_to(buffer, {0, byte_size("# def run do")})
-
-      highlight =
-        Highlight.new()
-        |> Highlight.put_names(["comment"])
-        |> Highlight.put_spans(1, [Span.new(0, byte_size("# def run do"), 0)])
-
-      _state = Editing.execute(command_state_with_highlight(buffer, highlight), :insert_newline)
-
-      assert BufferProcess.content(buffer) == "# def run do\n"
-    end
-
-    test "insert_newline does not add a block closer inside highlighted strings" do
-      buffer = start_buffer("def run do", filetype: :elixir)
-      BufferProcess.set_option(buffer, :autopair_block, true)
-      BufferProcess.move_to(buffer, {0, byte_size("def run do")})
-
-      highlight =
-        Highlight.new()
-        |> Highlight.put_names(["string"])
-        |> Highlight.put_spans(1, [Span.new(0, byte_size("def run do"), 0)])
-
-      _state = Editing.execute(command_state_with_highlight(buffer, highlight), :insert_newline)
-
-      assert BufferProcess.content(buffer) == "def run do\n"
-    end
-  end
-
-  describe "Layer 0/1 command state: undo, redo, and indent" do
-    test "undo and redo operate through direct command execution" do
       buffer = start_buffer("hello")
       state = command_state(buffer)
-
       state = Editing.execute(state, {:insert_char, "x"})
       assert BufferProcess.content(buffer) == "xhello"
-
       state = Editing.execute(state, :undo)
       assert BufferProcess.content(buffer) == "hello"
-
-      _state = Editing.execute(state, :redo)
+      Editing.execute(state, :redo)
       assert BufferProcess.content(buffer) == "xhello"
-    end
 
-    test "indent_line respects tab indentation" do
       buffer = start_buffer("hello")
       BufferProcess.set_option(buffer, :indent_with, :tabs)
-      state = command_state(buffer)
-
-      _state = Editing.execute(state, :indent_line)
-
+      Editing.execute(command_state(buffer), :indent_line)
       assert BufferProcess.content(buffer) == "\thello"
       assert BufferProcess.cursor(buffer) == {0, 1}
     end
+
+    test "autopair pairs, deletes, skips closing delimiters, and suppresses pairing in comments or strings" do
+      buffer = start_buffer("")
+      BufferProcess.set_option(buffer, :autopair, true)
+      state = command_state(buffer)
+      Editing.execute(state, {:insert_char, "("})
+      assert BufferProcess.content(buffer) == "()"
+      Editing.execute(state, :delete_before)
+      assert BufferProcess.content(buffer) == ""
+
+      string = highlighted_buffer("\"hello\"", "string", 0, 7, cursor: {0, 1})
+
+      Editing.execute(
+        command_state_with_highlight(string, highlight("string", 0, 7)),
+        {:insert_char, "("}
+      )
+
+      assert BufferProcess.content(string) == "\"(hello\""
+
+      closing = highlighted_buffer("\"()\"", "string", 0, 4, cursor: {0, 2})
+
+      Editing.execute(
+        command_state_with_highlight(closing, highlight("string", 0, 4)),
+        {:insert_char, ")"}
+      )
+
+      assert BufferProcess.content(closing) == "\"()\""
+      assert BufferProcess.cursor(closing) == {0, 3}
+
+      comment_cases = [
+        {"# x", {0, 2}, 0, 3, "# (x", {0, 3}},
+        {"x # comment", {0, byte_size("x # comment")}, 2, byte_size("x # comment"),
+         "x # comment(", {0, byte_size("x # comment(")}},
+        {"#x", {0, byte_size("#x")}, 0, byte_size("#x"), "#x(", {0, byte_size("#x(")}}
+      ]
+
+      for {content, cursor, start_byte, end_byte, expected, expected_cursor} <- comment_cases do
+        buffer =
+          highlighted_buffer(content, "comment", start_byte, end_byte,
+            cursor: cursor,
+            filetype: :elixir
+          )
+
+        Editing.execute(
+          command_state_with_highlight(buffer, highlight("comment", start_byte, end_byte)),
+          {:insert_char, "("}
+        )
+
+        assert BufferProcess.content(buffer) == expected
+        assert BufferProcess.cursor(buffer) == expected_cursor
+      end
+    end
+
+    test "block autopair inserts closers only for enabled code at the end of a block opener" do
+      enabled = start_buffer("def run do", filetype: :elixir)
+      BufferProcess.set_option(enabled, :autopair_block, true)
+      BufferProcess.set_option(enabled, :tab_width, 2)
+      BufferProcess.set_option(enabled, :indent_with, :spaces)
+      BufferProcess.move_to(enabled, {0, byte_size("def run do")})
+      Editing.execute(command_state(enabled), :insert_newline)
+      assert BufferProcess.content(enabled) == "def run do\n  \nend"
+      assert BufferProcess.cursor(enabled) == {1, 2}
+
+      cases = [
+        {start_buffer("def run do", filetype: :elixir), false, {0, byte_size("def run do")}, nil,
+         "def run do\n"},
+        {start_buffer("def run do rest", filetype: :elixir), true, {0, byte_size("def run do")},
+         nil, "def run do\n rest"},
+        {start_buffer("# def run do", filetype: :elixir), true, {0, byte_size("# def run do")},
+         "comment", "# def run do\n"},
+        {start_buffer("def run do", filetype: :elixir), true, {0, byte_size("def run do")},
+         "string", "def run do\n"}
+      ]
+
+      for {buffer, autopair_block, cursor, capture, expected} <- cases do
+        BufferProcess.set_option(buffer, :autopair_block, autopair_block)
+        BufferProcess.move_to(buffer, cursor)
+
+        state =
+          if capture == nil do
+            command_state(buffer)
+          else
+            command_state_with_highlight(buffer, highlight(capture, 0, elem(cursor, 1)))
+          end
+
+        Editing.execute(state, :insert_newline)
+        assert BufferProcess.content(buffer) == expected
+      end
+    end
   end
 
-  describe "Layer 0/1 command state: linewise paste" do
-    test "paste_after and paste_before insert linewise registers as full lines" do
+  describe "register, paste, operator, and visual contracts" do
+    test "linewise paste inserts full lines, positions the cursor, and ignores empty registers" do
       buffer = start_buffer("aaa\nbbb\nccc")
       state = command_state(buffer) |> with_register("", "aaa\n", :linewise)
-
       BufferProcess.move_to(buffer, {1, 2})
-      _state = Editing.execute(state, :paste_after)
+      Editing.execute(state, :paste_after)
       assert BufferProcess.content(buffer) == "aaa\nbbb\naaa\nccc"
 
       buffer = start_buffer("aaa\nbbb")
       state = command_state(buffer) |> with_register("", "bbb\n", :linewise)
-
       BufferProcess.move_to(buffer, {0, 0})
-      _state = Editing.execute(state, :paste_before)
+      Editing.execute(state, :paste_before)
       assert BufferProcess.content(buffer) == "bbb\naaa\nbbb"
-    end
 
-    test "linewise paste places cursor on first non-blank of pasted line" do
       buffer = start_buffer("  indented\nplain")
       state = command_state(buffer) |> with_register("", "  indented\n", :linewise)
-
       BufferProcess.move_to(buffer, {1, 0})
-      _state = Editing.execute(state, :paste_after)
-
+      Editing.execute(state, :paste_after)
       assert BufferProcess.cursor(buffer) == {2, 2}
-    end
 
-    test "empty registers leave paste commands as no-ops" do
       buffer = start_buffer("hello")
-      original = BufferProcess.content(buffer)
       state = command_state(buffer)
-
       state = Editing.execute(state, :paste_after)
-      _state = Editing.execute(state, :paste_before)
-
-      assert BufferProcess.content(buffer) == original
+      Editing.execute(state, :paste_before)
+      assert BufferProcess.content(buffer) == "hello"
     end
-  end
 
-  describe "Layer 0/1 command state: charwise delete and paste" do
-    test "delete_chars_at stores deleted chars and paste_after inserts them inline" do
+    test "charwise deletes clamp, preserve deleted text order, paste inline, and honor named registers" do
       buffer = start_buffer("abcdef")
       state = command_state(buffer)
-
       state = Editing.execute(state, {:delete_chars_at, 3})
       assert BufferProcess.content(buffer) == "def"
       assert register_entry(state) == {"abc", :charwise}
-
       BufferProcess.move_to(buffer, {0, 2})
-      _state = Editing.execute(state, :paste_after)
-
+      Editing.execute(state, :paste_after)
       assert BufferProcess.content(buffer) == "defabc"
-    end
 
-    test "delete_chars_at clamps to available characters" do
       buffer = start_buffer("ab")
-      state = command_state(buffer)
-
-      state = Editing.execute(state, {:delete_chars_at, 5})
-
+      state = command_state(buffer) |> Editing.execute({:delete_chars_at, 5})
       assert BufferProcess.content(buffer) == ""
       assert register_entry(state) == {"ab", :charwise}
-    end
 
-    test "delete_chars_before stores deleted chars in reading order" do
       buffer = start_buffer("abcdef")
       BufferProcess.move_to(buffer, {0, 4})
-      state = command_state(buffer)
-
-      state = Editing.execute(state, {:delete_chars_before, 3})
-
+      state = command_state(buffer) |> Editing.execute({:delete_chars_before, 3})
       assert BufferProcess.content(buffer) == "aef"
       assert register_entry(state) == {"bcd", :charwise}
-    end
 
-    test "x on empty line and X at column zero are no-ops" do
       buffer = start_buffer("")
-      state = command_state(buffer)
-
-      state = Editing.execute(state, {:delete_chars_at, 1})
+      state = command_state(buffer) |> Editing.execute({:delete_chars_at, 1})
       assert BufferProcess.content(buffer) == ""
       assert register_entry(state) == nil
 
       buffer = start_buffer("abc")
-      state = command_state(buffer)
-
-      state = Editing.execute(state, {:delete_chars_before, 1})
+      state = command_state(buffer) |> Editing.execute({:delete_chars_before, 1})
       assert BufferProcess.content(buffer) == "abc"
       assert register_entry(state) == nil
-    end
 
-    test "named and black-hole registers affect delete behavior" do
       buffer = start_buffer("abc")
-      state = command_state(buffer) |> with_active_register("a")
 
-      state = Editing.execute(state, {:delete_chars_at, 1})
+      state =
+        command_state(buffer)
+        |> with_active_register("a")
+        |> Editing.execute({:delete_chars_at, 1})
+
       assert BufferProcess.content(buffer) == "bc"
       assert register_entry(state, "a") == {"a", :charwise}
 
@@ -414,51 +269,34 @@ defmodule MingaEditor.Commands.EditingTest do
         command_state(buffer)
         |> with_register("", "seed", :charwise)
         |> with_active_register("_")
+        |> Editing.execute({:delete_chars_at, 1})
 
-      state = Editing.execute(state, {:delete_chars_at, 1})
       assert BufferProcess.content(buffer) == "bc"
       assert register_entry(state) == {"seed", :charwise}
     end
-  end
 
-  describe "Layer 0/1 command state: operators, registers, and paste" do
-    test "yy then paste_after pastes a yanked line below the target line" do
+    test "line operators preserve yank/delete/change register semantics through paste" do
       buffer = start_buffer("aaa\nbbb\nccc")
-      state = command_state(buffer)
-
-      state = Operators.execute(state, {:yank_lines_counted, 1})
+      state = command_state(buffer) |> Operators.execute({:yank_lines_counted, 1})
       BufferProcess.move_to(buffer, {1, 0})
-      _state = Editing.execute(state, :paste_after)
-
+      Editing.execute(state, :paste_after)
       assert BufferProcess.content(buffer) == "aaa\nbbb\naaa\nccc"
       assert register_entry(state) == {"aaa\n", :linewise}
       assert register_entry(state, "0") == {"aaa\n", :linewise}
-    end
 
-    test "dd then paste_before restores the deleted line above the cursor" do
       buffer = start_buffer("aaa\nbbb\nccc")
       BufferProcess.move_to(buffer, {1, 0})
-      state = command_state(buffer)
-
-      state = Operators.execute(state, {:delete_lines_counted, 1})
-      _state = Editing.execute(state, :paste_before)
-
+      state = command_state(buffer) |> Operators.execute({:delete_lines_counted, 1})
+      Editing.execute(state, :paste_before)
       assert BufferProcess.content(buffer) == "aaa\nbbb\nccc"
       assert register_entry(state) == {"bbb\n", :linewise}
       assert register_entry(state, "0") == nil
-    end
 
-    test "cc stores linewise register type before clearing" do
       buffer = start_buffer("hello\nworld")
-      state = command_state(buffer)
-
-      state = Operators.execute(state, {:change_lines_counted, 1})
-
+      state = command_state(buffer) |> Operators.execute({:change_lines_counted, 1})
       refute String.contains?(BufferProcess.content(buffer), "hello")
       assert register_entry(state) == {"hello\n", :linewise}
-    end
 
-    test "named register preserves linewise type through later unnamed operations" do
       buffer = start_buffer("alpha\nbeta\ngamma")
 
       state =
@@ -469,100 +307,77 @@ defmodule MingaEditor.Commands.EditingTest do
       BufferProcess.move_to(buffer, {1, 0})
       state = Operators.execute(state, {:delete_lines_counted, 1})
       state = with_active_register(state, "a")
-      _state = Editing.execute(state, :paste_after)
-
+      Editing.execute(state, :paste_after)
       assert BufferProcess.content(buffer) == "alpha\ngamma\nalpha"
     end
-  end
 
-  describe "Layer 0/1 command state: visual paste contracts" do
-    test "visual line yank then paste_after duplicates selected lines" do
+    test "visual line and char operations preserve linewise versus inline paste behavior" do
       buffer = start_buffer("aaa\nbbb\nccc\nddd")
       BufferProcess.move_to(buffer, {1, 0})
-      state = command_state(buffer) |> with_visual_selection({0, 0}, :line)
 
-      state = Visual.execute(state, :yank_visual_selection)
-      _state = Editing.execute(state, :paste_after)
+      state =
+        command_state(buffer)
+        |> with_visual_selection({0, 0}, :line)
+        |> Visual.execute(:yank_visual_selection)
 
+      Editing.execute(state, :paste_after)
       assert BufferProcess.content(buffer) == "aaa\nbbb\naaa\nbbb\nccc\nddd"
-    end
 
-    test "visual line delete then paste_after restores deleted lines as linewise" do
       buffer = start_buffer("aaa\nbbb\nccc")
       BufferProcess.move_to(buffer, {1, 0})
-      state = command_state(buffer) |> with_visual_selection({0, 0}, :line)
 
-      state = Visual.execute(state, :delete_visual_selection)
-      _state = Editing.execute(state, :paste_after)
+      state =
+        command_state(buffer)
+        |> with_visual_selection({0, 0}, :line)
+        |> Visual.execute(:delete_visual_selection)
 
+      Editing.execute(state, :paste_after)
       assert BufferProcess.content(buffer) == "ccc\naaa\nbbb"
-    end
 
-    test "visual char yank then paste_after stays inline" do
       buffer = start_buffer("abcdefgh")
       BufferProcess.move_to(buffer, {0, 3})
-      state = command_state(buffer) |> with_visual_selection({0, 0}, :char)
 
-      state = Visual.execute(state, :yank_visual_selection)
+      state =
+        command_state(buffer)
+        |> with_visual_selection({0, 0}, :char)
+        |> Visual.execute(:yank_visual_selection)
+
       BufferProcess.move_to(buffer, {0, 7})
-      _state = Editing.execute(state, :paste_after)
-
+      Editing.execute(state, :paste_after)
       assert BufferProcess.content(buffer) == "abcdefghabcd"
     end
   end
 
-  describe "Editor GenServer smoke: key routing" do
-    test "normal and insert routing inserts text and Escape returns to normal semantics" do
+  describe "Editor GenServer smoke layer" do
+    test "key routing covers insert, operator, visual, command, and paste paths" do
       {editor, buffer} = start_editor("")
-
       send_key(editor, ?i)
       Enum.each(~c"abc!", &send_key(editor, &1))
       send_key(editor, 27)
       send_key(editor, ?l)
-
       assert BufferProcess.content(buffer) == "abc!"
       assert BufferProcess.cursor(buffer) == {0, 3}
-    end
 
-    test "operator-pending yy then p routes through the editor" do
       {editor, buffer} = start_editor("aaa\nbbb\nccc")
-      send_key(editor, ?y)
-      send_key(editor, ?y)
-      send_key(editor, ?j)
-      send_key(editor, ?p)
-
+      Enum.each([?y, ?y, ?j, ?p], &send_key(editor, &1))
       assert BufferProcess.content(buffer) == "aaa\nbbb\naaa\nccc"
-    end
 
-    test "visual v d routes through the editor" do
       {editor, buffer} = start_editor("hello world")
-      send_key(editor, ?v)
-      send_key(editor, ?l)
-      send_key(editor, ?l)
-      send_key(editor, ?d)
-
+      Enum.each([?v, ?l, ?l, ?d], &send_key(editor, &1))
       assert BufferProcess.content(buffer) == "lo world"
-    end
 
-    test "command mode key routing enters command mode" do
       {editor, _buffer} = start_editor("hello")
       send_key(editor, ?:)
-
       assert sync_editor(editor) == :command
-    end
 
-    test "paste events route in normal and insert modes" do
       {editor, buffer} = start_editor("start")
-
       send(editor, {:minga_input, {:paste_event, " normal"}})
-      _ = sync_editor(editor)
+      sync_editor(editor)
       send_key(editor, ?i)
       send(editor, {:minga_input, {:paste_event, " insert"}})
-      _ = sync_editor(editor)
-
-      content = BufferProcess.content(buffer)
-      assert String.contains?(content, "normal")
-      assert String.contains?(content, "insert")
+      sync_editor(editor)
+      assert BufferProcess.content(buffer) =~ "normal"
+      assert BufferProcess.content(buffer) =~ "insert"
     end
   end
 
@@ -571,6 +386,20 @@ defmodule MingaEditor.Commands.EditingTest do
 
     assert mode == expected_mode
     assert commands == expected_commands
+  end
+
+  defp highlighted_buffer(content, capture, start_byte, end_byte, opts) do
+    buffer = start_buffer(content, filetype: Keyword.get(opts, :filetype, :text))
+    BufferProcess.set_option(buffer, :autopair, true)
+    BufferProcess.move_to(buffer, Keyword.fetch!(opts, :cursor))
+    _ = highlight(capture, start_byte, end_byte)
+    buffer
+  end
+
+  defp highlight(capture, start_byte, end_byte) do
+    Highlight.new()
+    |> Highlight.put_names([capture])
+    |> Highlight.put_spans(1, [Span.new(start_byte, end_byte, 0)])
   end
 
   defp start_editor(content) do
@@ -601,7 +430,7 @@ defmodule MingaEditor.Commands.EditingTest do
 
   defp send_key(editor, codepoint, mods \\ 0) do
     send(editor, {:minga_input, {:key_press, codepoint, mods}})
-    _ = sync_editor(editor)
+    sync_editor(editor)
   end
 
   defp sync_editor(editor), do: GenServer.call(editor, :api_mode, @sync_timeout)

--- a/test/minga_editor/state/buffer_lifecycle_test.exs
+++ b/test/minga_editor/state/buffer_lifecycle_test.exs
@@ -1,12 +1,6 @@
 defmodule MingaEditor.State.BufferLifecycleTest do
   @moduledoc """
   Pure-function tests for buffer lifecycle operations on `EditorState`.
-
-  Tests `add_buffer_pure/2` and `close_buffer_pure/2` without starting
-  any GenServer. Uses `base_state/1` from `RenderPipeline.TestHelpers`
-  to construct minimal state structs.
-
-  Part of work item B3 from `docs/PLAN-ui-stability.md`.
   """
 
   use ExUnit.Case, async: true
@@ -26,59 +20,27 @@ defmodule MingaEditor.State.BufferLifecycleTest do
 
   import MingaEditor.RenderPipeline.TestHelpers
 
-  # ── Helpers ──────────────────────────────────────────────────────────────────
-
-  # Creates a base state with a tab bar containing a single file tab.
-  # The file tab is set up with a context snapshot matching the current
-  # workspace state, simulating a real editor with an open file.
   @spec state_with_file_tab(keyword()) :: EditorState.t()
   defp state_with_file_tab(opts \\ []) do
     state = base_state(opts)
     tab = Tab.new_file(1, "test.ex")
-    tb = TabBar.new(tab)
-
-    # Snapshot the workspace into the active tab's context
-    context = EditorState.snapshot_tab_context(state)
-    tb = TabBar.update_context(tb, 1, context)
-
+    tb = TabBar.new(tab) |> TabBar.update_context(1, EditorState.snapshot_tab_context(state))
     EditorState.set_tab_bar(state, tb)
   end
 
   @spec state_with_file_tab_for_path(String.t(), String.t()) :: {EditorState.t(), pid()}
   defp state_with_file_tab_for_path(path, content) do
     buf = start_file_buffer(path, content)
-    win_id = 1
-    window = Window.new(win_id, buf, 24, 80)
-
-    state = %EditorState{
-      port_manager: self(),
-      workspace: %WorkspaceState{
-        viewport: Viewport.new(24, 80),
-        editing: VimState.new(),
-        buffers: %Buffers{active: buf, list: [buf], active_index: 0},
-        windows: %Windows{
-          tree: WindowTree.new(win_id),
-          map: %{win_id => window},
-          active: win_id,
-          next_id: win_id + 1
-        }
-      }
-    }
-
+    state = state_for_buffer(buf)
     tab = Tab.new_file(1, Path.basename(path))
-    context = EditorState.snapshot_tab_context(state)
-    tb = TabBar.new(tab)
-    tb = TabBar.update_context(tb, 1, context)
-
+    tb = TabBar.new(tab) |> TabBar.update_context(1, EditorState.snapshot_tab_context(state))
     {EditorState.set_tab_bar(state, tb), buf}
   end
 
-  # Creates a state with an agent tab active and an agent_chat window.
   @spec state_with_agent_tab() :: {EditorState.t(), pid()}
   defp state_with_agent_tab do
-    {:ok, agent_buf} = BufferProcess.start_link(content: "")
-    win_id = 1
-    agent_window = Window.new_agent_chat(win_id, agent_buf, 24, 80)
+    agent_buf = start_buffer("")
+    agent_window = Window.new_agent_chat(1, agent_buf, 24, 80)
 
     state = %EditorState{
       port_manager: self(),
@@ -88,24 +50,21 @@ defmodule MingaEditor.State.BufferLifecycleTest do
         keymap_scope: :agent,
         buffers: %Buffers{active: agent_buf, list: [agent_buf], active_index: 0},
         windows: %Windows{
-          tree: WindowTree.new(win_id),
-          map: %{win_id => agent_window},
-          active: win_id,
-          next_id: win_id + 1
+          tree: WindowTree.new(1),
+          map: %{1 => agent_window},
+          active: 1,
+          next_id: 2
         }
       }
     }
 
-    agent_tab = Tab.new_agent(1, "Agent")
-    context = EditorState.snapshot_tab_context(state)
-    tb = TabBar.new(agent_tab)
-    tb = TabBar.update_context(tb, 1, context)
-    state = EditorState.set_tab_bar(state, tb)
+    tb =
+      TabBar.new(Tab.new_agent(1, "Agent"))
+      |> TabBar.update_context(1, EditorState.snapshot_tab_context(state))
 
-    {state, agent_buf}
+    {EditorState.set_tab_bar(state, tb), agent_buf}
   end
 
-  # Starts a buffer for use in tests. Returns the pid.
   @spec start_buffer(String.t()) :: pid()
   defp start_buffer(content) do
     {:ok, pid} = BufferProcess.start_link(content: content)
@@ -119,377 +78,112 @@ defmodule MingaEditor.State.BufferLifecycleTest do
     pid
   end
 
-  # ── add_buffer_pure/2 ─────────────────────────────────────────────────────────
-
   describe "add_buffer_pure/2" do
-    test "adds buffer to empty state (no tab bar)" do
-      state = base_state()
+    test "adds buffers with no tab bar, opens file tabs, previews without overwriting context, and avoids duplicate monitors" do
+      no_tab = base_state()
       new_buf = start_buffer("new file")
-
-      {new_state, effects} = EditorState.add_buffer_pure(state, new_buf)
-
+      {new_state, effects} = EditorState.add_buffer_pure(no_tab, new_buf)
       assert new_buf in new_state.workspace.buffers.list
       assert new_state.workspace.buffers.active == new_buf
       assert {:monitor, new_buf} in effects
-    end
 
-    test "adds buffer when file tab active (in-place replace)" do
-      state = state_with_file_tab()
-      original_buf = state.workspace.buffers.active
-      new_buf = start_buffer("new file")
-
-      {new_state, effects} = EditorState.add_buffer_pure(state, new_buf)
-
-      # Buffer is in the pool and active
-      assert new_buf in new_state.workspace.buffers.list
-      assert new_state.workspace.buffers.active == new_buf
-
-      # Monitor effect is present
-      assert {:monitor, new_buf} in effects
-
-      # The active tab should still be a file tab (in-place replace, not new tab)
-      tb = new_state.shell_state.tab_bar
-      active_tab = TabBar.active(tb)
-      assert active_tab.kind == :file
-
-      # Should still have the same number of tabs (in-place, may create new file tab)
-      # The key invariant is that the new buffer is now active
-      assert new_state.workspace.buffers.active == new_buf
-      refute new_state.workspace.buffers.active == original_buf
-    end
-
-    test "opening a file from a file tab snapshots the outgoing tab before activating the new buffer" do
       state = state_with_file_tab()
       original_buf = state.workspace.buffers.active
       opened_buf = start_buffer("opened")
-
-      {new_state, effects} = EditorState.add_buffer_pure(state, opened_buf, context: :open)
-
+      {opened, effects} = EditorState.add_buffer_pure(state, opened_buf, context: :open)
+      tb = opened.shell_state.tab_bar
       assert {:monitor, opened_buf} in effects
-
-      tb = new_state.shell_state.tab_bar
       assert TabBar.count(tb) == 2
       assert tb.active_id == 2
       assert %Buffers{active: ^original_buf} = TabBar.get(tb, 1).context.buffers
       assert %Buffers{active: ^opened_buf} = TabBar.get(tb, 2).context.buffers
-      assert new_state.workspace.buffers.active == opened_buf
+      assert opened.workspace.buffers.active == opened_buf
+
+      preview_buf = start_buffer("preview")
+      {previewed, _effects} = EditorState.add_buffer_pure(state, preview_buf, context: :preview)
+      assert TabBar.count(previewed.shell_state.tab_bar) == 1
+      assert previewed.workspace.buffers.active == preview_buf
+
+      assert %Buffers{active: ^original_buf} =
+               TabBar.get(previewed.shell_state.tab_bar, 1).context.buffers
+
+      assert previewed.buffer_add_context == :open
+
+      duplicate = EditorState.add_buffer(state, opened_buf)
+      {switched_back, effects} = EditorState.add_buffer_pure(duplicate, original_buf)
+      assert switched_back.workspace.buffers.active == original_buf
+      assert effects == []
     end
 
-    test "opening a file from an agent tab snapshots the agent tab with the agent buffer" do
+    test "opening from an agent tab snapshots agent state, creates a file tab, switches scope, and stops the spinner" do
       {state, agent_buf} = state_with_agent_tab()
       file_buf = start_buffer("file content")
 
-      {new_state, _effects} = EditorState.add_buffer_pure(state, file_buf, context: :open)
-
+      {new_state, effects} = EditorState.add_buffer_pure(state, file_buf, context: :open)
       tb = new_state.shell_state.tab_bar
       agent_tab = TabBar.get(tb, 1)
       file_tab = TabBar.active(tb)
+      window = active_window(new_state)
 
+      assert {:monitor, file_buf} in effects
+      assert :stop_spinner in effects
+      assert TabBar.count(tb) == 2
       assert agent_tab.kind == :agent
       assert %Buffers{active: ^agent_buf} = agent_tab.context.buffers
       assert agent_tab.context.keymap_scope == :agent
       assert file_tab.kind == :file
       assert %Buffers{active: ^file_buf} = file_tab.context.buffers
       assert file_tab.context.keymap_scope == :editor
-    end
-
-    test "previewing a file does not overwrite the current tab context with the preview buffer" do
-      state = state_with_file_tab()
-      original_buf = state.workspace.buffers.active
-      preview_buf = start_buffer("preview")
-
-      {new_state, _effects} = EditorState.add_buffer_pure(state, preview_buf, context: :preview)
-
-      tb = new_state.shell_state.tab_bar
-      assert TabBar.count(tb) == 1
-      assert tb.active_id == 1
-      assert new_state.workspace.buffers.active == preview_buf
-      assert %Buffers{active: ^original_buf} = TabBar.get(tb, 1).context.buffers
-      assert new_state.buffer_add_context == :open
+      assert new_state.workspace.keymap_scope == :editor
+      assert new_state.workspace.buffers.active == file_buf
+      assert Content.buffer?(window.content)
     end
 
     @tag :tmp_dir
-    test "opening a file that already has a tab snapshots the outgoing tab before switching", %{
-      tmp_dir: tmp_dir
-    } do
+    test "file identity uses real paths, not just basenames, and existing tabs are reactivated without monitor effects",
+         %{tmp_dir: tmp_dir} do
       path1 = Path.join(tmp_dir, "one.ex")
       path2 = Path.join(tmp_dir, "two.ex")
       {state, buf1} = state_with_file_tab_for_path(path1, "one")
       buf2 = start_file_buffer(path2, "two")
 
       {state, _effects} = EditorState.add_buffer_pure(state, buf2, context: :open)
-      assert state.workspace.buffers.active == buf2
-
-      {new_state, effects} = EditorState.add_buffer_pure(state, buf1, context: :open)
-
+      {reactivated, effects} = EditorState.add_buffer_pure(state, buf1, context: :open)
       assert effects == []
+      assert reactivated.shell_state.tab_bar.active_id == 1
+      assert reactivated.workspace.buffers.active == buf1
 
-      tb = new_state.shell_state.tab_bar
-      assert tb.active_id == 1
-      assert new_state.workspace.buffers.active == buf1
-      assert %Buffers{active: ^buf1} = TabBar.get(tb, 1).context.buffers
-      assert %Buffers{active: ^buf2} = TabBar.get(tb, 2).context.buffers
-    end
+      assert %Buffers{active: ^buf1} =
+               TabBar.get(reactivated.shell_state.tab_bar, 1).context.buffers
 
-    @tag :tmp_dir
-    test "opening a different file with the same basename creates a distinct tab", %{
-      tmp_dir: tmp_dir
-    } do
+      assert %Buffers{active: ^buf2} =
+               TabBar.get(reactivated.shell_state.tab_bar, 2).context.buffers
+
       dir1 = Path.join(tmp_dir, "one")
       dir2 = Path.join(tmp_dir, "two")
       File.mkdir_p!(dir1)
       File.mkdir_p!(dir2)
-      path1 = Path.join(dir1, "same.ex")
-      path2 = Path.join(dir2, "same.ex")
-      {state, buf1} = state_with_file_tab_for_path(path1, "one")
-      buf2 = start_file_buffer(path2, "two")
+      same1 = Path.join(dir1, "same.ex")
+      same2 = Path.join(dir2, "same.ex")
+      {state, same_buf1} = state_with_file_tab_for_path(same1, "one")
+      same_buf2 = start_file_buffer(same2, "two")
 
-      {new_state, effects} = EditorState.add_buffer_pure(state, buf2, context: :open)
+      {distinct, effects} = EditorState.add_buffer_pure(state, same_buf2, context: :open)
+      assert {:monitor, same_buf2} in effects
+      assert TabBar.count(distinct.shell_state.tab_bar) == 2
+      assert TabBar.get(distinct.shell_state.tab_bar, 1).label == "same.ex"
+      assert TabBar.get(distinct.shell_state.tab_bar, 2).label == "same.ex"
 
-      assert {:monitor, buf2} in effects
-      tb = new_state.shell_state.tab_bar
-      assert TabBar.count(tb) == 2
-      assert tb.active_id == 2
-      assert TabBar.get(tb, 1).label == "same.ex"
-      assert TabBar.get(tb, 2).label == "same.ex"
-      assert %Buffers{active: ^buf1} = TabBar.get(tb, 1).context.buffers
-      assert %Buffers{active: ^buf2} = TabBar.get(tb, 2).context.buffers
+      assert %Buffers{active: ^same_buf1} =
+               TabBar.get(distinct.shell_state.tab_bar, 1).context.buffers
+
+      assert %Buffers{active: ^same_buf2} =
+               TabBar.get(distinct.shell_state.tab_bar, 2).context.buffers
     end
 
-    test "adds buffer when agent tab active (new file tab)" do
-      {state, _agent_buf} = state_with_agent_tab()
-      file_buf = start_buffer("file content")
-
-      {new_state, effects} = EditorState.add_buffer_pure(state, file_buf)
-
-      # Buffer is in the pool and active
-      assert file_buf in new_state.workspace.buffers.list
-      assert new_state.workspace.buffers.active == file_buf
-
-      # Monitor effect is present
-      assert {:monitor, file_buf} in effects
-
-      # A new file tab should be created and made active
-      tb = new_state.shell_state.tab_bar
-      active_tab = TabBar.active(tb)
-      assert active_tab.kind == :file
-
-      # Should have two tabs: the original agent tab + new file tab
-      assert TabBar.count(tb) == 2
-
-      # Keymap scope should switch from :agent to :editor
-      assert new_state.workspace.keymap_scope == :editor
-
-      # Active window content should be a buffer, not agent_chat
-      window = Map.fetch!(new_state.workspace.windows.map, new_state.workspace.windows.active)
-      assert Content.buffer?(window.content)
-    end
-
-    test "opening a file from an agent tab returns :stop_spinner effect" do
-      {state, _agent_buf} = state_with_agent_tab()
-      file_buf = start_buffer("file content")
-
-      {_new_state, effects} = EditorState.add_buffer_pure(state, file_buf, context: :open)
-
-      assert :stop_spinner in effects
-      assert {:monitor, file_buf} in effects
-    end
-
-    test "opening a file from a file tab does not return :stop_spinner effect" do
-      state = state_with_file_tab()
-      file_buf = start_buffer("new file")
-
-      {_new_state, effects} = EditorState.add_buffer_pure(state, file_buf, context: :open)
-
-      refute :stop_spinner in effects
-      assert {:monitor, file_buf} in effects
-    end
-
-    test "adds duplicate buffer (switches to existing tab)" do
-      state = state_with_file_tab()
-      buf = state.workspace.buffers.active
-
-      # Create a second file tab with a different buffer
-      {:ok, buf2} = BufferProcess.start_link(content: "second file")
-      state = EditorState.add_buffer(state, buf2)
-
-      # Now we have two tabs; the second (buf2) is active
-      tb = state.shell_state.tab_bar
-      assert TabBar.count(tb) >= 2
-      assert state.workspace.buffers.active == buf2
-
-      # "Add" the first buffer again - should switch to its existing tab
-      {new_state, effects} = EditorState.add_buffer_pure(state, buf)
-
-      # The first buffer should now be active
-      assert new_state.workspace.buffers.active == buf
-      # No monitor effect — buffer was already monitored from the first add
-      assert effects == []
-    end
-
-    test "syncs the active window buffer reference" do
-      state = state_with_file_tab()
-      new_buf = start_buffer("new file")
-
-      {new_state, _effects} = EditorState.add_buffer_pure(state, new_buf)
-
-      window = Map.fetch!(new_state.workspace.windows.map, new_state.workspace.windows.active)
-      assert window.buffer == new_buf
-    end
-  end
-
-  describe "switch_buffer/2" do
-    test "refreshes the active file tab context after an in-place buffer switch" do
-      state = state_with_file_tab()
-      original_buf = state.workspace.buffers.active
-      other_buf = start_buffer("other")
-
-      state =
-        EditorState.update_workspace(state, fn workspace ->
-          %Buffers{} = buffers = workspace.buffers
-
-          %{
-            workspace
-            | buffers: %{buffers | list: [original_buf, other_buf]}
-          }
-        end)
-
-      new_state = EditorState.switch_buffer(state, 1)
-
-      assert new_state.workspace.buffers.active == other_buf
-
-      assert %Buffers{active: ^other_buf} =
-               TabBar.active(new_state.shell_state.tab_bar).context.buffers
-    end
-
-    test "preview buffer switch does not rewrite the active file tab context" do
-      state = state_with_file_tab()
-      original_buf = state.workspace.buffers.active
-      preview_buf = start_buffer("preview")
-
-      state =
-        EditorState.update_workspace(state, fn workspace ->
-          %Buffers{} = buffers = workspace.buffers
-
-          %{
-            workspace
-            | buffers: %{buffers | list: [original_buf, preview_buf]}
-          }
-        end)
-        |> EditorState.set_buffer_add_context(:preview)
-
-      new_state = EditorState.switch_buffer(state, 1)
-
-      assert new_state.workspace.buffers.active == preview_buf
-      assert new_state.buffer_add_context == :open
-
-      assert %Buffers{active: ^original_buf} =
-               TabBar.active(new_state.shell_state.tab_bar).context.buffers
-    end
-  end
-
-  # ── close_buffer_pure/2 ────────────────────────────────────────────────────────
-
-  describe "close_buffer_pure/2" do
-    test "closes active buffer and switches to neighbor" do
-      state = base_state()
-      buf1 = state.workspace.buffers.active
-      buf2 = start_buffer("second")
-
-      # Add second buffer so we have two
-      state = EditorState.add_buffer(state, buf2)
-      assert state.workspace.buffers.active == buf2
-      assert length(state.workspace.buffers.list) == 2
-
-      # Monitor both buffers so close_buffer_pure can clean up
-      state = EditorState.monitor_buffer(state, buf1)
-      state = EditorState.monitor_buffer(state, buf2)
-
-      # Close the active buffer
-      {new_state, effects} = EditorState.close_buffer_pure(state, buf2)
-
-      # buf2 should be removed, buf1 should become active
-      refute buf2 in new_state.workspace.buffers.list
-      assert buf1 in new_state.workspace.buffers.list
-      assert new_state.workspace.buffers.active == buf1
-
-      # Effects list should be empty (close_buffer_pure returns [])
-      assert effects == []
-
-      # Monitor ref should be cleaned up
-      refute Map.has_key?(new_state.buffer_monitors, buf2)
-    end
-
-    test "closes only buffer gracefully" do
-      state = base_state()
-      buf = state.workspace.buffers.active
-      state = EditorState.monitor_buffer(state, buf)
-
-      {new_state, effects} = EditorState.close_buffer_pure(state, buf)
-
-      assert new_state.workspace.buffers.list == []
-      assert new_state.workspace.buffers.active == nil
-      assert effects == []
-      refute Map.has_key?(new_state.buffer_monitors, buf)
-    end
-
-    test "closes inactive buffer without affecting active" do
-      state = base_state()
-      buf1 = state.workspace.buffers.active
-      buf2 = start_buffer("second")
-      buf3 = start_buffer("third")
-
-      state = EditorState.add_buffer(state, buf2)
-      state = EditorState.add_buffer(state, buf3)
-      state = EditorState.monitor_buffer(state, buf1)
-      state = EditorState.monitor_buffer(state, buf2)
-      state = EditorState.monitor_buffer(state, buf3)
-
-      # buf3 is active; close buf1 (inactive)
-      assert state.workspace.buffers.active == buf3
-
-      {new_state, _effects} = EditorState.close_buffer_pure(state, buf1)
-
-      # Active buffer should remain buf3
-      assert new_state.workspace.buffers.active == buf3
-      refute buf1 in new_state.workspace.buffers.list
-    end
-
-    test "clears special buffer slot when messages buffer dies" do
-      {:ok, msg_buf} = BufferProcess.start_link(content: "")
-
-      state = %EditorState{
-        port_manager: self(),
-        workspace: %WorkspaceState{
-          viewport: Viewport.new(24, 80),
-          editing: VimState.new(),
-          buffers: %Buffers{
-            active: msg_buf,
-            list: [msg_buf],
-            active_index: 0,
-            messages: msg_buf
-          }
-        }
-      }
-
-      state = EditorState.monitor_buffer(state, msg_buf)
-
-      {new_state, _effects} = EditorState.close_buffer_pure(state, msg_buf)
-
-      assert new_state.workspace.buffers.messages == nil
-    end
-  end
-
-  # ── add_buffer_pure/2 with Board shell (agent_chat content guard) ──────────────
-
-  describe "add_buffer_pure/2 with agent_chat content" do
-    test "preserves agent_chat window content when adding buffer" do
-      # This tests the A1 content-type guard in sync_active_window_buffer.
-      # When a window has {:agent_chat, _} content, adding a new buffer
-      # to the buffer pool should NOT overwrite the window's content type.
-      {:ok, agent_buf} = BufferProcess.start_link(content: "")
-      win_id = 1
-      agent_window = Window.new_agent_chat(win_id, agent_buf, 24, 80)
+    test "agent chat windows without tab bars keep their content when a file buffer is added" do
+      agent_buf = start_buffer("")
+      agent_window = Window.new_agent_chat(1, agent_buf, 24, 80)
 
       state = %EditorState{
         port_manager: self(),
@@ -498,145 +192,178 @@ defmodule MingaEditor.State.BufferLifecycleTest do
           editing: VimState.new(),
           buffers: %Buffers{active: agent_buf, list: [agent_buf], active_index: 0},
           windows: %Windows{
-            tree: WindowTree.new(win_id),
-            map: %{win_id => agent_window},
-            active: win_id,
-            next_id: win_id + 1
+            tree: WindowTree.new(1),
+            map: %{1 => agent_window},
+            active: 1,
+            next_id: 2
           }
         }
       }
 
-      # Confirm starting state: agent_chat content
-      window = Map.fetch!(state.workspace.windows.map, win_id)
-      assert Content.agent_chat?(window.content)
-
-      # Add a new buffer without a tab bar (exercises the no-tab-bar clause)
       file_buf = start_buffer("file content")
       {new_state, effects} = EditorState.add_buffer_pure(state, file_buf)
+      window = active_window(new_state)
 
-      # The buffer should be added and active
       assert file_buf in new_state.workspace.buffers.list
       assert new_state.workspace.buffers.active == file_buf
       assert {:monitor, file_buf} in effects
-
-      # But the window should still have agent_chat content because
-      # sync_active_window_buffer guards on content type
-      window = Map.fetch!(new_state.workspace.windows.map, win_id)
-
-      assert Content.agent_chat?(window.content),
-             "agent_chat window content should be preserved, got #{inspect(window.content)}"
-
-      assert window.buffer == agent_buf,
-             "window buffer pid should remain the agent buffer"
+      assert Content.agent_chat?(window.content)
+      assert window.buffer == agent_buf
     end
   end
 
-  # ── Inactive tab scrubbing on buffer death ──────────────────────────────────
+  describe "switch_buffer/2" do
+    test "open switches refresh active file tab context, while preview switches keep the original context" do
+      state = state_with_file_tab()
+      original_buf = state.workspace.buffers.active
+      other_buf = start_buffer("other")
+      state = with_buffer_pool(state, [original_buf, other_buf])
 
-  describe "close_buffer_pure/2 scrubs inactive tab snapshots" do
-    test "removes dead pid from inactive tab's context.buffers" do
-      # Tab A is active with buf_a; Tab B is inactive holding buf_b
+      opened = EditorState.switch_buffer(state, 1)
+      assert opened.workspace.buffers.active == other_buf
+
+      assert %Buffers{active: ^other_buf} =
+               TabBar.active(opened.shell_state.tab_bar).context.buffers
+
+      preview_buf = start_buffer("preview")
+
+      preview_state =
+        state
+        |> with_buffer_pool([original_buf, preview_buf])
+        |> EditorState.set_buffer_add_context(:preview)
+
+      previewed = EditorState.switch_buffer(preview_state, 1)
+      assert previewed.workspace.buffers.active == preview_buf
+      assert previewed.buffer_add_context == :open
+
+      assert %Buffers{active: ^original_buf} =
+               TabBar.active(previewed.shell_state.tab_bar).context.buffers
+    end
+  end
+
+  describe "close_buffer_pure/2" do
+    test "closing active, only, inactive, and special buffers updates buffers and monitor refs" do
+      state = base_state()
+      buf1 = state.workspace.buffers.active
+      buf2 = start_buffer("second")
+
+      state =
+        state
+        |> EditorState.add_buffer(buf2)
+        |> EditorState.monitor_buffer(buf1)
+        |> EditorState.monitor_buffer(buf2)
+
+      {closed_active, effects} = EditorState.close_buffer_pure(state, buf2)
+      assert effects == []
+      refute buf2 in closed_active.workspace.buffers.list
+      assert closed_active.workspace.buffers.active == buf1
+      refute Map.has_key?(closed_active.buffer_monitors, buf2)
+
+      buf3 = start_buffer("third")
+
+      inactive_state =
+        state
+        |> EditorState.add_buffer(buf3)
+        |> EditorState.monitor_buffer(buf3)
+
+      {closed_inactive, _effects} = EditorState.close_buffer_pure(inactive_state, buf1)
+      assert closed_inactive.workspace.buffers.active == buf3
+      refute buf1 in closed_inactive.workspace.buffers.list
+
+      only_state = base_state()
+      only_buf = only_state.workspace.buffers.active
+      only_state = EditorState.monitor_buffer(only_state, only_buf)
+      {closed_only, effects} = EditorState.close_buffer_pure(only_state, only_buf)
+      assert effects == []
+      assert closed_only.workspace.buffers.list == []
+      assert closed_only.workspace.buffers.active == nil
+      refute Map.has_key?(closed_only.buffer_monitors, only_buf)
+
+      msg_buf = start_buffer("")
+
+      special_state =
+        state_for_buffer(msg_buf, messages: msg_buf) |> EditorState.monitor_buffer(msg_buf)
+
+      {closed_special, _effects} = EditorState.close_buffer_pure(special_state, msg_buf)
+      assert closed_special.workspace.buffers.messages == nil
+    end
+
+    test "closing buffers scrubs inactive tab snapshots, including tabs whose only buffer died" do
       buf_a = start_buffer("file A")
       buf_b = start_buffer("file B")
 
-      win_id = 1
-      window = Window.new(win_id, buf_a, 24, 80)
+      state =
+        state_for_buffer(buf_a, list: [buf_a, buf_b])
+        |> EditorState.monitor_buffers([buf_a, buf_b])
 
-      state = %EditorState{
-        port_manager: self(),
-        workspace: %WorkspaceState{
-          viewport: Viewport.new(24, 80),
-          editing: VimState.new(),
-          buffers: %Buffers{active: buf_a, list: [buf_a, buf_b], active_index: 0},
-          windows: %Windows{
-            tree: WindowTree.new(win_id),
-            map: %{win_id => window},
-            active: win_id,
-            next_id: win_id + 1
-          }
-        }
-      }
+      {state, tab_b} = state_with_inactive_tab_buffer(state, buf_b)
 
-      state = EditorState.monitor_buffer(state, buf_a)
-      state = EditorState.monitor_buffer(state, buf_b)
-
-      # Set up two tabs: Tab A (active, id=1), Tab B (inactive, id=2)
-      tab_a = Tab.new_file(1, "a.ex")
-      {tb, tab_b} = TabBar.insert(TabBar.new(tab_a), :file, "b.ex")
-
-      # Snapshot Tab B with buf_b as its active buffer
-      tab_b_context = %{
-        buffers: %Buffers{active: buf_b, list: [buf_b], active_index: 0},
-        editing: VimState.new(),
-        viewport: Viewport.new(24, 80)
-      }
-
-      tb = TabBar.update_context(tb, tab_b.id, tab_b_context)
-
-      # Snapshot Tab A (active) with current workspace
-      context_a = EditorState.snapshot_tab_context(EditorState.set_tab_bar(state, tb))
-      tb = TabBar.update_context(tb, 1, context_a)
-      state = EditorState.set_tab_bar(state, tb)
-
-      # Kill buf_b via close_buffer_pure
       {new_state, _effects} = EditorState.close_buffer_pure(state, buf_b)
-
-      # AC1 + AC2: Tab B's snapshot should be scrubbed
-      tb_after = EditorState.tab_bar(new_state)
-      tab_b_after = TabBar.get(tb_after, tab_b.id)
-
+      tab_b_after = TabBar.get(EditorState.tab_bar(new_state), tab_b.id)
       refute buf_b in tab_b_after.context.buffers.list
       assert tab_b_after.context.buffers.active != buf_b
 
-      # AC3: Restoring Tab B's context produces a usable workspace
       restored_ws = WorkspaceState.restore_tab_context(new_state.workspace, tab_b_after.context)
       refute buf_b in restored_ws.buffers.list
       assert restored_ws.buffers.active != buf_b
+
+      only = start_buffer("only buffer")
+      only_state = state_for_buffer(only) |> EditorState.monitor_buffer(only)
+      {only_state, only_tab} = state_with_inactive_tab_buffer(only_state, only)
+      {closed_only, _effects} = EditorState.close_buffer_pure(only_state, only)
+      only_tab_after = TabBar.get(EditorState.tab_bar(closed_only), only_tab.id)
+      assert only_tab_after.context.buffers.list == []
+      assert only_tab_after.context.buffers.active == nil
     end
+  end
 
-    test "handles tab whose only buffer died (empty list after scrub)" do
-      buf_only = start_buffer("only buffer")
-      win_id = 1
-      window = Window.new(win_id, buf_only, 24, 80)
+  defp state_for_buffer(buf, opts \\ []) do
+    buffers = %Buffers{
+      active: buf,
+      list: Keyword.get(opts, :list, [buf]),
+      active_index: 0,
+      messages: Keyword.get(opts, :messages)
+    }
 
-      state = %EditorState{
-        port_manager: self(),
-        workspace: %WorkspaceState{
-          viewport: Viewport.new(24, 80),
-          editing: VimState.new(),
-          buffers: %Buffers{active: buf_only, list: [buf_only], active_index: 0},
-          windows: %Windows{
-            tree: WindowTree.new(win_id),
-            map: %{win_id => window},
-            active: win_id,
-            next_id: win_id + 1
-          }
+    %EditorState{
+      port_manager: self(),
+      workspace: %WorkspaceState{
+        viewport: Viewport.new(24, 80),
+        editing: VimState.new(),
+        buffers: buffers,
+        windows: %Windows{
+          tree: WindowTree.new(1),
+          map: %{1 => Window.new(1, buf, 24, 80)},
+          active: 1,
+          next_id: 2
         }
       }
+    }
+  end
 
-      state = EditorState.monitor_buffer(state, buf_only)
+  defp with_buffer_pool(state, buffers) do
+    EditorState.update_workspace(state, fn workspace ->
+      %Buffers{} = current = workspace.buffers
+      %{workspace | buffers: %{current | list: buffers}}
+    end)
+  end
 
-      tab_a = Tab.new_file(1, "a.ex")
-      {tb, tab_b} = TabBar.insert(TabBar.new(tab_a), :file, "b.ex")
+  defp active_window(state),
+    do: Map.fetch!(state.workspace.windows.map, state.workspace.windows.active)
 
-      tab_b_context = %{
-        buffers: %Buffers{active: buf_only, list: [buf_only], active_index: 0},
-        editing: VimState.new(),
-        viewport: Viewport.new(24, 80)
-      }
+  defp state_with_inactive_tab_buffer(state, inactive_buf) do
+    tab_a = Tab.new_file(1, "a.ex")
+    {tb, tab_b} = TabBar.insert(TabBar.new(tab_a), :file, "b.ex")
 
-      tb = TabBar.update_context(tb, tab_b.id, tab_b_context)
-      context_a = EditorState.snapshot_tab_context(EditorState.set_tab_bar(state, tb))
-      tb = TabBar.update_context(tb, 1, context_a)
-      state = EditorState.set_tab_bar(state, tb)
+    tab_b_context = %{
+      buffers: %Buffers{active: inactive_buf, list: [inactive_buf], active_index: 0},
+      editing: VimState.new(),
+      viewport: Viewport.new(24, 80)
+    }
 
-      {new_state, _effects} = EditorState.close_buffer_pure(state, buf_only)
-
-      tb_after = EditorState.tab_bar(new_state)
-      tab_b_after = TabBar.get(tb_after, tab_b.id)
-
-      assert tab_b_after.context.buffers.list == []
-      assert tab_b_after.context.buffers.active == nil
-    end
+    tb = TabBar.update_context(tb, tab_b.id, tab_b_context)
+    state_with_tb = EditorState.set_tab_bar(state, tb)
+    tb = TabBar.update_context(tb, 1, EditorState.snapshot_tab_context(state_with_tb))
+    {EditorState.set_tab_bar(state, tb), tab_b}
   end
 end

--- a/test/minga_editor/state_test.exs
+++ b/test/minga_editor/state_test.exs
@@ -13,8 +13,6 @@ defmodule MingaEditor.StateTest do
   alias MingaEditor.Window.Content
   alias MingaEditor.WindowTree
 
-  # ── Helpers ──────────────────────────────────────────────────────────────────
-
   defp new_state do
     %EditorState{
       port_manager: nil,
@@ -25,7 +23,7 @@ defmodule MingaEditor.StateTest do
     }
   end
 
-  defp start_buffer(content \\ "hello") do
+  defp start_buffer(content) do
     {:ok, pid} = BufferProcess.start_link(content: content)
     pid
   end
@@ -45,425 +43,130 @@ defmodule MingaEditor.StateTest do
     tree = WindowTree.new(1)
     window = Window.new(1, buf, 24, 80)
 
-    %{
-      state
-      | workspace: %{
-          state.workspace
-          | windows: %Windows{tree: tree, map: %{1 => window}, active: 1, next_id: 2}
-        }
-    }
+    put_in(state.workspace.windows, %Windows{
+      tree: tree,
+      map: %{1 => window},
+      active: 1,
+      next_id: 2
+    })
   end
 
-  # ── add_buffer/2 ─────────────────────────────────────────────────────────────
-
-  describe "add_buffer/2" do
-    test "adds buffer and makes it active" do
-      {state, _buf1} = state_with_buffer()
-      buf2 = start_buffer("world")
-
-      new_state = EditorState.add_buffer(state, buf2)
-
-      assert new_state.workspace.buffers.active == buf2
-      assert length(new_state.workspace.buffers.list) == 2
-      assert new_state.workspace.buffers.active_index == 1
-    end
-
-    test "syncs the active window's buffer reference" do
-      {state, _buf1} = state_with_buffer()
-      buf2 = start_buffer("world")
-
-      new_state = EditorState.add_buffer(state, buf2)
-
-      window = Map.fetch!(new_state.workspace.windows.map, new_state.workspace.windows.active)
-      assert window.buffer == buf2
-    end
-
-    test "syncs window buffer in split mode" do
-      {state, _buf1} = state_with_buffer()
-
-      # Create a split: window 1 (active) and window 2
-      {:ok, tree} = WindowTree.split(state.workspace.windows.tree, 1, :vertical, 2)
-      win2 = Window.new(2, state.workspace.buffers.active, 24, 40)
-      ws = state.workspace.windows
-
-      state =
-        put_in(state.workspace.windows, %{
-          ws
-          | tree: tree,
-            map: Map.put(ws.map, 2, win2),
-            next_id: 3
-        })
-
-      buf2 = start_buffer("new file")
-      new_state = EditorState.add_buffer(state, buf2)
-
-      # Active window (1) should point to new buffer
-      assert Map.fetch!(new_state.workspace.windows.map, 1).buffer == buf2
-      # Inactive window (2) should still point to old buffer
-      assert Map.fetch!(new_state.workspace.windows.map, 2).buffer != buf2
-    end
-
-    test "works without windows initialized" do
-      state = new_state()
-      buf = start_buffer()
-      new_state = EditorState.add_buffer(state, buf)
-
-      assert new_state.workspace.buffers.active == buf
-    end
-  end
-
-  # ── switch_buffer/2 ──────────────────────────────────────────────────────────
-
-  describe "switch_buffer/2" do
-    test "switches to existing buffer by index" do
+  describe "buffer and window selection" do
+    test "add_buffer and switch_buffer sync the active window while preserving inactive split windows" do
       {state, buf1} = state_with_buffer()
       buf2 = start_buffer("world")
-      state = EditorState.add_buffer(state, buf2)
 
-      new_state = EditorState.switch_buffer(state, 0)
+      added = EditorState.add_buffer(state, buf2)
+      assert added.workspace.buffers.active == buf2
+      assert added.workspace.buffers.active_index == 1
+      assert added.workspace.buffers.list == [buf1, buf2]
+      assert active_window(added).buffer == buf2
 
-      assert new_state.workspace.buffers.active == buf1
-      assert new_state.workspace.buffers.active_index == 0
+      switched = EditorState.switch_buffer(added, 0)
+      assert switched.workspace.buffers.active == buf1
+      assert switched.workspace.buffers.active_index == 0
+      assert active_window(switched).buffer == buf1
+
+      split_state = added |> with_split_window(2, buf2)
+      split_switched = EditorState.switch_buffer(split_state, 0)
+      assert Map.fetch!(split_switched.workspace.windows.map, 1).buffer == buf1
+      assert Map.fetch!(split_switched.workspace.windows.map, 2).buffer == buf2
+
+      split_added = EditorState.add_buffer(split_state, start_buffer("new file"))
+
+      assert Map.fetch!(split_added.workspace.windows.map, 1).buffer ==
+               split_added.workspace.buffers.active
+
+      assert Map.fetch!(split_added.workspace.windows.map, 2).buffer == buf2
+
+      no_window = EditorState.add_buffer(new_state(), start_buffer("no window"))
+      assert is_pid(no_window.workspace.buffers.active)
     end
 
-    test "syncs active window's buffer reference on switch" do
-      {state, buf1} = state_with_buffer()
-      buf2 = start_buffer("world")
-      state = EditorState.add_buffer(state, buf2)
+    test "focus_window and sync_active_window_cursor snapshot and restore buffer cursors" do
+      {state, buf} = state_with_buffer("hello\nworld\nfoo")
+      BufferProcess.move_to(buf, {2, 0})
 
-      # Switch back to first buffer
-      new_state = EditorState.switch_buffer(state, 0)
+      state = state |> with_split_window(2, buf, second_cursor: {0, 0})
+      state = EditorState.sync_active_window_cursor(state)
+      assert Map.fetch!(state.workspace.windows.map, 1).cursor == {2, 0}
 
-      window = Map.fetch!(new_state.workspace.windows.map, new_state.workspace.windows.active)
-      assert window.buffer == buf1
-    end
-
-    test "syncs window buffer in split mode on switch" do
-      {state, buf1} = state_with_buffer()
-      buf2 = start_buffer("world")
-      state = EditorState.add_buffer(state, buf2)
-
-      # Create a split: window 1 (active, buf2) and window 2 (buf2)
-      {:ok, tree} = WindowTree.split(state.workspace.windows.tree, 1, :vertical, 2)
-      win2 = Window.new(2, buf2, 24, 40)
-      ws = state.workspace.windows
-
-      state =
-        put_in(state.workspace.windows, %{
-          ws
-          | tree: tree,
-            map: Map.put(ws.map, 2, win2),
-            next_id: 3
-        })
-
-      # Switch active window to buf1
-      new_state = EditorState.switch_buffer(state, 0)
-
-      assert Map.fetch!(new_state.workspace.windows.map, 1).buffer == buf1
-      # Window 2 unchanged
-      assert Map.fetch!(new_state.workspace.windows.map, 2).buffer == buf2
-    end
-  end
-
-  # ── focus_window/2 ───────────────────────────────────────────────────────────
-
-  describe "focus_window/2" do
-    test "switches active window and restores cursor" do
-      {state, buf1} = state_with_buffer("hello\nworld\nfoo")
-      BufferProcess.move_to(buf1, {2, 0})
-
-      # Split: window 1 at {2,0}, window 2 gets copy
-      {:ok, tree} = WindowTree.split(state.workspace.windows.tree, 1, :vertical, 2)
-      cursor = BufferProcess.cursor(buf1)
-      win1 = %{Map.fetch!(state.workspace.windows.map, 1) | cursor: cursor}
-      win2 = Window.new(2, buf1, 24, 40, {0, 0})
-
-      state =
-        put_in(state.workspace.windows, %Windows{
-          tree: tree,
-          map: %{1 => win1, 2 => win2},
-          active: 1,
-          next_id: 3
-        })
-
-      # Move cursor in active window to {2,0}
-      BufferProcess.move_to(buf1, {2, 0})
-
-      # Focus window 2 (which has stored cursor {0,0})
-      new_state = EditorState.focus_window(state, 2)
-
-      assert new_state.workspace.windows.active == 2
-      assert BufferProcess.cursor(buf1) == {0, 0}
-    end
-
-    test "saves outgoing window's cursor" do
-      {state, buf1} = state_with_buffer("hello\nworld\nfoo")
-
-      {:ok, tree} = WindowTree.split(state.workspace.windows.tree, 1, :vertical, 2)
-      win2 = Window.new(2, buf1, 24, 40)
-      ws = state.workspace.windows
-
-      state =
-        put_in(state.workspace.windows, %{
-          ws
-          | tree: tree,
-            map: Map.put(ws.map, 2, win2),
-            next_id: 3
-        })
-
-      # Move cursor to {1, 3}
-      BufferProcess.move_to(buf1, {1, 3})
-
-      new_state = EditorState.focus_window(state, 2)
-
-      # Window 1 should have saved cursor {1, 3}
-      assert Map.fetch!(new_state.workspace.windows.map, 1).cursor == {1, 3}
-    end
-
-    test "no-op when focusing already active window" do
-      {state, _buf} = state_with_buffer()
-      new_state = EditorState.focus_window(state, 1)
-      assert new_state == state
-    end
-
-    test "no-op when buffer is nil" do
-      state = new_state()
-      new_state = EditorState.focus_window(state, 2)
-      assert new_state == state
-    end
-  end
-
-  # ── sync_active_window_cursor/1 ─────────────────────────────────────────────
-
-  describe "sync_active_window_cursor/1" do
-    test "snapshots buffer cursor into active window" do
-      {state, buf} = state_with_buffer("hello\nworld")
       BufferProcess.move_to(buf, {1, 3})
+      focused = EditorState.focus_window(state, 2)
+      assert focused.workspace.windows.active == 2
+      assert BufferProcess.cursor(buf) == {0, 0}
+      assert Map.fetch!(focused.workspace.windows.map, 1).cursor == {1, 3}
 
-      new_state = EditorState.sync_active_window_cursor(state)
-
-      window = Map.fetch!(new_state.workspace.windows.map, 1)
-      assert window.cursor == {1, 3}
-    end
-
-    test "no-op when buffer is nil" do
-      state = new_state()
-      assert EditorState.sync_active_window_cursor(state) == state
+      assert EditorState.focus_window(focused, 2) == focused
+      assert EditorState.focus_window(new_state(), 2) == new_state()
+      assert EditorState.sync_active_window_cursor(new_state()) == new_state()
     end
   end
 
-  # ── screen_rect/1 ───────────────────────────────────────────────────────────
-
-  describe "screen_rect/1" do
-    test "excludes one row for minibuffer" do
-      {state, _} = state_with_buffer()
+  describe "window content synchronization" do
+    test "screen rect and buffer sync update buffer windows without rewriting agent chat content" do
+      {state, buf1} = state_with_buffer("hello")
       assert EditorState.screen_rect(state) == {0, 0, 80, 23}
-    end
-  end
 
-  # ── sync_active_window_buffer/1 — window.content field ───────────────────────
+      unchanged = EditorState.sync_active_window_buffer(state)
+      assert active_window(unchanged).buffer == buf1
+      assert active_window(unchanged).content == active_window(state).content
 
-  describe "sync_active_window_buffer/1 content field" do
-    test "updates window.content to {:buffer, new_pid} when buffer changes" do
-      {state, _buf1} = state_with_buffer("hello")
       buf2 = start_buffer("world")
+      state = put_in(state.workspace.buffers, Buffers.add(state.workspace.buffers, buf2))
+      synced = EditorState.sync_active_window_buffer(state)
+      assert active_window(synced).buffer == buf2
+      assert Content.buffer?(active_window(synced).content)
+      assert Content.buffer_pid(active_window(synced).content) == buf2
 
-      state = %{
-        state
-        | workspace: %{state.workspace | buffers: Buffers.add(state.workspace.buffers, buf2)}
-      }
-
-      new_state = EditorState.sync_active_window_buffer(state)
-
-      window = Map.fetch!(new_state.workspace.windows.map, new_state.workspace.windows.active)
-      assert window.buffer == buf2
-      assert Content.buffer?(window.content), "content should be a :buffer reference"
-
-      assert Content.buffer_pid(window.content) == buf2,
-             "content should reference the new buffer pid, " <>
-               "got #{inspect(window.content)}"
-    end
-
-    test "preserves agent_chat content when buffer changes" do
-      agent_buf = start_buffer("")
+      {agent_state, agent_buf} = state_with_agent_tab()
       file_buf = start_buffer("defmodule Foo, do: :ok")
 
-      # Build state with an agent_chat window
-      state =
-        %{
-          new_state()
-          | workspace: %{
-              new_state().workspace
-              | buffers: %Buffers{list: [agent_buf], active_index: 0, active: agent_buf}
-            }
-        }
+      agent_state =
+        put_in(
+          agent_state.workspace.buffers,
+          Buffers.add(agent_state.workspace.buffers, file_buf)
+        )
 
-      tree = WindowTree.new(1)
-      agent_window = Window.new_agent_chat(1, agent_buf, 24, 80)
-
-      state =
-        put_in(state.workspace.windows, %Windows{
-          tree: tree,
-          map: %{1 => agent_window},
-          active: 1,
-          next_id: 2
-        })
-
-      # Confirm starting state: agent_chat content
-      window = Map.fetch!(state.workspace.windows.map, 1)
-      assert Content.agent_chat?(window.content)
-
-      # Switch active buffer to the file buffer
-      state = %{
-        state
-        | workspace: %{state.workspace | buffers: Buffers.add(state.workspace.buffers, file_buf)}
-      }
-
-      # sync_active_window_buffer should NOT overwrite agent_chat content
-      new_state = EditorState.sync_active_window_buffer(state)
-
-      window = Map.fetch!(new_state.workspace.windows.map, 1)
-      assert window.buffer == agent_buf
-
-      assert Content.agent_chat?(window.content),
-             "content should remain agent_chat, got #{inspect(window.content)}"
+      synced_agent = EditorState.sync_active_window_buffer(agent_state)
+      assert active_window(synced_agent).buffer == agent_buf
+      assert Content.agent_chat?(active_window(synced_agent).content)
     end
 
-    test "no-op when buffer has not changed" do
-      {state, buf1} = state_with_buffer("hello")
-      window_before = Map.fetch!(state.workspace.windows.map, state.workspace.windows.active)
-
-      new_state = EditorState.sync_active_window_buffer(state)
-
-      window_after =
-        Map.fetch!(new_state.workspace.windows.map, new_state.workspace.windows.active)
-
-      assert window_after.buffer == buf1
-      assert window_after.content == window_before.content
-    end
-  end
-
-  # ── add_buffer/2 from agent tab ──────────────────────────────────────────────
-
-  describe "add_buffer/2 from agent tab" do
-    setup do
-      agent_buf = start_buffer("")
-
-      state =
-        %{
-          new_state()
-          | workspace: %{
-              new_state().workspace
-              | buffers: %Buffers{list: [agent_buf], active_index: 0, active: agent_buf}
-            }
-        }
-
-      tree = WindowTree.new(1)
-      agent_window = Window.new_agent_chat(1, agent_buf, 24, 80)
-
-      state =
-        put_in(state.workspace.windows, %Windows{
-          tree: tree,
-          map: %{1 => agent_window},
-          active: 1,
-          next_id: 2
-        })
-
-      state = put_in(state.workspace.keymap_scope, :agent)
-      state = EditorState.set_tab_bar(state, TabBar.new(Tab.new_agent(1, "Agent")))
-
-      %{state: state, agent_buf: agent_buf}
-    end
-
-    test "creates a file tab and makes it active", %{state: state} do
+    test "add_buffer from an agent tab creates an editor file tab and buffer content snapshot" do
+      {state, _agent_buf} = state_with_agent_tab()
       file_buf = start_buffer("file content")
       new_state = EditorState.add_buffer(state, file_buf)
-
       active_tab = TabBar.active(new_state.shell_state.tab_bar)
+      active_window = active_window(new_state)
+      tab_window = active_tab.context.windows.map[active_tab.context.windows.active]
+
       assert active_tab.kind == :file
-    end
-
-    test "switches keymap_scope from :agent to :editor", %{state: state} do
-      file_buf = start_buffer("file content")
-      new_state = EditorState.add_buffer(state, file_buf)
-
       assert new_state.workspace.keymap_scope == :editor
-    end
-
-    test "active window buffer points to the new file buffer", %{state: state} do
-      file_buf = start_buffer("file content")
-      new_state = EditorState.add_buffer(state, file_buf)
-
-      window = Map.fetch!(new_state.workspace.windows.map, new_state.workspace.windows.active)
-      assert window.buffer == file_buf
-    end
-
-    test "active window content is {:buffer, _}, not {:agent_chat, _}", %{state: state} do
-      file_buf = start_buffer("file content")
-      new_state = EditorState.add_buffer(state, file_buf)
-
-      window = Map.fetch!(new_state.workspace.windows.map, new_state.workspace.windows.active)
-
-      assert Content.buffer?(window.content),
-             "window content should be {:buffer, _} after opening file from agent tab, " <>
-               "got #{inspect(window.content)}"
-
-      refute Content.agent_chat?(window.content),
-             "window content should not be :agent_chat after opening file"
-    end
-
-    test "new file tab context has correct window content type", %{state: state} do
-      file_buf = start_buffer("file content")
-      new_state = EditorState.add_buffer(state, file_buf)
-
-      # The new file tab's snapshotted context should also have the correct
-      # window content type, so switching tabs restores it properly.
-      active_tab = TabBar.active(new_state.shell_state.tab_bar)
-      tab_windows = active_tab.context.windows
-
-      if tab_windows do
-        active_win_id = tab_windows.active
-        tab_window = Map.get(tab_windows.map, active_win_id)
-
-        if tab_window do
-          assert Content.buffer?(tab_window.content),
-                 "tab context window content should be {:buffer, _}, " <>
-                   "got #{inspect(tab_window.content)}"
-        end
-      end
+      assert active_window.buffer == file_buf
+      assert Content.buffer?(active_window.content)
+      refute Content.agent_chat?(active_window.content)
+      assert Content.buffer?(tab_window.content)
     end
   end
 
   describe "buffer monitoring" do
-    test "monitor_buffer/2 stores a monitor ref for the pid" do
-      buf = start_buffer()
-      state = new_state() |> EditorState.monitor_buffer(buf)
-
-      assert Map.has_key?(state.buffer_monitors, buf)
-      assert is_reference(state.buffer_monitors[buf])
-    end
-
-    test "monitor_buffer/2 is idempotent" do
-      buf = start_buffer()
-      state = new_state() |> EditorState.monitor_buffer(buf)
-      ref = state.buffer_monitors[buf]
-
-      state2 = EditorState.monitor_buffer(state, buf)
-      assert state2.buffer_monitors[buf] == ref
-      assert map_size(state2.buffer_monitors) == 1
-    end
-
-    test "monitor_buffers/2 monitors multiple pids" do
+    test "monitor helpers store idempotent refs for one or many buffers" do
       buf1 = start_buffer("one")
       buf2 = start_buffer("two")
-      state = new_state() |> EditorState.monitor_buffers([buf1, buf2])
 
-      assert map_size(state.buffer_monitors) == 2
-      assert Map.has_key?(state.buffer_monitors, buf1)
-      assert Map.has_key?(state.buffer_monitors, buf2)
+      state = new_state() |> EditorState.monitor_buffer(buf1)
+      assert is_reference(state.buffer_monitors[buf1])
+
+      state2 = EditorState.monitor_buffer(state, buf1)
+      assert state2.buffer_monitors[buf1] == state.buffer_monitors[buf1]
+      assert map_size(state2.buffer_monitors) == 1
+
+      state3 = new_state() |> EditorState.monitor_buffers([buf1, buf2])
+      assert Map.keys(state3.buffer_monitors) |> Enum.sort() == Enum.sort([buf1, buf2])
     end
 
-    test "remove_dead_buffer/2 removes pid from buffer list" do
+    test "remove_dead_buffer cleans lists, active buffer, monitors, and special slots" do
       buf1 = start_buffer("one")
       buf2 = start_buffer("two")
 
@@ -474,48 +177,73 @@ defmodule MingaEditor.StateTest do
         |> EditorState.monitor_buffer(buf1)
         |> EditorState.monitor_buffer(buf2)
 
-      state = EditorState.remove_dead_buffer(state, buf1)
+      removed_inactive = EditorState.remove_dead_buffer(state, buf1)
+      refute buf1 in removed_inactive.workspace.buffers.list
+      assert buf2 in removed_inactive.workspace.buffers.list
+      refute Map.has_key?(removed_inactive.buffer_monitors, buf1)
+      assert Map.has_key?(removed_inactive.buffer_monitors, buf2)
 
-      refute buf1 in state.workspace.buffers.list
-      assert buf2 in state.workspace.buffers.list
-      refute Map.has_key?(state.buffer_monitors, buf1)
-      assert Map.has_key?(state.buffer_monitors, buf2)
-    end
+      removed_active = EditorState.remove_dead_buffer(state, buf2)
+      assert removed_active.workspace.buffers.active == buf1
+      assert removed_active.workspace.buffers.list == [buf1]
 
-    test "remove_dead_buffer/2 switches active to next buffer" do
-      buf1 = start_buffer("one")
-      buf2 = start_buffer("two")
+      messages = start_buffer("messages")
 
-      state =
-        new_state()
-        |> EditorState.add_buffer(buf1)
-        |> EditorState.add_buffer(buf2)
-
-      # buf2 is active (last added)
-      assert state.workspace.buffers.active == buf2
-
-      state = EditorState.remove_dead_buffer(state, buf2)
-
-      assert state.workspace.buffers.active == buf1
-      assert state.workspace.buffers.list == [buf1]
-    end
-
-    test "remove_dead_buffer/2 clears special buffer slot" do
-      buf = start_buffer()
-
-      state =
+      special_state =
         put_in(new_state().workspace.buffers, %Buffers{
-          messages: buf,
-          list: [buf],
-          active: buf,
+          messages: messages,
+          list: [messages],
+          active: messages,
           active_index: 0
         })
+        |> EditorState.monitor_buffer(messages)
+        |> EditorState.remove_dead_buffer(messages)
 
-      state = EditorState.monitor_buffer(state, buf)
-      state = EditorState.remove_dead_buffer(state, buf)
-
-      assert state.workspace.buffers.messages == nil
-      assert state.workspace.buffers.list == []
+      assert special_state.workspace.buffers.messages == nil
+      assert special_state.workspace.buffers.list == []
     end
+  end
+
+  defp active_window(state) do
+    Map.fetch!(state.workspace.windows.map, state.workspace.windows.active)
+  end
+
+  defp with_split_window(state, id, buffer, opts \\ []) do
+    {:ok, tree} = WindowTree.split(state.workspace.windows.tree, 1, :vertical, id)
+    cursor = Keyword.get(opts, :second_cursor, {0, 0})
+    win2 = Window.new(id, buffer, 24, 40, cursor)
+    windows = state.workspace.windows
+
+    put_in(state.workspace.windows, %{
+      windows
+      | tree: tree,
+        map: Map.put(windows.map, id, win2),
+        next_id: id + 1
+    })
+  end
+
+  defp state_with_agent_tab do
+    agent_buf = start_buffer("")
+
+    state =
+      put_in(new_state().workspace.buffers, %Buffers{
+        list: [agent_buf],
+        active_index: 0,
+        active: agent_buf
+      })
+
+    agent_window = Window.new_agent_chat(1, agent_buf, 24, 80)
+
+    state =
+      put_in(state.workspace.windows, %Windows{
+        tree: WindowTree.new(1),
+        map: %{1 => agent_window},
+        active: 1,
+        next_id: 2
+      })
+      |> put_in([Access.key!(:workspace), Access.key!(:keymap_scope)], :agent)
+      |> EditorState.set_tab_bar(TabBar.new(Tab.new_agent(1, "Agent")))
+
+    {state, agent_buf}
   end
 end

--- a/test/minga_editor/ui/highlight_test.exs
+++ b/test/minga_editor/ui/highlight_test.exs
@@ -4,11 +4,9 @@ defmodule Minga.HighlightTest do
   alias Minga.Core.Face
   alias MingaEditor.UI.Highlight
 
-  # Helper: asserts styled segments match expected {text, face_attrs} pairs.
-  # Only checks face attributes that are explicitly specified in expected.
   defp assert_segments(result, expected) do
     assert length(result) == length(expected),
-           "expected #{length(expected)} segments, got #{length(result)}: #{inspect(Enum.map(result, fn {t, _} -> t end))}"
+           "expected #{length(expected)} segments, got #{length(result)}: #{inspect(Enum.map(result, fn {text, _face} -> text end))}"
 
     Enum.zip(result, expected)
     |> Enum.each(fn {{actual_text, actual_face}, {expected_text, expected_attrs}} ->
@@ -22,8 +20,6 @@ defmodule Minga.HighlightTest do
     end)
   end
 
-  # Helper: builds a %Highlight{} with a face registry from a theme map.
-  # Replaces manual struct construction in tests that need styles_for_line.
   defp highlight_with(attrs) do
     theme = Keyword.get(attrs, :theme, %{})
 
@@ -36,106 +32,72 @@ defmodule Minga.HighlightTest do
     }
   end
 
-  describe "new/0" do
-    test "creates empty state with default theme" do
+  describe "state construction and versioning" do
+    test "new, custom themes, capture names, and span versions keep their public contracts" do
       hl = Highlight.new()
       assert hl.version == 0
       assert hl.spans == {}
       assert hl.capture_names == {}
       assert is_map(hl.theme)
       assert map_size(hl.theme) > 0
-    end
-  end
 
-  describe "new/1" do
-    test "creates empty state with custom theme" do
       theme = %{"keyword" => [fg: 0xFF0000]}
-      hl = Highlight.new(theme)
-      assert hl.theme == theme
-    end
-  end
+      assert Highlight.new(theme).theme == theme
 
-  describe "put_names/2" do
-    test "stores capture names" do
-      hl = Highlight.new() |> Highlight.put_names(["keyword", "string"])
-      assert hl.capture_names == {"keyword", "string"}
-    end
-  end
+      assert Highlight.new()
+             |> Highlight.put_names(["keyword", "string"])
+             |> Map.fetch!(:capture_names) == {"keyword", "string"}
 
-  describe "put_spans/3" do
-    test "stores spans with matching version" do
-      spans = [%{start_byte: 0, end_byte: 5, capture_id: 0}]
-      hl = Highlight.new() |> Highlight.put_spans(1, spans)
-      assert hl.version == 1
-      assert hl.spans == List.to_tuple(spans)
-    end
-
-    test "rejects spans with older version" do
       spans1 = [%{start_byte: 0, end_byte: 5, capture_id: 0}]
       spans2 = [%{start_byte: 0, end_byte: 3, capture_id: 1}]
 
-      hl =
-        Highlight.new()
-        |> Highlight.put_spans(5, spans1)
-        |> Highlight.put_spans(3, spans2)
+      stored = Highlight.new() |> Highlight.put_spans(1, spans1)
+      assert stored.version == 1
+      assert stored.spans == List.to_tuple(spans1)
 
-      assert hl.version == 5
-      assert hl.spans == List.to_tuple(spans1)
+      stale = stored |> Highlight.put_spans(5, spans1) |> Highlight.put_spans(3, spans2)
+      assert stale.version == 5
+      assert stale.spans == List.to_tuple(spans1)
+
+      equal = Highlight.new() |> Highlight.put_spans(5, spans1) |> Highlight.put_spans(5, spans2)
+      assert equal.spans == List.to_tuple(spans2)
     end
 
-    test "accepts spans with equal version" do
-      spans1 = [%{start_byte: 0, end_byte: 5, capture_id: 0}]
-      spans2 = [%{start_byte: 0, end_byte: 3, capture_id: 1}]
-
-      hl =
-        Highlight.new()
-        |> Highlight.put_spans(5, spans1)
-        |> Highlight.put_spans(5, spans2)
-
-      assert hl.spans == List.to_tuple(spans2)
-    end
-  end
-
-  describe "byte_offset_for_line/2" do
-    test "first line starts at 0" do
+    test "line byte offsets count newlines and unicode bytes" do
       assert Highlight.byte_offset_for_line(["hello", "world"], 0) == 0
-    end
-
-    test "second line accounts for first line + newline" do
       assert Highlight.byte_offset_for_line(["hello", "world"], 1) == 6
-    end
-
-    test "third line" do
       assert Highlight.byte_offset_for_line(["ab", "cde", "f"], 2) == 7
-    end
-
-    test "unicode lines use byte_size not string length" do
-      # "café" is 5 bytes (é = 2 bytes)
       assert Highlight.byte_offset_for_line(["café", "x"], 1) == 6
     end
   end
 
   describe "styles_for_line/3" do
-    test "empty spans returns whole line unstyled" do
-      hl = Highlight.new()
-      result = Highlight.styles_for_line(hl, "hello world", 0)
-      assert [{text, %Face{}}] = result
-      assert text == "hello world"
-    end
+    test "empty or non-overlapping input returns unstyled or empty segments" do
+      assert_segments(Highlight.styles_for_line(Highlight.new(), "hello world", 0), [
+        {"hello world", []}
+      ])
 
-    test "empty line returns no segments" do
-      hl =
+      with_span =
         highlight_with(
           spans: [%{start_byte: 0, end_byte: 10, capture_id: 0}],
           capture_names: ["keyword"],
           theme: %{"keyword" => [fg: 0xFF0000]}
         )
 
-      assert Highlight.styles_for_line(hl, "", 5) == []
+      assert Highlight.styles_for_line(with_span, "", 5) == []
+
+      excluded =
+        highlight_with(
+          spans: [%{start_byte: 100, end_byte: 110, capture_id: 0}],
+          capture_names: ["keyword"],
+          theme: %{"keyword" => [fg: 0xFF0000]}
+        )
+
+      assert_segments(Highlight.styles_for_line(excluded, "hello", 0), [{"hello", []}])
     end
 
-    test "mismatched spans on a Unicode line preserve valid text" do
-      hl =
+    test "unicode boundaries preserve valid text and style only complete characters" do
+      mismatched =
         highlight_with(
           spans: [
             %{start_byte: 2, end_byte: 5, capture_id: 0},
@@ -146,152 +108,122 @@ defmodule Minga.HighlightTest do
         )
 
       line = "# ── Server Callbacks ──────"
-      result = Highlight.styles_for_line(hl, line, 0)
-      all_text = Enum.map_join(result, fn {text, _style} -> text end)
+      text = Highlight.styles_for_line(mismatched, line, 0) |> joined_text()
+      assert String.valid?(text)
+      assert text == line
 
-      assert String.valid?(all_text)
-      assert all_text == line
-    end
-
-    test "span boundary inside a multi-byte character preserves byte count" do
-      line = "──"
-
-      hl =
+      partial =
         highlight_with(
           spans: [%{start_byte: 0, end_byte: 1, capture_id: 0}],
           capture_names: ["comment"],
           theme: %{"comment" => [fg: 0x888888]}
         )
 
-      result = Highlight.styles_for_line(hl, line, 0)
-      all_text = Enum.map_join(result, fn {text, _style} -> text end)
-      assert byte_size(all_text) == byte_size(line)
-    end
+      assert Highlight.styles_for_line(partial, "──", 0) |> joined_text() |> byte_size() ==
+               byte_size("──")
 
-    test "span at a valid multi-byte character boundary applies style" do
-      line = "──"
-
-      hl =
+      complete =
         highlight_with(
           spans: [%{start_byte: 0, end_byte: 3, capture_id: 0}],
           capture_names: ["comment"],
           theme: %{"comment" => [fg: 0x888888]}
         )
 
-      result = Highlight.styles_for_line(hl, line, 0)
-
-      assert_segments(result, [{"─", fg: 0x888888}, {"─", []}])
-    end
-
-    test "single span covering part of line" do
-      hl =
-        highlight_with(
-          spans: [%{start_byte: 0, end_byte: 3, capture_id: 0}],
-          capture_names: ["keyword"],
-          theme: %{"keyword" => [fg: 0xFF0000]}
-        )
-
-      result = Highlight.styles_for_line(hl, "def foo", 0)
-      assert_segments(result, [{"def", fg: 0xFF0000}, {" foo", []}])
-    end
-
-    test "span in middle of line" do
-      hl =
-        highlight_with(
-          spans: [%{start_byte: 4, end_byte: 7, capture_id: 0}],
-          capture_names: ["string"],
-          theme: %{"string" => [fg: 0x00FF00]}
-        )
-
-      result = Highlight.styles_for_line(hl, "x = :foo + 1", 0)
-      assert_segments(result, [{"x = ", []}, {":fo", fg: 0x00FF00}, {"o + 1", []}])
-    end
-
-    test "multiple spans on one line" do
-      hl =
-        highlight_with(
-          spans: [
-            %{start_byte: 0, end_byte: 3, capture_id: 0},
-            %{start_byte: 4, end_byte: 7, capture_id: 1}
-          ],
-          capture_names: ["keyword", "function"],
-          theme: %{"keyword" => [fg: 0xFF0000], "function" => [fg: 0x00FF00]}
-        )
-
-      result = Highlight.styles_for_line(hl, "def foo()", 0)
-
-      assert_segments(result, [
-        {"def", fg: 0xFF0000},
-        {" ", []},
-        {"foo", fg: 0x00FF00},
-        {"()", []}
+      assert_segments(Highlight.styles_for_line(complete, "──", 0), [
+        {"─", fg: 0x888888},
+        {"─", []}
       ])
     end
 
-    test "span crossing line boundary is clamped" do
-      hl =
-        highlight_with(
-          spans: [%{start_byte: 0, end_byte: 20, capture_id: 0}],
-          capture_names: ["comment"],
-          theme: %{"comment" => [fg: 0x888888, italic: true]}
-        )
+    test "simple spans split leading, middle, multiple, crossing, unknown, and offset cases" do
+      cases = [
+        {
+          highlight_with(
+            spans: [%{start_byte: 0, end_byte: 3, capture_id: 0}],
+            capture_names: ["keyword"],
+            theme: %{"keyword" => [fg: 0xFF0000]}
+          ),
+          "def foo",
+          0,
+          [{"def", fg: 0xFF0000}, {" foo", []}]
+        },
+        {
+          highlight_with(
+            spans: [%{start_byte: 4, end_byte: 7, capture_id: 0}],
+            capture_names: ["string"],
+            theme: %{"string" => [fg: 0x00FF00]}
+          ),
+          "x = :foo + 1",
+          0,
+          [{"x = ", []}, {":fo", fg: 0x00FF00}, {"o + 1", []}]
+        },
+        {
+          highlight_with(
+            spans: [
+              %{start_byte: 0, end_byte: 3, capture_id: 0},
+              %{start_byte: 4, end_byte: 7, capture_id: 1}
+            ],
+            capture_names: ["keyword", "function"],
+            theme: %{"keyword" => [fg: 0xFF0000], "function" => [fg: 0x00FF00]}
+          ),
+          "def foo()",
+          0,
+          [{"def", fg: 0xFF0000}, {" ", []}, {"foo", fg: 0x00FF00}, {"()", []}]
+        },
+        {
+          highlight_with(
+            spans: [%{start_byte: 0, end_byte: 20, capture_id: 0}],
+            capture_names: ["comment"],
+            theme: %{"comment" => [fg: 0x888888, italic: true]}
+          ),
+          "hello",
+          5,
+          [{"hello", fg: 0x888888, italic: true}]
+        },
+        {
+          highlight_with(
+            spans: [%{start_byte: 0, end_byte: 3, capture_id: 99}],
+            capture_names: ["keyword"],
+            theme: %{"keyword" => [fg: 0xFF0000]}
+          ),
+          "def foo",
+          0,
+          [{"def", []}, {" foo", []}]
+        },
+        {
+          highlight_with(
+            spans: [%{start_byte: 8, end_byte: 11, capture_id: 0}],
+            capture_names: ["keyword"],
+            theme: %{"keyword" => [fg: 0xFF0000]}
+          ),
+          "bar baz",
+          8,
+          [{"bar", fg: 0xFF0000}, {" baz", []}]
+        }
+      ]
 
-      result = Highlight.styles_for_line(hl, "hello", 5)
-      assert [{text, %Minga.Core.Face{} = style}] = result
-      assert text == "hello"
-      assert style.fg == 0x888888
-      assert style.italic == true
+      for {hl, line, offset, expected} <- cases do
+        assert_segments(Highlight.styles_for_line(hl, line, offset), expected)
+      end
     end
 
-    test "span not overlapping this line is excluded" do
-      hl =
-        highlight_with(
-          spans: [%{start_byte: 100, end_byte: 110, capture_id: 0}],
-          capture_names: ["keyword"],
-          theme: %{"keyword" => [fg: 0xFF0000]}
-        )
-
-      result = Highlight.styles_for_line(hl, "hello", 0)
-      assert_segments(result, [{"hello", []}])
-    end
-
-    test "unknown capture_id returns empty style" do
-      hl =
-        highlight_with(
-          spans: [%{start_byte: 0, end_byte: 3, capture_id: 99}],
-          capture_names: ["keyword"],
-          theme: %{"keyword" => [fg: 0xFF0000]}
-        )
-
-      result = Highlight.styles_for_line(hl, "def foo", 0)
-      assert_segments(result, [{"def", []}, {" foo", []}])
-    end
-
-    test "same-width spans: higher pattern_index wins" do
-      # Two captures on the same node. Higher pattern_index = later in query = more specific.
-      hl =
+    test "overlap precedence keeps text intact and chooses the most specific visible style" do
+      same_width =
         highlight_with(
           spans: [
             %{start_byte: 0, end_byte: 9, capture_id: 0, pattern_index: 3},
             %{start_byte: 0, end_byte: 9, capture_id: 1, pattern_index: 10}
           ],
           capture_names: ["keyword", "keyword.function"],
-          theme: %{
-            "keyword" => [fg: 0xFF0000],
-            "keyword.function" => [fg: 0x00FF00]
-          }
+          theme: %{"keyword" => [fg: 0xFF0000], "keyword.function" => [fg: 0x00FF00]}
         )
 
-      result = Highlight.styles_for_line(hl, "defmodule Foo do", 0)
-      all_text = Enum.map_join(result, fn {text, _} -> text end)
-      assert all_text == "defmodule Foo do"
+      assert_segments(Highlight.styles_for_line(same_width, "defmodule Foo do", 0), [
+        {"defmodule", fg: 0x00FF00},
+        {" Foo do", []}
+      ])
 
-      # Higher pattern_index wins
-      assert_segments(result, [{"defmodule", fg: 0x00FF00}, {" Foo do", []}])
-    end
-
-    test "partially overlapping spans don't duplicate text" do
-      hl =
+      partial =
         highlight_with(
           spans: [
             %{start_byte: 0, end_byte: 5, capture_id: 0},
@@ -301,15 +233,29 @@ defmodule Minga.HighlightTest do
           theme: %{"keyword" => [fg: 0xFF0000], "string" => [fg: 0x00FF00]}
         )
 
-      result = Highlight.styles_for_line(hl, "hello world", 0)
-      all_text = Enum.map_join(result, fn {text, _} -> text end)
-      assert all_text == "hello world"
+      assert Highlight.styles_for_line(partial, "hello world", 0) |> joined_text() ==
+               "hello world"
+
+      injection =
+        highlight_with(
+          spans:
+            List.to_tuple([
+              %{start_byte: 0, end_byte: 5, capture_id: 0, pattern_index: 10, layer: 0},
+              %{start_byte: 0, end_byte: 10, capture_id: 1, pattern_index: 1, layer: 1}
+            ]),
+          capture_names: ["outer.keyword", "injection.string"],
+          theme: %{"outer.keyword" => [fg: 0xFF0000], "injection.string" => [fg: 0x00FF00]}
+        )
+
+      assert_segments(Highlight.styles_for_line(injection, "hello world", 0), [
+        {"hello", fg: 0x00FF00},
+        {" worl", fg: 0x00FF00},
+        {"d", []}
+      ])
     end
 
-    test "innermost-wins: child spans override parent spans" do
-      # String interpolation: #{content}
-      # Outer "embedded" span covers everything, inner "punctuation.special" covers #{ and }
-      hl =
+    test "innermost spans override parents across representative nesting shapes" do
+      interpolation =
         highlight_with(
           spans: [
             %{start_byte: 0, end_byte: 2, capture_id: 1, pattern_index: 10},
@@ -317,27 +263,16 @@ defmodule Minga.HighlightTest do
             %{start_byte: 9, end_byte: 10, capture_id: 1, pattern_index: 10}
           ],
           capture_names: ["embedded", "punctuation.special"],
-          theme: %{
-            "embedded" => [fg: 0xAAAAAA],
-            "punctuation.special" => [fg: 0xFF0000]
-          }
+          theme: %{"embedded" => [fg: 0xAAAAAA], "punctuation.special" => [fg: 0xFF0000]}
         )
 
-      result = Highlight.styles_for_line(hl, "\#{content}", 0)
-      all_text = Enum.map_join(result, fn {text, _} -> text end)
-      assert all_text == "\#{content}"
-
-      assert_segments(result, [
-        {"\#{", fg: 0xFF0000},
+      assert_segments(Highlight.styles_for_line(interpolation, ~S(#{content}), 0), [
+        {~S(#{), fg: 0xFF0000},
         {"content", fg: 0xAAAAAA},
         {"}", fg: 0xFF0000}
       ])
-    end
 
-    test "innermost-wins: module attribute with atoms" do
-      # @reference_forms [:alias, :import, :require]
-      # Parent @constant covers entire expression, child atoms get their own style
-      hl =
+      attributes =
         highlight_with(
           spans:
             List.to_tuple([
@@ -347,30 +282,23 @@ defmodule Minga.HighlightTest do
               %{start_byte: 35, end_byte: 43, capture_id: 0, pattern_index: 5}
             ]),
           capture_names: ["string.special.symbol", "constant"],
-          theme: %{
-            "string.special.symbol" => [fg: 0xAA00FF],
-            "constant" => [fg: 0xDA8548]
-          }
+          theme: %{"string.special.symbol" => [fg: 0xAA00FF], "constant" => [fg: 0xDA8548]}
         )
 
-      line = "@reference_forms [:alias, :import, :require]"
-      result = Highlight.styles_for_line(hl, line, 0)
-      all_text = Enum.map_join(result, fn {text, _} -> text end)
-      assert all_text == line
+      assert_segments(
+        Highlight.styles_for_line(attributes, "@reference_forms [:alias, :import, :require]", 0),
+        [
+          {"@reference_forms [", fg: 0xDA8548},
+          {":alias", fg: 0xAA00FF},
+          {", ", fg: 0xDA8548},
+          {":import", fg: 0xAA00FF},
+          {", ", fg: 0xDA8548},
+          {":require", fg: 0xAA00FF},
+          {"]", fg: 0xDA8548}
+        ]
+      )
 
-      assert_segments(result, [
-        {"@reference_forms [", fg: 0xDA8548},
-        {":alias", fg: 0xAA00FF},
-        {", ", fg: 0xDA8548},
-        {":import", fg: 0xAA00FF},
-        {", ", fg: 0xDA8548},
-        {":require", fg: 0xAA00FF},
-        {"]", fg: 0xDA8548}
-      ])
-    end
-
-    test "innermost-wins: three nesting levels" do
-      hl =
+      three_levels =
         highlight_with(
           spans:
             List.to_tuple([
@@ -386,11 +314,7 @@ defmodule Minga.HighlightTest do
           }
         )
 
-      result = Highlight.styles_for_line(hl, "01234567890123456789", 0)
-      all_text = Enum.map_join(result, fn {text, _} -> text end)
-      assert all_text == "01234567890123456789"
-
-      assert_segments(result, [
+      assert_segments(Highlight.styles_for_line(three_levels, "01234567890123456789", 0), [
         {"01234", fg: 0x111111},
         {"567", fg: 0x222222},
         {"8901", fg: 0x333333},
@@ -398,58 +322,14 @@ defmodule Minga.HighlightTest do
         {"56789", fg: 0x111111}
       ])
     end
-
-    test "injection layer always wins over outer layer" do
-      # layer=1 (injection) beats layer=0 (outer) even when outer is narrower
-      hl =
-        highlight_with(
-          spans:
-            List.to_tuple([
-              %{start_byte: 0, end_byte: 5, capture_id: 0, pattern_index: 10, layer: 0},
-              %{start_byte: 0, end_byte: 10, capture_id: 1, pattern_index: 1, layer: 1}
-            ]),
-          capture_names: ["outer.keyword", "injection.string"],
-          theme: %{
-            "outer.keyword" => [fg: 0xFF0000],
-            "injection.string" => [fg: 0x00FF00]
-          }
-        )
-
-      result = Highlight.styles_for_line(hl, "hello world", 0)
-
-      # Injection wins everywhere it covers, even though outer is narrower
-      assert_segments(result, [{"hello", fg: 0x00FF00}, {" worl", fg: 0x00FF00}, {"d", []}])
-    end
-
-    test "with line_start_byte offset" do
-      hl =
-        highlight_with(
-          spans: [%{start_byte: 8, end_byte: 11, capture_id: 0}],
-          capture_names: ["keyword"],
-          theme: %{"keyword" => [fg: 0xFF0000]}
-        )
-
-      result = Highlight.styles_for_line(hl, "bar baz", 8)
-      assert_segments(result, [{"bar", fg: 0xFF0000}, {" baz", []}])
-    end
   end
 
   describe "styles_for_visible_lines/2" do
-    test "empty highlights returns unstyled segments" do
-      hl = Highlight.new()
+    test "batch styling matches per-line styling and handles empty highlights" do
+      empty = Highlight.styles_for_visible_lines(Highlight.new(), [{"hello", 0}, {"world", 6}])
+      assert_segments(Enum.at(empty, 0), [{"hello", []}])
+      assert_segments(Enum.at(empty, 1), [{"world", []}])
 
-      result =
-        Highlight.styles_for_visible_lines(hl, [
-          {"hello", 0},
-          {"world", 6}
-        ])
-
-      assert length(result) == 2
-      assert_segments(Enum.at(result, 0), [{"hello", []}])
-      assert_segments(Enum.at(result, 1), [{"world", []}])
-    end
-
-    test "results match per-line styles_for_line" do
       hl =
         highlight_with(
           spans:
@@ -463,38 +343,28 @@ defmodule Minga.HighlightTest do
 
       lines = [{"def foo", 0}, {"world", 8}]
 
-      batch_result = Highlight.styles_for_visible_lines(hl, lines)
+      per_line =
+        Enum.map(lines, fn {text, offset} -> Highlight.styles_for_line(hl, text, offset) end)
 
-      per_line_result =
-        Enum.map(lines, fn {text, offset} ->
-          Highlight.styles_for_line(hl, text, offset)
-        end)
-
-      assert batch_result == per_line_result
+      assert Highlight.styles_for_visible_lines(hl, lines) == per_line
     end
 
-    test "multi-line span handled correctly across lines" do
-      hl =
+    test "batch styling carries multi-line spans and watermark state across visible lines" do
+      multiline =
         highlight_with(
-          spans:
-            List.to_tuple([
-              %{start_byte: 0, end_byte: 30, capture_id: 0, pattern_index: 1}
-            ]),
+          spans: List.to_tuple([%{start_byte: 0, end_byte: 30, capture_id: 0, pattern_index: 1}]),
           capture_names: ["comment"],
           theme: %{"comment" => [fg: 0x888888]}
         )
 
-      lines = [{"first", 0}, {"second", 6}, {"third", 13}]
-      result = Highlight.styles_for_visible_lines(hl, lines)
+      result =
+        Highlight.styles_for_visible_lines(multiline, [{"first", 0}, {"second", 6}, {"third", 13}])
 
-      assert length(result) == 3
       assert_segments(Enum.at(result, 0), [{"first", fg: 0x888888}])
       assert_segments(Enum.at(result, 1), [{"second", fg: 0x888888}])
       assert_segments(Enum.at(result, 2), [{"third", fg: 0x888888}])
-    end
 
-    test "watermark advances past consumed spans" do
-      hl =
+      watermark =
         highlight_with(
           spans:
             List.to_tuple([
@@ -505,10 +375,13 @@ defmodule Minga.HighlightTest do
           theme: %{"keyword" => [fg: 0xFF0000], "string" => [fg: 0x00FF00]}
         )
 
-      lines = [{"def foo", 0}, {"hello", 8}, {"world", 14}]
-      result = Highlight.styles_for_visible_lines(hl, lines)
+      result =
+        Highlight.styles_for_visible_lines(watermark, [
+          {"def foo", 0},
+          {"hello", 8},
+          {"world", 14}
+        ])
 
-      assert length(result) == 3
       assert_segments(Enum.at(result, 0), [{"def", fg: 0xFF0000}, {" foo", []}])
       assert_segments(Enum.at(result, 1), [{"he", []}, {"llo", fg: 0x00FF00}])
       assert_segments(Enum.at(result, 2), [{"w", fg: 0x00FF00}, {"orld", []}])
@@ -516,36 +389,25 @@ defmodule Minga.HighlightTest do
   end
 
   describe "from_theme/1" do
-    test "builds a highlight state with face registry" do
+    test "builds a face registry that resolves direct and dotted inherited styles" do
       theme = MingaEditor.UI.Theme.get!(:doom_one)
       hl = Highlight.from_theme(theme)
       assert hl.face_registry != nil
       assert hl.theme == theme.syntax
-    end
 
-    test "face registry resolves styles with inheritance" do
-      theme = MingaEditor.UI.Theme.get!(:doom_one)
-      hl = Highlight.from_theme(theme)
+      keyword = MingaEditor.UI.Face.Registry.style_for(hl.face_registry, "keyword")
+      assert keyword.bold == true
+      assert keyword.fg != nil
 
-      # "keyword" is defined in doom_one, should resolve with bold
-      face = MingaEditor.UI.Face.Registry.style_for(hl.face_registry, "keyword")
-      assert face.bold == true
-      assert face.fg != nil
-    end
-
-    test "face registry falls back through dotted names" do
-      theme = MingaEditor.UI.Theme.get!(:doom_one)
-      hl = Highlight.from_theme(theme)
-
-      # "keyword.function.builtin.whatever" doesn't exist, should fall back
-      face =
+      dotted =
         MingaEditor.UI.Face.Registry.style_for(
           hl.face_registry,
           "keyword.function.builtin.whatever"
         )
 
-      # Should get keyword.function or keyword's style
-      assert face.fg != nil
+      assert dotted.fg != nil
     end
   end
+
+  defp joined_text(result), do: Enum.map_join(result, fn {text, _style} -> text end)
 end


### PR DESCRIPTION
## Summary
- Consolidates four more oversized test suites into behavior-focused scenarios at the cheapest useful layer.
- Keeps coverage on public outcomes: editing command behavior, highlight segmentation, editor state transitions, and buffer lifecycle/tab effects.
- Reduces the batch from 2,328 lines to 1,474 and from 126 tests to 33.

## Test suite reductions
| File | Lines | Tests |
| --- | ---: | ---: |
| `test/minga_editor/commands/editing_test.exs` | 614 → 443 | 42 → 10 |
| `test/minga_editor/ui/highlight_test.exs` | 551 → 413 | 35 → 10 |
| `test/minga_editor/state_test.exs` | 521 → 249 | 28 → 6 |
| `test/minga_editor/state/buffer_lifecycle_test.exs` | 642 → 369 | 21 → 7 |

## Verification
- `mix test.llm test/minga_editor/commands/editing_test.exs test/minga_editor/ui/highlight_test.exs test/minga_editor/state_test.exs test/minga_editor/state/buffer_lifecycle_test.exs` → PASS: 33 tests, 0 failures
- Final reviewer gate: PASS
